### PR TITLE
feat(console): add system prompt injection mode and metaphor settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 - [core] Fleet Console now guides first-time operators with a commissioning walkthrough — registering a Theater, opening an Operation, and observing carriers — shown automatically on the first empty-bridge launch, reopenable anytime from the Welcome dashboard, and surfaced as a setup action in the empty Theater state.
+- [core] Fleet Console adds a global Settings screen to choose the system prompt injection mode (Append or Replace) and toggle the naval metaphor tone overlay, matching the options previously available only in the Fleet CLI; changes apply to newly launched sessions.
 
 ### Changed
 - [core] The Fleet Console Operations Map fullscreen no longer exits on the Esc key; it can now only be exited with the maximize/restore control.
+- [core] The Fleet Console global navigation bar now separates global Settings from per-carrier configuration, renaming the existing carrier entry to "Carriers" and adding a dedicated "Settings" entry.
 
 ## [1.7.1] - 2026-06-17
 

--- a/runtime/fleet-console/client/src/app.tsx
+++ b/runtime/fleet-console/client/src/app.tsx
@@ -15,6 +15,7 @@ import { startObserverConnection } from "./connection.js";
 import { useConsoleState } from "./hooks/use-store.js";
 import { CarrierSettings } from "./pages/carrier-settings.js";
 import { Codex } from "./pages/codex.js";
+import { GlobalSettings } from "./pages/global-settings.js";
 import { Operations } from "./pages/operations.js";
 import { applyObserverStatus, hydrateTerminalSessions, hydrateTheaterBootstrap, resolveOnboardingOnBootstrap, setState, toggleOperationSearch, toggleShell } from "./store.js";
 import { Welcome } from "./pages/welcome.js";
