### PR TITLE
fix(fleet-console): keep minimap visible by default

### DIFF
--- a/.changelog.d/pr-253.md
+++ b/.changelog.d/pr-253.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Changed
+- [fleet-console] Keep the minimap visible in the default canvas view and remove the Map collapse button.
+  ko: 기본 캔버스 화면에서 미니맵을 항상 표시하고 Map 접기 버튼을 제거합니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-minimap.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-minimap.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import { useRef, type PointerEvent as ReactPointerEvent } from "react";
 
-import { useFormationView, type CanvasViewport, type OperationGeometry } from "./canvas-store.js";
+import type { CanvasViewport, OperationGeometry } from "./canvas-store.js";
 import type { CanvasPoint } from "./coordinates.js";
 
 interface PluginOperationEntry {
@@ -30,28 +30,10 @@ const MINIMAP_HEIGHT = 176;
 const MINIMAP_PADDING = 12;
 // Operation/뷰포트 묶음 주변에 두는 world 여유 — 가장자리에 붙지 않게 한다.
 const WORLD_MARGIN = 220;
-const RADAR_COLLAPSED_STORAGE_KEY = "fleet-console.map.radarCollapsed";
 
 export function CanvasMinimap({ operations, pluginOperations, viewport, canvasSize, onJump }: CanvasMinimapProps) {
   const innerRef = useRef<HTMLDivElement | null>(null);
   const draggingRef = useRef(false);
-  const collapsedBeforeFormationRef = useRef<boolean | null>(null);
-  const [collapsed, setCollapsed] = useState(readCollapsed);
-  const formationView = useFormationView();
-
-  useEffect(() => {
-    if (formationView) {
-      if (collapsedBeforeFormationRef.current === null) {
-        collapsedBeforeFormationRef.current = collapsed;
-        setCollapsed(true);
-      }
-      return;
-    }
-    if (collapsedBeforeFormationRef.current === null) return;
-    // Formation의 기본 최소화와 수동 펼침은 세션 한정이다. 기존 Map 선호 저장값은 건드리지 않는다.
-    setCollapsed(collapsedBeforeFormationRef.current);
-    collapsedBeforeFormationRef.current = null;
-  }, [collapsed, formationView]);
 
   if (canvasSize.width <= 0 || canvasSize.height <= 0 || viewport.zoom <= 0) return null;
 
@@ -59,33 +41,8 @@ export function CanvasMinimap({ operations, pluginOperations, viewport, canvasSi
     ...Object.entries(operations).map(([id, g]) => ({ id, x: g.x, y: g.y, width: g.width, height: g.height })),
     ...Object.entries(pluginOperations).map(([id, e]) => ({ id, x: e.geometry.x, y: e.geometry.y, width: e.geometry.width, height: e.geometry.height })),
   ];
-  // 표시할 Operation이 없으면 위치 인지에 의미가 없으므로 미니맵(과 접힘 버튼)을 숨긴다.
+  // 표시할 Operation이 없으면 위치 인지에 의미가 없으므로 미니맵을 숨긴다.
   if (rects.length === 0) return null;
-
-  const toggle = () => {
-    setCollapsed((value) => {
-      const next = !value;
-      // Formation 중에는 종료 시 진입 전 상태를 복원하므로 수동 펼침을 영속 선호로 기록하지 않는다.
-      if (!formationView) writeCollapsed(next);
-      return next;
-    });
-  };
-
-  // 접힘: 우하단에 Map 아이콘 버튼 하나만 노출한다.
-  if (collapsed) {
-    return (
-      <button
-        type="button"
-        className="canvas-minimap-fab"
-        data-canvas-blocker
-        onClick={toggle}
-        aria-label="Open Map"
-        title="Open Map"
-      >
-        <MapGlyph />
-      </button>
-    );
-  }
 
   const innerW = MINIMAP_WIDTH - MINIMAP_PADDING * 2;
   const innerH = MINIMAP_HEIGHT - MINIMAP_PADDING * 2;
@@ -149,15 +106,6 @@ export function CanvasMinimap({ operations, pluginOperations, viewport, canvasSi
   return (
     <div className="canvas-minimap" data-canvas-blocker style={{ width: MINIMAP_WIDTH, height: MINIMAP_HEIGHT }}>
       <span className="canvas-minimap-label" aria-hidden="true">Map</span>
-      <button
-        type="button"
-        className="canvas-minimap-toggle"
-        onClick={toggle}
-        aria-label="Collapse Map"
-        title="Collapse Map"
-      >
-        <CollapseIcon />
-      </button>
       <div
         ref={innerRef}
         className="canvas-minimap-inner"
@@ -182,43 +130,5 @@ export function CanvasMinimap({ operations, pluginOperations, viewport, canvasSi
         />
       </div>
     </div>
-  );
-}
-
-function readCollapsed(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return window.localStorage.getItem(RADAR_COLLAPSED_STORAGE_KEY) === "true";
-  } catch {
-    return false;
-  }
-}
-
-function writeCollapsed(value: boolean): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(RADAR_COLLAPSED_STORAGE_KEY, String(value));
-  } catch {
-    // Map 접힘 선호 저장 실패는 런타임 동작을 막지 않는다.
-  }
-}
-
-function CollapseIcon() {
-  // 우하단으로 접는 방향을 가리키는 셰브런.
-  return (
-    <svg viewBox="0 0 16 16" aria-hidden="true">
-      <path d="M5.5 4.5 10.5 8l-5 3.5M11 8H5.5" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
-}
-
-function MapGlyph() {
-  // 접힌 Map을 나타내는 미니맵 모양 글리프.
-  return (
-    <svg viewBox="0 0 16 16" aria-hidden="true">
-      <rect x="2" y="3" width="12" height="10" rx="2" fill="none" stroke="currentColor" strokeWidth="1.2" />
-      <rect x="4.2" y="5" width="4.2" height="3.1" rx="0.6" fill="none" stroke="currentColor" strokeWidth="1" />
-      <circle cx="11" cy="10.2" r="0.95" fill="currentColor" />
-    </svg>
   );
 }

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -259,20 +259,22 @@ export function OperationsCanvas({
           onClose={() => setContextMenu(null)}
         />
       ) : null}
-      <CanvasMinimap
-        operations={visibleOperations}
-        pluginOperations={Object.fromEntries(theaterOperations.filter((operation) => !minimizedSet.has(operation.id)).map((operation) => [operation.id, {
-          theaterId: operation.theaterId,
-          geometry: canvas.operations[operation.id] ?? operation.geometry ?? ensurePluginGeometry(operation),
-        }]))}
-        viewport={canvas.viewport}
-        canvasSize={canvasSize}
-        onJump={(center) => setViewport({
-          x: canvasSize.width / 2 - center.x * canvas.viewport.zoom,
-          y: canvasSize.height / 2 - center.y * canvas.viewport.zoom,
-          zoom: canvas.viewport.zoom,
-        })}
-      />
+      {!formationView && !panelMaximized ? (
+        <CanvasMinimap
+          operations={visibleOperations}
+          pluginOperations={Object.fromEntries(theaterOperations.filter((operation) => !minimizedSet.has(operation.id)).map((operation) => [operation.id, {
+            theaterId: operation.theaterId,
+            geometry: canvas.operations[operation.id] ?? operation.geometry ?? ensurePluginGeometry(operation),
+          }]))}
+          viewport={canvas.viewport}
+          canvasSize={canvasSize}
+          onJump={(center) => setViewport({
+            x: canvasSize.width / 2 - center.x * canvas.viewport.zoom,
+            y: canvasSize.height / 2 - center.y * canvas.viewport.zoom,
+            zoom: canvas.viewport.zoom,
+          })}
+        />
+      ) : null}
     </main>
   );
 }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2137,11 +2137,6 @@
 }
 
 
-.operations-canvas.is-panel-maximized .canvas-minimap,
-.operations-canvas.is-panel-maximized .canvas-minimap-fab {
-  display: none;
-}
-
 /* 순정 셸 패널 — Operation과 구별되도록 띠바에 아우로라(살아있는 것) 톤의 옅은 강조를 준다. */
 .canvas-operation--shell .canvas-operation-titlebar {
   background: color-mix(in oklch, var(--aurora) 9%, color-mix(in oklch, var(--ink-deep) 28%, transparent));
@@ -2540,70 +2535,6 @@
     0 0 14px color-mix(in oklch, var(--brass) 32%, transparent),
     inset 0 0 12px color-mix(in oklch, var(--brass) 18%, transparent);
   pointer-events: none;
-}
-
-/* Map 접기 토글 — 미니맵 우상단 모서리. */
-.canvas-minimap-toggle {
-  position: absolute;
-  top: 5px;
-  right: 6px;
-  z-index: 4;
-  display: grid;
-  place-items: center;
-  width: 22px;
-  height: 22px;
-  border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
-  background: color-mix(in oklch, var(--surface-glass) 78%, var(--ink-deep));
-  color: var(--brass);
-  transition:
-    color var(--duration-fast) var(--ease-spring),
-    border-color var(--duration-fast) var(--ease-spring),
-    background var(--duration-fast) var(--ease-spring);
-}
-
-/* 접힌 Map — 우하단 단일 Map 아이콘 버튼. */
-.canvas-minimap-fab {
-  position: absolute;
-  right: var(--space-4);
-  bottom: var(--space-4);
-  z-index: 14;
-  display: grid;
-  place-items: center;
-  width: 36px;
-  height: 36px;
-  border: 1px solid color-mix(in oklch, var(--brass) 30%, var(--surface-rim));
-  border-radius: var(--radius-lg);
-  background:
-    radial-gradient(130% 100% at 50% 0%, color-mix(in oklch, var(--brass) 9%, transparent), transparent 62%),
-    color-mix(in oklch, var(--surface-glass) 60%, color-mix(in oklch, var(--ink-deep) 72%, transparent));
-  color: var(--brass);
-  box-shadow: var(--shadow-anchor);
-  transition:
-    color var(--duration-fast) var(--ease-spring),
-    border-color var(--duration-fast) var(--ease-spring),
-    background var(--duration-fast) var(--ease-spring);
-}
-
-.canvas-minimap-toggle:hover,
-.canvas-minimap-toggle:focus-visible,
-.canvas-minimap-fab:hover,
-.canvas-minimap-fab:focus-visible {
-  color: var(--brass-bright);
-  border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
-  background: color-mix(in oklch, var(--brass) 11%, var(--surface-glass));
-}
-
-.canvas-minimap-toggle svg {
-  display: block;
-  width: 13px;
-  height: 13px;
-}
-
-.canvas-minimap-fab svg {
-  display: block;
-  width: 18px;
-  height: 18px;
 }
 
 .operations-canvas-world {

--- a/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
+++ b/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
@@ -2,21 +2,57 @@
 
 import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { OperationsCanvas } from "../core/client/src/canvas/canvas.js";
 import { CanvasMinimap } from "../core/client/src/canvas/canvas-minimap.js";
-import { clearFormationView, loadForTheater, toggleFormationView } from "../core/client/src/canvas/canvas-store.js";
+import { clearFormationView, clearMaximizedOperationId, getSnapshot, loadForTheater, setMaximizedOperationId, setState, toggleFormationView } from "../core/client/src/canvas/canvas-store.js";
+import type { ConsoleState, OperationNode } from "../core/client/src/types.js";
+
+vi.mock("../core/client/src/plugin-registry.js", () => ({
+  usePluginRegistry: () => ({ plugins: [], operationKinds: [], settingsSections: [], notificationKinds: [], railPanels: [] }),
+}));
 
 let root: Root | null = null;
 let container: HTMLDivElement | null = null;
+let resizeObserverDescriptor: PropertyDescriptor | undefined;
+let setPointerCaptureDescriptor: PropertyDescriptor | undefined;
+let releasePointerCaptureDescriptor: PropertyDescriptor | undefined;
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 beforeEach(() => {
   document.body.replaceChildren();
   window.localStorage.clear();
-  loadForTheater("formation-minimap-test");
+  resizeObserverDescriptor = Object.getOwnPropertyDescriptor(globalThis, "ResizeObserver");
+  setPointerCaptureDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "setPointerCapture");
+  releasePointerCaptureDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "releasePointerCapture");
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    configurable: true,
+    value: class {
+      constructor(private readonly callback: ResizeObserverCallback) {}
+
+      observe(target: Element) {
+        Object.defineProperties(target, {
+          clientWidth: { configurable: true, value: 900 },
+          clientHeight: { configurable: true, value: 600 },
+        });
+        this.callback([], this as unknown as ResizeObserver);
+      }
+
+      disconnect() {}
+      unobserve() {}
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "setPointerCapture", { configurable: true, value: () => {} });
+  Object.defineProperty(HTMLElement.prototype, "releasePointerCapture", { configurable: true, value: () => {} });
+  loadForTheater("minimap-boundary");
   clearFormationView();
+  clearMaximizedOperationId();
+  setState({
+    viewport: { x: 0, y: 0, zoom: 1 },
+    operations: { operation: { x: 0, y: 0, width: 320, height: 200, zIndex: 1 } },
+  });
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -25,13 +61,20 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root?.unmount());
   clearFormationView();
+  clearMaximizedOperationId();
+  loadForTheater(null);
+  window.localStorage.clear();
+  restoreProperty(globalThis, "ResizeObserver", resizeObserverDescriptor);
+  restoreProperty(HTMLElement.prototype, "setPointerCapture", setPointerCaptureDescriptor);
+  restoreProperty(HTMLElement.prototype, "releasePointerCapture", releasePointerCaptureDescriptor);
   container?.remove();
   root = null;
   container = null;
 });
 
