### PR TITLE
fix(terminal): preserve scroll intent across resize

### DIFF
--- a/.changelog.d/pr-248.md
+++ b/.changelog.d/pr-248.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] Preserve terminal scroll intent when streaming status panels or other layout changes resize the terminal.
+  ko: 스트리밍 상태 패널이나 다른 레이아웃 변경으로 터미널 크기가 바뀌어도 사용자의 스크롤 위치를 보존합니다.

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-scroll-follow.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-scroll-follow.ts
@@ -1,0 +1,105 @@
+export interface TerminalViewportPosition {
+  readonly baseY: number;
+  readonly viewportY: number;
+}
+
+export interface TerminalScrollFollowController {
+  readonly isFollowing: () => boolean;
+  readonly recordUserViewportChange: () => void;
+  readonly recordUnclassifiedViewportChange: () => void;
+  readonly resumeFollowing: () => void;
+  readonly preserveAfterGeometryChange: (change: () => void) => void;
+  readonly restoreAfterOutputParsing: () => void;
+  readonly dispose: () => void;
+}
+
+interface TerminalScrollFollowOptions {
+  readonly getViewport: () => TerminalViewportPosition;
+  readonly scrollToBottom: () => void;
+  readonly scrollToLine: (line: number) => void;
+  readonly requestFrame: (callback: FrameRequestCallback) => number;
+  readonly cancelFrame: (handle: number) => void;
+}
+
+export function isTerminalViewportAtBottom({ baseY, viewportY }: TerminalViewportPosition): boolean {
+  return viewportY >= baseY;
+}
+
+// xterm emits the same onScroll event for user gestures, layout, and programmatic restores.
+// Callers ignore unclassified events and record intent after an explicit DOM gesture settles.
+export function createTerminalScrollFollow(options: TerminalScrollFollowOptions): TerminalScrollFollowController {
+  let following = true;
+  let manualBottomDistance: number | null = null;
+  let frame: number | null = null;
+
+  const rememberManualAnchor = () => {
+    const { baseY, viewportY } = options.getViewport();
+    manualBottomDistance = Math.max(0, baseY - viewportY);
+  };
+
+  const restoreManualAnchor = () => {
+    if (manualBottomDistance === null) return;
+    const { baseY } = options.getViewport();
+    options.scrollToLine(Math.max(0, Math.min(baseY, baseY - manualBottomDistance)));
+  };
+
+  const restoreCurrentAnchor = () => {
+    if (following) {
+      options.scrollToBottom();
+      return;
+    }
+    restoreManualAnchor();
+  };
+
+  const scheduleFrameRestore = () => {
+    if (frame !== null) return;
+    frame = options.requestFrame(() => {
+      frame = null;
+      restoreCurrentAnchor();
+    });
+  };
+
+  const restoreIfFollowing = () => {
+    if (!following) return;
+    restoreCurrentAnchor();
+    scheduleFrameRestore();
+  };
+
+  return {
+    isFollowing: () => following,
+    recordUserViewportChange: () => {
+      following = isTerminalViewportAtBottom(options.getViewport());
+      if (following) {
+        manualBottomDistance = null;
+        return;
+      }
+      rememberManualAnchor();
+    },
+    // A geometry/layout onScroll has no user-intent meaning. In particular it may arrive before
+    // ResizeObserver's debounced fit and must not clear a previously followed terminal.
+    recordUnclassifiedViewportChange: () => undefined,
+    resumeFollowing: () => {
+      following = true;
+      manualBottomDistance = null;
+      restoreIfFollowing();
+    },
+    preserveAfterGeometryChange: (change) => {
+      change();
+      restoreCurrentAnchor();
+      scheduleFrameRestore();
+    },
+    restoreAfterOutputParsing: () => {
+      if (following) {
+        restoreIfFollowing();
+        return;
+      }
+      // Output shifts baseY while a manual viewport remains fixed. Update the distance after
+      // parsing without moving it so the next fit restores the same visible content.
+      if (!isTerminalViewportAtBottom(options.getViewport())) rememberManualAnchor();
+    },
+    dispose: () => {
+      if (frame !== null) options.cancelFrame(frame);
+      frame = null;
+    },
+  };
+}

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -10,6 +10,7 @@ import { createImeShiftEnterHandler } from "./ime-shift-enter.js";
 import { createTerminalConnection, type TerminalConnection } from "./terminal-connection.js";
 import { TERMINAL_OPTIONS } from "./terminal-options.js";
 import { useTerminalPrefs } from "./terminal-prefs-store.js";
