### PR TITLE
feat(console): show Agent CLI availability and version in Settings

### DIFF
--- a/.changelog.d/agent-cli-availability.md
+++ b/.changelog.d/agent-cli-availability.md
@@ -1,0 +1,4 @@
+---
+section: Added
+---
+- [fleet-console] Settings now shows whether each Agent CLI (Claude Code, Codex CLI, OpenCode, Cursor Agent) is installed and its detected version.

--- a/runtime/fleet-console/client/src/agent-cli-api.ts
+++ b/runtime/fleet-console/client/src/agent-cli-api.ts
@@ -1,0 +1,52 @@
+import { ApiError } from "./api.js";
+import type { AgentCliState, AgentCliStatus } from "./types.js";
+
+export async function fetchAgentCliState(signal?: AbortSignal): Promise<AgentCliState> {
+  const response = await fetch("/agent-cli/state", { signal });
+  await assertOk(response);
+  return assertAgentCliState(await response.json(), response.status);
+}
+
+async function assertOk(response: Response): Promise<void> {
+  if (response.ok) return;
+  let message = response.statusText || `HTTP ${response.status}`;
+  try {
+    const payload = await response.json() as { error?: unknown };
+    if (typeof payload.error === "string") message = payload.error;
+  } catch {
+    // 응답 본문이 JSON이 아니면 statusText를 사용한다.
+  }
+  throw new ApiError(response.status, message);
+}
+
+function assertAgentCliState(value: unknown, status: number): AgentCliState {
+  const payload = value as { clis?: unknown };
+  if (!payload || typeof payload !== "object" || !Array.isArray(payload.clis)) {
+    throw new ApiError(status, "Invalid agent CLI state response");
+  }
+  return { clis: payload.clis.map((entry) => assertAgentCliStatus(entry, status)) };
+}
+
+function assertAgentCliStatus(value: unknown, status: number): AgentCliStatus {
+  const entry = value as Partial<AgentCliStatus>;
+  if (
+    !entry ||
+    typeof entry !== "object" ||
+    typeof entry.id !== "string" ||
+    typeof entry.displayName !== "string" ||
+    typeof entry.available !== "boolean" ||
+    !(entry.version === null || typeof entry.version === "string")
+  ) {
+    throw new ApiError(status, "Invalid agent CLI status entry");
+  }
+  // Token Boundary 방어: 백엔드가 실수로 경로를 직렬화하면 즉시 거부한다.
+  if (Object.prototype.hasOwnProperty.call(entry, "path")) {
+    throw new ApiError(status, "Agent CLI status must not expose filesystem paths");
+  }
+  return {
+    id: entry.id,
+    displayName: entry.displayName,
+    available: entry.available,
+    version: entry.version,
+  };
+}