-describe("CanvasMinimap Formation behavior", () => {
-  it("collapses on Formation entry and restores the pre-entry state on exit", () => {
+describe("CanvasMinimap visibility", () => {
+  it("always renders the full minimap in the default canvas state", () => {
+    window.localStorage.setItem("fleet-console.map.radarCollapsed", "true");
     act(() => root!.render(createElement(CanvasMinimap, {
       operations: { operation: { x: 0, y: 0, width: 320, height: 200, zIndex: 1 } },
       pluginOperations: {},
@@ -39,15 +82,139 @@ describe("CanvasMinimap Formation behavior", () => {
       canvasSize: { width: 900, height: 600 },
       onJump: () => {},
     })));
-    expect(document.querySelector('[aria-label="Collapse Map"]')).not.toBeNull();
+    expect(document.querySelector(".canvas-minimap")).not.toBeNull();
+    expect(document.querySelector('[aria-label="Open Map"]')).toBeNull();
+    expect(document.querySelector('[aria-label="Collapse Map"]')).toBeNull();
+  });
+
+  it("preserves the no-operations and invalid-viewport guards", () => {
+    act(() => root!.render(createElement(CanvasMinimap, {
+      operations: {},
+      pluginOperations: {},
+      viewport: { x: 0, y: 0, zoom: 1 },
+      canvasSize: { width: 900, height: 600 },
+      onJump: () => {},
+    })));
+    expect(document.querySelector(".canvas-minimap")).toBeNull();
+
+    act(() => root!.render(createElement(CanvasMinimap, {
+      operations: { operation: { x: 0, y: 0, width: 320, height: 200, zIndex: 1 } },
+      pluginOperations: {},
+      viewport: { x: 0, y: 0, zoom: 0 },
+      canvasSize: { width: 900, height: 600 },
+      onJump: () => {},
+    })));
+    expect(document.querySelector(".canvas-minimap")).toBeNull();
+  });
+
+  it("mounts at the OperationsCanvas boundary only in the default state and restores after Formation or maximize", () => {
+    renderOperationsCanvas();
+    expect(document.querySelector(".canvas-minimap")).not.toBeNull();
 
     act(() => toggleFormationView());
-    expect(document.querySelector('[aria-label="Open Map"]')).not.toBeNull();
-
-    act(() => document.querySelector<HTMLButtonElement>('[aria-label="Open Map"]')!.click());
-    expect(document.querySelector('[aria-label="Collapse Map"]')).not.toBeNull();
+    expect(document.querySelector(".canvas-minimap")).toBeNull();
 
     act(() => clearFormationView());
-    expect(document.querySelector('[aria-label="Collapse Map"]')).not.toBeNull();
+    expect(document.querySelector(".canvas-minimap")).not.toBeNull();
+
+    act(() => setMaximizedOperationId("operation"));
+    expect(document.querySelector(".canvas-minimap")).toBeNull();
+
+    act(() => clearMaximizedOperationId());
+    expect(document.querySelector(".canvas-minimap")).not.toBeNull();
+  });
+
+  it("moves the canvas viewport when the mounted minimap receives pointer navigation", () => {
+    renderOperationsCanvas();
+    const inner = document.querySelector<HTMLDivElement>(".canvas-minimap-inner");
+    expect(inner).not.toBeNull();
+    Object.defineProperty(inner!, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({ left: 0, top: 0 }),
+    });
+    const pointerDown = new MouseEvent("pointerdown", { bubbles: true, clientX: 0, clientY: 0 });
+    Object.defineProperty(pointerDown, "pointerId", { value: 1 });
+
+    act(() => inner!.dispatchEvent(pointerDown));
+
+    expect(getSnapshot().viewport).toMatchObject({ zoom: 1 });
+    expect(getSnapshot().viewport.x).toBeGreaterThan(0);
+    expect(getSnapshot().viewport.y).toBeGreaterThan(0);
   });
 });
+
+const OPERATION: OperationNode = {
+  id: "operation",
+  theaterId: "minimap-boundary",
+  type: "shell",
+  pluginId: "test-plugin",
+  title: "Minimap boundary",
+  payload: {},
+  geometry: { x: 0, y: 0, width: 320, height: 200, zIndex: 1 },
+  ts: { createdAt: 0, updatedAt: 0 },
+};
+
+const CANVAS_STATE: ConsoleState = {
+  connection: "connecting",
+  connectionError: null,
+  activeTheme: "maritime",
+  version: "test",
+  updateAvailable: false,
+  latestVersion: null,
+  portMode: "dynamic",
+  requestedPort: null,
+  effectivePort: 0,
+  portHonored: true,
+  theaters: [],
+  operations: [OPERATION],
+  operationsHydrated: true,
+  groups: [],
+  activeTheaterId: "minimap-boundary",
+  activeOperationId: null,
+  operationStatus: {},
+  addingTheater: false,
+  theaterError: null,
+  operationsViewActive: true,
+  operationSearchOpen: false,
+  whatsNewOpen: false,
+  releaseNotes: [],
+  releaseNotesLoading: false,
+  releaseNotesError: null,
+  releaseNotesSourceRef: null,
+  releaseNotesFetchedAt: null,
+  releaseNotesStale: false,
+  automaticWhatsNewVersion: null,
+  selectedReleaseNoteKey: null,
+  onboardingOpen: false,
+  bootstrapped: true,
+  pendingOperationFocus: null,
+  operationNotifications: {},
+  notificationPreferences: { globalMute: false, dnd: false, mutedTheaterIds: {} },
+  codexReader: null,
+  codexReaderExpanded: false,
+};
+
+function renderOperationsCanvas() {
+  act(() => root!.render(createElement(OperationsCanvas, {
+    state: CANVAS_STATE,
+    catalog: [],
+    canLaunch: false,
+    renderKindIcon: () => null,
+    onLaunchKind: () => {},
+    onLaunchAtGeometry: () => {},
+    onResetView: () => {},
+    onToggleFormation: () => {},
+    onClose: () => {},
+    onFocus: () => {},
+    onRename: () => {},
+    onSetAccent: () => {},
+  })));
+}
+
+function restoreProperty(target: object, key: PropertyKey, descriptor: PropertyDescriptor | undefined) {
+  if (descriptor) {
+    Object.defineProperty(target, key, descriptor);
+  } else {
+    Reflect.deleteProperty(target, key);
+  }
+}

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -39,12 +39,17 @@ describe("Instrument core design contract", () => {
     for (const path of OWNED_SOURCES) expect(source(path)).not.toMatch(FORBIDDEN_DECORATION);
   });
 
-  it("keeps Map labels and navigation behavior while removing animation controls", () => {
+  it("keeps minimap navigation while removing Map collapse controls", () => {
     const minimap = source("canvas/canvas-minimap.tsx");
+    const canvas = source("canvas/canvas.tsx");
+    const components = source("styles/components.css");
     const contextMenu = source("canvas/canvas-context-menu.tsx");
     expect(minimap).toContain(">Map<");
     expect(minimap).toContain("onPointerMove={onPointerMove}");
     expect(minimap).toContain("onJump({");
+    expect(minimap).not.toMatch(/localStorage|Collapsed|Open Map|Collapse Map|canvas-minimap-(?:fab|toggle)/);
+    expect(canvas).toContain("{!formationView && !panelMaximized ? (");
+    expect(components).not.toMatch(/canvas-minimap-(?:fab|toggle)/);
     expect(contextMenu).toContain("Formation view");
     expect(contextMenu).not.toContain("onToggleRadar");
     expect(contextMenu).not.toContain("onTogglePerimeter");


### PR DESCRIPTION
## Summary
- remove the collapsible Map button and its persisted preference
- always show the full minimap in the default canvas view
- hide the minimap during Formation and panel maximization, restoring it afterward

## Test Plan
- [x] Console production build with workspace dependencies
- [x] Console full test suite (749 passed, 22 skipped)
- [x] focused minimap render/navigation tests (15 passed)
- [x] headed browser E2E: default, Formation, maximize, responsive, stale preference, errors
- [x] `.changelog.d/pr-253.md` syntax, bilingual summaries, and fragment validation

## Notes
- Console typecheck reaches the client pass but is blocked by existing missing CSS and `virtual:fleet-plugins` declarations; the production Vite build passes.