+import { createTerminalScrollFollow, type TerminalScrollFollowController } from "./terminal-scroll-follow.js";
 import { waitForSymbolsNerdFontMono } from "./symbols-font.js";
 
 export interface TerminalSurfaceProps {
@@ -119,6 +120,7 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
   const connectionRef = useRef<TerminalConnection | null>(null);
   const webglAddonRef = useRef<WebglAddon | null>(null);
   const outputSchedulerRef = useRef<TerminalOutputScheduler | null>(null);
+  const scrollFollowRef = useRef<TerminalScrollFollowController | null>(null);
   // 줌 보정 effect에서 fit()을 재호출하기 위해 마운트 effect의 지역 FitAddon을 ref로 끌어올린다.
   const fitAddonRef = useRef<FitAddon | null>(null);
   // 실제 보정에 반영된 줌(=settle된 zoom). zoom prop은 보간 중 매 프레임 바뀌므로 디바운스로 이 값에 수렴시킨다.
@@ -174,14 +176,32 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
       imeEventTarget.addEventListener("focusout", imeHandler.onCompositionCancel);
       terminal.attachCustomKeyEventHandler(imeHandler.handleKeyEvent);
 
-      const outputScheduler = createTerminalOutputScheduler(terminal, activeRef.current !== false);
+      const scrollFollow = createTerminalScrollFollow({
+        getViewport: () => terminal.buffer.active,
+        scrollToBottom: () => scrollTerminalToBottom(terminal),
+        scrollToLine: (line) => scrollTerminalToLine(terminal, line),
+        requestFrame: (callback) => window.requestAnimationFrame(callback),
+        cancelFrame: (handle) => window.cancelAnimationFrame(handle),
+      });
+      scrollFollowRef.current = scrollFollow;
+      const scrollGesture = createTerminalScrollGestureTracker(
+        container,
+        imeEventTarget,
+        scrollFollow.recordUserViewportChange,
+      );
+      const outputScheduler = createTerminalOutputScheduler(terminal, activeRef.current !== false, scrollFollow.restoreAfterOutputParsing);
       outputSchedulerRef.current = outputScheduler;
       const connection = createTerminalConnection({
         operationId,
         ticketPath,
         wsPath,
         terminal: {
-          onData: (listener) => terminal.onData(listener),
+          onData: (listener) => terminal.onData((data) => {
+            // xterm's normal scrollOnUserInput behavior resumes follow for every local input,
+            // not only Enter. Keep the explicit follow state in lockstep with it.
+            scrollFollow.resumeFollowing();
+            listener(data);
+          }),
           write: outputScheduler.write,
         },
         onExit: () => onExitRef.current?.(),
@@ -191,13 +211,12 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
       });
       connectionRef.current = connection;
 
-      const fitAndResize = () => {
-        fitAddon.fit();
-        connection.resize(terminal.cols, terminal.rows);
-      };
       const fitResizeAndRefresh = () => {
-        fitAndResize();
-        terminal.refresh(0, terminal.rows - 1);
+        scrollFollow.preserveAfterGeometryChange(() => {
+          fitAddon.fit();
+          connection.resize(terminal.cols, terminal.rows);
+          terminal.refresh(0, terminal.rows - 1);
+        });
       };
       const scheduleFitAndResize = () => {
         if (resizeDebounce) clearTimeout(resizeDebounce);
@@ -231,10 +250,13 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
         imeEventTarget.removeEventListener("focusout", imeHandler.onCompositionCancel);
         imeHandler.dispose();
         connection.dispose();
+        scrollGesture.dispose();
         outputScheduler.dispose();
+        scrollFollow.dispose();
         terminalRef.current = null;
         connectionRef.current = null;
         outputSchedulerRef.current = null;
+        scrollFollowRef.current = null;
         fitAddonRef.current = null;
         // xterm WebglAddon(0.19.0)은 terminal.dispose() 시 AddonManager가 addon을 자동 정리하는
         // 경로에 내부 버그가 있어 TypeError(reading "_isDisposed")를 던질 수 있다. 이 예외가
@@ -262,15 +284,12 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
   }, [operationId, ticketPath, wsPath]);
 
   // 활성 전환 시(예: Map 검색으로 이동·확대된 직후) 이미 마운트된 xterm에 포커스를 다시 주고
