### PR TITLE
feat(console): add carrier settings web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Added
+- [core] Added a Fleet Console carrier settings page to edit each carrier's CLI, model, SubAgent mode, Task Force backends, and display name, committed with a single per-carrier save.
 - [core-unified-agent] Added explicit Claude Opus 4.7 [1M] and Opus 4.8 [1M] models to the Claude provider's selectable model list.
 - [core] Fleet Console now offers a console-wide Operation quick-search via Cmd/Ctrl+K, searching across all Theaters and switching to the selected Operation's Theater and the Operations route; the shortcut yields to Codex's own search when on the /codex path.
 - [core] Fleet Console's global navigation bar now has a keyboard-shortcuts button that opens a reference map listing every console, Operations, and Codex shortcut with a short description of what each one does.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       '@dotobokuri/core-agent':
         specifier: workspace:*
         version: link:../../packages/core-agent
+      '@dotobokuri/core-unified-agent':
+        specifier: workspace:*
+        version: link:../../packages/core-unified-agent
       '@dotobokuri/fleet-admiral':
         specifier: workspace:*
         version: link:../../packages/fleet-admiral

--- a/runtime/fleet-console/AGENTS.md
+++ b/runtime/fleet-console/AGENTS.md
@@ -35,14 +35,14 @@
 - MCP session tokens must never reach browser code, URL query strings, SSE payloads, terminal tickets, logs, or static assets.
 - Theater routes likewise do not expose admin bearer tokens, MCP/session tokens, terminal tickets, folder-grant identifiers, or raw working-directory paths to the browser.
 
-## Carrier Readiness Boundary
+## Carrier Readiness/Settings Boundary
 
-- `runtime/fleet-console/src/**` may import `@dotobokuri/fleet-carriers` public root exports to consume read-only Carrier Readiness read models for browser-safe observer payloads.
+- `runtime/fleet-console/src/**` may import `@dotobokuri/fleet-carriers` public root exports to consume Carrier Readiness read models and mutate global Carrier Settings through the carrier store.
 - `runtime/fleet-console/client/**` must not import `@dotobokuri/fleet-carriers`, carrier persona modules, deep carrier paths, or Node-only carrier runtime modules.
-- Fleet Console may render display-safe carrier readiness data such as carrier id, display name, role/category, resolved model/effort, Task Force backend count, and subagent mode/tag.
-- `fleet-carriers` remains the source of truth for carrier persona defaults, carrier-store interpretation, and carrier read-model construction. Console must not copy, reconstruct, mutate, or persist carrier persona policy or carrier runtime state.
+- Fleet Console may render and edit display-safe carrier settings data such as carrier id, display name, role/category, resolved CLI/model/effort, Task Force backend count/configuration, and subagent mode/tag.
+- `fleet-carriers` remains the source of truth for carrier persona defaults, carrier-store interpretation, store mutation, and carrier read-model construction. Console must not copy or reconstruct carrier persona policy or carrier runtime state.
 - Console must not deep-import `@dotobokuri/fleet-carriers/src/**`, `packages/fleet-carriers/src/**`, `runtime/fleet-cli/**`, or `@dotobokuri/fleet-cli`.
-- Carrier readiness browser payloads must not serialize prompt bodies, raw persona instructions, executor tool allowlists, tokens, credential values, auth env details, terminal/session/admin tickets, or raw filesystem paths.
+- Carrier readiness/settings browser payloads must not serialize prompt bodies, raw persona instructions, executor tool allowlists, tokens, credential values, auth env details, terminal/session/admin tickets, or raw filesystem paths.
 
 ## Server-side Dependency Boundary
 

--- a/runtime/fleet-console/client/src/app.tsx
+++ b/runtime/fleet-console/client/src/app.tsx
@@ -9,6 +9,7 @@ import { Toast } from "./components/toast.js";
 import { Topbar } from "./components/topbar.js";
 import { startObserverConnection } from "./connection.js";
 import { useConsoleState } from "./hooks/use-store.js";
+import { CarrierSettings } from "./pages/carrier-settings.js";
 import { Codex } from "./pages/codex.js";
 import { Operations } from "./pages/operations.js";
 import { applyObserverStatus, hydrateTerminalSessions, hydrateTheaterBootstrap, setState, toggleOperationSearch, toggleShell } from "./store.js";
