### PR TITLE
feat(agent-cli): add Cursor Agent runtime

### DIFF
--- a/.changelog.d/cursor-agent-runtime.md
+++ b/.changelog.d/cursor-agent-runtime.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- [fleet-admiral][fleet-cli][fleet-console] Cursor Agent can now be launched as a first-class Agent CLI runtime with Fleet plugin, hook, MCP, and session-capture support.

--- a/packages/fleet-admiral/src/agent-cli/builders/cursor.ts
+++ b/packages/fleet-admiral/src/agent-cli/builders/cursor.ts
@@ -1,0 +1,19 @@
+import type { AgentCliInjectionContext } from "../types.js";
+
+export function buildCursorNativeArgs(context: AgentCliInjectionContext): string[] {
+  return [
+    ...buildResumeArgs(context.resumeSessionId),
+    ...context.pluginRoots.flatMap((pluginRoot) => [
+      "--plugin-dir",
+      pluginRoot,
+    ]),
+    "--sandbox",
+    "disabled",
+    "--force",
+    ...(context.mcpServers.length > 0 ? ["--approve-mcps"] : []),
+  ];
+}
+
+function buildResumeArgs(resumeSessionId: string | undefined): string[] {
+  return resumeSessionId === undefined ? [] : ["--resume", resumeSessionId];
+}

