### PR TITLE
feat(console): remove Esc shortcut to exit Operations Map fullscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+- [core] The Fleet Console Operations Map fullscreen no longer exits on the Esc key; it can now only be exited with the maximize/restore control.
+
 ## [1.7.1] - 2026-06-17
 
 Release v1.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+- [core] Fleet Console now guides first-time operators with a commissioning walkthrough — registering a Theater, opening an Operation, and observing carriers — shown automatically on the first empty-bridge launch, reopenable anytime from the Welcome dashboard, and surfaced as a setup action in the empty Theater state.
+
 ### Changed
 - [core] The Fleet Console Operations Map fullscreen no longer exits on the Esc key; it can now only be exited with the maximize/restore control.
 

--- a/runtime/fleet-console/client/src/app.tsx
+++ b/runtime/fleet-console/client/src/app.tsx
@@ -4,6 +4,7 @@ import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { useMaximized } from "./canvas/canvas-store.js";
 import { useOperationsMode } from "./operations-mode.js";
 import { fetchObserverStatus, fetchTerminalSessions, fetchTheaterBootstrap } from "./api.js";
+import { CommissioningOverlay } from "./components/commissioning-overlay.js";
 import { ShortcutsOverlay } from "./components/shortcuts-overlay.js";
 import { ShellOverlay } from "./components/shell-overlay.js";
 import { OperationSearch } from "./components/operation-search.js";
@@ -15,7 +16,7 @@ import { useConsoleState } from "./hooks/use-store.js";
 import { CarrierSettings } from "./pages/carrier-settings.js";
 import { Codex } from "./pages/codex.js";
 import { Operations } from "./pages/operations.js";
-import { applyObserverStatus, hydrateTerminalSessions, hydrateTheaterBootstrap, setState, toggleOperationSearch, toggleShell } from "./store.js";
+import { applyObserverStatus, hydrateTerminalSessions, hydrateTheaterBootstrap, resolveOnboardingOnBootstrap, setState, toggleOperationSearch, toggleShell } from "./store.js";
 import { Welcome } from "./pages/welcome.js";
 
 // 서버는 부팅 시 update 체크를 fire-and-forget으로 시작하므로, 첫 방문이 registry 응답보다
