### PR TITLE
fix(fleet-console): disable rail width transition during resize drag

### DIFF
--- a/.changelog.d/fix-rail-resize-drag-lag.md
+++ b/.changelog.d/fix-rail-resize-drag-lag.md
@@ -1,0 +1,6 @@
+---
+section: Fixed
+---
+
+- [fleet-console] Activity Rail resize drag now tracks the cursor 1:1 instead of easing behind it and catching up only after the pointer stops.
+  ko: Activity Rail 리사이즈 드래그가 커서를 지연 추적하다 멈춰야 따라잡던 문제를 고쳐 1:1로 즉시 따라오도록 수정.

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -460,8 +460,14 @@
   transition: none;
 }
 
+/* 외곽 .right-rail의 width(calc + --right-rail-panel-width)도 같은 이유로 꺼야 한다.
+   외곽 transition만 살아 있으면 flex 부모의 애니메이션 중인 폭이 슬롯을 flex-shrink로
+   압축해 슬롯의 transition:none을 무력화한다(실측: 매 프레임 슬롯 폭 ≡ rail 폭 − 45px,
+   60px 스텝 완주에 ~200ms). 닫기 toggle(.is-closed: width→0)은 is-dragging이 아닐 때만
+   타므로 그대로 유지된다. */
 .right-rail.is-dragging {
   user-select: none;
+  transition: none;
 }
 
 /* ── 빌트인/플러그인 패널 구분선 ─────────────────────────────────


### PR DESCRIPTION
## Summary
- Activity Rail 리사이즈 드래그가 커서를 200ms ease로 지연 추적하다 포인터를 멈춰야 따라잡던 회귀를 수정.
- 원인: Command Band 개편에서 `.right-rail`에 추가된 `width: calc(44px + var(--right-rail-panel-width))` + `transition: width 200ms ease`가 드래그 중에도 살아 있어, 애니메이션 중인 flex 부모 폭이 슬롯을 flex-shrink로 압축해 기존 슬롯 `transition: none` 수정(f4524ecb)을 무력화 — headed e2e 실측에서 매 프레임 `슬롯 폭 ≡ rail 폭 − 45px`, 60px 스텝 완주에 ~200ms 소요 확인.
- 수정: `.right-rail.is-dragging`에 `transition: none` 추가(기존 슬롯 규칙과 동일 패턴). 열기/닫기 스프링은 is-dragging이 아닐 때만 타므로 영향 없음.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 75 files, 695 passed
- [x] `pnpm --filter @dotobokuri/fleet-console build` — green
- [x] 격리 인스턴스(`FLEET_CONSOLE_DIR` 분리, `serve`) headed agent-browser e2e: 실 마우스 드래그 60px 스텝 4회 — 모든 스텝이 단일 프레임 내 1:1 반영(램프 프레임 0, 수정 전 스텝당 ~15프레임 ease 추격)
- [x] 동일 e2e에서 패널 열기/닫기 스프링 애니메이션 보존 확인(44↔596px 부드러운 램프)
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK

## Changelog
- [x] `.changelog.d/fix-rail-resize-drag-lag.md` (Fixed, `[fleet-console]`)