### PR TITLE
fix(fleet-console): progressively center command band

### DIFF
--- a/.changelog.d/pr-260.md
+++ b/.changelog.d/pr-260.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Keep Command Band context progressively centered while resizing the Console and side chrome.
+  ko: Console과 좌우 사이드 크롬의 크기를 조절할 때 Command Band 컨텍스트가 점진적으로 중앙 정렬되도록 유지합니다.

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -6,7 +6,7 @@ import { FleetBrandHome } from "./side-bar-brand-foot.js";
 import { useConsoleState } from "../hooks/use-store.js";
 import { putRailPathContext } from "../rail/path-context-api.js";
 import { PathContextDeck } from "../rail/path-context-deck.js";
-import { mutateRailPathContext, setRailPathContextDeckOpen, toggleRailChrome, useRailChromeExpanded, useRailPathContextStore } from "../rail/rail-store.js";
+import { mutateRailPathContext, setRailPathContextDeckOpen, toggleRailChrome, useRailChromeExpanded, useRailPathContextStore, useRightRailWidth } from "../rail/rail-store.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
 import { setSideBarCollapsed, useSideBarState } from "../sidebar/operations-side-bar-store.js";
@@ -28,6 +28,7 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
   const registry = usePluginRegistry();
   const sideBar = useSideBarState();
   const railChromeExpanded = useRailChromeExpanded();
+  const rightRailWidth = useRightRailWidth();
   const modLabel = resolveModLabel();
   const sideBarShortcut = `${modLabel}${modLabel === "⌘" ? "" : "+"}B`;
   const railShortcut = `${modLabel}${modLabel === "⌘" ? "⌥" : "+Alt+"}B`;
