### PR TITLE
feat(console): add shortcuts to toggle left/right sidebars

### DIFF
--- a/.changelog.d/fleet-console-added.md
+++ b/.changelog.d/fleet-console-added.md
@@ -1,0 +1,6 @@
+---
+section: Added
+---
+
+- [fleet-console] Add `Mod+B` and `Mod+Alt+B` shortcuts to toggle the left sidebar and right Activity Rail.
+  ko: `Mod+B`와 `Mod+Alt+B` 단축키로 좌측 사이드바와 우측 Activity Rail을 토글합니다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Fleet is a multi-LLM orchestration kit. An Admiral host coordinates specialized 
 
 ## Repository-wide operational invariants
 
+- Repository-modifying work proceeds in a dedicated `canary`-based git worktree (via the `git-worktree` skill), not the main checkout, unless the user explicitly directs otherwise; read-only or conversational tasks need no worktree.
 - Commits use English Conventional Commits.
 - Unreleased notes live in `.changelog.d/`; `CHANGELOG.md` and `CHANGELOG.ko.md` are compiler-owned outputs and must not be edited directly.
 - Bilingual changelog summaries describe user-visible behavior and preserve literal or protocol tokens across locales; exact fragment organization, syntax, and tags belong to the `.changelog.d/` instructions and changelog compiler.

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -15,9 +15,11 @@ import { usePluginRegistry } from "./plugin-registry.js";
 import { CarrierSettings } from "./pages/carrier-settings.js";
 import { GlobalSettings } from "./pages/global-settings.js";
 import { Operations } from "./pages/operations.js";
+import { toggleRailChrome } from "./rail/rail-store.js";
 import { refreshObserverStatus } from "./operations-sse.js";
 import { hydrateGroups, hydrateOperations, hydrateTheaterBootstrap, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
 import { abortReleaseNotesFetch, requestReleaseNotes } from "./release-notes-fetch.js";
+import { getSideBarState, setSideBarCollapsed } from "./sidebar/operations-side-bar-store.js";
 import { resolveReleaseNotesLocale } from "./whatsnew-i18n.js";
 
 // 서버는 부팅 시 update 체크를 fire-and-forget으로 시작하므로, 첫 방문이 SSE 연결보다
@@ -82,6 +84,18 @@ export function App() {
         event.preventDefault();
         event.stopImmediatePropagation();
         toggleOperationSearch();
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && event.code === "KeyB" && event.altKey && !event.shiftKey) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        toggleRailChrome();
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && event.code === "KeyB" && !event.altKey && !event.shiftKey) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        setSideBarCollapsed(!getSideBarState().collapsed);
       }
     };
     window.addEventListener("keydown", handleKeyDown, true);

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -26,6 +26,19 @@ import { resolveReleaseNotesLocale } from "./whatsnew-i18n.js";
 // 빠르면 GNB 배지가 누락될 수 있다. 짧은 지연 후 status를 1회만 재조회해 cold-start를 보정한다(폴링 아님).
 const UPDATE_STATUS_RECHECK_DELAY_MS = 6_000;
 
