### PR TITLE
fix(fleet-console): restore Codex rail entry scrolling

### DIFF
--- a/.changelog.d/pr-255.md
+++ b/.changelog.d/pr-255.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Restore mouse-wheel scrolling for long Codex Wiki entry lists in the right rail.
+  ko: 우측 레일의 긴 Codex Wiki 엔트리 목록에서 마우스 휠 스크롤을 복원합니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -8059,6 +8059,12 @@ body[data-codex-reading="true"] .operations-side-bar {
   min-height: 0;
 }
 
+.codex-rail-host > .codex-host,
+.codex-nav-pane > .codex-host {
+  height: 100%;
+  min-height: 0;
+}
+
 .codex-rail-host.is-split {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 248px;

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -164,6 +164,37 @@ describe("Instrument core design contract", () => {
     expect(bodyChildrenBlock).toContain("flex: none;");
   });
 
+  it("bounds the Codex navigator host so long Wiki entry lists keep native scrolling", () => {
+    const components = source("styles/components.css");
+    const navigatorLayout = source("codex/styles/layout.css");
+    const railHostBlock = components.match(/\.codex-rail-host \{[^}]*\}/)?.[0] ?? "";
+    const splitRailHostBlock = components.match(/\.codex-rail-host\.is-split \{[^}]*\}/)?.[0] ?? "";
+    const navPaneBlock = components.match(/\.codex-nav-pane \{[^}]*\}/)?.[0] ?? "";
+    const hostBlock = components.match(/\.codex-rail-host > \.codex-host,\n\.codex-nav-pane > \.codex-host \{[^}]*\}/)?.[0] ?? "";
+    const navigatorBlock = navigatorLayout.match(/\.codex-navigator \{[^}]*\}/)?.[0] ?? "";
+    const navigatorScrollBlock = navigatorLayout.match(/\.codex-navigator-scroll \{[^}]*\}/)?.[0] ?? "";
+
+    expect(railHostBlock).toContain("height: 100%;");
+    expect(railHostBlock).toContain("min-height: 0;");
+    expect(splitRailHostBlock).toContain("display: grid;");
+    expect(splitRailHostBlock).toContain("grid-template-rows: minmax(0, 1fr);");
+    expect(splitRailHostBlock).toContain("height: 100%;");
+    expect(splitRailHostBlock).toContain("min-height: 0;");
+    expect(navPaneBlock).toContain("display: flex;");
+    expect(navPaneBlock).toContain("flex-direction: column;");
+    expect(navPaneBlock).toContain("min-height: 0;");
+    expect(navPaneBlock).toContain("overflow: hidden;");
+    expect(hostBlock).toContain("height: 100%;");
+    expect(hostBlock).toContain("min-height: 0;");
+    expect(navigatorBlock).toContain("display: flex;");
+    expect(navigatorBlock).toContain("flex-direction: column;");
+    expect(navigatorBlock).toContain("min-height: 0;");
+    expect(navigatorBlock).toContain("height: 100%;");
+    expect(navigatorScrollBlock).toContain("flex: 1;");
+    expect(navigatorScrollBlock).toContain("min-height: 0;");
+    expect(navigatorScrollBlock).toContain("overflow-y: auto;");
+  });
+
   it("locks Command Band coordinate invariance to tint-only state changes", () => {
     const layout = source("styles/layout.css");
     const components = source("styles/components.css");


### PR DESCRIPTION
## Summary
- bound the Codex right-rail navigator host to the available panel height
- restore native mouse-wheel scrolling for long Wiki entry lists in single and split modes
- lock the full scroll containment chain with a focused regression contract

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/instrument-design-contract.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console test`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] headed Console E2E with 32 Wiki entries; wheel down/up in single and split modes
- [ ] `pnpm --filter @dotobokuri/fleet-console typecheck` — blocked by the same pre-existing CSS/virtual-module declaration errors on clean canary

## Changelog
- [x] Added `.changelog.d/pr-255.md`.
- [x] Validated grouped syntax and bilingual summaries with `node scripts/compile-changelog-fragments.mjs --check`.
