### PR TITLE
feat(fleet-console): surface update availability without page refresh

### DIFF
--- a/.changelog.d/live-update-available-badge.md
+++ b/.changelog.d/live-update-available-badge.md
@@ -1,0 +1,4 @@
+---
+section: Fixed
+---
+- [fleet-console] Update Available badge now appears in open tabs without a page refresh when a new console release is detected.

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 
 import { useMapFullscreen } from "./canvas/canvas-store.js";
-import { fetchGroups, fetchObserverStatus, fetchOperations, fetchReleaseNotes, fetchTheaterBootstrap } from "./api.js";
+import { fetchGroups, fetchOperations, fetchReleaseNotes, fetchTheaterBootstrap } from "./api.js";
 import { CommissioningOverlay } from "./components/commissioning-overlay.js";
 import { OperationSearch } from "./components/operation-search.js";
 import { StatusBar } from "./components/statusbar.js";
@@ -14,9 +14,10 @@ import { usePluginRegistry } from "./plugin-registry.js";
 import { CarrierSettings } from "./pages/carrier-settings.js";
 import { GlobalSettings } from "./pages/global-settings.js";
 import { Operations } from "./pages/operations.js";
-import { applyObserverStatus, applyReleaseNotes, beginReleaseNotesFetch, failReleaseNotesFetch, hydrateGroups, hydrateOperations, hydrateTheaterBootstrap, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
+import { refreshObserverStatus } from "./operations-sse.js";
+import { applyReleaseNotes, beginReleaseNotesFetch, failReleaseNotesFetch, hydrateGroups, hydrateOperations, hydrateTheaterBootstrap, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
 
-// 서버는 부팅 시 update 체크를 fire-and-forget으로 시작하므로, 첫 방문이 registry 응답보다
+// 서버는 부팅 시 update 체크를 fire-and-forget으로 시작하므로, 첫 방문이 SSE 연결보다
 // 빠르면 GNB 배지가 누락될 수 있다. 짧은 지연 후 status를 1회만 재조회해 cold-start를 보정한다(폴링 아님).
 const UPDATE_STATUS_RECHECK_DELAY_MS = 6_000;
 
@@ -64,14 +65,9 @@ export function App() {
         if (abort.signal.aborted) return;
         failReleaseNotesFetch(error instanceof Error ? error.message : String(error));
       });
-    const refreshUpdateStatus = () => {
-      void fetchObserverStatus(state.activeTheaterId, abort.signal)
-        .then(applyObserverStatus)
-        .catch(() => {});
-    };
-    refreshUpdateStatus();
+    refreshObserverStatus();
     // cold-start 보정: 서버 백그라운드 refresh 완료를 기다렸다가 한 번 더 읽어 배지를 채운다.
-    const recheckTimer = window.setTimeout(refreshUpdateStatus, UPDATE_STATUS_RECHECK_DELAY_MS);
+    const recheckTimer = window.setTimeout(refreshObserverStatus, UPDATE_STATUS_RECHECK_DELAY_MS);
     return () => {
       window.clearTimeout(recheckTimer);
       abort.abort();

--- a/runtime/fleet-console/core/client/src/operations-sse.ts
+++ b/runtime/fleet-console/core/client/src/operations-sse.ts
@@ -1,14 +1,19 @@
-import { fetchOperations } from "./api.js";
-import { applyOperationUpdate, hydrateOperations } from "./store.js";
+import { fetchObserverStatus, fetchOperations } from "./api.js";
+import { applyObserverStatus, applyOperationUpdate, getState, hydrateOperations } from "./store.js";
 import type { OperationNode } from "./types.js";
 
 const MAX_RECONNECT_DELAY_MS = 30_000;
 
 let reconnectDelayMs = 1_000;
 let reconnectHandle: ReturnType<typeof setTimeout> | null = null;
+let statusRefreshInFlight: Promise<void> | null = null;
+let statusRefreshPending = false;
 
 export function connectOperationsSse(): void {
-  if (reconnectHandle !== null) clearTimeout(reconnectHandle);
+  if (reconnectHandle !== null) {
+    clearTimeout(reconnectHandle);
+    reconnectHandle = null;
+  }
   const source = new EventSource("/api/v1/operations/events");
 
   source.addEventListener("operation:changed", (e) => {
@@ -21,8 +26,13 @@ export function connectOperationsSse(): void {
     }
   });
 
+  source.addEventListener("update:available", () => {
+    refreshObserverStatus();
+  });
+
   source.onopen = () => {
     reconnectDelayMs = 1_000;
+    refreshObserverStatus();
   };
 
   source.onerror = () => {
@@ -36,6 +46,22 @@ export function connectOperationsSse(): void {
         .finally(connectOperationsSse);
     }, reconnectDelayMs);
   };
+}
+
+export function refreshObserverStatus(): void {
+  if (statusRefreshInFlight) {
+    statusRefreshPending = true;
+    return;
+  }
+  statusRefreshInFlight = fetchObserverStatus(getState().activeTheaterId)
+    .then(applyObserverStatus)
+    .catch(() => undefined)
+    .finally(() => {
+      statusRefreshInFlight = null;
+      if (!statusRefreshPending) return;
+      statusRefreshPending = false;
+      refreshObserverStatus();
+    });
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -234,6 +234,9 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   const pluginCleanupCallbacks = new Set<() => void | Promise<void>>();
   const pluginEventListeners = new Map<string, Set<(payload: unknown) => void>>();
   const operationSseSubscribers = new Set<http.ServerResponse>();
+  let unsubscribeUpdateCheckChanges = updateCheck.onChange?.(() => {
+    broadcastUpdateAvailable();
+  }) ?? null;
   const pluginHostCapabilities: FleetPluginHostCapabilities = {
     operations: {
       list: () => operations.list(),
@@ -827,6 +830,9 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   }
 
   async function disposeConsoleResources(currentLock: ConsoleLockHandle | null): Promise<void> {
+    updateCheck.stop?.();
+    unsubscribeUpdateCheckChanges?.();
+    unsubscribeUpdateCheckChanges = null;
     if (consoleResourcesDisposed) {
       currentLock?.release();
       return;
@@ -897,6 +903,14 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     }
   }
 
+  function broadcastUpdateAvailable(): void {
+    if (operationSseSubscribers.size === 0) return;
+    const data = encodeSseData("update:available", {});
+    for (const res of operationSseSubscribers) {
+      res.write(data);
+    }
+  }
+
   function persistDurableState(): void {
     try {
       durableStateStore.save({
@@ -951,6 +965,12 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
         throw error;
       }
       if (!activeEndpoint) throw new Error("Console endpoint unavailable");
+      if (unsubscribeUpdateCheckChanges === null) {
+        unsubscribeUpdateCheckChanges = updateCheck.onChange?.(() => {
+          broadcastUpdateAvailable();
+        }) ?? null;
+      }
+      updateCheck.start?.();
       void updateCheck.refresh();
       return activeEndpoint;
     },
@@ -1244,4 +1264,3 @@ function resolvePluginStorageFile(dataDir: string, pluginId: string, key: string
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error;
 }
-

--- a/runtime/fleet-console/core/host/update-check.ts
+++ b/runtime/fleet-console/core/host/update-check.ts
@@ -104,7 +104,12 @@ export function createConsoleUpdateCheckService(deps: ConsoleUpdateCheckDeps = {
       return NO_UPDATE_STATUS;
     }
     const latestVersion = await fetchLatest(FLEET_CONSOLE_PACKAGE_NAME);
-    if (!latestVersion || !isGreater(latestVersion, release.version)) {
+    if (latestVersion === undefined) {
+      // 실 fetchLatestVersion은 타임아웃·비정상 응답에서 throw 대신 undefined를 반환하므로,
+      // 여기서 throw로 승격해야 조회 실패가 짧은 오류 TTL(catch 경로)로 캐시된다.
+      throw new Error("registry lookup failed");
+    }
+    if (!isGreater(latestVersion, release.version)) {
       return NO_UPDATE_STATUS;
     }
     return { updateAvailable: true, latestVersion };

--- a/runtime/fleet-console/core/host/update-check.ts
+++ b/runtime/fleet-console/core/host/update-check.ts
@@ -10,6 +10,9 @@ export interface ConsoleUpdateStatus {
 export interface ConsoleUpdateCheckService {
   getStatus(): ConsoleUpdateStatus;
   refresh(options?: ConsoleUpdateRefreshOptions): Promise<ConsoleUpdateStatus>;
+  start?(): void;
+  stop?(): void;
+  onChange?(listener: ConsoleUpdateCheckChangeListener): () => void;
 }
 
 export interface ConsoleUpdateCheckDeps {
@@ -18,19 +21,32 @@ export interface ConsoleUpdateCheckDeps {
   readonly isGreater?: (left: string, right: string) => boolean;
   readonly now?: () => number;
   readonly ttlMs?: number;
+  readonly errorTtlMs?: number;
+  readonly intervalMs?: number;
+  readonly setInterval?: (callback: () => void, delayMs: number) => ConsoleUpdateCheckInterval;
+  readonly clearInterval?: (interval: ConsoleUpdateCheckInterval) => void;
 }
 
 export interface ConsoleUpdateRefreshOptions {
   readonly force?: boolean;
 }
 
+export type ConsoleUpdateCheckChangeListener = (status: ConsoleUpdateStatus) => void;
+
 interface CachedConsoleUpdateStatus {
   readonly status: ConsoleUpdateStatus;
   readonly checkedAt: number;
+  readonly ttlMs: number;
+}
+
+export interface ConsoleUpdateCheckInterval {
+  unref?(): void;
 }
 
 const FLEET_CONSOLE_PACKAGE_NAME = "@dotobokuri/fleet-console";
 const UPDATE_CHECK_TTL_MS = 60 * 60 * 1000;
+const UPDATE_CHECK_ERROR_TTL_MS = 5 * 60 * 1000;
+const UPDATE_CHECK_INTERVAL_MS = 30 * 60 * 1000;
 const NO_UPDATE_STATUS: ConsoleUpdateStatus = { updateAvailable: false };
 
 export function createConsoleUpdateCheckService(deps: ConsoleUpdateCheckDeps = {}): ConsoleUpdateCheckService {
@@ -39,12 +55,18 @@ export function createConsoleUpdateCheckService(deps: ConsoleUpdateCheckDeps = {
   const isGreater = deps.isGreater ?? isVersionGreater;
   const now = deps.now ?? Date.now;
   const ttlMs = deps.ttlMs ?? UPDATE_CHECK_TTL_MS;
+  const errorTtlMs = deps.errorTtlMs ?? UPDATE_CHECK_ERROR_TTL_MS;
+  const intervalMs = deps.intervalMs ?? UPDATE_CHECK_INTERVAL_MS;
+  const startInterval = deps.setInterval ?? ((callback, delayMs) => setInterval(callback, delayMs));
+  const stopInterval = deps.clearInterval ?? ((interval) => clearInterval(interval as NodeJS.Timeout));
   let cached: CachedConsoleUpdateStatus | null = null;
   let inFlight: Promise<ConsoleUpdateStatus> | null = null;
+  let interval: ConsoleUpdateCheckInterval | null = null;
+  const changeListeners = new Set<ConsoleUpdateCheckChangeListener>();
 
   const getStatus = (): ConsoleUpdateStatus => {
     const current = cached;
-    if (current && now() - current.checkedAt < ttlMs) {
+    if (current && now() - current.checkedAt < current.ttlMs) {
       return current.status;
     }
     void refresh();
@@ -53,7 +75,7 @@ export function createConsoleUpdateCheckService(deps: ConsoleUpdateCheckDeps = {
 
   const refresh = async (options: ConsoleUpdateRefreshOptions = {}): Promise<ConsoleUpdateStatus> => {
     const current = cached;
-    if (options.force !== true && current && now() - current.checkedAt < ttlMs) {
+    if (options.force !== true && current && now() - current.checkedAt < current.ttlMs) {
       return current.status;
     }
     if (inFlight) {
@@ -61,11 +83,13 @@ export function createConsoleUpdateCheckService(deps: ConsoleUpdateCheckDeps = {
     }
     inFlight = resolveUpdateStatus()
       .then((status) => {
-        cached = { status, checkedAt: now() };
+        const previousStatus = cached?.status ?? NO_UPDATE_STATUS;
+        cached = { status, checkedAt: now(), ttlMs };
+        notifyIfChanged(previousStatus, status);
         return status;
       })
       .catch(() => {
-        cached = { status: NO_UPDATE_STATUS, checkedAt: now() };
+        cached = { status: NO_UPDATE_STATUS, checkedAt: now(), ttlMs: errorTtlMs };
         return NO_UPDATE_STATUS;
       })
       .finally(() => {
@@ -86,5 +110,37 @@ export function createConsoleUpdateCheckService(deps: ConsoleUpdateCheckDeps = {
     return { updateAvailable: true, latestVersion };
   };
 
-  return { getStatus, refresh };
+  const start = (): void => {
+    if (interval) return;
+    interval = startInterval(() => {
+      void refresh({ force: true });
+    }, intervalMs);
+    interval.unref?.();
+  };
+
+  const stop = (): void => {
+    if (!interval) return;
+    stopInterval(interval);
+    interval = null;
+  };
+
+  const onChange = (listener: ConsoleUpdateCheckChangeListener): (() => void) => {
+    changeListeners.add(listener);
+    return () => changeListeners.delete(listener);
+  };
+
+  function notifyIfChanged(previous: ConsoleUpdateStatus, next: ConsoleUpdateStatus): void {
+    const updateBecameAvailable = !previous.updateAvailable && next.updateAvailable;
+    const latestVersionChanged = previous.latestVersion !== next.latestVersion;
+    if (!updateBecameAvailable && !latestVersionChanged) return;
+    for (const listener of changeListeners) {
+      try {
+        listener(next);
+      } catch {
+        // An observer must not turn a completed registry lookup into an error cache entry.
+      }
+    }
+  }
+
+  return { getStatus, refresh, start, stop, onChange };
 }

--- a/runtime/fleet-console/tests/operations-sse.test.ts
+++ b/runtime/fleet-console/tests/operations-sse.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  applyObserverStatus: vi.fn(),
+  applyOperationUpdate: vi.fn(),
+  fetchObserverStatus: vi.fn(),
+  fetchOperations: vi.fn(),
+  getState: vi.fn(),
+  hydrateOperations: vi.fn(),
+}));
+
+vi.mock("../core/client/src/api.js", () => ({
+  fetchObserverStatus: mocks.fetchObserverStatus,
+  fetchOperations: mocks.fetchOperations,
+}));
+
+vi.mock("../core/client/src/store.js", () => ({
+  applyObserverStatus: mocks.applyObserverStatus,
+  applyOperationUpdate: mocks.applyOperationUpdate,
+  getState: mocks.getState,
+  hydrateOperations: mocks.hydrateOperations,
+}));
+
+import { connectOperationsSse } from "../core/client/src/operations-sse.js";
+
+class TestEventSource {
+  static instances: TestEventSource[] = [];
+
+  onerror: (() => void) | null = null;
+  onopen: (() => void) | null = null;
+  private readonly listeners = new Map<string, (() => void)[]>();
+
+  constructor(_url: string) {
+    TestEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: () => void): void {
+    const registered = this.listeners.get(type) ?? [];
+    registered.push(listener);
+    this.listeners.set(type, registered);
+  }
+
+  close(): void {}
+
+  emit(type: string): void {
+    for (const listener of this.listeners.get(type) ?? []) listener();
+  }
+
+  open(): void {
+    this.onopen?.();
+  }
+}
+
+describe("operations SSE update availability", () => {
+  afterEach(() => {
+    TestEventSource.instances = [];
+    mocks.applyObserverStatus.mockReset();
+    mocks.applyOperationUpdate.mockReset();
+    mocks.fetchObserverStatus.mockReset();
+    mocks.fetchOperations.mockReset();
+    mocks.getState.mockReset();
+    mocks.hydrateOperations.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it("re-reads observer status instead of trusting an update frame payload", async () => {
+    const status = { version: "1.0.0", updateAvailable: true };
+    vi.stubGlobal("EventSource", TestEventSource);
+    mocks.getState.mockReturnValue({ activeTheaterId: "theater-1" });
+    mocks.fetchObserverStatus.mockResolvedValue(status);
+
+    connectOperationsSse();
+    TestEventSource.instances[0]?.emit("update:available");
+
+    await vi.waitFor(() => expect(mocks.applyObserverStatus).toHaveBeenCalledWith(status));
+    expect(mocks.fetchObserverStatus).toHaveBeenCalledWith("theater-1");
+  });
+
+  it("re-reads observer status when the SSE channel opens", async () => {
+    const status = { version: "1.0.0", updateAvailable: false };
+    vi.stubGlobal("EventSource", TestEventSource);
+    mocks.getState.mockReturnValue({ activeTheaterId: null });
+    mocks.fetchObserverStatus.mockResolvedValue(status);
+
+    connectOperationsSse();
+    TestEventSource.instances[0]?.open();
+
+    await vi.waitFor(() => expect(mocks.applyObserverStatus).toHaveBeenCalledWith(status));
+    expect(mocks.fetchObserverStatus).toHaveBeenCalledWith(null);
+  });
+
+  it("trails a status refresh when a later update frame arrives in flight", async () => {
+    let resolveFirstStatus: ((status: { version: string; updateAvailable: boolean }) => void) | null = null;
+    const staleStatus = { version: "1.0.0", updateAvailable: false };
+    const currentStatus = { version: "1.0.0", updateAvailable: true };
+    vi.stubGlobal("EventSource", TestEventSource);
+    mocks.getState.mockReturnValue({ activeTheaterId: null });
+    mocks.fetchObserverStatus
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveFirstStatus = resolve;
+      }))
+      .mockResolvedValueOnce(currentStatus);
+
+    connectOperationsSse();
+    TestEventSource.instances[0]?.emit("update:available");
+    TestEventSource.instances[0]?.emit("update:available");
+    const resolveStaleStatus: (status: { version: string; updateAvailable: boolean }) => void = resolveFirstStatus ?? (() => {
+      throw new Error("first status fetch did not start");
+    });
+    resolveStaleStatus(staleStatus);
+
+    await vi.waitFor(() => expect(mocks.fetchObserverStatus).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(mocks.applyObserverStatus).toHaveBeenLastCalledWith(currentStatus));
+  });
+});

--- a/runtime/fleet-console/tests/update-check.test.ts
+++ b/runtime/fleet-console/tests/update-check.test.ts
@@ -92,6 +92,31 @@ describe("console update check", () => {
     expect(lookupCount).toBe(2);
   });
 
+  it("treats an undefined registry lookup as a failure with the short error TTL", async () => {
+    let clock = 1_000;
+    let lookupCount = 0;
+    const service = createConsoleUpdateCheckService({
+      readRelease: () => ({ channel: "stable", version: "1.0.0", packageRoot: "/console" }),
+      // 실 fetchLatestVersion은 타임아웃·비정상 응답에서 throw 없이 undefined를 resolve한다.
+      fetchLatest: async () => {
+        lookupCount += 1;
+        return undefined;
+      },
+      now: () => clock,
+      ttlMs: 60_000,
+      errorTtlMs: 5_000,
+    });
+
+    await expect(service.refresh()).resolves.toEqual({ updateAvailable: false });
+    clock += 4_999;
+    await service.refresh();
+    expect(lookupCount).toBe(1);
+
+    clock += 1;
+    await service.refresh();
+    expect(lookupCount).toBe(2);
+  });
+
   it("periodically forces a recheck and releases its unref timer on stop", async () => {
     let scheduled: (() => void) | null = null;
     let lookupCount = 0;

--- a/runtime/fleet-console/tests/update-check.test.ts
+++ b/runtime/fleet-console/tests/update-check.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createConsoleUpdateCheckService } from "../core/host/update-check.js";
 
@@ -66,5 +66,80 @@ describe("console update check", () => {
 
     await expect(service.refresh()).resolves.toEqual({ updateAvailable: false });
     expect(service.getStatus()).toEqual({ updateAvailable: false });
+  });
+
+  it("retries a registry failure after the short error TTL", async () => {
+    let clock = 1_000;
+    let lookupCount = 0;
+    const service = createConsoleUpdateCheckService({
+      readRelease: () => ({ channel: "stable", version: "1.0.0", packageRoot: "/console" }),
+      fetchLatest: async () => {
+        lookupCount += 1;
+        throw new Error("offline");
+      },
+      now: () => clock,
+      ttlMs: 60_000,
+      errorTtlMs: 5_000,
+    });
+
+    await service.refresh();
+    clock += 4_999;
+    await service.refresh();
+    expect(lookupCount).toBe(1);
+
+    clock += 1;
+    await service.refresh();
+    expect(lookupCount).toBe(2);
+  });
+
+  it("periodically forces a recheck and releases its unref timer on stop", async () => {
+    let scheduled: (() => void) | null = null;
+    let lookupCount = 0;
+    const unref = vi.fn();
+    const clearInterval = vi.fn();
+    const service = createConsoleUpdateCheckService({
+      readRelease: () => ({ channel: "stable", version: "1.0.0", packageRoot: "/console" }),
+      fetchLatest: async () => {
+        lookupCount += 1;
+        return "1.1.0";
+      },
+      setInterval: (callback) => {
+        scheduled = callback;
+        return { unref };
+      },
+      clearInterval,
+    });
+
+    await service.refresh();
+    service.start?.();
+    service.start?.();
+    const triggerScheduledCheck = scheduled ?? (() => {
+      throw new Error("periodic check was not scheduled");
+    });
+    triggerScheduledCheck();
+    await vi.waitFor(() => expect(lookupCount).toBe(2));
+
+    expect(unref).toHaveBeenCalledOnce();
+    service.stop?.();
+    expect(clearInterval).toHaveBeenCalledOnce();
+  });
+
+  it("notifies when an update becomes available or its latest version changes", async () => {
+    let lookupCount = 0;
+    const listener = vi.fn();
+    const service = createConsoleUpdateCheckService({
+      readRelease: () => ({ channel: "stable", version: "1.0.0", packageRoot: "/console" }),
+      fetchLatest: async () => {
+        lookupCount += 1;
+        return lookupCount === 1 ? "1.1.0" : "1.2.0";
+      },
+    });
+    service.onChange?.(listener);
+
+    await service.refresh();
+    await service.refresh({ force: true });
+
+    expect(listener).toHaveBeenNthCalledWith(1, { updateAvailable: true, latestVersion: "1.1.0" });
+    expect(listener).toHaveBeenNthCalledWith(2, { updateAvailable: true, latestVersion: "1.2.0" });
   });
 });


### PR DESCRIPTION
## Summary
- Update Available 배지가 열린 탭에서 브라우저 새로고침 없이 실시간으로 점등됩니다. 서버(데몬)가 30분 주기로 npm 레지스트리를 강제 재검(unref 타이머, dispose 시 정리)하고, 상태 전환 순간 기존 `/api/v1/operations/events` SSE 채널로 payload 없는 `update:available` 트리거 프레임을 브로드캐스트합니다.
- 클라이언트는 프레임 payload를 신뢰하지 않고 `/api/v1/status` 재조회를 SSoT로 유지합니다. 동시 요청은 in-flight 합침 + trailing 1회 재조회로 마지막 전환 유실을 방지하고, SSE (재)연결 시에도 1회 재동기화해 단절 중 유실된 프레임을 보정합니다.
- npm 조회 실패가 "업데이트 없음"으로 1시간 캐시되던 정책을 분리해, 오류 결과는 5분 TTL로 재시도가 억제되지 않게 했습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 539 passed, 22 skipped (주기 재검·오류 TTL·onChange 알림·SSE 트리거→status 재조회·trailing refresh 회귀 테스트 포함)
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] Sentinel 코드 리뷰 1패스 + 발견 2건(트리거 유실 경합·stop→start 구독 복원) 수정 반영

## Changelog
- [x] `.changelog.d/live-update-available-badge.md` (`section: Fixed`, `[fleet-console]`)