-  // 스크롤백을 최신 출력으로 복귀시킨다. 비활성 전환에서는 scheduler 속도만 낮춘다.
+  // 기존 contract대로 bottom following을 명시적으로 재개한다. 비활성 전환에서는 scheduler 속도만 낮춘다.
   useEffect(() => {
     outputSchedulerRef.current?.setActive(active !== false);
     if (!active) return;
-    focusAndScrollTerminalToBottom(terminalRef.current);
-    const frame = window.requestAnimationFrame(() => {
-      if (activeRef.current === true) scrollTerminalToBottom(terminalRef.current);
-    });
-    return () => window.cancelAnimationFrame(frame);
+    terminalRef.current?.focus();
+    scrollFollowRef.current?.resumeFollowing();
   }, [active]);
 
   // Renderer changes only attach/detach the WebGL addon; the live terminal and websocket stay intact.
@@ -331,7 +350,7 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
     const terminal = terminalRef.current;
     if (!terminal) return;
     terminal.options.fontFamily = terminalFontSettings.family;
-    fitResizeAndRefreshTerminal(terminal, fitAddonRef.current, connectionRef.current);
+    fitResizeAndRefreshTerminal(terminal, fitAddonRef.current, connectionRef.current, scrollFollowRef.current);
   }, [terminalFontSettings.family, mountedTerminalEpoch]);
 
   // 줌 settle 감지: zoom prop은 rAF 보간 중 매 프레임 바뀌므로, 마지막 변경 후 ZOOM_SETTLE_MS가 지나야
@@ -358,7 +377,7 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
     // 바뀌면 xterm이 옵션 변경 핸들러(_handleOptionsChanged→_refreshCharAtlas→acquireTextureAtlas)에서 새
     // cell크기 키로 atlas를 자동 재획득하므로 수동 무효화는 불필요하다. atlas는 건드리지 않고 이 터미널만
     // fit + refresh로 재배치/재도색한다.
-    fitResizeAndRefreshTerminal(terminal, fitAddonRef.current, connectionRef.current);
+    fitResizeAndRefreshTerminal(terminal, fitAddonRef.current, connectionRef.current, scrollFollowRef.current);
   }, [appliedZoom, terminalFontSettings.size, mountedTerminalEpoch]);
 
   // 연결이 'live'면 상태 바를 숨겨 터미널 canvas가 카드를 가득 채우게 하고,
@@ -399,19 +418,95 @@ function terminalThemeFor(theme: "instrument" | "maritime" | "carbon"): ITheme {
   return INSTRUMENT_TERMINAL_THEME;
 }
 
-function focusAndScrollTerminalToBottom(terminal: XtermTerminal | null): void {
-  if (!terminal) return;
-  terminal.focus();
-  scrollTerminalToBottom(terminal);
-}
-
 function scrollTerminalToBottom(terminal: XtermTerminal | null): void {
   if (!terminal) return;
   terminal.scrollToBottom();
   if (terminal.rows > 0) terminal.refresh(0, terminal.rows - 1);
 }
 
