### PR TITLE
docs(fleet-console): add korean summary to rail path context fragment

### DIFF
--- a/.changelog.d/rail-path-context.md
+++ b/.changelog.d/rail-path-context.md
@@ -3,3 +3,4 @@ section: Added
 ---
 
 - [fleet-console] Add a shared Activity Rail path context so supported panels can focus on the same selected Theater root, worktree, or directory.
+  ko: 지원 패널들이 동일하게 선택된 Theater 루트·워크트리·디렉토리를 바라보도록 공유 Activity Rail 경로 컨텍스트를 추가했습니다.


### PR DESCRIPTION
## Summary
- PR #204의 changelog 프래그먼트가 새 bilingual 프래그먼트 규칙(각 영어 불릿에 `ko:` 병기) 이전 형식이라 컴파일 게이트가 실패함 — 한국어 요약 1줄을 추가합니다.

## Test Plan
- [x] `node scripts/compile-changelog-fragments.mjs --check` green