### PR TITLE
fix(fleet-admiral): use fixed Codex Fleet profile

### DIFF
--- a/.changelog.d/codex-fleet-profile-lww.md
+++ b/.changelog.d/codex-fleet-profile-lww.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- [fleet-admiral][fleet-cli] Codex launches now use a fixed Fleet-managed profile with hooks enabled instead of session-scoped profiles or hook trust bypassing.

--- a/packages/fleet-admiral/src/agent-cli/builders/codex.ts
+++ b/packages/fleet-admiral/src/agent-cli/builders/codex.ts
@@ -17,9 +17,6 @@ export function buildCodexNativeArgs(context: AgentCliInjectionContext): string[
     'approval_policy="never"',
     "-c",
     'sandbox_mode="danger-full-access"',
-    // hook 신뢰 프롬프트("Hooks need review")를 fleet 관리 세션에서 건너뛴다. bypass_hook_trust는
-    // config 키가 아니라 전용 CLI 플래그이므로 -c override가 아닌 플래그로 전달해야 한다.
-    "--dangerously-bypass-hook-trust",
   ];
   for (const server of context.mcpServers) {
     const prefix = `mcp_servers.${server.name}`;

--- a/packages/fleet-admiral/src/agent-cli/injection.ts
+++ b/packages/fleet-admiral/src/agent-cli/injection.ts
@@ -82,9 +82,11 @@ type StartupNativeDefinitions =
   | { readonly host: "claude"; readonly definitions: ClaudeSubagentDefinition[] }
   | { readonly host: "none"; readonly definitions: [] };
 
-const CODEX_FLEET_PROFILE_FILE_NAME_PATTERN = /^fleet-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.config\.toml$/;
-const CODEX_FLEET_PROFILE_MARKER = "# Fleet-managed Codex session profile";
-const CODEX_STALE_PROFILE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const CODEX_FLEET_PROFILE_NAME = "fleet";
+const CODEX_FLEET_PROFILE_FILE_NAME = `${CODEX_FLEET_PROFILE_NAME}.config.toml`;
+const CODEX_LEGACY_FLEET_PROFILE_FILE_NAME_PATTERN = /^fleet-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.config\.toml$/;
+const CODEX_FLEET_PROFILE_MARKER = "# Fleet-managed Codex profile";
+const CODEX_LEGACY_FLEET_PROFILE_MARKER = "# Fleet-managed Codex session profile";
 const SYSTEM_PROMPT_FILE_MODE = 0o600;
 
 export async function injectAgentCliProfile(
@@ -130,7 +132,7 @@ export async function injectAgentCliProfile(
           turnStartHookExec: options.turnStartHookExec,
           turnEndHookExec: options.turnEndHookExec,
           autoNameHookExec: options.autoNameHookExec,
-        }, (cleanup) => tempCleanups.push(cleanup))
+        })
       : undefined;
     const launchWarnings: string[] = [];
     // 과거 fleet-global/fleet-project 렌더가 Codex 설정에 남긴 등록·flat marketplace 잔재를 등록 루프 전에 1회 정리한다.
