### PR TITLE
fix(fleet-console): restore Codex Drydock patch review flow

### DIFF
--- a/.changelog.d/codex-drydock-patch-review-restore.md
+++ b/.changelog.d/codex-drydock-patch-review-restore.md
@@ -1,0 +1,4 @@
+---
+section: Fixed
+---
+- [fleet-console] Restored the Codex Drydock patch review flow: pending patches now render as a compact, clickable list, each opens its proposed wiki document in the Codex reading view, and can be approved or rejected with a reason from the rail or the expanded reading overlay.

--- a/runtime/fleet-console/core/client/src/codex-host.ts
+++ b/runtime/fleet-console/core/client/src/codex-host.ts
@@ -91,6 +91,16 @@ export function mountReaderInto(
   }
   activeReaderEntryId = opts.kind === "entry" ? (opts.initialEntryId ?? null) : null;
 
+  // relocate마다 현재 마운트 소유자(split/overlay)의 콜백을 컨트롤러에 반영한다.
+  // 재생성 경로에서도 idempotent이므로 항상 호출한다.
+  readerController.refreshCallbacks({
+    onPatchOpen: opts.onPatchOpen,
+    onDecided: opts.onDecided,
+    onRelatedClick: opts.onRelatedClick,
+    onClose: opts.onClose,
+    theaterId: opts.theaterId,
+  });
+
   // 같은 엔트리를 split→오버레이(Expand)로 옮길 때는 읽기 위치를 보존한다. 반대 방향
   // (오버레이→split, Esc)은 오버레이 언마운트로 reader가 먼저 detach되어 위치 복원이
   // 불안정하므로 상단부터 시작한다(콤팩트 뷰 복귀라 허용). 새 엔트리/뷰도 상단부터.

--- a/runtime/fleet-console/core/client/src/codex-host.ts
+++ b/runtime/fleet-console/core/client/src/codex-host.ts
@@ -23,6 +23,7 @@ let tocHostNode: HTMLDivElement | null = null;
 let readerController: ReadingController | null = null;
 let activeReaderKind: "entry" | "drydock" | "conflicts" | null = null;
 let activeReaderEntryId: string | null = null;
+let activeReaderSubId: string | undefined = undefined;
 let lastReaderScrollTop = 0;
 
 // ─── Public API ───────────────────────────────────────────────────────────────
@@ -79,9 +80,14 @@ export function mountReaderInto(
     readerController?.destroy();
     readerController = mountReadingInto(rNode, { ...opts, tocContainer: tNode });
     activeReaderKind = opts.kind;
+    activeReaderSubId = opts.subId;
   } else if (opts.kind === "entry" && opts.initialEntryId && opts.initialEntryId !== activeReaderEntryId) {
     // 엔트리가 실제로 바뀐 경우에만 재렌더(같은 엔트리 relocate는 재렌더 없이 스크롤 보존).
     void readerController.setEntry(opts.initialEntryId);
+  } else if ((opts.kind === "drydock" || opts.kind === "conflicts") && opts.subId !== activeReaderSubId) {
+    // 드라이독/컨플릭트: subId가 바뀐 경우(목록↔상세 전환) navigateSub으로 내부 재렌더
+    activeReaderSubId = opts.subId;
+    void readerController.navigateSub(opts.subId);
   }
   activeReaderEntryId = opts.kind === "entry" ? (opts.initialEntryId ?? null) : null;
 
@@ -106,6 +112,7 @@ export function teardownReaderNodes(): void {
   readerController?.destroy();
   readerController = null;
   activeReaderKind = null;
+  activeReaderSubId = undefined;
   if (readerHostNode?.parentElement) readerHostNode.parentElement.removeChild(readerHostNode);
   if (tocHostNode?.parentElement) tocHostNode.parentElement.removeChild(tocHostNode);
 }

