### PR TITLE
feat(fleet-console): add terminal font customization

### DIFF
--- a/.changelog.d/console-terminal-font.md
+++ b/.changelog.d/console-terminal-font.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- [fleet-console] Added per-browser terminal font family and size controls that apply live to all open terminals.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,6 +256,9 @@ importers:
       '@fontsource-variable/cascadia-code':
         specifier: ^5.2.2
         version: 5.2.2
+      '@fontsource-variable/fira-code':
+        specifier: ^5.2.7
+        version: 5.2.7
       '@fontsource-variable/fraunces':
         specifier: ^5.2.9
         version: 5.2.9
@@ -265,6 +268,9 @@ importers:
       '@fontsource-variable/manrope':
         specifier: ^5.2.8
         version: 5.2.8
+      '@fontsource-variable/source-code-pro':
+        specifier: ^5.2.7
+        version: 5.2.7
       '@types/node':
         specifier: ^24.10.0
         version: 24.12.2
@@ -638,6 +644,9 @@ packages:
   '@fontsource-variable/cascadia-code@5.2.2':
     resolution: {integrity: sha512-5Sn7CySADZaPggdZ9wXnC0CKdLfca+7G7ipaSWSOXFQvAxnH+zKnflktVAVj5A3loP8ZAs72w7+v/RCwOnPpaQ==}
 
+  '@fontsource-variable/fira-code@5.2.7':
+    resolution: {integrity: sha512-J2bxN7fz5rd8WpQYyau4o19WqTzxoTqaNj9jhsv4p21GSu1Rf34tbqsxqjyDCR+wDMHM3SajyFqtq+5uvRUQ7w==}
+
   '@fontsource-variable/fraunces@5.2.9':
     resolution: {integrity: sha512-Y6IjunlN9Ni723np+GIgAaKzCDBrPRrqNi01TZxHs5wtHYROWFM9W6yiT+/gGwSjWIRD18oX17kD/BRWekc/Lw==}
 
@@ -646,6 +655,9 @@ packages:
 
   '@fontsource-variable/manrope@5.2.8':
     resolution: {integrity: sha512-nc9lOuCRz73UHnovDE2bwXUdghE2SEOc7Aii0qGe3CLyE03W1a7VnY5Z6euRiapiKbCkGS+eXbY3s/kvWeGeSw==}
+
+  '@fontsource-variable/source-code-pro@5.2.7':
+    resolution: {integrity: sha512-kZ0VNwnhvSA7vu5MaiO52eicQ4zC+k+8HBLZb+1js0MK/RngLy25NEUFB1y/AKd0ZMwru88T433QBcFf9m/huw==}
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -2431,11 +2443,15 @@ snapshots:
 
   '@fontsource-variable/cascadia-code@5.2.2': {}
 
+  '@fontsource-variable/fira-code@5.2.7': {}
+
   '@fontsource-variable/fraunces@5.2.9': {}
 
   '@fontsource-variable/jetbrains-mono@5.2.8': {}
 
   '@fontsource-variable/manrope@5.2.8': {}
+
+  '@fontsource-variable/source-code-pro@5.2.7': {}
 
   '@iconify/types@2.0.0': {}
 

--- a/runtime/fleet-console/client/src/components/terminal.tsx
+++ b/runtime/fleet-console/client/src/components/terminal.tsx
@@ -25,10 +25,6 @@ interface TerminalProps {
   readonly zoom?: number;
 }
 
