### PR TITLE
fix(carriers): surface Codex ACP stderr diagnostics

### DIFF
--- a/.changelog.d/fix-codex-acp-stderr-diagnostics.md
+++ b/.changelog.d/fix-codex-acp-stderr-diagnostics.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- [core-unified-agent] [fleet-carriers] Include redacted Codex ACP stderr diagnostics in failed carrier jobs without adding stderr to successful results.

--- a/packages/core-unified-agent/src/connection/AcpConnection.ts
+++ b/packages/core-unified-agent/src/connection/AcpConnection.ts
@@ -175,7 +175,7 @@ export class AcpConnection extends BaseConnection {
       } catch {
         // 정리 실패는 원본 예외를 가리지 않음
       }
-      throw error;
+      throw this.withStderrDiagnostics(error, 'ACP initialize');
     }
   }
 
@@ -195,54 +195,58 @@ export class AcpConnection extends BaseConnection {
     strictMcp?: boolean,
     effort?: string,
   ): Promise<NewSessionResponse> {
-    const agent = this.getAgent();
-    const servers = mcpServers ?? [];
+    try {
+      const agent = this.getAgent();
+      const servers = mcpServers ?? [];
 
-    let session: NewSessionResponse;
-    if (sessionId) {
-      if (!agent.loadSession) {
-        throw new Error('연결된 에이전트가 session/load를 지원하지 않습니다');
-      }
-      const loadSessionParams: LoadSessionRequest & { _meta?: Record<string, unknown> } = {
-        sessionId,
-        cwd: workspace,
-        mcpServers: servers,
-      };
-      const meta = this.buildClaudeSessionMeta(systemPrompt, strictMcp, effort);
-      if (meta) {
-        loadSessionParams._meta = meta;
-      }
-      const loadResult = await this.withFixedTimeout(
-        agent.loadSession(loadSessionParams),
-        this.initTimeout,
-        'session/load',
-      );
-      session = { ...loadResult, sessionId } as LoadSessionResponse & NewSessionResponse;
-    } else {
-      const newSessionParams: {
-        cwd: string;
-        mcpServers: McpServer[];
-        _meta?: Record<string, unknown>;
-      } = {
-        cwd: workspace,
-        mcpServers: servers,
-      };
+      let session: NewSessionResponse;
+      if (sessionId) {
+        if (!agent.loadSession) {
+          throw new Error('연결된 에이전트가 session/load를 지원하지 않습니다');
+        }
+        const loadSessionParams: LoadSessionRequest & { _meta?: Record<string, unknown> } = {
+          sessionId,
+          cwd: workspace,
+          mcpServers: servers,
+        };
+        const meta = this.buildClaudeSessionMeta(systemPrompt, strictMcp, effort);
+        if (meta) {
+          loadSessionParams._meta = meta;
+        }
+        const loadResult = await this.withFixedTimeout(
+          agent.loadSession(loadSessionParams),
+          this.initTimeout,
+          'session/load',
+        );
+        session = { ...loadResult, sessionId } as LoadSessionResponse & NewSessionResponse;
+      } else {
+        const newSessionParams: {
+          cwd: string;
+          mcpServers: McpServer[];
+          _meta?: Record<string, unknown>;
+        } = {
+          cwd: workspace,
+          mcpServers: servers,
+        };
 
-      const meta = this.buildClaudeSessionMeta(systemPrompt, strictMcp, effort);
-      if (meta) {
-        newSessionParams._meta = meta;
+        const meta = this.buildClaudeSessionMeta(systemPrompt, strictMcp, effort);
+        if (meta) {
+          newSessionParams._meta = meta;
+        }
+
+        session = await this.withFixedTimeout(
+          agent.newSession(newSessionParams),
+          this.initTimeout,
+          'session/new',
+        );
       }
 
-      session = await this.withFixedTimeout(
-        agent.newSession(newSessionParams),
-        this.initTimeout,
-        'session/new',
-      );
+      this.setState('ready');
+      this.activeSessionId = session.sessionId;
+      return session;
+    } catch (error) {
+      throw this.withStderrDiagnostics(error, sessionId ? 'ACP session/load' : 'ACP session/new');
     }
-
-    this.setState('ready');
-    this.activeSessionId = session.sessionId;
-    return session;
   }
 
   /**
@@ -302,14 +306,18 @@ export class AcpConnection extends BaseConnection {
       loadSessionParams._meta = meta;
     }
 
-    const result = await this.withFixedTimeout(
-      agent.loadSession(loadSessionParams),
-      this.requestTimeout,
-      'session/load',
-    );
-    this.activeSessionId = params.sessionId;
-    this.setState('ready');
-    return result;
+    try {
+      const result = await this.withFixedTimeout(
+        agent.loadSession(loadSessionParams),
+        this.requestTimeout,
+        'session/load',
+      );
+      this.activeSessionId = params.sessionId;
+      this.setState('ready');
+      return result;
+    } catch (error) {
+      throw this.withStderrDiagnostics(error, 'ACP session/load');
+    }
   }
 
   /**

--- a/packages/core-unified-agent/src/connection/BaseConnection.ts
+++ b/packages/core-unified-agent/src/connection/BaseConnection.ts
@@ -57,8 +57,9 @@ const SECRET_PATTERNS: readonly SecretPattern[] = [
 ];
 
 // PEM 블록 헤더/푸터 감지용 패턴 (줄 단위 상태 기계에서 사용)
-const PEM_BEGIN_PATTERN = /^-----BEGIN [A-Z ]*PRIVATE KEY-----$/;
-const PEM_END_PATTERN = /^-----END [A-Z ]*PRIVATE KEY-----$/;
+// 앵커 없이 포함 여부를 검사해 "PREFIX=-----BEGIN PRIVATE KEY-----" 같은 임베디드 마커도 감지
+const PEM_BEGIN_PATTERN = /-----BEGIN [A-Z ]*PRIVATE KEY-----/;
+const PEM_END_PATTERN = /-----END [A-Z ]*PRIVATE KEY-----/;
 
 /**
  * 프로세스 Spawn + Stream 관리 기반 클래스.

--- a/packages/core-unified-agent/src/connection/BaseConnection.ts
+++ b/packages/core-unified-agent/src/connection/BaseConnection.ts
@@ -31,6 +31,31 @@ export interface BaseConnectionOptions {
   promptIdleTimeout?: number;
 }
 
+interface SecretPattern {
+  readonly label: string;
+  readonly pattern: RegExp;
+}
+
+const STDERR_DIAGNOSTIC_LINE_LIMIT = 20;
+const STDERR_DIAGNOSTIC_LINE_CHAR_LIMIT = 2_000;
+const STDERR_DIAGNOSTIC_TOTAL_BYTE_LIMIT = 8_000;
+const ANSI_PATTERN = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+const CONTROL_PATTERN = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
+const SECRET_PATTERNS: readonly SecretPattern[] = [
+  { label: 'aws_access_key', pattern: /AKIA[0-9A-Z]{16}/g },
+  { label: 'github_token', pattern: /gh[psour]_[A-Za-z0-9]{36}/g },
+  { label: 'jwt', pattern: /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g },
+  { label: 'openai_key', pattern: /\bsk-[A-Za-z0-9_-]{20,}\b/g },
+  {
+    label: 'generic_secret',
+    pattern: /\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)[A-Z0-9_]*\s*[:=]\s*["']?[^\s"']+["']?/gi,
+  },
+  {
+    label: 'pem_private_key',
+    pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----/g,
+  },
+];
+
 /**
  * 프로세스 Spawn + Stream 관리 기반 클래스.
  * child_process.spawn으로 CLI 프로세스를 생성하고,
@@ -50,6 +75,7 @@ export class BaseConnection extends EventEmitter {
   protected readonly initTimeout: number;
   protected readonly promptIdleTimeout: number;
   protected stderrBuffer = '';
+  private readonly diagnosticStderrTail: string[] = [];
 
   constructor(options: BaseConnectionOptions) {
     super();
@@ -219,8 +245,31 @@ export class BaseConnection extends EventEmitter {
       return;
     }
 
+    this.recordDiagnosticStderrLine(message);
     this.emit('log', message);
     this.emit('logEntry', this.createStructuredLogEntry(message));
+  }
+
+  /** 실패 메시지에 붙일 수 있는 짧고 마스킹된 stderr tail을 반환합니다. */
+  protected getStderrDiagnosticTail(): string {
+    return this.diagnosticStderrTail.join('\n');
+  }
+
+  /** 원본 에러에 stderr tail 진단을 붙여 상위 계층으로 전달합니다. */
+  protected withStderrDiagnostics(error: unknown, phase: string): Error {
+    const baseError = error instanceof Error ? error : new Error(String(error));
+    this.flushStderrBuffer();
+    const stderrTail = this.getStderrDiagnosticTail();
+    if (!stderrTail || baseError.message.includes(`${phase} stderr tail:`)) {
+      return baseError;
+    }
+
+    const diagnosticError = new Error(
+      `${baseError.message}\n\n${phase} stderr tail:\n${stderrTail}`,
+      { cause: baseError },
+    );
+    diagnosticError.name = baseError.name;
+    return diagnosticError;
   }
 
   /** 기본 구조화 stderr 로그 항목을 생성합니다. */
@@ -266,6 +315,24 @@ export class BaseConnection extends EventEmitter {
       }),
     ]);
   }
