### PR TITLE
feat(console): add minimize button to left sidebar operation chips

### DIFF
--- a/.changelog.d/pr-243.md
+++ b/.changelog.d/pr-243.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Added
+- [fleet-console] Add a minimize button to left sidebar operation chips so a panel can be minimized directly from the sidebar; it appears on hover to the left of the close button, and is hidden on already-minimized chips and on inactive-Theater preview chips.
+  ko: 좌측 사이드바 operation 칩에 최소화 버튼을 추가하여 사이드바에서 바로 패널을 최소화할 수 있게 합니다. 버튼은 hover 시 close 버튼 왼쪽에 나타나며, 이미 최소화된 칩과 비활성 Theater의 preview 칩에는 표시하지 않습니다.

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -5,7 +5,7 @@ import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 import type { ClientApiCapability, FleetClientPlugin } from "@fleet-console/sdk/plugin";
 
 import { addTheater, createGroup, deleteGroup, fetchGroups, fetchOperations, forgetTheater, issueTheaterFolderGrant, patchOperation, renameOperation, updateGroup, ApiError } from "../api.js";
-import { animateViewportTo, claimTopZIndex, clearMaximizedOperationId, ensureDefaultGeometry, focusOperation as focusCanvasOperation, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, loadForTheater, pruneOperations, restoreOperation, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
+import { animateViewportTo, claimTopZIndex, clearMaximizedOperationId, ensureDefaultGeometry, focusOperation as focusCanvasOperation, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, loadForTheater, minimizeOperation, pruneOperations, restoreOperation, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
 import { screenToCanvas, type CanvasPoint } from "../canvas/coordinates.js";
 import { OperationsCanvas } from "../canvas/canvas.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
@@ -191,6 +191,11 @@ export function Operations({ state }: OperationsProps) {
     if (viewportSize) focusCanvasOperation(operationId, viewportSize);
   }, []);
 
+  const handleMinimize = useCallback((operationId: string) => {
+    if (stateRef.current.activeOperationId === operationId) setActiveOperation(null);
+    minimizeOperation(operationId);
+  }, []);
+
   const handleSetAccent = useCallback((operationId: string, accentKey: string | null) => {
     void patchOperation(operationId, { accent: accentKey })
       .then(() => fetchOperations(null))
@@ -320,6 +325,7 @@ export function Operations({ state }: OperationsProps) {
         onLaunchKind={handleSideBarLaunchKind}
         onResetView={handleResetView}
         onClose={handleClose}
+        onMinimize={handleMinimize}
         onFocus={handleFocus}
         onSetAccent={handleSetAccent}
         onRename={handleRename}

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -170,6 +170,9 @@ export function OperationsSideBarChip({
           onPointerDown={stopClosePointer}
           onClick={(event) => {
             event.stopPropagation();
+            // 다른 칩 액션(focus·rename·accent)과 동일하게, 최소화 전에 armed close를 먼저 해제한다 —
+            // 그러지 않으면 최소화 후에도 "Close?" armed 상태가 타임아웃까지 남아 단발 클릭 close 위험이 생긴다.
+            onDisarmClose();
             onMinimize(operation.id);
           }}
           aria-label={`Minimize operation ${title}`}

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -28,6 +28,7 @@ interface SideBarChipProps {
   readonly onArmClose: (operationId: string) => void;
   readonly onDisarmClose: () => void;
   readonly onClose: (operationId: string) => void;
+  readonly onMinimize: (operationId: string) => void;
   readonly onFocus: (operationId: string) => void;
   readonly onKeyboardMove: (operationId: string, direction: -1 | 1) => void;
   readonly onPointerDragStart: (event: ReactPointerEvent<HTMLLIElement>, operationId: string) => void;
@@ -47,6 +48,7 @@ export function OperationsSideBarChip({
   onArmClose,
   onDisarmClose,
   onClose,
+  onMinimize,
   onFocus,
   onKeyboardMove,
   onPointerDragStart,
@@ -161,6 +163,21 @@ export function OperationsSideBarChip({
         aria-label={chipStatusLabel(status)}
         title={chipStatusLabel(status)}
       />
+      {!preview && !minimized ? (
+        <button
+          type="button"
+          className="side-bar-chip-minimize"
+          onPointerDown={stopClosePointer}
+          onClick={(event) => {
+            event.stopPropagation();
+            onMinimize(operation.id);
+          }}
+          aria-label={`Minimize operation ${title}`}
+          title="Minimize operation"
+        >
+          <SideBarMinimizeIcon />
+        </button>
+      ) : null}
       {preview ? null : (
         <button
           type="button"
@@ -203,6 +220,14 @@ function SideBarCloseIcon() {
         strokeWidth="1.35"
         strokeLinecap="round"
       />
+    </svg>
+  );
+}
+
+function SideBarMinimizeIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M3.5 11.5h9" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
     </svg>
   );
 }

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -36,6 +36,7 @@ interface OperationsSideBarProps {
   readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind) => void;
   readonly onResetView: () => void;
   readonly onClose: (operationId: string) => void;
+  readonly onMinimize: (operationId: string) => void;
   readonly onFocus: (operationId: string) => void;
   readonly onSetAccent: (operationId: string, accentKey: string | null) => void;
   readonly onRename: (operationId: string, title: string) => void;
@@ -156,6 +157,7 @@ export function OperationsSideBar({
   onLaunchKind,
   onResetView,
   onClose,
+  onMinimize,
   onFocus,
   onSetAccent,
   onRename,
@@ -654,6 +656,7 @@ export function OperationsSideBar({
                         onArmClose={armClose}
                         onDisarmClose={disarmClose}
                         onClose={onClose}
+                        onMinimize={onMinimize}
                         onFocus={onFocus}
                         onKeyboardMove={keyboardMove}
                         onPointerDragStart={beginPointerDrag}
@@ -965,6 +968,7 @@ function TheaterPeekSection({
                       onArmClose={() => {}}
                       onDisarmClose={() => {}}
                       onClose={() => {}}
+                      onMinimize={() => {}}
                       onFocus={onFocus}
                       onKeyboardMove={() => {}}
                       onPointerDragStart={() => {}}

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3254,15 +3254,39 @@
     color var(--duration-fast) var(--ease-spring);
 }
 
+.side-bar-chip-minimize {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  cursor: pointer;
+  color: var(--ink-fog);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    background var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring),
+    color var(--duration-fast) var(--ease-spring);
+}
+
 .side-bar-chip:hover .side-bar-chip-close,
 .side-bar-chip:focus-within .side-bar-chip-close,
+.side-bar-chip:hover .side-bar-chip-minimize,
+.side-bar-chip:focus-within .side-bar-chip-minimize,
 .side-bar-chip-close.is-armed {
   opacity: 1;
   pointer-events: auto;
 }
 
 .side-bar-chip-close:hover,
-.side-bar-chip-close:focus-visible {
+.side-bar-chip-close:focus-visible,
+.side-bar-chip-minimize:hover,
+.side-bar-chip-minimize:focus-visible {
   background: color-mix(in oklch, var(--ink-spectral) 10%, transparent);
   border-color: color-mix(in oklch, var(--ink-fog) 30%, transparent);
   color: var(--ink-spectral);
@@ -3270,6 +3294,11 @@
 }
 
 .side-bar-chip-close svg {
+  width: 12px;
+  height: 12px;
+}
+
+.side-bar-chip-minimize svg {
   width: 12px;
   height: 12px;
 }

--- a/runtime/fleet-console/tests/operations-side-bar-chip-status.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-chip-status.test.ts
@@ -63,6 +63,7 @@ function renderChip(status: OperationActivity | undefined): HTMLSpanElement {
     onArmClose: () => {},
     onDisarmClose: () => {},
     onClose: () => {},
+    onMinimize: () => {},
     onFocus: () => {},
     onKeyboardMove: () => {},
     onPointerDragStart: () => {},


### PR DESCRIPTION
## Summary
- 좌측 사이드바 operation 칩에 hover 시 노출되는 **최소화 전용 버튼**을 close 버튼 왼쪽에 추가했습니다. 클릭하면 해당 패널이 최소화됩니다(활성 패널이었다면 활성 해제).
- 복원은 기존 칩 본체 클릭(restore+focus) 동작을 그대로 유지합니다. 버튼은 이미 최소화된 칩과 비활성 Theater의 preview(peek) 칩에는 렌더하지 않습니다.
- 최소화/복원 상태는 기존 canvas-store(`minimizeOperation`/`restoreOperation`)를 재사용하며, close 버튼과 동일한 hover-reveal·디자인 토큰을 따릅니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — green
- [x] `vitest run tests/operations-side-bar-chip-status.test.ts` — 5/5 pass
- [x] `pnpm --filter @dotobokuri/fleet-console build` — green
- [x] headed console-e2e (Sentinel): 수용 기준 6/6 PASS — hover 노출·최소화+활성해제·최소화칩 버튼부재·칩클릭 복원회귀無·버블링방지·preview칩 버튼부재
- [ ] Changelog fragment: PR 번호 할당 후 추가 예정

## Changelog
- [ ] `.changelog.d/pr-<number>.md` (PR 번호 할당 대기)