### PR TITLE
fix(console): minimize carrier operation toasts

### DIFF
--- a/.changelog.d/0074-minimize-carrier-toasts-changed.md
+++ b/.changelog.d/0074-minimize-carrier-toasts-changed.md
@@ -1,4 +1,4 @@
 ---
 section: Changed
 ---
-- [fleet-console] Fleet Console now holds back an Operation's completion toast while that Operation still has a carrier job in flight, announcing completion only after the work has actually finished.
+- [fleet-console] Fleet Console no longer raises an Operation's completion toast while that Operation still has a carrier job running, since the work is still in progress and the live Operation panel already reflects it.

--- a/.changelog.d/0074-minimize-carrier-toasts-changed.md
+++ b/.changelog.d/0074-minimize-carrier-toasts-changed.md
@@ -1,0 +1,4 @@
+---
+section: Changed
+---
+- [fleet-console] Fleet Console now holds back an Operation's completion toast while that Operation still has a carrier job in flight, announcing completion only after the work has actually finished.

--- a/.changelog.d/0074-minimize-carrier-toasts-removed.md
+++ b/.changelog.d/0074-minimize-carrier-toasts-removed.md
@@ -1,0 +1,4 @@
+---
+section: Removed
+---
+- [fleet-console] Fleet Console no longer raises a toast when a carrier sorties; the live Operation panel already reflects the active job.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
-### Changed
-- [core] Fleet Console now holds back an Operation's completion toast while that Operation still has a carrier job in flight, announcing completion only after the work has actually finished.
-
-### Removed
-- [core] Fleet Console no longer raises a toast when a carrier sorties; the live Operation panel already reflects the active job.
-
 ## [1.8.0] - 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+- [core] Fleet Console now holds back an Operation's completion toast while that Operation still has a carrier job in flight, announcing completion only after the work has actually finished.
+
+### Removed
+- [core] Fleet Console no longer raises a toast when a carrier sorties; the live Operation panel already reflects the active job.
+
 ## [1.8.0] - 2026-06-18
 
 ### Added

--- a/runtime/fleet-console/client/src/components/operation-toasts.tsx
+++ b/runtime/fleet-console/client/src/components/operation-toasts.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { dismissOperationToast, focusOperation } from "../store.js";
@@ -8,17 +7,14 @@ interface OperationToastHostProps {
   readonly toasts: readonly OperationToast[];
 }
 
-// 상태 라벨 — fleet-harness 해군 메타포. 인디케이터 색(aurora/그린/amber)에 대응한다.
-//   sortie launched=캐리어 출격(aurora) · stood down=작업 완료(그린) · awaiting orders=입력 대기(amber).
+// 상태 라벨 — fleet-harness 해군 메타포. 인디케이터 색(그린/amber)에 대응한다.
+//   stood down=작업 완료(그린) · awaiting orders=입력 대기(amber).
 const TOAST_STATUS: Record<OperationToastKind, string> = {
-  "carrier-call": "Sortie launched",
   ended: "Stood down",
   "input-waiting": "Awaiting orders",
 };
 
