### PR TITLE
fix(fleet-console): stop auto-name overwriting renamed sessions

### DIFF
--- a/.changelog.d/issue-156-session-rename.md
+++ b/.changelog.d/issue-156-session-rename.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- [fleet-console] Session rename panel names now stick: user-set names are never overwritten by auto-name, auto-name fires on every subsequent prompt (not just the first), and renames are reflected in the browser in real-time via a new SSE channel without requiring a page refresh.

--- a/runtime/fleet-console/core/client/src/main.tsx
+++ b/runtime/fleet-console/core/client/src/main.tsx
@@ -21,6 +21,7 @@ import "./styles/layout.css";
 import "./styles/components.css";
 import { App } from "./app.js";
 import { fetchGlobalSettingsState } from "./global-settings-api.js";
+import { connectOperationsSse } from "./operations-sse.js";
 import { loadPluginRegistry, PluginRegistryProvider } from "./plugin-registry.js";
 import { setActiveTheme } from "./store.js";
 
@@ -56,6 +57,7 @@ try {
 }
 
 const registry = await loadPluginRegistry();
+connectOperationsSse();
 const app = document.querySelector("#app");
 if (app) {
   createRoot(app).render(

--- a/runtime/fleet-console/core/client/src/operations-sse.ts
+++ b/runtime/fleet-console/core/client/src/operations-sse.ts
@@ -1,0 +1,43 @@
+import { fetchOperations } from "./api.js";
+import { applyOperationUpdate, hydrateOperations } from "./store.js";
+import type { OperationNode } from "./types.js";
+
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
+let reconnectDelayMs = 1_000;
+let reconnectHandle: ReturnType<typeof setTimeout> | null = null;
+
+export function connectOperationsSse(): void {
+  if (reconnectHandle !== null) clearTimeout(reconnectHandle);
+  const source = new EventSource("/api/v1/operations/events");
+
+  source.addEventListener("operation:changed", (e) => {
+    const msg = e as MessageEvent<string>;
+    try {
+      const data = JSON.parse(msg.data) as { readonly operation?: unknown };
+      if (isRecord(data.operation)) applyOperationUpdate(data.operation as unknown as OperationNode);
+    } catch {
+      // ignore malformed SSE event
+    }
+  });
+
+  source.onopen = () => {
+    reconnectDelayMs = 1_000;
+  };
+
+  source.onerror = () => {
+    source.close();
+    reconnectHandle = setTimeout(() => {
+      reconnectHandle = null;
+      reconnectDelayMs = Math.min(reconnectDelayMs * 2, MAX_RECONNECT_DELAY_MS);
+      void fetchOperations()
+        .then(hydrateOperations)
+        .catch(() => undefined)
+        .finally(connectOperationsSse);
+    }, reconnectDelayMs);
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -173,6 +173,14 @@ export function hydrateOperations(operations: readonly OperationNode[]): void {
   setState({ operations, operationsHydrated: true });
 }
 
+export function applyOperationUpdate(operation: OperationNode): void {
+  const index = state.operations.findIndex((op) => op.id === operation.id);
+  if (index === -1) return;
+  const operations = [...state.operations];
+  operations[index] = operation;
+  setState({ operations });
+}
+
 export function hydrateGroups(groups: readonly OperationGroup[]): void {
   setState({ groups });
 }

--- a/runtime/fleet-console/core/host/operations/routes.ts
+++ b/runtime/fleet-console/core/host/operations/routes.ts
@@ -185,21 +185,16 @@ async function handleItem(req: http.IncomingMessage, res: http.ServerResponse, i
       return;
     }
     deps.persist();
-    if (previousNode && previousNode.title !== node.title) {
+    // 사용자 개시 rename(HTTP PATCH의 title)은 텍스트 변경 여부와 무관하게 rename 이벤트를 발행한다.
+    // 같은 텍스트로 커밋해도 사용자가 이름을 "확정"한 것이므로 terminal 구독자가 labelSource를 user로 무장해야 한다.
+    // 빈 텍스트는 reset(title:"")으로 발행해 기본 표시명 복원 + auto 재활성을 유도한다.
+    if (previousNode && typeof body.title === "string") {
       deps.publishRenameEvent?.({
         operationId: node.id,
         pluginId: node.pluginId,
         type: node.type,
-        title: node.title,
+        title: body.title.trim() === "" ? "" : node.title,
         previousTitle: previousNode.title,
-      });
-    } else if (typeof body.title === "string" && body.title.trim() === "") {
-      deps.publishRenameEvent?.({
-        operationId: node.id,
-        pluginId: node.pluginId,
-        type: node.type,
-        title: "",
-        previousTitle: node.title,
       });
     }
     deps.broadcastOperationChanged?.(deps.store.get(id) ?? node);

--- a/runtime/fleet-console/core/host/operations/routes.ts
+++ b/runtime/fleet-console/core/host/operations/routes.ts
@@ -12,6 +12,8 @@ export interface OperationsRouterDeps {
   readonly persist: () => void;
   readonly publishRenameEvent?: (event: OperationRenameEvent) => void;
   readonly publishDeleteEvent?: (event: OperationDeleteEvent) => void;
+  readonly broadcastOperationChanged?: (node: OperationNode) => void;
+  readonly subscribeOperationSse?: (res: http.ServerResponse) => void;
   readonly getPluginSensitiveFields?: (pluginId: string) => readonly string[];
   readonly resolveLaunchCatalog?: () => Promise<{ readonly plugins: readonly OperationCatalogPlugin[] }>;
 }
@@ -55,6 +57,14 @@ export function createOperationsRouter(deps: OperationsRouterDeps): OperationsRo
         return true;
       }
       deps.writeJson(res, 200, deps.resolveLaunchCatalog ? await deps.resolveLaunchCatalog() : { plugins: [] });
+      return true;
+    }
+    if (pathname === "/api/v1/operations/events") {
+      if (req.method !== "GET") {
+        deps.writeJson(res, 405, { error: "Method not allowed" });
+        return true;
+      }
+      deps.subscribeOperationSse?.(res);
       return true;
     }
     if (pathname === "/api/v1/operations/groups") {
@@ -183,7 +193,16 @@ async function handleItem(req: http.IncomingMessage, res: http.ServerResponse, i
         title: node.title,
         previousTitle: previousNode.title,
       });
+    } else if (typeof body.title === "string" && body.title.trim() === "") {
+      deps.publishRenameEvent?.({
+        operationId: node.id,
+        pluginId: node.pluginId,
+        type: node.type,
+        title: "",
+        previousTitle: node.title,
+      });
     }
+    deps.broadcastOperationChanged?.(deps.store.get(id) ?? node);
     deps.writeJson(res, 200, { operation: sanitizeOperationNode(node, deps) });
   } catch (error) {
     deps.writeJson(res, 400, { error: error instanceof Error ? error.message : "invalid_operation_patch" });

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -20,7 +20,9 @@ import { createGlobalSettingsRouter } from "./global-settings-routes.js";
 import { createPluginSettingsRouter } from "./plugin-settings-routes.js";
 import { createConsoleLock, type ConsoleLockHandle } from "./lock.js";
 import { createOperationsRouter } from "./operations/routes.js";
+import { createSanitizedOpDto } from "./operations/sanitize.js";
 import { createOperationStore } from "./operations/store.js";
+import type { OperationNode } from "./operations/types.js";
 import { createConsoleDataPaths } from "./paths.js";
 import { createPluginClientAssets } from "./plugin-host/client-assets.js";
 import { createFleetPluginHost } from "./plugin-host/host.js";
@@ -31,6 +33,7 @@ import { ConsoleReleaseNotesUnavailableError } from "./release-notes/types.js";
 import { RouteRegistry } from "./route-registry/route-registry.js";
 import { UpgradeRegistry } from "./route-registry/upgrade-registry.js";
 import { withSecurityHeaders } from "./security-headers.js";
+import { encodeSseData } from "./sse.js";
 import { createStaticConsoleHandler } from "./static-console.js";
 import { listTheaterFolders, TheaterFolderListError } from "./theater-folder-browser.js";
 import { createFolderGrantStore } from "./theater-folder-grants.js";
@@ -255,6 +258,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   const pluginLaunchCatalogProviders = new Map<string, OperationLaunchCatalogProvider[]>();
   const pluginCleanupCallbacks = new Set<() => void | Promise<void>>();
   const pluginEventListeners = new Map<string, Set<(payload: unknown) => void>>();
+  const operationSseSubscribers = new Set<http.ServerResponse>();
   const pluginHostCapabilities: FleetPluginHostCapabilities = {
     operations: {
       list: () => operations.list(),
@@ -265,8 +269,14 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
         return operation;
       },
       patch: (id, input) => {
+        const previousTitle = "title" in input ? operations.get(id)?.title : undefined;
         const operation = operations.patch(id, input);
-        if (operation) persistDurableState();
+        if (operation) {
+          persistDurableState();
+          if (previousTitle !== undefined && previousTitle !== operation.title) {
+            broadcastOperationChanged(operation);
+          }
+        }
         return operation;
       },
       delete: (id) => {
@@ -427,6 +437,19 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     resolveLaunchCatalog: resolveOperationCatalog,
     publishRenameEvent: (event) => pluginHostCapabilities.events.publish(OPERATION_RENAMED_EVENT_CHANNEL, event),
     publishDeleteEvent: (event) => pluginHostCapabilities.events.publish(OPERATION_DELETED_EVENT_CHANNEL, event),
+    broadcastOperationChanged,
+    subscribeOperationSse: (res) => {
+      res.writeHead(200, withSecurityHeaders({
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+      }));
+      res.write(":connected\n\n");
+      operationSseSubscribers.add(res);
+      res.on("close", () => {
+        operationSseSubscribers.delete(res);
+      });
+    },
   });
   routeRegistry.register("/api/v1/operations", operationsRouter);
   routeRegistry.register("/api/v1/settings", async (ctx) => {
@@ -884,6 +907,19 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
           console.warn(`[fleet-console] Codex workspace restore skipped for Theater ${theater.id}: ${error instanceof Error ? error.message : String(error)}`);
         }
       }
+    }
+  }
+
+  function broadcastOperationChanged(node: OperationNode): void {
+    if (operationSseSubscribers.size === 0) return;
+    const sensitiveFields = [
+      ...(pluginHost.sensitiveFieldsByPluginId.get(node.pluginId) ?? []),
+      ...(pluginPayloadSanitizers.get(node.pluginId) ?? []),
+    ];
+    const sanitized = createSanitizedOpDto(node, { sensitiveFields });
+    const data = encodeSseData("operation:changed", { operation: sanitized });
+    for (const res of operationSseSubscribers) {
+      res.write(data);
     }
   }
 

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -197,49 +197,51 @@ describe("console terminal observability", () => {
     expect(JSON.stringify(renamed)).not.toContain(dir);
   });
 
