### PR TITLE
fix(console): align Operations terminal cursor with map zoom

### DIFF
--- a/.changelog.d/map-zoom-terminal-cursor-fixed.md
+++ b/.changelog.d/map-zoom-terminal-cursor-fixed.md
@@ -1,0 +1,4 @@
+---
+section: Fixed
+---
+- [fleet-console] Mouse clicks and drag selections inside an Operations Map terminal now land on the correct cell after zooming the map in or out, instead of being offset until the view was reset.

--- a/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
@@ -239,7 +239,7 @@ export function CanvasPanel({ state, session, geometry, viewport, active }: Canv
             <span className="canvas-panel-dormant-action">Resume</span>
           </button>
         ) : (
-          <Terminal sessionId={session.sessionId} active={active} onExit={() => removeTerminalSession(session.sessionId)} />
+          <Terminal sessionId={session.sessionId} active={active} zoom={viewport.zoom} onExit={() => removeTerminalSession(session.sessionId)} />
         )}
       </div>
       <PanelResizeHandles geometry={geometry} zoom={viewport.zoom} onResize={(nextGeometry) => setPanelGeometry(session.sessionId, nextGeometry)} />

--- a/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
@@ -120,7 +120,7 @@ export function ShellCanvasPanel({ id, theaterId, geometry, viewport, active }: 
         </button>
       </div>
       <div className="canvas-panel-terminal" onPointerDown={stopCanvasPointer} onWheel={stopCanvasWheel} data-canvas-blocker>
-        <Terminal sessionId={id} kind="shell" theaterId={theaterId} active={active} onExit={() => removeShellPanel(id)} />
+        <Terminal sessionId={id} kind="shell" theaterId={theaterId} active={active} zoom={viewport.zoom} onExit={() => removeShellPanel(id)} />
       </div>
       <PanelResizeHandles geometry={geometry} zoom={viewport.zoom} onResize={(next) => setShellPanelGeometry(id, next)} />
     </article>

--- a/runtime/fleet-console/client/src/components/terminal.tsx
+++ b/runtime/fleet-console/client/src/components/terminal.tsx
@@ -4,7 +4,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal as XtermTerminal, type ITheme } from "@xterm/xterm";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 
 import { useConsoleState } from "../hooks/use-store.js";
 import { createTerminalConnection, type TerminalConnection } from "../terminal-connection.js";
@@ -18,7 +18,16 @@ interface TerminalProps {
   readonly onExit?: () => void;
   // 이 터미널이 활성(선택)으로 전환될 때 마우스 클릭 없이 키보드 포커스를 잡아준다(Map 검색 이동 등).
   readonly active?: boolean;
+  // 맵 캔버스의 줌 배율(viewport.zoom). 캔버스 외(classic/overlay) 사용처는 기본 1.
+  // 캔버스가 부모에 transform:scale(zoom)을 걸면 xterm의 마우스 셀 좌표 계산이 scale을 보정하지 못해
+  // zoom≠1에서 커서/선택 위치가 어긋난다(분자=scale 반영 화면거리, 분모=scale 미반영 cellWidth). 이를
+  // 터미널 마운트 단의 역스케일(scale(1/zoom)) + fontSize×zoom으로 net scale=1을 만들어 좌표를 정정한다.
+  readonly zoom?: number;
 }
