### PR TITLE
feat(desktop): sync Windows caption with console themes

### DIFF
--- a/.agents/skills/pr-workflow/SKILL.md
+++ b/.agents/skills/pr-workflow/SKILL.md
@@ -22,6 +22,7 @@ Replace each `<placeholder>` before running. Optional inputs may be left blank �
 - `<draft>` — `true` | `false`. Optional. Default `false`.
 - `<scope_hint>` — Optional. Free-form note restricting review-fix scope (e.g., "only Codex P1/P2"). If omitted, default to "every actionable, unresolved review comment on the PR".
 - `<review_poll_interval>` — Optional. Poll cadence for the Phase 3 background wait loop (e.g., `30s`). If omitted, default ~`30s` for the background poll (or `1m` for the cron fallback).
+- `<review_activation_timeout>` — Optional. Bounded wait after an explicit `@codex` review request for Codex to acknowledge it. Default `60s`. If no Codex reaction, review, or comment appears, treat automated review as unavailable and proceed to merge.
 - `<repo>` — `owner/name` slug. Optional. If omitted, infer from `gh repo view --json nameWithOwner` (must be `sbluemin/fleet-harness`).
 - `<merge_method>` — `squash` | `merge` | `rebase`. Optional. Default `squash` (the repo convention — squash-merge titles read `type(scope): summary (#N)`). Used by Phase 6 auto-merge.
 - `<auto_merge>` — `true` | `false`. Optional. Default `true`. When `true`, Phase 6 merges the PR after approval (rebasing the head onto `<base>` and force-pushing first when it conflicts). When `false`, stop at approval and report the PR as approved-but-unmerged (the legacy behavior).
