### PR TITLE
fix(fleet-console): restore minimap collapse controls

### DIFF
--- a/.changelog.d/pr-254.md
+++ b/.changelog.d/pr-254.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Changed
+- [fleet-console] Restore the minimap collapse controls while hiding Map surfaces during Formation and panel maximization.
+  ko: 미니맵 접기 컨트롤을 복원하고 Formation 및 패널 최대화 중에는 Map 화면과 단축 아이콘을 숨깁니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-minimap.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-minimap.tsx
@@ -1,6 +1,6 @@
-import { useRef, type PointerEvent as ReactPointerEvent } from "react";
+import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
 
-import type { CanvasViewport, OperationGeometry } from "./canvas-store.js";
+import { useFormationView, type CanvasViewport, type OperationGeometry } from "./canvas-store.js";
 import type { CanvasPoint } from "./coordinates.js";
 
 interface PluginOperationEntry {
@@ -30,10 +30,28 @@ const MINIMAP_HEIGHT = 176;
 const MINIMAP_PADDING = 12;
 // Operation/뷰포트 묶음 주변에 두는 world 여유 — 가장자리에 붙지 않게 한다.
 const WORLD_MARGIN = 220;
+const RADAR_COLLAPSED_STORAGE_KEY = "fleet-console.map.radarCollapsed";
 
 export function CanvasMinimap({ operations, pluginOperations, viewport, canvasSize, onJump }: CanvasMinimapProps) {
   const innerRef = useRef<HTMLDivElement | null>(null);
   const draggingRef = useRef(false);
+  const collapsedBeforeFormationRef = useRef<boolean | null>(null);
+  const [collapsed, setCollapsed] = useState(readCollapsed);
+  const formationView = useFormationView();
+
+  useEffect(() => {
+    if (formationView) {
+      if (collapsedBeforeFormationRef.current === null) {
+        collapsedBeforeFormationRef.current = collapsed;
+        setCollapsed(true);
+      }
+      return;
+    }
+    if (collapsedBeforeFormationRef.current === null) return;
+    // Formation의 임시 접힘은 저장하지 않고, 진입 전 Map 상태를 복원한다.
+    setCollapsed(collapsedBeforeFormationRef.current);
+    collapsedBeforeFormationRef.current = null;
+  }, [collapsed, formationView]);
 
   if (canvasSize.width <= 0 || canvasSize.height <= 0 || viewport.zoom <= 0) return null;
 
@@ -41,8 +59,33 @@ export function CanvasMinimap({ operations, pluginOperations, viewport, canvasSi
     ...Object.entries(operations).map(([id, g]) => ({ id, x: g.x, y: g.y, width: g.width, height: g.height })),
     ...Object.entries(pluginOperations).map(([id, e]) => ({ id, x: e.geometry.x, y: e.geometry.y, width: e.geometry.width, height: e.geometry.height })),
   ];
-  // 표시할 Operation이 없으면 위치 인지에 의미가 없으므로 미니맵을 숨긴다.
+  // 표시할 Operation이 없으면 위치 인지에 의미가 없으므로 미니맵과 접힘 버튼을 숨긴다.
   if (rects.length === 0) return null;
+
+  const toggle = () => {
+    setCollapsed((value) => {
+      const next = !value;
+      // Formation 중 수동 전환은 종료 시 원래 상태를 복원하므로 선호를 저장하지 않는다.
+      if (!formationView) writeCollapsed(next);
+      return next;
+    });
+  };
+
+  // 접힘: 우하단에 Map 아이콘 버튼 하나만 노출한다.
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        className="canvas-minimap-fab"
+        data-canvas-blocker
+        onClick={toggle}
+        aria-label="Open Map"
+        title="Open Map"
+      >
+        <MapGlyph />
+      </button>
+    );
+  }
 
   const innerW = MINIMAP_WIDTH - MINIMAP_PADDING * 2;
   const innerH = MINIMAP_HEIGHT - MINIMAP_PADDING * 2;
@@ -106,6 +149,15 @@ export function CanvasMinimap({ operations, pluginOperations, viewport, canvasSi
   return (
     <div className="canvas-minimap" data-canvas-blocker style={{ width: MINIMAP_WIDTH, height: MINIMAP_HEIGHT }}>
       <span className="canvas-minimap-label" aria-hidden="true">Map</span>
+      <button
+        type="button"
+        className="canvas-minimap-toggle"
+        onClick={toggle}
+        aria-label="Collapse Map"
+        title="Collapse Map"
+      >
+        <CollapseIcon />
+      </button>
       <div
         ref={innerRef}
         className="canvas-minimap-inner"
@@ -130,5 +182,43 @@ export function CanvasMinimap({ operations, pluginOperations, viewport, canvasSi
         />
       </div>
     </div>
+  );
+}
+
+function readCollapsed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(RADAR_COLLAPSED_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function writeCollapsed(value: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(RADAR_COLLAPSED_STORAGE_KEY, String(value));
+  } catch {
+    // Map 접힘 선호 저장 실패는 런타임 동작을 막지 않는다.
+  }
+}
+
+function CollapseIcon() {
+  // 우하단으로 접는 방향을 가리키는 셰브런.
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M5.5 4.5 10.5 8l-5 3.5M11 8H5.5" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function MapGlyph() {
+  // 접힌 Map을 나타내는 미니맵 모양 글리프.
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <rect x="2" y="3" width="12" height="10" rx="2" fill="none" stroke="currentColor" strokeWidth="1.2" />
+      <rect x="4.2" y="5" width="4.2" height="3.1" rx="0.6" fill="none" stroke="currentColor" strokeWidth="1" />
+      <circle cx="11" cy="10.2" r="0.95" fill="currentColor" />
+    </svg>
   );
 }

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -259,22 +259,20 @@ export function OperationsCanvas({
           onClose={() => setContextMenu(null)}
         />
       ) : null}
-      {!formationView && !panelMaximized ? (
-        <CanvasMinimap
-          operations={visibleOperations}
-          pluginOperations={Object.fromEntries(theaterOperations.filter((operation) => !minimizedSet.has(operation.id)).map((operation) => [operation.id, {
-            theaterId: operation.theaterId,
-            geometry: canvas.operations[operation.id] ?? operation.geometry ?? ensurePluginGeometry(operation),
-          }]))}
-          viewport={canvas.viewport}
-          canvasSize={canvasSize}
-          onJump={(center) => setViewport({
-            x: canvasSize.width / 2 - center.x * canvas.viewport.zoom,
-            y: canvasSize.height / 2 - center.y * canvas.viewport.zoom,
-            zoom: canvas.viewport.zoom,
-          })}
-        />
-      ) : null}
+      <CanvasMinimap
+        operations={visibleOperations}
+        pluginOperations={Object.fromEntries(theaterOperations.filter((operation) => !minimizedSet.has(operation.id)).map((operation) => [operation.id, {
+          theaterId: operation.theaterId,
+          geometry: canvas.operations[operation.id] ?? operation.geometry ?? ensurePluginGeometry(operation),
+        }]))}
+        viewport={canvas.viewport}
+        canvasSize={canvasSize}
+        onJump={(center) => setViewport({
+          x: canvasSize.width / 2 - center.x * canvas.viewport.zoom,
+          y: canvasSize.height / 2 - center.y * canvas.viewport.zoom,
+          zoom: canvas.viewport.zoom,
+        })}
+      />
     </main>
   );
 }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2136,6 +2136,12 @@
   opacity: 0.42;
 }
 