-  it("auto-names operations only on the first user prompt when the operator has not set a label", () => {
+  it("auto-names on every user prompt when the operator has not set a label", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-autoname-"));
     tempDirs.push(dir);
     const store = createConsoleObservabilityStore();
     store.createPendingTerminalSession({ sessionId: "session-a", cwd: dir, createdAt: 1_000 });
 
-    // 첫 자동 작명: label 없음 → auto 적용 + labelSource "auto" 기록(영속 투영에 반영).
+    // 첫 자동 작명: label 없음 → auto 적용 + labelSource "auto" 기록.
     const first = store.autoNameTerminalSession("session-a", "Fix the login redirect bug");
-    expect(first).toMatchObject({ changed: true, renamed: true });
+    expect(first).toMatchObject({ renamed: true });
     expect(first?.session.label).toBe("Fix the login redirect bug");
-    expect(store.listDurableOperations()[0]).toMatchObject({ label: "Fix the login redirect bug", labelSource: "auto", autoNamePromptSeen: true });
+    expect(store.listDurableOperations()[0]).toMatchObject({ label: "Fix the login redirect bug", labelSource: "auto" });
 
-    // 두 번째 UserPromptSubmit부터는 같은 라벨이든 다른 라벨이든 작전명을 바꾸지 않는다.
-    expect(store.autoNameTerminalSession("session-a", "Fix the login redirect bug")).toMatchObject({ changed: false, renamed: false });
-    expect(store.autoNameTerminalSession("session-a", "Add the search index")).toMatchObject({ changed: false, renamed: false });
-    expect(store.listDurableOperations()[0]?.label).toBe("Fix the login redirect bug");
+    // 두 번째 프롬프트도 다른 라벨이면 auto 갱신이 허용된다.
+    expect(store.autoNameTerminalSession("session-a", "Add the search index")).toMatchObject({ renamed: true });
+    expect(store.listDurableOperations()[0]?.label).toBe("Add the search index");
+
+    // 동일 라벨은 no-op.
+    expect(store.autoNameTerminalSession("session-a", "Add the search index")).toMatchObject({ renamed: false });
 
     // 사용자가 수동 rename → labelSource "user" 기록.
     store.renameTerminalSession("session-a", "Bridge Watch");
-    expect(store.listDurableOperations()[0]).toMatchObject({ label: "Bridge Watch", labelSource: "user", autoNamePromptSeen: true });
+    expect(store.listDurableOperations()[0]).toMatchObject({ label: "Bridge Watch", labelSource: "user" });
     // 사용자 라벨은 자동 작명이 절대 덮지 않는다.
-    expect(store.autoNameTerminalSession("session-a", "A brand new prompt topic")).toMatchObject({ changed: false, renamed: false });
+    expect(store.autoNameTerminalSession("session-a", "A brand new prompt topic")).toMatchObject({ renamed: false });
     expect(store.listDurableOperations()[0]?.label).toBe("Bridge Watch");
 
-    // 빈 rename은 label, labelSource, first-prompt marker를 함께 비워 다음 최초 프롬프트 자동 작명을 재활성화한다.
+    // 빈 rename은 label·labelSource를 비워 다음 프롬프트 자동 작명을 재활성화한다.
     store.renameTerminalSession("session-a", "   ");
     const cleared = store.listDurableOperations()[0];
     expect(cleared?.label).toBeUndefined();
     expect(cleared?.labelSource).toBeUndefined();
-    expect(cleared?.autoNamePromptSeen).toBeUndefined();
     expect(store.autoNameTerminalSession("session-a", "Re-enabled auto label")?.session.label).toBe("Re-enabled auto label");
   });
 
-  it("records a low-signal first user prompt so later prompts cannot auto-name the operation", () => {
+  it("treats a null or empty prompt as a no-op that does not block subsequent auto-names", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-autoname-empty-"));
     tempDirs.push(dir);
     const store = createConsoleObservabilityStore();
     store.createPendingTerminalSession({ sessionId: "session-a", cwd: dir, createdAt: 1_000 });
 
-    expect(store.autoNameTerminalSession("session-a", null)).toMatchObject({ changed: true, renamed: false });
-    expect(store.listDurableOperations()[0]).toMatchObject({ autoNamePromptSeen: true });
-    expect(store.autoNameTerminalSession("session-a", "Add the search index")).toMatchObject({ changed: false, renamed: false });
+    // null/empty 프롬프트는 no-op이며 이후 실제 프롬프트의 자동 작명을 차단하지 않는다.
+    expect(store.autoNameTerminalSession("session-a", null)).toMatchObject({ renamed: false });
     expect(store.listDurableOperations()[0]?.label).toBeUndefined();
+    expect(store.autoNameTerminalSession("session-a", "Add the search index")).toMatchObject({ renamed: true });
+    expect(store.listDurableOperations()[0]?.label).toBe("Add the search index");
   });
 
   it("protects legacy operator labels that predate labelSource from auto-naming", () => {
@@ -255,11 +257,11 @@ describe("console terminal observability", () => {
       createdAt: 1,
     });
     // read-time 해석: label이 있고 labelSource가 없으면 user로 보수 해석 → 자동 작명 차단.
-    expect(store.autoNameTerminalSession("legacy", "New auto topic")).toMatchObject({ changed: false, renamed: false });
+    expect(store.autoNameTerminalSession("legacy", "New auto topic")).toMatchObject({ renamed: false });
     expect(store.listDurableOperations()[0]?.label).toBe("Operator named");
   });
 
-  it("treats restored auto labels without a first-prompt marker as already auto-named", () => {
+  it("treats restored auto labels as replaceable by further auto-names", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-autoname-legacy-auto-"));
     tempDirs.push(dir);
     const store = createConsoleObservabilityStore();
@@ -269,12 +271,12 @@ describe("console terminal observability", () => {
       cwd: dir,
       label: "Existing auto label",
       labelSource: "auto",
-      autoNamePromptSeen: true,
       createdAt: 1,
     });
 
-    expect(store.autoNameTerminalSession("legacy-auto", "New auto topic")).toMatchObject({ changed: false, renamed: false });
-    expect(store.listDurableOperations()[0]).toMatchObject({ label: "Existing auto label", labelSource: "auto", autoNamePromptSeen: true });
+    // auto labelSource의 기존 라벨은 새 프롬프트로 재작명 가능하다.
+    expect(store.autoNameTerminalSession("legacy-auto", "New auto topic")).toMatchObject({ renamed: true });
+    expect(store.listDurableOperations()[0]).toMatchObject({ label: "New auto topic", labelSource: "auto" });
   });
 
   it.skip("replays existing observer events over SSE resync", async () => {

--- a/runtime/fleet-plugins/terminal/client/agent/api.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/api.ts
@@ -76,16 +76,6 @@ export async function createAgentSession(theaterId: string, cliId: string, signa
   return assertSessionInfo(await response.json(), response.status);
 }
 
-export async function renameAgentSession(sessionId: string, label: string, signal?: AbortSignal): Promise<SessionInfo> {
-  const response = await fetch(`/plugins/terminal/agent/sessions/${encodeURIComponent(sessionId)}`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ label }),
-    signal,
-  });
-  await assertOk(response);
-  return assertSessionInfo(await response.json(), response.status);
-}
 
 export async function resumeAgentSession(sessionId: string, signal?: AbortSignal): Promise<SessionInfo> {
   const response = await fetch(`/plugins/terminal/agent/sessions/${encodeURIComponent(sessionId)}/resume`, { method: "POST", signal });

--- a/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
@@ -52,7 +52,6 @@ interface PendingTerminalSessionState {
   readonly cwdLabel: string;
   label?: string;
   labelSource?: AgentLabelSource;
-  autoNamePromptSeen?: boolean;
   cliId?: string;
   cliLabel?: string;
   readonly createdAt: number;
@@ -69,7 +68,6 @@ type DormantOperationInput = AgentDurableOperation;
 
 interface AutoNameTerminalSessionResult {
   readonly session: AgentTerminalSessionInfo;
-  readonly changed: boolean;
   readonly renamed: boolean;
 }
 
@@ -234,7 +232,6 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
       cwdLabel: path.basename(operation.cwd) || operation.cwd,
       label: operation.label,
       labelSource: operation.labelSource,
-      autoNamePromptSeen: operation.autoNamePromptSeen,
       cliId: operation.cliId,
       cliLabel: operation.cliLabel,
       createdAt: operation.createdAt,
@@ -258,7 +255,6 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
       cwd: session.cwd,
       ...(session.label ? { label: session.label } : {}),
       ...(session.labelSource ? { labelSource: session.labelSource } : {}),
-      ...(session.autoNamePromptSeen ? { autoNamePromptSeen: true } : {}),
       ...(session.cliId ? { cliId: session.cliId } : {}),
       ...(session.cliLabel ? { cliLabel: session.cliLabel } : {}),
       createdAt: session.createdAt,
@@ -309,36 +305,34 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
     if (!session) return null;
     const label = rawLabel.trim().slice(0, 200);
     if (label.length === 0) {
-      // 빈 rename은 사용자가 기본 표시명(#N Operation)으로 되돌린 것이다. label과 labelSource를 같은 호출에서
-      // 함께 지워, 다음 최초 프롬프트부터 자동 작명이 재활성화되게 한다(둘을 분리하면 영구 자동 작명 차단 위험).
+      // 빈 rename은 사용자가 기본 표시명으로 되돌린 것이다. label과 labelSource를 함께 지워
+      // 다음 프롬프트부터 자동 작명이 재활성화되게 한다.
       delete session.label;
       delete session.labelSource;
-      delete session.autoNamePromptSeen;
     } else {
       session.label = label;
       session.labelSource = "user";
-      session.autoNamePromptSeen = true;
     }
     return toTerminalSessionInfo(session);
   }
 
-  // 자동 작명: 사용자 수동 라벨이 없고, 아직 UserPromptSubmit auto-name hook을 받은 적 없는 세션에만 적용한다.
+  // 자동 작명: 사용자 수동 라벨(labelSource "user")이 없는 세션에만 적용한다.
   // labelSource 미설정 레거시 세션은 label 유무로 보수 해석해 기존 사용자 라벨을 보호한다.
+  // 매 UserPromptSubmit마다 호출되며, 실제 라벨 변경이 있을 때만 patch/persist된다.
   function autoNameTerminalSession(sessionId: string, label: string | null): AutoNameTerminalSessionResult | null {
     const session = terminalSessionsById.get(sessionId);
     if (!session) return null;
     const effectiveSource: AgentLabelSource | undefined = session.labelSource ?? (session.label ? "user" : undefined);
-    if (effectiveSource === "user" || session.autoNamePromptSeen) {
-      return { session: toTerminalSessionInfo(session), changed: false, renamed: false };
+    if (effectiveSource === "user") {
+      return { session: toTerminalSessionInfo(session), renamed: false };
     }
-    session.autoNamePromptSeen = true;
     const next = label?.trim().slice(0, 200) ?? "";
     if (next.length === 0 || next === session.label) {
-      return { session: toTerminalSessionInfo(session), changed: true, renamed: false };
+      return { session: toTerminalSessionInfo(session), renamed: false };
     }
     session.label = next;
     session.labelSource = "auto";
-    return { session: toTerminalSessionInfo(session), changed: true, renamed: true };
+    return { session: toTerminalSessionInfo(session), renamed: true };
   }
 
   function notifySessionUpdated(session: AgentTerminalSessionInfo): void {

--- a/runtime/fleet-plugins/terminal/server/agent-api/types.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/types.ts
@@ -26,7 +26,6 @@ export interface AgentDurableOperation {
   readonly cwd: string;
   readonly label?: string;
   readonly labelSource?: AgentLabelSource;
-  readonly autoNamePromptSeen?: boolean;
   readonly cliId?: string;
   readonly cliLabel?: string;
   readonly createdAt: number;

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -113,7 +113,10 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       if (operation) {
         const cwd = readPayloadString(operation.payload, "cwd") || ctx.host.paths.resolveTheaterPath(operation.theaterId) || "";
         const providerSession = readProviderSession(operation.payload);
-        ctx.host.operations.patch(payload.operationId, { payload: toOperationPayload(cwd, updated, providerSession) });
+        // 빈 리네임(reset)이면 updated.label이 비므로 title도 기본 표시명(cwdLabel=basename)으로 되돌린다.
+        // core PATCH의 빈 title은 기존 title로 normalize되어 사용자 옛 이름이 남기 때문에, 여기서 명시적으로 복원한다.
+        // 이 patch는 store.patch(HTTP 미경유)라 operation:renamed를 재발행하지 않아 구독 루프를 만들지 않는다.
+        ctx.host.operations.patch(payload.operationId, { title: updated.label ?? updated.cwdLabel, payload: toOperationPayload(cwd, updated, providerSession) });
       }
     }
     injectRenameCommand(payload.operationId, payload.title);

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -25,7 +25,6 @@ import type { AgentTerminalSessionInfo, AgentLabelSource } from "./agent-api/typ
 import { buildModelAuthState } from "./model-auth-state.js";
 
 type SessionCreateBody = { readonly cliId?: unknown; readonly theaterId?: unknown };
-type SessionPatchBody = { readonly label?: unknown };
 type HookTurnBody = { readonly phase?: unknown };
 type HookAttentionBody = { readonly input?: unknown; readonly reason?: unknown };
 type HookAutoNameBody = { readonly input?: unknown; readonly prompt?: unknown };
@@ -107,6 +106,16 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
   const unsubscribeRename = ctx.host.events.subscribe(OPERATION_RENAMED_EVENT_CHANNEL, (payload) => {
     if (!isOperationRenamedEvent(payload)) return;
     if (payload.pluginId !== TERMINAL_PLUGIN_ID || payload.type !== AGENT_OPERATION_TYPE) return;
+    const updated = observability.renameTerminalSession(payload.operationId, payload.title);
+    if (updated) {
+      observability.notifySessionUpdated(updated);
+      const operation = ctx.host.operations.get(payload.operationId);
+      if (operation) {
+        const cwd = readPayloadString(operation.payload, "cwd") || ctx.host.paths.resolveTheaterPath(operation.theaterId) || "";
+        const providerSession = readProviderSession(operation.payload);
+        ctx.host.operations.patch(payload.operationId, { payload: toOperationPayload(cwd, updated, providerSession) });
+      }
+    }
     injectRenameCommand(payload.operationId, payload.title);
   });
   rehydrateDormantAgentOperations();
@@ -235,24 +244,6 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     if (req.method === "DELETE") {
       removeSession(sessionId);
       ctx.host.http.writeJson(res, 200, { ok: true });
-      return true;
-    }
-    if (req.method === "PATCH") {
-      const body = await ctx.host.http.readJsonBody<SessionPatchBody>(req);
-      if (!body || (body.label !== undefined && typeof body.label !== "string")) {
-        ctx.host.http.writeJson(res, 400, { error: "invalid_session_label" });
-        return true;
-      }
-      const updated = observability.renameTerminalSession(sessionId, body.label ?? "");
-      if (!updated) {
-        ctx.host.http.writeJson(res, 404, { error: "session_not_found" });
-        return true;
-      }
-      observability.notifySessionUpdated(updated);
-      const renamedCwd = readPayloadString(ctx.host.operations.get(sessionId)?.payload ?? {}, "cwd") ?? updated.cwdLabel;
-      ctx.host.operations.patch(sessionId, { title: updated.label ?? path.basename(renamedCwd) });
-      injectRenameCommand(sessionId, updated.label);
-      ctx.host.http.writeJson(res, 200, updated);
       return true;
     }
     return methodNotAllowed(res);


### PR DESCRIPTION
## Summary
- 세션 패널 리네임 시 auto-name 방어 가드(`labelSource="user"`)가 무장되지 않아, 이후 프롬프트의 auto-name이 사용자 지정 이름을 프롬프트 요약문으로 덮어쓰던 회귀를 수정합니다 (Issue #156, v1.16.0 회귀 — `operation:renamed` 구독 핸들러가 가드 무장을 누락한 "절반만 완성된 배선").
- 리네임하지 않은 세션은 최초 1회가 아니라 **매 사용자 프롬프트마다** auto-name으로 이름이 갱신되도록 1회성 게이트(`autoNamePromptSeen`)를 제거합니다.
- 리네임/auto-name에 의한 이름 변경이 브라우저 새로고침 없이 **실시간(SSE)** 으로 사이드바 칩·패널 title에 반영되도록 `GET /api/v1/operations/events` SSE 채널과 클라이언트 소비 루프를 신설합니다.
- 사용되지 않던 세션 rename PATCH 라우트와 클라이언트 헬퍼를 제거해 rename 진입점을 단일 경로로 일원화합니다.

Closes #156

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck | test (505 pass) | build` — green
- [x] `pnpm --filter @fleet-plugins/terminal typecheck | test (85 pass)` — green
- [x] console-e2e 실구동 실증 — T1(리네임 후 auto-name 차단), T2(미리네임 세션 매 프롬프트 갱신), T3(새로고침 없는 실시간 SSE 반영) 전부 PASS
- [x] Changelog fragment 포함 (`.changelog.d/issue-156-session-rename.md`, section: Fixed)