### PR TITLE
feat(fleet-console): compact stream dock into signal strip

### DIFF
--- a/.changelog.d/stream-dock-signal-strip.md
+++ b/.changelog.d/stream-dock-signal-strip.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- [fleet-console] Compacted the Agent panel carrier stream dock into a single-row signal strip (live pulse, carrier name, latest output line, elapsed time, and token estimate in one line) that expands to one compact row per track; the duplicated carrier name, redundant live badges, and the large fixed dead space below the stream are removed, and multi-carrier tracks now show captain-colored names.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4951,10 +4951,13 @@
   overflow: hidden;
 }
 
-/* 행 이름: 멀티잡=캡틴색, 단일잡+멀티트랙=무채색, 단일잡+단일트랙=생략 */
+/* 행 이름: 멀티잡=캡틴색, 단일잡+멀티트랙=무채색, 단일잡+단일트랙=생략 — 긴 이름은 잘라 상태·라인을 보호 */
 .job-dock-row-name {
   flex: none;
+  max-width: 12em;
+  overflow: hidden;
   white-space: nowrap;
+  text-overflow: ellipsis;
   font-family: var(--font-display);
   font-size: 11px;
   font-weight: 600;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4807,13 +4807,13 @@
   background: color-mix(in oklch, var(--carrier-taskforce) 6%, var(--surface-glass));
 }
 
-/* 헤더: 라이브 도트 · 캐리어명 · 경과 · 토큰 · 접기 그립 · 상세 버튼 */
-.job-dock-header {
+/* 스트립: 기본 상태 단일 행 계기판 — 펄스닷 · 캐리어명 · 최신 라인 · meta · 그립 · Details */
+.job-dock-strip {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-2) var(--space-3);
-  min-height: 32px;
+  padding: var(--space-1) var(--space-3);
+  min-height: 30px;
 }
 
 /* aurora 라이브 펄스닷 */
@@ -4832,9 +4832,10 @@
   }
 }
 
+/* 캐리어명: 스트립 고정폭(flex: none), 캡틴색 적용 대상 — 긴 이름은 잘라 우측 컨트롤을 보호 */
 .job-dock-carrier {
-  flex: 1;
-  min-width: 0;
+  flex: none;
+  max-width: 12em;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -4853,6 +4854,18 @@
 .job-dock-carrier[data-captain="vanguard"] { color: var(--captain-vanguard); }
 .job-dock-carrier[data-captain="tempest"] { color: var(--captain-tempest); }
 .job-dock-carrier[data-captain="chronicle"] { color: var(--captain-chronicle); }
+
+/* 스트립 최신 라인: 가변폭 ellipsis, 접힘 상태에서만 가시 */
+.job-dock-strip-line {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-spectral);
+}
 
 .job-dock-meta {
   flex: none;
@@ -4905,29 +4918,6 @@
   background: color-mix(in oklch, var(--brass) 10%, transparent);
 }
 