-function createTerminalOutputScheduler(terminal: XtermTerminal, initiallyActive: boolean): TerminalOutputScheduler {
+function scrollTerminalToLine(terminal: XtermTerminal | null, line: number): void {
+  if (!terminal) return;
+  terminal.scrollToLine(line);
+  if (terminal.rows > 0) terminal.refresh(0, terminal.rows - 1);
+}
+
+interface TerminalScrollGestureTracker {
+  readonly dispose: () => void;
+}
+
+function createTerminalScrollGestureTracker(
+  container: HTMLElement,
+  keyboardTarget: HTMLElement,
+  recordUserViewportChange: () => void,
+): TerminalScrollGestureTracker {
+  const viewport = container.querySelector<HTMLElement>(".xterm-viewport");
+  if (!viewport) return { dispose: () => undefined };
+
+  let pointerScrolling = false;
+  let gestureFrame: number | null = null;
+
+  const scheduleUserViewportRecord = () => {
+    if (gestureFrame !== null) window.cancelAnimationFrame(gestureFrame);
+    // xterm synchronizes its DOM viewport on the frame after key/wheel handling. Read the public
+    // buffer position after that synchronization instead of trying to correlate onScroll timing.
+    gestureFrame = window.requestAnimationFrame(() => {
+      gestureFrame = window.requestAnimationFrame(() => {
+        gestureFrame = null;
+        recordUserViewportChange();
+      });
+    });
+  };
+  const onWheel = () => scheduleUserViewportRecord();
+  const onTouchStart = () => { pointerScrolling = true; };
+  const onPointerDown = (event: PointerEvent) => {
+    // Native scrollbar drags target the viewport itself; touch panning may target terminal content.
+    pointerScrolling = event.pointerType === "touch" || event.target === viewport;
+  };
+  const onViewportScroll = () => {
+    if (pointerScrolling) scheduleUserViewportRecord();
+  };
+  const onPointerEnd = () => {
+    const shouldRecord = pointerScrolling;
+    pointerScrolling = false;
+    if (shouldRecord) scheduleUserViewportRecord();
+  };
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (isTerminalScrollbackKey(event)) scheduleUserViewportRecord();
+  };
+
+  // Capture the gesture boundary before xterm's viewport handlers; the tracker records the
+  // resulting public viewport after xterm has synchronized it, never from raw onScroll timing.
+  viewport.addEventListener("wheel", onWheel, { capture: true, passive: true });
+  viewport.addEventListener("touchstart", onTouchStart, { capture: true, passive: true });
+  viewport.addEventListener("touchend", onPointerEnd);
+  viewport.addEventListener("touchcancel", onPointerEnd);
+  viewport.addEventListener("pointerdown", onPointerDown, true);
+  viewport.addEventListener("scroll", onViewportScroll);
+  window.addEventListener("pointerup", onPointerEnd);
+  window.addEventListener("pointercancel", onPointerEnd);
+  keyboardTarget.addEventListener("keydown", onKeyDown, true);
+
+  return {
+    dispose: () => {
+      viewport.removeEventListener("wheel", onWheel, true);
+      viewport.removeEventListener("touchstart", onTouchStart, true);
+      viewport.removeEventListener("touchend", onPointerEnd);
+      viewport.removeEventListener("touchcancel", onPointerEnd);
+      viewport.removeEventListener("pointerdown", onPointerDown, true);
+      viewport.removeEventListener("scroll", onViewportScroll);
+      window.removeEventListener("pointerup", onPointerEnd);
+      window.removeEventListener("pointercancel", onPointerEnd);
+      keyboardTarget.removeEventListener("keydown", onKeyDown, true);
+      if (gestureFrame !== null) window.cancelAnimationFrame(gestureFrame);
+    },
+  };
+}
+
+function isTerminalScrollbackKey(event: KeyboardEvent): boolean {
+  return event.key === "PageUp" || event.key === "PageDown" || event.key === "Home" || event.key === "End";
+}
+
+function createTerminalOutputScheduler(terminal: XtermTerminal, initiallyActive: boolean, afterOutputParsing: () => void): TerminalOutputScheduler {
   let active = initiallyActive;
   let disposed = false;
   let flushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -430,7 +525,9 @@ function createTerminalOutputScheduler(terminal: XtermTerminal, initiallyActive:
     const output = concatTerminalOutput(pending, pendingBytes);
     pending = [];
     pendingBytes = 0;
-    terminal.write(output);
+    terminal.write(output, () => {
+      if (!disposed) afterOutputParsing();
+    });
   };
 
   const scheduleFlush = () => {
@@ -480,8 +577,20 @@ function concatTerminalOutput(chunks: readonly Uint8Array[], totalBytes: number)
   return output;
 }
 
-function fitResizeAndRefreshTerminal(terminal: XtermTerminal, fitAddon: FitAddon | null, connection: TerminalConnection | null): void {
-  fitAddon?.fit();
-  connection?.resize(terminal.cols, terminal.rows);
-  terminal.refresh(0, terminal.rows - 1);
+function fitResizeAndRefreshTerminal(
+  terminal: XtermTerminal,
+  fitAddon: FitAddon | null,
+  connection: TerminalConnection | null,
+  scrollFollow: TerminalScrollFollowController | null,
+): void {
+  const fitResizeAndRefresh = () => {
+    fitAddon?.fit();
+    connection?.resize(terminal.cols, terminal.rows);
+    terminal.refresh(0, terminal.rows - 1);
+  };
+  if (scrollFollow) {
+    scrollFollow.preserveAfterGeometryChange(fitResizeAndRefresh);
+    return;
+  }
+  fitResizeAndRefresh();
 }

--- a/runtime/fleet-plugins/terminal/tests/terminal-scroll-follow.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-scroll-follow.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createTerminalScrollFollow,
+  isTerminalViewportAtBottom,
+  type TerminalViewportPosition,
+} from "../client/shared/terminal-scroll-follow.js";
+
+describe("terminal scroll follow", () => {
+  it("recognizes the bottom in normal and alternate buffers through their public viewport positions", () => {
+    expect(isTerminalViewportAtBottom({ baseY: 280, viewportY: 280 })).toBe(true);
+    expect(isTerminalViewportAtBottom({ baseY: 280, viewportY: 278 })).toBe(false);
+    expect(isTerminalViewportAtBottom({ baseY: 0, viewportY: 0 })).toBe(true);
+  });
+
+  it("only lets explicit user scroll gestures change follow intent", () => {
+    const harness = createHarness({ baseY: 280, viewportY: 280 });
+    harness.viewport = { baseY: 280, viewportY: 260 };
+    harness.controller.recordUnclassifiedViewportChange();
+    expect(harness.controller.isFollowing()).toBe(true);
+
+    harness.controller.recordUserViewportChange();
+    expect(harness.controller.isFollowing()).toBe(false);
+
+    harness.viewport = { baseY: 280, viewportY: 280 };
+    harness.controller.recordUserViewportChange();
+    expect(harness.controller.isFollowing()).toBe(true);
+  });
+
+  it("keeps follow through an unclassified clamp before the debounced geometry fit", () => {
+    const harness = createHarness({ baseY: 280, viewportY: 280 });
+
+    // Exact regression ordering: dock removal clamps before ResizeObserver reaches fit().
+    harness.viewport = { baseY: 280, viewportY: 278 };
+    harness.controller.recordUnclassifiedViewportChange();
+    expect(harness.controller.isFollowing()).toBe(true);
+
+    harness.controller.preserveAfterGeometryChange(() => undefined);
+    expect(harness.scrolls).toBe(1);
+    harness.runFrame();
+    expect(harness.scrolls).toBe(2);
+  });
+
+  it("pins a followed terminal through row shrink, row growth, and output parsing", () => {
+    const harness = createHarness({ baseY: 280, viewportY: 280 });
+
+    harness.controller.preserveAfterGeometryChange(() => {
+      harness.viewport = { baseY: 282, viewportY: 282 };
+      harness.controller.recordUnclassifiedViewportChange();
+    });
+    expect(harness.controller.isFollowing()).toBe(true);
+    expect(harness.scrolls).toBe(1);
+
+    harness.runFrame();
+    expect(harness.scrolls).toBe(2);
+
+    harness.controller.preserveAfterGeometryChange(() => {
+      // A dock disappearing grows the viewport and can leave xterm two rows above baseY.
+      harness.viewport = { baseY: 280, viewportY: 278 };
+      harness.controller.recordUnclassifiedViewportChange();
+    });
+    expect(harness.controller.isFollowing()).toBe(true);
+    expect(harness.scrolls).toBe(3);
+    harness.runFrame();
+    expect(harness.scrolls).toBe(4);
+
+    harness.controller.restoreAfterOutputParsing();
+    expect(harness.scrolls).toBe(5);
+    harness.runFrame();
+    expect(harness.scrolls).toBe(6);
+  });
+
+  it("restores a manual anchor after an unclassified clamp and row shrink", () => {
+    const harness = createHarness({ baseY: 280, viewportY: 240 });
+    harness.controller.recordUserViewportChange();
+
+    // The browser clamps before the delayed fit; this must not replace the saved 40-row anchor.
+    harness.viewport = { baseY: 280, viewportY: 280 };
+    harness.controller.recordUnclassifiedViewportChange();
+    harness.controller.preserveAfterGeometryChange(() => {
+      harness.viewport = { baseY: 282, viewportY: 282 };
+      harness.controller.recordUnclassifiedViewportChange();
+    });
+    expect(harness.scrolls).toBe(0);
+    expect(harness.lines).toEqual([242]);
+    harness.runFrame();
+
+    expect(harness.controller.isFollowing()).toBe(false);
+    expect(harness.scrolls).toBe(0);
+    expect(harness.lines).toEqual([242, 242]);
+  });
+
+  it("restores a manual anchor after an unclassified clamp and row growth", () => {
+    const harness = createHarness({ baseY: 282, viewportY: 242 });
+    harness.controller.recordUserViewportChange();
+
+    harness.viewport = { baseY: 282, viewportY: 282 };
+    harness.controller.recordUnclassifiedViewportChange();
+    harness.controller.preserveAfterGeometryChange(() => {
+      harness.viewport = { baseY: 280, viewportY: 280 };
+      harness.controller.recordUnclassifiedViewportChange();
+    });
+    expect(harness.scrolls).toBe(0);
+    expect(harness.lines).toEqual([240]);
+    harness.runFrame();
+
+    expect(harness.lines).toEqual([240, 240]);
+  });
+
+  it("updates the manual anchor after parsed output without scrolling", () => {
+    const harness = createHarness({ baseY: 280, viewportY: 240 });
+    harness.controller.recordUserViewportChange();
+
+    // Appended output leaves viewportY fixed but increases the bottom distance from 40 to 45.
+    harness.viewport = { baseY: 285, viewportY: 240 };
+    harness.controller.restoreAfterOutputParsing();
+    expect(harness.scrolls).toBe(0);
+    expect(harness.lines).toEqual([]);
+
+    harness.controller.preserveAfterGeometryChange(() => {
+      harness.viewport = { baseY: 280, viewportY: 280 };
+    });
+    expect(harness.lines).toEqual([235]);
+    harness.runFrame();
+    expect(harness.lines).toEqual([235, 235]);
+  });
+
+  it("resumes follow for every local input and for active-panel re-entry", () => {
+    const harness = createHarness({ baseY: 280, viewportY: 260 });
+    harness.controller.recordUserViewportChange();
+
+    harness.controller.resumeFollowing();
+    expect(harness.controller.isFollowing()).toBe(true);
+    expect(harness.scrolls).toBe(1);
+    harness.runFrame();
+    expect(harness.scrolls).toBe(2);
+  });
+});
+
+function createHarness(initialViewport: TerminalViewportPosition) {
+  let frame: FrameRequestCallback | null = null;
+  const harness = {
+    viewport: initialViewport,
+    scrolls: 0,
+    lines: [] as number[],
+    controller: undefined as ReturnType<typeof createTerminalScrollFollow> | undefined,
+    runFrame: () => {
+      const callback = frame;
+      frame = null;
+      callback?.(0);
+    },
+  };
+  harness.controller = createTerminalScrollFollow({
+    getViewport: () => harness.viewport,
+    scrollToBottom: () => { harness.scrolls += 1; },
+    scrollToLine: (line) => { harness.lines.push(line); },
+    requestFrame: (callback) => {
+      frame = callback;
+      return 1;
+    },
+    cancelFrame: () => { frame = null; },
+  });
+  return harness as typeof harness & { readonly controller: ReturnType<typeof createTerminalScrollFollow> };
+}


### PR DESCRIPTION
## Summary
- Preserve terminal follow intent when streaming UI or other geometry changes resize xterm.
- Keep intentional manual scrollback anchored while background output continues.
- Restore bottom following after local input or active-panel re-entry.

## Type of Change
- [x] fix — bug fix

## Scope
- [x] `runtime/fleet-plugins/terminal`

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal test` — 148 passed
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Headed Console E2E: followed and manual scroll positions survive repeated 38 px shrink/grow cycles
- [x] Headed Console E2E: background output preserves manual scrollback and local input resumes bottom following

## Changelog
- [x] Added `.changelog.d/pr-248.md`
- [x] Grouped `fleet-plugin / Fixed` fragment with adjacent English and Korean summaries
- [x] `node scripts/compile-changelog-fragments.mjs --check`

## Notes
- Automated Codex review is intentionally skipped per maintainer instruction; required checks and branch protection remain enforced.