--- a/packages/fleet-admiral/src/agent-cli/builders/toml.ts
+++ b/packages/fleet-admiral/src/agent-cli/builders/toml.ts
@@ -1,3 +1,5 @@
+import process from "node:process";
+
 const TOML_BASIC_STRING_ESCAPE_PATTERN = /[\u0000-\u001f"\\\u007f]/g;
 
 // 멀티라인 basic string에서는 LF(\n)와 탭(\t)만 리터럴로 보존하고, 그 외 제어문자와
@@ -5,7 +7,6 @@ const TOML_BASIC_STRING_ESCAPE_PATTERN = /[\u0000-\u001f"\\\u007f]/g;
 // 깨뜨리고 CRLF가 LF로 정규화되어 원문 round-trip이 어긋나므로 이스케이프 대상에 포함한다.
 const TOML_MULTILINE_CONTROL_PATTERN = new RegExp("[\\u0000-\\u0008\\u000b-\\u001f\\u007f]", "g");
 const TOML_MULTILINE_QUOTE_RUN_PATTERN = /"+/g;
-
 export function escapeTomlBasicString(value: string): string {
   return value.replace(TOML_BASIC_STRING_ESCAPE_PATTERN, (char) => {
     switch (char) {
@@ -56,6 +57,15 @@ export function buildPosixShellCommand(values: readonly string[]): string {
   return values.map(posixShellQuote).join(" ");
 }
 
+export function buildHostShellCommand(values: readonly string[], platform: NodeJS.Platform = process.platform): string {
+  if (platform === "win32") return values.map(windowsShellQuote).join(" ");
+  return buildPosixShellCommand(values);
+}
+
 function posixShellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function windowsShellQuote(value: string): string {
+  return `"${value.replaceAll("\"", "\"\"")}"`;
 }

--- a/packages/fleet-admiral/src/agent-cli/capabilities.ts
+++ b/packages/fleet-admiral/src/agent-cli/capabilities.ts
@@ -9,6 +9,10 @@ const AGENT_CLI_INJECTION_CAPABILITIES: Record<AgentCliId, AgentCliInjectionCapa
     builderId: "codex-native",
     enabled: true,
   },
+  cursor: {
+    builderId: "cursor-native",
+    enabled: true,
+  },
 };
 
 export function getAgentCliInjectionCapability(

--- a/packages/fleet-admiral/src/agent-cli/cursor/cursor.ts
+++ b/packages/fleet-admiral/src/agent-cli/cursor/cursor.ts
@@ -1,0 +1,30 @@
+import { createChildEnv, resolveBinary } from "@dotobokuri/core-agent";
+
+import type { AgentCliDefinition, AgentCliProfileOptions } from "../types.js";
+
+export const cursorCli: AgentCliDefinition = {
+  id: "cursor",
+  label: "Cursor",
+  async createProfile(options: AgentCliProfileOptions) {
+    const { bin, prefixArgs } = resolveBinary("cursor-agent", "CURSOR_AGENT_BIN", options.env);
+    return {
+      args: [...prefixArgs, ...buildModelArgs(options.model)],
+      bin,
+      binPrefixArgs: prefixArgs,
+      cwd: options.cwd,
+      env: createChildEnv(options.env, {}),
+      id: "cursor",
+      label: "Cursor",
+      messagePolicy: {
+        bracketedPaste: true,
+        lineTerminator: "\r",
+        multilineStrategy: "paste-mode",
+      },
+      terminalName: "xterm-256color",
+    };
+  },
+};
+
+function buildModelArgs(model: string | undefined): string[] {
+  return model === undefined ? [] : ["--model", model];
+}

--- a/packages/fleet-admiral/src/agent-cli/injection.ts
+++ b/packages/fleet-admiral/src/agent-cli/injection.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import { buildClaudeNativeArgs } from "./builders/claude.js";
 import { buildCodexNativeArgs } from "./builders/codex.js";
+import { buildCursorNativeArgs } from "./builders/cursor.js";
 import { buildPosixShellCommand, escapeTomlBasicString, escapeTomlMultilineString } from "./builders/toml.js";
 import { getAgentCliInjectionCapability } from "./capabilities.js";
 import { cleanupDeprecatedCodexPluginState, createAgentCliPlugin, ensureCodexPluginRegistered, FLEET_MARKETPLACE_NAME } from "./plugin/index.js";
@@ -102,7 +103,9 @@ export async function injectAgentCliProfile(
       codexCommandRunner: options.codexCommandRunner,
       cwd: profile.cwd,
       dataDir: options.dataDir,
+      doctrine,
       rootDir: options.pluginRootDir,
+      mcpServers,
       captureSessionHookExec: options.captureSessionHookExec,
       turnStartHookExec: options.turnStartHookExec,
       turnEndHookExec: options.turnEndHookExec,
@@ -394,7 +397,7 @@ function requireCodexCommandRunner(
 }
 
 function buildAgentCliArgs(
-  builderId: "claude-native" | "codex-native",
+  builderId: "claude-native" | "codex-native" | "cursor-native",
   context: AgentCliInjectionContext,
 ): string[] {
   switch (builderId) {
@@ -402,12 +405,14 @@ function buildAgentCliArgs(
       return buildClaudeNativeArgs(context);
     case "codex-native":
       return buildCodexNativeArgs(context);
+    case "cursor-native":
+      return buildCursorNativeArgs(context);
   }
 }
 
 function mergeAgentCliArgs(
   profile: AgentCliProfile,
-  builderId: "claude-native" | "codex-native",
+  builderId: "claude-native" | "codex-native" | "cursor-native",
   context: AgentCliInjectionContext,
   injectedArgs: readonly string[],
 ): string[] {

--- a/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
@@ -1,9 +1,13 @@
 import path from "node:path";
 
 import { EMBEDDED_AGENT_CLI_SKILL_ASSETS } from "../assets.generated.js";
+import { buildHostShellCommand } from "../builders/toml.js";
 import { writePrivateFile, writePrivateJson } from "./fs.js";
+import type { AgentCliMcpServerArg } from "../types.js";
 import type { FleetHookExec } from "../types.js";
 import type { AssetPluginBundle, CreateAgentCliPluginOptions } from "./types.js";
+
+const CURSOR_DOCTRINE_RULE_FILE = "fleet-doctrine.mdc";
 
 export const assetBundle: AssetPluginBundle = {
   description: "Fleet carrier delegation and wiki evidence plugin",
@@ -22,6 +26,9 @@ export function renderAssetPluginRoot(
   renderEmbeddedSkillAssets(pluginRoot);
   if (options.cliId === "claude") {
     writePrivateJson(path.join(pluginRoot, "hooks", "hooks.json"), claudeHooks(options), pluginRoot);
+  }
+  if (options.cliId === "cursor") {
+    renderCursorPluginRoot(pluginRoot, options);
   }
 }
 
@@ -70,6 +77,70 @@ function claudeCommandHook(hookExec: FleetHookExec): unknown {
     args: [...hookExec.args],
     command: hookExec.command,
     type: "command",
+  };
+}
+
+function renderCursorPluginRoot(pluginRoot: string, options: CreateAgentCliPluginOptions): void {
+  if (options.doctrine !== undefined) {
+    writePrivateFile(path.join(pluginRoot, "rules", CURSOR_DOCTRINE_RULE_FILE), cursorDoctrineRule(options.doctrine), pluginRoot);
+  }
+  if ((options.mcpServers ?? []).length > 0) {
+    writePrivateJson(path.join(pluginRoot, "mcp.json"), cursorMcpConfig(options.mcpServers ?? []), pluginRoot);
+  }
+  const hooks = cursorHooks(options);
+  if (hooks !== undefined) {
+    writePrivateJson(path.join(pluginRoot, "hooks", "hooks.json"), hooks, pluginRoot);
+  }
+}
+
+function cursorDoctrineRule(doctrine: string): string {
+  return [
+    "---",
+    "alwaysApply: true",
+    "---",
+    "",
+    doctrine,
+    "",
+  ].join("\n");
+}
+
+function cursorMcpConfig(servers: readonly AgentCliMcpServerArg[]): unknown {
+  return {
+    mcpServers: Object.fromEntries(
+      servers.map((server) => [server.name, {
+        type: "http",
+        url: server.endpointUrl,
+        headers: {
+          Authorization: `Bearer ${server.bearerToken}`,
+        },
+      }]),
+    ),
+  };
+}
+
+function cursorHooks(options: CreateAgentCliPluginOptions): unknown | undefined {
+  // Cursor는 Claude native subagent 정의를 렌더하지 않으므로 SessionStart에는 세션 캡처만 건다.
+  const sessionStartExecs = [options.captureSessionHookExec]
+    .filter((exec): exec is FleetHookExec => exec !== undefined);
+  const beforeSubmitPromptExecs = [options.turnStartHookExec, options.autoNameHookExec]
+    .filter((exec): exec is FleetHookExec => exec !== undefined);
+  const stopExecs = [options.turnEndHookExec]
+    .filter((exec): exec is FleetHookExec => exec !== undefined);
+  if (sessionStartExecs.length === 0 && beforeSubmitPromptExecs.length === 0 && stopExecs.length === 0) return undefined;
+  return {
+    version: 1,
+    hooks: {
+      ...(sessionStartExecs.length > 0 ? { sessionStart: sessionStartExecs.map(cursorCommandHook) } : {}),
+      ...(beforeSubmitPromptExecs.length > 0 ? { beforeSubmitPrompt: beforeSubmitPromptExecs.map(cursorCommandHook) } : {}),
+      ...(stopExecs.length > 0 ? { stop: stopExecs.map(cursorCommandHook) } : {}),
+    },
+  };
+}
+
+function cursorCommandHook(hookExec: FleetHookExec): unknown {
+  return {
+    type: "command",
+    command: buildHostShellCommand([hookExec.command, ...hookExec.args]),
   };
 }
 

--- a/packages/fleet-admiral/src/agent-cli/plugin/index.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/index.ts
@@ -33,9 +33,12 @@ const MARKETPLACE_MANAGED_ENTRIES = [
   ".agents",
   ".claude-plugin",
   ".codex-plugin",
+  ".cursor-plugin",
   "hooks",
   "skills",
   "agents",
+  "rules",
+  "mcp.json",
   "claude",
   "codex-marketplace",
   "plugins",
@@ -44,9 +47,12 @@ const MARKETPLACE_PRUNE_ENTRIES = [
   ".agents",
   ".claude-plugin",
   ".codex-plugin",
+  ".cursor-plugin",
   "hooks",
   "skills",
   "agents",
+  "rules",
+  "mcp.json",
   "claude",
   "codex-marketplace",
 ] as const;
@@ -134,12 +140,15 @@ function renderPluginRoot(
     writePrivateJson(path.join(stagedPluginRoot, ".claude-plugin", "plugin.json"), claudeManifest(bundle), stagedPluginRoot);
     switch (bundle.source) {
       case "asset":
-        ensurePrivateDir(path.join(stagedPluginRoot, "agents"), stagedPluginRoot);
+        if (options.cliId === "claude") {
+          ensurePrivateDir(path.join(stagedPluginRoot, "agents"), stagedPluginRoot);
+        }
         ensurePrivateDir(path.join(stagedPluginRoot, "skills"), stagedPluginRoot);
         renderAssetPluginRoot(stagedPluginRoot, bundle, options);
         break;
     }
     writePrivateJson(path.join(stagedPluginRoot, ".codex-plugin", "plugin.json"), codexManifest(bundle, stagedPluginRoot), stagedPluginRoot);
+    writePrivateJson(path.join(stagedPluginRoot, ".cursor-plugin", "plugin.json"), cursorManifest(bundle, stagedPluginRoot), stagedPluginRoot);
     removePrivatePath(pluginRoot, parentRoot);
     renameSync(stagedPluginRoot, pluginRoot);
   } finally {
@@ -154,6 +163,7 @@ function renderMarketplaceRoot(target: MarketplaceTarget, bundles: readonly Plug
   try {
     writePrivateJson(path.join(stagedRoot, ".agents", "plugins", "marketplace.json"), codexMarketplace(target, bundles), stagedRoot);
     writePrivateJson(path.join(stagedRoot, ".claude-plugin", "marketplace.json"), claudeMarketplace(target, bundles), stagedRoot);
+    writePrivateJson(path.join(stagedRoot, ".cursor-plugin", "marketplace.json"), cursorMarketplace(target, bundles), stagedRoot);
     pruneMarketplaceRoot(target);
     pruneStalePluginDirs(target, bundles);
     for (const entry of readdirSync(stagedRoot)) {
@@ -303,6 +313,18 @@ function claudeMarketplace(target: MarketplaceTarget, bundles: readonly PluginBu
   };
 }
 
+function cursorMarketplace(target: MarketplaceTarget, bundles: readonly PluginBundle[]): unknown {
+  return {
+    name: target.name,
+    owner: "fleet",
+    plugins: bundles.map((bundle) => ({
+      name: bundle.name,
+      description: bundle.description,
+      source: marketplacePluginPath(target, bundle),
+    })),
+  };
+}
+
 function pluginRootForTarget(target: MarketplaceTarget, bundle: PluginBundle): string {
   return path.join(target.root, PLUGIN_BUNDLES_DIR_NAME, bundle.directoryName);
 }
@@ -318,6 +340,30 @@ function codexManifest(bundle: PluginBundle, pluginRoot: string): unknown {
     description: bundle.description,
     skills: "./skills/",
   };
+}
+
+function cursorManifest(bundle: PluginBundle, pluginRoot: string): unknown {
+  return {
+    name: bundle.name,
+    version: cursorManifestVersion(bundle, pluginRoot),
+    description: bundle.description,
+  };
+}
+
+function cursorManifestVersion(bundle: PluginBundle, pluginRoot: string): string {
+  const hash = crypto.createHash("sha256");
+  hash.update(bundle.name);
+  hash.update("\0");
+  hash.update(bundle.description);
+  hash.update("\0");
+  for (const filePath of listCursorEffectivePluginFiles(pluginRoot)) {
+    const relativePath = path.relative(pluginRoot, filePath);
+    hash.update(relativePath);
+    hash.update("\0");
+    hash.update(readFileSync(filePath));
+    hash.update("\0");
+  }
+  return `0.0.0+${hash.digest("hex").slice(0, 12)}`;
 }
 
 function codexManifestVersion(bundle: PluginBundle, pluginRoot: string): string {
@@ -341,6 +387,25 @@ function listCodexEffectivePluginFiles(pluginRoot: string): string[] {
   if (!existsSync(skillsPath)) return [];
   const files: string[] = [];
   collectRenderableFiles(pluginRoot, skillsPath, files, new Set());
+  return files.sort();
+}
+
+function listCursorEffectivePluginFiles(pluginRoot: string): string[] {
+  const files: string[] = [];
+  // mcp.json에는 세션별 bearer 토큰이 들어가므로 의도적으로 해시에 포함한다.
+  // Cursor가 새 세션마다 최신 MCP 토큰을 재적재하도록 플러그인 버전을 갱신한다.
+  for (const entry of ["skills", "rules", "hooks", "mcp.json"]) {
+    const entryPath = path.join(pluginRoot, entry);
+    if (!existsSync(entryPath)) continue;
+    const stat = lstatSync(entryPath);
+    if (stat.isFile()) {
+      files.push(entryPath);
+      continue;
+    }
+    if (stat.isDirectory()) {
+      collectRenderableFiles(pluginRoot, entryPath, files, new Set());
+    }
+  }
   return files.sort();
 }
 

--- a/packages/fleet-admiral/src/agent-cli/plugin/types.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/types.ts
@@ -1,4 +1,4 @@
-import type { CodexCommandResult, CodexPluginRegistrationCommand, FleetHookExec } from "../types.js";
+import type { AgentCliMcpServerArg, CodexCommandResult, CodexPluginRegistrationCommand, FleetHookExec } from "../types.js";
 export type { CodexCommandResult, CodexPluginRegistrationCommand } from "../types.js";
 
 export interface AgentCliPluginMarketplaceLock {
@@ -15,6 +15,8 @@ export interface CreateAgentCliPluginOptions {
   readonly codexCommandRunner?: CodexCommandRunner;
   readonly cwd: string;
   readonly dataDir: string;
+  readonly doctrine?: string;
+  readonly mcpServers?: readonly AgentCliMcpServerArg[];
   // 턴 시작(UserPromptSubmit)·턴 종료(Stop) 신호를 호스트로 알리는 hook. host가 빌드해 주입한다.
   readonly turnStartHookExec?: FleetHookExec;
   readonly turnEndHookExec?: FleetHookExec;

--- a/packages/fleet-admiral/src/agent-cli/registry.ts
+++ b/packages/fleet-admiral/src/agent-cli/registry.ts
@@ -1,5 +1,6 @@
 import { claudeCli } from "./claude/claude.js";
 import { codexCli } from "./codex/codex.js";
+import { cursorCli } from "./cursor/cursor.js";
 import type { AgentCliDefinition, AgentCliId, AgentCliProfile } from "./types.js";
 
 export interface ResolveAgentCliProfileOptions {
@@ -17,6 +18,7 @@ const DEFAULT_CLI_ID: AgentCliId = "claude";
 const DEFINITIONS: Record<AgentCliId, AgentCliDefinition> = {
   claude: claudeCli,
   codex: codexCli,
+  cursor: cursorCli,
 };
 
 export async function resolveAgentCliProfile(

--- a/packages/fleet-admiral/src/agent-cli/types.ts
+++ b/packages/fleet-admiral/src/agent-cli/types.ts
@@ -1,4 +1,4 @@
-export type AgentCliId = "claude" | "codex";
+export type AgentCliId = "claude" | "codex" | "cursor";
 
 export interface AgentCliProfile {
   readonly id: AgentCliId;
@@ -58,7 +58,7 @@ export interface AgentCliInjectionContext {
 
 export interface AgentCliInjectionCapabilityEnabled {
   readonly enabled: true;
-  readonly builderId: "claude-native" | "codex-native";
+  readonly builderId: "claude-native" | "codex-native" | "cursor-native";
 }
 
 export interface AgentCliInjectionCapabilityDisabled {

--- a/packages/fleet-admiral/tests/agent-cli-plugin-marketplace.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-plugin-marketplace.test.ts
@@ -192,8 +192,8 @@ describe("agent CLI plugin marketplace rendering", () => {
     expect(hooksJson.version).toBe(1);
     expect(hooksJson.hooks?.sessionStart?.map((hook) => hook.command)).toEqual([
       "'node' 'cli.mjs' 'hook' 'capture-session' 'cursor'",
-      "'node' 'cli.mjs' 'hook' 'subagents-context'",
     ]);
+    expect(JSON.stringify(hooksJson)).not.toContain("subagents-context");
     expect(hooksJson.hooks?.beforeSubmitPrompt?.map((hook) => hook.command)).toEqual([
       "'node' 'cli.mjs' 'hook' 'turn-start'",
       "'node' 'cli.mjs' 'hook' 'auto-name'",

--- a/packages/fleet-admiral/tests/agent-cli-plugin-marketplace.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-plugin-marketplace.test.ts
@@ -154,6 +154,56 @@ describe("agent CLI plugin marketplace rendering", () => {
     expect(userPromptSubmit).toEqual(["capture-session", "turn-start", "auto-name"]);
   });
 
+  it("renders Cursor plugin rules, hooks, and MCP config", async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "fleet-admiral-plugin-cursor-"));
+    tempDirs.push(root);
+    const dataDir = path.join(root, "data");
+    const cwd = path.join(root, "project");
+    mkdirSync(cwd, { recursive: true });
+
+    const plugin = await createAgentCliPlugin({
+      claudeDefinitions: [],
+      cliId: "cursor",
+      cwd,
+      dataDir,
+      doctrine: "Fleet doctrine",
+      hookExec: { command: "node", args: ["cli.mjs", "hook", "subagents-context"] },
+      captureSessionHookExec: { command: "node", args: ["cli.mjs", "hook", "capture-session", "cursor"] },
+      turnStartHookExec: { command: "node", args: ["cli.mjs", "hook", "turn-start"] },
+      turnEndHookExec: { command: "node", args: ["cli.mjs", "hook", "turn-end"] },
+      autoNameHookExec: { command: "node", args: ["cli.mjs", "hook", "auto-name"] },
+      mcpServers: [{ name: "fleet", endpointUrl: "http://127.0.0.1:48123/mcp", bearerToken: "token-123" }],
+      withMarketplaceLock: async (_target, fn) => fn(),
+    });
+
+    const manifest = JSON.parse(readFileSync(path.join(plugin.pluginRoot, ".cursor-plugin", "plugin.json"), "utf8")) as { readonly name?: unknown };
+    const rule = readFileSync(path.join(plugin.pluginRoot, "rules", "fleet-doctrine.mdc"), "utf8");
+    const hooksJson = JSON.parse(readFileSync(path.join(plugin.pluginRoot, "hooks", "hooks.json"), "utf8")) as {
+      readonly version?: unknown;
+      readonly hooks?: Record<string, ReadonlyArray<{ readonly command?: string }>>;
+    };
+    const mcpJson = JSON.parse(readFileSync(path.join(plugin.pluginRoot, "mcp.json"), "utf8")) as {
+      readonly mcpServers?: Record<string, { readonly headers?: { readonly Authorization?: string } }>;
+    };
+
+    expect(manifest.name).toBe("fleet");
+    expect(rule).toContain("alwaysApply: true");
+    expect(rule).toContain("Fleet doctrine");
+    expect(hooksJson.version).toBe(1);
+    expect(hooksJson.hooks?.sessionStart?.map((hook) => hook.command)).toEqual([
+      "'node' 'cli.mjs' 'hook' 'capture-session' 'cursor'",
+      "'node' 'cli.mjs' 'hook' 'subagents-context'",
+    ]);
+    expect(hooksJson.hooks?.beforeSubmitPrompt?.map((hook) => hook.command)).toEqual([
+      "'node' 'cli.mjs' 'hook' 'turn-start'",
+      "'node' 'cli.mjs' 'hook' 'auto-name'",
+    ]);
+    expect(hooksJson.hooks?.stop?.map((hook) => hook.command)).toEqual([
+      "'node' 'cli.mjs' 'hook' 'turn-end'",
+    ]);
+    expect(mcpJson.mcpServers?.fleet?.headers?.Authorization).toBe("Bearer token-123");
+  });
+
   it("prunes stale plugin directories left by removed bundles", async () => {
     const root = mkdtempSync(path.join(os.tmpdir(), "fleet-admiral-plugin-stale-"));
     tempDirs.push(root);

--- a/packages/fleet-admiral/tests/agent-cli-plugin-marketplace.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-plugin-marketplace.test.ts
@@ -162,12 +162,10 @@ describe("agent CLI plugin marketplace rendering", () => {
     mkdirSync(cwd, { recursive: true });
 
     const plugin = await createAgentCliPlugin({
-      claudeDefinitions: [],
       cliId: "cursor",
       cwd,
       dataDir,
       doctrine: "Fleet doctrine",
-      hookExec: { command: "node", args: ["cli.mjs", "hook", "subagents-context"] },
       captureSessionHookExec: { command: "node", args: ["cli.mjs", "hook", "capture-session", "cursor"] },
       turnStartHookExec: { command: "node", args: ["cli.mjs", "hook", "turn-start"] },
       turnEndHookExec: { command: "node", args: ["cli.mjs", "hook", "turn-end"] },

--- a/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
@@ -92,6 +92,57 @@ describe("agent CLI session resume and capture hooks", () => {
     expect(toml).not.toContain("args =");
   });
 
+  it("places Cursor resume before Fleet plugin and MCP approval flags", async () => {
+    const root = createTempRoot("fleet-admiral-cursor-resume-");
+    const profile = baseProfile("cursor", {
+      args: ["--model", "gpt-5"],
+      cwd: root,
+      env: { HOME: root },
+    });
+    const injected = await injectAgentCliProfile(profile, baseInjectOptions(root, {
+      captureSessionHookExec: hookExec("node", ["console.js", "hook", "capture-session", "cursor"]),
+      resumeSessionId: "cursor-session-789",
+    }));
+    const pluginRoot = path.join(root, "data", "marketplace", "plugins", "fleet");
+    const cursorManifest = JSON.parse(readFileSync(path.join(pluginRoot, ".cursor-plugin", "plugin.json"), "utf8")) as {
+      readonly name?: unknown;
+      readonly version?: unknown;
+    };
+    const doctrineRule = readFileSync(path.join(pluginRoot, "rules", "fleet-doctrine.mdc"), "utf8");
+    const mcpJson = JSON.parse(readFileSync(path.join(pluginRoot, "mcp.json"), "utf8")) as {
+      readonly mcpServers?: Record<string, { readonly headers?: { readonly Authorization?: string } }>;
+    };
+
+    expect(injected.args.slice(0, 4)).toEqual(["--model", "gpt-5", "--resume", "cursor-session-789"]);
+    expect(indexOfSequence(injected.args, ["--resume", "cursor-session-789"])).toBeLessThan(indexOfSequence(injected.args, ["--plugin-dir"]));
+    expect(indexOfSequence(injected.args, ["--sandbox", "disabled"])).toBeGreaterThan(indexOfSequence(injected.args, ["--plugin-dir"]));
+    expect(injected.args).toContain("--force");
+    expect(injected.args).toContain("--approve-mcps");
+    expect(injected.args).not.toContain("--trust");
+    expect(cursorManifest.name).toBe("fleet");
+    expect(cursorManifest.version).toMatch(/^0\.0\.0\+[0-9a-f]{12}$/);
+    expect(doctrineRule).toContain("alwaysApply: true");
+    expect(doctrineRule).toContain("Fleet doctrine");
+    expect(mcpJson.mcpServers?.fleet?.headers?.Authorization).toBe("Bearer token-123");
+  });
+
+  it("omits Cursor MCP approval when no dedicated MCP servers are available", async () => {
+    const root = createTempRoot("fleet-admiral-cursor-no-mcp-");
+    const profile = baseProfile("cursor", {
+      args: [],
+      cwd: root,
+      env: { HOME: root },
+    });
+    const injected = await injectAgentCliProfile(profile, baseInjectOptions(root, {
+      dedicatedMcpSession: createDedicatedMcpSession({ servers: [], tokens: [] }),
+      resumeSessionId: "cursor-session-empty-mcp",
+    }));
+
+    expect(injected.args).toContain("--plugin-dir");
+    expect(injected.args).toContain("--force");
+    expect(injected.args).not.toContain("--approve-mcps");
+  });
+
   it("exports createSessionCaptureHookExec from the root only", () => {
     const exec = Admiral.createSessionCaptureHookExec({
       entryPath: "/tmp/fleet-console/src/cli.ts",
@@ -290,6 +341,7 @@ function baseInjectOptions(
   root: string,
   overrides: {
     readonly captureSessionHookExec?: FleetHookExec;
+    readonly dedicatedMcpSession?: TestDedicatedMcpSession;
     readonly resumeSessionId?: string;
   } = {},
 ): Parameters<typeof injectAgentCliProfile>[1] {
@@ -297,7 +349,7 @@ function baseInjectOptions(
     buildSystemPrompt: () => "Fleet doctrine",
     codexCommandRunner: () => ({ status: 0, stderr: "", stdout: "" }),
     dataDir: path.join(root, "data"),
-    dedicatedMcpSession: createDedicatedMcpSession(),
+    dedicatedMcpSession: overrides.dedicatedMcpSession ?? createDedicatedMcpSession(),
     replaceSystemPrompt: true,
     ...(overrides.captureSessionHookExec ? { captureSessionHookExec: overrides.captureSessionHookExec } : {}),
     ...(overrides.resumeSessionId ? { resumeSessionId: overrides.resumeSessionId } : {}),
@@ -305,15 +357,22 @@ function baseInjectOptions(
   };
 }
 
-function createDedicatedMcpSession(): TestDedicatedMcpSession {
+function createDedicatedMcpSession(
+  options: {
+    readonly servers?: readonly { readonly name: string; readonly url: string }[];
+    readonly tokens?: readonly { readonly name: string; readonly token: string }[];
+  } = {},
+): TestDedicatedMcpSession {
   const releasedLabels: string[] = [];
+  const servers = options.servers ?? [{ name: "fleet", url: "http://127.0.0.1:48123/mcp" }];
+  const tokens = options.tokens ?? [{ name: "fleet", token: "token-123" }];
   return {
     releasedLabels,
     async getEndpoint() {
-      return { servers: [{ name: "fleet", url: "http://127.0.0.1:48123/mcp" }] };
+      return { servers };
     },
     issueSessionToken() {
-      return [{ name: "fleet", token: "token-123" }];
+      return tokens;
     },
     releaseSessionToken(label: string) {
       releasedLabels.push(label);

--- a/packages/fleet-admiral/tests/agent-cli-shell-command.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-shell-command.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { buildHostShellCommand, buildPosixShellCommand } from "../src/agent-cli/builders/toml.js";
+
+describe("agent CLI shell command builders", () => {
+  it("quotes POSIX hook commands with single quotes", () => {
+    expect(buildPosixShellCommand(["/opt/fleet node", "cli's.mjs"])).toBe("'/opt/fleet node' 'cli'\\''s.mjs'");
+  });
+
+  it("quotes Windows hook commands without POSIX single quotes", () => {
+    const command = buildHostShellCommand(["C:\\Program Files\\nodejs\\node.exe", "cli.mjs", "hook&capture"], "win32");
+
+    expect(command).toBe("\"C:\\Program Files\\nodejs\\node.exe\" \"cli.mjs\" \"hook&capture\"");
+    expect(command).not.toContain("'");
+  });
+});

--- a/runtime/fleet-cli/tests/agent-cli/catalog.test.ts
+++ b/runtime/fleet-cli/tests/agent-cli/catalog.test.ts
@@ -24,6 +24,7 @@ describe("agent CLI catalog", () => {
     expect(getAgentCliIds()).toEqual([
       "claude",
       "codex",
+      "cursor",
     ]);
   });
 
@@ -32,6 +33,9 @@ describe("agent CLI catalog", () => {
 
     await expect(resolveAgentCliProfile(env, "/tmp", { cliId: "codex" })).resolves.toMatchObject({
       id: "codex",
+    });
+    await expect(resolveAgentCliProfile(env, "/tmp", { cliId: "cursor" })).resolves.toMatchObject({
+      id: "cursor",
     });
     await expect(resolveAgentCliProfile({ ...env, FLEET_AGENT_CLI: "codex" }, "/tmp")).resolves.toMatchObject({
       id: "codex",
@@ -72,6 +76,10 @@ describe("agent CLI catalog", () => {
 
     expect(profile.args).toContain("--model");
     expect(profile.args).toContain("gpt-5.2");
+
+    const cursor = await resolveAgentCliProfile(env, "/tmp", { cliId: "cursor", model: "gpt-5" });
+    expect(cursor.args).toContain("--model");
+    expect(cursor.args).toContain("gpt-5");
   });
 
   it("omits model args when no model is provided", async () => {
@@ -91,6 +99,10 @@ describe("agent CLI catalog", () => {
       builderId: "codex-native",
       enabled: true,
     });
+    expect(getAgentCliInjectionCapability("cursor")).toEqual({
+      builderId: "cursor-native",
+      enabled: true,
+    });
   });
 });
 
@@ -99,6 +111,7 @@ function createEnvWithBins(): NodeJS.ProcessEnv {
   tempRoots.push(tempRoot);
   fs.writeFileSync(path.join(tempRoot, "claude"), "");
   fs.writeFileSync(path.join(tempRoot, "codex"), "");
+  fs.writeFileSync(path.join(tempRoot, "cursor-agent"), "");
   return {
     PATH: tempRoot,
   };

--- a/runtime/fleet-console/tests/agent-cli-detect.test.ts
+++ b/runtime/fleet-console/tests/agent-cli-detect.test.ts
@@ -96,4 +96,18 @@ describe("agent cli detector", () => {
       },
     ]);
   });
+
+  it("keeps Cursor Agent in the distinct binary catalog", async () => {
+    const detector = createAgentCliDetector({
+      resolve: (command) => (command === "cursor-agent" ? { bin: "/usr/local/bin/cursor-agent", prefixArgs: [] } : undefined),
+      runVersion: async () => "2026.07.01-41b2de7",
+    });
+    const result = await detector.detect();
+    expect(result.find((cli) => cli.id === "cursor-agent")).toEqual({
+      id: "cursor-agent",
+      displayName: "Cursor Agent",
+      available: true,
+      version: "2026.07.01",
+    });
+  });
 });

--- a/runtime/fleet-console/tests/agent-cli-launch-metadata.test.ts
+++ b/runtime/fleet-console/tests/agent-cli-launch-metadata.test.ts
@@ -5,6 +5,7 @@ import { combineAgentCliLaunchMetadata } from "../../fleet-plugins/terminal/serv
 const METADATA = [
   { id: "claude", label: "Claude" },
   { id: "codex", label: "Codex" },
+  { id: "cursor", label: "Cursor" },
 ] as const;
 
 describe("combineAgentCliLaunchMetadata", () => {
@@ -14,6 +15,7 @@ describe("combineAgentCliLaunchMetadata", () => {
       [
         { id: "claude", available: true },
         { id: "codex", available: true },
+        { id: "cursor-agent", available: true },
       ],
       [],
     );
@@ -21,6 +23,7 @@ describe("combineAgentCliLaunchMetadata", () => {
     expect(result).toEqual([
       { id: "claude", label: "Claude", available: true, signedIn: true },
       { id: "codex", label: "Codex", available: true, signedIn: true },
+      { id: "cursor", label: "Cursor", available: true, signedIn: true },
     ]);
   });
 
@@ -30,12 +33,14 @@ describe("combineAgentCliLaunchMetadata", () => {
       [
         { id: "claude", available: false },
         { id: "codex", available: true },
+        { id: "cursor-agent", available: true },
       ],
       [],
     );
 
     expect(result.find((cli) => cli.id === "claude")?.available).toBe(false);
     expect(result.find((cli) => cli.id === "codex")?.available).toBe(true);
+    expect(result.find((cli) => cli.id === "cursor")?.available).toBe(true);
   });
 
   it("탐지/auth 입력이 비면 available=false, signedIn=true로 둔다", () => {
@@ -53,5 +58,6 @@ describe("combineAgentCliLaunchMetadata", () => {
     expect(result.find((cli) => cli.id === "claude")?.signedIn).toBe(false);
     // authStatuses에 없는 CLI는 signedIn=true로 둔다.
     expect(result.find((cli) => cli.id === "codex")?.signedIn).toBe(true);
+    expect(result.find((cli) => cli.id === "cursor")?.signedIn).toBe(true);
   });
 });

--- a/runtime/fleet-console/tests/cli.test.ts
+++ b/runtime/fleet-console/tests/cli.test.ts
@@ -49,10 +49,63 @@ describe("fleet console CLI", () => {
   it("parses hook capture-session commands", () => {
     expect(parseConsoleHookCommand(["capture-session", "claude"])).toEqual({ command: "capture-session", provider: "claude" });
     expect(parseConsoleHookCommand(["capture-session", "codex"])).toEqual({ command: "capture-session", provider: "codex" });
+    expect(parseConsoleHookCommand(["capture-session", "cursor"])).toEqual({ command: "capture-session", provider: "cursor" });
     expect(parseConsoleHookCommand(["attention"])).toEqual({ command: "attention" });
     expect(() => parseConsoleHookCommand(["attention", "extra"])).toThrow("Unknown fleet-console hook command");
     expect(() => parseConsoleHookCommand(["capture-session"])).toThrow("Unknown fleet-console hook command");
     expect(() => parseConsoleHookCommand(["subagents-context"])).toThrow("Unknown fleet-console hook command");
+  });
+
+  it("records Cursor capture-session hook stdin with conversation_id", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-capture-cursor-"));
+    TEMP_DIRS.push(dir);
+    const paths = {
+      dir: path.join(dir, "console"),
+      stateFile: path.join(dir, "console", "state.json"),
+      capturesDir: path.join(dir, "console", "captures"),
+    };
+
+    const result = captureSession({
+      env: { FLEET_CONSOLE_SESSION_ID: "fleet-session-cursor" } as NodeJS.ProcessEnv,
+      input: JSON.stringify({
+        conversation_id: "cursor-conversation-secret",
+        source: "sessionStart",
+      }),
+      now: () => new Date("2026-06-16T00:00:00.000Z"),
+      paths,
+      provider: "cursor",
+    });
+    const written = JSON.parse(fs.readFileSync(path.join(paths.capturesDir, "fleet-session-cursor.json"), "utf8")) as Record<string, unknown>;
+
+    if (!result) throw new Error("expected capture result");
+    expect(written).toEqual({
+      provider: "cursor",
+      sessionId: "cursor-conversation-secret",
+      source: "sessionStart",
+      capturedAt: "2026-06-16T00:00:00.000Z",
+    });
+  });
+
+  it("skips Cursor capture-session hook stdin without a provider session id", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-capture-cursor-missing-id-"));
+    TEMP_DIRS.push(dir);
+    const paths = {
+      dir: path.join(dir, "console"),
+      stateFile: path.join(dir, "console", "state.json"),
+      capturesDir: path.join(dir, "console", "captures"),
+    };
+    const diagnostics: string[] = [];
+
+    expect(captureSession({
+      diagnostics: { write: (chunk: string | Uint8Array) => { diagnostics.push(String(chunk)); return true; } },
+      env: { FLEET_CONSOLE_SESSION_ID: "fleet-session-cursor" } as NodeJS.ProcessEnv,
+      input: JSON.stringify({ chatId: "cursor-chat-unrecognized", source: "sessionStart" }),
+      paths,
+      provider: "cursor",
+    })).toBeNull();
+
+    expect(fs.existsSync(paths.capturesDir)).toBe(false);
+    expect(diagnostics.join("")).toContain("missing_provider_session_id");
   });
 
   it("records capture-session hook stdin to the fleet session capture path atomically", () => {

--- a/runtime/fleet-console/tests/host-hooks.test.ts
+++ b/runtime/fleet-console/tests/host-hooks.test.ts
@@ -37,6 +37,18 @@ describe("console terminal host hooks", () => {
     });
   });
 
+  it("builds Cursor capture hook commands", () => {
+    const exec = buildConsoleCaptureHookCommand({
+      entryPath: "/app/fleet-console/dist/cli.mjs",
+      execPath: "/usr/local/bin/node",
+    }, "cursor");
+
+    expect(exec).toEqual({
+      command: "/usr/local/bin/node",
+      args: ["/app/fleet-console/dist/cli.mjs", "hook", "capture-session", "cursor"],
+    });
+  });
+
   it("builds attention hook commands for the input-waiting signal", () => {
     const exec = buildConsoleAttentionHookCommand({
       entryPath: "/app/fleet-console/dist/cli.mjs",

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -204,7 +204,6 @@ describe("createDefaultTerminalLaunchResolver", () => {
       command: "/node",
       args: ["--import", pathToFileURL("/loader/tsx.mjs").href, "/console/cli.ts", "hook", "capture-session", "cursor"],
     });
-    expect(injectedOptions[0]?.hookExec).toBeUndefined();
     expect(spec.args).toContain("/fleet/plugin");
   });
 

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -204,6 +204,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
       command: "/node",
       args: ["--import", pathToFileURL("/loader/tsx.mjs").href, "/console/cli.ts", "hook", "capture-session", "cursor"],
     });
+    expect(injectedOptions[0]?.hookExec).toBeUndefined();
     expect(spec.args).toContain("/fleet/plugin");
   });
 

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -174,6 +174,39 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(resolveProfile).toHaveBeenCalledWith(expect.any(Object), "/work/project", expect.objectContaining({ cliId: "codex" }));
   });
 
+  it("passes Cursor selection and capture provider to fleet-admiral injection", async () => {
+    const runtime = createFakeRuntime(() => undefined);
+    const injectedOptions: InjectAgentCliProfileOptions[] = [];
+    const resolveProfile = vi.fn(async (env: NodeJS.ProcessEnv, cwd: string) => ({ ...baseProfile, id: "cursor" as const, label: "Cursor", cwd, env: { ...env } }));
+    const injectProfile = vi.fn(async (profile: AgentCliProfile, options: InjectAgentCliProfileOptions) => {
+      injectedOptions.push(options);
+      return { ...profile, args: [...profile.args, "--plugin-dir", "/fleet/plugin"] };
+    });
+    const resolve = createDefaultTerminalLaunchResolver({
+      cwd: "/work",
+      entryPath: "/console/cli.ts",
+      env: { PATH: "/bin" } as NodeJS.ProcessEnv,
+      execPath: "/node",
+      tsxLoaderPath: "/loader/tsx.mjs",
+      agentRuntime: runtime as never,
+      injectProfile: injectProfile as never,
+      resolveProfile: resolveProfile as never,
+    });
+
+    const spec = await resolve("/work/project", { sessionId: "fleet-session-c", cliId: "cursor", resumeSessionId: "cursor-chat-a" });
+
+    expect(resolveProfile).toHaveBeenCalledWith(expect.any(Object), "/work/project", expect.objectContaining({
+      cliId: "cursor",
+      resumeSessionId: "cursor-chat-a",
+    }));
+    expect(injectedOptions[0]).toMatchObject({ resumeSessionId: "cursor-chat-a" });
+    expect(injectedOptions[0]?.captureSessionHookExec).toEqual({
+      command: "/node",
+      args: ["--import", pathToFileURL("/loader/tsx.mjs").href, "/console/cli.ts", "hook", "capture-session", "cursor"],
+    });
+    expect(spec.args).toContain("/fleet/plugin");
+  });
+
   it("honors a FLEET_TERMINAL_CMD override verbatim as an explicit operator override", async () => {
     const resolveProfile = vi.fn();
     const resolve = createDefaultTerminalLaunchResolver({

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -1575,6 +1575,7 @@ describe("console static and terminal ticket boundary", () => {
     expect((listed.agentClis ?? []).map((cli) => ({ id: cli.id, label: cli.label }))).toEqual([
       { id: "claude", label: "Claude" },
       { id: "codex", label: "Codex" },
+      { id: "cursor", label: "Cursor" },
     ]);
     for (const cli of listed.agentClis ?? []) {
       expect(typeof cli.available).toBe("boolean");

--- a/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-detect.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-detect.ts
@@ -34,11 +34,12 @@ const BINARY_DISPLAY_NAMES: Record<string, string> = {
 };
 
 // cliCommand → launch가 참조하는 바이너리 경로 override 환경변수(fleet-admiral resolveBinary와 동일).
-// claude 계열은 CLAUDE_BIN, codex는 CODEX_BIN을 쓴다. opencode/cursor-agent는 launch override가 없어 PATH로만
+// claude 계열은 CLAUDE_BIN, codex는 CODEX_BIN, cursor-agent는 CURSOR_AGENT_BIN을 쓴다. opencode는 PATH로만
 // 해석한다. 이 매핑을 두지 않으면 PATH 밖 절대경로 override 사용자가 미설치로 오판돼 게이트(409)에 막힌다.
 const OVERRIDE_ENV_BY_COMMAND: Record<string, string> = {
   claude: "CLAUDE_BIN",
   codex: "CODEX_BIN",
+  "cursor-agent": "CURSOR_AGENT_BIN",
 };
 
 // `--version` 실행 타임아웃(ms). 미설치/무응답이어도 설정 화면 로드를 막지 않도록 짧게 잡는다.

--- a/runtime/fleet-plugins/terminal/server/agent-api/host-hooks.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/host-hooks.ts
@@ -17,7 +17,7 @@ export interface ConsoleHookCommandEntry {
   readonly tsxLoaderPath?: string;
 }
 
-export type ConsoleCaptureProvider = "claude" | "codex";
+export type ConsoleCaptureProvider = "claude" | "codex" | "cursor";
 
 export type ConsoleTurnPhase = "start" | "end";
 
@@ -61,7 +61,9 @@ export function buildConsoleCaptureHookCommand(entry: ConsoleHookCommandEntry, c
 }
 
 export function toCaptureProvider(cliId: AgentCliId): ConsoleCaptureProvider {
-  return cliId === "codex" ? "codex" : "claude";
+  if (cliId === "codex") return "codex";
+  if (cliId === "cursor") return "cursor";
+  return "claude";
 }
 
 export function runCodexCommand(command: CodexPluginRegistrationCommand): CodexCommandResult {

--- a/runtime/fleet-plugins/terminal/server/agent-api/session-capture.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/session-capture.ts
@@ -23,6 +23,8 @@ export type ProviderSession = AgentProviderSession;
 
 type HookInput = {
   readonly session_id?: unknown;
+  readonly conversation_id?: unknown;
+  readonly chat_id?: unknown;
   readonly transcript_path?: unknown;
   readonly cwd?: unknown;
   readonly source?: unknown;
@@ -89,7 +91,7 @@ function captureSessionStrict(options: CaptureSessionOptions): CaptureSessionRes
 }
 
 function parseProvider(value: string): ProviderSession["provider"] {
-  if (value === "claude" || value === "codex") return value;
+  if (isProvider(value)) return value;
   throw new Error("invalid_provider");
 }
 
@@ -117,10 +119,10 @@ function toProviderSession(
   input: HookInput,
   now: () => Date,
 ): ProviderSession {
-  if (typeof input.session_id !== "string" || input.session_id.length === 0) throw new Error("missing_provider_session_id");
+  const sessionId = readProviderSessionId(input);
   return {
     provider,
-    sessionId: input.session_id,
+    sessionId,
     ...(typeof input.transcript_path === "string" && input.transcript_path.length > 0 ? { transcriptPath: input.transcript_path } : {}),
     ...(typeof input.source === "string" && input.source.length > 0 ? { source: input.source } : {}),
     capturedAt: now().toISOString(),
@@ -130,7 +132,7 @@ function toProviderSession(
 function sanitizeProviderSession(value: unknown): ProviderSession | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const candidate = value as { readonly provider?: unknown; readonly sessionId?: unknown; readonly transcriptPath?: unknown; readonly source?: unknown; readonly capturedAt?: unknown };
-  if ((candidate.provider !== "claude" && candidate.provider !== "codex") || typeof candidate.sessionId !== "string" || typeof candidate.capturedAt !== "string") return null;
+  if (!isProvider(candidate.provider) || typeof candidate.sessionId !== "string" || typeof candidate.capturedAt !== "string") return null;
   return {
     provider: candidate.provider,
     sessionId: candidate.sessionId,
@@ -138,6 +140,17 @@ function sanitizeProviderSession(value: unknown): ProviderSession | null {
     ...(typeof candidate.source === "string" && candidate.source.length > 0 ? { source: candidate.source } : {}),
     capturedAt: candidate.capturedAt,
   };
+}
+
+function readProviderSessionId(input: HookInput): string {
+  for (const value of [input.session_id, input.conversation_id, input.chat_id]) {
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  throw new Error("missing_provider_session_id");
+}
+
+function isProvider(value: unknown): value is ProviderSession["provider"] {
+  return value === "claude" || value === "codex" || value === "cursor";
 }
 
 function isSafeCaptureId(value: string): boolean {

--- a/runtime/fleet-plugins/terminal/server/agent-api/types.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/types.ts
@@ -13,7 +13,7 @@ export type AgentAttentionReason =
 export type AgentLabelSource = "user" | "auto";
 
 export interface AgentProviderSession {
-  readonly provider: "claude" | "codex";
+  readonly provider: "claude" | "codex" | "cursor";
   readonly sessionId: string;
   readonly transcriptPath?: string;
   readonly source?: string;

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -555,7 +555,7 @@ function readProviderSession(value: Record<string, unknown> | undefined): Provid
   const providerSession = value?.providerSession;
   if (!providerSession || typeof providerSession !== "object") return undefined;
   const candidate = providerSession as { readonly provider?: unknown; readonly sessionId?: unknown; readonly capturedAt?: unknown; readonly transcriptPath?: unknown; readonly source?: unknown };
-  if ((candidate.provider !== "claude" && candidate.provider !== "codex") || typeof candidate.sessionId !== "string" || typeof candidate.capturedAt !== "string") return undefined;
+  if (!isProvider(candidate.provider) || typeof candidate.sessionId !== "string" || typeof candidate.capturedAt !== "string") return undefined;
   return {
     provider: candidate.provider,
     sessionId: candidate.sessionId,
@@ -563,6 +563,10 @@ function readProviderSession(value: Record<string, unknown> | undefined): Provid
     ...(typeof candidate.transcriptPath === "string" ? { transcriptPath: candidate.transcriptPath } : {}),
     ...(typeof candidate.source === "string" ? { source: candidate.source } : {}),
   };
+}
+
+function isProvider(value: unknown): value is ProviderSession["provider"] {
+  return value === "claude" || value === "codex" || value === "cursor";
 }
 
 function resolveCarrierEventOrigin(event: { readonly jobId: string; readonly type: string; readonly originSessionId?: string }, jobOriginById: Map<string, string>): string | null {


### PR DESCRIPTION
## Summary

- Adds Cursor Agent as a first-class Agent CLI runtime alongside Claude and Codex.
- Renders Fleet Cursor plugin assets, including always-applied doctrine rules, hooks, MCP config, and marketplace metadata.
- Wires fleet-cli and fleet-console terminal launch, detection, and session-capture paths for `cursor-agent`.

## Type of Change

- [x] feat — new feature or carrier capability
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- [x] `extensions/fleet` (Admiral / Bridge / Carriers)
- [x] `bin/` or root tooling
- [ ] `extensions/core`
- [ ] `extensions/boot`
- [ ] `extensions/diagnostics`
- [ ] `extensions/metaphor`
- [ ] `packages/unified-agent`
- [ ] Documentation (README / SETUP / AGENTS.md)

## Test Plan

- [x] `git diff --check`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `pnpm --filter @dotobokuri/fleet-admiral typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-cli typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-admiral test -- tests/agent-cli-session-resume.test.ts tests/agent-cli-plugin-marketplace.test.ts tests/agent-cli-shell-command.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-cli test -- tests/agent-cli/catalog.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console test -- tests/cli.test.ts tests/host-hooks.test.ts tests/agent-cli-detect.test.ts tests/launch.test.ts tests/agent-cli-launch-metadata.test.ts tests/server.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-admiral build`
- [x] `pnpm --filter @dotobokuri/fleet-cli build`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Cursor Agent flag parse smoke: `cursor-agent --sandbox disabled --approve-mcps --plugin-dir /tmp --help`

## Changelog

- [x] Added one `.changelog.d/*.md` fragment, or applied the `no-changelog` label intentionally.
- [x] Fragment `section:` is one of `Added`, `Changed`, `Fixed`, `Removed`, or `Breaking Changes`.
- [x] Fragment bullets are English and use only `[core-agent]`, `[core-unified-agent]`, `[fleet-infra]`, `[fleet-admiral]`, `[fleet-carriers]`, `[fleet-wiki]`, `[fleet-console]`, or `[fleet-cli]`.

## Related Issues / PRs

N/A

## Notes for Reviewers

Cursor does not expose a Claude-style system prompt flag. Fleet injects Admiral doctrine through Cursor's official plugin rules surface by rendering `rules/fleet-doctrine.mdc` with `alwaysApply: true` and loading it via `--plugin-dir`.