-// 기본 폰트 크기(CSS px). 맵 줌 보정 시 fontSize = BASE_FONT_SIZE × zoom으로 키워, 부모 scale(zoom)과
-// 합쳐도 painted 글자 크기가 동일하게 유지되고(=base×parentZoom) xterm 좌표 분모(cellWidth)가 분자 단위와 맞는다.
-const BASE_FONT_SIZE = 14;
-
 const TERMINAL_OPTIONS = {
   // Unicode11Addon은 terminal.unicode(proposed API)를 사용하므로 이 옵션이 true여야 한다.
   // false이면 addon.activate()가 "must set allowProposedApi" 오류를 던져 터미널 마운트가 깨진다.
@@ -36,8 +32,6 @@ const TERMINAL_OPTIONS = {
   convertEol: true,
   cursorBlink: true,
   cursorStyle: "block" as const,
-  fontFamily: "\"Cascadia Code\", \"Cascadia Mono\", \"JetBrains Mono Variable\", ui-monospace, \"SF Mono\", Menlo, monospace",
-  fontSize: BASE_FONT_SIZE,
   lineHeight: 1.2,
 };
 
@@ -94,7 +88,7 @@ const CARBON_TERMINAL_THEME: ITheme = {
 };
 
 export function Terminal({ sessionId, kind, theaterId, onExit, active, zoom = 1 }: TerminalProps) {
-  const { activeTheme, terminalRenderer } = useConsoleState();
+  const { activeTheme, terminalRenderer, terminalFont } = useConsoleState();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const terminalRef = useRef<XtermTerminal | null>(null);
   const connectionRef = useRef<TerminalConnection | null>(null);
@@ -117,7 +111,12 @@ export function Terminal({ sessionId, kind, theaterId, onExit, active, zoom = 1 
     if (!container) return;
 
     let disposed = false;
-    const terminal = new XtermTerminal({ ...TERMINAL_OPTIONS, theme: terminalThemeFor(activeTheme) });
+    const terminal = new XtermTerminal({
+      ...TERMINAL_OPTIONS,
+      fontFamily: terminalFont.family,
+      fontSize: terminalFont.size * appliedZoom,
+      theme: terminalThemeFor(activeTheme),
+    });
     terminalRef.current = terminal;
     const fitAddon = new FitAddon();
     fitAddonRef.current = fitAddon;
@@ -266,6 +265,13 @@ export function Terminal({ sessionId, kind, theaterId, onExit, active, zoom = 1 
     terminal.options.theme = terminalThemeFor(activeTheme);
   }, [activeTheme]);
 
+  useEffect(() => {
+    const terminal = terminalRef.current;
+    if (!terminal) return;
+    terminal.options.fontFamily = terminalFont.family;
+    fitAndRefreshTerminal(terminal, fitAddonRef.current);
+  }, [terminalFont.family]);
+
   // 줌 settle 감지: zoom prop은 rAF 보간 중 매 프레임 바뀌므로, 마지막 변경 후 ZOOM_SETTLE_MS가 지나야
   // appliedZoom에 반영한다(타이머가 매 변경마다 리셋됨). 보간 중에는 부모 transform에 맡겨 글자가 부드럽게
   // 확대/축소되고, 보정(아래 effect)은 제스처당 1회만 발생한다.
@@ -281,9 +287,8 @@ export function Terminal({ sessionId, kind, theaterId, onExit, active, zoom = 1 
   // 그리드/픽셀 외형은 그대로 유지되며 xterm 좌표만 정정된다.
   useEffect(() => {
     const terminal = terminalRef.current;
-    const fitAddon = fitAddonRef.current;
-    if (!terminal || !fitAddon) return;
-    terminal.options.fontSize = BASE_FONT_SIZE * appliedZoom;
+    if (!terminal) return;
+    terminal.options.fontSize = terminalFont.size * appliedZoom;
     // 여기서 WebglAddon.clearTextureAtlas()를 호출하면 안 된다. xterm WebGL의 글리프 atlas는 동일 설정(폰트·
     // 테마·cell크기) 터미널들이 모듈 레벨 캐시(acquireTextureAtlas)에서 1개를 공유한다. 따라서 한 터미널이
     // atlas를 비우면 형제 터미널이 쓰는 공유 atlas까지 함께 비워지고, 형제에는 재그리기 신호가 가지 않아
@@ -291,9 +296,8 @@ export function Terminal({ sessionId, kind, theaterId, onExit, active, zoom = 1 
     // 바뀌면 xterm이 옵션 변경 핸들러(_handleOptionsChanged→_refreshCharAtlas→acquireTextureAtlas)에서 새
     // cell크기 키로 atlas를 자동 재획득하므로 수동 무효화는 불필요하다. atlas는 건드리지 않고 이 터미널만
     // fit + refresh로 재배치/재도색한다.
-    fitAddon.fit();
-    terminal.refresh(0, terminal.rows - 1);
-  }, [appliedZoom]);
+    fitAndRefreshTerminal(terminal, fitAddonRef.current);
+  }, [appliedZoom, terminalFont.size]);
 
   // 연결이 'live'면 상태 바를 숨겨 터미널 canvas가 카드를 가득 채우게 하고,
   // connecting/error 등 문제 상황에서만 상태를 노출한다.
@@ -329,4 +333,9 @@ export function Terminal({ sessionId, kind, theaterId, onExit, active, zoom = 1 
 
 function terminalThemeFor(theme: ThemeId): ITheme {
   return theme === "carbon" ? CARBON_TERMINAL_THEME : MARITIME_TERMINAL_THEME;
+}
+
+function fitAndRefreshTerminal(terminal: XtermTerminal, fitAddon: FitAddon | null): void {
+  fitAddon?.fit();
+  terminal.refresh(0, terminal.rows - 1);
 }

--- a/runtime/fleet-console/client/src/components/terminal.tsx
+++ b/runtime/fleet-console/client/src/components/terminal.tsx
@@ -269,7 +269,7 @@ export function Terminal({ sessionId, kind, theaterId, onExit, active, zoom = 1 
     const terminal = terminalRef.current;
     if (!terminal) return;
     terminal.options.fontFamily = terminalFont.family;
-    fitAndRefreshTerminal(terminal, fitAddonRef.current);
+    fitResizeAndRefreshTerminal(terminal, fitAddonRef.current, connectionRef.current);
   }, [terminalFont.family]);
 
   // 줌 settle 감지: zoom prop은 rAF 보간 중 매 프레임 바뀌므로, 마지막 변경 후 ZOOM_SETTLE_MS가 지나야
@@ -296,7 +296,7 @@ export function Terminal({ sessionId, kind, theaterId, onExit, active, zoom = 1 
     // 바뀌면 xterm이 옵션 변경 핸들러(_handleOptionsChanged→_refreshCharAtlas→acquireTextureAtlas)에서 새
     // cell크기 키로 atlas를 자동 재획득하므로 수동 무효화는 불필요하다. atlas는 건드리지 않고 이 터미널만
     // fit + refresh로 재배치/재도색한다.
-    fitAndRefreshTerminal(terminal, fitAddonRef.current);
+    fitResizeAndRefreshTerminal(terminal, fitAddonRef.current, connectionRef.current);
   }, [appliedZoom, terminalFont.size]);
 
   // 연결이 'live'면 상태 바를 숨겨 터미널 canvas가 카드를 가득 채우게 하고,
@@ -335,7 +335,8 @@ function terminalThemeFor(theme: ThemeId): ITheme {
   return theme === "carbon" ? CARBON_TERMINAL_THEME : MARITIME_TERMINAL_THEME;
 }
 
-function fitAndRefreshTerminal(terminal: XtermTerminal, fitAddon: FitAddon | null): void {
+function fitResizeAndRefreshTerminal(terminal: XtermTerminal, fitAddon: FitAddon | null, connection: TerminalConnection | null): void {
   fitAddon?.fit();
+  connection?.resize(terminal.cols, terminal.rows);
   terminal.refresh(0, terminal.rows - 1);
 }

--- a/runtime/fleet-console/client/src/main.tsx
+++ b/runtime/fleet-console/client/src/main.tsx
@@ -3,6 +3,8 @@ import "@fontsource-variable/fraunces/standard-italic.css";
 import "@fontsource-variable/manrope";
 import "@fontsource-variable/jetbrains-mono";
 import "@fontsource-variable/cascadia-code";
+import "@fontsource-variable/fira-code";
+import "@fontsource-variable/source-code-pro";
 import "./styles/theme.css";
 import "./styles/layout.css";
 import "./styles/components.css";

--- a/runtime/fleet-console/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/client/src/pages/global-settings.tsx
@@ -5,8 +5,9 @@ import { BackendApiSection } from "../components/backend-api-section.js";
 import { ModelAuthSection } from "../components/model-auth-section.js";
 import { loadGlobalSettings, setGlobalSettingsField, useGlobalSettingsStore } from "../global-settings-store.js";
 import { useConsoleState } from "../hooks/use-store.js";
-import { setActiveTheme, setTerminalRenderer } from "../store.js";
-import type { GlobalSettingsState, TerminalRenderer, ThemeId } from "../types.js";
+import { setActiveTheme, setCustomTerminalFont, setTerminalFont, setTerminalFontSize, setTerminalRenderer } from "../store.js";
+import { CURATED_TERMINAL_FONTS, TERMINAL_FONT_SIZE_RANGE, curatedTerminalFontById, resolveTerminalFont } from "../terminal-font.js";
+import type { GlobalSettingsState, TerminalFontId, TerminalFontSettings, TerminalRenderer, ThemeId } from "../types.js";
 
 interface SettingToggleRowProps {
   readonly title: string;
@@ -27,6 +28,17 @@ interface ThemeOption {
 interface RendererOption {
   readonly id: TerminalRenderer;
   readonly label: string;
+}
+
+interface TerminalFontCardProps {
+  readonly active: boolean;
+  readonly font: {
+    readonly id: TerminalFontId;
+    readonly name: string;
+    readonly family: string;
+    readonly meta: string;
+  };
+  readonly onSelect: () => void;
 }
 
 type SettingsSectionId = "appearance" | "general" | "agent-cli" | "backend-api";
@@ -123,9 +135,11 @@ function renderSettingsSection(sectionId: SettingsSectionId, state: GlobalSettin
   }
 }
 
-// 외관 설정 — 테마와 터미널 렌더러. 콘솔 로컬(브라우저별) 선호값이며 선택 즉시 적용된다(세션 설정과 달리 재실행 불요).
+// 외관 설정 — 테마, 터미널 렌더러, 터미널 폰트. 콘솔 로컬(브라우저별) 선호값이며 선택 즉시 적용된다(세션 설정과 달리 재실행 불요).
 function AppearanceCard() {
-  const { activeTheme, terminalRenderer } = useConsoleState();
+  const { activeTheme, terminalRenderer, terminalFont } = useConsoleState();
+  const resolution = resolveTerminalFont(terminalFont);
+  const currentFontLabel = terminalFontLabel(terminalFont);
   return (
     <section className="global-settings-card" aria-label="Appearance">
       <div className="global-settings-row">
@@ -179,9 +193,123 @@ function AppearanceCard() {
         </div>
       </div>
 
+      <div className="global-settings-row is-stack">
+        <div className="global-settings-row-text">
+          <p className="global-settings-resp-title">Terminal Font <span className="new-badge">New</span></p>
+          <p className="global-settings-help" id="terminal-font-help">Typeface and size for every terminal panel — agent-cli and shell alike. Applies live to all open terminals; remembered on this browser.</p>
+        </div>
+
+        <div className="font-control" aria-describedby="terminal-font-help">
+          <div className="current-readout" aria-live="polite">
+            <span className="cr-label">Currently</span>
+            <span className="cr-value">{currentFontLabel}</span>
+            <span className="cr-sep">·</span>
+            <span className="cr-value">{terminalFont.size}px</span>
+            <span className="cr-sep">·</span>
+            <span className={`cr-value ${resolution.status === "fallback" ? "is-fallback" : "is-ok"}`}>{resolution.status}</span>
+          </div>
+
+          <div className="font-cards" role="group" aria-label="Terminal font family">
+            {CURATED_TERMINAL_FONTS.map((font) => (
+              <TerminalFontCard
+                key={font.id}
+                font={font}
+                active={terminalFont.source === "curated" && terminalFont.id === font.id}
+                onSelect={() => setTerminalFont(font.id)}
+              />
+            ))}
+            <button
+              type="button"
+              aria-pressed={terminalFont.source === "custom"}
+              className={`font-card ${terminalFont.source === "custom" ? "is-active" : ""}`}
+              onClick={() => {
+                if (terminalFont.source !== "custom") setCustomTerminalFont("");
+              }}
+            >
+              <span className="fc-name">Custom…<span className="fc-check" aria-hidden="true">✓</span></span>
+              <span className="fc-sample is-custom" aria-hidden="true">type a font</span>
+              <span className="fc-meta">your installed face</span>
+              <span className="fc-bundled fc-addon">local OS font</span>
+            </button>
+          </div>
+
+          <div className={`custom-reveal ${terminalFont.source === "custom" ? "is-open" : ""}`}>
+            <div className="font-field-wrap">
+              <label className="font-field">
+                <span className="field-icon" aria-hidden="true">Aa</span>
+                <input
+                  type="text"
+                  spellCheck={false}
+                  value={terminalFont.customName}
+                  placeholder="e.g. MesloLGS NF, Fira Code, IBM Plex Mono"
+                  aria-label="Custom terminal font family"
+                  onChange={(event) => setCustomTerminalFont(event.currentTarget.value)}
+                />
+              </label>
+              <div className={`resolve-chip ${resolution.status === "fallback" ? "is-fallback" : "is-ok"}`} aria-live="polite">
+                <span className="rc-dot" aria-hidden="true" />
+                <span>{terminalFontResolveText(terminalFont)}</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="size-row">
+            <div className="size-stepper" role="group" aria-label="Font size">
+              <button
+                type="button"
+                aria-label="Decrease terminal font size"
+                disabled={terminalFont.size <= TERMINAL_FONT_SIZE_RANGE.min}
+                onClick={() => setTerminalFontSize(terminalFont.size - 1)}
+              >
+                −
+              </button>
+              <span className="size-val">{terminalFont.size}<span> px</span></span>
+              <button
+                type="button"
+                aria-label="Increase terminal font size"
+                disabled={terminalFont.size >= TERMINAL_FONT_SIZE_RANGE.max}
+                onClick={() => setTerminalFontSize(terminalFont.size + 1)}
+              >
+                +
+              </button>
+            </div>
+            <span className="size-label">Cell size — rescales every panel; zoom stays relative</span>
+          </div>
+        </div>
+      </div>
+
       <p className="global-settings-foot">Appearance preferences apply immediately and are stored per browser, separate from session settings.</p>
     </section>
   );
+}
+
+function TerminalFontCard({ active, font, onSelect }: TerminalFontCardProps) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      className={`font-card ${active ? "is-active" : ""}`}
+      onClick={onSelect}
+    >
+      <span className="fc-name">{font.name}<span className="fc-check" aria-hidden="true">✓</span></span>
+      <span className="fc-sample" style={{ fontFamily: font.family }} aria-hidden="true">Ag 0O ─┼ =&gt;</span>
+      <span className="fc-meta">{font.meta}</span>
+      <span className="fc-bundled">self-hosted</span>
+    </button>
+  );
+}
+
+function terminalFontLabel(font: TerminalFontSettings): string {
+  if (font.source === "custom") return font.customName || `${curatedTerminalFontById(null).name} (default)`;
+  return curatedTerminalFontById(font.id).name;
+}
+
+function terminalFontResolveText(font: TerminalFontSettings): string {
+  if (!font.customName) return `Empty — using default ${curatedTerminalFontById(null).name}`;
+  const resolution = resolveTerminalFont(font);
+  return resolution.status === "resolved"
+    ? `"${font.customName}" resolves on this machine`
+    : `"${font.customName}" not found — falls back to ${resolution.fallbackName}`;
 }
 
 function GeneralSettingsCard({

--- a/runtime/fleet-console/client/src/store.ts
+++ b/runtime/fleet-console/client/src/store.ts
@@ -2,6 +2,12 @@ import { applyEvent, createEmptyJob, isTerminalJobStatus, reduceSnapshotJob } fr
 import { sessionDisplayLabel } from "./format.js";
 import { buildOperationSearchEntries } from "./operation-search.js";
 import { clearStoredShellPanelsForTheater } from "./canvas/shell-panels.js";
+import {
+  createCuratedTerminalFontSettings,
+  createCustomTerminalFontSettings,
+  parseStoredTerminalFontSettings,
+  serializeTerminalFontSettings,
+} from "./terminal-font.js";
 import type {
   AttentionReason,
   ConsoleState,
@@ -17,6 +23,8 @@ import type {
   SessionInfo,
   SnapshotTenantJobs,
   TenantJobsView,
+  TerminalFontId,
+  TerminalFontSettings,
   TerminalRenderer,
   ThemeId,
   TheaterBootstrap,
@@ -37,6 +45,7 @@ const TENANT_JOB_LIMIT = 200;
 const ACTIVE_THEATER_STORAGE_KEY = "fleet-console.activeTheaterId";
 const THEME_STORAGE_KEY = "fleet-console.activeTheme";
 const RENDERER_STORAGE_KEY = "fleet-console.terminalRenderer";
+const TERMINAL_FONT_STORAGE_KEY = "fleet-console.terminalFont";
 const COMMISSIONING_SEEN_STORAGE_KEY = "fleet-console.commissioningSeen";
 const WHATS_NEW_SEEN_VERSION_STORAGE_KEY = "fleet-console.whatsNewSeenVersion";
 const NOTIFICATION_PREFERENCES_STORAGE_KEY = "fleet-console.notificationPreferences";
@@ -58,6 +67,7 @@ let state: ConsoleState = {
   connectionError: null,
   activeTheme: readStoredTheme(),
   terminalRenderer: readStoredRenderer(),
+  terminalFont: readStoredTerminalFont(),
   version: "",
   updateAvailable: false,
   latestVersion: null,
@@ -137,6 +147,26 @@ export function setTerminalRenderer(renderer: TerminalRenderer): void {
   setState({ terminalRenderer: renderer });
 }
 
+export function setTerminalFont(fontId: TerminalFontId): void {
+  const terminalFont = createCuratedTerminalFontSettings(fontId, state.terminalFont.size);
+  writeStoredTerminalFont(terminalFont);
+  setState({ terminalFont });
+}
+
+export function setCustomTerminalFont(customName: string): void {
+  const terminalFont = createCustomTerminalFontSettings(customName, state.terminalFont.size);
+  writeStoredTerminalFont(terminalFont);
+  setState({ terminalFont });
+}
+
+export function setTerminalFontSize(size: number): void {
+  const terminalFont = state.terminalFont.source === "custom"
+    ? createCustomTerminalFontSettings(state.terminalFont.customName, size)
+    : createCuratedTerminalFontSettings(state.terminalFont.id, size);
+  writeStoredTerminalFont(terminalFont);
+  setState({ terminalFont });
+}
+
 export function readStoredRenderer(): TerminalRenderer {
   if (typeof window === "undefined") return DEFAULT_RENDERER;
   try {
@@ -144,6 +174,15 @@ export function readStoredRenderer(): TerminalRenderer {
     return stored === "webgl" || stored === "dom" ? stored : DEFAULT_RENDERER;
   } catch {
     return DEFAULT_RENDERER;
+  }
+}
+
+export function readStoredTerminalFont(): TerminalFontSettings {
+  if (typeof window === "undefined") return parseStoredTerminalFontSettings(null);
+  try {
+    return parseStoredTerminalFontSettings(window.localStorage.getItem(TERMINAL_FONT_STORAGE_KEY));
+  } catch {
+    return parseStoredTerminalFontSettings(null);
   }
 }
 
@@ -922,6 +961,15 @@ function writeStoredRenderer(renderer: TerminalRenderer): void {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(RENDERER_STORAGE_KEY, renderer);
+  } catch {
+    // 브라우저 저장소가 막힌 환경에서는 현재 세션 상태만 유지한다.
+  }
+}
+
+function writeStoredTerminalFont(font: ConsoleState["terminalFont"]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(TERMINAL_FONT_STORAGE_KEY, serializeTerminalFontSettings(font));
   } catch {
     // 브라우저 저장소가 막힌 환경에서는 현재 세션 상태만 유지한다.
   }

--- a/runtime/fleet-console/client/src/styles/components.css
+++ b/runtime/fleet-console/client/src/styles/components.css
@@ -695,6 +695,328 @@
   height: 13px;
 }
 
+.global-settings-row.is-stack {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.new-badge {
+  display: inline-flex;
+  align-items: center;
+  margin-left: var(--space-2);
+  padding: 2px 7px;
+  border: 1px solid var(--aurora-glow);
+  border-radius: 999px;
+  background: var(--aurora-glow);
+  color: var(--aurora);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  line-height: 1.2;
+  text-transform: uppercase;
+  vertical-align: middle;
+}
+
+.font-control {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  width: 100%;
+}
+
+.current-readout {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-md);
+  background: oklch(24% 0.04 248 / 50%);
+}
+
+.current-readout .cr-label {
+  color: var(--ink-rim);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.current-readout .cr-value {
+  color: var(--ink-pearl);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.current-readout .cr-value.is-ok {
+  color: var(--positive);
+}
+
+.current-readout .cr-value.is-fallback {
+  color: var(--warn);
+}
+
+.current-readout .cr-sep {
+  color: var(--ink-rim);
+}
+
+.font-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: var(--space-3);
+}
+
+.font-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 128px;
+  padding: 14px 14px 12px;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--surface-glass-strong) 70%, transparent);
+  color: var(--ink-fog);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color var(--duration-base) var(--ease-spring),
+    box-shadow var(--duration-base) var(--ease-spring),
+    transform var(--duration-base) var(--ease-spring);
+}
+
+.font-card:hover {
+  border-color: var(--surface-rim-strong);
+  transform: translateY(-2px);
+}
+
+.font-card.is-active {
+  border-color: var(--brass);
+  box-shadow: 0 0 0 1px var(--brass-glow), 0 14px 30px -18px var(--brass-glow);
+}
+
+.font-card:active {
+  transform: translateY(1px);
+}
+
+.font-card .fc-name {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  color: var(--ink-pearl);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.font-card .fc-check {
+  color: var(--brass);
+  opacity: 0;
+  transition: opacity var(--duration-fast) var(--ease-spring);
+}
+
+.font-card.is-active .fc-check {
+  opacity: 1;
+}
+
+.font-card .fc-sample {
+  color: var(--ink-spectral);
+  font-size: 19px;
+  letter-spacing: 0.01em;
+  line-height: 1.25;
+}
+
+.font-card .fc-sample.is-custom {
+  color: var(--ink-fog);
+  font-family: var(--font-body);
+  font-style: italic;
+}
+
+.font-card .fc-meta {
+  color: var(--ink-rim);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.05em;
+}
+
+.font-card .fc-bundled {
+  color: var(--positive);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.font-card .fc-addon {
+  color: var(--warn);
+}
+
+.custom-reveal {
+  display: none;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 4px;
+}
+
+.custom-reveal.is-open {
+  display: flex;
+  animation: codex-rise var(--duration-base) var(--ease-spring);
+}
+
+.font-field-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.font-field {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 12px;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  background: var(--surface-pillar);
+  transition:
+    border-color var(--duration-base) var(--ease-spring),
+    box-shadow var(--duration-base) var(--ease-spring);
+}
+
+.font-field:focus-within {
+  border-color: var(--brass);
+  box-shadow: 0 0 0 1px var(--brass-glow);
+}
+
+.font-field input {
+  flex: 1;
+  min-width: 0;
+  padding: 12px 0;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: var(--ink-pearl);
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+.font-field input::placeholder {
+  color: var(--ink-rim);
+}
+
+.font-field .field-icon {
+  color: var(--ink-rim);
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+.resolve-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  width: fit-content;
+  padding: 6px 11px;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  transition:
+    color var(--duration-base) var(--ease-spring),
+    background var(--duration-base) var(--ease-spring),
+    border-color var(--duration-base) var(--ease-spring);
+}
+
+.resolve-chip .rc-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+
+.resolve-chip.is-ok {
+  border: 1px solid var(--positive-glow);
+  background: var(--positive-glow);
+  color: var(--positive);
+}
+
+.resolve-chip.is-ok .rc-dot {
+  background: var(--positive);
+  box-shadow: 0 0 8px var(--positive-glow);
+}
+
+.resolve-chip.is-fallback {
+  border: 1px solid var(--warn-glow);
+  background: var(--warn-glow);
+  color: var(--warn);
+}
+
+.resolve-chip.is-fallback .rc-dot {
+  background: var(--warn);
+  box-shadow: 0 0 8px var(--warn-glow);
+}
+
+.size-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+}
+
+.size-stepper {
+  display: inline-flex;
+  align-items: center;
+  overflow: hidden;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  background: var(--surface-pillar);
+}
+
+.size-stepper button {
+  width: 38px;
+  height: 38px;
+  border: 0;
+  background: transparent;
+  color: var(--ink-spectral);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-spring);
+}
+
+.size-stepper button:hover:not(:disabled) {
+  background: var(--surface-glass-strong);
+}
+
+.size-stepper button:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.size-stepper .size-val {
+  min-width: 58px;
+  color: var(--ink-pearl);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.size-stepper .size-val span {
+  color: var(--ink-fog);
+  font-size: 11px;
+}
+
+.size-label {
+  color: var(--ink-fog);
+  font-size: 12px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .custom-reveal.is-open {
+    animation: none;
+  }
+}
+
 /* 터미널 렌더러 — 2지선다 세그먼트 컨트롤. 트랙 위 활성 세그먼트만 brass로 채운다. */
 .segmented {
   display: inline-flex;

--- a/runtime/fleet-console/client/src/terminal-font.ts
+++ b/runtime/fleet-console/client/src/terminal-font.ts
@@ -24,8 +24,10 @@ const TERMINAL_FONT_FALLBACK_STACK = "ui-monospace, \"SF Mono\", Menlo, monospac
 const DEFAULT_TERMINAL_FONT_SIZE = 14;
 const MIN_TERMINAL_FONT_SIZE = 10;
 const MAX_TERMINAL_FONT_SIZE = 22;
+const MAX_CUSTOM_FONT_NAME_LENGTH = 128;
 const FONT_RESOLVE_THRESHOLD_PX = 0.5;
 const FONT_RESOLVE_PROBE = "mmmmmmmmmmwwwwiIl1 0O-_|┌ABCxyz";
+const CONTROL_CHARACTER_PATTERN = /[\x00-\x1F\x7F]/g;
 
 export const TERMINAL_FONT_SIZE_RANGE = {
   min: MIN_TERMINAL_FONT_SIZE,
@@ -93,12 +95,12 @@ export function createCuratedTerminalFontSettings(id: TerminalFontId | null, siz
 }
 
 export function createCustomTerminalFontSettings(customName: string, size: number): TerminalFontSettings {
-  const trimmedName = customName.trim();
+  const sanitizedName = sanitizeCustomFontFamilyName(customName);
   return {
     source: "custom",
     id: null,
-    customName: trimmedName,
-    family: trimmedName ? `"${escapeFontFamilyName(trimmedName)}", ${DEFAULT_TERMINAL_FONT.family}` : DEFAULT_TERMINAL_FONT.family,
+    customName: sanitizedName,
+    family: sanitizedName ? `"${escapeFontFamilyName(sanitizedName)}", ${DEFAULT_TERMINAL_FONT.family}` : DEFAULT_TERMINAL_FONT.family,
     size: clampTerminalFontSize(size),
   };
 }
@@ -166,6 +168,10 @@ function measureFontWidth(context: CanvasRenderingContext2D, family: string): nu
 
 function isTerminalFontId(value: string): value is TerminalFontId {
   return CURATED_TERMINAL_FONTS.some((font) => font.id === value);
+}
+
+function sanitizeCustomFontFamilyName(name: string): string {
+  return name.replace(CONTROL_CHARACTER_PATTERN, "").trim().slice(0, MAX_CUSTOM_FONT_NAME_LENGTH);
 }
 
 function escapeFontFamilyName(name: string): string {

--- a/runtime/fleet-console/client/src/terminal-font.ts
+++ b/runtime/fleet-console/client/src/terminal-font.ts
@@ -1,0 +1,173 @@
+import type { TerminalFontId, TerminalFontSettings } from "./types.js";
+
+export interface CuratedTerminalFont {
+  readonly id: TerminalFontId;
+  readonly name: string;
+  readonly familyName: string;
+  readonly family: string;
+  readonly meta: string;
+}
+
+export interface TerminalFontResolution {
+  readonly status: "self-hosted" | "resolved" | "fallback";
+  readonly fallbackName: string;
+}
+
+interface StoredTerminalFontSettings {
+  readonly source?: unknown;
+  readonly id?: unknown;
+  readonly customName?: unknown;
+  readonly size?: unknown;
+}
+
+const TERMINAL_FONT_FALLBACK_STACK = "ui-monospace, \"SF Mono\", Menlo, monospace";
+const DEFAULT_TERMINAL_FONT_SIZE = 14;
+const MIN_TERMINAL_FONT_SIZE = 10;
+const MAX_TERMINAL_FONT_SIZE = 22;
+const FONT_RESOLVE_THRESHOLD_PX = 0.5;
+const FONT_RESOLVE_PROBE = "mmmmmmmmmmwwwwiIl1 0O-_|┌ABCxyz";
+
+export const TERMINAL_FONT_SIZE_RANGE = {
+  min: MIN_TERMINAL_FONT_SIZE,
+  max: MAX_TERMINAL_FONT_SIZE,
+};
+
+export const DEFAULT_TERMINAL_FONT_ID: TerminalFontId = "cascadia";
+
+export const CURATED_TERMINAL_FONTS: readonly CuratedTerminalFont[] = [
+  {
+    id: "cascadia",
+    name: "Cascadia Code",
+    familyName: "Cascadia Code Variable",
+    family: "\"Cascadia Code Variable\", ui-monospace, \"SF Mono\", Menlo, monospace",
+    meta: "Variable · terminal tuned",
+  },
+  {
+    id: "jetbrains",
+    name: "JetBrains Mono",
+    familyName: "JetBrains Mono Variable",
+    family: "\"JetBrains Mono Variable\", ui-monospace, \"SF Mono\", Menlo, monospace",
+    meta: "Variable · console mono",
+  },
+  {
+    id: "fira-code",
+    name: "Fira Code",
+    familyName: "Fira Code Variable",
+    family: "\"Fira Code Variable\", ui-monospace, \"SF Mono\", Menlo, monospace",
+    meta: "Variable · ligatures",
+  },
+  {
+    id: "source-code-pro",
+    name: "Source Code Pro",
+    familyName: "Source Code Pro Variable",
+    family: "\"Source Code Pro Variable\", ui-monospace, \"SF Mono\", Menlo, monospace",
+    meta: "Variable · Adobe mono",
+  },
+];
+
+export const DEFAULT_TERMINAL_FONT = CURATED_TERMINAL_FONTS[0] as CuratedTerminalFont;
+
+export function curatedTerminalFontById(id: TerminalFontId | null): CuratedTerminalFont {
+  return CURATED_TERMINAL_FONTS.find((font) => font.id === id) ?? DEFAULT_TERMINAL_FONT;
+}
+
+export function createDefaultTerminalFontSettings(): TerminalFontSettings {
+  return {
+    source: "curated",
+    id: DEFAULT_TERMINAL_FONT_ID,
+    customName: "",
+    family: DEFAULT_TERMINAL_FONT.family,
+    size: DEFAULT_TERMINAL_FONT_SIZE,
+  };
+}
+
+export function createCuratedTerminalFontSettings(id: TerminalFontId | null, size: number): TerminalFontSettings {
+  const font = curatedTerminalFontById(id);
+  return {
+    source: "curated",
+    id: font.id,
+    customName: "",
+    family: font.family,
+    size: clampTerminalFontSize(size),
+  };
+}
+
+export function createCustomTerminalFontSettings(customName: string, size: number): TerminalFontSettings {
+  const trimmedName = customName.trim();
+  return {
+    source: "custom",
+    id: null,
+    customName: trimmedName,
+    family: trimmedName ? `"${escapeFontFamilyName(trimmedName)}", ${DEFAULT_TERMINAL_FONT.family}` : DEFAULT_TERMINAL_FONT.family,
+    size: clampTerminalFontSize(size),
+  };
+}
+
+export function parseStoredTerminalFontSettings(raw: string | null): TerminalFontSettings {
+  if (!raw) return createDefaultTerminalFontSettings();
+  try {
+    const stored = JSON.parse(raw) as StoredTerminalFontSettings;
+    const size = clampTerminalFontSize(typeof stored.size === "number" ? stored.size : DEFAULT_TERMINAL_FONT_SIZE);
+    if (stored.source === "custom" && typeof stored.customName === "string") {
+      return createCustomTerminalFontSettings(stored.customName, size);
+    }
+    if (typeof stored.id === "string" && isTerminalFontId(stored.id)) {
+      return createCuratedTerminalFontSettings(stored.id, size);
+    }
+  } catch {
+    // 손상된 localStorage 값은 기본 Cascadia self-hosted 설정으로 복구한다.
+  }
+  return createDefaultTerminalFontSettings();
+}
+
+export function serializeTerminalFontSettings(settings: TerminalFontSettings): string {
+  return JSON.stringify({
+    source: settings.source,
+    id: settings.id,
+    customName: settings.customName,
+    size: settings.size,
+  });
+}
+
+export function clampTerminalFontSize(size: number): number {
+  if (!Number.isFinite(size)) return DEFAULT_TERMINAL_FONT_SIZE;
+  return Math.min(MAX_TERMINAL_FONT_SIZE, Math.max(MIN_TERMINAL_FONT_SIZE, Math.round(size)));
+}
+
+export function resolveTerminalFont(settings: TerminalFontSettings): TerminalFontResolution {
+  if (settings.source === "curated") {
+    return { status: "self-hosted", fallbackName: DEFAULT_TERMINAL_FONT.name };
+  }
+  if (!settings.customName) {
+    return { status: "fallback", fallbackName: DEFAULT_TERMINAL_FONT.name };
+  }
+  return {
+    status: fontResolves(settings.customName) ? "resolved" : "fallback",
+    fallbackName: DEFAULT_TERMINAL_FONT.name,
+  };
+}
+
+function fontResolves(name: string): boolean {
+  if (typeof document === "undefined") return false;
+  const context = document.createElement("canvas").getContext("2d");
+  if (!context) return false;
+  for (const generic of ["monospace", "serif", "sans-serif"]) {
+    const candidateWidth = measureFontWidth(context, `"${escapeFontFamilyName(name)}", ${generic}`);
+    const genericWidth = measureFontWidth(context, generic);
+    if (Math.abs(candidateWidth - genericWidth) > FONT_RESOLVE_THRESHOLD_PX) return true;
+  }
+  return false;
+}
+
+function measureFontWidth(context: CanvasRenderingContext2D, family: string): number {
+  context.font = `28px ${family}`;
+  return context.measureText(FONT_RESOLVE_PROBE).width;
+}
+
+function isTerminalFontId(value: string): value is TerminalFontId {
+  return CURATED_TERMINAL_FONTS.some((font) => font.id === value);
+}
+
+function escapeFontFamilyName(name: string): string {
+  return name.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
+}

--- a/runtime/fleet-console/client/src/types.ts
+++ b/runtime/fleet-console/client/src/types.ts
@@ -2,6 +2,18 @@ export type ThemeId = "maritime" | "carbon";
 
 export type TerminalRenderer = "webgl" | "dom";
 
+export type TerminalFontId = "cascadia" | "jetbrains" | "fira-code" | "source-code-pro";
+
+export type TerminalFontSource = "curated" | "custom";
+
+export interface TerminalFontSettings {
+  readonly source: TerminalFontSource;
+  readonly id: TerminalFontId | null;
+  readonly customName: string;
+  readonly family: string;
+  readonly size: number;
+}
+
 export interface ReleaseNoteSection {
   readonly heading: "Added" | "Changed" | "Fixed" | "Removed" | "Breaking Changes";
   readonly items: readonly ReleaseNoteItem[];
@@ -333,6 +345,7 @@ export interface ConsoleState {
   readonly connectionError: string | null;
   readonly activeTheme: ThemeId;
   readonly terminalRenderer: TerminalRenderer;
+  readonly terminalFont: TerminalFontSettings;
   readonly version: string;
   readonly updateAvailable: boolean;
   readonly latestVersion: string | null;

--- a/runtime/fleet-console/client/src/vite-env.d.ts
+++ b/runtime/fleet-console/client/src/vite-env.d.ts
@@ -4,3 +4,5 @@ declare module "@fontsource-variable/fraunces";
 declare module "@fontsource-variable/manrope";
 declare module "@fontsource-variable/jetbrains-mono";
 declare module "@fontsource-variable/cascadia-code";
+declare module "@fontsource-variable/fira-code";
+declare module "@fontsource-variable/source-code-pro";

--- a/runtime/fleet-console/package.json
+++ b/runtime/fleet-console/package.json
@@ -72,9 +72,11 @@
   },
   "devDependencies": {
     "@fontsource-variable/cascadia-code": "^5.2.2",
+    "@fontsource-variable/fira-code": "^5.2.7",
     "@fontsource-variable/fraunces": "^5.2.9",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource-variable/manrope": "^5.2.8",
+    "@fontsource-variable/source-code-pro": "^5.2.7",
     "@types/node": "^24.10.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/runtime/fleet-console/tests/operation-search.test.ts
+++ b/runtime/fleet-console/tests/operation-search.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { buildOperationSearchEntries, filterOperationSearchEntries, groupOperationSearchEntries } from "../client/src/operation-search.js";
+import { createDefaultTerminalFontSettings } from "../client/src/terminal-font.js";
 import type { ConsoleState, SessionInfo, TheaterInfo } from "../client/src/types.js";
 
 const THEATER_ALPHA: TheaterInfo = { id: "theater-alpha", label: "Alpha Harbor", createdAt: "2026-06-16T00:00:00.000Z", lastOpenedAt: "2026-06-16T00:00:00.000Z", hasWiki: true, activeAdmiralCount: 1 };
@@ -16,6 +17,7 @@ function makeState(sessions: readonly (Omit<SessionInfo, "resumeAvailable" | "tu
     connectionError: null,
     activeTheme: "maritime",
     terminalRenderer: "webgl",
+    terminalFont: createDefaultTerminalFontSettings(),
     version: "1.8.0",
     updateAvailable: false,
     latestVersion: null,

--- a/runtime/fleet-console/tests/reduce.test.ts
+++ b/runtime/fleet-console/tests/reduce.test.ts
@@ -9,6 +9,7 @@ import {
   reduceSnapshotJob,
   splitNotificationsByVisibility,
 } from "../client/src/reduce.js";
+import { createDefaultTerminalFontSettings } from "../client/src/terminal-font.js";
 import type { ConsoleState, NotificationPreferences, ObservedEvent, OperationNotification } from "../client/src/types.js";
 
 function makeEvent(id: number, type: string, event: Record<string, unknown>, jobId = "job-1"): ObservedEvent {
@@ -38,6 +39,7 @@ function makeConsoleSnap(patch: Partial<ConsoleState> = {}): ConsoleState {
     connectionError: null,
     activeTheme: "maritime",
     terminalRenderer: "webgl",
+    terminalFont: createDefaultTerminalFontSettings(),
     version: "1.8.0",
     updateAvailable: false,
     latestVersion: null,

--- a/runtime/fleet-console/tests/store.test.ts
+++ b/runtime/fleet-console/tests/store.test.ts
@@ -26,6 +26,7 @@ import {
   openOperationSearch,
   openShortcuts,
   openWhatsNew,
+  readStoredTerminalFont,
   readStoredRenderer,
   removeTerminalSession,
   removeTheater,
@@ -37,6 +38,9 @@ import {
   setActiveTheater,
   setDnd,
   setGlobalMute,
+  setCustomTerminalFont,
+  setTerminalFont,
+  setTerminalFontSize,
   setTerminalRenderer,
   setState,
   theaterSessionOrder,
@@ -51,6 +55,7 @@ const TENANT: ObservedTenant = { tenantId: "tenant-1", tenantLabel: "Alpha", cre
 const THEATER_A: TheaterInfo = { id: "theater-a", label: "Alpha", createdAt: "2026-06-13T00:00:00.000Z", lastOpenedAt: "2026-06-13T00:00:00.000Z", hasWiki: true, activeAdmiralCount: 1 };
 const THEATER_B: TheaterInfo = { id: "theater-b", label: "Beta", createdAt: "2026-06-13T00:00:00.000Z", lastOpenedAt: "2026-06-13T00:00:01.000Z", hasWiki: false, activeAdmiralCount: 0 };
 const RENDERER_STORAGE_KEY = "fleet-console.terminalRenderer";
+const TERMINAL_FONT_STORAGE_KEY = "fleet-console.terminalFont";
 const COMMISSIONING_SEEN_STORAGE_KEY = "fleet-console.commissioningSeen";
 const NOTIFICATION_PREFERENCES_STORAGE_KEY = "fleet-console.notificationPreferences";
 
@@ -82,6 +87,7 @@ beforeEach(() => {
     connection: "connecting",
     connectionError: null,
     terminalRenderer: "webgl",
+    terminalFont: readStoredTerminalFont(),
     updateAvailable: false,
     latestVersion: null,
     tenants: [],
@@ -143,6 +149,62 @@ describe("store", () => {
 
     expect(getState().terminalRenderer).toBe("dom");
     expect(storage.get(RENDERER_STORAGE_KEY)).toBe("dom");
+  });
+
+  it("reads terminal font settings with self-hosted Cascadia as the default", () => {
+    expect(readStoredTerminalFont()).toMatchObject({
+      source: "curated",
+      id: "cascadia",
+      customName: "",
+      family: "\"Cascadia Code Variable\", ui-monospace, \"SF Mono\", Menlo, monospace",
+      size: 14,
+    });
+
+    const storage = new Map<string, string>();
+    mockLocalStorage(storage);
+    storage.set(TERMINAL_FONT_STORAGE_KEY, JSON.stringify({
+      source: "curated",
+      id: "fira-code",
+      size: 18,
+    }));
+
+    expect(readStoredTerminalFont()).toMatchObject({
+      source: "curated",
+      id: "fira-code",
+      family: "\"Fira Code Variable\", ui-monospace, \"SF Mono\", Menlo, monospace",
+      size: 18,
+    });
+  });
+
+  it("persists terminal font family and size changes into state and localStorage", () => {
+    const storage = new Map<string, string>();
+    mockLocalStorage(storage);
+
+    setTerminalFont("source-code-pro");
+    expect(getState().terminalFont).toMatchObject({
+      source: "curated",
+      id: "source-code-pro",
+      family: "\"Source Code Pro Variable\", ui-monospace, \"SF Mono\", Menlo, monospace",
+      size: 14,
+    });
+
+    setTerminalFontSize(30);
+    expect(getState().terminalFont.size).toBe(22);
+
+    setCustomTerminalFont("MesloLGS NF");
+    expect(getState().terminalFont).toMatchObject({
+      source: "custom",
+      id: null,
+      customName: "MesloLGS NF",
+      family: "\"MesloLGS NF\", \"Cascadia Code Variable\", ui-monospace, \"SF Mono\", Menlo, monospace",
+      size: 22,
+    });
+    expect(JSON.parse(storage.get(TERMINAL_FONT_STORAGE_KEY) ?? "{}")).toEqual({
+      source: "custom",
+      id: null,
+      customName: "MesloLGS NF",
+      size: 22,
+    });
   });
 
   it("applies observer update status to the global state", () => {

--- a/runtime/fleet-console/tests/terminal-font.test.ts
+++ b/runtime/fleet-console/tests/terminal-font.test.ts
@@ -34,6 +34,32 @@ describe("terminal font settings", () => {
     });
   });
 
+  it("removes control characters and caps custom font names before building font-family", () => {
+    const longName = "A".repeat(140);
+    const settings = createCustomTerminalFontSettings(`\t\n  Meslo\r"NF"\\${longName}\f  `, 14);
+
+    expect(settings.customName).toHaveLength(128);
+    expect(settings.customName).not.toMatch(/[\x00-\x1F\x7F]/);
+    expect(settings.family).not.toMatch(/[\r\n\t\f]/);
+    expect(settings.family).toContain("\\\"NF\\\"");
+    expect(settings.family).toContain("\\\\");
+  });
+
+  it("sanitizes custom font names restored from localStorage", () => {
+    const settings = parseStoredTerminalFontSettings(JSON.stringify({
+      source: "custom",
+      customName: "\n\t  \f",
+      size: 14,
+    }));
+
+    expect(settings).toMatchObject({
+      source: "custom",
+      customName: "",
+      family: "\"Cascadia Code Variable\", ui-monospace, \"SF Mono\", Menlo, monospace",
+      size: 14,
+    });
+  });
+
   it("uses canvas width comparison to distinguish resolved custom fonts from fallback", () => {
     mockCanvasWidths({
       monospace: 100,

--- a/runtime/fleet-console/tests/terminal-font.test.ts
+++ b/runtime/fleet-console/tests/terminal-font.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  CURATED_TERMINAL_FONTS,
+  createCustomTerminalFontSettings,
+  parseStoredTerminalFontSettings,
+  resolveTerminalFont,
+} from "../client/src/terminal-font.js";
+
+describe("terminal font settings", () => {
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, "document");
+  });
+
+  it("pins curated terminal fonts to the measured fontsource variable family names", () => {
+    expect(CURATED_TERMINAL_FONTS.map((font) => [font.name, font.family])).toEqual([
+      ["Cascadia Code", "\"Cascadia Code Variable\", ui-monospace, \"SF Mono\", Menlo, monospace"],
+      ["JetBrains Mono", "\"JetBrains Mono Variable\", ui-monospace, \"SF Mono\", Menlo, monospace"],
+      ["Fira Code", "\"Fira Code Variable\", ui-monospace, \"SF Mono\", Menlo, monospace"],
+      ["Source Code Pro", "\"Source Code Pro Variable\", ui-monospace, \"SF Mono\", Menlo, monospace"],
+    ]);
+  });
+
+  it("normalizes stored custom font names and clamps sizes", () => {
+    expect(parseStoredTerminalFontSettings(JSON.stringify({
+      source: "custom",
+      customName: "  MesloLGS NF  ",
+      size: 99,
+    }))).toMatchObject({
+      source: "custom",
+      customName: "MesloLGS NF",
+      family: "\"MesloLGS NF\", \"Cascadia Code Variable\", ui-monospace, \"SF Mono\", Menlo, monospace",
+      size: 22,
+    });
+  });
+
+  it("uses canvas width comparison to distinguish resolved custom fonts from fallback", () => {
+    mockCanvasWidths({
+      monospace: 100,
+      serif: 120,
+      "sans-serif": 130,
+      '"MesloLGS NF", monospace': 108,
+      '"Missing Mono", monospace': 100,
+      '"Missing Mono", serif': 120,
+      '"Missing Mono", sans-serif': 130,
+    });
+
+    expect(resolveTerminalFont(createCustomTerminalFontSettings("MesloLGS NF", 14))).toMatchObject({ status: "resolved" });
+    expect(resolveTerminalFont(createCustomTerminalFontSettings("Missing Mono", 14))).toMatchObject({ status: "fallback", fallbackName: "Cascadia Code" });
+  });
+});
+
+function mockCanvasWidths(widths: Readonly<Record<string, number>>): void {
+  let currentFamily = "";
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      createElement: () => ({
+        getContext: () => ({
+          set font(value: string) {
+            currentFamily = value.replace(/^28px /, "");
+          },
+          measureText: () => ({ width: widths[currentFamily] ?? 100 }),
+        }),
+      }),
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Settings → Appearance에 **Terminal Font** 행 추가: 큐레이트 4종(Cascadia Code · JetBrains Mono · Fira Code · Source Code Pro, 전부 자체 호스팅 `@fontsource-variable/*`)과 **Custom 자유입력**을 하이브리드로 제공. 선택/입력은 즉시 열려 있는 모든 터미널(agent-cli·shell, 동일 `Terminal` 컴포넌트)에 라이브 일괄 적용되고 브라우저 localStorage에 영속.
- **현재값 readout**(폰트·크기·해석상태)와 **크기 스테퍼**(10–22px) 제공. Custom 입력은 `document.fonts.check`의 거짓양성 함정을 피해 **canvas 폭 비교**로 실제 해석 여부를 판정하고, `--positive`(resolves) / `--warn`(falls back) 인디케이터로 표시(brass/aurora 의미 채널 불침범).
- 잠재 결함 동반 수선: 터미널이 `"Cascadia Code"`를 요청하나 번들 face 실제 등록명은 `"Cascadia Code Variable"`이라 OS 미설치 사용자에게 무성 폴백되던 문제를, 큐레이트 맵을 실측 family명으로 핀하여 해소.
- 견고성/보안: Custom 폰트명은 제어문자 제거·128자 제한·CSS 이스케이프로 정규화(입력·localStorage 복원 양 경로). 폰트 family/size 변경 시 xterm fit 후 **PTY resize까지 전송**해 TUI/full-screen 앱 정합 유지. xterm 폰트 크기는 zoom 보정(`size × appliedZoom`)과 결합 유지.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (41 files / 480 tests pass)
- [x] `pnpm --filter @dotobokuri/fleet-console build` (39 self-hosted woff2 번들, 신규 Fira/Source 포함, CDN 없음)
- [x] console-e2e 실브라우저: Terminal Font 행 렌더, 큐레이트 카드 선택→localStorage 영속, Custom resolve(설치 폰트=positive / 미설치=warn fallback), 크기 스테퍼 동작, 페이지 에러 0
- [x] Sentinel correctness/security 리뷰 PASS (P2 2건 수정 반영)

## Changelog

- [x] `.changelog.d/console-terminal-font.md` 추가 (`section: Added`, `[fleet-console]`)