### PR TITLE
fix(fleet-console): fix Diff repo picker dropdown and nested-repo auto-select

### DIFF
--- a/.changelog.d/diff-picker-dropdown-fix.md
+++ b/.changelog.d/diff-picker-dropdown-fix.md
@@ -1,0 +1,6 @@
+---
+section: Fixed
+---
+
+- [fleet-console] Fixed the Diff panel repository picker dropdown not appearing when clicked because it was positioned outside the panel and clipped.
+- [fleet-console] The Diff panel no longer auto-selects a nested repository when the Theater root is not a Git repository; pick one explicitly from the toolbar picker instead.

--- a/runtime/fleet-plugins/diff/client/diff.css
+++ b/runtime/fleet-plugins/diff/client/diff.css
@@ -58,6 +58,7 @@
 
 /* ── 플러그인 툴바 (List/Tree 토글) ── */
 .diff-plugin-toolbar {
+  position: relative; /* 저장소 피커 드롭다운(absolute)의 컨테이닝 블록 — 없으면 상위 기준으로 배치돼 화면 밖으로 클리핑됨 */
   display: flex;
   align-items: center;
   gap: 6px;
@@ -428,6 +429,9 @@
   left: 8px;
   right: 8px;
   top: calc(100% + 4px);
+  /* 저장소가 많아도 트리페인(overflow:hidden) 밖으로 넘쳐 잘리지 않도록 내부 스크롤 */
+  max-height: 340px;
+  overflow-y: auto;
   background: var(--surface-glass-strong);
   backdrop-filter: blur(18px) saturate(140%);
   border: 1px solid var(--surface-rim-strong);

--- a/runtime/fleet-plugins/diff/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/diff/client/rail-panel.tsx
@@ -258,7 +258,7 @@ function DiffPanel({ ctx }: DiffPanelProps) {
   const depthRef = useRef(depth);
   depthRef.current = depth;
 
-  const fetchRepos = useCallback((currentSubPath: string, maxDepth: number) => {
+  const fetchRepos = useCallback((maxDepth: number) => {
     if (!ctx.theaterId) return;
     const seq = ++fetchSeqRef.current;
     setReposLoading(true);
@@ -275,12 +275,8 @@ function DiffPanel({ ctx }: DiffPanelProps) {
       setRepos(fetched);
       setReposTruncated(data.truncated ?? false);
       setScanned(true);
-      // Smart 기본값: theater root가 저장소가 아닌데 다른 저장소가 있으면 첫 번째로 자동 전환
-      if (currentSubPath === "" && !fetched.some((r) => r.relPath === "") && fetched.length >= 1) {
-        const first = fetched[0]!;
-        setActiveSubPath(first.relPath);
-        if (ctx.theaterId) saveSubPath(ctx.theaterId, first.relPath);
-      }
+      // theater root가 저장소가 아니면 자동 선택하지 않는다 — 임의 하위 저장소를 여는 것은
+      // 사용자에게 혼란을 주므로, 하위 저장소는 드롭다운에서 명시적으로 선택하게 둔다.
       setReposLoading(false);
     }).catch(() => {
       if (seq !== fetchSeqRef.current) return;
@@ -298,7 +294,7 @@ function DiffPanel({ ctx }: DiffPanelProps) {
     setScanned(false);
     setMenuOpen(false);
     clearSelectedFile();
-    fetchRepos(sp, depthRef.current);
+    fetchRepos(depthRef.current);
   }, [ctx.theaterId, fetchRepos]);
 
   const handleTriggerClick = useCallback((e: React.MouseEvent) => {
@@ -318,12 +314,12 @@ function DiffPanel({ ctx }: DiffPanelProps) {
   const handleDepthChange = useCallback((newDepth: number) => {
     setDepth(newDepth);
     try { localStorage.setItem(PREFS_DEPTH, String(newDepth)); } catch { /* ignore */ }
-    fetchRepos(activeSubPath, newDepth);
-  }, [fetchRepos, activeSubPath]);
+    fetchRepos(newDepth);
+  }, [fetchRepos]);
 
   const handleRescan = useCallback(() => {
-    fetchRepos(activeSubPath, depth);
-  }, [fetchRepos, activeSubPath, depth]);
+    fetchRepos(depth);
+  }, [fetchRepos, depth]);
 
   // 외부 클릭으로 메뉴 닫기
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Diff 저장소 피커 드롭다운이 클릭해도 안 뜨던 버그 수정: `.diff-plugin-toolbar`에 `position: relative`가 없어 드롭다운(absolute)이 상위 컨테이너 기준으로 배치→트리페인 `overflow:hidden` 밖(`top:564` > pane bottom `560`)으로 완전 클리핑되던 것을 툴바 기준 배치로 교정. 긴 목록 대비 메뉴 `max-height`+내부 스크롤 추가.
- Theater root가 git 저장소가 아닐 때 하위 저장소를 자동 선택(smart 폴백)하던 동작 제거. 임의 저장소 자동 노출이 혼란스러우므로, "Not a Git repository" 상태를 유지하고 사용자가 툴바 드롭다운에서 명시적으로 선택하게 함.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` / `build` — pass
- [x] console-e2e(격리, **시각 실측**): 드롭다운이 툴바 바로 아래 뷰포트 내 표시(toolbarPosition=relative, inViewport=true) · non-repo theater에서 "Working tree"+"Not a Git repository"(자동노출 없음, fileRows=0) · 드롭다운에서 중첩 repo 명시 선택 시 해당 저장소 changes 표시
- 회귀 배경: PR #151 병합분에서 드롭다운이 DOM엔 있으나 시각적으로 클리핑됐고(당시 QA가 DOM 프로브만 통과), 사용자 보고로 재현·수정

## Changelog
- [x] `.changelog.d/diff-picker-dropdown-fix.md` (section: Fixed, `[fleet-console]`)