### PR TITLE
feat(console): formation layout selector and unified canvas menu

### DIFF
--- a/.changelog.d/pr-261.md
+++ b/.changelog.d/pr-261.md
@@ -1,0 +1,10 @@
+### fleet-console
+#### Added
+- [fleet-console] Add a Grid / Columns / Rows layout selector to Formation view; Columns splits panels into full-height vertical columns for ultrawide monitors, and the choice is remembered per machine.
+  ko: Formation view에 Grid / Columns / Rows 레이아웃 선택기를 추가합니다. Columns는 울트라와이드 모니터용으로 패널을 풀하이트 세로 컬럼으로 나누며, 선택은 기기별로 기억됩니다.
+#### Changed
+- [fleet-console] Enter Formation view from the layout buttons, move Reset view to an inline sidebar button, and unify the canvas right-click menu with the sidebar menu as a single Launch list.
+  ko: 레이아웃 버튼으로 Formation view에 진입하도록 바꾸고, Reset view를 사이드바 인라인 버튼으로 옮기며, 캔버스 우클릭 메뉴를 사이드바 메뉴와 동일한 Launch 목록으로 통일합니다.
+#### Removed
+- [fleet-console] Remove the Alt+Shift+F shortcut that opened Formation view including minimized panels.
+  ko: 최소화된 패널을 포함해 Formation view를 여는 Alt+Shift+F 단축키를 제거합니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -1,7 +1,5 @@
-import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console/sdk/operations";
-
-export type CanvasContextMenuMode = "full" | "launch";
 
 interface CanvasContextMenuProps {
   // 캔버스(<main>) 기준 화면 좌표. 메뉴를 이 지점에 띄운다.
@@ -9,53 +7,21 @@ interface CanvasContextMenuProps {
   readonly viewportBounds?: { readonly width: number; readonly height: number };
   // above = anchor.y를 캔버스 하단 거리로 보고 메뉴를 위로 띄운다(런처). cursor = anchor를 좌상단으로 본다(우클릭).
   readonly placement?: "above" | "cursor";
-  // full(기본): 탭바+3패널. launch: Operations만(＋New용).
-  readonly mode?: CanvasContextMenuMode;
   readonly catalog: readonly OperationCatalogPlugin[];
   readonly canLaunch: boolean;
-  readonly formationView?: boolean;
   // 아이콘은 플러그인 소유다 — console-core는 어떤 플러그인인지 모른 채 렌더만 위임한다.
   readonly renderKindIcon: (pluginId: string, kind: OperationLaunchKind) => ReactNode;
   readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind) => void;
-  readonly onResetView: () => void;
-  readonly onToggleFormation?: () => void;
   readonly onClose: () => void;
-}
-
-interface NavigatorWithUserAgentData extends Navigator {
-  readonly userAgentData?: {
-    readonly platform?: string;
-  };
-}
-
-type CanvasControlTab = "operations" | "map";
-
-interface CanvasControlTabDefinition {
-  readonly id: CanvasControlTab;
-  readonly label: string;
 }
 
 const MENU_WIDTH = 288;
 const MENU_MAX_HEIGHT = 520;
 const MENU_MARGIN = 12;
-const CANVAS_CONTROL_TABS: readonly CanvasControlTabDefinition[] = [
-  { id: "operations", label: "Operations" },
-  { id: "map", label: "Map" },
-];
-// userAgentData.platform은 "macOS"(소문자)를, navigator.platform은 "MacIntel"을 반환하므로
-// 대소문자 무시(i)로 두 표기를 모두 Apple 플랫폼으로 인식해야 ⌘가 올바르게 표시된다.
-const MAC_PLATFORM_PATTERN = /mac|iphone|ipad|ipod/i;
 
