### PR TITLE
feat(console): minimize Operations Map panels to a collapsible dock

### DIFF
--- a/.changelog.d/minimize-operations-dock.md
+++ b/.changelog.d/minimize-operations-dock.md
@@ -1,0 +1,4 @@
+---
+section: Added
+---
+- [fleet-console] Fleet Console Operations Map panels can now be minimized to a collapsible bottom dock and restored to their original position and size by double-clicking the dock entry or its restore button; the dock collapses to a single expand/collapse handle, each entry shows the panel's status light, name, Agent CLI, and active job count, and both the collapsed handle and the entries pulse while a minimized panel is busy.

--- a/runtime/fleet-console/client/src/canvas/canvas-dock.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-dock.tsx
@@ -1,0 +1,167 @@
+import type { CSSProperties, PointerEvent as ReactPointerEvent } from "react";
+
+import { sessionBeaconClassName, sessionDisplayLabel } from "../format.js";
+import { isTerminalJobStatus } from "../reduce.js";
+import { selectTerminalSession, sessionJobs } from "../store.js";
+import type { ConsoleState, SessionInfo } from "../types.js";
+import { restorePanel, toggleDockExpanded, useDockExpanded } from "./canvas-store.js";
+
+type Underway = "live" | "turn" | null;
+
+interface CanvasDockProps {
+  readonly state: ConsoleState;
+  readonly sessions: readonly SessionInfo[];
+  readonly minimized: readonly string[];
+}
+
+interface DockEntry {
+  readonly session: SessionInfo;
+  readonly activeJobCount: number;
+  readonly underway: Underway;
+  readonly active: boolean;
+}
+
+interface CanvasDockChipProps {
+  readonly entry: DockEntry;
+  readonly index: number;
+}
+
+export function CanvasDock({ state, sessions, minimized }: CanvasDockProps) {
+  const expanded = useDockExpanded();
+  // 최소화 목록 순서를 유지하며 실재 세션만 추려, 각 칩의 신호(underway)·활성 여부를 한 번에 계산한다.
+  const sessionById = new Map(sessions.map((session) => [session.sessionId, session]));
+  const entries: DockEntry[] = minimized
+    .map((sessionId) => sessionById.get(sessionId))
+    .filter((session): session is SessionInfo => Boolean(session))
+    .map((session) => {
+      const activeJobCount = sessionJobs(state, session).filter(({ job }) => !isTerminalJobStatus(job.status)).length;
+      const underway: Underway = session.status === "dormant"
+        ? null
+        : activeJobCount > 0
+          ? "live"
+          : session.turnState === "running"
+            ? "turn"
+            : null;
+      return { session, activeJobCount, underway, active: state.activeTerminalSessionId === session.sessionId };
+    });
+  if (entries.length === 0) return null;
+
+  // 접힘 핸들의 알림: 최소화 패널 중 살아있는 신호를 집계한다(live 우선, 없으면 turn).
+  const aggregate: Underway = entries.some((entry) => entry.underway === "live")
+    ? "live"
+    : entries.some((entry) => entry.underway === "turn")
+      ? "turn"
+      : null;
+
+  const toggleClassName = [
+    "canvas-dock-toggle",
+    aggregate ? `canvas-dock-toggle--attention-${aggregate}` : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={`canvas-dock ${expanded ? "is-expanded" : ""}`} data-canvas-blocker>
+      <button
+        type="button"
+        className={toggleClassName}
+        onClick={toggleDockExpanded}
+        aria-expanded={expanded}
+        aria-label={expanded ? "Collapse minimized panels" : "Expand minimized panels"}
+        title={expanded ? "Collapse" : "Expand"}
+      >
+        <span className="canvas-dock-toggle-beacon" aria-hidden="true" />
+        <span className="canvas-dock-toggle-chevron" aria-hidden="true">
+          <ChevronIcon />
+        </span>
+        <span className="canvas-dock-toggle-count">{entries.length}</span>
+      </button>
+      {/* 칩 트랙: 접힘 시 폭 0 + 페이드로 사라지고, inert로 숨은 칩이 키보드/AT에 잡히지 않게 한다. */}
+      <div
+        className="canvas-dock-chips"
+        role="toolbar"
+        aria-label="Minimized operations"
+        aria-hidden={!expanded}
+        inert={!expanded}
+      >
+        {entries.map((entry, index) => (
+          <CanvasDockChip key={entry.session.sessionId} entry={entry} index={index} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CanvasDockChip({ entry, index }: CanvasDockChipProps) {
+  const { session, activeJobCount, underway, active } = entry;
+  const displayLabel = sessionDisplayLabel(session);
+
+  // 복원: 최소화 목록에서 빼 원위치·원크기로 캔버스에 되돌리고, 그 세션을 활성화한다.
+  const restore = () => {
+    restorePanel(session.sessionId);
+    selectTerminalSession(session.sessionId);
+  };
+
+  const onRestoreButtonPointer = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+  };
+
+  const chipClassName = [
+    "canvas-dock-chip",
+    active ? "canvas-dock-chip--active" : "",
+    underway ? `canvas-dock-chip--underway canvas-dock-chip--underway-${underway}` : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      className={chipClassName}
+      role="button"
+      tabIndex={0}
+      aria-label={`Restore operation ${displayLabel}`}
+      title="Double-click to restore"
+      style={{ "--i": index } as CSSProperties}
+      onDoubleClick={restore}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          restore();
+        }
+      }}
+    >
+      <span className={sessionBeaconClassName(session, activeJobCount)} aria-hidden="true" />
+      <span className="canvas-dock-chip-name">{displayLabel}</span>
+      <span className="canvas-dock-chip-cli">{session.cliLabel ?? session.cliId ?? "CLI"}</span>
+      {activeJobCount > 0 ? <span className="canvas-dock-chip-count">{activeJobCount}</span> : null}
+      <button
+        type="button"
+        className="canvas-dock-chip-restore"
+        onPointerDown={onRestoreButtonPointer}
+        onClick={(event) => { event.stopPropagation(); restore(); }}
+        aria-label={`Restore operation ${displayLabel}`}
+        title="Restore panel"
+      >
+        <RestoreIcon />
+      </button>
+    </div>
+  );
+}
+
+function ChevronIcon() {
+  // 더블 chevron ›› (펼치기). 펼친 상태에서는 컨테이너 .is-expanded가 180° 회전시켜 ‹‹ (접기)로 보인다.
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M3 4l4 4-4 4M8 4l4 4-4 4" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function RestoreIcon() {
+  // 좌상향 L자 화살표 — 칩을 캔버스로 다시 끌어올리는(복원) 방향성.
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M4 11V5h6M4 11l3-3.5M4 11l3 3.5" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
@@ -215,9 +215,7 @@ export function CanvasPanel({ state, session, geometry, viewport, active }: Canv
           type="button"
           className="canvas-panel-icon-button"
           onPointerDown={stopButtonPointer}
-          // 활성 패널을 최소화하면 활성 선택을 비운다 — 숨겨진 패널이 "지금 보는 Operation"으로 남으면
-          // 입력 대기·턴 종료·캐리어 토스트가 isActiveOperation 억제에 걸려 사라지기 때문이다.
-          onClick={() => { if (active) selectTerminalSession(null); minimizePanel(session.sessionId); }}
+          onClick={() => { minimizePanel(session.sessionId); }}
           aria-label={`Minimize operation ${displayLabel}`}
           title="Minimize panel"
         >

--- a/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
@@ -215,7 +215,9 @@ export function CanvasPanel({ state, session, geometry, viewport, active }: Canv
           type="button"
           className="canvas-panel-icon-button"
           onPointerDown={stopButtonPointer}
-          onClick={() => { minimizePanel(session.sessionId); }}
+          // 활성 패널을 최소화하면 활성 선택을 비운다 — 숨겨진 패널이 "지금 보는 Operation"으로 남으면
+          // 입력 대기·턴 종료·캐리어 토스트가 isActiveOperation 억제에 걸려 사라지기 때문이다.
+          onClick={() => { if (active) selectTerminalSession(null); minimizePanel(session.sessionId); }}
           aria-label={`Minimize operation ${displayLabel}`}
           title="Minimize panel"
         >

--- a/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
@@ -7,7 +7,7 @@ import { sessionBeaconClassName, sessionDisplayLabel } from "../format.js";
 import { isTerminalJobStatus } from "../reduce.js";
 import { applySessionUpdate, failRenameTerminalSession, failResumeTerminalSession, failTerminateTerminalSession, removeTerminalSession, selectJob, selectTerminalSession, sessionJobs } from "../store.js";
 import type { ConsoleState, SessionInfo } from "../types.js";
-import { setPanelGeometry, type CanvasViewport, type PanelGeometry } from "./canvas-store.js";
+import { minimizePanel, setPanelGeometry, type CanvasViewport, type PanelGeometry } from "./canvas-store.js";
 import { PanelResizeHandles } from "./panel-resize.js";
 
 interface CanvasPanelProps {
@@ -215,6 +215,16 @@ export function CanvasPanel({ state, session, geometry, viewport, active }: Canv
           type="button"
           className="canvas-panel-icon-button"
           onPointerDown={stopButtonPointer}
+          onClick={() => { minimizePanel(session.sessionId); }}
+          aria-label={`Minimize operation ${displayLabel}`}
+          title="Minimize panel"
+        >
+          <MinimizeIcon />
+        </button>
+        <button
+          type="button"
+          className="canvas-panel-icon-button"
+          onPointerDown={stopButtonPointer}
           onClick={() => { void closeSession(session.sessionId); }}
           aria-label={`${dormant ? "Forget" : "Terminate"} operation ${displayLabel}`}
           title={dormant ? "Forget operation" : "Terminate operation"}
@@ -268,6 +278,15 @@ async function closeSession(sessionId: string): Promise<void> {
     return;
   }
   removeTerminalSession(sessionId);
+}
+
+function MinimizeIcon() {
+  // 타이틀바 하단 수평선 — 패널이 아래(태스크바)로 가라앉는 방향성을 내재한 최소화 마크.
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M3.5 11.5h9" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
 }
 
 function CloseIcon() {

--- a/runtime/fleet-console/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/client/src/canvas/canvas-store.ts
@@ -17,6 +17,8 @@ export interface CanvasViewport {
 export interface CanvasState {
   readonly viewport: CanvasViewport;
   readonly panels: Record<string, PanelGeometry>;
+  // 최소화된 Operation sessionId 목록. geometry는 panels에 그대로 보존되므로 복원은 원위치·원크기로 되돌린다.
+  readonly minimized: readonly string[];
 }
 
 export interface CanvasViewportSize {
@@ -29,6 +31,7 @@ type Listener = () => void;
 const STORAGE_KEY_PREFIX = "fleet-console.canvas.";
 const BACKGROUND_ANIMATION_STORAGE_KEY = "fleet-console.canvas.backgroundAnimation";
 const MAXIMIZED_STORAGE_KEY = "fleet-console.canvas.maximized";
+const DOCK_EXPANDED_STORAGE_KEY = "fleet-console.canvas.dockExpanded";
 const SAVE_DELAY_MS = 400;
 const DEFAULT_PANEL_WIDTH = 640;
 const DEFAULT_PANEL_HEIGHT = 400;
@@ -42,16 +45,18 @@ const ZOOM_TWEEN_FACTOR = 0.2;
 const ZOOM_TWEEN_POSITION_EPSILON = 0.5;
 const ZOOM_TWEEN_ZOOM_EPSILON = 0.001;
 const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
-const EMPTY_STATE: CanvasState = { viewport: DEFAULT_VIEWPORT, panels: {} };
+const EMPTY_STATE: CanvasState = { viewport: DEFAULT_VIEWPORT, panels: {}, minimized: [] };
 
 const listeners = new Set<Listener>();
 const backgroundAnimationListeners = new Set<Listener>();
 const maximizedListeners = new Set<Listener>();
+const dockExpandedListeners = new Set<Listener>();
 let activeTheaterId: string | null = null;
 let saveTimer: number | null = null;
 let state: CanvasState = EMPTY_STATE;
 let backgroundAnimationEnabled = readStoredBackgroundAnimation();
 let maximized = readStoredMaximized();
+let dockExpanded = readStoredDockExpanded();
 // 줌 보간 루프가 향하는 목표 viewport. 즉시 이동(pan/focus/load)은 이 값을 current와 동기화해 잔여 보간을 무효화한다.
 let targetViewport: CanvasViewport = DEFAULT_VIEWPORT;
 let zoomRaf: number | null = null;
@@ -82,10 +87,21 @@ export function useMaximized(): boolean {
   return useSyncExternalStore(subscribeMaximized, getMaximizedSnapshot, getMaximizedSnapshot);
 }
 
+// 최소화 목록은 CanvasState의 일부라 메인 listeners/emit을 그대로 공유한다(별도 채널 불필요).
+export function useMinimized(): readonly string[] {
+  return useSyncExternalStore(subscribe, getMinimizedSnapshot, getMinimizedSnapshot);
+}
+
+// 하단 Dock(최소화 패널 트레이)의 펼침/접힘 — 브라우저별 UI 선호라 maximized와 같은 패턴으로 영속한다.
+export function useDockExpanded(): boolean {
+  return useSyncExternalStore(subscribeDockExpanded, getDockExpandedSnapshot, getDockExpandedSnapshot);
+}
+
 export function setState(patch: Partial<CanvasState>): void {
   state = {
     viewport: patch.viewport ?? state.viewport,
     panels: patch.panels ?? state.panels,
+    minimized: patch.minimized ?? state.minimized,
   };
   scheduleSave();
   emit();
@@ -121,6 +137,29 @@ export function setPanelGeometry(sessionId: string, geometry: PanelGeometry): vo
   });
 }
 
+// 패널을 최소화한다 — 캔버스 렌더에서 빠지고 하단 태스크바에 표시된다. geometry는 panels에 보존한다.
+export function minimizePanel(sessionId: string): void {
+  if (state.minimized.includes(sessionId)) return;
+  setState({ minimized: [...state.minimized, sessionId] });
+}
+
+// 최소화한 패널을 복원한다 — 목록에서 제거하고 보존된 geometry를 최상단 zIndex로 끌어올려 원위치·원크기로 되돌린다.
+// 활성화(selectTerminalSession)는 호출 측 책임으로 남겨, 셸/Operations 상호배타 조정을 한 곳(canvas)에서 유지한다.
+export function restorePanel(sessionId: string): void {
+  if (!state.minimized.includes(sessionId)) return;
+  const minimized = state.minimized.filter((id) => id !== sessionId);
+  const geometry = state.panels[sessionId];
+  if (!geometry) {
+    setState({ minimized });
+    return;
+  }
+  const zIndex = claimTopZIndex();
+  setState({
+    minimized,
+    panels: { ...state.panels, [sessionId]: { ...geometry, zIndex } },
+  });
+}
+
 // 공유 z-index 카운터에서 다음 최상단 값을 발급한다(Operations·셸 공통). 패널을 활성화·생성할 때 호출한다.
 export function claimTopZIndex(): number {
   topZIndex += 1;
@@ -153,7 +192,10 @@ export function prunePanels(validSessionIds: readonly string[]): void {
       changed = true;
     }
   }
-  if (changed) setState({ panels });
+  // 사라진 세션은 최소화 목록에서도 함께 제거해 유령 칩이 태스크바에 남지 않게 한다.
+  const minimized = state.minimized.filter((sessionId) => valid.has(sessionId));
+  const minimizedChanged = minimized.length !== state.minimized.length;
+  if (changed || minimizedChanged) setState({ panels, minimized });
 }
 
 export function loadForTheater(theaterId: string | null): void {
@@ -183,12 +225,15 @@ export function focusPanel(sessionId: string, viewportSize: CanvasViewportSize):
   cancelZoomTween();
   targetViewport = focusedViewport;
   const zIndex = claimTopZIndex();
+  // 포커스(사이드바·검색 점프·Alt+화살표)는 최소화 상태도 함께 해제한다 — 안 그러면 "포커스했는데 안 보임"이 된다.
+  const wasMinimized = state.minimized.includes(sessionId);
   setState({
     viewport: focusedViewport,
     panels: {
       ...state.panels,
       [sessionId]: { ...normalizePanelGeometry(geometry, zIndex), zIndex },
     },
+    ...(wasMinimized ? { minimized: state.minimized.filter((id) => id !== sessionId) } : {}),
   });
 }
 
@@ -207,6 +252,12 @@ export function setMaximized(value: boolean): void {
   maximized = value;
   writeStoredMaximized(maximized);
   emitMaximized();
+}
+
+export function toggleDockExpanded(): void {
+  dockExpanded = !dockExpanded;
+  writeStoredDockExpanded(dockExpanded);
+  emitDockExpanded();
 }
 
 function subscribeBackgroundAnimation(listener: Listener): () => void {
@@ -239,8 +290,27 @@ function getMaximizedSnapshot(): boolean {
   return maximized;
 }
 
+function getMinimizedSnapshot(): readonly string[] {
+  return state.minimized;
+}
+
 function emitMaximized(): void {
   for (const listener of maximizedListeners) listener();
+}
+
+function subscribeDockExpanded(listener: Listener): () => void {
+  dockExpandedListeners.add(listener);
+  return () => {
+    dockExpandedListeners.delete(listener);
+  };
+}
+
+function getDockExpandedSnapshot(): boolean {
+  return dockExpanded;
+}
+
+function emitDockExpanded(): void {
+  for (const listener of dockExpandedListeners) listener();
 }
 
 // 줌 보간 한 프레임: current를 target 쪽으로 ZOOM_TWEEN_FACTOR만큼 당기고, 임계치 안이면 스냅 후 정지한다.
@@ -357,16 +427,52 @@ function writeStoredMaximized(value: boolean): void {
   }
 }
 
+function readStoredDockExpanded(): boolean {
+  // 기본값 true: 패널을 처음 최소화하면 곧바로 칩이 보이도록 펼친 상태로 시작한다.
+  if (typeof window === "undefined") return true;
+  try {
+    const stored = window.localStorage.getItem(DOCK_EXPANDED_STORAGE_KEY);
+    if (stored === null) return true;
+    return stored === "true";
+  } catch {
+    return true;
+  }
+}
+
+function writeStoredDockExpanded(value: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(DOCK_EXPANDED_STORAGE_KEY, String(value));
+  } catch {
+    // Dock 펼침 선호 저장 실패는 런타임 동작을 막지 않는다.
+  }
+}
+
 function storageKey(theaterId: string): string {
   return `${STORAGE_KEY_PREFIX}${theaterId}`;
 }
 
 function normalizeCanvasState(value: unknown): CanvasState {
   if (!isRecord(value)) return EMPTY_STATE;
+  const panels = normalizePanels(value.panels);
   return {
     viewport: normalizeViewport(value.viewport),
-    panels: normalizePanels(value.panels),
+    panels,
+    // 저장된 최소화 목록 중 실재하는 패널만 남긴다(stale 직렬화 방어).
+    minimized: normalizeMinimized(value.minimized, panels),
   };
+}
+
+function normalizeMinimized(value: unknown, panels: Record<string, PanelGeometry>): readonly string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const minimized: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string" || seen.has(entry) || !(entry in panels)) continue;
+    seen.add(entry);
+    minimized.push(entry);
+  }
+  return minimized;
 }
 
 function normalizeViewport(value: unknown): CanvasViewport {

--- a/runtime/fleet-console/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas.tsx
@@ -69,6 +69,15 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
   useEffect(() => {
     if (state.activeTerminalSessionId !== null) setActiveShellPanel(null);
   }, [state.activeTerminalSessionId]);
+  // 불변식: active Operation은 절대 최소화된(화면 밖) 세션이면 안 된다. 패널 최소화 액션은 물론,
+  // 리로드·Theater 전환 시 resolveVisibleSessionId가 canvas.minimized를 모른 채 최소화된 비-dormant 세션을
+  // active로 자동 선택하는 경로까지 한 곳에서 막는다 — 안 그러면 숨은 패널이 isActiveOperation 억제에 걸려
+  // 입력 대기·턴 종료·캐리어 토스트가 사라진다. (복원은 minimized 제거가 선행되므로 여기서 해제되지 않는다.)
+  useEffect(() => {
+    if (state.activeTerminalSessionId !== null && minimized.includes(state.activeTerminalSessionId)) {
+      selectTerminalSession(null);
+    }
+  }, [state.activeTerminalSessionId, minimized]);
   const interaction = useCanvasInteraction({
     viewport: canvas.viewport,
     disabled,

--- a/runtime/fleet-console/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas.tsx
@@ -4,10 +4,11 @@ import { createTheaterTerminalSession } from "../api.js";
 import { OperationLaunchMenu } from "../components/operation-launch-menu.js";
 import { beginCreateTerminalSession, completeCreateTerminalSession, failCreateTerminalSession, selectTerminalSession, theaterSessions } from "../store.js";
 import type { AgentCliMetadata, ConsoleState } from "../types.js";
-import { animateViewportTo, claimTopZIndex, setPanelGeometry, setViewport, toggleBackgroundAnimation, toggleMaximized, useBackgroundAnimation, useCanvasState, useMaximized, type PanelGeometry } from "./canvas-store.js";
+import { animateViewportTo, claimTopZIndex, setPanelGeometry, setViewport, toggleBackgroundAnimation, toggleMaximized, useBackgroundAnimation, useCanvasState, useMaximized, useMinimized, type PanelGeometry } from "./canvas-store.js";
 import { CanvasContextMenu } from "./canvas-context-menu.js";
 import { CanvasMinimap } from "./canvas-minimap.js";
 import { CanvasPanel } from "./canvas-panel.js";
+import { CanvasDock } from "./canvas-dock.js";
 import { CanvasGrid } from "./canvas-grid.js";
 import { MapShortcuts } from "./map-shortcuts.js";
 import { RubberBand } from "./rubber-band.js";
@@ -44,6 +45,7 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
   const canvas = useCanvasState();
   const backgroundAnimationEnabled = useBackgroundAnimation();
   const maximized = useMaximized();
+  const minimized = useMinimized();
   const shellPanels = useShellPanels();
   const activeShellId = useActiveShellId();
   const sessions = theaterSessions(state);
@@ -137,6 +139,11 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
     setContextMenu({ anchor, canvasPoint: screenToCanvas(anchor, canvas.viewport) });
   };
 
+  const minimizedSet = new Set(minimized);
+  // 최소화된 패널은 캔버스에서 빠지므로 미니맵(캔버스 개관)에서도 제외해 "사라진 blip" 불일치를 막는다.
+  const visiblePanels = Object.fromEntries(
+    Object.entries(canvas.panels).filter(([sessionId]) => !minimizedSet.has(sessionId)),
+  );
   const hasContent = sessions.length > 0 || Object.keys(shellPanels).length > 0;
 
   return (
@@ -181,6 +188,8 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
         {sessions.map((session) => {
           const geometry = canvas.panels[session.sessionId];
           if (!geometry) return null;
+          // 최소화된 패널은 캔버스에서 빠지고 하단 태스크바에 칩으로 표시된다(Terminal 언마운트→복원 시 재연결).
+          if (minimizedSet.has(session.sessionId)) return null;
           return (
             <CanvasPanel
               key={session.sessionId}
@@ -235,7 +244,7 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
         />
       ) : null}
       <CanvasMinimap
-        panels={canvas.panels}
+        panels={visiblePanels}
         shellPanels={shellPanels}
         viewport={canvas.viewport}
         canvasSize={canvasSize}
@@ -247,6 +256,8 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
       />
       {/* 콘텐츠가 없을 때는 좌하단 빈 상태 안내가 핵심 단축키를 이미 알려주므로, 겹침을 막기 위해 단축키 맵을 숨긴다. */}
       {hasContent ? <MapShortcuts /> : null}
+      {/* 최소화된 Operation 패널의 하단 중앙 Dock(world가 아닌 캔버스 고정 — 패널과 함께 이동·확대되지 않는다). */}
+      <CanvasDock state={state} sessions={sessions} minimized={minimized} />
     </main>
   );
 }

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -2091,6 +2091,286 @@
   -webkit-backdrop-filter: blur(18px) saturate(140%);
 }
 
+/* 최소화된 Operation 패널의 하단 중앙 Dock("잠망 트레이"). 미니맵·단축키와 같은 캔버스-고정(absolute) 계기다.
+   그룹 글래스 박스 없음 — 토글 핸들과 칩이 각자 독립 글래스로 떠 있다. max-width는 좌하단 FAB·우하단
+   미니맵을 양측에서 비키도록 캡한다(각 ~300px 확보). */
+.canvas-dock {
+  position: absolute;
+  bottom: var(--space-4);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 15;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  max-width: clamp(220px, calc(100% - 600px), 1100px);
+  animation: codex-rise 520ms var(--ease-spring) both;
+}
+
+/* ── 접기/펼치기 핸들 (최소화 패널이 1개 이상일 때만 렌더된다) ── */
+.canvas-dock-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: none;
+  height: 34px;
+  padding: 0 10px 0 9px;
+  cursor: pointer;
+  color: var(--ink-spectral);
+  background: var(--surface-glass-strong);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-pill);
+  box-shadow: var(--shadow-floating);
+  backdrop-filter: blur(22px) saturate(150%);
+  -webkit-backdrop-filter: blur(22px) saturate(150%);
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring);
+}
+
+.canvas-dock-toggle:hover,
+.canvas-dock-toggle:focus-visible {
+  border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
+  color: var(--brass-bright);
+}
+
+.canvas-dock-toggle-chevron {
+  display: grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+  transition: transform 320ms var(--ease-spring);
+}
+
+.canvas-dock-toggle-chevron svg {
+  display: block;
+  width: 14px;
+  height: 14px;
+}
+
+/* 펼침 상태: chevron 180° 회전(›› → ‹‹) */
+.canvas-dock.is-expanded .canvas-dock-toggle-chevron {
+  transform: rotate(180deg);
+}
+
+.canvas-dock-toggle-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--ink-fog);
+}
+
+/* 접힘 상태에서만 카운트 강조 — 칩이 안 보이므로 개수를 brass로 또렷이 알린다. */
+.canvas-dock:not(.is-expanded) .canvas-dock-toggle-count {
+  color: var(--brass-bright);
+}
+
+/* 접힘 핸들 안 알림 비콘 — 평소 숨김, 알림 시 신호색 점으로 표시한다. */
+.canvas-dock-toggle-beacon {
+  display: none;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex: none;
+}
+
+/* 알림: 접힌 핸들이 박동(접혀 있어도 "안에 살아있는 게 있다"를 알린다). 색은 신호를 따른다.
+   패널/칩과 동일한 panel-wake-ripple을 재사용하되 핸들은 --shadow-floating을 기준 그림자로 쓴다. */
+.canvas-dock-toggle--attention-live,
+.canvas-dock-toggle--attention-turn {
+  animation: panel-wake-ripple 2.2s ease-out infinite;
+}
+
+.canvas-dock-toggle--attention-live {
+  --uw-glow: var(--aurora-glow);
+  --uw-ring: color-mix(in oklch, var(--aurora) 45%, transparent);
+  border-color: color-mix(in oklch, var(--aurora) 40%, var(--surface-rim));
+}
+
+.canvas-dock-toggle--attention-turn {
+  --uw-glow: var(--warn-glow);
+  --uw-ring: color-mix(in oklch, var(--warn) 45%, transparent);
+  border-color: color-mix(in oklch, var(--warn) 40%, var(--surface-rim));
+}
+
+.canvas-dock-toggle--attention-live .canvas-dock-toggle-beacon {
+  display: block;
+  background: var(--aurora);
+  box-shadow: 0 0 8px var(--aurora-glow);
+  animation: beacon-pulse 1.8s ease-in-out infinite;
+}
+
+.canvas-dock-toggle--attention-turn .canvas-dock-toggle-beacon {
+  display: block;
+  background: var(--warn);
+  box-shadow: 0 0 8px var(--warn-glow);
+}
+
+/* ── 칩 트랙: 펼침 시에만 표시. 그룹 박스 없음 — flex 정렬 + 가로 스크롤만. ── */
+.canvas-dock-chips {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  max-width: 0;
+  opacity: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+  transition:
+    max-width 360ms var(--ease-spring),
+    opacity 240ms ease;
+}
+
+.canvas-dock-chips::-webkit-scrollbar {
+  display: none;
+}
+
+.canvas-dock.is-expanded .canvas-dock-chips {
+  max-width: 100%;
+  opacity: 1;
+}
+
+/* 칩: 최소화된 패널 하나. flex:none으로 스크롤 트랙 안에서 줄어들지 않는다. */
+.canvas-dock-chip {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: none;
+  gap: 6px;
+  height: 34px;
+  padding: 0 6px 0 10px;
+  white-space: nowrap;
+  cursor: pointer;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-lg);
+  background: var(--surface-glass-strong);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring);
+}
+
+/* 펼침 시 칩이 staggered codex-rise로 떠오른다(--i = 순번). */
+.canvas-dock.is-expanded .canvas-dock-chip {
+  animation: codex-rise 320ms var(--ease-spring) both;
+  animation-delay: calc(var(--i, 0) * 50ms);
+}
+
+.canvas-dock-chip:hover,
+.canvas-dock-chip:focus-visible {
+  border-color: color-mix(in oklch, var(--ink-fog) 36%, var(--surface-rim));
+  background: color-mix(in oklch, var(--surface-glass-strong) 92%, var(--ink-deep));
+}
+
+/* 활성(지금 보고 있던 패널) = brass. 선택 의미를 패널 is-active와 동일하게 brass로 표현한다. */
+.canvas-dock-chip--active {
+  border-color: color-mix(in oklch, var(--brass) 54%, var(--surface-rim));
+  background: color-mix(in oklch, var(--brass) 12%, var(--surface-glass));
+  box-shadow: 0 0 0 1px color-mix(in oklch, var(--brass) 16%, transparent), var(--shadow-soft);
+}
+
+.canvas-dock-chip--active .canvas-dock-chip-name {
+  color: var(--brass-bright);
+}
+
+/* 알림(underway) = 펼친 칩이 박동. 접힘 핸들과 같은 panel-wake-ripple·색 의미(live=aurora, turn=warn).
+   AGENTS.md 모션 규약의 sanctioned 예외 — 작업 중에만, prefers-reduced-motion에서 정적 글로우로 단락. */
+.canvas-dock.is-expanded .canvas-dock-chip--underway {
+  animation:
+    codex-rise 320ms var(--ease-spring) both,
+    panel-wake-ripple 2.2s ease-out infinite;
+  animation-delay: calc(var(--i, 0) * 50ms), calc(var(--i, 0) * 50ms + 320ms);
+}
+
+.canvas-dock-chip--underway-live {
+  --uw-glow: var(--aurora-glow);
+  --uw-ring: color-mix(in oklch, var(--aurora) 45%, transparent);
+}
+
+.canvas-dock-chip--underway-turn {
+  --uw-glow: var(--warn-glow);
+  --uw-ring: color-mix(in oklch, var(--warn) 45%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .canvas-dock-toggle--attention-live,
+  .canvas-dock-toggle--attention-turn {
+    animation: none;
+    box-shadow: var(--shadow-floating), 0 0 22px -6px var(--uw-glow);
+  }
+  .canvas-dock.is-expanded .canvas-dock-chip--underway {
+    animation: none;
+    box-shadow: var(--shadow-soft), 0 0 22px -6px var(--uw-glow);
+  }
+  .canvas-dock-toggle--attention-live .canvas-dock-toggle-beacon {
+    animation: none;
+  }
+}
+
+.canvas-dock-chip-name {
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink-spectral);
+}
+
+.canvas-dock-chip-cli {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-rim);
+}
+
+.canvas-dock-chip-count {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--aurora);
+  background: color-mix(in oklch, var(--aurora) 14%, transparent);
+  border: 1px solid color-mix(in oklch, var(--aurora) 28%, transparent);
+  border-radius: var(--radius-sm);
+  padding: 1px 6px;
+}
+
+.canvas-dock-chip-restore {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 22px;
+  height: 22px;
+  margin-left: 2px;
+  color: var(--ink-fog);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring);
+}
+
+.canvas-dock-chip-restore:hover,
+.canvas-dock-chip-restore:focus-visible {
+  color: var(--brass-bright);
+  border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
+  background: color-mix(in oklch, var(--brass) 12%, var(--surface-glass));
+}
+
+.canvas-dock-chip-restore svg {
+  display: block;
+  width: 12px;
+  height: 12px;
+}
+
 .canvas-panel-titlebar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- Fleet Console Operations Map 패널 타이틀바에 최소화 컨트롤을 추가해, 패널을 캔버스에서 빼 하단 중앙의 **접이식 Dock**에 보관합니다.
