### PR TITLE
feat(fleet-console): OS-style window system for Operations canvas

### DIFF
--- a/.changelog.d/console-window-system.md
+++ b/.changelog.d/console-window-system.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- [fleet-console] Reworked the Operations canvas panels into an OS-style window system with a persistent taskbar, panel maximize, Shell parity, and stable panel cycling.

--- a/runtime/fleet-console/client/src/app.tsx
+++ b/runtime/fleet-console/client/src/app.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import type { Location } from "react-router-dom";
 
-import { useMaximized } from "./canvas/canvas-store.js";
+import { useMapFullscreen } from "./canvas/canvas-store.js";
 import { setCodexViewMode, useCodexSideWidth, useCodexUserChosen, useCodexViewMode } from "./codex-view-mode.js";
 import { fetchObserverStatus, fetchReleaseNotes, fetchTerminalSessions, fetchTheaterBootstrap } from "./api.js";
 import { CommissioningOverlay } from "./components/commissioning-overlay.js";
@@ -29,7 +29,7 @@ export function App() {
   const location = useLocation();
   const pathname = location.pathname;
   const navigate = useNavigate();
-  const maximized = useMaximized();
+  const isMapFullscreen = useMapFullscreen();
   const codexViewMode = useCodexViewMode();
   const codexUserChosen = useCodexUserChosen();
   const codexSideWidth = useCodexSideWidth();
@@ -41,7 +41,7 @@ export function App() {
   const hasRealBackgroundRef = useRef<boolean>(!isCodexRoute);
   // 최대화는 localStorage에 영속되지만, GNB 숨김은 Operations 화면에서만 적용한다 —
   // 다른 라우트(Codex 등)로 가거나 그 상태로 로드되어도 내비게이션이 사라지지 않게 한다.
-  const maximizedActive = maximized && pathname.startsWith("/operations");
+  const mapFullscreenActive = isMapFullscreen && pathname.startsWith("/operations");
   // Codex 표현 모드 도출 — 오버레이(side)는 배경이 있거나 사용자가 직접 모드를 고른 경우 허용한다.
   // (deep-link로 막 들어온 첫 렌더에는 둘 다 아니므로 Full로 강등 → 승인된 "새로고침=Full".)
   // codexUserChosen은 reactive 구독이라, deep-link Full 상태에서 같은 값(side)을 다시 눌러도 재렌더된다.
@@ -192,7 +192,7 @@ export function App() {
   };
 
   return (
-    <div className={`console-shell ${maximizedActive ? "is-maximized" : ""}`}>
+    <div className={`console-shell ${mapFullscreenActive ? "is-map-fullscreen" : ""}`}>
       <Topbar state={state} />
       <Routes location={displayLocation}>
         <Route path="/" element={<Navigate to="/operations" replace />} />

--- a/runtime/fleet-console/client/src/canvas/canvas-dock.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-dock.tsx
@@ -186,6 +186,9 @@ function CanvasDockChip({ entry, index }: CanvasDockChipProps) {
       style={{ "--i": index } as CSSProperties}
       onClick={restore}
       onKeyDown={(event) => {
+        // 칩 본체에서 발생한 키만 복원으로 처리한다 — 닫기 버튼 등 중첩 컨트롤의 Enter/Space가 버블링되어
+        // preventDefault+restore가 닫기를 가로채는 것을 막는다(닫기 버튼은 자체 onClick으로 닫힌다).
+        if (event.target !== event.currentTarget) return;
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault();
           restore();

--- a/runtime/fleet-console/client/src/canvas/canvas-dock.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-dock.tsx
@@ -1,21 +1,23 @@
-import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
+import { useCallback, useEffect, useRef, useState, type CSSProperties, type SyntheticEvent } from "react";
 
 import { sessionBeaconClassName, sessionDisplayLabel } from "../format.js";
 import { isTerminalJobStatus } from "../reduce.js";
-import { selectTerminalSession, sessionJobs } from "../store.js";
+import { sessionJobs } from "../store.js";
 import type { ConsoleState, SessionInfo } from "../types.js";
-import { restorePanel, toggleDockExpanded, useDockExpanded } from "./canvas-store.js";
+import { closeWindowPanel, getMinimizedPanelHandles, restoreWindowPanel, type WindowPanelHandle } from "./window-registry.js";
 
 type Underway = "live" | "turn" | null;
 
 interface CanvasDockProps {
   readonly state: ConsoleState;
   readonly sessions: readonly SessionInfo[];
-  readonly minimized: readonly string[];
 }
 
 interface DockEntry {
-  readonly session: SessionInfo;
+  readonly handle: WindowPanelHandle;
+  readonly label: string;
+  readonly meta: string;
+  readonly beaconClassName: string;
   readonly activeJobCount: number;
   readonly underway: Underway;
   readonly active: boolean;
@@ -26,8 +28,6 @@ interface CanvasDockChipProps {
   readonly index: number;
 }
 
-// 칩 트랙(스크롤 뷰포트)의 페이지네이션 측정값. overflow=가용 폭 초과 여부, atStart/atEnd=양끝 도달,
-// page/pages=현재/총 페이지(좌→우 1-based, 우측 끝=최신=가장 큰 번호).
 interface PagerState {
   readonly overflow: boolean;
   readonly atStart: boolean;
@@ -38,19 +38,26 @@ interface PagerState {
 
 const INITIAL_PAGER: PagerState = { overflow: false, atStart: false, atEnd: true, page: 1, pages: 1 };
 
-export function CanvasDock({ state, sessions, minimized }: CanvasDockProps) {
-  const expanded = useDockExpanded();
+export function CanvasDock({ state, sessions }: CanvasDockProps) {
   const chipsRef = useRef<HTMLDivElement | null>(null);
-  // 우측 끝(최신 칩) 고정 여부 — 사용자가 '<'로 과거 칩을 보러 가면 풀리고, 우측 끝으로 돌아오면 다시 핀된다.
   const pinRightRef = useRef(true);
   const [pager, setPager] = useState<PagerState>(INITIAL_PAGER);
-  // 최소화 목록 순서를 유지하며 실재 세션만 추려, 각 칩의 신호(underway)·활성 여부를 한 번에 계산한다.
-  // 자연 순서(과거→최신)라 최신 칩이 트랙 오른쪽(토글 인접)에 도킹되고, 칩이 늘면 기존 칩이 왼쪽으로 밀린다.
   const sessionById = new Map(sessions.map((session) => [session.sessionId, session]));
-  const entries: DockEntry[] = minimized
-    .map((sessionId) => sessionById.get(sessionId))
-    .filter((session): session is SessionInfo => Boolean(session))
-    .map((session) => {
+  const operationIds = sessions.map((session) => session.sessionId);
+  const entries = getMinimizedPanelHandles(operationIds)
+    .map((handle): DockEntry | null => {
+      const session = sessionById.get(handle.id);
+      if (!session) {
+        return {
+          handle,
+          label: "Shell",
+          meta: "shell",
+          beaconClassName: "tenant-beacon is-live",
+          activeJobCount: 0,
+          underway: null,
+          active: false,
+        };
+      }
       const activeJobCount = sessionJobs(state, session).filter(({ job }) => !isTerminalJobStatus(job.status)).length;
       const underway: Underway = session.status === "dormant"
         ? null
@@ -59,53 +66,37 @@ export function CanvasDock({ state, sessions, minimized }: CanvasDockProps) {
           : session.turnState === "running"
             ? "turn"
             : null;
-      return { session, activeJobCount, underway, active: state.activeTerminalSessionId === session.sessionId };
-    });
-  // 핀/페이지 effect의 의존 키: 칩 개수뿐 아니라 minimized 세션 ID 집합·순서까지 반영한다. 같은 개수의 다른
-  // Theater로 전환하거나(개수 불변) ID가 교체될 때도 effect가 재실행돼 우측 끝 핀·페이지 상태를 새 칩 세트
-  // 기준으로 재설정한다 — entries.length만 의존하면 이런 경우 stale scrollLeft/pinRight/pager가 재사용된다.
-  const entriesKey = entries.map((entry) => entry.session.sessionId).join(",");
-  // 칩 폭에 영향을 주는 데이터(이름·CLI 라벨·활성 잡 수)의 서명. 같은 ID라도 이 값이 바뀌면 트랙 폭(scrollWidth)이
-  // 달라지지만 ResizeObserver는 콘텐츠 폭 변화엔 발화하지 않으므로, 이 키로 별도 effect를 돌려 페이지 수를
-  // 다시 측정한다(우측 핀 상태였으면 최신 칩을 계속 노출하고, 과거로 페이징한 상태면 위치를 보존).
-  const metricsKey = entries
-    .map((entry) => `${sessionDisplayLabel(entry.session)}${entry.session.cliLabel ?? entry.session.cliId ?? ""}${entry.activeJobCount}`)
-    .join("");
+      return {
+        handle,
+        label: sessionDisplayLabel(session),
+        meta: session.cliLabel ?? session.cliId ?? "CLI",
+        beaconClassName: sessionBeaconClassName(session, activeJobCount),
+        activeJobCount,
+        underway,
+        active: state.activeTerminalSessionId === session.sessionId,
+      };
+    })
+    .filter((entry): entry is DockEntry => Boolean(entry));
+  const entriesKey = entries.map((entry) => entry.handle.id).join(",");
+  const metricsKey = entries.map((entry) => `${entry.label}\u0001${entry.meta}\u0001${entry.activeJobCount}`).join("\u0002");
 
-  // 칩 트랙의 스크롤 위치로 페이지네이션 상태를 재계산한다(가용 폭 초과·양끝·현재/총 페이지).
-  // 페이지 번호는 우측 끝(최신)=1, 좌측으로 갈수록 증가한다.
   const measure = useCallback(() => {
     const el = chipsRef.current;
     if (!el) return;
-    const { scrollLeft, clientWidth, clientHeight, scrollWidth } = el;
+    const { scrollLeft, clientWidth, scrollWidth } = el;
     const maxScroll = Math.max(0, scrollWidth - clientWidth);
-    // 칩 트랙이 보이지 않으면(접힘 시 레일 max-height:0 → 트랙 clientHeight:0) overflow를 false로 둔다 — 안 그러면
-    // scrollWidth>0인 비어있지 않은 dock가 항상 overflow:true로 기록돼, 펼침 직후 stale 상태로 페이저가 떠
-    // 칩셋이 페이저 없이는 맞는데도 페이저가 계속 표시된다(페이저가 자기 폭만큼 트랙을 줄여 overflow를 자가 정당화).
-    const overflow = clientWidth > 0 && clientHeight > 0 && maxScroll > 1;
+    const overflow = clientWidth > 0 && maxScroll > 1;
     const pages = overflow ? Math.max(1, Math.ceil(scrollWidth / clientWidth)) : 1;
     const atEnd = scrollLeft >= maxScroll - 1;
-    // 페이지 번호(우측 끝=1): 우측 끝은 1로 고정하고, 그 외는 ceil로 올린다. round는 비정수 오버플로에서
-    // 좌측 끝을 과소보고하지만(예: cw=640·scrollWidth=1300이면 좌측 끝에서 round(660/640)+1=2≠pages),
-    // ceil((maxScroll-scrollLeft)/cw)+1은 좌측 끝에서 ceil(maxScroll/cw)+1=ceil(scrollWidth/cw)=pages로 정확히 맞는다.
     const page = overflow ? (atEnd ? 1 : Math.min(pages, Math.ceil((maxScroll - scrollLeft) / clientWidth) + 1)) : 1;
-    setPager({
-      overflow,
-      atStart: scrollLeft <= 1,
-      atEnd,
-      page,
-      pages,
-    });
+    setPager({ overflow, atStart: scrollLeft <= 1, atEnd, page, pages });
   }, []);
 
-  // 펼침·칩 세트(entriesKey) 변화 시 우측 끝(최신)으로 핀하고, ResizeObserver·scroll로 폭/위치 변화를 추적해
-  // 페이지 상태를 갱신한다. 핀 상태에선 레일 펼침 전환 등 폭이 변해도 최신 칩이 계속 우측에 노출되도록 다시
-  // 우측 끝에 맞춘다.
   useEffect(() => {
     const el = chipsRef.current;
     if (!el) return;
     pinRightRef.current = true;
-    if (expanded) el.scrollLeft = el.scrollWidth;
+    el.scrollLeft = el.scrollWidth;
     measure();
     const observer = typeof ResizeObserver !== "undefined"
       ? new ResizeObserver(() => {
@@ -124,39 +115,18 @@ export function CanvasDock({ state, sessions, minimized }: CanvasDockProps) {
       observer?.disconnect();
       el.removeEventListener("scroll", onScroll);
     };
-  }, [expanded, entriesKey, measure]);
+  }, [entriesKey, measure]);
 
-  // 같은 ID 칩이라도 이름·CLI 라벨·활성 잡 수가 바뀌면 트랙 폭(scrollWidth)이 달라진다. ResizeObserver는
-  // 뷰포트 박스 크기만 보고 콘텐츠 폭 변화엔 발화하지 않으므로, metricsKey가 바뀌면 여기서 다시 측정해
-  // 페이지 수를 갱신한다. 위 effect(ID 세트 변화)와 달리 강제 우측 핀은 하지 않고, 이미 우측에 핀돼 있던
-  // 경우에만 최신 칩을 다시 노출하도록 우측 끝에 맞춰 사용자의 페이징 위치를 보존한다.
   useEffect(() => {
     const el = chipsRef.current;
-    if (!el || !expanded) return;
+    if (!el) return;
     if (pinRightRef.current) el.scrollLeft = el.scrollWidth;
     measure();
-  }, [expanded, metricsKey, measure]);
+  }, [metricsKey, measure]);
 
   if (entries.length === 0) return null;
 
-  // 접힘 핸들의 알림: 최소화 패널 중 살아있는 신호를 집계한다(live 우선, 없으면 turn).
-  const aggregate: Underway = entries.some((entry) => entry.underway === "live")
-    ? "live"
-    : entries.some((entry) => entry.underway === "turn")
-      ? "turn"
-      : null;
-
-  const toggleClassName = [
-    "canvas-dock-toggle",
-    aggregate ? `canvas-dock-toggle--attention-${aggregate}` : "",
-  ]
-    .filter(Boolean)
-    .join(" ");
-
-  // 페이저는 펼침 + 가용 폭 초과일 때만 노출한다(접힘 시엔 칩 자체가 숨겨진다).
-  const showPager = expanded && pager.overflow;
-
-  // 한 페이지(클라이언트 폭)만큼 스크롤한다. prev('<')=좌측(과거), next('>')=우측(최신).
+  const showPager = pager.overflow;
   const turnPage = (direction: -1 | 1) => {
     const el = chipsRef.current;
     if (!el) return;
@@ -167,96 +137,51 @@ export function CanvasDock({ state, sessions, minimized }: CanvasDockProps) {
   };
 
   return (
-    <div className={`canvas-dock ${expanded ? "is-expanded" : ""}`} data-canvas-blocker>
-      {/* 토글(접힘 핸들): dock 세로 스택의 위쪽. 접힘 시 화면 하단 가로 중앙에 단독으로 놓이고(∧ 위 chevron),
-          펼치면 아래 레일이 한 줄 높이만큼 솟아 토글이 한 칸 위로 밀린다(∨ 아래 chevron). */}
-      <button
-        type="button"
-        className={toggleClassName}
-        onClick={toggleDockExpanded}
-        aria-expanded={expanded}
-        aria-label={expanded ? "Collapse minimized panels" : "Expand minimized panels"}
-        title={expanded ? "Collapse" : "Expand"}
-      >
-        <span className="canvas-dock-toggle-beacon" aria-hidden="true" />
-        <span className="canvas-dock-toggle-chevron" aria-hidden="true">
-          <ChevronIcon />
-        </span>
-        <span className="canvas-dock-toggle-count">{entries.length}</span>
-      </button>
-      {/* 토글 아래로 펼쳐지는 칩 행: 페이저 + 칩 트랙 + 페이지 표시. 화면 중앙에 정렬되고, 접힘 시 높이 0 +
-          inert로 숨는다. 칩이 가용폭(부모 max-width)을 넘으면 페이저로 페이지를 넘긴다. */}
-      <div
-        className="canvas-dock-rail"
-        role="toolbar"
-        aria-label="Minimized operations"
-        aria-hidden={!expanded}
-        inert={!expanded}
-      >
+    <div className="canvas-dock is-taskbar" data-canvas-blocker>
+      <div className="canvas-dock-rail" role="toolbar" aria-label="Minimized windows">
         {showPager ? (
-          <button
-            type="button"
-            className="canvas-dock-pager canvas-dock-pager--prev"
-            onClick={() => turnPage(-1)}
-            disabled={pager.atStart}
-            aria-label="Show older minimized operations"
-            title="Older"
-          >
+          <button type="button" className="canvas-dock-pager canvas-dock-pager--prev" onClick={() => turnPage(-1)} disabled={pager.atStart} aria-label="Show older minimized windows" title="Older">
             <PagerCaret direction="prev" />
           </button>
         ) : null}
         <div className="canvas-dock-chips" ref={chipsRef}>
           {entries.map((entry, index) => (
-            <CanvasDockChip key={entry.session.sessionId} entry={entry} index={index} />
+            <CanvasDockChip key={entry.handle.id} entry={entry} index={index} />
           ))}
         </div>
         {showPager ? (
-          <button
-            type="button"
-            className="canvas-dock-pager canvas-dock-pager--next"
-            onClick={() => turnPage(1)}
-            disabled={pager.atEnd}
-            aria-label="Show newer minimized operations"
-            title="Newer"
-          >
+          <button type="button" className="canvas-dock-pager canvas-dock-pager--next" onClick={() => turnPage(1)} disabled={pager.atEnd} aria-label="Show newer minimized windows" title="Newer">
             <PagerCaret direction="next" />
           </button>
         ) : null}
-        {showPager ? (
-          <span className="canvas-dock-page" aria-label={`Page ${pager.page} of ${pager.pages}`}>
-            {pager.page}/{pager.pages}
-          </span>
-        ) : null}
+        {showPager ? <span className="canvas-dock-page" aria-label={`Page ${pager.page} of ${pager.pages}`}>{pager.page}/{pager.pages}</span> : null}
       </div>
     </div>
   );
 }
 
 function CanvasDockChip({ entry, index }: CanvasDockChipProps) {
-  const { session, activeJobCount, underway, active } = entry;
-  const displayLabel = sessionDisplayLabel(session);
-
-  // 복원: 최소화 목록에서 빼 원위치·원크기로 캔버스에 되돌리고, 그 세션을 활성화한다.
-  const restore = () => {
-    restorePanel(session.sessionId);
-    selectTerminalSession(session.sessionId);
-  };
-
   const chipClassName = [
     "canvas-dock-chip",
-    active ? "canvas-dock-chip--active" : "",
-    underway ? `canvas-dock-chip--underway canvas-dock-chip--underway-${underway}` : "",
-  ]
-    .filter(Boolean)
-    .join(" ");
+    entry.active ? "canvas-dock-chip--active" : "",
+    entry.underway ? `canvas-dock-chip--underway canvas-dock-chip--underway-${entry.underway}` : "",
+  ].filter(Boolean).join(" ");
 
-  // 칩 전체가 복원 트리거 — 단일 클릭(또는 키보드 Enter/Space)으로 패널을 되돌린다(별도 복원 버튼 없음).
+  const restore = () => restoreWindowPanel(entry.handle);
+  // pointerdown은 전파만 막고(칩 복원·드래그 경로 차단), 실제 닫기는 click에서 한 번만 실행한다 —
+  // pointerdown과 click 양쪽에 닫기를 걸면 closeWindowPanel이 이중 호출되어 두 번째 terminate가 에러 토스트를 띄운다.
+  const stopClosePointer = (event: SyntheticEvent<HTMLButtonElement>) => { event.stopPropagation(); };
+  const close = (event: SyntheticEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    closeWindowPanel(entry.handle);
+  };
+
   return (
     <div
       className={chipClassName}
       role="button"
       tabIndex={0}
-      aria-label={`Restore operation ${displayLabel}`}
+      aria-label={`Restore ${entry.label}`}
       title="Click to restore"
       style={{ "--i": index } as CSSProperties}
       onClick={restore}
@@ -267,35 +192,29 @@ function CanvasDockChip({ entry, index }: CanvasDockChipProps) {
         }
       }}
     >
-      <span className={sessionBeaconClassName(session, activeJobCount)} aria-hidden="true" />
-      <span className="canvas-dock-chip-name">{displayLabel}</span>
-      <span className="canvas-dock-chip-cli">{session.cliLabel ?? session.cliId ?? "CLI"}</span>
-      {activeJobCount > 0 ? <span className="canvas-dock-chip-count">{activeJobCount}</span> : null}
+      <span className={entry.beaconClassName} aria-hidden="true" />
+      <span className="canvas-dock-chip-name">{entry.label}</span>
+      <span className="canvas-dock-chip-cli">{entry.meta}</span>
+      {entry.activeJobCount > 0 ? <span className="canvas-dock-chip-count">{entry.activeJobCount}</span> : null}
+      <button type="button" className="canvas-dock-chip-close" onPointerDown={stopClosePointer} onClick={close} aria-label={`Close ${entry.label}`} title="Close">
+        <CloseIcon />
+      </button>
     </div>
   );
 }
 
-function ChevronIcon() {
-  // 단일 chevron ∧ (위, 펼치기). 펼친 상태에서는 컨테이너 .is-expanded가 180° 회전시켜 ∨ (아래, 접기)로 보인다.
+function CloseIcon() {
   return (
     <svg viewBox="0 0 16 16" aria-hidden="true">
-      <path d="M4 10l4-4 4 4" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M4.6 4.6 11.4 11.4M11.4 4.6 4.6 11.4" fill="none" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" />
     </svg>
   );
 }
 
 function PagerCaret({ direction }: { readonly direction: "prev" | "next" }) {
-  // 단일 chevron — prev는 ‹(좌, 과거 페이지), next는 ›(우, 최신 페이지).
   return (
     <svg viewBox="0 0 16 16" aria-hidden="true">
-      <path
-        d={direction === "prev" ? "M10 3.5 5.5 8 10 12.5" : "M6 3.5 10.5 8 6 12.5"}
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+      <path d={direction === "prev" ? "M10 3.5 5.5 8 10 12.5" : "M6 3.5 10.5 8 6 12.5"} fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 }

--- a/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
@@ -7,8 +7,9 @@ import { sessionBeaconClassName, sessionDisplayLabel } from "../format.js";
 import { isTerminalJobStatus } from "../reduce.js";
 import { applySessionUpdate, failRenameTerminalSession, failResumeTerminalSession, failTerminateTerminalSession, removeTerminalSession, selectJob, selectTerminalSession, sessionJobs } from "../store.js";
 import type { ConsoleState, SessionInfo } from "../types.js";
-import { minimizePanel, setPanelGeometry, type CanvasViewport, type PanelGeometry } from "./canvas-store.js";
+import { setPanelGeometry, type CanvasViewport, type PanelGeometry } from "./canvas-store.js";
 import { PanelResizeHandles } from "./panel-resize.js";
+import { minimizeWindowPanel, operationPanelHandle } from "./window-registry.js";
 
 interface CanvasPanelProps {
   readonly state: ConsoleState;
@@ -16,6 +17,8 @@ interface CanvasPanelProps {
   readonly geometry: PanelGeometry;
   readonly viewport: CanvasViewport;
   readonly active: boolean;
+  readonly onFocusRequest: () => void;
+  readonly onMaximize: () => void;
 }
 
 interface DragState {
@@ -25,7 +28,7 @@ interface DragState {
   readonly geometry: PanelGeometry;
 }
 
-export function CanvasPanel({ state, session, geometry, viewport, active }: CanvasPanelProps) {
+export function CanvasPanel({ state, session, geometry, viewport, active, onFocusRequest, onMaximize }: CanvasPanelProps) {
   const dragRef = useRef<DragState | null>(null);
   const [renaming, setRenaming] = useState(false);
   const [draftLabel, setDraftLabel] = useState("");
@@ -182,6 +185,7 @@ export function CanvasPanel({ state, session, geometry, viewport, active }: Canv
         onPointerMove={updateDrag}
         onPointerUp={endDrag}
         onPointerCancel={endDrag}
+        onDoubleClick={onFocusRequest}
         data-canvas-blocker
       >
         <span className={sessionBeaconClassName(session, activeJobCount)} aria-hidden="true" />
@@ -206,7 +210,10 @@ export function CanvasPanel({ state, session, geometry, viewport, active }: Canv
           <span
             className="canvas-panel-title"
             onPointerDown={onNamePointerDown}
-            onDoubleClick={beginRename}
+            onDoubleClick={(event) => {
+              event.stopPropagation();
+              beginRename();
+            }}
             title="Double-click to rename"
           >
             {displayLabel}
@@ -218,11 +225,21 @@ export function CanvasPanel({ state, session, geometry, viewport, active }: Canv
           type="button"
           className="canvas-panel-icon-button"
           onPointerDown={stopButtonPointer}
-          onClick={() => { minimizePanel(session.sessionId); }}
+          onClick={() => { minimizeWindowPanel(operationPanelHandle(session.sessionId)); }}
           aria-label={`Minimize operation ${displayLabel}`}
           title="Minimize panel"
         >
           <MinimizeIcon />
+        </button>
+        <button
+          type="button"
+          className="canvas-panel-icon-button"
+          onPointerDown={stopButtonPointer}
+          onClick={onMaximize}
+          aria-label={`Maximize operation ${displayLabel}`}
+          title="Maximize panel"
+        >
+          <MaximizePanelIcon />
         </button>
         <button
           type="button"
@@ -288,6 +305,14 @@ function MinimizeIcon() {
   return (
     <svg viewBox="0 0 16 16" aria-hidden="true">
       <path d="M3.5 11.5h9" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function MaximizePanelIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M4.2 4.2h7.6v7.6H4.2z" fill="none" stroke="currentColor" strokeWidth="1.35" strokeLinejoin="round" />
     </svg>
   );
 }

--- a/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
@@ -9,7 +9,7 @@ import { applySessionUpdate, failRenameTerminalSession, failResumeTerminalSessio
 import type { ConsoleState, SessionInfo } from "../types.js";
 import { setPanelGeometry, type CanvasViewport, type PanelGeometry } from "./canvas-store.js";
 import { PanelResizeHandles } from "./panel-resize.js";
-import { minimizeWindowPanel, operationPanelHandle } from "./window-registry.js";
+import { clearMaximizedPanelId, minimizeWindowPanel, operationPanelHandle } from "./window-registry.js";
 
 interface CanvasPanelProps {
   readonly state: ConsoleState;
@@ -17,6 +17,8 @@ interface CanvasPanelProps {
   readonly geometry: PanelGeometry;
   readonly viewport: CanvasViewport;
   readonly active: boolean;
+  // 최대화 오버레이 렌더 여부 — drag/geometry 영속을 막고 닫기 시 최대화를 해제한다.
+  readonly maximized?: boolean;
   readonly onFocusRequest: () => void;
   readonly onMaximize: () => void;
 }
@@ -28,7 +30,7 @@ interface DragState {
   readonly geometry: PanelGeometry;
 }
 
-export function CanvasPanel({ state, session, geometry, viewport, active, onFocusRequest, onMaximize }: CanvasPanelProps) {
+export function CanvasPanel({ state, session, geometry, viewport, active, maximized = false, onFocusRequest, onMaximize }: CanvasPanelProps) {
   const dragRef = useRef<DragState | null>(null);
   const [renaming, setRenaming] = useState(false);
   const [draftLabel, setDraftLabel] = useState("");
@@ -55,7 +57,9 @@ export function CanvasPanel({ state, session, geometry, viewport, active, onFocu
 
   const bringToFront = () => {
     selectTerminalSession(session.sessionId);
-    setPanelGeometry(session.sessionId, geometry);
+    // 최대화 오버레이에선 패널이 오버레이 전용 geometry를 받으므로 그것을 저장 geometry로 영속하면 안 된다
+    // (복원 시 원래 위치·크기 손실). 활성화만 하고 geometry 영속은 건너뛴다.
+    if (!maximized) setPanelGeometry(session.sessionId, geometry);
   };
 
   // dock의 job을 선택할 때, 비활성 패널이면 먼저 그 세션을 활성화해야 JobOverlay가 해당 tenant에서
@@ -67,6 +71,8 @@ export function CanvasPanel({ state, session, geometry, viewport, active, onFocu
 
   const beginDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return;
+    // 최대화 상태에선 드래그 이동을 막는다(updateDrag가 오버레이 좌표를 저장 geometry에 덮어쓰지 않게).
+    if (maximized) return;
     event.preventDefault();
     event.stopPropagation();
     bringToFront();
@@ -245,7 +251,7 @@ export function CanvasPanel({ state, session, geometry, viewport, active, onFocu
           type="button"
           className="canvas-panel-icon-button"
           onPointerDown={stopButtonPointer}
-          onClick={() => { void closeSession(session.sessionId); }}
+          onClick={() => { if (maximized) clearMaximizedPanelId(); void closeSession(session.sessionId); }}
           aria-label={`${dormant ? "Forget" : "Terminate"} operation ${displayLabel}`}
           title={dormant ? "Forget operation" : "Terminate operation"}
         >

--- a/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
@@ -265,7 +265,7 @@ export function CanvasPanel({ state, session, geometry, viewport, active, maximi
             <span className="canvas-panel-dormant-action">Resume</span>
           </button>
         ) : (
-          <Terminal sessionId={session.sessionId} active={active} zoom={viewport.zoom} onExit={() => removeTerminalSession(session.sessionId)} />
+          <Terminal sessionId={session.sessionId} active={active} zoom={viewport.zoom} onExit={() => { if (maximized) clearMaximizedPanelId(); removeTerminalSession(session.sessionId); }} />
         )}
       </div>
       <PanelResizeHandles geometry={geometry} zoom={viewport.zoom} onResize={(nextGeometry) => setPanelGeometry(session.sessionId, nextGeometry)} />

--- a/runtime/fleet-console/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/client/src/canvas/canvas-store.ts
@@ -17,6 +17,7 @@ export interface CanvasViewport {
 export interface CanvasState {
   readonly viewport: CanvasViewport;
   readonly panels: Record<string, PanelGeometry>;
+  readonly panelCreatedAt: Record<string, number>;
   // 최소화된 Operation sessionId 목록. geometry는 panels에 그대로 보존되므로 복원은 원위치·원크기로 되돌린다.
   readonly minimized: readonly string[];
 }
@@ -30,8 +31,7 @@ type Listener = () => void;
 
 const STORAGE_KEY_PREFIX = "fleet-console.canvas.";
 const BACKGROUND_ANIMATION_STORAGE_KEY = "fleet-console.canvas.backgroundAnimation";
-const MAXIMIZED_STORAGE_KEY = "fleet-console.canvas.maximized";
-const DOCK_EXPANDED_STORAGE_KEY = "fleet-console.canvas.dockExpanded";
+const MAP_FULLSCREEN_STORAGE_KEY = "fleet-console.canvas.maximized";
 const SAVE_DELAY_MS = 400;
 const DEFAULT_PANEL_WIDTH = 640;
 const DEFAULT_PANEL_HEIGHT = 400;
@@ -45,21 +45,20 @@ const ZOOM_TWEEN_FACTOR = 0.2;
 const ZOOM_TWEEN_POSITION_EPSILON = 0.5;
 const ZOOM_TWEEN_ZOOM_EPSILON = 0.001;
 const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
-const EMPTY_STATE: CanvasState = { viewport: DEFAULT_VIEWPORT, panels: {}, minimized: [] };
+const EMPTY_STATE: CanvasState = { viewport: DEFAULT_VIEWPORT, panels: {}, panelCreatedAt: {}, minimized: [] };
 
 const listeners = new Set<Listener>();
 const backgroundAnimationListeners = new Set<Listener>();
-const maximizedListeners = new Set<Listener>();
-const dockExpandedListeners = new Set<Listener>();
+const mapFullscreenListeners = new Set<Listener>();
 let activeTheaterId: string | null = null;
 let saveTimer: number | null = null;
 let state: CanvasState = EMPTY_STATE;
 let backgroundAnimationEnabled = readStoredBackgroundAnimation();
-let maximized = readStoredMaximized();
-let dockExpanded = readStoredDockExpanded();
+let mapFullscreen = readStoredMapFullscreen();
 // 줌 보간 루프가 향하는 목표 viewport. 즉시 이동(pan/focus/load)은 이 값을 current와 동기화해 잔여 보간을 무효화한다.
 let targetViewport: CanvasViewport = DEFAULT_VIEWPORT;
 let zoomRaf: number | null = null;
+let createdAtCounter = 0;
 // 모든 패널(Operations + 셸)이 공유하는 단조 증가 z-index 발급기.
 // 두 레지스트리가 같은 카운터에서 값을 받아 "활성화한 패널이 최상단"이 패널 종류를 가로질러 성립한다.
 let topZIndex = 0;
@@ -83,8 +82,8 @@ export function useBackgroundAnimation(): boolean {
   return useSyncExternalStore(subscribeBackgroundAnimation, getBackgroundAnimationSnapshot, getBackgroundAnimationSnapshot);
 }
 
-export function useMaximized(): boolean {
-  return useSyncExternalStore(subscribeMaximized, getMaximizedSnapshot, getMaximizedSnapshot);
+export function useMapFullscreen(): boolean {
+  return useSyncExternalStore(subscribeMapFullscreen, getMapFullscreenSnapshot, getMapFullscreenSnapshot);
 }
 
 // 최소화 목록은 CanvasState의 일부라 메인 listeners/emit을 그대로 공유한다(별도 채널 불필요).
@@ -92,15 +91,11 @@ export function useMinimized(): readonly string[] {
   return useSyncExternalStore(subscribe, getMinimizedSnapshot, getMinimizedSnapshot);
 }
 
-// 하단 Dock(최소화 패널 트레이)의 펼침/접힘 — 브라우저별 UI 선호라 maximized와 같은 패턴으로 영속한다.
-export function useDockExpanded(): boolean {
-  return useSyncExternalStore(subscribeDockExpanded, getDockExpandedSnapshot, getDockExpandedSnapshot);
-}
-
 export function setState(patch: Partial<CanvasState>): void {
   state = {
     viewport: patch.viewport ?? state.viewport,
     panels: patch.panels ?? state.panels,
+    panelCreatedAt: patch.panelCreatedAt ?? state.panelCreatedAt,
     minimized: patch.minimized ?? state.minimized,
   };
   scheduleSave();
@@ -134,6 +129,7 @@ export function setPanelGeometry(sessionId: string, geometry: PanelGeometry): vo
       ...state.panels,
       [sessionId]: { ...normalizePanelGeometry(geometry, zIndex), zIndex },
     },
+    panelCreatedAt: ensurePanelCreatedAt(sessionId),
   });
 }
 
@@ -172,6 +168,15 @@ export function liftTopZIndex(toAtLeast: number): void {
   topZIndex = Math.max(topZIndex, toAtLeast);
 }
 
+export function claimPanelCreatedAt(): number {
+  createdAtCounter += 1;
+  return createdAtCounter;
+}
+
+export function liftPanelCreatedAt(toAtLeast: number): void {
+  createdAtCounter = Math.max(createdAtCounter, toAtLeast);
+}
+
 export function ensureDefaultGeometry(sessionId: string): PanelGeometry {
   const existing = state.panels[sessionId];
   if (existing) return existing;
@@ -183,7 +188,7 @@ export function ensureDefaultGeometry(sessionId: string): PanelGeometry {
     height: DEFAULT_PANEL_HEIGHT,
     zIndex: claimTopZIndex(),
   };
-  setState({ panels: { ...state.panels, [sessionId]: geometry } });
+  setState({ panels: { ...state.panels, [sessionId]: geometry }, panelCreatedAt: ensurePanelCreatedAt(sessionId) });
   return geometry;
 }
 
@@ -201,7 +206,9 @@ export function prunePanels(validSessionIds: readonly string[]): void {
   // 사라진 세션은 최소화 목록에서도 함께 제거해 유령 칩이 태스크바에 남지 않게 한다.
   const minimized = state.minimized.filter((sessionId) => valid.has(sessionId));
   const minimizedChanged = minimized.length !== state.minimized.length;
-  if (changed || minimizedChanged) setState({ panels, minimized });
+  const panelCreatedAt = Object.fromEntries(Object.entries(state.panelCreatedAt).filter(([sessionId]) => valid.has(sessionId)));
+  const createdAtChanged = Object.keys(panelCreatedAt).length !== Object.keys(state.panelCreatedAt).length;
+  if (changed || minimizedChanged || createdAtChanged) setState({ panels, panelCreatedAt, minimized });
 }
 
 export function loadForTheater(theaterId: string | null): void {
@@ -209,6 +216,7 @@ export function loadForTheater(theaterId: string | null): void {
   cancelZoomTween();
   activeTheaterId = theaterId;
   state = theaterId ? readStoredState(theaterId) : EMPTY_STATE;
+  liftPanelCreatedAt(maxCreatedAtOf(state.panelCreatedAt));
   targetViewport = state.viewport;
   // 복원된 패널의 최대 zIndex 위로 카운터를 끌어올린다 — 새로고침/Theater 전환 후에도 활성화→최상단을 보장한다.
   topZIndex = Math.max(topZIndex, maxZIndexOf(state.panels));
@@ -249,21 +257,15 @@ export function toggleBackgroundAnimation(): void {
   emitBackgroundAnimation();
 }
 
-export function toggleMaximized(): void {
-  setMaximized(!maximized);
+export function toggleMapFullscreen(): void {
+  setMapFullscreen(!mapFullscreen);
 }
 
-export function setMaximized(value: boolean): void {
-  if (maximized === value) return;
-  maximized = value;
-  writeStoredMaximized(maximized);
-  emitMaximized();
-}
-
-export function toggleDockExpanded(): void {
-  dockExpanded = !dockExpanded;
-  writeStoredDockExpanded(dockExpanded);
-  emitDockExpanded();
+export function setMapFullscreen(value: boolean): void {
+  if (mapFullscreen === value) return;
+  mapFullscreen = value;
+  writeStoredMapFullscreen(mapFullscreen);
+  emitMapFullscreen();
 }
 
 function subscribeBackgroundAnimation(listener: Listener): () => void {
@@ -285,38 +287,23 @@ function emitBackgroundAnimation(): void {
   for (const listener of backgroundAnimationListeners) listener();
 }
 
-function subscribeMaximized(listener: Listener): () => void {
-  maximizedListeners.add(listener);
+function subscribeMapFullscreen(listener: Listener): () => void {
+  mapFullscreenListeners.add(listener);
   return () => {
-    maximizedListeners.delete(listener);
+    mapFullscreenListeners.delete(listener);
   };
 }
 
-function getMaximizedSnapshot(): boolean {
-  return maximized;
+function getMapFullscreenSnapshot(): boolean {
+  return mapFullscreen;
 }
 
 function getMinimizedSnapshot(): readonly string[] {
   return state.minimized;
 }
 
-function emitMaximized(): void {
-  for (const listener of maximizedListeners) listener();
-}
-
-function subscribeDockExpanded(listener: Listener): () => void {
-  dockExpandedListeners.add(listener);
-  return () => {
-    dockExpandedListeners.delete(listener);
-  };
-}
-
-function getDockExpandedSnapshot(): boolean {
-  return dockExpanded;
-}
-
-function emitDockExpanded(): void {
-  for (const listener of dockExpandedListeners) listener();
+function emitMapFullscreen(): void {
+  for (const listener of mapFullscreenListeners) listener();
 }
 
 // 줌 보간 한 프레임: current를 target 쪽으로 ZOOM_TWEEN_FACTOR만큼 당기고, 임계치 안이면 스냅 후 정지한다.
@@ -394,6 +381,11 @@ function writeStoredState(theaterId: string | null, value: CanvasState): void {
   }
 }
 
+function ensurePanelCreatedAt(sessionId: string): Record<string, number> {
+  if (state.panelCreatedAt[sessionId] !== undefined) return state.panelCreatedAt;
+  return { ...state.panelCreatedAt, [sessionId]: claimPanelCreatedAt() };
+}
+
 function readStoredBackgroundAnimation(): boolean {
   if (typeof window === "undefined") return true;
   try {
@@ -414,43 +406,22 @@ function writeStoredBackgroundAnimation(value: boolean): void {
   }
 }
 
-function readStoredMaximized(): boolean {
+function readStoredMapFullscreen(): boolean {
   // 기본값 false: 저장된 선호가 없으면 GNB를 정상 노출해 첫 방문자가 내비게이션을 잃지 않는다.
   if (typeof window === "undefined") return false;
   try {
-    return window.localStorage.getItem(MAXIMIZED_STORAGE_KEY) === "true";
+    return window.localStorage.getItem(MAP_FULLSCREEN_STORAGE_KEY) === "true";
   } catch {
     return false;
   }
 }
 
-function writeStoredMaximized(value: boolean): void {
+function writeStoredMapFullscreen(value: boolean): void {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(MAXIMIZED_STORAGE_KEY, String(value));
+    window.localStorage.setItem(MAP_FULLSCREEN_STORAGE_KEY, String(value));
   } catch {
-    // 최대화 선호 저장 실패는 런타임 동작을 막지 않는다.
-  }
-}
-
-function readStoredDockExpanded(): boolean {
-  // 기본값 true: 패널을 처음 최소화하면 곧바로 칩이 보이도록 펼친 상태로 시작한다.
-  if (typeof window === "undefined") return true;
-  try {
-    const stored = window.localStorage.getItem(DOCK_EXPANDED_STORAGE_KEY);
-    if (stored === null) return true;
-    return stored === "true";
-  } catch {
-    return true;
-  }
-}
-
-function writeStoredDockExpanded(value: boolean): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(DOCK_EXPANDED_STORAGE_KEY, String(value));
-  } catch {
-    // Dock 펼침 선호 저장 실패는 런타임 동작을 막지 않는다.
+    // 맵 전체화면 선호 저장 실패는 런타임 동작을 막지 않는다.
   }
 }
 
@@ -464,9 +435,21 @@ function normalizeCanvasState(value: unknown): CanvasState {
   return {
     viewport: normalizeViewport(value.viewport),
     panels,
+    panelCreatedAt: normalizePanelCreatedAt(value.panelCreatedAt, panels),
     // 저장된 최소화 목록 중 실재하는 패널만 남긴다(stale 직렬화 방어).
     minimized: normalizeMinimized(value.minimized, panels),
   };
+}
+
+function normalizePanelCreatedAt(value: unknown, panels: Record<string, PanelGeometry>): Record<string, number> {
+  const result: Record<string, number> = {};
+  const stored = isRecord(value) ? value : {};
+  let fallback = 0;
+  for (const sessionId of Object.keys(panels)) {
+    fallback += 1;
+    result[sessionId] = readPositiveNumber(stored[sessionId], fallback);
+  }
+  return result;
 }
 
 function normalizeMinimized(value: unknown, panels: Record<string, PanelGeometry>): readonly string[] {
@@ -524,6 +507,10 @@ function nextZIndexForPanels(panels: Record<string, PanelGeometry>): number {
 
 function maxZIndexOf(panels: Record<string, PanelGeometry>): number {
   return Math.max(0, ...Object.values(panels).map((panel) => panel.zIndex));
+}
+
+function maxCreatedAtOf(value: Record<string, number>): number {
+  return Math.max(0, ...Object.values(value));
 }
 
 function readFiniteNumber(value: unknown, fallback: number): number {

--- a/runtime/fleet-console/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas.tsx
@@ -229,8 +229,11 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
           );
         })}
         {Object.entries(shellPanels).map(([id, entry]) => {
-          if (minimizedShellSet.has(id)) return null;
+          // 최대화된 셸은 오버레이에서 단독 렌더되므로 world 루프에서는 건너뛴다.
           if (maximizedPanelId === id) return null;
+          // 최소화된 셸은 언마운트하지 않고 visibility:hidden으로 숨긴다 — Terminal/WS를 살려둬
+          // theater-shell의 소켓 단절 grace(4s)가 발동해 실행 중 셸이 죽는 것을 막는다(복원 시 동일 PTY 재부착).
+          const minimizedShell = minimizedShellSet.has(id);
           const handle = panelHandles.find((panel) => panel.id === id) ?? shellPanelHandle(id);
           return (
             <ShellCanvasPanel
@@ -239,7 +242,8 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
               theaterId={entry.theaterId}
               geometry={entry.geometry}
               viewport={canvas.viewport}
-              active={activeShellId === id}
+              active={!minimizedShell && activeShellId === id}
+              minimized={minimizedShell}
               onFocusRequest={() => focusWindowPanel(shellPanelHandle(id), canvasSize)}
               onMaximize={() => maximizePanel(handle)}
             />

--- a/runtime/fleet-console/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas.tsx
@@ -16,7 +16,7 @@ import { ShellCanvasPanel } from "./shell-canvas-panel.js";
 import { addShellPanel, getMinimizedShellPanelIds, setActiveShellPanel, useActiveShellId, useShellPanels } from "./shell-panels.js";
 import { useCanvasInteraction } from "./use-canvas-interaction.js";
 import { screenToCanvas, type CanvasPoint, type CanvasRect } from "./coordinates.js";
-import { clearMaximizedPanelId, focusWindowPanel, getPanelHandles, minimizeWindowPanel, operationPanelHandle, restoreWindowPanel, setMaximizedPanelId, shellPanelHandle, useMaximizedPanelId, type WindowPanelHandle } from "./window-registry.js";
+import { clearMaximizedPanelId, focusWindowPanel, getPanelHandles, maximizeWindowPanel, operationPanelHandle, shellPanelHandle, useMaximizedPanelId, type WindowPanelHandle } from "./window-registry.js";
 
 interface OperationsCanvasProps {
   readonly state: ConsoleState;
@@ -160,13 +160,7 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
   const operationIds = sessions.map((session) => session.sessionId);
   const panelHandles = getPanelHandles(operationIds);
   const maximizedHandle = maximizedPanelId ? panelHandles.find((handle) => handle.id === maximizedPanelId) ?? null : null;
-  const maximizePanel = (target: WindowPanelHandle) => {
-    for (const handle of panelHandles) {
-      if (handle.id !== target.id) minimizeWindowPanel(handle);
-    }
-    restoreWindowPanel(target);
-    setMaximizedPanelId(target.id);
-  };
+  const maximizePanel = (target: WindowPanelHandle) => maximizeWindowPanel(target, panelHandles);
   const maximizedOverlayGeometry = {
     x: 0,
     y: 0,

--- a/runtime/fleet-console/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas.tsx
@@ -4,7 +4,7 @@ import { createTheaterTerminalSession } from "../api.js";
 import { OperationLaunchMenu } from "../components/operation-launch-menu.js";
 import { beginCreateTerminalSession, completeCreateTerminalSession, failCreateTerminalSession, selectTerminalSession, theaterSessions } from "../store.js";
 import type { AgentCliMetadata, ConsoleState } from "../types.js";
-import { animateViewportTo, claimTopZIndex, setPanelGeometry, setViewport, toggleBackgroundAnimation, toggleMaximized, useBackgroundAnimation, useCanvasState, useMaximized, useMinimized, type PanelGeometry } from "./canvas-store.js";
+import { animateViewportTo, claimTopZIndex, setPanelGeometry, setViewport, toggleBackgroundAnimation, toggleMapFullscreen, useBackgroundAnimation, useCanvasState, useMapFullscreen, useMinimized, type PanelGeometry } from "./canvas-store.js";
 import { CanvasContextMenu } from "./canvas-context-menu.js";
 import { CanvasMinimap } from "./canvas-minimap.js";
 import { CanvasPanel } from "./canvas-panel.js";
@@ -13,9 +13,10 @@ import { CanvasGrid } from "./canvas-grid.js";
 import { MapShortcuts } from "./map-shortcuts.js";
 import { RubberBand } from "./rubber-band.js";
 import { ShellCanvasPanel } from "./shell-canvas-panel.js";
-import { addShellPanel, setActiveShellPanel, useActiveShellId, useShellPanels } from "./shell-panels.js";
+import { addShellPanel, getMinimizedShellPanelIds, setActiveShellPanel, useActiveShellId, useShellPanels } from "./shell-panels.js";
 import { useCanvasInteraction } from "./use-canvas-interaction.js";
 import { screenToCanvas, type CanvasPoint, type CanvasRect } from "./coordinates.js";
+import { clearMaximizedPanelId, focusWindowPanel, getPanelHandles, minimizeWindowPanel, operationPanelHandle, restoreWindowPanel, setMaximizedPanelId, shellPanelHandle, useMaximizedPanelId, type WindowPanelHandle } from "./window-registry.js";
 
 interface OperationsCanvasProps {
   readonly state: ConsoleState;
@@ -44,8 +45,9 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
   const canvasRef = useRef<HTMLElement | null>(null);
   const canvas = useCanvasState();
   const backgroundAnimationEnabled = useBackgroundAnimation();
-  const maximized = useMaximized();
+  const isMapFullscreen = useMapFullscreen();
   const minimized = useMinimized();
+  const maximizedPanelId = useMaximizedPanelId();
   const shellPanels = useShellPanels();
   const activeShellId = useActiveShellId();
   const sessions = theaterSessions(state);
@@ -149,11 +151,29 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
   };
 
   const minimizedSet = new Set(minimized);
+  const minimizedShellSet = new Set(getMinimizedShellPanelIds());
   // 최소화된 패널은 캔버스에서 빠지므로 미니맵(캔버스 개관)에서도 제외해 "사라진 blip" 불일치를 막는다.
   const visiblePanels = Object.fromEntries(
     Object.entries(canvas.panels).filter(([sessionId]) => !minimizedSet.has(sessionId)),
   );
   const hasContent = sessions.length > 0 || Object.keys(shellPanels).length > 0;
+  const operationIds = sessions.map((session) => session.sessionId);
+  const panelHandles = getPanelHandles(operationIds);
+  const maximizedHandle = maximizedPanelId ? panelHandles.find((handle) => handle.id === maximizedPanelId) ?? null : null;
+  const maximizePanel = (target: WindowPanelHandle) => {
+    for (const handle of panelHandles) {
+      if (handle.id !== target.id) minimizeWindowPanel(handle);
+    }
+    restoreWindowPanel(target);
+    setMaximizedPanelId(target.id);
+  };
+  const maximizedOverlayGeometry = {
+    x: 0,
+    y: 0,
+    width: Math.max(320, canvasSize.width),
+    height: Math.max(240, canvasSize.height - 72),
+    zIndex: 20,
+  };
 
   return (
     <main
@@ -169,14 +189,14 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
       <CanvasGrid viewport={canvas.viewport} backgroundAnimationEnabled={backgroundAnimationEnabled} />
       <button
         type="button"
-        className={`canvas-background-toggle canvas-maximize-toggle ${maximized ? "is-active" : ""}`}
-        onClick={toggleMaximized}
+        className={`canvas-background-toggle canvas-maximize-toggle ${isMapFullscreen ? "is-active" : ""}`}
+        onClick={toggleMapFullscreen}
         data-canvas-blocker
-        aria-label={maximized ? "맵 최대화 해제" : "맵 최대화"}
-        aria-pressed={maximized}
-        title={maximized ? "Exit fullscreen" : "Maximize map"}
+        aria-label={isMapFullscreen ? "맵 전체화면 해제" : "맵 전체화면"}
+        aria-pressed={isMapFullscreen}
+        title={isMapFullscreen ? "Exit map fullscreen" : "Enter map fullscreen"}
       >
-        {maximized ? <RestoreIcon /> : <MaximizeIcon />}
+        {isMapFullscreen ? <RestoreIcon /> : <MaximizeIcon />}
       </button>
       <button
         type="button"
@@ -199,6 +219,8 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
           if (!geometry) return null;
           // 최소화된 패널은 캔버스에서 빠지고 하단 태스크바에 칩으로 표시된다(Terminal 언마운트→복원 시 재연결).
           if (minimizedSet.has(session.sessionId)) return null;
+          if (maximizedPanelId === session.sessionId) return null;
+          const handle = panelHandles.find((entry) => entry.id === session.sessionId) ?? operationPanelHandle(session.sessionId);
           return (
             <CanvasPanel
               key={session.sessionId}
@@ -207,20 +229,61 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
               geometry={geometry}
               viewport={canvas.viewport}
               active={state.activeTerminalSessionId === session.sessionId}
+              onFocusRequest={() => focusWindowPanel(operationPanelHandle(session.sessionId), canvasSize)}
+              onMaximize={() => maximizePanel(handle)}
             />
           );
         })}
-        {Object.entries(shellPanels).map(([id, entry]) => (
-          <ShellCanvasPanel
-            key={id}
-            id={id}
-            theaterId={entry.theaterId}
-            geometry={entry.geometry}
-            viewport={canvas.viewport}
-            active={activeShellId === id}
-          />
-        ))}
+        {Object.entries(shellPanels).map(([id, entry]) => {
+          if (minimizedShellSet.has(id)) return null;
+          if (maximizedPanelId === id) return null;
+          const handle = panelHandles.find((panel) => panel.id === id) ?? shellPanelHandle(id);
+          return (
+            <ShellCanvasPanel
+              key={id}
+              id={id}
+              theaterId={entry.theaterId}
+              geometry={entry.geometry}
+              viewport={canvas.viewport}
+              active={activeShellId === id}
+              onFocusRequest={() => focusWindowPanel(shellPanelHandle(id), canvasSize)}
+              onMaximize={() => maximizePanel(handle)}
+            />
+          );
+        })}
       </div>
+      {maximizedHandle ? (
+        <div className="canvas-panel-maximized-layer" data-canvas-blocker>
+          {sessions.map((session) => (
+            session.sessionId === maximizedHandle.id ? (
+              <CanvasPanel
+                key={session.sessionId}
+                state={state}
+                session={session}
+                geometry={maximizedOverlayGeometry}
+                viewport={{ x: 0, y: 0, zoom: 1 }}
+                active={state.activeTerminalSessionId === session.sessionId}
+                onFocusRequest={() => focusWindowPanel(maximizedHandle, canvasSize)}
+                onMaximize={clearMaximizedPanelId}
+              />
+            ) : null
+          ))}
+          {Object.entries(shellPanels).map(([id, entry]) => (
+            id === maximizedHandle.id ? (
+              <ShellCanvasPanel
+                key={id}
+                id={id}
+                theaterId={entry.theaterId}
+                geometry={maximizedOverlayGeometry}
+                viewport={{ x: 0, y: 0, zoom: 1 }}
+                active={activeShellId === id}
+                onFocusRequest={() => focusWindowPanel(maximizedHandle, canvasSize)}
+                onMaximize={clearMaximizedPanelId}
+              />
+            ) : null
+          ))}
+        </div>
+      ) : null}
       {!hasContent ? (
         <div className="operations-canvas-empty" data-canvas-blocker>
           <span className="operations-canvas-empty-mark" aria-hidden="true" />
@@ -267,7 +330,7 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
       {hasContent ? <MapShortcuts /> : null}
       {/* 최소화된 Operation 패널의 하단 Dock(world가 아닌 캔버스 고정 — 토글을 화면 가로 중앙 하단에 두고
           펼치면 그 아래로 칩이 중앙정렬로 펼쳐진다. 패널과 함께 이동·확대되지 않는다). */}
-      <CanvasDock state={state} sessions={sessions} minimized={minimized} />
+      <CanvasDock state={state} sessions={sessions} />
     </main>
   );
 }

--- a/runtime/fleet-console/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas.tsx
@@ -158,6 +158,10 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
   const visiblePanels = Object.fromEntries(
     Object.entries(canvas.panels).filter(([sessionId]) => !minimizedSet.has(sessionId)),
   );
+  // 최소화된 셸도 미니맵에서 제외한다(Operation과 동일) — 숨은 셸이 blip으로 남거나 미니맵 경계를 왜곡하지 않게.
+  const visibleShellPanels = Object.fromEntries(
+    Object.entries(shellPanels).filter(([id]) => !minimizedShellSet.has(id)),
+  );
   const hasContent = sessions.length > 0 || Object.keys(shellPanels).length > 0;
   const operationIds = sessions.map((session) => session.sessionId);
   const panelHandles = getPanelHandles(operationIds);
@@ -319,7 +323,7 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
       ) : null}
       <CanvasMinimap
         panels={visiblePanels}
-        shellPanels={shellPanels}
+        shellPanels={visibleShellPanels}
         viewport={canvas.viewport}
         canvasSize={canvasSize}
         onJump={(center) => setViewport({

--- a/runtime/fleet-console/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas.tsx
@@ -13,7 +13,7 @@ import { CanvasGrid } from "./canvas-grid.js";
 import { MapShortcuts } from "./map-shortcuts.js";
 import { RubberBand } from "./rubber-band.js";
 import { ShellCanvasPanel } from "./shell-canvas-panel.js";
-import { addShellPanel, getMinimizedShellPanelIds, setActiveShellPanel, useActiveShellId, useShellPanels } from "./shell-panels.js";
+import { addShellPanel, setActiveShellPanel, useActiveShellId, useMinimizedShellPanelIds, useShellPanels } from "./shell-panels.js";
 import { useCanvasInteraction } from "./use-canvas-interaction.js";
 import { screenToCanvas, type CanvasPoint, type CanvasRect } from "./coordinates.js";
 import { clearMaximizedPanelId, focusWindowPanel, getPanelHandles, maximizeWindowPanel, operationPanelHandle, shellPanelHandle, useMaximizedPanelId, type WindowPanelHandle } from "./window-registry.js";
@@ -50,6 +50,8 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
   const maximizedPanelId = useMaximizedPanelId();
   const shellPanels = useShellPanels();
   const activeShellId = useActiveShellId();
+  // 최소화 셸 id를 구독한다 — opportunistic read만 하면 비활성 셸 최소화 시 리렌더가 안 일어난다(Codex P2).
+  const minimizedShellIds = useMinimizedShellPanelIds();
   const sessions = theaterSessions(state);
   const [launchRequest, setLaunchRequest] = useState<LaunchRequest | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuRequest | null>(null);
@@ -151,7 +153,7 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
   };
 
   const minimizedSet = new Set(minimized);
-  const minimizedShellSet = new Set(getMinimizedShellPanelIds());
+  const minimizedShellSet = new Set(minimizedShellIds);
   // 최소화된 패널은 캔버스에서 빠지므로 미니맵(캔버스 개관)에서도 제외해 "사라진 blip" 불일치를 막는다.
   const visiblePanels = Object.fromEntries(
     Object.entries(canvas.panels).filter(([sessionId]) => !minimizedSet.has(sessionId)),

--- a/runtime/fleet-console/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas.tsx
@@ -260,6 +260,7 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
                 session={session}
                 geometry={maximizedOverlayGeometry}
                 viewport={{ x: 0, y: 0, zoom: 1 }}
+                maximized
                 active={state.activeTerminalSessionId === session.sessionId}
                 onFocusRequest={() => focusWindowPanel(maximizedHandle, canvasSize)}
                 onMaximize={clearMaximizedPanelId}
@@ -274,6 +275,7 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
                 theaterId={entry.theaterId}
                 geometry={maximizedOverlayGeometry}
                 viewport={{ x: 0, y: 0, zoom: 1 }}
+                maximized
                 active={activeShellId === id}
                 onFocusRequest={() => focusWindowPanel(maximizedHandle, canvasSize)}
                 onMaximize={clearMaximizedPanelId}

--- a/runtime/fleet-console/client/src/canvas/map-shortcuts.tsx
+++ b/runtime/fleet-console/client/src/canvas/map-shortcuts.tsx
@@ -91,10 +91,10 @@ function QuestionIcon() {
 }
 
 function CollapseIcon() {
-  // 좌하단으로 접는 방향을 가리키는 셰브런.
+  // 좌상단 도움말을 접는 방향을 가리키는 위쪽 셰브런.
   return (
     <svg viewBox="0 0 16 16" aria-hidden="true">
-      <path d="M10.5 4.5 5.5 8l5 3.5M11 8H5.5" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M4.5 10.5 8 5.5l3.5 5M8 11V5.5" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 }

--- a/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
@@ -6,7 +6,7 @@ import { failTerminateTerminalSession, selectTerminalSession } from "../store.js
 import { claimTopZIndex, type CanvasViewport, type PanelGeometry } from "./canvas-store.js";
 import { PanelResizeHandles } from "./panel-resize.js";
 import { removeShellPanel, setActiveShellPanel, setShellPanelGeometry } from "./shell-panels.js";
-import { minimizeWindowPanel, shellPanelHandle } from "./window-registry.js";
+import { clearMaximizedPanelId, minimizeWindowPanel, shellPanelHandle } from "./window-registry.js";
 
 interface ShellCanvasPanelProps {
   readonly id: string;
@@ -16,6 +16,8 @@ interface ShellCanvasPanelProps {
   readonly active: boolean;
   // 최소화 상태 — 언마운트 대신 숨겨 Terminal/WS를 살려둔다(theater-shell PTY가 grace로 죽지 않게).
   readonly minimized?: boolean;
+  // 최대화 오버레이 렌더 여부 — drag/geometry 영속을 막고 닫기 시 최대화를 해제한다.
+  readonly maximized?: boolean;
   readonly onFocusRequest: () => void;
   readonly onMaximize: () => void;
 }
@@ -27,7 +29,7 @@ interface DragState {
   readonly geometry: PanelGeometry;
 }
 
-export function ShellCanvasPanel({ id, theaterId, geometry, viewport, active, minimized = false, onFocusRequest, onMaximize }: ShellCanvasPanelProps) {
+export function ShellCanvasPanel({ id, theaterId, geometry, viewport, active, minimized = false, maximized = false, onFocusRequest, onMaximize }: ShellCanvasPanelProps) {
   const dragRef = useRef<DragState | null>(null);
 
   // 활성화: ① Operations 선택 해제(상호배타 — selectTerminalSession(null)) ② 이 셸을 활성으로 표시
@@ -35,11 +37,14 @@ export function ShellCanvasPanel({ id, theaterId, geometry, viewport, active, mi
   const bringToFront = () => {
     selectTerminalSession(null);
     setActiveShellPanel(id);
-    setShellPanelGeometry(id, { ...geometry, zIndex: claimTopZIndex() });
+    // 최대화 오버레이에선 오버레이 전용 geometry를 저장 geometry로 영속하지 않는다(복원 시 원래 위치·크기 보존).
+    if (!maximized) setShellPanelGeometry(id, { ...geometry, zIndex: claimTopZIndex() });
   };
 
   const beginDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return;
+    // 최대화 상태에선 드래그 이동을 막는다(updateDrag가 오버레이 좌표를 저장 geometry에 덮어쓰지 않게).
+    if (maximized) return;
     event.preventDefault();
     event.stopPropagation();
     bringToFront();
@@ -82,6 +87,9 @@ export function ShellCanvasPanel({ id, theaterId, geometry, viewport, active, mi
 
   // 닫기: 레지스트리에서 제거(언마운트)하고 백엔드 PTY도 즉시 종료한다(grace 대기 없이).
   const close = () => {
+    // 최대화된 셸을 닫으면 최대화 상태도 해제한다 — 안 그러면 maximizedPanelId가 사라진 셸을 가리켜
+    // 다음 Alt 순환이 의도치 않게 재최대화한다.
+    if (maximized) clearMaximizedPanelId();
     removeShellPanel(id);
     void terminateTerminalSession(id).catch((error) => {
       failTerminateTerminalSession(error instanceof Error ? error.message : String(error));

--- a/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
@@ -6,6 +6,7 @@ import { failTerminateTerminalSession, selectTerminalSession } from "../store.js
 import { claimTopZIndex, type CanvasViewport, type PanelGeometry } from "./canvas-store.js";
 import { PanelResizeHandles } from "./panel-resize.js";
 import { removeShellPanel, setActiveShellPanel, setShellPanelGeometry } from "./shell-panels.js";
+import { minimizeWindowPanel, shellPanelHandle } from "./window-registry.js";
 
 interface ShellCanvasPanelProps {
   readonly id: string;
@@ -13,6 +14,8 @@ interface ShellCanvasPanelProps {
   readonly geometry: PanelGeometry;
   readonly viewport: CanvasViewport;
   readonly active: boolean;
+  readonly onFocusRequest: () => void;
+  readonly onMaximize: () => void;
 }
 
 interface DragState {
@@ -22,7 +25,7 @@ interface DragState {
   readonly geometry: PanelGeometry;
 }
 
-export function ShellCanvasPanel({ id, theaterId, geometry, viewport, active }: ShellCanvasPanelProps) {
+export function ShellCanvasPanel({ id, theaterId, geometry, viewport, active, onFocusRequest, onMaximize }: ShellCanvasPanelProps) {
   const dragRef = useRef<DragState | null>(null);
 
   // 활성화: ① Operations 선택 해제(상호배타 — selectTerminalSession(null)) ② 이 셸을 활성으로 표시
@@ -103,11 +106,32 @@ export function ShellCanvasPanel({ id, theaterId, geometry, viewport, active }: 
         onPointerMove={updateDrag}
         onPointerUp={endDrag}
         onPointerCancel={endDrag}
+        onDoubleClick={onFocusRequest}
         data-canvas-blocker
       >
         <span className="tenant-beacon is-live" aria-hidden="true" />
         <span className="canvas-panel-title">Shell</span>
         <span className="canvas-panel-cli">shell</span>
+        <button
+          type="button"
+          className="canvas-panel-icon-button"
+          onPointerDown={stopButtonPointer}
+          onClick={() => { minimizeWindowPanel(shellPanelHandle(id)); }}
+          aria-label="Minimize shell panel"
+          title="Minimize panel"
+        >
+          <MinimizeIcon />
+        </button>
+        <button
+          type="button"
+          className="canvas-panel-icon-button"
+          onPointerDown={stopButtonPointer}
+          onClick={onMaximize}
+          aria-label="Maximize shell panel"
+          title="Maximize panel"
+        >
+          <MaximizePanelIcon />
+        </button>
         <button
           type="button"
           className="canvas-panel-icon-button"
@@ -131,6 +155,22 @@ function CloseIcon() {
   return (
     <svg viewBox="0 0 16 16" aria-hidden="true">
       <path d="M4.6 4.6 11.4 11.4M11.4 4.6 4.6 11.4" fill="none" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function MinimizeIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M3.5 11.5h9" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function MaximizePanelIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M4.2 4.2h7.6v7.6H4.2z" fill="none" stroke="currentColor" strokeWidth="1.35" strokeLinejoin="round" />
     </svg>
   );
 }

--- a/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
@@ -14,6 +14,8 @@ interface ShellCanvasPanelProps {
   readonly geometry: PanelGeometry;
   readonly viewport: CanvasViewport;
   readonly active: boolean;
+  // 최소화 상태 — 언마운트 대신 숨겨 Terminal/WS를 살려둔다(theater-shell PTY가 grace로 죽지 않게).
+  readonly minimized?: boolean;
   readonly onFocusRequest: () => void;
   readonly onMaximize: () => void;
 }
@@ -25,7 +27,7 @@ interface DragState {
   readonly geometry: PanelGeometry;
 }
 
-export function ShellCanvasPanel({ id, theaterId, geometry, viewport, active, onFocusRequest, onMaximize }: ShellCanvasPanelProps) {
+export function ShellCanvasPanel({ id, theaterId, geometry, viewport, active, minimized = false, onFocusRequest, onMaximize }: ShellCanvasPanelProps) {
   const dragRef = useRef<DragState | null>(null);
 
   // 활성화: ① Operations 선택 해제(상호배타 — selectTerminalSession(null)) ② 이 셸을 활성으로 표시
@@ -88,7 +90,7 @@ export function ShellCanvasPanel({ id, theaterId, geometry, viewport, active, on
 
   return (
     <article
-      className={`canvas-panel canvas-panel--shell ${active ? "is-active" : ""}`}
+      className={`canvas-panel canvas-panel--shell ${minimized ? "is-minimized" : ""} ${active ? "is-active" : ""}`}
       style={{
         left: geometry.x,
         top: geometry.y,
@@ -98,6 +100,7 @@ export function ShellCanvasPanel({ id, theaterId, geometry, viewport, active, on
       }}
       onPointerDown={bringToFront}
       data-canvas-panel
+      aria-hidden={minimized || undefined}
       aria-label="Shell panel"
     >
       <div

--- a/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
@@ -155,7 +155,7 @@ export function ShellCanvasPanel({ id, theaterId, geometry, viewport, active, mi
         </button>
       </div>
       <div className="canvas-panel-terminal" onPointerDown={stopCanvasPointer} onWheel={stopCanvasWheel} data-canvas-blocker>
-        <Terminal sessionId={id} kind="shell" theaterId={theaterId} active={active} zoom={viewport.zoom} onExit={() => removeShellPanel(id)} />
+        <Terminal sessionId={id} kind="shell" theaterId={theaterId} active={active} zoom={viewport.zoom} onExit={() => { if (maximized) clearMaximizedPanelId(); removeShellPanel(id); }} />
       </div>
       <PanelResizeHandles geometry={geometry} zoom={viewport.zoom} onResize={(next) => setShellPanelGeometry(id, next)} />
     </article>

--- a/runtime/fleet-console/client/src/canvas/shell-panels.ts
+++ b/runtime/fleet-console/client/src/canvas/shell-panels.ts
@@ -53,6 +53,12 @@ export function getMinimizedShellPanelIds(): readonly string[] {
   return minimized;
 }
 
+// 최소화된 셸 id 목록 구독 — minimizeShellPanel/restoreShellPanel이 minimized를 새 배열 참조로 교체하므로,
+// 이 스냅샷을 구독하면 비활성 셸을 최소화해도(panels·activeShellId 불변) 소비자가 즉시 리렌더된다(숨김·Dock 칩 반영).
+export function useMinimizedShellPanelIds(): readonly string[] {
+  return useSyncExternalStore(subscribe, getMinimizedShellPanelIds, getMinimizedShellPanelIds);
+}
+
 // 셸 패널을 활성(최상단 포커스)으로 표시한다. null이면 활성 셸 없음. activeShellId는 비영속이라 저장하지 않는다.
 export function setActiveShellPanel(id: string | null): void {
   if (activeShellId === id) return;

--- a/runtime/fleet-console/client/src/canvas/shell-panels.ts
+++ b/runtime/fleet-console/client/src/canvas/shell-panels.ts
@@ -1,11 +1,12 @@
 import { useSyncExternalStore } from "react";
 
-import { liftTopZIndex, type PanelGeometry } from "./canvas-store.js";
+import { claimPanelCreatedAt, claimTopZIndex, liftPanelCreatedAt, liftTopZIndex, type PanelGeometry } from "./canvas-store.js";
 
 export interface ShellPanelEntry {
   // 이 셸이 띄워진 Theater id. 백엔드 ticket이 이 id로 cwd(Theater 디렉터리)를 해석한다(raw 경로는 클라이언트에 없음).
   readonly theaterId: string;
   readonly geometry: PanelGeometry;
+  readonly createdAt: number;
 }
 
 type Listener = () => void;
@@ -23,6 +24,7 @@ const listeners = new Set<Listener>();
 // durable 세션을 공유하므로 localStorage지만, 셸은 탭별 PTY라 영속 범위가 다르다.
 // 새로고침하면 모듈은 비워지지만 loadShellPanelsForTheater가 복원하며, 같은 패널 id로 백엔드 PTY에 재부착한다.
 let panels: Record<string, ShellPanelEntry> = {};
+let minimized: readonly string[] = [];
 // 활성(포커스) 셸 패널 id. Operations의 activeTerminalSessionId와 별개의 단일 활성 상태다.
 // 두 종류가 동시에 활성으로 보이지 않도록 하는 상호배타는 상위(canvas) 레이어에서 조정한다.
 // 영속하지 않는다 — 새로고침 직후 어떤 셸도 활성 외형이 아니게 해 Operations 활성과 충돌하지 않게 한다.
@@ -47,6 +49,10 @@ export function getActiveShellId(): string | null {
   return activeShellId;
 }
 
+export function getMinimizedShellPanelIds(): readonly string[] {
+  return minimized;
+}
+
 // 셸 패널을 활성(최상단 포커스)으로 표시한다. null이면 활성 셸 없음. activeShellId는 비영속이라 저장하지 않는다.
 export function setActiveShellPanel(id: string | null): void {
   if (activeShellId === id) return;
@@ -56,7 +62,7 @@ export function setActiveShellPanel(id: string | null): void {
 
 export function addShellPanel(theaterId: string, geometry: PanelGeometry): string {
   const id = newShellPanelId();
-  panels = { ...panels, [id]: { theaterId, geometry } };
+  panels = { ...panels, [id]: { theaterId, geometry, createdAt: nextCreatedAt() } };
   scheduleSave();
   emit();
   return id;
@@ -70,11 +76,29 @@ export function setShellPanelGeometry(id: string, geometry: PanelGeometry): void
   emit();
 }
 
+export function minimizeShellPanel(id: string): void {
+  if (!(id in panels) || minimized.includes(id)) return;
+  minimized = [...minimized, id];
+  if (activeShellId === id) activeShellId = null;
+  scheduleSave();
+  emit();
+}
+
+export function restoreShellPanel(id: string): void {
+  if (!minimized.includes(id)) return;
+  minimized = minimized.filter((entry) => entry !== id);
+  const existing = panels[id];
+  if (existing) panels = { ...panels, [id]: { ...existing, geometry: { ...existing.geometry, zIndex: claimTopZIndex() } } };
+  scheduleSave();
+  emit();
+}
+
 export function removeShellPanel(id: string): void {
   if (!(id in panels)) return;
   const next = { ...panels };
   delete next[id];
   panels = next;
+  minimized = minimized.filter((entry) => entry !== id);
   if (activeShellId === id) activeShellId = null;
   scheduleSave();
   emit();
@@ -83,8 +107,9 @@ export function removeShellPanel(id: string): void {
 // 메모리 레지스트리만 비운다(영속 저장은 건드리지 않는다). Theater 전환·새로고침에는 전체 교체를 담당하는
 // loadShellPanelsForTheater를 쓰고, 이 함수는 영속 없이 화면만 비워야 하는 보조 경로용으로 남긴다.
 export function clearShellPanels(): void {
-  if (Object.keys(panels).length === 0 && activeShellId === null) return;
+  if (Object.keys(panels).length === 0 && activeShellId === null && minimized.length === 0) return;
   panels = {};
+  minimized = [];
   activeShellId = null;
   emit();
 }
@@ -94,7 +119,10 @@ export function clearShellPanels(): void {
 export function loadShellPanelsForTheater(theaterId: string | null): void {
   flushScheduledSave();
   activeTheaterId = theaterId;
-  panels = theaterId ? readStoredShellPanels(theaterId) : {};
+  const restored = theaterId ? readStoredShellPanels(theaterId) : { panels: {}, minimized: [] };
+  panels = restored.panels;
+  minimized = restored.minimized;
+  liftPanelCreatedAt(maxCreatedAtOf(panels));
   // 복원 직후에는 어떤 셸도 활성으로 두지 않는다(Operations 활성과의 상호배타를 깨지 않기 위함).
   activeShellId = null;
   liftTopZIndex(maxZIndexOf(panels));
@@ -118,6 +146,7 @@ export function clearStoredShellPanelsForTheater(theaterId: string): void {
     cancelScheduledSave();
     activeTheaterId = null;
     panels = {};
+    minimized = [];
     activeShellId = null;
     emit();
   }
@@ -160,21 +189,21 @@ function cancelScheduledSave(): void {
   saveTimer = null;
 }
 
-function readStoredShellPanels(theaterId: string): Record<string, ShellPanelEntry> {
-  if (typeof window === "undefined") return {};
+function readStoredShellPanels(theaterId: string): { readonly panels: Record<string, ShellPanelEntry>; readonly minimized: readonly string[] } {
+  if (typeof window === "undefined") return { panels: {}, minimized: [] };
   try {
     const stored = window.sessionStorage.getItem(storageKey(theaterId));
-    if (!stored) return {};
+    if (!stored) return { panels: {}, minimized: [] };
     return normalizeStoredShellPanels(JSON.parse(stored), theaterId);
   } catch {
-    return {};
+    return { panels: {}, minimized: [] };
   }
 }
 
 function writeStoredShellPanels(theaterId: string | null, value: Record<string, ShellPanelEntry>): void {
   if (!theaterId || typeof window === "undefined") return;
   try {
-    window.sessionStorage.setItem(storageKey(theaterId), JSON.stringify({ panels: value }));
+    window.sessionStorage.setItem(storageKey(theaterId), JSON.stringify({ panels: value, minimized }));
   } catch {
     // 저장 실패는 셸 복구성만 낮추므로 런타임 흐름을 막지 않는다.
   }
@@ -185,14 +214,28 @@ function storageKey(theaterId: string): string {
 }
 
 // 저장된 셸 패널을 검증·정규화한다. 셸 id가 아니거나 theaterId가 저장 키와 어긋난 stale 항목은 버린다.
-function normalizeStoredShellPanels(value: unknown, theaterId: string): Record<string, ShellPanelEntry> {
-  if (!isRecord(value) || !isRecord(value.panels)) return {};
+function normalizeStoredShellPanels(value: unknown, theaterId: string): { readonly panels: Record<string, ShellPanelEntry>; readonly minimized: readonly string[] } {
+  if (!isRecord(value) || !isRecord(value.panels)) return { panels: {}, minimized: [] };
   const result: Record<string, ShellPanelEntry> = {};
+  let fallbackCreatedAt = 0;
   for (const [id, entry] of Object.entries(value.panels)) {
     if (!id.startsWith("shell:") || !isRecord(entry)) continue;
     // 저장 키가 theaterId별이므로 entry.theaterId는 그 값과 일치해야 한다. 어긋나면 손상으로 보고 버린다.
     if (entry.theaterId !== theaterId) continue;
-    result[id] = { theaterId, geometry: normalizeGeometry(entry.geometry) };
+    fallbackCreatedAt += 1;
+    result[id] = { theaterId, geometry: normalizeGeometry(entry.geometry), createdAt: readPositiveNumber(entry.createdAt, fallbackCreatedAt) };
+  }
+  return { panels: result, minimized: normalizeMinimized(value.minimized, result) };
+}
+
+function normalizeMinimized(value: unknown, currentPanels: Record<string, ShellPanelEntry>): readonly string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const id of value) {
+    if (typeof id !== "string" || seen.has(id) || !(id in currentPanels)) continue;
+    seen.add(id);
+    result.push(id);
   }
   return result;
 }
@@ -212,6 +255,14 @@ function normalizeGeometry(value: unknown): PanelGeometry {
 
 function maxZIndexOf(value: Record<string, ShellPanelEntry>): number {
   return Math.max(0, ...Object.values(value).map((entry) => entry.geometry.zIndex));
+}
+
+function maxCreatedAtOf(value: Record<string, ShellPanelEntry>): number {
+  return Math.max(0, ...Object.values(value).map((entry) => entry.createdAt));
+}
+
+function nextCreatedAt(): number {
+  return claimPanelCreatedAt();
 }
 
 function readFiniteNumber(value: unknown, fallback: number): number {

--- a/runtime/fleet-console/client/src/canvas/window-registry.ts
+++ b/runtime/fleet-console/client/src/canvas/window-registry.ts
@@ -118,6 +118,9 @@ export function minimizeWindowPanel(handle: WindowPanelHandle): void {
 }
 
 export function restoreWindowPanel(handle: WindowPanelHandle): void {
+  // 다른 창을 월드로 되살릴 때 최대화를 해제한다 — 안 그러면 Dock 칩으로 복원한 창이 최대화 오버레이 뒤로
+  // 들어가 칩이 "아무 동작 안 함"처럼 보인다. (maximizeWindowPanel은 이 호출 직후 setMaximizedPanelId로 재설정한다.)
+  clearMaximizedPanelId();
   if (handle.kind === "operation") {
     restorePanel(handle.id);
     selectTerminalSession(handle.id);

--- a/runtime/fleet-console/client/src/canvas/window-registry.ts
+++ b/runtime/fleet-console/client/src/canvas/window-registry.ts
@@ -125,6 +125,18 @@ export function restoreWindowPanel(handle: WindowPanelHandle): void {
   setActiveShellPanel(handle.id);
 }
 
+// 패널 최대화 진입·전환의 단일 경로. 대상을 제외한 모든 핸들을 Dock으로 최소화하고(이전 최대화 패널도
+// minimizeWindowPanel의 clear 경유로 함께 내려감), 대상은 복원해 오버레이로 띄운다. restoreWindowPanel이
+// 종류별 활성(is-active) 상태까지 동기화하므로 별도 활성 처리가 필요 없다. viewport는 건드리지 않는다 —
+// 최대화 상태 Alt 순환이 "전환만, 카메라 고정"이 되도록.
+export function maximizeWindowPanel(target: WindowPanelHandle, allHandles: readonly WindowPanelHandle[]): void {
+  for (const handle of allHandles) {
+    if (handle.id !== target.id) minimizeWindowPanel(handle);
+  }
+  restoreWindowPanel(target);
+  setMaximizedPanelId(target.id);
+}
+
 export function closeWindowPanel(handle: WindowPanelHandle): void {
   if (handle.kind === "operation") {
     void terminateTerminalSession(handle.id)

--- a/runtime/fleet-console/client/src/canvas/window-registry.ts
+++ b/runtime/fleet-console/client/src/canvas/window-registry.ts
@@ -1,0 +1,175 @@
+import { useSyncExternalStore } from "react";
+
+import { terminateTerminalSession } from "../api.js";
+import { failTerminateTerminalSession, removeTerminalSession, selectTerminalSession } from "../store.js";
+import { animateViewportTo, claimTopZIndex, focusPanel, getSnapshot, minimizePanel, restorePanel, type CanvasViewport, type CanvasViewportSize } from "./canvas-store.js";
+import { getActiveShellId, getMinimizedShellPanelIds, getShellPanels, minimizeShellPanel, removeShellPanel, restoreShellPanel, setActiveShellPanel, setShellPanelGeometry } from "./shell-panels.js";
+
+export type WindowPanelKind = "operation" | "shell";
+
+export interface WindowPanelHandle {
+  readonly kind: WindowPanelKind;
+  readonly id: string;
+  readonly createdAt: number;
+}
+
+export interface WindowRegistryReadiness {
+  readonly operationSessionsHydrated: boolean;
+  readonly shellPanelsHydrated: boolean;
+  readonly theaterReady: boolean;
+}
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+const PANEL_FOCUS_PADDING = 96;
+const FOCUS_MIN_ZOOM = 0.25;
+const FOCUS_MAX_ZOOM = 1;
+
+let maximizedPanelId: string | null = null;
+
+export function useMaximizedPanelId(): string | null {
+  return useSyncExternalStore(subscribe, getMaximizedPanelId, getMaximizedPanelId);
+}
+
+export function getMaximizedPanelId(): string | null {
+  return maximizedPanelId;
+}
+
+export function setMaximizedPanelId(id: string): void {
+  if (maximizedPanelId === id) return;
+  maximizedPanelId = id;
+  emit();
+}
+
+export function clearMaximizedPanelId(): void {
+  if (maximizedPanelId === null) return;
+  maximizedPanelId = null;
+  emit();
+}
+
+export function operationPanelHandle(id: string): WindowPanelHandle {
+  return { kind: "operation", id, createdAt: 0 };
+}
+
+export function shellPanelHandle(id: string): WindowPanelHandle {
+  return { kind: "shell", id, createdAt: 0 };
+}
+
+export function getPanelHandles(operationSessionIds: readonly string[]): readonly WindowPanelHandle[] {
+  const canvas = getSnapshot();
+  const operationHandles = operationSessionIds
+    .filter((id) => canvas.panels[id])
+    .map((id) => ({ kind: "operation" as const, id, createdAt: canvas.panelCreatedAt[id] ?? 0 }));
+  const shellHandles = Object.entries(getShellPanels())
+    .map(([id, entry]) => ({ kind: "shell" as const, id, createdAt: entry.createdAt }));
+  return [...operationHandles, ...shellHandles].sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id));
+}
+
+export function getMinimizedPanelHandles(operationSessionIds: readonly string[]): readonly WindowPanelHandle[] {
+  const canvas = getSnapshot();
+  const validOperationIds = new Set(operationSessionIds);
+  const operationHandles = canvas.minimized
+    .filter((id) => validOperationIds.has(id) && canvas.panels[id])
+    .map((id) => ({ kind: "operation" as const, id, createdAt: canvas.panelCreatedAt[id] ?? 0 }));
+  const shellPanels = getShellPanels();
+  const shellHandles: WindowPanelHandle[] = [];
+  for (const id of getMinimizedShellPanelIds()) {
+    const panel = shellPanels[id];
+    if (panel) shellHandles.push({ kind: "shell", id, createdAt: panel.createdAt });
+  }
+  return [...operationHandles, ...shellHandles].sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id));
+}
+
+export function nextPanelHandle(handles: readonly WindowPanelHandle[], currentId: string | null, delta: number): WindowPanelHandle | null {
+  if (handles.length === 0) return null;
+  const currentIndex = Math.max(0, handles.findIndex((handle) => handle.id === currentId));
+  return handles[(currentIndex + delta + handles.length) % handles.length] ?? null;
+}
+
+export function focusWindowPanel(handle: WindowPanelHandle, viewportSize: CanvasViewportSize): void {
+  if (handle.kind === "operation") {
+    selectTerminalSession(handle.id);
+    focusPanel(handle.id, viewportSize);
+    return;
+  }
+  const panel = getShellPanels()[handle.id];
+  if (!panel) return;
+  restoreShellPanel(handle.id);
+  selectTerminalSession(null);
+  setActiveShellPanel(handle.id);
+  const zIndex = claimTopZIndex();
+  setShellPanelGeometry(handle.id, { ...panel.geometry, zIndex });
+  animateViewportTo(focusedViewportFor(panel.geometry, viewportSize));
+}
+
+export function minimizeWindowPanel(handle: WindowPanelHandle): void {
+  // 최대화된 패널을 최소화하면 최대화 상태도 함께 해제한다 — 안 그러면 오버레이가 그 패널을 계속 렌더해
+  // Dock 칩과 오버레이에 동시에 떠 있는 유령 상태가 된다.
+  if (maximizedPanelId === handle.id) clearMaximizedPanelId();
+  if (handle.kind === "operation") {
+    minimizePanel(handle.id);
+    return;
+  }
+  minimizeShellPanel(handle.id);
+}
+
+export function restoreWindowPanel(handle: WindowPanelHandle): void {
+  if (handle.kind === "operation") {
+    restorePanel(handle.id);
+    selectTerminalSession(handle.id);
+    return;
+  }
+  restoreShellPanel(handle.id);
+  selectTerminalSession(null);
+  setActiveShellPanel(handle.id);
+}
+
+export function closeWindowPanel(handle: WindowPanelHandle): void {
+  if (handle.kind === "operation") {
+    void terminateTerminalSession(handle.id)
+      .then(() => removeTerminalSession(handle.id))
+      .catch((error) => failTerminateTerminalSession(error instanceof Error ? error.message : String(error)));
+    if (maximizedPanelId === handle.id) clearMaximizedPanelId();
+    return;
+  }
+  removeShellPanel(handle.id);
+  void terminateTerminalSession(handle.id).catch((error) => {
+    failTerminateTerminalSession(error instanceof Error ? error.message : String(error));
+  });
+  if (maximizedPanelId === handle.id) clearMaximizedPanelId();
+}
+
+export function pruneDanglingMaximizedPanelId(
+  operationSessionIds: readonly string[],
+  readiness: WindowRegistryReadiness,
+): boolean {
+  if (!readiness.operationSessionsHydrated || !readiness.shellPanelsHydrated || !readiness.theaterReady) return false;
+  if (maximizedPanelId === null) return false;
+  if (getPanelHandles(operationSessionIds).some((handle) => handle.id === maximizedPanelId)) return false;
+  clearMaximizedPanelId();
+  return true;
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+function focusedViewportFor(geometry: { readonly x: number; readonly y: number; readonly width: number; readonly height: number }, viewportSize: CanvasViewportSize): CanvasViewport {
+  const zoom = Math.max(FOCUS_MIN_ZOOM, Math.min(FOCUS_MAX_ZOOM, Math.min(
+    (viewportSize.width - PANEL_FOCUS_PADDING) / geometry.width,
+    (viewportSize.height - PANEL_FOCUS_PADDING) / geometry.height,
+  )));
+  return {
+    x: viewportSize.width / 2 - (geometry.x + geometry.width / 2) * zoom,
+    y: viewportSize.height / 2 - (geometry.y + geometry.height / 2) * zoom,
+    zoom,
+  };
+}

--- a/runtime/fleet-console/client/src/canvas/window-registry.ts
+++ b/runtime/fleet-console/client/src/canvas/window-registry.ts
@@ -83,7 +83,10 @@ export function getMinimizedPanelHandles(operationSessionIds: readonly string[])
 
 export function nextPanelHandle(handles: readonly WindowPanelHandle[], currentId: string | null, delta: number): WindowPanelHandle | null {
   if (handles.length === 0) return null;
-  const currentIndex = Math.max(0, handles.findIndex((handle) => handle.id === currentId));
+  const currentIndex = handles.findIndex((handle) => handle.id === currentId);
+  // 현재/활성 핸들이 없으면(포커스 해제·stale id) delta 방향의 가장자리에서 시작한다.
+  // Math.max(0,-1)로 0에 박으면 Alt+→가 첫 창을 건너뛰고 둘째를 고르는 회귀가 난다(이전 nextOperationId 동작 복원).
+  if (currentIndex === -1) return (delta >= 0 ? handles[0] : handles[handles.length - 1]) ?? null;
   return handles[(currentIndex + delta + handles.length) % handles.length] ?? null;
 }
 

--- a/runtime/fleet-console/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/client/src/pages/operations.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { OperationsCanvas } from "../canvas/canvas.js";
 import { ensureDefaultGeometry, focusPanel, loadForTheater, prunePanels } from "../canvas/canvas-store.js";
 import { getActiveShellId, loadShellPanelsForTheater } from "../canvas/shell-panels.js";
-import { focusWindowPanel, getMaximizedPanelId, getPanelHandles, maximizeWindowPanel, nextPanelHandle, pruneDanglingMaximizedPanelId } from "../canvas/window-registry.js";
+import { clearMaximizedPanelId, focusWindowPanel, getMaximizedPanelId, getPanelHandles, maximizeWindowPanel, nextPanelHandle, pruneDanglingMaximizedPanelId } from "../canvas/window-registry.js";
 import { resumeTerminalSession } from "../api.js";
 import { FloatingJobOverlay } from "../components/floating-job-overlay.js";
 import { applySessionUpdate, consumeOperationFocus, failResumeTerminalSession, selectTerminalSession, theaterSessionOrder } from "../store.js";
@@ -105,6 +105,8 @@ export function Operations({ state }: OperationsProps) {
         }
       }
       if (cancelled) return;
+      // 검색/알림 점프는 패널 최대화를 해제한다(idempotent) — 안 그러면 대상이 최대화 오버레이 뒤로 포커스되어 화면이 그대로 보인다.
+      clearMaximizedPanelId();
       const viewportSize = viewportSizeFor(bodyRef.current);
       if (viewportSize) focusPanel(focusedSessionId, viewportSize);
       consumeOperationFocus();

--- a/runtime/fleet-console/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/client/src/pages/operations.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { OperationsCanvas } from "../canvas/canvas.js";
 import { ensureDefaultGeometry, focusPanel, loadForTheater, prunePanels } from "../canvas/canvas-store.js";
 import { getActiveShellId, loadShellPanelsForTheater } from "../canvas/shell-panels.js";
-import { focusWindowPanel, getMaximizedPanelId, getPanelHandles, nextPanelHandle, pruneDanglingMaximizedPanelId, setMaximizedPanelId } from "../canvas/window-registry.js";
+import { focusWindowPanel, getMaximizedPanelId, getPanelHandles, maximizeWindowPanel, nextPanelHandle, pruneDanglingMaximizedPanelId } from "../canvas/window-registry.js";
 import { resumeTerminalSession } from "../api.js";
 import { FloatingJobOverlay } from "../components/floating-job-overlay.js";
 import { applySessionUpdate, consumeOperationFocus, failResumeTerminalSession, selectTerminalSession, theaterSessionOrder } from "../store.js";
@@ -48,7 +48,8 @@ export function Operations({ state }: OperationsProps) {
       const next = nextPanelHandle(handles, currentId, delta);
       if (!next) return;
       if (maximizedPanelId) {
-        setMaximizedPanelId(next.id);
+        // 최대화 전환: 대상만 복원·최대화하고 이전 최대화 패널 포함 나머지는 Dock으로. viewport는 고정.
+        maximizeWindowPanel(next, handles);
         return;
       }
       const viewportSize = viewportSizeFor(bodyRef.current);

--- a/runtime/fleet-console/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/client/src/pages/operations.tsx
@@ -2,10 +2,11 @@ import { useEffect, useMemo, useRef } from "react";
 
 import { OperationsCanvas } from "../canvas/canvas.js";
 import { ensureDefaultGeometry, focusPanel, loadForTheater, prunePanels } from "../canvas/canvas-store.js";
-import { loadShellPanelsForTheater } from "../canvas/shell-panels.js";
+import { getActiveShellId, loadShellPanelsForTheater } from "../canvas/shell-panels.js";
+import { focusWindowPanel, getMaximizedPanelId, getPanelHandles, nextPanelHandle, pruneDanglingMaximizedPanelId, setMaximizedPanelId } from "../canvas/window-registry.js";
 import { resumeTerminalSession } from "../api.js";
 import { FloatingJobOverlay } from "../components/floating-job-overlay.js";
-import { applySessionUpdate, consumeOperationFocus, failResumeTerminalSession, focusOperation, nextOperationId, selectTerminalSession, theaterSessionOrder } from "../store.js";
+import { applySessionUpdate, consumeOperationFocus, failResumeTerminalSession, selectTerminalSession, theaterSessionOrder } from "../store.js";
 import type { ConsoleState } from "../types.js";
 
 interface OperationsProps {
@@ -36,11 +37,22 @@ export function Operations({ state }: OperationsProps) {
       const active = document.activeElement;
       if (active instanceof HTMLElement && active.matches("input, textarea, [contenteditable='true']") && !active.closest(".xterm")) return;
       const order = theaterSessionOrder(stateRef.current);
-      if (order.length === 0) return;
+      const handles = getPanelHandles(order);
+      if (handles.length === 0) return;
       event.preventDefault();
       event.stopImmediatePropagation();
-      const nextId = nextOperationId(order, stateRef.current.activeTerminalSessionId, event.key === "ArrowRight" ? 1 : -1);
-      if (nextId) focusOperation(nextId);
+      const maximizedPanelId = getMaximizedPanelId();
+      // 비-최대화 순환 앵커: 활성 Operation이 없으면 활성 Shell을 기준으로 삼아, 셸에 포커스된 채로도 순차 순환이 이어지게 한다.
+      const currentId = maximizedPanelId ?? stateRef.current.activeTerminalSessionId ?? getActiveShellId();
+      const delta = event.key === "ArrowRight" ? 1 : -1;
+      const next = nextPanelHandle(handles, currentId, delta);
+      if (!next) return;
+      if (maximizedPanelId) {
+        setMaximizedPanelId(next.id);
+        return;
+      }
+      const viewportSize = viewportSizeFor(bodyRef.current);
+      if (viewportSize) focusWindowPanel(next, viewportSize);
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
@@ -56,6 +68,14 @@ export function Operations({ state }: OperationsProps) {
     if (!state.terminalSessionsHydrated) return;
     prunePanels(sessionOrder);
   }, [sessionOrder, state.terminalSessionsHydrated]);
+
+  useEffect(() => {
+    pruneDanglingMaximizedPanelId(sessionOrder, {
+      operationSessionsHydrated: state.terminalSessionsHydrated,
+      shellPanelsHydrated: true,
+      theaterReady: state.activeTheaterId !== null,
+    });
+  }, [sessionOrder, state.activeTheaterId, state.terminalSessionsHydrated]);
 
   // 검색 등에서 들어온 일회성 이동 요청을 처리한다. 위의 loadForTheater/ensureDefaultGeometry
   // effect가 먼저 선언되어 해당 Theater의 패널이 로드·보장된 뒤 실행되므로 focusPanel이 안전하다.

--- a/runtime/fleet-console/client/src/shortcuts-catalog.ts
+++ b/runtime/fleet-console/client/src/shortcuts-catalog.ts
@@ -28,13 +28,14 @@ export const SHORTCUT_GROUPS: readonly ShortcutGroup[] = [
   {
     title: "Map",
     entries: [
-      { combos: [["Alt", "←"], ["Alt", "→"]], description: "Focus the previous / next Operation" },
+      { combos: [["Alt", "←"], ["Alt", "→"]], description: "Cycle Operation and Shell panels; switch the maximized panel when maximized" },
       { combos: [["Drag"]], description: "Pan the operations map" },
       { combos: [["Shift", "Drag"]], description: "Draw a new Operation terminal" },
       { combos: [["Space", "Drag"]], description: "Pan even while a terminal has focus" },
       { combos: [["Scroll"]], description: "Zoom the map in or out" },
       { combos: [["Right-click"]], description: "Open the canvas actions menu" },
-      { combos: [["Double-click"]], description: "Focus a panel from its title bar; rename from its name" },
+      { combos: [["Double-click"]], description: "Focus from a title bar; rename from an Operation name" },
+      { combos: [["□"]], description: "Maximize the panel into the canvas overlay" },
       { combos: [["Click"]], description: "Clear terminal focus on the empty canvas" },
     ],
   },

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -2832,7 +2832,9 @@
 .canvas-panel-maximized-layer {
   position: absolute;
   inset: 0 0 var(--canvas-dock-safe-inset, 58px) 0;
-  z-index: 14;
+  /* world 패널 위, 그러나 떠 있는 캔버스 컨트롤(단축키 z13·토글/미니맵 z14·Dock z15) "아래"에 둔다 —
+     맵 전체화면+패널 최대화 동시 상태에서 우상단 '맵 전체화면 해제' 토글이 오버레이에 가려 클릭 불가가 되는 트랩을 막는다. */
+  z-index: 12;
   pointer-events: auto;
   animation: codex-rise 260ms var(--ease-spring) both;
 }

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -2306,11 +2306,11 @@
   height: 18px;
 }
 
-/* 좌하단 Map 단축키 도움 — 레이더 계기와 같은 심해 글래스 카드. 접으면 '?' FAB만 남는다. */
+/* 좌상단 Map 단축키 도움 — 레이더 계기와 같은 심해 글래스 카드. 접으면 '?' FAB만 남는다. */
 .map-shortcuts {
   position: absolute;
   left: var(--space-4);
-  bottom: var(--space-4);
+  top: var(--space-4);
   z-index: 13;
   width: 250px;
   max-height: min(56%, 380px);
@@ -2327,7 +2327,8 @@
     inset 0 1px 0 color-mix(in oklch, var(--brass) 22%, transparent);
   backdrop-filter: blur(22px) saturate(150%);
   -webkit-backdrop-filter: blur(22px) saturate(150%);
-  animation: codex-rise 520ms var(--ease-spring) both;
+  transform-origin: top left;
+  animation: shortcuts-drop 360ms var(--ease-spring) both;
 }
 
 .map-shortcuts-head {
@@ -2378,14 +2379,14 @@
 .map-shortcuts-fab {
   position: absolute;
   left: var(--space-4);
-  bottom: var(--space-4);
+  top: var(--space-4);
   z-index: 13;
   width: 36px;
   height: 36px;
   box-shadow: var(--shadow-anchor);
   backdrop-filter: blur(18px) saturate(140%);
   -webkit-backdrop-filter: blur(18px) saturate(140%);
-  animation: codex-rise 420ms var(--ease-spring) both;
+  animation: shortcuts-drop 300ms var(--ease-spring) both;
 }
 
 .map-shortcuts-toggle svg {
@@ -2582,201 +2583,34 @@
   -webkit-backdrop-filter: blur(18px) saturate(140%);
 }
 
-/* 최소화된 Operation 패널의 하단 Dock("잠망 트레이"). 미니맵·단축키와 같은 캔버스-고정(absolute) 계기다.
-   그룹 글래스 박스 없음 — 토글 핸들과 칩이 각자 독립 글래스로 떠 있다.
-   앵커: 토글 핸들의 우측 모서리를 화면 가로 중앙(right:50%)에 고정한다. 칩은 토글 왼쪽에서만 좌측으로
-   확장되므로 패널이 늘어도 토글은 제자리에 머물고 좌하단 단축키 계기와는 칩 트랙 max-width로 비킨다. */
+/* 최소화된 Operation/Shell 창 taskbar. world transform 밖 좌하단에 고정되어 패널과 함께 이동/확대되지 않는다. */
 .canvas-dock {
   position: absolute;
   bottom: var(--space-4);
-  left: 50%;
-  transform: translateX(-50%);
+  left: var(--space-4);
+  --canvas-dock-safe-inset: 58px;
   z-index: 15;
   display: flex;
-  flex-direction: column;
-  align-items: center;
+  align-items: flex-end;
   gap: var(--space-2);
-  /* 중앙정렬 dock가 좌우대칭으로 펼쳐질 때의 가로 가용폭. 좌측 SHORTCUTS(좌단 --space-4 + 폭 250px =
-     우측끝 266px)·우측 RADAR(우단 --space-4 + 폭 256px = 좌측끝 272px) 계기 중 더 넓은 클리어런스(272px)에
-     숨돌리기 갭(--space-4)을 더해 양변 기준으로 잡는다(칩이 이 폭을 채우면 더 늘지 않고 페이지네이션으로
-     넘어간다 — 반응형으로 화면이 좁아질수록 가용폭이 줄어 더 많은 페이지로 나뉜다). 상한 1100px.
-     하한 260px: 약 800px 미만의 좁은 화면에선 calc 가용폭이 0/음수로 떨어져 펼친 칩·페이저가 통째로 잘려
-     복원조차 불가능해지므로, 칩+페이저 한 세트가 보이는 최소폭을 보장한다. 그 폭에선 side 계기와 일부
-     겹치나 dock가 z-index 15로 위에 있어 조작 가능하고, side 계기는 각자 FAB으로 접을 수 있다. */
-  max-width: clamp(260px, calc(100vw - (272px + var(--space-4)) * 2), 1100px);
-  /* 세로 스택이라 토글 행 좌우(rail이 넓을 때)에 투명 정렬 영역이 생긴다. dock 컨테이너는 입력을 통과시키고
-     인터랙티브 자식(토글·레일)만 입력을 받게 해, 그 빈 영역에서 캔버스 pan/zoom/우클릭이 막히지 않게 한다.
-     토글/레일 위 우클릭은 자식→dock(data-canvas-blocker) 버블링으로 여전히 컨텍스트 메뉴가 억제된다. */
+  max-width: min(920px, calc(100vw - var(--space-8)));
   pointer-events: none;
-  animation: codex-rise-centered 520ms var(--ease-spring) both;
+  animation: codex-rise 420ms var(--ease-spring) both;
 }
 
-.canvas-dock-toggle,
 .canvas-dock-rail {
   pointer-events: auto;
 }
 
-/* ── 접기/펼치기 핸들 (최소화 패널이 1개 이상일 때만 렌더된다) ── */
-.canvas-dock-toggle {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  flex: none;
-  height: 34px;
-  padding: 0 10px 0 9px;
-  cursor: pointer;
-  color: var(--ink-spectral);
-  background: var(--surface-glass-strong);
-  border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-pill);
-  box-shadow: var(--shadow-floating);
-  backdrop-filter: blur(22px) saturate(150%);
-  -webkit-backdrop-filter: blur(22px) saturate(150%);
-  transition:
-    color var(--duration-fast) var(--ease-spring),
-    border-color var(--duration-fast) var(--ease-spring),
-    background var(--duration-fast) var(--ease-spring);
-}
-
-.canvas-dock-toggle:hover,
-.canvas-dock-toggle:focus-visible {
-  border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
-  color: var(--brass-bright);
-}
-
-.canvas-dock-toggle-chevron {
-  display: grid;
-  place-items: center;
-  width: 16px;
-  height: 16px;
-  transition: transform 320ms var(--ease-spring);
-}
-
-.canvas-dock-toggle-chevron svg {
-  display: block;
-  width: 14px;
-  height: 14px;
-}
-
-/* 펼침 상태: chevron 180° 회전(∧ 위 → ∨ 아래) — 펼친 패널을 다시 접는 방향을 가리킨다. */
-.canvas-dock.is-expanded .canvas-dock-toggle-chevron {
-  transform: rotate(180deg);
-}
-
-.canvas-dock-toggle-count {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  color: var(--ink-fog);
-}
-
-/* 접힘 상태에서만 카운트 강조 — 칩이 안 보이므로 개수를 brass로 또렷이 알린다. */
-.canvas-dock:not(.is-expanded) .canvas-dock-toggle-count {
-  color: var(--brass-bright);
-}
-
-/* 접힘 핸들 안 알림 비콘 — 평소 숨김, 알림 시 신호색 점으로 표시한다. */
-.canvas-dock-toggle-beacon {
-  display: none;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  flex: none;
-}
-
-/* 알림: 접힌 핸들이 외곽 진행광으로 "안에 살아있는 게 있다"를 알린다. 색은 신호를 따른다.
-   펼친 상태에선 각 칩이 외곽 진행광으로 직접 상태를 표시하므로 토글 알림은 접힘(:not(.is-expanded))
-   상태에서만 작동한다 — 펼친 토글은 정적으로 둔다. */
-.canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-live,
-.canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-turn {
-  box-shadow: var(--shadow-floating), 0 0 22px -6px var(--uw-glow);
-}
-
-.canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-live {
-  --uw-tint: var(--aurora);
-  --uw-glow: var(--aurora-glow);
-  border-color: color-mix(in oklch, var(--aurora) 40%, var(--surface-rim));
-}
-
-.canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-turn {
-  --uw-tint: var(--warn);
-  --uw-glow: var(--warn-glow);
-  border-color: color-mix(in oklch, var(--warn) 40%, var(--surface-rim));
-}
-
-.canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-live::before,
-.canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-turn::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  padding: 1.5px;
-  border-radius: inherit;
-  pointer-events: none;
-  background: conic-gradient(
-    from var(--uw-angle),
-    color-mix(in oklch, var(--uw-tint) 12%, transparent) 0deg,
-    color-mix(in oklch, var(--uw-tint) 12%, transparent) 18deg,
-    var(--uw-tint) 52deg,
-    color-mix(in oklch, var(--uw-tint) 55%, transparent) 92deg,
-    color-mix(in oklch, var(--uw-tint) 12%, transparent) 150deg,
-    color-mix(in oklch, var(--uw-tint) 12%, transparent) 360deg
-  );
-  -webkit-mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-  mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  mask-composite: exclude;
-  animation: perimeter-orbit 2.4s linear infinite;
-}
-
-.canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-live .canvas-dock-toggle-beacon {
-  display: block;
-  background: var(--aurora);
-  box-shadow: 0 0 8px var(--aurora-glow);
-  animation: beacon-pulse 1.8s ease-in-out infinite;
-}
-
-.canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-turn .canvas-dock-toggle-beacon {
-  display: block;
-  background: var(--warn);
-  box-shadow: 0 0 8px var(--warn-glow);
-}
-
-/* ── 칩 레일: 펼침 시 토글 "아래"에 나타나는 가로 행(페이저 + 칩 트랙 + 페이지 표시)을 화면 중앙으로
-   정렬한다. 접힘 시 max-height:0 + 페이드로 사라지고, overflow:hidden으로 수직 펼침 전환을 깔끔히 와이프한다.
-   가로 폭은 부모(.canvas-dock)의 침범경계 max-width가 제한하고, 칩 트랙이 그 안에서 줄며 페이지네이션된다. ── */
 .canvas-dock-rail {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: var(--space-2);
   max-width: 100%;
-  min-height: 0;
-  max-height: 0;
-  opacity: 0;
-  overflow: hidden;
-  transition:
-    max-height 360ms var(--ease-spring),
-    opacity 240ms ease;
+  min-height: 40px;
 }
 
-/* 펼침: 한 줄 높이만큼(칩/페이저 34px + codex-rise 등장 오프셋·포커스 링 여유) 수직으로 와이프한다. */
-.canvas-dock.is-expanded .canvas-dock-rail {
-  max-height: 56px;
-  opacity: 1;
-}
-
-/* 칩 트랙(스크롤 뷰포트): 페이저/페이지 표시를 뺀 레일의 남는 가로폭을 차지하며(flex:0 1 auto + min-width:0),
-   콘텐츠가 그 폭을 넘으면 페이저로 페이지를 넘긴다. 폭 상한은 부모 .canvas-dock의 침범경계 max-width가
-   강제하므로 여기 별도 px 캡은 두지 않는다 — 화면이 좁을수록 트랙이 더 줄어 더 많은 페이지로 나뉜다.
-   overflow:hidden이라 스크롤바·휠 스크롤은 없고 '<'/'>' 버튼의 scrollBy(clientWidth)로만 페이지를 넘기며,
-   scroll-snap-align으로 페이지 경계가 칩 시작에 맞아 칩이 어중간하게 잘리지 않는다. */
 .canvas-dock-chips {
   display: flex;
   align-items: center;
@@ -2788,7 +2622,6 @@
   scroll-behavior: smooth;
 }
 
-/* ── 페이저: 칩이 가용 폭을 넘칠 때만 렌더된다(컴포넌트 조건부). 양끝 '<'/'>' + 'n/m' 표시. ── */
 .canvas-dock-pager {
   display: grid;
   place-items: center;
@@ -2826,7 +2659,6 @@
   height: 13px;
 }
 
-/* 페이지 표시 'n/m' — 토글 바로 왼쪽. tabular-nums로 자릿수 변화에도 흔들리지 않는다. */
 .canvas-dock-page {
   flex: none;
   font-family: var(--font-mono);
@@ -2837,7 +2669,6 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* 칩: 최소화된 패널 하나. flex:none으로 스크롤 트랙 안에서 줄어들지 않는다. */
 .canvas-dock-chip {
   position: relative;
   display: flex;
@@ -2845,7 +2676,7 @@
   flex: none;
   gap: 6px;
   height: 34px;
-  padding: 0 12px 0 10px;
+  padding: 0 7px 0 10px;
   white-space: nowrap;
   cursor: pointer;
   scroll-snap-align: start;
@@ -2859,12 +2690,6 @@
     color var(--duration-fast) var(--ease-spring),
     border-color var(--duration-fast) var(--ease-spring),
     background var(--duration-fast) var(--ease-spring);
-}
-
-/* 펼침 시 칩이 staggered codex-rise로 떠오른다(--i = 순번). */
-.canvas-dock.is-expanded .canvas-dock-chip {
-  animation: codex-rise 320ms var(--ease-spring) both;
-  animation-delay: calc(var(--i, 0) * 50ms);
 }
 
 .canvas-dock-chip:hover,
@@ -2885,8 +2710,7 @@
 }
 
 /* 알림(underway) = 진행 중 칩의 외곽 진행광. conic 하이라이트 호가 칩 테두리 링을
-   시계방향으로 순환한다. 색 의미는 동일(live=aurora, turn=warn). 칩 자체의 codex-rise
-   등장 모션은 위 .is-expanded .canvas-dock-chip 규칙에서 그대로 유지된다. */
+   시계방향으로 순환한다. 색 의미는 동일(live=aurora, turn=warn). */
 .canvas-dock-chip--underway-live {
   --uw-tint: var(--aurora);
   --uw-glow: var(--aurora-glow);
@@ -2901,7 +2725,7 @@
    회전하는 --uw-angle 기준으로 밝은 호가 한 바퀴 돌고, 나머지 둘레엔 옅은 상시 림이 남아 '전체 외곽'이
    정의된다. 펼친 dock의 칩에서만 표시 — 접힘 시엔 칩 자체가 숨겨지므로 토글 알림이 대신한다.
    AGENTS.md 모션 규약의 sanctioned 예외(작업 중에만, prefers-reduced-motion에서 정적 림으로 단락). */
-.canvas-dock.is-expanded .canvas-dock-chip--underway::before {
+.canvas-dock-chip--underway::before {
   content: "";
   position: absolute;
   inset: 0;
@@ -2930,22 +2754,17 @@
 }
 
 /* 진행 중 칩은 신호색 옅은 글로우를 정적으로 덧대 깊이를 준다(둘레 링 순환은 ::before가 담당). */
-.canvas-dock.is-expanded .canvas-dock-chip--underway {
+.canvas-dock-chip--underway {
   box-shadow: var(--shadow-soft), 0 0 18px -8px var(--uw-glow);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-live .canvas-dock-toggle-beacon {
+  .canvas-dock,
+  .canvas-dock-chip--underway::before {
     animation: none;
   }
-  .canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-live::before,
-  .canvas-dock:not(.is-expanded) .canvas-dock-toggle--attention-turn::before {
-    animation: none;
-    background: color-mix(in oklch, var(--uw-tint) 38%, transparent);
-  }
-  /* 칩 진행광: 순환 정지 + 정적 전체 림(전체 외곽을 옅게 유지). */
-  .canvas-dock.is-expanded .canvas-dock-chip--underway::before {
-    animation: none;
+
+  .canvas-dock-chip--underway::before {
     background: color-mix(in oklch, var(--uw-tint) 38%, transparent);
   }
 }
@@ -2977,6 +2796,62 @@
   border: 1px solid color-mix(in oklch, var(--aurora) 28%, transparent);
   border-radius: var(--radius-sm);
   padding: 1px 6px;
+}
+
+.canvas-dock-chip-close {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  flex: none;
+  margin-left: 2px;
+  cursor: pointer;
+  color: var(--ink-rim);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring);
+}
+
+.canvas-dock-chip-close:hover,
+.canvas-dock-chip-close:focus-visible {
+  color: var(--coral);
+  border-color: color-mix(in oklch, var(--coral) 34%, transparent);
+  background: color-mix(in oklch, var(--coral) 10%, transparent);
+}
+
+.canvas-dock-chip-close svg {
+  display: block;
+  width: 12px;
+  height: 12px;
+}
+
+.canvas-panel-maximized-layer {
+  position: absolute;
+  inset: 0 0 var(--canvas-dock-safe-inset, 58px) 0;
+  z-index: 14;
+  pointer-events: auto;
+  animation: codex-rise 260ms var(--ease-spring) both;
+}
+
+.canvas-panel-maximized-layer .canvas-panel {
+  max-width: none;
+  max-height: none;
+  border-radius: var(--radius-lg);
+}
+
+.canvas-panel-maximized-layer .canvas-panel-jobdock,
+.canvas-panel-maximized-layer .panel-resize-handle {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .canvas-panel-maximized-layer {
+    animation: none;
+  }
 }
 
 .canvas-panel-titlebar {

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -2125,6 +2125,14 @@
   background: color-mix(in oklch, var(--aurora) 9%, color-mix(in oklch, var(--ink-deep) 28%, transparent));
 }
 
+/* 최소화된 셸은 언마운트하지 않고 숨긴다 — Terminal/WS를 살려둬 theater-shell PTY가 단절 grace(4s)로
+   죽지 않게 한다. visibility:hidden은 박스 크기를 유지하므로 복원 시 xterm re-fit이 필요 없고,
+   pointer-events:none으로 숨은 패널이 캔버스 조작을 가로채지 않는다. Dock 칩이 최소화 표상을 담당한다. */
+.canvas-panel--shell.is-minimized {
+  visibility: hidden;
+  pointer-events: none;
+}
+
 /* 우클릭 캔버스 컨텍스트 메뉴의 그룹(섹션) 라벨. */
 .canvas-context-menu-group {
   margin: 0;
@@ -2846,7 +2854,7 @@
 }
 
 .canvas-panel-maximized-layer .canvas-panel-jobdock,
-.canvas-panel-maximized-layer .panel-resize-handle {
+.canvas-panel-maximized-layer .canvas-panel-resize {
   display: none;
 }
 

--- a/runtime/fleet-console/client/src/styles/layout.css
+++ b/runtime/fleet-console/client/src/styles/layout.css
@@ -11,13 +11,13 @@
 }
 
 /* 맵 최대화: GNB(topbar) 행을 0으로 접고 셸 여백을 없애 캔버스를 전체로 채운다(app.tsx가 Map canvas 화면에서만 부여). */
-.console-shell.is-maximized {
+.console-shell.is-map-fullscreen {
   grid-template-rows: 0 minmax(0, 1fr);
   gap: 0;
   padding: 0;
 }
 
-.console-shell.is-maximized .topbar {
+.console-shell.is-map-fullscreen .topbar {
   /* codex-rise 첫-페인트 애니메이션이 both fill로 opacity/transform 끝상태를 잡고 있어
      이를 해제해야 아래 fade+slide가 .topbar transition을 타고 적용된다. */
   animation: none;

--- a/runtime/fleet-console/client/src/styles/theme.css
+++ b/runtime/fleet-console/client/src/styles/theme.css
@@ -297,6 +297,19 @@ a {
   }
 }
 
+@keyframes shortcuts-drop {
+  from {
+    opacity: 0;
+    transform: translateY(-10px) scale(0.98);
+    filter: blur(5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    filter: blur(0);
+  }
+}
+
 @keyframes aurora-pulse {
   0%,
   100% {

--- a/runtime/fleet-console/tests/shell-panels.test.ts
+++ b/runtime/fleet-console/tests/shell-panels.test.ts
@@ -13,7 +13,8 @@ describe("ephemeral shell panel registry", () => {
     const id = addShellPanel("theater-a", { ...GEOMETRY });
     expect(id.startsWith("shell:")).toBe(true);
     const panels = getShellPanels();
-    expect(panels[id]).toEqual({ theaterId: "theater-a", geometry: { ...GEOMETRY } });
+    expect(panels[id]).toMatchObject({ theaterId: "theater-a", geometry: { ...GEOMETRY } });
+    expect(panels[id]?.createdAt).toBeGreaterThan(0);
   });
 
   it("assigns distinct ids to concurrent shell panels", () => {

--- a/runtime/fleet-console/tests/window-registry.test.ts
+++ b/runtime/fleet-console/tests/window-registry.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getSnapshot, loadForTheater, minimizePanel, restorePanel, setPanelGeometry, type PanelGeometry } from "../client/src/canvas/canvas-store.js";
+import { addShellPanel, clearShellPanels, getActiveShellId, getMinimizedShellPanelIds, loadShellPanelsForTheater, minimizeShellPanel, restoreShellPanel } from "../client/src/canvas/shell-panels.js";
+import { clearMaximizedPanelId, focusWindowPanel, getMaximizedPanelId, getMinimizedPanelHandles, getPanelHandles, minimizeWindowPanel, nextPanelHandle, pruneDanglingMaximizedPanelId, setMaximizedPanelId } from "../client/src/canvas/window-registry.js";
+
+const GEOMETRY: PanelGeometry = { x: 0, y: 0, width: 100, height: 100, zIndex: 0 };
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal("window", {
+    clearTimeout,
+    localStorage: createStorage(),
+    sessionStorage: createStorage(),
+    setTimeout,
+  });
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  loadForTheater("theater-a");
+  loadShellPanelsForTheater("theater-a");
+  clearMaximizedPanelId();
+});
+
+afterEach(() => {
+  clearShellPanels();
+  loadForTheater(null);
+  loadShellPanelsForTheater(null);
+  clearMaximizedPanelId();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("window registry facade", () => {
+  it("orders Operation and Shell handles by stable createdAt", () => {
+    setPanelGeometry("op-a", { ...GEOMETRY });
+    const shell = addShellPanel("theater-a", { ...GEOMETRY });
+    setPanelGeometry("op-b", { ...GEOMETRY });
+
+    expect(getPanelHandles(["op-a", "op-b"]).map((handle) => `${handle.kind}:${handle.id}`)).toEqual([
+      "operation:op-a",
+      `shell:${shell}`,
+      "operation:op-b",
+    ]);
+  });
+
+  it("does not reorder handles when focus changes z-index", () => {
+    setPanelGeometry("op-a", { ...GEOMETRY });
+    const shell = addShellPanel("theater-a", { ...GEOMETRY });
+    setPanelGeometry("op-b", { ...GEOMETRY });
+    const before = getPanelHandles(["op-a", "op-b"]).map((handle) => handle.id);
+
+    setPanelGeometry("op-a", { ...GEOMETRY });
+    restoreShellPanel(shell);
+
+    expect(getPanelHandles(["op-a", "op-b"]).map((handle) => handle.id)).toEqual(before);
+  });
+
+  it("synthesizes minimized Operation and Shell handles without mixing persistence", () => {
+    setPanelGeometry("op-a", { ...GEOMETRY });
+    const shell = addShellPanel("theater-a", { ...GEOMETRY });
+    minimizePanel("op-a");
+    minimizeShellPanel(shell);
+
+    expect(getMinimizedPanelHandles(["op-a"]).map((handle) => handle.id)).toEqual(["op-a", shell]);
+    expect(getSnapshot().minimized).toEqual(["op-a"]);
+    expect(getMinimizedShellPanelIds()).toEqual([shell]);
+    expect(window.localStorage.getItem("fleet-console.canvas.shell.theater-a")).toBeNull();
+  });
+
+  it("sets and clears maximizedPanelId", () => {
+    setMaximizedPanelId("op-a");
+    expect(getMaximizedPanelId()).toBe("op-a");
+    clearMaximizedPanelId();
+    expect(getMaximizedPanelId()).toBeNull();
+  });
+
+  it("clears maximizedPanelId when the maximized panel is minimized", () => {
+    setPanelGeometry("op-a", { ...GEOMETRY });
+    setMaximizedPanelId("op-a");
+    minimizeWindowPanel({ kind: "operation", id: "op-a", createdAt: 0 });
+    expect(getMaximizedPanelId()).toBeNull();
+    expect(getSnapshot().minimized).toEqual(["op-a"]);
+  });
+
+  it("defers dangling maximizedPanelId prune until all hydration readiness flags are true", () => {
+    setMaximizedPanelId("missing");
+    expect(pruneDanglingMaximizedPanelId([], {
+      operationSessionsHydrated: false,
+      shellPanelsHydrated: true,
+      theaterReady: true,
+    })).toBe(false);
+    expect(getMaximizedPanelId()).toBe("missing");
+
+    expect(pruneDanglingMaximizedPanelId([], {
+      operationSessionsHydrated: true,
+      shellPanelsHydrated: true,
+      theaterReady: true,
+    })).toBe(true);
+    expect(getMaximizedPanelId()).toBeNull();
+  });
+
+  it("focuses Shell panels through Shell geometry and center zoom", () => {
+    const shell = addShellPanel("theater-a", { x: 300, y: 200, width: 400, height: 200, zIndex: 1 });
+    focusWindowPanel({ kind: "shell", id: shell, createdAt: 1 }, { width: 1000, height: 800 });
+
+    expect(getActiveShellId()).toBe(shell);
+    expect(getSnapshot().viewport.zoom).toBe(1);
+    expect(getSnapshot().viewport.x).toBe(0);
+    expect(getSnapshot().viewport.y).toBe(100);
+  });
+
+  it("minimize state does not alter stable handle order", () => {
+    setPanelGeometry("op-a", { ...GEOMETRY });
+    const shell = addShellPanel("theater-a", { ...GEOMETRY });
+    const before = getPanelHandles(["op-a"]).map((handle) => handle.id);
+    minimizeWindowPanel({ kind: "shell", id: shell, createdAt: 0 });
+    minimizeWindowPanel({ kind: "operation", id: "op-a", createdAt: 0 });
+
+    expect(getPanelHandles(["op-a"]).map((handle) => handle.id)).toEqual(before);
+  });
+
+  it("cycles Operation and Shell handles in stable order", () => {
+    setPanelGeometry("op-a", { ...GEOMETRY });
+    const shell = addShellPanel("theater-a", { ...GEOMETRY });
+    setPanelGeometry("op-b", { ...GEOMETRY });
+    const handles = getPanelHandles(["op-a", "op-b"]);
+
+    expect(nextPanelHandle(handles, "op-a", 1)?.id).toBe(shell);
+    expect(nextPanelHandle(handles, shell, 1)?.id).toBe("op-b");
+    expect(nextPanelHandle(handles, "op-a", -1)?.id).toBe("op-b");
+  });
+
+  it("maximized cycling changes maximizedPanelId without viewport movement", () => {
+    setPanelGeometry("op-a", { ...GEOMETRY });
+    const shell = addShellPanel("theater-a", { ...GEOMETRY });
+    const handles = getPanelHandles(["op-a"]);
+    setMaximizedPanelId("op-a");
+    const before = getSnapshot().viewport;
+    const next = nextPanelHandle(handles, getMaximizedPanelId(), 1);
+    if (next) setMaximizedPanelId(next.id);
+
+    expect(getMaximizedPanelId()).toBe(shell);
+    expect(getSnapshot().viewport).toEqual(before);
+  });
+});
+
+function createStorage(): Storage {
+  const entries = new Map<string, string>();
+  return {
+    get length() {
+      return entries.size;
+    },
+    clear: () => entries.clear(),
+    getItem: (key) => entries.get(key) ?? null,
+    key: (index) => Array.from(entries.keys())[index] ?? null,
+    removeItem: (key) => entries.delete(key),
+    setItem: (key, value) => { entries.set(key, value); },
+  };
+}

--- a/runtime/fleet-console/tests/window-registry.test.ts
+++ b/runtime/fleet-console/tests/window-registry.test.ts
@@ -145,6 +145,17 @@ describe("window registry facade", () => {
     expect(nextPanelHandle(handles, "op-a", -1)?.id).toBe("op-b");
   });
 
+  it("starts Alt cycling from the edge when no handle matches the current id", () => {
+    setPanelGeometry("op-a", { ...GEOMETRY });
+    setPanelGeometry("op-b", { ...GEOMETRY });
+    const handles = getPanelHandles(["op-a", "op-b"]);
+
+    // currentId 없음/stale → 정방향은 첫 핸들, 역방향은 마지막 핸들에서 시작(Math.max(0,-1) 회귀 방지).
+    expect(nextPanelHandle(handles, null, 1)?.id).toBe("op-a");
+    expect(nextPanelHandle(handles, null, -1)?.id).toBe("op-b");
+    expect(nextPanelHandle(handles, "missing", 1)?.id).toBe("op-a");
+  });
+
   it("maximized cycling changes maximizedPanelId without viewport movement", () => {
     setPanelGeometry("op-a", { ...GEOMETRY });
     const shell = addShellPanel("theater-a", { ...GEOMETRY });

--- a/runtime/fleet-console/tests/window-registry.test.ts
+++ b/runtime/fleet-console/tests/window-registry.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getSnapshot, loadForTheater, minimizePanel, restorePanel, setPanelGeometry, type PanelGeometry } from "../client/src/canvas/canvas-store.js";
 import { addShellPanel, clearShellPanels, getActiveShellId, getMinimizedShellPanelIds, loadShellPanelsForTheater, minimizeShellPanel, restoreShellPanel } from "../client/src/canvas/shell-panels.js";
-import { clearMaximizedPanelId, focusWindowPanel, getMaximizedPanelId, getMinimizedPanelHandles, getPanelHandles, minimizeWindowPanel, nextPanelHandle, pruneDanglingMaximizedPanelId, setMaximizedPanelId } from "../client/src/canvas/window-registry.js";
+import { clearMaximizedPanelId, focusWindowPanel, getMaximizedPanelId, getMinimizedPanelHandles, getPanelHandles, maximizeWindowPanel, minimizeWindowPanel, nextPanelHandle, operationPanelHandle, pruneDanglingMaximizedPanelId, setMaximizedPanelId } from "../client/src/canvas/window-registry.js";
 
 const GEOMETRY: PanelGeometry = { x: 0, y: 0, width: 100, height: 100, zIndex: 0 };
 
@@ -72,6 +72,21 @@ describe("window registry facade", () => {
     expect(getMaximizedPanelId()).toBe("op-a");
     clearMaximizedPanelId();
     expect(getMaximizedPanelId()).toBeNull();
+  });
+
+  it("maximizeWindowPanel minimizes the others, restores the target, and replaces the previous maximize", () => {
+    setPanelGeometry("op-a", { ...GEOMETRY });
+    setPanelGeometry("op-b", { ...GEOMETRY });
+    const handles = getPanelHandles(["op-a", "op-b"]);
+
+    maximizeWindowPanel(operationPanelHandle("op-a"), handles);
+    expect(getMaximizedPanelId()).toBe("op-a");
+    expect(getSnapshot().minimized).toEqual(["op-b"]);
+
+    // 전환: op-b를 최대화하면 이전 최대화 op-a는 Dock으로 내려가고 op-b는 복원된다(유령 칩 없음).
+    maximizeWindowPanel(operationPanelHandle("op-b"), handles);
+    expect(getMaximizedPanelId()).toBe("op-b");
+    expect(getSnapshot().minimized).toEqual(["op-a"]);
   });
 
   it("clears maximizedPanelId when the maximized panel is minimized", () => {


### PR DESCRIPTION
## Summary
- Operations 캔버스를 OS 윈도우 시스템처럼 개편: 단축키 도움말을 좌상단으로 이동(하향 펼침 애니메이션), 최소화 패널 Dock을 좌하단 상시 표시 태스크바로 전환(칩별 닫기 + 오버플로 페이저).
- 패널별 최대화 추가: 타이틀바 버튼 순서 `-` `□` `X`, `□`는 패널을 캔버스 오버레이로 채우고 토글로 복원. 종류-불문 `window-registry` 파사드(`maximizedPanelId` + 단조 createdAt 안정 정렬)가 Operation/Shell을 단일 조정.
- Shell을 1급 창으로 승격(최소화/최대화/Dock/Alt 순환). Alt+Left/Right가 Operation과 Shell을 함께 순환하고, 최대화 상태에서는 viewport 이동 없이 최대화 대상만 전환.
- 타이틀바(이름 영역 외) 더블클릭 포커스 복원. 기존 맵 전체화면 토글은 `mapFullscreen`으로 개명하여 패널 최대화와 명명 충돌 없이 공존(기능 유지).
- 두 레지스트리(Operation=localStorage / Shell=sessionStorage 탭 격리)의 영속 비대칭과 공유 z-index·활성 상호배타 불변식 보존.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (39 files / 455 tests)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Sentinel console-e2e (Playwriter real browser): placement / minimized dock / maximize+restore / Shell parity / Alt cycling / double-click focus / map-fullscreen coexistence / zero console errors — all PASS

## Changelog
- [x] `.changelog.d/console-window-system.md` included (`Changed`, `[fleet-console]`)