### PR TITLE
fix(fleet-console): prevent terminals from corrupting each other

### DIFF
--- a/.changelog.d/console-terminal-shared-atlas-corruption-fixed.md
+++ b/.changelog.d/console-terminal-shared-atlas-corruption-fixed.md
@@ -1,0 +1,4 @@
+---
+section: Fixed
+---
+- [fleet-console] Fixed other open Operations terminals showing a corrupted display when an additional terminal was opened or a minimized terminal was restored from the dock.

--- a/runtime/fleet-console/client/src/components/terminal.tsx
+++ b/runtime/fleet-console/client/src/components/terminal.tsx
@@ -284,8 +284,13 @@ export function Terminal({ sessionId, kind, theaterId, onExit, active, zoom = 1 
     const fitAddon = fitAddonRef.current;
     if (!terminal || !fitAddon) return;
     terminal.options.fontSize = BASE_FONT_SIZE * appliedZoom;
-    // fontSize 변경 후 WebGL 글리프 atlas를 선제 무효화해 첫 프레임 깜빡임을 결정적으로 제거한다(DOM 렌더러는 무관).
-    webglAddonRef.current?.clearTextureAtlas();
+    // 여기서 WebglAddon.clearTextureAtlas()를 호출하면 안 된다. xterm WebGL의 글리프 atlas는 동일 설정(폰트·
+    // 테마·cell크기) 터미널들이 모듈 레벨 캐시(acquireTextureAtlas)에서 1개를 공유한다. 따라서 한 터미널이
+    // atlas를 비우면 형제 터미널이 쓰는 공유 atlas까지 함께 비워지고, 형제에는 재그리기 신호가 가지 않아
+    // 다른 터미널 화면이 깨진다(특히 마운트·복원 시 effect가 1회 실행되며 발생). 게다가 fontSize가 실제로
+    // 바뀌면 xterm이 옵션 변경 핸들러(_handleOptionsChanged→_refreshCharAtlas→acquireTextureAtlas)에서 새
+    // cell크기 키로 atlas를 자동 재획득하므로 수동 무효화는 불필요하다. atlas는 건드리지 않고 이 터미널만
+    // fit + refresh로 재배치/재도색한다.
     fitAddon.fit();
     terminal.refresh(0, terminal.rows - 1);
   }, [appliedZoom]);


### PR DESCRIPTION
## Summary
- Operations Map에서 터미널을 추가로 열거나 최소화된 터미널을 dock에서 복원할 때 다른 열려 있던 터미널들의 화면이 깨지던 회귀를 수정합니다.
- 원인: 줌 보정 effect가 매 실행(마운트·복원 포함)마다 `WebglAddon.clearTextureAtlas()`를 호출했는데, xterm WebGL 글리프 atlas는 동일 설정 터미널이 모듈 레벨에서 1개를 공유하므로 한 터미널이 비우면 형제 터미널의 공유 atlas까지 비워지고(형제엔 재그리기 신호 없음) 화면이 깨졌습니다.
- 해결: 수동 `clearTextureAtlas()` 호출 제거. fontSize 변경 시 xterm이 셀크기별 atlas를 자동 재획득하고 기존 `fit()`+`refresh()`가 재도색하므로 불필요·유해한 호출이었습니다. #90의 커서/줌 정렬(fontSize×zoom + 역스케일 CSS)은 그대로 유지됩니다.

## Type of Change
- [x] fix — bug fix

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` (통과)
- [x] `pnpm --filter @dotobokuri/fleet-console test` (416 passed; 실패 3건은 서버측 wiki/symlink·detached worker로 무수정 canary에서도 동일한 사전·환경 의존 실패, 본 변경 무관)
- [x] 대원수 수동 실측: 복수 터미널 + 최소화/복원 시 깨짐 해소 확인, 다른 사이드이펙트 없음
- [ ] 참고: 줌 제스처 깜빡임 무재발 — `refresh()` + xterm 자동 재획득이 처리

## Changelog
- [x] Added one `.changelog.d/*.md` fragment (`console-terminal-shared-atlas-corruption-fixed.md`, section: Fixed, `[fleet-console]`)