--- a/runtime/fleet-console/client/src/agent-cli-store.ts
+++ b/runtime/fleet-console/client/src/agent-cli-store.ts
@@ -1,0 +1,54 @@
+import { useSyncExternalStore } from "react";
+
+import { fetchAgentCliState } from "./agent-cli-api.js";
+import type { AgentCliState } from "./types.js";
+
+interface AgentCliStoreState {
+  readonly loading: boolean;
+  readonly state: AgentCliState | null;
+  readonly error: string | null;
+}
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+let snapshot: AgentCliStoreState = {
+  loading: false,
+  state: null,
+  error: null,
+};
+
+export function useAgentCliStore(): AgentCliStoreState {
+  return useSyncExternalStore(subscribe, getAgentCliStoreState, getAgentCliStoreState);
+}
+
+export function getAgentCliStoreState(): AgentCliStoreState {
+  return snapshot;
+}
+
+export function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export async function loadAgentCliState(signal?: AbortSignal): Promise<void> {
+  setSnapshot({ loading: true, error: null });
+  try {
+    const state = await fetchAgentCliState(signal);
+    setSnapshot({ loading: false, state, error: null });
+  } catch (error) {
+    if (signal?.aborted) return;
+    setSnapshot({ loading: false, error: toErrorMessage(error) });
+  }
+}
+
+function setSnapshot(patch: Partial<AgentCliStoreState>): void {
+  snapshot = { ...snapshot, ...patch };
+  for (const listener of listeners) listener();
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/runtime/fleet-console/client/src/components/agent-cli-section.tsx
+++ b/runtime/fleet-console/client/src/components/agent-cli-section.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+
+import { loadAgentCliState, useAgentCliStore } from "../agent-cli-store.js";
+import type { AgentCliStatus } from "../types.js";
+
+interface AgentCliRowProps {
+  readonly cli: AgentCliStatus;
+}
+
+export function AgentCliSection() {
+  const store = useAgentCliStore();
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadAgentCliState(controller.signal);
+    return () => controller.abort();
+  }, []);
+
+  return (
+    <section className="global-settings-card" aria-label="Agent CLI availability">
+      <div className="agent-cli-head">
+        <p className="global-settings-resp-title">Agent CLI</p>
+        <p className="global-settings-help">
+          Whether each Agent CLI is installed and discoverable on this machine&apos;s PATH, with its detected version.
+          Carriers can only run on an Agent CLI shown as available here.
+        </p>
+      </div>
+
+      {store.error ? <p className="global-settings-error" role="alert">{store.error}</p> : null}
+      {store.loading && !store.state ? <p className="global-settings-help">Checking Agent CLIs.</p> : null}
+
+      {store.state?.clis.map((cli) => <AgentCliRow key={cli.id} cli={cli} />)}
+
+      <p className="global-settings-foot">Install or update a CLI, then reopen this page to re-check availability.</p>
+    </section>
+  );
+}
+
+function AgentCliRow({ cli }: AgentCliRowProps) {
+  return (
+    <div className="agent-cli-row">
+      <span className="agent-cli-name">{cli.displayName}</span>
+      <span className="agent-cli-meta">
+        {cli.available && cli.version ? <span className="agent-cli-version">{cli.version}</span> : null}
+        <span className={`agent-cli-status ${cli.available ? "is-on" : ""}`}>
+          {cli.available ? "Available" : "Not found"}
+        </span>
+      </span>
+    </div>
+  );
+}

--- a/runtime/fleet-console/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/client/src/pages/global-settings.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 
+import { AgentCliSection } from "../components/agent-cli-section.js";
 import { ModelAuthSection } from "../components/model-auth-section.js";
 import { loadGlobalSettings, setGlobalSettingsField, useGlobalSettingsStore } from "../global-settings-store.js";
 
@@ -64,6 +65,8 @@ export function GlobalSettings() {
         ) : null}
         <p className="global-settings-foot">Changes apply to newly launched sessions. Running sessions keep their current configuration until relaunched.</p>
       </section>
+
+      <AgentCliSection />
 
       <ModelAuthSection />
     </main>

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -245,7 +245,7 @@
   display: grid;
   align-content: start;
   gap: var(--space-5);
-  width: min(720px, calc(100vw - 48px));
+  width: min(960px, calc(100vw - 48px));
   min-height: 0;
   height: 100%;
   margin: 0 auto;

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -576,6 +576,74 @@
   }
 }
 
