### PR TITLE
fix(unified-agent): upgrade claude acp bridge for opus 4.7

### DIFF
--- a/packages/unified-agent/README.md
+++ b/packages/unified-agent/README.md
@@ -14,7 +14,7 @@ Unified Agent provides two ways to control three major CLI agents — Gemini, Cl
 | CLI | Protocol | Spawn Command |
 |-----|----------|---------------|
 | **Gemini** | ACP | `gemini --acp` |
-| **Claude** | ACP | `npx --package=@agentclientprotocol/claude-agent-acp@0.26.0 claude-agent-acp` |
+| **Claude** | ACP | `npx --package=@agentclientprotocol/claude-agent-acp@0.29.2 claude-agent-acp` |
 | **Codex** | ACP | `npx --package=@zed-industries/codex-acp@0.11.1 codex-acp` |
 
 ### Prerequisites

--- a/packages/unified-agent/package-lock.json
+++ b/packages/unified-agent/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.18.2",
+        "@agentclientprotocol/sdk": "^0.19.0",
         "picocolors": "^1.1.1",
         "zod": "^4.3.6"
       },
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.18.2.tgz",
-      "integrity": "sha512-l/o9NKvUc00GPa6RFJ4AccQq2O/PAf83xQ75mThHuL3H571iN4+PEdwnTBez67sS8Nv2aSA373xCZ5CbTXEwzA==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.19.0.tgz",
+      "integrity": "sha512-U9I8ws9WTOk6jCBAWpXefGSDgVXn14/kV6HFzwWGcstQ02mOQgClMAROHmoIn9GqZbDBDEOkdIbP4P4TEMQdug==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/packages/unified-agent/package.json
+++ b/packages/unified-agent/package.json
@@ -55,7 +55,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@agentclientprotocol/sdk": "^0.18.2",
+    "@agentclientprotocol/sdk": "^0.19.0",
     "picocolors": "^1.1.1",
     "zod": "^4.3.6"
   }

--- a/packages/unified-agent/src/config/CliConfigs.ts
+++ b/packages/unified-agent/src/config/CliConfigs.ts
@@ -41,7 +41,7 @@ export const CLI_BACKENDS: Record<CliType, CliBackendConfig> = {
     cliCommand: 'claude',
     protocol: 'acp',
     authRequired: true,
-    npxPackage: '@agentclientprotocol/claude-agent-acp@0.26.0',
+    npxPackage: '@agentclientprotocol/claude-agent-acp@0.29.2',
     modes: [
       { id: 'default', label: 'Default' },
       { id: 'plan', label: 'Plan' },

--- a/packages/unified-agent/src/utils/npx.ts
+++ b/packages/unified-agent/src/utils/npx.ts
@@ -43,7 +43,7 @@ export function resolveNpxPath(
  * 패키지 스펙을 실행 파일 이름으로 잘못 해석할 수 있으므로,
  * 항상 `npx --package=<pkg> <bin>` 형태로 고정합니다.
  *
- * @param packageName - 실행할 npm 패키지 (e.g., '@agentclientprotocol/claude-agent-acp@0.26.0')
+ * @param packageName - 실행할 npm 패키지 (e.g., '@agentclientprotocol/claude-agent-acp@0.29.2')
  * @param preferOffline - npm 캐시 우선 사용 여부 (기본: false)
  * @returns npx 실행 인자 배열
  */
@@ -64,7 +64,7 @@ export function buildNpxArgs(
  * npm 패키지 스펙에서 실행 바이너리 이름을 추론합니다.
  *
  * 예:
- * - @agentclientprotocol/claude-agent-acp@0.26.0 -> claude-agent-acp
+ * - @agentclientprotocol/claude-agent-acp@0.29.2 -> claude-agent-acp
  * - @zed-industries/codex-acp@0.11.1 -> codex-acp
  */
 function inferBinName(packageName: string): string {

--- a/packages/unified-agent/tests/e2e/acp-session.raw.test.ts
+++ b/packages/unified-agent/tests/e2e/acp-session.raw.test.ts
@@ -33,7 +33,7 @@ const CLIS: CliDef[] = [
   {
     name: 'claude',
     command: 'npx',
-    args: ['--yes', '--package=@agentclientprotocol/claude-agent-acp@0.26.0', 'claude-agent-acp'],
+    args: ['--yes', '--package=@agentclientprotocol/claude-agent-acp@0.29.2', 'claude-agent-acp'],
   },
   {
     name: 'codex',

--- a/packages/unified-agent/tests/unit/CliConfigs.test.ts
+++ b/packages/unified-agent/tests/unit/CliConfigs.test.ts
@@ -35,7 +35,7 @@ describe('CliConfigs', () => {
 
       expect(config.command).toContain('npx');
       expect(config.args).not.toContain('--prefer-offline');
-      expect(config.args).toContain('--package=@agentclientprotocol/claude-agent-acp@0.26.0');
+      expect(config.args).toContain('--package=@agentclientprotocol/claude-agent-acp@0.29.2');
       expect(config.args).toContain('claude-agent-acp');
       expect(config.useNpx).toBe(true);
     });


### PR DESCRIPTION
## Summary
- upgrade the Claude ACP bridge in `packages/unified-agent` from `@agentclientprotocol/claude-agent-acp@0.26.0` to `0.29.2`
- bump `@agentclientprotocol/sdk` from `^0.18.2` to `^0.19.0` to match the Claude bridge dependency line
- update docs and test fixtures that pin the Claude ACP bridge package string

## Validation
- `npm run lint`
- `npx vitest run tests/unit/CliConfigs.test.ts tests/unit/ModelRegistry.test.ts`
- `npx vitest run tests/e2e/acp-session.raw.test.ts`
- `node dist/cli.mjs --json -c claude -m opus "지금 어떤 모델이야? 정확한 모델명만 답해."`
- `node dist/cli.mjs --json -c claude -m 'opus[1m]' "지금 어떤 모델이야? 정확한 모델명만 답해."`
- `node dist/cli.mjs --json -c codex "1+1만 답해"`

## Notes
- verified that the raw ACP E2E also passes for Gemini, so the SDK bump did not regress the Gemini path
- after the bridge upgrade, Claude alias resolution now returns `claude-opus-4-7` and `claude-opus-4-7[1m]` through `ait`
