### PR TITLE
feat(fleet-console): pulse alerts dock and widen canvas alert coverage

### DIFF
--- a/.changelog.d/alerts-dock-collapsed-pulse.md
+++ b/.changelog.d/alerts-dock-collapsed-pulse.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+- [fleet-console] The collapsed Alerts dock now plays a one-shot outline pulse when a new alert arrives, giving peripheral feedback without expanding the dock; the pulse color follows the alert state (amber for awaiting, emerald for completed) and adapts to the active theme.
+- [fleet-console] Canvas-mode operations now raise Alerts even when their panel is not minimized, so a visible canvas panel no longer suppresses its own alert.

--- a/runtime/fleet-console/client/src/components/notification-cluster.tsx
+++ b/runtime/fleet-console/client/src/components/notification-cluster.tsx
@@ -1,7 +1,6 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { useCanvasState } from "../canvas/canvas-store.js";
 import { useConsoleState } from "../hooks/use-store.js";
 import { useOperationsMode } from "../operations-mode.js";
 import { computeVisibleSessionIds, filterByPreferences, groupNotificationsByTheater, splitNotificationsByVisibility } from "../reduce.js";
@@ -23,7 +22,6 @@ const DEFAULT_DOCK_OPEN = false;
 // 닫힘=엣지 핸들(신호+카운트), 열림=도킹 패널(Theater 그룹). 클러스터는 보이지 않는 세션만 렌더한다.
 export function NotificationClusterHost() {
   const state = useConsoleState();
-  const canvas = useCanvasState();
   const mode = useOperationsMode();
   const navigate = useNavigate();
   const [open, setOpen] = useState(readDockOpen);
@@ -33,7 +31,7 @@ export function NotificationClusterHost() {
     () => Object.values(state.operationNotifications),
     [state.operationNotifications],
   );
-  const visibleIds = computeVisibleSessionIds(mode, state, canvas);
+  const visibleIds = computeVisibleSessionIds(mode, state);
   const eligible = splitNotificationsByVisibility(notifications, visibleIds).hidden;
   const filtered = filterByPreferences(eligible, state.notificationPreferences);
   const groups = groupNotificationsByTheater(filtered);
@@ -46,6 +44,25 @@ export function NotificationClusterHost() {
   const muted = groups.length === 0;
   // 신호 상태 — 입력 대기가 있으면 awaiting(warn·perimeter wake), 완료만이면 ended(positive), 없으면 muted.
   const signalState = muted ? "muted" : waitingCount > 0 ? "awaiting" : "ended";
+
+  // ── 접힘 상태 새 알림 외곽 펄스 ──
+  // filtered(음소거 제외) 알림의 최대 시퀀스를 watermark로 추적한다. lastRaisedSeq는 새 알림이
+  // 생성될 때만 단조 증가하므로, 증가分이 곧 "방금 도착한 새 알림"이다.
+  const latestSeq = useMemo(
+    () => filtered.reduce((max, notification) => Math.max(max, notification.lastRaisedSeq), 0),
+    [filtered],
+  );
+  const seenSeqRef = useRef(latestSeq);
+  const [pulseKey, setPulseKey] = useState(0);
+
+  useEffect(() => {
+    // 접힘 상태에서 시퀀스가 증가하면 외곽 펄스를 1회 재생한다. 펼침 상태에서 도착한 알림은
+    // 닫을 때 펄스가 몰아치지 않도록 watermark만 끌어올리고 트리거하지 않는다.
+    if (latestSeq > seenSeqRef.current && !open) {
+      setPulseKey((key) => key + 1);
+    }
+    seenSeqRef.current = latestSeq;
+  }, [latestSeq, open]);
 
   // 알림 사이드바는 알림 유무와 무관하게 항상 노출한다(대원수 지시) — 빈 상태도 핸들/패널을 유지한다.
 
@@ -71,6 +88,7 @@ export function NotificationClusterHost() {
         <span className="notification-handle-count">{muted ? 0 : totalCount}</span>
         <span className="notification-handle-label">Alerts</span>
         <ChevronIcon className="notification-handle-chevron" />
+        {pulseKey > 0 ? <span key={pulseKey} className="notification-handle-pulse" aria-hidden="true" /> : null}
       </button>
     );
   }

--- a/runtime/fleet-console/client/src/reduce.ts
+++ b/runtime/fleet-console/client/src/reduce.ts
@@ -1,4 +1,3 @@
-import type { CanvasState } from "./canvas/canvas-store.js";
 import type { OperationsMode } from "./operations-mode.js";
 import type { ConsoleState, JobView, NotificationPreferences, ObservedEvent, OperationNotification, SnapshotJob, TrackToolCall, TrackView } from "./types.js";
 
@@ -130,17 +129,14 @@ export function isTerminalJobStatus(status: string): boolean {
   return TERMINAL_JOB_STATUSES.has(status);
 }
 
-export function computeVisibleSessionIds(mode: OperationsMode, consoleSnap: ConsoleState, canvasSnap: CanvasState): ReadonlySet<string> {
+export function computeVisibleSessionIds(mode: OperationsMode, consoleSnap: ConsoleState): ReadonlySet<string> {
   if (!consoleSnap.operationsViewActive) return new Set();
   if (mode === "classic") {
     return consoleSnap.activeTerminalSessionId ? new Set([consoleSnap.activeTerminalSessionId]) : new Set();
   }
-  const minimized = new Set(canvasSnap.minimized);
-  const visible = new Set<string>();
-  for (const sessionId of Object.keys(canvasSnap.panels)) {
-    if (!minimized.has(sessionId)) visible.add(sessionId);
-  }
-  return visible;
+  // canvas 모드: 패널 최소화 여부와 무관하게 모든 Operation을 알림 대상으로 둔다(대원수 지시).
+  // 여러 패널을 동시에 보는 모드이므로 화면에 떠 있는 패널이라도 ALERTS dock으로 알림이 전송된다.
+  return new Set();
 }
 
 export function splitNotificationsByVisibility(

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -6090,6 +6090,24 @@
   animation: perimeter-orbit 3s linear infinite;
 }
 
+/* 새 알림 도착 외곽 펄스 — 접힘 핸들에서 lastRaisedSeq 증가 시 1회 재생되는 transient 신호.
+   색은 신호 상태를 따른다: 입력 대기=warn(amber), 완료=positive(emerald). aurora 미사용. */
+.notification-handle-pulse {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  border-radius: inherit;
+  pointer-events: none;
+  --pulse-tint: var(--warn);
+  --pulse-glow: var(--warn-glow);
+  animation: notification-wake-pulse 1.05s var(--ease-glide) both;
+}
+
+.notification-handle.is-ended .notification-handle-pulse {
+  --pulse-tint: var(--positive);
+  --pulse-glow: var(--positive-glow);
+}
+
 /* ── 열림: 우현 도킹 레이어 + 패널 ── */
 .notification-dock-layer {
   position: fixed;

--- a/runtime/fleet-console/client/src/styles/theme.css
+++ b/runtime/fleet-console/client/src/styles/theme.css
@@ -367,6 +367,31 @@ a {
   }
 }
 
+/* 접힘 알림 핸들 외곽 "항적 펄스(wake pulse)" — 새 알림이 도착하는 순간 외곽 rim이 밝아졌다
+   glow ring이 바깥으로 부풀어 확산하며 사라지는 1회성 신호. perimeter-orbit(지속 신호)과 달리
+   이벤트 1회만 재생된다. 색(--pulse-tint/--pulse-glow)은 도착 알림 kind를 따른다.
+   prefers-reduced-motion에선 iteration-count:1 단락으로 1회 짧게 끝난다. */
+@keyframes notification-wake-pulse {
+  0% {
+    opacity: 0.85;
+    box-shadow:
+      0 0 0 0 var(--pulse-tint),
+      0 0 12px 1px var(--pulse-glow);
+  }
+  55% {
+    opacity: 1;
+    box-shadow:
+      0 0 0 3px color-mix(in oklch, var(--pulse-tint) 42%, transparent),
+      0 0 28px 5px var(--pulse-glow);
+  }
+  100% {
+    opacity: 0;
+    box-shadow:
+      0 0 0 9px transparent,
+      0 0 40px 12px transparent;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/runtime/fleet-console/tests/reduce.test.ts
+++ b/runtime/fleet-console/tests/reduce.test.ts
@@ -9,7 +9,6 @@ import {
   reduceSnapshotJob,
   splitNotificationsByVisibility,
 } from "../client/src/reduce.js";
-import type { CanvasState } from "../client/src/canvas/canvas-store.js";
 import type { ConsoleState, NotificationPreferences, ObservedEvent, OperationNotification } from "../client/src/types.js";
 
 function makeEvent(id: number, type: string, event: Record<string, unknown>, jobId = "job-1"): ObservedEvent {
@@ -69,15 +68,6 @@ function makeConsoleSnap(patch: Partial<ConsoleState> = {}): ConsoleState {
     expandedSessionIds: [],
     operationNotifications: {},
     notificationPreferences: { globalMute: false, dnd: false, mutedTheaterIds: {} },
-    ...patch,
-  };
-}
-
-function makeCanvasSnap(patch: Partial<CanvasState> = {}): CanvasState {
-  return {
-    viewport: { x: 0, y: 0, zoom: 1 },
-    panels: {},
-    minimized: [],
     ...patch,
   };
 }
@@ -218,29 +208,21 @@ describe("reduceSnapshotJob", () => {
 
 describe("notification selectors", () => {
   it("computes visible sessions for classic Operations view and none outside Operations", () => {
-    const canvas = makeCanvasSnap();
-
     expect([...computeVisibleSessionIds("classic", makeConsoleSnap({
       operationsViewActive: true,
       activeTerminalSessionId: "session-a",
-    }), canvas)]).toEqual(["session-a"]);
+    }))]).toEqual(["session-a"]);
 
     expect([...computeVisibleSessionIds("classic", makeConsoleSnap({
       operationsViewActive: false,
       activeTerminalSessionId: "session-a",
-    }), canvas)]).toEqual([]);
+    }))]).toEqual([]);
   });
 
