### PR TITLE
feat(console): auto-open browser on global npm install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 - [core] Fleet Console adds a Model Sign-in section to the global Settings screen to register, verify, and remove a provider API key so carriers can run on that model, starting with Moonshot Kimi; keys are validated against the provider, stored locally, and never shown back in the browser.
+- [core] Installing Fleet Console globally via npm now automatically opens the console in the browser when the install finishes, limited to interactive desktop installs and skipped in CI, headless, or non-global installs; set `FLEET_CONSOLE_NO_AUTO_OPEN` to opt out.
 
 ### Fixed
 - [core] A Fleet Console run from source (`pnpm fleet-console`) now stores its persisted Theaters, Operations, and session captures under the project workspace instead of the shared home directory, so a development console no longer mixes its state with a globally installed Fleet Console.

--- a/runtime/fleet-console/postinstall.mjs
+++ b/runtime/fleet-console/postinstall.mjs
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { chmodSync, existsSync, readdirSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -9,6 +10,34 @@ if (process.platform === "darwin" && existsSync(NODE_MODULES_DIR)) {
   for (const filePath of findSpawnHelpers(NODE_MODULES_DIR)) {
     const mode = statSync(filePath).mode;
     chmodSync(filePath, mode | 0o755);
+  }
+}
+
+// 자동 열기는 "데스크탑에서 글로벌 설치"라는 의도에서만 동작하는 편의 기능이다.
+// 일반 dependency 설치·CI/비대화형·헤드리스 환경에서는 건너뛴다.
+const env = process.env;
+const isCI = Boolean(
+  env.CI ||
+  env.CONTINUOUS_INTEGRATION ||
+  env.BUILD_ID ||
+  env.GITHUB_ACTIONS,
+);
+const optedOut = Boolean(env.FLEET_CONSOLE_NO_AUTO_OPEN);
+// npm 글로벌 설치만 대상으로 삼아 일반 dependency 설치의 부작용을 막는다.
+const isGlobalInstall = env.npm_config_global === "true" || env.npm_config_location === "global";
+// Linux/X11 계열은 디스플레이 서버가 없으면 GUI를 띄울 수 없다.
+const hasDisplay = process.platform !== "linux" || Boolean(env.DISPLAY || env.WAYLAND_DISPLAY);
+const shouldAutoOpen = !isCI && !optedOut && isGlobalInstall && hasDisplay;
+
+if (shouldAutoOpen) {
+  const cliPath = path.join(PKG_ROOT, "dist", "cli.mjs");
+  if (existsSync(cliPath)) {
+    // 편의 기능이므로 실패가 설치를 막지 않도록 best-effort로 실행한다(60초 안전 타임아웃).
+    try {
+      spawnSync(process.execPath, [cliPath], { stdio: "inherit", timeout: 60_000 });
+    } catch {
+      // 자동 열기 실패는 무시한다 — 설치 자체는 성공으로 둔다.
+    }
   }
 }
 

--- a/runtime/fleet-console/src/browser.ts
+++ b/runtime/fleet-console/src/browser.ts
@@ -3,19 +3,24 @@ import os from "node:os";
 
 export interface OpenBrowserDeps {
   readonly platform?: NodeJS.Platform;
-  readonly spawnBrowser?: (command: string, args: readonly string[], options: { readonly detached: true; readonly stdio: "ignore" }) => void;
+  readonly spawnBrowser?: (command: string, args: readonly string[], options: { readonly detached: true; readonly stdio: "ignore"; readonly windowsHide: true }) => void;
 }
 
 export function openBrowser(url: string, deps: OpenBrowserDeps = {}): void {
   const platform = deps.platform ?? os.platform();
-  const spawnBrowser = deps.spawnBrowser ?? ((command, args, options) => { spawn(command, [...args], options).unref(); });
+  const spawnBrowser = deps.spawnBrowser ?? ((command, args, options) => {
+    const child = spawn(command, [...args], options);
+    // 브라우저 실행기 미설치/헤드리스로 인한 spawn 실패는 무해하게 무시한다 — uncaught 'error' 이벤트 방지.
+    child.once("error", () => {});
+    child.unref();
+  });
   if (platform === "darwin") {
-    spawnBrowser("open", [url], { detached: true, stdio: "ignore" });
+    spawnBrowser("open", [url], { detached: true, stdio: "ignore", windowsHide: true });
     return;
   }
   if (platform === "win32") {
-    spawnBrowser("cmd", ["/c", "start", "", url], { detached: true, stdio: "ignore" });
+    spawnBrowser("cmd", ["/c", "start", "", url], { detached: true, stdio: "ignore", windowsHide: true });
     return;
   }
-  spawnBrowser("xdg-open", [url], { detached: true, stdio: "ignore" });
+  spawnBrowser("xdg-open", [url], { detached: true, stdio: "ignore", windowsHide: true });
 }

--- a/runtime/fleet-console/src/cli.ts
+++ b/runtime/fleet-console/src/cli.ts
@@ -34,7 +34,7 @@ export interface ConsoleDaemonLifecycleDeps {
   readonly env?: NodeJS.ProcessEnv;
   readonly execPath?: string;
   readonly serverModulePath?: string;
-  readonly spawnDetached?: (execPath: string, args: readonly string[], options: { readonly detached: true; readonly env: NodeJS.ProcessEnv; readonly stdio: "ignore" }) => void;
+  readonly spawnDetached?: (execPath: string, args: readonly string[], options: { readonly detached: true; readonly env: NodeJS.ProcessEnv; readonly stdio: "ignore"; readonly windowsHide: true }) => void;
   readonly sleep?: (ms: number) => Promise<void>;
   readonly health?: ReturnType<typeof createConsoleHealthClient>;
 }
@@ -193,7 +193,12 @@ export function createConsoleDaemonLifecycle(deps: ConsoleDaemonLifecycleDeps = 
   const env = deps.env ?? process.env;
   const execPath = deps.execPath ?? process.execPath;
   const serverModulePath = deps.serverModulePath ?? resolveDefaultServerModulePath();
-  const spawnDetached = deps.spawnDetached ?? ((bin, args, options) => { spawn(bin, [...args], options).unref(); });
+  const spawnDetached = deps.spawnDetached ?? ((bin, args, options) => {
+    const child = spawn(bin, [...args], options);
+    // 데몬 spawn 실패는 이후 health probe 단계에서 처리하므로 여기서는 uncaught 'error'만 막는다.
+    child.once("error", () => {});
+    child.unref();
+  });
   const sleep = deps.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   const paths = createConsolePaths({ env });
   const lock = createConsoleLock();
@@ -242,7 +247,7 @@ export function createConsoleDaemonLifecycle(deps: ConsoleDaemonLifecycleDeps = 
       if (typeof probeResult.health?.workspaceCount === "number" && probeResult.health.workspaceCount > 0) return current.endpoint;
     }
     if (current) await stop();
-    spawnDetached(execPath, [serverModulePath, "serve"], { detached: true, env, stdio: "ignore" });
+    spawnDetached(execPath, [serverModulePath, "serve"], { detached: true, env, stdio: "ignore", windowsHide: true });
     for (let i = 0; i < 30; i += 1) {
       await sleep(100);
       const next = await probe();


### PR DESCRIPTION
## Summary
- npm 글로벌 설치가 끝나면 Fleet Console을 브라우저에서 자동으로 엽니다 (node-pty chmod fix 뒤 `dist/cli.mjs` 실행).
- 자동 열기는 "인터랙티브 데스크탑 글로벌 설치"로만 동작하도록 게이트됩니다: `npm_config_global`/`npm_config_location` 글로벌 표시 + Linux `DISPLAY`/`WAYLAND_DISPLAY` 존재가 필요하고, CI 또는 `FLEET_CONSOLE_NO_AUTO_OPEN` 설정 시 SKIP. spawn은 60초 타임아웃 best-effort라 실패해도 설치를 깨뜨리지 않습니다.
- 자동 실행 경로 강건화: 브라우저/데몬 spawn에 `error` 핸들러를 추가해 실행기 부재(헤드리스 `xdg-open` 등)로 인한 uncaught exception을 막고, Windows 콘솔창 깜빡임 방지를 위해 `windowsHide`를 전달합니다.

## Type of Change
- [x] feat — new feature or carrier capability

## Scope
- `runtime/fleet-console` — `postinstall.mjs`, `src/browser.ts`, `src/cli.ts` + `CHANGELOG.md`

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` — green (DTS 타입검증 통과)
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 337 passed
- [x] 게이트 6 시나리오 실측 — 일반설치/CI/opt-out/GITHUB_ACTIONS는 SKIP, 글로벌 설치는 RUN
- [x] 헤드리스(브라우저 미발견) 실측 — exit 0, uncaught exception 제거 확인
- [ ] `pnpm --filter @dotobokuri/fleet-console typecheck` — 베이스(canary)의 사전결함 2건(`dashboard.test.ts`, `operation-search.test.ts` 중복키)으로 실패하며, 본 PR 변경과는 무관합니다.

## Notes for Reviewers
- 기존 node-pty chmod fix는 그대로 유지하고 그 뒤에 자동 열기 게이트를 추가했습니다.
- 위 typecheck 사전결함은 별도 이슈이며 본 PR 범위 밖입니다.