### PR TITLE
feat(core-unified-agent): add OpenCode Go GLM and Kimi models

### DIFF
--- a/.changelog.d/opencode-go-glm-kimi-models.md
+++ b/.changelog.d/opencode-go-glm-kimi-models.md
@@ -1,0 +1,4 @@
+---
+section: Added
+---
+- [core-unified-agent] OpenCode Go model selection now includes GLM-5.2 and Kimi K2.7 Code.

--- a/packages/core-unified-agent/models.json
+++ b/packages/core-unified-agent/models.json
@@ -74,7 +74,9 @@
         { "modelId": "opencode-go/deepseek-v4-pro", "name": "DeepSeek V4 Pro", "effort": { "supported": false } },
         { "modelId": "opencode-go/glm-5", "name": "GLM-5", "effort": { "supported": false } },
         { "modelId": "opencode-go/glm-5.1", "name": "GLM-5.1", "effort": { "supported": false } },
-        { "modelId": "opencode-go/kimi-k2.6", "name": "Kimi K2.6 (3x limits)", "effort": { "supported": false } }
+        { "modelId": "opencode-go/glm-5.2", "name": "GLM-5.2", "effort": { "supported": false } },
+        { "modelId": "opencode-go/kimi-k2.6", "name": "Kimi K2.6 (3x limits)", "effort": { "supported": false } },
+        { "modelId": "opencode-go/kimi-k2.7-code", "name": "Kimi K2.7 Code", "effort": { "supported": false } }
       ]
     },
     "cursor": {

--- a/packages/core-unified-agent/tests/unit/ModelRegistry.test.ts
+++ b/packages/core-unified-agent/tests/unit/ModelRegistry.test.ts
@@ -21,6 +21,14 @@ describe('ModelRegistry', () => {
     expect(modelIds).toContain('gpt-5.5');
   });
 
+  it('OpenCode Go 정적 모델 목록에 GLM-5.2와 Kimi K2.7 Code를 포함한다', () => {
+    const provider = getProviderModels('opencode-go');
+    const modelIds = provider.models.map((model) => model.modelId);
+
+    expect(modelIds).toContain('opencode-go/glm-5.2');
+    expect(modelIds).toContain('opencode-go/kimi-k2.7-code');
+  });
+
   it('Cursor 정적 모델 목록은 cursor-agent CLI 모델 ID를 그대로 노출한다', () => {
     const provider = getProviderModels('cursor');
     const modelIds = provider.models.map((model) => model.modelId);


### PR DESCRIPTION
## Summary
- Add GLM-5.2 and Kimi K2.7 Code to the OpenCode Go model registry.
- Cover the new OpenCode Go model IDs in the ModelRegistry unit test.
- Add a changelog fragment for the user-visible model selection update.

## Type of Change

- [x] feat - new feature or carrier capability
- [ ] fix - bug fix
- [ ] docs - documentation only
- [ ] refactor - no behavior change
- [ ] chore - build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- [ ] `extensions/core`
- [ ] `extensions/fleet` (Admiral / Bridge / Carriers)
- [ ] `extensions/boot`
- [ ] `extensions/diagnostics`
- [ ] `extensions/metaphor`
- [x] `packages/unified-agent`
- [ ] `bin/` or root tooling
- [ ] Documentation (README / SETUP / AGENTS.md)

## Test Plan

- [x] `pnpm --filter @dotobokuri/core-unified-agent exec vitest run tests/unit/ModelRegistry.test.ts`
- [x] `pnpm --filter @dotobokuri/core-unified-agent lint`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `git diff --check`

## Changelog

- [x] Added one `.changelog.d/*.md` fragment, or applied the `no-changelog` label intentionally.
- [x] Fragment `section:` is one of `Added`, `Changed`, `Fixed`, `Removed`, or `Breaking Changes`.
- [x] Fragment bullets are English and use only `[core-agent]`, `[core-unified-agent]`, `[fleet-infra]`, `[fleet-admiral]`, `[fleet-carriers]`, `[fleet-wiki]`, `[fleet-console]`, or `[fleet-cli]`.

## Related Issues / PRs


## Notes for Reviewers

- `pnpm install --frozen-lockfile --ignore-scripts` was used in the worktree to restore test dependencies without changing the lockfile.