### PR TITLE
fix(fleet-console): hide unsupported Claude launch aliases

### DIFF
--- a/.changelog.d/fix-operation-controls-hide-claude-aliases.md
+++ b/.changelog.d/fix-operation-controls-hide-claude-aliases.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- [fleet-console] Hid unsupported Claude Kimi and Claude GLM launch aliases from Operation Controls.

--- a/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
@@ -4,25 +4,25 @@ import type { OperationLaunchKind } from "@fleet-console/sdk/operations";
 import type { AgentCliLaunchMetadata } from "./agent-cli-launch-metadata.js";
 
 const UNSUPPORTED_AGENT_CLI_IDS: ReadonlySet<AgentCliId> = new Set(["claude-kimi", "claude-glm"]);
-const UNSUPPORTED_AGENT_CLI_DISABLED_REASON = "Not supported";
 
 export function buildAgentCliLaunchKinds(
   metadata: readonly AgentCliLaunchMetadata[],
   operationType: string,
 ): OperationLaunchKind[] {
-  return metadata.map((cli) => {
-    const disabledReason = resolveDisabledReason(cli);
-    return {
-      id: cli.id,
-      type: operationType,
-      title: cli.label,
-      ...(disabledReason ? { disabled: true, disabledReason } : {}),
-    };
-  });
+  return metadata
+    .filter((cli) => !UNSUPPORTED_AGENT_CLI_IDS.has(cli.id))
+    .map((cli) => {
+      const disabledReason = resolveDisabledReason(cli);
+      return {
+        id: cli.id,
+        type: operationType,
+        title: cli.label,
+        ...(disabledReason ? { disabled: true, disabledReason } : {}),
+      };
+    });
 }
 
 function resolveDisabledReason(cli: AgentCliLaunchMetadata): string | undefined {
-  if (UNSUPPORTED_AGENT_CLI_IDS.has(cli.id)) return UNSUPPORTED_AGENT_CLI_DISABLED_REASON;
   if (!cli.available) return "Not installed";
   if (!cli.signedIn) return "Sign in required";
   return undefined;

--- a/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { buildAgentCliLaunchKinds } from "../server/agent-api/agent-cli-launch-kinds.js";
 
 describe("buildAgentCliLaunchKinds", () => {
-  it("Claude Kimi와 Claude GLM을 Operation Controls에서 미지원으로 비활성화한다", () => {
+  it("Claude Kimi와 Claude GLM을 Operation Controls 목록에서 숨긴다", () => {
     const result = buildAgentCliLaunchKinds(
       [
         { id: "claude", label: "Claude", available: true, signedIn: true },
@@ -16,8 +16,6 @@ describe("buildAgentCliLaunchKinds", () => {
 
     expect(result).toEqual([
       { id: "claude", type: "agent", title: "Claude" },
-      { id: "claude-kimi", type: "agent", title: "Claude Kimi", disabled: true, disabledReason: "Not supported" },
-      { id: "claude-glm", type: "agent", title: "Claude GLM", disabled: true, disabledReason: "Not supported" },
       { id: "codex", type: "agent", title: "Codex" },
     ]);
   });


### PR DESCRIPTION
## Summary
- Hide the unsupported Claude Kimi and Claude GLM launch aliases from the Operation Controls launch catalog instead of rendering them as disabled items.
- Update the terminal launch catalog unit test to assert the hidden-alias contract.
- Add a fleet-console changelog fragment for the visible UI fix.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal exec vitest run tests/agent-cli-launch-kinds.test.ts`
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `git diff --check`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Headed isolated console e2e: Operation Controls rendered `Claude`, `Codex`, and `Shell` only; `Claude Kimi`, `Claude GLM`, and `NOT SUPPORTED` were absent.

## Changelog
- [x] Added one `.changelog.d/*.md` fragment, or applied the `no-changelog` label intentionally.
- [x] Fragment `section:` is one of `Added`, `Changed`, `Fixed`, `Removed`, or `Breaking Changes`.
- [x] Fragment bullets are English and use only `[core-agent]`, `[core-unified-agent]`, `[fleet-infra]`, `[fleet-admiral]`, `[fleet-carriers]`, `[fleet-wiki]`, `[fleet-console]`, or `[fleet-cli]`.