### PR TITLE
feat(fleet-console): organize What's New by product

### DIFF
--- a/.changelog.d/fleet-console-changed.md
+++ b/.changelog.d/fleet-console-changed.md
@@ -4,3 +4,6 @@ section: Changed
 
 - [fleet-console] Split the sidebar Formation view toggle into a two-segment control, giving open-panel and include-minimized formation each their own button.
   ko: 사이드바 Formation view 토글을 2분할 세그먼트 컨트롤로 나눠, 열린 패널만과 최소화 패널 포함 Formation을 각각의 버튼으로 제공합니다.
+
+- [fleet-console] Organize What's New into Overview and product tabs while preserving legacy and mixed release updates.
+  ko: What's New를 Overview 및 제품 탭으로 구성하면서 레거시 및 혼합 릴리스 업데이트를 보존합니다.

--- a/.changelog.d/fleet-console-changed.md
+++ b/.changelog.d/fleet-console-changed.md
@@ -4,6 +4,5 @@ section: Changed
 
 - [fleet-console] Split the sidebar Formation view toggle into a two-segment control, giving open-panel and include-minimized formation each their own button.
   ko: 사이드바 Formation view 토글을 2분할 세그먼트 컨트롤로 나눠, 열린 패널만과 최소화 패널 포함 Formation을 각각의 버튼으로 제공합니다.
-
 - [fleet-console] Organize What's New into Overview and product tabs while preserving legacy and mixed release updates.
   ko: What's New를 Overview 및 제품 탭으로 구성하면서 레거시 및 혼합 릴리스 업데이트를 보존합니다.

