### PR TITLE
fix(console): keep operation auto-name to first prompt

### DIFF
--- a/.changelog.d/20260620050443-operation-auto-name-first-prompt-fixed.md
+++ b/.changelog.d/20260620050443-operation-auto-name-first-prompt-fixed.md
@@ -1,0 +1,4 @@
+---
+section: Fixed
+---
+- [fleet-console] Operation auto-naming now updates only from the first submitted prompt unless the operator clears the name to re-enable automatic naming.

--- a/runtime/fleet-console/src/durable-state.ts
+++ b/runtime/fleet-console/src/durable-state.ts
@@ -30,6 +30,8 @@ export interface DurableOperation {
   // 작전명 출처. 사용자가 수동 rename하면 "user", UserPromptSubmit 훅의 자동 작명이 설정하면 "auto".
   // 미설정(레거시) 상태는 read-time에 label 유무로 해석한다: label이 있으면 user로 보수 해석해 자동 덮어쓰기를 막는다.
   readonly labelSource?: ConsoleLabelSource;
+  // 최초 UserPromptSubmit auto-name hook 수신 여부. true면 이후 prompt는 자동 작명 후보여도 작전명을 바꾸지 않는다.
+  readonly autoNamePromptSeen?: boolean;
   readonly cliId?: string;
   readonly cliLabel?: string;
   readonly createdAt: number;
@@ -170,6 +172,9 @@ function sanitizeDurableOperation(value: unknown): DurableOperation | null {
   const sequence = readPositiveInteger(value.sequence);
   const createdAt = readFiniteNumber(value.createdAt);
   if (!sessionId || !theaterId || !cwd || !cwdLabel || sequence === null || createdAt === null) return null;
+  const label = readOptionalString(value.label);
+  const labelSource = readLabelSource(value.labelSource);
+  const autoNamePromptSeen = value.autoNamePromptSeen === true || (labelSource === "auto" && label !== undefined);
   const providerSession = sanitizeProviderSession(value.providerSession);
   return {
     sessionId,
@@ -177,8 +182,9 @@ function sanitizeDurableOperation(value: unknown): DurableOperation | null {
     cwd,
     cwdLabel,
     sequence,
-    ...(readOptionalString(value.label) ? { label: readOptionalString(value.label) } : {}),
-    ...(readLabelSource(value.labelSource) ? { labelSource: readLabelSource(value.labelSource) } : {}),
+    ...(label ? { label } : {}),
+    ...(labelSource ? { labelSource } : {}),
+    ...(autoNamePromptSeen ? { autoNamePromptSeen: true } : {}),
     ...(readOptionalString(value.cliId) ? { cliId: readOptionalString(value.cliId) } : {}),
     ...(readOptionalString(value.cliLabel) ? { cliLabel: readOptionalString(value.cliLabel) } : {}),
     createdAt,

--- a/runtime/fleet-console/src/observability-store.ts
+++ b/runtime/fleet-console/src/observability-store.ts
@@ -47,6 +47,7 @@ interface PendingTerminalSessionState {
   readonly sequence: number;
   label?: string;
   labelSource?: ConsoleLabelSource;
+  autoNamePromptSeen?: boolean;
   cliId?: string;
   cliLabel?: string;
   readonly createdAt: number;
@@ -57,6 +58,12 @@ interface PendingTerminalSessionState {
   registrationId?: string;
   cliRunId?: string;
   providerSession?: ProviderSession;
+}
+
+interface AutoNameTerminalSessionResult {
+  readonly session: ConsoleTerminalSessionInfo;
+  readonly changed: boolean;
+  readonly renamed: boolean;
 }
 
 interface TenantJobState {
@@ -226,6 +233,7 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
       sequence: operation.sequence,
       label: operation.label,
       labelSource: operation.labelSource,
+      autoNamePromptSeen: operation.autoNamePromptSeen,
       cliId: operation.cliId,
       cliLabel: operation.cliLabel,
       createdAt: operation.createdAt,
@@ -251,6 +259,7 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
       sequence: session.sequence,
       ...(session.label ? { label: session.label } : {}),
       ...(session.labelSource ? { labelSource: session.labelSource } : {}),
+      ...(session.autoNamePromptSeen ? { autoNamePromptSeen: true } : {}),
       ...(session.cliId ? { cliId: session.cliId } : {}),
       ...(session.cliLabel ? { cliLabel: session.cliLabel } : {}),
       createdAt: session.createdAt,
@@ -302,29 +311,35 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
     const label = rawLabel.trim().slice(0, 200);
     if (label.length === 0) {
       // 빈 rename은 사용자가 기본 표시명(#N Operation)으로 되돌린 것이다. label과 labelSource를 같은 호출에서
-      // 함께 지워, 다음 프롬프트부터 자동 작명이 재활성화되게 한다(둘을 분리하면 영구 자동 작명 차단 위험).
+      // 함께 지워, 다음 최초 프롬프트부터 자동 작명이 재활성화되게 한다(둘을 분리하면 영구 자동 작명 차단 위험).
       delete session.label;
       delete session.labelSource;
+      delete session.autoNamePromptSeen;
     } else {
       session.label = label;
       session.labelSource = "user";
+      session.autoNamePromptSeen = true;
     }
     return toTerminalSessionInfo(session);
   }
 
-  // 자동 작명: 사용자가 작전명을 수동 설정한 적이 없을 때만(effectiveSource !== "user") 후보 라벨을 적용한다.
-  // labelSource 미설정 레거시 세션은 label 유무로 보수 해석해 기존 사용자 라벨을 보호한다. 정규화 결과가
-  // 현재 라벨과 같으면(주제 무변동) sidebar churn을 피하려 변경하지 않는다.
-  function autoNameTerminalSession(sessionId: string, label: string): ConsoleTerminalSessionInfo | null {
+  // 자동 작명: 사용자 수동 라벨이 없고, 아직 UserPromptSubmit auto-name hook을 받은 적 없는 세션에만 적용한다.
+  // labelSource 미설정 레거시 세션은 label 유무로 보수 해석해 기존 사용자 라벨을 보호한다.
+  function autoNameTerminalSession(sessionId: string, label: string | null): AutoNameTerminalSessionResult | null {
     const session = terminalSessionsById.get(sessionId);
     if (!session) return null;
     const effectiveSource: ConsoleLabelSource | undefined = session.labelSource ?? (session.label ? "user" : undefined);
-    if (effectiveSource === "user") return null;
-    const next = label.trim().slice(0, 200);
-    if (next.length === 0 || next === session.label) return null;
+    if (effectiveSource === "user" || session.autoNamePromptSeen) {
+      return { session: toTerminalSessionInfo(session), changed: false, renamed: false };
+    }
+    session.autoNamePromptSeen = true;
+    const next = label?.trim().slice(0, 200) ?? "";
+    if (next.length === 0 || next === session.label) {
+      return { session: toTerminalSessionInfo(session), changed: true, renamed: false };
+    }
     session.label = next;
     session.labelSource = "auto";
-    return toTerminalSessionInfo(session);
+    return { session: toTerminalSessionInfo(session), changed: true, renamed: true };
   }
 
   function notifySessionUpdated(session: ConsoleTerminalSessionInfo): void {

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -413,7 +413,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
 
   // 자동 작명 hook 수신: UserPromptSubmit hook이 prompt를 lock 토큰으로 POST한다. turn/attention 라우트와
   // 동일하게 브라우저가 아닌 로컬 신뢰 프로세스이므로 lock-token bearer로만 인증한다. 사용자가 작전명을 수동
-  // 변경한 적 없을 때만(autoNameTerminalSession 내부 가드) prompt에서 도출한 라벨로 갱신한다.
+  // 변경한 적 없고 최초 UserPromptSubmit일 때만(autoNameTerminalSession 내부 가드) prompt에서 도출한 라벨로 갱신한다.
   // 자동 작명은 매 프롬프트마다 발생하므로 rename과 달리 PTY로 /rename 슬래시 명령을 주입하지 않는다.
   async function handleTerminalSessionAutoName(req: http.IncomingMessage, res: http.ServerResponse, sessionId: string): Promise<void> {
     if (req.method !== "POST") {
@@ -427,13 +427,15 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     }
     const body = await readJsonBody<{ readonly prompt?: unknown }>(req);
     const label = deriveOperationLabel(body?.prompt);
-    // 후보가 없거나 저신호이거나, 세션이 없거나, 사용자 보호 라벨/주제 무변동이면 작전명을 바꾸지 않는다.
-    const updated = label === null ? null : observability.autoNameTerminalSession(sessionId, label);
-    if (updated) {
-      observability.notifySessionUpdated(updated);
+    // 후보가 없거나 저신호여도 최초 UserPromptSubmit은 기록해 이후 prompt가 작전명을 바꾸지 못하게 한다.
+    const result = observability.autoNameTerminalSession(sessionId, label);
+    if (result?.renamed) {
+      observability.notifySessionUpdated(result.session);
+    }
+    if (result?.changed) {
       persistDurableState();
     }
-    writeJson(res, 200, { ok: true, renamed: updated !== null });
+    writeJson(res, 200, { ok: true, renamed: result?.renamed === true });
   }
 
   async function handleTerminalTicket(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {

--- a/runtime/fleet-console/tests/durable-state.test.ts
+++ b/runtime/fleet-console/tests/durable-state.test.ts
@@ -27,28 +27,33 @@ describe("durable console state", () => {
     expect(sanitizeDurableConsoleState({ version: 1, theaters: [{ id: "" }], operations: [{ sessionId: "missing" }] })).toEqual({ version: 1, theaters: [], operations: [] });
   });
 
-  it("preserves a valid labelSource and drops malformed ones without dropping the operation", () => {
+  it("preserves valid auto-name metadata and drops malformed values without dropping the operation", () => {
     const base = { sessionId: "s", theaterId: "t", cwd: "/p", cwdLabel: "p", sequence: 1, createdAt: 1 };
     const sanitized = sanitizeDurableConsoleState({
       version: 1,
       theaters: [],
       operations: [
         { ...base, sessionId: "user-op", label: "Bridge Watch", labelSource: "user" },
-        { ...base, sessionId: "auto-op", label: "Fix the parser", labelSource: "auto" },
+        { ...base, sessionId: "auto-op", label: "Fix the parser", labelSource: "auto", autoNamePromptSeen: true },
+        { ...base, sessionId: "legacy-auto-op", label: "Existing auto label", labelSource: "auto" },
         { ...base, sessionId: "legacy-op", label: "Legacy label" },
-        { ...base, sessionId: "bad-op", label: "Bad source", labelSource: "operator" },
+        { ...base, sessionId: "bad-op", label: "Bad source", labelSource: "operator", autoNamePromptSeen: "yes" },
       ],
     });
 
     const bySession = Object.fromEntries(sanitized.operations.map((operation) => [operation.sessionId, operation]));
     expect(bySession["user-op"]?.labelSource).toBe("user");
     expect(bySession["auto-op"]?.labelSource).toBe("auto");
+    expect(bySession["auto-op"]?.autoNamePromptSeen).toBe(true);
+    // 기존 자동 작명 Operation은 marker가 없더라도 이미 최초 prompt가 처리된 것으로 보수 backfill한다.
+    expect(bySession["legacy-auto-op"]?.autoNamePromptSeen).toBe(true);
     // 레거시(labelSource 없는) Operation은 그대로 보존되며 labelSource는 undefined로 남는다(read-time에 user로 해석).
     expect(bySession["legacy-op"]).toBeDefined();
     expect(bySession["legacy-op"]?.labelSource).toBeUndefined();
-    // 잘못된 labelSource는 필드만 떨궈지고 Operation 자체는 유지된다.
+    // 잘못된 metadata는 필드만 떨궈지고 Operation 자체는 유지된다.
     expect(bySession["bad-op"]?.label).toBe("Bad source");
     expect(bySession["bad-op"]?.labelSource).toBeUndefined();
+    expect(bySession["bad-op"]?.autoNamePromptSeen).toBeUndefined();
   });
 
   it("creates the state store with sensitive durable JSON settings", () => {

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -212,34 +212,49 @@ describe("console terminal observability", () => {
     expect(JSON.stringify(renamed)).not.toContain(dir);
   });
 
-  it("auto-names operations only when the operator has not set a label and records the auto source", () => {
+  it("auto-names operations only on the first user prompt when the operator has not set a label", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-autoname-"));
     tempDirs.push(dir);
     const store = createConsoleObservabilityStore();
     store.createPendingTerminalSession({ sessionId: "session-a", cwd: dir, createdAt: 1_000 });
 
     // 첫 자동 작명: label 없음 → auto 적용 + labelSource "auto" 기록(영속 투영에 반영).
-    expect(store.autoNameTerminalSession("session-a", "Fix the login redirect bug")?.label).toBe("Fix the login redirect bug");
-    expect(store.listDurableOperations()[0]).toMatchObject({ label: "Fix the login redirect bug", labelSource: "auto" });
+    const first = store.autoNameTerminalSession("session-a", "Fix the login redirect bug");
+    expect(first).toMatchObject({ changed: true, renamed: true });
+    expect(first?.session.label).toBe("Fix the login redirect bug");
+    expect(store.listDurableOperations()[0]).toMatchObject({ label: "Fix the login redirect bug", labelSource: "auto", autoNamePromptSeen: true });
 
-    // 동일 라벨 재요청은 sidebar churn을 막으려 변경 없음(null).
-    expect(store.autoNameTerminalSession("session-a", "Fix the login redirect bug")).toBeNull();
-    // 다른 라벨은 auto 소스이므로 갱신된다.
-    expect(store.autoNameTerminalSession("session-a", "Add the search index")?.label).toBe("Add the search index");
+    // 두 번째 UserPromptSubmit부터는 같은 라벨이든 다른 라벨이든 작전명을 바꾸지 않는다.
+    expect(store.autoNameTerminalSession("session-a", "Fix the login redirect bug")).toMatchObject({ changed: false, renamed: false });
+    expect(store.autoNameTerminalSession("session-a", "Add the search index")).toMatchObject({ changed: false, renamed: false });
+    expect(store.listDurableOperations()[0]?.label).toBe("Fix the login redirect bug");
 
     // 사용자가 수동 rename → labelSource "user" 기록.
     store.renameTerminalSession("session-a", "Bridge Watch");
-    expect(store.listDurableOperations()[0]).toMatchObject({ label: "Bridge Watch", labelSource: "user" });
+    expect(store.listDurableOperations()[0]).toMatchObject({ label: "Bridge Watch", labelSource: "user", autoNamePromptSeen: true });
     // 사용자 라벨은 자동 작명이 절대 덮지 않는다.
-    expect(store.autoNameTerminalSession("session-a", "A brand new prompt topic")).toBeNull();
+    expect(store.autoNameTerminalSession("session-a", "A brand new prompt topic")).toMatchObject({ changed: false, renamed: false });
     expect(store.listDurableOperations()[0]?.label).toBe("Bridge Watch");
 
-    // 빈 rename은 label과 labelSource를 함께 비워 다음 프롬프트부터 자동 작명을 재활성화한다.
+    // 빈 rename은 label, labelSource, first-prompt marker를 함께 비워 다음 최초 프롬프트 자동 작명을 재활성화한다.
     store.renameTerminalSession("session-a", "   ");
     const cleared = store.listDurableOperations()[0];
     expect(cleared?.label).toBeUndefined();
     expect(cleared?.labelSource).toBeUndefined();
-    expect(store.autoNameTerminalSession("session-a", "Re-enabled auto label")?.label).toBe("Re-enabled auto label");
+    expect(cleared?.autoNamePromptSeen).toBeUndefined();
+    expect(store.autoNameTerminalSession("session-a", "Re-enabled auto label")?.session.label).toBe("Re-enabled auto label");
+  });
+
+  it("records a low-signal first user prompt so later prompts cannot auto-name the operation", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-autoname-empty-"));
+    tempDirs.push(dir);
+    const store = createConsoleObservabilityStore();
+    store.createPendingTerminalSession({ sessionId: "session-a", cwd: dir, createdAt: 1_000 });
+
+    expect(store.autoNameTerminalSession("session-a", null)).toMatchObject({ changed: true, renamed: false });
+    expect(store.listDurableOperations()[0]).toMatchObject({ autoNamePromptSeen: true });
+    expect(store.autoNameTerminalSession("session-a", "Add the search index")).toMatchObject({ changed: false, renamed: false });
+    expect(store.listDurableOperations()[0]?.label).toBeUndefined();
   });
 
   it("protects legacy operator labels that predate labelSource from auto-naming", () => {
@@ -257,8 +272,28 @@ describe("console terminal observability", () => {
       createdAt: 1,
     });
     // read-time 해석: label이 있고 labelSource가 없으면 user로 보수 해석 → 자동 작명 차단.
-    expect(store.autoNameTerminalSession("legacy", "New auto topic")).toBeNull();
+    expect(store.autoNameTerminalSession("legacy", "New auto topic")).toMatchObject({ changed: false, renamed: false });
     expect(store.listDurableOperations()[0]?.label).toBe("Operator named");
+  });
+
+  it("treats restored auto labels without a first-prompt marker as already auto-named", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-autoname-legacy-auto-"));
+    tempDirs.push(dir);
+    const store = createConsoleObservabilityStore();
+    store.injectDormantOperation({
+      sessionId: "legacy-auto",
+      theaterId: workspaceHash(fs.realpathSync.native(dir)),
+      cwd: dir,
+      cwdLabel: path.basename(dir),
+      sequence: 1,
+      label: "Existing auto label",
+      labelSource: "auto",
+      autoNamePromptSeen: true,
+      createdAt: 1,
+    });
+
+    expect(store.autoNameTerminalSession("legacy-auto", "New auto topic")).toMatchObject({ changed: false, renamed: false });
+    expect(store.listDurableOperations()[0]).toMatchObject({ label: "Existing auto label", labelSource: "auto", autoNamePromptSeen: true });
   });
 
   it("replays existing observer events over SSE resync", async () => {


### PR DESCRIPTION
## Summary
- Persist a first-prompt marker for Fleet Console Operation auto-naming so later UserPromptSubmit hooks no longer rename the same Operation.
- Backfill existing auto-named durable Operations as already auto-named during restore.
- Add regression coverage for low-signal first prompts, legacy auto labels, manual rename protection, and clearing names to re-enable auto naming.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test -- tests/server.test.ts tests/durable-state.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] Sentinel console-e2e audit
- [x] Isolated Fleet Console e2e: first prompt renames, second prompt does not, restored auto label does not rename, Chrome pageerror count 0

## Changelog
- [x] Added `.changelog.d/20260620050443-operation-auto-name-first-prompt-fixed.md`