### PR TITLE
fix(fleet-console): disable unsupported Claude launch aliases

### DIFF
--- a/.changelog.d/fix-operation-controls-claude-aliases.md
+++ b/.changelog.d/fix-operation-controls-claude-aliases.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- [fleet-console] Disabled unsupported Claude Kimi and Claude GLM launch options in Operation Controls.

--- a/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
@@ -1,0 +1,29 @@
+import type { AgentCliId } from "@dotobokuri/fleet-admiral";
+import type { OperationLaunchKind } from "@fleet-console/sdk/operations";
+
+import type { AgentCliLaunchMetadata } from "./agent-cli-launch-metadata.js";
+
+const UNSUPPORTED_AGENT_CLI_IDS: ReadonlySet<AgentCliId> = new Set(["claude-kimi", "claude-glm"]);
+const UNSUPPORTED_AGENT_CLI_DISABLED_REASON = "Not supported";
+
+export function buildAgentCliLaunchKinds(
+  metadata: readonly AgentCliLaunchMetadata[],
+  operationType: string,
+): OperationLaunchKind[] {
+  return metadata.map((cli) => {
+    const disabledReason = resolveDisabledReason(cli);
+    return {
+      id: cli.id,
+      type: operationType,
+      title: cli.label,
+      ...(disabledReason ? { disabled: true, disabledReason } : {}),
+    };
+  });
+}
+
+function resolveDisabledReason(cli: AgentCliLaunchMetadata): string | undefined {
+  if (UNSUPPORTED_AGENT_CLI_IDS.has(cli.id)) return UNSUPPORTED_AGENT_CLI_DISABLED_REASON;
+  if (!cli.available) return "Not installed";
+  if (!cli.signedIn) return "Sign in required";
+  return undefined;
+}

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -13,6 +13,7 @@ import { createWorkspaceChangeScanner } from "./shared/index.js";
 import type { TerminalRuntime } from "./shared/index.js";
 
 import { createDefaultAgentCliDetector } from "./agent-api/agent-cli-detect.js";
+import { buildAgentCliLaunchKinds } from "./agent-api/agent-cli-launch-kinds.js";
 import { combineAgentCliLaunchMetadata, type AgentCliLaunchMetadata } from "./agent-api/agent-cli-launch-metadata.js";
 import { deriveOperationLabel } from "./agent-api/auto-name.js";
 import { normalizeAttentionReason } from "./agent-api/attention-hook.js";
@@ -435,15 +436,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
 
   async function buildLaunchKinds(): Promise<readonly OperationLaunchKind[]> {
     const metadata = await buildAgentCliLaunchMetadata();
-    return metadata.map((cli) => {
-      const disabled = !cli.available || !cli.signedIn;
-      return {
-        id: cli.id,
-        type: AGENT_OPERATION_TYPE,
-        title: cli.label,
-        ...(disabled ? { disabled: true, disabledReason: !cli.available ? "Not installed" : "Sign in required" } : {}),
-      };
-    });
+    return buildAgentCliLaunchKinds(metadata, AGENT_OPERATION_TYPE);
   }
 
   function launch(cwd: string | undefined, context: { readonly operationId?: string } | undefined) {

--- a/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAgentCliLaunchKinds } from "../server/agent-api/agent-cli-launch-kinds.js";
+
+describe("buildAgentCliLaunchKinds", () => {
+  it("Claude Kimi와 Claude GLM을 Operation Controls에서 미지원으로 비활성화한다", () => {
+    const result = buildAgentCliLaunchKinds(
+      [
+        { id: "claude", label: "Claude", available: true, signedIn: true },
+        { id: "claude-kimi", label: "Claude Kimi", available: true, signedIn: true },
+        { id: "claude-glm", label: "Claude GLM", available: true, signedIn: true },
+        { id: "codex", label: "Codex", available: true, signedIn: true },
+      ],
+      "agent",
+    );
+
+    expect(result).toEqual([
+      { id: "claude", type: "agent", title: "Claude" },
+      { id: "claude-kimi", type: "agent", title: "Claude Kimi", disabled: true, disabledReason: "Not supported" },
+      { id: "claude-glm", type: "agent", title: "Claude GLM", disabled: true, disabledReason: "Not supported" },
+      { id: "codex", type: "agent", title: "Codex" },
+    ]);
+  });
+
+  it("지원되는 CLI에는 기존 설치와 로그인 비활성화 사유를 유지한다", () => {
+    const result = buildAgentCliLaunchKinds(
+      [
+        { id: "claude", label: "Claude", available: false, signedIn: true },
+        { id: "codex", label: "Codex", available: true, signedIn: false },
+      ],
+      "agent",
+    );
+
+    expect(result).toEqual([
+      { id: "claude", type: "agent", title: "Claude", disabled: true, disabledReason: "Not installed" },
+      { id: "codex", type: "agent", title: "Codex", disabled: true, disabledReason: "Sign in required" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Disable Claude Kimi and Claude GLM in the Operation Controls launch catalog with a clear `Not supported` reason.
- Keep existing install and sign-in disabled reasons for supported Agent CLI options.
- Add a focused Terminal plugin regression test and changelog fragment.

## Type of Change
- [ ] feat — new feature or carrier capability
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope
- [ ] `extensions/core`
- [ ] `extensions/fleet` (Admiral / Bridge / Carriers)
- [ ] `extensions/boot`
- [ ] `extensions/diagnostics`
- [ ] `extensions/metaphor`
- [ ] `packages/unified-agent`
- [ ] `bin/` or root tooling
- [ ] Documentation (README / SETUP / AGENTS.md)

Runtime scope: `runtime/fleet-plugins/terminal` and Fleet Console Operation Controls.

## Test Plan
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `pnpm --filter @fleet-plugins/terminal exec vitest run tests/agent-cli-launch-kinds.test.ts`
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Headed `agent-browser` check against isolated Fleet Console: Operation Controls shows Claude Kimi and Claude GLM disabled with `NOT SUPPORTED`.

## Changelog
- [x] Added one `.changelog.d/*.md` fragment, or applied the `no-changelog` label intentionally.
- [x] Fragment `section:` is one of `Added`, `Changed`, `Fixed`, `Removed`, or `Breaking Changes`.
- [x] Fragment bullets are English and use only `[core-agent]`, `[core-unified-agent]`, `[fleet-infra]`, `[fleet-admiral]`, `[fleet-carriers]`, `[fleet-wiki]`, `[fleet-console]`, or `[fleet-cli]`.

## Related Issues / PRs

## Notes for Reviewers
- Screenshot evidence from the isolated browser check: `/tmp/fleet-console-operation-controls.png`.