### PR TITLE
fix(fleet-console): decouple command band background from canvas ramp

### DIFF
--- a/.changelog.d/command-band-legacy-theme-band-surface.md
+++ b/.changelog.d/command-band-legacy-theme-band-surface.md
@@ -1,0 +1,6 @@
+---
+section: Fixed
+---
+
+- [fleet-console] Command Band background now follows each theme's chrome palette, fixing the overly dark center and right segments in the Maritime and Carbon themes.
+  ko: Command Band 배경이 테마별 크롬 팔레트를 따르도록 바로잡아 Maritime·Carbon 테마에서 중앙·우측 구간이 지나치게 어둡던 문제를 해결했습니다.

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -26,7 +26,7 @@
   height: var(--chrome-band-height);
   min-height: var(--chrome-band-height);
   border-bottom: 1px solid var(--surface-rim);
-  background: var(--canvas-sea-core);
+  background: var(--surface-band);
 }
 
 .command-band.is-utility {
@@ -51,7 +51,7 @@
 
 .command-band-left.is-collapsed {
   border-color: transparent;
-  background: var(--canvas-sea-core);
+  background: var(--surface-band);
 }
 
 .command-band.is-utility .command-band-left {

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -59,6 +59,7 @@
   --surface-pillar: var(--ink-veil);
   --surface-rim: var(--hairline);
   --surface-rim-strong: var(--hairline-strong);
+  --surface-band: var(--canvas-sea-core);
 
   --identity-file-code: var(--aurora);
   --identity-file-markup: var(--brass);
@@ -155,6 +156,7 @@
   --surface-pillar: oklch(22% 0.05 248 / 86%);
   --surface-rim: oklch(64% 0.04 248 / 24%);
   --surface-rim-strong: oklch(72% 0.05 248 / 38%);
+  --surface-band: var(--ink-deep);
 
   --hairline: oklch(36% 0.035 248);
   --hairline-strong: oklch(48% 0.03 248);
@@ -197,6 +199,7 @@
   --surface-pillar: oklch(20% 0.008 252 / 88%);
   --surface-rim: oklch(62% 0.006 252 / 22%);
   --surface-rim-strong: oklch(70% 0.007 252 / 36%);
+  --surface-band: var(--ink-deep);
 
   --hairline: oklch(33% 0.006 252);
   --hairline-strong: oklch(45% 0.005 252);


### PR DESCRIPTION
## Summary
- Command Band(전 라우트 상단 44px 크롬) 배경을 캔버스 심도 토큰 `--canvas-sea-core` 직결에서 신규 팔레트 토큰 `--surface-band`로 분리했습니다.
- Instrument는 `--surface-band: var(--canvas-sea-core)`로 기존 렌더와 동일하고, Maritime/Carbon은 각 테마의 `var(--ink-deep)`로 오버라이드해 레거시 테마에서 밴드 center/right가 크롬 램프 대비 과도하게 어둡게 렌더되던 문제를 해결했습니다.
- 토큰명은 디자인 계약 테스트의 레거시 테마 블록 프리픽스 화이트리스트(`surface` 허용)에 맞춘 선택입니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 75 files / 704 passed
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK
- [x] headed 실측(격리 인스턴스, 3테마 픽셀 샘플링): Instrument 무변경 (4,8,13), Maritime (3,13,21)→(8,23,40), Carbon (8,11,16)→(16,18,20) — 두 레거시 테마 모두 좌측 glass 대비 Instrument와 동일한 투톤 관계 복원

## Changelog
- [x] `.changelog.d/command-band-legacy-theme-band-surface.md` (Fixed, `[fleet-console]`)