### PR TITLE
fix(fleet-admiral): preserve Codex hook trust state

### DIFF
--- a/.changelog.d/codex-hook-trust-state.md
+++ b/.changelog.d/codex-hook-trust-state.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- [fleet-admiral][fleet-cli] Fleet Codex profile rewrites now preserve persisted hook trust state for unchanged hooks.

--- a/packages/fleet-admiral/src/agent-cli/injection.ts
+++ b/packages/fleet-admiral/src/agent-cli/injection.ts
@@ -253,6 +253,7 @@ function writeCodexFleetProfile(
   pruneLegacyCodexFleetProfiles(codexHome);
   const profileName = CODEX_FLEET_PROFILE_NAME;
   const profilePath = path.join(codexHome, CODEX_FLEET_PROFILE_FILE_NAME);
+  const hookTrustState = readCodexFleetHookTrustState(profilePath);
   writeFileNoFollow(profilePath, [
     CODEX_FLEET_PROFILE_MARKER,
     // doctrine를 멀티라인 TOML 문자열로 직렬화해 실제 줄바꿈을 보존(pretty)한다.
@@ -270,6 +271,7 @@ function writeCodexFleetProfile(
       "",
     ]),
     ...codexHooksConfig(hookExecs),
+    ...hookTrustState,
   ].join("\n"));
   chmodBestEffort(profilePath, SYSTEM_PROMPT_FILE_MODE);
   return { profileName, profilePath };
@@ -311,6 +313,51 @@ function writeFileNoFollow(filePath: string, content: string): void {
   } finally {
     closeSync(fd);
   }
