### PR TITLE
feat(fleet-console): add Diff panel git-log History and commit graph

### DIFF
--- a/.changelog.d/diff-log-history-graph.md
+++ b/.changelog.d/diff-log-history-graph.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- [fleet-console] Diff panel now shows a collapsible "History" section under Changes, listing recent commits with a single-lane graph gutter (Flat/Graph toggle). Selecting a commit renders its full multi-file patch in the extended diff pane. A multi-lane topology (up to three active lanes, with overflow collapsed) visualises merges and branches within HEAD-reachable history.

--- a/runtime/fleet-plugins/diff/client/diff-view-store.ts
+++ b/runtime/fleet-plugins/diff/client/diff-view-store.ts
@@ -1,6 +1,6 @@
 import { useSyncExternalStore } from "react";
 
-import type { DiffFileEntry } from "../server/types.js";
+import type { DiffFileEntry, LogCommitEntry } from "../server/types.js";
 
 // ─── types ───────────────────────────────────────────────────────────────────
 
@@ -11,8 +11,15 @@ export interface SelectedFile {
   readonly subPath: string;
 }
 
+export interface SelectedCommit {
+  readonly commit: LogCommitEntry;
+  readonly subPath: string;
+  readonly theaterId: string;
+}
+
 interface DiffViewState {
   readonly file: SelectedFile | null;
+  readonly commit: SelectedCommit | null;
 }
 
 type Listener = () => void;
@@ -21,7 +28,7 @@ type Listener = () => void;
 
 const listeners = new Set<Listener>();
 
-let state: DiffViewState = { file: null };
+let state: DiffViewState = { file: null, commit: null };
 
 // ─── functions ───────────────────────────────────────────────────────────────
 
@@ -44,12 +51,28 @@ export function useSelectedFile(theaterId: string | null): SelectedFile | null {
   return s.file;
 }
 
+export function useSelectedCommit(theaterId: string | null): SelectedCommit | null {
+  const s = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  if (!s.commit || s.commit.theaterId !== theaterId) return null;
+  return s.commit;
+}
+
 export function setSelectedFile(entry: DiffFileEntry, subPath: string, theaterId: string): void {
-  state = { file: { entry, subPath, theaterId } };
+  state = { file: { entry, subPath, theaterId }, commit: null };
+  emit();
+}
+
+export function setSelectedCommit(commit: LogCommitEntry, subPath: string, theaterId: string): void {
+  state = { file: null, commit: { commit, subPath, theaterId } };
   emit();
 }
 
 export function clearSelectedFile(): void {
-  state = { file: null };
+  state = { file: null, commit: state.commit };
+  emit();
+}
+
+export function clearSelectedCommit(): void {
+  state = { file: state.file, commit: null };
   emit();
 }

--- a/runtime/fleet-plugins/diff/client/diff.css
+++ b/runtime/fleet-plugins/diff/client/diff.css
@@ -907,3 +907,147 @@
   font-size: 11px;
   color: var(--ink-fog);
 }
+
+/* ── 다중 파일 패치 파일 경계 행 ── */
+.diff-line-file-label {
+  background: var(--ink-mid);
+  border-top: 1px solid var(--surface-rim);
+  border-bottom: 1px solid var(--surface-rim);
+}
+
+.diff-line-file-label .diff-line-code,
+.diff-line-file-label td {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-spectral);
+  padding: 3px 10px;
+}
+
+/* ── Graph 토글 (View 토글과 동일 패턴) ── */
+.diff-graph-toggle {
+  display: inline-flex;
+  background: color-mix(in oklch, var(--ink-deep) 80%, transparent);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-xs);
+  padding: 2px;
+  gap: 2px;
+}
+
+/* ── History 섹션 ── */
+.diff-section-history .diff-section-head {
+  /* Changes 섹션과 동일한 골격, 별도 override 없음 */
+}
+
+/* ── 커밋 행 ── */
+.diff-commit-row {
+  display: grid;
+  grid-template-columns: 16px 7ch 1fr auto auto auto;
+  align-items: center;
+  gap: 0 8px;
+  width: 100%;
+  padding: 5px 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s;
+  min-width: 0;
+}
+
+.diff-commit-row:hover {
+  background: color-mix(in oklch, var(--ink-fog) 9%, transparent);
+}
+
+.diff-commit-row.is-cur {
+  background: color-mix(in oklch, var(--surface-highlight, var(--brass)) 12%, transparent);
+  box-shadow: inset 2px 0 0 var(--surface-highlight, var(--brass));
+}
+
+.diff-graph-gutter {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  flex: none;
+  align-self: stretch;
+}
+
+.diff-commit-sha {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: color-mix(in oklch, var(--ink-spectral) 55%, transparent);
+  flex: none;
+  white-space: nowrap;
+}
+
+.diff-commit-subject {
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  color: var(--ink-spectral);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.diff-commit-badges {
+  display: inline-flex;
+  gap: 4px;
+  flex: none;
+  flex-wrap: nowrap;
+}
+
+.diff-badge {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.06em;
+  border-radius: 999px;
+  padding: 0 5px;
+  white-space: nowrap;
+}
+
+.badge--head {
+  color: var(--brass);
+  border: 1px solid color-mix(in oklch, var(--brass) 60%, transparent);
+}
+
+.badge--tag {
+  color: var(--brass);
+  border: 1px solid color-mix(in oklch, var(--brass) 40%, transparent);
+}
+
+.badge--branch {
+  color: var(--aurora);
+  background: color-mix(in oklch, var(--aurora) 12%, transparent);
+  border: 1px solid transparent;
+}
+
+.badge--worktree {
+  color: var(--aurora);
+  border: 1px dashed color-mix(in oklch, var(--aurora) 50%, transparent);
+}
+
+.diff-commit-meta {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--ink-fog);
+  white-space: nowrap;
+  flex: none;
+}
+
+/* ── 커밋 모드 hunk 헤더 ── */
+.diff-hunk-commit-icon {
+  flex: none;
+  font-size: 13px;
+  color: var(--ink-rim);
+}
+
+.diff-hunk-sha {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: color-mix(in oklch, var(--ink-spectral) 60%, transparent);
+  background: color-mix(in oklch, var(--ink-fog) 12%, transparent);
+  border-radius: var(--radius-xs);
+  padding: 1px 5px;
+}

--- a/runtime/fleet-plugins/diff/client/graph-gutter.tsx
+++ b/runtime/fleet-plugins/diff/client/graph-gutter.tsx
@@ -1,0 +1,140 @@
+import type { GraphNode } from "./graph-layout.js";
+
+// ─── types ───────────────────────────────────────────────────────────────────
+
+interface GraphGutterProps {
+  readonly node: GraphNode;
+  readonly laneCount: number;
+  readonly collapsed?: boolean;
+}
+
+// ─── constants ───────────────────────────────────────────────────────────────
+
+const LANE_WIDTH = 12;
+const ROW_HEIGHT = 20;
+const NODE_R = 3;
+const HEAD_RING_R = 5;
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function laneCx(lane: number): number {
+  return lane * LANE_WIDTH + 6;
+}
+
+// ─── GraphGutter ─────────────────────────────────────────────────────────────
+
+export function GraphGutter({ node, laneCount, collapsed = false }: GraphGutterProps) {
+  const lanes = Math.max(laneCount, 1);
+  const collapseIndicatorWidth = collapsed ? 10 : 0;
+  const width = lanes * LANE_WIDTH + collapseIndicatorWidth;
+  const cx = laneCx(node.lane);
+  const cy = ROW_HEIGHT / 2;
+
+  return (
+    <svg
+      width={width}
+      height={ROW_HEIGHT}
+      viewBox={`0 0 ${width} ${ROW_HEIGHT}`}
+      aria-hidden="true"
+      style={{ display: "block", flexShrink: 0 }}
+    >
+      {/* passThrough 수직선 */}
+      {node.passThroughLanes.map((lane) => (
+        <line
+          key={`pt-${lane}`}
+          x1={laneCx(lane)}
+          y1={0}
+          x2={laneCx(lane)}
+          y2={ROW_HEIGHT}
+          stroke="var(--ink-rim)"
+          strokeWidth={1.5}
+        />
+      ))}
+
+      {/* 위로 연결선 */}
+      {node.connectAbove && (
+        <line
+          x1={cx}
+          y1={0}
+          x2={cx}
+          y2={cy - NODE_R}
+          stroke="var(--ink-rim)"
+          strokeWidth={1.5}
+        />
+      )}
+
+      {/* 아래로 연결선 */}
+      {node.connectBelow && (
+        <line
+          x1={cx}
+          y1={cy + NODE_R}
+          x2={cx}
+          y2={ROW_HEIGHT}
+          stroke="var(--ink-rim)"
+          strokeWidth={1.5}
+        />
+      )}
+
+      {/* mergeFromLanes: 병합으로 닫히는 레인 — 위쪽에서 노드로 대각선 */}
+      {node.mergeFromLanes.map((lane) => (
+        <line
+          key={`mf-${lane}`}
+          x1={laneCx(lane)}
+          y1={0}
+          x2={cx}
+          y2={cy}
+          stroke="var(--ink-rim)"
+          strokeWidth={1.5}
+          strokeLinecap="round"
+        />
+      ))}
+
+      {/* branchToLanes: 노드에서 새로 분기되는 레인 — 아래로 대각선 */}
+      {node.branchToLanes.map((lane) => (
+        <line
+          key={`bt-${lane}`}
+          x1={cx}
+          y1={cy}
+          x2={laneCx(lane)}
+          y2={ROW_HEIGHT}
+          stroke="var(--ink-rim)"
+          strokeWidth={1.5}
+          strokeLinecap="round"
+        />
+      ))}
+
+      {/* HEAD 링 */}
+      {node.isHead && (
+        <circle
+          cx={cx}
+          cy={cy}
+          r={HEAD_RING_R}
+          fill="none"
+          stroke="var(--brass)"
+          strokeWidth={1.5}
+        />
+      )}
+
+      {/* 노드 원 */}
+      <circle
+        cx={cx}
+        cy={cy}
+        r={NODE_R}
+        fill={node.isHead ? "var(--brass)" : "var(--ink-fog)"}
+      />
+
+      {/* collapse 인디케이터 */}
+      {collapsed && (
+        <text
+          x={lanes * LANE_WIDTH + 2}
+          y={cy + 4}
+          fontSize={10}
+          fontFamily="monospace"
+          fill="var(--ink-fog)"
+        >
+          ⋯
+        </text>
+      )}
+    </svg>
+  );
+}

