### PR TITLE
feat(console): improve Operations Map canvas (zoom, shell, minimap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,17 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+- [core] The Fleet Console Operations Map now zooms smoothly with interpolated wheel zoom while panning stays immediate.
+- [core] The Fleet Console Operations Map can open plain user-shell terminal panels in the active Theater's directory; they are not tracked as Operations and are not kept across reloads.
+- [core] The Fleet Console Operations Map adds a right-click canvas menu to start a new Operation, open a shell, or reset the view at the cursor position.
+- [core] Fleet Console Operations Map panels can now be focused by double-clicking their title tab, in addition to the focus button.
+- [core] The Fleet Console Operations Map adds a maximize control next to the radar toggle that hides the global navigation bar with an animation; exit with the control or Esc, remembered per browser.
+
 ### Changed
 - [core] The Fleet Console Operations radar sweep animation now consumes far less CPU and pauses automatically while the browser tab is hidden.
+- [core] The Fleet Console Operations Map now shows each panel's in-progress carrier job stream below the panel instead of above it.
+- [core] Collapsing the Fleet Console Operations Map sidebar now hides the whole panel, leaving only a fixed expand control on the left edge.
 
 ### Fixed
 - [core] The Fleet Console global navigation bar no longer overlaps the centered Theater selector with the toolbar at narrower window widths; the toolbar now progressively collapses its labels to icons and wraps onto a second row as the window shrinks, keeping the Theater selector centered.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - [core] The Fleet Console Operations Map now zooms smoothly with interpolated wheel zoom while panning stays immediate.
 - [core] The Fleet Console Operations Map can open plain user-shell terminal panels in the active Theater's directory; they are not tracked as Operations and are not kept across reloads.
 - [core] The Fleet Console Operations Map adds a right-click canvas menu to start a new Operation, open a shell, or reset the view at the cursor position.
-- [core] Fleet Console Operations Map panels can now be focused by double-clicking their title tab, in addition to the focus button.
-- [core] The Fleet Console Operations Map adds a maximize control next to the radar toggle that hides the global navigation bar with an animation; exit with the control or Esc, remembered per browser.
+- [core] Fleet Console Operations Map panels can now be focused by double-clicking an empty area of their title bar, in addition to the focus button.
+- [core] Fleet Console Operations Map panels can now be renamed inline by double-clicking the panel name, reusing the same rename flow as the Operations list.
+- [core] The Fleet Console Operations Map adds a bottom-right minimap showing all panels and the current viewport, draggable to navigate the canvas.
+- [core] The Fleet Console Operations Map adds a maximize control next to the radar toggle that hides the global navigation bar with an animation and auto-collapses the Operations sidebar; exit with the control or Esc, remembered per browser.
 
 ### Changed
 - [core] The Fleet Console Operations radar sweep animation now consumes far less CPU and pauses automatically while the browser tab is hidden.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - [core] Fleet Console Operations Map panels can now be focused by double-clicking an empty area of their title bar, in addition to the focus button.
 - [core] Fleet Console Operations Map panels can now be renamed inline by double-clicking the panel name, reusing the same rename flow as the Operations list.
 - [core] The Fleet Console Operations Map adds a bottom-right minimap showing all panels and the current viewport, draggable to navigate the canvas.
+- [core] Fleet Console Operations adds Alt+Left / Alt+Right to focus the previous / next Operation within the active Theater, working in both the Map and Helm views.
+- [core] The Fleet Console Operations Map adds a collapsible bottom-left shortcut reference panel that collapses to a "?" button.
 - [core] The Fleet Console Operations Map adds a maximize control next to the radar toggle that hides the global navigation bar with an animation and auto-collapses the Operations sidebar; exit with the control or Esc, remembered per browser.
 
 ### Changed

--- a/runtime/fleet-console/client/src/api.ts
+++ b/runtime/fleet-console/client/src/api.ts
@@ -2,6 +2,8 @@ import type { AgentCliMetadata, CarrierReadinessEntry, ObservedTenant, ObserverS
 
 export interface TerminalTicketOptions {
   readonly kind?: "shell";
+  // theater-shell(shell:<seq>) 티켓에서만 사용 — 서버가 이 id로 Theater 디렉터리를 cwd로 해석한다(raw 경로는 클라이언트에 없음).
+  readonly theaterId?: string;
   readonly signal?: AbortSignal;
 }
 
@@ -146,7 +148,11 @@ export async function requestTerminalTicket(sessionId: string, options?: AbortSi
   const response = await fetch("/terminal/ticket", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ sessionId, ...(ticketOptions.kind ? { kind: ticketOptions.kind } : {}) }),
+    body: JSON.stringify({
+      sessionId,
+      ...(ticketOptions.kind ? { kind: ticketOptions.kind } : {}),
+      ...(ticketOptions.theaterId ? { theaterId: ticketOptions.theaterId } : {}),
+    }),
     signal: ticketOptions.signal,
   });
   await assertOk(response);

--- a/runtime/fleet-console/client/src/app.tsx
+++ b/runtime/fleet-console/client/src/app.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 
+import { setMaximized, useMaximized } from "./canvas/canvas-store.js";
+import { useOperationsMode } from "./operations-mode.js";
 import { fetchObserverStatus, fetchTerminalSessions, fetchTheaterBootstrap } from "./api.js";
 import { ShortcutsOverlay } from "./components/shortcuts-overlay.js";
 import { ShellOverlay } from "./components/shell-overlay.js";