+.operations-canvas.is-formation-view .canvas-minimap,
+.operations-canvas.is-formation-view .canvas-minimap-fab,
+.operations-canvas.is-panel-maximized .canvas-minimap,
+.operations-canvas.is-panel-maximized .canvas-minimap-fab {
+  display: none;
+}
 
 /* 순정 셸 패널 — Operation과 구별되도록 띠바에 아우로라(살아있는 것) 톤의 옅은 강조를 준다. */
 .canvas-operation--shell .canvas-operation-titlebar {
@@ -2535,6 +2541,70 @@
     0 0 14px color-mix(in oklch, var(--brass) 32%, transparent),
     inset 0 0 12px color-mix(in oklch, var(--brass) 18%, transparent);
   pointer-events: none;
+}
+
+/* Map 접기 토글 — 미니맵 우상단 모서리. */
+.canvas-minimap-toggle {
+  position: absolute;
+  top: 5px;
+  right: 6px;
+  z-index: 4;
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--surface-glass) 78%, var(--ink-deep));
+  color: var(--brass);
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring);
+}
+
+/* 접힌 Map — 우하단 단일 Map 아이콘 버튼. */
+.canvas-minimap-fab {
+  position: absolute;
+  right: var(--space-4);
+  bottom: var(--space-4);
+  z-index: 14;
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border: 1px solid color-mix(in oklch, var(--brass) 30%, var(--surface-rim));
+  border-radius: var(--radius-lg);
+  background:
+    radial-gradient(130% 100% at 50% 0%, color-mix(in oklch, var(--brass) 9%, transparent), transparent 62%),
+    color-mix(in oklch, var(--surface-glass) 60%, color-mix(in oklch, var(--ink-deep) 72%, transparent));
+  color: var(--brass);
+  box-shadow: var(--shadow-anchor);
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring);
+}
+
+.canvas-minimap-toggle:hover,
+.canvas-minimap-toggle:focus-visible,
+.canvas-minimap-fab:hover,
+.canvas-minimap-fab:focus-visible {
+  color: var(--brass-bright);
+  border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
+  background: color-mix(in oklch, var(--brass) 11%, var(--surface-glass));
+}
+
+.canvas-minimap-toggle svg {
+  display: block;
+  width: 13px;
+  height: 13px;
+}
+
+.canvas-minimap-fab svg {
+  display: block;
+  width: 18px;
+  height: 18px;
 }
 
 .operations-canvas-world {

--- a/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
+++ b/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
@@ -72,9 +72,8 @@ afterEach(() => {
   container = null;
 });
 
-describe("CanvasMinimap visibility", () => {
-  it("always renders the full minimap in the default canvas state", () => {
-    window.localStorage.setItem("fleet-console.map.radarCollapsed", "true");
+describe("CanvasMinimap collapse behavior", () => {
+  it("persists default-canvas collapse and expand preference", () => {
     act(() => root!.render(createElement(CanvasMinimap, {
       operations: { operation: { x: 0, y: 0, width: 320, height: 200, zIndex: 1 } },
       pluginOperations: {},
@@ -83,8 +82,38 @@ describe("CanvasMinimap visibility", () => {
       onJump: () => {},
     })));
     expect(document.querySelector(".canvas-minimap")).not.toBeNull();
-    expect(document.querySelector('[aria-label="Open Map"]')).toBeNull();
-    expect(document.querySelector('[aria-label="Collapse Map"]')).toBeNull();
+    expect(document.querySelector('[aria-label="Collapse Map"]')).not.toBeNull();
+
+    act(() => document.querySelector<HTMLButtonElement>('[aria-label="Collapse Map"]')!.click());
+    expect(document.querySelector('[aria-label="Open Map"]')).not.toBeNull();
+    expect(window.localStorage.getItem("fleet-console.map.radarCollapsed")).toBe("true");
+
+    act(() => document.querySelector<HTMLButtonElement>('[aria-label="Open Map"]')!.click());
+    expect(document.querySelector('[aria-label="Collapse Map"]')).not.toBeNull();
+    expect(window.localStorage.getItem("fleet-console.map.radarCollapsed")).toBe("false");
+  });
+
+  it("does not mutate the saved preference in Formation and restores the pre-entry state", () => {
+    act(() => root!.render(createElement(CanvasMinimap, {
+      operations: { operation: { x: 0, y: 0, width: 320, height: 200, zIndex: 1 } },
+      pluginOperations: {},
+      viewport: { x: 0, y: 0, zoom: 1 },
+      canvasSize: { width: 900, height: 600 },
+      onJump: () => {},
+    })));
+    expect(document.querySelector('[aria-label="Collapse Map"]')).not.toBeNull();
+
+    act(() => toggleFormationView());
+    expect(document.querySelector('[aria-label="Open Map"]')).not.toBeNull();
+    expect(window.localStorage.getItem("fleet-console.map.radarCollapsed")).toBeNull();
+
+    act(() => document.querySelector<HTMLButtonElement>('[aria-label="Open Map"]')!.click());
+    expect(document.querySelector('[aria-label="Collapse Map"]')).not.toBeNull();
+    expect(window.localStorage.getItem("fleet-console.map.radarCollapsed")).toBeNull();
+
+    act(() => clearFormationView());
+    expect(document.querySelector('[aria-label="Collapse Map"]')).not.toBeNull();
+    expect(window.localStorage.getItem("fleet-console.map.radarCollapsed")).toBeNull();
   });
 
   it("preserves the no-operations and invalid-viewport guards", () => {
@@ -107,21 +136,24 @@ describe("CanvasMinimap visibility", () => {
     expect(document.querySelector(".canvas-minimap")).toBeNull();
   });
 
-  it("mounts at the OperationsCanvas boundary only in the default state and restores after Formation or maximize", () => {
+  it("keeps the minimap mounted through Formation and maximize so the collapsed preference restores", () => {
+    window.localStorage.setItem("fleet-console.map.radarCollapsed", "true");
     renderOperationsCanvas();
-    expect(document.querySelector(".canvas-minimap")).not.toBeNull();
+    expect(document.querySelector('[aria-label="Open Map"]')).not.toBeNull();
 
     act(() => toggleFormationView());
-    expect(document.querySelector(".canvas-minimap")).toBeNull();
+    expect(document.querySelector(".operations-canvas")?.classList.contains("is-formation-view")).toBe(true);
+    expect(document.querySelector('[aria-label="Open Map"]')).not.toBeNull();
 
     act(() => clearFormationView());
-    expect(document.querySelector(".canvas-minimap")).not.toBeNull();
+    expect(document.querySelector('[aria-label="Open Map"]')).not.toBeNull();
 
     act(() => setMaximizedOperationId("operation"));
-    expect(document.querySelector(".canvas-minimap")).toBeNull();
+    expect(document.querySelector(".operations-canvas")?.classList.contains("is-panel-maximized")).toBe(true);
+    expect(document.querySelector('[aria-label="Open Map"]')).not.toBeNull();
 
     act(() => clearMaximizedOperationId());
-    expect(document.querySelector(".canvas-minimap")).not.toBeNull();
+    expect(document.querySelector('[aria-label="Open Map"]')).not.toBeNull();
   });
 
   it("moves the canvas viewport when the mounted minimap receives pointer navigation", () => {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -39,7 +39,7 @@ describe("Instrument core design contract", () => {
     for (const path of OWNED_SOURCES) expect(source(path)).not.toMatch(FORBIDDEN_DECORATION);
   });
 
-  it("keeps minimap navigation while removing Map collapse controls", () => {
+  it("keeps minimap navigation and collapse controls while hiding Map in Formation and maximize", () => {
     const minimap = source("canvas/canvas-minimap.tsx");
     const canvas = source("canvas/canvas.tsx");
     const components = source("styles/components.css");
@@ -47,9 +47,17 @@ describe("Instrument core design contract", () => {
     expect(minimap).toContain(">Map<");
     expect(minimap).toContain("onPointerMove={onPointerMove}");
     expect(minimap).toContain("onJump({");
-    expect(minimap).not.toMatch(/localStorage|Collapsed|Open Map|Collapse Map|canvas-minimap-(?:fab|toggle)/);
-    expect(canvas).toContain("{!formationView && !panelMaximized ? (");
-    expect(components).not.toMatch(/canvas-minimap-(?:fab|toggle)/);
+    expect(minimap).toContain("fleet-console.map.radarCollapsed");
+    expect(minimap).toContain('aria-label="Open Map"');
+    expect(minimap).toContain('aria-label="Collapse Map"');
+    expect(minimap).toContain("canvas-minimap-fab");
+    expect(minimap).toContain("canvas-minimap-toggle");
+    expect(canvas).toContain("<CanvasMinimap");
+    expect(canvas).not.toContain("{!formationView && !panelMaximized ? (");
+    expect(components).toContain(".operations-canvas.is-formation-view .canvas-minimap,");
+    expect(components).toContain(".operations-canvas.is-formation-view .canvas-minimap-fab,");
+    expect(components).toContain(".operations-canvas.is-panel-maximized .canvas-minimap,");
+    expect(components).toContain(".operations-canvas.is-panel-maximized .canvas-minimap-fab {");
     expect(contextMenu).toContain("Formation view");
     expect(contextMenu).not.toContain("onToggleRadar");
     expect(contextMenu).not.toContain("onTogglePerimeter");


### PR DESCRIPTION
## Summary
- restore the minimap collapse/expand controls and persisted preference
- hide both the minimap and its shortcut icon during Formation View
- hide both surfaces during panel maximization and restore the prior state afterward

## Test Plan
- [x] Console production build with workspace dependencies
- [x] Console full test suite (751 passed, 22 skipped)
- [x] focused minimap state/navigation tests (16 passed)
- [x] browser E2E: expanded/collapsed, Formation, maximization, reload persistence, responsive layout, errors
- [x] `.changelog.d/pr-254.md` syntax, bilingual summaries, and fragment validation

## Notes
- Console typecheck is blocked by the existing missing CSS and `virtual:fleet-plugins` declarations; the production Vite build passes.