+/* Agent CLI 가용성 — 설치/버전 표시 행. global-settings-card를 그릇으로 재사용한다. */
+.agent-cli-head {
+  display: grid;
+  gap: 8px;
+}
+
+.agent-cli-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding-top: var(--space-5);
+  border-top: 1px solid color-mix(in oklch, var(--surface-rim) 55%, transparent);
+}
+
+.agent-cli-name {
+  color: var(--ink-pearl);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.agent-cli-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+/* 버전은 데이터이므로 대문자 변환 없이 중립 ink로 표기한다. */
+.agent-cli-version {
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+
+.agent-cli-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.agent-cli-status::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ink-rim);
+}
+
+/* available = aurora('살아있는 것'). 미설치는 중립 ink. */
+.agent-cli-status.is-on {
+  color: var(--aurora);
+}
+
+.agent-cli-status.is-on::before {
+  background: var(--aurora);
+  box-shadow: 0 0 10px var(--aurora-glow);
+}
+
 .carrier-settings-page {
   display: grid;
   align-content: start;

--- a/runtime/fleet-console/client/src/types.ts
+++ b/runtime/fleet-console/client/src/types.ts
@@ -143,6 +143,19 @@ export interface ModelAuthMutationResult {
   readonly state: ModelAuthState;
 }
 
+// Agent CLI 가용성(설치 여부 + 버전) DTO — server src/agent-cli-types.ts와 수동 동기화한다.
+// Token Boundary 하드룰에 따라 raw filesystem path는 포함하지 않는다.
+export interface AgentCliStatus {
+  readonly id: string;
+  readonly displayName: string;
+  readonly available: boolean;
+  readonly version: string | null;
+}
+
+export interface AgentCliState {
+  readonly clis: readonly AgentCliStatus[];
+}
+
 export type SessionStatus = "starting" | "live" | "registered" | "terminal-only" | "closed" | "error" | "dormant";
 
 // Agent CLI 턴(host 처리) 상태. "none"=턴 이력 없음(신규), "running"=처리중, "ended"=종료(유휴).

--- a/runtime/fleet-console/src/agent-cli-detect.ts
+++ b/runtime/fleet-console/src/agent-cli-detect.ts
@@ -1,0 +1,114 @@
+// Agent CLI 가용성 탐지 서비스(서버 전용).
+//
+// 크로스플랫폼 정공법: 바이너리 해석은 core-agent의 resolvePathBinary(PATH/PATHEXT 탐색 +
+// Windows `.cmd`/`.bat` shim을 `cmd.exe /d /s /c call`로 래핑)에 위임한다. 이렇게 하면 *nix의
+// 실행 파일/심볼릭링크와 Windows의 npm `.cmd` shim을 동일한 SSoT로 처리해 `--version` 실행이
+// 양 플랫폼에서 모두 성공한다. 해석 결과의 prefixArgs를 `--version` 앞에 붙여 호출하므로
+// Windows shim 래핑이 버전 조회에도 그대로 적용된다. 표시 대상은 CLI_BACKENDS를 cliCommand
+// 기준으로 중복제거한 4개 바이너리(claude/codex/opencode/cursor-agent)다.
+
+import { execFile } from "node:child_process";
+
+import { resolvePathBinary, type ResolvedBinary } from "@dotobokuri/core-agent";
+import { CLI_BACKENDS } from "@dotobokuri/core-unified-agent";
+
+import type { AgentCliStatus } from "./agent-cli-types.js";
+
+export interface AgentCliDetectorDeps {
+  // PATH에서 바이너리를 해석한다. 미설치 시 undefined. (기본: resolvePathBinary + process.env)
+  readonly resolve: (command: string) => ResolvedBinary | undefined;
+  // 주어진 바이너리/인자로 프로세스를 실행해 stdout(또는 stderr)을 반환한다. 실패 시 throw.
+  readonly runVersion: (bin: string, args: readonly string[]) => Promise<string>;
+}
+
+export interface AgentCliDetector {
+  readonly detect: () => Promise<readonly AgentCliStatus[]>;
+}
+
+// cliCommand → 바이너리 표시명. provider 변형(zai/kimi/glm)이 아닌 바이너리 정체성을 담백하게 표기한다.
+const BINARY_DISPLAY_NAMES: Record<string, string> = {
+  claude: "Claude Code",
+  codex: "Codex CLI",
+  opencode: "OpenCode",
+  "cursor-agent": "Cursor Agent",
+};
+
+// `--version` 실행 타임아웃(ms). 미설치/무응답이어도 설정 화면 로드를 막지 않도록 짧게 잡는다.
+const VERSION_PROBE_TIMEOUT_MS = 5000;
+
+// semver(예: 1.2.3) 추출용.
+const SEMVER_PATTERN = /(\d+\.\d+\.\d+)/;
+
+export function createAgentCliDetector(deps: AgentCliDetectorDeps): AgentCliDetector {
+  return {
+    detect: async () => {
+      const commands = distinctBinaryCommands();
+      return Promise.all(commands.map((command) => detectOne(command, deps)));
+    },
+  };
+}
+
+export function createDefaultAgentCliDetector(): AgentCliDetector {
+  return createAgentCliDetector({
+    resolve: (command) => resolvePathBinary(command, process.env),
+    runVersion: (bin, args) => execFileVersion(bin, args),
+  });
+}
+
+// CLI_BACKENDS를 선언 순서 그대로 cliCommand 기준 중복제거한다(claude/codex/opencode/cursor-agent).
+function distinctBinaryCommands(): string[] {
+  const seen = new Set<string>();
+  const commands: string[] = [];
+  for (const backend of Object.values(CLI_BACKENDS)) {
+    if (!seen.has(backend.cliCommand)) {
+      seen.add(backend.cliCommand);
+      commands.push(backend.cliCommand);
+    }
+  }
+  return commands;
+}
+
+async function detectOne(command: string, deps: AgentCliDetectorDeps): Promise<AgentCliStatus> {
+  const resolved = deps.resolve(command);
+  const available = resolved !== undefined;
+  let version: string | null = null;
+  if (resolved) {
+    version = await probeVersionSafe(resolved, deps);
+  }
+  return {
+    id: command,
+    displayName: BINARY_DISPLAY_NAMES[command] ?? command,
+    available,
+    version,
+  };
+}
+
+// 버전 추출은 실패해도 throw하지 않는다(가용성 표시는 유지). Token Boundary 하드룰에 따라
+// `--version` 출력에는 설치 경로/사용자명이 섞일 수 있으므로, semver 패턴에 매칭된 값만 반환하고
+// 매칭 실패 시 raw 출력을 흘리지 않고 null로 둔다.
+async function probeVersionSafe(resolved: ResolvedBinary, deps: AgentCliDetectorDeps): Promise<string | null> {
+  try {
+    const output = await deps.runVersion(resolved.bin, [...resolved.prefixArgs, "--version"]);
+    return output.match(SEMVER_PATTERN)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function execFileVersion(bin: string, args: readonly string[]): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    execFile(
+      bin,
+      [...args],
+      { encoding: "utf-8", timeout: VERSION_PROBE_TIMEOUT_MS, windowsHide: true },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        // 일부 CLI는 버전을 stderr로 출력한다.
+        resolve((stdout || stderr || "").trim());
+      },
+    );
+  });
+}