+
+// 기본 폰트 크기(CSS px). 맵 줌 보정 시 fontSize = BASE_FONT_SIZE × zoom으로 키워, 부모 scale(zoom)과
+// 합쳐도 painted 글자 크기가 동일하게 유지되고(=base×parentZoom) xterm 좌표 분모(cellWidth)가 분자 단위와 맞는다.
+const BASE_FONT_SIZE = 14;
 
 const TERMINAL_OPTIONS = {
   // Unicode11Addon은 terminal.unicode(proposed API)를 사용하므로 이 옵션이 true여야 한다.
@@ -28,11 +37,15 @@ const TERMINAL_OPTIONS = {
   cursorBlink: true,
   cursorStyle: "block" as const,
   fontFamily: "\"Cascadia Code\", \"Cascadia Mono\", \"JetBrains Mono Variable\", ui-monospace, \"SF Mono\", Menlo, monospace",
-  fontSize: 14,
+  fontSize: BASE_FONT_SIZE,
   lineHeight: 1.2,
 };
 
 const RESIZE_DEBOUNCE_MS = 80;
+// 줌 보간(rAF tween)이 멈춘 뒤 보정을 1회만 적용하기 위한 디바운스. zoom prop은 보간 중 매 프레임 바뀌므로,
+// 마지막 변경 후 이 시간이 지나야(=settle) counter-scale/fontSize/fit을 적용한다. 보간 중에는 부모 transform에
+// 맡겨 글자가 부드럽게 확대/축소되고, atlas 재생성을 제스처당 1회로 묶어 WebGL 비용을 억제한다.
+const ZOOM_SETTLE_MS = 120;
 
 const MARITIME_TERMINAL_THEME: ITheme = {
   background: "oklch(23% 0.03 248)",
@@ -80,12 +93,17 @@ const CARBON_TERMINAL_THEME: ITheme = {
   brightWhite: "oklch(95% 0.003 250)",
 };
 
-export function Terminal({ sessionId, kind, theaterId, onExit, active }: TerminalProps) {
+export function Terminal({ sessionId, kind, theaterId, onExit, active, zoom = 1 }: TerminalProps) {
   const { activeTheme, terminalRenderer } = useConsoleState();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const terminalRef = useRef<XtermTerminal | null>(null);
   const connectionRef = useRef<TerminalConnection | null>(null);
   const webglAddonRef = useRef<WebglAddon | null>(null);
+  // 줌 보정 effect에서 fit()을 재호출하기 위해 마운트 effect의 지역 FitAddon을 ref로 끌어올린다.
+  const fitAddonRef = useRef<FitAddon | null>(null);
+  // 실제 보정에 반영된 줌(=settle된 zoom). zoom prop은 보간 중 매 프레임 바뀌므로 디바운스로 이 값에 수렴시킨다.
+  // 초기값을 zoom으로 두어 이미 확대된 패널이 마운트될 때 첫 렌더부터 올바른 스타일을 갖게 한다.
+  const [appliedZoom, setAppliedZoom] = useState(zoom);
   // onExit는 매 렌더 새 함수일 수 있으므로 ref로 고정해 connection effect의 의존성에서 제외한다.
   const onExitRef = useRef(onExit);
   onExitRef.current = onExit;
@@ -102,6 +120,7 @@ export function Terminal({ sessionId, kind, theaterId, onExit, active }: Termina
     const terminal = new XtermTerminal({ ...TERMINAL_OPTIONS, theme: terminalThemeFor(activeTheme) });
     terminalRef.current = terminal;
     const fitAddon = new FitAddon();
+    fitAddonRef.current = fitAddon;
     terminal.loadAddon(fitAddon);
     terminal.open(container);
     terminal.loadAddon(new Unicode11Addon());
@@ -173,6 +192,7 @@ export function Terminal({ sessionId, kind, theaterId, onExit, active }: Termina
       connection.dispose();
       terminalRef.current = null;
       connectionRef.current = null;
+      fitAddonRef.current = null;
       // xterm WebglAddon(0.19.0)은 terminal.dispose() 시 AddonManager가 addon을 자동 정리하는
       // 경로에 내부 버그가 있어 TypeError(reading "_isDisposed")를 던질 수 있다. 이 예외가
       // useEffect cleanup 밖으로 전파되면 error boundary가 없는 React 트리가 통째로 언마운트되어
@@ -246,9 +266,44 @@ export function Terminal({ sessionId, kind, theaterId, onExit, active }: Termina
     terminal.options.theme = terminalThemeFor(activeTheme);
   }, [activeTheme]);
 
+  // 줌 settle 감지: zoom prop은 rAF 보간 중 매 프레임 바뀌므로, 마지막 변경 후 ZOOM_SETTLE_MS가 지나야
+  // appliedZoom에 반영한다(타이머가 매 변경마다 리셋됨). 보간 중에는 부모 transform에 맡겨 글자가 부드럽게
+  // 확대/축소되고, 보정(아래 effect)은 제스처당 1회만 발생한다.
+  useEffect(() => {
+    if (zoom === appliedZoom) return;
+    const timer = setTimeout(() => setAppliedZoom(zoom), ZOOM_SETTLE_MS);
+    return () => clearTimeout(timer);
+  }, [zoom, appliedZoom]);
+
+  // appliedZoom 반영: 마운트 단(.terminal-canvas)의 역스케일은 인라인 style(아래 zoomStyle)로 선언적으로
+  // 적용되고, 여기서는 fontSize×zoom과 1회 refit만 명령형으로 수행한다. fontSize를 zoom배로 키워 부모
+  // scale(zoom)과 합쳐도 painted 글자 크기가 동일하고(=base×parentZoom), cols/rows는 zoom에 불변이라
+  // 그리드/픽셀 외형은 그대로 유지되며 xterm 좌표만 정정된다.
+  useEffect(() => {
+    const terminal = terminalRef.current;
+    const fitAddon = fitAddonRef.current;
+    if (!terminal || !fitAddon) return;
+    terminal.options.fontSize = BASE_FONT_SIZE * appliedZoom;
+    // fontSize 변경 후 WebGL 글리프 atlas를 선제 무효화해 첫 프레임 깜빡임을 결정적으로 제거한다(DOM 렌더러는 무관).
+    webglAddonRef.current?.clearTextureAtlas();
+    fitAddon.fit();
+    terminal.refresh(0, terminal.rows - 1);
+  }, [appliedZoom]);
+
   // 연결이 'live'면 상태 바를 숨겨 터미널 canvas가 카드를 가득 채우게 하고,
   // connecting/error 등 문제 상황에서만 상태를 노출한다.
   const isLive = status.startsWith("live");
+  // 줌 보정: 마운트 단을 레이아웃상 zoom배로 키운 뒤 scale(1/zoom)으로 되돌려 부모 scale(zoom)과 net 1로 상쇄한다.
+  // %는 position:relative인 .terminal-viewport 기준이라 별도 측정 없이 inner 크기에 정확히 맞춰진다. zoom=1이면
+  // 기본 스타일(.terminal-canvas의 inset:0)을 그대로 써 캔버스 외 사용처(classic/overlay)에 영향이 없다.
+  const zoomStyle: CSSProperties | undefined = appliedZoom === 1
+    ? undefined
+    : {
+        width: `${appliedZoom * 100}%`,
+        height: `${appliedZoom * 100}%`,
+        transform: `scale(${1 / appliedZoom})`,
+        transformOrigin: "0 0",
+      };
 
   return (
     <section className="terminal-stage" aria-label={kind === "shell" ? "Shell terminal" : "Fleet terminal"}>
@@ -259,7 +314,9 @@ export function Terminal({ sessionId, kind, theaterId, onExit, active }: Termina
             {status}
           </div>
         ) : null}
-        <div className="terminal-canvas" ref={containerRef} />
+        <div className="terminal-viewport">
+          <div className="terminal-canvas" ref={containerRef} style={zoomStyle} />
+        </div>
       </div>
     </section>
   );

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -4814,9 +4814,20 @@
   background: var(--warn);
 }
 
-.terminal-canvas {
+/* 줌 보정 레이어: position:relative 기준 박스를 제공해 .terminal-canvas의 역스케일(%-기반)이
+   측정 없이 inner 크기에 정확히 맞도록 한다. flex:1로 상태바 아래 남는 공간을 채운다. */
+.terminal-viewport {
+  position: relative;
   flex: 1;
+  min-width: 0;
   min-height: 0;
+}
+
+/* xterm 마운트 단. 기본은 viewport를 가득 채우고(inset:0), 맵 줌 시 인라인 style로 width/height를 zoom배 +
+   transform:scale(1/zoom)을 받아 부모 scale(zoom)과 net 1로 상쇄된다(좌표 정정). transform-origin은 인라인에서 지정. */
+.terminal-canvas {
+  position: absolute;
+  inset: 0;
   border-radius: var(--radius-md);
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- 맵 모드에서 줌 인/아웃 후 패널 터미널에 마우스 클릭·드래그 선택 시 커서 위치가 어긋나던 문제를 수정합니다(Reset View 시에만 정상이던 증상).
- 원인: 캔버스 줌은 `.operations-canvas-world`의 `transform: scale(zoom)`인데, xterm의 셀 좌표 계산은 scale 반영된 `getBoundingClientRect`(분자)를 scale 미반영 `cellWidth`(분모)로 나눠 zoom 배수만큼 어긋남.
- 해결: 터미널 마운트 단을 `scale(1/zoom)` + `fontSize × zoom`으로 역보정해 xterm을 net scale=1에서 동작시킵니다. 보정은 줌 보간이 멈춘 뒤(debounce settle) 1회만 적용해 WebGL atlas 재생성을 제스처당 1회로 억제합니다. painted 글자 크기·열 수는 동일하게 유지되어 외형은 그대로이고 좌표만 정정됩니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (416 passed)
- [x] 실브라우저(playwriter): world `scale(2)`에서 `.xterm-screen` net scale = **1.0** (미수정 시 2.0), painted 폭 608→1221(2×) 확대·열 수 불변, `.terminal-canvas` painted == `.terminal-viewport`(클리핑 없음), pageerror 0
- [x] 대원수 수동 실측 완료

## Changelog
- [x] `.changelog.d/map-zoom-terminal-cursor-fixed.md` 포함 (section: Fixed, `[fleet-console]`)