### PR TITLE
fix(console): preserve panel layout and shell panels across refresh

### DIFF
--- a/.changelog.d/console-refresh-layout-persistence-fixed.md
+++ b/.changelog.d/console-refresh-layout-persistence-fixed.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+- [fleet-console] Operations Map panel positions and sizes now persist across a browser refresh instead of resetting to defaults.
+- [fleet-console] Map shell panels now survive a browser refresh instead of disappearing.

--- a/runtime/fleet-console/client/src/app.tsx
+++ b/runtime/fleet-console/client/src/app.tsx
@@ -94,7 +94,9 @@ export function App() {
       .then(hydrateTerminalSessions)
       .catch((error) => {
         if (abort.signal.aborted) return;
-        setState({ terminalSessionError: error instanceof Error ? error.message : String(error) });
+        // 적재 실패도 "로딩 종료"로 본다 — terminalSessionsHydrated를 올려야 빈 sessionOrder가 권위를 얻어
+        // 패널 prune이 풀린다(올리지 않으면 fetch 1회 실패로 prune이 영구 보류된다).
+        setState({ terminalSessionError: error instanceof Error ? error.message : String(error), terminalSessionsHydrated: true });
       });
     const refreshUpdateStatus = () => {
       void fetchObserverStatus(state.activeTheaterId, abort.signal)

--- a/runtime/fleet-console/client/src/app.tsx
+++ b/runtime/fleet-console/client/src/app.tsx
@@ -94,9 +94,10 @@ export function App() {
       .then(hydrateTerminalSessions)
       .catch((error) => {
         if (abort.signal.aborted) return;
-        // 적재 실패도 "로딩 종료"로 본다 — terminalSessionsHydrated를 올려야 빈 sessionOrder가 권위를 얻어
-        // 패널 prune이 풀린다(올리지 않으면 fetch 1회 실패로 prune이 영구 보류된다).
-        setState({ terminalSessionError: error instanceof Error ? error.message : String(error), terminalSessionsHydrated: true });
+        // 적재 실패 시에는 terminalSessionsHydrated를 올리지 않는다. sessions를 알 수 없는 상태에서 빈
+        // sessionOrder로 prune하면 방금 복원한 패널 레이아웃을 지우고 그 빈 상태를 영속해, 일시적 500·네트워크
+        // 오류가 사용자 레이아웃의 영구 손실이 된다. prune은 성공 적재(빈 배열 포함) 시에만 권위를 갖는다.
+        setState({ terminalSessionError: error instanceof Error ? error.message : String(error) });
       });
     const refreshUpdateStatus = () => {
       void fetchObserverStatus(state.activeTheaterId, abort.signal)

--- a/runtime/fleet-console/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/client/src/canvas/canvas-store.ts
@@ -166,6 +166,12 @@ export function claimTopZIndex(): number {
   return topZIndex;
 }
 
+// 공유 카운터를 주어진 값 이상으로 끌어올린다. 셸 패널 레지스트리(별도 모듈)가 새로고침 복원 시
+// 복원된 셸의 최대 zIndex를 반영해, "활성화→최상단"이 Operations·셸을 가로질러 계속 성립하게 한다.
+export function liftTopZIndex(toAtLeast: number): void {
+  topZIndex = Math.max(topZIndex, toAtLeast);
+}
+
 export function ensureDefaultGeometry(sessionId: string): PanelGeometry {
   const existing = state.panels[sessionId];
   if (existing) return existing;

--- a/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
@@ -120,7 +120,7 @@ export function ShellCanvasPanel({ id, theaterId, geometry, viewport, active }: 
         </button>
       </div>
       <div className="canvas-panel-terminal" onPointerDown={stopCanvasPointer} onWheel={stopCanvasWheel} data-canvas-blocker>
-        <Terminal sessionId={id} kind="shell" theaterId={theaterId} onExit={() => removeShellPanel(id)} />
+        <Terminal sessionId={id} kind="shell" theaterId={theaterId} active={active} onExit={() => removeShellPanel(id)} />
       </div>
       <PanelResizeHandles geometry={geometry} zoom={viewport.zoom} onResize={(next) => setShellPanelGeometry(id, next)} />
     </article>

--- a/runtime/fleet-console/client/src/canvas/shell-panels.ts
+++ b/runtime/fleet-console/client/src/canvas/shell-panels.ts
@@ -1,6 +1,6 @@
 import { useSyncExternalStore } from "react";
 
-import type { PanelGeometry } from "./canvas-store.js";
+import { liftTopZIndex, type PanelGeometry } from "./canvas-store.js";
 
 export interface ShellPanelEntry {
   // 이 셸이 띄워진 Theater id. 백엔드 ticket이 이 id로 cwd(Theater 디렉터리)를 해석한다(raw 경로는 클라이언트에 없음).
@@ -10,13 +10,23 @@ export interface ShellPanelEntry {
 
 type Listener = () => void;
 
+const STORAGE_KEY_PREFIX = "fleet-console.canvas.shell.";
+const SAVE_DELAY_MS = 400;
+const DEFAULT_SHELL_WIDTH = 560;
+const DEFAULT_SHELL_HEIGHT = 360;
+
 const listeners = new Set<Listener>();
-// 메모리 전용 레지스트리 — localStorage 직렬화·canvas-store 영속·prunePanels에 일절 관여하지 않는다.
-// 새로고침하면 모듈이 새로 로드되며 비워지므로 "상태 미유지" 요구가 자연히 충족된다.
+// Theater별 localStorage에 영속한다(키: fleet-console.canvas.shell.<theaterId>). Operations 패널과 같은
+// theater-scoped 영속 패턴을 따르되, 두 레지스트리의 lifecycle은 분리한다(canvas-store의 CanvasState와 별개).
+// 새로고침하면 모듈은 비워지지만 loadShellPanelsForTheater가 복원하며, 같은 패널 id로 백엔드 PTY에 재부착한다.
 let panels: Record<string, ShellPanelEntry> = {};
 // 활성(포커스) 셸 패널 id. Operations의 activeTerminalSessionId와 별개의 단일 활성 상태다.
 // 두 종류가 동시에 활성으로 보이지 않도록 하는 상호배타는 상위(canvas) 레이어에서 조정한다.
+// 영속하지 않는다 — 새로고침 직후 어떤 셸도 활성 외형이 아니게 해 Operations 활성과 충돌하지 않게 한다.
 let activeShellId: string | null = null;
+// 현재 로드된 Theater id. 영속 저장 키를 해석하며, null이면 저장을 건너뛴다(canvas-store와 동일 규약).
+let activeTheaterId: string | null = null;
+let saveTimer: number | null = null;
 
 export function useShellPanels(): Record<string, ShellPanelEntry> {
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
@@ -34,7 +44,7 @@ export function getActiveShellId(): string | null {
   return activeShellId;
 }
 
-// 셸 패널을 활성(최상단 포커스)으로 표시한다. null이면 활성 셸 없음.
+// 셸 패널을 활성(최상단 포커스)으로 표시한다. null이면 활성 셸 없음. activeShellId는 비영속이라 저장하지 않는다.
 export function setActiveShellPanel(id: string | null): void {
   if (activeShellId === id) return;
   activeShellId = id;
@@ -44,6 +54,7 @@ export function setActiveShellPanel(id: string | null): void {
 export function addShellPanel(theaterId: string, geometry: PanelGeometry): string {
   const id = newShellPanelId();
   panels = { ...panels, [id]: { theaterId, geometry } };
+  scheduleSave();
   emit();
   return id;
 }
@@ -52,6 +63,7 @@ export function setShellPanelGeometry(id: string, geometry: PanelGeometry): void
   const existing = panels[id];
   if (!existing) return;
   panels = { ...panels, [id]: { ...existing, geometry } };
+  scheduleSave();
   emit();
 }
 
@@ -61,13 +73,28 @@ export function removeShellPanel(id: string): void {
   delete next[id];
   panels = next;
   if (activeShellId === id) activeShellId = null;
+  scheduleSave();
   emit();
 }
 
+// 메모리 레지스트리만 비운다(영속 저장은 건드리지 않는다). Theater 전환·새로고침에는 전체 교체를 담당하는
+// loadShellPanelsForTheater를 쓰고, 이 함수는 영속 없이 화면만 비워야 하는 보조 경로용으로 남긴다.
 export function clearShellPanels(): void {
   if (Object.keys(panels).length === 0 && activeShellId === null) return;
   panels = {};
   activeShellId = null;
+  emit();
+}
+
+// Theater 전환·새로고침 시 호출한다. 이전 Theater의 보류 저장을 flush한 뒤 해당 Theater의 셸을 localStorage에서
+// 복원한다. 복원된 셸의 최대 zIndex로 공유 카운터를 끌어올려 "활성화→최상단"이 새로고침 후에도 성립하게 한다.
+export function loadShellPanelsForTheater(theaterId: string | null): void {
+  flushScheduledSave();
+  activeTheaterId = theaterId;
+  panels = theaterId ? readStoredShellPanels(theaterId) : {};
+  // 복원 직후에는 어떤 셸도 활성으로 두지 않는다(Operations 활성과의 상호배타를 깨지 않기 위함).
+  activeShellId = null;
+  liftTopZIndex(maxZIndexOf(panels));
   emit();
 }
 
@@ -86,9 +113,97 @@ function emit(): void {
   for (const listener of listeners) listener();
 }
 
-// 전역 고유 셸 패널 id. "shell:" prefix는 백엔드 theater-shell 판별을 위해 유지하되, 탭/새로고침 간
-// 충돌을 막도록 무작위 성분을 붙인다 — 다른 브라우저 컨텍스트가 같은 sessionId로 서로의 PTY에
-// 잘못 attach/대체되어 엉뚱한 Theater cwd를 물려받는 것을 방지한다.
+function scheduleSave(): void {
+  if (!activeTheaterId || typeof window === "undefined") return;
+  cancelScheduledSave();
+  saveTimer = window.setTimeout(() => {
+    saveTimer = null;
+    writeStoredShellPanels(activeTheaterId, panels);
+  }, SAVE_DELAY_MS);
+}
+
+function flushScheduledSave(): void {
+  if (!saveTimer || !activeTheaterId || typeof window === "undefined") return;
+  window.clearTimeout(saveTimer);
+  saveTimer = null;
+  writeStoredShellPanels(activeTheaterId, panels);
+}
+
+function cancelScheduledSave(): void {
+  if (!saveTimer || typeof window === "undefined") return;
+  window.clearTimeout(saveTimer);
+  saveTimer = null;
+}
+
+function readStoredShellPanels(theaterId: string): Record<string, ShellPanelEntry> {
+  if (typeof window === "undefined") return {};
+  try {
+    const stored = window.localStorage.getItem(storageKey(theaterId));
+    if (!stored) return {};
+    return normalizeStoredShellPanels(JSON.parse(stored), theaterId);
+  } catch {
+    return {};
+  }
+}
+
+function writeStoredShellPanels(theaterId: string | null, value: Record<string, ShellPanelEntry>): void {
+  if (!theaterId || typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(storageKey(theaterId), JSON.stringify({ panels: value }));
+  } catch {
+    // 저장 실패는 셸 복구성만 낮추므로 런타임 흐름을 막지 않는다.
+  }
+}
+
+function storageKey(theaterId: string): string {
+  return `${STORAGE_KEY_PREFIX}${theaterId}`;
+}
+
+// 저장된 셸 패널을 검증·정규화한다. 셸 id가 아니거나 theaterId가 저장 키와 어긋난 stale 항목은 버린다.
+function normalizeStoredShellPanels(value: unknown, theaterId: string): Record<string, ShellPanelEntry> {
+  if (!isRecord(value) || !isRecord(value.panels)) return {};
+  const result: Record<string, ShellPanelEntry> = {};
+  for (const [id, entry] of Object.entries(value.panels)) {
+    if (!id.startsWith("shell:") || !isRecord(entry)) continue;
+    // 저장 키가 theaterId별이므로 entry.theaterId는 그 값과 일치해야 한다. 어긋나면 손상으로 보고 버린다.
+    if (entry.theaterId !== theaterId) continue;
+    result[id] = { theaterId, geometry: normalizeGeometry(entry.geometry) };
+  }
+  return result;
+}
+
+function normalizeGeometry(value: unknown): PanelGeometry {
+  if (!isRecord(value)) {
+    return { x: 0, y: 0, width: DEFAULT_SHELL_WIDTH, height: DEFAULT_SHELL_HEIGHT, zIndex: 0 };
+  }
+  return {
+    x: readFiniteNumber(value.x, 0),
+    y: readFiniteNumber(value.y, 0),
+    width: readPositiveNumber(value.width, DEFAULT_SHELL_WIDTH),
+    height: readPositiveNumber(value.height, DEFAULT_SHELL_HEIGHT),
+    zIndex: readFiniteNumber(value.zIndex, 0),
+  };
+}
+
+function maxZIndexOf(value: Record<string, ShellPanelEntry>): number {
+  return Math.max(0, ...Object.values(value).map((entry) => entry.geometry.zIndex));
+}
+
+function readFiniteNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function readPositiveNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// 전역 고유 셸 패널 id. "shell:" prefix는 백엔드 theater-shell 판별을 위해 유지하되, 탭 간 충돌을 막도록
+// 무작위 성분을 붙인다 — 다른 브라우저 컨텍스트가 같은 sessionId로 서로의 PTY에 잘못 attach/대체되는 것을
+// 막는다. 같은 탭의 새로고침은 localStorage 복원으로 동일 id를 재사용해 살아 있는 PTY에 재부착한다.
 function newShellPanelId(): string {
   const unique = typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
     ? crypto.randomUUID()

--- a/runtime/fleet-console/client/src/canvas/shell-panels.ts
+++ b/runtime/fleet-console/client/src/canvas/shell-panels.ts
@@ -16,8 +16,11 @@ const DEFAULT_SHELL_WIDTH = 560;
 const DEFAULT_SHELL_HEIGHT = 360;
 
 const listeners = new Set<Listener>();
-// Theater별 localStorage에 영속한다(키: fleet-console.canvas.shell.<theaterId>). Operations 패널과 같은
-// theater-scoped 영속 패턴을 따르되, 두 레지스트리의 lifecycle은 분리한다(canvas-store의 CanvasState와 별개).
+// Theater별 sessionStorage에 영속한다(키: fleet-console.canvas.shell.<theaterId>). sessionStorage는 탭
+// 단위라 같은 탭의 새로고침에는 복원되지만 다른 탭과는 격리된다 — localStorage로 두면 두 번째 탭이 같은
+// shell:* PTY에 attach해 첫 탭의 세션을 가로채므로(terminal session manager가 sessionId 중복 attach 시
+// 이전 소켓을 replacement code로 닫는다) 의도적으로 탭별로 제한한다. Operations 패널(canvas-store)은 서버
+// durable 세션을 공유하므로 localStorage지만, 셸은 탭별 PTY라 영속 범위가 다르다.
 // 새로고침하면 모듈은 비워지지만 loadShellPanelsForTheater가 복원하며, 같은 패널 id로 백엔드 PTY에 재부착한다.
 let panels: Record<string, ShellPanelEntry> = {};
 // 활성(포커스) 셸 패널 id. Operations의 activeTerminalSessionId와 별개의 단일 활성 상태다.
@@ -138,7 +141,7 @@ function cancelScheduledSave(): void {
 function readStoredShellPanels(theaterId: string): Record<string, ShellPanelEntry> {
   if (typeof window === "undefined") return {};
   try {
-    const stored = window.localStorage.getItem(storageKey(theaterId));
+    const stored = window.sessionStorage.getItem(storageKey(theaterId));
     if (!stored) return {};
     return normalizeStoredShellPanels(JSON.parse(stored), theaterId);
   } catch {
@@ -149,7 +152,7 @@ function readStoredShellPanels(theaterId: string): Record<string, ShellPanelEntr
 function writeStoredShellPanels(theaterId: string | null, value: Record<string, ShellPanelEntry>): void {
   if (!theaterId || typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(storageKey(theaterId), JSON.stringify({ panels: value }));
+    window.sessionStorage.setItem(storageKey(theaterId), JSON.stringify({ panels: value }));
   } catch {
     // 저장 실패는 셸 복구성만 낮추므로 런타임 흐름을 막지 않는다.
   }
@@ -203,7 +206,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 // 전역 고유 셸 패널 id. "shell:" prefix는 백엔드 theater-shell 판별을 위해 유지하되, 탭 간 충돌을 막도록
 // 무작위 성분을 붙인다 — 다른 브라우저 컨텍스트가 같은 sessionId로 서로의 PTY에 잘못 attach/대체되는 것을
-// 막는다. 같은 탭의 새로고침은 localStorage 복원으로 동일 id를 재사용해 살아 있는 PTY에 재부착한다.
+// 막는다. 같은 탭의 새로고침은 sessionStorage 복원으로 동일 id를 재사용해 살아 있는 PTY에 재부착한다.
 function newShellPanelId(): string {
   const unique = typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
     ? crypto.randomUUID()

--- a/runtime/fleet-console/client/src/canvas/shell-panels.ts
+++ b/runtime/fleet-console/client/src/canvas/shell-panels.ts
@@ -101,6 +101,28 @@ export function loadShellPanelsForTheater(theaterId: string | null): void {
   emit();
 }
 
+// Theater를 잊을 때 저장된 셸 패널도 함께 제거한다 — 안 그러면 같은 폴더를 같은 탭에서 재등록할 때 같은
+// theaterId의 stale 엔트리가 삭제했던 셸을 되살리고 새 PTY를 마운트한다. Operations 패널은 서버 발급
+// sessionId라 prune으로 자연 정리되지만, 셸 id는 클라이언트 발급이라 명시적 정리가 필요하다.
+export function clearStoredShellPanelsForTheater(theaterId: string): void {
+  if (typeof window !== "undefined") {
+    try {
+      window.sessionStorage.removeItem(storageKey(theaterId));
+    } catch {
+      // 정리 실패는 stale 복원 가능성만 남기므로 런타임 흐름을 막지 않는다.
+    }
+  }
+  // 잊는 Theater가 현재 로드된 것이면 보류 저장을 취소(잊은 키에 다시 쓰지 않도록)하고 메모리를 비운다.
+  // 이후 activeTheater 전환이 loadShellPanelsForTheater로 새 Theater를 재로드한다.
+  if (activeTheaterId === theaterId) {
+    cancelScheduledSave();
+    activeTheaterId = null;
+    panels = {};
+    activeShellId = null;
+    emit();
+  }
+}
+
 function subscribe(listener: Listener): () => void {
   listeners.add(listener);
   return () => {

--- a/runtime/fleet-console/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/client/src/pages/operations.tsx
@@ -51,10 +51,13 @@ export function Operations({ state }: OperationsProps) {
   }, []);
 
   useEffect(() => {
-    // 첫 sessions 스냅샷이 적재되기 전의 빈 sessionOrder는 "로딩 중"일 뿐이다. 이때 prune하면 방금 복원한
-    // 패널을 전부 지운다(theater bootstrap이 sessions보다 먼저 도착하는 race). 적재 완료 후에만 정리한다.
-    if (!state.terminalSessionsHydrated) return;
+    // 알려진 세션에는 항상 geometry를 보장한다 — 적재 실패 후 SSE로 늦게 도착한 세션도 캔버스에 보이게 한다
+    // (geometry가 없으면 OperationsCanvas가 그 패널을 렌더하지 않는다). ensureDefaultGeometry는 기존 패널을
+    // 덮어쓰지 않으므로 복원된 레이아웃에도 안전하다.
     for (const sessionId of sessionOrder) ensureDefaultGeometry(sessionId);
+    // prune만 가드한다 — 첫 sessions 스냅샷 적재 전 빈 sessionOrder는 "로딩 중"이라, 이때 정리하면 방금 복원한
+    // 패널을 지운다(bootstrap이 sessions보다 먼저 도착하는 race). 적재 완료(권위 있는 상태) 후에만 정리한다.
+    if (!state.terminalSessionsHydrated) return;
     prunePanels(sessionOrder);
   }, [sessionOrder, state.terminalSessionsHydrated]);
 

--- a/runtime/fleet-console/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/client/src/pages/operations.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { OperationsCanvas } from "../canvas/canvas.js";
 import { ensureDefaultGeometry, focusPanel, loadForTheater, prunePanels } from "../canvas/canvas-store.js";
-import { clearShellPanels } from "../canvas/shell-panels.js";
+import { loadShellPanelsForTheater } from "../canvas/shell-panels.js";
 import { resumeTerminalSession } from "../api.js";
 import { FloatingJobOverlay } from "../components/floating-job-overlay.js";
 import { FloatingSidebar } from "../components/floating-sidebar.js";
@@ -18,15 +18,17 @@ interface OperationsProps {
 export function Operations({ state }: OperationsProps) {
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const mode = useOperationsMode();
-  const sessionOrder = theaterSessionOrder(state);
+  // theaterSessionOrder는 매 호출 새 배열을 반환하므로 참조를 안정화한다 — 아래 prune effect가 매 렌더 도는 것을 막는다.
+  const sessionOrder = useMemo(() => theaterSessionOrder(state), [state.sessions, state.sessionOrder, state.activeTheaterId]);
   // 최신 state를 keydown 핸들러에서 읽기 위한 ref(핸들러는 한 번만 등록).
   const stateRef = useRef(state);
   stateRef.current = state;
 
   useEffect(() => {
     loadForTheater(state.activeTheaterId);
-    // Theater가 바뀌면 이전 Theater cwd에 묶인 ephemeral 셸 패널을 비운다(언마운트 → 백엔드 grace 정리).
-    clearShellPanels();
+    // 셸 패널도 같은 activeTheaterId 기준으로 복원한다(새로고침 후 유지, Theater 전환 시 해당 Theater 셸로 교체).
+    // Operations 패널의 loadForTheater와 대칭이며, 이전 Theater의 보류 저장은 내부에서 flush된다.
+    loadShellPanelsForTheater(state.activeTheaterId);
   }, [state.activeTheaterId]);
 
   // Alt+←/→ 로 현재 Theater 내 Operation 포커스를 순환 이동한다(Map=resume+확대, Helm=선택). 두 모드 공통.
@@ -49,9 +51,12 @@ export function Operations({ state }: OperationsProps) {
   }, []);
 
   useEffect(() => {
+    // 첫 sessions 스냅샷이 적재되기 전의 빈 sessionOrder는 "로딩 중"일 뿐이다. 이때 prune하면 방금 복원한
+    // 패널을 전부 지운다(theater bootstrap이 sessions보다 먼저 도착하는 race). 적재 완료 후에만 정리한다.
+    if (!state.terminalSessionsHydrated) return;
     for (const sessionId of sessionOrder) ensureDefaultGeometry(sessionId);
     prunePanels(sessionOrder);
-  }, [sessionOrder]);
+  }, [sessionOrder, state.terminalSessionsHydrated]);
 
   // 검색 등에서 들어온 일회성 이동 요청을 처리한다. 위의 loadForTheater/ensureDefaultGeometry
   // effect가 먼저 선언되어 해당 Theater의 패널이 로드·보장된 뒤 실행되므로 focusPanel이 안전하다.

--- a/runtime/fleet-console/client/src/store.ts
+++ b/runtime/fleet-console/client/src/store.ts
@@ -67,6 +67,7 @@ let state: ConsoleState = {
   shortcutsOpen: false,
   onboardingOpen: false,
   bootstrapped: false,
+  terminalSessionsHydrated: false,
   pendingOperationFocus: null,
   selectedJobId: null,
   expandedSessionIds: readStoredExpandedSessions(),
@@ -149,6 +150,8 @@ export function hydrateTerminalSessions(sessions: readonly SessionInput[]): void
     sessions: merged,
     sessionOrder,
     activeTerminalSessionId: resolveVisibleSessionId(state.activeTheaterId, merged, sessionOrder, state.activeTerminalSessionId),
+    // 첫 스냅샷 적재 완료를 표시한다(단방향). 이후 패널 prune이 빈 sessionOrder를 권위 있는 상태로 신뢰한다.
+    terminalSessionsHydrated: true,
   });
 }
 

--- a/runtime/fleet-console/client/src/store.ts
+++ b/runtime/fleet-console/client/src/store.ts
@@ -1,6 +1,7 @@
 import { applyEvent, createEmptyJob, isTerminalJobStatus, reduceSnapshotJob } from "./reduce.js";
 import { sessionDisplayLabel } from "./format.js";
 import { buildOperationSearchEntries } from "./operation-search.js";
+import { clearStoredShellPanelsForTheater } from "./canvas/shell-panels.js";
 import type {
   ConsoleState,
   JobView,
@@ -385,6 +386,8 @@ export function failRenameTerminalSession(error: string): void {
 }
 
 export function removeTheater(theaterId: string): void {
+  // Theater의 Operations뿐 아니라 영속된 셸 패널 저장도 함께 정리한다 — stale 셸이 같은 폴더 재등록 시 부활하지 않게 한다.
+  clearStoredShellPanelsForTheater(theaterId);
   const theaters = state.theaters.filter((theater) => theater.id !== theaterId);
   const sessions: Record<string, SessionInfo> = {};
   const sessionOrder: string[] = [];

--- a/runtime/fleet-console/client/src/types.ts
+++ b/runtime/fleet-console/client/src/types.ts
@@ -288,6 +288,9 @@ export interface ConsoleState {
   readonly shortcutsOpen: boolean;
   readonly onboardingOpen: boolean;
   readonly bootstrapped: boolean;
+  // 첫 terminal sessions 스냅샷이 적재(성공·실패 무관)되었는지. theater bootstrap과 sessions fetch가 독립
+  // 비동기라, 이 플래그가 true가 되기 전에는 빈 sessionOrder를 "아직 로딩 중"으로 보고 패널 prune을 보류한다.
+  readonly terminalSessionsHydrated: boolean;
   // 검색 등에서 특정 Operation으로 이동을 요청한 일회성 신호. Map 모드는 이를 소비해 해당 패널로 확대한다.
   readonly pendingOperationFocus: string | null;
   readonly selectedJobId: string | null;

--- a/runtime/fleet-console/tests/dashboard.test.ts
+++ b/runtime/fleet-console/tests/dashboard.test.ts
@@ -31,6 +31,7 @@ const BASE_STATE: ConsoleState = {
   shortcutsOpen: false,
   onboardingOpen: false,
   bootstrapped: false,
+  terminalSessionsHydrated: false,
   pendingOperationFocus: null,
   selectedJobId: null,
   expandedSessionIds: [],

--- a/runtime/fleet-console/tests/operation-search.test.ts
+++ b/runtime/fleet-console/tests/operation-search.test.ts
@@ -37,6 +37,7 @@ function makeState(sessions: readonly (Omit<SessionInfo, "resumeAvailable" | "tu
     shortcutsOpen: false,
     onboardingOpen: false,
     bootstrapped: false,
+    terminalSessionsHydrated: false,
     pendingOperationFocus: null,
     selectedJobId: null,
     expandedSessionIds: [],


### PR DESCRIPTION
## Summary
- 브라우저 새로고침 시 Operations Map 패널의 위치·크기가 기본값으로 리셋되던 회귀를 수정합니다 (bootstrap/sessions 도착 순서 race로 복원된 패널이 prune되던 근본 원인을 `terminalSessionsHydrated` 가드로 차단).
- 새로고침 시 사라지던 Map 쉘 패널을 theaterId별 localStorage에 영속화해 복원합니다 (살아있는 PTY에는 재부착, 없으면 같은 cwd로 cold-start — 서버 단일 진실에 위임).
- 복원된 쉘 패널의 최대 z-index로 공유 카운터를 끌어올려 새로고침 후에도 "활성화→최상단"이 유지됩니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (30 files / 362 tests green)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] console-e2e 실측: 패널 이동(-89,152)+리사이즈(763×493)+쉘 추가 → 새로고침 후 위치·크기·쉘·z-index 전부 보존, pageerror 0
- [x] `.changelog.d` 프래그먼트 추가 (`node scripts/compile-changelog-fragments.mjs --check` 통과)