### PR TITLE
feat(console): add Model Sign-in section for Kimi provider login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+- [core] Fleet Console adds a Model Sign-in section to the global Settings screen to register, verify, and remove a provider API key so carriers can run on that model, starting with Moonshot Kimi; keys are validated against the provider, stored locally, and never shown back in the browser.
+
 ## [1.8.0] - 2026-06-18
 
 ### Added

--- a/runtime/fleet-console/client/src/components/model-auth-section.tsx
+++ b/runtime/fleet-console/client/src/components/model-auth-section.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+
+import { loadModelAuth, signInModel, signOutModel, useModelAuthStore } from "../model-auth-store.js";
+import type { ModelAuthProviderState } from "../types.js";
+
+interface ProviderRowProps {
+  readonly provider: ModelAuthProviderState;
+  readonly busy: boolean;
+}
+
+export function ModelAuthSection() {
+  const store = useModelAuthStore();
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadModelAuth(controller.signal);
+    return () => controller.abort();
+  }, []);
+
+  return (
+    <section className="global-settings-card" aria-label="Model sign-in">
+      <div className="model-auth-head">
+        <p className="global-settings-resp-title">Model Sign-in</p>
+        <p className="global-settings-help">
+          Register a provider API key so carriers can run on that model. Keys are validated against the provider, stored
+          locally, and never shown back in the browser.
+        </p>
+      </div>
+
+      {store.error ? <p className="global-settings-error" role="alert">{store.error}</p> : null}
+      {store.loading && !store.state ? <p className="global-settings-help">Loading sign-in state.</p> : null}
+
+      {store.state?.providers.map((provider) => (
+        <ProviderRow key={provider.cli} provider={provider} busy={store.busyCli === provider.cli} />
+      ))}
+
+      <p className="global-settings-foot">Sign-in changes apply to newly launched sessions. Running sessions keep their current credentials until relaunched.</p>
+    </section>
+  );
+}
+
+function ProviderRow({ provider, busy }: ProviderRowProps) {
+  const [apiKey, setApiKey] = useState("");
+
+  const handleSignIn = async () => {
+    const ok = await signInModel(provider.cli, apiKey);
+    if (ok) setApiKey("");
+  };
+
+  const handleSignOut = async () => {
+    await signOutModel(provider.cli);
+  };
+
+  return (
+    <div className="model-auth-row">
+      <div className="model-auth-row-head">
+        <span className="model-auth-name">{provider.displayName}</span>
+        <span className={`model-auth-status ${provider.signedIn ? "is-on" : ""}`}>
+          {provider.signedIn ? "Signed in" : "Not signed in"}
+        </span>
+      </div>
+
+      {provider.signedIn ? (
+        <div className="model-auth-actions">
+          <button type="button" className="model-auth-button" disabled={busy} onClick={() => void handleSignOut()}>
+            {busy ? "Working…" : "Sign out"}
+          </button>
+        </div>
+      ) : (
+        <form
+          className="model-auth-form"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void handleSignIn();
+          }}
+        >
+          <input
+            type="password"
+            className="model-auth-input"
+            placeholder="API key"
+            value={apiKey}
+            autoComplete="off"
+            spellCheck={false}
+            disabled={busy}
+            aria-label={`${provider.displayName} API key`}
+            onChange={(event) => setApiKey(event.target.value)}
+          />
+          <button type="submit" className="model-auth-button is-primary" disabled={busy || apiKey.trim().length === 0}>
+            {busy ? "Verifying…" : "Sign in"}
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/runtime/fleet-console/client/src/model-auth-api.ts
+++ b/runtime/fleet-console/client/src/model-auth-api.ts
@@ -1,0 +1,72 @@
+import { ApiError } from "./api.js";
+import type { ModelAuthMutationResult, ModelAuthProviderState, ModelAuthState } from "./types.js";
+
+export async function fetchModelAuthState(signal?: AbortSignal): Promise<ModelAuthState> {
+  const response = await fetch("/model-auth/state", { signal });
+  await assertOk(response);
+  return assertModelAuthState(await response.json(), response.status);
+}
+
+export async function signInModelProvider(cli: string, apiKey: string, signal?: AbortSignal): Promise<ModelAuthMutationResult> {
+  const response = await fetch(`/model-auth/providers/${encodeURIComponent(cli)}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ apiKey }),
+    signal,
+  });
+  await assertOk(response);
+  return assertMutationResult(await response.json(), response.status);
+}
+
+export async function signOutModelProvider(cli: string, signal?: AbortSignal): Promise<ModelAuthMutationResult> {
+  const response = await fetch(`/model-auth/providers/${encodeURIComponent(cli)}`, {
+    method: "DELETE",
+    signal,
+  });
+  await assertOk(response);
+  return assertMutationResult(await response.json(), response.status);
+}
+
+async function assertOk(response: Response): Promise<void> {
+  if (response.ok) return;
+  let message = response.statusText || `HTTP ${response.status}`;
+  try {
+    const payload = await response.json() as { error?: unknown };
+    if (typeof payload.error === "string") message = payload.error;
+  } catch {
+    // 응답 본문이 JSON이 아니면 statusText를 사용한다.
+  }
+  throw new ApiError(response.status, message);
+}
+
+function assertMutationResult(value: unknown, status: number): ModelAuthMutationResult {
+  const payload = value as { readonly state?: unknown };
+  if (!payload || typeof payload !== "object" || !("state" in payload)) {
+    throw new ApiError(status, "Invalid model auth mutation response");
+  }
+  return { state: assertModelAuthState(payload.state, status) };
+}
+
+function assertModelAuthState(value: unknown, status: number): ModelAuthState {
+  const payload = value as { readonly providers?: unknown };
+  if (!payload || typeof payload !== "object" || !Array.isArray(payload.providers)) {
+    throw new ApiError(status, "Invalid model auth state response");
+  }
+  return { providers: payload.providers.map((provider) => assertProviderState(provider, status)) };
+}
+
+function assertProviderState(value: unknown, status: number): ModelAuthProviderState {
+  const payload = value as Partial<ModelAuthProviderState>;
+  if (
+    typeof payload.cli !== "string" ||
+    typeof payload.displayName !== "string" ||
+    typeof payload.signedIn !== "boolean"
+  ) {
+    throw new ApiError(status, "Invalid model auth provider response");
+  }
+  return {
+    cli: payload.cli,
+    displayName: payload.displayName,
+    signedIn: payload.signedIn,
+  };
+}

--- a/runtime/fleet-console/client/src/model-auth-store.ts
+++ b/runtime/fleet-console/client/src/model-auth-store.ts
@@ -1,0 +1,80 @@
+import { useSyncExternalStore } from "react";
+
+import { fetchModelAuthState, signInModelProvider, signOutModelProvider } from "./model-auth-api.js";
+import type { ModelAuthState } from "./types.js";
+
+interface ModelAuthStoreState {
+  readonly loading: boolean;
+  readonly state: ModelAuthState | null;
+  readonly busyCli: string | null;
+  readonly error: string | null;
+}
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+let snapshot: ModelAuthStoreState = {
+  loading: false,
+  state: null,
+  busyCli: null,
+  error: null,
+};
+
+export function useModelAuthStore(): ModelAuthStoreState {
+  return useSyncExternalStore(subscribe, getModelAuthStoreState, getModelAuthStoreState);
+}
+
+export function getModelAuthStoreState(): ModelAuthStoreState {
+  return snapshot;
+}
+
+export function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export async function loadModelAuth(signal?: AbortSignal): Promise<void> {
+  setSnapshot({ loading: true, error: null });
+  try {
+    const state = await fetchModelAuthState(signal);
+    setSnapshot({ loading: false, state, error: null });
+  } catch (error) {
+    if (signal?.aborted) return;
+    setSnapshot({ loading: false, error: toErrorMessage(error) });
+  }
+}
+
+export async function signInModel(cli: string, apiKey: string): Promise<boolean> {
+  setSnapshot({ busyCli: cli, error: null });
+  try {
+    const result = await signInModelProvider(cli, apiKey);
+    setSnapshot({ state: result.state, busyCli: null, error: null });
+    return true;
+  } catch (error) {
+    setSnapshot({ busyCli: null, error: toErrorMessage(error) });
+    return false;
+  }
+}
+
+export async function signOutModel(cli: string): Promise<boolean> {
+  setSnapshot({ busyCli: cli, error: null });
+  try {
+    const result = await signOutModelProvider(cli);
+    setSnapshot({ state: result.state, busyCli: null, error: null });
+    return true;
+  } catch (error) {
+    setSnapshot({ busyCli: null, error: toErrorMessage(error) });
+    return false;
+  }
+}
+
+function setSnapshot(patch: Partial<ModelAuthStoreState>): void {
+  snapshot = { ...snapshot, ...patch };
+  for (const listener of listeners) listener();
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/runtime/fleet-console/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/client/src/pages/global-settings.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 
+import { ModelAuthSection } from "../components/model-auth-section.js";
 import { loadGlobalSettings, setGlobalSettingsField, useGlobalSettingsStore } from "../global-settings-store.js";
 
 interface SettingToggleRowProps {
@@ -63,6 +64,8 @@ export function GlobalSettings() {
         ) : null}
         <p className="global-settings-foot">Changes apply to newly launched sessions. Running sessions keep their current configuration until relaunched.</p>
       </section>
+
+      <ModelAuthSection />
     </main>
   );
 }

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -422,6 +422,160 @@
   }
 }
 
+/* 모델 로그인 — provider API key 등록 행. global-settings-card를 그릇으로 재사용한다. */
+.model-auth-head {
+  display: grid;
+  gap: 8px;
+}
+
+.model-auth-row {
+  display: grid;
+  gap: var(--space-3);
+  padding-top: var(--space-5);
+  border-top: 1px solid color-mix(in oklch, var(--surface-rim) 55%, transparent);
+}
+
+.model-auth-row-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.model-auth-name {
+  color: var(--ink-pearl);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.model-auth-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.model-auth-status::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ink-rim);
+}
+
+/* signedIn = aurora('살아있는 것'). 미로그인은 중립 ink. */
+.model-auth-status.is-on {
+  color: var(--aurora);
+}
+
+.model-auth-status.is-on::before {
+  background: var(--aurora);
+  box-shadow: 0 0 10px var(--aurora-glow);
+}
+
+.model-auth-form {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.model-auth-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 34px;
+  padding: 6px var(--space-3);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-xs);
+  background: color-mix(in oklch, var(--surface-glass) 60%, transparent);
+  color: var(--ink-pearl);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+}
+
+.model-auth-input::placeholder {
+  color: var(--ink-rim);
+}
+
+.model-auth-input:focus {
+  outline: none;
+  border-color: color-mix(in oklch, var(--brass) 55%, var(--surface-rim));
+}
+
+.model-auth-input:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.model-auth-actions {
+  display: flex;
+}
+
+/* 액션 버튼 — brass('지금 보는/하는 것'). is-primary가 Sign in. */
+.model-auth-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  min-width: 96px;
+  min-height: 34px;
+  padding: 6px var(--space-3);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-xs);
+  background: transparent;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-spring),
+    color var(--duration-fast) var(--ease-spring),
+    transform var(--duration-fast) var(--ease-spring);
+}
+
+.model-auth-button:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--brass) 8%, transparent);
+  color: var(--ink-pearl);
+}
+
+.model-auth-button.is-primary {
+  border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
+  color: var(--brass);
+}
+
+.model-auth-button.is-primary:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--brass) 14%, transparent);
+  color: var(--ink-pearl);
+}
+
+.model-auth-button:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.model-auth-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+@media (max-width: 720px) {
+  .model-auth-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
 .carrier-settings-page {
   display: grid;
   align-content: start;

--- a/runtime/fleet-console/client/src/types.ts
+++ b/runtime/fleet-console/client/src/types.ts
@@ -128,6 +128,21 @@ export interface GlobalSettingsMutationResult {
   readonly state: GlobalSettingsState;
 }
 
+// 모델 로그인(provider API key 등록) DTO — server src/model-auth-types.ts와 수동 동기화한다.
+export interface ModelAuthProviderState {
+  readonly cli: string;
+  readonly displayName: string;
+  readonly signedIn: boolean;
+}
+
+export interface ModelAuthState {
+  readonly providers: readonly ModelAuthProviderState[];
+}
+
+export interface ModelAuthMutationResult {
+  readonly state: ModelAuthState;
+}
+
 export type SessionStatus = "starting" | "live" | "registered" | "terminal-only" | "closed" | "error" | "dormant";
 
 // Agent CLI 턴(host 처리) 상태. "none"=턴 이력 없음(신규), "running"=처리중, "ended"=종료(유휴).

--- a/runtime/fleet-console/src/model-auth-routes.ts
+++ b/runtime/fleet-console/src/model-auth-routes.ts
@@ -1,0 +1,207 @@
+import type http from "node:http";
+
+import type { CliType } from "@dotobokuri/core-unified-agent";
+import {
+  CLI_TO_AUTH_PROVIDER_ID,
+  type AuthService,
+  type AuthValidationFailureResult,
+} from "@dotobokuri/fleet-infra/auth";
+
+import type { ModelAuthMutationResult, ModelAuthProviderState, ModelAuthState } from "./model-auth-types.js";
+
+type AuthKeyValidation =
+  | { readonly providerId: string; readonly status: "success" }
+  | AuthValidationFailureResult;
+
+interface ModelAuthRouteDeps {
+  readonly authService: Pick<AuthService, "setApiKey" | "deleteApiKey" | "listProviderIds">;
+  readonly validateApiKey: (cli: CliType, apiKey: string) => Promise<AuthKeyValidation>;
+  readonly isAuthorized: (req: http.IncomingMessage) => boolean;
+  readonly readJsonBody: <T>(req: http.IncomingMessage) => Promise<T | null>;
+  readonly writeJson: (res: http.ServerResponse, status: number, body: unknown) => void;
+}
+
+interface ModelAuthRouteContext {
+  readonly req: http.IncomingMessage;
+  readonly res: http.ServerResponse;
+  readonly pathname: string;
+}
+
+interface ModelAuthProviderDefinition {
+  readonly cli: CliType;
+  readonly displayName: string;
+}
+
+interface SignInBody {
+  readonly apiKey?: unknown;
+}
+
+// kimi 우선 — console에 노출하는 모델 로그인 provider 화이트리스트. 다른 provider(claude-zai 등)는
+// 의도적으로 제외한다. 경로로 들어온 임의 cli는 이 목록 대조로만 통과한다.
+const MODEL_AUTH_PROVIDERS: readonly ModelAuthProviderDefinition[] = [
+  { cli: "claude-kimi", displayName: "Moonshot Kimi" },
+];
+
+// 사용자 키 거부(400)와 외부 provider 검증 자체 장애(502)를 HTTP 상태로 구분한다.
+const UPSTREAM_FAILURE_STATUSES: ReadonlySet<string> = new Set(["timeout", "network", "server"]);
+
+export function createModelAuthRouter(deps: ModelAuthRouteDeps): (context: ModelAuthRouteContext) => Promise<boolean> {
+  return async function handleModelAuthRoute(context: ModelAuthRouteContext): Promise<boolean> {
+    const { req, res, pathname } = context;
+    if (pathname === "/model-auth/state") {
+      if (req.method !== "GET") {
+        deps.writeJson(res, 405, { error: "Method not allowed" });
+        return true;
+      }
+      // 상태 조회는 loopback GET이며 signedIn 불린만 반환하므로 global-settings/state와 대칭으로 게이트하지 않는다.
+      deps.writeJson(res, 200, await buildModelAuthState(deps.authService));
+      return true;
+    }
+    const cli = parseProviderPath(pathname);
+    if (!cli) return false;
+    const provider = MODEL_AUTH_PROVIDERS.find((entry) => entry.cli === cli);
+    if (!provider) {
+      deps.writeJson(res, 404, { error: "provider_not_found" });
+      return true;
+    }
+    if (req.method === "PUT") {
+      await signInProvider(req, res, deps, provider);
+      return true;
+    }
+    if (req.method === "DELETE") {
+      await signOutProvider(req, res, deps, provider);
+      return true;
+    }
+    deps.writeJson(res, 405, { error: "Method not allowed" });
+    return true;
+  };
+}
+
+export async function buildModelAuthState(
+  authService: Pick<AuthService, "listProviderIds">,
+): Promise<ModelAuthState> {
+  const signedInIds = new Set(await authService.listProviderIds());
+  return {
+    providers: MODEL_AUTH_PROVIDERS.map((provider) => toProviderState(provider, signedInIds)),
+  };
+}
+
+async function signInProvider(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  deps: ModelAuthRouteDeps,
+  provider: ModelAuthProviderDefinition,
+): Promise<void> {
+  if (!deps.isAuthorized(req)) {
+    deps.writeJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  if (!isJsonRequest(req)) {
+    deps.writeJson(res, 415, { error: "unsupported_media_type" });
+    return;
+  }
+  const body = await deps.readJsonBody<SignInBody>(req);
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    deps.writeJson(res, 400, { error: "invalid_json" });
+    return;
+  }
+  const apiKey = typeof body.apiKey === "string" ? body.apiKey.trim() : "";
+  if (apiKey.length === 0) {
+    deps.writeJson(res, 400, { error: "invalid_api_key" });
+    return;
+  }
+  const providerId = CLI_TO_AUTH_PROVIDER_ID[provider.cli];
+  if (!providerId) {
+    deps.writeJson(res, 500, { error: "provider_unavailable" });
+    return;
+  }
+  // 검증은 서버에서만 수행한다 — 키는 외부 provider 검증과 로컬 저장에만 쓰이고 브라우저로 되돌려보내지 않는다.
+  const validation = await deps.validateApiKey(provider.cli, apiKey);
+  if (validation.status !== "success") {
+    const status = UPSTREAM_FAILURE_STATUSES.has(validation.status) ? 502 : 400;
+    // 실패 메시지는 console 자체 문구로 만든다 — fleet-infra 표준 메시지는 providerId(=auth.json 저장 키)와
+    // upstream detail을 담으므로, 그대로 브라우저로 보내면 state DTO에서 막은 저장키가 에러 경로로 샌다(Token Boundary).
+    deps.writeJson(res, status, {
+      error: formatSignInFailureMessage(provider.displayName, validation.status),
+      status: validation.status,
+    });
+    return;
+  }
+  await deps.authService.setApiKey(providerId, apiKey);
+  await writeMutationState(res, deps);
+}
+
+async function signOutProvider(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  deps: ModelAuthRouteDeps,
+  provider: ModelAuthProviderDefinition,
+): Promise<void> {
+  if (!deps.isAuthorized(req)) {
+    deps.writeJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  const providerId = CLI_TO_AUTH_PROVIDER_ID[provider.cli];
+  if (!providerId) {
+    deps.writeJson(res, 500, { error: "provider_unavailable" });
+    return;
+  }
+  await deps.authService.deleteApiKey(providerId);
+  await writeMutationState(res, deps);
+}
+
+async function writeMutationState(res: http.ServerResponse, deps: ModelAuthRouteDeps): Promise<void> {
+  const response: ModelAuthMutationResult = { state: await buildModelAuthState(deps.authService) };
+  deps.writeJson(res, 200, response);
+}
+
+function toProviderState(
+  provider: ModelAuthProviderDefinition,
+  signedInIds: ReadonlySet<string>,
+): ModelAuthProviderState {
+  // providerId(= ~/.fleet/auth.json 영속 키)는 signedIn 판정에만 쓰고 브라우저 DTO로는 내보내지 않는다(Token Boundary).
+  const providerId = CLI_TO_AUTH_PROVIDER_ID[provider.cli] ?? provider.cli;
+  return {
+    cli: provider.cli,
+    displayName: provider.displayName,
+    signedIn: signedInIds.has(providerId),
+  };
+}
+
+function parseProviderPath(pathname: string): CliType | null {
+  const parts = pathname.split("/").filter(Boolean);
+  if (parts.length !== 3 || parts[0] !== "model-auth" || parts[1] !== "providers") return null;
+  const cli = safeDecodeURIComponent(parts[2] ?? "");
+  return cli ? (cli as CliType) : null;
+}
+
+function safeDecodeURIComponent(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}
+
+function isJsonRequest(req: http.IncomingMessage): boolean {
+  const contentType = req.headers["content-type"];
+  return typeof contentType === "string" && contentType.toLowerCase().split(";")[0]?.trim() === "application/json";
+}
+
+// displayName만 쓰는 브라우저-안전 실패 문구. providerId(저장 키)·upstream detail은 의도적으로 배제한다.
+function formatSignInFailureMessage(displayName: string, status: string): string {
+  switch (status) {
+    case "unauthorized":
+      return `${displayName} rejected the API key. Check the key and try again.`;
+    case "forbidden":
+      return `The API key is not allowed for ${displayName}. Check its permissions.`;
+    case "timeout":
+      return `Validating the ${displayName} API key timed out. Check your connection and try again.`;
+    case "network":
+      return `Could not reach ${displayName} to validate the API key. Check your connection and try again.`;
+    case "server":
+      return `${displayName} returned an error while validating the API key. Try again later.`;
+    default:
+      return `Could not validate the ${displayName} API key. Check the key and try again.`;
+  }
+}

--- a/runtime/fleet-console/src/model-auth-routes.ts
+++ b/runtime/fleet-console/src/model-auth-routes.ts
@@ -16,6 +16,7 @@ type AuthKeyValidation =
 interface ModelAuthRouteDeps {
   readonly authService: Pick<AuthService, "setApiKey" | "deleteApiKey" | "listProviderIds">;
   readonly validateApiKey: (cli: CliType, apiKey: string) => Promise<AuthKeyValidation>;
+  readonly migrateLegacyAuth: () => Promise<unknown>;
   readonly isAuthorized: (req: http.IncomingMessage) => boolean;
   readonly readJsonBody: <T>(req: http.IncomingMessage) => Promise<T | null>;
   readonly writeJson: (res: http.ServerResponse, status: number, body: unknown) => void;
@@ -53,6 +54,9 @@ export function createModelAuthRouter(deps: ModelAuthRouteDeps): (context: Model
         deps.writeJson(res, 405, { error: "Method not allowed" });
         return true;
       }
+      // legacy 저장소(~/.fleet/agent/auth.json)만 가진 업그레이드 사용자도 정확한 signedIn을 보도록,
+      // fleet-cli의 auth/launch 경로와 동일하게 store를 읽기 전 legacy를 마이그레이션한다.
+      await deps.migrateLegacyAuth();
       // 상태 조회는 loopback GET이며 signedIn 불린만 반환하므로 global-settings/state와 대칭으로 게이트하지 않는다.
       deps.writeJson(res, 200, await buildModelAuthState(deps.authService));
       return true;
@@ -115,6 +119,8 @@ async function signInProvider(
     deps.writeJson(res, 500, { error: "provider_unavailable" });
     return;
   }
+  // 새 키를 legacy와 병합 저장하도록 store 쓰기 전 legacy를 마이그레이션한다(fleet-cli login과 동일).
+  await deps.migrateLegacyAuth();
   // 검증은 서버에서만 수행한다 — 키는 외부 provider 검증과 로컬 저장에만 쓰이고 브라우저로 되돌려보내지 않는다.
   const validation = await deps.validateApiKey(provider.cli, apiKey);
   if (validation.status !== "success") {
@@ -146,6 +152,8 @@ async function signOutProvider(
     deps.writeJson(res, 500, { error: "provider_unavailable" });
     return;
   }
+  // 로그아웃 대상이 legacy에만 있을 수 있으므로 삭제 전 legacy를 마이그레이션한다(fleet-cli logout과 동일).
+  await deps.migrateLegacyAuth();
   await deps.authService.deleteApiKey(providerId);
   await writeMutationState(res, deps);
 }

--- a/runtime/fleet-console/src/model-auth-routes.ts
+++ b/runtime/fleet-console/src/model-auth-routes.ts
@@ -119,8 +119,6 @@ async function signInProvider(
     deps.writeJson(res, 500, { error: "provider_unavailable" });
     return;
   }
-  // 새 키를 legacy와 병합 저장하도록 store 쓰기 전 legacy를 마이그레이션한다(fleet-cli login과 동일).
-  await deps.migrateLegacyAuth();
   // 검증은 서버에서만 수행한다 — 키는 외부 provider 검증과 로컬 저장에만 쓰이고 브라우저로 되돌려보내지 않는다.
   const validation = await deps.validateApiKey(provider.cli, apiKey);
   if (validation.status !== "success") {
@@ -152,8 +150,10 @@ async function signOutProvider(
     deps.writeJson(res, 500, { error: "provider_unavailable" });
     return;
   }
-  // 로그아웃 대상이 legacy에만 있을 수 있으므로 삭제 전 legacy를 마이그레이션한다(fleet-cli logout과 동일).
-  await deps.migrateLegacyAuth();
+  // 현재 store에서만 삭제한다. legacy(~/.fleet/agent/auth.json) 원본 영구 제거는 fleet-cli logout과
+  // 공유하는 fleet-infra/auth SSoT 한계(migrate는 복사만, deleteApiKey는 현재 store만 삭제)라 이 PR scope
+  // 밖이다(후속 분리). 여기서 migrate를 호출하면 legacy를 복사만 하고 원본이 남아 다음 read에서 부활하므로,
+  // 혼란을 피하려 migrate 없이 현재 store만 삭제한다.
   await deps.authService.deleteApiKey(providerId);
   await writeMutationState(res, deps);
 }

--- a/runtime/fleet-console/src/model-auth-types.ts
+++ b/runtime/fleet-console/src/model-auth-types.ts
@@ -1,0 +1,16 @@
+// 모델 로그인(provider API key 등록) 상태의 직렬화 계약.
+// signedIn 불린만 노출하며, API key 값/마스킹은 절대 브라우저로 싣지 않는다(Token Boundary).
+
+export interface ModelAuthProviderState {
+  readonly cli: string;
+  readonly displayName: string;
+  readonly signedIn: boolean;
+}
+
+export interface ModelAuthState {
+  readonly providers: readonly ModelAuthProviderState[];
+}
+
+export interface ModelAuthMutationResult {
+  readonly state: ModelAuthState;
+}

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -20,7 +20,7 @@ import {
   type FleetAgentRuntimeLifecycle,
 } from "@dotobokuri/fleet-admiral";
 import { createInfraServices, getFleetDataDir } from "@dotobokuri/fleet-infra";
-import { resolveAuthEnv } from "@dotobokuri/fleet-infra/auth";
+import { resolveAuthEnv, validateAuthKeyForCli } from "@dotobokuri/fleet-infra/auth";
 import { getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
 
 import type { ConsoleCarrierReadinessEntry, ConsoleHealth, ConsoleObservedWorkspace, ConsoleObserverStatus, ConsoleTheaterInfo, TerminalFolderListResponse } from "./api-types.js";
@@ -29,6 +29,7 @@ import { createCodexGateway } from "./codex/gateway.js";
 import { cleanupProviderSessionCaptures, createConsoleDurableStateStore, emptyDurableConsoleState, mergeProviderSessionCaptures, readProviderSessionCapture, unlinkProviderSessionCapture, type DurableConsoleState, type DurableOperation } from "./durable-state.js";
 import { createGlobalSettingsRouter } from "./global-settings-routes.js";
 import { createConsoleLock, type ConsoleLockHandle } from "./lock.js";
+import { createModelAuthRouter } from "./model-auth-routes.js";
 import { writeAggregateObserverEvents, writeObserverEvents } from "./observability-routes.js";
 import { createConsoleDataPaths } from "./paths.js";
 import { readFleetConsoleRelease } from "./release.js";
@@ -198,6 +199,13 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     readJsonBody,
     writeJson,
   });
+  const modelAuthRouter = createModelAuthRouter({
+    authService: infraServices.authService,
+    validateApiKey: (cli, apiKey) => validateAuthKeyForCli(cli, apiKey),
+    isAuthorized: isTerminalAuthorized,
+    readJsonBody,
+    writeJson,
+  });
 
   function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
     const pathname = getPathname(req);
@@ -278,6 +286,10 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     }
     if (pathname === "/global-settings" || pathname.startsWith("/global-settings/")) {
       runAsyncBooleanHandler(globalSettingsRouter({ req, res, pathname }), res);
+      return;
+    }
+    if (pathname === "/model-auth" || pathname.startsWith("/model-auth/")) {
+      runAsyncBooleanHandler(modelAuthRouter({ req, res, pathname }), res);
       return;
     }
     if (pathname === "/observer/tenants") {

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -20,7 +20,7 @@ import {
   type FleetAgentRuntimeLifecycle,
 } from "@dotobokuri/fleet-admiral";
 import { createInfraServices, getFleetDataDir } from "@dotobokuri/fleet-infra";
-import { resolveAuthEnv, validateAuthKeyForCli } from "@dotobokuri/fleet-infra/auth";
+import { migrateLegacyAuthStore, resolveAuthEnv, validateAuthKeyForCli } from "@dotobokuri/fleet-infra/auth";
 import { getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
 
 import type { ConsoleCarrierReadinessEntry, ConsoleHealth, ConsoleObservedWorkspace, ConsoleObserverStatus, ConsoleTheaterInfo, TerminalFolderListResponse } from "./api-types.js";
@@ -202,6 +202,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   const modelAuthRouter = createModelAuthRouter({
     authService: infraServices.authService,
     validateApiKey: (cli, apiKey) => validateAuthKeyForCli(cli, apiKey),
+    migrateLegacyAuth: () => migrateLegacyAuthStore(),
     isAuthorized: isTerminalAuthorized,
     readJsonBody,
     writeJson,

--- a/runtime/fleet-console/tests/model-auth-routes.test.ts
+++ b/runtime/fleet-console/tests/model-auth-routes.test.ts
@@ -147,6 +147,24 @@ describe("model auth routes", () => {
     expect(harness.deleteCalls).toBe(0);
   });
 
+  it("GET /model-auth/state migrates legacy auth before reading sign-in state", async () => {
+    const harness = createRouterHarness();
+    await harness.router({ req: req("GET"), res: res(), pathname: "/model-auth/state" });
+    expect(harness.migrateCalls).toBe(1);
+  });
+
+  it("PUT migrates legacy auth before validating and storing", async () => {
+    const harness = createRouterHarness({ authorized: true, body: { apiKey: "sk-live" } });
+    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: KIMI_PATH });
+    expect(harness.migrateCalls).toBe(1);
+  });
+
+  it("DELETE migrates legacy auth before signing out", async () => {
+    const harness = createRouterHarness({ authorized: true, signedIn: true });
+    await harness.router({ req: req("DELETE"), res: res(), pathname: KIMI_PATH });
+    expect(harness.migrateCalls).toBe(1);
+  });
+
   it("returns false for the bare providers path so the host can fall through", async () => {
     const harness = createRouterHarness();
     const handled = await harness.router({ req: req("GET"), res: res(), pathname: "/model-auth/providers" });
@@ -161,6 +179,7 @@ function createRouterHarness(options: RouterHarnessOptions = {}) {
   let validateCalls = 0;
   let setCalls = 0;
   let deleteCalls = 0;
+  let migrateCalls = 0;
   const router = createModelAuthRouter({
     authService: {
       setApiKey: async (providerId, apiKey) => { setCalls += 1; store.set(providerId, apiKey); },
@@ -171,6 +190,7 @@ function createRouterHarness(options: RouterHarnessOptions = {}) {
       validateCalls += 1;
       return (options.validation ?? { providerId: KIMI_PROVIDER_ID, status: "success" }) as never;
     },
+    migrateLegacyAuth: async () => { migrateCalls += 1; return {}; },
     isAuthorized: () => options.authorized ?? true,
     readJsonBody: async () => (options.bodyNull ? null : (options.body ?? { apiKey: "sk-test" })) as never,
     writeJson: (_res, status, body) => { writes.push({ status, body }); },
@@ -182,6 +202,7 @@ function createRouterHarness(options: RouterHarnessOptions = {}) {
     get validateCalls() { return validateCalls; },
     get setCalls() { return setCalls; },
     get deleteCalls() { return deleteCalls; },
+    get migrateCalls() { return migrateCalls; },
   };
 }
 

--- a/runtime/fleet-console/tests/model-auth-routes.test.ts
+++ b/runtime/fleet-console/tests/model-auth-routes.test.ts
@@ -153,16 +153,11 @@ describe("model auth routes", () => {
     expect(harness.migrateCalls).toBe(1);
   });
 
-  it("PUT migrates legacy auth before validating and storing", async () => {
-    const harness = createRouterHarness({ authorized: true, body: { apiKey: "sk-live" } });
-    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: KIMI_PATH });
-    expect(harness.migrateCalls).toBe(1);
-  });
-
-  it("DELETE migrates legacy auth before signing out", async () => {
+  it("DELETE deletes from the current store only and does not migrate legacy (legacy purge is out of PR scope)", async () => {
     const harness = createRouterHarness({ authorized: true, signedIn: true });
     await harness.router({ req: req("DELETE"), res: res(), pathname: KIMI_PATH });
-    expect(harness.migrateCalls).toBe(1);
+    expect(harness.deleteCalls).toBe(1);
+    expect(harness.migrateCalls).toBe(0);
   });
 
   it("returns false for the bare providers path so the host can fall through", async () => {

--- a/runtime/fleet-console/tests/model-auth-routes.test.ts
+++ b/runtime/fleet-console/tests/model-auth-routes.test.ts
@@ -1,0 +1,198 @@
+import type http from "node:http";
+
+import { describe, expect, it } from "vitest";
+
+import { createModelAuthRouter } from "../src/model-auth-routes.js";
+
+interface WriteJsonCall {
+  readonly status: number;
+  readonly body: unknown;
+}
+
+interface ValidationResult {
+  readonly providerId: string;
+  readonly status: string;
+  readonly detail?: string;
+}
+
+interface RouterHarnessOptions {
+  readonly authorized?: boolean;
+  readonly signedIn?: boolean;
+  readonly body?: unknown;
+  readonly bodyNull?: boolean;
+  readonly validation?: ValidationResult;
+}
+
+const KIMI_PROVIDER_ID = "Claude Code with Moonshot Kimi";
+const KIMI_PATH = "/model-auth/providers/claude-kimi";
+
+describe("model auth routes", () => {
+  it("GET /model-auth/state reports the kimi provider and reflects signed-in status", async () => {
+    const harness = createRouterHarness({ signedIn: true });
+    const handled = await harness.router({ req: req("GET"), res: res(), pathname: "/model-auth/state" });
+    expect(handled).toBe(true);
+    const body = harness.writes[0]?.body as { providers: Array<{ cli: string; signedIn: boolean }> };
+    expect(body.providers).toHaveLength(1);
+    expect(body.providers[0]).toMatchObject({ cli: "claude-kimi", signedIn: true });
+  });
+
+  it("GET /model-auth/state never serializes the api key or the internal provider storage key", async () => {
+    const harness = createRouterHarness({ signedIn: true });
+    await harness.router({ req: req("GET"), res: res(), pathname: "/model-auth/state" });
+    const serialized = JSON.stringify(harness.writes);
+    expect(serialized).not.toContain("stored-key");
+    expect(serialized).not.toContain(KIMI_PROVIDER_ID);
+    expect(serialized).toContain("\"signedIn\":true");
+  });
+
+  it("GET /model-auth/state rejects non-GET methods with 405", async () => {
+    const harness = createRouterHarness();
+    await harness.router({ req: req("POST"), res: res(), pathname: "/model-auth/state" });
+    expect(harness.writes[0]?.status).toBe(405);
+  });
+
+  it("PUT validates then stores the api key and returns signed-in state", async () => {
+    const harness = createRouterHarness({ authorized: true, body: { apiKey: "sk-live" } });
+    const handled = await harness.router({ req: jsonReq("PUT"), res: res(), pathname: KIMI_PATH });
+    expect(handled).toBe(true);
+    expect(harness.validateCalls).toBe(1);
+    expect(harness.setCalls).toBe(1);
+    expect(harness.store.get(KIMI_PROVIDER_ID)).toBe("sk-live");
+    const body = harness.writes[0]?.body as { state: { providers: Array<{ signedIn: boolean }> } };
+    expect(body.state.providers[0]?.signedIn).toBe(true);
+  });
+
+  it("PUT trims the api key before validating and storing", async () => {
+    const harness = createRouterHarness({ authorized: true, body: { apiKey: "  sk-pad  " } });
+    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: KIMI_PATH });
+    expect(harness.store.get(KIMI_PROVIDER_ID)).toBe("sk-pad");
+  });
+
+  it("PUT rejects a key the provider refuses with 400 and does not store it", async () => {
+    const harness = createRouterHarness({
+      authorized: true,
+      body: { apiKey: "bad" },
+      validation: { providerId: KIMI_PROVIDER_ID, status: "unauthorized" },
+    });
+    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: KIMI_PATH });
+    expect(harness.writes[0]?.status).toBe(400);
+    expect(harness.setCalls).toBe(0);
+  });
+
+  it("PUT failure messages never leak the internal provider storage key", async () => {
+    const harness = createRouterHarness({
+      authorized: true,
+      body: { apiKey: "bad" },
+      validation: { providerId: KIMI_PROVIDER_ID, status: "unauthorized" },
+    });
+    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: KIMI_PATH });
+    const serialized = JSON.stringify(harness.writes);
+    expect(serialized).not.toContain(KIMI_PROVIDER_ID);
+    expect(serialized).toContain("Moonshot Kimi");
+  });
+
+  it("PUT maps upstream validation failures to 502", async () => {
+    const harness = createRouterHarness({
+      authorized: true,
+      body: { apiKey: "x" },
+      validation: { providerId: KIMI_PROVIDER_ID, status: "network", detail: "boom" },
+    });
+    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: KIMI_PATH });
+    expect(harness.writes[0]?.status).toBe(502);
+    expect(harness.setCalls).toBe(0);
+  });
+
+  it("PUT rejects unauthorized requests with 401 before validating or storing", async () => {
+    const harness = createRouterHarness({ authorized: false, body: { apiKey: "x" } });
+    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: KIMI_PATH });
+    expect(harness.writes[0]?.status).toBe(401);
+    expect(harness.validateCalls).toBe(0);
+    expect(harness.setCalls).toBe(0);
+  });
+
+  it("PUT rejects non-JSON content types with 415", async () => {
+    const harness = createRouterHarness({ authorized: true });
+    await harness.router({ req: req("PUT", "text/plain"), res: res(), pathname: KIMI_PATH });
+    expect(harness.writes[0]?.status).toBe(415);
+    expect(harness.setCalls).toBe(0);
+  });
+
+  it("PUT rejects an empty api key with 400 without contacting the provider", async () => {
+    const harness = createRouterHarness({ authorized: true, body: { apiKey: "   " } });
+    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: KIMI_PATH });
+    expect(harness.writes[0]?.status).toBe(400);
+    expect(harness.validateCalls).toBe(0);
+    expect(harness.setCalls).toBe(0);
+  });
+
+  it("rejects providers outside the kimi whitelist with 404", async () => {
+    const harness = createRouterHarness({ authorized: true, body: { apiKey: "x" } });
+    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/model-auth/providers/claude-zai" });
+    expect(harness.writes[0]?.status).toBe(404);
+    expect(harness.setCalls).toBe(0);
+  });
+
+  it("DELETE signs out the provider and reports signedIn false", async () => {
+    const harness = createRouterHarness({ authorized: true, signedIn: true });
+    await harness.router({ req: req("DELETE"), res: res(), pathname: KIMI_PATH });
+    expect(harness.deleteCalls).toBe(1);
+    const body = harness.writes[0]?.body as { state: { providers: Array<{ signedIn: boolean }> } };
+    expect(body.state.providers[0]?.signedIn).toBe(false);
+  });
+
+  it("DELETE rejects unauthorized requests with 401", async () => {
+    const harness = createRouterHarness({ authorized: false, signedIn: true });
+    await harness.router({ req: req("DELETE"), res: res(), pathname: KIMI_PATH });
+    expect(harness.writes[0]?.status).toBe(401);
+    expect(harness.deleteCalls).toBe(0);
+  });
+
+  it("returns false for the bare providers path so the host can fall through", async () => {
+    const harness = createRouterHarness();
+    const handled = await harness.router({ req: req("GET"), res: res(), pathname: "/model-auth/providers" });
+    expect(handled).toBe(false);
+    expect(harness.writes).toEqual([]);
+  });
+});
+
+function createRouterHarness(options: RouterHarnessOptions = {}) {
+  const writes: WriteJsonCall[] = [];
+  const store = new Map<string, string>(options.signedIn ? [[KIMI_PROVIDER_ID, "stored-key"]] : []);
+  let validateCalls = 0;
+  let setCalls = 0;
+  let deleteCalls = 0;
+  const router = createModelAuthRouter({
+    authService: {
+      setApiKey: async (providerId, apiKey) => { setCalls += 1; store.set(providerId, apiKey); },
+      deleteApiKey: async (providerId) => { deleteCalls += 1; return store.delete(providerId); },
+      listProviderIds: async () => [...store.keys()],
+    },
+    validateApiKey: async () => {
+      validateCalls += 1;
+      return (options.validation ?? { providerId: KIMI_PROVIDER_ID, status: "success" }) as never;
+    },
+    isAuthorized: () => options.authorized ?? true,
+    readJsonBody: async () => (options.bodyNull ? null : (options.body ?? { apiKey: "sk-test" })) as never,
+    writeJson: (_res, status, body) => { writes.push({ status, body }); },
+  });
+  return {
+    router,
+    writes,
+    store,
+    get validateCalls() { return validateCalls; },
+    get setCalls() { return setCalls; },
+    get deleteCalls() { return deleteCalls; },
+  };
+}
+
+function req(method: string, contentType?: string): http.IncomingMessage {
+  return { method, headers: contentType ? { "content-type": contentType } : {} } as unknown as http.IncomingMessage;
+}
+
+function jsonReq(method: string): http.IncomingMessage {
+  return req(method, "application/json");
+}
+
+function res(): http.ServerResponse {
+  return {} as unknown as http.ServerResponse;
+}


### PR DESCRIPTION
## Summary
- fleet-console의 전역 Settings 화면에 **Model Sign-in** 섹션을 추가해 모델 provider(Moonshot Kimi) API key를 등록·검증·로그아웃할 수 있습니다.
- 인증 로직은 `@dotobokuri/fleet-infra/auth`(fleet-cli와 동일 SSoT)를 재사용하고, console에는 UI 계층(`/model-auth` 라우트 + 프론트 api/store/section 3계층)만 신설합니다.
- API key와 그 저장 키(providerId)는 state·mutation·에러 어느 경로로도 브라우저에 노출되지 않습니다(Token Boundary). 우선 지원 대상인 Kimi만 화이트리스트로 노출합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 352 passed (저장키 미직렬화·미인증 부작용 차단 케이스 포함)
- [x] `pnpm --filter @dotobokuri/fleet-console build` — green
- [x] 변경분 typecheck clean (베이스 canary의 기존 `operationsViewActive` 중복 키 에러 2건은 본 PR scope 밖이라 미수정)
- [x] Sentinel 보안 리뷰 + 수정 — state DTO 및 검증 실패 에러 메시지에서 auth 저장 키 노출 차단
- [x] 실브라우저 E2E — `/console/settings` 렌더, Model Sign-in 섹션·Kimi 행 정상, pageerror 0, API 실증(state/PUT/whitelist 404)