### PR TITLE
feat(fleet-console): refine maximized-mode canvas controls

### DIFF
--- a/.changelog.d/console-maximize-controls.md
+++ b/.changelog.d/console-maximize-controls.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- [fleet-console] Hide the floating canvas controls (minimap, shortcuts, and the fullscreen and background-animation toggles) while a panel is maximized, and highlight the maximized panel's maximize button.

--- a/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas-panel.tsx
@@ -239,11 +239,11 @@ export function CanvasPanel({ state, session, geometry, viewport, active, maximi
         </button>
         <button
           type="button"
-          className="canvas-panel-icon-button"
+          className={`canvas-panel-icon-button ${maximized ? "is-active" : ""}`}
           onPointerDown={stopButtonPointer}
           onClick={onMaximize}
-          aria-label={`Maximize operation ${displayLabel}`}
-          title="Maximize panel"
+          aria-label={maximized ? `Restore operation ${displayLabel}` : `Maximize operation ${displayLabel}`}
+          title={maximized ? "Restore panel" : "Maximize panel"}
         >
           <MaximizePanelIcon />
         </button>

--- a/runtime/fleet-console/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/client/src/canvas/canvas.tsx
@@ -177,7 +177,7 @@ export function OperationsCanvas({ state }: OperationsCanvasProps) {
 
   return (
     <main
-      className={`operations-canvas ${interaction.spaceActive ? "is-panning" : ""} ${interaction.shiftActive ? "is-creating" : ""}`}
+      className={`operations-canvas ${interaction.spaceActive ? "is-panning" : ""} ${interaction.shiftActive ? "is-creating" : ""} ${maximizedPanelId ? "is-panel-maximized" : ""}`}
       onPointerDown={interaction.onPointerDown}
       onPointerMove={interaction.onPointerMove}
       onPointerUp={interaction.onPointerUp}

--- a/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
@@ -135,11 +135,11 @@ export function ShellCanvasPanel({ id, theaterId, geometry, viewport, active, mi
         </button>
         <button
           type="button"
-          className="canvas-panel-icon-button"
+          className={`canvas-panel-icon-button ${maximized ? "is-active" : ""}`}
           onPointerDown={stopButtonPointer}
           onClick={onMaximize}
-          aria-label="Maximize shell panel"
-          title="Maximize panel"
+          aria-label={maximized ? "Restore shell panel" : "Maximize shell panel"}
+          title={maximized ? "Restore panel" : "Maximize panel"}
         >
           <MaximizePanelIcon />
         </button>

--- a/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
+++ b/runtime/fleet-console/client/src/canvas/shell-canvas-panel.tsx
@@ -108,7 +108,7 @@ export function ShellCanvasPanel({ id, theaterId, geometry, viewport, active, mi
       }}
       onPointerDown={bringToFront}
       data-canvas-panel
-      aria-hidden={minimized || undefined}
+      inert={minimized}
       aria-label="Shell panel"
     >
       <div

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -2120,6 +2120,17 @@
   right: calc(var(--space-4) + 36px + var(--space-2));
 }
 
+/* 패널 최대화 중에는 떠 있는 캔버스 컨트롤(미니맵·단축키·맵 풀스크린/배경 애니메이션 토글)을 숨긴다 —
+   최대화 패널이 캔버스를 점유하므로 컨트롤이 그 위를 덮지 않게 한다(좌하단 Dock은 유지). 해제 시 자동 복원.
+   .canvas-background-toggle 선택자는 배경 애니메이션 토글과 맵 풀스크린 토글(같은 클래스 공유)을 함께 가린다. */
+.operations-canvas.is-panel-maximized .canvas-background-toggle,
+.operations-canvas.is-panel-maximized .canvas-minimap,
+.operations-canvas.is-panel-maximized .canvas-minimap-fab,
+.operations-canvas.is-panel-maximized .map-shortcuts,
+.operations-canvas.is-panel-maximized .map-shortcuts-fab {
+  display: none;
+}
+
 /* 순정 셸 패널 — Operation과 구별되도록 띠바에 아우로라(살아있는 것) 톤의 옅은 강조를 준다. */
 .canvas-panel--shell .canvas-panel-titlebar {
   background: color-mix(in oklch, var(--aurora) 9%, color-mix(in oklch, var(--ink-deep) 28%, transparent));
@@ -2964,6 +2975,14 @@
   color: var(--brass-bright);
   border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
   background: color-mix(in oklch, var(--brass) 12%, var(--surface-glass));
+}
+
+/* 최대화 상태 패널의 □ 버튼 — 활성(토글하면 복원) 상태를 brass로 또렷이 하이라이트한다(hover보다 강하게). */
+.canvas-panel-icon-button.is-active {
+  color: var(--brass-bright);
+  border-color: color-mix(in oklch, var(--brass) 60%, var(--surface-rim));
+  background: color-mix(in oklch, var(--brass) 22%, var(--surface-glass));
+  box-shadow: 0 0 0 1px color-mix(in oklch, var(--brass) 30%, transparent);
 }
 
 .canvas-panel-icon-button svg {


### PR DESCRIPTION
## Summary
- 패널 최대화 시 떠 있는 캔버스 컨트롤(레이더 미니맵·단축키·맵 풀스크린 토글·배경 애니메이션 토글)을 숨겨 최대화 패널이 캔버스를 점유하게 한다(좌하단 Dock은 유지). 해제 시 자동 복원.
- 최대화된 패널의 □(최대화) 버튼을 brass `is-active`로 하이라이트하고 aria-label/title을 "Restore"로 전환.
- 최소화된 셸 패널의 a11y 처리를 `aria-hidden` → `inert`로 교체(포커스된 자식으로 인한 Chrome "Blocked aria-hidden" 경고 해소).

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (39 files / 456 tests)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Sentinel console-e2e (Playwriter real browser): 최대화 시 컨트롤 4종 숨김·Dock 유지 / 해제 시 복원 / □ 하이라이트 / 셸 최소화 a11y 경고 0 / Alt·Dock·더블클릭 회귀 없음 — 전 항목 PASS, console warning/error/pageerror/4xx 0

## Changelog
- [x] `.changelog.d/console-maximize-controls.md` (`Changed`, `[fleet-console]`)

> Note: Admiral 지시로 Codex 자동 리뷰 없이 생성 직후 머지합니다.