### PR TITLE
fix(carriers): submit tier two instructions with prompts

### DIFF
--- a/.changelog.d/pr-247.md
+++ b/.changelog.d/pr-247.md
@@ -1,6 +1,6 @@
 ### fleet-plugin
 #### Changed
-- [fleet-plugin] Default new Codex Agent CLI settings to App Server while preserving explicit ACP selections.
+- [fleet-console] Default new Codex Agent CLI settings to App Server while preserving explicit ACP selections.
   ko: 새 Codex Agent CLI 설정의 기본값을 App Server로 지정하며 명시적인 ACP 선택은 유지합니다.
 
 ### fleet-core

--- a/.changelog.d/pr-247.md
+++ b/.changelog.d/pr-247.md
@@ -1,0 +1,9 @@
+### fleet-plugin
+#### Changed
+- [fleet-plugin] Default new Codex Agent CLI settings to App Server while preserving explicit ACP selections.
+  ko: 새 Codex Agent CLI 설정의 기본값을 App Server로 지정하며 명시적인 ACP 선택은 유지합니다.
+
+### fleet-core
+#### Changed
+- [core-unified-agent] Use App Server for Codex connections when no launch-mode override is configured.
+  ko: 시작 모드 재정의가 없으면 Codex 연결에 App Server를 사용합니다.

--- a/.changelog.d/pr-247.md
+++ b/.changelog.d/pr-247.md
@@ -1,9 +1,0 @@
-### fleet-plugin
-#### Changed
-- [fleet-console] Default new Codex Agent CLI settings to App Server while preserving explicit ACP selections.
-  ko: 새 Codex Agent CLI 설정의 기본값을 App Server로 지정하며 명시적인 ACP 선택은 유지합니다.
-
-### fleet-core
-#### Changed
-- [core-unified-agent] Use App Server for Codex connections when no launch-mode override is configured.
-  ko: 시작 모드 재정의가 없으면 Codex 연결에 App Server를 사용합니다.

--- a/.changelog.d/pr-249.md
+++ b/.changelog.d/pr-249.md
@@ -1,0 +1,11 @@
+### fleet-plugin
+#### Changed
+- [fleet-console] Default new Codex Agent CLI settings to App Server while preserving explicit ACP selections.
+  ko: 새 Codex Agent CLI 설정의 기본값을 App Server로 지정하며 명시적인 ACP 선택은 유지합니다.
+
+### fleet-core
+#### Changed
+- [core-unified-agent] Use App Server for Codex connections when no launch-mode override is configured.
+  ko: 시작 모드 재정의가 없으면 Codex 연결에 App Server를 사용합니다.
+- [core-unified-agent] Deliver Claude and Codex Carrier instructions with the submitted prompt and require Kirov dispatches to name and produce their plan file.
+  ko: Claude와 Codex의 Carrier 지침을 제출 프롬프트에 함께 전달하고 Kirov 디스패치가 플랜 파일을 지정하고 생성하도록 요구합니다.

