### PR TITLE
fix(fleet-admiral): drop removed Codex child_agents_md feature flag

### DIFF
--- a/.changelog.d/codex-0142-launch-fix.md
+++ b/.changelog.d/codex-0142-launch-fix.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- [fleet-admiral] Launching the Codex CLI no longer fails to start on Codex 0.142.0 and later; Fleet was passing a Codex feature flag that newer versions removed, which made Codex abort on startup.

--- a/packages/fleet-admiral/src/agent-cli/builders/codex.ts
+++ b/packages/fleet-admiral/src/agent-cli/builders/codex.ts
@@ -10,8 +10,6 @@ export function buildCodexNativeArgs(context: AgentCliInjectionContext): string[
     "--enable",
     "plugins",
     "--enable",
-    "child_agents_md",
-    "--enable",
     "hooks",
     "--profile",
     profileName,

--- a/runtime/fleet-cli/tests/agent-wiki-mcp.test.ts
+++ b/runtime/fleet-cli/tests/agent-wiki-mcp.test.ts
@@ -272,7 +272,8 @@ describe("fleet-cli agent CLI MCP registration", () => {
 	        "plugin add fleet -m fleet-harness",
 	      ]);
       expect(profile.args).toContain("--enable");
-      expect(profile.args).toContain("child_agents_md");
+      // codex 0.142.0에서 제거된 기능 플래그라 인자에 포함되면 "Unknown feature flag"로 기동 실패한다.
+      expect(profile.args).not.toContain("child_agents_md");
       expect(profile.args).toContain("--profile");
       const profileName = argValue(profile.args, "--profile");
       expect(profileName).toMatch(FLEET_PROFILE_NAME_PATTERN);
@@ -420,7 +421,7 @@ describe("fleet-cli agent CLI MCP registration", () => {
         withMarketplaceLock: WITH_TEST_MARKETPLACE_LOCK,
       });
 
-      expect(profile.args).toContain("child_agents_md");
+      expect(profile.args).not.toContain("child_agents_md");
       const profileName = argValue(profile.args, "--profile");
       expect(profileName).toMatch(FLEET_PROFILE_NAME_PATTERN);
       const profilePath = path.join(codexHome, `${profileName}.config.toml`);


### PR DESCRIPTION
## Summary

Codex CLI 0.142.0이 `child_agents_md` 기능 플래그를 완전히 제거하면서, Fleet이 Codex 직접 실행 시 넘기던 `--enable child_agents_md`가 `Error: Unknown feature flag`로 Codex 기동을 즉시 중단시켰습니다(`--strict-config`와 무관). 그 결과 0.142.0 업데이트 이후 fleet-console에서 Codex CLI 실행이 전면 불가했습니다. 해당 플래그를 실행 인자에서 제거해 복구합니다. 남는 `plugins`/`hooks`는 0.142.0에서도 유효한 stable 플래그입니다.

## Type of Change

- [x] fix — bug fix

## Scope

- `packages/fleet-admiral` — Codex native launch args
- `runtime/fleet-cli` — profile-arg 회귀 가드 테스트

## Test Plan

- [x] 실제 codex 0.142.0 바이너리로 실패 재현(`Error: Unknown feature flag: child_agents_md`) 후, 플래그 제거 시 프로파일(v2) + `plugins`/`hooks` + MCP `-c` 인자 전체가 정상 파싱되어 Codex 기동(세션 헤더 출력)까지 도달함을 확인
- [x] `pnpm --filter @dotobokuri/fleet-admiral build` (tsc/dts) green
- [x] `pnpm --filter @dotobokuri/fleet-cli exec vitest run tests/agent-wiki-mcp.test.ts` — 5/5 pass
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK

## Changelog

- [x] Added one `.changelog.d/*.md` fragment (section: `Fixed`).
- [x] Fragment `section:` is `Fixed`.