### PR TITLE
fix(fleet-console): restore markdown preview assets

### DIFF
--- a/.changelog.d/fix-file-explorer-markdown-assets.md
+++ b/.changelog.d/fix-file-explorer-markdown-assets.md
@@ -2,4 +2,4 @@
 section: Fixed
 ---
 
-- [fleet-console] Restore local images and file links in File Explorer markdown previews.
+- [fleet-console] Restore README images and file links in File Explorer markdown previews.

--- a/.changelog.d/fix-file-explorer-markdown-assets.md
+++ b/.changelog.d/fix-file-explorer-markdown-assets.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- [fleet-console] Restore local images and file links in File Explorer markdown previews.

--- a/runtime/fleet-console/core/host/security-headers.ts
+++ b/runtime/fleet-console/core/host/security-headers.ts
@@ -3,7 +3,7 @@ import type http from "node:http";
 // connect-src에 https://api.github.com만 명시 허용한다 — GNB의 GitHub star 카운트가 토큰 없이 공개
 // REST(stargazers_count)를 클라이언트에서 직접 읽기 위함. 와일드카드/서브도메인은 열지 않는다.
 export const CONSOLE_SECURITY_HEADERS = {
-  "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' ws: wss: https://api.github.com; object-src 'none'; base-uri 'none'",
+  "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://img.shields.io; font-src 'self' data:; connect-src 'self' ws: wss: https://api.github.com; object-src 'none'; base-uri 'none'",
   "X-Content-Type-Options": "nosniff",
   "Referrer-Policy": "no-referrer",
   "Cache-Control": "no-store",

--- a/runtime/fleet-console/tests/security-headers.test.ts
+++ b/runtime/fleet-console/tests/security-headers.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { CONSOLE_SECURITY_HEADERS } from "../core/host/security-headers.js";
+
+describe("console security headers", () => {
+  it("allows only the badge image host needed by markdown previews", () => {
+    const policy = CONSOLE_SECURITY_HEADERS["Content-Security-Policy"];
+    expect(policy).toContain("img-src 'self' data: https://img.shields.io");
+    expect(policy).not.toContain("img-src *");
+  });
+});

--- a/runtime/fleet-plugins/file-explorer/client/explorer.css
+++ b/runtime/fleet-plugins/file-explorer/client/explorer.css
@@ -389,6 +389,20 @@
   padding: 16px;
 }
 
