### PR TITLE
feat(fleet-console): persist Settings General to console settings.json

### DIFF
--- a/.changelog.d/console-settings-general-server-persist.md
+++ b/.changelog.d/console-settings-general-server-persist.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- [fleet-console] Console Settings General (theme and console port) is now persisted server-side in the console data directory; the selected theme is shared across browsers and survives restarts instead of being remembered only per browser.

--- a/packages/fleet-infra/src/global-options/store.ts
+++ b/packages/fleet-infra/src/global-options/store.ts
@@ -16,8 +16,6 @@ const GLOBAL_OPTIONS_FILE_NAME = "settings.json";
 const LOCK_DIR_NAME = "settings.json.lock";
 const LOCK_OWNER_FILE_NAME = "owner";
 const TEMP_FILE_PREFIX = `.tmp-${GLOBAL_OPTIONS_FILE_NAME}-`;
-const MIN_CONSOLE_STATIC_PORT = 1024;
-const MAX_CONSOLE_STATIC_PORT = 65535;
 
 export function createGlobalOptionsStore(deps: CreateGlobalOptionsStoreDeps = {}): GlobalOptionsStore {
   const dataDir = deps.dataDir ?? getFleetDataDir();
@@ -63,23 +61,15 @@ export function sanitizeGlobalOptionsData(value: unknown): GlobalOptionsValidati
     version: GLOBAL_OPTIONS_VERSION,
     ...(typeof value.replaceSystemPrompt === "boolean" ? { replaceSystemPrompt: value.replaceSystemPrompt } : {}),
     ...(typeof value.enableMetaphor === "boolean" ? { enableMetaphor: value.enableMetaphor } : {}),
-    ...(value.consolePortMode === "dynamic" || value.consolePortMode === "static" ? { consolePortMode: value.consolePortMode } : {}),
-    ...(isValidConsoleStaticPort(value.consoleStaticPort) ? { consoleStaticPort: value.consoleStaticPort } : {}),
   };
-  const allowedKeys = new Set(["version", "replaceSystemPrompt", "enableMetaphor", "consolePortMode", "consoleStaticPort"]);
+  const allowedKeys = new Set(["version", "replaceSystemPrompt", "enableMetaphor"]);
   const changed = Object.keys(value).some((key) => !allowedKeys.has(key)) ||
     ("replaceSystemPrompt" in value && typeof value.replaceSystemPrompt !== "boolean") ||
-    ("enableMetaphor" in value && typeof value.enableMetaphor !== "boolean") ||
-    ("consolePortMode" in value && value.consolePortMode !== "dynamic" && value.consolePortMode !== "static") ||
-    ("consoleStaticPort" in value && !isValidConsoleStaticPort(value.consoleStaticPort));
+    ("enableMetaphor" in value && typeof value.enableMetaphor !== "boolean");
 
   return { data, changed };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isValidConsoleStaticPort(value: unknown): value is number {
-  return typeof value === "number" && Number.isInteger(value) && value >= MIN_CONSOLE_STATIC_PORT && value <= MAX_CONSOLE_STATIC_PORT;
 }

