### PR TITLE
fix(fleet-console): stabilize Diff panel layouts

### DIFF
--- a/.changelog.d/diff-plugin-fatal-bugs.md
+++ b/.changelog.d/diff-plugin-fatal-bugs.md
@@ -1,0 +1,6 @@
+---
+section: Fixed
+---
+
+- [fleet-console] Fix Diff panels for file selection, non-Git Theaters, and narrow History layouts.
+  ko: Diff 파일 선택, Non-Git Theater 및 좁은 History 레이아웃 문제를 수정합니다.

--- a/runtime/fleet-plugins/diff/client/diff.css
+++ b/runtime/fleet-plugins/diff/client/diff.css
@@ -21,6 +21,7 @@
   transition: none;
 }
 
+.diff-list-pane,
 .diff-tree-pane {
   display: grid;
   grid-template-rows: auto 1fr;
@@ -565,7 +566,7 @@
 }
 
 .history-root.has-detail {
-  grid-template-columns: minmax(250px, 1fr) minmax(360px, 1.4fr);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.4fr);
 }
 
 .history-list-pane,

--- a/runtime/fleet-plugins/diff/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/diff/client/rail-panel.tsx
@@ -102,11 +102,11 @@ function DiffPanelBody({ ctx }: DiffPanelProps) {
   return (
     <div ref={rootRef} className={`diff-root${selectedFile ? " has-hunk" : ""}${isDragging ? " is-dragging" : ""}`} style={selectedFile ? { gridTemplateColumns: buildDiffGridTemplate(listPaneWidth) } : undefined}>
       {selectedFile && hunkMode ? <div className="diff-hunk-pane"><div className="diff-hunk-head"><span>{selectedFile.entry.path}</span><button type="button" onClick={handleCloseHunk}>✕</button></div><HunkView ctx={ctx} file={selectedFile.entry} mode={hunkMode} subPath={selectedFile.subPath} /></div> : null}
+      {selectedFile ? <div className="diff-divider" onPointerDown={handleDividerDown} aria-hidden="true" /> : null}
       <div className="diff-list-pane">
         <div className="diff-toolbar"><div className="diff-view-toggle"><button type="button" className={`diff-toggle-btn${viewMode === "list" ? " is-active" : ""}`} title="List view" aria-pressed={viewMode === "list"} onClick={() => handleViewMode("list")}><svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><line x1="2" y1="3.5" x2="12" y2="3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" /><line x1="2" y1="7" x2="12" y2="7" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" /><line x1="2" y1="10.5" x2="12" y2="10.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" /></svg></button><button type="button" className={`diff-toggle-btn${viewMode === "tree" ? " is-active" : ""}`} title="Tree view" aria-pressed={viewMode === "tree"} onClick={() => handleViewMode("tree")}><svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><rect x="1" y="1" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /><rect x="9" y="1" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /><rect x="1" y="9" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /><rect x="9" y="9" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /></svg></button></div></div>
         <ChangedFiles ctx={ctx} viewMode={viewMode} selectedPath={selectedFile?.entry.path ?? null} subPath={subPath} onSelect={handleSelectFile} />
       </div>
-      {selectedFile ? <div className="diff-divider" onPointerDown={handleDividerDown} aria-hidden="true" /> : null}
     </div>
   );
 }

--- a/runtime/fleet-plugins/diff/server/diff.ts
+++ b/runtime/fleet-plugins/diff/server/diff.ts
@@ -60,6 +60,10 @@ async function fetchUntrackedFiles(cwd: string): Promise<DiffFileEntry[]> {
   }));
 }
 
+async function ensureGitRepository(cwd: string): Promise<void> {
+  await runGit(["rev-parse", "--is-inside-work-tree"], { cwd });
+}
+
 // no-HEAD repo(초기 커밋 없는 신규 저장소) 감지: git stderr에 "unknown revision" 또는 "bad revision" 포함
 function isNoHeadError(error: unknown): boolean {
   if (!(error instanceof GitExecutorError)) return false;
@@ -122,6 +126,7 @@ export async function handleDiffChanged(
   const { gitCwd } = cwdResult;
 
   try {
+    await ensureGitRepository(gitCwd);
     let files: DiffFileEntry[];
     let truncated = false;
 

--- a/runtime/fleet-plugins/diff/tests/context-scoped-routes.test.ts
+++ b/runtime/fleet-plugins/diff/tests/context-scoped-routes.test.ts
@@ -191,3 +191,27 @@ describe("selected subdirectory diff route scope", () => {
     expect(commit.content).not.toContain(`${INSIDE_DIR}/committed.txt`);
   });
 });
+
+describe("changed route non-Git theater handling", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "fleet-diff-no-git-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns the client-friendly no_git_repo notice contract", async () => {
+    const writes: JsonWrite[] = [];
+
+    await handleDiffChanged(
+      { method: "POST" } as never,
+      {} as never,
+      makeContext(tmpDir, { theaterId: "theater" }, writes),
+    );
+
+    expect(writes).toEqual([{ status: 422, payload: { error: "no_git_repo" } }]);
+  });
+});


### PR DESCRIPTION
## Summary

- Keep the Diff file list and hunk pane split aligned when selecting a file.
- Route non-Git changed requests to the existing user-facing repository notice.
- Keep History commit details within narrow Console panels.

## Test Plan

- [x] `pnpm --filter @fleet-plugins/diff test`
- [x] `pnpm --filter @fleet-plugins/diff typecheck`
- [x] `pnpm --filter @fleet-plugins/diff build`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Headed `console-e2e` for Diff, History, and non-Git states
- [x] `node scripts/compile-changelog-fragments.mjs --check`

## Changelog

- [x] Added `.changelog.d/diff-plugin-fatal-bugs.md` with a `Fixed` section and `[fleet-console]` entry.