- Dock은 단일 펼치기/접기 핸들(`››`/`‹‹`)로 접히고, 펼치면 최소화된 패널을 칩으로 나열합니다(상태 비콘·이름·Agent CLI·활성 job 수). 칩 더블클릭 또는 복원 버튼으로 **원위치·원크기**로 복원합니다.
- 작업 중인 최소화 패널이 있으면 접힌 핸들과 펼친 칩이 신호색(live=aurora / turn=amber)으로 박동합니다. 그룹 컨테이너 박스 없이 핸들·칩이 독립 글래스로 떠 있습니다.

## Type of Change

- [x] feat — new feature or carrier capability

## Scope

- [x] `runtime/fleet-console` — Operations Map canvas (panel minimize/restore dock)

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — pass
- [x] `pnpm --filter @dotobokuri/fleet-console build` — pass
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 357/357 pass
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK (5 fragments)
- [x] Real-browser (isolated instance, bundle-hash matched): minimize → Dock appears; collapse/expand toggle (chevron rotate, chips `inert` when collapsed); restore via button + double-click with exact geometry preserved; attention pulse on both collapsed handle and expanded chips; minimap excludes minimized panels

## Changelog

- [x] Added one `.changelog.d/*.md` fragment (`minimize-operations-dock.md`)
- [x] Fragment `section:` is `Added`
- [x] Fragment bullet is English and uses `[fleet-console]`

## Notes for Reviewers

- New canvas store state: `minimized` list (persisted per-Theater alongside geometry) and a per-browser `dockExpanded` toggle. Focusing a panel via sidebar/search/keyboard auto-restores it; `prunePanels`/`normalizeCanvasState` keep the minimized list free of stale ids.
- No new keyframes — reuses existing `codex-rise` and `panel-wake-ripple` per the Maritime Console motion doctrine; attention motion stays short-circuited by `prefers-reduced-motion`.