### PR TITLE
refactor(core-unified-agent): rename Claude and Codex display names

### DIFF
--- a/.changelog.d/rename-provider-display-names.md
+++ b/.changelog.d/rename-provider-display-names.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- [core-unified-agent] Renamed the Claude and Codex provider display names to "Claude Code" and "Codex".

--- a/packages/core-unified-agent/models.json
+++ b/packages/core-unified-agent/models.json
@@ -3,7 +3,7 @@
   "updatedAt": "2026-07-04T00:00:00Z",
   "providers": {
     "claude": {
-      "name": "Claude Code with Anthropic",
+      "name": "Claude Code",
       "defaultModel": "opus[1m]",
       "models": [
         { "modelId": "haiku", "name": "Claude Haiku", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max"], "default": "low" } },
@@ -16,7 +16,7 @@
       ]
     },
     "codex": {
-      "name": "OpenAI Codex CLI",
+      "name": "Codex",
       "defaultModel": "gpt-5.4",
       "models": [
         { "modelId": "gpt-5.4", "name": "GPT-5.4", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh"], "default": "high" } },

--- a/packages/fleet-carriers/tests/dispatch/framework.test.ts
+++ b/packages/fleet-carriers/tests/dispatch/framework.test.ts
@@ -578,14 +578,14 @@ describe("carrier_dispatch taskforce stream metadata", () => {
     expect(registered.tracks).toEqual([
       expect.objectContaining({
         displayCli: "claude",
-        displayName: "Claude Code with Anthropic",
+        displayName: "Claude Code",
         effort: claudeEffort,
         kind: "backend",
         model: claudeModel,
       }),
       expect.objectContaining({
         displayCli: "codex",
-        displayName: "OpenAI Codex CLI",
+        displayName: "Codex",
         effort: codexEffort,
         kind: "backend",
         model: codexModel,

--- a/runtime/fleet-cli/tests/job-bar-renderer.test.ts
+++ b/runtime/fleet-cli/tests/job-bar-renderer.test.ts
@@ -317,7 +317,7 @@ describe("job bar renderer", () => {
     const text = stripAnsi(rendered);
 
     expect(text).toContain("gpt safe - high");
-    expect(text).toContain("OpenAI Codex CLI");
+    expect(text).toContain("Codex");
     expect(rendered).not.toContain("\x1b]52");
     expect(rendered).not.toContain("\u009b31m");
     expect(rendered).not.toContain("\u202e");


### PR DESCRIPTION
## Summary
- Provider 카탈로그 SSoT(`packages/core-unified-agent/models.json`)의 표시 이름을 단순화합니다: "Claude Code with Anthropic" -> "Claude Code", "OpenAI Codex CLI" -> "Codex".
- 이 표시 이름은 Job Bar 렌더러와 Task Force 트랙 메타데이터로 파생되므로, 해당 테스트 기대값을 함께 동기화했습니다. `name`은 순수 display 필드로 provider id/cliType 로직과 분리되어 있어 동작 변화는 없습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-carriers exec vitest run tests/dispatch/framework.test.ts` — 25 passed
- [x] `pnpm --filter @dotobokuri/fleet-cli exec vitest run tests/job-bar-renderer.test.ts` — 19 passed
- [x] `pnpm --filter @dotobokuri/core-unified-agent build` — pass (models.json 스키마 검증)
- [x] `pnpm check:core-boundary` — pass
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK

## Changelog
- [x] `.changelog.d/rename-provider-display-names.md` 포함 (section: Changed, `[core-unified-agent]`).