--- a/packages/core-unified-agent/README.md
+++ b/packages/core-unified-agent/README.md
@@ -219,7 +219,7 @@ const result = await client.connect({
 });
 ```
 
-For Codex, `systemPrompt` is passed to the native app-server as `developerInstructions` during thread creation rather than being prefixed onto the first user turn.
+For Claude and Codex, `systemPrompt` is prepended once to the first user turn of a fresh session. It is not sent through provider system/developer-instruction channels, is not repeated on later turns, and is not injected when connecting to an existing session.
 
 #### `sendMessage(content: string | AcpContentBlock[]): Promise<PromptResponse>`
 

--- a/packages/core-unified-agent/src/client/IUnifiedAgentClient.ts
+++ b/packages/core-unified-agent/src/client/IUnifiedAgentClient.ts
@@ -178,7 +178,7 @@ export interface IUnifiedAgentClient {
   /**
    * CLI에 연결합니다.
    *
-   * @param options - 연결 옵션. `options.effort`는 Claude 구현에서만 connect 시점 `_meta`로 사용됩니다.
+   * @param options - 연결 옵션. provider별 연결·첫 프롬프트 설정을 포함합니다.
    * @returns 연결 결과
    */
   connect(options: UnifiedClientOptions): Promise<ConnectResult>;

--- a/packages/core-unified-agent/src/client/UnifiedClaudeAgentClient.ts
+++ b/packages/core-unified-agent/src/client/UnifiedClaudeAgentClient.ts
@@ -50,6 +50,7 @@ export class UnifiedClaudeAgentClient extends EventEmitter implements IUnifiedAg
   private sessionId: string | null = null;
   private sessionCwd: string | null = null;
   private currentSystemPrompt: string | null = null;
+  private firstPromptPending: string | null = null;
   private currentEffort: string | null = null;
   private detector = new CliDetector();
   private readonly cliType: CliType & 'claude';
@@ -151,7 +152,7 @@ export class UnifiedClaudeAgentClient extends EventEmitter implements IUnifiedAg
         options.cwd,
         options.sessionId,
         acpMcpServers,
-        options.systemPrompt,
+        undefined,
         options.strictMcp,
         options.effort,
       );
@@ -214,7 +215,20 @@ export class UnifiedClaudeAgentClient extends EventEmitter implements IUnifiedAg
       throw new Error('연결되어 있지 않습니다');
     }
 
-    return this.connection.sendPrompt(this.sessionId, content);
+    const systemPrompt = this.firstPromptPending;
+    if (!systemPrompt) {
+      return this.connection.sendPrompt(this.sessionId, content);
+    }
+
+    const userBlocks: AcpContentBlock[] = typeof content === 'string'
+      ? [{ type: 'text', text: content }]
+      : content;
+    const response = await this.connection.sendPrompt(this.sessionId, [
+      { type: 'text', text: systemPrompt },
+      ...userBlocks,
+    ]);
+    this.firstPromptPending = null;
+    return response;
   }
 
   async cancelPrompt(): Promise<void> {
@@ -282,6 +296,7 @@ export class UnifiedClaudeAgentClient extends EventEmitter implements IUnifiedAg
     }, this.currentEffort ?? undefined);
     this.sessionId = sessionId;
     this.currentSystemPrompt = null;
+    this.firstPromptPending = null;
   }
 
   async resetSession(cwd?: string): Promise<ConnectResult> {
@@ -297,26 +312,18 @@ export class UnifiedClaudeAgentClient extends EventEmitter implements IUnifiedAg
     await this.connection.endSession(this.sessionId);
     this.sessionId = null;
 
-    const session = this.currentSystemPrompt
-      ? await this.connection.reconnectSession(
-          targetCwd,
-          undefined,
-          undefined,
-          this.currentSystemPrompt,
-          undefined,
-          this.currentEffort ?? undefined,
-        )
-      : await this.connection.reconnectSession(
-          targetCwd,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          this.currentEffort ?? undefined,
-        );
+    const session = await this.connection.reconnectSession(
+      targetCwd,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      this.currentEffort ?? undefined,
+    );
 
     this.sessionId = session.sessionId;
     this.sessionCwd = targetCwd;
+    this.firstPromptPending = this.currentSystemPrompt;
 
     return {
       cli: this.cliType,
@@ -352,6 +359,7 @@ export class UnifiedClaudeAgentClient extends EventEmitter implements IUnifiedAg
     this.sessionId = session.sessionId;
     this.sessionCwd = options.cwd;
     this.currentSystemPrompt = options.systemPrompt ?? null;
+    this.firstPromptPending = options.sessionId ? null : this.currentSystemPrompt;
     this.currentEffort = options.effort ?? null;
 
     return {
@@ -365,6 +373,7 @@ export class UnifiedClaudeAgentClient extends EventEmitter implements IUnifiedAg
     this.sessionId = null;
     this.sessionCwd = null;
     this.currentSystemPrompt = null;
+    this.firstPromptPending = null;
     this.currentEffort = null;
   }
 

--- a/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
+++ b/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
@@ -194,7 +194,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     this.sessionCwd = options.cwd;
     this.currentSystemPrompt = developerInstructions;
     this.pendingOverrides = {
-      turnConfig: {},
+      turnConfig: options.effort ? { effort: options.effort } : {},
       threadConfig: {
         approvalPolicy: modeMapping.approvalPolicy,
         sandbox: modeMapping.sandbox,

--- a/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
+++ b/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
@@ -887,9 +887,9 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
   }
 }
 
-// 호출별 환경변수로 Codex 전송 경로를 선택하며, 미설정은 ACP로 유지한다.
+// 호출별 환경변수로 Codex 전송 경로를 선택하며, 미설정은 App Server를 사용한다.
 function shouldUseCodexAcp(options: UnifiedClientOptions): boolean {
   const value = options.env?.CODEX_USE_ACP ?? process.env.CODEX_USE_ACP;
   const normalized = value?.trim().toLowerCase();
-  return normalized !== 'false' && normalized !== '0';
+  return normalized !== undefined && normalized !== 'false' && normalized !== '0';
 }

--- a/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
+++ b/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
@@ -88,6 +88,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
   private sessionId: string | null = null;
   private sessionCwd: string | null = null;
   private currentSystemPrompt: string | null = null;
+  private firstPromptPending: string | null = null;
   private pendingOverrides: CodexPendingOverrides | null = null;
   private detector = new CliDetector();
 
@@ -138,7 +139,6 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     const cleanEnv = cleanEnvironment(process.env, options.env);
     const command = options.cliPath ?? backend.cliCommand;
     const baseArgs = backend.appServerArgs ?? ['app-server', '--listen', 'stdio://'];
-    const developerInstructions = options.systemPrompt ?? null;
     const modeMapping = this.resolveMode(options.yoloMode === false ? 'default' : 'yolo');
     const args = [
       ...baseArgs,
@@ -171,13 +171,13 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
         this.buildCodexThreadDefaultsForResume(
           options.cwd,
           options.model,
-          developerInstructions,
+          null,
           modeMapping,
         ),
       );
     } else {
       await connection.connect({
-        developerInstructions: developerInstructions ?? undefined,
+        developerInstructions: undefined,
         model: options.model,
         approvalPolicy: modeMapping.approvalPolicy,
         sandbox: modeMapping.sandbox,
@@ -192,7 +192,8 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
 
     this.sessionId = sessionId;
     this.sessionCwd = options.cwd;
-    this.currentSystemPrompt = developerInstructions;
+    this.currentSystemPrompt = options.systemPrompt ?? null;
+    this.firstPromptPending = options.sessionId ? null : this.currentSystemPrompt;
     this.pendingOverrides = {
       turnConfig: options.effort ? { effort: options.effort } : {},
       threadConfig: {
@@ -211,10 +212,9 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
   private async connectAcp(options: UnifiedClientOptions): Promise<ConnectResult> {
     const cleanEnv = cleanEnvironment(process.env, options.env);
     const spawnConfig = createSpawnConfig('codex', options);
-    // codex-acp 브릿지는 argv를 무시하므로 systemPrompt/configOverrides는 CODEX_CONFIG env로 주입한다.
+    // codex-acp 브릿지는 argv를 무시하므로 configOverrides는 CODEX_CONFIG env로 주입한다.
     // 브릿지가 thread/start·thread/resume config에 spread하며, 모든 플랫폼 단일 경로로 동작한다.
     const codexConfigEnv = buildCodexConfigEnv(
-      options.systemPrompt,
       options.configOverrides,
       cleanEnv.CODEX_CONFIG as string | undefined,
     );
@@ -334,9 +334,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
       if (!this.sessionId) {
         throw new Error('연결되어 있지 않습니다');
       }
-      // systemPrompt는 connect 시점 CODEX_CONFIG env로 이미 주입되어 프로세스 전체에 상주하므로
-      // 프롬프트에 prepend하지 않는다.
-      return this.connection.sendPrompt(this.sessionId, content);
+      return this.sendPromptWithPendingSystemPrompt(content);
     }
 
     this.applyPendingOverrides();
@@ -345,8 +343,38 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
       : content.map((block) => ('text' in block
         ? { type: 'text' as const, text: block.text, text_elements: [] }
         : { type: 'text' as const, text: JSON.stringify(block), text_elements: [] }));
-    await this.connection.sendMessage(input);
+    const systemPrompt = this.firstPromptPending;
+    const prompt = systemPrompt
+      ? [{ type: 'text' as const, text: systemPrompt, text_elements: [] }, ...input]
+      : input;
+    await this.connection.sendMessage(prompt);
+    if (systemPrompt) {
+      this.firstPromptPending = null;
+    }
     return { stopReason: 'end_turn' } as PromptResponse;
+  }
+
+  private async sendPromptWithPendingSystemPrompt(
+    content: string | AcpContentBlock[],
+  ): Promise<PromptResponse> {
+    if (!(this.connection instanceof AcpConnection) || !this.sessionId) {
+      throw new Error('연결되어 있지 않습니다');
+    }
+
+    const systemPrompt = this.firstPromptPending;
+    if (!systemPrompt) {
+      return this.connection.sendPrompt(this.sessionId, content);
+    }
+
+    const userBlocks: AcpContentBlock[] = typeof content === 'string'
+      ? [{ type: 'text', text: content }]
+      : content;
+    const response = await this.connection.sendPrompt(this.sessionId, [
+      { type: 'text', text: systemPrompt },
+      ...userBlocks,
+    ]);
+    this.firstPromptPending = null;
+    return response;
   }
 
   async cancelPrompt(): Promise<void> {
@@ -440,7 +468,8 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
         mcpServers: this.resolveAcpMcpServers(mcpServers),
       });
       this.sessionId = sessionId;
-      // connect 시점 CODEX_CONFIG env 지침이 load 이후에도 상주하므로 snapshot을 보존한다.
+      this.currentSystemPrompt = null;
+      this.firstPromptPending = null;
       return;
     }
 
@@ -456,11 +485,13 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
       this.buildCodexThreadDefaultsForResume(
         targetCwd,
         undefined,
-        this.currentSystemPrompt,
+        null,
         this.pendingOverrides?.threadConfig ?? {},
       ),
     );
     this.sessionId = sessionId;
+    this.currentSystemPrompt = null;
+    this.firstPromptPending = null;
   }
 
   async resetSession(cwd?: string): Promise<ConnectResult> {
@@ -481,7 +512,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
       const session = await this.connection.reconnectSession(targetCwd);
       this.sessionId = session.sessionId;
       this.sessionCwd = targetCwd;
-      // CODEX_CONFIG env는 프로세스 수준이라 reconnectSession의 새 thread/start가 지침을 자동 재적용한다.
+      this.firstPromptPending = this.currentSystemPrompt;
 
       return {
         cli: 'codex',
@@ -495,6 +526,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     );
     this.sessionId = result.thread.id;
     this.sessionCwd = targetCwd;
+    this.firstPromptPending = this.currentSystemPrompt;
     this.pendingOverrides = {
       turnConfig: {},
       threadConfig: this.pendingOverrides?.threadConfig ?? {},
@@ -516,6 +548,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     this.sessionId = session.sessionId;
     this.sessionCwd = options.cwd;
     this.currentSystemPrompt = options.systemPrompt ?? null;
+    this.firstPromptPending = options.sessionId ? null : this.currentSystemPrompt;
     this.pendingOverrides = {
       turnConfig: {},
       threadConfig: {},
@@ -537,6 +570,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     this.sessionId = null;
     this.sessionCwd = null;
     this.currentSystemPrompt = null;
+    this.firstPromptPending = null;
     this.pendingOverrides = null;
   }
 
@@ -730,7 +764,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
       cwd,
       approvalPolicy,
       sandbox,
-      developerInstructions: this.currentSystemPrompt ?? undefined,
+      developerInstructions: undefined,
       config,
     };
   }

--- a/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
+++ b/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
@@ -184,7 +184,13 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
       });
     }
 
-    this.sessionId = connection.sessionId;
+    const sessionId = connection.sessionId;
+    if (!sessionId) {
+      await this.cleanupFailedConnection();
+      throw new Error('[codex] App Server 연결에서 유효한 세션 ID를 받지 못했습니다.');
+    }
+
+    this.sessionId = sessionId;
     this.sessionCwd = options.cwd;
     this.currentSystemPrompt = developerInstructions;
     this.pendingOverrides = {
@@ -198,6 +204,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     return {
       cli: 'codex',
       protocol: 'codex-app-server',
+      session: { sessionId },
     };
   }
 

--- a/packages/core-unified-agent/src/config/CliConfigs.ts
+++ b/packages/core-unified-agent/src/config/CliConfigs.ts
@@ -196,15 +196,13 @@ export function getAllBackendConfigs(): CliBackendConfig[] {
 /**
  * Codex ACP 브릿지(`codex-acp`)가 읽는 `CODEX_CONFIG` 환경변수 값을 생성합니다.
  * 브릿지는 이 JSON 맵을 `thread/start`/`thread/resume` config에 spread하므로,
- * developer instruction과 설정 오버라이드를 argv 대신 env로 주입합니다.
+ * 설정 오버라이드를 argv 대신 env로 주입합니다.
  *
- * @param systemPrompt - 세션 시작 시 주입할 시스템 지침 (있으면 최우선으로 developer_instructions에 반영)
  * @param configOverrides - `key=value` 형태의 설정 오버라이드 배열 (dotted key는 중첩 객체로 확장)
  * @param baseConfigJson - 호출자가 이미 지정한 CODEX_CONFIG(JSON) 값. 유효한 JSON 객체면 시작점으로 병합.
  * @returns JSON 문자열(맵에 키가 하나 이상일 때) 또는 undefined(빈 맵)
  */
 export function buildCodexConfigEnv(
-  systemPrompt?: string | null,
   configOverrides?: string[],
   baseConfigJson?: string,
 ): string | undefined {
@@ -218,11 +216,6 @@ export function buildCodexConfigEnv(
     const key = override.slice(0, eqIndex);
     const rawValue = override.slice(eqIndex + 1);
     assignNestedKey(map, key, parseOverrideValue(rawValue));
-  }
-
-  if (systemPrompt) {
-    // developer_instructions는 base/override보다 우선하도록 마지막에 설정한다.
-    map.developer_instructions = systemPrompt;
   }
 
   if (Object.keys(map).length === 0) {
@@ -340,4 +333,3 @@ function assignNestedKey(
   }
   cursor[segments[segments.length - 1]] = value;
 }
-

--- a/packages/core-unified-agent/src/connection/AcpConnection.ts
+++ b/packages/core-unified-agent/src/connection/AcpConnection.ts
@@ -191,7 +191,7 @@ export class AcpConnection extends BaseConnection {
     workspace: string,
     sessionId?: string,
     mcpServers?: McpServer[],
-    systemPrompt?: string,
+    _systemPrompt?: string,
     strictMcp?: boolean,
     effort?: string,
   ): Promise<NewSessionResponse> {
@@ -209,7 +209,7 @@ export class AcpConnection extends BaseConnection {
           cwd: workspace,
           mcpServers: servers,
         };
-        const meta = this.buildClaudeSessionMeta(systemPrompt, strictMcp, effort);
+        const meta = this.buildClaudeSessionMeta(strictMcp, effort);
         if (meta) {
           loadSessionParams._meta = meta;
         }
@@ -229,7 +229,7 @@ export class AcpConnection extends BaseConnection {
           mcpServers: servers,
         };
 
-        const meta = this.buildClaudeSessionMeta(systemPrompt, strictMcp, effort);
+        const meta = this.buildClaudeSessionMeta(strictMcp, effort);
         if (meta) {
           newSessionParams._meta = meta;
         }
@@ -301,7 +301,7 @@ export class AcpConnection extends BaseConnection {
         ? { additionalDirectories: params.additionalDirectories }
         : {}),
     };
-    const meta = this.buildClaudeSessionMeta(undefined, undefined, effort);
+    const meta = this.buildClaudeSessionMeta(undefined, effort);
     if (meta) {
       loadSessionParams._meta = meta;
     }
@@ -385,22 +385,8 @@ export class AcpConnection extends BaseConnection {
     return this.cliType === 'claude';
   }
 
-  /** Claude bridge만 native system prompt append를 지원하므로 이 경로만 사용합니다. */
-  private getClaudeSystemPrompt(systemPrompt?: string): string | null {
-    if (!this.isClaudeBackend()) {
-      return null;
-    }
-
-    if (!systemPrompt) {
-      return null;
-    }
-
-    return systemPrompt;
-  }
-
-  /** Claude bridge 전용 `_meta`를 조립합니다. */
+  /** Claude bridge 전용 strict-MCP와 effort `_meta`를 조립합니다. */
   private buildClaudeSessionMeta(
-    systemPrompt?: string,
     strictMcp?: boolean,
     effort?: string,
   ): Record<string, unknown> | undefined {
@@ -408,21 +394,14 @@ export class AcpConnection extends BaseConnection {
       return undefined;
     }
 
-    const claudeSystemPrompt = this.getClaudeSystemPrompt(systemPrompt);
     const shouldInjectStrictMcp = strictMcp;
     const shouldInjectEffort = !!effort;
 
-    if (!claudeSystemPrompt && !shouldInjectStrictMcp && !shouldInjectEffort) {
+    if (!shouldInjectStrictMcp && !shouldInjectEffort) {
       return undefined;
     }
 
     const meta: Record<string, unknown> = {};
-    if (claudeSystemPrompt) {
-      meta.systemPrompt = {
-        append: claudeSystemPrompt,
-      };
-    }
-
     if (shouldInjectStrictMcp || shouldInjectEffort) {
       const claudeOptions: Record<string, unknown> = {};
       if (shouldInjectStrictMcp) {

--- a/packages/core-unified-agent/src/types/config.ts
+++ b/packages/core-unified-agent/src/types/config.ts
@@ -134,10 +134,8 @@ export interface UnifiedClientOptions extends ConnectionOptions {
   /** 재개할 기존 세션 ID */
   sessionId?: string;
   /** 세션 초기 시스템 지침.
-   * Claude에서는 native system prompt에 append되며,
-   * Codex에서는 app-server의 developerInstructions로 전달되고,
-   * OpenCode Go에서는 세션의 최초 user turn 앞에 선행 text block으로 주입됨
-   * (best-effort initial session instructions). */
+   * Claude와 Codex는 fresh 세션의 첫 user turn 앞에 한 번만 선행 text block으로 주입하며,
+   * resetSession()은 이를 다시 대기시킵니다. 기존 세션의 connect(sessionId) 및 loadSession()에는 주입하지 않습니다. */
   systemPrompt?: string;
   /** 에이전트에 연결할 MCP 서버 목록 (선택) */
   mcpServers?: McpServerConfig[];

--- a/packages/core-unified-agent/tests/e2e/codex.test.ts
+++ b/packages/core-unified-agent/tests/e2e/codex.test.ts
@@ -5,7 +5,7 @@
 
 import { EventEmitter } from 'events';
 import type { ChildProcess } from 'child_process';
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import {
   isCliInstalled,
   connectClient,
@@ -101,11 +101,28 @@ const CODEX_EFFORT_MATRIX = [
 
 describe.skipIf(!installed)('E2E: Codex official ACP bridge', () => {
   let client: IUnifiedAgentClient | null = null;
+  let originalCodexUseAcp: string | undefined;
+
+  beforeEach(() => {
+    originalCodexUseAcp = process.env.CODEX_USE_ACP;
+    process.env.CODEX_USE_ACP = 'true';
+  });
 
   afterEach(async () => {
-    if (client) {
-      await client.disconnect();
-      client = null;
+    try {
+      if (client) {
+        try {
+          await client.disconnect();
+        } finally {
+          client = null;
+        }
+      }
+    } finally {
+      if (originalCodexUseAcp === undefined) {
+        delete process.env.CODEX_USE_ACP;
+      } else {
+        process.env.CODEX_USE_ACP = originalCodexUseAcp;
+      }
     }
   });
 

--- a/packages/core-unified-agent/tests/e2e/unified-agent.contract.test.ts
+++ b/packages/core-unified-agent/tests/e2e/unified-agent.contract.test.ts
@@ -5,7 +5,7 @@
  * UnifiedAgent 빌더를 사용하는 외부 호출자는 동일한 기대 동작을 관찰해야 합니다.
  */
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   UnifiedAgent,
@@ -35,7 +35,7 @@ const CONTRACT_CASES: ContractCase[] = [
   },
   {
     cli: 'codex',
-    expectedProtocol: 'acp',
+    expectedProtocol: 'codex-app-server',
     model: 'gpt-5.6-sol',
     supportsResetSession: true,
   },
@@ -46,11 +46,31 @@ for (const contractCase of CONTRACT_CASES) {
 
   describe.skipIf(!installed)(`UnifiedAgent contract: ${contractCase.cli}`, () => {
     let client: IUnifiedAgentClient | null = null;
+    let originalCodexUseAcp: string | undefined;
+
+    beforeEach(() => {
+      if (contractCase.cli !== 'codex') return;
+      originalCodexUseAcp = process.env.CODEX_USE_ACP;
+      delete process.env.CODEX_USE_ACP;
+    });
 
     afterEach(async () => {
-      if (client) {
-        await client.disconnect();
-        client = null;
+      try {
+        if (client) {
+          try {
+            await client.disconnect();
+          } finally {
+            client = null;
+          }
+        }
+      } finally {
+        if (contractCase.cli === 'codex') {
+          if (originalCodexUseAcp === undefined) {
+            delete process.env.CODEX_USE_ACP;
+          } else {
+            process.env.CODEX_USE_ACP = originalCodexUseAcp;
+          }
+        }
       }
     });
 

--- a/packages/core-unified-agent/tests/unit/AcpConnection.sessionLifecycle.test.ts
+++ b/packages/core-unified-agent/tests/unit/AcpConnection.sessionLifecycle.test.ts
@@ -61,6 +61,28 @@ describe('AcpConnection stderr diagnostics', () => {
   });
 });
 
+describe('AcpConnection Claude session metadata', () => {
+  it('ignores the legacy systemPrompt argument instead of emitting _meta.systemPrompt', async () => {
+    const conn = new TestAcpConnection({
+      command: 'claude',
+      args: ['--acp'],
+      cliType: 'claude',
+      cwd: process.cwd(),
+    }) as unknown as TestableAcpConnection;
+    const mockAgent = createMockAgent();
+    conn.agentProxy = mockAgent;
+
+    await (conn as unknown as {
+      createSession: (workspace: string, sessionId?: string, mcpServers?: unknown[], systemPrompt?: string) => Promise<NewSessionResponse>;
+    }).createSession('/workspace', undefined, [], 'Tier-2 지침');
+
+    expect(mockAgent.newSession).toHaveBeenCalledWith({
+      cwd: '/workspace',
+      mcpServers: [],
+    });
+  });
+});
+
 // ─── endSession ───────────────────────────────────────────
 
 describe('AcpConnection.endSession()', () => {

--- a/packages/core-unified-agent/tests/unit/CliConfigs.codexConfigEnv.test.ts
+++ b/packages/core-unified-agent/tests/unit/CliConfigs.codexConfigEnv.test.ts
@@ -8,7 +8,7 @@ function parse(json: string | undefined): Record<string, unknown> {
 
 describe('buildCodexConfigEnv', () => {
   it('dotted key는 중첩 객체로 확장한다', () => {
-    const json = buildCodexConfigEnv(undefined, ['mcp_servers.fleet.url="http://127.0.0.1:1234"']);
+    const json = buildCodexConfigEnv(['mcp_servers.fleet.url="http://127.0.0.1:1234"']);
     expect(parse(json)).toEqual({
       mcp_servers: { fleet: { url: 'http://127.0.0.1:1234' } },
     });
@@ -16,14 +16,14 @@ describe('buildCodexConfigEnv', () => {
 
   it('같은 상위 경로를 공유하는 override는 기존 중첩 객체에 병합한다', () => {
     const base = JSON.stringify({ mcp_servers: { fleet: { url: 'http://a' } } });
-    const json = buildCodexConfigEnv(undefined, ['mcp_servers.fleet.tool_timeout_sec=180'], base);
+    const json = buildCodexConfigEnv(['mcp_servers.fleet.tool_timeout_sec=180'], base);
     expect(parse(json)).toEqual({
       mcp_servers: { fleet: { url: 'http://a', tool_timeout_sec: 180 } },
     });
   });
 
   it('JSON 값은 파싱해 number/boolean/string 타입을 보존한다', () => {
-    const json = buildCodexConfigEnv(undefined, [
+    const json = buildCodexConfigEnv([
       'tool_timeout_sec=180',
       'enabled=true',
       'model="gpt-5.4"',
@@ -37,36 +37,35 @@ describe('buildCodexConfigEnv', () => {
 
   it('JSON.parse 실패 시 감싼 큰따옴표 한 쌍을 제거한 원시 문자열로 강등한다', () => {
     // `"a"b"`는 유효한 JSON이 아니므로 큰따옴표를 벗겨 `a"b`로 처리된다.
-    const json = buildCodexConfigEnv(undefined, ['label="a"b"']);
+    const json = buildCodexConfigEnv(['label="a"b"']);
     expect(parse(json)).toEqual({ label: 'a"b' });
   });
 
-  it('developer_instructions는 base/override보다 systemPrompt가 우선한다', () => {
+  it('명시적 developer_instructions override는 base 설정을 갱신한다', () => {
     const base = JSON.stringify({ developer_instructions: 'base 지침', model: 'gpt-5.4' });
-    const json = buildCodexConfigEnv('최종 지침', ['developer_instructions="override 지침"'], base);
+    const json = buildCodexConfigEnv(['developer_instructions="override 지침"'], base);
     expect(parse(json)).toEqual({
-      developer_instructions: '최종 지침',
+      developer_instructions: 'override 지침',
       model: 'gpt-5.4',
     });
   });
 
   it('유효하지 않은 baseConfigJson은 무시하고 빈 맵에서 시작한다', () => {
-    const json = buildCodexConfigEnv('지침', undefined, 'not-json');
-    expect(parse(json)).toEqual({ developer_instructions: '지침' });
+    const json = buildCodexConfigEnv(undefined, 'not-json');
+    expect(parse(json)).toEqual({});
   });
 
   it('배열/스칼라 baseConfigJson도 객체가 아니므로 무시한다', () => {
-    const json = buildCodexConfigEnv('지침', undefined, '[1,2,3]');
-    expect(parse(json)).toEqual({ developer_instructions: '지침' });
+    const json = buildCodexConfigEnv(undefined, '[1,2,3]');
+    expect(parse(json)).toEqual({});
   });
 
   it('입력이 비면 undefined를 반환한다', () => {
     expect(buildCodexConfigEnv()).toBeUndefined();
-    expect(buildCodexConfigEnv(undefined, [], undefined)).toBeUndefined();
-    expect(buildCodexConfigEnv('', [], '')).toBeUndefined();
+    expect(buildCodexConfigEnv([], undefined)).toBeUndefined();
   });
 
   it('`=`가 없는 override 항목은 건너뛴다', () => {
-    expect(buildCodexConfigEnv(undefined, ['no-equals-here'])).toBeUndefined();
+    expect(buildCodexConfigEnv(['no-equals-here'])).toBeUndefined();
   });
 });

--- a/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
+++ b/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
@@ -13,6 +13,7 @@ const mockSetPendingEffort = vi.fn();
 const mockRemoveAllListeners = vi.fn();
 
 const mockAcpConnect = vi.fn();
+const mockAcpLoadSession = vi.fn();
 const mockAcpSendPrompt = vi.fn();
 const mockAcpSetMode = vi.fn();
 const mockAcpSetModel = vi.fn();
@@ -58,6 +59,7 @@ function createMockAcpConnection(): Record<string, unknown> {
     emit: emitter.emit.bind(emitter),
     removeAllListeners: vi.fn(),
     connect: mockAcpConnect,
+    loadSession: mockAcpLoadSession,
     sendPrompt: mockAcpSendPrompt,
     setMode: mockAcpSetMode,
     setModel: mockAcpSetModel,
@@ -129,6 +131,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
     mockCodexSendMessage.mockResolvedValue(undefined);
     mockCodexCancelPrompt.mockResolvedValue(undefined);
     mockAcpConnect.mockResolvedValue({ sessionId: 'acp-session-1' });
+    mockAcpLoadSession.mockResolvedValue({});
     mockAcpSendPrompt.mockResolvedValue({ stopReason: 'endTurn' });
     mockAcpSetMode.mockResolvedValue(undefined);
     mockAcpSetModel.mockResolvedValue(undefined);
@@ -274,9 +277,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
     expect(AcpConnection).not.toHaveBeenCalled();
   });
 
-  it('ACP resetSession 후 첫 프롬프트는 사용자 content만 전달한다(prepend 없음)', async () => {
-    // systemPrompt 주입은 connect 시점 CODEX_CONFIG env가 담당하므로, reconnect 후에도
-    // 프롬프트에 지침을 prepend하지 않고 사용자 입력만 그대로 전달해야 한다.
+  it('ACP resetSession 후 첫 프롬프트에 systemPrompt를 한 번만 prepend한다', async () => {
     const client = new UnifiedCodexAgentClient();
     const mockAcpConnection = Object.assign(Object.create(AcpConnection.prototype), {
       canResetSession: true,
@@ -290,6 +291,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
       sessionId: 'acp-session-1',
       sessionCwd: '/workspace',
       currentSystemPrompt: '리셋 후 지침',
+      firstPromptPending: null,
     });
 
     await client.resetSession();
@@ -298,13 +300,15 @@ describe('UnifiedCodexAgentClient config staging', () => {
 
     expect(mockAcpConnection.endSession).toHaveBeenCalledWith('acp-session-1');
     expect(mockAcpConnection.reconnectSession).toHaveBeenCalledWith('/workspace');
-    expect(mockAcpConnection.sendPrompt).toHaveBeenNthCalledWith(1, 'acp-session-2', '첫 요청');
+    expect(mockAcpConnection.sendPrompt).toHaveBeenNthCalledWith(1, 'acp-session-2', [
+      { type: 'text', text: '리셋 후 지침' },
+      { type: 'text', text: '첫 요청' },
+    ]);
     expect(mockAcpConnection.sendPrompt).toHaveBeenNthCalledWith(2, 'acp-session-2', '두 번째 요청');
-    // 리셋 이후에도 snapshot은 보존된다(env 상주).
     expect(client.getCurrentSystemPrompt()).toBe('리셋 후 지침');
   });
 
-  it('ACP 연결은 systemPrompt를 CODEX_CONFIG env로 주입하고 argv에는 넣지 않는다', async () => {
+  it('ACP 연결은 systemPrompt를 CODEX_CONFIG에 주입하지 않고 첫 프롬프트에만 prepend한다', async () => {
     const client = new UnifiedCodexAgentClient();
 
     await client.connect({
@@ -315,14 +319,71 @@ describe('UnifiedCodexAgentClient config staging', () => {
     });
 
     const options = acpCtorOptions();
-    const config = JSON.parse(options.env?.CODEX_CONFIG ?? '{}') as Record<string, unknown>;
-    expect(config.developer_instructions).toBe('개발자 지침');
-    // argv에는 -c / developer_instructions 흔적이 없어야 한다(argv 주입 폐기).
-    expect(options.args).not.toContain('-c');
-    expect(options.args.some((arg) => arg.includes('developer_instructions'))).toBe(false);
+    expect(options.env?.CODEX_CONFIG).toBeUndefined();
+
+    await client.sendMessage('첫 요청');
+    await client.sendMessage('두 번째 요청');
+
+    expect(mockAcpSendPrompt).toHaveBeenNthCalledWith(1, 'acp-session-1', [
+      { type: 'text', text: '개발자 지침' },
+      { type: 'text', text: '첫 요청' },
+    ]);
+    expect(mockAcpSendPrompt).toHaveBeenNthCalledWith(2, 'acp-session-1', '두 번째 요청');
   });
 
-  it('호출자 제공 CODEX_CONFIG(valid JSON)는 병합되고 developer_instructions는 systemPrompt가 우선한다', async () => {
+  it('Codex ACP failed-first-send는 Tier-2를 재시도하고 성공 뒤에는 반복하지 않는다', async () => {
+    mockAcpSendPrompt
+      .mockRejectedValueOnce(new Error('transient send failure'))
+      .mockResolvedValue({ stopReason: 'endTurn' });
+    const client = new UnifiedCodexAgentClient();
+
+    await client.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+      systemPrompt: 'Tier-2 지침',
+      env: { CODEX_USE_ACP: 'true' },
+    });
+    await expect(client.sendMessage('첫 요청')).rejects.toThrow('transient send failure');
+    await client.sendMessage('재시도 요청');
+    await client.sendMessage('다음 요청');
+
+    expect(mockAcpSendPrompt).toHaveBeenNthCalledWith(1, 'acp-session-1', [
+      { type: 'text', text: 'Tier-2 지침' },
+      { type: 'text', text: '첫 요청' },
+    ]);
+    expect(mockAcpSendPrompt).toHaveBeenNthCalledWith(2, 'acp-session-1', [
+      { type: 'text', text: 'Tier-2 지침' },
+      { type: 'text', text: '재시도 요청' },
+    ]);
+    expect(mockAcpSendPrompt).toHaveBeenNthCalledWith(3, 'acp-session-1', '다음 요청');
+  });
+
+  it('Codex ACP resumed and loaded sessions send user content only', async () => {
+    const resumed = new UnifiedCodexAgentClient();
+    await resumed.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+      sessionId: 'existing',
+      systemPrompt: 'Tier-2 지침',
+      env: { CODEX_USE_ACP: 'true' },
+    });
+    await resumed.sendMessage('재개 요청');
+
+    const loaded = new UnifiedCodexAgentClient();
+    await loaded.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+      systemPrompt: 'Tier-2 지침',
+      env: { CODEX_USE_ACP: 'true' },
+    });
+    await loaded.loadSession('loaded-session');
+    await loaded.sendMessage('로드 요청');
+
+    expect(mockAcpSendPrompt).toHaveBeenNthCalledWith(1, 'acp-session-1', '재개 요청');
+    expect(mockAcpSendPrompt).toHaveBeenNthCalledWith(2, 'loaded-session', '로드 요청');
+  });
+
+  it('호출자 제공 CODEX_CONFIG의 developer_instructions는 systemPrompt와 별개로 보존한다', async () => {
     const client = new UnifiedCodexAgentClient();
 
     await client.connect({
@@ -337,7 +398,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
 
     const options = acpCtorOptions();
     const config = JSON.parse(options.env?.CODEX_CONFIG ?? '{}') as Record<string, unknown>;
-    expect(config).toEqual({ model: 'gpt-5.4', developer_instructions: '우선 지침' });
+    expect(config).toEqual({ model: 'gpt-5.4', developer_instructions: '무시될 지침' });
   });
 
   it('systemPrompt·configOverrides·호출자 CODEX_CONFIG가 모두 없으면 env에 CODEX_CONFIG를 넣지 않는다', async () => {
@@ -353,10 +414,10 @@ describe('UnifiedCodexAgentClient config staging', () => {
     expect(options.env?.CODEX_CONFIG).toBeUndefined();
   });
 
-  it('codex 연결 시 systemPrompt를 developerInstructions로 전달한다', async () => {
+  it('App Server 연결은 systemPrompt를 developerInstructions로 전달하지 않고 첫 프롬프트에만 prepend한다', async () => {
     const client = new UnifiedCodexAgentClient();
 
-    await connectAppServer(client, {
+    await client.connect({
       cwd: '/workspace',
       cli: 'codex',
       systemPrompt: '개발자 지침',
@@ -375,12 +436,57 @@ describe('UnifiedCodexAgentClient config staging', () => {
       ],
     }));
     expect(mockCodexConnect).toHaveBeenCalledWith({
-      developerInstructions: '개발자 지침',
+      developerInstructions: undefined,
       model: 'gpt-5.4',
       approvalPolicy: 'never',
       sandbox: 'danger-full-access',
     });
+    await client.sendMessage('첫 요청');
+    await client.sendMessage('두 번째 요청');
+    expect(mockCodexSendMessage).toHaveBeenNthCalledWith(1, [
+      { type: 'text', text: '개발자 지침', text_elements: [] },
+      { type: 'text', text: '첫 요청', text_elements: [] },
+    ]);
+    expect(mockCodexSendMessage).toHaveBeenNthCalledWith(2, [
+      { type: 'text', text: '두 번째 요청', text_elements: [] },
+    ]);
     expect(client.getConnectionInfo().protocol).toBe('codex-app-server');
+  });
+
+  it('Codex App Server failed-first-send는 Tier-2를 재시도하고 성공 뒤에는 반복하지 않는다', async () => {
+    mockCodexSendMessage
+      .mockRejectedValueOnce(new Error('transient send failure'))
+      .mockResolvedValue(undefined);
+    const client = new UnifiedCodexAgentClient();
+
+    await client.connect({ cwd: '/workspace', cli: 'codex', systemPrompt: 'Tier-2 지침' });
+    await expect(client.sendMessage('첫 요청')).rejects.toThrow('transient send failure');
+    await client.sendMessage('재시도 요청');
+    await client.sendMessage('다음 요청');
+
+    expect(mockCodexSendMessage).toHaveBeenNthCalledWith(1, [
+      { type: 'text', text: 'Tier-2 지침', text_elements: [] },
+      { type: 'text', text: '첫 요청', text_elements: [] },
+    ]);
+    expect(mockCodexSendMessage).toHaveBeenNthCalledWith(2, [
+      { type: 'text', text: 'Tier-2 지침', text_elements: [] },
+      { type: 'text', text: '재시도 요청', text_elements: [] },
+    ]);
+    expect(mockCodexSendMessage).toHaveBeenNthCalledWith(3, [
+      { type: 'text', text: '다음 요청', text_elements: [] },
+    ]);
+  });
+
+  it('Codex App Server loaded sessions send user content only', async () => {
+    const client = new UnifiedCodexAgentClient();
+
+    await client.connect({ cwd: '/workspace', cli: 'codex', systemPrompt: 'Tier-2 지침' });
+    await client.loadSession('loaded-thread');
+    await client.sendMessage('로드 요청');
+
+    expect(mockCodexSendMessage).toHaveBeenCalledWith([
+      { type: 'text', text: '로드 요청', text_elements: [] },
+    ]);
   });
 
   it('codex MCP 서버 설정은 app-server 시작 -c 인자로 전달한다', async () => {
@@ -438,7 +544,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
     }));
   });
 
-  it('codex session resume은 thread/resume에 정책과 systemPrompt를 재전달한다', async () => {
+  it('codex session resume은 systemPrompt를 developerInstructions나 첫 프롬프트에 재전달하지 않는다', async () => {
     const client = new UnifiedCodexAgentClient();
 
     const result = await connectAppServer(client, {
@@ -458,10 +564,14 @@ describe('UnifiedCodexAgentClient config staging', () => {
       model: 'gpt-5.4',
       approvalPolicy: 'never',
       sandbox: 'danger-full-access',
-      developerInstructions: '재개 지침',
+      developerInstructions: undefined,
       config: undefined,
     });
     expect(result.session).toEqual({ sessionId: 'codex-thread-9' });
+    await client.sendMessage('재개 요청');
+    expect(mockCodexSendMessage).toHaveBeenCalledWith([
+      { type: 'text', text: '재개 요청', text_elements: [] },
+    ]);
     expect(client.getCurrentSystemPrompt()).toBe('재개 지침');
   });
 
@@ -525,7 +635,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
     expect(mockCodexSendMessage).toHaveBeenCalledTimes(1);
   });
 
-  it('resetSession은 초기 mode와 systemPrompt를 thread/start payload로 보존한다', async () => {
+  it('resetSession은 systemPrompt를 developerInstructions 없이 다음 첫 프롬프트에 전달한다', async () => {
     const client = new UnifiedCodexAgentClient();
     await connectAppServer(client, {
       cwd: '/workspace',
@@ -540,9 +650,14 @@ describe('UnifiedCodexAgentClient config staging', () => {
       cwd: '/workspace',
       approvalPolicy: 'on-request',
       sandbox: 'read-only',
-      developerInstructions: '초기 지침',
+      developerInstructions: undefined,
       config: undefined,
     });
+    await client.sendMessage('리셋 후 요청');
+    expect(mockCodexSendMessage).toHaveBeenCalledWith([
+      { type: 'text', text: '초기 지침', text_elements: [] },
+      { type: 'text', text: '리셋 후 요청', text_elements: [] },
+    ]);
     expect(client.getCurrentSystemPrompt()).toBe('초기 지침');
   });
 
@@ -563,7 +678,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
       cwd: '/next-workspace',
       approvalPolicy: 'on-request',
       sandbox: 'workspace-write',
-      developerInstructions: '리셋 지침',
+      developerInstructions: undefined,
       config: {
         notify: 'false',
         model_reasoning_summary: 'auto',
@@ -577,7 +692,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
     }));
   });
 
-  it('sessionId resume 경로도 fresh thread/start와 동등한 정책과 developerInstructions를 전달한다', async () => {
+  it('sessionId resume 경로는 developerInstructions를 전달하지 않는다', async () => {
     const client = new UnifiedCodexAgentClient();
 
     await connectAppServer(client, {
@@ -595,7 +710,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
     });
     expect(mockCodexLoadSession).toHaveBeenCalledWith('thread-existing', {
       cwd: '/workspace',
-      developerInstructions: '재개 지침',
+      developerInstructions: undefined,
       model: 'gpt-5.4',
       approvalPolicy: 'on-request',
       sandbox: 'read-only',

--- a/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
+++ b/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
@@ -84,8 +84,8 @@ const { AcpConnection } = await import('../../src/connection/AcpConnection.js');
 
 type CodexClient = InstanceType<typeof UnifiedCodexAgentClient>;
 
-// 공개 connect()는 CODEX_USE_ACP 기본값(true)으로 항상 ACP 경로를 타므로,
-// 레거시 app-server config 스테이징 검증은 내부 connectAppServer 경로를 직접 구동한다.
+// 특정 app-server config 스테이징 검증은 전송 선택과 분리하기 위해
+// 내부 connectAppServer 경로를 직접 구동한다.
 // (소스 동작은 변경하지 않는 테스트 전용 우회 — element access로 private 메서드 호출)
 async function connectAppServer(
   client: CodexClient,
@@ -132,13 +132,13 @@ describe('UnifiedCodexAgentClient config staging', () => {
     restoreEnvironmentVariable('CODEX_CONFIG', originalCodexConfig);
   });
 
-  it('CODEX_USE_ACP 미설정 시 ACP로 연결한다', async () => {
+  it('CODEX_USE_ACP 미설정 시 App Server로 연결한다', async () => {
     const client = new UnifiedCodexAgentClient();
 
     await client.connect({ cwd: '/workspace', cli: 'codex' });
 
-    expect(AcpConnection).toHaveBeenCalledTimes(1);
-    expect(CodexAppServerConnection).not.toHaveBeenCalled();
+    expect(CodexAppServerConnection).toHaveBeenCalledTimes(1);
+    expect(AcpConnection).not.toHaveBeenCalled();
   });
 
   it("options.env CODEX_USE_ACP='false'는 App Server로 연결한다", async () => {
@@ -180,7 +180,36 @@ describe('UnifiedCodexAgentClient config staging', () => {
     expect(CodexAppServerConnection).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['false', false],
+    ['0', false],
+    ['true', true],
+    ['yes', true],
+  ] as const)('process.env CODEX_USE_ACP=%s 선택을 적용한다', async (value, usesAcp) => {
+    process.env.CODEX_USE_ACP = value;
+    const client = new UnifiedCodexAgentClient();
+
+    await client.connect({ cwd: '/workspace', cli: 'codex' });
+
+    expect(AcpConnection).toHaveBeenCalledTimes(usesAcp ? 1 : 0);
+    expect(CodexAppServerConnection).toHaveBeenCalledTimes(usesAcp ? 0 : 1);
+  });
+
   it('options.env가 process.env CODEX_USE_ACP보다 우선한다', async () => {
+    process.env.CODEX_USE_ACP = 'true';
+    const client = new UnifiedCodexAgentClient();
+
+    await client.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+      env: { CODEX_USE_ACP: 'false' },
+    });
+
+    expect(CodexAppServerConnection).toHaveBeenCalledTimes(1);
+    expect(AcpConnection).not.toHaveBeenCalled();
+  });
+
+  it('options.env ACP 선택도 process.env App Server 선택보다 우선한다', async () => {
     process.env.CODEX_USE_ACP = 'false';
     const client = new UnifiedCodexAgentClient();
 
@@ -256,6 +285,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
       cwd: '/workspace',
       cli: 'codex',
       systemPrompt: '개발자 지침',
+      env: { CODEX_USE_ACP: 'true' },
     });
 
     const options = acpCtorOptions();
@@ -274,6 +304,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
       cli: 'codex',
       systemPrompt: '우선 지침',
       env: {
+        CODEX_USE_ACP: 'true',
         CODEX_CONFIG: JSON.stringify({ model: 'gpt-5.4', developer_instructions: '무시될 지침' }),
       },
     });
@@ -289,6 +320,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
     await client.connect({
       cwd: '/workspace',
       cli: 'codex',
+      env: { CODEX_USE_ACP: 'true' },
     });
 
     const options = acpCtorOptions();

--- a/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
+++ b/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
@@ -488,6 +488,29 @@ describe('UnifiedCodexAgentClient config staging', () => {
     expect(mockSetPendingEffort).toHaveBeenCalledTimes(1);
   });
 
+  it('App Server 연결 effort는 첫 sendMessage에서 한 번만 적용한다', async () => {
+    const client = new UnifiedCodexAgentClient();
+
+    await client.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+      effort: 'high',
+    });
+    await client.sendMessage('첫 요청');
+
+    expect(mockSetPendingEffort).toHaveBeenCalledWith('high');
+    expect(mockCodexSendMessage).toHaveBeenCalledWith([
+      { type: 'text', text: '첫 요청', text_elements: [] },
+    ]);
+
+    await client.sendMessage('두 번째 요청');
+
+    expect(mockSetPendingEffort).toHaveBeenCalledTimes(1);
+    expect(mockCodexSendMessage).toHaveBeenNthCalledWith(2, [
+      { type: 'text', text: '두 번째 요청', text_elements: [] },
+    ]);
+  });
+
   it('setMode는 Codex pending mode로 저장되고 즉시 ACP 호출하지 않는다', async () => {
     const client = new UnifiedCodexAgentClient();
     await connectAppServer(client, {

--- a/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
+++ b/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
@@ -21,22 +21,30 @@ const originalCodexUseAcp = process.env.CODEX_USE_ACP;
 const originalCodexConfig = process.env.CODEX_CONFIG;
 
 function createMockCodexConnection(): EventEmitter & Record<string, unknown> {
-  const emitter = new EventEmitter();
-  Object.assign(emitter, {
-    connect: mockCodexConnect,
+  const connection = new EventEmitter() as EventEmitter & Record<string, unknown>;
+  Object.assign(connection, {
+    connect: async (...args: unknown[]) => {
+      const result = await mockCodexConnect(...args);
+      connection.sessionId = result.thread.id;
+      return result;
+    },
     disconnect: mockCodexDisconnect,
     endSession: mockCodexEndSession,
     resetSession: mockCodexResetSession,
-    loadSession: mockCodexLoadSession,
+    loadSession: async (...args: unknown[]) => {
+      const result = await mockCodexLoadSession(...args);
+      connection.sessionId = result.thread.id;
+      return result;
+    },
     sendMessage: mockCodexSendMessage,
     cancelPrompt: mockCodexCancelPrompt,
     setPendingModel: mockSetPendingModel,
     setPendingEffort: mockSetPendingEffort,
     removeAllListeners: mockRemoveAllListeners,
     connectionState: 'ready',
-    sessionId: 'codex-thread-1',
+    sessionId: null,
   });
-  return emitter as EventEmitter & Record<string, unknown>;
+  return connection;
 }
 
 // ACP 경로용 mock 연결. instanceof AcpConnection이 true가 되도록 prototype을 상속시키고,
@@ -87,11 +95,11 @@ type CodexClient = InstanceType<typeof UnifiedCodexAgentClient>;
 // 특정 app-server config 스테이징 검증은 전송 선택과 분리하기 위해
 // 내부 connectAppServer 경로를 직접 구동한다.
 // (소스 동작은 변경하지 않는 테스트 전용 우회 — element access로 private 메서드 호출)
-async function connectAppServer(
+function connectAppServer(
   client: CodexClient,
   options: Parameters<CodexClient['connect']>[0],
-): Promise<void> {
-  await client['connectAppServer'](options);
+): ReturnType<CodexClient['connect']> {
+  return client['connectAppServer'](options);
 }
 
 // ACP 연결 생성자에 전달된 첫 호출 인자(env/args)를 추출한다.
@@ -135,10 +143,28 @@ describe('UnifiedCodexAgentClient config staging', () => {
   it('CODEX_USE_ACP 미설정 시 App Server로 연결한다', async () => {
     const client = new UnifiedCodexAgentClient();
 
-    await client.connect({ cwd: '/workspace', cli: 'codex' });
+    const result = await client.connect({ cwd: '/workspace', cli: 'codex' });
 
     expect(CodexAppServerConnection).toHaveBeenCalledTimes(1);
     expect(AcpConnection).not.toHaveBeenCalled();
+    expect(result.session).toEqual({ sessionId: 'codex-thread-1' });
+  });
+
+  it('App Server가 세션 ID 없이 연결되면 연결을 정리하고 실패한다', async () => {
+    mockCodexConnect.mockResolvedValue({ thread: { id: '' } });
+    const client = new UnifiedCodexAgentClient();
+
+    await expect(client.connect({ cwd: '/workspace', cli: 'codex' })).rejects.toThrow(
+      '[codex] App Server 연결에서 유효한 세션 ID를 받지 못했습니다.',
+    );
+
+    expect(mockCodexDisconnect).toHaveBeenCalledTimes(1);
+    expect(client.getConnectionInfo()).toEqual({
+      cli: null,
+      protocol: null,
+      sessionId: null,
+      state: 'disconnected',
+    });
   });
 
   it("options.env CODEX_USE_ACP='false'는 App Server로 연결한다", async () => {
@@ -415,7 +441,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
   it('codex session resume은 thread/resume에 정책과 systemPrompt를 재전달한다', async () => {
     const client = new UnifiedCodexAgentClient();
 
-    await connectAppServer(client, {
+    const result = await connectAppServer(client, {
       cwd: '/workspace',
       cli: 'codex',
       sessionId: 'codex-thread-existing',
@@ -435,6 +461,7 @@ describe('UnifiedCodexAgentClient config staging', () => {
       developerInstructions: '재개 지침',
       config: undefined,
     });
+    expect(result.session).toEqual({ sessionId: 'codex-thread-9' });
     expect(client.getCurrentSystemPrompt()).toBe('재개 지침');
   });
 

--- a/packages/core-unified-agent/tests/unit/UnifiedAgentClient.resetSession.test.ts
+++ b/packages/core-unified-agent/tests/unit/UnifiedAgentClient.resetSession.test.ts
@@ -8,6 +8,8 @@ const mockConnect = vi.fn();
 const mockDisconnect = vi.fn();
 const mockEndSession = vi.fn();
 const mockReconnectSession = vi.fn();
+const mockLoadSession = vi.fn();
+const mockSendPrompt = vi.fn();
 const mockSetMode = vi.fn();
 const mockSetModel = vi.fn();
 const mockRemoveAllListeners = vi.fn();
@@ -19,6 +21,8 @@ function createMockAcpConnection(): EventEmitter & Record<string, unknown> {
     disconnect: mockDisconnect,
     endSession: mockEndSession,
     reconnectSession: mockReconnectSession,
+    loadSession: mockLoadSession,
+    sendPrompt: mockSendPrompt,
     setMode: mockSetMode,
     setModel: mockSetModel,
     connectionState: 'ready',
@@ -138,5 +142,80 @@ describe('resetSession()', () => {
     await client.resetSession();
 
     expect(callOrder).toEqual(['endSession', 'reconnectSession']);
+  });
+
+  it('Claude systemPrompt는 ACP meta가 아닌 fresh 세션의 첫 프롬프트에 한 번만 prepend한다', async () => {
+    mockConnect.mockResolvedValue(initialSession);
+    mockSendPrompt.mockResolvedValue({ stopReason: 'endTurn' });
+    const client = new UnifiedClaudeAgentClient();
+
+    await client.connect({ cwd: '/workspace', cli: 'claude', systemPrompt: 'Tier-2 지침' });
+    await client.sendMessage('첫 요청');
+    await client.sendMessage('두 번째 요청');
+
+    expect(mockConnect).toHaveBeenCalledWith('/workspace', undefined, [], undefined, undefined, undefined);
+    expect(mockSendPrompt).toHaveBeenNthCalledWith(1, 'initial-session', [
+      { type: 'text', text: 'Tier-2 지침' },
+      { type: 'text', text: '첫 요청' },
+    ]);
+    expect(mockSendPrompt).toHaveBeenNthCalledWith(2, 'initial-session', '두 번째 요청');
+  });
+
+  it('Claude resetSession은 systemPrompt를 새 세션의 첫 프롬프트에 다시 prepend한다', async () => {
+    mockConnect.mockResolvedValue(initialSession);
+    mockReconnectSession.mockResolvedValue(newSession);
+    mockSendPrompt.mockResolvedValue({ stopReason: 'endTurn' });
+    const client = new UnifiedClaudeAgentClient();
+
+    await client.connect({ cwd: '/workspace', cli: 'claude', systemPrompt: 'Tier-2 지침' });
+    await client.resetSession();
+    await client.sendMessage('리셋 후 요청');
+
+    expect(mockReconnectSession).toHaveBeenCalledWith('/workspace', undefined, undefined, undefined, undefined, undefined);
+    expect(mockSendPrompt).toHaveBeenCalledWith('new-session-after-reset', [
+      { type: 'text', text: 'Tier-2 지침' },
+      { type: 'text', text: '리셋 후 요청' },
+    ]);
+  });
+
+  it('Claude failed-first-send는 Tier-2를 재시도하고 성공 뒤에는 반복하지 않는다', async () => {
+    mockConnect.mockResolvedValue(initialSession);
+    mockSendPrompt
+      .mockRejectedValueOnce(new Error('transient send failure'))
+      .mockResolvedValue({ stopReason: 'endTurn' });
+    const client = new UnifiedClaudeAgentClient();
+
+    await client.connect({ cwd: '/workspace', cli: 'claude', systemPrompt: 'Tier-2 지침' });
+    await expect(client.sendMessage('첫 요청')).rejects.toThrow('transient send failure');
+    await client.sendMessage('재시도 요청');
+    await client.sendMessage('다음 요청');
+
+    expect(mockSendPrompt).toHaveBeenNthCalledWith(1, 'initial-session', [
+      { type: 'text', text: 'Tier-2 지침' },
+      { type: 'text', text: '첫 요청' },
+    ]);
+    expect(mockSendPrompt).toHaveBeenNthCalledWith(2, 'initial-session', [
+      { type: 'text', text: 'Tier-2 지침' },
+      { type: 'text', text: '재시도 요청' },
+    ]);
+    expect(mockSendPrompt).toHaveBeenNthCalledWith(3, 'initial-session', '다음 요청');
+  });
+
+  it('Claude resumed and loaded sessions send user content only', async () => {
+    mockConnect.mockResolvedValue(initialSession);
+    mockLoadSession.mockResolvedValue({});
+    mockSendPrompt.mockResolvedValue({ stopReason: 'endTurn' });
+    const resumed = new UnifiedClaudeAgentClient();
+
+    await resumed.connect({ cwd: '/workspace', cli: 'claude', sessionId: 'existing', systemPrompt: 'Tier-2 지침' });
+    await resumed.sendMessage('재개 요청');
+
+    const loaded = new UnifiedClaudeAgentClient();
+    await loaded.connect({ cwd: '/workspace', cli: 'claude', systemPrompt: 'Tier-2 지침' });
+    await loaded.loadSession('loaded-session');
+    await loaded.sendMessage('로드 요청');
+
+    expect(mockSendPrompt).toHaveBeenNthCalledWith(1, 'initial-session', '재개 요청');
+    expect(mockSendPrompt).toHaveBeenNthCalledWith(2, 'loaded-session', '로드 요청');
   });
 });

--- a/packages/fleet-admiral/assets/skills/carrier-contracts/SKILL.md
+++ b/packages/fleet-admiral/assets/skills/carrier-contracts/SKILL.md
@@ -17,7 +17,7 @@ All carriers accept an optional `<prior_jobs>` block: Prior finalized carrier jo
   - <artifacts?> optional: Relevant code snippets, file paths, error logs to examine.
 - **kirov** (Kirov · Operational Planning) — wrap request content in these blocks (? = optional):
   - <goal> required: What the user wants to build, fix, or achieve — specific feature, PRD, behavior, and any stated constraints.
-  - <plan_file?> optional: If provided, exact repo-relative .fleet/plans/{name}.md path Kirov must create or update. Do not choose a different filename.
+  - <plan_file> required: Required exact repo-relative .fleet/plans/{name}.md path Kirov must create or update. Do not choose a different filename.
   - <context?> optional: Relevant codebase context — files, modules, patterns, prior host-agent direction, or implementation realities the planner should respect.
   - <constraints?> optional: Business rules, tech stack requirements, scope boundaries, fixed decisions, or explicit exclusions the plan must respect.
   - <intent_type?> optional: If known: Refactoring | Build from Scratch | Mid-sized | Collaborative | Architecture Follow-through | Research-to-Plan.

--- a/packages/fleet-carriers/src/personas/kirov.ts
+++ b/packages/fleet-carriers/src/personas/kirov.ts
@@ -39,7 +39,7 @@ export const CARRIER_METADATA: CarrierMetadata = {
   ],
   requestBlocks: [
     { tag: "goal", hint: "What the user wants to build, fix, or achieve — specific feature, PRD, behavior, and any stated constraints.", required: true },
-    { tag: "plan_file", hint: "If provided, exact repo-relative .fleet/plans/{name}.md path Kirov must create or update. Do not choose a different filename.", required: false },
+    { tag: "plan_file", hint: "Required exact repo-relative .fleet/plans/{name}.md path Kirov must create or update. Do not choose a different filename.", required: true },
     { tag: "context", hint: "Relevant codebase context — files, modules, patterns, prior host-agent direction, or implementation realities the planner should respect.", required: false },
     { tag: "constraints", hint: "Business rules, tech stack requirements, scope boundaries, fixed decisions, or explicit exclusions the plan must respect.", required: false },
     { tag: "intent_type", hint: "If known: Refactoring | Build from Scratch | Mid-sized | Collaborative | Architecture Follow-through | Research-to-Plan.", required: false },
@@ -49,14 +49,14 @@ export const CARRIER_METADATA: CarrierMetadata = {
   // ── Tier 2: Composition ──
   permissions: [
     "CRITICAL: Write access strictly limited to .fleet/plans/*.md and .fleet/drafts/*.md. NEVER modify source code, configs, or any non-markdown file.",
-    "MUST honor exact provided .fleet/plans/*.md paths. Keep one plan_file as the execution SSoT: Success means creating or updating that executable plan_file unless the host agent explicitly requests draft-only work. Do not create split plan files for parallel lanes.",
+    "Every Kirov dispatch with the required plan_file is an artifact-writing mission. Its primary completion goal is creating or updating that exact executable plan_file, verifying it exists, and reading it back; analysis or a report alone is never completion. Keep one plan_file as the execution SSoT and do not create split plan files for parallel lanes.",
     "MUST return unresolved architecture choices, system-design trade-offs, and technical path decisions to the host agent for direction instead of silently deciding them.",
     "MUST report Blockers or Host Direction Needed instead of claiming completion when the plan file cannot be written or the schema cannot be filled.",
   ],
   outputFormat:
     `After completing the plan, provide a structured plan summary.\n` +
     `[Required] always include:\n` +
-    `  **Plan file** — Exact generated or updated .fleet/plans/{name}.md path.\n` +
+    `  **Plan file** — Exact generated or updated .fleet/plans/{name}.md path, verified to exist and read back.\n` +
     `  **Execution Topology** — Ordered waves, stable Wave/Lane IDs, parallel markers (e.g., "W1 → W2 || W3 → W4"), and critical dependencies.\n` +
     `  **Dispatch Manifest** — Each lane's exact write set, start condition, eligible concurrent lanes, integration gate, handoff, and rollback unit.\n` +
     `  **Scope: IN** — What is explicitly included in the plan.\n` +
