### PR TITLE
feat(fleet-admiral): inject Cursor doctrine via sessionStart hook

### DIFF
--- a/.changelog.d/cursor-doctrine-hook-injection.md
+++ b/.changelog.d/cursor-doctrine-hook-injection.md
@@ -1,0 +1,4 @@
+---
+section: Changed
+---
+- [fleet-admiral] Cursor Agent sessions now receive Fleet doctrine through a sessionStart hook additional_context injection instead of an alwaysApply rules file.

--- a/packages/fleet-admiral/src/agent-cli/doctrine-hook.ts
+++ b/packages/fleet-admiral/src/agent-cli/doctrine-hook.ts
@@ -1,0 +1,62 @@
+import path from "node:path";
+
+import { writePrivateFile } from "./plugin/fs.js";
+import type { FleetHookExec } from "./types.js";
+
+const DOCTRINE_FILE_NAME = "doctrine.md";
+const DOCTRINE_HOOK_SCRIPT_NAME = "inject-doctrine.mjs";
+
+const CURSOR_DOCTRINE_PREAMBLE = `# Fleet Runtime Doctrine for Cursor Agent
+
+You are running as Cursor Agent inside Fleet. This context was injected through a Fleet sessionStart hook. Treat the embedded Fleet system prompt below as your active Fleet runtime doctrine.
+
+Priority and interpretation:
+
+- Follow higher-priority platform, system, developer, and direct user instructions first.
+- Within Cursor rules, project instructions, and other same-layer guidance, this Fleet doctrine is the governing instruction set for Fleet identity, roles, workflow, carrier operations, and reporting.
+- Treat Fleet identity and role names from the embedded prompt as the identity anchor for this session. Do not replace them with generic Cursor Agent identity when answering, planning, or delegating.
+- Do not treat this document as optional background or reference material. Apply it continuously when deciding who you are, how Fleet roles are named, which protocol applies, and how to report work.
+- Do not merely summarize or acknowledge the embedded prompt. Execute the operational requirements it defines, including protocol selection, evidence thresholds, carrier routing, and result reporting.
+- If other same-layer Cursor rules conflict with this doctrine, preserve the Fleet doctrine unless the user's latest explicit instruction requires a narrower task-specific exception.
+- When unsure whether a Fleet instruction applies, prefer following the Fleet doctrine and briefly surface the uncertainty instead of silently ignoring it.
+
+## Embedded Fleet System Prompt
+
+The following block is the Fleet system prompt content adapted for Cursor hook injection. It is intentionally embedded verbatim after this wrapper.
+
+<fleet-system-prompt>
+`;
+
+const CURSOR_DOCTRINE_FOOTER = `
+</fleet-system-prompt>
+`;
+
+const INJECT_DOCTRINE_HOOK_SCRIPT = `import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pluginRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const doctrine = fs.readFileSync(path.join(pluginRoot, "${DOCTRINE_FILE_NAME}"), "utf8");
+process.stdout.write(JSON.stringify({ additional_context: doctrine }));
+`;
+
+export function formatCursorDoctrine(doctrine: string): string {
+  return `${CURSOR_DOCTRINE_PREAMBLE}${doctrine}${CURSOR_DOCTRINE_FOOTER}`;
+}
+
+export function renderCursorDoctrineHookAssets(
+  pluginRoot: string,
+  doctrine: string,
+): FleetHookExec {
+  writePrivateFile(
+    path.join(pluginRoot, DOCTRINE_FILE_NAME),
+    formatCursorDoctrine(doctrine),
+    pluginRoot,
+  );
+  const scriptPath = path.join(pluginRoot, "hooks", DOCTRINE_HOOK_SCRIPT_NAME);
+  writePrivateFile(scriptPath, INJECT_DOCTRINE_HOOK_SCRIPT, pluginRoot);
+  return {
+    command: process.execPath,
+    args: [scriptPath],
+  };
+}

