### PR TITLE
fix(fleet-console): English non-git Diff notice + File Explorer text

### DIFF
--- a/.changelog.d/console-plugin-english-copy.md
+++ b/.changelog.d/console-plugin-english-copy.md
@@ -1,0 +1,6 @@
+---
+section: Changed
+---
+
+- [fleet-console] The Diff panel now shows a clear English message when the selected folder is not a Git repository or when Git is not available, instead of a cryptic raw error.
+- [fleet-console] All File Explorer panel text is now in English.

--- a/runtime/fleet-plugins/diff/client/changed-files.tsx
+++ b/runtime/fleet-plugins/diff/client/changed-files.tsx
@@ -10,6 +10,7 @@ import { DiffTreeView } from "./diff-tree.js";
 type PairLoadState =
   | { readonly kind: "loading" }
   | { readonly kind: "ok"; readonly staged: readonly DiffFileEntry[]; readonly changes: readonly DiffFileEntry[] }
+  | { readonly kind: "notice"; readonly reason: "no_git_repo" | "git_unavailable" }
   | { readonly kind: "error"; readonly message: string };
 
 interface ChangedFilesProps {
@@ -72,21 +73,42 @@ export function ChangedFiles({ ctx, viewMode, selectedPath, selectedSection, onS
     let cancelled = false;
     setState({ kind: "loading" });
 
-    const fetchMode = (mode: "workdir" | "staged") =>
-      ctx.api.fetch("diff", "changed", {
+    const fetchMode = async (mode: "workdir" | "staged"): Promise<DiffListResult> => {
+      const res = await fetch("/plugins/diff/changed", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ theaterId: ctx.theaterId, mode }),
-      }).then(async (res) => (await res.json()) as DiffListResult);
+      });
+      if (!res.ok) {
+        const payload = await res.json() as { error?: string };
+        throw new Error(payload.error ?? "git_failed");
+      }
+      return res.json() as Promise<DiffListResult>;
+    };
 
-    Promise.all([fetchMode("workdir"), fetchMode("staged")]).then(([workdir, staged]) => {
-      if (!cancelled) setState({ kind: "ok", staged: staged.files, changes: workdir.files });
-    }).catch((err: unknown) => {
-      if (!cancelled) setState({ kind: "error", message: err instanceof Error ? err.message : "unknown" });
+    // allSettled로 두 모드를 모두 평가한다. Promise.all은 먼저 reject되는 쪽으로 실패하는데,
+    // repo 밖에서 workdir(`git diff`)는 "not a git repository"를 내지만 staged(`git diff --cached`)는
+    // "unknown option `cached'"로 실패해 git_failed로 분류된다 → 레이스로 notice가 비결정적이 된다.
+    // 한쪽이라도 not-a-repo / git 미설치를 보고하면 그것이 폴더에 대한 권위적 사유이므로 우선 채택한다.
+    Promise.allSettled([fetchMode("workdir"), fetchMode("staged")]).then(([workdir, staged]) => {
+      if (cancelled) return;
+      if (workdir.status === "fulfilled" && staged.status === "fulfilled") {
+        setState({ kind: "ok", staged: staged.value.files, changes: workdir.value.files });
+        return;
+      }
+      const reasons = [workdir, staged].map((r) =>
+        r.status === "rejected" ? (r.reason instanceof Error ? r.reason.message : "unknown") : null,
+      );
+      const notice = reasons.find((m) => m === "no_git_repo" || m === "git_unavailable");
+      if (notice === "no_git_repo" || notice === "git_unavailable") {
+        setState({ kind: "notice", reason: notice });
+        return;
+      }
+      setState({ kind: "error", message: reasons.find((m) => m !== null) ?? "unknown" });
     });
 
     return () => { cancelled = true; };
-  }, [ctx.api, ctx.theaterId, refreshToken]);
+  }, [ctx.theaterId, refreshToken]);
 
   const handleRetry = useCallback(() => setRefreshToken((t) => t + 1), []);
 
