### PR TITLE
feat(core): remove the raw-CLI Native launch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - [core] Gateway auto-refresh now defers stale daemon replacement while active tenants are connected, preserving existing session tokens until an explicit restart.
 
 ### Removed
+- [core] Removed the raw-CLI Native launch mode; dedicated CLIs now always launch with the Fleet persona injected.
 - Removed the `@dotobokuri/core-mcp-server` workspace package; consumers should import generic MCP APIs from `@dotobokuri/core-agent` instead.
 
 ### Breaking Changes

--- a/packages/fleet-infra/src/global-options/store.ts
+++ b/packages/fleet-infra/src/global-options/store.ts
@@ -59,13 +59,11 @@ export function sanitizeGlobalOptionsData(value: unknown): GlobalOptionsValidati
 
   const data: GlobalOptionsData = {
     version: GLOBAL_OPTIONS_VERSION,
-    ...(typeof value.native === "boolean" ? { native: value.native } : {}),
     ...(typeof value.replaceSystemPrompt === "boolean" ? { replaceSystemPrompt: value.replaceSystemPrompt } : {}),
     ...(typeof value.enableMetaphor === "boolean" ? { enableMetaphor: value.enableMetaphor } : {}),
   };
-  const allowedKeys = new Set(["version", "native", "replaceSystemPrompt", "enableMetaphor"]);
+  const allowedKeys = new Set(["version", "replaceSystemPrompt", "enableMetaphor"]);
   const changed = Object.keys(value).some((key) => !allowedKeys.has(key)) ||
-    ("native" in value && typeof value.native !== "boolean") ||
     ("replaceSystemPrompt" in value && typeof value.replaceSystemPrompt !== "boolean") ||
     ("enableMetaphor" in value && typeof value.enableMetaphor !== "boolean");
 

--- a/packages/fleet-infra/src/global-options/types.ts
+++ b/packages/fleet-infra/src/global-options/types.ts
@@ -1,6 +1,5 @@
 export interface GlobalOptionsData {
   readonly version: 1;
-  readonly native?: boolean;
   readonly replaceSystemPrompt?: boolean;
   readonly enableMetaphor?: boolean;
 }

