### PR TITLE
feat(console): operation indicators, toasts, and folder browser UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - [core] Fleet Console Operations adds Alt+Left / Alt+Right to focus the previous / next Operation within the active Theater, working in both the Map and Helm views.
 - [core] The Fleet Console Operations Map adds a collapsible bottom-left shortcut reference panel that collapses to a "?" button.
 - [core] The Fleet Console Operations Map adds a maximize control next to the radar toggle that hides the global navigation bar with an animation and auto-collapses the Operations sidebar; exit with the control or Esc, remembered per browser.
+- [core] Fleet Console Operation indicators now reflect the live Agent CLI turn state — grey before the first turn, amber while the agent is processing a turn, green once the turn ends, and the existing live colour whenever a carrier job is running.
 
 ### Changed
 - [core] Fleet Console now uses an in-console directory browser for Theater and workspace folder selection, replacing OS-native folder dialogs (PowerShell/COM, osascript, zenity/kdialog, WSL); folder browsing works from remote and headless browser sessions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - [core] Fleet Console raises a global top-centre toast when a background Operation reports a carrier sortie or stands down, naming its Theater and Operation with a Go control to jump there; it dismisses on close or after ten seconds, and the Operation currently in view is suppressed.
 
 ### Changed
-- [core] Fleet Console now uses an in-console directory browser for Theater and workspace folder selection, replacing OS-native folder dialogs (PowerShell/COM, osascript, zenity/kdialog, WSL); folder browsing works from remote and headless browser sessions.
+- [core] Fleet Console now uses an in-console directory browser for Theater and workspace folder selection — a focused single-column folder list with breadcrumb path navigation, type-to-filter, full keyboard navigation, and single-click descent — replacing OS-native folder dialogs (PowerShell/COM, osascript, zenity/kdialog, WSL); folder browsing works from remote and headless browser sessions.
 - [core] The Fleet Console Operations radar sweep animation now consumes far less CPU and pauses automatically while the browser tab is hidden.
 - [core] The Fleet Console Operations Map now shows each panel's in-progress carrier job stream below the panel instead of above it.
 - [core] Collapsing the Fleet Console Operations Map sidebar now hides the whole panel, leaving only a fixed expand control on the left edge.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - [core] The Fleet Console Operations Map adds a collapsible bottom-left shortcut reference panel that collapses to a "?" button.
 - [core] The Fleet Console Operations Map adds a maximize control next to the radar toggle that hides the global navigation bar with an animation and auto-collapses the Operations sidebar; exit with the control or Esc, remembered per browser.
 - [core] Fleet Console Operation indicators now reflect the live Agent CLI turn state — grey before the first turn, amber while the agent is processing a turn, green once the turn ends, and the existing live colour whenever a carrier job is running.
+- [core] Fleet Console raises a global top-centre toast when a background Operation reports a carrier sortie or stands down, naming its Theater and Operation with a Go control to jump there; it dismisses on close or after ten seconds, and the Operation currently in view is suppressed.
 
 ### Changed
 - [core] Fleet Console now uses an in-console directory browser for Theater and workspace folder selection, replacing OS-native folder dialogs (PowerShell/COM, osascript, zenity/kdialog, WSL); folder browsing works from remote and headless browser sessions.

--- a/packages/fleet-admiral/src/agent-cli/injection.ts
+++ b/packages/fleet-admiral/src/agent-cli/injection.ts
@@ -32,6 +32,9 @@ export interface InjectAgentCliProfileOptions {
   readonly replaceSystemPrompt?: boolean;
   readonly enableMetaphor?: boolean;
   readonly captureSessionHookExec?: FleetHookExec;
+  // 턴 시작(UserPromptSubmit)·턴 종료(Stop) 신호 hook. host가 빌드해 주입하며 claude/codex 양쪽에 와이어링된다.
+  readonly turnStartHookExec?: FleetHookExec;
+  readonly turnEndHookExec?: FleetHookExec;
   readonly codexCommandRunner?: (command: CodexPluginRegistrationCommand) => CodexCommandResult;
   readonly hookExec?: FleetHookExec;
   readonly onCleanup?: (cleanup: () => void) => void;
@@ -47,6 +50,12 @@ interface AgentCliPluginMarketplaceLock {
 interface CodexFleetProfile {
   readonly profileName: string;
   readonly profilePath: string;
+}
+
+interface CodexProfileHookExecs {
+  readonly captureSessionHookExec?: FleetHookExec;
+  readonly turnStartHookExec?: FleetHookExec;
+  readonly turnEndHookExec?: FleetHookExec;
 }
 
 interface DedicatedMcpSession {
@@ -102,12 +111,18 @@ export async function injectAgentCliProfile(
       dataDir: options.dataDir,
       rootDir: options.pluginRootDir,
       captureSessionHookExec: options.captureSessionHookExec,
+      turnStartHookExec: options.turnStartHookExec,
+      turnEndHookExec: options.turnEndHookExec,
       hookExec: startupDefinitions.host === "claude" ? requireHookExec(options.hookExec) : undefined,
       withMarketplaceLock: options.withMarketplaceLock,
     });
     const codexPluginKeys = plugin.codexRegistrations.map((registration) => `${registration.pluginName}@${registration.marketplaceName}`);
     const codexProfile = profile.id === "codex"
-      ? writeCodexFleetProfile(profile.env, doctrine, codexPluginKeys, options.captureSessionHookExec, (cleanup) => tempCleanups.push(cleanup))
+      ? writeCodexFleetProfile(profile.env, doctrine, codexPluginKeys, {
+          captureSessionHookExec: options.captureSessionHookExec,
+          turnStartHookExec: options.turnStartHookExec,
+          turnEndHookExec: options.turnEndHookExec,
+        }, (cleanup) => tempCleanups.push(cleanup))
       : undefined;
     const launchWarnings: string[] = [];
     // Codex CLI가 Windows .cmd shim이면 profile.bin은 cmd.exe, binPrefixArgs는 /d /s /c <shim>이다.
@@ -205,7 +220,7 @@ function writeCodexFleetProfile(
   env: Readonly<Record<string, string>>,
   doctrine: string,
   pluginKeys: readonly string[],
-  captureSessionHookExec: FleetHookExec | undefined,
+  hookExecs: CodexProfileHookExecs,
   onCleanup: (cleanup: () => void) => void,
 ): CodexFleetProfile {
   const codexHome = env.CODEX_HOME ?? path.join(env.HOME ?? os.homedir(), ".codex");
@@ -227,20 +242,38 @@ function writeCodexFleetProfile(
       "enabled = true",
       "",
     ]),
-    ...codexCaptureHookConfig(captureSessionHookExec),
+    ...codexHooksConfig(hookExecs),
   ].join("\n"));
   chmodBestEffort(profilePath, SYSTEM_PROMPT_FILE_MODE);
   return { profileName, profilePath };
 }
 