@@ -69,7 +69,7 @@ export const CARRIER_METADATA: CarrierMetadata = {
   principles: [
     CARRIER_JOBS_SELF_CALL_HINT,
     "Clarify only to unlock planning — ask the minimum questions needed to produce a reliable execution plan.",
-    "Pre-plan gap analysis is mandatory internal input, never a substitute final output. May launch background explore/librarian sub-agents for context gathering. Use incremental write protocol: Write() skeleton first, then Edit() in 2-4 task batches.",
+    "Pre-plan gap analysis is mandatory internal input, never a substitute final output. For every dispatch, create or update the exact required plan_file, verify it exists, and read it back before completion; never claim completion with only analysis or a report. May launch background explore/librarian sub-agents for context gathering. Use incremental write protocol: Write() skeleton first, then Edit() in 2-4 task batches.",
     "The .fleet/plans/*.md file MUST contain this exact default Markdown template unless the host agent provides a different template: " +
       "# Objective, # File Ownership, # Execution Topology, - Execution mode: Sequential | Parallel, - Shared mutable resources:, # Waves, " +
       "## Wave N — <name>, ### Lane WN-X — <name>, - Exact write set:, - Read dependencies:, - Dependency/start condition:, " +

--- a/packages/fleet-carriers/tests/dispatch/prompt.test.ts
+++ b/packages/fleet-carriers/tests/dispatch/prompt.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { CarrierMetadata } from "../../src/index.js";
-import { formatRequestBlocksGuide, validateRequiredRequestBlocks } from "../../src/index.js";
+import { KIROV_METADATA, formatRequestBlocksGuide, validateRequiredRequestBlocks } from "../../src/index.js";
 
 const META: CarrierMetadata = {
   category: "operations",
@@ -42,6 +42,15 @@ describe("validateRequiredRequestBlocks", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toContain("(empty body)");
+  });
+
+  it("rejects a Kirov dispatch without its required plan_file", () => {
+    const result = validateRequiredRequestBlocks(KIROV_METADATA, "<goal>Plan the migration</goal>", "kirov");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.missing).toEqual(["plan_file"]);
+    expect(result.error).toContain("<plan_file> required:");
   });
 });
 

