### PR TITLE
feat(console): add ZhipuAI GLM provider to Model Sign-in

### DIFF
--- a/.changelog.d/0076-console-glm-signin-added.md
+++ b/.changelog.d/0076-console-glm-signin-added.md
@@ -1,0 +1,4 @@
+---
+section: Added
+---
+- [fleet-console] The Settings Model Sign-in section now lists ZhipuAI GLM alongside Moonshot Kimi, so its API key can be registered, validated, and signed out directly from the Console.

--- a/runtime/fleet-console/src/model-auth-routes.ts
+++ b/runtime/fleet-console/src/model-auth-routes.ts
@@ -37,10 +37,12 @@ interface SignInBody {
   readonly apiKey?: unknown;
 }
 
-// kimi 우선 — console에 노출하는 모델 로그인 provider 화이트리스트. 다른 provider(claude-zai 등)는
+// console에 노출하는 모델 로그인 provider 화이트리스트. 다른 provider(claude-zai 등)는
 // 의도적으로 제외한다. 경로로 들어온 임의 cli는 이 목록 대조로만 통과한다.
+// displayName은 브라우저-안전 표기만 쓴다 — providerId(저장 키)는 절대 노출하지 않는다(Token Boundary).
 const MODEL_AUTH_PROVIDERS: readonly ModelAuthProviderDefinition[] = [
   { cli: "claude-kimi", displayName: "Moonshot Kimi" },
+  { cli: "claude-glm", displayName: "ZhipuAI GLM" },
 ];
 
 // 사용자 키 거부(400)와 외부 provider 검증 자체 장애(502)를 HTTP 상태로 구분한다.

--- a/runtime/fleet-console/tests/model-auth-routes.test.ts
+++ b/runtime/fleet-console/tests/model-auth-routes.test.ts
@@ -25,15 +25,18 @@ interface RouterHarnessOptions {
 
 const KIMI_PROVIDER_ID = "Claude Code with Moonshot Kimi";
 const KIMI_PATH = "/model-auth/providers/claude-kimi";
+const GLM_PROVIDER_ID = "Claude Code with ZhipuAI GLM";
+const GLM_PATH = "/model-auth/providers/claude-glm";
 
 describe("model auth routes", () => {
-  it("GET /model-auth/state reports the kimi provider and reflects signed-in status", async () => {
+  it("GET /model-auth/state reports the kimi and glm providers and reflects signed-in status", async () => {
     const harness = createRouterHarness({ signedIn: true });
     const handled = await harness.router({ req: req("GET"), res: res(), pathname: "/model-auth/state" });
     expect(handled).toBe(true);
     const body = harness.writes[0]?.body as { providers: Array<{ cli: string; signedIn: boolean }> };
-    expect(body.providers).toHaveLength(1);
+    expect(body.providers).toHaveLength(2);
     expect(body.providers[0]).toMatchObject({ cli: "claude-kimi", signedIn: true });
+    expect(body.providers[1]).toMatchObject({ cli: "claude-glm", signedIn: false });
   });
 
   it("GET /model-auth/state never serializes the api key or the internal provider storage key", async () => {
@@ -125,7 +128,16 @@ describe("model auth routes", () => {
     expect(harness.setCalls).toBe(0);
   });
 
-  it("rejects providers outside the kimi whitelist with 404", async () => {
+  it("PUT signs in the glm provider and stores under its own provider id", async () => {
+    const harness = createRouterHarness({ authorized: true, body: { apiKey: "sk-glm" } });
+    const handled = await harness.router({ req: jsonReq("PUT"), res: res(), pathname: GLM_PATH });
+    expect(handled).toBe(true);
+    expect(harness.validateCalls).toBe(1);
+    expect(harness.setCalls).toBe(1);
+    expect(harness.store.get(GLM_PROVIDER_ID)).toBe("sk-glm");
+  });
+
+  it("rejects providers outside the whitelist with 404", async () => {
     const harness = createRouterHarness({ authorized: true, body: { apiKey: "x" } });
     await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/model-auth/providers/claude-zai" });
     expect(harness.writes[0]?.status).toBe(404);


### PR DESCRIPTION
## Summary
- Console **Settings → Model Sign-in** 섹션에 `claude-glm`(ZhipuAI GLM)을 provider 화이트리스트에 추가해, API key 로그인·검증·로그아웃이 콘솔에서 가능해집니다.
- GLM auth 백엔드(provider id·base URL·env·검증)는 #75에서 이미 출하됐고, 누락된 곳은 콘솔 sign-in 화이트리스트 단 1곳이었습니다. 클라이언트는 데이터 주도라 서버 노출만으로 UI가 자동 렌더됩니다(클라이언트 무변경).
- Token Boundary 준수: 브라우저-안전 displayName(`ZhipuAI GLM`)만 노출하고 provider 저장 키는 직렬화하지 않습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (362 passed)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] console-e2e: 격리 인스턴스(번들 해시 일치)에서 `/model-auth/state`가 kimi+glm 반환, 실브라우저 Settings에 GLM row + API key 입력/Sign in 정상 렌더(page error 0)

## Changelog
- [x] `.changelog.d/0076-console-glm-signin-added.md` (`[fleet-console]`, section: Added)