### PR TITLE
fix(console): widen Local Shell overlay to 80% of console width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+- [core] Fleet Console's local shell overlay now spans 80% of the console width instead of being capped at a fixed maximum, so it no longer looks narrow on wide displays.
+
 ## [1.5.2] - 2026-06-14
 
 ### Fixed

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -2062,7 +2062,8 @@
   z-index: 1;
   display: flex;
   flex-direction: column;
-  width: min(1320px, 94vw);
+  /* 오버레이는 콘솔 창(뷰포트) 전체를 덮으므로, 카드 폭은 콘솔 전체 가로폭의 80%로 맞춘다. */
+  width: 80vw;
   height: 90vh;
   max-height: 90vh;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- Local Shell 오버레이 카드가 `min(1320px, 94vw)`의 1320px 픽셀 상한에 묶여, 넓은 콘솔 창에서 콘솔 폭 대비 좁게(≤69%) 보이던 문제를 해결합니다.
- 카드 폭을 `80vw`로 변경해 콘솔 전체(뷰포트) 가로의 80%를 일관되게 차지하도록 했습니다. 모바일(≤760px)의 풀폭(`width:100%`) 규칙은 그대로 유지합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 빌드 통과, 번들 CSS에 `.shell-overlay-card{…width:80vw}` 반영 확인
- [x] Fleet Console에서 Local Shell(Cmd/Ctrl+\`)을 열어 데스크톱 환경에서 폭이 콘솔의 ~80%인지 육안 확인