### PR TITLE
fix(console): open-panel Formation keeps maximize-docked panels docked

### DIFF
--- a/.changelog.d/pr-239.md
+++ b/.changelog.d/pr-239.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Changed
+- [fleet-console] Formation view's open-panel segment now leaves minimized and maximize-docked panels in the dock, arranging only the currently open panels; the include-minimized segment still restores every panel first.
+  ko: Formation view의 열린 패널만 세그먼트는 이제 최소화·최대화로 도크에 내려간 패널을 그대로 두고 현재 열린 패널만 정렬하며, 최소화 패널 포함 세그먼트는 여전히 모든 패널을 먼저 복원합니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
@@ -395,8 +395,8 @@ export function toggleFormationView(options?: { readonly restoreMinimized?: bool
     clearFormationView();
     return;
   }
-  if (options?.restoreMinimized === true || maximizedOperationId !== null) {
-    // Maximize-created minimization is indistinguishable from manual minimization, so entering from maximize must restore all panels.
+  if (options?.restoreMinimized === true) {
+    // Only the include-minimized entry restores docked panels. Open-panel entry keeps them minimized — including the panels a maximize sent to the dock, which stay docked until an explicit restore.
     setState({ minimized: [] });
   }
   clearMaximizedOperationId();

--- a/runtime/fleet-console/tests/canvas-store.test.ts
+++ b/runtime/fleet-console/tests/canvas-store.test.ts
@@ -81,13 +81,26 @@ describe("canvas store", () => {
     expect(getSnapshot().minimized).toEqual(["op-a"]);
   });
 
-  it("restores every minimized Operation when entering Formation from maximize", () => {
+  it("keeps maximize-docked Operations minimized when entering open-panel Formation", () => {
     setOperationGeometry("op-a", { ...GEOMETRY });
     setOperationGeometry("op-b", { ...GEOMETRY });
     setOperationGeometry("op-c", { ...GEOMETRY });
     setMaximizedOperationId("op-b");
 
     toggleFormationView();
+
+    expect(getFormationView()).toBe(true);
+    expect(getMaximizedOperationId()).toBeNull();
+    expect(getSnapshot().minimized).toEqual(["op-a", "op-c"]);
+  });
+
+  it("restores maximize-docked Operations when entering Formation with restoreMinimized", () => {
+    setOperationGeometry("op-a", { ...GEOMETRY });
+    setOperationGeometry("op-b", { ...GEOMETRY });
+    setOperationGeometry("op-c", { ...GEOMETRY });
+    setMaximizedOperationId("op-b");
+
+    toggleFormationView({ restoreMinimized: true });
 
     expect(getFormationView()).toBe(true);
     expect(getMaximizedOperationId()).toBeNull();


### PR DESCRIPTION
## Summary
- Fix a regression from the two-segment Formation toggle split (#233): opening the **open-panel** Formation view (Alt+F) while a panel was maximized cleared every minimized panel, so all panels reappeared in the grid instead of only the currently open ones.
- The minimized-clearing is now restricted to the **include-minimized** entry (Alt+Shift+F). Open-panel entry un-maximizes without touching the dock, so maximize-docked and manually minimized panels stay docked.
- Root cause: `toggleFormationView()` cleared `minimized` whenever `maximizedOperationId !== null`. The docked/open distinction lives entirely in `canvas-store`, and the grid already renders only non-minimized operations (`canvas.tsx` `formationOperationIds` filter).

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 728 passed / 22 skipped (canvas-store regression test reworked + symmetric include-minimized test added)
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — exit 0
- [x] `pnpm --filter @dotobokuri/fleet-console build` — exit 0
- [x] Store-logic regression verified at the authoritative surface (canvas-store unit test asserts docked panels stay docked on open-panel entry, and are restored on include-minimized entry)

## Changelog
- [x] `.changelog.d/pr-239.md` — fleet-console / Changed, bilingual summary, validated with `node scripts/compile-changelog-fragments.mjs --check`.