### PR TITLE
fix(fleet-console): decouple radar sweep from panel pulse toggle

### DIFF
--- a/.changelog.d/radar-sweep-panel-pulse-decoupling.md
+++ b/.changelog.d/radar-sweep-panel-pulse-decoupling.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- [fleet-console] The Operations canvas radar sweep now animates whenever Radar sweep is enabled, no longer requiring Panel pulse to be on; Panel pulse independently controls the remaining ambient animations.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3228,7 +3228,6 @@
   animation: perimeter-orbit 2.4s linear infinite;
 }
 
-.operations-canvas.is-perimeter-anim-off .operations-radar-sweep,
 .operations-canvas.is-perimeter-anim-off .canvas-operation.is-running::before,
 .operations-canvas.is-perimeter-anim-off .status-dot--live,
 .operations-canvas.is-perimeter-anim-off .tenant-beacon.is-awaiting,


### PR DESCRIPTION
## Summary
- Panel pulse 토글을 끄면(`.operations-canvas.is-perimeter-anim-off`) radar sweep 애니메이션까지 함께 멈춰, 좌측 사이드바에서 Radar sweep만 켜도 레이더는 표시되지만 회전 애니메이션이 작동하지 않던 문제를 수정합니다.
- `.operations-radar-sweep`를 `is-perimeter-anim-off` 셀렉터 그룹에서 분리하여, radar sweep은 Radar sweep 토글에만 종속되도록 했습니다. Panel pulse는 그 외 애니메이션(running perimeter, live status dot, awaiting beacon, job summary dot, tool chip)만 제어합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` (green)
- [x] console-e2e (headed): Radar sweep ON + Panel pulse OFF -> `.operations-radar-sweep` animationName=`radar-sweep`, playState=`running`, duration=`18s`
- [x] 회귀: CSSOM상 나머지 5개 perimeter 대상 셀렉터 유지(radar-sweep만 분리), Radar sweep OFF 시 radar div 미렌더 확인
- [x] Changelog fragment 포함 (`.changelog.d/radar-sweep-panel-pulse-decoupling.md`, section: Fixed)