### PR TITLE
fix(console): collapse sidebar chip actions at rest

### DIFF
--- a/.changelog.d/pr-257.md
+++ b/.changelog.d/pr-257.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Changed
+- [fleet-console] Show sidebar action controls only on hover or keyboard focus so Operation names have more room.
+  ko: 사이드바 액션 컨트롤을 hover 또는 키보드 포커스에서만 표시해 Operation 이름 공간을 넓힙니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3165,41 +3165,29 @@
   50% { opacity: 1; }
 }
 
-.side-bar-chip-close {
-  display: grid;
-  place-items: center;
-  flex: none;
-  width: 20px;
-  height: 20px;
-  padding: 0;
-  border: 1px solid transparent;
-  border-radius: var(--radius-md);
-  background: transparent;
-  cursor: pointer;
-  color: var(--ink-fog);
-  opacity: 0;
-  pointer-events: none;
-  transition:
-    background var(--duration-fast) var(--ease-spring),
-    border-color var(--duration-fast) var(--ease-spring),
-    color var(--duration-fast) var(--ease-spring);
-}
-
+.side-bar-chip-close,
 .side-bar-chip-minimize {
   display: grid;
   place-items: center;
-  flex: none;
-  width: 20px;
-  height: 20px;
+  flex: 0 0 0;
+  width: 0;
+  height: 0;
   padding: 0;
-  border: 1px solid transparent;
+  margin-left: calc(-1 * var(--space-2));
+  overflow: hidden;
+  border: 0 solid transparent;
   border-radius: var(--radius-md);
   background: transparent;
   cursor: pointer;
-  color: var(--ink-fog);
+  color: transparent;
   opacity: 0;
   pointer-events: none;
   transition:
+    width var(--duration-base) var(--ease-spring),
+    height var(--duration-base) var(--ease-spring),
+    padding var(--duration-base) var(--ease-spring),
+    margin-left var(--duration-base) var(--ease-spring),
+    opacity var(--duration-base) var(--ease-spring),
     background var(--duration-fast) var(--ease-spring),
     border-color var(--duration-fast) var(--ease-spring),
     color var(--duration-fast) var(--ease-spring);
@@ -3208,8 +3196,15 @@
 .side-bar-chip:hover .side-bar-chip-close,
 .side-bar-chip:focus-within .side-bar-chip-close,
 .side-bar-chip:hover .side-bar-chip-minimize,
-.side-bar-chip:focus-within .side-bar-chip-minimize,
-.side-bar-chip-close.is-armed {
+.side-bar-chip:focus-within .side-bar-chip-minimize {
+  flex: none;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  margin-left: 0;
+  border: 1px solid var(--surface-rim);
+  color: var(--ink-fog);
+  background: color-mix(in oklch, var(--surface-glass) 58%, transparent);
   opacity: 1;
   pointer-events: auto;
 }
@@ -3234,20 +3229,26 @@
   height: 12px;
 }
 
-.side-bar-chip-close.is-armed {
+/* .side-bar-chip 프리픽스는 reveal 규칙과 같은 특이도를 유지해 포인터가 떠나도 ARM 폭을 보존한다. */
+.side-bar-chip .side-bar-chip-close.is-armed {
+  flex: none;
   background: color-mix(in oklch, var(--coral) 20%, transparent);
-  border-color: color-mix(in oklch, var(--coral) 50%, transparent);
+  border: 1px solid color-mix(in oklch, var(--coral) 50%, transparent);
   color: var(--coral);
   font-family: var(--font-body);
   font-size: 11px;
   font-weight: 700;
   width: auto;
+  height: 20px;
   padding: 0 6px;
+  margin-left: 0;
+  opacity: 1;
+  pointer-events: auto;
   animation: chip-close-arm 1.5s linear forwards;
 }
 
-.side-bar-chip-close.is-armed:hover,
-.side-bar-chip-close.is-armed:focus-visible {
+.side-bar-chip .side-bar-chip-close.is-armed:hover,
+.side-bar-chip .side-bar-chip-close.is-armed:focus-visible {
   background: color-mix(in oklch, var(--coral) 32%, transparent);
   outline: none;
 }
@@ -3259,7 +3260,12 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .side-bar-chip-close.is-armed {
+  .side-bar-chip-close,
+  .side-bar-chip-minimize {
+    transition-duration: 0.01ms;
+  }
+
+  .side-bar-chip .side-bar-chip-close.is-armed {
     animation: none;
   }
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -86,6 +86,37 @@ describe("Instrument core design contract", () => {
     expect(accentSources).not.toMatch(/--op-accent|--chip-accent/);
   });
 
+  it("collapses sidebar chip actions out of layout until hover or focus-within", () => {
+    const components = source("styles/components.css");
+    const restingActions = components.match(/\.side-bar-chip-close,\n\.side-bar-chip-minimize \{[^}]*\}/)?.[0] ?? "";
+    const revealedActions = components.match(/\.side-bar-chip:hover \.side-bar-chip-close,[^]*?\.side-bar-chip:focus-within \.side-bar-chip-minimize \{[^}]*\}/)?.[0] ?? "";
+    const armedClose = components.match(/\.side-bar-chip \.side-bar-chip-close\.is-armed \{[^}]*\}/)?.[0] ?? "";
+
+    expect(restingActions).toContain("flex: 0 0 0;");
+    expect(restingActions).toContain("width: 0;");
+    expect(restingActions).toContain("height: 0;");
+    expect(restingActions).toContain("margin-left: calc(-1 * var(--space-2));");
+    expect(restingActions).toContain("overflow: hidden;");
+    expect(restingActions).toContain("opacity: 0;");
+    expect(restingActions).toContain("width var(--duration-base) var(--ease-spring)");
+    expect(restingActions).toContain("margin-left var(--duration-base) var(--ease-spring)");
+    expect(restingActions).toContain("opacity var(--duration-base) var(--ease-spring)");
+    expect(revealedActions).toContain("flex: none;");
+    expect(revealedActions).toContain("width: 20px;");
+    expect(revealedActions).toContain("height: 20px;");
+    expect(revealedActions).toContain("margin-left: 0;");
+    expect(revealedActions).toContain("opacity: 1;");
+    expect(revealedActions).toContain("pointer-events: auto;");
+    expect(armedClose).toContain("width: auto;");
+    expect(armedClose).toContain("margin-left: 0;");
+    expect(armedClose).toContain("border: 1px solid color-mix(in oklch, var(--coral) 50%, transparent);");
+    expect(armedClose).toContain("opacity: 1;");
+    expect(armedClose).toContain("pointer-events: auto;");
+    expect(components.indexOf(".side-bar-chip .side-bar-chip-close.is-armed")).toBeGreaterThan(components.indexOf(".side-bar-chip:hover .side-bar-chip-close"));
+    expect(components).toContain(".side-bar-chip-close,\n  .side-bar-chip-minimize {\n    transition-duration: 0.01ms;");
+    expect(components).toContain(".side-bar-chip .side-bar-chip-close.is-armed {\n    animation: none;");
+  });
+
   it("keeps Formation and maximize store contracts without the retired focus mode", () => {
     const store = source("canvas/canvas-store.ts");
     expect(store).toContain("toggleFormationView");


### PR DESCRIPTION
## Summary
- collapse hidden sidebar minimize/close controls out of layout so names and status dots use the full row
- reveal controls on hover or keyboard focus with the existing panel spring motion
- preserve armed-close and reduced-motion behavior with focused regression coverage

## Test Plan
- [x] `pnpm --dir runtime/fleet-console exec vitest run tests/instrument-design-contract.test.ts tests/operations-side-bar-chip-status.test.ts`
- [x] `pnpm --dir runtime/fleet-console build`
- [x] isolated headed-browser rest/hover geometry and screenshot verification
- [x] `.changelog.d/pr-257.md` syntax and bilingual summaries validated
- [x] `node scripts/compile-changelog-fragments.mjs --check`

## Notes
- `pnpm --dir runtime/fleet-console typecheck` is baseline-blocked by the same CSS/virtual-module declaration errors on clean `canary`.