+}
+
+function readCodexFleetHookTrustState(profilePath: string): string[] {
+  try {
+    const content = readFileNoFollow(profilePath);
+    if ((content.split(/\r?\n/, 1)[0] ?? "") !== CODEX_FLEET_PROFILE_MARKER) return [];
+    return extractCodexHookTrustStateSections(content);
+  } catch {
+    return [];
+  }
+}
+
+function readFileNoFollow(filePath: string): string {
+  const fd = openSync(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    return readFileSync(fd, "utf8");
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function extractCodexHookTrustStateSections(content: string): string[] {
+  const sections: string[] = [];
+  let current: string[] | undefined;
+  for (const line of content.split(/\r?\n/)) {
+    if (/^\[hooks\.state\./.test(line)) {
+      if (current !== undefined) pushCodexHookTrustStateSection(sections, current);
+      current = [line];
+      continue;
+    }
+    if (current === undefined) continue;
+    if (/^\s*\[/.test(line)) {
+      pushCodexHookTrustStateSection(sections, current);
+      current = undefined;
+      continue;
+    }
+    current.push(line);
+  }
+  if (current !== undefined) pushCodexHookTrustStateSection(sections, current);
+  return sections;
+}
+
+function pushCodexHookTrustStateSection(sections: string[], section: readonly string[]): void {
+  sections.push(...section);
+  if (section[section.length - 1] !== "") sections.push("");
 }
 
 function pruneLegacyCodexFleetProfiles(codexHome: string): void {

--- a/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -35,6 +35,7 @@ interface CodexPluginManifest {
 }
 
 const tempDirs: string[] = [];
+const CODEX_FLEET_PROFILE_MARKER = "# Fleet-managed Codex profile";
 
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
@@ -191,6 +192,76 @@ describe("agent CLI session resume and capture hooks", () => {
     expect(pluginJson.version).toMatch(/^0\.0\.0\+[0-9a-f]{12}$/);
     expect(toml).not.toContain("SessionStart =");
     expect(toml).not.toContain("subagents-context");
+  });
+
+  it("preserves Codex hook trust state while rewriting the fixed Fleet profile", async () => {
+    const root = createTempRoot("fleet-admiral-codex-trust-state-");
+    const codexHome = path.join(root, "codex-home");
+    const profilePath = path.join(codexHome, "fleet.config.toml");
+    mkdirSync(codexHome, { recursive: true });
+    writeFileSync(profilePath, [
+      CODEX_FLEET_PROFILE_MARKER,
+      'developer_instructions = """',
+      "old doctrine",
+      '"""',
+      "",
+      '[hooks.state."/Users/sbluemin/.codex/fleet.config.toml:user_prompt_submit:0:0"]',
+      'trusted_hash = "sha256:user-prompt-submit"',
+      "",
+      '[plugins."stale@marketplace"]',
+      "enabled = true",
+      "",
+      '[hooks.state."/Users/sbluemin/.codex/fleet.config.toml:stop:0:0"]',
+      'trusted_hash = "sha256:stop"',
+      "",
+    ].join("\n"), { encoding: "utf8" });
+    const profile = baseProfile("codex", {
+      args: ["--no-alt-screen"],
+      cwd: root,
+      env: { CODEX_HOME: codexHome, HOME: root },
+    });
+
+    await injectAgentCliProfile(profile, baseInjectOptions(root, {
+      captureSessionHookExec: hookExec("node", ["console.js", "hook", "capture-session", "codex"]),
+    }));
+    const toml = readFileSync(profilePath, "utf8");
+
+    expect(toml).toContain("[hooks]\n");
+    expect(toml).toContain("[hooks.state.\"/Users/sbluemin/.codex/fleet.config.toml:user_prompt_submit:0:0\"]");
+    expect(toml).toContain('trusted_hash = "sha256:user-prompt-submit"');
+    expect(toml).toContain("[hooks.state.\"/Users/sbluemin/.codex/fleet.config.toml:stop:0:0\"]");
+    expect(toml).toContain('trusted_hash = "sha256:stop"');
+    expect(toml).not.toContain('[plugins."stale@marketplace"]');
+  });
+
+  it("does not preserve hook trust state from a non-Fleet fixed profile", async () => {
+    const root = createTempRoot("fleet-admiral-codex-user-profile-");
+    const codexHome = path.join(root, "codex-home");
+    const profilePath = path.join(codexHome, "fleet.config.toml");
+    mkdirSync(codexHome, { recursive: true });
+    writeFileSync(profilePath, [
+      "# User-managed Codex profile",
+      "[features]",
+      "hooks = true",
+      "",
+      '[hooks.state."/Users/sbluemin/.codex/fleet.config.toml:user_prompt_submit:0:0"]',
+      'trusted_hash = "sha256:user-managed"',
+      "",
+    ].join("\n"), { encoding: "utf8" });
+    const profile = baseProfile("codex", {
+      args: ["--no-alt-screen"],
+      cwd: root,
+      env: { CODEX_HOME: codexHome, HOME: root },
+    });
+
+    await injectAgentCliProfile(profile, baseInjectOptions(root, {
+      captureSessionHookExec: hookExec("node", ["console.js", "hook", "capture-session", "codex"]),
+    }));
+    const toml = readFileSync(profilePath, "utf8");
+
+    expect(toml.startsWith(CODEX_FLEET_PROFILE_MARKER)).toBe(true);
+    expect(toml).not.toContain("[hooks.state.");
+    expect(toml).not.toContain("trusted_hash");
   });
 });
 


### PR DESCRIPTION
## Summary
- Preserve Codex `[hooks.state.*]` trust records when Fleet rewrites its managed fixed profile.
- Ignore trust state from non-Fleet profiles and avoid carrying stale plugin config across rewrites.
- Add regression coverage for preserved Fleet trust state and rejected user-managed trust state.

## Type of Change
- [ ] feat - new feature or carrier capability
- [x] fix - bug fix
- [ ] docs - documentation only
- [ ] refactor - no behavior change
- [ ] chore - build, tooling, deps
- [ ] BREAKING CHANGE

## Scope
- [x] `extensions/fleet` (Admiral / Bridge / Carriers)
- [ ] Documentation (README / SETUP / AGENTS.md)

## Test Plan
- [x] `git diff --check`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [ ] `pnpm --filter @dotobokuri/fleet-admiral exec vitest run tests/agent-cli-session-resume.test.ts` - blocked in this worktree because workspace dependency links are unavailable (`@dotobokuri/fleet-carriers` cannot be resolved).
- [ ] `pnpm --filter @dotobokuri/fleet-admiral typecheck` - blocked in this worktree because workspace dependencies and dev tools (`@dotobokuri/fleet-carriers`, `@dotobokuri/core-agent`, `vitest`, `tsup`) cannot be resolved.

## Changelog
- [x] Added one `.changelog.d/*.md` fragment, or applied the `no-changelog` label intentionally.
- [x] Fragment `section:` is one of `Added`, `Changed`, `Fixed`, `Removed`, or `Breaking Changes`.
- [x] Fragment bullets are English and use only `[core-agent]`, `[core-unified-agent]`, `[fleet-infra]`, `[fleet-admiral]`, `[fleet-carriers]`, `[fleet-wiki]`, `[fleet-console]`, or `[fleet-cli]`.

## Related Issues / PRs

## Notes for Reviewers
- The preserved trust records are restricted to existing Fleet-managed profiles by the Fleet profile marker.
- The file read uses no-follow semantics so a symlinked fixed profile is not trusted as an input source.