@@ -38,10 +39,14 @@ export function App() {
   useEffect(() => {
     const abort = new AbortController();
     void fetchTheaterBootstrap(abort.signal)
-      .then(hydrateTheaterBootstrap)
+      .then((bootstrap) => {
+        hydrateTheaterBootstrap(bootstrap);
+        resolveOnboardingOnBootstrap();
+      })
       .catch((error) => {
         if (abort.signal.aborted) return;
         setState({ theaterError: error instanceof Error ? error.message : String(error) });
+        resolveOnboardingOnBootstrap();
       });
     void fetchTerminalSessions(abort.signal)
       .then(hydrateTerminalSessions)
@@ -100,6 +105,7 @@ export function App() {
       <ShellOverlay state={state} />
       <OperationSearch state={state} />
       <ShortcutsOverlay state={state} />
+      <CommissioningOverlay state={state} />
       <Toast
         open={state.connectionError !== null}
         tone="error"

--- a/runtime/fleet-console/client/src/app.tsx
+++ b/runtime/fleet-console/client/src/app.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 
-import { setMaximized, useMaximized } from "./canvas/canvas-store.js";
+import { useMaximized } from "./canvas/canvas-store.js";
 import { useOperationsMode } from "./operations-mode.js";
 import { fetchObserverStatus, fetchTerminalSessions, fetchTheaterBootstrap } from "./api.js";
 import { ShortcutsOverlay } from "./components/shortcuts-overlay.js";
@@ -15,7 +15,7 @@ import { useConsoleState } from "./hooks/use-store.js";
 import { CarrierSettings } from "./pages/carrier-settings.js";
 import { Codex } from "./pages/codex.js";
 import { Operations } from "./pages/operations.js";
-import { applyObserverStatus, getState, hydrateTerminalSessions, hydrateTheaterBootstrap, setState, toggleOperationSearch, toggleShell } from "./store.js";
+import { applyObserverStatus, hydrateTerminalSessions, hydrateTheaterBootstrap, setState, toggleOperationSearch, toggleShell } from "./store.js";
 import { Welcome } from "./pages/welcome.js";
 
 // 서버는 부팅 시 update 체크를 fire-and-forget으로 시작하므로, 첫 방문이 registry 응답보다
@@ -30,26 +30,9 @@ export function App() {
   // 최대화는 localStorage에 영속되지만, GNB 숨김은 Map(canvas) Operations 화면에서만 적용한다 —
   // 다른 라우트(Welcome/Codex/Helm)로 가거나 그 상태로 로드되어도 내비게이션이 사라지지 않게 한다.
   const maximizedActive = maximized && pathname.startsWith("/operations") && operationsMode === "canvas";
-  // Esc 핸들러(capture, 한 번만 등록)에서 최신 maximizedActive를 읽기 위한 ref.
-  const maximizedActiveRef = useRef(maximizedActive);
-  maximizedActiveRef.current = maximizedActive;
 
   useEffect(() => {
     return startObserverConnection();
-  }, []);
-
-  // 최대화 중 Esc로 해제한다. capture 단계에서 가장 먼저 실행되며, 아직 어떤 모달/메뉴도 Esc로 닫히기 전이므로
-  // 라이브 store 상태를 읽어 상위 모달(셸·검색·단축키)이나 열린 메뉴가 있으면 그쪽 Esc에 양보한다(전체화면 유지).
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape" || !maximizedActiveRef.current) return;
-      const live = getState();
-      if (live.shellOpen || live.operationSearchOpen || live.shortcutsOpen) return;
-      if (document.querySelector('[role="menu"], [role="dialog"]')) return;
-      setMaximized(false);
-    };
-    window.addEventListener("keydown", handleKeyDown, true);
-    return () => window.removeEventListener("keydown", handleKeyDown, true);
   }, []);
 
   useEffect(() => {

--- a/runtime/fleet-console/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas.tsx
@@ -158,7 +158,7 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
         data-canvas-blocker
         aria-label={maximized ? "맵 최대화 해제" : "맵 최대화"}
         aria-pressed={maximized}
-        title={maximized ? "Exit fullscreen (Esc)" : "Maximize map"}
+        title={maximized ? "Exit fullscreen" : "Maximize map"}
       >
         {maximized ? <RestoreIcon /> : <MaximizeIcon />}
       </button>

--- a/runtime/fleet-console/client/src/components/commissioning-overlay.tsx
+++ b/runtime/fleet-console/client/src/components/commissioning-overlay.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { addTheater, issueTerminalFolderGrant } from "../api.js";
+import { beginAddTheater, closeOnboarding, completeAddTheater, failAddTheater } from "../store.js";
+import type { ConsoleState } from "../types.js";
+import { DirectoryBrowserModal } from "./directory-browser-modal.js";
+
+interface CommissioningOverlayProps {
+  readonly state: ConsoleState;
+}
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+export function CommissioningOverlay({ state }: CommissioningOverlayProps) {
+  const [browserOpen, setBrowserOpen] = useState(false);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+  const primaryActionRef = useRef<HTMLButtonElement | HTMLAnchorElement | null>(null);
+  const cardRef = useRef<HTMLElement | null>(null);
+  const theaterRegistered = state.theaters.length > 0;
+
+  useEffect(() => {
+    if (!state.onboardingOpen) return;
+    returnFocusRef.current = document.activeElement as HTMLElement | null;
+    primaryActionRef.current?.focus();
+    return () => {
+      const target = returnFocusRef.current;
+      returnFocusRef.current = null;
+      target?.focus?.();
+    };
+  }, [state.onboardingOpen]);
+
+  useEffect(() => {
+    if (!state.onboardingOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (browserOpen) return;
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeOnboarding();
+      } else if (event.key === "Tab") {
+        trapFocus(event, cardRef.current);
+      }
+      event.stopImmediatePropagation();
+    };
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [browserOpen, state.onboardingOpen]);
+
+  if (!state.onboardingOpen) return null;
+
+  const handleChooseFolder = () => {
+    setBrowserOpen(true);
+  };
+
+  const handleBrowserCancel = () => {
+    setBrowserOpen(false);
+  };
+
+  const handleBrowserConfirm = async (path: string) => {
+    setBrowserOpen(false);
+    beginAddTheater();
+    try {
+      const folderGrantId = await issueTerminalFolderGrant(path);
+      const result = await addTheater(folderGrantId);
+      completeAddTheater(result);
+    } catch (error) {
+      failAddTheater(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  return (
+    <div className="commissioning-overlay" role="dialog" aria-modal="true" aria-labelledby="commissioning-title">
+      <button type="button" className="commissioning-scrim" onClick={closeOnboarding} aria-label="Close Commissioning guide" />
+      <section className="commissioning-card" ref={cardRef}>
+        <header className="commissioning-header">
+          <span className="commissioning-eyebrow">COMMISSIONING · FLEET CONSOLE</span>
+          <h2 id="commissioning-title">Bring your fleet online</h2>
+          <p>Three steps to go from an empty bridge to live carrier operations.</p>
+        </header>
+
+        <ol className="commissioning-steps">
+          <li className={`commissioning-step commissioning-step--primary ${theaterRegistered ? "is-complete" : "is-current"}`}>
+            <span className="commissioning-step-node" aria-hidden="true">{theaterRegistered ? "✓" : "01"}</span>
+            <div className="commissioning-step-body">
+              <h3>Register a Theater</h3>
+              <p>A Theater is a project directory the fleet operates in. Choose the folder you want to work from.</p>
+              {theaterRegistered ? (
+                <Link
+                  ref={(node) => {
+                    primaryActionRef.current = node;
+                  }}
+                  className="commissioning-primary-action"
+                  to="/operations"
+                  onClick={closeOnboarding}
+                >
+                  Go to Operations →
+                </Link>
+              ) : (
+                <button
+                  ref={(node) => {
+                    primaryActionRef.current = node;
+                  }}
+                  type="button"
+                  className="commissioning-primary-action is-live"
+                  disabled={state.addingTheater}
+                  onClick={handleChooseFolder}
+                >
+                  {state.addingTheater ? "Adding Theater…" : "Choose a folder…"}
+                </button>
+              )}
+              {state.theaterError ? <p className="commissioning-error" role="alert">{state.theaterError}</p> : null}
+            </div>
+          </li>
+
+          <li className="commissioning-step">
+            <span className="commissioning-step-node" aria-hidden="true">02</span>
+            <div className="commissioning-step-body">
+              <h3>Open an Operation</h3>
+              <p>An Operation is a live terminal session running an Agent CLI. Start one from the Operations tab to begin a working session.</p>
+              <Link className="commissioning-secondary-link" to="/operations" onClick={closeOnboarding}>
+                Go to Operations
+              </Link>
+            </div>
+          </li>
+
+          <li className="commissioning-step">
+            <span className="commissioning-step-node" aria-hidden="true">03</span>
+            <div className="commissioning-step-body">
+              <h3>Observe carriers</h3>
+              <p>Carriers are specialist agents your Admiral dispatches. Their sorties stream here in real time as they run.</p>
+            </div>
+          </li>
+        </ol>
+
+        <footer className="commissioning-footer">
+          <p>Theaters with a Fleet Wiki knowledge root also unlock Codex — your decision log and reference library.</p>
+          <button type="button" className="commissioning-skip" onClick={closeOnboarding}>Skip for now</button>
+        </footer>
+      </section>
+      <DirectoryBrowserModal open={browserOpen} onCancel={handleBrowserCancel} onConfirm={handleBrowserConfirm} />
+    </div>
+  );
+}
+
+function trapFocus(event: KeyboardEvent, container: HTMLElement | null): void {
+  if (!container) return;
+  const focusable = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (!first || !last) return;
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}

--- a/runtime/fleet-console/client/src/pages/welcome.tsx
+++ b/runtime/fleet-console/client/src/pages/welcome.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { fetchCarriers, fetchObserverStatus } from "../api.js";
 import { buildBridgeView, type BridgeView, type TheaterReadiness } from "../dashboard.js";
 import { fetchKnowledgeReadiness, type KnowledgeReadinessSummary } from "../dashboard-knowledge.js";
+import { openOnboarding } from "../store.js";
 import type { CarrierReadinessEntry, ConsoleState, ObserverStatus } from "../types.js";
 
 interface WelcomeProps {
@@ -90,23 +91,40 @@ export function Welcome({ state }: WelcomeProps) {
 
   return (
     <main className="welcome-page">
+      <header className="welcome-header">
+        <div>
+          <p className="bridge-kicker">Bridge Readiness</p>
+          <h2>Welcome</h2>
+        </div>
+        <button type="button" className="welcome-guide-button" onClick={openOnboarding}>
+          Commissioning guide
+        </button>
+      </header>
+
       <section className="bridge-matrix" aria-labelledby="bridge-matrix-title">
         <div className="bridge-section-heading">
           <p className="bridge-kicker">Theater Capability Matrix</p>
           <h3 id="bridge-matrix-title">Registered Theaters</h3>
         </div>
-        <div className="bridge-matrix-table" role="table" aria-label="Theater capability matrix">
-          <div className="bridge-matrix-row bridge-matrix-head" role="row">
-            <span role="columnheader">Theater</span>
-            <span role="columnheader">Codex</span>
-            <span role="columnheader">Active</span>
-            <span role="columnheader">Terminals</span>
-            <span role="columnheader">Updated</span>
+        {view.theaters.length > 0 ? (
+          <div className="bridge-matrix-table" role="table" aria-label="Theater capability matrix">
+            <div className="bridge-matrix-row bridge-matrix-head" role="row">
+              <span role="columnheader">Theater</span>
+              <span role="columnheader">Codex</span>
+              <span role="columnheader">Active</span>
+              <span role="columnheader">Terminals</span>
+              <span role="columnheader">Updated</span>
+            </div>
+            {view.theaters.map((theater) => <TheaterRow key={theater.id} theater={theater} />)}
           </div>
-          {view.theaters.length > 0 ? view.theaters.map((theater) => <TheaterRow key={theater.id} theater={theater} />) : (
-            <p className="bridge-matrix-empty">No Theaters registered.</p>
-          )}
-        </div>
+        ) : (
+          <div className="bridge-matrix-empty bridge-matrix-empty--first-run">
+            <p>No Theaters registered. Set up a project directory first, then open an Operation from that Theater.</p>
+            <button type="button" className="bridge-matrix-empty-action" onClick={openOnboarding}>
+              Set up your fleet
+            </button>
+          </div>
+        )}
       </section>
 
       <section className="bridge-carriers" aria-labelledby="bridge-carriers-title">

--- a/runtime/fleet-console/client/src/store.ts
+++ b/runtime/fleet-console/client/src/store.ts
@@ -34,6 +34,7 @@ const ACTIVE_THEATER_STORAGE_KEY = "fleet-console.activeTheaterId";
 const THEME_STORAGE_KEY = "fleet-console.activeTheme";
 const RENDERER_STORAGE_KEY = "fleet-console.terminalRenderer";
 const EXPANDED_SESSIONS_STORAGE_KEY = "fleet-console.expandedSessions";
+const COMMISSIONING_SEEN_STORAGE_KEY = "fleet-console.commissioningSeen";
 const DEFAULT_THEME: ThemeId = "maritime";
 const DEFAULT_RENDERER: TerminalRenderer = "webgl";
 export const SHELL_SESSION_ID = "shell";
@@ -63,6 +64,8 @@ let state: ConsoleState = {
   shellOpen: false,
   operationSearchOpen: false,
   shortcutsOpen: false,
+  onboardingOpen: false,
+  bootstrapped: false,
   pendingOperationFocus: null,
   selectedJobId: null,
   expandedSessionIds: readStoredExpandedSessions(),
@@ -317,6 +320,23 @@ export function closeShortcuts(): void {
 
 export function toggleShortcuts(): void {
   setState({ shortcutsOpen: !state.shortcutsOpen });
+}
+
+export function openOnboarding(): void {
+  if (state.onboardingOpen) return;
+  setState({ onboardingOpen: true });
+}
+
+export function closeOnboarding(): void {
+  writeStoredCommissioningSeen(true);
+  if (!state.onboardingOpen) return;
+  setState({ onboardingOpen: false });
+}
+
+export function resolveOnboardingOnBootstrap(): void {
+  if (state.bootstrapped) return;
+  const shouldOpen = state.theaters.length === 0 && !readStoredCommissioningSeen();
+  setState({ bootstrapped: true, onboardingOpen: shouldOpen ? true : state.onboardingOpen });
 }
 
 export function toggleTerminalZoom(sessionId: string): void {
@@ -681,6 +701,15 @@ function readStoredExpandedSessions(): readonly string[] {
   }
 }
 
+function readStoredCommissioningSeen(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(COMMISSIONING_SEEN_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
 function writeStoredTheme(theme: ThemeId): void {
   if (typeof window === "undefined") return;
   try {
@@ -703,6 +732,15 @@ function writeStoredExpandedSessions(ids: readonly string[]): void {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(EXPANDED_SESSIONS_STORAGE_KEY, JSON.stringify(ids));
+  } catch {
+    // 브라우저 저장소가 막힌 환경에서는 현재 세션 상태만 유지한다.
+  }
+}
+
+function writeStoredCommissioningSeen(seen: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(COMMISSIONING_SEEN_STORAGE_KEY, seen ? "1" : "0");
   } catch {
     // 브라우저 저장소가 막힌 환경에서는 현재 세션 상태만 유지한다.
   }

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -3440,6 +3440,48 @@
   padding: var(--space-7) var(--space-6) var(--space-10);
 }
 
+.welcome-header {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid color-mix(in oklch, var(--surface-rim) 64%, transparent);
+}
+
+.welcome-header h2 {
+  margin: 0;
+  color: var(--ink-pearl);
+  font-family: var(--font-display);
+  font-size: 30px;
+  font-variation-settings: "opsz" 42;
+  font-weight: 560;
+  letter-spacing: 0;
+}
+
+.welcome-guide-button {
+  min-height: 36px;
+  padding: 0 var(--space-4);
+  border: 1px solid color-mix(in oklch, var(--brass) 32%, var(--surface-rim));
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--surface-glass) 42%, transparent);
+  color: var(--brass-bright);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 760;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  transition:
+    border-color var(--duration-fast) var(--ease-glide),
+    background var(--duration-fast) var(--ease-glide);
+}
+
+.welcome-guide-button:hover {
+  border-color: color-mix(in oklch, var(--brass) 52%, var(--surface-rim));
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
+}
+
 .bridge-kicker {
   margin: 0;
   color: var(--ink-fog);
@@ -3752,6 +3794,43 @@
   padding: var(--space-4);
   color: var(--ink-fog);
   font-size: 13px;
+}
+
+.bridge-matrix-empty--first-run {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  border-top: 1px solid color-mix(in oklch, var(--surface-rim) 72%, transparent);
+  border-bottom: 1px solid color-mix(in oklch, var(--surface-rim) 58%, transparent);
+}
+
+.bridge-matrix-empty--first-run p {
+  margin: 0;
+}
+
+.bridge-matrix-empty-action {
+  flex: none;
+  min-height: 38px;
+  padding: 0 var(--space-4);
+  border: 1px solid color-mix(in oklch, var(--aurora) 48%, var(--surface-rim));
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--aurora) 16%, transparent);
+  color: var(--ink-pearl);
+  box-shadow: 0 0 0 1px color-mix(in oklch, var(--aurora) 14%, transparent), 0 0 18px -8px var(--aurora-glow);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 780;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition:
+    border-color var(--duration-fast) var(--ease-glide),
+    background var(--duration-fast) var(--ease-glide);
+}
+
+.bridge-matrix-empty-action:hover {
+  border-color: color-mix(in oklch, var(--aurora) 64%, var(--surface-rim));
+  background: color-mix(in oklch, var(--aurora) 22%, transparent);
 }
 
 /* ── Operations 터미널 ─────────────────────────────────────────────
@@ -4397,11 +4476,271 @@
   line-height: 1.55;
 }
 
+.commissioning-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 94;
+  display: grid;
+  place-items: center;
+  padding: var(--space-6);
+}
+
+.commissioning-scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: color-mix(in oklch, var(--ink-abyss) 62%, transparent);
+  backdrop-filter: blur(8px) saturate(126%);
+  cursor: default;
+}
+
+.commissioning-card {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: var(--space-5);
+  width: min(920px, 94vw);
+  max-height: min(820px, 88vh);
+  padding: var(--space-6);
+  overflow: hidden;
+  border: 1px solid var(--surface-rim-strong);
+  border-radius: var(--radius-xl);
+  background:
+    radial-gradient(120% 80% at 50% -12%, color-mix(in oklch, var(--brass) 10%, transparent), transparent 58%),
+    radial-gradient(70% 80% at 100% 20%, color-mix(in oklch, var(--aurora) 8%, transparent), transparent 62%),
+    var(--surface-glass-strong);
+  box-shadow: var(--shadow-floating), var(--shadow-anchor);
+  backdrop-filter: blur(20px) saturate(142%);
+  animation: codex-rise 360ms var(--ease-spring) both;
+}
+
+.commissioning-header {
+  display: grid;
+  gap: var(--space-2);
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid color-mix(in oklch, var(--surface-rim) 72%, transparent);
+}
+
+.commissioning-eyebrow {
+  color: var(--brass-bright);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 780;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.commissioning-header h2 {
+  margin: 0;
+  color: var(--ink-pearl);
+  font-family: var(--font-display);
+  font-size: 52px;
+  font-variation-settings: "opsz" 60;
+  font-weight: 560;
+  letter-spacing: 0;
+  line-height: 0.98;
+}
+
+.commissioning-header p {
+  max-width: 560px;
+  margin: 0;
+  color: var(--ink-spectral);
+  font-size: 16px;
+  line-height: 1.55;
+}
+
+.commissioning-steps {
+  display: grid;
+  gap: 0;
+  min-height: 0;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.commissioning-step {
+  position: relative;
+  display: grid;
+  grid-template-columns: 58px minmax(0, 1fr);
+  gap: var(--space-4);
+  min-height: 150px;
+  padding: var(--space-4) 0;
+}
+
+.commissioning-step::after {
+  content: "";
+  position: absolute;
+  top: calc(var(--space-4) + 42px);
+  bottom: calc(var(--space-4) * -1);
+  left: 21px;
+  width: 1px;
+  background: linear-gradient(180deg, color-mix(in oklch, var(--brass) 34%, transparent), color-mix(in oklch, var(--surface-rim) 78%, transparent));
+}
+
+.commissioning-step:last-child::after {
+  display: none;
+}
+
+.commissioning-step-node {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  border: 1px solid color-mix(in oklch, var(--brass) 48%, var(--surface-rim));
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--ink-deep) 76%, var(--surface-glass));
+  color: var(--brass-bright);
+  box-shadow: var(--shadow-anchor);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 820;
+  letter-spacing: 0.08em;
+}
+
+.commissioning-step.is-current .commissioning-step-node {
+  border-color: color-mix(in oklch, var(--aurora) 54%, var(--surface-rim));
+  color: var(--aurora);
+  box-shadow: 0 0 0 1px color-mix(in oklch, var(--aurora) 18%, transparent), 0 0 18px -6px var(--aurora-glow);
+}
+
+.commissioning-step.is-complete .commissioning-step-node {
+  color: var(--brass-bright);
+}
+
+.commissioning-step-body {
+  display: grid;
+  align-content: start;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.commissioning-step-body h3 {
+  margin: 0;
+  color: var(--ink-pearl);
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-variation-settings: "opsz" 36;
+  font-weight: 560;
+  letter-spacing: 0;
+}
+
+.commissioning-step-body p {
+  max-width: 620px;
+  margin: 0;
+  color: var(--ink-fog);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.commissioning-primary-action,
+.commissioning-secondary-link,
+.commissioning-skip {
+  justify-self: start;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  font-weight: 780;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.commissioning-primary-action {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 40px;
+  padding: 0 var(--space-4);
+  border-color: color-mix(in oklch, var(--aurora) 50%, var(--surface-rim));
+  background: color-mix(in oklch, var(--aurora) 18%, transparent);
+  color: var(--ink-pearl);
+  box-shadow: 0 0 0 1px color-mix(in oklch, var(--aurora) 14%, transparent), 0 0 20px -8px var(--aurora-glow);
+  font-size: 11px;
+  transition:
+    border-color var(--duration-fast) var(--ease-glide),
+    background var(--duration-fast) var(--ease-glide);
+}
+
+.commissioning-primary-action.is-live::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--aurora);
+  box-shadow: 0 0 0 0 var(--aurora-glow);
+  animation: aurora-pulse 1.4s var(--ease-glide) infinite;
+}
+
+.commissioning-primary-action:hover:not(:disabled) {
+  border-color: color-mix(in oklch, var(--aurora) 68%, var(--surface-rim));
+  background: color-mix(in oklch, var(--aurora) 24%, transparent);
+}
+
+.commissioning-primary-action:disabled {
+  color: var(--ink-rim);
+  cursor: not-allowed;
+}
+
+.commissioning-secondary-link,
+.commissioning-skip {
+  min-height: 34px;
+  padding: 0 var(--space-3);
+  color: var(--brass-bright);
+  background: color-mix(in oklch, var(--brass) 10%, transparent);
+  font-size: 10px;
+  line-height: 32px;
+  transition:
+    border-color var(--duration-fast) var(--ease-glide),
+    background var(--duration-fast) var(--ease-glide);
+}
+
+.commissioning-secondary-link:hover,
+.commissioning-skip:hover {
+  border-color: color-mix(in oklch, var(--brass) 52%, var(--surface-rim));
+  background: color-mix(in oklch, var(--brass) 16%, transparent);
+}
+
+.commissioning-error {
+  color: var(--coral) !important;
+  font-family: var(--font-mono);
+  font-size: 11px !important;
+}
+
+.commissioning-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding-top: var(--space-4);
+  border-top: 1px solid color-mix(in oklch, var(--surface-rim) 72%, transparent);
+}
+
+.commissioning-footer p {
+  margin: 0;
+  color: var(--ink-fog);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.commissioning-skip {
+  flex: none;
+  background: color-mix(in oklch, var(--surface-glass) 52%, transparent);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .job-overlay-card,
   .shell-overlay-card,
   .operation-search-overlay,
-  .shortcuts-overlay-card {
+  .shortcuts-overlay-card,
+  .commissioning-card {
+    animation: none;
+  }
+
+  .commissioning-primary-action.is-live::before {
     animation: none;
   }
 
@@ -5495,6 +5834,17 @@
     grid-template-columns: minmax(0, 1fr);
   }
 
+  .welcome-header,
+  .bridge-matrix-empty--first-run {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .welcome-guide-button,
+  .bridge-matrix-empty-action {
+    width: 100%;
+  }
+
   .bridge-knowledge-grid,
   .bridge-health-strip {
     grid-template-columns: minmax(0, 1fr);
@@ -5526,5 +5876,40 @@
 
   .operation-search-theater {
     max-width: 100%;
+  }
+
+  .commissioning-overlay {
+    padding: var(--space-3);
+  }
+
+  .commissioning-card {
+    max-height: calc(100vh - (var(--space-3) * 2));
+    padding: var(--space-4);
+  }
+
+  .commissioning-header h2 {
+    font-size: 34px;
+  }
+
+  .commissioning-step {
+    grid-template-columns: 46px minmax(0, 1fr);
+  }
+
+  .commissioning-step::after {
+    left: 18px;
+  }
+
+  .commissioning-step-node {
+    width: 38px;
+    height: 38px;
+  }
+
+  .commissioning-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .commissioning-skip {
+    width: 100%;
   }
 }

--- a/runtime/fleet-console/client/src/types.ts
+++ b/runtime/fleet-console/client/src/types.ts
@@ -258,6 +258,8 @@ export interface ConsoleState {
   readonly shellOpen: boolean;
   readonly operationSearchOpen: boolean;
   readonly shortcutsOpen: boolean;
+  readonly onboardingOpen: boolean;
+  readonly bootstrapped: boolean;
   // 검색 등에서 특정 Operation으로 이동을 요청한 일회성 신호. Map 모드는 이를 소비해 해당 패널로 확대한다.
   readonly pendingOperationFocus: string | null;
   readonly selectedJobId: string | null;

--- a/runtime/fleet-console/tests/dashboard.test.ts
+++ b/runtime/fleet-console/tests/dashboard.test.ts
@@ -28,6 +28,8 @@ const BASE_STATE: ConsoleState = {
   shellOpen: false,
   operationSearchOpen: false,
   shortcutsOpen: false,
+  onboardingOpen: false,
+  bootstrapped: false,
   pendingOperationFocus: null,
   selectedJobId: null,
   expandedSessionIds: [],

--- a/runtime/fleet-console/tests/operation-search.test.ts
+++ b/runtime/fleet-console/tests/operation-search.test.ts
@@ -34,6 +34,8 @@ function makeState(sessions: readonly (Omit<SessionInfo, "resumeAvailable" | "tu
     shellOpen: false,
     operationSearchOpen: false,
     shortcutsOpen: false,
+    onboardingOpen: false,
+    bootstrapped: false,
     pendingOperationFocus: null,
     selectedJobId: null,
     expandedSessionIds: [],

--- a/runtime/fleet-console/tests/store.test.ts
+++ b/runtime/fleet-console/tests/store.test.ts
@@ -14,14 +14,17 @@ import {
   closeShell,
   completeCreateTerminalSession,
   closeOperationSearch,
+  closeOnboarding,
   failResumeTerminalSession,
   focusOperation,
   getState,
   hydrateTerminalSessions,
   hydrateTheaters,
+  openOnboarding,
   openOperationSearch,
   openShortcuts,
   readStoredRenderer,
+  resolveOnboardingOnBootstrap,
   selectJob,
   selectTerminalSession,
   selectedJob,
@@ -41,6 +44,7 @@ const TENANT: ObservedTenant = { tenantId: "tenant-1", tenantLabel: "Alpha", cre
 const THEATER_A: TheaterInfo = { id: "theater-a", label: "Alpha", createdAt: "2026-06-13T00:00:00.000Z", lastOpenedAt: "2026-06-13T00:00:00.000Z", hasWiki: true, activeAdmiralCount: 1 };
 const THEATER_B: TheaterInfo = { id: "theater-b", label: "Beta", createdAt: "2026-06-13T00:00:00.000Z", lastOpenedAt: "2026-06-13T00:00:01.000Z", hasWiki: false, activeAdmiralCount: 0 };
 const RENDERER_STORAGE_KEY = "fleet-console.terminalRenderer";
+const COMMISSIONING_SEEN_STORAGE_KEY = "fleet-console.commissioningSeen";
 
 function makeEvent(id: number, type: string, event: Record<string, unknown>, tenantId = "tenant-1", jobId = "job-1"): ObservedEvent {
   return { id, tenantId, jobId, type, at: 1_000 + id, event: { type, jobId, ...event } };
@@ -84,6 +88,8 @@ beforeEach(() => {
     shellOpen: false,
     operationSearchOpen: false,
     shortcutsOpen: false,
+    onboardingOpen: false,
+    bootstrapped: false,
     pendingOperationFocus: null,
     selectedJobId: null,
   });
@@ -361,6 +367,52 @@ describe("store", () => {
 
     toggleShortcuts();
     expect(getState().shortcutsOpen).toBe(false);
+  });
+
+  it("opens commissioning automatically after bootstrap only when no Theaters are registered and it has not been seen", () => {
+    const storage = new Map<string, string>();
+    mockLocalStorage(storage);
+
+    hydrateTheaters([]);
+    expect(getState()).toMatchObject({ bootstrapped: false, onboardingOpen: false });
+
+    resolveOnboardingOnBootstrap();
+
+    expect(getState()).toMatchObject({ bootstrapped: true, onboardingOpen: true });
+  });
+
+  it("does not open commissioning automatically when Theaters exist", () => {
+    const storage = new Map<string, string>();
+    mockLocalStorage(storage);
+
+    hydrateTheaters([THEATER_A]);
+    resolveOnboardingOnBootstrap();
+
+    expect(getState()).toMatchObject({ bootstrapped: true, onboardingOpen: false });
+  });
+
+  it("does not open commissioning automatically after it has been dismissed", () => {
+    const storage = new Map<string, string>([[COMMISSIONING_SEEN_STORAGE_KEY, "1"]]);
+    mockLocalStorage(storage);
+
+    hydrateTheaters([]);
+    resolveOnboardingOnBootstrap();
+
+    expect(getState()).toMatchObject({ bootstrapped: true, onboardingOpen: false });
+  });
+
+  it("opens and closes commissioning manually while persisting the dismissed marker", () => {
+    const storage = new Map<string, string>();
+    mockLocalStorage(storage);
+
+    expect(getState().onboardingOpen).toBe(false);
+
+    openOnboarding();
+    expect(getState().onboardingOpen).toBe(true);
+
+    closeOnboarding();
+    expect(getState().onboardingOpen).toBe(false);
+    expect(storage.get(COMMISSIONING_SEEN_STORAGE_KEY)).toBe("1");
   });
 
   it("binds hydrated terminal sessions to tenants without changing the active session", () => {


### PR DESCRIPTION
## Summary
- Operations Map(canvas) 전체화면을 ESC 키로 빠져나가던 단축키를 원천 제거하고, 전체화면 진입/해제는 우하단 maximize/restore 단추로만 수행하도록 변경합니다.
- `app.tsx`의 전역 ESC keydown 핸들러와 그 전용 ref·고아 import를 제거하고, `canvas.tsx` 단추 tooltip의 `(Esc)` 표기를 제거했습니다. Map 단축키 카탈로그에는 ESC 항목이 없어 변경이 없습니다.

## Type of Change
- [x] feat — new feature or carrier capability

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — green
- [x] `pnpm --filter @dotobokuri/fleet-console build` — green
- [x] console-e2e(실브라우저): 전체화면 중 ESC 입력해도 해제되지 않음 확인, 단추로만 진입/해제 동작, 회귀로 패널 rename ESC 취소·Operation search(Cmd+K) 오버레이 ESC 닫기 정상

## Notes for Reviewers
- ESC 제거는 의도된 UX 변경입니다(단축키 폐지 → 단추 일원화). `canvas-panel`의 rename 취소 ESC와 오버레이 닫기 ESC는 별개 핸들러로 그대로 보존됩니다.