### PR TITLE
fix(fleet-console): preserve Korean IME Shift+Enter input

### DIFF
--- a/.changelog.d/fix-terminal-ime-shift-enter.md
+++ b/.changelog.d/fix-terminal-ime-shift-enter.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- [fleet-console] Korean IME input now keeps composed text together when Shift+Enter inserts a newline in terminal panels.

--- a/runtime/fleet-plugins/terminal/client/shared/ime-shift-enter.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/ime-shift-enter.ts
@@ -1,0 +1,147 @@
+// IME composition 중 Shift+Enter 처리 헬퍼.
+//
+// 문제: xterm 커스텀 키 핸들러는 keydown 단계에서 호출된다. xterm CompositionHelper는
+// compositionend에서 setTimeout(0)으로 최종 한글을 전송하는데, 핸들러가 keydown에서 즉시
+// terminal.input("\n")을 호출하면 LF가 최종 한글보다 먼저 들어가 한글이 줄 사이에 분리된다.
+//
+// 해결: xterm helper textarea의 compositionend 이벤트에서 setTimeout(0)으로 LF를 예약한다.
+// 이 리스너는 terminal.open() 이후 등록하므로 xterm의 compositionend 리스너가 먼저 실행돼
+// setTimeout(0)을 큐에 넣고, 우리 타이머가 그 뒤에 들어가 FIFO 순서로 한글 뒤에 LF가 붙는다.
+// 실제 IME는 compositionend 직후 같은 이벤트 흐름에서 Shift+Enter keydown을 낼 수 있으므로,
+// compositionend 후 xterm의 최종 전송 타이머가 도는 한 tick 동안도 composition finalizing 상태로 본다.
+
+export interface ImeShiftEnterHandler {
+  readonly onCompositionStart: () => void;
+  readonly onCompositionEnd: () => void;
+  readonly onCompositionCancel: () => void;
+  // attachCustomKeyEventHandler에 그대로 전달한다. false=xterm 기본 동작 차단, true=통과.
+  readonly handleKeyEvent: (event: ImeShiftEnterKeyEvent) => boolean;
+  // composition 중 pendingLF 타이머를 취소하고 상태를 초기화한다.
+  readonly dispose: () => void;
+}
+
+export interface ImeShiftEnterKeyEvent {
+  readonly code?: string;
+  readonly key: string;
+  readonly keyCode?: number;
+  readonly preventDefault?: () => void;
+  readonly shiftKey: boolean;
+  readonly type: string;
+  readonly which?: number;
+  readonly isComposing?: boolean;
+}
+
+// sendLF: terminal.input("\n")을 감싼 콜백. 테스트에서는 vi.fn()으로 대체한다.
+export function createImeShiftEnterHandler(sendLF: () => void): ImeShiftEnterHandler {
+  let isComposing = false;
+  let isCompositionFinalizing = false;
+  let pendingLF = false;
+  let handledShiftEnterKeyDown = false;
+  let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+  let finalizingTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearPendingLF = () => {
+    if (pendingTimer !== null) {
+      clearTimeout(pendingTimer);
+      pendingTimer = null;
+    }
+    pendingLF = false;
+  };
+  const clearFinalizing = () => {
+    if (finalizingTimer !== null) {
+      clearTimeout(finalizingTimer);
+      finalizingTimer = null;
+    }
+    isCompositionFinalizing = false;
+  };
+  const markCompositionFinalizing = () => {
+    clearFinalizing();
+    isCompositionFinalizing = true;
+    finalizingTimer = setTimeout(() => {
+      finalizingTimer = null;
+      isCompositionFinalizing = false;
+    }, 0);
+  };
+  const schedulePendingLF = () => {
+    pendingLF = false;
+    if (pendingTimer !== null) clearTimeout(pendingTimer);
+    if (finalizingTimer !== null) {
+      clearTimeout(finalizingTimer);
+      finalizingTimer = null;
+    }
+    pendingTimer = setTimeout(() => {
+      pendingTimer = null;
+      isCompositionFinalizing = false;
+      sendLF();
+    }, 0);
+  };
+  const cancelComposition = () => {
+    isComposing = false;
+    if (pendingTimer !== null) {
+      return;
+    }
+    clearFinalizing();
+    pendingLF = false;
+  };
+  const dispose = () => {
+    isComposing = false;
+    handledShiftEnterKeyDown = false;
+    clearFinalizing();
+    clearPendingLF();
+  };
+  const handleShiftEnterInput = (event: ImeShiftEnterKeyEvent) => {
+    if (pendingTimer !== null) return;
+    if (isComposing || isCompositionFinalizing || isImeCompositionKeyEvent(event)) {
+      // composition 종료 후 LF를 한 번 전송하도록 예약한다.
+      pendingLF = true;
+      if (isCompositionFinalizing && !isComposing) {
+        schedulePendingLF();
+      } else {
+        isComposing = true;
+      }
+      return;
+    }
+    sendLF();
+  };
+
+  return {
+    onCompositionStart() {
+      isComposing = true;
+    },
+    onCompositionEnd() {
+      isComposing = false;
+      markCompositionFinalizing();
+      if (!pendingLF) return;
+      // xterm의 compositionend setTimeout(0)이 먼저 큐에 들어간 뒤 이 타이머가 뒤따르므로
+      // 최종 조합 문자가 터미널에 기록된 다음에 LF가 전송된다.
+      schedulePendingLF();
+    },
+    onCompositionCancel: cancelComposition,
+    handleKeyEvent(event) {
+      if (isEnterKeyEvent(event) && event.shiftKey) {
+        event.preventDefault?.();
+        if (event.type === "keydown") {
+          handledShiftEnterKeyDown = true;
+          handleShiftEnterInput(event);
+        } else if (event.type === "keypress") {
+          if (!handledShiftEnterKeyDown) handleShiftEnterInput(event);
+          handledShiftEnterKeyDown = false;
+        } else if (event.type === "keyup") {
+          handledShiftEnterKeyDown = false;
+        }
+        // keydown/keypress 모두 false를 반환해 xterm 기본 CR 전송을 차단한다.
+        return false;
+      }
+      return true;
+    },
+    dispose,
+  };
+}
+
+function isEnterKeyEvent(event: ImeShiftEnterKeyEvent): boolean {
+  return event.key === "Enter" || event.code === "Enter" || event.keyCode === 13 || event.which === 13;
+}
+
+function isImeCompositionKeyEvent(event: ImeShiftEnterKeyEvent): boolean {
+  return event.isComposing === true || event.keyCode === 229 || event.which === 229;
+}

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -6,6 +6,7 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal as XtermTerminal, type ITheme } from "@xterm/xterm";
 import { useEffect, useRef, useState, type CSSProperties } from "react";
 
