### PR TITLE
feat(fleet-console): add manual and live refresh to File Explorer

### DIFF
--- a/.changelog.d/file-explorer-refresh.md
+++ b/.changelog.d/file-explorer-refresh.md
@@ -2,4 +2,4 @@
 section: Added
 ---
 
-- [fleet-console] File Explorer now offers a manual refresh button in the toolbar, re-reads folder contents every time a directory is expanded, and live-updates the file tree as files change on disk with a watch indicator dot.
+- [fleet-console] File Explorer now offers a manual refresh button in the toolbar, re-reads folder contents every time a directory is expanded, and live-updates the file tree as files change on disk.

--- a/.changelog.d/file-explorer-refresh.md
+++ b/.changelog.d/file-explorer-refresh.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- [fleet-console] File Explorer now has a manual refresh button (↻) in the toolbar, always re-fetches folder contents when expanding a previously-collapsed directory, and automatically refreshes the tree via a live file watcher (SSE) with an aurora dot indicating active watch status.

--- a/.changelog.d/file-explorer-refresh.md
+++ b/.changelog.d/file-explorer-refresh.md
@@ -2,4 +2,4 @@
 section: Added
 ---
 
-- [fleet-console] File Explorer now has a manual refresh button (↻) in the toolbar, always re-fetches folder contents when expanding a previously-collapsed directory, and automatically refreshes the tree via a live file watcher (SSE) with an aurora dot indicating active watch status.
+- [fleet-console] File Explorer now offers a manual refresh button in the toolbar, re-reads folder contents every time a directory is expanded, and live-updates the file tree as files change on disk with a watch indicator dot.

--- a/runtime/fleet-plugins/file-explorer/client/explorer.css
+++ b/runtime/fleet-plugins/file-explorer/client/explorer.css
@@ -476,3 +476,44 @@
 .fexp-hidden-toggle.is-active {
   color: var(--brass);
 }
+
+/* ── 수동 새로고침 버튼 ── */
+.fexp-refresh-btn {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--ink-fog);
+  font-size: 15px;
+  padding: 2px 4px;
+  border-radius: var(--radius-xs);
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  transition: color 0.1s;
+}
+
+.fexp-refresh-btn:hover {
+  color: var(--ink-spectral);
+}
+
+/* ── 감시 활성 aurora dot (WATCHING 시맨틱) ── */
+.fexp-watch-dot {
+  flex-shrink: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--aurora);
+  animation: fexp-watch-pulse 2s ease-in-out infinite;
+}
+
+@keyframes fexp-watch-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fexp-watch-dot {
+    animation: none;
+  }
+}

--- a/runtime/fleet-plugins/file-explorer/client/explorer.css
+++ b/runtime/fleet-plugins/file-explorer/client/explorer.css
@@ -496,24 +496,3 @@
 .fexp-refresh-btn:hover {
   color: var(--ink-spectral);
 }
-
-/* ── 감시 활성 aurora dot (WATCHING 시맨틱) ── */
-.fexp-watch-dot {
-  flex-shrink: 0;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--aurora);
-  animation: fexp-watch-pulse 2s ease-in-out infinite;
-}
-
-@keyframes fexp-watch-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.35; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .fexp-watch-dot {
-    animation: none;
-  }
-}

