### PR TITLE
feat(core-unified-agent): switch claude-kimi to kimi-k2.7-code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+- [core-unified-agent] Claude Code with Moonshot Kimi now runs the Kimi K2.7 coding model as the default, slot-mapped, and subagent model.
+
 ## [1.4.0] - 2026-06-10
 
 ### Added

--- a/packages/core-unified-agent/models.json
+++ b/packages/core-unified-agent/models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-05-21T00:00:00Z",
+  "updatedAt": "2026-06-13T00:00:00Z",
   "providers": {
     "claude": {
       "name": "Claude Code with Anthropic",
@@ -31,14 +31,14 @@
       "name": "Claude Code with Moonshot Kimi",
       "defaultModel": "opus",
       "models": [
-        { "modelId": "haiku", "name": "Kimi K2.5 (Haiku slot)", "effort": { "supported": false } },
-        { "modelId": "sonnet", "name": "Kimi K2.5 (Sonnet slot)", "effort": { "supported": false } },
-        { "modelId": "opus", "name": "Kimi K2.6 (Opus slot)", "effort": { "supported": false } }
+        { "modelId": "haiku", "name": "Kimi K2.7 Code (Haiku slot)", "effort": { "supported": false } },
+        { "modelId": "sonnet", "name": "Kimi K2.7 Code (Sonnet slot)", "effort": { "supported": false } },
+        { "modelId": "opus", "name": "Kimi K2.7 Code (Opus slot)", "effort": { "supported": false } }
       ],
       "modelsMapping": {
-        "haiku": "kimi-k2",
-        "sonnet": "kimi-k2.5",
-        "opus": "kimi-k2.6"
+        "haiku": "kimi-k2.7-code",
+        "sonnet": "kimi-k2.7-code",
+        "opus": "kimi-k2.7-code"
       }
     },
     "codex": {

--- a/packages/core-unified-agent/src/config/CliConfigs.ts
+++ b/packages/core-unified-agent/src/config/CliConfigs.ts
@@ -73,7 +73,8 @@ export const CLI_BACKENDS = {
     defaultEnv: {
       ANTHROPIC_BASE_URL: 'https://api.kimi.com/coding/',
       ENABLE_TOOL_SEARCH: 'false',
-      CLAUDE_CODE_SUBAGENT_MODEL: 'kimi-k2.5',
+      ANTHROPIC_MODEL: 'kimi-k2.7-code',
+      CLAUDE_CODE_SUBAGENT_MODEL: 'kimi-k2.7-code',
       API_TIMEOUT_MS: '3000000',
     },
   },

--- a/packages/fleet-infra/tests/auth/auth-providers.test.ts
+++ b/packages/fleet-infra/tests/auth/auth-providers.test.ts
@@ -52,7 +52,8 @@ describe("auth providers", () => {
       ANTHROPIC_AUTH_TOKEN: "kimi-token",
       ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/",
       ENABLE_TOOL_SEARCH: "false",
-      CLAUDE_CODE_SUBAGENT_MODEL: "kimi-k2.5",
+      ANTHROPIC_MODEL: "kimi-k2.7-code",
+      CLAUDE_CODE_SUBAGENT_MODEL: "kimi-k2.7-code",
       API_TIMEOUT_MS: "3000000",
     });
     // baseUrl 파생 값도 기존 리터럴과 동일한 검증 URL을 만들어야 한다


### PR DESCRIPTION
## Summary

Kimi가 새 coding 모델 `kimi-k2.7-code`를 출시함에 따라([agent-support 가이드](https://platform.kimi.ai/docs/guide/agent-support)), `claude-kimi`(Claude Code with Moonshot Kimi) 프로바이더의 실행 모델을 전환합니다.

- `CLI_BACKENDS` defaultEnv에 `ANTHROPIC_MODEL=kimi-k2.7-code`를 추가하고 `CLAUDE_CODE_SUBAGENT_MODEL`을 갱신 — `resolveAuthEnv`를 거치는 fleet-cli spawn 경로에 그대로 전파됩니다.
- `models.json`의 claude-kimi 3슬롯(haiku/sonnet/opus) 매핑을 공식 가이드대로 전부 `kimi-k2.7-code`로 통일 — unified-agent ACP 경로(`ANTHROPIC_DEFAULT_*_MODEL`)에 적용됩니다.
- base URL은 기존 coding plan 엔드포인트(`api.kimi.com/coding/`)를 유지합니다. 가이드의 `api.moonshot.ai`는 오픈플랫폼(종량제)용으로 기존 인증과 비호환이며, `kimi-k2.7-code`는 현행 엔드포인트에서 라이브 프로브로 실서빙을 확인했습니다.
- `opencode-go/kimi-k2.6` 항목은 별도 백엔드(2.7 지원 미확인)이므로 의도적으로 미변경.

## Type of Change

- [x] feat — new feature or carrier capability

## Scope

- [x] `packages/unified-agent`

## Test Plan

- [x] `kimi-k2.7-code` 라이브 API 프로브 — coding 엔드포인트가 해당 모델 그대로 서빙 확인
- [x] `pnpm -r build` (tsc 포함) green
- [x] `@dotobokuri/fleet-infra` 테스트 67/67 통과 (`resolveAuthEnv` 기대 env 갱신 포함)
- [x] `@dotobokuri/core-unified-agent` unit 96/96 통과
- [x] `@dotobokuri/fleet-cli` 테스트 — `update-installer.test.ts` 2건 실패는 canary에서도 동일한 기존 결함(Windows shim 감지)으로 본 변경과 무관

## Notes for Reviewers

Sentinel 정밀 리뷰 PASS(발견사항 0건): env 누출 없음, `defaultEnv < mappingEnv < options.env` 병합 우선순위 일관, models.json 스키마는 슬롯 동일값 매핑 허용, 잔존 구모델 문자열 없음.