### PR TITLE
feat(fleet-console): add drive rail and path jump to Add Theater

### DIFF
--- a/.changelog.d/console-theater-drive-rail.md
+++ b/.changelog.d/console-theater-drive-rail.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- [fleet-console] Add Theater directory browser can now reach other drives through a drive rail (C:, D:, and so on) and jump straight to an absolute path via a direct path input, so projects outside the home drive can be registered; the picker is also enlarged for more visible folders.

--- a/runtime/fleet-console/client/src/components/directory-browser-modal.tsx
+++ b/runtime/fleet-console/client/src/components/directory-browser-modal.tsx
@@ -22,6 +22,7 @@ export function DirectoryBrowserModal({ open, onCancel, onConfirm }: DirectoryBr
   const [loadingPath, setLoadingPath] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
+  const [jumpPath, setJumpPath] = useState("");
   const [highlight, setHighlight] = useState(0);
   const filterRef = useRef<HTMLInputElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -66,6 +67,9 @@ export function DirectoryBrowserModal({ open, onCancel, onConfirm }: DirectoryBr
   }, [entries, query]);
 
   const breadcrumb = useMemo(() => (listing ? buildBreadcrumb(listing) : []), [listing]);
+  const activeDrive = listing ? getDrivePrefix(listing.path) : null;
+  const roots = listing?.roots ?? [];
+  const showRoots = roots.length > 1;
 
   // filtered가 줄면 하이라이트가 범위를 벗어날 수 있으니 항상 끝으로 클램프한다.
   const activeIndex = filtered.length === 0 ? -1 : Math.min(highlight, filtered.length - 1);