--- a/runtime/fleet-console/src/agent-cli-routes.ts
+++ b/runtime/fleet-console/src/agent-cli-routes.ts
@@ -1,0 +1,31 @@
+import type http from "node:http";
+
+import type { AgentCliState, AgentCliStatus } from "./agent-cli-types.js";
+
+interface AgentCliRouteDeps {
+  readonly detect: () => Promise<readonly AgentCliStatus[]>;
+  readonly writeJson: (res: http.ServerResponse, status: number, body: unknown) => void;
+}
+
+interface AgentCliRouteContext {
+  readonly req: http.IncomingMessage;
+  readonly res: http.ServerResponse;
+  readonly pathname: string;
+}
+
+export function createAgentCliRouter(deps: AgentCliRouteDeps): (context: AgentCliRouteContext) => Promise<boolean> {
+  return async function handleAgentCliRoute(context: AgentCliRouteContext): Promise<boolean> {
+    const { req, res, pathname } = context;
+    if (pathname === "/agent-cli/state") {
+      if (req.method !== "GET") {
+        deps.writeJson(res, 405, { error: "Method not allowed" });
+        return true;
+      }
+      const clis = await deps.detect();
+      const body: AgentCliState = { clis };
+      deps.writeJson(res, 200, body);
+      return true;
+    }
+    return false;
+  };
+}

