### PR TITLE
fix(console): minimize each Theater's panels on first view

### DIFF
--- a/.changelog.d/pr-246.md
+++ b/.changelog.d/pr-246.md
@@ -1,4 +1,4 @@
 ### fleet-console
 #### Changed
-- [fleet-console] Start existing Operation panels minimized when Fleet Console opens.
-  ko: Fleet Console을 열 때 기존 Operation 패널을 최소화된 상태로 시작합니다.
+- [fleet-console] Start existing Operation panels minimized the first time each Theater opens in a session, and reveal a selected panel on its own.
+  ko: 세션 중 각 Theater를 처음 열 때 기존 Operation 패널을 최소화된 상태로 시작하고, 선택한 패널만 단독으로 나타냅니다.

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -34,7 +34,7 @@ function isBlockingDialogOpen(): boolean {
 
 export function App() {
   const state = useConsoleState();
-  const bootPanelsMinimizedRef = useRef(false);
+  const minimizedTheatersRef = useRef<Set<string>>(new Set());
   const bootOperationIdsRef = useRef<readonly string[] | null>(null);
   const location = useLocation();
   const registry = usePluginRegistry();
@@ -43,9 +43,13 @@ export function App() {
   const pathname = location.pathname;
   const operationsViewVisible = pathname.startsWith("/operations");
 
-  const claimBootPanelMinimization = useCallback((): readonly string[] | null => {
-    if (bootPanelsMinimizedRef.current || bootOperationIdsRef.current === null) return null;
-    bootPanelsMinimizedRef.current = true;
+  // 세션 중 각 Theater를 처음 여는 시점에 한 번, 그 Theater의 "부팅 시점에 이미 존재하던" 패널 집합을 최소화 대상으로 반환한다.
+  // App boot의 활성 Theater뿐 아니라 이후 선택·전환으로 처음 진입하는 Theater도 깨끗하게 열려, 선택한 패널만 하나씩 표면화된다.
+  // 반환값은 전 Theater를 아우르는 초기 id 목록이고, 실제 최소화는 호출 측이 현재 Theater 패널로 좁힌다.
+  const claimBootPanelMinimization = useCallback((theaterId: string): readonly string[] | null => {
+    if (bootOperationIdsRef.current === null) return null;
+    if (minimizedTheatersRef.current.has(theaterId)) return null;
+    minimizedTheatersRef.current.add(theaterId);
     return bootOperationIdsRef.current;
   }, []);
 

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -25,7 +25,7 @@ const closingOperationIds = new Set<string>();
 
 interface OperationsProps {
   readonly state: ConsoleState;
-  readonly claimBootPanelMinimization: () => readonly string[] | null;
+  readonly claimBootPanelMinimization: (theaterId: string) => readonly string[] | null;
 }
 
 export function Operations({ state, claimBootPanelMinimization }: OperationsProps) {
@@ -109,11 +109,15 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
     for (const operationId of operationOrder) ensureDefaultGeometry(operationId);
     if (!state.operationsHydrated) return;
     pruneOperations(operationOrder);
-    // App 최초 요청에서 받은 id만 한 번 최소화한다. 이후 생성·Theater 전환·route 재진입은 초기화에 포함하지 않는다.
+    // 각 Theater를 세션 중 처음 열 때 한 번, 그 Theater의 부팅 시점 기존 패널을 최소화한다.
+    // (App boot 활성 Theater뿐 아니라 선택·전환으로 처음 진입하는 Theater도 포함 — Map을 항상 깨끗하게 연다.)
+    // 이후 생성·route 재진입·같은 세션 재진입은 대상에서 빠져, 사용자의 restore를 보존한다.
     if (!state.activeTheaterId) return;
-    const bootOperationIds = claimBootPanelMinimization();
+    const bootOperationIds = claimBootPanelMinimization(state.activeTheaterId);
     if (bootOperationIds === null) return;
-    minimizeOperations(bootOperationIds);
+    // 선택으로 진입한 경우(pendingOperationFocus) 그 패널은 최소화에서 제외해 곧바로 표면화한다 — 선택한 패널만 하나씩 노출.
+    const focusId = stateRef.current.pendingOperationFocus;
+    minimizeOperations(focusId ? bootOperationIds.filter((id) => id !== focusId) : bootOperationIds);
   }, [claimBootPanelMinimization, operationOrder, state.activeTheaterId, state.operationsHydrated]);
 
   // 검색·ALERTS 등에서 들어온 일회성 이동 요청을 처리한다.

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -6,7 +6,7 @@ import { BrowserRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getSnapshot, loadForTheater, restoreOperation, setOperationGeometry } from "../core/client/src/canvas/canvas-store.js";
-import { getState, hydrateOperations, setState } from "../core/client/src/store.js";
+import { focusOperation, getState, hydrateOperations, setState } from "../core/client/src/store.js";
 import type { OperationNode, TheaterBootstrap } from "../core/client/src/types.js";
 
 const apiMocks = vi.hoisted(() => ({
@@ -157,6 +157,48 @@ describe("Operations boot minimization", () => {
     expect(getSnapshot().operations).toHaveProperty("initial");
     expect(getSnapshot().operations).toHaveProperty("launched");
   });
+
+  it("minimizes a second Theater's existing panels on first in-session view, surfacing only the selected panel", async () => {
+    const operations = deferred<readonly OperationNode[]>();
+    const theaters = deferred<TheaterBootstrap>();
+    apiMocks.fetchOperations.mockReturnValueOnce(operations.promise);
+    apiMocks.fetchTheaterBootstrap.mockReturnValueOnce(theaters.promise);
+    const { App } = await import("../core/client/src/app.js");
+
+    await act(async () => {
+      root!.render(createElement(BrowserRouter, null, createElement(App)));
+    });
+
+    // 부팅 응답에는 두 Theater의 기존 패널이 모두 담긴다.
+    await act(async () => {
+      operations.resolve([
+        operation("a1", 1, "theater-a"),
+        operation("b1", 1, "theater-b"),
+        operation("b2", 1, "theater-b"),
+      ]);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      theaters.resolve({ theaters: [theater(), theater("theater-b", "Theater B")] });
+      await Promise.resolve();
+    });
+
+    // 활성 Theater(A)는 부팅 최소화로 깨끗하게 열린다.
+    expect(getState().activeTheaterId).toBe("theater-a");
+    expect(getSnapshot().minimized).toEqual(["a1"]);
+
+    // 다른 Theater(B)의 패널을 선택 = Theater 전환. B는 이번 세션 최초 진입이므로 기존 패널을 최소화하되,
+    // 선택한 b1만 표면화되어 "하나씩" 노출된다. (수정 전에는 B의 모든 패널이 한꺼번에 노출됐다.)
+    await act(async () => {
+      focusOperation("b1");
+      await Promise.resolve();
+    });
+
+    expect(getState().activeTheaterId).toBe("theater-b");
+    expect(getSnapshot().minimized).toEqual(["b2"]);
+    expect(getSnapshot().operations).toHaveProperty("b1");
+    expect(getSnapshot().operations).toHaveProperty("b2");
+  });
 });
 
 async function navigateTo(pathname: string): Promise<void> {
@@ -175,10 +217,10 @@ function deferred<Value>() {
   return { promise, resolve };
 }
 
-function theater() {
+function theater(id = "theater-a", label = "Theater A") {
   return {
-    id: "theater-a",
-    label: "Theater A",
+    id,
+    label,
     createdAt: "2026-07-12T00:00:00.000Z",
     lastOpenedAt: "2026-07-12T00:00:00.000Z",
     hasWiki: false,
@@ -186,10 +228,10 @@ function theater() {
   };
 }
 
-function operation(id: string, createdAt = 1): OperationNode {
+function operation(id: string, createdAt = 1, theaterId = "theater-a"): OperationNode {
   return {
     id,
-    theaterId: "theater-a",
+    theaterId,
     type: "shell",
     pluginId: "terminal",
     title: id,


### PR DESCRIPTION
## Summary
- PR #246은 App 부팅 시 활성 Theater의 패널만 1회 최소화했다. 다른 Theater의 패널(peek 칩)을 선택하면 Theater가 전환되며 그 Theater의 저장된 canvas 상태(`minimized=[]`)가 그대로 로드돼 **모든 패널이 Map에 한꺼번에 노출**됐다. 부팅 최소화는 전역 1회성이라 재적용되지 않았다.
- 최소화를 **App boot 전역 1회 → 세션 중 각 Theater 최초 진입 시 1회**로 일반화한다. 어떤 Theater를 선택·전환해 처음 열든 Map을 깨끗하게 연다.
- 선택으로 진입한 경우(`pendingOperationFocus`) 그 패널만 최소화에서 제외해 **선택한 패널만 하나씩** 표면화한다.
- later launch(부팅 이후 생성), route 재진입, 같은 세션 내 restore는 그대로 보존한다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` (747 passed, 22 skipped) — cross-Theater 전환 시나리오 회귀 테스트 추가
- [x] `pnpm --filter @dotobokuri/fleet-console build` (green)
- [x] headed `agent-browser` console-e2e (격리 서버·2 Theater·각 3 op):
  - 부팅 시 활성 Theater 3패널 모두 최소화(Map 비어있음)
  - Theater A peek 칩 선택 → A-op1 하나만 노출, A-op2·A-op3 최소화
  - Theater B 재진입 → 선택 B-op2 하나만 노출, 나머지 최소화 보존
  - page error 0

## Changelog
- [x] 미출시 PR #246 동작에 대한 정제이므로 standalone `pr-250.md` 대신 pending `.changelog.d/pr-246.md`에 fold (`.changelog.d/AGENTS.md`의 Release Baseline 규칙)
- [x] `node scripts/compile-changelog-fragments.mjs --check` (OK: 19 entries)
- [x] 이중언어 요약·grouped syntax 유지