### PR TITLE
feat(fleet-console): add desktop console zoom and reload controls

### DIFF
--- a/.changelog.d/fleet-desktop-added.md
+++ b/.changelog.d/fleet-desktop-added.md
@@ -3,3 +3,5 @@ section: Added
 ---
 - [fleet-console] Synchronize the Fleet Desktop Windows title bar overlay with the saved Fleet Console theme and live theme changes.
   ko: 저장된 Fleet Console 테마와 실시간 테마 변경에 맞춰 Fleet Desktop Windows 제목 표시줄 오버레이를 동기화합니다.
+- [fleet-console] Add native Console zoom and reload controls with persistent zoom levels.
+  ko: 영속 줌 수준을 사용하는 네이티브 Console 확대와 새로 고침 제어를 추가합니다.

--- a/runtime/fleet-desktop/src/console-controls.ts
+++ b/runtime/fleet-desktop/src/console-controls.ts
@@ -1,0 +1,93 @@
+import { clampZoomLevel, type ZoomState } from "./zoom-state.js";
+
+export interface ConsoleControlsWebContents {
+  getZoomLevel(): number;
+  setZoomLevel(level: number): void;
+  reload(): void;
+}
+
+export interface ConsoleControlsWindow {
+  isDestroyed(): boolean;
+  readonly webContents: ConsoleControlsWebContents;
+}
+
+export interface ConsoleControlsDependencies {
+  readonly zoomState: ZoomState;
+  readonly refreshNativeActions: () => void;
+  readonly schedule?: (callback: () => void) => void;
+}
+
+export interface ConsoleControls {
+  attachWindow(window: ConsoleControlsWindow): void;
+  handoffStarted(): void;
+  onConsoleLoaded(): void;
+  zoomChanged(contents: ConsoleControlsWebContents): void;
+  zoomIn(): void;
+  zoomOut(): void;
+  actualSize(): void;
+  reloadConsole(): void;
+  consoleReady(): boolean;
+}
+
+export function createConsoleControls(dependencies: ConsoleControlsDependencies): ConsoleControls {
+  // 휠 줌은 zoom-changed 발화 시점에 아직 적용 전일 수 있어 매크로태스크로 지연 판독한다.
+  const schedule = dependencies.schedule ?? ((callback: () => void) => { setImmediate(callback); });
+  let window: ConsoleControlsWindow | null = null;
+  let handoffPending = false;
+  let handoffComplete = false;
+  let zoomSavePending = false;
+  let scheduledContents: ConsoleControlsWebContents | null = null;
+
+  const activeContents = (): ConsoleControlsWebContents | null => window && !window.isDestroyed() ? window.webContents : null;
+  const runWhenReady = (action: (contents: ConsoleControlsWebContents) => void): void => {
+    const contents = handoffComplete ? activeContents() : null;
+    if (contents) action(contents);
+  };
+
+  return {
+    attachWindow(nextWindow): void {
+      window = nextWindow;
+      handoffPending = false;
+      handoffComplete = false;
+      zoomSavePending = false;
+      scheduledContents = null;
+    },
+    handoffStarted(): void {
+      if (activeContents()) handoffPending = true;
+    },
+    onConsoleLoaded(): void {
+      const contents = handoffPending ? activeContents() : null;
+      if (!contents) return;
+      handoffPending = false;
+      handoffComplete = true;
+      contents.setZoomLevel(dependencies.zoomState.load());
+      dependencies.refreshNativeActions();
+    },
+    zoomChanged(contents): void {
+      if (!handoffComplete || activeContents() !== contents || zoomSavePending) return;
+      zoomSavePending = true;
+      scheduledContents = contents;
+      schedule(() => {
+        if (scheduledContents !== contents) return;
+        zoomSavePending = false;
+        scheduledContents = null;
+        if (!handoffComplete || activeContents() !== contents) return;
+        const current = contents.getZoomLevel();
+        const clamped = clampZoomLevel(current);
+        if (clamped !== current) contents.setZoomLevel(clamped);
+        dependencies.zoomState.save(clamped);
+      });
+    },
+    zoomIn: () => runWhenReady((contents) => setAndSaveZoom(contents, contents.getZoomLevel() + 0.5, dependencies.zoomState)),
+    zoomOut: () => runWhenReady((contents) => setAndSaveZoom(contents, contents.getZoomLevel() - 0.5, dependencies.zoomState)),
+    actualSize: () => runWhenReady((contents) => setAndSaveZoom(contents, 0, dependencies.zoomState)),
+    reloadConsole: () => runWhenReady((contents) => contents.reload()),
+    consoleReady: () => handoffComplete && activeContents() !== null,
+  };
+}
+
+function setAndSaveZoom(contents: ConsoleControlsWebContents, nextLevel: number, zoomState: ZoomState): void {
+  const level = clampZoomLevel(nextLevel);
+  contents.setZoomLevel(level);
+  zoomState.save(level);
+}

