### PR TITLE
fix(wiki-ui): move CLI self-run block to a dedicated bin entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Breaking Changes
 - The `@dotobokuri/core-mcp-server` package is no longer published or resolvable; migrate imports to `@dotobokuri/core-agent`.
 
+### Fixed
+- [core][wiki-web] Fixed Fleet Wiki web opening automatically in the browser when agent CLI sessions start.
+
 ## [1.4.0] - 2026-06-10
 
 ### Added

--- a/runtime/fleet-cli/src/index.ts
+++ b/runtime/fleet-cli/src/index.ts
@@ -43,7 +43,7 @@ if (argv[0] === "hook") {
 }
 
 if (argv[0] === "wiki") {
-  process.exit(await relayToPackageCli("@dotobokuri/fleet-wiki-ui/cli-bin", argv.slice(1)));
+  process.exit(await relayToPackageCli(resolveWikiCliSpecifier(), argv.slice(1)));
 }
 
 if (argv[0] === "console") {
@@ -132,4 +132,14 @@ async function relayToPackageCli(specifier: string, args: readonly string[]): Pr
       resolve(0);
     });
   });
+}
+
+// 구버전 fleet-wiki-ui에는 ./cli-bin export가 없으므로 자기실행형 ./cli 엔트리로 폴백한다.
+function resolveWikiCliSpecifier(): string {
+  try {
+    require.resolve("@dotobokuri/fleet-wiki-ui/cli-bin");
+    return "@dotobokuri/fleet-wiki-ui/cli-bin";
+  } catch {
+    return "@dotobokuri/fleet-wiki-ui/cli";
+  }
 }