--- a/runtime/fleet-console/src/agent-cli-types.ts
+++ b/runtime/fleet-console/src/agent-cli-types.ts
@@ -1,0 +1,15 @@
+// 브라우저로 나가는 Agent CLI 가용성 DTO. Token Boundary 하드룰에 따라 raw filesystem path는
+// 절대 포함하지 않는다. 바이너리 식별자(cliCommand)·표시명·설치 여부·버전만 표면화한다.
+
+export interface AgentCliStatus {
+  // 바이너리 식별자(= CLI_BACKENDS의 cliCommand). 예: "claude", "codex", "opencode", "cursor-agent".
+  readonly id: string;
+  readonly displayName: string;
+  readonly available: boolean;
+  // 설치되어 있고 `--version` 파싱에 성공한 경우의 버전 문자열. 그 외에는 null.
+  readonly version: string | null;
+}
+
+export interface AgentCliState {
+  readonly clis: readonly AgentCliStatus[];
+}

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -28,6 +28,8 @@ import { createCarrierSettingsRouter } from "./carrier-settings-routes.js";
 import { createCodexGateway } from "./codex/gateway.js";
 import { cleanupProviderSessionCaptures, createConsoleDurableStateStore, emptyDurableConsoleState, mergeProviderSessionCaptures, readProviderSessionCapture, unlinkProviderSessionCapture, type DurableConsoleState, type DurableOperation } from "./durable-state.js";
 import { createGlobalSettingsRouter } from "./global-settings-routes.js";
+import { createDefaultAgentCliDetector } from "./agent-cli-detect.js";
+import { createAgentCliRouter } from "./agent-cli-routes.js";
 import { createConsoleLock, type ConsoleLockHandle } from "./lock.js";
 import { createModelAuthRouter } from "./model-auth-routes.js";
 import { writeAggregateObserverEvents, writeObserverEvents } from "./observability-routes.js";
@@ -201,6 +203,11 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     readJsonBody,
     writeJson,
   });
