### PR TITLE
fix(unified-agent): Windows Codex/Claude CLI spawn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,12 @@
 {
   "name": "pi-fleet",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "pi-fleet",
+      "version": "0.1.0",
       "hasInstallScript": true,
       "workspaces": [
         "packages/unified-agent",
@@ -3417,7 +3420,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3435,7 +3437,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3453,7 +3454,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3471,7 +3471,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3489,7 +3488,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3507,7 +3505,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3525,7 +3522,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3543,7 +3539,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3561,7 +3556,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3579,7 +3573,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3597,7 +3590,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3615,7 +3607,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3633,7 +3624,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3651,7 +3641,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3669,7 +3658,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3687,7 +3675,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3705,7 +3692,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3723,7 +3709,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3741,7 +3726,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3759,7 +3743,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3777,7 +3760,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3795,7 +3777,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3813,7 +3794,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3831,7 +3811,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3849,7 +3828,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3867,7 +3845,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5473,7 +5450,7 @@
     },
     "packages/unified-agent": {
       "name": "@sbluemin/unified-agent",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.19.0",

--- a/packages/unified-agent/package.json
+++ b/packages/unified-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbluemin/unified-agent",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Codex CLI, Claude Code, Gemini CLI를 통합하는 TypeScript 기반 SDK",
   "bin": {

--- a/packages/unified-agent/src/connection/BaseConnection.ts
+++ b/packages/unified-agent/src/connection/BaseConnection.ts
@@ -77,23 +77,28 @@ export class BaseConnection extends EventEmitter {
   protected spawnRawProcess(): ChildProcess {
     this.setState('connecting');
 
-    // Windows에서 .cmd 래퍼(npx.cmd, gemini.cmd 등)를 실행하려면 cmd.exe가 필요합니다.
-    // shell: true를 사용하면 Node.js가 내부적으로 cmd.exe /d /s /c "..." 형태로 감싸면서
-    // windowsVerbatimArguments=true를 강제하고 stdio 파이프가 불안정해집니다 (EPIPE).
-    // cmd.exe /c를 직접 spawn(shell: false)하면 Node.js 기본 인자 이스케이프가 적용되어
-    // stdio 파이프가 안정적으로 동작합니다.
-    const command = isWindows()
-      ? ((this.env.ComSpec as string) ?? 'cmd.exe')
-      : this.command;
-    const args = isWindows()
-      ? ['/c', this.command, ...this.args]
-      : this.args;
-
-    const child = spawn(command, args, {
-      cwd: this.cwd,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: this.env as NodeJS.ProcessEnv,
-    });
+    // Windows에서 .cmd 래퍼(npx.cmd, gemini.cmd 등)를 실행하려면 cmd.exe를 경유해야 합니다.
+    // cmd.exe /C 단순 래핑은 경로에 공백이 있을 때(예: C:\Program Files\nodejs\npx.cmd)
+    // cmd의 quote-stripping 규칙에 따라 바깥 따옴표가 벗겨져 명령이 공백에서 끊깁니다.
+    // 이를 회피하려면 cmd.exe /S /C ""<cmd>" <args>" 관용구와 windowsVerbatimArguments를
+    // 함께 사용해 cmd가 바깥쪽 이중 따옴표만 벗기고 내부 인용은 보존하도록 합니다.
+    // 또한 cmd는 MSVCRT식 `\"` 이스케이프를 인식하지 않으므로 내부 `"`는 `""`로 이중화합니다.
+    const child = isWindows()
+      ? spawn(
+          (this.env.ComSpec as string) ?? 'cmd.exe',
+          buildWindowsCmdArgs(this.command, this.args),
+          {
+            cwd: this.cwd,
+            stdio: ['pipe', 'pipe', 'pipe'],
+            env: this.env as NodeJS.ProcessEnv,
+            windowsVerbatimArguments: true,
+          },
+        )
+      : spawn(this.command, this.args, {
+          cwd: this.cwd,
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env: this.env as NodeJS.ProcessEnv,
+        });
 
     this.childExitPromise = new Promise<void>((resolve) => {
       child.once('exit', () => {
@@ -255,4 +260,32 @@ export class BaseConnection extends EventEmitter {
       }),
     ]);
   }
+}
+
+/**
+ * 단일 토큰을 cmd.exe의 인용 규칙에 맞게 감쌉니다.
+ * 공백, `"`, cmd-특수문자(`& < > ( ) @ ^ |`)를 포함하면 외곽을 `"..."`로 감싸고
+ * 내부의 `"`는 `""`로 이중화하여 cmd 내부에서 리터럴로 보존되게 합니다.
+ * 빈 문자열은 `""`로 반환해 인자 소실을 방지합니다.
+ */
+function quoteForCmd(token: string): string {
+  if (token === '') {
+    return '""';
+  }
+  if (!/[\s"&<>()@^|]/.test(token)) {
+    return token;
+  }
+  return `"${token.replace(/"/g, '""')}"`;
+}
+
+/**
+ * `cmd.exe /S /C ""<cmd>" <args>"` 호출에 필요한 args 배열을 생성합니다.
+ * `/S`는 cmd의 첫/마지막 따옴표 제거 예외 규칙을 끄고, 외곽 이중 따옴표를
+ * 벗긴 뒤 내부 인용은 그대로 보존하게 합니다. spawn 호출 시
+ * windowsVerbatimArguments: true 와 함께 사용해야 Node가 자동 이스케이프로
+ * 구성을 깨뜨리지 않습니다.
+ */
+function buildWindowsCmdArgs(command: string, args: string[]): string[] {
+  const line = [command, ...args].map(quoteForCmd).join(' ');
+  return ['/S', '/C', `"${line}"`];
 }

--- a/packages/unified-agent/src/utils/npx.ts
+++ b/packages/unified-agent/src/utils/npx.ts
@@ -15,7 +15,8 @@ import { isWindows } from './env.js';
 export function resolveNpxPath(
   env?: Record<string, string | undefined>,
 ): string {
-  const whichCmd = isWindows() ? 'where npx' : 'which npx';
+  const windows = isWindows();
+  const whichCmd = windows ? 'where npx' : 'which npx';
 
   try {
     const result = execSync(whichCmd, {
@@ -25,11 +26,28 @@ export function resolveNpxPath(
       env: env as NodeJS.ProcessEnv,
     }).trim();
 
-    // Windows의 `where`는 여러 줄을 반환할 수 있음 — 첫 번째 결과 사용
-    return result.split('\n')[0].trim();
+    const candidates = result
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    if (windows) {
+      // Windows의 `where`는 확장자 없는 shell script(`npx`)와 `npx.cmd`를 함께 반환합니다.
+      // 단독 실행 가능한 배치/실행 파일만 선별해 우선 사용합니다.
+      const executable = candidates.find((p) => /\.(cmd|bat|exe)$/i.test(p));
+      if (executable) {
+        return executable;
+      }
+    }
+
+    if (candidates.length > 0) {
+      return candidates[0];
+    }
+
+    return windows ? 'npx.cmd' : 'npx';
   } catch {
     // PATH가 정제된 환경에서는 기본 경로 시도
-    if (isWindows()) {
+    if (windows) {
       return 'npx.cmd';
     }
     return 'npx';


### PR DESCRIPTION
## Summary
- Windows에서 node가 공백 포함 경로(예: `C:\Program Files\nodejs\`)에 설치된 경우 `cmd.exe /C <path> <args>` 구성이 cmd의 quote-stripping 규칙에 걸려 외곽 따옴표가 벗겨지고 `'C:\Program'`이 명령으로 해석되어 Codex/Claude npx 브릿지 기동에 실패하던 문제를 수정.
- `cmd.exe /S /C ""<cmd>" <args>"` 관용구 + `windowsVerbatimArguments: true`로 교체하고 내부 `"`는 `""`로 이중화하여 공백·인용 포함 인자(`service_tier="fast"` 등)가 Codex까지 무손실로 전달되도록 함.
- `resolveNpxPath`가 `where npx` 결과에서 실행 가능한 `.cmd`/`.exe`/`.bat`을 우선 선택하도록 보강.
- `@sbluemin/unified-agent` 버전을 1.0.0 → 1.0.1로 patch 범프.

## Root cause
`cmd.exe /?`의 규정: `/C`에 전달된 커맨드라인에 따옴표가 2개를 초과하거나 `/S`가 있으면, 첫 `"`와 마지막 `"`를 각각 제거한다. 기존 spawn 구성은 Node가 경로와 `service_tier="fast"`를 각각 인용해 총 4개의 `"`를 만들어 규칙이 발동 → 경로 외곽 인용이 벗겨져 공백에서 파싱이 끊김. 확장자(`.cmd` 여부)와 무관한 cmd 문법 문제였다.

## Verification
Windows 11 + `C:\Program Files\nodejs\node.exe` 환경에서 직접 재현·검증:
- Before: `'C:\Program'은(는) ... 명령이 아닙니다` 로 child exit=1.
- After: initialize + session/new 연속 송신 시 두 응답 모두 정상 수신, Codex stderr에 TOML 설정 파싱 에러 없음.
- 복잡 인자 (공백·인용 혼재 `mcp_servers.demo.http_headers={"X-Token" = "abc def"}`)도 구조 유지.
- 비-Windows 분기는 수정 없음 — macOS/Linux 회귀 위험 없음.

## Scope & compat
- 영향: Codex ACP 브릿지, Claude ACP 브릿지(동일 spawn 경로), Gemini 직접 spawn(cliPath가 공백 경로일 때).
- 회귀 위험: Windows에서도 공백 무관하게 idempotent한 래핑이므로 기존 환경(공백 없는 경로)은 동일 동작.
- 잔여 사전 한계: cmd의 `%VAR%` 치환은 `""` 내부에서도 일어나며 현행 대비 변화 없음(회귀 아님). 사용자 지정 configOverrides에 리터럴 `%`가 들어갈 경우 별도 하드닝 필요.

## Test plan
- [x] Windows 공백 경로 환경에서 수동 재현 및 정정 확인 (initialize + session/new)
- [x] CI/로컬 macOS/Linux에서 기존 E2E 테스트(`claude.acp.test.ts`, `codex.acp.test.ts`, `gemini.acp.test.ts`) 회귀 확인
- [x] Windows 공백 없는 경로 환경에서 회귀 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)