### PR TITLE
feat(codex): default to app server transport

### DIFF
--- a/.changelog.d/pr-247.md
+++ b/.changelog.d/pr-247.md
@@ -1,6 +1,6 @@
 ### fleet-plugin
 #### Changed
-- [fleet-plugin] Default new Codex Agent CLI settings to App Server while preserving explicit ACP selections.
+- [fleet-console] Default new Codex Agent CLI settings to App Server while preserving explicit ACP selections.
   ko: 새 Codex Agent CLI 설정의 기본값을 App Server로 지정하며 명시적인 ACP 선택은 유지합니다.
 
 ### fleet-core

--- a/.changelog.d/pr-247.md
+++ b/.changelog.d/pr-247.md
@@ -1,0 +1,9 @@
+### fleet-plugin
+#### Changed
+- [fleet-plugin] Default new Codex Agent CLI settings to App Server while preserving explicit ACP selections.
+  ko: 새 Codex Agent CLI 설정의 기본값을 App Server로 지정하며 명시적인 ACP 선택은 유지합니다.
+
+### fleet-core
+#### Changed
+- [core-unified-agent] Use App Server for Codex connections when no launch-mode override is configured.
+  ko: 시작 모드 재정의가 없으면 Codex 연결에 App Server를 사용합니다.

--- a/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
+++ b/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
@@ -194,7 +194,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     this.sessionCwd = options.cwd;
     this.currentSystemPrompt = developerInstructions;
     this.pendingOverrides = {
-      turnConfig: {},
+      turnConfig: options.effort ? { effort: options.effort } : {},
       threadConfig: {
         approvalPolicy: modeMapping.approvalPolicy,
         sandbox: modeMapping.sandbox,

--- a/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
+++ b/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
@@ -887,9 +887,9 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
   }
 }
 
-// 호출별 환경변수로 Codex 전송 경로를 선택하며, 미설정은 ACP로 유지한다.
+// 호출별 환경변수로 Codex 전송 경로를 선택하며, 미설정은 App Server를 사용한다.
 function shouldUseCodexAcp(options: UnifiedClientOptions): boolean {
   const value = options.env?.CODEX_USE_ACP ?? process.env.CODEX_USE_ACP;
   const normalized = value?.trim().toLowerCase();
-  return normalized !== 'false' && normalized !== '0';
+  return normalized !== undefined && normalized !== 'false' && normalized !== '0';
 }

--- a/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
+++ b/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
@@ -184,7 +184,13 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
       });
     }
 
-    this.sessionId = connection.sessionId;
+    const sessionId = connection.sessionId;
+    if (!sessionId) {
+      await this.cleanupFailedConnection();
+      throw new Error('[codex] App Server 연결에서 유효한 세션 ID를 받지 못했습니다.');
+    }
+
+    this.sessionId = sessionId;
     this.sessionCwd = options.cwd;
     this.currentSystemPrompt = developerInstructions;
     this.pendingOverrides = {
@@ -198,6 +204,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     return {
       cli: 'codex',
       protocol: 'codex-app-server',
+      session: { sessionId },
     };
   }
 

