### PR TITLE
feat(fleet-console): float carrier stream dock as an overlay

### DIFF
--- a/.changelog.d/pr-258.md
+++ b/.changelog.d/pr-258.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Changed
+- [fleet-console] Float the carrier stream dock as an overlay so expanding it no longer resizes the terminal.
+  ko: 캐리어 스트림 도크를 오버레이로 띄워, 펼쳐도 터미널 크기가 바뀌지 않습니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4019,20 +4019,20 @@
   min-height: 0;
 }
 
-/* agent-stream-host: 터미널(flex:1, 위) + 도크(flex:none, 하단)를 flex 컬럼으로 쌓는 호스트.
-   도크가 없으면 terminal-stage가 전체 높이를 회복한다. */
+/* agent-stream-host: 터미널과 StreamDock의 absolute offset parent.
+   도크는 terminal-stage 위에 떠 있으므로 상태 변화가 xterm 캔버스 높이를 바꾸지 않는다. */
 .agent-stream-host {
   display: flex;
   flex-direction: column;
+  position: relative;
   height: 100%;
   min-height: 0;
 }
 
-/* 도크 존재 시 terminal-stage가 남은 높이를 flex로 채우도록 보정.
-   .canvas-operation-terminal의 height:100% 규칙을 덮는다. */
+/* StreamDock과 무관하게 터미널 stage가 호스트 전체를 유지한다. */
 .agent-stream-host .terminal-stage {
-  flex: 1;
-  height: auto;
+  position: absolute;
+  inset: 0;
   min-height: 0;
 }
 
@@ -4813,19 +4813,32 @@
 }
 
 /* ══════════════════════════════════════════════════════════════
-   StreamDock: 패널 하단 상주 접이식 스트림 도크.
-   agent-stream-host flex 컬럼 내 마지막 자식(flex:none).
+   StreamDock: terminal stage 위에 부유하는 패널 하단 접이식 스트림 도크.
+   펼침/접힘/마운트 변화는 terminal geometry에 참여하지 않는다.
    ══════════════════════════════════════════════════════════════ */
 .job-dock {
-  flex: none;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 3;
+  /* 도크는 패널보다 높을 수 없다 — 최소 높이 패널에서 스트립이 잘려 접기/Details가
+     사라지지 않도록 상한을 두고, 스트립은 고정하고 body만 수축·스크롤한다. */
+  max-height: 100%;
   display: flex;
   flex-direction: column;
   border-top: 1px solid color-mix(in oklch, var(--aurora) 30%, var(--surface-rim));
-  background: color-mix(in oklch, var(--aurora) 4%, var(--surface-glass));
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  /* 불투명 표면 도트린: backdrop blur 금지(instrument-design-contract). 오버레이 구분은
+     surface-glass-strong 불투명 배경 + floating shadow로만 확보한다. */
+  background: color-mix(in oklch, var(--aurora) 6%, var(--surface-glass-strong));
+  box-shadow: var(--shadow-floating);
+  overflow: hidden;
 }
 
 /* 스트립: 기본 상태 단일 행 계기판 — 펄스닷 · 캐리어명 · 최신 라인 · meta · 그립 · Details */
 .job-dock-strip {
+  flex: none;
   display: flex;
   align-items: center;
   gap: var(--space-2);
@@ -4964,9 +4977,13 @@
   background: color-mix(in oklch, var(--brass) 10%, transparent);
 }
 
-/* 바디 래퍼: follow-button 위치 기준(position: relative) */
+/* 바디 래퍼: follow-button 위치 기준(position: relative).
+   flex column + min-height:0으로 도크가 max-height:100%에 눌릴 때 body만 수축시킨다. */
 .job-dock-body-wrap {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
   border-top: 1px solid var(--surface-rim);
 }
 
@@ -4974,8 +4991,11 @@
   display: none;
 }
 
-/* 바디: 스크롤 가능한 트랙 행 스택, 하단 고정 여백 제거 */
+/* 바디: 스크롤 가능한 트랙 행 스택, 하단 고정 여백 제거.
+   flex:1 1 auto + min-height:0으로 좁은 패널에서 200px 미만으로 수축하며 내부 스크롤한다. */
 .job-dock-body {
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
   max-height: 200px;
   padding: var(--space-1) var(--space-3) var(--space-2);


### PR DESCRIPTION
## Summary
- 인패널 캐리어 StreamDock을 터미널과 나란한 flex 형제에서 `agent-stream-host` 위에 떠 있는 absolute bottom 오버레이(z-index 3)로 전환했습니다. 터미널 stage가 `absolute inset:0`으로 호스트 전체를 유지하므로, 도크의 펼침/접힘/마운트/언마운트/retention 만료가 xterm 캔버스 높이를 더 이상 바꾸지 않습니다 — 도크발 `ResizeObserver → FitAddon.fit → PTY resize` 연쇄가 구조적으로 사라집니다.
- 범용 geometry 패치(`preserveAfterGeometryChange`, `recordUnclassifiedViewportChange`)와 리핏 로직은 진짜 패널 리사이즈·줌에 여전히 필요하므로 그대로 보존했습니다. 변경은 `components.css` 레이아웃/포지셔닝에 한정됩니다.
- 오버레이는 불투명 `--surface-glass-strong` 배경 + `--shadow-floating`으로 구분하며(도트린상 backdrop-filter 금지), 최소 높이 패널에서는 `max-height:100%` + body flex 수축 체인으로 스트립을 고정하고 body만 스크롤시켜 접기/Details 접근성을 보장합니다.

## Test Plan
- [x] `@dotobokuri/fleet-console` build 통과 (tsc)
- [x] `@fleet-plugins/terminal` test 통과 (15 files, 150 tests)
- [x] `instrument-design-contract.test.ts` 12/12 통과 (backdrop-filter 금지 충족)
- [x] 라이브 실측(격리 콘솔, 실 스타일시트): terminal stage/canvas가 도크 상태와 무관하게 일정(stage 638×438, canvas 612×378) · 오버레이 도크 z-index:3 부양 · Details 모달 z-index:4가 도크 위 · 도크 body 내부 스크롤 정상
- [x] 최소 높이 패널(200px) 실측: 도크 max-height:100%(198px) 상한 · 스트립 가시 · Details 클릭 가능 · body 166px로 수축·스크롤
- [ ] Changelog fragment (PR 번호 배정 후 추가 예정)

Codex reviewed (Sentinel 선행 리뷰 Medium 2건 수정: 최소높이 스트립 클리핑, backdrop-filter 도트린 위반).