--- a/packages/fleet-infra/src/global-options/types.ts
+++ b/packages/fleet-infra/src/global-options/types.ts
@@ -2,8 +2,6 @@ export interface GlobalOptionsData {
   readonly version: 1;
   readonly replaceSystemPrompt?: boolean;
   readonly enableMetaphor?: boolean;
-  readonly consolePortMode?: "dynamic" | "static";
-  readonly consoleStaticPort?: number;
 }
 
 export interface GlobalOptionsValidationResult {

--- a/packages/fleet-infra/tests/global-options-store.test.ts
+++ b/packages/fleet-infra/tests/global-options-store.test.ts
@@ -63,6 +63,8 @@ describe("global options store", () => {
       [["cursor", "Sync"].join("")]: false,
       [["default", "CliId"].join("")]: "claude",
       model: "opus",
+      consolePortMode: "static",
+      consoleStaticPort: 8080,
     })).toEqual({
       changed: true,
       data: {
@@ -116,6 +118,23 @@ describe("global options store", () => {
       enableMetaphor: false,
     });
     expect(fs.readdirSync(dataDir).filter((name) => name.startsWith(".tmp-settings.json"))).toEqual([]);
+  });
+
+  it("sanitizes stale console port fields that migrated to console-settings store", () => {
+    expect(sanitizeGlobalOptionsData({
+      version: 1,
+      replaceSystemPrompt: true,
+      enableMetaphor: false,
+      consolePortMode: "static",
+      consoleStaticPort: 8080,
+    })).toEqual({
+      changed: true,
+      data: {
+        version: 1,
+        replaceSystemPrompt: true,
+        enableMetaphor: false,
+      },
+    });
   });
 
   it("recovers stale locks and times out on fresh locks", () => {

--- a/runtime/fleet-console/core/client/src/global-settings-api.ts
+++ b/runtime/fleet-console/core/client/src/global-settings-api.ts
@@ -40,12 +40,14 @@ function assertGlobalSettingsState(value: unknown, status: number): GlobalSettin
     !payload
     || (payload.consolePortMode !== "dynamic" && payload.consolePortMode !== "static")
     || (payload.consoleStaticPort !== null && !isValidConsoleStaticPort(payload.consoleStaticPort))
+    || (payload.theme !== "maritime" && payload.theme !== "carbon")
   ) {
     throw new ApiError(status, "Invalid global settings state response");
   }
   return {
     consolePortMode: payload.consolePortMode,
     consoleStaticPort: payload.consoleStaticPort,
+    theme: payload.theme,
   };
 }
 

--- a/runtime/fleet-console/core/client/src/main.tsx
+++ b/runtime/fleet-console/core/client/src/main.tsx
@@ -20,8 +20,9 @@ import "./styles/theme.css";
 import "./styles/layout.css";
 import "./styles/components.css";
 import { App } from "./app.js";
+import { fetchGlobalSettingsState } from "./global-settings-api.js";
 import { loadPluginRegistry, PluginRegistryProvider } from "./plugin-registry.js";
-import { initThemeFromStorage } from "./store.js";
+import { setActiveTheme } from "./store.js";
 
 interface FleetConsoleRuntime {
   readonly "react": typeof reactNs;
@@ -47,7 +48,12 @@ globalThis.__fleetConsoleRuntime__ = {
   "@fleet-console/sdk/react/browser": sdkReactBrowser,
 };
 
-initThemeFromStorage();
+try {
+  const settings = await fetchGlobalSettingsState();
+  setActiveTheme(settings.theme);
+} catch {
+  // 서버 미응답 시 DEFAULT_THEME 유지
+}
 
 const registry = await loadPluginRegistry();
 const app = document.querySelector("#app");

--- a/runtime/fleet-console/core/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/core/client/src/pages/global-settings.tsx
@@ -197,7 +197,7 @@ function ThemeCard() {
       <div className="global-settings-row">
         <div className="global-settings-row-text">
           <p className="global-settings-resp-title">Theme</p>
-          <p className="global-settings-help">Console color scheme. Applies immediately and is remembered on this browser.</p>
+          <p className="global-settings-help">Console color scheme. Applies immediately and is saved server-side.</p>
         </div>
         {/* role="group" + aria-pressed — 단일선택 패턴. 선택 = brass(지금 보고 있는 곳). */}
         <div className="theme-picker" role="group" aria-label="Theme">
@@ -209,7 +209,7 @@ function ThemeCard() {
                 type="button"
                 aria-pressed={isActive}
                 className={`theme-card ${isActive ? "is-active" : ""}`}
-                onClick={() => setActiveTheme(theme.id)}
+                onClick={() => { setActiveTheme(theme.id); void setGlobalSettingsField("theme", theme.id); }}
               >
                 <span className="theme-card-swatch" aria-hidden="true">
                   {theme.swatch.map((color) => <i key={color} style={{ background: color }} />)}
@@ -221,7 +221,7 @@ function ThemeCard() {
           })}
         </div>
       </div>
-      <p className="global-settings-foot">Theme applies immediately and is stored per browser.</p>
+      <p className="global-settings-foot">Theme applies immediately and is stored server-side.</p>
     </section>
   );
 }

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -21,7 +21,6 @@ import type {
 type Listener = () => void;
 
 const ACTIVE_THEATER_STORAGE_KEY = "fleet-console.activeTheaterId";
-const THEME_STORAGE_KEY = "fleet-console.activeTheme";
 const COMMISSIONING_SEEN_STORAGE_KEY = "fleet-console.commissioningSeen";
 const WHATS_NEW_SEEN_VERSION_STORAGE_KEY = "fleet-console.whatsNewSeenVersion";
 const NOTIFICATION_PREFERENCES_STORAGE_KEY = "fleet-console.notificationPreferences";
@@ -41,7 +40,7 @@ let whatsNewSeenVersionMemo: string | null = null;
 let state: ConsoleState = {
   connection: "connecting",
   connectionError: null,
-  activeTheme: readStoredTheme(),
+  activeTheme: DEFAULT_THEME,
   version: "",
   updateAvailable: false,
   latestVersion: null,
@@ -99,12 +98,7 @@ export function setOperationsViewActive(active: boolean): void {
   setState({ operationsViewActive: active });
 }
 
-export function initThemeFromStorage(): void {
-  applyThemeToDocument(readStoredTheme());
-}
-
 export function setActiveTheme(theme: ThemeId): void {
-  writeStoredTheme(theme);
   applyThemeToDocument(theme);
   setState({ activeTheme: theme });
 }
@@ -544,16 +538,6 @@ function writeStoredActiveTheaterId(theaterId: string | null): void {
   }
 }
 
-function readStoredTheme(): ThemeId {
-  if (typeof window === "undefined") return DEFAULT_THEME;
-  try {
-    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
-    return stored === "maritime" || stored === "carbon" ? stored : DEFAULT_THEME;
-  } catch {
-    return DEFAULT_THEME;
-  }
-}
-
 function readStoredNotificationPreferences(): NotificationPreferences {
   if (typeof window === "undefined") return DEFAULT_NOTIFICATION_PREFERENCES;
   try {
@@ -620,15 +604,6 @@ function writeStoredNotificationPreferences(preferences: NotificationPreferences
       version: NOTIFICATION_PREFERENCES_VERSION,
       preferences,
     }));
-  } catch {
-    // 저장소가 막힌 환경에서는 현재 세션 상태만 유지한다.
-  }
-}
-
-function writeStoredTheme(theme: ThemeId): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
   } catch {
     // 저장소가 막힌 환경에서는 현재 세션 상태만 유지한다.
   }

