### PR TITLE
feat(fleet-admiral): require evidence before classifying a deviation as harmless

### DIFF
--- a/.changelog.d/doctrine-harmless-deviation.md
+++ b/.changelog.d/doctrine-harmless-deviation.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- [fleet-admiral] The Artifact Inspection Gate now requires evidence before an Admiral classifies a carrier-diff deviation as harmless: a deviation is treated as a defect unless it is confirmed to change no observable behavior, contract, or output and to be unreachable by any real execution path.

--- a/packages/fleet-admiral/src/protocols/standing-orders/result-integrity.ts
+++ b/packages/fleet-admiral/src/protocols/standing-orders/result-integrity.ts
@@ -48,6 +48,10 @@ Disposition (report one line): ${"`"}inspection: pass${"`"} | ${"`"}inspection: 
 deviations corrected by the Admiral${"`"} | ${"`"}inspection: rejected — re-dispatched
 with findings${"`"}. Small deviations the Admiral corrects directly during
 integration; systematic deviations route back to the owning carrier.
+"Small/harmless" is a claim that needs evidence, not an eyeball impression:
+before so classifying a deviation, confirm it changes no observable behavior,
+contract, or output and is unreachable by any real execution path; if
+unconfirmed, treat it as a defect, not a small deviation.
 Proportionality: full-diff reading for doctrine/prompt/structural changes;
 stat + targeted sampling for large mechanical changes. Read-only jobs skip
 this gate — their claims route through Deep Dive instead.


### PR DESCRIPTION
## Summary
- Result Integrity Standing Order의 **Artifact Inspection Gate**에 "무해(small/harmless) 편차" 판정 기준을 추가합니다. `small/harmless`는 눈대중 추정이 아니라 **증거를 요구하는 주장**으로, 그 편차가 (관찰 가능한 동작·계약·산출물을 바꾸지 않고) (어떤 실제 실행 경로로도 도달 불가함)을 확인해야 무해로 분류할 수 있으며, 미확인 시 defect(수정 또는 재-dispatch)로 처리합니다.
- 특정 제품/UI/릴리스에 묶지 않고 모든 도메인(code/docs/plans/prompts)·모든 캐리어에 적용되도록 원리 수준으로 일반화했습니다.
- 배경: 이슈 #156(PR #159) 검수 중 빈 리네임 title 복원 편차를 "무해 편차"로 오분류했고 Codex가 real 회귀(P2)로 회수 — gate가 무해 판정축을 결여했음이 드러났습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-admiral typecheck | test (29 pass, 프롬프트 토큰 예산 포함) | build` - green
- [x] `pnpm check:protocol-sync` - green
- [x] Changelog fragment 포함 (`.changelog.d/doctrine-harmless-deviation.md`, section: Changed)