### PR TITLE
fix(console): preserve What's New controls with long content

### DIFF
--- a/.changelog.d/pr-242.md
+++ b/.changelog.d/pr-242.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Keep What's New controls visible when release notes overflow the modal body.
+  ko: 릴리스 노트가 모달 본문을 넘쳐도 What's New 제어 버튼이 계속 보이도록 합니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7283,12 +7283,17 @@ body[data-codex-side="true"] .command-card {
 }
 
 .whatsnew-body {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 18px;
   min-height: 0;
   padding: 22px clamp(22px, 4vw, 36px);
   overflow: auto;
   scrollbar-color: color-mix(in oklch, var(--brass) 42%, transparent) transparent;
+}
+
+.whatsnew-body > * {
+  flex: none;
 }
 
 .whatsnew-version-selector {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -144,6 +144,21 @@ describe("Instrument core design contract", () => {
     expect(layout).not.toContain("--command-band-carrier");
   });
 
+  it("keeps long What's new content inside the scrollable body without shrinking controls", () => {
+    const components = source("styles/components.css");
+    const cardBlock = components.match(/\.whatsnew-card \{[^}]*\}/)?.[0] ?? "";
+    const bodyBlock = components.match(/\.whatsnew-body \{[^}]*\}/)?.[0] ?? "";
+    const bodyChildrenBlock = components.match(/\.whatsnew-body > \* \{[^}]*\}/)?.[0] ?? "";
+
+    expect(cardBlock).toContain("grid-template-rows: auto minmax(0, 1fr) auto;");
+    expect(cardBlock).toContain("overflow: hidden;");
+    expect(bodyBlock).toContain("display: flex;");
+    expect(bodyBlock).toContain("flex-direction: column;");
+    expect(bodyBlock).toContain("min-height: 0;");
+    expect(bodyBlock).toContain("overflow: auto;");
+    expect(bodyChildrenBlock).toContain("flex: none;");
+  });
+
   it("locks Command Band coordinate invariance to tint-only state changes", () => {
     const layout = source("styles/layout.css");
     const components = source("styles/components.css");


### PR DESCRIPTION
## Summary
- Prevent long What's New release notes from shrinking the version controls and product tabs.
- Keep the modal footer fixed while the release-note body remains independently scrollable.
- Add a design-contract regression test for the overflow layout.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Headed desktop and 390x844 mobile overflow verification
- [x] Added bilingual `.changelog.d/pr-242.md`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