-export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor", mode = "full", catalog, canLaunch, formationView = false, renderKindIcon, onLaunchKind, onResetView, onToggleFormation, onClose }: CanvasContextMenuProps) {
+export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor", catalog, canLaunch, renderKindIcon, onLaunchKind, onClose }: CanvasContextMenuProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
-  const tabRefs = useRef<Record<CanvasControlTab, HTMLButtonElement | null>>({ operations: null, map: null });
-  const [activeTab, setActiveTab] = useState<CanvasControlTab>("operations");
-  const modLabel = resolveModLabel();
-
-  const showTabs = mode === "full";
-  const showOperations = mode === "full" || mode === "launch";
-  const showMap = mode === "full";
 
   useEffect(() => {
     const handlePointer = (event: MouseEvent) => {
@@ -77,28 +43,6 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     menuRef.current?.focus();
   }, []);
 
-  const activateTab = (tab: CanvasControlTab, focus = false) => {
-    setActiveTab(tab);
-    if (focus) window.requestAnimationFrame(() => tabRefs.current[tab]?.focus());
-  };
-
-  const handleTabKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
-    const currentIndex = CANVAS_CONTROL_TABS.findIndex((tab) => tab.id === activeTab);
-    const lastIndex = CANVAS_CONTROL_TABS.length - 1;
-    if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
-      event.preventDefault();
-      const delta = event.key === "ArrowRight" ? 1 : -1;
-      const next = CANVAS_CONTROL_TABS[(currentIndex + delta + CANVAS_CONTROL_TABS.length) % CANVAS_CONTROL_TABS.length]!;
-      activateTab(next.id, true);
-    } else if (event.key === "Home") {
-      event.preventDefault();
-      activateTab(CANVAS_CONTROL_TABS[0]!.id, true);
-    } else if (event.key === "End") {
-      event.preventDefault();
-      activateTab(CANVAS_CONTROL_TABS[lastIndex]!.id, true);
-    }
-  };
-
   return (
     <div
       className={`operation-launch-control operation-launch-control--canvas ${placement === "above" ? "operation-launch-control--up" : ""}`}
@@ -113,85 +57,31 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
             <strong>Canvas controls</strong>
           </span>
         </div>
-        {showTabs ? (
-          <div className="canvas-context-menu-tabs" role="tablist" aria-label="Canvas control sections">
-            {CANVAS_CONTROL_TABS.map((tab) => (
-              <button
-                key={tab.id}
-                ref={(node) => { tabRefs.current[tab.id] = node; }}
-                type="button"
-                id={`canvas-control-tab-${tab.id}`}
-                className="canvas-context-menu-tab"
-                role="tab"
-                aria-selected={activeTab === tab.id}
-                aria-controls={`canvas-control-panel-${tab.id}`}
-                tabIndex={activeTab === tab.id ? 0 : -1}
-                onClick={() => activateTab(tab.id)}
-                onKeyDown={handleTabKeyDown}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
-        ) : null}
-        {showOperations ? (
-          <div
-            id="canvas-control-panel-operations"
-            role="tabpanel"
-            aria-labelledby="canvas-control-tab-operations"
-            className="canvas-context-menu-panel"
-            hidden={showTabs ? activeTab !== "operations" : undefined}
-          >
-            <p className="canvas-context-menu-section">Launch</p>
-            {catalog.length > 0 ? catalog.map((plugin, index) => (
-              <div key={plugin.id}>
-                {index > 0 ? <div className="theater-menu-divider" role="separator" /> : null}
-                <p className="canvas-context-menu-plugin">{plugin.title}</p>
-                {plugin.kinds.map((kind) => {
-                  const disabled = kind.disabled === true || !canLaunch;
-                  return (
-                    <button
-                      key={`${plugin.id}:${kind.id}`}
-                      type="button"
-                      role="menuitem"
-                      className="theater-menu-item canvas-context-menu-item operation-launch-menu-item"
-                      disabled={disabled}
-                      title={kind.disabledReason}
-                      onClick={() => onLaunchKind(plugin.id, kind)}
-                    >
-                      <span className="theater-menu-check" aria-hidden="true">{renderKindIcon(plugin.id, kind) ?? <FallbackGlyph />}</span>
-                      <span className="theater-menu-label">{kind.title}</span>
-                      {kind.disabledReason ? <span className="operation-launch-menu-reason">{kind.disabledReason}</span> : null}
-                    </button>
-                  );
-                })}
-              </div>
-            )) : <p className="theater-menu-empty">No operations available.</p>}
-          </div>
-        ) : null}
-        {showMap ? (
-          <>
-            <div
-              id="canvas-control-panel-map"
-              role="tabpanel"
-              aria-labelledby="canvas-control-tab-map"
-              className="canvas-context-menu-panel"
-              hidden={showTabs ? activeTab !== "map" : undefined}
-            >
-              <p className="canvas-context-menu-section">View</p>
-              <button type="button" role="menuitem" className="theater-menu-item canvas-context-menu-item" onClick={onResetView}>
-                <span className="theater-menu-check" aria-hidden="true"><ResetGlyph /></span>
-                <span className="theater-menu-label">Reset view</span>
-              </button>
-              {onToggleFormation ? (
-                <button type="button" role="menuitemcheckbox" aria-checked={formationView} className="theater-menu-item canvas-context-menu-item" onClick={onToggleFormation}>
-                  <span className="theater-menu-check" aria-hidden="true">{formationView ? "✓" : <FormationGlyph />}</span>
-                  <span className="theater-menu-label">Formation view</span>
+        <p className="canvas-context-menu-section">Launch</p>
+        {catalog.length > 0 ? catalog.map((plugin, index) => (
+          <div key={plugin.id}>
+            {index > 0 ? <div className="theater-menu-divider" role="separator" /> : null}
+            <p className="canvas-context-menu-plugin">{plugin.title}</p>
+            {plugin.kinds.map((kind) => {
+              const disabled = kind.disabled === true || !canLaunch;
+              return (
+                <button
+                  key={`${plugin.id}:${kind.id}`}
+                  type="button"
+                  role="menuitem"
+                  className="theater-menu-item canvas-context-menu-item operation-launch-menu-item"
+                  disabled={disabled}
+                  title={kind.disabledReason}
+                  onClick={() => onLaunchKind(plugin.id, kind)}
+                >
+                  <span className="theater-menu-check" aria-hidden="true">{renderKindIcon(plugin.id, kind) ?? <FallbackGlyph />}</span>
+                  <span className="theater-menu-label">{kind.title}</span>
+                  {kind.disabledReason ? <span className="operation-launch-menu-reason">{kind.disabledReason}</span> : null}
                 </button>
-              ) : null}
-            </div>
-          </>
-        ) : null}
+              );
+            })}
+          </div>
+        )) : <p className="theater-menu-empty">No operations available.</p>}
       </div>
     </div>
   );
@@ -222,31 +112,6 @@ function clampedAnchorStyle(
   const top = bounds ? Math.max(MENU_MARGIN, Math.min(anchor.y, bounds.height - MENU_MAX_HEIGHT - MENU_MARGIN)) : anchor.y;
   return { left, top };
 }
-
-function resolveModLabel(): string {
-  const userAgentDataPlatform = (navigator as NavigatorWithUserAgentData).userAgentData?.platform;
-  const platform = userAgentDataPlatform ?? navigator.platform;
-  return MAC_PLATFORM_PATTERN.test(platform) ? "⌘" : "Ctrl";
-}
-
-function ResetGlyph() {
-  // 뷰 리셋 — 원점 복귀를 뜻하는 되돌림 화살표 마크(console-core 자체 액션).
-  return (
-    <svg viewBox="0 0 16 16" aria-hidden="true">
-      <path d="M4.4 7.2A4 4 0 1 1 4 9.2" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M2.4 4.6v2.8h2.8" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
-}
-
-function FormationGlyph() {
-  return (
-    <svg viewBox="0 0 16 16" aria-hidden="true">
-      <path d="M3 3h4v4H3zM9 3h4v4H9zM3 9h4v4H3zM9 9h4v4H9z" fill="none" stroke="currentColor" strokeWidth="1.2" />
-    </svg>
-  );
-}
-
 
 // 플러그인이 아이콘을 등록하지 않았을 때의 일반 폴백 마크 — 특정 플러그인 지식이 아니다.
 function FallbackGlyph() {

--- a/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
@@ -44,9 +44,12 @@ export interface GridSlotGeometry {
   readonly height: number;
 }
 
+export type FormationLayout = "grid" | "columns" | "rows";
+
 type Listener = () => void;
 
 const STORAGE_KEY_PREFIX = "fleet-console.canvas.";
+const FORMATION_LAYOUT_STORAGE_KEY = "fleet-console.formation-layout";
 const SAVE_DELAY_MS = 400;
 const DEFAULT_OPERATION_WIDTH = 640;
 const DEFAULT_OPERATION_HEIGHT = 400;
@@ -69,6 +72,7 @@ const EMPTY_STATE: CanvasState = { viewport: DEFAULT_VIEWPORT, operations: {}, o
 const listeners = new Set<Listener>();
 const maximizedOperationListeners = new Set<Listener>();
 const formationViewListeners = new Set<Listener>();
+const formationLayoutListeners = new Set<Listener>();
 const maximizedOperationIdsByTheater = new Map<string, string>();
 const formationViewsByTheater = new Map<string, true>();
 let activeTheaterId: string | null = null;
@@ -76,6 +80,7 @@ let saveTimer: number | null = null;
 let state: CanvasState = EMPTY_STATE;
 let maximizedOperationId: string | null = null;
 let formationView = false;
+let formationLayout = readStoredFormationLayout();
 // 줌 보간 루프가 향하는 목표 viewport. 즉시 이동(pan/focus/load)은 이 값을 current와 동기화해 잔여 보간을 무효화한다.
 let targetViewport: CanvasViewport = DEFAULT_VIEWPORT;
 let zoomRaf: number | null = null;
@@ -102,6 +107,10 @@ export function getFormationView(): boolean {
   return formationView;
 }
 
+export function getFormationLayout(): FormationLayout {
+  return formationLayout;
+}
+
 // canvas 스토어가 현재 로드한 Theater id. maximizedOperationId·maximizedOperationIdsByTheater 등
 // 최대화 상태는 이 Theater 기준으로 동작하므로, 최대화 관련 가드는 store.activeTheaterId가 아니라 이 값을 기준으로 삼아야 한다.
 // (loadForTheater가 passive effect로 갱신되어 store.activeTheaterId보다 한 박자 늦을 수 있다.)
@@ -119,6 +128,10 @@ export function useMaximizedOperationId(): string | null {
 
 export function useFormationView(): boolean {
   return useSyncExternalStore(subscribeFormationView, getFormationView, getFormationView);
+}
+
+export function useFormationLayout(): FormationLayout {
+  return useSyncExternalStore(subscribeFormationLayout, getFormationLayout, getFormationLayout);
 }
 
 // 최소화 목록은 CanvasState의 일부라 메인 listeners/emit을 그대로 공유한다(별도 채널 불필요).
@@ -190,12 +203,43 @@ export function calculateGridSlots(
   minimumHeight = MIN_OPERATION_HEIGHT,
   gap = OPERATION_GRID_GAP,
   padding = OPERATION_GRID_PADDING,
+  layout: FormationLayout = "grid",
 ): readonly GridSlotGeometry[] {
   if (!Number.isFinite(count) || count <= 0) return [];
-  const columns = Math.ceil(Math.sqrt(count));
-  const rows = Math.ceil(count / columns);
   const innerWidth = Math.max(0, rect.width - padding * 2);
   const innerHeight = Math.max(0, rect.height - padding * 2);
+  if (layout === "columns") {
+    const availableWidth = Math.max(0, innerWidth - gap * (count - 1));
+    const naturalWidth = availableWidth / count;
+    const effectiveMinWidth = Math.min(minimumWidth, naturalWidth);
+    const width = Math.min(Math.max(effectiveMinWidth, naturalWidth), availableWidth);
+    const naturalHeight = innerHeight;
+    const effectiveMinHeight = Math.min(minimumHeight, naturalHeight);
+    const height = Math.min(Math.max(effectiveMinHeight, naturalHeight), innerHeight);
+    return Array.from({ length: count }, (_, index) => ({
+      x: rect.x + padding + index * (width + gap),
+      y: rect.y + padding,
+      width,
+      height,
+    }));
+  }
+  if (layout === "rows") {
+    const naturalWidth = innerWidth;
+    const effectiveMinWidth = Math.min(minimumWidth, naturalWidth);
+    const width = Math.min(Math.max(effectiveMinWidth, naturalWidth), innerWidth);
+    const availableHeight = Math.max(0, innerHeight - gap * (count - 1));
+    const naturalHeight = availableHeight / count;
+    const effectiveMinHeight = Math.min(minimumHeight, naturalHeight);
+    const height = Math.min(Math.max(effectiveMinHeight, naturalHeight), availableHeight);
+    return Array.from({ length: count }, (_, index) => ({
+      x: rect.x + padding,
+      y: rect.y + padding + index * (height + gap),
+      width,
+      height,
+    }));
+  }
+  const columns = Math.ceil(Math.sqrt(count));
+  const rows = Math.ceil(count / columns);
   const availableHeight = Math.max(0, innerHeight - gap * (rows - 1));
   const naturalHeight = availableHeight / rows;
   const effectiveMinHeight = Math.min(minimumHeight, naturalHeight);
@@ -403,24 +447,31 @@ export function clearMaximizedOperationId(): void {
   emitMaximizedOperation();
 }
 
-export function toggleFormationView(options?: { readonly restoreMinimized?: boolean }): void {
+export function toggleFormationView(): void {
   if (!activeTheaterId) return;
   if (formationView) {
-    if (options?.restoreMinimized === true && state.minimized.length > 0) {
-      setState({ minimized: [] });
-      return;
-    }
     clearFormationView();
     return;
-  }
-  if (options?.restoreMinimized === true) {
-    // Only the include-minimized entry restores docked panels. Open-panel entry keeps them minimized — including the panels a maximize sent to the dock, which stay docked until an explicit restore.
-    setState({ minimized: [] });
   }
   clearMaximizedOperationId();
   formationViewsByTheater.set(activeTheaterId, true);
   formationView = true;
   emitFormationView();
+}
+
+export function selectFormationLayout(layout: FormationLayout): void {
+  if (!activeTheaterId) return;
+  if (formationView && formationLayout === layout) {
+    clearFormationView();
+    return;
+  }
+  setFormationLayout(layout);
+  if (!formationView) {
+    clearMaximizedOperationId();
+    formationViewsByTheater.set(activeTheaterId, true);
+    formationView = true;
+    emitFormationView();
+  }
 }
 
 export function clearFormationView(): void {
@@ -430,10 +481,23 @@ export function clearFormationView(): void {
   emitFormationView();
 }
 
+export function setFormationLayout(layout: FormationLayout): void {
+  formationLayout = layout;
+  writeStoredFormationLayout(layout);
+  emitFormationLayout();
+}
+
 export function subscribeFormationView(listener: Listener): () => void {
   formationViewListeners.add(listener);
   return () => {
     formationViewListeners.delete(listener);
+  };
+}
+
+export function subscribeFormationLayout(listener: Listener): () => void {
+  formationLayoutListeners.add(listener);
+  return () => {
+    formationLayoutListeners.delete(listener);
   };
 }
 
@@ -454,6 +518,10 @@ function getMaximizedOperationSnapshot(): string | null {
 
 function emitFormationView(): void {
   for (const listener of formationViewListeners) listener();
+}
+
+function emitFormationLayout(): void {
+  for (const listener of formationLayoutListeners) listener();
 }
 
 function getMinimizedSnapshot(): readonly string[] {
@@ -557,6 +625,25 @@ function writeStoredState(theaterId: string | null, value: CanvasState): void {
     window.localStorage.setItem(storageKey(theaterId), JSON.stringify(value));
   } catch {
     // 저장 실패는 캔버스 복구성만 낮추므로 런타임 흐름을 막지 않는다.
+  }
+}
+
+function readStoredFormationLayout(): FormationLayout {
+  if (typeof window === "undefined") return "grid";
+  try {
+    const stored = window.localStorage.getItem(FORMATION_LAYOUT_STORAGE_KEY);
+    return stored === "columns" || stored === "rows" || stored === "grid" ? stored : "grid";
+  } catch {
+    return "grid";
+  }
+}
+
+function writeStoredFormationLayout(layout: FormationLayout): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(FORMATION_LAYOUT_STORAGE_KEY, layout);
+  } catch {
+    // 저장 실패는 Formation 레이아웃 복구성만 낮추므로 런타임 흐름을 막지 않는다.
   }
 }
 

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -8,7 +8,7 @@ import { flattenGroupedOrder, hydrateOperations, setActiveOperation } from "../s
 import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import type { ConsoleState, OperationNode } from "../types.js";
-import { calculateGridSlots, animateViewportTo, claimTopZIndex, clearMaximizedOperationId, focusOperation, getSnapshot as getCanvasSnapshot, minimizeOperation, restoreOperation, setMaximizedOperationId, setOperationGeometry, setViewport, useCanvasState, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "./canvas-store.js";
+import { calculateGridSlots, animateViewportTo, claimTopZIndex, clearMaximizedOperationId, focusOperation, getSnapshot as getCanvasSnapshot, minimizeOperation, restoreOperation, setMaximizedOperationId, setOperationGeometry, setViewport, useCanvasState, useFormationLayout, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "./canvas-store.js";
 import { CanvasContextMenu } from "./canvas-context-menu.js";
 import { CanvasMinimap } from "./canvas-minimap.js";
 import { CanvasGrid } from "./canvas-grid.js";
@@ -70,6 +70,7 @@ export function OperationsCanvas({
 }: OperationsCanvasProps) {
   const canvasRef = useRef<HTMLElement | null>(null);
   const canvas = useCanvasState();
+  const formationLayout = useFormationLayout();
   const formationView = useFormationView();
   const maximizedOperationId = useMaximizedOperationId();
   const minimized = useMinimized();
@@ -151,7 +152,7 @@ export function OperationsCanvas({
     canvas.operationOrder,
     [],
   ).filter((operation) => !minimizedSet.has(operation.id)).map((operation) => operation.id);
-  const formationSlots = formationView ? calculateGridSlots({ x: 0, y: 0, width: canvasSize.width, height: canvasSize.height }, formationOperationIds.length) : [];
+  const formationSlots = formationView ? calculateGridSlots({ x: 0, y: 0, width: canvasSize.width, height: canvasSize.height }, formationOperationIds.length, undefined, undefined, undefined, undefined, formationLayout) : [];
   const formationSlotByOperationId = new Map(formationOperationIds.map((operationId, index) => [operationId, formationSlots[index]!]));
   // 최대화 시에는 net scale 1(기본 줌)로 렌더한다 — 현재 배율과 무관하게 터미널이 선명하게 그려진다.
   const effectiveZoom = panelMaximized || formationView ? 1 : canvas.viewport.zoom;

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -24,8 +24,6 @@ interface OperationsCanvasProps {
   readonly renderKindIcon: (pluginId: string, kind: OperationLaunchKind) => ReactNode;
   readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind, canvasPoint: CanvasPoint) => void;
   readonly onLaunchAtGeometry: (pluginId: string, kind: OperationLaunchKind, geometry: OperationGeometry) => void;
-  readonly onResetView: () => void;
-  readonly onToggleFormation: () => void;
   readonly onClose: (operationId: string) => void;
   readonly onFocus: (operationId: string) => void;
   readonly onRename: (operationId: string, title: string) => void;
@@ -61,8 +59,6 @@ export function OperationsCanvas({
   renderKindIcon,
   onLaunchKind,
   onLaunchAtGeometry,
-  onResetView,
-  onToggleFormation,
   onClose,
   onFocus,
   onRename,
@@ -116,11 +112,6 @@ export function OperationsCanvas({
     setContextMenu(null);
     if (!point) return;
     onLaunchKind(pluginId, kind, point);
-  };
-
-  const handleContextMenuResetView = () => {
-    setContextMenu(null);
-    onResetView();
   };
 
   const handleContextMenu = (event: ReactMouseEvent<HTMLElement>) => {
@@ -251,12 +242,6 @@ export function OperationsCanvas({
           canLaunch={canLaunch && !formationView}
           renderKindIcon={renderKindIcon}
           onLaunchKind={handleContextMenuLaunchKind}
-          onResetView={handleContextMenuResetView}
-          formationView={formationView}
-          onToggleFormation={() => {
-            onToggleFormation();
-            setContextMenu(null);
-          }}
           onClose={() => setContextMenu(null)}
         />
       ) : null}

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -44,10 +44,6 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
   const stateRef = useRef(state);
   stateRef.current = state;
 
-  const handleToggleFormation = useCallback(() => {
-    toggleFormationView();
-  }, []);
-
   useEffect(() => {
     loadForTheater(state.activeTheaterId);
   }, [state.activeTheaterId]);
@@ -103,7 +99,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, [formationView, handleToggleFormation, maximizedOperationId]);
+  }, [formationView, maximizedOperationId]);
 
   useEffect(() => {
     for (const operationId of operationOrder) ensureDefaultGeometry(operationId);
@@ -359,8 +355,6 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
           renderKindIcon={renderKindIcon}
           onLaunchKind={handleCanvasLaunchKind}
           onLaunchAtGeometry={handleLaunchAtGeometry}
-          onResetView={handleResetView}
-          onToggleFormation={handleToggleFormation}
           onClose={handleClose}
           onFocus={handleFocus}
           onRename={handleRename}

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -67,10 +67,10 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       const active = document.activeElement;
       if (active instanceof HTMLElement && active.matches("input, textarea, [contenteditable='true']") && !active.closest(".xterm")) return;
       // macOS의 Option+문자는 합성 문자를 내보내므로(event.key가 "©"/"ƒ") 물리 키 기준인 event.code로 판별한다.
-      if (event.code === "KeyF") {
+      if (event.code === "KeyF" && !event.shiftKey) {
         event.preventDefault();
         event.stopImmediatePropagation();
-        toggleFormationView({ restoreMinimized: event.shiftKey });
+        toggleFormationView();
         return;
       }
       if (event.shiftKey || (event.key !== "ArrowLeft" && event.key !== "ArrowRight")) return;

--- a/runtime/fleet-console/core/client/src/shortcuts-catalog.ts
+++ b/runtime/fleet-console/core/client/src/shortcuts-catalog.ts
@@ -31,8 +31,7 @@ export const SHORTCUT_GROUPS: readonly ShortcutGroup[] = [
     title: "Map",
     entries: [
       { combos: [["Alt", "←"], ["Alt", "→"]], description: "Focus the previous / next Operation" },
-      { combos: [["Alt", "F"]], description: "Toggle Formation view (open panels only)" },
-      { combos: [["Alt", "Shift", "F"]], description: "Formation view including minimized panels" },
+      { combos: [["Alt", "F"]], description: "Toggle Formation view" },
       { combos: [["Drag"]], description: "Pan the operations map" },
       { combos: [["Shift", "Drag"]], description: "Draw a new Operation terminal" },
       { combos: [["Space", "Drag"]], description: "Pan even while a terminal has focus" },

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -508,6 +508,8 @@ export function OperationsSideBar({
       <div className="side-bar-theater-add-row">
         <button type="button" className="side-bar-theater-add-btn" onClick={openTheaterBrowser} disabled={addingTheater} aria-label="Add Theater" title={addingTheater ? "Adding Theater" : "Add Theater"}><PlusIcon /><span>Add Theater</span></button>
         <div className="side-bar-formation-group" role="group" aria-label="Formation view">
+          <button type="button" className="side-bar-formation-toggle side-bar-formation-seg" onClick={() => onResetView()} disabled={activeTheaterId === null} aria-label="Reset canvas view" title="Reset canvas view"><ResetViewIcon /></button>
+          <span className="side-bar-formation-divider" aria-hidden="true" />
           <button type="button" className="side-bar-formation-toggle side-bar-formation-seg" onClick={() => selectFormationLayout("grid")} disabled={activeTheaterId === null} aria-pressed={formationView && formationLayout === "grid"} aria-label="Formation view — Grid layout" title="Formation view — Grid layout"><FormationGridIcon /></button>
           <button type="button" className="side-bar-formation-toggle side-bar-formation-seg" onClick={() => selectFormationLayout("columns")} disabled={activeTheaterId === null} aria-pressed={formationView && formationLayout === "columns"} aria-label="Formation view — Columns layout" title="Formation view — Columns layout"><FormationColumnsIcon /></button>
           <button type="button" className="side-bar-formation-toggle side-bar-formation-seg" onClick={() => selectFormationLayout("rows")} disabled={activeTheaterId === null} aria-pressed={formationView && formationLayout === "rows"} aria-label="Formation view — Rows layout" title="Formation view — Rows layout"><FormationRowsIcon /></button>
@@ -692,12 +694,10 @@ export function OperationsSideBar({
           anchor={newMenu.anchor}
           viewportBounds={newMenu.viewportBounds}
           placement="cursor"
-          mode="launch"
           catalog={catalog}
           canLaunch={canLaunch}
           renderKindIcon={renderKindIcon}
           onLaunchKind={(pluginId, kind) => { setNewMenu(null); onLaunchKind(pluginId, kind); }}
-          onResetView={onResetView}
           onClose={() => setNewMenu(null)}
         />,
         document.body,
@@ -753,6 +753,10 @@ export function OperationsSideBar({
 
 function FormationGridIcon() {
   return <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3 3h4v4H3zM9 3h4v4H9zM3 9h4v4H3zM9 9h4v4H9z" fill="none" stroke="currentColor" strokeWidth="1.2" /></svg>;
+}
+
+function ResetViewIcon() {
+  return <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M4.4 7.2A4 4 0 1 1 4 9.2" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" /><path d="M2.4 4.6v2.8h2.8" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" /></svg>;
 }
 
 function FormationColumnsIcon() {

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -11,7 +11,7 @@ import { DirectoryBrowserModal } from "../components/directory-browser-modal.js"
 import { useConsoleState } from "../hooks/use-store.js";
 import { GroupContextMenu } from "../canvas/group-context-menu.js";
 import { operationAccentFromNode, resolveAccentColor } from "../canvas/operation-accent.js";
-import { setOperationOrder, toggleFormationView, toggleGroupCollapsed, useCanvasState, useCollapsedGroups, useFormationView } from "../canvas/canvas-store.js";
+import { selectFormationLayout, setOperationOrder, toggleGroupCollapsed, useCanvasState, useCollapsedGroups, useFormationLayout, useFormationView } from "../canvas/canvas-store.js";
 import { sortOperationsByOrder } from "../store.js";
 import { SideBarBrandFoot } from "../components/side-bar-brand-foot.js";
 import { applyVisibleReorder, groupDropIndexFromPoint, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderGroupIds, reorderWithinSegment, type DropSectionInfo } from "./operations-side-bar-hit-test.js";
@@ -178,6 +178,7 @@ export function OperationsSideBar({
   const { width, collapsed } = sideBar;
   const previousCollapsedRef = useRef(collapsed);
   const canvas = useCanvasState();
+  const formationLayout = useFormationLayout();
   const formationView = useFormationView();
   const closeArmTimeoutRef = useRef<number | null>(null);
   const [armedCloseId, setArmedCloseId] = useState<string | null>(null);
@@ -507,8 +508,9 @@ export function OperationsSideBar({
       <div className="side-bar-theater-add-row">
         <button type="button" className="side-bar-theater-add-btn" onClick={openTheaterBrowser} disabled={addingTheater} aria-label="Add Theater" title={addingTheater ? "Adding Theater" : "Add Theater"}><PlusIcon /><span>Add Theater</span></button>
         <div className="side-bar-formation-group" role="group" aria-label="Formation view">
-          <button type="button" className="side-bar-formation-toggle side-bar-formation-seg" onClick={() => toggleFormationView()} disabled={activeTheaterId === null} aria-pressed={formationView} aria-label="Formation view (open panels only)" title="Formation view (Alt+F)"><FormationIcon /></button>
-          <button type="button" className="side-bar-formation-toggle side-bar-formation-seg" onClick={() => toggleFormationView({ restoreMinimized: true })} disabled={activeTheaterId === null} aria-pressed={formationView && minimizedSet.size === 0} aria-label="Formation view including minimized panels" title="Formation view incl. minimized (Alt+Shift+F)"><FormationFilledIcon /></button>
+          <button type="button" className="side-bar-formation-toggle side-bar-formation-seg" onClick={() => selectFormationLayout("grid")} disabled={activeTheaterId === null} aria-pressed={formationView && formationLayout === "grid"} aria-label="Formation view — Grid layout" title="Formation view — Grid layout"><FormationGridIcon /></button>
+          <button type="button" className="side-bar-formation-toggle side-bar-formation-seg" onClick={() => selectFormationLayout("columns")} disabled={activeTheaterId === null} aria-pressed={formationView && formationLayout === "columns"} aria-label="Formation view — Columns layout" title="Formation view — Columns layout"><FormationColumnsIcon /></button>
+          <button type="button" className="side-bar-formation-toggle side-bar-formation-seg" onClick={() => selectFormationLayout("rows")} disabled={activeTheaterId === null} aria-pressed={formationView && formationLayout === "rows"} aria-label="Formation view — Rows layout" title="Formation view — Rows layout"><FormationRowsIcon /></button>
         </div>
       </div>
       {!collapsed && theaterError ? <p className="side-bar-theater-error">{theaterError}</p> : null}
@@ -749,12 +751,16 @@ export function OperationsSideBar({
   );
 }
 
-function FormationIcon() {
+function FormationGridIcon() {
   return <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3 3h4v4H3zM9 3h4v4H9zM3 9h4v4H3zM9 9h4v4H9z" fill="none" stroke="currentColor" strokeWidth="1.2" /></svg>;
 }
 
-function FormationFilledIcon() {
-  return <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3 3h4v4H3zM9 3h4v4H9zM3 9h4v4H3zM9 9h4v4H9z" fill="currentColor" /></svg>;
+function FormationColumnsIcon() {
+  return <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M2.5 2.5h3v11h-3zM6.5 2.5h3v11h-3zM10.5 2.5h3v11h-3z" fill="none" stroke="currentColor" strokeWidth="1.2" /></svg>;
+}
+
+function FormationRowsIcon() {
+  return <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M2.5 2.5h11v3h-11zM2.5 6.5h11v3h-11zM2.5 10.5h11v3h-11z" fill="none" stroke="currentColor" strokeWidth="1.2" /></svg>;
 }
 
 interface GroupSection {

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2188,70 +2188,7 @@
   white-space: nowrap;
 }
 
-.canvas-context-menu-tabs {
-  display: flex;
-  gap: 2px;
-  margin: var(--space-3) var(--space-1) var(--space-1);
-  padding: 3px;
-  border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-sm);
-  background: color-mix(in oklch, var(--ink-abyss) 55%, transparent);
-}
-
-.canvas-context-menu-tab {
-  position: relative;
-  flex: 1;
-  padding: 7px 6px 8px;
-  border: 0;
-  border-radius: var(--radius-xs);
-  background: transparent;
-  color: var(--ink-fog);
-  cursor: pointer;
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  transition:
-    color var(--duration-fast) var(--ease-spring),
-    background var(--duration-fast) var(--ease-spring);
-}
-
-.canvas-context-menu-tab:hover {
-  color: var(--ink-spectral);
-}
-
-.canvas-context-menu-tab[aria-selected="true"] {
-  background: color-mix(in oklch, var(--brass) 14%, var(--surface-glass));
-  color: var(--ink-pearl);
-}
-
-.canvas-context-menu-tab[aria-selected="true"]::after {
-  content: "";
-  position: absolute;
-  right: 22%;
-  bottom: 2px;
-  left: 22%;
-  height: 2px;
-  border-radius: 999px;
-  background: var(--brass);
-  box-shadow: 0 0 8px var(--brass-glow);
-}
-
-.canvas-context-menu-tab:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 1px;
-}
-
-.canvas-context-menu-panel {
-  padding-top: var(--space-1);
-}
-
-.canvas-context-menu-panel[hidden] {
-  display: none;
-}
-
-/* Operations / Map / Help 섹션 라벨 — 작전 통제면을 행위 카테고리로 나눈다(브래스="보는 곳"). */
+/* Launch 섹션 라벨. */
 .canvas-context-menu-section {
   margin: var(--space-2) 0 0;
   padding: var(--space-1) var(--space-2);
@@ -2277,93 +2214,6 @@
   font-size: 9px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-}
-
-.canvas-context-menu-switch {
-  display: flex;
-  width: 100%;
-  align-items: center;
-  gap: var(--space-3);
-  padding: var(--space-2);
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--ink-spectral);
-  cursor: pointer;
-  font: inherit;
-  text-align: left;
-  transition:
-    border-color var(--duration-fast) var(--ease-spring),
-    background var(--duration-fast) var(--ease-spring),
-    color var(--duration-fast) var(--ease-spring);
-}
-
-.canvas-context-menu-switch:hover,
-.canvas-context-menu-switch:focus-visible {
-  outline: none;
-  border-color: var(--surface-rim);
-  background: var(--surface-glass);
-  color: var(--ink-pearl);
-}
-
-.canvas-context-menu-switch-icon {
-  display: grid;
-  place-items: center;
-  flex: none;
-  width: 18px;
-  height: 18px;
-  color: var(--ink-fog);
-}
-
-.canvas-context-menu-switch-icon svg {
-  width: 16px;
-  height: 16px;
-}
-
-.canvas-context-menu-switch.is-on .canvas-context-menu-switch-icon {
-  color: var(--brass);
-}
-
-.canvas-context-menu-switch-label {
-  flex: 1;
-  font-size: 13px;
-}
-
-.canvas-context-menu-switch-track {
-  position: relative;
-  flex: none;
-  width: 34px;
-  height: 19px;
-  border: 1px solid var(--surface-rim);
-  border-radius: 999px;
-  background: color-mix(in oklch, var(--ink-mid) 80%, transparent);
-  transition:
-    background var(--duration-base) var(--ease-glide),
-    border-color var(--duration-base) var(--ease-glide);
-}
-
-.canvas-context-menu-switch-track::after {
-  content: "";
-  position: absolute;
-  top: 1.5px;
-  left: 1.5px;
-  width: 14px;
-  height: 14px;
-  border-radius: 999px;
-  background: var(--ink-fog);
-  transition:
-    transform var(--duration-base) var(--ease-spring),
-    background var(--duration-base) var(--ease-glide);
-}
-
-.canvas-context-menu-switch.is-on .canvas-context-menu-switch-track {
-  border-color: var(--brass);
-  background: color-mix(in oklch, var(--brass) 60%, var(--brass-deep));
-}
-
-.canvas-context-menu-switch.is-on .canvas-context-menu-switch-track::after {
-  background: var(--ink-pearl);
-  transform: translateX(15px);
 }
 
 .canvas-context-menu-help {
@@ -2803,6 +2653,13 @@
 
 .side-bar-formation-group .side-bar-formation-seg + .side-bar-formation-seg {
   border-left: 1px solid var(--surface-rim);
+}
+
+.side-bar-formation-divider {
+  align-self: stretch;
+  flex: none;
+  width: 1px;
+  background: var(--surface-rim);
 }
 
 .side-bar-formation-toggle {
@@ -5991,13 +5848,6 @@
   .operation-search-overlay,
   .commissioning-card {
     animation: none;
-  }
-
-  .canvas-context-menu-switch-track,
-  .canvas-context-menu-switch-track::after,
-  .canvas-context-menu-tab,
-  .canvas-context-menu-switch {
-    transition: none;
   }
 
   .commissioning-primary-action.is-live::before {

--- a/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
+++ b/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
@@ -234,8 +234,6 @@ function renderOperationsCanvas() {
     renderKindIcon: () => null,
     onLaunchKind: () => {},
     onLaunchAtGeometry: () => {},
-    onResetView: () => {},
-    onToggleFormation: () => {},
     onClose: () => {},
     onFocus: () => {},
     onRename: () => {},

--- a/runtime/fleet-console/tests/canvas-store.test.ts
+++ b/runtime/fleet-console/tests/canvas-store.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { calculateGridSlots, clearFormationView, clearMaximizedOperationId, getFormationView, getMaximizedOperationId, getSnapshot, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, setMaximizedOperationId, setOperationAccent, setOperationGeometry, setOperationOrder, toggleFormationView, type OperationGeometry } from "../core/client/src/canvas/canvas-store.js";
+import { calculateGridSlots, clearFormationView, clearMaximizedOperationId, getFormationLayout, getFormationView, getMaximizedOperationId, getSnapshot, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, selectFormationLayout, setFormationLayout, setMaximizedOperationId, setOperationAccent, setOperationGeometry, setOperationOrder, toggleFormationView, type OperationGeometry } from "../core/client/src/canvas/canvas-store.js";
 
 const GEOMETRY: OperationGeometry = { x: 0, y: 0, width: 100, height: 100, zIndex: 0 };
 
@@ -15,6 +15,7 @@ beforeEach(() => {
     setTimeout,
   });
   window.localStorage.clear();
+  setFormationLayout("grid");
   loadForTheater("theater-a");
   clearMaximizedOperationId();
   clearFormationView();
@@ -139,19 +140,6 @@ describe("canvas store", () => {
     expect(getSnapshot().minimized).toEqual(["op-a", "op-c"]);
   });
 
-  it("restores maximize-docked Operations when entering Formation with restoreMinimized", () => {
-    setOperationGeometry("op-a", { ...GEOMETRY });
-    setOperationGeometry("op-b", { ...GEOMETRY });
-    setOperationGeometry("op-c", { ...GEOMETRY });
-    setMaximizedOperationId("op-b");
-
-    toggleFormationView({ restoreMinimized: true });
-
-    expect(getFormationView()).toBe(true);
-    expect(getMaximizedOperationId()).toBeNull();
-    expect(getSnapshot().minimized).toEqual([]);
-  });
-
   it("keeps manually minimized Operations minimized when entering Formation", () => {
     setOperationGeometry("op-a", { ...GEOMETRY });
     setOperationGeometry("op-b", { ...GEOMETRY });
@@ -161,37 +149,6 @@ describe("canvas store", () => {
 
     expect(getFormationView()).toBe(true);
     expect(getSnapshot().minimized).toEqual(["op-b"]);
-  });
-
-  it("restores every minimized Operation when entering Formation with restoreMinimized", () => {
-    setOperationGeometry("op-a", { ...GEOMETRY });
-    setOperationGeometry("op-b", { ...GEOMETRY });
-    minimizeOperation("op-b");
-
-    toggleFormationView({ restoreMinimized: true });
-
-    expect(getFormationView()).toBe(true);
-    expect(getSnapshot().minimized).toEqual([]);
-  });
-
-  it("adds minimized Operations to active Formation when restoreMinimized is requested", () => {
-    setOperationGeometry("op-a", { ...GEOMETRY });
-    setOperationGeometry("op-b", { ...GEOMETRY });
-    minimizeOperation("op-b");
-    toggleFormationView();
-
-    toggleFormationView({ restoreMinimized: true });
-
-    expect(getFormationView()).toBe(true);
-    expect(getSnapshot().minimized).toEqual([]);
-  });
-
-  it("exits active Formation when restoreMinimized is requested with no minimized Operations", () => {
-    toggleFormationView();
-
-    toggleFormationView({ restoreMinimized: true });
-
-    expect(getFormationView()).toBe(false);
   });
 
   it("exits active Formation when toggled without options", () => {
@@ -260,6 +217,47 @@ describe("canvas store", () => {
     const [slot] = calculateGridSlots({ x: 0, y: 0, width: 300, height: 250 }, 1);
 
     expect(slot).toEqual({ x: 0, y: 0, width: 300, height: 250 });
+  });
+
+  it("calculates full-height columns with configured gap and padding", () => {
+    const slots = calculateGridSlots({ x: 10, y: 20, width: 1000, height: 800 }, 5, 320, 200, 10, 20, "columns");
+
+    expect(slots).toHaveLength(5);
+    expect(slots[0]).toEqual({ x: 30, y: 40, width: 184, height: 760 });
+    expect(slots[4]).toEqual({ x: 806, y: 40, width: 184, height: 760 });
+  });
+
+  it("calculates full-width rows with configured gap and padding", () => {
+    const slots = calculateGridSlots({ x: 10, y: 20, width: 1000, height: 800 }, 5, 320, 200, 10, 20, "rows");
+
+    expect(slots).toHaveLength(5);
+    expect(slots[0]).toEqual({ x: 30, y: 40, width: 960, height: 144 });
+    expect(slots[4]).toEqual({ x: 30, y: 656, width: 960, height: 144 });
+  });
+
+  it("defaults Formation layout to grid and persists the global selection", () => {
+    expect(getFormationLayout()).toBe("grid");
+
+    setFormationLayout("columns");
+    expect(getFormationLayout()).toBe("columns");
+    expect(window.localStorage.getItem("fleet-console.formation-layout")).toBe("columns");
+
+    loadForTheater("theater-b");
+    expect(getFormationLayout()).toBe("columns");
+  });
+
+  it("selects a Formation layout to enter, switch, and exit Formation", () => {
+    selectFormationLayout("columns");
+    expect(getFormationView()).toBe(true);
+    expect(getFormationLayout()).toBe("columns");
+
+    selectFormationLayout("rows");
+    expect(getFormationView()).toBe(true);
+    expect(getFormationLayout()).toBe("rows");
+
+    selectFormationLayout("rows");
+    expect(getFormationView()).toBe(false);
+    expect(getFormationLayout()).toBe("rows");
   });
 
   it("keeps Formation view independent per Theater without modifying saved geometry", () => {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -156,10 +156,12 @@ describe("Instrument core design contract", () => {
     expect(commandBand).not.toContain("command-band-formation-toggle");
     const sidebar = source("sidebar/operations-side-bar.tsx");
     expect(sidebar).toContain('<div className="side-bar-formation-group" role="group" aria-label="Formation view">');
-    expect(sidebar).toContain('className="side-bar-formation-toggle side-bar-formation-seg" onClick={() => toggleFormationView()}');
-    expect(sidebar).toContain('aria-pressed={formationView} aria-label="Formation view (open panels only)"');
-    expect(sidebar).toContain('className="side-bar-formation-toggle side-bar-formation-seg" onClick={() => toggleFormationView({ restoreMinimized: true })}');
-    expect(sidebar).toContain('aria-pressed={formationView && minimizedSet.size === 0} aria-label="Formation view including minimized panels"');
+    expect(sidebar).toContain('onClick={() => selectFormationLayout("grid")}');
+    expect(sidebar).toContain('onClick={() => selectFormationLayout("columns")}');
+    expect(sidebar).toContain('onClick={() => selectFormationLayout("rows")}');
+    expect(sidebar).toContain('aria-pressed={formationView && formationLayout === "grid"}');
+    expect(sidebar).not.toContain("restoreMinimized");
+    expect(sidebar).not.toContain("Formation view including minimized panels");
     expect(components).toContain(".side-bar-formation-group {");
     expect(components).toContain("border-left: 1px solid var(--surface-rim);");
     expect(commandBand).toContain('"--command-band-left-width": `${sideBar.width}px`');

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -58,7 +58,11 @@ describe("Instrument core design contract", () => {
     expect(components).toContain(".operations-canvas.is-formation-view .canvas-minimap-fab,");
     expect(components).toContain(".operations-canvas.is-panel-maximized .canvas-minimap,");
     expect(components).toContain(".operations-canvas.is-panel-maximized .canvas-minimap-fab {");
-    expect(contextMenu).toContain("Formation view");
+    expect(contextMenu).toContain('<p className="canvas-context-menu-section">Launch</p>');
+    expect(contextMenu).not.toContain("CanvasContextMenuMode");
+    expect(contextMenu).not.toContain("canvas-context-menu-tabs");
+    expect(contextMenu).not.toContain("Formation view");
+    expect(contextMenu).not.toContain("ResetGlyph");
     expect(contextMenu).not.toContain("onToggleRadar");
     expect(contextMenu).not.toContain("onTogglePerimeter");
   });
@@ -156,6 +160,9 @@ describe("Instrument core design contract", () => {
     expect(commandBand).not.toContain("command-band-formation-toggle");
     const sidebar = source("sidebar/operations-side-bar.tsx");
     expect(sidebar).toContain('<div className="side-bar-formation-group" role="group" aria-label="Formation view">');
+    expect(sidebar).toContain('aria-label="Reset canvas view"');
+    expect(sidebar).toContain("<ResetViewIcon />");
+    expect(sidebar).toContain('className="side-bar-formation-divider"');
     expect(sidebar).toContain('onClick={() => selectFormationLayout("grid")}');
     expect(sidebar).toContain('onClick={() => selectFormationLayout("columns")}');
     expect(sidebar).toContain('onClick={() => selectFormationLayout("rows")}');
@@ -327,7 +334,7 @@ describe("Instrument core design contract", () => {
     const components = source("styles/components.css");
     const rail = source("styles/rail.css");
 
-    expect(source("canvas/canvas-context-menu.tsx")).toContain('export type CanvasContextMenuMode = "full" | "launch";');
+    expect(source("canvas/canvas-context-menu.tsx")).not.toContain("CanvasContextMenuMode");
     expect(brandFoot).toContain('className="brand-foot-dropup-menu" role="menu"');
     expect(brandFoot).toContain("System Menu");
     expect(brandFoot).toContain("Keyboard Shortcuts");


### PR DESCRIPTION
## Summary
- Formation view에 **Grid / Columns / Rows** 레이아웃 방향 선택기를 추가합니다. Columns는 울트라와이드용 세로 전용 분할(1×N 풀하이트), Rows는 N×1, Grid(기본)는 기존과 동일합니다.
- 사이드바 formation 그룹의 레이아웃 3버튼이 formation의 **유일한 진입점**입니다(클릭 = 진입 / 전환 / 동일 재클릭 시 해제). 선택한 레이아웃은 **클라이언트 전역 영속**(모니터 단위, 기본 Grid)이며 새로고침·재시작에도 유지됩니다. `Alt+F`는 기억된 레이아웃으로 토글하며, 거의 쓰이지 않던 `Alt+Shift+F`(include-minimized)는 제거했습니다.
- 캔버스 우클릭 컨텍스트 메뉴의 **Map 탭을 제거**해 사이드바 우클릭 메뉴와 동일한 flat Launch 메뉴로 통일했습니다. Map에 있던 `Reset view`는 formation 그룹 **왼쪽 인라인 버튼**(원형 화살표)으로 이관했고, `Formation view` 토글은 3버튼이 대체하므로 폐기했습니다.

## Test Plan
- [x] `vitest run tests/canvas-store.test.ts tests/instrument-design-contract.test.ts tests/canvas-minimap-formation.test.ts` — 39 passed
- [x] `pnpm --filter @dotobokuri/fleet-console build` — green (tsc)
- [x] console-e2e(격리 인스턴스): Columns 클릭 → formation 진입 + 패널 세로 풀하이트(1034px) 리플로우, Rows 전환, 동일 재클릭 해제, 새로고침 영속, `Alt+F` 기억 레이아웃 진입
- [x] console-e2e: 캔버스 우클릭 = flat Launch 메뉴(Map/탭/Reset-view/Formation-item 0), 사이드바 formation 그룹 = Reset + divider + Grid/Columns/Rows

## Changelog
- [x] `.changelog.d/pr-261.md` — grouped fleet-console Added/Changed/Removed, bilingual, `compile-changelog-fragments.mjs --check` 통과