@@ -100,7 +101,7 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
   };
 
   return (
-    <header className={`command-band${operationsViewVisible ? " is-operations" : " is-utility"}`} style={{ "--command-band-left-width": `${sideBar.width}px` } as CSSProperties}>
+    <header className={`command-band${operationsViewVisible ? " is-operations" : " is-utility"}`} style={{ "--command-band-left-width": `${sideBar.width}px`, "--command-band-right-width": `${rightRailWidth}px` } as CSSProperties}>
       <div className={`command-band-left${operationsViewVisible && sideBar.collapsed ? " is-collapsed" : ""}`}>
         <FleetBrandHome className="command-band-brand" />
         {operationsViewVisible ? <button type="button" className="command-band-button command-band-sidebar-toggle" onClick={() => setSideBarCollapsed(!sideBar.collapsed)} aria-label={`${sideBar.collapsed ? "Expand sidebar" : "Collapse sidebar"} (${sideBarShortcut})`} title={`${sideBar.collapsed ? "Expand sidebar" : "Collapse sidebar"} (${sideBarShortcut})`}>

--- a/runtime/fleet-console/core/client/src/rail/rail-store.ts
+++ b/runtime/fleet-console/core/client/src/rail/rail-store.ts
@@ -12,6 +12,7 @@ interface RailPathContextState {
 interface RailStore {
   readonly activeRailPanelId: string | null;
   readonly railChromeExpanded: boolean;
+  readonly rightRailWidth: number;
   readonly panelExtraWidth: number;
   readonly pathContextTheaterId: string | null;
   readonly pathContext: RailPathContext | null;
@@ -38,6 +39,7 @@ let activePathGeneration = 0;
 let store: RailStore = {
   activeRailPanelId: readStoredPanelId(),
   railChromeExpanded: readStoredChromeExpanded(),
+  rightRailWidth: 44,
   panelExtraWidth: 0,
   pathContextTheaterId: null,
   pathContext: null,
@@ -89,6 +91,12 @@ export function setRailChromeExpanded(expanded: boolean): void {
 
 export function toggleRailChrome(): void {
   setRailChromeExpanded(!store.railChromeExpanded);
+}
+
+export function setRightRailWidth(width: number): void {
+  const next = Number.isFinite(width) ? Math.max(0, width) : 0;
+  if (store.rightRailWidth === next) return;
+  setStore({ ...store, rightRailWidth: next });
 }
 
 export function requestRailPanelExtraWidth(panelId: string, px: number | null): void {
@@ -166,6 +174,10 @@ export function useActiveRailPanelId(): string | null {
 
 export function useRailChromeExpanded(): boolean {
   return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).railChromeExpanded;
+}
+
+export function useRightRailWidth(): number {
+  return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).rightRailWidth;
 }
 
 export function useRailPanelExtraWidth(): number {

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -9,7 +9,7 @@ import { focusCommandBandToggleWhenPanelContainsActiveElement } from "../compone
 import { fetchRailPathContext, putRailPathContext } from "./path-context-api.js";
 import { getState, subscribe } from "../store.js";
 import { PathContextDeck } from "./path-context-deck.js";
-import { canRenderPathAwarePanelBody, closeRailPanel, hydrateRailPathContext, mutateRailPathContext, requestRailPanelExtraWidth, selectRailPathContextTheater, setRailPathContextDeckOpen, toggleRailPanel, useActiveRailPanelId, useRailChromeExpanded, useRailPanelExtraWidth, useRailPathContextStore } from "./rail-store.js";
+import { canRenderPathAwarePanelBody, closeRailPanel, hydrateRailPathContext, mutateRailPathContext, requestRailPanelExtraWidth, selectRailPathContextTheater, setRailPathContextDeckOpen, setRightRailWidth, toggleRailPanel, useActiveRailPanelId, useRailChromeExpanded, useRailPanelExtraWidth, useRailPathContextStore } from "./rail-store.js";
 import { useRailPanels } from "./rail-registry.js";
 import { useCodexSplitExtraWidth } from "./use-codex-split-extra-width.js";
 
@@ -54,6 +54,19 @@ export function RightRail({ theaterId, api }: RightRailProps) {
   const [panelWidth, setPanelWidthState] = useState(readStoredPanelWidth);
   const panelWidthRef = useRef(panelWidth);
   const [isDragging, setIsDragging] = useState(false);
+
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const publishWidth = () => setRightRailWidth(root.getBoundingClientRect().width);
+    publishWidth();
+    const observer = new ResizeObserver(publishWidth);
+    observer.observe(root);
+    return () => {
+      observer.disconnect();
+      setRightRailWidth(0);
+    };
+  }, []);
 
   useLayoutEffect(() => {
     if (previousRailChromeExpandedRef.current && !railChromeExpanded) focusCommandBandToggleWhenPanelContainsActiveElement(rootRef.current, ".command-band-rail-toggle");

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -21,7 +21,7 @@
 
 .command-band {
   display: grid;
-  grid-template-columns: var(--command-band-left-width, 280px) minmax(0, 1fr) auto;
+  grid-template-columns: minmax(var(--command-band-left-width, 280px), 1fr) minmax(0, max-content) minmax(var(--command-band-right-width, 44px), 1fr);
   flex: none;
   height: var(--chrome-band-height);
   min-height: var(--chrome-band-height);
@@ -42,6 +42,7 @@
 }
 
 .command-band-left {
+  width: var(--command-band-left-width, 280px);
   gap: var(--space-1);
   padding-inline: var(--space-2);
   border-right: 1px solid var(--surface-rim);
@@ -94,6 +95,7 @@
 }
 
 .command-band-right {
+  justify-content: flex-end;
   gap: var(--space-1);
   padding-inline: var(--space-2);
   /* titlebar-area-width는 드래그 영역 폭이므로, 창 폭에서 x 좌표와 그 폭을 빼 창 컨트롤 예약 폭만 계산한다. */

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -163,7 +163,20 @@ describe("Instrument core design contract", () => {
     expect(components).toContain(".side-bar-formation-group {");
     expect(components).toContain("border-left: 1px solid var(--surface-rim);");
     expect(commandBand).toContain('"--command-band-left-width": `${sideBar.width}px`');
-    expect(layout).toContain("grid-template-columns: var(--command-band-left-width, 280px) minmax(0, 1fr) auto;");
+    expect(commandBand).toContain("useRightRailWidth");
+    expect(commandBand).toContain('"--command-band-right-width": `${rightRailWidth}px`');
+    expect(layout).toContain("grid-template-columns: minmax(var(--command-band-left-width, 280px), 1fr) minmax(0, max-content) minmax(var(--command-band-right-width, 44px), 1fr);");
+    expect(layout).toContain("width: var(--command-band-left-width, 280px);");
+    const commandBandCenterBlock = layout.match(/\.command-band-center \{[^}]*\}/)?.[0] ?? "";
+    const commandBandRightBlocks = [...layout.matchAll(/\.command-band-right \{[^}]*\}/g)].map((match) => match[0]);
+    expect(commandBandCenterBlock).toContain("justify-content: center;");
+    expect(commandBandCenterBlock).not.toContain("overflow:");
+    expect(commandBandRightBlocks.some((block) => block.includes("justify-content: flex-end;"))).toBe(true);
+    const rightRail = source("rail/right-rail.tsx");
+    const railStore = source("rail/rail-store.ts");
+    expect(rightRail).toContain("new ResizeObserver(publishWidth)");
+    expect(rightRail).toContain("setRightRailWidth(root.getBoundingClientRect().width)");
+    expect(railStore).toContain("export function useRightRailWidth(): number");
     expect(layout).toContain('html[data-desktop-shell="true"] .command-band {');
     // 브랜드 홈(a)·rename(input)까지 no-drag — button만 겨냥하면 데스크톱 드래그 영역이 클릭을 삼킨다.
     expect(layout).toContain('html[data-desktop-shell="true"] .command-band button,');


### PR DESCRIPTION
## Summary
- progressively center Command Band context content while viewport space permits
- track live left sidebar and Activity Rail widths through resize and open/close transitions
- preserve the path-context deck and right rail toggle placement across collision layouts

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (753 passed, 22 skipped)
- [x] headed Console E2E across 1600px, 1280px, and 900px viewports with live left/right drag, reload, inverse resize, and deck visibility checks
- [x] no page errors or unhandled rejections in the final headed E2E session
- [ ] `pnpm --filter @dotobokuri/fleet-console typecheck` (blocked by pre-existing CSS side-effect and `virtual:fleet-plugins` declaration errors before changed-code diagnostics)

## Changelog
- [x] Added `.changelog.d/pr-260.md`
- [x] Validated bilingual fragment syntax with `node scripts/compile-changelog-fragments.mjs --check`