### PR TITLE
feat(fleet-console): drag-to-reorder Operation groups by header

### DIFF
--- a/.changelog.d/sidebar-group-drag-reorder.md
+++ b/.changelog.d/sidebar-group-drag-reorder.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- [fleet-console] Add drag-to-reorder for Operation groups by dragging group headers in the Operations sidebar.

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -219,6 +219,22 @@ export function Operations({ state }: OperationsProps) {
       .catch(() => {});
   }, []);
 
+  const handleReorderGroups = useCallback((orderedGroupIds: readonly string[]) => {
+    const groupById = new Map(stateRef.current.groups.map((group) => [group.id, group]));
+    const patches = orderedGroupIds.flatMap((groupId, order) => {
+      const group = groupById.get(groupId);
+      if (!group || group.order === order) return [];
+      return [updateGroup(groupId, { order })];
+    });
+    if (patches.length === 0) return;
+    // 일부 PATCH가 실패해도 항상 서버 실제 순서로 재동기화한다 — Promise.all은 첫 실패에서 reject되어
+    // refetch를 건너뛰므로, 성공/실패가 섞이면 낙관적 순서가 서버와 어긋난 채 UI에 남는다.
+    void Promise.allSettled(patches)
+      .then(() => fetchGroups(null))
+      .then(hydrateGroups)
+      .catch(() => {});
+  }, []);
+
   const handleUngroupAll = useCallback((groupId: string) => {
     void deleteGroup(groupId)
       .then(() => Promise.all([
@@ -266,6 +282,7 @@ export function Operations({ state }: OperationsProps) {
         onCreateGroup={handleCreateGroup}
         onSetGroupColor={handleSetGroupColor}
         onRenameGroup={handleRenameGroup}
+        onReorderGroups={handleReorderGroups}
         onUngroupAll={handleUngroupAll}
       />
       <OperationsCanvas

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-group-header.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-group-header.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, MouseEvent } from "react";
+import { useRef, type CSSProperties, type MouseEvent, type PointerEvent as ReactPointerEvent } from "react";
 
 import type { OperationGroup } from "../types.js";
 import { resolveAccentColor } from "../canvas/operation-accent.js";
@@ -8,8 +8,12 @@ interface GroupHeaderProps {
   readonly count: number;
   readonly collapsed: boolean;
   readonly tier: "rail" | "list" | "detail";
+  readonly dragging: boolean;
+  readonly dropTarget: boolean;
+  readonly dragOffsetY: number;
   readonly onToggle: (groupId: string) => void;
   readonly onContextMenu: (groupId: string, anchor: DOMRect) => void;
+  readonly onPointerDragStart: (event: ReactPointerEvent<HTMLDivElement>, groupId: string) => void;
 }
 
 export function OperationsSideBarGroupHeader({
@@ -17,29 +21,59 @@ export function OperationsSideBarGroupHeader({
   count,
   collapsed,
   tier,
+  dragging,
+  dropTarget,
+  dragOffsetY,
   onToggle,
   onContextMenu,
+  onPointerDragStart,
 }: GroupHeaderProps) {
+  const suppressClickRef = useRef(false);
   const grpColor = resolveAccentColor(group.color);
-  const headerStyle = grpColor ? ({ "--grp-color": grpColor } as CSSProperties) : undefined;
+  const headerClassName = [
+    "side-bar-group-header",
+    tier === "rail" ? "side-bar-group-header--rail" : "",
+    dragging ? "side-bar-group-header--dragging" : "",
+    dropTarget ? "side-bar-group-header--drop-target" : "",
+  ].filter(Boolean).join(" ");
+  const headerStyle = {
+    ...(grpColor ? { "--grp-color": grpColor } : {}),
+    ...(dragging ? { "--drag-dy": `${Math.round(dragOffsetY)}px` } : {}),
+  } as CSSProperties;
 
   const handleContextMenu = (event: MouseEvent<HTMLDivElement>) => {
     event.preventDefault();
     onContextMenu(group.id, event.currentTarget.getBoundingClientRect());
   };
+  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.target instanceof Element && event.target.closest("button")) return;
+    onPointerDragStart(event, group.id);
+  };
+  const handlePointerUp = () => {
+    if (dragging) suppressClickRef.current = true;
+  };
+  const toggle = () => {
+    if (suppressClickRef.current) {
+      suppressClickRef.current = false;
+      return;
+    }
+    onToggle(group.id);
+  };
 
   if (tier === "rail") {
     return (
       <div
-        className="side-bar-group-header side-bar-group-header--rail"
+        className={headerClassName}
         data-tier="rail"
         style={headerStyle}
-        onClick={() => onToggle(group.id)}
+        onClick={toggle}
         onContextMenu={handleContextMenu}
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
         role="button"
         tabIndex={0}
         aria-label={`Group ${group.name}`}
-        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onToggle(group.id); } }}
+        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggle(); } }}
       >
         <span className="side-bar-group-header__dot" aria-hidden="true" />
       </div>
@@ -48,9 +82,11 @@ export function OperationsSideBarGroupHeader({
 
   return (
     <div
-      className="side-bar-group-header"
+      className={headerClassName}
       style={headerStyle}
       onContextMenu={handleContextMenu}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
       role="group"
       aria-label={group.name}
     >

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-hit-test.ts
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-hit-test.ts
@@ -59,6 +59,25 @@ export function dropTargetFromPoint(
   return { groupId: last?.groupId ?? null, index: last?.entryIds.length ?? 0 };
 }
 
+export function groupDropIndexFromPoint(
+  clientY: number,
+  orderedGroupIds: readonly string[],
+  container: HTMLOListElement | null,
+  sourceGroupId?: string,
+): number {
+  if (!container) return 0;
+  const groupElements = Array.from(container.querySelectorAll<HTMLElement>("[data-drop-zone-group-id]"));
+  for (const groupEl of groupElements) {
+    const id = groupEl.dataset.dropZoneGroupId;
+    if (!id || id === "__ungrouped__" || id === sourceGroupId) continue;
+    const index = orderedGroupIds.indexOf(id);
+    if (index === -1) continue;
+    const rect = groupEl.getBoundingClientRect();
+    if (clientY <= rect.top + rect.height / 2) return index;
+  }
+  return orderedGroupIds.length;
+}
+
 // cross-group 드롭용: sourceId를 allIds에서 제거하고 대상 segment의 dropIndex 위치에 삽입한다.
 // dropIndex = source가 없는 대상 entryIds 기준 타깃 슬롯; 보정 없음(source가 segment에 없음).
 // sourceId는 segment에 속하지 않으며, segment의 기존 순서는 allIds 내에서의 순서를 따른다.
@@ -119,6 +138,21 @@ export function applyVisibleReorder(
   return currentOrder.map((id) =>
     visibleSet.has(id) ? (nextVisibleOrder[visIdx++] ?? id) : id,
   );
+}
+
+// group 드롭용: dropIndex = source를 포함한 orderedGroupIds 기준 포인터 슬롯; downward 드래그 시 -1 보정한다.
+export function reorderGroupIds(
+  orderedGroupIds: readonly string[],
+  sourceGroupId: string,
+  dropIndex: number,
+): string[] {
+  const sourceIndex = orderedGroupIds.indexOf(sourceGroupId);
+  if (sourceIndex === -1) return [...orderedGroupIds];
+  const next = orderedGroupIds.filter((id) => id !== sourceGroupId);
+  const adjusted = dropIndex > sourceIndex ? dropIndex - 1 : dropIndex;
+  const bounded = Math.max(0, Math.min(adjusted, next.length));
+  next.splice(bounded, 0, sourceGroupId);
+  return next;
 }
 
 // keyboard 이동 전용: targetIndex = source가 제거된 목록 기준 삽입 위치(보정 없음).

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -9,7 +9,7 @@ import { GroupContextMenu } from "../canvas/group-context-menu.js";
 import { operationAccentFromNode, resolveAccentColor } from "../canvas/operation-accent.js";
 import { setOperationOrder, toggleGroupCollapsed, useCanvasState, useCollapsedGroups } from "../canvas/canvas-store.js";
 import { sortOperationsByOrder } from "../store.js";
-import { applyVisibleReorder, dropIndexFromPoint, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderWithinSegment, type DropSectionInfo } from "./operations-side-bar-hit-test.js";
+import { applyVisibleReorder, groupDropIndexFromPoint, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderGroupIds, reorderWithinSegment, type DropSectionInfo } from "./operations-side-bar-hit-test.js";
 import { OperationsSideBarChip, type SideBarEntry } from "./operations-side-bar-chip.js";
 import { OperationsSideBarGroupHeader } from "./operations-side-bar-group-header.js";
 import { MIN_RAIL_PX, setSideBarCollapsed, setSideBarWidth, tierFromWidth, useSideBarState } from "./operations-side-bar-store.js";
@@ -40,6 +40,7 @@ interface OperationsSideBarProps {
   readonly onCreateGroup: (theaterId: string, name: string, operationId: string) => void;
   readonly onSetGroupColor: (groupId: string, color: string | null) => void;
   readonly onRenameGroup: (groupId: string, name: string) => void;
+  readonly onReorderGroups: (orderedGroupIds: readonly string[]) => void;
   readonly onUngroupAll: (groupId: string) => void;
 }
 
@@ -52,7 +53,8 @@ interface NewMenuState {
   readonly viewportBounds?: { readonly width: number; readonly height: number };
 }
 
-interface DragState {
+interface ChipDragState {
+  readonly kind: "chip";
   readonly sourceId: string;
   readonly sourceGroupId: string | null;
   readonly pointerId: number;
@@ -63,6 +65,19 @@ interface DragState {
   readonly dropIndex: number;
   readonly dropGroupId: string | null;
 }
+
+interface GroupDragState {
+  readonly kind: "group";
+  readonly sourceGroupId: string;
+  readonly pointerId: number;
+  readonly startX: number;
+  readonly startY: number;
+  readonly currentY: number;
+  readonly dragging: boolean;
+  readonly dropIndex: number;
+}
+
+type DragState = ChipDragState | GroupDragState;
 
 const CLOSE_ARM_DURATION_MS = 1500;
 const DRAG_THRESHOLD_PX = 6;
@@ -94,6 +109,7 @@ export function OperationsSideBar({
   onCreateGroup,
   onSetGroupColor,
   onRenameGroup,
+  onReorderGroups,
   onUngroupAll,
 }: OperationsSideBarProps) {
   const chipsRef = useRef<HTMLOListElement | null>(null);
@@ -108,7 +124,9 @@ export function OperationsSideBar({
   const entriesRef = useRef<SideBarEntry[]>([]);
   const currentOrderRef = useRef<string[]>([]);
   const dropSectionsRef = useRef<DropSectionInfo[]>([]);
+  const orderedGroupIdsRef = useRef<string[]>([]);
   const onSetGroupIdRef = useRef(onSetGroupId);
+  const onReorderGroupsRef = useRef(onReorderGroups);
   const [activeContextMenu, setActiveContextMenu] = useState<ActiveContextMenu | null>(null);
   const [newMenu, setNewMenu] = useState<NewMenuState | null>(null);
   const [settingsMenu, setSettingsMenu] = useState<NewMenuState | null>(null);
@@ -128,6 +146,7 @@ export function OperationsSideBar({
     };
   });
   const groupedSections = groupOperations(allEntries, groups, canvas.operationOrder);
+  const orderedGroupIds = groupedSections.flatMap((section) => section.groupId ? [section.groupId] : []);
   const visibleEntries = groupedSections.flatMap((section) =>
     collapsedGroupSet.has(section.groupId ?? "") ? [] : section.entries,
   );
@@ -196,7 +215,9 @@ export function OperationsSideBar({
     entriesRef.current = allEntries;
     currentOrderRef.current = currentOrder;
     dropSectionsRef.current = dropSections;
+    orderedGroupIdsRef.current = orderedGroupIds;
     onSetGroupIdRef.current = onSetGroupId;
+    onReorderGroupsRef.current = onReorderGroups;
   });
 
   const updateDrag = (next: DragState | null) => {
@@ -220,9 +241,14 @@ export function OperationsSideBar({
       const distance = Math.hypot(event.clientX - current.startX, event.clientY - current.startY);
       if (!current.dragging && distance < DRAG_THRESHOLD_PX) return;
       if (current.dragging) event.preventDefault();
-      const dropTarget = dropTargetFromPoint(event.clientY, dropSectionsRef.current, chipsRef.current, current.sourceId);
       autoScrollSideBar(event.clientY, chipsRef.current);
-      updateDrag({ ...current, currentY: event.clientY, dragging: true, dropIndex: dropTarget.index, dropGroupId: dropTarget.groupId });
+      if (current.kind === "chip") {
+        const dropTarget = dropTargetFromPoint(event.clientY, dropSectionsRef.current, chipsRef.current, current.sourceId);
+        updateDrag({ ...current, currentY: event.clientY, dragging: true, dropIndex: dropTarget.index, dropGroupId: dropTarget.groupId });
+        return;
+      }
+      const dropIndex = groupDropIndexFromPoint(event.clientY, orderedGroupIdsRef.current, chipsRef.current, current.sourceGroupId);
+      updateDrag({ ...current, currentY: event.clientY, dragging: true, dropIndex });
     };
 
     const onUp = (event: PointerEvent) => {
@@ -230,6 +256,13 @@ export function OperationsSideBar({
       const snap = dragRef.current;
       updateDrag(null);
       if (!snap?.dragging) return;
+
+      if (snap.kind === "group") {
+        const nextGroupIds = reorderGroupIds(orderedGroupIdsRef.current, snap.sourceGroupId, snap.dropIndex);
+        if (nextGroupIds.join("\0") === orderedGroupIdsRef.current.join("\0")) return;
+        onReorderGroupsRef.current(nextGroupIds);
+        return;
+      }
 
       const { sourceId, sourceGroupId, dropIndex, dropGroupId } = snap;
       const sections = dropSectionsRef.current;
@@ -275,6 +308,7 @@ export function OperationsSideBar({
     const sourceEntry = allEntries.find((e) => e.operation.id === operationId);
     const sourceGroupId = sourceEntry?.operation.groupId ?? null;
     updateDrag({
+      kind: "chip",
       sourceId: operationId,
       sourceGroupId,
       pointerId: event.pointerId,
@@ -284,6 +318,24 @@ export function OperationsSideBar({
       dragging: false,
       dropIndex: currentOrder.indexOf(operationId),
       dropGroupId: sourceGroupId,
+    });
+  };
+
+  const beginGroupPointerDrag = (event: ReactPointerEvent<HTMLDivElement>, groupId: string) => {
+    if (event.button !== 0) return;
+    if (event.target instanceof Element && event.target.closest("button")) return;
+    if (!orderedGroupIds.includes(groupId)) return;
+    setActiveContextMenu(null);
+    disarmClose();
+    updateDrag({
+      kind: "group",
+      sourceGroupId: groupId,
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      currentY: event.clientY,
+      dragging: false,
+      dropIndex: orderedGroupIds.indexOf(groupId),
     });
   };
 
@@ -433,16 +485,38 @@ export function OperationsSideBar({
           const isCollapsed = section.groupId !== null && collapsedGroupSet.has(section.groupId);
           const grpColor = section.group ? resolveAccentColor(section.group.color) : null;
           const sectionStyle = grpColor ? ({ "--grp-color": grpColor } as CSSProperties) : undefined;
+          const groupIndex = section.groupId ? orderedGroupIds.indexOf(section.groupId) : -1;
+          const isGroupDragging = drag?.kind === "group" && drag.sourceGroupId === section.groupId && drag.dragging;
+          const groupDropBefore = drag?.kind === "group"
+            && drag.dragging
+            && section.groupId !== null
+            && drag.sourceGroupId !== section.groupId
+            && drag.dropIndex === groupIndex;
+          const groupDropAfter = drag?.kind === "group"
+            && drag.dragging
+            && section.groupId !== null
+            && drag.sourceGroupId !== section.groupId
+            && groupIndex === orderedGroupIds.length - 1
+            && drag.dropIndex === orderedGroupIds.length;
+          const sectionClassName = [
+            section.groupId ? "side-bar-group-section" : "side-bar-ungrouped-section",
+            groupDropBefore ? "side-bar-group-section--drop-before" : "",
+            groupDropAfter ? "side-bar-group-section--drop-after" : "",
+          ].filter(Boolean).join(" ");
           return (
-            <li key={section.groupId ?? "__ungrouped__"} data-drop-zone-group-id={section.groupId ?? "__ungrouped__"} className={section.groupId ? "side-bar-group-section" : "side-bar-ungrouped-section"} style={sectionStyle}>
+            <li key={section.groupId ?? "__ungrouped__"} data-drop-zone-group-id={section.groupId ?? "__ungrouped__"} className={sectionClassName} style={sectionStyle}>
               {section.group ? (
                 <OperationsSideBarGroupHeader
                   group={section.group}
                   count={section.entries.length}
                   collapsed={isCollapsed}
                   tier={tier}
+                  dragging={isGroupDragging}
+                  dragOffsetY={isGroupDragging ? drag.currentY - drag.startY : 0}
+                  dropTarget={groupDropBefore}
                   onToggle={toggleGroupCollapsed}
                   onContextMenu={(groupId, anchor) => setActiveContextMenu({ kind: "group", groupId, anchor })}
+                  onPointerDragStart={beginGroupPointerDrag}
                 />
               ) : section.entries.length > 0 ? (
                 <div className="side-bar-ungrouped-label" aria-label="Ungrouped operations">
@@ -453,7 +527,7 @@ export function OperationsSideBar({
                 <ol
                   className={[
                     "side-bar-group-chips",
-                    drag?.dragging && drag.dropGroupId === section.groupId && drag.dropGroupId !== drag.sourceGroupId
+                    drag?.kind === "chip" && drag.dragging && drag.dropGroupId === section.groupId && drag.dropGroupId !== drag.sourceGroupId
                       ? "side-bar-section--drop-target"
                       : "",
                   ].filter(Boolean).join(" ")}
@@ -472,10 +546,11 @@ export function OperationsSideBar({
                         index={globalIndex}
                         isCloseArmed={armedCloseId === entry.operation.id}
                         accentValue={accentValue}
-                        dragging={drag?.sourceId === entry.operation.id && drag.dragging}
-                        dragOffsetY={drag?.sourceId === entry.operation.id && drag.dragging ? drag.currentY - drag.startY : 0}
+                        dragging={drag?.kind === "chip" && drag.sourceId === entry.operation.id && drag.dragging}
+                        dragOffsetY={drag?.kind === "chip" && drag.sourceId === entry.operation.id && drag.dragging ? drag.currentY - drag.startY : 0}
                         dropTarget={
-                          drag?.dragging === true
+                          drag?.kind === "chip"
+                          && drag.dragging === true
                           && drag.dropGroupId === section.groupId
                           && drag.dropGroupId === drag.sourceGroupId
                           && drag.dropIndex === sectionLocalIndex

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3483,12 +3483,35 @@
 
 /* 연속 좌측 레일 — group section 전체 관통 (ungrouped 제외) */
 .side-bar-group-section {
+  position: relative;
   list-style: none;
   display: flex;
   flex-direction: column;
   margin-left: var(--space-1);
   padding-left: var(--space-1);
   border-left: 3px solid var(--grp-color, transparent);
+}
+
+.side-bar-group-section--drop-before::before,
+.side-bar-group-section--drop-after::after {
+  content: "";
+  position: absolute;
+  left: 2px;
+  right: var(--space-1);
+  height: 2px;
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--brass) 78%, var(--ink-spectral));
+  box-shadow: 0 0 0 1px color-mix(in oklch, var(--brass) 22%, transparent);
+  pointer-events: none;
+  z-index: 12;
+}
+
+.side-bar-group-section--drop-before::before {
+  top: -2px;
+}
+
+.side-bar-group-section--drop-after::after {
+  bottom: -2px;
 }
 
 /* rail tier에서는 56px 폭 제약 때문에 좌측 offset 최소화 */
@@ -3517,6 +3540,25 @@
   border-radius: var(--radius-md);
   user-select: none;
   background: color-mix(in oklch, var(--grp-color, transparent) 14%, transparent);
+  cursor: grab;
+  transition:
+    background var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring),
+    box-shadow var(--duration-fast) var(--ease-spring),
+    transform var(--duration-fast) var(--ease-spring);
+}
+
+.side-bar-group-header--drop-target {
+  background: color-mix(in oklch, var(--brass) 12%, var(--grp-color, transparent));
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass) 34%, transparent);
+}
+
+.side-bar-group-header--dragging {
+  opacity: 0.88;
+  transform: translateY(var(--drag-dy, 0)) scale(1.015);
+  z-index: 20;
+  box-shadow: var(--shadow-soft);
+  cursor: grabbing;
 }
 
 .side-bar-group-header__toggle {
@@ -3551,6 +3593,14 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .side-bar-group-header {
+    transition: none;
+  }
+
+  .side-bar-group-header--dragging {
+    transform: translateY(var(--drag-dy, 0));
+  }
+
   .side-bar-group-header__arrow {
     transition: none;
   }

--- a/runtime/fleet-console/tests/operations-side-bar-hit-test.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-hit-test.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 
-import { dropIndexFromPoint } from "../core/client/src/sidebar/operations-side-bar-hit-test.js";
+import { dropIndexFromPoint, groupDropIndexFromPoint, reorderGroupIds } from "../core/client/src/sidebar/operations-side-bar-hit-test.js";
 
 describe("operations side bar reorder hit testing", () => {
   it("ignores the dragged source chip when resolving the drop index", () => {
@@ -32,6 +32,52 @@ describe("operations side bar reorder hit testing", () => {
   });
 });
 
+describe("groupDropIndexFromPoint", () => {
+  it("uses section wrapper midpoints and skips the dragged source group", () => {
+    const sections = document.createElement("ol");
+    sections.append(
+      createGroupSection("g-a", 0, 40),
+      createGroupSection("g-b", 40, 100),
+      createGroupSection("g-c", 100, 150),
+    );
+
+    expect(groupDropIndexFromPoint(70, ["g-a", "g-b", "g-c"], sections, "g-b")).toBe(2);
+  });
+
+  it("ignores the ungrouped wrapper as a group drop target", () => {
+    const sections = document.createElement("ol");
+    sections.append(
+      createGroupSection("g-a", 0, 40),
+      createGroupSection("__ungrouped__", 40, 100),
+    );
+
+    expect(groupDropIndexFromPoint(50, ["g-a"], sections)).toBe(1);
+  });
+});
+
+describe("reorderGroupIds", () => {
+  it("moves a group upward", () => {
+    expect(reorderGroupIds(["g-a", "g-b", "g-c"], "g-c", 0)).toEqual(["g-c", "g-a", "g-b"]);
+  });
+
+  it("moves a group downward with source-inclusive drop index adjustment", () => {
+    expect(reorderGroupIds(["g-a", "g-b", "g-c"], "g-a", 3)).toEqual(["g-b", "g-c", "g-a"]);
+  });
+
+  it("returns stable order when dropped on itself", () => {
+    expect(reorderGroupIds(["g-a", "g-b", "g-c"], "g-b", 1)).toEqual(["g-a", "g-b", "g-c"]);
+  });
+
+  it("clamps to first and last positions", () => {
+    expect(reorderGroupIds(["g-a", "g-b", "g-c"], "g-b", -10)).toEqual(["g-b", "g-a", "g-c"]);
+    expect(reorderGroupIds(["g-a", "g-b", "g-c"], "g-b", 99)).toEqual(["g-a", "g-c", "g-b"]);
+  });
+
+  it("keeps a single group unchanged", () => {
+    expect(reorderGroupIds(["g-a"], "g-a", 1)).toEqual(["g-a"]);
+  });
+});
+
 function createChip(id: string, top: number, bottom: number): HTMLElement {
   const chip = document.createElement("li");
   chip.dataset.sideBarChipId = id;
@@ -47,4 +93,21 @@ function createChip(id: string, top: number, bottom: number): HTMLElement {
     toJSON: () => ({}),
   });
   return chip;
+}
+
+function createGroupSection(id: string, top: number, bottom: number): HTMLElement {
+  const section = document.createElement("li");
+  section.dataset.dropZoneGroupId = id;
+  section.getBoundingClientRect = () => ({
+    x: 0,
+    y: top,
+    top,
+    left: 0,
+    right: 200,
+    bottom,
+    width: 200,
+    height: bottom - top,
+    toJSON: () => ({}),
+  });
+  return section;
 }


### PR DESCRIPTION
## Summary
- Operations Left SideBar 그룹 헤더를 드래그해 그룹 전체 순서를 바꿀 수 있습니다(기존 chip 드래그의 자연스러운 확장). 순서는 `OperationGroup.order`로 서버에 영속되어 새로고침 후에도 유지됩니다.
- 기존 포인터 드래그 기구를 discriminated `DragState`(`chip | group`)로 공유 재사용하고, 순수 헬퍼 `groupDropIndexFromPoint`/`reorderGroupIds`로 대상 슬롯을 계산합니다. Ungrouped 섹션은 항상 맨 아래에 고정되며 드래그 소스/타깃이 되지 않고, 접힌(collapsed) 그룹도 재정렬 가능합니다.
- 서버/API 무변경 — 이미 존재하는 groups PATCH(`order`)를 재사용합니다. 부분 PATCH 실패 시에도 `Promise.allSettled` 후 항상 재조회하여 서버 실제 순서로 재동기화합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (52 files, 533 passed / 22 skipped) — `reorderGroupIds`/`groupDropIndexFromPoint` 단위 테스트 포함(상/하/무변경/경계/단일 그룹)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Headed console-e2e: 실제 PointerEvent로 그룹 헤더 드래그 → 양방향 재정렬 및 새로고침 후 순서 영속 확인, 페이지 에러 없음
- [x] Changelog fragment: `.changelog.d/sidebar-group-drag-reorder.md` (`section: Added`, `[fleet-console]`)