--- a/packages/fleet-carriers/tests/personas.test.ts
+++ b/packages/fleet-carriers/tests/personas.test.ts
@@ -169,8 +169,13 @@ describe("Kirov and Ohio parallel execution contract", () => {
     expect(KIROV_METADATA.summary).toContain("one executable .fleet/plans/*.md plan_file SSoT");
     expect(KIROV_METADATA.outputFormat).toContain("**Execution Topology**");
     expect(KIROV_METADATA.outputFormat).toContain("**Dispatch Manifest**");
+    expect(KIROV_METADATA.requestBlocks).toContainEqual({
+      tag: "plan_file",
+      hint: "Required exact repo-relative .fleet/plans/{name}.md path Kirov must create or update. Do not choose a different filename.",
+      required: true,
+    });
     expect(KIROV_METADATA.permissions).toContain(
-      "MUST honor exact provided .fleet/plans/*.md paths. Keep one plan_file as the execution SSoT: Success means creating or updating that executable plan_file unless the host agent explicitly requests draft-only work. Do not create split plan files for parallel lanes.",
+      "Every Kirov dispatch with the required plan_file is an artifact-writing mission. Its primary completion goal is creating or updating that exact executable plan_file, verifying it exists, and reading it back; analysis or a report alone is never completion. Keep one plan_file as the execution SSoT and do not create split plan files for parallel lanes.",
     );
     expect(KIROV_METADATA.principles).toContain(
       "Execution Topology is mandatory for every plan. It MUST declare Execution mode: Sequential | Parallel, shared mutable resources, ordered waves, and stable Wave/Lane IDs; a lane may be marked parallel only when its exact non-overlapping write set and read dependencies prove it is safe to run concurrently.",

--- a/runtime/fleet-plugins/terminal/server/settings-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/settings-routes.ts
@@ -58,7 +58,7 @@ export function registerTerminalSettingsRoutes(ctx: FleetPluginServerContext, de
 export function toTerminalSettingsState(data: GlobalOptionsData): TerminalSettingsState {
   return {
     enableMetaphor: data.enableMetaphor ?? false,
-    codexLaunchMode: data.codexLaunchMode ?? "acp",
+    codexLaunchMode: data.codexLaunchMode ?? "app-server",
   };
 }
 

--- a/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
@@ -19,13 +19,22 @@ interface HarnessOptions {
 }
 
 describe("terminal settings routes", () => {
-  it("GET /plugins/terminal/settings returns the default ACP Codex launch mode", async () => {
+  it("GET /plugins/terminal/settings returns the default App Server Codex launch mode", async () => {
     const harness = createRouteHarness({
       data: { version: 1, enableMetaphor: false },
     });
     await harness.handle({ req: req("GET"), res: res(), pathname: "/plugins/terminal/settings" });
-    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "acp" } }]);
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "app-server" } }]);
     expect(harness.writes[0]?.body).not.toHaveProperty("consolePortMode");
+  });
+
+  it("GET /plugins/terminal/settings preserves the persisted ACP Codex launch mode", async () => {
+    const harness = createRouteHarness({
+      data: { version: 1, enableMetaphor: false, codexLaunchMode: "acp" },
+    });
+    await harness.handle({ req: req("GET"), res: res(), pathname: "/plugins/terminal/settings" });
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "acp" } }]);
+    expect(harness.currentData()).toEqual({ version: 1, enableMetaphor: false, codexLaunchMode: "acp" });
   });
 
   it("PUT /plugins/terminal/settings updates enableMetaphor in global options", async () => {
@@ -46,6 +55,16 @@ describe("terminal settings routes", () => {
     await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
     expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "app-server" } }]);
     expect(harness.currentData()).toEqual({ version: 1, enableMetaphor: false, codexLaunchMode: "app-server" });