-/* 요청 라벨: 헤더 아래 1줄 ellipsis, 단일 잡에서만 렌더됨 */
-.job-dock-label {
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  line-height: 1.5;
-  color: var(--ink-fog);
-  padding: 0 var(--space-3) var(--space-1);
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-/* 테일: 접힘 상태의 최신 출력 1줄 */
-.job-dock-tail {
-  padding: 0 var(--space-3) var(--space-2);
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  color: var(--ink-fog);
-}
-
 /* 바디 래퍼: follow-button 위치 기준(position: relative) */
 .job-dock-body-wrap {
   position: relative;
@@ -4938,42 +4928,51 @@
   display: none;
 }
 
-/* 바디: 스크롤 가능한 트랙 스택 */
+/* 바디: 스크롤 가능한 트랙 행 스택, 하단 고정 여백 제거 */
 .job-dock-body {
   overflow-y: auto;
-  max-height: 240px;
-  padding: var(--space-2) var(--space-3) var(--space-12);
+  max-height: 200px;
+  padding: var(--space-1) var(--space-3) var(--space-2);
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
 }
 
-/* 트랙 행: 컴팩트 뷰 */
-.job-dock-track {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
+/* follow 버튼 도크 스코프 오버라이드 — 바디 상하 여백에 맞게 위치 조정 */
+.job-dock-body-wrap .follow-button {
+  bottom: var(--space-2);
 }
 
-.job-dock-track-head {
+/* 트랙 행: 단일 flex 행 — [이름(조건부)] + 상태 + 최신 라인 */
+.job-dock-row {
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  min-height: 22px;
+  overflow: hidden;
 }
 
-.job-dock-track-name {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
+/* 행 이름: 멀티잡=캡틴색, 단일잡+멀티트랙=무채색, 단일잡+단일트랙=생략 */
+.job-dock-row-name {
+  flex: none;
   white-space: nowrap;
-  text-overflow: ellipsis;
   font-family: var(--font-display);
-  font-size: 11.5px;
+  font-size: 11px;
   font-weight: 600;
   color: var(--ink-spectral);
 }
 
-.job-dock-track-status {
+/* 캡틴 고유색 — 멀티잡 캐리어 식별용, 행 이름 텍스트 채널 */
+.job-dock-row-name[data-captain="nimitz"] { color: var(--captain-nimitz); }
+.job-dock-row-name[data-captain="kirov"] { color: var(--captain-kirov); }
+.job-dock-row-name[data-captain="genesis"] { color: var(--captain-genesis); }
+.job-dock-row-name[data-captain="ohio"] { color: var(--captain-ohio); }
+.job-dock-row-name[data-captain="sentinel"] { color: var(--captain-sentinel); }
+.job-dock-row-name[data-captain="vanguard"] { color: var(--captain-vanguard); }
+.job-dock-row-name[data-captain="tempest"] { color: var(--captain-tempest); }
+.job-dock-row-name[data-captain="chronicle"] { color: var(--captain-chronicle); }
+
+/* 행 상태: 9.5px mono uppercase, 라이브 시 aurora */
+.job-dock-row-status {
   flex: none;
   font-family: var(--font-mono);
   font-size: 9.5px;
@@ -4981,31 +4980,40 @@
   color: var(--ink-fog);
   letter-spacing: 0.06em;
   text-transform: uppercase;
+  white-space: nowrap;
 }
 
-.job-dock-track-status--live {
+.job-dock-row-status--live {
   color: var(--aurora);
 }
 
-/* 사고: dim 단일 행 */
-.job-dock-track-thought {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  color: var(--ink-fog);
-  opacity: 0.65;
-}
-
-/* 출력: mono 단일 행 + aurora 캐럿 */
-.job-dock-track-text {
+/* 행 최신 라인: 가변폭 ellipsis + aurora 캐럿 */
+.job-dock-row-line {
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
   font-family: var(--font-mono);
   font-size: 11px;
   color: var(--ink-spectral);
+}
+
+/* thought 라인: 텍스트 없을 때 디밍 */
+.job-dock-row-line.is-thought {
+  opacity: 0.65;
+}
+
+/* 요청 라벨: 단일 잡 펼침 첫 행, 디밍 mono 10.5px */
+.job-dock-row-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--ink-fog);
 }
 
 /* aurora 스트림 캐럿 */
@@ -5028,28 +5036,6 @@
   .job-dock-detail-btn {
     transition: none;
   }
-}
-
-/* 툴 칩 목록 */
-.job-dock-tools {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-1);
-}
-
-.job-dock-tool-chip {
-  padding: 1px var(--space-2);
-  border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-xs);
-  font-family: var(--font-mono);
-  font-size: 9.5px;
-  color: var(--ink-fog);
-}
-
-/* running 툴 칩: aurora 테두리 */
-.job-dock-tool-chip--live {
-  border-color: color-mix(in oklch, var(--aurora) 45%, var(--surface-rim));
-  color: var(--aurora);
 }
 
 .follow-button {

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -42,6 +42,13 @@ interface RendererOption {
   readonly label: string;
 }
 
+interface DockRowProps {
+  readonly track: TrackView;
+  readonly job: JobView;
+  readonly multiJob: boolean;
+  readonly singleTrack: boolean;
+}
+
 interface PinnedScrollLocal {
   readonly containerRef: React.RefObject<HTMLDivElement | null>;
   readonly pinned: boolean;
@@ -55,7 +62,9 @@ const RENDERERS: readonly RendererOption[] = [
 
 const AGENT_TICKET_PATH = "/plugins/terminal/agent/ticket";
 const TERMINAL_WS_PATH = "/plugins/terminal/ws";
-const DOCK_COLLAPSED_KEY = "fleet-plugin.terminal.stream-dock-collapsed";
+const DOCK_EXPANDED_KEY = "fleet-plugin.terminal.stream-dock-expanded";
+// Signal Strip 개편 이전 접힘 키 — 신규 코드는 읽지 않으며 초기화 시 1회 제거만 한다.
+const LEGACY_DOCK_COLLAPSED_KEY = "fleet-plugin.terminal.stream-dock-collapsed";
 const PIN_SLACK_PX = 56;
 
 export const agentOperationKind = defineOperationKind({
@@ -164,29 +173,31 @@ function usePinnedScrollLocal(resetKey: unknown, contentKey: unknown): PinnedScr
   return { containerRef, pinned, jumpToLatest };
 }
 
-function useDockCollapsed(): [boolean, (next: boolean) => void] {
-  const [collapsed, setCollapsedState] = React.useState(() => {
+function useDockExpanded(): [boolean, (next: boolean) => void] {
+  // 기본값 접힘(false). 펼치면 "true" 저장, 접으면 키 제거.
+  const [expanded, setExpandedState] = React.useState(() => {
     try {
-      return localStorage.getItem(DOCK_COLLAPSED_KEY) === "true";
+      localStorage.removeItem(LEGACY_DOCK_COLLAPSED_KEY);
+      return localStorage.getItem(DOCK_EXPANDED_KEY) === "true";
     } catch {
       return false;
     }
   });
 
-  const setCollapsed = React.useCallback((next: boolean) => {
+  const setExpanded = React.useCallback((next: boolean) => {
     try {
       if (next) {
-        localStorage.setItem(DOCK_COLLAPSED_KEY, "true");
+        localStorage.setItem(DOCK_EXPANDED_KEY, "true");
       } else {
-        localStorage.removeItem(DOCK_COLLAPSED_KEY);
+        localStorage.removeItem(DOCK_EXPANDED_KEY);
       }
     } catch {
       // localStorage 비가용 환경 무시
     }
-    setCollapsedState(next);
+    setExpandedState(next);
   }, []);
 
-  return [collapsed, setCollapsed];
+  return [expanded, setExpanded];
 }
 
 function useElapsed(startedAt: number | undefined): string {
@@ -309,7 +320,7 @@ function StreamDock({
   readonly onOpenDetail: () => void;
   readonly detailBtnRef?: React.RefObject<HTMLButtonElement | null>;
 }) {
-  const [collapsed, setCollapsed] = useDockCollapsed();
+  const [expanded, setExpanded] = useDockExpanded();
   const primaryJob = activeJobs[0];
   const elapsed = useElapsed(primaryJob?.startedAt);
   const totalTokens = activeJobs.reduce((sum, job) => sum + estimateJobTokens(job), 0);
@@ -325,14 +336,26 @@ function StreamDock({
 
   const tailText = getDockTailText(activeJobs);
   const contentKey = activeJobs.map((j) => `${j.jobId}:${j.lastEventId}`).join(",");
-  const resetKey = `${!collapsed}:${activeJobs.map((j) => j.jobId).join(",")}`;
+  const resetKey = `${expanded}:${activeJobs.map((j) => j.jobId).join(",")}`;
   const { containerRef, pinned, jumpToLatest } = usePinnedScrollLocal(resetKey, contentKey);
+
+  // 스트립 라인 라이브 캐럿: 활성 트랙 중 하나라도 라이브면 표시
+  const stripIsLive = activeJobs.some((job) =>
+    job.trackOrder.some((id) => {
+      const t = job.tracks[id];
+      return t ? isTrackLive(t.status) : false;
+    })
+  );
 
   return (
     <div className="job-dock" data-signature={sig}>
-      <div className="job-dock-header">
+      <div className="job-dock-strip">
         <span className="job-dock-dot" aria-hidden="true" />
-        <span className="job-dock-carrier" data-captain={captain}>{carrierLabel}</span>
+        <span className="job-dock-carrier" data-captain={captain} title={jobLabel}>{carrierLabel}</span>
+        <span className="job-dock-strip-line" style={expanded ? { display: "none" } : undefined} aria-hidden="true">
+          {tailText}
+          {!expanded && stripIsLive && tailText ? <span className="job-dock-caret" aria-hidden="true" /> : null}
+        </span>
         <span className="job-dock-meta">
           {elapsed ? <span>{elapsed}</span> : null}
           {tokenLabel ? <span>{tokenLabel}</span> : null}
@@ -340,11 +363,11 @@ function StreamDock({
         <button
           type="button"
           className="job-dock-grip"
-          aria-label={collapsed ? "Expand stream dock" : "Collapse stream dock"}
-          aria-expanded={!collapsed}
-          onClick={() => setCollapsed(!collapsed)}
+          aria-label={expanded ? "Collapse stream dock" : "Expand stream dock"}
+          aria-expanded={expanded}
+          onClick={() => setExpanded(!expanded)}
         >
-          {collapsed ? "▲" : "▼"}
+          {expanded ? "▼" : "▲"}
         </button>
         <button
           ref={detailBtnRef}
@@ -355,18 +378,29 @@ function StreamDock({
           Details
         </button>
       </div>
-      {jobLabel ? <div className="job-dock-label" title={jobLabel}>{jobLabel}</div> : null}
-      {collapsed ? (
-        tailText ? <div className="job-dock-tail" aria-hidden="true">{tailText}</div> : null
-      ) : null}
-      <div className={`job-dock-body-wrap${collapsed ? " is-collapsed" : ""}`}>
+      <div className={`job-dock-body-wrap${expanded ? "" : " is-collapsed"}`}>
         <div ref={containerRef} className="job-dock-body" tabIndex={-1}>
-          {activeJobs.map((job) =>
-            job.trackOrder.map((trackId) => {
+          {activeJobs.length === 1 && jobLabel ? (
+            <div className="job-dock-row">
+              <span className="job-dock-row-label">{jobLabel}</span>
+            </div>
+          ) : null}
+          {activeJobs.map((job) => {
+            const multiJob = activeJobs.length > 1;
+            const singleTrack = !multiJob && job.trackOrder.length === 1;
+            return job.trackOrder.map((trackId) => {
               const track = job.tracks[trackId];
-              return track ? <DockTrackRow key={`${job.jobId}:${trackId}`} track={track} /> : null;
-            })
-          )}
+              return track ? (
+                <DockRow
+                  key={`${job.jobId}:${trackId}`}
+                  track={track}
+                  job={job}
+                  multiJob={multiJob}
+                  singleTrack={singleTrack}
+                />
+              ) : null;
+            });
+          })}
         </div>
         {!pinned ? (
           <button type="button" className="follow-button" onClick={jumpToLatest}>
@@ -378,42 +412,31 @@ function StreamDock({
   );
 }
 
-function DockTrackRow({ track }: { readonly track: TrackView }) {
-  const isLive = trackCardModifier(track.status) === "track-card--live";
+function DockRow({ track, job, multiJob, singleTrack }: DockRowProps) {
+  const isLive = isTrackLive(track.status);
   const tailOutput = getLastLine(track.text);
   const tailThought = getLastLine(track.thought);
+  const displayLine = tailOutput || tailThought;
+  const isThought = !tailOutput && Boolean(tailThought);
+  const activeTool = isLive ? getActiveToolName(track) : undefined;
+
+  // 멀티잡=캡틴색, 단일잡+멀티트랙=무채색, 단일잡+단일트랙=생략
+  const showName = multiJob || !singleTrack;
+  const nameCaptain = multiJob ? resolveCarrierCaptain(job.ownerCarrierId) : undefined;
+
   return (
-    <div className="job-dock-track">
-      <div className="job-dock-track-head">
-        <span className="job-dock-track-name">{track.displayName}</span>
-        <span className={`job-dock-track-status${isLive ? " job-dock-track-status--live" : ""}`}>
-          {track.status}
-        </span>
-      </div>
-      {!tailOutput && tailThought ? (
-        <div className="job-dock-track-thought" aria-label="Thinking">{tailThought}</div>
+    <div className="job-dock-row">
+      {showName ? (
+        <span className="job-dock-row-name" data-captain={nameCaptain}>{track.displayName}</span>
       ) : null}
-      {tailOutput ? (
-        <div className="job-dock-track-text">
-          {tailOutput}
+      <span className={`job-dock-row-status${isLive ? " job-dock-row-status--live" : ""}`}>
+        {track.status}{activeTool ? ` · ${activeTool}` : ""}
+      </span>
+      {displayLine ? (
+        <span className={`job-dock-row-line${isThought ? " is-thought" : ""}`}>
+          {displayLine}
           {isLive ? <span className="job-dock-caret" aria-hidden="true" /> : null}
-        </div>
-      ) : null}
-      {track.tools.length > 0 ? (
-        <div className="job-dock-tools">
-          {track.tools.map((tool) => {
-            const isDone = tool.status === "completed" || tool.status === "failed" || tool.status === "error";
-            const chipLive = isLive && !isDone;
-            return (
-              <span
-                key={tool.id}
-                className={`job-dock-tool-chip${chipLive ? " job-dock-tool-chip--live" : ""}`}
-              >
-                {tool.name ?? tool.id}
-              </span>
-            );
-          })}
-        </div>
+        </span>
       ) : null}
     </div>
   );
@@ -614,6 +637,17 @@ function readPayloadNumber(payload: Record<string, unknown>, key: string): numbe
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
+function isTrackLive(status: string): boolean {
+  return status === "stream" || status === "live" || status === "running" || status === "active";
+}
+
+function getActiveToolName(track: TrackView): string | undefined {
+  const tool = track.tools.find(
+    (t) => t.status !== "completed" && t.status !== "failed" && t.status !== "error"
+  );
+  return tool ? (tool.name ?? tool.id) : undefined;
+}
+
 function getDockTailText(activeJobs: readonly JobView[]): string {
   // 모든 활성 트랙을 트랙별 lastEventId(전역 단조 증가) 최신순으로 정렬해, 가장 최근 활동 트랙의
   // latestLine(리듀서가 text/thought 델타 중 가장 최근 것으로 갱신)을 접힘 테일로 고른다.
@@ -789,7 +823,8 @@ function terminalFontResolveText(font: TerminalFontSettings): string {
 }
 
 function trackCardModifier(status: string): string {
-  if (status === "stream" || status === "live" || status === "running" || status === "active") {
+  // 라이브 판정은 isTrackLive 단일 소유 — 도크 행/스트립 캐럿과 판정이 갈라지지 않게 위임한다.
+  if (isTrackLive(status)) {
     return "track-card--live";
   }
   if (status === "error") return "track-card--bad";


### PR DESCRIPTION
## Summary

Agent 패널 상주 캐리어 스트림 도크(PR #166)를 단일행 Signal Strip으로 재설계합니다. 기본 상태가 ~31px 한 행(라이브 펄스 + 캐리어명 + 최신 출력 라인 + 경과·토큰 + 컨트롤)으로 응축되고, 펼치면 트랙당 1행씩 늘어납니다. 실측 기준 기본 82.5→31px(−62%), 펼침 154→88px(−43%), 하단 고정 여백 48→8px.

- 정보 중복 제거: 캐리어명 2회 표기(헤더+트랙헤드) → 1회, 라이브 신호 3중(펄스닷·STREAM 배지·캐럿) → 2채널(펄스닷+캐럿)
- 요청 라벨은 캐리어명 툴팁 + 펼침 첫 행으로 이동, 툴칩 행은 status 뒤 " · tool" 접미로 대체(전체 툴 이력은 Details 모달 유지)
- 멀티 캐리어 잡은 트랙 행 이름에 캡틴색 적용(기존엔 전부 무채색) — 식별성 향상
- 접힘 영속 키를 `stream-dock-expanded`로 전환(기본=접힘 스트립), 구 키는 초기화 시 1회 정리
- 채널 불가침 유지: 캡틴색=이름 텍스트만, CLI 시그니처=rim/bg만, aurora=라이브 전용, prefers-reduced-motion 단락 보존

## Type of Change

- [x] feat — new feature or carrier capability

## Scope

- [x] `runtime/fleet-plugins/terminal` (Agent panel StreamDock)
- [x] `runtime/fleet-console` (components.css job-dock block)

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 49 files, 505 passed / 22 skipped
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 12 entries OK
- [x] 실브라우저 픽셀 하버스(실 theme.css/components.css 임포트): 기본 31px · 펼침 88px(하단 여백 8px) · 3캐리어 110px, 캡틴색/시그니처 채널 렌더 확인
- [x] Sentinel 코드 리뷰 PASS (Critical/High 0; Medium 1은 설계 의도로 기각 — follow-button은 unpinned 전용 오버레이, Low 3건 반영)

## Changelog

- [x] Added one `.changelog.d/*.md` fragment, or applied the `no-changelog` label intentionally.
- [x] Fragment `section:` is one of `Added`, `Changed`, `Fixed`, `Removed`, or `Breaking Changes`.
- [x] Fragment bullets are English and use only `[core-agent]`, `[core-unified-agent]`, `[fleet-infra]`, `[fleet-admiral]`, `[fleet-carriers]`, `[fleet-wiki]`, `[fleet-console]`, or `[fleet-cli]`.

## Related Issues / PRs

- References #166 (resident stream dock 원 구현 — 본 PR은 그 후속 컴팩트화)

## Notes for Reviewers

- 펼침 시 follow-button이 스크롤 업 상태에서 마지막 행 우측을 부분적으로 덮는 것은 의도된 오버레이 패턴입니다(버튼은 unpinned 상태에서만 렌더되고 도크 행은 비인터랙티브). 48px 상시 하단 예약 제거가 이번 개편의 핵심 목표입니다.
- Details 모달·reducer·서버/SSE 계약은 의도적으로 무변입니다.