@@ -108,6 +130,22 @@ export function ChangedFiles({ ctx, viewMode, selectedPath, selectedSection, onS
 
   if (state.kind === "loading") {
     return <div className="diff-sections-loading">Loading…</div>;
+  }
+
+  if (state.kind === "notice") {
+    const title = state.reason === "no_git_repo"
+      ? "Not a Git repository"
+      : "Git isn't available";
+    const body = state.reason === "no_git_repo"
+      ? "This folder isn't a Git repository, so there are no changes to show."
+      : "Git was not found on this system. Install Git and make sure it's on your PATH.";
+    return (
+      <div className="diff-sections-notice">
+        <strong className="diff-notice-title">{title}</strong>
+        <span className="diff-notice-body">{body}</span>
+        <button type="button" className="diff-refresh-btn" onClick={handleRetry}>Retry</button>
+      </div>
+    );
   }
 
   if (state.kind === "error") {

--- a/runtime/fleet-plugins/diff/client/diff.css
+++ b/runtime/fleet-plugins/diff/client/diff.css
@@ -128,6 +128,24 @@
   gap: 8px;
 }
 
+.diff-sections-notice {
+  padding: 16px 12px;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.diff-notice-title {
+  color: var(--ink-spectral);
+  font-weight: 600;
+}
+
+.diff-notice-body {
+  color: var(--ink-fog);
+}
+
 /* ── 아코디언 섹션 ── */
 .diff-section {
   border-bottom: 1px solid var(--surface-rim);

--- a/runtime/fleet-plugins/diff/server/diff.ts
+++ b/runtime/fleet-plugins/diff/server/diff.ts
@@ -115,7 +115,10 @@ export async function handleDiffChanged(
     ctx.host.http.writeJson(res, 200, { files, truncated: nameStatusResult.truncated || numstatResult.truncated });
   } catch (error) {
     if (error instanceof GitExecutorError) {
-      if (error.code === "no_git_repo") { ctx.host.http.writeJson(res, 422, { error: "no_git_repo" }); return; }
+      if (error.code === "no_git_repo" || error.code === "git_unavailable") {
+        ctx.host.http.writeJson(res, 422, { error: error.code });
+        return;
+      }
       ctx.host.http.writeJson(res, 500, { error: "git_failed" });
       return;
     }
@@ -201,7 +204,10 @@ export async function handleDiffFile(
     ctx.host.http.writeJson(res, 200, { content: result.stdout, truncated: result.truncated });
   } catch (error) {
     if (error instanceof GitExecutorError) {
-      if (error.code === "no_git_repo") { ctx.host.http.writeJson(res, 422, { error: "no_git_repo" }); return; }
+      if (error.code === "no_git_repo" || error.code === "git_unavailable") {
+        ctx.host.http.writeJson(res, 422, { error: error.code });
+        return;
+      }
       ctx.host.http.writeJson(res, 500, { error: "git_failed" });
       return;
     }

--- a/runtime/fleet-plugins/diff/server/git-executor.ts
+++ b/runtime/fleet-plugins/diff/server/git-executor.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 
-export type GitErrorCode = "timeout" | "non_zero_exit" | "spawn_failed" | "no_git_repo";
+export type GitErrorCode = "timeout" | "non_zero_exit" | "spawn_failed" | "no_git_repo" | "git_unavailable";
 
 export class GitExecutorError extends Error {
   readonly code: GitErrorCode;
@@ -37,7 +37,9 @@ export function runGit(
       // Windows에서 자식 프로세스 콘솔 창이 깜빡이며 떴다 사라지는 현상 방지
       child = spawn("git", args as string[], { cwd: opts.cwd, shell: false, windowsHide: true });
     } catch (error) {
-      reject(new GitExecutorError("spawn_failed", String(error)));
+      // spawn 동기 예외에서도 ENOENT는 git 바이너리 미설치로 분류한다(방어적 처리).
+      const code = (error as NodeJS.ErrnoException).code === "ENOENT" ? "git_unavailable" : "spawn_failed";
+      reject(new GitExecutorError(code, String(error)));
       return;
     }
 
@@ -72,7 +74,9 @@ export function runGit(
 
     child.on("error", (error) => {
       clearTimeout(timer);
-      reject(new GitExecutorError("spawn_failed", error.message));
+      // ENOENT = git 바이너리가 PATH에 없음; 나머지는 일반 spawn 실패
+      const code = (error as NodeJS.ErrnoException).code === "ENOENT" ? "git_unavailable" : "spawn_failed";
+      reject(new GitExecutorError(code, error.message));
     });
 
     child.on("close", (code) => {
@@ -85,7 +89,8 @@ export function runGit(
           resolve({ stdout, truncated });
           return;
         }
-        const isNoRepo = stderr.includes("not a git repository");
+        // macOS git diff는 "Not a git repository"(대문자 N)로 출력하므로 대소문자 무관하게 비교
+        const isNoRepo = stderr.toLowerCase().includes("not a git repository");
         reject(new GitExecutorError(isNoRepo ? "no_git_repo" : "non_zero_exit", stderr, code ?? undefined));
         return;
       }

--- a/runtime/fleet-plugins/diff/tests/git-executor.test.ts
+++ b/runtime/fleet-plugins/diff/tests/git-executor.test.ts
@@ -1,0 +1,27 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { GitExecutorError, runGit } from "../server/git-executor.js";
+
+describe("runGit", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "fleet-diff-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("git 리포가 아닌 디렉터리에서 실행하면 no_git_repo 코드로 reject한다", async () => {
+    await expect(
+      runGit(["diff"], { cwd: tmpDir }),
+    ).rejects.toSatisfy((err: unknown) =>
+      err instanceof GitExecutorError && err.code === "no_git_repo",
+    );
+  });
+});

--- a/runtime/fleet-plugins/file-explorer/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/rail-panel.tsx
@@ -77,7 +77,7 @@ function FileExplorerPanel({ theaterId }: RailPanelContext) {
       }
       setViewState(theaterId, { kind: "code", relativePath: result.relativePath, content: result.content, lang: result.lang, truncated: result.truncated });
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : "파일을 불러올 수 없습니다";
+      const msg = e instanceof Error ? e.message : "Unable to load file";
       if (msg === "binary_file") {
         setViewState(theaterId, { kind: "binary", name });
       } else {
@@ -139,16 +139,16 @@ function FileExplorerPanel({ theaterId }: RailPanelContext) {
               : ""}
           </span>
           {isViewerActive && (
-            <button className="fexp-viewer-close" type="button" onClick={handleCloseViewer} aria-label="뷰어 닫기">
+            <button className="fexp-viewer-close" type="button" onClick={handleCloseViewer} aria-label="Close viewer">
               ✕
             </button>
           )}
         </div>
         <div className="fexp-viewer-body">
           {viewState.kind === "none" && (
-            <div className="fexp-viewer-empty">파일 트리에서 항목을 선택하면 여기서 내용을 미리 볼 수 있습니다.</div>
+            <div className="fexp-viewer-empty">Select an item in the file tree to preview its contents here.</div>
           )}
-          {viewState.kind === "loading" && <div className="fexp-viewer-loading">로딩 중…</div>}
+          {viewState.kind === "loading" && <div className="fexp-viewer-loading">Loading…</div>}
           {viewState.kind === "error" && <div className="fexp-viewer-error">{viewState.message}</div>}
           {viewState.kind === "code" && viewState.lang === "markdown" && (
             <MarkdownViewer content={viewState.content} truncated={viewState.truncated} />

--- a/runtime/fleet-plugins/file-explorer/client/tree.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/tree.tsx
@@ -111,7 +111,7 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
   useEffect(() => {
     if (!theaterId) return;
     files.listFolder(currentPath || undefined).then(setResult).catch((e: unknown) => {
-      setError(e instanceof Error ? e.message : "폴더를 불러올 수 없습니다");
+      setError(e instanceof Error ? e.message : "Unable to load folder");
     });
   }, [theaterId, currentPath, files]);
 
@@ -180,9 +180,9 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
   const totalHeight = flatRows.length * ROW_HEIGHT;
   const offsetY = startIdx * ROW_HEIGHT;
 
-  if (!theaterId) return <div className="fexp-tree-empty">Theater를 선택하세요</div>;
+  if (!theaterId) return <div className="fexp-tree-empty">Select a Theater</div>;
   if (error) return <div className="fexp-tree-error">{error}</div>;
-  if (!result) return <div className="fexp-tree-loading">로딩 중…</div>;
+  if (!result) return <div className="fexp-tree-loading">Loading…</div>;
 
   return (
     <div className="fexp-tree-container">
@@ -193,14 +193,14 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
           placeholder="Filter…"
           value={filterText}
           onChange={(e) => setFilterText(e.target.value)}
-          aria-label="파일 필터"
+          aria-label="Filter files"
         />
         {filterText && (
           <button
             type="button"
             className="fexp-filter-clear"
             onClick={() => setFilterText("")}
-            aria-label="필터 지우기"
+            aria-label="Clear filter"
           >
             ✕
           </button>
@@ -210,8 +210,8 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
           className={`fexp-hidden-toggle${showHidden ? " is-active" : ""}`}
           onClick={handleToggleHidden}
           aria-pressed={showHidden}
-          aria-label={showHidden ? "숨김 파일 숨기기" : "숨김 파일 표시"}
-          title={showHidden ? "숨김 파일 숨기기" : "숨김 파일 표시"}
+          aria-label={showHidden ? "Hide hidden files" : "Show hidden files"}
+          title={showHidden ? "Hide hidden files" : "Show hidden files"}
         >
           {showHidden ? (
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
@@ -231,7 +231,7 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
         ref={treeRef}
         className="fexp-tree"
         role="tree"
-        aria-label="파일 트리"
+        aria-label="File tree"
         onScroll={shouldVirtualize ? handleScroll : undefined}
       >
         {result.parentRelativePath !== null && !filterText && (
@@ -239,7 +239,7 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
             className="fexp-tree-up"
             type="button"
             onClick={() => setCurrentPath(result.parentRelativePath ?? "")}
-            aria-label="상위 폴더"
+            aria-label="Parent folder"
           >
             ↑ ..
           </button>
@@ -258,13 +258,13 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
           ))
         )}
         {flatRows.length === 0 && filterText && (
-          <div className="fexp-tree-empty">일치하는 항목 없음</div>
+          <div className="fexp-tree-empty">No matching items</div>
         )}
         {flatRows.length === 0 && !filterText && result.entries.length === 0 && (
-          <div className="fexp-tree-empty">폴더가 비어 있습니다</div>
+          <div className="fexp-tree-empty">This folder is empty</div>
         )}
         {hasOnlyHiddenEntries && (
-          <div className="fexp-tree-empty">숨김 항목만 있습니다 — 눈 아이콘으로 표시</div>
+          <div className="fexp-tree-empty">Only hidden items — use the eye icon to show them</div>
         )}
       </div>
     </div>

--- a/runtime/fleet-plugins/file-explorer/client/viewer/binary.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/viewer/binary.tsx
@@ -9,7 +9,7 @@ export function BinaryViewer({ name, sizeHint }: BinaryViewerProps) {
       <span className="fexp-bin-glyph" aria-hidden="true">⊘</span>
       <p className="fexp-bin-name">{name}</p>
       {sizeHint && <p className="fexp-bin-meta">{sizeHint}</p>}
-      <p className="fexp-bin-hint">바이너리 파일은 미리 볼 수 없습니다</p>
+      <p className="fexp-bin-hint">Binary files can't be previewed</p>
     </div>
   );
 }

--- a/runtime/fleet-plugins/file-explorer/client/viewer/code.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/viewer/code.tsx
@@ -13,7 +13,7 @@ export function CodeViewer({ content, lang, truncated }: CodeViewerProps) {
 
   return (
     <div className="fexp-code-wrap">
-      {truncated && <div className="fexp-truncated-badge">파일이 너무 커서 일부만 표시됩니다</div>}
+      {truncated && <div className="fexp-truncated-badge">File is too large — showing a partial preview</div>}
       <div className="fexp-code-scroll">
         <table className="fexp-code-table" aria-label="File contents">
           <tbody>

--- a/runtime/fleet-plugins/file-explorer/client/viewer/markdown.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/viewer/markdown.tsx
@@ -10,7 +10,7 @@ export function MarkdownViewer({ content, truncated }: MarkdownViewerProps) {
 
   return (
     <div className="fexp-md-wrap">
-      {truncated && <div className="fexp-truncated-badge">파일이 너무 커서 일부만 표시됩니다</div>}
+      {truncated && <div className="fexp-truncated-badge">File is too large — showing a partial preview</div>}
       <div
         className="fexp-md-body v-md"
         // eslint-disable-next-line react/no-danger


### PR DESCRIPTION
## Summary
- Diff panel: when the selected folder is not a Git repository, or when Git is not installed / not on PATH, the panel now shows a clear English notice ("Not a Git repository" / "Git isn't available") with a Retry button instead of a cryptic raw error. Detection is case-insensitive (macOS `git diff` emits a capital "Not a git repository"), a missing git binary is classified as `git_unavailable` (HTTP 422), and the workdir/staged requests use `Promise.allSettled` so the not-a-repo notice wins deterministically over the staged `git diff --cached` "unknown option" failure.
- File Explorer panel: all user-facing strings (empty/loading states, aria-labels, tooltips, binary and large-file viewer messages) are now in English. Korean code comments are unchanged.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` (exit 0)
- [x] `pnpm --filter @dotobokuri/fleet-console build` (exit 0)
- [x] `pnpm --filter @fleet-plugins/diff test` (13 passed; added a runGit non-repo classification test)
- [x] console-e2e (headed, Sentinel): non-git Theater shows the English notice, stable across 3+ reloads with no git_failed flicker; File Explorer shows English strings with no Korean in the UI; real git repo Diff happy-path still renders Staged/Changes.

## Changelog
- [x] Includes a `.changelog.d/*.md` fragment (console-plugin-english-copy.md, section Changed).