### PR TITLE
fix(carriers): retain job information for six hours

### DIFF
--- a/.changelog.d/pr-240.md
+++ b/.changelog.d/pr-240.md
@@ -1,0 +1,4 @@
+### fleet-core
+#### Changed
+- [fleet-carriers] Retain finalized carrier job information for 6 hours.
+  ko: 완료된 캐리어 작업 정보를 6시간 동안 보존합니다.

--- a/packages/fleet-carriers/src/dispatch/tool-spec.ts
+++ b/packages/fleet-carriers/src/dispatch/tool-spec.ts
@@ -146,7 +146,7 @@ export function buildCarrierDispatchToolSpec(registry: CarrierRegistry, deps: Ca
       `When composing a request, provide only background, context, objective, and constraints.` +
         ` Do NOT prescribe implementation details or step-by-step instructions — trust the carrier's own reasoning.` +
         ` Launch response schema is { job_id, accepted, error? } and never includes synchronous result content.` +
-        ` Full output is available only through carrier_jobs(action:"result", format:"full"), is finalized-only, and remains read-many for 3h.`,
+        ` Full output is available only through carrier_jobs(action:"result", format:"full"), is finalized-only, and remains read-many for 6h.`,
       `Do not poll, wait-check, or call carrier_jobs merely to see whether the job is done.` +
         ` Continue independent work if available; otherwise stop tool use and wait passively for the [carrier:result] follow-up push.`,
       `Some carriers require structured request blocks (e.g., <objective>, <context>).` +

--- a/packages/fleet-carriers/src/jobs/dispatch.ts
+++ b/packages/fleet-carriers/src/jobs/dispatch.ts
@@ -65,18 +65,18 @@ export const CARRIER_JOBS_DOCTRINE = {
     `carrier_jobs — Lookup/control detached carrier jobs: status, result, cancel, list.`,
   whenToUse: [
     `Use carrier_jobs when a follow-up push is missing, explicit job inspection is required, or the Admiral needs completion metadata, full archived output, cancellation, or a job list.`,
-    `Use action:"result" only after the job is finalized; full results remain repeatable for 3 hours.`,
+    `Use action:"result" only after the job is finalized; full results remain repeatable for 6 hours.`,
   ],
   whenNotToUse: [
     `Do not use carrier_jobs to delegate new work; use carrier_dispatch.`,
-    `Do not request results for active jobs. Results are finalized-only, read-many for 3 hours, and expire by TTL.`,
+    `Do not request results for active jobs. Results are finalized-only, read-many for 6 hours, and expire by TTL.`,
     `Do not poll, wait-check, or call carrier_jobs merely to see whether a launched job is done; terminal results arrive through the [carrier:result] follow-up push.`,
   ],
   usageGuidelines: [
     `carrier_jobs has exactly four actions: status, result, cancel, list.`,
     `After launch, continue independent work if available; otherwise stop tool use and wait passively for the follow-up push instead of issuing status probes.`,
     `Treat carrier_jobs as the fallback channel for missing pushes or explicit lookups, not as a polling loop.`,
-    `Results are finalized-only, read-many for 3h in process memory.`,
+    `Results are finalized-only, read-many for 6h in process memory.`,
     `Task Force dispatch full responses return results: { [cliType]: "..." }; non-Task-Force full responses still return full_result.`,
     `carrier_jobs reads the process-memory summary cache and JobStreamArchive only. It never reads the Agent Panel stream-store.`,
   ],

--- a/packages/fleet-carriers/src/jobs/types.ts
+++ b/packages/fleet-carriers/src/jobs/types.ts
@@ -101,7 +101,7 @@ export interface JobSummaryOptions {
   readonly workspaceChanges?: WorkspaceChangeManifest;
 }
 
-export const CARRIER_JOB_TTL_MS = 3 * 60 * 60 * 1000;
+export const CARRIER_JOB_TTL_MS = 6 * 60 * 60 * 1000;
 export const CARRIER_JOBS_FULL_RESULT_BYTE_CAP = 20_000;
 export const CARRIER_JOBS_PER_SUBOP_BYTE_CAP = 20_000;
 export const CARRIER_JOBS_GLOBAL_BYTE_CAP = 60_000;

--- a/packages/fleet-carriers/tests/carrier-job-shared.test.ts
+++ b/packages/fleet-carriers/tests/carrier-job-shared.test.ts
@@ -278,7 +278,7 @@ describe("job stream archive", () => {
     expect(archive?.blocks[0]?.text).toBe("[REDACTED:generic_secret]");
   });
 
-  it("expires archives after the 3h TTL", () => {
+  it("expires archives after the 6h TTL", () => {
     createJobArchive("sortie:1", 1000);
     expect(hasJobArchive("sortie:1", 1000 + CARRIER_JOB_TTL_MS - 1)).toBe(true);
     expect(hasJobArchive("sortie:1", 1000 + CARRIER_JOB_TTL_MS)).toBe(false);
@@ -454,7 +454,7 @@ describe("summary LRU cache", () => {
     expect(getJobSummary("sortie:1", 1002)?.summary).toBe("done");
   });
 
-  it("expires summaries after the 3h TTL", () => {
+  it("expires summaries after the 6h TTL", () => {
     putJobSummary(buildSummary("sortie:1", 1000), 1000);
     expect(getJobSummary("sortie:1", 1000 + CARRIER_JOB_TTL_MS - 1)).not.toBeNull();
     expect(getJobSummary("sortie:1", 1000 + CARRIER_JOB_TTL_MS)).toBeNull();


### PR DESCRIPTION
## Summary
- Extend finalized carrier job archive and summary retention from 3 hours to 6 hours.
- Keep `carrier_jobs` doctrine and TTL boundary test descriptions aligned with the runtime constant.

## Test Plan
- [x] `git diff --check`
- [x] Verify `CARRIER_JOB_TTL_MS` evaluates to `21600000` with Node type stripping
- [x] Verify all model-facing TTL doctrine states 6 hours with no stale 3-hour wording
- [ ] Run fleet-carriers Vitest and typecheck (unavailable: this fresh worktree has no `pnpm` or installed dependencies)
- [x] Add `.changelog.d/pr-240.md` with bilingual summaries
- [x] Validate changelog fragments with `node scripts/compile-changelog-fragments.mjs --check`