### PR TITLE
fix(core-unified-agent): codex ACP system prompt via CODEX_CONFIG env

### DIFF
--- a/.changelog.d/codex-acp-config-env.md
+++ b/.changelog.d/codex-acp-config-env.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+
+- [core-unified-agent] Codex system prompts and config overrides are now reliably applied on new ACP sessions across all platforms; previously they were silently dropped.

--- a/packages/core-unified-agent/AGENTS.md
+++ b/packages/core-unified-agent/AGENTS.md
@@ -160,10 +160,11 @@ ait (model) ❯ {input}            # Omitted if effort is not supported
 7. **System Prompt Injection (Provider-aware)**:
    - **Claude**: `AcpConnection` appends to the native system prompt via `_meta.systemPrompt.append` when calling `session/new`. The `claude-agent-acp` bridge handles this.
    - **Codex (Dual-path)**: 
-     - **ACP path**: Passes `systemPrompt` via spawn args `-c developer_instructions="..."`.
+     - **ACP path**: `systemPrompt` (and `configOverrides`) are delivered via the `CODEX_CONFIG` env JSON; `codex-acp` merges it into `thread/start` and `thread/resume` config, so injection applies to fresh sessions, resets, and resumes on all platforms.
      - **AppServer path**: Passes `systemPrompt` as `developerInstructions` when creating/resuming a thread.
    - **OpenCode Go**: `UnifiedOpenCodeAgentClient` manages `firstPromptPending` state since `_meta.systemPrompt.append` is unsupported. Session reset is handled via disconnect + reconnect.
-   - **Session Persistence Contract**: Re-armed for new sessions after `resetSession()`. Codex resume/load paths via `sessionId` re-pass the current client's `systemPrompt`, policies (`approvalPolicy`/`sandbox`), and thread config to `thread/resume`. Claude session resume follows a best-effort policy prioritizing conversation continuity; if intentional drift cleanup is needed, the caller must invoke `resetSession()`.
+   - **Cursor**: `UnifiedCursorAgentClient` manages `firstPromptPending` (prepends `systemPrompt` as a text block on the first prompt) since the bridge does not support `_meta.systemPrompt.append`; session resume does not re-arm it.
+   - **Session Persistence Contract**: Re-armed for new sessions after `resetSession()`. On the Codex ACP path the `CODEX_CONFIG` env is process-level, so the injected instructions persist across `resetSession()`/`loadSession()` without re-sending; resume/load paths via `sessionId` still re-pass policies (`approvalPolicy`/`sandbox`) and thread config to `thread/resume`. Claude session resume follows a best-effort policy prioritizing conversation continuity; if intentional drift cleanup is needed, the caller must invoke `resetSession()`.
 
 8. **CLI_BACKENDS Single Source of Truth**: `CLI_BACKENDS` in `src/config/CliConfigs.ts` is the sole configuration registry for all CLI providers. `CliType` is derived as `keyof typeof CLI_BACKENDS`. Each entry defines:
    - `id`, `cliCommand`, `protocol`, `authRequired`
@@ -176,7 +177,7 @@ ait (model) ❯ {input}            # Omitted if effort is not supported
 
 9. **Claude Effort via `_meta` Bridge Channel**: Claude reasoning effort is delivered through `_meta.claudeCode.options.effort` spread in `session/new` and `session/load` payloads (not via `session/set_config_option` RPC). This channel bypasses alias resolution issues on the bridge and ensures effort applies consistently across new sessions and session resumption.
 
