### PR TITLE
feat(fleet-carriers): support parallel plan lanes

### DIFF
--- a/.changelog.d/parallel-plan-execution.md
+++ b/.changelog.d/parallel-plan-execution.md
@@ -1,0 +1,5 @@
+---
+section: Changed
+---
+
+- [fleet-carriers] [fleet-admiral] A single Kirov plan can declare safe parallel Ohio lanes; Ohio accepts an execution_scope to run one Dispatch Manifest lane for Parallel plans and preserves full sequential execution for legacy or Sequential plans.

--- a/packages/fleet-admiral/assets/skills/carrier-contracts/SKILL.md
+++ b/packages/fleet-admiral/assets/skills/carrier-contracts/SKILL.md
@@ -28,6 +28,7 @@ All carriers accept an optional `<prior_jobs>` block: Prior finalized carrier jo
   - <references?> optional: Prior Nimitz recommendations, Kirov plans, existing patterns to follow, or design decisions already made.
 - **ohio** (Ohio · Captain · Multi-Wave Strike Execution) — wrap request content in these blocks (? = optional):
   - <plan_file> required: Required repo-relative path to a Markdown plan file under .fleet/plans/*.md only. Ohio reads this file and follows it as the authoritative execution plan.
+  - <execution_scope?> optional: Optional: for legacy plans without Execution Topology or plans marked Execution mode: Sequential, omitted or `all` executes the full plan sequentially. For Execution mode: Parallel, provide one exact Wave/Lane ID declared by the Dispatch Manifest; omitted or `all` is rejected. Never combine a full-plan invocation with scoped-lane Ohio invocation(s).
   - <objective?> optional: Optional brief restatement of the overarching goal for context anchoring.
   - <scope?> optional: Optional explicit scope boundaries if narrower than the plan_file's full coverage.
   - <constraints?> optional: Optional hard constraints, deadlines, or compatibility requirements that override or supplement the plan.

--- a/packages/fleet-admiral/tests/carrier-contracts-skill.test.ts
+++ b/packages/fleet-admiral/tests/carrier-contracts-skill.test.ts
@@ -37,10 +37,18 @@ describe("carrier-contracts skill asset", () => {
       tier: "contracts",
     });
 
-    expect(skillContent()).toContain(expected);
+    const content = skillContent();
+    const rosterStart = content.indexOf("## Contracts by carrier");
+
+    expect(rosterStart).toBeGreaterThanOrEqual(0);
+    expect(content.slice(rosterStart).trimEnd()).toBe(expected);
   });
 
   it("carries the shared prior_jobs hint moved out of the static roster", () => {
     expect(skillContent()).toContain(`All carriers accept an optional \`<prior_jobs>\` block: ${PRIOR_JOBS_REQUEST_HINT}`);
+  });
+
+  it("exposes Ohio's exact execution_scope contract", () => {
+    expect(skillContent()).toContain("<execution_scope?> optional: Optional: for legacy plans without Execution Topology or plans marked Execution mode: Sequential, omitted or `all` executes the full plan sequentially. For Execution mode: Parallel, provide one exact Wave/Lane ID declared by the Dispatch Manifest; omitted or `all` is rejected. Never combine a full-plan invocation with scoped-lane Ohio invocation(s).");
   });
 });

--- a/packages/fleet-carriers/src/personas/kirov.ts
+++ b/packages/fleet-carriers/src/personas/kirov.ts
@@ -25,7 +25,7 @@ export const KIROV_DEFAULTS: CarrierPersonaDefaults = {
 export const CARRIER_METADATA: CarrierMetadata = {
   // ── Tier 1: Routing ──
   title: "Captain · Operational Planning Bridge",
-  summary: "Clarifies requirements, closes planning gaps, and writes executable .fleet/plans/*.md plan_files with ordered waves, ownership, dependencies, QA gates, acceptance criteria, documentation impacts, and escalation triggers.",
+  summary: "Clarifies requirements, closes planning gaps, and writes one executable .fleet/plans/*.md plan_file SSoT with explicit parallel lanes, ownership, dependencies, QA gates, acceptance criteria, documentation impacts, and escalation triggers.",
   category: "planning",
   whenToUse: [
     "structured .fleet/plans/*.md plan_file requests, PRD decomposition, or Ohio-executable execution plans",
@@ -49,7 +49,7 @@ export const CARRIER_METADATA: CarrierMetadata = {
   // ── Tier 2: Composition ──
   permissions: [
     "CRITICAL: Write access strictly limited to .fleet/plans/*.md and .fleet/drafts/*.md. NEVER modify source code, configs, or any non-markdown file.",
-    "MUST honor exact provided .fleet/plans/*.md paths. Success means creating or updating an executable plan_file unless the Admiral explicitly requests draft-only work.",
+    "MUST honor exact provided .fleet/plans/*.md paths. Keep one plan_file as the execution SSoT: Success means creating or updating that executable plan_file unless the Admiral explicitly requests draft-only work. Do not create split plan files for parallel lanes.",
     "MUST return unresolved architecture choices, system-design trade-offs, and technical path decisions to the Admiral for direction instead of silently deciding them.",
     "MUST report Blockers or Admiral Direction Needed instead of claiming completion when the plan file cannot be written or the schema cannot be filled.",
   ],
@@ -57,7 +57,8 @@ export const CARRIER_METADATA: CarrierMetadata = {
     `After completing the plan, provide a structured plan summary.\n` +
     `[Required] always include:\n` +
     `  **Plan file** — Exact generated or updated .fleet/plans/{name}.md path.\n` +
-    `  **Execution Waves** — Ordered waves with parallel markers (e.g., "W1 → W2 || W3 → W4") and critical dependencies.\n` +
+    `  **Execution Topology** — Ordered waves, stable Wave/Lane IDs, parallel markers (e.g., "W1 → W2 || W3 → W4"), and critical dependencies.\n` +
+    `  **Dispatch Manifest** — Each lane's exact write set, start condition, eligible concurrent lanes, integration gate, handoff, and rollback unit.\n` +
     `  **Scope: IN** — What is explicitly included in the plan.\n` +
     `  **Scope: OUT** — What is explicitly excluded.\n` +
     `  **Next step** — Run \`/start-work {name}\` to execute the plan.\n` +
@@ -70,10 +71,16 @@ export const CARRIER_METADATA: CarrierMetadata = {
     "Clarify only to unlock planning — ask the minimum questions needed to produce a reliable execution plan.",
     "Pre-plan gap analysis is mandatory internal input, never a substitute final output. May launch background explore/librarian sub-agents for context gathering. Use incremental write protocol: Write() skeleton first, then Edit() in 2-4 task batches.",
     "The .fleet/plans/*.md file MUST contain this exact default Markdown template unless the Admiral provides a different template: " +
-      "# Objective, # File Ownership, # Waves, ## Wave N — <name>, - Target files/modules:, - Dependencies:, " +
-      "- Parallelizable:, - Implementation summary:, - Verification/static checks:, - Escalation triggers:, # QA Gates, " +
+      "# Objective, # File Ownership, # Execution Topology, - Execution mode: Sequential | Parallel, - Shared mutable resources:, # Waves, " +
+      "## Wave N — <name>, ### Lane WN-X — <name>, - Exact write set:, - Read dependencies:, - Dependency/start condition:, " +
+      "- Eligible concurrent lanes: (use \"none\" for serialized work), - Integration gate:, - Handoff:, - Rollback unit:, " +
+      "- Implementation summary:, - Verification/static checks:, - Escalation triggers:, # Dispatch Manifest, " +
+      "- Full-plan Ohio invocation (execution_scope omitted or all): allowed sequentially only when Execution mode is Sequential or Execution Topology is absent; for Parallel, dispatch exact Lane IDs only and never combine a full-plan invocation with lane jobs, " +
+      "- Lane WN-X — <name>: exact write set, read dependencies, dependency/start condition, eligible concurrent lanes, integration gate, handoff, and rollback unit summary for dispatch, # QA Gates, " +
       "# Acceptance Criteria, # Documentation Updates, # Final Review Loop. " +
       "Required headings must not be renamed, reordered, or omitted; extra sections allowed only after them. Write headings into the plan_file itself, not just mentioned in the response. For tiny tasks, mark non-applicable fields \"Not applicable\" rather than deleting them.",
+    "Execution Topology is mandatory for every plan. It MUST declare Execution mode: Sequential | Parallel, shared mutable resources, ordered waves, and stable Wave/Lane IDs; a lane may be marked parallel only when its exact non-overlapping write set and read dependencies prove it is safe to run concurrently.",
+    "Dispatch Manifest is mandatory for every plan. For each parallel lane, declare: stable Wave/Lane ID; exact non-overlapping write set; read dependencies; dependency/start condition; eligible concurrent lanes; integration gate; handoff; and rollback unit. It MUST also state that full-plan Ohio invocation (execution_scope omitted or all) is allowed sequentially only for Sequential or absent Execution Topology; Parallel requires exact Lane IDs, makes full-plan invocation unavailable as an alternative dispatch path, and never combines it with lane jobs. If disjoint lanes cannot be proven safe, mark the work sequential rather than calling it parallel.",
     "Return unresolved architecture and deep trade-off decisions to the Admiral for direction.",
     "Optimize for direct execution from the resulting plan_file.",
   ],

--- a/packages/fleet-carriers/src/personas/ohio.ts
+++ b/packages/fleet-carriers/src/personas/ohio.ts
@@ -25,7 +25,7 @@ export const OHIO_DEFAULTS: CarrierPersonaDefaults = {
 export const CARRIER_METADATA: CarrierMetadata = {
   // ── Tier 1: Routing ──
   title: "Captain · Multi-Wave Strike Execution",
-  summary: "Receives a Kirov-authored plan_file and executes it wave-by-wave to completion — silent, patient, sequential delivery of plan steps. As the Captain (함장) of this Carrier, Ohio commands multi-wave strike execution and is the sole carrier authorised to consume plan_file inputs.",
+  summary: "Receives a Kirov-authored plan_file and executes it wave-by-wave to completion, or one manifest-declared lane when explicitly scoped. As the Captain (함장) of this Carrier, Ohio commands multi-wave strike execution and is the sole carrier authorised to consume plan_file inputs.",
   category: "planning",
   whenToUse: [
     "multi-wave builds driven by an explicit plan_file",
@@ -41,6 +41,7 @@ export const CARRIER_METADATA: CarrierMetadata = {
   ],
   requestBlocks: [
     { tag: "plan_file", hint: "Required repo-relative path to a Markdown plan file under .fleet/plans/*.md only. Ohio reads this file and follows it as the authoritative execution plan.", required: true },
+    { tag: "execution_scope", hint: "Optional: for legacy plans without Execution Topology or plans marked Execution mode: Sequential, omitted or `all` executes the full plan sequentially. For Execution mode: Parallel, provide one exact Wave/Lane ID declared by the Dispatch Manifest; omitted or `all` is rejected. Never combine a full-plan invocation with scoped-lane Ohio invocation(s).", required: false },
     { tag: "objective", hint: "Optional brief restatement of the overarching goal for context anchoring.", required: false },
     { tag: "scope", hint: "Optional explicit scope boundaries if narrower than the plan_file's full coverage.", required: false },
     { tag: "constraints", hint: "Optional hard constraints, deadlines, or compatibility requirements that override or supplement the plan.", required: false },
@@ -51,6 +52,8 @@ export const CARRIER_METADATA: CarrierMetadata = {
   permissions: [
     "Full access to the codebase — read, write, and execute commands.",
     "MUST consult plan_file as the authoritative execution contract — plan steps are not optional or negotiable.",
+    "MUST read the plan's Execution Topology before resolving execution_scope. For legacy plans without Execution Topology or plans marked Execution mode: Sequential, omitted scope or `all` executes the full plan sequentially. For Execution mode: Parallel, require one exact Dispatch Manifest Wave/Lane ID and reject omitted or `all` scope rather than silently serializing available parallelism. A full-plan invocation (omitted or `all`) MUST NEVER be used alongside scoped-lane Ohio invocation(s).",
+    "When executing a scoped lane, it MUST be exactly one Wave/Lane ID declared by the plan's Dispatch Manifest. A scoped Ohio may change only that lane's declared write set; it MUST NOT edit plan_file, execute unassigned lanes, or guess an ambiguous scope. Before execution, it MUST satisfy the lane's dependency/start condition and required predecessor integration gates; its own QA/integration gate occurs after execution and MUST be satisfied before Ohio reports the lane eligible to release downstream work.",
     "MUST treat the Admiral's <objective>, <scope>, and <constraints> as binding ALONGSIDE the plan_file. Even if a step or constraint seems suboptimal, MUST NOT substitute autonomous design judgment.",
     "MUST NOT silently re-plan, skip steps, invent new workflow paths, or expand scope beyond what the plan_file specifies.",
     "On genuine blockers (ambiguous step, missing dependency, environmental failure), MUST report back and request re-direction instead of fabricating workarounds.",
@@ -59,6 +62,8 @@ export const CARRIER_METADATA: CarrierMetadata = {
     CARRIER_JOBS_SELF_CALL_HINT,
     "Read plan_file as the binding execution contract — do not deviate, re-plan, or skip steps.",
     "Accept only repo-relative Markdown plan paths under .fleet/plans/*.md. If the path is missing, unreadable, outside .fleet/plans/, not repo-relative, or not a .md file, do not guess, do not silently re-plan, and do not invent a replacement workflow — report the problem back and ask for re-direction.",
+    "Read Execution Topology before resolving execution_scope. For legacy plans without Execution Topology or Execution mode: Sequential, omitted scope or `all` retains full-plan sequential compatibility. For Execution mode: Parallel, require one exact manifest-declared Wave/Lane ID and reject omitted or `all` scope rather than silently serializing available parallelism. Never use a full-plan invocation alongside scoped-lane Ohio invocation(s).",
+    "For a lane scope, change only that lane's declared write set. Never edit plan_file or execute another lane. Before execution, satisfy the lane's dependency/start condition and required predecessor integration gates; after execution, satisfy that lane's own QA/integration gate before reporting it eligible to release downstream work.",
     "Execute waves in the declared order; preserve QA checkpoints between waves and do not collapse them.",
     "If a wave or constraint should be redesigned, MUST escalate to the Admiral via the completion report instead of silently altering the wave's intent.",
     "Escalate genuine blockers (ambiguous step, missing dependency, environmental failure) instead of fabricating workarounds.",
@@ -67,6 +72,7 @@ export const CARRIER_METADATA: CarrierMetadata = {
   outputFormat:
     `After completing the assigned wave(s), provide a structured wave-completion report.\n` +
     `[Required] always include:\n` +
+    `  **Execution scope** — \`all\` or the exact Wave/Lane ID executed from the plan's Dispatch Manifest.\n` +
     `  **Wave(s) executed** — Ordered list of wave/step IDs from the plan_file actually completed.\n` +
     `  **Changes** — Every file created/modified/deleted with a 1-line summary each.\n` +
     `  **QA results** — Outcome of each wave's QA checkpoint (pass/fail with detail).\n` +

--- a/packages/fleet-carriers/tests/personas.test.ts
+++ b/packages/fleet-carriers/tests/personas.test.ts
@@ -160,6 +160,52 @@ describe("persona defaults", () => {
   }
 });
 
+describe("Kirov and Ohio parallel execution contract", () => {
+  it("Kirov requires one plan SSoT plus an Execution Topology and Dispatch Manifest", () => {
+    const template = (KIROV_METADATA.principles ?? []).find((principle) =>
+      principle.startsWith("The .fleet/plans/*.md file MUST contain this exact default Markdown template"),
+    ) ?? "";
+
+    expect(KIROV_METADATA.summary).toContain("one executable .fleet/plans/*.md plan_file SSoT");
+    expect(KIROV_METADATA.outputFormat).toContain("**Execution Topology**");
+    expect(KIROV_METADATA.outputFormat).toContain("**Dispatch Manifest**");
+    expect(KIROV_METADATA.permissions).toContain(
+      "MUST honor exact provided .fleet/plans/*.md paths. Keep one plan_file as the execution SSoT: Success means creating or updating that executable plan_file unless the Admiral explicitly requests draft-only work. Do not create split plan files for parallel lanes.",
+    );
+    expect(KIROV_METADATA.principles).toContain(
+      "Execution Topology is mandatory for every plan. It MUST declare Execution mode: Sequential | Parallel, shared mutable resources, ordered waves, and stable Wave/Lane IDs; a lane may be marked parallel only when its exact non-overlapping write set and read dependencies prove it is safe to run concurrently.",
+    );
+    expect(KIROV_METADATA.principles).toContain(
+      "Dispatch Manifest is mandatory for every plan. For each parallel lane, declare: stable Wave/Lane ID; exact non-overlapping write set; read dependencies; dependency/start condition; eligible concurrent lanes; integration gate; handoff; and rollback unit. It MUST also state that full-plan Ohio invocation (execution_scope omitted or all) is allowed sequentially only for Sequential or absent Execution Topology; Parallel requires exact Lane IDs, makes full-plan invocation unavailable as an alternative dispatch path, and never combines it with lane jobs. If disjoint lanes cannot be proven safe, mark the work sequential rather than calling it parallel.",
+    );
+    expect(template).toContain("# Execution Topology, - Execution mode: Sequential | Parallel, - Shared mutable resources:");
+    expect(template).toContain("# Waves, ## Wave N — <name>, ### Lane WN-X — <name>");
+    expect(template).toContain("- Exact write set:, - Read dependencies:, - Dependency/start condition:");
+    expect(template).toContain("- Eligible concurrent lanes: (use \"none\" for serialized work), - Integration gate:, - Handoff:, - Rollback unit:");
+    expect(template.indexOf("# Waves")).toBeLessThan(template.indexOf("# Dispatch Manifest"));
+    expect(template).toContain("# Dispatch Manifest, - Full-plan Ohio invocation (execution_scope omitted or all): allowed sequentially only when Execution mode is Sequential or Execution Topology is absent; for Parallel, dispatch exact Lane IDs only and never combine a full-plan invocation with lane jobs");
+    expect(template).toContain("- Lane WN-X — <name>: exact write set, read dependencies, dependency/start condition, eligible concurrent lanes, integration gate, handoff, and rollback unit summary for dispatch");
+  });
+
+  it("Ohio accepts only manifest-declared execution scopes and preserves unscoped sequential execution", () => {
+    expect(OHIO_METADATA.requestBlocks).toContainEqual({
+      tag: "execution_scope",
+      hint: "Optional: for legacy plans without Execution Topology or plans marked Execution mode: Sequential, omitted or `all` executes the full plan sequentially. For Execution mode: Parallel, provide one exact Wave/Lane ID declared by the Dispatch Manifest; omitted or `all` is rejected. Never combine a full-plan invocation with scoped-lane Ohio invocation(s).",
+      required: false,
+    });
+    expect(OHIO_METADATA.permissions).toContain(
+      "MUST read the plan's Execution Topology before resolving execution_scope. For legacy plans without Execution Topology or plans marked Execution mode: Sequential, omitted scope or `all` executes the full plan sequentially. For Execution mode: Parallel, require one exact Dispatch Manifest Wave/Lane ID and reject omitted or `all` scope rather than silently serializing available parallelism. A full-plan invocation (omitted or `all`) MUST NEVER be used alongside scoped-lane Ohio invocation(s).",
+    );
+    expect(OHIO_METADATA.principles).toContain(
+      "Read Execution Topology before resolving execution_scope. For legacy plans without Execution Topology or Execution mode: Sequential, omitted scope or `all` retains full-plan sequential compatibility. For Execution mode: Parallel, require one exact manifest-declared Wave/Lane ID and reject omitted or `all` scope rather than silently serializing available parallelism. Never use a full-plan invocation alongside scoped-lane Ohio invocation(s).",
+    );
+    expect(OHIO_METADATA.principles).toContain(
+      "For a lane scope, change only that lane's declared write set. Never edit plan_file or execute another lane. Before execution, satisfy the lane's dependency/start condition and required predecessor integration gates; after execution, satisfy that lane's own QA/integration gate before reporting it eligible to release downstream work.",
+    );
+    expect(OHIO_METADATA.outputFormat).toContain("**Execution scope** — `all` or the exact Wave/Lane ID executed");
+  });
+});
+
 describe("explicit default registration", () => {
   const registry = createCarrierRegistry();
 


### PR DESCRIPTION
## Summary

- Add a single-plan execution topology and Dispatch Manifest to Kirov plans for safe parallel Ohio lanes.
- Require exact Ohio lane scopes for Parallel plans while preserving legacy and Sequential full-plan execution.
- Expose the carrier contract through Fleet Admiral assets without specializing `protocol-frontline`.

## Type of Change

- [x] feat - new feature or carrier capability

## Scope

- [x] `extensions/fleet` (Admiral / Bridge / Carriers)
- [x] Documentation (changelog fragment)

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-carriers exec vitest run tests/personas.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-admiral test -- tests/carrier-contracts-skill.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-carriers typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-admiral typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-carriers build`
- [x] `pnpm --filter @dotobokuri/fleet-admiral build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`

## Changelog

- [x] Added `.changelog.d/parallel-plan-execution.md`.
- [x] Uses `section: Changed` and valid `[fleet-carriers] [fleet-admiral]` prefixes.

## Notes for Reviewers

- `protocol-frontline` intentionally remains carrier-neutral; the lane rules live in Kirov, Ohio, and carrier-contracts.