### PR TITLE
fix(fleet-console): give the Skills reading overlay a stable height

### DIFF
--- a/.changelog.d/skills-overlay-height.md
+++ b/.changelog.d/skills-overlay-height.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- [fleet-console] Fixed the Skills SKILL.md reading overlay collapsing to only a few lines tall; it now opens at a stable reading height with a scrollable body.

--- a/runtime/fleet-plugins/skills/client/skills.css
+++ b/runtime/fleet-plugins/skills/client/skills.css
@@ -361,7 +361,10 @@
   border-radius: var(--radius-xl);
   display: flex;
   flex-direction: column;
-  max-height: 80vh;
+  /* 확정 높이가 필수 — content-driven 높이에서는 body의 flex-grow가 분배할 공간이
+     없어 다이얼로그가 헤더+한 줄 높이로 붕괴한다(Codex Reading Sheet와 동일한
+     고정 컨테이너 패턴). max-height 상한만으로는 높이가 만들어지지 않는다. */
+  height: min(80vh, 900px);
   max-width: min(720px, calc(100vw - 120px));
   overflow: hidden;
   width: 100%;
@@ -407,6 +410,8 @@
 
 .skills-overlay-body {
   flex: 1 1 0;
+  /* flex 자식의 min-height:auto 기본값은 내용만큼 늘어나 스크롤을 깨뜨린다. */
+  min-height: 0;
   overflow-y: auto;
   padding: var(--space-4);
 }


### PR DESCRIPTION
## Summary
- Skills SKILL.md Reading 오버레이가 헤더+한 줄 높이로 붕괴하던 결함 수정 (PR #153 후속, 대원수 실사용 보고).
- 원인: 다이얼로그가 `max-height`(상한)만 갖고 확정 높이가 없는 상태에서 본문이 `flex: 1 1 0`(basis 0) — content-driven flex column에는 분배할 여유 공간이 없어 본문이 0 근처로 붕괴.
- 수정: 다이얼로그에 확정 높이 `height: min(80vh, 900px)`(Codex Reading Sheet의 고정 컨테이너 패턴) + 본문에 `min-height: 0`(flex 자식 스크롤 정석).

## Test Plan
- [x] 격리 인스턴스(headed) 재검증: dialog 실측 높이 462px = 뷰포트 80% 기대값 정확 일치, body 스크롤 정상(scrollHeight 4224), 스크린샷 확보
- [x] `pnpm --filter @dotobokuri/fleet-console build` clean
- [x] `node scripts/compile-changelog-fragments.mjs --check` OK (`.changelog.d/skills-overlay-height.md`, Fixed)