### PR TITLE
feat(fleet-console): tab group edge rail and header fill

### DIFF
--- a/.changelog.d/tab-group-edge-rail.md
+++ b/.changelog.d/tab-group-edge-rail.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- [fleet-console] Operation groups in the Operations left sidebar are now marked by a continuous colored rail down the group's left edge and a tinted group header, replacing the small per-entry color stub, so a group reads as one bounded run at a glance.

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -29,7 +29,6 @@ interface SideBarChipProps {
   readonly onPointerDragMove: (event: ReactPointerEvent<HTMLLIElement>) => void;
   readonly onPointerDragEnd: (event: ReactPointerEvent<HTMLLIElement>) => void;
   readonly onPointerDragCancel: (event: ReactPointerEvent<HTMLLIElement>) => void;
-  readonly grpColor?: string | null;
   readonly onOpenAccent: (operationId: string, anchor: DOMRect) => void;
   readonly onRename: (operationId: string, title: string) => void;
 }
@@ -51,7 +50,6 @@ export function OperationsSideBarChip({
   onPointerDragMove,
   onPointerDragEnd,
   onPointerDragCancel,
-  grpColor,
   onOpenAccent,
   onRename,
 }: SideBarChipProps) {
@@ -70,7 +68,6 @@ export function OperationsSideBarChip({
   const chipStyle = {
     "--i": index,
     ...(accentValue ? { "--chip-accent": accentValue } : {}),
-    ...(grpColor ? { "--grp-color": grpColor } : {}),
     ...(dragging ? { "--drag-dy": `${Math.round(dragOffsetY)}px` } : {}),
   } as CSSProperties;
 
@@ -145,7 +142,6 @@ export function OperationsSideBarChip({
       onPointerUpCapture={(event) => onPointerDragEnd(event)}
       onPointerCancelCapture={(event) => onPointerDragCancel(event)}
     >
-      {grpColor ? <div className="side-bar-chip__rail" aria-hidden="true" /> : null}
       <span className="side-bar-chip-beacon-button" aria-hidden="true">
         <span className="side-bar-chip-op-icon">
           {entry.icon ?? <DefaultOpIcon />}

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -373,8 +373,10 @@ export function OperationsSideBar({
       <ol className="operations-side-bar-chips" ref={chipsRef} aria-label="Operations">
         {groupedSections.map((section) => {
           const isCollapsed = section.groupId !== null && collapsedGroupSet.has(section.groupId);
+          const grpColor = section.group ? resolveAccentColor(section.group.color) : null;
+          const sectionStyle = grpColor ? ({ "--grp-color": grpColor } as CSSProperties) : undefined;
           return (
-            <li key={section.groupId ?? "__ungrouped__"} data-drop-zone-group-id={section.groupId ?? "__ungrouped__"} className={section.groupId ? "side-bar-group-section" : "side-bar-ungrouped-section"}>
+            <li key={section.groupId ?? "__ungrouped__"} data-drop-zone-group-id={section.groupId ?? "__ungrouped__"} className={section.groupId ? "side-bar-group-section" : "side-bar-ungrouped-section"} style={sectionStyle}>
               {section.group ? (
                 <OperationsSideBarGroupHeader
                   group={section.group}
@@ -405,7 +407,6 @@ export function OperationsSideBar({
                     const sectionLocalIndex = section.entries.indexOf(entry);
                     const accentKey = canvas.operationAccent[entry.operation.id] ?? operationAccentFromNode(entry.operation);
                     const accentValue = accentKey ? resolveAccentColor(accentKey) : null;
-                    const grpColor = section.group ? resolveAccentColor(section.group.color) : null;
                     return (
                       <OperationsSideBarChip
                         key={entry.operation.id}
@@ -413,7 +414,6 @@ export function OperationsSideBar({
                         index={globalIndex}
                         isCloseArmed={armedCloseId === entry.operation.id}
                         accentValue={accentValue}
-                        grpColor={grpColor}
                         dragging={drag?.sourceId === entry.operation.id && drag.dragging}
                         dragOffsetY={drag?.sourceId === entry.operation.id && drag.dragging ? drag.currentY - drag.startY : 0}
                         dropTarget={

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3687,33 +3687,28 @@
 }
 
 
-/* ── Group Rail Bar (--grp-color 채널 전용 — chip ::before perimeter와 독립) ───── */
-
-.side-bar-chip__rail {
-  position: absolute;
-  left: 0;
-  top: 4px;
-  bottom: 4px;
-  width: 3px;
-  border-radius: 2px;
-  background: var(--grp-color, transparent);
-  flex: none;
-  pointer-events: none;
-}
-
-/* rail tier에서도 바는 그대로 표시 (아이콘 왼쪽) */
-.operations-side-bar[data-tier="rail"] .side-bar-chip__rail {
-  top: 3px;
-  bottom: 3px;
-}
-
 /* ── Group Section Layout ──────────────────────────────────────────────────────── */
 
-.side-bar-group-section,
 .side-bar-ungrouped-section {
   list-style: none;
   display: flex;
   flex-direction: column;
+}
+
+/* 연속 좌측 레일 — group section 전체 관통 (ungrouped 제외) */
+.side-bar-group-section {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  margin-left: var(--space-1);
+  padding-left: var(--space-1);
+  border-left: 3px solid var(--grp-color, transparent);
+}
+
+/* rail tier에서는 56px 폭 제약 때문에 좌측 offset 최소화 */
+.operations-side-bar[data-tier="rail"] .side-bar-group-section {
+  margin-left: 0;
+  padding-left: 2px;
 }
 
 .side-bar-group-chips {
@@ -3732,9 +3727,10 @@
   align-items: center;
   gap: var(--space-1);
   padding: 4px var(--space-1) 4px var(--space-2);
-  margin: 2px var(--space-1) 0;
+  margin: 2px var(--space-1) 0 0;
   border-radius: var(--radius-md);
   user-select: none;
+  background: color-mix(in oklch, var(--grp-color, transparent) 14%, transparent);
 }
 
 .side-bar-group-header__toggle {
@@ -3747,7 +3743,7 @@
   background: transparent;
   border: none;
   cursor: pointer;
-  color: var(--ink-fog);
+  color: var(--grp-color, var(--ink-fog));
   border-radius: var(--radius-sm);
   transition: color var(--duration-fast) var(--ease-spring);
 }
@@ -3784,7 +3780,7 @@
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--grp-color, var(--ink-fog));
+  color: color-mix(in oklch, var(--grp-color, var(--ink-fog)) 92%, var(--ink-pearl));
 }
 
 .side-bar-group-header__count {


### PR DESCRIPTION
## Summary
- 좌측 Operations SideBar의 Operation 그룹 시인성을 개선합니다. 그룹 컬러가 기존엔 헤더 텍스트 + 칩마다의 짧은 좌측 stub으로만 보여 그룹이 '점·선'처럼 흩어져 읽혔습니다.
- per-chip 좌측 컬러 stub을 제거하고, 그룹 섹션 전체를 관통하는 **연속 좌측 직선 레일(3px)** + **그룹 헤더 컬러 fill(14%)**로 전환해 그룹을 하나의 경계 있는 영역으로 인지하게 합니다.
- 그룹 컬러(`--grp-color`)는 자체 채널을 유지합니다 — brass(active)·aurora(status/count)·user-accent(1px ring) 시그널 채널을 침범하지 않으며, 모든 색은 `color-mix(var(--grp-color))`로 Maritime·Carbon 양 테마에 자동 적응합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` / `build` / `test` (48 files, 469 passed | 23 skipped) — green
- [x] Sentinel console-e2e 헤드 브라우저 QA: detail/rail tier, Maritime/Carbon, per-chip stub 제거, 시그널 채널 공존 — 전부 PASS (Critical/High 0)
- [x] `oklch([0-9` 하드코딩 0건, theme.css 불변
- [x] changelog fragment 포함 (`.changelog.d/tab-group-edge-rail.md`, Changed)