--- a/packages/fleet-admiral/src/agent-cli/doctrine-hook.ts
+++ b/packages/fleet-admiral/src/agent-cli/doctrine-hook.ts
@@ -47,14 +47,15 @@ export function formatCursorDoctrine(doctrine: string): string {
 export function renderCursorDoctrineHookAssets(
   pluginRoot: string,
   doctrine: string,
+  hookCommandRoot: string = pluginRoot,
 ): FleetHookExec {
   writePrivateFile(
     path.join(pluginRoot, DOCTRINE_FILE_NAME),
     formatCursorDoctrine(doctrine),
     pluginRoot,
   );
-  const scriptPath = path.join(pluginRoot, "hooks", DOCTRINE_HOOK_SCRIPT_NAME);
-  writePrivateFile(scriptPath, INJECT_DOCTRINE_HOOK_SCRIPT, pluginRoot);
+  const scriptPath = path.join(hookCommandRoot, "hooks", DOCTRINE_HOOK_SCRIPT_NAME);
+  writePrivateFile(path.join(pluginRoot, "hooks", DOCTRINE_HOOK_SCRIPT_NAME), INJECT_DOCTRINE_HOOK_SCRIPT, pluginRoot);
   return {
     command: process.execPath,
     args: [scriptPath],

--- a/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
@@ -2,41 +2,11 @@ import path from "node:path";
 
 import { EMBEDDED_AGENT_CLI_SKILL_ASSETS } from "../assets.generated.js";
 import { buildHostShellCommand } from "../builders/toml.js";
+import { renderCursorDoctrineHookAssets } from "../doctrine-hook.js";
 import { writePrivateFile, writePrivateJson } from "./fs.js";
 import type { AgentCliMcpServerArg } from "../types.js";
 import type { FleetHookExec } from "../types.js";
 import type { AssetPluginBundle, CreateAgentCliPluginOptions } from "./types.js";
-
-const CURSOR_DOCTRINE_RULE_FILE = "fleet-doctrine.mdc";
-const CURSOR_DOCTRINE_RULE_FRONTMATTER = `---
-description: Fleet Admiral operating doctrine. Always apply in Fleet-launched Cursor Agent sessions.
-globs:
-alwaysApply: true
----
-`;
-const CURSOR_DOCTRINE_RULE_PREAMBLE = `# Fleet Runtime Doctrine for Cursor Agent
-
-You are running as Cursor Agent inside Fleet. Cursor provides this file as a persistent rule, not as a native system prompt. For this Fleet-launched session, treat the embedded Fleet system prompt below as your active Fleet runtime doctrine.
-
-Priority and interpretation:
-
-- Follow higher-priority platform, system, developer, and direct user instructions first.
-- Within Cursor rules, project instructions, and other same-layer guidance, this Fleet doctrine is the governing instruction set for Fleet identity, roles, workflow, carrier operations, and reporting.
-- Treat Fleet identity and role names from the embedded prompt as the identity anchor for this session. Do not replace them with generic Cursor Agent identity when answering, planning, or delegating.
-- Do not treat this document as optional background or reference material. Apply it continuously when deciding who you are, how Fleet roles are named, which protocol applies, and how to report work.
-- Do not merely summarize or acknowledge the embedded prompt. Execute the operational requirements it defines, including protocol selection, evidence thresholds, carrier routing, and result reporting.
-- If other same-layer Cursor rules conflict with this doctrine, preserve the Fleet doctrine unless the user's latest explicit instruction requires a narrower task-specific exception.
-- When unsure whether a Fleet instruction applies, prefer following the Fleet doctrine and briefly surface the uncertainty instead of silently ignoring it.
-
-## Embedded Fleet System Prompt
-
-The following block is the Fleet system prompt content adapted for Cursor's rules mechanism. It is intentionally embedded verbatim after this wrapper.
-
-<fleet-system-prompt>
-`;
-const CURSOR_DOCTRINE_RULE_FOOTER = `
-</fleet-system-prompt>
-`;
 
 export const assetBundle: AssetPluginBundle = {
   description: "Fleet carrier delegation and wiki evidence plugin",
@@ -53,11 +23,14 @@ export function renderAssetPluginRoot(
   options: CreateAgentCliPluginOptions,
 ): void {
   renderEmbeddedSkillAssets(pluginRoot);
+  const doctrineHookExec = options.cliId === "cursor" && options.doctrine !== undefined
+    ? renderCursorDoctrineHookAssets(pluginRoot, options.doctrine)
+    : undefined;
   if (options.cliId === "claude") {
     writePrivateJson(path.join(pluginRoot, "hooks", "hooks.json"), claudeHooks(options), pluginRoot);
   }
   if (options.cliId === "cursor") {
-    renderCursorPluginRoot(pluginRoot, options);
+    renderCursorPluginRoot(pluginRoot, options, doctrineHookExec);
   }
 }
 
@@ -109,25 +82,18 @@ function claudeCommandHook(hookExec: FleetHookExec): unknown {
   };
 }
 
-function renderCursorPluginRoot(pluginRoot: string, options: CreateAgentCliPluginOptions): void {
-  if (options.doctrine !== undefined) {
-    renderCursorDoctrineRule(pluginRoot, options.doctrine);
-  }
+function renderCursorPluginRoot(
+  pluginRoot: string,
+  options: CreateAgentCliPluginOptions,
+  doctrineHookExec: FleetHookExec | undefined,
+): void {
   if ((options.mcpServers ?? []).length > 0) {
     writePrivateJson(path.join(pluginRoot, "mcp.json"), cursorMcpConfig(options.mcpServers ?? []), pluginRoot);
   }
-  const hooks = cursorHooks(options);
+  const hooks = cursorHooks(options, doctrineHookExec);
   if (hooks !== undefined) {
     writePrivateJson(path.join(pluginRoot, "hooks", "hooks.json"), hooks, pluginRoot);
   }
-}
-
-function renderCursorDoctrineRule(pluginRoot: string, doctrine: string): void {
-  writePrivateFile(
-    path.join(pluginRoot, "rules", CURSOR_DOCTRINE_RULE_FILE),
-    `${CURSOR_DOCTRINE_RULE_FRONTMATTER}${CURSOR_DOCTRINE_RULE_PREAMBLE}${doctrine}${CURSOR_DOCTRINE_RULE_FOOTER}`,
-    pluginRoot,
-  );
 }
 
 function cursorMcpConfig(servers: readonly AgentCliMcpServerArg[]): unknown {
@@ -144,8 +110,11 @@ function cursorMcpConfig(servers: readonly AgentCliMcpServerArg[]): unknown {
   };
 }
 
-function cursorHooks(options: CreateAgentCliPluginOptions): unknown | undefined {
-  const sessionStartExecs = [options.captureSessionHookExec]
+function cursorHooks(
+  options: CreateAgentCliPluginOptions,
+  doctrineHookExec: FleetHookExec | undefined,
+): unknown | undefined {
+  const sessionStartExecs = [doctrineHookExec, options.captureSessionHookExec]
     .filter((exec): exec is FleetHookExec => exec !== undefined);
   const beforeSubmitPromptExecs = [options.turnStartHookExec, options.autoNameHookExec]
     .filter((exec): exec is FleetHookExec => exec !== undefined);

--- a/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
@@ -24,7 +24,11 @@ export function renderAssetPluginRoot(
 ): void {
   renderEmbeddedSkillAssets(pluginRoot);
   const doctrineHookExec = options.cliId === "cursor" && options.doctrine !== undefined
-    ? renderCursorDoctrineHookAssets(pluginRoot, options.doctrine)
+    ? renderCursorDoctrineHookAssets(
+      pluginRoot,
+      options.doctrine,
+      options.installedPluginRoot ?? pluginRoot,
+    )
     : undefined;
   if (options.cliId === "claude") {
     writePrivateJson(path.join(pluginRoot, "hooks", "hooks.json"), claudeHooks(options), pluginRoot);

--- a/packages/fleet-admiral/src/agent-cli/plugin/index.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/index.ts
@@ -144,7 +144,7 @@ function renderPluginRoot(
           ensurePrivateDir(path.join(stagedPluginRoot, "agents"), stagedPluginRoot);
         }
         ensurePrivateDir(path.join(stagedPluginRoot, "skills"), stagedPluginRoot);
-        renderAssetPluginRoot(stagedPluginRoot, bundle, options);
+        renderAssetPluginRoot(stagedPluginRoot, bundle, { ...options, installedPluginRoot: pluginRoot });
         break;
     }
     writePrivateJson(path.join(stagedPluginRoot, ".codex-plugin", "plugin.json"), codexManifest(bundle, stagedPluginRoot), stagedPluginRoot);

--- a/packages/fleet-admiral/src/agent-cli/plugin/index.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/index.ts
@@ -394,7 +394,7 @@ function listCursorEffectivePluginFiles(pluginRoot: string): string[] {
   const files: string[] = [];
   // mcp.json에는 세션별 bearer 토큰이 들어가므로 의도적으로 해시에 포함한다.
   // Cursor가 새 세션마다 최신 MCP 토큰을 재적재하도록 플러그인 버전을 갱신한다.
-  for (const entry of ["skills", "rules", "hooks", "mcp.json"]) {
+  for (const entry of ["skills", "hooks", "doctrine.md", "mcp.json"]) {
     const entryPath = path.join(pluginRoot, entry);
     if (!existsSync(entryPath)) continue;
     const stat = lstatSync(entryPath);

--- a/packages/fleet-admiral/src/agent-cli/plugin/types.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/types.ts
@@ -23,6 +23,8 @@ export interface CreateAgentCliPluginOptions {
   // 입력 대기(AskUserQuestion의 PreToolUse · permission/idle/elicitation Notification) 신호를 호스트로
   // 알리는 hook. AskUserQuestion은 Notification 훅을 발화하지 않으므로 두 이벤트 경로로 건다. Claude 전용.
   readonly inputWaitingHookExec?: FleetHookExec;
+  // atomic install 시 staging 경로가 아닌 최종 plugin root를 hook command에 기록한다.
+  readonly installedPluginRoot?: string;
   // 작전명 자동 작명(UserPromptSubmit)을 위해 prompt를 호스트로 전달하는 hook. claude/codex 양쪽에 와이어링된다.
   readonly autoNameHookExec?: FleetHookExec;
   readonly onCleanup?: (cleanup: () => void) => void;

--- a/packages/fleet-admiral/tests/agent-cli-plugin-marketplace.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-plugin-marketplace.test.ts
@@ -204,6 +204,7 @@ describe("agent CLI plugin marketplace rendering", () => {
     expect(hooksJson.version).toBe(1);
     expect(hooksJson.hooks?.sessionStart).toHaveLength(2);
     expect(hooksJson.hooks?.sessionStart?.[0]?.command).toContain("inject-doctrine.mjs");
+    expect(hooksJson.hooks?.sessionStart?.[0]?.command).not.toContain(".fleet-stage-");
     expect(hooksJson.hooks?.sessionStart?.[1]?.command).toBe("'node' 'cli.mjs' 'hook' 'capture-session' 'cursor'");
     expect(JSON.stringify(hooksJson)).not.toContain("subagents-context");
     expect(JSON.stringify(hooksJson)).not.toContain("additional-context-file");

--- a/packages/fleet-admiral/tests/agent-cli-plugin-marketplace.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-plugin-marketplace.test.ts
@@ -1,6 +1,8 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
+import process from "node:process";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -154,7 +156,7 @@ describe("agent CLI plugin marketplace rendering", () => {
     expect(userPromptSubmit).toEqual(["capture-session", "turn-start", "auto-name"]);
   });
 
-  it("renders Cursor plugin rules hooks and MCP config", async () => {
+  it("renders Cursor doctrine hook, session hooks, and MCP config", async () => {
     const root = mkdtempSync(path.join(os.tmpdir(), "fleet-admiral-plugin-cursor-"));
     tempDirs.push(root);
     const dataDir = path.join(root, "data");
@@ -175,8 +177,9 @@ describe("agent CLI plugin marketplace rendering", () => {
     });
 
     const manifest = JSON.parse(readFileSync(path.join(plugin.pluginRoot, ".cursor-plugin", "plugin.json"), "utf8")) as { readonly name?: unknown };
-    const doctrineRuleFile = path.join(plugin.pluginRoot, "rules", "fleet-doctrine.mdc");
-    const doctrineRule = readFileSync(doctrineRuleFile, "utf8");
+    const doctrineFile = path.join(plugin.pluginRoot, "doctrine.md");
+    const doctrine = readFileSync(doctrineFile, "utf8");
+    const doctrineHookScript = path.join(plugin.pluginRoot, "hooks", "inject-doctrine.mjs");
     const hooksJson = JSON.parse(readFileSync(path.join(plugin.pluginRoot, "hooks", "hooks.json"), "utf8")) as {
       readonly version?: unknown;
       readonly hooks?: Record<string, ReadonlyArray<{ readonly command?: string }>>;
@@ -184,19 +187,24 @@ describe("agent CLI plugin marketplace rendering", () => {
     const mcpJson = JSON.parse(readFileSync(path.join(plugin.pluginRoot, "mcp.json"), "utf8")) as {
       readonly mcpServers?: Record<string, { readonly headers?: { readonly Authorization?: string } }>;
     };
+    const hookOutput = spawnSync(process.execPath, [doctrineHookScript], { encoding: "utf8" });
 
     expect(manifest.name).toBe("fleet");
-    expect(doctrineRule).toContain("alwaysApply: true");
-    expect(doctrineRule).toContain("Fleet Runtime Doctrine for Cursor Agent");
-    expect(doctrineRule).toContain("treat the embedded Fleet system prompt below as your active Fleet runtime doctrine");
-    expect(doctrineRule).toContain("identity anchor for this session");
-    expect(doctrineRule).toContain("Do not merely summarize or acknowledge the embedded prompt");
-    expect(doctrineRule).toContain("<fleet-system-prompt>\nFleet doctrine\n</fleet-system-prompt>");
+    expect(doctrine).toContain("Fleet Runtime Doctrine for Cursor Agent");
+    expect(doctrine).toContain("sessionStart hook");
+    expect(doctrine).toContain("identity anchor for this session");
+    expect(doctrine).toContain("Do not merely summarize or acknowledge the embedded prompt");
+    expect(doctrine).toContain("<fleet-system-prompt>\nFleet doctrine\n</fleet-system-prompt>");
+    expect(existsSync(path.join(plugin.pluginRoot, "rules", "fleet-doctrine.mdc"))).toBe(false);
     expect(existsSync(path.join(plugin.pluginRoot, "context", "fleet-system-prompt.txt"))).toBe(false);
+    expect(hookOutput.status).toBe(0);
+    expect(JSON.parse(hookOutput.stdout)).toEqual({
+      additional_context: doctrine,
+    });
     expect(hooksJson.version).toBe(1);
-    expect(hooksJson.hooks?.sessionStart?.map((hook) => hook.command)).toEqual([
-      "'node' 'cli.mjs' 'hook' 'capture-session' 'cursor'",
-    ]);
+    expect(hooksJson.hooks?.sessionStart).toHaveLength(2);
+    expect(hooksJson.hooks?.sessionStart?.[0]?.command).toContain("inject-doctrine.mjs");
+    expect(hooksJson.hooks?.sessionStart?.[1]?.command).toBe("'node' 'cli.mjs' 'hook' 'capture-session' 'cursor'");
     expect(JSON.stringify(hooksJson)).not.toContain("subagents-context");
     expect(JSON.stringify(hooksJson)).not.toContain("additional-context-file");
     expect(hooksJson.hooks?.beforeSubmitPrompt?.map((hook) => hook.command)).toEqual([

--- a/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
@@ -131,6 +131,7 @@ describe("agent CLI session resume and capture hooks", () => {
     expect(doctrine).toContain("<fleet-system-prompt>\nFleet doctrine\n</fleet-system-prompt>");
     expect(hooksJson.hooks?.sessionStart).toHaveLength(2);
     expect(hooksJson.hooks?.sessionStart?.[0]?.command).toContain("inject-doctrine.mjs");
+    expect(hooksJson.hooks?.sessionStart?.[0]?.command).not.toContain(".fleet-stage-");
     expect(hooksJson.hooks?.sessionStart?.[1]?.command).toBe("'node' 'console.js' 'hook' 'capture-session' 'cursor'");
     expect(hooksJson.hooks?.sessionStart?.[1]?.command).not.toContain("additional-context-file");
     expect(mcpJson.mcpServers?.fleet?.headers?.Authorization).toBe("Bearer token-123");

--- a/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
@@ -108,8 +108,8 @@ describe("agent CLI session resume and capture hooks", () => {
       readonly name?: unknown;
       readonly version?: unknown;
     };
-    const doctrineRuleFile = path.join(pluginRoot, "rules", "fleet-doctrine.mdc");
-    const doctrineRule = readFileSync(doctrineRuleFile, "utf8");
+    const doctrineFile = path.join(pluginRoot, "doctrine.md");
+    const doctrine = readFileSync(doctrineFile, "utf8");
     const hooksJson = JSON.parse(readFileSync(path.join(pluginRoot, "hooks", "hooks.json"), "utf8")) as {
       readonly hooks?: {
         readonly sessionStart?: readonly { readonly command?: string }[];
@@ -127,10 +127,12 @@ describe("agent CLI session resume and capture hooks", () => {
     expect(injected.args).not.toContain("--trust");
     expect(cursorManifest.name).toBe("fleet");
     expect(cursorManifest.version).toMatch(/^0\.0\.0\+[0-9a-f]{12}$/);
-    expect(doctrineRule).toContain("Fleet Runtime Doctrine for Cursor Agent");
-    expect(doctrineRule).toContain("<fleet-system-prompt>\nFleet doctrine\n</fleet-system-prompt>");
-    expect(hooksJson.hooks?.sessionStart?.[0]?.command).toBe("'node' 'console.js' 'hook' 'capture-session' 'cursor'");
-    expect(hooksJson.hooks?.sessionStart?.[0]?.command).not.toContain("additional-context-file");
+    expect(doctrine).toContain("Fleet Runtime Doctrine for Cursor Agent");
+    expect(doctrine).toContain("<fleet-system-prompt>\nFleet doctrine\n</fleet-system-prompt>");
+    expect(hooksJson.hooks?.sessionStart).toHaveLength(2);
+    expect(hooksJson.hooks?.sessionStart?.[0]?.command).toContain("inject-doctrine.mjs");
+    expect(hooksJson.hooks?.sessionStart?.[1]?.command).toBe("'node' 'console.js' 'hook' 'capture-session' 'cursor'");
+    expect(hooksJson.hooks?.sessionStart?.[1]?.command).not.toContain("additional-context-file");
     expect(mcpJson.mcpServers?.fleet?.headers?.Authorization).toBe("Bearer token-123");
   });
 
@@ -242,8 +244,6 @@ describe("agent CLI session resume and capture hooks", () => {
     expect(toml).not.toContain("args =");
     expect(pluginJson.hooks).toBeUndefined();
     expect(pluginJson.version).toMatch(/^0\.0\.0\+[0-9a-f]{12}$/);
-    expect(toml).not.toContain("SessionStart =");
-    expect(toml).not.toContain("subagents-context");
   });
 
   it("preserves Codex hook trust state while rewriting the fixed Fleet profile", async () => {


### PR DESCRIPTION
## Summary

- Cursor Agent sessions now receive Fleet doctrine through a `sessionStart` hook that emits `additional_context` from `doctrine.md`, replacing the alwaysApply `fleet-doctrine.mdc` rule file.
- Claude (`--append-system-prompt-file`) and Codex (`developer_instructions` profile) doctrine delivery is unchanged.
- Cursor plugin manifest hashing now tracks `doctrine.md` instead of `rules/`.

## Test Plan

- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `pnpm --filter @dotobokuri/fleet-admiral build`
- [x] `pnpm --filter @dotobokuri/fleet-admiral test` (41/41)

## Changelog

- [x] `.changelog.d/cursor-doctrine-hook-injection.md` included

Made with [Cursor](https://cursor.com)