--- a/runtime/fleet-plugins/diff/client/graph-layout.ts
+++ b/runtime/fleet-plugins/diff/client/graph-layout.ts
@@ -1,0 +1,141 @@
+import type { LogCommitEntry } from "../server/types.js";
+
+// ─── types ───────────────────────────────────────────────────────────────────
+
+export interface GraphNode {
+  readonly lane: number;
+  readonly isHead: boolean;
+  readonly connectAbove: boolean;
+  readonly connectBelow: boolean;
+  readonly passThroughLanes: readonly number[];
+  readonly mergeFromLanes: readonly number[];
+  readonly branchToLanes: readonly number[];
+}
+
+export interface GraphLayout {
+  readonly nodes: readonly GraphNode[];
+  readonly activeLaneCount: number;
+  readonly collapsed: boolean;
+}
+
+// ─── constants ───────────────────────────────────────────────────────────────
+
+const LANE_HARD_CAP = 3;
+
+// ─── functions ───────────────────────────────────────────────────────────────
+
+export function layoutGraph(commits: readonly LogCommitEntry[]): GraphLayout {
+  if (commits.length === 0) {
+    return { nodes: [], activeLaneCount: 0, collapsed: false };
+  }
+
+  // laneHeads[i]: 레인 i가 다음에 매치되기를 기다리는 부모 커밋 해시. null = 비어있음(재사용 가능)
+  const laneHeads: (string | null)[] = [];
+  const nodes: GraphNode[] = [];
+  let collapsed = false;
+  let maxLaneIndex = 0;
+
+  for (let idx = 0; idx < commits.length; idx++) {
+    const c = commits[idx]!;
+    const hash = c.fullHash;
+    const parents = [...c.parents];
+
+    // 이 커밋 해시를 기다리는 레인들을 찾는다
+    const matched: number[] = [];
+    for (let i = 0; i < laneHeads.length; i++) {
+      if (laneHeads[i] === hash) matched.push(i);
+    }
+
+    let myLane: number;
+    const mergeFromLanes: number[] = [];
+
+    if (matched.length === 0) {
+      // 새 레인 개설: 빈 슬롯 재사용 또는 append
+      const freeSlot = laneHeads.indexOf(null);
+      if (freeSlot >= 0) {
+        myLane = freeSlot;
+      } else {
+        myLane = laneHeads.length;
+        laneHeads.push(null);
+      }
+    } else {
+      // 가장 작은 인덱스 레인을 이 커밋의 레인으로
+      myLane = Math.min(...matched);
+      // 나머지 매치 레인은 병합으로 닫힘
+      for (const m of matched) {
+        if (m !== myLane) {
+          mergeFromLanes.push(m);
+          laneHeads[m] = null;
+        }
+      }
+    }
+
+    // 부모 갱신
+    const branchToLanes: number[] = [];
+    if (parents.length === 0) {
+      laneHeads[myLane] = null;
+    } else {
+      // 첫 번째 부모: 현재 레인 계승
+      laneHeads[myLane] = parents[0] ?? null;
+      // 나머지 부모: 기존 레인에 이미 기다리는 것이 있으면 재사용, 없으면 새 레인
+      for (const parent of parents.slice(1)) {
+        const existing = laneHeads.indexOf(parent);
+        if (existing >= 0) {
+          // 이미 다른 레인이 이 해시를 기다리고 있음 — 새 레인 불필요
+        } else {
+          const freeSlot = laneHeads.indexOf(null);
+          if (freeSlot >= 0) {
+            laneHeads[freeSlot] = parent;
+            branchToLanes.push(freeSlot);
+          } else {
+            const newLane = laneHeads.length;
+            laneHeads.push(parent);
+            branchToLanes.push(newLane);
+          }
+        }
+      }
+    }
+
+    // 하드캡 3 적용: 활성 레인 수 초과 시 초과분 제거
+    const activeLanes = laneHeads
+      .map((h, i) => ({ h, i }))
+      .filter(({ h }) => h !== null)
+      .map(({ i }) => i);
+
+    if (activeLanes.length > LANE_HARD_CAP) {
+      collapsed = true;
+      // 가장 최근에 새로 개설된 레인(인덱스가 큰 것)부터 축약
+      const toCollapse = activeLanes
+        .filter((i) => i !== myLane)
+        .sort((a, b) => b - a)
+        .slice(0, activeLanes.length - LANE_HARD_CAP);
+      for (const lane of toCollapse) {
+        laneHeads[lane] = null;
+        // branchToLanes에서도 제거
+        const btIdx = branchToLanes.indexOf(lane);
+        if (btIdx >= 0) branchToLanes.splice(btIdx, 1);
+      }
+    }
+
+    // passThroughLanes: 이 행 처리 후 활성인 레인 중 myLane이 아닌 것들
+    const passThroughLanes = laneHeads
+      .map((h, i) => ({ h, i }))
+      .filter(({ h, i }) => h !== null && i !== myLane)
+      .map(({ i }) => i);
+
+    // 최대 레인 인덱스 추적
+    maxLaneIndex = Math.max(maxLaneIndex, myLane, ...branchToLanes, ...passThroughLanes);
+
+    nodes.push({
+      lane: myLane,
+      isHead: c.refs.includes("HEAD") || idx === 0,
+      connectAbove: idx > 0,
+      connectBelow: idx < commits.length - 1,
+      passThroughLanes,
+      mergeFromLanes,
+      branchToLanes,
+    });
+  }
+
+  return { nodes, activeLaneCount: maxLaneIndex + 1, collapsed };
+}

