### PR TITLE
feat(fleet-console): Codex ACP | App Server launch mode toggle in Agent CLI settings

### DIFF
--- a/.changelog.d/codex-launch-mode.md
+++ b/.changelog.d/codex-launch-mode.md
@@ -1,0 +1,12 @@
+---
+section: Added
+---
+
+- [fleet-console] Add an ACP | App Server click toggle on the Codex row in Settings > Agent CLI; the choice persists in ~/.fleet/settings.json as codexLaunchMode and defaults to ACP.
+  ko: Settings > Agent CLI의 Codex 행에 ACP | App Server 클릭 토글을 추가하며, 선택값은 ~/.fleet/settings.json의 codexLaunchMode로 영속되고 기본값은 ACP입니다.
+- [core-infra] Persist codexLaunchMode (acp or app-server) in ~/.fleet/settings.json global options.
+  ko: 전역 옵션 ~/.fleet/settings.json에 codexLaunchMode(acp 또는 app-server)를 영속합니다.
+- [core-unified-agent] Route Codex carrier sessions through ACP or legacy App Server based on the CODEX_USE_ACP runtime environment toggle, defaulting to ACP when unset.
+  ko: CODEX_USE_ACP 런타임 환경변수 토글에 따라 Codex 캐리어 세션을 ACP 또는 레거시 App Server로 연결하며, 미설정 시 기본값은 ACP입니다.
+- [fleet-admiral] [fleet-cli] Apply the saved codexLaunchMode as CODEX_USE_ACP when launching new Codex carrier sessions.
+  ko: 새 Codex 캐리어 세션을 시작할 때 저장된 codexLaunchMode를 CODEX_USE_ACP로 적용합니다.

--- a/packages/core-infra/src/data-dir/settings/store.ts
+++ b/packages/core-infra/src/data-dir/settings/store.ts
@@ -60,10 +60,14 @@ export function sanitizeGlobalOptionsData(value: unknown): GlobalOptionsValidati
   const data: GlobalOptionsData = {
     version: GLOBAL_OPTIONS_VERSION,
     ...(typeof value.enableMetaphor === "boolean" ? { enableMetaphor: value.enableMetaphor } : {}),
+    ...(value.codexLaunchMode === "acp" || value.codexLaunchMode === "app-server"
+      ? { codexLaunchMode: value.codexLaunchMode }
+      : {}),
   };
-  const allowedKeys = new Set(["version", "enableMetaphor"]);
+  const allowedKeys = new Set(["version", "enableMetaphor", "codexLaunchMode"]);
   const changed = Object.keys(value).some((key) => !allowedKeys.has(key)) ||
-    ("enableMetaphor" in value && typeof value.enableMetaphor !== "boolean");
+    ("enableMetaphor" in value && typeof value.enableMetaphor !== "boolean") ||
+    ("codexLaunchMode" in value && value.codexLaunchMode !== "acp" && value.codexLaunchMode !== "app-server");
 
   return { data, changed };
 }

--- a/packages/core-infra/src/data-dir/settings/types.ts
+++ b/packages/core-infra/src/data-dir/settings/types.ts
@@ -1,6 +1,7 @@
 export interface GlobalOptionsData {
   readonly version: 1;
   readonly enableMetaphor?: boolean;
+  readonly codexLaunchMode?: 'acp' | 'app-server';
 }
 
 export interface GlobalOptionsValidationResult {

--- a/packages/core-infra/tests/data-dir-settings-store.test.ts
+++ b/packages/core-infra/tests/data-dir-settings-store.test.ts
@@ -74,6 +74,38 @@ describe("data-dir settings store", () => {
     });
   });
 
