### PR TITLE
fix(fleet-console): restore recursive filter and history resizing

### DIFF
--- a/.changelog.d/fix-plugin-filter-history-drag.md
+++ b/.changelog.d/fix-plugin-filter-history-drag.md
@@ -1,0 +1,5 @@
+---
+section: Fixed
+---
+- [fleet-console] Search unopened File Explorer folders recursively and resize History detail panes by dragging.
+  ko: 열지 않은 File Explorer 폴더를 재귀적으로 검색하고 드래그로 History 상세 패널 크기를 조절합니다.

--- a/runtime/fleet-plugins/diff/client/diff.css
+++ b/runtime/fleet-plugins/diff/client/diff.css
@@ -621,10 +621,17 @@
   min-height: 0;
   overflow: hidden;
   container-type: inline-size;
+  transition: grid-template-columns var(--duration-base) var(--ease-spring);
 }
 
-.history-root.has-detail {
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.4fr);
+@media (prefers-reduced-motion: reduce) {
+  .history-root {
+    transition-duration: 0.01ms;
+  }
+}
+
+.history-root.is-dragging {
+  transition: none;
 }
 
 .history-list-pane,
@@ -640,8 +647,19 @@
   grid-template-rows: auto minmax(0, 1fr);
 }
 
-.history-root.has-detail .history-list-pane {
-  grid-column: 2;
+.history-divider {
+  width: 4px;
+  cursor: col-resize;
+  background: var(--surface-rim);
+  transition: background 140ms;
+}
+
+.history-divider:hover {
+  background: color-mix(in oklch, var(--brass) 50%, transparent);
+}
+
+.history-divider:active {
+  background: color-mix(in oklch, var(--brass) 80%, transparent);
 }
 
 .history-toolbar {

--- a/runtime/fleet-plugins/diff/client/history-panel.tsx
+++ b/runtime/fleet-plugins/diff/client/history-panel.tsx
@@ -9,6 +9,7 @@ import { layoutGraph } from "./graph-layout.js";
 import type { CommitSelection } from "./hunk-view.js";
 import { HunkView } from "./hunk-view.js";
 import { formatCommitTime, refBadges } from "./log-parse.js";
+import { DIFF_DIVIDER_WIDTH, HISTORY_DETAIL_PANE_MIN_WIDTH, buildHistoryGridTemplate, clampListPaneWidth, installPointerDragLifecycle } from "./rail-layout.js";
 
 type LoadState =
   | { readonly kind: "loading" }
@@ -30,6 +31,9 @@ interface CommitRowProps {
 }
 
 const EXTENDED_EXTRA_WIDTH = 400;
+const PREFS_LIST_PANE_WIDTH = "fleet-console.history.listPaneWidth";
+const LIST_PANE_DEFAULT_WIDTH = 360;
+const LIST_PANE_MIN_WIDTH = 220;
 
 export function findDetachedCheckout(entry: LogCommitEntry, checkouts: readonly WorktreeCheckout[]): WorktreeCheckout | null {
   return checkouts.find((checkout) => checkout.branch === null && checkout.sha === entry.fullHash) ?? null;
@@ -71,7 +75,12 @@ function HistoryPanelBody({ ctx }: HistoryPanelProps) {
   const [selectedCommit, setSelectedCommit] = useState<CommitSelection | null>(null);
   const [filterText, setFilterText] = useState("");
   const [refreshToken, setRefreshToken] = useState(0);
+  const [listPaneWidth, setListPaneWidth] = useState(readListPaneWidth);
   const fetchSeqRef = useRef(0);
+  const listPaneWidthRef = useRef(listPaneWidth);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const dragDisposeRef = useRef<(() => void) | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
   const subPath = ctx.pathContext.relPath ?? "";
 
   useEffect(() => {
@@ -100,13 +109,42 @@ function HistoryPanelBody({ ctx }: HistoryPanelProps) {
     return () => ctx.requestExtraWidth?.(null);
   }, [ctx.requestExtraWidth, selectedCommit]);
 
+  useEffect(() => () => {
+    dragDisposeRef.current?.();
+    dragDisposeRef.current = null;
+  }, []);
+
   const handleSelectCommit = useCallback((entry: LogCommitEntry) => {
     if (ctx.theaterId) setSelectedCommit({ commit: entry, subPath, theaterId: ctx.theaterId });
   }, [ctx.theaterId, subPath]);
+  const handleDividerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const container = rootRef.current;
+    if (!container) return;
+    const containerWidth = container.getBoundingClientRect().width;
+    const startX = event.clientX;
+    const startWidth = listPaneWidthRef.current;
+    dragDisposeRef.current?.();
+    setIsDragging(true);
+    const onMove = (event: Event) => {
+      const move = event as PointerEvent;
+      const next = clampListPaneWidth({ startWidth, dx: move.clientX - startX, containerWidth, listPaneMinWidth: LIST_PANE_MIN_WIDTH, hunkPaneMinWidth: HISTORY_DETAIL_PANE_MIN_WIDTH, dividerWidth: DIFF_DIVIDER_WIDTH });
+      if (next !== null) {
+        listPaneWidthRef.current = next;
+        setListPaneWidth(next);
+      }
+    };
+    const onFinish = () => {
+      dragDisposeRef.current = null;
+      setIsDragging(false);
+      try { localStorage.setItem(PREFS_LIST_PANE_WIDTH, String(listPaneWidthRef.current)); } catch { /* ignore */ }
+    };
+    dragDisposeRef.current = installPointerDragLifecycle({ documentTarget: document, windowTarget: window, onMove, onFinish });
+  }, []);
   const visibleCommits = useMemo(() => state.kind === "ok" ? filterHistoryCommits(state.commits, filterText) : [], [filterText, state]);
   const layout = state.kind === "ok" ? layoutGraph(visibleCommits) : null;
   const countLabel = state.kind === "ok" ? filterText ? `${visibleCommits.length}/${state.commits.length}` : String(state.commits.length) : null;
-  return <div className={`history-root${selectedCommit ? " has-detail" : ""}`}>{selectedCommit ? <div className="history-detail-pane"><div className="history-detail-head"><span className="history-detail-sha">{selectedCommit.commit.shortHash}</span><span className="history-detail-subject">{selectedCommit.commit.subject}</span><button type="button" className="history-detail-close" aria-label="Close commit diff" onClick={() => setSelectedCommit(null)}>✕</button></div><div className="history-detail-body"><HunkView ctx={ctx} file={{ path: "", status: "M", additions: 0, deletions: 0 }} mode="unified" subPath={selectedCommit.subPath} commit={selectedCommit} /></div></div> : null}<div className="history-list-pane"><div className="history-toolbar"><div className="history-filter"><input type="text" className="history-filter-input" placeholder="Filter…" aria-label="Filter commits" value={filterText} onChange={(event) => setFilterText(event.target.value)} />{filterText ? <button type="button" className="history-filter-clear" aria-label="Clear filter" onClick={() => setFilterText("")}>✕</button> : null}</div>{countLabel ? <span className="history-count">{countLabel}</span> : null}</div><div className="history-list">{state.kind === "loading" ? <div className="history-empty">Loading…</div> : null}{state.kind === "error" ? <div className="history-error"><span>{state.message}</span><button type="button" className="diff-refresh-btn" onClick={() => setRefreshToken((value) => value + 1)}>Retry</button></div> : null}{state.kind === "ok" && state.commits.length === 0 ? <div className="history-empty">No history</div> : null}{state.kind === "ok" && state.commits.length > 0 && visibleCommits.length === 0 ? <div className="history-empty">No matching items</div> : null}{state.kind === "ok" && layout ? visibleCommits.map((entry, index) => <CommitRow key={entry.fullHash} entry={entry} checkouts={state.checkouts} selected={selectedCommit?.commit.fullHash === entry.fullHash} graphNode={layout.nodes[index]!} laneCount={layout.activeLaneCount} layoutCollapsed={layout.collapsed} onSelect={handleSelectCommit} />) : null}{state.kind === "ok" && (state.truncated || state.commits.length >= 200) ? <div className="history-truncated">History capped at 200 commits.</div> : null}</div></div></div>;
+  return <div ref={rootRef} className={`history-root${selectedCommit ? " has-detail" : ""}${isDragging ? " is-dragging" : ""}`} style={selectedCommit ? { gridTemplateColumns: buildHistoryGridTemplate(listPaneWidth) } : undefined}>{selectedCommit ? <div className="history-detail-pane"><div className="history-detail-head"><span className="history-detail-sha">{selectedCommit.commit.shortHash}</span><span className="history-detail-subject">{selectedCommit.commit.subject}</span><button type="button" className="history-detail-close" aria-label="Close commit diff" onClick={() => setSelectedCommit(null)}>✕</button></div><div className="history-detail-body"><HunkView ctx={ctx} file={{ path: "", status: "M", additions: 0, deletions: 0 }} mode="unified" subPath={selectedCommit.subPath} commit={selectedCommit} /></div></div> : null}{selectedCommit ? <div className="history-divider" onPointerDown={handleDividerDown} aria-hidden="true" /> : null}<div className="history-list-pane"><div className="history-toolbar"><div className="history-filter"><input type="text" className="history-filter-input" placeholder="Filter…" aria-label="Filter commits" value={filterText} onChange={(event) => setFilterText(event.target.value)} />{filterText ? <button type="button" className="history-filter-clear" aria-label="Clear filter" onClick={() => setFilterText("")}>✕</button> : null}</div>{countLabel ? <span className="history-count">{countLabel}</span> : null}</div><div className="history-list">{state.kind === "loading" ? <div className="history-empty">Loading…</div> : null}{state.kind === "error" ? <div className="history-error"><span>{state.message}</span><button type="button" className="diff-refresh-btn" onClick={() => setRefreshToken((value) => value + 1)}>Retry</button></div> : null}{state.kind === "ok" && state.commits.length === 0 ? <div className="history-empty">No history</div> : null}{state.kind === "ok" && state.commits.length > 0 && visibleCommits.length === 0 ? <div className="history-empty">No matching items</div> : null}{state.kind === "ok" && layout ? visibleCommits.map((entry, index) => <CommitRow key={entry.fullHash} entry={entry} checkouts={state.checkouts} selected={selectedCommit?.commit.fullHash === entry.fullHash} graphNode={layout.nodes[index]!} laneCount={layout.activeLaneCount} layoutCollapsed={layout.collapsed} onSelect={handleSelectCommit} />) : null}{state.kind === "ok" && (state.truncated || state.commits.length >= 200) ? <div className="history-truncated">History capped at 200 commits.</div> : null}</div></div></div>;
 }
 
 function HistoryIcon() {
@@ -120,3 +158,12 @@ export const historyPanel: RailPanelDescriptor = {
   pathAware: true,
   render: (ctx: RailPanelContext) => <HistoryPanel ctx={ctx} />,
 };
+
+function readListPaneWidth(): number {
+  try {
+    const value = localStorage.getItem(PREFS_LIST_PANE_WIDTH);
+    const width = value === null ? NaN : Number.parseFloat(value);
+    if (Number.isFinite(width) && width > 0) return Math.max(LIST_PANE_MIN_WIDTH, width);
+  } catch { /* ignore */ }
+  return LIST_PANE_DEFAULT_WIDTH;
+}

--- a/runtime/fleet-plugins/diff/client/rail-layout.ts
+++ b/runtime/fleet-plugins/diff/client/rail-layout.ts
@@ -9,9 +9,22 @@ interface ListPaneWidthInput {
   readonly dividerWidth: number;
 }
 
+interface PointerDragEventTarget {
+  addEventListener(type: string, listener: (event: Event) => void): void;
+  removeEventListener(type: string, listener: (event: Event) => void): void;
+}
+
+interface PointerDragLifecycleInput {
+  readonly documentTarget: PointerDragEventTarget;
+  readonly windowTarget: PointerDragEventTarget;
+  readonly onMove: (event: Event) => void;
+  readonly onFinish: () => void;
+}
+
 // ─── 상수 ────────────────────────────────────────────────────────────────────
 
 export const HUNK_PANE_MIN_WIDTH = 140;
+export const HISTORY_DETAIL_PANE_MIN_WIDTH = 140;
 export const DIFF_DIVIDER_WIDTH = 4;
 
 const NO_OP_SENTINEL = null;
@@ -34,4 +47,36 @@ export function clampListPaneWidth({
 export function buildDiffGridTemplate(listPaneWidth: number): string {
   const preservedLeftWidth = HUNK_PANE_MIN_WIDTH + DIFF_DIVIDER_WIDTH;
   return `minmax(0, 1fr) ${DIFF_DIVIDER_WIDTH}px minmax(0, min(${listPaneWidth}px, calc(100% - ${preservedLeftWidth}px)))`;
+}
+
+export function buildHistoryGridTemplate(listPaneWidth: number): string {
+  const preservedLeftWidth = HISTORY_DETAIL_PANE_MIN_WIDTH + DIFF_DIVIDER_WIDTH;
+  return `minmax(0, 1fr) ${DIFF_DIVIDER_WIDTH}px minmax(0, min(${listPaneWidth}px, calc(100% - ${preservedLeftWidth}px)))`;
+}
+
+export function installPointerDragLifecycle({ documentTarget, windowTarget, onMove, onFinish }: PointerDragLifecycleInput): () => void {
+  let active = true;
+  const removeListeners = () => {
+    documentTarget.removeEventListener("pointermove", onMove);
+    documentTarget.removeEventListener("pointerup", finish);
+    documentTarget.removeEventListener("pointercancel", finish);
+    windowTarget.removeEventListener("blur", finish);
+  };
+  const finish = () => {
+    if (!active) return;
+    active = false;
+    removeListeners();
+    onFinish();
+  };
+  const dispose = () => {
+    if (!active) return;
+    active = false;
+    removeListeners();
+  };
+
+  documentTarget.addEventListener("pointermove", onMove);
+  documentTarget.addEventListener("pointerup", finish);
+  documentTarget.addEventListener("pointercancel", finish);
+  windowTarget.addEventListener("blur", finish);
+  return dispose;
 }

--- a/runtime/fleet-plugins/diff/tests/rail-layout.test.ts
+++ b/runtime/fleet-plugins/diff/tests/rail-layout.test.ts
@@ -2,10 +2,35 @@ import { describe, expect, it } from "vitest";
 
 import {
   DIFF_DIVIDER_WIDTH,
+  HISTORY_DETAIL_PANE_MIN_WIDTH,
   HUNK_PANE_MIN_WIDTH,
   buildDiffGridTemplate,
+  buildHistoryGridTemplate,
   clampListPaneWidth,
+  installPointerDragLifecycle,
 } from "../client/rail-layout.js";
+
+class FakeEventTarget {
+  private readonly listeners = new Map<string, Set<(event: Event) => void>>();
+
+  addEventListener(type: string, listener: (event: Event) => void): void {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: (event: Event) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  dispatch(type: string): void {
+    for (const listener of this.listeners.get(type) ?? []) listener({ type } as Event);
+  }
+
+  listenerCount(type: string): number {
+    return this.listeners.get(type)?.size ?? 0;
+  }
+}
 
 describe("clampListPaneWidth", () => {
   it("keeps the right list pane at its px width when the divider does not move", () => {
@@ -59,5 +84,79 @@ describe("buildDiffGridTemplate", () => {
     expect(buildDiffGridTemplate(568)).toBe(
       `minmax(0, 1fr) ${DIFF_DIVIDER_WIDTH}px minmax(0, min(568px, calc(100% - ${preservedLeftWidth}px)))`,
     );
+  });
+});
+
+describe("History detail/list layout", () => {
+  it("clamps the history list to preserve the detail pane minimum", () => {
+    expect(clampListPaneWidth({
+      startWidth: 360,
+      dx: -600,
+      containerWidth: 712,
+      listPaneMinWidth: 220,
+      hunkPaneMinWidth: HISTORY_DETAIL_PANE_MIN_WIDTH,
+      dividerWidth: DIFF_DIVIDER_WIDTH,
+    })).toBe(568);
+  });
+
+  it("builds a history grid that preserves the detail pane while honoring the stored list width", () => {
+    const preservedDetailWidth = HISTORY_DETAIL_PANE_MIN_WIDTH + DIFF_DIVIDER_WIDTH;
+    expect(buildHistoryGridTemplate(360)).toBe(
+      `minmax(0, 1fr) ${DIFF_DIVIDER_WIDTH}px minmax(0, min(360px, calc(100% - ${preservedDetailWidth}px)))`,
+    );
+  });
+});
+
+describe("installPointerDragLifecycle", () => {
+  it.each(["pointerup", "pointercancel"])("cleans every listener and finishes once on %s", (terminalEvent) => {
+    const documentTarget = new FakeEventTarget();
+    const windowTarget = new FakeEventTarget();
+    let moves = 0;
+    let finishes = 0;
+
+    installPointerDragLifecycle({ documentTarget, windowTarget, onMove: () => { moves += 1; }, onFinish: () => { finishes += 1; } });
+    documentTarget.dispatch("pointermove");
+    documentTarget.dispatch(terminalEvent);
+    documentTarget.dispatch("pointermove");
+    documentTarget.dispatch("pointerup");
+    windowTarget.dispatch("blur");
+
+    expect(moves).toBe(1);
+    expect(finishes).toBe(1);
+    expect(documentTarget.listenerCount("pointermove")).toBe(0);
+    expect(documentTarget.listenerCount("pointerup")).toBe(0);
+    expect(documentTarget.listenerCount("pointercancel")).toBe(0);
+    expect(windowTarget.listenerCount("blur")).toBe(0);
+  });
+
+  it("finishes and removes listeners when the window blurs", () => {
+    const documentTarget = new FakeEventTarget();
+    const windowTarget = new FakeEventTarget();
+    let finishes = 0;
+
+    installPointerDragLifecycle({ documentTarget, windowTarget, onMove: () => {}, onFinish: () => { finishes += 1; } });
+    windowTarget.dispatch("blur");
+
+    expect(finishes).toBe(1);
+    expect(documentTarget.listenerCount("pointermove")).toBe(0);
+    expect(windowTarget.listenerCount("blur")).toBe(0);
+  });
+
+  it("removes listeners without finishing when disposed during unmount", () => {
+    const documentTarget = new FakeEventTarget();
+    const windowTarget = new FakeEventTarget();
+    let moves = 0;
+    let finishes = 0;
+
+    const dispose = installPointerDragLifecycle({ documentTarget, windowTarget, onMove: () => { moves += 1; }, onFinish: () => { finishes += 1; } });
+    dispose();
+    documentTarget.dispatch("pointermove");
+    documentTarget.dispatch("pointercancel");
+    windowTarget.dispatch("blur");
+
+    expect(moves).toBe(0);
+    expect(finishes).toBe(0);
+    expect(documentTarget.listenerCount("pointermove")).toBe(0);
+    expect(windowTarget.listenerCount("blur")).toBe(0);
   });
 });

--- a/runtime/fleet-plugins/file-explorer/client/tree.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/tree.tsx
@@ -26,33 +26,68 @@ interface FlatRow {
   readonly isLoading: boolean;
 }
 
+interface FilterDescendantLoadOptions {
+  readonly entries: readonly FolderEntry[];
+  readonly cachedResults: ReadonlyMap<string, FolderListResult>;
+  readonly files: PluginFilesClient;
+  readonly showHidden: boolean;
+  readonly isCurrent: () => boolean;
+  readonly onFolderResult: (relativePath: string, result: FolderListResult) => void;
+}
+
 const VIRTUALIZE_THRESHOLD = 200;
 const ROW_HEIGHT = 30;
 const OVERSCAN = 5;
 const PREFS_SHOW_HIDDEN = "fleet-console.fileExplorer.showHidden";
+export const FILTER_DIRECTORY_CAP = 500;
 
 export function isCurrentContextRequest(requestContextKey: string, currentContextKey: string): boolean {
   return requestContextKey === currentContextKey;
 }
 
-function hasFilterMatch(
-  entries: readonly FolderEntry[],
-  childResults: Map<string, FolderListResult>,
-  low: string,
-  showHidden: boolean,
-): boolean {
-  for (const e of entries) {
-    if (!showHidden && e.name.startsWith(".")) continue;
-    if (e.name.toLowerCase().includes(low)) return true;
-    if (e.kind === "dir") {
-      const children = childResults.get(e.relativePath)?.entries;
-      if (children && hasFilterMatch(children, childResults, low, showHidden)) return true;
+export async function loadFilterDescendants({ entries, cachedResults, files, showHidden, isCurrent, onFolderResult }: FilterDescendantLoadOptions): Promise<void> {
+  const pending: FolderEntry[] = [];
+  const knownResults = new Map(cachedResults);
+  const queuedPaths = new Set<string>();
+  const visitedFolders = new Set<string>();
+  let requestCount = 0;
+  const enqueue = (candidates: readonly FolderEntry[]) => {
+    for (const candidate of candidates) {
+      if (!isVisibleDirectory(candidate, showHidden) || queuedPaths.has(candidate.relativePath)) continue;
+      if (queuedPaths.size >= FILTER_DIRECTORY_CAP) return;
+      queuedPaths.add(candidate.relativePath);
+      pending.push(candidate);
+    }
+  };
+
+  enqueue(entries);
+  while (pending.length > 0 && isCurrent()) {
+    const entry = pending.shift();
+    if (!entry) return;
+    const cached = knownResults.get(entry.relativePath);
+    if (cached) {
+      if (visitedFolders.has(cached.relativePath)) continue;
+      visitedFolders.add(cached.relativePath);
+      enqueue(cached.entries);
+      continue;
+    }
+    if (requestCount >= FILTER_DIRECTORY_CAP) return;
+    requestCount += 1;
+    try {
+      const result = await files.listFolder(entry.relativePath);
+      if (!isCurrent()) return;
+      knownResults.set(entry.relativePath, result);
+      onFolderResult(entry.relativePath, result);
+      if (visitedFolders.has(result.relativePath)) continue;
+      visitedFolders.add(result.relativePath);
+      enqueue(result.entries);
+    } catch {
+      // 권한 오류나 사라진 폴더는 해당 하위 트리만 건너뛴다.
     }
   }
-  return false;
 }
 
-function buildFlatRows(
+export function buildFlatRows(
   entries: readonly FolderEntry[],
   depth: number,
   selectedPath: string | null,
@@ -61,31 +96,33 @@ function buildFlatRows(
   childResults: Map<string, FolderListResult>,
   low: string,
   showHidden: boolean,
+  ancestorFolders: ReadonlySet<string> = new Set(),
 ): FlatRow[] {
   const rows: FlatRow[] = [];
   for (const entry of entries) {
     if (!showHidden && entry.name.startsWith(".")) continue;
+    const childResult = childResults.get(entry.relativePath);
+    const children = childResult?.entries;
+    const folderIdentity = childResult?.relativePath ?? entry.relativePath;
+    const isCycle = entry.kind === "dir" && ancestorFolders.has(folderIdentity);
+    const childMatch = entry.kind === "dir" && !isCycle && hasFilterMatch(children ?? [], childResults, low, showHidden);
     if (low) {
       const directMatch = entry.name.toLowerCase().includes(low);
-      const childMatch = entry.kind === "dir" && hasFilterMatch(
-        childResults.get(entry.relativePath)?.entries ?? [],
-        childResults,
-        low,
-        showHidden,
-      );
       if (!directMatch && !childMatch) continue;
     }
+    const isExpanded = expandedDirs.has(entry.relativePath) || Boolean(low && childMatch);
     rows.push({
       entry,
       depth,
       isSelected: selectedPath === entry.relativePath,
-      isExpanded: expandedDirs.has(entry.relativePath),
+      isExpanded,
       isLoading: loadingDirs.has(entry.relativePath),
     });
-    if (entry.kind === "dir" && expandedDirs.has(entry.relativePath)) {
-      const children = childResults.get(entry.relativePath)?.entries;
+    if (entry.kind === "dir" && isExpanded && !isCycle) {
       if (children) {
-        rows.push(...buildFlatRows(children, depth + 1, selectedPath, expandedDirs, loadingDirs, childResults, low, showHidden));
+        const nextAncestorFolders = new Set(ancestorFolders);
+        nextAncestorFolders.add(folderIdentity);
+        rows.push(...buildFlatRows(children, depth + 1, selectedPath, expandedDirs, loadingDirs, childResults, low, showHidden, nextAncestorFolders));
       }
     }
   }
@@ -114,6 +151,10 @@ export function FileTree({ contextKey, contextRelPath, files, theaterId, selecte
   filesRef.current = files;
   const contextKeyRef = useRef(contextKey);
   contextKeyRef.current = contextKey;
+  const childResultsRef = useRef<Map<string, FolderListResult>>(childResults);
+  childResultsRef.current = childResults;
+  const filterRequestRef = useRef(0);
+  const isFiltering = Boolean(filterText);
 
   useEffect(() => {
     if (!theaterId) return;
@@ -138,6 +179,28 @@ export function FileTree({ contextKey, contextRelPath, files, theaterId, selecte
       setError(e instanceof Error ? e.message : "Unable to load folder");
     });
   }, [contextKey, theaterId, currentPath, files]);
+
+  useEffect(() => {
+    const requestId = ++filterRequestRef.current;
+    if (!isFiltering || !result) return;
+    let active = true;
+    const requestContextKey = contextKey;
+    const isCurrent = () => active
+      && requestId === filterRequestRef.current
+      && isCurrentContextRequest(requestContextKey, contextKeyRef.current);
+    void loadFilterDescendants({
+      entries: result.entries,
+      cachedResults: childResultsRef.current,
+      files,
+      showHidden,
+      isCurrent,
+      onFolderResult: (relativePath, folderResult) => {
+        if (!isCurrent()) return;
+        setChildResults((prev) => new Map(prev).set(relativePath, folderResult));
+      },
+    });
+    return () => { active = false; };
+  }, [contextKey, files, isFiltering, result, showHidden]);
 
   useEffect(() => {
     const el = treeRef.current;
@@ -399,6 +462,32 @@ export function FileTree({ contextKey, contextRelPath, files, theaterId, selecte
       </div>
     </div>
   );
+}
+
+function hasFilterMatch(
+  entries: readonly FolderEntry[],
+  childResults: Map<string, FolderListResult>,
+  low: string,
+  showHidden: boolean,
+  visitedFolders: ReadonlySet<string> = new Set(),
+): boolean {
+  for (const e of entries) {
+    if (!showHidden && e.name.startsWith(".")) continue;
+    if (e.name.toLowerCase().includes(low)) return true;
+    if (e.kind === "dir") {
+      const result = childResults.get(e.relativePath);
+      if (result && !visitedFolders.has(result.relativePath)) {
+        const nextVisitedFolders = new Set(visitedFolders);
+        nextVisitedFolders.add(result.relativePath);
+        if (hasFilterMatch(result.entries, childResults, low, showHidden, nextVisitedFolders)) return true;
+      }
+    }
+  }
+  return false;
+}
+
+function isVisibleDirectory(entry: FolderEntry, showHidden: boolean): boolean {
+  return entry.kind === "dir" && (showHidden || !entry.name.startsWith("."));
 }
 
 interface FlatTreeRowProps {

--- a/runtime/fleet-plugins/file-explorer/tests/tree-context-state.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/tree-context-state.test.ts
@@ -1,8 +1,22 @@
 import fs from "node:fs";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { isCurrentContextRequest } from "../client/tree.js";
+import type { FolderListResult } from "../server/types.js";
+
+import { buildFlatRows, FILTER_DIRECTORY_CAP, isCurrentContextRequest, loadFilterDescendants, type PluginFilesClient } from "../client/tree.js";
+
+const ROOT_ENTRIES = [{ name: "src", relativePath: "src", kind: "dir" }] as const;
+const SRC_RESULT: FolderListResult = {
+  relativePath: "src",
+  parentRelativePath: "",
+  entries: [{ name: "nested", relativePath: "src/nested", kind: "dir" }, { name: ".git", relativePath: "src/.git", kind: "dir" }],
+};
+const NESTED_RESULT: FolderListResult = {
+  relativePath: "src/nested",
+  parentRelativePath: "src",
+  entries: [{ name: "match.ts", relativePath: "src/nested/match.ts", kind: "file" }],
+};
 
 describe("FileTree context request guard", () => {
   it("applies a list response only to the context that started it", () => {
@@ -14,5 +28,141 @@ describe("FileTree context request guard", () => {
   it("remounts before a new context can render the previous tree result", () => {
     const source = fs.readFileSync(new URL("../client/rail-panel.tsx", import.meta.url), "utf8");
     expect(source).toMatch(/<FileTree\s+key=\{contextScope\}/);
+  });
+
+  it("loads unopened descendants for a filter and renders their matching path", async () => {
+    const results = new Map<string, FolderListResult>();
+    const listFolder = vi.fn(async (relativePath?: string) => {
+      if (relativePath === "src") return SRC_RESULT;
+      if (relativePath === "src/nested") return NESTED_RESULT;
+      throw new Error(`unexpected path: ${relativePath}`);
+    });
+    const files: PluginFilesClient = { listFolder };
+
+    await loadFilterDescendants({
+      entries: ROOT_ENTRIES,
+      cachedResults: new Map(),
+      files,
+      showHidden: false,
+      isCurrent: () => true,
+      onFolderResult: (relativePath, result) => results.set(relativePath, result),
+    });
+
+    expect(listFolder).toHaveBeenCalledWith("src");
+    expect(listFolder).toHaveBeenCalledWith("src/nested");
+    expect(listFolder).not.toHaveBeenCalledWith("src/.git");
+    expect(buildFlatRows(ROOT_ENTRIES, 0, null, new Set(), new Set(), results, "match", false).map((row) => row.entry.relativePath)).toEqual([
+      "src",
+      "src/nested",
+      "src/nested/match.ts",
+    ]);
+  });
+
+  it("stops a stale filter traversal before applying or requesting later descendants", async () => {
+    let current = true;
+    const onFolderResult = vi.fn(() => { current = false; });
+    const files: PluginFilesClient = {
+      listFolder: vi.fn(async () => SRC_RESULT),
+    };
+
+    await loadFilterDescendants({
+      entries: ROOT_ENTRIES,
+      cachedResults: new Map(),
+      files,
+      showHidden: false,
+      isCurrent: () => current,
+      onFolderResult,
+    });
+
+    expect(onFolderResult).toHaveBeenCalledOnce();
+    expect(files.listFolder).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses cached folder results before requesting descendants again", async () => {
+    const listFolder = vi.fn();
+    const files: PluginFilesClient = { listFolder };
+    const cachedResults = new Map<string, FolderListResult>([
+      ["src", SRC_RESULT],
+      ["src/nested", NESTED_RESULT],
+    ]);
+
+    await loadFilterDescendants({
+      entries: ROOT_ENTRIES,
+      cachedResults,
+      files,
+      showHidden: false,
+      isCurrent: () => true,
+      onFolderResult: vi.fn(),
+    });
+
+    expect(listFolder).not.toHaveBeenCalled();
+  });
+
+  it("keeps one recursive walk active while filter text remains non-empty", () => {
+    const source = fs.readFileSync(new URL("../client/tree.tsx", import.meta.url), "utf8");
+
+    expect(source).toContain("const isFiltering = Boolean(filterText);");
+    expect(source).toContain("}, [contextKey, files, isFiltering, result, showHidden]);");
+  });
+
+  it("stops traversing when a server result repeats a visited relative path", async () => {
+    const cycleResult: FolderListResult = {
+      relativePath: "src",
+      parentRelativePath: "",
+      entries: [{ name: "loop", relativePath: "src/loop", kind: "dir" }],
+    };
+    const listFolder = vi.fn(async () => cycleResult);
+    const files: PluginFilesClient = { listFolder };
+
+    await loadFilterDescendants({
+      entries: ROOT_ENTRIES,
+      cachedResults: new Map(),
+      files,
+      showHidden: false,
+      isCurrent: () => true,
+      onFolderResult: vi.fn(),
+    });
+
+    expect(listFolder).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not recursively render a cached cyclic folder result", () => {
+    const cycleResult: FolderListResult = {
+      relativePath: "src",
+      parentRelativePath: "",
+      entries: [
+        { name: "loop", relativePath: "src/loop", kind: "dir" },
+        { name: "match.ts", relativePath: "src/match.ts", kind: "file" },
+      ],
+    };
+    const rows = buildFlatRows(ROOT_ENTRIES, 0, null, new Set(), new Set(), new Map([
+      ["src", cycleResult],
+      ["src/loop", cycleResult],
+    ]), "match", false);
+
+    expect(rows.map((row) => row.entry.relativePath)).toEqual(["src", "src/match.ts"]);
+  });
+
+  it("caps distinct directory requests during recursive discovery", async () => {
+    const listFolder = vi.fn(async (relativePath?: string) => {
+      const index = Number(relativePath?.split("-").at(-1) ?? "0");
+      return {
+        relativePath: relativePath ?? "",
+        parentRelativePath: null,
+        entries: [{ name: `dir-${index + 1}`, relativePath: `dir-${index + 1}`, kind: "dir" }],
+      } satisfies FolderListResult;
+    });
+    const files: PluginFilesClient = { listFolder };
+
+    await loadFilterDescendants({
+      entries: [{ name: "dir-0", relativePath: "dir-0", kind: "dir" }],
+      cachedResults: new Map(),
+      files,
+      showHidden: false,
+      isCurrent: () => true,
+      onFolderResult: vi.fn(),
+    });
+
+    expect(listFolder).toHaveBeenCalledTimes(FILTER_DIRECTORY_CAP);
   });
 });


### PR DESCRIPTION
## Summary

- Search unopened File Explorer descendants recursively with bounded, cycle-safe traversal and cache reuse.
- Add persisted drag resizing to the Diff History detail/list layout with safe cancellation and unmount cleanup.
- Add focused regression coverage and a bilingual changelog fragment.

## Type of Change

- [x] fix — bug fix

## Test Plan

- [x] `pnpm --filter @fleet-plugins/file-explorer test`
- [x] `pnpm --filter @fleet-plugins/file-explorer typecheck`
- [x] `pnpm --filter @fleet-plugins/file-explorer build`
- [x] `pnpm --filter @fleet-plugins/diff test`
- [x] `pnpm --filter @fleet-plugins/diff typecheck`
- [x] `pnpm --filter @fleet-plugins/diff build`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Headed browser verification for recursive discovery and pointer drag resizing
- [x] Sentinel review and remediation re-review

## Changelog

- [x] Added one `.changelog.d/*.md` fragment.
- [x] Fragment section and bilingual entries pass `node scripts/compile-changelog-fragments.mjs --check`.

## Notes for Reviewers

- Recursive discovery is capped at 500 directories and deduplicates canonical folder identities to avoid symlink cycles.
- Keyboard separator semantics are not introduced here to preserve parity with the existing Diff and File Explorer dividers.