@@ -99,6 +100,7 @@ export function App() {
         <Route path="/" element={<Welcome state={state} />} />
         <Route path="/operations" element={<Operations state={state} />} />
         <Route path="/carrier-settings" element={<CarrierSettings />} />
+        <Route path="/settings" element={<GlobalSettings />} />
         <Route path="/codex/*" element={<Codex state={state} />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/runtime/fleet-console/client/src/components/topbar.tsx
+++ b/runtime/fleet-console/client/src/components/topbar.tsx
@@ -45,6 +45,8 @@ export function Topbar({ state }: TopbarProps) {
   const sigil = pathname.startsWith("/codex")
     ? <CodexIcon />
     : pathname.startsWith("/carrier-settings")
+      ? <CarriersIcon />
+    : pathname.startsWith("/settings")
       ? <SettingsIcon />
     : pathname.startsWith("/operations")
       ? <OperationsIcon />
@@ -104,6 +106,14 @@ export function Topbar({ state }: TopbarProps) {
           to="/carrier-settings"
           className={({ isActive }) => `topbar-nav-link ${isActive ? "is-active" : ""}`}
           title="Carrier settings"
+        >
+          <span className="topbar-nav-icon" aria-hidden="true"><CarriersIcon /></span>
+          <span>Carriers</span>
+        </NavLink>
+        <NavLink
+          to="/settings"
+          className={({ isActive }) => `topbar-nav-link ${isActive ? "is-active" : ""}`}
+          title="Settings"
         >
           <span className="topbar-nav-icon" aria-hidden="true"><SettingsIcon /></span>
           <span>Settings</span>
@@ -513,13 +523,25 @@ function CodexIcon() {
 }
 
 function SettingsIcon() {
-  // Settings 시그니처 — 조정 노브 모티프. carrier 설정 화면과 GNB nav가 같은 도형을 공유한다.
+  // Settings 시그니처 — 조정 노브 모티프. 전역 설정(/settings) 화면과 GNB nav가 같은 도형을 공유한다.
   return (
     <svg viewBox="0 0 16 16" aria-hidden="true">
       <path d="M3 4.4h10M3 8h10M3 11.6h10" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
       <circle cx="6.2" cy="4.4" r="1.3" fill="var(--surface-glass-strong)" stroke="currentColor" strokeWidth="1.2" />
       <circle cx="10" cy="8" r="1.3" fill="var(--surface-glass-strong)" stroke="currentColor" strokeWidth="1.2" />
       <circle cx="7.4" cy="11.6" r="1.3" fill="var(--surface-glass-strong)" stroke="currentColor" strokeWidth="1.2" />
+    </svg>
+  );
+}
+
+function CarriersIcon() {
+  // Carriers 시그니처 — 함장 로스터(점 + 라인 3행) 모티프. 캐리어 설정(/carrier-settings) 화면과 GNB nav가 같은 도형을 공유한다.
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <circle cx="4" cy="4.2" r="1.15" fill="currentColor" />
+      <circle cx="4" cy="8" r="1.15" fill="currentColor" />
+      <circle cx="4" cy="11.8" r="1.15" fill="currentColor" />
+      <path d="M7.2 4.2h6M7.2 8h6M7.2 11.8h6" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
     </svg>
   );
 }

--- a/runtime/fleet-console/client/src/global-settings-api.ts
+++ b/runtime/fleet-console/client/src/global-settings-api.ts
@@ -1,0 +1,46 @@
+import { ApiError } from "./api.js";
+import type { GlobalSettingsMutationResult, GlobalSettingsState } from "./types.js";
+
+export async function fetchGlobalSettingsState(signal?: AbortSignal): Promise<GlobalSettingsState> {
+  const response = await fetch("/global-settings/state", { signal });
+  await assertOk(response);
+  return assertGlobalSettingsState(await response.json(), response.status);
+}
+
+export async function updateGlobalSettings(patch: Partial<GlobalSettingsState>, signal?: AbortSignal): Promise<GlobalSettingsMutationResult> {
+  const response = await fetch("/global-settings", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(patch),
+    signal,
+  });
+  await assertOk(response);
+  const payload = await response.json() as { readonly state?: unknown };
+  if (!payload || typeof payload !== "object" || !("state" in payload)) {
+    throw new ApiError(response.status, "Invalid global settings mutation response");
+  }
+  return { state: assertGlobalSettingsState(payload.state, response.status) };
+}
+
+async function assertOk(response: Response): Promise<void> {
+  if (response.ok) return;
+  let message = response.statusText || `HTTP ${response.status}`;
+  try {
+    const payload = await response.json() as { error?: unknown };
+    if (typeof payload.error === "string") message = payload.error;
+  } catch {
+    // 응답 본문이 JSON이 아니면 statusText를 사용한다.
+  }
+  throw new ApiError(response.status, message);
+}
+
+function assertGlobalSettingsState(value: unknown, status: number): GlobalSettingsState {
+  const payload = value as Partial<GlobalSettingsState>;
+  if (!payload || typeof payload.replaceSystemPrompt !== "boolean" || typeof payload.enableMetaphor !== "boolean") {
+    throw new ApiError(status, "Invalid global settings state response");
+  }
+  return {
+    replaceSystemPrompt: payload.replaceSystemPrompt,
+    enableMetaphor: payload.enableMetaphor,
+  };
+}

--- a/runtime/fleet-console/client/src/global-settings-store.ts
+++ b/runtime/fleet-console/client/src/global-settings-store.ts
@@ -1,0 +1,70 @@
+import { useSyncExternalStore } from "react";
+
+import { fetchGlobalSettingsState, updateGlobalSettings } from "./global-settings-api.js";
+import type { GlobalSettingsState } from "./types.js";
+
+export type GlobalSettingsField = "replaceSystemPrompt" | "enableMetaphor";
+
+interface GlobalSettingsStoreState {
+  readonly loading: boolean;
+  readonly state: GlobalSettingsState | null;
+  readonly savingField: GlobalSettingsField | null;
+  readonly error: string | null;
+}
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+let snapshot: GlobalSettingsStoreState = {
+  loading: false,
+  state: null,
+  savingField: null,
+  error: null,
+};
+
+export function useGlobalSettingsStore(): GlobalSettingsStoreState {
+  return useSyncExternalStore(subscribe, getGlobalSettingsStoreState, getGlobalSettingsStoreState);
+}
+
+export function getGlobalSettingsStoreState(): GlobalSettingsStoreState {
+  return snapshot;
+}
+
+export function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export async function loadGlobalSettings(signal?: AbortSignal): Promise<void> {
+  setSnapshot({ loading: true, error: null });
+  try {
+    const state = await fetchGlobalSettingsState(signal);
+    setSnapshot({ loading: false, state, error: null });
+  } catch (error) {
+    if (signal?.aborted) return;
+    setSnapshot({ loading: false, error: toErrorMessage(error) });
+  }
+}
+
+export async function setGlobalSettingsField(field: GlobalSettingsField, value: boolean): Promise<boolean> {
+  setSnapshot({ savingField: field, error: null });
+  try {
+    const result = await updateGlobalSettings({ [field]: value });
+    setSnapshot({ state: result.state, savingField: null, error: null });
+    return true;
+  } catch (error) {
+    setSnapshot({ savingField: null, error: toErrorMessage(error) });
+    return false;
+  }
+}
+
+function setSnapshot(patch: Partial<GlobalSettingsStoreState>): void {
+  snapshot = { ...snapshot, ...patch };
+  for (const listener of listeners) listener();
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/runtime/fleet-console/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/client/src/pages/global-settings.tsx
@@ -1,0 +1,88 @@
+import { useEffect } from "react";
+
+import { loadGlobalSettings, setGlobalSettingsField, useGlobalSettingsStore } from "../global-settings-store.js";
+
+interface SettingToggleRowProps {
+  readonly title: string;
+  readonly help: string;
+  readonly onLabel: string;
+  readonly offLabel: string;
+  readonly value: boolean;
+  readonly disabled: boolean;
+  readonly onToggle: () => void;
+}
+
+export function GlobalSettings() {
+  const settings = useGlobalSettingsStore();
+  const state = settings.state;
+  const saving = settings.savingField !== null;
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadGlobalSettings(controller.signal);
+    return () => controller.abort();
+  }, []);
+
+  return (
+    <main className="global-settings-page">
+      <section className="global-settings-hero" aria-labelledby="global-settings-title">
+        <div>
+          <p className="bridge-kicker">Fleet Control Surface</p>
+          <h2 id="global-settings-title">Settings</h2>
+        </div>
+        <div className="global-settings-status" role="status" aria-live="polite">
+          {saving ? "Saving…" : ""}
+        </div>
+      </section>
+
+      {settings.error ? <p className="global-settings-error" role="alert">{settings.error}</p> : null}
+
+      <section className="global-settings-card" aria-label="Fleet global settings">
+        {settings.loading && !state ? <p className="global-settings-help">Loading settings.</p> : null}
+        {state ? (
+          <>
+            <SettingToggleRow
+              title="System Prompt Injection"
+              help="Append keeps the Agent CLI's built-in system prompt and layers Fleet doctrine on top. Replace swaps it entirely for Fleet doctrine. Affects Claude-family CLIs only; Codex always receives doctrine through its profile."
+              onLabel="Replace"
+              offLabel="Append"
+              value={state.replaceSystemPrompt}
+              disabled={saving}
+              onToggle={() => void setGlobalSettingsField("replaceSystemPrompt", !state.replaceSystemPrompt)}
+            />
+            <SettingToggleRow
+              title="Metaphor"
+              help="Enabled layers the naval tone overlay — clipped reporting cadence and Fleet vocabulary — onto every session. Off keeps the Admiral persona without the tone."
+              onLabel="Enabled"
+              offLabel="Off"
+              value={state.enableMetaphor}
+              disabled={saving}
+              onToggle={() => void setGlobalSettingsField("enableMetaphor", !state.enableMetaphor)}
+            />
+          </>
+        ) : null}
+        <p className="global-settings-foot">Changes apply to newly launched sessions. Running sessions keep their current configuration until relaunched.</p>
+      </section>
+    </main>
+  );
+}
+
+function SettingToggleRow({ title, help, onLabel, offLabel, value, disabled, onToggle }: SettingToggleRowProps) {
+  return (
+    <div className="global-settings-row">
+      <div className="global-settings-row-text">
+        <p className="global-settings-resp-title">{title}</p>
+        <p className="global-settings-help">{help}</p>
+      </div>
+      <button
+        type="button"
+        className={`global-settings-toggle ${value ? "is-on" : ""}`}
+        disabled={disabled}
+        aria-pressed={value}
+        onClick={onToggle}
+      >
+        <span>{value ? onLabel : offLabel}</span>
+      </button>
+    </div>
+  );
+}

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -240,6 +240,188 @@
   font-family: var(--font-mono);
 }
 
