### PR TITLE
feat(fleet-console): operation groups in Operations SideBar

### DIFF
--- a/.changelog.d/operation-groups.md
+++ b/.changelog.d/operation-groups.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- [fleet-console] Operations SideBar now supports named groups: create, rename, recolor, and dissolve groups from a right-click menu, drag chips between groups, and collapse or expand a group's member chips. Group membership is shown by a colored rail that stays independent of the accent and in-progress status channels.

--- a/runtime/fleet-console/core/client/src/api.ts
+++ b/runtime/fleet-console/core/client/src/api.ts
@@ -1,4 +1,4 @@
-import type { ConsoleUpdateApplyAcceptedResponse, OperationNode, ObserverStatus, ReleaseNoteItem, ReleaseNoteSection, ReleaseNotes, ReleaseNotesResponse, TheaterBootstrap, TheaterInfo } from "./types.js";
+import type { ConsoleUpdateApplyAcceptedResponse, OperationGroup, OperationNode, ObserverStatus, ReleaseNoteItem, ReleaseNoteSection, ReleaseNotes, ReleaseNotesResponse, TheaterBootstrap, TheaterInfo } from "./types.js";
 
 export interface TheaterFolderListEntry {
   readonly name: string;
@@ -23,6 +23,19 @@ export interface ReleaseNotesFetchOptions {
 export interface OperationPatchClientInput {
   readonly title?: string;
   readonly accent?: string | null;
+  readonly groupId?: string | null;
+}
+
+export interface OperationGroupCreateInput {
+  readonly theaterId: string;
+  readonly name: string;
+  readonly color: string;
+}
+
+export interface OperationGroupPatchInput {
+  readonly name?: string;
+  readonly color?: string;
+  readonly order?: number;
 }
 
 const FORBIDDEN_BROWSER_PAYLOAD_KEYS = ["canonicalCwd", "cwd", "providerSession", "ticket", "token", "transcriptPath"] as const;
@@ -119,6 +132,44 @@ export async function fetchOperations(theaterId?: string | null, signal?: AbortS
   return payload.operations.map((operation) => assertOperationNode(operation, response.status));
 }
 
+export async function fetchGroups(theaterId?: string | null, signal?: AbortSignal): Promise<readonly OperationGroup[]> {
+  const suffix = theaterId ? `?theaterId=${encodeURIComponent(theaterId)}` : "";
+  const response = await fetch(`/api/v1/operations/groups${suffix}`, { signal });
+  await assertOk(response);
+  const payload = await response.json() as { readonly groups?: unknown };
+  if (!Array.isArray(payload.groups)) throw new ApiError(response.status, "Invalid groups response");
+  return payload.groups.map((group) => assertOperationGroup(group, response.status));
+}
+
+export async function createGroup(input: OperationGroupCreateInput, signal?: AbortSignal): Promise<OperationGroup> {
+  const response = await fetch("/api/v1/operations/groups", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+    signal,
+  });
+  await assertOk(response);
+  const payload = await response.json() as { readonly group?: unknown };
+  return assertOperationGroup(payload.group, response.status);
+}
+
+export async function updateGroup(groupId: string, patch: OperationGroupPatchInput, signal?: AbortSignal): Promise<OperationGroup> {
+  const response = await fetch(`/api/v1/operations/groups/${encodeURIComponent(groupId)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(patch),
+    signal,
+  });
+  await assertOk(response);
+  const payload = await response.json() as { readonly group?: unknown };
+  return assertOperationGroup(payload.group, response.status);
+}
+
+export async function deleteGroup(groupId: string, signal?: AbortSignal): Promise<void> {
+  const response = await fetch(`/api/v1/operations/groups/${encodeURIComponent(groupId)}`, { method: "DELETE", signal });
+  await assertOk(response);
+}
+
 export async function renameOperation(operationId: string, title: string, signal?: AbortSignal): Promise<OperationNode> {
   return patchOperation(operationId, { title }, signal);
 }
@@ -203,8 +254,33 @@ function assertOperationNode(value: unknown, status: number): OperationNode {
     geometry: payload.geometry ?? null,
     // 서버가 영속한 accent를 노드에 보존한다. 누락 시 server→store 동기화가 사용자 accent를 null로 덮어쓴다.
     accent: typeof payload.accent === "string" ? payload.accent : null,
+    // 서버가 영속한 groupId를 보존한다. null = Ungrouped 명시, undefined = 미설정(Ungrouped와 동일 취급).
+    groupId: payload.groupId === null ? null : typeof payload.groupId === "string" ? payload.groupId : undefined,
     state: payload.state && typeof payload.state === "object" && !Array.isArray(payload.state) ? payload.state : {},
     ts: payload.ts,
+  };
+}
+
+function assertOperationGroup(value: unknown, status: number): OperationGroup {
+  const payload = value as Partial<OperationGroup>;
+  if (
+    !payload
+    || typeof payload.id !== "string"
+    || typeof payload.theaterId !== "string"
+    || typeof payload.name !== "string"
+    || typeof payload.color !== "string"
+    || typeof payload.order !== "number"
+    || typeof payload.createdAt !== "number"
+  ) {
+    throw new ApiError(status, "Invalid group response");
+  }
+  return {
+    id: payload.id,
+    theaterId: payload.theaterId,
+    name: payload.name,
+    color: payload.color,
+    order: payload.order,
+    createdAt: payload.createdAt,
   };
 }
 

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 
 import { useMapFullscreen } from "./canvas/canvas-store.js";
-import { fetchObserverStatus, fetchOperations, fetchReleaseNotes, fetchTheaterBootstrap } from "./api.js";
+import { fetchGroups, fetchObserverStatus, fetchOperations, fetchReleaseNotes, fetchTheaterBootstrap } from "./api.js";
 import { CommissioningOverlay } from "./components/commissioning-overlay.js";
 import { OperationSearch } from "./components/operation-search.js";
 import { Toast } from "./components/toast.js";
@@ -14,7 +14,7 @@ import { usePluginRegistry } from "./plugin-registry.js";
 import { CarrierSettings } from "./pages/carrier-settings.js";
 import { GlobalSettings } from "./pages/global-settings.js";
 import { Operations } from "./pages/operations.js";
-import { applyObserverStatus, applyReleaseNotes, beginReleaseNotesFetch, failReleaseNotesFetch, hydrateOperations, hydrateTheaterBootstrap, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
+import { applyObserverStatus, applyReleaseNotes, beginReleaseNotesFetch, failReleaseNotesFetch, hydrateGroups, hydrateOperations, hydrateTheaterBootstrap, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
 
 // 서버는 부팅 시 update 체크를 fire-and-forget으로 시작하므로, 첫 방문이 registry 응답보다
 // 빠르면 GNB 배지가 누락될 수 있다. 짧은 지연 후 status를 1회만 재조회해 cold-start를 보정한다(폴링 아님).
@@ -75,6 +75,7 @@ export function App() {
         resolveOnboardingOnBootstrap();
       });
     void fetchOperations(null, abort.signal).then(hydrateOperations).catch(() => {});
+    void fetchGroups(null, abort.signal).then(hydrateGroups).catch(() => {});
     beginReleaseNotesFetch();
     void fetchReleaseNotes({ signal: abort.signal })
       .then(applyReleaseNotes)

--- a/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
@@ -21,6 +21,8 @@ export interface CanvasState {
   readonly operationAccent: Record<string, string>;
   // 최소화된 Operation id 목록. geometry는 operations에 그대로 보존되므로 복원은 원위치·원크기로 되돌린다.
   readonly minimized: readonly string[];
+  // 접힌 그룹 id 목록(per-Theater localStorage). 접힘은 시각 표시 상태라 클라이언트 SSoT.
+  readonly collapsedGroups: readonly string[];
 }
 
 export interface CanvasViewportSize {
@@ -47,7 +49,7 @@ const ZOOM_TWEEN_FACTOR = 0.2;
 const ZOOM_TWEEN_POSITION_EPSILON = 0.5;
 const ZOOM_TWEEN_ZOOM_EPSILON = 0.001;
 const DEFAULT_VIEWPORT: CanvasViewport = { x: 0, y: 0, zoom: 1 };
-const EMPTY_STATE: CanvasState = { viewport: DEFAULT_VIEWPORT, operations: {}, operationOrder: [], operationAccent: {}, minimized: [] };
+const EMPTY_STATE: CanvasState = { viewport: DEFAULT_VIEWPORT, operations: {}, operationOrder: [], operationAccent: {}, minimized: [], collapsedGroups: [] };
 
 const listeners = new Set<Listener>();
 const backgroundAnimationListeners = new Set<Listener>();
@@ -123,9 +125,21 @@ export function setState(patch: Partial<CanvasState>): void {
     operationOrder: patch.operationOrder ?? state.operationOrder,
     operationAccent: patch.operationAccent ?? state.operationAccent,
     minimized: patch.minimized ?? state.minimized,
+    collapsedGroups: patch.collapsedGroups ?? state.collapsedGroups,
   };
   scheduleSave();
   emit();
+}
+
+export function toggleGroupCollapsed(groupId: string): void {
+  const collapsed = state.collapsedGroups.includes(groupId)
+    ? state.collapsedGroups.filter((id) => id !== groupId)
+    : [...state.collapsedGroups, groupId];
+  setState({ collapsedGroups: collapsed });
+}
+
+export function useCollapsedGroups(): readonly string[] {
+  return useSyncExternalStore(subscribe, getCollapsedGroupsSnapshot, getCollapsedGroupsSnapshot);
 }
 
 // 즉시 이동(pan 드래그·검색 이동 등). 진행 중 줌 보간을 취소하고 current·target을 같은 값으로 맞춘다.
@@ -419,6 +433,10 @@ function getMinimizedSnapshot(): readonly string[] {
   return state.minimized;
 }
 
+function getCollapsedGroupsSnapshot(): readonly string[] {
+  return state.collapsedGroups;
+}
+
 function emitMapFullscreen(): void {
   for (const listener of mapFullscreenListeners) listener();
 }
@@ -610,6 +628,7 @@ function normalizeCanvasState(value: unknown): CanvasState {
     operationAccent: normalizeOperationAccent(value.operationAccent),
     // 저장된 최소화 목록 중 실재하는 Operation만 남긴다(stale 직렬화 방어).
     minimized: normalizeMinimized(value.minimized, operations),
+    collapsedGroups: normalizeStringArray(value.collapsedGroups),
   };
 }
 
@@ -702,4 +721,16 @@ function readPositiveNumber(value: unknown, fallback: number): number {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string" || seen.has(item)) continue;
+    seen.add(item);
+    result.push(item);
+  }
+  return result;
 }

--- a/runtime/fleet-console/core/client/src/canvas/group-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/group-context-menu.tsx
@@ -1,0 +1,283 @@
+import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties } from "react";
+import { createPortal } from "react-dom";
+
+import type { OperationGroup, OperationNode } from "../types.js";
+import { OPERATION_ACCENTS, resolveAccentColor } from "./operation-accent.js";
+
+export interface GroupContextMenuChipActions {
+  readonly onSetAccent: (key: string | null) => void;
+  readonly onSetGroupId: (groupId: string | null) => void;
+  readonly onCreateGroup: (name: string) => void;
+}
+
+export interface GroupContextMenuHeaderActions {
+  readonly onSetColor: (color: string | null) => void;
+  readonly onRename: (name: string) => void;
+  readonly onUngroupAll: () => void;
+}
+
+type GroupContextMenuProps =
+  | {
+      readonly kind: "chip";
+      readonly operation: OperationNode;
+      readonly groups: readonly OperationGroup[];
+      readonly accentKey: string | null;
+      readonly anchor: DOMRect;
+      readonly actions: GroupContextMenuChipActions;
+      readonly onClose: () => void;
+    }
+  | {
+      readonly kind: "group-header";
+      readonly group: OperationGroup;
+      readonly anchor: DOMRect;
+      readonly actions: GroupContextMenuHeaderActions;
+      readonly onClose: () => void;
+    };
+
+const POPOVER_GAP = 8;
+const POPOVER_ESTIMATED_HEIGHT = 260;
+
+export function GroupContextMenu(props: GroupContextMenuProps) {
+  const { anchor, onClose } = props;
+  const [style, setStyle] = useState<CSSProperties | undefined>(undefined);
+
+  useLayoutEffect(() => {
+    const left = Math.max(8, Math.min(anchor.left, window.innerWidth - 208));
+    const below = anchor.bottom + POPOVER_GAP;
+    const flipUp = below + POPOVER_ESTIMATED_HEIGHT > window.innerHeight;
+    setStyle(
+      flipUp
+        ? { position: "fixed", left, top: "auto", bottom: Math.round(window.innerHeight - anchor.top + POPOVER_GAP) }
+        : { position: "fixed", left, top: Math.round(below) },
+    );
+  }, [anchor]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") { event.preventDefault(); onClose(); }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("resize", onClose);
+    window.addEventListener("scroll", onClose, true);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("resize", onClose);
+      window.removeEventListener("scroll", onClose, true);
+    };
+  }, [onClose]);
+
+  return createPortal(
+    <div className="group-context-menu-overlay" role="presentation" onPointerDown={onClose}>
+      {style ? (
+        <div
+          className="group-context-menu-card"
+          role="menu"
+          aria-label={props.kind === "chip" ? "Operation options" : `${props.group.name} options`}
+          style={style}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          {props.kind === "chip" ? (
+            <ChipMenuContent {...props} />
+          ) : (
+            <GroupHeaderMenuContent {...props} />
+          )}
+        </div>
+      ) : null}
+    </div>,
+    document.body,
+  );
+}
+
+function ChipMenuContent({
+  operation,
+  groups,
+  accentKey,
+  actions,
+  onClose,
+}: {
+  operation: OperationNode;
+  groups: readonly OperationGroup[];
+  accentKey: string | null;
+  actions: GroupContextMenuChipActions;
+  onClose: () => void;
+}) {
+  const [showNewInput, setShowNewInput] = useState(false);
+  const [newName, setNewName] = useState(`Group ${groups.length + 1}`);
+  const composingRef = useRef(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (showNewInput) { inputRef.current?.select(); }
+  }, [showNewInput]);
+
+  const confirmNewGroup = () => {
+    const name = newName.trim();
+    if (!name) return;
+    actions.onCreateGroup(name);
+    onClose();
+  };
+
+  return (
+    <>
+      <div className="group-context-menu-section-label">Group</div>
+      {groups.map((group) => {
+        const color = resolveAccentColor(group.color);
+        const isSelected = operation.groupId === group.id;
+        return (
+          <button
+            key={group.id}
+            type="button"
+            className={`group-context-menu-item${isSelected ? " is-selected" : ""}`}
+            role="menuitemradio"
+            aria-checked={isSelected}
+            onClick={() => { actions.onSetGroupId(isSelected ? null : group.id); onClose(); }}
+          >
+            <span
+              className="group-context-menu-item__dot"
+              style={color ? { background: color } as CSSProperties : undefined}
+              aria-hidden="true"
+            />
+            <span className="group-context-menu-item__name">{group.name}</span>
+            {isSelected ? <CheckMark /> : null}
+          </button>
+        );
+      })}
+      {showNewInput ? (
+        <input
+          ref={inputRef}
+          className="group-context-menu-new-input"
+          type="text"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          onCompositionStart={() => { composingRef.current = true; }}
+          onCompositionEnd={() => { composingRef.current = false; }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !composingRef.current) { e.preventDefault(); confirmNewGroup(); }
+            if (e.key === "Escape") { e.preventDefault(); setShowNewInput(false); }
+          }}
+          onBlur={() => setShowNewInput(false)}
+          aria-label="New group name"
+          placeholder="Group name"
+        />
+      ) : (
+        <button
+          type="button"
+          className="group-context-menu-item group-context-menu-item--new"
+          role="menuitem"
+          onClick={() => setShowNewInput(true)}
+        >
+          <span className="group-context-menu-item__new-label">＋ New group</span>
+        </button>
+      )}
+      <div className="group-context-menu-divider" aria-hidden="true" />
+      <div className="group-context-menu-section-label">Accent</div>
+      <button
+        type="button"
+        className="accent-popover-swatch accent-popover-swatch--clear"
+        role="menuitem"
+        aria-label="No accent"
+        aria-pressed={accentKey === null}
+        onClick={() => { actions.onSetAccent(null); onClose(); }}
+      >
+        <span />
+        None
+      </button>
+      <div className="group-context-menu-swatches">
+        {OPERATION_ACCENTS.map((accent) => (
+          <button
+            key={accent.key}
+            type="button"
+            className="accent-popover-swatch"
+            role="menuitem"
+            aria-label={accent.label}
+            aria-pressed={accentKey === accent.key}
+            onClick={() => { actions.onSetAccent(accent.key); onClose(); }}
+          >
+            <span style={{ background: accent.color }} />
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}
+
+function GroupHeaderMenuContent({
+  group,
+  actions,
+  onClose,
+}: {
+  group: OperationGroup;
+  actions: GroupContextMenuHeaderActions;
+  onClose: () => void;
+}) {
+  const [renameValue, setRenameValue] = useState(group.name);
+  const [ungroupArmed, setUngroupArmed] = useState(false);
+  const composingRef = useRef(false);
+
+  const confirmRename = () => {
+    const name = renameValue.trim();
+    if (!name || name === group.name) { onClose(); return; }
+    actions.onRename(name);
+    onClose();
+  };
+
+  return (
+    <>
+      {/* 그룹 색은 durable 스키마상 16색 중 하나로 필수다(무색 그룹 미지원). None 항목은 제공하지 않는다. */}
+      <div className="group-context-menu-section-label">Color</div>
+      <div className="group-context-menu-swatches">
+        {OPERATION_ACCENTS.map((accent) => (
+          <button
+            key={accent.key}
+            type="button"
+            className="accent-popover-swatch"
+            role="menuitem"
+            aria-label={accent.label}
+            aria-pressed={group.color === accent.key}
+            onClick={() => { actions.onSetColor(accent.key); onClose(); }}
+          >
+            <span style={{ background: accent.color }} />
+          </button>
+        ))}
+      </div>
+      <div className="group-context-menu-divider" aria-hidden="true" />
+      <div className="group-context-menu-section-label">Rename</div>
+      <input
+        className="group-context-menu-new-input"
+        type="text"
+        value={renameValue}
+        onChange={(e) => setRenameValue(e.target.value)}
+        onCompositionStart={() => { composingRef.current = true; }}
+        onCompositionEnd={() => { composingRef.current = false; }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !composingRef.current) { e.preventDefault(); confirmRename(); }
+          if (e.key === "Escape") { e.preventDefault(); onClose(); }
+        }}
+        onBlur={confirmRename}
+        aria-label="Group name"
+      />
+      <div className="group-context-menu-divider" aria-hidden="true" />
+      <button
+        type="button"
+        className={`group-context-menu-item group-context-menu-item--danger${ungroupArmed ? " is-armed" : ""}`}
+        role="menuitem"
+        onClick={() => {
+          if (!ungroupArmed) { setUngroupArmed(true); return; }
+          actions.onUngroupAll();
+          onClose();
+        }}
+        aria-label={ungroupArmed ? "Confirm: remove all members and delete group" : "Ungroup all members and delete group"}
+      >
+        {ungroupArmed ? "Confirm ungroup all?" : "Ungroup all"}
+      </button>
+    </>
+  );
+}
+
+function CheckMark() {
+  return (
+    <svg viewBox="0 0 12 12" className="group-context-menu-item__check" aria-hidden="true">
+      <path d="M2 6l3 3 5-5" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -4,7 +4,7 @@ import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console
 import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 import type { ClientApiCapability, FleetClientPlugin } from "@fleet-console/sdk/plugin";
 
-import { fetchOperations, patchOperation, renameOperation } from "../api.js";
+import { createGroup, deleteGroup, fetchGroups, fetchOperations, patchOperation, renameOperation, updateGroup } from "../api.js";
 import { animateViewportTo, claimTopZIndex, clearMaximizedOperationId, ensureDefaultGeometry, focusOperation as focusCanvasOperation, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, loadForTheater, pruneOperations, restoreOperation, setMaximizedOperationId, setOperationGeometry, toggleBackgroundAnimation, toggleMapFullscreen, togglePerimeterAnimation, useBackgroundAnimation, useMapFullscreen, useMaximizedOperationId, useMinimized, usePerimeterAnimation, type OperationGeometry } from "../canvas/canvas-store.js";
 import { screenToCanvas, type CanvasPoint } from "../canvas/coordinates.js";
 import { OperationsCanvas } from "../canvas/canvas.js";
@@ -13,7 +13,7 @@ import { usePluginRegistry } from "../plugin-registry.js";
 import { RightRail } from "../rail/right-rail.js";
 import { OperationsSideBar } from "../sidebar/operations-side-bar.js";
 import { CodexReadingSheet } from "../components/codex-reading-sheet.js";
-import { compareOperationCreatedAt, consumeOperationFocus, focusOperation, getState, hydrateOperations, nextOperationId, setActiveOperation, sortOperationsByOrder } from "../store.js";
+import { compareOperationCreatedAt, consumeOperationFocus, flattenGroupedOrder, focusOperation, getState, hydrateGroups, hydrateOperations, nextOperationId, setActiveOperation, sortOperationsByOrder } from "../store.js";
 import type { ConsoleState, OperationNode } from "../types.js";
 
 const STABLE_RAIL_API: ClientApiCapability = createHostCapabilities().api;
@@ -61,11 +61,14 @@ export function Operations({ state }: OperationsProps) {
       if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
       const active = document.activeElement;
       if (active instanceof HTMLElement && active.matches("input, textarea, [contenteditable='true']") && !active.closest(".xterm")) return;
-      // Alt 순환 순서를 Left SideBar 표시 순서(드래그 재정렬 반영)와 정확히 일치시킨다.
+      // Alt 순환 순서를 Left SideBar 표시 순서(비-collapsed 그룹 order → 그룹 내 operationOrder → ungrouped)와 정확히 일치시킨다.
       const snapshot = stateRef.current;
-      const order = sortOperationsByOrder(
+      const canvas = getCanvasSnapshot();
+      const order = flattenGroupedOrder(
         snapshot.operations.filter((operation) => operation.theaterId === snapshot.activeTheaterId),
-        getCanvasSnapshot().operationOrder,
+        snapshot.groups.filter((g) => g.theaterId === snapshot.activeTheaterId),
+        canvas.operationOrder,
+        canvas.collapsedGroups,
       ).map((operation) => operation.id);
       if (order.length === 0) return;
       event.preventDefault();
@@ -109,6 +112,7 @@ export function Operations({ state }: OperationsProps) {
 
   const canLaunch = !!state.activeTheaterId && !state.addingTheater;
   const theaterOperations = (state.operations ?? []).filter((op) => op.theaterId === state.activeTheaterId);
+  const theaterGroups = (state.groups ?? []).filter((g) => g.theaterId === state.activeTheaterId);
 
   const renderKindIcon = useCallback((pluginId: string, kind: OperationLaunchKind): ReactNode => {
     const plugin = registry.plugins.find((p) => p.id === pluginId);
@@ -183,6 +187,47 @@ export function Operations({ state }: OperationsProps) {
       .catch(() => {});
   }, []);
 
+  const handleSetGroupId = useCallback((operationId: string, groupId: string | null) => {
+    void patchOperation(operationId, { groupId })
+      .then(() => fetchOperations(null))
+      .then(hydrateOperations)
+      .catch(() => {});
+  }, []);
+
+  const handleCreateGroup = useCallback((theaterId: string, name: string, operationId: string) => {
+    void createGroup({ theaterId, name, color: "blue" })
+      .then((group) => patchOperation(operationId, { groupId: group.id }))
+      .then(() => Promise.all([
+        fetchOperations(null).then(hydrateOperations),
+        fetchGroups(null).then(hydrateGroups),
+      ]))
+      .catch(() => {});
+  }, []);
+
+  const handleSetGroupColor = useCallback((groupId: string, color: string | null) => {
+    if (!color) return;
+    void updateGroup(groupId, { color })
+      .then(() => fetchGroups(null))
+      .then(hydrateGroups)
+      .catch(() => {});
+  }, []);
+
+  const handleRenameGroup = useCallback((groupId: string, name: string) => {
+    void updateGroup(groupId, { name })
+      .then(() => fetchGroups(null))
+      .then(hydrateGroups)
+      .catch(() => {});
+  }, []);
+
+  const handleUngroupAll = useCallback((groupId: string) => {
+    void deleteGroup(groupId)
+      .then(() => Promise.all([
+        fetchOperations(null).then(hydrateOperations),
+        fetchGroups(null).then(hydrateGroups),
+      ]))
+      .catch(() => {});
+  }, []);
+
   const handleClose = useCallback((operationId: string) => {
     if (closingOperationIds.has(operationId)) return;
     closingOperationIds.add(operationId);
@@ -198,6 +243,7 @@ export function Operations({ state }: OperationsProps) {
     >
       <OperationsSideBar
         operations={theaterOperations}
+        groups={theaterGroups}
         minimized={minimized}
         activeOperationId={state.activeOperationId}
         operationNotifications={state.operationNotifications}
@@ -216,6 +262,11 @@ export function Operations({ state }: OperationsProps) {
         onFocus={handleFocus}
         onSetAccent={handleSetAccent}
         onRename={handleRename}
+        onSetGroupId={handleSetGroupId}
+        onCreateGroup={handleCreateGroup}
+        onSetGroupColor={handleSetGroupColor}
+        onRenameGroup={handleRenameGroup}
+        onUngroupAll={handleUngroupAll}
       />
       <OperationsCanvas
         state={state}

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -29,6 +29,7 @@ interface SideBarChipProps {
   readonly onPointerDragMove: (event: ReactPointerEvent<HTMLLIElement>) => void;
   readonly onPointerDragEnd: (event: ReactPointerEvent<HTMLLIElement>) => void;
   readonly onPointerDragCancel: (event: ReactPointerEvent<HTMLLIElement>) => void;
+  readonly grpColor?: string | null;
   readonly onOpenAccent: (operationId: string, anchor: DOMRect) => void;
   readonly onRename: (operationId: string, title: string) => void;
 }
@@ -50,6 +51,7 @@ export function OperationsSideBarChip({
   onPointerDragMove,
   onPointerDragEnd,
   onPointerDragCancel,
+  grpColor,
   onOpenAccent,
   onRename,
 }: SideBarChipProps) {
@@ -68,6 +70,7 @@ export function OperationsSideBarChip({
   const chipStyle = {
     "--i": index,
     ...(accentValue ? { "--chip-accent": accentValue } : {}),
+    ...(grpColor ? { "--grp-color": grpColor } : {}),
     ...(dragging ? { "--drag-dy": `${Math.round(dragOffsetY)}px` } : {}),
   } as CSSProperties;
 
@@ -142,6 +145,7 @@ export function OperationsSideBarChip({
       onPointerUpCapture={(event) => onPointerDragEnd(event)}
       onPointerCancelCapture={(event) => onPointerDragCancel(event)}
     >
+      {grpColor ? <div className="side-bar-chip__rail" aria-hidden="true" /> : null}
       <span className="side-bar-chip-beacon-button" aria-hidden="true">
         <span className="side-bar-chip-op-icon">
           {entry.icon ?? <DefaultOpIcon />}

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-group-header.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-group-header.tsx
@@ -1,0 +1,83 @@
+import type { CSSProperties, MouseEvent } from "react";
+
+import type { OperationGroup } from "../types.js";
+import { resolveAccentColor } from "../canvas/operation-accent.js";
+
+interface GroupHeaderProps {
+  readonly group: OperationGroup;
+  readonly count: number;
+  readonly collapsed: boolean;
+  readonly tier: "rail" | "list" | "detail";
+  readonly onToggle: (groupId: string) => void;
+  readonly onContextMenu: (groupId: string, anchor: DOMRect) => void;
+}
+
+export function OperationsSideBarGroupHeader({
+  group,
+  count,
+  collapsed,
+  tier,
+  onToggle,
+  onContextMenu,
+}: GroupHeaderProps) {
+  const grpColor = resolveAccentColor(group.color);
+  const headerStyle = grpColor ? ({ "--grp-color": grpColor } as CSSProperties) : undefined;
+
+  const handleContextMenu = (event: MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    onContextMenu(group.id, event.currentTarget.getBoundingClientRect());
+  };
+
+  if (tier === "rail") {
+    return (
+      <div
+        className="side-bar-group-header side-bar-group-header--rail"
+        data-tier="rail"
+        style={headerStyle}
+        onClick={() => onToggle(group.id)}
+        onContextMenu={handleContextMenu}
+        role="button"
+        tabIndex={0}
+        aria-label={`Group ${group.name}`}
+        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onToggle(group.id); } }}
+      >
+        <span className="side-bar-group-header__dot" aria-hidden="true" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="side-bar-group-header"
+      style={headerStyle}
+      onContextMenu={handleContextMenu}
+      role="group"
+      aria-label={group.name}
+    >
+      <button
+        type="button"
+        className="side-bar-group-header__toggle"
+        onClick={() => onToggle(group.id)}
+        aria-expanded={!collapsed}
+        aria-label={collapsed ? `Expand group ${group.name}` : `Collapse group ${group.name}`}
+        title={collapsed ? "Expand" : "Collapse"}
+      >
+        <CollapseArrow collapsed={collapsed} />
+      </button>
+      <span className="side-bar-group-header__name">{group.name}</span>
+      <span className="side-bar-group-header__count" aria-label={`${count} operations`}>{count}</span>
+    </div>
+  );
+}
+
+function CollapseArrow({ collapsed }: { readonly collapsed: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 12 12"
+      aria-hidden="true"
+      className={`side-bar-group-header__arrow${collapsed ? " is-collapsed" : ""}`}
+    >
+      <path d="M3 5l3 3 3-3" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-hit-test.ts
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-hit-test.ts
@@ -1,3 +1,8 @@
+export interface DropSectionInfo {
+  readonly groupId: string | null;
+  readonly entryIds: readonly string[];
+}
+
 export function dropIndexFromPoint(
   clientY: number,
   orderedIds: readonly string[],
@@ -13,4 +18,120 @@ export function dropIndexFromPoint(
     if (clientY <= rect.top + rect.height / 2) return Math.max(0, orderedIds.indexOf(id));
   }
   return orderedIds.length;
+}
+
+export function dropTargetFromPoint(
+  clientY: number,
+  sections: readonly DropSectionInfo[],
+  container: HTMLOListElement | null,
+  sourceId?: string,
+): { readonly groupId: string | null; readonly index: number } {
+  if (!container) return { groupId: null, index: 0 };
+
+  for (const section of sections) {
+    const sectionKey = section.groupId ?? "__ungrouped__";
+    // 헤더+chips를 감싸는 wrapper([data-drop-zone-group-id])로 hit test한다.
+    // collapsed 그룹이나 그룹 헤더 위도 올바른 그룹으로 매핑된다.
+    const wrapperEl = container.querySelector<HTMLElement>(`[data-drop-zone-group-id="${sectionKey}"]`);
+    if (!wrapperEl) continue;
+    const wrapperRect = wrapperEl.getBoundingClientRect();
+    if (clientY < wrapperRect.top || clientY > wrapperRect.bottom) continue;
+
+    const chipsEl = wrapperEl.querySelector<HTMLElement>(`[data-group-section-id="${sectionKey}"]`);
+    if (!chipsEl || clientY < chipsEl.getBoundingClientRect().top) {
+      // 헤더 영역이거나 chips ol이 없는 collapsed 그룹 → 맨 앞에 삽입
+      return { groupId: section.groupId, index: 0 };
+    }
+
+    const chipEls = Array.from(chipsEl.querySelectorAll<HTMLElement>("[data-side-bar-chip-id]"));
+    for (const chipEl of chipEls) {
+      const id = chipEl.dataset.sideBarChipId;
+      if (!id || id === sourceId) continue;
+      const chipRect = chipEl.getBoundingClientRect();
+      if (clientY <= chipRect.top + chipRect.height / 2) {
+        return { groupId: section.groupId, index: Math.max(0, section.entryIds.indexOf(id)) };
+      }
+    }
+    return { groupId: section.groupId, index: section.entryIds.length };
+  }
+
+  const last = sections[sections.length - 1];
+  return { groupId: last?.groupId ?? null, index: last?.entryIds.length ?? 0 };
+}
+
+// cross-group 드롭용: sourceId를 allIds에서 제거하고 대상 segment의 dropIndex 위치에 삽입한다.
+// dropIndex = source가 없는 대상 entryIds 기준 타깃 슬롯; 보정 없음(source가 segment에 없음).
+// sourceId는 segment에 속하지 않으며, segment의 기존 순서는 allIds 내에서의 순서를 따른다.
+export function insertIntoSegment(
+  allIds: readonly string[],
+  sourceId: string,
+  dropIndex: number,
+  segmentIds: readonly string[],
+): string[] {
+  const withoutSource = allIds.filter((id) => id !== sourceId);
+  const segmentSet = new Set(segmentIds);
+  const currentSegment = withoutSource.filter((id) => segmentSet.has(id));
+  const bounded = Math.max(0, Math.min(dropIndex, currentSegment.length));
+  if (currentSegment.length === 0) return [...withoutSource, sourceId];
+  if (bounded < currentSegment.length) {
+    const insertIdx = withoutSource.indexOf(currentSegment[bounded]!);
+    const result = [...withoutSource];
+    result.splice(insertIdx, 0, sourceId);
+    return result;
+  }
+  const lastIdx = withoutSource.indexOf(currentSegment[currentSegment.length - 1]!);
+  const result = [...withoutSource];
+  result.splice(lastIdx + 1, 0, sourceId);
+  return result;
+}
+
+// same-section 드롭용: dropIndex = source를 포함한 entryIds 기준 포인터 슬롯; 내부에서 source 제거분 -1 보정.
+export function reorderWithinSegment(
+  allIds: readonly string[],
+  sourceId: string,
+  dropIndex: number,
+  segmentIds: readonly string[],
+): string[] {
+  const segmentSet = new Set(segmentIds);
+  const currentSegment = allIds.filter((id) => segmentSet.has(id));
+  const sourceIndex = currentSegment.indexOf(sourceId);
+  const withoutSource = currentSegment.filter((id) => id !== sourceId);
+  // dropIndex는 source 포함 entryIds 기준이므로 downward 드래그 시 -1 보정한다.
+  const adjusted = dropIndex > sourceIndex ? dropIndex - 1 : dropIndex;
+  const bounded = Math.max(0, Math.min(adjusted, withoutSource.length));
+  withoutSource.splice(bounded, 0, sourceId);
+
+  let segIdx = 0;
+  return allIds.map((id) => (segmentSet.has(id) ? (withoutSource[segIdx++] ?? id) : id));
+}
+
+// keyboard 재배치용: currentOrder(collapsed 포함 전체)에서 visible op 자리만 nextVisibleOrder로 교체하고
+// hidden(collapsed) op은 기존 위치를 그대로 유지한다.
+// nextVisibleOrder 길이가 visibleOrder와 다르면 매핑이 어긋나 op 손실 — currentOrder 그대로 반환.
+export function applyVisibleReorder(
+  currentOrder: readonly string[],
+  visibleOrder: readonly string[],
+  nextVisibleOrder: readonly string[],
+): string[] {
+  if (nextVisibleOrder.length !== visibleOrder.length) return [...currentOrder];
+  const visibleSet = new Set(visibleOrder);
+  let visIdx = 0;
+  return currentOrder.map((id) =>
+    visibleSet.has(id) ? (nextVisibleOrder[visIdx++] ?? id) : id,
+  );
+}
+
+// keyboard 이동 전용: targetIndex = source가 제거된 목록 기준 삽입 위치(보정 없음).
+// drag drop index(source 포함 기준)와 달리 visibleEntries의 인접 슬롯 번호를 그대로 사용한다.
+export function moveByTargetIndex(
+  orderedIds: readonly string[],
+  sourceId: string,
+  targetIndex: number,
+): string[] {
+  const sourceIdx = orderedIds.indexOf(sourceId);
+  if (sourceIdx === -1) return [...orderedIds];
+  const next = orderedIds.filter((id) => id !== sourceId);
+  const bounded = Math.max(0, Math.min(targetIndex, next.length));
+  next.splice(bounded, 0, sourceId);
+  return next;
 }

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -3,18 +3,20 @@ import { createPortal } from "react-dom";
 
 import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console/sdk/operations";
 
-import type { OperationNode, OperationNotification } from "../types.js";
-import { AccentPopover } from "../canvas/accent-popover.js";
+import type { OperationGroup, OperationNode, OperationNotification } from "../types.js";
 import { CanvasContextMenu } from "../canvas/canvas-context-menu.js";
+import { GroupContextMenu } from "../canvas/group-context-menu.js";
 import { operationAccentFromNode, resolveAccentColor } from "../canvas/operation-accent.js";
-import { setOperationOrder, useCanvasState } from "../canvas/canvas-store.js";
+import { setOperationOrder, toggleGroupCollapsed, useCanvasState, useCollapsedGroups } from "../canvas/canvas-store.js";
 import { sortOperationsByOrder } from "../store.js";
-import { dropIndexFromPoint } from "./operations-side-bar-hit-test.js";
+import { applyVisibleReorder, dropIndexFromPoint, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderWithinSegment, type DropSectionInfo } from "./operations-side-bar-hit-test.js";
 import { OperationsSideBarChip, type SideBarEntry } from "./operations-side-bar-chip.js";
+import { OperationsSideBarGroupHeader } from "./operations-side-bar-group-header.js";
 import { MIN_RAIL_PX, setSideBarCollapsed, setSideBarWidth, tierFromWidth, useSideBarState } from "./operations-side-bar-store.js";
 
 interface OperationsSideBarProps {
   readonly operations: readonly OperationNode[];
+  readonly groups: readonly OperationGroup[];
   readonly minimized: readonly string[];
   readonly activeOperationId: string | null;
   readonly operationNotifications: Readonly<Record<string, OperationNotification>>;
@@ -33,12 +35,16 @@ interface OperationsSideBarProps {
   readonly onFocus: (operationId: string) => void;
   readonly onSetAccent: (operationId: string, accentKey: string | null) => void;
   readonly onRename: (operationId: string, title: string) => void;
+  readonly onSetGroupId: (operationId: string, groupId: string | null) => void;
+  readonly onCreateGroup: (theaterId: string, name: string, operationId: string) => void;
+  readonly onSetGroupColor: (groupId: string, color: string | null) => void;
+  readonly onRenameGroup: (groupId: string, name: string) => void;
+  readonly onUngroupAll: (groupId: string) => void;
 }
 
-interface AccentPopoverState {
-  readonly operationId: string;
-  readonly anchor: DOMRect;
-}
+type ActiveContextMenu =
+  | { readonly kind: "chip"; readonly operationId: string; readonly anchor: DOMRect }
+  | { readonly kind: "group"; readonly groupId: string; readonly anchor: DOMRect };
 
 interface NewMenuState {
   readonly anchor: { readonly x: number; readonly y: number };
@@ -47,12 +53,14 @@ interface NewMenuState {
 
 interface DragState {
   readonly sourceId: string;
+  readonly sourceGroupId: string | null;
   readonly pointerId: number;
   readonly startX: number;
   readonly startY: number;
   readonly currentY: number;
   readonly dragging: boolean;
   readonly dropIndex: number;
+  readonly dropGroupId: string | null;
 }
 
 const CLOSE_ARM_DURATION_MS = 1500;
@@ -62,6 +70,7 @@ const AUTO_SCROLL_STEP_PX = 18;
 
 export function OperationsSideBar({
   operations,
+  groups,
   minimized,
   activeOperationId,
   operationNotifications,
@@ -80,6 +89,11 @@ export function OperationsSideBar({
   onFocus,
   onSetAccent,
   onRename,
+  onSetGroupId,
+  onCreateGroup,
+  onSetGroupColor,
+  onRenameGroup,
+  onUngroupAll,
 }: OperationsSideBarProps) {
   const chipsRef = useRef<HTMLOListElement | null>(null);
   const sideBar = useSideBarState();
@@ -89,12 +103,14 @@ export function OperationsSideBar({
   const closeArmTimeoutRef = useRef<number | null>(null);
   const [armedCloseId, setArmedCloseId] = useState<string | null>(null);
   const [drag, setDrag] = useState<DragState | null>(null);
-  const [accentPopover, setAccentPopover] = useState<AccentPopoverState | null>(null);
+  const [activeContextMenu, setActiveContextMenu] = useState<ActiveContextMenu | null>(null);
   const [newMenu, setNewMenu] = useState<NewMenuState | null>(null);
   const [settingsMenu, setSettingsMenu] = useState<NewMenuState | null>(null);
+  const collapsedGroups = useCollapsedGroups();
 
   const minimizedSet = new Set(minimized);
-  const entries: SideBarEntry[] = sortOperationsByOrder(operations, canvas.operationOrder).map((operation) => {
+  const collapsedGroupSet = new Set(collapsedGroups);
+  const allEntries: SideBarEntry[] = sortOperationsByOrder(operations, canvas.operationOrder).map((operation) => {
     const kind = catalog.find((p) => p.id === operation.pluginId)?.kinds.find((k) => k.type === operation.type) ?? null;
     const icon = kind ? renderKindIcon(operation.pluginId, kind) : null;
     return {
@@ -105,8 +121,11 @@ export function OperationsSideBar({
       icon,
     };
   });
-  const currentOrder = entries.map((entry) => entry.operation.id);
-  const dragSourceIndex = drag ? currentOrder.indexOf(drag.sourceId) : -1;
+  const groupedSections = groupOperations(allEntries, groups, canvas.operationOrder);
+  const visibleEntries = groupedSections.flatMap((section) =>
+    collapsedGroupSet.has(section.groupId ?? "") ? [] : section.entries,
+  );
+  const currentOrder = allEntries.map((entry) => entry.operation.id);
 
   const clearCloseArmTimer = useCallback(() => {
     if (closeArmTimeoutRef.current === null) return;
@@ -135,40 +154,54 @@ export function OperationsSideBar({
 
   useEffect(() => {
     if (armedCloseId === null) return;
-    if (entries.some((entry) => entry.operation.id === armedCloseId)) return;
+    if (allEntries.some((entry) => entry.operation.id === armedCloseId)) return;
     disarmClose();
-  }, [armedCloseId, entries, disarmClose]);
+  }, [armedCloseId, allEntries, disarmClose]);
 
-  const popoverOperation = accentPopover
-    ? entries.find((entry) => entry.operation.id === accentPopover.operationId)?.operation ?? null
+  const contextMenuOperation = activeContextMenu?.kind === "chip"
+    ? allEntries.find((entry) => entry.operation.id === activeContextMenu.operationId)?.operation ?? null
+    : null;
+  const contextMenuGroup = activeContextMenu?.kind === "group"
+    ? groups.find((g) => g.id === activeContextMenu.groupId) ?? null
     : null;
 
   const keyboardMove = (operationId: string, direction: -1 | 1) => {
-    const index = currentOrder.indexOf(operationId);
+    const index = visibleEntries.findIndex((e) => e.operation.id === operationId);
     if (index === -1) return;
-    const targetIndex = Math.max(0, Math.min(currentOrder.length - 1, index + direction));
+    const targetIndex = Math.max(0, Math.min(visibleEntries.length - 1, index + direction));
     if (targetIndex === index) return;
-    const nextOrder = [...currentOrder];
-    const [moved] = nextOrder.splice(index, 1);
-    if (moved === undefined) return;
-    nextOrder.splice(targetIndex, 0, moved);
-    setOperationOrder(nextOrder);
+    const visibleOrder = visibleEntries.map((e) => e.operation.id);
+    const nextVisibleOrder = moveByTargetIndex(visibleOrder, operationId, targetIndex);
+    // currentOrder(collapsed 포함 전체)에 visible 재배치를 반영해 hidden op 순서를 보존한다.
+    setOperationOrder(applyVisibleReorder(currentOrder, visibleOrder, nextVisibleOrder));
   };
+
+  // entryIds는 collapsed 그룹도 실제 멤버를 담는다. dropTargetFromPoint는 DOM 기반이라 collapsed에서
+  // index 0을 early-return하며 entryIds를 쓰지 않고, insertIntoSegment는 멤버 순서가 있어야 드롭 위치를
+  // 올바르게 계산한다(빈 배열이면 멤버를 가진 collapsed 그룹에 드롭한 chip이 그룹 끝으로 밀린다).
+  const dropSections: DropSectionInfo[] = groupedSections.map((section) => ({
+    groupId: section.groupId,
+    entryIds: section.entries.map((e) => e.operation.id),
+  }));
 
   const beginPointerDrag = (event: ReactPointerEvent<HTMLLIElement>, operationId: string) => {
     if (event.button !== 0) return;
     if (event.target instanceof Element && event.target.closest("button")) return;
     event.currentTarget.setPointerCapture(event.pointerId);
-    setAccentPopover(null);
+    setActiveContextMenu(null);
     disarmClose();
+    const sourceEntry = allEntries.find((e) => e.operation.id === operationId);
+    const sourceGroupId = sourceEntry?.operation.groupId ?? null;
     setDrag({
       sourceId: operationId,
+      sourceGroupId,
       pointerId: event.pointerId,
       startX: event.clientX,
       startY: event.clientY,
       currentY: event.clientY,
       dragging: false,
       dropIndex: currentOrder.indexOf(operationId),
+      dropGroupId: sourceGroupId,
     });
   };
 
@@ -176,20 +209,34 @@ export function OperationsSideBar({
     if (!drag || drag.pointerId !== event.pointerId) return;
     const distance = Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY);
     if (!drag.dragging && distance < DRAG_THRESHOLD_PX) return;
-    const dropIndex = dropIndexFromPoint(event.clientY, currentOrder, chipsRef.current, drag.sourceId);
+    const dropTarget = dropTargetFromPoint(event.clientY, dropSections, chipsRef.current, drag.sourceId);
     autoScrollSideBar(event.clientY, chipsRef.current);
-    setDrag({ ...drag, currentY: event.clientY, dragging: true, dropIndex });
+    setDrag({ ...drag, currentY: event.clientY, dragging: true, dropIndex: dropTarget.index, dropGroupId: dropTarget.groupId });
   };
 
   const finishPointerDrag = (event: ReactPointerEvent<HTMLLIElement>) => {
     if (!drag || drag.pointerId !== event.pointerId) return;
     if (event.currentTarget.hasPointerCapture(event.pointerId)) event.currentTarget.releasePointerCapture(event.pointerId);
-    const { sourceId, dragging, dropIndex } = drag;
+    const { sourceId, sourceGroupId, dragging, dropIndex, dropGroupId } = drag;
     setDrag(null);
     if (!dragging) return;
-    const sourceIndex = currentOrder.indexOf(sourceId);
-    if (sourceIndex === -1 || dropIndex === sourceIndex) return;
-    const nextOrder = reorderIds(currentOrder, sourceId, dropIndex);
+
+    if (dropGroupId !== sourceGroupId) {
+      // cross-group: groupId 변경 + 대상 그룹 내 dropIndex 위치로 order 재배치를 함께 처리한다.
+      const dropSection = dropSections.find((s) => s.groupId === dropGroupId);
+      const dropSegmentIds = dropSection?.entryIds ?? [];
+      const allIds = allEntries.map((e) => e.operation.id);
+      setOperationOrder(insertIntoSegment(allIds, sourceId, dropIndex, dropSegmentIds));
+      onSetGroupId(sourceId, dropGroupId);
+      return;
+    }
+
+    const section = groupedSections.find((s) => s.groupId === sourceGroupId);
+    const segmentIds = section ? section.entries.map((e) => e.operation.id) : [];
+    const currentLocalIndex = segmentIds.indexOf(sourceId);
+    if (currentLocalIndex === -1 || dropIndex === currentLocalIndex) return;
+    const allIds = allEntries.map((e) => e.operation.id);
+    const nextOrder = reorderWithinSegment(allIds, sourceId, dropIndex, segmentIds);
     setOperationOrder(nextOrder);
   };
 
@@ -250,7 +297,7 @@ export function OperationsSideBar({
 
   const displayWidth = collapsed ? MIN_RAIL_PX : width;
 
-  if (entries.length === 0 && tier === "rail") {
+  if (allEntries.length === 0 && tier === "rail") {
     return (
       <aside
         className="operations-side-bar"
@@ -324,31 +371,75 @@ export function OperationsSideBar({
       </header>
 
       <ol className="operations-side-bar-chips" ref={chipsRef} aria-label="Operations">
-        {entries.map((entry, index) => {
-          const accentKey = canvas.operationAccent[entry.operation.id] ?? operationAccentFromNode(entry.operation);
-          const accentValue = accentKey ? resolveAccentColor(accentKey) : null;
+        {groupedSections.map((section) => {
+          const isCollapsed = section.groupId !== null && collapsedGroupSet.has(section.groupId);
           return (
-            <OperationsSideBarChip
-              key={entry.operation.id}
-              entry={entry}
-              index={index}
-              isCloseArmed={armedCloseId === entry.operation.id}
-              accentValue={accentValue}
-              dragging={drag?.sourceId === entry.operation.id && drag.dragging}
-              dragOffsetY={drag?.sourceId === entry.operation.id && drag.dragging ? drag.currentY - drag.startY : 0}
-              dropTarget={drag?.dragging === true && drag.dropIndex === index && dragSourceIndex !== index}
-              onArmClose={armClose}
-              onDisarmClose={disarmClose}
-              onClose={onClose}
-              onFocus={onFocus}
-              onKeyboardMove={keyboardMove}
-              onPointerDragStart={beginPointerDrag}
-              onPointerDragMove={updatePointerDrag}
-              onPointerDragEnd={finishPointerDrag}
-              onPointerDragCancel={cancelPointerDrag}
-              onOpenAccent={(operationId, anchor) => setAccentPopover({ operationId, anchor })}
-              onRename={onRename}
-            />
+            <li key={section.groupId ?? "__ungrouped__"} data-drop-zone-group-id={section.groupId ?? "__ungrouped__"} className={section.groupId ? "side-bar-group-section" : "side-bar-ungrouped-section"}>
+              {section.group ? (
+                <OperationsSideBarGroupHeader
+                  group={section.group}
+                  count={section.entries.length}
+                  collapsed={isCollapsed}
+                  tier={tier}
+                  onToggle={toggleGroupCollapsed}
+                  onContextMenu={(groupId, anchor) => setActiveContextMenu({ kind: "group", groupId, anchor })}
+                />
+              ) : section.entries.length > 0 ? (
+                <div className="side-bar-ungrouped-label" aria-label="Ungrouped operations">
+                  {tier !== "rail" ? <span>Ungrouped</span> : null}
+                </div>
+              ) : null}
+              {!isCollapsed ? (
+                <ol
+                  className={[
+                    "side-bar-group-chips",
+                    drag?.dragging && drag.dropGroupId === section.groupId && drag.dropGroupId !== drag.sourceGroupId
+                      ? "side-bar-section--drop-target"
+                      : "",
+                  ].filter(Boolean).join(" ")}
+                  data-group-section-id={section.groupId ?? "__ungrouped__"}
+                  aria-label={section.group ? section.group.name : "Ungrouped"}
+                >
+                  {section.entries.map((entry) => {
+                    const globalIndex = allEntries.indexOf(entry);
+                    const sectionLocalIndex = section.entries.indexOf(entry);
+                    const accentKey = canvas.operationAccent[entry.operation.id] ?? operationAccentFromNode(entry.operation);
+                    const accentValue = accentKey ? resolveAccentColor(accentKey) : null;
+                    const grpColor = section.group ? resolveAccentColor(section.group.color) : null;
+                    return (
+                      <OperationsSideBarChip
+                        key={entry.operation.id}
+                        entry={entry}
+                        index={globalIndex}
+                        isCloseArmed={armedCloseId === entry.operation.id}
+                        accentValue={accentValue}
+                        grpColor={grpColor}
+                        dragging={drag?.sourceId === entry.operation.id && drag.dragging}
+                        dragOffsetY={drag?.sourceId === entry.operation.id && drag.dragging ? drag.currentY - drag.startY : 0}
+                        dropTarget={
+                          drag?.dragging === true
+                          && drag.dropGroupId === section.groupId
+                          && drag.dropGroupId === drag.sourceGroupId
+                          && drag.dropIndex === sectionLocalIndex
+                          && drag.sourceId !== entry.operation.id
+                        }
+                        onArmClose={armClose}
+                        onDisarmClose={disarmClose}
+                        onClose={onClose}
+                        onFocus={onFocus}
+                        onKeyboardMove={keyboardMove}
+                        onPointerDragStart={beginPointerDrag}
+                        onPointerDragMove={updatePointerDrag}
+                        onPointerDragEnd={finishPointerDrag}
+                        onPointerDragCancel={cancelPointerDrag}
+                        onOpenAccent={(operationId, anchor) => setActiveContextMenu({ kind: "chip", operationId, anchor })}
+                        onRename={onRename}
+                      />
+                    );
+                  })}
+                </ol>
+              ) : null}
+            </li>
           );
         })}
       </ol>
@@ -400,27 +491,71 @@ export function OperationsSideBar({
         document.body,
       ) : null}
 
-      {accentPopover && popoverOperation ? (
-        <AccentPopover
-          anchor={accentPopover.anchor}
-          accentKey={canvas.operationAccent[popoverOperation.id] ?? operationAccentFromNode(popoverOperation)}
-          onSelect={(accentKey) => onSetAccent(popoverOperation.id, accentKey)}
-          onClose={() => setAccentPopover(null)}
+      {activeContextMenu?.kind === "chip" && contextMenuOperation ? (
+        <GroupContextMenu
+          kind="chip"
+          operation={contextMenuOperation}
+          groups={groups}
+          accentKey={canvas.operationAccent[contextMenuOperation.id] ?? operationAccentFromNode(contextMenuOperation)}
+          anchor={activeContextMenu.anchor}
+          actions={{
+            onSetAccent: (key) => onSetAccent(contextMenuOperation.id, key),
+            onSetGroupId: (groupId) => onSetGroupId(contextMenuOperation.id, groupId),
+            onCreateGroup: (name) => onCreateGroup(contextMenuOperation.theaterId, name, contextMenuOperation.id),
+          }}
+          onClose={() => setActiveContextMenu(null)}
+        />
+      ) : activeContextMenu?.kind === "group" && contextMenuGroup ? (
+        <GroupContextMenu
+          kind="group-header"
+          group={contextMenuGroup}
+          anchor={activeContextMenu.anchor}
+          actions={{
+            onSetColor: (color) => onSetGroupColor(contextMenuGroup.id, color),
+            onRename: (name) => onRenameGroup(contextMenuGroup.id, name),
+            onUngroupAll: () => onUngroupAll(contextMenuGroup.id),
+          }}
+          onClose={() => setActiveContextMenu(null)}
         />
       ) : null}
     </aside>
   );
 }
 
-function reorderIds(orderedIds: readonly string[], sourceId: string, dropIndex: number): string[] {
-  const sourceIndex = orderedIds.indexOf(sourceId);
-  if (sourceIndex === -1) return [...orderedIds];
-  const next = orderedIds.filter((id) => id !== sourceId);
-  const insertAt = dropIndex > sourceIndex ? dropIndex - 1 : dropIndex;
-  const bounded = Math.max(0, Math.min(insertAt, next.length));
-  next.splice(bounded, 0, sourceId);
-  return next;
+interface GroupSection {
+  readonly groupId: string | null;
+  readonly group: OperationGroup | null;
+  readonly entries: SideBarEntry[];
 }
+
+export function groupOperations(
+  entries: readonly SideBarEntry[],
+  groups: readonly OperationGroup[],
+  operationOrder: readonly string[],
+): GroupSection[] {
+  const sortedGroups = [...groups].sort((a, b) => a.order - b.order || a.createdAt - b.createdAt);
+  const sections: GroupSection[] = sortedGroups.map((group) => ({
+    groupId: group.id,
+    group,
+    entries: [],
+  }));
+  const ungrouped: GroupSection = { groupId: null, group: null, entries: [] };
+  const groupById = new Map(sortedGroups.map((g) => [g.id, g]));
+
+  for (const entry of entries) {
+    const gid = entry.operation.groupId ?? null;
+    if (gid !== null && groupById.has(gid)) {
+      const section = sections.find((s) => s.groupId === gid);
+      section?.entries.push(entry);
+    } else {
+      ungrouped.entries.push(entry);
+    }
+  }
+
+  void operationOrder;
+  return [...sections, ungrouped];
+}
+
 
 function autoScrollSideBar(clientY: number, chipsElement: HTMLOListElement | null): void {
   if (!chipsElement) return;

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -8,6 +8,7 @@ import type {
   ConsoleState,
   NotificationKind,
   NotificationPreferences,
+  OperationGroup,
   OperationNotification,
   OperationNode,
   ObserverStatus,
@@ -51,6 +52,7 @@ let state: ConsoleState = {
   theaters: [],
   operations: [],
   operationsHydrated: false,
+  groups: [],
   activeTheaterId: null,
   activeOperationId: null,
   operationStatus: {},
@@ -177,6 +179,10 @@ export function hydrateOperations(operations: readonly OperationNode[]): void {
   setState({ operations, operationsHydrated: true });
 }
 
+export function hydrateGroups(groups: readonly OperationGroup[]): void {
+  setState({ groups });
+}
+
 export function setActiveTheater(theaterId: string | null): void {
   writeStoredActiveTheaterId(theaterId);
   setState({ activeTheaterId: theaterId });
@@ -296,6 +302,37 @@ export function sortOperationsByOrder(
     if (rightIndex !== undefined) return 1;
     return compareOperationCreatedAt(left, right);
   });
+}
+
+// 그룹 적용 visible 순서(비-collapsed 그룹 order → 그룹 내 operationOrder → ungrouped)로 flatten한 배열을 반환.
+// SideBar visible 순서와 Alt+←/→ cycling 순서의 공유 SSoT.
+// collapsedGroups: 접힌 그룹 id 목록 — 해당 그룹의 멤버는 결과에서 제외한다.
+export function flattenGroupedOrder(
+  operations: readonly OperationNode[],
+  groups: readonly OperationGroup[],
+  operationOrder: readonly string[],
+  collapsedGroups: readonly string[] = [],
+): readonly OperationNode[] {
+  const sorted = sortOperationsByOrder(operations, operationOrder);
+  const collapsedSet = new Set(collapsedGroups);
+  const sortedGroups = [...groups].sort((a, b) => a.order - b.order || a.createdAt - b.createdAt);
+  const buckets = new Map<string | null, OperationNode[]>();
+  for (const group of sortedGroups) buckets.set(group.id, []);
+  buckets.set(null, []);
+  for (const op of sorted) {
+    const gid = op.groupId ?? null;
+    if (gid !== null && buckets.has(gid)) {
+      buckets.get(gid)!.push(op);
+    } else {
+      buckets.get(null)!.push(op);
+    }
+  }
+  return [
+    ...sortedGroups
+      .filter((g) => !collapsedSet.has(g.id))
+      .flatMap((g) => buckets.get(g.id) ?? []),
+    ...(buckets.get(null) ?? []),
+  ];
 }
 
 export function compareOperationCreatedAt(left: OperationNode, right: OperationNode): number {

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3687,6 +3687,169 @@
 }
 
 
+/* ── Group Rail Bar (--grp-color 채널 전용 — chip ::before perimeter와 독립) ───── */
+
+.side-bar-chip__rail {
+  position: absolute;
+  left: 0;
+  top: 4px;
+  bottom: 4px;
+  width: 3px;
+  border-radius: 2px;
+  background: var(--grp-color, transparent);
+  flex: none;
+  pointer-events: none;
+}
+
+/* rail tier에서도 바는 그대로 표시 (아이콘 왼쪽) */
+.operations-side-bar[data-tier="rail"] .side-bar-chip__rail {
+  top: 3px;
+  bottom: 3px;
+}
+
+/* ── Group Section Layout ──────────────────────────────────────────────────────── */
+
+.side-bar-group-section,
+.side-bar-ungrouped-section {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+}
+
+.side-bar-group-chips {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* ── Group Header ──────────────────────────────────────────────────────────────── */
+
+.side-bar-group-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 4px var(--space-1) 4px var(--space-2);
+  margin: 2px var(--space-1) 0;
+  border-radius: var(--radius-md);
+  user-select: none;
+}
+
+.side-bar-group-header__toggle {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--ink-fog);
+  border-radius: var(--radius-sm);
+  transition: color var(--duration-fast) var(--ease-spring);
+}
+
+.side-bar-group-header__toggle:hover,
+.side-bar-group-header__toggle:focus-visible {
+  color: var(--ink-spectral);
+  outline: none;
+}
+
+.side-bar-group-header__arrow {
+  width: 12px;
+  height: 12px;
+  transition: transform var(--duration-fast) var(--ease-spring);
+}
+
+.side-bar-group-header__arrow.is-collapsed {
+  transform: rotate(-90deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .side-bar-group-header__arrow {
+    transition: none;
+  }
+}
+
+.side-bar-group-header__name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-body);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--grp-color, var(--ink-fog));
+}
+
+.side-bar-group-header__count {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--ink-fog);
+  min-width: 14px;
+  text-align: right;
+}
+
+/* rail tier 그룹 헤더: 색상 dot만 표시 */
+.side-bar-group-header--rail {
+  justify-content: center;
+  padding: 4px 0;
+  margin: 2px 0 0;
+  cursor: pointer;
+}
+
+.side-bar-group-header__dot {
+  display: block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--grp-color, var(--ink-fog));
+}
+
+/* Ungrouped label */
+.side-bar-ungrouped-label {
+  padding: 2px var(--space-1) 2px var(--space-2);
+  font-family: var(--font-body);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-fog);
+  opacity: 0.5;
+}
+
+.operations-side-bar[data-tier="rail"] .side-bar-ungrouped-label {
+  display: none;
+}
+
+/* ── Cross-section drop target (aurora tint on target group chip list) ─────────── */
+
+.side-bar-section--drop-target {
+  background: color-mix(in oklch, var(--aurora) 6%, transparent);
+  border-radius: var(--radius-md);
+  outline: 1px dashed color-mix(in oklch, var(--aurora) 40%, transparent);
+  outline-offset: -1px;
+}
+
+/* ── 3-tier indent for chips inside groups ──────────────────────────────────────── */
+
+.operations-side-bar[data-tier="list"] .side-bar-group-section .side-bar-chip,
+.operations-side-bar[data-tier="detail"] .side-bar-group-section .side-bar-chip {
+  padding-left: 18px;
+}
+
+.operations-side-bar[data-tier="rail"] .side-bar-group-section .side-bar-chip {
+  padding-left: 0;
+  padding-right: 0;
+}
+
 /* ── Resize Handle (우측 가장자리 4px, col-resize cursor) ───────────────────────── */
 
 .operations-side-bar-resize-handle {
@@ -3749,6 +3912,148 @@
 
 /* accent 설정 팝업 — 패널/Dock 좌측 인디케이터 클릭으로 열린다. 트리거에 앵커되는 오버레이 팝업.
    오버레이는 바깥 클릭을 받아 닫는 투명 click-catcher(딤 없음), 카드는 인라인 좌표(position:fixed)로 트리거 옆에 뜬다. */
+/* ── Group Context Menu (chip + group-header 통합 오버레이) ─────────────────────── */
+
+.group-context-menu-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+}
+
+.group-context-menu-card {
+  position: fixed;
+  z-index: 1;
+  min-width: 192px;
+  max-width: 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--surface-glass-strong) 88%, var(--ink-deep));
+  box-shadow: var(--shadow-anchor);
+  backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+}
+
+.group-context-menu-section-label {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-fog);
+  padding: 4px 6px 2px;
+}
+
+.group-context-menu-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 5px 8px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink-spectral);
+  transition:
+    background var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring);
+}
+
+.group-context-menu-item:hover,
+.group-context-menu-item:focus-visible {
+  background: color-mix(in oklch, var(--ink-spectral) 8%, transparent);
+  border-color: color-mix(in oklch, var(--ink-fog) 20%, transparent);
+  outline: none;
+}
+
+.group-context-menu-item.is-selected {
+  background: color-mix(in oklch, var(--brass) 10%, transparent);
+  color: color-mix(in oklch, var(--brass) 80%, var(--ink-spectral));
+}
+
+.group-context-menu-item--new {
+  color: var(--ink-fog);
+  font-style: italic;
+}
+
+.group-context-menu-item--danger {
+  color: var(--coral);
+}
+
+.group-context-menu-item--danger.is-armed {
+  background: color-mix(in oklch, var(--coral) 12%, transparent);
+  border-color: color-mix(in oklch, var(--coral) 30%, transparent);
+  font-weight: 700;
+}
+
+.group-context-menu-item__dot {
+  display: block;
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--ink-fog);
+}
+
+.group-context-menu-item__name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.group-context-menu-item__check {
+  flex: none;
+  width: 12px;
+  height: 12px;
+  color: var(--brass);
+}
+
+.group-context-menu-item__new-label {
+  color: var(--ink-fog);
+}
+
+.group-context-menu-new-input {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 4px 8px;
+  border: 1px solid color-mix(in oklch, var(--ink-fog) 30%, transparent);
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--ink-spectral) 6%, transparent);
+  color: var(--ink-spectral);
+  font-family: var(--font-body);
+  font-size: 13px;
+  outline: none;
+}
+
+.group-context-menu-new-input:focus {
+  border-color: color-mix(in oklch, var(--brass) 60%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in oklch, var(--brass) 30%, transparent);
+}
+
+.group-context-menu-divider {
+  height: 1px;
+  margin: 4px 0;
+  background: var(--surface-rim);
+}
+
+.group-context-menu-swatches {
+  display: grid;
+  grid-template-columns: repeat(8, 24px);
+  gap: 4px;
+  padding: 2px 4px 4px;
+}
+
+/* ── Accent Popover ─────────────────────────────────────────────────────────────── */
+
 .accent-popover-overlay {
   position: fixed;
   inset: 0;

--- a/runtime/fleet-console/core/client/src/types.ts
+++ b/runtime/fleet-console/core/client/src/types.ts
@@ -73,6 +73,15 @@ export interface OperationGeometry {
   readonly zIndex: number;
 }
 
+export interface OperationGroup {
+  readonly id: string;
+  readonly name: string;
+  readonly color: string;
+  readonly order: number;
+  readonly theaterId: string;
+  readonly createdAt: number;
+}
+
 export interface OperationNode {
   readonly id: string;
   readonly theaterId: string;
@@ -85,6 +94,8 @@ export interface OperationNode {
   readonly geometry: OperationGeometry | null;
   // 사용자 지정 accent 키(서버 영속). 미설정 시 부재. Dock 칩 perimeter 링 색의 SSoT다.
   readonly accent?: string | null;
+  // 사용자 지정 그룹 id(서버 영속). null이면 Ungrouped, 미설정 시 부재(Ungrouped와 동일 취급).
+  readonly groupId?: string | null;
   readonly state: Record<string, unknown>;
   readonly ts: {
     readonly createdAt: number;
@@ -209,6 +220,7 @@ export interface ConsoleState {
   readonly theaters: readonly TheaterInfo[];
   readonly operations: readonly OperationNode[];
   readonly operationsHydrated: boolean;
+  readonly groups: readonly OperationGroup[];
   readonly activeTheaterId: string | null;
   readonly activeOperationId: string | null;
   readonly operationStatus: Readonly<Record<string, OperationActivity>>;

--- a/runtime/fleet-console/core/host/durable-state.ts
+++ b/runtime/fleet-console/core/host/durable-state.ts
@@ -7,10 +7,19 @@ import {
 } from "@dotobokuri/fleet-infra";
 
 import { createConsoleDataPaths, type ConsoleDataPaths } from "./paths.js";
-import type { OperationNode } from "./operations/types.js";
+import { MAX_GROUP_NAME_LENGTH, type OperationNode } from "./operations/types.js";
 import type { TheaterRegistration } from "./theaters.js";
 
 export type ConsoleLabelSource = "user" | "auto";
+
+export interface DurableOperationGroup {
+  readonly id: string;
+  readonly name: string;
+  readonly color: string;
+  readonly order: number;
+  readonly theaterId: string;
+  readonly createdAt: number;
+}
 
 export interface DurableOperation {
   readonly sessionId: string;
@@ -35,6 +44,7 @@ export interface DurableConsoleState {
   readonly theaters: readonly TheaterRegistration[];
   readonly operations: readonly DurableOperation[];
   readonly operationNodes: readonly OperationNode[];
+  readonly groups?: readonly DurableOperationGroup[];
 }
 
 export interface CreateConsoleDurableStateStoreDeps {
@@ -47,6 +57,12 @@ const STATE_VERSION = 2;
 const STATE_LOCK_DIR_NAME = "state.lock";
 const STATE_LOCK_OWNER_FILE_NAME = "owner.json";
 const STATE_TEMP_PREFIX = ".state.";
+// 그룹 색상 키 화이트리스트 — 16색 accent 팔레트(operation-accent.ts)와 동일 키만 durable에 허용한다.
+const VALID_GROUP_COLOR_KEYS = new Set([
+  "red", "orange", "amber", "yellow", "lime", "green",
+  "emerald", "teal", "cyan", "sky", "blue", "indigo",
+  "violet", "purple", "magenta", "rose",
+]);
 
 export function createConsoleDurableStateStore(deps: CreateConsoleDurableStateStoreDeps = {}): DurableJsonStore<DurableConsoleState> {
   const paths = deps.paths ?? createConsoleDataPaths();
@@ -71,11 +87,12 @@ export function sanitizeDurableConsoleState(value: unknown): DurableConsoleState
     theaters: readTheaterRegistrations(value.theaters),
     operations: readDurableOperations(value.operations),
     operationNodes: readOperationNodes(value.operationNodes),
+    groups: readOperationGroups(value.groups),
   };
 }
 
 export function emptyDurableConsoleState(): DurableConsoleState {
-  return { version: STATE_VERSION, theaters: [], operations: [], operationNodes: [] };
+  return { version: STATE_VERSION, theaters: [], operations: [], operationNodes: [], groups: [] };
 }
 
 function readTheaterRegistrations(value: unknown): readonly TheaterRegistration[] {
@@ -115,6 +132,7 @@ function migrateV1DurableConsoleState(value: Record<string, unknown>): DurableCo
     theaters: readTheaterRegistrations(value.theaters),
     operations,
     operationNodes: operations.map(operationToNode),
+    groups: [],
   };
 }
 
@@ -169,6 +187,7 @@ function sanitizeOperationNode(value: unknown): OperationNode | null {
   const ts = sanitizeOperationTimestamps(value.ts);
   if (!id || !theaterId || !type || !pluginId || !title || !ts) return null;
   const accent = readOptionalAccent(value.accent);
+  const groupId = readOptionalGroupId(value.groupId);
   return {
     id,
     theaterId,
@@ -181,6 +200,7 @@ function sanitizeOperationNode(value: unknown): OperationNode | null {
     geometry: sanitizeOperationGeometry(value.geometry),
     state: readRecord(value.state),
     ...(accent ? { accent } : {}),
+    ...(groupId !== undefined ? { groupId } : {}),
     ts,
   };
 }
@@ -270,4 +290,41 @@ function readPositiveInteger(value: unknown): number | null {
 
 function readFiniteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function readNonNegativeInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function readOptionalGroupId(value: unknown): string | null | undefined {
+  if (value === null) return null;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed.slice(0, 64) : undefined;
+  }
+  return undefined;
+}
+
+function readOperationGroups(value: unknown): readonly DurableOperationGroup[] {
+  if (!Array.isArray(value)) return [];
+  const groups: DurableOperationGroup[] = [];
+  for (const item of value) {
+    const group = sanitizeOperationGroup(item);
+    if (group) groups.push(group);
+  }
+  return groups;
+}
+
+function sanitizeOperationGroup(value: unknown): DurableOperationGroup | null {
+  if (!isRecord(value)) return null;
+  const id = readNonEmptyString(value.id);
+  const theaterId = readNonEmptyString(value.theaterId);
+  const rawName = readNonEmptyString(value.name);
+  const color = readNonEmptyString(value.color);
+  const order = readNonNegativeInteger(value.order);
+  const createdAt = readFiniteNumber(value.createdAt);
+  if (!id || !theaterId || !rawName || !color || order === null || createdAt === null) return null;
+  if (rawName.length > MAX_GROUP_NAME_LENGTH) return null;
+  if (!VALID_GROUP_COLOR_KEYS.has(color)) return null;
+  return { id, theaterId, name: rawName, color, order, createdAt };
 }

--- a/runtime/fleet-console/core/host/operations/routes.ts
+++ b/runtime/fleet-console/core/host/operations/routes.ts
@@ -1,7 +1,7 @@
 import type http from "node:http";
 
 import type { OperationCatalogPlugin } from "../plugin-host/types.js";
-import type { OperationCreateInput, OperationNode, OperationStore } from "./types.js";
+import type { OperationCreateInput, OperationGroup, OperationGroupCreateInput, OperationGroupPatchInput, OperationNode, OperationStore } from "./types.js";
 import { createSanitizedOpDto } from "./sanitize.js";
 
 export interface OperationsRouterDeps {
@@ -37,10 +37,13 @@ type PatchOperationBody = {
   readonly title?: unknown;
   readonly parentId?: unknown;
   readonly accent?: unknown;
+  readonly groupId?: unknown;
   readonly payload?: unknown;
   readonly state?: unknown;
   readonly geometry?: unknown;
 };
+type CreateGroupBody = Partial<OperationGroupCreateInput>;
+type PatchGroupBody = Partial<OperationGroupPatchInput>;
 
 export function createOperationsRouter(deps: OperationsRouterDeps): OperationsRouter {
   return async ({ req, res, pathname }) => {
@@ -54,6 +57,15 @@ export function createOperationsRouter(deps: OperationsRouterDeps): OperationsRo
         return true;
       }
       deps.writeJson(res, 200, deps.resolveLaunchCatalog ? await deps.resolveLaunchCatalog() : { plugins: [] });
+      return true;
+    }
+    if (pathname === "/api/v1/operations/groups") {
+      await handleGroupCollection(req, res, deps);
+      return true;
+    }
+    const groupItemMatch = pathname.match(/^\/api\/v1\/operations\/groups\/([^/]+)$/);
+    if (groupItemMatch) {
+      await handleGroupItem(req, res, decodeURIComponent(groupItemMatch[1] ?? ""), deps);
       return true;
     }
     const childrenMatch = pathname.match(/^\/api\/v1\/operations\/([^/]+)\/children$/);
@@ -162,9 +174,13 @@ async function handleItem(req: http.IncomingMessage, res: http.ServerResponse, i
     deps.writeJson(res, 400, { error: "invalid_operation_patch" });
     return;
   }
-  // accent는 문자열(설정)·null(해제)·생략(무변경)만 허용한다. geometry의 null-clear 계약과 동일하다.
+  // accent/groupId는 문자열(설정)·null(해제)·생략(무변경)만 허용한다. geometry의 null-clear 계약과 동일하다.
   if (body.accent !== undefined && body.accent !== null && typeof body.accent !== "string") {
     deps.writeJson(res, 400, { error: "invalid_operation_accent" });
+    return;
+  }
+  if (body.groupId !== undefined && body.groupId !== null && typeof body.groupId !== "string") {
+    deps.writeJson(res, 400, { error: "invalid_operation_groupId" });
     return;
   }
   try {
@@ -173,6 +189,7 @@ async function handleItem(req: http.IncomingMessage, res: http.ServerResponse, i
       ...(typeof body.title === "string" ? { title: body.title } : {}),
       ...(typeof body.parentId === "string" || body.parentId === null ? { parentId: body.parentId } : {}),
       ...(typeof body.accent === "string" || body.accent === null ? { accent: body.accent } : {}),
+      ...(typeof body.groupId === "string" || body.groupId === null ? { groupId: body.groupId } : {}),
       ...(isRecord(body.payload) ? { payload: body.payload } : {}),
       ...(isRecord(body.state) ? { state: body.state } : {}),
       ...(isRecord(body.geometry) || body.geometry === null ? { geometry: body.geometry === null ? null : readGeometry(body.geometry) } : {}),
@@ -199,6 +216,75 @@ async function handleItem(req: http.IncomingMessage, res: http.ServerResponse, i
 
 function sanitizeOperationNode(node: OperationNode, deps: OperationsRouterDeps): OperationNode {
   return createSanitizedOpDto(node, { sensitiveFields: deps.getPluginSensitiveFields?.(node.pluginId) ?? [] });
+}
+
+async function handleGroupCollection(req: http.IncomingMessage, res: http.ServerResponse, deps: OperationsRouterDeps): Promise<void> {
+  if (req.method === "GET") {
+    // operations 컬렉션(handleCollection)과 동일한 계약: theaterId가 있으면 Theater별, 없으면 전체.
+    // 클라이언트는 전체 groups를 받아 activeTheaterId로 필터하므로(theaterGroups) null 호출도 200이어야 한다.
+    const theaterId = readRequestUrl(req).searchParams.get("theaterId");
+    const groups = theaterId ? deps.store.listGroups(theaterId) : deps.store.listAllGroups();
+    deps.writeJson(res, 200, { groups });
+    return;
+  }
+  if (req.method !== "POST") {
+    deps.writeJson(res, 405, { error: "Method not allowed" });
+    return;
+  }
+  if (!deps.isAuthorized(req)) {
+    deps.writeJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  const body = await deps.readJsonBody<CreateGroupBody>(req);
+  if (!body || typeof body.theaterId !== "string" || typeof body.name !== "string" || typeof body.color !== "string") {
+    deps.writeJson(res, 400, { error: "invalid_group" });
+    return;
+  }
+  try {
+    const group = deps.store.createGroup({
+      theaterId: body.theaterId,
+      name: body.name,
+      color: body.color,
+      ...(typeof body.order === "number" ? { order: body.order } : {}),
+    });
+    deps.persist();
+    deps.writeJson(res, 201, { group });
+  } catch (error) {
+    deps.writeJson(res, 400, { error: error instanceof Error ? error.message : "invalid_group" });
+  }
+}
+
+async function handleGroupItem(req: http.IncomingMessage, res: http.ServerResponse, id: string, deps: OperationsRouterDeps): Promise<void> {
+  if (req.method !== "PATCH" && req.method !== "DELETE") {
+    deps.writeJson(res, 405, { error: "Method not allowed" });
+    return;
+  }
+  if (!deps.isAuthorized(req)) {
+    deps.writeJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  if (req.method === "DELETE") {
+    const deleted = deps.store.deleteGroup(id);
+    if (deleted) deps.persist();
+    deps.writeJson(res, deleted ? 200 : 404, deleted ? { ok: true } : { error: "group_not_found" });
+    return;
+  }
+  const body = await deps.readJsonBody<PatchGroupBody>(req);
+  if (!body) {
+    deps.writeJson(res, 400, { error: "invalid_group_patch" });
+    return;
+  }
+  const group: OperationGroup | null = deps.store.updateGroup(id, {
+    ...(typeof body.name === "string" ? { name: body.name } : {}),
+    ...(typeof body.color === "string" ? { color: body.color } : {}),
+    ...(typeof body.order === "number" ? { order: body.order } : {}),
+  });
+  if (!group) {
+    deps.writeJson(res, 404, { error: "group_not_found" });
+    return;
+  }
+  deps.persist();
+  deps.writeJson(res, 200, { group });
 }
 
 function readGeometry(value: Record<string, unknown>) {

--- a/runtime/fleet-console/core/host/operations/store.ts
+++ b/runtime/fleet-console/core/host/operations/store.ts
@@ -1,12 +1,13 @@
 import crypto from "node:crypto";
 
-import type { OperationCreateInput, OperationNode, OperationPatchInput, OperationStore } from "./types.js";
+import { MAX_GROUP_NAME_LENGTH, type OperationCreateInput, type OperationGroup, type OperationGroupCreateInput, type OperationGroupPatchInput, type OperationNode, type OperationPatchInput, type OperationStore } from "./types.js";
 
 const MAX_OPERATION_DEPTH = 2;
 
 export function createOperationStore(deps: { readonly now?: () => number } = {}): OperationStore {
   const now = deps.now ?? Date.now;
   const nodes = new Map<string, OperationNode>();
+  const groups = new Map<string, OperationGroup>();
 
   function list(): readonly OperationNode[] {
     return Array.from(nodes.values()).sort(compareOperationNodes);
@@ -79,6 +80,7 @@ export function createOperationStore(deps: { readonly now?: () => number } = {})
       nodes.delete(node.id);
       deleted += 1;
     }
+    deleteGroupsByTheater(theaterId);
     return deleted;
   }
 
@@ -88,7 +90,72 @@ export function createOperationStore(deps: { readonly now?: () => number } = {})
     for (const node of validNodes) nodes.set(node.id, node);
   }
 
-  return { list, listByTheater, listChildren, get, create, upsert, patch, delete: deleteNode, deleteByTheater, replace };
+  function createGroup(input: OperationGroupCreateInput): OperationGroup {
+    const id = input.id ?? crypto.randomUUID();
+    if (groups.has(id)) throw new Error("group_exists");
+    const order = input.order ?? groups.size;
+    const group: OperationGroup = {
+      id,
+      theaterId: input.theaterId,
+      name: input.name.trim().slice(0, MAX_GROUP_NAME_LENGTH) || "Group",
+      color: input.color,
+      order,
+      createdAt: now(),
+    };
+    groups.set(id, group);
+    return group;
+  }
+
+  function updateGroup(id: string, input: OperationGroupPatchInput): OperationGroup | null {
+    const existing = groups.get(id);
+    if (!existing) return null;
+    const updated: OperationGroup = {
+      ...existing,
+      ...(input.name !== undefined ? { name: input.name.trim().slice(0, MAX_GROUP_NAME_LENGTH) || existing.name } : {}),
+      ...(input.color !== undefined ? { color: input.color } : {}),
+      ...(input.order !== undefined ? { order: input.order } : {}),
+    };
+    groups.set(id, updated);
+    return updated;
+  }
+
+  function deleteGroup(id: string): boolean {
+    if (!groups.has(id)) return false;
+    groups.delete(id);
+    for (const [nodeId, node] of nodes.entries()) {
+      if (node.groupId === id) nodes.set(nodeId, { ...node, groupId: null });
+    }
+    return true;
+  }
+
+  function listGroups(theaterId: string): readonly OperationGroup[] {
+    return Array.from(groups.values())
+      .filter((g) => g.theaterId === theaterId)
+      .sort((a, b) => a.order - b.order || a.createdAt - b.createdAt);
+  }
+
+  function listAllGroups(): readonly OperationGroup[] {
+    return Array.from(groups.values()).sort((a, b) => a.order - b.order || a.createdAt - b.createdAt);
+  }
+
+  function deleteGroupsByTheater(theaterId: string): number {
+    let deleted = 0;
+    for (const [id, group] of Array.from(groups.entries())) {
+      if (group.theaterId !== theaterId) continue;
+      groups.delete(id);
+      deleted += 1;
+    }
+    return deleted;
+  }
+
+  function replaceGroups(nextGroups: readonly OperationGroup[]): void {
+    groups.clear();
+    for (const group of nextGroups) {
+      if (!groups.has(group.id)) groups.set(group.id, group);
+    }
+  }
+
+  return { list, listByTheater, listChildren, get, create, upsert, patch, delete: deleteNode, deleteByTheater, replace, createGroup, updateGroup, deleteGroup, listGroups, listAllGroups, deleteGroupsByTheater, replaceGroups };
 }
 
 function normalizeCreateInput(input: OperationCreateInput, id: string, timestamp: number, nodes: ReadonlyMap<string, OperationNode>): OperationNode {
@@ -102,6 +169,7 @@ function normalizeCreateInput(input: OperationCreateInput, id: string, timestamp
     pluginId: input.pluginId,
     title: input.title.trim() || "Untitled Operation",
     ...(input.accent ? { accent: input.accent.trim() } : {}),
+    ...(input.groupId !== undefined ? { groupId: input.groupId } : {}),
     payload: input.payload ?? {},
     geometry: input.geometry ?? null,
     state: input.state ?? {},
@@ -121,6 +189,7 @@ function normalizePatch(existing: OperationNode, input: OperationPatchInput, tim
     parentId,
     ...(title !== undefined ? { renamedTitle: title.length > 0 ? title : undefined, title: title.length > 0 ? title : existing.title } : {}),
     ...(input.accent !== undefined ? { accent: input.accent && input.accent.trim() ? input.accent.trim() : undefined } : {}),
+    ...(input.groupId !== undefined ? { groupId: input.groupId } : {}),
     ...(input.payload !== undefined ? { payload: input.payload } : {}),
     ...(input.geometry !== undefined ? { geometry: input.geometry } : {}),
     ...(input.state !== undefined ? { state: input.state } : {}),

--- a/runtime/fleet-console/core/host/operations/types.ts
+++ b/runtime/fleet-console/core/host/operations/types.ts
@@ -6,16 +6,42 @@ import type {
 
 export type { OperationGeometry, OperationTimestamps } from "@fleet-console/sdk/operations";
 
+export interface OperationGroup {
+  readonly id: string;
+  readonly name: string;
+  readonly color: string;
+  readonly order: number;
+  readonly theaterId: string;
+  readonly createdAt: number;
+}
+
+export interface OperationGroupCreateInput {
+  readonly id?: string;
+  readonly name: string;
+  readonly color: string;
+  readonly order?: number;
+  readonly theaterId: string;
+}
+
+export interface OperationGroupPatchInput {
+  readonly name?: string;
+  readonly color?: string;
+  readonly order?: number;
+}
+
 export interface OperationNode extends SdkOperationNode {
   readonly accent?: string;
+  readonly groupId?: string | null;
 }
 
 export interface OperationCreateInput extends SdkOperationCreateInput {
   readonly accent?: string;
+  readonly groupId?: string | null;
 }
 
 export interface OperationPatchInput extends SdkOperationPatchInput {
   readonly accent?: string | null;
+  readonly groupId?: string | null;
 }
 
 export interface OperationStore {
@@ -29,4 +55,14 @@ export interface OperationStore {
   delete(id: string): boolean;
   deleteByTheater(theaterId: string): number;
   replace(nodes: readonly OperationNode[]): void;
+  createGroup(input: OperationGroupCreateInput): OperationGroup;
+  updateGroup(id: string, input: OperationGroupPatchInput): OperationGroup | null;
+  deleteGroup(id: string): boolean;
+  listGroups(theaterId: string): readonly OperationGroup[];
+  listAllGroups(): readonly OperationGroup[];
+  deleteGroupsByTheater(theaterId: string): number;
+  replaceGroups(groups: readonly OperationGroup[]): void;
 }
+
+// 그룹 이름 최대 길이 — durable sanitize(영속 검증)와 store(생성/수정) 양쪽이 공유하는 단일 제한.
+export const MAX_GROUP_NAME_LENGTH = 64;

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -855,11 +855,13 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       state = durableStateStore.load();
       theaters.restore(state.theaters);
       operations.replace(state.operationNodes);
+      operations.replaceGroups(state.groups ?? []);
     } catch (error) {
       console.warn(`[fleet-console] Durable state restore skipped: ${error instanceof Error ? error.message : String(error)}`);
       state = emptyDurableConsoleState();
       theaters.restore([]);
       operations.replace([]);
+      operations.replaceGroups([]);
     }
     // Codex WorkspaceRegistry는 인메모리라 재시작 시 비워진다. hasWiki 판정이 이 레지스트리에
     // 의존하므로(getWorkspace !== null), 복원된 Theater를 재등록하지 않으면 위키가 있는 Theater도
@@ -895,6 +897,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
         theaters: theaters.list(),
         operations: [],
         operationNodes: operations.list(),
+        groups: operations.listAllGroups(),
       });
     } catch (error) {
       console.warn(`[fleet-console] Durable state save failed: ${error instanceof Error ? error.message : String(error)}`);

--- a/runtime/fleet-console/tests/durable-state.test.ts
+++ b/runtime/fleet-console/tests/durable-state.test.ts
@@ -17,8 +17,8 @@ afterEach(() => {
 
 describe("durable console state", () => {
   it("falls back to an empty state for version mismatch or malformed data", () => {
-    expect(sanitizeDurableConsoleState({ version: 3, theaters: [], operations: [] })).toEqual({ version: 2, theaters: [], operations: [], operationNodes: [] });
-    expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ id: "" }], operations: [{ sessionId: "missing" }], operationNodes: [{ id: "" }] })).toEqual({ version: 2, theaters: [], operations: [], operationNodes: [] });
+    expect(sanitizeDurableConsoleState({ version: 3, theaters: [], operations: [] })).toEqual({ version: 2, theaters: [], operations: [], operationNodes: [], groups: [] });
+    expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ id: "" }], operations: [{ sessionId: "missing" }], operationNodes: [{ id: "" }] })).toEqual({ version: 2, theaters: [], operations: [], operationNodes: [], groups: [] });
   });
 
   it("migrates v1 durable operations into v2 OperationNodes one-way", () => {

--- a/runtime/fleet-console/tests/operation-search.test.ts
+++ b/runtime/fleet-console/tests/operation-search.test.ts
@@ -37,6 +37,7 @@ function makeState(operations: readonly OperationNode[], theaters: readonly Thea
     theaters,
     operations,
     operationsHydrated: true,
+    groups: [],
     activeTheaterId: "theater-alpha",
     activeOperationId: null,
     operationStatus: {},

--- a/runtime/fleet-console/tests/operations-groups.durable-state.test.ts
+++ b/runtime/fleet-console/tests/operations-groups.durable-state.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeDurableConsoleState } from "../core/host/durable-state.js";
+
+const BASE_NODE = {
+  id: "op-1",
+  theaterId: "theater-1",
+  parentId: null,
+  type: "shell",
+  pluginId: "terminal",
+  title: "Test",
+  payload: {},
+  geometry: null,
+  state: {},
+  ts: { createdAt: 1, updatedAt: 1 },
+};
+
+const BASE_GROUP = {
+  id: "grp-1",
+  theaterId: "theater-1",
+  name: "Alpha",
+  color: "blue",
+  order: 0,
+  createdAt: 100,
+};
+
+describe("DurableConsoleState v2 — groups", () => {
+  it("groups 없는 v2 state를 빈 배열로 hydrate한다 (backward-compat)", () => {
+    const result = sanitizeDurableConsoleState({
+      version: 2,
+      theaters: [],
+      operations: [],
+      operationNodes: [],
+    });
+    expect(result.groups).toEqual([]);
+  });
+
+  it("유효한 groups를 그대로 복원한다", () => {
+    const result = sanitizeDurableConsoleState({
+      version: 2,
+      theaters: [],
+      operations: [],
+      operationNodes: [],
+      groups: [BASE_GROUP],
+    });
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups?.[0]).toMatchObject({ id: "grp-1", name: "Alpha", color: "blue", order: 0 });
+  });
+
+  it("잘못된 color 키를 가진 그룹을 버린다", () => {
+    const result = sanitizeDurableConsoleState({
+      version: 2,
+      theaters: [],
+      operations: [],
+      operationNodes: [],
+      groups: [
+        { ...BASE_GROUP, id: "valid", color: "teal" },
+        { ...BASE_GROUP, id: "invalid-color", color: "neon-pink" },
+        { ...BASE_GROUP, id: "empty-color", color: "" },
+      ],
+    });
+    expect(result.groups?.map((g) => g.id)).toEqual(["valid"]);
+  });
+
+  it("name이 64자를 초과하는 그룹을 버린다", () => {
+    const result = sanitizeDurableConsoleState({
+      version: 2,
+      theaters: [],
+      operations: [],
+      operationNodes: [],
+      groups: [
+        { ...BASE_GROUP, id: "short", name: "Short" },
+        { ...BASE_GROUP, id: "long", name: "x".repeat(65) },
+      ],
+    });
+    expect(result.groups?.map((g) => g.id)).toEqual(["short"]);
+  });
+
+  it("OperationNode의 groupId가 trim·null·undefined 모두 정상 처리된다", () => {
+    const result = sanitizeDurableConsoleState({
+      version: 2,
+      theaters: [],
+      operations: [],
+      operationNodes: [
+        { ...BASE_NODE, id: "with-group", groupId: "  grp-1  " },
+        { ...BASE_NODE, id: "null-group", groupId: null },
+        { ...BASE_NODE, id: "no-group" },
+      ],
+    });
+    const byId = Object.fromEntries(result.operationNodes.map((n) => [n.id, n]));
+    expect(byId["with-group"]?.groupId).toBe("grp-1");
+    expect(byId["null-group"]?.groupId).toBeNull();
+    expect(byId["no-group"]?.groupId).toBeUndefined();
+  });
+
+  it("groupId가 64자를 초과하면 truncate한다", () => {
+    const longId = "a".repeat(80);
+    const result = sanitizeDurableConsoleState({
+      version: 2,
+      theaters: [],
+      operations: [],
+      operationNodes: [{ ...BASE_NODE, id: "op", groupId: longId }],
+    });
+    expect(result.operationNodes[0]?.groupId).toHaveLength(64);
+  });
+
+  it("v1 → v2 마이그레이션 시 groups는 빈 배열로 초기화된다", () => {
+    const result = sanitizeDurableConsoleState({
+      version: 1,
+      theaters: [],
+      operations: [{
+        sessionId: "sess-1",
+        theaterId: "theater-1",
+        cwd: "/proj",
+        cwdLabel: "proj",
+        sequence: 1,
+        createdAt: 1,
+      }],
+    });
+    expect(result.version).toBe(2);
+    expect(result.groups).toEqual([]);
+  });
+});

--- a/runtime/fleet-console/tests/operations-groups.store.test.ts
+++ b/runtime/fleet-console/tests/operations-groups.store.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import { createOperationStore } from "../core/host/operations/store.js";
+import { MAX_GROUP_NAME_LENGTH } from "../core/host/operations/types.js";
+
+function makeStore() {
+  let ts = 1000;
+  return createOperationStore({ now: () => ts++ });
+}
+
+const BASE_OP = {
+  theaterId: "theater-1",
+  type: "shell",
+  pluginId: "terminal",
+  title: "Shell",
+};
+
+describe("OperationStore — 그룹 CRUD", () => {
+  it("createGroup → listGroups로 조회된다", () => {
+    const store = makeStore();
+    const group = store.createGroup({ theaterId: "theater-1", name: "Alpha", color: "blue" });
+    expect(group.id).toBeTruthy();
+    expect(group.name).toBe("Alpha");
+    expect(group.color).toBe("blue");
+    const list = store.listGroups("theater-1");
+    expect(list).toHaveLength(1);
+    expect(list[0]?.id).toBe(group.id);
+  });
+
+  it("listGroups는 theaterId 기준으로 필터링된다", () => {
+    const store = makeStore();
+    store.createGroup({ theaterId: "theater-1", name: "A", color: "teal" });
+    store.createGroup({ theaterId: "theater-2", name: "B", color: "rose" });
+    expect(store.listGroups("theater-1")).toHaveLength(1);
+    expect(store.listGroups("theater-2")).toHaveLength(1);
+    expect(store.listGroups("theater-X")).toHaveLength(0);
+  });
+
+  it("updateGroup으로 name/color/order를 변경한다", () => {
+    const store = makeStore();
+    const group = store.createGroup({ theaterId: "theater-1", name: "Alpha", color: "blue" });
+    const updated = store.updateGroup(group.id, { name: "Bravo", color: "green", order: 5 });
+    expect(updated).not.toBeNull();
+    expect(updated?.name).toBe("Bravo");
+    expect(updated?.color).toBe("green");
+    expect(updated?.order).toBe(5);
+  });
+
+  it("updateGroup은 존재하지 않는 id에 null을 반환한다", () => {
+    const store = makeStore();
+    expect(store.updateGroup("nonexistent", { name: "X" })).toBeNull();
+  });
+
+  it("createGroup/updateGroup은 name을 durable 한계(MAX_GROUP_NAME_LENGTH)로 clamp한다", () => {
+    // durable sanitize가 64자 초과 그룹을 drop하므로, 생성/수정 단계에서 동일 한계로 clamp해 재시작 후 소실을 막는다.
+    const store = makeStore();
+    const longName = "x".repeat(MAX_GROUP_NAME_LENGTH + 20);
+    const created = store.createGroup({ theaterId: "theater-1", name: longName, color: "blue" });
+    expect(created.name.length).toBe(MAX_GROUP_NAME_LENGTH);
+    const updated = store.updateGroup(created.id, { name: longName });
+    expect(updated?.name.length).toBe(MAX_GROUP_NAME_LENGTH);
+  });
+
+  it("deleteGroup은 멤버 chip의 groupId를 null로 unset한다", () => {
+    const store = makeStore();
+    const group = store.createGroup({ theaterId: "theater-1", name: "Alpha", color: "blue" });
+    const op = store.create({ ...BASE_OP, title: "Shell", groupId: group.id });
+    expect(store.get(op.id)?.groupId).toBe(group.id);
+
+    const deleted = store.deleteGroup(group.id);
+    expect(deleted).toBe(true);
+    expect(store.listGroups("theater-1")).toHaveLength(0);
+    expect(store.get(op.id)?.groupId).toBeNull();
+  });
+
+  it("deleteGroup은 존재하지 않는 id에 false를 반환한다", () => {
+    const store = makeStore();
+    expect(store.deleteGroup("nonexistent")).toBe(false);
+  });
+
+  it("deleteByTheater는 해당 Theater의 그룹도 cascade 삭제한다", () => {
+    const store = makeStore();
+    store.createGroup({ theaterId: "theater-1", name: "A", color: "teal" });
+    store.createGroup({ theaterId: "theater-1", name: "B", color: "rose" });
+    store.createGroup({ theaterId: "theater-2", name: "C", color: "amber" });
+    store.create({ ...BASE_OP, title: "Shell" });
+
+    store.deleteByTheater("theater-1");
+    expect(store.listGroups("theater-1")).toHaveLength(0);
+    expect(store.listGroups("theater-2")).toHaveLength(1);
+  });
+
+  it("replaceGroups는 기존 그룹을 완전히 대체한다", () => {
+    const store = makeStore();
+    store.createGroup({ theaterId: "theater-1", name: "Alpha", color: "blue" });
+    store.replaceGroups([
+      { id: "grp-x", theaterId: "theater-1", name: "X", color: "teal", order: 0, createdAt: 1 },
+      { id: "grp-y", theaterId: "theater-2", name: "Y", color: "rose", order: 1, createdAt: 2 },
+    ]);
+    expect(store.listGroups("theater-1")).toHaveLength(1);
+    expect(store.listGroups("theater-1")[0]?.id).toBe("grp-x");
+    expect(store.listGroups("theater-2")[0]?.id).toBe("grp-y");
+  });
+
+  it("listAllGroups는 모든 Theater의 그룹을 반환한다", () => {
+    const store = makeStore();
+    store.createGroup({ theaterId: "theater-1", name: "A", color: "teal" });
+    store.createGroup({ theaterId: "theater-2", name: "B", color: "rose" });
+    expect(store.listAllGroups()).toHaveLength(2);
+  });
+
+  it("PATCH로 operation의 groupId를 변경하고 null로 해제할 수 있다", () => {
+    const store = makeStore();
+    const group = store.createGroup({ theaterId: "theater-1", name: "Alpha", color: "blue" });
+    const op = store.create({ ...BASE_OP, title: "Shell" });
+
+    const patched = store.patch(op.id, { groupId: group.id });
+    expect(patched?.groupId).toBe(group.id);
+
+    const unset = store.patch(op.id, { groupId: null });
+    expect(unset?.groupId).toBeNull();
+  });
+});

--- a/runtime/fleet-console/tests/operations-side-bar-group.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-group.test.ts
@@ -1,0 +1,450 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+
+import { applyVisibleReorder, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderWithinSegment, type DropSectionInfo } from "../core/client/src/sidebar/operations-side-bar-hit-test.js";
+import { groupOperations } from "../core/client/src/sidebar/operations-side-bar.js";
+import type { SideBarEntry } from "../core/client/src/sidebar/operations-side-bar-chip.js";
+import type { OperationGroup, OperationNode } from "../core/client/src/types.js";
+
+function makeNode(id: string, groupId?: string | null): OperationNode {
+  return {
+    id,
+    theaterId: "t1",
+    parentId: null,
+    type: "shell",
+    pluginId: "terminal",
+    title: id,
+    payload: {},
+    geometry: null,
+    groupId,
+    state: {},
+    ts: { createdAt: 1, updatedAt: 1 },
+  };
+}
+
+function makeEntry(id: string, groupId?: string | null): SideBarEntry {
+  return {
+    operation: makeNode(id, groupId),
+    active: false,
+    minimized: false,
+    notificationCount: 0,
+    icon: null,
+  };
+}
+
+function makeGroup(id: string, order: number): OperationGroup {
+  return { id, name: id, color: "blue", order, theaterId: "t1", createdAt: order };
+}
+
+// ── dropTargetFromPoint ──────────────────────────────────────────────────────────
+
+function buildChipsContainer(sections: Array<{
+  sectionId: string | null;
+  chipIds: string[];
+  chipHeight?: number;
+  headerHeight?: number; // 그룹 헤더 영역 높이 (기본 0)
+  collapsed?: boolean;   // chips ol 없음 (collapsed 그룹 시뮬레이션)
+}>): HTMLOListElement {
+  const ol = document.createElement("ol");
+  let yOffset = 0;
+
+  for (const section of sections) {
+    const headerH = section.headerHeight ?? 0;
+    const chipH = section.chipHeight ?? 36;
+    const key = sectionId(section.sectionId);
+
+    // wrapper li: 헤더+chips를 감싸는 요소 (data-drop-zone-group-id)
+    const wrapperLi = document.createElement("li");
+    wrapperLi.dataset.dropZoneGroupId = key;
+    const wrapperTop = yOffset;
+
+    yOffset += headerH;
+
+    if (!section.collapsed) {
+      // chips ol (data-group-section-id)
+      const innerOl = document.createElement("ol");
+      innerOl.dataset.groupSectionId = key;
+      const chipsTop = yOffset;
+
+      for (const id of section.chipIds) {
+        const li = document.createElement("li");
+        li.dataset.sideBarChipId = id;
+        const top = yOffset;
+        li.getBoundingClientRect = () => ({
+          top, bottom: top + chipH, height: chipH, left: 0, right: 200, width: 200, x: 0, y: top, toJSON: () => ({}),
+        });
+        innerOl.append(li);
+        yOffset += chipH;
+      }
+
+      const chipsBottom = yOffset;
+      innerOl.getBoundingClientRect = () => ({
+        top: chipsTop, bottom: chipsBottom, height: chipsBottom - chipsTop,
+        left: 0, right: 200, width: 200, x: 0, y: chipsTop, toJSON: () => ({}),
+      });
+      wrapperLi.append(innerOl);
+    }
+
+    const wrapperBottom = yOffset;
+    wrapperLi.getBoundingClientRect = () => ({
+      top: wrapperTop, bottom: wrapperBottom, height: wrapperBottom - wrapperTop,
+      left: 0, right: 200, width: 200, x: 0, y: wrapperTop, toJSON: () => ({}),
+    });
+
+    ol.append(wrapperLi);
+  }
+
+  return ol as unknown as HTMLOListElement;
+}
+
+function sectionId(groupId: string | null): string {
+  return groupId ?? "__ungrouped__";
+}
+
+describe("dropTargetFromPoint", () => {
+  it("returns index 0 when container is null", () => {
+    expect(dropTargetFromPoint(0, [], null)).toEqual({ groupId: null, index: 0 });
+  });
+
+  it("returns correct groupId and chip index when pointer is over first chip of group", () => {
+    const sections: DropSectionInfo[] = [
+      { groupId: "g1", entryIds: ["op-a", "op-b"] },
+      { groupId: null, entryIds: ["op-c"] },
+    ];
+    const container = buildChipsContainer([
+      { sectionId: "g1", chipIds: ["op-a", "op-b"] },
+      { sectionId: null, chipIds: ["op-c"] },
+    ]);
+    // clientY = 5 → top half of first chip (op-a, top=0 height=36, midpoint=18)
+    expect(dropTargetFromPoint(5, sections, container)).toEqual({ groupId: "g1", index: 0 });
+  });
+
+  it("returns index after last chip when pointer is below all chips in a section", () => {
+    const sections: DropSectionInfo[] = [
+      { groupId: "g1", entryIds: ["op-a"] },
+      { groupId: null, entryIds: ["op-b"] },
+    ];
+    const container = buildChipsContainer([
+      { sectionId: "g1", chipIds: ["op-a"] },
+      { sectionId: null, chipIds: ["op-b"] },
+    ]);
+    // clientY = 35 → bottom of op-a (top=0, height=36, midpoint=18), so past midpoint → index 1 (after op-a)
+    expect(dropTargetFromPoint(35, sections, container)).toEqual({ groupId: "g1", index: 1 });
+  });
+
+  it("skips sourceId chip when computing drop index", () => {
+    const sections: DropSectionInfo[] = [{ groupId: null, entryIds: ["op-a", "op-b", "op-c"] }];
+    const container = buildChipsContainer([
+      { sectionId: null, chipIds: ["op-a", "op-b", "op-c"] },
+    ]);
+    // pointer at y=5, sourceId=op-a → op-a is skipped, first candidate is op-b (top=36, midpoint=54)
+    // y=5 < 54, so index = indexOf("op-b") = 1
+    expect(dropTargetFromPoint(5, sections, container, "op-a")).toEqual({ groupId: null, index: 1 });
+  });
+
+  it("selects ungrouped section when pointer is over it", () => {
+    const sections: DropSectionInfo[] = [
+      { groupId: "g1", entryIds: ["op-a"] },
+      { groupId: null, entryIds: ["op-b"] },
+    ];
+    const container = buildChipsContainer([
+      { sectionId: "g1", chipIds: ["op-a"] },
+      { sectionId: null, chipIds: ["op-b"] },
+    ]);
+    // op-b starts at y=36, midpoint=54; pointer at y=36 → below midpoint of nothing → index=0 for ungrouped
+    expect(dropTargetFromPoint(37, sections, container)).toEqual({ groupId: null, index: 0 });
+  });
+
+  it("그룹 헤더 영역(chips ol 위)에서 드롭 시 해당 그룹 index=0 반환", () => {
+    // g1: headerHeight=32, chips top=32, op-a top=32, op-b top=68
+    // clientY=10 → wrapper(top=0) 안, chips ol top=32보다 위 → 헤더 영역 → {g1, 0}
+    const sections: DropSectionInfo[] = [
+      { groupId: "g1", entryIds: ["op-a", "op-b"] },
+      { groupId: null, entryIds: ["op-c"] },
+    ];
+    const container = buildChipsContainer([
+      { sectionId: "g1", chipIds: ["op-a", "op-b"], headerHeight: 32 },
+      { sectionId: null, chipIds: ["op-c"] },
+    ]);
+    expect(dropTargetFromPoint(10, sections, container)).toEqual({ groupId: "g1", index: 0 });
+  });
+
+  it("collapsed 그룹(chips ol 없음) 위에서 드롭 시 해당 그룹 index=0 반환", () => {
+    // g1 collapsed: wrapper top=0 bottom=32 (헤더만), chips ol 없음
+    // null: wrapper top=32 bottom=68
+    const sections: DropSectionInfo[] = [
+      { groupId: "g1", entryIds: [] },
+      { groupId: null, entryIds: ["op-c"] },
+    ];
+    const container = buildChipsContainer([
+      { sectionId: "g1", chipIds: [], headerHeight: 32, collapsed: true },
+      { sectionId: null, chipIds: ["op-c"] },
+    ]);
+    expect(dropTargetFromPoint(16, sections, container)).toEqual({ groupId: "g1", index: 0 });
+  });
+
+  it("빈 그룹(chips ol 있지만 멤버 0)에서 드롭 시 해당 그룹 index=0 반환", () => {
+    const sections: DropSectionInfo[] = [
+      { groupId: "g1", entryIds: [] },
+      { groupId: null, entryIds: ["op-c"] },
+    ];
+    const container = buildChipsContainer([
+      { sectionId: "g1", chipIds: [], headerHeight: 32 },
+      { sectionId: null, chipIds: ["op-c"] },
+    ]);
+    // clientY=10: 헤더 영역 → {g1, 0}
+    expect(dropTargetFromPoint(10, sections, container)).toEqual({ groupId: "g1", index: 0 });
+  });
+
+  it("컨테이너 빈 하단 영역(마지막 섹션 이후)은 fallback으로 마지막 그룹 반환", () => {
+    const sections: DropSectionInfo[] = [
+      { groupId: "g1", entryIds: ["op-a"] },
+      { groupId: null, entryIds: ["op-b"] },
+    ];
+    const container = buildChipsContainer([
+      { sectionId: "g1", chipIds: ["op-a"] },
+      { sectionId: null, chipIds: ["op-b"] },
+    ]);
+    // clientY=999: 모든 wrapper 밖 → fallback = 마지막 섹션(null) index=1
+    expect(dropTargetFromPoint(999, sections, container)).toEqual({ groupId: null, index: 1 });
+  });
+});
+
+// ── reorderWithinSegment ─────────────────────────────────────────────────────────
+
+describe("reorderWithinSegment", () => {
+  it("moves source to the beginning of the segment", () => {
+    const allIds = ["a", "b", "c", "x", "y"];
+    const segment = ["b", "c"];
+    expect(reorderWithinSegment(allIds, "c", 0, segment)).toEqual(["a", "c", "b", "x", "y"]);
+  });
+
+  it("moves source to the end of the segment", () => {
+    const allIds = ["a", "b", "c", "x"];
+    const segment = ["b", "c"];
+    expect(reorderWithinSegment(allIds, "b", 2, segment)).toEqual(["a", "c", "b", "x"]);
+  });
+
+  it("preserves non-segment entries in their original positions", () => {
+    const allIds = ["a", "b", "c", "d", "e"];
+    const segment = ["b", "d"];
+    // move d before b
+    expect(reorderWithinSegment(allIds, "d", 0, segment)).toEqual(["a", "d", "c", "b", "e"]);
+  });
+
+  it("clamps drop index to segment bounds", () => {
+    const allIds = ["a", "b", "c"];
+    const segment = ["a", "b", "c"];
+    expect(reorderWithinSegment(allIds, "a", 100, segment)).toEqual(["b", "c", "a"]);
+    expect(reorderWithinSegment(allIds, "c", -5, segment)).toEqual(["c", "a", "b"]);
+  });
+
+  it("returns stable order when source and destination are the same", () => {
+    const allIds = ["a", "b", "c"];
+    const segment = ["a", "b", "c"];
+    expect(reorderWithinSegment(allIds, "b", 1, segment)).toEqual(["a", "b", "c"]);
+  });
+});
+
+// ── groupOperations ──────────────────────────────────────────────────────────────
+
+describe("groupOperations", () => {
+  it("places groups in ascending order by group.order, ungrouped last", () => {
+    const entries = [
+      makeEntry("op-a", "g2"),
+      makeEntry("op-b", "g1"),
+      makeEntry("op-c", null),
+    ];
+    const groups = [makeGroup("g1", 1), makeGroup("g2", 2)];
+    const sections = groupOperations(entries, groups, []);
+
+    expect(sections.map((s) => s.groupId)).toEqual(["g1", "g2", null]);
+    expect(sections[0]?.entries.map((e) => e.operation.id)).toEqual(["op-b"]);
+    expect(sections[1]?.entries.map((e) => e.operation.id)).toEqual(["op-a"]);
+    expect(sections[2]?.entries.map((e) => e.operation.id)).toEqual(["op-c"]);
+  });
+
+  it("puts operations with unknown groupId in ungrouped", () => {
+    const entries = [makeEntry("op-a", "nonexistent"), makeEntry("op-b", null)];
+    const groups: OperationGroup[] = [];
+    const sections = groupOperations(entries, groups, []);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]?.groupId).toBeNull();
+    expect(sections[0]?.entries.map((e) => e.operation.id)).toEqual(["op-a", "op-b"]);
+  });
+
+  it("breaks group.order ties by createdAt", () => {
+    const entries = [makeEntry("op-a", "g2"), makeEntry("op-b", "g1")];
+    const g1 = { ...makeGroup("g1", 0), createdAt: 2 };
+    const g2 = { ...makeGroup("g2", 0), createdAt: 1 };
+    const sections = groupOperations(entries, [g1, g2], []);
+    expect(sections.map((s) => s.groupId)).toEqual(["g2", "g1", null]);
+  });
+
+  it("always appends ungrouped section even when empty", () => {
+    const entries = [makeEntry("op-a", "g1")];
+    const groups = [makeGroup("g1", 1)];
+    const sections = groupOperations(entries, groups, []);
+    expect(sections[sections.length - 1]?.groupId).toBeNull();
+    expect(sections[sections.length - 1]?.entries).toHaveLength(0);
+  });
+});
+
+// ── insertIntoSegment ────────────────────────────────────────────────────────────
+
+describe("insertIntoSegment", () => {
+  it("cross-group: sourceId를 대상 segment의 첫 번째 위치(index=0)에 삽입한다", () => {
+    // allIds: [op-a(g1), op-b(g1), op-c(g2), op-d(g2)]
+    // op-e(현재 g1)를 g2 index=0 위치로 이동
+    const allIds = ["op-a", "op-b", "op-c", "op-d", "op-e"];
+    const segmentIds = ["op-c", "op-d"]; // g2 현재 멤버
+    expect(insertIntoSegment(allIds, "op-e", 0, segmentIds)).toEqual([
+      "op-a", "op-b", "op-e", "op-c", "op-d",
+    ]);
+  });
+
+  it("cross-group: sourceId를 대상 segment의 마지막(index=segment.length) 위치에 삽입한다", () => {
+    const allIds = ["op-a", "op-b", "op-c", "op-d", "op-e"];
+    const segmentIds = ["op-c", "op-d"];
+    expect(insertIntoSegment(allIds, "op-e", 2, segmentIds)).toEqual([
+      "op-a", "op-b", "op-c", "op-d", "op-e",
+    ]);
+  });
+
+  it("cross-group: sourceId를 대상 segment의 중간(index=1) 위치에 삽입한다", () => {
+    const allIds = ["op-a", "op-b", "op-c", "op-d", "op-e"];
+    const segmentIds = ["op-c", "op-d"];
+    expect(insertIntoSegment(allIds, "op-e", 1, segmentIds)).toEqual([
+      "op-a", "op-b", "op-c", "op-e", "op-d",
+    ]);
+  });
+
+  it("빈 segment(collapsed 그룹 등)로의 드롭 시 sourceId를 allIds 끝에 추가한다", () => {
+    const allIds = ["op-a", "op-b", "op-c"];
+    expect(insertIntoSegment(allIds, "op-a", 0, [])).toEqual(["op-b", "op-c", "op-a"]);
+  });
+
+  it("dropIndex가 범위를 초과해도 segment 마지막에 안전하게 삽입한다", () => {
+    const allIds = ["op-a", "op-b", "op-c"];
+    const segmentIds = ["op-b", "op-c"];
+    expect(insertIntoSegment(allIds, "op-a", 99, segmentIds)).toEqual(["op-b", "op-c", "op-a"]);
+  });
+
+  it("dropIndex 음수는 0으로 처리해 segment 첫 번째에 삽입한다", () => {
+    const allIds = ["op-a", "op-b", "op-c"];
+    const segmentIds = ["op-b", "op-c"];
+    expect(insertIntoSegment(allIds, "op-a", -5, segmentIds)).toEqual(["op-a", "op-b", "op-c"]);
+  });
+});
+
+// ── reorderWithinSegment (P2-6 드롭 인덱스 보정) ─────────────────────────────────
+
+describe("reorderWithinSegment — downward/upward 보정", () => {
+  it("downward: A→C 앞(index=2)으로 드래그 시 [B,A,C]가 된다", () => {
+    // [A,B,C], source=A(index=0), drop=index 2(C 앞) → 기대 [B,A,C]
+    // 보정: 2 > 0 → 2-1=1, splice(1)=[B,A,C]
+    const result = reorderWithinSegment(["A", "B", "C"], "A", 2, ["A", "B", "C"]);
+    expect(result).toEqual(["B", "A", "C"]);
+  });
+
+  it("downward: A→끝(index=3)으로 드래그 시 [B,C,A]가 된다", () => {
+    // [A,B,C], source=A(index=0), drop=3(끝) → 보정: 3-1=2 → [B,C,A]
+    const result = reorderWithinSegment(["A", "B", "C"], "A", 3, ["A", "B", "C"]);
+    expect(result).toEqual(["B", "C", "A"]);
+  });
+
+  it("upward: C→B 앞(index=1)으로 드래그 시 [A,C,B]가 된다", () => {
+    // [A,B,C], source=C(index=2), drop=1(B 앞) → 보정 없음(1 <= 2) → splice(1)=[A,C,B]
+    const result = reorderWithinSegment(["A", "B", "C"], "C", 1, ["A", "B", "C"]);
+    expect(result).toEqual(["A", "C", "B"]);
+  });
+
+  it("upward: C→A 앞(index=0)으로 드래그 시 [C,A,B]가 된다", () => {
+    const result = reorderWithinSegment(["A", "B", "C"], "C", 0, ["A", "B", "C"]);
+    expect(result).toEqual(["C", "A", "B"]);
+  });
+
+  it("segment 밖 op이 포함된 allIds에서도 segment 내 순서만 변경된다", () => {
+    // allIds: [X, A, B, C, Y], segment=[A,B,C], A→C 앞
+    const result = reorderWithinSegment(["X", "A", "B", "C", "Y"], "A", 2, ["A", "B", "C"]);
+    expect(result).toEqual(["X", "B", "A", "C", "Y"]);
+  });
+});
+
+// ── applyVisibleReorder (P2-7 keyboard 재배치 hidden 보존) ───────────────────────
+
+describe("applyVisibleReorder", () => {
+  it("visible op만 재배치하고 hidden(collapsed) op은 제자리를 유지한다", () => {
+    // currentOrder: [h1, v1, h2, v2, v3]  (h=hidden, v=visible)
+    // visibleOrder: [v1, v2, v3], nextVisibleOrder: [v3, v1, v2]
+    // 기대: [h1, v3, h2, v1, v2]
+    const result = applyVisibleReorder(
+      ["h1", "v1", "h2", "v2", "v3"],
+      ["v1", "v2", "v3"],
+      ["v3", "v1", "v2"],
+    );
+    expect(result).toEqual(["h1", "v3", "h2", "v1", "v2"]);
+  });
+
+  it("hidden op이 없을 때 nextVisibleOrder와 동일하다", () => {
+    const result = applyVisibleReorder(["a", "b", "c"], ["a", "b", "c"], ["c", "a", "b"]);
+    expect(result).toEqual(["c", "a", "b"]);
+  });
+
+  it("visible op이 없을 때 currentOrder를 그대로 반환한다", () => {
+    const result = applyVisibleReorder(["h1", "h2"], [], []);
+    expect(result).toEqual(["h1", "h2"]);
+  });
+
+  it("visible 재배치가 인접하지 않은 hidden op 사이를 올바르게 채운다", () => {
+    // currentOrder: [v1, h1, v2, h2, v3]
+    // visibleOrder: [v1, v2, v3] → nextVisibleOrder: [v2, v3, v1]
+    // 기대: [v2, h1, v3, h2, v1]
+    const result = applyVisibleReorder(
+      ["v1", "h1", "v2", "h2", "v3"],
+      ["v1", "v2", "v3"],
+      ["v2", "v3", "v1"],
+    );
+    expect(result).toEqual(["v2", "h1", "v3", "h2", "v1"]);
+  });
+
+  it("nextVisibleOrder 길이가 visibleOrder와 다르면 currentOrder를 그대로 반환한다(op 손실 방지)", () => {
+    // 길이 불일치 → fallback
+    const currentOrder = ["a", "b", "c", "h1"];
+    const result = applyVisibleReorder(currentOrder, ["a", "b", "c"], ["a", "b"]);
+    expect(result).toEqual(currentOrder);
+  });
+});
+
+// ── moveByTargetIndex (keyboard ArrowDown/Up 전용) ───────────────────────────────
+
+describe("moveByTargetIndex", () => {
+  it("ArrowDown: A(index=0)를 targetIndex=1로 이동 시 [B,A,C]가 된다", () => {
+    // drag reorderIds와 달리 -1 보정이 없으므로 targetIndex=1이 그대로 삽입 위치
+    expect(moveByTargetIndex(["A", "B", "C"], "A", 1)).toEqual(["B", "A", "C"]);
+  });
+
+  it("ArrowDown: A(index=0)를 targetIndex=2로 이동 시 [B,C,A]가 된다", () => {
+    expect(moveByTargetIndex(["A", "B", "C"], "A", 2)).toEqual(["B", "C", "A"]);
+  });
+
+  it("ArrowUp: C(index=2)를 targetIndex=1로 이동 시 [A,C,B]가 된다", () => {
+    expect(moveByTargetIndex(["A", "B", "C"], "C", 1)).toEqual(["A", "C", "B"]);
+  });
+
+  it("ArrowUp: C(index=2)를 targetIndex=0으로 이동 시 [C,A,B]가 된다", () => {
+    expect(moveByTargetIndex(["A", "B", "C"], "C", 0)).toEqual(["C", "A", "B"]);
+  });
+
+  it("경계값: targetIndex가 0이면 맨 앞으로 이동한다", () => {
+    expect(moveByTargetIndex(["A", "B", "C"], "B", 0)).toEqual(["B", "A", "C"]);
+  });
+
+  it("경계값: targetIndex가 배열 끝을 넘으면 맨 뒤로 이동한다", () => {
+    expect(moveByTargetIndex(["A", "B", "C"], "A", 99)).toEqual(["B", "C", "A"]);
+  });
+
+  it("sourceId가 없으면 배열을 그대로 반환한다", () => {
+    expect(moveByTargetIndex(["A", "B", "C"], "X", 1)).toEqual(["A", "B", "C"]);
+  });
+});

--- a/runtime/fleet-console/tests/reduce.test.ts
+++ b/runtime/fleet-console/tests/reduce.test.ts
@@ -50,6 +50,7 @@ function makeConsoleSnap(patch: Partial<ConsoleState> = {}): ConsoleState {
     theaters: [],
     operations: [],
     operationsHydrated: true,
+    groups: [],
     activeTheaterId: null,
     activeOperationId: null,
     operationStatus: {},

--- a/runtime/fleet-console/tests/store-flatten-grouped-order.test.ts
+++ b/runtime/fleet-console/tests/store-flatten-grouped-order.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import { flattenGroupedOrder } from "../core/client/src/store.js";
+import type { OperationGroup, OperationNode } from "../core/client/src/types.js";
+
+function makeOp(id: string, groupId: string | null = null, createdAt = 1): OperationNode {
+  return {
+    id,
+    theaterId: "t1",
+    parentId: null,
+    type: "shell",
+    pluginId: "terminal",
+    title: id,
+    payload: {},
+    geometry: null,
+    groupId,
+    state: {},
+    ts: { createdAt, updatedAt: createdAt },
+  };
+}
+
+function makeGroup(id: string, order: number, createdAt = order): OperationGroup {
+  return { id, name: id, color: "blue", order, theaterId: "t1", createdAt };
+}
+
+describe("flattenGroupedOrder", () => {
+  it("그룹 없이 operationOrder 순서대로 반환한다", () => {
+    const ops = [makeOp("op-a"), makeOp("op-b"), makeOp("op-c")];
+    const result = flattenGroupedOrder(ops, [], ["op-c", "op-a", "op-b"]);
+    expect(result.map((o) => o.id)).toEqual(["op-c", "op-a", "op-b"]);
+  });
+
+  it("그룹 order가 낮은 그룹의 op이 먼저 온다 — operationOrder는 무시한 경우에도", () => {
+    // op-old는 group2 소속이지만 createdAt이 오래됨, op-new는 group1 소속으로 새로 생성
+    // operationOrder: [op-old, op-new] (생성 순)
+    // group1.order=1 < group2.order=2 이므로 group1의 op-new가 먼저 cycling
+    const ops = [makeOp("op-old", "g2", 1), makeOp("op-new", "g1", 2)];
+    const groups = [makeGroup("g1", 1), makeGroup("g2", 2)];
+    const result = flattenGroupedOrder(ops, groups, ["op-old", "op-new"]);
+    expect(result.map((o) => o.id)).toEqual(["op-new", "op-old"]);
+  });
+
+  it("그룹 내부는 operationOrder를 따른다", () => {
+    const ops = [makeOp("op-a", "g1", 1), makeOp("op-b", "g1", 2), makeOp("op-c", "g1", 3)];
+    const groups = [makeGroup("g1", 1)];
+    // operationOrder: c → a → b
+    const result = flattenGroupedOrder(ops, groups, ["op-c", "op-a", "op-b"]);
+    expect(result.map((o) => o.id)).toEqual(["op-c", "op-a", "op-b"]);
+  });
+
+  it("ungrouped는 마지막에 온다", () => {
+    const ops = [makeOp("op-ungrouped", null, 1), makeOp("op-grouped", "g1", 2)];
+    const groups = [makeGroup("g1", 1)];
+    const result = flattenGroupedOrder(ops, groups, []);
+    expect(result.map((o) => o.id)).toEqual(["op-grouped", "op-ungrouped"]);
+  });
+
+  it("존재하지 않는 groupId는 ungrouped로 분류된다", () => {
+    const ops = [makeOp("op-a", "nonexistent", 1), makeOp("op-b", "g1", 2)];
+    const groups = [makeGroup("g1", 1)];
+    const result = flattenGroupedOrder(ops, groups, []);
+    expect(result.map((o) => o.id)).toEqual(["op-b", "op-a"]);
+  });
+
+  it("그룹 order 동점일 때 createdAt으로 순서를 결정한다", () => {
+    const ops = [makeOp("op-a", "g2"), makeOp("op-b", "g1")];
+    const g1 = { ...makeGroup("g1", 0), createdAt: 2 };
+    const g2 = { ...makeGroup("g2", 0), createdAt: 1 };
+    // g2.createdAt=1 < g1.createdAt=2 이므로 g2 먼저
+    const result = flattenGroupedOrder(ops, [g1, g2], []);
+    expect(result.map((o) => o.id)).toEqual(["op-a", "op-b"]);
+  });
+
+  it("그룹이 여러 개일 때 sidebar groupOperations와 동일한 flat 순서를 반환한다", () => {
+    // sidebar: sortedGroups=[g1(order=1), g2(order=2)] → g1엔트리→g2엔트리→ungrouped
+    // operationOrder: [op-z, op-y, op-x, op-w, op-v]
+    const ops = [
+      makeOp("op-z", "g2", 5),  // g2 소속
+      makeOp("op-y", "g1", 4),  // g1 소속
+      makeOp("op-x", null, 3),  // ungrouped
+      makeOp("op-w", "g2", 2),  // g2 소속
+      makeOp("op-v", "g1", 1),  // g1 소속
+    ];
+    const groups = [makeGroup("g1", 1), makeGroup("g2", 2)];
+    const operationOrder = ["op-z", "op-y", "op-x", "op-w", "op-v"];
+    const result = flattenGroupedOrder(ops, groups, operationOrder);
+    // g1: operationOrder 기준 [op-y, op-v], g2: [op-z, op-w], ungrouped: [op-x]
+    expect(result.map((o) => o.id)).toEqual(["op-y", "op-v", "op-z", "op-w", "op-x"]);
+  });
+
+  it("collapsedGroups 지정 시 해당 그룹 멤버를 결과에서 제외한다", () => {
+    const ops = [makeOp("op-a", "g1"), makeOp("op-b", "g2"), makeOp("op-c", null)];
+    const groups = [makeGroup("g1", 1), makeGroup("g2", 2)];
+    // g1이 collapsed → op-a 제외, g2·ungrouped는 포함
+    const result = flattenGroupedOrder(ops, groups, [], ["g1"]);
+    expect(result.map((o) => o.id)).toEqual(["op-b", "op-c"]);
+  });
+
+  it("모든 그룹이 collapsed이면 ungrouped만 반환한다", () => {
+    const ops = [makeOp("op-a", "g1"), makeOp("op-b", "g2"), makeOp("op-c", null)];
+    const groups = [makeGroup("g1", 1), makeGroup("g2", 2)];
+    const result = flattenGroupedOrder(ops, groups, [], ["g1", "g2"]);
+    expect(result.map((o) => o.id)).toEqual(["op-c"]);
+  });
+
+  it("collapsedGroups 빈 배열이면 모든 멤버를 포함한다(기존 동작 보존)", () => {
+    const ops = [makeOp("op-a", "g1"), makeOp("op-b", "g2"), makeOp("op-c", null)];
+    const groups = [makeGroup("g1", 1), makeGroup("g2", 2)];
+    const result = flattenGroupedOrder(ops, groups, [], []);
+    expect(result.map((o) => o.id)).toEqual(["op-a", "op-b", "op-c"]);
+  });
+
+  it("collapsedGroups 생략 시 기본값 빈 배열로 동작한다", () => {
+    const ops = [makeOp("op-a", "g1"), makeOp("op-b", null)];
+    const groups = [makeGroup("g1", 1)];
+    const result = flattenGroupedOrder(ops, groups, []);
+    expect(result.map((o) => o.id)).toEqual(["op-a", "op-b"]);
+  });
+});


### PR DESCRIPTION
## Summary
- 좌측 Operations SideBar에 Operation 그룹(크롬 탭그룹 스타일)을 도입: 그룹 헤더(접기 토글 + 멤버 count), Ungrouped 섹션, 멤버 chip 좌측 그룹색 rail bar.
- **색 채널 3분리**: 그룹색(좌측 rail bar) / accent(chip border) / status(perimeter conic) 가 서로 독립 — 한 chip에 동시 표시되어도 충돌 없음.
- 통합 우클릭 오버레이(전역 최상위): chip 우클릭 = 그룹 가감 / 새 그룹 생성 / Accent, 그룹 헤더 우클릭 = 색 변경 / Rename / Ungroup all. 드래그로 그룹 가입·탈퇴, rail/list/detail 3-tier 적응.
- 그룹 정의와 멤버십(groupId)은 서버 durable 영속(v2 optional field, backward-compat), 접기 상태와 순서는 localStorage.

## Test Plan
- [x] `typecheck` / `test` (422 passed) / `build` green
- [x] console-e2e (격리 인스턴스, headed): 그룹 렌더, 색 채널 3분리(accent border + group rail 동시), 통합 우클릭 메뉴, 접기 토글, 3-tier, Carbon Dark, 재시작 서버 영속 PASS
- [x] `.changelog.d/operation-groups.md` (ASCII, `[fleet-console]`)