### PR TITLE
refactor(fleet-console): move theme & renderer controls to Settings

### DIFF
--- a/.changelog.d/settings-appearance-section-changed.md
+++ b/.changelog.d/settings-appearance-section-changed.md
@@ -1,0 +1,4 @@
+---
+section: Changed
+---
+- [fleet-console] Theme selection and terminal renderer controls move out of the global navigation bar into a new Appearance section at the top of the Settings screen, decluttering the navigation bar; both still apply immediately and are remembered per browser.

--- a/runtime/fleet-console/client/src/components/topbar.tsx
+++ b/runtime/fleet-console/client/src/components/topbar.tsx
@@ -4,8 +4,8 @@ import { Link, NavLink, useLocation } from "react-router-dom";
 import { addTheater, ApiError, applyConsoleUpdate, forgetTheater, issueTerminalFolderGrant } from "../api.js";
 import { setOperationsMode, useOperationsMode, type OperationsMode } from "../operations-mode.js";
 import { setCodexViewMode, type CodexViewMode } from "../codex-view-mode.js";
-import { beginAddTheater, cancelAddTheater, completeAddTheater, failAddTheater, openShortcuts, removeTheater, setActiveTheater, setActiveTheme, setTerminalRenderer, toggleShell } from "../store.js";
-import type { ConsoleState, TerminalRenderer, ThemeId } from "../types.js";
+import { beginAddTheater, cancelAddTheater, completeAddTheater, failAddTheater, openShortcuts, removeTheater, setActiveTheater, toggleShell } from "../store.js";
+import type { ConsoleState } from "../types.js";
 import { CodexModeToggle } from "./codex-mode-toggle.js";
 import { DirectoryBrowserModal } from "./directory-browser-modal.js";
 import { WhatsNewButton } from "./whatsnew-button.js";
@@ -20,12 +20,6 @@ interface NavItem {
   readonly label: string;
   readonly end: boolean;
   readonly icon: "operations" | "codex";
-}
-
-interface ThemeOption {
-  readonly id: ThemeId;
-  readonly label: string;
-  readonly swatch: readonly [string, string, string];
 }
 
 type UpdateApplyState = "idle" | "applying" | "accepted" | "completed" | "blocked" | "error";
@@ -46,11 +40,6 @@ interface GithubStarsState {
 const NAV_ITEMS: readonly NavItem[] = [
   { to: "/operations", label: "Operation", end: false, icon: "operations" },
   { to: "/codex", label: "Codex", end: false, icon: "codex" },
-];
-
-const THEMES: readonly ThemeOption[] = [
-  { id: "maritime", label: "Maritime", swatch: ["oklch(78% 0.13 75)", "oklch(82% 0.13 195)", "oklch(32% 0.04 248)"] },
-  { id: "carbon", label: "Carbon", swatch: ["oklch(76% 0.115 62)", "oklch(80% 0.105 205)", "oklch(25% 0.007 252)"] },
 ];
 
 const UPDATE_APPLY_COMPLETE_DELAY_MS = 1_400;
@@ -142,8 +131,6 @@ export function Topbar({ state, codexMode }: TopbarProps) {
           <span className="topbar-nav-icon" aria-hidden="true"><SettingsIcon /></span>
           <span>Settings</span>
         </NavLink>
-        <ThemeControl activeTheme={state.activeTheme} />
-        <RendererToggle renderer={state.terminalRenderer} />
       </div>
     </header>
   );
@@ -443,117 +430,6 @@ function TheaterControl({ state }: { readonly state: ConsoleState }) {
   );
 }
 
