### PR TITLE
fix(diff): align history graph nodes with their commit rows

### DIFF
--- a/.changelog.d/pr-241.md
+++ b/.changelog.d/pr-241.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] Align the Diff History commit graph nodes with their commit rows so each graph marker no longer sits half a row below the commit it belongs to.
+  ko: Diff History 커밋 그래프 노드를 해당 커밋 행에 정렬해 각 그래프 마커가 더 이상 커밋보다 반 행 아래로 어긋나지 않게 합니다.

--- a/runtime/fleet-plugins/diff/client/diff.css
+++ b/runtime/fleet-plugins/diff/client/diff.css
@@ -911,7 +911,10 @@
 .history-root > .history-divider { grid-column: 2; grid-row: 1; touch-action: none; }
 .history-divider { touch-action: none; }
 .history-commit-row { grid-template-columns: auto minmax(96px, 1fr) 7ch auto auto; gap: 0 7px; }
-.history-graph-gutter { grid-column: 1; }
+/* gutter는 DOM 최후미이나 col 1에 놓이므로 grid-row를 고정하지 않으면 auto-placement가 커서를 되돌리지 못해
+   유령 2행 트랙(0px 28px)을 만든다 → 텍스트는 0px 트랙 상단, 노드는 28px 트랙 중앙으로 반 행 어긋난다.
+   grid-row: 1로 전 셀을 단일 28px 트랙에 묶어 노드와 커밋 텍스트를 정렬한다. */
+.history-graph-gutter { grid-column: 1; grid-row: 1; }
 .history-commit-subject { grid-column: 2; min-width: 96px; }
 .history-commit-sha { grid-column: 3; }
 .history-commit-time { grid-column: 4; }


### PR DESCRIPTION
## Summary
- diff History 패널에서 커밋 그래프 노드가 해당 커밋 행보다 **반 행 아래**로 어긋나던 결함을 수정합니다.
- 원인: `.history-graph-gutter`는 DOM 최후미이나 `grid-column: 1`에 놓여, 명시적 `grid-row`가 없으면 CSS 그리드 auto-placement가 커서를 되돌리지 못해 **유령 2행 트랙**을 만듭니다. 행의 `grid-template-rows`가 `0px 28px`로 해석되어 커밋 텍스트는 0px 트랙(상단 정렬)에, 그래프 노드는 28px 트랙(중앙)에 놓이며 14px 어긋났습니다.
- 수정: gutter를 `grid-row: 1`로 고정해 전 셀을 단일 28px 트랙에 묶어 노드와 커밋 텍스트를 정렬합니다.

## Test Plan
- [x] console-e2e headed 실측: `gridTemplateRows`가 단일 `28px`로 병합, `node_minus_subj == 0`(전 행) — 수정 전 `0px 28px`/`+14px`
- [x] 스크린샷 대조: 수정 후 모든 그래프 노드(멀티레인 브랜치 포함)가 커밋 행 중앙에 정렬
- [x] `pnpm --filter @fleet-plugins/diff typecheck` — 통과
- [x] `pnpm --filter @fleet-plugins/diff test` — 107/107 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 성공

## Changelog
- [x] `.changelog.d/pr-241.md` (fleet-plugin / Fixed, `[fleet-console]`) — 이중언어 요약, `compile-changelog-fragments.mjs --check` 통과