### PR TITLE
fix(fleet-console): align operation panel attention motion

### DIFF
--- a/.changelog.d/console-panel-motion-changed.md
+++ b/.changelog.d/console-panel-motion-changed.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+- [fleet-console] Replaced running Operation attention motion with a consistent perimeter signal across open panels and minimized Dock controls.
+- [fleet-console] Aligned minimized Operation labels with open panel title typography.

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -2148,7 +2148,7 @@
   position: absolute;
   inset: 0;
   z-index: 3;
-  padding: 1.5px;
+  padding: 2px;
   border-radius: inherit;
   pointer-events: none;
   background: conic-gradient(

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -2114,38 +2114,35 @@
 }
 
 /* 작업 진행 중인 에이전트 패널 = "출항(underway)" 상태.
-   인디케이터(비콘) 색을 따르는 외곽 "물결(wake)" 애니메이션 + 정적 림으로 진행을 표시한다.
+   인디케이터(비콘) 색을 따르는 외곽 진행광 + 정적 글로우로 진행을 표시한다.
    색 변형: is-running--live=aurora(활성 캐리어 job), is-running--turn=warn(에이전트 턴 진행 = "그냥 작업중").
-   외곽 글로우/물결은 패널 box-shadow(overflow:hidden 비클리핑), 림은 inset 의사요소로 그린다.
-   brass(선택)와 역할 분리 — 선택+진행이 겹쳐도 brass 보더와 인디케이터색 물결이 각자 의미로 공존.
+   외곽 진행광은 최소화 칩과 같은 perimeter-orbit 방식으로, 림은 inset 의사요소로 그린다.
+   brass(선택)와 역할 분리 — 선택+진행이 겹쳐도 brass 보더와 인디케이터색 진행광이 각자 의미로 공존.
    AGENTS.md 모션 규약의 sanctioned 예외(작업 중에만, prefers-reduced-motion에서 정적 림+글로우로 단락). */
 .canvas-panel.is-running {
   box-shadow:
     var(--shadow-soft),
     0 0 22px -6px var(--uw-glow);
-  animation: panel-wake-ripple 2.2s ease-out infinite;
 }
 
 /* 인디케이터 색 추종 — live: aurora("지금 살아있는 것", 활성 캐리어 job) */
 .canvas-panel.is-running--live {
   --uw-tint: var(--aurora);
   --uw-glow: var(--aurora-glow);
-  --uw-ring: color-mix(in oklch, var(--aurora) 50%, transparent);
 }
 
 /* 인디케이터 색 추종 — turn: warn/amber(에이전트 턴 진행 = "그냥 작업중") */
 .canvas-panel.is-running--turn {
   --uw-tint: var(--warn);
   --uw-glow: var(--warn-glow);
-  --uw-ring: color-mix(in oklch, var(--warn) 50%, transparent);
 }
 
-/* 선택(is-active) + 진행 동시: brass 선택 보더 + 인디케이터색 물결/글로우 공존 */
+/* 선택(is-active) + 진행 동시: brass 선택 보더 + 인디케이터색 진행광/글로우 공존 */
 .canvas-panel.is-running.is-active {
   border-color: color-mix(in oklch, var(--brass) 54%, var(--surface-rim));
 }
 