+.fexp-md-blocked-image {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 3px 8px;
+  border: 1px dashed color-mix(in oklch, var(--ink-fog) 48%, transparent);
+  border-radius: var(--radius-sm);
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.4;
+  vertical-align: middle;
+}
+
 /* ── 이미지 뷰어 ── */
 .fexp-img-wrap {
   height: 100%;

--- a/runtime/fleet-plugins/file-explorer/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/rail-panel.tsx
@@ -55,17 +55,20 @@ function FileExplorerPanel(ctx: RailPanelContext) {
   // theaterId 변경마다 새 클라이언트 인스턴스를 생성한다(PluginFilesClient는 stateless).
   const files = useMemo(() => makeFilesClient(theaterId), [theaterId]);
 
-  const handleSelect = useCallback(async (entry: FolderEntry) => {
-    if (entry.kind !== "file") return;
-    setSelectedPath(theaterId, entry.relativePath);
-    const name = entry.name;
+  const openFilePath = useCallback(async (relativePath: string, displayName?: string) => {
+    if (!theaterId) {
+      setViewState(theaterId, { kind: "error", message: "no_theater" });
+      return;
+    }
+    setSelectedPath(theaterId, relativePath);
+    const name = displayName ?? relativePath.split("/").filter(Boolean).at(-1) ?? relativePath;
     const ext = name.slice(name.lastIndexOf(".")).toLowerCase();
 
     if (IMAGE_EXTS.has(ext)) {
       const src = theaterId
-        ? `/plugins/file-explorer/files/image?theaterId=${encodeURIComponent(theaterId)}&path=${encodeURIComponent(entry.relativePath)}`
+        ? `/plugins/file-explorer/files/image?theaterId=${encodeURIComponent(theaterId)}&path=${encodeURIComponent(relativePath)}`
         : "";
-      setViewState(theaterId, { kind: "image", relativePath: entry.relativePath, name, src });
+      setViewState(theaterId, { kind: "image", relativePath, name, src });
       return;
     }
 
@@ -75,7 +78,7 @@ function FileExplorerPanel(ctx: RailPanelContext) {
       const res = await fetch("/plugins/file-explorer/files/read", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ theaterId, relativePath: entry.relativePath }),
+        body: JSON.stringify({ theaterId, relativePath }),
       });
       if (!res.ok) {
         const payload = await res.json() as { error?: string };
@@ -96,6 +99,10 @@ function FileExplorerPanel(ctx: RailPanelContext) {
       }
     }
   }, [theaterId]);
+  const handleSelect = useCallback(async (entry: FolderEntry) => {
+    if (entry.kind !== "file") return;
+    await openFilePath(entry.relativePath, entry.name);
+  }, [openFilePath]);
 
   const handleCloseViewer = useCallback(() => {
     setViewState(theaterId, { kind: "none" });
@@ -160,7 +167,13 @@ function FileExplorerPanel(ctx: RailPanelContext) {
               {viewState.kind === "loading" && <div className="fexp-viewer-loading">Loading…</div>}
               {viewState.kind === "error" && <div className="fexp-viewer-error">{viewState.message}</div>}
               {viewState.kind === "code" && viewState.lang === "markdown" && (
-                <MarkdownViewer content={viewState.content} truncated={viewState.truncated} />
+                <MarkdownViewer
+                  content={viewState.content}
+                  onOpenPath={openFilePath}
+                  relativePath={viewState.relativePath}
+                  theaterId={theaterId}
+                  truncated={viewState.truncated}
+                />
               )}
               {viewState.kind === "code" && viewState.lang !== "markdown" && (
                 <CodeViewer content={viewState.content} lang={viewState.lang} truncated={viewState.truncated} />

--- a/runtime/fleet-plugins/file-explorer/client/viewer/markdown-links.ts
+++ b/runtime/fleet-plugins/file-explorer/client/viewer/markdown-links.ts
@@ -1,5 +1,6 @@
 export const MARKDOWN_IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".webp", ".gif"]);
 
+const ALLOWED_EXTERNAL_IMAGE_HOSTS = new Set(["img.shields.io"]);
 const EXTERNAL_REF_PATTERN = /^[a-z][a-z0-9+.-]*:/i;
 
 export function resolveMarkdownFileRef(rawRef: string, currentRelativePath: string): string | null {
@@ -22,6 +23,15 @@ export function isSupportedMarkdownImagePath(relativePath: string): boolean {
 
 export function buildFileExplorerImageSrc(theaterId: string, relativePath: string): string {
   return `/plugins/file-explorer/files/image?theaterId=${encodeURIComponent(theaterId)}&path=${encodeURIComponent(relativePath)}`;
+}
+
+export function isAllowedExternalMarkdownImageSrc(rawSrc: string): boolean {
+  try {
+    const url = new URL(rawSrc);
+    return url.protocol === "https:" && ALLOWED_EXTERNAL_IMAGE_HOSTS.has(url.hostname);
+  } catch {
+    return false;
+  }
 }
 
 function stripQueryAndHash(value: string): string {

--- a/runtime/fleet-plugins/file-explorer/client/viewer/markdown-links.ts
+++ b/runtime/fleet-plugins/file-explorer/client/viewer/markdown-links.ts
@@ -1,0 +1,61 @@
+export const MARKDOWN_IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".webp", ".gif"]);
+
+const EXTERNAL_REF_PATTERN = /^[a-z][a-z0-9+.-]*:/i;
+
+export function resolveMarkdownFileRef(rawRef: string, currentRelativePath: string): string | null {
+  const trimmed = rawRef.trim();
+  if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith("//") || EXTERNAL_REF_PATTERN.test(trimmed)) return null;
+
+  const pathOnly = stripQueryAndHash(trimmed);
+  if (!pathOnly) return null;
+
+  const decoded = decodeMarkdownPath(pathOnly);
+  if (decoded === null) return null;
+
+  return normalizeRelativePath(decoded, currentRelativePath);
+}
+
+export function isSupportedMarkdownImagePath(relativePath: string): boolean {
+  const lower = stripQueryAndHash(relativePath).toLowerCase();
+  return [...MARKDOWN_IMAGE_EXTENSIONS].some((extension) => lower.endsWith(extension));
+}
+
+export function buildFileExplorerImageSrc(theaterId: string, relativePath: string): string {
+  return `/plugins/file-explorer/files/image?theaterId=${encodeURIComponent(theaterId)}&path=${encodeURIComponent(relativePath)}`;
+}
+
+function stripQueryAndHash(value: string): string {
+  const markerIndex = value.search(/[?#]/);
+  return markerIndex === -1 ? value : value.slice(0, markerIndex);
+}
+
+function decodeMarkdownPath(value: string): string | null {
+  try {
+    return decodeURI(value);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeRelativePath(rawPath: string, currentRelativePath: string): string | null {
+  const normalizedInput = rawPath.replace(/\\/g, "/");
+  const baseDir = currentRelativePath.includes("/")
+    ? currentRelativePath.slice(0, currentRelativePath.lastIndexOf("/"))
+    : "";
+  const candidate = normalizedInput.startsWith("/")
+    ? normalizedInput
+    : `${baseDir}/${normalizedInput}`;
+  const segments: string[] = [];
+
+  for (const segment of candidate.split("/")) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      if (segments.length === 0) return null;
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+
+  return segments.length > 0 ? segments.join("/") : null;
+}

--- a/runtime/fleet-plugins/file-explorer/client/viewer/markdown-links.ts
+++ b/runtime/fleet-plugins/file-explorer/client/viewer/markdown-links.ts
@@ -49,8 +49,9 @@ function decodeMarkdownPath(value: string): string | null {
 
 function normalizeRelativePath(rawPath: string, currentRelativePath: string): string | null {
   const normalizedInput = rawPath.replace(/\\/g, "/");
-  const baseDir = currentRelativePath.includes("/")
-    ? currentRelativePath.slice(0, currentRelativePath.lastIndexOf("/"))
+  const normalizedCurrentPath = currentRelativePath.replace(/\\/g, "/");
+  const baseDir = normalizedCurrentPath.includes("/")
+    ? normalizedCurrentPath.slice(0, normalizedCurrentPath.lastIndexOf("/"))
     : "";
   const candidate = normalizedInput.startsWith("/")
     ? normalizedInput

--- a/runtime/fleet-plugins/file-explorer/client/viewer/markdown.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/viewer/markdown.tsx
@@ -5,6 +5,7 @@ import "@fleet-console/markdown/styles.css";
 
 import {
   buildFileExplorerImageSrc,
+  isAllowedExternalMarkdownImageSrc,
   isSupportedMarkdownImagePath,
   resolveMarkdownFileRef,
 } from "./markdown-links.js";
@@ -109,7 +110,7 @@ export function MarkdownViewer({ content, onOpenPath, relativePath, theaterId, t
 
 // 신뢰 불가 미리보기에서 위험 요소를 무력화한다(구 정규식 렌더러의 안전 수준 보존):
 // - 로컬 상대 링크는 href 대신 data-fexp-open-path로 바꿔 SPA URL hijack을 차단한다.
-// - 로컬 이미지는 same-origin 이미지 라우트로만 되살리고, 외부 이미지는 auto-fetch를 차단한다.
+// - 로컬 이미지는 same-origin 이미지 라우트로 되살리고, allowlist 밖 외부 이미지는 auto-fetch를 차단한다.
 function neutralizeUntrustedDom(root: ParentNode, options: NeutralizeOptions): void {
   for (const anchor of root.querySelectorAll("a[href]")) {
     const href = anchor.getAttribute("href") ?? "";
@@ -141,6 +142,11 @@ function neutralizeUntrustedDom(root: ParentNode, options: NeutralizeOptions): v
       continue;
     }
     element.removeAttribute("data-fexp-local-image-path");
+    if (element.tagName === "IMG" && isAllowedExternalMarkdownImageSrc(src)) {
+      element.removeAttribute("srcset");
+      element.removeAttribute("aria-hidden");
+      continue;
+    }
     const localPath = resolveMarkdownFileRef(src, options.currentRelativePath);
     element.removeAttribute("srcset");
     if (element.tagName === "IMG" && options.theaterId && localPath && isSupportedMarkdownImagePath(localPath)) {

--- a/runtime/fleet-plugins/file-explorer/client/viewer/markdown.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/viewer/markdown.tsx
@@ -3,26 +3,40 @@ import { renderMarkdown } from "@fleet-console/markdown/core";
 import { installDiagramHydrator } from "@fleet-console/markdown/mermaid";
 import "@fleet-console/markdown/styles.css";
 
+import {
+  buildFileExplorerImageSrc,
+  isSupportedMarkdownImagePath,
+  resolveMarkdownFileRef,
+} from "./markdown-links.js";
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 interface MarkdownViewerProps {
   readonly content: string;
+  readonly onOpenPath: (relativePath: string) => void;
+  readonly relativePath: string;
+  readonly theaterId: string | null;
   readonly truncated?: boolean;
+}
+
+interface NeutralizeOptions {
+  readonly allowLocalImageMarkers: boolean;
+  readonly currentRelativePath: string;
+  readonly theaterId: string | null;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export function MarkdownViewer({ content, truncated }: MarkdownViewerProps) {
+export function MarkdownViewer({ content, onOpenPath, relativePath, theaterId, truncated }: MarkdownViewerProps) {
   // file-explorer는 신뢰할 수 없는 임의 .md를 미리보기하므로, 렌더 HTML을 DOM에 mount하기 전에
-  // 위험 요소를 무력화한다. 특히 이미지 src는 dangerouslySetInnerHTML로 삽입되는 즉시 브라우저가
-  // fetch하므로(렌더 이후 실행되는 useEffect로는 이미 늦다) 반드시 mount 전에 제거해야 추적
-  // (tracking pixel)·IP 노출을 막을 수 있다. 경로 링크 href도 함께 사전 제거한다.
+  // 위험 요소를 무력화한다. 로컬 이미지/링크는 안전한 console 내부 경로로만 되살리고, 외부
+  // 이미지는 mount 전에 제거해야 추적(tracking pixel)·IP 노출을 막을 수 있다.
   const html = useMemo(() => {
     const rendered = renderMarkdown(content).html;
     const doc = new DOMParser().parseFromString(rendered, "text/html");
-    neutralizeUntrustedDom(doc.body);
+    neutralizeUntrustedDom(doc.body, { allowLocalImageMarkers: false, currentRelativePath: relativePath, theaterId });
     return doc.body.innerHTML;
-  }, [content]);
+  }, [content, relativePath, theaterId]);
   const rootRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -31,11 +45,11 @@ export function MarkdownViewer({ content, truncated }: MarkdownViewerProps) {
     installDiagramHydrator(root);
     // Mermaid 하이드레이터가 비동기로 삽입하는 노드/속성(SPA href 등)도 즉시 무력화한다
     // (mount 전 사전 처리만으로는 비동기 삽입분이 누락되기 때문).
-    neutralizeUntrustedDom(root);
-    const observer = new MutationObserver(() => neutralizeUntrustedDom(root));
+    neutralizeUntrustedDom(root, { allowLocalImageMarkers: true, currentRelativePath: relativePath, theaterId });
+    const observer = new MutationObserver(() => neutralizeUntrustedDom(root, { allowLocalImageMarkers: true, currentRelativePath: relativePath, theaterId }));
     observer.observe(root, { childList: true, subtree: true, attributes: true, attributeFilter: ["href", "src", "srcset"] });
     return () => observer.disconnect();
-  }, [html]);
+  }, [html, relativePath, theaterId]);
 
   // 공유 렌더러가 코드 블록에 주입하는 Copy 버튼(data-action="copy-code")을 처리한다.
   // codex는 자체 위임 핸들러를 두지만 file-explorer엔 없어 버튼이 무동작이었다 —
@@ -52,6 +66,29 @@ export function MarkdownViewer({ content, truncated }: MarkdownViewerProps) {
       button.textContent = original;
     }, 1200);
   }, []);
+  const handleLinkClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    const localLink = target.closest<HTMLElement>("[data-fexp-open-path]");
+    if (!localLink) return;
+    const nextPath = localLink.dataset.fexpOpenPath;
+    if (!nextPath) return;
+    e.preventDefault();
+    onOpenPath(nextPath);
+  }, [onOpenPath]);
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== "Enter" && e.key !== " ") return;
+    const target = e.target as HTMLElement;
+    const localLink = target.closest<HTMLElement>("[data-fexp-open-path]");
+    if (!localLink) return;
+    const nextPath = localLink.dataset.fexpOpenPath;
+    if (!nextPath) return;
+    e.preventDefault();
+    onOpenPath(nextPath);
+  }, [onOpenPath]);
+  const handleClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    handleCopyClick(e);
+    handleLinkClick(e);
+  }, [handleCopyClick, handleLinkClick]);
 
   return (
     <div className="fexp-md-wrap">
@@ -59,7 +96,8 @@ export function MarkdownViewer({ content, truncated }: MarkdownViewerProps) {
       <div
         ref={rootRef}
         className="markdown-body"
-        onClick={handleCopyClick}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: html }}
       />
@@ -70,22 +108,56 @@ export function MarkdownViewer({ content, truncated }: MarkdownViewerProps) {
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 // 신뢰 불가 미리보기에서 위험 요소를 무력화한다(구 정규식 렌더러의 안전 수준 보존):
-// - 상대/절대 경로 링크 href 제거 — 클릭(중간·우클릭 'open link' 포함) 시 console SPA 탭
-//   hijack을 차단한다. 외부 링크(http/mailto)와 문서 내 앵커(#)는 보존한다.
-// - 이미지 src 제거 — 외부 이미지 auto-fetch로 인한 추적·IP 노출을 차단한다.
-function neutralizeUntrustedDom(root: ParentNode): void {
+// - 로컬 상대 링크는 href 대신 data-fexp-open-path로 바꿔 SPA URL hijack을 차단한다.
+// - 로컬 이미지는 same-origin 이미지 라우트로만 되살리고, 외부 이미지는 auto-fetch를 차단한다.
+function neutralizeUntrustedDom(root: ParentNode, options: NeutralizeOptions): void {
   for (const anchor of root.querySelectorAll("a[href]")) {
     const href = anchor.getAttribute("href") ?? "";
-    if (href && !/^(https?:|mailto:|#)/i.test(href)) {
+    const localPath = resolveMarkdownFileRef(href, options.currentRelativePath);
+    if (localPath) {
+      anchor.removeAttribute("href");
+      anchor.setAttribute("role", "link");
+      anchor.setAttribute("tabindex", "0");
+      anchor.setAttribute("data-fexp-open-path", localPath);
+      anchor.removeAttribute("aria-disabled");
+    } else if (href && !/^(https?:|mailto:|#)/i.test(href)) {
       anchor.removeAttribute("href");
       anchor.setAttribute("role", "link");
       anchor.setAttribute("aria-disabled", "true");
     }
   }
-  // 이미지 로드 속성(src·srcset)을 제거해 외부 auto-fetch를 차단한다(img 및 picture>source 모두).
-  for (const el of root.querySelectorAll("img[src], img[srcset], source[src], source[srcset]")) {
-    el.removeAttribute("src");
-    el.removeAttribute("srcset");
-    if (el.tagName === "IMG") el.setAttribute("aria-hidden", "true");
+
+  for (const element of root.querySelectorAll("img[src], img[srcset], source[src], source[srcset]")) {
+    const src = element.getAttribute("src") ?? "";
+    const localImagePath = element.getAttribute("data-fexp-local-image-path");
+    if (
+      element.tagName === "IMG"
+      && options.allowLocalImageMarkers
+      && options.theaterId
+      && localImagePath
+      && src === buildFileExplorerImageSrc(options.theaterId, localImagePath)
+    ) {
+      element.removeAttribute("srcset");
+      continue;
+    }
+    element.removeAttribute("data-fexp-local-image-path");
+    const localPath = resolveMarkdownFileRef(src, options.currentRelativePath);
+    element.removeAttribute("srcset");
+    if (element.tagName === "IMG" && options.theaterId && localPath && isSupportedMarkdownImagePath(localPath)) {
+      element.setAttribute("src", buildFileExplorerImageSrc(options.theaterId, localPath));
+      element.setAttribute("data-fexp-local-image-path", localPath);
+      element.removeAttribute("aria-hidden");
+      continue;
+    }
+    element.removeAttribute("src");
+    if (element.tagName === "IMG") replaceBlockedImage(element);
   }
+}
+
+function replaceBlockedImage(element: Element): void {
+  const alt = element.getAttribute("alt")?.trim();
+  const placeholder = element.ownerDocument.createElement("span");
+  placeholder.className = "fexp-md-blocked-image";
+  placeholder.textContent = alt ? `Image blocked: ${alt}` : "Image blocked";
+  element.replaceWith(placeholder);
 }

--- a/runtime/fleet-plugins/file-explorer/server/image-server.ts
+++ b/runtime/fleet-plugins/file-explorer/server/image-server.ts
@@ -19,7 +19,7 @@ export interface ImageReadResult {
   readonly buffer: Buffer;
 }
 
-const IMAGE_SIZE_CAP = 4 * 1024 * 1024;
+const IMAGE_SIZE_CAP = 16 * 1024 * 1024;
 
 const MIME_ALLOWLIST: Readonly<Record<string, string>> = {
   ".png": "image/png",

--- a/runtime/fleet-plugins/file-explorer/tests/file-reader-security.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/file-reader-security.test.ts
@@ -22,6 +22,7 @@ beforeAll(async () => {
   // Theater 안 정상 파일
   await fs.promises.writeFile(path.join(theaterPath, "normal.txt"), "hello");
   await fs.promises.writeFile(path.join(theaterPath, "normal.png"), Buffer.alloc(4, 0));
+  await fs.promises.writeFile(path.join(theaterPath, "readme-demo.gif"), Buffer.alloc(10 * 1024 * 1024, 0));
 
   // Theater 안에서 Theater 밖을 가리키는 심링크
   await fs.promises.symlink(
@@ -62,6 +63,12 @@ describe("readFileForTheater — symlink containment", () => {
 });
 
 describe("readImageForTheater — symlink containment", () => {
+  it("serves README-scale local GIF assets inside the Theater", async () => {
+    const result = await readImageForTheater(theaterPath, "readme-demo.gif");
+    expect(result.mimeType).toBe("image/gif");
+    expect(result.buffer.byteLength).toBe(10 * 1024 * 1024);
+  });
+
   it("rejects a symlinked image that resolves outside the Theater", async () => {
     await expect(
       readImageForTheater(theaterPath, "link-outside.png"),

--- a/runtime/fleet-plugins/file-explorer/tests/markdown-links.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/markdown-links.test.ts
@@ -18,6 +18,11 @@ describe("file explorer markdown links", () => {
     expect(resolveMarkdownFileRef("./setup.md#install", "docs/guides/README.md")).toBe("docs/guides/setup.md");
   });
 
+  it("Windows 경로 구분자로 전달된 현재 문서 위치도 정규화한다", () => {
+    expect(resolveMarkdownFileRef("./image.png", "docs\\guides\\README.md")).toBe("docs/guides/image.png");
+    expect(resolveMarkdownFileRef("../assets/logo.png", "docs\\guides\\README.md")).toBe("docs/assets/logo.png");
+  });
+
   it("외부 링크와 root 밖으로 나가는 링크는 내부 파일 링크로 바꾸지 않는다", () => {
     expect(resolveMarkdownFileRef("https://example.com/badge.svg", "README.md")).toBeNull();
     expect(resolveMarkdownFileRef("//example.com/badge.svg", "README.md")).toBeNull();

--- a/runtime/fleet-plugins/file-explorer/tests/markdown-links.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/markdown-links.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildFileExplorerImageSrc,
+  isAllowedExternalMarkdownImageSrc,
   isSupportedMarkdownImagePath,
   resolveMarkdownFileRef,
 } from "../client/viewer/markdown-links.js";
@@ -34,5 +35,11 @@ describe("file explorer markdown links", () => {
     expect(isSupportedMarkdownImagePath(".github/logo.png")).toBe(true);
     expect(isSupportedMarkdownImagePath(".github/fleet-harness.gif")).toBe(true);
     expect(isSupportedMarkdownImagePath(".github/logo.svg")).toBe(false);
+  });
+
+  it("README badge용 shields.io HTTPS 이미지만 외부 auto-fetch를 허용한다", () => {
+    expect(isAllowedExternalMarkdownImageSrc("https://img.shields.io/npm/v/@dotobokuri/fleet-cli?color=blue")).toBe(true);
+    expect(isAllowedExternalMarkdownImageSrc("http://img.shields.io/npm/v/pkg")).toBe(false);
+    expect(isAllowedExternalMarkdownImageSrc("https://example.com/tracker.png")).toBe(false);
   });
 });

--- a/runtime/fleet-plugins/file-explorer/tests/markdown-links.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/markdown-links.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFileExplorerImageSrc,
+  isSupportedMarkdownImagePath,
+  resolveMarkdownFileRef,
+} from "../client/viewer/markdown-links.js";
+
+describe("file explorer markdown links", () => {
+  it("README 기준 상대 이미지 경로를 Theater 내부 경로로 해석한다", () => {
+    expect(resolveMarkdownFileRef(".github/logo.png", "README.md")).toBe(".github/logo.png");
+    expect(resolveMarkdownFileRef("./docs/fleet-development-reference.md", "README.md")).toBe("docs/fleet-development-reference.md");
+  });
+
+  it("하위 문서의 상대 링크를 현재 문서 위치 기준으로 정규화한다", () => {
+    expect(resolveMarkdownFileRef("../assets/logo.png", "docs/guides/README.md")).toBe("docs/assets/logo.png");
+    expect(resolveMarkdownFileRef("./setup.md#install", "docs/guides/README.md")).toBe("docs/guides/setup.md");
+  });
+
+  it("외부 링크와 root 밖으로 나가는 링크는 내부 파일 링크로 바꾸지 않는다", () => {
+    expect(resolveMarkdownFileRef("https://example.com/badge.svg", "README.md")).toBeNull();
+    expect(resolveMarkdownFileRef("//example.com/badge.svg", "README.md")).toBeNull();
+    expect(resolveMarkdownFileRef("../../etc/passwd", "README.md")).toBeNull();
+    expect(resolveMarkdownFileRef("#quick-start", "README.md")).toBeNull();
+  });
+
+  it("image route는 same-origin plugin 경로와 인코딩된 Theater/path query만 만든다", () => {
+    expect(buildFileExplorerImageSrc("abc 123", ".github/logo.png")).toBe(
+      "/plugins/file-explorer/files/image?theaterId=abc%20123&path=.github%2Flogo.png",
+    );
+  });
+
+  it("서버 이미지 allowlist와 맞는 markdown image 확장자만 지원한다", () => {
+    expect(isSupportedMarkdownImagePath(".github/logo.png")).toBe(true);
+    expect(isSupportedMarkdownImagePath(".github/fleet-harness.gif")).toBe(true);
+    expect(isSupportedMarkdownImagePath(".github/logo.svg")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Restores README images in File Explorer markdown previews by routing local assets through the existing same-origin image endpoint.
- Turns local markdown file links into File Explorer viewer navigation instead of stripping them.
- Allows `img.shields.io` README badge images through the preview sanitizer and console CSP while keeping other external image auto-fetches blocked.

## Type of Change
- [ ] feat — new feature or carrier capability
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope
- [ ] `extensions/core`
- [ ] `extensions/fleet` (Admiral / Bridge / Carriers)
- [ ] `extensions/boot`
- [ ] `extensions/diagnostics`
- [ ] `extensions/metaphor`
- [ ] `packages/unified-agent`
- [ ] `bin/` or root tooling
- [ ] Documentation (README / SETUP / AGENTS.md)
- [x] Fleet Console / File Explorer plugin

## Test Plan
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `pnpm --filter @fleet-plugins/file-explorer test`
- [x] `pnpm --filter @fleet-plugins/file-explorer typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/security-headers.test.ts tests/codex-security-markdown.test.ts --reporter=dot`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/codex-security-markdown.test.ts --reporter=dot`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `git diff --check`
- [x] Headed browser verification against an isolated Fleet Console instance: README local images load, npm/license badges render from `img.shields.io`, and `SETUP.md` opens inside the File Explorer viewer.

## Changelog
- [x] Added one `.changelog.d/*.md` fragment, or applied the `no-changelog` label intentionally.
- [x] Fragment `section:` is one of `Added`, `Changed`, `Fixed`, `Removed`, or `Breaking Changes`.
- [x] Fragment bullets are English and use only `[core-agent]`, `[core-unified-agent]`, `[fleet-infra]`, `[fleet-admiral]`, `[fleet-carriers]`, `[fleet-wiki]`, `[fleet-console]`, or `[fleet-cli]`.

## Related Issues / PRs

## Notes for Reviewers
- Arbitrary external markdown images remain blocked to avoid tracking-pixel auto-fetches; only HTTPS `img.shields.io` badge images are allowed.
- Local images remain served through the symlink-contained File Explorer image route.