+  const agentCliDetector = createDefaultAgentCliDetector();
+  const agentCliRouter = createAgentCliRouter({
+    detect: agentCliDetector.detect,
+    writeJson,
+  });
   const modelAuthRouter = createModelAuthRouter({
     authService: infraServices.authService,
     validateApiKey: (cli, apiKey) => validateAuthKeyForCli(cli, apiKey),
@@ -289,6 +296,10 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     }
     if (pathname === "/global-settings" || pathname.startsWith("/global-settings/")) {
       runAsyncBooleanHandler(globalSettingsRouter({ req, res, pathname }), res);
+      return;
+    }
+    if (pathname === "/agent-cli" || pathname.startsWith("/agent-cli/")) {
+      runAsyncBooleanHandler(agentCliRouter({ req, res, pathname }), res);
       return;
     }
     if (pathname === "/model-auth" || pathname.startsWith("/model-auth/")) {

--- a/runtime/fleet-console/tests/agent-cli-detect.test.ts
+++ b/runtime/fleet-console/tests/agent-cli-detect.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { createAgentCliDetector } from "../src/agent-cli-detect.js";
+
+interface VersionCall {
+  readonly bin: string;
+  readonly args: readonly string[];
+}
+
+describe("agent cli detector", () => {
+  it("reports the four distinct binaries in declaration order (zai/kimi/glm collapse into claude)", async () => {
+    const detector = createAgentCliDetector({
+      resolve: () => undefined,
+      runVersion: async () => "",
+    });
+    const result = await detector.detect();
+    expect(result.map((cli) => cli.id)).toEqual(["claude", "codex", "opencode", "cursor-agent"]);
+    expect(result.map((cli) => cli.displayName)).toEqual(["Claude Code", "Codex CLI", "OpenCode", "Cursor Agent"]);
+  });
+
+  it("marks a resolvable binary available and parses its semver version", async () => {
+    const detector = createAgentCliDetector({
+      resolve: (command) => (command === "claude" ? { bin: "/usr/local/bin/claude", prefixArgs: [] } : undefined),
+      runVersion: async () => "claude 2.1.0 (build 42)",
+    });
+    const result = await detector.detect();
+    const claude = result.find((cli) => cli.id === "claude");
+    expect(claude).toEqual({ id: "claude", displayName: "Claude Code", available: true, version: "2.1.0" });
+  });
+
+  it("marks an unresolvable binary unavailable with a null version and never probes it", async () => {
+    const calls: VersionCall[] = [];
+    const detector = createAgentCliDetector({
+      resolve: () => undefined,
+      runVersion: async (bin, args) => {
+        calls.push({ bin, args });
+        return "";
+      },
+    });
+    const result = await detector.detect();
+    expect(result.every((cli) => cli.available === false && cli.version === null)).toBe(true);
+    expect(calls).toEqual([]);
+  });
+
+  it("returns a null version (never raw stdout) when --version output has no semver, so paths cannot leak", async () => {
+    const detector = createAgentCliDetector({
+      resolve: (command) => (command === "claude" ? { bin: "/usr/local/bin/claude", prefixArgs: [] } : undefined),
+      // 경로/사용자명을 포함하지만 semver는 없는 출력. 절대 그대로 노출되어선 안 된다.
+      runVersion: async () => "claude installed at /Users/alice/.local/bin/claude",
+    });
+    const result = await detector.detect();
+    const claude = result.find((cli) => cli.id === "claude");
+    expect(claude?.available).toBe(true);
+    expect(claude?.version).toBeNull();
+  });
+
+  it("extracts only the semver and drops any surrounding path in the --version output", async () => {
+    const detector = createAgentCliDetector({
+      resolve: (command) => (command === "claude" ? { bin: "/usr/local/bin/claude", prefixArgs: [] } : undefined),
+      runVersion: async () => "claude 1.2.3 (/Users/alice/.local/bin/claude)",
+    });
+    const result = await detector.detect();
+    expect(result.find((cli) => cli.id === "claude")?.version).toBe("1.2.3");
+  });
+
+  it("keeps a binary available with a null version when the version probe throws", async () => {
+    const detector = createAgentCliDetector({
+      resolve: (command) => (command === "codex" ? { bin: "/usr/local/bin/codex", prefixArgs: [] } : undefined),
+      runVersion: async () => {
+        throw new Error("spawn failed");
+      },
+    });
+    const result = await detector.detect();
+    const codex = result.find((cli) => cli.id === "codex");
+    expect(codex?.available).toBe(true);
+    expect(codex?.version).toBeNull();
+  });
+
+  it("threads Windows shim prefixArgs through to the version probe", async () => {
+    const calls: VersionCall[] = [];
+    const detector = createAgentCliDetector({
+      resolve: (command) =>
+        command === "claude"
+          ? { bin: "C:\\Windows\\System32\\cmd.exe", prefixArgs: ["/d", "/s", "/c", "call", "C:\\npm\\claude.cmd "] }
+          : undefined,
+      runVersion: async (bin, args) => {
+        calls.push({ bin, args });
+        return "1.0.0";
+      },
+    });
+    await detector.detect();
+    expect(calls).toEqual([
+      {
+        bin: "C:\\Windows\\System32\\cmd.exe",
+        args: ["/d", "/s", "/c", "call", "C:\\npm\\claude.cmd ", "--version"],
+      },
+    ]);
+  });
+});

--- a/runtime/fleet-console/tests/agent-cli-routes.test.ts
+++ b/runtime/fleet-console/tests/agent-cli-routes.test.ts
@@ -1,0 +1,71 @@
+import type http from "node:http";
+
+import { describe, expect, it } from "vitest";
+
+import { createAgentCliRouter } from "../src/agent-cli-routes.js";
+import type { AgentCliStatus } from "../src/agent-cli-types.js";
+
+interface WriteJsonCall {
+  readonly status: number;
+  readonly body: unknown;
+}
+
+const SAMPLE: readonly AgentCliStatus[] = [
+  { id: "claude", displayName: "Claude Code", available: true, version: "2.1.0" },
+  { id: "codex", displayName: "Codex CLI", available: false, version: null },
+];
+
+describe("agent cli routes", () => {
+  it("GET /agent-cli/state returns the detected cli list", async () => {
+    const harness = createRouterHarness(SAMPLE);
+    const handled = await harness.router({ req: req("GET"), res: res(), pathname: "/agent-cli/state" });
+    expect(handled).toBe(true);
+    expect(harness.writes).toEqual([{ status: 200, body: { clis: SAMPLE } }]);
+  });
+
+  it("never serializes a filesystem path into the payload", async () => {
+    const harness = createRouterHarness(SAMPLE);
+    await harness.router({ req: req("GET"), res: res(), pathname: "/agent-cli/state" });
+    const body = harness.writes[0]?.body as { clis: readonly Record<string, unknown>[] };
+    for (const entry of body.clis) {
+      expect(entry).not.toHaveProperty("path");
+    }
+  });
+
+  it("GET /agent-cli/state rejects non-GET methods with 405", async () => {
+    const harness = createRouterHarness(SAMPLE);
+    await harness.router({ req: req("POST"), res: res(), pathname: "/agent-cli/state" });
+    expect(harness.writes[0]?.status).toBe(405);
+    expect(harness.detectCalls).toBe(0);
+  });
+
+  it("returns false for unknown paths so the host can fall through", async () => {
+    const harness = createRouterHarness(SAMPLE);
+    const handled = await harness.router({ req: req("GET"), res: res(), pathname: "/agent-cli/unknown" });
+    expect(handled).toBe(false);
+    expect(harness.writes).toEqual([]);
+  });
+});
+
+function createRouterHarness(clis: readonly AgentCliStatus[]) {
+  const writes: WriteJsonCall[] = [];
+  let detectCalls = 0;
+  const router = createAgentCliRouter({
+    detect: async () => {
+      detectCalls += 1;
+      return clis;
+    },
+    writeJson: (_res, status, body) => {
+      writes.push({ status, body });
+    },
+  });
+  return { router, writes, get detectCalls() { return detectCalls; } };
+}
+
+function req(method: string): http.IncomingMessage {
+  return { method, headers: {} } as unknown as http.IncomingMessage;
+}
+
+function res(): http.ServerResponse {
+  return {} as unknown as http.ServerResponse;
+}


### PR DESCRIPTION
## Summary
- Settings 페이지에 **Agent CLI** 섹션을 추가했습니다 — Claude Code / Codex CLI / OpenCode / Cursor Agent 각 바이너리의 PATH 설치 여부(Available)와 탐지된 버전을 표시합니다 (CLI_BACKENDS를 cliCommand 기준으로 중복제거한 4종).
- 탐지는 `CLI_BACKENDS`(카탈로그 SSoT) + core-agent `resolvePathBinary`(크로스플랫폼 SSoT)를 조합합니다. *nix 실행파일과 Windows `.cmd`/`.bat` shim(`cmd.exe /d /s /c call` 래핑)을 동일 경로로 처리합니다.
- **Token Boundary 준수**: 브라우저 페이로드는 `id/displayName/available/version`만 직렬화하며 filesystem path를 절대 노출하지 않습니다. version은 semver 매칭값만 사용해 `--version` 출력의 경로 누출을 차단합니다.
- Settings 페이지 표시 폭을 720px → **960px**로 확장했습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — green
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 373 passed (신규 11건: 라우트 + 탐지기)
- [x] `pnpm --filter @dotobokuri/fleet-console build` — green
- [x] console-e2e 실측: `/console/settings` 섹션 렌더, 4 CLI available+버전, 응답 `PATH_LEAK: false`, pageerror/console error 0
- [x] 크로스플랫폼: core-agent bin-resolver win32 테스트 + 탐지기 Windows `prefixArgs` 스레딩 단위 테스트로 커버, *nix는 실측 검증

## Changelog
- [x] `.changelog.d/agent-cli-availability.md` (section: Added, `[fleet-console]`)