--- a/packages/fleet-infra/tests/global-options-store.test.ts
+++ b/packages/fleet-infra/tests/global-options-store.test.ts
@@ -32,7 +32,6 @@ describe("global options store", () => {
       [["default", "CliId"].join("")]: "codex",
       byCli: {
         codex: {
-          native: true,
           replaceSystemPrompt: true,
           enableMetaphor: true,
         },
@@ -57,7 +56,7 @@ describe("global options store", () => {
   it("sanitizes unknown schema fields and invalid values", () => {
     expect(sanitizeGlobalOptionsData({
       version: 1,
-      native: true,
+      obsoleteOption: true,
       replaceSystemPrompt: "yes",
       enableMetaphor: false,
       byCli: { claude: { model: "opus" } },
@@ -68,7 +67,6 @@ describe("global options store", () => {
       changed: true,
       data: {
         version: 1,
-        native: true,
         enableMetaphor: false,
       },
     });
@@ -76,7 +74,7 @@ describe("global options store", () => {
 
   it("ignores stale settings files without the current schema marker", () => {
     expect(sanitizeGlobalOptionsData({
-      native: true,
+      obsoleteOption: true,
       replaceSystemPrompt: true,
       enableMetaphor: true,
       oldSection: {},
@@ -92,7 +90,7 @@ describe("global options store", () => {
     const dataDir = makeTempDir();
     fs.writeFileSync(path.join(dataDir, "settings.json"), JSON.stringify({
       version: 99,
-      native: true,
+      obsoleteOption: true,
       replaceSystemPrompt: true,
       enableMetaphor: true,
     }));
@@ -108,14 +106,12 @@ describe("global options store", () => {
 
     service.save({
       version: 1,
-      native: true,
       replaceSystemPrompt: true,
       enableMetaphor: false,
     });
 
     expect(JSON.parse(fs.readFileSync(path.join(dataDir, "settings.json"), "utf-8"))).toEqual({
       version: 1,
-      native: true,
       replaceSystemPrompt: true,
       enableMetaphor: false,
     });
@@ -174,13 +170,13 @@ describe("global options store", () => {
     const second = createGlobalOptionsStore({ dataDir, timeoutMs: 1_000 });
 
     await Promise.all([
-      Promise.resolve().then(() => first.update((current) => ({ ...current, native: true }))),
+      Promise.resolve().then(() => first.update((current) => ({ ...current, replaceSystemPrompt: false }))),
       Promise.resolve().then(() => second.update((current) => ({ ...current, enableMetaphor: true }))),
     ]);
 
     expect(first.load()).toEqual({
       version: 1,
-      native: true,
+      replaceSystemPrompt: false,
       enableMetaphor: true,
     });
   });

--- a/runtime/fleet-cli/src/app.ts
+++ b/runtime/fleet-cli/src/app.ts
@@ -89,7 +89,6 @@ export async function runApp(options: RunAppOptions = {}): Promise<void> {
     defaults: {
       cliId: getDefaultAgentCliId(),
       enableMetaphor: false,
-      native: false,
       replaceSystemPrompt: true,
     },
     env: process.env,
@@ -135,18 +134,16 @@ export async function runApp(options: RunAppOptions = {}): Promise<void> {
     carrierRuntime: runtime.carrierRuntime,
     createPtyHost: (profile) => createPtyHost({ profile }),
     injectProfile: (profile, launchOptions) =>
-      (launchOptions ?? sessionOptionsRuntime.getDraft()).native
-        ? Promise.resolve(profile)
-        : injectAgentCliProfile(profile, {
-            buildSystemPrompt,
-            carrierRuntime: runtime.carrierRuntime,
-            dedicatedMcpSession: runtime.dedicatedMcpSession,
-            enableMetaphor: (launchOptions ?? sessionOptionsRuntime.getDraft()).enableMetaphor,
-            onCleanup: (cleanup) => agentCliCleanupCallbacks.add(cleanup),
-            replaceSystemPrompt: (launchOptions ?? sessionOptionsRuntime.getDraft()).replaceSystemPrompt,
-            pluginAssetsDir: options.pluginAssetsDir,
-            pluginEntry: options.pluginEntry,
-          }),
+      injectAgentCliProfile(profile, {
+        buildSystemPrompt,
+        carrierRuntime: runtime.carrierRuntime,
+        dedicatedMcpSession: runtime.dedicatedMcpSession,
+        enableMetaphor: (launchOptions ?? sessionOptionsRuntime.getDraft()).enableMetaphor,
+        onCleanup: (cleanup) => agentCliCleanupCallbacks.add(cleanup),
+        replaceSystemPrompt: (launchOptions ?? sessionOptionsRuntime.getDraft()).replaceSystemPrompt,
+        pluginAssetsDir: options.pluginAssetsDir,
+        pluginEntry: options.pluginEntry,
+      }),
     loadedCounts: discoverMissionControlCounts({ invocationCwd }),
     onExitFleet: () => stop(),
     onRenderRequest: () => {

--- a/runtime/fleet-cli/src/mission-control/controller.ts
+++ b/runtime/fleet-cli/src/mission-control/controller.ts
@@ -343,10 +343,6 @@ export function createMissionControlController(options: CreateMissionControlCont
         options.sessionOptions?.toggleEnableMetaphor();
         options.onRenderRequest();
       },
-      toggleNative: () => {
-        options.sessionOptions?.toggleNative();
-        options.onRenderRequest();
-      },
       toggleReplaceSystemPrompt: () => {
         options.sessionOptions?.toggleReplaceSystemPrompt();
         options.onRenderRequest();
@@ -453,7 +449,6 @@ function createMissionRootPanel(options: {
   readonly selectedCliId: () => AgentCliId;
   readonly sessionOptions: CreateMissionControlControllerOptions["sessionOptions"];
   readonly toggleEnableMetaphor: () => void;
-  readonly toggleNative: () => void;
   readonly toggleReplaceSystemPrompt: () => void;
 }): MenuPanel {
   return createSectionedListPanel({
@@ -492,8 +487,9 @@ function createMissionRootRows(options: Parameters<typeof createMissionRootPanel
       kind: "toggle",
       id: "option:mode",
       label: "Mode",
-      value: values?.native ? "Native" : "Fleet Action",
-      toggle: options.toggleNative,
+      // Native 모드 제거로 선택값은 "Fleet Action" 하나뿐 — Mode 개념/행은 유지하되 토글은 no-op.
+      value: "Fleet Action",
+      toggle: () => {},
     },
     {
       kind: "toggle",
@@ -660,9 +656,6 @@ function formatSystemPromptOption(sessionOptions: CreateMissionControlController
   const values = sessionOptions?.getResolved().values;
   if (values === undefined) {
     return "Unavailable";
-  }
-  if (values.native) {
-    return "Native";
   }
   return values.replaceSystemPrompt ? "Replace" : "Append";
 }

--- a/runtime/fleet-cli/src/mission-control/options/resolver.ts
+++ b/runtime/fleet-cli/src/mission-control/options/resolver.ts
@@ -9,11 +9,6 @@ export function resolveSessionOptions(input: SessionOptionsResolverInput): Resol
   const envCliId = input.parseCliId(input.env.FLEET_AGENT_CLI);
   const cliId = input.cliIdOverride ?? envCliId ?? input.defaults.cliId;
   const cliIdSource = input.cliIdOverride !== undefined ? "arg" : envCliId !== undefined ? "env" : "default";
-  const native = chooseBooleanWithoutArg({
-    env: parseBooleanEnv(input.env.FLEET_NATIVE),
-    globalOptions: input.globalOptions.native,
-    fallback: input.defaults.native,
-  });
   const replaceSystemPrompt = chooseBooleanWithoutArg({
     env: parseBooleanEnv(input.env.FLEET_REPLACE_SYSTEM_PROMPT),
     globalOptions: input.globalOptions.replaceSystemPrompt,
@@ -29,14 +24,12 @@ export function resolveSessionOptions(input: SessionOptionsResolverInput): Resol
     values: {
       cliId,
       model: input.defaults.model,
-      native: native.value,
       replaceSystemPrompt: replaceSystemPrompt.value,
       enableMetaphor: enableMetaphor.value,
     },
     sources: {
       cliId: cliIdSource,
       model: "default",
-      native: native.source,
       replaceSystemPrompt: replaceSystemPrompt.source,
       enableMetaphor: enableMetaphor.source,
     },

--- a/runtime/fleet-cli/src/mission-control/options/runtime.ts
+++ b/runtime/fleet-cli/src/mission-control/options/runtime.ts
@@ -27,7 +27,6 @@ export function createSessionOptionsRuntime(options: CreateSessionOptionsRuntime
       } as SessionOptions;
       markSession("cliId");
     },
-    toggleNative: () => updateBoolean("native", !draft.native),
     toggleReplaceSystemPrompt: () => updateBoolean("replaceSystemPrompt", !draft.replaceSystemPrompt),
     toggleEnableMetaphor: () => updateBoolean("enableMetaphor", !draft.enableMetaphor),
     setModel: (model) => {
@@ -64,7 +63,7 @@ export function createSessionOptionsRuntime(options: CreateSessionOptionsRuntime
     sessionFields = new Set(sessionFields).add(field);
   }
 
-  function persistGlobalOptions(field: "native" | "replaceSystemPrompt" | "enableMetaphor", value: boolean): void {
+  function persistGlobalOptions(field: "replaceSystemPrompt" | "enableMetaphor", value: boolean): void {
     statusLines = [];
     void Promise.resolve()
       .then(() => {
@@ -88,7 +87,7 @@ export function createSessionOptionsRuntime(options: CreateSessionOptionsRuntime
     };
   }
 
-  function updateBoolean(field: "native" | "replaceSystemPrompt" | "enableMetaphor", value: boolean): void {
+  function updateBoolean(field: "replaceSystemPrompt" | "enableMetaphor", value: boolean): void {
     globalOptions = { ...globalOptions, [field]: value };
     resolved = resolve();
     draft = { ...draft, [field]: value };

--- a/runtime/fleet-cli/src/mission-control/options/types.ts
+++ b/runtime/fleet-cli/src/mission-control/options/types.ts
@@ -8,7 +8,6 @@ export type SessionOptionSource = "arg" | "env" | "global-options" | "default" |
 export interface SessionOptions {
   readonly cliId: AgentCliId;
   readonly model?: string;
-  readonly native: boolean;
   readonly replaceSystemPrompt: boolean;
   readonly enableMetaphor: boolean;
 }
@@ -32,7 +31,6 @@ export interface SessionOptionsRuntime {
   readonly getDraft: () => SessionOptions;
   readonly getStatusLines: () => readonly string[];
   readonly selectCli: (cliId: AgentCliId) => void;
-  readonly toggleNative: () => void;
   readonly toggleReplaceSystemPrompt: () => void;
   readonly toggleEnableMetaphor: () => void;
   readonly setModel: (model: string | undefined) => void;

--- a/runtime/fleet-cli/tests/mission-control.test.ts
+++ b/runtime/fleet-cli/tests/mission-control.test.ts
@@ -224,6 +224,7 @@ describe("Mission Control controller", () => {
     expect(optionsOutput).toContain(FLEET_BANNER_SAMPLE);
     expect(optionsOutput).toContain("OPTION");
     expect(optionsOutput).toContain("Mode");
+    expect(optionsOutput).toContain("Fleet Action");
     expect(optionsOutput).not.toContain(["Save", "defaults"].join(" "));
     const systemController = createTestController({
       sessionOptions: createFakeSessionOptionsRuntime(),
@@ -332,14 +333,14 @@ describe("Mission Control controller", () => {
     const controller = createTestController({ sessionOptions });
 
     openOptions(controller);
+    // OPTION 첫 행은 Mode(no-op) — Enter해도 calls에 기록되지 않는다.
     controller.ptyHost.write("\r");
     controller.ptyHost.write("\x1b[B");
     controller.ptyHost.write("\r");
-    await waitForAsyncLaunch();
     controller.ptyHost.write("\x1b[B");
     controller.ptyHost.write("\r");
 
-    expect(sessionOptions.calls).toEqual(["toggleNative", "toggleReplaceSystemPrompt", "toggleEnableMetaphor"]);
+    expect(sessionOptions.calls).toEqual(["toggleReplaceSystemPrompt", "toggleEnableMetaphor"]);
   });
 
   it("renders auto-save failures without unhandled rejections", async () => {
@@ -372,16 +373,16 @@ describe("Mission Control controller", () => {
 
     openOptions(controller);
     controller.ptyHost.write("\r");
-    expect(renderPlain(controller)).toMatch(/Mode\s+Native/);
+    expect(renderPlain(controller)).toMatch(/Mode\s+Fleet Action/);
 
     controller.ptyHost.write("\x1b[B");
     controller.ptyHost.write("\r");
-    expect(renderPlain(controller)).toMatch(/System prompt\s+Native/);
+    expect(renderPlain(controller)).toMatch(/System prompt\s+Append/);
 
     controller.ptyHost.write("\x1b[B");
     controller.ptyHost.write("\r");
     expect(renderPlain(controller)).toMatch(/Metaphor\s+Enabled/);
-    expect(sessionOptions.calls).toEqual(["toggleNative", "toggleReplaceSystemPrompt", "toggleEnableMetaphor"]);
+    expect(sessionOptions.calls).toEqual(["toggleReplaceSystemPrompt", "toggleEnableMetaphor"]);
   });
 
   it("edits launch-time model override from the Start panel", () => {
@@ -1138,7 +1139,6 @@ describe("Mission Control controller", () => {
         cliId: "codex" as const,
         enableMetaphor: true,
         model: "draft-model",
-        native: true,
         replaceSystemPrompt: false,
       }),
     };
@@ -1249,7 +1249,6 @@ describe("Mission Control controller", () => {
       cliId: "codex",
       enableMetaphor: true,
       model: "draft-test",
-      native: true,
       replaceSystemPrompt: false,
     });
 
@@ -1309,14 +1308,12 @@ function createFakeSessionOptionsRuntime(): SessionOptionsRuntime & { readonly c
     cliId: "claude" as const,
     enableMetaphor: false,
     model: "preset-model",
-    native: false,
     replaceSystemPrompt: true,
   };
   let sources: ResolvedSessionOptions["sources"] = {
     cliId: "default" as const,
     enableMetaphor: "default" as const,
     model: "session" as const,
-    native: "default" as const,
     replaceSystemPrompt: "default" as const,
   };
   return {
@@ -1340,11 +1337,6 @@ function createFakeSessionOptionsRuntime(): SessionOptionsRuntime & { readonly c
       calls.push("toggleEnableMetaphor");
       draft = { ...draft, enableMetaphor: !draft.enableMetaphor };
       sources = { ...sources, enableMetaphor: "session" };
-    },
-    toggleNative: () => {
-      calls.push("toggleNative");
-      draft = { ...draft, native: !draft.native };
-      sources = { ...sources, native: "session" };
     },
     toggleReplaceSystemPrompt: () => {
       calls.push("toggleReplaceSystemPrompt");

--- a/runtime/fleet-cli/tests/session-options.test.ts
+++ b/runtime/fleet-cli/tests/session-options.test.ts
@@ -10,7 +10,6 @@ import type { SessionOptions } from "../src/mission-control/options/types.js";
 const DEFAULTS: SessionOptions = {
   cliId: "claude",
   enableMetaphor: false,
-  native: false,
   replaceSystemPrompt: true,
 };
 const EMPTY_GLOBAL_OPTIONS = {
@@ -26,12 +25,10 @@ describe("session options resolver", () => {
       env: {
         FLEET_AGENT_CLI: "claude-kimi",
         FLEET_ENABLE_METAPHOR: "1",
-        FLEET_NATIVE: "1",
         FLEET_REPLACE_SYSTEM_PROMPT: "0",
       },
       globalOptions: {
         version: 1,
-        native: false,
         replaceSystemPrompt: true,
         enableMetaphor: false,
       },
@@ -41,14 +38,12 @@ describe("session options resolver", () => {
     expect(resolved.values).toEqual({
       cliId: "codex",
       enableMetaphor: true,
-      native: true,
       replaceSystemPrompt: false,
     });
     expect(resolved.sources).toEqual({
       cliId: "arg",
       enableMetaphor: "env",
       model: "default",
-      native: "env",
       replaceSystemPrompt: "env",
     });
   });
@@ -60,7 +55,6 @@ describe("session options resolver", () => {
       env: { FLEET_AGENT_CLI: "claude-kimi" },
       globalOptions: {
         version: 1,
-        native: true,
         replaceSystemPrompt: true,
         enableMetaphor: true,
       },
@@ -69,7 +63,7 @@ describe("session options resolver", () => {
 
     expect(resolved.values.cliId).toBe("claude-kimi");
     expect(resolved.sources.cliId).toBe("env");
-    expect(resolved.sources.native).toBe("global-options");
+    expect(resolved.sources.enableMetaphor).toBe("global-options");
   });
 
   it("rejects invalid env CLI IDs", () => {
@@ -88,7 +82,7 @@ describe("session options resolver", () => {
     resolveSessionOptions({
       argv: parseFleetCliOptions([], {}),
       defaults: DEFAULTS,
-      env: { FLEET_NATIVE: "1" },
+      env: { FLEET_ENABLE_METAPHOR: "1" },
       globalOptions: EMPTY_GLOBAL_OPTIONS,
       parseCliId: parseAgentCliId,
     });
@@ -133,12 +127,12 @@ describe("session options runtime", () => {
     });
 
     runtime.setModel("draft-model");
-    runtime.toggleNative();
+    runtime.toggleEnableMetaphor();
     await Promise.resolve();
 
     expect(calls).toEqual([{
       version: 1,
-      native: true,
+      enableMetaphor: true,
     }]);
   });
 
@@ -205,13 +199,13 @@ describe("session options runtime", () => {
       parseCliId: parseAgentCliId,
     });
 
-    runtime.toggleNative();
+    runtime.toggleReplaceSystemPrompt();
     runtime.toggleEnableMetaphor();
     await Promise.resolve();
 
     expect(calls.at(-1)).toEqual({
       version: 1,
-      native: true,
+      replaceSystemPrompt: false,
       enableMetaphor: true,
     });
   });
@@ -233,11 +227,11 @@ describe("session options runtime", () => {
       parseCliId: parseAgentCliId,
     });
 
-    runtime.toggleNative();
+    runtime.toggleEnableMetaphor();
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(runtime.getDraft().native).toBe(true);
+    expect(runtime.getDraft().enableMetaphor).toBe(true);
     expect(runtime.getStatusLines()).toEqual(["Save failed: disk full"]);
   });
 });


### PR DESCRIPTION
## Summary
- raw-CLI Native 모드(페르소나 주입 없이 dedicated CLI를 그대로 실행)를 제거했습니다. dedicated CLI는 이제 **항상 Fleet 페르소나가 주입**됩니다.
- `SessionOptions.native` / `FLEET_NATIVE` env / `GlobalOptionsData.native` 영속 축을 제거하고, `app.ts`의 injection-skip 분기를 삭제했습니다. (기존 `~/.fleet/settings.json`의 잔존 `native` 키는 unknown key로 graceful drop — 데이터 손실 없음)
- OPTION 의 "Mode" 행은 개념·UI를 유지하되 "Fleet Action" 고정 no-op 토글로 남겼습니다.
- (B) Native(SubAgent) carrier 모드, `replaceSystemPrompt` / `enableMetaphor`, Windows native, Codex app-server native 로그는 보존했습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-cli build` (tsc) — green
- [x] `pnpm --filter @dotobokuri/fleet-cli test` — 313 passed / 2 skipped
- [x] `pnpm --filter @dotobokuri/fleet-infra build` — green
- [x] `pnpm --filter @dotobokuri/fleet-infra test` — 67 passed
- [x] 잔존 native 참조 grep 0건 (`.native` / `toggleNative` / `FLEET_NATIVE` / `option:mode`)