### PR TITLE
fix(fleet-console): clean plugin bundle cache lifecycle

### DIFF
--- a/.changelog.d/plugin-cache-lifecycle-cleanup.md
+++ b/.changelog.d/plugin-cache-lifecycle-cleanup.md
@@ -1,0 +1,6 @@
+---
+section: Fixed
+---
+
+- [fleet-console] Clean stale plugin bundles at startup and current-run bundles at shutdown without disturbing active Console processes.
+  ko: 활성 Fleet Console 프로세스를 방해하지 않으면서 시작 시 오래된 플러그인 번들을, 종료 시 현재 실행의 번들을 정리합니다.

--- a/runtime/fleet-console/core/host/plugin-host/host.ts
+++ b/runtime/fleet-console/core/host/plugin-host/host.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -16,12 +16,19 @@ export interface FleetPluginHostDeps extends DiscoverFleetPluginsOptions {
   readonly host: FleetPluginHostCapabilities;
   readonly importModule?: (entry: string) => Promise<FleetPluginRouteModule>;
   readonly bundleCacheDir?: string;
+  readonly isProcessAlive?: (pid: number) => boolean;
+  readonly removeBundleDir?: (dir: string) => Promise<void>;
 }
 
 export interface FleetPluginHost {
   readonly plugins: readonly DiscoveredFleetPlugin[];
   readonly sensitiveFieldsByPluginId: ReadonlyMap<string, readonly string[]>;
   boot(): Promise<void>;
+  cleanup(): Promise<void>;
+}
+
+interface PluginBundleOwner {
+  readonly pid: number;
 }
 
 const PLUGIN_DEV_EXTERNALS = [
@@ -37,14 +44,22 @@ const PLUGIN_DEV_EXTERNALS = [
   "ws",
   "@fleet-plugins/*",
 ];
+const PLUGIN_BUNDLE_DIR_PREFIX = "fleet-console-plugin-";
+const PLUGIN_BUNDLE_OWNER_FILE = ".fleet-console-plugin-owner.json";
+const PLUGIN_BUNDLE_PID_PATTERN = /^fleet-console-plugin-(\d+)-/u;
+const MAX_PLUGIN_BUNDLE_OWNER_PID = 0x7fff_ffff;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export function createFleetPluginHost(deps: FleetPluginHostDeps): FleetPluginHost {
   const plugins = filterDiscoveredPlugins(discoverFleetPlugins(deps));
   const sensitiveFieldsByPluginId = new Map(plugins.map((plugin) => [plugin.manifest.id, plugin.manifest.sensitiveFields ?? []]));
-  const importModule = deps.importModule ?? ((entry) => importPluginModule(entry, deps.bundleCacheDir));
+  const generatedBundleDirs = new Set<string>();
+  const isProcessAlive = deps.isProcessAlive ?? isPluginBundleOwnerAlive;
+  const removeBundleDir = deps.removeBundleDir ?? removePluginBundleDir;
+  const importModule = deps.importModule ?? ((entry) => importPluginModule(entry, deps.bundleCacheDir, generatedBundleDirs));
 
   async function boot(): Promise<void> {
+    await removeStalePluginBundleDirs(deps.bundleCacheDir, isProcessAlive, removeBundleDir);
     for (const plugin of plugins) {
       if (!plugin.routesEntry) continue;
       if (!plugin.external) {
@@ -59,7 +74,22 @@ export function createFleetPluginHost(deps: FleetPluginHostDeps): FleetPluginHos
     }
   }
 
-  return { plugins, sensitiveFieldsByPluginId, boot };
+  async function cleanup(): Promise<void> {
+    const dirs = [...generatedBundleDirs];
+    const cleanupResults = await Promise.allSettled(dirs.map((dir) => removeBundleDir(dir)));
+    for (const [index, result] of cleanupResults.entries()) {
+      const dir = dirs[index]!;
+      if (result.status === "fulfilled") {
+        generatedBundleDirs.delete(dir);
+        continue;
+      }
+      if (result.status === "rejected") {
+        console.warn(`[fleet-console] Plugin bundle cache cleanup failed: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`);
+      }
+    }
+  }
+
+  return { plugins, sensitiveFieldsByPluginId, boot, cleanup };
 
   async function bootPluginRoutes(plugin: DiscoveredFleetPlugin): Promise<void> {
     const mod = await importModule(plugin.routesEntry!);
@@ -96,7 +126,7 @@ function filterDiscoveredPlugins(plugins: readonly DiscoveredFleetPlugin[]): rea
   return accepted;
 }
 
-async function importPluginModule(entry: string, bundleCacheDir?: string): Promise<FleetPluginRouteModule> {
+async function importPluginModule(entry: string, bundleCacheDir: string | undefined, generatedBundleDirs: Set<string>): Promise<FleetPluginRouteModule> {
   if (entry.endsWith(".ts")) {
     const { build } = await import("esbuild");
     const output = await build({
@@ -112,19 +142,77 @@ async function importPluginModule(entry: string, bundleCacheDir?: string): Promi
     });
     const bundled = output.outputFiles[0]?.text;
     if (!bundled) throw new Error("plugin_bundle_failed");
-    const bundledPath = await writeTemporaryPluginBundle(entry, bundled, bundleCacheDir);
+    const bundledPath = await writeTemporaryPluginBundle(entry, bundled, bundleCacheDir, generatedBundleDirs);
     return await import(pathToFileURL(bundledPath).href) as FleetPluginRouteModule;
   }
   return await import(pathToFileURL(entry).href) as FleetPluginRouteModule;
 }
 
-async function writeTemporaryPluginBundle(entry: string, source: string, bundleCacheDir?: string): Promise<string> {
+async function writeTemporaryPluginBundle(entry: string, source: string, bundleCacheDir: string | undefined, generatedBundleDirs: Set<string>): Promise<string> {
   const cacheRoot = bundleCacheDir ?? path.join(resolvePluginBundleNodeModules(entry), ".cache");
   await mkdir(cacheRoot, { recursive: true });
-  const dir = await mkdtemp(path.join(cacheRoot, "fleet-console-plugin-"));
+  const dir = await mkdtemp(path.join(cacheRoot, `${PLUGIN_BUNDLE_DIR_PREFIX}${process.pid}-`));
+  if (bundleCacheDir) {
+    generatedBundleDirs.add(dir);
+    await writePluginBundleOwner(dir, process.pid);
+  }
   const file = path.join(dir, "routes.mjs");
   await writeFile(file, source, "utf8");
   return file;
+}
+
+async function removeStalePluginBundleDirs(bundleCacheDir: string | undefined, isProcessAlive: (pid: number) => boolean, removeBundleDir: (dir: string) => Promise<void>): Promise<void> {
+  if (!bundleCacheDir) return;
+  try {
+    await mkdir(bundleCacheDir, { recursive: true });
+    const entries = await readdir(bundleCacheDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.name.startsWith(PLUGIN_BUNDLE_DIR_PREFIX)) continue;
+      const entryPath = path.join(bundleCacheDir, entry.name);
+      const ownerPid = await readPluginBundleOwnerPid(entryPath, entry.name);
+      if (ownerPid !== null && isProcessAlive(ownerPid)) continue;
+      try {
+        await removeBundleDir(entryPath);
+      } catch (error) {
+        console.warn(`[fleet-console] Plugin bundle cache startup cleanup failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  } catch (error) {
+    console.warn(`[fleet-console] Plugin bundle cache startup cleanup failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function removePluginBundleDir(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true });
+}
+
+async function writePluginBundleOwner(dir: string, pid: number): Promise<void> {
+  await writeFile(path.join(dir, PLUGIN_BUNDLE_OWNER_FILE), JSON.stringify({ pid }), "utf8");
+}
+
+async function readPluginBundleOwnerPid(dir: string, name: string): Promise<number | null> {
+  try {
+    const parsed = JSON.parse(await readFile(path.join(dir, PLUGIN_BUNDLE_OWNER_FILE), "utf8")) as PluginBundleOwner;
+    if (isPluginBundleOwnerPid(parsed.pid)) return parsed.pid;
+  } catch {
+    // Marker write can be interrupted; fall back to the PID embedded in the directory name.
+  }
+  const pid = Number(PLUGIN_BUNDLE_PID_PATTERN.exec(name)?.[1]);
+  return isPluginBundleOwnerPid(pid) ? pid : null;
+}
+
+function isPluginBundleOwnerAlive(pid: number): boolean {
+  if (!isPluginBundleOwnerPid(pid)) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return Boolean(error && typeof error === "object" && "code" in error && error.code === "EPERM");
+  }
+}
+
+function isPluginBundleOwnerPid(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 && value <= MAX_PLUGIN_BUNDLE_OWNER_PID;
 }
 
 function resolvePluginBundleNodeModules(entry: string): string {

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -948,6 +948,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
         console.warn(`[fleet-console] Plugin cleanup failed: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`);
       }
     }
+    await pluginHost.cleanup();
     pluginCleanupCallbacks.clear();
     pluginEventListeners.clear();
     currentLock?.release();

--- a/runtime/fleet-console/tests/plugin-host.test.ts
+++ b/runtime/fleet-console/tests/plugin-host.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import * as fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -80,6 +81,101 @@ describe("plugin host", () => {
 
     expect(fs.readdirSync(cacheDir).some((entry) => entry.startsWith("fleet-console-plugin-"))).toBe(true);
     expect(fs.existsSync(path.join(dir, "home", ".fleet", "plugins", "node_modules", ".cache"))).toBe(false);
+  });
+
+  it("clears stale supplied cache contents at boot and removes this run's bundles during cleanup", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-plugin-cache-lifecycle-"));
+    tempDirs.push(dir);
+    const pluginRoot = path.join(dir, "home", ".fleet", "plugins", "note");
+    const cacheDir = path.join(dir, "console-data", "plugin-cache");
+    const durablePluginData = path.join(dir, "console-data", "plugins", "note", "state.json");
+    writePlugin(pluginRoot, "note", { apiVersion: 1 });
+    fs.writeFileSync(path.join(pluginRoot, "routes.ts"), "export function register() {}\n");
+    fs.mkdirSync(path.join(cacheDir, "fleet-console-plugin-crashed"), { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, "fleet-console-plugin-crashed", "routes.mjs"), "stale");
+    fs.mkdirSync(path.dirname(durablePluginData), { recursive: true });
+    fs.writeFileSync(durablePluginData, "durable");
+
+    const host = createFleetPluginHost({
+      cwd: dir,
+      homeDir: path.join(dir, "home"),
+      bundleCacheDir: cacheDir,
+      routes: new RouteRegistry(),
+      upgrades: new UpgradeRegistry(),
+      host: noopHostCapabilities,
+    });
+    await host.boot();
+
+    const generatedDirs = fs.readdirSync(cacheDir).filter((entry) => entry.startsWith("fleet-console-plugin-"));
+    expect(fs.existsSync(path.join(cacheDir, "fleet-console-plugin-crashed"))).toBe(false);
+    expect(generatedDirs).toHaveLength(1);
+    expect(fs.readFileSync(durablePluginData, "utf8")).toBe("durable");
+
+    await host.cleanup();
+
+    expect(fs.readdirSync(cacheDir)).toEqual([]);
+  });
+
+  it("removes stale bundle owners while preserving an active concurrent owner", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-plugin-cache-owners-"));
+    tempDirs.push(dir);
+    const pluginRoot = path.join(dir, "runtime", "fleet-plugins", "demo");
+    const cacheDir = path.join(dir, "console-data", "plugin-cache");
+    const activeDir = path.join(cacheDir, "fleet-console-plugin-4242-active");
+    const staleDir = path.join(cacheDir, "fleet-console-plugin-9999-crashed");
+    const invalidOwnerDir = path.join(cacheDir, "fleet-console-plugin-2147483648-corrupted");
+    writePlugin(pluginRoot, "demo", { routes: "routes.mjs" }, false);
+    fs.mkdirSync(activeDir, { recursive: true });
+    fs.mkdirSync(staleDir, { recursive: true });
+    fs.mkdirSync(invalidOwnerDir, { recursive: true });
+    fs.writeFileSync(path.join(staleDir, ".fleet-console-plugin-owner.json"), JSON.stringify({ pid: 9999 }));
+    fs.writeFileSync(path.join(invalidOwnerDir, ".fleet-console-plugin-owner.json"), JSON.stringify({ pid: 2_147_483_648 }));
+
+    const host = createFleetPluginHost({
+      cwd: dir,
+      homeDir: "/missing",
+      bundleCacheDir: cacheDir,
+      isProcessAlive: (pid) => pid === 4242,
+      routes: new RouteRegistry(),
+      upgrades: new UpgradeRegistry(),
+      host: noopHostCapabilities,
+    });
+    await host.boot();
+
+    expect(fs.existsSync(activeDir)).toBe(true);
+    expect(fs.existsSync(staleDir)).toBe(false);
+    expect(fs.existsSync(invalidOwnerDir)).toBe(false);
+  });
+
+  it("retains failed bundle removals for a later cleanup retry", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-plugin-cache-retry-"));
+    tempDirs.push(dir);
+    const pluginRoot = path.join(dir, "home", ".fleet", "plugins", "note");
+    const cacheDir = path.join(dir, "console-data", "plugin-cache");
+    writePlugin(pluginRoot, "note", { apiVersion: 1 });
+    fs.writeFileSync(path.join(pluginRoot, "routes.ts"), "export function register() {}\n");
+    let failRemoval = true;
+    const host = createFleetPluginHost({
+      cwd: dir,
+      homeDir: path.join(dir, "home"),
+      bundleCacheDir: cacheDir,
+      removeBundleDir: async (target) => {
+        if (failRemoval) throw new Error("remove failed");
+        await fsPromises.rm(target, { recursive: true, force: true });
+      },
+      routes: new RouteRegistry(),
+      upgrades: new UpgradeRegistry(),
+      host: noopHostCapabilities,
+    });
+    await host.boot();
+    const [generatedDir] = fs.readdirSync(cacheDir).filter((entry) => entry.startsWith("fleet-console-plugin-"));
+
+    await host.cleanup();
+
+    expect(fs.existsSync(path.join(cacheDir, generatedDir!))).toBe(true);
+    failRemoval = false;
+    await host.cleanup();
+    expect(fs.readdirSync(cacheDir)).toEqual([]);
   });
 
   it("discovers built-in and home plugins while excluding shared", () => {

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -547,6 +547,29 @@ describe("console static and terminal ticket boundary", () => {
     }
   });
 
+  it("cleans stale plugin bundles on startup and this run's bundles on server stop", async () => {
+    const pluginPackage = createPluginPackageRoot({
+      demoRoutes: "export function register() {}",
+      demoRoutesFile: "routes.ts",
+    });
+    const fixture = await startFixture({
+      release: pluginPackage.release,
+      beforeCreateServer: ({ carrierStoreDir }) => {
+        const staleBundleDir = path.join(carrierStoreDir, "console", "plugin-cache", "fleet-console-plugin-crashed");
+        fs.mkdirSync(staleBundleDir, { recursive: true });
+        fs.writeFileSync(path.join(staleBundleDir, "routes.mjs"), "stale");
+      },
+    });
+    const cacheDir = path.join(fixture.carrierStoreDir, "console", "plugin-cache");
+
+    expect(fs.existsSync(path.join(cacheDir, "fleet-console-plugin-crashed"))).toBe(false);
+    expect(fs.readdirSync(cacheDir).filter((entry) => entry.startsWith("fleet-console-plugin-"))).not.toEqual([]);
+
+    await fixture.server.stop();
+
+    expect(fs.readdirSync(cacheDir)).toEqual([]);
+  });
+
   it.skip("keeps MCP bearer tokens out of terminal tickets, observer snapshots, SSE frames, static HTML, and launch errors", async () => {
     const fakeToken = "mcp-token-seeded-secret";
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-token-boundary-"));
@@ -2072,7 +2095,7 @@ function createStubAgentCliDetector(overrides: Record<string, boolean> = {}): Ag
   };
 }
 
-function createPluginPackageRoot(options: { readonly demoRoutes: string }): { readonly release: ConsoleServerDeps["release"] } {
+function createPluginPackageRoot(options: { readonly demoRoutes: string; readonly demoRoutesFile?: "routes.mjs" | "routes.ts" }): { readonly release: ConsoleServerDeps["release"] } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-plugin-package-"));
   tempDirs.push(dir);
   const packageRoot = path.join(dir, "runtime", "fleet-console");
@@ -2081,15 +2104,15 @@ function createPluginPackageRoot(options: { readonly demoRoutes: string }): { re
     "export function register(ctx) {",
     "}",
   ].join("\n"));
-  writeTestPlugin(path.join(pluginsRoot, "demo"), "demo", options.demoRoutes);
+  writeTestPlugin(path.join(pluginsRoot, "demo"), "demo", options.demoRoutes, options.demoRoutesFile);
   fs.mkdirSync(packageRoot, { recursive: true });
   return { release: { channel: "local", version: "test", packageRoot } };
 }
 
-function writeTestPlugin(pluginRoot: string, id: string, routes: string): void {
+function writeTestPlugin(pluginRoot: string, id: string, routes: string, routesFile: "routes.mjs" | "routes.ts" = "routes.mjs"): void {
   fs.mkdirSync(pluginRoot, { recursive: true });
-  fs.writeFileSync(path.join(pluginRoot, "plugin.json"), JSON.stringify({ id, routes: "routes.mjs" }));
-  fs.writeFileSync(path.join(pluginRoot, "routes.mjs"), routes);
+  fs.writeFileSync(path.join(pluginRoot, "plugin.json"), JSON.stringify({ id, routes: routesFile }));
+  fs.writeFileSync(path.join(pluginRoot, routesFile), routes);
 }
 
 function createDeferred<T>(): { readonly promise: Promise<T>; resolve(value: T): void; reject(error: unknown): void } {


### PR DESCRIPTION
## Summary

- remove stale Fleet Console plugin bundles during startup while preserving bundles owned by active processes
- clean bundles created by the current Console run during graceful shutdown with best-effort retry semantics
- add focused lifecycle, concurrency, and cleanup regression coverage

## Type of Change

- [x] fix — bug fix

## Scope

- [x] `runtime/fleet-console`

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/plugin-host.test.ts tests/server.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit -p tsconfig.json`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `git diff --check`

## Changelog

- [x] Added `.changelog.d/plugin-cache-lifecycle-cleanup.md`.
- [x] Fragment uses `section: Fixed` and the `[fleet-console]` tag.

## Notes for Reviewers

- Cache ownership uses PID markers so concurrent Console startups do not delete each other's active bundles.
- Prebuilt `.mjs` plugin routes continue to bypass bundle-cache generation.