+  it("preserves valid codex launch modes and strips invalid values", () => {
+    expect(sanitizeGlobalOptionsData({
+      version: 1,
+      codexLaunchMode: "acp",
+    })).toEqual({
+      changed: false,
+      data: {
+        version: 1,
+        codexLaunchMode: "acp",
+      },
+    });
+    expect(sanitizeGlobalOptionsData({
+      version: 1,
+      codexLaunchMode: "app-server",
+    })).toEqual({
+      changed: false,
+      data: {
+        version: 1,
+        codexLaunchMode: "app-server",
+      },
+    });
+    expect(sanitizeGlobalOptionsData({
+      version: 1,
+      codexLaunchMode: "legacy",
+    })).toEqual({
+      changed: true,
+      data: {
+        version: 1,
+      },
+    });
+  });
+
   it("drops the legacy replaceSystemPrompt option while preserving enableMetaphor", () => {
     // 이전 릴리스가 남긴 ~/.fleet/settings.json의 replaceSystemPrompt(boolean) 키는
     // 이제 미허용 키이므로 changed=true와 함께 안전 드롭되고 enableMetaphor는 보존되어야 한다.

--- a/packages/core-unified-agent/AGENTS.md
+++ b/packages/core-unified-agent/AGENTS.md
@@ -146,7 +146,7 @@ ait (model) ❯ {input}            # Omitted if effort is not supported
 | CLI | Protocol | spawn Method | set_config_option | set_mode |
 |-----|----------|--------------|-------------------|----------|
 | Claude | ACP (npx bridge) | `npx --package=@agentclientprotocol/claude-agent-acp@0.33.1 claude-agent-acp` | ✅ | ✅ |
-| Codex | ACP (`codex-acp`) / `app-server` | (Toggle) `npx --yes --package=@agentclientprotocol/codex-acp@1.1.2 codex-acp` / `codex app-server` | ✅ (ACP) / Pending (Legacy) | ✅ (ACP) / Pending (Legacy) |
+| Codex | ACP (`codex-acp`) / `app-server` | Runtime `CODEX_USE_ACP` env toggle (default ACP): `npx --yes --package=@agentclientprotocol/codex-acp@1.1.2 codex-acp` / `codex app-server` | ✅ (ACP) / Pending (Legacy) | ✅ (ACP) / Pending (Legacy) |
 | opencode-go | ACP | `opencode acp` | ✅ | ✅ |
 
 ## Architecture Decisions
@@ -179,7 +179,7 @@ ait (model) ❯ {input}            # Omitted if effort is not supported
 
 10. **Codex Official ACP Bridge**: Codex uses `@agentclientprotocol/codex-acp@1.1.2` on the ACP path. Model changes use standard `session/set_config_option` with `configId: "model"`, while public Fleet `effort` maps to Codex's advertised `reasoning_effort` config option. Config and instruction delivery uses the `CODEX_CONFIG` env JSON channel because the bridge does not forward CLI argv to the spawned `codex` app-server.
 
-11. **Validation-mode Dual-Path for Codex**: Codex currently supports two transport paths (official ACP npx bridge and legacy AppServer) controlled by a `CODEX_USE_ACP` toggle. This is a temporary validation wave for protocol transition; a permanent switch will occur in a future wave, deprecating the legacy AppServer path and associated types.
+11. **Validation-mode Dual-Path for Codex**: Codex currently supports two transport paths (official ACP npx bridge and legacy AppServer) controlled by the runtime `CODEX_USE_ACP` environment toggle (default ACP). This is a temporary validation wave for protocol transition; a permanent switch will occur in a future wave, deprecating the legacy AppServer path and associated types.
 
 ## Adding a New CLI Provider
 

--- a/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
+++ b/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
@@ -74,11 +74,10 @@ interface CodexThreadDefaultsForResume {
   config?: Record<string, CodexJsonValue>;
 }
 
+type CodexConnection = CodexAppServerConnection | AcpConnection;
+
 const CODEX_TURN_LEVEL_CONFIG_KEYS = new Set(['effort', 'model']);
 const CODEX_THREAD_POLICY_CONFIG_KEYS = new Set(['approvalPolicy', 'sandbox']);
-const CODEX_USE_ACP = true;
-
-type CodexConnection = CodexAppServerConnection | AcpConnection;
 
 /**
  * Codex app-server 전용 내부 클라이언트.
@@ -127,7 +126,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     }
     this.validateModelEffort(options.model, options.effort);
 
-    if (CODEX_USE_ACP) {
+    if (shouldUseCodexAcp(options)) {
       return this.connectAcp(options);
     }
 
@@ -886,4 +885,11 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
   private matchAnyPattern(text: string, patterns: RegExp[]): boolean {
     return patterns.some((pattern) => pattern.test(text));
   }
+}
+
+// 호출별 환경변수로 Codex 전송 경로를 선택하며, 미설정은 ACP로 유지한다.
+function shouldUseCodexAcp(options: UnifiedClientOptions): boolean {
+  const value = options.env?.CODEX_USE_ACP ?? process.env.CODEX_USE_ACP;
+  const normalized = value?.trim().toLowerCase();
+  return normalized !== 'false' && normalized !== '0';
 }

--- a/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
+++ b/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EventEmitter } from 'events';
 
 const mockCodexConnect = vi.fn();
@@ -17,6 +17,8 @@ const mockAcpSendPrompt = vi.fn();
 const mockAcpSetMode = vi.fn();
 const mockAcpSetModel = vi.fn();
 const mockAcpSetConfigOption = vi.fn();
+const originalCodexUseAcp = process.env.CODEX_USE_ACP;
+const originalCodexConfig = process.env.CODEX_CONFIG;
 
 function createMockCodexConnection(): EventEmitter & Record<string, unknown> {
   const emitter = new EventEmitter();
@@ -98,8 +100,18 @@ function acpCtorOptions(): { env?: Record<string, string | undefined>; args: str
   return call[0] as unknown as { env?: Record<string, string | undefined>; args: string[] };
 }
 
+function restoreEnvironmentVariable(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
 describe('UnifiedCodexAgentClient config staging', () => {
   beforeEach(() => {
+    delete process.env.CODEX_USE_ACP;
+    delete process.env.CODEX_CONFIG;
     vi.clearAllMocks();
     mockCodexConnect.mockResolvedValue({ thread: { id: 'codex-thread-1' } });
     mockCodexDisconnect.mockResolvedValue(undefined);
@@ -113,6 +125,73 @@ describe('UnifiedCodexAgentClient config staging', () => {
     mockAcpSetMode.mockResolvedValue(undefined);
     mockAcpSetModel.mockResolvedValue(undefined);
     mockAcpSetConfigOption.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    restoreEnvironmentVariable('CODEX_USE_ACP', originalCodexUseAcp);
+    restoreEnvironmentVariable('CODEX_CONFIG', originalCodexConfig);
+  });
+
+  it('CODEX_USE_ACP 미설정 시 ACP로 연결한다', async () => {
+    const client = new UnifiedCodexAgentClient();
+
+    await client.connect({ cwd: '/workspace', cli: 'codex' });
+
+    expect(AcpConnection).toHaveBeenCalledTimes(1);
+    expect(CodexAppServerConnection).not.toHaveBeenCalled();
+  });
+
+  it("options.env CODEX_USE_ACP='false'는 App Server로 연결한다", async () => {
+    const client = new UnifiedCodexAgentClient();
+
+    await client.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+      env: { CODEX_USE_ACP: 'false' },
+    });
+
+    expect(CodexAppServerConnection).toHaveBeenCalledTimes(1);
+    expect(AcpConnection).not.toHaveBeenCalled();
+  });
+
+  it("options.env CODEX_USE_ACP='0'는 App Server로 연결한다", async () => {
+    const client = new UnifiedCodexAgentClient();
+
+    await client.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+      env: { CODEX_USE_ACP: '0' },
+    });
+
+    expect(CodexAppServerConnection).toHaveBeenCalledTimes(1);
+    expect(AcpConnection).not.toHaveBeenCalled();
+  });
+
+  it("options.env CODEX_USE_ACP='true'는 ACP로 연결한다", async () => {
+    const client = new UnifiedCodexAgentClient();
+
+    await client.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+      env: { CODEX_USE_ACP: 'true' },
+    });
+
+    expect(AcpConnection).toHaveBeenCalledTimes(1);
+    expect(CodexAppServerConnection).not.toHaveBeenCalled();
+  });
+
+  it('options.env가 process.env CODEX_USE_ACP보다 우선한다', async () => {
+    process.env.CODEX_USE_ACP = 'false';
+    const client = new UnifiedCodexAgentClient();
+
+    await client.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+      env: { CODEX_USE_ACP: 'true' },
+    });
+
+    expect(AcpConnection).toHaveBeenCalledTimes(1);
+    expect(CodexAppServerConnection).not.toHaveBeenCalled();
   });
 
   it('ACP mode 매핑은 공식 codex-acp bridge mode ID를 사용한다', () => {

--- a/packages/fleet-admiral/src/agent-runtime/index.ts
+++ b/packages/fleet-admiral/src/agent-runtime/index.ts
@@ -12,7 +12,9 @@ import {
 	type McpToolRegistry,
 	type McpToolSnapshotStore,
 	type RegisterExecutorToolOptions,
+	type AuthEnvResolver,
 } from "@dotobokuri/core-agent";
+import type { GlobalOptionsService } from "@dotobokuri/core-infra";
 import { getFleetDataDir } from "@dotobokuri/core-infra/data-dir";
 import {
 	createCarrierRuntime,
@@ -33,6 +35,7 @@ export interface FleetAgentRuntimeToolRegistration {
 
 export interface FleetAgentRuntimeLifecycleDeps {
 	readonly dataDir?: string;
+	readonly globalOptionsService?: GlobalOptionsService;
 	readonly workspaceChangeScanner?: WorkspaceChangeScanner;
 	readonly extraExecutorTools?: readonly FleetAgentRuntimeToolRegistration[];
 	readonly wikiToolSpecs?: readonly AgentToolSpec[];
@@ -156,7 +159,7 @@ function registerFleetAgentRuntimeTools(
 	deps: FleetAgentRuntimeLifecycleDeps,
 ): void {
 	registerAgentToolDefaults(mcpRegistry, carrierRuntime, {
-		authEnvResolver: async () => ({}),
+		authEnvResolver: createAuthEnvResolver(deps.globalOptionsService),
 		reservedExternalMcpServerIds: buildReservedExternalMcpServerIds(deps.reservedExternalMcpServerIds),
 		workspaceChangeScanner: deps.workspaceChangeScanner,
 	});
@@ -212,4 +215,18 @@ function buildReservedExternalMcpServerIds(
 	injectedIds: readonly string[] | undefined,
 ): readonly string[] {
 	return [...new Set([...DEFAULT_RESERVED_EXTERNAL_MCP_SERVER_IDS, ...(injectedIds ?? [])])];
+}
+
+function createAuthEnvResolver(
+	globalOptionsService: GlobalOptionsService | undefined,
+): AuthEnvResolver {
+	return async (cli): Promise<Record<string, string>> => {
+		if (cli !== "codex" || !globalOptionsService) return {};
+		try {
+			const mode = globalOptionsService.load().codexLaunchMode;
+			return { CODEX_USE_ACP: mode === "app-server" ? "false" : "true" };
+		} catch {
+			return {};
+		}
+	};
 }

--- a/packages/fleet-admiral/src/agent-runtime/index.ts
+++ b/packages/fleet-admiral/src/agent-runtime/index.ts
@@ -118,6 +118,22 @@ export function createFleetAgentRuntimeLifecycle(
 	};
 }
 
+export function createAuthEnvResolver(
+	globalOptionsService: GlobalOptionsService | undefined,
+): AuthEnvResolver {
+	return async (cli): Promise<Record<string, string>> => {
+		if (cli !== "codex" || !globalOptionsService) return {};
+		try {
+			const mode = globalOptionsService.load().codexLaunchMode;
+			// 저장된 모드가 없으면 주입하지 않는다 — process.env 폴백과 기본 ACP 우선순위를 보존한다.
+			if (!mode) return {};
+			return { CODEX_USE_ACP: mode === "app-server" ? "false" : "true" };
+		} catch {
+			return {};
+		}
+	};
+}
+
 function createFleetAgentRuntimeMcpServices(): FleetAgentRuntimeMcpServices {
 	const mcpRegistry = createMcpToolRegistry();
 	const mcpToolSnapshotStore = createMcpToolSnapshotStore();
@@ -215,18 +231,4 @@ function buildReservedExternalMcpServerIds(
 	injectedIds: readonly string[] | undefined,
 ): readonly string[] {
 	return [...new Set([...DEFAULT_RESERVED_EXTERNAL_MCP_SERVER_IDS, ...(injectedIds ?? [])])];
-}
-
-function createAuthEnvResolver(
-	globalOptionsService: GlobalOptionsService | undefined,
-): AuthEnvResolver {
-	return async (cli): Promise<Record<string, string>> => {
-		if (cli !== "codex" || !globalOptionsService) return {};
-		try {
-			const mode = globalOptionsService.load().codexLaunchMode;
-			return { CODEX_USE_ACP: mode === "app-server" ? "false" : "true" };
-		} catch {
-			return {};
-		}
-	};
 }

--- a/packages/fleet-admiral/tests/agent-runtime-auth-env.test.ts
+++ b/packages/fleet-admiral/tests/agent-runtime-auth-env.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import type { GlobalOptionsService } from "@dotobokuri/core-infra";
+
+import { createAuthEnvResolver } from "../src/agent-runtime/index.js";
+
+function createServiceStub(load: GlobalOptionsService["load"]): GlobalOptionsService {
+	return {
+		load,
+		save: (data) => data,
+		update: (mutate) => mutate({ version: 1 }),
+	};
+}
+
+describe("createAuthEnvResolver", () => {
+	it("codex가 아닌 CLI에는 아무것도 주입하지 않는다", async () => {
+		const resolver = createAuthEnvResolver(createServiceStub(() => ({ version: 1, codexLaunchMode: "app-server" })));
+		await expect(resolver("claude")).resolves.toEqual({});
+	});
+
+	it("globalOptionsService가 없으면 아무것도 주입하지 않는다", async () => {
+		const resolver = createAuthEnvResolver(undefined);
+		await expect(resolver("codex")).resolves.toEqual({});
+	});
+
+	it("codexLaunchMode 미저장 시 주입하지 않아 process.env 폴백을 보존한다", async () => {
+		const resolver = createAuthEnvResolver(createServiceStub(() => ({ version: 1 })));
+		await expect(resolver("codex")).resolves.toEqual({});
+	});
+
+	it("저장된 acp 모드는 CODEX_USE_ACP=true로 주입한다", async () => {
+		const resolver = createAuthEnvResolver(createServiceStub(() => ({ version: 1, codexLaunchMode: "acp" })));
+		await expect(resolver("codex")).resolves.toEqual({ CODEX_USE_ACP: "true" });
+	});
+
+	it("저장된 app-server 모드는 CODEX_USE_ACP=false로 주입한다", async () => {
+		const resolver = createAuthEnvResolver(createServiceStub(() => ({ version: 1, codexLaunchMode: "app-server" })));
+		await expect(resolver("codex")).resolves.toEqual({ CODEX_USE_ACP: "false" });
+	});
+
+	it("설정 로드가 실패하면 빈 객체로 폴백한다", async () => {
+		const resolver = createAuthEnvResolver(createServiceStub(() => {
+			throw new Error("settings unavailable");
+		}));
+		await expect(resolver("codex")).resolves.toEqual({});
+	});
+});

--- a/runtime/fleet-cli/src/runtime/runtime.ts
+++ b/runtime/fleet-cli/src/runtime/runtime.ts
@@ -62,6 +62,7 @@ async function startRuntime(deps: FleetRuntimeLifecycleDeps): Promise<StartedRun
 	const infraServices = createInfraServices();
 	const agentRuntime = createFleetAgentRuntimeLifecycle({
 		...(deps.dataDir ? { dataDir: deps.dataDir } : {}),
+		globalOptionsService: infraServices.globalOptionsService,
 		onMcpServerStartError: (error) => {
 			console.error("[fleet-cli] Failed to start MCP server", error);
 		},

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -617,8 +617,6 @@ function AgentCliRow({
     <div className="agent-cli-row">
       <span className="agent-cli-name">{cli.displayName}</span>
       <span className="agent-cli-meta">
-        {cli.available && cli.version ? <span className="agent-cli-version">{cli.version}</span> : null}
-        <span className={`agent-cli-status ${cli.available ? "is-on" : ""}`}>{cli.available ? "Available" : "Missing"}</span>
         {cli.id === "codex" && codexLaunchMode ? (
           <span className="segmented" role="group" aria-label="Codex launch mode">
             <button
@@ -641,6 +639,8 @@ function AgentCliRow({
             </button>
           </span>
         ) : null}
+        {cli.available && cli.version ? <span className="agent-cli-version">{cli.version}</span> : null}
+        <span className={`agent-cli-status ${cli.available ? "is-on" : ""}`}>{cli.available ? "Available" : "Missing"}</span>
       </span>
     </div>
   );

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -504,6 +504,7 @@ function AgentCliSection() {
   const [clis, setClis] = React.useState<readonly AgentCliStatus[]>([]);
   const [error, setError] = React.useState<string | null>(null);
   const { renderer: terminalRenderer, font: terminalFont } = useTerminalPrefs();
+  const settings = useSystemPromptSettingsStore();
 
   React.useEffect(() => {
     const abort = new AbortController();
@@ -527,8 +528,18 @@ function AgentCliSection() {
         <p className="global-settings-help">Whether each Agent CLI is installed and discoverable on this machine's PATH, with its detected version. Carriers can only run on an Agent CLI shown as available here.</p>
         {error ? <p className="settings-error">{error}</p> : null}
         <div className="agent-cli-list">
-          {clis.map((cli) => <AgentCliRow key={cli.id} cli={cli} />)}
+          {clis.map((cli) => (
+            <AgentCliRow
+              key={cli.id}
+              cli={cli}
+              codexLaunchMode={settings.state?.codexLaunchMode}
+              disabled={settings.savingField !== null}
+              onCodexLaunchModeChange={(mode) => void setSystemPromptSettingsField("codexLaunchMode", mode)}
+            />
+          ))}
         </div>
+        {settings.error ? <p className="global-settings-error" role="alert">{settings.error}</p> : null}
+        <p className="global-settings-help">Codex launch mode controls the unified-agent carrier protocol for new Codex sessions; it does not affect the interactive Codex TUI in terminal panels.</p>
         <p className="global-settings-foot">Install or update a CLI, then reopen this page to re-check availability.</p>
       </section>
       <TerminalFontSettingsCard terminalFont={terminalFont} />
@@ -591,13 +602,45 @@ function SettingToggleRow({ title, help, onLabel, offLabel, value, disabled, onT
   );
 }
 
-function AgentCliRow({ cli }: { readonly cli: AgentCliStatus }) {
+function AgentCliRow({
+  cli,
+  codexLaunchMode,
+  disabled,
+  onCodexLaunchModeChange,
+}: {
+  readonly cli: AgentCliStatus;
+  readonly codexLaunchMode: "acp" | "app-server" | undefined;
+  readonly disabled: boolean;
+  readonly onCodexLaunchModeChange: (mode: "acp" | "app-server") => void;
+}) {
   return (
     <div className="agent-cli-row">
       <span className="agent-cli-name">{cli.displayName}</span>
       <span className="agent-cli-meta">
         {cli.available && cli.version ? <span className="agent-cli-version">{cli.version}</span> : null}
         <span className={`agent-cli-status ${cli.available ? "is-on" : ""}`}>{cli.available ? "Available" : "Missing"}</span>
+        {cli.id === "codex" && codexLaunchMode ? (
+          <span className="segmented" role="group" aria-label="Codex launch mode">
+            <button
+              type="button"
+              aria-pressed={codexLaunchMode === "acp"}
+              className={`segmented-option ${codexLaunchMode === "acp" ? "is-active" : ""}`}
+              disabled={disabled}
+              onClick={() => onCodexLaunchModeChange("acp")}
+            >
+              ACP
+            </button>
+            <button
+              type="button"
+              aria-pressed={codexLaunchMode === "app-server"}
+              className={`segmented-option ${codexLaunchMode === "app-server" ? "is-active" : ""}`}
+              disabled={disabled}
+              onClick={() => onCodexLaunchModeChange("app-server")}
+            >
+              App Server
+            </button>
+          </span>
+        ) : null}
       </span>
     </div>
   );

--- a/runtime/fleet-plugins/terminal/client/agent/settings-api.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/settings-api.ts
@@ -1,6 +1,13 @@
+export type CodexLaunchMode = "acp" | "app-server";
+
 export interface SystemPromptSettingsState {
   readonly enableMetaphor: boolean;
+  readonly codexLaunchMode: CodexLaunchMode;
 }
+
+export type SystemPromptSettingsUpdate =
+  | { readonly enableMetaphor: boolean }
+  | { readonly codexLaunchMode: CodexLaunchMode };
 
 export class TerminalSettingsApiError extends Error {
   readonly status: number;
@@ -18,7 +25,7 @@ export async function fetchSystemPromptSettings(signal?: AbortSignal): Promise<S
   return assertSystemPromptSettingsState(await response.json(), response.status);
 }
 
-export async function saveSystemPromptSettings(settings: SystemPromptSettingsState, signal?: AbortSignal): Promise<SystemPromptSettingsState> {
+export async function saveSystemPromptSettings(settings: SystemPromptSettingsUpdate, signal?: AbortSignal): Promise<SystemPromptSettingsState> {
   const response = await fetch("/plugins/terminal/settings", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
@@ -46,10 +53,12 @@ function assertSystemPromptSettingsState(value: unknown, status: number): System
   if (
     !payload
     || typeof payload.enableMetaphor !== "boolean"
+    || (payload.codexLaunchMode !== "acp" && payload.codexLaunchMode !== "app-server")
   ) {
     throw new TerminalSettingsApiError(status, "Invalid Terminal settings response");
   }
   return {
     enableMetaphor: payload.enableMetaphor,
+    codexLaunchMode: payload.codexLaunchMode,
   };
 }

--- a/runtime/fleet-plugins/terminal/client/agent/settings-store.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/settings-store.ts
@@ -61,9 +61,12 @@ export async function setSystemPromptSettingsField<Field extends SystemPromptSet
   // 진행 중인 로드 응답이 이 저장 결과를 덮지 않도록 세대값을 올린다.
   loadGeneration += 1;
   const optimistic = { ...current, [field]: value };
+  const update = field === "enableMetaphor"
+    ? { enableMetaphor: optimistic.enableMetaphor }
+    : { codexLaunchMode: optimistic.codexLaunchMode };
   setSnapshot({ state: optimistic, savingField: field, error: null });
   try {
-    const state = await saveSystemPromptSettings(optimistic);
+    const state = await saveSystemPromptSettings(update);
     setSnapshot({ state, savingField: null, error: null });
     return true;
   } catch (error) {

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -68,6 +68,7 @@ export function buildAgentLaunchKindBackfillPatch(operation: AgentLaunchKindBack
 
 function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: TerminalRuntime, deps: AgentRouteDeps) {
   const runtime = createFleetAgentRuntimeLifecycle({
+    globalOptionsService: deps.globalOptionsService,
     onMcpServerStartError: (error) => {
       console.error("[fleet-console] Failed to start MCP server", error);
     },

--- a/runtime/fleet-plugins/terminal/server/settings-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/settings-routes.ts
@@ -10,14 +10,16 @@ interface TerminalSettingsRouteDeps {
 
 interface TerminalSettingsBody {
   readonly enableMetaphor?: unknown;
+  readonly codexLaunchMode?: unknown;
 }
 
-interface TerminalSettingsUpdate {
-  readonly enableMetaphor: boolean;
-}
+type TerminalSettingsUpdate =
+  | { readonly enableMetaphor: boolean }
+  | { readonly codexLaunchMode: "acp" | "app-server" };
 
 export interface TerminalSettingsState {
   readonly enableMetaphor: boolean;
+  readonly codexLaunchMode: "acp" | "app-server";
 }
 
 export function registerTerminalSettingsRoutes(ctx: FleetPluginServerContext, deps: TerminalSettingsRouteDeps): void {
@@ -43,7 +45,7 @@ export function registerTerminalSettingsRoutes(ctx: FleetPluginServerContext, de
       }
       const updated = deps.globalOptionsService.update((current) => ({
         ...current,
-        enableMetaphor: body.enableMetaphor,
+        ...body,
       }));
       ctx.host.http.writeJson(res, 200, toTerminalSettingsState(updated));
       return true;
@@ -56,15 +58,18 @@ export function registerTerminalSettingsRoutes(ctx: FleetPluginServerContext, de
 export function toTerminalSettingsState(data: GlobalOptionsData): TerminalSettingsState {
   return {
     enableMetaphor: data.enableMetaphor ?? false,
+    codexLaunchMode: data.codexLaunchMode ?? "acp",
   };
 }
 
 function isTerminalSettingsBody(value: unknown): value is TerminalSettingsUpdate {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-  // 계약: enableMetaphor 단일 키만 허용한다(추가 키는 거부).
-  if (Object.keys(value).length !== 1) return false;
+  // 계약: 알려진 설정 키 중 정확히 하나만 허용한다(추가 키와 복수 키는 거부).
+  const keys = Object.keys(value);
+  if (keys.length !== 1) return false;
   const body = value as TerminalSettingsBody;
-  return typeof body.enableMetaphor === "boolean";
+  if (keys[0] === "enableMetaphor") return typeof body.enableMetaphor === "boolean";
+  return keys[0] === "codexLaunchMode" && (body.codexLaunchMode === "acp" || body.codexLaunchMode === "app-server");
 }
 
 function isJsonRequest(req: http.IncomingMessage): boolean {

--- a/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
@@ -19,23 +19,33 @@ interface HarnessOptions {
 }
 
 describe("terminal settings routes", () => {
-  it("GET /plugins/terminal/settings returns only prompt booleans", async () => {
+  it("GET /plugins/terminal/settings returns the default ACP Codex launch mode", async () => {
     const harness = createRouteHarness({
       data: { version: 1, enableMetaphor: false },
     });
     await harness.handle({ req: req("GET"), res: res(), pathname: "/plugins/terminal/settings" });
-    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false } }]);
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "acp" } }]);
     expect(harness.writes[0]?.body).not.toHaveProperty("consolePortMode");
   });
 
   it("PUT /plugins/terminal/settings updates enableMetaphor in global options", async () => {
     const harness = createRouteHarness({
       body: { enableMetaphor: true },
+      data: { version: 1, enableMetaphor: false, codexLaunchMode: "app-server" },
+    });
+    await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: true, codexLaunchMode: "app-server" } }]);
+    expect(harness.currentData()).toEqual({ version: 1, enableMetaphor: true, codexLaunchMode: "app-server" });
+  });
+
+  it("PUT /plugins/terminal/settings updates the Codex launch mode in global options", async () => {
+    const harness = createRouteHarness({
+      body: { codexLaunchMode: "app-server" },
       data: { version: 1, enableMetaphor: false },
     });
     await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
-    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: true } }]);
-    expect(harness.currentData()).toEqual({ version: 1, enableMetaphor: true });
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "app-server" } }]);
+    expect(harness.currentData()).toEqual({ version: 1, enableMetaphor: false, codexLaunchMode: "app-server" });
   });
 
   it("PUT /plugins/terminal/settings rejects non-boolean payloads", async () => {
@@ -47,6 +57,27 @@ describe("terminal settings routes", () => {
 
   it("PUT /plugins/terminal/settings rejects payloads with unknown extra keys", async () => {
     const harness = createRouteHarness({ body: { enableMetaphor: true, consolePortMode: "static" } });
+    await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
+    expect(harness.writes[0]?.status).toBe(400);
+    expect(harness.updateCalls).toBe(0);
+  });
+
+  it("PUT /plugins/terminal/settings rejects payloads with unknown keys", async () => {
+    const harness = createRouteHarness({ body: { terminalRenderer: "webgl" } });
+    await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
+    expect(harness.writes[0]?.status).toBe(400);
+    expect(harness.updateCalls).toBe(0);
+  });
+
+  it("PUT /plugins/terminal/settings rejects invalid Codex launch modes", async () => {
+    const harness = createRouteHarness({ body: { codexLaunchMode: "tcp" } });
+    await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
+    expect(harness.writes[0]?.status).toBe(400);
+    expect(harness.updateCalls).toBe(0);
+  });
+
+  it("PUT /plugins/terminal/settings rejects payloads with multiple known keys", async () => {
+    const harness = createRouteHarness({ body: { enableMetaphor: true, codexLaunchMode: "app-server" } });
     await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
     expect(harness.writes[0]?.status).toBe(400);
     expect(harness.updateCalls).toBe(0);

--- a/runtime/fleet-plugins/terminal/tests/system-prompt-settings-api.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/system-prompt-settings-api.test.ts
@@ -8,16 +8,16 @@ describe("system prompt settings api", () => {
   });
 
   it("loads Terminal prompt settings from the plugin route", async () => {
-    const fetchMock = vi.fn(async () => jsonResponse({ enableMetaphor: false }));
+    const fetchMock = vi.fn(async () => jsonResponse({ enableMetaphor: false, codexLaunchMode: "acp" }));
     vi.stubGlobal("fetch", fetchMock);
-    await expect(fetchSystemPromptSettings()).resolves.toEqual({ enableMetaphor: false });
+    await expect(fetchSystemPromptSettings()).resolves.toEqual({ enableMetaphor: false, codexLaunchMode: "acp" });
     expect(fetchMock).toHaveBeenCalledWith("/plugins/terminal/settings", { signal: undefined });
   });
 
   it("saves the prompt boolean to the plugin route", async () => {
-    const fetchMock = vi.fn(async () => jsonResponse({ enableMetaphor: true }));
+    const fetchMock = vi.fn(async () => jsonResponse({ enableMetaphor: true, codexLaunchMode: "acp" }));
     vi.stubGlobal("fetch", fetchMock);
-    await expect(saveSystemPromptSettings({ enableMetaphor: true })).resolves.toEqual({ enableMetaphor: true });
+    await expect(saveSystemPromptSettings({ enableMetaphor: true })).resolves.toEqual({ enableMetaphor: true, codexLaunchMode: "acp" });
     expect(fetchMock).toHaveBeenCalledWith("/plugins/terminal/settings", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -26,8 +26,20 @@ describe("system prompt settings api", () => {
     });
   });
 
-  it("rejects responses missing the enableMetaphor boolean field", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({ consolePortMode: "dynamic" })));
+  it("saves the Codex launch mode to the plugin route", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ enableMetaphor: false, codexLaunchMode: "app-server" }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(saveSystemPromptSettings({ codexLaunchMode: "app-server" })).resolves.toEqual({ enableMetaphor: false, codexLaunchMode: "app-server" });
+    expect(fetchMock).toHaveBeenCalledWith("/plugins/terminal/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ codexLaunchMode: "app-server" }),
+      signal: undefined,
+    });
+  });
+
+  it("rejects responses missing a required settings field", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({ enableMetaphor: false })));
     await expect(fetchSystemPromptSettings()).rejects.toThrow("Invalid Terminal settings response");
   });
 });


### PR DESCRIPTION
## Summary

Adds a click toggle on the Codex row in **Settings > Agent CLI** that switches how unified-agent carrier sessions run Codex: official **ACP** bridge (default) or legacy **App Server**. The choice persists server-side in `~/.fleet/settings.json` as `codexLaunchMode` and is applied to each new Codex carrier connect via the runtime `CODEX_USE_ACP` environment toggle — no UnifiedAgent interface change, env-injection only.

Supersedes #209 (was based on `main`; this PR is rebased onto `canary` with the bilingual changelog fragment).

## Changes

- **core-unified-agent** — replace the hardcoded `CODEX_USE_ACP = true` constant with runtime env resolution (`options.env` → `process.env` → default ACP; `false`/`0` selects App Server). AGENTS.md now matches the documented env-toggle behavior.
- **core-infra** — persist `codexLaunchMode?: 'acp' | 'app-server'` in the global options store with sanitize allowlist validation.
- **fleet-admiral** — `authEnvResolver` policy injects `CODEX_USE_ACP` from the persisted setting for `codex` connects; safe fallback to ACP when the service is absent or fails.
- **fleet-cli / fleet-console terminal plugin** — hosts pass their existing `globalOptionsService` into the agent runtime lifecycle.
- **terminal plugin UI** — segmented `ACP | App Server` control on the Codex row (left of version info), optimistic save, strict one-known-key PUT contract on `/plugins/terminal/settings`.

## Notes

- The interactive Codex TUI launched from terminal panels is unaffected by design; the toggle governs carrier (unified-agent) sessions only, applying from the next new session (pooled live sessions keep their transport).
- QA (Sentinel): live App Server smoke against codex 0.144.1 succeeded (`codex-app-server` protocol round-trip), ACP regression smoke green, route boundary cases (400/401/415) verified by real calls, no regressions on `enableMetaphor`.
- Follow-up candidate: a dedicated App Server smoke e2e — the existing Codex e2e suite hardcodes ACP protocol/tool names and reports expected mismatches when forced to App Server mode.

## Testing

- `core-unified-agent` / `core-infra` / `fleet-admiral`: build + tests green
- `fleet-console` (rebased on canary): typecheck, 540 tests, build green; terminal plugin runner: 132 tests green
- `pnpm check:core-boundary` green; bilingual changelog fragment validated (`compile-changelog-fragments.mjs --check`, 14 entries)