--- a/runtime/fleet-console/core/client/src/types.ts
+++ b/runtime/fleet-console/core/client/src/types.ts
@@ -162,6 +162,7 @@ export interface CarrierSettingsMutationResult {
 export interface GlobalSettingsState {
   readonly consolePortMode: "dynamic" | "static";
   readonly consoleStaticPort: number | null;
+  readonly theme: ThemeId;
 }
 
 export interface GlobalSettingsMutationResult {

--- a/runtime/fleet-console/core/host/console-settings.ts
+++ b/runtime/fleet-console/core/host/console-settings.ts
@@ -1,0 +1,89 @@
+import path from "node:path";
+
+import {
+  createDurableJsonStore,
+  type CreateDurableJsonStoreDeps,
+  type DurableJsonStore,
+} from "@dotobokuri/fleet-infra";
+
+import { createConsoleDataPaths, type ConsoleDataPaths } from "./paths.js";
+
+export type ConsoleThemeId = "maritime" | "carbon";
+
+export interface ConsoleGeneralSettings {
+  readonly consolePortMode?: "dynamic" | "static";
+  readonly consoleStaticPort?: number;
+  readonly theme?: ConsoleThemeId;
+}
+
+export interface ConsoleSettingsData {
+  readonly version: 1;
+  readonly general?: ConsoleGeneralSettings;
+}
+
+export interface CreateConsoleSettingsStoreDeps {
+  readonly paths?: ConsoleDataPaths;
+  readonly createStore?: (deps: CreateDurableJsonStoreDeps<ConsoleSettingsData>) => DurableJsonStore<ConsoleSettingsData>;
+  readonly now?: () => number;
+}
+
+const SETTINGS_VERSION = 1;
+const SETTINGS_LOCK_DIR_NAME = "settings.lock";
+const SETTINGS_LOCK_OWNER_FILE_NAME = "owner.json";
+const SETTINGS_TEMP_PREFIX = ".settings.";
+const MIN_CONSOLE_STATIC_PORT = 1024;
+const MAX_CONSOLE_STATIC_PORT = 65535;
+
+export function createConsoleSettingsStore(deps: CreateConsoleSettingsStoreDeps = {}): DurableJsonStore<ConsoleSettingsData> {
+  const paths = deps.paths ?? createConsoleDataPaths();
+  const createStore = deps.createStore ?? createDurableJsonStore;
+  return createStore({
+    filePath: paths.settingsFile,
+    lockDir: path.join(paths.dir, SETTINGS_LOCK_DIR_NAME),
+    lockOwnerFileName: SETTINGS_LOCK_OWNER_FILE_NAME,
+    now: deps.now,
+    sanitize: sanitizeConsoleSettingsData,
+    sensitivity: "sensitive",
+    tempCleanupPrefix: SETTINGS_TEMP_PREFIX,
+  });
+}
+
+export function sanitizeConsoleSettingsData(value: unknown): ConsoleSettingsData {
+  if (!isRecord(value)) return emptyConsoleSettingsData();
+  if (value.version !== SETTINGS_VERSION) return emptyConsoleSettingsData();
+  const general = readConsoleGeneralSettings(value.general);
+  return {
+    version: SETTINGS_VERSION,
+    general: general ?? {},
+  };
+}
+
+export function emptyConsoleSettingsData(): ConsoleSettingsData {
+  return { version: 1, general: {} };
+}
+
+function readConsoleGeneralSettings(value: unknown): ConsoleGeneralSettings | null {
+  if (!isRecord(value)) return null;
+  const consolePortMode = value.consolePortMode === "dynamic" || value.consolePortMode === "static"
+    ? value.consolePortMode
+    : undefined;
+  const consoleStaticPort = isValidConsoleStaticPort(value.consoleStaticPort)
+    ? value.consoleStaticPort
+    : undefined;
+  const theme = value.theme === "maritime" || value.theme === "carbon"
+    ? value.theme
+    : undefined;
+  return {
+    ...(consolePortMode !== undefined ? { consolePortMode } : {}),
+    ...(consoleStaticPort !== undefined ? { consoleStaticPort } : {}),
+    ...(theme !== undefined ? { theme } : {}),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isValidConsoleStaticPort(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= MIN_CONSOLE_STATIC_PORT && value <= MAX_CONSOLE_STATIC_PORT;
+}

--- a/runtime/fleet-console/core/host/global-settings-routes.ts
+++ b/runtime/fleet-console/core/host/global-settings-routes.ts
@@ -1,12 +1,13 @@
 import type http from "node:http";
 
-import type { GlobalOptionsData, GlobalOptionsService } from "@dotobokuri/fleet-infra";
+import type { DurableJsonStore } from "@dotobokuri/fleet-infra";
 
 import type { ApiCatalogEntry } from "./api-catalog.js";
+import type { ConsoleSettingsData } from "./console-settings.js";
 import type { GlobalSettingsMutationResult, GlobalSettingsState } from "./global-settings-types.js";
 
 interface GlobalSettingsRouteDeps {
-  readonly globalOptionsService: GlobalOptionsService;
+  readonly consoleSettingsStore: DurableJsonStore<ConsoleSettingsData>;
   readonly isAuthorized: (req: http.IncomingMessage) => boolean;
   readonly readJsonBody: <T>(req: http.IncomingMessage) => Promise<T | null>;
   readonly writeJson: (res: http.ServerResponse, status: number, body: unknown) => void;
@@ -21,6 +22,7 @@ interface GlobalSettingsRouteContext {
 interface GlobalSettingsBody {
   readonly consolePortMode?: unknown;
   readonly consoleStaticPort?: unknown;
+  readonly theme?: unknown;
 }
 
 const MIN_CONSOLE_STATIC_PORT = 1024;
@@ -48,7 +50,7 @@ export function createGlobalSettingsRouter(deps: GlobalSettingsRouteDeps): (cont
     const { req, res, pathname } = context;
     if (pathname === "/api/v1/settings/global") {
       if (req.method === "GET") {
-        deps.writeJson(res, 200, buildGlobalSettingsState(deps.globalOptionsService));
+        deps.writeJson(res, 200, buildGlobalSettingsState(deps.consoleSettingsStore));
         return true;
       }
       if (req.method === "PUT") {
@@ -62,8 +64,8 @@ export function createGlobalSettingsRouter(deps: GlobalSettingsRouteDeps): (cont
   };
 }
 
-export function buildGlobalSettingsState(service: GlobalOptionsService): GlobalSettingsState {
-  return toGlobalSettingsState(service.load());
+export function buildGlobalSettingsState(store: DurableJsonStore<ConsoleSettingsData>): GlobalSettingsState {
+  return toGlobalSettingsState(store.load());
 }
 
 async function mutateGlobalSettings(
@@ -92,19 +94,29 @@ async function mutateGlobalSettings(
     deps.writeJson(res, 400, { error: "invalid_console_static_port" });
     return;
   }
-  const updated = deps.globalOptionsService.update((current) => ({
-    ...current,
-    ...(body.consolePortMode === "dynamic" || body.consolePortMode === "static" ? { consolePortMode: body.consolePortMode } : {}),
-    ...(isValidConsoleStaticPort(body.consoleStaticPort) ? { consoleStaticPort: body.consoleStaticPort } : {}),
+  if (body.theme !== undefined && body.theme !== "maritime" && body.theme !== "carbon") {
+    deps.writeJson(res, 400, { error: "invalid_theme" });
+    return;
+  }
+  const updated = deps.consoleSettingsStore.update((current) => ({
+    version: 1,
+    general: {
+      ...current.general,
+      ...(body.consolePortMode === "dynamic" || body.consolePortMode === "static" ? { consolePortMode: body.consolePortMode } : {}),
+      ...(isValidConsoleStaticPort(body.consoleStaticPort) ? { consoleStaticPort: body.consoleStaticPort } : {}),
+      ...(body.theme === "maritime" || body.theme === "carbon" ? { theme: body.theme } : {}),
+    },
   }));
   const response: GlobalSettingsMutationResult = { state: toGlobalSettingsState(updated) };
   deps.writeJson(res, 200, response);
 }
 
-function toGlobalSettingsState(data: GlobalOptionsData): GlobalSettingsState {
+function toGlobalSettingsState(data: ConsoleSettingsData): GlobalSettingsState {
+  const general = data.general ?? {};
   return {
-    consolePortMode: data.consolePortMode ?? "dynamic",
-    consoleStaticPort: data.consoleStaticPort ?? null,
+    consolePortMode: general.consolePortMode ?? "dynamic",
+    consoleStaticPort: general.consoleStaticPort ?? null,
+    theme: general.theme ?? "maritime",
   };
 }
 

--- a/runtime/fleet-console/core/host/global-settings-types.ts
+++ b/runtime/fleet-console/core/host/global-settings-types.ts
@@ -1,9 +1,10 @@
-// 브라우저로 나가는 전역 옵션 DTO. fleet-infra의 GlobalOptionsData에서 내부 격리 키(version)를
-// 제외하고, 브라우저에 안전한 General 설정만 표면화한다.
+// 브라우저로 나가는 General 설정 DTO. console-settings.ts의 ConsoleSettingsData에서
+// 내부 격리 키(version)를 제외하고 flat으로 변환해 표면화한다.
 
 export interface GlobalSettingsState {
   readonly consolePortMode: "dynamic" | "static";
   readonly consoleStaticPort: number | null;
+  readonly theme: "maritime" | "carbon";
 }
 
 export interface GlobalSettingsMutationResult {

--- a/runtime/fleet-console/core/host/paths.ts
+++ b/runtime/fleet-console/core/host/paths.ts
@@ -14,6 +14,7 @@ export interface ConsoleDataPaths {
   readonly dir: string;
   readonly stateFile: string;
   readonly capturesDir: string;
+  readonly settingsFile: string;
 }
 
 export interface CreateConsolePathsDeps {
@@ -35,6 +36,7 @@ const CONSOLE_RUNTIME_DIR_NAME = "console";
 const LOCK_FILE_NAME = "console.lock";
 const CONSOLE_DATA_DIR_NAME = "console";
 const CONSOLE_STATE_FILE_NAME = "state.json";
+const CONSOLE_SETTINGS_FILE_NAME = "settings.json";
 const CONSOLE_CAPTURES_DIR_NAME = "captures";
 
 export function createConsolePaths(deps: CreateConsolePathsDeps = {}): ConsolePaths {
@@ -49,6 +51,7 @@ export function createConsoleDataPaths(deps: CreateConsoleDataPathsDeps = {}): C
   return {
     dir,
     stateFile: path.join(dir, CONSOLE_STATE_FILE_NAME),
+    settingsFile: path.join(dir, CONSOLE_SETTINGS_FILE_NAME),
     capturesDir: path.join(dir, CONSOLE_CAPTURES_DIR_NAME),
   };
 }

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -14,6 +14,7 @@ import { buildApiCatalog, type ApiCatalogEntry } from "./api-catalog.js";
 import type { ConsoleHealth, ConsoleObserverStatus, ConsoleTheaterFolderListResponse, ConsoleTheaterInfo, ConsoleUpdateApplyAcceptedResponse } from "./api-types.js";
 import { createCarrierSettingsRouter } from "./carrier-settings-routes.js";
 import { createCodexGateway } from "./codex/gateway.js";
+import { createConsoleSettingsStore } from "./console-settings.js";
 import { createConsoleDurableStateStore, emptyDurableConsoleState, type DurableConsoleState } from "./durable-state.js";
 import { createGlobalSettingsRouter } from "./global-settings-routes.js";
 import { createConsoleLock, type ConsoleLockHandle } from "./lock.js";
@@ -239,6 +240,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   // channel은 createConsoleDataPaths가 release SSoT로 자체 감지한다(hook 서브프로세스·fallback과 동일 경로).
   const durablePaths = createConsoleDataPaths({ fleetDataDir: deps.dataDir });
   const durableStateStore = createConsoleDurableStateStore({ paths: durablePaths });
+  const consoleSettingsStore = createConsoleSettingsStore({ paths: durablePaths });
   const codex = createCodexGateway({
     cwd: deps.codexCwd ?? process.cwd(),
     host,
@@ -400,7 +402,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     writeJson,
   });
   const globalSettingsRouter = createGlobalSettingsRouter({
-    globalOptionsService: infraServices.globalOptionsService,
+    consoleSettingsStore,
     isAuthorized: isTerminalAuthorized,
     readJsonBody,
     writeJson,
@@ -952,7 +954,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
         allowFallback: false,
       };
     }
-    const options = infraServices.globalOptionsService.load();
+    const options = consoleSettingsStore.load().general ?? {};
     if (options.consolePortMode === "static" && isValidConsoleStaticPort(options.consoleStaticPort)) {
       return {
         port: options.consoleStaticPort,

--- a/runtime/fleet-console/tests/console-settings.test.ts
+++ b/runtime/fleet-console/tests/console-settings.test.ts
@@ -1,0 +1,148 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createConsoleSettingsStore,
+  sanitizeConsoleSettingsData,
+  emptyConsoleSettingsData,
+} from "../core/host/console-settings.js";
+import type { ConsoleDataPaths } from "../core/host/paths.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-settings-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeFakePaths(dir: string): ConsoleDataPaths {
+  return {
+    dir,
+    stateFile: path.join(dir, "state.json"),
+    settingsFile: path.join(dir, "settings.json"),
+    capturesDir: path.join(dir, "captures"),
+  };
+}
+
+describe("sanitizeConsoleSettingsData", () => {
+  it("returns empty for non-object input", () => {
+    expect(sanitizeConsoleSettingsData(null)).toEqual({ version: 1, general: {} });
+    expect(sanitizeConsoleSettingsData("string")).toEqual({ version: 1, general: {} });
+    expect(sanitizeConsoleSettingsData([])).toEqual({ version: 1, general: {} });
+  });
+
+  it("returns empty for version mismatch", () => {
+    expect(sanitizeConsoleSettingsData({ version: 2, general: { theme: "carbon" } })).toEqual({ version: 1, general: {} });
+    expect(sanitizeConsoleSettingsData({ general: { theme: "carbon" } })).toEqual({ version: 1, general: {} });
+  });
+
+  it("accepts valid version 1 with no general", () => {
+    expect(sanitizeConsoleSettingsData({ version: 1 })).toEqual({ version: 1, general: {} });
+  });
+
+  it("accepts valid general fields", () => {
+    expect(sanitizeConsoleSettingsData({
+      version: 1,
+      general: { consolePortMode: "static", consoleStaticPort: 9000, theme: "carbon" },
+    })).toEqual({
+      version: 1,
+      general: { consolePortMode: "static", consoleStaticPort: 9000, theme: "carbon" },
+    });
+  });
+
+  it("drops invalid consolePortMode", () => {
+    expect(sanitizeConsoleSettingsData({
+      version: 1,
+      general: { consolePortMode: "auto", theme: "maritime" },
+    })).toEqual({ version: 1, general: { theme: "maritime" } });
+  });
+
+  it("drops out-of-range consoleStaticPort", () => {
+    expect(sanitizeConsoleSettingsData({
+      version: 1,
+      general: { consoleStaticPort: 80, theme: "maritime" },
+    })).toEqual({ version: 1, general: { theme: "maritime" } });
+
+    expect(sanitizeConsoleSettingsData({
+      version: 1,
+      general: { consoleStaticPort: 99999, theme: "maritime" },
+    })).toEqual({ version: 1, general: { theme: "maritime" } });
+  });
+
+  it("drops invalid theme", () => {
+    expect(sanitizeConsoleSettingsData({
+      version: 1,
+      general: { theme: "neon" },
+    })).toEqual({ version: 1, general: {} });
+  });
+
+  it("accepts maritime theme", () => {
+    expect(sanitizeConsoleSettingsData({
+      version: 1,
+      general: { theme: "maritime" },
+    })).toEqual({ version: 1, general: { theme: "maritime" } });
+  });
+
+  it("accepts carbon theme", () => {
+    expect(sanitizeConsoleSettingsData({
+      version: 1,
+      general: { theme: "carbon" },
+    })).toEqual({ version: 1, general: { theme: "carbon" } });
+  });
+
+  it("accepts minimum valid port boundary", () => {
+    expect(sanitizeConsoleSettingsData({
+      version: 1,
+      general: { consoleStaticPort: 1024 },
+    })).toEqual({ version: 1, general: { consoleStaticPort: 1024 } });
+  });
+
+  it("accepts maximum valid port boundary", () => {
+    expect(sanitizeConsoleSettingsData({
+      version: 1,
+      general: { consoleStaticPort: 65535 },
+    })).toEqual({ version: 1, general: { consoleStaticPort: 65535 } });
+  });
+
+  it("drops non-integer port", () => {
+    expect(sanitizeConsoleSettingsData({
+      version: 1,
+      general: { consoleStaticPort: 8080.5 },
+    })).toEqual({ version: 1, general: {} });
+  });
+
+  it("round-trips valid data through store", () => {
+    const dir = makeTempDir();
+    const paths = makeFakePaths(dir);
+    const store = createConsoleSettingsStore({ paths });
+
+    expect(store.load()).toEqual({ version: 1, general: {} });
+
+    store.update(() => ({
+      version: 1,
+      general: { consolePortMode: "static", consoleStaticPort: 7777, theme: "carbon" },
+    }));
+
+    expect(store.load()).toEqual({
+      version: 1,
+      general: { consolePortMode: "static", consoleStaticPort: 7777, theme: "carbon" },
+    });
+
+    const raw = JSON.parse(fs.readFileSync(paths.settingsFile, "utf-8")) as unknown;
+    expect(raw).toEqual({ version: 1, general: { consolePortMode: "static", consoleStaticPort: 7777, theme: "carbon" } });
+  });
+});
+
+describe("emptyConsoleSettingsData", () => {
+  it("returns version 1 with empty general", () => {
+    expect(emptyConsoleSettingsData()).toEqual({ version: 1, general: {} });
+  });
+});

--- a/runtime/fleet-console/tests/durable-state.test.ts
+++ b/runtime/fleet-console/tests/durable-state.test.ts
@@ -101,6 +101,7 @@ describe("durable console state", () => {
     const paths: ConsoleDataPaths = {
       dir: "/tmp/fleet/console",
       stateFile: "/tmp/fleet/console/state.json",
+      settingsFile: "/tmp/fleet/console/settings.json",
       capturesDir: "/tmp/fleet/console/captures",
     };
 

--- a/runtime/fleet-console/tests/global-settings-routes.test.ts
+++ b/runtime/fleet-console/tests/global-settings-routes.test.ts
@@ -3,6 +3,7 @@ import type http from "node:http";
 import { describe, expect, it } from "vitest";
 
 import { createGlobalSettingsRouter } from "../core/host/global-settings-routes.js";
+import type { ConsoleSettingsData, ConsoleGeneralSettings } from "../core/host/console-settings.js";
 
 interface WriteJsonCall {
   readonly status: number;
@@ -13,23 +14,23 @@ interface RouterHarnessOptions {
   readonly authorized?: boolean;
   readonly body?: unknown;
   readonly bodyNull?: boolean;
-  readonly data?: {
-    readonly replaceSystemPrompt?: boolean;
-    readonly enableMetaphor?: boolean;
-    readonly consolePortMode?: "dynamic" | "static";
-    readonly consoleStaticPort?: number;
-  };
+  readonly general?: ConsoleGeneralSettings;
 }
 
 describe("global settings routes", () => {
-  it("GET /global-settings/state returns the Console settings surface without internal keys", async () => {
-    const harness = createRouterHarness({ data: { replaceSystemPrompt: true, enableMetaphor: false } });
+  it("GET /global-settings/state returns flat Console settings with defaults", async () => {
+    const harness = createRouterHarness({ general: {} });
     const handled = await harness.router({ req: req("GET"), res: res(), pathname: "/api/v1/settings/global" });
     expect(handled).toBe(true);
-    expect(harness.writes).toEqual([{ status: 200, body: { consolePortMode: "dynamic", consoleStaticPort: null } }]);
+    expect(harness.writes).toEqual([{ status: 200, body: { consolePortMode: "dynamic", consoleStaticPort: null, theme: "maritime" } }]);
     expect(harness.writes[0]?.body).not.toHaveProperty("version");
-    expect(harness.writes[0]?.body).not.toHaveProperty("replaceSystemPrompt");
-    expect(harness.writes[0]?.body).not.toHaveProperty("enableMetaphor");
+    expect(harness.writes[0]?.body).not.toHaveProperty("general");
+  });
+
+  it("GET /global-settings/state reflects stored values", async () => {
+    const harness = createRouterHarness({ general: { consolePortMode: "static", consoleStaticPort: 9000, theme: "carbon" } });
+    await harness.router({ req: req("GET"), res: res(), pathname: "/api/v1/settings/global" });
+    expect(harness.writes[0]).toEqual({ status: 200, body: { consolePortMode: "static", consoleStaticPort: 9000, theme: "carbon" } });
   });
 
   it("GET /global-settings/state rejects non-GET methods with 405", async () => {
@@ -38,27 +39,34 @@ describe("global settings routes", () => {
     expect(harness.writes[0]?.status).toBe(405);
   });
 
-  it("PUT /global-settings updates and returns the new port-only state", async () => {
-    const harness = createRouterHarness({ authorized: true, body: { consolePortMode: "static", consoleStaticPort: 8080 } });
+  it("PUT /global-settings updates and returns the new state", async () => {
+    const harness = createRouterHarness({ authorized: true, body: { consolePortMode: "static", consoleStaticPort: 8080, theme: "carbon" } });
     const handled = await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/api/v1/settings/global" });
     expect(handled).toBe(true);
-    expect(harness.writes[0]).toEqual({ status: 200, body: { state: { consolePortMode: "static", consoleStaticPort: 8080 } } });
-    expect(harness.currentData()).toMatchObject({ version: 1, consolePortMode: "static", consoleStaticPort: 8080 });
+    expect(harness.writes[0]).toEqual({ status: 200, body: { state: { consolePortMode: "static", consoleStaticPort: 8080, theme: "carbon" } } });
+    expect(harness.currentGeneral()).toMatchObject({ consolePortMode: "static", consoleStaticPort: 8080, theme: "carbon" });
   });
 
-  it("PUT /global-settings ignores removed prompt fields without mutating stored prompt settings", async () => {
+  it("PUT /global-settings stores a theme", async () => {
+    const harness = createRouterHarness({ authorized: true, body: { theme: "carbon" } });
+    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/api/v1/settings/global" });
+    expect(harness.writes[0]).toEqual({ status: 200, body: { state: { consolePortMode: "dynamic", consoleStaticPort: null, theme: "carbon" } } });
+    expect(harness.currentGeneral()).toMatchObject({ theme: "carbon" });
+  });
+
+  it("PUT /global-settings ignores replaceSystemPrompt/enableMetaphor body fields", async () => {
     const harness = createRouterHarness({
       authorized: true,
       body: { replaceSystemPrompt: false, enableMetaphor: true },
-      data: { replaceSystemPrompt: true, enableMetaphor: false, consolePortMode: "static", consoleStaticPort: 8080 },
+      general: { consolePortMode: "static", consoleStaticPort: 8080, theme: "maritime" },
     });
     await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/api/v1/settings/global" });
-    expect(harness.writes[0]?.body).toEqual({ state: { consolePortMode: "static", consoleStaticPort: 8080 } });
-    expect(harness.currentData()).toEqual({ version: 1, replaceSystemPrompt: true, enableMetaphor: false, consolePortMode: "static", consoleStaticPort: 8080 });
+    expect(harness.writes[0]?.body).toEqual({ state: { consolePortMode: "static", consoleStaticPort: 8080, theme: "maritime" } });
+    expect(harness.currentGeneral()).toEqual({ consolePortMode: "static", consoleStaticPort: 8080, theme: "maritime" });
   });
 
   it("PUT /global-settings rejects unauthorized requests with 401", async () => {
-    const harness = createRouterHarness({ authorized: false, body: { enableMetaphor: true } });
+    const harness = createRouterHarness({ authorized: false, body: { theme: "carbon" } });
     await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/api/v1/settings/global" });
     expect(harness.writes[0]?.status).toBe(401);
     expect(harness.updateCalls).toBe(0);
@@ -81,7 +89,7 @@ describe("global settings routes", () => {
   it("PUT /global-settings stores a static console port", async () => {
     const harness = createRouterHarness({ authorized: true, body: { consolePortMode: "static", consoleStaticPort: 8080 } });
     await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/api/v1/settings/global" });
-    expect(harness.writes[0]).toEqual({ status: 200, body: { state: { consolePortMode: "static", consoleStaticPort: 8080 } } });
+    expect(harness.writes[0]).toEqual({ status: 200, body: { state: { consolePortMode: "static", consoleStaticPort: 8080, theme: "maritime" } } });
   });
 
   it("PUT /global-settings rejects an out-of-range static port with 400", async () => {
@@ -93,6 +101,13 @@ describe("global settings routes", () => {
 
   it("PUT /global-settings rejects an invalid console port mode with 400", async () => {
     const harness = createRouterHarness({ authorized: true, body: { consolePortMode: "auto" } });
+    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/api/v1/settings/global" });
+    expect(harness.writes[0]?.status).toBe(400);
+    expect(harness.updateCalls).toBe(0);
+  });
+
+  it("PUT /global-settings rejects an invalid theme with 400", async () => {
+    const harness = createRouterHarness({ authorized: true, body: { theme: "neon" } });
     await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/api/v1/settings/global" });
     expect(harness.writes[0]?.status).toBe(400);
     expect(harness.updateCalls).toBe(0);
@@ -114,25 +129,20 @@ describe("global settings routes", () => {
 
 function createRouterHarness(options: RouterHarnessOptions = {}) {
   const writes: WriteJsonCall[] = [];
-  let data: {
-    version: 1;
-    replaceSystemPrompt?: boolean;
-    enableMetaphor?: boolean;
-    consolePortMode?: "dynamic" | "static";
-    consoleStaticPort?: number;
-  } = { version: 1, ...options.data };
+  let data: ConsoleSettingsData = { version: 1, general: options.general ?? {} };
   let updateCalls = 0;
   const router = createGlobalSettingsRouter({
-    globalOptionsService: {
+    consoleSettingsStore: {
+      path: "/fake/settings.json",
       load: () => data,
-      save: (next) => { data = next; return data; },
+      save: (next) => { data = next; },
       update: (mutate) => { updateCalls += 1; data = mutate(data); return data; },
     },
     isAuthorized: () => options.authorized ?? true,
     readJsonBody: async () => (options.bodyNull ? null : (options.body ?? {})) as never,
     writeJson: (_res, status, body) => { writes.push({ status, body }); },
   });
-  return { router, writes, currentData: () => data, get updateCalls() { return updateCalls; } };
+  return { router, writes, currentGeneral: () => data.general, get updateCalls() { return updateCalls; } };
 }
 
 function req(method: string, contentType?: string): http.IncomingMessage {


### PR DESCRIPTION
## Summary
- Settings의 General 섹션(Theme + Console Port)을 console 특화 영속 데이터로 분리하여 console 데이터 디렉터리의 `settings.json`에 nested `general` 스키마로 저장합니다.
- Theme을 브라우저별 localStorage 영속에서 서버 영속으로 전환합니다. 부트 시 마운트 직전 서버 값을 적용(top-level await)해 FOUC가 없으며, 선택한 테마가 모든 브라우저에서 공유되고 재시작 후에도 유지됩니다.
- System Prompt / Metaphor(`replaceSystemPrompt` / `enableMetaphor`)는 Admiral CLI 소유로 `~/.fleet/settings.json`(fleet-infra)에 그대로 남기고, console port 필드는 `GlobalOptionsData`에서 제거합니다. 기존 값 마이그레이션은 의도적으로 수행하지 않습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-infra build` / `test` (62 passed)
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` / `build` / `test` (474 passed)
- [x] console-e2e 실브라우저 QA (Sentinel, PASS): Theme 서버 영속·재시작 유지·`localStorage['fleet-console.activeTheme']` 부재, Console Port 영속, `settings.json` nested `general` 스키마 실측, System Prompt/Metaphor 회귀 없음
- [x] `.changelog.d/console-settings-general-server-persist.md` fragment 포함 (section: Changed, `[fleet-console]`)