### PR TITLE
feat(console): add keyboard shortcuts map overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Added
 - [core-unified-agent] Added explicit Claude Opus 4.7 [1M] and Opus 4.8 [1M] models to the Claude provider's selectable model list.
 - [core] Fleet Console now offers a console-wide Operation quick-search via Cmd/Ctrl+K, searching across all Theaters and switching to the selected Operation's Theater and the Operations route; the shortcut yields to Codex's own search when on the /codex path.
+- [core] Fleet Console's global navigation bar now has a keyboard-shortcuts button that opens a reference map listing every console, Operations, and Codex shortcut with a short description of what each one does.
 
 ## [1.5.5] - 2026-06-15
 

--- a/runtime/fleet-console/client/src/app.tsx
+++ b/runtime/fleet-console/client/src/app.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 
 import { fetchObserverStatus, fetchTerminalSessions, fetchTheaterBootstrap } from "./api.js";
+import { ShortcutsOverlay } from "./components/shortcuts-overlay.js";
 import { ShellOverlay } from "./components/shell-overlay.js";
 import { OperationSearch } from "./components/operation-search.js";
 import { Toast } from "./components/toast.js";
@@ -87,6 +88,7 @@ export function App() {
       </Routes>
       <ShellOverlay state={state} />
       <OperationSearch state={state} />
+      <ShortcutsOverlay state={state} />
       <Toast
         open={state.connectionError !== null}
         tone="error"

--- a/runtime/fleet-console/client/src/components/shortcuts-overlay.tsx
+++ b/runtime/fleet-console/client/src/components/shortcuts-overlay.tsx
@@ -41,6 +41,10 @@ export function ShortcutsOverlay({ state }: ShortcutsOverlayProps) {
     if (!state.shortcutsOpen) return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        // 최상위 모달이므로 Esc를 소비해, 배경에 떠 있는 다른 오버레이(JobOverlay/ShellOverlay)의
+        // window Esc 리스너가 같은 키 입력으로 함께 닫히는 것을 막는다.
+        event.stopImmediatePropagation();
+        event.preventDefault();
         closeShortcuts();
         return;
       }
@@ -48,9 +52,10 @@ export function ShortcutsOverlay({ state }: ShortcutsOverlayProps) {
       if (event.key === "Tab") trapFocus(event, cardRef.current);
     };
     closeButtonRef.current?.focus();
-    window.addEventListener("keydown", handleKeyDown);
+    // capture 단계로 등록해야 먼저 마운트된 배경 오버레이의 bubble 단계 Esc 리스너보다 앞서 이벤트를 소비할 수 있다.
+    window.addEventListener("keydown", handleKeyDown, true);
     return () => {
-      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keydown", handleKeyDown, true);
       const target = returnFocusRef.current;
       returnFocusRef.current = null;
       target?.focus?.();

--- a/runtime/fleet-console/client/src/components/shortcuts-overlay.tsx
+++ b/runtime/fleet-console/client/src/components/shortcuts-overlay.tsx
@@ -41,15 +41,17 @@ export function ShortcutsOverlay({ state }: ShortcutsOverlayProps) {
     if (!state.shortcutsOpen) return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        // 최상위 모달이므로 Esc를 소비해, 배경에 떠 있는 다른 오버레이(JobOverlay/ShellOverlay)의
-        // window Esc 리스너가 같은 키 입력으로 함께 닫히는 것을 막는다.
-        event.stopImmediatePropagation();
-        event.preventDefault();
         closeShortcuts();
-        return;
+        event.preventDefault();
+      } else if (event.key === "Tab") {
+        // Tab/Shift+Tab은 카드 안에 포커스를 가둔다.
+        trapFocus(event, cardRef.current);
       }
-      // aria-modal 다이얼로그이므로 Tab/Shift+Tab이 모달 밖(토버·터미널)으로 새지 않게 카드 안에 포커스를 가둔다.
-      if (event.key === "Tab") trapFocus(event, cardRef.current);
+      // aria-modal 다이얼로그가 열린 동안에는 모든 키 입력을 이 모달이 소비해, 배경 단축키
+      // (App의 ⌘`/Ctrl+` 셸 토글, Codex의 ⌘K/Ctrl+K 팔레트, 다른 오버레이의 Esc 등)가
+      // 함께 발동하는 것을 막는다. capture 단계 + stopImmediatePropagation으로 먼저 등록된
+      // window/document 리스너를 선점하되, 기본 동작(버튼 활성화 등)은 유지하려 preventDefault는 Esc에만 건다.
+      event.stopImmediatePropagation();
     };
     closeButtonRef.current?.focus();
     // capture 단계로 등록해야 먼저 마운트된 배경 오버레이의 bubble 단계 Esc 리스너보다 앞서 이벤트를 소비할 수 있다.

--- a/runtime/fleet-console/client/src/components/shortcuts-overlay.tsx
+++ b/runtime/fleet-console/client/src/components/shortcuts-overlay.tsx
@@ -18,10 +18,21 @@ interface NavigatorWithUserAgentData extends Navigator {
 // 대소문자 무시(i)로 두 표기를 모두 Apple 플랫폼으로 인식해야 ⌘가 올바르게 표시된다.
 const MAC_PLATFORM_PATTERN = /mac|iphone|ipad|ipod/i;
 
+// aria-modal 다이얼로그 안에 포커스를 가두기 위한 포커스 가능 요소 선택자(Codex 팔레트/라이트박스와 동일 관례).
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
 export function ShortcutsOverlay({ state }: ShortcutsOverlayProps) {
   // 단축키 맵을 열기 직전의 포커스를 저장해 닫힐 때 GNB/본문 조작 흐름을 복원한다.
   const returnFocusRef = useRef<HTMLElement | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const cardRef = useRef<HTMLElement | null>(null);
   if (state.shortcutsOpen && returnFocusRef.current === null) {
     returnFocusRef.current = document.activeElement as HTMLElement | null;
   }
@@ -29,7 +40,12 @@ export function ShortcutsOverlay({ state }: ShortcutsOverlayProps) {
   useEffect(() => {
     if (!state.shortcutsOpen) return;
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") closeShortcuts();
+      if (event.key === "Escape") {
+        closeShortcuts();
+        return;
+      }
+      // aria-modal 다이얼로그이므로 Tab/Shift+Tab이 모달 밖(토버·터미널)으로 새지 않게 카드 안에 포커스를 가둔다.
+      if (event.key === "Tab") trapFocus(event, cardRef.current);
     };
     closeButtonRef.current?.focus();
     window.addEventListener("keydown", handleKeyDown);
@@ -48,7 +64,7 @@ export function ShortcutsOverlay({ state }: ShortcutsOverlayProps) {
   return (
     <div className="shortcuts-overlay" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts">
       <button type="button" className="shortcuts-overlay-scrim" onClick={closeShortcuts} aria-label="Close keyboard shortcuts" />
-      <section className="shortcuts-overlay-card">
+      <section className="shortcuts-overlay-card" ref={cardRef}>
         <header className="shortcuts-overlay-header">
           <span className="shortcuts-overlay-kicker">Reference Map</span>
           <h2>Keyboard Shortcuts</h2>
@@ -91,4 +107,20 @@ function resolveModLabel(): string {
   const userAgentDataPlatform = (navigator as NavigatorWithUserAgentData).userAgentData?.platform;
   const platform = userAgentDataPlatform ?? navigator.platform;
   return MAC_PLATFORM_PATTERN.test(platform) ? "⌘" : "Ctrl";
+}
+
+// Tab 포커스를 카드 경계에서 순환시켜 모달 밖으로 벗어나지 못하게 한다.
+function trapFocus(event: KeyboardEvent, container: HTMLElement | null): void {
+  if (!container) return;
+  const focusable = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (!first || !last) return;
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault();
+    first.focus();
+  }
 }

--- a/runtime/fleet-console/client/src/components/shortcuts-overlay.tsx
+++ b/runtime/fleet-console/client/src/components/shortcuts-overlay.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef } from "react";
+
+import { SHORTCUT_GROUPS } from "../shortcuts-catalog.js";
+import { closeShortcuts } from "../store.js";
+import type { ConsoleState } from "../types.js";
+
+interface ShortcutsOverlayProps {
+  readonly state: ConsoleState;
+}
+
+interface NavigatorWithUserAgentData extends Navigator {
+  readonly userAgentData?: {
+    readonly platform?: string;
+  };
+}
+
+// userAgentData.platform은 "macOS"(소문자)를, navigator.platform은 "MacIntel"을 반환하므로
+// 대소문자 무시(i)로 두 표기를 모두 Apple 플랫폼으로 인식해야 ⌘가 올바르게 표시된다.
+const MAC_PLATFORM_PATTERN = /mac|iphone|ipad|ipod/i;
+
+export function ShortcutsOverlay({ state }: ShortcutsOverlayProps) {
+  // 단축키 맵을 열기 직전의 포커스를 저장해 닫힐 때 GNB/본문 조작 흐름을 복원한다.
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  if (state.shortcutsOpen && returnFocusRef.current === null) {
+    returnFocusRef.current = document.activeElement as HTMLElement | null;
+  }
+
+  useEffect(() => {
+    if (!state.shortcutsOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeShortcuts();
+    };
+    closeButtonRef.current?.focus();
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      const target = returnFocusRef.current;
+      returnFocusRef.current = null;
+      target?.focus?.();
+    };
+  }, [state.shortcutsOpen]);
+
+  if (!state.shortcutsOpen) return null;
+
+  const modLabel = resolveModLabel();
+
+  return (
+    <div className="shortcuts-overlay" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts">
+      <button type="button" className="shortcuts-overlay-scrim" onClick={closeShortcuts} aria-label="Close keyboard shortcuts" />
+      <section className="shortcuts-overlay-card">
+        <header className="shortcuts-overlay-header">
+          <span className="shortcuts-overlay-kicker">Reference Map</span>
+          <h2>Keyboard Shortcuts</h2>
+        </header>
+        <button ref={closeButtonRef} type="button" className="shortcuts-overlay-close" onClick={closeShortcuts} aria-label="Close keyboard shortcuts">
+          ×
+        </button>
+        <div className="shortcuts-overlay-groups">
+          {SHORTCUT_GROUPS.map((group) => (
+            <section key={group.title} className="shortcuts-group" aria-labelledby={`shortcuts-${group.title.toLowerCase()}`}>
+              <h3 id={`shortcuts-${group.title.toLowerCase()}`}>{group.title}</h3>
+              <dl className="shortcuts-list">
+                {group.entries.map((entry) => (
+                  <div key={`${group.title}:${entry.description}`} className="shortcuts-entry">
+                    <dt className="shortcuts-combos">
+                      {entry.combos.map((combo, comboIndex) => (
+                        <span key={`${entry.description}:${combo.join("+")}`} className="shortcuts-combo">
+                          {comboIndex > 0 ? <span className="shortcuts-combo-separator">or</span> : null}
+                          <span className="shortcuts-keyset">
+                            {combo.map((key) => (
+                              <kbd key={key}>{key === "Mod" ? modLabel : key}</kbd>
+                            ))}
+                          </span>
+                        </span>
+                      ))}
+                    </dt>
+                    <dd>{entry.description}</dd>
+                  </div>
+                ))}
+              </dl>
+            </section>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function resolveModLabel(): string {
+  const userAgentDataPlatform = (navigator as NavigatorWithUserAgentData).userAgentData?.platform;
+  const platform = userAgentDataPlatform ?? navigator.platform;
+  return MAC_PLATFORM_PATTERN.test(platform) ? "⌘" : "Ctrl";
+}

--- a/runtime/fleet-console/client/src/components/topbar.tsx
+++ b/runtime/fleet-console/client/src/components/topbar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent }
 import { Link, NavLink, useLocation } from "react-router-dom";
 
 import { addTheater } from "../api.js";
-import { beginAddTheater, cancelAddTheater, completeAddTheater, failAddTheater, setActiveTheater, setActiveTheme, setTerminalRenderer, toggleShell } from "../store.js";
+import { beginAddTheater, cancelAddTheater, completeAddTheater, failAddTheater, openShortcuts, setActiveTheater, setActiveTheme, setTerminalRenderer, toggleShell } from "../store.js";
 import type { ConsoleState, TerminalRenderer, ThemeId } from "../types.js";
 
 interface TopbarProps {
@@ -88,6 +88,9 @@ export function Topbar({ state }: TopbarProps) {
         <button type="button" className="topbar-shell-button" onMouseDown={(event) => event.preventDefault()} onClick={toggleShell} aria-label="Shell" title="Shell (⌘`)">
           <ShellIcon />
           <span>Shell</span>
+        </button>
+        <button type="button" className="topbar-shell-button topbar-shortcuts-button" onMouseDown={(event) => event.preventDefault()} onClick={openShortcuts} aria-label="Keyboard shortcuts" title="Keyboard shortcuts">
+          <KeyboardIcon />
         </button>
         <ThemeControl activeTheme={state.activeTheme} />
         <RendererToggle renderer={state.terminalRenderer} />
@@ -434,6 +437,15 @@ function ShellIcon() {
     <svg viewBox="0 0 16 16" aria-hidden="true">
       <path d="M2.8 4.2h10.4v7.6H2.8z" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
       <path d="M5 6.7 6.8 8 5 9.3M8.2 9.4h2.6" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function KeyboardIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <rect x="2.4" y="4.1" width="11.2" height="7.8" rx="1.8" fill="none" stroke="currentColor" strokeWidth="1.2" />
+      <path d="M4.5 6.3h.1M6.8 6.3h.1M9.1 6.3h.1M11.4 6.3h.1M4.5 8.2h.1M6.8 8.2h.1M9.1 8.2h.1M11.4 8.2h.1M5.8 10.1h4.4" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
     </svg>
   );
 }

--- a/runtime/fleet-console/client/src/shortcuts-catalog.ts
+++ b/runtime/fleet-console/client/src/shortcuts-catalog.ts
@@ -34,6 +34,7 @@ export const SHORTCUT_GROUPS: readonly ShortcutGroup[] = [
       { combos: [["Tab"]], description: "Move focus within the command palette" },
       { combos: [["Esc"]], description: "Close the command palette or diagram lightbox" },
       { combos: [["+"], ["−"], ["0"]], description: "Zoom the diagram lightbox in / out / reset" },
+      { combos: [["F"]], description: "Fit the diagram lightbox to the viewport" },
     ],
   },
 ];

--- a/runtime/fleet-console/client/src/shortcuts-catalog.ts
+++ b/runtime/fleet-console/client/src/shortcuts-catalog.ts
@@ -1,0 +1,39 @@
+export interface ShortcutEntry {
+  readonly combos: readonly (readonly string[])[];
+  readonly description: string;
+}
+
+export interface ShortcutGroup {
+  readonly title: string;
+  readonly entries: readonly ShortcutEntry[];
+}
+
+export const SHORTCUT_GROUPS: readonly ShortcutGroup[] = [
+  {
+    title: "Console",
+    entries: [
+      { combos: [["Mod", "`"]], description: "Toggle the local shell" },
+      { combos: [["Esc"]], description: "Close the open overlay or menu" },
+    ],
+  },
+  {
+    title: "Operations",
+    entries: [
+      { combos: [["Esc"]], description: "Close the carrier job stream" },
+      { combos: [["Shift", "Enter"]], description: "Insert a newline in the terminal instead of submitting" },
+      { combos: [["Enter"], ["Esc"]], description: "Confirm or cancel a session rename" },
+      { combos: [["↑"], ["↓"]], description: "Move between Theater, Theme, and launch menu items" },
+    ],
+  },
+  {
+    title: "Codex",
+    entries: [
+      { combos: [["Mod", "K"]], description: "Toggle the command palette" },
+      { combos: [["↑"], ["↓"]], description: "Move through command palette results" },
+      { combos: [["Enter"]], description: "Open the selected result" },
+      { combos: [["Tab"]], description: "Move focus within the command palette" },
+      { combos: [["Esc"]], description: "Close the command palette or diagram lightbox" },
+      { combos: [["+"], ["−"], ["0"]], description: "Zoom the diagram lightbox in / out / reset" },
+    ],
+  },
+];

--- a/runtime/fleet-console/client/src/store.ts
+++ b/runtime/fleet-console/client/src/store.ts
@@ -56,6 +56,7 @@ let state: ConsoleState = {
   timelineOpen: false,
   shellOpen: false,
   operationSearchOpen: false,
+  shortcutsOpen: false,
   selectedJobId: null,
   expandedSessionIds: readStoredExpandedSessions(),
 };
@@ -264,6 +265,20 @@ export function closeShell(): void {
   // 백엔드 세션은 살아남아, 다시 열 때 기존 셸 프로세스·scrollback·cwd에 그대로 재부착된다.
   // shell PTY는 셸이 스스로 종료(exit)하거나 콘솔 서버가 멈출 때만 사라진다.
   setState({ shellOpen: false });
+}
+
+export function openShortcuts(): void {
+  if (state.shortcutsOpen) return;
+  setState({ shortcutsOpen: true });
+}
+
+export function closeShortcuts(): void {
+  if (!state.shortcutsOpen) return;
+  setState({ shortcutsOpen: false });
+}
+
+export function toggleShortcuts(): void {
+  setState({ shortcutsOpen: !state.shortcutsOpen });
 }
 
 export function toggleTerminalZoom(sessionId: string): void {

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -1257,6 +1257,10 @@
   height: 15px;
 }
 
+.topbar-shortcuts-button {
+  padding-inline: var(--space-1);
+}
+
 .theme-control {
   position: relative;
   display: inline-flex;
@@ -2369,10 +2373,218 @@
   box-shadow: none;
 }
 
+.shortcuts-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-6);
+}
+
+.shortcuts-overlay-scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: color-mix(in oklch, var(--ink-abyss) 48%, transparent);
+  backdrop-filter: blur(4px) saturate(120%);
+  cursor: default;
+}
+
+.shortcuts-overlay-card {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  /* Local Shell 오버레이와 동일하게 콘솔 가로폭의 80%를 차지하는 대형 카드로 띄운다. */
+  width: 80vw;
+  height: 90vh;
+  max-height: 90vh;
+  overflow: hidden;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-xl);
+  background: var(--surface-glass);
+  box-shadow: var(--shadow-floating);
+  backdrop-filter: blur(18px) saturate(140%);
+  animation: codex-rise 360ms var(--ease-spring) both;
+}
+
+.shortcuts-overlay-header {
+  flex: 0 0 auto;
+  padding: var(--space-5) calc(var(--space-6) + 34px) var(--space-4) var(--space-5);
+  border-bottom: 1px solid var(--surface-rim);
+  background:
+    linear-gradient(90deg, color-mix(in oklch, var(--brass) 10%, transparent), transparent 68%),
+    color-mix(in oklch, var(--ink-mid) 42%, transparent);
+}
+
+.shortcuts-overlay-kicker {
+  display: block;
+  margin-bottom: var(--space-1);
+  color: var(--brass-bright);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.shortcuts-overlay-header h2 {
+  margin: 0;
+  color: var(--ink-pearl);
+  font-family: var(--font-display);
+  font-size: 24px;
+  font-weight: 560;
+  letter-spacing: 0;
+}
+
+.shortcuts-overlay-close {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  z-index: 2;
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border: 1px solid color-mix(in oklch, var(--brass) 42%, var(--surface-rim));
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--surface-glass-strong) 82%, transparent);
+  color: var(--brass-bright);
+  box-shadow: var(--shadow-anchor);
+  backdrop-filter: blur(18px) saturate(140%);
+  font-family: var(--font-mono);
+  font-size: 18px;
+  line-height: 1;
+  transition:
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring);
+}
+
+.shortcuts-overlay-close:hover {
+  border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim));
+  background: color-mix(in oklch, var(--brass) 14%, var(--surface-glass-strong));
+}
+
+.shortcuts-overlay-groups {
+  /* 헤더 아래 남은 카드 높이를 모두 채워 Local Shell처럼 꽉 찬 대형 프레임을 만든다. */
+  flex: 1 1 auto;
+  display: grid;
+  /* 섹션을 세로로 쌓지 않고 Console/Operations/Codex를 3-컬럼으로 펼치고, 한 행이 높이를 채운다. */
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-rows: minmax(0, 1fr);
+  align-items: stretch;
+  gap: var(--space-4);
+  min-height: 0;
+  overflow: auto;
+  padding: var(--space-5);
+}
+
+.shortcuts-group {
+  display: grid;
+  align-content: start;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid color-mix(in oklch, var(--surface-rim) 76%, transparent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in oklch, var(--ink-mid) 24%, transparent);
+}
+
+.shortcuts-group h3 {
+  margin: 0;
+  color: var(--brass-bright);
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 560;
+  letter-spacing: 0;
+}
+
+.shortcuts-list {
+  display: grid;
+  gap: var(--space-2);
+  margin: 0;
+}
+
+.shortcuts-entry {
+  display: grid;
+  /* 3-컬럼 안에서는 폭이 좁으므로 키 조합을 위, 설명을 아래로 쌓아 가독성을 지킨다. */
+  gap: var(--space-2);
+  align-items: start;
+  padding: var(--space-3) 0;
+  border-top: 1px solid color-mix(in oklch, var(--surface-rim) 56%, transparent);
+}
+
+.shortcuts-entry:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.shortcuts-entry:last-child {
+  padding-bottom: 0;
+}
+
+.shortcuts-combos {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+  margin: 0;
+}
+
+.shortcuts-combo {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.shortcuts-combo-separator {
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.shortcuts-keyset {
+  display: inline-flex;
+  gap: 5px;
+  align-items: center;
+}
+
+.shortcuts-keyset kbd {
+  display: inline-grid;
+  min-width: 30px;
+  min-height: 28px;
+  place-items: center;
+  padding: 0 var(--space-2);
+  border: 1px solid color-mix(in oklch, var(--brass) 34%, var(--surface-rim));
+  border-radius: var(--radius-sm);
+  background:
+    linear-gradient(180deg, color-mix(in oklch, var(--brass) 8%, transparent), transparent),
+    color-mix(in oklch, var(--surface-glass-strong) 78%, transparent);
+  color: var(--ink-pearl);
+  box-shadow: var(--shadow-anchor);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.shortcuts-entry dd {
+  margin: 0;
+  color: var(--ink-spectral);
+  font-family: var(--font-ui);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .job-overlay-card,
   .shell-overlay-card,
-  .operation-search-overlay {
+  .operation-search-overlay,
+  .shortcuts-overlay-card {
     animation: none;
   }
 }
@@ -2768,6 +2980,32 @@
 
   .shell-overlay-header {
     padding: var(--space-4) calc(var(--space-5) + 34px) var(--space-3) var(--space-4);
+  }
+
+  .shortcuts-overlay {
+    padding: var(--space-3);
+  }
+
+  .shortcuts-overlay-card {
+    width: 100%;
+    height: auto;
+    max-height: calc(100vh - (var(--space-3) * 2));
+  }
+
+  .shortcuts-overlay-header {
+    padding: var(--space-4) calc(var(--space-5) + 34px) var(--space-3) var(--space-4);
+  }
+
+  .shortcuts-overlay-groups {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: none;
+    padding: var(--space-4);
+  }
+
+  .shortcuts-entry {
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--space-2);
+    align-items: start;
   }
 
   .welcome-page {

--- a/runtime/fleet-console/client/src/types.ts
+++ b/runtime/fleet-console/client/src/types.ts
@@ -179,6 +179,7 @@ export interface ConsoleState {
   readonly timelineOpen: boolean;
   readonly shellOpen: boolean;
   readonly operationSearchOpen: boolean;
+  readonly shortcutsOpen: boolean;
   readonly selectedJobId: string | null;
   readonly expandedSessionIds: readonly string[];
 }

--- a/runtime/fleet-console/tests/dashboard.test.ts
+++ b/runtime/fleet-console/tests/dashboard.test.ts
@@ -26,6 +26,7 @@ const BASE_STATE: ConsoleState = {
   timelineOpen: false,
   shellOpen: false,
   operationSearchOpen: false,
+  shortcutsOpen: false,
   selectedJobId: null,
   expandedSessionIds: [],
 };

--- a/runtime/fleet-console/tests/operation-search.test.ts
+++ b/runtime/fleet-console/tests/operation-search.test.ts
@@ -31,6 +31,7 @@ function makeState(sessions: readonly SessionInfo[], theaters: readonly TheaterI
     timelineOpen: false,
     shellOpen: false,
     operationSearchOpen: false,
+    shortcutsOpen: false,
     selectedJobId: null,
     expandedSessionIds: [],
   };

--- a/runtime/fleet-console/tests/store.test.ts
+++ b/runtime/fleet-console/tests/store.test.ts
@@ -10,6 +10,7 @@ import {
   beginCreateTerminalSession,
   completeAddTheater,
   clearSelectedJob,
+  closeShortcuts,
   closeShell,
   completeCreateTerminalSession,
   closeOperationSearch,
@@ -18,6 +19,7 @@ import {
   hydrateTerminalSessions,
   hydrateTheaters,
   openOperationSearch,
+  openShortcuts,
   readStoredRenderer,
   selectJob,
   selectTerminalSession,
@@ -29,6 +31,7 @@ import {
   theaterSessionOrder,
   theaterSessions,
   toggleOperationSearch,
+  toggleShortcuts,
   toggleShell,
 } from "../client/src/store.js";
 import type { ObservedEvent, ObservedTenant, TheaterInfo } from "../client/src/types.js";
@@ -79,6 +82,7 @@ beforeEach(() => {
     timelineOpen: false,
     shellOpen: false,
     operationSearchOpen: false,
+    shortcutsOpen: false,
     selectedJobId: null,
   });
 });
@@ -280,6 +284,28 @@ describe("store", () => {
 
     closeOperationSearch();
     expect(getState().operationSearchOpen).toBe(false);
+  });
+
+  it("opens, closes, and toggles the keyboard shortcuts overlay", () => {
+    expect(getState().shortcutsOpen).toBe(false);
+
+    openShortcuts();
+    expect(getState().shortcutsOpen).toBe(true);
+
+    openShortcuts();
+    expect(getState().shortcutsOpen).toBe(true);
+
+    closeShortcuts();
+    expect(getState().shortcutsOpen).toBe(false);
+
+    closeShortcuts();
+    expect(getState().shortcutsOpen).toBe(false);
+
+    toggleShortcuts();
+    expect(getState().shortcutsOpen).toBe(true);
+
+    toggleShortcuts();
+    expect(getState().shortcutsOpen).toBe(false);
   });
 
   it("binds hydrated terminal sessions to tenants without changing the active session", () => {


### PR DESCRIPTION
## Summary
- GNB(상단바)에 키보드 단축키 버튼을 추가해, Console·Operations·Codex가 제공하는 모든 단축키와 각 기능 설명을 보여주는 참조 오버레이를 연다.
- 오버레이는 Local Shell과 동일한 크기(80vw × 90vh)로 세 섹션을 풀-하이트 3-컬럼으로 펼친다. Esc·스크림·닫기 버튼으로 닫고, 수식 키는 Apple 플랫폼에서 `⌘`, 그 외에서 `Ctrl`로 표기한다.
- Maritime Console 디자인 정체성(글래스 카드·brass 강조·Fraunces 헤딩·mono 키칩, aurora 역할색 미사용)을 따른다. 단축키 동작 자체는 기존 그대로이며 표시 전용 추가다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 252 passed
- [x] 실브라우저 E2E(playwriter): GNB 버튼으로 오버레이 오픈, 3-컬럼 렌더, macOS에서 `⌘` 표기, Esc/스크림 닫기 확인