--- a/runtime/fleet-plugins/diff/client/graph-layout.ts
+++ b/runtime/fleet-plugins/diff/client/graph-layout.ts
@@ -128,7 +128,7 @@ export function layoutGraph(commits: readonly LogCommitEntry[]): GraphLayout {
 
     nodes.push({
       lane: myLane,
-      isHead: c.refs.includes("HEAD") || idx === 0,
+      isHead: c.refs.some((r) => r === "HEAD" || r.startsWith("HEAD ->")) || idx === 0,
       connectAbove: idx > 0,
       connectBelow: idx < commits.length - 1,
       passThroughLanes,

--- a/runtime/fleet-plugins/diff/client/history-section.tsx
+++ b/runtime/fleet-plugins/diff/client/history-section.tsx
@@ -1,0 +1,178 @@
+import { useCallback, useEffect, useState } from "react";
+
+import type { RailPanelContext } from "@fleet-console/sdk/rail";
+
+import type { LogCommitEntry, LogResult } from "../server/types.js";
+import { setSelectedCommit, useSelectedCommit } from "./diff-view-store.js";
+import { GraphGutter } from "./graph-gutter.js";
+import { layoutGraph } from "./graph-layout.js";
+import { refBadges } from "./log-parse.js";
+
+// ─── types ───────────────────────────────────────────────────────────────────
+
+type LoadState =
+  | { readonly kind: "loading" }
+  | { readonly kind: "ok"; readonly commits: readonly LogCommitEntry[] }
+  | { readonly kind: "error"; readonly message: string };
+
+interface HistorySectionProps {
+  readonly ctx: RailPanelContext;
+  readonly subPath: string;
+  readonly refreshToken?: number;
+  readonly graphMode?: "flat" | "graph";
+}
+
+// ─── constants ───────────────────────────────────────────────────────────────
+
+const PREFS_HISTORY_COLLAPSED = "fleet-console.diff.historyCollapsed";
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function readCollapsed(key: string): boolean {
+  try { return localStorage.getItem(key) === "1"; } catch { return false; }
+}
+
+// ─── CommitRow ───────────────────────────────────────────────────────────────
+
+interface CommitRowProps {
+  readonly entry: LogCommitEntry;
+  readonly isCur: boolean;
+  readonly onClick: (entry: LogCommitEntry) => void;
+  readonly graphNode?: import("./graph-layout.js").GraphNode | null;
+  readonly laneCount?: number;
+  readonly layoutCollapsed?: boolean;
+}
+
+function CommitRow({ entry, isCur, onClick, graphNode, laneCount = 0, layoutCollapsed = false }: CommitRowProps) {
+  const handleClick = useCallback(() => onClick(entry), [entry, onClick]);
+  const badges = refBadges(entry);
+
+  return (
+    <button
+      type="button"
+      className={`diff-commit-row${isCur ? " is-cur" : ""}`}
+      onClick={handleClick}
+    >
+      <span className="diff-graph-gutter" aria-hidden="true">
+        {graphNode ? <GraphGutter node={graphNode} laneCount={laneCount} collapsed={layoutCollapsed} /> : null}
+      </span>
+      <span className="diff-commit-sha">{entry.shortHash}</span>
+      <span className="diff-commit-subject">{entry.subject}</span>
+      {badges.length > 0 && (
+        <span className="diff-commit-badges">
+          {badges.map((b, i) => (
+            <span key={i} className={`diff-badge badge--${b.kind}`}>{b.label}</span>
+          ))}
+        </span>
+      )}
+      <span className="diff-nums">
+        {entry.additions > 0 && <span className="diff-additions">+{entry.additions}</span>}
+        {entry.deletions > 0 && <span className="diff-deletions">−{entry.deletions}</span>}
+      </span>
+      <span className="diff-commit-meta">{entry.authorName} · {entry.relTime}</span>
+    </button>
+  );
+}
+
+// ─── HistorySection ──────────────────────────────────────────────────────────
+
+export function HistorySection({ ctx, subPath, refreshToken = 0, graphMode = "flat" }: HistorySectionProps) {
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+  const [collapsed, setCollapsed] = useState(() => readCollapsed(PREFS_HISTORY_COLLAPSED));
+  const [localRefreshToken, setLocalRefreshToken] = useState(0);
+  const selectedCommit = useSelectedCommit(ctx.theaterId ?? null);
+
+  useEffect(() => {
+    if (!ctx.theaterId) {
+      setState({ kind: "ok", commits: [] });
+      return;
+    }
+    let cancelled = false;
+    setState({ kind: "loading" });
+
+    ctx.api.fetch("diff", "log", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ theaterId: ctx.theaterId, subPath }),
+    }).then(async (res) => {
+      if (!res.ok) {
+        const payload = await res.json() as { error?: string };
+        const code = payload.error ?? "unknown";
+        if (!cancelled) {
+          if (code === "git_unavailable") {
+            setState({ kind: "ok", commits: [] });
+          } else {
+            setState({ kind: "error", message: code });
+          }
+        }
+        return;
+      }
+      const data = await res.json() as LogResult;
+      if (!cancelled) setState({ kind: "ok", commits: data.commits });
+    }).catch((err: unknown) => {
+      if (!cancelled) setState({ kind: "error", message: err instanceof Error ? err.message : "unknown" });
+    });
+
+    return () => { cancelled = true; };
+  }, [ctx.theaterId, ctx.api, subPath, refreshToken, localRefreshToken]);
+
+  const handleToggle = useCallback(() => {
+    setCollapsed((v) => {
+      const next = !v;
+      try { localStorage.setItem(PREFS_HISTORY_COLLAPSED, next ? "1" : "0"); } catch { /* ignore */ }
+      return next;
+    });
+  }, []);
+
+  const handleRetry = useCallback(() => setLocalRefreshToken((t) => t + 1), []);
+
+  const handleSelectCommit = useCallback((entry: LogCommitEntry) => {
+    if (!ctx.theaterId) return;
+    setSelectedCommit(entry, subPath, ctx.theaterId);
+  }, [ctx.theaterId, subPath]);
+
+  const commitCount = state.kind === "ok" ? state.commits.length : 0;
+  const layout = state.kind === "ok" && graphMode === "graph"
+    ? layoutGraph(state.commits)
+    : null;
+  const layoutCollapsed = layout?.collapsed ?? false;
+
+  return (
+    <div className={`diff-section diff-section-history${collapsed ? " is-collapsed" : ""}`}>
+      <button type="button" className="diff-section-head" onClick={handleToggle}>
+        <svg className="diff-section-chevron" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+          <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+        <span className="diff-section-name">History</span>
+        {state.kind === "ok" && <span className="diff-count-badge">{commitCount}</span>}
+      </button>
+      {!collapsed && (
+        <div className="diff-section-rows">
+          {state.kind === "loading" && (
+            <div className="diff-empty-row">Loading…</div>
+          )}
+          {state.kind === "error" && (
+            <div className="diff-sections-error">
+              <span>{state.message}</span>
+              <button type="button" className="diff-refresh-btn" onClick={handleRetry}>Retry</button>
+            </div>
+          )}
+          {state.kind === "ok" && state.commits.length === 0 && (
+            <div className="diff-empty-row">No history</div>
+          )}
+          {state.kind === "ok" && state.commits.map((entry, i) => (
+            <CommitRow
+              key={entry.fullHash}
+              entry={entry}
+              isCur={selectedCommit?.commit.fullHash === entry.fullHash}
+              onClick={handleSelectCommit}
+              graphNode={layout ? layout.nodes[i] ?? null : null}
+              laneCount={layout ? layout.activeLaneCount : 0}
+              layoutCollapsed={layoutCollapsed}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/runtime/fleet-plugins/diff/client/hunk-parse.ts
+++ b/runtime/fleet-plugins/diff/client/hunk-parse.ts
@@ -1,17 +1,19 @@
 // ─── types ───────────────────────────────────────────────────────────────────
 
-export type HunkLineKind = "hunk-label" | "add" | "del" | "ctx";
+export type HunkLineKind = "hunk-label" | "add" | "del" | "ctx" | "file-label";
 
 export interface ParsedLine {
   readonly kind: HunkLineKind;
   readonly text: string;
   readonly oldLine?: number;
   readonly newLine?: number;
+  readonly oldPath?: string;
 }
 
 // ─── constants ───────────────────────────────────────────────────────────────
 
 const HUNK_HEADER_RE = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@(.*)/;
+const DIFF_GIT_RE = /^diff --git a\/(.+) b\/(.+)$/;
 
 // ─── functions ───────────────────────────────────────────────────────────────
 
@@ -23,39 +25,56 @@ export function parseHunk(content: string): ParsedLine[] {
   if (rawLines[rawLines.length - 1] === "") rawLines.pop();
   const result: ParsedLine[] = [];
 
-  // 첫 번째 @@ 이전까지 파일 레벨 헤더(diff --git, index, ---, +++ 등) 드롭
-  let headerEnd = 0;
-  while (headerEnd < rawLines.length && rawLines[headerEnd]?.startsWith("@@") === false) {
-    headerEnd++;
-  }
-
-  // hunk가 하나도 없는 diff(바이너리 수정, 모드 변경 등)는 파일 헤더 4종만 걷어내고
-  // 나머지 정보성 라인("Binary files ... differ" 등)을 라인번호 없는 ctx로 보존한다
-  if (headerEnd === rawLines.length) {
-    for (const line of rawLines) {
-      if (line === "") continue;
-      if (
-        line.startsWith("diff --git") ||
-        line.startsWith("index ") ||
-        line.startsWith("--- ") ||
-        line.startsWith("+++ ")
-      ) {
-        continue;
-      }
-      // 뷰가 unified 프리픽스 1글자(slice(1))를 걷어내므로 ctx 규약대로 앞 공백을 붙인다
-      result.push({ kind: "ctx", text: ` ${line}` });
-    }
-    return result;
-  }
-
   let oldLine = 0;
   let newLine = 0;
+  // 현재 파일 헤더 구간(diff --git ~ 첫 @@ 이전)인지
+  let inHeader = true;
 
-  for (const line of rawLines.slice(headerEnd)) {
+  for (const line of rawLines) {
     // "\ No newline at end of file" — 파일 내용이 아닌 diff 메타 어노테이션이므로 라인번호를 소모하지 않는다
     if (line.startsWith("\\")) continue;
 
+    if (line.startsWith("diff --git ")) {
+      // 새 파일 블록 시작 — b/ 경로를 파일 레이블로 삽입
+      const m = DIFF_GIT_RE.exec(line);
+      const oldPath = m?.[1];
+      const newPath = m?.[2] ?? line;
+      const oldPathField = (oldPath !== undefined && oldPath !== newPath) ? oldPath : undefined;
+      result.push({ kind: "file-label", text: newPath, oldPath: oldPathField });
+      inHeader = true;
+      continue;
+    }
+
+    if (inHeader) {
+      // diff --git ~ @@ 이전 헤더 라인 드롭(index, ---, +++, mode 변경 등)
+      if (
+        line.startsWith("index ") ||
+        line.startsWith("--- ") ||
+        line.startsWith("+++ ") ||
+        line.startsWith("new file mode") ||
+        line.startsWith("deleted file mode") ||
+        line.startsWith("old mode") ||
+        line.startsWith("new mode") ||
+        line.startsWith("rename from ") ||
+        line.startsWith("rename to ") ||
+        line.startsWith("similarity index") ||
+        line.startsWith("dissimilarity index")
+      ) {
+        continue;
+      }
+
+      if (!line.startsWith("@@")) {
+        // 헤더 구간의 알 수 없는 라인("Binary files ... differ" 등) — ctx로 보존
+        if (line !== "") {
+          // 뷰가 unified 프리픽스 1글자(slice(1))를 걷어내므로 ctx 규약대로 앞 공백을 붙인다
+          result.push({ kind: "ctx", text: ` ${line}` });
+        }
+        continue;
+      }
+    }
+
     if (line.startsWith("@@")) {
+      inHeader = false;
       const m = HUNK_HEADER_RE.exec(line);
       if (m) {
         oldLine = parseInt(m[1] ?? "0", 10);

--- a/runtime/fleet-plugins/diff/client/hunk-view.tsx
+++ b/runtime/fleet-plugins/diff/client/hunk-view.tsx
@@ -79,7 +79,10 @@ export function HunkView({ ctx, file, mode, subPath, commit }: HunkViewProps) {
   }
 
   const { result } = state;
-  const lines = parseHunk(result.content);
+  // 커밋(git show)은 다중 파일이라 파일 경계 라벨이 필요하지만, 단일 파일 뷰는 페인 헤더가 이미
+  // 파일명을 표시하므로 file-label 행은 중복이다 — 커밋 모드에서만 렌더한다.
+  const parsed = parseHunk(result.content);
+  const lines = commit ? parsed : parsed.filter((l) => l.kind !== "file-label");
 
   return (
     <div className="diff-hunk-wrap">

--- a/runtime/fleet-plugins/diff/client/hunk-view.tsx
+++ b/runtime/fleet-plugins/diff/client/hunk-view.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from "react";
 
 import type { RailPanelContext } from "@fleet-console/sdk/rail";
 
-import type { DiffFileEntry, DiffFileMode, DiffHunkResult } from "../server/types.js";
+import type { CommitDiffResult, DiffFileEntry, DiffFileMode, DiffHunkResult } from "../server/types.js";
+import type { SelectedCommit } from "./diff-view-store.js";
 import { parseHunk } from "./hunk-parse.js";
 
 // ─── types ───────────────────────────────────────────────────────────────────
@@ -12,11 +13,12 @@ interface HunkViewProps {
   readonly file: DiffFileEntry;
   readonly mode: DiffFileMode;
   readonly subPath: string;
+  readonly commit?: SelectedCommit | null;
 }
 
 type LoadState =
   | { readonly kind: "loading" }
-  | { readonly kind: "ok"; readonly result: DiffHunkResult }
+  | { readonly kind: "ok"; readonly result: DiffHunkResult | CommitDiffResult }
   | { readonly kind: "error"; readonly message: string };
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
@@ -30,7 +32,7 @@ function escapeHtml(s: string): string {
 
 // ─── HunkView ────────────────────────────────────────────────────────────────
 
-export function HunkView({ ctx, file, mode, subPath }: HunkViewProps) {
+export function HunkView({ ctx, file, mode, subPath, commit }: HunkViewProps) {
   const [state, setState] = useState<LoadState>({ kind: "loading" });
 
   useEffect(() => {
@@ -40,18 +42,33 @@ export function HunkView({ ctx, file, mode, subPath }: HunkViewProps) {
     }
     let cancelled = false;
     setState({ kind: "loading" });
-    ctx.api.fetch("diff", "file", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ theaterId: ctx.theaterId, filePath: file.path, mode, subPath }),
-    }).then(async (res) => {
-      const result = await res.json() as DiffHunkResult;
-      if (!cancelled) setState({ kind: "ok", result });
-    }).catch((err: unknown) => {
-      if (!cancelled) setState({ kind: "error", message: err instanceof Error ? err.message : "unknown" });
-    });
+
+    if (commit) {
+      ctx.api.fetch("diff", "commit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ theaterId: commit.theaterId, ref: commit.commit.fullHash, subPath: commit.subPath }),
+      }).then(async (res) => {
+        const result = await res.json() as CommitDiffResult;
+        if (!cancelled) setState({ kind: "ok", result });
+      }).catch((err: unknown) => {
+        if (!cancelled) setState({ kind: "error", message: err instanceof Error ? err.message : "unknown" });
+      });
+    } else {
+      ctx.api.fetch("diff", "file", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ theaterId: ctx.theaterId, filePath: file.path, mode, subPath }),
+      }).then(async (res) => {
+        const result = await res.json() as DiffHunkResult;
+        if (!cancelled) setState({ kind: "ok", result });
+      }).catch((err: unknown) => {
+        if (!cancelled) setState({ kind: "error", message: err instanceof Error ? err.message : "unknown" });
+      });
+    }
+
     return () => { cancelled = true; };
-  }, [ctx.api, file.path, mode, subPath, ctx.theaterId]);
+  }, [ctx.api, ctx.theaterId, file.path, mode, subPath, commit]);
 
   if (state.kind === "loading") {
     return <div className="diff-hunk-loading">Loading…</div>;
@@ -76,6 +93,13 @@ export function HunkView({ ctx, file, mode, subPath }: HunkViewProps) {
                   <td
                     colSpan={4}
                     className="diff-line-label"
+                    // eslint-disable-next-line react/no-danger
+                    dangerouslySetInnerHTML={{ __html: escapeHtml(line.text) }}
+                  />
+                ) : line.kind === "file-label" ? (
+                  <td
+                    colSpan={4}
+                    className="diff-line-file-label"
                     // eslint-disable-next-line react/no-danger
                     dangerouslySetInnerHTML={{ __html: escapeHtml(line.text) }}
                   />

--- a/runtime/fleet-plugins/diff/client/log-parse.ts
+++ b/runtime/fleet-plugins/diff/client/log-parse.ts
@@ -1,0 +1,34 @@
+import type { LogCommitEntry } from "../server/types.js";
+
+// ─── types ───────────────────────────────────────────────────────────────────
+
+export type RefBadgeKind = "head" | "tag" | "branch" | "worktree";
+
+export interface RefBadge {
+  readonly label: string;
+  readonly kind: RefBadgeKind;
+}
+
+// ─── functions ───────────────────────────────────────────────────────────────
+
+export function formatRelTime(entry: LogCommitEntry): string {
+  return entry.relTime;
+}
+
+export function refBadges(entry: LogCommitEntry): RefBadge[] {
+  const badges: RefBadge[] = [];
+  for (const ref of entry.refs) {
+    if (ref === "HEAD") {
+      badges.push({ label: "HEAD", kind: "head" });
+    } else if (ref.startsWith("tag: ")) {
+      badges.push({ label: ref.slice(5), kind: "tag" });
+    } else if (ref.startsWith("refs/worktrees/")) {
+      badges.push({ label: ref.slice(15), kind: "worktree" });
+    } else if (ref.startsWith("refs/heads/")) {
+      badges.push({ label: ref.slice(11), kind: "branch" });
+    } else {
+      badges.push({ label: ref, kind: "branch" });
+    }
+  }
+  return badges;
+}

--- a/runtime/fleet-plugins/diff/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/diff/client/rail-panel.tsx
@@ -5,13 +5,22 @@ import type { RailPanelContext, RailPanelDescriptor } from "@fleet-console/sdk/r
 import type { DiffFileEntry, DiffFileMode, RepoEntry, ReposDiscoveryResult } from "../server/types.js";
 import "./diff.css";
 import { ChangedFiles } from "./changed-files.js";
-import { clearSelectedFile, setSelectedFile, type SelectedFile, useSelectedFile } from "./diff-view-store.js";
+import {
+  clearSelectedCommit,
+  clearSelectedFile,
+  setSelectedFile,
+  type SelectedFile,
+  useSelectedCommit,
+  useSelectedFile,
+} from "./diff-view-store.js";
+import { HistorySection } from "./history-section.js";
 import { HunkView } from "./hunk-view.js";
 import { groupRepos, relativeToParent } from "./repo-grouping.js";
 
 // ─── types ───────────────────────────────────────────────────────────────────
 
 type ViewMode = "list" | "tree";
+type GraphMode = "flat" | "graph";
 
 interface DiffPanelProps {
   readonly ctx: RailPanelContext;
@@ -36,6 +45,7 @@ const PREFS_VIEW_MODE = "fleet-console.diff.viewMode";
 const PREFS_SPLIT_RATIO = "fleet-console.diff.splitRatio";
 const PREFS_DEPTH = "fleet-console.diff.depth";
 const PREFS_REPO_PREFIX = "fleet-console.diff.repo.";
+const PREFS_HISTORY_GRAPH_MODE = "fleet-console.diff.historyGraphMode";
 
 const EXTENDED_EXTRA_WIDTH = 400;
 // 호스트가 뷰포트 클램프로 400 미만만 부여했을 때: 문서 페인부터 축소(min 140)하고 리스트 페인(min 220)을 보존한다
@@ -84,6 +94,14 @@ function readDepth(): number {
     }
   } catch { /* ignore */ }
   return DEFAULT_DEPTH;
+}
+
+function readGraphMode(): GraphMode {
+  try {
+    const v = localStorage.getItem(PREFS_HISTORY_GRAPH_MODE);
+    if (v === "flat" || v === "graph") return v;
+  } catch { /* ignore */ }
+  return "flat";
 }
 
 function readSubPath(theaterId: string): string {
@@ -281,7 +299,9 @@ function ChevronIcon() {
 
 function DiffPanel({ ctx }: DiffPanelProps) {
   const [viewMode, setViewMode] = useState<ViewMode>(readViewMode);
+  const [graphMode, setGraphModeState] = useState<GraphMode>(readGraphMode);
   const selectedFile = useSelectedFile(ctx.theaterId ?? null);
+  const selectedCommit = useSelectedCommit(ctx.theaterId ?? null);
   const [splitRatio, setSplitRatioState] = useState(readSplitRatio);
   const splitRatioRef = useRef(splitRatio);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -335,6 +355,7 @@ function DiffPanel({ ctx }: DiffPanelProps) {
     setReposTruncated(false);
     setMenuOpen(false);
     clearSelectedFile();
+    clearSelectedCommit();
     fetchRepos(depthRef.current);
   }, [ctx.theaterId, fetchRepos]);
 
@@ -349,7 +370,8 @@ function DiffPanel({ ctx }: DiffPanelProps) {
     if (relPath === activeSubPath) return;
     setActiveSubPath(relPath);
     if (ctx.theaterId) saveSubPath(ctx.theaterId, relPath);
-    clearSelectedFile(); // 저장소 변경 시 선택 파일 초기화
+    clearSelectedFile();
+    clearSelectedCommit();
   }, [activeSubPath, ctx.theaterId]);
 
   const handleDepthChange = useCallback((newDepth: number) => {
@@ -385,11 +407,19 @@ function DiffPanel({ ctx }: DiffPanelProps) {
     setSelectedFile(entry, activeSubPath, ctx.theaterId);
   }, [ctx.theaterId, activeSubPath]);
 
-  const handleCloseHunk = useCallback(() => { clearSelectedFile(); }, []);
+  const handleCloseHunk = useCallback(() => {
+    clearSelectedFile();
+    clearSelectedCommit();
+  }, []);
 
   const handleViewMode = useCallback((next: ViewMode) => {
     setViewMode(next);
     try { localStorage.setItem(PREFS_VIEW_MODE, next); } catch { /* ignore */ }
+  }, []);
+
+  const handleGraphMode = useCallback((next: GraphMode) => {
+    setGraphModeState(next);
+    try { localStorage.setItem(PREFS_HISTORY_GRAPH_MODE, next); } catch { /* ignore */ }
   }, []);
 
   const handleDividerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
@@ -423,10 +453,10 @@ function DiffPanel({ ctx }: DiffPanelProps) {
     document.addEventListener("pointerup", onUp);
   }, []);
 
-  // 파일 선택 시 패널 좌측 400px 확장, 해제 시 원복 — 단일 지점 호출
+  // 파일/커밋 선택 시 패널 좌측 400px 확장, 해제 시 원복
   useLayoutEffect(() => {
-    ctx.requestExtraWidth?.(selectedFile ? EXTENDED_EXTRA_WIDTH : null);
-  }, [ctx, selectedFile]);
+    ctx.requestExtraWidth?.((selectedFile || selectedCommit) ? EXTENDED_EXTRA_WIDTH : null);
+  }, [ctx, selectedFile, selectedCommit]);
 
   // 활성 저장소 정보 — 스캔 전에는 subPath 기반 표시 이름만 사용
   const activeRepo = repos.find((r) => r.relPath === activeSubPath) ?? null;
@@ -435,30 +465,41 @@ function DiffPanel({ ctx }: DiffPanelProps) {
   const activeBranch = activeRepo?.branch ?? null;
 
   const hunkMode: DiffFileMode = selectedFile ? getHunkMode(selectedFile) : "unified";
+  const hasHunk = !!(selectedFile || selectedCommit);
 
   return (
     <div
       ref={rootRef}
-      className={`diff-root${selectedFile ? " has-hunk" : ""}${isDragging ? " is-dragging" : ""}`}
-      style={selectedFile ? {
+      className={`diff-root${hasHunk ? " has-hunk" : ""}${isDragging ? " is-dragging" : ""}`}
+      style={hasHunk ? {
         gridTemplateColumns: `minmax(${HUNK_PANE_MIN_WIDTH}px, ${splitRatio}fr) 4px minmax(${LIST_PANE_MIN_WIDTH}px, ${1 - splitRatio}fr)`,
       } : undefined}
     >
-      {selectedFile && (
+      {hasHunk && (
         <div className="diff-hunk-pane">
           <div className="diff-hunk-head">
-            <span className={`diff-status-glyph diff-status-${selectedFile.entry.status.toLowerCase()}`}>
-              {selectedFile.entry.status}
-            </span>
-            <span className="diff-hunk-filename">{selectedFile.entry.path}</span>
-            <span className="diff-nums">
-              {selectedFile.entry.additions > 0 && (
-                <span className="diff-additions">+{selectedFile.entry.additions}</span>
-              )}
-              {selectedFile.entry.deletions > 0 && (
-                <span className="diff-deletions">−{selectedFile.entry.deletions}</span>
-              )}
-            </span>
+            {selectedCommit ? (
+              <>
+                <span className="diff-hunk-commit-icon" aria-hidden="true">⊙</span>
+                <span className="diff-hunk-sha">{selectedCommit.commit.shortHash}</span>
+                <span className="diff-hunk-filename">{selectedCommit.commit.subject}</span>
+              </>
+            ) : selectedFile ? (
+              <>
+                <span className={`diff-status-glyph diff-status-${selectedFile.entry.status.toLowerCase()}`}>
+                  {selectedFile.entry.status}
+                </span>
+                <span className="diff-hunk-filename">{selectedFile.entry.path}</span>
+                <span className="diff-nums">
+                  {selectedFile.entry.additions > 0 && (
+                    <span className="diff-additions">+{selectedFile.entry.additions}</span>
+                  )}
+                  {selectedFile.entry.deletions > 0 && (
+                    <span className="diff-deletions">−{selectedFile.entry.deletions}</span>
+                  )}
+                </span>
+              </>
+            ) : null}
             <button
               type="button"
               className="diff-hunk-close"
@@ -469,11 +510,21 @@ function DiffPanel({ ctx }: DiffPanelProps) {
             </button>
           </div>
           <div className="diff-hunk-body">
-            <HunkView ctx={ctx} file={selectedFile.entry} mode={hunkMode} subPath={selectedFile.subPath} />
+            {selectedCommit ? (
+              <HunkView
+                ctx={ctx}
+                file={{ path: "", status: "M", additions: 0, deletions: 0 }}
+                mode="unified"
+                subPath={selectedCommit.subPath}
+                commit={selectedCommit}
+              />
+            ) : selectedFile ? (
+              <HunkView ctx={ctx} file={selectedFile.entry} mode={hunkMode} subPath={selectedFile.subPath} />
+            ) : null}
           </div>
         </div>
       )}
-      {selectedFile && (
+      {hasHunk && (
         <div
           className="diff-divider"
           onPointerDown={handleDividerDown}
@@ -529,6 +580,42 @@ function DiffPanel({ ctx }: DiffPanelProps) {
               </svg>
             </button>
           </div>
+          <div className="diff-graph-toggle">
+            <button
+              type="button"
+              className={`diff-toggle-btn${graphMode === "flat" ? " is-active" : ""}`}
+              title="Flat history"
+              aria-pressed={graphMode === "flat"}
+              onClick={() => handleGraphMode("flat")}
+            >
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                <line x1="3" y1="4" x2="3" y2="10" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+                <circle cx="3" cy="4" r="1.5" fill="currentColor" />
+                <circle cx="3" cy="7" r="1.5" fill="currentColor" />
+                <circle cx="3" cy="10" r="1.5" fill="currentColor" />
+                <line x1="6" y1="4" x2="12" y2="4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+                <line x1="6" y1="7" x2="11" y2="7" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+                <line x1="6" y1="10" x2="10" y2="10" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              className={`diff-toggle-btn${graphMode === "graph" ? " is-active" : ""}`}
+              title="Graph history"
+              aria-pressed={graphMode === "graph"}
+              onClick={() => handleGraphMode("graph")}
+            >
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                <line x1="3" y1="2" x2="3" y2="12" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+                <line x1="8" y1="5" x2="8" y2="12" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+                <path d="M3 5 Q5 5 8 5" stroke="currentColor" strokeWidth="1.2" fill="none" strokeLinecap="round" />
+                <circle cx="3" cy="3" r="1.8" fill="currentColor" />
+                <circle cx="3" cy="8" r="1.5" fill="currentColor" />
+                <circle cx="8" cy="8" r="1.5" fill="currentColor" />
+                <circle cx="3" cy="11.5" r="1.5" fill="currentColor" />
+              </svg>
+            </button>
+          </div>
         </div>
         <ChangedFiles
           ctx={ctx}
@@ -537,6 +624,7 @@ function DiffPanel({ ctx }: DiffPanelProps) {
           subPath={activeSubPath}
           onSelect={handleSelectFile}
         />
+        <HistorySection ctx={ctx} subPath={activeSubPath} graphMode={graphMode} />
         {menuOpen && (
           <CommandDeck
             theaterId={ctx.theaterId ?? ""}

--- a/runtime/fleet-plugins/diff/routes.ts
+++ b/runtime/fleet-plugins/diff/routes.ts
@@ -1,6 +1,8 @@
 import { definePlugin, registerRouter } from "@fleet-console/sdk/plugin/node";
 
+import { handleDiffCommit } from "./server/commit.js";
 import { handleDiffChanged, handleDiffFile } from "./server/diff.js";
+import { handleDiffLog } from "./server/log.js";
 import { handleDiffRepos } from "./server/repos.js";
 
 export default definePlugin({
@@ -16,6 +18,14 @@ export default definePlugin({
     });
     registerRouter(ctx, "file", async ({ req, res }) => {
       await handleDiffFile(req, res, ctx);
+      return true;
+    });
+    registerRouter(ctx, "log", async ({ req, res }) => {
+      await handleDiffLog(req, res, ctx);
+      return true;
+    });
+    registerRouter(ctx, "commit", async ({ req, res }) => {
+      await handleDiffCommit(req, res, ctx);
       return true;
     });
   },

--- a/runtime/fleet-plugins/diff/server/commit.ts
+++ b/runtime/fleet-plugins/diff/server/commit.ts
@@ -1,0 +1,66 @@
+import type http from "node:http";
+
+import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
+
+import { GitExecutorError, runGit } from "./git-executor.js";
+import { resolveGitCwd } from "./diff.js";
+
+// ─── constants ────────────────────────────────────────────────────────────────
+
+const REF_RE = /^[0-9a-f]{7,40}$/i;
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// ─── handlers ────────────────────────────────────────────────────────────────
+
+export async function handleDiffCommit(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  ctx: FleetPluginServerContext,
+): Promise<void> {
+  if (req.method !== "POST") { ctx.host.http.writeJson(res, 405, { error: "Method not allowed" }); return; }
+  if (!ctx.host.security.isTerminalAuthorized(req)) { ctx.host.http.writeJson(res, 401, { error: "unauthorized" }); return; }
+
+  const body = await ctx.host.http.readJsonBody<{
+    readonly theaterId?: unknown;
+    readonly subPath?: unknown;
+    readonly ref?: unknown;
+  }>(req);
+  if (!isPlainObject(body)) { ctx.host.http.writeJson(res, 400, { error: "invalid_request" }); return; }
+
+  const theaterId = body.theaterId;
+  if (typeof theaterId !== "string") { ctx.host.http.writeJson(res, 400, { error: "invalid_request" }); return; }
+
+  const ref = body.ref;
+  if (typeof ref !== "string" || !REF_RE.test(ref)) {
+    ctx.host.http.writeJson(res, 400, { error: "invalid_ref" });
+    return;
+  }
+
+  const theaterPath = ctx.host.paths.resolveTheaterPath(theaterId);
+  if (!theaterPath) { ctx.host.http.writeJson(res, 404, { error: "theater_not_found" }); return; }
+
+  const rawSubPath = typeof body.subPath === "string" ? body.subPath : "";
+  const cwdResult = await resolveGitCwd(theaterPath, rawSubPath);
+  if (!cwdResult) { ctx.host.http.writeJson(res, 403, { error: "path_outside_theater" }); return; }
+  const { gitCwd } = cwdResult;
+
+  try {
+    const result = await runGit(["show", ref, "--unified=3", "--format="], { cwd: gitCwd });
+    ctx.host.http.writeJson(res, 200, { content: result.stdout, ...(result.truncated ? { truncated: true } : {}) });
+  } catch (error) {
+    if (error instanceof GitExecutorError) {
+      if (error.code === "no_git_repo" || error.code === "git_unavailable") {
+        ctx.host.http.writeJson(res, 422, { error: error.code });
+        return;
+      }
+      ctx.host.http.writeJson(res, 500, { error: "git_failed" });
+      return;
+    }
+    throw error;
+  }
+}

--- a/runtime/fleet-plugins/diff/server/diff.ts
+++ b/runtime/fleet-plugins/diff/server/diff.ts
@@ -69,7 +69,7 @@ function isNoHeadError(error: unknown): boolean {
 
 // subPath 포함·realpath 이중 containment 검증 후 gitCwd 반환.
 // 검증 실패 시 null 반환 — 호출자가 적절한 HTTP 오류를 반환한다.
-async function resolveGitCwd(
+export async function resolveGitCwd(
   theaterPath: string,
   rawSubPath: string,
 ): Promise<{ gitCwd: string } | null> {

--- a/runtime/fleet-plugins/diff/server/log.ts
+++ b/runtime/fleet-plugins/diff/server/log.ts
@@ -102,9 +102,12 @@ export async function handleDiffLog(
         ctx.host.http.writeJson(res, 422, { error: error.code });
         return;
       }
-    }
-    if (isNoHeadError(error)) {
-      ctx.host.http.writeJson(res, 200, { commits: [] });
+      // no-HEAD 신규 저장소(HEAD 미존재)는 빈 배열 graceful; 그 외 비정상 종료는 500 — 500 분기보다 먼저 검사한다
+      if (isNoHeadError(error)) {
+        ctx.host.http.writeJson(res, 200, { commits: [] });
+        return;
+      }
+      ctx.host.http.writeJson(res, 500, { error: "git_failed" });
       return;
     }
     throw error;

--- a/runtime/fleet-plugins/diff/server/log.ts
+++ b/runtime/fleet-plugins/diff/server/log.ts
@@ -1,0 +1,112 @@
+import type http from "node:http";
+
+import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
+
+import { GitExecutorError, runGit } from "./git-executor.js";
+import type { LogCommitEntry } from "./types.js";
+import { resolveGitCwd } from "./diff.js";
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseLogOutput(stdout: string): LogCommitEntry[] {
+  if (!stdout.trim()) return [];
+  const commits: LogCommitEntry[] = [];
+
+  for (const chunk of stdout.split("\x1e")) {
+    const trimmed = chunk.trimStart();
+    if (!trimmed) continue;
+
+    const lines = trimmed.split("\n");
+    const firstLine = lines[0] ?? "";
+    const fields = firstLine.split("\x00");
+
+    const fullHash = fields[0] ?? "";
+    const shortHash = fields[1] ?? "";
+    const subject = fields[2] ?? "";
+    const authorName = fields[3] ?? "";
+    const relTime = fields[4] ?? "";
+    const refsRaw = fields[5] ?? "";
+    const parentsRaw = fields[6] ?? "";
+
+    if (!fullHash) continue;
+
+    const refs = refsRaw.split(",").map((r) => r.trim()).filter(Boolean);
+    const parents = parentsRaw.split(" ").map((p) => p.trim()).filter(Boolean);
+
+    let additions = 0;
+    let deletions = 0;
+    for (const line of lines.slice(1)) {
+      if (!line.trim()) continue;
+      const parts = line.split("\t");
+      if (parts.length < 2) continue;
+      const a = parseInt(parts[0] ?? "0", 10);
+      const d = parseInt(parts[1] ?? "0", 10);
+      if (!isNaN(a)) additions += a;
+      if (!isNaN(d)) deletions += d;
+    }
+
+    commits.push({ shortHash, fullHash, subject, authorName, relTime, refs, parents, additions, deletions });
+  }
+
+  return commits;
+}
+
+function isNoHeadError(error: unknown): boolean {
+  if (!(error instanceof GitExecutorError)) return false;
+  if (error.code !== "non_zero_exit") return false;
+  return error.stderr.includes("unknown revision") || error.stderr.includes("bad revision");
+}
+
+// ─── handlers ────────────────────────────────────────────────────────────────
+
+export async function handleDiffLog(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  ctx: FleetPluginServerContext,
+): Promise<void> {
+  if (req.method !== "POST") { ctx.host.http.writeJson(res, 405, { error: "Method not allowed" }); return; }
+  if (!ctx.host.security.isTerminalAuthorized(req)) { ctx.host.http.writeJson(res, 401, { error: "unauthorized" }); return; }
+
+  const body = await ctx.host.http.readJsonBody<{ readonly theaterId?: unknown; readonly subPath?: unknown }>(req);
+  if (!isPlainObject(body)) { ctx.host.http.writeJson(res, 400, { error: "invalid_request" }); return; }
+
+  const theaterId = body.theaterId;
+  if (typeof theaterId !== "string") { ctx.host.http.writeJson(res, 400, { error: "invalid_request" }); return; }
+
+  const theaterPath = ctx.host.paths.resolveTheaterPath(theaterId);
+  if (!theaterPath) { ctx.host.http.writeJson(res, 404, { error: "theater_not_found" }); return; }
+
+  const rawSubPath = typeof body.subPath === "string" ? body.subPath : "";
+  const cwdResult = await resolveGitCwd(theaterPath, rawSubPath);
+  if (!cwdResult) { ctx.host.http.writeJson(res, 403, { error: "path_outside_theater" }); return; }
+  const { gitCwd } = cwdResult;
+
+  try {
+    const result = await runGit(
+      ["log", "-n", "50", "--numstat", "--pretty=format:%x1e%H%x00%h%x00%s%x00%an%x00%ar%x00%D%x00%P"],
+      { cwd: gitCwd },
+    );
+    const commits = parseLogOutput(result.stdout);
+    ctx.host.http.writeJson(res, 200, { commits, ...(result.truncated ? { truncated: true } : {}) });
+  } catch (error) {
+    if (error instanceof GitExecutorError) {
+      if (error.code === "no_git_repo") {
+        ctx.host.http.writeJson(res, 200, { commits: [] });
+        return;
+      }
+      if (error.code === "git_unavailable") {
+        ctx.host.http.writeJson(res, 422, { error: error.code });
+        return;
+      }
+    }
+    if (isNoHeadError(error)) {
+      ctx.host.http.writeJson(res, 200, { commits: [] });
+      return;
+    }
+    throw error;
+  }
+}

--- a/runtime/fleet-plugins/diff/server/types.ts
+++ b/runtime/fleet-plugins/diff/server/types.ts
@@ -32,3 +32,25 @@ export interface ReposDiscoveryResult {
   readonly repos: readonly RepoEntry[];
   readonly truncated?: boolean;
 }
+
+export interface LogCommitEntry {
+  readonly shortHash: string;
+  readonly fullHash: string;
+  readonly subject: string;
+  readonly authorName: string;
+  readonly relTime: string;
+  readonly refs: readonly string[];
+  readonly parents: readonly string[];
+  readonly additions: number;
+  readonly deletions: number;
+}
+
+export interface LogResult {
+  readonly commits: readonly LogCommitEntry[];
+  readonly truncated?: boolean;
+}
+
+export interface CommitDiffResult {
+  readonly content: string;
+  readonly truncated?: boolean;
+}

--- a/runtime/fleet-plugins/diff/tests/commit-ref-validate.test.ts
+++ b/runtime/fleet-plugins/diff/tests/commit-ref-validate.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+// ref 검증 정규식: commit.ts의 REF_RE와 동일 계약
+const REF_RE = /^[0-9a-f]{7,40}$/i;
+
+describe("commit ref 검증 정규식", () => {
+  it("7자 short hash를 허용한다", () => {
+    expect(REF_RE.test("abc1234")).toBe(true);
+  });
+
+  it("40자 full hash를 허용한다", () => {
+    expect(REF_RE.test("abc1234def5678abc1234def5678abc1234def56")).toBe(true);
+  });
+
+  it("대소문자 혼합 hex를 허용한다", () => {
+    expect(REF_RE.test("ABC1234")).toBe(true);
+    expect(REF_RE.test("AbCdEf1")).toBe(true);
+  });
+
+  it("6자 이하(너무 짧음)를 거부한다", () => {
+    expect(REF_RE.test("abc123")).toBe(false);
+    expect(REF_RE.test("abc")).toBe(false);
+  });
+
+  it("41자 이상(너무 긴 hex)을 거부한다", () => {
+    expect(REF_RE.test("abc1234def5678abc1234def5678abc1234def567")).toBe(false);
+  });
+
+  it("HEAD를 거부한다", () => {
+    expect(REF_RE.test("HEAD")).toBe(false);
+  });
+
+  it("브랜치명(main, feature/foo)을 거부한다", () => {
+    expect(REF_RE.test("main")).toBe(false);
+    expect(REF_RE.test("feature/foo")).toBe(false);
+  });
+
+  it("태그명(v1.0.0)을 거부한다", () => {
+    expect(REF_RE.test("v1.0.0")).toBe(false);
+  });
+
+  it("경로 이탈 시도를 거부한다", () => {
+    expect(REF_RE.test("../etc/passwd")).toBe(false);
+    expect(REF_RE.test("--help")).toBe(false);
+  });
+
+  it("공백 포함 값을 거부한다", () => {
+    expect(REF_RE.test("abc1234 --something")).toBe(false);
+  });
+
+  it("빈 문자열을 거부한다", () => {
+    expect(REF_RE.test("")).toBe(false);
+  });
+
+  it("hex 이외 문자 포함을 거부한다", () => {
+    expect(REF_RE.test("xyz1234")).toBe(false);
+    expect(REF_RE.test("abc1234g")).toBe(false);
+  });
+});

--- a/runtime/fleet-plugins/diff/tests/graph-layout.test.ts
+++ b/runtime/fleet-plugins/diff/tests/graph-layout.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+
+import { layoutGraph } from "../client/graph-layout.js";
+import type { LogCommitEntry } from "../server/types.js";
+
+function makeCommit(overrides: Partial<LogCommitEntry> = {}): LogCommitEntry {
+  return {
+    shortHash: "abc1234",
+    fullHash: "abc1234def5678abc1234def5678abc1234def56",
+    subject: "test commit",
+    authorName: "Author",
+    relTime: "1 hour ago",
+    refs: [],
+    parents: [],
+    additions: 0,
+    deletions: 0,
+    ...overrides,
+  };
+}
+
+describe("layoutGraph — Phase 1 단일 레인 skeleton", () => {
+  it("① 빈 커밋 배열에서 빈 레이아웃을 반환한다", () => {
+    const layout = layoutGraph([]);
+    expect(layout.nodes).toHaveLength(0);
+    expect(layout.activeLaneCount).toBe(0);
+    expect(layout.collapsed).toBe(false);
+  });
+
+  it("② 단일 커밋에서 lane=0, connectAbove=false, connectBelow=false", () => {
+    const layout = layoutGraph([makeCommit()]);
+    expect(layout.nodes).toHaveLength(1);
+    expect(layout.nodes[0]?.lane).toBe(0);
+    expect(layout.nodes[0]?.connectAbove).toBe(false);
+    expect(layout.nodes[0]?.connectBelow).toBe(false);
+    expect(layout.activeLaneCount).toBe(1);
+    expect(layout.collapsed).toBe(false);
+  });
+
+  it("③ 여러 커밋에서 모든 lane=0, 양 끝 연결선 규칙을 따른다", () => {
+    const commits = [
+      makeCommit({ fullHash: "aaa" }),
+      makeCommit({ fullHash: "bbb" }),
+      makeCommit({ fullHash: "ccc" }),
+    ];
+    const layout = layoutGraph(commits);
+    expect(layout.nodes).toHaveLength(3);
+    expect(layout.nodes.every((n) => n.lane === 0)).toBe(true);
+    // 첫 커밋: connectAbove=false, connectBelow=true
+    expect(layout.nodes[0]?.connectAbove).toBe(false);
+    expect(layout.nodes[0]?.connectBelow).toBe(true);
+    // 중간 커밋: connectAbove=true, connectBelow=true
+    expect(layout.nodes[1]?.connectAbove).toBe(true);
+    expect(layout.nodes[1]?.connectBelow).toBe(true);
+    // 마지막 커밋: connectAbove=true, connectBelow=false
+    expect(layout.nodes[2]?.connectAbove).toBe(true);
+    expect(layout.nodes[2]?.connectBelow).toBe(false);
+  });
+
+  it("④ 첫 커밋(index 0)은 항상 isHead=true", () => {
+    const layout = layoutGraph([makeCommit({ refs: [] })]);
+    expect(layout.nodes[0]?.isHead).toBe(true);
+  });
+
+  it("⑤ refs에 'HEAD'가 포함된 커밋은 isHead=true", () => {
+    const commits = [
+      makeCommit({ refs: [] }),
+      makeCommit({ refs: ["HEAD", "refs/heads/main"] }),
+      makeCommit({ refs: [] }),
+    ];
+    const layout = layoutGraph(commits);
+    // index 0는 항상 isHead=true
+    expect(layout.nodes[0]?.isHead).toBe(true);
+    // index 1는 refs에 HEAD 포함
+    expect(layout.nodes[1]?.isHead).toBe(true);
+    // index 2는 refs에 HEAD 없음, index 0 아님 → isHead=false
+    expect(layout.nodes[2]?.isHead).toBe(false);
+  });
+
+  it("⑥ Phase 1에서 passThroughLanes/mergeFromLanes/branchToLanes는 모두 빈 배열", () => {
+    const layout = layoutGraph([makeCommit(), makeCommit(), makeCommit()]);
+    for (const node of layout.nodes) {
+      expect(node.passThroughLanes).toEqual([]);
+      expect(node.mergeFromLanes).toEqual([]);
+      expect(node.branchToLanes).toEqual([]);
+    }
+  });
+
+  it("⑦ activeLaneCount는 커밋이 있으면 1", () => {
+    const layout = layoutGraph([makeCommit(), makeCommit()]);
+    expect(layout.activeLaneCount).toBe(1);
+  });
+
+  it("⑧ collapsed는 항상 false (Phase 1)", () => {
+    const layout = layoutGraph([makeCommit(), makeCommit()]);
+    expect(layout.collapsed).toBe(false);
+  });
+});
+
+describe("layoutGraph — Phase 2 다중 레인 topology", () => {
+  it("① linear 5 commits → 모든 lane=0, passThrough=[], activeLaneCount=1, collapsed=false", () => {
+    const commits = [
+      makeCommit({ fullHash: "aaa", parents: ["bbb"] }),
+      makeCommit({ fullHash: "bbb", parents: ["ccc"] }),
+      makeCommit({ fullHash: "ccc", parents: ["ddd"] }),
+      makeCommit({ fullHash: "ddd", parents: ["eee"] }),
+      makeCommit({ fullHash: "eee", parents: [] }),
+    ];
+    const layout = layoutGraph(commits);
+    expect(layout.nodes.every((n) => n.lane === 0)).toBe(true);
+    expect(layout.nodes.every((n) => n.passThroughLanes.length === 0)).toBe(true);
+    expect(layout.activeLaneCount).toBe(1);
+    expect(layout.collapsed).toBe(false);
+  });
+
+  it("② merge commit(2 parents) → 병합 커밋 이후 새 lane 개설, mergeFromLanes/branchToLanes 정확 배정", () => {
+    // merge: hash=M, parents=[A, B]
+    // A: hash=A, parents=[]
+    // B: hash=B, parents=[]
+    const commits = [
+      makeCommit({ fullHash: "M", parents: ["A", "B"] }),
+      makeCommit({ fullHash: "A", parents: [] }),
+      makeCommit({ fullHash: "B", parents: [] }),
+    ];
+    const layout = layoutGraph(commits);
+    // M은 lane 0 (새로 개설)
+    expect(layout.nodes[0]?.lane).toBe(0);
+    // M의 branchToLanes에는 B를 기다리는 새 레인이 있어야 함
+    expect(layout.nodes[0]?.branchToLanes.length).toBeGreaterThan(0);
+    // A는 laneHeads[0] = A 이므로 lane 0 매치
+    expect(layout.nodes[1]?.lane).toBe(0);
+    // B는 branchToLanes에서 개설된 레인 매치
+    const bLane = layout.nodes[0]?.branchToLanes[0] ?? -1;
+    expect(layout.nodes[2]?.lane).toBe(bLane);
+    // A에서 mergeFromLanes는 빈 배열 (A는 M의 첫 번째 부모이므로 닫힘이 없음)
+    expect(layout.nodes[1]?.mergeFromLanes).toEqual([]);
+    // collapsed는 false (2레인 = 캡 3 이하)
+    expect(layout.collapsed).toBe(false);
+  });
+
+  it("③ octopus 4 parents → 활성 레인이 3 초과 즉시 collapsed=true", () => {
+    // C의 parents: [A, B, D, E] — 4개 부모 → 4개 레인 개설 → 캡 3 초과
+    const commits = [
+      makeCommit({ fullHash: "C", parents: ["A", "B", "D", "E"] }),
+      makeCommit({ fullHash: "A", parents: [] }),
+      makeCommit({ fullHash: "B", parents: [] }),
+      makeCommit({ fullHash: "D", parents: [] }),
+      makeCommit({ fullHash: "E", parents: [] }),
+    ];
+    const layout = layoutGraph(commits);
+    expect(layout.collapsed).toBe(true);
+    // 활성 레인은 3 이하
+    const activeLanes = new Set<number>();
+    for (const node of layout.nodes) activeLanes.add(node.lane);
+    expect(activeLanes.size).toBeLessThanOrEqual(3);
+  });
+
+  it("④ dangling parent(로그 범위 밖) → 남은 laneHead가 매치 없이 종료해도 크래시 없음", () => {
+    const commits = [
+      makeCommit({ fullHash: "A", parents: ["MISSING"] }),
+      makeCommit({ fullHash: "B", parents: [] }),
+    ];
+    expect(() => layoutGraph(commits)).not.toThrow();
+    const layout = layoutGraph(commits);
+    expect(layout.nodes).toHaveLength(2);
+  });
+});

--- a/runtime/fleet-plugins/diff/tests/hunk-parse-multi-file.test.ts
+++ b/runtime/fleet-plugins/diff/tests/hunk-parse-multi-file.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import { parseHunk } from "../client/hunk-parse.js";
+
+const MULTI_FILE_PATCH = [
+  "diff --git a/src/a.ts b/src/a.ts",
+  "index 111..222 100644",
+  "--- a/src/a.ts",
+  "+++ b/src/a.ts",
+  "@@ -1,3 +1,3 @@",
+  " ctx1",
+  "-old1",
+  "+new1",
+  " ctx2",
+  "diff --git a/src/b.ts b/src/b.ts",
+  "index 333..444 100644",
+  "--- a/src/b.ts",
+  "+++ b/src/b.ts",
+  "@@ -10,2 +10,2 @@",
+  " line10",
+  "-oldB",
+  "+newB",
+].join("\n");
+
+const RENAMED_FILE_PATCH = [
+  "diff --git a/old.ts b/new.ts",
+  "similarity index 90%",
+  "rename from old.ts",
+  "rename to new.ts",
+  "index aaa..bbb 100644",
+  "--- a/old.ts",
+  "+++ b/new.ts",
+  "@@ -1,2 +1,2 @@",
+  " ctx",
+  "-old",
+  "+new",
+].join("\n");
+
+const BINARY_AND_TEXT_PATCH = [
+  "diff --git a/img.png b/img.png",
+  "index abc..def 100644",
+  "Binary files a/img.png and b/img.png differ",
+  "diff --git a/src/code.ts b/src/code.ts",
+  "index 111..222 100644",
+  "--- a/src/code.ts",
+  "+++ b/src/code.ts",
+  "@@ -1,2 +1,2 @@",
+  " line1",
+  "-old",
+  "+new",
+].join("\n");
+
+describe("parseHunk — 다중 파일 패치", () => {
+  it("① diff --git 경계마다 file-label 라인을 삽입한다", () => {
+    const lines = parseHunk(MULTI_FILE_PATCH);
+    const fileLabels = lines.filter((l) => l.kind === "file-label");
+    expect(fileLabels).toHaveLength(2);
+    expect(fileLabels[0]?.text).toBe("src/a.ts");
+    expect(fileLabels[1]?.text).toBe("src/b.ts");
+  });
+
+  it("② file-label 이후 헤더(index, ---, +++)는 드롭된다", () => {
+    const lines = parseHunk(MULTI_FILE_PATCH);
+    const hasHeader = lines.some((l) =>
+      l.text.startsWith("index ") ||
+      l.text.startsWith("--- ") ||
+      l.text.startsWith("+++ ")
+    );
+    expect(hasHeader).toBe(false);
+  });
+
+  it("③ 파일 경계에서 라인번호가 리셋된다", () => {
+    const lines = parseHunk(MULTI_FILE_PATCH);
+    const delA = lines.find((l) => l.kind === "del" && l.text === "-old1");
+    const delB = lines.find((l) => l.kind === "del" && l.text === "-oldB");
+    expect(delA?.oldLine).toBe(2);
+    expect(delB?.oldLine).toBe(11);
+  });
+
+  it("④ 파일 내부 add/del/ctx 분류가 각각 올바르다", () => {
+    const lines = parseHunk(MULTI_FILE_PATCH);
+    const adds = lines.filter((l) => l.kind === "add");
+    const dels = lines.filter((l) => l.kind === "del");
+    const ctxs = lines.filter((l) => l.kind === "ctx");
+    expect(adds).toHaveLength(2);
+    expect(dels).toHaveLength(2);
+    expect(ctxs).toHaveLength(3);
+  });
+
+  it("⑤ 리네임 파일에서 oldPath 필드가 채워진다", () => {
+    const lines = parseHunk(RENAMED_FILE_PATCH);
+    const label = lines.find((l) => l.kind === "file-label");
+    expect(label?.text).toBe("new.ts");
+    expect(label?.oldPath).toBe("old.ts");
+  });
+
+  it("⑥ 동일 경로 파일은 oldPath가 undefined다", () => {
+    const lines = parseHunk(MULTI_FILE_PATCH);
+    const label = lines.find((l) => l.kind === "file-label");
+    expect(label?.oldPath).toBeUndefined();
+  });
+
+  it("⑦ 바이너리와 텍스트 파일이 혼합된 패치를 처리한다", () => {
+    const lines = parseHunk(BINARY_AND_TEXT_PATCH);
+    const fileLabels = lines.filter((l) => l.kind === "file-label");
+    expect(fileLabels).toHaveLength(2);
+    expect(fileLabels[0]?.text).toBe("img.png");
+    expect(fileLabels[1]?.text).toBe("src/code.ts");
+    // 바이너리 안내는 ctx로 보존
+    const ctxLines = lines.filter((l) => l.kind === "ctx");
+    expect(ctxLines.some((l) => l.text.includes("Binary files"))).toBe(true);
+  });
+
+  it("⑧ 단일 파일 diff에서도 file-label 1개가 삽입된다", () => {
+    const single = [
+      "diff --git a/src/foo.ts b/src/foo.ts",
+      "index abc..def 100644",
+      "--- a/src/foo.ts",
+      "+++ b/src/foo.ts",
+      "@@ -1,2 +1,2 @@",
+      " ctx",
+      "-old",
+      "+new",
+    ].join("\n");
+    const lines = parseHunk(single);
+    const fileLabels = lines.filter((l) => l.kind === "file-label");
+    expect(fileLabels).toHaveLength(1);
+    expect(fileLabels[0]?.text).toBe("src/foo.ts");
+  });
+});

--- a/runtime/fleet-plugins/diff/tests/hunk-parse.test.ts
+++ b/runtime/fleet-plugins/diff/tests/hunk-parse.test.ts
@@ -74,7 +74,7 @@ describe("parseHunk", () => {
   });
 
   it("④ add/del/ctx가 정확히 분류된다", () => {
-    const lines = parseHunk(SAMPLE_UNIFIED).filter((l) => l.kind !== "hunk-label");
+    const lines = parseHunk(SAMPLE_UNIFIED).filter((l) => l.kind !== "hunk-label" && l.kind !== "file-label");
     const kinds = lines.map((l) => l.kind);
     expect(kinds).toEqual(["ctx", "del", "add", "add", "ctx"]);
   });
@@ -100,13 +100,14 @@ describe("parseHunk", () => {
     ].join("\n");
     expect(() => parseHunk(binary)).not.toThrow();
     const lines = parseHunk(binary);
-    // 파일 헤더(diff --git/index)는 드롭, 바이너리 안내는 살아남는다
-    expect(lines).toHaveLength(1);
-    expect(lines[0]?.kind).toBe("ctx");
+    // diff --git는 file-label로 변환, index는 드롭, 바이너리 안내는 ctx로 살아남는다
+    const ctxLines = lines.filter((l) => l.kind === "ctx");
+    expect(ctxLines).toHaveLength(1);
+    expect(ctxLines[0]?.kind).toBe("ctx");
     // 뷰의 slice(1) 규약에 맞춰 앞 공백 프리픽스가 붙는다
-    expect(lines[0]?.text).toBe(" Binary files a/img.png and b/img.png differ");
-    expect(lines[0]?.oldLine).toBeUndefined();
-    expect(lines[0]?.newLine).toBeUndefined();
+    expect(ctxLines[0]?.text).toBe(" Binary files a/img.png and b/img.png differ");
+    expect(ctxLines[0]?.oldLine).toBeUndefined();
+    expect(ctxLines[0]?.newLine).toBeUndefined();
   });
 
   it("⑧ '\\ No newline at end of file' 어노테이션은 결과에서 제외되고 라인번호를 소모하지 않는다", () => {

--- a/runtime/fleet-plugins/diff/tests/log-parse.test.ts
+++ b/runtime/fleet-plugins/diff/tests/log-parse.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { formatRelTime, refBadges } from "../client/log-parse.js";
+import type { LogCommitEntry } from "../server/types.js";
+
+function makeEntry(overrides: Partial<LogCommitEntry> = {}): LogCommitEntry {
+  return {
+    shortHash: "abc1234",
+    fullHash: "abc1234def5678abc1234def5678abc1234def56",
+    subject: "feat: add something",
+    authorName: "Author Name",
+    relTime: "3 days ago",
+    refs: [],
+    parents: ["parent1234"],
+    additions: 10,
+    deletions: 2,
+    ...overrides,
+  };
+}
+
+describe("formatRelTime", () => {
+  it("서버 응답의 relTime을 그대로 반환한다", () => {
+    const entry = makeEntry({ relTime: "5 hours ago" });
+    expect(formatRelTime(entry)).toBe("5 hours ago");
+  });
+});
+
+describe("refBadges", () => {
+  it("refs가 없으면 빈 배열을 반환한다", () => {
+    expect(refBadges(makeEntry({ refs: [] }))).toEqual([]);
+  });
+
+  it("HEAD를 head 종류 배지로 분류한다", () => {
+    const badges = refBadges(makeEntry({ refs: ["HEAD"] }));
+    expect(badges).toHaveLength(1);
+    expect(badges[0]).toEqual({ label: "HEAD", kind: "head" });
+  });
+
+  it("'tag: v1.0.0' 형식 ref를 tag 배지로 분류하고 'tag: ' 접두사를 제거한다", () => {
+    const badges = refBadges(makeEntry({ refs: ["tag: v1.0.0"] }));
+    expect(badges).toHaveLength(1);
+    expect(badges[0]).toEqual({ label: "v1.0.0", kind: "tag" });
+  });
+
+  it("'refs/heads/main' 형식 ref를 branch 배지로 분류하고 접두사를 제거한다", () => {
+    const badges = refBadges(makeEntry({ refs: ["refs/heads/main"] }));
+    expect(badges).toHaveLength(1);
+    expect(badges[0]).toEqual({ label: "main", kind: "branch" });
+  });
+
+  it("'refs/worktrees/' 접두사 ref를 worktree 배지로 분류하고 접두사를 제거한다", () => {
+    const badges = refBadges(makeEntry({ refs: ["refs/worktrees/my-wt"] }));
+    expect(badges).toHaveLength(1);
+    expect(badges[0]).toEqual({ label: "my-wt", kind: "worktree" });
+  });
+
+  it("알 수 없는 ref는 branch 배지로 처리한다", () => {
+    const badges = refBadges(makeEntry({ refs: ["origin/main"] }));
+    expect(badges).toHaveLength(1);
+    expect(badges[0]?.kind).toBe("branch");
+  });
+
+  it("HEAD + branch + tag 혼합 ref를 모두 분류한다", () => {
+    const badges = refBadges(makeEntry({ refs: ["HEAD", "refs/heads/main", "tag: v2.0"] }));
+    expect(badges).toHaveLength(3);
+    expect(badges[0]?.kind).toBe("head");
+    expect(badges[1]?.kind).toBe("branch");
+    expect(badges[2]?.kind).toBe("tag");
+  });
+});


### PR DESCRIPTION
## Summary
- Diff 패널에 "Changes" 아래 접이식 **History 섹션**을 추가합니다. 최근 커밋(해시·subject·author·상대시간·numstat·HEAD/tag/ref 배지)을 나열하고, 커밋을 선택하면 기존 확장 diff 페인에 그 커밋의 다중 파일 패치(`git show`)를 렌더합니다.
- **Flat/Graph 토글**로 커밋 그래프 거터를 켤 수 있습니다. Phase 1은 단일 레인 spine(node+line, HEAD는 brass 링), Phase 2는 `%P` parents 기반 **다중 레인 topology**(병합/분기 커넥터, 활성 레인 ≤3 하드캡 + 초과 시 collapse). 범위는 HEAD 도달 가능 히스토리로 한정합니다.
- 신규 서버 라우트 `log`(git log)·`commit`(git show)을 추가하며, `commit` 라우트의 `ref`는 `/^[0-9a-f]{7,40}$/i`로 엄격 검증해 git 인자 인젝션을 차단합니다. 두 라우트 모두 기존 `isTerminalAuthorized` + `resolveGitCwd` 이중 컨테인먼트를 재사용합니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/diff typecheck` — green
- [x] `pnpm --filter @fleet-plugins/diff test` — 76/76 pass (8 files; log 파서·ref 검증·다중파일 hunk·레인 배정 단위테스트 포함)
- [x] `pnpm --filter @fleet-plugins/diff build` (tsc) — green
- [x] 루트 `pnpm build` — green (전역 회귀)
- [x] 실브라우저 e2e(격리 콘솔): History 50커밋·배지·Flat/Graph 토글·SVG 거터(HEAD 링·구조색)·커밋클릭→다중파일 diff(numstat 정확)·ref 인젝션 400 차단
- [x] Sentinel 보안/정확성 리뷰 PASS + 발견 3건 반영(오버피팅 1건 배제)

## Changelog
- [x] `.changelog.d/diff-log-history-graph.md` 포함 (`section: Added`, `[fleet-console]`)