### PR TITLE
fix(fleet-console): preserve maximized panels per theater

### DIFF
--- a/.changelog.d/fix-console-theater-maximized-panel-state.md
+++ b/.changelog.d/fix-console-theater-maximized-panel-state.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- [fleet-console] Preserve maximized Operation panel state independently across Theaters.

--- a/runtime/fleet-console/client/src/canvas/window-registry.ts
+++ b/runtime/fleet-console/client/src/canvas/window-registry.ts
@@ -27,6 +27,8 @@ const FOCUS_MIN_ZOOM = 0.25;
 const FOCUS_MAX_ZOOM = 1;
 
 let maximizedPanelId: string | null = null;
+let activeTheaterId: string | null = null;
+const maximizedPanelIdsByTheater = new Map<string, string>();
 
 export function useMaximizedPanelId(): string | null {
   return useSyncExternalStore(subscribe, getMaximizedPanelId, getMaximizedPanelId);
@@ -36,13 +38,24 @@ export function getMaximizedPanelId(): string | null {
   return maximizedPanelId;
 }
 
+export function loadMaximizedPanelForTheater(theaterId: string | null): void {
+  saveMaximizedPanelForActiveTheater();
+  activeTheaterId = theaterId;
+  const next = theaterId ? maximizedPanelIdsByTheater.get(theaterId) ?? null : null;
+  if (maximizedPanelId === next) return;
+  maximizedPanelId = next;
+  emit();
+}
+
 export function setMaximizedPanelId(id: string): void {
+  if (activeTheaterId) maximizedPanelIdsByTheater.set(activeTheaterId, id);
   if (maximizedPanelId === id) return;
   maximizedPanelId = id;
   emit();
 }
 
 export function clearMaximizedPanelId(): void {
+  if (activeTheaterId) maximizedPanelIdsByTheater.delete(activeTheaterId);
   if (maximizedPanelId === null) return;
   maximizedPanelId = null;
   emit();
@@ -193,6 +206,15 @@ function subscribe(listener: Listener): () => void {
 
 function emit(): void {
   for (const listener of listeners) listener();
+}
+
+function saveMaximizedPanelForActiveTheater(): void {
+  if (!activeTheaterId) return;
+  if (maximizedPanelId) {
+    maximizedPanelIdsByTheater.set(activeTheaterId, maximizedPanelId);
+  } else {
+    maximizedPanelIdsByTheater.delete(activeTheaterId);
+  }
 }
 
 function sortPanelHandles(handles: readonly WindowPanelHandle[], panelOrder: readonly string[]): readonly WindowPanelHandle[] {

--- a/runtime/fleet-console/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/client/src/pages/operations.tsx
@@ -4,7 +4,7 @@ import { resumeTerminalSession } from "../api.js";
 import { OperationsCanvas } from "../canvas/canvas.js";
 import { ensureDefaultGeometry, focusPanel, getSnapshot, loadForTheater, prunePanels, setPanelAccent } from "../canvas/canvas-store.js";
 import { getActiveShellId, loadShellPanelsForTheater } from "../canvas/shell-panels.js";
-import { clearMaximizedPanelId, focusWindowPanel, getMaximizedPanelId, getPanelHandles, maximizeWindowPanel, nextPanelHandle, pruneDanglingMaximizedPanelId } from "../canvas/window-registry.js";
+import { clearMaximizedPanelId, focusWindowPanel, getMaximizedPanelId, getPanelHandles, loadMaximizedPanelForTheater, maximizeWindowPanel, nextPanelHandle, pruneDanglingMaximizedPanelId } from "../canvas/window-registry.js";
 import { FloatingJobOverlay } from "../components/floating-job-overlay.js";
 import { applySessionUpdate, consumeOperationFocus, failResumeTerminalSession, selectTerminalSession, theaterSessionOrder } from "../store.js";
 import type { ConsoleState } from "../types.js";
@@ -26,6 +26,7 @@ export function Operations({ state }: OperationsProps) {
     // 셸 패널도 같은 activeTheaterId 기준으로 복원한다(새로고침 후 유지, Theater 전환 시 해당 Theater 셸로 교체).
     // Operations 패널의 loadForTheater와 대칭이며, 이전 Theater의 보류 저장은 내부에서 flush된다.
     loadShellPanelsForTheater(state.activeTheaterId);
+    loadMaximizedPanelForTheater(state.activeTheaterId);
   }, [state.activeTheaterId]);
 
   // Alt+←/→ 로 현재 Theater 내 Operation 포커스를 순환 이동한다.

--- a/runtime/fleet-console/tests/window-registry.test.ts
+++ b/runtime/fleet-console/tests/window-registry.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { forgetPanelMetadata, getSnapshot, loadForTheater, minimizePanel, prunePanels, restorePanel, setPanelAccent, setPanelGeometry, setPanelOrder, type PanelGeometry } from "../client/src/canvas/canvas-store.js";
 import { addShellPanel, clearShellPanels, getActiveShellId, getMinimizedShellPanelIds, loadShellPanelsForTheater, minimizeShellPanel, restoreShellPanel } from "../client/src/canvas/shell-panels.js";
-import { activateWindowPanel, clearMaximizedPanelId, focusWindowPanel, getMaximizedPanelId, getMinimizedPanelHandles, getPanelHandles, maximizeWindowPanel, minimizeWindowPanel, nextPanelHandle, operationPanelHandle, pruneDanglingMaximizedPanelId, setMaximizedPanelId } from "../client/src/canvas/window-registry.js";
+import { activateWindowPanel, clearMaximizedPanelId, focusWindowPanel, getMaximizedPanelId, getMinimizedPanelHandles, getPanelHandles, loadMaximizedPanelForTheater, maximizeWindowPanel, minimizeWindowPanel, nextPanelHandle, operationPanelHandle, pruneDanglingMaximizedPanelId, setMaximizedPanelId } from "../client/src/canvas/window-registry.js";
 
 const GEOMETRY: PanelGeometry = { x: 0, y: 0, width: 100, height: 100, zIndex: 0 };
 
@@ -18,14 +18,16 @@ beforeEach(() => {
   window.sessionStorage.clear();
   loadForTheater("theater-a");
   loadShellPanelsForTheater("theater-a");
+  loadMaximizedPanelForTheater("theater-a");
   clearMaximizedPanelId();
 });
 
 afterEach(() => {
   clearShellPanels();
+  clearMaximizedPanelId();
+  loadMaximizedPanelForTheater(null);
   loadForTheater(null);
   loadShellPanelsForTheater(null);
-  clearMaximizedPanelId();
   vi.unstubAllGlobals();
   vi.useRealTimers();
 });
@@ -199,6 +201,36 @@ describe("window registry facade", () => {
     expect(getMaximizedPanelId()).toBe("op-a");
     clearMaximizedPanelId();
     expect(getMaximizedPanelId()).toBeNull();
+  });
+
+  it("restores the maximized panel independently for each Theater", () => {
+    setMaximizedPanelId("op-a");
+
+    loadMaximizedPanelForTheater("theater-b");
+    expect(getMaximizedPanelId()).toBeNull();
+    setMaximizedPanelId("op-b");
+
+    loadMaximizedPanelForTheater("theater-a");
+    expect(getMaximizedPanelId()).toBe("op-a");
+
+    loadMaximizedPanelForTheater("theater-b");
+    expect(getMaximizedPanelId()).toBe("op-b");
+  });
+
+  it("does not clear another Theater's maximized panel when pruning the active Theater", () => {
+    setMaximizedPanelId("op-a");
+
+    loadMaximizedPanelForTheater("theater-b");
+    setMaximizedPanelId("missing");
+    expect(pruneDanglingMaximizedPanelId([], {
+      operationSessionsHydrated: true,
+      shellPanelsHydrated: true,
+      theaterReady: true,
+    })).toBe(true);
+    expect(getMaximizedPanelId()).toBeNull();
+
+    loadMaximizedPanelForTheater("theater-a");
+    expect(getMaximizedPanelId()).toBe("op-a");
   });
 
   it("maximizeWindowPanel minimizes the others, restores the target, and replaces the previous maximize", () => {


### PR DESCRIPTION
## Summary
- Preserve maximized Operation/Shell panel state per Theater when switching between Theaters.
- Restore the Theater-local maximized panel alongside canvas and shell panel state.
- Add regression coverage and a fleet-console changelog fragment.

## Type of Change
- [ ] feat — new feature or carrier capability
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope
- [ ] `extensions/core`
- [ ] `extensions/fleet` (Admiral / Bridge / Carriers)
- [ ] `extensions/boot`
- [ ] `extensions/diagnostics`
- [ ] `extensions/metaphor`
- [ ] `packages/unified-agent`
- [ ] `bin/` or root tooling
- [ ] Documentation (README / SETUP / AGENTS.md)

## Test Plan
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/window-registry.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Headless Chrome/CDP: Bravo maximized -> Alpha unmaximized -> Alpha maximized -> Bravo restored -> Alpha restored, with no page errors.

## Changelog
- [x] Added one `.changelog.d/*.md` fragment, or applied the `no-changelog` label intentionally.
- [x] Fragment `section:` is one of `Added`, `Changed`, `Fixed`, `Removed`, or `Breaking Changes`.
- [x] Fragment bullets are English and use only `[core-agent]`, `[core-unified-agent]`, `[fleet-infra]`, `[fleet-admiral]`, `[fleet-carriers]`, `[fleet-wiki]`, `[fleet-console]`, or `[fleet-cli]`.

## Related Issues / PRs

## Notes for Reviewers
- The browser scenario was run against an isolated console data directory with two dormant Operations, so no user daemon or terminal process was touched.
