### PR TITLE
fix(desktop): block bootstrap history re-entry

### DIFF
--- a/.changelog.d/pr-251.md
+++ b/.changelog.d/pr-251.md
@@ -1,4 +1,4 @@
 ### fleet-desktop
 #### Fixed
-- [fleet-desktop] Prevent back navigation from reopening the bootstrap page after Console handoff.
+- [fleet-console] Prevent back navigation from reopening the bootstrap page after Console handoff.
   ko: Console 전환 후 뒤로가기로 부트스트랩 페이지가 다시 열리지 않도록 수정했습니다.

--- a/.changelog.d/pr-251.md
+++ b/.changelog.d/pr-251.md
@@ -1,0 +1,4 @@
+### fleet-desktop
+#### Fixed
+- [fleet-desktop] Prevent back navigation from reopening the bootstrap page after Console handoff.
+  ko: Console 전환 후 뒤로가기로 부트스트랩 페이지가 다시 열리지 않도록 수정했습니다.

--- a/runtime/fleet-desktop/e2e/desktop-shell.spec.ts
+++ b/runtime/fleet-desktop/e2e/desktop-shell.spec.ts
@@ -14,9 +14,47 @@ test.describe("unpackaged desktop shell", () => {
     const app = await electron.launch({ args: [path.resolve(main)], env: { ...process.env, FLEET_CONSOLE_NODE_PATH: nodePath } });
     try {
       const window = await app.firstWindow();
-      await expect(window.getByText("Fleet Console")).toBeVisible();
       await expect(window).toHaveURL(/\/console\//);
       expect(new URL(window.url()).search).toBe("");
+
+      const handoffUrl = window.url();
+      const history = await app.evaluate(({ BrowserWindow }) => {
+        const contents = BrowserWindow.getAllWindows()[0]?.webContents;
+        if (!contents) throw new Error("desktop_window_unavailable");
+        return {
+          activeIndex: contents.navigationHistory.getActiveIndex(),
+          canGoBack: contents.navigationHistory.canGoBack(),
+          entries: contents.navigationHistory.getAllEntries().map(({ url }) => url),
+        };
+      });
+      expect(history).toEqual({ activeIndex: 0, canGoBack: false, entries: [handoffUrl] });
+
+      await window.evaluate(() => history.back());
+      await window.waitForTimeout(250);
+      expect(window.url()).toBe(handoffUrl);
+      await expect(window.locator(".entry-body")).toHaveCount(0);
+
+      expect(await window.goBack({ waitUntil: "domcontentloaded" })).toBeNull();
+      expect(window.url()).toBe(handoffUrl);
+      await expect(window.locator(".entry-body")).toHaveCount(0);
+
+      const mainProcessBack = await app.evaluate(({ BrowserWindow }) => {
+        const contents = BrowserWindow.getAllWindows()[0]?.webContents;
+        if (!contents) throw new Error("desktop_window_unavailable");
+        const canGoBack = contents.navigationHistory.canGoBack();
+        if (canGoBack) contents.navigationHistory.goBack();
+        return canGoBack;
+      });
+      expect(mainProcessBack).toBe(false);
+      await window.waitForTimeout(250);
+      expect(window.url()).toBe(handoffUrl);
+      await expect(window.locator(".entry-body")).toHaveCount(0);
+
+      await window.evaluate(() => history.pushState({}, "", "/console/history-probe"));
+      expect(new URL(window.url()).pathname).toBe("/console/history-probe");
+      await window.goBack();
+      expect(window.url()).toBe(handoffUrl);
+      await expect(window.locator(".entry-body")).toHaveCount(0);
     } finally {
       await app.close();
     }

--- a/runtime/fleet-desktop/src/launch-controller.ts
+++ b/runtime/fleet-desktop/src/launch-controller.ts
@@ -6,7 +6,7 @@ export interface LaunchWindow {
   isDestroyed?(): boolean;
   loadURL(url: string): Promise<void>;
   show(): void;
-  webContents: EntryPageWebContents;
+  webContents: EntryPageWebContents & { navigationHistory: { clear(): void } };
 }
 
 export interface LaunchControllerDependencies {
@@ -52,7 +52,10 @@ export function createLaunchController(dependencies: LaunchControllerDependencie
       dependencies.handoffOrigin(origin);
       await dependencies.synchronizeTheme?.(origin);
       await push("starting", "ready");
-      if (!window.isDestroyed?.()) await window.loadURL(consoleUrl);
+      if (!window.isDestroyed?.()) {
+        await window.loadURL(consoleUrl);
+        if (!window.isDestroyed?.()) window.webContents.navigationHistory.clear();
+      }
       if (!window.isDestroyed?.()) dependencies.onConsoleLoaded?.();
       return window;
     },

--- a/runtime/fleet-desktop/tests/launch-controller.test.ts
+++ b/runtime/fleet-desktop/tests/launch-controller.test.ts
@@ -5,16 +5,90 @@ import { createLaunchController } from "../src/launch-controller.js";
 describe("launch controller", () => {
   it("shows entry before startOrAdopt and arms the exact loopback origin before handoff", async () => {
     const order: string[] = [];
-    const contents = { executeJavaScript: vi.fn(async () => undefined) };
+    const contents = { executeJavaScript: vi.fn(async () => undefined), navigationHistory: { clear: vi.fn(() => order.push("history-cleared")) } };
     const window = { webContents: contents, show: vi.fn(() => order.push("show")), loadURL: vi.fn(async () => { order.push("handoff"); }) };
     const controller = createLaunchController({ createWindow: vi.fn(async () => window), pushEntry: vi.fn(async () => { order.push("entry"); }), startOrAdopt: vi.fn(async () => { order.push("start"); return "http://127.0.0.1:4310/console/"; }), handoffOrigin: vi.fn((origin) => { order.push(`origin=${origin}`); }), onConsoleLoaded: () => { order.push("console-loaded"); } });
     await controller.start();
-    expect(order).toEqual(["entry", "show", "start", "origin=http://127.0.0.1:4310", "entry", "handoff", "console-loaded"]);
+    expect(order).toEqual(["entry", "show", "start", "origin=http://127.0.0.1:4310", "entry", "handoff", "history-cleared", "console-loaded"]);
+  });
+
+  it("clears the bootstrap entry from back history only after the Console handoff succeeds", async () => {
+    const order: string[] = [];
+    const history = ["file:///desktop/entry/index.html"];
+    const contents = {
+      executeJavaScript: vi.fn(async () => undefined),
+      navigationHistory: { clear: vi.fn(() => {
+        order.push("history-cleared");
+        history.splice(0, history.length, "http://127.0.0.1:4310/console/");
+      }) },
+    };
+    const window = {
+      webContents: contents,
+      show: vi.fn(),
+      loadURL: vi.fn(async (url: string) => {
+        order.push("handoff");
+        history.push(url);
+      }),
+    };
+    const controller = createLaunchController({
+      createWindow: vi.fn(async () => window),
+      pushEntry: vi.fn(async () => undefined),
+      startOrAdopt: vi.fn(async () => "http://127.0.0.1:4310/console/"),
+      handoffOrigin: vi.fn(),
+      onConsoleLoaded: () => order.push("console-loaded"),
+    });
+
+    await controller.start();
+
+    expect(order).toEqual(["handoff", "history-cleared", "console-loaded"]);
+    expect(contents.navigationHistory.clear).toHaveBeenCalledOnce();
+    expect(history).toEqual(["http://127.0.0.1:4310/console/"]);
+  });
+
+  it("does not clear history when the Console handoff fails", async () => {
+    const clear = vi.fn();
+    const window = {
+      webContents: { executeJavaScript: vi.fn(async () => undefined), navigationHistory: { clear } },
+      show: vi.fn(),
+      loadURL: vi.fn(async () => { throw new Error("console_load_failed"); }),
+    };
+    const controller = createLaunchController({
+      createWindow: vi.fn(async () => window),
+      pushEntry: vi.fn(async () => undefined),
+      startOrAdopt: vi.fn(async () => "http://127.0.0.1:4310/console/"),
+      handoffOrigin: vi.fn(),
+    });
+
+    await expect(controller.start()).rejects.toThrow("console_load_failed");
+    expect(clear).not.toHaveBeenCalled();
+  });
+
+  it("does not clear history if the window closes during the Console handoff", async () => {
+    let destroyed = false;
+    const clear = vi.fn();
+    const onConsoleLoaded = vi.fn();
+    const window = {
+      isDestroyed: () => destroyed,
+      webContents: { executeJavaScript: vi.fn(async () => undefined), navigationHistory: { clear } },
+      show: vi.fn(),
+      loadURL: vi.fn(async () => { destroyed = true; }),
+    };
+    const controller = createLaunchController({
+      createWindow: vi.fn(async () => window),
+      pushEntry: vi.fn(async () => undefined),
+      startOrAdopt: vi.fn(async () => "http://127.0.0.1:4310/console/"),
+      handoffOrigin: vi.fn(),
+      onConsoleLoaded,
+    });
+
+    await controller.start();
+    expect(clear).not.toHaveBeenCalled();
+    expect(onConsoleLoaded).not.toHaveBeenCalled();
   });
 
   it("synchronizes the Console-owned title bar theme after origin activation and before handoff", async () => {
     const order: string[] = [];
-    const window = { webContents: { executeJavaScript: vi.fn(async () => undefined) }, show: vi.fn(), loadURL: vi.fn(async () => { order.push("handoff"); }) };
+    const window = { webContents: { executeJavaScript: vi.fn(async () => undefined), navigationHistory: { clear: vi.fn() } }, show: vi.fn(), loadURL: vi.fn(async () => { order.push("handoff"); }) };
     const controller = createLaunchController({
       createWindow: vi.fn(async () => window),
       pushEntry: vi.fn(async () => undefined),
@@ -31,7 +105,7 @@ describe("launch controller", () => {
   it("wires runtime progress, first-run failure Retry, and same-window handoff through the production launch graph", async () => {
     const snapshots: string[] = [];
     let progress: ((state: "checking" | "node" | "installing" | "offline" | "firstfail" | "starting" | "dev", detail?: string, progress?: number) => Promise<void>) | undefined;
-    const contents = { executeJavaScript: vi.fn(async () => undefined) };
+    const contents = { executeJavaScript: vi.fn(async () => undefined), navigationHistory: { clear: vi.fn() } };
     const window = { webContents: contents, show: vi.fn(), loadURL: vi.fn(async () => undefined) };
     let attempts = 0;
     const controller = createLaunchController({
@@ -56,7 +130,7 @@ describe("launch controller", () => {
   it("does not mislabel supervisor ownership failures as first-run procurement failures", async () => {
     const pushEntry = vi.fn(async () => undefined);
     const onFirstRunFailure = vi.fn(async () => true);
-    const window = { webContents: { executeJavaScript: vi.fn(async () => undefined) }, show: vi.fn(), loadURL: vi.fn(async () => undefined) };
+    const window = { webContents: { executeJavaScript: vi.fn(async () => undefined), navigationHistory: { clear: vi.fn() } }, show: vi.fn(), loadURL: vi.fn(async () => undefined) };
     const controller = createLaunchController({ createWindow: vi.fn(async () => window), pushEntry, startOrAdopt: vi.fn(async () => { throw new Error("cli_daemon_requires_confirmation"); }), handoffOrigin: vi.fn(), onFirstRunFailure });
     await expect(controller.start()).rejects.toThrow("cli_daemon_requires_confirmation");
     expect(onFirstRunFailure).not.toHaveBeenCalled();
@@ -66,7 +140,7 @@ describe("launch controller", () => {
   it("does not push or hand off a window destroyed while procurement was pending", async () => {
     let destroyed = false;
     const pushEntry = vi.fn(async () => undefined);
-    const window = { isDestroyed: () => destroyed, webContents: { executeJavaScript: vi.fn(async () => undefined) }, show: vi.fn(), loadURL: vi.fn(async () => { throw new Error("destroyed window"); }) };
+    const window = { isDestroyed: () => destroyed, webContents: { executeJavaScript: vi.fn(async () => undefined), navigationHistory: { clear: vi.fn() } }, show: vi.fn(), loadURL: vi.fn(async () => { throw new Error("destroyed window"); }) };
     const controller = createLaunchController({
       createWindow: vi.fn(async () => window),
       pushEntry,


### PR DESCRIPTION
## Summary
- remove the passive Desktop bootstrap page from navigation history after a successful Console handoff
- keep failed and destroyed handoffs safe while preserving Console-internal back navigation
- cover renderer, CDP, and Electron main-process back paths in headed E2E

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-desktop test`
- [x] `pnpm --filter @dotobokuri/fleet-desktop typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-desktop build`
- [x] macOS arm64 headed Electron `desktop-shell.spec.ts`

## Changelog
- [x] `.changelog.d/pr-251.md`
- [x] grouped bilingual fragment syntax
- [x] `node scripts/compile-changelog-fragments.mjs --check`