### PR TITLE
fix(fleet-console): apply hook panel names once

### DIFF
--- a/.changelog.d/panel-auto-name-once.md
+++ b/.changelog.d/panel-auto-name-once.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+- [fleet-console] Hook-provided panel names now apply only once per running panel while preserving operator renames.
+  ko: 이제 Hook이 제공하는 패널 이름은 실행 중인 패널마다 한 번만 적용되며 사용자가 변경한 이름은 그대로 유지됩니다.

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -220,7 +220,7 @@ describe("console terminal observability", () => {
     expect(JSON.stringify(renamed)).not.toContain(dir);
   });
 
-  it("auto-names on every user prompt when the operator has not set a label", () => {
+  it("auto-names only the first valid user prompt and keeps the decision in memory", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-autoname-"));
     tempDirs.push(dir);
     const store = createConsoleObservabilityStore();
@@ -232,12 +232,12 @@ describe("console terminal observability", () => {
     expect(first?.session.label).toBe("Fix the login redirect bug");
     expect(store.listDurableOperations()[0]).toMatchObject({ label: "Fix the login redirect bug", labelSource: "auto" });
 
-    // 두 번째 프롬프트도 다른 라벨이면 auto 갱신이 허용된다.
-    expect(store.autoNameTerminalSession("session-a", "Add the search index")).toMatchObject({ renamed: true });
-    expect(store.listDurableOperations()[0]?.label).toBe("Add the search index");
+    // 두 번째 프롬프트부터는 다른 라벨이어도 최초 자동 작명을 유지한다.
+    expect(store.autoNameTerminalSession("session-a", "Add the search index")).toMatchObject({ renamed: false });
+    expect(store.listDurableOperations()[0]?.label).toBe("Fix the login redirect bug");
 
     // 동일 라벨은 no-op.
-    expect(store.autoNameTerminalSession("session-a", "Add the search index")).toMatchObject({ renamed: false });
+    expect(store.autoNameTerminalSession("session-a", "Fix the login redirect bug")).toMatchObject({ renamed: false });
 
     // 사용자가 수동 rename → labelSource "user" 기록.
     store.renameTerminalSession("session-a", "Bridge Watch");
@@ -246,12 +246,13 @@ describe("console terminal observability", () => {
     expect(store.autoNameTerminalSession("session-a", "A brand new prompt topic")).toMatchObject({ renamed: false });
     expect(store.listDurableOperations()[0]?.label).toBe("Bridge Watch");
 
-    // 빈 rename은 label·labelSource를 비워 다음 프롬프트 자동 작명을 재활성화한다.
+    // 빈 rename은 label·labelSource를 비우지만 인메모리 최초 처리 상태는 유지한다.
     store.renameTerminalSession("session-a", "   ");
     const cleared = store.listDurableOperations()[0];
     expect(cleared?.label).toBeUndefined();
     expect(cleared?.labelSource).toBeUndefined();
-    expect(store.autoNameTerminalSession("session-a", "Re-enabled auto label")?.session.label).toBe("Re-enabled auto label");
+    expect(store.autoNameTerminalSession("session-a", "Re-enabled auto label")).toMatchObject({ renamed: false });
+    expect(JSON.stringify(cleared)).not.toContain("autoNamePromptSeen");
   });
 
   it("treats a null or empty prompt as a no-op that does not block subsequent auto-names", () => {

--- a/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
@@ -52,6 +52,7 @@ interface PendingTerminalSessionState {
   readonly cwdLabel: string;
   label?: string;
   labelSource?: AgentLabelSource;
+  autoNamePromptSeen?: boolean;
   cliId?: string;
   cliLabel?: string;
   readonly createdAt: number;
@@ -316,20 +317,22 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
     return toTerminalSessionInfo(session);
   }
 
-  // 자동 작명: 사용자 수동 라벨(labelSource "user")이 없는 세션에만 적용한다.
+  // 자동 작명: 사용자 수동 라벨(labelSource "user")이 없는 세션의 첫 유효 프롬프트에만 적용한다.
   // labelSource 미설정 레거시 세션은 label 유무로 보수 해석해 기존 사용자 라벨을 보호한다.
-  // 매 UserPromptSubmit마다 호출되며, 실제 라벨 변경이 있을 때만 patch/persist된다.
+  // 처리 여부는 패널의 인메모리 상태에만 남기며 durable operation에는 포함하지 않는다.
   function autoNameTerminalSession(sessionId: string, label: string | null): AutoNameTerminalSessionResult | null {
     const session = terminalSessionsById.get(sessionId);
     if (!session) return null;
     const effectiveSource: AgentLabelSource | undefined = session.labelSource ?? (session.label ? "user" : undefined);
-    if (effectiveSource === "user") {
+    if (effectiveSource === "user" || session.autoNamePromptSeen) {
       return { session: toTerminalSessionInfo(session), renamed: false };
     }
     const next = label?.trim().slice(0, 200) ?? "";
-    if (next.length === 0 || next === session.label) {
+    if (next.length === 0) {
       return { session: toTerminalSessionInfo(session), renamed: false };
     }
+    session.autoNamePromptSeen = true;
+    if (next === session.label) return { session: toTerminalSessionInfo(session), renamed: false };
     session.label = next;
     session.labelSource = "auto";
     return { session: toTerminalSessionInfo(session), renamed: true };


### PR DESCRIPTION
## Summary
- apply a Hook-provided panel name only for the first valid prompt in a panel runtime
- keep the one-shot decision in memory while preserving operator renames
- add regression coverage and a Fleet Console changelog fragment

## Type of Change
- [x] fix — bug fix

## Scope
- [x] Fleet Console Terminal plugin runtime

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/server.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] isolated headed browser E2E: first Hook rename, operator rename, second Hook ignored
- [x] `node scripts/compile-changelog-fragments.mjs --check`

## Changelog
- [x] Added one `.changelog.d/*.md` fragment.
- [x] Fragment `section:` is `Fixed`.
- [x] Fragment uses the supported `[fleet-console]` tag with English and Korean summaries.