-function ThemeControl({ activeTheme }: { readonly activeTheme: ThemeId }) {
-  const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
-  const menuRef = useRef<HTMLDivElement | null>(null);
-  const active = THEMES.find((theme) => theme.id === activeTheme) ?? THEMES[0]!;
-
-  useEffect(() => {
-    if (!open) return;
-    const handlePointer = (event: MouseEvent) => {
-      if (!containerRef.current?.contains(event.target as Node)) setOpen(false);
-    };
-    const handleKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setOpen(false);
-        triggerRef.current?.focus();
-      }
-    };
-    document.addEventListener("mousedown", handlePointer);
-    document.addEventListener("keydown", handleKey);
-    return () => {
-      document.removeEventListener("mousedown", handlePointer);
-      document.removeEventListener("keydown", handleKey);
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const menu = menuRef.current;
-    if (!menu) return;
-    const target = menu.querySelector<HTMLElement>('[data-active="true"]') ?? menu.querySelector<HTMLElement>("[role^='menuitem']");
-    target?.focus();
-  }, [open]);
-
-  const handleSelect = (theme: ThemeId) => {
-    setActiveTheme(theme);
-    setOpen(false);
-    triggerRef.current?.focus();
-  };
-
-  const handleMenuKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
-    event.preventDefault();
-    const items = Array.from(menuRef.current?.querySelectorAll<HTMLElement>("[role^='menuitem']") ?? []);
-    if (items.length === 0) return;
-    const current = items.indexOf(document.activeElement as HTMLElement);
-    const delta = event.key === "ArrowDown" ? 1 : -1;
-    const next = (current + delta + items.length) % items.length;
-    items[next]?.focus();
-  };
-
-  return (
-    <div className="theme-control" ref={containerRef}>
-      <button
-        type="button"
-        ref={triggerRef}
-        className={`theme-trigger ${open ? "is-open" : ""}`}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        aria-label="Theme"
-        onClick={() => setOpen((value) => !value)}
-      >
-        <ThemeIcon />
-        <span className="theme-trigger-label">{active.label}</span>
-        <span className="theme-trigger-caret" aria-hidden="true"><CaretIcon /></span>
-      </button>
-      {open ? (
-        <div className="theme-menu" role="menu" aria-label="Theme" ref={menuRef} onKeyDown={handleMenuKeyDown}>
-          {THEMES.map((theme) => {
-            const isActive = theme.id === activeTheme;
-            return (
-              <button
-                key={theme.id}
-                type="button"
-                role="menuitemradio"
-                aria-checked={isActive}
-                data-active={isActive ? "true" : undefined}
-                className={`theme-menu-item ${isActive ? "is-active" : ""}`}
-                onClick={() => handleSelect(theme.id)}
-              >
-                <span className="theme-swatch" aria-hidden="true">
-                  {theme.swatch.map((color) => <i key={color} style={{ background: color }} />)}
-                </span>
-                <span className="theme-menu-label">{theme.label}</span>
-                <span className="theme-menu-check" aria-hidden="true">{isActive ? <CheckIcon /> : null}</span>
-              </button>
-            );
-          })}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function RendererToggle({ renderer }: { readonly renderer: TerminalRenderer }) {
-  const nextRenderer = renderer === "webgl" ? "dom" : "webgl";
-  const label = renderer === "webgl" ? "WebGL" : "DOM";
-  return (
-    <button
-      type="button"
-      className="theme-trigger"
-      aria-label={`Terminal renderer: ${label}`}
-      title={`Terminal renderer: ${label}`}
-      onClick={() => setTerminalRenderer(nextRenderer)}
-    >
-      <RendererIcon />
-      <span className="theme-trigger-label">{label}</span>
-    </button>
-  );
-}
-
 // GitHub 레포 이동 마크 + 라이브 star 카운트. 둘 다 새 탭으로 열리는 외부 링크다(noopener/noreferrer).
 function GithubLinks() {
   const stars = useGithubStars();
@@ -668,15 +544,6 @@ function TheaterSigil() {
   );
 }
 
-function RendererIcon() {
-  return (
-    <svg viewBox="0 0 16 16" aria-hidden="true">
-      <rect x="2.5" y="3" width="11" height="8" rx="1.2" fill="none" stroke="currentColor" strokeWidth="1.2" />
-      <path d="M5.2 13h5.6M8 11v2" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-    </svg>
-  );
-}
-
 function CaretIcon() {
   return (
     <svg viewBox="0 0 16 16" aria-hidden="true">
@@ -697,18 +564,6 @@ function CloseIcon() {
   return (
     <svg viewBox="0 0 16 16" aria-hidden="true">
       <path d="M4.7 4.7 11.3 11.3M11.3 4.7 4.7 11.3" fill="none" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" />
-    </svg>
-  );
-}
-
-function ThemeIcon() {
-  // Theme — 세 톤 팔레트 모티프.
-  return (
-    <svg viewBox="0 0 16 16" aria-hidden="true">
-      <path d="M8 2.6a5.4 5.4 0 0 0-5.4 5.5c0 2.4 1.8 4.5 4.2 5 .8.2 1.2-.2 1.2-.8 0-.5-.4-.8-.4-1.3 0-.7.6-1.1 1.3-1.1h1.1c1.9 0 3.4-1.5 3.4-3.3C13.4 4.4 11 2.6 8 2.6Z" fill="none" stroke="currentColor" strokeWidth="1.15" strokeLinejoin="round" />
-      <circle cx="5.6" cy="6.4" r=".75" fill="currentColor" />
-      <circle cx="8" cy="5.2" r=".75" fill="currentColor" />
-      <circle cx="10.4" cy="6.5" r=".75" fill="currentColor" />
     </svg>
   );
 }

--- a/runtime/fleet-console/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/client/src/pages/global-settings.tsx
@@ -3,6 +3,9 @@ import { useEffect } from "react";
 import { AgentCliSection } from "../components/agent-cli-section.js";
 import { ModelAuthSection } from "../components/model-auth-section.js";
 import { loadGlobalSettings, setGlobalSettingsField, useGlobalSettingsStore } from "../global-settings-store.js";
+import { useConsoleState } from "../hooks/use-store.js";
+import { setActiveTheme, setTerminalRenderer } from "../store.js";
+import type { TerminalRenderer, ThemeId } from "../types.js";
 
 interface SettingToggleRowProps {
   readonly title: string;
@@ -13,6 +16,28 @@ interface SettingToggleRowProps {
   readonly disabled: boolean;
   readonly onToggle: () => void;
 }
+
+interface ThemeOption {
+  readonly id: ThemeId;
+  readonly label: string;
+  readonly swatch: readonly [string, string, string];
+}
+
+interface RendererOption {
+  readonly id: TerminalRenderer;
+  readonly label: string;
+}
+
+// 테마 선택지 — 각 항목의 3톤 스와치는 해당 테마의 brass/aurora/ink 시그니처를 미리보기로 보존한다(콘텐츠 색이라 역할색 규칙과 무관).
+const THEMES: readonly ThemeOption[] = [
+  { id: "maritime", label: "Maritime", swatch: ["oklch(78% 0.13 75)", "oklch(82% 0.13 195)", "oklch(32% 0.04 248)"] },
+  { id: "carbon", label: "Carbon", swatch: ["oklch(76% 0.115 62)", "oklch(80% 0.105 205)", "oklch(25% 0.007 252)"] },
+];
+
+const RENDERERS: readonly RendererOption[] = [
+  { id: "webgl", label: "WebGL" },
+  { id: "dom", label: "DOM" },
+];
 
 export function GlobalSettings() {
   const settings = useGlobalSettingsStore();
@@ -38,6 +63,8 @@ export function GlobalSettings() {
       </section>
 
       {settings.error ? <p className="global-settings-error" role="alert">{settings.error}</p> : null}
+
+      <AppearanceCard />
 
       <section className="global-settings-card" aria-label="Fleet global settings">
         {settings.loading && !state ? <p className="global-settings-help">Loading settings.</p> : null}
@@ -73,6 +100,67 @@ export function GlobalSettings() {
   );
 }
 
+// 외관 설정 — 테마와 터미널 렌더러. 콘솔 로컬(브라우저별) 선호값이며 선택 즉시 적용된다(세션 설정과 달리 재실행 불요).
+function AppearanceCard() {
+  const { activeTheme, terminalRenderer } = useConsoleState();
+  return (
+    <section className="global-settings-card" aria-label="Appearance">
+      <div className="global-settings-row">
+        <div className="global-settings-row-text">
+          <p className="global-settings-resp-title">Theme</p>
+          <p className="global-settings-help">Console color scheme. Applies immediately and is remembered on this browser.</p>
+        </div>
+        {/* role="group" + aria-pressed — 기존 Operation Map/Helm 토글과 동일한 단일선택 패턴. 선택 = brass(지금 보고 있는 곳). */}
+        <div className="theme-picker" role="group" aria-label="Theme">
+          {THEMES.map((theme) => {
+            const isActive = theme.id === activeTheme;
+            return (
+              <button
+                key={theme.id}
+                type="button"
+                aria-pressed={isActive}
+                className={`theme-card ${isActive ? "is-active" : ""}`}
+                onClick={() => setActiveTheme(theme.id)}
+              >
+                <span className="theme-card-swatch" aria-hidden="true">
+                  {theme.swatch.map((color) => <i key={color} style={{ background: color }} />)}
+                </span>
+                <span className="theme-card-label">{theme.label}</span>
+                <span className="theme-card-check" aria-hidden="true">{isActive ? <CheckIcon /> : null}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="global-settings-row">
+        <div className="global-settings-row-text">
+          <p className="global-settings-resp-title">Terminal Renderer</p>
+          <p className="global-settings-help">WebGL paints the terminal on the GPU for sharper, faster output; DOM is a compatibility fallback. Switching applies to the live terminal instantly without dropping the session.</p>
+        </div>
+        <div className="segmented" role="group" aria-label="Terminal renderer">
+          {RENDERERS.map((renderer) => {
+            const isActive = renderer.id === terminalRenderer;
+            return (
+              <button
+                key={renderer.id}
+                type="button"
+                aria-pressed={isActive}
+                className={`segmented-option ${isActive ? "is-active" : ""}`}
+                onClick={() => setTerminalRenderer(renderer.id)}
+              >
+                {renderer.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <p className="global-settings-foot">Appearance preferences apply immediately and are stored per browser, separate from session settings.</p>
+    </section>
+  );
+}
+
 function SettingToggleRow({ title, help, onLabel, offLabel, value, disabled, onToggle }: SettingToggleRowProps) {
   return (
     <div className="global-settings-row">
@@ -90,5 +178,13 @@ function SettingToggleRow({ title, help, onLabel, offLabel, value, disabled, onT
         <span>{value ? onLabel : offLabel}</span>
       </button>
     </div>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M3.5 8.5 6.5 11.5 12.5 5" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
   );
 }

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -529,6 +529,128 @@
   }
 }
 
+/* Appearance — 테마/렌더러 단일선택 컨트롤. 선택 상태는 brass(지금 보고 있는 곳)로만 표기하고 aurora와 혼용하지 않는다. */
+
+/* 테마 선택 — GNB 드롭다운의 3톤 스와치를 보존한 카드형 단일선택 그룹. */
+.theme-picker {
+  display: flex;
+  flex: none;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.theme-card {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 8px var(--space-3);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--surface-glass-strong) 55%, transparent);
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring),
+    transform var(--duration-fast) var(--ease-spring);
+}
+
+.theme-card:hover {
+  color: var(--ink-pearl);
+  border-color: color-mix(in oklch, var(--brass) 40%, var(--surface-rim));
+}
+
+.theme-card.is-active {
+  color: var(--ink-pearl);
+  border-color: color-mix(in oklch, var(--brass) 70%, transparent);
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in oklch, var(--brass) 42%, transparent), var(--shadow-soft);
+}
+
+.theme-card:active {
+  transform: translateY(1px);
+}
+
+.theme-card-swatch {
+  display: inline-flex;
+  flex: none;
+  gap: 3px;
+}
+
+.theme-card-swatch i {
+  width: 10px;
+  height: 10px;
+  flex: none;
+  border: 1px solid var(--surface-rim);
+  border-radius: 999px;
+}
+
+.theme-card-label {
+  line-height: 1;
+}
+
+.theme-card-check {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 14px;
+  height: 14px;
+  color: var(--brass);
+}
+
+.theme-card-check svg {
+  display: block;
+  width: 13px;
+  height: 13px;
+}
+
+/* 터미널 렌더러 — 2지선다 세그먼트 컨트롤. 트랙 위 활성 세그먼트만 brass로 채운다. */
+.segmented {
+  display: inline-flex;
+  flex: none;
+  align-self: flex-start;
+  padding: 3px;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--ink-abyss) 42%, transparent);
+}
+
+.segmented-option {
+  min-width: 72px;
+  min-height: 30px;
+  padding: 5px var(--space-4);
+  border: 0;
+  border-radius: var(--radius-xs);
+  background: transparent;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring);
+}
+
+.segmented-option:hover:not(.is-active) {
+  color: var(--ink-pearl);
+}
+
+.segmented-option.is-active {
+  background: color-mix(in oklch, var(--brass) 16%, transparent);
+  color: var(--brass);
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass) 38%, transparent);
+}
+
 /* 모델 로그인 — provider API key 등록 행. global-settings-card를 그릇으로 재사용한다. */
 .model-auth-head {
   display: grid;
@@ -4051,125 +4173,6 @@
   padding-inline: var(--space-1);
 }
 
-.theme-control {
-  position: relative;
-  display: inline-flex;
-  flex: 0 0 auto;
-}
-
-.theme-trigger {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: 6px var(--space-1);
-  color: var(--ink-fog);
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  font-weight: 600;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  transition: color var(--duration-fast) var(--ease-spring);
-}
-
-.theme-trigger:hover,
-.theme-trigger.is-open {
-  color: var(--ink-pearl);
-}
-
-.theme-trigger svg {
-  display: block;
-  width: 15px;
-  height: 15px;
-}
-
-.theme-trigger-caret {
-  display: grid;
-  place-items: center;
-  opacity: 0.62;
-}
-
-.theme-trigger-caret svg {
-  width: 11px;
-  height: 11px;
-}
-
-.theme-menu {
-  position: absolute;
-  top: calc(100% + var(--space-2));
-  right: 0;
-  z-index: 40;
-  min-width: 180px;
-  padding: var(--space-2);
-  border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-lg);
-  background: color-mix(in oklch, var(--ink-deep) 60%, var(--surface-pillar));
-  backdrop-filter: blur(20px) saturate(150%);
-  box-shadow: var(--shadow-floating);
-  animation: codex-rise var(--duration-fast) var(--ease-spring);
-}
-
-.theme-menu-item {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  width: 100%;
-  padding: var(--space-2);
-  border-radius: var(--radius-sm);
-  color: var(--ink-fog);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  letter-spacing: 0.04em;
-  text-align: left;
-  transition:
-    color var(--duration-fast) var(--ease-spring),
-    background var(--duration-fast) var(--ease-spring);
-}
-
-.theme-menu-item:hover,
-.theme-menu-item:focus-visible {
-  color: var(--ink-pearl);
-  background: color-mix(in oklch, var(--ink-pearl) 8%, transparent);
-}
-
-.theme-menu-item.is-active {
-  color: var(--ink-pearl);
-}
-
-.theme-swatch {
-  display: inline-flex;
-  flex: none;
-  gap: 3px;
-}
-
-.theme-swatch i {
-  width: 9px;
-  height: 9px;
-  flex: none;
-  border: 1px solid var(--surface-rim);
-  border-radius: 999px;
-}
-
-.theme-menu-label {
-  flex: 1;
-  min-width: 0;
-  text-align: left;
-}
-
-.theme-menu-check {
-  display: grid;
-  place-items: center;
-  flex: none;
-  width: 14px;
-  height: 14px;
-  color: var(--ink-pearl);
-}
-
-.theme-menu-check svg {
-  display: block;
-  width: 13px;
-  height: 13px;
-}
-
 .theater-control {
   position: relative;
   display: flex;
@@ -6707,17 +6710,16 @@
    2행으로 stack한다. 임계치는 meta 고유폭 실측(full 741 / 보조라벨숨김 518 / 전체아이콘 406)과
    트랙폭 회귀(track ≈ 0.5·vw − 157, 겹침0 ⇔ vw ≳ 2·meta + 314)에서 도출했다. */
 
-/* Tier A (≤1800px) — full 라벨은 ~1796px 이상에서만 안 겹친다. 보조 컨트롤(Shell·Settings·Theme·
-   Renderer) 라벨과 상시 PREVIEW 배지를 접어 meta 고유폭을 ~518px로 줄인다(안전 하한 ~1350px). */
+/* Tier A (≤1800px) — full 라벨은 ~1796px 이상에서만 안 겹친다. 보조 컨트롤(Shell·Settings)
+   라벨과 상시 PREVIEW 배지를 접어 meta 고유폭을 줄인다(안전 하한 ~1350px). */
 @media (max-width: 1800px) {
   .topbar-preview-badge {
     display: none;
   }
 
-  /* Shell 라벨 / Theme·Renderer 라벨 / Settings(=.topbar-meta 직속 nav-link) 라벨만 숨기고
+  /* Shell 라벨 / Settings(=.topbar-meta 직속 nav-link) 라벨만 숨기고
      주요 nav(Operation·Codex, =.topbar-nav 내부)는 이 단계에서 유지한다. */
   .topbar-shell-button > span,
-  .theme-trigger-label,
   .topbar-meta > .topbar-nav-link > span:not(.topbar-nav-icon) {
     display: none;
   }


### PR DESCRIPTION
## Summary
- GNB(상단 내비게이션)에 상시 노출되던 **Theme 드롭다운**과 **Terminal Renderer 토글**을 제거하고, Settings 화면 최상단에 신규 **Appearance** 카드로 통합했습니다.
- Appearance 카드는 테마=3톤 스와치 라디오 카드, 렌더러=WebGL/DOM 세그먼트 컨트롤로 구성되며, 둘 다 즉시 적용되고 브라우저별로 기억됩니다.
- 선택 상태는 brass(=지금 보고 있는 곳)로만 표기해 aurora(live) 역할 혼용을 피했고, 기존 `OperationsModeToggle`과 동일한 `role="group"`+`aria-pressed` 패턴을 따릅니다.
- topbar의 `ThemeControl`/`RendererToggle`과 전용 아이콘·dead CSS를 함께 제거했습니다(TheaterControl이 쓰는 CaretIcon/CheckIcon은 보존).

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (419/419 pass)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] console-e2e(격리 인스턴스): GNB에서 테마/렌더러 컨트롤 소거, Appearance 카드 최상단 렌더, 테마 클릭 시 `data-theme` 라이브 적용, 렌더러 클릭 시 localStorage 영속 — pageerror 0
- [x] `.changelog.d/*.md` 프래그먼트 포함 (`[fleet-console]` Changed)