### PR TITLE
feat(console): gate Operation launch by CLI install/sign-in state

### DIFF
--- a/.changelog.d/operation-launch-cli-gating-changed.md
+++ b/.changelog.d/operation-launch-cli-gating-changed.md
@@ -1,0 +1,4 @@
+---
+section: Changed
+---
+- [fleet-console] The Operation launch menus now disable an Agent CLI choice when its CLI is not installed, or when a sign-in-gated model is not signed in, labeling each disabled choice with the reason, and the server rejects session-creation requests for those CLIs.

--- a/runtime/fleet-console/client/src/api.ts
+++ b/runtime/fleet-console/client/src/api.ts
@@ -275,10 +275,16 @@ function assertTerminalFolderListEntry(value: unknown, status: number): Terminal
 
 function assertAgentCliMetadata(value: unknown, status: number): AgentCliMetadata {
   const payload = value as Partial<AgentCliMetadata>;
-  if (!payload || typeof payload.id !== "string" || typeof payload.label !== "string") {
+  if (
+    !payload
+    || typeof payload.id !== "string"
+    || typeof payload.label !== "string"
+    || typeof payload.available !== "boolean"
+    || typeof payload.signedIn !== "boolean"
+  ) {
     throw new ApiError(status, "Invalid Agent CLI metadata response");
   }
-  return { id: payload.id, label: payload.label };
+  return { id: payload.id, label: payload.label, available: payload.available, signedIn: payload.signedIn };
 }
 
 function assertObservedTenant(value: unknown, status: number): ObservedTenant {

--- a/runtime/fleet-console/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-context-menu.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 
-import { agentCliIcon } from "../components/operation-launch-menu.js";
+import { agentCliIcon, launchDisabledReason } from "../components/operation-launch-menu.js";
 import type { AgentCliMetadata, ConsoleState } from "../types.js";
 
 interface CanvasContextMenuProps {
@@ -55,20 +55,27 @@ export function CanvasContextMenu({ state, anchor, viewportBounds, onLaunchCli, 
         <p className="canvas-context-menu-group">New Operation</p>
         {state.agentClis.length > 0 ? (
           <ul className="theater-menu-list">
-            {state.agentClis.map((cli) => (
-              <li key={cli.id}>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className="theater-menu-item operation-launch-menu-item"
-                  disabled={launchDisabled}
-                  onClick={() => onLaunchCli(cli)}
-                >
-                  <span className="theater-menu-check" aria-hidden="true">{agentCliIcon(cli.id)}</span>
-                  <span className="theater-menu-label">{cli.label}</span>
-                </button>
-              </li>
-            ))}
+            {state.agentClis.map((cli) => {
+              const reason = launchDisabledReason(cli);
+              const itemDisabled = launchDisabled || reason !== null;
+              return (
+                <li key={cli.id}>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="theater-menu-item operation-launch-menu-item"
+                    disabled={itemDisabled}
+                    aria-disabled={itemDisabled}
+                    title={reason ?? undefined}
+                    onClick={() => { if (reason === null && !launchDisabled) onLaunchCli(cli); }}
+                  >
+                    <span className="theater-menu-check" aria-hidden="true">{agentCliIcon(cli.id)}</span>
+                    <span className="theater-menu-label">{cli.label}</span>
+                    {reason ? <span className="operation-launch-menu-reason">{reason}</span> : null}
+                  </button>
+                </li>
+              );
+            })}
           </ul>
         ) : (
           <p className="theater-menu-empty">No Agent CLI available.</p>

--- a/runtime/fleet-console/client/src/components/operation-launch-menu.tsx
+++ b/runtime/fleet-console/client/src/components/operation-launch-menu.tsx
@@ -61,7 +61,8 @@ export function OperationLaunchMenu({ state, onSelect, mode = DEFAULT_MODE, anch
   };
 
   const handleSelect = async (cli: AgentCliMetadata) => {
-    if (disabled) return;
+    // 전역 비활성(세션 생성 중 등)과 개별 비활성(미설치/미로그인)을 모두 차단한다.
+    if (disabled || launchDisabledReason(cli) !== null) return;
     setOpen(false);
     triggerRef.current?.focus();
     await onSelect(cli);
@@ -105,14 +106,27 @@ export function OperationLaunchMenu({ state, onSelect, mode = DEFAULT_MODE, anch
         <div className="operation-launch-menu theater-menu" role="menu" aria-label="Launch operation" tabIndex={-1} ref={menuRef} onKeyDown={handleMenuKeyDown}>
           {state.agentClis.length > 0 ? (
             <ul className="theater-menu-list">
-              {state.agentClis.map((cli) => (
-                <li key={cli.id}>
-                  <button type="button" role="menuitem" className="theater-menu-item operation-launch-menu-item" disabled={disabled} onClick={() => { void handleSelect(cli); }}>
-                    <span className="theater-menu-check" aria-hidden="true">{agentCliIcon(cli.id)}</span>
-                    <span className="theater-menu-label">{cli.label}</span>
-                  </button>
-                </li>
-              ))}
+              {state.agentClis.map((cli) => {
+                const reason = launchDisabledReason(cli);
+                const itemDisabled = disabled || reason !== null;
+                return (
+                  <li key={cli.id}>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className="theater-menu-item operation-launch-menu-item"
+                      disabled={itemDisabled}
+                      aria-disabled={itemDisabled}
+                      title={reason ?? undefined}
+                      onClick={() => { void handleSelect(cli); }}
+                    >
+                      <span className="theater-menu-check" aria-hidden="true">{agentCliIcon(cli.id)}</span>
+                      <span className="theater-menu-label">{cli.label}</span>
+                      {reason ? <span className="operation-launch-menu-reason">{reason}</span> : null}
+                    </button>
+                  </li>
+                );
+              })}
             </ul>
           ) : (
             <p className="theater-menu-empty">No Agent CLI available.</p>
@@ -121,6 +135,15 @@ export function OperationLaunchMenu({ state, onSelect, mode = DEFAULT_MODE, anch
       ) : null}
     </div>
   );
+}
+
+// 미설치/미로그인 CLI의 비활성 사유. 모든 Operation launch UI(사이드바 메뉴·캔버스 우클릭 메뉴)가
+// 동일 정책을 공유하도록 export한다. null이면 활성(실행 가능).
+export function launchDisabledReason(cli: AgentCliMetadata): string | null {
+  // 비활성 사유 우선순위: 미설치 > 미로그인. 설치돼 있어도 로그인 게이트 대상이면 미로그인을 표시한다.
+  if (!cli.available) return "Not installed";
+  if (!cli.signedIn) return "Sign-in required";
+  return null;
 }
 
 function clampedAnchorStyle(anchor: { readonly x: number; readonly y: number }, bounds: { readonly width: number; readonly height: number } | undefined): { readonly left: number; readonly top: number } {

--- a/runtime/fleet-console/client/src/components/operation-launch-menu.tsx
+++ b/runtime/fleet-console/client/src/components/operation-launch-menu.tsx
@@ -71,7 +71,9 @@ export function OperationLaunchMenu({ state, onSelect, mode = DEFAULT_MODE, anch
   const handleMenuKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
     if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
     event.preventDefault();
-    const items = Array.from(menuRef.current?.querySelectorAll<HTMLElement>("[role^='menuitem']") ?? []);
+    // 비활성(미설치/미로그인) 항목은 roving-focus 대상에서 제외한다. disabled 버튼은 .focus()가 no-op이라
+    // 포함하면 화살표 이동이 비활성 항목에서 멈춰 뒤의 활성 항목에 도달하지 못한다.
+    const items = Array.from(menuRef.current?.querySelectorAll<HTMLElement>("[role^='menuitem']:not(:disabled)") ?? []);
     if (items.length === 0) return;
     const current = items.indexOf(document.activeElement as HTMLElement);
     // 아직 아무 항목도 포커스되지 않았으면(메뉴 컨테이너 포커스 상태) ArrowDown=첫 항목, ArrowUp=마지막 항목.

--- a/runtime/fleet-console/client/src/model-auth-store.ts
+++ b/runtime/fleet-console/client/src/model-auth-store.ts
@@ -1,6 +1,8 @@
 import { useSyncExternalStore } from "react";
 
+import { fetchTheaterBootstrap } from "./api.js";
 import { fetchModelAuthState, signInModelProvider, signOutModelProvider } from "./model-auth-api.js";
+import { hydrateTheaterBootstrap } from "./store.js";
 import type { ModelAuthState } from "./types.js";
 
 interface ModelAuthStoreState {
@@ -51,6 +53,7 @@ export async function signInModel(cli: string, apiKey: string): Promise<boolean>
   try {
     const result = await signInModelProvider(cli, apiKey);
     setSnapshot({ state: result.state, busyCli: null, error: null });
+    await refreshLaunchMetadata();
     return true;
   } catch (error) {
     setSnapshot({ busyCli: null, error: toErrorMessage(error) });
@@ -63,10 +66,22 @@ export async function signOutModel(cli: string): Promise<boolean> {
   try {
     const result = await signOutModelProvider(cli);
     setSnapshot({ state: result.state, busyCli: null, error: null });
+    await refreshLaunchMetadata();
     return true;
   } catch (error) {
     setSnapshot({ busyCli: null, error: toErrorMessage(error) });
     return false;
+  }
+}
+
+// 로그인/로그아웃으로 signedIn이 바뀌면 launch 메뉴의 게이트가 즉시 반영되도록 theater bootstrap을 다시
+// 적재해 state.agentClis를 갱신한다(agentClis는 부트스트랩에서만 채워지므로 갱신하지 않으면 stale해진다).
+// 갱신 실패는 무시한다 — 기존 값이 유지되고 다음 부트스트랩에서 다시 동기화된다.
+async function refreshLaunchMetadata(): Promise<void> {
+  try {
+    hydrateTheaterBootstrap(await fetchTheaterBootstrap());
+  } catch {
+    // no-op
   }
 }
 

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -4267,6 +4267,27 @@
   letter-spacing: 0.04em;
 }
 
+/* 미설치/미로그인 CLI 항목: 흐리게 표시하고 포인터를 막는다. */
+.operation-launch-menu-item:disabled {
+  color: color-mix(in oklch, var(--ink-fog) 45%, transparent);
+  cursor: not-allowed;
+}
+
+.operation-launch-menu-item:disabled .theater-menu-check {
+  color: color-mix(in oklch, var(--brass) 40%, transparent);
+}
+
+/* 비활성 사유(미설치/미로그인)를 항목 우측에 작은 보조 라벨로 표시한다. */
+.operation-launch-menu-reason {
+  margin-left: auto;
+  padding-left: var(--space-2);
+  flex: none;
+  color: color-mix(in oklch, var(--ink-fog) 70%, transparent);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
 .theater-menu-error {
   margin: var(--space-1) 0 0;
   padding: var(--space-1) var(--space-2);

--- a/runtime/fleet-console/client/src/types.ts
+++ b/runtime/fleet-console/client/src/types.ts
@@ -26,6 +26,11 @@ export interface TheaterInfo {
 export interface AgentCliMetadata {
   readonly id: string;
   readonly label: string;
+  // 설치(PATH 탐지) 여부. false면 Operation 생성 메뉴에서 비활성화한다.
+  readonly available: boolean;
+  // 로그인 여부. model-auth 게이트 대상(claude-kimi/glm)만 실제 상태를 반영하고,
+  // 자체 인증 CLI(claude/codex)는 항상 true다. false면 비활성화한다.
+  readonly signedIn: boolean;
 }
 
 export interface TheaterBootstrap {

--- a/runtime/fleet-console/src/agent-cli-detect.ts
+++ b/runtime/fleet-console/src/agent-cli-detect.ts
@@ -33,6 +33,14 @@ const BINARY_DISPLAY_NAMES: Record<string, string> = {
   "cursor-agent": "Cursor Agent",
 };
 
+// cliCommand → launch가 참조하는 바이너리 경로 override 환경변수(fleet-admiral resolveBinary와 동일).
+// claude 계열은 CLAUDE_BIN, codex는 CODEX_BIN을 쓴다. opencode/cursor-agent는 launch override가 없어 PATH로만
+// 해석한다. 이 매핑을 두지 않으면 PATH 밖 절대경로 override 사용자가 미설치로 오판돼 게이트(409)에 막힌다.
+const OVERRIDE_ENV_BY_COMMAND: Record<string, string> = {
+  claude: "CLAUDE_BIN",
+  codex: "CODEX_BIN",
+};
+
 // `--version` 실행 타임아웃(ms). 미설치/무응답이어도 설정 화면 로드를 막지 않도록 짧게 잡는다.
 const VERSION_PROBE_TIMEOUT_MS = 5000;
 
@@ -50,9 +58,20 @@ export function createAgentCliDetector(deps: AgentCliDetectorDeps): AgentCliDete
 
 export function createDefaultAgentCliDetector(): AgentCliDetector {
   return createAgentCliDetector({
-    resolve: (command) => resolvePathBinary(command, process.env),
+    resolve: (command) => resolveCommandWithOverride(command, process.env),
     runVersion: (bin, args) => execFileVersion(bin, args),
   });
+}
+
+// launch의 resolveBinary와 동일한 우선순위(override env → PATH)로 바이너리를 해석한다. override가 설정됐지만
+// 그 경로가 실재하지 않으면 undefined(미설치)로 본다 — launch도 동일 입력에서 실패하므로 게이트 판정이 일치한다.
+function resolveCommandWithOverride(command: string, env: NodeJS.ProcessEnv): ResolvedBinary | undefined {
+  const overrideName = OVERRIDE_ENV_BY_COMMAND[command];
+  const override = overrideName ? env[overrideName] : undefined;
+  if (override && override.trim().length > 0) {
+    return resolvePathBinary(override, env);
+  }
+  return resolvePathBinary(command, env);
 }
 
 // CLI_BACKENDS를 선언 순서 그대로 cliCommand 기준 중복제거한다(claude/codex/opencode/cursor-agent).

--- a/runtime/fleet-console/src/agent-cli-launch-metadata.ts
+++ b/runtime/fleet-console/src/agent-cli-launch-metadata.ts
@@ -1,0 +1,45 @@
+// Operation 생성 메뉴용 Agent CLI 목록에 설치(available)·로그인(signedIn) 상태를 결합하는 순수 로직.
+//
+// 정책을 새로 만들지 않고 기존 SSoT만 합친다: 설치 여부는 cliCommand(바이너리) 기준 탐지 결과로,
+// 로그인 여부는 model-auth provider(cli id) 기준 상태로 매핑한다. available/signedIn은 불린만 노출하며
+// 경로·버전·providerId는 싣지 않는다(Token Boundary). IO(탐지/auth 조회)는 호출자가 수행하고, 이 함수는
+// 결합만 담당하므로 환경에 의존하지 않는 deterministic 단위 테스트가 가능하다.
+
+import { CLI_BACKENDS } from "@dotobokuri/core-unified-agent";
+import type { AgentCliId } from "@dotobokuri/fleet-admiral";
+
+export interface AgentCliLaunchMetadata {
+  readonly id: AgentCliId;
+  readonly label: string;
+  readonly available: boolean;
+  readonly signedIn: boolean;
+}
+
+export interface AgentCliInstallStatus {
+  // 탐지 단위인 바이너리 명령(cliCommand): claude/codex/opencode/cursor-agent.
+  readonly id: string;
+  readonly available: boolean;
+}
+
+export interface AgentCliAuthStatus {
+  readonly cli: string;
+  readonly signedIn: boolean;
+}
+
+export function combineAgentCliLaunchMetadata(
+  metadata: readonly { readonly id: AgentCliId; readonly label: string }[],
+  installStatuses: readonly AgentCliInstallStatus[],
+  authStatuses: readonly AgentCliAuthStatus[],
+): AgentCliLaunchMetadata[] {
+  const availableByCommand = new Map(installStatuses.map((entry) => [entry.id, entry.available]));
+  const signedInByCli = new Map(authStatuses.map((entry) => [entry.cli, entry.signedIn]));
+  return metadata.map((meta) => ({
+    id: meta.id,
+    label: meta.label,
+    // claude 계열 3종은 같은 `claude` 바이너리를 공유하므로 cliCommand로 설치 여부를 판정한다.
+    available: availableByCommand.get(CLI_BACKENDS[meta.id].cliCommand) ?? false,
+    // model-auth 게이트 대상(claude-kimi/glm)만 실제 로그인 상태를 반영하고,
+    // 자체 인증 CLI(claude/codex)는 Fleet이 로그인 여부를 알 수 없으므로 게이트하지 않는다(true).
+    signedIn: signedInByCli.has(meta.id) ? (signedInByCli.get(meta.id) ?? false) : true,
+  }));
+}

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -677,9 +677,10 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   // Operation 생성 메뉴에 내려보낼 Agent CLI 목록에 설치(available)·로그인(signedIn) 상태를 결합한다.
   // IO(탐지/auth 조회)만 여기서 수행하고, 매핑은 순수 함수 combineAgentCliLaunchMetadata에 위임한다.
   async function buildAgentCliLaunchMetadata(): Promise<readonly AgentCliLaunchMetadata[]> {
-    // /model-auth/state와 동일하게 legacy auth를 먼저 마이그레이션한다. legacy(~/.fleet/agent/auth.json)에만
-    // 키가 있는 업그레이드 사용자가 미로그인으로 오판돼 게이트(409)에 막히는 것을 막는다.
-    await migrateLegacyAuthStore();
+    // signedIn은 현재 auth store만 보고 판정한다. legacy(~/.fleet/agent/auth.json) 마이그레이션은 여기서
+    // 의도적으로 하지 않는다 — sign-out 직후 refresh가 이 경로를 호출하므로, 여기서 migrate하면 방금
+    // sign-out으로 현재 store에서 지운 legacy 키가 되살아나 게이트가 다시 열린다(부활). legacy-only 키의
+    // 노출은 /model-auth/state(Settings 진입)의 migrate가 담당하며, 그 SSoT 결함 자체는 별도 후속 사안이다.
     const [detected, modelAuth] = await Promise.all([
       agentCliDetector.detect(),
       buildModelAuthState(infraServices.authService),

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -677,6 +677,13 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   // Operation 생성 메뉴에 내려보낼 Agent CLI 목록에 설치(available)·로그인(signedIn) 상태를 결합한다.
   // IO(탐지/auth 조회)만 여기서 수행하고, 매핑은 순수 함수 combineAgentCliLaunchMetadata에 위임한다.
   async function buildAgentCliLaunchMetadata(): Promise<readonly AgentCliLaunchMetadata[]> {
+    const metadata = getAgentCliMetadata();
+    // FLEET_TERMINAL_CMD operator override가 설정되면 launch는 cliId를 무시하고 그 명령을 실행하므로,
+    // 모든 항목을 실행 가능으로 표시한다. 이렇게 override 처리를 한 곳에 모아 UI 메뉴와 서버 세션 생성
+    // 게이트가 일관되게 우회한다(override 존재 여부만 불린으로 반영하고 명령 값은 노출하지 않는다 — Token Boundary).
+    if ((process.env.FLEET_TERMINAL_CMD ?? "").trim().length > 0) {
+      return metadata.map((meta) => ({ id: meta.id, label: meta.label, available: true, signedIn: true }));
+    }
     // signedIn은 현재 auth store만 보고 판정한다. legacy(~/.fleet/agent/auth.json) 마이그레이션은 여기서
     // 의도적으로 하지 않는다 — sign-out 직후 refresh가 이 경로를 호출하므로, 여기서 migrate하면 방금
     // sign-out으로 현재 store에서 지운 legacy 키가 되살아나 게이트가 다시 열린다(부활). legacy-only 키의
@@ -685,7 +692,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       agentCliDetector.detect(),
       buildModelAuthState(infraServices.authService),
     ]);
-    return combineAgentCliLaunchMetadata(getAgentCliMetadata(), detected, modelAuth.providers);
+    return combineAgentCliLaunchMetadata(metadata, detected, modelAuth.providers);
   }
 
   async function handleObserverTheaters(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
@@ -767,12 +774,10 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   }
 
   async function createTerminalSessionForCwd(cwd: string, res: http.ServerResponse, cliId?: AgentCliId): Promise<void> {
-    // FLEET_TERMINAL_CMD operator override가 설정되면 launch는 cliId를 무시하고 그 명령으로 실행하므로
-    // 설치/로그인 게이트를 건너뛴다 — 게이트가 막아도 override launch는 유효하기 때문이다.
-    const hasTerminalCmdOverride = (process.env.FLEET_TERMINAL_CMD ?? "").trim().length > 0;
-    if (cliId && !hasTerminalCmdOverride) {
-      // UI 비활성화를 API 경계에서도 강제한다: 미설치/미로그인 CLI로의 세션 생성을 거부한다.
-      // launch 직전에 설치/auth를 재조회해 TOCTOU를 줄인다.
+    if (cliId) {
+      // UI 비활성화를 API 경계에서도 강제한다: 미설치/미로그인 CLI로의 세션 생성을 거부한다. launch 직전에
+      // 설치/auth를 재조회해 TOCTOU를 줄인다. FLEET_TERMINAL_CMD override 시에는 buildAgentCliLaunchMetadata가
+      // 모든 항목을 available로 반환하므로 이 게이트를 통과한다(UI와 동일 판정).
       const meta = (await buildAgentCliLaunchMetadata()).find((entry) => entry.id === cliId);
       if (!meta || !meta.available || !meta.signedIn) {
         writeJson(res, 409, { error: "agent_cli_unavailable" });

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -767,7 +767,10 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   }
 
   async function createTerminalSessionForCwd(cwd: string, res: http.ServerResponse, cliId?: AgentCliId): Promise<void> {
-    if (cliId) {
+    // FLEET_TERMINAL_CMD operator override가 설정되면 launch는 cliId를 무시하고 그 명령으로 실행하므로
+    // 설치/로그인 게이트를 건너뛴다 — 게이트가 막아도 override launch는 유효하기 때문이다.
+    const hasTerminalCmdOverride = (process.env.FLEET_TERMINAL_CMD ?? "").trim().length > 0;
+    if (cliId && !hasTerminalCmdOverride) {
       // UI 비활성화를 API 경계에서도 강제한다: 미설치/미로그인 CLI로의 세션 생성을 거부한다.
       // launch 직전에 설치/auth를 재조회해 TOCTOU를 줄인다.
       const meta = (await buildAgentCliLaunchMetadata()).find((entry) => entry.id === cliId);

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -677,6 +677,9 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   // Operation 생성 메뉴에 내려보낼 Agent CLI 목록에 설치(available)·로그인(signedIn) 상태를 결합한다.
   // IO(탐지/auth 조회)만 여기서 수행하고, 매핑은 순수 함수 combineAgentCliLaunchMetadata에 위임한다.
   async function buildAgentCliLaunchMetadata(): Promise<readonly AgentCliLaunchMetadata[]> {
+    // /model-auth/state와 동일하게 legacy auth를 먼저 마이그레이션한다. legacy(~/.fleet/agent/auth.json)에만
+    // 키가 있는 업그레이드 사용자가 미로그인으로 오판돼 게이트(409)에 막히는 것을 막는다.
+    await migrateLegacyAuthStore();
     const [detected, modelAuth] = await Promise.all([
       agentCliDetector.detect(),
       buildModelAuthState(infraServices.authService),

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -29,10 +29,11 @@ import { createCodexGateway } from "./codex/gateway.js";
 import { cleanupProviderSessionCaptures, createConsoleDurableStateStore, emptyDurableConsoleState, mergeProviderSessionCaptures, readProviderSessionCapture, unlinkProviderSessionCapture, type DurableConsoleState, type DurableOperation } from "./durable-state.js";
 import { deriveOperationLabel } from "./auto-name.js";
 import { createGlobalSettingsRouter } from "./global-settings-routes.js";
-import { createDefaultAgentCliDetector } from "./agent-cli-detect.js";
+import { createDefaultAgentCliDetector, type AgentCliDetector } from "./agent-cli-detect.js";
+import { combineAgentCliLaunchMetadata, type AgentCliLaunchMetadata } from "./agent-cli-launch-metadata.js";
 import { createAgentCliRouter } from "./agent-cli-routes.js";
 import { createConsoleLock, type ConsoleLockHandle } from "./lock.js";
-import { createModelAuthRouter } from "./model-auth-routes.js";
+import { buildModelAuthState, createModelAuthRouter } from "./model-auth-routes.js";
 import { writeAggregateObserverEvents, writeObserverEvents } from "./observability-routes.js";
 import { createConsoleDataPaths } from "./paths.js";
 import { readFleetConsoleRelease, type FleetConsoleRelease } from "./release.js";
@@ -60,6 +61,8 @@ export interface ConsoleServerDeps {
   readonly terminalLaunch?: TerminalLaunchResolver;
   readonly terminalLaunchResolverDeps?: Omit<TerminalLaunchResolverDeps, "agentRuntime" | "dataDir" | "infraServices" | "onRuntimeSessionStart">;
   readonly agentRuntime?: FleetAgentRuntimeLifecycle;
+  // Agent CLI 설치 탐지기. 테스트가 환경에 의존하지 않도록 주입할 수 있다(기본: PATH 실측).
+  readonly agentCliDetector?: AgentCliDetector;
   readonly terminalStartShell?: typeof startTerminalShell;
   readonly maxTerminalSessions?: number;
   readonly release?: FleetConsoleRelease;
@@ -213,7 +216,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     readJsonBody,
     writeJson,
   });
-  const agentCliDetector = createDefaultAgentCliDetector();
+  const agentCliDetector = deps.agentCliDetector ?? createDefaultAgentCliDetector();
   const agentCliRouter = createAgentCliRouter({
     detect: agentCliDetector.detect,
     writeJson,
@@ -671,9 +674,19 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     }
   }
 
+  // Operation 생성 메뉴에 내려보낼 Agent CLI 목록에 설치(available)·로그인(signedIn) 상태를 결합한다.
+  // IO(탐지/auth 조회)만 여기서 수행하고, 매핑은 순수 함수 combineAgentCliLaunchMetadata에 위임한다.
+  async function buildAgentCliLaunchMetadata(): Promise<readonly AgentCliLaunchMetadata[]> {
+    const [detected, modelAuth] = await Promise.all([
+      agentCliDetector.detect(),
+      buildModelAuthState(infraServices.authService),
+    ]);
+    return combineAgentCliLaunchMetadata(getAgentCliMetadata(), detected, modelAuth.providers);
+  }
+
   async function handleObserverTheaters(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
     if (req.method === "GET") {
-      writeJson(res, 200, { theaters: listTheaterInfos(), agentClis: getAgentCliMetadata() });
+      writeJson(res, 200, { theaters: listTheaterInfos(), agentClis: await buildAgentCliLaunchMetadata() });
       return;
     }
     if (req.method !== "POST") {
@@ -750,6 +763,15 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   }
 
   async function createTerminalSessionForCwd(cwd: string, res: http.ServerResponse, cliId?: AgentCliId): Promise<void> {
+    if (cliId) {
+      // UI 비활성화를 API 경계에서도 강제한다: 미설치/미로그인 CLI로의 세션 생성을 거부한다.
+      // launch 직전에 설치/auth를 재조회해 TOCTOU를 줄인다.
+      const meta = (await buildAgentCliLaunchMetadata()).find((entry) => entry.id === cliId);
+      if (!meta || !meta.available || !meta.signedIn) {
+        writeJson(res, 409, { error: "agent_cli_unavailable" });
+        return;
+      }
+    }
     const sessionId = crypto.randomUUID();
     const session = observability.createPendingTerminalSession({ sessionId, cwd, cliId });
     try {

--- a/runtime/fleet-console/tests/agent-cli-launch-metadata.test.ts
+++ b/runtime/fleet-console/tests/agent-cli-launch-metadata.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { combineAgentCliLaunchMetadata } from "../src/agent-cli-launch-metadata.js";
+
+const METADATA = [
+  { id: "claude", label: "Claude" },
+  { id: "claude-kimi", label: "Claude Kimi" },
+  { id: "claude-glm", label: "Claude GLM" },
+  { id: "codex", label: "Codex" },
+] as const;
+
+describe("combineAgentCliLaunchMetadata", () => {
+  it("설치된 바이너리와 로그인 게이트를 각 CLI에 결합한다", () => {
+    const result = combineAgentCliLaunchMetadata(
+      METADATA,
+      [
+        { id: "claude", available: true },
+        { id: "codex", available: true },
+      ],
+      [
+        { cli: "claude-kimi", signedIn: true },
+        { cli: "claude-glm", signedIn: false },
+      ],
+    );
+
+    expect(result).toEqual([
+      // 자체 인증 CLI는 게이트하지 않으므로 signedIn=true.
+      { id: "claude", label: "Claude", available: true, signedIn: true },
+      // model-auth 대상은 실제 로그인 상태를 반영한다.
+      { id: "claude-kimi", label: "Claude Kimi", available: true, signedIn: true },
+      { id: "claude-glm", label: "Claude GLM", available: true, signedIn: false },
+      { id: "codex", label: "Codex", available: true, signedIn: true },
+    ]);
+  });
+
+  it("claude 바이너리가 미설치면 claude 계열 3종이 모두 available=false가 된다", () => {
+    const result = combineAgentCliLaunchMetadata(
+      METADATA,
+      [
+        { id: "claude", available: false },
+        { id: "codex", available: true },
+      ],
+      [
+        { cli: "claude-kimi", signedIn: true },
+        { cli: "claude-glm", signedIn: true },
+      ],
+    );
+
+    expect(result.find((cli) => cli.id === "claude")?.available).toBe(false);
+    expect(result.find((cli) => cli.id === "claude-kimi")?.available).toBe(false);
+    expect(result.find((cli) => cli.id === "claude-glm")?.available).toBe(false);
+    expect(result.find((cli) => cli.id === "codex")?.available).toBe(true);
+  });
+
+  it("탐지/auth 입력이 비면 available=false, 게이트 정보가 없으므로 signedIn=true로 둔다", () => {
+    // authStatuses에 들어온 cli만 게이트 대상으로 본다(서버는 buildModelAuthState로 항상 대상 전체를 넘긴다).
+    // 따라서 입력이 비면 어떤 CLI도 게이트하지 않는다.
+    const result = combineAgentCliLaunchMetadata(METADATA, [], []);
+    expect(result.every((cli) => cli.available === false)).toBe(true);
+    expect(result.every((cli) => cli.signedIn === true)).toBe(true);
+  });
+
+  it("게이트 대상이 명시적으로 미로그인이면 signedIn=false가 된다", () => {
+    const result = combineAgentCliLaunchMetadata(
+      METADATA,
+      [{ id: "claude", available: true }],
+      [
+        { cli: "claude-kimi", signedIn: false },
+        { cli: "claude-glm", signedIn: false },
+      ],
+    );
+    expect(result.find((cli) => cli.id === "claude-kimi")?.signedIn).toBe(false);
+    expect(result.find((cli) => cli.id === "claude-glm")?.signedIn).toBe(false);
+    // 게이트 대상이 아닌 claude는 영향받지 않는다.
+    expect(result.find((cli) => cli.id === "claude")?.signedIn).toBe(true);
+  });
+});

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -10,6 +10,7 @@ import type { ConsoleLockPayload } from "../src/api-types.js";
 import { createConsoleLock } from "../src/lock.js";
 import { createConsoleObservabilityStore } from "../src/observability-store.js";
 import { createConsoleServer, type ConsoleServer, type ConsoleServerDeps } from "../src/server.js";
+import type { AgentCliDetector } from "../src/agent-cli-detect.js";
 import { workspaceHash } from "../src/theater.js";
 import { TheaterRegistry } from "../src/theaters.js";
 import { WorkspaceRegistry } from "../src/codex/workspaces.js";
@@ -372,6 +373,24 @@ describe("console terminal observability", () => {
     ]);
     expect(observerJobs.tenants[0]?.jobs[0]?.jobId).toBe("job-a");
   });
+
+  it("rejects a Theater session for a not-installed CLI with 409", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-gate-uninstalled-"));
+    tempDirs.push(dir);
+    const fixture = await startFixture({ agentCliDetector: createStubAgentCliDetector({ claude: false }) });
+    const theater = await createTheater(fixture, dir);
+    const res = await fetch(`${fixture.endpoint}observer/theaters/${encodeURIComponent(theater.id)}/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ cliId: "claude" }),
+    });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "agent_cli_unavailable" });
+  });
+  // 참고: signedIn 게이트의 거부 경로는 위 미설치 테스트가 동일 조건문(!available || !signedIn)을 태워 커버하고,
+  // signedIn=false 판정 자체는 combineAgentCliLaunchMetadata 단위 테스트가 검증한다. signedIn은 글로벌
+  // ~/.fleet/auth.json(authService)에 의존하므로 통합 레벨에서 deterministic하게 만들 별도 주입점이 없어
+  // 환경 의존 테스트를 추가하지 않는다.
 });
 
 describe("console static and terminal ticket boundary", () => {
@@ -1574,12 +1593,18 @@ describe("console static and terminal ticket boundary", () => {
     expect(typeof payload.createdAt).toBe("string");
     expect(typeof payload.lastOpenedAt).toBe("string");
     expect(listed.theaters).toHaveLength(1);
-    expect(listed.agentClis).toEqual([
+    // id/label은 환경 무관하게 고정이지만 available/signedIn은 실제 설치/auth에 의존하므로
+    // 매핑(id/label)만 단언하고 게이트 불린은 타입만 확인한다. 결합 로직은 별도 단위 테스트가 검증한다.
+    expect((listed.agentClis ?? []).map((cli) => ({ id: cli.id, label: cli.label }))).toEqual([
       { id: "claude", label: "Claude" },
       { id: "claude-kimi", label: "Claude Kimi" },
       { id: "claude-glm", label: "Claude GLM" },
       { id: "codex", label: "Codex" },
     ]);
+    for (const cli of listed.agentClis ?? []) {
+      expect(typeof cli.available).toBe("boolean");
+      expect(typeof cli.signedIn).toBe("boolean");
+    }
     expect(payload).not.toHaveProperty("path");
     expect(listed.theaters[0]).not.toHaveProperty("path");
     expect(serialized).not.toContain(dir);
@@ -2029,6 +2054,7 @@ describe("observer theater forget", () => {
 
 async function startFixture(options: {
   readonly agentRuntime?: ConsoleServerDeps["agentRuntime"];
+  readonly agentCliDetector?: ConsoleServerDeps["agentCliDetector"];
   readonly beforeCreateServer?: (paths: { readonly carrierStoreDir: string }) => void;
   readonly terminalLaunch?: ConsoleServerDeps["terminalLaunch"];
   readonly terminalLaunchResolverDeps?: ConsoleServerDeps["terminalLaunchResolverDeps"];
@@ -2047,6 +2073,9 @@ async function startFixture(options: {
     port: 0,
     version: "test",
     agentRuntime: options.agentRuntime,
+    // 기본은 4개 바이너리 모두 설치된 것으로 stub해 기존 테스트(claude/codex 세션)가 PATH 환경에
+    // 의존하지 않게 한다. 게이트 거부 케이스는 개별 테스트가 overrides로 미설치를 주입한다.
+    agentCliDetector: options.agentCliDetector ?? createStubAgentCliDetector(),
     dataDir: carrierStoreDir,
     terminalLaunch: options.terminalLaunch,
     terminalLaunchResolverDeps: options.terminalLaunchResolverDeps,
@@ -2059,6 +2088,19 @@ async function startFixture(options: {
   const endpoint = await server.start({ dir, lockFile });
   const lock = createConsoleLock().readLock(lockFile)!;
   return { dir, carrierStoreDir, lockFile, server, endpoint, lock };
+}
+
+function createStubAgentCliDetector(overrides: Record<string, boolean> = {}): AgentCliDetector {
+  // cliCommand 단위 바이너리(claude/codex/opencode/cursor-agent)별 설치 여부를 stub한다. 기본 모두 설치됨.
+  const commands = ["claude", "codex", "opencode", "cursor-agent"];
+  return {
+    detect: async () => commands.map((id) => ({
+      id,
+      displayName: id,
+      available: overrides[id] ?? true,
+      version: null,
+    })),
+  };
 }
 
 async function createTerminalSession(fixture: ServerFixture, headers: Record<string, string>, cwd: string): Promise<{ readonly sessionId: string }> {


### PR DESCRIPTION
## Summary
- Operation 생성 런치 메뉴(사이드바·캔버스 우클릭)에서 미설치 또는 미로그인 상태의 Agent CLI 항목을 비활성화하고, 비활성 사유("Not installed" / "Sign-in required")를 라벨로 표시합니다.
- 비활성 사유 정책을 공용 helper(`launchDisabledReason`)로 분리해 모든 런치 UI가 동일 게이트를 공유합니다(SSoT).
- 서버 세션 생성 경로(`/observer/theaters/:id/sessions`, folder-grant 세션)도 미설치/미로그인 CLI 요청을 409로 거부해 API 경계에서 정책을 강제합니다.
- 설치(detect)·로그인(model-auth) 상태 결합을 순수 함수 `combineAgentCliLaunchMetadata`로 분리하고, CLI detector를 주입 가능하게 하여 서버 테스트를 환경 비의존으로 유지합니다. `available`/`signedIn`은 boolean만 노출합니다(Token Boundary).

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (414 passed)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`

## Changelog
- [x] `.changelog.d/operation-launch-cli-gating-changed.md` 포함 (`section: Changed`, `[fleet-console]`)