### PR TITLE
fix(fleet-console): make per-panel alerts last-writer-wins

### DIFF
--- a/.changelog.d/notification-last-writer-wins.md
+++ b/.changelog.d/notification-last-writer-wins.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- [fleet-console] Repeated alerts from the same Operation panel now replace the previous alert instead of accumulating a count; ALERTS badges and Theater group tallies show the number of panels with an active alert, and the per-row repeat-count badge is removed.

--- a/runtime/fleet-console/core/client/src/notification-reduce.ts
+++ b/runtime/fleet-console/core/client/src/notification-reduce.ts
@@ -4,7 +4,6 @@ export interface NotificationTheaterGroup {
   readonly theaterId: string | null;
   readonly theaterLabel: string;
   readonly notifications: readonly OperationNotification[];
-  readonly totalCount: number;
 }
 
 export interface VisibilitySplitNotifications {
@@ -51,17 +50,15 @@ export function splitNotificationsByVisibility(
 }
 
 export function groupNotificationsByTheater(notifications: readonly OperationNotification[]): readonly NotificationTheaterGroup[] {
-  const groups = new Map<string, { theaterId: string | null; theaterLabel: string; notifications: OperationNotification[]; totalCount: number }>();
+  const groups = new Map<string, { theaterId: string | null; theaterLabel: string; notifications: OperationNotification[] }>();
   for (const notification of [...notifications].sort((a, b) => b.lastRaisedSeq - a.lastRaisedSeq)) {
     const key = notification.theaterId ?? "__unknown__";
     const group = groups.get(key) ?? {
       theaterId: notification.theaterId,
       theaterLabel: notification.theaterLabel,
       notifications: [],
-      totalCount: 0,
     };
     group.notifications.push(notification);
-    group.totalCount += notification.count;
     groups.set(key, group);
   }
   return [...groups.values()].sort((a, b) => {

--- a/runtime/fleet-console/core/client/src/rail/alerts-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/alerts-panel.tsx
@@ -96,7 +96,7 @@ export function AlertsPanelBody() {
             >
               <header className="notification-cluster-group-head">
                 <span className="notification-cluster-theater">{group.theaterLabel}</span>
-                <span className="notification-cluster-group-count">{group.totalCount}</span>
+                <span className="notification-cluster-group-count">{group.notifications.length}</span>
               </header>
               <ul className="notification-cluster-roster">
                 {group.notifications.map((notification) => (
@@ -111,9 +111,6 @@ export function AlertsPanelBody() {
                         {KIND_LABEL[notification.kind]}
                       </span>
                     </span>
-                    {notification.count > 1 ? (
-                      <span className="notification-row-count">{notification.count}</span>
-                    ) : null}
                     <button
                       type="button"
                       className="notification-row-move"
@@ -146,7 +143,7 @@ function AlertsIcon() {
   const eligible = splitNotificationsByVisibility(notifications, visibleIds).hidden;
   const filtered = filterByPreferences(eligible, state.notificationPreferences);
   const groups = groupNotificationsByTheater(filtered);
-  const totalCount = groups.reduce((sum, group) => sum + group.totalCount, 0);
+  const totalCount = groups.reduce((sum, group) => sum + group.notifications.length, 0);
   const waitingCount = countByKind(groups, "input-waiting");
 
   // 패널이 닫혀있을 때 신규 알림 도착 시 외곽 펄스 1회 재생
@@ -246,7 +243,6 @@ function collectMuteableTheaterGroups(
       theaterLabel:
         theaters.find((theater) => theater.id === theaterId)?.label ?? theaterId,
       notifications: [],
-      totalCount: 0,
     });
   }
   return [...byId.values()];
@@ -259,7 +255,7 @@ function countByKind(
   let total = 0;
   for (const group of groups) {
     for (const notification of group.notifications) {
-      if (notification.kind === kind) total += notification.count;
+      if (notification.kind === kind) total += 1;
     }
   }
   return total;

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -122,7 +122,7 @@ export function OperationsSideBar({
       operation,
       active: activeOperationId === operation.id,
       minimized: minimizedSet.has(operation.id),
-      notificationCount: operationNotifications[operation.id]?.count ?? 0,
+      notificationCount: operationNotifications[operation.id] ? 1 : 0,
       icon,
     };
   });

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -212,8 +212,7 @@ export function raiseOperationNotification(input: ClientNotification): void {
   const operationLabel = operation.title;
   const kind = mapNotificationKind(input.kind);
   notificationSeq += 1;
-  const existing = state.operationNotifications[input.operationId];
-  const count = existing ? existing.count + 1 : 1;
+  // 같은 패널의 알림은 누적하지 않고 최신 것으로 교체한다(last-writer-wins).
   setState({
     operationNotifications: {
       ...state.operationNotifications,
@@ -223,7 +222,6 @@ export function raiseOperationNotification(input: ClientNotification): void {
         theaterId,
         theaterLabel,
         operationLabel,
-        count,
         lastRaisedSeq: notificationSeq,
       },
     },

--- a/runtime/fleet-console/core/client/src/styles/rail-alerts.css
+++ b/runtime/fleet-console/core/client/src/styles/rail-alerts.css
@@ -290,22 +290,6 @@
   color: var(--positive);
 }
 
-.notification-row-count {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 5px;
-  border-radius: 999px;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 600;
-  color: var(--ink-spectral);
-  background: color-mix(in oklch, var(--ink-fog) 17%, transparent);
-  flex-shrink: 0;
-}
-
 .notification-row-move {
   flex-shrink: 0;
   padding: 4px 11px;

--- a/runtime/fleet-console/core/client/src/types.ts
+++ b/runtime/fleet-console/core/client/src/types.ts
@@ -187,7 +187,6 @@ export interface OperationNotification {
   readonly theaterId: string | null;
   readonly theaterLabel: string;
   readonly operationLabel: string;
-  readonly count: number;
   readonly lastRaisedSeq: number;
 }
 

--- a/runtime/fleet-console/tests/reduce.test.ts
+++ b/runtime/fleet-console/tests/reduce.test.ts
@@ -23,7 +23,6 @@ function makeNotification(
   operationId: string,
   theaterId: string | null,
   lastRaisedSeq: number,
-  count = 1,
 ): OperationNotification {
   return {
     kind: "input-waiting",
@@ -31,7 +30,6 @@ function makeNotification(
     theaterId,
     theaterLabel: theaterId ?? "Unknown",
     operationLabel: operationId,
-    count,
     lastRaisedSeq,
   };
 }
@@ -316,14 +314,14 @@ describe("notification selectors", () => {
 
   it("groups notifications by Theater and sorts by last raised sequence", () => {
     const groups = groupNotificationsByTheater([
-      makeNotification("session-a", "theater-a", 1, 2),
+      makeNotification("session-a", "theater-a", 1),
       makeNotification("session-b", "theater-b", 5),
       makeNotification("session-c", "theater-a", 3),
     ]);
 
-    expect(groups.map((group) => [group.theaterId, group.totalCount, group.notifications.map((item) => item.operationId)])).toEqual([
-      ["theater-b", 1, ["session-b"]],
-      ["theater-a", 3, ["session-c", "session-a"]],
+    expect(groups.map((group) => [group.theaterId, group.notifications.map((item) => item.operationId)])).toEqual([
+      ["theater-b", ["session-b"]],
+      ["theater-a", ["session-c", "session-a"]],
     ]);
   });
 


### PR DESCRIPTION
## Summary

동일 Operation 패널에서 알림이 반복 발생할 때 `count`로 누적하던 것을 최신 알림으로 교체(last-writer-wins)하도록 변경합니다. `OperationNotification.count` 필드와 파생 `totalCount`, ALERTS 행별 반복 횟수 배지를 제거하고, ALERTS 아이콘·Theater 그룹 배지는 "활성 알림이 있는 패널 수"를 표시합니다. 사이드바 칩 배지는 0/1로 수렴합니다.

## Type of Change

- [x] fix — bug fix

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console test` — 49 files / 505 passed (22 skipped)
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — green
- [x] `pnpm --filter @dotobokuri/fleet-console build` — green
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK

## Changelog

- [x] Added one `.changelog.d/*.md` fragment (`notification-last-writer-wins.md`).
- [x] Fragment `section:` is `Changed`.
- [x] Fragment bullets are English and use only the `[fleet-console]` tag.