### PR TITLE
feat(fleet-console): right-click SideBar empty area to open launcher

### DIFF
--- a/.changelog.d/sidebar-empty-area-launcher.md
+++ b/.changelog.d/sidebar-empty-area-launcher.md
@@ -1,0 +1,4 @@
+---
+section: Added
+---
+- [fleet-console] Right-click an empty area of the left Operations SideBar to open the New Operation launcher at the cursor, the same overlay as the New Operation button.

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -282,6 +282,20 @@ export function OperationsSideBar({
     });
   };
 
+  // 사이드바 빈 영역 우클릭 = ＋New 버튼과 동일한 launch 오버레이를 커서 위치에 연다.
+  // chip/그룹 헤더는 자체 우클릭 핸들러가 preventDefault()를 호출하므로(버블로 도달 시
+  // defaultPrevented=true), 그쪽 우클릭은 accent/그룹 메뉴를 유지하고 여기서는 무시한다.
+  const openNewMenuAtCursor = (event: React.MouseEvent<HTMLElement>) => {
+    if (event.defaultPrevented) return;
+    event.preventDefault();
+    setSettingsMenu(null);
+    setActiveContextMenu(null);
+    setNewMenu({
+      anchor: { x: event.clientX, y: event.clientY },
+      viewportBounds: { width: window.innerWidth, height: window.innerHeight },
+    });
+  };
+
   const openSettingsMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (settingsMenu) {
       setSettingsMenu(null);
@@ -304,6 +318,7 @@ export function OperationsSideBar({
         data-tier={tier}
         data-canvas-blocker
         style={{ "--side-bar-width": `${displayWidth}px` } as CSSProperties}
+        onContextMenu={openNewMenuAtCursor}
       >
         <header className="operations-side-bar-header">
           <button
@@ -343,6 +358,7 @@ export function OperationsSideBar({
       data-tier={tier}
       data-canvas-blocker
       style={{ "--side-bar-width": `${displayWidth}px` } as CSSProperties}
+      onContextMenu={openNewMenuAtCursor}
     >
       <header className="operations-side-bar-header">
         <button


### PR DESCRIPTION
## Summary
- 좌측 Operations Left SideBar의 빈 영역에서 우클릭하면, New Operation(＋New) 버튼을 눌렀을 때와 동일한 launch 오버레이가 커서 위치에 노출됩니다.
- chip/그룹 헤더 우클릭은 기존 accent/그룹 컨텍스트 메뉴를 그대로 유지합니다 (`event.defaultPrevented` 버블 가드로 충돌 방지).
- `<aside class="operations-side-bar">`의 두 렌더 경로(빈 rail early-return + 메인)에 동일한 `onContextMenu` 핸들러를 연결했습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — green (exit 0)
- [x] `pnpm --filter @dotobokuri/fleet-console build` — green (exit 0)
- [x] console-e2e headed QA (Sentinel): 빈 영역 우클릭 런처 노출(＋New와 class/text 일치), 뷰포트 4방향 clamp, chip 우클릭 accent 회귀 없음, ＋New 토글·Settings 동작, 콘솔 에러 0 — 전 항목 PASS
- [x] Changelog fragment 포함 (`.changelog.d/sidebar-empty-area-launcher.md`, `section: Added`)