### PR TITLE
feat(fleet-console): group worktrees in diff repo dropdown

### DIFF
--- a/.changelog.d/diff-worktree-grouping.md
+++ b/.changelog.d/diff-worktree-grouping.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- [fleet-console] Diff panel repository dropdown now groups linked worktrees under their parent repository with a collapsible disclosure, instead of listing them as independent entries.

--- a/runtime/fleet-plugins/diff/client/diff.css
+++ b/runtime/fleet-plugins/diff/client/diff.css
@@ -562,6 +562,80 @@
   margin-top: 1px;
 }
 
+/* ── 워크트리 그룹 행 레이아웃 ── */
+/* 선택 버튼(flex:1)과 펼침 버튼(flex:none)을 나란히 배치 */
+.diff-repo-group-row {
+  display: flex;
+  align-items: center;
+}
+
+.diff-repo-group-row .diff-repo-opt {
+  flex: 1;
+  min-width: 0;
+  /* 그룹 행 내에서는 width:100% 대신 flex:1로 */
+  width: auto;
+}
+
+/* 워크트리 펼침 버튼 — 선택 버튼의 형제 요소(button-in-button 금지) */
+.diff-repo-expand {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 4px 7px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--ink-rim);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.04em;
+  border-radius: var(--radius-xs);
+  white-space: nowrap;
+  transition: color var(--duration-fast), background var(--duration-fast);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .diff-repo-expand {
+    transition-duration: 0.01ms;
+  }
+}
+
+.diff-repo-expand:hover {
+  color: var(--ink-spectral);
+  background: color-mix(in oklch, var(--ink-fog) 9%, transparent);
+}
+
+.diff-repo-expand[aria-expanded="true"] {
+  color: var(--brass);
+}
+
+/* 자식 행: 들여쓰기 + 좌측 연결선 */
+.diff-repo-child-row {
+  position: relative;
+  padding-left: 18px;
+}
+
+/* 좌측 1px 연결선 (var(--surface-rim)) */
+.diff-repo-child-row::before {
+  content: "";
+  position: absolute;
+  left: 10px;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--surface-rim);
+}
+
+/* 마지막 자식: 연결선을 행 중간까지만 그린다 */
+.diff-repo-child-row:last-child::before {
+  bottom: 50%;
+}
+
+.diff-repo-child-row .diff-repo-opt {
+  width: 100%;
+}
+
 /* ── 드롭다운 푸터: Depth + Rescan ── */
 .diff-repo-menu-foot {
   display: flex;

--- a/runtime/fleet-plugins/diff/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/diff/client/rail-panel.tsx
@@ -7,6 +7,7 @@ import "./diff.css";
 import { ChangedFiles } from "./changed-files.js";
 import { clearSelectedFile, setSelectedFile, type SelectedFile, useSelectedFile } from "./diff-view-store.js";
 import { HunkView } from "./hunk-view.js";
+import { groupRepos, relativeToParent } from "./repo-grouping.js";
 
 // ─── types ───────────────────────────────────────────────────────────────────
 
@@ -106,6 +107,17 @@ function basename(p: string): string {
 // ─── RepoDropdown ─────────────────────────────────────────────────────────────
 
 function RepoDropdown({ repos, loading, truncated, activeSubPath, depth, onSelect, onDepthChange, onRescan, onClose }: RepoPickerProps) {
+  // 현재 선택된 항목이 워크트리이면 해당 부모 그룹을 메뉴 열릴 때 자동 펼침
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => {
+    const active = repos.find((r) => r.relPath === activeSubPath);
+    if (active?.worktreeOf !== undefined) {
+      return new Set([active.worktreeOf]);
+    }
+    return new Set();
+  });
+
+  const { groups, topLevelCount } = groupRepos(repos);
+
   const handleClick = useCallback((e: React.MouseEvent) => {
     // 메뉴 내부 클릭은 바깥 클릭 핸들러로 버블링되지 않도록 막는다
     e.stopPropagation();
@@ -117,6 +129,31 @@ function RepoDropdown({ repos, loading, truncated, activeSubPath, depth, onSelec
     if (!isNaN(val)) onDepthChange(val);
   }, [onDepthChange]);
 
+  const toggleGroup = useCallback((relPath: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(relPath)) {
+        next.delete(relPath);
+      } else {
+        next.add(relPath);
+      }
+      return next;
+    });
+  }, []);
+
+  // 메뉴가 열린 뒤에 repos fetch가 도착하는 경합에서도 현재 선택의 부모 그룹을 펼친다
+  useEffect(() => {
+    const active = repos.find((r) => r.relPath === activeSubPath);
+    const parent = active?.worktreeOf;
+    if (parent === undefined) return;
+    setExpandedGroups((prev) => {
+      if (prev.has(parent)) return prev;
+      const next = new Set(prev);
+      next.add(parent);
+      return next;
+    });
+  }, [repos, activeSubPath]);
+
   return (
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
     <div
@@ -127,7 +164,7 @@ function RepoDropdown({ repos, loading, truncated, activeSubPath, depth, onSelec
     >
       <div className="diff-repo-menu-eyebrow">
         <span>Repositories</span>
-        {!loading && <span>{repos.length} found</span>}
+        {!loading && <span>{topLevelCount} found</span>}
       </div>
 
       {loading ? (
@@ -140,36 +177,95 @@ function RepoDropdown({ repos, loading, truncated, activeSubPath, depth, onSelec
           No Git repositories within depth {depth}.
         </div>
       ) : (
-        repos.map((repo) => {
+        groups.map(({ repo, worktrees }) => {
           const isCur = repo.relPath === activeSubPath;
+          const hasWorktrees = worktrees.length > 0;
+          const isExpanded = expandedGroups.has(repo.relPath);
+          const isOrphanWorktree = repo.isWorktree === true && repo.worktreeOf === undefined;
+
           return (
-            <button
-              key={repo.relPath}
-              type="button"
-              role="option"
-              aria-selected={isCur}
-              className={`diff-repo-opt${isCur ? " is-cur" : ""}`}
-              onClick={() => { onSelect(repo.relPath); onClose(); }}
-            >
-              <svg className="diff-repo-mark" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-                {isCur && (
-                  <path d="M3 7.5L6 10.5L11 4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-                )}
-              </svg>
-              <span>
-                <span className="diff-repo-line1">
-                  <span className="diff-repo-opt-name">{repo.name}</span>
-                  <span className="diff-repo-branch">
-                    <BranchIcon />
-                    <span>{repo.branch}</span>
+            <div key={repo.relPath} className="diff-repo-group">
+              {/* 부모/최상위 저장소 행: 선택 버튼 + 워크트리 펼침 버튼(있을 때만) */}
+              <div className="diff-repo-group-row">
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={isCur}
+                  className={`diff-repo-opt${isCur ? " is-cur" : ""}`}
+                  onClick={() => { onSelect(repo.relPath); onClose(); }}
+                >
+                  <svg className="diff-repo-mark" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                    {isCur && (
+                      <path d="M3 7.5L6 10.5L11 4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+                    )}
+                  </svg>
+                  <span>
+                    <span className="diff-repo-line1">
+                      <span className="diff-repo-opt-name">{repo.name}</span>
+                      <span className="diff-repo-branch">
+                        <BranchIcon />
+                        <span>{repo.branch}</span>
+                      </span>
+                      {repo.relPath === "" && <span className="diff-repo-badge">root</span>}
+                      {/* 고아 워크트리(부모 theater 밖): worktree 뱃지 */}
+                      {isOrphanWorktree && <span className="diff-repo-badge">worktree</span>}
+                    </span>
+                    <span className="diff-repo-opt-path">
+                      {repo.relPath === "" ? "· Theater root" : repo.relPath}
+                    </span>
                   </span>
-                  {repo.relPath === "" && <span className="diff-repo-badge">root</span>}
-                </span>
-                <span className="diff-repo-opt-path">
-                  {repo.relPath === "" ? "· Theater root" : repo.relPath}
-                </span>
-              </span>
-            </button>
+                </button>
+
+                {/* 워크트리 펼침 버튼 — button-in-button 금지로 형제 요소로 배치 */}
+                {hasWorktrees && (
+                  <button
+                    type="button"
+                    className="diff-repo-expand"
+                    aria-expanded={isExpanded}
+                    onClick={(e) => { e.stopPropagation(); toggleGroup(repo.relPath); }}
+                  >
+                    {isExpanded ? "▾" : "▸"} {worktrees.length} {worktrees.length === 1 ? "worktree" : "worktrees"}
+                  </button>
+                )}
+              </div>
+
+              {/* 자식 워크트리 목록 — 기본 접힘, 펼쳤을 때만 렌더 */}
+              {isExpanded && (
+                <div className="diff-repo-children" role="group">
+                  {worktrees.map((wt) => {
+                    const isWtCur = wt.relPath === activeSubPath;
+                    const relLabel = relativeToParent(wt.relPath, repo.relPath);
+                    return (
+                      <div key={wt.relPath} className="diff-repo-child-row">
+                        <button
+                          type="button"
+                          role="option"
+                          aria-selected={isWtCur}
+                          className={`diff-repo-opt diff-repo-child-opt${isWtCur ? " is-cur" : ""}`}
+                          onClick={() => { onSelect(wt.relPath); onClose(); }}
+                        >
+                          <svg className="diff-repo-mark" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                            {isWtCur && (
+                              <path d="M3 7.5L6 10.5L11 4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+                            )}
+                          </svg>
+                          <span>
+                            <span className="diff-repo-line1">
+                              <span className="diff-repo-opt-name">{wt.name}</span>
+                              <span className="diff-repo-branch">
+                                <BranchIcon />
+                                <span>{wt.branch}</span>
+                              </span>
+                            </span>
+                            <span className="diff-repo-opt-path">{relLabel}</span>
+                          </span>
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
           );
         })
       )}
@@ -251,7 +347,6 @@ function DiffPanel({ ctx }: DiffPanelProps) {
   const [repos, setRepos] = useState<RepoEntry[]>([]);
   const [reposLoading, setReposLoading] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
-  const [scanned, setScanned] = useState(false);
   const [reposTruncated, setReposTruncated] = useState(false);
   const fetchSeqRef = useRef(0);
   // depthRef: 렌더 중 동기 갱신 — theater useEffect에서 deps 없이 최신 depth 접근
@@ -274,7 +369,6 @@ function DiffPanel({ ctx }: DiffPanelProps) {
       const fetched = data.repos as RepoEntry[];
       setRepos(fetched);
       setReposTruncated(data.truncated ?? false);
-      setScanned(true);
       // theater root가 저장소가 아니면 자동 선택하지 않는다 — 임의 하위 저장소를 여는 것은
       // 사용자에게 혼란을 주므로, 하위 저장소는 드롭다운에서 명시적으로 선택하게 둔다.
       setReposLoading(false);
@@ -291,7 +385,6 @@ function DiffPanel({ ctx }: DiffPanelProps) {
     setActiveSubPath(sp);
     setRepos([]);
     setReposTruncated(false);
-    setScanned(false);
     setMenuOpen(false);
     clearSelectedFile();
     fetchRepos(depthRef.current);

--- a/runtime/fleet-plugins/diff/client/repo-grouping.ts
+++ b/runtime/fleet-plugins/diff/client/repo-grouping.ts
@@ -1,0 +1,57 @@
+import type { RepoEntry } from "../server/types.js";
+
+// ─── types ───────────────────────────────────────────────────────────────────
+
+export interface RepoGroup {
+  readonly repo: RepoEntry;
+  readonly worktrees: readonly RepoEntry[];
+}
+
+export interface GroupedRepos {
+  readonly groups: readonly RepoGroup[];
+  /** worktreeOf 있는 항목을 제외한 최상위 저장소 수 */
+  readonly topLevelCount: number;
+}
+
+// ─── functions ───────────────────────────────────────────────────────────────
+
+/**
+ * repos 배열을 부모-자식 그룹으로 구조화한다.
+ * worktreeOf가 있는 항목은 해당 부모 그룹의 worktrees 배열에 들어간다.
+ * 부모가 없는 고아 워크트리(isWorktree=true, worktreeOf 없음)는 단독 그룹으로 유지된다.
+ */
+export function groupRepos(repos: readonly RepoEntry[]): GroupedRepos {
+  const worktreesByParent = new Map<string, RepoEntry[]>();
+
+  for (const repo of repos) {
+    if (repo.worktreeOf !== undefined) {
+      const children = worktreesByParent.get(repo.worktreeOf) ?? [];
+      children.push(repo);
+      worktreesByParent.set(repo.worktreeOf, children);
+    }
+  }
+
+  const topLevel = repos.filter((r) => r.worktreeOf === undefined);
+  const groups: RepoGroup[] = topLevel.map((repo) => ({
+    repo,
+    worktrees: worktreesByParent.get(repo.relPath) ?? [],
+  }));
+
+  return { groups, topLevelCount: topLevel.length };
+}
+
+/**
+ * 자식 워크트리의 경로를 부모 기준 상대경로로 변환한다.
+ * 예: childRelPath="repos/main/.worktrees/feat", parentRelPath="repos/main" → ".worktrees/feat"
+ */
+export function relativeToParent(childRelPath: string, parentRelPath: string): string {
+  if (parentRelPath === "") return childRelPath;
+  // 경로 구분자 정규화 (서버가 OS 구분자로 전송할 수 있음)
+  const childNorm = childRelPath.replace(/\\/g, "/");
+  const parentNorm = parentRelPath.replace(/\\/g, "/");
+  const prefix = parentNorm + "/";
+  if (childNorm.startsWith(prefix)) {
+    return childNorm.slice(prefix.length);
+  }
+  return childNorm;
+}

--- a/runtime/fleet-plugins/diff/server/repos.ts
+++ b/runtime/fleet-plugins/diff/server/repos.ts
@@ -8,6 +8,17 @@ import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 import { runGit } from "./git-executor.js";
 import type { RepoEntry, ReposDiscoveryResult } from "./types.js";
 
+// ─── types ───────────────────────────────────────────────────────────────────
+
+/**
+ * scanRepos 내부 전용 확장 타입 — handleDiffRepos에서 resolveWorktreeParents로 처리 후
+ * 외부로는 노출되지 않는다. 테스트에서만 직접 사용 가능.
+ */
+export interface RawRepoEntry extends RepoEntry {
+  /** 워크트리 부모의 realpath-resolved 절대경로. resolveWorktreeParents에서 worktreeOf로 변환됨 */
+  readonly _wtParentAbs?: string;
+}
+
 // ─── constants ───────────────────────────────────────────────────────────────
 
 export const REPOS_CAP = 200;
@@ -36,25 +47,86 @@ export async function resolveRepoBranch(repoDir: string): Promise<string> {
   }
 }
 
+/**
+ * .git 파일 내용에서 gitdir 포인터를 파싱해 링크드 워크트리 여부와 부모 절대경로를 반환.
+ * 서브모듈(.git 파일이지만 /modules/ 경로)은 null 반환 → 독립 저장소로 유지.
+ * 워크트리이면 { isWorktree: true, parentAbs } 반환.
+ */
+async function detectWorktreeParent(
+  dir: string,
+  gitFileContent: string,
+): Promise<{ isWorktree: true; parentAbs: string } | null> {
+  const match = gitFileContent.trim().match(/^gitdir:\s*(.+)$/m);
+  if (!match) return null;
+
+  const rawPointer = match[1]!.trim();
+  // 상대경로이면 워크트리 디렉터리 기준으로 resolve.
+  // Windows에서 git은 gitdir 포인터를 슬래시(/)로 기록할 수 있으므로 OS 구분자로 정규화한다.
+  const resolvedGitdir = path.normalize(
+    path.isAbsolute(rawPointer) ? rawPointer : path.resolve(dir, rawPointer),
+  );
+
+  // 서브모듈(.git/modules/ 패턴): 워크트리로 분류하지 않음
+  if (resolvedGitdir.includes(`${path.sep}modules${path.sep}`)) {
+    return null;
+  }
+
+  // 링크드 워크트리(.git/worktrees/ 패턴): 부모 저장소 도출
+  const worktreesSegment = `${path.sep}.git${path.sep}worktrees${path.sep}`;
+  const wtIdx = resolvedGitdir.indexOf(worktreesSegment);
+  if (wtIdx === -1) {
+    // 알 수 없는 .git 파일 패턴 — 워크트리로 분류하지 않음
+    return null;
+  }
+
+  const parentAbsRaw = resolvedGitdir.slice(0, wtIdx);
+
+  // realpath로 정규화 (심링크 경로 vs 실제 경로 불일치 방지)
+  let parentAbs: string;
+  try {
+    parentAbs = await fs.realpath(parentAbsRaw);
+  } catch {
+    parentAbs = path.normalize(parentAbsRaw);
+  }
+
+  return { isWorktree: true, parentAbs };
+}
+
 export async function scanRepos(
   theaterPath: string,
   realTheaterPath: string,
   dir: string,
   currentDepth: number,
   maxDepth: number,
-  repos: RepoEntry[],
+  repos: RawRepoEntry[],
   cap = REPOS_CAP,
 ): Promise<boolean> {
   if (repos.length >= cap) return true;
 
-  // .git 파일 또는 디렉터리 존재 여부 확인 (워크트리·서브모듈은 .git이 파일임)
+  // .git 파일 또는 디렉터리 존재 여부 확인
   const gitPath = path.join(dir, ".git");
   try {
-    await fs.stat(gitPath);
+    const gitStat = await fs.stat(gitPath);
     const relPath = path.relative(theaterPath, dir);
     const name = relPath === "" ? path.basename(theaterPath) : path.basename(dir);
     const branch = await resolveRepoBranch(dir);
-    repos.push({ relPath, name, branch });
+
+    if (gitStat.isFile()) {
+      // .git이 파일 → 워크트리 또는 서브모듈
+      const content = await fs.readFile(gitPath, "utf8");
+      const worktreeResult = await detectWorktreeParent(dir, content);
+      if (worktreeResult) {
+        // 링크드 워크트리: _wtParentAbs 임시 저장
+        repos.push({ relPath, name, branch, isWorktree: true, _wtParentAbs: worktreeResult.parentAbs });
+      } else {
+        // 서브모듈 또는 알 수 없는 .git 파일 → 독립 저장소
+        repos.push({ relPath, name, branch });
+      }
+    } else {
+      // .git이 디렉터리 → 일반 저장소
+      repos.push({ relPath, name, branch });
+    }
+
     if (repos.length >= cap) return true;
   } catch {
     // .git 없음 — 이 디렉터리는 저장소가 아님
@@ -110,6 +182,42 @@ export async function scanRepos(
   }
 }
 
+/**
+ * scanRepos 결과에서 워크트리의 worktreeOf를 해결한다.
+ * realTheaterPath 기준으로 각 저장소 절대경로 맵을 구축하고,
+ * _wtParentAbs가 맵에 존재하면 해당 relPath를 worktreeOf로 설정한다.
+ * 부모가 theater 밖이거나 스캔에 없으면 worktreeOf 없이 isWorktree만 남긴다.
+ */
+export function resolveWorktreeParents(
+  raw: readonly RawRepoEntry[],
+  realTheaterPath: string,
+): RepoEntry[] {
+  // realTheaterPath 기준 절대경로 → relPath 맵 구축
+  const absToRelPath = new Map<string, string>();
+  for (const entry of raw) {
+    const absDir = path.normalize(
+      entry.relPath === ""
+        ? realTheaterPath
+        : path.join(realTheaterPath, entry.relPath),
+    );
+    absToRelPath.set(absDir, entry.relPath);
+  }
+
+  return raw.map((entry): RepoEntry => {
+    // _wtParentAbs 제거 후 DTO 변환
+    const { _wtParentAbs, ...rest } = entry;
+    if (_wtParentAbs && entry.isWorktree) {
+      const normalizedParent = path.normalize(_wtParentAbs);
+      const parentRelPath = absToRelPath.get(normalizedParent);
+      if (parentRelPath !== undefined) {
+        // 부모가 동일 theater 내에 존재 → worktreeOf 설정
+        return { ...rest, worktreeOf: parentRelPath };
+      }
+    }
+    return rest;
+  });
+}
+
 // ─── handler ─────────────────────────────────────────────────────────────────
 
 export async function handleDiffRepos(
@@ -144,16 +252,19 @@ export async function handleDiffRepos(
     return;
   }
 
-  const repos: RepoEntry[] = [];
-  const truncated = await scanRepos(theaterPath, realTheaterPath, theaterPath, 0, maxDepth, repos);
+  const raw: RawRepoEntry[] = [];
+  const truncated = await scanRepos(theaterPath, realTheaterPath, theaterPath, 0, maxDepth, raw);
+
+  // 워크트리 부모 해결 (realTheaterPath 기준)
+  const resolved = resolveWorktreeParents(raw, realTheaterPath);
 
   // 정렬: theater root("") 먼저, 그다음 relPath 사전순
-  repos.sort((a, b) => {
+  resolved.sort((a, b) => {
     if (a.relPath === "") return -1;
     if (b.relPath === "") return 1;
     return a.relPath.localeCompare(b.relPath);
   });
 
-  const result: ReposDiscoveryResult = { repos, ...(truncated ? { truncated: true } : {}) };
+  const result: ReposDiscoveryResult = { repos: resolved, ...(truncated ? { truncated: true } : {}) };
   ctx.host.http.writeJson(res, 200, result);
 }

--- a/runtime/fleet-plugins/diff/server/types.ts
+++ b/runtime/fleet-plugins/diff/server/types.ts
@@ -22,6 +22,10 @@ export interface RepoEntry {
   readonly relPath: string;
   readonly name: string;
   readonly branch: string;
+  /** 링크드 워크트리인 경우 true. 고아 워크트리(부모가 theater 밖)도 포함 */
+  readonly isWorktree?: boolean;
+  /** 부모 저장소의 relPath. 부모가 동일 theater 내에 있을 때만 설정됨 */
+  readonly worktreeOf?: string;
 }
 
 export interface ReposDiscoveryResult {

--- a/runtime/fleet-plugins/diff/tests/repo-grouping.test.ts
+++ b/runtime/fleet-plugins/diff/tests/repo-grouping.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { groupRepos, relativeToParent } from "../client/repo-grouping.js";
+import type { RepoEntry } from "../server/types.js";
+
+// 클라이언트 순수 로직 — DOM/React 없이 Node.js 환경에서 단위 테스트 가능.
+
+describe("groupRepos", () => {
+  it("worktreeOf 없는 항목만 있으면 그룹이 1:1로 생성된다", () => {
+    const repos: RepoEntry[] = [
+      { relPath: "", name: "root", branch: "main" },
+      { relPath: "sub", name: "sub", branch: "dev" },
+    ];
+    const { groups, topLevelCount } = groupRepos(repos);
+    expect(topLevelCount).toBe(2);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]!.worktrees).toHaveLength(0);
+    expect(groups[1]!.worktrees).toHaveLength(0);
+  });
+
+  it("worktreeOf가 있는 항목은 부모 그룹의 worktrees 배열에 들어간다", () => {
+    const repos: RepoEntry[] = [
+      { relPath: "main", name: "main", branch: "main" },
+      { relPath: "main/.wt/feat", name: ".wt/feat", branch: "feat", isWorktree: true, worktreeOf: "main" },
+    ];
+    const { groups, topLevelCount } = groupRepos(repos);
+    // topLevelCount는 worktreeOf 없는 항목 수
+    expect(topLevelCount).toBe(1);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.repo.relPath).toBe("main");
+    expect(groups[0]!.worktrees).toHaveLength(1);
+    expect(groups[0]!.worktrees[0]!.relPath).toBe("main/.wt/feat");
+  });
+
+  it("여러 워크트리가 동일 부모에 묶인다", () => {
+    const repos: RepoEntry[] = [
+      { relPath: "repo", name: "repo", branch: "main" },
+      { relPath: "repo/.wt/a", name: "a", branch: "a", isWorktree: true, worktreeOf: "repo" },
+      { relPath: "repo/.wt/b", name: "b", branch: "b", isWorktree: true, worktreeOf: "repo" },
+      { relPath: "repo/.wt/c", name: "c", branch: "c", isWorktree: true, worktreeOf: "repo" },
+    ];
+    const { groups, topLevelCount } = groupRepos(repos);
+    expect(topLevelCount).toBe(1);
+    expect(groups[0]!.worktrees).toHaveLength(3);
+  });
+
+  it("고아 워크트리(isWorktree=true, worktreeOf 없음)는 단독 최상위 그룹으로 유지된다", () => {
+    const repos: RepoEntry[] = [
+      { relPath: "orphan", name: "orphan", branch: "feat", isWorktree: true },
+    ];
+    const { groups, topLevelCount } = groupRepos(repos);
+    expect(topLevelCount).toBe(1);
+    expect(groups[0]!.repo.isWorktree).toBe(true);
+    expect(groups[0]!.worktrees).toHaveLength(0);
+  });
+
+  it("빈 배열이면 groups=[], topLevelCount=0을 반환한다", () => {
+    const { groups, topLevelCount } = groupRepos([]);
+    expect(groups).toHaveLength(0);
+    expect(topLevelCount).toBe(0);
+  });
+
+  it("복수 부모+복수 워크트리 혼합 시나리오", () => {
+    const repos: RepoEntry[] = [
+      { relPath: "a", name: "a", branch: "main" },
+      { relPath: "b", name: "b", branch: "main" },
+      { relPath: "a/.wt/x", name: "x", branch: "x", isWorktree: true, worktreeOf: "a" },
+      { relPath: "b/.wt/y", name: "y", branch: "y", isWorktree: true, worktreeOf: "b" },
+      { relPath: "standalone", name: "standalone", branch: "main" },
+    ];
+    const { groups, topLevelCount } = groupRepos(repos);
+    expect(topLevelCount).toBe(3); // a, b, standalone (워크트리 제외)
+    expect(groups).toHaveLength(3);
+    const groupA = groups.find((g) => g.repo.relPath === "a")!;
+    expect(groupA.worktrees).toHaveLength(1);
+    expect(groupA.worktrees[0]!.relPath).toBe("a/.wt/x");
+  });
+});
+
+describe("relativeToParent", () => {
+  it("부모 접두사를 제거해 상대경로를 반환한다", () => {
+    expect(relativeToParent("repos/main/.worktrees/feat", "repos/main")).toBe(".worktrees/feat");
+  });
+
+  it("parentRelPath가 빈 문자열이면 childRelPath 전체를 반환한다", () => {
+    expect(relativeToParent("some/path", "")).toBe("some/path");
+  });
+
+  it("경로가 부모 접두사로 시작하지 않으면 childRelPath(정규화)를 반환한다", () => {
+    expect(relativeToParent("other/path", "repos/main")).toBe("other/path");
+  });
+
+  it("Windows 역슬래시 경로도 정규화해 처리한다", () => {
+    expect(relativeToParent("repos\\main\\.wt\\feat", "repos\\main")).toBe(".wt/feat");
+  });
+
+  it("theater root가 부모(relPath='')인 워크트리 경로도 처리한다", () => {
+    expect(relativeToParent(".worktrees/hotfix", "")).toBe(".worktrees/hotfix");
+  });
+});

--- a/runtime/fleet-plugins/diff/tests/repos-discovery.test.ts
+++ b/runtime/fleet-plugins/diff/tests/repos-discovery.test.ts
@@ -5,8 +5,8 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { GitExecutorError, runGit } from "../server/git-executor.js";
-import { REPOS_CAP, resolveRepoBranch, scanRepos } from "../server/repos.js";
-import type { RepoEntry } from "../server/types.js";
+import { REPOS_CAP, resolveRepoBranch, resolveWorktreeParents, scanRepos } from "../server/repos.js";
+import type { RawRepoEntry } from "../server/repos.js";
 
 // 실제 파일 시스템 + 실제 git 명령어를 사용하는 화이트박스 테스트.
 
@@ -34,7 +34,7 @@ describe("repos 디스커버리", () => {
   it("theater root 자체가 git 저장소면 relPath '' 로 등록된다", async () => {
     await initGitRepo(tmpDir);
     const realTheater = await fs.realpath(tmpDir);
-    const repos: RepoEntry[] = [];
+    const repos: RawRepoEntry[] = [];
     await scanRepos(tmpDir, realTheater, tmpDir, 0, 3, repos);
     expect(repos).toHaveLength(1);
     expect(repos[0]!.relPath).toBe("");
@@ -45,21 +45,117 @@ describe("repos 디스커버리", () => {
     await mkdirp(inner);
     await initGitRepo(inner);
     const realTheater = await fs.realpath(tmpDir);
-    const repos: RepoEntry[] = [];
+    const repos: RawRepoEntry[] = [];
     await scanRepos(tmpDir, realTheater, tmpDir, 0, 3, repos);
     expect(repos.some((r) => r.relPath === "sub")).toBe(true);
   });
 
-  it(".git 파일(워크트리)도 저장소로 탐지한다", async () => {
+  it(".git 파일(링크드 워크트리)을 isWorktree:true로 분류한다", async () => {
     const inner = path.join(tmpDir, "wt");
     await mkdirp(inner);
-    // 워크트리는 .git이 파일로 존재함
+    // 링크드 워크트리는 .git이 파일로 존재하며 /worktrees/ 포인터를 가짐
     await fs.writeFile(path.join(inner, ".git"), "gitdir: /some/path/.git/worktrees/wt");
     const realTheater = await fs.realpath(tmpDir);
-    const repos: RepoEntry[] = [];
+    const repos: RawRepoEntry[] = [];
     await scanRepos(tmpDir, realTheater, tmpDir, 0, 3, repos);
-    // branch 해석은 git repo가 아니라 "unknown"이 되지만 저장소로 등록돼야 한다
-    expect(repos.some((r) => r.relPath === "wt")).toBe(true);
+    const wtEntry = repos.find((r) => r.relPath === "wt");
+    expect(wtEntry).toBeDefined();
+    // 워크트리로 분류돼야 한다
+    expect(wtEntry?.isWorktree).toBe(true);
+    // 부모(/some/path)가 theater 밖이므로 _wtParentAbs는 설정되지만 worktreeOf는 없다
+    expect(wtEntry?.worktreeOf).toBeUndefined();
+  });
+
+  it("gitdir 포인터 → theater 내 부모가 있으면 worktreeOf를 도출한다", async () => {
+    // 부모 저장소(더미 .git 디렉터리)
+    const parentDir = path.join(tmpDir, "main");
+    await mkdirp(path.join(parentDir, ".git"));
+
+    // 워크트리: .git 파일이 부모의 /worktrees/ 경로를 가리킴
+    const wtDir = path.join(tmpDir, "feature");
+    await mkdirp(wtDir);
+    await fs.writeFile(
+      path.join(wtDir, ".git"),
+      `gitdir: ${parentDir}/.git/worktrees/feature`,
+    );
+
+    const realTheater = await fs.realpath(tmpDir);
+    const raw: RawRepoEntry[] = [];
+    await scanRepos(tmpDir, realTheater, tmpDir, 0, 3, raw);
+
+    const resolved = resolveWorktreeParents(raw, realTheater);
+
+    const featureEntry = resolved.find((r) => r.relPath === "feature");
+    expect(featureEntry?.isWorktree).toBe(true);
+    expect(featureEntry?.worktreeOf).toBe("main");
+
+    const mainEntry = resolved.find((r) => r.relPath === "main");
+    expect(mainEntry?.isWorktree).toBeUndefined();
+    expect(mainEntry?.worktreeOf).toBeUndefined();
+  });
+
+  it("/modules/ 경로를 가진 .git 파일(서브모듈)은 워크트리로 분류하지 않는다", async () => {
+    const inner = path.join(tmpDir, "submodule");
+    await mkdirp(inner);
+    // 서브모듈의 .git 파일은 /modules/ 경로를 가짐
+    await fs.writeFile(
+      path.join(inner, ".git"),
+      "gitdir: /parent/.git/modules/submodule",
+    );
+    const realTheater = await fs.realpath(tmpDir);
+    const repos: RawRepoEntry[] = [];
+    await scanRepos(tmpDir, realTheater, tmpDir, 0, 3, repos);
+    const smEntry = repos.find((r) => r.relPath === "submodule");
+    // 서브모듈은 독립 저장소로 등록돼야 한다
+    expect(smEntry).toBeDefined();
+    expect(smEntry?.isWorktree).toBeUndefined();
+    expect(smEntry?.worktreeOf).toBeUndefined();
+  });
+
+  it("부모가 theater 밖인 고아 워크트리는 isWorktree:true이지만 worktreeOf 없이 top-level 유지", async () => {
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), "fleet-repos-outside-"));
+    try {
+      const wtDir = path.join(tmpDir, "orphan-wt");
+      await mkdirp(wtDir);
+      // 부모가 theater 밖
+      await fs.writeFile(
+        path.join(wtDir, ".git"),
+        `gitdir: ${outside}/.git/worktrees/orphan-wt`,
+      );
+      const realTheater = await fs.realpath(tmpDir);
+      const raw: RawRepoEntry[] = [];
+      await scanRepos(tmpDir, realTheater, tmpDir, 0, 3, raw);
+      const resolved = resolveWorktreeParents(raw, realTheater);
+      const orphan = resolved.find((r) => r.relPath === "orphan-wt");
+      expect(orphan).toBeDefined();
+      expect(orphan?.isWorktree).toBe(true);
+      expect(orphan?.worktreeOf).toBeUndefined();
+    } finally {
+      await fs.rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("상대 gitdir 경로도 워크트리로 올바르게 resolve한다", async () => {
+    // 부모 저장소
+    const parentDir = path.join(tmpDir, "repo");
+    await mkdirp(path.join(parentDir, ".git"));
+
+    // 워크트리: 상대경로로 gitdir 포인터 작성
+    const wtDir = path.join(tmpDir, "repo", "linked-wt");
+    await mkdirp(wtDir);
+    // 상대경로: wtDir 기준으로 ../../repo/.git/worktrees/linked-wt
+    // = path.relative(wtDir, parentDir + "/.git/worktrees/linked-wt")
+    const relGitdir = path.relative(wtDir, path.join(parentDir, ".git", "worktrees", "linked-wt"));
+    await fs.writeFile(path.join(wtDir, ".git"), `gitdir: ${relGitdir}`);
+
+    const realTheater = await fs.realpath(tmpDir);
+    const raw: RawRepoEntry[] = [];
+    await scanRepos(tmpDir, realTheater, tmpDir, 0, 5, raw);
+    const resolved = resolveWorktreeParents(raw, realTheater);
+
+    const wtEntry = resolved.find((r) => r.relPath === path.join("repo", "linked-wt"));
+    expect(wtEntry?.isWorktree).toBe(true);
+    expect(wtEntry?.worktreeOf).toBe("repo");
   });
 
   it("maxDepth=1 이면 depth 2 이상 저장소를 탐지하지 않는다", async () => {
@@ -68,7 +164,7 @@ describe("repos 디스커버리", () => {
     await mkdirp(d2);
     await initGitRepo(d2);
     const realTheater = await fs.realpath(tmpDir);
-    const repos: RepoEntry[] = [];
+    const repos: RawRepoEntry[] = [];
     await scanRepos(tmpDir, realTheater, tmpDir, 0, 1, repos);
     expect(repos.some((r) => r.relPath === path.join("a", "b"))).toBe(false);
     void d1; // 미사용 경고 억제
@@ -79,7 +175,7 @@ describe("repos 디스커버리", () => {
     await mkdirp(d2);
     await initGitRepo(d2);
     const realTheater = await fs.realpath(tmpDir);
-    const repos: RepoEntry[] = [];
+    const repos: RawRepoEntry[] = [];
     await scanRepos(tmpDir, realTheater, tmpDir, 0, 2, repos);
     expect(repos.some((r) => r.relPath.endsWith("b"))).toBe(true);
   });
@@ -89,7 +185,7 @@ describe("repos 디스커버리", () => {
     await mkdirp(nm);
     await initGitRepo(nm);
     const realTheater = await fs.realpath(tmpDir);
-    const repos: RepoEntry[] = [];
+    const repos: RawRepoEntry[] = [];
     await scanRepos(tmpDir, realTheater, tmpDir, 0, 5, repos);
     expect(repos.some((r) => r.relPath.includes("node_modules"))).toBe(false);
   });
@@ -102,7 +198,7 @@ describe("repos 디스커버리", () => {
       await initGitRepo(d);
     }
     const realTheater = await fs.realpath(tmpDir);
-    const repos: RepoEntry[] = [];
+    const repos: RawRepoEntry[] = [];
     const truncated = await scanRepos(tmpDir, realTheater, tmpDir, 0, 3, repos, 1);
     expect(truncated).toBe(true);
     expect(repos.length).toBeLessThanOrEqual(1);
@@ -122,7 +218,7 @@ describe("repos 디스커버리", () => {
       const link = path.join(tmpDir, "symlink-to-outside");
       await fs.symlink(outside, link);
       const realTheater = await fs.realpath(tmpDir);
-      const repos: RepoEntry[] = [];
+      const repos: RawRepoEntry[] = [];
       await scanRepos(tmpDir, realTheater, tmpDir, 0, 3, repos);
       // 심링크를 통해 외부 저장소가 등록되어서는 안 된다
       expect(repos.some((r) => r.relPath === "symlink-to-outside")).toBe(false);


### PR DESCRIPTION
## Summary
- Diff 패널 저장소 드롭다운이 git linked worktree를 독립 저장소처럼 평면 나열하던 문제를 해소: 워크트리를 부모 저장소 아래 접이식 그룹(기본 접힘)으로 표시하고, 헤더 카운트를 top-level 저장소 수 기준으로 정직하게 표기
- 서버 discovery가 `.git` 파일의 `gitdir:` 포인터를 파싱해 워크트리(`/worktrees/`)를 분류 — submodule(`/modules/`)은 기존대로 독립 저장소 유지, 부모가 Theater 밖인 고아 워크트리는 top-level + `worktree` 뱃지로 유지 (`RepoEntry`에 옵셔널 `isWorktree`/`worktreeOf` 추가, 하위호환)
- 선택된 워크트리가 접힌 그룹에 있으면 드롭다운 오픈 시 부모 그룹 자동 펼침; 선택 영속(localStorage relPath 키)은 무변경

## Test Plan
- [x] `pnpm --filter @fleet-plugins/diff test` — 27/27 통과 (gitdir 포인터 분류·submodule 제외·고아 fallback·상대 gitdir resolve·그룹핑 단위 테스트 포함)
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 무오류 (workspace deps 빌드 후)
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 성공
- [x] console-e2e 실브라우저 QA (격리 인스턴스 + 저장소 2개/워크트리 4개 fixture): "2 found" 카운트·펼침/접힘·워크트리 diff 로드·재오픈 자동 펼침·새로고침 영속·Depth/Rescan/아코디언/List-Tree 회귀 — 6/6 PASS
- [x] `.changelog.d` fragment 포함 (`section: Changed`, `[fleet-console]`) + ASCII 검증 통과