### PR TITLE
chore: native PTY input/resize hardening, console operation controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - [core] Added `fleet --headless` flag to opt a session into registration with a running Fleet Console for live observation.
 - [core] Fleet now runs Fleet Console as the local fullstack control surface, removes the global gateway daemon, and returns MCP connectivity to per-CLI in-process servers.
 - [core-agent] Added shared CLI registration contracts and generic in-process MCP server primitives for Fleet runtimes.
+- [core] Fleet Console's Operations sidebar now has a close control on each operation card that terminates the underlying session and removes it from the rail.
 
 ### Changed
 - [core-unified-agent] Claude Code with Moonshot Kimi now runs the Kimi K2.7 coding model as the default, slot-mapped, and subagent model.
@@ -32,6 +33,7 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - [core] Renamed the Admiral protocol-mode skills to `protocol-baseline`, `protocol-midline`, `protocol-redline`, and `protocol-frontline`, and the auxiliary gap-audit skill to `assumption-audit`, dropping the redundant `fleet-` prefix from built-in skill identifiers.
 - [core] Fleet Console's native folder picker now opens the modern Windows Explorer-style folder dialog (address bar, search, path paste) instead of the legacy folder-tree dialog on both native Windows and WSL, and under WSL it starts in the Linux filesystem so WSL folders are reachable from the navigation pane without typing the path.
 - [core] Fleet Console browser payloads no longer expose raw working-directory paths; observer Theater and workspace rows now carry display labels only.
+- [core] Fleet Console's Operations launch (+) control now adopts the Theater selector's glass-well instrument styling with a vector plus mark.
 
 ### Removed
 - [wiki-web] Removed the standalone `fleet-wiki-ui` runtime package; Fleet Wiki browsing is now served by Fleet Console.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - [core-agent] The `@dotobokuri/core-mcp-server` package is no longer published or resolvable; migrate imports to `@dotobokuri/core-agent`.
 
 ### Fixed
+- [core] Claude Code on Windows now shows the terminal cursor and accepts Korean/CJK IME input correctly in the default (non-native) mode; previously the cursor was hidden and stray spaces were inserted while composing. Pass `--disable-cursor-sync` or set `FLEET_CURSOR_SYNC=0` to opt out on terminals where cursor projection still misbehaves.
 - [core] Fleet Console now preserves active CLI sessions across local server health refreshes until an explicit restart.
 - [core][wiki-web] Fixed Fleet Wiki web opening automatically in the browser when agent CLI sessions start.
 - [core] Fleet Console's native folder picker now works under WSL by opening the Windows folder dialog through interop and translating the chosen Windows or WSL path back to a native Linux path.

--- a/runtime/fleet-cli/AGENTS.md
+++ b/runtime/fleet-cli/AGENTS.md
@@ -57,9 +57,8 @@ The default app uses the permanent vertical two-pane layout:
 
 Outer-terminal cursor sync policy is owned here; `src/tui/` supplies the local renderer and generic anchor primitives (`getCursorAnchor`, `setCursorAnchorTarget`, `cursorSyncEnabled`, post-flush `requestRender` callback).
 
-- **Policy sync**: `createCursorPolicySync()` in `src/controls/render.ts` runs before each scheduled render and sets `LocalTui.setCursorAnchorTarget(...)`. Active target is the Agent CLI PTY view when cursor sync is on, the Fleet PTY has no active overlay, and Mission Control has no active panel; otherwise the target is cleared.
-- **Windows Claude Code compatibility**: Native Windows (`process.platform === "win32"`) auto-clears the cursor anchor target for Claude-family Agent CLI profiles unless cursor sync was explicitly enabled with `FLEET_CURSOR_SYNC=1`/`true`/`yes`/`on`.
-- **Off-switch** (read-only env; do not mutate `process.env`): `RunAppOptions.cursorSync` (default on), CLI `--disable-cursor-sync`, and `FLEET_CURSOR_SYNC=0` or `false` parsed in `cli-args.ts` and passed through `index.ts`.
+- **Policy sync**: `createCursorPolicySync()` in `src/controls/render.ts` runs before each scheduled render and sets `LocalTui.setCursorAnchorTarget(...)`. Active target is the Agent CLI PTY view when cursor sync is on, the Fleet PTY has no active overlay, and Mission Control has no active panel; otherwise the target is cleared. Cursor sync defaults on for all platforms and Agent CLI profiles — the trailing-padding-trim projection in `src/controls/terminal-view.ts` keeps the Windows ConPTY/Ink cursor anchored at the input cell, so the former `win32`+Claude-family auto-disable was removed (it hid the cursor entirely and broke CJK IME composition; see CHANGELOG).
+- **Off-switch** (read-only env; do not mutate `process.env`): `RunAppOptions.cursorSync` (default on), CLI `--disable-cursor-sync`, and `FLEET_CURSOR_SYNC=0` or `false` parsed in `cli-args.ts` and passed through `index.ts`. This is the escape hatch for any terminal whose IME anchoring still misbehaves.
 - **Boundary**: IME/terminal compatibility decisions and overlay gating stay in this package; do not push host policy into generic `src/tui` renderer or anchor types.
 
 ## Development & Execution

--- a/runtime/fleet-cli/src/app.ts
+++ b/runtime/fleet-cli/src/app.ts
@@ -225,9 +225,7 @@ export async function runApp(options: RunAppOptions = {}): Promise<void> {
   });
   syncCursorPolicy = createCursorPolicySync({
     cursorSync: argvOptions.cursorSync,
-    cursorSyncExplicitlyEnabled: argvOptions.cursorSyncExplicitlyEnabled,
     fleetPty: missionBridge.ptyApi,
-    getActiveAgentProfileId: () => missionControl.getActiveProfile()?.id,
     hasActiveMissionControlPanel: missionControl.hasActivePanel,
     ptyView: missionControl.ptyView,
     ui,
@@ -261,7 +259,6 @@ function createRunAppArgOptions(options: RunAppOptions): FleetCliOptions {
       cursorSync: options.cursorSync === false,
     },
     cursorSync: options.cursorSync !== false,
-    cursorSyncExplicitlyEnabled: false,
     headless: false,
     nativeTerminal: false,
     help: false,

--- a/runtime/fleet-cli/src/cli-args.ts
+++ b/runtime/fleet-cli/src/cli-args.ts
@@ -14,7 +14,6 @@ import { readFleetCliRelease, type FleetCliRelease } from "./release.js";
 
 export interface FleetCliOptions {
   readonly cursorSync: boolean;
-  readonly cursorSyncExplicitlyEnabled: boolean;
   readonly argvOverrides: FleetCliArgOverrides;
   readonly help: boolean;
   readonly headless: boolean;
@@ -40,12 +39,9 @@ type MutableFleetCliArgOverrides = {
 const FALSE_VALUES = new Set(["0", "false", "no", "off"]);
 const HELP_BANNER_INDENT = "  ";
 const HELP_HINT = "Run 'fleet --help' for usage.";
-const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
 
 export function parseFleetCliOptions(argv: readonly string[], env: NodeJS.ProcessEnv = process.env): FleetCliOptions {
-  const cursorSyncEnv = parseCursorSyncEnv(env.FLEET_CURSOR_SYNC);
-  let cursorSync = cursorSyncEnv.value;
-  let cursorSyncExplicitlyEnabled = cursorSyncEnv.explicitlyEnabled;
+  let cursorSync = parseCursorSyncEnv(env.FLEET_CURSOR_SYNC);
   let help = false;
   let headless = false;
   let nativeTerminal = false;
@@ -60,13 +56,12 @@ export function parseFleetCliOptions(argv: readonly string[], env: NodeJS.Proces
       headless = true;
     } else if (arg === "--disable-cursor-sync") {
       cursorSync = false;
-      cursorSyncExplicitlyEnabled = false;
       argvOverrides.cursorSync = true;
     } else {
       throw new Error(formatUnknownFleetOption(arg));
     }
   }
-  return { cursorSync, cursorSyncExplicitlyEnabled, argvOverrides, help, headless, nativeTerminal };
+  return { cursorSync, argvOverrides, help, headless, nativeTerminal };
 }
 
 export function parseFleetHookCommand(argv: readonly string[]): FleetHookCommand {
@@ -107,9 +102,7 @@ export function buildFleetHelpText(options: BuildFleetHelpTextOptions = {}): str
     `  ${option("--headless", colorEnabled)}         ${dim("Register this session to a running Fleet Console for live observation.", colorEnabled)}`,
     `  ${option("--disable-cursor-sync", colorEnabled)}`,
     `                      ${dim("Disable outer-terminal cursor projection for terminals", colorEnabled)}`,
-    `                      ${dim("with problematic IME cursor anchoring.", colorEnabled)}`,
-    `                      ${dim("Claude Code on Windows defaults to disabled; set", colorEnabled)}`,
-    `                      ${dim("FLEET_CURSOR_SYNC=1 to override.", colorEnabled)}`,
+    `                      ${dim("with problematic IME cursor anchoring (or FLEET_CURSOR_SYNC=0).", colorEnabled)}`,
     "",
   ];
   const text = `${lines.join("\n")}`;
@@ -126,19 +119,10 @@ function formatUnknownFleetOption(option: string): string {
   return `Unknown fleet option: ${option}\n${HELP_HINT}`;
 }
 
-function parseCursorSyncEnv(value: string | undefined): { readonly explicitlyEnabled: boolean; readonly value: boolean } {
+function parseCursorSyncEnv(value: string | undefined): boolean {
   if (value === undefined) {
-    return { explicitlyEnabled: false, value: true };
+    return true;
   }
 
-  const normalized = value.trim().toLowerCase();
-  if (TRUE_VALUES.has(normalized)) {
-    return { explicitlyEnabled: true, value: true };
-  }
-
-  if (FALSE_VALUES.has(normalized)) {
-    return { explicitlyEnabled: false, value: false };
-  }
-
-  return { explicitlyEnabled: false, value: true };
+  return !FALSE_VALUES.has(value.trim().toLowerCase());
 }

--- a/runtime/fleet-cli/src/controls/pty/shell.ts
+++ b/runtime/fleet-cli/src/controls/pty/shell.ts
@@ -15,7 +15,25 @@ export function startShell(config: PtyLaunchConfig, opts: PtyStartOptions): IPty
 }
 
 export function resizeShell(child: IPty | undefined, cols: number, rows: number): void {
-  child?.resize(cols, rows);
+  if (child === undefined) {
+    return;
+  }
+  try {
+    child.resize(cols, rows);
+  } catch (error) {
+    // Windows ConPTY에서 child PTY가 종료된 직후, exit 이벤트가 host로 전파되어 child 참조가
+    // 비워지기 전 짧은 경합 창이 존재한다. 이 창에서 마지막 출력 flush가 유발한 렌더→resize가
+    // 이미 종료된 PTY에 도달하면 node-pty가 동기 throw를 던진다. resize는 순수 화면 보정이므로
+    // 이 종료-경합 케이스만 무시하고, 잘못된 cols/rows 같은 그 외 오류는 그대로 다시 던진다.
+    if (isPtyAlreadyExitedError(error)) {
+      return;
+    }
+    throw error;
+  }
+}
+
+function isPtyAlreadyExitedError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("already exited");
 }
 
 export function killShell(child: IPty | undefined): void {

--- a/runtime/fleet-cli/src/controls/pty/shell.ts
+++ b/runtime/fleet-cli/src/controls/pty/shell.ts
@@ -11,6 +11,7 @@ export function startShell(config: PtyLaunchConfig, opts: PtyStartOptions): IPty
     env: config.profile.env,
     name: config.profile.terminalName,
     rows: opts.rows,
+    useConptyDll: opts.useConptyDll,
   });
 }
 

