### PR TITLE
feat(fleet-carriers): deterministic carrier report contract

### DIFF
--- a/.changelog.d/carrier-report-contract.md
+++ b/.changelog.d/carrier-report-contract.md
@@ -1,0 +1,6 @@
+---
+section: Changed
+---
+
+- [fleet-carriers] Carriers now wrap their final output in a `<report>` block; `carrier_jobs(format:"full")` extracts and returns only that block, falling back to the full archive when absent, and a new `format:"raw"` option returns the unprocessed archive for debugging.
+- [fleet-carriers] Removed redundant echo fields (`action`, `format`, `summary_available`) from `carrier_jobs` responses, and removed derived fields (`attribution`, `available`, `statLine`) from the workspace-changes DTO to reduce response payload size.

--- a/packages/fleet-carriers/src/dispatch/prompt.ts
+++ b/packages/fleet-carriers/src/dispatch/prompt.ts
@@ -33,12 +33,21 @@ export interface CarrierToolSpecDeps {
 
 const CARRIER_FLEET_BACKGROUND = String.raw`You are an autonomous agent (Carrier) operating within a coordinated multi-agent Fleet system. The Admiral, your superior, dispatches specialized tasks to you and synthesizes your output for the user. Below is your identity, operational permissions, behavioral principles, and required output format. Your assigned task arrives in the user message channel below.`;
 
+// 모든 캐리어 공통 응답 프로토콜 — metadata 유무와 무관하게 항상 주입한다.
+const COMMON_RESPONSE_PROTOCOL = `<response_protocol>
+Keep progress narration concise — at most one line per meaningful step. No verbose play-by-play or step-by-step essays (short streaming lines are acceptable for the live observation channel).
+
+When the mission is complete, wrap the entire final output in a <report>...</report> tag and emit it exactly once, at the very end. The Admiral retrieves only the report block, so everything you need to convey — results, evidence, file paths, caveats — must be inside it. Your persona's output_format structure applies inside the report block as usual.
+
+Do not mention or demonstrate the literal opening and closing report tag anywhere in the body outside that final block.
+</response_protocol>`;
+
 // ═════════════════════════════════════════════════════════
 // 캐리어 시스템 프롬프트 (Tier 2)
 // ═════════════════════════════════════════════════════════
 
 export function buildCarrierSystemPrompt(metadata?: CarrierMetadata): string {
-  const parts: string[] = [CARRIER_FLEET_BACKGROUND];
+  const parts: string[] = [CARRIER_FLEET_BACKGROUND, COMMON_RESPONSE_PROTOCOL];
 
   if (metadata) {
     parts.push(`<your_identity>\n${metadata.title}\n${metadata.summary}\n</your_identity>`);

--- a/packages/fleet-carriers/src/jobs/dispatch.ts
+++ b/packages/fleet-carriers/src/jobs/dispatch.ts
@@ -6,6 +6,8 @@ import { getFinalized, hasFinalizedJobArchive, hasJobArchive, serializeJobArchiv
 import { cancelJob, getActiveJob, listActiveJobs } from "./lifecycle.js";
 import { getJobSummary, listJobSummaries } from "./summary-cache.js";
 import { isCarrierJobId, CARRIER_JOBS_FULL_RESULT_BYTE_CAP, CARRIER_JOBS_GLOBAL_BYTE_CAP, CARRIER_JOBS_PER_SUBOP_BYTE_CAP, type ArchiveBlock, type CarrierJobRecord, type CarrierJobStatus, type CarrierJobSummary, type JobArchive, type CarrierJobsAvailability, type CarrierJobsFormat, type CarrierJobsParams } from "./types.js";
+import { extractFinalReport } from "./report-extract.js";
+import { buildStatLine } from "./workspace-manifest.js";
 
 // summary cache / launch-response는 하위 모듈로 분리됨 — 기존 소비자를 위한 동명 re-export
 export {
@@ -34,8 +36,6 @@ export interface CarrierResultSystemReminderInput {
 }
 
 export interface CarrierJobsResponse {
-  action: string;
-  format?: CarrierJobsFormat;
   job_id?: string;
   ok: boolean;
   status?: string;
@@ -48,7 +48,6 @@ export interface CarrierJobsResponse {
   full_invalidated?: boolean;
   retry_after?: string;
   notice?: string;
-  summary_available?: boolean;
   cancelled?: boolean;
   error?: string;
 }
@@ -84,6 +83,7 @@ export const CARRIER_JOBS_DOCTRINE = {
 };
 
 const REMINDER_TEXT_LIMIT = 500;
+// eslint-disable-next-line no-control-regex
 const REMINDER_CONTROL_CHARS = /[\u0000-\u001F\u007F-\u009F]/g;
 const REMINDER_WHITESPACE = /\s+/g;
 
@@ -93,11 +93,14 @@ const ACTIVE_CANCEL_NOTICE =
   "Cancel did not apply: the job is still running normally, not hung. Long-running carrier jobs are expected — do not retry cancel without an explicit user request to abort. The [carrier:result] push will arrive automatically; stop calling tools and return control to the user.";
 
 export function buildCarrierResultSystemReminder(input: CarrierResultSystemReminderInput): string {
+  const changes = input.summary.workspaceChanges
+    ? buildStatLine(input.summary.workspaceChanges.changes.length, input.summary.workspaceChanges.truncated)
+    : "unavailable";
   const lines = [`- ${input.jobId}: ${sanitizeReminderText(input.summary.summary)}`];
   const metadata = [
     `kind=${input.kind}`,
     `status=${input.status}`,
-    `changes=${sanitizeReminderText(input.summary.workspaceChanges?.statLine ?? "unavailable")}`,
+    `changes=${sanitizeReminderText(changes)}`,
     input.label ? `label=${sanitizeReminderText(input.label)}` : undefined,
     input.taskforceBackend ? `backend=${sanitizeReminderText(input.taskforceBackend)}` : undefined,
     input.error ? `error=${sanitizeReminderText(input.error)}` : undefined,
@@ -123,8 +126,8 @@ export function buildCarrierJobsSchema(): TObject {
     })),
     format: Type.Optional(Type.Unsafe<string>({
       type: "string",
-      enum: ["summary", "full"],
-      description: "Optional result detail level for renderers and result lookups.",
+      enum: ["summary", "full", "raw"],
+      description: `Optional result detail level. "full" returns the final report (extracted deterministically from the carrier's <report> block; falls back to the raw archive when absent). "summary" returns metadata only. "raw" returns the unprocessed full archive (debugging/audit). Defaults to "full" when omitted.`,
     })),
   });
 }
@@ -147,7 +150,6 @@ export function buildCarrierJobsToolSpec(): AgentToolSpec {
 export function dispatchCarrierJobsAction(params: CarrierJobsParams, now = Date.now()): CarrierJobsResponse {
   if (params.action === "list") {
     return {
-      action: "list",
       ok: true,
       active: listActiveJobs(),
       recent: listJobSummaries(now),
@@ -157,7 +159,6 @@ export function dispatchCarrierJobsAction(params: CarrierJobsParams, now = Date.
   const jobIdError = validateJobId(params.job_id);
   if (jobIdError) {
     return {
-      action: params.action,
       job_id: params.job_id,
       ok: false,
       error: jobIdError,
@@ -170,7 +171,6 @@ export function dispatchCarrierJobsAction(params: CarrierJobsParams, now = Date.
   if (params.action === "cancel") return cancelResponse(jobId, now);
 
   return {
-    action: String((params as { action?: unknown }).action),
     job_id: jobId,
     ok: false,
     error: "unsupported action",
@@ -207,7 +207,6 @@ function statusResponse(jobId: string, now: number): CarrierJobsResponse {
   const summary = getJobSummary(jobId, now);
   const availability = getAvailability(jobId, summary, now);
   return {
-    action: "status",
     job_id: jobId,
     ok: Boolean(active || summary || availability.full_available),
     status: active?.status ?? summary?.status ?? "not_found",
@@ -223,8 +222,6 @@ function resultResponse(jobId: string, format: CarrierJobsFormat, now: number): 
   const availability = getAvailability(jobId, summary, now);
   if (active) {
     return {
-      action: "result",
-      format,
       job_id: jobId,
       ok: false,
       status: active.status,
@@ -239,8 +236,6 @@ function resultResponse(jobId: string, format: CarrierJobsFormat, now: number): 
 
   if (format === "summary") {
     return {
-      action: "result",
-      format,
       job_id: jobId,
       ok: Boolean(summary),
       status: summary?.status ?? "not_found",
@@ -256,17 +251,36 @@ function resultResponse(jobId: string, format: CarrierJobsFormat, now: number): 
   const serializeOpts = isSubOpJob
     ? { perSubOpMaxBytes: CARRIER_JOBS_PER_SUBOP_BYTE_CAP, maxBytes: CARRIER_JOBS_GLOBAL_BYTE_CAP }
     : { maxBytes: CARRIER_JOBS_FULL_RESULT_BYTE_CAP };
-  const fullResult = archive ? serializeJobArchive(archive, serializeOpts) : undefined;
+
+  let fullResult: string | undefined;
+  let results: Record<string, string> | undefined;
+
+  if (archive) {
+    if (isTaskForceJob) {
+      results = serializeTaskForceResultsByBackend(archive, format);
+    } else if (format === "raw") {
+      // raw: 추출 없이 현행 전문 직렬화
+      fullResult = serializeJobArchive(archive, serializeOpts);
+    } else {
+      // full: <report> 블록 추출 시도 → 실패 시 현행 전문 폴백
+      const rawSerialized = serializeJobArchive(archive);
+      const reportBody = extractFinalReport(rawSerialized);
+      if (reportBody !== null) {
+        fullResult = capTextBytes(reportBody, CARRIER_JOBS_FULL_RESULT_BYTE_CAP);
+      } else {
+        fullResult = serializeJobArchive(archive, serializeOpts);
+      }
+    }
+  }
+
   return {
-    action: "result",
-    format,
     job_id: jobId,
     ok: Boolean(archive),
     status: archive?.status ?? summary?.status ?? "not_found",
     summary: summary ?? undefined,
     ...availability,
     full_result: isTaskForceJob ? undefined : fullResult,
-    results: archive && isTaskForceJob ? serializeTaskForceResultsByBackend(archive) : undefined,
+    results: archive && isTaskForceJob ? results : undefined,
     error: archive ? undefined : "full result unavailable or expired",
   };
 }
@@ -276,7 +290,6 @@ function cancelResponse(jobId: string, now: number): CarrierJobsResponse {
   const active = getActiveJob(jobId);
   const summary = getJobSummary(jobId, now);
   return {
-    action: "cancel",
     job_id: jobId,
     ok: result.cancelled,
     cancelled: result.cancelled,
@@ -291,7 +304,6 @@ function cancelResponse(jobId: string, now: number): CarrierJobsResponse {
 function getAvailability(jobId: string, summary: CarrierJobSummary | null, now: number): CarrierJobsAvailability {
   const fullAvailable = hasFinalizedJobArchive(jobId, now);
   return {
-    summary_available: Boolean(summary),
     full_available: fullAvailable,
     full_invalidated: !hasJobArchive(jobId, now) && Boolean(summary),
   };
@@ -304,10 +316,11 @@ function validateJobId(jobId: string | undefined): string | null {
 }
 
 function normalizeFormat(format: CarrierJobsParams["format"]): CarrierJobsFormat {
-  return format === "summary" ? "summary" : "full";
+  if (format === "summary" || format === "raw") return format;
+  return "full";
 }
 
-function serializeTaskForceResultsByBackend(archive: JobArchive): Record<string, string> {
+function serializeTaskForceResultsByBackend(archive: JobArchive, format: CarrierJobsFormat): Record<string, string> {
   const grouped = new Map<string, ArchiveBlock[]>();
   const orderedKeys: string[] = [];
   for (const block of archive.blocks) {
@@ -322,10 +335,36 @@ function serializeTaskForceResultsByBackend(archive: JobArchive): Record<string,
   const results: Record<string, string> = {};
   for (const cliType of orderedKeys) {
     const blocks = grouped.get(cliType)!;
-    results[cliType] = serializeJobArchive(
-      { ...archive, blocks },
-      { maxBytes: CARRIER_JOBS_PER_SUBOP_BYTE_CAP },
-    );
+    const subArchive = { ...archive, blocks };
+
+    if (format === "raw") {
+      // raw: 추출 없이 현행 전문 직렬화
+      results[cliType] = serializeJobArchive(subArchive, { maxBytes: CARRIER_JOBS_PER_SUBOP_BYTE_CAP });
+    } else {
+      // full: <report> 블록 추출 시도 → 실패 시 현행 전문 폴백
+      const rawSerialized = serializeJobArchive(subArchive);
+      const reportBody = extractFinalReport(rawSerialized);
+      if (reportBody !== null) {
+        results[cliType] = capTextBytes(reportBody, CARRIER_JOBS_PER_SUBOP_BYTE_CAP);
+      } else {
+        results[cliType] = serializeJobArchive(subArchive, { maxBytes: CARRIER_JOBS_PER_SUBOP_BYTE_CAP });
+      }
+    }
   }
   return results;
+}
+
+/**
+ * 추출된 report 본문에 바이트 캡을 적용합니다.
+ * 기존 정화 파이프(ANSI 제거, 비밀 마스킹)는 serializeJobArchive 단계에서 이미 적용됩니다.
+ */
+function capTextBytes(text: string, maxBytes: number): string {
+  if (Buffer.byteLength(text, "utf8") <= maxBytes) return text;
+  const buf = Buffer.from(text, "utf8");
+  const marker = "\n\n[truncated]";
+  const markerBytes = Buffer.byteLength(marker, "utf8");
+  let end = Math.max(0, maxBytes - markerBytes);
+  // UTF-8 멀티바이트 경계 조정
+  while (end > 0 && (buf[end]! & 0xc0) === 0x80) end--;
+  return buf.subarray(0, end).toString("utf8") + marker;
 }

--- a/packages/fleet-carriers/src/jobs/report-extract.ts
+++ b/packages/fleet-carriers/src/jobs/report-extract.ts
@@ -1,0 +1,42 @@
+/**
+ * jobs/report-extract.ts — 캐리어 최종 보고 블록 파서
+ *
+ * 캐리어 출력에서 마지막 완결된 <report>...</report> 블록을 추출합니다.
+ * 소문자 report, 속성 없는 태그만 인정합니다.
+ */
+
+const REPORT_OPEN = "<report>";
+const REPORT_CLOSE = "</report>";
+
+/**
+ * 텍스트에서 마지막 완결된 <report>...</report> 블록의 본문(트림)을 반환합니다.
+ *
+ * - 열림/닫힘 쌍이 완결되지 않으면 null.
+ * - 빈 본문(공백만)이면 null (폴백 유도).
+ * - 대소문자: 정확히 소문자 `report`만 인정.
+ * - 속성 없는 태그만 인정 (`<report>` 리터럴 매칭).
+ */
+export function extractFinalReport(text: string): string | null {
+  const openLen = REPORT_OPEN.length;
+  const closeLen = REPORT_CLOSE.length;
+
+  let lastBodyStart = -1;
+  let lastBodyEnd = -1;
+  let searchFrom = 0;
+
+  while (searchFrom < text.length) {
+    const openIdx = text.indexOf(REPORT_OPEN, searchFrom);
+    if (openIdx === -1) break;
+    const bodyStart = openIdx + openLen;
+    const closeIdx = text.indexOf(REPORT_CLOSE, bodyStart);
+    if (closeIdx === -1) break; // 미완결 — 이전까지 찾은 마지막 완결 블록으로 귀환
+    lastBodyStart = bodyStart;
+    lastBodyEnd = closeIdx;
+    searchFrom = closeIdx + closeLen;
+  }
+
+  if (lastBodyStart === -1) return null;
+  const body = text.slice(lastBodyStart, lastBodyEnd).trim();
+  if (!body) return null;
+  return body;
+}

--- a/packages/fleet-carriers/src/jobs/report-extract.ts
+++ b/packages/fleet-carriers/src/jobs/report-extract.ts
@@ -11,32 +11,29 @@ const REPORT_CLOSE = "</report>";
 /**
  * 텍스트에서 마지막 완결된 <report>...</report> 블록의 본문(트림)을 반환합니다.
  *
- * - 열림/닫힘 쌍이 완결되지 않으면 null.
- * - 빈 본문(공백만)이면 null (폴백 유도).
+ * 역방향 앵커: **마지막 열림 태그**부터 시도해 그 뒤 첫 닫힘 태그와 짝짓고,
+ * 미완결이거나 본문이 비어 있으면 그 앞 열림 태그로 후퇴한다. 진짜 최종 보고는
+ * 항상 출력 끝에 완결 쌍으로 오므로, 앞선 진행 텍스트에 미매칭 열림 태그가 실수로
+ * 섞여 있어도(전진 탐색이라면 그 stray 열림이 진짜 닫힘과 짝지어져 결과를
+ * 오염시킨다) 최종 블록만 격리 추출된다.
+ *
+ * - 완결되고 비어 있지 않은 쌍이 없으면 null (폴백 유도).
  * - 대소문자: 정확히 소문자 `report`만 인정.
  * - 속성 없는 태그만 인정 (`<report>` 리터럴 매칭).
  */
 export function extractFinalReport(text: string): string | null {
-  const openLen = REPORT_OPEN.length;
-  const closeLen = REPORT_CLOSE.length;
+  let openIdx = text.lastIndexOf(REPORT_OPEN);
 
-  let lastBodyStart = -1;
-  let lastBodyEnd = -1;
-  let searchFrom = 0;
-
-  while (searchFrom < text.length) {
-    const openIdx = text.indexOf(REPORT_OPEN, searchFrom);
-    if (openIdx === -1) break;
-    const bodyStart = openIdx + openLen;
+  while (openIdx !== -1) {
+    const bodyStart = openIdx + REPORT_OPEN.length;
     const closeIdx = text.indexOf(REPORT_CLOSE, bodyStart);
-    if (closeIdx === -1) break; // 미완결 — 이전까지 찾은 마지막 완결 블록으로 귀환
-    lastBodyStart = bodyStart;
-    lastBodyEnd = closeIdx;
-    searchFrom = closeIdx + closeLen;
+    if (closeIdx !== -1) {
+      const body = text.slice(bodyStart, closeIdx).trim();
+      if (body) return body;
+    }
+    // 미완결 또는 빈 본문 — 그 앞 열림 태그로 후퇴
+    openIdx = openIdx === 0 ? -1 : text.lastIndexOf(REPORT_OPEN, openIdx - 1);
   }
 
-  if (lastBodyStart === -1) return null;
-  const body = text.slice(lastBodyStart, lastBodyEnd).trim();
-  if (!body) return null;
-  return body;
+  return null;
 }

--- a/packages/fleet-carriers/src/jobs/types.ts
+++ b/packages/fleet-carriers/src/jobs/types.ts
@@ -1,5 +1,5 @@
 export type CarrierJobsAction = "status" | "result" | "cancel" | "list";
-export type CarrierJobsFormat = "summary" | "full";
+export type CarrierJobsFormat = "summary" | "full" | "raw";
 
 export interface CarrierJobsParams {
   action: CarrierJobsAction;
@@ -8,7 +8,6 @@ export interface CarrierJobsParams {
 }
 
 export interface CarrierJobsAvailability {
-  summary_available: boolean;
   full_available: boolean;
   full_invalidated: boolean;
 }
@@ -61,11 +60,7 @@ export interface CarrierJobSummary extends CarrierJobBase {
 }
 
 export interface WorkspaceChangeManifest {
-  attribution: "window-approximate";
-  available: boolean;
-  reason?: string;
   changes: WorkspaceChangeManifestEntry[];
-  statLine: string;
   truncated: boolean;
 }
 

--- a/packages/fleet-carriers/src/jobs/workspace-manifest.ts
+++ b/packages/fleet-carriers/src/jobs/workspace-manifest.ts
@@ -16,7 +16,6 @@ interface NormalizedWorkspaceChangeSnapshotEntry {
   readonly contentHash?: string;
 }
 
-export const WORKSPACE_CHANGE_ATTRIBUTION = "window-approximate";
 export const WORKSPACE_CHANGE_LIMIT = 200;
 /** baseline에서 dirty였다가 종료 스냅샷에서 사라진 경로의 합성 status — 원복/삭제 탐지용. */
 export const WORKSPACE_CHANGE_CLEARED_STATUS = "cleared";
@@ -38,10 +37,8 @@ export async function captureJobWindowManifest(
   scanner: WorkspaceChangeScanner | undefined,
   cwd: string,
   baseline: readonly WorkspaceChangeSnapshotEntry[] | null,
-): Promise<WorkspaceChangeManifest> {
-  if (!scanner) {
-    return unavailableWorkspaceManifest("scanner-not-configured");
-  }
+): Promise<WorkspaceChangeManifest | undefined> {
+  if (!scanner) return undefined;
   const end = await captureWorkspaceSnapshot(scanner, cwd);
   return buildWorkspaceManifest(baseline, end);
 }
@@ -49,11 +46,8 @@ export async function captureJobWindowManifest(
 export function buildWorkspaceManifest(
   baseline: readonly WorkspaceChangeSnapshotEntry[] | null,
   end: readonly WorkspaceChangeSnapshotEntry[] | null,
-  reason?: string,
-): WorkspaceChangeManifest {
-  if (!baseline || !end) {
-    return unavailableWorkspaceManifest(reason ?? "snapshot-unavailable");
-  }
+): WorkspaceChangeManifest | undefined {
+  if (!baseline || !end) return undefined;
 
   const baselineByPath = new Map(baseline.map((entry) => [entry.path, normalizeSnapshotEntry(entry)]));
   const endChanges = end
@@ -71,23 +65,14 @@ export function buildWorkspaceManifest(
   const capped = changes.slice(0, WORKSPACE_CHANGE_LIMIT);
 
   return {
-    attribution: WORKSPACE_CHANGE_ATTRIBUTION,
-    available: true,
     changes: capped,
-    statLine: buildStatLine(changes.length, truncated),
     truncated,
   };
 }
 
-export function unavailableWorkspaceManifest(reason: string): WorkspaceChangeManifest {
-  return {
-    attribution: WORKSPACE_CHANGE_ATTRIBUTION,
-    available: false,
-    reason,
-    changes: [],
-    statLine: "unavailable",
-    truncated: false,
-  };
+export function buildStatLine(changeCount: number, truncated: boolean): string {
+  const suffix = changeCount === 1 ? "file" : "files";
+  return `${truncated ? `${WORKSPACE_CHANGE_LIMIT}+` : String(changeCount)} ${suffix} (window-approx)`;
 }
 
 function normalizeSnapshotEntry(entry: WorkspaceChangeSnapshotEntry): NormalizedWorkspaceChangeSnapshotEntry {
@@ -115,9 +100,4 @@ function hasWindowChange(
     return baseline.contentHash !== end.contentHash;
   }
   return false;
-}
-
-function buildStatLine(changeCount: number, truncated: boolean): string {
-  const suffix = changeCount === 1 ? "file" : "files";
-  return `${truncated ? `${WORKSPACE_CHANGE_LIMIT}+` : String(changeCount)} ${suffix} (window-approx)`;
 }

--- a/packages/fleet-carriers/tests/dispatch/framework.test.ts
+++ b/packages/fleet-carriers/tests/dispatch/framework.test.ts
@@ -560,10 +560,8 @@ describe("carrier_dispatch native subagent mode delegation", () => {
 
     await vi.waitFor(() => {
       expect(getJobSummary("carrier:dispatch-manifest", Date.now())?.workspaceChanges).toMatchObject({
-        attribution: "window-approximate",
-        available: true,
         changes: [{ status: "M", path: "src/file.ts" }],
-        statLine: "1 file (window-approx)",
+        truncated: false,
       });
     });
     unregister();
@@ -593,11 +591,7 @@ describe("carrier_dispatch native subagent mode delegation", () => {
       accepted: true,
     });
     await vi.waitFor(() => {
-      expect(getJobSummary("carrier:dispatch-no-scanner", Date.now())?.workspaceChanges).toMatchObject({
-        available: false,
-        reason: "scanner-not-configured",
-        statLine: "unavailable",
-      });
+      expect(getJobSummary("carrier:dispatch-no-scanner", Date.now())?.workspaceChanges).toBeUndefined();
     });
   });
 
@@ -811,10 +805,8 @@ describe("carrier_dispatch taskforce stream metadata", () => {
 
     await vi.waitFor(() => {
       expect(getJobSummary("taskforce:dispatch-taskforce-manifest", Date.now())?.workspaceChanges).toMatchObject({
-        attribution: "window-approximate",
-        available: true,
         changes: [{ status: "A", path: "docs/plan.md" }],
-        statLine: "1 file (window-approx)",
+        truncated: false,
       });
     });
     unregister();

--- a/packages/fleet-carriers/tests/jobs/report-extract.test.ts
+++ b/packages/fleet-carriers/tests/jobs/report-extract.test.ts
@@ -64,16 +64,22 @@ describe("extractFinalReport", () => {
     expect(extractFinalReport(text)).toBe("line 1\nline 2\nline 3");
   });
 
-  it("중첩처럼 보이는 구조 — 마지막 닫힘 기준으로 처리", () => {
-    // <report>...</report> 안에 plain text로 report 태그가 있는 경우
-    // 첫 번째 </report>에서 끊어진 후, 다음 <report>를 찾는다.
-    // <report>outer <report>inner</report> rest</report>
-    // → inner가 마지막 완결이 아니라 outer의 마지막 닫힘이 먼저 발견되므로 "outer <report>inner"
-    // 본 구현은 단순 indexOf 기반 — 중첩을 파싱하지 않음.
+  it("중첩처럼 보이는 구조 — 마지막 열림 태그의 완결 쌍을 반환", () => {
+    // 역방향 앵커: 마지막 <report>(inner)부터 시도 → 그 뒤 첫 </report>와 짝
+    // 본 구현은 단순 문자열 매칭 — 중첩을 재귀 파싱하지 않음.
     const text = "<report>outer <report>inner</report> rest</report>";
-    // 첫 <report> + 첫 </report>: body = "outer <report>inner"
-    // 두 번째 <report>(없음) → 루프 종료
-    // 실제로 두 번째 "rest</report>"에 <report>가 없으므로 body = "outer <report>inner"
-    expect(extractFinalReport(text)).toBe("outer <report>inner");
+    expect(extractFinalReport(text)).toBe("inner");
+  });
+
+  it("stray 열림 태그가 앞선 내레이션에 섞여도 최종 블록만 추출한다", () => {
+    // 전진 탐색이라면 stray <report>가 진짜 닫힘과 짝지어져 결과를 오염시키는 시나리오
+    const text = "progress note accidentally mentions <report> here\nmore work...\n<report>real final report</report>";
+    expect(extractFinalReport(text)).toBe("real final report");
+  });
+
+  it("마지막 블록이 빈 본문이면 그 앞 완결 블록으로 후퇴한다", () => {
+    expect(
+      extractFinalReport("<report>real</report> narration <report>   </report>"),
+    ).toBe("real");
   });
 });

--- a/packages/fleet-carriers/tests/jobs/report-extract.test.ts
+++ b/packages/fleet-carriers/tests/jobs/report-extract.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { extractFinalReport } from "../../src/jobs/report-extract.js";
+
+describe("extractFinalReport", () => {
+  it("정상 추출 — <report> 블록 본문을 반환한다", () => {
+    expect(extractFinalReport("some narration\n<report>\nresult\n</report>")).toBe("result");
+  });
+
+  it("태그 부재 → null", () => {
+    expect(extractFinalReport("no tags here")).toBeNull();
+  });
+
+  it("빈 문자열 → null", () => {
+    expect(extractFinalReport("")).toBeNull();
+  });
+
+  it("다중 블록 → 마지막 완결 블록 반환", () => {
+    expect(
+      extractFinalReport("<report>first</report> narration <report>second</report>"),
+    ).toBe("second");
+  });
+
+  it("미완결 태그(닫힘 없음) → null", () => {
+    expect(extractFinalReport("<report>unfinished content")).toBeNull();
+  });
+
+  it("빈 본문(공백만) → null", () => {
+    expect(extractFinalReport("<report>   </report>")).toBeNull();
+    expect(extractFinalReport("<report>\n\t\n</report>")).toBeNull();
+  });
+
+  it("태그 앞뒤 내레이션 섞임 — 본문만 반환", () => {
+    const text = "Step 1: done\nStep 2: done\n<report>\n## Report\nAll done.\n</report>\nEnd.";
+    expect(extractFinalReport(text)).toBe("## Report\nAll done.");
+  });
+
+  it("완결 블록 뒤에 미완결 블록 — 마지막 완결 블록 반환", () => {
+    expect(
+      extractFinalReport("<report>first</report> <report>incomplete"),
+    ).toBe("first");
+  });
+
+  it("대문자 REPORT → null (소문자만 인정)", () => {
+    expect(extractFinalReport("<REPORT>content</REPORT>")).toBeNull();
+    expect(extractFinalReport("<Report>content</Report>")).toBeNull();
+  });
+
+  it("속성 있는 태그 → null (속성 없는 태그만 인정)", () => {
+    expect(extractFinalReport('<report class="x">content</report>')).toBeNull();
+    expect(extractFinalReport('<report id="y">content</report>')).toBeNull();
+  });
+
+  it("TaskForce backend별 — 각 backend 직렬화 결과에 독립적으로 적용", () => {
+    // extractFinalReport는 순수 함수이므로 backend별로 독립 호출
+    const backendA = "narration A\n<report>result-A</report>";
+    const backendB = "narration B\n<report>result-B</report>";
+    expect(extractFinalReport(backendA)).toBe("result-A");
+    expect(extractFinalReport(backendB)).toBe("result-B");
+  });
+
+  it("멀티라인 본문 — 내부 줄바꿈 보존", () => {
+    const text = "<report>\nline 1\nline 2\nline 3\n</report>";
+    expect(extractFinalReport(text)).toBe("line 1\nline 2\nline 3");
+  });
+
+  it("중첩처럼 보이는 구조 — 마지막 닫힘 기준으로 처리", () => {
+    // <report>...</report> 안에 plain text로 report 태그가 있는 경우
+    // 첫 번째 </report>에서 끊어진 후, 다음 <report>를 찾는다.
+    // <report>outer <report>inner</report> rest</report>
+    // → inner가 마지막 완결이 아니라 outer의 마지막 닫힘이 먼저 발견되므로 "outer <report>inner"
+    // 본 구현은 단순 indexOf 기반 — 중첩을 파싱하지 않음.
+    const text = "<report>outer <report>inner</report> rest</report>";
+    // 첫 <report> + 첫 </report>: body = "outer <report>inner"
+    // 두 번째 <report>(없음) → 루프 종료
+    // 실제로 두 번째 "rest</report>"에 <report>가 없으므로 body = "outer <report>inner"
+    expect(extractFinalReport(text)).toBe("outer <report>inner");
+  });
+});

--- a/packages/fleet-carriers/tests/jobs/workspace-manifest.test.ts
+++ b/packages/fleet-carriers/tests/jobs/workspace-manifest.test.ts
@@ -3,15 +3,13 @@ import { describe, expect, it } from "vitest";
 import {
   buildWorkspaceManifest,
   captureWorkspaceSnapshot,
-  unavailableWorkspaceManifest,
-  WORKSPACE_CHANGE_ATTRIBUTION,
   WORKSPACE_CHANGE_CLEARED_STATUS,
   WORKSPACE_CHANGE_LIMIT,
   type WorkspaceChangeScanner,
 } from "../../src/jobs/workspace-manifest.js";
 
 describe("workspace change manifest helpers", () => {
-  it("builds an available window-approximate manifest from changed end entries", () => {
+  it("builds a window-approximate manifest from changed end entries", () => {
     const manifest = buildWorkspaceManifest(
       [{ status: "M", path: "same.ts" }],
       [
@@ -21,10 +19,7 @@ describe("workspace change manifest helpers", () => {
     );
 
     expect(manifest).toEqual({
-      attribution: WORKSPACE_CHANGE_ATTRIBUTION,
-      available: true,
       changes: [{ status: "A", path: "new.ts" }],
-      statLine: "1 file (window-approx)",
       truncated: false,
     });
   });
@@ -35,8 +30,8 @@ describe("workspace change manifest helpers", () => {
       [{ status: "M", path: "dirty.ts", contentHash: "after-hash" }],
     );
 
-    expect(manifest.changes).toEqual([{ status: "M", path: "dirty.ts" }]);
-    expect(manifest.statLine).toBe("1 file (window-approx)");
+    expect(manifest).toBeDefined();
+    expect(manifest!.changes).toEqual([{ status: "M", path: "dirty.ts" }]);
   });
 
   it("falls back to status-only comparison when hashes are absent", () => {
@@ -45,30 +40,14 @@ describe("workspace change manifest helpers", () => {
       [{ status: "M", path: "dirty.ts" }],
     );
 
-    expect(manifest.changes).toEqual([]);
-    expect(manifest.statLine).toBe("0 files (window-approx)");
+    expect(manifest).toBeDefined();
+    expect(manifest!.changes).toEqual([]);
   });
 
-  it("returns unavailable manifests for null baseline or end snapshots", () => {
-    expect(buildWorkspaceManifest(null, [])).toMatchObject({
-      attribution: WORKSPACE_CHANGE_ATTRIBUTION,
-      available: false,
-      reason: "snapshot-unavailable",
-      statLine: "unavailable",
-      truncated: false,
-    });
-    expect(buildWorkspaceManifest([], null, "git-unavailable")).toMatchObject({
-      available: false,
-      reason: "git-unavailable",
-    });
-  });
-
-  it("returns scanner-not-configured when no scanner is provided", () => {
-    expect(unavailableWorkspaceManifest("scanner-not-configured")).toMatchObject({
-      available: false,
-      reason: "scanner-not-configured",
-      changes: [],
-    });
+  it("returns undefined for null baseline or end snapshots", () => {
+    expect(buildWorkspaceManifest(null, [])).toBeUndefined();
+    expect(buildWorkspaceManifest([], null)).toBeUndefined();
+    expect(buildWorkspaceManifest(null, null)).toBeUndefined();
   });
 
   it("caps changes at the configured limit and marks truncation", () => {
@@ -79,9 +58,9 @@ describe("workspace change manifest helpers", () => {
 
     const manifest = buildWorkspaceManifest([], end);
 
-    expect(manifest.changes).toHaveLength(WORKSPACE_CHANGE_LIMIT);
-    expect(manifest.truncated).toBe(true);
-    expect(manifest.statLine).toBe(`${WORKSPACE_CHANGE_LIMIT}+ files (window-approx)`);
+    expect(manifest).toBeDefined();
+    expect(manifest!.changes).toHaveLength(WORKSPACE_CHANGE_LIMIT);
+    expect(manifest!.truncated).toBe(true);
   });
 
   it("baseline에서 dirty였다가 종료 스냅샷에서 사라진 경로를 cleared로 방출", () => {
@@ -94,11 +73,11 @@ describe("workspace change manifest helpers", () => {
       [{ status: "M", path: "kept.ts" }],
     );
 
-    expect(manifest.changes).toEqual([
+    expect(manifest).toBeDefined();
+    expect(manifest!.changes).toEqual([
       { status: WORKSPACE_CHANGE_CLEARED_STATUS, path: "reverted.ts" },
       { status: WORKSPACE_CHANGE_CLEARED_STATUS, path: "removed.txt" },
     ]);
-    expect(manifest.statLine).toBe("2 files (window-approx)");
   });
 
   it("preserves flattened rename paths", () => {
@@ -106,7 +85,8 @@ describe("workspace change manifest helpers", () => {
       { status: "R", path: "old.ts -> new.ts" },
     ]);
 
-    expect(manifest.changes).toEqual([{ status: "R", path: "old.ts -> new.ts" }]);
+    expect(manifest).toBeDefined();
+    expect(manifest!.changes).toEqual([{ status: "R", path: "old.ts -> new.ts" }]);
   });
 
   it("wraps scanner failures as null snapshots", async () => {


### PR DESCRIPTION
## Summary
- 캐리어 공통 응답 프로토콜 신설: 진행 내레이션은 스텝당 한 줄 이내로 간결화(실시간 스트리밍 관전 채널은 유지), 최종 산출물은 `<report>...</report>` 블록으로 감싸 마지막에 1회 출력 — 전 8캐리어 시스템 프롬프트에 일괄 주입
- `carrier_jobs(format:"full")`가 마지막 완결 `<report>` 블록만 결정론적으로 추출해 반환(태그 부재·미완결·빈 본문 시 **현행 전문 폴백**), 감사/디버깅용 `format:"raw"`(무가공 아카이브) 신설 — Task Force backend별 결과에도 동일 적용
- 응답 JSON 다이어트: 에코백(`action`/`format`)·파생 필드(`summary_available`, workspaceChanges의 `attribution`/`available`/`statLine`/`reason`) 제거, 완료 푸시 리마인더의 `changes=` 라인은 변경 목록에서 재계산(출력 형식 불변). 캐리어 prior_jobs 폴백이 의존하는 `full_invalidated`는 보존

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-carriers test` — 147/147 (신규 report-extract 13케이스: 마지막 완결 블록·미완결/빈 본문 폴백·대소문자/속성 격리·TaskForce 등)
- [x] `pnpm --filter @dotobokuri/fleet-carriers build` / `@dotobokuri/fleet-admiral build+test`(29/29) / `@dotobokuri/fleet-cli build` / `@dotobokuri/fleet-console build` — 하류 소비자 전부 green
- [x] 제거 필드 소비자 전수 grep 0건(fleet-carriers/admiral/cli/console) + 정화 파이프(ANSI·비밀 마스킹) 우회 없음 확인 — Sentinel 정적 보안 리뷰 PASS(Critical/High/Medium 0)
- [x] `.changelog.d` fragment 포함(`section: Changed`, `[fleet-carriers]`) + `--check` 통과
- [ ] 라이브 실캐리어 회수 실측은 Fleet 데몬 재기동이 필요해 머지 후 자연 검증(현 세션 MCP 안정성 보호)