-  it("computes visible canvas sessions from non-minimized panels", () => {
-    const visible = computeVisibleSessionIds("canvas", makeConsoleSnap({ operationsViewActive: true }), makeCanvasSnap({
-      panels: {
-        "session-a": { x: 0, y: 0, width: 100, height: 100, zIndex: 1 },
-        "session-b": { x: 0, y: 0, width: 100, height: 100, zIndex: 2 },
-      },
-      minimized: ["session-b"],
-    }));
-
-    expect([...visible]).toEqual(["session-a"]);
+  it("treats every canvas operation as hidden so alerts surface regardless of minimized state", () => {
+    // canvas 모드는 가시성에 의한 알림 억제를 하지 않는다 — 최소화하지 않은 패널도 ALERTS로 알림이 간다.
+    const visible = computeVisibleSessionIds("canvas", makeConsoleSnap({ operationsViewActive: true }));
+    expect([...visible]).toEqual([]);
   });
 
   it("splits hidden and visible notifications by session id", () => {


### PR DESCRIPTION
## Summary
- 접힘 상태의 ALERTS dock에 새 알림이 도착하면 외곽을 1회 펄스(항적광)로 강조해, dock을 펼치지 않아도 주변시(peripheral) 피드백을 준다. 펄스 색은 알림 상태(awaiting=amber, completed=emerald)를 따르고 maritime/carbon 테마에 자동 대응하며 `prefers-reduced-motion`에서 단락된다.
- canvas 모드 Operation은 패널을 최소화하지 않아도 ALERTS dock으로 알림이 전송된다(기존: 최소화한 패널만 알림). 가시성 의존이 사라진 notification cluster의 canvas store 구독도 제거했다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 430 passed (37 files)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] console-e2e 실측: maritime/carbon 양 테마에서 awaiting(amber)/ended(emerald) 펄스 색 확인
- [x] Changelog fragment 포함: `.changelog.d/alerts-dock-collapsed-pulse.md` (`compile-changelog-fragments --check` OK)