+  });
+
+  it("PUT /plugins/terminal/settings updates the Codex launch mode to ACP in global options", async () => {
+    const harness = createRouteHarness({
+      body: { codexLaunchMode: "acp" },
+      data: { version: 1, enableMetaphor: false, codexLaunchMode: "app-server" },
+    });
+    await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "acp" } }]);
+    expect(harness.currentData()).toEqual({ version: 1, enableMetaphor: false, codexLaunchMode: "acp" });
   });
 
   it("PUT /plugins/terminal/settings rejects non-boolean payloads", async () => {


### PR DESCRIPTION
## Summary
- Default Codex Agent CLI connections to App Server while preserving explicit ACP choices and session/effort behavior.
- Deliver Claude and Codex Carrier Tier-2 instructions with the first submitted prompt instead of provider system/developer channels.
- Require Kirov dispatches to provide and produce the exact plan file artifact.

## Test Plan
- [x] Core Unified Agent lint and focused unit tests
- [x] Fleet Carriers typecheck and focused tests
- [x] Fleet Admiral asset generation, typecheck, and contract tests
- [x] Changelog compiler tests
- [x] Added `.changelog.d/pr-249.md` with bilingual grouped entries and validated the complete fragment set

## Review
- Codex automated review intentionally skipped by direct user instruction.