### PR TITLE
fix(fleet-console): preserve terminal TUI cursor movement

### DIFF
--- a/.changelog.d/fix-terminal-tui-repaint.md
+++ b/.changelog.d/fix-terminal-tui-repaint.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- [fleet-console] Terminal Shell sessions now preserve raw TUI cursor movement so nvim-style fullscreen apps repaint reliably.

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-options.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-options.ts
@@ -1,0 +1,11 @@
+export const TERMINAL_OPTIONS = {
+  // Unicode11Addon은 terminal.unicode(proposed API)를 사용하므로 이 옵션이 true여야 한다.
+  // false이면 addon.activate()가 "must set allowProposedApi" 오류를 던져 터미널 마운트가 깨진다.
+  allowProposedApi: true,
+  // PTY 기반 TUI(nvim 등)는 raw LF와 cursor 제어 시퀀스를 직접 관리한다.
+  // LF를 CRLF로 변환하면 alternate screen에서 열 위치가 틀어져 화면이 깨질 수 있다.
+  convertEol: false,
+  cursorBlink: true,
+  cursorStyle: "block" as const,
+  lineHeight: 1,
+};

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef, useState, type CSSProperties } from "react";
 
 import { createImeShiftEnterHandler } from "./ime-shift-enter.js";
 import { createTerminalConnection, type TerminalConnection } from "./terminal-connection.js";
+import { TERMINAL_OPTIONS } from "./terminal-options.js";
 import { useTerminalPrefs } from "./terminal-prefs-store.js";
 
 export interface TerminalSurfaceProps {
@@ -30,16 +31,6 @@ interface TerminalOutputScheduler {
   readonly setActive: (active: boolean) => void;
   readonly dispose: () => void;
 }
-
-const TERMINAL_OPTIONS = {
-  // Unicode11Addon은 terminal.unicode(proposed API)를 사용하므로 이 옵션이 true여야 한다.
-  // false이면 addon.activate()가 "must set allowProposedApi" 오류를 던져 터미널 마운트가 깨진다.
-  allowProposedApi: true,
-  convertEol: true,
-  cursorBlink: true,
-  cursorStyle: "block" as const,
-  lineHeight: 1,
-};
 
 const RESIZE_DEBOUNCE_MS = 80;
 const ACTIVE_OUTPUT_FLUSH_MS = 16;
@@ -186,7 +177,7 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "mari
       // 폰트 로딩 대기 중 세션이 전환되면(effect cleanup) 이미 dispose된 터미널에
       // fit/start를 호출하지 않는다 — 그렇지 않으면 빈 화면이나 잘못된 크기로 이어진다.
       if (disposed) return;
-      fitAndResize();
+      fitResizeAndRefresh();
       connection.start();
       // 마운트(셸 열기·세션 전환) 직후 xterm에 포커스를 줘 마우스 클릭 없이 바로 입력되게 한다.
       // 단, Map의 비활성 패널(active===false)은 건너뛴다 — 여러 패널이 마운트되며 포커스를 다투지 않게 한다.

--- a/runtime/fleet-plugins/terminal/tests/terminal-options.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-options.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { TERMINAL_OPTIONS } from "../client/shared/terminal-options.js";
+
+describe("TERMINAL_OPTIONS", () => {
+  it("preserves raw PTY LF semantics for fullscreen TUI applications", () => {
+    expect(TERMINAL_OPTIONS.convertEol).toBe(false);
+  });
+
+  it("keeps proposed APIs enabled for the Unicode11 addon", () => {
+    expect(TERMINAL_OPTIONS.allowProposedApi).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve raw PTY LF semantics in Terminal Shell sessions so fullscreen TUI apps such as nvim keep cursor column state intact.
- Refresh the xterm surface after the initial fit before the terminal connection starts.
- Add regression coverage for the terminal option contract and a changelog fragment.

## Type of Change
- [x] fix — bug fix
- [ ] feat — new feature or carrier capability
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope
- [ ] `extensions/core`
- [ ] `extensions/fleet` (Admiral / Bridge / Carriers)
- [ ] `extensions/boot`
- [ ] `extensions/diagnostics`
- [ ] `extensions/metaphor`
- [ ] `packages/unified-agent`
- [ ] `bin/` or root tooling
- [ ] Documentation (README / SETUP / AGENTS.md)

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal test`
- [x] `pnpm --filter @fleet-plugins/terminal... build`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check --allow-empty`
- [x] `git diff --check`
- [x] Headed console-e2e raw LF repro: before fix `B` returned to column 1; after fix `B` stayed under `A`.
- [x] Headed console-e2e nvim PageDown/PageUp stress: WebGL canvases stayed present, WebSocket stayed live, no browser errors/rejections.

## Changelog
- [x] Added one `.changelog.d/*.md` fragment, or applied the `no-changelog` label intentionally.
- [x] Fragment `section:` is one of `Added`, `Changed`, `Fixed`, `Removed`, or `Breaking Changes`.
- [x] Fragment bullets are English and use only `[core-agent]`, `[core-unified-agent]`, `[fleet-infra]`, `[fleet-admiral]`, `[fleet-carriers]`, `[fleet-wiki]`, `[fleet-console]`, or `[fleet-cli]`.

## Related Issues / PRs

## Notes for Reviewers
- Worktree validation required a local `pnpm install --offline --frozen-lockfile --ignore-scripts` because the dedicated worktree initially had no `node_modules`.