### PR TITLE
fix(fleet-console): surface ALERTS notifications for non-active operations

### DIFF
--- a/.changelog.d/alerts-active-visibility.md
+++ b/.changelog.d/alerts-active-visibility.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- [fleet-console] ALERTS now surfaces Awaiting and Complete notifications for every operation except the one you are actively viewing, regardless of its Theater or minimized/maximized state; previously notifications were suppressed for all operations while the Operations canvas was open, so the rail stayed empty.

--- a/runtime/fleet-console/core/client/src/notification-reduce.ts
+++ b/runtime/fleet-console/core/client/src/notification-reduce.ts
@@ -13,8 +13,11 @@ export interface VisibilitySplitNotifications {
 }
 
 export function computeVisibleOperationIds(consoleSnap: ConsoleState): ReadonlySet<string> {
-  if (!consoleSnap.operationsViewActive) return new Set();
-  return new Set(consoleSnap.operations.map((operation) => operation.id));
+  // 현재 보고 있는 패널(operations 화면이 떠 있고 active인 패널) 하나만 "보임"으로 간주한다.
+  // Theater·최소화·최대화와 무관하게 그 외 모든 패널의 Awaiting/Complete 알림은 ALERTS로 노출하고,
+  // 지금 보고 있는 active 패널의 알림만 무시한다.
+  if (!consoleSnap.operationsViewActive || !consoleSnap.activeOperationId) return new Set();
+  return new Set([consoleSnap.activeOperationId]);
 }
 
 export function splitNotificationsByVisibility(

--- a/runtime/fleet-console/core/client/src/notification-reduce.ts
+++ b/runtime/fleet-console/core/client/src/notification-reduce.ts
@@ -13,11 +13,25 @@ export interface VisibilitySplitNotifications {
 }
 
 export function computeVisibleOperationIds(consoleSnap: ConsoleState): ReadonlySet<string> {
-  // 현재 보고 있는 패널(operations 화면이 떠 있고 active인 패널) 하나만 "보임"으로 간주한다.
+  // 현재 보고 있는 패널(operations 화면이 떠 있고, 현재 Theater에 실재하는 active 패널) 하나만 "보임"으로 간주한다.
   // Theater·최소화·최대화와 무관하게 그 외 모든 패널의 Awaiting/Complete 알림은 ALERTS로 노출하고,
-  // 지금 보고 있는 active 패널의 알림만 무시한다.
+  // 지금 보고 있는 active 패널의 알림만 무시한다. Theater 전환 등으로 stale해진 activeOperationId
+  // (다른 Theater를 가리키거나 이미 닫힌 패널)는 "보임"에서 제외해 그 알림이 계속 노출되게 한다.
   if (!consoleSnap.operationsViewActive || !consoleSnap.activeOperationId) return new Set();
-  return new Set([consoleSnap.activeOperationId]);
+  const active = consoleSnap.operations.find((operation) => operation.id === consoleSnap.activeOperationId);
+  if (!active || active.theaterId !== consoleSnap.activeTheaterId) return new Set();
+  return new Set([active.id]);
+}
+
+// 이미 닫힌(operations에 더는 존재하지 않는) 패널의 잔존 알림을 ALERTS 대상에서 제외하는 폴백.
+// 활성 패널이 awaiting/complete로 전이된 뒤 닫히면 알림만 남을 수 있고, 그 알림은 이동해도 대상 패널이
+// 없어 아무 반응이 없으므로 표시 자체를 막는다.
+export function filterByLiveOperations(
+  notifications: readonly OperationNotification[],
+  operations: readonly { readonly id: string }[],
+): readonly OperationNotification[] {
+  const live = new Set(operations.map((operation) => operation.id));
+  return notifications.filter((notification) => live.has(notification.operationId));
 }
 
 export function splitNotificationsByVisibility(

--- a/runtime/fleet-console/core/client/src/rail/alerts-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/alerts-panel.tsx
@@ -8,6 +8,7 @@ import { useActiveRailPanelId } from "./rail-store.js";
 import { useConsoleState } from "../hooks/use-store.js";
 import {
   computeVisibleOperationIds,
+  filterByLiveOperations,
   filterByPreferences,
   groupNotificationsByTheater,
   splitNotificationsByVisibility,
@@ -35,8 +36,8 @@ export function AlertsPanelBody() {
   const [settingsOpen, setSettingsOpen] = useState(false);
 
   const notifications = useMemo(
-    () => Object.values(state.operationNotifications),
-    [state.operationNotifications],
+    () => filterByLiveOperations(Object.values(state.operationNotifications), state.operations),
+    [state.operationNotifications, state.operations],
   );
   const visibleIds = computeVisibleOperationIds(state);
   const eligible = splitNotificationsByVisibility(notifications, visibleIds).hidden;
@@ -138,8 +139,8 @@ function AlertsIcon() {
   const isActive = activeId === "alerts";
 
   const notifications = useMemo(
-    () => Object.values(state.operationNotifications),
-    [state.operationNotifications],
+    () => filterByLiveOperations(Object.values(state.operationNotifications), state.operations),
+    [state.operationNotifications, state.operations],
   );
   const visibleIds = computeVisibleOperationIds(state);
   const eligible = splitNotificationsByVisibility(notifications, visibleIds).hidden;

--- a/runtime/fleet-console/tests/reduce.test.ts
+++ b/runtime/fleet-console/tests/reduce.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../fleet-plugins/terminal/client/agent/reduce.js";
 import {
   computeVisibleOperationIds,
+  filterByLiveOperations,
   filterByPreferences,
   groupNotificationsByTheater,
   splitNotificationsByVisibility,
@@ -222,6 +223,7 @@ describe("notification selectors", () => {
   it("computes only the active operation as visible while Operations is mounted", () => {
     const visible = computeVisibleOperationIds(makeConsoleSnap({
       operationsViewActive: true,
+      activeTheaterId: "theater-a",
       activeOperationId: "operation-a",
       operations: [
         {
@@ -265,6 +267,41 @@ describe("notification selectors", () => {
         ts: { createdAt: 1, updatedAt: 1 },
       }],
     }))]).toEqual([]);
+  });
+
+  it("treats a stale active operation in another Theater as not visible", () => {
+    const op = (id: string, theaterId: string) => ({
+      id,
+      theaterId,
+      type: "shell",
+      pluginId: "terminal",
+      title: "Shell",
+      payload: {},
+      geometry: null,
+      ts: { createdAt: 1, updatedAt: 1 },
+    });
+    // Theater 전환 후 activeOperationId가 이전 Theater 패널을 가리키면(stale) 보임이 아니라 알림으로 노출되어야 한다.
+    expect([...computeVisibleOperationIds(makeConsoleSnap({
+      operationsViewActive: true,
+      activeTheaterId: "theater-a",
+      activeOperationId: "operation-b",
+      operations: [op("operation-a", "theater-a"), op("operation-b", "theater-b")],
+    }))]).toEqual([]);
+  });
+
+  it("treats a closed active operation as not visible", () => {
+    expect([...computeVisibleOperationIds(makeConsoleSnap({
+      operationsViewActive: true,
+      activeTheaterId: "theater-a",
+      activeOperationId: "ghost",
+      operations: [],
+    }))]).toEqual([]);
+  });
+
+  it("drops notifications for operations that no longer exist", () => {
+    const live = makeNotification("operation-a", "theater-a", 1);
+    const closed = makeNotification("operation-ghost", "theater-a", 2);
+    expect(filterByLiveOperations([live, closed], [{ id: "operation-a" }])).toEqual([live]);
   });
 
   it("splits hidden and visible notifications by operation id", () => {

--- a/runtime/fleet-console/tests/reduce.test.ts
+++ b/runtime/fleet-console/tests/reduce.test.ts
@@ -219,9 +219,41 @@ describe("notification selectors", () => {
     }))]).toEqual([]);
   });
 
-  it("computes visible operations while the Operations canvas is mounted", () => {
+  it("computes only the active operation as visible while Operations is mounted", () => {
     const visible = computeVisibleOperationIds(makeConsoleSnap({
       operationsViewActive: true,
+      activeOperationId: "operation-a",
+      operations: [
+        {
+          id: "operation-a",
+          theaterId: "theater-a",
+          type: "shell",
+          pluginId: "terminal",
+          title: "Shell",
+          payload: {},
+          geometry: null,
+          ts: { createdAt: 1, updatedAt: 1 },
+        },
+        {
+          id: "operation-b",
+          theaterId: "theater-b",
+          type: "shell",
+          pluginId: "terminal",
+          title: "Shell",
+          payload: {},
+          geometry: null,
+          ts: { createdAt: 1, updatedAt: 1 },
+        },
+      ],
+    }));
+    // active 패널만 visible — 같은/다른 Theater의 비active 패널은 ALERTS로 노출되도록 hidden 처리한다.
+    expect([...visible]).toEqual(["operation-a"]);
+  });
+
+  it("computes no visible operations when no operation is active", () => {
+    expect([...computeVisibleOperationIds(makeConsoleSnap({
+      operationsViewActive: true,
+      activeOperationId: null,
       operations: [{
         id: "operation-a",
         theaterId: "theater-a",
@@ -232,8 +264,7 @@ describe("notification selectors", () => {
         geometry: null,
         ts: { createdAt: 1, updatedAt: 1 },
       }],
-    }));
-    expect([...visible]).toEqual(["operation-a"]);
+    }))]).toEqual([]);
   });
 
   it("splits hidden and visible notifications by operation id", () => {


### PR DESCRIPTION
## Summary
- ALERTS now surfaces Awaiting/Complete notifications for every operation **except the one being actively viewed**, regardless of its Theater or minimized/maximized state. Previously the Operations canvas marked every operation as `visible` while mounted, so the visibility filter suppressed all notifications and the rail stayed empty.
- ALERTS "Open" reuses the same `focusOperation` + `navigate` path as the Cmd/Ctrl+K quick-search, which already switches to the operation's Theater and focuses the panel. Restoring notification visibility therefore also restores navigation to other-Theater panels (no separate move-logic change was needed).

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (458 passed / 22 skipped)
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] Live console-e2e (notification surfacing + Open navigation across Theaters) recommended before/after merge

## Changelog
- [x] `.changelog.d/alerts-active-visibility.md` (Fixed)