--- a/packages/core-unified-agent/tests/e2e/codex.test.ts
+++ b/packages/core-unified-agent/tests/e2e/codex.test.ts
@@ -5,7 +5,7 @@
 
 import { EventEmitter } from 'events';
 import type { ChildProcess } from 'child_process';
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import {
   isCliInstalled,
   connectClient,
@@ -101,11 +101,28 @@ const CODEX_EFFORT_MATRIX = [
 
 describe.skipIf(!installed)('E2E: Codex official ACP bridge', () => {
   let client: IUnifiedAgentClient | null = null;
+  let originalCodexUseAcp: string | undefined;
+
+  beforeEach(() => {
+    originalCodexUseAcp = process.env.CODEX_USE_ACP;
+    process.env.CODEX_USE_ACP = 'true';
+  });
 
   afterEach(async () => {
-    if (client) {
-      await client.disconnect();
-      client = null;
+    try {
+      if (client) {
+        try {
+          await client.disconnect();
+        } finally {
+          client = null;
+        }
+      }
+    } finally {
+      if (originalCodexUseAcp === undefined) {
+        delete process.env.CODEX_USE_ACP;
+      } else {
+        process.env.CODEX_USE_ACP = originalCodexUseAcp;
+      }
     }
   });
 

--- a/packages/core-unified-agent/tests/e2e/unified-agent.contract.test.ts
+++ b/packages/core-unified-agent/tests/e2e/unified-agent.contract.test.ts
@@ -5,7 +5,7 @@
  * UnifiedAgent 빌더를 사용하는 외부 호출자는 동일한 기대 동작을 관찰해야 합니다.
  */
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   UnifiedAgent,
@@ -35,7 +35,7 @@ const CONTRACT_CASES: ContractCase[] = [
   },
   {
     cli: 'codex',
-    expectedProtocol: 'acp',
+    expectedProtocol: 'codex-app-server',
     model: 'gpt-5.6-sol',
     supportsResetSession: true,
   },
@@ -46,11 +46,31 @@ for (const contractCase of CONTRACT_CASES) {
 
   describe.skipIf(!installed)(`UnifiedAgent contract: ${contractCase.cli}`, () => {
     let client: IUnifiedAgentClient | null = null;
+    let originalCodexUseAcp: string | undefined;
+
+    beforeEach(() => {
+      if (contractCase.cli !== 'codex') return;
+      originalCodexUseAcp = process.env.CODEX_USE_ACP;
+      delete process.env.CODEX_USE_ACP;
+    });
 
     afterEach(async () => {
-      if (client) {
-        await client.disconnect();
-        client = null;
+      try {
+        if (client) {
+          try {
+            await client.disconnect();
+          } finally {
+            client = null;
+          }
+        }
+      } finally {
+        if (contractCase.cli === 'codex') {
+          if (originalCodexUseAcp === undefined) {
+            delete process.env.CODEX_USE_ACP;
+          } else {
+            process.env.CODEX_USE_ACP = originalCodexUseAcp;
+          }
+        }
       }
     });
 

--- a/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
+++ b/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
@@ -84,8 +84,8 @@ const { AcpConnection } = await import('../../src/connection/AcpConnection.js');
 
 type CodexClient = InstanceType<typeof UnifiedCodexAgentClient>;
 
-// 공개 connect()는 CODEX_USE_ACP 기본값(true)으로 항상 ACP 경로를 타므로,
-// 레거시 app-server config 스테이징 검증은 내부 connectAppServer 경로를 직접 구동한다.
+// 특정 app-server config 스테이징 검증은 전송 선택과 분리하기 위해
+// 내부 connectAppServer 경로를 직접 구동한다.
 // (소스 동작은 변경하지 않는 테스트 전용 우회 — element access로 private 메서드 호출)
 async function connectAppServer(
   client: CodexClient,
@@ -132,13 +132,13 @@ describe('UnifiedCodexAgentClient config staging', () => {
     restoreEnvironmentVariable('CODEX_CONFIG', originalCodexConfig);
   });
 
-  it('CODEX_USE_ACP 미설정 시 ACP로 연결한다', async () => {
+  it('CODEX_USE_ACP 미설정 시 App Server로 연결한다', async () => {
     const client = new UnifiedCodexAgentClient();
 
     await client.connect({ cwd: '/workspace', cli: 'codex' });
 
-    expect(AcpConnection).toHaveBeenCalledTimes(1);
-    expect(CodexAppServerConnection).not.toHaveBeenCalled();
+    expect(CodexAppServerConnection).toHaveBeenCalledTimes(1);
+    expect(AcpConnection).not.toHaveBeenCalled();
   });
 
   it("options.env CODEX_USE_ACP='false'는 App Server로 연결한다", async () => {
@@ -180,7 +180,36 @@ describe('UnifiedCodexAgentClient config staging', () => {
     expect(CodexAppServerConnection).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['false', false],
+    ['0', false],
+    ['true', true],
+    ['yes', true],
+  ] as const)('process.env CODEX_USE_ACP=%s 선택을 적용한다', async (value, usesAcp) => {
+    process.env.CODEX_USE_ACP = value;
+    const client = new UnifiedCodexAgentClient();
+
+    await client.connect({ cwd: '/workspace', cli: 'codex' });
+
+    expect(AcpConnection).toHaveBeenCalledTimes(usesAcp ? 1 : 0);
+    expect(CodexAppServerConnection).toHaveBeenCalledTimes(usesAcp ? 0 : 1);
+  });
+
   it('options.env가 process.env CODEX_USE_ACP보다 우선한다', async () => {
+    process.env.CODEX_USE_ACP = 'true';
+    const client = new UnifiedCodexAgentClient();
+
+    await client.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+      env: { CODEX_USE_ACP: 'false' },
+    });
+
+    expect(CodexAppServerConnection).toHaveBeenCalledTimes(1);
+    expect(AcpConnection).not.toHaveBeenCalled();
+  });
+
+  it('options.env ACP 선택도 process.env App Server 선택보다 우선한다', async () => {
     process.env.CODEX_USE_ACP = 'false';
     const client = new UnifiedCodexAgentClient();
 
@@ -256,6 +285,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
       cwd: '/workspace',
       cli: 'codex',
       systemPrompt: '개발자 지침',
+      env: { CODEX_USE_ACP: 'true' },
     });
 
     const options = acpCtorOptions();
@@ -274,6 +304,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
       cli: 'codex',
       systemPrompt: '우선 지침',
       env: {
+        CODEX_USE_ACP: 'true',
         CODEX_CONFIG: JSON.stringify({ model: 'gpt-5.4', developer_instructions: '무시될 지침' }),
       },
     });
@@ -289,6 +320,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
     await client.connect({
       cwd: '/workspace',
       cli: 'codex',
+      env: { CODEX_USE_ACP: 'true' },
     });
 
     const options = acpCtorOptions();

--- a/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
+++ b/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
@@ -488,6 +488,29 @@ describe('UnifiedCodexAgentClient config staging', () => {
     expect(mockSetPendingEffort).toHaveBeenCalledTimes(1);
   });
 
+  it('App Server 연결 effort는 첫 sendMessage에서 한 번만 적용한다', async () => {
+    const client = new UnifiedCodexAgentClient();
+
+    await client.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+      effort: 'high',
+    });
+    await client.sendMessage('첫 요청');
+
+    expect(mockSetPendingEffort).toHaveBeenCalledWith('high');
+    expect(mockCodexSendMessage).toHaveBeenCalledWith([
+      { type: 'text', text: '첫 요청', text_elements: [] },
+    ]);
+
+    await client.sendMessage('두 번째 요청');
+
+    expect(mockSetPendingEffort).toHaveBeenCalledTimes(1);
+    expect(mockCodexSendMessage).toHaveBeenNthCalledWith(2, [
+      { type: 'text', text: '두 번째 요청', text_elements: [] },
+    ]);
+  });
+
   it('setMode는 Codex pending mode로 저장되고 즉시 ACP 호출하지 않는다', async () => {
     const client = new UnifiedCodexAgentClient();
     await connectAppServer(client, {

--- a/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
+++ b/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
@@ -21,22 +21,30 @@ const originalCodexUseAcp = process.env.CODEX_USE_ACP;
 const originalCodexConfig = process.env.CODEX_CONFIG;
 
 function createMockCodexConnection(): EventEmitter & Record<string, unknown> {
-  const emitter = new EventEmitter();
-  Object.assign(emitter, {
-    connect: mockCodexConnect,
+  const connection = new EventEmitter() as EventEmitter & Record<string, unknown>;
+  Object.assign(connection, {
+    connect: async (...args: unknown[]) => {
+      const result = await mockCodexConnect(...args);
+      connection.sessionId = result.thread.id;
+      return result;
+    },
     disconnect: mockCodexDisconnect,
     endSession: mockCodexEndSession,
     resetSession: mockCodexResetSession,
-    loadSession: mockCodexLoadSession,
+    loadSession: async (...args: unknown[]) => {
+      const result = await mockCodexLoadSession(...args);
+      connection.sessionId = result.thread.id;
+      return result;
+    },
     sendMessage: mockCodexSendMessage,
     cancelPrompt: mockCodexCancelPrompt,
     setPendingModel: mockSetPendingModel,
     setPendingEffort: mockSetPendingEffort,
     removeAllListeners: mockRemoveAllListeners,
     connectionState: 'ready',
-    sessionId: 'codex-thread-1',
+    sessionId: null,
   });
-  return emitter as EventEmitter & Record<string, unknown>;
+  return connection;
 }
 
 // ACP 경로용 mock 연결. instanceof AcpConnection이 true가 되도록 prototype을 상속시키고,
@@ -87,11 +95,11 @@ type CodexClient = InstanceType<typeof UnifiedCodexAgentClient>;
 // 특정 app-server config 스테이징 검증은 전송 선택과 분리하기 위해
 // 내부 connectAppServer 경로를 직접 구동한다.
 // (소스 동작은 변경하지 않는 테스트 전용 우회 — element access로 private 메서드 호출)
-async function connectAppServer(
+function connectAppServer(
   client: CodexClient,
   options: Parameters<CodexClient['connect']>[0],
-): Promise<void> {
-  await client['connectAppServer'](options);
+): ReturnType<CodexClient['connect']> {
+  return client['connectAppServer'](options);
 }
 
 // ACP 연결 생성자에 전달된 첫 호출 인자(env/args)를 추출한다.
@@ -135,10 +143,28 @@ describe('UnifiedCodexAgentClient config staging', () => {
   it('CODEX_USE_ACP 미설정 시 App Server로 연결한다', async () => {
     const client = new UnifiedCodexAgentClient();
 
-    await client.connect({ cwd: '/workspace', cli: 'codex' });
+    const result = await client.connect({ cwd: '/workspace', cli: 'codex' });
 
     expect(CodexAppServerConnection).toHaveBeenCalledTimes(1);
     expect(AcpConnection).not.toHaveBeenCalled();
+    expect(result.session).toEqual({ sessionId: 'codex-thread-1' });
+  });
+
+  it('App Server가 세션 ID 없이 연결되면 연결을 정리하고 실패한다', async () => {
+    mockCodexConnect.mockResolvedValue({ thread: { id: '' } });
+    const client = new UnifiedCodexAgentClient();
+
+    await expect(client.connect({ cwd: '/workspace', cli: 'codex' })).rejects.toThrow(
+      '[codex] App Server 연결에서 유효한 세션 ID를 받지 못했습니다.',
+    );
+
+    expect(mockCodexDisconnect).toHaveBeenCalledTimes(1);
+    expect(client.getConnectionInfo()).toEqual({
+      cli: null,
+      protocol: null,
+      sessionId: null,
+      state: 'disconnected',
+    });
   });
 
   it("options.env CODEX_USE_ACP='false'는 App Server로 연결한다", async () => {
@@ -415,7 +441,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
   it('codex session resume은 thread/resume에 정책과 systemPrompt를 재전달한다', async () => {
     const client = new UnifiedCodexAgentClient();
 
-    await connectAppServer(client, {
+    const result = await connectAppServer(client, {
       cwd: '/workspace',
       cli: 'codex',
       sessionId: 'codex-thread-existing',
@@ -435,6 +461,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
       developerInstructions: '재개 지침',
       config: undefined,
     });
+    expect(result.session).toEqual({ sessionId: 'codex-thread-9' });
     expect(client.getCurrentSystemPrompt()).toBe('재개 지침');
   });
 

--- a/runtime/fleet-plugins/terminal/server/settings-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/settings-routes.ts
@@ -58,7 +58,7 @@ export function registerTerminalSettingsRoutes(ctx: FleetPluginServerContext, de
 export function toTerminalSettingsState(data: GlobalOptionsData): TerminalSettingsState {
   return {
     enableMetaphor: data.enableMetaphor ?? false,
-    codexLaunchMode: data.codexLaunchMode ?? "acp",
+    codexLaunchMode: data.codexLaunchMode ?? "app-server",
   };
 }
 

--- a/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
@@ -19,13 +19,22 @@ interface HarnessOptions {
 }
 
 describe("terminal settings routes", () => {
-  it("GET /plugins/terminal/settings returns the default ACP Codex launch mode", async () => {
+  it("GET /plugins/terminal/settings returns the default App Server Codex launch mode", async () => {
     const harness = createRouteHarness({
       data: { version: 1, enableMetaphor: false },
     });
     await harness.handle({ req: req("GET"), res: res(), pathname: "/plugins/terminal/settings" });
-    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "acp" } }]);
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "app-server" } }]);
     expect(harness.writes[0]?.body).not.toHaveProperty("consolePortMode");
+  });
+
+  it("GET /plugins/terminal/settings preserves the persisted ACP Codex launch mode", async () => {
+    const harness = createRouteHarness({
+      data: { version: 1, enableMetaphor: false, codexLaunchMode: "acp" },
+    });
+    await harness.handle({ req: req("GET"), res: res(), pathname: "/plugins/terminal/settings" });
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "acp" } }]);
+    expect(harness.currentData()).toEqual({ version: 1, enableMetaphor: false, codexLaunchMode: "acp" });
   });
 
   it("PUT /plugins/terminal/settings updates enableMetaphor in global options", async () => {
@@ -46,6 +55,16 @@ describe("terminal settings routes", () => {
     await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
     expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "app-server" } }]);
     expect(harness.currentData()).toEqual({ version: 1, enableMetaphor: false, codexLaunchMode: "app-server" });
+  });
+
+  it("PUT /plugins/terminal/settings updates the Codex launch mode to ACP in global options", async () => {
+    const harness = createRouteHarness({
+      body: { codexLaunchMode: "acp" },
+      data: { version: 1, enableMetaphor: false, codexLaunchMode: "app-server" },
+    });
+    await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "acp" } }]);
+    expect(harness.currentData()).toEqual({ version: 1, enableMetaphor: false, codexLaunchMode: "acp" });
   });
 
   it("PUT /plugins/terminal/settings rejects non-boolean payloads", async () => {


### PR DESCRIPTION
## Summary
- default Codex transport selection to App Server when no override is configured
- align Fleet Console Settings > Agent CLI with the App Server default
- preserve explicit ACP selection and environment precedence with regression coverage

## Test Plan
- [x] core-unified-agent targeted unit and contract E2E tests
- [x] terminal settings route tests and typecheck
- [x] dependency-aware Fleet Console build
- [x] headed isolated Console E2E confirms App Server is selected
- [x] add and validate `.changelog.d/pr-247.md` with bilingual summaries