### PR TITLE
fix(fleet-console): remove English fallback badge

### DIFF
--- a/.changelog.d/remove-english-fallback.md
+++ b/.changelog.d/remove-english-fallback.md
@@ -1,0 +1,6 @@
+---
+section: Removed
+---
+
+- [fleet-console] Remove the English fallback badge from localized What's New release notes.
+  ko: 현지화된 What's New 릴리스 노트에서 English fallback 배지를 제거합니다.

--- a/runtime/fleet-console/core/client/src/components/whatsnew-modal.tsx
+++ b/runtime/fleet-console/core/client/src/components/whatsnew-modal.tsx
@@ -106,7 +106,6 @@ export function WhatsNewModal({ state }: WhatsNewModalProps) {
           <div className="whatsnew-meta-row">
             {selected.date ? <time className="whatsnew-date" dateTime={selected.date}>Released {selected.date}</time> : <span className="whatsnew-date">Unreleased</span>}
             {state.releaseNotesStale ? <span className="whatsnew-stale">Stale</span> : null}
-            {locale === "ko" && selected.localizationFallback ? <span className="whatsnew-fallback">English fallback</span> : null}
           </div>
         </header>
         <button ref={closeButtonRef} type="button" className="whatsnew-close" onClick={closeWhatsNew} aria-label="Close What's new">


### PR DESCRIPTION
## Summary

- Remove the `English fallback` badge from the What's New modal.
- Add the Fleet Console changelog fragment for the user-visible removal.

## Test Plan

- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `pnpm --filter '@dotobokuri/fleet-console...' build`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (`63` files, `624` passed, `22` skipped)
- [x] `git diff --check`

## Changelog

- [x] Added `.changelog.d/remove-english-fallback.md`.
- [x] Fragment section is `Removed` with English and Korean summaries.
