### PR TITLE
feat(console): split sidebar Formation toggle into two segments

### DIFF
--- a/.changelog.d/fleet-console-changed.md
+++ b/.changelog.d/fleet-console-changed.md
@@ -1,0 +1,6 @@
+---
+section: Changed
+---
+
+- [fleet-console] Split the sidebar Formation view toggle into a two-segment control, giving open-panel and include-minimized formation each their own button.
+  ko: 사이드바 Formation view 토글을 2분할 세그먼트 컨트롤로 나눠, 열린 패널만과 최소화 패널 포함 Formation을 각각의 버튼으로 제공합니다.

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -504,7 +504,10 @@ export function OperationsSideBar({
     >
       <div className="side-bar-theater-add-row">
         <button type="button" className="side-bar-theater-add-btn" onClick={openTheaterBrowser} disabled={addingTheater} aria-label="Add Theater" title={addingTheater ? "Adding Theater" : "Add Theater"}><PlusIcon /><span>Add Theater</span></button>
-        <button type="button" className="side-bar-formation-toggle" onClick={() => toggleFormationView()} disabled={activeTheaterId === null} aria-pressed={formationView} aria-label="Formation view" title="Formation view (Alt+F)"><FormationIcon /></button>
+        <div className="side-bar-formation-group" role="group" aria-label="Formation view">
+          <button type="button" className="side-bar-formation-toggle side-bar-formation-seg" onClick={() => toggleFormationView()} disabled={activeTheaterId === null} aria-pressed={formationView} aria-label="Formation view (open panels only)" title="Formation view (Alt+F)"><FormationIcon /></button>
+          <button type="button" className="side-bar-formation-toggle side-bar-formation-seg" onClick={() => toggleFormationView({ restoreMinimized: true })} disabled={activeTheaterId === null} aria-pressed={formationView && minimizedSet.size === 0} aria-label="Formation view including minimized panels" title="Formation view incl. minimized (Alt+Shift+F)"><FormationFilledIcon /></button>
+        </div>
       </div>
       {!collapsed && theaterError ? <p className="side-bar-theater-error">{theaterError}</p> : null}
 
@@ -745,6 +748,10 @@ export function OperationsSideBar({
 
 function FormationIcon() {
   return <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3 3h4v4H3zM9 3h4v4H9zM3 9h4v4H3zM9 9h4v4H9z" fill="none" stroke="currentColor" strokeWidth="1.2" /></svg>;
+}
+
+function FormationFilledIcon() {
+  return <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3 3h4v4H3zM9 3h4v4H9zM3 9h4v4H3zM9 9h4v4H9z" fill="currentColor" /></svg>;
 }
 
 interface GroupSection {

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2788,6 +2788,22 @@
   opacity: 0.55;
 }
 
+.side-bar-formation-group {
+  display: flex;
+  flex: none;
+  align-items: center;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.side-bar-formation-group .side-bar-formation-seg {
+  border-radius: 0;
+}
+
+.side-bar-formation-group .side-bar-formation-seg + .side-bar-formation-seg {
+  border-left: 1px solid var(--surface-rim);
+}
+
 .side-bar-formation-toggle {
   display: grid;
   place-items: center;

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -110,8 +110,14 @@ describe("Instrument core design contract", () => {
     expect(commandBand).toContain('className="command-band-button command-band-rail-toggle"');
     expect(commandBand).toContain("onClick={toggleRailChrome}");
     expect(commandBand).not.toContain("command-band-formation-toggle");
-    expect(source("sidebar/operations-side-bar.tsx")).toContain('className="side-bar-formation-toggle"');
-    expect(source("sidebar/operations-side-bar.tsx")).toContain("onClick={() => toggleFormationView()}");
+    const sidebar = source("sidebar/operations-side-bar.tsx");
+    expect(sidebar).toContain('<div className="side-bar-formation-group" role="group" aria-label="Formation view">');
+    expect(sidebar).toContain('className="side-bar-formation-toggle side-bar-formation-seg" onClick={() => toggleFormationView()}');
+    expect(sidebar).toContain('aria-pressed={formationView} aria-label="Formation view (open panels only)"');
+    expect(sidebar).toContain('className="side-bar-formation-toggle side-bar-formation-seg" onClick={() => toggleFormationView({ restoreMinimized: true })}');
+    expect(sidebar).toContain('aria-pressed={formationView && minimizedSet.size === 0} aria-label="Formation view including minimized panels"');
+    expect(components).toContain(".side-bar-formation-group {");
+    expect(components).toContain("border-left: 1px solid var(--surface-rim);");
     expect(commandBand).toContain('"--command-band-left-width": `${sideBar.width}px`');
     expect(layout).toContain("grid-template-columns: var(--command-band-left-width, 280px) minmax(0, 1fr) auto;");
     expect(layout).toContain('html[data-desktop-shell="true"] .command-band {');


### PR DESCRIPTION
## Summary
- 좌측 사이드바 헤더의 단일 Formation view 토글을 2분할 세그먼트 컨트롤로 개편합니다 — 좌: 열린 패널만(Alt+F), 우: 최소화 패널 포함(Alt+Shift+F).
- 우 세그먼트는 채운 4-사각형 아이콘과 테마 토큰(`--surface-rim`) divider를 사용하며, `aria-pressed`는 `formationView && minimizedSet.size === 0`을 반영합니다.
- 상태 로직·store·단축키는 불변이며 사이드바 UI 표면만 확장합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` / `build` green
- [x] `instrument-design-contract.test.ts` 10/10 pass (2세그먼트 마크업·aria-pressed 계약)
- [x] 헤디드 e2e(격리 콘솔): 렌더(group/2세그먼트/outline·filled 아이콘/divider), 좌 세그먼트 토글 교번, 우 세그먼트 formation 진입, aria-pressed 전이
- [x] `node scripts/compile-changelog-fragments.mjs --check` OK

## Changelog
- [x] `.changelog.d/fleet-console-changed.md` 포함 (section: Changed, 이중언어)