### PR TITLE
fix(fleet-console): keep maximized view when creating a new panel

### DIFF
--- a/.changelog.d/console-maximize-preserve-new-panel.md
+++ b/.changelog.d/console-maximize-preserve-new-panel.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- [fleet-console] Creating a new Operation while a panel is maximized now keeps the maximized view and makes the new panel the maximized one, instead of dropping out of the maximized view.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
@@ -84,6 +84,13 @@ export function getMaximizedOperationId(): string | null {
   return maximizedOperationId;
 }
 
+// canvas 스토어가 현재 로드한 Theater id. maximizedOperationId·maximizedOperationIdsByTheater 등
+// 최대화 상태는 이 Theater 기준으로 동작하므로, 최대화 관련 가드는 store.activeTheaterId가 아니라 이 값을 기준으로 삼아야 한다.
+// (loadForTheater가 passive effect로 갱신되어 store.activeTheaterId보다 한 박자 늦을 수 있다.)
+export function getLoadedTheaterId(): string | null {
+  return activeTheaterId;
+}
+
 export function useCanvasState(): CanvasState {
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -13,7 +13,7 @@ import { usePluginRegistry } from "../plugin-registry.js";
 import { RightRail } from "../rail/right-rail.js";
 import { OperationsSideBar } from "../sidebar/operations-side-bar.js";
 import { CodexReadingSheet } from "../components/codex-reading-sheet.js";
-import { compareOperationCreatedAt, consumeOperationFocus, focusOperation, hydrateOperations, nextOperationId, setActiveOperation, sortOperationsByOrder } from "../store.js";
+import { compareOperationCreatedAt, consumeOperationFocus, focusOperation, getState, hydrateOperations, nextOperationId, setActiveOperation, sortOperationsByOrder } from "../store.js";
 import type { ConsoleState, OperationNode } from "../types.js";
 
 const STABLE_RAIL_API: ClientApiCapability = createHostCapabilities().api;
@@ -286,7 +286,13 @@ async function launchViaPlugin(
   // 최대화 패널이 떠 있는 상태에서 새 Operation을 만들면 최대화를 유지하고 새 패널을 최대화 대상으로 승계한다.
   // focusOperation은 pendingOperationFocus 경로로 clearMaximizedOperationId를 부르므로(최대화 해제), 최대화 중에는 호출하지 않는다.
   // handleFocus(operations.tsx)·Alt+←/→ 순환과 동일 정책으로, setMaximizedOperationId가 나머지 패널을 최소화해 새 패널만 전면화한다.
-  if (getMaximizedOperationId() !== null) {
+  //
+  // 단, 비동기 launch 동안 사용자가 다른 Theater로 전환했을 수 있다. getMaximizedOperationId/setMaximizedOperationId는
+  // 현재 활성 Theater 기준으로 동작하므로, 활성 Theater가 launch 시점 Theater와 같을 때만 승계해야 한다.
+  // 다르면 setMaximizedOperationId가 현재 Theater에 타 Theater 소속 op를 최대화 대상으로 잘못 등록해 패널 상태를 망가뜨린다.
+  // 이 경우 Theater-aware한 focusOperation으로 launch Theater에 돌아가 새 op를 포커스한다.
+  const stillOnLaunchTheater = getState().activeTheaterId === theaterId;
+  if (stillOnLaunchTheater && getMaximizedOperationId() !== null) {
     setActiveOperation(newOperationId);
     setMaximizedOperationId(newOperationId);
   } else {

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -282,7 +282,16 @@ async function launchViaPlugin(
     newOperationId = operation.id;
   }
   await fetchOperations(null).then(hydrateOperations).catch(() => {});
-  if (newOperationId) focusOperation(newOperationId);
+  if (!newOperationId) return;
+  // 최대화 패널이 떠 있는 상태에서 새 Operation을 만들면 최대화를 유지하고 새 패널을 최대화 대상으로 승계한다.
+  // focusOperation은 pendingOperationFocus 경로로 clearMaximizedOperationId를 부르므로(최대화 해제), 최대화 중에는 호출하지 않는다.
+  // handleFocus(operations.tsx)·Alt+←/→ 순환과 동일 정책으로, setMaximizedOperationId가 나머지 패널을 최소화해 새 패널만 전면화한다.
+  if (getMaximizedOperationId() !== null) {
+    setActiveOperation(newOperationId);
+    setMaximizedOperationId(newOperationId);
+  } else {
+    focusOperation(newOperationId);
+  }
 }
 
 async function closeOperation(operationId: string, plugin: FleetClientPlugin | null): Promise<void> {

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -5,7 +5,7 @@ import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 import type { ClientApiCapability, FleetClientPlugin } from "@fleet-console/sdk/plugin";
 
 import { fetchOperations, patchOperation } from "../api.js";
-import { animateViewportTo, claimTopZIndex, clearMaximizedOperationId, ensureDefaultGeometry, focusOperation as focusCanvasOperation, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, loadForTheater, pruneOperations, restoreOperation, setMaximizedOperationId, setOperationGeometry, toggleBackgroundAnimation, toggleMapFullscreen, togglePerimeterAnimation, useBackgroundAnimation, useMapFullscreen, useMaximizedOperationId, useMinimized, usePerimeterAnimation, type OperationGeometry } from "../canvas/canvas-store.js";
+import { animateViewportTo, claimTopZIndex, clearMaximizedOperationId, ensureDefaultGeometry, focusOperation as focusCanvasOperation, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, loadForTheater, pruneOperations, restoreOperation, setMaximizedOperationId, setOperationGeometry, toggleBackgroundAnimation, toggleMapFullscreen, togglePerimeterAnimation, useBackgroundAnimation, useMapFullscreen, useMaximizedOperationId, useMinimized, usePerimeterAnimation, type OperationGeometry } from "../canvas/canvas-store.js";
 import { screenToCanvas, type CanvasPoint } from "../canvas/coordinates.js";
 import { OperationsCanvas } from "../canvas/canvas.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
@@ -13,7 +13,7 @@ import { usePluginRegistry } from "../plugin-registry.js";
 import { RightRail } from "../rail/right-rail.js";
 import { OperationsSideBar } from "../sidebar/operations-side-bar.js";
 import { CodexReadingSheet } from "../components/codex-reading-sheet.js";
-import { compareOperationCreatedAt, consumeOperationFocus, focusOperation, getState, hydrateOperations, nextOperationId, setActiveOperation, sortOperationsByOrder } from "../store.js";
+import { compareOperationCreatedAt, consumeOperationFocus, focusOperation, hydrateOperations, nextOperationId, setActiveOperation, sortOperationsByOrder } from "../store.js";
 import type { ConsoleState, OperationNode } from "../types.js";
 
 const STABLE_RAIL_API: ClientApiCapability = createHostCapabilities().api;
@@ -288,10 +288,12 @@ async function launchViaPlugin(
   // handleFocus(operations.tsx)·Alt+←/→ 순환과 동일 정책으로, setMaximizedOperationId가 나머지 패널을 최소화해 새 패널만 전면화한다.
   //
   // 단, 비동기 launch 동안 사용자가 다른 Theater로 전환했을 수 있다. getMaximizedOperationId/setMaximizedOperationId는
-  // 현재 활성 Theater 기준으로 동작하므로, 활성 Theater가 launch 시점 Theater와 같을 때만 승계해야 한다.
-  // 다르면 setMaximizedOperationId가 현재 Theater에 타 Theater 소속 op를 최대화 대상으로 잘못 등록해 패널 상태를 망가뜨린다.
-  // 이 경우 Theater-aware한 focusOperation으로 launch Theater에 돌아가 새 op를 포커스한다.
-  const stillOnLaunchTheater = getState().activeTheaterId === theaterId;
+  // canvas 스토어가 로드한 Theater 기준으로 동작하므로, 그 로드된 Theater가 launch 시점 Theater와 같을 때만 승계해야 한다.
+  // 다르면 setMaximizedOperationId가 다른 Theater에 타 Theater 소속 op를 최대화 대상으로 잘못 등록해 패널 상태를 망가뜨린다.
+  // store.activeTheaterId가 아니라 getLoadedTheaterId()를 보는 이유: loadForTheater가 passive effect라 store보다 늦게
+  // 갱신되어, A→B→A 왕복 시 store는 A인데 canvas는 아직 B인 desync 창이 생기기 때문이다.
+  // Theater가 다르면 Theater-aware한 focusOperation으로 launch Theater에 돌아가 새 op를 포커스한다.
+  const stillOnLaunchTheater = getLoadedTheaterId() === theaterId;
   if (stillOnLaunchTheater && getMaximizedOperationId() !== null) {
     setActiveOperation(newOperationId);
     setMaximizedOperationId(newOperationId);

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -13,7 +13,7 @@ import { usePluginRegistry } from "../plugin-registry.js";
 import { RightRail } from "../rail/right-rail.js";
 import { OperationsSideBar } from "../sidebar/operations-side-bar.js";
 import { CodexReadingSheet } from "../components/codex-reading-sheet.js";
-import { compareOperationCreatedAt, consumeOperationFocus, focusOperation, hydrateOperations, nextOperationId, setActiveOperation, sortOperationsByOrder } from "../store.js";
+import { compareOperationCreatedAt, consumeOperationFocus, focusOperation, getState, hydrateOperations, nextOperationId, setActiveOperation, sortOperationsByOrder } from "../store.js";
 import type { ConsoleState, OperationNode } from "../types.js";
 
 const STABLE_RAIL_API: ClientApiCapability = createHostCapabilities().api;
@@ -292,12 +292,16 @@ async function launchViaPlugin(
   // 다르면 setMaximizedOperationId가 다른 Theater에 타 Theater 소속 op를 최대화 대상으로 잘못 등록해 패널 상태를 망가뜨린다.
   // store.activeTheaterId가 아니라 getLoadedTheaterId()를 보는 이유: loadForTheater가 passive effect라 store보다 늦게
   // 갱신되어, A→B→A 왕복 시 store는 A인데 canvas는 아직 B인 desync 창이 생기기 때문이다.
-  // Theater가 다르면 Theater-aware한 focusOperation으로 launch Theater에 돌아가 새 op를 포커스한다.
   const stillOnLaunchTheater = getLoadedTheaterId() === theaterId;
-  if (stillOnLaunchTheater && getMaximizedOperationId() !== null) {
+  // fetchOperations 실패(.catch)로 hydrate가 누락되면 store에 newOperationId가 없다. 이때 승계하면
+  // setMaximizedOperationId가 기존 패널을 전부 최소화하지만 새 id는 캔버스에 없어 빈 화면이 박제된다.
+  // hydrate된 경우에만 승계하고, 아니면 focusOperation(op 부재 시 안전하게 no-op)으로 기존 최대화 패널을 그대로 둔다.
+  const operationHydrated = getState().operations.some((operation) => operation.id === newOperationId);
+  if (stillOnLaunchTheater && operationHydrated && getMaximizedOperationId() !== null) {
     setActiveOperation(newOperationId);
     setMaximizedOperationId(newOperationId);
   } else {
+    // Theater가 다르거나 hydrate 누락이면 Theater-aware한 focusOperation으로 처리한다(launch Theater로 복귀·포커스, 부재 시 no-op).
     focusOperation(newOperationId);
   }
 }

--- a/runtime/fleet-plugins/terminal/routes.ts
+++ b/runtime/fleet-plugins/terminal/routes.ts
@@ -36,7 +36,7 @@ export default definePlugin({
       authService: infraServices.authService,
       globalOptionsService: infraServices.globalOptionsService,
     });
-    registerLaunchCatalog(ctx, async () => [SHELL_LAUNCH_KIND, ...await agentLaunchKinds()]);
+    registerLaunchCatalog(ctx, async () => [...await agentLaunchKinds(), SHELL_LAUNCH_KIND]);
   },
 });
 


### PR DESCRIPTION
## Summary
- 최대화된 패널이 떠 있는 상태에서 새 Operation을 생성하면 최대화가 풀려 버리던 버그를 수정한다.
- 원인: `launchViaPlugin`이 생성 직후 항상 `focusOperation`을 호출 → `pendingOperationFocus` 경로의 effect가 무조건 `clearMaximizedOperationId()`를 실행해 최대화가 해제됨.
- 수정: 생성 시점에 최대화 중이면 `setActiveOperation` + `setMaximizedOperationId`로 최대화를 새 패널에 승계(나머지 패널은 자동 minimize)하고, 비최대화면 기존 `focusOperation` 경로를 유지한다. 기존 `handleFocus` 패널 전환 / Alt+Left·Right 순환과 동일 정책으로, CLAUDE.md Window System 교리("new panel added while maximized -> maximized state kept, new panel becomes the maximized one")를 그대로 구현한다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] console-e2e (Sentinel QA): 최대화 유지 상태에서 새 패널 생성 시 최대화 승계 PASS(신규 패널 `is-maximized`+`is-active`, 기존 패널 `is-minimized`, `.operations-canvas`는 `is-panel-maximized` 유지)
- [x] console-e2e (Sentinel QA): 비최대화 상태에서 새 패널 생성 시 최대화 미발생 회귀 없음 PASS

## Changelog
- [x] `.changelog.d/console-maximize-preserve-new-panel.md` (section: Fixed, `[fleet-console]`)