+import { createImeShiftEnterHandler } from "./ime-shift-enter.js";
 import { createTerminalConnection, type TerminalConnection } from "./terminal-connection.js";
 import { useTerminalPrefs } from "./terminal-prefs-store.js";
 
@@ -135,18 +136,16 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "mari
     terminal.loadAddon(new Unicode11Addon());
     terminal.unicode.activeVersion = "11";
 
-    // Shift+Enter는 개행(LF)으로 처리한다. xterm 기본 동작은 Shift 여부와 무관하게 Enter를
-    // CR(\r)로 보내 TUI가 이를 "제출"로 해석하므로, Shift+Enter는 직접 LF(\n)를 입력시키고
-    // (input()이 onData를 트리거해 기존 전송 경로를 탄다) 기본 CR 전송을 막는다.
-    // 이 핸들러는 keydown뿐 아니라 keypress 이벤트에서도 호출되므로, keydown에서만 LF를 한 번
-    // 입력시키되 false 반환은 모든 이벤트 타입에 적용해야 keypress 경로의 CR 전송까지 차단된다.
-    terminal.attachCustomKeyEventHandler((event) => {
-      if (event.key === "Enter" && event.shiftKey) {
-        if (event.type === "keydown") terminal.input("\n");
-        return false;
-      }
-      return true;
-    });
+    // Shift+Enter를 LF(\n)로 처리한다. xterm 기본 동작은 Shift 무관하게 Enter를 CR(\r)로 보내
+    // TUI가 "제출"로 해석하므로, Shift+Enter는 LF를 직접 전송하고 기본 CR 전송을 막는다.
+    // IME composition 중에는 xterm helper textarea의 compositionend 뒤 setTimeout(0)으로 LF를 예약해
+    // xterm CompositionHelper의 최종 한글 전송(compositionend→setTimeout(0)) 뒤에 LF가 붙게 한다.
+    const imeHandler = createImeShiftEnterHandler(() => terminal.input("\n"));
+    const imeEventTarget = container.querySelector<HTMLElement>("textarea.xterm-helper-textarea, textarea") ?? container;
+    imeEventTarget.addEventListener("compositionstart", imeHandler.onCompositionStart);
+    imeEventTarget.addEventListener("compositionend", imeHandler.onCompositionEnd);
+    imeEventTarget.addEventListener("focusout", imeHandler.onCompositionCancel);
+    terminal.attachCustomKeyEventHandler(imeHandler.handleKeyEvent);
 
     const outputScheduler = createTerminalOutputScheduler(terminal, activeRef.current !== false);
     outputSchedulerRef.current = outputScheduler;
