### PR TITLE
feat(fleet-console): integrate Operation panel chrome into a single surface

### DIFF
--- a/.changelog.d/panel-integrated-chrome.md
+++ b/.changelog.d/panel-integrated-chrome.md
@@ -2,5 +2,5 @@
 section: Changed
 ---
 
-- [fleet-console] Operation panels drop the separate title bar for an integrated single surface, moving the name, CLI badge, and window controls into a floating top-right cluster that also serves as the drag handle.
-  ko: Operation 패널이 별도의 상단 바를 없애고 일체형 단일 면으로 바뀌며, 이름·CLI 배지·창 조작 버튼을 이동 핸들을 겸하는 우측 상단 플로팅 클러스터로 옮깁니다.
+- [fleet-console] Operation panels drop the separate title bar for an integrated single surface; each panel shows only a status dot at rest and reveals a top-right cluster with its name, CLI badge, and window controls on hover, which also serves as the drag handle.
+  ko: Operation 패널이 별도의 상단 바를 없애고 일체형 단일 면으로 바뀌며, 평상시에는 상태 dot만 보이다가 마우스를 올리면 이름·CLI 배지·창 조작 버튼이 담긴 우측 상단 클러스터가 나타나고 이 클러스터가 이동 핸들도 겸합니다.

--- a/.changelog.d/panel-integrated-chrome.md
+++ b/.changelog.d/panel-integrated-chrome.md
@@ -1,0 +1,6 @@
+---
+section: Changed
+---
+
+- [fleet-console] Operation panels drop the separate title bar for an integrated single surface, moving the name, CLI badge, and window controls into a floating top-right cluster that also serves as the drag handle.
+  ko: Operation 패널이 별도의 상단 바를 없애고 일체형 단일 면으로 바뀌며, 이름·CLI 배지·창 조작 버튼을 이동 핸들을 겸하는 우측 상단 플로팅 클러스터로 옮깁니다.

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -186,6 +186,17 @@ export function OperationFrame({ operation, active, geometry, zoom, subtitle, st
       aria-label={`Operation ${displayTitle}`}
       inert={minimized ? true : undefined}
     >
+      {!maximized && !interactionDisabled ? (
+        <div
+          className="canvas-operation-drag-edge"
+          onPointerDown={beginDrag}
+          onPointerMove={updateDrag}
+          onPointerUp={endDrag}
+          onPointerCancel={endDrag}
+          data-canvas-blocker
+          aria-hidden="true"
+        />
+      ) : null}
       <div
         className="canvas-operation-titlebar"
         onPointerDown={beginDrag}
@@ -207,7 +218,7 @@ export function OperationFrame({ operation, active, geometry, zoom, subtitle, st
             <span className={beaconStatusClass(status)} aria-hidden="true" />
           </button>
         ) : (
-          <span className={beaconStatusClass(status)} aria-hidden="true" />
+          <span className={beaconStatusClass(status)} onPointerDown={stopTitlePointer} aria-hidden="true" />
         )}
         {rename.renaming ? (
           <input
@@ -225,7 +236,7 @@ export function OperationFrame({ operation, active, geometry, zoom, subtitle, st
             {displayTitle}
           </span>
         )}
-        {subtitle ? <span className="canvas-operation-cli">{subtitle}</span> : null}
+        {subtitle ? <span className="canvas-operation-cli" onPointerDown={stopTitlePointer}>{subtitle}</span> : null}
         <button type="button" className="canvas-operation-icon-button" onPointerDown={stopButtonPointer} onClick={minimize} aria-label={`Minimize operation ${displayTitle}`} title="Minimize operation">
           <MinimizeIcon />
         </button>

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4051,23 +4051,49 @@
   z-index: 6;
   display: flex;
   align-items: center;
-  gap: var(--space-1);
-  min-width: 0;
+  gap: 0;
+  width: fit-content;
+  min-width: 22px;
   max-width: calc(100% - (var(--space-2) * 2));
-  min-height: 36px;
-  padding: 4px 5px 4px 8px;
-  border: 1px solid color-mix(in oklch, var(--surface-rim) 86%, transparent);
+  min-height: 22px;
+  padding: 0;
+  border: 0 solid transparent;
   border-radius: var(--radius-lg);
-  background: color-mix(in oklch, var(--ink-deep) 64%, var(--surface-glass));
-  box-shadow: 0 8px 18px -12px color-mix(in oklch, var(--ink-deep) 88%, transparent);
-  backdrop-filter: blur(12px) saturate(140%);
-  -webkit-backdrop-filter: blur(12px) saturate(140%);
+  overflow: hidden;
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
   cursor: grab;
   touch-action: none;
+  transition:
+    gap var(--duration-base) var(--ease-spring),
+    min-height var(--duration-base) var(--ease-spring),
+    padding var(--duration-base) var(--ease-spring),
+    border-color var(--duration-base) var(--ease-spring),
+    background var(--duration-base) var(--ease-spring),
+    box-shadow var(--duration-base) var(--ease-spring),
+    backdrop-filter var(--duration-base) var(--ease-spring);
 }
 
 .canvas-operation-titlebar:active {
   cursor: grabbing;
+}
+
+/* rest에서는 accent beacon만 코너에 남긴다. Tab으로 숨은 컨트롤에 진입하면
+   필 스코프의 focus-within만으로 다시 열려 xterm 본문 포커스와 분리된다. */
+.canvas-operation:hover .canvas-operation-titlebar,
+.canvas-operation-titlebar:focus-within {
+  gap: var(--space-1);
+  min-height: 36px;
+  padding: 4px 33px 4px 8px;
+  border-color: color-mix(in oklch, var(--surface-rim) 86%, transparent);
+  border-width: 1px;
+  overflow: visible;
+  background: color-mix(in oklch, var(--ink-deep) 64%, var(--surface-glass));
+  box-shadow: 0 8px 18px -12px color-mix(in oklch, var(--ink-deep) 88%, transparent);
+  backdrop-filter: blur(12px) saturate(140%);
+  -webkit-backdrop-filter: blur(12px) saturate(140%);
 }
 
 .canvas-operation-drag-edge {
@@ -4088,12 +4114,15 @@
 /* 좌측 상태 인디케이터(beacon)를 감싼 클릭 어포던스 — 누르면 accent 설정 모달을 연다.
    accent-immune: 도트 fill은 상태색 단독 소유이고, 버튼 테두리/배경은 중립 ink만 쓴다(사용자 accent 누출 금지). */
 .canvas-operation-beacon-button {
+  position: absolute;
+  top: 0;
+  right: 0;
   display: grid;
   place-items: center;
   flex: none;
   width: 22px;
   height: 22px;
-  margin-left: -4px;
+  margin-left: 0;
   padding: 0;
   cursor: pointer;
   border: 1px solid transparent;
@@ -4326,18 +4355,31 @@
 }
 
 .canvas-operation-title {
+  flex: 0 0 0;
+  width: 0;
   min-width: 0;
-  max-width: 15ch;
+  max-width: 0;
+  height: 0;
   overflow: hidden;
-  color: var(--ink-pearl);
+  padding: 0;
+  margin: 0;
+  border: 0;
+  color: transparent;
   font-weight: 700;
   text-overflow: ellipsis;
   white-space: nowrap;
   /* 이름 영역은 더블클릭 rename 대상 — 텍스트 커서로 드래그(grab)되는 띠바 영역과 시각적으로 구분한다. */
   cursor: text;
-  padding: 2px 4px;
-  margin: 0 -2px;
   border-radius: var(--radius-xs);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    width var(--duration-base) var(--ease-spring),
+    max-width var(--duration-base) var(--ease-spring),
+    height var(--duration-base) var(--ease-spring),
+    padding var(--duration-base) var(--ease-spring),
+    margin var(--duration-base) var(--ease-spring),
+    opacity var(--duration-base) var(--ease-spring);
 }
 
 .canvas-operation-title:hover {
@@ -4346,17 +4388,29 @@
 
 /* 패널 이름 인라인 변경 입력 — Operations 사이드바 rename 입력과 같은 brass 포커스 언어를 띠바 폭에 맞춘다. */
 .canvas-operation-rename-input {
-  flex: 0 1 15ch;
+  flex: 0 0 0;
+  width: 0;
   min-width: 0;
-  padding: 4px 7px;
-  border: 1px solid color-mix(in oklch, var(--brass) 44%, var(--surface-rim));
+  max-width: 0;
+  height: 0;
+  padding: 0;
+  border: 0;
   border-radius: var(--radius-xs);
-  background: color-mix(in oklch, var(--ink-deep) 84%, var(--surface-glass));
-  color: var(--ink-pearl);
+  background: transparent;
+  color: transparent;
   font: inherit;
   font-weight: 700;
   outline: none;
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass) 12%, transparent);
+  box-shadow: none;
+  opacity: 0;
+  pointer-events: none;
+  overflow: hidden;
+  transition:
+    width var(--duration-base) var(--ease-spring),
+    max-width var(--duration-base) var(--ease-spring),
+    height var(--duration-base) var(--ease-spring),
+    padding var(--duration-base) var(--ease-spring),
+    opacity var(--duration-base) var(--ease-spring);
 }
 
 .canvas-operation-rename-input:focus {
@@ -4366,17 +4420,29 @@
     0 0 0 2px color-mix(in oklch, var(--brass) 18%, transparent);
 }
 
-.canvas-operation-cli,
-.canvas-operation-job-count {
-  flex: none;
-  padding: 4px 7px;
-  border: 1px solid color-mix(in oklch, var(--aurora) 38%, var(--surface-rim));
+.canvas-operation-cli {
+  flex: 0 0 0;
+  width: 0;
+  min-width: 0;
+  max-width: 0;
+  height: 0;
+  padding: 0;
+  border: 0;
   border-radius: var(--radius-sm);
-  color: var(--aurora);
+  color: transparent;
   font-family: var(--font-mono);
   font-size: 10px;
   font-weight: 700;
   line-height: 1;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    width var(--duration-base) var(--ease-spring),
+    max-width var(--duration-base) var(--ease-spring),
+    height var(--duration-base) var(--ease-spring),
+    padding var(--duration-base) var(--ease-spring),
+    opacity var(--duration-base) var(--ease-spring);
 }
 
 .canvas-operation-cli {
@@ -4384,6 +4450,14 @@
 }
 
 .canvas-operation-job-count {
+  flex: none;
+  padding: 4px 7px;
+  border: 1px solid color-mix(in oklch, var(--aurora) 38%, var(--surface-rim));
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
   border-color: color-mix(in oklch, var(--brass) 42%, var(--surface-rim));
   color: var(--brass-bright);
 }
@@ -4391,14 +4465,22 @@
 .canvas-operation-icon-button {
   display: grid;
   place-items: center;
-  flex: none;
-  width: 28px;
-  height: 28px;
-  border: 1px solid var(--surface-rim);
+  flex: 0 0 0;
+  width: 0;
+  height: 0;
+  padding: 0;
+  overflow: hidden;
+  border: 0 solid transparent;
   border-radius: var(--radius-sm);
-  color: var(--ink-fog);
-  background: color-mix(in oklch, var(--surface-glass) 58%, transparent);
+  color: transparent;
+  background: transparent;
+  opacity: 0;
+  pointer-events: none;
   transition:
+    width var(--duration-base) var(--ease-spring),
+    height var(--duration-base) var(--ease-spring),
+    padding var(--duration-base) var(--ease-spring),
+    opacity var(--duration-base) var(--ease-spring),
     color var(--duration-fast) var(--ease-spring),
     border-color var(--duration-fast) var(--ease-spring),
     background var(--duration-fast) var(--ease-spring);
@@ -4413,12 +4495,6 @@
   outline-offset: 2px;
 }
 
-.canvas-operation:hover .canvas-operation-icon-button,
-.canvas-operation:focus-within .canvas-operation-icon-button {
-  color: var(--brass-bright);
-  border-color: color-mix(in oklch, var(--brass) 36%, var(--surface-rim));
-}
-
 .canvas-operation-icon-button.is-active {
   color: var(--brass-bright);
   border-color: color-mix(in oklch, var(--brass) 60%, var(--surface-rim));
@@ -4430,6 +4506,73 @@
   display: block;
   width: 15px;
   height: 15px;
+}
+
+.canvas-operation:hover .canvas-operation-title,
+.canvas-operation-titlebar:focus-within .canvas-operation-title {
+  flex: 0 1 15ch;
+  width: auto;
+  min-width: 0;
+  max-width: 15ch;
+  height: auto;
+  padding: 2px 4px;
+  margin: 0 -2px;
+  color: var(--ink-pearl);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.canvas-operation:hover .canvas-operation-rename-input,
+.canvas-operation-titlebar:focus-within .canvas-operation-rename-input {
+  flex: 0 1 15ch;
+  width: auto;
+  min-width: 0;
+  max-width: 15ch;
+  height: auto;
+  padding: 4px 7px;
+  border: 1px solid color-mix(in oklch, var(--brass) 44%, var(--surface-rim));
+  background: color-mix(in oklch, var(--ink-deep) 84%, var(--surface-glass));
+  color: var(--ink-pearl);
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass) 12%, transparent);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.canvas-operation:hover .canvas-operation-cli,
+.canvas-operation-titlebar:focus-within .canvas-operation-cli {
+  flex: none;
+  width: auto;
+  min-width: 0;
+  max-width: none;
+  height: auto;
+  padding: 4px 7px;
+  border: 1px solid color-mix(in oklch, var(--aurora) 38%, var(--surface-rim));
+  color: var(--aurora);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.canvas-operation:hover .canvas-operation-icon-button,
+.canvas-operation-titlebar:focus-within .canvas-operation-icon-button {
+  flex: none;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--surface-rim);
+  color: var(--ink-fog);
+  background: color-mix(in oklch, var(--surface-glass) 58%, transparent);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .canvas-operation-titlebar,
+  .canvas-operation-title,
+  .canvas-operation-rename-input,
+  .canvas-operation-cli,
+  .canvas-operation-icon-button {
+    transition-duration: 0.01ms;
+  }
 }
 
 .canvas-operation-terminal {

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2560,11 +2560,6 @@
   display: none;
 }
 
-/* 순정 셸 패널 — Operation과 구별되도록 띠바에 아우로라(살아있는 것) 톤의 옅은 강조를 준다. */
-.canvas-operation--shell .canvas-operation-titlebar {
-  background: color-mix(in oklch, var(--aurora) 9%, color-mix(in oklch, var(--ink-deep) 28%, transparent));
-}
-
 /* Operations Control 헤더 — 레티클 마크 + 타이틀.
    좌하단 런처와 우클릭 메뉴를 단순 'add'에서 작전 통제면으로 승격하는 정체성 블록. */
 .canvas-context-menu-head {
@@ -3058,7 +3053,7 @@
 .canvas-operation {
   position: absolute;
   display: grid;
-  grid-template-rows: 42px minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
   min-width: 320px;
   min-height: 200px;
   overflow: hidden;
@@ -3091,7 +3086,7 @@
    코너에서 끊긴다. 부모 .operations-canvas는 radius-xl(24px) + 보더 1px이라 overflow:hidden 클립
    반경이 23px(=radius-xl − 보더). 패널 radius를 이 클립 반경에 정확히 맞추면 패널의 둥근 코너가
    클립과 일치해 검은 갭 없이 accent가 둥근 모서리를 그대로 감싼다.
-   드래그/리사이즈가 차단된 상태이므로 타이틀바의 grab 어포던스 커서도 기본값으로 되돌린다. */
+   드래그/리사이즈가 차단된 상태이므로 코너 필의 grab 어포던스 커서도 기본값으로 되돌린다. */
 .canvas-operation.is-maximized {
   border-radius: calc(var(--radius-xl) - 1px);
 }
@@ -4050,19 +4045,43 @@
 
 
 .canvas-operation-titlebar {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  z-index: 6;
   display: flex;
   align-items: center;
-  gap: var(--space-2);
+  gap: var(--space-1);
   min-width: 0;
-  height: 42px;
-  padding: 0 var(--space-2) 0 var(--space-3);
-  border-bottom: 1px solid var(--surface-rim);
-  background: color-mix(in oklch, var(--ink-deep) 28%, transparent);
+  max-width: calc(100% - (var(--space-2) * 2));
+  min-height: 36px;
+  padding: 4px 5px 4px 8px;
+  border: 1px solid color-mix(in oklch, var(--surface-rim) 86%, transparent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in oklch, var(--ink-deep) 64%, var(--surface-glass));
+  box-shadow: 0 8px 18px -12px color-mix(in oklch, var(--ink-deep) 88%, transparent);
+  backdrop-filter: blur(12px) saturate(140%);
+  -webkit-backdrop-filter: blur(12px) saturate(140%);
   cursor: grab;
   touch-action: none;
 }
 
 .canvas-operation-titlebar:active {
+  cursor: grabbing;
+}
+
+.canvas-operation-drag-edge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 4;
+  height: 14px;
+  cursor: grab;
+  touch-action: none;
+}
+
+.canvas-operation-drag-edge:active {
   cursor: grabbing;
 }
 
@@ -4308,6 +4327,7 @@
 
 .canvas-operation-title {
   min-width: 0;
+  max-width: 15ch;
   overflow: hidden;
   color: var(--ink-pearl);
   font-weight: 700;
@@ -4326,7 +4346,7 @@
 
 /* 패널 이름 인라인 변경 입력 — Operations 사이드바 rename 입력과 같은 brass 포커스 언어를 띠바 폭에 맞춘다. */
 .canvas-operation-rename-input {
-  flex: 1 1 auto;
+  flex: 0 1 15ch;
   min-width: 0;
   padding: 4px 7px;
   border: 1px solid color-mix(in oklch, var(--brass) 44%, var(--surface-rim));
@@ -4360,7 +4380,7 @@
 }
 
 .canvas-operation-cli {
-  margin-left: auto;
+  margin-left: 0;
 }
 
 .canvas-operation-job-count {
@@ -4389,6 +4409,14 @@
   color: var(--brass-bright);
   border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
   background: color-mix(in oklch, var(--brass) 12%, var(--surface-glass));
+  outline: 2px solid color-mix(in oklch, var(--brass) 48%, transparent);
+  outline-offset: 2px;
+}
+
+.canvas-operation:hover .canvas-operation-icon-button,
+.canvas-operation:focus-within .canvas-operation-icon-button {
+  color: var(--brass-bright);
+  border-color: color-mix(in oklch, var(--brass) 36%, var(--surface-rim));
 }
 
 .canvas-operation-icon-button.is-active {


### PR DESCRIPTION
## Summary
- Operation 패널의 42px 상단 바(배경 틴트 + 하단 헤어라인 이음새)를 제거해 각 패널을 이음새 없는 단일 면으로 개편합니다.
- 이름·상태 beacon·CLI 배지·창 조작 버튼을 우측 상단의 떠 있는 글래스 클러스터로 통합하고, 이 클러스터가 주 이동 핸들을 겸합니다(상단 전폭 14px drag-edge가 보조 핸들).
- 버튼은 평상시 저대비, 패널 hover/focus-within 시 brass로 점등하되 항상 탭 순서에 있고 focus-visible 링이 있어 호버 없이도(키보드/터치) 조작 가능합니다.
- rename(더블클릭)·accent 팝오버·최소화 PTY 보존·최대화 특례(default 커서·drag-edge/리사이즈 미렌더·Restore 아이콘)·8방향 리사이즈를 모두 보존하며, 공유 `OperationFrame`을 통해 모든 패널 종류에 일괄 적용됩니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (624 passed / 22 skipped)
- [x] 격리 콘솔 e2e(Sentinel PASS): 이동 드래그(필·edge)·드래그 제외(버튼/이름/배지/beacon)·최소화 PTY 보존(env 마커 확증)·최대화/복원·닫기·rename·accent(외곽선만 변경)·키보드 focus-visible·터미널 침해 ~8%(의도 범위)·겹침 식별·prefers-reduced-motion

## Changelog
- [x] `.changelog.d/panel-integrated-chrome.md` (section: Changed, `[fleet-console]`)