+// 사이드바/레일 토글 단축키(Mod+B / Mod+Alt+B)가 터미널·텍스트 입력 포커스를 가로채지 않도록 판별한다.
+// 예: 터미널 포커스 중 Ctrl+B는 readline backward-character나 tmux prefix로 터미널에 전달돼야 한다.
+function isTextEntryFocused(event: KeyboardEvent): boolean {
+  for (const node of [event.target, document.activeElement]) {
+    if (!(node instanceof Element)) continue;
+    if (node.closest(".xterm")) return true;
+    const tag = node.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+    if (node.closest('[contenteditable=""], [contenteditable="true"], [role="textbox"]')) return true;
+  }
+  return false;
+}
+
 export function App() {
   const state = useConsoleState();
   const location = useLocation();
@@ -86,13 +99,13 @@ export function App() {
         toggleOperationSearch();
         return;
       }
-      if ((event.metaKey || event.ctrlKey) && event.code === "KeyB" && event.altKey && !event.shiftKey) {
+      if ((event.metaKey || event.ctrlKey) && event.code === "KeyB" && event.altKey && !event.shiftKey && !isTextEntryFocused(event)) {
         event.preventDefault();
         event.stopImmediatePropagation();
         toggleRailChrome();
         return;
       }
-      if ((event.metaKey || event.ctrlKey) && event.code === "KeyB" && !event.altKey && !event.shiftKey) {
+      if ((event.metaKey || event.ctrlKey) && event.code === "KeyB" && !event.altKey && !event.shiftKey && !isTextEntryFocused(event)) {
         event.preventDefault();
         event.stopImmediatePropagation();
         setSideBarCollapsed(!getSideBarState().collapsed);

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -39,6 +39,12 @@ function isTextEntryFocused(event: KeyboardEvent): boolean {
   return false;
 }
 
+// aria-modal 대화상자(Operation Search, 디렉터리 브라우저 등)가 열려 있으면 배경 크롬(사이드바/레일)을
+// 토글하지 않는다 — 모달 경계와 포커스 트랩 의미를 지키기 위함(포커스가 모달 내 버튼으로 이동한 경우 포함).
+function isBlockingDialogOpen(): boolean {
+  return document.querySelector('[aria-modal="true"]:not([hidden])') !== null;
+}
+
 export function App() {
   const state = useConsoleState();
   const location = useLocation();
@@ -99,13 +105,13 @@ export function App() {
         toggleOperationSearch();
         return;
       }
-      if ((event.metaKey || event.ctrlKey) && event.code === "KeyB" && event.altKey && !event.shiftKey && !isTextEntryFocused(event)) {
+      if ((event.metaKey || event.ctrlKey) && event.code === "KeyB" && event.altKey && !event.shiftKey && !isTextEntryFocused(event) && !isBlockingDialogOpen()) {
         event.preventDefault();
         event.stopImmediatePropagation();
         toggleRailChrome();
         return;
       }
-      if ((event.metaKey || event.ctrlKey) && event.code === "KeyB" && !event.altKey && !event.shiftKey && !isTextEntryFocused(event)) {
+      if ((event.metaKey || event.ctrlKey) && event.code === "KeyB" && !event.altKey && !event.shiftKey && !isTextEntryFocused(event) && !isBlockingDialogOpen()) {
         event.preventDefault();
         event.stopImmediatePropagation();
         setSideBarCollapsed(!getSideBarState().collapsed);

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -13,6 +13,12 @@ import { setSideBarCollapsed, useSideBarState } from "../sidebar/operations-side
 import { hydrateOperations, toggleOperationSearch } from "../store.js";
 import { useInlineRename } from "../use-inline-rename.js";
 
+interface NavigatorWithUserAgentData extends Navigator {
+  readonly userAgentData?: {
+    readonly platform?: string;
+  };
+}
+
 interface CommandBandProps {
   readonly operationsViewVisible: boolean;
 }
@@ -22,6 +28,9 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
   const registry = usePluginRegistry();
   const sideBar = useSideBarState();
   const railChromeExpanded = useRailChromeExpanded();
+  const modLabel = resolveModLabel();
+  const sideBarShortcut = `${modLabel}${modLabel === "⌘" ? "" : "+"}B`;
+  const railShortcut = `${modLabel}${modLabel === "⌘" ? "⌥" : "+Alt+"}B`;
   const activeTheater = state.theaters.find((theater) => theater.id === state.activeTheaterId) ?? null;
   const activeOperation = state.operations.find((operation) => operation.id === state.activeOperationId) ?? null;
   const activePlugin = activeOperation ? registry.plugins.find((plugin) => plugin.id === activeOperation.pluginId) : null;
@@ -94,7 +103,7 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
     <header className={`command-band${operationsViewVisible ? " is-operations" : " is-utility"}`} style={{ "--command-band-left-width": `${sideBar.width}px` } as CSSProperties}>
       <div className={`command-band-left${operationsViewVisible && sideBar.collapsed ? " is-collapsed" : ""}`}>
         <FleetBrandHome className="command-band-brand" />
-        {operationsViewVisible ? <button type="button" className="command-band-button command-band-sidebar-toggle" onClick={() => setSideBarCollapsed(!sideBar.collapsed)} aria-label={sideBar.collapsed ? "Expand sidebar" : "Collapse sidebar"} title={sideBar.collapsed ? "Expand sidebar" : "Collapse sidebar"}>
+        {operationsViewVisible ? <button type="button" className="command-band-button command-band-sidebar-toggle" onClick={() => setSideBarCollapsed(!sideBar.collapsed)} aria-label={`${sideBar.collapsed ? "Expand sidebar" : "Collapse sidebar"} (${sideBarShortcut})`} title={`${sideBar.collapsed ? "Expand sidebar" : "Collapse sidebar"} (${sideBarShortcut})`}>
           <PanelToggleIcon side="left" />
         </button> : null}
         <button type="button" className="command-band-button command-band-search" onClick={toggleOperationSearch} aria-label="Search sessions" title="Search sessions (⌘K)">
@@ -116,12 +125,18 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
         </div></> : null}
       </div>
       <div className="command-band-right">
-        {operationsViewVisible ? <button type="button" className="command-band-button command-band-rail-toggle" onClick={toggleRailChrome} aria-label={railChromeExpanded ? "Collapse Activity Rail" : "Expand Activity Rail"} title={railChromeExpanded ? "Collapse Activity Rail" : "Expand Activity Rail"}>
+        {operationsViewVisible ? <button type="button" className="command-band-button command-band-rail-toggle" onClick={toggleRailChrome} aria-label={`${railChromeExpanded ? "Collapse Activity Rail" : "Expand Activity Rail"} (${railShortcut})`} title={`${railChromeExpanded ? "Collapse Activity Rail" : "Expand Activity Rail"} (${railShortcut})`}>
           <PanelToggleIcon side="right" />
         </button> : null}
       </div>
     </header>
   );
+}
+
+function resolveModLabel(): string {
+  const userAgentDataPlatform = (navigator as NavigatorWithUserAgentData).userAgentData?.platform;
+  const platform = userAgentDataPlatform ?? navigator.platform;
+  return /mac|iphone|ipad|ipod/i.test(platform) ? "⌘" : "Ctrl";
 }
 
 function SearchIcon() {

--- a/runtime/fleet-console/core/client/src/shortcuts-catalog.ts
+++ b/runtime/fleet-console/core/client/src/shortcuts-catalog.ts
@@ -13,6 +13,8 @@ export const SHORTCUT_GROUPS: readonly ShortcutGroup[] = [
     title: "Console",
     entries: [
       { combos: [["Mod", "K"]], description: "Search Operations across Theaters" },
+      { combos: [["Mod", "B"]], description: "Toggle the left sidebar" },
+      { combos: [["Mod", "Alt", "B"]], description: "Toggle the right activity rail" },
       { combos: [["Esc"]], description: "Close the open overlay or menu" },
     ],
   },


### PR DESCRIPTION
## Summary
- 좌측 사이드바 토글 `Mod+B`(⌘B / Ctrl+B), 우측 Activity Rail 토글 `Mod+Alt+B`(⌘⌥B / Ctrl+Alt+B) 전역 단축키 추가. 기존 `Mod+K` 핸들러의 modal 가드·capture-phase·preventDefault 구조를 그대로 미러링하고 `event.code === "KeyB"`로 키보드 레이아웃·macOS Option 합성문자 안전을 보장(Alt 분기 우선 검사로 좌/우 분별).
- Shortcuts 모달 카탈로그에 두 항목 등록 + Command Band 토글 버튼 툴팁에 플랫폼별(⌘/Ctrl) 힌트 표기.
- 루트 `AGENTS.md`에 운영 불변식 1줄 추가: 명시적 지시가 없으면 저장소 수정 작업은 `canary` 기반 git 워크트리에서 진행(read-only/대화형 작업 제외).

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` (host + core/client) green
- [x] 헤디드 e2e (agent-browser): `⌘B`/`Ctrl+B` 좌측 토글, `⌘⌥B`/`Ctrl+Alt+B` 우측 토글, Alt 분별(좌/우 상호 무간섭), meta·ctrl 양 경로, Shortcuts 모달 뒤 단축키 누출 차단, 페이지 에러 0 — 전항목 PASS
- [x] `node scripts/compile-changelog-fragments.mjs --check` OK

## Changelog
- [x] `.changelog.d/fleet-console-added.md` (Added, `[fleet-console]`)