+/* ===== Global Settings — 전역 옵션(시스템 프롬프트 주입 + 메타포) 표면 ===== */
+.global-settings-page {
+  display: grid;
+  align-content: start;
+  gap: var(--space-5);
+  width: min(720px, calc(100vw - 48px));
+  min-height: 0;
+  height: 100%;
+  margin: 0 auto;
+  padding: var(--space-5) 0 var(--space-10);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.global-settings-hero {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-4) 0 var(--space-2);
+}
+
+.global-settings-hero h2 {
+  margin: 0;
+  color: var(--ink-pearl);
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: clamp(42px, 6vw, 72px);
+  font-weight: 300;
+  letter-spacing: -0.03em;
+  line-height: 0.95;
+}
+
+.global-settings-status {
+  flex: none;
+  min-height: 16px;
+  color: var(--aurora);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.global-settings-card {
+  display: grid;
+  gap: var(--space-5);
+  padding: var(--space-6);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-xl);
+  background: var(--surface-glass);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+}
+
+.global-settings-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-5);
+}
+
+.global-settings-row + .global-settings-row {
+  padding-top: var(--space-5);
+  border-top: 1px solid color-mix(in oklch, var(--surface-rim) 55%, transparent);
+}
+
+.global-settings-row-text {
+  display: grid;
+  gap: 8px;
+  max-width: 48ch;
+}
+
+.global-settings-resp-title {
+  margin: 0;
+  color: var(--ink-pearl);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.global-settings-help {
+  margin: 0;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.6;
+}
+
+.global-settings-foot {
+  margin: 0;
+  padding-top: var(--space-4);
+  border-top: 1px solid color-mix(in oklch, var(--surface-rim) 40%, transparent);
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.55;
+}
+
+.global-settings-error {
+  margin: 0;
+  padding: var(--space-3);
+  border: 1px solid color-mix(in oklch, var(--coral) 48%, var(--surface-rim));
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--coral) 10%, transparent);
+  color: var(--coral);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+/* 토글 — carrier-settings 토글과 동일한 brass/aurora 스위치 어휘. */
+.global-settings-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  flex: none;
+  min-width: 96px;
+  min-height: 34px;
+  padding: 6px var(--space-3);
+  border: 0;
+  border-radius: var(--radius-xs);
+  background: transparent;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  transition:
+    background var(--duration-fast) var(--ease-spring),
+    color var(--duration-fast) var(--ease-spring),
+    transform var(--duration-fast) var(--ease-spring);
+}
+
+.global-settings-toggle::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ink-rim);
+}
+
+.global-settings-toggle:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--brass) 8%, transparent);
+  color: var(--ink-pearl);
+}
+
+.global-settings-toggle.is-on {
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  color: var(--aurora);
+}
+
+.global-settings-toggle.is-on::before {
+  background: var(--aurora);
+  box-shadow: 0 0 10px var(--aurora-glow);
+  animation: aurora-pulse 1.8s ease-in-out infinite;
+}
+
+.global-settings-toggle:active:not(:disabled) {
+  background: color-mix(in oklch, var(--brass) 16%, transparent);
+  transform: translateY(1px);
+}
+
+.global-settings-toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  transform: none;
+}
+
+@media (max-width: 720px) {
+  .global-settings-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
 .carrier-settings-page {
   display: grid;
   align-content: start;

--- a/runtime/fleet-console/client/src/types.ts
+++ b/runtime/fleet-console/client/src/types.ts
@@ -118,6 +118,16 @@ export interface CarrierSettingsMutationResult {
   readonly state: CarrierSettingsState;
 }
 
+// 전역 설정(시스템 프롬프트 주입 방식 + 메타포) DTO — server src/global-settings-types.ts와 수동 동기화한다.
+export interface GlobalSettingsState {
+  readonly replaceSystemPrompt: boolean;
+  readonly enableMetaphor: boolean;
+}
+
+export interface GlobalSettingsMutationResult {
+  readonly state: GlobalSettingsState;
+}
+
 export type SessionStatus = "starting" | "live" | "registered" | "terminal-only" | "closed" | "error" | "dormant";
 
 // Agent CLI 턴(host 처리) 상태. "none"=턴 이력 없음(신규), "running"=처리중, "ended"=종료(유휴).

--- a/runtime/fleet-console/src/global-settings-routes.ts
+++ b/runtime/fleet-console/src/global-settings-routes.ts
@@ -1,0 +1,97 @@
+import type http from "node:http";
+
+import type { GlobalOptionsData, GlobalOptionsService } from "@dotobokuri/fleet-infra";
+
+import type { GlobalSettingsMutationResult, GlobalSettingsState } from "./global-settings-types.js";
+
+interface GlobalSettingsRouteDeps {
+  readonly globalOptionsService: GlobalOptionsService;
+  readonly isAuthorized: (req: http.IncomingMessage) => boolean;
+  readonly readJsonBody: <T>(req: http.IncomingMessage) => Promise<T | null>;
+  readonly writeJson: (res: http.ServerResponse, status: number, body: unknown) => void;
+}
+
+interface GlobalSettingsRouteContext {
+  readonly req: http.IncomingMessage;
+  readonly res: http.ServerResponse;
+  readonly pathname: string;
+}
+
+interface GlobalSettingsBody {
+  readonly replaceSystemPrompt?: unknown;
+  readonly enableMetaphor?: unknown;
+}
+
+export function createGlobalSettingsRouter(deps: GlobalSettingsRouteDeps): (context: GlobalSettingsRouteContext) => Promise<boolean> {
+  return async function handleGlobalSettingsRoute(context: GlobalSettingsRouteContext): Promise<boolean> {
+    const { req, res, pathname } = context;
+    if (pathname === "/global-settings/state") {
+      if (req.method !== "GET") {
+        deps.writeJson(res, 405, { error: "Method not allowed" });
+        return true;
+      }
+      deps.writeJson(res, 200, buildGlobalSettingsState(deps.globalOptionsService));
+      return true;
+    }
+    if (pathname === "/global-settings") {
+      if (req.method !== "PUT") {
+        deps.writeJson(res, 405, { error: "Method not allowed" });
+        return true;
+      }
+      await mutateGlobalSettings(req, res, deps);
+      return true;
+    }
+    return false;
+  };
+}
+
+export function buildGlobalSettingsState(service: GlobalOptionsService): GlobalSettingsState {
+  return toGlobalSettingsState(service.load());
+}
+
+async function mutateGlobalSettings(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  deps: GlobalSettingsRouteDeps,
+): Promise<void> {
+  if (!deps.isAuthorized(req)) {
+    deps.writeJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  if (!isJsonRequest(req)) {
+    deps.writeJson(res, 415, { error: "unsupported_media_type" });
+    return;
+  }
+  const body = await deps.readJsonBody<GlobalSettingsBody>(req);
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    deps.writeJson(res, 400, { error: "invalid_json" });
+    return;
+  }
+  if (body.replaceSystemPrompt !== undefined && typeof body.replaceSystemPrompt !== "boolean") {
+    deps.writeJson(res, 400, { error: "invalid_replace_system_prompt" });
+    return;
+  }
+  if (body.enableMetaphor !== undefined && typeof body.enableMetaphor !== "boolean") {
+    deps.writeJson(res, 400, { error: "invalid_enable_metaphor" });
+    return;
+  }
+  const updated = deps.globalOptionsService.update((current) => ({
+    ...current,
+    ...(typeof body.replaceSystemPrompt === "boolean" ? { replaceSystemPrompt: body.replaceSystemPrompt } : {}),
+    ...(typeof body.enableMetaphor === "boolean" ? { enableMetaphor: body.enableMetaphor } : {}),
+  }));
+  const response: GlobalSettingsMutationResult = { state: toGlobalSettingsState(updated) };
+  deps.writeJson(res, 200, response);
+}
+
+function toGlobalSettingsState(data: GlobalOptionsData): GlobalSettingsState {
+  return {
+    replaceSystemPrompt: data.replaceSystemPrompt ?? false,
+    enableMetaphor: data.enableMetaphor ?? false,
+  };
+}
+
+function isJsonRequest(req: http.IncomingMessage): boolean {
+  const contentType = req.headers["content-type"];
+  return typeof contentType === "string" && contentType.toLowerCase().split(";")[0]?.trim() === "application/json";
+}

--- a/runtime/fleet-console/src/global-settings-types.ts
+++ b/runtime/fleet-console/src/global-settings-types.ts
@@ -1,0 +1,11 @@
+// 브라우저로 나가는 전역 옵션 DTO. fleet-infra의 GlobalOptionsData에서 내부 격리 키(version)를
+// 제외하고, 시스템 프롬프트 주입 방식과 메타포 토글만 boolean으로 표면화한다.
+
+export interface GlobalSettingsState {
+  readonly replaceSystemPrompt: boolean;
+  readonly enableMetaphor: boolean;
+}
+
+export interface GlobalSettingsMutationResult {
+  readonly state: GlobalSettingsState;
+}

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -27,6 +27,7 @@ import type { ConsoleCarrierReadinessEntry, ConsoleHealth, ConsoleObservedWorksp
 import { createCarrierSettingsRouter } from "./carrier-settings-routes.js";
 import { createCodexGateway } from "./codex/gateway.js";
 import { cleanupProviderSessionCaptures, createConsoleDurableStateStore, emptyDurableConsoleState, mergeProviderSessionCaptures, readProviderSessionCapture, unlinkProviderSessionCapture, type DurableConsoleState, type DurableOperation } from "./durable-state.js";
+import { createGlobalSettingsRouter } from "./global-settings-routes.js";
 import { createConsoleLock, type ConsoleLockHandle } from "./lock.js";
 import { writeAggregateObserverEvents, writeObserverEvents } from "./observability-routes.js";
 import { createConsoleDataPaths } from "./paths.js";
@@ -191,6 +192,12 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     readJsonBody,
     writeJson,
   });
+  const globalSettingsRouter = createGlobalSettingsRouter({
+    globalOptionsService: infraServices.globalOptionsService,
+    isAuthorized: isTerminalAuthorized,
+    readJsonBody,
+    writeJson,
+  });
 
   function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
     const pathname = getPathname(req);
@@ -262,6 +269,10 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     }
     if (pathname === "/carrier-settings" || pathname.startsWith("/carrier-settings/")) {
       runAsyncBooleanHandler(carrierSettingsRouter({ req, res, pathname }), res);
+      return;
+    }
+    if (pathname === "/global-settings" || pathname.startsWith("/global-settings/")) {
+      runAsyncBooleanHandler(globalSettingsRouter({ req, res, pathname }), res);
       return;
     }
     if (pathname === "/observer/tenants") {

--- a/runtime/fleet-console/src/terminal/launch.ts
+++ b/runtime/fleet-console/src/terminal/launch.ts
@@ -177,19 +177,20 @@ async function createAgentCliLaunchSpec(options: {
       cliId: options.cliId,
       resumeSessionId: options.resumeSessionId,
     });
+    const globalSettings = readGlobalSettingsSnapshot(options.infraServices);
     const injectedProfile = await options.injectProfile(profile, {
       buildSystemPrompt: (injectTone) => createSystemPromptBuilder({ carrierRuntime: agentRuntime.carrierRuntime }).build(injectTone),
       carrierRuntime: agentRuntime.carrierRuntime,
       codexCommandRunner: runCodexCommand,
       dataDir: options.dataDir,
       dedicatedMcpSession: agentRuntime.dedicatedMcpSession,
-      enableMetaphor: false,
+      enableMetaphor: globalSettings.enableMetaphor,
       captureSessionHookExec: buildConsoleCaptureHookCommand(options.hookEntry, profile.id),
       turnStartHookExec: buildConsoleTurnHookCommand(options.hookEntry, "start"),
       turnEndHookExec: buildConsoleTurnHookCommand(options.hookEntry, "end"),
       hookExec: buildConsoleHookCommand(options.hookEntry),
       onCleanup: (cleanup) => cleanupStack.push(cleanup),
-      replaceSystemPrompt: false,
+      replaceSystemPrompt: globalSettings.replaceSystemPrompt,
       resumeSessionId: options.resumeSessionId,
       withMarketplaceLock: withConsoleMarketplaceLock,
       mcpSessionLabel: options.sessionId,
@@ -295,5 +296,20 @@ function resolveOptionalPackage(id: string): string | undefined {
     return require.resolve(id);
   } catch {
     return undefined;
+  }
+}
+
+// 세션 launch 직전에 전역 옵션(~/.fleet/settings.json)을 1회 스냅샷한다. daemon 재시작 없이도
+// 신규 세션이 최신 토글 값을 반영하도록 부팅 캐시가 아닌 launch 시점에 읽는다. 로드 실패(락 타임아웃 등)는
+// 세션 launch를 막지 않고 기본값(append / 메타포 off)으로 폴백한다.
+function readGlobalSettingsSnapshot(infraServices: InfraServices): { readonly enableMetaphor: boolean; readonly replaceSystemPrompt: boolean } {
+  try {
+    const data = infraServices.globalOptionsService.load();
+    return {
+      enableMetaphor: data.enableMetaphor ?? false,
+      replaceSystemPrompt: data.replaceSystemPrompt ?? false,
+    };
+  } catch {
+    return { enableMetaphor: false, replaceSystemPrompt: false };
   }
 }

--- a/runtime/fleet-console/tests/global-settings-routes.test.ts
+++ b/runtime/fleet-console/tests/global-settings-routes.test.ts
@@ -1,0 +1,117 @@
+import type http from "node:http";
+
+import { describe, expect, it } from "vitest";
+
+import { createGlobalSettingsRouter } from "../src/global-settings-routes.js";
+
+interface WriteJsonCall {
+  readonly status: number;
+  readonly body: unknown;
+}
+
+interface RouterHarnessOptions {
+  readonly authorized?: boolean;
+  readonly body?: unknown;
+  readonly bodyNull?: boolean;
+  readonly data?: { readonly replaceSystemPrompt?: boolean; readonly enableMetaphor?: boolean };
+}
+
+describe("global settings routes", () => {
+  it("GET /global-settings/state returns only the two booleans without internal keys", async () => {
+    const harness = createRouterHarness({ data: { replaceSystemPrompt: true, enableMetaphor: false } });
+    const handled = await harness.router({ req: req("GET"), res: res(), pathname: "/global-settings/state" });
+    expect(handled).toBe(true);
+    expect(harness.writes).toEqual([{ status: 200, body: { replaceSystemPrompt: true, enableMetaphor: false } }]);
+    expect(harness.writes[0]?.body).not.toHaveProperty("version");
+  });
+
+  it("GET /global-settings/state rejects non-GET methods with 405", async () => {
+    const harness = createRouterHarness();
+    await harness.router({ req: req("POST"), res: res(), pathname: "/global-settings/state" });
+    expect(harness.writes[0]?.status).toBe(405);
+  });
+
+  it("PUT /global-settings updates and returns the new state", async () => {
+    const harness = createRouterHarness({ authorized: true, body: { replaceSystemPrompt: true, enableMetaphor: true } });
+    const handled = await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/global-settings" });
+    expect(handled).toBe(true);
+    expect(harness.writes[0]).toEqual({ status: 200, body: { state: { replaceSystemPrompt: true, enableMetaphor: true } } });
+    expect(harness.currentData()).toMatchObject({ version: 1, replaceSystemPrompt: true, enableMetaphor: true });
+  });
+
+  it("PUT /global-settings applies only the provided field", async () => {
+    const harness = createRouterHarness({ authorized: true, body: { enableMetaphor: true }, data: { replaceSystemPrompt: true } });
+    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/global-settings" });
+    expect(harness.writes[0]?.body).toEqual({ state: { replaceSystemPrompt: true, enableMetaphor: true } });
+  });
+
+  it("PUT /global-settings rejects unauthorized requests with 401", async () => {
+    const harness = createRouterHarness({ authorized: false, body: { enableMetaphor: true } });
+    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/global-settings" });
+    expect(harness.writes[0]?.status).toBe(401);
+    expect(harness.updateCalls).toBe(0);
+  });
+
+  it("PUT /global-settings rejects non-JSON content types with 415", async () => {
+    const harness = createRouterHarness({ authorized: true });
+    await harness.router({ req: req("PUT", "text/plain"), res: res(), pathname: "/global-settings" });
+    expect(harness.writes[0]?.status).toBe(415);
+    expect(harness.updateCalls).toBe(0);
+  });
+
+  it("PUT /global-settings rejects non-boolean fields with 400", async () => {
+    const harness = createRouterHarness({ authorized: true, body: { enableMetaphor: "yes" } });
+    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/global-settings" });
+    expect(harness.writes[0]?.status).toBe(400);
+    expect(harness.updateCalls).toBe(0);
+  });
+
+  it("PUT /global-settings rejects a missing body with 400", async () => {
+    const harness = createRouterHarness({ authorized: true, bodyNull: true });
+    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/global-settings" });
+    expect(harness.writes[0]?.status).toBe(400);
+    expect(harness.updateCalls).toBe(0);
+  });
+
+  it("/global-settings rejects non-PUT methods with 405", async () => {
+    const harness = createRouterHarness();
+    await harness.router({ req: req("GET"), res: res(), pathname: "/global-settings" });
+    expect(harness.writes[0]?.status).toBe(405);
+  });
+
+  it("returns false for unknown paths so the host can fall through", async () => {
+    const harness = createRouterHarness();
+    const handled = await harness.router({ req: req("GET"), res: res(), pathname: "/global-settings/unknown" });
+    expect(handled).toBe(false);
+    expect(harness.writes).toEqual([]);
+  });
+});
+
+function createRouterHarness(options: RouterHarnessOptions = {}) {
+  const writes: WriteJsonCall[] = [];
+  let data: { version: 1; replaceSystemPrompt?: boolean; enableMetaphor?: boolean } = { version: 1, ...options.data };
+  let updateCalls = 0;
+  const router = createGlobalSettingsRouter({
+    globalOptionsService: {
+      load: () => data,
+      save: (next) => { data = next; return data; },
+      update: (mutate) => { updateCalls += 1; data = mutate(data); return data; },
+    },
+    isAuthorized: () => options.authorized ?? true,
+    readJsonBody: async () => (options.bodyNull ? null : (options.body ?? {})) as never,
+    writeJson: (_res, status, body) => { writes.push({ status, body }); },
+  });
+  return { router, writes, currentData: () => data, get updateCalls() { return updateCalls; } };
+}
+
+function req(method: string, contentType?: string): http.IncomingMessage {
+  return { method, headers: contentType ? { "content-type": contentType } : {} } as unknown as http.IncomingMessage;
+}
+
+function jsonReq(method: string): http.IncomingMessage {
+  return req(method, "application/json");
+}
+
+function res(): http.ServerResponse {
+  return {} as unknown as http.ServerResponse;
+}

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -37,6 +37,20 @@ const baseProfile = {
 
 const TEMP_DIRS: string[] = [];
 
+// 전역 옵션(replaceSystemPrompt/enableMetaphor)을 고정 반환하는 InfraServices 스텁 —
+// launch resolver가 실제 ~/.fleet/settings.json을 읽지 않도록 테스트를 격리한다.
+function createFakeInfraServices(globalOptions: { readonly replaceSystemPrompt?: boolean; readonly enableMetaphor?: boolean } = {}) {
+  const data = { version: 1 as const, ...globalOptions };
+  return {
+    authService: {},
+    globalOptionsService: {
+      load: () => data,
+      save: () => data,
+      update: () => data,
+    },
+  };
+}
+
 describe("createDefaultTerminalLaunchResolver", () => {
   afterEach(() => {
     for (const dir of TEMP_DIRS.splice(0)) {
@@ -61,6 +75,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
       cwd: "/work",
       env: { PATH: "/bin" } as NodeJS.ProcessEnv,
       agentRuntime: runtime as never,
+      infraServices: createFakeInfraServices() as never,
       injectProfile: injectProfile as never,
       resolveProfile: resolveProfile as never,
     });
@@ -83,6 +98,30 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(resolveProfile).toHaveBeenCalledWith(expect.any(Object), "/work/project", expect.objectContaining({ authEnvResolver: expect.any(Function) }));
     expect(injectProfile).toHaveBeenCalledTimes(1);
     expect(events).toEqual([]);
+  });
+
+  it("injects global settings (metaphor + system prompt mode) into fleet-admiral injection", async () => {
+    const runtime = createFakeRuntime(() => undefined);
+    let captured: InjectAgentCliProfileOptions | null = null;
+    const resolveProfile = vi.fn(async (env: NodeJS.ProcessEnv, cwd: string) => ({ ...baseProfile, cwd, env: { ...env } }));
+    const injectProfile = vi.fn(async (profile: AgentCliProfile, options: InjectAgentCliProfileOptions) => {
+      captured = options;
+      return profile;
+    });
+    const resolve = createDefaultTerminalLaunchResolver({
+      cwd: "/work",
+      env: { PATH: "/bin" } as NodeJS.ProcessEnv,
+      agentRuntime: runtime as never,
+      infraServices: createFakeInfraServices({ replaceSystemPrompt: true, enableMetaphor: true }) as never,
+      injectProfile: injectProfile as never,
+      resolveProfile: resolveProfile as never,
+    });
+
+    await resolve("/work/project", { sessionId: "session-g" });
+
+    expect(captured).not.toBeNull();
+    expect(captured!.enableMetaphor).toBe(true);
+    expect(captured!.replaceSystemPrompt).toBe(true);
   });
 
   it("passes resumeSessionId and capture hook exec to fleet-admiral injection", async () => {


### PR DESCRIPTION
## Summary
- fleet-console에 전역 **Settings** 화면을 추가해 시스템 프롬프트 주입 방식(Append/Replace)과 메타포(해군 톤 오버레이) 토글을 제공합니다 — 그동안 fleet-cli에만 있던 옵션을 콘솔에서 동등하게 노출합니다.
- 설정값은 `~/.fleet/settings.json`을 `infraServices.globalOptionsService` 경유로 **세션 launch 시점**에 읽어 반영합니다(신규 세션부터 적용, 기존 세션은 재기동 시 반영). fleet-admiral 패키지는 수정하지 않았습니다.
- GNB를 전역 Settings와 캐리어별 설정으로 분리했습니다: 기존 진입점을 **"Carriers"**로 재명명하고 **"Settings"**(전역)를 신설.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (325 passed — 신규 라우트 보안/검증 테스트 10건 포함)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] console-e2e 실측: `/console/settings` 렌더 · `GET /global-settings/state` · 토글 `PUT /global-settings` 왕복 · GNB "Carriers"/"Settings" 분리 확인 (pageerror 0)