@@ -83,6 +84,7 @@ export function App() {
       <Routes>
         <Route path="/" element={<Welcome state={state} />} />
         <Route path="/operations" element={<Operations state={state} />} />
+        <Route path="/carrier-settings" element={<CarrierSettings />} />
         <Route path="/codex/*" element={<Codex state={state} />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/runtime/fleet-console/client/src/carrier-settings-api.ts
+++ b/runtime/fleet-console/client/src/carrier-settings-api.ts
@@ -1,0 +1,219 @@
+import { ApiError } from "./api.js";
+import type {
+  CarrierSettingsAgentMode,
+  CarrierSettingsCarrier,
+  CarrierSettingsCliOption,
+  CarrierSettingsModelOption,
+  CarrierSettingsMutationResult,
+  CarrierSettingsOptions,
+  CarrierSettingsState,
+  CarrierSettingsTaskForceBackend,
+} from "./types.js";
+
+interface ModelSelection {
+  readonly model: string;
+  readonly effort?: string;
+}
+
+const LEAKED_FIELD_NAMES = new Set([
+  "token",
+  "credential",
+  "cwd",
+  "path",
+  "persona",
+  "prompt",
+  "toolAllowlist",
+  "allowedExecutorTools",
+]);
+
+export async function fetchCarrierSettingsState(signal?: AbortSignal): Promise<CarrierSettingsState> {
+  const response = await fetch("/carrier-settings/state", { signal });
+  await assertOk(response);
+  return assertCarrierSettingsState(await response.json(), response.status);
+}
+
+export async function fetchCarrierSettingsOptions(signal?: AbortSignal): Promise<CarrierSettingsOptions> {
+  const response = await fetch("/carrier-settings/options", { signal });
+  await assertOk(response);
+  return assertCarrierSettingsOptions(await response.json(), response.status);
+}
+
+export async function updateCarrierCli(carrierId: string, cliType: string, signal?: AbortSignal): Promise<CarrierSettingsMutationResult> {
+  return mutateState(`/carrier-settings/carriers/${encodeURIComponent(carrierId)}/cli`, "PUT", { cliType }, signal);
+}
+
+export async function updateCarrierModel(carrierId: string, selection: ModelSelection, signal?: AbortSignal): Promise<CarrierSettingsMutationResult> {
+  return mutateState(`/carrier-settings/carriers/${encodeURIComponent(carrierId)}/model`, "PUT", selection, signal);
+}
+
+export async function updateCarrierDisplayName(carrierId: string, displayName: string, signal?: AbortSignal): Promise<CarrierSettingsMutationResult> {
+  return mutateState(`/carrier-settings/carriers/${encodeURIComponent(carrierId)}/display-name`, "PATCH", { displayName }, signal);
+}
+
+export async function updateCarrierAgentMode(carrierId: string, agentMode: CarrierSettingsAgentMode, signal?: AbortSignal): Promise<CarrierSettingsMutationResult> {
+  return mutateState(`/carrier-settings/carriers/${encodeURIComponent(carrierId)}/agent-mode`, "PUT", { agentMode }, signal);
+}
+
+export async function setCarrierTaskForceBackend(carrierId: string, cliType: string, selection: ModelSelection, signal?: AbortSignal): Promise<CarrierSettingsMutationResult> {
+  return mutateState(`/carrier-settings/carriers/${encodeURIComponent(carrierId)}/taskforce/${encodeURIComponent(cliType)}`, "PUT", selection, signal);
+}
+
+export async function deleteCarrierTaskForceBackend(carrierId: string, cliType: string, signal?: AbortSignal): Promise<CarrierSettingsMutationResult> {
+  return mutateState(`/carrier-settings/carriers/${encodeURIComponent(carrierId)}/taskforce/${encodeURIComponent(cliType)}`, "DELETE", {}, signal);
+}
+
+export async function deleteCarrierTaskForce(carrierId: string, signal?: AbortSignal): Promise<CarrierSettingsMutationResult> {
+  return mutateState(`/carrier-settings/carriers/${encodeURIComponent(carrierId)}/taskforce`, "DELETE", {}, signal);
+}
+
+async function mutateState(url: string, method: string, body: unknown, signal?: AbortSignal): Promise<CarrierSettingsMutationResult> {
+  const response = await fetch(url, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal,
+  });
+  await assertOk(response);
+  const payload = await response.json() as { readonly state?: unknown };
+  if (!payload || typeof payload !== "object" || !("state" in payload)) {
+    throw new ApiError(response.status, "Invalid carrier settings mutation response");
+  }
+  return { state: assertCarrierSettingsState(payload.state, response.status) };
+}
+
+async function assertOk(response: Response): Promise<void> {
+  if (response.ok) return;
+  let message = response.statusText || `HTTP ${response.status}`;
+  try {
+    const payload = await response.json() as { error?: unknown };
+    if (typeof payload.error === "string") message = payload.error;
+  } catch {
+    // 응답 본문이 JSON이 아니면 statusText를 사용한다.
+  }
+  throw new ApiError(response.status, message);
+}
+
+function assertCarrierSettingsState(value: unknown, status: number): CarrierSettingsState {
+  rejectLeakedFields(value, status);
+  const payload = value as Partial<CarrierSettingsState>;
+  if (!payload || typeof payload.generation !== "number" || !Array.isArray(payload.carriers)) {
+    throw new ApiError(status, "Invalid carrier settings state response");
+  }
+  return {
+    generation: payload.generation,
+    carriers: payload.carriers.map((carrier) => assertCarrierSettingsCarrier(carrier, status)),
+  };
+}
+
+function assertCarrierSettingsOptions(value: unknown, status: number): CarrierSettingsOptions {
+  rejectLeakedFields(value, status);
+  const payload = value as Partial<CarrierSettingsOptions>;
+  if (!payload || !Array.isArray(payload.cliTypes) || !payload.taskForceConstraints || typeof payload.taskForceConstraints.minBackends !== "number") {
+    throw new ApiError(status, "Invalid carrier settings options response");
+  }
+  return {
+    cliTypes: payload.cliTypes.map((cli) => assertCliOption(cli, status)),
+    taskForceConstraints: { minBackends: payload.taskForceConstraints.minBackends },
+  };
+}
+
+function assertCarrierSettingsCarrier(value: unknown, status: number): CarrierSettingsCarrier {
+  const payload = value as Partial<CarrierSettingsCarrier>;
+  if (
+    !payload
+    || typeof payload.carrierId !== "string"
+    || typeof payload.displayName !== "string"
+    || typeof payload.sourceDisplayName !== "string"
+    || typeof payload.role !== "string"
+    || typeof payload.roleDescription !== "string"
+    || typeof payload.slot !== "number"
+    || typeof payload.cliType !== "string"
+    || typeof payload.defaultCliType !== "string"
+    || typeof payload.model !== "string"
+    || (payload.effort !== undefined && typeof payload.effort !== "string")
+    || (payload.agentMode !== "cli" && payload.agentMode !== "subagent")
+    || typeof payload.subagentMode !== "boolean"
+    || typeof payload.taskForceBackendCount !== "number"
+    || !payload.taskforce
+    || !Array.isArray(payload.taskforce.backends)
+  ) {
+    throw new ApiError(status, "Invalid carrier settings carrier response");
+  }
+  return {
+    carrierId: payload.carrierId,
+    displayName: payload.displayName,
+    sourceDisplayName: payload.sourceDisplayName,
+    role: payload.role,
+    roleDescription: payload.roleDescription,
+    ...(payload.category ? { category: payload.category } : {}),
+    slot: payload.slot,
+    cliType: payload.cliType,
+    defaultCliType: payload.defaultCliType,
+    model: payload.model,
+    ...(payload.effort ? { effort: payload.effort } : {}),
+    agentMode: payload.agentMode,
+    subagentMode: payload.subagentMode,
+    taskForceBackendCount: payload.taskForceBackendCount,
+    taskforce: { backends: payload.taskforce.backends.map((backend) => assertTaskForceBackend(backend, status)) },
+  };
+}
+
+function assertCliOption(value: unknown, status: number): CarrierSettingsCliOption {
+  const payload = value as Partial<CarrierSettingsCliOption>;
+  if (
+    !payload
+    || typeof payload.id !== "string"
+    || typeof payload.displayName !== "string"
+    || typeof payload.supportsSubagent !== "boolean"
+    || !Array.isArray(payload.models)
+    || typeof payload.defaultModel !== "string"
+  ) {
+    throw new ApiError(status, "Invalid carrier settings CLI option");
+  }
+  return {
+    id: payload.id,
+    displayName: payload.displayName,
+    supportsSubagent: payload.supportsSubagent,
+    models: payload.models.map((model) => assertModelOption(model, status)),
+    defaultModel: payload.defaultModel,
+  };
+}
+
+function assertModelOption(value: unknown, status: number): CarrierSettingsModelOption {
+  const payload = value as Partial<CarrierSettingsModelOption>;
+  if (!payload || typeof payload.modelId !== "string" || typeof payload.name !== "string") {
+    throw new ApiError(status, "Invalid carrier settings model option");
+  }
+  if (payload.effort !== undefined && (!Array.isArray(payload.effort.levels) || typeof payload.effort.default !== "string")) {
+    throw new ApiError(status, "Invalid carrier settings effort option");
+  }
+  return {
+    modelId: payload.modelId,
+    name: payload.name,
+    ...(payload.effort ? { effort: { levels: payload.effort.levels.filter((level): level is string => typeof level === "string"), default: payload.effort.default } } : {}),
+  };
+}
+
+function assertTaskForceBackend(value: unknown, status: number): CarrierSettingsTaskForceBackend {
+  const payload = value as Partial<CarrierSettingsTaskForceBackend>;
+  if (!payload || typeof payload.cliType !== "string" || typeof payload.model !== "string" || (payload.effort !== undefined && typeof payload.effort !== "string")) {
+    throw new ApiError(status, "Invalid carrier settings Task Force backend");
+  }
+  return {
+    cliType: payload.cliType,
+    model: payload.model,
+    ...(payload.effort ? { effort: payload.effort } : {}),
+  };
+}
+
+function rejectLeakedFields(value: unknown, status: number): void {
+  const stack: unknown[] = [value];
+  while (stack.length > 0) {
+    const item = stack.pop();
+    if (!item || typeof item !== "object") continue;
+    for (const [key, nested] of Object.entries(item)) {
+      if (LEAKED_FIELD_NAMES.has(key)) throw new ApiError(status, "Carrier settings response leaked a restricted field");
+      if (nested && typeof nested === "object") stack.push(nested);
+    }
+  }
+}

--- a/runtime/fleet-console/client/src/carrier-settings-store.ts
+++ b/runtime/fleet-console/client/src/carrier-settings-store.ts
@@ -147,7 +147,9 @@ export async function saveCarrierAll(desiredTaskForce: readonly CarrierSettingsT
       latestState = (await updateCarrierModel(carrier.carrierId, selectionFromDraft(draft))).state;
     }
     if (draft.agentMode === "subagent") {
-      if (carrier.agentMode !== "subagent") {
+      // 이미 subagent여도 서버에 TF 백엔드가 남아 있으면(불일치 데이터) SA-enable PUT을 보내
+      // 서버가 TF를 원자적으로 정리하게 한다. carrier.agentMode만 보고 스킵하면 stale TF가 남는다.
+      if (carrier.agentMode !== "subagent" || carrier.taskForceBackendCount > 0) {
         latestState = (await updateCarrierAgentMode(carrier.carrierId, "subagent")).state;
       }
     } else {

--- a/runtime/fleet-console/client/src/carrier-settings-store.ts
+++ b/runtime/fleet-console/client/src/carrier-settings-store.ts
@@ -135,10 +135,15 @@ export async function saveCarrierAll(desiredTaskForce: readonly CarrierSettingsT
     if (draft.displayName !== carrier.displayName) {
       latestState = (await updateCarrierDisplayName(carrier.carrierId, draft.displayName)).state;
     }
-    if (draft.cliType !== carrier.cliType) {
+    const cliChanged = draft.cliType !== carrier.cliType;
+    if (cliChanged) {
       latestState = (await updateCarrierCli(carrier.carrierId, draft.cliType)).state;
     }
-    if (draft.model !== carrier.model || (draft.effort || "") !== (carrier.effort || "")) {
+    // CLI 변경 시 updateCarrierCli가 대상 CLI에 저장돼 있던 이전 선택을 복원할 수 있다.
+    // 변경 전(구 CLI) carrier와의 모델 비교만으로 PUT을 건너뛰면, 신 CLI 기본값이 구 CLI
+    // 모델과 우연히 같을 때 복원된 선택이 draft와 다르게 저장된다. CLI가 바뀌었으면 항상
+    // draft 모델을 명시 전송해 사용자가 본 draft 선택이 우선되게 한다.
+    if (cliChanged || draft.model !== carrier.model || (draft.effort || "") !== (carrier.effort || "")) {
       latestState = (await updateCarrierModel(carrier.carrierId, selectionFromDraft(draft))).state;
     }
     if (draft.agentMode === "subagent") {

--- a/runtime/fleet-console/client/src/carrier-settings-store.ts
+++ b/runtime/fleet-console/client/src/carrier-settings-store.ts
@@ -1,0 +1,255 @@
+import { useSyncExternalStore } from "react";
+
+import {
+  deleteCarrierTaskForceBackend,
+  fetchCarrierSettingsOptions,
+  fetchCarrierSettingsState,
+  setCarrierTaskForceBackend,
+  updateCarrierAgentMode,
+  updateCarrierCli,
+  updateCarrierDisplayName,
+  updateCarrierModel,
+} from "./carrier-settings-api.js";
+import type {
+  CarrierSettingsAgentMode,
+  CarrierSettingsCarrier,
+  CarrierSettingsOptions,
+  CarrierSettingsState,
+} from "./types.js";
+
+interface CarrierSettingsDraft {
+  readonly cliType: string;
+  readonly model: string;
+  readonly effort: string;
+  readonly displayName: string;
+  readonly agentMode: CarrierSettingsAgentMode;
+  readonly taskforce: Readonly<Record<string, { readonly model: string; readonly effort: string }>>;
+}
+
+export interface CarrierSettingsTaskForceSaveInput {
+  readonly cliType: string;
+  readonly model: string;
+  readonly effort?: string;
+}
+
+interface CarrierSettingsStoreState {
+  readonly loading: boolean;
+  readonly state: CarrierSettingsState | null;
+  readonly options: CarrierSettingsOptions | null;
+  readonly activeCarrierId: string | null;
+  readonly draft: CarrierSettingsDraft;
+  readonly savingActionId: string | null;
+  readonly error: string | null;
+}
+
+type Listener = () => void;
+
+const EMPTY_DRAFT: CarrierSettingsDraft = {
+  cliType: "",
+  model: "",
+  effort: "",
+  displayName: "",
+  agentMode: "cli",
+  taskforce: {},
+};
+
+const listeners = new Set<Listener>();
+let snapshot: CarrierSettingsStoreState = {
+  loading: false,
+  state: null,
+  options: null,
+  activeCarrierId: null,
+  draft: EMPTY_DRAFT,
+  savingActionId: null,
+  error: null,
+};
+
+export function useCarrierSettingsStore(): CarrierSettingsStoreState {
+  return useSyncExternalStore(subscribe, getCarrierSettingsStoreState, getCarrierSettingsStoreState);
+}
+
+export function getCarrierSettingsStoreState(): CarrierSettingsStoreState {
+  return snapshot;
+}
+
+export function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export async function loadCarrierSettings(signal?: AbortSignal): Promise<void> {
+  setSnapshot({ loading: true, error: null });
+  try {
+    const [state, options] = await Promise.all([
+      fetchCarrierSettingsState(signal),
+      fetchCarrierSettingsOptions(signal),
+    ]);
+    hydrateCarrierSettings(state, options);
+  } catch (error) {
+    if (signal?.aborted) return;
+    setSnapshot({ loading: false, error: toErrorMessage(error) });
+  }
+}
+
+export function selectCarrierSettingsCarrier(carrierId: string): void {
+  const carrier = snapshot.state?.carriers.find((item) => item.carrierId === carrierId);
+  setSnapshot({
+    activeCarrierId: carrierId,
+    draft: carrier ? buildDraft(carrier, snapshot.options) : snapshot.draft,
+    error: null,
+  });
+}
+
+export function updateCarrierSettingsDraft(patch: Partial<CarrierSettingsDraft>): void {
+  setSnapshot({ draft: { ...snapshot.draft, ...patch }, error: null });
+}
+
+export function updateCarrierSettingsTaskForceDraft(cliType: string, patch: { readonly model?: string; readonly effort?: string }): void {
+  const current = snapshot.draft.taskforce[cliType] ?? { model: "", effort: "" };
+  setSnapshot({
+    draft: {
+      ...snapshot.draft,
+      taskforce: {
+        ...snapshot.draft.taskforce,
+        [cliType]: { ...current, ...patch },
+      },
+    },
+    error: null,
+  });
+}
+
+export function resetCarrierSettingsDraft(): void {
+  const carrier = getActiveCarrier();
+  if (!carrier) return;
+  setSnapshot({ draft: buildDraft(carrier, snapshot.options), error: null });
+}
+
+export async function saveCarrierAll(desiredTaskForce: readonly CarrierSettingsTaskForceSaveInput[]): Promise<boolean> {
+  const carrier = getActiveCarrier();
+  if (!carrier) return false;
+  return runMutation("save-all", async () => {
+    const draft = snapshot.draft;
+    let latestState: CarrierSettingsState | null = null;
+    if (draft.displayName !== carrier.displayName) {
+      latestState = (await updateCarrierDisplayName(carrier.carrierId, draft.displayName)).state;
+    }
+    if (draft.cliType !== carrier.cliType) {
+      latestState = (await updateCarrierCli(carrier.carrierId, draft.cliType)).state;
+    }
+    if (draft.model !== carrier.model || (draft.effort || "") !== (carrier.effort || "")) {
+      latestState = (await updateCarrierModel(carrier.carrierId, selectionFromDraft(draft))).state;
+    }
+    if (draft.agentMode === "subagent") {
+      if (carrier.agentMode !== "subagent") {
+        latestState = (await updateCarrierAgentMode(carrier.carrierId, "subagent")).state;
+      }
+    } else {
+      if (carrier.agentMode !== "cli") {
+        latestState = (await updateCarrierAgentMode(carrier.carrierId, "cli")).state;
+      }
+      latestState = await saveTaskForceForCarrier(carrier, desiredTaskForce, latestState);
+    }
+    return { state: latestState ?? await fetchCarrierSettingsState() };
+  });
+}
+
+function hydrateCarrierSettings(state: CarrierSettingsState, options: CarrierSettingsOptions): void {
+  const activeCarrierId = resolveActiveCarrierId(state, snapshot.activeCarrierId);
+  const carrier = state.carriers.find((item) => item.carrierId === activeCarrierId) ?? null;
+  setSnapshot({
+    loading: false,
+    state,
+    options,
+    activeCarrierId,
+    draft: carrier ? buildDraft(carrier, options) : snapshot.draft,
+    error: null,
+  });
+}
+
+async function runMutation(actionId: string, operation: () => Promise<{ readonly state: CarrierSettingsState }>): Promise<boolean> {
+  setSnapshot({ savingActionId: actionId, error: null });
+  try {
+    const result = await operation();
+    hydrateCarrierSettings(result.state, snapshot.options ?? { cliTypes: [], taskForceConstraints: { minBackends: 2 } });
+    setSnapshot({ savingActionId: null });
+    return true;
+  } catch (error) {
+    setSnapshot({ savingActionId: null, error: toErrorMessage(error) });
+    return false;
+  }
+}
+
+function buildDraft(carrier: CarrierSettingsCarrier, options: CarrierSettingsOptions | null): CarrierSettingsDraft {
+  const taskforce = Object.fromEntries(
+    (options?.cliTypes ?? []).map((cli) => {
+      const backend = carrier.taskforce.backends.find((item) => item.cliType === cli.id);
+      return [cli.id, {
+        model: backend?.model ?? cli.defaultModel,
+        effort: backend?.effort ?? defaultEffortForModel(cli.id, backend?.model ?? cli.defaultModel, options) ?? "",
+      }];
+    }),
+  );
+  return {
+    cliType: carrier.cliType,
+    model: carrier.model,
+    effort: carrier.effort ?? "",
+    displayName: carrier.displayName,
+    agentMode: carrier.agentMode,
+    taskforce,
+  };
+}
+
+function defaultEffortForModel(cliType: string, modelId: string, options: CarrierSettingsOptions | null): string | null {
+  const cli = options?.cliTypes.find((item) => item.id === cliType);
+  const model = cli?.models.find((item) => item.modelId === modelId);
+  return model?.effort?.default ?? null;
+}
+
+function selectionFromDraft(draft: CarrierSettingsDraft): { readonly model: string; readonly effort?: string } {
+  return {
+    model: draft.model,
+    ...(draft.effort ? { effort: draft.effort } : {}),
+  };
+}
+
+function getActiveCarrier(): CarrierSettingsCarrier | null {
+  return snapshot.state?.carriers.find((carrier) => carrier.carrierId === snapshot.activeCarrierId) ?? null;
+}
+
+async function saveTaskForceForCarrier(
+  carrier: CarrierSettingsCarrier,
+  desired: readonly CarrierSettingsTaskForceSaveInput[],
+  latestState: CarrierSettingsState | null,
+): Promise<CarrierSettingsState | null> {
+  const desiredCliTypes = new Set(desired.map((backend) => backend.cliType));
+  for (const backend of carrier.taskforce.backends) {
+    if (!desiredCliTypes.has(backend.cliType)) {
+      latestState = (await deleteCarrierTaskForceBackend(carrier.carrierId, backend.cliType)).state;
+    }
+  }
+  for (const backend of desired) {
+    const current = carrier.taskforce.backends.find((item) => item.cliType === backend.cliType);
+    if (current && current.model === backend.model && (current.effort || "") === (backend.effort || "")) continue;
+    latestState = (await setCarrierTaskForceBackend(carrier.carrierId, backend.cliType, {
+      model: backend.model,
+      ...(backend.effort ? { effort: backend.effort } : {}),
+    })).state;
+  }
+  return latestState;
+}
+
+function resolveActiveCarrierId(state: CarrierSettingsState, activeCarrierId: string | null): string | null {
+  if (activeCarrierId && state.carriers.some((carrier) => carrier.carrierId === activeCarrierId)) return activeCarrierId;
+  return state.carriers[0]?.carrierId ?? null;
+}
+
+function setSnapshot(patch: Partial<CarrierSettingsStoreState>): void {
+  snapshot = { ...snapshot, ...patch };
+  for (const listener of listeners) listener();
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/runtime/fleet-console/client/src/components/topbar.tsx
+++ b/runtime/fleet-console/client/src/components/topbar.tsx
@@ -13,7 +13,7 @@ interface NavItem {
   readonly to: string;
   readonly label: string;
   readonly end: boolean;
-  readonly icon: "operations" | "codex";
+  readonly icon: "operations" | "codex" | "settings";
 }
 
 interface ThemeOption {
@@ -25,6 +25,7 @@ interface ThemeOption {
 // GNB 항목 — Welcome으로의 이동은 브랜드 로고 클릭이 담당하므로 여기서는 제외한다.
 const NAV_ITEMS: readonly NavItem[] = [
   { to: "/operations", label: "Operation", end: false, icon: "operations" },
+  { to: "/carrier-settings", label: "Settings", end: false, icon: "settings" },
   { to: "/codex", label: "Codex", end: false, icon: "codex" },
 ];
 
@@ -40,6 +41,8 @@ export function Topbar({ state }: TopbarProps) {
   const pathname = useLocation().pathname;
   const sigil = pathname.startsWith("/codex")
     ? <CodexIcon />
+    : pathname.startsWith("/carrier-settings")
+      ? <SettingsIcon />
     : pathname.startsWith("/operations")
       ? <OperationsIcon />
       : <FleetSigil />;
@@ -79,7 +82,7 @@ export function Topbar({ state }: TopbarProps) {
               className={({ isActive }) => `topbar-nav-link ${isActive ? "is-active" : ""}`}
             >
               <span className="topbar-nav-icon" aria-hidden="true">
-                {item.icon === "operations" ? <OperationsIcon /> : <CodexIcon />}
+                {item.icon === "operations" ? <OperationsIcon /> : item.icon === "settings" ? <SettingsIcon /> : <CodexIcon />}
               </span>
               <span>{item.label}</span>
             </NavLink>
@@ -420,6 +423,18 @@ function CodexIcon() {
       <circle cx="12" cy="12" r="3.2" fill="currentColor" stroke="none" opacity="0.16" />
       <path d="M12 3v3.6M12 17.4V21M3 12h3.6M17.4 12H21" />
       <path d="M12 8.6 14.2 12 12 15.4 9.8 12Z" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+function SettingsIcon() {
+  // Settings 시그니처 — 조정 노브 모티프. carrier 설정 화면과 GNB nav가 같은 도형을 공유한다.
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M3 4.4h10M3 8h10M3 11.6h10" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+      <circle cx="6.2" cy="4.4" r="1.3" fill="var(--surface-glass-strong)" stroke="currentColor" strokeWidth="1.2" />
+      <circle cx="10" cy="8" r="1.3" fill="var(--surface-glass-strong)" stroke="currentColor" strokeWidth="1.2" />
+      <circle cx="7.4" cy="11.6" r="1.3" fill="var(--surface-glass-strong)" stroke="currentColor" strokeWidth="1.2" />
     </svg>
   );
 }

--- a/runtime/fleet-console/client/src/main.tsx
+++ b/runtime/fleet-console/client/src/main.tsx
@@ -1,4 +1,5 @@
 import "@fontsource-variable/fraunces";
+import "@fontsource-variable/fraunces/standard-italic.css";
 import "@fontsource-variable/manrope";
 import "@fontsource-variable/jetbrains-mono";
 import "@fontsource-variable/cascadia-code";

--- a/runtime/fleet-console/client/src/pages/carrier-settings.tsx
+++ b/runtime/fleet-console/client/src/pages/carrier-settings.tsx
@@ -226,10 +226,13 @@ export function CarrierSettings() {
                     <p className="carrier-settings-resp-title">SubAgent</p>
                     <p className="carrier-settings-help">{taskForceDraftActive ? "Task Force draft is present. Remove every backend to enable SubAgent." : activeCli.supportsSubagent ? "Enabling SubAgent clears Task Force backends when saved." : "This CLI does not support SubAgent mode."}</p>
                   </div>
+                  {/* 켜는 경로만 막는다. 비지원 CLI/TF draft 상태에서도 이미 subagent로 켜진 캐리어는
+                      끌 수 있어야 한다(서버는 비지원 CLI의 cli 전환을 허용). 끄기까지 막으면 codex+subagent
+                      같은 불일치 상태에 갇힌다. */}
                   <button
                     type="button"
                     className={`carrier-settings-toggle ${subagentDraftOn ? "is-on" : ""}`}
-                    disabled={!activeCli.supportsSubagent || taskForceDraftActive || isSavingAll}
+                    disabled={isSavingAll || (!subagentDraftOn && (!activeCli.supportsSubagent || taskForceDraftActive))}
                     aria-pressed={subagentDraftOn}
                     onClick={() => updateCarrierSettingsDraft({ agentMode: subagentDraftOn ? "cli" : "subagent" })}
                   >

--- a/runtime/fleet-console/client/src/pages/carrier-settings.tsx
+++ b/runtime/fleet-console/client/src/pages/carrier-settings.tsx
@@ -45,7 +45,9 @@ export function CarrierSettings() {
   const [taskForceRows, setTaskForceRows] = useState<readonly string[]>([]);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
   const taskForceDraftActive = taskForceRows.length > 0;
-  const subagentDraftOn = settings.draft.agentMode === "subagent" && !taskForceDraftActive;
+  // raw draft.agentMode 기준. TF 백엔드가 함께 있는 불일치 상태에서도 subagent가 켜진 것으로
+  // 보고 끌 수 있어야 하므로 !taskForceDraftActive로 배제하지 않는다.
+  const subagentSelected = settings.draft.agentMode === "subagent";
   const taskForceDisabled = settings.draft.agentMode === "subagent";
   const isSavingAll = settings.savingActionId === "save-all";
   const dirty = activeCarrier ? hasCarrierDraftChanges(activeCarrier, settings.draft, taskForceRows) : false;
@@ -226,17 +228,18 @@ export function CarrierSettings() {
                     <p className="carrier-settings-resp-title">SubAgent</p>
                     <p className="carrier-settings-help">{taskForceDraftActive ? "Task Force draft is present. Remove every backend to enable SubAgent." : activeCli.supportsSubagent ? "Enabling SubAgent clears Task Force backends when saved." : "This CLI does not support SubAgent mode."}</p>
                   </div>
-                  {/* 켜는 경로만 막는다. 비지원 CLI/TF draft 상태에서도 이미 subagent로 켜진 캐리어는
-                      끌 수 있어야 한다(서버는 비지원 CLI의 cli 전환을 허용). 끄기까지 막으면 codex+subagent
-                      같은 불일치 상태에 갇힌다. */}
+                  {/* 켜는 경로만 막는다. 이미 subagent로 켜진 캐리어는 비지원 CLI든 TF 백엔드가 함께
+                      있는 불일치 상태든 끌 수 있어야 한다(서버는 어느 CLI에서도 cli 전환을 허용). 끄기까지
+                      막으면 codex+subagent 또는 subagent+TF 같은 상태에서 양쪽 다 못 끄는 교착에 갇힌다.
+                      SA를 끄면 TF 패널 비활성이 풀려 TF 행을 정리할 수 있다. */}
                   <button
                     type="button"
-                    className={`carrier-settings-toggle ${subagentDraftOn ? "is-on" : ""}`}
-                    disabled={isSavingAll || (!subagentDraftOn && (!activeCli.supportsSubagent || taskForceDraftActive))}
-                    aria-pressed={subagentDraftOn}
-                    onClick={() => updateCarrierSettingsDraft({ agentMode: subagentDraftOn ? "cli" : "subagent" })}
+                    className={`carrier-settings-toggle ${subagentSelected ? "is-on" : ""}`}
+                    disabled={isSavingAll || (!subagentSelected && (!activeCli.supportsSubagent || taskForceDraftActive))}
+                    aria-pressed={subagentSelected}
+                    onClick={() => updateCarrierSettingsDraft({ agentMode: subagentSelected ? "cli" : "subagent" })}
                   >
-                    <span>{subagentDraftOn ? "On" : "Off"}</span>
+                    <span>{subagentSelected ? "On" : "Off"}</span>
                   </button>
                 </div>
               </div>

--- a/runtime/fleet-console/client/src/pages/carrier-settings.tsx
+++ b/runtime/fleet-console/client/src/pages/carrier-settings.tsx
@@ -1,0 +1,500 @@
+import { useEffect, useState, type CSSProperties } from "react";
+
+import {
+  loadCarrierSettings,
+  resetCarrierSettingsDraft,
+  saveCarrierAll,
+  selectCarrierSettingsCarrier,
+  updateCarrierSettingsDraft,
+  updateCarrierSettingsTaskForceDraft,
+  useCarrierSettingsStore,
+} from "../carrier-settings-store.js";
+import type { CarrierSettingsAgentMode, CarrierSettingsCarrier, CarrierSettingsCliOption, CarrierSettingsModelOption } from "../types.js";
+
+type CaptainColorStyle = CSSProperties & { "--cap-color": string };
+type SaveStatus = "idle" | "saving" | "saved";
+
+interface CarrierSettingsDraftView {
+  readonly cliType: string;
+  readonly model: string;
+  readonly effort: string;
+  readonly displayName: string;
+  readonly agentMode: CarrierSettingsAgentMode;
+  readonly taskforce: Readonly<Record<string, { readonly model: string; readonly effort: string }>>;
+}
+
+const DISPLAY_NAME_MAX_LENGTH = 50;
+const SAVE_FEEDBACK_DURATION_MS = 2400;
+const CAPTAIN_COLOR_TOKENS: Readonly<Record<string, string>> = {
+  nimitz: "var(--captain-nimitz)",
+  kirov: "var(--captain-kirov)",
+  genesis: "var(--captain-genesis)",
+  ohio: "var(--captain-ohio)",
+  sentinel: "var(--captain-sentinel)",
+  vanguard: "var(--captain-vanguard)",
+  tempest: "var(--captain-tempest)",
+  chronicle: "var(--captain-chronicle)",
+};
+
+export function CarrierSettings() {
+  const settings = useCarrierSettingsStore();
+  const activeCarrier = settings.state?.carriers.find((carrier) => carrier.carrierId === settings.activeCarrierId) ?? null;
+  const activeCli = settings.options?.cliTypes.find((cli) => cli.id === settings.draft.cliType) ?? null;
+  const activeModel = activeCli?.models.find((model) => model.modelId === settings.draft.model) ?? null;
+  const [editingDisplayName, setEditingDisplayName] = useState(false);
+  const [taskForceRows, setTaskForceRows] = useState<readonly string[]>([]);
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
+  const taskForceDraftActive = taskForceRows.length > 0;
+  const subagentDraftOn = settings.draft.agentMode === "subagent" && !taskForceDraftActive;
+  const taskForceDisabled = settings.draft.agentMode === "subagent";
+  const isSavingAll = settings.savingActionId === "save-all";
+  const dirty = activeCarrier ? hasCarrierDraftChanges(activeCarrier, settings.draft, taskForceRows) : false;
+  const taskForceConfigKey = activeCarrier?.taskforce.backends.map((backend) => `${backend.cliType}:${backend.model}:${backend.effort ?? ""}`).join("|") ?? "";
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadCarrierSettings(controller.signal);
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => {
+    setEditingDisplayName(false);
+    setTaskForceRows(activeCarrier?.taskforce.backends.map((backend) => backend.cliType) ?? []);
+    setSaveStatus("idle");
+  }, [activeCarrier?.carrierId, taskForceConfigKey]);
+
+  useEffect(() => {
+    if (saveStatus !== "saved") return;
+    const timeout = window.setTimeout(() => setSaveStatus("idle"), SAVE_FEEDBACK_DURATION_MS);
+    return () => window.clearTimeout(timeout);
+  }, [saveStatus]);
+
+  function handleDiscard(): void {
+    if (!activeCarrier) return;
+    resetCarrierSettingsDraft();
+    setTaskForceRows(activeCarrier.taskforce.backends.map((backend) => backend.cliType));
+    setEditingDisplayName(false);
+    setSaveStatus("idle");
+  }
+
+  async function handleSave(): Promise<void> {
+    if (!activeCarrier) return;
+    setSaveStatus("saving");
+    const saved = await saveCarrierAll(buildDesiredTaskForce(taskForceRows, settings.draft.taskforce));
+    if (!saved) {
+      setSaveStatus("idle");
+      return;
+    }
+    setEditingDisplayName(false);
+    setSaveStatus("saved");
+  }
+
+  return (
+    <main className="carrier-settings-page">
+      <section className="carrier-settings-hero" aria-labelledby="carrier-settings-title">
+        <div>
+          <p className="bridge-kicker">Carrier Control Surface</p>
+          <h2 id="carrier-settings-title">Carrier Settings</h2>
+        </div>
+        <div className="carrier-settings-hero-actions">
+          <div className={`carrier-settings-save-status ${saveStatus === "saved" ? "is-positive" : ""}`} role="status" aria-live="polite">
+            {saveStatus === "saving" || isSavingAll ? "Saving…" : saveStatus === "saved" ? "Saved ✓" : ""}
+          </div>
+          {activeCarrier ? (
+            <div className="carrier-settings-save-actions">
+              <button type="button" className={`carrier-settings-action-button ${dirty ? "is-dirty" : ""}`} disabled={!dirty || isSavingAll} onClick={() => void handleSave()}>
+                Save
+              </button>
+              <button type="button" className={`carrier-settings-action-button ${dirty ? "is-dirty" : ""}`} disabled={!dirty || isSavingAll} onClick={handleDiscard}>
+                Discard
+              </button>
+            </div>
+          ) : null}
+          <button type="button" className="carrier-settings-action-button carrier-settings-hero-refresh" disabled={settings.loading} onClick={() => void loadCarrierSettings()}>
+            Refresh
+          </button>
+        </div>
+      </section>
+
+      {settings.error ? <p className="carrier-settings-error" role="alert">{settings.error}</p> : null}
+
+      <section className="carrier-settings-grid">
+        <div className="carrier-settings-list" aria-label="Carrier list">
+          {settings.loading && !settings.state ? <p className="carrier-settings-empty">Loading carrier settings.</p> : null}
+          {settings.state && settings.state.carriers.length === 0 ? <p className="carrier-settings-empty">No carriers registered.</p> : null}
+          {settings.state?.carriers.map((carrier) => (
+            <CarrierRow
+              key={carrier.carrierId}
+              carrier={carrier}
+              active={carrier.carrierId === settings.activeCarrierId}
+              minBackends={settings.options?.taskForceConstraints.minBackends ?? 2}
+              onSelect={() => selectCarrierSettingsCarrier(carrier.carrierId)}
+            />
+          ))}
+        </div>
+
+        {activeCarrier && settings.options && activeCli ? (
+          <div key={activeCarrier.carrierId} className="carrier-settings-detail" style={getCaptainColorStyle(activeCarrier.carrierId)}>
+            <div className="carrier-settings-detail-head">
+              <div className="carrier-settings-detail-title-block">
+                <div className="carrier-settings-captain-id"><span>Captain</span> · {activeCarrier.carrierId.toUpperCase()}</div>
+                <div className={`carrier-settings-name-line ${editingDisplayName ? "is-editing" : ""}`}>
+                  {editingDisplayName ? (
+                    <>
+                      <input
+                        id="carrier-display-name"
+                        className="carrier-settings-input carrier-settings-name-input"
+                        value={settings.draft.displayName}
+                        maxLength={DISPLAY_NAME_MAX_LENGTH}
+                        onChange={(event) => updateCarrierSettingsDraft({ displayName: event.target.value })}
+                      />
+                      <button type="button" className="carrier-settings-icon-button" aria-label="Save display name" disabled={isSavingAll} onClick={() => {
+                        setEditingDisplayName(false);
+                      }}>
+                        <CheckIcon />
+                      </button>
+                      <button type="button" className="carrier-settings-icon-button" aria-label="Cancel display name edit" onClick={() => {
+                        updateCarrierSettingsDraft({ displayName: activeCarrier.displayName });
+                        setEditingDisplayName(false);
+                      }}>
+                        <CloseIcon />
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <h3 className="carrier-settings-captain-name">{activeCarrier.displayName}</h3>
+                      <button type="button" className="carrier-settings-icon-button" aria-label="Edit display name" onClick={() => {
+                        updateCarrierSettingsDraft({ displayName: activeCarrier.displayName });
+                        setEditingDisplayName(true);
+                      }}>
+                        <PencilIcon />
+                      </button>
+                    </>
+                  )}
+                </div>
+                <div className="carrier-settings-captain-role">{activeCarrier.role}</div>
+              </div>
+              <div className="carrier-settings-cli-badge">
+                <span className="ind" aria-hidden="true" />
+                {activeCarrier.cliType}
+              </div>
+            </div>
+
+            <div className="carrier-settings-body">
+              <div className="carrier-settings-control-group">
+                <div className="carrier-settings-resp-title">Identity</div>
+                <div className="carrier-settings-mission">"{activeCarrier.roleDescription}"</div>
+              </div>
+
+              <div className="carrier-settings-control-group">
+                <div className="carrier-settings-resp-title">Runtime</div>
+                <div className="carrier-settings-runtime">
+                  <div className="carrier-settings-runtime-row carrier-settings-runtime-row--cli">
+                    <div className="carrier-settings-field carrier-settings-field--wide">
+                      <label className="carrier-settings-label" htmlFor="carrier-cli">CLI</label>
+                      <select
+                        id="carrier-cli"
+                        className="carrier-settings-select"
+                        value={settings.draft.cliType}
+                        onChange={(event) => handleCliDraftChange(event.target.value, settings.options?.cliTypes ?? [])}
+                      >
+                        {settings.options.cliTypes.map((cli) => <option key={cli.id} value={cli.id}>{cli.displayName}</option>)}
+                      </select>
+                    </div>
+                  </div>
+                  <div className="carrier-settings-runtime-row carrier-settings-runtime-row--model">
+                    <ModelSelect
+                      id="carrier-model"
+                      label="Model"
+                      models={activeCli.models}
+                      value={settings.draft.model}
+                      onChange={(modelId) => handleModelDraftChange(activeCli, modelId)}
+                    />
+                    <EffortSelect
+                      id="carrier-effort"
+                      model={activeModel}
+                      value={settings.draft.effort}
+                      onChange={(effort) => updateCarrierSettingsDraft({ effort })}
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <div className="carrier-settings-control-group">
+                <div className="carrier-settings-toggle-row">
+                  <div>
+                    <p className="carrier-settings-resp-title">SubAgent</p>
+                    <p className="carrier-settings-help">{taskForceDraftActive ? "Task Force draft is present. Remove every backend to enable SubAgent." : activeCli.supportsSubagent ? "Enabling SubAgent clears Task Force backends when saved." : "This CLI does not support SubAgent mode."}</p>
+                  </div>
+                  <button
+                    type="button"
+                    className={`carrier-settings-toggle ${subagentDraftOn ? "is-on" : ""}`}
+                    disabled={!activeCli.supportsSubagent || taskForceDraftActive || isSavingAll}
+                    aria-pressed={subagentDraftOn}
+                    onClick={() => updateCarrierSettingsDraft({ agentMode: subagentDraftOn ? "cli" : "subagent" })}
+                  >
+                    <span>{subagentDraftOn ? "On" : "Off"}</span>
+                  </button>
+                </div>
+              </div>
+
+              <TaskForcePanel
+                carrier={activeCarrier}
+                cliOptions={settings.options.cliTypes}
+                minBackends={settings.options.taskForceConstraints.minBackends}
+                savingActionId={settings.savingActionId}
+                rows={taskForceRows}
+                disabled={taskForceDisabled}
+                onRowsChange={setTaskForceRows}
+              />
+            </div>
+          </div>
+        ) : (
+          <div className="carrier-settings-detail">
+            <p className="carrier-settings-empty">Select a carrier.</p>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function CarrierRow({ carrier, active, minBackends, onSelect }: { readonly carrier: CarrierSettingsCarrier; readonly active: boolean; readonly minBackends: number; readonly onSelect: () => void }) {
+  const tfReady = carrier.taskForceBackendCount >= minBackends;
+  return (
+    <button type="button" className={`carrier-settings-row ${active ? "is-active" : ""}`} style={getCaptainColorStyle(carrier.carrierId)} onClick={onSelect}>
+      <span className="carrier-settings-captain-dot" aria-hidden="true" />
+      <span className="carrier-settings-row-text">
+        <span className="carrier-settings-row-name">{carrier.displayName}</span>
+        <span className="carrier-settings-row-role">{carrier.role}</span>
+      </span>
+      <span className="carrier-settings-row-live" aria-hidden="true">
+        <span className={`carrier-settings-live-dot ${carrier.subagentMode ? "is-live" : ""}`} />
+        <span className={`carrier-settings-live-dot ${tfReady ? "is-live" : ""}`} />
+      </span>
+    </button>
+  );
+}
+
+function ModelSelect({ id, label, models, value, disabled = false, onChange }: { readonly id: string; readonly label: string; readonly models: readonly CarrierSettingsModelOption[]; readonly value: string; readonly disabled?: boolean; readonly onChange: (modelId: string) => void }) {
+  return (
+    <div className="carrier-settings-field">
+      <label className="carrier-settings-label" htmlFor={id}>{label}</label>
+      <select id={id} className="carrier-settings-select" value={value} disabled={disabled} onChange={(event) => onChange(event.target.value)}>
+        {models.map((model) => <option key={model.modelId} value={model.modelId}>{model.name}</option>)}
+      </select>
+    </div>
+  );
+}
+
+function EffortSelect({ id, model, value, disabled = false, onChange }: { readonly id: string; readonly model: CarrierSettingsModelOption | null | undefined; readonly value: string; readonly disabled?: boolean; readonly onChange: (effort: string) => void }) {
+  if (!model?.effort) {
+    return (
+      <div className="carrier-settings-field">
+        <span className="carrier-settings-label">Effort</span>
+        <p className="carrier-settings-help">Not supported for this model.</p>
+      </div>
+    );
+  }
+  return (
+    <div className="carrier-settings-field">
+      <label className="carrier-settings-label" htmlFor={id}>Effort</label>
+      <select id={id} className="carrier-settings-select" value={value || model.effort.default} disabled={disabled} onChange={(event) => onChange(event.target.value)}>
+        {model.effort.levels.map((level) => <option key={level} value={level}>{level}</option>)}
+      </select>
+    </div>
+  );
+}
+
+function TaskForcePanel({
+  carrier,
+  cliOptions,
+  minBackends,
+  savingActionId,
+  rows,
+  disabled,
+  onRowsChange,
+}: {
+  readonly carrier: CarrierSettingsCarrier;
+  readonly cliOptions: readonly CarrierSettingsCliOption[];
+  readonly minBackends: number;
+  readonly savingActionId: string | null;
+  readonly rows: readonly string[];
+  readonly disabled: boolean;
+  readonly onRowsChange: (rows: readonly string[]) => void;
+}) {
+  const settings = useCarrierSettingsStore();
+  // 구성된 백엔드가 있으면 기본 펼침, 없으면 접힘. detail이 carrierId로 remount되어 캐리어별로 재초기화된다.
+  const configuredCount = carrier.taskforce.backends.length;
+  const [expanded, setExpanded] = useState(configuredCount > 0);
+  const [addOpen, setAddOpen] = useState(false);
+  const [addCliType, setAddCliType] = useState("");
+  const active = carrier.taskForceBackendCount >= minBackends;
+  const availableCliOptions = cliOptions.filter((cli) => !rows.includes(cli.id));
+  const selectedAddCliType = addCliType || availableCliOptions[0]?.id || "";
+  return (
+    <div className={`carrier-settings-control-group carrier-settings-control-group--taskforce ${expanded ? "is-expanded" : ""} ${disabled ? "is-disabled" : ""}`}>
+      <div className="carrier-settings-section-head">
+        <div>
+          <p className="carrier-settings-resp-title">Task Force</p>
+          <p className="carrier-settings-help">
+            {disabled
+              ? "Disabled while SubAgent is on. Turn SubAgent off before composing Task Force backends."
+              : configuredCount > 0
+              ? `${configuredCount} backend${configuredCount === 1 ? "" : "s"} configured${active ? " · active" : ` · needs ${minBackends}+ to activate`}.`
+              : `Run this carrier across multiple CLI backends. Needs at least ${minBackends} to activate.`}
+          </p>
+        </div>
+        <div className="carrier-settings-tf-head-actions">
+          <button type="button" className="carrier-settings-tf-toggle" aria-expanded={expanded} onClick={() => setExpanded((value) => !value)}>
+            {expanded ? "Hide" : "Configure"}
+          </button>
+        </div>
+      </div>
+      {expanded ? (
+      <div className="carrier-settings-tf-list">
+        {rows.length === 0 ? <p className="carrier-settings-tf-empty">No Task Force backend drafted.</p> : null}
+        {rows.map((cliType) => {
+          const cli = cliOptions.find((item) => item.id === cliType);
+          if (!cli) return null;
+          const draft = settings.draft.taskforce[cli.id] ?? { model: cli.defaultModel, effort: "" };
+          const model = cli.models.find((item) => item.modelId === draft.model) ?? cli.models[0] ?? null;
+          const active = carrier.taskforce.backends.some((backend) => backend.cliType === cli.id);
+          return (
+            <div className={`carrier-settings-tf-item ${active ? "is-active" : ""}`} key={cli.id}>
+              <div className="carrier-settings-tf-title">
+                <span className={`carrier-settings-live-dot ${active ? "is-live" : ""}`} aria-hidden="true" />
+                <strong>{cli.displayName}</strong>
+              </div>
+              <ModelSelect id={`tf-${cli.id}-model`} label="Model" models={cli.models} value={draft.model} disabled={disabled} onChange={(modelId) => handleTaskForceModelDraftChange(cli, modelId)} />
+              <EffortSelect id={`tf-${cli.id}-effort`} model={model} value={draft.effort} disabled={disabled} onChange={(effort) => updateCarrierSettingsTaskForceDraft(cli.id, { effort })} />
+              <div className="carrier-settings-tf-actions">
+                <button type="button" className="carrier-settings-ghost-button" disabled={disabled || savingActionId === "save-all"} onClick={() => onRowsChange(rows.filter((item) => item !== cli.id))}>
+                  Remove
+                </button>
+              </div>
+            </div>
+          );
+        })}
+        <div className="carrier-settings-tf-add-row">
+          {addOpen && availableCliOptions.length > 0 ? (
+            <select className="carrier-settings-select carrier-settings-tf-add-select" value={selectedAddCliType} onChange={(event) => setAddCliType(event.target.value)} aria-label="Task Force CLI to add">
+              {availableCliOptions.map((cli) => <option key={cli.id} value={cli.id}>{cli.displayName}</option>)}
+            </select>
+          ) : null}
+          <button type="button" className="carrier-settings-ghost-button" disabled={disabled || availableCliOptions.length === 0 || savingActionId === "save-all"} onClick={() => {
+            if (!addOpen) {
+              setAddOpen(true);
+              return;
+            }
+            const cliType = selectedAddCliType;
+            const cli = cliOptions.find((item) => item.id === cliType);
+            const model = cli?.models.find((item) => item.modelId === cli.defaultModel) ?? cli?.models[0] ?? null;
+            if (!cli || !model) return;
+            updateCarrierSettingsTaskForceDraft(cli.id, { model: model.modelId, effort: model.effort?.default ?? "" });
+            onRowsChange(rows.includes(cli.id) ? rows : [...rows, cli.id]);
+            setAddCliType("");
+            setAddOpen(false);
+          }}>
+            Add
+          </button>
+        </div>
+      </div>
+      ) : null}
+    </div>
+  );
+}
+
+function handleCliDraftChange(cliType: string, cliOptions: readonly CarrierSettingsCliOption[]): void {
+  const cli = cliOptions.find((item) => item.id === cliType);
+  const model = cli?.models.find((item) => item.modelId === cli.defaultModel) ?? cli?.models[0] ?? null;
+  const patch: { cliType: string; model: string; effort: string; agentMode?: CarrierSettingsAgentMode } = {
+    cliType,
+    model: model?.modelId ?? "",
+    effort: model?.effort?.default ?? "",
+  };
+  if (!cli?.supportsSubagent) patch.agentMode = "cli";
+  updateCarrierSettingsDraft(patch);
+}
+
+function handleModelDraftChange(cli: CarrierSettingsCliOption, modelId: string): void {
+  const model = cli.models.find((item) => item.modelId === modelId);
+  updateCarrierSettingsDraft({
+    model: modelId,
+    effort: model?.effort?.default ?? "",
+  });
+}
+
+function handleTaskForceModelDraftChange(cli: CarrierSettingsCliOption, modelId: string): void {
+  const model = cli.models.find((item) => item.modelId === modelId);
+  updateCarrierSettingsTaskForceDraft(cli.id, {
+    model: modelId,
+    effort: model?.effort?.default ?? "",
+  });
+}
+
+function hasCarrierDraftChanges(carrier: CarrierSettingsCarrier, draft: CarrierSettingsDraftView, rows: readonly string[]): boolean {
+  if (draft.displayName !== carrier.displayName) return true;
+  if (draft.cliType !== carrier.cliType) return true;
+  if (draft.model !== carrier.model) return true;
+  if ((draft.effort || "") !== (carrier.effort || "")) return true;
+  if (draft.agentMode !== carrier.agentMode) return true;
+  if (draft.agentMode === "subagent") return false;
+  return hasTaskForceChanges(carrier, rows, draft.taskforce);
+}
+
+function hasTaskForceChanges(carrier: CarrierSettingsCarrier, rows: readonly string[], draft: Readonly<Record<string, { readonly model: string; readonly effort: string }>>): boolean {
+  if (rows.length !== carrier.taskforce.backends.length) return true;
+  const rowSet = new Set(rows);
+  for (const backend of carrier.taskforce.backends) {
+    if (!rowSet.has(backend.cliType)) return true;
+    const selection = draft[backend.cliType];
+    if (!selection) return true;
+    if (selection.model !== backend.model) return true;
+    if ((selection.effort || "") !== (backend.effort || "")) return true;
+  }
+  return false;
+}
+
+function buildDesiredTaskForce(rows: readonly string[], draft: CarrierSettingsDraftView["taskforce"]): readonly { readonly cliType: string; readonly model: string; readonly effort?: string }[] {
+  return rows
+    .map((cliType) => {
+      const selection = draft[cliType];
+      return selection ? {
+        cliType,
+        model: selection.model,
+        ...(selection.effort ? { effort: selection.effort } : {}),
+      } : null;
+    })
+    .filter((backend): backend is { readonly cliType: string; readonly model: string; readonly effort?: string } => backend !== null);
+}
+
+function getCaptainColorStyle(carrierId: string): CaptainColorStyle {
+  return { "--cap-color": CAPTAIN_COLOR_TOKENS[carrierId] ?? "var(--brass)" };
+}
+
+function PencilIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+      <path d="M10.8 2.2 13.8 5.2 5.2 13.8 2 14.5 2.7 11.3 10.8 2.2Z" />
+      <path d="M9.7 3.4 12.6 6.3" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+      <path d="M3 8.3 6.4 11.7 13.2 4.5" />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+      <path d="M4.2 4.2 11.8 11.8" />
+      <path d="M11.8 4.2 4.2 11.8" />
+    </svg>
+  );
+}

--- a/runtime/fleet-console/client/src/pages/carrier-settings.tsx
+++ b/runtime/fleet-console/client/src/pages/carrier-settings.tsx
@@ -445,7 +445,9 @@ function hasCarrierDraftChanges(carrier: CarrierSettingsCarrier, draft: CarrierS
   if (draft.model !== carrier.model) return true;
   if ((draft.effort || "") !== (carrier.effort || "")) return true;
   if (draft.agentMode !== carrier.agentMode) return true;
-  if (draft.agentMode === "subagent") return false;
+  // subagent인데 서버에 TF 백엔드가 남아 있으면(불일치 데이터) 정리 대상이므로 dirty로 본다.
+  // 그래야 Save가 활성화되어 saveCarrierAll의 stale TF 정리 경로가 실제로 실행된다.
+  if (draft.agentMode === "subagent") return carrier.taskForceBackendCount > 0;
   return hasTaskForceChanges(carrier, rows, draft.taskforce);
 }
 

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -201,6 +201,770 @@
   font-family: var(--font-mono);
 }
 
+.carrier-settings-page {
+  display: grid;
+  align-content: start;
+  gap: var(--space-5);
+  width: min(1440px, calc(100vw - 48px));
+  /* 셸의 minmax(0,1fr) 행 안에서 페이지 자체가 스크롤 컨테이너가 된다(welcome-page와 동일 모델). */
+  min-height: 0;
+  height: 100%;
+  margin: 0 auto;
+  padding: var(--space-5) 0 var(--space-10);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.carrier-settings-hero {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-4) 0 var(--space-2);
+}
+
+.carrier-settings-hero-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: none;
+}
+
+/* hero 액션 버튼 — GNB nav 버튼 어휘(idle/hover/active/pressed). 평소 muted, 변경(dirty) 시 brass 하이라이트. */
+.carrier-settings-action-button {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px var(--space-3);
+  border: 1px solid transparent;
+  border-radius: var(--radius-xs);
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring),
+    transform var(--duration-fast) var(--ease-spring);
+}
+
+.carrier-settings-action-button:hover:not(:disabled) {
+  color: var(--ink-pearl);
+  background: color-mix(in oklch, var(--brass) 8%, transparent);
+}
+
+.carrier-settings-action-button:active:not(:disabled) {
+  background: color-mix(in oklch, var(--brass) 16%, transparent);
+  transform: translateY(1px);
+}
+
+/* 변경사항 있을 때(dirty) Save/Discard를 brass로 하이라이트 — GNB active와 동일 어휘. */
+.carrier-settings-action-button.is-dirty {
+  color: var(--brass-bright);
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
+}
+
+.carrier-settings-action-button:disabled {
+  color: var(--ink-rim);
+  cursor: not-allowed;
+}
+
+/* 순서: SAVE, DISCARD, (조금 간격) REFRESH */
+.carrier-settings-hero-refresh {
+  margin-left: var(--space-4);
+}
+
+.carrier-settings-hero h2 {
+  margin: 0;
+  color: var(--ink-pearl);
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: clamp(42px, 6vw, 72px);
+  font-weight: 300;
+  letter-spacing: -0.03em;
+  line-height: 0.95;
+}
+
+.carrier-settings-grid {
+  display: grid;
+  grid-template-columns: 360px minmax(0, 1fr);
+  gap: var(--space-6);
+  align-items: start;
+}
+
+.carrier-settings-list {
+  position: sticky;
+  top: var(--space-2);
+  align-self: start;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+  /* 함장 수가 뷰포트를 넘으면 리스트 자체가 스크롤한다. */
+  max-height: calc(100dvh - 132px);
+  overflow-y: auto;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-xl);
+  background: var(--surface-glass);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+}
+
+.carrier-settings-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  min-width: 0;
+  padding: 14px 16px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  animation: codex-rise var(--duration-slow) var(--ease-spring) both;
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring),
+    box-shadow var(--duration-fast) var(--ease-spring),
+    transform var(--duration-fast) var(--ease-spring);
+}
+
+.carrier-settings-row:nth-child(1) { animation-delay: 0ms; }
+.carrier-settings-row:nth-child(2) { animation-delay: 40ms; }
+.carrier-settings-row:nth-child(3) { animation-delay: 80ms; }
+.carrier-settings-row:nth-child(4) { animation-delay: 120ms; }
+.carrier-settings-row:nth-child(5) { animation-delay: 160ms; }
+.carrier-settings-row:nth-child(6) { animation-delay: 200ms; }
+.carrier-settings-row:nth-child(7) { animation-delay: 240ms; }
+.carrier-settings-row:nth-child(8) { animation-delay: 280ms; }
+
+.carrier-settings-row:hover {
+  background: color-mix(in oklch, var(--ink-mid) 72%, transparent);
+  transform: translateX(2px);
+}
+
+.carrier-settings-row.is-active {
+  border-color: color-mix(in oklch, var(--brass) 30%, transparent);
+  background: var(--surface-glass-strong);
+  box-shadow: var(--shadow-anchor);
+}
+
+.carrier-settings-captain-dot {
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: var(--cap-color);
+  box-shadow: 0 0 10px var(--cap-color);
+}
+
+.carrier-settings-row-text {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.carrier-settings-row-name {
+  overflow: hidden;
+  color: var(--ink-spectral);
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 20px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: color var(--duration-fast) var(--ease-spring);
+}
+
+.carrier-settings-row:hover .carrier-settings-row-name,
+.carrier-settings-row.is-active .carrier-settings-row-name {
+  color: var(--ink-pearl);
+}
+
+.carrier-settings-row-role {
+  overflow: hidden;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: color var(--duration-fast) var(--ease-spring);
+}
+
+.carrier-settings-row.is-active .carrier-settings-row-role {
+  color: var(--brass-bright);
+}
+
+.carrier-settings-row-live {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.carrier-settings-live-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--ink-rim);
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--ink-fog) 18%, transparent);
+}
+
+.carrier-settings-live-dot.is-live,
+.carrier-settings-toggle.is-on::before {
+  background: var(--aurora);
+  box-shadow: 0 0 10px var(--aurora-glow);
+  animation: aurora-pulse 1.8s ease-in-out infinite;
+}
+
+.carrier-settings-detail {
+  position: relative;
+  min-height: 420px;
+  overflow: hidden;
+  padding: 36px;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-xl);
+  background: var(--surface-glass);
+  box-shadow: var(--shadow-soft);
+  animation: codex-rise var(--duration-slow) var(--ease-spring) both;
+  backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+}
+
+.carrier-settings-detail::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 3px;
+  background: linear-gradient(180deg, var(--cap-color, var(--brass)), transparent 80%);
+}
+
+.carrier-settings-detail-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  flex-wrap: wrap;
+  margin-bottom: 28px;
+}
+
+.carrier-settings-detail-title-block {
+  min-width: 0;
+  flex: 1;
+}
+
+.carrier-settings-captain-id {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  color: var(--cap-color, var(--brass-bright));
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.carrier-settings-captain-id::after {
+  content: "";
+  height: 1px;
+  max-width: 40px;
+  flex: 1;
+  background: linear-gradient(90deg, var(--cap-color, var(--brass)), transparent);
+}
+
+.carrier-settings-captain-name {
+  margin: 0 0 8px;
+  color: var(--ink-pearl);
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: clamp(40px, 5.6vw, 64px);
+  font-weight: 300;
+  letter-spacing: -0.03em;
+  line-height: 1;
+}
+
+.carrier-settings-captain-role {
+  margin-bottom: 0;
+  color: var(--ink-spectral);
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.carrier-settings-name-line {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.carrier-settings-name-line.is-editing {
+  max-width: min(100%, 640px);
+}
+
+.carrier-settings-cli-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border: 1px solid var(--surface-rim-strong);
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--ink-mid) 70%, transparent);
+  color: var(--ink-spectral);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.carrier-settings-cli-badge .ind {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--cap-color);
+  box-shadow: 0 0 8px var(--cap-color);
+}
+
+.carrier-settings-body {
+  display: grid;
+  gap: 24px;
+}
+
+.carrier-settings-mission {
+  padding: 20px 24px;
+  border-left: 2px solid var(--cap-color);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  background: color-mix(in oklch, var(--ink-deep) 70%, transparent);
+  color: var(--ink-spectral);
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 22px;
+  font-weight: 300;
+  letter-spacing: -0.005em;
+  line-height: 1.45;
+}
+
+.carrier-settings-control-group {
+  display: grid;
+  gap: 14px;
+}
+
+.carrier-settings-resp-title,
+.carrier-settings-label,
+.carrier-settings-help,
+.carrier-settings-empty,
+.carrier-settings-error {
+  font-family: var(--font-mono);
+}
+
+.carrier-settings-resp-title {
+  margin: 0;
+  color: var(--ink-fog);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.carrier-settings-label {
+  display: block;
+  margin: 0;
+  color: var(--ink-fog);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.carrier-settings-help,
+.carrier-settings-empty {
+  margin: 0;
+  color: var(--ink-fog);
+  font-size: 11px;
+  line-height: 1.55;
+}
+
+.carrier-settings-inline,
+.carrier-settings-button-stack,
+.carrier-settings-tf-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.carrier-settings-field {
+  display: grid;
+  min-width: 0;
+  gap: 8px;
+}
+
+.carrier-settings-field--wide {
+  flex: 1 1 auto;
+}
+
+.carrier-settings-tf-item {
+  display: grid;
+  grid-template-columns: minmax(160px, 0.75fr) minmax(220px, 1.2fr) minmax(140px, 0.65fr) auto;
+  align-items: end;
+  gap: var(--space-3);
+}
+
+/* Runtime 컨트롤 — CLI는 한 행, Model·Effort는 다음 행으로 분리해 폼 밀도를 낮춘다. */
+.carrier-settings-runtime {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.carrier-settings-runtime-row {
+  display: grid;
+  align-items: end;
+  gap: var(--space-3);
+}
+
+.carrier-settings-runtime-row--cli {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.carrier-settings-runtime-row--model {
+  grid-template-columns: minmax(0, 1.5fr) minmax(0, 0.85fr);
+}
+
+.carrier-settings-input,
+.carrier-settings-select {
+  width: 100%;
+  min-height: 42px;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--ink-mid) 48%, transparent);
+  color: var(--ink-pearl);
+  font: 600 13px/1.2 var(--font-body);
+  box-shadow: inset 0 1px 0 color-mix(in oklch, var(--ink-pearl) 5%, transparent);
+}
+
+.carrier-settings-input {
+  padding: 0 13px;
+}
+
+.carrier-settings-name-input {
+  min-height: 54px;
+  color: var(--ink-pearl);
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: clamp(32px, 4.5vw, 52px);
+  font-weight: 300;
+  letter-spacing: -0.03em;
+}
+
+.carrier-settings-select {
+  padding: 0 11px;
+}
+
+.carrier-settings-input:focus,
+.carrier-settings-select:focus {
+  border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim));
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--brass) 18%, transparent);
+}
+
+.carrier-settings-button,
+.carrier-settings-ghost-button,
+.carrier-settings-toggle,
+.carrier-settings-icon-button,
+.carrier-settings-tf-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  padding: 6px var(--space-3);
+  border: 0;
+  border-radius: var(--radius-xs);
+  background: transparent;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  transition:
+    background var(--duration-fast) var(--ease-spring),
+    color var(--duration-fast) var(--ease-spring),
+    transform var(--duration-fast) var(--ease-spring);
+}
+
+.carrier-settings-button:hover:not(:disabled),
+.carrier-settings-ghost-button:hover:not(:disabled),
+.carrier-settings-toggle:hover:not(:disabled),
+.carrier-settings-icon-button:hover:not(:disabled),
+.carrier-settings-tf-toggle:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--brass) 8%, transparent);
+  color: var(--ink-pearl);
+}
+
+.carrier-settings-button.is-active,
+.carrier-settings-toggle.is-on,
+.carrier-settings-tf-toggle[aria-expanded="true"] {
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  color: var(--brass-bright);
+}
+
+.carrier-settings-button:active:not(:disabled),
+.carrier-settings-ghost-button:active:not(:disabled),
+.carrier-settings-toggle:active:not(:disabled),
+.carrier-settings-icon-button:active:not(:disabled),
+.carrier-settings-tf-toggle:active:not(:disabled) {
+  background: color-mix(in oklch, var(--brass) 16%, transparent);
+  color: var(--ink-pearl);
+  transform: translateY(1px);
+}
+
+.carrier-settings-button:disabled,
+.carrier-settings-ghost-button:disabled,
+.carrier-settings-toggle:disabled,
+.carrier-settings-icon-button:disabled,
+.carrier-settings-tf-toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  transform: none;
+}
+
+.carrier-settings-icon-button {
+  width: 34px;
+  min-width: 34px;
+  min-height: 34px;
+  padding: 0;
+}
+
+.carrier-settings-icon-button svg {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.7;
+}
+
+.carrier-settings-toggle {
+  gap: 8px;
+  min-width: 84px;
+}
+
+.carrier-settings-toggle::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ink-rim);
+}
+
+.carrier-settings-toggle.is-on {
+  color: var(--aurora);
+}
+
+.carrier-settings-action-cell {
+  display: flex;
+  align-items: end;
+  height: 100%;
+}
+
+.carrier-settings-toggle-row,
+.carrier-settings-section-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.carrier-settings-tf-head-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex: none;
+}
+
+/* Task Force 펼침/접힘 토글 — GNB와 같은 brass 계열 하이라이트. */
+.carrier-settings-tf-toggle {
+  align-items: center;
+  gap: 9px;
+  min-height: 38px;
+  padding: 6px var(--space-3);
+}
+
+.carrier-settings-tf-toggle::after {
+  content: "›";
+  font-size: 15px;
+  line-height: 0;
+  transform: rotate(90deg);
+  transition: transform var(--duration-base) var(--ease-spring);
+}
+
+.carrier-settings-control-group--taskforce.is-expanded .carrier-settings-tf-toggle::after {
+  transform: rotate(-90deg);
+}
+
+.carrier-settings-control-group--taskforce.is-disabled .carrier-settings-tf-list {
+  opacity: 0.58;
+}
+
+/* 컨트롤 그룹 사이 하이라인 구분 — 레퍼런스의 섹션 리듬을 살린 에디토리얼 분리. */
+.carrier-settings-control-group + .carrier-settings-control-group {
+  padding-top: var(--space-5);
+  border-top: 1px solid color-mix(in oklch, var(--surface-rim) 55%, transparent);
+}
+
+.carrier-settings-tf-list {
+  display: grid;
+  gap: 8px;
+}
+
+.carrier-settings-tf-item {
+  padding: 12px 14px;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--ink-mid) 42%, transparent);
+  color: var(--ink-spectral);
+  transition:
+    border-color var(--duration-fast) var(--ease-spring),
+    color var(--duration-fast) var(--ease-spring),
+    transform var(--duration-fast) var(--ease-spring);
+}
+
+.carrier-settings-tf-item:hover {
+  border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
+  color: var(--ink-pearl);
+  transform: translateX(3px);
+}
+
+.carrier-settings-tf-item.is-active {
+  border-color: color-mix(in oklch, var(--aurora) 40%, var(--surface-rim));
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--aurora) 12%, transparent);
+}
+
+.carrier-settings-tf-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  align-self: center;
+}
+
+.carrier-settings-tf-title strong {
+  overflow: hidden;
+  color: var(--ink-spectral);
+  font-size: 14px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.carrier-settings-tf-add-row,
+.carrier-settings-save-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.carrier-settings-tf-add-select {
+  max-width: 260px;
+}
+
+.carrier-settings-tf-empty {
+  margin: 0;
+  padding: 10px 2px;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.carrier-settings-save-status {
+  min-width: 76px;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-align: right;
+}
+
+.carrier-settings-save-status.is-positive {
+  color: var(--positive);
+  text-shadow: 0 0 12px var(--positive-glow);
+}
+
+.carrier-settings-error {
+  margin: 0;
+  padding: var(--space-3);
+  border: 1px solid color-mix(in oklch, var(--coral) 48%, var(--surface-rim));
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--coral) 10%, transparent);
+  color: var(--coral);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+@media (max-width: 1120px) {
+  .carrier-settings-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .carrier-settings-list {
+    position: static;
+    flex-flow: row wrap;
+  }
+
+  .carrier-settings-row {
+    flex: 1 1 190px;
+  }
+
+  .carrier-settings-runtime-grid,
+  .carrier-settings-tf-item {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .carrier-settings-page {
+    width: min(100vw - 28px, 760px);
+  }
+
+  .carrier-settings-hero,
+  .carrier-settings-detail-head,
+  .carrier-settings-toggle-row,
+  .carrier-settings-section-head,
+  .carrier-settings-inline,
+  .carrier-settings-button-stack,
+  .carrier-settings-tf-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .carrier-settings-hero-actions {
+    flex-wrap: wrap;
+  }
+
+  .carrier-settings-save-status {
+    text-align: left;
+  }
+
+  .carrier-settings-detail {
+    padding: var(--space-6);
+  }
+}
+
 .status-dot,
 .tenant-beacon {
   width: 8px;

--- a/runtime/fleet-console/client/src/styles/theme.css
+++ b/runtime/fleet-console/client/src/styles/theme.css
@@ -27,15 +27,22 @@
   --positive: oklch(80% 0.15 152);
   --positive-glow: oklch(80% 0.15 152 / 24%);
 
-  /* 캐리어 시그니처 색 — fleet-cli PROVIDER_RGBS(runtime/fleet-cli/src/styles/carriers.ts) 미러.
-     프로바이더 정체성 축으로 상태색과 의미가 겹치지 않으며, brand 고정값이라 테마 불변(carbon에서 재정의하지 않음). */
-  --carrier-claude: rgb(255 149 0);
-  --carrier-claude-zai: rgb(0 200 120);
-  --carrier-claude-kimi: rgb(180 100 255);
-  --carrier-codex: rgb(169 169 169);
-  --carrier-opencode-go: rgb(0 200 160);
-  --carrier-cursor: rgb(0 122 204);
-  --carrier-taskforce: rgb(100 180 255);
+  /* 캐리어 시그니처 색 — 콘솔 팔레트에서 재정의한 provider 정체성 축. */
+  --carrier-claude: oklch(78% 0.15 62);
+  --carrier-claude-zai: oklch(76% 0.13 155);
+  --carrier-claude-kimi: oklch(75% 0.15 315);
+  --carrier-codex: oklch(78% 0.035 248);
+  --carrier-opencode-go: oklch(76% 0.12 184);
+  --carrier-cursor: oklch(72% 0.13 238);
+  --carrier-taskforce: oklch(78% 0.12 216);
+  --captain-nimitz: #d4af37;
+  --captain-kirov: #e8a854;
+  --captain-genesis: #ff6b6b;
+  --captain-ohio: #a78bfa;
+  --captain-sentinel: #fb7185;
+  --captain-vanguard: #5fd673;
+  --captain-tempest: #3dd5f3;
+  --captain-chronicle: #3dd5f3;
 
   --surface-glass: oklch(28% 0.04 248 / 60%);
   --surface-glass-strong: oklch(32% 0.04 248 / 78%);

--- a/runtime/fleet-console/client/src/types.ts
+++ b/runtime/fleet-console/client/src/types.ts
@@ -57,6 +57,67 @@ export interface CarrierReadinessEntry {
   readonly cliType: string;
 }
 
+export type CarrierSettingsAgentMode = "cli" | "subagent";
+
+export interface CarrierSettingsModelOption {
+  readonly modelId: string;
+  readonly name: string;
+  readonly effort?: {
+    readonly levels: readonly string[];
+    readonly default: string;
+  };
+}
+
+export interface CarrierSettingsCliOption {
+  readonly id: string;
+  readonly displayName: string;
+  readonly supportsSubagent: boolean;
+  readonly models: readonly CarrierSettingsModelOption[];
+  readonly defaultModel: string;
+}
+
+export interface CarrierSettingsOptions {
+  readonly cliTypes: readonly CarrierSettingsCliOption[];
+  readonly taskForceConstraints: {
+    readonly minBackends: number;
+  };
+}
+
+export interface CarrierSettingsTaskForceBackend {
+  readonly cliType: string;
+  readonly model: string;
+  readonly effort?: string;
+}
+
+export interface CarrierSettingsCarrier {
+  readonly carrierId: string;
+  readonly displayName: string;
+  readonly sourceDisplayName: string;
+  readonly role: string;
+  readonly roleDescription: string;
+  readonly category?: "strategy" | "planning" | "operations";
+  readonly slot: number;
+  readonly cliType: string;
+  readonly defaultCliType: string;
+  readonly model: string;
+  readonly effort?: string;
+  readonly agentMode: CarrierSettingsAgentMode;
+  readonly subagentMode: boolean;
+  readonly taskForceBackendCount: number;
+  readonly taskforce: {
+    readonly backends: readonly CarrierSettingsTaskForceBackend[];
+  };
+}
+
+export interface CarrierSettingsState {
+  readonly generation: number;
+  readonly carriers: readonly CarrierSettingsCarrier[];
+}
+
+export interface CarrierSettingsMutationResult {
+  readonly state: CarrierSettingsState;
+}
+
 export type SessionStatus = "starting" | "live" | "registered" | "terminal-only" | "closed" | "error";
 
 export interface SessionInfo {

--- a/runtime/fleet-console/package.json
+++ b/runtime/fleet-console/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@dotobokuri/core-agent": "workspace:*",
+    "@dotobokuri/core-unified-agent": "workspace:*",
     "@dotobokuri/fleet-admiral": "workspace:*",
     "@dotobokuri/fleet-carriers": "workspace:*",
     "@dotobokuri/fleet-infra": "workspace:*",

--- a/runtime/fleet-console/src/carrier-settings-routes.ts
+++ b/runtime/fleet-console/src/carrier-settings-routes.ts
@@ -227,6 +227,16 @@ async function mutateCarrierCli(
     return;
   }
   await controller.changeCliType(carrierId, cliType);
+  // 비지원(비-Claude) CLI로 전환하면 SubAgent는 유효하지 않다. agent-mode 라우트는 비지원 CLI의
+  // SA enable을 거부하지만 CLI 변경 경로는 그 가드를 우회하므로, 여기서 SA를 해제해 codex+subagent
+  // 같은 불일치 상태가 서버에 영속되지 않게 한다.
+  if (!SUBAGENT_CLI_TYPES.has(cliType)) {
+    const resolved = readCarriersSnapshot(buildDefaultsByCarrier(deps.registry)).carriers[carrierId];
+    if (resolved?.agentMode === "subagent") {
+      const config = requireCarrierConfig(deps.registry, carrierId);
+      updateCarrierAgentModeAtomically(carrierId, "cli", config.defaultAgentMode ?? "cli");
+    }
+  }
   writeMutationState(res, deps);
 }
 

--- a/runtime/fleet-console/src/carrier-settings-routes.ts
+++ b/runtime/fleet-console/src/carrier-settings-routes.ts
@@ -1,0 +1,571 @@
+import type http from "node:http";
+
+import { CLI_BACKENDS, getEffort, getProviderModels, type CliType } from "@dotobokuri/core-unified-agent";
+import {
+  applyAgentCliTypeSelectionUpdate,
+  buildCarrierModelDefaults,
+  CLI_DISPLAY_NAMES,
+  getAgentCliSelection,
+  getCarrierSourceDisplayName,
+  getConfiguredTaskForceCarrierIds,
+  getRegisteredCarrierConfig,
+  getRegisteredOrder,
+  notifyStatusUpdate,
+  normalizeCarrierDisplayNameInput,
+  readCarriersSnapshot,
+  resetCarrierTaskForceConfig,
+  resetTaskForceModelSelection,
+  resolveAgentCliType,
+  saveAgentCliSelection,
+  setCarrierAgentMode,
+  setTaskForceConfiguredCarriers,
+  StatusOverlayController,
+  TASKFORCE_CLI_TYPES,
+  updateAgentCliSelection,
+  updateCarrierCliType,
+  updateCarrierDisplayName,
+  updateCarriers,
+  updateTaskForceModelSelection,
+  type AgentCliSelection,
+  type CarrierAgentMode,
+  type CarrierConfig,
+  type CarrierRegistry,
+  type ResolvedCarrierState,
+} from "@dotobokuri/fleet-carriers";
+
+import type {
+  CarrierSettingsCarrier,
+  CarrierSettingsCliOption,
+  CarrierSettingsModelOption,
+  CarrierSettingsMutationResult,
+  CarrierSettingsOptions,
+  CarrierSettingsState,
+  CarrierSettingsTaskForceBackend,
+} from "./carrier-settings-types.js";
+
+interface CarrierSettingsRouteDeps {
+  readonly registry: CarrierRegistry;
+  readonly isAuthorized: (req: http.IncomingMessage) => boolean;
+  readonly readJsonBody: <T>(req: http.IncomingMessage) => Promise<T | null>;
+  readonly writeJson: (res: http.ServerResponse, status: number, body: unknown) => void;
+}
+
+interface CarrierSettingsRouteContext {
+  readonly req: http.IncomingMessage;
+  readonly res: http.ServerResponse;
+  readonly pathname: string;
+}
+
+interface CliBody {
+  readonly cliType?: unknown;
+}
+
+interface ModelBody {
+  readonly model?: unknown;
+  readonly effort?: unknown;
+}
+
+interface DisplayNameBody {
+  readonly displayName?: unknown;
+}
+
+interface AgentModeBody {
+  readonly agentMode?: unknown;
+}
+
+type ParsedCarrierMutation =
+  | { readonly kind: "cli"; readonly carrierId: string }
+  | { readonly kind: "model"; readonly carrierId: string }
+  | { readonly kind: "display-name"; readonly carrierId: string }
+  | { readonly kind: "agent-mode"; readonly carrierId: string }
+  | { readonly kind: "taskforce-backend"; readonly carrierId: string; readonly cliType: string }
+  | { readonly kind: "taskforce-all"; readonly carrierId: string };
+
+type JsonBodyResult<T> =
+  | { readonly ok: true; readonly body: T }
+  | { readonly ok: false };
+
+const SUBAGENT_CLI_TYPES = new Set<CliType>(["claude", "claude-zai", "claude-kimi"]);
+const TASKFORCE_MIN_BACKENDS = 2;
+
+export function createCarrierSettingsRouter(deps: CarrierSettingsRouteDeps): (context: CarrierSettingsRouteContext) => Promise<boolean> {
+  const controller = createStatusOverlayController(deps.registry);
+
+  return async function handleCarrierSettingsRoute(context: CarrierSettingsRouteContext): Promise<boolean> {
+    const { req, res, pathname } = context;
+    if (pathname === "/carrier-settings/state") {
+      if (req.method !== "GET") {
+        deps.writeJson(res, 405, { error: "Method not allowed" });
+        return true;
+      }
+      deps.writeJson(res, 200, buildCarrierSettingsState(deps.registry));
+      return true;
+    }
+    if (pathname === "/carrier-settings/options") {
+      if (req.method !== "GET") {
+        deps.writeJson(res, 405, { error: "Method not allowed" });
+        return true;
+      }
+      deps.writeJson(res, 200, buildCarrierSettingsOptions());
+      return true;
+    }
+    const mutation = parseCarrierMutation(pathname);
+    if (!mutation) return false;
+    await handleCarrierMutation(req, res, deps, controller, mutation);
+    return true;
+  };
+}
+
+export function buildCarrierSettingsState(registry: CarrierRegistry): CarrierSettingsState {
+  const defaultsByCarrier = buildDefaultsByCarrier(registry);
+  const snapshot = readCarriersSnapshot(defaultsByCarrier);
+  return {
+    generation: snapshot.generation,
+    carriers: getRegisteredOrder(registry).map((carrierId) => {
+      const config = requireCarrierConfig(registry, carrierId);
+      const resolved = snapshot.carriers[carrierId] ?? fallbackResolvedState(config);
+      return toCarrierSettingsCarrier(registry, config, resolved);
+    }),
+  };
+}
+
+export function buildCarrierSettingsOptions(): CarrierSettingsOptions {
+  return {
+    cliTypes: getCliTypes().map(toCliOption),
+    taskForceConstraints: { minBackends: TASKFORCE_MIN_BACKENDS },
+  };
+}
+
+async function handleCarrierMutation(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  deps: CarrierSettingsRouteDeps,
+  controller: StatusOverlayController,
+  mutation: ParsedCarrierMutation,
+): Promise<void> {
+  const method = req.method ?? "GET";
+  const expectedMethod = mutation.kind === "display-name" ? "PATCH" : mutation.kind === "taskforce-backend" || mutation.kind === "taskforce-all" ? method : "PUT";
+  if (!isExpectedCarrierMethod(mutation, method, expectedMethod)) {
+    deps.writeJson(res, 405, { error: "Method not allowed" });
+    return;
+  }
+  if (!deps.isAuthorized(req)) {
+    deps.writeJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  if (!isJsonRequest(req)) {
+    deps.writeJson(res, 415, { error: "unsupported_media_type" });
+    return;
+  }
+  if (!getRegisteredCarrierConfig(deps.registry, mutation.carrierId)) {
+    deps.writeJson(res, 404, { error: "carrier_not_found" });
+    return;
+  }
+  if (mutation.kind === "taskforce-backend" && !isCliType(mutation.cliType)) {
+    deps.writeJson(res, 400, { error: "invalid_cli_type" });
+    return;
+  }
+  try {
+    if (mutation.kind === "cli") {
+      const body = await readRequiredJsonBody<CliBody>(req, res, deps);
+      if (!body.ok) return;
+      await mutateCarrierCli(res, deps, controller, mutation.carrierId, body.body);
+      return;
+    }
+    if (mutation.kind === "model") {
+      const body = await readRequiredJsonBody<ModelBody>(req, res, deps);
+      if (!body.ok) return;
+      await mutateCarrierModel(res, deps, mutation.carrierId, body.body);
+      return;
+    }
+    if (mutation.kind === "display-name") {
+      const body = await readRequiredJsonBody<DisplayNameBody>(req, res, deps);
+      if (!body.ok) return;
+      mutateDisplayName(res, deps, mutation.carrierId, body.body);
+      return;
+    }
+    if (mutation.kind === "agent-mode") {
+      const body = await readRequiredJsonBody<AgentModeBody>(req, res, deps);
+      if (!body.ok) return;
+      mutateAgentMode(res, deps, mutation.carrierId, body.body);
+      return;
+    }
+    if (mutation.kind === "taskforce-backend") {
+      if (method === "DELETE") {
+        const body = await readRequiredJsonBody<Record<string, never>>(req, res, deps);
+        if (!body.ok) return;
+        resetTaskForceModelSelection(mutation.carrierId, mutation.cliType);
+        refreshTaskForceConfiguredCarriers(deps.registry);
+        writeMutationState(res, deps);
+        return;
+      }
+      const body = await readRequiredJsonBody<ModelBody>(req, res, deps);
+      if (!body.ok) return;
+      mutateTaskForceBackend(res, deps, mutation.carrierId, mutation.cliType as CliType, body.body);
+      return;
+    }
+    const body = await readRequiredJsonBody<Record<string, never>>(req, res, deps);
+    if (!body.ok) return;
+    resetCarrierTaskForceConfig(mutation.carrierId);
+    refreshTaskForceConfiguredCarriers(deps.registry);
+    writeMutationState(res, deps);
+  } catch (error) {
+    deps.writeJson(res, 400, { error: error instanceof Error ? error.message : "invalid_request" });
+  }
+}
+
+async function mutateCarrierCli(
+  res: http.ServerResponse,
+  deps: CarrierSettingsRouteDeps,
+  controller: StatusOverlayController,
+  carrierId: string,
+  body: CliBody,
+): Promise<void> {
+  const cliType = readCliType(body.cliType);
+  if (!cliType) {
+    deps.writeJson(res, 400, { error: "invalid_cli_type" });
+    return;
+  }
+  await controller.changeCliType(carrierId, cliType);
+  writeMutationState(res, deps);
+}
+
+async function mutateCarrierModel(
+  res: http.ServerResponse,
+  deps: CarrierSettingsRouteDeps,
+  carrierId: string,
+  body: ModelBody,
+): Promise<void> {
+  const config = requireCarrierConfig(deps.registry, carrierId);
+  const cliType = resolveAgentCliType(carrierId, config.defaultCliType);
+  const selection = readSelection(cliType, body);
+  if (!selection) {
+    deps.writeJson(res, 400, { error: "invalid_model_selection" });
+    return;
+  }
+  await updateAgentCliSelection(carrierId, cliType, selection);
+  notifyStatusUpdate(deps.registry);
+  writeMutationState(res, deps);
+}
+
+function mutateDisplayName(
+  res: http.ServerResponse,
+  deps: CarrierSettingsRouteDeps,
+  carrierId: string,
+  body: DisplayNameBody,
+): void {
+  const displayName = normalizeCarrierDisplayNameInput(body.displayName);
+  if (displayName === null) {
+    deps.writeJson(res, 400, { error: "invalid_display_name" });
+    return;
+  }
+  updateCarrierDisplayName(carrierId, displayName, getCarrierSourceDisplayName(deps.registry, carrierId));
+  notifyStatusUpdate(deps.registry);
+  writeMutationState(res, deps);
+}
+
+function mutateAgentMode(
+  res: http.ServerResponse,
+  deps: CarrierSettingsRouteDeps,
+  carrierId: string,
+  body: AgentModeBody,
+): void {
+  const config = requireCarrierConfig(deps.registry, carrierId);
+  const agentMode = body.agentMode;
+  if (agentMode !== "cli" && agentMode !== "subagent") {
+    deps.writeJson(res, 400, { error: "invalid_agent_mode" });
+    return;
+  }
+  const cliType = resolveAgentCliType(carrierId, config.defaultCliType);
+  if (agentMode === "subagent" && !SUBAGENT_CLI_TYPES.has(cliType)) {
+    deps.writeJson(res, 400, { error: "subagent_unsupported" });
+    return;
+  }
+  updateCarrierAgentModeAtomically(carrierId, agentMode, config.defaultAgentMode ?? "cli");
+  if (agentMode === "subagent") refreshTaskForceConfiguredCarriers(deps.registry);
+  notifyStatusUpdate(deps.registry);
+  writeMutationState(res, deps);
+}
+
+function mutateTaskForceBackend(
+  res: http.ServerResponse,
+  deps: CarrierSettingsRouteDeps,
+  carrierId: string,
+  cliType: CliType,
+  body: ModelBody,
+): void {
+  const selection = readSelection(cliType, body);
+  if (!selection) {
+    deps.writeJson(res, 400, { error: "invalid_model_selection" });
+    return;
+  }
+  updateTaskForceBackendAtomically(carrierId, cliType, selection);
+  refreshTaskForceConfiguredCarriers(deps.registry);
+  notifyStatusUpdate(deps.registry);
+  writeMutationState(res, deps);
+}
+
+function writeMutationState(res: http.ServerResponse, deps: CarrierSettingsRouteDeps): void {
+  const response: CarrierSettingsMutationResult = { state: buildCarrierSettingsState(deps.registry) };
+  deps.writeJson(res, 200, response);
+}
+
+async function readRequiredJsonBody<T>(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  deps: CarrierSettingsRouteDeps,
+): Promise<JsonBodyResult<T>> {
+  const body = await deps.readJsonBody<T>(req);
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    deps.writeJson(res, 400, { error: "invalid_json" });
+    return { ok: false };
+  }
+  return { ok: true, body };
+}
+
+function buildDefaultsByCarrier(registry: CarrierRegistry): Record<string, { readonly cliType: CliType; readonly defaultAgentMode?: CarrierAgentMode; readonly defaultModel?: string; readonly defaultEffort?: string }> {
+  return Object.fromEntries(
+    getRegisteredOrder(registry).map((carrierId) => {
+      const config = requireCarrierConfig(registry, carrierId);
+      return [carrierId, {
+        cliType: config.defaultCliType,
+        ...(config.defaultAgentMode ? { defaultAgentMode: config.defaultAgentMode } : {}),
+        ...buildCarrierModelDefaults(config, config.defaultCliType),
+      }];
+    }),
+  );
+}
+
+function toCarrierSettingsCarrier(
+  registry: CarrierRegistry,
+  config: CarrierConfig,
+  resolved: ResolvedCarrierState,
+): CarrierSettingsCarrier {
+  const cliType = resolved.agentCliType ?? config.defaultCliType;
+  const selection = resolved.agentCli[cliType] ?? readDefaultSelection(cliType);
+  const taskForceBackends = toTaskForceBackends(resolved.taskforce);
+  return {
+    carrierId: config.id,
+    displayName: resolved.displayName ?? getCarrierSourceDisplayName(registry, config.id),
+    sourceDisplayName: getCarrierSourceDisplayName(registry, config.id),
+    role: config.carrierMetadata?.title ?? config.displayName,
+    roleDescription: config.carrierMetadata?.summary ?? "",
+    ...(config.carrierMetadata?.category ? { category: config.carrierMetadata.category } : {}),
+    slot: config.slot,
+    cliType,
+    defaultCliType: config.defaultCliType,
+    model: selection.model,
+    ...(selection.effort ? { effort: selection.effort } : {}),
+    agentMode: resolved.agentMode,
+    subagentMode: resolved.agentMode === "subagent",
+    taskForceBackendCount: taskForceBackends.length,
+    taskforce: { backends: taskForceBackends },
+  };
+}
+
+function toTaskForceBackends(taskforce: ResolvedCarrierState["taskforce"]): readonly CarrierSettingsTaskForceBackend[] {
+  return TASKFORCE_CLI_TYPES
+    .map((cliType) => {
+      const selection = taskforce[cliType];
+      if (!selection) return null;
+      return {
+        cliType,
+        model: selection.model,
+        ...(selection.effort ? { effort: selection.effort } : {}),
+      };
+    })
+    .filter((backend): backend is CarrierSettingsTaskForceBackend => backend !== null);
+}
+
+function toCliOption(cliType: CliType): CarrierSettingsCliOption {
+  const provider = getProviderModels(cliType);
+  return {
+    id: cliType,
+    displayName: CLI_DISPLAY_NAMES[cliType] ?? provider.name,
+    supportsSubagent: SUBAGENT_CLI_TYPES.has(cliType),
+    models: provider.models.map((model): CarrierSettingsModelOption => {
+      const effort = getEffort(cliType, model.modelId);
+      return {
+        modelId: model.modelId,
+        name: model.name,
+        ...(effort.supported ? { effort: { levels: effort.levels, default: effort.default } } : {}),
+      };
+    }),
+    defaultModel: provider.defaultModel ?? provider.models[0]?.modelId,
+  };
+}
+
+function createStatusOverlayController(registry: CarrierRegistry): StatusOverlayController {
+  return new StatusOverlayController({
+    getEntries: () => [],
+    getRegisteredOrder: () => getRegisteredOrder(registry),
+    getCarrierConfig: (carrierId) => getRegisteredCarrierConfig(registry, carrierId),
+    getResolvedCliType: (carrierId) => {
+      const config = getRegisteredCarrierConfig(registry, carrierId);
+      return config ? resolveAgentCliType(carrierId, config.defaultCliType) : undefined;
+    },
+    getCurrentModelSelection: (carrierId) => {
+      return readCurrentModelSelection(registry, carrierId);
+    },
+    getAvailableModels: (cliType) => {
+      const provider = getProviderModels(cliType);
+      return {
+        defaultModel: provider.defaultModel,
+        models: provider.models.map((model) => ({
+          modelId: model.modelId,
+          name: model.name,
+          effort: getEffort(cliType, model.modelId),
+        })),
+      };
+    },
+    getEffort: (cliType, modelId) => getEffort(cliType, modelId),
+    getAgentCliSelection: (carrierId, cliType) => getAgentCliSelection(carrierId, cliType),
+    saveAgentCliSelection,
+    updateCarrierCliType: (carrierId, cliType) => updateCarrierCliType(registry, carrierId, cliType),
+    applyAgentCliTypeSelectionUpdate,
+    refreshAgentPanel: () => undefined,
+    syncModelConfig: () => undefined,
+    notifyStatusUpdate: () => notifyStatusUpdate(registry),
+  });
+}
+
+function updateCarrierAgentModeAtomically(
+  carrierId: string,
+  agentMode: CarrierAgentMode,
+  defaultAgentMode: CarrierAgentMode,
+): void {
+  if (agentMode === "cli") {
+    setCarrierAgentMode(carrierId, false, defaultAgentMode);
+    return;
+  }
+  updateCarriers((states) => {
+    const carriers = { ...(states.carriers ?? {}) };
+    const current = carriers[carrierId] ?? {};
+    const next = { ...current };
+    next.agentMode = "subagent";
+    delete next.taskforce;
+    carriers[carrierId] = next;
+    states.carriers = carriers;
+  });
+}
+
+function updateTaskForceBackendAtomically(carrierId: string, cliType: CliType, selection: AgentCliSelection): void {
+  updateCarriers((states) => {
+    const carriers = { ...(states.carriers ?? {}) };
+    const current = carriers[carrierId] ?? {};
+    carriers[carrierId] = {
+      ...current,
+      agentMode: "cli",
+      taskforce: {
+        ...(current.taskforce ?? {}),
+        [cliType]: selection,
+      },
+    };
+    states.carriers = carriers;
+  });
+}
+
+function refreshTaskForceConfiguredCarriers(registry: CarrierRegistry): void {
+  setTaskForceConfiguredCarriers(registry, getConfiguredTaskForceCarrierIds(getRegisteredOrder(registry)));
+  notifyStatusUpdate(registry);
+}
+
+function readSelection(cliType: CliType, body: ModelBody): AgentCliSelection | null {
+  if (typeof body.model !== "string") return null;
+  const provider = getProviderModels(cliType);
+  if (!provider.models.some((model) => model.modelId === body.model)) return null;
+  const effort = getEffort(cliType, body.model);
+  if (!effort.supported) {
+    return body.effort === undefined ? { model: body.model } : null;
+  }
+  if (typeof body.effort !== "string" || !effort.levels.includes(body.effort)) return null;
+  return { model: body.model, effort: body.effort };
+}
+
+function readDefaultSelection(cliType: CliType): AgentCliSelection {
+  const provider = getProviderModels(cliType);
+  const model = provider.defaultModel;
+  const effort = getEffort(cliType, model);
+  return {
+    model,
+    ...(effort.supported ? { effort: effort.default } : {}),
+  };
+}
+
+function readCurrentModelSelection(registry: CarrierRegistry, carrierId: string): AgentCliSelection | undefined {
+  const config = getRegisteredCarrierConfig(registry, carrierId);
+  if (!config) return undefined;
+  const defaults = {
+    [carrierId]: {
+      cliType: config.defaultCliType,
+      ...(config.defaultAgentMode ? { defaultAgentMode: config.defaultAgentMode } : {}),
+      ...buildCarrierModelDefaults(config, config.defaultCliType),
+    },
+  };
+  const resolved = readCarriersSnapshot(defaults).carriers[carrierId] ?? fallbackResolvedState(config);
+  const cliType = resolved.agentCliType ?? config.defaultCliType;
+  return resolved.agentCli[cliType] ?? readDefaultSelection(cliType);
+}
+
+function fallbackResolvedState(config: CarrierConfig): ResolvedCarrierState {
+  return {
+    agentMode: config.defaultAgentMode ?? "cli",
+    agentCliType: config.defaultCliType,
+    agentCli: { [config.defaultCliType]: readDefaultSelection(config.defaultCliType) },
+    taskforce: {},
+  };
+}
+
+function parseCarrierMutation(pathname: string): ParsedCarrierMutation | null {
+  const parts = pathname.split("/").filter(Boolean);
+  if (parts[0] !== "carrier-settings" || parts[1] !== "carriers" || !parts[2]) return null;
+  const carrierId = safeDecodeURIComponent(parts[2]);
+  if (!carrierId) return null;
+  if (parts.length === 4 && parts[3] === "cli") return { kind: "cli", carrierId };
+  if (parts.length === 4 && parts[3] === "model") return { kind: "model", carrierId };
+  if (parts.length === 4 && parts[3] === "display-name") return { kind: "display-name", carrierId };
+  if (parts.length === 4 && parts[3] === "agent-mode") return { kind: "agent-mode", carrierId };
+  if (parts.length === 4 && parts[3] === "taskforce") return { kind: "taskforce-all", carrierId };
+  if (parts.length === 5 && parts[3] === "taskforce") {
+    const cliType = safeDecodeURIComponent(parts[4] ?? "");
+    return cliType ? { kind: "taskforce-backend", carrierId, cliType } : null;
+  }
+  return null;
+}
+
+function safeDecodeURIComponent(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}
+
+function isExpectedCarrierMethod(mutation: ParsedCarrierMutation, method: string, expectedMethod: string): boolean {
+  if (mutation.kind === "taskforce-backend") return method === "PUT" || method === "DELETE";
+  if (mutation.kind === "taskforce-all") return method === "DELETE";
+  return method === expectedMethod;
+}
+
+function isJsonRequest(req: http.IncomingMessage): boolean {
+  const contentType = req.headers["content-type"];
+  return typeof contentType === "string" && contentType.toLowerCase().split(";")[0]?.trim() === "application/json";
+}
+
+function readCliType(value: unknown): CliType | null {
+  return typeof value === "string" && isCliType(value) ? value : null;
+}
+
+function isCliType(value: string): value is CliType {
+  return Object.prototype.hasOwnProperty.call(CLI_BACKENDS, value);
+}
+
+function getCliTypes(): readonly CliType[] {
+  return Object.keys(CLI_BACKENDS) as CliType[];
+}
+
+function requireCarrierConfig(registry: CarrierRegistry, carrierId: string): CarrierConfig {
+  const config = getRegisteredCarrierConfig(registry, carrierId);
+  if (!config) throw new Error(`Carrier not found: ${carrierId}`);
+  return config;
+}

--- a/runtime/fleet-console/src/carrier-settings-types.ts
+++ b/runtime/fleet-console/src/carrier-settings-types.ts
@@ -1,0 +1,61 @@
+import type { CliType } from "@dotobokuri/core-unified-agent";
+import type { CarrierAgentMode } from "@dotobokuri/fleet-carriers";
+
+export interface CarrierSettingsModelOption {
+  readonly modelId: string;
+  readonly name: string;
+  readonly effort?: {
+    readonly levels: readonly string[];
+    readonly default: string;
+  };
+}
+
+export interface CarrierSettingsCliOption {
+  readonly id: CliType;
+  readonly displayName: string;
+  readonly supportsSubagent: boolean;
+  readonly models: readonly CarrierSettingsModelOption[];
+  readonly defaultModel: string;
+}
+
+export interface CarrierSettingsOptions {
+  readonly cliTypes: readonly CarrierSettingsCliOption[];
+  readonly taskForceConstraints: {
+    readonly minBackends: number;
+  };
+}
+
+export interface CarrierSettingsTaskForceBackend {
+  readonly cliType: CliType;
+  readonly model: string;
+  readonly effort?: string;
+}
+
+export interface CarrierSettingsCarrier {
+  readonly carrierId: string;
+  readonly displayName: string;
+  readonly sourceDisplayName: string;
+  readonly role: string;
+  readonly roleDescription: string;
+  readonly category?: "strategy" | "planning" | "operations";
+  readonly slot: number;
+  readonly cliType: CliType;
+  readonly defaultCliType: CliType;
+  readonly model: string;
+  readonly effort?: string;
+  readonly agentMode: CarrierAgentMode;
+  readonly subagentMode: boolean;
+  readonly taskForceBackendCount: number;
+  readonly taskforce: {
+    readonly backends: readonly CarrierSettingsTaskForceBackend[];
+  };
+}
+
+export interface CarrierSettingsState {
+  readonly generation: number;
+  readonly carriers: readonly CarrierSettingsCarrier[];
+}
+
+export interface CarrierSettingsMutationResult {
+  readonly state: CarrierSettingsState;
+}

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -3,6 +3,7 @@ import http from "node:http";
 
 import {
   createCarrierRegistry,
+  initStore,
   readCarrierStatusEntries,
   registerDefaultCarriers,
   type CarrierJobStreamEvent,
@@ -24,6 +25,7 @@ import { getFleetDataDir } from "@dotobokuri/fleet-infra/data-dir";
 import { getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
 
 import type { ConsoleCarrierReadinessEntry, ConsoleHealth, ConsoleObservedWorkspace, ConsoleObserverStatus, ConsoleTheaterInfo } from "./api-types.js";
+import { createCarrierSettingsRouter } from "./carrier-settings-routes.js";
 import { createCodexGateway } from "./codex/gateway.js";
 import { createConsoleLock, type ConsoleLockHandle } from "./lock.js";
 import { writeAggregateObserverEvents, writeObserverEvents } from "./observability-routes.js";
@@ -96,6 +98,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   const folderGrants = createFolderGrantStore();
   const infraServices = createInfraServices();
   const dataDir = deps.dataDir ?? getFleetDataDir();
+  initStore(dataDir);
   const authEnvResolver = (cli: Parameters<typeof resolveAuthEnv>[0]) => resolveAuthEnv(cli, { authService: infraServices.authService });
   const ownsAgentRuntime = deps.agentRuntime === undefined;
   const agentRuntime = deps.agentRuntime ?? createFleetAgentRuntimeLifecycle({
@@ -169,6 +172,12 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   let activeEndpoint: string | null = null;
   let agentRuntimeStopped = false;
   let consoleResourcesDisposed = false;
+  const carrierSettingsRouter = createCarrierSettingsRouter({
+    registry: carrierRegistry,
+    isAuthorized: isTerminalAuthorized,
+    readJsonBody,
+    writeJson,
+  });
 
   function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
     const pathname = getPathname(req);
@@ -217,6 +226,10 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     }
     if (pathname === "/observer/carriers") {
       handleObserverCarriers(req, res);
+      return;
+    }
+    if (pathname === "/carrier-settings" || pathname.startsWith("/carrier-settings/")) {
+      runAsyncBooleanHandler(carrierSettingsRouter({ req, res, pathname }), res);
       return;
     }
     if (pathname === "/observer/tenants") {

--- a/runtime/fleet-console/tests/carrier-settings.test.ts
+++ b/runtime/fleet-console/tests/carrier-settings.test.ts
@@ -1,0 +1,351 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CLI_BACKENDS, getEffort, getProviderModels, type CliType } from "@dotobokuri/core-unified-agent";
+import { initStore, resetStoreForTests } from "@dotobokuri/fleet-carriers";
+
+import type { ConsoleLockPayload } from "../src/api-types.js";
+import { createConsoleLock } from "../src/lock.js";
+import { createConsoleServer, type ConsoleServer, type ConsoleServerDeps } from "../src/server.js";
+
+interface ServerFixture {
+  readonly dir: string;
+  readonly carrierStoreDir: string;
+  readonly lockFile: string;
+  readonly server: ConsoleServer;
+  readonly endpoint: string;
+  readonly lock: ConsoleLockPayload;
+}
+
+interface CarrierSettingsState {
+  readonly generation: number;
+  readonly carriers: readonly CarrierSettingsCarrier[];
+}
+
+interface CarrierSettingsCarrier {
+  readonly carrierId: string;
+  readonly displayName: string;
+  readonly sourceDisplayName: string;
+  readonly cliType: string;
+  readonly defaultCliType: string;
+  readonly model: string;
+  readonly effort?: string;
+  readonly agentMode: "cli" | "subagent";
+  readonly taskForceBackendCount: number;
+  readonly taskforce: {
+    readonly backends: ReadonlyArray<{ readonly cliType: string; readonly model: string; readonly effort?: string }>;
+  };
+}
+
+interface CarrierSettingsOptions {
+  readonly cliTypes: ReadonlyArray<{
+    readonly id: string;
+    readonly supportsSubagent: boolean;
+    readonly models: ReadonlyArray<{ readonly modelId: string; readonly name: string; readonly effort?: { readonly levels: readonly string[]; readonly default: string } }>;
+    readonly defaultModel: string;
+  }>;
+  readonly taskForceConstraints: { readonly minBackends: number };
+}
+
+interface FakeConsoleRuntime {
+  readonly carrierRuntime: {
+    readonly jobs: {
+      readonly streaming: {
+        register(callback: (event: unknown) => void): () => void;
+      };
+    };
+  };
+  readonly cleanup: ReturnType<typeof vi.fn>;
+}
+
+const tempDirs: string[] = [];
+const servers: ConsoleServer[] = [];
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) await server.stop();
+  resetStoreForTests();
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("carrier settings routes", () => {
+  it("serves state and options without restricted browser fields", async () => {
+    const fixture = await startFixture();
+    const state = await getJson<CarrierSettingsState>(`${fixture.endpoint}carrier-settings/state`);
+    const options = await getJson<CarrierSettingsOptions>(`${fixture.endpoint}carrier-settings/options`);
+    const serialized = JSON.stringify({ state, options });
+
+    expect(state.generation).toBeGreaterThanOrEqual(0);
+    expect(state.carriers.length).toBeGreaterThan(0);
+    expect(options.taskForceConstraints.minBackends).toBe(2);
+    expect(options.cliTypes.some((cli) => cli.id === "claude" && cli.supportsSubagent)).toBe(true);
+    expect(serialized).not.toContain(fixture.lock.token);
+    expect(serialized).not.toContain("credential");
+    expect(serialized).not.toContain("prompt");
+    expect(serialized).not.toContain("persona");
+    expect(serialized).not.toContain("toolAllowlist");
+    expect(serialized).not.toContain("allowedExecutorTools");
+    expect(serialized).not.toContain(fixture.carrierStoreDir);
+  });
+
+  it("serves provider defaults and model options from the validation registry", async () => {
+    const fixture = await startFixture();
+    const options = await getJson<CarrierSettingsOptions>(`${fixture.endpoint}carrier-settings/options`);
+
+    for (const cliType of getCliTypes()) {
+      const option = options.cliTypes.find((item) => item.id === cliType);
+      const provider = getProviderModels(cliType);
+      expect(option?.defaultModel).toBe(provider.defaultModel);
+      expect(option?.models.map((model) => ({ modelId: model.modelId, name: model.name }))).toEqual(
+        provider.models.map((model) => ({ modelId: model.modelId, name: model.name })),
+      );
+      for (const model of option?.models ?? []) {
+        const effort = getEffort(cliType, model.modelId);
+        expect(model.effort).toEqual(effort.supported ? { levels: effort.levels, default: effort.default } : undefined);
+      }
+    }
+  });
+
+  it("uses getEffort defaults for advertised effort options", async () => {
+    const fixture = await startFixture();
+    const options = await getJson<CarrierSettingsOptions>(`${fixture.endpoint}carrier-settings/options`);
+
+    for (const cli of options.cliTypes) {
+      for (const model of cli.models) {
+        const effort = getEffort(cli.id as CliType, model.modelId);
+        if (effort.supported) expect(model.effort?.default).toBe(effort.default);
+        else expect(model.effort).toBeUndefined();
+      }
+    }
+    const codex = options.cliTypes.find((cli) => cli.id === "codex");
+    expect(codex).toBeDefined();
+    if (!codex) return;
+    const codexDefault = codex.models.find((model) => model.modelId === codex.defaultModel);
+    const codexEffort = getEffort("codex", codex.defaultModel);
+    expect(codexEffort.supported).toBe(true);
+    if (codexEffort.supported) expect(codexDefault?.effort?.default).toBe(codexEffort.default);
+  });
+
+  it("rejects mutation requests without terminal origin and JSON content type", async () => {
+    const fixture = await startFixture();
+    const state = await getJson<CarrierSettingsState>(`${fixture.endpoint}carrier-settings/state`);
+    const carrier = state.carriers[0]!;
+
+    const wrongOrigin = await fetch(`${fixture.endpoint}carrier-settings/carriers/${carrier.carrierId}/display-name`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Origin: "http://127.0.0.1:1" },
+      body: JSON.stringify({ displayName: "Blocked" }),
+    });
+    const wrongType = await fetch(`${fixture.endpoint}carrier-settings/carriers/${carrier.carrierId}/display-name`, {
+      method: "PATCH",
+      headers: { "Content-Type": "text/plain" },
+      body: JSON.stringify({ displayName: "Blocked" }),
+    });
+
+    expect(wrongOrigin.status).toBe(401);
+    expect(wrongType.status).toBe(415);
+  });
+
+  it("initializes the store and persists display name changes to carriers.json", async () => {
+    const fixture = await startFixture();
+    const state = await getJson<CarrierSettingsState>(`${fixture.endpoint}carrier-settings/state`);
+    const carrier = state.carriers[0]!;
+
+    const changed = await mutate<{ readonly state: CarrierSettingsState }>(
+      fixture,
+      `/carrier-settings/carriers/${carrier.carrierId}/display-name`,
+      "PATCH",
+      { displayName: "Console Carrier" },
+    );
+    const persisted = JSON.parse(fs.readFileSync(path.join(fixture.carrierStoreDir, "carriers.json"), "utf8")) as { readonly carriers?: Record<string, { readonly displayName?: string }> };
+    const reset = await mutate<{ readonly state: CarrierSettingsState }>(
+      fixture,
+      `/carrier-settings/carriers/${carrier.carrierId}/display-name`,
+      "PATCH",
+      { displayName: carrier.sourceDisplayName },
+    );
+
+    expect(changed.state.carriers.find((item) => item.carrierId === carrier.carrierId)?.displayName).toBe("Console Carrier");
+    expect(persisted.carriers?.[carrier.carrierId]?.displayName).toBe("Console Carrier");
+    expect(reset.state.carriers.find((item) => item.carrierId === carrier.carrierId)?.displayName).toBe(carrier.sourceDisplayName);
+  });
+
+  it("validates model and effort combinations server-side", async () => {
+    const fixture = await startFixture();
+    const state = await getJson<CarrierSettingsState>(`${fixture.endpoint}carrier-settings/state`);
+    const carrier = state.carriers[0]!;
+
+    const invalid = await rawMutate(fixture, `/carrier-settings/carriers/${carrier.carrierId}/model`, "PUT", { model: "missing-model", effort: "max" });
+
+    expect(invalid.status).toBe(400);
+  });
+
+  it("does not return 500 for malformed percent-encoded carrier ids", async () => {
+    const fixture = await startFixture();
+
+    const response = await rawMutate(fixture, "/carrier-settings/carriers/%ZZ/model", "PUT", { model: "missing-model" });
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(response.status).toBeLessThan(500);
+  });
+
+  it("accepts every advertised model and effort selection in mutations", async () => {
+    const fixture = await startFixture();
+    const options = await getJson<CarrierSettingsOptions>(`${fixture.endpoint}carrier-settings/options`);
+    const state = await getJson<CarrierSettingsState>(`${fixture.endpoint}carrier-settings/state`);
+    const carrier = state.carriers[0]!;
+
+    for (const cli of options.cliTypes) {
+      await mutate<{ readonly state: CarrierSettingsState }>(
+        fixture,
+        `/carrier-settings/carriers/${carrier.carrierId}/cli`,
+        "PUT",
+        { cliType: cli.id },
+      );
+      for (const model of cli.models) {
+        const response = await rawMutate(
+          fixture,
+          `/carrier-settings/carriers/${carrier.carrierId}/model`,
+          "PUT",
+          selectionFor(model),
+        );
+        expect(response.status, `${cli.id}/${model.modelId}`).toBe(200);
+        await response.arrayBuffer();
+      }
+    }
+  });
+
+  it("clears Task Force atomically when SubAgent is enabled", async () => {
+    const fixture = await startFixture();
+    const options = await getJson<CarrierSettingsOptions>(`${fixture.endpoint}carrier-settings/options`);
+    const carrier = await findClaudeCarrier(fixture);
+    const tfCli = options.cliTypes.find((cli) => cli.id !== carrier.cliType) ?? options.cliTypes[0]!;
+    const tfModel = tfCli.models[0]!;
+
+    const withTf = await mutate<{ readonly state: CarrierSettingsState }>(
+      fixture,
+      `/carrier-settings/carriers/${carrier.carrierId}/taskforce/${tfCli.id}`,
+      "PUT",
+      selectionFor(tfModel),
+    );
+    const withSa = await mutate<{ readonly state: CarrierSettingsState }>(
+      fixture,
+      `/carrier-settings/carriers/${carrier.carrierId}/agent-mode`,
+      "PUT",
+      { agentMode: "subagent" },
+    );
+    const afterTf = withTf.state.carriers.find((item) => item.carrierId === carrier.carrierId)!;
+    const afterSa = withSa.state.carriers.find((item) => item.carrierId === carrier.carrierId)!;
+
+    expect(afterTf.taskForceBackendCount).toBe(1);
+    expect(afterTf.agentMode).toBe("cli");
+    expect(afterSa.agentMode).toBe("subagent");
+    expect(afterSa.taskForceBackendCount).toBe(0);
+  });
+
+  it("disables SubAgent atomically when a Task Force backend is set", async () => {
+    const fixture = await startFixture();
+    const options = await getJson<CarrierSettingsOptions>(`${fixture.endpoint}carrier-settings/options`);
+    const carrier = await findClaudeCarrier(fixture);
+    const tfCli = options.cliTypes.find((cli) => cli.id !== carrier.cliType) ?? options.cliTypes[0]!;
+    const tfModel = tfCli.models[0]!;
+
+    await mutate<{ readonly state: CarrierSettingsState }>(
+      fixture,
+      `/carrier-settings/carriers/${carrier.carrierId}/agent-mode`,
+      "PUT",
+      { agentMode: "subagent" },
+    );
+    const withTf = await mutate<{ readonly state: CarrierSettingsState }>(
+      fixture,
+      `/carrier-settings/carriers/${carrier.carrierId}/taskforce/${tfCli.id}`,
+      "PUT",
+      selectionFor(tfModel),
+    );
+    const updated = withTf.state.carriers.find((item) => item.carrierId === carrier.carrierId)!;
+
+    expect(updated.agentMode).toBe("cli");
+    expect(updated.taskForceBackendCount).toBe(1);
+  });
+
+});
+
+async function startFixture(options: {
+  readonly beforeCreateServer?: (paths: { readonly carrierStoreDir: string }) => void;
+  readonly agentRuntime?: ConsoleServerDeps["agentRuntime"];
+} = {}): Promise<ServerFixture> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-carrier-settings-"));
+  const carrierStoreDir = path.join(dir, "fleet-home");
+  initStore(carrierStoreDir);
+  options.beforeCreateServer?.({ carrierStoreDir });
+  tempDirs.push(dir);
+  const lockFile = path.join(dir, "console.lock");
+  const server = createConsoleServer({
+    port: 0,
+    version: "test",
+    agentRuntime: options.agentRuntime ?? createFakeConsoleRuntime() as never,
+    dataDir: carrierStoreDir,
+  });
+  servers.push(server);
+  const endpoint = await server.start({ dir, lockFile });
+  const lock = createConsoleLock().readLock(lockFile)!;
+  return { dir, carrierStoreDir, lockFile, server, endpoint, lock };
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  expect(response.status).toBe(200);
+  return response.json() as Promise<T>;
+}
+
+async function mutate<T>(fixture: ServerFixture, pathname: string, method: string, body: unknown): Promise<T> {
+  const response = await rawMutate(fixture, pathname, method, body);
+  expect(response.status).toBe(200);
+  return response.json() as Promise<T>;
+}
+
+async function rawMutate(fixture: ServerFixture, pathname: string, method: string, body: unknown): Promise<Response> {
+  return fetch(`${fixture.endpoint}${pathname.replace(/^\//, "")}`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Origin: `http://127.0.0.1:${fixture.lock.port}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function findClaudeCarrier(fixture: ServerFixture): Promise<CarrierSettingsCarrier> {
+  const state = await getJson<CarrierSettingsState>(`${fixture.endpoint}carrier-settings/state`);
+  return state.carriers.find((carrier) => carrier.cliType === "claude") ?? state.carriers[0]!;
+}
+
+function selectionFor(model: { readonly modelId: string; readonly effort?: { readonly default: string } }): { readonly model: string; readonly effort?: string } {
+  return {
+    model: model.modelId,
+    ...(model.effort ? { effort: model.effort.default } : {}),
+  };
+}
+
+function getCliTypes(): readonly CliType[] {
+  return Object.keys(CLI_BACKENDS) as CliType[];
+}
+
+function createFakeConsoleRuntime(): FakeConsoleRuntime {
+  const handlers = new Set<(event: unknown) => void>();
+  return {
+    carrierRuntime: {
+      jobs: {
+        streaming: {
+          register(callback) {
+            handlers.add(callback);
+            return () => handlers.delete(callback);
+          },
+        },
+      },
+    },
+    cleanup: vi.fn(async () => undefined),
+  };
+}


### PR DESCRIPTION
## Summary

Fleet Console에 전용 캐리어 설정 화면(`/console/carrier-settings`, GNB `Settings` 탭)을 추가합니다. 랜딩 페이지의 Captains Roster 디자인(Fraunces italic·함장별 시그니처색·계기 콘솔 레이아웃)을 본떴습니다. 각 캐리어의 CLI·모델/effort·SubAgent 모드·Task Force 백엔드·표시 이름을 draft로 편집한 뒤 **캐리어당 단일 Save**로 일괄 커밋하며(저장 피드백 제공, Discard 되돌림), SubAgent/Task Force 상호배타는 서버에서 원자적으로 강제합니다.

## Type of Change

- [x] feat — new feature or carrier capability

## Scope

- `runtime/fleet-console` — 서버 `/carrier-settings/*` REST API + React 설정 페이지
- `@dotobokuri/fleet-carriers` store mutator를 server-side에서 직접 호출(전역 `~/.fleet/carriers.json` SSoT를 CLI와 공유)

## Details

- 루트 `/carrier-settings/*` REST API는 terminal과 동일한 Origin 가드 아래 fine-grained 라우트로 store mutator를 직접 호출합니다. 서버가 `initStore(dataDir)`로 store를 초기화해 쓰기가 전역 `carriers.json`에 영속됩니다.
- 브라우저에는 display-safe 페이로드만 전달합니다(토큰·원시 경로·프롬프트·persona·tool allowlist 미노출). `fleet-carriers`·`fleet-admiral`은 server-only를 유지합니다.
- 옵션 endpoint가 광고하는 모델·effort 기본값을 서버 검증과 동일 출처(`getProviderModels`/`getEffort`)로 통일했습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm check:core-boundary`
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 21 files / 269 tests
- [x] 실브라우저 e2e(격리 인스턴스): 페이지 렌더·캐리어 전환·draft 편집·단일 Save 피드백·TaskForce ADD·연필 인라인 편집·스크롤·SA/TF 배타 확인