-/* 상시 외곽 림 — running의 정적 신호(색은 인디케이터 따라감). 마스크로 테두리 띠만 남긴다. */
+/* 외곽 진행광 링 — 최소화된 칩과 같은 conic 하이라이트 호가 패널 테두리를 순환한다. */
 .canvas-panel.is-running::before {
   content: "";
   position: absolute;
@@ -2154,7 +2151,15 @@
   padding: 1.5px;
   border-radius: inherit;
   pointer-events: none;
-  background: color-mix(in oklch, var(--uw-tint) 38%, transparent);
+  background: conic-gradient(
+    from var(--uw-angle),
+    color-mix(in oklch, var(--uw-tint) 12%, transparent) 0deg,
+    color-mix(in oklch, var(--uw-tint) 12%, transparent) 18deg,
+    var(--uw-tint) 52deg,
+    color-mix(in oklch, var(--uw-tint) 55%, transparent) 92deg,
+    color-mix(in oklch, var(--uw-tint) 12%, transparent) 150deg,
+    color-mix(in oklch, var(--uw-tint) 12%, transparent) 360deg
+  );
   -webkit-mask:
     linear-gradient(#fff 0 0) content-box,
     linear-gradient(#fff 0 0);
@@ -2163,15 +2168,14 @@
     linear-gradient(#fff 0 0) content-box,
     linear-gradient(#fff 0 0);
   mask-composite: exclude;
+  animation: perimeter-orbit 2.4s linear infinite;
 }
 
-/* prefers-reduced-motion: 물결 정지, 정적 림 + 정적 글로우만 유지(색은 인디케이터 따라감) */
+/* prefers-reduced-motion: 순환 정지, 정적 림 + 정적 글로우만 유지(색은 인디케이터 따라감) */
 @media (prefers-reduced-motion: reduce) {
-  .canvas-panel.is-running {
+  .canvas-panel.is-running::before {
     animation: none;
-    box-shadow:
-      var(--shadow-soft),
-      0 0 22px -6px var(--uw-glow);
+    background: color-mix(in oklch, var(--uw-tint) 38%, transparent);
   }
 }
 
@@ -2209,6 +2213,7 @@
 
 /* ── 접기/펼치기 핸들 (최소화 패널이 1개 이상일 때만 렌더된다) ── */
 .canvas-dock-toggle {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -2276,25 +2281,53 @@
   flex: none;
 }
 
-/* 알림: 접힌 핸들이 박동(접혀 있어도 "안에 살아있는 게 있다"를 알린다). 색은 신호를 따른다.
+/* 알림: 접힌 핸들이 외곽 진행광으로 "안에 살아있는 게 있다"를 알린다. 색은 신호를 따른다.
    펼친 상태에선 각 칩이 외곽 진행광으로 직접 상태를 표시하므로 토글 알림은 접힘(:not(.is-expanded))
-   상태에서만 작동한다 — 펼친 토글은 정적으로 둔다. 패널/칩과 동일한 panel-wake-ripple을 재사용하되
-   핸들은 --shadow-floating을 기준 그림자로 쓴다. */
+   상태에서만 작동한다 — 펼친 토글은 정적으로 둔다. */
 .canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-live,
 .canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-turn {
-  animation: panel-wake-ripple 2.2s ease-out infinite;
+  box-shadow: var(--shadow-floating), 0 0 22px -6px var(--uw-glow);
 }
 
 .canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-live {
+  --uw-tint: var(--aurora);
   --uw-glow: var(--aurora-glow);
-  --uw-ring: color-mix(in oklch, var(--aurora) 45%, transparent);
   border-color: color-mix(in oklch, var(--aurora) 40%, var(--surface-rim));
 }
 
 .canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-turn {
+  --uw-tint: var(--warn);
   --uw-glow: var(--warn-glow);
-  --uw-ring: color-mix(in oklch, var(--warn) 45%, transparent);
   border-color: color-mix(in oklch, var(--warn) 40%, var(--surface-rim));
+}
+
+.canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-live::before,
+.canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-turn::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  padding: 1.5px;
+  border-radius: inherit;
+  pointer-events: none;
+  background: conic-gradient(
+    from var(--uw-angle),
+    color-mix(in oklch, var(--uw-tint) 12%, transparent) 0deg,
+    color-mix(in oklch, var(--uw-tint) 12%, transparent) 18deg,
+    var(--uw-tint) 52deg,
+    color-mix(in oklch, var(--uw-tint) 55%, transparent) 92deg,
+    color-mix(in oklch, var(--uw-tint) 12%, transparent) 150deg,
+    color-mix(in oklch, var(--uw-tint) 12%, transparent) 360deg
+  );
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+  animation: perimeter-orbit 2.4s linear infinite;
 }
 
 .canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-live .canvas-dock-toggle-beacon {
@@ -2450,8 +2483,8 @@
   color: var(--brass-bright);
 }
 
-/* 알림(underway) = 진행 중 칩의 외곽 진행광. 숨결(panel-wake-ripple) 대신 conic 하이라이트 호가
-   칩 테두리 링을 시계방향으로 순환한다. 색 의미는 동일(live=aurora, turn=warn). 칩 자체의 codex-rise
+/* 알림(underway) = 진행 중 칩의 외곽 진행광. conic 하이라이트 호가 칩 테두리 링을
+   시계방향으로 순환한다. 색 의미는 동일(live=aurora, turn=warn). 칩 자체의 codex-rise
    등장 모션은 위 .is-expanded .canvas-dock-chip 규칙에서 그대로 유지된다. */
 .canvas-dock-chip--underway-live {
   --uw-tint: var(--aurora);
@@ -2501,13 +2534,13 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-live,
-  .canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-turn {
-    animation: none;
-    box-shadow: var(--shadow-floating), 0 0 22px -6px var(--uw-glow);
-  }
   .canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-live .canvas-dock-toggle-beacon {
     animation: none;
+  }
+  .canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-live::before,
+  .canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-turn::before {
+    animation: none;
+    background: color-mix(in oklch, var(--uw-tint) 38%, transparent);
   }
   /* 칩 진행광: 순환 정지 + 정적 전체 림(전체 외곽을 옅게 유지). */
   .canvas-dock.is-expanded .canvas-dock-chip--underway::before {
@@ -2520,9 +2553,9 @@
   max-width: 140px;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-family: var(--font-display);
+  font-family: var(--font-body);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 700;
   color: var(--ink-spectral);
 }
 

--- a/runtime/fleet-console/client/src/styles/theme.css
+++ b/runtime/fleet-console/client/src/styles/theme.css
@@ -305,27 +305,9 @@ a {
   }
 }
 
-/* 진행 중(running) Operation 패널 외곽의 "항적(wake)" 물결 — 한 겹의 링이 바깥으로 번지며 사라진다.
-   패널 자체 box-shadow로 그려 overflow: hidden 클리핑을 피한다(자식 의사요소의 외향 글로우는 잘림).
-   색(--uw-ring/--uw-glow)은 인디케이터(비콘)를 따른다. AGENTS.md 모션 규약의 sanctioned 예외. */
-@keyframes panel-wake-ripple {
-  0% {
-    box-shadow:
-      var(--shadow-soft),
-      0 0 22px -6px var(--uw-glow),
-      0 0 0 0 var(--uw-ring);
-  }
-  100% {
-    box-shadow:
-      var(--shadow-soft),
-      0 0 22px -6px var(--uw-glow),
-      0 0 2px 18px transparent;
-  }
-}
-
-/* 최소화된(진행 중) Operation 칩 외곽의 "진행광(running light)" — conic 하이라이트 호(arc)가 칩 테두리
+/* 진행 중 Operation 패널/최소화 Dock 외곽의 "진행광(running light)" — conic 하이라이트 호(arc)가 테두리
    링을 따라 한 방향으로 순환한다. 각도(--uw-angle)는 @property로 등록해야 커스텀 속성이 부드럽게
-   보간된다(미등록 시 이산 점프). 색(--uw-tint)은 인디케이터를 따른다. 칩이 최소화 dock에 떠 있을 때만,
+   보간된다(미등록 시 이산 점프). 색(--uw-tint)은 인디케이터를 따른다. 작업 중 신호가 있는 동안만,
    prefers-reduced-motion에선 정적 림으로 단락 — AGENTS.md 모션 규약의 sanctioned 예외(작업 중 신호). */
 @property --uw-angle {
   syntax: "<angle>";


### PR DESCRIPTION
> **PR Target:** base is `canary`.

## PR Title

fix(fleet-console): align operation panel attention motion

## Summary

Replaces the running Operation panel and minimized Dock attention motion with one consistent perimeter-ring signal. Also aligns minimized Operation labels with the open panel title typography.

## Type of Change

- [ ] feat — new feature or carrier capability
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- [ ] `extensions/core`
- [ ] `extensions/fleet` (Admiral / Bridge / Carriers)
- [ ] `extensions/boot`
- [ ] `extensions/diagnostics`
- [ ] `extensions/metaphor`
- [ ] `packages/unified-agent`
- [ ] `bin/` or root tooling
- [ ] Documentation (README / SETUP / AGENTS.md)
- [x] `runtime/fleet-console`

## Test Plan

- [x] `rg -n -- "panel-wake-ripple|--uw-ring" runtime/fleet-console` returns no matches
- [x] `node scripts/compile-changelog-fragments.mjs --check --allow-empty`
- [x] `git diff --check`
- [x] `pnpm --filter @dotobokuri/fleet-console test`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Sentinel console-e2e QA PASS

## Changelog

- [x] Added one `.changelog.d/*.md` fragment, or applied the `no-changelog` label intentionally.
- [x] Fragment `section:` is one of `Added`, `Changed`, `Fixed`, `Removed`, or `Breaking Changes`.
- [x] Fragment bullets are English and use only `[core-agent]`, `[core-unified-agent]`, `[fleet-infra]`, `[fleet-admiral]`, `[fleet-carriers]`, `[fleet-wiki]`, `[fleet-console]`, or `[fleet-cli]`.

## Related Issues / PRs

N/A

## Notes for Reviewers

Vite reported existing large chunk warnings during build; no new build failure was introduced.