### PR TITLE
fix(console): keep wiki Theaters' Codex mounted after console restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Removed
 - [core] The Fleet Console Operations Map panel title bar no longer has a focus button for zooming a panel to fit, and the title-bar double-click that triggered the same zoom is removed along with it.
 
+### Fixed
+- [core] Fleet Console now keeps a Theater's Codex (Fleet Wiki) view available after the console is restarted; previously a restart made Theaters that have wiki data incorrectly appear to have no Codex until they were removed and added again.
+
 ## [1.7.1] - 2026-06-17
 
 Release v1.7.1

--- a/runtime/fleet-console/src/codex/gateway.ts
+++ b/runtime/fleet-console/src/codex/gateway.ts
@@ -48,6 +48,7 @@ export function createCodexGateway(deps: CodexGatewayDeps): CodexGateway {
   const workspaces = new WorkspaceRegistry();
   let accessSets: AllowedAccessSets | null = null;
   let initialWorkspace: Promise<WorkspaceRegistration> | null = null;
+  let initialWorkspaceId: string | null = null;
 
   async function handle(request: IncomingMessage, response: ServerResponse): Promise<boolean> {
     let selected: WorkspaceSelection;
@@ -105,7 +106,9 @@ export function createCodexGateway(deps: CodexGatewayDeps): CodexGateway {
 
   async function ensureInitialWorkspace(): Promise<WorkspaceRegistration> {
     initialWorkspace ??= workspaces.register(deps.cwd);
-    return initialWorkspace;
+    const workspace = await initialWorkspace;
+    initialWorkspaceId = workspace.id;
+    return workspace;
   }
 
   return {
@@ -113,7 +116,15 @@ export function createCodexGateway(deps: CodexGatewayDeps): CodexGateway {
     handle,
     listWorkspaceRegistrations: () => workspaces.listRegistrations(),
     registerWorkspace: (cwd) => workspaces.register(cwd),
-    unregisterWorkspace: (id) => workspaces.remove(id),
+    unregisterWorkspace: (id) => {
+      // 캐시된 initial workspace가 해제 대상이면 캐시를 비워, 이후 비프리픽스 라우트가
+      // 레지스트리에서 사라진 등록을 계속 서빙하지 않게 한다(다음 접근 시 재평가).
+      if (initialWorkspaceId === id) {
+        initialWorkspace = null;
+        initialWorkspaceId = null;
+      }
+      return workspaces.remove(id);
+    },
   };
 }
 

--- a/runtime/fleet-console/src/codex/gateway.ts
+++ b/runtime/fleet-console/src/codex/gateway.ts
@@ -41,6 +41,7 @@ export interface CodexGateway {
   handle(request: IncomingMessage, response: ServerResponse): Promise<boolean>;
   listWorkspaceRegistrations(): readonly WorkspaceRegistration[];
   registerWorkspace(cwd: string): Promise<WorkspaceRegistration>;
+  unregisterWorkspace(id: string): boolean;
 }
 
 export function createCodexGateway(deps: CodexGatewayDeps): CodexGateway {
@@ -112,6 +113,7 @@ export function createCodexGateway(deps: CodexGatewayDeps): CodexGateway {
     handle,
     listWorkspaceRegistrations: () => workspaces.listRegistrations(),
     registerWorkspace: (cwd) => workspaces.register(cwd),
+    unregisterWorkspace: (id) => workspaces.remove(id),
   };
 }
 

--- a/runtime/fleet-console/src/codex/gateway.ts
+++ b/runtime/fleet-console/src/codex/gateway.ts
@@ -40,7 +40,7 @@ export interface CodexGateway {
   getWorkspace(id: string): WorkspaceRegistration | null;
   handle(request: IncomingMessage, response: ServerResponse): Promise<boolean>;
   listWorkspaceRegistrations(): readonly WorkspaceRegistration[];
-  registerWorkspace(cwd: string): Promise<WorkspaceRegistration>;
+  registerWorkspace(cwd: string, lastOpenedAt?: string): Promise<WorkspaceRegistration>;
   unregisterWorkspace(id: string): boolean;
 }
 
@@ -115,7 +115,7 @@ export function createCodexGateway(deps: CodexGatewayDeps): CodexGateway {
     getWorkspace: (id) => workspaces.get(id),
     handle,
     listWorkspaceRegistrations: () => workspaces.listRegistrations(),
-    registerWorkspace: (cwd) => workspaces.register(cwd),
+    registerWorkspace: (cwd, lastOpenedAt) => workspaces.register(cwd, lastOpenedAt),
     unregisterWorkspace: (id) => {
       // 캐시된 initial workspace가 해제 대상이면 캐시를 비워, 이후 비프리픽스 라우트가
       // 레지스트리에서 사라진 등록을 계속 서빙하지 않게 한다(다음 접근 시 재평가).

--- a/runtime/fleet-console/src/codex/workspaces.ts
+++ b/runtime/fleet-console/src/codex/workspaces.ts
@@ -21,7 +21,7 @@ export class WorkspaceRegistry {
   readonly #items = new Map<string, WorkspaceRegistration>();
   #mruId: string | null = null;
 
-  async register(cwdInput: string): Promise<WorkspaceRegistration> {
+  async register(cwdInput: string, lastOpenedAt?: string): Promise<WorkspaceRegistration> {
     const cwd = path.resolve(cwdInput);
     const real = await canonicalizeTheaterPath(cwd);
     const paths = resolveFleetWikiMemoryPaths(real);
@@ -41,7 +41,9 @@ export class WorkspaceRegistry {
       label: path.basename(cwd),
       paths,
       registeredAt: existing?.registeredAt ?? now,
-      lastOpenedAt: now,
+      // 복원 경로는 durable lastOpenedAt을 그대로 보존해 재시작 후에도 워크스페이스 최근성
+      // 순서(MRU·listRegistrations 동순위 처리)가 durable 상태와 일치하게 한다. 일반 등록은 now.
+      lastOpenedAt: lastOpenedAt ?? now,
     };
     this.#items.set(id, item);
     this.#mruId = id;

--- a/runtime/fleet-console/src/codex/workspaces.ts
+++ b/runtime/fleet-console/src/codex/workspaces.ts
@@ -52,6 +52,13 @@ export class WorkspaceRegistry {
     return this.#items.get(id) ?? null;
   }
 
+  remove(id: string): boolean {
+    const deleted = this.#items.delete(id);
+    // MRU가 제거 대상이면 포인터를 비워 getMru()가 사라진 워크스페이스를 가리키지 않게 한다.
+    if (this.#mruId === id) this.#mruId = null;
+    return deleted;
+  }
+
   getMru(): WorkspaceRegistration | null {
     return this.#mruId ? this.get(this.#mruId) : null;
   }

--- a/runtime/fleet-console/src/codex/workspaces.ts
+++ b/runtime/fleet-console/src/codex/workspaces.ts
@@ -54,8 +54,10 @@ export class WorkspaceRegistry {
 
   remove(id: string): boolean {
     const deleted = this.#items.delete(id);
-    // MRU가 제거 대상이면 포인터를 비워 getMru()가 사라진 워크스페이스를 가리키지 않게 한다.
-    if (this.#mruId === id) this.#mruId = null;
+    // MRU를 제거하면 다음으로 최근에 열린 남은 워크스페이스를 MRU로 승격한다(없으면 null).
+    // null로 비우면 getMru() 기반 라우트(/console/codex, /console/codex/api/...)가 남은
+    // Theater 대신 deps.cwd 폴백으로 떨어지므로, TheaterRegistry.remove()와 동일하게 승계한다.
+    if (this.#mruId === id) this.#mruId = this.listRegistrations()[0]?.id ?? null;
     return deleted;
   }
 

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -901,18 +901,20 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   }
 
   async function restoreCodexWorkspaces(): Promise<void> {
-    await Promise.all(
-      theaters.list().map(async (theater) => {
-        try {
-          await codex.registerWorkspace(theater.path);
-        } catch (error) {
-          // 위키 지식 루트가 없는 Theater는 Codex 미보유 상태가 정상이므로 조용히 건너뛴다.
-          if (!(error instanceof Error && error.message === "knowledge_root_missing")) {
-            console.warn(`[fleet-console] Codex workspace restore skipped for Theater ${theater.id}: ${error instanceof Error ? error.message : String(error)}`);
-          }
+    // durable lastOpenedAt 오름차순으로 순차 등록한다. register()가 매번 MRU를 갱신하므로
+    // 가장 최근에 열린 Theater가 마지막에 등록되어 codex MRU가 되고, getMru() 기반 라우트가
+    // 재시작 후에도 durable 최근성 순서를 유지한다(병렬 등록은 stat 완료 순서에 의존해 비결정적).
+    const ordered = [...theaters.list()].sort((left, right) => left.lastOpenedAt.localeCompare(right.lastOpenedAt));
+    for (const theater of ordered) {
+      try {
+        await codex.registerWorkspace(theater.path);
+      } catch (error) {
+        // 위키 지식 루트가 없는 Theater는 Codex 미보유 상태가 정상이므로 조용히 건너뛴다.
+        if (!(error instanceof Error && error.message === "knowledge_root_missing")) {
+          console.warn(`[fleet-console] Codex workspace restore skipped for Theater ${theater.id}: ${error instanceof Error ? error.message : String(error)}`);
         }
-      }),
-    );
+      }
+    }
   }
 
   function persistDurableState(): void {

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -905,10 +905,12 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     // register()가 매번 MRU를 갱신하므로 가장 최근에 열린 Theater가 마지막에 등록되어 codex
     // MRU가 되고, durable 타임스탬프 보존으로 listRegistrations()의 동순위(같은 밀리초) 모호성
     // 없이 getMru() 기반 라우트가 재시작 후에도 durable 최근성 순서를 유지한다.
+    // 등록은 durable realpath로 한다. theater.path(심볼릭일 수 있음)를 다시 정규화하면 정지 중
+    // 심볼릭 타깃이 바뀐 경우 theater.id와 다른 workspaceHash로 등록되어 hasWiki 판정이 깨진다.
     const ordered = [...theaters.list()].sort((left, right) => left.lastOpenedAt.localeCompare(right.lastOpenedAt));
     for (const theater of ordered) {
       try {
-        await codex.registerWorkspace(theater.path, theater.lastOpenedAt);
+        await codex.registerWorkspace(theater.realpath, theater.lastOpenedAt);
       } catch (error) {
         // 위키 지식 루트가 없는 Theater는 Codex 미보유 상태가 정상이므로 조용히 건너뛴다.
         if (!(error instanceof Error && error.message === "knowledge_root_missing")) {

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -901,13 +901,14 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   }
 
   async function restoreCodexWorkspaces(): Promise<void> {
-    // durable lastOpenedAt 오름차순으로 순차 등록한다. register()가 매번 MRU를 갱신하므로
-    // 가장 최근에 열린 Theater가 마지막에 등록되어 codex MRU가 되고, getMru() 기반 라우트가
-    // 재시작 후에도 durable 최근성 순서를 유지한다(병렬 등록은 stat 완료 순서에 의존해 비결정적).
+    // durable lastOpenedAt 오름차순으로 순차 등록하면서 durable 타임스탬프를 그대로 보존한다.
+    // register()가 매번 MRU를 갱신하므로 가장 최근에 열린 Theater가 마지막에 등록되어 codex
+    // MRU가 되고, durable 타임스탬프 보존으로 listRegistrations()의 동순위(같은 밀리초) 모호성
+    // 없이 getMru() 기반 라우트가 재시작 후에도 durable 최근성 순서를 유지한다.
     const ordered = [...theaters.list()].sort((left, right) => left.lastOpenedAt.localeCompare(right.lastOpenedAt));
     for (const theater of ordered) {
       try {
-        await codex.registerWorkspace(theater.path);
+        await codex.registerWorkspace(theater.path, theater.lastOpenedAt);
       } catch (error) {
         // 위키 지식 루트가 없는 Theater는 Codex 미보유 상태가 정상이므로 조용히 건너뛴다.
         if (!(error instanceof Error && error.message === "knowledge_root_missing")) {

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -651,6 +651,9 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     // DELETE는 idempotent해야 한다 — Theater가 레지스트리에 이미 없어도(유령 항목이나 중복 forget) 목표 상태(부재)는
     // 이미 달성된 것이므로 404가 아닌 성공으로 처리하고, 남아 있을 수 있는 소속 Operation도 함께 정리한다.
     theaters.remove(theaterId);
+    // Theater를 잊을 때 Codex 워크스페이스 등록도 함께 해제한다. 등록을 남겨두면
+    // /console/codex/w/:id/ 직접 URL이 재시작 전까지 잊은 Theater의 위키를 계속 서빙한다(등록/복원 경로와 대칭).
+    codex.unregisterWorkspace(theaterId);
     for (const operation of operations) forgetTerminalSession(operation.sessionId, { persist: false });
     persistDurableState();
     writeJson(res, 200, { ok: true });

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -861,7 +861,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     currentLock?.release();
   }
 
-  function rehydrateDurableState(): void {
+  async function rehydrateDurableState(): Promise<void> {
     let state: DurableConsoleState;
     try {
       state = durableStateStore.load();
@@ -871,6 +871,11 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       state = emptyDurableConsoleState();
       theaters.restore([]);
     }
+    // Codex WorkspaceRegistry는 인메모리라 재시작 시 비워진다. hasWiki 판정이 이 레지스트리에
+    // 의존하므로(getWorkspace !== null), 복원된 Theater를 재등록하지 않으면 위키가 있는 Theater도
+    // hasWiki=false가 되어 Console 재실행마다 Codex(Wiki)가 마운트되지 않는다. POST 추가 경로와
+    // 대칭으로 복원 Theater의 워크스페이스를 best-effort 재등록한다.
+    await restoreCodexWorkspaces();
     const merged = mergeProviderSessionCaptures(state, { capturesDir: durablePaths.capturesDir });
     syncProviderSessionsToObservability(merged);
     const restorable = {
@@ -890,6 +895,21 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     for (const operation of restorable.operations) {
       if (theaters.get(operation.theaterId)) observability.injectDormantOperation(operation);
     }
+  }
+
+  async function restoreCodexWorkspaces(): Promise<void> {
+    await Promise.all(
+      theaters.list().map(async (theater) => {
+        try {
+          await codex.registerWorkspace(theater.path);
+        } catch (error) {
+          // 위키 지식 루트가 없는 Theater는 Codex 미보유 상태가 정상이므로 조용히 건너뛴다.
+          if (!(error instanceof Error && error.message === "knowledge_root_missing")) {
+            console.warn(`[fleet-console] Codex workspace restore skipped for Theater ${theater.id}: ${error instanceof Error ? error.message : String(error)}`);
+          }
+        }
+      }),
+    );
   }
 
   function persistDurableState(): void {
@@ -926,7 +946,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     async start(lockPaths) {
       if (server && lockHandle) return lockHandle.payload.endpoint;
       try {
-        rehydrateDurableState();
+        await rehydrateDurableState();
         await new Promise<void>((resolve, reject) => {
           const srv = createHttpServer(handleRequest, terminalUpgrade);
           srv.once("error", reject);

--- a/runtime/fleet-console/tests/dashboard.test.ts
+++ b/runtime/fleet-console/tests/dashboard.test.ts
@@ -20,6 +20,7 @@ const BASE_STATE: ConsoleState = {
   sessions: {},
   sessionOrder: [],
   activeTerminalSessionId: null,
+  operationsViewActive: false,
   creatingTerminalSession: false,
   terminalSessionError: null,
   tenantJobs: {},

--- a/runtime/fleet-console/tests/operation-search.test.ts
+++ b/runtime/fleet-console/tests/operation-search.test.ts
@@ -26,6 +26,7 @@ function makeState(sessions: readonly (Omit<SessionInfo, "resumeAvailable" | "tu
     sessions: Object.fromEntries(entries.map((session) => [session.sessionId, session])),
     sessionOrder: entries.map((session) => session.sessionId),
     activeTerminalSessionId: null,
+    operationsViewActive: false,
     creatingTerminalSession: false,
     terminalSessionError: null,
     tenantJobs: {},

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -798,6 +798,26 @@ describe("console static and terminal ticket boundary", () => {
     expect(afterRestart.theaters.find((entry) => entry.id === theater.id)?.hasWiki).toBe(true);
   });
 
+  it("unregisters a Theater's Codex workspace when the Theater is forgotten", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-codex-forget-"));
+    tempDirs.push(dir);
+    fs.mkdirSync(path.join(dir, ".fleet", "knowledge"), { recursive: true });
+    const fixture = await startFixture();
+    const theater = await createTheater(fixture, dir);
+
+    // 등록 직후에는 codex 워크스페이스 라우트가 위키 health를 200으로 서빙한다.
+    const beforeForget = await fetch(`${fixture.endpoint}console/codex/w/${encodeURIComponent(theater.id)}/api/health`, { redirect: "manual" });
+    const deleted = await fetch(`${fixture.endpoint}observer/theaters/${encodeURIComponent(theater.id)}`, { method: "DELETE" });
+    // forget 후에는 워크스페이스가 해제되어 같은 라우트가 codex 홈으로 302 리다이렉트된다.
+    const afterForget = await fetch(`${fixture.endpoint}console/codex/w/${encodeURIComponent(theater.id)}/api/health`, { redirect: "manual" });
+    const remaining = await getJson<{ readonly theaters: ReadonlyArray<{ readonly id: string }> }>(`${fixture.endpoint}observer/theaters`);
+
+    expect(beforeForget.status).toBe(200);
+    expect(deleted.status).toBe(200);
+    expect(afterForget.status).toBe(302);
+    expect(remaining.theaters.find((entry) => entry.id === theater.id)).toBeUndefined();
+  });
+
   it("rehydrates durable state as dormant without starting PTYs and merges capture files server-side", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-rehydrate-"));
     tempDirs.push(dir);

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -818,6 +818,27 @@ describe("console static and terminal ticket boundary", () => {
     expect(remaining.theaters.find((entry) => entry.id === theater.id)).toBeUndefined();
   });
 
+  it("promotes the next most-recent Codex workspace as MRU when the active Theater is forgotten", async () => {
+    const dirA = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-codex-mru-a-"));
+    const dirB = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-codex-mru-b-"));
+    tempDirs.push(dirA, dirB);
+    fs.mkdirSync(path.join(dirA, ".fleet", "knowledge"), { recursive: true });
+    fs.mkdirSync(path.join(dirB, ".fleet", "knowledge"), { recursive: true });
+    const fixture = await startFixture();
+    await createTheater(fixture, dirA);
+    const theaterB = await createTheater(fixture, dirB); // 마지막 등록 = MRU
+
+    // MRU(B)를 forget하면 남은 A가 MRU로 승격되어, getMru() 기반 비프리픽스 라우트가
+    // deps.cwd 폴백이 아니라 A의 위키를 서빙해야 한다.
+    const deleted = await fetch(`${fixture.endpoint}observer/theaters/${encodeURIComponent(theaterB.id)}`, { method: "DELETE" });
+    const health = await fetch(`${fixture.endpoint}console/codex/api/health`, { redirect: "manual" });
+    const body = await health.json() as { readonly knowledgeRoot?: string };
+
+    expect(deleted.status).toBe(200);
+    expect(health.status).toBe(200);
+    expect(body.knowledgeRoot).toBe(path.join(fs.realpathSync.native(dirA), ".fleet", "knowledge"));
+  });
+
   it("rehydrates durable state as dormant without starting PTYs and merges capture files server-side", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-rehydrate-"));
     tempDirs.push(dir);

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -773,6 +773,31 @@ describe("console static and terminal ticket boundary", () => {
     expect(serialized).not.toContain("providerSession");
   });
 
+  it("keeps a wiki Theater's hasWiki true after a console restart by re-registering its Codex workspace", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-codex-haswiki-"));
+    tempDirs.push(dir);
+    // Theater 디렉터리에 Fleet Wiki 지식 루트를 만들어 hasWiki=true 조건을 충족시킨다.
+    fs.mkdirSync(path.join(dir, ".fleet", "knowledge"), { recursive: true });
+    const fixture = await startFixture();
+    const theater = await createTheater(fixture, dir);
+
+    const beforeRestart = await getJson<{ readonly theaters: ReadonlyArray<{ readonly id: string; readonly hasWiki: boolean }> }>(`${fixture.endpoint}observer/theaters`);
+    await fixture.server.stop();
+
+    const restartDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-codex-haswiki-lock-"));
+    tempDirs.push(restartDir);
+    const restartedServer = createConsoleServer({ port: 0, version: "test", dataDir: fixture.carrierStoreDir });
+    servers.push(restartedServer);
+    const restartedEndpoint = await restartedServer.start({ dir: restartDir, lockFile: path.join(restartDir, "console.lock") });
+
+    const afterRestart = await getJson<{ readonly theaters: ReadonlyArray<{ readonly id: string; readonly hasWiki: boolean }> }>(`${restartedEndpoint}observer/theaters`);
+
+    // 추가 직후에는 POST 경로가 워크스페이스를 등록하므로 hasWiki=true이고,
+    // 재시작 후에도 복원된 Theater의 워크스페이스를 재등록해 hasWiki가 유지되어야 한다.
+    expect(beforeRestart.theaters.find((entry) => entry.id === theater.id)?.hasWiki).toBe(true);
+    expect(afterRestart.theaters.find((entry) => entry.id === theater.id)?.hasWiki).toBe(true);
+  });
+
   it("rehydrates durable state as dormant without starting PTYs and merges capture files server-side", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-rehydrate-"));
     tempDirs.push(dir);

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -839,6 +839,39 @@ describe("console static and terminal ticket boundary", () => {
     expect(body.knowledgeRoot).toBe(path.join(fs.realpathSync.native(dirA), ".fleet", "knowledge"));
   });
 
+  it("restores the most-recently-opened Codex workspace as MRU after a restart", async () => {
+    const dirA = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-codex-restart-mru-a-"));
+    const dirB = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-codex-restart-mru-b-"));
+    tempDirs.push(dirA, dirB);
+    fs.mkdirSync(path.join(dirA, ".fleet", "knowledge"), { recursive: true });
+    fs.mkdirSync(path.join(dirB, ".fleet", "knowledge"), { recursive: true });
+    const fixture = await startFixture();
+    await createTheater(fixture, dirA);
+    const theaterB = await createTheater(fixture, dirB);
+
+    // durable lastOpenedAt을 명시적으로 구분해 B를 가장 최근으로 만든다(생성 타이밍 의존 제거).
+    const statePath = path.join(fixture.carrierStoreDir, "console", "state.json");
+    const state = JSON.parse(fs.readFileSync(statePath, "utf8")) as { readonly theaters: { id: string; lastOpenedAt: string }[] };
+    for (const theater of state.theaters) {
+      theater.lastOpenedAt = theater.id === theaterB.id ? "2026-06-01T00:00:00.000Z" : "2026-01-01T00:00:00.000Z";
+    }
+    fs.writeFileSync(statePath, JSON.stringify(state));
+    await fixture.server.stop();
+
+    const restartDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-codex-restart-mru-lock-"));
+    tempDirs.push(restartDir);
+    const restartedServer = createConsoleServer({ port: 0, version: "test", dataDir: fixture.carrierStoreDir });
+    servers.push(restartedServer);
+    const restartedEndpoint = await restartedServer.start({ dir: restartDir, lockFile: path.join(restartDir, "console.lock") });
+
+    // 재시작 후 codex MRU는 가장 최근에 열린 B여야 하므로 비프리픽스 health가 B의 knowledgeRoot를 서빙한다.
+    const health = await fetch(`${restartedEndpoint}console/codex/api/health`, { redirect: "manual" });
+    const body = await health.json() as { readonly knowledgeRoot?: string };
+
+    expect(health.status).toBe(200);
+    expect(body.knowledgeRoot).toBe(path.join(fs.realpathSync.native(dirB), ".fleet", "knowledge"));
+  });
+
   it("rehydrates durable state as dormant without starting PTYs and merges capture files server-side", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-rehydrate-"));
     tempDirs.push(dir);

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -872,6 +872,35 @@ describe("console static and terminal ticket boundary", () => {
     expect(body.knowledgeRoot).toBe(path.join(fs.realpathSync.native(dirB), ".fleet", "knowledge"));
   });
 
+  it("restores a symlinked Theater's Codex workspace from the durable realpath", async () => {
+    const realDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-codex-symlink-real-"));
+    const otherDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-codex-symlink-other-"));
+    const linkDir = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-codex-symlink-link-")), "theater");
+    tempDirs.push(realDir, otherDir, path.dirname(linkDir));
+    fs.mkdirSync(path.join(realDir, ".fleet", "knowledge"), { recursive: true });
+    fs.mkdirSync(path.join(otherDir, ".fleet", "knowledge"), { recursive: true });
+    fs.symlinkSync(realDir, linkDir);
+
+    const fixture = await startFixture();
+    const theater = await createTheater(fixture, linkDir); // 심볼릭 경로로 등록 → id는 realDir 기준
+    await fixture.server.stop();
+
+    // 정지 중 심볼릭 타깃을 다른 디렉터리로 바꾼다. theater.path를 다시 정규화하면 id가 달라지지만,
+    // durable realpath로 복원하면 원래 id를 그대로 유지해 hasWiki 판정이 깨지지 않아야 한다.
+    fs.unlinkSync(linkDir);
+    fs.symlinkSync(otherDir, linkDir);
+
+    const restartDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-codex-symlink-lock-"));
+    tempDirs.push(restartDir);
+    const restartedServer = createConsoleServer({ port: 0, version: "test", dataDir: fixture.carrierStoreDir });
+    servers.push(restartedServer);
+    const restartedEndpoint = await restartedServer.start({ dir: restartDir, lockFile: path.join(restartDir, "console.lock") });
+
+    const bootstrap = await getJson<{ readonly theaters: ReadonlyArray<{ readonly id: string; readonly hasWiki: boolean }> }>(`${restartedEndpoint}observer/theaters`);
+
+    expect(bootstrap.theaters.find((entry) => entry.id === theater.id)?.hasWiki).toBe(true);
+  });
+
   it("rehydrates durable state as dormant without starting PTYs and merges capture files server-side", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-rehydrate-"));
     tempDirs.push(dir);


### PR DESCRIPTION
## Summary

- Console 재시작 시 durable state에서 복원된 Theater의 Codex 워크스페이스가 재등록되지 않아, in-memory WorkspaceRegistry에 의존하는 `hasWiki`가 false로 떨어지던 문제를 수정합니다. 그 결과 위키가 있는 Theater도 재실행마다 Codex(Fleet Wiki) 대신 "Codex unavailable" 빈 상태를 렌더했습니다. 이제 rehydrate 시 복원된 Theater의 워크스페이스를 best-effort 재등록(추가 경로와 대칭)해 재시작 후에도 hasWiki=true를 유지합니다.
- (동반) canary가 물려준 typecheck 결함을 함께 보정합니다 — 필수 필드 `operationsViewActive`가 `ConsoleState`에 추가되었으나 `dashboard.test.ts`·`operation-search.test.ts` 픽스처에 누락되어 typecheck program이 깨지던 것을 기본값(false)으로 채웠습니다.

## Type of Change

- [x] fix — bug fix
- [x] test — 누락된 상태 픽스처 보정(typecheck)

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — green
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 333 passed (재시작 후 hasWiki 유지 회귀 테스트 신규 추가)
- [x] `pnpm --filter @dotobokuri/fleet-console build` — green
- [x] 실브라우저(console-e2e): 콘솔 재시작 후 `/console/codex`에서 `.codex-host`(Fleet Wiki 리딩 표면) 마운트 확인, `hasWiki=true`, pageerror 없음

## Notes

- 회귀 테스트는 수정 없이는 실패(재시작 후 `hasWiki=false`)하고 수정 적용 시 통과함을 양방향으로 확인했습니다.