### PR TITLE
refactor(console): extract desktop protocol package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
         specifier: ^8.18.0
         version: 8.21.0
     devDependencies:
+      '@fleet-console/desktop-protocol':
+        specifier: workspace:*
+        version: link:desktop-protocol
       '@fontsource-variable/cascadia-code':
         specifier: ^5.2.2
         version: 5.2.2
@@ -343,6 +346,15 @@ importers:
       vitest:
         specifier: ^4.0.13
         version: 4.1.5(@types/node@24.12.2)(jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.3))(vite@7.3.2(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+
+  runtime/fleet-console/desktop-protocol:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.10.0
+        version: 24.12.2
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
 
   runtime/fleet-console/font-picker:
     devDependencies:
@@ -423,6 +435,9 @@ importers:
       '@electron/fuses':
         specifier: 2.1.3
         version: 2.1.3
+      '@fleet-console/desktop-protocol':
+        specifier: workspace:*
+        version: link:../fleet-console/desktop-protocol
       electron:
         specifier: 43.1.0
         version: 43.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ packages:
   - "packages/fleet-wiki"
   - "runtime/fleet-console"
   - "runtime/fleet-desktop"
+  - "runtime/fleet-console/desktop-protocol"
   - "runtime/fleet-console/sdk"
   - "runtime/fleet-console/markdown"
   - "runtime/fleet-console/font-picker"

--- a/runtime/fleet-console/AGENTS.md
+++ b/runtime/fleet-console/AGENTS.md
@@ -8,6 +8,7 @@
 |---|---|
 | `core/host/` | Server lifecycle, security, durable state, and core APIs |
 | `core/client/` | React application, host chrome, and browser state |
+| `desktop-protocol/` | Shared Console-Desktop protocol contract |
 | `sdk/` | Plugin-facing contracts and stateless helpers |
 | `markdown/` | Shared sanitized markdown and diagram rendering |
 | `font-picker/` | Shared controlled font-selection surface |
@@ -37,5 +38,6 @@
 
 - Console serves its own web build; there is no second gateway or embedded web owner.
 - Published Console artifacts are self-contained: workspace packages are bundled and must not survive as workspace-version dependencies.
+- The published `./desktop-protocol` subpath is a compatibility surface for shipped Desktop shells under always-latest Console installs; keep its export surface unchanged.
 - Host and built-in plugin bundles may load separate copies of a module. Never coordinate across that boundary through module-scoped singleton state.
 - Built-in plugin server code must resolve package-level native or external dependencies from the Console package rather than the generated plugin cache; validate the affected path against the built distribution because source tests and builds can stay green.

--- a/runtime/fleet-console/core/host/desktop-protocol.ts
+++ b/runtime/fleet-console/core/host/desktop-protocol.ts
@@ -2,56 +2,43 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 
-export type ConsoleOwnerKind = "cli" | "desktop";
+import {
+  DESKTOP_DEVELOPMENT_ENV,
+  DESKTOP_OWNER_ID_ENV,
+  DESKTOP_OWNER_KIND_ENV,
+  DESKTOP_PROTOCOL_VERSION,
+  DESKTOP_PROTOCOL_VERSION_ENV,
+  DESKTOP_RESOURCE_ROOT_ENV,
+  DESKTOP_RESOURCE_ROOT_MARKER,
+  isDesktopDevelopmentEnvironment as isDesktopDevelopmentEnvironmentFor,
+  isDesktopResourceRootMarkerValid,
+} from "@fleet-console/desktop-protocol";
+import type { DesktopProtocolEnvironment } from "@fleet-console/desktop-protocol";
 
-export interface ConsoleOwnerMetadata {
-  readonly kind: ConsoleOwnerKind;
-  readonly id: string;
-  readonly protocolVersion: number;
-}
-
-export interface DesktopProtocolEnvironment {
-  readonly owner: ConsoleOwnerMetadata;
-  readonly resourceRoot: string;
-}
-
-export interface CanonicalConsolePaths {
-  readonly dir: string;
-  readonly lockFile: string;
-  readonly dataDir: string;
-  readonly stateFile: string;
-  readonly settingsFile: string;
-  readonly capturesDir: string;
-}
-
-export interface ResolveCanonicalConsolePathsInput {
-  readonly tmpDir: string;
-  readonly uid: number;
-  readonly fleetDataDir: string;
-  readonly consoleDirOverride?: string;
-}
-
-export interface ResolveCanonicalLocalConsolePathsInput {
-  readonly packageRoot: string;
-}
+export {
+  DESKTOP_DEVELOPMENT_ENV,
+  DESKTOP_OWNER_ID_ENV,
+  DESKTOP_OWNER_KIND_ENV,
+  DESKTOP_PROTOCOL_VERSION,
+  DESKTOP_PROTOCOL_VERSION_ENV,
+  DESKTOP_RESOURCE_ROOT_ENV,
+  DESKTOP_RESOURCE_ROOT_MARKER,
+  isCompatibleDesktopOwner,
+  resolveCanonicalLocalConsolePaths,
+  resolveCanonicalStableConsolePaths,
+} from "@fleet-console/desktop-protocol";
+export type {
+  CanonicalConsolePaths,
+  ConsoleOwnerKind,
+  ConsoleOwnerMetadata,
+  DesktopProtocolEnvironment,
+  ResolveCanonicalConsolePathsInput,
+  ResolveCanonicalLocalConsolePathsInput,
+} from "@fleet-console/desktop-protocol";
 
 export interface DesktopProtocolValidationDeps {
   readonly expectedPackageRoot?: string;
 }
-
-export const DESKTOP_PROTOCOL_VERSION = 1;
-export const DESKTOP_RESOURCE_ROOT_ENV = "FLEET_CONSOLE_RESOURCE_ROOT";
-export const DESKTOP_OWNER_ID_ENV = "FLEET_CONSOLE_OWNER_ID";
-export const DESKTOP_OWNER_KIND_ENV = "FLEET_CONSOLE_OWNER_KIND";
-export const DESKTOP_PROTOCOL_VERSION_ENV = "FLEET_CONSOLE_PROTOCOL_VERSION";
-export const DESKTOP_RESOURCE_ROOT_MARKER = ".fleet-console-resource-root";
-export const DESKTOP_DEVELOPMENT_ENV = "FLEET_CONSOLE_DESKTOP_DEVELOPMENT";
-const LOCK_DIR_NAME = "fleet-console";
-const LOCK_FILE_NAME = "console.lock";
-const CONSOLE_DATA_DIR_NAME = "console";
-const CONSOLE_STATE_FILE_NAME = "state.json";
-const CONSOLE_SETTINGS_FILE_NAME = "settings.json";
-const CONSOLE_CAPTURES_DIR_NAME = "captures";
 
 export function readDesktopProtocolEnvironment(env: NodeJS.ProcessEnv = process.env, deps: DesktopProtocolValidationDeps = {}): DesktopProtocolEnvironment | null {
   const resourceRoot = env[DESKTOP_RESOURCE_ROOT_ENV];
@@ -71,41 +58,7 @@ export function readDesktopProtocolEnvironment(env: NodeJS.ProcessEnv = process.
 }
 
 export function isDesktopDevelopmentEnvironment(env: NodeJS.ProcessEnv = process.env): boolean {
-  return env[DESKTOP_DEVELOPMENT_ENV] === "1";
-}
-
-export function isCompatibleDesktopOwner(owner: ConsoleOwnerMetadata | undefined, version: string, expected: { readonly id: string; readonly version: string }): boolean {
-  return owner?.kind === "desktop"
-    && owner.id === expected.id
-    && owner.protocolVersion === DESKTOP_PROTOCOL_VERSION
-    && version === expected.version;
-}
-
-// Published CLI/browser and desktop share this resolver. Inputs are supplied by each host so
-// this leaf has no dependency on Console runtime internals, Electron, or process-global state.
-export function resolveCanonicalStableConsolePaths(input: ResolveCanonicalConsolePathsInput): CanonicalConsolePaths {
-  const dir = input.consoleDirOverride ?? path.join(input.tmpDir, `${LOCK_DIR_NAME}-${input.uid}-stable`);
-  const dataDir = input.consoleDirOverride ?? path.join(input.fleetDataDir, CONSOLE_DATA_DIR_NAME);
-  return {
-    dir,
-    lockFile: path.join(dir, LOCK_FILE_NAME),
-    dataDir,
-    stateFile: path.join(dataDir, CONSOLE_STATE_FILE_NAME),
-    settingsFile: path.join(dataDir, CONSOLE_SETTINGS_FILE_NAME),
-    capturesDir: path.join(dataDir, CONSOLE_CAPTURES_DIR_NAME),
-  };
-}
-
-export function resolveCanonicalLocalConsolePaths(input: ResolveCanonicalLocalConsolePathsInput): CanonicalConsolePaths {
-  const dir = path.join(path.resolve(input.packageRoot, "..", ".."), ".fleet", CONSOLE_DATA_DIR_NAME);
-  return {
-    dir,
-    lockFile: path.join(dir, LOCK_FILE_NAME),
-    dataDir: dir,
-    stateFile: path.join(dir, CONSOLE_STATE_FILE_NAME),
-    settingsFile: path.join(dir, CONSOLE_SETTINGS_FILE_NAME),
-    capturesDir: path.join(dir, CONSOLE_CAPTURES_DIR_NAME),
-  };
+  return isDesktopDevelopmentEnvironmentFor(env);
 }
 
 export function validateDesktopResourceRoot(root: string, expectedPackageRoot = resolveDesktopProtocolPackageRoot()): string {
@@ -114,8 +67,8 @@ export function validateDesktopResourceRoot(root: string, expectedPackageRoot = 
   const expectedRoot = fs.realpathSync(expectedPackageRoot);
   if (resolvedRoot !== expectedRoot) throw new Error("desktop_resource_root_invalid");
   const markerPath = path.join(resolvedRoot, DESKTOP_RESOURCE_ROOT_MARKER);
-  const marker = fs.readFileSync(markerPath, "utf8").trim();
-  if (marker !== String(DESKTOP_PROTOCOL_VERSION)) throw new Error("desktop_resource_root_marker_invalid");
+  const marker = fs.readFileSync(markerPath, "utf8");
+  if (!isDesktopResourceRootMarkerValid(marker)) throw new Error("desktop_resource_root_marker_invalid");
   return resolvedRoot;
 }
 

--- a/runtime/fleet-console/desktop-protocol/AGENTS.md
+++ b/runtime/fleet-console/desktop-protocol/AGENTS.md
@@ -1,0 +1,9 @@
+# Desktop Protocol
+
+`@fleet-console/desktop-protocol` is the source-only shared contract between Fleet Console and Fleet Desktop: protocol version, owner metadata, control env names, resource-root marker format, and canonical Console path resolution.
+
+## Constraints
+
+- Contract only: types, constants, and stateless helpers over caller-supplied inputs. No filesystem, process spawning, or Electron access; resource-root and ownership validation stays in Console host.
+- Import nothing from Console core, Desktop, plugins, or `@dotobokuri/*`; both hosts bundle this package and consume its declared exports only.
+- Exports are a live published protocol for independently versioned shipped shells: changing version-1 semantics, env names, marker format, or canonical paths is a protocol revision, not a refactor.

--- a/runtime/fleet-console/desktop-protocol/index.ts
+++ b/runtime/fleet-console/desktop-protocol/index.ts
@@ -1,0 +1,93 @@
+import path from "node:path";
+
+export type ConsoleOwnerKind = "cli" | "desktop";
+
+export interface ConsoleOwnerMetadata {
+  readonly kind: ConsoleOwnerKind;
+  readonly id: string;
+  readonly protocolVersion: number;
+}
+
+export interface DesktopProtocolEnvironment {
+  readonly owner: ConsoleOwnerMetadata;
+  readonly resourceRoot: string;
+}
+
+export interface CanonicalConsolePaths {
+  readonly dir: string;
+  readonly lockFile: string;
+  readonly dataDir: string;
+  readonly stateFile: string;
+  readonly settingsFile: string;
+  readonly capturesDir: string;
+}
+
+export interface ResolveCanonicalConsolePathsInput {
+  readonly tmpDir: string;
+  readonly uid: number;
+  readonly fleetDataDir: string;
+  readonly consoleDirOverride?: string;
+}
+
+export interface ResolveCanonicalLocalConsolePathsInput {
+  readonly packageRoot: string;
+}
+
+export const DESKTOP_PROTOCOL_VERSION = 1;
+export const DESKTOP_RESOURCE_ROOT_ENV = "FLEET_CONSOLE_RESOURCE_ROOT";
+export const DESKTOP_OWNER_ID_ENV = "FLEET_CONSOLE_OWNER_ID";
+export const DESKTOP_OWNER_KIND_ENV = "FLEET_CONSOLE_OWNER_KIND";
+export const DESKTOP_PROTOCOL_VERSION_ENV = "FLEET_CONSOLE_PROTOCOL_VERSION";
+export const DESKTOP_RESOURCE_ROOT_MARKER = ".fleet-console-resource-root";
+export const DESKTOP_DEVELOPMENT_ENV = "FLEET_CONSOLE_DESKTOP_DEVELOPMENT";
+
+const LOCK_DIR_NAME = "fleet-console";
+const LOCK_FILE_NAME = "console.lock";
+const CONSOLE_DATA_DIR_NAME = "console";
+const CONSOLE_STATE_FILE_NAME = "state.json";
+const CONSOLE_SETTINGS_FILE_NAME = "settings.json";
+const CONSOLE_CAPTURES_DIR_NAME = "captures";
+
+export function isDesktopDevelopmentEnvironment(env: Readonly<Record<string, string | undefined>>): boolean {
+  return env[DESKTOP_DEVELOPMENT_ENV] === "1";
+}
+
+export function isCompatibleDesktopOwner(owner: ConsoleOwnerMetadata | undefined, version: string, expected: { readonly id: string; readonly version: string }): boolean {
+  return owner?.kind === "desktop"
+    && owner.id === expected.id
+    && owner.protocolVersion === DESKTOP_PROTOCOL_VERSION
+    && version === expected.version;
+}
+
+export function resolveCanonicalStableConsolePaths(input: ResolveCanonicalConsolePathsInput): CanonicalConsolePaths {
+  const dir = input.consoleDirOverride ?? path.join(input.tmpDir, `${LOCK_DIR_NAME}-${input.uid}-stable`);
+  const dataDir = input.consoleDirOverride ?? path.join(input.fleetDataDir, CONSOLE_DATA_DIR_NAME);
+  return {
+    dir,
+    lockFile: path.join(dir, LOCK_FILE_NAME),
+    dataDir,
+    stateFile: path.join(dataDir, CONSOLE_STATE_FILE_NAME),
+    settingsFile: path.join(dataDir, CONSOLE_SETTINGS_FILE_NAME),
+    capturesDir: path.join(dataDir, CONSOLE_CAPTURES_DIR_NAME),
+  };
+}
+
+export function resolveCanonicalLocalConsolePaths(input: ResolveCanonicalLocalConsolePathsInput): CanonicalConsolePaths {
+  const dir = path.join(path.resolve(input.packageRoot, "..", ".."), ".fleet", CONSOLE_DATA_DIR_NAME);
+  return {
+    dir,
+    lockFile: path.join(dir, LOCK_FILE_NAME),
+    dataDir: dir,
+    stateFile: path.join(dir, CONSOLE_STATE_FILE_NAME),
+    settingsFile: path.join(dir, CONSOLE_SETTINGS_FILE_NAME),
+    capturesDir: path.join(dir, CONSOLE_CAPTURES_DIR_NAME),
+  };
+}
+
+export function formatDesktopResourceRootMarker(): string {
+  return `${DESKTOP_PROTOCOL_VERSION}\n`;
+}
+
+export function isDesktopResourceRootMarkerValid(content: string): boolean {
+  return content.trim() === String(DESKTOP_PROTOCOL_VERSION);
+}

--- a/runtime/fleet-console/desktop-protocol/package.json
+++ b/runtime/fleet-console/desktop-protocol/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@fleet-console/desktop-protocol",
+  "version": "1.24.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./index.ts",
+      "import": "./index.ts",
+      "default": "./index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.0",
+    "typescript": "^6.0.2"
+  }
+}

--- a/runtime/fleet-console/desktop-protocol/tsconfig.json
+++ b/runtime/fleet-console/desktop-protocol/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules"]
+}

--- a/runtime/fleet-console/package.json
+++ b/runtime/fleet-console/package.json
@@ -38,17 +38,19 @@
     "node": ">=20.19.0"
   },
   "scripts": {
-    "build": "pnpm generate:admiral-assets && pnpm generate:shim-keys && tsup && vite build --config core/client/vite.config.ts",
+    "build": "pnpm generate:admiral-assets && pnpm generate:shim-keys && tsup && pnpm generate:desktop-protocol-declaration && pnpm verify:desktop-protocol && vite build --config core/client/vite.config.ts",
     "cli": "tsx core/host/cli.ts",
     "dev": "vite --config core/client/vite.config.ts",
     "generate:admiral-assets": "node ../../scripts/generate-fleet-admiral-assets.mjs",
+    "generate:desktop-protocol-declaration": "tsup core/host/desktop-protocol.ts --dts --dts-resolve --dts-only --out-dir dist --format esm --no-config",
     "generate:shim-keys": "node ../../scripts/generate-fleet-console-shim-keys.mjs",
     "predev": "pnpm generate:admiral-assets && pnpm generate:shim-keys",
     "prepack": "node ../../scripts/pack-fleet-console-manifest.mjs prepack",
     "postpack": "node ../../scripts/pack-fleet-console-manifest.mjs postpack",
     "publish:npm": "node ../../scripts/publish-fleet-console.mjs",
     "test": "pnpm generate:admiral-assets && pnpm generate:shim-keys && vitest run",
-    "typecheck": "pnpm generate:admiral-assets && pnpm generate:shim-keys && tsc --noEmit -p tsconfig.json && tsc --noEmit -p core/client/tsconfig.json"
+    "typecheck": "pnpm generate:admiral-assets && pnpm generate:shim-keys && tsc --noEmit -p tsconfig.json && tsc --noEmit -p core/client/tsconfig.json",
+    "verify:desktop-protocol": "node verify-desktop-protocol-compatibility.mjs"
   },
   "dependencies": {
     "@dotobokuri/core-agent": "workspace:*",
@@ -79,6 +81,7 @@
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource-variable/manrope": "^5.2.8",
     "@fontsource-variable/source-code-pro": "^5.2.7",
+    "@fleet-console/desktop-protocol": "workspace:*",
     "@types/node": "^24.10.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/runtime/fleet-console/tests/desktop-protocol.test.ts
+++ b/runtime/fleet-console/tests/desktop-protocol.test.ts
@@ -5,6 +5,8 @@ import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import { formatDesktopResourceRootMarker, isDesktopResourceRootMarkerValid } from "@fleet-console/desktop-protocol";
+
 import {
   DESKTOP_DEVELOPMENT_ENV,
   DESKTOP_OWNER_ID_ENV,
@@ -27,6 +29,21 @@ afterEach(() => {
 });
 
 describe("desktop protocol", () => {
+  it("shares the version-1 resource-root marker formatter and trim-tolerant validator", () => {
+    expect(formatDesktopResourceRootMarker()).toBe("1\n");
+    expect(isDesktopResourceRootMarkerValid("1\n")).toBe(true);
+    expect(isDesktopResourceRootMarkerValid(" \t1\r\n")).toBe(true);
+    expect(isDesktopResourceRootMarkerValid("2\n")).toBe(false);
+  });
+
+  it("keeps the shared contract free of host and filesystem ownership", () => {
+    const source = fs.readFileSync(path.join(CONSOLE_PACKAGE_ROOT, "desktop-protocol", "index.ts"), "utf8");
+
+    expect(source).not.toMatch(/node:(?:fs|child_process)/);
+    expect(source).not.toMatch(/(?:@dotobokuri\/|fleet-desktop|fleet-plugins)/);
+    expect(source).not.toMatch(/\b(?:process|electron)\b/);
+  });
+
   it("validates the marked resource root and exact owner protocol", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-desktop-resource-"));
     TEMP_DIRS.push(root);

--- a/runtime/fleet-console/tests/published-manifest.test.ts
+++ b/runtime/fleet-console/tests/published-manifest.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error The executable manifest transformer is intentionally JavaScript.
+import { createPublishedFleetConsoleManifest } from "../../../scripts/pack-fleet-console-manifest.mjs";
+
+describe("published Console manifest", () => {
+  it("removes workspace specifiers from every copied dependency section", () => {
+    const manifest = createPublishedFleetConsoleManifest({
+      name: "@dotobokuri/fleet-console",
+      private: true,
+      dependencies: {
+        "node-pty": "^1.0.0",
+        ws: "^8.18.0",
+        "font-list": "^2.1.0",
+        "@fleet-console/desktop-protocol": "workspace:*",
+      },
+      devDependencies: {
+        typescript: "^6.0.2",
+        "@fleet-console/desktop-protocol": "workspace:*",
+      },
+      optionalDependencies: { fixture: "workspace:^" },
+      peerDependencies: { react: "^19.0.0" },
+      scripts: { build: "pnpm build" },
+    });
+
+    for (const [section, entries] of Object.entries(manifest)) {
+      if (!section.endsWith("Dependencies") || entries === null || typeof entries !== "object" || Array.isArray(entries)) continue;
+      expect(Object.values(entries).some((value) => typeof value === "string" && value.startsWith("workspace:"))).toBe(false);
+    }
+    expect(manifest.devDependencies).toEqual({ typescript: "^6.0.2" });
+    expect(manifest.dependencies).toEqual({ "node-pty": "^1.0.0", ws: "^8.18.0", "font-list": "^2.1.0" });
+  });
+});

--- a/runtime/fleet-console/tsconfig.json
+++ b/runtime/fleet-console/tsconfig.json
@@ -21,7 +21,8 @@
       "@dotobokuri/fleet-admiral": ["../../packages/fleet-admiral/dist/index.d.ts"],
       "@dotobokuri/fleet-carriers": ["../../packages/fleet-carriers/dist/index.d.ts"],
       "@dotobokuri/core-infra": ["../../packages/core-infra/dist/index.d.ts"],
-      "@dotobokuri/fleet-wiki": ["../../packages/fleet-wiki/dist/index.d.ts"]
+      "@dotobokuri/fleet-wiki": ["../../packages/fleet-wiki/dist/index.d.ts"],
+      "@fleet-console/desktop-protocol": ["desktop-protocol/index.ts"]
     }
   },
   "include": ["core/host/**/*.ts", "tests/**/*.ts", "tsup.config.ts", "vitest.config.ts"]

--- a/runtime/fleet-console/tsup.config.ts
+++ b/runtime/fleet-console/tsup.config.ts
@@ -15,14 +15,14 @@ export default defineConfig([
     // 선언(.d.ts)은 패키지가 타입으로 노출하는 cli 엔트리에만 생성한다.
     // 빌트인 플러그인 라우트 번들은 런타임 산출물일 뿐 타입 소비 대상이 아니며,
     // tsconfig include 밖이라 source-only @fleet-console/sdk(.ts) 타입을 DTS 패스에서 해석하지 못한다.
-    dts: { entry: { cli: "core/host/cli.ts", "desktop-protocol": "core/host/desktop-protocol.ts" } },
+    dts: { entry: { cli: "core/host/cli.ts" }, resolve: true },
     sourcemap: false,
     clean: false,
     // workspace 패키지(@dotobokuri/*)는 npm에 개별 발행하지 않으므로 번들에 인라인한다.
     // native(node-pty)·동적 require(ws)·font-list의 플랫폼 helper는 정적 분석 대상이 아니라 external로 남으며,
     // publish 스크립트가 published dependencies로 유지한다.
-    // @fleet-console/markdown과 source-only font-picker 워크스페이스 패키지는 npm publish 시 번들 흡수한다.
-    noExternal: [/^@dotobokuri\/core-process(\/|$)/, /^@dotobokuri\//, /^@fleet-console\/(sdk|markdown|font-picker)(\/|$)/],
+    // @fleet-console source-only 워크스페이스 패키지는 npm publish 시 번들 흡수한다.
+    noExternal: [/^@dotobokuri\/core-process(\/|$)/, /^@dotobokuri\//, /^@fleet-console\/(sdk|markdown|font-picker|desktop-protocol)(\/|$)/],
     // esbuild는 plugin-host의 dev .ts 로더에서만 동적 import되는 devDependency다.
     // 번들에 인라인하면 esbuild 내부 CJS의 require("fs")가 ESM 출력에서 boot 시 throw하므로 external로 남긴다.
     external: ["esbuild", "font-list"],

--- a/runtime/fleet-console/verify-desktop-protocol-compatibility.mjs
+++ b/runtime/fleet-console/verify-desktop-protocol-compatibility.mjs
@@ -1,0 +1,49 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const runtimeExports = [
+  "DESKTOP_DEVELOPMENT_ENV",
+  "DESKTOP_OWNER_ID_ENV",
+  "DESKTOP_OWNER_KIND_ENV",
+  "DESKTOP_PROTOCOL_VERSION",
+  "DESKTOP_PROTOCOL_VERSION_ENV",
+  "DESKTOP_RESOURCE_ROOT_ENV",
+  "DESKTOP_RESOURCE_ROOT_MARKER",
+  "isCompatibleDesktopOwner",
+  "isDesktopDevelopmentEnvironment",
+  "readDesktopProtocolEnvironment",
+  "resolveCanonicalLocalConsolePaths",
+  "resolveCanonicalStableConsolePaths",
+  "validateDesktopDevelopmentResourceRoot",
+  "validateDesktopResourceRoot",
+];
+const declarationExports = [
+  ...runtimeExports,
+  "CanonicalConsolePaths",
+  "ConsoleOwnerKind",
+  "ConsoleOwnerMetadata",
+  "DesktopProtocolEnvironment",
+  "DesktopProtocolValidationDeps",
+  "ResolveCanonicalConsolePathsInput",
+  "ResolveCanonicalLocalConsolePathsInput",
+];
+
+const protocol = await import(pathToFileURL(path.join(__dirname, "dist", "desktop-protocol.mjs")).href);
+assertExactExports("runtime", Object.keys(protocol), runtimeExports);
+
+const declaration = await readFile(path.join(__dirname, "dist", "desktop-protocol.d.ts"), "utf8");
+if (declaration.includes("workspace:") || declaration.includes("@fleet-console/desktop-protocol")) {
+  throw new Error("desktop_protocol_compatibility_declaration_workspace_import");
+}
+const declarationExport = [...declaration.matchAll(/export \{([^}]*)\};/gs)].at(-1)?.[1];
+if (declarationExport === undefined) throw new Error("desktop_protocol_compatibility_declaration_exports_missing");
+assertExactExports("declaration", declarationExport.split(",").map((entry) => entry.trim().replace(/^type\s+/, "")), declarationExports);
+
+function assertExactExports(kind, actual, expected) {
+  const actualNames = [...actual].sort();
+  const expectedNames = [...expected].sort();
+  if (actualNames.length === expectedNames.length && actualNames.every((name, index) => name === expectedNames[index])) return;
+  throw new Error(`desktop_protocol_compatibility_${kind}_exports_changed: expected ${expectedNames.join(",")}; received ${actualNames.join(",")}`);
+}

--- a/runtime/fleet-desktop/AGENTS.md
+++ b/runtime/fleet-desktop/AGENTS.md
@@ -14,7 +14,7 @@
 
 ## Constraints
 
-- The Console product remains the sole server, PTY, provider, plugin, durable-state, and React owner. Desktop imports only `@dotobokuri/fleet-console/desktop-protocol`; never Console internals.
+- The Console product remains the sole server, PTY, provider, plugin, durable-state, and React owner. Desktop production source imports the shared `@fleet-console/desktop-protocol` contract; never Console internals. Packaged integration tests remain anchored to the published `@dotobokuri/fleet-console/desktop-protocol` compatibility surface.
 - The main process hands the single window to `/console/` only after verifying Desktop ownership and protocol for one exact loopback origin; the browser URL remains token-free.
 - Every renderer remains sandboxed and Node-free. Navigation is confined to the activated Console origin's `/console/` paths; popups and non-Console navigation remain denied.
 - The entry surface is view-only and one-way. Do not add preload, raw IPC, renderer input, a renderer fork, or a Desktop HTTP server; native dialogs are the input surface.

--- a/runtime/fleet-desktop/package.json
+++ b/runtime/fleet-desktop/package.json
@@ -27,6 +27,7 @@
     "@dotobokuri/core-process": "workspace:*",
     "@electron/asar": "3.4.1",
     "@dotobokuri/fleet-console": "workspace:*",
+    "@fleet-console/desktop-protocol": "workspace:*",
     "@electron/fuses": "2.1.3",
     "electron": "43.1.0",
     "electron-builder": "26.15.3",

--- a/runtime/fleet-desktop/src/environment.ts
+++ b/runtime/fleet-desktop/src/environment.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { prependPathEntries } from "@dotobokuri/core-process";
-import { DESKTOP_DEVELOPMENT_ENV, DESKTOP_OWNER_ID_ENV, DESKTOP_OWNER_KIND_ENV, DESKTOP_PROTOCOL_VERSION, DESKTOP_PROTOCOL_VERSION_ENV, DESKTOP_RESOURCE_ROOT_ENV, resolveCanonicalLocalConsolePaths, resolveCanonicalStableConsolePaths } from "@dotobokuri/fleet-console/desktop-protocol";
+import { DESKTOP_DEVELOPMENT_ENV, DESKTOP_OWNER_ID_ENV, DESKTOP_OWNER_KIND_ENV, DESKTOP_PROTOCOL_VERSION, DESKTOP_PROTOCOL_VERSION_ENV, DESKTOP_RESOURCE_ROOT_ENV, resolveCanonicalLocalConsolePaths, resolveCanonicalStableConsolePaths } from "@fleet-console/desktop-protocol";
 
 export interface DesktopEnvironment {
   readonly ownerId: string;

--- a/runtime/fleet-desktop/src/runtime/console-installer.ts
+++ b/runtime/fleet-desktop/src/runtime/console-installer.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
+import { DESKTOP_RESOURCE_ROOT_MARKER, formatDesktopResourceRootMarker, isDesktopResourceRootMarkerValid } from "@fleet-console/desktop-protocol";
+
 import { satisfiesNodeEngine } from "./node-bootstrap.js";
 import type { RuntimePaths } from "./runtime-paths.js";
 
@@ -42,8 +44,6 @@ export interface InstalledConsole {
 }
 
 const STABLE_SEMVER = /^\d+\.\d+\.\d+$/;
-const RESOURCE_ROOT_MARKER = ".fleet-console-resource-root";
-const DESKTOP_PROTOCOL_VERSION = "1";
 
 export async function installConsole(options: InstallConsoleOptions): Promise<InstalledConsole> {
   if (!STABLE_SEMVER.test(options.version)) throw new Error("console_install_version_invalid");
@@ -202,7 +202,7 @@ async function normalizePrefixInstallation(root: string, packageName: string, fi
   } finally {
     await fileSystem.rm(heldPackage);
   }
-  await fileSystem.writeFile(path.join(root, RESOURCE_ROOT_MARKER), `${DESKTOP_PROTOCOL_VERSION}\n`);
+  await fileSystem.writeFile(path.join(root, DESKTOP_RESOURCE_ROOT_MARKER), formatDesktopResourceRootMarker());
 }
 
 async function verifyInstallation(root: string, expectedVersion: string, nodeRuntimeVersion: string, fileSystem: ConsoleInstallerFileSystem): Promise<void> {
@@ -214,8 +214,8 @@ async function verifyInstallation(root: string, expectedVersion: string, nodeRun
   if (packageJson.version !== expectedVersion) throw new Error("console_install_version_mismatch");
   const engine = typeof packageJson.engines?.node === "string" ? packageJson.engines.node : null;
   if (!satisfiesNodeEngine(nodeRuntimeVersion, engine)) throw new Error("console_install_node_engine_incompatible");
-  const marker = await fileSystem.readFile(path.join(root, RESOURCE_ROOT_MARKER));
-  if (marker.trim() !== DESKTOP_PROTOCOL_VERSION) throw new Error("console_install_marker_invalid");
+  const marker = await fileSystem.readFile(path.join(root, DESKTOP_RESOURCE_ROOT_MARKER));
+  if (!isDesktopResourceRootMarkerValid(marker)) throw new Error("console_install_marker_invalid");
 }
 
 function nodeBinaryPath(nodeRoot: string, platform: NodeJS.Platform): string {

--- a/runtime/fleet-desktop/src/sidecar-supervisor.ts
+++ b/runtime/fleet-desktop/src/sidecar-supervisor.ts
@@ -2,7 +2,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
-import { isCompatibleDesktopOwner, type ConsoleOwnerMetadata } from "@dotobokuri/fleet-console/desktop-protocol";
+import { isCompatibleDesktopOwner, type ConsoleOwnerMetadata } from "@fleet-console/desktop-protocol";
 
 export interface SidecarRuntime { readonly nodePath: string; readonly cliPath: string; readonly serviceRoot: string; readonly serviceVersion: string; }
 export interface SidecarSupervisorOptions { readonly nodePath?: string; readonly cliPath?: string; readonly serviceRoot?: string; readonly serviceVersion: string; readonly resolveRuntime?: () => Promise<SidecarRuntime>; readonly env: NodeJS.ProcessEnv; readonly lockFile: string; readonly ownerId: string; readonly log: { info(message: string): void; error(message: string): void }; }

--- a/runtime/fleet-desktop/tests/environment.test.ts
+++ b/runtime/fleet-desktop/tests/environment.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { DESKTOP_DEVELOPMENT_ENV, DESKTOP_OWNER_ID_ENV, DESKTOP_OWNER_KIND_ENV, DESKTOP_PROTOCOL_VERSION_ENV, DESKTOP_RESOURCE_ROOT_ENV } from "@dotobokuri/fleet-console/desktop-protocol";
+import { DESKTOP_DEVELOPMENT_ENV, DESKTOP_OWNER_ID_ENV, DESKTOP_OWNER_KIND_ENV, DESKTOP_PROTOCOL_VERSION_ENV, DESKTOP_RESOURCE_ROOT_ENV } from "@fleet-console/desktop-protocol";
 
 import { createDesktopEnvironment, desktopExecutableSearchPaths, resolveDesktopUserDataDirectory, sanitizeEnvironment } from "../src/environment.js";
 

--- a/runtime/fleet-desktop/tsup.config.ts
+++ b/runtime/fleet-desktop/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   entry: { main: "src/main.ts" },
   external: ["electron"],
   format: ["esm"],
-  noExternal: ["@dotobokuri/fleet-console/desktop-protocol"],
+  noExternal: ["@fleet-console/desktop-protocol"],
   outDir: "dist",
   outExtension: () => ({ js: ".mjs" }),
   platform: "node",

--- a/scripts/pack-fleet-console-manifest.mjs
+++ b/scripts/pack-fleet-console-manifest.mjs
@@ -8,14 +8,31 @@ const BACKUP_PATH = path.resolve(__dirname, "../runtime/fleet-console/.package.j
 const TEMP_PATH = path.resolve(__dirname, "../runtime/fleet-console/.package.json.prepack-tmp");
 const EXTERNAL_DEP_NAMES = ["node-pty", "ws", "font-list"];
 
-const action = process.argv[2];
+if (process.argv[1] !== undefined && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const action = process.argv[2];
 
-if (action === "prepack") {
-  prepack();
-} else if (action === "postpack") {
-  postpack();
-} else {
-  throw new Error("Usage: pack-fleet-console-manifest.mjs <prepack|postpack>");
+  if (action === "prepack") {
+    prepack();
+  } else if (action === "postpack") {
+    postpack();
+  } else {
+    throw new Error("Usage: pack-fleet-console-manifest.mjs <prepack|postpack>");
+  }
+}
+
+export function createPublishedFleetConsoleManifest(originalPkg) {
+  const pkg = JSON.parse(JSON.stringify(originalPkg));
+  const externalDeps = {};
+  for (const name of EXTERNAL_DEP_NAMES) {
+    const range = pkg.dependencies?.[name];
+    if (!range) throw new Error(`external dependency ${name} not found in ${PKG_PATH}`);
+    externalDeps[name] = range;
+  }
+  delete pkg.private;
+  pkg.dependencies = externalDeps;
+  pkg.scripts = { postinstall: "node postinstall.mjs" };
+  stripWorkspaceDependencySpecifiers(pkg);
+  return pkg;
 }
 
 function prepack() {
@@ -25,21 +42,9 @@ function prepack() {
   const original = readFileSync(PKG_PATH, "utf8");
   let backupCreated = false;
   try {
-    const pkg = JSON.parse(original);
-    const externalDeps = {};
-    for (const name of EXTERNAL_DEP_NAMES) {
-      const range = pkg.dependencies?.[name];
-      if (!range) {
-        throw new Error(`external dependency ${name} not found in ${PKG_PATH}`);
-      }
-      externalDeps[name] = range;
-    }
-
     atomicWrite(BACKUP_PATH, original);
     backupCreated = true;
-    delete pkg.private;
-    pkg.dependencies = externalDeps;
-    pkg.scripts = { postinstall: "node postinstall.mjs" };
+    const pkg = createPublishedFleetConsoleManifest(JSON.parse(original));
     atomicWrite(PKG_PATH, `${JSON.stringify(pkg, null, 2)}\n`);
   } catch (error) {
     if (backupCreated) {
@@ -63,4 +68,13 @@ function restoreBackup() {
 function atomicWrite(targetPath, content) {
   writeFileSync(TEMP_PATH, content);
   renameSync(TEMP_PATH, targetPath);
+}
+
+function stripWorkspaceDependencySpecifiers(pkg) {
+  for (const [section, entries] of Object.entries(pkg)) {
+    if (!section.endsWith("Dependencies") || entries === null || typeof entries !== "object" || Array.isArray(entries)) continue;
+    for (const [name, value] of Object.entries(entries)) {
+      if (typeof value === "string" && value.startsWith("workspace:")) delete entries[name];
+    }
+  }
 }

--- a/scripts/publish-fleet-console.mjs
+++ b/scripts/publish-fleet-console.mjs
@@ -3,6 +3,8 @@ import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { createPublishedFleetConsoleManifest } from "./pack-fleet-console-manifest.mjs";
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PKG_PATH = path.resolve(__dirname, "../runtime/fleet-console/package.json");
 const PKG_DIR = path.dirname(PKG_PATH);
@@ -17,20 +19,6 @@ const originalPkg = JSON.parse(original);
 const pkgName = originalPkg.name;
 const targetVersion = version ?? originalPkg.version;
 
-// 번들에 인라인되지 않는 의존성만 published manifest에 남긴다.
-// @dotobokuri/* workspace 패키지는 tsup noExternal로 번들 흡수되고,
-// node-pty(native)와 ws는 src에서 동적 require로 호출되고, font-list는 플랫폼 helper를 유지해야 하므로 external로 남긴다.
-const EXTERNAL_DEP_NAMES = ["node-pty", "ws", "font-list"];
-const EXTERNAL_DEPS = {};
-for (const name of EXTERNAL_DEP_NAMES) {
-  const range = originalPkg.dependencies?.[name];
-  if (!range) {
-    console.error(`external dependency ${name} not found in ${PKG_PATH}`);
-    process.exit(1);
-  }
-  EXTERNAL_DEPS[name] = range;
-}
-
 try {
   execSync(`npm view ${pkgName}@${targetVersion} version`, { stdio: "pipe" });
   console.log(`${pkgName}@${targetVersion} already published. Updating dist-tag to ${tag}.`);
@@ -41,11 +29,7 @@ try {
 execSync("pnpm build", { cwd: PKG_DIR, stdio: "inherit" });
 
 try {
-  const pkg = JSON.parse(original);
-
-  delete pkg.private;
-  pkg.dependencies = EXTERNAL_DEPS;
-  pkg.scripts = { postinstall: "node postinstall.mjs" };
+  const pkg = createPublishedFleetConsoleManifest(JSON.parse(original));
   if (version) pkg.version = version;
 
   writeFileSync(PKG_PATH, JSON.stringify(pkg, null, 2) + "\n");


### PR DESCRIPTION
## Summary

- Extract the versioned Console-Desktop protocol into the private source-only `@fleet-console/desktop-protocol` workspace package.
- Preserve the published `@dotobokuri/fleet-console/desktop-protocol` runtime and declaration surface while removing duplicated Desktop marker/version logic.
- Make Console packaging verify self-contained declarations and strip workspace dependency metadata from every published dependency section.

## Type of Change

- [x] refactor — no behavior change

## Scope

- [x] Fleet Console and Desktop runtime contracts
- [x] Root packaging tooling
- [x] Documentation (`AGENTS.md`)

## Test Plan

- [x] Console, shared protocol, and Desktop typechecks pass
- [x] Console and Desktop builds pass
- [x] Console protocol/manifest tests and Desktop test suite pass
- [x] Compatibility gate preserves 14 runtime and 21 declaration exports
- [x] Real `npm pack` contains no `workspace:*` metadata or private workspace imports
- [x] Sentinel final review reports no findings

## Changelog

- [x] Apply the `no-changelog` label intentionally; this is a behavior-preserving internal refactor.

## Notes for Reviewers

The shared package owns only types, constants, and stateless helpers. Filesystem and package-root security validation remain in the Console host, and packaged integration tests stay anchored to the published Console compatibility subpath.