--- a/runtime/fleet-console/core/client/src/codex/reading-controller.ts
+++ b/runtime/fleet-console/core/client/src/codex/reading-controller.ts
@@ -29,6 +29,7 @@ export interface ReadingController {
   destroy(): void;
   setEntry(entryId: string): Promise<void>;
   navigateSub(subId: string | undefined): Promise<void>;
+  refreshCallbacks(next: Partial<Pick<MountReadingOptions, "onPatchOpen" | "onDecided" | "onRelatedClick" | "onClose" | "theaterId">>): void;
 }
 
 export interface MountReadingOptions {
@@ -58,6 +59,8 @@ export function mountReadingInto(
 ): ReadingController {
   let destroyed = false;
   let cleanupSpy: (() => void) | null = null;
+  // relocate(split↔overlay) 시 현재 마운트 소유자의 콜백이 반영되도록 가변 참조로 유지
+  let liveOpts = opts;
 
   // 드라이독 결정 상태 (패치 상세 뷰에서 관리)
   type DecisionPhase = "idle" | "approving" | "rejecting" | "submitting";
@@ -77,7 +80,7 @@ export function mountReadingInto(
     if (patchRowBtn) {
       event.preventDefault();
       const patchId = patchRowBtn.dataset.patchId || undefined;
-      opts.onPatchOpen?.(patchId);
+      liveOpts.onPatchOpen?.(patchId);
       return;
     }
 
@@ -85,7 +88,7 @@ export function mountReadingInto(
     const relatedBtn = target.closest<HTMLElement>("[data-entry-id]");
     if (relatedBtn?.dataset.entryId) {
       event.preventDefault();
-      opts.onRelatedClick(relatedBtn.dataset.entryId);
+      liveOpts.onRelatedClick(relatedBtn.dataset.entryId);
       return;
     }
 
@@ -122,7 +125,7 @@ export function mountReadingInto(
     if (!action) return;
 
     if (action === "back") {
-      opts.onPatchOpen?.(undefined);
+      liveOpts.onPatchOpen?.(undefined);
       return;
     }
 
@@ -175,8 +178,8 @@ export function mountReadingInto(
     decisionError = null;
     redrawDecisionBar();
     try {
-      await decideDrydock(opts.theaterId, currentDetailPatchId, action, reason);
-      opts.onDecided?.();
+      await decideDrydock(liveOpts.theaterId, currentDetailPatchId, action, reason);
+      liveOpts.onDecided?.();
     } catch (err) {
       decisionPhase = action === "approve" ? "approving" : "rejecting";
       decisionError = err instanceof Error ? err.message : String(err);
@@ -203,7 +206,7 @@ export function mountReadingInto(
     cleanupReader();
 
     try {
-      const entry = await fetchEntry(opts.theaterId, entryId);
+      const entry = await fetchEntry(liveOpts.theaterId, entryId);
       if (destroyed) return;
 
       const { index } = getState();
@@ -252,7 +255,7 @@ export function mountReadingInto(
 
     try {
       if (patchId) {
-        const detail = await fetchDrydockDetail(opts.theaterId, patchId);
+        const detail = await fetchDrydockDetail(liveOpts.theaterId, patchId);
         if (destroyed) return;
 
         currentDetailMeta = detail.meta;
@@ -271,7 +274,7 @@ export function mountReadingInto(
           cleanupSpy = installTocScrollSpy(article, toc, opts.tocContainer);
         }
       } else {
-        const list = await fetchDrydock(opts.theaterId, "pending");
+        const list = await fetchDrydock(liveOpts.theaterId, "pending");
         if (destroyed) return;
         opts.tocContainer.innerHTML = "";
         readContainer.innerHTML = renderDrydockList(list.items, "Drydock — Pending Patches");
@@ -288,12 +291,12 @@ export function mountReadingInto(
 
     try {
       if (conflictId) {
-        const detail = await fetchConflictDetail(opts.theaterId, conflictId);
+        const detail = await fetchConflictDetail(liveOpts.theaterId, conflictId);
         if (destroyed) return;
         opts.tocContainer.innerHTML = "";
         readContainer.innerHTML = renderConflictDetail(detail);
       } else {
-        const conflicts = await fetchConflicts(opts.theaterId);
+        const conflicts = await fetchConflicts(liveOpts.theaterId);
         if (destroyed) return;
         opts.tocContainer.innerHTML = "";
         readContainer.innerHTML = renderConflictList(conflicts);
@@ -326,6 +329,9 @@ export function mountReadingInto(
       } else if (opts.kind === "conflicts") {
         await renderConflictsView(subId);
       }
+    },
+    refreshCallbacks(next): void {
+      liveOpts = { ...liveOpts, ...next };
     },
   };
 }

--- a/runtime/fleet-console/core/client/src/codex/reading-controller.ts
+++ b/runtime/fleet-console/core/client/src/codex/reading-controller.ts
@@ -1,14 +1,21 @@
 import {
+  decideDrydock,
   fetchConflictDetail,
   fetchConflicts,
   fetchDrydock,
   fetchDrydockDetail,
   fetchEntry,
 } from "./api.js";
-import type { ConflictDetailResponse, ConflictListItem, DrydockDetailResponse, DrydockListItem, EntryResponse } from "./api.js";
+import type {
+  ConflictDetailResponse,
+  ConflictListItem,
+  DrydockDetailResponse,
+  DrydockListItem,
+  DrydockMeta,
+  EntryResponse,
+} from "./api.js";
 import { installDiagramHydrator } from "@fleet-console/markdown/mermaid";
 import { renderMarkdown } from "@fleet-console/markdown/core";
-import type { TocItem } from "@fleet-console/markdown/core";
 import { buildCompactContext, buildProvenanceContext, buildRelatedContextPack, renderCopyContextActions } from "./components/copy-context-actions.js";
 import { renderMetaChips, renderTagChips } from "./components/meta-chips.js";
 import { installTocScrollSpy, renderTocSheet } from "./components/toc-sheet.js";
@@ -21,6 +28,7 @@ import { escapeAttribute, escapeHtml } from "./utils/html.js";
 export interface ReadingController {
   destroy(): void;
   setEntry(entryId: string): Promise<void>;
+  navigateSub(subId: string | undefined): Promise<void>;
 }
 
 export interface MountReadingOptions {
@@ -30,12 +38,17 @@ export interface MountReadingOptions {
   readonly theaterId: string | null;
   readonly onRelatedClick: (id: string) => void;
   readonly onClose: () => void;
+  /** 패치 행 클릭(상세 진입) 또는 뒤로가기(undefined) 콜백 */
+  readonly onPatchOpen?: (patchId: string | undefined) => void;
+  /** 승인/반려 결정 완료 후 목록 갱신을 트리거하는 콜백 */
+  readonly onDecided?: () => void;
   readonly tocContainer: HTMLElement;
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const OP_BADGE_GLYPHS: Record<string, string> = { create_wiki: "+", update_wiki: "↻" };
+const OP_LABELS: Record<string, string> = { create_wiki: "Create", update_wiki: "Update" };
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
@@ -46,12 +59,29 @@ export function mountReadingInto(
   let destroyed = false;
   let cleanupSpy: (() => void) | null = null;
 
+  // 드라이독 결정 상태 (패치 상세 뷰에서 관리)
+  type DecisionPhase = "idle" | "approving" | "rejecting" | "submitting";
+  let decisionPhase: DecisionPhase = "idle";
+  let decisionError: string | null = null;
+  let currentDetailMeta: DrydockMeta | null = null;
+  let currentDetailPatchId: string | null = null;
+
   installDiagramHydrator(readContainer);
 
   function handleClick(event: MouseEvent): void {
     const target = event.target;
     if (!(target instanceof Element)) return;
 
+    // 패치 행 클릭 (목록 → 상세 또는 뒤로가기)
+    const patchRowBtn = target.closest<HTMLElement>("[data-patch-id]");
+    if (patchRowBtn) {
+      event.preventDefault();
+      const patchId = patchRowBtn.dataset.patchId || undefined;
+      opts.onPatchOpen?.(patchId);
+      return;
+    }
+
+    // Related 엔트리 클릭
     const relatedBtn = target.closest<HTMLElement>("[data-entry-id]");
     if (relatedBtn?.dataset.entryId) {
       event.preventDefault();
@@ -59,6 +89,15 @@ export function mountReadingInto(
       return;
     }
 
+    // 드라이독 결정/뒤로가기 액션
+    const drydockBtn = target.closest<HTMLElement>("[data-drydock-action]");
+    if (drydockBtn) {
+      event.preventDefault();
+      handleDrydockAction(drydockBtn.dataset.drydockAction);
+      return;
+    }
+
+    // 복사 컨텍스트 액션 (엔트리 전용)
     const actionBtn = target.closest<HTMLElement>("[data-action]");
     if (!actionBtn) return;
     const action = actionBtn.dataset.action;
@@ -77,6 +116,78 @@ export function mountReadingInto(
         whyEl.hidden = !whyEl.hidden;
       }
     }
+  }
+
+  function handleDrydockAction(action: string | undefined): void {
+    if (!action) return;
+
+    if (action === "back") {
+      opts.onPatchOpen?.(undefined);
+      return;
+    }
+
+    if (action === "approve") {
+      decisionPhase = "approving";
+      decisionError = null;
+      redrawDecisionBar();
+      return;
+    }
+
+    if (action === "approve-confirm") {
+      void submitDecision("approve", undefined);
+      return;
+    }
+
+    if (action === "reject") {
+      decisionPhase = "rejecting";
+      decisionError = null;
+      redrawDecisionBar();
+      return;
+    }
+
+    if (action === "reject-submit") {
+      const reason = readContainer
+        .querySelector<HTMLTextAreaElement>("#queue-reject-reason")
+        ?.value.trim();
+      if (!reason) {
+        decisionError = "Rejection reason is required.";
+        redrawDecisionBar();
+        return;
+      }
+      void submitDecision("reject", reason);
+      return;
+    }
+
+    if (action === "cancel") {
+      decisionPhase = "idle";
+      decisionError = null;
+      redrawDecisionBar();
+      return;
+    }
+  }
+
+  async function submitDecision(
+    action: "approve" | "reject",
+    reason: string | undefined,
+  ): Promise<void> {
+    if (!currentDetailPatchId) return;
+    decisionPhase = "submitting";
+    decisionError = null;
+    redrawDecisionBar();
+    try {
+      await decideDrydock(opts.theaterId, currentDetailPatchId, action, reason);
+      opts.onDecided?.();
+    } catch (err) {
+      decisionPhase = action === "approve" ? "approving" : "rejecting";
+      decisionError = err instanceof Error ? err.message : String(err);
+      redrawDecisionBar();
+    }
+  }
+
+  function redrawDecisionBar(): void {
+    const wrap = readContainer.querySelector<HTMLElement>("[data-decision-bar-wrap]");
+    if (!wrap) return;
+    wrap.innerHTML = renderDecisionBarContent(decisionPhase, decisionError);
   }
 
   readContainer.addEventListener("click", handleClick);
@@ -131,16 +242,38 @@ export function mountReadingInto(
   async function renderDrydockView(patchId: string | undefined): Promise<void> {
     if (destroyed) return;
     showLoading(readContainer, opts.tocContainer);
-    opts.tocContainer.innerHTML = "";
+    cleanupReader();
+
+    // 새 뷰 진입 시 결정 상태 초기화
+    currentDetailMeta = null;
+    currentDetailPatchId = null;
+    decisionPhase = "idle";
+    decisionError = null;
 
     try {
       if (patchId) {
         const detail = await fetchDrydockDetail(opts.theaterId, patchId);
         if (destroyed) return;
-        readContainer.innerHTML = renderPatchDetail(detail);
+
+        currentDetailMeta = detail.meta;
+        currentDetailPatchId = patchId;
+
+        const { html: markdownHtml, toc } = renderMarkdown(detail.wikiEntry.body, {
+          omitDuplicateTitle: detail.wikiEntry.title,
+          resolveWikiLink: (id) => entryPath(id),
+        });
+
+        readContainer.innerHTML = renderPatchDetail(detail, markdownHtml);
+
+        opts.tocContainer.innerHTML = renderTocSheet(toc);
+        const article = readContainer.querySelector<HTMLElement>("article");
+        if (article && toc.length > 0) {
+          cleanupSpy = installTocScrollSpy(article, toc, opts.tocContainer);
+        }
       } else {
         const list = await fetchDrydock(opts.theaterId, "pending");
         if (destroyed) return;
+        opts.tocContainer.innerHTML = "";
         readContainer.innerHTML = renderDrydockList(list.items, "Drydock — Pending Patches");
       }
     } catch (error) {
@@ -151,16 +284,18 @@ export function mountReadingInto(
   async function renderConflictsView(conflictId: string | undefined): Promise<void> {
     if (destroyed) return;
     showLoading(readContainer, opts.tocContainer);
-    opts.tocContainer.innerHTML = "";
+    cleanupReader();
 
     try {
       if (conflictId) {
         const detail = await fetchConflictDetail(opts.theaterId, conflictId);
         if (destroyed) return;
+        opts.tocContainer.innerHTML = "";
         readContainer.innerHTML = renderConflictDetail(detail);
       } else {
         const conflicts = await fetchConflicts(opts.theaterId);
         if (destroyed) return;
+        opts.tocContainer.innerHTML = "";
         readContainer.innerHTML = renderConflictList(conflicts);
       }
     } catch (error) {
@@ -184,6 +319,13 @@ export function mountReadingInto(
     },
     async setEntry(entryId: string): Promise<void> {
       await renderEntryView(entryId);
+    },
+    async navigateSub(subId: string | undefined): Promise<void> {
+      if (opts.kind === "drydock") {
+        await renderDrydockView(subId);
+      } else if (opts.kind === "conflicts") {
+        await renderConflictsView(subId);
+      }
     },
   };
 }
@@ -244,50 +386,136 @@ function renderRelatedList(currentId: string, currentTags: string[], entries: Re
   `;
 }
 
-function renderPatchDetail(detail: DrydockDetailResponse): string {
-  const op = detail.patch.frontmatter.op;
-  const glyph = OP_BADGE_GLYPHS[op] ?? "?";
+function renderDrydockList(items: DrydockListItem[], title: string): string {
+  if (items.length === 0) {
+    return `<div class="codex-reader-empty"><p class="queue-empty">No pending patches.</p></div>`;
+  }
   return `
     <article class="document">
       <header class="document-header">
         <nav class="breadcrumb" aria-label="Entry location">
-          <ol><li><span>Codex</span></li><li><span>Drydock</span></li></ol>
+          <ol>
+            <li><span>Codex</span></li>
+            <li><span aria-current="page">Drydock</span></li>
+          </ol>
         </nav>
-        <h1><span class="op-badge">${glyph}</span> ${escapeHtml(detail.patch.frontmatter.target)}</h1>
-        <p class="eyebrow">${escapeHtml(detail.meta.status)}</p>
+        <h1>${escapeHtml(title)}</h1>
       </header>
-      <div class="markdown-body">
-        <pre><code>${escapeHtml(detail.patch.body)}</code></pre>
+      <div class="queue-row-list">
+        ${items.map(renderQueueRow).join("")}
       </div>
     </article>
   `;
 }
 
-function renderDrydockList(items: DrydockListItem[], title: string): string {
-  if (items.length === 0) {
-    return `<div class="codex-reader-empty"><p>No pending patches.</p></div>`;
-  }
+function renderQueueRow(item: DrydockListItem): string {
+  const op = item.op ?? "create_wiki";
+  const glyph = OP_BADGE_GLYPHS[op] ?? "?";
+  const opLabel = OP_LABELS[op] ?? "Patch";
+  const target = item.target ?? item.id;
+  const time = formatRelativeTime(item.meta.createdAt);
+  const metaParts = [time].filter(Boolean);
+  return `
+    <button class="queue-row" type="button" data-patch-id="${escapeAttribute(item.id)}" aria-label="${escapeAttribute(opLabel + ": " + target)}">
+      <span class="queue-row-badge" aria-hidden="true">
+        <span class="op-badge">${glyph}</span>
+      </span>
+      <span class="queue-row-body">
+        <span class="queue-row-target">${escapeHtml(target)}</span>
+        ${item.summary ? `<span class="queue-row-summary">${escapeHtml(item.summary)}</span>` : ""}
+        ${metaParts.length > 0 ? `<span class="queue-row-meta">${metaParts.map(escapeHtml).join(" · ")}</span>` : ""}
+      </span>
+    </button>
+  `;
+}
+
+function renderPatchDetail(detail: DrydockDetailResponse, markdownHtml: string): string {
+  const { patch, meta, wikiEntry, targetExists } = detail;
+  const op = patch.frontmatter.op;
+  const glyph = OP_BADGE_GLYPHS[op] ?? "?";
+  const opLabel = OP_LABELS[op] ?? "Patch";
+  const targetLabel = targetExists ? "기존 문서 대체" : "신규 문서 생성";
+  const isPending = meta.status === "pending";
+
   return `
     <article class="document">
       <header class="document-header">
-        <h1>${escapeHtml(title)}</h1>
+        <nav class="breadcrumb" aria-label="Entry location">
+          <ol>
+            <li><span>Codex</span></li>
+            <li><span>Drydock</span></li>
+            <li><span aria-current="page">${escapeHtml(opLabel)}</span></li>
+          </ol>
+        </nav>
+        <button type="button" class="queue-back-btn" data-drydock-action="back">‹ Queue</button>
+        <h1><span class="op-badge">${glyph}</span> ${escapeHtml(wikiEntry.title)}</h1>
+        <p class="eyebrow">${escapeHtml(patch.frontmatter.target)} · v${wikiEntry.version} · ${escapeHtml(targetLabel)}</p>
+        ${renderPatchMetaChips(patch.frontmatter.proposer, wikiEntry.tags)}
       </header>
-      <div class="markdown-body">
-        <ul class="queue-list">
-          ${items
-            .map(
-              (item) =>
-                `<li class="queue-item">
-                  <span class="op-badge">${escapeHtml(OP_BADGE_GLYPHS[item.op ?? ""] ?? "?")}</span>
-                  <strong>${escapeHtml(item.target ?? item.id)}</strong>
-                  ${item.summary ? `<span class="queue-summary">${escapeHtml(item.summary)}</span>` : ""}
-                </li>`,
-            )
-            .join("")}
-        </ul>
+      <div class="markdown-body" id="codex-reader-body">
+        ${markdownHtml}
+      </div>
+      <div class="queue-decision-section" data-decision-bar-wrap>
+        ${isPending
+          ? renderDecisionBarContent("idle", null)
+          : renderDecidedState(meta)}
       </div>
     </article>
   `;
+}
+
+function renderPatchMetaChips(proposer: string, tags: string[]): string {
+  const parts: string[] = [];
+  if (proposer) parts.push(`<span class="meta-chip">${escapeHtml(proposer)}</span>`);
+  if (tags.length > 0) parts.push(renderTagChips(tags));
+  if (parts.length === 0) return "";
+  return `<div class="meta-chips">${parts.join("")}</div>`;
+}
+
+function renderDecisionBarContent(
+  phase: "idle" | "approving" | "rejecting" | "submitting",
+  error: string | null,
+): string {
+  if (phase === "submitting") {
+    return `<span class="queue-action-spinner" role="status" aria-label="Processing…"></span>`;
+  }
+  if (phase === "approving") {
+    return `
+      <p class="queue-decision-confirm">Apply this patch to the wiki?</p>
+      <div class="queue-action-buttons">
+        <button type="button" class="queue-action-btn queue-action-btn--approve" data-drydock-action="approve-confirm">✓ Yes, Approve</button>
+        <button type="button" class="queue-action-btn queue-action-btn--cancel" data-drydock-action="cancel">Cancel</button>
+      </div>
+      ${error ? `<p class="queue-action-error">${escapeHtml(error)}</p>` : ""}
+    `;
+  }
+  if (phase === "rejecting") {
+    return `
+      <div class="queue-reject-form">
+        <textarea class="queue-reject-textarea" id="queue-reject-reason" placeholder="Rejection reason (required)…" rows="3"></textarea>
+        <div class="queue-action-buttons">
+          <button type="button" class="queue-action-btn queue-action-btn--reject-submit" data-drydock-action="reject-submit">Submit Rejection</button>
+          <button type="button" class="queue-action-btn queue-action-btn--cancel" data-drydock-action="cancel">Cancel</button>
+        </div>
+        ${error ? `<p class="queue-action-error">${escapeHtml(error)}</p>` : ""}
+      </div>
+    `;
+  }
+  // idle
+  return `
+    <div class="queue-action-buttons">
+      <button type="button" class="queue-action-btn queue-action-btn--approve" data-drydock-action="approve">✓ Approve</button>
+      <button type="button" class="queue-action-btn queue-action-btn--reject" data-drydock-action="reject">✕ Reject</button>
+    </div>
+  `;
+}
+
+function renderDecidedState(meta: DrydockMeta): string {
+  const isAccepted = meta.status === "accepted";
+  const label = isAccepted ? "✓ Approved" : "✕ Rejected";
+  const cls = isAccepted ? "queue-decision-decided--approve" : "queue-decision-decided--reject";
+  const reason = meta.reason ? ` · ${escapeHtml(meta.reason)}` : "";
+  return `<p class="queue-decision-decided ${cls}">${label}${reason}</p>`;
 }
 
 function renderConflictDetail(detail: ConflictDetailResponse): string {
@@ -332,4 +560,19 @@ function renderConflictList(conflicts: ConflictListItem[]): string {
       </div>
     </article>
   `;
+}
+
+function formatRelativeTime(isoString: string): string {
+  try {
+    const diffMs = Date.now() - new Date(isoString).getTime();
+    const diffHours = diffMs / (1000 * 60 * 60);
+    if (diffHours < 1) return "< 1h ago";
+    if (diffHours < 24) return `${Math.floor(diffHours)}h ago`;
+    const diffDays = diffHours / 24;
+    if (diffDays < 7) return `${Math.floor(diffDays)}d ago`;
+    if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
+    return `${Math.floor(diffDays / 30)}mo ago`;
+  } catch {
+    return "";
+  }
 }

--- a/runtime/fleet-console/core/client/src/codex/styles/components.css
+++ b/runtime/fleet-console/core/client/src/codex/styles/components.css
@@ -1427,6 +1427,82 @@ kbd {
   gap: var(--space-3);
 }
 
+/* 컴팩트 대화형 패치 행 (레일 목록 뷰) */
+.queue-row-list {
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-2) 0;
+}
+
+.queue-row {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: var(--space-2);
+  align-items: start;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  background: transparent;
+  border: 1px solid transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  width: 100%;
+  min-width: 0;
+  transition:
+    background var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring);
+}
+
+.queue-row:hover {
+  background: color-mix(in oklch, var(--brass) 6%, transparent);
+  border-color: color-mix(in oklch, var(--brass) 22%, transparent);
+}
+
+.queue-row-badge {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 1px;
+}
+
+.queue-row-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.queue-row-target {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: var(--ink-pearl);
+  letter-spacing: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.queue-row-summary {
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  color: var(--ink-spectral);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.queue-row-meta {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-2xs);
+  color: var(--ink-fog);
+  letter-spacing: 0.04em;
+  margin-top: 2px;
+}
+
 .queue-empty {
   margin: 0;
   padding: var(--space-5) 0;
@@ -1736,6 +1812,71 @@ kbd {
   overflow-x: auto;
   display: block;
   white-space: pre;
+}
+
+/* 패치 상세 뒤로가기 버튼 */
+.queue-back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 3px 8px;
+  border-radius: var(--radius-xs);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  margin-bottom: var(--space-4);
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring);
+}
+
+.queue-back-btn:hover {
+  color: var(--ink-pearl);
+  border-color: var(--surface-rim);
+  background: var(--surface-glass);
+}
+
+/* 패치 상세 결정 바 */
+.queue-decision-section {
+  margin-top: var(--space-8);
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--surface-rim);
+}
+
+.queue-decision-confirm {
+  margin: 0 0 var(--space-3) 0;
+  font-size: var(--font-size-md);
+  color: var(--ink-spectral);
+  font-family: var(--font-body);
+}
+
+.queue-decision-decided {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-xs);
+  display: inline-flex;
+  align-items: center;
+}
+
+.queue-decision-decided--approve {
+  color: var(--brass-bright);
+  background: color-mix(in oklch, var(--brass) 10%, transparent);
+  border: 1px solid color-mix(in oklch, var(--brass) 30%, transparent);
+}
+
+.queue-decision-decided--reject {
+  color: var(--coral);
+  background: color-mix(in oklch, var(--coral) 8%, transparent);
+  border: 1px solid color-mix(in oklch, var(--coral) 25%, transparent);
 }
 
 /* ===== Drydock 액션 카드 ===== */

--- a/runtime/fleet-console/core/client/src/components/codex-reading-sheet.tsx
+++ b/runtime/fleet-console/core/client/src/components/codex-reading-sheet.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom";
 import { mountReaderInto, saveReaderScroll } from "../codex-host.js";
 import { useConsoleState } from "../hooks/use-store.js";
 import { collapseCodexReader, expandCodexReader, openCodexReader } from "../store.js";
+import { loadInitialData } from "../codex/state.js";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -108,6 +109,15 @@ export function CodexReadingSheet() {
         expandCodexReader();
       },
       onClose: closeReading,
+      onPatchOpen: (pid) => {
+        openCodexReader({ kind: "drydock", patchId: pid });
+        expandCodexReader();
+      },
+      onDecided: () => {
+        void loadInitialData();
+        openCodexReader({ kind: "drydock", patchId: undefined });
+        expandCodexReader();
+      },
     });
 
     requestAnimationFrame(() => {

--- a/runtime/fleet-console/core/client/src/rail/codex-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/codex-panel.tsx
@@ -12,6 +12,7 @@ import {
   teardownReaderNodes,
 } from "../codex-host.js";
 import { closeCodexReader, expandCodexReader, openCodexReader } from "../store.js";
+import { loadInitialData } from "../codex/state.js";
 
 // ─── Rail panel descriptor ────────────────────────────────────────────────────
 
@@ -95,6 +96,11 @@ function CodexRailPanel() {
       theaterId: activeTheaterId,
       onRelatedClick: (id) => openCodexReader({ kind: "entry", entryId: id }),
       onClose: () => closeCodexReader(),
+      onPatchOpen: (pid) => openCodexReader({ kind: "drydock", patchId: pid }),
+      onDecided: () => {
+        void loadInitialData();
+        openCodexReader({ kind: "drydock", patchId: undefined });
+      },
     });
   }, [shouldMountCodex, activeTheaterId, hasReader, expanded, readerKey]);
 


### PR DESCRIPTION
## Summary

Codex 레일 재개편 과정에서 Drydock 패치 큐 리뷰 UI가 읽기 전용 stub으로 남아, 목록이 거대 세리프로 넘쳐 잘리고, 항목을 클릭할 수 없으며, 승인/반려 수단이 없었습니다(리뷰 루프 절단 회귀). 백엔드 라우트·클라이언트 API·디자인 CSS는 모두 온전했고 **클라이언트 렌더/인터랙션 배선만** 잘려 있었습니다.

- **목록**: 오버플로우되던 정적 목록을 컴팩트 대화형 행(op 배지·target·요약·상대시간)으로 복원.
- **상세**: 행 클릭 시 제안된 위키 문서를 공유 Codex 마크다운 파이프라인(`renderMarkdown` + `.markdown-body` + ToC)으로 렌더 — 기존의 raw 패치 본문 덤프를 대체. (diff가 아닌 문서 렌더가 목표)
- **결정 바**: 승인 2단계 확인 + 반려 사유 필수. 기존 decision 엔드포인트에 배선하고, 결정 후 pending 카운트 갱신·목록 복귀.
- 인레일 split 뷰와 확장 Reading 오버레이 양쪽에서 동작(reader 싱글톤 relocate 경로 재사용).

백엔드(`core/host/codex/**`)·클라이언트 `api.ts` 시그니처는 불변, 소비만 했습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (478 passed / 22 skipped)
- [x] console-e2e 실측(격리 인스턴스 + pending 패치 시드): 목록 대화형 행·오버플로우 0 / 마크다운 상세 렌더 / 승인 2단계→wiki 파일 생성→배지 감소 / 반려 사유필수→archive status:rejected+reason 영속 / Expand 오버레이 문서+ToC+결정 바 / JS 에러 0

## Changelog

- [x] `.changelog.d/*.md` fragment included (`section: Fixed`, `[fleet-console]`)