-10. **Codex Official ACP Bridge**: Codex uses `@agentclientprotocol/codex-acp@1.1.2` on the ACP path. Model changes use standard `session/set_config_option` with `configId: "model"`, while public Fleet `effort` maps to Codex's advertised `reasoning_effort` config option.
+10. **Codex Official ACP Bridge**: Codex uses `@agentclientprotocol/codex-acp@1.1.2` on the ACP path. Model changes use standard `session/set_config_option` with `configId: "model"`, while public Fleet `effort` maps to Codex's advertised `reasoning_effort` config option. Config and instruction delivery uses the `CODEX_CONFIG` env JSON channel because the bridge does not forward CLI argv to the spawned `codex` app-server.
 
 11. **Validation-mode Dual-Path for Codex**: Codex currently supports two transport paths (official ACP npx bridge and legacy AppServer) controlled by a `CODEX_USE_ACP` toggle. This is a temporary validation wave for protocol transition; a permanent switch will occur in a future wave, deprecating the legacy AppServer path and associated types.
 

--- a/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
+++ b/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
@@ -33,7 +33,7 @@ import { AcpConnection } from '../connection/AcpConnection.js';
 import { CodexAppServerConnection } from '../connection/CodexAppServerConnection.js';
 import { CliDetector } from '../detector/CliDetector.js';
 import {
-  buildCodexDeveloperInstructionConfig,
+  buildCodexConfigEnv,
   buildConfigOverrideArgs,
   createSpawnConfig,
   getBackendConfig,
@@ -77,10 +77,6 @@ interface CodexThreadDefaultsForResume {
 const CODEX_TURN_LEVEL_CONFIG_KEYS = new Set(['effort', 'model']);
 const CODEX_THREAD_POLICY_CONFIG_KEYS = new Set(['approvalPolicy', 'sandbox']);
 const CODEX_USE_ACP = true;
-// Windows의 32K argv 한도(`CreateProcessW`)에 걸려 ENAMETOOLONG이 발생하므로
-// Codex ACP 경로에서는 Windows에서만 첫 메시지 prepend 폴백을 사용한다.
-// 다른 플랫폼은 충분한 argv 여유가 있어 기존 `-c developer_instructions=...` argv 주입을 유지.
-const CODEX_ACP_PROMPT_FALLBACK = process.platform === 'win32';
 
 type CodexConnection = CodexAppServerConnection | AcpConnection;
 
@@ -93,7 +89,6 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
   private sessionId: string | null = null;
   private sessionCwd: string | null = null;
   private currentSystemPrompt: string | null = null;
-  private firstPromptPending: string | null = null;
   private pendingOverrides: CodexPendingOverrides | null = null;
   private detector = new CliDetector();
 
@@ -210,22 +205,19 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
   private async connectAcp(options: UnifiedClientOptions): Promise<ConnectResult> {
     const cleanEnv = cleanEnvironment(process.env, options.env);
     const spawnConfig = createSpawnConfig('codex', options);
-    const developerInstructions = CODEX_ACP_PROMPT_FALLBACK ? undefined : (options.systemPrompt ?? undefined);
-    const args = [
-      ...spawnConfig.args,
-      ...this.buildStartupConfigArgs(
-        options.configOverrides,
-        undefined,
-        undefined,
-        developerInstructions,
-      ),
-    ];
+    // codex-acp 브릿지는 argv를 무시하므로 systemPrompt/configOverrides는 CODEX_CONFIG env로 주입한다.
+    // 브릿지가 thread/start·thread/resume config에 spread하며, 모든 플랫폼 단일 경로로 동작한다.
+    const codexConfigEnv = buildCodexConfigEnv(
+      options.systemPrompt,
+      options.configOverrides,
+      cleanEnv.CODEX_CONFIG as string | undefined,
+    );
     const connection = new AcpConnection({
       command: spawnConfig.command,
-      args,
+      args: spawnConfig.args,
       cliType: 'codex',
       cwd: options.cwd,
-      env: { ...cleanEnv },
+      env: { ...cleanEnv, ...(codexConfigEnv ? { CODEX_CONFIG: codexConfigEnv } : {}) },
       requestTimeout: options.timeout ?? 600_000,
       initTimeout: options.timeout ?? 60_000,
       promptIdleTimeout: options.promptIdleTimeout ?? 600_000,
@@ -336,19 +328,9 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
       if (!this.sessionId) {
         throw new Error('연결되어 있지 않습니다');
       }
-      const systemPrompt = this.firstPromptPending;
-      if (!systemPrompt) {
-        return this.connection.sendPrompt(this.sessionId, content);
-      }
-      const userBlocks: AcpContentBlock[] = typeof content === 'string'
-        ? [{ type: 'text', text: content }]
-        : content;
-      const response = await this.connection.sendPrompt(this.sessionId, [
-        { type: 'text', text: systemPrompt },
-        ...userBlocks,
-      ]);
-      this.firstPromptPending = null;
-      return response;
+      // systemPrompt는 connect 시점 CODEX_CONFIG env로 이미 주입되어 프로세스 전체에 상주하므로
+      // 프롬프트에 prepend하지 않는다.
+      return this.connection.sendPrompt(this.sessionId, content);
     }
 
     this.applyPendingOverrides();
@@ -452,8 +434,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
         mcpServers: this.resolveAcpMcpServers(mcpServers),
       });
       this.sessionId = sessionId;
-      this.currentSystemPrompt = null;
-      this.firstPromptPending = null;
+      // connect 시점 CODEX_CONFIG env 지침이 load 이후에도 상주하므로 snapshot을 보존한다.
       return;
     }
 
@@ -494,7 +475,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
       const session = await this.connection.reconnectSession(targetCwd);
       this.sessionId = session.sessionId;
       this.sessionCwd = targetCwd;
-      this.firstPromptPending = this.currentSystemPrompt;
+      // CODEX_CONFIG env는 프로세스 수준이라 reconnectSession의 새 thread/start가 지침을 자동 재적용한다.
 
       return {
         cli: 'codex',
@@ -529,9 +510,6 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     this.sessionId = session.sessionId;
     this.sessionCwd = options.cwd;
     this.currentSystemPrompt = options.systemPrompt ?? null;
-    this.firstPromptPending = CODEX_ACP_PROMPT_FALLBACK && !options.sessionId
-      ? (options.systemPrompt ?? null)
-      : null;
     this.pendingOverrides = {
       turnConfig: {},
       threadConfig: {},
@@ -553,7 +531,6 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     this.sessionId = null;
     this.sessionCwd = null;
     this.currentSystemPrompt = null;
-    this.firstPromptPending = null;
     this.pendingOverrides = null;
   }
 
@@ -801,10 +778,8 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     overrides?: string[],
     servers?: McpServerConfig[],
     modeMapping?: CodexModeMapping,
-    developerInstructions?: string | null,
   ): string[] {
     const configArgs = [
-      ...buildCodexDeveloperInstructionConfig(developerInstructions),
       ...(modeMapping ? [
         `approval_policy="${modeMapping.approvalPolicy}"`,
         `sandbox_mode="${modeMapping.sandbox}"`,

--- a/packages/core-unified-agent/src/config/CliConfigs.ts
+++ b/packages/core-unified-agent/src/config/CliConfigs.ts
@@ -10,6 +10,7 @@ import type {
   ConnectionOptions,
   McpServerConfig,
 } from '../types/config.js';
+import type { CodexJsonValue } from '../types/codex-app-server.js';
 import { resolveNpxPath, buildNpxArgs } from '../utils/npx.js';
 import { cleanEnvironment } from '../utils/env.js';
 import { resolveCursorSpawnModel } from '../models/ModelRegistry.js';
@@ -193,17 +194,41 @@ export function getAllBackendConfigs(): CliBackendConfig[] {
 }
 
 /**
- * Codex developer instruction을 `-c` 오버라이드 값으로 변환합니다.
+ * Codex ACP 브릿지(`codex-acp`)가 읽는 `CODEX_CONFIG` 환경변수 값을 생성합니다.
+ * 브릿지는 이 JSON 맵을 `thread/start`/`thread/resume` config에 spread하므로,
+ * developer instruction과 설정 오버라이드를 argv 대신 env로 주입합니다.
  *
- * @param systemPrompt - 세션 시작 시 주입할 시스템 지침
- * @returns `developer_instructions="..."` 형태의 설정 배열
+ * @param systemPrompt - 세션 시작 시 주입할 시스템 지침 (있으면 최우선으로 developer_instructions에 반영)
+ * @param configOverrides - `key=value` 형태의 설정 오버라이드 배열 (dotted key는 중첩 객체로 확장)
+ * @param baseConfigJson - 호출자가 이미 지정한 CODEX_CONFIG(JSON) 값. 유효한 JSON 객체면 시작점으로 병합.
+ * @returns JSON 문자열(맵에 키가 하나 이상일 때) 또는 undefined(빈 맵)
  */
-export function buildCodexDeveloperInstructionConfig(systemPrompt?: string | null): string[] {
-  if (!systemPrompt) {
-    return [];
+export function buildCodexConfigEnv(
+  systemPrompt?: string | null,
+  configOverrides?: string[],
+  baseConfigJson?: string,
+): string | undefined {
+  const map = parseBaseConfigMap(baseConfigJson);
+
+  for (const override of configOverrides ?? []) {
+    const eqIndex = override.indexOf('=');
+    if (eqIndex < 0) {
+      continue;
+    }
+    const key = override.slice(0, eqIndex);
+    const rawValue = override.slice(eqIndex + 1);
+    assignNestedKey(map, key, parseOverrideValue(rawValue));
   }
 
-  return [`developer_instructions="${escapeTomlBasicString(systemPrompt)}"`];
+  if (systemPrompt) {
+    // developer_instructions는 base/override보다 우선하도록 마지막에 설정한다.
+    map.developer_instructions = systemPrompt;
+  }
+
+  if (Object.keys(map).length === 0) {
+    return undefined;
+  }
+  return JSON.stringify(map);
 }
 
 /**
@@ -261,27 +286,58 @@ export function mcpServerConfigsToAcp(servers: McpServerConfig[]): McpServer[] {
   })) as McpServer[];
 }
 
-// TOML basic string 이스케이프. 단축 이스케이프가 없는 제어문자(U+0000-U+001F)와
-// DEL(U+007F)은 \uXXXX 형태로 폴백 이스케이프해 깨진 TOML 생성을 방지한다.
-function escapeTomlBasicString(value: string): string {
-  return value.replace(/[\u0000-\u001f"\\\u007f]/g, (char) => {
-    switch (char) {
-      case '\b':
-        return '\\b';
-      case '\t':
-        return '\\t';
-      case '\n':
-        return '\\n';
-      case '\f':
-        return '\\f';
-      case '\r':
-        return '\\r';
-      case '"':
-        return '\\"';
-      case '\\':
-        return '\\\\';
-      default:
-        return `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`;
+// baseConfigJson을 JSON 객체 맵으로 파싱한다. 유효한 JSON 객체가 아니면(부재/배열/스칼라/파싱 실패)
+// 조용히 빈 맵에서 시작한다.
+function parseBaseConfigMap(baseConfigJson?: string): Record<string, CodexJsonValue> {
+  if (!baseConfigJson) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(baseConfigJson) as unknown;
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, CodexJsonValue>;
     }
-  });
+  } catch {
+    // 잘못된 JSON은 무시하고 빈 맵에서 시작한다.
+  }
+  return {};
 }
+
+// 오버라이드 값을 파싱한다. JSON.parse를 우선 시도하고, 실패하면 감싼 큰따옴표 한 쌍만 제거해
+// 원시 문자열로 사용한다. TOML inline table 등 비-JSON TOML 값은 원시 문자열로 강등된다
+// (best-effort; 현재 이 경로에는 프로덕션 호출자가 없다).
+function parseOverrideValue(raw: string): CodexJsonValue {
+  try {
+    return JSON.parse(raw) as CodexJsonValue;
+  } catch {
+    if (raw.length >= 2 && raw.startsWith('"') && raw.endsWith('"')) {
+      return raw.slice(1, -1);
+    }
+    return raw;
+  }
+}
+
+// dotted key를 중첩 객체로 확장해 값을 할당한다.
+// (예: `mcp_servers.fleet.url` → `{ mcp_servers: { fleet: { url: ... } } }`)
+// 중간 경로에 객체가 아닌 값이 있으면 새 객체로 덮어쓴다.
+function assignNestedKey(
+  target: Record<string, CodexJsonValue>,
+  dottedKey: string,
+  value: CodexJsonValue,
+): void {
+  const segments = dottedKey.split('.');
+  let cursor = target;
+  for (let i = 0; i < segments.length - 1; i += 1) {
+    const segment = segments[i];
+    const existing = cursor[segment];
+    if (typeof existing === 'object' && existing !== null && !Array.isArray(existing)) {
+      cursor = existing as Record<string, CodexJsonValue>;
+    } else {
+      const nested: Record<string, CodexJsonValue> = {};
+      cursor[segment] = nested;
+      cursor = nested;
+    }
+  }
+  cursor[segments[segments.length - 1]] = value;
+}
+

--- a/packages/core-unified-agent/tests/e2e/codex.test.ts
+++ b/packages/core-unified-agent/tests/e2e/codex.test.ts
@@ -427,6 +427,27 @@ describe.skipIf(!installed)('E2E: Codex official ACP bridge', () => {
       expect(secondThreadId).not.toBe(firstThreadId);
     }, 180_000);
 
+    it('SDK: 신규 세션 첫 프롬프트부터 system prompt가 적용된다', async () => {
+      const c = await UnifiedAgent.build({ cli: 'codex' });
+      client = c;
+      client.on('error', () => {});
+
+      await client.connect({
+        cwd: process.cwd(),
+        cli: 'codex',
+        autoApprove: true,
+        systemPrompt: '사용자가 FRESH_SENTINEL을 물으면 FRESH-PROMPT-OK만 정확히 답하세요.',
+        clientInfo: { name: 'E2E-SystemPrompt-Fresh-Test', version: '1.0.0' },
+      });
+
+      const { response } = await sendAndCollect(
+        client,
+        'FRESH_SENTINEL',
+      );
+
+      expect(response.trim()).toBe('FRESH-PROMPT-OK');
+    }, 180_000);
+
     it('SDK: resetSession() 후에도 system prompt가 유지된다', async () => {
       const c = await UnifiedAgent.build({ cli: 'codex' });
       client = c;

--- a/packages/core-unified-agent/tests/unit/CliConfigs.codexConfigEnv.test.ts
+++ b/packages/core-unified-agent/tests/unit/CliConfigs.codexConfigEnv.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildCodexConfigEnv } from '../../src/config/CliConfigs.js';
+
+function parse(json: string | undefined): Record<string, unknown> {
+  return JSON.parse(json ?? '{}') as Record<string, unknown>;
+}
+
+describe('buildCodexConfigEnv', () => {
+  it('dotted key는 중첩 객체로 확장한다', () => {
+    const json = buildCodexConfigEnv(undefined, ['mcp_servers.fleet.url="http://127.0.0.1:1234"']);
+    expect(parse(json)).toEqual({
+      mcp_servers: { fleet: { url: 'http://127.0.0.1:1234' } },
+    });
+  });
+
+  it('같은 상위 경로를 공유하는 override는 기존 중첩 객체에 병합한다', () => {
+    const base = JSON.stringify({ mcp_servers: { fleet: { url: 'http://a' } } });
+    const json = buildCodexConfigEnv(undefined, ['mcp_servers.fleet.tool_timeout_sec=180'], base);
+    expect(parse(json)).toEqual({
+      mcp_servers: { fleet: { url: 'http://a', tool_timeout_sec: 180 } },
+    });
+  });
+
+  it('JSON 값은 파싱해 number/boolean/string 타입을 보존한다', () => {
+    const json = buildCodexConfigEnv(undefined, [
+      'tool_timeout_sec=180',
+      'enabled=true',
+      'model="gpt-5.4"',
+    ]);
+    expect(parse(json)).toEqual({
+      tool_timeout_sec: 180,
+      enabled: true,
+      model: 'gpt-5.4',
+    });
+  });
+
+  it('JSON.parse 실패 시 감싼 큰따옴표 한 쌍을 제거한 원시 문자열로 강등한다', () => {
+    // `"a"b"`는 유효한 JSON이 아니므로 큰따옴표를 벗겨 `a"b`로 처리된다.
+    const json = buildCodexConfigEnv(undefined, ['label="a"b"']);
+    expect(parse(json)).toEqual({ label: 'a"b' });
+  });
+
+  it('developer_instructions는 base/override보다 systemPrompt가 우선한다', () => {
+    const base = JSON.stringify({ developer_instructions: 'base 지침', model: 'gpt-5.4' });
+    const json = buildCodexConfigEnv('최종 지침', ['developer_instructions="override 지침"'], base);
+    expect(parse(json)).toEqual({
+      developer_instructions: '최종 지침',
+      model: 'gpt-5.4',
+    });
+  });
+
+  it('유효하지 않은 baseConfigJson은 무시하고 빈 맵에서 시작한다', () => {
+    const json = buildCodexConfigEnv('지침', undefined, 'not-json');
+    expect(parse(json)).toEqual({ developer_instructions: '지침' });
+  });
+
+  it('배열/스칼라 baseConfigJson도 객체가 아니므로 무시한다', () => {
+    const json = buildCodexConfigEnv('지침', undefined, '[1,2,3]');
+    expect(parse(json)).toEqual({ developer_instructions: '지침' });
+  });
+
+  it('입력이 비면 undefined를 반환한다', () => {
+    expect(buildCodexConfigEnv()).toBeUndefined();
+    expect(buildCodexConfigEnv(undefined, [], undefined)).toBeUndefined();
+    expect(buildCodexConfigEnv('', [], '')).toBeUndefined();
+  });
+
+  it('`=`가 없는 override 항목은 건너뛴다', () => {
+    expect(buildCodexConfigEnv(undefined, ['no-equals-here'])).toBeUndefined();
+  });
+});

--- a/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
+++ b/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
@@ -12,6 +12,12 @@ const mockSetPendingModel = vi.fn();
 const mockSetPendingEffort = vi.fn();
 const mockRemoveAllListeners = vi.fn();
 
+const mockAcpConnect = vi.fn();
+const mockAcpSendPrompt = vi.fn();
+const mockAcpSetMode = vi.fn();
+const mockAcpSetModel = vi.fn();
+const mockAcpSetConfigOption = vi.fn();
+
 function createMockCodexConnection(): EventEmitter & Record<string, unknown> {
   const emitter = new EventEmitter();
   Object.assign(emitter, {
@@ -31,12 +37,36 @@ function createMockCodexConnection(): EventEmitter & Record<string, unknown> {
   return emitter as EventEmitter & Record<string, unknown>;
 }
 
+// ACP 경로용 mock 연결. instanceof AcpConnection이 true가 되도록 prototype을 상속시키고,
+// EventEmitter 기반 이벤트 메서드와 connect/sendPrompt 등 사용 메서드를 주입한다.
+function createMockAcpConnection(): Record<string, unknown> {
+  const emitter = new EventEmitter();
+  return Object.assign(Object.create(AcpConnection.prototype), {
+    on: emitter.on.bind(emitter),
+    off: emitter.off.bind(emitter),
+    once: emitter.once.bind(emitter),
+    emit: emitter.emit.bind(emitter),
+    removeAllListeners: vi.fn(),
+    connect: mockAcpConnect,
+    sendPrompt: mockAcpSendPrompt,
+    setMode: mockAcpSetMode,
+    setModel: mockAcpSetModel,
+    setConfigOption: mockAcpSetConfigOption,
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    endSession: vi.fn().mockResolvedValue(undefined),
+    cancelSession: vi.fn().mockResolvedValue(undefined),
+    canResetSession: true,
+    connectionState: 'ready',
+    sessionId: 'acp-session-1',
+  });
+}
+
 vi.mock('../../src/connection/CodexAppServerConnection.js', () => ({
   CodexAppServerConnection: vi.fn(() => createMockCodexConnection()),
 }));
 
 vi.mock('../../src/connection/AcpConnection.js', () => ({
-  AcpConnection: vi.fn(),
+  AcpConnection: vi.fn(() => createMockAcpConnection()),
 }));
 
 vi.mock('../../src/detector/CliDetector.js', () => ({
@@ -62,6 +92,12 @@ async function connectAppServer(
   await client['connectAppServer'](options);
 }
 
+// ACP 연결 생성자에 전달된 첫 호출 인자(env/args)를 추출한다.
+function acpCtorOptions(): { env?: Record<string, string | undefined>; args: string[] } {
+  const call = vi.mocked(AcpConnection).mock.calls[0];
+  return call[0] as unknown as { env?: Record<string, string | undefined>; args: string[] };
+}
+
 describe('UnifiedCodexAgentClient config staging', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -72,6 +108,11 @@ describe('UnifiedCodexAgentClient config staging', () => {
     mockCodexLoadSession.mockResolvedValue({ thread: { id: 'codex-thread-9' } });
     mockCodexSendMessage.mockResolvedValue(undefined);
     mockCodexCancelPrompt.mockResolvedValue(undefined);
+    mockAcpConnect.mockResolvedValue({ sessionId: 'acp-session-1' });
+    mockAcpSendPrompt.mockResolvedValue({ stopReason: 'endTurn' });
+    mockAcpSetMode.mockResolvedValue(undefined);
+    mockAcpSetModel.mockResolvedValue(undefined);
+    mockAcpSetConfigOption.mockResolvedValue(undefined);
   });
 
   it('ACP mode 매핑은 공식 codex-acp bridge mode ID를 사용한다', () => {
@@ -99,7 +140,9 @@ describe('UnifiedCodexAgentClient config staging', () => {
     expect(AcpConnection).not.toHaveBeenCalled();
   });
 
-  it('ACP resetSession 후 첫 프롬프트에 systemPrompt를 한 번만 재주입한다', async () => {
+  it('ACP resetSession 후 첫 프롬프트는 사용자 content만 전달한다(prepend 없음)', async () => {
+    // systemPrompt 주입은 connect 시점 CODEX_CONFIG env가 담당하므로, reconnect 후에도
+    // 프롬프트에 지침을 prepend하지 않고 사용자 입력만 그대로 전달해야 한다.
     const client = new UnifiedCodexAgentClient();
     const mockAcpConnection = Object.assign(Object.create(AcpConnection.prototype), {
       canResetSession: true,
@@ -113,7 +156,6 @@ describe('UnifiedCodexAgentClient config staging', () => {
       sessionId: 'acp-session-1',
       sessionCwd: '/workspace',
       currentSystemPrompt: '리셋 후 지침',
-      firstPromptPending: null,
     });
 
     await client.resetSession();
@@ -122,11 +164,56 @@ describe('UnifiedCodexAgentClient config staging', () => {
 
     expect(mockAcpConnection.endSession).toHaveBeenCalledWith('acp-session-1');
     expect(mockAcpConnection.reconnectSession).toHaveBeenCalledWith('/workspace');
-    expect(mockAcpConnection.sendPrompt).toHaveBeenNthCalledWith(1, 'acp-session-2', [
-      { type: 'text', text: '리셋 후 지침' },
-      { type: 'text', text: '첫 요청' },
-    ]);
+    expect(mockAcpConnection.sendPrompt).toHaveBeenNthCalledWith(1, 'acp-session-2', '첫 요청');
     expect(mockAcpConnection.sendPrompt).toHaveBeenNthCalledWith(2, 'acp-session-2', '두 번째 요청');
+    // 리셋 이후에도 snapshot은 보존된다(env 상주).
+    expect(client.getCurrentSystemPrompt()).toBe('리셋 후 지침');
+  });
+
+  it('ACP 연결은 systemPrompt를 CODEX_CONFIG env로 주입하고 argv에는 넣지 않는다', async () => {
+    const client = new UnifiedCodexAgentClient();
+
+    await client.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+      systemPrompt: '개발자 지침',
+    });
+
+    const options = acpCtorOptions();
+    const config = JSON.parse(options.env?.CODEX_CONFIG ?? '{}') as Record<string, unknown>;
+    expect(config.developer_instructions).toBe('개발자 지침');
+    // argv에는 -c / developer_instructions 흔적이 없어야 한다(argv 주입 폐기).
+    expect(options.args).not.toContain('-c');
+    expect(options.args.some((arg) => arg.includes('developer_instructions'))).toBe(false);
+  });
+
+  it('호출자 제공 CODEX_CONFIG(valid JSON)는 병합되고 developer_instructions는 systemPrompt가 우선한다', async () => {
+    const client = new UnifiedCodexAgentClient();
+
+    await client.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+      systemPrompt: '우선 지침',
+      env: {
+        CODEX_CONFIG: JSON.stringify({ model: 'gpt-5.4', developer_instructions: '무시될 지침' }),
+      },
+    });
+
+    const options = acpCtorOptions();
+    const config = JSON.parse(options.env?.CODEX_CONFIG ?? '{}') as Record<string, unknown>;
+    expect(config).toEqual({ model: 'gpt-5.4', developer_instructions: '우선 지침' });
+  });
+
+  it('systemPrompt·configOverrides·호출자 CODEX_CONFIG가 모두 없으면 env에 CODEX_CONFIG를 넣지 않는다', async () => {
+    const client = new UnifiedCodexAgentClient();
+
+    await client.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+    });
+
+    const options = acpCtorOptions();
+    expect(options.env?.CODEX_CONFIG).toBeUndefined();
   });
 
   it('codex 연결 시 systemPrompt를 developerInstructions로 전달한다', async () => {


### PR DESCRIPTION
## Summary
- codex-acp 브리지가 CLI argv를 무시해 신규 ACP 세션마다 `-c developer_instructions` 주입이 조용히 유실되던 결함을 수정합니다.
- systemPrompt·configOverrides를 `CODEX_CONFIG` env JSON으로 전달하도록 교체 — 브리지가 `thread/start`/`thread/resume` config에 병합하므로 신규 세션·리셋·리줌 전부에 적용되고, Windows 전용 첫-프롬프트 prepend 폴백(`CODEX_ACP_PROMPT_FALLBACK`)과 `firstPromptPending`을 퇴역시켜 전 플랫폼 단일 경로가 됩니다.
- 이번 결함이 빠져나갔던 신규-세션 직행 경로에 대한 e2e 회귀 테스트를 추가하고, AGENTS.md 주입 문서를 현행화(누락됐던 Cursor 항목 포함)했습니다.

## Test Plan
- [x] `pnpm build` (tsc) + 유닛 테스트 123 pass (`tests/unit`)
- [x] `pnpm check:core-boundary` + 하류 의존 패키지 10개 빌드 green
- [x] 실구동 마커 프로브: argv 무누수 / 신규 세션 지침 적용 / resetSession 후 유지 — 3/3 PASS
- [x] 실 codex e2e: 신규-세션 system prompt(신규) + resetSession 유지 — 2/2 PASS
- [x] `.changelog.d/codex-acp-config-env.md` 프래그먼트 포함 (`compile-changelog-fragments.mjs --check` OK)