-function codexCaptureHookConfig(captureSessionHookExec: FleetHookExec | undefined): string[] {
-  if (captureSessionHookExec === undefined) return [];
-  const command = buildPosixShellCommand([captureSessionHookExec.command, ...captureSessionHookExec.args]);
-  return [
-    "[hooks]",
-    `UserPromptSubmit = [{ hooks = [{ type = "command", command = "${escapeTomlBasicString(command)}" }] }]`,
-    "",
-  ];
+function codexHooksConfig(hookExecs: CodexProfileHookExecs): string[] {
+  // UserPromptSubmit = 세션 캡처 + 턴 시작, Stop = 턴 종료. codex hook 이벤트 키는 PascalCase.
+  const userPromptSubmitExecs = [hookExecs.captureSessionHookExec, hookExecs.turnStartHookExec]
+    .filter((exec): exec is FleetHookExec => exec !== undefined);
+  const stopExecs = [hookExecs.turnEndHookExec]
+    .filter((exec): exec is FleetHookExec => exec !== undefined);
+  if (userPromptSubmitExecs.length === 0 && stopExecs.length === 0) return [];
+  const lines = ["[hooks]"];
+  if (userPromptSubmitExecs.length > 0) {
+    lines.push(`UserPromptSubmit = ${codexHookHandlersInline(userPromptSubmitExecs)}`);
+  }
+  if (stopExecs.length > 0) {
+    lines.push(`Stop = ${codexHookHandlersInline(stopExecs)}`);
+  }
+  lines.push("");
+  return lines;
+}
+
+function codexHookHandlersInline(execs: readonly FleetHookExec[]): string {
+  const handlers = execs
+    .map((exec) => {
+      const command = buildPosixShellCommand([exec.command, ...exec.args]);
+      return `{ type = "command", command = "${escapeTomlBasicString(command)}" }`;
+    })
+    .join(", ");
+  return `[{ hooks = [${handlers}] }]`;
 }
 
 function writeFileNoFollow(filePath: string, content: string): void {

--- a/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 
 import { EMBEDDED_AGENT_CLI_SKILL_ASSETS } from "../assets.generated.js";
 import { writePrivateFile, writePrivateJson } from "./fs.js";
+import type { FleetHookExec } from "../types.js";
 import type { AssetPluginBundle, CreateAgentCliPluginOptions } from "./types.js";
 
 const CLAUDE_AGENT_FILE_STEM_ALLOWLIST = /^[A-Za-z0-9][A-Za-z0-9_-]{0,79}$/;
@@ -51,15 +52,25 @@ function claudeHooks(options: CreateAgentCliPluginOptions): unknown {
   if (!hookExec) {
     throw new Error("Fleet Claude session hook command is required");
   }
-  const captureSessionHookExec = options.captureSessionHookExec;
+  // UserPromptSubmit: 세션 캡처 + 턴 시작 신호를 같은 이벤트에 함께 건다(배열 순서대로 실행).
+  const userPromptSubmitExecs = [options.captureSessionHookExec, options.turnStartHookExec]
+    .filter((exec): exec is FleetHookExec => exec !== undefined);
+  // Stop: 턴 종료 신호.
+  const stopExecs = [options.turnEndHookExec]
+    .filter((exec): exec is FleetHookExec => exec !== undefined);
   return {
     hooks: {
       SessionStart: [{
         hooks: [claudeCommandHook(hookExec)],
       }],
-      ...(captureSessionHookExec ? {
+      ...(userPromptSubmitExecs.length > 0 ? {
         UserPromptSubmit: [{
-          hooks: [claudeCommandHook(captureSessionHookExec)],
+          hooks: userPromptSubmitExecs.map(claudeCommandHook),
+        }],
+      } : {}),
+      ...(stopExecs.length > 0 ? {
+        Stop: [{
+          hooks: stopExecs.map(claudeCommandHook),
         }],
       } : {}),
     },

--- a/packages/fleet-admiral/src/agent-cli/plugin/types.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/types.ts
@@ -19,6 +19,9 @@ export interface CreateAgentCliPluginOptions {
   readonly cwd: string;
   readonly dataDir: string;
   readonly hookExec?: FleetHookExec;
+  // 턴 시작(UserPromptSubmit)·턴 종료(Stop) 신호를 호스트로 알리는 hook. host가 빌드해 주입한다.
+  readonly turnStartHookExec?: FleetHookExec;
+  readonly turnEndHookExec?: FleetHookExec;
   readonly onCleanup?: (cleanup: () => void) => void;
   readonly rootDir?: string;
   readonly withMarketplaceLock: AgentCliPluginMarketplaceLock;

--- a/runtime/fleet-console/client/src/api.ts
+++ b/runtime/fleet-console/client/src/api.ts
@@ -223,6 +223,7 @@ function assertSessionInfo(value: unknown, status: number): SessionInfo {
     cliId: typeof payload.cliId === "string" ? payload.cliId : undefined,
     cliLabel: typeof payload.cliLabel === "string" ? payload.cliLabel : undefined,
     status: payload.status,
+    turnState: payload.turnState === "running" || payload.turnState === "ended" ? payload.turnState : "none",
     createdAt: payload.createdAt,
     theaterId: typeof payload.theaterId === "string" ? payload.theaterId : undefined,
     tenantId: typeof payload.tenantId === "string" ? payload.tenantId : undefined,

--- a/runtime/fleet-console/client/src/app.tsx
+++ b/runtime/fleet-console/client/src/app.tsx
@@ -7,6 +7,7 @@ import { fetchObserverStatus, fetchTerminalSessions, fetchTheaterBootstrap } fro
 import { ShortcutsOverlay } from "./components/shortcuts-overlay.js";
 import { ShellOverlay } from "./components/shell-overlay.js";
 import { OperationSearch } from "./components/operation-search.js";
+import { OperationToastHost } from "./components/operation-toasts.js";
 import { Toast } from "./components/toast.js";
 import { Topbar } from "./components/topbar.js";
 import { startObserverConnection } from "./connection.js";
@@ -122,6 +123,7 @@ export function App() {
         title="Console link interrupted"
         message={state.connectionError ?? undefined}
       />
+      <OperationToastHost toasts={state.operationToasts} />
     </div>
   );
 }

--- a/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, 
 import { renameTerminalSession, resumeTerminalSession, terminateTerminalSession } from "../api.js";
 import { CarrierJobLines } from "../components/carrier-job-lines.js";
 import { Terminal } from "../components/terminal.js";
-import { sessionDisplayLabel } from "../format.js";
+import { sessionBeaconClassName, sessionDisplayLabel } from "../format.js";
 import { isTerminalJobStatus } from "../reduce.js";
 import { applySessionUpdate, failRenameTerminalSession, failResumeTerminalSession, failTerminateTerminalSession, removeTerminalSession, selectJob, selectTerminalSession, sessionJobs } from "../store.js";
 import type { ConsoleState, SessionInfo } from "../types.js";
@@ -44,7 +44,6 @@ export function CanvasPanel({ state, session, geometry, viewport, active, getCan
   const activeJobs = jobs.filter(({ job }) => !isTerminalJobStatus(job.status)).map(({ job }) => job);
   const activeJobCount = activeJobs.length;
   const dormant = session.status === "dormant";
-  const live = activeJobCount > 0 || session.status === "registered" || session.status === "live" || session.status === "terminal-only";
   const displayLabel = sessionDisplayLabel(session);
 
   const bringToFront = () => {
@@ -209,7 +208,7 @@ export function CanvasPanel({ state, session, geometry, viewport, active, getCan
         onPointerCancel={endDrag}
         data-canvas-blocker
       >
-        <span className={`tenant-beacon ${live ? "is-live" : dormant ? "is-dormant" : ""}`} aria-hidden="true" />
+        <span className={sessionBeaconClassName(session, activeJobCount)} aria-hidden="true" />
         {renaming ? (
           <input
             ref={inputRef}

--- a/runtime/fleet-console/client/src/components/directory-browser-modal.tsx
+++ b/runtime/fleet-console/client/src/components/directory-browser-modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { createPortal } from "react-dom";
 
 import { ApiError, listTerminalFolders, type TerminalFolderListResponse } from "../api.js";
@@ -9,37 +9,32 @@ interface DirectoryBrowserModalProps {
   readonly onConfirm: (path: string) => void;
 }
 
+// 경로 한 마디 = breadcrumb 항로 위의 한 구역. path는 그 마디까지 누적된 절대 경로다.
+interface BreadcrumbSegment {
+  readonly label: string;
+  readonly path: string;
+}
+
+const LIST_ID = "directory-browser-sectors";
+
 export function DirectoryBrowserModal({ open, onCancel, onConfirm }: DirectoryBrowserModalProps) {
   const [listing, setListing] = useState<TerminalFolderListResponse | null>(null);
-  const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [loadingPath, setLoadingPath] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const closeRef = useRef<HTMLButtonElement | null>(null);
+  const [query, setQuery] = useState("");
+  const [highlight, setHighlight] = useState(0);
+  const filterRef = useRef<HTMLInputElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    closeRef.current?.focus();
-    const controller = new AbortController();
-    void loadPath(null, controller.signal);
-    const handleKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onCancel();
-    };
-    document.addEventListener("keydown", handleKey);
-    return () => {
-      controller.abort();
-      document.removeEventListener("keydown", handleKey);
-    };
-  }, [open]);
-
-  if (!open) return null;
-
+  // 디렉터리 한 레벨을 정찰해 목록으로 받는다. 진입/상위이동/breadcrumb 점프가 모두 이 경로를 탄다.
   const loadPath = async (path: string | null, signal?: AbortSignal) => {
     setLoadingPath(path);
     setError(null);
+    setQuery("");
+    setHighlight(0);
     try {
       const next = await listTerminalFolders(path, signal);
       setListing(next);
-      setSelectedPath(next.path);
     } catch (loadError) {
       if (loadError instanceof DOMException && loadError.name === "AbortError") return;
       setError(loadError instanceof ApiError ? loadError.message : String(loadError));
@@ -48,62 +43,297 @@ export function DirectoryBrowserModal({ open, onCancel, onConfirm }: DirectoryBr
     }
   };
 
-  const confirmPath = selectedPath ?? listing?.path ?? null;
+  // 모달이 열리는 순간 홈 디렉터리부터 정찰을 시작한다. 닫히면 abort.
+  useEffect(() => {
+    if (!open) return;
+    const controller = new AbortController();
+    void loadPath(null, controller.signal);
+    return () => controller.abort();
+    // loadPath는 매 렌더 새로 만들어지지만 open 전이에서만 트리거하면 충분하다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // 진입할 때마다 필터 입력에 포커스를 둬 곧바로 타이핑 검색이 가능하게 한다.
+  useEffect(() => {
+    if (open) filterRef.current?.focus();
+  }, [open, listing?.path]);
+
+  const entries = listing?.entries ?? [];
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (needle === "") return entries;
+    return entries.filter((entry) => entry.name.toLowerCase().includes(needle));
+  }, [entries, query]);
+
+  const breadcrumb = useMemo(() => (listing ? buildBreadcrumb(listing) : []), [listing]);
+
+  // filtered가 줄면 하이라이트가 범위를 벗어날 수 있으니 항상 끝으로 클램프한다.
+  const activeIndex = filtered.length === 0 ? -1 : Math.min(highlight, filtered.length - 1);
+
+  // 하이라이트된 구역을 항상 보이도록 스크롤한다.
+  useEffect(() => {
+    if (activeIndex < 0) return;
+    const node = listRef.current?.querySelector<HTMLElement>(`[data-index="${activeIndex}"]`);
+    node?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, listing?.path]);
+
+  if (!open) return null;
+
+  const enterSector = (entry: { readonly path: string; readonly accessible: boolean }) => {
+    if (entry.accessible && loadingPath === null) void loadPath(entry.path);
+  };
+
+  const goUp = () => {
+    if (listing?.parentPath != null && loadingPath === null) void loadPath(listing.parentPath);
+  };
+
+  const currentPath = listing?.path ?? null;
+  const activeRowId = activeIndex >= 0 ? `${LIST_ID}-${activeIndex}` : undefined;
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    switch (event.key) {
+      case "Escape":
+        // 필터가 차 있으면 먼저 비우고, 비어 있으면 모달을 닫는다.
+        if (query !== "") setQuery("");
+        else onCancel();
+        return;
+      case "ArrowDown":
+        event.preventDefault();
+        setHighlight((value) => Math.min(value + 1, Math.max(filtered.length - 1, 0)));
+        return;
+      case "ArrowUp":
+        event.preventDefault();
+        setHighlight((value) => Math.max(value - 1, 0));
+        return;
+      case "Enter": {
+        event.preventDefault();
+        const target = filtered[activeIndex];
+        if (target) enterSector(target);
+        return;
+      }
+      case "Backspace":
+        // 빈 필터에서의 Backspace만 상위 구역으로 — 입력 편집을 방해하지 않는다.
+        if (query === "") {
+          event.preventDefault();
+          goUp();
+        }
+        return;
+      default:
+        return;
+    }
+  };
 
   return createPortal(
-    <div className="directory-browser-overlay" role="dialog" aria-modal="true" aria-label="Choose Theater folder">
+    <div className="directory-browser-overlay" role="presentation">
       <button type="button" className="directory-browser-scrim" aria-label="Close" onClick={onCancel} />
-      <section className="directory-browser-card">
+      <section
+        className="directory-browser-card"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Establish Theater of Operations"
+        onKeyDown={handleKeyDown}
+      >
         <header className="directory-browser-header">
-          <span className="directory-browser-kicker">Theater Folder</span>
-          <h2>Choose Folder</h2>
-          <button type="button" ref={closeRef} className="directory-browser-close" onClick={onCancel} aria-label="Close">×</button>
+          <span className="directory-browser-sigil" aria-hidden="true"><TheaterSigil /></span>
+          <div className="directory-browser-heading">
+            <span className="directory-browser-kicker">Theater of Operations</span>
+            <h2>Establish Theater</h2>
+          </div>
+          <button type="button" className="directory-browser-close" onClick={onCancel} aria-label="Close">×</button>
         </header>
-        <div className="directory-browser-body">
-          <div className="directory-browser-path" title={listing?.path ?? ""}>{listing?.path ?? "Loading..."}</div>
-          <div className="directory-browser-roots" aria-label="Roots">
-            {listing?.roots.map((root) => (
-              <button type="button" key={root} className="directory-browser-root" onClick={() => void loadPath(root)}>{root}</button>
-            ))}
+
+        <nav className="directory-browser-course" aria-label="Path">
+          {breadcrumb.map((segment, index) => {
+            const isLast = index === breadcrumb.length - 1;
+            return (
+              <span className="directory-browser-course-seg" key={segment.path}>
+                {index > 0 ? <span className="directory-browser-course-sep" aria-hidden="true">›</span> : null}
+                <button
+                  type="button"
+                  className={`directory-browser-crumb ${isLast ? "is-current" : ""}`}
+                  aria-current={isLast ? "location" : undefined}
+                  disabled={isLast || loadingPath !== null}
+                  title={segment.path}
+                  onClick={() => void loadPath(segment.path)}
+                >
+                  {segment.label}
+                </button>
+              </span>
+            );
+          })}
+        </nav>
+
+        <div className="directory-browser-toolbar">
+          <div className="directory-browser-filter">
+            <span className="directory-browser-filter-glyph" aria-hidden="true"><ScanGlyph /></span>
+            <input
+              ref={filterRef}
+              type="text"
+              className="directory-browser-filter-input"
+              placeholder="Filter sectors…"
+              aria-label="Filter folders"
+              aria-controls={LIST_ID}
+              value={query}
+              spellCheck={false}
+              autoComplete="off"
+              onChange={(event) => {
+                setQuery(event.target.value);
+                setHighlight(0);
+              }}
+            />
           </div>
-          <div className="directory-browser-toolbar">
-            <button type="button" className="directory-browser-button" disabled={!listing?.parentPath || loadingPath !== null} onClick={() => void loadPath(listing?.parentPath ?? null)}>
-              Parent
-            </button>
-            <button type="button" className="directory-browser-button" disabled={!listing || loadingPath !== null} onClick={() => void loadPath(listing?.path ?? null)}>
-              Retry
-            </button>
-          </div>
-          {error ? <p className="directory-browser-error">{error}</p> : null}
-          <div className="directory-browser-list" aria-busy={loadingPath !== null}>
-            {loadingPath !== null ? <p className="directory-browser-empty">Loading...</p> : null}
-            {listing && loadingPath === null && listing.entries.length === 0 ? <p className="directory-browser-empty">No child folders.</p> : null}
-            {listing?.entries.map((entry) => (
-              <button
-                type="button"
-                key={entry.path}
-                className={`directory-browser-row ${selectedPath === entry.path ? "is-selected" : ""}`}
-                disabled={!entry.accessible}
-                title={entry.path}
-                onClick={() => setSelectedPath(entry.path)}
-                onDoubleClick={() => entry.accessible && void loadPath(entry.path)}
-              >
-                <span className="directory-browser-row-icon" aria-hidden="true">▸</span>
-                <span className="directory-browser-row-name">{entry.name}</span>
-                {!entry.accessible ? <span className="directory-browser-row-state">Locked</span> : null}
-              </button>
-            ))}
-          </div>
-          {listing?.truncated ? <p className="directory-browser-note">Showing first 500 folders.</p> : null}
-        </div>
-        <footer className="directory-browser-actions">
-          <button type="button" className="directory-browser-button" onClick={onCancel}>Cancel</button>
-          <button type="button" className="directory-browser-button is-primary" disabled={!confirmPath || loadingPath !== null} onClick={() => confirmPath && onConfirm(confirmPath)}>
-            Choose
+          <button
+            type="button"
+            className="directory-browser-up"
+            disabled={listing?.parentPath == null || loadingPath !== null}
+            title="Up one sector (Backspace)"
+            onClick={goUp}
+          >
+            <UpGlyph />
+            <span>Up</span>
           </button>
+        </div>
+
+        {error ? <p className="directory-browser-error" role="alert">{error}</p> : null}
+
+        <div
+          className="directory-browser-list"
+          id={LIST_ID}
+          role="listbox"
+          aria-label="Folders"
+          aria-busy={loadingPath !== null}
+          aria-activedescendant={activeRowId}
+          ref={listRef}
+        >
+          {loadingPath !== null ? (
+            <p className="directory-browser-state is-live"><span className="directory-browser-scan-dot" aria-hidden="true" />Scouting…</p>
+          ) : filtered.length === 0 ? (
+            <p className="directory-browser-state">{query !== "" ? "No sectors match the filter." : "No sectors to advance into."}</p>
+          ) : (
+            filtered.map((entry, index) => (
+              <div
+                key={entry.path}
+                id={`${LIST_ID}-${index}`}
+                data-index={index}
+                role="option"
+                aria-selected={index === activeIndex}
+                aria-disabled={!entry.accessible}
+                className={`directory-browser-sector ${index === activeIndex ? "is-active" : ""} ${entry.accessible ? "" : "is-locked"}`}
+                title={entry.path}
+                onClick={() => {
+                  setHighlight(index);
+                  enterSector(entry);
+                }}
+              >
+                <span className="directory-browser-sector-glyph" aria-hidden="true"><FolderGlyph /></span>
+                <span className="directory-browser-sector-name">{entry.name}</span>
+                {entry.accessible ? (
+                  <span className="directory-browser-sector-advance" aria-hidden="true">›</span>
+                ) : (
+                  <span className="directory-browser-sector-lock"><LockGlyph /> Locked</span>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+
+        {listing?.truncated ? <p className="directory-browser-note">Charting first 500 sectors only.</p> : null}
+
+        <footer className="directory-browser-actions">
+          <div className="directory-browser-target">
+            <span className="directory-browser-target-label">Theater Root</span>
+            <span className="directory-browser-target-path" title={currentPath ?? ""}>{currentPath ?? "Scouting…"}</span>
+          </div>
+          <div className="directory-browser-buttons">
+            <button type="button" className="directory-browser-button" onClick={onCancel}>Cancel</button>
+            <button
+              type="button"
+              className="directory-browser-button is-primary"
+              disabled={currentPath === null || loadingPath !== null}
+              onClick={() => currentPath && onConfirm(currentPath)}
+            >
+              Establish Theater
+            </button>
+          </div>
         </footer>
       </section>
     </div>,
     document.body,
+  );
+}
+
+// 현재 절대 경로를 breadcrumb 마디 배열로 분해한다. 루트(/ 또는 C:\)가 항상 첫 마디다.
+function buildBreadcrumb(listing: TerminalFolderListResponse): BreadcrumbSegment[] {
+  const separator = detectSeparator(listing);
+  if (separator === "/") {
+    const segments: BreadcrumbSegment[] = [{ label: "/", path: "/" }];
+    let accumulated = "";
+    for (const part of listing.path.split("/").filter(Boolean)) {
+      accumulated += `/${part}`;
+      segments.push({ label: part, path: accumulated });
+    }
+    return segments;
+  }
+  const driveMatch = /^([A-Za-z]:)\\?/.exec(listing.path);
+  const drive = driveMatch ? `${driveMatch[1]}\\` : (listing.roots[0] ?? "C:\\");
+  const segments: BreadcrumbSegment[] = [{ label: drive, path: drive }];
+  let accumulated = drive.replace(/\\$/, "");
+  for (const part of listing.path.slice(drive.length).split("\\").filter(Boolean)) {
+    accumulated += `\\${part}`;
+    segments.push({ label: part, path: accumulated });
+  }
+  return segments;
+}
+
+// win32 드라이브 루트(C:\)나 백슬래시 경로면 \, 그 외에는 POSIX /.
+function detectSeparator(listing: TerminalFolderListResponse): "\\" | "/" {
+  if (listing.roots.some((root) => /^[A-Za-z]:\\$/.test(root))) return "\\";
+  if (/^[A-Za-z]:\\/.test(listing.path)) return "\\";
+  return "/";
+}
+
+function TheaterSigil() {
+  // 작전구역(Theater of Operations) — 측위 레티클: 동심 링 + 십자 조준선으로 '구역을 조준해 지정'을 표상한다.
+  return (
+    <svg viewBox="0 0 20 20" aria-hidden="true">
+      <circle cx="10" cy="10" r="6.6" fill="none" stroke="currentColor" strokeWidth="1.2" />
+      <circle cx="10" cy="10" r="2.1" fill="currentColor" />
+      <path d="M10 1.6v3.2M10 15.2v3.2M1.6 10h3.2M15.2 10h3.2" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function FolderGlyph() {
+  return (
+    <svg viewBox="0 0 18 18" aria-hidden="true">
+      <path d="M2.4 5.2c0-.7.6-1.3 1.3-1.3h2.7l1.4 1.5h6.5c.7 0 1.3.6 1.3 1.3v6.4c0 .7-.6 1.3-1.3 1.3H3.7c-.7 0-1.3-.6-1.3-1.3z" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function ScanGlyph() {
+  // 정찰/탐색 — 돋보기.
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <circle cx="7" cy="7" r="4.2" fill="none" stroke="currentColor" strokeWidth="1.3" />
+      <path d="M10.2 10.2 13.5 13.5" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function UpGlyph() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M8 12.5V4M4.5 7.5 8 4l3.5 3.5" fill="none" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function LockGlyph() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <rect x="3.6" y="7" width="8.8" height="6.2" rx="1.4" fill="none" stroke="currentColor" strokeWidth="1.2" />
+      <path d="M5.6 7V5.4a2.4 2.4 0 0 1 4.8 0V7" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
   );
 }

--- a/runtime/fleet-console/client/src/components/floating-sidebar.tsx
+++ b/runtime/fleet-console/client/src/components/floating-sidebar.tsx
@@ -3,7 +3,7 @@ import { memo, useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardE
 import { createTheaterTerminalSession, renameTerminalSession, resumeTerminalSession, terminateTerminalSession } from "../api.js";
 import { ensureDefaultGeometry, focusPanel, useMaximized } from "../canvas/canvas-store.js";
 import { OperationLaunchMenu } from "./operation-launch-menu.js";
-import { describeJobStatus, formatCarrierName, sessionDisplayLabel, shortJobId, statusTone } from "../format.js";
+import { describeJobStatus, formatCarrierName, sessionBeaconClassName, sessionDisplayLabel, shortJobId, statusTone } from "../format.js";
 import { isTerminalJobStatus } from "../reduce.js";
 import { applySessionUpdate, beginCreateTerminalSession, completeCreateTerminalSession, failCreateTerminalSession, failRenameTerminalSession, failResumeTerminalSession, failTerminateTerminalSession, removeTerminalSession, selectJob, selectTerminalSession, sessionJobs, theaterSessionOrder } from "../store.js";
 import type { SessionJob } from "../store.js";
@@ -143,7 +143,6 @@ const FloatingSessionEntry = memo(function FloatingSessionEntry({ session, activ
   const skipBlurCommitRef = useRef(false);
   const activeCount = jobs.filter(({ job }) => !isTerminalJobStatus(job.status)).length;
   const dormant = session.status === "dormant";
-  const live = activeCount > 0 || session.status === "registered" || session.status === "live" || session.status === "terminal-only";
   const displayLabel = sessionDisplayLabel(session);
   const orderedJobs = [...jobs].sort((a, b) => Number(isTerminalJobStatus(a.job.status)) - Number(isTerminalJobStatus(b.job.status)));
 
@@ -196,7 +195,7 @@ const FloatingSessionEntry = memo(function FloatingSessionEntry({ session, activ
       <div className="session-row-shell">
         {renaming ? (
           <div className={`session-row session-row-edit ${active ? "is-active" : ""}`}>
-            <span className={`tenant-beacon ${live ? "is-live" : dormant ? "is-dormant" : ""}`} aria-hidden="true" />
+            <span className={sessionBeaconClassName(session, activeCount)} aria-hidden="true" />
             <input
               ref={inputRef}
               className="session-rename-input"
@@ -222,7 +221,7 @@ const FloatingSessionEntry = memo(function FloatingSessionEntry({ session, activ
             aria-current={active || undefined}
             aria-label={`Operation ${displayLabel}`}
           >
-            <span className={`tenant-beacon ${live ? "is-live" : dormant ? "is-dormant" : ""}`} aria-hidden="true" />
+            <span className={sessionBeaconClassName(session, activeCount)} aria-hidden="true" />
             <span className="tenant-row-text">
               <span className="tenant-label">{displayLabel}</span>
               {dormant ? <span className="job-row-meta">Dormant</span> : null}

--- a/runtime/fleet-console/client/src/components/operation-toasts.tsx
+++ b/runtime/fleet-console/client/src/components/operation-toasts.tsx
@@ -1,0 +1,70 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { dismissOperationToast, focusOperation } from "../store.js";
+import type { OperationToast, OperationToastKind } from "../types.js";
+
+interface OperationToastHostProps {
+  readonly toasts: readonly OperationToast[];
+}
+
+// 상태 라벨 — fleet-harness 해군 메타포. 인디케이터 색(aurora/그린)에 대응한다.
+//   sortie launched=캐리어 출격(aurora) · stood down=작업 완료(그린).
+const TOAST_STATUS: Record<OperationToastKind, string> = {
+  "carrier-call": "Sortie launched",
+  ended: "Stood down",
+};
+
+const OPERATION_TOAST_TTL_MS = 10_000;
+
+// Theater 무관 전역 Operation 상태 알림 스택. 우하단 고정, 카드별 5초 자동 닫힘.
+export function OperationToastHost({ toasts }: OperationToastHostProps) {
+  if (toasts.length === 0) return null;
+  return (
+    <div className="app-toast-host operation-toast-stack" aria-live="polite">
+      {toasts.map((toast) => (
+        <OperationToastCard key={toast.id} toast={toast} />
+      ))}
+    </div>
+  );
+}
+
+function OperationToastCard({ toast }: { readonly toast: OperationToast }) {
+  const navigate = useNavigate();
+  // US-7: 5초 뒤 자동 닫힘.
+  useEffect(() => {
+    const timer = setTimeout(() => dismissOperationToast(toast.id), OPERATION_TOAST_TTL_MS);
+    return () => clearTimeout(timer);
+  }, [toast.id]);
+
+  // US-5: 이동 — 해당 Theater로 전환 + Operation 선택 후 Operations로 이동, 토스트 닫기.
+  const handleGo = () => {
+    focusOperation(toast.sessionId);
+    navigate("/operations");
+    dismissOperationToast(toast.id);
+  };
+
+  return (
+    <div className={`app-toast operation-toast operation-toast--${toast.kind}`} role="status">
+      <span className="app-toast-dot" aria-hidden="true" />
+      {/* US-4: 한 줄, Theater › Operation 순으로 강조하고 상태는 muted eyebrow로 후행 표기 */}
+      <span className="operation-toast-text">
+        <span className="operation-toast-theater">{toast.theaterLabel}</span>
+        <span className="operation-toast-sep" aria-hidden="true">›</span>
+        <span className="operation-toast-op">{toast.operationLabel}</span>
+        <span className="operation-toast-status">{TOAST_STATUS[toast.kind]}</span>
+      </span>
+      <div className="operation-toast-actions">
+        <button type="button" className="operation-toast-go" onClick={handleGo}>Go</button>
+        <button
+          type="button"
+          className="app-toast-close"
+          onClick={() => dismissOperationToast(toast.id)}
+          aria-label="Dismiss notification"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/runtime/fleet-console/client/src/components/sidebar.tsx
+++ b/runtime/fleet-console/client/src/components/sidebar.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardE
 
 import { createTheaterTerminalSession, renameTerminalSession, resumeTerminalSession, terminateTerminalSession } from "../api.js";
 import { OperationLaunchMenu } from "./operation-launch-menu.js";
-import { describeJobStatus, formatCarrierName, sessionDisplayLabel, shortJobId, statusTone } from "../format.js";
+import { describeJobStatus, formatCarrierName, sessionBeaconClassName, sessionDisplayLabel, shortJobId, statusTone } from "../format.js";
 import { isTerminalJobStatus } from "../reduce.js";
 import { applySessionUpdate, beginCreateTerminalSession, completeCreateTerminalSession, failCreateTerminalSession, failRenameTerminalSession, failResumeTerminalSession, failTerminateTerminalSession, removeTerminalSession, selectJob, selectTerminalSession, sessionJobs, theaterSessionOrder } from "../store.js";
 import type { SessionJob } from "../store.js";
@@ -68,7 +68,6 @@ const SessionEntry = memo(function SessionEntry({ session, active, jobs, selecte
   const committingRef = useRef(false);
   const skipBlurCommitRef = useRef(false);
   const activeCount = jobs.filter(({ job }) => !isTerminalJobStatus(job.status)).length;
-  const live = activeCount > 0 || session.status === "registered" || session.status === "live" || session.status === "terminal-only";
   const dormant = session.status === "dormant";
   const displayLabel = sessionDisplayLabel(session);
   // 진행 중인 잡을 위로, 완료(terminal)된 잡을 아래로 모은다. 안정 정렬이라 그룹 내부 등록 순서는 그대로 유지된다.
@@ -138,7 +137,7 @@ const SessionEntry = memo(function SessionEntry({ session, active, jobs, selecte
       <div className="session-row-shell">
         {renaming ? (
           <div className={`session-row session-row-edit ${active ? "is-active" : ""}`}>
-            <span className={`tenant-beacon ${live ? "is-live" : ""}`} aria-hidden="true" />
+            <span className={sessionBeaconClassName(session, activeCount)} aria-hidden="true" />
             <input
               ref={inputRef}
               className="session-rename-input"
@@ -164,7 +163,7 @@ const SessionEntry = memo(function SessionEntry({ session, active, jobs, selecte
             aria-current={active || undefined}
             aria-label={`Operation ${displayLabel}`}
           >
-            <span className={`tenant-beacon ${live ? "is-live" : dormant ? "is-dormant" : ""}`} aria-hidden="true" />
+            <span className={sessionBeaconClassName(session, activeCount)} aria-hidden="true" />
             <span className="tenant-row-text">
               <span className="tenant-label">{displayLabel}</span>
               {dormant ? <span className="job-row-meta">Dormant</span> : null}

--- a/runtime/fleet-console/client/src/format.ts
+++ b/runtime/fleet-console/client/src/format.ts
@@ -68,6 +68,20 @@ export function describeTrackStatus(status: string): string {
   }
 }
 
+// Operation 인디케이터(tenant-beacon) 클래스. 우선순위(Job 우선):
+//   dormant(PTY 종료) → brass
+//   활성 캐리어 Job 있음 → aurora(is-live)            [US-3 및 턴 진행 중 Job 동시 케이스 포함]
+//   턴 진행 중(turnState=running) → 노랑(is-turn-running) [US-1]
+//   턴 종료(turnState=ended) → 그린(is-turn-ended)        [US-2]
+//   그 외(신규/턴 이력 없음) → 회색(기본)                 [US-0]
+export function sessionBeaconClassName(session: SessionInfo, activeJobCount: number): string {
+  if (session.status === "dormant") return "tenant-beacon is-dormant";
+  if (activeJobCount > 0) return "tenant-beacon is-live";
+  if (session.turnState === "running") return "tenant-beacon is-turn-running";
+  if (session.turnState === "ended") return "tenant-beacon is-turn-ended";
+  return "tenant-beacon";
+}
+
 export function statusTone(status: string): "live" | "ok" | "bad" | "idle" {
   switch (status) {
     case "stream":

--- a/runtime/fleet-console/client/src/sse.ts
+++ b/runtime/fleet-console/client/src/sse.ts
@@ -120,6 +120,7 @@ function readSessionInfo(value: unknown): SessionInfo | null {
     cliId: typeof session.cliId === "string" ? session.cliId : undefined,
     cliLabel: typeof session.cliLabel === "string" ? session.cliLabel : undefined,
     status: session.status,
+    turnState: session.turnState === "running" || session.turnState === "ended" ? session.turnState : "none",
     createdAt: session.createdAt,
     theaterId: typeof session.theaterId === "string" ? session.theaterId : undefined,
     tenantId: typeof session.tenantId === "string" ? session.tenantId : undefined,

--- a/runtime/fleet-console/client/src/store.ts
+++ b/runtime/fleet-console/client/src/store.ts
@@ -14,6 +14,7 @@ import type {
   ThemeId,
   TheaterBootstrap,
   TheaterInfo,
+  TurnState,
 } from "./types.js";
 
 type Listener = () => void;
@@ -23,7 +24,7 @@ export interface SessionJob {
   readonly tenant: TenantJobsView;
 }
 
-type SessionInput = Omit<SessionInfo, "resumeAvailable"> & { readonly resumeAvailable?: boolean };
+type SessionInput = Omit<SessionInfo, "resumeAvailable" | "turnState"> & { readonly resumeAvailable?: boolean; readonly turnState?: TurnState };
 
 const TENANT_JOB_LIMIT = 200;
 const ACTIVE_THEATER_STORAGE_KEY = "fleet-console.activeTheaterId";
@@ -532,6 +533,7 @@ function normalizeSession(session: SessionInput): SessionInfo {
     ...session,
     terminalSessionId: session.terminalSessionId ?? session.sessionId,
     status: session.status === "starting" && session.tenantId ? "registered" : session.status,
+    turnState: session.turnState ?? "none",
     resumeAvailable: session.resumeAvailable === true,
   };
 }

--- a/runtime/fleet-console/client/src/store.ts
+++ b/runtime/fleet-console/client/src/store.ts
@@ -1,4 +1,5 @@
 import { applyEvent, createEmptyJob, reduceSnapshotJob } from "./reduce.js";
+import { sessionDisplayLabel } from "./format.js";
 import { buildOperationSearchEntries } from "./operation-search.js";
 import type {
   ConsoleState,
@@ -7,6 +8,8 @@ import type {
   ObservedTenant,
   ObserverStatus,
   ObserverTruncation,
+  OperationToast,
+  OperationToastKind,
   SessionInfo,
   SnapshotTenantJobs,
   TenantJobsView,
@@ -63,7 +66,13 @@ let state: ConsoleState = {
   pendingOperationFocus: null,
   selectedJobId: null,
   expandedSessionIds: readStoredExpandedSessions(),
+  operationToasts: [],
 };
+
+// 초기 SSE replay(재연결 포함)가 과거 job 이벤트를 재전송하므로, carrier-call 토스트는
+// 이벤트가 충분히 최신일 때만 띄워 과거/재연결 폭주를 막는다. session:updated는 라이브 전용이라 무관.
+const OPERATION_TOAST_FRESH_MS = 10_000;
+let operationToastSeq = 0;
 
 export function getState(): ConsoleState {
   return state;
@@ -258,11 +267,18 @@ export function applySessionUpdate(session: SessionInput): void {
   const sessionOrder = known
     ? state.sessionOrder
     : [normalized.sessionId, ...state.sessionOrder.filter((sessionId) => sessionId !== normalized.sessionId)];
+  // 기존 세션의 턴 상태 전이만 알림(신규 세션의 첫 프레임은 전이가 아니므로 제외).
+  const turnToasts = current ? buildTurnTransitionToasts(current, normalized) : [];
   setState({
     sessions,
     sessionOrder,
     activeTerminalSessionId: resolveVisibleSessionId(state.activeTheaterId, sessions, sessionOrder, state.activeTerminalSessionId),
+    operationToasts: turnToasts.length > 0 ? [...state.operationToasts, ...turnToasts] : state.operationToasts,
   });
+}
+
+export function dismissOperationToast(id: number): void {
+  setState({ operationToasts: state.operationToasts.filter((toast) => toast.id !== id) });
 }
 
 export function failCreateTerminalSession(error: string): void {
@@ -431,8 +447,14 @@ export function applyObservedEvent(event: ObservedEvent, tenantLabel?: string): 
     truncation: { droppedCount: 0 },
   };
   let nextTenant = tenantLabel && tenant.tenantLabel !== tenantLabel ? { ...tenant, tenantLabel } : tenant;
+  let carrierToast: OperationToast | null = null;
   if (event.jobId) {
     const existingJob = nextTenant.jobs[event.jobId];
+    // 새 jobId가 처음 등장 = 캐리어 호출(carrier_dispatch). 라이브 이벤트(최신)에 한해 알림한다.
+    if (!existingJob && Date.now() - event.at < OPERATION_TOAST_FRESH_MS) {
+      const session = state.sessions[event.tenantId];
+      if (session && !isActiveOperation(session)) carrierToast = makeOperationToast("carrier-call", session);
+    }
     const job = applyEvent(existingJob ?? createEmptyJob(event.tenantId, event.jobId, event.at), event);
     const jobOrder = existingJob ? nextTenant.jobOrder : [...nextTenant.jobOrder, event.jobId];
     nextTenant = {
@@ -448,6 +470,7 @@ export function applyObservedEvent(event: ObservedEvent, tenantLabel?: string): 
     connectionError: null,
     tenantJobs: nextTenantJobs,
     tenantOrder: state.tenantOrder.includes(event.tenantId) ? state.tenantOrder : [...state.tenantOrder, event.tenantId],
+    operationToasts: carrierToast ? [...state.operationToasts, carrierToast] : state.operationToasts,
   };
   emit();
   return { unknownTenant };
@@ -536,6 +559,34 @@ function normalizeSession(session: SessionInput): SessionInfo {
     turnState: session.turnState ?? "none",
     resumeAvailable: session.resumeAvailable === true,
   };
+}
+
+// 현재 보고 있는 Operation(활성 Theater + 활성 세션)인지. 활성 Operation은 토스트를 억제한다.
+function isActiveOperation(session: SessionInfo): boolean {
+  return state.activeTheaterId === (session.theaterId ?? null) && state.activeTerminalSessionId === session.sessionId;
+}
+
+function theaterLabelFor(theaterId: string | undefined): string {
+  if (!theaterId) return "—";
+  return state.theaters.find((theater) => theater.id === theaterId)?.label ?? theaterId;
+}
+
+function makeOperationToast(kind: OperationToastKind, session: SessionInfo): OperationToast {
+  operationToastSeq += 1;
+  return {
+    id: operationToastSeq,
+    kind,
+    sessionId: session.sessionId,
+    theaterLabel: theaterLabelFor(session.theaterId),
+    operationLabel: sessionDisplayLabel(session),
+  };
+}
+
+function buildTurnTransitionToasts(prev: SessionInfo, next: SessionInfo): readonly OperationToast[] {
+  if (isActiveOperation(next)) return [];
+  // 작업 완료(턴 종료)만 알린다. 턴 진행 시작(running)은 알리지 않는다.
+  if (prev.turnState !== "ended" && next.turnState === "ended") return [makeOperationToast("ended", next)];
+  return [];
 }
 
 function mergeTenantBindings(sessions: Readonly<Record<string, SessionInfo>>, tenants: readonly ObservedTenant[]): Record<string, SessionInfo> {

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -4894,15 +4894,16 @@
   z-index: 95;
   display: grid;
   place-items: center;
-  padding: var(--space-5);
+  padding: var(--space-6);
 }
 
 .directory-browser-scrim {
   position: absolute;
   inset: 0;
   border: 0;
-  background: color-mix(in oklch, var(--ink-abyss) 48%, transparent);
-  backdrop-filter: blur(4px) saturate(120%);
+  /* 카드를 집중형 규격으로 좁힌 만큼, 배경 노출은 더 짙은 scrim으로 막는다(카드 크기로 막던 종전 방식 폐기). */
+  background: color-mix(in oklch, var(--ink-abyss) 64%, transparent);
+  backdrop-filter: blur(6px) saturate(118%);
   cursor: default;
 }
 
@@ -4911,49 +4912,57 @@
   z-index: 1;
   display: flex;
   flex-direction: column;
-  /* Keyboard Shortcuts·Local Shell 오버레이와 동일한 대형 카드 규격(80vw×90vh)으로 맞춘다.
-     작은 카드는 큰 화면에서 scrim 영역이 넓게 노출돼 동일 scrim 값이어도 배경이 비쳐
-     백그라운드 처리가 다르게 보였다. 카드를 표준 규격으로 키워 배경 노출을 제거한다. */
-  width: 80vw;
-  height: 90vh;
-  max-height: 90vh;
+  gap: var(--space-3);
+  /* 피커는 대시보드가 아니라 계기다 — 80vw×90vh 과대 카드 대신 집중형 규격. */
+  width: min(640px, 92vw);
+  height: min(680px, 86vh);
+  padding: var(--space-5) var(--space-5) var(--space-4);
   overflow: hidden;
-  border: 1px solid var(--surface-rim);
+  border: 1px solid var(--surface-rim-strong);
   border-radius: var(--radius-xl);
-  background: var(--surface-glass);
-  box-shadow: var(--shadow-floating);
-  backdrop-filter: blur(18px) saturate(140%);
+  background:
+    radial-gradient(120% 80% at 50% -10%, color-mix(in oklch, var(--brass) 9%, transparent), transparent 60%),
+    var(--surface-glass-strong);
+  box-shadow: var(--shadow-floating), var(--shadow-anchor);
+  backdrop-filter: blur(20px) saturate(140%);
   animation: codex-rise 360ms var(--ease-spring) both;
 }
 
 .directory-browser-header {
-  position: relative;
   flex: none;
-  padding: var(--space-5) calc(var(--space-6) + 34px) var(--space-4) var(--space-5);
-  border-bottom: 1px solid var(--surface-rim);
-  background:
-    linear-gradient(90deg, color-mix(in oklch, var(--brass) 10%, transparent), transparent 68%),
-    color-mix(in oklch, var(--ink-mid) 42%, transparent);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-3);
 }
 
-.directory-browser-kicker,
-.directory-browser-path,
-.directory-browser-root,
-.directory-browser-button,
-.directory-browser-error,
-.directory-browser-empty,
-.directory-browser-note,
-.directory-browser-row-state {
-  font-family: var(--font-mono);
+.directory-browser-sigil {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border: 1px solid color-mix(in oklch, var(--brass) 38%, var(--surface-rim));
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  color: var(--brass-bright);
+}
+
+.directory-browser-sigil svg {
+  width: 22px;
+  height: 22px;
+}
+
+.directory-browser-heading {
+  min-width: 0;
 }
 
 .directory-browser-kicker {
   display: block;
-  margin-bottom: var(--space-1);
   color: var(--brass-bright);
+  font-family: var(--font-mono);
   font-size: 10px;
   font-weight: 700;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
 }
 
@@ -4961,77 +4970,388 @@
   margin: 0;
   color: var(--ink-pearl);
   font-family: var(--font-display);
-  font-size: 24px;
+  font-size: 23px;
   font-weight: 560;
   letter-spacing: 0;
+  line-height: 1.1;
 }
 
 .directory-browser-close {
-  position: absolute;
-  top: var(--space-3);
-  right: var(--space-3);
   display: grid;
   width: 34px;
   height: 34px;
   place-items: center;
-  border: 1px solid color-mix(in oklch, var(--brass) 42%, var(--surface-rim));
+  border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--surface-glass-strong) 82%, transparent);
-  color: var(--brass-bright);
+  color: var(--ink-fog);
   font-size: 18px;
   line-height: 1;
+  transition: color var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide);
 }
 
-.directory-browser-body {
-  flex: 1;
-  display: grid;
-  grid-template-rows: auto auto auto auto minmax(0, 1fr) auto;
-  gap: var(--space-3);
-  min-height: 0;
-  padding: var(--space-4);
+.directory-browser-close:hover {
+  border-color: color-mix(in oklch, var(--brass) 46%, var(--surface-rim));
+  color: var(--brass-bright);
 }
 
-.directory-browser-path {
-  overflow: hidden;
-  padding: var(--space-3);
+/* 항로(course) breadcrumb — 죽은 path 스트립을 대체하는 클릭형 경로 마디. */
+.directory-browser-course {
+  flex: none;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 2px;
+  padding: var(--space-2) var(--space-3);
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
-  background: color-mix(in oklch, var(--ink-mid) 48%, transparent);
+  background: color-mix(in oklch, var(--ink-deep) 55%, transparent);
+}
+
+.directory-browser-course-seg {
+  display: inline-flex;
+  align-items: center;
+}
+
+.directory-browser-course-sep {
+  margin: 0 1px;
+  color: var(--ink-rim);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.directory-browser-crumb {
+  max-width: 220px;
+  overflow: hidden;
+  padding: 3px 7px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-xs);
+  background: transparent;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide);
+}
+
+.directory-browser-crumb:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--brass) 14%, transparent);
+  color: var(--brass-bright);
+}
+
+.directory-browser-crumb.is-current {
   color: var(--ink-pearl);
+  font-weight: 600;
+  cursor: default;
+}
+
+.directory-browser-toolbar {
+  flex: none;
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-2);
+}
+
+.directory-browser-filter {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--ink-mid) 42%, transparent);
+  transition: border-color var(--duration-fast) var(--ease-glide), box-shadow var(--duration-fast) var(--ease-glide);
+}
+
+.directory-browser-filter:focus-within {
+  border-color: color-mix(in oklch, var(--brass) 50%, var(--surface-rim));
+  box-shadow: 0 0 0 3px var(--brass-glow);
+}
+
+.directory-browser-filter-glyph {
+  display: grid;
+  place-items: center;
+  color: var(--ink-rim);
+}
+
+.directory-browser-filter-glyph svg {
+  width: 15px;
+  height: 15px;
+}
+
+.directory-browser-filter-input {
+  flex: 1;
+  min-width: 0;
+  height: 36px;
+  border: 0;
+  background: transparent;
+  color: var(--ink-pearl);
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+.directory-browser-filter-input::placeholder {
+  color: var(--ink-rim);
+}
+
+.directory-browser-filter-input:focus {
+  outline: none;
+}
+
+.directory-browser-up {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--ink-mid) 46%, transparent);
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  transition: color var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide);
+}
+
+.directory-browser-up svg {
+  width: 14px;
+  height: 14px;
+}
+
+.directory-browser-up:hover:not(:disabled) {
+  border-color: color-mix(in oklch, var(--brass) 46%, var(--surface-rim));
+  color: var(--brass-bright);
+}
+
+.directory-browser-up:disabled {
+  color: var(--ink-rim);
+  cursor: not-allowed;
+}
+
+.directory-browser-error {
+  flex: none;
+  margin: 0;
+  color: var(--coral);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+/* sector 리스트 — 단일 컬럼 스캔형 + 옅은 해도(chart) 좌표 그리드 텍스처. */
+.directory-browser-list {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-height: 0;
+  padding: var(--space-2);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-lg);
+  background-color: color-mix(in oklch, var(--ink-abyss) 32%, transparent);
+  background-image:
+    linear-gradient(color-mix(in oklch, var(--brass) 5%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in oklch, var(--brass) 5%, transparent) 1px, transparent 1px);
+  background-size: 30px 30px;
+  overflow-y: auto;
+}
+
+.directory-browser-sector {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 9px var(--space-3);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--ink-spectral);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide);
+}
+
+.directory-browser-sector-glyph {
+  display: grid;
+  place-items: center;
+  color: var(--ink-rim);
+  transition: color var(--duration-fast) var(--ease-glide);
+}
+
+.directory-browser-sector-glyph svg {
+  width: 18px;
+  height: 18px;
+}
+
+.directory-browser-sector-name {
+  overflow: hidden;
+  font-size: 13.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.directory-browser-sector-advance {
+  color: var(--ink-rim);
+  font-family: var(--font-mono);
+  font-size: 15px;
+  opacity: 0;
+  transform: translateX(-3px);
+  transition: opacity var(--duration-fast) var(--ease-glide), transform var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide);
+}
+
+.directory-browser-sector:hover,
+.directory-browser-sector.is-active {
+  border-color: color-mix(in oklch, var(--brass) 34%, transparent);
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  color: var(--ink-pearl);
+}
+
+.directory-browser-sector:hover .directory-browser-sector-glyph,
+.directory-browser-sector.is-active .directory-browser-sector-glyph {
+  color: var(--brass-bright);
+}
+
+.directory-browser-sector:hover .directory-browser-sector-advance,
+.directory-browser-sector.is-active .directory-browser-sector-advance {
+  color: var(--brass-bright);
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.directory-browser-sector.is-locked {
+  color: var(--ink-rim);
+  cursor: not-allowed;
+}
+
+.directory-browser-sector.is-locked:hover {
+  border-color: transparent;
+  background: transparent;
+  color: var(--ink-rim);
+}
+
+.directory-browser-sector.is-locked .directory-browser-sector-glyph {
+  color: var(--ink-veil);
+}
+
+.directory-browser-sector-lock {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--ink-rim);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.directory-browser-sector-lock svg {
+  width: 13px;
+  height: 13px;
+}
+
+.directory-browser-state {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+  padding: var(--space-4) var(--space-3);
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.directory-browser-state.is-live {
+  color: var(--aurora);
+}
+
+.directory-browser-scan-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--aurora);
+  box-shadow: 0 0 0 0 var(--aurora-glow);
+  animation: aurora-pulse 1.4s var(--ease-glide) infinite;
+}
+
+.directory-browser-note {
+  flex: none;
+  margin: 0;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.directory-browser-actions {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--surface-rim);
+}
+
+.directory-browser-target {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.directory-browser-target-label {
+  color: var(--brass-bright);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.directory-browser-target-path {
+  overflow: hidden;
+  color: var(--ink-pearl);
+  font-family: var(--font-mono);
   font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.directory-browser-roots,
-.directory-browser-toolbar,
-.directory-browser-actions {
+.directory-browser-buttons {
+  flex: none;
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
   gap: var(--space-2);
 }
 
-.directory-browser-root,
 .directory-browser-button {
-  min-height: 32px;
-  padding: 6px var(--space-3);
+  min-height: 36px;
+  padding: 0 var(--space-4);
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-xs);
+  border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-mid) 46%, transparent);
   color: var(--ink-fog);
-  font-size: 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  transition: color var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide);
 }
 
-.directory-browser-button.is-primary,
-.directory-browser-root:hover,
 .directory-browser-button:hover:not(:disabled) {
-  border-color: color-mix(in oklch, var(--brass) 48%, var(--surface-rim));
-  background: color-mix(in oklch, var(--brass) 14%, transparent);
+  border-color: color-mix(in oklch, var(--brass) 46%, var(--surface-rim));
   color: var(--brass-bright);
+}
+
+.directory-browser-button.is-primary {
+  border-color: color-mix(in oklch, var(--brass) 52%, var(--surface-rim));
+  background: color-mix(in oklch, var(--brass) 18%, transparent);
+  color: var(--brass-bright);
+}
+
+.directory-browser-button.is-primary:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--brass) 26%, transparent);
 }
 
 .directory-browser-button:disabled {
@@ -5039,67 +5359,10 @@
   cursor: not-allowed;
 }
 
-.directory-browser-error {
-  margin: 0;
-  color: var(--coral);
-  font-size: 11px;
-}
-
-.directory-browser-list {
-  display: grid;
-  /* 대형 카드(80vw)를 채우도록 폴더 항목을 다단으로 배치한다. 좁은 화면에서는 자동으로
-     컬럼 수가 줄어 1열까지 수렴한다(auto-fill + minmax). */
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  align-content: start;
-  gap: 4px var(--space-2);
-  min-height: 0;
-  overflow-y: auto;
-}
-
-.directory-browser-row {
-  display: grid;
-  grid-template-columns: 18px minmax(0, 1fr) auto;
-  align-items: center;
-  gap: var(--space-2);
-  width: 100%;
-  padding: 10px var(--space-3);
-  border: 1px solid transparent;
-  border-radius: var(--radius-md);
-  color: var(--ink-spectral);
-  text-align: left;
-}
-
-.directory-browser-row:hover:not(:disabled),
-.directory-browser-row.is-selected {
-  border-color: color-mix(in oklch, var(--brass) 30%, transparent);
-  background: color-mix(in oklch, var(--brass) 10%, transparent);
-  color: var(--ink-pearl);
-}
-
-.directory-browser-row:disabled {
-  color: var(--ink-rim);
-  cursor: not-allowed;
-}
-
-.directory-browser-row-name {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.directory-browser-row-state,
-.directory-browser-empty,
-.directory-browser-note {
-  margin: 0;
-  color: var(--ink-fog);
-  font-size: 11px;
-}
-
-.directory-browser-actions {
-  flex: none;
-  justify-content: flex-end;
-  padding: var(--space-4);
-  border-top: 1px solid var(--surface-rim);
+@media (prefers-reduced-motion: reduce) {
+  .directory-browser-card { animation: none; }
+  .directory-browser-scan-dot { animation: none; }
+  .directory-browser-sector-advance { transition: none; }
 }
 
 /* === GNB 반응형 ladder — 중앙 THEATER 보존 (실측 기반) ===

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -4517,6 +4517,141 @@
   background: color-mix(in oklch, var(--ink-fog) 14%, transparent);
 }
 
+/* Operation 상태 전이 알림 토스트 — 상단 중앙 정렬 스택(연결 토스트의 우하단 host와 분리). */
+.operation-toast-stack {
+  top: var(--space-5);
+  left: 50%;
+  right: auto;
+  bottom: auto;
+  transform: translateX(-50%);
+  align-items: center;
+  max-width: min(94vw, 620px);
+}
+
+/* 한 줄 레이아웃: 상태 점 · 텍스트(말줄임) · 액션. 좌측에 상태색 계기 레일. */
+.operation-toast {
+  align-items: center;
+  width: max-content;
+  max-width: min(94vw, 620px);
+  border-left-width: 2.5px;
+}
+
+.operation-toast .app-toast-dot {
+  margin-top: 0;
+}
+
+/* 인디케이터와 동일한 색의 좌측 액센트 레일(계기판 느낌). */
+.operation-toast--carrier-call {
+  border-left-color: var(--aurora);
+}
+
+.operation-toast--ended {
+  border-left-color: var(--positive);
+}
+
+/* 캐리어 출격은 살아있는 상태(aurora) — beacon의 is-live와 동일하게 펄스. */
+.operation-toast--carrier-call .app-toast-dot {
+  animation: aurora-pulse 1.8s ease-in-out infinite;
+}
+
+.operation-toast-text {
+  flex: 1;
+  min-width: 0;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 7px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+/* 강조 1순위 — Theater. */
+.operation-toast-theater {
+  flex: none;
+  color: var(--ink-pearl);
+  font-weight: 650;
+  font-size: 12.5px;
+  letter-spacing: 0.01em;
+}
+
+/* brass = 항행/내비게이션 역할 — Theater → Operation 구분자(chevron). */
+.operation-toast-sep {
+  flex: none;
+  color: color-mix(in oklch, var(--brass) 72%, var(--ink-fog));
+  font-size: 13px;
+  line-height: 1;
+}
+
+/* 강조 2순위 — Operation(길면 말줄임). */
+.operation-toast-op {
+  min-width: 0;
+  color: var(--ink-pearl);
+  font-weight: 560;
+  font-size: 12.5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* 상태는 비강조 — 인디케이터 색이 상태를 전달하므로 muted mono eyebrow로 후행 표기. */
+.operation-toast-status {
+  flex: none;
+  margin-left: 2px;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  opacity: 0.78;
+}
+
+.operation-toast--carrier-call {
+  border-color: color-mix(in oklch, var(--aurora) 40%, var(--surface-rim));
+}
+
+.operation-toast--ended {
+  border-color: color-mix(in oklch, var(--positive) 40%, var(--surface-rim));
+}
+
+.operation-toast--carrier-call .app-toast-dot {
+  background: var(--aurora);
+  box-shadow: 0 0 10px var(--aurora-glow);
+}
+
+.operation-toast--ended .app-toast-dot {
+  background: var(--positive);
+  box-shadow: 0 0 9px var(--positive-glow);
+}
+
+.operation-toast-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-left: auto;
+}
+
+/* 내비게이션 = brass 역할(doctrine: brass="지금 보고 있는 곳"). */
+.operation-toast-go {
+  flex: none;
+  padding: 4px 11px;
+  border: 1px solid color-mix(in oklch, var(--brass) 46%, var(--surface-rim));
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--brass) 13%, transparent);
+  color: var(--brass-bright);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring);
+}
+
+.operation-toast-go:hover {
+  background: color-mix(in oklch, var(--brass) 24%, transparent);
+  border-color: color-mix(in oklch, var(--brass) 64%, var(--surface-rim));
+}
+
 .operation-search-overlay {
   position: fixed;
   inset: 0;

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -1025,6 +1025,18 @@
   box-shadow: 0 0 8px color-mix(in oklch, var(--brass) 30%, transparent);
 }
 
+/* Agent CLI 턴 진행 중 — 노랑(--warn). 처리 중을 알리되 aurora(살아있는 Job)와 구별한다. */
+.tenant-beacon.is-turn-running {
+  background: var(--warn);
+  box-shadow: 0 0 10px var(--warn-glow);
+}
+
+/* Agent CLI 턴 종료(유휴) — 그린(--positive). 입력 대기 상태. */
+.tenant-beacon.is-turn-ended {
+  background: var(--positive);
+  box-shadow: 0 0 9px var(--positive-glow);
+}
+
 .status-dot--lg {
   width: 10px;
   height: 10px;

--- a/runtime/fleet-console/client/src/types.ts
+++ b/runtime/fleet-console/client/src/types.ts
@@ -120,6 +120,9 @@ export interface CarrierSettingsMutationResult {
 
 export type SessionStatus = "starting" | "live" | "registered" | "terminal-only" | "closed" | "error" | "dormant";
 
+// Agent CLI 턴(host 처리) 상태. "none"=턴 이력 없음(신규), "running"=처리중, "ended"=종료(유휴).
+export type TurnState = "none" | "running" | "ended";
+
 export interface SessionInfo {
   readonly sessionId: string;
   readonly terminalSessionId: string;
@@ -129,6 +132,7 @@ export interface SessionInfo {
   readonly cliId?: string;
   readonly cliLabel?: string;
   readonly status: SessionStatus;
+  readonly turnState: TurnState;
   readonly createdAt: number;
   readonly theaterId?: string;
   readonly tenantId?: string;

--- a/runtime/fleet-console/client/src/types.ts
+++ b/runtime/fleet-console/client/src/types.ts
@@ -222,6 +222,18 @@ export interface TenantJobsView {
 
 export type ConnectionState = "connecting" | "live";
 
+// Operation 상태 전이 알림 토스트. kind는 인디케이터 상태에 대응:
+//   carrier-call=캐리어 출격(Job 발생, aurora) · ended=작업 완료(턴 종료, 그린).
+export type OperationToastKind = "carrier-call" | "ended";
+
+export interface OperationToast {
+  readonly id: number;
+  readonly kind: OperationToastKind;
+  readonly sessionId: string;
+  readonly theaterLabel: string;
+  readonly operationLabel: string;
+}
+
 export interface ConsoleState {
   readonly connection: ConnectionState;
   readonly connectionError: string | null;
@@ -250,4 +262,6 @@ export interface ConsoleState {
   readonly pendingOperationFocus: string | null;
   readonly selectedJobId: string | null;
   readonly expandedSessionIds: readonly string[];
+  // Theater 무관 전역 Operation 상태 전이 알림 토스트 큐(현재 보는 Operation은 억제).
+  readonly operationToasts: readonly OperationToast[];
 }

--- a/runtime/fleet-console/src/api-types.ts
+++ b/runtime/fleet-console/src/api-types.ts
@@ -88,6 +88,9 @@ export interface CreateTheaterResponse extends ConsoleTheaterInfo {}
 
 export type ConsoleTerminalSessionStatus = "starting" | "terminal-only" | "registered" | "closed" | "error" | "dormant";
 
+// Agent CLI 턴(host 처리) 상태. "none"=턴 이력 없음(신규), "running"=처리중, "ended"=종료(유휴).
+export type ConsoleTurnState = "none" | "running" | "ended";
+
 export interface ConsoleTerminalSessionInfo {
   readonly sessionId: string;
   readonly terminalSessionId: string;
@@ -97,6 +100,7 @@ export interface ConsoleTerminalSessionInfo {
   readonly cliId?: string;
   readonly cliLabel?: string;
   readonly status: ConsoleTerminalSessionStatus;
+  readonly turnState: ConsoleTurnState;
   readonly createdAt: number;
   readonly theaterId: string;
   readonly registrationId?: string;

--- a/runtime/fleet-console/src/cli.ts
+++ b/runtime/fleet-console/src/cli.ts
@@ -25,6 +25,7 @@ import { createConsolePaths } from "./paths.js";
 import { createConsoleServer } from "./server.js";
 import { runCaptureSessionHook } from "./session-capture.js";
 import { createConsoleStalePolicy } from "./stale.js";
+import { runTurnStateHook } from "./turn-state-hook.js";
 
 export type ConsoleCliMode = "start" | "stop" | "restart" | "status" | "help";
 
@@ -85,7 +86,7 @@ export interface BuildConsoleHelpTextOptions {
 const FIXED_HOST = "127.0.0.1";
 const HELP_BANNER_INDENT = "  ";
 const DEFAULT_HELP_RELEASE = "local";
-const CONSOLE_HOOK_COMMANDS = new Set(["capture-session", "subagents-context"]);
+const CONSOLE_HOOK_COMMANDS = new Set(["capture-session", "subagents-context", "turn-start", "turn-end"]);
 
 export function parseConsoleCliMode(argv: readonly string[]): ConsoleCliMode {
   // 인자가 없으면 기본 동작은 start(서버 보장 + 브라우저 열기)다.
@@ -113,12 +114,14 @@ export function parseConsoleCliMode(argv: readonly string[]): ConsoleCliMode {
   return mode;
 }
 
-export function parseConsoleHookCommand(argv: readonly string[]): { readonly command: "capture-session"; readonly provider: string } | { readonly command: "subagents-context" } {
+export function parseConsoleHookCommand(argv: readonly string[]): { readonly command: "capture-session"; readonly provider: string } | { readonly command: "subagents-context" } | { readonly command: "turn-start" } | { readonly command: "turn-end" } {
   const [commandName, ...rest] = argv;
   if (!commandName || !CONSOLE_HOOK_COMMANDS.has(commandName)) {
     throw new Error("Unknown fleet-console hook command");
   }
   if (commandName === "subagents-context" && rest.length === 0) return { command: "subagents-context" };
+  if (commandName === "turn-start" && rest.length === 0) return { command: "turn-start" };
+  if (commandName === "turn-end" && rest.length === 0) return { command: "turn-end" };
   if (commandName === "capture-session" && rest.length === 1 && rest[0]) return { command: "capture-session", provider: rest[0] };
   throw new Error("Unknown fleet-console hook command");
 }
@@ -360,6 +363,11 @@ export async function main(): Promise<void> {
     const hookCommand = parseConsoleHookCommand(process.argv.slice(3));
     if (hookCommand.command === "subagents-context") {
       process.stdout.write(`${runSubagentsContextHook(process.env)}\n`);
+      return;
+    }
+    if (hookCommand.command === "turn-start" || hookCommand.command === "turn-end") {
+      // 턴 상태 hook은 항상 무출력·exit 0 best-effort다(codex Stop exit2=continuation, claude block 출력 금지).
+      await runTurnStateHook(hookCommand.command === "turn-start" ? "start" : "end", process.env);
       return;
     }
     await runCaptureSessionHook(hookCommand.provider, process.env);

--- a/runtime/fleet-console/src/observability-store.ts
+++ b/runtime/fleet-console/src/observability-store.ts
@@ -8,6 +8,7 @@ import type {
   ConsoleSessionUpdatedEvent,
   ConsoleTerminalSessionInfo,
   ConsoleTerminalSessionStatus,
+  ConsoleTurnState,
 } from "./api-types.js";
 import type { DurableOperation, ProviderSession } from "./durable-state.js";
 import { canonicalizeTheaterPathSync, workspaceHash } from "./theater.js";
@@ -50,6 +51,7 @@ interface PendingTerminalSessionState {
   readonly theaterId: string;
   readonly terminalSessionId: string;
   status: ConsoleTerminalSessionStatus;
+  turnState?: ConsoleTurnState;
   registrationId?: string;
   cliRunId?: string;
   providerSession?: ProviderSession;
@@ -270,6 +272,13 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
     return toTerminalSessionInfo(session);
   }
 
+  function setTerminalSessionTurnState(sessionId: string, turnState: ConsoleTurnState): ConsoleTerminalSessionInfo | null {
+    const session = terminalSessionsById.get(sessionId);
+    if (!session) return null;
+    session.turnState = turnState;
+    return toTerminalSessionInfo(session);
+  }
+
   function transitionTerminalSessionToDormant(sessionId: string, providerSession: ProviderSession): ConsoleTerminalSessionInfo | null {
     const session = terminalSessionsById.get(sessionId);
     if (!session) return null;
@@ -343,6 +352,7 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
     subscribeAll,
     updateTerminalSessionProviderSession,
     updateTerminalSessionStatus,
+    setTerminalSessionTurnState,
     transitionTerminalSessionToDormant,
     removeTerminalSession,
     registerTerminalRuntimeSession,
@@ -416,6 +426,7 @@ function toTerminalSessionInfo(state: PendingTerminalSessionState): ConsoleTermi
     cliId: state.cliId,
     cliLabel: state.cliLabel,
     status: state.status,
+    turnState: state.turnState ?? "none",
     createdAt: state.createdAt,
     theaterId: state.theaterId,
     registrationId: state.registrationId,

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -228,6 +228,11 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       runAsyncHandler(handleTerminalSessionResume(req, res, decodeURIComponent(terminalSessionResumeMatch[1] ?? "")), res);
       return;
     }
+    const terminalSessionTurnMatch = pathname.match(/^\/terminal\/sessions\/([^/]+)\/turn$/);
+    if (terminalSessionTurnMatch) {
+      runAsyncHandler(handleTerminalSessionTurn(req, res, decodeURIComponent(terminalSessionTurnMatch[1] ?? "")), res);
+      return;
+    }
     const terminalSessionItemMatch = pathname.match(/^\/terminal\/sessions\/([^/]+)$/);
     if (terminalSessionItemMatch) {
       runAsyncHandler(handleTerminalSessionItem(req, res, decodeURIComponent(terminalSessionItemMatch[1] ?? "")), res);
@@ -294,6 +299,33 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       workspaceCount: observability.workspaceCount(),
     };
     writeJson(res, 200, body);
+  }
+
+  // Agent CLI 턴 상태 hook 수신: provider CLI의 UserPromptSubmit/Stop hook이 lock 토큰으로 POST한다.
+  // 브라우저가 아닌 로컬 신뢰 프로세스이므로 terminal Origin 검사 대신 lock-token bearer로만 인증한다.
+  async function handleTerminalSessionTurn(req: http.IncomingMessage, res: http.ServerResponse, sessionId: string): Promise<void> {
+    if (req.method !== "POST") {
+      writeJson(res, 405, { error: "Method not allowed" });
+      return;
+    }
+    const token = lockHandle?.payload.token;
+    if (!token || req.headers.authorization !== `Bearer ${token}`) {
+      writeJson(res, 401, { error: "Unauthorized" });
+      return;
+    }
+    const body = await readJsonBody<{ readonly phase?: unknown }>(req);
+    const turnState = body?.phase === "start" ? "running" : body?.phase === "end" ? "ended" : null;
+    if (turnState === null) {
+      writeJson(res, 400, { error: "invalid_phase" });
+      return;
+    }
+    const updated = observability.setTerminalSessionTurnState(sessionId, turnState);
+    if (!updated) {
+      writeJson(res, 404, { error: "terminal_session_not_found" });
+      return;
+    }
+    observability.notifySessionUpdated(updated);
+    writeJson(res, 200, { ok: true });
   }
 
   async function handleTerminalTicket(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {

--- a/runtime/fleet-console/src/terminal/host-hooks.ts
+++ b/runtime/fleet-console/src/terminal/host-hooks.ts
@@ -19,6 +19,8 @@ export interface ConsoleHookCommandEntry {
 
 export type ConsoleCaptureProvider = "claude" | "codex";
 
+export type ConsoleTurnPhase = "start" | "end";
+
 const JAVASCRIPT_ENTRY_EXTENSIONS = new Set([".cjs", ".js", ".mjs"]);
 const TYPESCRIPT_ENTRY_EXTENSIONS = new Set([".cts", ".mts", ".ts", ".tsx"]);
 const MARKETPLACE_LOCK_DIR_SUFFIX = ".lock";
@@ -27,23 +29,11 @@ export function buildConsoleHookCommand(entry: ConsoleHookCommandEntry | undefin
   if (entry === undefined) {
     throw new Error("Fleet Console session hook command requires the current console entry path");
   }
-  const extension = path.extname(entry.entryPath);
-  if (JAVASCRIPT_ENTRY_EXTENSIONS.has(extension)) {
-    return {
-      command: entry.execPath,
-      args: [entry.entryPath, "hook", "subagents-context"],
-    };
-  }
-  if (TYPESCRIPT_ENTRY_EXTENSIONS.has(extension)) {
-    if (!entry.tsxLoaderPath) {
-      throw new Error("Fleet Console session hook command for TypeScript entries requires a tsx loader path");
-    }
-    return {
-      command: entry.execPath,
-      args: ["--import", pathToFileURL(entry.tsxLoaderPath).href, entry.entryPath, "hook", "subagents-context"],
-    };
-  }
-  throw new Error(`Unsupported Fleet Console session hook entry extension: ${extension}`);
+  return buildConsoleCliHookExec(entry, ["hook", "subagents-context"]);
+}
+
+export function buildConsoleTurnHookCommand(entry: ConsoleHookCommandEntry, phase: ConsoleTurnPhase): FleetHookExec {
+  return buildConsoleCliHookExec(entry, ["hook", phase === "start" ? "turn-start" : "turn-end"]);
 }
 
 export function buildConsoleCaptureHookCommand(entry: ConsoleHookCommandEntry, cliId: AgentCliId): FleetHookExec {
@@ -92,4 +82,24 @@ export function withConsoleMarketplaceLock<T>(target: string, fn: () => T): T {
   const lockDir = `${target}${MARKETPLACE_LOCK_DIR_SUFFIX}`;
   mkdirSync(path.dirname(lockDir), { recursive: true });
   return withDirectoryLock({ lockDir }, fn);
+}
+
+function buildConsoleCliHookExec(entry: ConsoleHookCommandEntry, trailingArgs: readonly string[]): FleetHookExec {
+  const extension = path.extname(entry.entryPath);
+  if (JAVASCRIPT_ENTRY_EXTENSIONS.has(extension)) {
+    return {
+      command: entry.execPath,
+      args: [entry.entryPath, ...trailingArgs],
+    };
+  }
+  if (TYPESCRIPT_ENTRY_EXTENSIONS.has(extension)) {
+    if (!entry.tsxLoaderPath) {
+      throw new Error("Fleet Console session hook command for TypeScript entries requires a tsx loader path");
+    }
+    return {
+      command: entry.execPath,
+      args: ["--import", pathToFileURL(entry.tsxLoaderPath).href, entry.entryPath, ...trailingArgs],
+    };
+  }
+  throw new Error(`Unsupported Fleet Console session hook entry extension: ${extension}`);
 }

--- a/runtime/fleet-console/src/terminal/launch.ts
+++ b/runtime/fleet-console/src/terminal/launch.ts
@@ -18,7 +18,7 @@ import { createInfraServices, getFleetDataDir, type InfraServices } from "@dotob
 import { resolveAuthEnv } from "@dotobokuri/fleet-infra/auth";
 
 import type { TerminalLaunchContext, TerminalLaunchSpec, TerminalPtyHandle } from "./types.js";
-import { buildConsoleCaptureHookCommand, buildConsoleHookCommand, runCodexCommand, withConsoleMarketplaceLock, type ConsoleHookCommandEntry } from "./host-hooks.js";
+import { buildConsoleCaptureHookCommand, buildConsoleHookCommand, buildConsoleTurnHookCommand, runCodexCommand, withConsoleMarketplaceLock, type ConsoleHookCommandEntry } from "./host-hooks.js";
 
 export interface TerminalLaunchResolverDeps {
   readonly cwd?: string;
@@ -185,6 +185,8 @@ async function createAgentCliLaunchSpec(options: {
       dedicatedMcpSession: agentRuntime.dedicatedMcpSession,
       enableMetaphor: false,
       captureSessionHookExec: buildConsoleCaptureHookCommand(options.hookEntry, profile.id),
+      turnStartHookExec: buildConsoleTurnHookCommand(options.hookEntry, "start"),
+      turnEndHookExec: buildConsoleTurnHookCommand(options.hookEntry, "end"),
       hookExec: buildConsoleHookCommand(options.hookEntry),
       onCleanup: (cleanup) => cleanupStack.push(cleanup),
       replaceSystemPrompt: false,

--- a/runtime/fleet-console/src/turn-state-hook.ts
+++ b/runtime/fleet-console/src/turn-state-hook.ts
@@ -1,0 +1,49 @@
+import process from "node:process";
+
+import { createConsoleLock } from "./lock.js";
+import { createConsolePaths } from "./paths.js";
+
+export interface TurnStateHookOptions {
+  readonly fetchImpl?: typeof fetch;
+  readonly timeoutMs?: number;
+}
+
+const TURN_POST_TIMEOUT_MS = 1500;
+
+export async function runTurnStateHook(
+  phase: "start" | "end",
+  env: NodeJS.ProcessEnv = process.env,
+  options: TurnStateHookOptions = {},
+): Promise<void> {
+  // 턴 상태 알림은 best-effort UI 신호다. 락 부재·서버 미응답·타임아웃 등 어떤 실패도
+  // provider 턴 진행을 막거나 hook 출력(codex Stop의 exit2/JSON, claude block)으로 새어나가선 안 된다.
+  try {
+    await postTurnState(phase, env, options);
+  } catch {
+    // 모든 실패를 무시한다(무출력·exit 0).
+  }
+}
+
+async function postTurnState(phase: "start" | "end", env: NodeJS.ProcessEnv, options: TurnStateHookOptions): Promise<void> {
+  const sessionId = env.FLEET_CONSOLE_SESSION_ID;
+  if (!sessionId) return;
+  const paths = createConsolePaths({ env });
+  const lock = createConsoleLock().readLock(paths.lockFile);
+  if (!lock) return;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), options.timeoutMs ?? TURN_POST_TIMEOUT_MS);
+  try {
+    await fetchImpl(`${lock.endpoint}terminal/sessions/${encodeURIComponent(sessionId)}/turn`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${lock.token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ phase }),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/runtime/fleet-console/tests/dashboard.test.ts
+++ b/runtime/fleet-console/tests/dashboard.test.ts
@@ -4,6 +4,7 @@ import { buildBridgeView, collectTheaterReadiness, summarizeOperationsReadiness 
 import type { ConsoleState, JobView } from "../client/src/types.js";
 
 const BASE_STATE: ConsoleState = {
+  operationToasts: [],
   connection: "live",
   connectionError: null,
   activeTheme: "maritime",

--- a/runtime/fleet-console/tests/dashboard.test.ts
+++ b/runtime/fleet-console/tests/dashboard.test.ts
@@ -44,7 +44,7 @@ describe("dashboard bridge derivation", () => {
         { tenantId: "tenant-a", tenantLabel: "Alpha CLI", createdAt: 1_000, sessions: 1, status: "live", theaterId: "theater-a", terminalSessionId: "session-a" },
       ],
       sessions: {
-        "session-a": { sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, status: "registered", createdAt: 1_500, theaterId: "theater-a", tenantId: "tenant-a", resumeAvailable: false },
+        "session-a": { sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, status: "registered", turnState: "none", createdAt: 1_500, theaterId: "theater-a", tenantId: "tenant-a", resumeAvailable: false },
       },
       sessionOrder: ["session-a"],
       activeTerminalSessionId: "session-a",
@@ -98,7 +98,7 @@ describe("dashboard bridge derivation", () => {
     const noJobs: ConsoleState = {
       ...noSessions,
       sessions: {
-        "session-a": { sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, status: "terminal-only", createdAt: 1_000, theaterId: "theater-a", resumeAvailable: false },
+        "session-a": { sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, status: "terminal-only", turnState: "none", createdAt: 1_000, theaterId: "theater-a", resumeAvailable: false },
       },
       sessionOrder: ["session-a"],
     };

--- a/runtime/fleet-console/tests/format.test.ts
+++ b/runtime/fleet-console/tests/format.test.ts
@@ -10,6 +10,7 @@ function makeSession(overrides: Partial<SessionInfo>): SessionInfo {
     cwdLabel: "alpha",
     sequence: 1,
     status: "terminal-only",
+    turnState: "none",
     createdAt: 1,
     resumeAvailable: false,
     ...overrides,

--- a/runtime/fleet-console/tests/operation-search.test.ts
+++ b/runtime/fleet-console/tests/operation-search.test.ts
@@ -10,6 +10,7 @@ const THEATER_GAMMA: TheaterInfo = { id: "theater-gamma", label: "Alpha Harbor",
 function makeState(sessions: readonly (Omit<SessionInfo, "resumeAvailable" | "turnState"> & { readonly resumeAvailable?: boolean; readonly turnState?: SessionInfo["turnState"] })[], theaters: readonly TheaterInfo[] = [THEATER_ALPHA, THEATER_BETA]): ConsoleState {
   const entries: SessionInfo[] = sessions.map((session) => ({ ...session, resumeAvailable: session.resumeAvailable ?? false, turnState: session.turnState ?? "none" }));
   return {
+    operationToasts: [],
     connection: "connecting",
     connectionError: null,
     activeTheme: "maritime",

--- a/runtime/fleet-console/tests/operation-search.test.ts
+++ b/runtime/fleet-console/tests/operation-search.test.ts
@@ -7,8 +7,8 @@ const THEATER_ALPHA: TheaterInfo = { id: "theater-alpha", label: "Alpha Harbor",
 const THEATER_BETA: TheaterInfo = { id: "theater-beta", label: "Beta Dock", createdAt: "2026-06-16T00:00:00.000Z", lastOpenedAt: "2026-06-16T00:00:00.000Z", hasWiki: false, activeAdmiralCount: 0 };
 const THEATER_GAMMA: TheaterInfo = { id: "theater-gamma", label: "Alpha Harbor", createdAt: "2026-06-16T00:00:00.000Z", lastOpenedAt: "2026-06-16T00:00:00.000Z", hasWiki: false, activeAdmiralCount: 0 };
 
-function makeState(sessions: readonly (Omit<SessionInfo, "resumeAvailable"> & { readonly resumeAvailable?: boolean })[], theaters: readonly TheaterInfo[] = [THEATER_ALPHA, THEATER_BETA]): ConsoleState {
-  const entries: SessionInfo[] = sessions.map((session) => ({ ...session, resumeAvailable: session.resumeAvailable ?? false }));
+function makeState(sessions: readonly (Omit<SessionInfo, "resumeAvailable" | "turnState"> & { readonly resumeAvailable?: boolean; readonly turnState?: SessionInfo["turnState"] })[], theaters: readonly TheaterInfo[] = [THEATER_ALPHA, THEATER_BETA]): ConsoleState {
+  const entries: SessionInfo[] = sessions.map((session) => ({ ...session, resumeAvailable: session.resumeAvailable ?? false, turnState: session.turnState ?? "none" }));
   return {
     connection: "connecting",
     connectionError: null,


### PR DESCRIPTION
## Summary

`console-op-indicator` 브랜치의 Fleet Console UX 작업 3건을 `canary`에 반영합니다.

- **Operation 인디케이터 — 턴 상태 반영**: Agent CLI 턴 상태에 따라 첫 턴 전 grey, 처리 중 amber, 종료 후 green으로 표시하고, 캐리어 작업이 실행 중일 때는 기존 live 색을 유지합니다.
- **Operation 상태변경 토스트**: 백그라운드 Operation이 캐리어 출격/귀환을 보고하면 상단 중앙 토스트가 해당 Theater·Operation을 알리고 Go 컨트롤로 점프합니다(닫기 또는 10초 후 해제, 현재 보고 있는 Operation은 억제).
- **in-console 디렉터리 브라우저 재설계**: 다단 폴더 그리드를 집중형 **단일 컬럼** 브라우저로 교체 — breadcrumb 경로 내비, 타입투필터, 전체 키보드 내비(↑↓/Enter/Backspace/Esc 2단계), 싱글클릭 진입, footer의 "Theater Root + Establish Theater"로 선택 대상 명확화. Maritime Console 토큰 위에서 "theater of operations" 정체성으로 정렬(작전구역 — 정박지 아님).

## Type of Change

- [x] feat — new feature or carrier capability

## Scope

- [x] `runtime/fleet-console` — Console React surface(컴포넌트/스타일) + CHANGELOG

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — green
- [x] `pnpm --filter @dotobokuri/fleet-console build` — green
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 310 passed (27 files)
- [x] console-e2e(playwriter 실브라우저): 디렉터리 브라우저 필터(87→1)/키보드 하이라이트/breadcrumb 점프/Enter 진입/Up/locked 행/Escape 2단계 검증, pageerror 0