### PR TITLE
feat(fleet-console): move Skills panel job status to a bottom dock

### DIFF
--- a/.changelog.d/skills-status-dock.md
+++ b/.changelog.d/skills-status-dock.md
@@ -1,0 +1,4 @@
+---
+section: Changed
+---
+- [fleet-console] Skills panel shows update and install progress in a collapsible status dock docked to the bottom of the panel, keeping the skill list unobstructed; the dock auto-dismisses on success and keeps a Retry action on failure.

--- a/runtime/fleet-plugins/skills/client/find-tab.tsx
+++ b/runtime/fleet-plugins/skills/client/find-tab.tsx
@@ -2,12 +2,14 @@ import { useCallback, useEffect, useRef } from "react";
 
 import type { Scope, SkillListItem, SkillSearchItem } from "../server/types.js";
 import { InstallFlow } from "./install-flow.js";
+import { JobStatusDock } from "./job-status-dock.js";
 import {
   setInstallFormOpenId,
   setSearchQuery,
   setSearchState,
   useSkillsStore,
 } from "./skills-store.js";
+import { useJobLog, type UseJobLogReturn } from "./use-job-log.js";
 
 // ─── types ───────────────────────────────────────────────────────────────────
 
@@ -24,6 +26,7 @@ interface FindResultCardProps {
   readonly onInstallClick: () => void;
   readonly onReadMore: (skill: SkillListItem, registryId: string) => void;
   readonly onInstallSuccess: (skillName: string, scope: Scope) => void;
+  readonly jobLog: UseJobLogReturn;
 }
 
 // ─── constants ───────────────────────────────────────────────────────────────
@@ -61,6 +64,7 @@ function FindResultCard({
   onInstallClick,
   onReadMore,
   onInstallSuccess,
+  jobLog,
 }: FindResultCardProps) {
   const previewSkill: SkillListItem = {
     name: result.name,
@@ -105,6 +109,7 @@ function FindResultCard({
             onInstallClick();
             onInstallSuccess(result.name, installedScope);
           }}
+          jobLog={jobLog}
         />
       )}
     </div>
