### PR TITLE
chore(core-unified-agent): support GPT-5.6 via official Codex ACP

### DIFF
--- a/.changelog.d/gpt-5-6-codex-models.md
+++ b/.changelog.d/gpt-5-6-codex-models.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+
+- [core-unified-agent] Switch Codex ACP to the official bridge, add GPT-5.6 Codex model support with updated reasoning effort levels, and preserve deprecated ACP model type aliases for migration compatibility.

--- a/packages/core-unified-agent/AGENTS.md
+++ b/packages/core-unified-agent/AGENTS.md
@@ -146,7 +146,7 @@ ait (model) ❯ {input}            # Omitted if effort is not supported
 | CLI | Protocol | spawn Method | set_config_option | set_mode |
 |-----|----------|--------------|-------------------|----------|
 | Claude | ACP (npx bridge) | `npx --package=@agentclientprotocol/claude-agent-acp@0.33.1 claude-agent-acp` | ✅ | ✅ |
-| Codex | `codex-acp` / `app-server` | (Toggle) `npx --yes --package=@zed-industries/codex-acp@0.14.0 codex-acp` / `codex app-server` | ✅ (ACP) / Pending (Legacy) | ✅ (ACP) / Pending (Legacy) |
+| Codex | ACP (`codex-acp`) / `app-server` | (Toggle) `npx --yes --package=@agentclientprotocol/codex-acp@1.1.2 codex-acp` / `codex app-server` | ✅ (ACP) / Pending (Legacy) | ✅ (ACP) / Pending (Legacy) |
 | opencode-go | ACP | `opencode acp` | ✅ | ✅ |
 
 ## Architecture Decisions
@@ -176,7 +176,9 @@ ait (model) ❯ {input}            # Omitted if effort is not supported
 
 9. **Claude Effort via `_meta` Bridge Channel**: Claude reasoning effort is delivered through `_meta.claudeCode.options.effort` spread in `session/new` and `session/load` payloads (not via `session/set_config_option` RPC). This channel bypasses alias resolution issues on the bridge and ensures effort applies consistently across new sessions and session resumption.
 
-10. **Validation-mode Dual-Path for Codex**: Codex currently supports two transport paths (ACP npx bridge and legacy AppServer) controlled by a `CODEX_USE_ACP` toggle. This is a temporary validation wave for protocol transition; a permanent switch will occur in a future wave, deprecating the legacy AppServer path and associated types.
+10. **Codex Official ACP Bridge**: Codex uses `@agentclientprotocol/codex-acp@1.1.2` on the ACP path. Model changes use standard `session/set_config_option` with `configId: "model"`, while public Fleet `effort` maps to Codex's advertised `reasoning_effort` config option.
+
+11. **Validation-mode Dual-Path for Codex**: Codex currently supports two transport paths (official ACP npx bridge and legacy AppServer) controlled by a `CODEX_USE_ACP` toggle. This is a temporary validation wave for protocol transition; a permanent switch will occur in a future wave, deprecating the legacy AppServer path and associated types.
 
 ## Adding a New CLI Provider
 

--- a/packages/core-unified-agent/README.md
+++ b/packages/core-unified-agent/README.md
@@ -16,7 +16,7 @@ Unified Agent provides two ways to control supported CLI agents — Claude, Code
 | CLI | Protocol | Spawn Command |
 |-----|----------|---------------|
 | **Claude** | ACP | `npx --package=@agentclientprotocol/claude-agent-acp@0.33.1 claude-agent-acp` |
-| **Codex** | `codex-acp` / `app-server` | (Toggle) `npx --yes --package=@zed-industries/codex-acp@0.14.0 codex-acp` / `codex app-server` |
+| **Codex** | ACP (`codex-acp`) / `app-server` | (Toggle) `npx --yes --package=@agentclientprotocol/codex-acp@1.1.2 codex-acp` / `codex app-server` |
 | **OpenCode Go** | ACP | `opencode acp` |
 | **Cursor Agent** | ACP | `cursor-agent acp` |
 
@@ -92,8 +92,8 @@ ait -c claude "Review this code"
 # Select a model
 ait -c claude -m opus "Find bugs"
 
-# Set reasoning effort (Codex)
-ait -c codex -e high "Refactor this module"
+# Set reasoning effort (Codex GPT-5.6 Sol/Terra also support `ultra`)
+ait -c codex -m gpt-5.6-sol -e ultra "Refactor this module"
 
 # Claude Sonnet supports `low | medium | high | max`
 ait -c claude -m sonnet -e max "Review this code"