--- a/runtime/fleet-cli/src/index.ts
+++ b/runtime/fleet-cli/src/index.ts
@@ -43,7 +43,7 @@ if (argv[0] === "hook") {
 }
 
 if (argv[0] === "wiki") {
-  process.exit(await relayToPackageCli("@dotobokuri/fleet-wiki-ui/cli", argv.slice(1)));
+  process.exit(await relayToPackageCli("@dotobokuri/fleet-wiki-ui/cli-bin", argv.slice(1)));
 }
 
 if (argv[0] === "console") {

--- a/runtime/fleet-wiki-ui/AGENTS.md
+++ b/runtime/fleet-wiki-ui/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## Owns
 
-- The `fleet-wiki` CLI entry point. 글로벌 `fleet-wiki` CLI 진입점은 `process.cwd()`에서 부모 방향으로 가장 가까운 `runtime/fleet-wiki-ui/dist/cli.mjs`를 탐색해 자기 자신과 다르면 그 경로로 재spawn(`spawnSync`, `stdio: inherit`)한다. 이를 통해 git worktree 안에서도 worktree-local dist가 자동 사용된다. 무한 재spawn은 경로 비교 + `FLEET_WIKI_TRAMPOLINED=1` 보조 가드로 방지.
+- The `fleet-wiki` CLI entry point. 글로벌 `fleet-wiki` binary 진입점은 `dist/cli-bin.mjs`이며, `process.cwd()`에서 부모 방향으로 가장 가까운 `runtime/fleet-wiki-ui/dist/cli-bin.mjs`를 우선 탐색하고 구버전 worktree 호환을 위해 `dist/cli.mjs`로 폴백해 자기 자신과 다르면 그 경로로 재spawn(`spawnSync`, `stdio: inherit`)한다. 이를 통해 git worktree 안에서도 worktree-local dist가 자동 사용된다. 무한 재spawn은 경로 비교 + `FLEET_WIKI_TRAMPOLINED=1` 보조 가드로 방지. `dist/cli.mjs`는 `./cli` export의 부수효과 없는 라이브러리 엔트리다.
 - The detached per-user local HTTP daemon for Fleet Wiki browsing.
 - Web API routing, daemon PID/port lock handling, in-memory workspace registration, browser launch helpers, and the standalone Vite client SPA.
 - The full visual identity of the Fleet Wiki reading experience — typography, color, spatial composition, motion, and atmosphere.
@@ -69,7 +69,8 @@ POST Origin guard for browser-facing queue mutations, lockfile bearer auth for C
 
 ## Build Output
 
-- `dist/cli.mjs` is the package binary and the worktree-aware trampoline entry point.
+- `dist/cli.mjs` is the side-effect-free `./cli` library entry.
+- `dist/cli-bin.mjs` is the package binary and the worktree-aware trampoline entry point.
 - `dist/server.mjs` is the detached server entry.
 - `dist/client/` is produced by Vite and contains `index.html`, bundled `assets/*.js`, `assets/*.css`, and font `assets/*.woff2` shards.
 

--- a/runtime/fleet-wiki-ui/package.json
+++ b/runtime/fleet-wiki-ui/package.json
@@ -16,12 +16,15 @@
   "main": "./dist/cli.mjs",
   "types": "./dist/cli.d.ts",
   "bin": {
-    "fleet-wiki": "./dist/cli.mjs"
+    "fleet-wiki": "./dist/cli-bin.mjs"
   },
   "exports": {
     "./cli": {
       "types": "./dist/cli.d.ts",
       "default": "./dist/cli.mjs"
+    },
+    "./cli-bin": {
+      "default": "./dist/cli-bin.mjs"
     },
     "./dist/cli.mjs": {
       "types": "./dist/cli.d.ts",

--- a/runtime/fleet-wiki-ui/src/cli-bin.ts
+++ b/runtime/fleet-wiki-ui/src/cli-bin.ts
@@ -1,0 +1,64 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { findLocalCliMjs, main } from "./cli.js";
+
+const TRAMPOLINE_ENV = "FLEET_WIKI_TRAMPOLINED";
+const SIGNAL_EXIT_FALLBACK_MS = 1000;
+
+maybeTrampolineToLocalCli();
+await main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});
+
+function maybeTrampolineToLocalCli(): void {
+  if (process.env[TRAMPOLINE_ENV] === "1") return;
+  const localCli = findLocalCliMjs(process.cwd());
+  if (!localCli) return;
+
+  const currentCli = fileURLToPath(import.meta.url);
+  if (path.resolve(localCli) === path.resolve(currentCli)) return;
+  if (!isSameGitCommonDir(localCli, currentCli)) return;
+
+  const cyan = process.stderr.isTTY ? "\x1b[36m" : "";
+  const reset = process.stderr.isTTY ? "\x1b[0m" : "";
+  process.stderr.write(`${cyan}fleet-wiki: redirecting to ${localCli}${reset}\n`);
+
+  const result = spawnSync(process.execPath, [localCli, ...process.argv.slice(2)], {
+    stdio: "inherit",
+    env: { ...process.env, [TRAMPOLINE_ENV]: "1" },
+  });
+  if (result.error) {
+    process.stderr.write(`fleet-wiki: trampoline failed: ${result.error.message}\n`);
+    process.exit(1);
+  }
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+    setTimeout(() => process.exit(1), SIGNAL_EXIT_FALLBACK_MS);
+    return;
+  }
+  process.exit(result.status ?? 1);
+}
+
+function isSameGitCommonDir(candidateCli: string, currentCli: string): boolean {
+  const candidateCommonDir = gitCommonDir(path.dirname(candidateCli));
+  const currentCommonDir = gitCommonDir(path.dirname(currentCli));
+  return candidateCommonDir !== null && currentCommonDir !== null && candidateCommonDir === currentCommonDir;
+}
+
+function gitCommonDir(cwd: string): string | null {
+  const result = spawnSync("git", ["-C", cwd, "rev-parse", "--git-common-dir"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (result.error || result.status !== 0 || typeof result.stdout !== "string") {
+    return null;
+  }
+  const rawCommonDir = result.stdout.trim();
+  if (!rawCommonDir) {
+    return null;
+  }
+  return path.resolve(cwd, rawCommonDir);
+}

--- a/runtime/fleet-wiki-ui/src/cli.ts
+++ b/runtime/fleet-wiki-ui/src/cli.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { stat } from "node:fs/promises";
 import net from "node:net";
@@ -74,8 +74,6 @@ const DEFAULT_PORT = 3737;
 const DEFAULT_HOST = "127.0.0.1";
 const HEALTH_TIMEOUT_MS = 5000;
 const HEALTH_INTERVAL_MS = 150;
-const TRAMPOLINE_ENV = "FLEET_WIKI_TRAMPOLINED";
-const SIGNAL_EXIT_FALLBACK_MS = 1000;
 const HELP_BANNER_INDENT = "  ";
 const DEFAULT_HELP_RELEASE = "local";
 const RFC1123_HOSTNAME = /^(?=.{1,253}$)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)*[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/;
@@ -95,24 +93,18 @@ export function parseCliArgs(argv: string[]): CliArgs {
     } else if (arg === "--port") {
       const raw = argv[i + 1];
       if (!raw || raw.startsWith("--")) {
-        process.stderr.write("--port requires a value\n");
-        process.exit(1);
-        return result;
+        throw new Error("--port requires a value");
       }
       i += 1;
       const port = Number(raw);
       if (!Number.isInteger(port) || port <= 0 || port > 65535) {
-        process.stderr.write(`Invalid --port value: ${raw}\n`);
-        process.exit(1);
-        return result;
+        throw new Error(`Invalid --port value: ${raw}`);
       }
       result.port = port;
     } else if (arg === "--host") {
       const raw = argv[i + 1];
       if (!raw || raw.startsWith("--")) {
-        process.stderr.write("--host requires a value\n");
-        process.exit(1);
-        return result;
+        throw new Error("--host requires a value");
       }
       i += 1;
       result.host = parseHostValue(raw);
@@ -120,18 +112,16 @@ export function parseCliArgs(argv: string[]): CliArgs {
       const raw = arg.slice("--port=".length);
       const port = Number(raw);
       if (!Number.isInteger(port) || port <= 0 || port > 65535) {
-        process.stderr.write(`Invalid --port value: ${raw}\n`);
-        process.exit(1);
-        return result;
+        throw new Error(`Invalid --port value: ${raw}`);
       }
       result.port = port;
     } else if (arg.startsWith("--host=")) {
       const raw = arg.slice("--host=".length);
       result.host = parseHostValue(raw);
     } else if (arg.startsWith("--")) {
-      process.stderr.write(`Unknown option: ${arg}\n`);
-      process.exit(1);
-      return result;
+      throw new Error(`Unknown option: ${arg}`);
+    } else {
+      throw new Error(`Unexpected positional argument: ${arg}`);
     }
   }
   return result;
@@ -262,9 +252,13 @@ export async function main(): Promise<void> {
 export function findLocalCliMjs(cwd: string): string | null {
   let currentDir = path.resolve(cwd);
   while (true) {
-    const candidate = path.join(currentDir, "runtime", "fleet-wiki-ui", "dist", "cli.mjs");
-    if (existsSync(candidate)) {
-      return candidate;
+    const cliBinCandidate = path.join(currentDir, "runtime", "fleet-wiki-ui", "dist", "cli-bin.mjs");
+    if (existsSync(cliBinCandidate)) {
+      return cliBinCandidate;
+    }
+    const legacyCliCandidate = path.join(currentDir, "runtime", "fleet-wiki-ui", "dist", "cli.mjs");
+    if (existsSync(legacyCliCandidate)) {
+      return legacyCliCandidate;
     }
     const parentDir = path.dirname(currentDir);
     if (parentDir === currentDir) {
@@ -453,9 +447,7 @@ function configuredPort(): number {
 
 function parseHostValue(raw: string): string {
   if (!isValidHostValue(raw)) {
-    process.stderr.write(`Invalid --host value: ${raw}\n`);
-    process.exit(1);
-    return raw;
+    throw new Error(`Invalid --host value: ${raw}`);
   }
   return raw;
 }
@@ -499,65 +491,6 @@ function signalProcess(pid: number, signal: NodeJS.Signals): boolean {
   }
 }
 
-function maybeTrampolineToLocalCli(): void {
-  if (process.env[TRAMPOLINE_ENV] === "1") return;
-  const localCli = findLocalCliMjs(process.cwd());
-  if (!localCli) return;
-
-  const currentCli = fileURLToPath(import.meta.url);
-  if (path.resolve(localCli) === path.resolve(currentCli)) return;
-  if (!isSameGitCommonDir(localCli, currentCli)) return;
-
-  const cyan = process.stderr.isTTY ? "\x1b[36m" : "";
-  const reset = process.stderr.isTTY ? "\x1b[0m" : "";
-  process.stderr.write(`${cyan}fleet-wiki: redirecting to ${localCli}${reset}\n`);
-
-  const result = spawnSync(process.execPath, [localCli, ...process.argv.slice(2)], {
-    stdio: "inherit",
-    env: { ...process.env, [TRAMPOLINE_ENV]: "1" },
-  });
-  if (result.error) {
-    process.stderr.write(`fleet-wiki: trampoline failed: ${result.error.message}\n`);
-    process.exit(1);
-  }
-  if (result.signal) {
-    process.kill(process.pid, result.signal);
-    setTimeout(() => process.exit(1), SIGNAL_EXIT_FALLBACK_MS);
-    return;
-  }
-  process.exit(result.status ?? 1);
-}
-
-function isSameGitCommonDir(candidateCli: string, currentCli: string): boolean {
-  const candidateCommonDir = gitCommonDir(path.dirname(candidateCli));
-  const currentCommonDir = gitCommonDir(path.dirname(currentCli));
-  return candidateCommonDir !== null && currentCommonDir !== null && candidateCommonDir === currentCommonDir;
-}
-
-function gitCommonDir(cwd: string): string | null {
-  const result = spawnSync("git", ["-C", cwd, "rev-parse", "--git-common-dir"], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-  });
-  if (result.error || result.status !== 0 || typeof result.stdout !== "string") {
-    return null;
-  }
-  const rawCommonDir = result.stdout.trim();
-  if (!rawCommonDir) {
-    return null;
-  }
-  return path.resolve(cwd, rawCommonDir);
-}
-
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error;
-}
-
-const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
-if (isDirectRun) {
-  maybeTrampolineToLocalCli();
-  await main().catch((error) => {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exitCode = 1;
-  });
 }

--- a/runtime/fleet-wiki-ui/tests/cli-args.test.ts
+++ b/runtime/fleet-wiki-ui/tests/cli-args.test.ts
@@ -1,19 +1,6 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { formatHostForUrl, parseCliArgs, resolveBrowserOpenHost, resolveLocalControlHost, serverUrl } from "../src/cli.js";
-
-const originalExit = process.exit;
-const originalStderrWrite = process.stderr.write;
-
-beforeEach(() => {
-  process.exit = vi.fn() as never;
-  process.stderr.write = vi.fn() as never;
-});
-
-afterEach(() => {
-  process.exit = originalExit;
-  process.stderr.write = originalStderrWrite;
-});
 
 describe("parseCliArgs", () => {
   it("parses --port with space-separated value", () => {
@@ -40,62 +27,56 @@ describe("parseCliArgs", () => {
     expect(parseCliArgs(["--help"])).toEqual({ mode: "help" });
   });
 
-  it("exits with error for unknown -- flags", () => {
-    parseCliArgs(["--unknown", "value"]);
-    expect(process.exit).toHaveBeenCalledWith(1);
+  it("throws for unknown -- flags", () => {
+    expect(() => parseCliArgs(["--unknown", "value"])).toThrow("Unknown option: --unknown");
   });
 
-  it("exits with error for unknown -- flag without value", () => {
-    parseCliArgs(["--another"]);
-    expect(process.exit).toHaveBeenCalledWith(1);
+  it("throws for unknown -- flag without value", () => {
+    expect(() => parseCliArgs(["--another"])).toThrow("Unknown option: --another");
   });
 
-  it("ignores non-dash positional arguments", () => {
-    expect(parseCliArgs(["somefile.txt"])).toEqual({ mode: "run" });
+  it("throws for non-dash positional arguments", () => {
+    expect(() => parseCliArgs(["somefile.txt"])).toThrow("Unexpected positional argument: somefile.txt");
+  });
+
+  it("throws for fleet hook positional arguments", () => {
+    expect(() => parseCliArgs(["hook", "subagents-context"])).toThrow("Unexpected positional argument: hook");
   });
 
   it("returns empty object for no args", () => {
     expect(parseCliArgs([])).toEqual({ mode: "run" });
   });
 
-  it("exits with error for --host missing value", () => {
-    parseCliArgs(["--host"]);
-    expect(process.exit).toHaveBeenCalledWith(1);
+  it("throws for --host missing value", () => {
+    expect(() => parseCliArgs(["--host"])).toThrow("--host requires a value");
   });
 
-  it("exits with error for invalid --host value", () => {
-    parseCliArgs(["--host=bad_host!"]);
-    expect(process.exit).toHaveBeenCalledWith(1);
+  it("throws for invalid --host value", () => {
+    expect(() => parseCliArgs(["--host=bad_host!"])).toThrow("Invalid --host value: bad_host!");
   });
 
-  it("exits with error for --port missing value", () => {
-    parseCliArgs(["--port"]);
-    expect(process.exit).toHaveBeenCalledWith(1);
+  it("throws for --port missing value", () => {
+    expect(() => parseCliArgs(["--port"])).toThrow("--port requires a value");
   });
 
-  it("exits with error for --port with non-numeric value", () => {
-    parseCliArgs(["--port", "abc"]);
-    expect(process.exit).toHaveBeenCalledWith(1);
+  it("throws for --port with non-numeric value", () => {
+    expect(() => parseCliArgs(["--port", "abc"])).toThrow("Invalid --port value: abc");
   });
 
-  it("exits with error for --port out of range (0)", () => {
-    parseCliArgs(["--port", "0"]);
-    expect(process.exit).toHaveBeenCalledWith(1);
+  it("throws for --port out of range (0)", () => {
+    expect(() => parseCliArgs(["--port", "0"])).toThrow("Invalid --port value: 0");
   });
 
-  it("exits with error for --port out of range (negative)", () => {
-    parseCliArgs(["--port", "-1"]);
-    expect(process.exit).toHaveBeenCalledWith(1);
+  it("throws for --port out of range (negative)", () => {
+    expect(() => parseCliArgs(["--port", "-1"])).toThrow("Invalid --port value: -1");
   });
 
-  it("exits with error for --port out of range (>65535)", () => {
-    parseCliArgs(["--port", "65536"]);
-    expect(process.exit).toHaveBeenCalledWith(1);
+  it("throws for --port out of range (>65535)", () => {
+    expect(() => parseCliArgs(["--port", "65536"])).toThrow("Invalid --port value: 65536");
   });
 
   it("treats next flag as missing value for --port", () => {
-    parseCliArgs(["--port", "--host", "0.0.0.0"]);
-    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(() => parseCliArgs(["--port", "--host", "0.0.0.0"])).toThrow("--port requires a value");
   });
 });
 

--- a/runtime/fleet-wiki-ui/tests/cli-trampoline.test.ts
+++ b/runtime/fleet-wiki-ui/tests/cli-trampoline.test.ts
@@ -17,10 +17,10 @@ afterEach(async () => {
 });
 
 describe("findLocalCliMjs", () => {
-  it("runtime/fleet-wiki-ui/dist/cli.mjs를 부모 방향으로 탐색해 찾는다", async () => {
+  it("runtime/fleet-wiki-ui/dist/cli-bin.mjs를 부모 방향으로 탐색해 찾는다", async () => {
     const distDir = path.join(tempDir, "runtime", "fleet-wiki-ui", "dist");
     await mkdir(distDir, { recursive: true });
-    const cliPath = path.join(distDir, "cli.mjs");
+    const cliPath = path.join(distDir, "cli-bin.mjs");
     await writeFile(cliPath, "// stub\n", "utf8");
 
     const nestedCwd = path.join(tempDir, "packages", "some-package", "src");
@@ -28,6 +28,25 @@ describe("findLocalCliMjs", () => {
 
     expect(findLocalCliMjs(nestedCwd)).toBe(cliPath);
     expect(findLocalCliMjs(tempDir)).toBe(cliPath);
+  });
+
+  it("cli-bin.mjs가 없으면 구버전 worktree 호환을 위해 cli.mjs로 폴백한다", async () => {
+    const distDir = path.join(tempDir, "runtime", "fleet-wiki-ui", "dist");
+    await mkdir(distDir, { recursive: true });
+    const legacyCliPath = path.join(distDir, "cli.mjs");
+    await writeFile(legacyCliPath, "// stub\n", "utf8");
+
+    expect(findLocalCliMjs(tempDir)).toBe(legacyCliPath);
+  });
+
+  it("cli-bin.mjs를 cli.mjs보다 우선한다", async () => {
+    const distDir = path.join(tempDir, "runtime", "fleet-wiki-ui", "dist");
+    await mkdir(distDir, { recursive: true });
+    const cliBinPath = path.join(distDir, "cli-bin.mjs");
+    await writeFile(cliBinPath, "// stub\n", "utf8");
+    await writeFile(path.join(distDir, "cli.mjs"), "// legacy stub\n", "utf8");
+
+    expect(findLocalCliMjs(tempDir)).toBe(cliBinPath);
   });
 
   it("로컬 dist가 없으면 null을 반환한다", () => {

--- a/runtime/fleet-wiki-ui/tsup.config.ts
+++ b/runtime/fleet-wiki-ui/tsup.config.ts
@@ -27,8 +27,23 @@ export default defineConfig([
       cli: "src/cli.ts"
     },
     format: ["esm"],
-    banner: { js: "#!/usr/bin/env node" },
     dts: true,
+    sourcemap: false,
+    clean: false,
+    noExternal: [/^@dotobokuri\//],
+    splitting: false,
+    treeshake: true,
+    target: "node20",
+    outDir: "dist",
+    outExtension: () => ({ js: ".mjs" }),
+  },
+  {
+    entry: {
+      "cli-bin": "src/cli-bin.ts"
+    },
+    format: ["esm"],
+    banner: { js: "#!/usr/bin/env node" },
+    dts: false,
     sourcemap: false,
     clean: false,
     noExternal: [/^@dotobokuri\//],


### PR DESCRIPTION
## Summary
- fleet-cli로 agent CLI를 LAUNCH할 때마다 Fleet Wiki 웹이 브라우저에 자동으로 열리던 문제를 수정합니다.
- 원인: esbuild 단일 번들인 fleet-cli `dist/index.js`에 `@dotobokuri/fleet-wiki-ui/cli`의 top-level 자기실행 가드(`isDirectRun`)가 함께 번들되어, SessionStart 훅이 `node dist/index.js hook subagents-context`를 직접 실행할 때 `import.meta.url`이 argv[1]과 일치해 오발동 → `openFleetWikiWorkspace()` → 무조건 `openBrowser()`.
- 수정: 자기실행 블록과 worktree 트램펄린을 전용 bin 엔트리(`src/cli-bin.ts` → `dist/cli-bin.mjs`)로 분리해 `./cli` export를 부수효과 없는 순수 라이브러리로 만들고, `fleet-wiki` bin과 `fleet wiki` 서브커맨드 릴레이를 새 엔트리로 전환(구버전 worktree dist는 `cli.mjs` 폴백). 방어선으로 `parseCliArgs`가 알 수 없는 위치 인자를 거부하도록 변경(오류 채널 throw 전환).

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-wiki-ui typecheck && test && build` — 228/228 green
- [x] `pnpm --filter @dotobokuri/fleet-cli build` — tsc green
- [x] 훅 E2E: `/tmp`에서 `node <로컬빌드>/runtime/fleet-cli/dist/index.js hook subagents-context` → wiki 부수효과 없이 훅 JSON만 출력 (수정 전에는 wiki CLI 에러/브라우저 오픈 발생)
- [x] `node dist/cli-bin.mjs --help` 정상, 위치 인자(`hook foo`) exit 1 거부
- [x] sentinel 정확성·보안 리뷰 PASS (finding 0건)
- 참고: fleet-cli `update-installer.test.ts` 실패 2건은 기저 canary에서도 동일 실패하는 무관한 기존 결함