@@ -116,6 +121,7 @@ function FindResultCard({
 export function FindTab({ theaterId, onReadMore, onInstallSuccess }: FindTabProps) {
   const { searchQuery, searchResults, searchLoading, installFormOpenId } = useSkillsStore();
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const installJobLog = useJobLog();
 
   const handleQueryChange = useCallback((q: string) => {
     setSearchQuery(q);
@@ -128,42 +134,61 @@ export function FindTab({ theaterId, onReadMore, onInstallSuccess }: FindTabProp
     if (debounceRef.current) clearTimeout(debounceRef.current);
   }, []);
 
+  const installingName =
+    installFormOpenId != null
+      ? (searchResults.find((r) => r.id === installFormOpenId)?.name ?? "")
+      : "";
+
+  const installRunningLabel = installingName ? `Installing ${installingName}…` : "Installing…";
+
   return (
-    <div className="skills-tab-body">
-      <input
-        type="search"
-        className="skills-filter-input"
-        placeholder="Search skills.sh registry…"
-        value={searchQuery}
-        onChange={(e) => handleQueryChange(e.target.value)}
-        aria-label="Search skills registry"
-      />
+    <>
+      <div className="skills-tab-body">
+        <input
+          type="search"
+          className="skills-filter-input"
+          placeholder="Search skills.sh registry…"
+          value={searchQuery}
+          onChange={(e) => handleQueryChange(e.target.value)}
+          aria-label="Search skills registry"
+        />
 
-      {searchLoading && <div className="skills-empty-state">Searching…</div>}
+        {searchLoading && <div className="skills-empty-state">Searching…</div>}
 
-      {!searchLoading && searchQuery.length >= MIN_QUERY_LEN && searchResults.length === 0 && (
-        <div className="skills-empty-state">No results for "{searchQuery}".</div>
-      )}
+        {!searchLoading && searchQuery.length >= MIN_QUERY_LEN && searchResults.length === 0 && (
+          <div className="skills-empty-state">No results for "{searchQuery}".</div>
+        )}
 
-      {!searchLoading && searchQuery.length > 0 && searchQuery.length < MIN_QUERY_LEN && (
-        <div className="skills-empty-state">Type at least 2 characters to search.</div>
-      )}
+        {!searchLoading && searchQuery.length > 0 && searchQuery.length < MIN_QUERY_LEN && (
+          <div className="skills-empty-state">Type at least 2 characters to search.</div>
+        )}
 
-      <div className="skills-card-list">
-        {searchResults.map((result) => (
-          <FindResultCard
-            key={result.id}
-            result={result}
-            theaterId={theaterId}
-            isFormOpen={installFormOpenId === result.id}
-            onInstallClick={() =>
-              setInstallFormOpenId(installFormOpenId === result.id ? null : result.id)
-            }
-            onReadMore={onReadMore}
-            onInstallSuccess={onInstallSuccess}
-          />
-        ))}
+        <div className="skills-card-list">
+          {searchResults.map((result) => (
+            <FindResultCard
+              key={result.id}
+              result={result}
+              theaterId={theaterId}
+              isFormOpen={installFormOpenId === result.id}
+              onInstallClick={() =>
+                setInstallFormOpenId(installFormOpenId === result.id ? null : result.id)
+              }
+              onReadMore={onReadMore}
+              onInstallSuccess={onInstallSuccess}
+              jobLog={installJobLog}
+            />
+          ))}
+        </div>
       </div>
-    </div>
+
+      <JobStatusDock
+        status={installJobLog.status}
+        lines={installJobLog.lines}
+        runningLabel={installRunningLabel}
+        doneLabel="Installed"
+        errorLabel="Install failed"
+        onDismiss={installJobLog.reset}
+      />
+    </>
   );
 }

--- a/runtime/fleet-plugins/skills/client/find-tab.tsx
+++ b/runtime/fleet-plugins/skills/client/find-tab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { Scope, SkillListItem, SkillSearchItem } from "../server/types.js";
 import { InstallFlow } from "./install-flow.js";
@@ -25,7 +25,7 @@ interface FindResultCardProps {
   readonly isFormOpen: boolean;
   readonly onInstallClick: () => void;
   readonly onReadMore: (skill: SkillListItem, registryId: string) => void;
-  readonly onInstallSuccess: (skillName: string, scope: Scope) => void;
+  readonly onInstallStarted: (skillName: string, scope: Scope) => void;
   readonly jobLog: UseJobLogReturn;
 }
 
@@ -63,7 +63,7 @@ function FindResultCard({
   isFormOpen,
   onInstallClick,
   onReadMore,
-  onInstallSuccess,
+  onInstallStarted,
   jobLog,
 }: FindResultCardProps) {
   const previewSkill: SkillListItem = {
@@ -105,10 +105,7 @@ function FindResultCard({
           skill={result.name}
           theaterId={theaterId}
           onCancel={onInstallClick}
-          onSuccess={(installedScope) => {
-            onInstallClick();
-            onInstallSuccess(result.name, installedScope);
-          }}
+          onStarted={(installedScope) => onInstallStarted(result.name, installedScope)}
           jobLog={jobLog}
         />
       )}
@@ -122,6 +119,7 @@ export function FindTab({ theaterId, onReadMore, onInstallSuccess }: FindTabProp
   const { searchQuery, searchResults, searchLoading, installFormOpenId } = useSkillsStore();
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const installJobLog = useJobLog();
+  const [installTarget, setInstallTarget] = useState<{ name: string; scope: Scope } | null>(null);
 
   const handleQueryChange = useCallback((q: string) => {
     setSearchQuery(q);
@@ -134,12 +132,17 @@ export function FindTab({ theaterId, onReadMore, onInstallSuccess }: FindTabProp
     if (debounceRef.current) clearTimeout(debounceRef.current);
   }, []);
 
-  const installingName =
-    installFormOpenId != null
-      ? (searchResults.find((r) => r.id === installFormOpenId)?.name ?? "")
-      : "";
+  // 설치 완료 전파(설치 목록 새로고침·Installed 탭 전환·토스트)는 잡 소유자인 FindTab이
+  // 소유한다. 설치 도중 사용자가 InstallFlow 폼을 접어 언마운트해도, 여기서 status==="done"을
+  // 보고 확실히 전파한다(폼 내부 타이머에 의존해 완료가 고아가 되지 않는다).
+  useEffect(() => {
+    if (installJobLog.status !== "done" || !installTarget) return;
+    onInstallSuccess(installTarget.name, installTarget.scope);
+    setInstallFormOpenId(null);
+    setInstallTarget(null);
+  }, [installJobLog.status, installTarget, onInstallSuccess]);
 
-  const installRunningLabel = installingName ? `Installing ${installingName}…` : "Installing…";
+  const installRunningLabel = installTarget ? `Installing ${installTarget.name}…` : "Installing…";
 
   return (
     <>
@@ -174,7 +177,7 @@ export function FindTab({ theaterId, onReadMore, onInstallSuccess }: FindTabProp
                 setInstallFormOpenId(installFormOpenId === result.id ? null : result.id)
               }
               onReadMore={onReadMore}
-              onInstallSuccess={onInstallSuccess}
+              onInstallStarted={(name, scope) => setInstallTarget({ name, scope })}
               jobLog={installJobLog}
             />
           ))}

--- a/runtime/fleet-plugins/skills/client/install-flow.tsx
+++ b/runtime/fleet-plugins/skills/client/install-flow.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import type { AgentId, Scope } from "../server/types.js";
-import { useJobLog } from "./use-job-log.js";
+import type { UseJobLogReturn } from "./use-job-log.js";
 
 // ─── types ───────────────────────────────────────────────────────────────────
 
@@ -11,6 +11,7 @@ interface InstallFlowProps {
   readonly theaterId: string | null;
   readonly onCancel: () => void;
   readonly onSuccess: (scope: Scope) => void;
+  readonly jobLog: UseJobLogReturn;
 }
 
 // ─── constants ───────────────────────────────────────────────────────────────
@@ -31,12 +32,12 @@ const SUCCESS_LINGER_MS = 1200;
 
 // ─── InstallFlow ──────────────────────────────────────────────────────────────
 
-export function InstallFlow({ source, skill, theaterId, onCancel, onSuccess }: InstallFlowProps) {
+export function InstallFlow({ source, skill, theaterId, onCancel, onSuccess, jobLog }: InstallFlowProps) {
   const [scope, setScope] = useState<Scope>(theaterId ? "project" : "global");
   const [allAgents, setAllAgents] = useState(true);
   const [selectedAgents, setSelectedAgents] = useState<Set<AgentId>>(new Set(AGENT_IDS));
 
-  const { status, lines, start } = useJobLog();
+  const { status, start } = jobLog;
   const isRunning = status === "running";
   const isDone = status === "done";
   const isError = status === "error";
@@ -138,21 +139,6 @@ export function InstallFlow({ source, skill, theaterId, onCancel, onSuccess }: I
           >
             Install now
           </button>
-        </div>
-      )}
-
-      {(isRunning || isDone || isError) && (
-        <div className="skills-update-log">
-          {lines.map((line, i) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <div key={i} className="skills-update-log-line">{line}</div>
-          ))}
-          {isDone && (
-            <div className="skills-update-log-line skills-update-log-done">✓ Installed</div>
-          )}
-          {isError && (
-            <div className="skills-update-log-line skills-update-log-error">✗ Install failed</div>
-          )}
         </div>
       )}
     </div>

--- a/runtime/fleet-plugins/skills/client/install-flow.tsx
+++ b/runtime/fleet-plugins/skills/client/install-flow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 
 import type { AgentId, Scope } from "../server/types.js";
 import type { UseJobLogReturn } from "./use-job-log.js";
@@ -10,7 +10,7 @@ interface InstallFlowProps {
   readonly skill: string;
   readonly theaterId: string | null;
   readonly onCancel: () => void;
-  readonly onSuccess: (scope: Scope) => void;
+  readonly onStarted: (scope: Scope) => void;
   readonly jobLog: UseJobLogReturn;
 }
 
@@ -28,11 +28,9 @@ const AGENT_LABELS: Record<AgentId, string> = {
 const PERMISSION_WARNING =
   "Skills run with full agent permissions. Review before use — open the name to read SKILL.md.";
 
-const SUCCESS_LINGER_MS = 1200;
-
 // ─── InstallFlow ──────────────────────────────────────────────────────────────
 
-export function InstallFlow({ source, skill, theaterId, onCancel, onSuccess, jobLog }: InstallFlowProps) {
+export function InstallFlow({ source, skill, theaterId, onCancel, onStarted, jobLog }: InstallFlowProps) {
   const [scope, setScope] = useState<Scope>(theaterId ? "project" : "global");
   const [allAgents, setAllAgents] = useState(true);
   const [selectedAgents, setSelectedAgents] = useState<Set<AgentId>>(new Set(AGENT_IDS));
@@ -41,12 +39,6 @@ export function InstallFlow({ source, skill, theaterId, onCancel, onSuccess, job
   const isRunning = status === "running";
   const isDone = status === "done";
   const isError = status === "error";
-
-  useEffect(() => {
-    if (!isDone) return;
-    const timer = setTimeout(() => onSuccess(scope), SUCCESS_LINGER_MS);
-    return () => clearTimeout(timer);
-  }, [isDone, onSuccess, scope]);
 
   const handleToggleAll = useCallback(() => {
     setAllAgents(true);
@@ -74,7 +66,10 @@ export function InstallFlow({ source, skill, theaterId, onCancel, onSuccess, job
     if (scope === "project" && theaterId) body["theaterId"] = theaterId;
 
     start("/plugins/skills/install", body);
-  }, [allAgents, selectedAgents, source, skill, scope, theaterId, start]);
+    // 완료 전파(설치 목록 새로고침·탭 전환)는 잡 소유자(FindTab)가 status로 구동하므로,
+    // 이 transient 폼은 설치 대상 scope만 시작 시점에 상위로 알린다.
+    onStarted(scope);
+  }, [allAgents, selectedAgents, source, skill, scope, theaterId, start, onStarted]);
 
   return (
     <div className="skills-install-flow">

--- a/runtime/fleet-plugins/skills/client/installed-tab.tsx
+++ b/runtime/fleet-plugins/skills/client/installed-tab.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 
 import type { SkillListItem } from "../server/types.js";
+import { JobStatusDock } from "./job-status-dock.js";
 import { SkillCard } from "./skill-card.js";
 import {
   setFilterText,
@@ -74,6 +75,10 @@ export function InstalledTab({ theaterId, onReadMore, refreshKey }: InstalledTab
       .catch(() => null);
   }, [theaterId, loadList]);
 
+  const handleRetry = useCallback(() => {
+    if (updateScopeRef.current) handleUpdate(updateScopeRef.current);
+  }, [handleUpdate]);
+
   const visibleScope: Scope = scope === "project" && !theaterId ? "global" : scope;
   const filtered = installedList.filter((s) => {
     if (s.scope !== visibleScope) return false;
@@ -85,70 +90,67 @@ export function InstalledTab({ theaterId, onReadMore, refreshKey }: InstalledTab
     updateLog.status === "running" && updateScopeRef.current === visibleScope;
 
   return (
-    <div className="skills-tab-body">
-      <div className="skills-scope-toggle">
-        <button
-          type="button"
-          className={`skills-scope-btn${visibleScope === "project" ? " is-active" : ""}`}
-          onClick={() => setScope("project")}
-          disabled={!theaterId}
-          title={!theaterId ? "Select a Theater to view project skills" : undefined}
-        >
-          Project
-        </button>
-        <button
-          type="button"
-          className={`skills-scope-btn${visibleScope === "global" ? " is-active" : ""}`}
-          onClick={() => setScope("global")}
-        >
-          Global
-        </button>
-      </div>
+    <>
+      <div className="skills-tab-body">
+        <div className="skills-scope-toggle">
+          <button
+            type="button"
+            className={`skills-scope-btn${visibleScope === "project" ? " is-active" : ""}`}
+            onClick={() => setScope("project")}
+            disabled={!theaterId}
+            title={!theaterId ? "Select a Theater to view project skills" : undefined}
+          >
+            Project
+          </button>
+          <button
+            type="button"
+            className={`skills-scope-btn${visibleScope === "global" ? " is-active" : ""}`}
+            onClick={() => setScope("global")}
+          >
+            Global
+          </button>
+        </div>
 
-      <input
-        type="search"
-        className="skills-filter-input"
-        placeholder="Filter installed skills…"
-        value={filterText}
-        onChange={(e) => setFilterText(e.target.value)}
-        aria-label="Filter installed skills"
-      />
+        <input
+          type="search"
+          className="skills-filter-input"
+          placeholder="Filter installed skills…"
+          value={filterText}
+          onChange={(e) => setFilterText(e.target.value)}
+          aria-label="Filter installed skills"
+        />
 
-      {(updateLog.status === "running" || updateLog.status === "done" || updateLog.status === "error") && (
-        <div className="skills-update-log">
-          {updateLog.lines.map((line, i) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <div key={i} className="skills-update-log-line">{line}</div>
+        {installedLoading && <div className="skills-empty-state">Loading…</div>}
+
+        {!installedLoading && filtered.length === 0 && (
+          <div className="skills-empty-state">
+            {filterText ? "No skills match the filter." : `No ${visibleScope} skills installed.`}
+          </div>
+        )}
+
+        <div className="skills-card-list">
+          {filtered.map((skill) => (
+            <SkillCard
+              key={`${skill.scope}:${skill.name}`}
+              skill={skill}
+              onReadMore={onReadMore}
+              onUpdate={handleUpdate}
+              onRemove={handleRemove}
+              isUpdating={isUpdating}
+            />
           ))}
-          {updateLog.status === "done" && (
-            <div className="skills-update-log-line skills-update-log-done">✓ Update complete</div>
-          )}
-          {updateLog.status === "error" && (
-            <div className="skills-update-log-line skills-update-log-error">✗ Update failed</div>
-          )}
         </div>
-      )}
-
-      {installedLoading && <div className="skills-empty-state">Loading…</div>}
-
-      {!installedLoading && filtered.length === 0 && (
-        <div className="skills-empty-state">
-          {filterText ? "No skills match the filter." : `No ${visibleScope} skills installed.`}
-        </div>
-      )}
-
-      <div className="skills-card-list">
-        {filtered.map((skill) => (
-          <SkillCard
-            key={`${skill.scope}:${skill.name}`}
-            skill={skill}
-            onReadMore={onReadMore}
-            onUpdate={handleUpdate}
-            onRemove={handleRemove}
-            isUpdating={isUpdating}
-          />
-        ))}
       </div>
-    </div>
+
+      <JobStatusDock
+        status={updateLog.status}
+        lines={updateLog.lines}
+        runningLabel="Updating skills…"
+        doneLabel="Updated"
+        errorLabel="Update failed"
+        onDismiss={updateLog.reset}
+        onRetry={handleRetry}
+      />
+    </>
   );
 }

--- a/runtime/fleet-plugins/skills/client/job-status-dock.tsx
+++ b/runtime/fleet-plugins/skills/client/job-status-dock.tsx
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { JobLogStatus } from "./use-job-log.js";
+
+// ─── types ───────────────────────────────────────────────────────────────────
+
+export interface JobStatusDockProps {
+  readonly status: JobLogStatus;
+  readonly lines: readonly string[];
+  readonly runningLabel: string;
+  readonly doneLabel: string;
+  readonly errorLabel: string;
+  readonly onDismiss: () => void;
+  readonly onRetry?: (() => void) | undefined;
+}
+
+// ─── constants ───────────────────────────────────────────────────────────────
+
+const DONE_LINGER_MS = 4000;
+
+// ─── JobStatusDock ────────────────────────────────────────────────────────────
+
+export function JobStatusDock({
+  status,
+  lines,
+  runningLabel,
+  doneLabel,
+  errorLabel,
+  onDismiss,
+  onRetry,
+}: JobStatusDockProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const logRef = useRef<HTMLDivElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // collapse when a new job starts
+  useEffect(() => {
+    if (status === "running") setIsOpen(false);
+  }, [status]);
+
+  // auto-scroll log when lines arrive
+  useEffect(() => {
+    const el = logRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [lines]);
+
+  // auto-collapse then dismiss after done linger
+  useEffect(() => {
+    if (status !== "done") return;
+    timerRef.current = setTimeout(() => {
+      setIsOpen(false);
+      onDismiss();
+    }, DONE_LINGER_MS);
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [status, onDismiss]);
+
+  const dismiss = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setIsOpen(false);
+    onDismiss();
+  }, [onDismiss]);
+
+  const toggle = useCallback(() => setIsOpen((o) => !o), []);
+
+  if (status === "idle") return null;
+
+  const dotClass =
+    status === "running"
+      ? "skills-dock-dot is-live"
+      : status === "done"
+        ? "skills-dock-dot is-ok"
+        : "skills-dock-dot is-err";
+
+  const labelClass =
+    status === "done"
+      ? "skills-dock-label is-ok"
+      : status === "error"
+        ? "skills-dock-label is-err"
+        : "skills-dock-label";
+
+  const label =
+    status === "running" ? runningLabel : status === "done" ? doneLabel : errorLabel;
+
+  return (
+    <div className="skills-dock">
+      {isOpen && (
+        <div ref={logRef} className="skills-dock-log">
+          {lines.map((line, i) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <div key={i} className="skills-dock-log-line">{line}</div>
+          ))}
+          {status === "done" && (
+            <div className="skills-dock-log-line skills-dock-log-done">✓ {doneLabel}</div>
+          )}
+          {status === "error" && (
+            <div className="skills-dock-log-line skills-dock-log-error">✗ {errorLabel}</div>
+          )}
+        </div>
+      )}
+      <div
+        role="button"
+        tabIndex={0}
+        className={`skills-dock-summary${isOpen ? " is-open" : ""}`}
+        aria-expanded={isOpen}
+        onClick={toggle}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            toggle();
+          }
+        }}
+      >
+        <span className={dotClass} aria-hidden="true" />
+        <span className={labelClass} aria-live="polite">{label}</span>
+        {status === "running" && lines.length > 0 && (
+          <span className="skills-dock-count">
+            {lines.length} {lines.length === 1 ? "line" : "lines"}
+          </span>
+        )}
+        {status === "done" && (
+          <button
+            type="button"
+            className="skills-dock-dismiss"
+            aria-label="Dismiss"
+            onClick={(e) => { e.stopPropagation(); dismiss(); }}
+          >
+            ✕
+          </button>
+        )}
+        {status === "error" && onRetry != null && (
+          <button
+            type="button"
+            className="skills-dock-retry"
+            onClick={(e) => { e.stopPropagation(); onRetry(); }}
+          >
+            Retry
+          </button>
+        )}
+        <span className={`skills-dock-chevron${isOpen ? " is-open" : ""}`} aria-hidden="true">▾</span>
+      </div>
+    </div>
+  );
+}

--- a/runtime/fleet-plugins/skills/client/job-status-dock.tsx
+++ b/runtime/fleet-plugins/skills/client/job-status-dock.tsx
@@ -112,6 +112,9 @@ export function JobStatusDock({
         aria-expanded={isOpen}
         onClick={toggle}
         onKeyDown={(e) => {
+          // 자식 버튼(Dismiss/Retry)에서 버블링된 키 이벤트가 도크 토글을 삼키지 않도록,
+          // 요약 바 자체에 포커스가 있을 때만 Enter/Space를 처리한다.
+          if (e.target !== e.currentTarget) return;
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             toggle();

--- a/runtime/fleet-plugins/skills/client/job-status-dock.tsx
+++ b/runtime/fleet-plugins/skills/client/job-status-dock.tsx
@@ -135,14 +135,27 @@ export function JobStatusDock({
             ✕
           </button>
         )}
-        {status === "error" && onRetry != null && (
-          <button
-            type="button"
-            className="skills-dock-retry"
-            onClick={(e) => { e.stopPropagation(); onRetry(); }}
-          >
-            Retry
-          </button>
+        {status === "error" && (
+          // error는 자동소멸하지 않으므로, Retry(있으면)와 함께 수동 해제용 ✕를 항상 제공한다.
+          <>
+            {onRetry != null && (
+              <button
+                type="button"
+                className="skills-dock-retry"
+                onClick={(e) => { e.stopPropagation(); onRetry(); }}
+              >
+                Retry
+              </button>
+            )}
+            <button
+              type="button"
+              className="skills-dock-dismiss"
+              aria-label="Dismiss"
+              onClick={(e) => { e.stopPropagation(); dismiss(); }}
+            >
+              ✕
+            </button>
+          </>
         )}
         <span className={`skills-dock-chevron${isOpen ? " is-open" : ""}`} aria-hidden="true">▾</span>
       </div>

--- a/runtime/fleet-plugins/skills/client/skills.css
+++ b/runtime/fleet-plugins/skills/client/skills.css
@@ -269,24 +269,144 @@
   .skills-btn { transition: none; }
 }
 
-/* ─── update log ─────────────────────────────────────────────────────────────── */
+/* ─── status dock ────────────────────────────────────────────────────────────── */
 
-.skills-update-log {
-  background: color-mix(in srgb, var(--surface-glass) 30%, transparent);
-  border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-md);
-  font-family: "JetBrains Mono Variable", monospace;
-  font-size: 0.6875rem;
-  max-height: 160px;
-  overflow-y: auto;
-  padding: var(--space-2);
+.skills-dock {
+  flex-shrink: 0;
+  border-top: 1px solid var(--surface-rim);
+  background: color-mix(in srgb, var(--surface-glass) 80%, transparent);
+  display: flex;
+  flex-direction: column;
 }
 
-.skills-update-log-line { color: var(--ink-body); line-height: 1.5; }
+.skills-dock-log {
+  font-family: "JetBrains Mono Variable", monospace;
+  font-size: 0.6875rem;
+  line-height: 1.5;
+  max-height: 150px;
+  overflow-y: auto;
+  padding: var(--space-2) var(--space-3) 0;
+}
 
-.skills-update-log-done { color: var(--aurora); }
+.skills-dock-log-line {
+  color: var(--ink-body);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
-.skills-update-log-error { color: var(--coral); }
+.skills-dock-log-done { color: var(--positive); }
+
+.skills-dock-log-error { color: var(--coral); }
+
+.skills-dock-summary {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  gap: var(--space-2);
+  padding: 9px var(--space-3);
+  user-select: none;
+}
+
+.skills-dock-summary:focus-visible {
+  outline: 2px solid var(--brass);
+  outline-offset: -2px;
+}
+
+.skills-dock-dot {
+  background: var(--ink-fog);
+  border-radius: 50%;
+  flex-shrink: 0;
+  height: 8px;
+  width: 8px;
+}
+
+.skills-dock-dot.is-live {
+  animation: skills-dock-pulse 1.6s ease-in-out infinite;
+  background: var(--aurora);
+}
+
+.skills-dock-dot.is-ok { background: var(--positive); }
+
+.skills-dock-dot.is-err { background: var(--coral); }
+
+@keyframes skills-dock-pulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--aurora) 22%, transparent);
+    opacity: 0.7;
+  }
+  50% {
+    box-shadow: 0 0 10px 2px color-mix(in srgb, var(--aurora) 22%, transparent);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skills-dock-dot.is-live { animation-duration: 0.01ms; }
+}
+
+.skills-dock-label {
+  color: var(--ink-spectral);
+  flex: 1;
+  font-size: 0.78rem;
+  font-weight: 500;
+}
+
+.skills-dock-label.is-ok { color: var(--positive); }
+
+.skills-dock-label.is-err { color: var(--coral); }
+
+.skills-dock-count {
+  color: var(--ink-fog);
+  font-family: "JetBrains Mono Variable", monospace;
+  font-size: 0.6875rem;
+}
+
+.skills-dock-dismiss {
+  background: none;
+  border: none;
+  color: var(--ink-fog);
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1;
+  padding: 0 2px;
+}
+
+.skills-dock-dismiss:hover { color: var(--ink-spectral); }
+
+.skills-dock-dismiss:focus-visible {
+  outline: 2px solid var(--brass);
+  outline-offset: 2px;
+}
+
+.skills-dock-retry {
+  background: color-mix(in srgb, var(--coral) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--coral) 40%, transparent);
+  border-radius: var(--radius-md);
+  color: var(--coral);
+  cursor: pointer;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  padding: 2px 8px;
+}
+
+.skills-dock-retry:focus-visible {
+  outline: 2px solid var(--coral);
+  outline-offset: 2px;
+}
+
+.skills-dock-chevron {
+  color: var(--ink-fog);
+  font-size: 0.72rem;
+  pointer-events: none;
+  transition: transform var(--duration-base) ease;
+}
+
+.skills-dock-chevron.is-open { transform: rotate(180deg); }
+
+@media (prefers-reduced-motion: reduce) {
+  .skills-dock-chevron { transition: none; }
+}
 
 /* ─── install flow ───────────────────────────────────────────────────────────── */
 


### PR DESCRIPTION
## Summary
- Skills 패널의 update/install 진행 로그가 필터와 카드 리스트 **사이 인라인**으로 렌더되어 스크롤 컬럼을 침범하던 것을, 스크롤 밖 패널 하단의 공유 `JobStatusDock`(접이식 요약 + 스크롤 로그)으로 이관했습니다. 목록은 더 이상 밀리거나 잘리지 않습니다.
- running=`--aurora`(live pulse) · done=`--positive` · error=`--coral`(Retry)로 색 역할을 도트린에 맞춰 교정했고, 성공 시 짧은 잔류 후 **자동 소멸**합니다(Installed 탭에서 상태 로그가 영구 잔존하던 결함 해소).
- 요약 바는 `aria-expanded`/`aria-live`로 키보드 조작 가능하며, pulse·chevron 모션은 `prefers-reduced-motion`에서 단락됩니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/skills typecheck`
- [x] `pnpm --filter @fleet-plugins/skills test` (81 passed / 1 skipped)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] console-e2e (격리 인스턴스, 백엔드 목킹·실 스킬 무변경): idle→running→expanded→done→auto-dismiss 전 구간 검증 — 도크가 스크롤 컬럼 밖 렌더, 카드 무변위, JS 에러 0
- [x] `.changelog.d/*.md` fragment 포함 (`[fleet-console]`, section Changed)