@@ -203,6 +202,10 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "mari
       disposed = true;
       resizeObserver.disconnect();
       if (resizeDebounce) clearTimeout(resizeDebounce);
+      imeEventTarget.removeEventListener("compositionstart", imeHandler.onCompositionStart);
+      imeEventTarget.removeEventListener("compositionend", imeHandler.onCompositionEnd);
+      imeEventTarget.removeEventListener("focusout", imeHandler.onCompositionCancel);
+      imeHandler.dispose();
       connection.dispose();
       outputScheduler.dispose();
       terminalRef.current = null;

--- a/runtime/fleet-plugins/terminal/tests/ime-shift-enter.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ime-shift-enter.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createImeShiftEnterHandler, type ImeShiftEnterKeyEvent } from "../client/shared/ime-shift-enter.js";
+
+// KeyboardEvent의 Pick 서브셋을 만드는 헬퍼
+function makeKey(
+  key: string,
+  shiftKey: boolean,
+  type: "keydown" | "keypress" | "keyup" = "keydown",
+  overrides: Partial<ImeShiftEnterKeyEvent> = {},
+): ImeShiftEnterKeyEvent {
+  return { key, shiftKey, type, ...overrides };
+}
+
+describe("createImeShiftEnterHandler", () => {
+  let sendLF: ReturnType<typeof vi.fn<() => void>>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sendLF = vi.fn<() => void>();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ── 비-IME 경로 ──────────────────────────────────────────────────────────────
+
+  it("composition 없는 상태에서 Shift+Enter keydown → 즉시 LF 전송", () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    const result = handler.handleKeyEvent(makeKey("Enter", true, "keydown"));
+    expect(result).toBe(false);
+    expect(sendLF).toHaveBeenCalledTimes(1);
+  });
+
+  it("Shift+Enter는 textarea 기본 개행을 막기 위해 preventDefault 호출", () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    const preventDefault = vi.fn();
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown", { preventDefault }));
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("IME가 key 대신 code=Enter만 주는 Shift+Enter도 처리", () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    const preventDefault = vi.fn();
+    const result = handler.handleKeyEvent(makeKey("Process", true, "keydown", { code: "Enter", preventDefault }));
+    expect(result).toBe(false);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(sendLF).toHaveBeenCalledTimes(1);
+  });
+
+  it("IME가 keyCode=13만 주는 Shift+Enter도 처리", () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    const preventDefault = vi.fn();
+    const result = handler.handleKeyEvent(makeKey("Process", true, "keydown", { keyCode: 13, preventDefault }));
+    expect(result).toBe(false);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(sendLF).toHaveBeenCalledTimes(1);
+  });
+
+  it("keydown 뒤 keypress에서 Shift+Enter → LF 중복 전송 안 함, false 반환", () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown"));
+    const result = handler.handleKeyEvent(makeKey("Enter", true, "keypress"));
+    expect(result).toBe(false);
+    expect(sendLF).toHaveBeenCalledTimes(1);
+  });
+
+  it("keydown 없이 keypress만 오는 Shift+Enter → LF 전송", () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    const result = handler.handleKeyEvent(makeKey("Enter", true, "keypress"));
+    expect(result).toBe(false);
+    expect(sendLF).toHaveBeenCalledTimes(1);
+  });
+
+  it("Shift 없는 Enter → 기본 동작 통과(true 반환)", () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    const result = handler.handleKeyEvent(makeKey("Enter", false, "keydown"));
+    expect(result).toBe(true);
+    expect(sendLF).not.toHaveBeenCalled();
+  });
+
+  it("다른 키는 true 반환하고 sendLF 미호출", () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    expect(handler.handleKeyEvent(makeKey("a", false))).toBe(true);
+    expect(handler.handleKeyEvent(makeKey("ArrowUp", true))).toBe(true);
+    expect(sendLF).not.toHaveBeenCalled();
+  });
+
+  // ── IME composition 경로 ─────────────────────────────────────────────────────
+
+  it("composition 중 Shift+Enter keydown → LF 즉시 전송 안 됨", () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    handler.onCompositionStart();
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown"));
+    expect(sendLF).not.toHaveBeenCalled();
+  });
+
+  it("event.isComposing만 true여도 Shift+Enter keydown → LF 즉시 전송 안 됨", () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown", { isComposing: true }));
+    expect(sendLF).not.toHaveBeenCalled();
+  });
+
+  it("keyCode 229만 있는 IME Shift+Enter keydown → LF 즉시 전송 안 됨", () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown", { keyCode: 229 }));
+    expect(sendLF).not.toHaveBeenCalled();
+  });
+
+  it("code=Enter + keyCode 229인 IME Shift+Enter keydown → LF 즉시 전송 안 됨", () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    handler.handleKeyEvent(makeKey("Process", true, "keydown", { code: "Enter", keyCode: 229 }));
+    expect(sendLF).not.toHaveBeenCalled();
+  });
+
+  it("keydown 없이 keypress만 오는 IME Shift+Enter → compositionend까지 LF 지연", async () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    handler.handleKeyEvent(makeKey("Enter", true, "keypress", { isComposing: true }));
+    expect(sendLF).not.toHaveBeenCalled();
+    handler.onCompositionEnd();
+    await vi.runAllTimersAsync();
+    expect(sendLF).toHaveBeenCalledTimes(1);
+  });
+
+  it("which 229만 있는 IME Shift+Enter keydown → LF 즉시 전송 안 됨", () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown", { which: 229 }));
+    expect(sendLF).not.toHaveBeenCalled();
+  });
+
+  it("composition 중 Shift+Enter 후 compositionend → 다음 tick에 LF 전송", async () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    handler.onCompositionStart();
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown"));
+    handler.onCompositionEnd();
+    // 아직 setTimeout(0) 이전 — LF 미전송
+    expect(sendLF).not.toHaveBeenCalled();
+    // 타이머 진행 후 전송
+    await vi.runAllTimersAsync();
+    expect(sendLF).toHaveBeenCalledTimes(1);
+  });
+
+  it("compositionend 직후 같은 tick의 Shift+Enter → 다음 tick에 LF 전송", async () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    handler.onCompositionStart();
+    handler.onCompositionEnd();
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown"));
+    expect(sendLF).not.toHaveBeenCalled();
+    await vi.runAllTimersAsync();
+    expect(sendLF).toHaveBeenCalledTimes(1);
+  });
+
+  it("compositionend 직후 LF 타이머 대기 중 추가 Shift+Enter → LF 중복 전송 안 함", async () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    handler.onCompositionStart();
+    handler.onCompositionEnd();
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown"));
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown"));
+    expect(sendLF).not.toHaveBeenCalled();
+    await vi.runAllTimersAsync();
+    expect(sendLF).toHaveBeenCalledTimes(1);
+  });
+
+  it("composition 중 Shift+Enter 없이 compositionend → LF 전송 안 됨", async () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    handler.onCompositionStart();
+    handler.onCompositionEnd();
+    await vi.runAllTimersAsync();
+    expect(sendLF).not.toHaveBeenCalled();
+  });
+
+  it("compositionend 뒤 예약된 LF는 focusout cancel이 취소하지 않음", async () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    handler.onCompositionStart();
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown"));
+    handler.onCompositionEnd();
+    handler.onCompositionCancel();
+    await vi.runAllTimersAsync();
+    expect(sendLF).toHaveBeenCalledTimes(1);
+  });
+
+  it("compositionend 뒤 예약된 LF는 focusout 직후 추가 Shift+Enter와 중복되지 않음", async () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    handler.onCompositionStart();
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown"));
+    handler.onCompositionEnd();
+    handler.onCompositionCancel();
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown"));
+    await vi.runAllTimersAsync();
+    expect(sendLF).toHaveBeenCalledTimes(1);
+  });
+
+  it("composition 중 Shift+Enter 여러 번 → LF는 compositionend 후 딱 한 번", async () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    handler.onCompositionStart();
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown"));
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown"));
+    handler.onCompositionEnd();
+    await vi.runAllTimersAsync();
+    expect(sendLF).toHaveBeenCalledTimes(1);
+  });
+
+  it("compositionend 후 isComposing이 false가 돼 이후 Shift+Enter는 즉시 LF", async () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    handler.onCompositionStart();
+    handler.onCompositionEnd();
+    await vi.runAllTimersAsync();
+    // 이제 composition 해제 — 즉시 경로로 돌아와야 함
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown"));
+    expect(sendLF).toHaveBeenCalledTimes(1);
+  });
+
+  // ── dispose 경로 ─────────────────────────────────────────────────────────────
+
+  it("pendingLF 대기 중 dispose → 타이머 취소되고 LF 전송 안 됨", async () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    handler.onCompositionStart();
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown"));
+    handler.onCompositionEnd();
+    handler.dispose();
+    await vi.runAllTimersAsync();
+    expect(sendLF).not.toHaveBeenCalled();
+  });
+
+  it("pendingLF 대기 중 composition cancel → 이후 Shift+Enter는 즉시 LF", async () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    handler.onCompositionStart();
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown"));
+    handler.onCompositionCancel();
+    await vi.runAllTimersAsync();
+    expect(sendLF).not.toHaveBeenCalled();
+    handler.handleKeyEvent(makeKey("Enter", true, "keydown"));
+    expect(sendLF).toHaveBeenCalledTimes(1);
+  });
+
+  it("pendingLF 없는 상태의 dispose는 부작용 없음", () => {
+    const handler = createImeShiftEnterHandler(sendLF);
+    expect(() => handler.dispose()).not.toThrow();
+    expect(sendLF).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- route terminal Shift+Enter handling through an IME-aware helper that waits for xterm composition finalization before sending LF
- attach composition listeners to xterm helper textareas and prevent default textarea newlines
- cover IME event variants including key=Process/code=Enter, keyCode/which 229, keypress-only Shift+Enter, focusout, and dispose paths

## Validation
- pnpm --filter @fleet-plugins/terminal test
- pnpm --filter @fleet-plugins/terminal build
- pnpm --filter @dotobokuri/fleet-console typecheck
- pnpm --filter @dotobokuri/fleet-console build
- node scripts/compile-changelog-fragments.mjs --check
- git diff --check
- Headed agent-browser e2e on Shell, Claude, and Codex terminal panels: Korean IME composition payload remained `한글` followed by `\n`

## Notes
- Windows CMD/PowerShell are expected to share this frontend xterm input path; unit coverage includes Windows/Chromium-style IME key shapes, but physical Windows host e2e was not available in this workspace.