@@ -97,8 +98,13 @@ This policy governs Phase 4 (classification / verification) and Phase 5 (self-ve
 The Codex automated reviewer (`chatgpt-codex-connector[bot]`) posts asynchronously. The skill **waits with a deterministic background poll that wakes you only when something real changes** — never ask the Admiral to run `/loop` by hand, and prefer this over a fixed-interval cron that re-invokes the model every tick whether or not anything happened. A cheap `gh` loop runs in the background (no model tokens) and re-invokes you on the first genuine signal.
 
 0. **Ensure PR metadata and the right branch.** Confirm `<pr_number>`, `<repo>`, and `<headRefName>` are known. On a fresh run they come from Phase 2; on a resume entry, resolve them first via `gh pr view --json number,headRefName,url` for the current branch (or the `<pr_number>` carried in the resume prompt). Never poll or push without them. Then confirm the **current branch equals `<headRefName>`** (`git branch --show-current`); if it does not, stop and ask the Admiral before editing or committing — do not auto-checkout and never commit fixes onto a non-head branch. Finally confirm the **working tree is clean** (`git status --short`); if there are unrelated uncommitted changes, stop and ask the Admiral before editing — never overwrite them or fold pre-existing changes into a review-fix commit.
-1. **Freeze the wait baseline.** Record what is *already* on the PR so the poll only fires on something new: the latest pushed head commit timestamp `HEAD_TS` (`gh api repos/<repo>/commits/<head_sha> -q .commit.committer.date`, or the time of the Phase 2 / Phase 5 push) and the current review count `BASE_REVIEWS` (`gh pr view <pr_number> --repo <repo> --json reviews -q '.reviews | length'`).
-2. **Launch the background poll (signal-driven, not interval-driven).** Start one `run_in_background` Bash loop that polls with `gh` every ~30s (or `<review_poll_interval>`), capped at ~40 min, and **exits — re-invoking you — only on a genuine signal**, printing which:
+1. **Activate the initial review before waiting.** Apply this gate once per PR, before the first long-running poll. Skip it after Codex has already reacted, reviewed, commented, or been explicitly requested.
+   1. Check PR-body reactions, reviews, and Codex top-level comments. Any `chatgpt-codex-connector[bot]` reaction, review, or comment means the reviewer is active; continue to step 2.
+   2. If no Codex signal exists, post `@codex Please review this PR.` as a PR comment and record its comment ID, URL, and creation time. Do not start the 40-minute poll yet.
+   3. For `<review_activation_timeout>` (default 60 seconds), check every ~10 seconds for a Codex reaction on either the PR body or request comment, a Codex review, or a Codex top-level comment newer than the request. Any one is activation; continue to step 2. An `eyes` reaction means active, not approved.
+   4. If the bounded window expires, refresh all four surfaces once to avoid a boundary race. If no signal exists, set `REVIEW_BYPASS_REASON=codex_activation_timeout` and go directly to Phase 6. This fallback is not approval and never bypasses branch protection or required checks.
+2. **Freeze the wait baseline.** Record what is *already* on the PR so the poll only fires on something new: the latest pushed head commit timestamp `HEAD_TS` (`gh api repos/<repo>/commits/<head_sha> -q .commit.committer.date`, or the time of the Phase 2 / Phase 5 push) and the current review count `BASE_REVIEWS` (`gh pr view <pr_number> --repo <repo> --json reviews -q '.reviews | length'`).
+3. **Launch the background poll (signal-driven, not interval-driven).** Start one `run_in_background` Bash loop that polls with `gh` every ~30s (or `<review_poll_interval>`), capped at ~40 min, and **exits — re-invoking you — only on a genuine signal**, printing which:
    - **approval** — a `chatgpt-codex-connector[bot]` `+1` reaction on the PR body with `created_at > HEAD_TS` (fresh, not a stale carry-over);
    - **new review** — the review count exceeds `BASE_REVIEWS` (a new review pass carries its inline comments);
    - **new top-level** — a Codex top-level comment with `created_at > HEAD_TS`.
@@ -121,10 +127,10 @@ The Codex automated reviewer (`chatgpt-codex-connector[bot]`) posts asynchronous
      echo "SIGNAL=TIMEOUT"; exit 0
      ```
      Do **not** wrap the loop in `nohup … &` — that detaches it from the harness, so its exit never re-invokes you. The `run_in_background` call itself is the only backgrounding needed.
-3. **On wake, read the full state and route.** When the poll exits, read: `gh pr view <pr_number> --repo <repo> --json reviews,comments,reviewDecision`; inline comments `gh api repos/<repo>/pulls/<pr_number>/comments`; top-level comments `gh api repos/<repo>/issues/<pr_number>/comments`; PR-body reactions `gh api repos/<repo>/issues/<pr_number>/reactions -H "Accept: application/vnd.github.squirrel-girl-preview+json"`. Then:
+4. **On wake, read the full state and route.** When the poll exits, read: `gh pr view <pr_number> --repo <repo> --json reviews,comments,reviewDecision`; inline comments `gh api repos/<repo>/pulls/<pr_number>/comments`; top-level comments `gh api repos/<repo>/issues/<pr_number>/comments`; PR-body reactions `gh api repos/<repo>/issues/<pr_number>/reactions -H "Accept: application/vnd.github.squirrel-girl-preview+json"`. Then:
    - **Approval = merge trigger.** A fresh `chatgpt-codex-connector[bot]` `+1` on the PR body (`created_at` newer than both the latest pushed head commit and the most recent `@codex` re-review comment) **and** no new actionable comments → approval is final, go to Phase 6 (auto-merge). A `+1` predating the latest push is stale (GitHub keeps the old reaction) — ignore it. A bare `eyes` reaction means the review is still in progress (pending), not approval.
    - **New actionable feedback** → Phase 4.
-   - **Spurious wake or timeout** (only `eyes`, a re-anchored old comment, or nothing genuinely new) → relaunch the background poll (step 2) and keep waiting.
+   - **Spurious wake or timeout** (only `eyes`, a re-anchored old comment, or nothing genuinely new) → relaunch the background poll (step 3) and keep waiting.
 
 **Fallback — cron.** If the harness cannot re-invoke you when a background task completes, fall back to a recurring `CronCreate` (`*/1 * * * *`, `recurring: true`, prompt re-entering Phase 3 with `<pr_number>`/`<repo>`), armed exactly once; the same baseline, freshness, and re-anchor rules apply on each tick. Stop it with `CronDelete` at Phase 6 (instead of `TaskStop`).
 
@@ -160,9 +166,9 @@ The Codex automated reviewer (`chatgpt-codex-connector[bot]`) posts asynchronous
 
 ### Phase 6 — Auto-merge
 
-Reached only after Phase 3 confirms a final approval (a fresh Codex `+1` with no open actionable comments). When `<auto_merge>` is `false`, skip this phase: stop the Phase 3 wait poll (`TaskStop` the background task, or `CronDelete` the cron-fallback job) and go straight to Phase 7, reporting the PR as approved-but-unmerged.
+Reached after Phase 3 confirms either final approval (a fresh Codex `+1` with no open actionable comments) or `REVIEW_BYPASS_REASON=codex_activation_timeout` from the bounded explicit activation gate. The timeout fallback authorizes normal merge checks only; it never bypasses branch protection or required checks. When `<auto_merge>` is `false`, skip this phase and report the PR as approved-but-unmerged or review-unavailable-and-unmerged.
 
-1. **Stop the wait loop.** Stop the Phase 3 background poll — `TaskStop` its task id (or `CronDelete` the cron-fallback job). Approval is final, no more review polling.
+1. **Stop the wait loop.** If Phase 3 started a background poll, stop it with `TaskStop` (or `CronDelete` for the cron fallback). Under `codex_activation_timeout`, no long-running poll exists; continue directly. No more review polling occurs after this point.
 2. **Check mergeability.** `gh pr view <pr_number> --repo <repo> --json mergeable,mergeStateStatus,baseRefName,headRefName`.
    - `mergeable: MERGEABLE` with `mergeStateStatus` `CLEAN` / `UNSTABLE` / `BEHIND` (no conflict) → go to step 4 (merge directly).
    - `mergeable: CONFLICTING` or `mergeStateStatus: DIRTY` → the head conflicts with `<base>`; go to step 3 (rebase path).
@@ -189,7 +195,7 @@ Then report in Korean:
 - Each review item across all passes: fix / declined / deferred, with verification evidence.
 - Files changed, commit SHA(s), push target(s).
 - Validation commands and pass/fail status; note any check not run.
-- The approval signal observed (Codex `+1` on the PR body) and the `@codex` follow-up comment URL(s).
+- The approval signal observed (Codex `+1` on the PR body), or the explicit activation request URL plus `codex_activation_timeout`; include every `@codex` follow-up comment URL.
 - **Merge outcome**: merged (`<merge_method>` + merge commit SHA + whether a pre-merge rebase/force-push was needed), or — when `<auto_merge>` is `false` or auto-merge halted — the approved-but-unmerged state and the reason. The Phase 3 wait poll was stopped in Phase 6.
 - **Cleanup outcome**: worktree removed / tmux session killed / local branch force-deleted, or skipped (with reason).
 

--- a/.changelog.d/fleet-desktop-added.md
+++ b/.changelog.d/fleet-desktop-added.md
@@ -1,0 +1,5 @@
+---
+section: Added
+---
+- [fleet-console] Synchronize the Fleet Desktop Windows title bar overlay with the saved Fleet Console theme and live theme changes.
+  ko: 저장된 Fleet Console 테마와 실시간 테마 변경에 맞춰 Fleet Desktop Windows 제목 표시줄 오버레이를 동기화합니다.

--- a/runtime/fleet-console/core/host/api-catalog.ts
+++ b/runtime/fleet-console/core/host/api-catalog.ts
@@ -1,4 +1,5 @@
 import { CARRIER_SETTINGS_API_CATALOG } from "./carrier-settings-routes.js";
+import { DESKTOP_THEME_API_CATALOG } from "./desktop-theme-routes.js";
 import { GLOBAL_SETTINGS_API_CATALOG } from "./global-settings-routes.js";
 import { PLUGIN_SETTINGS_API_CATALOG } from "./plugin-settings-routes.js";
 import { SERVER_API_CATALOG } from "./server.js";
@@ -19,6 +20,7 @@ export function buildApiCatalog(): ApiCatalogEntry[] {
   return [
     ...SERVER_API_CATALOG,
     ...CARRIER_SETTINGS_API_CATALOG,
+    ...DESKTOP_THEME_API_CATALOG,
     ...GLOBAL_SETTINGS_API_CATALOG,
     ...PLUGIN_SETTINGS_API_CATALOG,
     ...SYSTEM_FONTS_API_CATALOG,

--- a/runtime/fleet-console/core/host/desktop-theme-routes.ts
+++ b/runtime/fleet-console/core/host/desktop-theme-routes.ts
@@ -1,0 +1,62 @@
+import type http from "node:http";
+
+import {
+  DESKTOP_THEME_EVENTS_PATH,
+  DESKTOP_THEME_PATH,
+  type ConsoleThemeId,
+  type DesktopThemeSnapshot,
+} from "@fleet-console/desktop-protocol";
+
+import type { ApiCatalogEntry } from "./api-catalog.js";
+import { desktopThemeSnapshot } from "./desktop-theme.js";
+
+interface DesktopThemeRouteDeps {
+  readonly getTheme: () => ConsoleThemeId;
+  readonly isAuthorized: (req: http.IncomingMessage) => boolean;
+  readonly subscribe: (res: http.ServerResponse, snapshot: DesktopThemeSnapshot) => void;
+  readonly writeJson: (res: http.ServerResponse, status: number, body: unknown) => void;
+}
+
+interface DesktopThemeRouteContext {
+  readonly req: http.IncomingMessage;
+  readonly res: http.ServerResponse;
+  readonly pathname: string;
+}
+
+export const DESKTOP_THEME_API_CATALOG: readonly ApiCatalogEntry[] = [
+  {
+    method: "GET",
+    path: DESKTOP_THEME_PATH,
+    summary: "Get the Console-owned Desktop title bar theme.",
+    category: "Desktop",
+    gate: "origin-strict",
+  },
+  {
+    method: "GET",
+    path: DESKTOP_THEME_EVENTS_PATH,
+    summary: "Stream server-confirmed Desktop title bar theme changes.",
+    category: "Desktop",
+    gate: "origin-strict",
+  },
+];
+
+export function createDesktopThemeRouter(deps: DesktopThemeRouteDeps): (context: DesktopThemeRouteContext) => boolean {
+  return ({ req, res, pathname }) => {
+    if (pathname !== DESKTOP_THEME_PATH && pathname !== DESKTOP_THEME_EVENTS_PATH) return false;
+    if (req.method !== "GET") {
+      deps.writeJson(res, 405, { error: "Method not allowed" });
+      return true;
+    }
+    if (!deps.isAuthorized(req)) {
+      deps.writeJson(res, 401, { error: "unauthorized" });
+      return true;
+    }
+    const snapshot = desktopThemeSnapshot(deps.getTheme());
+    if (pathname === DESKTOP_THEME_PATH) {
+      deps.writeJson(res, 200, snapshot);
+      return true;
+    }
+    deps.subscribe(res, snapshot);
+    return true;
+  };
+}

--- a/runtime/fleet-console/core/host/desktop-theme-routes.ts
+++ b/runtime/fleet-console/core/host/desktop-theme-routes.ts
@@ -1,14 +1,13 @@
 import type http from "node:http";
 
+import type { ApiCatalogEntry } from "./api-catalog.js";
+import type { ConsoleThemeId } from "./console-settings.js";
 import {
   DESKTOP_THEME_EVENTS_PATH,
   DESKTOP_THEME_PATH,
-  type ConsoleThemeId,
+  desktopThemeSnapshot,
   type DesktopThemeSnapshot,
-} from "@fleet-console/desktop-protocol";
-
-import type { ApiCatalogEntry } from "./api-catalog.js";
-import { desktopThemeSnapshot } from "./desktop-theme.js";
+} from "./desktop-theme.js";
 
 interface DesktopThemeRouteDeps {
   readonly getTheme: () => ConsoleThemeId;

--- a/runtime/fleet-console/core/host/desktop-theme.ts
+++ b/runtime/fleet-console/core/host/desktop-theme.ts
@@ -1,9 +1,9 @@
 import type { ConsoleThemeId, DesktopThemeSnapshot } from "@fleet-console/desktop-protocol";
 
 const DESKTOP_TITLE_BAR_OVERLAYS: Readonly<Record<ConsoleThemeId, DesktopThemeSnapshot["titleBarOverlay"]>> = {
-  instrument: { color: "#090f15", symbolColor: "#989fa6", height: 44 },
-  maritime: { color: "#041729", symbolColor: "#c8c4b7", height: 44 },
-  carbon: { color: "#101215", symbolColor: "#bfc1c3", height: 44 },
+  instrument: { color: "#090f15", symbolColor: "#989fa6", height: 43 },
+  maritime: { color: "#041729", symbolColor: "#c8c4b7", height: 43 },
+  carbon: { color: "#101215", symbolColor: "#bfc1c3", height: 43 },
 };
 
 export function desktopThemeSnapshot(theme: ConsoleThemeId): DesktopThemeSnapshot {

--- a/runtime/fleet-console/core/host/desktop-theme.ts
+++ b/runtime/fleet-console/core/host/desktop-theme.ts
@@ -1,4 +1,19 @@
-import type { ConsoleThemeId, DesktopThemeSnapshot } from "@fleet-console/desktop-protocol";
+import type { ConsoleThemeId } from "./console-settings.js";
+
+export interface DesktopTitleBarOverlay {
+  readonly color: string;
+  readonly symbolColor: string;
+  readonly height: number;
+}
+
+export interface DesktopThemeSnapshot {
+  readonly theme: ConsoleThemeId;
+  readonly titleBarOverlay: DesktopTitleBarOverlay;
+}
+
+export const DESKTOP_THEME_PATH = "/api/v1/desktop/theme";
+export const DESKTOP_THEME_EVENTS_PATH = "/api/v1/desktop/theme/events";
+export const DESKTOP_THEME_EVENT = "desktop:theme";
 
 const DESKTOP_TITLE_BAR_OVERLAYS: Readonly<Record<ConsoleThemeId, DesktopThemeSnapshot["titleBarOverlay"]>> = {
   instrument: { color: "#03080e", symbolColor: "#989fa6", height: 43 },

--- a/runtime/fleet-console/core/host/desktop-theme.ts
+++ b/runtime/fleet-console/core/host/desktop-theme.ts
@@ -1,7 +1,7 @@
 import type { ConsoleThemeId, DesktopThemeSnapshot } from "@fleet-console/desktop-protocol";
 
 const DESKTOP_TITLE_BAR_OVERLAYS: Readonly<Record<ConsoleThemeId, DesktopThemeSnapshot["titleBarOverlay"]>> = {
-  instrument: { color: "#090f15", symbolColor: "#989fa6", height: 43 },
+  instrument: { color: "#03080e", symbolColor: "#989fa6", height: 43 },
   maritime: { color: "#041729", symbolColor: "#c8c4b7", height: 43 },
   carbon: { color: "#101215", symbolColor: "#bfc1c3", height: 43 },
 };

--- a/runtime/fleet-console/core/host/desktop-theme.ts
+++ b/runtime/fleet-console/core/host/desktop-theme.ts
@@ -1,0 +1,11 @@
+import type { ConsoleThemeId, DesktopThemeSnapshot } from "@fleet-console/desktop-protocol";
+
+const DESKTOP_TITLE_BAR_OVERLAYS: Readonly<Record<ConsoleThemeId, DesktopThemeSnapshot["titleBarOverlay"]>> = {
+  instrument: { color: "#090f15", symbolColor: "#989fa6", height: 44 },
+  maritime: { color: "#041729", symbolColor: "#c8c4b7", height: 44 },
+  carbon: { color: "#101215", symbolColor: "#bfc1c3", height: 44 },
+};
+
+export function desktopThemeSnapshot(theme: ConsoleThemeId): DesktopThemeSnapshot {
+  return { theme, titleBarOverlay: { ...DESKTOP_TITLE_BAR_OVERLAYS[theme] } };
+}

--- a/runtime/fleet-console/core/host/global-settings-routes.ts
+++ b/runtime/fleet-console/core/host/global-settings-routes.ts
@@ -3,7 +3,7 @@ import type http from "node:http";
 import type { DurableJsonStore } from "@dotobokuri/core-infra";
 
 import type { ApiCatalogEntry } from "./api-catalog.js";
-import { DEFAULT_UI_FONT_SETTINGS, isUiFontSettings, type ConsoleSettingsData } from "./console-settings.js";
+import { DEFAULT_UI_FONT_SETTINGS, isUiFontSettings, type ConsoleSettingsData, type ConsoleThemeId } from "./console-settings.js";
 import type { GlobalSettingsMutationResult, GlobalSettingsState } from "./global-settings-types.js";
 
 interface GlobalSettingsRouteDeps {
@@ -11,6 +11,7 @@ interface GlobalSettingsRouteDeps {
   readonly isAuthorized: (req: http.IncomingMessage) => boolean;
   readonly readJsonBody: <T>(req: http.IncomingMessage) => Promise<T | null>;
   readonly writeJson: (res: http.ServerResponse, status: number, body: unknown) => void;
+  readonly onThemeChanged?: (theme: ConsoleThemeId) => void;
 }
 
 interface GlobalSettingsRouteContext {
@@ -108,6 +109,7 @@ async function mutateGlobalSettings(
     deps.writeJson(res, 400, { error: "invalid_ui_font" });
     return;
   }
+  const theme = body.theme === "instrument" || body.theme === "maritime" || body.theme === "carbon" ? body.theme : undefined;
   const updated = deps.consoleSettingsStore.update((current) => ({
     ...current,
     version: 1,
@@ -116,11 +118,12 @@ async function mutateGlobalSettings(
       ...(body.consolePortMode === "dynamic" || body.consolePortMode === "static" ? { consolePortMode: body.consolePortMode } : {}),
       ...(isValidConsoleStaticPort(body.consoleStaticPort) ? { consoleStaticPort: body.consoleStaticPort } : {}),
       ...(body.language === "auto" || body.language === "en" || body.language === "ko" ? { language: body.language } : {}),
-      ...(body.theme === "instrument" || body.theme === "maritime" || body.theme === "carbon" ? { theme: body.theme } : {}),
+      ...(theme !== undefined ? { theme } : {}),
       ...(isUiFontSettings(body.uiFont) ? { uiFont: body.uiFont } : {}),
     },
     plugins: current.plugins,
   }));
+  if (theme !== undefined) deps.onThemeChanged?.(theme);
   const response: GlobalSettingsMutationResult = { state: toGlobalSettingsState(updated) };
   deps.writeJson(res, 200, response);
 }

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -8,6 +8,7 @@ import {
   registerDefaultCarriers,
 } from "@dotobokuri/fleet-carriers";
 import { createInfraServices } from "@dotobokuri/core-infra";
+import { DESKTOP_THEME_EVENT, type ConsoleThemeId } from "@fleet-console/desktop-protocol";
 
 import { buildApiCatalog, type ApiCatalogEntry } from "./api-catalog.js";
 import type { ConsoleHealth, ConsoleObserverStatus, ConsoleTheaterFolderListResponse, ConsoleTheaterInfo, ConsoleUpdateApplyAcceptedResponse } from "./api-types.js";
@@ -15,6 +16,8 @@ import { createCarrierSettingsRouter } from "./carrier-settings-routes.js";
 import { createCodexWorkspaceContextRouter } from "./codex/context-routes.js";
 import { createCodexGateway } from "./codex/gateway.js";
 import { createConsoleSettingsStore } from "./console-settings.js";
+import { desktopThemeSnapshot } from "./desktop-theme.js";
+import { createDesktopThemeRouter } from "./desktop-theme-routes.js";
 import { createConsoleDurableStateStore, emptyDurableConsoleState, type DurableConsoleState } from "./durable-state.js";
 import { createGlobalSettingsRouter } from "./global-settings-routes.js";
 import { createPluginSettingsRouter } from "./plugin-settings-routes.js";
@@ -292,6 +295,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   const pluginCleanupCallbacks = new Set<() => void | Promise<void>>();
   const pluginEventListeners = new Map<string, Set<(payload: unknown) => void>>();
   const operationSseSubscribers = new Set<http.ServerResponse>();
+  const desktopThemeSseSubscribers = new Set<http.ServerResponse>();
   let unsubscribeUpdateCheckChanges = updateCheck.onChange?.(() => {
     broadcastUpdateAvailable();
   }) ?? null;
@@ -456,6 +460,25 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     isAuthorized: isTerminalAuthorized,
     readJsonBody,
     writeJson,
+    onThemeChanged: broadcastDesktopThemeChanged,
+  });
+  const desktopThemeRouter = createDesktopThemeRouter({
+    getTheme: () => consoleSettingsStore.load().general?.theme ?? "instrument",
+    isAuthorized: isExactConsoleOrigin,
+    writeJson,
+    subscribe: (res, snapshot) => {
+      res.writeHead(200, withSecurityHeaders({
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+      }));
+      res.write(":connected\n\n");
+      res.write(encodeSseData(DESKTOP_THEME_EVENT, snapshot));
+      desktopThemeSseSubscribers.add(res);
+      res.on("close", () => {
+        desktopThemeSseSubscribers.delete(res);
+      });
+    },
   });
   const pluginSettingsRouter = createPluginSettingsRouter({
     consoleSettingsStore,
@@ -531,6 +554,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     if (await systemFontsRouter(ctx)) return true;
     return globalSettingsRouter(ctx);
   });
+  routeRegistry.register("/api/v1/desktop", desktopThemeRouter);
   routeRegistry.register("/plugin-runtime", handlePluginRuntimeRoute);
 
   function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
@@ -1032,6 +1056,14 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     if (operationSseSubscribers.size === 0) return;
     const data = encodeSseData("update:available", {});
     for (const res of operationSseSubscribers) {
+      res.write(data);
+    }
+  }
+
+  function broadcastDesktopThemeChanged(theme: ConsoleThemeId): void {
+    if (desktopThemeSseSubscribers.size === 0) return;
+    const data = encodeSseData(DESKTOP_THEME_EVENT, desktopThemeSnapshot(theme));
+    for (const res of desktopThemeSseSubscribers) {
       res.write(data);
     }
   }

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -8,15 +8,14 @@ import {
   registerDefaultCarriers,
 } from "@dotobokuri/fleet-carriers";
 import { createInfraServices } from "@dotobokuri/core-infra";
-import { DESKTOP_THEME_EVENT, type ConsoleThemeId } from "@fleet-console/desktop-protocol";
 
 import { buildApiCatalog, type ApiCatalogEntry } from "./api-catalog.js";
 import type { ConsoleHealth, ConsoleObserverStatus, ConsoleTheaterFolderListResponse, ConsoleTheaterInfo, ConsoleUpdateApplyAcceptedResponse } from "./api-types.js";
 import { createCarrierSettingsRouter } from "./carrier-settings-routes.js";
 import { createCodexWorkspaceContextRouter } from "./codex/context-routes.js";
 import { createCodexGateway } from "./codex/gateway.js";
-import { createConsoleSettingsStore } from "./console-settings.js";
-import { desktopThemeSnapshot } from "./desktop-theme.js";
+import { createConsoleSettingsStore, type ConsoleThemeId } from "./console-settings.js";
+import { DESKTOP_THEME_EVENT, desktopThemeSnapshot } from "./desktop-theme.js";
 import { createDesktopThemeRouter } from "./desktop-theme-routes.js";
 import { createConsoleDurableStateStore, emptyDurableConsoleState, type DurableConsoleState } from "./durable-state.js";
 import { createGlobalSettingsRouter } from "./global-settings-routes.js";

--- a/runtime/fleet-console/desktop-protocol/index.ts
+++ b/runtime/fleet-console/desktop-protocol/index.ts
@@ -33,20 +33,6 @@ export interface ResolveCanonicalLocalConsolePathsInput {
   readonly packageRoot: string;
 }
 
-export type ConsoleThemeId = "instrument" | "maritime" | "carbon";
-export type DesktopThemeId = string;
-
-export interface DesktopTitleBarOverlay {
-  readonly color: string;
-  readonly symbolColor: string;
-  readonly height: number;
-}
-
-export interface DesktopThemeSnapshot {
-  readonly theme: DesktopThemeId;
-  readonly titleBarOverlay: DesktopTitleBarOverlay;
-}
-
 export const DESKTOP_PROTOCOL_VERSION = 1;
 export const DESKTOP_RESOURCE_ROOT_ENV = "FLEET_CONSOLE_RESOURCE_ROOT";
 export const DESKTOP_OWNER_ID_ENV = "FLEET_CONSOLE_OWNER_ID";
@@ -54,9 +40,6 @@ export const DESKTOP_OWNER_KIND_ENV = "FLEET_CONSOLE_OWNER_KIND";
 export const DESKTOP_PROTOCOL_VERSION_ENV = "FLEET_CONSOLE_PROTOCOL_VERSION";
 export const DESKTOP_RESOURCE_ROOT_MARKER = ".fleet-console-resource-root";
 export const DESKTOP_DEVELOPMENT_ENV = "FLEET_CONSOLE_DESKTOP_DEVELOPMENT";
-export const DESKTOP_THEME_PATH = "/api/v1/desktop/theme";
-export const DESKTOP_THEME_EVENTS_PATH = "/api/v1/desktop/theme/events";
-export const DESKTOP_THEME_EVENT = "desktop:theme";
 
 const LOCK_DIR_NAME = "fleet-console";
 const LOCK_FILE_NAME = "console.lock";
@@ -64,10 +47,6 @@ const CONSOLE_DATA_DIR_NAME = "console";
 const CONSOLE_STATE_FILE_NAME = "state.json";
 const CONSOLE_SETTINGS_FILE_NAME = "settings.json";
 const CONSOLE_CAPTURES_DIR_NAME = "captures";
-const ELECTRON_COLOR_PATTERN = /^#(?:[\da-f]{3,4}|[\da-f]{6}|[\da-f]{8})$/i;
-const MIN_TITLE_BAR_OVERLAY_HEIGHT = 24;
-const MAX_TITLE_BAR_OVERLAY_HEIGHT = 128;
-const DESKTOP_THEME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 
 export function isDesktopDevelopmentEnvironment(env: Readonly<Record<string, string | undefined>>): boolean {
   return env[DESKTOP_DEVELOPMENT_ENV] === "1";
@@ -111,30 +90,4 @@ export function formatDesktopResourceRootMarker(): string {
 
 export function isDesktopResourceRootMarkerValid(content: string): boolean {
   return content.trim() === String(DESKTOP_PROTOCOL_VERSION);
-}
-
-export function isDesktopThemeSnapshot(value: unknown): value is DesktopThemeSnapshot {
-  if (!isRecord(value) || !isDesktopThemeId(value.theme) || !isRecord(value.titleBarOverlay)) return false;
-  return isElectronColor(value.titleBarOverlay.color)
-    && isElectronColor(value.titleBarOverlay.symbolColor)
-    && isTitleBarOverlayHeight(value.titleBarOverlay.height);
-}
-
-function isDesktopThemeId(value: unknown): value is DesktopThemeId {
-  return typeof value === "string" && DESKTOP_THEME_ID_PATTERN.test(value);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isElectronColor(value: unknown): value is string {
-  return typeof value === "string" && ELECTRON_COLOR_PATTERN.test(value);
-}
-
-function isTitleBarOverlayHeight(value: unknown): value is number {
-  return typeof value === "number"
-    && Number.isInteger(value)
-    && value >= MIN_TITLE_BAR_OVERLAY_HEIGHT
-    && value <= MAX_TITLE_BAR_OVERLAY_HEIGHT;
 }

--- a/runtime/fleet-console/desktop-protocol/index.ts
+++ b/runtime/fleet-console/desktop-protocol/index.ts
@@ -33,6 +33,20 @@ export interface ResolveCanonicalLocalConsolePathsInput {
   readonly packageRoot: string;
 }
 
+export type ConsoleThemeId = "instrument" | "maritime" | "carbon";
+export type DesktopThemeId = string;
+
+export interface DesktopTitleBarOverlay {
+  readonly color: string;
+  readonly symbolColor: string;
+  readonly height: number;
+}
+
+export interface DesktopThemeSnapshot {
+  readonly theme: DesktopThemeId;
+  readonly titleBarOverlay: DesktopTitleBarOverlay;
+}
+
 export const DESKTOP_PROTOCOL_VERSION = 1;
 export const DESKTOP_RESOURCE_ROOT_ENV = "FLEET_CONSOLE_RESOURCE_ROOT";
 export const DESKTOP_OWNER_ID_ENV = "FLEET_CONSOLE_OWNER_ID";
@@ -40,6 +54,9 @@ export const DESKTOP_OWNER_KIND_ENV = "FLEET_CONSOLE_OWNER_KIND";
 export const DESKTOP_PROTOCOL_VERSION_ENV = "FLEET_CONSOLE_PROTOCOL_VERSION";
 export const DESKTOP_RESOURCE_ROOT_MARKER = ".fleet-console-resource-root";
 export const DESKTOP_DEVELOPMENT_ENV = "FLEET_CONSOLE_DESKTOP_DEVELOPMENT";
+export const DESKTOP_THEME_PATH = "/api/v1/desktop/theme";
+export const DESKTOP_THEME_EVENTS_PATH = "/api/v1/desktop/theme/events";
+export const DESKTOP_THEME_EVENT = "desktop:theme";
 
 const LOCK_DIR_NAME = "fleet-console";
 const LOCK_FILE_NAME = "console.lock";
@@ -47,6 +64,10 @@ const CONSOLE_DATA_DIR_NAME = "console";
 const CONSOLE_STATE_FILE_NAME = "state.json";
 const CONSOLE_SETTINGS_FILE_NAME = "settings.json";
 const CONSOLE_CAPTURES_DIR_NAME = "captures";
+const ELECTRON_COLOR_PATTERN = /^#(?:[\da-f]{3,4}|[\da-f]{6}|[\da-f]{8})$/i;
+const MIN_TITLE_BAR_OVERLAY_HEIGHT = 24;
+const MAX_TITLE_BAR_OVERLAY_HEIGHT = 128;
+const DESKTOP_THEME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 
 export function isDesktopDevelopmentEnvironment(env: Readonly<Record<string, string | undefined>>): boolean {
   return env[DESKTOP_DEVELOPMENT_ENV] === "1";
@@ -90,4 +111,30 @@ export function formatDesktopResourceRootMarker(): string {
 
 export function isDesktopResourceRootMarkerValid(content: string): boolean {
   return content.trim() === String(DESKTOP_PROTOCOL_VERSION);
+}
+
+export function isDesktopThemeSnapshot(value: unknown): value is DesktopThemeSnapshot {
+  if (!isRecord(value) || !isDesktopThemeId(value.theme) || !isRecord(value.titleBarOverlay)) return false;
+  return isElectronColor(value.titleBarOverlay.color)
+    && isElectronColor(value.titleBarOverlay.symbolColor)
+    && isTitleBarOverlayHeight(value.titleBarOverlay.height);
+}
+
+function isDesktopThemeId(value: unknown): value is DesktopThemeId {
+  return typeof value === "string" && DESKTOP_THEME_ID_PATTERN.test(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isElectronColor(value: unknown): value is string {
+  return typeof value === "string" && ELECTRON_COLOR_PATTERN.test(value);
+}
+
+function isTitleBarOverlayHeight(value: unknown): value is number {
+  return typeof value === "number"
+    && Number.isInteger(value)
+    && value >= MIN_TITLE_BAR_OVERLAY_HEIGHT
+    && value <= MAX_TITLE_BAR_OVERLAY_HEIGHT;
 }

--- a/runtime/fleet-console/tests/desktop-protocol.test.ts
+++ b/runtime/fleet-console/tests/desktop-protocol.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { formatDesktopResourceRootMarker, isDesktopResourceRootMarkerValid } from "@fleet-console/desktop-protocol";
+import { formatDesktopResourceRootMarker, isDesktopResourceRootMarkerValid, isDesktopThemeSnapshot } from "@fleet-console/desktop-protocol";
 
 import {
   DESKTOP_DEVELOPMENT_ENV,
@@ -42,6 +42,18 @@ describe("desktop protocol", () => {
     expect(source).not.toMatch(/node:(?:fs|child_process)/);
     expect(source).not.toMatch(/(?:@dotobokuri\/|fleet-desktop|fleet-plugins)/);
     expect(source).not.toMatch(/\b(?:process|electron)\b/);
+    expect(source).not.toContain("DESKTOP_TITLE_BAR_OVERLAYS");
+    expect(source).not.toContain("desktopThemeSnapshot");
+  });
+
+  it("accepts safely shaped future Console overlay colors without bundling a palette", () => {
+    expect(isDesktopThemeSnapshot({ theme: "maritime", titleBarOverlay: { color: "#123456", symbolColor: "#abcdef", height: 48 } })).toBe(true);
+    expect(isDesktopThemeSnapshot({ theme: "future-aurora", titleBarOverlay: { color: "#123456", symbolColor: "#abcdef", height: 48 } })).toBe(true);
+    expect(isDesktopThemeSnapshot({ theme: "carbon", titleBarOverlay: { color: "#1234", symbolColor: "#abc", height: 52 } })).toBe(true);
+    expect(isDesktopThemeSnapshot({ theme: "future aurora", titleBarOverlay: { color: "#123456", symbolColor: "#abcdef", height: 48 } })).toBe(false);
+    expect(isDesktopThemeSnapshot({ theme: "carbon", titleBarOverlay: { color: "white", symbolColor: "#abcdef", height: 44 } })).toBe(false);
+    expect(isDesktopThemeSnapshot({ theme: "carbon", titleBarOverlay: { color: "#abcdef", symbolColor: "#abcdef", height: 12.5 } })).toBe(false);
+    expect(isDesktopThemeSnapshot({ theme: "carbon", titleBarOverlay: { color: "#abcdef", symbolColor: "#abcdef", height: 129 } })).toBe(false);
   });
 
   it("validates the marked resource root and exact owner protocol", () => {

--- a/runtime/fleet-console/tests/desktop-protocol.test.ts
+++ b/runtime/fleet-console/tests/desktop-protocol.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { formatDesktopResourceRootMarker, isDesktopResourceRootMarkerValid, isDesktopThemeSnapshot } from "@fleet-console/desktop-protocol";
+import { formatDesktopResourceRootMarker, isDesktopResourceRootMarkerValid } from "@fleet-console/desktop-protocol";
 
 import {
   DESKTOP_DEVELOPMENT_ENV,
@@ -46,14 +46,10 @@ describe("desktop protocol", () => {
     expect(source).not.toContain("desktopThemeSnapshot");
   });
 
-  it("accepts safely shaped future Console overlay colors without bundling a palette", () => {
-    expect(isDesktopThemeSnapshot({ theme: "maritime", titleBarOverlay: { color: "#123456", symbolColor: "#abcdef", height: 48 } })).toBe(true);
-    expect(isDesktopThemeSnapshot({ theme: "future-aurora", titleBarOverlay: { color: "#123456", symbolColor: "#abcdef", height: 48 } })).toBe(true);
-    expect(isDesktopThemeSnapshot({ theme: "carbon", titleBarOverlay: { color: "#1234", symbolColor: "#abc", height: 52 } })).toBe(true);
-    expect(isDesktopThemeSnapshot({ theme: "future aurora", titleBarOverlay: { color: "#123456", symbolColor: "#abcdef", height: 48 } })).toBe(false);
-    expect(isDesktopThemeSnapshot({ theme: "carbon", titleBarOverlay: { color: "white", symbolColor: "#abcdef", height: 44 } })).toBe(false);
-    expect(isDesktopThemeSnapshot({ theme: "carbon", titleBarOverlay: { color: "#abcdef", symbolColor: "#abcdef", height: 12.5 } })).toBe(false);
-    expect(isDesktopThemeSnapshot({ theme: "carbon", titleBarOverlay: { color: "#abcdef", symbolColor: "#abcdef", height: 129 } })).toBe(false);
+  it("publishes no theme transport exports", () => {
+    const source = fs.readFileSync(path.join(CONSOLE_PACKAGE_ROOT, "desktop-protocol", "index.ts"), "utf8");
+
+    expect(source).not.toMatch(/^export (?:type |interface |const |function )(?:ConsoleThemeId|DesktopThemeId|DesktopTitleBarOverlay|DesktopThemeSnapshot|DESKTOP_THEME_PATH|DESKTOP_THEME_EVENTS_PATH|DESKTOP_THEME_EVENT|isDesktopThemeSnapshot)\b/gmu);
   });
 
   it("validates the marked resource root and exact owner protocol", () => {

--- a/runtime/fleet-console/tests/desktop-theme-routes.test.ts
+++ b/runtime/fleet-console/tests/desktop-theme-routes.test.ts
@@ -1,0 +1,65 @@
+import type http from "node:http";
+
+import { describe, expect, it } from "vitest";
+
+import { DESKTOP_THEME_EVENTS_PATH, DESKTOP_THEME_PATH } from "@fleet-console/desktop-protocol";
+
+import { desktopThemeSnapshot } from "../core/host/desktop-theme.js";
+import { createDesktopThemeRouter, DESKTOP_THEME_API_CATALOG } from "../core/host/desktop-theme-routes.js";
+
+describe("desktop theme routes", () => {
+  it("declares snapshot and SSE endpoints as exact-origin only", () => {
+    expect(DESKTOP_THEME_API_CATALOG.map((entry) => entry.gate)).toEqual(["origin-strict", "origin-strict"]);
+  });
+
+  it("serves the Console-owned native overlay snapshot", () => {
+    const harness = createHarness("maritime");
+
+    expect(harness.router({ req: request("GET"), res: response(), pathname: DESKTOP_THEME_PATH })).toBe(true);
+    expect(harness.writes).toEqual([{ status: 200, body: desktopThemeSnapshot("maritime") }]);
+  });
+
+  it("subscribes SSE clients with the current server-confirmed snapshot", () => {
+    const harness = createHarness("carbon");
+    const res = response();
+
+    expect(harness.router({ req: request("GET"), res, pathname: DESKTOP_THEME_EVENTS_PATH })).toBe(true);
+    expect(harness.subscriptions).toEqual([{ res, snapshot: desktopThemeSnapshot("carbon") }]);
+  });
+
+  it("keeps the additive endpoints method-scoped and lets other routes fall through", () => {
+    const harness = createHarness("instrument");
+
+    expect(harness.router({ req: request("POST"), res: response(), pathname: DESKTOP_THEME_PATH })).toBe(true);
+    expect(harness.writes).toEqual([{ status: 405, body: { error: "Method not allowed" } }]);
+    expect(harness.router({ req: request("GET"), res: response(), pathname: "/api/v1/desktop/other" })).toBe(false);
+  });
+
+  it("rejects a cross-origin subscriber before opening an SSE response", () => {
+    const harness = createHarness("instrument", false);
+
+    expect(harness.router({ req: request("GET"), res: response(), pathname: DESKTOP_THEME_EVENTS_PATH })).toBe(true);
+    expect(harness.writes).toEqual([{ status: 401, body: { error: "unauthorized" } }]);
+    expect(harness.subscriptions).toEqual([]);
+  });
+});
+
+function createHarness(theme: "instrument" | "maritime" | "carbon", authorized = true) {
+  const writes: { status: number; body: unknown }[] = [];
+  const subscriptions: { res: http.ServerResponse; snapshot: ReturnType<typeof desktopThemeSnapshot> }[] = [];
+  const router = createDesktopThemeRouter({
+    getTheme: () => theme,
+    isAuthorized: () => authorized,
+    writeJson: (_res, status, body) => { writes.push({ status, body }); },
+    subscribe: (res, snapshot) => { subscriptions.push({ res, snapshot }); },
+  });
+  return { router, writes, subscriptions };
+}
+
+function request(method: string): http.IncomingMessage {
+  return { method } as http.IncomingMessage;
+}
+
+function response(): http.ServerResponse {
+  return {} as http.ServerResponse;
+}

--- a/runtime/fleet-console/tests/desktop-theme-routes.test.ts
+++ b/runtime/fleet-console/tests/desktop-theme-routes.test.ts
@@ -2,9 +2,7 @@ import type http from "node:http";
 
 import { describe, expect, it } from "vitest";
 
-import { DESKTOP_THEME_EVENTS_PATH, DESKTOP_THEME_PATH } from "@fleet-console/desktop-protocol";
-
-import { desktopThemeSnapshot } from "../core/host/desktop-theme.js";
+import { DESKTOP_THEME_EVENTS_PATH, DESKTOP_THEME_PATH, desktopThemeSnapshot } from "../core/host/desktop-theme.js";
 import { createDesktopThemeRouter, DESKTOP_THEME_API_CATALOG } from "../core/host/desktop-theme-routes.js";
 
 describe("desktop theme routes", () => {

--- a/runtime/fleet-console/tests/desktop-theme.test.ts
+++ b/runtime/fleet-console/tests/desktop-theme.test.ts
@@ -12,7 +12,7 @@ describe("Console Desktop theme mapping", () => {
   it("keeps native title bar colors in parity with the Console CSS theme tokens", () => {
     const css = fs.readFileSync(path.join(CONSOLE_PACKAGE_ROOT, "core", "client", "src", "styles", "theme.css"), "utf8");
     expect(desktopThemeSnapshot("instrument").titleBarOverlay).toMatchObject({
-      color: oklchToHex(readToken(css, "base", "ink-deep")),
+      color: oklchToHex(readToken(css, "base", "canvas-sea-core")),
       symbolColor: oklchToHex(readToken(css, "base", "text-secondary")),
       height: 43,
     });

--- a/runtime/fleet-console/tests/desktop-theme.test.ts
+++ b/runtime/fleet-console/tests/desktop-theme.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { desktopThemeSnapshot } from "../core/host/desktop-theme.js";
+
+const CONSOLE_PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("Console Desktop theme mapping", () => {
+  it("keeps native title bar colors in parity with the Console CSS theme tokens", () => {
+    const css = fs.readFileSync(path.join(CONSOLE_PACKAGE_ROOT, "core", "client", "src", "styles", "theme.css"), "utf8");
+    expect(desktopThemeSnapshot("instrument").titleBarOverlay).toMatchObject({
+      color: oklchToHex(readToken(css, "base", "ink-deep")),
+      symbolColor: oklchToHex(readToken(css, "base", "text-secondary")),
+    });
+    for (const theme of ["maritime", "carbon"] as const) {
+      expect(desktopThemeSnapshot(theme).titleBarOverlay).toMatchObject({
+        color: oklchToHex(readToken(css, theme, "ink-deep")),
+        symbolColor: oklchToHex(readToken(css, theme, "ink-spectral")),
+      });
+    }
+  });
+});
+
+function readToken(css: string, theme: "base" | "maritime" | "carbon", token: string): [number, number, number] {
+  const tokenPattern = new RegExp(`--${token}: oklch\\(([^%]+)% ([^ ]+) ([^)]+)\\);`, "u");
+  const blocks = theme === "base"
+    ? [css.slice(0, css.indexOf(':root[data-theme="instrument"]'))]
+    : [...css.matchAll(new RegExp(`:root\\[data-theme="${theme}"\\][^{]*\\{([^}]*)\\}`, "gu"))].map((match) => match[1] ?? "");
+  for (const block of blocks) {
+    const match = block.match(tokenPattern);
+    if (match) return [Number(match[1]), Number(match[2]), Number(match[3])];
+  }
+  throw new Error(`missing_theme_token:${theme}:${token}`);
+}
+
+function oklchToHex([lightnessPercent, chroma, hue]: [number, number, number]): string {
+  const lightness = lightnessPercent / 100;
+  const a = chroma * Math.cos(hue * Math.PI / 180);
+  const b = chroma * Math.sin(hue * Math.PI / 180);
+  const l = (lightness + 0.3963377774 * a + 0.2158037573 * b) ** 3;
+  const m = (lightness - 0.1055613458 * a - 0.0638541728 * b) ** 3;
+  const s = (lightness - 0.0894841775 * a - 1.291485548 * b) ** 3;
+  const channels = [
+    4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  ];
+  return `#${channels.map(toSrgbByte).map((channel) => channel.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function toSrgbByte(value: number): number {
+  const srgb = value <= 0.0031308 ? 12.92 * value : 1.055 * value ** (1 / 2.4) - 0.055;
+  return Math.round(Math.max(0, Math.min(1, srgb)) * 255);
+}

