### PR TITLE
fix(console): minimize panels on startup

### DIFF
--- a/.changelog.d/pr-246.md
+++ b/.changelog.d/pr-246.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Changed
+- [fleet-console] Start existing Operation panels minimized when Fleet Console opens.
+  ko: Fleet Console을 열 때 기존 Operation 패널을 최소화된 상태로 시작합니다.

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -17,7 +17,7 @@ import { GlobalSettings } from "./pages/global-settings.js";
 import { Operations } from "./pages/operations.js";
 import { toggleRailChrome } from "./rail/rail-store.js";
 import { refreshObserverStatus } from "./operations-sse.js";
-import { hydrateGroups, hydrateOperations, hydrateTheaterBootstrap, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
+import { hydrateGroups, hydrateInitialOperations, hydrateOperations, hydrateTheaterBootstrap, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
 import { abortReleaseNotesFetch, requestReleaseNotes } from "./release-notes-fetch.js";
 import { getSideBarState, setSideBarCollapsed } from "./sidebar/operations-side-bar-store.js";
 import { resolveReleaseNotesLocale } from "./whatsnew-i18n.js";
@@ -35,6 +35,7 @@ function isBlockingDialogOpen(): boolean {
 export function App() {
   const state = useConsoleState();
   const bootPanelsMinimizedRef = useRef(false);
+  const bootOperationIdsRef = useRef<readonly string[] | null>(null);
   const location = useLocation();
   const registry = usePluginRegistry();
   const globalSettings = useGlobalSettingsStore();
@@ -42,10 +43,10 @@ export function App() {
   const pathname = location.pathname;
   const operationsViewVisible = pathname.startsWith("/operations");
 
-  const claimBootPanelMinimization = useCallback((): boolean => {
-    if (bootPanelsMinimizedRef.current) return false;
+  const claimBootPanelMinimization = useCallback((): readonly string[] | null => {
+    if (bootPanelsMinimizedRef.current || bootOperationIdsRef.current === null) return null;
     bootPanelsMinimizedRef.current = true;
-    return true;
+    return bootOperationIdsRef.current;
   }, []);
 
   useEffect(() => {
@@ -74,7 +75,10 @@ export function App() {
         setState({ theaterError: error instanceof Error ? error.message : String(error) });
         resolveOnboardingOnBootstrap();
       });
-    void fetchOperations(null, abort.signal).then(hydrateOperations).catch(() => {});
+    void fetchOperations(null, abort.signal).then((operations) => {
+      bootOperationIdsRef.current = operations.map((operation) => operation.id);
+      hydrateInitialOperations(operations);
+    }).catch(() => {});
     void fetchGroups(null, abort.signal).then(hydrateGroups).catch(() => {});
     refreshObserverStatus();
     // cold-start 보정: 서버 백그라운드 refresh 완료를 기다렸다가 한 번 더 읽어 배지를 채운다.

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 
 import { fetchGroups, fetchOperations, fetchTheaterBootstrap } from "./api.js";
@@ -34,12 +34,19 @@ function isBlockingDialogOpen(): boolean {
 
 export function App() {
   const state = useConsoleState();
+  const bootPanelsMinimizedRef = useRef(false);
   const location = useLocation();
   const registry = usePluginRegistry();
   const globalSettings = useGlobalSettingsStore();
   const releaseNotesLocale = resolveReleaseNotesLocale(globalSettings.state?.language ?? "auto");
   const pathname = location.pathname;
   const operationsViewVisible = pathname.startsWith("/operations");
+
+  const claimBootPanelMinimization = useCallback((): boolean => {
+    if (bootPanelsMinimizedRef.current) return false;
+    bootPanelsMinimizedRef.current = true;
+    return true;
+  }, []);
 
   useEffect(() => {
     const capabilities = createHostCapabilities(() => {
@@ -118,7 +125,7 @@ export function App() {
       <main className="console-route-content">
         <Routes>
           <Route path="/" element={<Navigate to="/operations" replace />} />
-          <Route path="/operations" element={<Operations state={state} />} />
+          <Route path="/operations" element={<Operations state={state} claimBootPanelMinimization={claimBootPanelMinimization} />} />
           <Route path="/carrier-settings" element={<CarrierSettings />} />
           <Route path="/settings" element={<GlobalSettings />} />
           <Route path="*" element={<Navigate to="/operations" replace />} />

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -75,8 +75,12 @@ export function App() {
         setState({ theaterError: error instanceof Error ? error.message : String(error) });
         resolveOnboardingOnBootstrap();
       });
+    const bootOperationsRequestStartedAt = Date.now();
     void fetchOperations(null, abort.signal).then((operations) => {
-      bootOperationIdsRef.current = operations.map((operation) => operation.id);
+      // 요청 시작 뒤 생성된 Operation은 응답에 포함돼도 새 launch로 취급한다.
+      bootOperationIdsRef.current = operations
+        .filter((operation) => operation.ts.createdAt < bootOperationsRequestStartedAt)
+        .map((operation) => operation.id);
       hydrateInitialOperations(operations);
     }).catch(() => {});
     void fetchGroups(null, abort.signal).then(hydrateGroups).catch(() => {});

--- a/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
@@ -225,14 +225,19 @@ export function minimizeOperation(sessionId: string): void {
   setState({ minimized: [...state.minimized, sessionId] });
 }
 
-// 초기 부팅처럼 현재 존재하는 패널 집합 전체를 최소화할 때 쓴다. geometry는 유지하고 없는 id는 무시한다.
+// 초기 부팅처럼 현재 존재하는 패널 집합을 최소화할 때 쓴다. 기존 최소화 순서는 보존하고 새 id만 뒤에 더한다.
 export function minimizeOperations(sessionIds: readonly string[]): void {
   const seen = new Set<string>();
-  const minimized = sessionIds.filter((sessionId) => {
+  const validMinimized = state.minimized.filter((sessionId) => {
     if (seen.has(sessionId) || !(sessionId in state.operations)) return false;
     seen.add(sessionId);
     return true;
   });
+  const minimized = [...validMinimized, ...sessionIds.filter((sessionId) => {
+    if (seen.has(sessionId) || !(sessionId in state.operations)) return false;
+    seen.add(sessionId);
+    return true;
+  })];
   if (stringArraysEqual(state.minimized, minimized)) return;
   if (maximizedOperationId && minimized.includes(maximizedOperationId)) clearMaximizedOperationId();
   setState({ minimized });

--- a/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
@@ -225,6 +225,19 @@ export function minimizeOperation(sessionId: string): void {
   setState({ minimized: [...state.minimized, sessionId] });
 }
 
+// 초기 부팅처럼 현재 존재하는 패널 집합 전체를 최소화할 때 쓴다. geometry는 유지하고 없는 id는 무시한다.
+export function minimizeOperations(sessionIds: readonly string[]): void {
+  const seen = new Set<string>();
+  const minimized = sessionIds.filter((sessionId) => {
+    if (seen.has(sessionId) || !(sessionId in state.operations)) return false;
+    seen.add(sessionId);
+    return true;
+  });
+  if (stringArraysEqual(state.minimized, minimized)) return;
+  if (maximizedOperationId && minimized.includes(maximizedOperationId)) clearMaximizedOperationId();
+  setState({ minimized });
+}
+
 // 최소화한 Operation을 복원한다 — 목록에서 제거하고 보존된 geometry를 최상단 zIndex로 끌어올려 원위치·원크기로 되돌린다.
 // 활성화(selectTerminalSession)는 호출 측 책임으로 남겨, Operation 활성 조정을 한 곳(canvas)에서 유지한다.
 export function restoreOperation(sessionId: string): void {

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -25,7 +25,7 @@ const closingOperationIds = new Set<string>();
 
 interface OperationsProps {
   readonly state: ConsoleState;
-  readonly claimBootPanelMinimization: () => boolean;
+  readonly claimBootPanelMinimization: () => readonly string[] | null;
 }
 
 export function Operations({ state, claimBootPanelMinimization }: OperationsProps) {
@@ -109,9 +109,11 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
     for (const operationId of operationOrder) ensureDefaultGeometry(operationId);
     if (!state.operationsHydrated) return;
     pruneOperations(operationOrder);
-    // App 부트에서 한 번만 권한을 얻는다. 이후 생성·Theater 전환·route 재진입은 초기화에 포함하지 않는다.
-    if (!state.activeTheaterId || !claimBootPanelMinimization()) return;
-    minimizeOperations(operationOrder);
+    // App 최초 요청에서 받은 id만 한 번 최소화한다. 이후 생성·Theater 전환·route 재진입은 초기화에 포함하지 않는다.
+    if (!state.activeTheaterId) return;
+    const bootOperationIds = claimBootPanelMinimization();
+    if (bootOperationIds === null) return;
+    minimizeOperations(bootOperationIds);
   }, [claimBootPanelMinimization, operationOrder, state.activeTheaterId, state.operationsHydrated]);
 
   // 검색·ALERTS 등에서 들어온 일회성 이동 요청을 처리한다.

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -5,7 +5,7 @@ import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 import type { ClientApiCapability, FleetClientPlugin } from "@fleet-console/sdk/plugin";
 
 import { addTheater, createGroup, deleteGroup, fetchGroups, fetchOperations, forgetTheater, issueTheaterFolderGrant, patchOperation, renameOperation, updateGroup, ApiError } from "../api.js";
-import { animateViewportTo, claimTopZIndex, clearMaximizedOperationId, ensureDefaultGeometry, focusOperation as focusCanvasOperation, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, loadForTheater, minimizeOperation, pruneOperations, restoreOperation, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
+import { animateViewportTo, claimTopZIndex, clearMaximizedOperationId, ensureDefaultGeometry, focusOperation as focusCanvasOperation, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, restoreOperation, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
 import { screenToCanvas, type CanvasPoint } from "../canvas/coordinates.js";
 import { OperationsCanvas } from "../canvas/canvas.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
@@ -25,9 +25,10 @@ const closingOperationIds = new Set<string>();
 
 interface OperationsProps {
   readonly state: ConsoleState;
+  readonly claimBootPanelMinimization: () => boolean;
 }
 
-export function Operations({ state }: OperationsProps) {
+export function Operations({ state, claimBootPanelMinimization }: OperationsProps) {
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const maximizedOperationId = useMaximizedOperationId();
   const formationView = useFormationView();
@@ -106,8 +107,12 @@ export function Operations({ state }: OperationsProps) {
 
   useEffect(() => {
     for (const operationId of operationOrder) ensureDefaultGeometry(operationId);
-    if (state.operationsHydrated) pruneOperations(operationOrder);
-  }, [operationOrder, state.operationsHydrated]);
+    if (!state.operationsHydrated) return;
+    pruneOperations(operationOrder);
+    // App 부트에서 한 번만 권한을 얻는다. 이후 생성·Theater 전환·route 재진입은 초기화에 포함하지 않는다.
+    if (!state.activeTheaterId || !claimBootPanelMinimization()) return;
+    minimizeOperations(operationOrder);
+  }, [claimBootPanelMinimization, operationOrder, state.activeTheaterId, state.operationsHydrated]);
 
   // 검색·ALERTS 등에서 들어온 일회성 이동 요청을 처리한다.
   useEffect(() => {

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -197,6 +197,13 @@ export function hydrateOperations(operations: readonly OperationNode[]): void {
   setState({ operations, operationsHydrated: true });
 }
 
+// 초기 요청 응답이 늦는 동안 launch 수화가 먼저 도착할 수 있다. 그 패널을 초기 응답이 덮어쓰지 않게 합친다.
+export function hydrateInitialOperations(operations: readonly OperationNode[]): void {
+  const initialIds = new Set(operations.map((operation) => operation.id));
+  const launchedBeforeInitialHydration = state.operations.filter((operation) => !initialIds.has(operation.id));
+  setState({ operations: [...operations, ...launchedBeforeInitialHydration], operationsHydrated: true });
+}
+
 export function applyOperationUpdate(operation: OperationNode): void {
   const index = state.operations.findIndex((op) => op.id === operation.id);
   if (index === -1) return;

--- a/runtime/fleet-console/tests/canvas-store.test.ts
+++ b/runtime/fleet-console/tests/canvas-store.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { calculateGridSlots, clearFormationView, clearMaximizedOperationId, getFormationView, getMaximizedOperationId, getSnapshot, loadForTheater, minimizeOperation, pruneOperations, setMaximizedOperationId, setOperationAccent, setOperationGeometry, setOperationOrder, toggleFormationView, type OperationGeometry } from "../core/client/src/canvas/canvas-store.js";
+import { calculateGridSlots, clearFormationView, clearMaximizedOperationId, getFormationView, getMaximizedOperationId, getSnapshot, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, setMaximizedOperationId, setOperationAccent, setOperationGeometry, setOperationOrder, toggleFormationView, type OperationGeometry } from "../core/client/src/canvas/canvas-store.js";
 
 const GEOMETRY: OperationGeometry = { x: 0, y: 0, width: 100, height: 100, zIndex: 0 };
 
@@ -79,6 +79,41 @@ describe("canvas store", () => {
 
     expect(getMaximizedOperationId()).toBe("op-b");
     expect(getSnapshot().minimized).toEqual(["op-a"]);
+  });
+
+  it("minimizes boot panels without changing their stored geometry", () => {
+    setOperationGeometry("op-a", { ...GEOMETRY, x: 48, y: 72, zIndex: 4 });
+    setOperationGeometry("op-b", { ...GEOMETRY, x: 96, y: 144, zIndex: 8 });
+    const geometry = getSnapshot().operations;
+
+    minimizeOperations(["op-a", "op-b", "missing"]);
+
+    expect(getSnapshot().minimized).toEqual(["op-a", "op-b"]);
+    expect(getSnapshot().operations).toEqual(geometry);
+  });
+
+  it("does not minimize Operations added after boot initialization", () => {
+    setOperationGeometry("op-a", { ...GEOMETRY });
+    minimizeOperations(["op-a"]);
+    setOperationGeometry("op-b", { ...GEOMETRY });
+
+    expect(getSnapshot().minimized).toEqual(["op-a"]);
+  });
+
+  it("keeps boot-minimized panels and geometry scoped to their Theater", () => {
+    setOperationGeometry("op-a", { ...GEOMETRY, x: 48, y: 72 });
+    minimizeOperations(["op-a"]);
+
+    loadForTheater("theater-b");
+    setOperationGeometry("op-b", { ...GEOMETRY, x: 96, y: 144 });
+
+    loadForTheater("theater-a");
+    expect(getSnapshot().minimized).toEqual(["op-a"]);
+    expect(getSnapshot().operations["op-a"]).toMatchObject({ x: 48, y: 72 });
+
+    loadForTheater("theater-b");
+    expect(getSnapshot().minimized).toEqual([]);
+    expect(getSnapshot().operations["op-b"]).toMatchObject({ x: 96, y: 144 });
   });
 
   it("keeps maximize-docked Operations minimized when entering open-panel Formation", () => {

--- a/runtime/fleet-console/tests/canvas-store.test.ts
+++ b/runtime/fleet-console/tests/canvas-store.test.ts
@@ -92,6 +92,16 @@ describe("canvas store", () => {
     expect(getSnapshot().operations).toEqual(geometry);
   });
 
+  it("keeps existing minimized panels first when adding boot panels", () => {
+    setOperationGeometry("launched", { ...GEOMETRY });
+    setOperationGeometry("initial", { ...GEOMETRY });
+    minimizeOperation("launched");
+
+    minimizeOperations(["initial", "launched", "missing", "initial"]);
+
+    expect(getSnapshot().minimized).toEqual(["launched", "initial"]);
+  });
+
   it("does not minimize Operations added after boot initialization", () => {
     setOperationGeometry("op-a", { ...GEOMETRY });
     minimizeOperations(["op-a"]);

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -5,7 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getSnapshot, loadForTheater, restoreOperation, setOperationGeometry } from "../core/client/src/canvas/canvas-store.js";
+import { getSnapshot, loadForTheater, minimizeOperation, restoreOperation, setOperationGeometry } from "../core/client/src/canvas/canvas-store.js";
 import { getState, hydrateOperations, setState } from "../core/client/src/store.js";
 import type { OperationNode, TheaterBootstrap } from "../core/client/src/types.js";
 
@@ -144,14 +144,15 @@ describe("Operations boot minimization", () => {
     await act(async () => {
       hydrateOperations([operation("launched")]);
     });
-    expect(getSnapshot().minimized).toEqual([]);
+    minimizeOperation("launched");
+    expect(getSnapshot().minimized).toEqual(["launched"]);
 
     await act(async () => {
       operations.resolve([operation("initial")]);
       await Promise.resolve();
     });
 
-    expect(getSnapshot().minimized).toEqual(["initial"]);
+    expect(getSnapshot().minimized).toEqual(["launched", "initial"]);
     expect(getSnapshot().operations).toHaveProperty("initial");
     expect(getSnapshot().operations).toHaveProperty("launched");
   });

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -5,7 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getSnapshot, loadForTheater, minimizeOperation, restoreOperation, setOperationGeometry } from "../core/client/src/canvas/canvas-store.js";
+import { getSnapshot, loadForTheater, restoreOperation, setOperationGeometry } from "../core/client/src/canvas/canvas-store.js";
 import { getState, hydrateOperations, setState } from "../core/client/src/store.js";
 import type { OperationNode, TheaterBootstrap } from "../core/client/src/types.js";
 
@@ -80,6 +80,7 @@ afterEach(() => {
   root = null;
   container = null;
   vi.clearAllMocks();
+  vi.restoreAllMocks();
 });
 
 describe("Operations boot minimization", () => {
@@ -126,6 +127,7 @@ describe("Operations boot minimization", () => {
   it("does not minimize an Operation launched before the initial fetch resolves", async () => {
     const operations = deferred<readonly OperationNode[]>();
     const theaters = deferred<TheaterBootstrap>();
+    vi.spyOn(Date, "now").mockReturnValue(100);
     apiMocks.fetchOperations.mockReturnValueOnce(operations.promise);
     apiMocks.fetchTheaterBootstrap.mockReturnValueOnce(theaters.promise);
     const { App } = await import("../core/client/src/app.js");
@@ -142,17 +144,16 @@ describe("Operations boot minimization", () => {
     expect(getState().operationsHydrated).toBe(false);
 
     await act(async () => {
-      hydrateOperations([operation("launched")]);
+      hydrateOperations([operation("launched", 100)]);
     });
-    minimizeOperation("launched");
-    expect(getSnapshot().minimized).toEqual(["launched"]);
+    expect(getSnapshot().minimized).toEqual([]);
 
     await act(async () => {
-      operations.resolve([operation("initial")]);
+      operations.resolve([operation("initial", 99), operation("launched", 100)]);
       await Promise.resolve();
     });
 
-    expect(getSnapshot().minimized).toEqual(["launched", "initial"]);
+    expect(getSnapshot().minimized).toEqual(["initial"]);
     expect(getSnapshot().operations).toHaveProperty("initial");
     expect(getSnapshot().operations).toHaveProperty("launched");
   });
@@ -185,7 +186,7 @@ function theater() {
   };
 }
 
-function operation(id: string): OperationNode {
+function operation(id: string, createdAt = 1): OperationNode {
   return {
     id,
     theaterId: "theater-a",
@@ -194,6 +195,6 @@ function operation(id: string): OperationNode {
     title: id,
     payload: {},
     geometry: null,
-    ts: { createdAt: 1, updatedAt: 1 },
+    ts: { createdAt, updatedAt: createdAt },
   };
 }

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getSnapshot, loadForTheater, restoreOperation, setOperationGeometry } from "../core/client/src/canvas/canvas-store.js";
+import { getState, hydrateOperations } from "../core/client/src/store.js";
+import type { OperationNode, TheaterBootstrap } from "../core/client/src/types.js";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchTheaterBootstrap: vi.fn(),
+  fetchOperations: vi.fn(),
+  fetchGroups: vi.fn(),
+}));
+
+vi.mock("../core/client/src/api.js", () => ({
+  ...apiMocks,
+  ApiError: class ApiError extends Error {
+    readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+  addTheater: vi.fn(),
+  createGroup: vi.fn(),
+  deleteGroup: vi.fn(),
+  forgetTheater: vi.fn(),
+  issueTheaterFolderGrant: vi.fn(),
+  patchOperation: vi.fn(),
+  renameOperation: vi.fn(),
+  updateGroup: vi.fn(),
+}));
+
+vi.mock("@fleet-console/sdk/operations/browser", () => ({ fetchOperationCatalog: vi.fn().mockResolvedValue([]) }));
+vi.mock("../core/client/src/canvas/canvas.js", () => ({ OperationsCanvas: () => null }));
+vi.mock("../core/client/src/components/codex-reading-sheet.js", () => ({ CodexReadingSheet: () => null }));
+vi.mock("../core/client/src/components/command-band.js", () => ({ CommandBand: () => null }));
+vi.mock("../core/client/src/components/commissioning-overlay.js", () => ({ CommissioningOverlay: () => null }));
+vi.mock("../core/client/src/components/keyboard-shortcuts-dialog.js", () => ({ isKeyboardShortcutsModalOpen: () => false, shouldHandleOperationsKeyboardShortcut: () => false }));
+vi.mock("../core/client/src/components/operation-search.js", () => ({ OperationSearch: () => null }));
+vi.mock("../core/client/src/components/toast.js", () => ({ Toast: () => null }));
+vi.mock("../core/client/src/components/whatsnew-modal.js", () => ({ WhatsNewModal: () => null }));
+vi.mock("../core/client/src/global-settings-store.js", () => ({ useGlobalSettingsStore: () => ({ state: null }) }));
+vi.mock("../core/client/src/operations-sse.js", () => ({ refreshObserverStatus: vi.fn() }));
+vi.mock("../core/client/src/pages/carrier-settings.js", () => ({ CarrierSettings: () => null }));
+vi.mock("../core/client/src/pages/global-settings.js", () => ({ GlobalSettings: () => createElement("div", { "data-route": "settings" }) }));
+vi.mock("../core/client/src/plugin-capabilities.js", () => ({ createHostCapabilities: () => ({ api: {} }) }));
+vi.mock("../core/client/src/plugin-registry.js", () => ({ usePluginRegistry: () => ({ plugins: [], operationKinds: [], settingsSections: [], notificationKinds: [], railPanels: [] }) }));
+vi.mock("../core/client/src/rail/rail-store.js", () => ({ toggleRailChrome: vi.fn() }));
+vi.mock("../core/client/src/rail/right-rail.js", () => ({ RightRail: () => null }));
+vi.mock("../core/client/src/release-notes-fetch.js", () => ({ abortReleaseNotesFetch: vi.fn(), requestReleaseNotes: vi.fn() }));
+vi.mock("../core/client/src/sidebar/operations-side-bar-store.js", () => ({ getSideBarState: () => ({ collapsed: false }), setSideBarCollapsed: vi.fn() }));
+vi.mock("../core/client/src/sidebar/operations-side-bar.js", () => ({ OperationsSideBar: () => null }));
+vi.mock("../core/client/src/whatsnew-i18n.js", () => ({ resolveReleaseNotesLocale: () => "en" }));
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  window.localStorage.clear();
+  window.history.replaceState({}, "", "/operations");
+  loadForTheater(null);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  apiMocks.fetchGroups.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  vi.clearAllMocks();
+});
+
+describe("Operations boot minimization", () => {
+  it("minimizes initial hydrated panels once across /operations -> /settings -> /operations", async () => {
+    const operations = deferred<readonly OperationNode[]>();
+    const theaters = deferred<TheaterBootstrap>();
+    apiMocks.fetchOperations.mockReturnValueOnce(operations.promise);
+    apiMocks.fetchTheaterBootstrap.mockReturnValueOnce(theaters.promise);
+    const { App } = await import("../core/client/src/app.js");
+
+    await act(async () => {
+      root!.render(createElement(BrowserRouter, null, createElement(App)));
+    });
+
+    await act(async () => {
+      operations.resolve([operation("initial")]);
+      await Promise.resolve();
+    });
+    expect(getState().operationsHydrated).toBe(true);
+    expect(getSnapshot().minimized).toEqual([]);
+
+    await act(async () => {
+      theaters.resolve({ theaters: [theater()] });
+      await Promise.resolve();
+    });
+    expect(getSnapshot().minimized).toEqual(["initial"]);
+
+    await act(async () => {
+      hydrateOperations([operation("initial"), operation("later")]);
+    });
+    setOperationGeometry("later", { x: 96, y: 144, width: 640, height: 400, zIndex: 2 });
+    restoreOperation("initial");
+    expect(getSnapshot().minimized).toEqual([]);
+
+    await navigateTo("/settings");
+    expect(document.querySelector('[data-route="settings"]')).not.toBeNull();
+    await navigateTo("/operations");
+
+    expect(getSnapshot().minimized).toEqual([]);
+    expect(getSnapshot().operations).toHaveProperty("initial");
+    expect(getSnapshot().operations).toHaveProperty("later");
+  });
+});
+
+async function navigateTo(pathname: string): Promise<void> {
+  await act(async () => {
+    window.history.pushState({}, "", pathname);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    await Promise.resolve();
+  });
+}
+
+function deferred<Value>() {
+  let resolve!: (value: Value) => void;
+  const promise = new Promise<Value>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function theater() {
+  return {
+    id: "theater-a",
+    label: "Theater A",
+    createdAt: "2026-07-12T00:00:00.000Z",
+    lastOpenedAt: "2026-07-12T00:00:00.000Z",
+    hasWiki: false,
+    activeAdmiralCount: 0,
+  };
+}
+
+function operation(id: string): OperationNode {
+  return {
+    id,
+    theaterId: "theater-a",
+    type: "shell",
+    pluginId: "terminal",
+    title: id,
+    payload: {},
+    geometry: null,
+    ts: { createdAt: 1, updatedAt: 1 },
+  };
+}

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -6,7 +6,7 @@ import { BrowserRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getSnapshot, loadForTheater, restoreOperation, setOperationGeometry } from "../core/client/src/canvas/canvas-store.js";
-import { getState, hydrateOperations } from "../core/client/src/store.js";
+import { getState, hydrateOperations, setState } from "../core/client/src/store.js";
 import type { OperationNode, TheaterBootstrap } from "../core/client/src/types.js";
 
 const apiMocks = vi.hoisted(() => ({
@@ -67,6 +67,7 @@ beforeEach(() => {
   window.localStorage.clear();
   window.history.replaceState({}, "", "/operations");
   loadForTheater(null);
+  setState({ activeOperationId: null, activeTheaterId: null, groups: [], operations: [], operationsHydrated: false, theaters: [] });
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -120,6 +121,39 @@ describe("Operations boot minimization", () => {
     expect(getSnapshot().minimized).toEqual([]);
     expect(getSnapshot().operations).toHaveProperty("initial");
     expect(getSnapshot().operations).toHaveProperty("later");
+  });
+
+  it("does not minimize an Operation launched before the initial fetch resolves", async () => {
+    const operations = deferred<readonly OperationNode[]>();
+    const theaters = deferred<TheaterBootstrap>();
+    apiMocks.fetchOperations.mockReturnValueOnce(operations.promise);
+    apiMocks.fetchTheaterBootstrap.mockReturnValueOnce(theaters.promise);
+    const { App } = await import("../core/client/src/app.js");
+
+    await act(async () => {
+      root!.render(createElement(BrowserRouter, null, createElement(App)));
+    });
+
+    await act(async () => {
+      theaters.resolve({ theaters: [theater()] });
+      await Promise.resolve();
+    });
+    expect(getState().activeTheaterId).toBe("theater-a");
+    expect(getState().operationsHydrated).toBe(false);
+
+    await act(async () => {
+      hydrateOperations([operation("launched")]);
+    });
+    expect(getSnapshot().minimized).toEqual([]);
+
+    await act(async () => {
+      operations.resolve([operation("initial")]);
+      await Promise.resolve();
+    });
+
+    expect(getSnapshot().minimized).toEqual(["initial"]);
+    expect(getSnapshot().operations).toHaveProperty("initial");
+    expect(getSnapshot().operations).toHaveProperty("launched");
   });
 });
 


### PR DESCRIPTION
## Summary
- minimize every existing Operation panel once when a Console client boots
- preserve panel restores, later launches, Theater switches, and route navigation
- add store and React integration coverage for hydration and remount behavior

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` (744 passed, 22 skipped)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] headed `agent-browser` cold-start verification with two minimized panels and zero page errors
- [x] `git diff --check`

## Changelog
- [x] `.changelog.d/pr-246.md`
- [x] grouped fragment syntax and bilingual summaries
- [x] `node scripts/compile-changelog-fragments.mjs --check`

## Notes
- The standalone Console typecheck currently reports pre-existing CSS side-effect and `virtual:fleet-plugins` declaration resolution errors; the production build and focused client checks pass.