--- a/runtime/fleet-cli/src/controls/pty/shell.ts
+++ b/runtime/fleet-cli/src/controls/pty/shell.ts
@@ -11,7 +11,6 @@ export function startShell(config: PtyLaunchConfig, opts: PtyStartOptions): IPty
     env: config.profile.env,
     name: config.profile.terminalName,
     rows: opts.rows,
-    useConptyDll: opts.useConptyDll,
   });
 }
 

--- a/runtime/fleet-cli/src/controls/render.ts
+++ b/runtime/fleet-cli/src/controls/render.ts
@@ -1,6 +1,5 @@
 import { LocalTui } from "../tui/renderer.js";
 
-import type { AgentCliId } from "../agent-cli/types.js";
 import type { Component, FleetPtyApi } from "./types.js";
 
 export type RenderCallback = () => void;
@@ -11,7 +10,6 @@ interface RenderSchedulerUi {
 }
 
 const RENDER_THROTTLE_MS = 16;
-const CLAUDE_CODE_AGENT_IDS = new Set<AgentCliId>(["claude", "claude-kimi"]);
 
 export function createRenderScheduler(ui: RenderSchedulerUi, beforeRender: () => void): RenderScheduler {
   let renderPending = false;
@@ -56,9 +54,7 @@ export function createFleetPtyViewport(fleetPty: FleetPtyApi): Component {
 
 export function createCursorPolicySync(options: {
   readonly cursorSync: boolean;
-  readonly cursorSyncExplicitlyEnabled?: boolean;
   readonly fleetPty: FleetPtyApi;
-  readonly getActiveAgentProfileId?: () => AgentCliId | undefined;
   readonly hasActiveMissionControlPanel: () => boolean;
   readonly ptyView: Component;
   readonly ui: LocalTui;
@@ -68,7 +64,6 @@ export function createCursorPolicySync(options: {
       !options.cursorSync
       || options.hasActiveMissionControlPanel()
       || options.fleetPty.hasActiveOverlay()
-      || shouldAutoDisableCursorSync(options.getActiveAgentProfileId?.(), options.cursorSyncExplicitlyEnabled === true)
     ) {
       options.ui.setCursorAnchorTarget(undefined);
       return;
@@ -76,11 +71,4 @@ export function createCursorPolicySync(options: {
 
     options.ui.setCursorAnchorTarget(options.ptyView);
   };
-}
-
-function shouldAutoDisableCursorSync(
-  profileId: AgentCliId | undefined,
-  cursorSyncExplicitlyEnabled = false,
-): boolean {
-  return process.platform === "win32" && !cursorSyncExplicitlyEnabled && profileId !== undefined && CLAUDE_CODE_AGENT_IDS.has(profileId);
 }

--- a/runtime/fleet-cli/src/controls/types.ts
+++ b/runtime/fleet-cli/src/controls/types.ts
@@ -24,6 +24,9 @@ export interface MouseProtocolState {
 export interface PtyStartOptions {
   readonly cols: number;
   readonly rows: number;
+  // Windows ConPTY 전용: true면 node-pty가 OS 내장 conhost 대신 번들 conpty.dll을 사용한다.
+  // 비-Windows에서는 무시된다. 미지정 시 node-pty 기본값(false).
+  readonly useConptyDll?: boolean;
 }
 
 export interface PtyLaunchProfile {

--- a/runtime/fleet-cli/src/controls/types.ts
+++ b/runtime/fleet-cli/src/controls/types.ts
@@ -24,9 +24,6 @@ export interface MouseProtocolState {
 export interface PtyStartOptions {
   readonly cols: number;
   readonly rows: number;
-  // Windows ConPTY 전용: true면 node-pty가 OS 내장 conhost 대신 번들 conpty.dll을 사용한다.
-  // 비-Windows에서는 무시된다. 미지정 시 node-pty 기본값(false).
-  readonly useConptyDll?: boolean;
 }
 
 export interface PtyLaunchProfile {

--- a/runtime/fleet-cli/src/native-app.ts
+++ b/runtime/fleet-cli/src/native-app.ts
@@ -1,5 +1,7 @@
 import { createSystemPromptBuilder } from "@dotobokuri/fleet-admiral";
 import type { CarrierJobStreamEvent } from "@dotobokuri/fleet-carriers";
+import { appendFileSync } from "node:fs";
+import { join } from "node:path";
 import type { IDisposable, IPty } from "node-pty";
 
 import { injectAgentCliProfile, type FleetHookCommandEntry } from "./agent-cli/injection.js";
@@ -28,14 +30,11 @@ import { getTerminalSize } from "./tui/terminal-size.js";
 import { checkForUpdate } from "./update/check.js";
 
 export interface NativeTerminalLaunchStrategyDeps {
-  readonly detachInput: () => void;
   readonly getTerminalSize?: () => { readonly columns: number; readonly rows: number };
   readonly onActiveChildChange?: (child: NativeActiveChild | undefined) => void;
   readonly onAfterResume?: () => void;
-  readonly registerInput: () => void;
   readonly runCleanup: () => void;
   readonly startShell?: ShellStarter;
-  readonly stdin?: NativeInputStream;
   readonly stdout?: Pick<NodeJS.WriteStream, "write">;
   readonly ui: Pick<LocalTui, "refreshSize" | "start" | "stop">;
 }
@@ -52,16 +51,6 @@ export interface NativeActiveChild {
   readonly profile: AgentCliProfile;
 }
 
-interface NativeInputStream {
-  on(event: "data", listener: (data: Buffer | string) => void): NativeInputStream;
-  off(event: "data", listener: (data: Buffer | string) => void): NativeInputStream;
-  resume(): NativeInputStream;
-  setEncoding(encoding: BufferEncoding): NativeInputStream;
-  setRawMode?(mode: boolean): NativeInputStream;
-  readonly isRaw?: boolean;
-  readonly isTTY?: boolean;
-}
-
 interface NativeRawPtySession {
   readonly bridge: NativeRawPtyBridge;
   readonly dispose: () => void;
@@ -69,6 +58,7 @@ interface NativeRawPtySession {
 }
 
 type ProcessFatalEvent = "uncaughtException" | "unhandledRejection";
+type NativeInputDebugDetail = Readonly<Record<string, unknown>>;
 
 export async function runNativeApp(options: RunAppOptions = {}): Promise<void> {
   const argvOptions = options.argvOptions ?? createRunNativeAppArgOptions(options);
@@ -76,11 +66,11 @@ export async function runNativeApp(options: RunAppOptions = {}): Promise<void> {
   const agentCliCleanupCallbacks = new Set<() => void>();
   const runtime = await runtimeLifecycle.start();
   const invocationCwd = resolveInvocationCwd();
+  const debugNativeInput = createNativeInputDebugger(invocationCwd);
   const ui = new LocalTui({ cursorSyncEnabled: true });
   const initialStdinRaw = process.stdin.isRaw;
   let activeNativeChild: NativeActiveChild | undefined;
   let disposeCarrierReminderSubscription = () => {};
-  let disposeInputStream = () => {};
   let disposeMissionControlInput = () => {};
   let stopping = false;
   let shutdownExitCode = 0;
@@ -119,27 +109,36 @@ export async function runNativeApp(options: RunAppOptions = {}): Promise<void> {
     onChange: scheduleRender,
   });
   const release = readFleetCliRelease();
-  const detachInput = () => {
-    disposeInputStream();
-    disposeInputStream = () => {};
-    disposeMissionControlInput();
-    disposeMissionControlInput = () => {};
-  };
-  const registerInput = () => {
-    detachInput();
-    disposeMissionControlInput = ui.addInputListener((data) => {
-      missionControl.component.handleInput?.(data);
+  const onStdinData = (data: Buffer | string) => {
+    const text = Buffer.isBuffer(data) ? data.toString("utf8") : data;
+    const child = activeNativeChild;
+    debugNativeInput("stdin-data", {
+      flowing: process.stdin.readableFlowing,
+      isRaw: process.stdin.isRaw,
+      len: text.length,
+      sink: child === undefined ? "launcher" : "child",
     });
-    disposeInputStream = attachNativeInputStream(ui);
+    if (child !== undefined) {
+      child.bridge.writeRaw(text);
+      return;
+    }
+    ui.emitInput(text);
   };
   let resumeHook = scheduleRender;
   const launchProfile = createNativeTerminalLaunchStrategy({
-    detachInput,
     onActiveChildChange: (child) => {
       activeNativeChild = child;
+      if (child !== undefined) {
+        debugNativeInput("child-enter", {});
+        return;
+      }
+      debugNativeInput("resume", {
+        flowing: process.stdin.readableFlowing,
+        isRaw: process.stdin.isRaw,
+        listenerCount: process.stdin.listenerCount("data"),
+      });
     },
     onAfterResume: () => resumeHook(),
-    registerInput,
     runCleanup: runAgentCliCleanup,
     ui,
   });
@@ -208,7 +207,9 @@ export async function runNativeApp(options: RunAppOptions = {}): Promise<void> {
     stop();
   };
   const cleanupTerminal = () => {
-    detachInput();
+    process.stdin.off("data", onStdinData);
+    disposeMissionControlInput();
+    disposeMissionControlInput = () => {};
     disposeCarrierReminderSubscription();
     disposeCarrierReminderSubscription = () => {};
     const activeChild = activeNativeChild;
@@ -238,7 +239,20 @@ export async function runNativeApp(options: RunAppOptions = {}): Promise<void> {
   applyMissionControlSize();
   ui.start();
   process.stdout.write(KITTY_ENABLE);
-  registerInput();
+  disposeMissionControlInput = ui.addInputListener((data) => {
+    missionControl.component.handleInput?.(data);
+  });
+  process.stdin.setEncoding("utf8");
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true);
+  }
+  process.stdin.resume();
+  process.stdin.on("data", onStdinData);
+  debugNativeInput("boot-attach", {
+    isRaw: process.stdin.isRaw,
+    isTTY: process.stdin.isTTY,
+    listenerCount: process.stdin.listenerCount("data"),
+  });
   const resize = () => {
     const size = getTerminalSize();
     if (activeNativeChild !== undefined) {
@@ -253,13 +267,13 @@ export async function runNativeApp(options: RunAppOptions = {}): Promise<void> {
 
 export function createNativeTerminalLaunchStrategy(deps: NativeTerminalLaunchStrategyDeps): MissionControlLaunchProfile {
   const stdout = deps.stdout ?? process.stdout;
-  const stdin = deps.stdin ?? process.stdin;
   const readTerminalSize = deps.getTerminalSize ?? getTerminalSize;
   const startShellFn = deps.startShell ?? startShell;
 
   return async (launch: MissionControlLaunchProfileOptions): Promise<void> => {
     let cleanupRan = false;
     let rawSession: NativeRawPtySession | undefined;
+    let activeChildCleared = false;
     let resumed = false;
     const runCleanupOnce = () => {
       if (cleanupRan) {
@@ -272,28 +286,32 @@ export function createNativeTerminalLaunchStrategy(deps: NativeTerminalLaunchStr
       rawSession?.dispose();
       rawSession = undefined;
     };
+    const clearActiveChildOnce = () => {
+      if (activeChildCleared) {
+        return;
+      }
+      activeChildCleared = true;
+      deps.onActiveChildChange?.(undefined);
+    };
     const resumeFleetOnce = () => {
       if (resumed) {
         return;
       }
       resumed = true;
       disposeRawSession();
-      deps.onActiveChildChange?.(undefined);
+      clearActiveChildOnce();
       deps.ui.refreshSize(readTerminalSize());
       deps.ui.start();
       stdout.write(KITTY_ENABLE);
-      deps.registerInput();
       deps.onAfterResume?.();
     };
 
-    deps.detachInput();
     stdout.write(KITTY_DISABLE);
     deps.ui.stop();
     try {
       rawSession = startNativeRawPtySession({
         launch,
         startShell: startShellFn,
-        stdin,
         stdout,
       });
       deps.onActiveChildChange?.({
@@ -301,16 +319,17 @@ export function createNativeTerminalLaunchStrategy(deps: NativeTerminalLaunchStr
         dispose: disposeRawSession,
         profile: launch.profile,
       });
+      activeChildCleared = false;
       launch.onNativeActive(launch.profile);
       const event = await rawSession.waitExit();
+      clearActiveChildOnce();
       disposeRawSession();
-      deps.onActiveChildChange?.(undefined);
       runCleanupOnce();
       launch.onExit(event);
       resumeFleetOnce();
     } catch (error) {
       disposeRawSession();
-      deps.onActiveChildChange?.(undefined);
+      clearActiveChildOnce();
       runCleanupOnce();
       resumeFleetOnce();
       throw error;
@@ -334,22 +353,21 @@ function resolveInvocationCwd(): string {
   return process.env.INIT_CWD || process.cwd();
 }
 
-function attachNativeInputStream(ui: LocalTui): () => void {
-  const stdin = process.stdin;
-  const onData = (data: Buffer | string) => {
-    ui.emitInput(Buffer.isBuffer(data) ? data.toString("utf8") : data);
-  };
-
-  stdin.setEncoding("utf8");
-  if (stdin.isTTY) {
-    stdin.setRawMode(true);
+function createNativeInputDebugger(invocationCwd: string): (event: string, detail: NativeInputDebugDetail) => void {
+  const debugValue = process.env.FLEET_DEBUG_NATIVE_INPUT;
+  if (debugValue === undefined || debugValue === "" || debugValue === "0") {
+    return () => undefined;
   }
-  stdin.resume();
-  stdin.on("data", onData);
-
-  return createOnce(() => {
-    stdin.off("data", onData);
-  });
+  const logPath = debugValue === "1" || debugValue === "true"
+    ? join(invocationCwd, "fleet-native-input-debug.log")
+    : debugValue;
+  return (event, detail) => {
+    try {
+      appendFileSync(logPath, `${JSON.stringify({ ts: Date.now(), event, ...detail })}\n`);
+    } catch {
+      // 진단 로그 실패는 native 입력 경로를 방해하지 않는다.
+    }
+  };
 }
 
 function restoreNativeInputRawMode(initialRaw: boolean | undefined): void {
@@ -361,10 +379,9 @@ function restoreNativeInputRawMode(initialRaw: boolean | undefined): void {
 function startNativeRawPtySession(options: {
   readonly launch: MissionControlLaunchProfileOptions;
   readonly startShell: ShellStarter;
-  readonly stdin: NativeInputStream;
   readonly stdout: Pick<NodeJS.WriteStream, "write">;
 }): NativeRawPtySession {
-  const { launch, stdin, stdout } = options;
+  const { launch, stdout } = options;
   const pty = options.startShell({
     profile: {
       ...launch.profile,
@@ -373,20 +390,11 @@ function startNativeRawPtySession(options: {
   }, {
     cols: launch.cols,
     rows: launch.rows,
-    // Windows ConPTY backend를 OS 내장 conhost 대신 번들 conpty.dll로 전환한다. 기본 경로는
-    // child kill 시 conpty_console_list_agent를 부모와 같은 콘솔에 fork하고 ClosePseudoConsole로
-    // 정리하는데, 이 과정이 부모 콘솔 입력 핸들/read-loop를 교란해 child 종료 후 Mission Control
-    // 키 입력이 죽는다. conpty.dll 경로는 cleanup/release 순서가 달라 이 교란을 피한다. node-pty
-    // #894(PowerShell 출력 지연) 리스크가 있어 Windows에만 적용한다.
-    useConptyDll: process.platform === "win32",
   });
   const dataDisposable = pty.onData((chunk) => {
     stdout.write(chunk);
   });
   let exitDisposable: IDisposable | undefined;
-  const rawInput = (data: Buffer | string) => {
-    pty.write(Buffer.isBuffer(data) ? data.toString("utf8") : data);
-  };
   const exitPromise = new Promise<PtyExitEvent>((resolve) => {
     exitDisposable = pty.onExit((event) => {
       exitDisposable?.dispose();
@@ -397,11 +405,7 @@ function startNativeRawPtySession(options: {
       });
     });
   });
-  const disposeRawInput = createOnce(() => {
-    stdin.off("data", rawInput);
-  });
   const dispose = createOnce(() => {
-    disposeRawInput();
     dataDisposable.dispose();
     exitDisposable?.dispose();
     exitDisposable = undefined;
@@ -411,10 +415,6 @@ function startNativeRawPtySession(options: {
     resize: (cols, rows) => pty.resize(cols, rows),
     writeRaw: (data) => pty.write(data),
   };
-
-  stdin.setEncoding("utf8");
-  stdin.resume();
-  stdin.on("data", rawInput);
 
   return {
     bridge,

--- a/runtime/fleet-cli/src/native-app.ts
+++ b/runtime/fleet-cli/src/native-app.ts
@@ -318,6 +318,23 @@ export function createNativeTerminalLaunchStrategy(deps: NativeTerminalLaunchStr
   };
 }
 
+export function resyncNativeInputRawMode(stdin: NativeInputStream = process.stdin): void {
+  if (!stdin.isTTY || stdin.setRawMode === undefined) {
+    return;
+  }
+  // Windows 콘솔 한정 회귀 방어: 직전에 종료된 native child(node-pty/ConPTY)가 실제
+  // 콘솔 입력 모드를 cooked(line/echo)로 되돌려 놓지만, libuv `uv_tty_set_mode`는 내부
+  // 모드 캐시가 이미 RAW이면 `setRawMode(true)`를 early-return으로 no-op 처리해 실제
+  // `SetConsoleMode`를 호출하지 않는다(win/tty.c). 그 결과 콘솔이 cooked로 남아 Mission
+  // Control이 키 입력(raw byte)을 받지 못한다. NORMAL을 한 번 경유시켜 libuv 캐시를
+  // 무효화하면 다음 `setRawMode(true)`가 실제 콘솔 모드를 RAW로 강제 재설정한다. termios
+  // 기반 macOS/Linux는 child PTY가 부모 stdin 모드를 오염시키지 않으므로 토글이 불필요하다.
+  if (process.platform === "win32") {
+    stdin.setRawMode(false);
+  }
+  stdin.setRawMode(true);
+}
+
 function createRunNativeAppArgOptions(options: RunAppOptions): FleetCliOptions {
   return {
     argvOverrides: {
@@ -342,9 +359,7 @@ function attachNativeInputStream(ui: LocalTui): () => void {
   };
 
   stdin.setEncoding("utf8");
-  if (stdin.isTTY) {
-    stdin.setRawMode(true);
-  }
+  resyncNativeInputRawMode(stdin);
   stdin.resume();
   stdin.on("data", onData);
 

--- a/runtime/fleet-cli/src/native-app.ts
+++ b/runtime/fleet-cli/src/native-app.ts
@@ -341,7 +341,6 @@ function createRunNativeAppArgOptions(options: RunAppOptions): FleetCliOptions {
       cursorSync: options.cursorSync === false,
     },
     cursorSync: options.cursorSync !== false,
-    cursorSyncExplicitlyEnabled: false,
     help: false,
     headless: false,
     nativeTerminal: true,

--- a/runtime/fleet-cli/src/native-app.ts
+++ b/runtime/fleet-cli/src/native-app.ts
@@ -318,23 +318,6 @@ export function createNativeTerminalLaunchStrategy(deps: NativeTerminalLaunchStr
   };
 }
 
-export function resyncNativeInputRawMode(stdin: NativeInputStream = process.stdin): void {
-  if (!stdin.isTTY || stdin.setRawMode === undefined) {
-    return;
-  }
-  // Windows 콘솔 한정 회귀 방어: 직전에 종료된 native child(node-pty/ConPTY)가 실제
-  // 콘솔 입력 모드를 cooked(line/echo)로 되돌려 놓지만, libuv `uv_tty_set_mode`는 내부
-  // 모드 캐시가 이미 RAW이면 `setRawMode(true)`를 early-return으로 no-op 처리해 실제
-  // `SetConsoleMode`를 호출하지 않는다(win/tty.c). 그 결과 콘솔이 cooked로 남아 Mission
-  // Control이 키 입력(raw byte)을 받지 못한다. NORMAL을 한 번 경유시켜 libuv 캐시를
-  // 무효화하면 다음 `setRawMode(true)`가 실제 콘솔 모드를 RAW로 강제 재설정한다. termios
-  // 기반 macOS/Linux는 child PTY가 부모 stdin 모드를 오염시키지 않으므로 토글이 불필요하다.
-  if (process.platform === "win32") {
-    stdin.setRawMode(false);
-  }
-  stdin.setRawMode(true);
-}
-
 function createRunNativeAppArgOptions(options: RunAppOptions): FleetCliOptions {
   return {
     argvOverrides: {
@@ -358,7 +341,9 @@ function attachNativeInputStream(ui: LocalTui): () => void {
   };
 
   stdin.setEncoding("utf8");
-  resyncNativeInputRawMode(stdin);
+  if (stdin.isTTY) {
+    stdin.setRawMode(true);
+  }
   stdin.resume();
   stdin.on("data", onData);
 
@@ -388,6 +373,12 @@ function startNativeRawPtySession(options: {
   }, {
     cols: launch.cols,
     rows: launch.rows,
+    // Windows ConPTY backend를 OS 내장 conhost 대신 번들 conpty.dll로 전환한다. 기본 경로는
+    // child kill 시 conpty_console_list_agent를 부모와 같은 콘솔에 fork하고 ClosePseudoConsole로
+    // 정리하는데, 이 과정이 부모 콘솔 입력 핸들/read-loop를 교란해 child 종료 후 Mission Control
+    // 키 입력이 죽는다. conpty.dll 경로는 cleanup/release 순서가 달라 이 교란을 피한다. node-pty
+    // #894(PowerShell 출력 지연) 리스크가 있어 Windows에만 적용한다.
+    useConptyDll: process.platform === "win32",
   });
   const dataDisposable = pty.onData((chunk) => {
     stdout.write(chunk);

--- a/runtime/fleet-cli/tests/app-cursor-policy.test.ts
+++ b/runtime/fleet-cli/tests/app-cursor-policy.test.ts
@@ -71,58 +71,58 @@ describe("app cursor policy", () => {
     expect(cursorTarget).toBeUndefined();
   });
 
-  it("clears cursor target for Claude Code on native Windows by default", () => {
-    mockPlatform("win32");
+  it("clears cursor target when cursor sync is disabled", () => {
+    let cursorTarget: unknown = "visible";
     const ptyView = {};
-    const cursorTarget = runCursorPolicy({
-      getActiveAgentProfileId: () => "claude",
+    const syncCursorPolicy = createCursorPolicySync({
+      cursorSync: false,
+      fleetPty: { hasActiveOverlay: () => false },
+      hasActiveMissionControlPanel: () => false,
       ptyView,
-    });
+      ui: {
+        setCursorAnchorTarget(target: unknown): void {
+          cursorTarget = target;
+        },
+      },
+    } as never);
 
-    expect(cursorTarget()).toBeUndefined();
+    syncCursorPolicy();
+
+    expect(cursorTarget).toBeUndefined();
   });
 
-  it("keeps cursor target for Claude Code outside native Windows", () => {
+  it("clears cursor target while the Fleet PTY has an active overlay", () => {
+    let cursorTarget: unknown = "visible";
+    const ptyView = {};
+    const syncCursorPolicy = createCursorPolicySync({
+      cursorSync: true,
+      fleetPty: { hasActiveOverlay: () => true },
+      hasActiveMissionControlPanel: () => false,
+      ptyView,
+      ui: {
+        setCursorAnchorTarget(target: unknown): void {
+          cursorTarget = target;
+        },
+      },
+    } as never);
+
+    syncCursorPolicy();
+
+    expect(cursorTarget).toBeUndefined();
+  });
+
+  it("keeps cursor target on native Windows now that the Claude auto-disable is removed", () => {
+    mockPlatform("win32");
+    const ptyView = {};
+    const cursorTarget = runCursorPolicy({ ptyView });
+
+    expect(cursorTarget()).toBe(ptyView);
+  });
+
+  it("keeps cursor target outside native Windows", () => {
     mockPlatform("linux");
     const ptyView = {};
-    const cursorTarget = runCursorPolicy({
-      getActiveAgentProfileId: () => "claude",
-      ptyView,
-    });
-
-    expect(cursorTarget()).toBe(ptyView);
-  });
-
-  it("clears cursor target for Claude Kimi on native Windows by default", () => {
-    mockPlatform("win32");
-    const ptyView = {};
-    const cursorTarget = runCursorPolicy({
-      getActiveAgentProfileId: () => "claude-kimi",
-      ptyView,
-    });
-
-    expect(cursorTarget()).toBeUndefined();
-  });
-
-  it("keeps cursor target for Codex on native Windows", () => {
-    mockPlatform("win32");
-    const ptyView = {};
-    const cursorTarget = runCursorPolicy({
-      getActiveAgentProfileId: () => "codex",
-      ptyView,
-    });
-
-    expect(cursorTarget()).toBe(ptyView);
-  });
-
-  it("keeps cursor target for Claude Code on native Windows when cursor sync is explicitly enabled", () => {
-    mockPlatform("win32");
-    const ptyView = {};
-    const cursorTarget = runCursorPolicy({
-      cursorSyncExplicitlyEnabled: true,
-      getActiveAgentProfileId: () => "claude",
-      ptyView,
-    });
+    const cursorTarget = runCursorPolicy({ ptyView });
 
     expect(cursorTarget()).toBe(ptyView);
   });
@@ -134,17 +134,11 @@ describe("app cursor policy", () => {
   });
 });
 
-function runCursorPolicy(options: {
-  readonly cursorSyncExplicitlyEnabled?: boolean;
-  readonly getActiveAgentProfileId?: () => "claude" | "claude-kimi" | "codex" | undefined;
-  readonly ptyView: unknown;
-}): () => unknown {
+function runCursorPolicy(options: { readonly ptyView: unknown }): () => unknown {
   let cursorTarget: unknown = "visible";
   const syncCursorPolicy = createCursorPolicySync({
     cursorSync: true,
-    cursorSyncExplicitlyEnabled: options.cursorSyncExplicitlyEnabled,
     fleetPty: { hasActiveOverlay: () => false },
-    getActiveAgentProfileId: options.getActiveAgentProfileId,
     hasActiveMissionControlPanel: () => false,
     ptyView: options.ptyView,
     ui: {

--- a/runtime/fleet-cli/tests/cli-args.test.ts
+++ b/runtime/fleet-cli/tests/cli-args.test.ts
@@ -5,7 +5,6 @@ import { buildFleetHelpText, parseFleetCliOptions } from "../src/cli-args.js";
 describe("fleet CLI args", () => {
   it("enables cursor sync by default", () => {
     expect(parseFleetCliOptions([], {}).cursorSync).toBe(true);
-    expect(parseFleetCliOptions([], {}).cursorSyncExplicitlyEnabled).toBe(false);
     expect(parseFleetCliOptions([], {}).headless).toBe(false);
     expect(parseFleetCliOptions([], {}).nativeTerminal).toBe(false);
   });
@@ -41,18 +40,18 @@ describe("fleet CLI args", () => {
   it("parses the cursor sync environment off-switch without mutating process.env", () => {
     const before = { ...process.env };
 
-    expect(parseFleetCliOptions([], { FLEET_CURSOR_SYNC: "0" }).cursorSync).toBe(false);
-    expect(parseFleetCliOptions([], { FLEET_CURSOR_SYNC: "false" }).cursorSync).toBe(false);
-    expect(parseFleetCliOptions([], { FLEET_CURSOR_SYNC: "1" }).cursorSync).toBe(true);
-    expect(parseFleetCliOptions([], { FLEET_CURSOR_SYNC: "1" }).cursorSyncExplicitlyEnabled).toBe(true);
-    expect(parseFleetCliOptions([], { FLEET_CURSOR_SYNC: "true" }).cursorSyncExplicitlyEnabled).toBe(true);
+    for (const off of ["0", "false", "no", "off"]) {
+      expect(parseFleetCliOptions([], { FLEET_CURSOR_SYNC: off }).cursorSync).toBe(false);
+    }
+    for (const on of ["1", "true", "yes", "on", "anything-else"]) {
+      expect(parseFleetCliOptions([], { FLEET_CURSOR_SYNC: on }).cursorSync).toBe(true);
+    }
     expect(process.env).toEqual(before);
   });
 
-  it("does not treat disable flags as explicit cursor sync enablement", () => {
+  it("lets the disable flag override an enabling env value", () => {
     expect(parseFleetCliOptions(["--disable-cursor-sync"], { FLEET_CURSOR_SYNC: "1" })).toMatchObject({
       cursorSync: false,
-      cursorSyncExplicitlyEnabled: false,
     });
   });
 
@@ -73,8 +72,7 @@ describe("fleet CLI args", () => {
     expect(helpText).toContain("--headless");
     expect(helpText).toContain("Register this session to a running Fleet Console");
     expect(helpText).toContain("--disable-cursor-sync");
-    expect(helpText).toContain("Claude Code on Windows defaults to disabled");
-    expect(helpText).toContain("FLEET_CURSOR_SYNC=1 to override");
+    expect(helpText).toContain("problematic IME cursor anchoring (or FLEET_CURSOR_SYNC=0)");
     expect(helpText).not.toContain("\x1b[");
     expect(helpText).not.toContain("fleet —");
   });

--- a/runtime/fleet-cli/tests/controls/pty-host.test.ts
+++ b/runtime/fleet-cli/tests/controls/pty-host.test.ts
@@ -34,6 +34,28 @@ describe("PtyHost exit lifecycle", () => {
     assert.deepEqual(events, [{ exitCode: 7, signal: 15 }]);
   });
 
+  it("ignores resize attempts on a pty that has already exited", () => {
+    const fake = createFakePty();
+    fake.resize = () => {
+      throw new Error("Cannot resize a pty that has already exited");
+    };
+    const host = createPtyHost(TEST_CONFIG, { startShell: () => fake });
+    host.start({ cols: 80, rows: 24 });
+
+    assert.doesNotThrow(() => host.resize(100, 30));
+  });
+
+  it("propagates resize errors that are not the exit race", () => {
+    const fake = createFakePty();
+    fake.resize = () => {
+      throw new Error("resizing must be done using positive cols and rows");
+    };
+    const host = createPtyHost(TEST_CONFIG, { startShell: () => fake });
+    host.start({ cols: 80, rows: 24 });
+
+    assert.throws(() => host.resize(0, 0), /positive cols and rows/);
+  });
+
   it("allows multiple exit handlers and ignores duplicate notifications", () => {
     const fake = createFakePty();
     const host = createPtyHost(TEST_CONFIG, { startShell: () => fake });

--- a/runtime/fleet-cli/tests/native-app.test.ts
+++ b/runtime/fleet-cli/tests/native-app.test.ts
@@ -89,13 +89,20 @@ describe("native terminal app", () => {
     const handleInput = vi.fn();
     const missionControlResize = vi.fn();
     const addInputListener = vi.fn();
+    const stdinListeners = new Set<(data: Buffer | string) => void>();
     const processOn = vi.spyOn(process, "on").mockImplementation(() => process);
     const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     vi.spyOn(process.stdout, "on").mockImplementation(() => process.stdout);
     vi.spyOn(process.stdin, "setEncoding").mockImplementation(() => process.stdin);
     vi.spyOn(process.stdin, "resume").mockImplementation(() => process.stdin);
-    vi.spyOn(process.stdin, "on").mockImplementation(() => process.stdin);
-    vi.spyOn(process.stdin, "off").mockImplementation(() => process.stdin);
+    const stdinOn = vi.spyOn(process.stdin, "on").mockImplementation((_event, listener) => {
+      stdinListeners.add(listener as (data: Buffer | string) => void);
+      return process.stdin;
+    });
+    const stdinOff = vi.spyOn(process.stdin, "off").mockImplementation((_event, listener) => {
+      stdinListeners.delete(listener as (data: Buffer | string) => void);
+      return process.stdin;
+    });
 
     class FakeLocalTui {
       private listeners: Array<(data: string) => void> = [];
@@ -217,11 +224,15 @@ describe("native terminal app", () => {
     const { runNativeApp } = await import("../src/native-app.js");
 
     await runNativeApp();
-    tuiInstances[0]?.emitInput("\r");
+    for (const listener of stdinListeners) {
+      listener(Buffer.from("\r"));
+    }
 
     expect(tuiInstances).toHaveLength(1);
     expect(addInputListener).toHaveBeenCalledTimes(1);
     expect(handleInput).toHaveBeenCalledWith("\r");
+    expect(stdinOn).toHaveBeenCalledTimes(1);
+    expect(stdinOff).not.toHaveBeenCalled();
     // 런처가 빈 화면이 되지 않도록 Mission Control에 터미널 크기가 전파되어야 한다.
     expect(missionControlResize).toHaveBeenCalled();
     expect(processOn).toHaveBeenCalled();
@@ -232,6 +243,7 @@ describe("native terminal app", () => {
     vi.resetModules();
     const pty = new FakePty();
     const stdinListeners = new Set<(data: Buffer | string) => void>();
+    const handleInput = vi.fn();
     const unregisterCarrierStream = vi.fn();
     const missionControlResize = vi.fn();
     let carrierStreamHandler: ((event: {
@@ -257,11 +269,11 @@ describe("native terminal app", () => {
     vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     vi.spyOn(process.stdin, "setEncoding").mockImplementation(() => process.stdin);
     vi.spyOn(process.stdin, "resume").mockImplementation(() => process.stdin);
-    vi.spyOn(process.stdin, "on").mockImplementation((_event: string | symbol, listener: (...args: unknown[]) => void) => {
+    const stdinOn = vi.spyOn(process.stdin, "on").mockImplementation((_event: string | symbol, listener: (...args: unknown[]) => void) => {
       stdinListeners.add(listener as (data: Buffer | string) => void);
       return process.stdin;
     });
-    vi.spyOn(process.stdin, "off").mockImplementation((_event: string | symbol, listener: (...args: unknown[]) => void) => {
+    const stdinOff = vi.spyOn(process.stdin, "off").mockImplementation((_event: string | symbol, listener: (...args: unknown[]) => void) => {
       stdinListeners.delete(listener as (data: Buffer | string) => void);
       return process.stdin;
     });
@@ -275,10 +287,21 @@ describe("native terminal app", () => {
     }));
     vi.doMock("../src/tui/renderer.js", () => ({
       LocalTui: class {
-        addInputListener(): () => void {
-          return () => undefined;
+        private listeners: Array<(data: string) => void> = [];
+
+        addInputListener(listener: (data: string) => void): () => void {
+          this.listeners.push(listener);
+          return () => {
+            this.listeners = this.listeners.filter((candidate) => candidate !== listener);
+          };
         }
-        emitInput(): void {}
+
+        emitInput(data: string): void {
+          for (const listener of this.listeners) {
+            listener(data);
+          }
+        }
+
         refreshSize(): void {}
         requestRender(): void {}
         setChildren(): void {}
@@ -317,7 +340,7 @@ describe("native terminal app", () => {
         launchProfile = options.launchProfile;
         return {
           component: {
-            handleInput: () => undefined,
+            handleInput,
             invalidate: () => undefined,
             render: () => [],
           },
@@ -407,43 +430,36 @@ describe("native terminal app", () => {
     carrierStreamHandler?.(finalizedReminderEvent("after exit"));
 
     expect(startShell).toHaveBeenCalledTimes(1);
+    expect(stdinOn).toHaveBeenCalledTimes(1);
+    expect(stdinOff).not.toHaveBeenCalled();
     expect(pty.resizes).toEqual([{ cols: 120, rows: 50 }]);
     expect(pty.writes).toEqual(["active reminder\r", "typed"]);
     expect(exits).toEqual([{ exitCode: 0, signal: undefined }]);
+    for (const listener of stdinListeners) {
+      listener("after-exit-input");
+    }
+    expect(handleInput).toHaveBeenCalledWith("after-exit-input");
     expect(unregisterCarrierStream).not.toHaveBeenCalled();
   });
 
   it("hands off to a raw node-pty bridge and resumes Fleet in order", async () => {
     const events: string[] = [];
     const pty = new FakePty();
-    const stdinListeners = new Set<(data: Buffer | string) => void>();
-    const stdin = {
-      off: vi.fn((_event: "data", listener: (data: Buffer | string) => void) => {
-        stdinListeners.delete(listener);
-        events.push("stdin-off");
-        return stdin;
-      }),
-      on: vi.fn((_event: "data", listener: (data: Buffer | string) => void) => {
-        stdinListeners.add(listener);
-        events.push("stdin-on");
-        return stdin;
-      }),
-      resume: vi.fn(() => stdin),
-      setEncoding: vi.fn(() => stdin),
-    };
+    let activeChild: { readonly bridge: { readonly writeRaw: (data: string) => void } } | undefined;
     const startShellCalls: Array<{ readonly args: readonly string[]; readonly env: Record<string, string> }> = [];
     const launch = createNativeTerminalLaunchStrategy({
-      detachInput: () => events.push("detach"),
       getTerminalSize: () => ({ columns: 100, rows: 40 }),
+      onActiveChildChange: (child) => {
+        activeChild = child;
+        events.push(child === undefined ? "active-child:clear" : "active-child:set");
+      },
       onAfterResume: () => events.push("render"),
-      registerInput: () => events.push("reattach"),
       runCleanup: () => events.push("cleanup"),
       startShell: ((config, opts) => {
         events.push(`start:${config.profile.bin}:${opts.cols}x${opts.rows}`);
         startShellCalls.push({ args: config.profile.args, env: { ...config.profile.env } });
         return pty as never;
       }) as never,
-      stdin,
       stdout: {
         write: (chunk: string) => {
           events.push(chunk === KITTY_DISABLE ? "kitty-disable" : chunk === KITTY_ENABLE ? "kitty-enable" : `stdout:${chunk}`);
@@ -476,164 +492,42 @@ describe("native terminal app", () => {
     });
 
     expect(events).toEqual([
-      "detach",
       "kitty-disable",
       "ui-stop",
       "start:codex:80x24",
-      "stdin-on",
+      "active-child:set",
       "native-active",
     ]);
-    for (const listener of stdinListeners) {
-      listener("raw\r");
-    }
+    activeChild?.bridge.writeRaw("raw\r");
     pty.emitData("child-output");
     pty.emitExit({ exitCode: 0 });
     await promise;
 
     expect(events).toEqual([
-      "detach",
       "kitty-disable",
       "ui-stop",
       "start:codex:80x24",
-      "stdin-on",
+      "active-child:set",
       "native-active",
       "stdout:child-output",
-      "stdin-off",
+      "active-child:clear",
       "cleanup",
       "resize:100x40",
       "ui-start",
       "kitty-enable",
-      "reattach",
       "render",
     ]);
     expect(pty.writes).toEqual(["raw\r"]);
-    expect(stdin.off).toHaveBeenCalledTimes(1);
     expect(startShellCalls).toEqual([{ args: ["--model", "test"], env: { FLEET_TEST: "1" } }]);
     expect(startShellCalls[0]?.env).not.toBe(TEST_PROFILE.env);
     expect(exitEvents).toEqual([{ exitCode: 0, signal: undefined }]);
   });
 
-  it("enables the bundled conpty.dll backend for native spawns on Windows", async () => {
-    const originalPlatform = process.platform;
-    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
-    try {
-      const pty = new FakePty();
-      let captured: boolean | undefined;
-      const launch = createNativeTerminalLaunchStrategy({
-        detachInput: () => undefined,
-        getTerminalSize: () => ({ columns: 80, rows: 24 }),
-        registerInput: () => undefined,
-        runCleanup: () => undefined,
-        startShell: ((_config, opts) => {
-          captured = opts.useConptyDll;
-          return pty as never;
-        }) as never,
-        stdin: {
-          off: () => undefined as never,
-          on: () => undefined as never,
-          resume: () => undefined as never,
-          setEncoding: () => undefined as never,
-        },
-        stdout: { write: () => true },
-        ui: {
-          refreshSize: () => undefined,
-          start: () => undefined,
-          stop: () => undefined,
-        },
-      });
-      const promise = launch({
-        cols: 80,
-        createPtyHost: () => {
-          throw new Error("must not create PTY host");
-        },
-        createPtyView: () => {
-          throw new Error("must not create PTY view");
-        },
-        onActive: () => {
-          throw new Error("must not create embedded launch");
-        },
-        onExit: () => undefined,
-        onNativeActive: () => undefined,
-        onRenderRequest: () => undefined,
-        profile: TEST_PROFILE,
-        rows: 24,
-      });
-      pty.emitExit({ exitCode: 0 });
-      await promise;
-
-      expect(captured).toBe(true);
-    } finally {
-      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
-    }
-  });
-
-  it("keeps the conpty.dll backend off for native spawns on non-Windows", async () => {
-    const originalPlatform = process.platform;
-    Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
-    try {
-      const pty = new FakePty();
-      let captured: boolean | undefined;
-      const launch = createNativeTerminalLaunchStrategy({
-        detachInput: () => undefined,
-        getTerminalSize: () => ({ columns: 80, rows: 24 }),
-        registerInput: () => undefined,
-        runCleanup: () => undefined,
-        startShell: ((_config, opts) => {
-          captured = opts.useConptyDll;
-          return pty as never;
-        }) as never,
-        stdin: {
-          off: () => undefined as never,
-          on: () => undefined as never,
-          resume: () => undefined as never,
-          setEncoding: () => undefined as never,
-        },
-        stdout: { write: () => true },
-        ui: {
-          refreshSize: () => undefined,
-          start: () => undefined,
-          stop: () => undefined,
-        },
-      });
-      const promise = launch({
-        cols: 80,
-        createPtyHost: () => {
-          throw new Error("must not create PTY host");
-        },
-        createPtyView: () => {
-          throw new Error("must not create PTY view");
-        },
-        onActive: () => {
-          throw new Error("must not create embedded launch");
-        },
-        onExit: () => undefined,
-        onNativeActive: () => undefined,
-        onRenderRequest: () => undefined,
-        profile: TEST_PROFILE,
-        rows: 24,
-      });
-      pty.emitExit({ exitCode: 0 });
-      await promise;
-
-      expect(captured).toBe(false);
-    } finally {
-      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
-    }
-  });
-
   it("preserves node-pty signal exits for Mission Control diagnostics", async () => {
     const pty = new FakePty();
     const launch = createNativeTerminalLaunchStrategy({
-      detachInput: () => undefined,
-      registerInput: () => undefined,
       runCleanup: () => undefined,
       startShell: (() => pty as never) as never,
-      stdin: {
-        off: () => undefined as never,
-        on: () => undefined as never,
-        resume: () => undefined as never,
-        setEncoding: () => undefined as never,
-      },
       stdout: { write: () => true },
       ui: {
         refreshSize: () => undefined,
@@ -667,19 +561,16 @@ describe("native terminal app", () => {
   it("restores Fleet when native PTY startup throws", async () => {
     const events: string[] = [];
     const launch = createNativeTerminalLaunchStrategy({
-      detachInput: () => events.push("detach"),
-      registerInput: () => events.push("reattach"),
       runCleanup: () => events.push("cleanup"),
       startShell: (() => {
         throw new Error("spawn failed");
       }) as never,
-      stdin: {
-        off: () => undefined as never,
-        on: () => undefined as never,
-        resume: () => undefined as never,
-        setEncoding: () => undefined as never,
+      stdout: {
+        write: (chunk: string) => {
+          events.push(chunk === KITTY_DISABLE ? "kitty-disable" : chunk === KITTY_ENABLE ? "kitty-enable" : `stdout:${chunk}`);
+          return true;
+        },
       },
-      stdout: { write: () => true },
       ui: {
         refreshSize: () => events.push("resize"),
         start: () => events.push("ui-start"),
@@ -703,7 +594,7 @@ describe("native terminal app", () => {
     });
 
     await expect(promise).rejects.toThrow("spawn failed");
-    expect(events).toEqual(["detach", "ui-stop", "cleanup", "resize", "ui-start", "reattach"]);
+    expect(events).toEqual(["kitty-disable", "ui-stop", "cleanup", "resize", "ui-start", "kitty-enable"]);
   });
 });
 

--- a/runtime/fleet-cli/tests/native-app.test.ts
+++ b/runtime/fleet-cli/tests/native-app.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AgentCliProfile } from "../src/agent-cli/types.js";
 import { KITTY_DISABLE, KITTY_ENABLE, type PtyExitEvent } from "../src/controls/index.js";
-import { createNativeTerminalLaunchStrategy } from "../src/native-app.js";
+import { createNativeTerminalLaunchStrategy, resyncNativeInputRawMode } from "../src/native-app.js";
 
 class FakePty {
   readonly writes: string[] = [];
@@ -596,6 +596,56 @@ describe("native terminal app", () => {
 
     await expect(promise).rejects.toThrow("spawn failed");
     expect(events).toEqual(["detach", "ui-stop", "cleanup", "resize", "ui-start", "reattach"]);
+  });
+});
+
+describe("resyncNativeInputRawMode", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+  });
+
+  function createRawModeProbe(isTTY: boolean): {
+    readonly calls: boolean[];
+    readonly stdin: Parameters<typeof resyncNativeInputRawMode>[0];
+  } {
+    const calls: boolean[] = [];
+    const stdin = {
+      isTTY,
+      setRawMode(mode: boolean) {
+        calls.push(mode);
+        return stdin;
+      },
+    };
+    return { calls, stdin: stdin as unknown as Parameters<typeof resyncNativeInputRawMode>[0] };
+  }
+
+  it("toggles raw mode off then on under Windows to bypass the libuv mode cache", () => {
+    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+    const probe = createRawModeProbe(true);
+
+    resyncNativeInputRawMode(probe.stdin);
+
+    expect(probe.calls).toEqual([false, true]);
+  });
+
+  it("sets raw mode once on non-Windows platforms", () => {
+    Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
+    const probe = createRawModeProbe(true);
+
+    resyncNativeInputRawMode(probe.stdin);
+
+    expect(probe.calls).toEqual([true]);
+  });
+
+  it("leaves raw mode untouched when stdin is not a TTY", () => {
+    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+    const probe = createRawModeProbe(false);
+
+    resyncNativeInputRawMode(probe.stdin);
+
+    expect(probe.calls).toEqual([]);
   });
 });
 

--- a/runtime/fleet-cli/tests/native-app.test.ts
+++ b/runtime/fleet-cli/tests/native-app.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AgentCliProfile } from "../src/agent-cli/types.js";
 import { KITTY_DISABLE, KITTY_ENABLE, type PtyExitEvent } from "../src/controls/index.js";
-import { createNativeTerminalLaunchStrategy, resyncNativeInputRawMode } from "../src/native-app.js";
+import { createNativeTerminalLaunchStrategy } from "../src/native-app.js";
 
 class FakePty {
   readonly writes: string[] = [];
@@ -513,6 +513,114 @@ describe("native terminal app", () => {
     expect(exitEvents).toEqual([{ exitCode: 0, signal: undefined }]);
   });
 
+  it("enables the bundled conpty.dll backend for native spawns on Windows", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+    try {
+      const pty = new FakePty();
+      let captured: boolean | undefined;
+      const launch = createNativeTerminalLaunchStrategy({
+        detachInput: () => undefined,
+        getTerminalSize: () => ({ columns: 80, rows: 24 }),
+        registerInput: () => undefined,
+        runCleanup: () => undefined,
+        startShell: ((_config, opts) => {
+          captured = opts.useConptyDll;
+          return pty as never;
+        }) as never,
+        stdin: {
+          off: () => undefined as never,
+          on: () => undefined as never,
+          resume: () => undefined as never,
+          setEncoding: () => undefined as never,
+        },
+        stdout: { write: () => true },
+        ui: {
+          refreshSize: () => undefined,
+          start: () => undefined,
+          stop: () => undefined,
+        },
+      });
+      const promise = launch({
+        cols: 80,
+        createPtyHost: () => {
+          throw new Error("must not create PTY host");
+        },
+        createPtyView: () => {
+          throw new Error("must not create PTY view");
+        },
+        onActive: () => {
+          throw new Error("must not create embedded launch");
+        },
+        onExit: () => undefined,
+        onNativeActive: () => undefined,
+        onRenderRequest: () => undefined,
+        profile: TEST_PROFILE,
+        rows: 24,
+      });
+      pty.emitExit({ exitCode: 0 });
+      await promise;
+
+      expect(captured).toBe(true);
+    } finally {
+      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    }
+  });
+
+  it("keeps the conpty.dll backend off for native spawns on non-Windows", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
+    try {
+      const pty = new FakePty();
+      let captured: boolean | undefined;
+      const launch = createNativeTerminalLaunchStrategy({
+        detachInput: () => undefined,
+        getTerminalSize: () => ({ columns: 80, rows: 24 }),
+        registerInput: () => undefined,
+        runCleanup: () => undefined,
+        startShell: ((_config, opts) => {
+          captured = opts.useConptyDll;
+          return pty as never;
+        }) as never,
+        stdin: {
+          off: () => undefined as never,
+          on: () => undefined as never,
+          resume: () => undefined as never,
+          setEncoding: () => undefined as never,
+        },
+        stdout: { write: () => true },
+        ui: {
+          refreshSize: () => undefined,
+          start: () => undefined,
+          stop: () => undefined,
+        },
+      });
+      const promise = launch({
+        cols: 80,
+        createPtyHost: () => {
+          throw new Error("must not create PTY host");
+        },
+        createPtyView: () => {
+          throw new Error("must not create PTY view");
+        },
+        onActive: () => {
+          throw new Error("must not create embedded launch");
+        },
+        onExit: () => undefined,
+        onNativeActive: () => undefined,
+        onRenderRequest: () => undefined,
+        profile: TEST_PROFILE,
+        rows: 24,
+      });
+      pty.emitExit({ exitCode: 0 });
+      await promise;
+
+      expect(captured).toBe(false);
+    } finally {
+      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    }
+  });
+
   it("preserves node-pty signal exits for Mission Control diagnostics", async () => {
     const pty = new FakePty();
     const launch = createNativeTerminalLaunchStrategy({
@@ -596,56 +704,6 @@ describe("native terminal app", () => {
 
     await expect(promise).rejects.toThrow("spawn failed");
     expect(events).toEqual(["detach", "ui-stop", "cleanup", "resize", "ui-start", "reattach"]);
-  });
-});
-
-describe("resyncNativeInputRawMode", () => {
-  const originalPlatform = process.platform;
-
-  afterEach(() => {
-    Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
-  });
-
-  function createRawModeProbe(isTTY: boolean): {
-    readonly calls: boolean[];
-    readonly stdin: Parameters<typeof resyncNativeInputRawMode>[0];
-  } {
-    const calls: boolean[] = [];
-    const stdin = {
-      isTTY,
-      setRawMode(mode: boolean) {
-        calls.push(mode);
-        return stdin;
-      },
-    };
-    return { calls, stdin: stdin as unknown as Parameters<typeof resyncNativeInputRawMode>[0] };
-  }
-
-  it("toggles raw mode off then on under Windows to bypass the libuv mode cache", () => {
-    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
-    const probe = createRawModeProbe(true);
-
-    resyncNativeInputRawMode(probe.stdin);
-
-    expect(probe.calls).toEqual([false, true]);
-  });
-
-  it("sets raw mode once on non-Windows platforms", () => {
-    Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
-    const probe = createRawModeProbe(true);
-
-    resyncNativeInputRawMode(probe.stdin);
-
-    expect(probe.calls).toEqual([true]);
-  });
-
-  it("leaves raw mode untouched when stdin is not a TTY", () => {
-    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
-    const probe = createRawModeProbe(false);
-
-    resyncNativeInputRawMode(probe.stdin);
-
-    expect(probe.calls).toEqual([]);
   });
 });
 

--- a/runtime/fleet-console/client/src/api.ts
+++ b/runtime/fleet-console/client/src/api.ts
@@ -96,6 +96,11 @@ export async function createTerminalSession(folderGrantId: string, signal?: Abor
   return assertSessionInfo(await response.json(), response.status);
 }
 
+export async function terminateTerminalSession(sessionId: string, signal?: AbortSignal): Promise<void> {
+  const response = await fetch(`/terminal/sessions/${encodeURIComponent(sessionId)}`, { method: "DELETE", signal });
+  await assertOk(response);
+}
+
 export async function fetchTerminalSessions(signal?: AbortSignal): Promise<readonly SessionInfo[]> {
   const response = await fetch("/terminal/sessions", { signal });
   await assertOk(response);

--- a/runtime/fleet-console/client/src/components/sidebar.tsx
+++ b/runtime/fleet-console/client/src/components/sidebar.tsx
@@ -1,9 +1,9 @@
 import { memo } from "react";
 
-import { createTheaterTerminalSession } from "../api.js";
+import { createTheaterTerminalSession, terminateTerminalSession } from "../api.js";
 import { describeJobStatus, formatCarrierName, latestStreamLine, shortJobId, statusTone } from "../format.js";
 import { isTerminalJobStatus } from "../reduce.js";
-import { beginCreateTerminalSession, completeCreateTerminalSession, failCreateTerminalSession, selectJob, selectTerminalSession, sessionJobs, theaterSessionOrder } from "../store.js";
+import { beginCreateTerminalSession, completeCreateTerminalSession, failCreateTerminalSession, failTerminateTerminalSession, removeTerminalSession, selectJob, selectTerminalSession, sessionJobs, theaterSessionOrder } from "../store.js";
 import type { SessionJob } from "../store.js";
 import type { ConsoleState, JobView, SessionInfo } from "../types.js";
 
@@ -39,7 +39,7 @@ export function Sidebar({ state }: SidebarProps) {
       <div className="sidebar-heading">
         <p className="sidebar-eyebrow">Operations</p>
         <button type="button" className="workspace-add-button" onClick={handleCreateSession} disabled={state.creatingTerminalSession || state.addingTheater || !state.activeTheaterId} aria-label="Launch operation">
-          +
+          <PlusIcon />
         </button>
       </div>
       {visibleSessionOrder.length > 0 ? (
@@ -78,14 +78,25 @@ const SessionEntry = memo(function SessionEntry({ session, active, jobs, selecte
   const orderedJobs = [...jobs].sort((a, b) => Number(isTerminalJobStatus(a.job.status)) - Number(isTerminalJobStatus(b.job.status)));
   return (
     <li className={`session-item ${active ? "is-active" : ""}`}>
-      <button type="button" className={`session-row ${active ? "is-active" : ""}`} onClick={() => selectTerminalSession(session.sessionId)} aria-current={active || undefined}>
-        <span className={`tenant-beacon ${live ? "is-live" : ""}`} aria-hidden="true" />
-        <span className="tenant-row-text">
-          <span className="tenant-label">{session.cwdLabel}</span>
-          <span className="tenant-path">{session.status}</span>
-        </span>
-        {!active && jobs.length > 0 ? <span className="tenant-count">{jobs.length}</span> : null}
-      </button>
+      <div className="session-row-shell">
+        <button type="button" className={`session-row ${active ? "is-active" : ""}`} onClick={() => selectTerminalSession(session.sessionId)} aria-current={active || undefined}>
+          <span className={`tenant-beacon ${live ? "is-live" : ""}`} aria-hidden="true" />
+          <span className="tenant-row-text">
+            <span className="tenant-label">{session.cwdLabel}</span>
+            <span className="tenant-path">{session.status}</span>
+          </span>
+          {!active && jobs.length > 0 ? <span className="tenant-count">{jobs.length}</span> : null}
+        </button>
+        <button
+          type="button"
+          className="session-close"
+          onClick={() => { void closeSession(session.sessionId); }}
+          aria-label={`Terminate operation ${session.cwdLabel}`}
+          title="Terminate operation"
+        >
+          <CloseIcon />
+        </button>
+      </div>
       {active ? (
         <ol className="session-job-list">
           {orderedJobs.length > 0 ? (
@@ -123,3 +134,33 @@ const JobEntry = memo(function JobEntry({ job, active }: JobEntryProps) {
     </li>
   );
 });
+
+// X 버튼 종료 — 백엔드 PTY 세션을 끝낸 뒤에만 카드를 내린다. DELETE는 이미 없는 세션도 200 멱등 처리하므로
+// throw는 진짜 실패(네트워크/401/5xx)뿐 — 이때는 카드를 남기고 오류를 표기해 살아있는 PTY를 은폐하지 않는다.
+async function closeSession(sessionId: string): Promise<void> {
+  try {
+    await terminateTerminalSession(sessionId);
+  } catch (error) {
+    failTerminateTerminalSession(error instanceof Error ? error.message : String(error));
+    return;
+  }
+  removeTerminalSession(sessionId);
+}
+
+function PlusIcon() {
+  // Theater 박스 메뉴의 PlusIcon과 같은 가는 stroke·둥근 끝 마크를 공유한다.
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M8 3.4v9.2M3.4 8h9.2" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  // Operation 종료 — Theater 박스 아이콘과 같은 가는 stroke·둥근 끝 언어를 공유하는 X 마크.
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M4.6 4.6 11.4 11.4M11.4 4.6 4.6 11.4" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/runtime/fleet-console/client/src/store.ts
+++ b/runtime/fleet-console/client/src/store.ts
@@ -173,6 +173,11 @@ export function closeShell(): void {
   setState({ shellOpen: false });
 }
 
+export function failTerminateTerminalSession(error: string): void {
+  // 종료 실패 시 카드는 남기고 사이드바 오류 라인에만 사유를 표기한다(살아있는 PTY를 숨기지 않는다).
+  setState({ terminalSessionError: error });
+}
+
 export function removeTerminalSession(sessionId: string): void {
   if (!state.sessions[sessionId]) return;
   const sessions = { ...state.sessions };

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -198,19 +198,29 @@
   width: 30px;
   height: 30px;
   place-items: center;
-  border: 1px solid color-mix(in oklch, var(--brass) 42%, var(--surface-rim));
-  border-radius: var(--radius-md);
-  color: var(--brass-bright);
-  font-family: var(--font-mono);
-  font-size: 18px;
-  line-height: 1;
+  /* Theater 박스(theater-trigger)와 같은 글라스 웰 + 중립 헤어라인 + 브래스 아이콘 언어를 공유한다. */
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--surface-glass) 78%, var(--ink-deep));
+  color: var(--brass);
   transition:
+    color var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring),
     background var(--duration-fast) var(--ease-spring),
     transform var(--duration-fast) var(--ease-spring);
 }
 
+.workspace-add-button svg {
+  display: block;
+  width: 14px;
+  height: 14px;
+}
+
 .workspace-add-button:hover:not(:disabled) {
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  /* hover에서만 brass로 리프트 — theater-trigger:hover와 동일 교리. */
+  color: var(--brass-bright);
+  border-color: color-mix(in oklch, var(--brass) 45%, transparent);
+  background: color-mix(in oklch, var(--brass) 12%, var(--surface-glass));
   transform: translateY(-1px);
 }
 
@@ -230,6 +240,61 @@
 
 .session-item {
   border-radius: var(--radius-lg);
+}
+
+/* Operation 카드 = 세션 행 위에 종료(X) 버튼을 우측 안쪽으로 겹쳐 앉히기 위한 포지셔닝 컨텍스트. */
+.session-row-shell {
+  position: relative;
+}
+
+.session-close {
+  position: absolute;
+  top: 50%;
+  right: var(--space-2);
+  transform: translateY(-50%);
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  /* Theater 박스 아이콘 언어(가는 stroke·둥근 끝)를 공유하되, 종료=파괴 동작이라 hover에서 coral로 신호한다. */
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--ink-fog);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring),
+    opacity var(--duration-fast) var(--ease-spring);
+}
+
+.session-close svg {
+  display: block;
+  width: 12px;
+  height: 12px;
+}
+
+/* 행 hover·키보드 포커스·활성 세션에서만 X를 드러낸다 — 휴지 상태는 조용히 유지(계기판 언어). */
+.session-row-shell:hover .session-close,
+.session-row-shell:focus-within .session-close,
+.session-item.is-active .session-close {
+  opacity: 0.72;
+  pointer-events: auto;
+}
+
+/* X가 드러날 때 우측 카운트 배지와 겹치지 않도록 카운트를 가린다. */
+.session-row-shell:hover .tenant-count,
+.session-row-shell:focus-within .tenant-count {
+  opacity: 0;
+}
+
+.session-close:hover,
+.session-close:focus-visible {
+  opacity: 1;
+  color: var(--coral);
+  border-color: color-mix(in oklch, var(--coral) 42%, transparent);
+  background: color-mix(in oklch, var(--coral) 14%, transparent);
 }
 
 .session-item.is-active {
@@ -342,6 +407,7 @@
   border-radius: 999px;
   color: var(--ink-spectral);
   font-size: 10px;
+  transition: opacity var(--duration-fast) var(--ease-spring);
 }
 
 .job-list {

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -148,6 +148,11 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       runAsyncHandler(handleTerminalSessions(req, res), res);
       return;
     }
+    const terminalSessionItemMatch = pathname.match(/^\/terminal\/sessions\/([^/]+)$/);
+    if (terminalSessionItemMatch) {
+      handleTerminalSessionItem(req, res, decodeURIComponent(terminalSessionItemMatch[1] ?? ""));
+      return;
+    }
     if (pathname === "/observer/theaters") {
       runAsyncHandler(handleObserverTheaters(req, res), res);
       return;
@@ -352,6 +357,21 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       return;
     }
     await createTerminalSessionForCwd(cwd, res);
+  }
+
+  function handleTerminalSessionItem(req: http.IncomingMessage, res: http.ServerResponse, sessionId: string): void {
+    if (req.method !== "DELETE") {
+      writeJson(res, 405, { error: "Method not allowed" });
+      return;
+    }
+    if (!isTerminalAuthorized(req)) {
+      writeJson(res, 401, { error: "unauthorized" });
+      return;
+    }
+    // 운영자 X 버튼 종료 — PTY 자식을 끝내고(멱등) 콘솔 세션 목록에서도 제거한다. 이미 종료된 세션이어도 200으로 멱등 처리한다.
+    terminalSessions.terminate(sessionId);
+    observability.removeTerminalSession(sessionId);
+    writeJson(res, 200, { ok: true });
   }
 
   async function handleObserverTheaters(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {

--- a/runtime/fleet-console/src/terminal/session-manager.ts
+++ b/runtime/fleet-console/src/terminal/session-manager.ts
@@ -69,6 +69,14 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     getOrCreateSession(context);
   }
 
+  function terminate(sessionId: string): boolean {
+    const session = sessions.get(sessionId);
+    if (!session) return false;
+    // PTY 자식까지 죽이고(removeSession 기본 killPty: true) onSessionExit로 콘솔 세션 목록을 정리한다.
+    removeSession(session);
+    return true;
+  }
+
   function stop(): void {
     for (const session of sessions.values()) {
       killSession(session);
@@ -160,7 +168,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     if (killPty) session.pty.kill();
   }
 
-  return { canAttach, createSession, attach, stop };
+  return { canAttach, createSession, attach, terminate, stop };
 }
 
 function toBuffer(data: TerminalSocketData): Buffer {

--- a/runtime/fleet-console/src/terminal/types.ts
+++ b/runtime/fleet-console/src/terminal/types.ts
@@ -47,5 +47,7 @@ export interface TerminalSessionManager {
   canAttach(sessionId: string): boolean;
   createSession(context: TerminalTicketContext): void;
   attach(socket: TerminalSocket, context: TerminalTicketContext): void;
+  // 운영자 종료(X 버튼) — PTY 자식까지 끝내고 onSessionExit로 콘솔 목록을 정리한다. 세션이 없으면 false(멱등).
+  terminate(sessionId: string): boolean;
   stop(): void;
 }

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -485,13 +485,42 @@ describe("console static and terminal ticket boundary", () => {
     expect(sessions.sessions[0]?.theaterId).toBe(theater.id);
   });
 
+  it("terminates a terminal session over DELETE and drops it from the session list", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-session-delete-"));
+    tempDirs.push(dir);
+    const fixture = await startFixture({
+      terminalPickFolder: async () => ({ kind: "selected", cwd: dir }),
+      terminalStartShell: () => createMockPty(),
+    });
+    const headers = { "Content-Type": "application/json" };
+
+    const picked = await fetch(`${fixture.endpoint}terminal/folders/pick`, { method: "POST", headers });
+    const grant = await picked.json() as { readonly folderGrantId: string };
+    const created = await fetch(`${fixture.endpoint}terminal/sessions`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ folderGrantId: grant.folderGrantId }),
+    });
+    const session = await created.json() as { readonly sessionId: string };
+    const deleted = await fetch(`${fixture.endpoint}terminal/sessions/${encodeURIComponent(session.sessionId)}`, { method: "DELETE" });
+    const afterList = await getJson<{ sessions: readonly unknown[] }>(`${fixture.endpoint}terminal/sessions`);
+    // 이미 종료된 세션 재삭제도 200으로 멱등 처리한다.
+    const repeat = await fetch(`${fixture.endpoint}terminal/sessions/${encodeURIComponent(session.sessionId)}`, { method: "DELETE" });
+
+    expect(created.status).toBe(200);
+    expect(deleted.status).toBe(200);
+    await expect(deleted.json()).resolves.toEqual({ ok: true });
+    expect(afterList.sessions).toHaveLength(0);
+    expect(repeat.status).toBe(200);
+  });
+
   it("rejects terminal WebSocket upgrades without a valid ticket boundary", () => {
     let destroyed = 0;
     const handler = createTerminalUpgradeHandler({
       expectedHost: "127.0.0.1",
       getExpectedPort: () => 37283,
       tickets: { consume: () => null },
-      sessions: { canAttach: () => true, createSession: () => undefined, attach: () => undefined, stop: () => undefined },
+      sessions: { canAttach: () => true, createSession: () => undefined, attach: () => undefined, terminate: () => false, stop: () => undefined },
       validateHost: () => true,
     });
 
@@ -524,6 +553,7 @@ describe("console static and terminal ticket boundary", () => {
         },
         createSession: () => undefined,
         attach: () => undefined,
+        terminate: () => false,
         stop: () => undefined,
       },
       validateHost: () => true,

--- a/runtime/fleet-console/tests/session-manager.test.ts
+++ b/runtime/fleet-console/tests/session-manager.test.ts
@@ -87,6 +87,29 @@ describe("terminal session manager", () => {
     expect(firstB.sent.map((chunk) => chunk.toString("utf8"))).toEqual(["beta"]);
   });
 
+  it("terminates a session, killing the pty and notifying exit exactly once", () => {
+    const ptys = new Map<string, MockPty>();
+    const exits: string[] = [];
+    const manager = createTerminalSessionManager({
+      launch: (cwd, context) => ({ bin: "mock", args: [], cwd: cwd ?? "/", env: { SESSION: context?.sessionId } }),
+      startShell: (launch) => {
+        const pty = createMockPty();
+        ptys.set(String(launch.env.SESSION), pty);
+        return pty;
+      },
+      onSessionExit: (sessionId) => exits.push(sessionId),
+    });
+
+    manager.createSession({ sessionId: "session-a", cwd: "/a" });
+
+    expect(manager.terminate("session-a")).toBe(true);
+    expect(ptys.get("session-a")?.killed()).toBe(true);
+    expect(exits).toEqual(["session-a"]);
+    // 멱등 — 이미 종료된 세션 재종료는 false이고 중복 통지하지 않는다.
+    expect(manager.terminate("session-a")).toBe(false);
+    expect(exits).toEqual(["session-a"]);
+  });
+
   it("passes the terminal kind into the launch resolver", () => {
     const launchKinds: Array<string | undefined> = [];
     const manager = createTerminalSessionManager({


### PR DESCRIPTION
## Summary
- **fleet-cli (native PTY/input)**: 네이티브 모드에서 자식 종료 후 PTY resize 레이스 가드, raw input 복원, Claude 커서 동기화 복원, Windows 네이티브 자식의 번들 conpty.dll 사용, 네이티브 입력을 단일 상시 stdin 리스너로 일원화 — 입력/resize 수명주기 안정화.
- **fleet-console (Operations UI)**: Operations 사이드바의 각 Operation 카드에 종료(X) 컨트롤 추가. 신규 `DELETE /terminal/sessions/:id` 엔드포인트로 백엔드 터미널 세션(PTY 자식)을 실제 종료하고, 성공 시에만 카드를 제거(실패 시 오류 표기로 살아있는 프로세스 은폐 방지). 런치(+) 버튼은 Theater 선택기와 동일한 글라스-웰 계기판 스타일로 재설계.

## Type of Change
- [x] feat — new feature or carrier capability (fleet-console)
- [x] fix — bug fix (fleet-cli native PTY/input)
- [x] docs
- [x] refactor
- [x] chore
- [x] BREAKING CHANGE

## Scope
- `runtime/fleet-cli` — 네이티브 PTY 입력/resize 수명주기
- `runtime/fleet-console` — Operations 사이드바 + 터미널 세션 수명주기(서버 라우트/세션 매니저/클라이언트)

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — pass
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 214 passed (신규 terminate 멱등 + DELETE 라우트 테스트 포함)
- [x] `pnpm --filter @dotobokuri/fleet-console build` — pass
- [ ] 콘솔 UI 육안: Operation 카드 hover 시 우측 X 노출 → 클릭 시 세션 종료·카드 제거, + 버튼 Theater 스타일 확인
- [ ] fleet-cli 네이티브 PTY 수정분 검증은 해당 작업 범위에서 별도 수행

## Notes for Reviewers
- 본 PR은 두 갈래 변경을 함께 담습니다: fleet-cli 네이티브 PTY/입력 수정(다수 커밋)과 fleet-console Operation 종료/런치 버튼 기능(1커밋).
- 보안 참고: 신규 `DELETE /terminal/sessions/:id`는 형제 터미널 라우트와 동일하게 loopback + Origin-check 인증을 따릅니다(브라우저 bearer 토큰 미사용은 콘솔 교리상 의도된 설계). terminate는 기존 create/attach 라우트보다 약한 동작이라 신규 위험면이 아닙니다.