-const OPERATION_TOAST_TTL_MS = 10_000;
-
-// Theater 무관 전역 Operation 상태 알림 스택. 상단 중앙 고정, 카드별 자동 닫힘(단 '완료' 상태는 계속 표시).
+// Theater 무관 전역 Operation 상태 알림 스택. 상단 중앙 고정, 수동 닫기 또는 클릭 이동으로 닫힌다.
 export function OperationToastHost({ toasts }: OperationToastHostProps) {
   if (toasts.length === 0) return null;
   return (
@@ -32,13 +28,6 @@ export function OperationToastHost({ toasts }: OperationToastHostProps) {
 
 function OperationToastCard({ toast }: { readonly toast: OperationToast }) {
   const navigate = useNavigate();
-  // US-7: 자동 닫힘 — 단, '완료'(ended)·'입력 대기'(input-waiting)는 시간제한 없이 계속 표시하고
-  // 클릭 이동 또는 수동 닫기로만 사라진다(자리를 비웠다 돌아와도 보이도록).
-  useEffect(() => {
-    if (toast.kind === "ended" || toast.kind === "input-waiting") return;
-    const timer = setTimeout(() => dismissOperationToast(toast.id), OPERATION_TOAST_TTL_MS);
-    return () => clearTimeout(timer);
-  }, [toast.id, toast.kind]);
 
   // US-5: 이동 — 해당 Theater로 전환 + Operation 선택 후 Operations로 이동, 토스트 닫기.
   const handleGo = () => {

--- a/runtime/fleet-console/client/src/store.ts
+++ b/runtime/fleet-console/client/src/store.ts
@@ -487,6 +487,8 @@ export function applyObservedEvent(event: ObservedEvent, tenantLabel?: string): 
     truncation: { droppedCount: 0 },
   };
   let nextTenant = tenantLabel && tenant.tenantLabel !== tenantLabel ? { ...tenant, tenantLabel } : tenant;
+  // 이벤트 적용 전 미완료 job이 있었는지 — job 완료 전이(작업 완료 토스트) 판정용.
+  const hadActiveJob = tenantHasActiveJob(existingTenant);
   if (event.jobId) {
     const existingJob = nextTenant.jobs[event.jobId];
     const job = applyEvent(existingJob ?? createEmptyJob(event.tenantId, event.jobId, event.at), event);
@@ -498,12 +500,21 @@ export function applyObservedEvent(event: ObservedEvent, tenantLabel?: string): 
     };
   }
   const nextTenantJobs = { ...state.tenantJobs, [event.tenantId]: nextTenant };
+  // 작업 완료(ended) 토스트 — 턴이 이미 종료된 비활성 Operation에서 방금 마지막 미완료 job이
+  // 완료된 순간에만 발행한다. 턴 종료가 job보다 먼저 도착해 buildTurnTransitionToasts가 억제했던
+  // 완료 알림을, 실제 작업이 끝나는 이 시점에 마무리한다.
+  const session = findSessionByTenantId(event.tenantId);
+  const completionToast =
+    session && hadActiveJob && !tenantHasActiveJob(nextTenant) && session.turnState === "ended" && !isActiveOperation(session)
+      ? makeOperationToast("ended", session)
+      : null;
   state = {
     ...state,
     connection: "live",
     connectionError: null,
     tenantJobs: nextTenantJobs,
     tenantOrder: state.tenantOrder.includes(event.tenantId) ? state.tenantOrder : [...state.tenantOrder, event.tenantId],
+    operationToasts: completionToast ? [...state.operationToasts, completionToast] : state.operationToasts,
   };
   emit();
   return { unknownTenant };
@@ -618,7 +629,8 @@ function makeOperationToast(kind: OperationToastKind, session: SessionInfo): Ope
 function buildTurnTransitionToasts(prev: SessionInfo, next: SessionInfo): readonly OperationToast[] {
   if (isActiveOperation(next)) return [];
   // 작업 완료(턴 종료)만 알린다. 턴 진행 시작(running)은 알리지 않는다.
-  // 캐리어 출격 중(미완료 job이 있음)에는 ended 알림을 억제한다 — 실제 작업은 계속 진행 중이므로.
+  // 캐리어 출격 중(미완료 job이 있음)에는 ended 알림을 억제하고, 완료 토스트는 job이 끝나는 시점에
+  // applyObservedEvent가 마무리 발행한다 — 실제 작업은 계속 진행 중이므로.
   if (prev.turnState !== "ended" && next.turnState === "ended" && !hasActiveCarrierJob(next)) {
     return [makeOperationToast("ended", next)];
   }
@@ -626,10 +638,18 @@ function buildTurnTransitionToasts(prev: SessionInfo, next: SessionInfo): readon
 }
 
 function hasActiveCarrierJob(session: SessionInfo): boolean {
-  if (!session.tenantId) return false;
-  const tenantJobs = state.tenantJobs[session.tenantId];
-  if (!tenantJobs) return false;
-  return tenantJobs.jobOrder.some((jobId) => !tenantJobs.jobs[jobId]?.finishedAt);
+  const tenantId = resolveSessionTenantId(session);
+  if (!tenantId) return false;
+  return tenantHasActiveJob(state.tenantJobs[tenantId]);
+}
+
+function tenantHasActiveJob(tenant: TenantJobsView | undefined): boolean {
+  if (!tenant) return false;
+  return tenant.jobOrder.some((jobId) => !tenant.jobs[jobId]?.finishedAt);
+}
+
+function findSessionByTenantId(tenantId: string): SessionInfo | undefined {
+  return Object.values(state.sessions).find((session) => resolveSessionTenantId(session) === tenantId);
 }
 
 function mergeTenantBindings(sessions: Readonly<Record<string, SessionInfo>>, tenants: readonly ObservedTenant[]): Record<string, SessionInfo> {

--- a/runtime/fleet-console/client/src/store.ts
+++ b/runtime/fleet-console/client/src/store.ts
@@ -1,4 +1,4 @@
-import { applyEvent, createEmptyJob, reduceSnapshotJob } from "./reduce.js";
+import { applyEvent, createEmptyJob, isTerminalJobStatus, reduceSnapshotJob } from "./reduce.js";
 import { sessionDisplayLabel } from "./format.js";
 import { buildOperationSearchEntries } from "./operation-search.js";
 import type {
@@ -487,8 +487,6 @@ export function applyObservedEvent(event: ObservedEvent, tenantLabel?: string): 
     truncation: { droppedCount: 0 },
   };
   let nextTenant = tenantLabel && tenant.tenantLabel !== tenantLabel ? { ...tenant, tenantLabel } : tenant;
-  // 이벤트 적용 전 미완료 job이 있었는지 — job 완료 전이(작업 완료 토스트) 판정용.
-  const hadActiveJob = tenantHasActiveJob(existingTenant);
   if (event.jobId) {
     const existingJob = nextTenant.jobs[event.jobId];
     const job = applyEvent(existingJob ?? createEmptyJob(event.tenantId, event.jobId, event.at), event);
@@ -500,21 +498,12 @@ export function applyObservedEvent(event: ObservedEvent, tenantLabel?: string): 
     };
   }
   const nextTenantJobs = { ...state.tenantJobs, [event.tenantId]: nextTenant };
-  // 작업 완료(ended) 토스트 — 턴이 이미 종료된 비활성 Operation에서 방금 마지막 미완료 job이
-  // 완료된 순간에만 발행한다. 턴 종료가 job보다 먼저 도착해 buildTurnTransitionToasts가 억제했던
-  // 완료 알림을, 실제 작업이 끝나는 이 시점에 마무리한다.
-  const session = findSessionByTenantId(event.tenantId);
-  const completionToast =
-    session && hadActiveJob && !tenantHasActiveJob(nextTenant) && session.turnState === "ended" && !isActiveOperation(session)
-      ? makeOperationToast("ended", session)
-      : null;
   state = {
     ...state,
     connection: "live",
     connectionError: null,
     tenantJobs: nextTenantJobs,
     tenantOrder: state.tenantOrder.includes(event.tenantId) ? state.tenantOrder : [...state.tenantOrder, event.tenantId],
-    operationToasts: completionToast ? [...state.operationToasts, completionToast] : state.operationToasts,
   };
   emit();
   return { unknownTenant };
@@ -629,8 +618,7 @@ function makeOperationToast(kind: OperationToastKind, session: SessionInfo): Ope
 function buildTurnTransitionToasts(prev: SessionInfo, next: SessionInfo): readonly OperationToast[] {
   if (isActiveOperation(next)) return [];
   // 작업 완료(턴 종료)만 알린다. 턴 진행 시작(running)은 알리지 않는다.
-  // 캐리어 출격 중(미완료 job이 있음)에는 ended 알림을 억제하고, 완료 토스트는 job이 끝나는 시점에
-  // applyObservedEvent가 마무리 발행한다 — 실제 작업은 계속 진행 중이므로.
+  // 캐리어 출격 중(미완료 job이 있음)에는 ended 알림을 억제한다 — 실제 작업은 계속 진행 중이므로.
   if (prev.turnState !== "ended" && next.turnState === "ended" && !hasActiveCarrierJob(next)) {
     return [makeOperationToast("ended", next)];
   }
@@ -645,11 +633,12 @@ function hasActiveCarrierJob(session: SessionInfo): boolean {
 
 function tenantHasActiveJob(tenant: TenantJobsView | undefined): boolean {
   if (!tenant) return false;
-  return tenant.jobOrder.some((jobId) => !tenant.jobs[jobId]?.finishedAt);
-}
-
-function findSessionByTenantId(tenantId: string): SessionInfo | undefined {
-  return Object.values(state.sessions).find((session) => resolveSessionTenantId(session) === tenantId);
+  // finalize 이벤트가 보존 한도로 잘려 finishedAt이 비어도, 스냅샷이 신뢰한 종결 상태(done/error/aborted)로
+  // 완료를 판정한다 — 그렇지 않으면 복원된 완료 job이 영원히 진행 중으로 오인돼 stop 토스트가 영구 억제된다.
+  return tenant.jobOrder.some((jobId) => {
+    const job = tenant.jobs[jobId];
+    return job ? !job.finishedAt && !isTerminalJobStatus(job.status) : false;
+  });
 }
 
 function mergeTenantBindings(sessions: Readonly<Record<string, SessionInfo>>, tenants: readonly ObservedTenant[]): Record<string, SessionInfo> {

--- a/runtime/fleet-console/client/src/store.ts
+++ b/runtime/fleet-console/client/src/store.ts
@@ -73,9 +73,6 @@ let state: ConsoleState = {
   operationToasts: [],
 };
 
-// 초기 SSE replay(재연결 포함)가 과거 job 이벤트를 재전송하므로, carrier-call 토스트는
-// 이벤트가 충분히 최신일 때만 띄워 과거/재연결 폭주를 막는다. session:updated는 라이브 전용이라 무관.
-const OPERATION_TOAST_FRESH_MS = 10_000;
 let operationToastSeq = 0;
 
 export function getState(): ConsoleState {
@@ -490,14 +487,8 @@ export function applyObservedEvent(event: ObservedEvent, tenantLabel?: string): 
     truncation: { droppedCount: 0 },
   };
   let nextTenant = tenantLabel && tenant.tenantLabel !== tenantLabel ? { ...tenant, tenantLabel } : tenant;
-  let carrierToast: OperationToast | null = null;
   if (event.jobId) {
     const existingJob = nextTenant.jobs[event.jobId];
-    // 새 jobId가 처음 등장 = 캐리어 호출(carrier_dispatch). 라이브 이벤트(최신)에 한해 알림한다.
-    if (!existingJob && Date.now() - event.at < OPERATION_TOAST_FRESH_MS) {
-      const session = state.sessions[event.tenantId];
-      if (session && !isActiveOperation(session)) carrierToast = makeOperationToast("carrier-call", session);
-    }
     const job = applyEvent(existingJob ?? createEmptyJob(event.tenantId, event.jobId, event.at), event);
     const jobOrder = existingJob ? nextTenant.jobOrder : [...nextTenant.jobOrder, event.jobId];
     nextTenant = {
@@ -513,7 +504,6 @@ export function applyObservedEvent(event: ObservedEvent, tenantLabel?: string): 
     connectionError: null,
     tenantJobs: nextTenantJobs,
     tenantOrder: state.tenantOrder.includes(event.tenantId) ? state.tenantOrder : [...state.tenantOrder, event.tenantId],
-    operationToasts: carrierToast ? [...state.operationToasts, carrierToast] : state.operationToasts,
   };
   emit();
   return { unknownTenant };
@@ -628,8 +618,18 @@ function makeOperationToast(kind: OperationToastKind, session: SessionInfo): Ope
 function buildTurnTransitionToasts(prev: SessionInfo, next: SessionInfo): readonly OperationToast[] {
   if (isActiveOperation(next)) return [];
   // 작업 완료(턴 종료)만 알린다. 턴 진행 시작(running)은 알리지 않는다.
-  if (prev.turnState !== "ended" && next.turnState === "ended") return [makeOperationToast("ended", next)];
+  // 캐리어 출격 중(미완료 job이 있음)에는 ended 알림을 억제한다 — 실제 작업은 계속 진행 중이므로.
+  if (prev.turnState !== "ended" && next.turnState === "ended" && !hasActiveCarrierJob(next)) {
+    return [makeOperationToast("ended", next)];
+  }
   return [];
+}
+
+function hasActiveCarrierJob(session: SessionInfo): boolean {
+  if (!session.tenantId) return false;
+  const tenantJobs = state.tenantJobs[session.tenantId];
+  if (!tenantJobs) return false;
+  return tenantJobs.jobOrder.some((jobId) => !tenantJobs.jobs[jobId]?.finishedAt);
 }
 
 function mergeTenantBindings(sessions: Readonly<Record<string, SessionInfo>>, tenants: readonly ObservedTenant[]): Record<string, SessionInfo> {

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -5277,21 +5277,12 @@
 }
 
 /* 인디케이터와 동일한 색의 좌측 액센트 레일(계기판 느낌). */
-.operation-toast--carrier-call {
-  border-left-color: var(--aurora);
-}
-
 .operation-toast--ended {
   border-left-color: var(--positive);
 }
 
 .operation-toast--input-waiting {
   border-left-color: var(--warn);
-}
-
-/* 캐리어 출격은 살아있는 상태(aurora) — beacon의 is-live와 동일하게 펄스. */
-.operation-toast--carrier-call .app-toast-dot {
-  animation: aurora-pulse 1.8s ease-in-out infinite;
 }
 
 .operation-toast-text {
@@ -5343,17 +5334,8 @@
   opacity: 0.78;
 }
 
-.operation-toast--carrier-call {
-  border-color: color-mix(in oklch, var(--aurora) 40%, var(--surface-rim));
-}
-
 .operation-toast--ended {
   border-color: color-mix(in oklch, var(--positive) 40%, var(--surface-rim));
-}
-
-.operation-toast--carrier-call .app-toast-dot {
-  background: var(--aurora);
-  box-shadow: 0 0 10px var(--aurora-glow);
 }
 
 .operation-toast--ended .app-toast-dot {

--- a/runtime/fleet-console/client/src/types.ts
+++ b/runtime/fleet-console/client/src/types.ts
@@ -248,9 +248,8 @@ export interface TenantJobsView {
 export type ConnectionState = "connecting" | "live";
 
 // Operation 상태 전이/입력 대기 알림 토스트. kind는 인디케이터 상태에 대응:
-//   carrier-call=캐리어 출격(Job 발생, aurora) · ended=작업 완료(턴 종료, 그린)
-//   · input-waiting=입력 대기(AskUserQuestion·권한/유휴/elicitation, amber).
-export type OperationToastKind = "carrier-call" | "ended" | "input-waiting";
+//   ended=작업 완료(턴 종료, 그린) · input-waiting=입력 대기(AskUserQuestion·권한/유휴/elicitation, amber).
+export type OperationToastKind = "ended" | "input-waiting";
 
 export interface OperationToast {
   readonly id: number;

--- a/runtime/fleet-console/tests/dashboard.test.ts
+++ b/runtime/fleet-console/tests/dashboard.test.ts
@@ -5,7 +5,6 @@ import type { ConsoleState, JobView } from "../client/src/types.js";
 
 const BASE_STATE: ConsoleState = {
   operationToasts: [],
-  operationsViewActive: false,
   connection: "live",
   connectionError: null,
   activeTheme: "maritime",

--- a/runtime/fleet-console/tests/operation-search.test.ts
+++ b/runtime/fleet-console/tests/operation-search.test.ts
@@ -11,7 +11,6 @@ function makeState(sessions: readonly (Omit<SessionInfo, "resumeAvailable" | "tu
   const entries: SessionInfo[] = sessions.map((session) => ({ ...session, resumeAvailable: session.resumeAvailable ?? false, turnState: session.turnState ?? "none" }));
   return {
     operationToasts: [],
-    operationsViewActive: false,
     connection: "connecting",
     connectionError: null,
     activeTheme: "maritime",

--- a/runtime/fleet-console/tests/store.test.ts
+++ b/runtime/fleet-console/tests/store.test.ts
@@ -467,6 +467,52 @@ describe("store", () => {
     expect(getState().operationToasts[1]).toMatchObject({ kind: "input-waiting", sessionId: "session-a" });
   });
 
+  it("never raises a carrier-call toast when a fresh carrier job appears on an inactive operation", () => {
+    setState({ operationToasts: [], tenantJobs: {}, tenantOrder: [] });
+    hydrateTheaters([THEATER_A, THEATER_B]);
+    hydrateTerminalSessions([
+      { sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a" },
+      { sessionId: "session-b", terminalSessionId: "session-b", cwdLabel: "beta", sequence: 2, label: "Aux", status: "registered", createdAt: 2, theaterId: "theater-b" },
+    ]);
+    // session-b를 보고 있는 상태 → session-a는 비활성 Operation(예전이라면 carrier-call 토스트 대상).
+    setActiveTheater("theater-b");
+    selectTerminalSession("session-b");
+    applyTenantSnapshot([{ ...TENANT, terminalSessionId: "session-a", registrationId: "registration-a" }]);
+
+    // 갓 발생한(최신 타임스탬프) 새 carrier job — carrier-call 토스트가 폐지됐으므로 어떤 토스트도 뜨지 않는다.
+    applyObservedEvent({ id: 1, tenantId: "tenant-1", jobId: "job-1", type: "job:registered", at: Date.now(), event: { type: "job:registered", jobId: "job-1" } });
+
+    expect(getState().operationToasts).toHaveLength(0);
+  });
+
+  it("suppresses the ended toast while a carrier job is in flight, then fires it after the job finalizes", () => {
+    setState({ operationToasts: [], tenantJobs: {}, tenantOrder: [] });
+    hydrateTheaters([THEATER_A, THEATER_B]);
+    hydrateTerminalSessions([
+      { sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a" },
+      { sessionId: "session-b", terminalSessionId: "session-b", cwdLabel: "beta", sequence: 2, label: "Aux", status: "registered", createdAt: 2, theaterId: "theater-b" },
+    ]);
+    // session-b를 보고 있으므로 session-a의 턴 종료 토스트는 발행 대상(비활성 Operation).
+    setActiveTheater("theater-b");
+    selectTerminalSession("session-b");
+    applyTenantSnapshot([{ ...TENANT, terminalSessionId: "session-a", registrationId: "registration-a" }]);
+
+    // 턴 처리 시작 + 미완료 carrier job 발생.
+    applySessionUpdate({ sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a", turnState: "running" });
+    applyObservedEvent({ id: 1, tenantId: "tenant-1", jobId: "job-1", type: "job:registered", at: Date.now(), event: { type: "job:registered", jobId: "job-1" } });
+
+    // 턴 종료 — job이 진행 중이므로 ended 토스트 억제.
+    applySessionUpdate({ sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a", turnState: "ended" });
+    expect(getState().operationToasts).toHaveLength(0);
+
+    // job 완료(finalized) 후 다음 턴 종료 전이에서는 ended 토스트가 발행된다.
+    applyObservedEvent({ id: 2, tenantId: "tenant-1", jobId: "job-1", type: "job:finalized", at: Date.now(), event: { type: "job:finalized", jobId: "job-1", status: "done" } });
+    applySessionUpdate({ sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a", turnState: "running" });
+    applySessionUpdate({ sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a", turnState: "ended" });
+    expect(getState().operationToasts).toHaveLength(1);
+    expect(getState().operationToasts[0]).toMatchObject({ kind: "ended", sessionId: "session-a" });
+  });
+
   it("selects a job into the centered overlay and toggles it closed", () => {
     hydrateTerminalSessions([{ sessionId: "tenant-1", terminalSessionId: "tenant-1", cwdLabel: "alpha", sequence: 1, status: "terminal-only", createdAt: 1 }]);
     selectTerminalSession("tenant-1");

--- a/runtime/fleet-console/tests/store.test.ts
+++ b/runtime/fleet-console/tests/store.test.ts
@@ -485,14 +485,14 @@ describe("store", () => {
     expect(getState().operationToasts).toHaveLength(0);
   });
 
-  it("suppresses the ended toast while a carrier job is in flight, then fires it on job finalization without a new turn", () => {
+  it("suppresses the ended toast while a carrier job is in flight and emits none on bare job finalization", () => {
     setState({ operationToasts: [], tenantJobs: {}, tenantOrder: [] });
     hydrateTheaters([THEATER_A, THEATER_B]);
     hydrateTerminalSessions([
       { sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a" },
       { sessionId: "session-b", terminalSessionId: "session-b", cwdLabel: "beta", sequence: 2, label: "Aux", status: "registered", createdAt: 2, theaterId: "theater-b" },
     ]);
-    // session-b를 보고 있으므로 session-a의 작업 완료 토스트는 발행 대상(비활성 Operation).
+    // session-b를 보고 있으므로 session-a는 비활성 Operation.
     setActiveTheater("theater-b");
     selectTerminalSession("session-b");
     applyTenantSnapshot([{ ...TENANT, terminalSessionId: "session-a", registrationId: "registration-a" }]);
@@ -505,8 +505,35 @@ describe("store", () => {
     applySessionUpdate({ sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a", turnState: "ended" });
     expect(getState().operationToasts).toHaveLength(0);
 
-    // 새 턴 없이 job이 완료(finalized)되는 흔한 흐름 — 작업이 끝나는 이 시점에 완료 토스트가 발행된다.
+    // 출격 작업의 완료(job:finalized)만으로는 완료 토스트를 발행하지 않는다 — 라이브 Operation 패널이 표시.
     applyObservedEvent({ id: 2, tenantId: "tenant-1", jobId: "job-1", type: "job:finalized", at: Date.now(), event: { type: "job:finalized", jobId: "job-1", status: "done" } });
+    expect(getState().operationToasts).toHaveLength(0);
+  });
+
+  it("treats a snapshot-restored finished job without finishedAt as inactive so a later turn end still fires", () => {
+    setState({ operationToasts: [], tenantJobs: {}, tenantOrder: [] });
+    hydrateTheaters([THEATER_A, THEATER_B]);
+    hydrateTerminalSessions([
+      { sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a" },
+      { sessionId: "session-b", terminalSessionId: "session-b", cwdLabel: "beta", sequence: 2, label: "Aux", status: "registered", createdAt: 2, theaterId: "theater-b" },
+    ]);
+    setActiveTheater("theater-b");
+    selectTerminalSession("session-b");
+    applyTenantSnapshot([{ ...TENANT, terminalSessionId: "session-a", registrationId: "registration-a" }]);
+
+    // finalize 이벤트가 보존 한도로 잘려 status는 done이지만 finishedAt이 없는 스냅샷 복원 job.
+    applyJobsSnapshot([
+      {
+        tenantId: "tenant-1",
+        tenantLabel: "Alpha",
+        truncation: { droppedCount: 0 },
+        jobs: [{ jobId: "job-1", status: "done", updatedAt: 1_001, events: [] }],
+      },
+    ]);
+
+    // 출격은 이미 종결(done)이므로 턴 종료 시 stop 토스트가 정상 발행돼야 한다(영구 억제 회귀 방지).
+    applySessionUpdate({ sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a", turnState: "running" });
+    applySessionUpdate({ sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a", turnState: "ended" });
     expect(getState().operationToasts).toHaveLength(1);
     expect(getState().operationToasts[0]).toMatchObject({ kind: "ended", sessionId: "session-a" });
   });

--- a/runtime/fleet-console/tests/store.test.ts
+++ b/runtime/fleet-console/tests/store.test.ts
@@ -485,14 +485,14 @@ describe("store", () => {
     expect(getState().operationToasts).toHaveLength(0);
   });
 
-  it("suppresses the ended toast while a carrier job is in flight, then fires it after the job finalizes", () => {
+  it("suppresses the ended toast while a carrier job is in flight, then fires it on job finalization without a new turn", () => {
     setState({ operationToasts: [], tenantJobs: {}, tenantOrder: [] });
     hydrateTheaters([THEATER_A, THEATER_B]);
     hydrateTerminalSessions([
       { sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a" },
       { sessionId: "session-b", terminalSessionId: "session-b", cwdLabel: "beta", sequence: 2, label: "Aux", status: "registered", createdAt: 2, theaterId: "theater-b" },
     ]);
-    // session-b를 보고 있으므로 session-a의 턴 종료 토스트는 발행 대상(비활성 Operation).
+    // session-b를 보고 있으므로 session-a의 작업 완료 토스트는 발행 대상(비활성 Operation).
     setActiveTheater("theater-b");
     selectTerminalSession("session-b");
     applyTenantSnapshot([{ ...TENANT, terminalSessionId: "session-a", registrationId: "registration-a" }]);
@@ -505,9 +505,30 @@ describe("store", () => {
     applySessionUpdate({ sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a", turnState: "ended" });
     expect(getState().operationToasts).toHaveLength(0);
 
-    // job 완료(finalized) 후 다음 턴 종료 전이에서는 ended 토스트가 발행된다.
+    // 새 턴 없이 job이 완료(finalized)되는 흔한 흐름 — 작업이 끝나는 이 시점에 완료 토스트가 발행된다.
     applyObservedEvent({ id: 2, tenantId: "tenant-1", jobId: "job-1", type: "job:finalized", at: Date.now(), event: { type: "job:finalized", jobId: "job-1", status: "done" } });
+    expect(getState().operationToasts).toHaveLength(1);
+    expect(getState().operationToasts[0]).toMatchObject({ kind: "ended", sessionId: "session-a" });
+  });
+
+  it("fires the ended toast on turn end when the carrier job already finished first", () => {
+    setState({ operationToasts: [], tenantJobs: {}, tenantOrder: [] });
+    hydrateTheaters([THEATER_A, THEATER_B]);
+    hydrateTerminalSessions([
+      { sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a" },
+      { sessionId: "session-b", terminalSessionId: "session-b", cwdLabel: "beta", sequence: 2, label: "Aux", status: "registered", createdAt: 2, theaterId: "theater-b" },
+    ]);
+    setActiveTheater("theater-b");
+    selectTerminalSession("session-b");
+    applyTenantSnapshot([{ ...TENANT, terminalSessionId: "session-a", registrationId: "registration-a" }]);
+
+    // job이 턴보다 먼저 끝나는 흐름: 등록→완료(턴은 아직 running) — job 완료만으로는 토스트 없음.
     applySessionUpdate({ sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a", turnState: "running" });
+    applyObservedEvent({ id: 1, tenantId: "tenant-1", jobId: "job-1", type: "job:registered", at: Date.now(), event: { type: "job:registered", jobId: "job-1" } });
+    applyObservedEvent({ id: 2, tenantId: "tenant-1", jobId: "job-1", type: "job:finalized", at: Date.now(), event: { type: "job:finalized", jobId: "job-1", status: "done" } });
+    expect(getState().operationToasts).toHaveLength(0);
+
+    // 턴 종료 시점엔 미완료 job이 없으므로 turn 전이 경로가 완료 토스트를 발행한다.
     applySessionUpdate({ sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a", turnState: "ended" });
     expect(getState().operationToasts).toHaveLength(1);
     expect(getState().operationToasts[0]).toMatchObject({ kind: "ended", sessionId: "session-a" });


### PR DESCRIPTION
## Summary
- 캐리어 출격 시 발생하던 "Sortie launched"(carrier-call) 토스트를 제거 — 라이브 Operation 패널이 이미 활성 job 상태를 보여주므로 중복 알림이었음.
- 캐리어 출격 중(미완료 job 존재) Operation의 턴이 종료돼도 "Stood down"(ended) 완료 토스트를 억제 — 실제 작업은 계속 진행 중이므로 완료 알림은 job이 모두 끝난 뒤에만 발행.
- carrier-call 토스트의 kind 타입 / CSS / 렌더 코드를 일괄 제거(정공법)하고 `[Unreleased]` CHANGELOG에 반영.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 339 passed (carrier-call 미발행 + ended 억제→완료 후 발행 단위 테스트 2건 신규)
- [x] `pnpm --filter @dotobokuri/fleet-console build` — green (tsc + vite)
- [x] console-e2e(실브라우저, 격리 인스턴스): pageerror/console error 0, 번들 내 `carrier-call` 문자열 0, 토스트 CSS 룰은 `ended`/`input-waiting`만 잔존(carrier-call 부재), ended/input-waiting 토스트 시각 렌더 정상