### PR TITLE
fix(fleet-console): suppress idle awaiting-orders toast during dispatch

### DIFF
--- a/.changelog.d/attention-toast-idle-suppression-fixed.md
+++ b/.changelog.d/attention-toast-idle-suppression-fixed.md
@@ -1,0 +1,4 @@
+---
+section: Fixed
+---
+- [fleet-console] Stopped a carrier-dispatch idle pause from raising a false "Awaiting orders" notification while the dispatched carrier job is still running; genuine input-waiting prompts (permission requests, questions, elicitation dialogs) still notify as before.

--- a/runtime/fleet-console/client/src/connection.ts
+++ b/runtime/fleet-console/client/src/connection.ts
@@ -77,7 +77,7 @@ async function consumeStream(
         continue;
       }
       if (interpreted.kind === "attention" && interpreted.session) {
-        applySessionAttention(interpreted.session);
+        applySessionAttention(interpreted.session, interpreted.reason);
         continue;
       }
       if (interpreted.event) {

--- a/runtime/fleet-console/client/src/sse.ts
+++ b/runtime/fleet-console/client/src/sse.ts
@@ -1,4 +1,4 @@
-import type { ObservedEvent, ObserverTruncation, SessionInfo } from "./types.js";
+import type { AttentionReason, ObservedEvent, ObserverTruncation, SessionInfo } from "./types.js";
 
 export interface SseFrame {
   readonly event: string;
@@ -12,6 +12,7 @@ export interface ObserverFrame {
   readonly event?: ObservedEvent;
   readonly truncation?: ObserverTruncation;
   readonly session?: SessionInfo;
+  readonly reason?: AttentionReason;
 }
 
 interface AggregateFramePayload {
@@ -19,7 +20,17 @@ interface AggregateFramePayload {
   readonly event?: Partial<ObservedEvent>;
   readonly truncation?: ObserverTruncation;
   readonly session?: Partial<SessionInfo>;
+  readonly reason?: unknown;
 }
+
+const ATTENTION_REASONS: ReadonlySet<AttentionReason> = new Set([
+  "idle_prompt",
+  "permission_prompt",
+  "auth_success",
+  "elicitation_dialog",
+  "elicitation_complete",
+  "elicitation_response",
+]);
 
 /** SSE 바이트 스트림을 프레임 단위로 잘라내는 증분 파서. */
 export function createSseFrameParser(): (chunk: string) => readonly SseFrame[] {
@@ -61,7 +72,7 @@ export function interpretObserverFrame(frame: SseFrame): ObserverFrame | null {
   if (frame.event === "session:attention") {
     const session = readSessionInfo(parsed.session);
     if (!session) return null;
-    return { kind: "attention", tenantId: session.tenantId ?? session.sessionId, session };
+    return { kind: "attention", tenantId: session.tenantId ?? session.sessionId, session, reason: readAttentionReason(parsed.reason) };
   }
   const event = readObservedEvent(parsed.event) ?? readObservedEvent(parsed);
   if (!event) return null;
@@ -132,4 +143,10 @@ function readSessionInfo(value: unknown): SessionInfo | null {
     registrationId: typeof session.registrationId === "string" ? session.registrationId : undefined,
     resumeAvailable: session.resumeAvailable === true,
   };
+}
+
+function readAttentionReason(value: unknown): AttentionReason | undefined {
+  return typeof value === "string" && ATTENTION_REASONS.has(value as AttentionReason)
+    ? (value as AttentionReason)
+    : undefined;
 }

--- a/runtime/fleet-console/client/src/store.ts
+++ b/runtime/fleet-console/client/src/store.ts
@@ -3,6 +3,7 @@ import { sessionDisplayLabel } from "./format.js";
 import { buildOperationSearchEntries } from "./operation-search.js";
 import { clearStoredShellPanelsForTheater } from "./canvas/shell-panels.js";
 import type {
+  AttentionReason,
   ConsoleState,
   JobView,
   ObservedEvent,
@@ -292,12 +293,16 @@ export function applySessionUpdate(session: SessionInput): void {
 
 // 입력 대기(AskUserQuestion·권한/유휴/elicitation) 1회성 신호. 세션 상태는 갱신하지 않고,
 // 현재 보고 있지 않은 Operation에 한해 입력 대기 토스트만 띄운다(현재 보는 Operation은 억제).
-export function applySessionAttention(session: SessionInput): void {
+export function applySessionAttention(session: SessionInput, reason?: AttentionReason): void {
   const target = state.sessions[session.sessionId] ?? normalizeSession(session);
   // Operations 뷰가 화면에 떠 있고(=/operations) 그 Operation을 실제로 보고 있을 때만 억제한다.
   // Welcome·Codex 등 다른 화면에선 어떤 Operation도 보이지 않으므로 백그라운드 입력 대기를 반드시 알린다
   // (라우트 전이가 activeTerminalSessionId를 비우지 않아 isActiveOperation만으로는 화면 밖을 구분 못 한다).
   if (state.operationsViewActive && isActiveOperation(target)) return;
+  // 캐리어 출격 중(미완료 job 존재)의 idle_prompt는 입력 대기가 아니라 비동기 작업 대기다 —
+  // ended 경로(buildTurnTransitionToasts)와 동일 근거로 억제한다. 권한 요청·AskUserQuestion·elicitation
+  // (또는 reason 부재)은 출격 중에도 실제 입력 대기이므로 알림을 유지한다.
+  if (reason === "idle_prompt" && hasActiveCarrierJob(target)) return;
   // AskUserQuestion은 PreToolUse와 Notification을 함께 발화할 수 있고 입력 대기가 반복 알림될 수도 있다.
   // 같은 세션의 입력 대기 토스트가 아직 떠 있으면 중복 발행하지 않는다(닫히면 다음 대기 때 다시 뜬다).
   if (state.operationToasts.some((toast) => toast.kind === "input-waiting" && toast.sessionId === session.sessionId)) return;

--- a/runtime/fleet-console/client/src/types.ts
+++ b/runtime/fleet-console/client/src/types.ts
@@ -277,6 +277,16 @@ export interface TenantJobsView {
 
 export type ConnectionState = "connecting" | "live";
 
+// Notification hook의 notification_type 신호. idle_prompt만 캐리어 출격 중 억제 대상이고,
+// 권한 요청·elicitation 등과 부재(예: AskUserQuestion=PreToolUse)는 실제 입력 대기로 간주해 알림을 유지한다.
+export type AttentionReason =
+  | "idle_prompt"
+  | "permission_prompt"
+  | "auth_success"
+  | "elicitation_dialog"
+  | "elicitation_complete"
+  | "elicitation_response";
+
 // Operation 상태 전이/입력 대기 알림 토스트. kind는 인디케이터 상태에 대응:
 //   ended=작업 완료(턴 종료, 그린) · input-waiting=입력 대기(AskUserQuestion·권한/유휴/elicitation, amber).
 export type OperationToastKind = "ended" | "input-waiting";

--- a/runtime/fleet-console/src/api-types.ts
+++ b/runtime/fleet-console/src/api-types.ts
@@ -114,11 +114,22 @@ export interface ConsoleSessionUpdatedEvent {
   readonly session: ConsoleTerminalSessionInfo;
 }
 
+// Notification hook의 notification_type. idle_prompt만 캐리어 출격 중 억제 대상이고,
+// 권한 요청·elicitation 등과 부재(예: AskUserQuestion=PreToolUse)는 실제 입력 대기로 간주한다.
+export type ConsoleAttentionReason =
+  | "idle_prompt"
+  | "permission_prompt"
+  | "auth_success"
+  | "elicitation_dialog"
+  | "elicitation_complete"
+  | "elicitation_response";
+
 // Agent CLI가 사용자 입력을 기다리며 중단된 transient 신호(턴 상태는 "running" 유지). session:updated와 달리
-// 세션 메타를 갱신하지 않고 1회성 알림만 흘린다.
+// 세션 메타를 갱신하지 않고 1회성 알림만 흘린다. reason은 출격 중 오탐(idle_prompt)을 구분하기 위한 신호다.
 export interface ConsoleSessionAttentionEvent {
   readonly type: "session:attention";
   readonly session: ConsoleTerminalSessionInfo;
+  readonly reason?: ConsoleAttentionReason;
 }
 
 export interface TerminalFolderListEntry {

--- a/runtime/fleet-console/src/attention-hook.ts
+++ b/runtime/fleet-console/src/attention-hook.ts
@@ -1,14 +1,28 @@
 import process from "node:process";
 
+import type { ConsoleAttentionReason } from "./api-types.js";
 import { createConsoleLock } from "./lock.js";
 import { createConsolePaths } from "./paths.js";
 
 export interface AttentionHookOptions {
   readonly fetchImpl?: typeof fetch;
   readonly timeoutMs?: number;
+  readonly stdin?: NodeJS.ReadableStream;
+  readonly stdinTimeoutMs?: number;
 }
 
 const ATTENTION_POST_TIMEOUT_MS = 1500;
+const ATTENTION_STDIN_TIMEOUT_MS = 500;
+// Claude Notification hook의 notification_type 값. 이 집합 밖(예: AskUserQuestion=PreToolUse는 필드 자체가 없음)은
+// reason 없이 흘려, 클라이언트가 실제 입력 대기로 처리하게 한다. 임의 문자열이 브라우저로 새는 것도 막는다.
+const ATTENTION_REASONS: ReadonlySet<ConsoleAttentionReason> = new Set([
+  "idle_prompt",
+  "permission_prompt",
+  "auth_success",
+  "elicitation_dialog",
+  "elicitation_complete",
+  "elicitation_response",
+]);
 
 export async function runAttentionHook(
   env: NodeJS.ProcessEnv = process.env,
@@ -23,12 +37,63 @@ export async function runAttentionHook(
   }
 }
 
-async function postAttention(env: NodeJS.ProcessEnv, options: AttentionHookOptions): Promise<void> {
+// hook stdin(JSON)의 notification_type을 알려진 reason으로 정규화한다. 알 수 없거나 부재면 undefined.
+// server 수신부와 동일 정규화를 공유해 임의 문자열이 브라우저 페이로드로 새지 않게 한다.
+export function normalizeAttentionReason(value: unknown): ConsoleAttentionReason | undefined {
+  return typeof value === "string" && ATTENTION_REASONS.has(value as ConsoleAttentionReason)
+    ? (value as ConsoleAttentionReason)
+    : undefined;
+}
+
+async function readHookReason(options: AttentionHookOptions): Promise<ConsoleAttentionReason | undefined> {
+  const stream = options.stdin ?? process.stdin;
+  const raw = await readHookStdin(stream, options.stdinTimeoutMs ?? ATTENTION_STDIN_TIMEOUT_MS);
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as { readonly notification_type?: unknown };
+    return normalizeAttentionReason(parsed?.notification_type);
+  } catch {
+    return undefined;
+  }
+}
+
+async function readHookStdin(stream: NodeJS.ReadableStream, timeoutMs: number): Promise<string> {
+  // hook stdin은 Claude가 JSON을 쓰고 닫는다(EOF). best-effort: 미연결·무종료 stdin에서 hang하지 않도록 짧게 가드한다.
+  return await new Promise<string>((resolve) => {
+    const chunks: Buffer[] = [];
+    let settled = false;
+    const finish = (value: string): void => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    const timer = setTimeout(() => finish(""), timeoutMs);
+    if (typeof timer.unref === "function") timer.unref();
+    stream.on("data", (chunk: Buffer | string) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    stream.on("end", () => {
+      clearTimeout(timer);
+      finish(Buffer.concat(chunks).toString("utf8"));
+    });
+    stream.on("error", () => {
+      clearTimeout(timer);
+      finish("");
+    });
+  });
+}
+
+async function postAttention(
+  env: NodeJS.ProcessEnv,
+  options: AttentionHookOptions,
+): Promise<void> {
   const sessionId = env.FLEET_CONSOLE_SESSION_ID;
   if (!sessionId) return;
   const paths = createConsolePaths({ env });
   const lock = createConsoleLock().readLock(paths.lockFile);
   if (!lock) return;
+  // 세션·락 확인 뒤에야 stdin을 읽는다 — early-return 경로에서 불필요하게 stdin을 건드리지 않는다.
+  const reason = await readHookReason(options);
   const fetchImpl = options.fetchImpl ?? fetch;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), options.timeoutMs ?? ATTENTION_POST_TIMEOUT_MS);
@@ -39,7 +104,7 @@ async function postAttention(env: NodeJS.ProcessEnv, options: AttentionHookOptio
         authorization: `Bearer ${lock.token}`,
         "content-type": "application/json",
       },
-      body: JSON.stringify({}),
+      body: JSON.stringify(reason ? { reason } : {}),
       signal: controller.signal,
     });
   } finally {

--- a/runtime/fleet-console/src/observability-routes.ts
+++ b/runtime/fleet-console/src/observability-routes.ts
@@ -61,9 +61,13 @@ export function writeAggregateObserverEvents(
   const unsubscribers = options.subscribeAll
     ? [
       store.subscribeAll((event) => {
-        // session:updated·session:attention은 동일하게 { session }만 직렬화한다(event.type이 식별자).
-        if (isSessionUpdatedEvent(event) || isSessionAttentionEvent(event)) {
+        // session:updated는 { session }만, session:attention은 reason까지 직렬화한다(event.type이 식별자).
+        if (isSessionUpdatedEvent(event)) {
           writeEvent(res, 0, event.type, { session: event.session });
+          return;
+        }
+        if (isSessionAttentionEvent(event)) {
+          writeEvent(res, 0, event.type, { session: event.session, reason: event.reason });
           return;
         }
         writeEvent(res, event.id, event.type, { tenant: resolvedWorkspaceSnapshot(resolveWorkspace, event.tenantId), event });

--- a/runtime/fleet-console/src/observability-store.ts
+++ b/runtime/fleet-console/src/observability-store.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 
 import type {
+  ConsoleAttentionReason,
   ConsoleObservedEvent,
   ConsoleObservedJob,
   ConsoleObservedWorkspace,
@@ -353,8 +354,8 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
     return session ? toTerminalSessionInfo(session) : null;
   }
 
-  function notifySessionAttention(session: ConsoleTerminalSessionInfo): void {
-    const event: ConsoleSessionAttentionEvent = { type: "session:attention", session };
+  function notifySessionAttention(session: ConsoleTerminalSessionInfo, reason?: ConsoleAttentionReason): void {
+    const event: ConsoleSessionAttentionEvent = { type: "session:attention", session, reason };
     // 입력 대기 알림은 1회성 신호다. session:updated와 같은 aggregate 경로로 흘리되 세션 메타는 갱신하지 않는다.
     for (const listener of allListeners) listener(event);
   }

--- a/runtime/fleet-console/src/server.ts
+++ b/runtime/fleet-console/src/server.ts
@@ -24,6 +24,7 @@ import { resolveAuthEnv, validateAuthKeyForCli } from "@dotobokuri/fleet-infra/a
 import { getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
 
 import type { ConsoleCarrierReadinessEntry, ConsoleHealth, ConsoleObservedWorkspace, ConsoleObserverStatus, ConsoleTheaterInfo, ConsoleUpdateApplyAcceptedResponse, TerminalFolderListResponse } from "./api-types.js";
+import { normalizeAttentionReason } from "./attention-hook.js";
 import { createCarrierSettingsRouter } from "./carrier-settings-routes.js";
 import { createCodexGateway } from "./codex/gateway.js";
 import { cleanupProviderSessionCaptures, createConsoleDurableStateStore, emptyDurableConsoleState, mergeProviderSessionCaptures, readProviderSessionCapture, unlinkProviderSessionCapture, type DurableConsoleState, type DurableOperation } from "./durable-state.js";
@@ -409,7 +410,10 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       writeJson(res, 404, { error: "terminal_session_not_found" });
       return;
     }
-    observability.notifySessionAttention(session);
+    // hook이 실은 reason(notification_type)을 best-effort로 동봉한다. 부재/미상은 undefined로 두어
+    // 클라이언트가 실제 입력 대기로 처리하게 한다(idle_prompt만 출격 중 억제 대상).
+    const body = await readJsonBody<{ readonly reason?: unknown }>(req);
+    observability.notifySessionAttention(session, normalizeAttentionReason(body?.reason));
     writeJson(res, 200, { ok: true });
   }
 

--- a/runtime/fleet-console/tests/attention-hook.test.ts
+++ b/runtime/fleet-console/tests/attention-hook.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Readable } from "node:stream";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -57,7 +58,7 @@ describe("runAttentionHook", () => {
       return {} as unknown as Response;
     }) as unknown as typeof fetch;
 
-    await expect(runAttentionHook({ FLEET_CONSOLE_SESSION_ID: "session-x", FLEET_CONSOLE_DIR: dir }, { fetchImpl })).resolves.toBeUndefined();
+    await expect(runAttentionHook({ FLEET_CONSOLE_SESSION_ID: "session-x", FLEET_CONSOLE_DIR: dir }, { fetchImpl, stdin: Readable.from([]) })).resolves.toBeUndefined();
 
     expect(calls).toHaveLength(1);
     expect(calls[0]?.url).toBe("http://127.0.0.1:51234/terminal/sessions/session-x/attention");
@@ -83,7 +84,61 @@ describe("runAttentionHook", () => {
       throw new Error("connection refused");
     }) as unknown as typeof fetch;
 
-    await expect(runAttentionHook({ FLEET_CONSOLE_SESSION_ID: "session-y", FLEET_CONSOLE_DIR: dir }, { fetchImpl })).resolves.toBeUndefined();
+    await expect(runAttentionHook({ FLEET_CONSOLE_SESSION_ID: "session-y", FLEET_CONSOLE_DIR: dir }, { fetchImpl, stdin: Readable.from([]) })).resolves.toBeUndefined();
     expect(called).toBe(true);
+  });
+
+  it("forwards the notification_type from hook stdin as the attention reason in the post body", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "fleet-console-attn-reason-"));
+    tempDirs.push(dir);
+    const paths = createConsolePaths({ env: { FLEET_CONSOLE_DIR: dir } });
+    createConsoleLock().writeLock({
+      dir: paths.dir,
+      lockFile: paths.lockFile,
+      pid: process.pid,
+      port: 51236,
+      endpoint: "http://127.0.0.1:51236/",
+      version: "test",
+    });
+    const calls: Array<{ readonly init: RequestInit | undefined }> = [];
+    const fetchImpl = (async (_url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ init });
+      return {} as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await runAttentionHook(
+      { FLEET_CONSOLE_SESSION_ID: "session-z", FLEET_CONSOLE_DIR: dir },
+      { fetchImpl, stdin: Readable.from([JSON.stringify({ hook_event_name: "Notification", notification_type: "idle_prompt" })]) },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({ reason: "idle_prompt" });
+  });
+
+  it("omits the reason for an unknown notification_type (e.g. AskUserQuestion PreToolUse)", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "fleet-console-attn-noreason-"));
+    tempDirs.push(dir);
+    const paths = createConsolePaths({ env: { FLEET_CONSOLE_DIR: dir } });
+    createConsoleLock().writeLock({
+      dir: paths.dir,
+      lockFile: paths.lockFile,
+      pid: process.pid,
+      port: 51237,
+      endpoint: "http://127.0.0.1:51237/",
+      version: "test",
+    });
+    const calls: Array<{ readonly init: RequestInit | undefined }> = [];
+    const fetchImpl = (async (_url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ init });
+      return {} as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await runAttentionHook(
+      { FLEET_CONSOLE_SESSION_ID: "session-w", FLEET_CONSOLE_DIR: dir },
+      { fetchImpl, stdin: Readable.from([JSON.stringify({ hook_event_name: "PreToolUse", tool_name: "AskUserQuestion" })]) },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({});
   });
 });

--- a/runtime/fleet-console/tests/sse.test.ts
+++ b/runtime/fleet-console/tests/sse.test.ts
@@ -89,6 +89,47 @@ describe("interpretObserverFrame", () => {
     expect(frame?.event).toBeUndefined();
   });
 
+  it("carries a known attention reason through the attention frame", () => {
+    const frame = interpretObserverFrame({
+      event: "session:attention",
+      data: JSON.stringify({
+        reason: "idle_prompt",
+        session: {
+          sessionId: "session-a",
+          terminalSessionId: "session-a",
+          cwdLabel: "alpha",
+          sequence: 1,
+          label: "Bridge",
+          status: "registered",
+          createdAt: 1_000,
+        },
+      }),
+    });
+
+    expect(frame).toMatchObject({ kind: "attention", reason: "idle_prompt", session: { sessionId: "session-a" } });
+  });
+
+  it("drops an unknown attention reason to undefined", () => {
+    const frame = interpretObserverFrame({
+      event: "session:attention",
+      data: JSON.stringify({
+        reason: "totally-bogus",
+        session: {
+          sessionId: "session-a",
+          terminalSessionId: "session-a",
+          cwdLabel: "alpha",
+          sequence: 1,
+          label: "Bridge",
+          status: "registered",
+          createdAt: 1_000,
+        },
+      }),
+    });
+
+    expect(frame).toMatchObject({ kind: "attention" });
+    expect(frame?.reason).toBeUndefined();
+  });
+
   it("returns null for malformed payloads", () => {
     expect(interpretObserverFrame({ event: "message", data: "not-json" })).toBeNull();
     expect(interpretObserverFrame({ event: "message", data: "{}" })).toBeNull();

--- a/runtime/fleet-console/tests/store.test.ts
+++ b/runtime/fleet-console/tests/store.test.ts
@@ -510,6 +510,37 @@ describe("store", () => {
     expect(getState().operationToasts).toHaveLength(0);
   });
 
+  it("suppresses an idle_prompt attention toast while a carrier job is in flight, but keeps permission/absent reasons", () => {
+    setState({ operationToasts: [], tenantJobs: {}, tenantOrder: [] });
+    hydrateTheaters([THEATER_A, THEATER_B]);
+    hydrateTerminalSessions([
+      { sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a" },
+      { sessionId: "session-b", terminalSessionId: "session-b", cwdLabel: "beta", sequence: 2, label: "Aux", status: "registered", createdAt: 2, theaterId: "theater-b" },
+    ]);
+    // session-b를 보고 있으므로 session-a는 비활성(백그라운드) Operation.
+    setActiveTheater("theater-b");
+    selectTerminalSession("session-b");
+    setState({ operationsViewActive: true });
+    applyTenantSnapshot([{ ...TENANT, terminalSessionId: "session-a", registrationId: "registration-a" }]);
+
+    // 캐리어 출격 중(미완료 job).
+    applyObservedEvent({ id: 1, tenantId: "tenant-1", jobId: "job-1", type: "job:registered", at: Date.now(), event: { type: "job:registered", jobId: "job-1" } });
+
+    // idle_prompt는 입력 대기가 아니라 비동기 작업 대기 → 출격 중 억제.
+    applySessionAttention({ sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a" }, "idle_prompt");
+    expect(getState().operationToasts).toHaveLength(0);
+
+    // 권한 요청은 출격 중에도 실제 입력 대기 → 알림.
+    applySessionAttention({ sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a" }, "permission_prompt");
+    expect(getState().operationToasts).toHaveLength(1);
+    expect(getState().operationToasts[0]).toMatchObject({ kind: "input-waiting", sessionId: "session-a" });
+
+    // reason 부재(예: AskUserQuestion=PreToolUse)는 idle로 추정하지 않고 알림을 유지한다.
+    setState({ operationToasts: [] });
+    applySessionAttention({ sessionId: "session-a", terminalSessionId: "session-a", cwdLabel: "alpha", sequence: 1, label: "Bridge", status: "registered", createdAt: 1, theaterId: "theater-a" });
+    expect(getState().operationToasts).toHaveLength(1);
+  });
+
   it("treats a snapshot-restored finished job without finishedAt as inactive so a later turn end still fires", () => {
     setState({ operationToasts: [], tenantJobs: {}, tenantOrder: [] });
     hydrateTheaters([THEATER_A, THEATER_B]);


### PR DESCRIPTION
## Summary
- A carrier-dispatch idle pause raised a false "Awaiting orders" notification while the dispatched carrier job was still running. The attention signal carried no reason, so the input-waiting toast path (unlike the ended-toast path) had no in-flight carrier guard.
- Thread the Claude Notification hook's `notification_type` through the attention signal as a normalized `reason` (hook stdin -> POST body -> observer SSE -> client), and suppress the input-waiting toast only for `idle_prompt` while a carrier job is in flight.
- `permission_prompt`, `AskUserQuestion` (PreToolUse, no reason), `elicitation`, and any unknown/absent reason still raise the toast, so real input waits are never hidden. fleet-admiral's hook matcher is left untouched (console-internal change).

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (36 files, 419 tests)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`

## Changelog
- [x] Added `.changelog.d/attention-toast-idle-suppression-fixed.md` (section: Fixed, `[fleet-console]`)