--- a/runtime/fleet-console/tests/desktop-theme.test.ts
+++ b/runtime/fleet-console/tests/desktop-theme.test.ts
@@ -14,11 +14,13 @@ describe("Console Desktop theme mapping", () => {
     expect(desktopThemeSnapshot("instrument").titleBarOverlay).toMatchObject({
       color: oklchToHex(readToken(css, "base", "ink-deep")),
       symbolColor: oklchToHex(readToken(css, "base", "text-secondary")),
+      height: 43,
     });
     for (const theme of ["maritime", "carbon"] as const) {
       expect(desktopThemeSnapshot(theme).titleBarOverlay).toMatchObject({
         color: oklchToHex(readToken(css, theme, "ink-deep")),
         symbolColor: oklchToHex(readToken(css, theme, "ink-spectral")),
+        height: 43,
       });
     }
   });

--- a/runtime/fleet-console/tests/global-settings-routes.test.ts
+++ b/runtime/fleet-console/tests/global-settings-routes.test.ts
@@ -16,6 +16,7 @@ interface RouterHarnessOptions {
   readonly bodyNull?: boolean;
   readonly general?: ConsoleGeneralSettings;
   readonly plugins?: ConsoleSettingsData["plugins"];
+  readonly onThemeChanged?: (theme: "instrument" | "maritime" | "carbon") => void;
 }
 
 describe("global settings routes", () => {
@@ -93,6 +94,20 @@ describe("global settings routes", () => {
       expect(harness.writes[0]).toEqual({ status: 200, body: { state: { consolePortMode: "dynamic", consoleStaticPort: null, language: "auto", theme, uiFont: { source: "builtin", id: "manrope", size: 14 } } } });
       expect(harness.currentGeneral()).toMatchObject({ theme });
     }
+  });
+
+  it("publishes a theme only after the durable settings update succeeds", async () => {
+    const published: string[] = [];
+    const harness = createRouterHarness({
+      authorized: true,
+      body: { theme: "carbon" },
+      onThemeChanged: (theme) => published.push(theme),
+    });
+
+    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/api/v1/settings/global" });
+
+    expect(harness.currentGeneral()?.theme).toBe("carbon");
+    expect(published).toEqual(["carbon"]);
   });
 
   it("PUT /global-settings ignores enableMetaphor body field", async () => {
@@ -215,6 +230,7 @@ function createRouterHarness(options: RouterHarnessOptions = {}) {
       update: (mutate) => { updateCalls += 1; data = mutate(data); return data; },
     },
     isAuthorized: () => options.authorized ?? true,
+    onThemeChanged: options.onThemeChanged,
     readJsonBody: async () => (options.bodyNull ? null : (options.body ?? {})) as never,
     writeJson: (_res, status, body) => { writes.push({ status, body }); },
   });

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -6,9 +6,9 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { initStore, resetStoreForTests } from "@dotobokuri/fleet-carriers";
-import { DESKTOP_THEME_EVENTS_PATH, DESKTOP_THEME_PATH } from "@fleet-console/desktop-protocol";
 
 import type { ConsoleLockPayload } from "../core/host/api-types.js";
+import { DESKTOP_THEME_EVENTS_PATH, DESKTOP_THEME_PATH } from "../core/host/desktop-theme.js";
 import { createConsoleLock } from "../core/host/lock.js";
 import { createConsoleObservabilityStore } from "../../fleet-plugins/terminal/server/agent-api/observability-store.js";
 import { createConsoleServer, type ConsoleServer, type ConsoleServerDeps } from "../core/host/server.js";

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { initStore, resetStoreForTests } from "@dotobokuri/fleet-carriers";
+import { DESKTOP_THEME_EVENTS_PATH, DESKTOP_THEME_PATH } from "@fleet-console/desktop-protocol";
 
 import type { ConsoleLockPayload } from "../core/host/api-types.js";
 import { createConsoleLock } from "../core/host/lock.js";
@@ -79,6 +80,23 @@ afterEach(async () => {
 });
 
 describe("console terminal observability", () => {
+  it("requires the exact Console Origin for Desktop theme snapshot and SSE routes", async () => {
+    const fixture = await startFixture();
+    const origin = new URL(fixture.endpoint).origin;
+
+    for (const pathname of [DESKTOP_THEME_PATH, DESKTOP_THEME_EVENTS_PATH]) {
+      const exact = await fetch(new URL(pathname.slice(1), fixture.endpoint), { headers: { Origin: origin } });
+      expect(exact.status).toBe(200);
+      await exact.body?.cancel();
+
+      const missing = await fetch(new URL(pathname.slice(1), fixture.endpoint));
+      expect(missing.status).toBe(401);
+
+      const foreign = await fetch(new URL(pathname.slice(1), fixture.endpoint), { headers: { Origin: "http://127.0.0.1:9999" } });
+      expect(foreign.status).toBe(401);
+    }
+  });
+
   it("uses an OS-assigned port for local development despite a persisted static-port preference", async () => {
     const staticPort = 43_199;
     const fixture = await startFixture({

--- a/runtime/fleet-desktop/src/desktop-theme-sync.ts
+++ b/runtime/fleet-desktop/src/desktop-theme-sync.ts
@@ -1,0 +1,170 @@
+import {
+  DESKTOP_THEME_EVENT,
+  DESKTOP_THEME_EVENTS_PATH,
+  DESKTOP_THEME_PATH,
+  isDesktopThemeSnapshot,
+  type DesktopThemeSnapshot,
+} from "@fleet-console/desktop-protocol";
+
+export interface DesktopThemeSynchronizer {
+  start(origin: string): Promise<void>;
+  stop(): void;
+}
+
+export interface DesktopThemeSynchronizerDeps {
+  readonly applyTheme: (snapshot: DesktopThemeSnapshot) => void;
+  readonly fetch?: typeof fetch;
+  readonly reconnectDelayMs?: number;
+  readonly setTimeout?: (callback: () => void, delay: number) => ReturnType<typeof setTimeout>;
+  readonly clearTimeout?: (timer: ReturnType<typeof setTimeout>) => void;
+}
+
+const INITIAL_LOAD_TIMEOUT_MS = 1_000;
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
+const MAX_PROTOCOL_VIOLATION_RECONNECT_DELAY_MS = 30_000;
+type SnapshotEndpointStatus = "supported" | "legacy" | "transient";
+
+export const MAX_DESKTOP_THEME_SSE_BUFFER_CHARS = 64 * 1024;
+
+class DesktopThemeSseProtocolError extends Error {}
+
+export function createDesktopThemeSynchronizer(deps: DesktopThemeSynchronizerDeps): DesktopThemeSynchronizer {
+  const fetchFor = deps.fetch ?? globalThis.fetch;
+  const reconnectDelayMs = deps.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS;
+  const schedule = deps.setTimeout ?? globalThis.setTimeout;
+  const cancelSchedule = deps.clearTimeout ?? globalThis.clearTimeout;
+  let activeOrigin: string | null = null;
+  let eventController: AbortController | null = null;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let protocolViolationCount = 0;
+
+  const stop = (): void => {
+    activeOrigin = null;
+    eventController?.abort();
+    eventController = null;
+    if (reconnectTimer !== null) cancelSchedule(reconnectTimer);
+    reconnectTimer = null;
+    protocolViolationCount = 0;
+  };
+
+  const scheduleReconnect = (origin: string, delay: number): void => {
+    reconnectTimer = schedule(() => {
+      reconnectTimer = null;
+      connect(origin);
+    }, delay);
+  };
+
+  const connect = (origin: string): void => {
+    if (activeOrigin !== origin) return;
+    eventController?.abort();
+    const controller = new AbortController();
+    eventController = controller;
+    void consumeThemeEvents(fetchFor, desktopThemeUrl(origin, DESKTOP_THEME_EVENTS_PATH), controller.signal, deps.applyTheme)
+      .then(() => {
+        if (activeOrigin !== origin || controller.signal.aborted) return;
+        protocolViolationCount = 0;
+        scheduleReconnect(origin, reconnectDelayMs);
+      })
+      .catch((error: unknown) => {
+        if (activeOrigin !== origin || controller.signal.aborted) return;
+        const delay = error instanceof DesktopThemeSseProtocolError
+          ? Math.min(reconnectDelayMs * 2 ** Math.min(++protocolViolationCount, 5), MAX_PROTOCOL_VIOLATION_RECONNECT_DELAY_MS)
+          : reconnectDelayMs;
+        scheduleReconnect(origin, delay);
+      });
+  };
+
+  return {
+    async start(origin: string): Promise<void> {
+      const normalizedOrigin = normalizeConsoleOrigin(origin);
+      stop();
+      activeOrigin = normalizedOrigin;
+      const snapshotStatus = await loadInitialTheme(fetchFor, normalizedOrigin, deps.applyTheme);
+      if (activeOrigin === normalizedOrigin && snapshotStatus !== "legacy") connect(normalizedOrigin);
+    },
+    stop,
+  };
+}
+
+async function loadInitialTheme(fetchFor: typeof fetch, origin: string, applyTheme: (snapshot: DesktopThemeSnapshot) => void): Promise<SnapshotEndpointStatus> {
+  try {
+    const response = await fetchFor(desktopThemeUrl(origin, DESKTOP_THEME_PATH), {
+      headers: { Accept: "application/json", Origin: origin },
+      signal: AbortSignal.timeout(INITIAL_LOAD_TIMEOUT_MS),
+    });
+    if (response.status === 404 || response.status === 405) return "legacy";
+    if (!response.ok) return "transient";
+    const payload: unknown = await response.json();
+    if (isDesktopThemeSnapshot(payload)) applyTheme(payload);
+    return "supported";
+  } catch {
+    return "transient";
+  }
+}
+
+async function consumeThemeEvents(
+  fetchFor: typeof fetch,
+  url: string,
+  signal: AbortSignal,
+  applyTheme: (snapshot: DesktopThemeSnapshot) => void,
+): Promise<void> {
+  const response = await fetchFor(url, { headers: { Accept: "text/event-stream", Origin: new URL(url).origin }, signal });
+  if (!response.ok || !response.body) throw new Error("desktop_theme_stream_unavailable");
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+  try {
+    while (true) {
+      const result = await reader.read();
+      if (result.done) return;
+      buffered += decoder.decode(result.value, { stream: true });
+      const frames = buffered.split(/\r?\n\r?\n/u);
+      buffered = frames.pop() ?? "";
+      if (buffered.length > MAX_DESKTOP_THEME_SSE_BUFFER_CHARS || frames.some((frame) => frame.length > MAX_DESKTOP_THEME_SSE_BUFFER_CHARS)) {
+        await reader.cancel().catch(() => undefined);
+        throw new DesktopThemeSseProtocolError("desktop_theme_sse_frame_too_large");
+      }
+      for (const frame of frames) {
+        const snapshot = parseDesktopThemeEvent(frame);
+        if (snapshot) applyTheme(snapshot);
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export function parseDesktopThemeEvent(frame: string): DesktopThemeSnapshot | null {
+  let event = "message";
+  const data: string[] = [];
+  for (const line of frame.split(/\r?\n/u)) {
+    if (line.startsWith("event:")) event = line.slice("event:".length).trim();
+    if (line.startsWith("data:")) data.push(line.slice("data:".length).trimStart());
+  }
+  if (event !== DESKTOP_THEME_EVENT || data.length === 0) return null;
+  try {
+    const payload: unknown = JSON.parse(data.join("\n"));
+    return isDesktopThemeSnapshot(payload) ? payload : null;
+  } catch {
+    return null;
+  }
+}
+
+function desktopThemeUrl(origin: string, pathname: string): string {
+  return new URL(pathname, `${origin}/`).toString();
+}
+
+function normalizeConsoleOrigin(origin: string): string {
+  const parsed = new URL(origin);
+  if (
+    parsed.protocol !== "http:"
+    || parsed.hostname !== "127.0.0.1"
+    || !parsed.port
+    || parsed.pathname !== "/"
+    || parsed.search
+    || parsed.hash
+    || parsed.username
+    || parsed.password
+  ) throw new Error("desktop_theme_origin_invalid");
+  return parsed.origin;
+}

--- a/runtime/fleet-desktop/src/desktop-theme-sync.ts
+++ b/runtime/fleet-desktop/src/desktop-theme-sync.ts
@@ -1,10 +1,21 @@
-import {
-  DESKTOP_THEME_EVENT,
-  DESKTOP_THEME_EVENTS_PATH,
-  DESKTOP_THEME_PATH,
-  isDesktopThemeSnapshot,
-  type DesktopThemeSnapshot,
-} from "@fleet-console/desktop-protocol";
+interface DesktopTitleBarOverlay {
+  readonly color: string;
+  readonly symbolColor: string;
+  readonly height: number;
+}
+
+interface DesktopThemeSnapshot {
+  readonly theme: string;
+  readonly titleBarOverlay: DesktopTitleBarOverlay;
+}
+
+const DESKTOP_THEME_PATH = "/api/v1/desktop/theme";
+const DESKTOP_THEME_EVENTS_PATH = "/api/v1/desktop/theme/events";
+const DESKTOP_THEME_EVENT = "desktop:theme";
+const ELECTRON_COLOR_PATTERN = /^#(?:[\da-f]{3,4}|[\da-f]{6}|[\da-f]{8})$/i;
+const MIN_TITLE_BAR_OVERLAY_HEIGHT = 24;
+const MAX_TITLE_BAR_OVERLAY_HEIGHT = 128;
+const DESKTOP_THEME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 
 export interface DesktopThemeSynchronizer {
   start(origin: string): Promise<void>;
@@ -148,6 +159,32 @@ export function parseDesktopThemeEvent(frame: string): DesktopThemeSnapshot | nu
   } catch {
     return null;
   }
+}
+
+function isDesktopThemeSnapshot(value: unknown): value is DesktopThemeSnapshot {
+  if (!isRecord(value) || !isDesktopThemeId(value.theme) || !isRecord(value.titleBarOverlay)) return false;
+  return isElectronColor(value.titleBarOverlay.color)
+    && isElectronColor(value.titleBarOverlay.symbolColor)
+    && isTitleBarOverlayHeight(value.titleBarOverlay.height);
+}
+
+function isDesktopThemeId(value: unknown): value is string {
+  return typeof value === "string" && DESKTOP_THEME_ID_PATTERN.test(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isElectronColor(value: unknown): value is string {
+  return typeof value === "string" && ELECTRON_COLOR_PATTERN.test(value);
+}
+
+function isTitleBarOverlayHeight(value: unknown): value is number {
+  return typeof value === "number"
+    && Number.isInteger(value)
+    && value >= MIN_TITLE_BAR_OVERLAY_HEIGHT
+    && value <= MAX_TITLE_BAR_OVERLAY_HEIGHT;
 }
 
 function desktopThemeUrl(origin: string, pathname: string): string {

--- a/runtime/fleet-desktop/src/launch-controller.ts
+++ b/runtime/fleet-desktop/src/launch-controller.ts
@@ -12,6 +12,7 @@ export interface LaunchWindow {
 export interface LaunchControllerDependencies {
   readonly createWindow: () => Promise<LaunchWindow>;
   readonly handoffOrigin: (origin: string) => void;
+  readonly synchronizeTheme?: (origin: string) => Promise<void>;
   readonly pushEntry: (contents: EntryPageWebContents, snapshot: EntryPageSnapshot) => Promise<void>;
   readonly startOrAdopt: () => Promise<string>;
   readonly dev?: boolean;
@@ -46,7 +47,9 @@ export function createLaunchController(dependencies: LaunchControllerDependencie
         }
       }
       if (window.isDestroyed?.()) return window;
-      dependencies.handoffOrigin(new URL(consoleUrl).origin);
+      const origin = new URL(consoleUrl).origin;
+      dependencies.handoffOrigin(origin);
+      await dependencies.synchronizeTheme?.(origin);
       await push("starting", "ready");
       if (!window.isDestroyed?.()) await window.loadURL(consoleUrl);
       return window;

--- a/runtime/fleet-desktop/src/main.ts
+++ b/runtime/fleet-desktop/src/main.ts
@@ -12,6 +12,7 @@ import { pushEntrySnapshot } from "./entry-page.js";
 import { applyDesktopDockIcon, applyDesktopIdentity } from "./identity.js";
 import { createLaunchController, type RuntimeEntryState } from "./launch-controller.js";
 import { createDesktopLogger, describeError, type DesktopLogger } from "./logging.js";
+import { createDesktopThemeSynchronizer } from "./desktop-theme-sync.js";
 import { installApplicationMenu } from "./menu.js";
 import { resolveDesktopResourcePaths } from "./resource-paths.js";
 import { createConsoleInstallerDependencies, installConsole, reconcileConsoleInstallations, repairConsoleNativeExecutables } from "./runtime/console-installer.js";
@@ -70,11 +71,20 @@ async function boot(): Promise<void> {
   });
   let window: BrowserWindow | null = null;
   let policy: ReturnType<typeof applyWindowPolicy> | null = null;
+  const themeSynchronizer = process.platform === "win32"
+    ? createDesktopThemeSynchronizer({
+      applyTheme: (snapshot) => {
+        if (!window || window.isDestroyed()) return;
+        window.setTitleBarOverlay(snapshot.titleBarOverlay);
+      },
+    })
+    : null;
   let refreshNativeUpdateActions: (() => void) | null = null;
   const lifecycle = createDesktopLifecycle(app, async () => {
     const launch = createLaunchController({
       createWindow: async () => {
         window = createSecureWindow(BrowserWindow, { iconPath: desktopResources.iconPath, platform: process.platform });
+        window.once("closed", () => themeSynchronizer?.stop());
         lifecycle.attachWindow(window);
         policy = applyWindowPolicy(window.webContents, async (external) => shell.openExternal(external));
         await window.loadFile(desktopResources.entryPagePath);
@@ -82,6 +92,7 @@ async function boot(): Promise<void> {
       },
       dev: !isPackaged,
       handoffOrigin: (origin) => policy?.activateConsoleOrigin(origin),
+      synchronizeTheme: async (origin) => { await themeSynchronizer?.start(origin); },
       onFirstRunFailure: async () => showFirstRunFailure(),
       onWindowReady: (push) => { pushRuntimeProgress = push; },
       pushEntry: pushEntrySnapshot,

--- a/runtime/fleet-desktop/src/window-policy.ts
+++ b/runtime/fleet-desktop/src/window-policy.ts
@@ -12,8 +12,7 @@ export interface WindowPolicy {
 export const DESKTOP_WINDOW_TITLE = "Fleet Console";
 
 const CANVAS_FAR_BACKGROUND_COLOR = "#010204";
-const WINDOWS_TITLE_BAR_COLOR = "#090f15";
-const WINDOWS_TITLE_BAR_SYMBOL_COLOR = "#989fa6";
+const INITIAL_WINDOWS_TITLE_BAR_OVERLAY = { color: "#090f15", symbolColor: "#989fa6", height: 44 } as const;
 
 export function createSecureWindow(BrowserWindowCtor: typeof BrowserWindow, options: SecureWindowOptions): BrowserWindow {
   const windowOptions: BrowserWindowConstructorOptions = {
@@ -25,8 +24,7 @@ export function createSecureWindow(BrowserWindowCtor: typeof BrowserWindow, opti
     minHeight: 560,
     // 신호등 좌표와 오버레이 높이(44)는 클라이언트 CSS의 --chrome-band-height: 44px 및 macOS 88px 인셋과 합의된 값이므로 변경 시 양쪽을 동기화한다.
     ...(options.platform === "darwin" ? { titleBarStyle: "hiddenInset", trafficLightPosition: { x: 16, y: 14 } } : {}),
-    // `--ink-deep` oklch(16.5% 0.016 245)의 sRGB hex 근사값은 #090f15, `--text-secondary` oklch(70% 0.012 245)의 sRGB hex 근사값은 #989fa6이다. TODO: 테마 변경 시 setTitleBarOverlay 재호출로 실시간 추종한다.
-    ...(options.platform === "win32" ? { titleBarStyle: "hidden", titleBarOverlay: { color: WINDOWS_TITLE_BAR_COLOR, symbolColor: WINDOWS_TITLE_BAR_SYMBOL_COLOR, height: 44 } } : {}),
+    ...(options.platform === "win32" ? { titleBarStyle: "hidden", titleBarOverlay: INITIAL_WINDOWS_TITLE_BAR_OVERLAY } : {}),
     webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, webSecurity: true },
   };
   return new BrowserWindowCtor(windowOptions);

--- a/runtime/fleet-desktop/src/window-policy.ts
+++ b/runtime/fleet-desktop/src/window-policy.ts
@@ -12,7 +12,7 @@ export interface WindowPolicy {
 export const DESKTOP_WINDOW_TITLE = "Fleet Console";
 
 const CANVAS_FAR_BACKGROUND_COLOR = "#010204";
-const INITIAL_WINDOWS_TITLE_BAR_OVERLAY = { color: "#090f15", symbolColor: "#989fa6", height: 44 } as const;
+const INITIAL_WINDOWS_TITLE_BAR_OVERLAY = { color: "#090f15", symbolColor: "#989fa6", height: 43 } as const;
 
 export function createSecureWindow(BrowserWindowCtor: typeof BrowserWindow, options: SecureWindowOptions): BrowserWindow {
   const windowOptions: BrowserWindowConstructorOptions = {
@@ -22,7 +22,7 @@ export function createSecureWindow(BrowserWindowCtor: typeof BrowserWindow, opti
     backgroundColor: CANVAS_FAR_BACKGROUND_COLOR,
     minWidth: 900,
     minHeight: 560,
-    // 신호등 좌표와 오버레이 높이(44)는 클라이언트 CSS의 --chrome-band-height: 44px 및 macOS 88px 인셋과 합의된 값이므로 변경 시 양쪽을 동기화한다.
+    // Windows 오버레이 43px + Command Band 하단 divider 1px가 클라이언트 --chrome-band-height: 44px를 채운다. macOS 88px 인셋과 함께 변경 시 양쪽을 동기화한다.
     ...(options.platform === "darwin" ? { titleBarStyle: "hiddenInset", trafficLightPosition: { x: 16, y: 14 } } : {}),
     ...(options.platform === "win32" ? { titleBarStyle: "hidden", titleBarOverlay: INITIAL_WINDOWS_TITLE_BAR_OVERLAY } : {}),
     webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, webSecurity: true },

--- a/runtime/fleet-desktop/src/window-policy.ts
+++ b/runtime/fleet-desktop/src/window-policy.ts
@@ -12,7 +12,7 @@ export interface WindowPolicy {
 export const DESKTOP_WINDOW_TITLE = "Fleet Console";
 
 const CANVAS_FAR_BACKGROUND_COLOR = "#010204";
-const INITIAL_WINDOWS_TITLE_BAR_OVERLAY = { color: "#090f15", symbolColor: "#989fa6", height: 43 } as const;
+const INITIAL_WINDOWS_TITLE_BAR_OVERLAY = { color: "#03080e", symbolColor: "#989fa6", height: 43 } as const;
 
 export function createSecureWindow(BrowserWindowCtor: typeof BrowserWindow, options: SecureWindowOptions): BrowserWindow {
   const windowOptions: BrowserWindowConstructorOptions = {

--- a/runtime/fleet-desktop/tests/desktop-theme-sync.test.ts
+++ b/runtime/fleet-desktop/tests/desktop-theme-sync.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { DESKTOP_THEME_EVENT } from "@fleet-console/desktop-protocol";
-
 import { createDesktopThemeSynchronizer, MAX_DESKTOP_THEME_SSE_BUFFER_CHARS, parseDesktopThemeEvent } from "../src/desktop-theme-sync.js";
+
+const DESKTOP_THEME_EVENT = "desktop:theme";
 
 describe("desktop theme synchronizer", () => {
   it("applies the saved Console snapshot before subscribing to same-origin events", async () => {
@@ -42,7 +42,7 @@ describe("desktop theme synchronizer", () => {
   it("aborts an active same-origin event stream during cleanup", async () => {
     let eventSignal: AbortSignal | undefined;
     const fetch = vi.fn((url: Parameters<typeof globalThis.fetch>[0], init?: Parameters<typeof globalThis.fetch>[1]) => {
-      if (String(url).endsWith("/api/v1/desktop/theme")) return Promise.resolve(jsonResponse(snapshot("instrument", "#090f15", "#989fa6")));
+      if (String(url).endsWith("/api/v1/desktop/theme")) return Promise.resolve(jsonResponse(snapshot("instrument", "#03080e", "#989fa6")));
       eventSignal = init?.signal ?? undefined;
       return new Promise<Response>((_resolve, reject) => {
         eventSignal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
@@ -54,7 +54,7 @@ describe("desktop theme synchronizer", () => {
     await synchronizer.start("http://127.0.0.1:4310");
     synchronizer.stop();
 
-    expect(applyTheme).toHaveBeenCalledWith(snapshot("instrument", "#090f15", "#989fa6"));
+    expect(applyTheme).toHaveBeenCalledWith(snapshot("instrument", "#03080e", "#989fa6"));
     expect(eventSignal?.aborted).toBe(true);
   });
 
@@ -78,7 +78,7 @@ describe("desktop theme synchronizer", () => {
     let cancelled = false;
     const setTimeout = vi.fn((_callback: () => void, delay: number) => delay as never);
     const fetch = vi.fn((url: Parameters<typeof globalThis.fetch>[0]) => {
-      if (String(url).endsWith("/api/v1/desktop/theme")) return Promise.resolve(jsonResponse(snapshot("instrument", "#090f15", "#989fa6")));
+      if (String(url).endsWith("/api/v1/desktop/theme")) return Promise.resolve(jsonResponse(snapshot("instrument", "#03080e", "#989fa6")));
       const stream = new ReadableStream({
         start: (controller) => {
           controller.enqueue(new TextEncoder().encode(`${":".repeat(MAX_DESKTOP_THEME_SSE_BUFFER_CHARS)}\n\n`));
@@ -101,7 +101,7 @@ describe("desktop theme synchronizer", () => {
     let cancelled = false;
     const setTimeout = vi.fn((_callback: () => void, delay: number) => delay as never);
     const fetch = vi.fn((url: Parameters<typeof globalThis.fetch>[0]) => {
-      if (String(url).endsWith("/api/v1/desktop/theme")) return Promise.resolve(jsonResponse(snapshot("instrument", "#090f15", "#989fa6")));
+      if (String(url).endsWith("/api/v1/desktop/theme")) return Promise.resolve(jsonResponse(snapshot("instrument", "#03080e", "#989fa6")));
       return Promise.resolve(new Response(new ReadableStream({
         start: (controller) => controller.enqueue(new TextEncoder().encode(`${":".repeat(MAX_DESKTOP_THEME_SSE_BUFFER_CHARS + 1)}\n\n`)),
         cancel: () => { cancelled = true; },
@@ -123,7 +123,7 @@ describe("desktop theme synchronizer", () => {
       return scheduled.length as never;
     });
     const fetch = vi.fn((url: Parameters<typeof globalThis.fetch>[0]) => {
-      if (String(url).endsWith("/api/v1/desktop/theme")) return Promise.resolve(jsonResponse(snapshot("instrument", "#090f15", "#989fa6")));
+      if (String(url).endsWith("/api/v1/desktop/theme")) return Promise.resolve(jsonResponse(snapshot("instrument", "#03080e", "#989fa6")));
       return Promise.resolve(new Response(new ReadableStream({
         start: (controller) => controller.enqueue(new TextEncoder().encode(":".repeat(MAX_DESKTOP_THEME_SSE_BUFFER_CHARS + 1))),
         cancel: () => { cancelled += 1; },
@@ -149,7 +149,7 @@ describe("desktop theme synchronizer", () => {
       return 1 as never;
     });
     const fetch = vi.fn((url: Parameters<typeof globalThis.fetch>[0]) => {
-      if (String(url).endsWith("/api/v1/desktop/theme")) return Promise.resolve(jsonResponse(snapshot("instrument", "#090f15", "#989fa6")));
+      if (String(url).endsWith("/api/v1/desktop/theme")) return Promise.resolve(jsonResponse(snapshot("instrument", "#03080e", "#989fa6")));
       eventRequests += 1;
       if (eventRequests === 1) return Promise.resolve(new Response(new ReadableStream({ start: (controller) => controller.close() })));
       return new Promise<Response>(() => undefined);
@@ -168,6 +168,7 @@ describe("desktop theme synchronizer", () => {
     const synchronizer = createDesktopThemeSynchronizer({ applyTheme: vi.fn(), fetch: vi.fn() });
 
     await expect(synchronizer.start("https://fleet.example")).rejects.toThrow("desktop_theme_origin_invalid");
+    expect(parseDesktopThemeEvent(`event: ${DESKTOP_THEME_EVENT}\ndata: ${JSON.stringify(snapshot("future-aurora", "#123456", "#abcdef", 48))}`)).toEqual(snapshot("future-aurora", "#123456", "#abcdef", 48));
     expect(parseDesktopThemeEvent(`event: ${DESKTOP_THEME_EVENT}\ndata: {"theme":"carbon","titleBarOverlay":{"color":"white","symbolColor":"#ffffff","height":44}}`)).toBeNull();
     expect(parseDesktopThemeEvent(`event: other\ndata: ${JSON.stringify(snapshot("carbon", "#334455", "#ddeeff", 52))}`)).toBeNull();
     expect(parseDesktopThemeEvent(`event: ${DESKTOP_THEME_EVENT}\ndata: ${JSON.stringify(snapshot("carbon", "#334455", "#ddeeff", 52))}`)).toEqual(snapshot("carbon", "#334455", "#ddeeff", 52));
@@ -178,6 +179,6 @@ function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), { headers: { "Content-Type": "application/json" } });
 }
 
-function snapshot(theme: string, color: string, symbolColor: string, height = 44) {
+function snapshot(theme: string, color: string, symbolColor: string, height = 43) {
   return { theme, titleBarOverlay: { color, symbolColor, height } } as const;
 }

--- a/runtime/fleet-desktop/tests/desktop-theme-sync.test.ts
+++ b/runtime/fleet-desktop/tests/desktop-theme-sync.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { DESKTOP_THEME_EVENT } from "@fleet-console/desktop-protocol";
+
+import { createDesktopThemeSynchronizer, MAX_DESKTOP_THEME_SSE_BUFFER_CHARS, parseDesktopThemeEvent } from "../src/desktop-theme-sync.js";
+
+describe("desktop theme synchronizer", () => {
+  it("applies the saved Console snapshot before subscribing to same-origin events", async () => {
+    const applied: string[] = [];
+    const fetch = vi.fn(async (url: Parameters<typeof globalThis.fetch>[0], _init?: Parameters<typeof globalThis.fetch>[1]) => {
+      if (String(url).endsWith("/api/v1/desktop/theme")) return jsonResponse(snapshot("future-aurora", "#123456", "#abcdef", 48));
+      return new Promise<Response>(() => undefined);
+    });
+    const synchronizer = createDesktopThemeSynchronizer({ applyTheme: (snapshot) => applied.push(snapshot.theme), fetch });
+
+    await synchronizer.start("http://127.0.0.1:4310");
+
+    expect(applied).toEqual(["future-aurora"]);
+    expect(fetch.mock.calls.map(([url]) => String(url))).toEqual([
+      "http://127.0.0.1:4310/api/v1/desktop/theme",
+      "http://127.0.0.1:4310/api/v1/desktop/theme/events",
+    ]);
+    expect(fetch.mock.calls.map(([, init]) => init?.headers)).toEqual([
+      { Accept: "application/json", Origin: "http://127.0.0.1:4310" },
+      { Accept: "text/event-stream", Origin: "http://127.0.0.1:4310" },
+    ]);
+    synchronizer.stop();
+  });
+
+  it.each([404, 405])("keeps the Instrument fallback and does not subscribe when a v1 Console returns %i", async (status) => {
+    const fetch = vi.fn(async (_url: Parameters<typeof globalThis.fetch>[0], _init?: Parameters<typeof globalThis.fetch>[1]) => new Response(null, { status }));
+    const applyTheme = vi.fn();
+    const synchronizer = createDesktopThemeSynchronizer({ applyTheme, fetch });
+
+    await synchronizer.start("http://127.0.0.1:4310");
+
+    expect(applyTheme).not.toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(fetch.mock.calls[0]?.[1]?.headers).toEqual({ Accept: "application/json", Origin: "http://127.0.0.1:4310" });
+  });
+
+  it("aborts an active same-origin event stream during cleanup", async () => {
+    let eventSignal: AbortSignal | undefined;
+    const fetch = vi.fn((url: Parameters<typeof globalThis.fetch>[0], init?: Parameters<typeof globalThis.fetch>[1]) => {
+      if (String(url).endsWith("/api/v1/desktop/theme")) return Promise.resolve(jsonResponse(snapshot("instrument", "#090f15", "#989fa6")));
+      eventSignal = init?.signal ?? undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        eventSignal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+      });
+    });
+    const applyTheme = vi.fn();
+    const synchronizer = createDesktopThemeSynchronizer({ applyTheme, fetch });
+
+    await synchronizer.start("http://127.0.0.1:4310");
+    synchronizer.stop();
+
+    expect(applyTheme).toHaveBeenCalledWith(snapshot("instrument", "#090f15", "#989fa6"));
+    expect(eventSignal?.aborted).toBe(true);
+  });
+
+  it("keeps SSE retry available after a transient snapshot failure", async () => {
+    const fetch = vi.fn((url: Parameters<typeof globalThis.fetch>[0]) => {
+      if (String(url).endsWith("/api/v1/desktop/theme")) return Promise.resolve(new Response(null, { status: 503 }));
+      return new Promise<Response>(() => undefined);
+    });
+    const synchronizer = createDesktopThemeSynchronizer({ applyTheme: vi.fn(), fetch });
+
+    await synchronizer.start("http://127.0.0.1:4310");
+
+    expect(fetch.mock.calls.map(([url]) => String(url))).toEqual([
+      "http://127.0.0.1:4310/api/v1/desktop/theme",
+      "http://127.0.0.1:4310/api/v1/desktop/theme/events",
+    ]);
+    synchronizer.stop();
+  });
+
+  it("accepts an SSE frame exactly at the buffer boundary", async () => {
+    let cancelled = false;
+    const setTimeout = vi.fn((_callback: () => void, delay: number) => delay as never);
+    const fetch = vi.fn((url: Parameters<typeof globalThis.fetch>[0]) => {
+      if (String(url).endsWith("/api/v1/desktop/theme")) return Promise.resolve(jsonResponse(snapshot("instrument", "#090f15", "#989fa6")));
+      const stream = new ReadableStream({
+        start: (controller) => {
+          controller.enqueue(new TextEncoder().encode(`${":".repeat(MAX_DESKTOP_THEME_SSE_BUFFER_CHARS)}\n\n`));
+          controller.close();
+        },
+        cancel: () => { cancelled = true; },
+      });
+      return Promise.resolve(new Response(stream));
+    });
+    const synchronizer = createDesktopThemeSynchronizer({ applyTheme: vi.fn(), fetch, reconnectDelayMs: 1, setTimeout });
+
+    await synchronizer.start("http://127.0.0.1:4310");
+    await vi.waitFor(() => expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 1));
+
+    expect(cancelled).toBe(false);
+    synchronizer.stop();
+  });
+
+  it("cancels a terminated SSE frame one character over the buffer boundary", async () => {
+    let cancelled = false;
+    const setTimeout = vi.fn((_callback: () => void, delay: number) => delay as never);
+    const fetch = vi.fn((url: Parameters<typeof globalThis.fetch>[0]) => {
+      if (String(url).endsWith("/api/v1/desktop/theme")) return Promise.resolve(jsonResponse(snapshot("instrument", "#090f15", "#989fa6")));
+      return Promise.resolve(new Response(new ReadableStream({
+        start: (controller) => controller.enqueue(new TextEncoder().encode(`${":".repeat(MAX_DESKTOP_THEME_SSE_BUFFER_CHARS + 1)}\n\n`)),
+        cancel: () => { cancelled = true; },
+      })));
+    });
+    const synchronizer = createDesktopThemeSynchronizer({ applyTheme: vi.fn(), fetch, reconnectDelayMs: 1, setTimeout });
+
+    await synchronizer.start("http://127.0.0.1:4310");
+    await vi.waitFor(() => expect(cancelled).toBe(true));
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 2);
+    synchronizer.stop();
+  });
+
+  it("cancels oversized unterminated SSE frames and exponentially backs off repeats", async () => {
+    let cancelled = 0;
+    const scheduled: { callback: () => void; delay: number }[] = [];
+    const setTimeout = vi.fn((callback: () => void, delay: number) => {
+      scheduled.push({ callback, delay });
+      return scheduled.length as never;
+    });
+    const fetch = vi.fn((url: Parameters<typeof globalThis.fetch>[0]) => {
+      if (String(url).endsWith("/api/v1/desktop/theme")) return Promise.resolve(jsonResponse(snapshot("instrument", "#090f15", "#989fa6")));
+      return Promise.resolve(new Response(new ReadableStream({
+        start: (controller) => controller.enqueue(new TextEncoder().encode(":".repeat(MAX_DESKTOP_THEME_SSE_BUFFER_CHARS + 1))),
+        cancel: () => { cancelled += 1; },
+      })));
+    });
+    const synchronizer = createDesktopThemeSynchronizer({ applyTheme: vi.fn(), fetch, reconnectDelayMs: 1, setTimeout });
+
+    await synchronizer.start("http://127.0.0.1:4310");
+    await vi.waitFor(() => expect(cancelled).toBe(1));
+    expect(scheduled.map(({ delay }) => delay)).toEqual([2]);
+
+    scheduled[0]?.callback();
+    await vi.waitFor(() => expect(cancelled).toBe(2));
+    expect(scheduled.map(({ delay }) => delay)).toEqual([2, 4]);
+    synchronizer.stop();
+  });
+
+  it("reconnects after an SSE close", async () => {
+    let eventRequests = 0;
+    let reconnect: (() => void) | undefined;
+    const setTimeout = vi.fn((callback: () => void) => {
+      reconnect = callback;
+      return 1 as never;
+    });
+    const fetch = vi.fn((url: Parameters<typeof globalThis.fetch>[0]) => {
+      if (String(url).endsWith("/api/v1/desktop/theme")) return Promise.resolve(jsonResponse(snapshot("instrument", "#090f15", "#989fa6")));
+      eventRequests += 1;
+      if (eventRequests === 1) return Promise.resolve(new Response(new ReadableStream({ start: (controller) => controller.close() })));
+      return new Promise<Response>(() => undefined);
+    });
+    const synchronizer = createDesktopThemeSynchronizer({ applyTheme: vi.fn(), fetch, reconnectDelayMs: 1, setTimeout });
+
+    await synchronizer.start("http://127.0.0.1:4310");
+    await vi.waitFor(() => expect(reconnect).toBeTypeOf("function"));
+    reconnect?.();
+
+    await vi.waitFor(() => expect(eventRequests).toBe(2));
+    synchronizer.stop();
+  });
+
+  it("rejects arbitrary origins and malformed or forged SSE payloads", async () => {
+    const synchronizer = createDesktopThemeSynchronizer({ applyTheme: vi.fn(), fetch: vi.fn() });
+
+    await expect(synchronizer.start("https://fleet.example")).rejects.toThrow("desktop_theme_origin_invalid");
+    expect(parseDesktopThemeEvent(`event: ${DESKTOP_THEME_EVENT}\ndata: {"theme":"carbon","titleBarOverlay":{"color":"white","symbolColor":"#ffffff","height":44}}`)).toBeNull();
+    expect(parseDesktopThemeEvent(`event: other\ndata: ${JSON.stringify(snapshot("carbon", "#334455", "#ddeeff", 52))}`)).toBeNull();
+    expect(parseDesktopThemeEvent(`event: ${DESKTOP_THEME_EVENT}\ndata: ${JSON.stringify(snapshot("carbon", "#334455", "#ddeeff", 52))}`)).toEqual(snapshot("carbon", "#334455", "#ddeeff", 52));
+  });
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { headers: { "Content-Type": "application/json" } });
+}
+
+function snapshot(theme: string, color: string, symbolColor: string, height = 44) {
+  return { theme, titleBarOverlay: { color, symbolColor, height } } as const;
+}

--- a/runtime/fleet-desktop/tests/launch-controller.test.ts
+++ b/runtime/fleet-desktop/tests/launch-controller.test.ts
@@ -12,6 +12,22 @@ describe("launch controller", () => {
     expect(order).toEqual(["entry", "show", "start", "origin=http://127.0.0.1:4310", "entry", "handoff"]);
   });
 
+  it("synchronizes the Console-owned title bar theme after origin activation and before handoff", async () => {
+    const order: string[] = [];
+    const window = { webContents: { executeJavaScript: vi.fn(async () => undefined) }, show: vi.fn(), loadURL: vi.fn(async () => { order.push("handoff"); }) };
+    const controller = createLaunchController({
+      createWindow: vi.fn(async () => window),
+      pushEntry: vi.fn(async () => undefined),
+      startOrAdopt: vi.fn(async () => "http://127.0.0.1:4310/console/"),
+      handoffOrigin: vi.fn(() => { order.push("origin"); }),
+      synchronizeTheme: vi.fn(async () => { order.push("theme"); }),
+    });
+
+    await controller.start();
+
+    expect(order).toEqual(["origin", "theme", "handoff"]);
+  });
+
   it("wires runtime progress, first-run failure Retry, and same-window handoff through the production launch graph", async () => {
     const snapshots: string[] = [];
     let progress: ((state: "checking" | "node" | "installing" | "offline" | "firstfail" | "starting" | "dev", detail?: string, progress?: number) => Promise<void>) | undefined;

--- a/runtime/fleet-desktop/tests/window-policy.test.ts
+++ b/runtime/fleet-desktop/tests/window-policy.test.ts
@@ -13,7 +13,7 @@ describe("secure window policy", () => {
     const Ctor = vi.fn();
     createSecureWindow(Ctor as never, { iconPath: "/assets/icon.png", platform: "win32" });
 
-    expect(Ctor).toHaveBeenCalledWith({ show: false, title: "Fleet Console", icon: "/assets/icon.png", backgroundColor: "#010204", minWidth: 900, minHeight: 560, titleBarStyle: "hidden", titleBarOverlay: { color: "#090f15", symbolColor: "#989fa6", height: 43 }, webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, webSecurity: true } });
+    expect(Ctor).toHaveBeenCalledWith({ show: false, title: "Fleet Console", icon: "/assets/icon.png", backgroundColor: "#010204", minWidth: 900, minHeight: 560, titleBarStyle: "hidden", titleBarOverlay: { color: "#03080e", symbolColor: "#989fa6", height: 43 }, webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, webSecurity: true } });
   });
 
   it("keeps the Linux native title bar without an overlay", () => {

--- a/runtime/fleet-desktop/tests/window-policy.test.ts
+++ b/runtime/fleet-desktop/tests/window-policy.test.ts
@@ -13,7 +13,7 @@ describe("secure window policy", () => {
     const Ctor = vi.fn();
     createSecureWindow(Ctor as never, { iconPath: "/assets/icon.png", platform: "win32" });
 
-    expect(Ctor).toHaveBeenCalledWith({ show: false, title: "Fleet Console", icon: "/assets/icon.png", backgroundColor: "#010204", minWidth: 900, minHeight: 560, titleBarStyle: "hidden", titleBarOverlay: { color: "#090f15", symbolColor: "#989fa6", height: 44 }, webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, webSecurity: true } });
+    expect(Ctor).toHaveBeenCalledWith({ show: false, title: "Fleet Console", icon: "/assets/icon.png", backgroundColor: "#010204", minWidth: 900, minHeight: 560, titleBarStyle: "hidden", titleBarOverlay: { color: "#090f15", symbolColor: "#989fa6", height: 43 }, webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, webSecurity: true } });
   });
 
   it("keeps the Linux native title bar without an overlay", () => {


### PR DESCRIPTION
## Summary

- Synchronize the Windows Electron title bar overlay with Instrument, Maritime, and Carbon theme changes from Fleet Console.
- Preserve the Command Band divider and exact Instrument surface color while keeping older version-1 Console runtimes on a safe fallback.
- Keep the published desktop protocol export surface unchanged and protect the new loopback snapshot/SSE routes with exact-Origin validation.

## Type of Change

- [x] feat — new feature or carrier capability
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/desktop-protocol.test.ts tests/desktop-theme.test.ts tests/desktop-theme-routes.test.ts tests/global-settings-routes.test.ts tests/server.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-desktop exec vitest run tests/desktop-theme-sync.test.ts tests/window-policy.test.ts tests/launch-controller.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-desktop typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-desktop build`
- [x] Manually verified all three themes and the Command Band divider on Windows.

## Changelog

- [x] Added one `.changelog.d/*.md` fragment.
- [x] Fragment `section:` is `Added`.
- [x] Fragment contains adjacent English and Korean summaries with an allowed package tag.

## Notes for Reviewers

- `DESKTOP_PROTOCOL_VERSION` remains `1`.
- The published `./desktop-protocol` export surface is byte-identical to `canary`; the theme wire contract stays internal to the two runtime hosts.