@@ -245,14 +247,12 @@ function writeCodexFleetProfile(
   doctrine: string,
   pluginKeys: readonly string[],
   hookExecs: CodexProfileHookExecs,
-  onCleanup: (cleanup: () => void) => void,
 ): CodexFleetProfile {
   const codexHome = env.CODEX_HOME ?? path.join(env.HOME ?? os.homedir(), ".codex");
   mkdirSync(codexHome, { recursive: true });
-  pruneStaleCodexFleetProfiles(codexHome);
-  const profileName = `fleet-${crypto.randomUUID()}`;
-  const profilePath = path.join(codexHome, `${profileName}.config.toml`);
-  onCleanup(() => rmBestEffort(profilePath));
+  pruneLegacyCodexFleetProfiles(codexHome);
+  const profileName = CODEX_FLEET_PROFILE_NAME;
+  const profilePath = path.join(codexHome, CODEX_FLEET_PROFILE_FILE_NAME);
   writeFileNoFollow(profilePath, [
     CODEX_FLEET_PROFILE_MARKER,
     // doctrine를 멀티라인 TOML 문자열로 직렬화해 실제 줄바꿈을 보존(pretty)한다.
@@ -260,6 +260,9 @@ function writeCodexFleetProfile(
     `developer_instructions = """`,
     escapeTomlMultilineString(doctrine),
     `"""`,
+    "",
+    "[features]",
+    "hooks = true",
     "",
     ...pluginKeys.flatMap((pluginKey) => [
       `[plugins."${escapeTomlBasicString(pluginKey)}"]`,
@@ -310,28 +313,27 @@ function writeFileNoFollow(filePath: string, content: string): void {
   }
 }
 
-function pruneStaleCodexFleetProfiles(codexHome: string): void {
+function pruneLegacyCodexFleetProfiles(codexHome: string): void {
   let entries: string[];
   try {
     entries = readdirSync(codexHome);
   } catch {
     return;
   }
-  const now = Date.now();
   for (const entry of entries) {
-    if (!CODEX_FLEET_PROFILE_FILE_NAME_PATTERN.test(entry)) continue;
+    if (!CODEX_LEGACY_FLEET_PROFILE_FILE_NAME_PATTERN.test(entry)) continue;
     const filePath = path.join(codexHome, entry);
-    if (!isStaleFleetCodexProfile(filePath, now)) continue;
+    if (!isLegacyFleetCodexProfile(filePath)) continue;
     unlinkBestEffort(filePath);
   }
 }
 
-function isStaleFleetCodexProfile(filePath: string, now: number): boolean {
+function isLegacyFleetCodexProfile(filePath: string): boolean {
   try {
     const stat = lstatSync(filePath);
     if (!stat.isFile() || stat.isSymbolicLink()) return false;
-    if (now - stat.mtimeMs <= CODEX_STALE_PROFILE_MAX_AGE_MS) return false;
-    return readFirstLine(filePath) === CODEX_FLEET_PROFILE_MARKER;
+    const firstLine = readFirstLine(filePath);
+    return firstLine === CODEX_LEGACY_FLEET_PROFILE_MARKER;
   } catch {
     return false;
   }

--- a/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
@@ -76,16 +76,18 @@ describe("agent CLI session resume and capture hooks", () => {
       resumeSessionId: "codex-session-456",
     }));
     const profileName = injected.args[injected.args.indexOf("--profile") + 1];
-    const profilePath = path.join(codexHome, `${profileName}.config.toml`);
+    const profilePath = path.join(codexHome, "fleet.config.toml");
     const toml = readFileSync(profilePath, "utf8");
 
+    expect(profileName).toBe("fleet");
     expect(injected.args.slice(0, 6)).toEqual(["/shim/codex", "resume", "codex-session-456", "--no-alt-screen", "--model", "gpt-5.4"]);
     expect(indexOfSequence(injected.args, ["resume", "codex-session-456"])).toBeLessThan(indexOfSequence(injected.args, ["--no-alt-screen"]));
     expect(indexOfSequence(injected.args, ["resume", "codex-session-456"])).toBeLessThan(indexOfSequence(injected.args, ["--profile"]));
     expect(indexOfSequence(injected.args, ["resume", "codex-session-456"])).toBeLessThan(indexOfSequence(injected.args, ["-c"]));
     expect(indexOfSequence(injected.args, ["resume", "codex-session-456"])).toBeLessThan(indexOfSequence(injected.args, ["--enable"]));
     expect(indexOfSequence(injected.args, ["--enable", "hooks"])).toBeGreaterThan(indexOfSequence(injected.args, ["resume", "codex-session-456"]));
-    expect(indexOfSequence(injected.args, ["--dangerously-bypass-hook-trust"])).toBeGreaterThan(indexOfSequence(injected.args, ["resume", "codex-session-456"]));
+    expect(injected.args).not.toContain("--dangerously-bypass-hook-trust");
+    expect(toml).toContain("[features]\nhooks = true");
     expect(toml).toContain("[hooks]\n");
     expect(toml).toContain('UserPromptSubmit = [{ hooks = [{ type = "command", command = "\'node\' \'console.js\' \'hook\' \'capture-session\' \'codex\'" }] }]');
     expect(toml).not.toContain("args =");
@@ -160,7 +162,7 @@ describe("agent CLI session resume and capture hooks", () => {
     expect(codexPluginJson.hooks).toBeUndefined();
   });
 
-  it("writes Codex UserPromptSubmit capture command in the session profile without plugin inline hooks", async () => {
+  it("writes Codex UserPromptSubmit capture command in the fixed Fleet profile without plugin inline hooks", async () => {
     const root = createTempRoot("fleet-admiral-codex-hooks-");
     const codexHome = path.join(root, "codex-home");
     const profile = baseProfile("codex", {
@@ -173,13 +175,15 @@ describe("agent CLI session resume and capture hooks", () => {
       captureSessionHookExec,
     }));
     const profileName = injected.args[injected.args.indexOf("--profile") + 1];
-    const profilePath = path.join(codexHome, `${profileName}.config.toml`);
+    const profilePath = path.join(codexHome, "fleet.config.toml");
     const toml = readFileSync(profilePath, "utf8");
     const pluginJson = JSON.parse(readFileSync(path.join(root, "data", "marketplace", "plugins", "fleet", ".codex-plugin", "plugin.json"), "utf8")) as CodexPluginManifest;
 
-    expect(readdirSync(codexHome).filter((entry) => entry.endsWith(".config.toml"))).toHaveLength(1);
+    expect(profileName).toBe("fleet");
+    expect(readdirSync(codexHome).filter((entry) => entry.endsWith(".config.toml"))).toEqual(["fleet.config.toml"]);
     expect(indexOfSequence(injected.args, ["--enable", "hooks"])).toBeGreaterThanOrEqual(0);
-    expect(indexOfSequence(injected.args, ["--dangerously-bypass-hook-trust"])).toBeGreaterThanOrEqual(0);
+    expect(injected.args).not.toContain("--dangerously-bypass-hook-trust");
+    expect(toml).toContain("[features]\nhooks = true");
     expect(toml).toContain("[hooks]\n");
     expect(toml).toContain('UserPromptSubmit = [{ hooks = [{ type = "command", command = "\'/opt/fleet node\' \'console path.js\' \'hook\' \'capture-session\' \'codex\'" }] }]');
     expect(toml).not.toContain("args =");

--- a/runtime/fleet-cli/tests/agent-wiki-mcp.test.ts
+++ b/runtime/fleet-cli/tests/agent-wiki-mcp.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -46,8 +46,10 @@ const CHRONICLE_ONLY_WIKI_TOOL_IDS = [
   "wiki_compile_source",
   "wiki_query",
 ] as const;
-const CODEX_FLEET_PROFILE_MARKER = "# Fleet-managed Codex session profile";
-const FLEET_PROFILE_NAME_PATTERN = /^fleet-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const CODEX_FLEET_PROFILE_MARKER = "# Fleet-managed Codex profile";
+const CODEX_LEGACY_FLEET_PROFILE_MARKER = "# Fleet-managed Codex session profile";
+const FLEET_PROFILE_NAME = "fleet";
+const FLEET_PROFILE_FILE_NAME = `${FLEET_PROFILE_NAME}.config.toml`;
 const TEST_HOOK_ENTRY = {
   entryPath: "/opt/fleet/dist/index.js",
   execPath: "/opt/node/bin/node",
@@ -197,9 +199,9 @@ describe("fleet-cli agent CLI MCP registration", () => {
   it("registers Codex plugin through the resolved Codex CLI before launch args are returned", async () => {
     const rootDir = mkdtempSync(path.join(os.tmpdir(), "fleet-agent-root-"));
     const codexHome = mkdtempSync(path.join(os.tmpdir(), "fleet-codex-home-"));
-    const staleProfilePath = path.join(codexHome, "fleet-00000000-0000-4000-8000-000000000000.config.toml");
-    const freshProfilePath = path.join(codexHome, "fleet-00000000-0000-4000-8000-000000000001.config.toml");
-    const userFleetProfilePath = path.join(codexHome, "fleet.config.toml");
+    const legacyProfilePath = path.join(codexHome, "fleet-00000000-0000-4000-8000-000000000000.config.toml");
+    const legacyFreshProfilePath = path.join(codexHome, "fleet-00000000-0000-4000-8000-000000000001.config.toml");
+    const fleetProfilePath = path.join(codexHome, FLEET_PROFILE_FILE_NAME);
     const commands: string[] = [];
     const codexState = {
       installed: new Set<string>(),
@@ -207,11 +209,9 @@ describe("fleet-cli agent CLI MCP registration", () => {
     };
     const releaseSessionToken = vi.fn();
     try {
-      writeFileSync(staleProfilePath, `${CODEX_FLEET_PROFILE_MARKER}\nold = true\n`, { encoding: "utf8" });
-      writeFileSync(freshProfilePath, `${CODEX_FLEET_PROFILE_MARKER}\nfresh = true\n`, { encoding: "utf8" });
-      writeFileSync(userFleetProfilePath, "user = true\n", { encoding: "utf8" });
-      const staleMtime = new Date(Date.now() - (25 * 60 * 60 * 1000));
-      utimesSync(staleProfilePath, staleMtime, staleMtime);
+      writeFileSync(legacyProfilePath, `${CODEX_LEGACY_FLEET_PROFILE_MARKER}\nold = true\n`, { encoding: "utf8" });
+      writeFileSync(legacyFreshProfilePath, `${CODEX_LEGACY_FLEET_PROFILE_MARKER}\nfresh = true\n`, { encoding: "utf8" });
+      writeFileSync(fleetProfilePath, "user = true\n", { encoding: "utf8" });
       const profile = await injectAgentCliProfile({
         args: ["--no-alt-screen"],
         bin: "/usr/local/bin/codex",
@@ -227,28 +227,28 @@ describe("fleet-cli agent CLI MCP registration", () => {
           expect(command.bin).toBe("/usr/local/bin/codex");
           const line = command.args.join(" ");
           commands.push(line);
-	          if (line === "plugin marketplace list") {
-	            return {
-	              status: 0,
-	              stderr: "",
-	              stdout: codexState.marketplaceRoot === undefined ? "" : `fleet-harness ${codexState.marketplaceRoot}\n`,
-	            };
-	          }
+          if (line === "plugin marketplace list") {
+            return {
+              status: 0,
+              stderr: "",
+              stdout: codexState.marketplaceRoot === undefined ? "" : `fleet-harness ${codexState.marketplaceRoot}\n`,
+            };
+          }
           if (line.startsWith("plugin marketplace add ")) {
             codexState.marketplaceRoot = line.slice("plugin marketplace add ".length);
             return { status: 0, stderr: "", stdout: "" };
           }
           if (line === "plugin list") {
-	            return {
-	              status: 0,
-	              stderr: "",
-	              stdout: [...codexState.installed].map((pluginName) => `${pluginName}@fleet-harness  installed, enabled`).join("\n"),
-	            };
-	          }
-	          if (line.startsWith("plugin add ") && line.endsWith(" -m fleet-harness")) {
-	            codexState.installed.add(line.slice("plugin add ".length, line.length - " -m fleet-harness".length));
-	            return { status: 0, stderr: "", stdout: "" };
-	          }
+            return {
+              status: 0,
+              stderr: "",
+              stdout: [...codexState.installed].map((pluginName) => `${pluginName}@fleet-harness  installed, enabled`).join("\n"),
+            };
+          }
+          if (line.startsWith("plugin add ") && line.endsWith(" -m fleet-harness")) {
+            codexState.installed.add(line.slice("plugin add ".length, line.length - " -m fleet-harness".length));
+            return { status: 0, stderr: "", stdout: "" };
+          }
           return { status: 0, stderr: "", stdout: "" };
         },
         dataDir: rootDir,
@@ -264,37 +264,39 @@ describe("fleet-cli agent CLI MCP registration", () => {
       });
 
       expect(commands).toEqual([
-	        "plugin marketplace list",
-	        "plugin list",
-	        "plugin marketplace list",
-	        `plugin marketplace add ${path.join(rootDir, "marketplace")}`,
-	        "plugin list",
-	        "plugin add fleet -m fleet-harness",
-	      ]);
+        "plugin marketplace list",
+        "plugin list",
+        "plugin marketplace list",
+        `plugin marketplace add ${path.join(rootDir, "marketplace")}`,
+        "plugin list",
+        "plugin add fleet -m fleet-harness",
+      ]);
       expect(profile.args).toContain("--enable");
       // codex 0.142.0에서 제거된 기능 플래그라 인자에 포함되면 "Unknown feature flag"로 기동 실패한다.
       expect(profile.args).not.toContain("child_agents_md");
       expect(profile.args).toContain("--profile");
       const profileName = argValue(profile.args, "--profile");
-      expect(profileName).toMatch(FLEET_PROFILE_NAME_PATTERN);
-      const profilePath = path.join(codexHome, `${profileName}.config.toml`);
+      expect(profileName).toBe(FLEET_PROFILE_NAME);
       expect(profile.args).not.toContain("plugin_hooks");
-      expect(profile.args).toContain("--dangerously-bypass-hook-trust");
-      expect(readFileSync(profilePath, "utf8")).toBe([
+      expect(profile.args).not.toContain("--dangerously-bypass-hook-trust");
+      expect(readFileSync(fleetProfilePath, "utf8")).toBe([
         CODEX_FLEET_PROFILE_MARKER,
         'developer_instructions = """',
         "private fleet prompt",
         '"""',
         "",
+        "[features]",
+        "hooks = true",
+        "",
         '[plugins."fleet@fleet-harness"]',
         "enabled = true",
         "",
       ].join("\n"));
-      expect(existsSync(staleProfilePath)).toBe(false);
-      expect(existsSync(freshProfilePath)).toBe(true);
-      expect(existsSync(userFleetProfilePath)).toBe(true);
+      expect(existsSync(legacyProfilePath)).toBe(false);
+      expect(existsSync(legacyFreshProfilePath)).toBe(false);
+      expect(existsSync(fleetProfilePath)).toBe(true);
       profile.cleanup?.();
-      expect(existsSync(profilePath)).toBe(false);
+      expect(existsSync(fleetProfilePath)).toBe(true);
       expect(releaseSessionToken).toHaveBeenCalledTimes(1);
     } finally {
       rmSync(rootDir, { recursive: true, force: true });
@@ -302,7 +304,7 @@ describe("fleet-cli agent CLI MCP registration", () => {
     }
   });
 
-  it("enables every rendered Codex plugin in the Fleet session profile", async () => {
+  it("enables every rendered Codex plugin in the fixed Fleet profile", async () => {
     const rootDir = mkdtempSync(path.join(os.tmpdir(), "fleet-agent-root-"));
     const codexHome = mkdtempSync(path.join(os.tmpdir(), "fleet-codex-home-"));
     const cwd = mkdtempSync(path.join(os.tmpdir(), "fleet-project-cwd-"));
@@ -374,12 +376,15 @@ describe("fleet-cli agent CLI MCP registration", () => {
       ]);
       expect(codexState.installed).toEqual(new Set(["fleet@fleet-harness"]));
       const profileName = argValue(profile.args, "--profile");
-      expect(profileName).toMatch(FLEET_PROFILE_NAME_PATTERN);
-      expect(readFileSync(path.join(codexHome, `${profileName}.config.toml`), "utf8")).toBe([
+      expect(profileName).toBe(FLEET_PROFILE_NAME);
+      expect(readFileSync(path.join(codexHome, FLEET_PROFILE_FILE_NAME), "utf8")).toBe([
         CODEX_FLEET_PROFILE_MARKER,
         'developer_instructions = """',
         "private fleet prompt",
         '"""',
+        "",
+        "[features]",
+        "hooks = true",
         "",
         '[plugins."fleet@fleet-harness"]',
         "enabled = true",
@@ -423,13 +428,16 @@ describe("fleet-cli agent CLI MCP registration", () => {
 
       expect(profile.args).not.toContain("child_agents_md");
       const profileName = argValue(profile.args, "--profile");
-      expect(profileName).toMatch(FLEET_PROFILE_NAME_PATTERN);
-      const profilePath = path.join(codexHome, `${profileName}.config.toml`);
+      expect(profileName).toBe(FLEET_PROFILE_NAME);
+      const profilePath = path.join(codexHome, FLEET_PROFILE_FILE_NAME);
       expect(readFileSync(profilePath, "utf8")).toBe([
         CODEX_FLEET_PROFILE_MARKER,
         'developer_instructions = """',
         "private fleet prompt",
         '"""',
+        "",
+        "[features]",
+        "hooks = true",
         "",
         '[plugins."fleet@fleet-harness"]',
         "enabled = true",
@@ -438,7 +446,7 @@ describe("fleet-cli agent CLI MCP registration", () => {
       expect(profile.launchWarnings?.[0]).toContain("codex plugin marketplace list failed");
       expect(profile.launchWarnings?.[0]).toContain("codex plugin exploded");
       profile.cleanup?.();
-      expect(existsSync(profilePath)).toBe(false);
+      expect(existsSync(profilePath)).toBe(true);
     } finally {
       rmSync(rootDir, { recursive: true, force: true });
       rmSync(codexHome, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Replaces session-scoped Codex Fleet profile files with the fixed `fleet.config.toml` profile.
- Enables Codex hooks through `[features] hooks = true` while removing `--dangerously-bypass-hook-trust`.
- Keeps Codex plugin rendering and registration active, with tests updated for the LWW profile behavior.

## Type of Change
- [x] fix — bug fix
- [ ] feat — new feature or carrier capability
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope
- [x] `extensions/fleet` (Admiral / Bridge / Carriers)
- [x] `runtime/fleet-cli`
- [ ] Documentation (README / SETUP / AGENTS.md)

## Test Plan
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `git diff --check`
- [x] `pnpm --filter @dotobokuri/fleet-cli build` (boundary guard passed; stopped at missing `tsc` because this worktree has no `node_modules`)
- [ ] `pnpm --filter @dotobokuri/fleet-admiral typecheck` (blocked: `tsc` not found because this worktree has no `node_modules`)
- [ ] `pnpm --filter @dotobokuri/fleet-admiral exec vitest run tests/agent-cli-session-resume.test.ts` (blocked: `vitest` not found because this worktree has no `node_modules`)
- [ ] `pnpm --filter @dotobokuri/fleet-cli exec vitest run tests/agent-wiki-mcp.test.ts` (blocked: `vitest` not found because this worktree has no `node_modules`)

## Changelog
- [x] Added one `.changelog.d/*.md` fragment, or applied the `no-changelog` label intentionally.
- [x] Fragment `section:` is one of `Added`, `Changed`, `Fixed`, `Removed`, or `Breaking Changes`.
- [x] Fragment bullets are English and use only `[core-agent]`, `[core-unified-agent]`, `[fleet-infra]`, `[fleet-admiral]`, `[fleet-carriers]`, `[fleet-wiki]`, `[fleet-console]`, or `[fleet-cli]`.

## Notes for Reviewers
- Sentinel reviewed the change and reported PASS with no Critical, High, or Medium findings.
- The fixed `fleet.config.toml` profile is intentionally persistent; cleanup no longer deletes it after Codex exit.