@@ -85,6 +89,11 @@ export function DirectoryBrowserModal({ open, onCancel, onConfirm }: DirectoryBr
 
   const goUp = () => {
     if (listing?.parentPath != null && loadingPath === null) void loadPath(listing.parentPath);
+  };
+
+  const jumpToPath = () => {
+    const target = jumpPath.trim();
+    if (target !== "" && loadingPath === null) void loadPath(target);
   };
 
   const currentPath = listing?.path ?? null;
@@ -142,6 +151,33 @@ export function DirectoryBrowserModal({ open, onCancel, onConfirm }: DirectoryBr
           <button type="button" className="directory-browser-close" onClick={onCancel} aria-label="Close">×</button>
         </header>
 
+        {showRoots ? (
+          <div className="directory-browser-roots" role="group" aria-label="Drives">
+            <span className="directory-browser-kicker">Stations</span>
+            <div className="directory-browser-root-chips">
+              {roots.map((root) => {
+                const isActive = activeDrive != null && getDrivePrefix(root) === activeDrive;
+                return (
+                  <button
+                    type="button"
+                    key={root}
+                    className={`directory-browser-root-chip ${isActive ? "is-active" : ""}`}
+                    aria-current={isActive ? "location" : undefined}
+                    disabled={loadingPath !== null}
+                    title={root}
+                    onClick={() => {
+                      if (loadingPath === null) void loadPath(root);
+                    }}
+                    onKeyDown={(event) => event.stopPropagation()}
+                  >
+                    {formatRootLabel(root)}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ) : null}
+
         <nav className="directory-browser-course" aria-label="Path">
           {breadcrumb.map((segment, index) => {
             const isLast = index === breadcrumb.length - 1;
@@ -191,6 +227,35 @@ export function DirectoryBrowserModal({ open, onCancel, onConfirm }: DirectoryBr
           >
             <UpGlyph />
             <span>Up</span>
+          </button>
+        </div>
+
+        <div className="directory-browser-jump">
+          <input
+            type="text"
+            className="directory-browser-jump-input"
+            placeholder="Or jump to a path — e.g. D:\\projects"
+            aria-label="Jump to absolute path"
+            value={jumpPath}
+            spellCheck={false}
+            autoComplete="off"
+            onChange={(event) => setJumpPath(event.target.value)}
+            onKeyDown={(event) => {
+              event.stopPropagation();
+              if (event.key === "Enter") {
+                event.preventDefault();
+                jumpToPath();
+              }
+            }}
+          />
+          <button
+            type="button"
+            className="directory-browser-jump-button"
+            disabled={jumpPath.trim() === "" || loadingPath !== null}
+            onClick={jumpToPath}
+            onKeyDown={(event) => event.stopPropagation()}
+          >
+            Go
           </button>
         </div>
 
@@ -290,6 +355,15 @@ function detectSeparator(listing: TerminalFolderListResponse): "\\" | "/" {
   if (listing.roots.some((root) => /^[A-Za-z]:\\$/.test(root))) return "\\";
   if (/^[A-Za-z]:\\/.test(listing.path)) return "\\";
   return "/";
+}
+
+function getDrivePrefix(path: string): string | null {
+  const match = /^([A-Za-z]:)\\?/.exec(path);
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+function formatRootLabel(root: string): string {
+  return root.replace(/[\\/]+$/, "") || root;
 }
 
 function TheaterSigil() {

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -5719,8 +5719,8 @@
   flex-direction: column;
   gap: var(--space-3);
   /* 피커는 대시보드가 아니라 계기다 — 80vw×90vh 과대 카드 대신 집중형 규격. */
-  width: min(640px, 92vw);
-  height: min(680px, 86vh);
+  width: min(760px, 94vw);
+  height: min(820px, 90vh);
   padding: var(--space-5) var(--space-5) var(--space-4);
   overflow: hidden;
   border: 1px solid var(--surface-rim-strong);
@@ -5798,6 +5798,57 @@
 .directory-browser-close:hover {
   border-color: color-mix(in oklch, var(--brass) 46%, var(--surface-rim));
   color: var(--brass-bright);
+}
+
+.directory-browser-roots {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.directory-browser-roots .directory-browser-kicker {
+  flex: none;
+  color: var(--ink-rim);
+}
+
+.directory-browser-root-chips {
+  display: flex;
+  flex: 1;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.directory-browser-root-chip {
+  min-height: 28px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--ink-mid) 42%, transparent);
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  transition: color var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide);
+}
+
+.directory-browser-root-chip:hover:not(:disabled) {
+  border-color: color-mix(in oklch, var(--brass) 46%, var(--surface-rim));
+  color: var(--brass-bright);
+}
+
+.directory-browser-root-chip.is-active {
+  border-color: color-mix(in oklch, var(--brass) 54%, var(--surface-rim));
+  background: color-mix(in oklch, var(--brass) 16%, transparent);
+  color: var(--brass-bright);
+}
+
+.directory-browser-root-chip:disabled {
+  color: var(--ink-rim);
+  cursor: not-allowed;
 }
 
 /* 항로(course) breadcrumb — 죽은 path 스트립을 대체하는 클릭형 경로 마디. */
@@ -5934,6 +5985,62 @@
 }
 
 .directory-browser-up:disabled {
+  color: var(--ink-rim);
+  cursor: not-allowed;
+}
+
+.directory-browser-jump {
+  flex: none;
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-2);
+}
+
+.directory-browser-jump-input {
+  flex: 1;
+  min-width: 0;
+  height: 36px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--ink-deep) 46%, transparent);
+  color: var(--ink-pearl);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  transition: border-color var(--duration-fast) var(--ease-glide), box-shadow var(--duration-fast) var(--ease-glide);
+}
+
+.directory-browser-jump-input::placeholder {
+  color: var(--ink-rim);
+}
+
+.directory-browser-jump-input:focus {
+  border-color: color-mix(in oklch, var(--brass) 50%, var(--surface-rim));
+  box-shadow: 0 0 0 3px var(--brass-glow);
+  outline: none;
+}
+
+.directory-browser-jump-button {
+  min-height: 36px;
+  padding: 0 var(--space-4);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--ink-mid) 46%, transparent);
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: color var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide);
+}
+
+.directory-browser-jump-button:hover:not(:disabled) {
+  border-color: color-mix(in oklch, var(--brass) 46%, var(--surface-rim));
+  color: var(--brass-bright);
+}
+
+.directory-browser-jump-button:disabled {
   color: var(--ink-rim);
   cursor: not-allowed;
 }


### PR DESCRIPTION
## Summary
- 'Add Theater' 디렉터리 브라우저가 홈 드라이브(C:) 트리에 갇혀 `D:\` 등 다른 드라이브로 갈 동선이 전혀 없던 문제를 해결합니다.
- 서버가 이미 응답(`roots`)으로 내려주던 드라이브 목록을 breadcrumb 위 **드라이브 레일**로 노출하고, **절대경로 직접 점프 입력**을 추가했으며, 모달 폭·높이를 키웠습니다.
- 드라이브 레일은 `roots.length > 1`일 때만 노출됩니다(POSIX 단일 루트 자연 소거). 서버/API 변경은 없습니다 — 기존 `roots` 페이로드와 경로 검증(`normalizeFolderBrowserPath`)을 그대로 재사용합니다.

## Type of Change
- [x] feat — new feature or carrier capability

## Scope
- fleet-console 클라이언트 UI (`runtime/fleet-console/client/**`) 단독. 백엔드/API 무변경.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 변경 파일 오류 0건 (잔존 오류는 기존 `release-notes.generated.ts` 사전 결함으로 본 PR 범위 밖)
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과 (신규 클라이언트 번들 생성 확인)
- [x] 실측: 구동 콘솔 `POST /terminal/folders/list` 응답 `roots: ["C:\\","D:\\","W:\\","X:\\","Y:\\","Z:\\"]` — 드라이브 데이터는 이미 클라이언트에 도착하나 UI 동선만 부재였음을 확인
- [ ] 브라우저 시각 확인(드라이브 레일 클릭 전환 / 경로 점프) — Playwriter 확장 재활성화 후 후속

## Changelog
- [x] Added one `.changelog.d/*.md` fragment — `console-theater-drive-rail.md` (`section: Added`, `[fleet-console]`)