--- a/runtime/fleet-plugins/file-explorer/client/tree.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/tree.tsx
@@ -118,7 +118,10 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
 
   useEffect(() => {
     if (!theaterId) return;
-    files.listFolder(currentPath || undefined).then(setResult).catch((e: unknown) => {
+    files.listFolder(currentPath || undefined).then((r) => {
+      setResult(r);
+      setError(null);
+    }).catch((e: unknown) => {
       setError(e instanceof Error ? e.message : "Unable to load folder");
     });
   }, [theaterId, currentPath, files]);
@@ -140,8 +143,16 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
     const url = `/plugins/file-explorer/files/watch?theaterId=${encodeURIComponent(theaterId)}`;
     const es = new EventSource(url);
 
+    // 루트 재조회 성공 시 stale error를 함께 걷어 에러 화면에서 회복한다
+    const reloadRoot = () => {
+      filesRef.current.listFolder(currentPathRef.current || undefined).then((r) => {
+        setResult(r);
+        setError(null);
+      }).catch(() => {});
+    };
+
     const doFullRefresh = () => {
-      filesRef.current.listFolder(currentPathRef.current || undefined).then(setResult).catch(() => {});
+      reloadRoot();
       for (const relPath of expandedDirsRef.current) {
         filesRef.current.listFolder(relPath).then((r) => {
           setChildResults((prev) => new Map(prev).set(relPath, r));
@@ -150,10 +161,17 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
     };
 
     es.addEventListener("change", (e) => {
-      const relDir = (e as MessageEvent).data as string;
+      // 서버가 JSON 프레이밍한 상대경로 — 개행 포함 파일명도 안전하게 전달된다
+      let relDir: string;
+      try {
+        relDir = JSON.parse((e as MessageEvent).data as string) as string;
+      } catch {
+        return;
+      }
+      if (typeof relDir !== "string") return;
       // 루트 레벨 변경 또는 현재 탐색 경로 변경
       if (relDir === "" || relDir === currentPathRef.current) {
-        filesRef.current.listFolder(currentPathRef.current || undefined).then(setResult).catch(() => {});
+        reloadRoot();
       }
       // 펼쳐진 폴더에 해당하면 해당 폴더만 재조회
       if (relDir !== "" && expandedDirsRef.current.has(relDir)) {
@@ -222,8 +240,11 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
 
   const handleRefresh = useCallback(() => {
     if (!theaterId) return;
-    // 루트 재조회
-    files.listFolder(currentPath || undefined).then(setResult).catch((e: unknown) => {
+    // 루트 재조회 — 성공 시 stale error를 걷어 에러 화면에서도 복구 가능하게 한다
+    files.listFolder(currentPath || undefined).then((r) => {
+      setResult(r);
+      setError(null);
+    }).catch((e: unknown) => {
       setError(e instanceof Error ? e.message : "Unable to load folder");
     });
     // 펼쳐진 모든 폴더 재조회

--- a/runtime/fleet-plugins/file-explorer/client/tree.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/tree.tsx
@@ -23,8 +23,6 @@ interface FlatRow {
   readonly isLoading: boolean;
 }
 
-type WatchState = "inactive" | "watching" | "degraded";
-
 const VIRTUALIZE_THRESHOLD = 200;
 const ROW_HEIGHT = 30;
 const OVERSCAN = 5;
@@ -98,7 +96,6 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
   const [scrollTop, setScrollTop] = useState(0);
   const [containerHeight, setContainerHeight] = useState(600);
   const [showHidden, setShowHidden] = useState<boolean>(() => readShowHidden());
-  const [watchState, setWatchState] = useState<WatchState>("inactive");
   const treeRef = useRef<HTMLDivElement>(null);
 
   // SSE 핸들러가 최신 상태를 참조하도록 ref로 유지
@@ -137,10 +134,7 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
 
   // SSE 자동 새로고침 — theaterId/files 변경 시 재구독, 언마운트 시 close
   useEffect(() => {
-    if (!theaterId) {
-      setWatchState("inactive");
-      return;
-    }
+    if (!theaterId) return;
 
     let isFirstOpen = true;
     const url = `/plugins/file-explorer/files/watch?theaterId=${encodeURIComponent(theaterId)}`;
@@ -154,10 +148,6 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
         }).catch(() => {});
       }
     };
-
-    es.addEventListener("state", (e) => {
-      setWatchState((e as MessageEvent).data as WatchState);
-    });
 
     es.addEventListener("change", (e) => {
       const relDir = (e as MessageEvent).data as string;
@@ -184,7 +174,6 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
 
     return () => {
       es.close();
-      setWatchState("inactive");
     };
   }, [theaterId, files]);
 
@@ -295,9 +284,6 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
         >
           ↻
         </button>
-        {watchState === "watching" && (
-          <span className="fexp-watch-dot" aria-hidden="true" />
-        )}
         <button
           type="button"
           className={`fexp-hidden-toggle${showHidden ? " is-active" : ""}`}

--- a/runtime/fleet-plugins/file-explorer/client/tree.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/tree.tsx
@@ -23,6 +23,8 @@ interface FlatRow {
   readonly isLoading: boolean;
 }
 
+type WatchState = "inactive" | "watching" | "degraded";
+
 const VIRTUALIZE_THRESHOLD = 200;
 const ROW_HEIGHT = 30;
 const OVERSCAN = 5;
@@ -96,7 +98,16 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
   const [scrollTop, setScrollTop] = useState(0);
   const [containerHeight, setContainerHeight] = useState(600);
   const [showHidden, setShowHidden] = useState<boolean>(() => readShowHidden());
+  const [watchState, setWatchState] = useState<WatchState>("inactive");
   const treeRef = useRef<HTMLDivElement>(null);
+
+  // SSE 핸들러가 최신 상태를 참조하도록 ref로 유지
+  const expandedDirsRef = useRef<Set<string>>(expandedDirs);
+  expandedDirsRef.current = expandedDirs;
+  const currentPathRef = useRef<string>(currentPath);
+  currentPathRef.current = currentPath;
+  const filesRef = useRef<PluginFilesClient>(files);
+  filesRef.current = files;
 
   useEffect(() => {
     if (!theaterId) return;
@@ -124,15 +135,71 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
     return () => ro.disconnect();
   }, []);
 
+  // SSE 자동 새로고침 — theaterId/files 변경 시 재구독, 언마운트 시 close
+  useEffect(() => {
+    if (!theaterId) {
+      setWatchState("inactive");
+      return;
+    }
+
+    let isFirstOpen = true;
+    const url = `/plugins/file-explorer/files/watch?theaterId=${encodeURIComponent(theaterId)}`;
+    const es = new EventSource(url);
+
+    const doFullRefresh = () => {
+      filesRef.current.listFolder(currentPathRef.current || undefined).then(setResult).catch(() => {});
+      for (const relPath of expandedDirsRef.current) {
+        filesRef.current.listFolder(relPath).then((r) => {
+          setChildResults((prev) => new Map(prev).set(relPath, r));
+        }).catch(() => {});
+      }
+    };
+
+    es.addEventListener("state", (e) => {
+      setWatchState((e as MessageEvent).data as WatchState);
+    });
+
+    es.addEventListener("change", (e) => {
+      const relDir = (e as MessageEvent).data as string;
+      // 루트 레벨 변경 또는 현재 탐색 경로 변경
+      if (relDir === "" || relDir === currentPathRef.current) {
+        filesRef.current.listFolder(currentPathRef.current || undefined).then(setResult).catch(() => {});
+      }
+      // 펼쳐진 폴더에 해당하면 해당 폴더만 재조회
+      if (relDir !== "" && expandedDirsRef.current.has(relDir)) {
+        filesRef.current.listFolder(relDir).then((r) => {
+          setChildResults((prev) => new Map(prev).set(relDir, r));
+        }).catch(() => {});
+      }
+    });
+
+    es.onopen = () => {
+      if (isFirstOpen) {
+        isFirstOpen = false;
+        return;
+      }
+      // 재연결: 놓친 변경 보정을 위해 전체 재조회
+      doFullRefresh();
+    };
+
+    return () => {
+      es.close();
+      setWatchState("inactive");
+    };
+  }, [theaterId, files]);
+
   const handleDirClick = useCallback((entry: FolderEntry) => {
     const relPath = entry.relativePath;
+    // 현재 펼침 상태를 읽어 펼치는 동작인지 판단
+    const isExpanding = !expandedDirs.has(relPath);
     setExpandedDirs((prev) => {
       const next = new Set(prev);
       if (next.has(relPath)) { next.delete(relPath); return next; }
       next.add(relPath);
       return next;
     });
-    if (!childResults.has(relPath)) {
+    // 폴더를 펼 때마다 항상 서버에서 재조회 (영구 캐시 제거)
+    if (isExpanding) {
       setLoadingDirs((prev) => new Set(prev).add(relPath));
       files.listFolder(relPath).then((r) => {
         setChildResults((prev) => new Map(prev).set(relPath, r));
@@ -141,7 +208,7 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
         setLoadingDirs((prev) => { const s = new Set(prev); s.delete(relPath); return s; });
       });
     }
-  }, [files, childResults]);
+  }, [files, expandedDirs]);
 
   const handleEntryClick = useCallback((entry: FolderEntry) => {
     if (entry.kind === "dir") handleDirClick(entry);
@@ -163,6 +230,20 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
       return next;
     });
   }, []);
+
+  const handleRefresh = useCallback(() => {
+    if (!theaterId) return;
+    // 루트 재조회
+    files.listFolder(currentPath || undefined).then(setResult).catch((e: unknown) => {
+      setError(e instanceof Error ? e.message : "Unable to load folder");
+    });
+    // 펼쳐진 모든 폴더 재조회
+    for (const relPath of expandedDirs) {
+      files.listFolder(relPath).then((r) => {
+        setChildResults((prev) => new Map(prev).set(relPath, r));
+      }).catch(() => {});
+    }
+  }, [files, currentPath, expandedDirs, theaterId]);
 
   const low = filterText.toLowerCase();
 
@@ -204,6 +285,18 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
           >
             ✕
           </button>
+        )}
+        <button
+          type="button"
+          className="fexp-refresh-btn"
+          onClick={handleRefresh}
+          aria-label="Refresh file tree"
+          title="Refresh file tree"
+        >
+          ↻
+        </button>
+        {watchState === "watching" && (
+          <span className="fexp-watch-dot" aria-hidden="true" />
         )}
         <button
           type="button"

--- a/runtime/fleet-plugins/file-explorer/client/tree.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/tree.tsx
@@ -272,7 +272,9 @@ export function FileTree({ files, theaterId, selectedPath, onSelect }: FileTreeP
   const offsetY = startIdx * ROW_HEIGHT;
 
   if (!theaterId) return <div className="fexp-tree-empty">Select a Theater</div>;
-  if (error) return <div className="fexp-tree-error">{error}</div>;
+  // 전체 에러 화면은 보여줄 트리가 아예 없을 때(초기 로드 실패)만 —
+  // 이전 result가 있으면 트리를 유지해 ↻ 재시도 경로를 보존한다
+  if (error && !result) return <div className="fexp-tree-error">{error}</div>;
   if (!result) return <div className="fexp-tree-loading">Loading…</div>;
 
   return (

--- a/runtime/fleet-plugins/file-explorer/routes.ts
+++ b/runtime/fleet-plugins/file-explorer/routes.ts
@@ -1,6 +1,6 @@
 import { definePlugin, registerRouter } from "@fleet-console/sdk/plugin/node";
 
-import { handleFilesImage, handleFilesList, handleFilesRead } from "./server/handlers.js";
+import { handleFilesImage, handleFilesList, handleFilesRead, handleFilesWatch } from "./server/handlers.js";
 
 export default definePlugin({
   id: "file-explorer",
@@ -15,6 +15,10 @@ export default definePlugin({
     });
     registerRouter(ctx, "files/image", async ({ req, res }) => {
       await handleFilesImage(req, res, ctx);
+      return true;
+    });
+    registerRouter(ctx, "files/watch", ({ req, res }) => {
+      handleFilesWatch(req, res, ctx);
       return true;
     });
   },

--- a/runtime/fleet-plugins/file-explorer/server/handlers.ts
+++ b/runtime/fleet-plugins/file-explorer/server/handlers.ts
@@ -146,7 +146,8 @@ export function handleFilesWatch(
   const unsubscribe = watcherRegistry.subscribe(
     theaterId,
     theaterPath,
-    (relDir) => sendEvent("change", relDir),
+    // 개행 포함 파일명이 SSE 필드 경계를 깨지 않도록 JSON으로 프레이밍한다
+    (relDir) => sendEvent("change", JSON.stringify(relDir)),
     (state) => sendEvent("state", state),
   );
 

--- a/runtime/fleet-plugins/file-explorer/server/handlers.ts
+++ b/runtime/fleet-plugins/file-explorer/server/handlers.ts
@@ -5,6 +5,7 @@ import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 import { FileReadError, readFileForTheater } from "./file-reader.js";
 import { FolderBrowserError, listTheaterContents } from "./folder-browser.js";
 import { ImageServeError, readImageForTheater, writeImageResponse } from "./image-server.js";
+import { watcherRegistry } from "./watcher.js";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -107,4 +108,50 @@ export async function handleFilesImage(
     }
     throw error;
   }
+}
+
+export function handleFilesWatch(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  ctx: FleetPluginServerContext,
+): void {
+  if (req.method !== "GET") { ctx.host.http.writeJson(res, 405, { error: "Method not allowed" }); return; }
+  // EventSource는 same-origin GET — origin 헤더 미첨부여도 isTerminalAuthorized 통과
+  if (!ctx.host.security.isTerminalAuthorized(req)) { ctx.host.http.writeJson(res, 401, { error: "unauthorized" }); return; }
+
+  const url = readUrl(req);
+  const theaterId = url.searchParams.get("theaterId");
+  if (!theaterId) { ctx.host.http.writeJson(res, 400, { error: "invalid_request" }); return; }
+
+  const theaterPath = ctx.host.paths.resolveTheaterPath(theaterId);
+  if (!theaterPath) { ctx.host.http.writeJson(res, 404, { error: "theater_not_found" }); return; }
+
+  // SSE 헤더 — 응답을 스트림으로 유지
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "X-Accel-Buffering": "no",
+  });
+  res.flushHeaders();
+
+  function sendEvent(name: string, data: string): void {
+    try {
+      res.write(`event: ${name}\ndata: ${data}\n\n`);
+    } catch {
+      // 연결 종료 후 쓰기 시도 무시
+    }
+  }
+
+  const unsubscribe = watcherRegistry.subscribe(
+    theaterId,
+    theaterPath,
+    (relDir) => sendEvent("change", relDir),
+    (state) => sendEvent("state", state),
+  );
+
+  req.on("close", () => {
+    unsubscribe();
+    try { res.end(); } catch { /* 이미 종료된 경우 무시 */ }
+  });
 }

--- a/runtime/fleet-plugins/file-explorer/server/watcher.ts
+++ b/runtime/fleet-plugins/file-explorer/server/watcher.ts
@@ -59,7 +59,8 @@ export function createWatcherRegistry(
       if (entry.subscriberCount <= 0) {
         for (const t of entry.debounceTimers.values()) clearTimeout(t);
         entry.watcher.close();
-        entries.delete(theaterId);
+        // error 이후 교체된 새 entry를 지우지 않도록 동일 entry일 때만 제거한다
+        if (entries.get(theaterId) === entry) entries.delete(theaterId);
       }
     };
   }
@@ -103,17 +104,19 @@ export function createWatcherRegistry(
       return () => {};
     }
 
+    const entry: WatcherEntry = { watcher, subscribers, stateSubscribers, subscriberCount: 1, debounceTimers };
+
     // 감시 런타임 오류(감시 대상 삭제 등): unhandled 'error'로 프로세스가 죽지 않도록
     // 구독자 전원에게 degrade를 알리고 watcher를 정리한다. SSE 연결 자체는 유지된다.
     watcher.on("error", () => {
       for (const t of debounceTimers.values()) clearTimeout(t);
       debounceTimers.clear();
       try { watcher.close(); } catch { /* 이미 닫힌 경우 무시 */ }
-      entries.delete(theaterId);
+      // 교체된 새 entry를 지우지 않도록 동일 entry일 때만 제거한다
+      if (entries.get(theaterId) === entry) entries.delete(theaterId);
       for (const notify of stateSubscribers) notify("degraded");
     });
 
-    const entry: WatcherEntry = { watcher, subscribers, stateSubscribers, subscriberCount: 1, debounceTimers };
     entries.set(theaterId, entry);
     subscribers.add(onChange);
     stateSubscribers.add(onState);
@@ -129,10 +132,10 @@ export const watcherRegistry: WatcherRegistry = createWatcherRegistry();
 
 function computeRelDir(filename: string | null): string {
   if (!filename) return "";
-  // OS 구분자를 포워드슬래시로 정규화
-  const normalized = filename.replace(/\\/g, "/");
-  const lastSlash = normalized.lastIndexOf("/");
-  // 루트 레벨 파일(슬래시 없음 또는 맨 앞에만)이면 루트 dir('')로
-  if (lastSlash <= 0) return "";
-  return normalized.slice(0, lastSlash);
+  // 구분자를 변환하지 않는다 — files/list의 relativePath(path.relative, OS-native 구분자)와
+  // 동일한 형태여야 클라이언트의 expandedDirs 비교가 Windows에서도 일치한다.
+  const lastSep = Math.max(filename.lastIndexOf("/"), filename.lastIndexOf("\\"));
+  // 루트 레벨 파일(구분자 없음 또는 맨 앞에만)이면 루트 dir('')로
+  if (lastSep <= 0) return "";
+  return filename.slice(0, lastSep);
 }

--- a/runtime/fleet-plugins/file-explorer/server/watcher.ts
+++ b/runtime/fleet-plugins/file-explorer/server/watcher.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs";
+
+// fs.FSWatcher 중 레지스트리가 실제로 쓰는 최소 계약 — 테스트 mock이 이 형태만 만족하면 된다
+export interface WatcherHandle {
+  close(): void;
+  on(event: "error", listener: (error: Error) => void): unknown;
+}
+
+// watcher 팩토리 타입 — 테스트에서 주입 가능
+export type WatcherFactory = (
+  watchPath: string,
+  options: { recursive: boolean },
+  callback: (event: string, filename: string | null) => void,
+) => WatcherHandle;
+
+export type WatchChangeCallback = (relDir: string) => void;
+export type WatchStateCallback = (state: "watching" | "degraded") => void;
+
+export interface WatcherRegistry {
+  subscribe(
+    theaterId: string,
+    theaterPath: string,
+    onChange: WatchChangeCallback,
+    onState: WatchStateCallback,
+  ): () => void;
+}
+
+interface WatcherEntry {
+  readonly watcher: WatcherHandle;
+  readonly subscribers: Set<WatchChangeCallback>;
+  readonly stateSubscribers: Set<WatchStateCallback>;
+  subscriberCount: number;
+  readonly debounceTimers: Map<string, ReturnType<typeof setTimeout>>;
+}
+
+// 서버 측 debounce 간격 — 이벤트 폭풍 흡수
+const DEBOUNCE_MS = 200;
+
+export function createWatcherRegistry(
+  watcherFactory: WatcherFactory = (p, opts, cb) =>
+    fs.watch(p, opts, (ev, fn) => cb(ev, typeof fn === "string" ? fn : null)),
+  debounceMs = DEBOUNCE_MS,
+): WatcherRegistry {
+  const entries = new Map<string, WatcherEntry>();
+
+  function makeUnsubscribe(
+    theaterId: string,
+    onChange: WatchChangeCallback,
+    onState: WatchStateCallback,
+    entry: WatcherEntry,
+  ): () => void {
+    let called = false;
+    return () => {
+      if (called) return;
+      called = true;
+      entry.subscribers.delete(onChange);
+      entry.stateSubscribers.delete(onState);
+      entry.subscriberCount--;
+      if (entry.subscriberCount <= 0) {
+        for (const t of entry.debounceTimers.values()) clearTimeout(t);
+        entry.watcher.close();
+        entries.delete(theaterId);
+      }
+    };
+  }
+
+  function subscribe(
+    theaterId: string,
+    theaterPath: string,
+    onChange: WatchChangeCallback,
+    onState: WatchStateCallback,
+  ): () => void {
+    const existing = entries.get(theaterId);
+    if (existing) {
+      existing.subscribers.add(onChange);
+      existing.stateSubscribers.add(onState);
+      existing.subscriberCount++;
+      onState("watching");
+      return makeUnsubscribe(theaterId, onChange, onState, existing);
+    }
+
+    const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+    const subscribers = new Set<WatchChangeCallback>();
+    const stateSubscribers = new Set<WatchStateCallback>();
+
+    let watcher: WatcherHandle;
+    try {
+      watcher = watcherFactory(theaterPath, { recursive: true }, (_, filename) => {
+        const relDir = computeRelDir(filename);
+        const pending = debounceTimers.get(relDir);
+        if (pending) clearTimeout(pending);
+        debounceTimers.set(
+          relDir,
+          setTimeout(() => {
+            debounceTimers.delete(relDir);
+            for (const sub of subscribers) sub(relDir);
+          }, debounceMs),
+        );
+      });
+    } catch {
+      // fs.watch 미지원 플랫폼: graceful degrade — 감시 불가 상태만 알리고 연결 유지
+      onState("degraded");
+      return () => {};
+    }
+
+    // 감시 런타임 오류(감시 대상 삭제 등): unhandled 'error'로 프로세스가 죽지 않도록
+    // 구독자 전원에게 degrade를 알리고 watcher를 정리한다. SSE 연결 자체는 유지된다.
+    watcher.on("error", () => {
+      for (const t of debounceTimers.values()) clearTimeout(t);
+      debounceTimers.clear();
+      try { watcher.close(); } catch { /* 이미 닫힌 경우 무시 */ }
+      entries.delete(theaterId);
+      for (const notify of stateSubscribers) notify("degraded");
+    });
+
+    const entry: WatcherEntry = { watcher, subscribers, stateSubscribers, subscriberCount: 1, debounceTimers };
+    entries.set(theaterId, entry);
+    subscribers.add(onChange);
+    stateSubscribers.add(onState);
+    onState("watching");
+    return makeUnsubscribe(theaterId, onChange, onState, entry);
+  }
+
+  return { subscribe };
+}
+
+// 기본 싱글턴 레지스트리 — handlers.ts에서 사용
+export const watcherRegistry: WatcherRegistry = createWatcherRegistry();
+
+function computeRelDir(filename: string | null): string {
+  if (!filename) return "";
+  // OS 구분자를 포워드슬래시로 정규화
+  const normalized = filename.replace(/\\/g, "/");
+  const lastSlash = normalized.lastIndexOf("/");
+  // 루트 레벨 파일(슬래시 없음 또는 맨 앞에만)이면 루트 dir('')로
+  if (lastSlash <= 0) return "";
+  return normalized.slice(0, lastSlash);
+}

--- a/runtime/fleet-plugins/file-explorer/server/watcher.ts
+++ b/runtime/fleet-plugins/file-explorer/server/watcher.ts
@@ -36,6 +36,9 @@ interface WatcherEntry {
 // 서버 측 debounce 간격 — 이벤트 폭풍 흡수
 const DEBOUNCE_MS = 200;
 
+// 기본 싱글턴 레지스트리 — handlers.ts에서 사용 (함수 선언 호이스팅에 의존)
+export const watcherRegistry: WatcherRegistry = createWatcherRegistry();
+
 export function createWatcherRegistry(
   watcherFactory: WatcherFactory = (p, opts, cb) =>
     fs.watch(p, opts, (ev, fn) => cb(ev, typeof fn === "string" ? fn : null)),
@@ -126,9 +129,6 @@ export function createWatcherRegistry(
 
   return { subscribe };
 }
-
-// 기본 싱글턴 레지스트리 — handlers.ts에서 사용
-export const watcherRegistry: WatcherRegistry = createWatcherRegistry();
 
 function computeRelDir(filename: string | null): string {
   if (!filename) return "";

--- a/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { WatcherFactory } from "../server/watcher.js";
+import { createWatcherRegistry } from "../server/watcher.js";
+
+describe("createWatcherRegistry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("첫 구독자가 watcher를 생성한다", () => {
+    const mockClose = vi.fn();
+    const mockFactory: WatcherFactory = vi.fn().mockReturnValue({ close: mockClose, on: vi.fn() });
+    const registry = createWatcherRegistry(mockFactory);
+
+    const unsub = registry.subscribe("t1", "/path", () => {}, () => {});
+    expect(mockFactory).toHaveBeenCalledOnce();
+    expect(mockFactory).toHaveBeenCalledWith("/path", { recursive: true }, expect.any(Function));
+    unsub();
+  });
+
+  it("두 번째 구독자는 기존 watcher를 재사용한다", () => {
+    const mockFactory: WatcherFactory = vi.fn().mockReturnValue({ close: vi.fn(), on: vi.fn() });
+    const registry = createWatcherRegistry(mockFactory);
+
+    const unsub1 = registry.subscribe("t1", "/path", () => {}, () => {});
+    const unsub2 = registry.subscribe("t1", "/path", () => {}, () => {});
+
+    expect(mockFactory).toHaveBeenCalledOnce();
+    unsub1();
+    unsub2();
+  });
+
+  it("마지막 구독자 해제 시 watcher.close()를 호출한다", () => {
+    const mockClose = vi.fn();
+    const mockFactory: WatcherFactory = vi.fn().mockReturnValue({ close: mockClose, on: vi.fn() });
+    const registry = createWatcherRegistry(mockFactory);
+
+    const unsub1 = registry.subscribe("t1", "/path", () => {}, () => {});
+    const unsub2 = registry.subscribe("t1", "/path", () => {}, () => {});
+
+    unsub1();
+    expect(mockClose).not.toHaveBeenCalled();
+    unsub2();
+    expect(mockClose).toHaveBeenCalledOnce();
+  });
+
+  it("중간 구독자 해제 후 나머지 구독자가 이벤트를 수신한다", () => {
+    let watchCb: ((event: string, filename: string | null) => void) | undefined;
+    const mockFactory: WatcherFactory = vi.fn().mockImplementation((_, __, cb) => {
+      watchCb = cb;
+      return { close: vi.fn(), on: vi.fn() };
+    });
+    const registry = createWatcherRegistry(mockFactory, 50);
+
+    const onChange1 = vi.fn();
+    const onChange2 = vi.fn();
+    const unsub1 = registry.subscribe("t1", "/path", onChange1, () => {});
+    const unsub2 = registry.subscribe("t1", "/path", onChange2, () => {});
+
+    unsub1();
+    watchCb!("change", "src/file.ts");
+    vi.advanceTimersByTime(100);
+
+    expect(onChange1).not.toHaveBeenCalled();
+    expect(onChange2).toHaveBeenCalledWith("src");
+
+    unsub2();
+  });
+
+  it("같은 디렉토리 이벤트를 debounce로 합쳐 한 번만 발화한다", () => {
+    let watchCb: ((event: string, filename: string | null) => void) | undefined;
+    const mockFactory: WatcherFactory = vi.fn().mockImplementation((_, __, cb) => {
+      watchCb = cb;
+      return { close: vi.fn(), on: vi.fn() };
+    });
+    const registry = createWatcherRegistry(mockFactory, 100);
+
+    const onChange = vi.fn();
+    const unsub = registry.subscribe("t1", "/path", onChange, () => {});
+
+    watchCb!("change", "src/file1.ts");
+    watchCb!("change", "src/file2.ts");
+    watchCb!("change", "src/file3.ts");
+
+    expect(onChange).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(150);
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith("src");
+
+    unsub();
+  });
+
+  it("서로 다른 디렉토리 이벤트는 별도로 발화한다", () => {
+    let watchCb: ((event: string, filename: string | null) => void) | undefined;
+    const mockFactory: WatcherFactory = vi.fn().mockImplementation((_, __, cb) => {
+      watchCb = cb;
+      return { close: vi.fn(), on: vi.fn() };
+    });
+    const registry = createWatcherRegistry(mockFactory, 50);
+
+    const onChange = vi.fn();
+    const unsub = registry.subscribe("t1", "/path", onChange, () => {});
+
+    watchCb!("change", "src/file.ts");
+    watchCb!("change", "lib/other.ts");
+
+    vi.advanceTimersByTime(100);
+    expect(onChange).toHaveBeenCalledTimes(2);
+    const dirs = onChange.mock.calls.map(([d]: [string]) => d).sort();
+    expect(dirs).toEqual(["lib", "src"]);
+
+    unsub();
+  });
+
+  it("fs.watch 실패 시 degraded 상태를 전달하고 no-op 해제 함수를 반환한다", () => {
+    const mockFactory: WatcherFactory = vi.fn().mockImplementation(() => {
+      throw new Error("ENOSYS: function not implemented");
+    });
+    const registry = createWatcherRegistry(mockFactory);
+
+    const onState = vi.fn();
+    const unsub = registry.subscribe("t1", "/path", () => {}, onState);
+
+    expect(onState).toHaveBeenCalledWith("degraded");
+    expect(() => unsub()).not.toThrow();
+  });
+
+  it("첫 구독자는 watching, 추가 구독자도 watching 상태를 받는다", () => {
+    const mockFactory: WatcherFactory = vi.fn().mockReturnValue({ close: vi.fn(), on: vi.fn() });
+    const registry = createWatcherRegistry(mockFactory);
+
+    const onState1 = vi.fn();
+    const onState2 = vi.fn();
+    const unsub1 = registry.subscribe("t1", "/path", () => {}, onState1);
+    const unsub2 = registry.subscribe("t1", "/path", () => {}, onState2);
+
+    expect(onState1).toHaveBeenCalledWith("watching");
+    expect(onState2).toHaveBeenCalledWith("watching");
+
+    unsub1();
+    unsub2();
+  });
+
+  it("filename이 null이면 루트('')로 발화한다", () => {
+    let watchCb: ((event: string, filename: string | null) => void) | undefined;
+    const mockFactory: WatcherFactory = vi.fn().mockImplementation((_, __, cb) => {
+      watchCb = cb;
+      return { close: vi.fn(), on: vi.fn() };
+    });
+    const registry = createWatcherRegistry(mockFactory, 50);
+
+    const onChange = vi.fn();
+    const unsub = registry.subscribe("t1", "/path", onChange, () => {});
+
+    watchCb!("change", null);
+    vi.advanceTimersByTime(100);
+
+    expect(onChange).toHaveBeenCalledWith("");
+    unsub();
+  });
+
+  it("루트 레벨 파일(서브디렉토리 없음)은 루트('')로 발화한다", () => {
+    let watchCb: ((event: string, filename: string | null) => void) | undefined;
+    const mockFactory: WatcherFactory = vi.fn().mockImplementation((_, __, cb) => {
+      watchCb = cb;
+      return { close: vi.fn(), on: vi.fn() };
+    });
+    const registry = createWatcherRegistry(mockFactory, 50);
+
+    const onChange = vi.fn();
+    const unsub = registry.subscribe("t1", "/path", onChange, () => {});
+
+    watchCb!("change", "README.md");
+    vi.advanceTimersByTime(100);
+
+    expect(onChange).toHaveBeenCalledWith("");
+    unsub();
+  });
+
+  it("unsub를 두 번 호출해도 watcher.close()는 한 번만 호출된다", () => {
+    const mockClose = vi.fn();
+    const mockFactory: WatcherFactory = vi.fn().mockReturnValue({ close: mockClose, on: vi.fn() });
+    const registry = createWatcherRegistry(mockFactory);
+
+    const unsub = registry.subscribe("t1", "/path", () => {}, () => {});
+    unsub();
+    unsub();
+
+    expect(mockClose).toHaveBeenCalledOnce();
+  });
+
+  it("watcher 런타임 error 시 구독자 전원에게 degraded를 알리고 정리한다", () => {
+    let errorCb: ((error: Error) => void) | undefined;
+    const mockClose = vi.fn();
+    const mockFactory: WatcherFactory = vi.fn().mockReturnValue({
+      close: mockClose,
+      on: vi.fn().mockImplementation((event: string, cb: (error: Error) => void) => {
+        if (event === "error") errorCb = cb;
+      }),
+    });
+    const registry = createWatcherRegistry(mockFactory);
+
+    const onState1 = vi.fn();
+    const onState2 = vi.fn();
+    registry.subscribe("t1", "/path", () => {}, onState1);
+    registry.subscribe("t1", "/path", () => {}, onState2);
+
+    errorCb!(new Error("EPERM: watched directory removed"));
+
+    expect(onState1).toHaveBeenCalledWith("degraded");
+    expect(onState2).toHaveBeenCalledWith("degraded");
+    expect(mockClose).toHaveBeenCalledOnce();
+
+    // error 정리 이후의 재구독은 새 watcher를 생성한다
+    registry.subscribe("t1", "/path", () => {}, vi.fn());
+    expect(mockFactory).toHaveBeenCalledTimes(2);
+  });
+
+  it("서로 다른 theaterId는 독립적인 watcher를 가진다", () => {
+    const mockClose1 = vi.fn();
+    const mockClose2 = vi.fn();
+    let callCount = 0;
+    const mockFactory: WatcherFactory = vi.fn().mockImplementation(() => {
+      callCount++;
+      return { close: callCount === 1 ? mockClose1 : mockClose2, on: vi.fn() };
+    });
+    const registry = createWatcherRegistry(mockFactory);
+
+    const unsub1 = registry.subscribe("t1", "/path1", () => {}, () => {});
+    const unsub2 = registry.subscribe("t2", "/path2", () => {}, () => {});
+
+    expect(mockFactory).toHaveBeenCalledTimes(2);
+
+    unsub1();
+    expect(mockClose1).toHaveBeenCalledOnce();
+    expect(mockClose2).not.toHaveBeenCalled();
+
+    unsub2();
+    expect(mockClose2).toHaveBeenCalledOnce();
+  });
+});

--- a/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
@@ -193,6 +193,56 @@ describe("createWatcherRegistry", () => {
     expect(mockClose).toHaveBeenCalledOnce();
   });
 
+  it("Windows 백슬래시 경로도 list API와 동일한 OS-native 구분자로 발화한다", () => {
+    let watchCb: ((event: string, filename: string | null) => void) | undefined;
+    const mockFactory: WatcherFactory = vi.fn().mockImplementation((_, __, cb) => {
+      watchCb = cb;
+      return { close: vi.fn(), on: vi.fn() };
+    });
+    const registry = createWatcherRegistry(mockFactory, 50);
+
+    const onChange = vi.fn();
+    const unsub = registry.subscribe("t1", "/path", onChange, () => {});
+
+    watchCb!("change", "src\\nested\\file.ts");
+    vi.advanceTimersByTime(100);
+
+    // path.relative가 만드는 클라이언트 저장값(src\nested)과 동일해야 한다
+    expect(onChange).toHaveBeenCalledWith("src\\nested");
+    unsub();
+  });
+
+  it("error 후 옛 구독 해제가 교체 watcher를 레지스트리에서 제거하지 않는다", () => {
+    const errorCbs: Array<(error: Error) => void> = [];
+    const closes: Array<ReturnType<typeof vi.fn>> = [];
+    const mockFactory: WatcherFactory = vi.fn().mockImplementation(() => {
+      const close = vi.fn();
+      closes.push(close);
+      return {
+        close,
+        on: vi.fn().mockImplementation((event: string, cb: (error: Error) => void) => {
+          if (event === "error") errorCbs.push(cb);
+        }),
+      };
+    });
+    const registry = createWatcherRegistry(mockFactory);
+
+    const unsubOld = registry.subscribe("t1", "/path", () => {}, vi.fn());
+    errorCbs[0]!(new Error("EPERM"));
+
+    // 교체 watcher 생성 (2번째 factory 호출)
+    registry.subscribe("t1", "/path", () => {}, vi.fn());
+    expect(mockFactory).toHaveBeenCalledTimes(2);
+
+    // 옛 구독 해제 — 교체 entry를 지우면 안 된다
+    unsubOld();
+
+    // 교체 entry가 살아있으면 재구독은 watcher를 재사용한다 (3번째 factory 호출 없음)
+    registry.subscribe("t1", "/path", () => {}, vi.fn());
+    expect(mockFactory).toHaveBeenCalledTimes(2);
+    expect(closes[1]).not.toHaveBeenCalled();
+  });
+
   it("watcher 런타임 error 시 구독자 전원에게 degraded를 알리고 정리한다", () => {
     let errorCb: ((error: Error) => void) | undefined;
     const mockClose = vi.fn();


### PR DESCRIPTION
## Summary
- File Explorer 트리 툴바에 수동 새로고침 버튼 추가 — 루트와 펼쳐진 모든 폴더를 재조회하며 펼침 상태·선택을 유지
- 접었다 다시 편 폴더는 항상 서버에서 재조회 (기존 영구 in-memory 캐시 제거)
- Theater 루트 fs.watch 기반 SSE push 자동 새로고침 (`GET /plugins/file-explorer/files/watch`) — 변경된 디렉토리의 상대경로만 push하고 클라이언트는 루트/펼쳐진 폴더에 한해 재조회
- Watcher registry: theaterId별 단일 watcher를 구독자 카운트로 공유, 200ms debounce, 마지막 구독 해제 시 close, 런타임 error 시 degraded 통지 후 정리 (프로세스 크래시 방지), fs.watch 미지원 플랫폼 graceful degrade
- 감시 상태 표시 UI(aurora dot)는 제품 결정으로 미탑재 — SSE `state` 이벤트(watching/degraded)는 채널 계약으로 유지하되 클라이언트는 소비하지 않음

## Security
- SSE 페이로드는 Theater-상대 디렉토리 경로만 포함 (절대경로·파일 내용 비노출)
- 기존 파일 라우트와 동일한 `isTerminalAuthorized` Origin 게이트 + `resolveTheaterPath` 해석 적용, SDK/core 표면 무변경

## Test Plan
- [x] `pnpm --filter @fleet-plugins/file-explorer test` — 19 tests (watcher registry 12건 포함)
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 478 passed
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Sentinel console-e2e 실브라우저 QA PASS — 자동 반영(~2s, 루트+하위폴더), 수동 새로고침 상태 유지, 재펼침 재조회, SSE 수명주기(패널 닫힘 시 해제·재열기 시 재구독), 기존 Filter/숨김토글/미리보기 회귀 무결, 콘솔 오류 0
- [x] `.changelog.d/file-explorer-refresh.md` 프래그먼트 포함 (`node scripts/compile-changelog-fragments.mjs --check` OK)