@@ -21,10 +23,29 @@ const UPDATE_STATUS_RECHECK_DELAY_MS = 6_000;
 
 export function App() {
   const state = useConsoleState();
+  const pathname = useLocation().pathname;
+  const maximized = useMaximized();
+  const operationsMode = useOperationsMode();
+  // 최대화는 localStorage에 영속되지만, GNB 숨김은 Map(canvas) Operations 화면에서만 적용한다 —
+  // 다른 라우트(Welcome/Codex/Helm)로 가거나 그 상태로 로드되어도 내비게이션이 사라지지 않게 한다.
+  const maximizedActive = maximized && pathname.startsWith("/operations") && operationsMode === "canvas";
 
   useEffect(() => {
     return startObserverConnection();
   }, []);
+
+  // 최대화 중 Esc로 해제한다. 단, 상위 모달(셸 오버레이·검색·단축키)이나 열린 메뉴가 있으면 그쪽 Esc에 양보한다.
+  useEffect(() => {
+    if (!maximizedActive) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (state.shellOpen || state.operationSearchOpen || state.shortcutsOpen) return;
+      if (document.querySelector('[role="menu"], [role="dialog"]')) return;
+      setMaximized(false);
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [maximizedActive, state.shellOpen, state.operationSearchOpen, state.shortcutsOpen]);
 
   useEffect(() => {
     const abort = new AbortController();
@@ -79,7 +100,7 @@ export function App() {
   }, []);
 
   return (
-    <div className="console-shell">
+    <div className={`console-shell ${maximizedActive ? "is-maximized" : ""}`}>
       <Topbar state={state} />
       <Routes>
         <Route path="/" element={<Welcome state={state} />} />

--- a/runtime/fleet-console/client/src/app.tsx
+++ b/runtime/fleet-console/client/src/app.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 
 import { setMaximized, useMaximized } from "./canvas/canvas-store.js";
@@ -14,7 +14,7 @@ import { useConsoleState } from "./hooks/use-store.js";
 import { CarrierSettings } from "./pages/carrier-settings.js";
 import { Codex } from "./pages/codex.js";
 import { Operations } from "./pages/operations.js";
-import { applyObserverStatus, hydrateTerminalSessions, hydrateTheaterBootstrap, setState, toggleOperationSearch, toggleShell } from "./store.js";
+import { applyObserverStatus, getState, hydrateTerminalSessions, hydrateTheaterBootstrap, setState, toggleOperationSearch, toggleShell } from "./store.js";
 import { Welcome } from "./pages/welcome.js";
 
 // 서버는 부팅 시 update 체크를 fire-and-forget으로 시작하므로, 첫 방문이 registry 응답보다
@@ -29,23 +29,27 @@ export function App() {
   // 최대화는 localStorage에 영속되지만, GNB 숨김은 Map(canvas) Operations 화면에서만 적용한다 —
   // 다른 라우트(Welcome/Codex/Helm)로 가거나 그 상태로 로드되어도 내비게이션이 사라지지 않게 한다.
   const maximizedActive = maximized && pathname.startsWith("/operations") && operationsMode === "canvas";
+  // Esc 핸들러(capture, 한 번만 등록)에서 최신 maximizedActive를 읽기 위한 ref.
+  const maximizedActiveRef = useRef(maximizedActive);
+  maximizedActiveRef.current = maximizedActive;
 
   useEffect(() => {
     return startObserverConnection();
   }, []);
 
-  // 최대화 중 Esc로 해제한다. 단, 상위 모달(셸 오버레이·검색·단축키)이나 열린 메뉴가 있으면 그쪽 Esc에 양보한다.
+  // 최대화 중 Esc로 해제한다. capture 단계에서 가장 먼저 실행되며, 아직 어떤 모달/메뉴도 Esc로 닫히기 전이므로
+  // 라이브 store 상태를 읽어 상위 모달(셸·검색·단축키)이나 열린 메뉴가 있으면 그쪽 Esc에 양보한다(전체화면 유지).
   useEffect(() => {
-    if (!maximizedActive) return;
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return;
-      if (state.shellOpen || state.operationSearchOpen || state.shortcutsOpen) return;
+      if (event.key !== "Escape" || !maximizedActiveRef.current) return;
+      const live = getState();
+      if (live.shellOpen || live.operationSearchOpen || live.shortcutsOpen) return;
       if (document.querySelector('[role="menu"], [role="dialog"]')) return;
       setMaximized(false);
     };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [maximizedActive, state.shellOpen, state.operationSearchOpen, state.shortcutsOpen]);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, []);
 
   useEffect(() => {
     const abort = new AbortController();

--- a/runtime/fleet-console/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-context-menu.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef } from "react";
+
+import { agentCliIcon } from "../components/operation-launch-menu.js";
+import type { AgentCliMetadata, ConsoleState } from "../types.js";
+
+interface CanvasContextMenuProps {
+  readonly state: ConsoleState;
+  // 캔버스(<main>) 기준 화면 좌표. 메뉴를 이 지점에 띄운다.
+  readonly anchor: { readonly x: number; readonly y: number };
+  readonly viewportBounds?: { readonly width: number; readonly height: number };
+  readonly onLaunchCli: (cli: AgentCliMetadata) => void;
+  readonly onOpenShell: () => void;
+  readonly onResetView: () => void;
+  readonly onClose: () => void;
+}
+
+const MENU_WIDTH = 208;
+const MENU_MAX_HEIGHT = 360;
+const MENU_MARGIN = 12;
+
+export function CanvasContextMenu({ state, anchor, viewportBounds, onLaunchCli, onOpenShell, onResetView, onClose }: CanvasContextMenuProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const launchDisabled = state.creatingTerminalSession || state.addingTheater || !state.activeTheaterId || state.agentClis.length === 0;
+  const shellDisabled = !state.activeTheaterId;
+
+  useEffect(() => {
+    const handlePointer = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) onClose();
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", handlePointer);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handlePointer);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [onClose]);
+
+  useEffect(() => {
+    // 첫 항목을 강제 포커스하지 않고 컨테이너만 포커스해 '이미 선택된 듯한' UX를 피한다.
+    menuRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      className="operation-launch-control operation-launch-control--canvas"
+      ref={containerRef}
+      style={clampedAnchorStyle(anchor, viewportBounds)}
+      data-canvas-blocker
+    >
+      <div className="operation-launch-menu theater-menu canvas-context-menu" role="menu" aria-label="Canvas actions" tabIndex={-1} ref={menuRef}>
+        <p className="canvas-context-menu-group">New Operation</p>
+        {state.agentClis.length > 0 ? (
+          <ul className="theater-menu-list">
+            {state.agentClis.map((cli) => (
+              <li key={cli.id}>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="theater-menu-item operation-launch-menu-item"
+                  disabled={launchDisabled}
+                  onClick={() => onLaunchCli(cli)}
+                >
+                  <span className="theater-menu-check" aria-hidden="true">{agentCliIcon(cli.id)}</span>
+                  <span className="theater-menu-label">{cli.label}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="theater-menu-empty">No Agent CLI available.</p>
+        )}
+        <div className="theater-menu-divider" role="separator" />
+        <button type="button" role="menuitem" className="theater-menu-item canvas-context-menu-item" disabled={shellDisabled} onClick={onOpenShell}>
+          <span className="theater-menu-check" aria-hidden="true"><ShellGlyph /></span>
+          <span className="theater-menu-label">Open Shell</span>
+        </button>
+        <div className="theater-menu-divider" role="separator" />
+        <button type="button" role="menuitem" className="theater-menu-item canvas-context-menu-item" onClick={onResetView}>
+          <span className="theater-menu-check" aria-hidden="true"><ResetGlyph /></span>
+          <span className="theater-menu-label">Reset view</span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function clampedAnchorStyle(
+  anchor: { readonly x: number; readonly y: number },
+  bounds: { readonly width: number; readonly height: number } | undefined,
+): { readonly left: number; readonly top: number } {
+  if (!bounds) return { left: anchor.x, top: anchor.y };
+  return {
+    left: Math.max(MENU_MARGIN, Math.min(anchor.x, bounds.width - MENU_WIDTH - MENU_MARGIN)),
+    top: Math.max(MENU_MARGIN, Math.min(anchor.y, bounds.height - MENU_MAX_HEIGHT - MENU_MARGIN)),
+  };
+}
+
+function ShellGlyph() {
+  // 순정 셸 — topbar Shell 버튼과 같은 화면+프롬프트 stroke 언어를 공유한다.
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <rect x="2.8" y="3.4" width="10.4" height="9.2" rx="1.4" fill="none" stroke="currentColor" strokeWidth="1.15" />
+      <path d="M5 6.6 6.8 8.4 5 10.2M8.4 10.2h2.8" fill="none" stroke="currentColor" strokeWidth="1.15" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function ResetGlyph() {
+  // 뷰 리셋 — 원점 복귀를 뜻하는 되돌림 화살표 마크.
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M4.4 7.2A4 4 0 1 1 4 9.2" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M2.4 4.6v2.8h2.8" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/runtime/fleet-console/client/src/canvas/canvas-minimap.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-minimap.tsx
@@ -1,0 +1,130 @@
+import { useRef, type PointerEvent as ReactPointerEvent } from "react";
+
+import type { CanvasViewport, PanelGeometry } from "./canvas-store.js";
+import type { CanvasPoint } from "./coordinates.js";
+import type { ShellPanelEntry } from "./shell-panels.js";
+
+interface CanvasMinimapProps {
+  readonly panels: Record<string, PanelGeometry>;
+  readonly shellPanels: Record<string, ShellPanelEntry>;
+  readonly viewport: CanvasViewport;
+  readonly canvasSize: { readonly width: number; readonly height: number };
+  // 미니맵의 한 지점을 캔버스 중앙으로 가져오도록 뷰포트를 옮긴다(world 좌표).
+  readonly onJump: (center: CanvasPoint) => void;
+}
+
+interface MiniRect {
+  readonly id: string;
+  readonly kind: "op" | "shell";
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+const MINIMAP_WIDTH = 200;
+const MINIMAP_HEIGHT = 132;
+const MINIMAP_PADDING = 10;
+// 패널/뷰포트 묶음 주변에 두는 world 여유 — 가장자리에 붙지 않게 한다.
+const WORLD_MARGIN = 220;
+
+export function CanvasMinimap({ panels, shellPanels, viewport, canvasSize, onJump }: CanvasMinimapProps) {
+  const innerRef = useRef<HTMLDivElement | null>(null);
+  const draggingRef = useRef(false);
+
+  if (canvasSize.width <= 0 || canvasSize.height <= 0 || viewport.zoom <= 0) return null;
+
+  const rects: MiniRect[] = [
+    ...Object.entries(panels).map(([id, g]) => ({ id, kind: "op" as const, x: g.x, y: g.y, width: g.width, height: g.height })),
+    ...Object.entries(shellPanels).map(([id, e]) => ({ id, kind: "shell" as const, x: e.geometry.x, y: e.geometry.y, width: e.geometry.width, height: e.geometry.height })),
+  ];
+  // 표시할 패널이 없으면 위치 인지에 의미가 없으므로 미니맵을 숨긴다.
+  if (rects.length === 0) return null;
+
+  const innerW = MINIMAP_WIDTH - MINIMAP_PADDING * 2;
+  const innerH = MINIMAP_HEIGHT - MINIMAP_PADDING * 2;
+
+  // 현재 화면에 보이는 world 영역(뷰포트 인디케이터의 근거).
+  const view = {
+    x: -viewport.x / viewport.zoom,
+    y: -viewport.y / viewport.zoom,
+    width: canvasSize.width / viewport.zoom,
+    height: canvasSize.height / viewport.zoom,
+  };
+
+  let minX = Math.min(view.x, ...rects.map((r) => r.x));
+  let minY = Math.min(view.y, ...rects.map((r) => r.y));
+  let maxX = Math.max(view.x + view.width, ...rects.map((r) => r.x + r.width));
+  let maxY = Math.max(view.y + view.height, ...rects.map((r) => r.y + r.height));
+  minX -= WORLD_MARGIN;
+  minY -= WORLD_MARGIN;
+  maxX += WORLD_MARGIN;
+  maxY += WORLD_MARGIN;
+
+  const worldW = maxX - minX;
+  const worldH = maxY - minY;
+  const scale = Math.min(innerW / worldW, innerH / worldH);
+  const offsetX = (innerW - worldW * scale) / 2;
+  const offsetY = (innerH - worldH * scale) / 2;
+
+  const miniLeft = (wx: number) => offsetX + (wx - minX) * scale;
+  const miniTop = (wy: number) => offsetY + (wy - minY) * scale;
+
+  const jumpToEvent = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const rect = innerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const cx = event.clientX - rect.left;
+    const cy = event.clientY - rect.top;
+    onJump({ x: minX + (cx - offsetX) / scale, y: minY + (cy - offsetY) / scale });
+  };
+
+  const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+    draggingRef.current = true;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    jumpToEvent(event);
+  };
+
+  const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!draggingRef.current) return;
+    event.stopPropagation();
+    jumpToEvent(event);
+  };
+
+  const onPointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+    draggingRef.current = false;
+    try {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    } catch {
+      // 포인터 캡처 해제 실패는 무시한다(이미 해제된 경우).
+    }
+  };
+
+  return (
+    <div className="canvas-minimap" data-canvas-blocker style={{ width: MINIMAP_WIDTH, height: MINIMAP_HEIGHT }}>
+      <div
+        ref={innerRef}
+        className="canvas-minimap-inner"
+        style={{ inset: MINIMAP_PADDING }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        role="presentation"
+        aria-label="Canvas minimap — drag to navigate"
+      >
+        {rects.map((r) => (
+          <div
+            key={r.id}
+            className={`canvas-minimap-panel ${r.kind === "shell" ? "is-shell" : ""}`}
+            style={{ left: miniLeft(r.x), top: miniTop(r.y), width: Math.max(2, r.width * scale), height: Math.max(2, r.height * scale) }}
+          />
+        ))}
+        <div
+          className="canvas-minimap-view"
+          style={{ left: miniLeft(view.x), top: miniTop(view.y), width: view.width * scale, height: view.height * scale }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/runtime/fleet-console/client/src/canvas/canvas-minimap.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-minimap.tsx
@@ -22,9 +22,9 @@ interface MiniRect {
   readonly height: number;
 }
 
-const MINIMAP_WIDTH = 200;
-const MINIMAP_HEIGHT = 132;
-const MINIMAP_PADDING = 10;
+const MINIMAP_WIDTH = 256;
+const MINIMAP_HEIGHT = 176;
+const MINIMAP_PADDING = 12;
 // 패널/뷰포트 묶음 주변에 두는 world 여유 — 가장자리에 붙지 않게 한다.
 const WORLD_MARGIN = 220;
 
@@ -102,6 +102,7 @@ export function CanvasMinimap({ panels, shellPanels, viewport, canvasSize, onJum
 
   return (
     <div className="canvas-minimap" data-canvas-blocker style={{ width: MINIMAP_WIDTH, height: MINIMAP_HEIGHT }}>
+      <span className="canvas-minimap-label" aria-hidden="true">Radar</span>
       <div
         ref={innerRef}
         className="canvas-minimap-inner"

--- a/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
@@ -1,11 +1,11 @@
-import { useRef, useState, type PointerEvent as ReactPointerEvent, type WheelEvent as ReactWheelEvent } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent, type WheelEvent as ReactWheelEvent } from "react";
 
-import { resumeTerminalSession, terminateTerminalSession } from "../api.js";
+import { renameTerminalSession, resumeTerminalSession, terminateTerminalSession } from "../api.js";
 import { CarrierJobLines } from "../components/carrier-job-lines.js";
 import { Terminal } from "../components/terminal.js";
 import { sessionDisplayLabel } from "../format.js";
 import { isTerminalJobStatus } from "../reduce.js";
-import { applySessionUpdate, failResumeTerminalSession, failTerminateTerminalSession, removeTerminalSession, selectJob, selectTerminalSession, sessionJobs } from "../store.js";
+import { applySessionUpdate, failRenameTerminalSession, failResumeTerminalSession, failTerminateTerminalSession, removeTerminalSession, selectJob, selectTerminalSession, sessionJobs } from "../store.js";
 import type { ConsoleState, SessionInfo } from "../types.js";
 import { focusPanel, setPanelGeometry, setViewport, type CanvasViewport, type PanelGeometry } from "./canvas-store.js";
 import { PanelResizeHandles } from "./panel-resize.js";
@@ -35,6 +35,11 @@ export function CanvasPanel({ state, session, geometry, viewport, active, getCan
   const dragRef = useRef<DragState | null>(null);
   const lastTitlePointerRef = useRef<{ readonly time: number; readonly x: number; readonly y: number } | null>(null);
   const [restoreViewport, setRestoreViewport] = useState<CanvasViewport | null>(null);
+  const [renaming, setRenaming] = useState(false);
+  const [draftLabel, setDraftLabel] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const committingRef = useRef(false);
+  const skipBlurCommitRef = useRef(false);
   const jobs = sessionJobs(state, session);
   const activeJobs = jobs.filter(({ job }) => !isTerminalJobStatus(job.status)).map(({ job }) => job);
   const activeJobCount = activeJobs.length;
@@ -120,6 +125,58 @@ export function CanvasPanel({ state, session, geometry, viewport, active, getCan
     focusPanel(session.sessionId, { width: canvasRect.width, height: canvasRect.height });
   };
 
+  useEffect(() => {
+    if (!renaming) return;
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, [renaming]);
+
+  // 이름 영역 더블클릭 → 인라인 이름 변경. Operations(FloatingSessionEntry)의 rename 동작을 그대로 따른다.
+  const beginRename = () => {
+    bringToFront();
+    skipBlurCommitRef.current = false;
+    setDraftLabel(displayLabel);
+    setRenaming(true);
+  };
+
+  const cancelRename = () => {
+    skipBlurCommitRef.current = true;
+    setRenaming(false);
+    setDraftLabel("");
+  };
+
+  const commitRename = async () => {
+    if (committingRef.current) return;
+    committingRef.current = true;
+    try {
+      applySessionUpdate(await renameTerminalSession(session.sessionId, draftLabel));
+    } catch (error) {
+      failRenameTerminalSession(error instanceof Error ? error.message : String(error));
+    } finally {
+      committingRef.current = false;
+      skipBlurCommitRef.current = true;
+      setRenaming(false);
+    }
+  };
+
+  const handleRenameKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      void commitRename();
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      cancelRename();
+    }
+  };
+
+  // 이름 영역 pointerdown은 드래그/포커스 경로(beginDrag)로 전파하지 않는다 — 더블클릭은 오직 rename.
+  const onNamePointerDown = (event: ReactPointerEvent<HTMLElement>) => {
+    event.stopPropagation();
+    bringToFront();
+  };
+
   const stopCanvasPointer = (event: ReactPointerEvent<HTMLElement>) => {
     event.stopPropagation();
     bringToFront();
@@ -153,7 +210,33 @@ export function CanvasPanel({ state, session, geometry, viewport, active, getCan
         data-canvas-blocker
       >
         <span className={`tenant-beacon ${live ? "is-live" : dormant ? "is-dormant" : ""}`} aria-hidden="true" />
-        <span className="canvas-panel-title">{displayLabel}</span>
+        {renaming ? (
+          <input
+            ref={inputRef}
+            className="canvas-panel-rename-input"
+            value={draftLabel}
+            aria-label={`${displayLabel} 이름 변경`}
+            onPointerDown={(event) => event.stopPropagation()}
+            onChange={(event) => setDraftLabel(event.target.value)}
+            onKeyDown={handleRenameKeyDown}
+            onBlur={() => {
+              if (skipBlurCommitRef.current) {
+                skipBlurCommitRef.current = false;
+                return;
+              }
+              void commitRename();
+            }}
+          />
+        ) : (
+          <span
+            className="canvas-panel-title"
+            onPointerDown={onNamePointerDown}
+            onDoubleClick={beginRename}
+            title="Double-click to rename"
+          >
+            {displayLabel}
+          </span>
+        )}
         <span className="canvas-panel-cli">{session.cliLabel ?? session.cliId ?? "CLI"}</span>
         {activeJobCount > 0 ? <span className="canvas-panel-job-count">{activeJobCount}</span> : null}
         <button

--- a/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
@@ -26,8 +26,14 @@ interface DragState {
   readonly geometry: PanelGeometry;
 }
 
+// 제목 탭 더블클릭 판정: beginDrag가 pointerdown에서 preventDefault/pointer-capture를 호출해
+// native dblclick이 신뢰되지 않으므로, 두 번의 pointerdown 간격·이동량으로 직접 더블클릭을 가린다.
+const TITLE_DOUBLE_CLICK_MS = 320;
+const TITLE_DOUBLE_CLICK_DISTANCE = 6;
+
 export function CanvasPanel({ state, session, geometry, viewport, active, getCanvasRect }: CanvasPanelProps) {
   const dragRef = useRef<DragState | null>(null);
+  const lastTitlePointerRef = useRef<{ readonly time: number; readonly x: number; readonly y: number } | null>(null);
   const [restoreViewport, setRestoreViewport] = useState<CanvasViewport | null>(null);
   const jobs = sessionJobs(state, session);
   const activeJobs = jobs.filter(({ job }) => !isTerminalJobStatus(job.status)).map(({ job }) => job);
@@ -52,6 +58,20 @@ export function CanvasPanel({ state, session, geometry, viewport, active, getCan
     if (event.button !== 0) return;
     event.preventDefault();
     event.stopPropagation();
+    // 제목 탭 더블클릭 → 포커스 토글(확대 ↔ 복귀). 근접한 두 번째 pointerdown이면 드래그 대신 포커스로 처리한다.
+    const now = Date.now();
+    const last = lastTitlePointerRef.current;
+    if (
+      last
+      && now - last.time < TITLE_DOUBLE_CLICK_MS
+      && Math.abs(event.clientX - last.x) < TITLE_DOUBLE_CLICK_DISTANCE
+      && Math.abs(event.clientY - last.y) < TITLE_DOUBLE_CLICK_DISTANCE
+    ) {
+      lastTitlePointerRef.current = null;
+      handleFocusToggle();
+      return;
+    }
+    lastTitlePointerRef.current = { time: now, x: event.clientX, y: event.clientY };
     bringToFront();
     dragRef.current = {
       pointerId: event.pointerId,
@@ -170,11 +190,11 @@ export function CanvasPanel({ state, session, geometry, viewport, active, getCan
       <PanelResizeHandles geometry={geometry} zoom={viewport.zoom} onResize={(nextGeometry) => setPanelGeometry(session.sessionId, nextGeometry)} />
     </article>
     {activeJobs.length > 0 ? (
-      // 캔버스 공간을 살려 진행 중 캐리어 스트림을 패널 '바깥 위'에 floating으로 띄운다(터미널 출력을 가리지 않음).
-      // world 좌표계에 두어 패널과 함께 이동·확대되며, CSS translateY로 패널 상단 위에 정렬한다.
+      // 진행 중 캐리어 스트림을 패널 '바깥 아래'에 floating으로 띄운다(터미널 출력을 가리지 않음).
+      // world 좌표계에 두어 패널과 함께 이동·확대되며, top을 패널 하단 모서리에 맞춰 그 아래로 정렬한다.
       <div
         className="canvas-panel-jobdock"
-        style={{ left: geometry.x, top: geometry.y, width: geometry.width, zIndex: geometry.zIndex }}
+        style={{ left: geometry.x, top: geometry.y + geometry.height, width: geometry.width, zIndex: geometry.zIndex }}
         data-canvas-blocker
         aria-label={`Active carrier jobs for ${displayLabel}`}
       >

--- a/runtime/fleet-console/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/client/src/canvas/canvas-store.ts
@@ -28,6 +28,7 @@ type Listener = () => void;
 
 const STORAGE_KEY_PREFIX = "fleet-console.canvas.";
 const BACKGROUND_ANIMATION_STORAGE_KEY = "fleet-console.canvas.backgroundAnimation";
+const MAXIMIZED_STORAGE_KEY = "fleet-console.canvas.maximized";
 const SAVE_DELAY_MS = 400;
 const DEFAULT_PANEL_WIDTH = 640;
 const DEFAULT_PANEL_HEIGHT = 400;
@@ -35,15 +36,25 @@ const DEFAULT_PANEL_OFFSET = 40;
 const PANEL_FOCUS_PADDING = 96;
 const FOCUS_MIN_ZOOM = 0.25;
 const FOCUS_MAX_ZOOM = 1;
+// 줌 보간: 매 프레임 현재 viewport를 target 쪽으로 이 비율만큼 당긴다(지수 감쇠).
+const ZOOM_TWEEN_FACTOR = 0.2;
+// 이 임계치 미만으로 좁혀지면 target에 스냅하고 보간을 멈춘다(위치 px, 줌 배율).
+const ZOOM_TWEEN_POSITION_EPSILON = 0.5;
+const ZOOM_TWEEN_ZOOM_EPSILON = 0.001;
 const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
 const EMPTY_STATE: CanvasState = { viewport: DEFAULT_VIEWPORT, panels: {} };
 
 const listeners = new Set<Listener>();
 const backgroundAnimationListeners = new Set<Listener>();
+const maximizedListeners = new Set<Listener>();
 let activeTheaterId: string | null = null;
 let saveTimer: number | null = null;
 let state: CanvasState = EMPTY_STATE;
 let backgroundAnimationEnabled = readStoredBackgroundAnimation();
+let maximized = readStoredMaximized();
+// 줌 보간 루프가 향하는 목표 viewport. 즉시 이동(pan/focus/load)은 이 값을 current와 동기화해 잔여 보간을 무효화한다.
+let targetViewport: CanvasViewport = DEFAULT_VIEWPORT;
+let zoomRaf: number | null = null;
 
 export function subscribe(listener: Listener): () => void {
   listeners.add(listener);
@@ -64,6 +75,10 @@ export function useBackgroundAnimation(): boolean {
   return useSyncExternalStore(subscribeBackgroundAnimation, getBackgroundAnimationSnapshot, getBackgroundAnimationSnapshot);
 }
 
+export function useMaximized(): boolean {
+  return useSyncExternalStore(subscribeMaximized, getMaximizedSnapshot, getMaximizedSnapshot);
+}
+
 export function setState(patch: Partial<CanvasState>): void {
   state = {
     viewport: patch.viewport ?? state.viewport,
@@ -73,8 +88,24 @@ export function setState(patch: Partial<CanvasState>): void {
   emit();
 }
 
+// 즉시 이동(pan 드래그·검색 이동 등). 진행 중 줌 보간을 취소하고 current·target을 같은 값으로 맞춘다.
 export function setViewport(viewport: CanvasViewport): void {
-  setState({ viewport: normalizeViewport(viewport) });
+  cancelZoomTween();
+  const next = normalizeViewport(viewport);
+  targetViewport = next;
+  setState({ viewport: next });
+}
+
+// 보간 이동(휠 줌). target만 갱신하고 rAF 루프가 current를 target으로 부드럽게 당긴다.
+// prefers-reduced-motion이거나 rAF를 못 쓰면 즉시 적용한다.
+export function animateViewportTo(viewport: CanvasViewport): void {
+  const next = normalizeViewport(viewport);
+  if (typeof window === "undefined" || typeof window.requestAnimationFrame !== "function" || prefersReducedMotion()) {
+    setViewport(next);
+    return;
+  }
+  targetViewport = next;
+  if (zoomRaf === null) zoomRaf = window.requestAnimationFrame(stepZoomTween);
 }
 
 export function setPanelGeometry(sessionId: string, geometry: PanelGeometry): void {
@@ -117,8 +148,10 @@ export function prunePanels(validSessionIds: readonly string[]): void {
 
 export function loadForTheater(theaterId: string | null): void {
   flushScheduledSave();
+  cancelZoomTween();
   activeTheaterId = theaterId;
   state = theaterId ? readStoredState(theaterId) : EMPTY_STATE;
+  targetViewport = state.viewport;
   emit();
 }
 
@@ -129,12 +162,16 @@ export function focusPanel(sessionId: string, viewportSize: CanvasViewportSize):
     (viewportSize.width - PANEL_FOCUS_PADDING) / geometry.width,
     (viewportSize.height - PANEL_FOCUS_PADDING) / geometry.height,
   )));
+  const focusedViewport: CanvasViewport = {
+    x: viewportSize.width / 2 - (geometry.x + geometry.width / 2) * zoom,
+    y: viewportSize.height / 2 - (geometry.y + geometry.height / 2) * zoom,
+    zoom,
+  };
+  // 진행 중 줌 보간을 취소하고 target을 포커스 결과로 맞춰, 마지막 tween 프레임이 포커스를 되돌리지 못하게 한다.
+  cancelZoomTween();
+  targetViewport = focusedViewport;
   setState({
-    viewport: {
-      x: viewportSize.width / 2 - (geometry.x + geometry.width / 2) * zoom,
-      y: viewportSize.height / 2 - (geometry.y + geometry.height / 2) * zoom,
-      zoom,
-    },
+    viewport: focusedViewport,
     panels: {
       ...state.panels,
       [sessionId]: { ...normalizePanelGeometry(geometry, nextZIndex()), zIndex: nextZIndex() },
@@ -146,6 +183,17 @@ export function toggleBackgroundAnimation(): void {
   backgroundAnimationEnabled = !backgroundAnimationEnabled;
   writeStoredBackgroundAnimation(backgroundAnimationEnabled);
   emitBackgroundAnimation();
+}
+
+export function toggleMaximized(): void {
+  setMaximized(!maximized);
+}
+
+export function setMaximized(value: boolean): void {
+  if (maximized === value) return;
+  maximized = value;
+  writeStoredMaximized(maximized);
+  emitMaximized();
 }
 
 function subscribeBackgroundAnimation(listener: Listener): () => void {
@@ -165,6 +213,53 @@ function emit(): void {
 
 function emitBackgroundAnimation(): void {
   for (const listener of backgroundAnimationListeners) listener();
+}
+
+function subscribeMaximized(listener: Listener): () => void {
+  maximizedListeners.add(listener);
+  return () => {
+    maximizedListeners.delete(listener);
+  };
+}
+
+function getMaximizedSnapshot(): boolean {
+  return maximized;
+}
+
+function emitMaximized(): void {
+  for (const listener of maximizedListeners) listener();
+}
+
+// 줌 보간 한 프레임: current를 target 쪽으로 ZOOM_TWEEN_FACTOR만큼 당기고, 임계치 안이면 스냅 후 정지한다.
+function stepZoomTween(): void {
+  const current = state.viewport;
+  const dx = targetViewport.x - current.x;
+  const dy = targetViewport.y - current.y;
+  const dz = targetViewport.zoom - current.zoom;
+  if (Math.abs(dx) < ZOOM_TWEEN_POSITION_EPSILON && Math.abs(dy) < ZOOM_TWEEN_POSITION_EPSILON && Math.abs(dz) < ZOOM_TWEEN_ZOOM_EPSILON) {
+    zoomRaf = null;
+    setState({ viewport: targetViewport });
+    return;
+  }
+  setState({
+    viewport: {
+      x: current.x + dx * ZOOM_TWEEN_FACTOR,
+      y: current.y + dy * ZOOM_TWEEN_FACTOR,
+      zoom: current.zoom + dz * ZOOM_TWEEN_FACTOR,
+    },
+  });
+  zoomRaf = typeof window !== "undefined" ? window.requestAnimationFrame(stepZoomTween) : null;
+}
+
+function cancelZoomTween(): void {
+  if (zoomRaf === null || typeof window === "undefined") return;
+  window.cancelAnimationFrame(zoomRaf);
+  zoomRaf = null;
+}
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }
 
 function scheduleSave(): void {
@@ -227,6 +322,25 @@ function writeStoredBackgroundAnimation(value: boolean): void {
     window.localStorage.setItem(BACKGROUND_ANIMATION_STORAGE_KEY, String(value));
   } catch {
     // 배경 애니메이션 선호 저장 실패는 런타임 동작을 막지 않는다.
+  }
+}
+
+function readStoredMaximized(): boolean {
+  // 기본값 false: 저장된 선호가 없으면 GNB를 정상 노출해 첫 방문자가 내비게이션을 잃지 않는다.
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(MAXIMIZED_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function writeStoredMaximized(value: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(MAXIMIZED_STORAGE_KEY, String(value));
+  } catch {
+    // 최대화 선호 저장 실패는 런타임 동작을 막지 않는다.
   }
 }
 

--- a/runtime/fleet-console/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import { useEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
 
 import { createTheaterTerminalSession } from "../api.js";
 import { OperationLaunchMenu } from "../components/operation-launch-menu.js";
@@ -6,6 +6,7 @@ import { beginCreateTerminalSession, completeCreateTerminalSession, failCreateTe
 import type { AgentCliMetadata, ConsoleState } from "../types.js";
 import { animateViewportTo, setPanelGeometry, setViewport, toggleBackgroundAnimation, toggleMaximized, useBackgroundAnimation, useCanvasState, useMaximized, type PanelGeometry } from "./canvas-store.js";
 import { CanvasContextMenu } from "./canvas-context-menu.js";
+import { CanvasMinimap } from "./canvas-minimap.js";
 import { CanvasPanel } from "./canvas-panel.js";
 import { CanvasGrid } from "./canvas-grid.js";
 import { RubberBand } from "./rubber-band.js";
@@ -46,7 +47,19 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
   const sessions = theaterSessions(state);
   const [launchRequest, setLaunchRequest] = useState<LaunchRequest | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuRequest | null>(null);
+  // 미니맵의 뷰포트 인디케이터 계산에 필요한 캔버스 픽셀 크기를 ResizeObserver로 추적한다.
+  const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
   const disabled = !state.activeTheaterId || state.agentClis.length === 0 || state.creatingTerminalSession || state.addingTheater;
+
+  useEffect(() => {
+    const element = canvasRef.current;
+    if (!element || typeof ResizeObserver === "undefined") return;
+    const update = () => setCanvasSize({ width: element.clientWidth, height: element.clientHeight });
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
   const interaction = useCanvasInteraction({
     viewport: canvas.viewport,
     disabled,
@@ -210,6 +223,17 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
           onClose={() => setContextMenu(null)}
         />
       ) : null}
+      <CanvasMinimap
+        panels={canvas.panels}
+        shellPanels={shellPanels}
+        viewport={canvas.viewport}
+        canvasSize={canvasSize}
+        onJump={(center) => setViewport({
+          x: canvasSize.width / 2 - center.x * canvas.viewport.zoom,
+          y: canvasSize.height / 2 - center.y * canvas.viewport.zoom,
+          zoom: canvas.viewport.zoom,
+        })}
+      />
     </main>
   );
 }

--- a/runtime/fleet-console/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas.tsx
@@ -1,15 +1,18 @@
-import { useRef, useState } from "react";
+import { useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
 
 import { createTheaterTerminalSession } from "../api.js";
 import { OperationLaunchMenu } from "../components/operation-launch-menu.js";
 import { beginCreateTerminalSession, completeCreateTerminalSession, failCreateTerminalSession, selectTerminalSession, theaterSessions } from "../store.js";
 import type { AgentCliMetadata, ConsoleState } from "../types.js";
-import { setPanelGeometry, setViewport, toggleBackgroundAnimation, useBackgroundAnimation, useCanvasState, type PanelGeometry } from "./canvas-store.js";
+import { animateViewportTo, setPanelGeometry, setViewport, toggleBackgroundAnimation, toggleMaximized, useBackgroundAnimation, useCanvasState, useMaximized, type PanelGeometry } from "./canvas-store.js";
+import { CanvasContextMenu } from "./canvas-context-menu.js";
 import { CanvasPanel } from "./canvas-panel.js";
 import { CanvasGrid } from "./canvas-grid.js";
 import { RubberBand } from "./rubber-band.js";
+import { ShellCanvasPanel } from "./shell-canvas-panel.js";
+import { addShellPanel, useShellPanels } from "./shell-panels.js";
 import { useCanvasInteraction } from "./use-canvas-interaction.js";
-import type { CanvasPoint, CanvasRect } from "./coordinates.js";
+import { screenToCanvas, type CanvasPoint, type CanvasRect } from "./coordinates.js";
 
 interface OperationsCanvasProps {
   readonly state: ConsoleState;
@@ -20,22 +23,39 @@ interface LaunchRequest {
   readonly anchor: CanvasPoint;
 }
 
-const EMPTY_GUIDE = "Shift-drag to create an Operation. Drag to pan; scroll to zoom.";
+interface ContextMenuRequest {
+  // 캔버스(<main>) 기준 화면 좌표(메뉴 표시 위치).
+  readonly anchor: CanvasPoint;
+  // 우클릭 지점의 캔버스(world) 좌표(새 패널 배치 기준).
+  readonly canvasPoint: CanvasPoint;
+}
+
+const EMPTY_GUIDE = "Shift-drag to create an Operation. Right-click for actions. Drag to pan; scroll to zoom.";
+const DEFAULT_OPERATION_WIDTH = 640;
+const DEFAULT_OPERATION_HEIGHT = 400;
+const DEFAULT_SHELL_WIDTH = 560;
+const DEFAULT_SHELL_HEIGHT = 360;
+const RESET_VIEWPORT = { x: 0, y: 0, zoom: 1 } as const;
 
 export function OperationsCanvas({ state }: OperationsCanvasProps) {
   const canvasRef = useRef<HTMLElement | null>(null);
   const canvas = useCanvasState();
   const backgroundAnimationEnabled = useBackgroundAnimation();
+  const maximized = useMaximized();
+  const shellPanels = useShellPanels();
   const sessions = theaterSessions(state);
   const [launchRequest, setLaunchRequest] = useState<LaunchRequest | null>(null);
+  const [contextMenu, setContextMenu] = useState<ContextMenuRequest | null>(null);
   const disabled = !state.activeTheaterId || state.agentClis.length === 0 || state.creatingTerminalSession || state.addingTheater;
   const interaction = useCanvasInteraction({
     viewport: canvas.viewport,
     disabled,
+    // pan은 즉시, 휠 줌은 보간 경로(스토어 rAF tween)로 분기한다.
     onViewportChange: setViewport,
-    onCreate: (rect, anchor) => setLaunchRequest({ rect, anchor }),
-    consumePointerDown: launchRequest !== null,
-    onConsumePointerDown: () => setLaunchRequest(null),
+    onZoom: animateViewportTo,
+    onCreate: (rect, anchor) => { setContextMenu(null); setLaunchRequest({ rect, anchor }); },
+    consumePointerDown: launchRequest !== null || contextMenu !== null,
+    onConsumePointerDown: () => { setLaunchRequest(null); setContextMenu(null); },
     onClick: clearTerminalFocus,
   });
 
@@ -53,6 +73,48 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
     }
   };
 
+  // 우클릭 컨텍스트 메뉴에서 새 Operation을 우클릭 지점에 생성한다.
+  const handleContextLaunch = async (cli: AgentCliMetadata) => {
+    const point = contextMenu?.canvasPoint;
+    setContextMenu(null);
+    if (!state.activeTheaterId || !point) return;
+    beginCreateTerminalSession();
+    try {
+      const session = await createTheaterTerminalSession(state.activeTheaterId, cli.id);
+      setPanelGeometry(session.sessionId, geometryAt(point, DEFAULT_OPERATION_WIDTH, DEFAULT_OPERATION_HEIGHT));
+      completeCreateTerminalSession(session);
+      selectTerminalSession(session.sessionId);
+    } catch (error) {
+      failCreateTerminalSession(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  // 순정 셸 패널을 우클릭 지점에 띄운다(Operation 미분류·비영속).
+  const handleOpenShell = () => {
+    const point = contextMenu?.canvasPoint;
+    setContextMenu(null);
+    if (!state.activeTheaterId || !point) return;
+    addShellPanel(state.activeTheaterId, geometryAt(point, DEFAULT_SHELL_WIDTH, DEFAULT_SHELL_HEIGHT));
+  };
+
+  const handleResetView = () => {
+    setContextMenu(null);
+    setViewport({ ...RESET_VIEWPORT });
+  };
+
+  const handleContextMenu = (event: ReactMouseEvent<HTMLElement>) => {
+    // 빈 캔버스에서만 컨텍스트 메뉴를 띄운다 — 패널/메뉴/터미널 위 우클릭은 무시(기본 동작 유지).
+    if (event.target instanceof Element && event.target.closest("[data-canvas-blocker], [data-canvas-panel]")) return;
+    event.preventDefault();
+    const rect = canvasRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const anchor: CanvasPoint = { x: event.clientX - rect.left, y: event.clientY - rect.top };
+    setLaunchRequest(null);
+    setContextMenu({ anchor, canvasPoint: screenToCanvas(anchor, canvas.viewport) });
+  };
+
+  const hasContent = sessions.length > 0 || Object.keys(shellPanels).length > 0;
+
   return (
     <main
       className={`operations-canvas ${interaction.spaceActive ? "is-panning" : ""} ${interaction.shiftActive ? "is-creating" : ""}`}
@@ -61,9 +123,21 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
       onPointerUp={interaction.onPointerUp}
       onPointerCancel={interaction.onPointerCancel}
       onWheel={interaction.onWheel}
+      onContextMenu={handleContextMenu}
       ref={canvasRef}
     >
       <CanvasGrid viewport={canvas.viewport} backgroundAnimationEnabled={backgroundAnimationEnabled} />
+      <button
+        type="button"
+        className={`canvas-background-toggle canvas-maximize-toggle ${maximized ? "is-active" : ""}`}
+        onClick={toggleMaximized}
+        data-canvas-blocker
+        aria-label={maximized ? "맵 최대화 해제" : "맵 최대화"}
+        aria-pressed={maximized}
+        title={maximized ? "Exit fullscreen (Esc)" : "Maximize map"}
+      >
+        {maximized ? <RestoreIcon /> : <MaximizeIcon />}
+      </button>
       <button
         type="button"
         className={`canvas-background-toggle ${backgroundAnimationEnabled ? "is-active" : ""}`}
@@ -95,8 +169,17 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
             />
           );
         })}
+        {Object.entries(shellPanels).map(([id, entry]) => (
+          <ShellCanvasPanel
+            key={id}
+            id={id}
+            theaterId={entry.theaterId}
+            geometry={entry.geometry}
+            viewport={canvas.viewport}
+          />
+        ))}
       </div>
-      {sessions.length === 0 ? (
+      {!hasContent ? (
         <div className="operations-canvas-empty" data-canvas-blocker>
           <span className="operations-canvas-empty-mark" aria-hidden="true" />
           <p>{state.activeTheaterId ? EMPTY_GUIDE : "Add a Theater from the top bar to start operations."}</p>
@@ -115,6 +198,18 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
           onClose={() => setLaunchRequest(null)}
         />
       ) : null}
+      {contextMenu ? (
+        <CanvasContextMenu
+          key={`${contextMenu.anchor.x}:${contextMenu.anchor.y}`}
+          state={state}
+          anchor={contextMenu.anchor}
+          viewportBounds={viewportBoundsFor(canvasRef.current)}
+          onLaunchCli={(cli) => { void handleContextLaunch(cli); }}
+          onOpenShell={handleOpenShell}
+          onResetView={handleResetView}
+          onClose={() => setContextMenu(null)}
+        />
+      ) : null}
     </main>
   );
 }
@@ -126,6 +221,24 @@ function RadarToggleIcon() {
       <circle cx="8" cy="8" r="2.6" fill="none" stroke="currentColor" strokeWidth="1.1" opacity="0.72" />
       <path d="M8 8 12.2 5.8" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
       <circle cx="8" cy="8" r=".9" fill="currentColor" />
+    </svg>
+  );
+}
+
+function MaximizeIcon() {
+  // 맵 최대화 — 네 모서리 바깥 화살표(확장) 마크.
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M3 6.4V3h3.4M13 6.4V3H9.6M3 9.6V13h3.4M13 9.6V13H9.6" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function RestoreIcon() {
+  // 최대화 해제 — 안쪽 화살표(축소) 마크.
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M6.4 3v3.4H3M9.6 3v3.4H13M6.4 13V9.6H3M9.6 13V9.6H13" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 }
@@ -151,6 +264,17 @@ function rectToGeometry(rect: CanvasRect): PanelGeometry {
     y: rect.y,
     width: rect.width,
     height: rect.height,
+    zIndex: Date.now(),
+  };
+}
+
+// 캔버스 좌표 지점에 기본 크기 패널을 배치하는 geometry를 만든다(우클릭 메뉴 생성용).
+function geometryAt(point: CanvasPoint, width: number, height: number): PanelGeometry {
+  return {
+    x: point.x,
+    y: point.y,
+    width,
+    height,
     zIndex: Date.now(),
   };
 }

--- a/runtime/fleet-console/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas.tsx
@@ -235,7 +235,8 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
           zoom: canvas.viewport.zoom,
         })}
       />
-      <MapShortcuts />
+      {/* 콘텐츠가 없을 때는 좌하단 빈 상태 안내가 핵심 단축키를 이미 알려주므로, 겹침을 막기 위해 단축키 맵을 숨긴다. */}
+      {hasContent ? <MapShortcuts /> : null}
     </main>
   );
 }

--- a/runtime/fleet-console/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas.tsx
@@ -9,6 +9,7 @@ import { CanvasContextMenu } from "./canvas-context-menu.js";
 import { CanvasMinimap } from "./canvas-minimap.js";
 import { CanvasPanel } from "./canvas-panel.js";
 import { CanvasGrid } from "./canvas-grid.js";
+import { MapShortcuts } from "./map-shortcuts.js";
 import { RubberBand } from "./rubber-band.js";
 import { ShellCanvasPanel } from "./shell-canvas-panel.js";
 import { addShellPanel, useShellPanels } from "./shell-panels.js";
@@ -234,6 +235,7 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
           zoom: canvas.viewport.zoom,
         })}
       />
+      <MapShortcuts />
     </main>
   );
 }

--- a/runtime/fleet-console/client/src/canvas/map-shortcuts.tsx
+++ b/runtime/fleet-console/client/src/canvas/map-shortcuts.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+
+import { SHORTCUT_GROUPS } from "../shortcuts-catalog.js";
+
+const STORAGE_KEY = "fleet-console.map.shortcutsCollapsed";
+const MAP_GROUP = SHORTCUT_GROUPS.find((group) => group.title === "Map") ?? null;
+
+export function MapShortcuts() {
+  const [collapsed, setCollapsed] = useState(readCollapsed);
+
+  if (!MAP_GROUP) return null;
+
+  const toggle = () => {
+    setCollapsed((value) => {
+      const next = !value;
+      writeCollapsed(next);
+      return next;
+    });
+  };
+
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        className="map-shortcuts-fab"
+        data-canvas-blocker
+        onClick={toggle}
+        aria-label="맵 단축키 보기"
+        title="Map shortcuts"
+      >
+        <QuestionIcon />
+      </button>
+    );
+  }
+
+  return (
+    <aside className="map-shortcuts" data-canvas-blocker aria-label="Map shortcuts">
+      <div className="map-shortcuts-head">
+        <span className="map-shortcuts-label">Shortcuts</span>
+        <button type="button" className="map-shortcuts-toggle" onClick={toggle} aria-label="맵 단축키 접기" title="Collapse">
+          <CollapseIcon />
+        </button>
+      </div>
+      <dl className="map-shortcuts-list">
+        {MAP_GROUP.entries.map((entry) => (
+          <div key={entry.description} className="map-shortcuts-entry">
+            <dt className="map-shortcuts-combos">
+              {entry.combos.map((combo, comboIndex) => (
+                <span key={combo.join("+")} className="map-shortcuts-combo">
+                  {comboIndex > 0 ? <span className="map-shortcuts-or">or</span> : null}
+                  <span className="map-shortcuts-keyset">
+                    {combo.map((key) => <kbd key={key}>{key}</kbd>)}
+                  </span>
+                </span>
+              ))}
+            </dt>
+            <dd>{entry.description}</dd>
+          </div>
+        ))}
+      </dl>
+    </aside>
+  );
+}
+
+function readCollapsed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function writeCollapsed(value: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(value));
+  } catch {
+    // 도움말 접힘 선호 저장 실패는 런타임 동작을 막지 않는다.
+  }
+}
+
+function QuestionIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" strokeWidth="1.2" />
+      <path d="M6.3 6.1a1.8 1.8 0 1 1 2.5 1.7c-.5.3-.8.6-.8 1.2v.3" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
+      <circle cx="8" cy="11.4" r=".8" fill="currentColor" />
+    </svg>
+  );
+}
+
+function CollapseIcon() {
+  // 좌하단으로 접는 방향을 가리키는 셰브런.
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M10.5 4.5 5.5 8l5 3.5M11 8H5.5" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
@@ -1,0 +1,131 @@
+import { useRef, type PointerEvent as ReactPointerEvent, type WheelEvent as ReactWheelEvent } from "react";
+
+import { terminateTerminalSession } from "../api.js";
+import { Terminal } from "../components/terminal.js";
+import { failTerminateTerminalSession } from "../store.js";
+import type { CanvasViewport, PanelGeometry } from "./canvas-store.js";
+import { PanelResizeHandles } from "./panel-resize.js";
+import { removeShellPanel, setShellPanelGeometry } from "./shell-panels.js";
+
+interface ShellCanvasPanelProps {
+  readonly id: string;
+  readonly theaterId: string;
+  readonly geometry: PanelGeometry;
+  readonly viewport: CanvasViewport;
+}
+
+interface DragState {
+  readonly pointerId: number;
+  readonly startX: number;
+  readonly startY: number;
+  readonly geometry: PanelGeometry;
+}
+
+export function ShellCanvasPanel({ id, theaterId, geometry, viewport }: ShellCanvasPanelProps) {
+  const dragRef = useRef<DragState | null>(null);
+
+  const bringToFront = () => {
+    setShellPanelGeometry(id, { ...geometry, zIndex: Date.now() });
+  };
+
+  const beginDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    bringToFront();
+    dragRef.current = { pointerId: event.pointerId, startX: event.clientX, startY: event.clientY, geometry };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const updateDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    event.stopPropagation();
+    setShellPanelGeometry(id, {
+      ...drag.geometry,
+      x: drag.geometry.x + (event.clientX - drag.startX) / viewport.zoom,
+      y: drag.geometry.y + (event.clientY - drag.startY) / viewport.zoom,
+    });
+  };
+
+  const endDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (dragRef.current?.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    event.stopPropagation();
+    dragRef.current = null;
+    event.currentTarget.releasePointerCapture(event.pointerId);
+  };
+
+  const stopButtonPointer = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+  };
+
+  const stopCanvasPointer = (event: ReactPointerEvent<HTMLElement>) => {
+    event.stopPropagation();
+    bringToFront();
+  };
+
+  const stopCanvasWheel = (event: ReactWheelEvent<HTMLElement>) => {
+    event.stopPropagation();
+  };
+
+  // 닫기: 레지스트리에서 제거(언마운트)하고 백엔드 PTY도 즉시 종료한다(grace 대기 없이).
+  const close = () => {
+    removeShellPanel(id);
+    void terminateTerminalSession(id).catch((error) => {
+      failTerminateTerminalSession(error instanceof Error ? error.message : String(error));
+    });
+  };
+
+  return (
+    <article
+      className="canvas-panel canvas-panel--shell"
+      style={{
+        left: geometry.x,
+        top: geometry.y,
+        width: geometry.width,
+        height: geometry.height,
+        zIndex: geometry.zIndex,
+      }}
+      onPointerDown={bringToFront}
+      data-canvas-panel
+      aria-label="Shell panel"
+    >
+      <div
+        className="canvas-panel-titlebar"
+        onPointerDown={beginDrag}
+        onPointerMove={updateDrag}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+        data-canvas-blocker
+      >
+        <span className="tenant-beacon is-live" aria-hidden="true" />
+        <span className="canvas-panel-title">Shell</span>
+        <span className="canvas-panel-cli">shell</span>
+        <button
+          type="button"
+          className="canvas-panel-icon-button"
+          onPointerDown={stopButtonPointer}
+          onClick={close}
+          aria-label="Close shell panel"
+          title="Close shell"
+        >
+          <CloseIcon />
+        </button>
+      </div>
+      <div className="canvas-panel-terminal" onPointerDown={stopCanvasPointer} onWheel={stopCanvasWheel} data-canvas-blocker>
+        <Terminal sessionId={id} kind="shell" theaterId={theaterId} onExit={() => removeShellPanel(id)} />
+      </div>
+      <PanelResizeHandles geometry={geometry} zoom={viewport.zoom} onResize={(next) => setShellPanelGeometry(id, next)} />
+    </article>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M4.6 4.6 11.4 11.4M11.4 4.6 4.6 11.4" fill="none" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/runtime/fleet-console/client/src/canvas/shell-panels.ts
+++ b/runtime/fleet-console/client/src/canvas/shell-panels.ts
@@ -14,7 +14,6 @@ const listeners = new Set<Listener>();
 // 메모리 전용 레지스트리 — localStorage 직렬화·canvas-store 영속·prunePanels에 일절 관여하지 않는다.
 // 새로고침하면 모듈이 새로 로드되며 비워지므로 "상태 미유지" 요구가 자연히 충족된다.
 let panels: Record<string, ShellPanelEntry> = {};
-let seq = 0;
 
 export function useShellPanels(): Record<string, ShellPanelEntry> {
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
@@ -25,8 +24,7 @@ export function getShellPanels(): Record<string, ShellPanelEntry> {
 }
 
 export function addShellPanel(theaterId: string, geometry: PanelGeometry): string {
-  seq += 1;
-  const id = `shell:${seq}`;
+  const id = newShellPanelId();
   panels = { ...panels, [id]: { theaterId, geometry } };
   emit();
   return id;
@@ -66,4 +64,14 @@ function getSnapshot(): Record<string, ShellPanelEntry> {
 
 function emit(): void {
   for (const listener of listeners) listener();
+}
+
+// 전역 고유 셸 패널 id. "shell:" prefix는 백엔드 theater-shell 판별을 위해 유지하되, 탭/새로고침 간
+// 충돌을 막도록 무작위 성분을 붙인다 — 다른 브라우저 컨텍스트가 같은 sessionId로 서로의 PTY에
+// 잘못 attach/대체되어 엉뚱한 Theater cwd를 물려받는 것을 방지한다.
+function newShellPanelId(): string {
+  const unique = typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+    ? crypto.randomUUID()
+    : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  return `shell:${unique}`;
 }

--- a/runtime/fleet-console/client/src/canvas/shell-panels.ts
+++ b/runtime/fleet-console/client/src/canvas/shell-panels.ts
@@ -1,0 +1,69 @@
+import { useSyncExternalStore } from "react";
+
+import type { PanelGeometry } from "./canvas-store.js";
+
+export interface ShellPanelEntry {
+  // 이 셸이 띄워진 Theater id. 백엔드 ticket이 이 id로 cwd(Theater 디렉터리)를 해석한다(raw 경로는 클라이언트에 없음).
+  readonly theaterId: string;
+  readonly geometry: PanelGeometry;
+}
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+// 메모리 전용 레지스트리 — localStorage 직렬화·canvas-store 영속·prunePanels에 일절 관여하지 않는다.
+// 새로고침하면 모듈이 새로 로드되며 비워지므로 "상태 미유지" 요구가 자연히 충족된다.
+let panels: Record<string, ShellPanelEntry> = {};
+let seq = 0;
+
+export function useShellPanels(): Record<string, ShellPanelEntry> {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+export function getShellPanels(): Record<string, ShellPanelEntry> {
+  return panels;
+}
+
+export function addShellPanel(theaterId: string, geometry: PanelGeometry): string {
+  seq += 1;
+  const id = `shell:${seq}`;
+  panels = { ...panels, [id]: { theaterId, geometry } };
+  emit();
+  return id;
+}
+
+export function setShellPanelGeometry(id: string, geometry: PanelGeometry): void {
+  const existing = panels[id];
+  if (!existing) return;
+  panels = { ...panels, [id]: { ...existing, geometry } };
+  emit();
+}
+
+export function removeShellPanel(id: string): void {
+  if (!(id in panels)) return;
+  const next = { ...panels };
+  delete next[id];
+  panels = next;
+  emit();
+}
+
+export function clearShellPanels(): void {
+  if (Object.keys(panels).length === 0) return;
+  panels = {};
+  emit();
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): Record<string, ShellPanelEntry> {
+  return panels;
+}
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}

--- a/runtime/fleet-console/client/src/canvas/use-canvas-interaction.ts
+++ b/runtime/fleet-console/client/src/canvas/use-canvas-interaction.ts
@@ -6,7 +6,10 @@ interface CanvasInteractionOptions {
   readonly viewport: CanvasViewport;
   readonly disabled?: boolean;
   readonly consumePointerDown?: boolean;
+  // pan(드래그)은 즉시 적용한다.
   readonly onViewportChange: (viewport: CanvasViewport) => void;
+  // 휠 줌은 보간 경로로 보낸다(스토어 rAF tween).
+  readonly onZoom: (viewport: CanvasViewport) => void;
   readonly onCreate: (rect: CanvasRect, anchor: CanvasPoint) => void;
   readonly onConsumePointerDown?: () => void;
   readonly onClick?: () => void;
@@ -41,7 +44,7 @@ const MIN_CREATE_HEIGHT = 150;
 const CLICK_MOVE_THRESHOLD = 5;
 const ZOOM_STEP = 0.0018;
 
-export function useCanvasInteraction({ viewport, disabled = false, consumePointerDown = false, onViewportChange, onCreate, onConsumePointerDown, onClick }: CanvasInteractionOptions): CanvasInteractionResult {
+export function useCanvasInteraction({ viewport, disabled = false, consumePointerDown = false, onViewportChange, onZoom, onCreate, onConsumePointerDown, onClick }: CanvasInteractionOptions): CanvasInteractionResult {
   const dragRef = useRef<DragState | null>(null);
   const viewportRef = useRef(viewport);
   const [rubberBand, setRubberBand] = useState<CanvasRect | null>(null);
@@ -128,9 +131,10 @@ export function useCanvasInteraction({ viewport, disabled = false, consumePointe
     const screen = eventScreenPoint(event);
     const current = viewportRef.current;
     // 기본 휠 업/다운으로 포인터 위치를 기준점 삼아 줌 인/아웃한다(Ctrl/⌘ 보조키 없이). 맵 이동은 드래그가 담당한다.
+    // 줌 목표는 보간 경로(onZoom)로 보내 스토어 rAF tween이 부드럽게 수렴시킨다(기준점은 현재 viewport 기준으로 계산).
     const zoom = clamp(current.zoom * Math.exp(-event.deltaY * ZOOM_STEP), MIN_ZOOM, MAX_ZOOM);
     const canvas = screenToCanvas(screen, current);
-    onViewportChange({
+    onZoom({
       x: screen.x - canvas.x * zoom,
       y: screen.y - canvas.y * zoom,
       zoom,

--- a/runtime/fleet-console/client/src/components/floating-sidebar.tsx
+++ b/runtime/fleet-console/client/src/components/floating-sidebar.tsx
@@ -62,8 +62,26 @@ export function FloatingSidebar({ state, getViewportSize }: FloatingSidebarProps
     }
   };
 
+  // 접힘: OPERATIONS 패널 전체를 제거하고, 화면 왼쪽에 고정된 펼치기 버튼만 남긴다.
+  if (collapsed) {
+    return (
+      <aside className="floating-sidebar-layer is-collapsed" data-canvas-blocker>
+        <button
+          type="button"
+          className="floating-sidebar-collapsed-toggle"
+          onClick={() => setCollapsed(false)}
+          aria-expanded={false}
+          aria-label="Operations 목록 펼치기"
+          title="Show Operations"
+        >
+          <ExpandListIcon />
+        </button>
+      </aside>
+    );
+  }
+
   return (
-    <aside className={`floating-sidebar-layer ${collapsed ? "is-collapsed" : ""}`} data-canvas-blocker>
+    <aside className="floating-sidebar-layer" data-canvas-blocker>
       <section className="floating-sidebar" aria-label="Floating operations list">
         <div className="floating-sidebar-heading">
           <p className="sidebar-eyebrow">Operations</p>
@@ -72,43 +90,39 @@ export function FloatingSidebar({ state, getViewportSize }: FloatingSidebarProps
             <button
               type="button"
               className="floating-sidebar-toggle"
-              onClick={() => setCollapsed((value) => !value)}
-              aria-expanded={!collapsed}
-              aria-label={collapsed ? "Operations 목록 펼치기" : "Operations 목록 접기"}
+              onClick={() => setCollapsed(true)}
+              aria-expanded={true}
+              aria-label="Operations 목록 접기"
             >
-              {collapsed ? <ExpandListIcon /> : <CollapseListIcon />}
+              <CollapseListIcon />
             </button>
           </div>
         </div>
-        {!collapsed ? (
-          <>
-            {visibleSessionOrder.length > 0 ? (
-              <ol className="floating-session-list">
-                {visibleSessionOrder.map((sessionId) => {
-                  const session = state.sessions[sessionId];
-                  if (!session) return null;
-                  return (
-                    <FloatingSessionEntry
-                      key={sessionId}
-                      session={session}
-                      active={state.activeTerminalSessionId === sessionId}
-                      jobs={sessionJobs(state, session)}
-                      selectedJobId={state.selectedJobId}
-                      onFocus={focusSession}
-                    />
-                  );
-                })}
-              </ol>
-            ) : null}
-            {state.terminalSessionError ? <p className="sidebar-error">{state.terminalSessionError}</p> : null}
-            {visibleSessionOrder.length === 0 ? (
-              <p className="sidebar-empty">
-                {state.activeTheaterId ? "No operations in this Theater." : "No Theaters registered."}
-                <br />
-                {state.activeTheaterId ? "Drag on the canvas or use +." : "Add a Theater from the top bar."}
-              </p>
-            ) : null}
-          </>
+        {visibleSessionOrder.length > 0 ? (
+          <ol className="floating-session-list">
+            {visibleSessionOrder.map((sessionId) => {
+              const session = state.sessions[sessionId];
+              if (!session) return null;
+              return (
+                <FloatingSessionEntry
+                  key={sessionId}
+                  session={session}
+                  active={state.activeTerminalSessionId === sessionId}
+                  jobs={sessionJobs(state, session)}
+                  selectedJobId={state.selectedJobId}
+                  onFocus={focusSession}
+                />
+              );
+            })}
+          </ol>
+        ) : null}
+        {state.terminalSessionError ? <p className="sidebar-error">{state.terminalSessionError}</p> : null}
+        {visibleSessionOrder.length === 0 ? (
+          <p className="sidebar-empty">
+            {state.activeTheaterId ? "No operations in this Theater." : "No Theaters registered."}
+            <br />
+            {state.activeTheaterId ? "Drag on the canvas or use +." : "Add a Theater from the top bar."}
+          </p>
         ) : null}
       </section>
     </aside>

--- a/runtime/fleet-console/client/src/components/floating-sidebar.tsx
+++ b/runtime/fleet-console/client/src/components/floating-sidebar.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 
 import { createTheaterTerminalSession, renameTerminalSession, resumeTerminalSession, terminateTerminalSession } from "../api.js";
-import { ensureDefaultGeometry, focusPanel } from "../canvas/canvas-store.js";
+import { ensureDefaultGeometry, focusPanel, useMaximized } from "../canvas/canvas-store.js";
 import { OperationLaunchMenu } from "./operation-launch-menu.js";
 import { describeJobStatus, formatCarrierName, sessionDisplayLabel, shortJobId, statusTone } from "../format.js";
 import { isTerminalJobStatus } from "../reduce.js";
@@ -29,7 +29,13 @@ interface FloatingJobEntryProps {
 
 export function FloatingSidebar({ state, getViewportSize }: FloatingSidebarProps) {
   const [collapsed, setCollapsed] = useState(false);
+  const maximized = useMaximized();
   const visibleSessionOrder = theaterSessionOrder(state);
+
+  // 맵 최대화(전체화면) 시 Operations 패널을 자동으로 접고, 해제하면 다시 펼친다.
+  useEffect(() => {
+    setCollapsed(maximized);
+  }, [maximized]);
 
   const focusSession = async (sessionId: string) => {
     const session = state.sessions[sessionId];

--- a/runtime/fleet-console/client/src/components/operation-launch-menu.tsx
+++ b/runtime/fleet-console/client/src/components/operation-launch-menu.tsx
@@ -140,7 +140,7 @@ function PlusIcon() {
   );
 }
 
-function agentCliIcon(id: string) {
+export function agentCliIcon(id: string) {
   // Agent CLI별로 시각 구별 마크를 부여한다: Claude=스파크, Claude Kimi=초승달, Codex=꺾쇠.
   if (id === "claude") return <ClaudeMarkIcon />;
   if (id === "claude-kimi") return <ClaudeKimiMarkIcon />;

--- a/runtime/fleet-console/client/src/components/terminal.tsx
+++ b/runtime/fleet-console/client/src/components/terminal.tsx
@@ -13,6 +13,8 @@ import type { ThemeId } from "../types.js";
 interface TerminalProps {
   readonly sessionId: string;
   readonly kind?: "shell";
+  // theater-shell 패널에서만 지정 — Theater cwd 셸 ticket 발급에 쓰인다.
+  readonly theaterId?: string;
   readonly onExit?: () => void;
   // 이 터미널이 활성(선택)으로 전환될 때 마우스 클릭 없이 키보드 포커스를 잡아준다(Map 검색 이동 등).
   readonly active?: boolean;
@@ -78,7 +80,7 @@ const CARBON_TERMINAL_THEME: ITheme = {
   brightWhite: "oklch(95% 0.003 250)",
 };
 
-export function Terminal({ sessionId, kind, onExit, active }: TerminalProps) {
+export function Terminal({ sessionId, kind, theaterId, onExit, active }: TerminalProps) {
   const { activeTheme, terminalRenderer } = useConsoleState();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const terminalRef = useRef<XtermTerminal | null>(null);
@@ -121,6 +123,7 @@ export function Terminal({ sessionId, kind, onExit, active }: TerminalProps) {
     const connection = createTerminalConnection({
       sessionId,
       kind,
+      theaterId,
       terminal,
       onExit: () => onExitRef.current?.(),
       onStatus: (nextStatus, message) => {
@@ -181,7 +184,7 @@ export function Terminal({ sessionId, kind, onExit, active }: TerminalProps) {
         // xterm 내부 dispose 버그(위 주석)를 흡수한다.
       }
     };
-  }, [kind, sessionId]);
+  }, [kind, sessionId, theaterId]);
 
   // 활성 전환 시(예: Map 검색으로 이동·확대된 직후) 이미 마운트된 xterm에 포커스를 다시 줘
   // 마우스 클릭 없이 바로 입력되게 한다. 비활성 전환에서는 아무 것도 하지 않는다.

--- a/runtime/fleet-console/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/client/src/pages/operations.tsx
@@ -8,7 +8,7 @@ import { FloatingJobOverlay } from "../components/floating-job-overlay.js";
 import { FloatingSidebar } from "../components/floating-sidebar.js";
 import { useOperationsMode } from "../operations-mode.js";
 import { OperationsClassic } from "./operations-classic.js";
-import { applySessionUpdate, consumeOperationFocus, failResumeTerminalSession, selectTerminalSession, theaterSessionOrder } from "../store.js";
+import { applySessionUpdate, consumeOperationFocus, failResumeTerminalSession, focusOperation, nextOperationId, selectTerminalSession, theaterSessionOrder } from "../store.js";
 import type { ConsoleState } from "../types.js";
 
 interface OperationsProps {
@@ -19,12 +19,34 @@ export function Operations({ state }: OperationsProps) {
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const mode = useOperationsMode();
   const sessionOrder = theaterSessionOrder(state);
+  // 최신 state를 keydown 핸들러에서 읽기 위한 ref(핸들러는 한 번만 등록).
+  const stateRef = useRef(state);
+  stateRef.current = state;
 
   useEffect(() => {
     loadForTheater(state.activeTheaterId);
     // Theater가 바뀌면 이전 Theater cwd에 묶인 ephemeral 셸 패널을 비운다(언마운트 → 백엔드 grace 정리).
     clearShellPanels();
   }, [state.activeTheaterId]);
+
+  // Alt+←/→ 로 현재 Theater 내 Operation 포커스를 순환 이동한다(Map=resume+확대, Helm=선택). 두 모드 공통.
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (!event.altKey || event.metaKey || event.ctrlKey) return;
+      if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+      // rename/검색 등 일반 입력 중에는 양보한다. 단, 터미널(xterm) 포커스 중에는 패널 전환을 허용한다.
+      const active = document.activeElement;
+      if (active instanceof HTMLElement && active.matches("input, textarea, [contenteditable='true']") && !active.closest(".xterm")) return;
+      const order = theaterSessionOrder(stateRef.current);
+      if (order.length === 0) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      const nextId = nextOperationId(order, stateRef.current.activeTerminalSessionId, event.key === "ArrowRight" ? 1 : -1);
+      if (nextId) focusOperation(nextId);
+    };
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, []);
 
   useEffect(() => {
     for (const sessionId of sessionOrder) ensureDefaultGeometry(sessionId);

--- a/runtime/fleet-console/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/client/src/pages/operations.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 
 import { OperationsCanvas } from "../canvas/canvas.js";
 import { ensureDefaultGeometry, focusPanel, loadForTheater, prunePanels } from "../canvas/canvas-store.js";
+import { clearShellPanels } from "../canvas/shell-panels.js";
 import { resumeTerminalSession } from "../api.js";
 import { FloatingJobOverlay } from "../components/floating-job-overlay.js";
 import { FloatingSidebar } from "../components/floating-sidebar.js";
@@ -21,6 +22,8 @@ export function Operations({ state }: OperationsProps) {
 
   useEffect(() => {
     loadForTheater(state.activeTheaterId);
+    // Theater가 바뀌면 이전 Theater cwd에 묶인 ephemeral 셸 패널을 비운다(언마운트 → 백엔드 grace 정리).
+    clearShellPanels();
   }, [state.activeTheaterId]);
 
   useEffect(() => {

--- a/runtime/fleet-console/client/src/shortcuts-catalog.ts
+++ b/runtime/fleet-console/client/src/shortcuts-catalog.ts
@@ -29,10 +29,13 @@ export const SHORTCUT_GROUPS: readonly ShortcutGroup[] = [
   {
     title: "Map",
     entries: [
+      { combos: [["Alt", "←"], ["Alt", "→"]], description: "Focus the previous / next Operation (also in Helm)" },
       { combos: [["Drag"]], description: "Pan the operations map" },
       { combos: [["Shift", "Drag"]], description: "Draw a new Operation terminal" },
       { combos: [["Space", "Drag"]], description: "Pan even while a terminal has focus" },
       { combos: [["Scroll"]], description: "Zoom the map in or out" },
+      { combos: [["Right-click"]], description: "Open the canvas actions menu" },
+      { combos: [["Double-click"]], description: "Focus a panel from its title bar; rename from its name" },
       { combos: [["Click"]], description: "Clear terminal focus on the empty canvas" },
     ],
   },

--- a/runtime/fleet-console/client/src/store.ts
+++ b/runtime/fleet-console/client/src/store.ts
@@ -210,6 +210,17 @@ export function consumeOperationFocus(): void {
   setState({ pendingOperationFocus: null });
 }
 
+// 포커스 순환(Alt+←/→)용 다음 Operation id 계산. delta>0=다음, delta<0=이전. 끝에서 순환(wrap)한다.
+// 현재 선택이 목록에 없으면(또는 null) delta 방향에 따라 첫/마지막 항목을 고른다.
+export function nextOperationId(order: readonly string[], currentId: string | null, delta: number): string | null {
+  if (order.length === 0) return null;
+  const current = currentId ? order.indexOf(currentId) : -1;
+  const nextIndex = current === -1
+    ? (delta > 0 ? 0 : order.length - 1)
+    : (current + delta + order.length) % order.length;
+  return order[nextIndex] ?? null;
+}
+
 export function openOperationSearch(): void {
   setState({ operationSearchOpen: true });
 }

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -1306,47 +1306,106 @@
   color: var(--ink-fog);
 }
 
-/* 우하단 캔버스 미니맵 — 패널 분포와 현재 뷰포트 위치를 한눈에 보여주고, 드래그로 이동한다. */
+/* 우하단 캔버스 미니맵 — 해군 레이더 스코프. 심해 글래스 위에 동심 링/그리드 텍스처를 깔고
+   현재 뷰포트를 발광 브래스 렌즈로 표시한다(브래스="보는 곳", 아우로라="살아있는 셸"). */
 .canvas-minimap {
   position: absolute;
   right: var(--space-4);
   bottom: var(--space-4);
   z-index: 14;
-  border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-md);
-  background: color-mix(in oklch, var(--surface-glass) 82%, var(--ink-deep));
-  box-shadow: var(--shadow-anchor);
-  backdrop-filter: blur(18px) saturate(140%);
-  -webkit-backdrop-filter: blur(18px) saturate(140%);
+  border: 1px solid color-mix(in oklch, var(--brass) 30%, var(--surface-rim));
+  border-radius: var(--radius-lg);
+  background:
+    radial-gradient(130% 100% at 50% 0%, color-mix(in oklch, var(--brass) 9%, transparent), transparent 62%),
+    color-mix(in oklch, var(--surface-glass) 60%, color-mix(in oklch, var(--ink-deep) 72%, transparent));
+  box-shadow:
+    var(--shadow-floating),
+    inset 0 1px 0 color-mix(in oklch, var(--brass) 24%, transparent);
+  backdrop-filter: blur(22px) saturate(150%);
+  -webkit-backdrop-filter: blur(22px) saturate(150%);
   overflow: hidden;
+  animation: codex-rise 520ms var(--ease-spring) both;
+}
+
+/* 계기 캡션 — JetBrains Mono 대문자 트래킹. */
+.canvas-minimap-label {
+  position: absolute;
+  top: 7px;
+  left: 12px;
+  z-index: 3;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: color-mix(in oklch, var(--brass-bright) 78%, var(--ink-fog));
+  pointer-events: none;
 }
 
 .canvas-minimap-inner {
   position: absolute;
+  border-radius: var(--radius-md);
+  overflow: hidden;
   cursor: crosshair;
   touch-action: none;
+  background:
+    radial-gradient(ellipse at 50% 48%, color-mix(in oklch, var(--ink-deep) 50%, transparent), transparent 72%),
+    linear-gradient(150deg, color-mix(in oklch, var(--ink-deep) 38%, transparent), transparent 70%);
 }
 
-/* Operation 패널 마커 — 중립 톤(브래스/아우로라 역할과 섞지 않는다). */
+/* 동심 레이더 링(구조 장식=브래스). */
+.canvas-minimap-inner::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-radial-gradient(
+    circle at 50% 50%,
+    transparent 0 15px,
+    color-mix(in oklch, var(--brass) 11%, transparent) 15px 16px
+  );
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+/* 미세 그리드 점 — 캔버스 그리드와 동일 언어(아우로라). */
+.canvas-minimap-inner::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle, color-mix(in oklch, var(--aurora) 16%, transparent) 0.5px, transparent 1px);
+  background-size: 13px 13px;
+  opacity: 0.32;
+  pointer-events: none;
+}
+
+/* Operation 패널 블립 — 중립 진주 톤 글래스(브래스/아우로라 역할과 섞지 않는다). */
 .canvas-minimap-panel {
   position: absolute;
-  border-radius: 2px;
-  background: color-mix(in oklch, var(--ink-fog) 30%, transparent);
-  border: 1px solid color-mix(in oklch, var(--ink-fog) 52%, transparent);
+  z-index: 1;
+  border-radius: 3px;
+  background: color-mix(in oklch, var(--ink-pearl) 16%, transparent);
+  border: 1px solid color-mix(in oklch, var(--ink-pearl) 40%, transparent);
+  box-shadow: 0 0 7px color-mix(in oklch, var(--ink-rim) 45%, transparent);
 }
 
-/* 순정 셸 패널 마커 — '살아있는 것' 아우로라. */
+/* 순정 셸 블립 — '살아있는 것' 아우로라 발광. */
 .canvas-minimap-panel.is-shell {
-  background: color-mix(in oklch, var(--aurora) 26%, transparent);
-  border-color: color-mix(in oklch, var(--aurora) 52%, transparent);
+  background: color-mix(in oklch, var(--aurora) 22%, transparent);
+  border-color: color-mix(in oklch, var(--aurora) 58%, transparent);
+  box-shadow: 0 0 9px color-mix(in oklch, var(--aurora) 38%, transparent);
 }
 
-/* 현재 뷰포트 인디케이터 — '지금 보고 있는 곳' 브래스. */
+/* 현재 뷰포트 렌즈 — '지금 보고 있는 곳' 발광 브래스 스코프. */
 .canvas-minimap-view {
   position: absolute;
-  border: 1px solid color-mix(in oklch, var(--brass-bright) 72%, transparent);
-  border-radius: 2px;
-  background: color-mix(in oklch, var(--brass) 10%, transparent);
+  z-index: 2;
+  border: 1.5px solid color-mix(in oklch, var(--brass-bright) 80%, transparent);
+  border-radius: 3px;
+  background: color-mix(in oklch, var(--brass) 13%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in oklch, var(--brass) 22%, transparent),
+    0 0 14px color-mix(in oklch, var(--brass) 32%, transparent),
+    inset 0 0 12px color-mix(in oklch, var(--brass) 18%, transparent);
   pointer-events: none;
 }
 

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -1306,6 +1306,50 @@
   color: var(--ink-fog);
 }
 
+/* 우하단 캔버스 미니맵 — 패널 분포와 현재 뷰포트 위치를 한눈에 보여주고, 드래그로 이동한다. */
+.canvas-minimap {
+  position: absolute;
+  right: var(--space-4);
+  bottom: var(--space-4);
+  z-index: 14;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--surface-glass) 82%, var(--ink-deep));
+  box-shadow: var(--shadow-anchor);
+  backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+  overflow: hidden;
+}
+
+.canvas-minimap-inner {
+  position: absolute;
+  cursor: crosshair;
+  touch-action: none;
+}
+
+/* Operation 패널 마커 — 중립 톤(브래스/아우로라 역할과 섞지 않는다). */
+.canvas-minimap-panel {
+  position: absolute;
+  border-radius: 2px;
+  background: color-mix(in oklch, var(--ink-fog) 30%, transparent);
+  border: 1px solid color-mix(in oklch, var(--ink-fog) 52%, transparent);
+}
+
+/* 순정 셸 패널 마커 — '살아있는 것' 아우로라. */
+.canvas-minimap-panel.is-shell {
+  background: color-mix(in oklch, var(--aurora) 26%, transparent);
+  border-color: color-mix(in oklch, var(--aurora) 52%, transparent);
+}
+
+/* 현재 뷰포트 인디케이터 — '지금 보고 있는 곳' 브래스. */
+.canvas-minimap-view {
+  position: absolute;
+  border: 1px solid color-mix(in oklch, var(--brass-bright) 72%, transparent);
+  border-radius: 2px;
+  background: color-mix(in oklch, var(--brass) 10%, transparent);
+  pointer-events: none;
+}
+
 @keyframes radar-sweep {
   from {
     transform: translate(-50%, -50%) rotate(0deg);
@@ -1386,6 +1430,37 @@
   font-weight: 700;
   text-overflow: ellipsis;
   white-space: nowrap;
+  /* 이름 영역은 더블클릭 rename 대상 — 텍스트 커서로 드래그(grab)되는 띠바 영역과 시각적으로 구분한다. */
+  cursor: text;
+  padding: 2px 4px;
+  margin: 0 -2px;
+  border-radius: var(--radius-xs);
+}
+
+.canvas-panel-title:hover {
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
+}
+
+/* 패널 이름 인라인 변경 입력 — Operations 사이드바 rename 입력과 같은 brass 포커스 언어를 띠바 폭에 맞춘다. */
+.canvas-panel-rename-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 4px 7px;
+  border: 1px solid color-mix(in oklch, var(--brass) 44%, var(--surface-rim));
+  border-radius: var(--radius-xs);
+  background: color-mix(in oklch, var(--ink-deep) 84%, var(--surface-glass));
+  color: var(--ink-pearl);
+  font: inherit;
+  font-weight: 700;
+  outline: none;
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass) 12%, transparent);
+}
+
+.canvas-panel-rename-input:focus {
+  border-color: color-mix(in oklch, var(--brass) 68%, var(--surface-rim));
+  box-shadow:
+    inset 0 0 0 1px color-mix(in oklch, var(--brass) 20%, transparent),
+    0 0 0 2px color-mix(in oklch, var(--brass) 18%, transparent);
 }
 
 .canvas-panel-cli,

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -1409,6 +1409,155 @@
   pointer-events: none;
 }
 
+/* 좌하단 Map 단축키 도움 — 레이더 계기와 같은 심해 글래스 카드. 접으면 '?' FAB만 남는다. */
+.map-shortcuts {
+  position: absolute;
+  left: var(--space-4);
+  bottom: var(--space-4);
+  z-index: 13;
+  width: 250px;
+  max-height: min(56%, 380px);
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-3);
+  border: 1px solid color-mix(in oklch, var(--brass) 26%, var(--surface-rim));
+  border-radius: var(--radius-lg);
+  background:
+    radial-gradient(120% 90% at 0% 100%, color-mix(in oklch, var(--brass) 8%, transparent), transparent 60%),
+    color-mix(in oklch, var(--surface-glass) 62%, color-mix(in oklch, var(--ink-deep) 70%, transparent));
+  box-shadow:
+    var(--shadow-floating),
+    inset 0 1px 0 color-mix(in oklch, var(--brass) 22%, transparent);
+  backdrop-filter: blur(22px) saturate(150%);
+  -webkit-backdrop-filter: blur(22px) saturate(150%);
+  animation: codex-rise 520ms var(--ease-spring) both;
+}
+
+.map-shortcuts-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.map-shortcuts-label {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: color-mix(in oklch, var(--brass-bright) 78%, var(--ink-fog));
+}
+
+.map-shortcuts-toggle,
+.map-shortcuts-fab {
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--surface-glass) 78%, var(--ink-deep));
+  color: var(--brass);
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring);
+}
+
+.map-shortcuts-toggle {
+  width: 24px;
+  height: 24px;
+}
+
+.map-shortcuts-toggle:hover,
+.map-shortcuts-toggle:focus-visible,
+.map-shortcuts-fab:hover,
+.map-shortcuts-fab:focus-visible {
+  color: var(--brass-bright);
+  border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
+  background: color-mix(in oklch, var(--brass) 11%, var(--surface-glass));
+}
+
+.map-shortcuts-fab {
+  position: absolute;
+  left: var(--space-4);
+  bottom: var(--space-4);
+  z-index: 13;
+  width: 36px;
+  height: 36px;
+  box-shadow: var(--shadow-anchor);
+  backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+  animation: codex-rise 420ms var(--ease-spring) both;
+}
+
+.map-shortcuts-toggle svg {
+  display: block;
+  width: 14px;
+  height: 14px;
+}
+
+.map-shortcuts-fab svg {
+  display: block;
+  width: 18px;
+  height: 18px;
+}
+
+.map-shortcuts-list {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.map-shortcuts-entry {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.map-shortcuts-combos {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  flex-wrap: wrap;
+}
+
+.map-shortcuts-or {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--ink-fog);
+}
+
+.map-shortcuts-keyset {
+  display: inline-flex;
+  gap: 3px;
+}
+
+.map-shortcuts kbd {
+  display: inline-block;
+  min-width: 16px;
+  padding: 1px 5px;
+  border: 1px solid color-mix(in oklch, var(--brass) 34%, var(--surface-rim));
+  border-radius: var(--radius-xs);
+  background: color-mix(in oklch, var(--ink-deep) 70%, var(--surface-glass));
+  color: color-mix(in oklch, var(--brass-bright) 72%, var(--ink-pearl));
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.map-shortcuts-entry dd {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.35;
+  color: var(--ink-fog);
+}
+
 @keyframes radar-sweep {
   from {
     transform: translate(-50%, -50%) rotate(0deg);

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -1285,6 +1285,27 @@
   height: 19px;
 }
 
+/* 맵 최대화 토글 — 레이더(배경 애니메이션) 토글 바로 왼쪽에 같은 칩 스타일로 배치한다. */
+.canvas-maximize-toggle {
+  right: calc(var(--space-4) + 36px + var(--space-2));
+}
+
+/* 순정 셸 패널 — Operation과 구별되도록 띠바에 아우로라(살아있는 것) 톤의 옅은 강조를 준다. */
+.canvas-panel--shell .canvas-panel-titlebar {
+  background: color-mix(in oklch, var(--aurora) 9%, color-mix(in oklch, var(--ink-deep) 28%, transparent));
+}
+
+/* 우클릭 캔버스 컨텍스트 메뉴의 그룹(섹션) 라벨. */
+.canvas-context-menu-group {
+  margin: 0;
+  padding: var(--space-2) var(--space-2) var(--space-1);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-fog);
+}
+
 @keyframes radar-sweep {
   from {
     transform: translate(-50%, -50%) rotate(0deg);
@@ -1324,11 +1345,11 @@
     0 0 0 1px color-mix(in oklch, var(--brass) 18%, transparent);
 }
 
-/* 진행 중 캐리어 스트림을 패널 바깥 위에 floating으로 띄우는 dock. left/top/width는 패널 geometry를
-   인라인으로 받고, translateY로 자기 높이만큼 위로 올려 터미널을 가리지 않게 패널 상단 위에 정렬한다. */
+/* 진행 중 캐리어 스트림을 패널 바깥 아래에 floating으로 띄우는 dock. left/top/width는 패널 geometry를
+   인라인으로 받고(top=패널 하단 모서리), translateY로 작은 간격만큼 아래로 내려 패널 하단에 정렬한다. */
 .canvas-panel-jobdock {
   position: absolute;
-  transform: translateY(calc(-100% - var(--space-2)));
+  transform: translateY(var(--space-2));
   box-sizing: border-box;
   max-height: 40vh;
   overflow-y: auto;
@@ -1633,9 +1654,44 @@
   animation: codex-rise 520ms var(--ease-spring) both;
 }
 
+/* 접힘: OPERATIONS 패널은 렌더되지 않고, 화면 왼쪽 세로 중앙에 펼치기 버튼만 떠 있는다. */
 .floating-sidebar-layer.is-collapsed {
   width: auto;
-  bottom: auto;
+  display: flex;
+  align-items: center;
+}
+
+.floating-sidebar-collapsed-toggle {
+  pointer-events: auto;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 46px;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--surface-glass) 88%, var(--ink-deep));
+  color: var(--brass);
+  box-shadow: var(--shadow-floating);
+  backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+  animation: codex-rise 520ms var(--ease-spring) both;
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring);
+}
+
+.floating-sidebar-collapsed-toggle:hover,
+.floating-sidebar-collapsed-toggle:focus-visible {
+  color: var(--brass-bright);
+  border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
+  background: color-mix(in oklch, var(--brass) 11%, var(--surface-glass));
+}
+
+.floating-sidebar-collapsed-toggle svg {
+  display: block;
+  width: 16px;
+  height: 16px;
 }
 
 .floating-sidebar-heading {

--- a/runtime/fleet-console/client/src/styles/layout.css
+++ b/runtime/fleet-console/client/src/styles/layout.css
@@ -4,6 +4,27 @@
   height: 100%;
   padding: var(--space-4);
   gap: var(--space-4);
+  transition:
+    grid-template-rows var(--duration-slow) var(--ease-spring),
+    gap var(--duration-slow) var(--ease-spring),
+    padding var(--duration-slow) var(--ease-spring);
+}
+
+/* 맵 최대화: GNB(topbar) 행을 0으로 접고 셸 여백을 없애 캔버스를 전체로 채운다(app.tsx가 Map canvas 화면에서만 부여). */
+.console-shell.is-maximized {
+  grid-template-rows: 0 minmax(0, 1fr);
+  gap: 0;
+  padding: 0;
+}
+
+.console-shell.is-maximized .topbar {
+  /* codex-rise 첫-페인트 애니메이션이 both fill로 opacity/transform 끝상태를 잡고 있어
+     이를 해제해야 아래 fade+slide가 .topbar transition을 타고 적용된다. */
+  animation: none;
+  opacity: 0;
+  transform: translateY(-12px);
+  pointer-events: none;
+  overflow: hidden;
 }
 
 .console-body {
@@ -122,6 +143,9 @@
 
 .topbar {
   animation-delay: 40ms;
+  transition:
+    opacity var(--duration-base) ease,
+    transform var(--duration-slow) var(--ease-spring);
 }
 
 .operations-sidebar {

--- a/runtime/fleet-console/client/src/terminal-connection.ts
+++ b/runtime/fleet-console/client/src/terminal-connection.ts
@@ -8,6 +8,8 @@ export interface TerminalLike {
 export interface TerminalConnectionOptions {
   readonly sessionId: string;
   readonly kind?: "shell";
+  // theater-shell 패널의 ticket 발급에 쓰인다 — 서버가 이 id로 Theater cwd를 해석한다.
+  readonly theaterId?: string;
   readonly terminal: TerminalLike;
   readonly onStatus?: (status: TerminalConnectionStatus, message?: string) => void;
   // 서버가 세션을 종료(PTY exit 등)해 재연결이 의미 없을 때 호출된다.
@@ -73,7 +75,7 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
       options.onStatus?.("connecting");
       try {
         const fetchTicket = options.fetchTicket ?? requestTerminalTicket;
-        const { ticket } = await fetchTicket(options.sessionId, { kind: options.kind, signal: abort.signal });
+        const { ticket } = await fetchTicket(options.sessionId, { kind: options.kind, theaterId: options.theaterId, signal: abort.signal });
         if (abort.signal.aborted) return;
         await attachSocket(buildTerminalWsUrl(ticket, options.location), options);
         reconnectDelay = INITIAL_RECONNECT_DELAY_MS;

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -78,6 +78,8 @@ const DEFAULT_HOST = "127.0.0.1";
 // start()에서 srv.address()의 actualPort로 캡처해 락 파일에 기록한다.
 const DEFAULT_PORT = 0;
 const SHELL_TERMINAL_SESSION_ID = "shell";
+// 캔버스의 순정 셸 패널 세션 id 접두사. 이 접두사 + theaterId가 함께 오면 Theater 디렉터리에서 셸을 띄운다.
+const THEATER_SHELL_SESSION_PREFIX = "shell:";
 const SERVER_TIMEOUT_MS = 30 * 60 * 1000;
 const MAX_BODY_BYTES = 1024 * 1024;
 
@@ -299,19 +301,34 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       writeJson(res, 401, { error: "Unauthorized" });
       return;
     }
-    const body = await readJsonBody<{ readonly sessionId?: string; readonly kind?: string }>(req);
+    const body = await readJsonBody<{ readonly sessionId?: string; readonly kind?: string; readonly theaterId?: string }>(req);
     const kind = body?.kind === "shell" ? "shell" : "fleet";
     const requestedSessionId = body?.sessionId;
+    const requestedTheaterId = typeof body?.theaterId === "string" ? body.theaterId : undefined;
     let sessionId: string;
+    let cwd: string | null;
     if (kind === "shell") {
-      sessionId = SHELL_TERMINAL_SESSION_ID;
+      if (typeof requestedSessionId === "string" && requestedSessionId.startsWith(THEATER_SHELL_SESSION_PREFIX) && requestedTheaterId) {
+        // theater-shell: 캔버스 순정 셸 패널. theaterId로 Theater 디렉터리를 서버 측에서만 해석한다(raw 경로 비노출).
+        const theater = theaters.get(requestedTheaterId);
+        if (!theater) {
+          writeJson(res, 404, { error: "theater_not_found" });
+          return;
+        }
+        sessionId = requestedSessionId;
+        cwd = theater.path;
+      } else {
+        // 싱글톤 셸 오버레이(Cmd+`) — 기존 계약 보존: 고정 sessionId + 빈 cwd(서버 cwd 폴백).
+        sessionId = SHELL_TERMINAL_SESSION_ID;
+        cwd = "";
+      }
     } else if (typeof requestedSessionId === "string" && requestedSessionId.length > 0) {
       sessionId = requestedSessionId;
+      cwd = observability.getLaunchCwd(sessionId);
     } else {
       writeJson(res, 400, { error: "terminal_session_not_found" });
       return;
     }
-    const cwd = kind === "shell" ? "" : observability.getLaunchCwd(sessionId);
     if (cwd === null) {
       writeJson(res, 404, { error: "terminal_session_not_found" });
       return;

--- a/runtime/fleet-console/src/terminal/session-manager.ts
+++ b/runtime/fleet-console/src/terminal/session-manager.ts
@@ -24,6 +24,8 @@ interface TerminalSession {
   activeSocket: TerminalSocket | null;
   cols: number;
   rows: number;
+  // theater-shell(캔버스 순정 셸) 전용: 소켓 단절 후 PTY 정리까지의 grace 타이머. 재연결 시 취소된다.
+  graceTimer: ReturnType<typeof setTimeout> | null;
 }
 
 interface KillSessionOptions {
@@ -35,6 +37,10 @@ const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
 const DEFAULT_SCROLLBACK_LIMIT = 512;
 const WS_OPEN_STATE = 1;
+// 캔버스 순정 셸 패널 세션 id 접두사(싱글톤 오버레이 "shell"과 구별).
+const THEATER_SHELL_SESSION_PREFIX = "shell:";
+// theater-shell 소켓 단절 후 PTY를 정리하기까지의 유예(일시적 WS 끊김 재연결을 흡수).
+const THEATER_SHELL_DETACH_GRACE_MS = 4_000;
 
 export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): TerminalSessionManager {
   const startShell = deps.startShell ?? startTerminalShell;
@@ -49,6 +55,8 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
 
   async function attach(socket: TerminalSocket, context: TerminalTicketContext): Promise<void> {
     const session = await getOrCreateSession(context);
+    // (재)연결이 들어오면 theater-shell 정리 grace 타이머를 취소한다.
+    clearGraceTimer(session);
     if (session.activeSocket && session.activeSocket !== socket) {
       session.activeSocket.close(4000, "terminal_replaced");
     }
@@ -138,6 +146,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
       activeSocket: null,
       cols: DEFAULT_COLS,
       rows: DEFAULT_ROWS,
+      graceTimer: null,
     };
     const dataDisposable = pty.onData((data) => handlePtyData(session, data));
     // 자연종료 후에도 node-pty agent.kill() 경로를 한 번 지나 conout/inSocket 정리를 시도한다.
@@ -183,6 +192,15 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     // 죽은 소켓으로의 전송을 막고, 출력은 scrollback에 계속 쌓여 재연결 시 attach가 그대로 재생한다.
     // PTY는 오직 PTY 자가종료·운영자 terminate·서버 stop에서만 죽는다(자동 종료 grace 타이머는 제거됨).
     session.activeSocket = null;
+    // 예외: theater-shell(캔버스 순정 셸)은 "상태 미유지" 요구에 따라 소켓 단절 후 짧은 grace 뒤 PTY를 정리한다.
+    // 패널 닫기·새로고침이 이 경로로 흘러 orphan PTY를 막는다. 재연결이 들어오면 attach가 타이머를 취소한다.
+    if (isTheaterShell(session.id)) {
+      clearGraceTimer(session);
+      session.graceTimer = setTimeout(() => {
+        session.graceTimer = null;
+        if (session.activeSocket === null) removeSession(session);
+      }, THEATER_SHELL_DETACH_GRACE_MS);
+    }
   }
 
   function replayScrollback(session: TerminalSession, socket: TerminalSocket): void {
@@ -202,6 +220,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
 
   async function killSession(session: TerminalSession, options: KillSessionOptions = {}): Promise<void> {
     const killPty = options.killPty ?? true;
+    clearGraceTimer(session);
     session.activeSocket?.close(4001, "terminal_closed");
     session.activeSocket = null;
     for (const disposable of session.disposables) disposable.dispose();
@@ -229,6 +248,16 @@ function killPtyBestEffort(pty: TerminalPtyHandle): void {
   } catch {
     // Teardown-only cleanup: kill failures must not block session exit or launch cleanup.
   }
+}
+
+function isTheaterShell(sessionId: string): boolean {
+  return sessionId.startsWith(THEATER_SHELL_SESSION_PREFIX);
+}
+
+function clearGraceTimer(session: TerminalSession): void {
+  if (session.graceTimer === null) return;
+  clearTimeout(session.graceTimer);
+  session.graceTimer = null;
 }
 
 function toBuffer(data: TerminalSocketData): Buffer {

--- a/runtime/fleet-console/tests/operation-focus.test.ts
+++ b/runtime/fleet-console/tests/operation-focus.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { nextOperationId } from "../client/src/store.js";
+
+describe("nextOperationId — Alt+←/→ focus cycle", () => {
+  const order = ["a", "b", "c"];
+
+  it("moves to the next operation, wrapping past the end", () => {
+    expect(nextOperationId(order, "a", 1)).toBe("b");
+    expect(nextOperationId(order, "b", 1)).toBe("c");
+    expect(nextOperationId(order, "c", 1)).toBe("a");
+  });
+
+  it("moves to the previous operation, wrapping past the start", () => {
+    expect(nextOperationId(order, "c", -1)).toBe("b");
+    expect(nextOperationId(order, "b", -1)).toBe("a");
+    expect(nextOperationId(order, "a", -1)).toBe("c");
+  });
+
+  it("starts from an edge when nothing (or an unknown id) is active", () => {
+    expect(nextOperationId(order, null, 1)).toBe("a");
+    expect(nextOperationId(order, null, -1)).toBe("c");
+    expect(nextOperationId(order, "missing", 1)).toBe("a");
+  });
+
+  it("stays on the only operation and returns null when there are none", () => {
+    expect(nextOperationId(["solo"], "solo", 1)).toBe("solo");
+    expect(nextOperationId(["solo"], "solo", -1)).toBe("solo");
+    expect(nextOperationId([], "a", 1)).toBeNull();
+  });
+});

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -400,6 +400,37 @@ describe("console static and terminal ticket boundary", () => {
     expect(shellBody.cwd).toBeUndefined();
   });
 
+  it("issues theater-shell tickets resolving Theater cwd server-side and rejects unknown Theaters", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-theater-shell-"));
+    tempDirs.push(dir);
+    const fixture = await startFixture({
+      terminalPickFolder: async () => ({ kind: "selected", cwd: dir }),
+      terminalStartShell: () => createMockPty(),
+    });
+    const theater = await (await fetch(`${fixture.endpoint}observer/theaters`, { method: "POST" })).json() as { readonly id: string };
+
+    const issued = await fetch(`${fixture.endpoint}terminal/ticket`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sessionId: "shell:1", kind: "shell", theaterId: theater.id }),
+    });
+    const issuedBody = await issued.json() as { readonly ticket?: unknown; readonly cwd?: unknown };
+
+    const unknownTheater = await fetch(`${fixture.endpoint}terminal/ticket`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sessionId: "shell:2", kind: "shell", theaterId: "deadbeefdead" }),
+    });
+    const unknownBody = await unknownTheater.json();
+
+    expect(issued.status).toBe(200);
+    expect(typeof issuedBody.ticket).toBe("string");
+    // theater-shell ticket도 raw Theater 경로를 응답에 노출하지 않는다(cwd는 서버 측에서만 해석).
+    expect(issuedBody.cwd).toBeUndefined();
+    expect(unknownTheater.status).toBe(404);
+    expect(unknownBody).toEqual({ error: "theater_not_found" });
+  });
+
   it("keeps MCP bearer tokens out of terminal tickets, observer snapshots, SSE frames, static HTML, and launch errors", async () => {
     const fakeToken = "mcp-token-seeded-secret";
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-token-boundary-"));

--- a/runtime/fleet-console/tests/shell-panels.test.ts
+++ b/runtime/fleet-console/tests/shell-panels.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { addShellPanel, clearShellPanels, getShellPanels, removeShellPanel, setShellPanelGeometry } from "../client/src/canvas/shell-panels.js";
+
+const GEOMETRY = { x: 10, y: 20, width: 300, height: 200, zIndex: 1 } as const;
+
+afterEach(() => {
+  clearShellPanels();
+});
+
+describe("ephemeral shell panel registry", () => {
+  it("adds shell panels with shell:<seq> ids and tracks theaterId + geometry", () => {
+    const id = addShellPanel("theater-a", { ...GEOMETRY });
+    expect(id.startsWith("shell:")).toBe(true);
+    const panels = getShellPanels();
+    expect(panels[id]).toEqual({ theaterId: "theater-a", geometry: { ...GEOMETRY } });
+  });
+
+  it("assigns distinct ids to concurrent shell panels", () => {
+    const a = addShellPanel("t", { ...GEOMETRY });
+    const b = addShellPanel("t", { ...GEOMETRY });
+    expect(a).not.toBe(b);
+    expect(Object.keys(getShellPanels())).toHaveLength(2);
+  });
+
+  it("updates geometry without touching theaterId", () => {
+    const id = addShellPanel("theater-a", { ...GEOMETRY });
+    setShellPanelGeometry(id, { ...GEOMETRY, x: 99 });
+    expect(getShellPanels()[id]?.geometry.x).toBe(99);
+    expect(getShellPanels()[id]?.theaterId).toBe("theater-a");
+  });
+
+  it("removes a single panel and clears all", () => {
+    const id = addShellPanel("t", { ...GEOMETRY });
+    addShellPanel("t", { ...GEOMETRY });
+    removeShellPanel(id);
+    expect(getShellPanels()[id]).toBeUndefined();
+    expect(Object.keys(getShellPanels())).toHaveLength(1);
+    clearShellPanels();
+    expect(Object.keys(getShellPanels())).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- 캔버스 줌 보간(부드러운 rAF tween, pan은 즉시) · 순정 쉘 터미널 패널(Theater cwd, Operation 미분류·비영속) · 빈 캔버스 우클릭 컨텍스트 메뉴(New Operation/Open Shell/Reset view)
- 패널 제목 막대 더블클릭 → 포커스, 이름 더블클릭 → 인라인 rename(Operations 사이드바와 동일 흐름·영역 분리)
- 캐리어 Job 진행 dock을 패널 하단으로 이동 · OPERATIONS 사이드바 완전 접기(좌측 고정 펼치기 버튼)
- 맵 최대화 컨트롤(GNB 애니메이션 숨김 + 사이드바 자동 접힘, localStorage 영속, 버튼/Esc 해제) · 우하단 미니맵(해군 레이더 스코프, 패널·뷰포트 표시, 드래그 이동)
- Alt+←/→ 로 활성 Theater 내 Operation 포커스 순환(Map·Helm 공통) · 좌하단 Map 단축키 도움 UI(접기 시 "?" 펼치기)
- 버그 수정: 콘텐츠 없을 때 단축키 맵 숨겨 빈 안내와 겹침 해소 · 전체화면 중 오버레이(검색/셸/단축키/메뉴) Esc가 최대화를 함께 풀지 않도록

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (26 files / 308 tests)
- [x] console-e2e (playwriter 실브라우저): 줌 보간·컨텍스트 메뉴·셸 패널 생성/종료·더블클릭 포커스/rename·사이드바 접기·최대화(GNB 숨김)·미니맵·Alt 포커스 순환·빈 상태 겹침 해소·전체화면 Esc 양보 검증