### PR TITLE
fix(desktop): hydrate login shell path for sidecar

### DIFF
--- a/.changelog.d/pr-245.md
+++ b/.changelog.d/pr-245.md
@@ -1,4 +1,4 @@
 ### fleet-desktop
 #### Fixed
-- [fleet-desktop] Restore Agent CLI discovery from the macOS login-shell PATH.
+- [fleet-console] Restore Agent CLI discovery from the macOS login-shell PATH.
   ko: macOS 로그인 셸 PATH에서 Agent CLI 검색을 복원합니다.

--- a/.changelog.d/pr-245.md
+++ b/.changelog.d/pr-245.md
@@ -1,0 +1,4 @@
+### fleet-desktop
+#### Fixed
+- [fleet-desktop] Restore Agent CLI discovery from the macOS login-shell PATH.
+  ko: macOS 로그인 셸 PATH에서 Agent CLI 검색을 복원합니다.

--- a/runtime/fleet-desktop/src/environment.ts
+++ b/runtime/fleet-desktop/src/environment.ts
@@ -136,11 +136,12 @@ export function sanitizeEnvironment(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
 }
 
 function createPackagedServiceEnvironment(sanitized: NodeJS.ProcessEnv, loginShellPath: string | undefined, platform: NodeJS.Platform): NodeJS.ProcessEnv {
-  if (platform !== "darwin") return prependPathEntries(sanitized, desktopExecutableSearchPaths(os.homedir(), sanitized, platform), { platform });
+  const fallbackEnvironment = prependPathEntries(sanitized, desktopExecutableSearchPaths(os.homedir(), sanitized, platform), { platform });
+  if (platform !== "darwin" || loginShellPath === undefined) return fallbackEnvironment;
   // 로그인 셸, Finder가 물려준 PATH, 기존의 결정적 폴백 순서로 한 번만 정규화한다.
   // 셸에서 온 값은 오직 PATH 출력이며, 다른 셸 환경 변수는 sidecar로 전달하지 않는다.
   const inheritedAndFallbackPath = [sanitized.PATH, ...desktopExecutableSearchPaths(os.homedir(), sanitized, platform)].filter((value): value is string => value !== undefined).join(path.delimiter);
-  return prependPathEntries({ ...sanitized, PATH: inheritedAndFallbackPath }, loginShellPath?.split(path.delimiter) ?? [], { platform });
+  return prependPathEntries({ ...sanitized, PATH: inheritedAndFallbackPath }, loginShellPath.split(path.delimiter), { platform });
 }
 
 function isSafeLoginShellPath(value: string): boolean {

--- a/runtime/fleet-desktop/src/environment.ts
+++ b/runtime/fleet-desktop/src/environment.ts
@@ -1,7 +1,9 @@
+import { execFile } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 
 import { prependPathEntries } from "@dotobokuri/core-process";
 import { DESKTOP_DEVELOPMENT_ENV, DESKTOP_OWNER_ID_ENV, DESKTOP_OWNER_KIND_ENV, DESKTOP_PROTOCOL_VERSION, DESKTOP_PROTOCOL_VERSION_ENV, DESKTOP_RESOURCE_ROOT_ENV, resolveCanonicalLocalConsolePaths, resolveCanonicalStableConsolePaths } from "@fleet-console/desktop-protocol";
@@ -13,6 +15,15 @@ export interface DesktopEnvironment {
   readonly serviceEnv: NodeJS.ProcessEnv;
 }
 
+export interface LoginShellPathProbe {
+  readonly run: (file: string, arguments_: readonly string[], options: { readonly env: NodeJS.ProcessEnv; readonly maxBuffer: number; readonly timeout: number; readonly windowsHide: boolean }) => Promise<{ readonly stdout: string }>;
+}
+
+export interface HydratedDesktopEnvironmentOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly loginShellPathProbe?: LoginShellPathProbe;
+}
+
 const DESKTOP_CONTROL_ENV_KEYS = new Set([
   DESKTOP_DEVELOPMENT_ENV,
   DESKTOP_OWNER_ID_ENV,
@@ -22,14 +33,24 @@ const DESKTOP_CONTROL_ENV_KEYS = new Set([
   "FLEET_CONSOLE_DESKTOP_VERSION",
   "FLEET_CONSOLE_DIR",
 ]);
+const LOGIN_SHELL_ARGUMENTS = ["-ilc", "printf '%s' \"$PATH\""] as const;
+const LOGIN_SHELL_PATH_TIMEOUT_MS = 1_000;
+const LOGIN_SHELL_PATH_MAX_BUFFER = 8 * 1_024;
+const INVALID_PATH_OUTPUT = /[\u0000-\u001f\u007f]/;
+const execFileAsync = promisify(execFile);
+const defaultLoginShellPathProbe: LoginShellPathProbe = {
+  run: async (file, arguments_, options) => {
+    const result = await execFileAsync(file, arguments_, options);
+    return { stdout: result.stdout };
+  },
+};
 
 export function resolveDesktopUserDataDirectory(userDataDir: string, resourceRoot: string, isPackaged: boolean): string {
   return isPackaged ? userDataDir : path.join(resolveCanonicalLocalConsolePaths({ packageRoot: resourceRoot }).dir, "desktop");
 }
 
-export function createDesktopEnvironment(userDataDir: string, appVersion: string, resourceRoot: string, isPackaged: boolean, env: NodeJS.ProcessEnv = process.env): DesktopEnvironment {
-  const overrideDirectory = isPackaged ? readEnvironmentValue(env, "FLEET_CONSOLE_DIR") : undefined;
-  if (overrideDirectory !== undefined && !path.isAbsolute(overrideDirectory)) throw new Error("desktop_console_dir_must_be_absolute");
+export function createDesktopEnvironment(userDataDir: string, appVersion: string, resourceRoot: string, isPackaged: boolean, env: NodeJS.ProcessEnv = process.env, options: HydratedDesktopEnvironmentOptions & { readonly loginShellPath?: string } = {}): DesktopEnvironment {
+  const overrideDirectory = resolvePackagedConsoleDirectoryOverride(isPackaged, env);
   const paths = isPackaged
     ? resolveCanonicalStableConsolePaths({ tmpDir: os.tmpdir(), uid: typeof process.getuid === "function" ? process.getuid() : 0, fleetDataDir: path.join(os.homedir(), ".fleet"), consoleDirOverride: overrideDirectory })
     : resolveCanonicalLocalConsolePaths({ packageRoot: resourceRoot });
@@ -39,7 +60,9 @@ export function createDesktopEnvironment(userDataDir: string, appVersion: string
   const ownerId = fs.existsSync(ownerFile) ? fs.readFileSync(ownerFile, "utf8").trim() : crypto.randomUUID();
   if (!fs.existsSync(ownerFile)) fs.writeFileSync(ownerFile, `${ownerId}\n`, { mode: 0o600 });
   const sanitized = sanitizeEnvironment(env);
-  const serviceBase = isPackaged ? prependPathEntries(sanitized, desktopExecutableSearchPaths(os.homedir(), sanitized, process.platform), { platform: process.platform }) : sanitized;
+  const serviceBase = isPackaged
+    ? createPackagedServiceEnvironment(sanitized, options.loginShellPath, options.platform ?? process.platform)
+    : sanitized;
   return {
     ownerId,
     consoleDir: paths.dir,
@@ -55,6 +78,32 @@ export function createDesktopEnvironment(userDataDir: string, appVersion: string
       FLEET_CONSOLE_DESKTOP_VERSION: appVersion,
     },
   };
+}
+
+export async function createHydratedDesktopEnvironment(userDataDir: string, appVersion: string, resourceRoot: string, isPackaged: boolean, env: NodeJS.ProcessEnv = process.env, options: HydratedDesktopEnvironmentOptions = {}): Promise<DesktopEnvironment> {
+  const platform = options.platform ?? process.platform;
+  resolvePackagedConsoleDirectoryOverride(isPackaged, env);
+  const loginShellPath = await readInteractiveLoginShellPath(isPackaged, env, options);
+  return createDesktopEnvironment(userDataDir, appVersion, resourceRoot, isPackaged, env, { platform, loginShellPath });
+}
+
+export async function readInteractiveLoginShellPath(isPackaged: boolean, env: NodeJS.ProcessEnv, options: HydratedDesktopEnvironmentOptions = {}): Promise<string | undefined> {
+  const platform = options.platform ?? process.platform;
+  if (!isPackaged || platform !== "darwin") return undefined;
+  const sanitized = sanitizeEnvironment(env);
+  const shellPath = readEnvironmentValue(sanitized, "SHELL");
+  if (shellPath === undefined || !path.isAbsolute(shellPath)) return undefined;
+  try {
+    const { stdout } = await (options.loginShellPathProbe ?? defaultLoginShellPathProbe).run(shellPath, LOGIN_SHELL_ARGUMENTS, {
+      env: sanitized,
+      maxBuffer: LOGIN_SHELL_PATH_MAX_BUFFER,
+      timeout: LOGIN_SHELL_PATH_TIMEOUT_MS,
+      windowsHide: true,
+    });
+    return isSafeLoginShellPath(stdout) ? stdout : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export function desktopExecutableSearchPaths(homeDirectory: string, env: NodeJS.ProcessEnv, platform: NodeJS.Platform): readonly string[] {
@@ -84,6 +133,24 @@ export function sanitizeEnvironment(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
     if (value !== undefined && normalizedKey !== "NODE_OPTIONS" && !normalizedKey.startsWith("ELECTRON_") && !DESKTOP_CONTROL_ENV_KEYS.has(normalizedKey)) next[key] = value;
   }
   return next;
+}
+
+function createPackagedServiceEnvironment(sanitized: NodeJS.ProcessEnv, loginShellPath: string | undefined, platform: NodeJS.Platform): NodeJS.ProcessEnv {
+  if (platform !== "darwin") return prependPathEntries(sanitized, desktopExecutableSearchPaths(os.homedir(), sanitized, platform), { platform });
+  // 로그인 셸, Finder가 물려준 PATH, 기존의 결정적 폴백 순서로 한 번만 정규화한다.
+  // 셸에서 온 값은 오직 PATH 출력이며, 다른 셸 환경 변수는 sidecar로 전달하지 않는다.
+  const inheritedAndFallbackPath = [sanitized.PATH, ...desktopExecutableSearchPaths(os.homedir(), sanitized, platform)].filter((value): value is string => value !== undefined).join(path.delimiter);
+  return prependPathEntries({ ...sanitized, PATH: inheritedAndFallbackPath }, loginShellPath?.split(path.delimiter) ?? [], { platform });
+}
+
+function isSafeLoginShellPath(value: string): boolean {
+  return value.trim().length > 0 && !INVALID_PATH_OUTPUT.test(value);
+}
+
+function resolvePackagedConsoleDirectoryOverride(isPackaged: boolean, env: NodeJS.ProcessEnv): string | undefined {
+  const overrideDirectory = isPackaged ? readEnvironmentValue(env, "FLEET_CONSOLE_DIR") : undefined;
+  if (overrideDirectory !== undefined && !path.isAbsolute(overrideDirectory)) throw new Error("desktop_console_dir_must_be_absolute");
+  return overrideDirectory;
 }
 
 function readEnvironmentValue(env: NodeJS.ProcessEnv, name: string): string | undefined {

--- a/runtime/fleet-desktop/src/main.ts
+++ b/runtime/fleet-desktop/src/main.ts
@@ -8,7 +8,7 @@ import { app, BrowserWindow, dialog, Menu, shell, Tray } from "electron";
 import { createDesktopLifecycle } from "./app-lifecycle.js";
 import { isConsoleConflict, showConsoleConflictAndQuit } from "./console-conflict.js";
 import { createConsoleControls } from "./console-controls.js";
-import { createDesktopEnvironment, resolveDesktopUserDataDirectory } from "./environment.js";
+import { createHydratedDesktopEnvironment, resolveDesktopUserDataDirectory } from "./environment.js";
 import { pushEntrySnapshot } from "./entry-page.js";
 import { applyDesktopDockIcon, applyDesktopIdentity } from "./identity.js";
 import { createLaunchController, type RuntimeEntryState } from "./launch-controller.js";
@@ -55,7 +55,7 @@ async function boot(): Promise<void> {
   await app.whenReady();
   applyDesktopDockIcon(app, desktopResources.iconPath);
   const runtimePaths = resolveRuntimePaths(os.homedir());
-  const environment = createDesktopEnvironment(app.getPath("userData"), app.getVersion(), desktopResources.serviceRoot, isPackaged);
+  const environment = await createHydratedDesktopEnvironment(app.getPath("userData"), app.getVersion(), desktopResources.serviceRoot, isPackaged);
   const logger = createDesktopLogger(path.join(app.getPath("userData"), "logs"));
   bootLogger = logger;
   const registry = createRegistryChecker({ packageName: PACKAGE_NAME, statePath: path.join(runtimePaths.root, "registry-state.json") });

--- a/runtime/fleet-desktop/tests/environment.test.ts
+++ b/runtime/fleet-desktop/tests/environment.test.ts
@@ -2,11 +2,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DESKTOP_DEVELOPMENT_ENV, DESKTOP_OWNER_ID_ENV, DESKTOP_OWNER_KIND_ENV, DESKTOP_PROTOCOL_VERSION_ENV, DESKTOP_RESOURCE_ROOT_ENV } from "@fleet-console/desktop-protocol";
 
-import { createDesktopEnvironment, desktopExecutableSearchPaths, resolveDesktopUserDataDirectory, sanitizeEnvironment } from "../src/environment.js";
+import { createDesktopEnvironment, createHydratedDesktopEnvironment, desktopExecutableSearchPaths, readInteractiveLoginShellPath, resolveDesktopUserDataDirectory, sanitizeEnvironment } from "../src/environment.js";
 
 const TEMP_DIRS: string[] = [];
 
@@ -107,6 +107,82 @@ describe("desktop environment", () => {
 
   it("sanitizes case-insensitive Electron, Node, and Desktop control keys", () => {
     expect(sanitizeEnvironment({ Electron_No_Asar: "1", node_options: "--inspect", FLEET_CONSOLE_DIR: "/console", Fleet_Console_Owner_Id: "owner", PRESERVED: "yes" })).toEqual({ PRESERVED: "yes" });
+  });
+
+  it("reads only a valid interactive login-shell PATH with a sanitized probe environment", async () => {
+    const run = vi.fn(async () => ({ stdout: "/Users/alice/.opencode/bin:/usr/bin" }));
+
+    await expect(readInteractiveLoginShellPath(true, {
+      SHELL: "/bin/zsh",
+      PATH: "/usr/bin",
+      NODE_OPTIONS: "--require attacker.js",
+      ELECTRON_RUN_AS_NODE: "1",
+      FLEET_CONSOLE_DIR: "/untrusted/console",
+      PRESERVED: "yes",
+    }, { platform: "darwin", loginShellPathProbe: { run } })).resolves.toBe("/Users/alice/.opencode/bin:/usr/bin");
+
+    expect(run).toHaveBeenCalledWith("/bin/zsh", ["-ilc", "printf '%s' \"$PATH\""], {
+      env: { SHELL: "/bin/zsh", PATH: "/usr/bin", PRESERVED: "yes" },
+      maxBuffer: 8 * 1_024,
+      timeout: 1_000,
+      windowsHide: true,
+    });
+  });
+
+  it("does not probe outside packaged macOS", async () => {
+    const run = vi.fn(async () => ({ stdout: "/Users/alice/.opencode/bin" }));
+
+    await expect(readInteractiveLoginShellPath(false, { SHELL: "/bin/zsh" }, { platform: "darwin", loginShellPathProbe: { run } })).resolves.toBeUndefined();
+    await expect(readInteractiveLoginShellPath(true, { SHELL: "/bin/zsh" }, { platform: "linux", loginShellPathProbe: { run } })).resolves.toBeUndefined();
+    await expect(readInteractiveLoginShellPath(true, {}, { platform: "darwin", loginShellPathProbe: { run } })).resolves.toBeUndefined();
+    await expect(readInteractiveLoginShellPath(true, { SHELL: "zsh" }, { platform: "darwin", loginShellPathProbe: { run } })).resolves.toBeUndefined();
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid login-shell output and falls back after probe failure or timeout", async () => {
+    for (const stdout of ["", "/Users/alice/.opencode/bin\n/usr/bin", "/Users/alice/.opencode\u0000/bin", "\u001b[31m/usr/bin"]) {
+      const invalid = { run: vi.fn(async () => ({ stdout })) };
+      await expect(readInteractiveLoginShellPath(true, { SHELL: "/bin/zsh" }, { platform: "darwin", loginShellPathProbe: invalid })).resolves.toBeUndefined();
+    }
+
+    const fallbackProbes = [
+      { run: vi.fn(async () => ({ stdout: "/Users/alice/.opencode/bin\n/usr/bin" })) },
+      { run: vi.fn(async () => { throw new Error("shell failed"); }) },
+      { run: vi.fn(async () => { throw Object.assign(new Error("timed out"), { code: "ETIMEDOUT" }); }) },
+    ];
+    for (const loginShellPathProbe of fallbackProbes) {
+      const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-desktop-shell-path-fallback-"));
+      TEMP_DIRS.push(userDataDir);
+      const environment = await createHydratedDesktopEnvironment(userDataDir, "1.23.0", "/packaged/resources/fleet-console", true, {
+        SHELL: "/bin/zsh",
+        PATH: "/inherited/bin",
+      }, { platform: "darwin", loginShellPathProbe });
+      expect(environment.serviceEnv.PATH).toContain("/inherited/bin");
+      expect(environment.serviceEnv.PATH).not.toContain(".opencode");
+    }
+  });
+
+  it("orders and deduplicates packaged macOS shell, inherited, and deterministic PATH entries", async () => {
+    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-desktop-shell-path-"));
+    TEMP_DIRS.push(userDataDir);
+    const home = os.homedir();
+    const environment = await createHydratedDesktopEnvironment(userDataDir, "1.23.0", "/packaged/resources/fleet-console", true, {
+      SHELL: "/bin/zsh",
+      PATH: "/inherited/bin:/shared/bin",
+      npm_config_prefix: "/fallback-prefix",
+      PNPM_HOME: "/shared/bin",
+    }, { platform: "darwin", loginShellPathProbe: { run: vi.fn(async () => ({ stdout: "/Users/alice/.opencode/bin:/shared/bin" })) } });
+
+    expect(environment.serviceEnv.PATH).toBe([
+      "/Users/alice/.opencode/bin",
+      "/shared/bin",
+      "/inherited/bin",
+      "/fallback-prefix/bin",
+      path.join(home, ".local", "bin"),
+      path.join(home, "Library", "pnpm"),
+      "/opt/homebrew/bin",
+      "/usr/local/bin",
+    ].join(path.delimiter));
   });
 
   it("adds macOS user and npm executable locations for a packaged GUI launch", () => {

--- a/runtime/fleet-desktop/tests/environment.test.ts
+++ b/runtime/fleet-desktop/tests/environment.test.ts
@@ -157,7 +157,13 @@ describe("desktop environment", () => {
         SHELL: "/bin/zsh",
         PATH: "/inherited/bin",
       }, { platform: "darwin", loginShellPathProbe });
-      expect(environment.serviceEnv.PATH).toContain("/inherited/bin");
+      expect(environment.serviceEnv.PATH?.split(path.delimiter)).toEqual([
+        path.join(os.homedir(), ".local", "bin"),
+        path.join(os.homedir(), "Library", "pnpm"),
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/inherited/bin",
+      ]);
       expect(environment.serviceEnv.PATH).not.toContain(".opencode");
     }
   });


### PR DESCRIPTION
## Summary
- hydrate packaged macOS Desktop sidecars with the user's interactive login-shell PATH
- bound and sanitize the PATH-only probe while preserving inherited and deterministic fallback paths
- keep Desktop provider-agnostic without explicit Agent CLI paths or CLI-specific install directories

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-desktop exec vitest run tests/environment.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-desktop test`
- [x] `pnpm --filter @dotobokuri/fleet-desktop typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-desktop build`
- [x] `pnpm --filter @dotobokuri/fleet-desktop package:dir`
- [x] Verify OpenCode appears in Settings > Agent CLI from an isolated packaged Desktop
- [x] Verify a Vanguard sortie completes through the packaged Desktop sidecar
- [x] Add `.changelog.d/pr-245.md` with bilingual summaries
- [x] `node scripts/compile-changelog-fragments.mjs --check`