### PR TITLE
perf(file-explorer): prefetch bounded directory entries

### DIFF
--- a/.changelog.d/pr-256.md
+++ b/.changelog.d/pr-256.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Changed
+- [fleet-console] Improve File Explorer responsiveness when listing large directories by prefetching the bounded directory window.
+  ko: 제한된 디렉터리 범위를 미리 가져와 대규모 디렉터리 목록을 표시할 때 File Explorer의 응답성을 개선합니다.

--- a/runtime/fleet-plugins/file-explorer/server/folder-browser.ts
+++ b/runtime/fleet-plugins/file-explorer/server/folder-browser.ts
@@ -99,7 +99,7 @@ async function collectContentsEntries(
 
 async function openDirectory(targetPath: string, opendir: typeof fs.promises.opendir): Promise<fs.Dir> {
   try {
-    return await opendir(targetPath);
+    return await opendir(targetPath, { bufferSize: DIRECTORY_ENTRY_CAP + 1 });
   } catch (error) {
     throw mapFsError(error);
   }

--- a/runtime/fleet-plugins/file-explorer/tests/theater-contents.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/theater-contents.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { listTheaterContents } from "../server/folder-browser.js";
 
@@ -38,5 +38,31 @@ describe("listTheaterContents", () => {
     expect(fileNames).toEqual([...fileNames].sort((a, b) => a.localeCompare(b)));
 
     fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it.each([
+    { entryCount: 499, expectedLength: 499, truncated: false },
+    { entryCount: 500, expectedLength: 500, truncated: false },
+    { entryCount: 501, expectedLength: 500, truncated: true },
+  ])("$entryCount개 항목에서 500개 cap과 truncation을 유지한다", async ({ entryCount, expectedLength, truncated }) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-contents-cap-"));
+    const opendir = vi.fn(fs.promises.opendir);
+    for (let index = 0; index < entryCount; index++) {
+      fs.writeFileSync(path.join(dir, `file-${String(index).padStart(3, "0")}.txt`), "");
+    }
+
+    try {
+      const result = await listTheaterContents(dir, "", { opendir });
+
+      expect(opendir).toHaveBeenCalledWith(fs.realpathSync(dir), { bufferSize: 501 });
+      expect(result.entries).toHaveLength(expectedLength);
+      if (truncated) {
+        expect(result).toMatchObject({ truncated: true });
+      } else {
+        expect(result).not.toHaveProperty("truncated");
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- prefetch the bounded File Explorer directory window to reduce filesystem refill overhead
- preserve the 500-entry cap, truncation behavior, sorting, and symlink containment
- add deterministic regression coverage for 499, 500, and 501 entries

## Test Plan
- [x] `pnpm --filter @fleet-plugins/file-explorer test`
- [x] `pnpm --filter @fleet-plugins/file-explorer typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Headed File Explorer E2E with a 500-file Theater
- [x] Add `.changelog.d/pr-256.md`
- [x] Validate bilingual changelog syntax with `node scripts/compile-changelog-fragments.mjs --check`