+
+  private recordDiagnosticStderrLine(message: string): void {
+    const sanitized = sanitizeDiagnosticStderrLine(message);
+    if (!sanitized) {
+      return;
+    }
+
+    this.diagnosticStderrTail.push(sanitized);
+    while (this.diagnosticStderrTail.length > STDERR_DIAGNOSTIC_LINE_LIMIT) {
+      this.diagnosticStderrTail.shift();
+    }
+    while (
+      byteLength(this.getStderrDiagnosticTail()) > STDERR_DIAGNOSTIC_TOTAL_BYTE_LIMIT &&
+      this.diagnosticStderrTail.length > 1
+    ) {
+      this.diagnosticStderrTail.shift();
+    }
+  }
 }
 
 /**
@@ -294,4 +361,24 @@ function quoteForCmd(token: string): string {
 function buildWindowsCmdArgs(command: string, args: string[]): string[] {
   const line = [command, ...args].map(quoteForCmd).join(' ');
   return ['/S', '/C', `"${line}"`];
+}
+
+function sanitizeDiagnosticStderrLine(value: string): string {
+  const cleaned = redactDiagnosticSecrets(value.replace(ANSI_PATTERN, '').replace(CONTROL_PATTERN, '')).trim();
+  if (cleaned.length <= STDERR_DIAGNOSTIC_LINE_CHAR_LIMIT) {
+    return cleaned;
+  }
+  const omitted = cleaned.length - STDERR_DIAGNOSTIC_LINE_CHAR_LIMIT;
+  return `${cleaned.slice(0, STDERR_DIAGNOSTIC_LINE_CHAR_LIMIT)} [truncated ${omitted} chars]`;
+}
+
+function redactDiagnosticSecrets(value: string): string {
+  return SECRET_PATTERNS.reduce(
+    (text, { label, pattern }) => text.replace(pattern, `[REDACTED:${label}]`),
+    value,
+  );
+}
+
+function byteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf8');
 }

--- a/packages/core-unified-agent/src/connection/BaseConnection.ts
+++ b/packages/core-unified-agent/src/connection/BaseConnection.ts
@@ -56,6 +56,10 @@ const SECRET_PATTERNS: readonly SecretPattern[] = [
   },
 ];
 
+// PEM 블록 헤더/푸터 감지용 패턴 (줄 단위 상태 기계에서 사용)
+const PEM_BEGIN_PATTERN = /^-----BEGIN [A-Z ]*PRIVATE KEY-----$/;
+const PEM_END_PATTERN = /^-----END [A-Z ]*PRIVATE KEY-----$/;
+
 /**
  * 프로세스 Spawn + Stream 관리 기반 클래스.
  * child_process.spawn으로 CLI 프로세스를 생성하고,
@@ -76,6 +80,8 @@ export class BaseConnection extends EventEmitter {
   protected readonly promptIdleTimeout: number;
   protected stderrBuffer = '';
   private readonly diagnosticStderrTail: string[] = [];
+  // PEM 블록 내부 여부 추적 (줄 단위 수신 시 바디 라인 누출 방지)
+  private inPemBlock = false;
 
   constructor(options: BaseConnectionOptions) {
     super();
@@ -317,7 +323,21 @@ export class BaseConnection extends EventEmitter {
   }
 
   private recordDiagnosticStderrLine(message: string): void {
-    const sanitized = sanitizeDiagnosticStderrLine(message);
+    const pemMarkerLine = normalizePemMarkerLine(message);
+
+    // PEM BEGIN 마커: 이후 모든 라인(바디·END 포함)을 비밀로 처리
+    if (PEM_BEGIN_PATTERN.test(pemMarkerLine)) {
+      this.inPemBlock = true;
+    }
+
+    const inBlock = this.inPemBlock;
+
+    // PEM END 마커: 현재 라인까지 비밀 처리 후 블록 종료
+    if (PEM_END_PATTERN.test(pemMarkerLine)) {
+      this.inPemBlock = false;
+    }
+
+    const sanitized = sanitizeDiagnosticStderrLine(message, inBlock);
     if (!sanitized) {
       return;
     }
@@ -363,13 +383,22 @@ function buildWindowsCmdArgs(command: string, args: string[]): string[] {
   return ['/S', '/C', `"${line}"`];
 }
 
-function sanitizeDiagnosticStderrLine(value: string): string {
-  const cleaned = redactDiagnosticSecrets(value.replace(ANSI_PATTERN, '').replace(CONTROL_PATTERN, '')).trim();
+function sanitizeDiagnosticStderrLine(value: string, isPemLine: boolean): string {
+  // PEM 블록 라인은 ANSI 제거·시크릿 스캔 없이 즉시 리댁트
+  const cleaned = (
+    isPemLine
+      ? '[REDACTED:pem_private_key]'
+      : redactDiagnosticSecrets(value.replace(ANSI_PATTERN, '').replace(CONTROL_PATTERN, ''))
+  ).trim();
   if (cleaned.length <= STDERR_DIAGNOSTIC_LINE_CHAR_LIMIT) {
     return cleaned;
   }
   const omitted = cleaned.length - STDERR_DIAGNOSTIC_LINE_CHAR_LIMIT;
   return `${cleaned.slice(0, STDERR_DIAGNOSTIC_LINE_CHAR_LIMIT)} [truncated ${omitted} chars]`;
+}
+
+function normalizePemMarkerLine(value: string): string {
+  return value.replace(ANSI_PATTERN, '').replace(CONTROL_PATTERN, '').trim();
 }
 
 function redactDiagnosticSecrets(value: string): string {

--- a/packages/core-unified-agent/tests/unit/AcpConnection.sessionLifecycle.test.ts
+++ b/packages/core-unified-agent/tests/unit/AcpConnection.sessionLifecycle.test.ts
@@ -8,12 +8,20 @@ interface TestableAcpConnection {
   agentCapabilities: { sessionCapabilities?: { close?: unknown }; loadSession?: boolean } | null;
   command: string;
   connectionState: string;
+  createSession: (workspace: string, sessionId?: string) => Promise<NewSessionResponse>;
   endSession: (sessionId: string) => Promise<void>;
+  pushStderr: (chunk: string) => void;
   reconnectSession: (cwd: string, sessionId?: string) => Promise<NewSessionResponse>;
 }
 
+class TestAcpConnection extends AcpConnection {
+  pushStderr(chunk: string): void {
+    this.consumeStderrChunk(chunk);
+  }
+}
+
 function createConnection(): TestableAcpConnection {
-  return new AcpConnection({
+  return new TestAcpConnection({
     command: 'test-cli',
     args: ['--acp'],
     cwd: process.cwd(),
@@ -34,6 +42,24 @@ function createMockAgent(overrides?: Partial<Agent>): Agent {
     ...overrides,
   } as unknown as Agent;
 }
+
+// ─── stderr diagnostics ──────────────────────────────────
+
+describe('AcpConnection stderr diagnostics', () => {
+  it('session/new 실패 메시지에 stderr tail을 포함한다', async () => {
+    const conn = createConnection();
+    const mockAgent = createMockAgent({
+      newSession: vi.fn().mockRejectedValue(new Error('new session failed')),
+    } as unknown as Partial<Agent>);
+    conn.agentProxy = mockAgent;
+
+    conn.pushStderr('codex-acp: workspace must be a git repository\n');
+
+    await expect(conn.createSession('/workspace')).rejects.toThrow(
+      /new session failed[\s\S]+ACP session\/new stderr tail:[\s\S]+codex-acp: workspace must be a git repository/,
+    );
+  });
+});
 
 // ─── endSession ───────────────────────────────────────────
 

--- a/packages/core-unified-agent/tests/unit/BaseConnection.logEntry.test.ts
+++ b/packages/core-unified-agent/tests/unit/BaseConnection.logEntry.test.ts
@@ -19,6 +19,14 @@ class TestConnection extends BaseConnection {
   flush(): void {
     this.flushStderrBuffer();
   }
+
+  diagnosticTail(): string {
+    return this.getStderrDiagnosticTail();
+  }
+
+  diagnose(error: unknown, phase: string): Error {
+    return this.withStderrDiagnostics(error, phase);
+  }
 }
 
 describe('BaseConnection logEntry', () => {
@@ -41,5 +49,24 @@ describe('BaseConnection logEntry', () => {
     expect(logs).toEqual(['first line', 'second line', 'third line']);
     expect(entries.map((entry) => entry.message)).toEqual(['first line', 'second line', 'third line']);
     expect(entries.every((entry) => entry.source === 'stderr')).toBe(true);
+  });
+
+  it('stderr 진단 tail은 최근 라인만 보존하고 secret을 마스킹한다', () => {
+    const connection = new TestConnection();
+
+    for (let index = 0; index < 25; index += 1) {
+      connection.push(`stderr-${index} OPENAI_API_KEY=sk-testsecretvalue${String(index).padStart(20, '0')}\n`);
+    }
+
+    const tail = connection.diagnosticTail();
+    expect(tail).toContain('stderr-24');
+    expect(tail).not.toContain('stderr-0');
+    expect(tail).toContain('[REDACTED:generic_secret]');
+    expect(tail).not.toContain('sk-testsecretvalue');
+
+    const error = connection.diagnose(new Error('session failed'), 'ACP session/new');
+    expect(error.message).toContain('session failed');
+    expect(error.message).toContain('ACP session/new stderr tail:');
+    expect(error.message).toContain('stderr-24');
   });
 });

--- a/packages/core-unified-agent/tests/unit/BaseConnection.logEntry.test.ts
+++ b/packages/core-unified-agent/tests/unit/BaseConnection.logEntry.test.ts
@@ -128,6 +128,23 @@ describe('BaseConnection logEntry', () => {
     expect(tail.match(/\[REDACTED:pem_private_key\]/g)?.length).toBe(3);
   });
 
+  it('환경변수 형식 등 BEGIN 마커가 임베디드된 라인도 PEM 모드로 전환하고 바디가 누출되지 않는다', () => {
+    const connection = new TestConnection();
+
+    // "PREFIX=-----BEGIN PRIVATE KEY-----" 형태: 앵커 매치 안 되는 케이스
+    connection.push('PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\n');
+    connection.push('embedded-secret-body\n');
+    connection.push('-----END PRIVATE KEY-----\n');
+
+    const tail = connection.diagnosticTail();
+
+    // 바디가 누출되지 않아야 함
+    expect(tail).not.toContain('embedded-secret-body');
+    // BEGIN이 포함된 라인 전체도 리댁트
+    expect(tail).not.toContain('PRIVATE_KEY=');
+    expect(tail).toContain('[REDACTED:pem_private_key]');
+  });
+
   it('stderr 진단 tail은 최근 라인만 보존하고 secret을 마스킹한다', () => {
     const connection = new TestConnection();
 

--- a/packages/core-unified-agent/tests/unit/BaseConnection.logEntry.test.ts
+++ b/packages/core-unified-agent/tests/unit/BaseConnection.logEntry.test.ts
@@ -51,6 +51,83 @@ describe('BaseConnection logEntry', () => {
     expect(entries.every((entry) => entry.source === 'stderr')).toBe(true);
   });
 
+  it('PEM private key 블록이 줄 단위로 수신되어도 바디 라인이 diagnosticTail에 누출되지 않는다', () => {
+    const connection = new TestConnection();
+
+    connection.push('normal line before\n');
+    connection.push('-----BEGIN PRIVATE KEY-----\n');
+    connection.push('MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC\n');
+    connection.push('-----END PRIVATE KEY-----\n');
+    connection.push('normal line after\n');
+
+    const tail = connection.diagnosticTail();
+
+    // PEM 바디가 누출되지 않아야 함
+    expect(tail).not.toContain('MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC');
+    // BEGIN/END/바디 모두 REDACTED 처리
+    expect(tail.match(/\[REDACTED:pem_private_key\]/g)?.length).toBe(3);
+    // 비밀 외 정상 라인은 유지
+    expect(tail).toContain('normal line before');
+    expect(tail).toContain('normal line after');
+  });
+
+  it('청크 경계로 PEM 블록이 분할 수신되어도 바디가 누출되지 않는다', () => {
+    const connection = new TestConnection();
+
+    // BEGIN과 바디가 서로 다른 청크로 도착하는 경우
+    connection.push('-----BEGIN EC PRIVATE KEY-----\ntop-secret-key-material\n');
+    connection.push('more-secret-material\n-----END EC PRIVATE KEY-----\n');
+
+    const tail = connection.diagnosticTail();
+
+    expect(tail).not.toContain('top-secret-key-material');
+    expect(tail).not.toContain('more-secret-material');
+    expect(tail).toContain('[REDACTED:pem_private_key]');
+  });
+
+  it('withStderrDiagnostics 출력에 PEM 바디가 누출되지 않는다', () => {
+    const connection = new TestConnection();
+
+    connection.push('-----BEGIN RSA PRIVATE KEY-----\n');
+    connection.push('supersecretprivatekey\n');
+    connection.push('-----END RSA PRIVATE KEY-----\n');
+
+    const error = connection.diagnose(new Error('connection failed'), 'ACP session/new');
+
+    expect(error.message).not.toContain('supersecretprivatekey');
+    expect(error.message).toContain('[REDACTED:pem_private_key]');
+    expect(error.message).toContain('ACP session/new stderr tail:');
+  });
+
+  it('PEM 블록 앞뒤의 정상 stderr는 리댁트 없이 보존된다', () => {
+    const connection = new TestConnection();
+
+    connection.push('before-pem\n');
+    connection.push('-----BEGIN PRIVATE KEY-----\n');
+    connection.push('secretbody\n');
+    connection.push('-----END PRIVATE KEY-----\n');
+    connection.push('after-pem\n');
+
+    const tail = connection.diagnosticTail();
+
+    expect(tail).toContain('before-pem');
+    expect(tail).toContain('after-pem');
+    expect(tail).not.toContain('secretbody');
+  });
+
+  it('CRLF로 수신된 PEM 블록도 바디가 누출되지 않는다', () => {
+    const connection = new TestConnection();
+
+    connection.push('-----BEGIN PRIVATE KEY-----\r\n');
+    connection.push('crlf-secret-body\r\n');
+    connection.push('-----END PRIVATE KEY-----\r\n');
+
+    const tail = connection.diagnosticTail();
+
+    expect(tail).not.toContain('crlf-secret-body');
+    expect(tail.match(/\[REDACTED:pem_private_key\]/g)?.length).toBe(3);
+  });
+
   it('stderr 진단 tail은 최근 라인만 보존하고 secret을 마스킹한다', () => {
     const connection = new TestConnection();
 

--- a/packages/fleet-carriers/src/dispatch/tool-spec.ts
+++ b/packages/fleet-carriers/src/dispatch/tool-spec.ts
@@ -303,6 +303,9 @@ async function runCarrierJobInBackground(opts: CarrierBackgroundOptions): Promis
   try {
     result = await runSingleCarrier(opts);
     finalStatus = result.status;
+    if (finalStatus === "error") {
+      finalError = result.error ?? result.responseText;
+    }
   } catch (error) {
     finalStatus = "error";
     finalError = error instanceof Error ? error.message : String(error);

--- a/packages/fleet-carriers/tests/dispatch/codex-acp-stderr.e2e.test.ts
+++ b/packages/fleet-carriers/tests/dispatch/codex-acp-stderr.e2e.test.ts
@@ -1,0 +1,306 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  disconnectAll,
+  executorMcpRuntimeProviderRuntime,
+  executorPortRuntime,
+  type AgentToolCtx,
+} from "@dotobokuri/core-agent";
+import { getProviderModels } from "@dotobokuri/core-unified-agent";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildCarrierDispatchToolSpec,
+  buildCarrierJobsToolSpec,
+  createCarrierRegistry,
+  initStore,
+  registerCarrier,
+  resetJobArchivesForTest,
+  resetJobCancelRegistryForTest,
+  resetJobConcurrencyForTest,
+  resetJobSummaryCacheForTest,
+  resetStoreForTests,
+  type CarrierConfig,
+  type CarrierJobsResponse,
+} from "../../src/index.js";
+
+interface ToolExecutionResult<T> {
+  readonly details: T;
+  readonly isError: boolean;
+}
+
+const SECRET_VALUE = "sk-e2e-secret-value-00000000000000000000";
+
+let tempDir: string | null = null;
+let fakeBinDir: string | null = null;
+
+describe("carrier_jobs Codex ACP stderr diagnostics e2e", () => {
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-codex-acp-stderr-"));
+    fakeBinDir = path.join(tempDir, "bin");
+    fs.mkdirSync(fakeBinDir, { recursive: true });
+    initStore(path.join(tempDir, "store"));
+    executorPortRuntime.register({
+      getScopeExternalMcpServerIds: () => [],
+      getExecutorMcpTools: () => [],
+    });
+    executorMcpRuntimeProviderRuntime.register({
+      getExecutorMcpRouterRuntimes: () => [],
+    });
+    resetJobArchivesForTest();
+    resetJobSummaryCacheForTest();
+    resetJobConcurrencyForTest();
+    resetJobCancelRegistryForTest();
+  });
+
+  afterEach(async () => {
+    await disconnectAll();
+    resetJobArchivesForTest();
+    resetJobSummaryCacheForTest();
+    resetJobConcurrencyForTest();
+    resetJobCancelRegistryForTest();
+    resetStoreForTests();
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+    tempDir = null;
+    fakeBinDir = null;
+  });
+
+  it("carrier_jobs summary에서 redacted codex-acp stderr tail을 확인한다", async () => {
+    const cwd = tempDir;
+    const binDir = fakeBinDir;
+    if (!cwd || !binDir) throw new Error("테스트 디렉토리가 초기화되지 않았습니다.");
+    writeFailingFakeNpx(binDir);
+
+    const registry = createCarrierRegistry();
+    registerCarrier(registry, createCodexCarrierConfig("stderr_probe", "Stderr Probe"));
+    const dispatchTool = buildCarrierDispatchToolSpec(registry, {
+      authEnvResolver: async () => ({
+        OPENAI_API_KEY: SECRET_VALUE,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      }),
+    });
+    const dispatchCtx: AgentToolCtx = {
+      cwd,
+      toolCallId: "codex-acp-stderr",
+    };
+
+    const dispatchResult = await dispatchTool.execute({
+      carrier_id: "stderr_probe",
+      label: "Capture codex-acp stderr",
+      request: "Trigger deterministic codex-acp startup failure.",
+    }, dispatchCtx) as ToolExecutionResult<{ job_id: string; accepted: boolean; error?: string }>;
+
+    expect(dispatchResult.isError).toBe(false);
+    expect(dispatchResult.details).toEqual({
+      job_id: "carrier:codex-acp-stderr",
+      accepted: true,
+    });
+
+    const jobsTool = buildCarrierJobsToolSpec();
+    let errorText = "";
+
+    await vi.waitFor(async () => {
+      const jobsResult = await jobsTool.execute({
+        action: "result",
+        format: "summary",
+        job_id: "carrier:codex-acp-stderr",
+      }, {
+        cwd,
+        toolCallId: "carrier-jobs-codex-acp-stderr",
+      }) as ToolExecutionResult<CarrierJobsResponse>;
+      const response = jobsResult.details;
+
+      expect(response.ok).toBe(true);
+      expect(response.status).toBe("error");
+      expect(response.summary?.error).toContain("ACP initialize stderr tail:");
+      errorText = response.summary?.error ?? "";
+    }, { timeout: 5_000 });
+
+    expect(errorText).toContain("codex-acp deterministic failure: git repository required");
+    expect(errorText).toContain("[REDACTED:generic_secret]");
+    expect(errorText).not.toContain(SECRET_VALUE);
+  });
+
+  it("성공한 carrier_jobs 결과에는 stderr 진단을 싣지 않는다", async () => {
+    const cwd = tempDir;
+    const binDir = fakeBinDir;
+    if (!cwd || !binDir) throw new Error("테스트 디렉토리가 초기화되지 않았습니다.");
+    writeSuccessfulFakeNpx(binDir);
+
+    const registry = createCarrierRegistry();
+    registerCarrier(registry, createCodexCarrierConfig("stderr_success", "Stderr Success"));
+    const dispatchTool = buildCarrierDispatchToolSpec(registry, {
+      authEnvResolver: async () => ({
+        OPENAI_API_KEY: SECRET_VALUE,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      }),
+    });
+
+    const dispatchResult = await dispatchTool.execute({
+      carrier_id: "stderr_success",
+      label: "Ignore successful stderr",
+      request: "Complete successfully after stderr noise.",
+    }, {
+      cwd,
+      toolCallId: "codex-acp-success-stderr",
+    }) as ToolExecutionResult<{ job_id: string; accepted: boolean; error?: string }>;
+
+    expect(dispatchResult.isError).toBe(false);
+    expect(dispatchResult.details).toEqual({
+      job_id: "carrier:codex-acp-success-stderr",
+      accepted: true,
+    });
+
+    const jobsTool = buildCarrierJobsToolSpec();
+    let summaryPayload = "";
+
+    await vi.waitFor(async () => {
+      const jobsResult = await jobsTool.execute({
+        action: "result",
+        format: "summary",
+        job_id: "carrier:codex-acp-success-stderr",
+      }, {
+        cwd,
+        toolCallId: "carrier-jobs-codex-acp-success-summary",
+      }) as ToolExecutionResult<CarrierJobsResponse>;
+      const response = jobsResult.details;
+      summaryPayload = JSON.stringify(response);
+
+      expect(response.ok).toBe(true);
+      expect(response.status).toBe("done");
+      expect(response.summary?.error).toBeUndefined();
+      expect(response.summary?.summary).toBe("carrier job completed: 1 done, 0 failed");
+    }, { timeout: 5_000 });
+
+    const fullResult = await jobsTool.execute({
+      action: "result",
+      format: "full",
+      job_id: "carrier:codex-acp-success-stderr",
+    }, {
+      cwd,
+      toolCallId: "carrier-jobs-codex-acp-success-full",
+    }) as ToolExecutionResult<CarrierJobsResponse>;
+    const fullPayload = JSON.stringify(fullResult.details);
+
+    expect(summaryPayload).not.toContain("ACP initialize stderr tail:");
+    expect(summaryPayload).not.toContain("codex-acp success stderr noise");
+    expect(fullPayload).not.toContain("ACP initialize stderr tail:");
+    expect(fullPayload).not.toContain("codex-acp success stderr noise");
+  });
+});
+
+function createCodexCarrierConfig(id: string, displayName: string): CarrierConfig {
+  return {
+    id,
+    displayName,
+    slot: 1,
+    defaultCliType: "codex",
+    defaultModel: firstCodexModel(),
+  };
+}
+
+function firstCodexModel(): string {
+  const model = getProviderModels("codex").models[0]?.modelId;
+  if (!model) {
+    throw new Error("Codex 테스트 모델을 찾지 못했습니다.");
+  }
+  return model;
+}
+
+function writeFailingFakeNpx(binDir: string): void {
+  const script = `#!/usr/bin/env node
+process.stderr.write("codex-acp deterministic failure: git repository required\\n");
+process.stderr.write("OPENAI_API_KEY=${SECRET_VALUE}\\n");
+
+let buffer = "";
+let responded = false;
+
+function respond(line) {
+  if (responded) return;
+  responded = true;
+  let id = null;
+  try {
+    const request = JSON.parse(line);
+    id = request.id ?? null;
+  } catch {
+  }
+  process.stdout.write(JSON.stringify({
+    jsonrpc: "2.0",
+    id,
+    error: {
+      code: -32000,
+      message: "deterministic initialize failure",
+    },
+  }) + "\\n");
+  setTimeout(() => process.exit(1), 10);
+}
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  const newlineIndex = buffer.indexOf("\\n");
+  if (newlineIndex >= 0) {
+    respond(buffer.slice(0, newlineIndex));
+  }
+});
+
+setTimeout(() => {
+  process.stderr.write("codex-acp timed out waiting for initialize\\n");
+  process.exit(1);
+}, 2000);
+`;
+  fs.writeFileSync(path.join(binDir, "npx"), script, { mode: 0o755 });
+}
+
+function writeSuccessfulFakeNpx(binDir: string): void {
+  const script = `#!/usr/bin/env node
+process.stderr.write("codex-acp success stderr noise\\n");
+
+let buffer = "";
+
+function resultFor(method) {
+  if (method === "initialize") {
+    return { agentCapabilities: {} };
+  }
+  if (method === "session/new") {
+    return { sessionId: "success-session" };
+  }
+  if (method === "session/prompt") {
+    process.stderr.write("codex-acp success stderr noise during prompt\\n");
+    return { stopReason: "endTurn" };
+  }
+  return {};
+}
+
+function respond(line) {
+  let request;
+  try {
+    request = JSON.parse(line);
+  } catch {
+    return;
+  }
+  process.stdout.write(JSON.stringify({
+    jsonrpc: "2.0",
+    id: request.id ?? null,
+    result: resultFor(request.method),
+  }) + "\\n");
+}
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  while (true) {
+    const newlineIndex = buffer.indexOf("\\n");
+    if (newlineIndex < 0) break;
+    const line = buffer.slice(0, newlineIndex);
+    buffer = buffer.slice(newlineIndex + 1);
+    respond(line);
+  }
+});
+`;
+  fs.writeFileSync(path.join(binDir, "npx"), script, { mode: 0o755 });
+}


### PR DESCRIPTION
## Summary
- Adds redacted stderr tail diagnostics to Codex ACP initialize/session failures.
- Propagates executor-returned error states into carrier job summaries so carrier_jobs can surface the diagnostic.
- Adds deterministic carrier_jobs e2e coverage for failed and successful Codex ACP stderr behavior.

## Test Plan
- [x] node scripts/compile-changelog-fragments.mjs --check
- [x] pnpm --filter @dotobokuri/core-unified-agent typecheck:test
- [x] pnpm --filter @dotobokuri/core-unified-agent exec vitest run tests/unit/BaseConnection.logEntry.test.ts tests/unit/AcpConnection.sessionLifecycle.test.ts
- [x] pnpm --filter @dotobokuri/fleet-carriers typecheck
- [x] pnpm --filter @dotobokuri/fleet-carriers exec vitest run tests/dispatch/framework.test.ts tests/dispatch/codex-acp-stderr.e2e.test.ts
- [x] pnpm --filter @dotobokuri/core-unified-agent build
- [x] pnpm --filter @dotobokuri/core-agent build
- [x] pnpm --filter @dotobokuri/fleet-infra build
- [x] pnpm --filter @dotobokuri/fleet-carriers build

## Changelog
- [x] Added `.changelog.d/fix-codex-acp-stderr-diagnostics.md`.