--- a/runtime/fleet-desktop/src/console-controls.ts
+++ b/runtime/fleet-desktop/src/console-controls.ts
@@ -14,14 +14,13 @@ export interface ConsoleControlsWindow {
 export interface ConsoleControlsDependencies {
   readonly zoomState: ZoomState;
   readonly refreshNativeActions: () => void;
-  readonly schedule?: (callback: () => void) => void;
 }
 
 export interface ConsoleControls {
   attachWindow(window: ConsoleControlsWindow): void;
   handoffStarted(): void;
   onConsoleLoaded(): void;
-  zoomChanged(contents: ConsoleControlsWebContents): void;
+  zoomChanged(contents: ConsoleControlsWebContents, zoomDirection: "in" | "out"): void;
   zoomIn(): void;
   zoomOut(): void;
   actualSize(): void;
@@ -30,13 +29,9 @@ export interface ConsoleControls {
 }
 
 export function createConsoleControls(dependencies: ConsoleControlsDependencies): ConsoleControls {
-  // 휠 줌은 zoom-changed 발화 시점에 아직 적용 전일 수 있어 매크로태스크로 지연 판독한다.
-  const schedule = dependencies.schedule ?? ((callback: () => void) => { setImmediate(callback); });
   let window: ConsoleControlsWindow | null = null;
   let handoffPending = false;
   let handoffComplete = false;
-  let zoomSavePending = false;
-  let scheduledContents: ConsoleControlsWebContents | null = null;
 
   const activeContents = (): ConsoleControlsWebContents | null => window && !window.isDestroyed() ? window.webContents : null;
   const runWhenReady = (action: (contents: ConsoleControlsWebContents) => void): void => {
@@ -49,8 +44,6 @@ export function createConsoleControls(dependencies: ConsoleControlsDependencies)
       window = nextWindow;
       handoffPending = false;
       handoffComplete = false;
-      zoomSavePending = false;
-      scheduledContents = null;
     },
     handoffStarted(): void {
       if (activeContents()) handoffPending = true;
@@ -63,20 +56,10 @@ export function createConsoleControls(dependencies: ConsoleControlsDependencies)
       contents.setZoomLevel(dependencies.zoomState.load());
       dependencies.refreshNativeActions();
     },
-    zoomChanged(contents): void {
-      if (!handoffComplete || activeContents() !== contents || zoomSavePending) return;
-      zoomSavePending = true;
-      scheduledContents = contents;
-      schedule(() => {
-        if (scheduledContents !== contents) return;
-        zoomSavePending = false;
-        scheduledContents = null;
-        if (!handoffComplete || activeContents() !== contents) return;
-        const current = contents.getZoomLevel();
-        const clamped = clampZoomLevel(current);
-        if (clamped !== current) contents.setZoomLevel(clamped);
-        dependencies.zoomState.save(clamped);
-      });
+    zoomChanged(contents, zoomDirection): void {
+      // zoom-changed는 상태 통지가 아니라 사용자 요청이다 — Chromium이 줌을 적용해 주지 않으므로 방향대로 직접 적용·저장한다.
+      if (!handoffComplete || activeContents() !== contents) return;
+      setAndSaveZoom(contents, contents.getZoomLevel() + (zoomDirection === "in" ? 0.5 : -0.5), dependencies.zoomState);
     },
     zoomIn: () => runWhenReady((contents) => setAndSaveZoom(contents, contents.getZoomLevel() + 0.5, dependencies.zoomState)),
     zoomOut: () => runWhenReady((contents) => setAndSaveZoom(contents, contents.getZoomLevel() - 0.5, dependencies.zoomState)),

--- a/runtime/fleet-desktop/src/launch-controller.ts
+++ b/runtime/fleet-desktop/src/launch-controller.ts
@@ -13,6 +13,7 @@ export interface LaunchControllerDependencies {
   readonly createWindow: () => Promise<LaunchWindow>;
   readonly handoffOrigin: (origin: string) => void;
   readonly synchronizeTheme?: (origin: string) => Promise<void>;
+  readonly onConsoleLoaded?: () => void;
   readonly pushEntry: (contents: EntryPageWebContents, snapshot: EntryPageSnapshot) => Promise<void>;
   readonly startOrAdopt: () => Promise<string>;
   readonly dev?: boolean;
@@ -52,6 +53,7 @@ export function createLaunchController(dependencies: LaunchControllerDependencie
       await dependencies.synchronizeTheme?.(origin);
       await push("starting", "ready");
       if (!window.isDestroyed?.()) await window.loadURL(consoleUrl);
+      if (!window.isDestroyed?.()) dependencies.onConsoleLoaded?.();
       return window;
     },
   };

--- a/runtime/fleet-desktop/src/main.ts
+++ b/runtime/fleet-desktop/src/main.ts
@@ -93,7 +93,7 @@ async function boot(): Promise<void> {
         controls.attachWindow(createdWindow);
         lifecycle.attachWindow(createdWindow);
         policy = applyWindowPolicy(createdWindow.webContents, async (external) => shell.openExternal(external));
-        createdWindow.webContents.on("zoom-changed", () => controls.zoomChanged(createdWindow.webContents));
+        createdWindow.webContents.on("zoom-changed", (_event, zoomDirection) => controls.zoomChanged(createdWindow.webContents, zoomDirection));
         refreshNativeUpdateActions?.();
         await createdWindow.loadFile(desktopResources.entryPagePath);
         return createdWindow;

--- a/runtime/fleet-desktop/src/main.ts
+++ b/runtime/fleet-desktop/src/main.ts
@@ -7,6 +7,7 @@ import { app, BrowserWindow, dialog, Menu, shell, Tray } from "electron";
 
 import { createDesktopLifecycle } from "./app-lifecycle.js";
 import { isConsoleConflict, showConsoleConflictAndQuit } from "./console-conflict.js";
+import { createConsoleControls } from "./console-controls.js";
 import { createDesktopEnvironment, resolveDesktopUserDataDirectory } from "./environment.js";
 import { pushEntrySnapshot } from "./entry-page.js";
 import { applyDesktopDockIcon, applyDesktopIdentity } from "./identity.js";
@@ -23,6 +24,7 @@ import { SidecarSupervisor, type SidecarRuntime } from "./sidecar-supervisor.js"
 import { configureTray } from "./tray.js";
 import { createNoopUpdateController, createUpdateController, showWindowsHiddenUpdateDialog } from "./update-controller.js";
 import { applyWindowPolicy, createSecureWindow } from "./window-policy.js";
+import { createZoomState } from "./zoom-state.js";
 
 type RuntimeProgress = (state: RuntimeEntryState, detail?: string, progress?: number) => Promise<void>;
 
@@ -80,19 +82,29 @@ async function boot(): Promise<void> {
     })
     : null;
   let refreshNativeUpdateActions: (() => void) | null = null;
+  const zoomState = createZoomState(path.join(app.getPath("userData"), "desktop-state.json"));
+  const controls = createConsoleControls({ zoomState, refreshNativeActions: () => refreshNativeUpdateActions?.() });
   const lifecycle = createDesktopLifecycle(app, async () => {
     const launch = createLaunchController({
       createWindow: async () => {
-        window = createSecureWindow(BrowserWindow, { iconPath: desktopResources.iconPath, platform: process.platform });
-        window.once("closed", () => themeSynchronizer?.stop());
-        lifecycle.attachWindow(window);
-        policy = applyWindowPolicy(window.webContents, async (external) => shell.openExternal(external));
-        await window.loadFile(desktopResources.entryPagePath);
-        return window;
+        const createdWindow = createSecureWindow(BrowserWindow, { iconPath: desktopResources.iconPath, platform: process.platform });
+        window = createdWindow;
+        createdWindow.once("closed", () => themeSynchronizer?.stop());
+        controls.attachWindow(createdWindow);
+        lifecycle.attachWindow(createdWindow);
+        policy = applyWindowPolicy(createdWindow.webContents, async (external) => shell.openExternal(external));
+        createdWindow.webContents.on("zoom-changed", () => controls.zoomChanged(createdWindow.webContents));
+        refreshNativeUpdateActions?.();
+        await createdWindow.loadFile(desktopResources.entryPagePath);
+        return createdWindow;
       },
       dev: !isPackaged,
-      handoffOrigin: (origin) => policy?.activateConsoleOrigin(origin),
+      handoffOrigin: (origin) => {
+        policy?.activateConsoleOrigin(origin);
+        controls.handoffStarted();
+      },
       synchronizeTheme: async (origin) => { await themeSynchronizer?.start(origin); },
+      onConsoleLoaded: () => controls.onConsoleLoaded(),
       onFirstRunFailure: async () => showFirstRunFailure(),
       onWindowReady: (push) => { pushRuntimeProgress = push; },
       pushEntry: pushEntrySnapshot,
@@ -111,10 +123,23 @@ async function boot(): Promise<void> {
       onStateChange: () => refreshNativeUpdateActions?.(),
     })
     : createNoopUpdateController();
-  const actions = { show: () => { void lifecycle.show(); }, quit: () => { void lifecycle.quit(); }, diagnostics: () => { void shell.openPath(path.join(app.getPath("userData"), "logs")); }, updates };
-  if (process.platform !== "darwin") trayHolder.current = new Tray(desktopResources.iconPath);
+  const actions = {
+    show: () => { void lifecycle.show(); },
+    quit: () => { void lifecycle.quit(); },
+    diagnostics: () => { void shell.openPath(path.join(app.getPath("userData"), "logs")); },
+    zoomIn: () => controls.zoomIn(),
+    zoomOut: () => controls.zoomOut(),
+    actualSize: () => controls.actualSize(),
+    reloadConsole: () => controls.reloadConsole(),
+    consoleReady: () => controls.consoleReady(),
+    updates,
+  };
+  if (process.platform !== "darwin") {
+    trayHolder.current = new Tray(desktopResources.iconPath);
+    trayHolder.current.on("click", actions.show);
+  }
   refreshNativeUpdateActions = () => {
-    installApplicationMenu(Menu, actions, process.platform);
+    installApplicationMenu(Menu, actions, process.platform, window ?? undefined);
     if (trayHolder.current) configureTray(trayHolder.current, Menu, actions);
   };
   refreshNativeUpdateActions();

--- a/runtime/fleet-desktop/src/menu.ts
+++ b/runtime/fleet-desktop/src/menu.ts
@@ -1,4 +1,4 @@
-import type { Menu, MenuItemConstructorOptions } from "electron";
+import type { BrowserWindow, Menu, MenuItemConstructorOptions } from "electron";
 
 import type { UpdateController } from "./update-controller.js";
 
@@ -6,12 +6,23 @@ export interface ApplicationMenuActions {
   readonly show: () => void;
   readonly quit: () => void;
   readonly diagnostics: () => void;
+  readonly zoomIn: () => void;
+  readonly zoomOut: () => void;
+  readonly actualSize: () => void;
+  readonly reloadConsole: () => void;
+  readonly consoleReady: () => boolean;
   readonly updates: UpdateController;
 }
 
-export function installApplicationMenu(MenuCtor: typeof Menu, actions: ApplicationMenuActions, platform: NodeJS.Platform): void {
+export function installApplicationMenu(MenuCtor: typeof Menu, actions: ApplicationMenuActions, platform: NodeJS.Platform, window?: BrowserWindow): void {
   if (platform !== "darwin") {
-    MenuCtor.setApplicationMenu(null);
+    const menu = MenuCtor.buildFromTemplate([{
+      label: "Fleet Console",
+      submenu: nonDarwinConsoleActions(actions),
+    }]);
+    MenuCtor.setApplicationMenu(menu);
+    window?.setMenu(menu);
+    window?.setMenuBarVisibility(false);
     return;
   }
   const template: MenuItemConstructorOptions[] = [
@@ -27,6 +38,45 @@ export function installApplicationMenu(MenuCtor: typeof Menu, actions: Applicati
       ],
     },
     { role: "editMenu" },
+    { label: "View", submenu: darwinConsoleActions(actions) },
   ];
   MenuCtor.setApplicationMenu(MenuCtor.buildFromTemplate(template));
+}
+
+function darwinConsoleActions(actions: ApplicationMenuActions): MenuItemConstructorOptions[] {
+  return [
+    consoleAction("Reload Console", "Command+R", actions.reloadConsole, actions),
+    { type: "separator" },
+    consoleAction("Zoom In", "Command+Plus", actions.zoomIn, actions),
+    consoleAction("Zoom In", "Command+=", actions.zoomIn, actions, true),
+    consoleAction("Zoom In", "Command+numadd", actions.zoomIn, actions, true),
+    consoleAction("Zoom Out", "Command+-", actions.zoomOut, actions),
+    consoleAction("Zoom Out", "Command+numsub", actions.zoomOut, actions, true),
+    consoleAction("Actual Size", "Command+0", actions.actualSize, actions),
+  ];
+}
+
+function nonDarwinConsoleActions(actions: ApplicationMenuActions): MenuItemConstructorOptions[] {
+  return [
+    consoleAction("Reload Console", "Ctrl+R", actions.reloadConsole, actions),
+    consoleAction("Reload Console", "F5", actions.reloadConsole, actions),
+    { type: "separator" },
+    consoleAction("Zoom In", "Ctrl+=", actions.zoomIn, actions),
+    consoleAction("Zoom In", "Ctrl+Shift+=", actions.zoomIn, actions),
+    consoleAction("Zoom In", "Ctrl+numadd", actions.zoomIn, actions),
+    consoleAction("Zoom Out", "Ctrl+-", actions.zoomOut, actions),
+    consoleAction("Zoom Out", "Ctrl+numsub", actions.zoomOut, actions),
+    consoleAction("Actual Size", "Ctrl+0", actions.actualSize, actions),
+  ];
+}
+
+function consoleAction(label: string, accelerator: string, action: () => void, actions: ApplicationMenuActions, hidden = false): MenuItemConstructorOptions {
+  const enabled = actions.consoleReady();
+  return {
+    label,
+    accelerator,
+    enabled,
+    ...(hidden ? { visible: false } : {}),
+    click: () => { if (actions.consoleReady()) action(); },
+  };
 }

--- a/runtime/fleet-desktop/src/tray.ts
+++ b/runtime/fleet-desktop/src/tray.ts
@@ -6,6 +6,11 @@ export interface TrayActions {
   readonly show: () => void;
   readonly quit: () => void;
   readonly diagnostics: () => void;
+  readonly zoomIn: () => void;
+  readonly zoomOut: () => void;
+  readonly actualSize: () => void;
+  readonly reloadConsole: () => void;
+  readonly consoleReady: () => boolean;
   readonly updates: UpdateController;
 }
 
@@ -13,11 +18,24 @@ export function configureTray(tray: Tray, MenuCtor: typeof Menu, actions: TrayAc
   tray.setContextMenu(MenuCtor.buildFromTemplate([
     { label: "Show Fleet Console", click: actions.show },
     { type: "separator" },
+    consoleAction("Zoom In", "Ctrl+=", actions.zoomIn, actions),
+    consoleAction("Zoom Out", "Ctrl+-", actions.zoomOut, actions),
+    consoleAction("Actual Size", "Ctrl+0", actions.actualSize, actions),
+    consoleAction("Reload Console", "Ctrl+R", actions.reloadConsole, actions),
+    { type: "separator" },
     ...(actions.updates.enabled() ? [{ label: "Check for Updates", click: () => void actions.updates.check() }, ...(actions.updates.availableVersion() ? [{ label: `Update to ${actions.updates.availableVersion()}…`, sublabel: "restarts console", click: () => void actions.updates.install() }] : [])] : []),
     { type: "separator" },
     { label: "Diagnostics", click: actions.diagnostics },
     { type: "separator" },
     { label: "Quit", click: actions.quit },
   ]));
-  tray.on("click", actions.show);
+}
+
+function consoleAction(label: string, accelerator: string, action: () => void, actions: TrayActions): { label: string; accelerator: string; enabled: boolean; click: () => void } {
+  return {
+    label,
+    accelerator,
+    enabled: actions.consoleReady(),
+    click: () => { if (actions.consoleReady()) action(); },
+  };
 }

--- a/runtime/fleet-desktop/src/window-policy.ts
+++ b/runtime/fleet-desktop/src/window-policy.ts
@@ -22,6 +22,7 @@ export function createSecureWindow(BrowserWindowCtor: typeof BrowserWindow, opti
     backgroundColor: CANVAS_FAR_BACKGROUND_COLOR,
     minWidth: 900,
     minHeight: 560,
+    ...(options.platform !== "darwin" ? { autoHideMenuBar: false } : {}),
     // Windows 오버레이 43px + Command Band 하단 divider 1px가 클라이언트 --chrome-band-height: 44px를 채운다. macOS 88px 인셋과 함께 변경 시 양쪽을 동기화한다.
     ...(options.platform === "darwin" ? { titleBarStyle: "hiddenInset", trafficLightPosition: { x: 16, y: 14 } } : {}),
     ...(options.platform === "win32" ? { titleBarStyle: "hidden", titleBarOverlay: INITIAL_WINDOWS_TITLE_BAR_OVERLAY } : {}),

--- a/runtime/fleet-desktop/src/zoom-state.ts
+++ b/runtime/fleet-desktop/src/zoom-state.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const DEFAULT_ZOOM_LEVEL = 0;
+export const MIN_ZOOM_LEVEL = -3;
+export const MAX_ZOOM_LEVEL = 3;
+
+interface ZoomStateFileSystem {
+  readFileSync(path: string, encoding: "utf8"): string;
+  mkdirSync(path: string, options: { recursive: true }): string | undefined;
+  writeFileSync(path: string, data: string, encoding: "utf8"): void;
+  renameSync(oldPath: string, newPath: string): void;
+}
+
+export interface ZoomState {
+  load(): number;
+  save(zoomLevel: number): void;
+}
+
+export function clampZoomLevel(zoomLevel: number): number {
+  if (!Number.isFinite(zoomLevel)) return DEFAULT_ZOOM_LEVEL;
+  return Math.min(MAX_ZOOM_LEVEL, Math.max(MIN_ZOOM_LEVEL, zoomLevel));
+}
+
+export function createZoomState(statePath: string, fileSystem: ZoomStateFileSystem = fs): ZoomState {
+  const temporaryPath = `${statePath}.tmp`;
+  return {
+    load(): number {
+      try {
+        const parsed: unknown = JSON.parse(fileSystem.readFileSync(statePath, "utf8"));
+        if (!isZoomState(parsed)) return DEFAULT_ZOOM_LEVEL;
+        return clampZoomLevel(parsed.zoomLevel);
+      } catch {
+        return DEFAULT_ZOOM_LEVEL;
+      }
+    },
+    save(zoomLevel: number): void {
+      try {
+        fileSystem.mkdirSync(path.dirname(statePath), { recursive: true });
+        fileSystem.writeFileSync(temporaryPath, `${JSON.stringify({ zoomLevel: clampZoomLevel(zoomLevel) })}\n`, "utf8");
+        fileSystem.renameSync(temporaryPath, statePath);
+      } catch {
+        // Zoom persistence is best-effort; a read-only userData directory must not interrupt the Console.
+      }
+    },
+  };
+}
+
+function isZoomState(value: unknown): value is { zoomLevel: number } {
+  return typeof value === "object" && value !== null && "zoomLevel" in value && typeof value.zoomLevel === "number";
+}

--- a/runtime/fleet-desktop/tests/console-controls.test.ts
+++ b/runtime/fleet-desktop/tests/console-controls.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createConsoleControls } from "../src/console-controls.js";
+
+function createWindow(zoomLevel = 0) {
+  let level = zoomLevel;
+  return {
+    destroyed: false,
+    webContents: {
+      getZoomLevel: () => level,
+      setZoomLevel: vi.fn((next: number) => { level = next; }),
+      reload: vi.fn(),
+    },
+    isDestroyed(): boolean { return this.destroyed; },
+  };
+}
+
+describe("console controls", () => {
+  it("keeps every control gated until Console load completes and resets the gate for a recreated window", () => {
+    const refreshNativeActions = vi.fn();
+    const zoomState = { load: vi.fn(() => 1.5), save: vi.fn() };
+    const controls = createConsoleControls({ zoomState, refreshNativeActions });
+    const first = createWindow();
+
+    controls.attachWindow(first);
+    controls.zoomIn();
+    controls.zoomOut();
+    controls.actualSize();
+    controls.reloadConsole();
+    expect(first.webContents.setZoomLevel).not.toHaveBeenCalled();
+    expect(first.webContents.reload).not.toHaveBeenCalled();
+    expect(controls.consoleReady()).toBe(false);
+
+    controls.handoffStarted();
+    controls.zoomIn();
+    controls.reloadConsole();
+    expect(first.webContents.setZoomLevel).not.toHaveBeenCalled();
+    expect(first.webContents.reload).not.toHaveBeenCalled();
+    expect(refreshNativeActions).not.toHaveBeenCalled();
+
+    controls.onConsoleLoaded();
+    expect(first.webContents.setZoomLevel).toHaveBeenCalledWith(1.5);
+    expect(refreshNativeActions).toHaveBeenCalledOnce();
+    expect(controls.consoleReady()).toBe(true);
+    controls.zoomIn();
+    controls.reloadConsole();
+    expect(first.webContents.setZoomLevel).toHaveBeenLastCalledWith(2);
+    expect(first.webContents.reload).toHaveBeenCalledOnce();
+
+    first.destroyed = true;
+    controls.zoomOut();
+    controls.reloadConsole();
+    expect(controls.consoleReady()).toBe(false);
+    const second = createWindow();
+    controls.attachWindow(second);
+    controls.zoomIn();
+    controls.reloadConsole();
+    expect(second.webContents.setZoomLevel).not.toHaveBeenCalled();
+    expect(second.webContents.reload).not.toHaveBeenCalled();
+  });
+
+  it("applies and persists the clamped delayed wheel zoom once per tick", () => {
+    const scheduled: Array<() => void> = [];
+    let stored = 1;
+    const zoomState = { load: vi.fn(() => stored), save: vi.fn((level: number) => { stored = level; }) };
+    const controls = createConsoleControls({ zoomState, refreshNativeActions: vi.fn(), schedule: (callback) => { scheduled.push(callback); } });
+    const first = createWindow();
+
+    controls.attachWindow(first);
+    controls.handoffStarted();
+    controls.onConsoleLoaded();
+    first.webContents.setZoomLevel.mockClear();
+    first.webContents.setZoomLevel(4);
+    first.webContents.setZoomLevel.mockClear();
+    controls.zoomChanged(first.webContents);
+    controls.zoomChanged(first.webContents);
+    controls.zoomChanged(first.webContents);
+    expect(scheduled).toHaveLength(1);
+    expect(zoomState.save).not.toHaveBeenCalled();
+
+    scheduled[0]!();
+    expect(first.webContents.setZoomLevel).toHaveBeenCalledWith(3);
+    expect(zoomState.save).toHaveBeenCalledOnce();
+    expect(zoomState.save).toHaveBeenCalledWith(3);
+
+    const second = createWindow();
+    controls.attachWindow(second);
+    controls.handoffStarted();
+    controls.onConsoleLoaded();
+    expect(second.webContents.setZoomLevel).toHaveBeenCalledWith(3);
+  });
+});

--- a/runtime/fleet-desktop/tests/console-controls.test.ts
+++ b/runtime/fleet-desktop/tests/console-controls.test.ts
@@ -59,32 +59,36 @@ describe("console controls", () => {
     expect(second.webContents.reload).not.toHaveBeenCalled();
   });
 
-  it("applies and persists the clamped delayed wheel zoom once per tick", () => {
-    const scheduled: Array<() => void> = [];
+  it("applies and persists the requested wheel zoom direction with clamping", () => {
+    // zoom-changed는 상태 통지가 아니라 요청 이벤트다 — coordinator가 방향대로 직접 적용해야 휠 줌이 동작한다.
     let stored = 1;
     const zoomState = { load: vi.fn(() => stored), save: vi.fn((level: number) => { stored = level; }) };
-    const controls = createConsoleControls({ zoomState, refreshNativeActions: vi.fn(), schedule: (callback) => { scheduled.push(callback); } });
+    const controls = createConsoleControls({ zoomState, refreshNativeActions: vi.fn() });
     const first = createWindow();
 
     controls.attachWindow(first);
+    controls.zoomChanged(first.webContents, "in");
+    expect(first.webContents.setZoomLevel).not.toHaveBeenCalled();
+
     controls.handoffStarted();
     controls.onConsoleLoaded();
     first.webContents.setZoomLevel.mockClear();
-    first.webContents.setZoomLevel(4);
-    first.webContents.setZoomLevel.mockClear();
-    controls.zoomChanged(first.webContents);
-    controls.zoomChanged(first.webContents);
-    controls.zoomChanged(first.webContents);
-    expect(scheduled).toHaveLength(1);
-    expect(zoomState.save).not.toHaveBeenCalled();
 
-    scheduled[0]!();
-    expect(first.webContents.setZoomLevel).toHaveBeenCalledWith(3);
-    expect(zoomState.save).toHaveBeenCalledOnce();
-    expect(zoomState.save).toHaveBeenCalledWith(3);
+    controls.zoomChanged(first.webContents, "in");
+    expect(first.webContents.setZoomLevel).toHaveBeenLastCalledWith(1.5);
+    expect(zoomState.save).toHaveBeenLastCalledWith(1.5);
+    controls.zoomChanged(first.webContents, "out");
+    expect(first.webContents.setZoomLevel).toHaveBeenLastCalledWith(1);
+    expect(zoomState.save).toHaveBeenLastCalledWith(1);
+
+    for (let step = 0; step < 5; step++) controls.zoomChanged(first.webContents, "in");
+    expect(first.webContents.setZoomLevel).toHaveBeenLastCalledWith(3);
+    expect(zoomState.save).toHaveBeenLastCalledWith(3);
 
     const second = createWindow();
     controls.attachWindow(second);
+    controls.zoomChanged(first.webContents, "in");
+    expect(second.webContents.setZoomLevel).not.toHaveBeenCalled();
     controls.handoffStarted();
     controls.onConsoleLoaded();
     expect(second.webContents.setZoomLevel).toHaveBeenCalledWith(3);

--- a/runtime/fleet-desktop/tests/launch-controller.test.ts
+++ b/runtime/fleet-desktop/tests/launch-controller.test.ts
@@ -7,9 +7,9 @@ describe("launch controller", () => {
     const order: string[] = [];
     const contents = { executeJavaScript: vi.fn(async () => undefined) };
     const window = { webContents: contents, show: vi.fn(() => order.push("show")), loadURL: vi.fn(async () => { order.push("handoff"); }) };
-    const controller = createLaunchController({ createWindow: vi.fn(async () => window), pushEntry: vi.fn(async () => { order.push("entry"); }), startOrAdopt: vi.fn(async () => { order.push("start"); return "http://127.0.0.1:4310/console/"; }), handoffOrigin: vi.fn((origin) => { order.push(`origin=${origin}`); }) });
+    const controller = createLaunchController({ createWindow: vi.fn(async () => window), pushEntry: vi.fn(async () => { order.push("entry"); }), startOrAdopt: vi.fn(async () => { order.push("start"); return "http://127.0.0.1:4310/console/"; }), handoffOrigin: vi.fn((origin) => { order.push(`origin=${origin}`); }), onConsoleLoaded: () => { order.push("console-loaded"); } });
     await controller.start();
-    expect(order).toEqual(["entry", "show", "start", "origin=http://127.0.0.1:4310", "entry", "handoff"]);
+    expect(order).toEqual(["entry", "show", "start", "origin=http://127.0.0.1:4310", "entry", "handoff", "console-loaded"]);
   });
 
   it("synchronizes the Console-owned title bar theme after origin activation and before handoff", async () => {

--- a/runtime/fleet-desktop/tests/menu.test.ts
+++ b/runtime/fleet-desktop/tests/menu.test.ts
@@ -3,25 +3,74 @@ import { describe, expect, it, vi } from "vitest";
 import { installApplicationMenu } from "../src/menu.js";
 
 describe("application menu", () => {
-  it("keeps the macOS application and edit menus with all desktop actions", () => {
+  it("keeps the macOS application and edit menus while adding gated View actions and every accelerator", () => {
     const menu = { buildFromTemplate: vi.fn((_template: unknown) => "menu"), setApplicationMenu: vi.fn() };
     const updates = { check: vi.fn(async () => undefined), install: vi.fn(async () => undefined), availableVersion: () => "1.2.4", enabled: () => true };
+    let consoleReady = false;
+    const zoomIn = vi.fn();
+    const zoomOut = vi.fn();
+    const actualSize = vi.fn();
+    const reloadConsole = vi.fn();
 
-    installApplicationMenu(menu as never, { show: vi.fn(), quit: vi.fn(), diagnostics: vi.fn(), updates }, "darwin");
+    installApplicationMenu(menu as never, { show: vi.fn(), quit: vi.fn(), diagnostics: vi.fn(), zoomIn, zoomOut, actualSize, reloadConsole, consoleReady: () => consoleReady, updates }, "darwin");
 
-    const template = menu.buildFromTemplate.mock.calls[0]![0] as unknown as Array<{ role?: string; submenu?: Array<{ label?: string; role?: string }> }>;
-    expect(template.map((item) => item.role)).toEqual(["appMenu", "editMenu"]);
+    const template = menu.buildFromTemplate.mock.calls[0]![0] as unknown as Array<{ label?: string; role?: string; submenu?: Array<{ label?: string; role?: string; accelerator?: string; enabled?: boolean; visible?: boolean; click?: () => void }> }>;
+    expect(template.map((item) => item.role ?? item.label)).toEqual(["appMenu", "editMenu", "View"]);
     expect(template[0]!.submenu?.map((item) => item.label ?? item.role)).toEqual(["Show", undefined, "Check for Updates", "Update to 1.2.4…", undefined, "Diagnostics", "quit"]);
+    const view = template[2]!.submenu!;
+    expect(view.filter((item) => item.accelerator).map((item) => item.accelerator)).toEqual(["Command+R", "Command+Plus", "Command+=", "Command+numadd", "Command+-", "Command+numsub", "Command+0"]);
+    expect(view.filter((item) => item.accelerator).every((item) => item.enabled === false)).toBe(true);
+    expect(view.filter((item) => item.visible === false).map((item) => item.accelerator)).toEqual(["Command+=", "Command+numadd", "Command+numsub"]);
+    view[0]!.click?.();
+    expect(reloadConsole).not.toHaveBeenCalled();
+
+    consoleReady = true;
+    installApplicationMenu(menu as never, { show: vi.fn(), quit: vi.fn(), diagnostics: vi.fn(), zoomIn, zoomOut, actualSize, reloadConsole, consoleReady: () => consoleReady, updates }, "darwin");
+    const enabledView = (menu.buildFromTemplate.mock.calls[1]![0] as typeof template)[2]!.submenu!;
+    expect(enabledView.filter((item) => item.accelerator).every((item) => item.enabled === true)).toBe(true);
+    enabledView[0]!.click?.();
+    enabledView[2]!.click?.();
+    enabledView[5]!.click?.();
+    enabledView[7]!.click?.();
+    expect(reloadConsole).toHaveBeenCalledOnce();
+    expect(zoomIn).toHaveBeenCalledOnce();
+    expect(zoomOut).toHaveBeenCalledOnce();
+    expect(actualSize).toHaveBeenCalledOnce();
     expect(menu.setApplicationMenu).toHaveBeenCalledWith("menu");
   });
 
-  it.each(["win32", "linux"] as const)("removes the native menu bar on %s", (platform) => {
-    const menu = { buildFromTemplate: vi.fn(), setApplicationMenu: vi.fn() };
+  it.each(["win32", "linux"] as const)("installs hidden accelerators and permanently hides the native menu bar on %s", (platform) => {
+    const menu = { buildFromTemplate: vi.fn((_template: unknown) => "menu"), setApplicationMenu: vi.fn() };
     const updates = { check: vi.fn(async () => undefined), install: vi.fn(async () => undefined), availableVersion: () => null, enabled: () => true };
+    const window = { setMenu: vi.fn(), setMenuBarVisibility: vi.fn() };
+    const zoomIn = vi.fn();
+    const zoomOut = vi.fn();
+    const actualSize = vi.fn();
+    const reloadConsole = vi.fn();
+    let consoleReady = false;
 
-    installApplicationMenu(menu as never, { show: vi.fn(), quit: vi.fn(), diagnostics: vi.fn(), updates }, platform);
+    installApplicationMenu(menu as never, { show: vi.fn(), quit: vi.fn(), diagnostics: vi.fn(), zoomIn, zoomOut, actualSize, reloadConsole, consoleReady: () => consoleReady, updates }, platform, window as never);
 
-    expect(menu.buildFromTemplate).not.toHaveBeenCalled();
-    expect(menu.setApplicationMenu).toHaveBeenCalledWith(null);
+    const template = menu.buildFromTemplate.mock.calls[0]![0] as Array<{ submenu: Array<{ accelerator?: string; enabled?: boolean; click?: () => void }> }>;
+    const hiddenActions = template[0]!.submenu.filter((item) => item.accelerator);
+    expect(hiddenActions.map((item) => item.accelerator)).toEqual(["Ctrl+R", "F5", "Ctrl+=", "Ctrl+Shift+=", "Ctrl+numadd", "Ctrl+-", "Ctrl+numsub", "Ctrl+0"]);
+    expect(hiddenActions.every((item) => item.enabled === false)).toBe(true);
+    hiddenActions[0]!.click?.();
+    expect(reloadConsole).not.toHaveBeenCalled();
+    expect(window.setMenu).toHaveBeenCalledWith("menu");
+    expect(window.setMenuBarVisibility).toHaveBeenCalledWith(false);
+
+    consoleReady = true;
+    installApplicationMenu(menu as never, { show: vi.fn(), quit: vi.fn(), diagnostics: vi.fn(), zoomIn, zoomOut, actualSize, reloadConsole, consoleReady: () => consoleReady, updates }, platform, window as never);
+    const enabledActions = ((menu.buildFromTemplate.mock.calls[1]![0] as typeof template)[0]!.submenu.filter((item) => item.accelerator));
+    expect(enabledActions.every((item) => item.enabled === true)).toBe(true);
+    enabledActions[0]!.click?.();
+    enabledActions[2]!.click?.();
+    enabledActions[5]!.click?.();
+    enabledActions[7]!.click?.();
+    expect(reloadConsole).toHaveBeenCalledOnce();
+    expect(zoomIn).toHaveBeenCalledOnce();
+    expect(zoomOut).toHaveBeenCalledOnce();
+    expect(actualSize).toHaveBeenCalledOnce();
   });
 });

--- a/runtime/fleet-desktop/tests/tray.test.ts
+++ b/runtime/fleet-desktop/tests/tray.test.ts
@@ -3,25 +3,47 @@ import { describe, expect, it, vi } from "vitest";
 import { configureTray } from "../src/tray.js";
 
 describe("tray menu", () => {
-  it("keeps update and diagnostics actions available after menu bar retirement", () => {
+  it("places gated Console actions directly below Show without moving update, diagnostics, or quit", () => {
     const tray = { setContextMenu: vi.fn(), on: vi.fn() };
     const menu = { buildFromTemplate: vi.fn((_template: unknown) => "menu") };
     const show = vi.fn();
     const quit = vi.fn();
     const diagnostics = vi.fn();
+    const zoomIn = vi.fn();
+    const zoomOut = vi.fn();
+    const actualSize = vi.fn();
+    const reloadConsole = vi.fn();
+    let consoleReady = false;
     const updates = { check: vi.fn(async () => undefined), install: vi.fn(async () => undefined), availableVersion: () => "1.2.4", enabled: () => true };
 
-    configureTray(tray as never, menu as never, { show, quit, diagnostics, updates });
+    configureTray(tray as never, menu as never, { show, quit, diagnostics, zoomIn, zoomOut, actualSize, reloadConsole, consoleReady: () => consoleReady, updates });
 
-    const template = menu.buildFromTemplate.mock.calls[0]![0] as unknown as Array<{ label?: string; click?: () => void }>;
-    expect(template.map((item) => item.label).filter(Boolean)).toEqual(["Show Fleet Console", "Check for Updates", "Update to 1.2.4…", "Diagnostics", "Quit"]);
-    template[2]!.click?.();
-    template[3]!.click?.();
+    const template = menu.buildFromTemplate.mock.calls[0]![0] as unknown as Array<{ label?: string; accelerator?: string; enabled?: boolean; click?: () => void }>;
+    expect(template.map((item) => item.label).filter(Boolean)).toEqual(["Show Fleet Console", "Zoom In", "Zoom Out", "Actual Size", "Reload Console", "Check for Updates", "Update to 1.2.4…", "Diagnostics", "Quit"]);
+    expect(template.slice(2, 6).map((item) => item.accelerator)).toEqual(["Ctrl+=", "Ctrl+-", "Ctrl+0", "Ctrl+R"]);
+    expect(template.slice(2, 6).every((item) => item.enabled === false)).toBe(true);
     template[5]!.click?.();
+    expect(reloadConsole).not.toHaveBeenCalled();
+
+    consoleReady = true;
+    configureTray(tray as never, menu as never, { show, quit, diagnostics, zoomIn, zoomOut, actualSize, reloadConsole, consoleReady: () => consoleReady, updates });
+    const enabledTemplate = menu.buildFromTemplate.mock.calls[1]![0] as typeof template;
+    expect(enabledTemplate.slice(2, 6).every((item) => item.enabled === true)).toBe(true);
+    enabledTemplate[2]!.click?.();
+    enabledTemplate[3]!.click?.();
+    enabledTemplate[4]!.click?.();
+    enabledTemplate[5]!.click?.();
+    enabledTemplate[7]!.click?.();
+    enabledTemplate[8]!.click?.();
+    enabledTemplate[10]!.click?.();
+    expect(zoomIn).toHaveBeenCalledOnce();
+    expect(zoomOut).toHaveBeenCalledOnce();
+    expect(actualSize).toHaveBeenCalledOnce();
+    expect(reloadConsole).toHaveBeenCalledOnce();
     expect(updates.check).toHaveBeenCalledOnce();
     expect(updates.install).toHaveBeenCalledOnce();
     expect(diagnostics).toHaveBeenCalledOnce();
     expect(tray.setContextMenu).toHaveBeenCalledWith("menu");
-    expect(tray.on).toHaveBeenCalledWith("click", show);
+    expect(tray.on).not.toHaveBeenCalled();
   });
 });

--- a/runtime/fleet-desktop/tests/window-policy.test.ts
+++ b/runtime/fleet-desktop/tests/window-policy.test.ts
@@ -13,14 +13,14 @@ describe("secure window policy", () => {
     const Ctor = vi.fn();
     createSecureWindow(Ctor as never, { iconPath: "/assets/icon.png", platform: "win32" });
 
-    expect(Ctor).toHaveBeenCalledWith({ show: false, title: "Fleet Console", icon: "/assets/icon.png", backgroundColor: "#010204", minWidth: 900, minHeight: 560, titleBarStyle: "hidden", titleBarOverlay: { color: "#03080e", symbolColor: "#989fa6", height: 43 }, webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, webSecurity: true } });
+    expect(Ctor).toHaveBeenCalledWith({ show: false, title: "Fleet Console", icon: "/assets/icon.png", backgroundColor: "#010204", minWidth: 900, minHeight: 560, autoHideMenuBar: false, titleBarStyle: "hidden", titleBarOverlay: { color: "#03080e", symbolColor: "#989fa6", height: 43 }, webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, webSecurity: true } });
   });
 
   it("keeps the Linux native title bar without an overlay", () => {
     const Ctor = vi.fn();
     createSecureWindow(Ctor as never, { iconPath: "/assets/icon.png", platform: "linux" });
 
-    expect(Ctor).toHaveBeenCalledWith({ show: false, title: "Fleet Console", icon: "/assets/icon.png", backgroundColor: "#010204", minWidth: 900, minHeight: 560, webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, webSecurity: true } });
+    expect(Ctor).toHaveBeenCalledWith({ show: false, title: "Fleet Console", icon: "/assets/icon.png", backgroundColor: "#010204", minWidth: 900, minHeight: 560, autoHideMenuBar: false, webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, webSecurity: true } });
   });
 
   it("allows only exact-origin Console routes", () => {

--- a/runtime/fleet-desktop/tests/zoom-state.test.ts
+++ b/runtime/fleet-desktop/tests/zoom-state.test.ts
@@ -1,0 +1,48 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { DEFAULT_ZOOM_LEVEL, MAX_ZOOM_LEVEL, MIN_ZOOM_LEVEL, clampZoomLevel, createZoomState } from "../src/zoom-state.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
+});
+
+describe("zoom state", () => {
+  it("clamps zoom levels to the supported Desktop range", () => {
+    expect(clampZoomLevel(MIN_ZOOM_LEVEL - 1)).toBe(MIN_ZOOM_LEVEL);
+    expect(clampZoomLevel(MAX_ZOOM_LEVEL + 1)).toBe(MAX_ZOOM_LEVEL);
+    expect(clampZoomLevel(1.5)).toBe(1.5);
+    expect(clampZoomLevel(Number.NaN)).toBe(DEFAULT_ZOOM_LEVEL);
+  });
+
+  it("atomically saves a bounded zoom level and loads it again", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-desktop-zoom-state-"));
+    temporaryDirectories.push(directory);
+    const statePath = path.join(directory, "desktop-state.json");
+    const state = createZoomState(statePath);
+
+    state.save(9);
+
+    expect(fs.readFileSync(statePath, "utf8")).toBe('{"zoomLevel":3}\n');
+    expect(fs.existsSync(`${statePath}.tmp`)).toBe(false);
+    expect(state.load()).toBe(MAX_ZOOM_LEVEL);
+  });
+
+  it("falls back to the default for missing or corrupt state", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-desktop-zoom-state-"));
+    temporaryDirectories.push(directory);
+    const statePath = path.join(directory, "desktop-state.json");
+    const state = createZoomState(statePath);
+
+    expect(state.load()).toBe(DEFAULT_ZOOM_LEVEL);
+    fs.writeFileSync(statePath, "not json", "utf8");
+    expect(state.load()).toBe(DEFAULT_ZOOM_LEVEL);
+    fs.writeFileSync(statePath, '{"zoomLevel":"large"}', "utf8");
+    expect(state.load()).toBe(DEFAULT_ZOOM_LEVEL);
+  });
+});


### PR DESCRIPTION
## Summary
- fleet-desktop 셸에 네 가지 콘솔 동작을 추가합니다: Zoom In / Zoom Out / Actual Size / Reload Console.
- macOS는 가시 View 메뉴(⌘R·⌘+·⌘−·⌘0), Windows/Linux는 메뉴 바를 영구 비노출한 숨김 가속기(Ctrl+= 변형·Ctrl+0·Ctrl+R·F5) + 트레이 우클릭 메뉴의 신설 구분선 섹션(키 힌트 병기)으로 제공합니다.
- 줌 레벨은 userData의 `desktop-state.json`에 영속(클램프 ±3)되어 콘솔 핸드오프 후 적용되며, 콘솔 페이지 로드가 끝나기 전에는 메뉴·가속기·트레이 세 경로 전부 게이팅됩니다(`console-controls` coordinator로 추출, 상태 전이 단위 계약 포함).

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-desktop typecheck` green
- [x] `pnpm --filter @dotobokuri/fleet-desktop test` green (27 files, 120 tests — 메뉴/트레이 구성·가속기 세트·게이팅 전이·줌 저장/로드/클램프/손상 폴백 계약 포함)
- [x] `pnpm --filter @dotobokuri/fleet-desktop build` green
- [x] `node scripts/compile-changelog-fragments.mjs --check` green
- [x] macOS 실기: 시딩한 zoomLevel(1.0, 1.5)이 재부팅 후 콘솔 핸드오프 시점에 정확히 적용됨을 CDP로 실측(dpr 2→2.4 / 2→2.629 = ×1.2^level 일치)
- [ ] Windows/Linux 실기(트레이 섹션·숨김 가속기·Alt 미노출)는 @sbluemin 이 별도 확인 예정 — 단위 계약 테스트로 선커버

## Changelog
- [x] `.changelog.d/fleet-desktop-added.md` 프래그먼트 포함 (Added, 이중언어)