--- a/runtime/fleet-console/core/client/src/api.ts
+++ b/runtime/fleet-console/core/client/src/api.ts
@@ -1,4 +1,4 @@
-import type { ConsoleUpdateApplyAcceptedResponse, OperationGroup, OperationNode, ObserverStatus, ReleaseNoteItem, ReleaseNoteSection, ReleaseNotes, ReleaseNotesLocale, ReleaseNotesResponse, TheaterBootstrap, TheaterInfo } from "./types.js";
+import type { ConsoleUpdateApplyAcceptedResponse, OperationGroup, OperationNode, ObserverStatus, ReleaseNoteItem, ReleaseNoteProduct, ReleaseNoteSection, ReleaseNotes, ReleaseNotesLocale, ReleaseNotesResponse, TheaterBootstrap, TheaterInfo } from "./types.js";
 
 export interface TheaterFolderListEntry {
   readonly name: string;
@@ -457,10 +457,22 @@ function assertReleaseNoteSection(value: unknown, status: number): ReleaseNoteSe
 
 function assertReleaseNoteItem(value: unknown, status: number): ReleaseNoteItem {
   const payload = value as Partial<ReleaseNoteItem>;
-  if (!payload || !Array.isArray(payload.packageTags) || !payload.packageTags.every((tag) => typeof tag === "string") || typeof payload.text !== "string") {
+  if (
+    !payload
+    || !Array.isArray(payload.packageTags)
+    || !payload.packageTags.every((tag) => typeof tag === "string")
+    || typeof payload.text !== "string"
+    || ("product" in payload && !isReleaseNoteProduct(payload.product))
+  ) {
     throw new ApiError(status, "Invalid release notes response");
   }
-  return { packageTags: payload.packageTags, text: payload.text };
+  return "product" in payload
+    ? { packageTags: payload.packageTags, text: payload.text, product: payload.product }
+    : { packageTags: payload.packageTags, text: payload.text };
+}
+
+function isReleaseNoteProduct(value: unknown): value is ReleaseNoteProduct {
+  return value === "fleet-cli" || value === "fleet-console" || value === "fleet-desktop" || value === "fleet-plugin" || value === "fleet-core";
 }
 
 function assertTheaterFolderList(value: unknown, status: number): TheaterFolderListResponse {

--- a/runtime/fleet-console/core/client/src/components/whatsnew-modal.tsx
+++ b/runtime/fleet-console/core/client/src/components/whatsnew-modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 
 import { setGlobalSettingsField, useGlobalSettingsStore } from "../global-settings-store.js";
@@ -6,6 +6,7 @@ import { requestReleaseNotes } from "../release-notes-fetch.js";
 import { closeWhatsNew, selectReleaseNote } from "../store.js";
 import type { ConsoleState, ReleaseNoteItem, ReleaseNoteSection } from "../types.js";
 import { resolveReleaseNotesLocale } from "../whatsnew-i18n.js";
+import { deriveWhatsNewOverview, deriveWhatsNewTabs, filterWhatsNewSections, isWhatsNewTabAvailable, type WhatsNewTabId } from "../whatsnew-tabs.js";
 
 interface WhatsNewModalProps {
   readonly state: ConsoleState;
@@ -28,11 +29,38 @@ const RELEASE_NOTE_PAGE_SIZE = 10;
 
 export function WhatsNewModal({ state }: WhatsNewModalProps) {
   const returnFocusRef = useRef<HTMLElement | null>(null);
+  const outsideFocusHistoryRef = useRef<HTMLElement[]>([]);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const cardRef = useRef<HTMLElement | null>(null);
+  const tabRefs = useRef(new Map<WhatsNewTabId, HTMLButtonElement>());
+  const [activeTab, setActiveTab] = useState<WhatsNewTabId>("overview");
   const globalSettings = useGlobalSettingsStore();
   // 모달 크롬은 영어 원형을 유지한다 — locale은 릴리스 노트 "본문" 언어(fetch·폴백 배지·선택기 상태)에만 관여한다.
   const locale = resolveReleaseNotesLocale(globalSettings.state?.language ?? "auto");
+  const selectedKey = state.selectedReleaseNoteKey ?? releaseNoteKey(state.releaseNotes[0]?.version ?? "", 0);
+  const selectedIndex = state.releaseNotes.findIndex((note, index) => releaseNoteKey(note.version, index) === selectedKey);
+  const selected = state.releaseNotes[selectedIndex] ?? state.releaseNotes[0];
+  const selectedValue = selected ? releaseNoteKey(selected.version, selectedIndex >= 0 ? selectedIndex : 0) : "";
+  const tabs = selected ? deriveWhatsNewTabs(selected) : [];
+
+  useEffect(() => {
+    setActiveTab("overview");
+  }, [selectedValue]);
+
+  useEffect(() => {
+    if (selected && !isWhatsNewTabAvailable(selected, activeTab)) setActiveTab("overview");
+  }, [activeTab, selected]);
+
+  useEffect(() => {
+    const rememberOutsideFocus = (event: FocusEvent) => {
+      const target = event.target instanceof HTMLElement ? event.target : null;
+      if (!target || target.closest(".whatsnew-card")) return;
+      const history = outsideFocusHistoryRef.current.filter((element) => element !== target && element.isConnected);
+      outsideFocusHistoryRef.current = [...history.slice(-4), target];
+    };
+    document.addEventListener("focusin", rememberOutsideFocus, true);
+    return () => document.removeEventListener("focusin", rememberOutsideFocus, true);
+  }, []);
 
   // What's new는 자동으로 열리므로, 다른 우선 오버레이가 떠 있거나 아직 theater bootstrap이 끝나지 않은
   // 동안에는 양보한다. 그렇지 않으면 뒤에 숨은 What's new의 window capture 리스너가 stopImmediatePropagation으로
@@ -54,6 +82,8 @@ export function WhatsNewModal({ state }: WhatsNewModalProps) {
       if (event.key === "Escape") {
         event.preventDefault();
         closeWhatsNew();
+      } else if (handleTabNavigation(event, cardRef.current, setActiveTab)) {
+        event.preventDefault();
       } else if (event.key === "Tab") {
         trapFocus(event, cardRef.current);
       }
@@ -63,17 +93,15 @@ export function WhatsNewModal({ state }: WhatsNewModalProps) {
     window.addEventListener("keydown", handleKeyDown, true);
     return () => {
       window.removeEventListener("keydown", handleKeyDown, true);
-      const target = returnFocusRef.current;
+      const target = returnFocusRef.current?.isConnected
+        ? returnFocusRef.current
+        : [...outsideFocusHistoryRef.current].reverse().find((element) => element.isConnected);
       returnFocusRef.current = null;
       target?.focus?.();
     };
   }, [state.whatsNewOpen, whatsNewSuppressed]);
 
-  if (!state.whatsNewOpen || whatsNewSuppressed || state.releaseNotes.length === 0) return null;
-  const selectedKey = state.selectedReleaseNoteKey ?? releaseNoteKey(state.releaseNotes[0]?.version ?? "", 0);
-  const selectedIndex = state.releaseNotes.findIndex((note, index) => releaseNoteKey(note.version, index) === selectedKey);
-  const selected = state.releaseNotes[selectedIndex] ?? state.releaseNotes[0]!;
-  const selectedValue = releaseNoteKey(selected.version, selectedIndex >= 0 ? selectedIndex : 0);
+  if (!state.whatsNewOpen || whatsNewSuppressed || selected === undefined) return null;
   const handleRefresh = () => {
     void requestReleaseNotes({ force: true, locale });
   };
@@ -92,6 +120,10 @@ export function WhatsNewModal({ state }: WhatsNewModalProps) {
     const targetIndex = targetPage * RELEASE_NOTE_PAGE_SIZE;
     const target = state.releaseNotes[targetIndex];
     if (target) selectReleaseNote(releaseNoteKey(target.version, targetIndex));
+  };
+  const selectTabAndFocus = (tabId: WhatsNewTabId) => {
+    setActiveTab(tabId);
+    requestAnimationFrame(() => tabRefs.current.get(tabId)?.focus());
   };
 
   return (
@@ -152,10 +184,44 @@ export function WhatsNewModal({ state }: WhatsNewModalProps) {
               {state.releaseNotesLoading ? "Refreshing" : "Refresh"}
             </button>
           </div>
+          <div className="whatsnew-tabs" role="tablist" aria-label="Release update categories">
+            {tabs.map((tab) => (
+              <button
+                key={tab.id}
+                ref={(element) => {
+                  if (element) tabRefs.current.set(tab.id, element);
+                  else tabRefs.current.delete(tab.id);
+                }}
+                id={`whatsnew-tab-${tab.id}`}
+                type="button"
+                role="tab"
+                className="whatsnew-tab"
+                data-tab-id={tab.id}
+                aria-selected={activeTab === tab.id}
+                aria-controls="whatsnew-tab-panel"
+                tabIndex={activeTab === tab.id ? 0 : -1}
+                onClick={() => setActiveTab(tab.id)}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
           {state.releaseNotesError ? <p className="whatsnew-error">Release notes could not be refreshed.</p> : null}
-          {selected.sections.map((section, index) => (
-            <ReleaseNoteSectionView key={section.heading} section={section} index={index} />
-          ))}
+          <div id="whatsnew-tab-panel" role="tabpanel" aria-labelledby={`whatsnew-tab-${activeTab}`}>
+            {activeTab === "overview" ? (
+              <div className="whatsnew-overview" aria-label="Release update overview">
+                {deriveWhatsNewOverview(selected).map((item) => (
+                  <button key={item.id} type="button" className="whatsnew-overview-card" onClick={() => selectTabAndFocus(item.id)}>
+                    <span className="whatsnew-overview-label">{item.label}</span>
+                    <span className="whatsnew-overview-count">{item.count} {item.count === 1 ? "update" : "updates"}</span>
+                    <span className="whatsnew-overview-summary">{item.summary}</span>
+                  </button>
+                ))}
+              </div>
+            ) : filterWhatsNewSections(selected, activeTab).map((section, index) => (
+              <ReleaseNoteSectionView key={section.heading} section={section} index={index} />
+            ))}
+          </div>
         </div>
         <footer className="whatsnew-footer">
           <button type="button" className="whatsnew-done" onClick={closeWhatsNew}>
@@ -216,4 +282,24 @@ function trapFocus(event: KeyboardEvent, container: HTMLElement | null): void {
     event.preventDefault();
     first.focus();
   }
+}
+
+function handleTabNavigation(
+  event: KeyboardEvent,
+  container: HTMLElement | null,
+  setActiveTab: (tab: WhatsNewTabId) => void,
+): boolean {
+  if (event.key !== "ArrowLeft" && event.key !== "ArrowRight" && event.key !== "Home" && event.key !== "End") return false;
+  const target = event.target instanceof HTMLElement ? event.target.closest<HTMLButtonElement>(".whatsnew-tab[role='tab']") : null;
+  if (!target || !container) return false;
+  const tabs = Array.from(container.querySelectorAll<HTMLButtonElement>(".whatsnew-tab[role='tab']"));
+  const currentIndex = tabs.indexOf(target);
+  if (currentIndex < 0 || tabs.length === 0) return false;
+  const nextIndex = event.key === "Home" ? 0 : event.key === "End" ? tabs.length - 1 : (currentIndex + (event.key === "ArrowRight" ? 1 : -1) + tabs.length) % tabs.length;
+  const next = tabs[nextIndex]!;
+  const tabId = next.dataset.tabId as WhatsNewTabId | undefined;
+  if (!tabId) return false;
+  setActiveTab(tabId);
+  next.focus();
+  return true;
 }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7372,6 +7372,81 @@ body[data-codex-side="true"] .command-card {
   opacity: 0.65;
 }
 
+.whatsnew-tabs {
+  display: flex;
+  gap: 6px;
+  min-width: 0;
+  overflow-x: auto;
+  padding: 2px;
+  scrollbar-color: color-mix(in oklch, var(--brass) 42%, transparent) transparent;
+}
+
+.whatsnew-tab {
+  flex: none;
+  min-height: 34px;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  padding: 0 10px;
+  background: color-mix(in oklch, var(--ink-mid) 62%, transparent);
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 760;
+  white-space: nowrap;
+}
+
+.whatsnew-tab[aria-selected="true"] {
+  border-color: color-mix(in oklch, var(--brass) 50%, transparent);
+  background: color-mix(in oklch, var(--brass) 14%, transparent);
+  color: var(--brass-bright);
+}
+
+.whatsnew-tab:hover,
+.whatsnew-tab:focus-visible {
+  border-color: color-mix(in oklch, var(--brass) 60%, transparent);
+  color: var(--ink-pearl);
+}
+
+.whatsnew-overview {
+  display: grid;
+  gap: 10px;
+}
+
+.whatsnew-overview-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 5px 12px;
+  width: 100%;
+  padding: 14px;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--ink-mid) 54%, transparent);
+  color: var(--ink-spectral);
+  text-align: left;
+}
+
+.whatsnew-overview-card:hover,
+.whatsnew-overview-card:focus-visible {
+  border-color: color-mix(in oklch, var(--brass) 50%, transparent);
+}
+
+.whatsnew-overview-label,
+.whatsnew-overview-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.whatsnew-overview-label { color: var(--brass-bright); }
+.whatsnew-overview-count { color: var(--ink-fog); }
+.whatsnew-overview-summary {
+  grid-column: 1 / -1;
+  overflow: hidden;
+  color: var(--ink-spectral);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .whatsnew-pagination {
   display: inline-flex;
   align-items: center;
@@ -7772,6 +7847,10 @@ body[data-codex-side="true"] .command-card {
 
   .whatsnew-section {
     padding: 15px;
+  }
+
+  .whatsnew-tabs {
+    margin-inline: -2px;
   }
 }
 

--- a/runtime/fleet-console/core/client/src/types.ts
+++ b/runtime/fleet-console/core/client/src/types.ts
@@ -4,6 +4,8 @@ export type ThemeId = "instrument" | "maritime" | "carbon";
 
 export type ReleaseNotesLocale = "en" | "ko";
 
+export type ReleaseNoteProduct = "fleet-cli" | "fleet-console" | "fleet-desktop" | "fleet-plugin" | "fleet-core";
+
 export type ConsoleLanguagePreference = "auto" | ReleaseNotesLocale;
 
 export type UiFontId = "manrope" | "jetbrains-mono" | "source-code-pro";
@@ -20,6 +22,7 @@ export interface ReleaseNoteSection {
 export interface ReleaseNoteItem {
   readonly packageTags: readonly string[];
   readonly text: string;
+  readonly product?: ReleaseNoteProduct;
 }
 
 export interface ReleaseNotes {

--- a/runtime/fleet-console/core/client/src/whatsnew-tabs.ts
+++ b/runtime/fleet-console/core/client/src/whatsnew-tabs.ts
@@ -1,0 +1,66 @@
+import type { ReleaseNoteProduct, ReleaseNoteSection, ReleaseNotes } from "./types.js";
+
+export type WhatsNewTabId = "overview" | "all-updates" | "other-updates" | ReleaseNoteProduct;
+
+export interface WhatsNewTab {
+  readonly id: WhatsNewTabId;
+  readonly label: string;
+}
+
+export interface WhatsNewOverviewItem {
+  readonly id: Exclude<WhatsNewTabId, "overview">;
+  readonly label: string;
+  readonly count: number;
+  readonly summary: string;
+}
+
+const PRODUCT_TABS: readonly (WhatsNewTab & { readonly id: ReleaseNoteProduct })[] = [
+  { id: "fleet-cli", label: "Fleet CLI" },
+  { id: "fleet-console", label: "Fleet Console" },
+  { id: "fleet-desktop", label: "Fleet Desktop" },
+  { id: "fleet-plugin", label: "Fleet Plugin" },
+  { id: "fleet-core", label: "Fleet Core" },
+];
+
+const OVERVIEW_TAB: WhatsNewTab = { id: "overview", label: "Overview" };
+const ALL_UPDATES_TAB: WhatsNewTab = { id: "all-updates", label: "All updates" };
+const OTHER_UPDATES_TAB: WhatsNewTab = { id: "other-updates", label: "Other updates" };
+
+export function deriveWhatsNewTabs(note: ReleaseNotes): readonly WhatsNewTab[] {
+  const hasLegacyItems = note.sections.some((section) => section.items.some((item) => item.product === undefined));
+  const productTabs = PRODUCT_TABS.filter((tab) => note.sections.some((section) => section.items.some((item) => item.product === tab.id)));
+  if (productTabs.length === 0) return [OVERVIEW_TAB, ALL_UPDATES_TAB];
+  return hasLegacyItems ? [OVERVIEW_TAB, ...productTabs, OTHER_UPDATES_TAB] : [OVERVIEW_TAB, ...productTabs];
+}
+
+export function filterWhatsNewSections(note: ReleaseNotes, tabId: WhatsNewTabId): readonly ReleaseNoteSection[] {
+  if (tabId === "overview") return [];
+  return note.sections
+    .map((section) => ({
+      ...section,
+      items: section.items.filter((item) => tabId === "all-updates" || tabId === "other-updates" ? item.product === undefined : item.product === tabId),
+    }))
+    .filter((section) => section.items.length > 0);
+}
+
+export function deriveWhatsNewOverview(note: ReleaseNotes): readonly WhatsNewOverviewItem[] {
+  const productItems = PRODUCT_TABS.flatMap((tab) => {
+    const items = note.sections.flatMap((section) => section.items.filter((item) => item.product === tab.id));
+    return items.length === 0 ? [] : [{ id: tab.id, label: tab.label, count: items.length, summary: items[0]!.text }];
+  });
+  const legacyItems = note.sections.flatMap((section) => section.items.filter((item) => item.product === undefined));
+  if (legacyItems.length === 0) return productItems;
+  return [
+    ...productItems,
+    {
+      id: productItems.length === 0 ? "all-updates" : "other-updates",
+      label: productItems.length === 0 ? "Pre-product-grouping updates" : "Other updates",
+      count: legacyItems.length,
+      summary: legacyItems[0]!.text,
+    },
+  ];
+}
+
+export function isWhatsNewTabAvailable(note: ReleaseNotes, tabId: WhatsNewTabId): boolean {
+  return deriveWhatsNewTabs(note).some((tab) => tab.id === tabId);
+}

--- a/runtime/fleet-console/core/host/release-notes/parser.ts
+++ b/runtime/fleet-console/core/host/release-notes/parser.ts
@@ -1,4 +1,4 @@
-import type { ConsoleReleaseNoteItem, ConsoleReleaseNoteSection, ConsoleReleaseNotes } from "./types.js";
+import type { ConsoleReleaseNoteItem, ConsoleReleaseNoteSection, ConsoleReleaseNotes, ReleaseNoteProduct } from "./types.js";
 
 type ReleaseNoteHeading = ConsoleReleaseNoteSection["heading"];
 
@@ -10,7 +10,7 @@ interface MutableReleaseNoteSection {
 const RELEASE_NOTE_HEADINGS: readonly ReleaseNoteHeading[] = ["Added", "Changed", "Fixed", "Removed", "Breaking Changes"];
 const VERSION_HEADER_PATTERN = /^## \[([^\]]+)\](?: - ([0-9]{4}-[0-9]{2}-[0-9]{2}))?$/;
 const SECTION_HEADER_PATTERN = /^### (Added|Changed|Fixed|Removed|Breaking Changes)$/;
-const PRODUCT_HEADER_PATTERN = /^### fleet-(cli|console|desktop|plugin|core)$/;
+const PRODUCT_HEADER_PATTERN = /^### (fleet-(?:cli|console|desktop|plugin|core))$/;
 const PRODUCT_SECTION_HEADER_PATTERN = /^#### (Added|Changed|Fixed|Removed|Breaking Changes)$/;
 const BULLET_PATTERN = /^- (.+)$/;
 const PACKAGE_TAG_PATTERN = /^\[([^\]]+)\]/;
@@ -38,29 +38,30 @@ function collectSections(lines: readonly string[]): readonly ConsoleReleaseNoteS
   const productSections = new Map<ReleaseNoteHeading, MutableReleaseNoteSection>();
   const legacyHeadings = new Set<ReleaseNoteHeading>();
   let current: MutableReleaseNoteSection | null = null;
-  let isProductContext = false;
+  let currentProduct: ReleaseNoteProduct | null = null;
   for (const line of lines) {
     const sectionMatch = SECTION_HEADER_PATTERN.exec(line);
     if (sectionMatch !== null) {
       const heading = sectionMatch[1] as ReleaseNoteHeading;
-      isProductContext = false;
+      currentProduct = null;
       current = legacyHeadings.has(heading) ? null : getSection(legacySections, heading);
       legacyHeadings.add(heading);
       continue;
     }
-    if (PRODUCT_HEADER_PATTERN.test(line)) {
-      isProductContext = true;
+    const productMatch = PRODUCT_HEADER_PATTERN.exec(line);
+    if (productMatch !== null) {
+      currentProduct = productMatch[1] as ReleaseNoteProduct;
       current = null;
       continue;
     }
     if (line.startsWith("### ")) {
-      isProductContext = false;
+      currentProduct = null;
       current = null;
       continue;
     }
     const productSectionMatch = PRODUCT_SECTION_HEADER_PATTERN.exec(line);
     if (productSectionMatch !== null) {
-      current = isProductContext ? getSection(productSections, productSectionMatch[1] as ReleaseNoteHeading) : null;
+      current = currentProduct === null ? null : getSection(productSections, productSectionMatch[1] as ReleaseNoteHeading);
       continue;
     }
     if (current === null) continue;
@@ -69,7 +70,7 @@ function collectSections(lines: readonly string[]): readonly ConsoleReleaseNoteS
       continue;
     }
     const bulletMatch = BULLET_PATTERN.exec(line);
-    if (bulletMatch !== null) current.items.push(parseReleaseNoteItem(bulletMatch[1] ?? ""));
+    if (bulletMatch !== null) current.items.push(parseReleaseNoteItem(bulletMatch[1] ?? "", currentProduct));
   }
   return RELEASE_NOTE_HEADINGS
     .map((heading) => combineSections(heading, legacySections.get(heading), productSections.get(heading)))
@@ -96,7 +97,7 @@ function getSection(
   return section;
 }
 
-function parseReleaseNoteItem(rawText: string): ConsoleReleaseNoteItem {
+function parseReleaseNoteItem(rawText: string, product: ReleaseNoteProduct | null): ConsoleReleaseNoteItem {
   const packageTags: string[] = [];
   let text = rawText.trim();
   while (true) {
@@ -105,5 +106,5 @@ function parseReleaseNoteItem(rawText: string): ConsoleReleaseNoteItem {
     packageTags.push(match[1] ?? "");
     text = text.slice(match[0].length).trimStart();
   }
-  return { packageTags, text: text.trim() };
+  return product === null ? { packageTags, text: text.trim() } : { packageTags, text: text.trim(), product };
 }

--- a/runtime/fleet-console/core/host/release-notes/service.ts
+++ b/runtime/fleet-console/core/host/release-notes/service.ts
@@ -1,5 +1,5 @@
 import { parseConsoleReleaseNotes } from "./parser.js";
-import { ConsoleReleaseNotesUnavailableError, type ConsoleReleaseNotes, type ConsoleReleaseNotesResponse, type LocalizedConsoleReleaseNotes, type ReleaseNotesLocale } from "./types.js";
+import { ConsoleReleaseNotesUnavailableError, type ConsoleReleaseNoteSection, type ConsoleReleaseNotes, type ConsoleReleaseNotesResponse, type LocalizedConsoleReleaseNotes, type ReleaseNotesLocale } from "./types.js";
 
 interface ConsoleReleaseNotesServiceDeps {
   readonly fetchImpl?: typeof fetch;
@@ -175,7 +175,7 @@ function mergeKoreanOverlay(canonical: ConsoleReleaseNotesResponse, koreanNotes:
     notes: canonical.notes.map((english) => {
       const korean = occurrences.get(english.version)?.shift();
       return korean && hasMatchingStructure(english, korean)
-        ? { ...english, sections: korean.sections, localizationFallback: false }
+        ? { ...english, sections: overlayLocalizedText(english.sections, korean.sections), localizationFallback: false }
         : withFallback(english);
     }),
   };
@@ -192,8 +192,24 @@ function hasMatchingStructure(english: ConsoleReleaseNotes, korean: ConsoleRelea
       const localizedSection = korean.sections[sectionIndex];
       return localizedSection?.heading === section.heading
         && localizedSection.items.length === section.items.length
-        && section.items.every((item, itemIndex) => sameTags(item.packageTags, localizedSection.items[itemIndex]?.packageTags));
+        && section.items.every((item, itemIndex) => {
+          const localizedItem = localizedSection.items[itemIndex];
+          return sameTags(item.packageTags, localizedItem?.packageTags) && item.product === localizedItem?.product;
+        });
     });
+}
+
+function overlayLocalizedText(
+  englishSections: readonly ConsoleReleaseNoteSection[],
+  koreanSections: readonly ConsoleReleaseNoteSection[],
+): readonly ConsoleReleaseNoteSection[] {
+  return englishSections.map((section, sectionIndex) => ({
+    ...section,
+    items: section.items.map((item, itemIndex) => ({
+      ...item,
+      text: koreanSections[sectionIndex]!.items[itemIndex]!.text,
+    })),
+  }));
 }
 
 function sameTags(left: readonly string[], right: readonly string[] | undefined): boolean {

--- a/runtime/fleet-console/core/host/release-notes/types.ts
+++ b/runtime/fleet-console/core/host/release-notes/types.ts
@@ -1,6 +1,9 @@
+export type ReleaseNoteProduct = "fleet-cli" | "fleet-console" | "fleet-desktop" | "fleet-plugin" | "fleet-core";
+
 export interface ConsoleReleaseNoteItem {
   readonly packageTags: readonly string[];
   readonly text: string;
+  readonly product?: ReleaseNoteProduct;
 }
 
 export interface ConsoleReleaseNoteSection {

--- a/runtime/fleet-console/tests/api.test.ts
+++ b/runtime/fleet-console/tests/api.test.ts
@@ -43,4 +43,25 @@ describe("client api parsing", () => {
     globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({ notes: [{ version: "1", date: null, sections: [] }], sourceRef: "main", fetchedAt: 10, stale: false }))) as typeof fetch;
     await expect(fetchReleaseNotes()).rejects.toBeInstanceOf(ApiError);
   });
+
+  it("accepts omitted or known provenance and rejects null, unknown, and non-string values", async () => {
+    const responseFor = (product: unknown, includeProduct = true) => new Response(JSON.stringify({
+      notes: [{ version: "1", date: null, sections: [{ heading: "Added", items: [{ packageTags: [], text: "Note", ...(includeProduct ? { product } : {}) }] }], localizationFallback: false }],
+      sourceRef: "main",
+      fetchedAt: 10,
+      stale: false,
+    }));
+
+    for (const product of ["fleet-cli", "fleet-console", "fleet-desktop", "fleet-plugin", "fleet-core"] as const) {
+      globalThis.fetch = vi.fn(async () => responseFor(product)) as typeof fetch;
+      await expect(fetchReleaseNotes()).resolves.toMatchObject({ notes: [{ sections: [{ items: [{ product }] }] }] });
+    }
+    globalThis.fetch = vi.fn(async () => responseFor(undefined, false)) as typeof fetch;
+    await expect(fetchReleaseNotes()).resolves.toMatchObject({ notes: [{ sections: [{ items: [{ text: "Note" }] }] }] });
+
+    for (const product of [null, "fleet-unknown", 7]) {
+      globalThis.fetch = vi.fn(async () => responseFor(product)) as typeof fetch;
+      await expect(fetchReleaseNotes()).rejects.toBeInstanceOf(ApiError);
+    }
+  });
 });

--- a/runtime/fleet-console/tests/release-notes-parser.test.ts
+++ b/runtime/fleet-console/tests/release-notes-parser.test.ts
@@ -177,6 +177,23 @@ const UNKNOWN_PRODUCT_CONTEXT_CHANGELOG = `# Changelog
 - [fleet-console] Ignore the post-product note.
 `;
 
+const MISLEADING_TAGS_CHANGELOG = `# Changelog
+
+## [0.27.0] - 2026-07-12
+
+### fleet-cli
+
+#### Added
+
+- [fleet-console] Keep the misleading tag.
+
+### fleet-unknown
+
+#### Added
+
+- [fleet-cli] Ignore the unknown product.
+`;
+
 describe("release note parser", () => {
   it("collects every non-empty version block without collapsing duplicates", () => {
     const notes = parseConsoleReleaseNotes(CHANGELOG);
@@ -201,6 +218,7 @@ describe("release note parser", () => {
       text: "Runtime notes now load lazily.",
     });
     expect(notes[1]?.sections[1]?.items[0]).toEqual({ packageTags: [], text: "Plain text fix." });
+    expect(Object.hasOwn(notes[1]?.sections[1]?.items[0] ?? {}, "product")).toBe(false);
   });
 
   it("flattens future product sections in product order without expanding the API", () => {
@@ -209,17 +227,17 @@ describe("release note parser", () => {
 
     expect(sections?.map((section) => section.heading)).toEqual(["Added", "Fixed", "Removed"]);
     expect(sections?.[0]?.items).toEqual([
-      { packageTags: ["fleet-cli"], text: "Open the embedded app." },
-      { packageTags: ["fleet-console"], text: "Add the Console surface." },
-      { packageTags: ["fleet-console"], text: "Add the Desktop shell." },
-      { packageTags: ["fleet-console"], text: "Add the plugin surface." },
-      { packageTags: ["fleet-admiral"], text: "Add the core surface." },
+      { packageTags: ["fleet-cli"], text: "Open the embedded app.", product: "fleet-cli" },
+      { packageTags: ["fleet-console"], text: "Add the Console surface.", product: "fleet-console" },
+      { packageTags: ["fleet-console"], text: "Add the Desktop shell.", product: "fleet-desktop" },
+      { packageTags: ["fleet-console"], text: "Add the plugin surface.", product: "fleet-plugin" },
+      { packageTags: ["fleet-admiral"], text: "Add the core surface.", product: "fleet-core" },
     ]);
     expect(sections?.[1]?.items).toEqual([
-      { packageTags: ["fleet-console"], text: "Fix the Console surface." },
-      { packageTags: ["fleet-console"], text: "Fix the plugin surface." },
+      { packageTags: ["fleet-console"], text: "Fix the Console surface.", product: "fleet-console" },
+      { packageTags: ["fleet-console"], text: "Fix the plugin surface.", product: "fleet-plugin" },
     ]);
-    expect(sections?.[2]?.items).toEqual([{ packageTags: ["fleet-cli"], text: "Remove the legacy mode." }]);
+    expect(sections?.[2]?.items).toEqual([{ packageTags: ["fleet-cli"], text: "Remove the legacy mode.", product: "fleet-cli" }]);
   });
 
   it("keeps only the first repeated legacy section", () => {
@@ -236,8 +254,8 @@ describe("release note parser", () => {
 
     expect(fixed?.items).toEqual([
       { packageTags: ["fleet-console"], text: "Keep the legacy fix first." },
-      { packageTags: ["fleet-cli"], text: "Keep the CLI product fix." },
-      { packageTags: ["fleet-console"], text: "Keep the Console product fix." },
+      { packageTags: ["fleet-cli"], text: "Keep the CLI product fix.", product: "fleet-cli" },
+      { packageTags: ["fleet-console"], text: "Keep the Console product fix.", product: "fleet-console" },
     ]);
   });
 
@@ -247,9 +265,17 @@ describe("release note parser", () => {
     expect(notes[0]?.sections).toEqual([{
       heading: "Added",
       items: [
-        { packageTags: ["fleet-cli"], text: "Keep the CLI product note." },
-        { packageTags: ["fleet-console"], text: "Keep the Console product note." },
+        { packageTags: ["fleet-cli"], text: "Keep the CLI product note.", product: "fleet-cli" },
+        { packageTags: ["fleet-console"], text: "Keep the Console product note.", product: "fleet-console" },
       ],
     }]);
+  });
+
+  it("stamps only recognized product headings and never infers provenance from package tags", () => {
+    const notes = parseConsoleReleaseNotes(MISLEADING_TAGS_CHANGELOG);
+
+    expect(notes[0]?.sections[0]?.items).toEqual([
+      { packageTags: ["fleet-console"], text: "Keep the misleading tag.", product: "fleet-cli" },
+    ]);
   });
 });

--- a/runtime/fleet-console/tests/release-notes-service.test.ts
+++ b/runtime/fleet-console/tests/release-notes-service.test.ts
@@ -21,6 +21,28 @@ const KOREAN_CHANGELOG = `# 변경 이력
 - [fleet-console] 런타임 노트.
 `;
 
+const PRODUCT_CHANGELOG = `# Changelog
+
+## [1.1.0] - 2026-06-21
+
+### fleet-cli
+
+#### Changed
+
+- [fleet-console] CLI product text.
+`;
+
+const KOREAN_PRODUCT_CHANGELOG = `# 변경 이력
+
+## [1.1.0] - 2026-06-21
+
+### fleet-cli
+
+#### Changed
+
+- [fleet-console] CLI 제품 텍스트.
+`;
+
 describe("release note service", () => {
   it("fetches the main changelog and returns the settled envelope", async () => {
     let now = 10;
@@ -139,6 +161,26 @@ describe("release note service", () => {
       "https://raw.githubusercontent.com/sbluemin/fleet-harness/main/CHANGELOG.md",
       "https://raw.githubusercontent.com/sbluemin/fleet-harness/main/CHANGELOG.ko.md",
     ]));
+  });
+
+  it("keeps English metadata and replaces only matching Korean text", async () => {
+    const fetchImpl = vi.fn(async (url: string) => new Response(url.endsWith("CHANGELOG.ko.md") ? KOREAN_PRODUCT_CHANGELOG : PRODUCT_CHANGELOG));
+    const service = createConsoleReleaseNotesService({ fetchImpl: fetchImpl as typeof fetch, now: () => 10 });
+
+    const result = await service.refresh({ locale: "ko" });
+    const item = result.notes[0]?.sections[0]?.items[0];
+
+    expect(item).toEqual({ packageTags: ["fleet-console"], product: "fleet-cli", text: "CLI 제품 텍스트." });
+  });
+
+  it("falls back for a Korean provenance mismatch", async () => {
+    const mismatchedKorean = KOREAN_PRODUCT_CHANGELOG.replace("### fleet-cli", "### fleet-console");
+    const fetchImpl = vi.fn(async (url: string) => new Response(url.endsWith("CHANGELOG.ko.md") ? mismatchedKorean : PRODUCT_CHANGELOG));
+    const service = createConsoleReleaseNotesService({ fetchImpl: fetchImpl as typeof fetch, now: () => 10 });
+
+    const result = await service.refresh({ locale: "ko" });
+
+    expect(result.notes[0]).toMatchObject({ localizationFallback: true, sections: [{ items: [{ product: "fleet-cli", text: "CLI product text." }] }] });
   });
 
   it("falls back per release for missing, mismatched, and duplicate Korean occurrences", async () => {

--- a/runtime/fleet-console/tests/whatsnew-tabs.test.ts
+++ b/runtime/fleet-console/tests/whatsnew-tabs.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveWhatsNewOverview, deriveWhatsNewTabs, filterWhatsNewSections, isWhatsNewTabAvailable } from "../core/client/src/whatsnew-tabs.js";
+import type { ReleaseNotes } from "../core/client/src/types.js";
+
+function note(items: ReleaseNotes["sections"][number]["items"]): ReleaseNotes {
+  return { version: "1.0.0", date: "2026-07-12", localizationFallback: false, sections: [{ heading: "Added", items }] };
+}
+
+describe("What's New tabs", () => {
+  it("derives fixed-order product tabs without reading package tags", () => {
+    const release = note([
+      { packageTags: ["fleet-cli"], text: "Console provenance", product: "fleet-console" },
+      { packageTags: ["fleet-core"], text: "CLI provenance", product: "fleet-cli" },
+      { packageTags: ["fleet-desktop"], text: "Desktop provenance", product: "fleet-desktop" },
+    ]);
+
+    expect(deriveWhatsNewTabs(release)).toEqual([
+      { id: "overview", label: "Overview" },
+      { id: "fleet-cli", label: "Fleet CLI" },
+      { id: "fleet-console", label: "Fleet Console" },
+      { id: "fleet-desktop", label: "Fleet Desktop" },
+    ]);
+    expect(filterWhatsNewSections(release, "fleet-cli")[0]?.items).toEqual([{ packageTags: ["fleet-core"], text: "CLI provenance", product: "fleet-cli" }]);
+  });
+
+  it("uses All updates for legacy and Other updates only for mixed releases", () => {
+    const legacy = note([{ packageTags: ["fleet-console"], text: "Legacy" }]);
+    const mixed = note([{ packageTags: [], text: "Legacy" }, { packageTags: [], text: "Core", product: "fleet-core" }]);
+
+    expect(deriveWhatsNewTabs(legacy).map((tab) => tab.id)).toEqual(["overview", "all-updates"]);
+    expect(filterWhatsNewSections(legacy, "all-updates")[0]?.items).toEqual(legacy.sections[0]?.items);
+    expect(deriveWhatsNewTabs(mixed).map((tab) => tab.id)).toEqual(["overview", "fleet-core", "other-updates"]);
+    expect(filterWhatsNewSections(mixed, "other-updates")[0]?.items).toEqual([{ packageTags: [], text: "Legacy" }]);
+  });
+
+  it("derives compact product, legacy, and mixed overview summaries", () => {
+    const release = note([{ packageTags: [], text: "Plugin", product: "fleet-plugin" }]);
+    const legacy = note([{ packageTags: [], text: "Earlier release" }]);
+    const mixed = note([{ packageTags: [], text: "Earlier release" }, { packageTags: [], text: "Plugin", product: "fleet-plugin" }]);
+
+    expect(deriveWhatsNewOverview(release)).toEqual([{ id: "fleet-plugin", label: "Fleet Plugin", count: 1, summary: "Plugin" }]);
+    expect(deriveWhatsNewOverview(legacy)).toEqual([{ id: "all-updates", label: "Pre-product-grouping updates", count: 1, summary: "Earlier release" }]);
+    expect(deriveWhatsNewOverview(mixed)).toEqual([
+      { id: "fleet-plugin", label: "Fleet Plugin", count: 1, summary: "Plugin" },
+      { id: "other-updates", label: "Other updates", count: 1, summary: "Earlier release" },
+    ]);
+    expect(filterWhatsNewSections(release, "overview")).toEqual([]);
+    expect(isWhatsNewTabAvailable(release, "fleet-plugin")).toBe(true);
+    expect(isWhatsNewTabAvailable(release, "fleet-core")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Add closed item-level product provenance while preserving the existing flat release-note envelope and legacy payloads.
- Organize What's New into a compact Overview plus product tabs, with conservative All updates and Other updates fallbacks for legacy and mixed releases.
- Preserve EN/KO text-only localization, version history, pagination, package chips, and accessible keyboard/focus behavior.

## Type of Change

- [x] feat — new feature or carrier capability
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- `runtime/fleet-console` host release-note parsing/service and client What's New modal

## Test Plan

- [x] `npx --yes pnpm@10.33.2 --filter @dotobokuri/fleet-console exec vitest run tests/release-notes-parser.test.ts tests/release-notes-service.test.ts tests/release-notes-fetch.test.ts tests/whatsnew-i18n.test.ts tests/api.test.ts tests/whatsnew-tabs.test.ts` — 31/31
- [x] `npx --yes pnpm@10.33.2 --filter @dotobokuri/fleet-console typecheck`
- [x] `npx --yes pnpm@10.33.2 --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] Headed product, legacy, mixed, pagination, EN/KO, keyboard/focus, and 390x844 overflow verification

## Changelog

- [x] Added one `.changelog.d/*.md` fragment.
- [x] Fragment `section:` is `Changed`.
- [x] Fragment uses an allowed `[fleet-console]` tag with adjacent EN/KO summaries.

## Notes for Reviewers

The public route, response envelope, flattened `sections[]` tree, and package-tag display contract remain unchanged. Product classification derives only from the optional `item.product` field.