@@ -150,10 +150,11 @@ On error:
 
 ### Reasoning Effort Support
 
-- **Codex**: supported via native `codex-app-server` turn config
+- **Codex**: supported via the official `codex-acp` bridge's `reasoning_effort` config option. GPT-5.6-Sol and GPT-5.6-Terra support `low | medium | high | xhigh | max | ultra`; GPT-5.6-Luna supports `low | medium | high | xhigh | max`.
 - **Claude (ACP via `claude-agent-acp`)**: supported on the `claude` provider with `low | medium | high | max`
 
 Fleet sends Claude ACP effort through the bridge's advertised `effort` config option. Only the primary `claude` provider exposes effort in `models.json`.
+Fleet sends Codex ACP model changes through `model` and public `effort` changes through the bridge's `reasoning_effort` config option.
 
 ---
 

--- a/packages/core-unified-agent/models.json
+++ b/packages/core-unified-agent/models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-07-04T00:00:00Z",
+  "updatedAt": "2026-07-10T00:00:00Z",
   "providers": {
     "claude": {
       "name": "Claude Code",
@@ -17,10 +17,13 @@
     },
     "codex": {
       "name": "Codex",
-      "defaultModel": "gpt-5.4",
+      "defaultModel": "gpt-5.6-sol",
       "models": [
-        { "modelId": "gpt-5.4", "name": "GPT-5.4", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh"], "default": "high" } },
+        { "modelId": "gpt-5.6-sol", "name": "GPT-5.6-Sol", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max", "ultra"], "default": "low" } },
+        { "modelId": "gpt-5.6-terra", "name": "GPT-5.6-Terra", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max", "ultra"], "default": "medium" } },
+        { "modelId": "gpt-5.6-luna", "name": "GPT-5.6-Luna", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max"], "default": "medium" } },
         { "modelId": "gpt-5.5", "name": "GPT-5.5", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh"], "default": "high" } },
+        { "modelId": "gpt-5.4", "name": "GPT-5.4", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh"], "default": "high" } },
         { "modelId": "gpt-5.4-mini", "name": "GPT-5.4 Mini", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh"], "default": "high" } }
       ]
     },

--- a/packages/core-unified-agent/package.json
+++ b/packages/core-unified-agent/package.json
@@ -53,7 +53,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@agentclientprotocol/sdk": "^0.21.0",
+    "@agentclientprotocol/sdk": "^1.2.1",
     "@dotobokuri/core-process": "workspace:*",
     "picocolors": "^1.1.1",
     "zod": "^4.3.6"

--- a/packages/core-unified-agent/src/cli.ts
+++ b/packages/core-unified-agent/src/cli.ts
@@ -30,7 +30,7 @@ const ce = picocolors.createColors(picocolors.isColorSupported && isErrTTY);
 // ─── 인자 파싱 ────────────────────────────────────────────
 
 const VALID_CLIS = Object.keys(CLI_BACKENDS) as CliType[];
-const VALID_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+const VALID_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'] as const;
 
 let parsed: ReturnType<typeof parseArgs>;
 try {

--- a/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
+++ b/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
@@ -130,6 +130,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     if (options.cli && options.cli !== 'codex') {
       throw new Error('UnifiedCodexAgentClient는 codex CLI만 지원합니다.');
     }
+    this.validateModelEffort(options.model, options.effort);
 
     if (CODEX_USE_ACP) {
       return this.connectAcp(options);
@@ -493,9 +494,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
       const session = await this.connection.reconnectSession(targetCwd);
       this.sessionId = session.sessionId;
       this.sessionCwd = targetCwd;
-      if (CODEX_ACP_PROMPT_FALLBACK) {
-        this.firstPromptPending = this.currentSystemPrompt;
-      }
+      this.firstPromptPending = this.currentSystemPrompt;
 
       return {
         cli: 'codex',
@@ -556,6 +555,27 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     this.currentSystemPrompt = null;
     this.firstPromptPending = null;
     this.pendingOverrides = null;
+  }
+
+  private validateModelEffort(modelId: string | undefined, effort: string | undefined): void {
+    if (!effort) {
+      return;
+    }
+
+    const provider = getProviderModels('codex');
+    const resolvedModelId = modelId ?? provider.defaultModel;
+    const model = provider.models.find((entry) => entry.modelId === resolvedModelId);
+    if (!model) {
+      return;
+    }
+    if (!model.effort.supported) {
+      throw new Error(`codex/${resolvedModelId} 모델은 reasoning effort를 지원하지 않습니다.`);
+    }
+    if (!model.effort.levels.includes(effort)) {
+      throw new Error(
+        `codex/${resolvedModelId} 모델은 effort "${effort}"을(를) 지원하지 않습니다. 사용 가능: ${model.effort.levels.join(', ')}`,
+      );
+    }
   }
 
   private setupEventForwarding(): void {
@@ -769,9 +789,9 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
   private resolveAcpMode(modeId: string): string {
     switch (modeId) {
       case 'autoEdit':
-        return 'auto';
+        return 'agent';
       case 'yolo':
-        return 'full-access';
+        return 'agent-full-access';
       default:
         return 'read-only';
     }

--- a/packages/core-unified-agent/src/config/CliConfigs.ts
+++ b/packages/core-unified-agent/src/config/CliConfigs.ts
@@ -38,7 +38,7 @@ export const CLI_BACKENDS = {
     cliCommand: 'codex',
     protocol: 'codex-app-server',
     authRequired: true,
-    npxPackage: '@zed-industries/codex-acp@0.14.0',
+    npxPackage: '@agentclientprotocol/codex-acp@1.1.2',
     acpArgs: [],
     appServerArgs: ['app-server', '--listen', 'stdio://'],
     modes: [

--- a/packages/core-unified-agent/src/connection/AcpConnection.ts
+++ b/packages/core-unified-agent/src/connection/AcpConnection.ts
@@ -314,7 +314,7 @@ export class AcpConnection extends BaseConnection {
       );
       this.activeSessionId = params.sessionId;
       this.setState('ready');
-      return result;
+      return result ?? {};
     } catch (error) {
       throw this.withStderrDiagnostics(error, 'ACP session/load');
     }
@@ -476,7 +476,7 @@ export class AcpConnection extends BaseConnection {
       ? ([{ type: 'text', text: content }] as Array<Extract<ContentBlock, { type: 'text' }>>)
       : content;
 
-    const rawPromise = agent.prompt({ sessionId, prompt });
+    const rawPromise = Promise.resolve(agent.prompt({ sessionId, prompt }));
 
     // idle timeout 래핑 (활동 기반 타임아웃)
     const [idleWrapped, keepAlive] = this.createIdleTimeoutRace(
@@ -542,23 +542,13 @@ export class AcpConnection extends BaseConnection {
 
   /**
    * 모델을 변경합니다.
-   * session/set_model (primary) → session/set_config_option (fallback)
+   * session/set_config_option(configId: "model") RPC를 사용합니다.
    *
    * @param sessionId - 세션 ID
    * @param model - 모델 이름
    */
   async setModel(sessionId: string, model: string): Promise<void> {
-    const agent = this.getAgent();
-
-    // session/set_model (unstable) 단일 채널.
-    // 과거 fallback이었던 session/set_config_option(configId:'model')은
-    // claude-agent-acp 0.33.1에서 alias(opus 등)를 거부해 dead path가 되어 폐기합니다.
-    // 호출자는 미지원/실패 시 disconnect/reconnect로 처리합니다.
-    await this.withFixedTimeout(
-      agent.unstable_setSessionModel?.({ sessionId, modelId: model }),
-      this.requestTimeout,
-      'session/set_model',
-    );
+    await this.setConfigOption(sessionId, 'model', model);
   }
 
   /**
@@ -861,7 +851,7 @@ export class AcpConnection extends BaseConnection {
    * connect, loadSession, cancel 등 제어 RPC에서 사용합니다.
    */
   private async withFixedTimeout<T>(
-    promise: Promise<T> | undefined,
+    promise: T | Promise<T> | undefined,
     timeoutMs: number,
     label: string,
   ): Promise<T> {
@@ -870,15 +860,16 @@ export class AcpConnection extends BaseConnection {
     }
 
     if (timeoutMs <= 0) {
-      return promise;
+      return Promise.resolve(promise);
     }
 
+    const wrappedPromise = Promise.resolve(promise);
     return new Promise<T>((resolve, reject) => {
       const timeoutId = setTimeout(() => {
         reject(new Error(`${label} 요청이 ${timeoutMs}ms 내에 완료되지 않았습니다`));
       }, timeoutMs);
 
-      promise
+      wrappedPromise
         .then((result) => {
           clearTimeout(timeoutId);
           resolve(result);

--- a/packages/core-unified-agent/src/models/schemas.ts
+++ b/packages/core-unified-agent/src/models/schemas.ts
@@ -14,6 +14,7 @@ export const EffortLevelSchema: z.ZodType<string> = z.enum([
   'high',
   'xhigh',
   'max',
+  'ultra',
 ]);
 
 /** effort 지원 스키마 (discriminated union) */

--- a/packages/core-unified-agent/src/types/acp.ts
+++ b/packages/core-unified-agent/src/types/acp.ts
@@ -17,6 +17,43 @@ export type AcpAvailableCommandsUpdate = Extract<
 export type AcpAvailableCommand =
   AcpAvailableCommandsUpdate['availableCommands'][number];
 
+/**
+ * @deprecated SDK 1.2에서는 model 전용 RPC 타입이 제거되었습니다.
+ * 모델 변경은 `AcpSessionSetConfigParams`에 `configId: "model"`을 사용하세요.
+ */
+export type AcpModelId = string;
+
+/**
+ * @deprecated SDK 1.2에서는 model 전용 상태 타입이 제거되었습니다.
+ * 모델 정보는 provider registry 또는 config option surface를 사용하세요.
+ */
+export type AcpModelInfo = {
+  _meta?: Record<string, unknown> | null;
+  description?: string | null;
+  modelId: AcpModelId;
+  name: string;
+};
+
+/**
+ * @deprecated SDK 1.2에서는 model 전용 상태 타입이 제거되었습니다.
+ * 현재 모델 조회는 각 bridge의 config option surface로 이관하세요.
+ */
+export type AcpSessionModelState = {
+  _meta?: Record<string, unknown> | null;
+  availableModels: AcpModelInfo[];
+  currentModelId: AcpModelId;
+};
+
+/**
+ * @deprecated SDK 1.2에서는 `session/set_model`이 제거되었습니다.
+ * 모델 변경은 `AcpSessionSetConfigParams`에 `configId: "model"`을 사용하세요.
+ */
+export type AcpSessionSetModelParams = {
+  _meta?: Record<string, unknown> | null;
+  modelId: AcpModelId;
+  sessionId: string;
+};
+
 // 공식 SDK 타입 re-export
 export type {
   InitializeRequest as AcpInitializeParams,
@@ -29,7 +66,6 @@ export type {
   PromptRequest as AcpSessionPromptParams,
   PromptResponse as AcpPromptResponse,
   SetSessionModeRequest as AcpSessionSetModeParams,
-  SetSessionModelRequest as AcpSessionSetModelParams,
   SetSessionConfigOptionRequest as AcpSessionSetConfigParams,
   SessionNotification as AcpSessionUpdateParams,
   SessionUpdate as AcpSessionUpdate,
@@ -47,9 +83,6 @@ export type {
   SessionConfigOption as AcpConfigOption,
   SessionMode as AcpSessionMode,
   StopReason as AcpStopReason,
-  SessionModelState as AcpSessionModelState,
-  ModelInfo as AcpModelInfo,
-  ModelId as AcpModelId,
 } from '@agentclientprotocol/sdk';
 
 // 도구 호출 관련 타입 re-export

--- a/packages/core-unified-agent/tests/e2e/codex.test.ts
+++ b/packages/core-unified-agent/tests/e2e/codex.test.ts
@@ -1,6 +1,6 @@
 /**
- * E2E: Codex native app-server 테스트
- * Codex CLI를 native app-server 프로토콜로 연결하여 프롬프트, 모델, effort, 세션 재개를 검증합니다.
+ * E2E: Codex 공식 ACP bridge 테스트
+ * Codex CLI를 공식 codex-acp bridge로 연결하여 프롬프트, 모델, effort, 세션 재개를 검증합니다.
  */
 
 import { EventEmitter } from 'events';
@@ -78,8 +78,28 @@ class MockCodexAppServerConnection extends CodexAppServerConnection {
 
 const CLI = 'codex';
 const installed = isCliInstalled(CLI);
+const CODEX_MODEL_MATRIX = ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'] as const;
+const CODEX_EFFORT_MATRIX = [
+  ['gpt-5.6-sol', 'low'],
+  ['gpt-5.6-sol', 'medium'],
+  ['gpt-5.6-sol', 'high'],
+  ['gpt-5.6-sol', 'xhigh'],
+  ['gpt-5.6-sol', 'max'],
+  ['gpt-5.6-sol', 'ultra'],
+  ['gpt-5.6-terra', 'low'],
+  ['gpt-5.6-terra', 'medium'],
+  ['gpt-5.6-terra', 'high'],
+  ['gpt-5.6-terra', 'xhigh'],
+  ['gpt-5.6-terra', 'max'],
+  ['gpt-5.6-terra', 'ultra'],
+  ['gpt-5.6-luna', 'low'],
+  ['gpt-5.6-luna', 'medium'],
+  ['gpt-5.6-luna', 'high'],
+  ['gpt-5.6-luna', 'xhigh'],
+  ['gpt-5.6-luna', 'max'],
+] as const;
 
-describe.skipIf(!installed)('E2E: Codex native app-server', () => {
+describe.skipIf(!installed)('E2E: Codex official ACP bridge', () => {
   let client: IUnifiedAgentClient | null = null;
 
   afterEach(async () => {
@@ -94,12 +114,12 @@ describe.skipIf(!installed)('E2E: Codex native app-server', () => {
   // ═══════════════════════════════════════════════
 
   describe('기본 연결 & 프롬프트', () => {
-    it('SDK: native app-server 연결 → 프롬프트 → 응답 검증', async () => {
+    it('SDK: 공식 ACP bridge 연결 → 프롬프트 → 응답 검증', async () => {
       const { client: c, sessionId } = await connectClient('codex');
       client = c;
 
       expect(sessionId).toBeTruthy();
-      expect(client.getConnectionInfo().protocol).toBe('codex-app-server');
+      expect(client.getConnectionInfo().protocol).toBe('acp');
 
       const { response } = await sendAndCollect(client, SIMPLE_PROMPT);
       expect(response).toContain('2');
@@ -135,7 +155,7 @@ describe.skipIf(!installed)('E2E: Codex native app-server', () => {
   describe('Disconnect 후 프로세스 종료', () => {
     it('SDK: 연결 → 프롬프트 → disconnect → 프로세스 종료 및 상태 초기화 검증', async () => {
       // 최소 모델/effort로 연결
-      const { client: c, sessionId } = await connectClient('codex', { model: 'gpt-5.3-codex-spark' });
+      const { client: c, sessionId } = await connectClient('codex', { model: 'gpt-5.6-sol' });
       client = c;
       expect(sessionId).toBeTruthy();
 
@@ -143,7 +163,7 @@ describe.skipIf(!installed)('E2E: Codex native app-server', () => {
       const { response } = await sendAndCollect(client, SIMPLE_PROMPT);
       expect(response).toContain('2');
 
-      // disconnect → Codex native 프로세스 종료
+      // disconnect → Codex ACP bridge 프로세스 종료
       await client.disconnect();
 
       // 연결 상태 초기화 확인
@@ -295,7 +315,7 @@ describe.skipIf(!installed)('E2E: Codex native app-server', () => {
 
       const response = chunks.join('');
       expect(response).toContain('42');
-      expect(toolCalls).toContain('test-math/add_numbers');
+      expect(toolCalls).toContain('mcp.test-math.add_numbers');
       expect(response).not.toMatch(/도구.*(없|못 찾|찾을 수)|tool.*not.*found|lazy[- ]?load/i);
     }, 180_000);
   });
@@ -305,7 +325,7 @@ describe.skipIf(!installed)('E2E: Codex native app-server', () => {
   // ═══════════════════════════════════════════════
 
   describe('모델별 프롬프트', () => {
-    it.each(['gpt-5.3-codex', 'gpt-5.3-codex-spark', 'gpt-5.4'])(
+    it.each(CODEX_MODEL_MATRIX)(
       'CLI: 모델 %s → 프롬프트 → 응답 검증',
       async (model) => {
         const { stdout, exitCode } = await runCli(
@@ -326,11 +346,11 @@ describe.skipIf(!installed)('E2E: Codex native app-server', () => {
   // ═══════════════════════════════════════════════
 
   describe('Reasoning effort', () => {
-    it.each(['low', 'medium', 'high', 'xhigh'])(
-      'CLI: effort %s → 프롬프트 → 응답 검증',
-      async (effort) => {
+    it.each(CODEX_EFFORT_MATRIX)(
+      'CLI: 모델 %s effort %s → 프롬프트 → 응답 검증',
+      async (model, effort) => {
         const { stdout, exitCode } = await runCli(
-          ['--json', '-c', 'codex', '-e', effort, SIMPLE_PROMPT],
+          ['--json', '-c', 'codex', '-m', model, '-e', effort, SIMPLE_PROMPT],
         );
 
         expect(exitCode).toBe(0);
@@ -402,7 +422,7 @@ describe.skipIf(!installed)('E2E: Codex native app-server', () => {
       const resetResult = await client.resetSession();
       const secondThreadId = client.getConnectionInfo().sessionId;
 
-      expect(resetResult.protocol).toBe('codex-app-server');
+      expect(resetResult.protocol).toBe('acp');
       expect(secondThreadId).toBeTruthy();
       expect(secondThreadId).not.toBe(firstThreadId);
     }, 180_000);

--- a/packages/core-unified-agent/tests/e2e/unified-agent.contract.test.ts
+++ b/packages/core-unified-agent/tests/e2e/unified-agent.contract.test.ts
@@ -35,8 +35,8 @@ const CONTRACT_CASES: ContractCase[] = [
   },
   {
     cli: 'codex',
-    expectedProtocol: 'codex-app-server',
-    model: 'gpt-5.3-codex-spark',
+    expectedProtocol: 'acp',
+    model: 'gpt-5.6-sol',
     supportsResetSession: true,
   },
 ];

--- a/packages/core-unified-agent/tests/unit/AcpConnection.sessionLifecycle.test.ts
+++ b/packages/core-unified-agent/tests/unit/AcpConnection.sessionLifecycle.test.ts
@@ -12,6 +12,7 @@ interface TestableAcpConnection {
   endSession: (sessionId: string) => Promise<void>;
   pushStderr: (chunk: string) => void;
   reconnectSession: (cwd: string, sessionId?: string) => Promise<NewSessionResponse>;
+  setModel: (sessionId: string, model: string) => Promise<void>;
 }
 
 class TestAcpConnection extends AcpConnection {
@@ -37,7 +38,6 @@ function createMockAgent(overrides?: Partial<Agent>): Agent {
     cancel: vi.fn().mockResolvedValue(undefined),
     closeSession: vi.fn().mockResolvedValue({}),
     setSessionMode: vi.fn().mockResolvedValue(undefined),
-    unstable_setSessionModel: vi.fn().mockResolvedValue(undefined),
     setSessionConfigOption: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   } as unknown as Agent;
@@ -201,5 +201,23 @@ describe('AcpConnection.reconnectSession()', () => {
     await conn.reconnectSession('/workspace');
 
     expect(conn.connectionState).toBe('ready');
+  });
+});
+
+// ─── setModel ─────────────────────────────────────────────
+
+describe('AcpConnection.setModel()', () => {
+  it('표준 session/set_config_option model config를 호출한다', async () => {
+    const conn = createConnection();
+    const mockAgent = createMockAgent();
+    conn.agentProxy = mockAgent;
+
+    await conn.setModel('session-1', 'gpt-5.6-sol');
+
+    expect(mockAgent.setSessionConfigOption).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      configId: 'model',
+      value: 'gpt-5.6-sol',
+    });
   });
 });

--- a/packages/core-unified-agent/tests/unit/CliConfigs.test.ts
+++ b/packages/core-unified-agent/tests/unit/CliConfigs.test.ts
@@ -23,7 +23,7 @@ describe('CliConfigs', () => {
       expect(config.command).toContain('npx');
       expect(config.args).toEqual([
         '--yes',
-        '--package=@zed-industries/codex-acp@0.14.0',
+        '--package=@agentclientprotocol/codex-acp@1.1.2',
         'codex-acp',
       ]);
       expect(config.useNpx).toBe(true);
@@ -38,7 +38,7 @@ describe('CliConfigs', () => {
       expect(config.command).toContain('npx');
       expect(config.args).toEqual([
         '--yes',
-        '--package=@zed-industries/codex-acp@0.14.0',
+        '--package=@agentclientprotocol/codex-acp@1.1.2',
         'codex-acp',
       ]);
     });

--- a/packages/core-unified-agent/tests/unit/ModelRegistry.test.ts
+++ b/packages/core-unified-agent/tests/unit/ModelRegistry.test.ts
@@ -14,11 +14,37 @@ describe('ModelRegistry', () => {
     expect(modelIds).not.toContain('sonnet[1m]');
   });
 
-  it('Codex 정적 모델 목록에 GPT-5.5를 포함한다', () => {
+  it('Codex 정적 모델 목록에 GPT-5.6 모델들과 기존 모델들을 포함한다', () => {
     const provider = getProviderModels('codex');
     const modelIds = provider.models.map((model) => model.modelId);
 
+    expect(provider.defaultModel).toBe('gpt-5.6-sol');
+    expect(modelIds.slice(0, 3)).toEqual(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']);
     expect(modelIds).toContain('gpt-5.5');
+    expect(modelIds).not.toContain('gpt-5.6-lunar');
+  });
+
+  it('Codex GPT-5.6 모델별 effort contract를 정확히 노출한다', () => {
+    const provider = getProviderModels('codex');
+    const efforts = Object.fromEntries(
+      provider.models.map((model) => [model.modelId, model.effort]),
+    );
+
+    expect(efforts['gpt-5.6-sol']).toEqual({
+      supported: true,
+      levels: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+      default: 'low',
+    });
+    expect(efforts['gpt-5.6-terra']).toEqual({
+      supported: true,
+      levels: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+      default: 'medium',
+    });
+    expect(efforts['gpt-5.6-luna']).toEqual({
+      supported: true,
+      levels: ['low', 'medium', 'high', 'xhigh', 'max'],
+      default: 'medium',
+    });
   });
 
   it('OpenCode Go 정적 모델 목록에 GLM-5.2와 Kimi K2.7 Code를 포함한다', () => {
@@ -72,6 +98,30 @@ describe('ModelRegistry', () => {
         },
       },
     })).toThrow('{effort}');
+  });
+
+  it('public effort schema는 ultra를 허용한다', () => {
+    expect(() => ModelsRegistrySchema.parse({
+      version: 1,
+      updatedAt: '2026-07-10T00:00:00Z',
+      providers: {
+        codex: {
+          name: 'Codex',
+          defaultModel: 'gpt-5.6-sol',
+          models: [
+            {
+              modelId: 'gpt-5.6-sol',
+              name: 'GPT-5.6-Sol',
+              effort: {
+                supported: true,
+                levels: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+                default: 'ultra',
+              },
+            },
+          ],
+        },
+      },
+    })).not.toThrow();
   });
 
   it('정적 모델 effort levels는 raw none/minimal을 포함하지 않는다', () => {

--- a/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
+++ b/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
@@ -48,6 +48,7 @@ vi.mock('../../src/detector/CliDetector.js', () => ({
 
 const { UnifiedCodexAgentClient } = await import('../../src/client/UnifiedCodexAgentClient.js');
 const { CodexAppServerConnection } = await import('../../src/connection/CodexAppServerConnection.js');
+const { AcpConnection } = await import('../../src/connection/AcpConnection.js');
 
 type CodexClient = InstanceType<typeof UnifiedCodexAgentClient>;
 
@@ -71,6 +72,61 @@ describe('UnifiedCodexAgentClient config staging', () => {
     mockCodexLoadSession.mockResolvedValue({ thread: { id: 'codex-thread-9' } });
     mockCodexSendMessage.mockResolvedValue(undefined);
     mockCodexCancelPrompt.mockResolvedValue(undefined);
+  });
+
+  it('ACP mode 매핑은 공식 codex-acp bridge mode ID를 사용한다', () => {
+    const client = new UnifiedCodexAgentClient();
+    const testClient = client as unknown as {
+      resolveAcpMode: (modeId: string) => string;
+    };
+
+    expect(testClient.resolveAcpMode('default')).toBe('read-only');
+    expect(testClient.resolveAcpMode('autoEdit')).toBe('agent');
+    expect(testClient.resolveAcpMode('yolo')).toBe('agent-full-access');
+  });
+
+  it('지원하지 않는 model+effort 조합은 ACP bridge 생성 전에 로컬 오류로 거부한다', async () => {
+    const client = new UnifiedCodexAgentClient();
+
+    await expect(client.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+      model: 'gpt-5.6-luna',
+      effort: 'ultra',
+    })).rejects.toThrow(
+      'codex/gpt-5.6-luna 모델은 effort "ultra"을(를) 지원하지 않습니다. 사용 가능: low, medium, high, xhigh, max',
+    );
+    expect(AcpConnection).not.toHaveBeenCalled();
+  });
+
+  it('ACP resetSession 후 첫 프롬프트에 systemPrompt를 한 번만 재주입한다', async () => {
+    const client = new UnifiedCodexAgentClient();
+    const mockAcpConnection = Object.assign(Object.create(AcpConnection.prototype), {
+      canResetSession: true,
+      connectionState: 'ready',
+      endSession: vi.fn().mockResolvedValue(undefined),
+      reconnectSession: vi.fn().mockResolvedValue({ sessionId: 'acp-session-2' }),
+      sendPrompt: vi.fn().mockResolvedValue({ stopReason: 'endTurn' }),
+    });
+    Object.assign(client as unknown as Record<string, unknown>, {
+      connection: mockAcpConnection,
+      sessionId: 'acp-session-1',
+      sessionCwd: '/workspace',
+      currentSystemPrompt: '리셋 후 지침',
+      firstPromptPending: null,
+    });
+
+    await client.resetSession();
+    await client.sendMessage('첫 요청');
+    await client.sendMessage('두 번째 요청');
+
+    expect(mockAcpConnection.endSession).toHaveBeenCalledWith('acp-session-1');
+    expect(mockAcpConnection.reconnectSession).toHaveBeenCalledWith('/workspace');
+    expect(mockAcpConnection.sendPrompt).toHaveBeenNthCalledWith(1, 'acp-session-2', [
+      { type: 'text', text: '리셋 후 지침' },
+      { type: 'text', text: '첫 요청' },
+    ]);
+    expect(mockAcpConnection.sendPrompt).toHaveBeenNthCalledWith(2, 'acp-session-2', '두 번째 요청');
   });
 
   it('codex 연결 시 systemPrompt를 developerInstructions로 전달한다', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,8 +74,8 @@ importers:
   packages/core-unified-agent:
     dependencies:
       '@agentclientprotocol/sdk':
-        specifier: ^0.21.0
-        version: 0.21.0(zod@4.4.1)
+        specifier: ^1.2.1
+        version: 1.2.1(zod@4.4.1)
       '@dotobokuri/core-process':
         specifier: workspace:*
         version: link:../core-process
@@ -526,8 +526,8 @@ importers:
 
 packages:
 
-  '@agentclientprotocol/sdk@0.21.0':
-    resolution: {integrity: sha512-ONj+Q8qOdNQp5XbH5jnMwzT9IKZJsSN0p0lkceS4GtUtNOPVLpNzSS8gqQdGMKfBvA0ESbkL8BTaSN1Rc9miEw==}
+  '@agentclientprotocol/sdk@1.2.1':
+    resolution: {integrity: sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
@@ -2378,7 +2378,7 @@ packages:
 
 snapshots:
 
-  '@agentclientprotocol/sdk@0.21.0(zod@4.4.1)':
+  '@agentclientprotocol/sdk@1.2.1(zod@4.4.1)':
     dependencies:
       zod: 4.4.1
 


### PR DESCRIPTION
## Summary

- Add GPT-5.6 Sol, Terra, and Luna model catalogs with model-specific reasoning effort levels.
- Switch Codex ACP to `@agentclientprotocol/codex-acp@1.1.2` and upgrade the ACP SDK to 1.2.1.
- Preserve deprecated model type aliases and cover official bridge mode, MCP, reset, and config behavior.

## Type of Change

- [ ] feat - new feature or carrier capability
- [ ] fix - bug fix
- [ ] docs - documentation only
- [ ] refactor - no behavior change
- [x] chore - build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- [x] `packages/unified-agent`
- [x] Documentation (README / SETUP / AGENTS.md)

## Test Plan

- [x] `pnpm --filter @dotobokuri/core-unified-agent exec vitest run tests/unit` (111/111)
- [x] `pnpm --filter @dotobokuri/core-unified-agent lint`
- [x] `pnpm --filter @dotobokuri/core-unified-agent typecheck:test`
- [x] `pnpm --filter @dotobokuri/core-unified-agent build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] Live Codex GPT-5.6 model and supported effort matrix (17/17)
- [x] Live Codex MCP/reset regression tests and common ACP contract tests

## Changelog

- [x] Added one `.changelog.d/*.md` fragment.
- [x] Fragment `section:` is `Added`.
- [x] Fragment bullet is ASCII English and uses `[core-unified-agent]`.

## Notes for Reviewers

- This PR is configured for immediate merge per maintainer instruction; automated Codex review is intentionally skipped.