### PR TITLE
feat(console): mark running operation panels with aurora underway glow

### DIFF
--- a/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
@@ -188,7 +188,7 @@ export function CanvasPanel({ state, session, geometry, viewport, active, getCan
   return (
     <>
     <article
-      className={`canvas-panel ${active ? "is-active" : ""}`}
+      className={`canvas-panel ${active ? "is-active" : ""} ${activeJobCount > 0 ? "is-running" : ""}`}
       style={{
         left: geometry.x,
         top: geometry.y,

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -1676,6 +1676,73 @@
     0 0 0 1px color-mix(in oklch, var(--brass) 18%, transparent);
 }
 
+/* 작업 진행 중(activeJobCount > 0)인 에이전트 패널 = "출항(underway)" 상태.
+   aurora("지금 살아있는 것") 언어로 선체를 표현한다. brass(선택/포커스)와 역할이
+   분리되므로 선택+진행이 겹쳐도 brass 보더와 aurora 링이 각자 의미로 공존한다.
+   overflow: hidden을 피해 외곽 글로우는 패널 자체 box-shadow로, 외곽선은 inset 의사요소로 그린다. */
+.canvas-panel.is-running {
+  --underway-glow: 18px;
+  box-shadow:
+    var(--shadow-soft),
+    0 0 var(--underway-glow) -6px var(--aurora-glow);
+  animation: panel-underway-breathe 1.8s ease-in-out infinite;
+}
+
+/* 선택(is-active) + 진행(is-running) 동시: brass 선택 링 + aurora 출항 글로우 공존 */
+.canvas-panel.is-running.is-active {
+  border-color: color-mix(in oklch, var(--brass) 54%, var(--surface-rim));
+  box-shadow:
+    var(--shadow-soft),
+    0 0 0 1px color-mix(in oklch, var(--brass) 18%, transparent),
+    0 0 var(--underway-glow) -6px var(--aurora-glow);
+}
+
+/* 선체 외곽선 두 겹: ::before = 상시 aurora 림(running 기준선), ::after = 순회 항적광.
+   linear-gradient 마스크로 테두리 띠만 남겨 링을 만든다(가운데는 마스킹되어 비침). */
+.canvas-panel.is-running::before,
+.canvas-panel.is-running::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  padding: 1.5px;
+  border-radius: inherit;
+  pointer-events: none;
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+}
+
+/* 상시 aurora 선체 림 — running의 정적 기준선(reduced-motion에서도 잔존) */
+.canvas-panel.is-running::before {
+  background: color-mix(in oklch, var(--aurora) 38%, transparent);
+}
+
+/* 순회하는 aurora 항적광(comet) — 선체를 따라 도는 밝은 호 */
+.canvas-panel.is-running::after {
+  background: conic-gradient(
+    from var(--wake-angle),
+    transparent 0deg,
+    transparent 210deg,
+    color-mix(in oklch, var(--aurora) 55%, transparent) 300deg,
+    var(--aurora) 345deg,
+    transparent 360deg
+  );
+  animation: panel-underway-orbit 4.5s linear infinite;
+}
+
+/* prefers-reduced-motion: 항적광/호흡 정지, 정적 aurora 림 + 정적 글로우만 유지 */
+@media (prefers-reduced-motion: reduce) {
+  .canvas-panel.is-running::after {
+    display: none;
+  }
+}
+
 /* 진행 중 캐리어 스트림을 패널 바깥 아래에 floating으로 띄우는 dock. left/top/width는 패널 geometry를
    인라인으로 받고(top=패널 하단 모서리), translateY로 작은 간격만큼 아래로 내려 패널 하단에 정렬한다. */
 .canvas-panel-jobdock {

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -1677,15 +1677,15 @@
 }
 
 /* 작업 진행 중(activeJobCount > 0)인 에이전트 패널 = "출항(underway)" 상태.
-   aurora("지금 살아있는 것") 언어로 선체를 표현한다. brass(선택/포커스)와 역할이
-   분리되므로 선택+진행이 겹쳐도 brass 보더와 aurora 링이 각자 의미로 공존한다.
+   aurora("지금 살아있는 것") 언어로 선체를 정적으로 표현한다. brass(선택/포커스)와 역할이
+   분리되므로 선택+진행이 겹쳐도 brass 보더와 aurora 림이 각자 의미로 공존한다.
+   AGENTS.md 모션 규약상 ambient 무한 모션은 금지되므로 진행 신호는 정적 aurora 림+글로우로
+   표현하고, 살아있는 모션은 기존 허용된 라이브 비콘(점)에 맡긴다.
    overflow: hidden을 피해 외곽 글로우는 패널 자체 box-shadow로, 외곽선은 inset 의사요소로 그린다. */
 .canvas-panel.is-running {
-  --underway-glow: 18px;
   box-shadow:
     var(--shadow-soft),
-    0 0 var(--underway-glow) -6px var(--aurora-glow);
-  animation: panel-underway-breathe 1.8s ease-in-out infinite;
+    0 0 20px -6px var(--aurora-glow);
 }
 
 /* 선택(is-active) + 진행(is-running) 동시: brass 선택 링 + aurora 출항 글로우 공존 */
@@ -1694,13 +1694,12 @@
   box-shadow:
     var(--shadow-soft),
     0 0 0 1px color-mix(in oklch, var(--brass) 18%, transparent),
-    0 0 var(--underway-glow) -6px var(--aurora-glow);
+    0 0 20px -6px var(--aurora-glow);
 }
 
-/* 선체 외곽선 두 겹: ::before = 상시 aurora 림(running 기준선), ::after = 순회 항적광.
+/* 상시 aurora 선체 림 — running의 정적 신호.
    linear-gradient 마스크로 테두리 띠만 남겨 링을 만든다(가운데는 마스킹되어 비침). */
-.canvas-panel.is-running::before,
-.canvas-panel.is-running::after {
+.canvas-panel.is-running::before {
   content: "";
   position: absolute;
   inset: 0;
@@ -1708,6 +1707,7 @@
   padding: 1.5px;
   border-radius: inherit;
   pointer-events: none;
+  background: color-mix(in oklch, var(--aurora) 38%, transparent);
   -webkit-mask:
     linear-gradient(#fff 0 0) content-box,
     linear-gradient(#fff 0 0);
@@ -1716,31 +1716,6 @@
     linear-gradient(#fff 0 0) content-box,
     linear-gradient(#fff 0 0);
   mask-composite: exclude;
-}
-
-/* 상시 aurora 선체 림 — running의 정적 기준선(reduced-motion에서도 잔존) */
-.canvas-panel.is-running::before {
-  background: color-mix(in oklch, var(--aurora) 38%, transparent);
-}
-
-/* 순회하는 aurora 항적광(comet) — 선체를 따라 도는 밝은 호 */
-.canvas-panel.is-running::after {
-  background: conic-gradient(
-    from var(--wake-angle),
-    transparent 0deg,
-    transparent 210deg,
-    color-mix(in oklch, var(--aurora) 55%, transparent) 300deg,
-    var(--aurora) 345deg,
-    transparent 360deg
-  );
-  animation: panel-underway-orbit 4.5s linear infinite;
-}
-
-/* prefers-reduced-motion: 항적광/호흡 정지, 정적 aurora 림 + 정적 글로우만 유지 */
-@media (prefers-reduced-motion: reduce) {
-  .canvas-panel.is-running::after {
-    display: none;
-  }
 }
 
 /* 진행 중 캐리어 스트림을 패널 바깥 아래에 floating으로 띄우는 dock. left/top/width는 패널 geometry를

--- a/runtime/fleet-console/client/src/styles/theme.css
+++ b/runtime/fleet-console/client/src/styles/theme.css
@@ -305,6 +305,39 @@ a {
   }
 }
 
+/* 작업 진행 중(running) 에이전트 패널의 "출항(underway)" 시각효과 토큰.
+   --wake-angle: 선체 외곽을 순회하는 aurora 항적광의 각도.
+   --underway-glow: 선체 외곽 호흡 글로우의 blur 반경(@property 등록으로 부드러운 보간). */
+@property --wake-angle {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+
+@property --underway-glow {
+  syntax: "<length>";
+  initial-value: 18px;
+  inherits: false;
+}
+
+/* aurora 항적광이 선체를 한 바퀴 순회 */
+@keyframes panel-underway-orbit {
+  to {
+    --wake-angle: 360deg;
+  }
+}
+
+/* 선체 외곽 글로우가 호흡하듯 맥동(라이브 비콘과 동일 리듬) */
+@keyframes panel-underway-breathe {
+  0%,
+  100% {
+    --underway-glow: 14px;
+  }
+  50% {
+    --underway-glow: 28px;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/runtime/fleet-console/client/src/styles/theme.css
+++ b/runtime/fleet-console/client/src/styles/theme.css
@@ -305,39 +305,6 @@ a {
   }
 }
 
-/* 작업 진행 중(running) 에이전트 패널의 "출항(underway)" 시각효과 토큰.
-   --wake-angle: 선체 외곽을 순회하는 aurora 항적광의 각도.
-   --underway-glow: 선체 외곽 호흡 글로우의 blur 반경(@property 등록으로 부드러운 보간). */
-@property --wake-angle {
-  syntax: "<angle>";
-  initial-value: 0deg;
-  inherits: false;
-}
-
-@property --underway-glow {
-  syntax: "<length>";
-  initial-value: 18px;
-  inherits: false;
-}
-
-/* aurora 항적광이 선체를 한 바퀴 순회 */
-@keyframes panel-underway-orbit {
-  to {
-    --wake-angle: 360deg;
-  }
-}
-
-/* 선체 외곽 글로우가 호흡하듯 맥동(라이브 비콘과 동일 리듬) */
-@keyframes panel-underway-breathe {
-  0%,
-  100% {
-    --underway-glow: 14px;
-  }
-  50% {
-    --underway-glow: 28px;
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,


### PR DESCRIPTION
## Summary
- Operations 캔버스에서 **작업이 진행 중인(running)** 에이전트 패널 외곽에 fleet-harness 메타포의 "출항(underway)" 시각효과를 추가합니다 — aurora("지금 살아있는 것") 언어로 선체 외곽선·순회 항적광·호흡 글로우를 표현해 진행 상태를 한눈에 식별합니다.
- 진행 판정은 활성 캐리어 작업(`activeJobCount > 0`)으로 기존 aurora 라이브 비콘(`is-live`)과 동일 조건입니다. brass(선택/포커스)와 aurora(라이브) 역할을 분리해 선택+진행이 겹쳐도 각자 의미로 공존합니다.

## Type of Change
- [x] feat — new feature or carrier capability

## Scope
- `runtime/fleet-console` (client: Operations 캔버스 패널 스타일링)

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과 (효과 CSS 번들 반영 확인)
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 310/310 통과
- [x] console-e2e 실브라우저 실측 — IDLE vs RUNNING 식별, RUNNING+SELECTED 역할 분리, orbit 애니메이션 구동, reduced-motion 폴백(항적광 정지·정적 림 유지), pageerror 없음

## Notes for Reviewers
- CSS 3레이어 규약 준수(theme=토큰/@property/키프레임, components=구체 표면). `overflow:hidden` 클리핑 회피를 위해 외광은 패널 box-shadow, 외곽선은 inset 의사요소(마스크 링)로 구현.
- `prefers-reduced-motion`은 제거하지 않고 확장(항적광/호흡 정지, 정적 aurora 림+글로우 유지).
- 진행 트리거를 `turnState === "running"`(비콘 amber)까지 확장할지는 색 의미론상 별도 판단으로 제외.