### PR TITLE
fix(pty-input): submit Windows Codex reminders via delayed CR

### DIFF
--- a/.changelog.d/pr-263.md
+++ b/.changelog.d/pr-263.md
@@ -1,0 +1,9 @@
+### fleet-cli
+#### Fixed
+- [fleet-cli] Submit carrier-result reminders to the Codex TUI on Windows instead of leaving them unsent in the prompt.
+  ko: Windows에서 carrier-result 리마인더가 프롬프트에 남지 않고 Codex TUI에 제출됩니다.
+
+### fleet-plugin
+#### Fixed
+- [fleet-console] Submit terminal carrier-result reminders to Codex reliably on Windows ConPTY.
+  ko: Windows ConPTY에서 터미널 carrier-result 리마인더가 Codex에 안정적으로 제출됩니다.

--- a/packages/fleet-admiral/src/agent-cli/builders/toml.ts
+++ b/packages/fleet-admiral/src/agent-cli/builders/toml.ts
@@ -55,6 +55,15 @@ export function buildPosixShellCommand(values: readonly string[]): string {
   return values.map(posixShellQuote).join(" ");
 }
 
+export function buildHostShellCommand(values: readonly string[], platform: NodeJS.Platform = process.platform): string {
+  if (platform === "win32") return values.map(windowsShellQuote).join(" ");
+  return buildPosixShellCommand(values);
+}
+
 function posixShellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function windowsShellQuote(value: string): string {
+  return `"${value.replaceAll("\"", "\"\"")}"`;
 }

--- a/packages/fleet-admiral/src/agent-cli/codex/codex.ts
+++ b/packages/fleet-admiral/src/agent-cli/codex/codex.ts
@@ -17,6 +17,7 @@ export const codexCli: AgentCliDefinition = {
       label: "Codex",
       messagePolicy: {
         bracketedPaste: true,
+        conptyPasteBurst: true,
         lineTerminator: "\r",
         multilineStrategy: "paste-mode",
       },

--- a/packages/fleet-admiral/src/agent-cli/injection.ts
+++ b/packages/fleet-admiral/src/agent-cli/injection.ts
@@ -7,7 +7,7 @@ import { getFleetDataDir } from "@dotobokuri/core-infra/data-dir";
 
 import { buildClaudeNativeArgs } from "./builders/claude.js";
 import { buildCodexNativeArgs } from "./builders/codex.js";
-import { buildPosixShellCommand, escapeTomlBasicString, escapeTomlMultilineString } from "./builders/toml.js";
+import { buildHostShellCommand, escapeTomlBasicString, escapeTomlMultilineString } from "./builders/toml.js";
 import { getAgentCliInjectionCapability } from "./capabilities.js";
 import { cleanupDeprecatedCodexPluginState, createAgentCliPlugin, ensureCodexPluginRegistered, FLEET_MARKETPLACE_NAME } from "./plugin/index.js";
 import type {
@@ -269,7 +269,7 @@ function codexHooksConfig(hookExecs: CodexProfileHookExecs): string[] {
 function codexHookHandlersInline(execs: readonly FleetHookExec[]): string {
   const handlers = execs
     .map((exec) => {
-      const command = buildPosixShellCommand([exec.command, ...exec.args]);
+      const command = buildHostShellCommand([exec.command, ...exec.args]);
       return `{ type = "command", command = "${escapeTomlBasicString(command)}" }`;
     })
     .join(", ");

--- a/packages/fleet-admiral/src/agent-cli/types.ts
+++ b/packages/fleet-admiral/src/agent-cli/types.ts
@@ -22,8 +22,15 @@ export interface AgentCliProfile {
 
 export interface CliMessagePolicy {
   readonly bracketedPaste?: boolean;
+  // true면 Windows(win32)에서 crossterm/ConPTY paste-burst 우회를 적용: bracketed paste 마커 없이 순수 텍스트를 보낸 뒤 제출 CR을 지연된 별도 write로 분리한다. Codex 계열 crossterm TUI 전용.
+  readonly conptyPasteBurst?: boolean;
   readonly lineTerminator?: string;
   readonly multilineStrategy?: "literal" | "paste-mode";
+}
+
+export interface PtyInputChunk {
+  readonly data: string;
+  readonly submitDelayMs?: number;
 }
 
 export interface AgentCliDefinition {

--- a/packages/fleet-admiral/src/agent-runtime/reminder-router.ts
+++ b/packages/fleet-admiral/src/agent-runtime/reminder-router.ts
@@ -22,8 +22,14 @@ export function createCarrierResultReminderRouter(deps: {
   readonly streamRegister: (handler: (event: CarrierJobStreamEvent) => void) => () => void;
   readonly resolveSink: (event: CarrierJobStreamEvent) => PtyWriteSink | undefined;
   readonly resolvePolicy?: (event: CarrierJobStreamEvent) => CliMessagePolicy;
+  readonly resolveSessionKey?: (event: CarrierJobStreamEvent) => string | undefined;
   readonly platform?: NodeJS.Platform;
 }): () => void {
+  // 세션별 지연 제출 직렬화 tail. Windows 지연 경로에서 같은 세션으로 두 리마인더가 250ms
+  // 지연 창 안에 도착하면 텍스트가 뒤섞이고(textA textB) CR이 결합/공백 제출되므로, 이전
+  // 제출의 종결자(CR)까지 flush된 뒤 다음 리마인더의 첫 write가 시작되도록 체인한다.
+  const submitTails = new Map<string, Promise<void>>();
+
   return deps.streamRegister((event) => {
     if (event.type !== "job:finalized") return;
     if (typeof event.systemReminder !== "string") return;
@@ -36,7 +42,24 @@ export function createCarrierResultReminderRouter(deps: {
 
     // host가 활성 프로파일의 messagePolicy를 제공하면 그대로 적용한다. 미제공 시 기본 정책.
     const policy = deps.resolvePolicy?.(event) ?? {};
-    writeChunksWithDelay((data) => sink.write(data), formatCarrierResultReminderMessage(policy, reminder, deps.platform));
+    const chunks = formatCarrierResultReminderMessage(policy, reminder, deps.platform);
+    const write = (data: string) => sink.write(data);
+
+    // 지연 청크(Windows conpty 경로)만 직렬화한다. 동기 단일 write 경로는 즉시 flush되어
+    // 인터리브가 불가능하므로, 세션 키가 있어도 기존 동기 동작을 그대로 유지한다.
+    const key = deps.resolveSessionKey?.(event);
+    const hasDelay = chunks.some((chunk) => chunk.submitDelayMs !== undefined);
+    if (!hasDelay || key === undefined) {
+      void writeChunksWithDelay(write, chunks);
+      return;
+    }
+
+    const prev = submitTails.get(key) ?? Promise.resolve();
+    const tail = prev.then(() => writeChunksWithDelay(write, chunks)).catch(() => {});
+    submitTails.set(key, tail);
+    void tail.then(() => {
+      if (submitTails.get(key) === tail) submitTails.delete(key);
+    });
   });
 }
 
@@ -88,28 +111,33 @@ function applyMessagePolicy(
   }];
 }
 
-function writeChunksWithDelay(write: (data: string) => void, chunks: readonly PtyInputChunk[]): void {
-  let index = 0;
+function writeChunksWithDelay(write: (data: string) => void, chunks: readonly PtyInputChunk[]): Promise<void> {
+  return new Promise((resolve) => {
+    let index = 0;
 
-  const writeNext = (): void => {
-    const chunk = chunks[index++];
-    if (!chunk) return;
-
-    const commit = () => {
-      try {
-        write(chunk.data);
-      } catch {
-        // Sessions may close before a deferred submit reaches the host PTY.
+    const writeNext = (): void => {
+      const chunk = chunks[index++];
+      if (!chunk) {
+        resolve();
+        return;
       }
-      writeNext();
+
+      const commit = () => {
+        try {
+          write(chunk.data);
+        } catch {
+          // Sessions may close before a deferred submit reaches the host PTY.
+        }
+        writeNext();
+      };
+
+      if (chunk.submitDelayMs === undefined) {
+        commit();
+      } else {
+        setTimeout(commit, chunk.submitDelayMs);
+      }
     };
 
-    if (chunk.submitDelayMs === undefined) {
-      commit();
-    } else {
-      setTimeout(commit, chunk.submitDelayMs);
-    }
-  };
-
-  writeNext();
+    writeNext();
+  });
 }

--- a/packages/fleet-admiral/src/agent-runtime/reminder-router.ts
+++ b/packages/fleet-admiral/src/agent-runtime/reminder-router.ts
@@ -6,11 +6,6 @@ export interface PtyWriteSink {
   write(data: string): void;
 }
 
-interface AppliedMessagePolicy {
-  readonly payload: string;
-  readonly submit?: string;
-}
-
 const DEFAULT_BRACKETED_PASTE = false;
 const DEFAULT_LINE_TERMINATOR = "\r";
 const DEFAULT_MULTILINE_STRATEGY = "literal";
@@ -57,10 +52,7 @@ export function formatCarrierResultReminderMessage(
   text: string,
 ): string[] {
   const resolvedPolicy = resolveMessagePolicy(policy);
-  const appliedPolicy = applyMessagePolicy(text, resolvedPolicy);
-  return appliedPolicy.submit === undefined || appliedPolicy.submit.length === 0
-    ? [appliedPolicy.payload]
-    : [appliedPolicy.payload, appliedPolicy.submit];
+  return [applyMessagePolicy(text, resolvedPolicy)];
 }
 
 function resolveMessagePolicy(policy: CliMessagePolicy): Required<CliMessagePolicy> {
@@ -71,18 +63,13 @@ function resolveMessagePolicy(policy: CliMessagePolicy): Required<CliMessagePoli
   };
 }
 
-function applyMessagePolicy(
-  text: string,
-  policy: Required<CliMessagePolicy>,
-): AppliedMessagePolicy {
+function applyMessagePolicy(text: string, policy: Required<CliMessagePolicy>): string {
   const usePasteMode = policy.bracketedPaste || (policy.multilineStrategy === "paste-mode" && LINE_BREAK_PATTERN.test(text));
+  const body = usePasteMode ? `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}` : text;
 
-  if (!usePasteMode) {
-    return { payload: `${text}${policy.lineTerminator}` };
-  }
-
-  return {
-    payload: `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}`,
-    submit: policy.lineTerminator,
-  };
+  // paste 블록과 제출 종결자(CR)를 반드시 하나의 PTY write로 내보낸다. 둘을 별도 write로
+  // 쪼개면 Windows ConPTY의 Codex TUI가 뒤따르는 CR을 Enter로 인식하지 못해, 붙여넣은
+  // 리마인더가 프롬프트에 남고 제출되지 않는다. 단일 원자적 write는 하나의 입력 레코드로
+  // 전달되어 안정적으로 제출되며, macOS/유닉스 PTY 동작에는 영향이 없다.
+  return `${body}${policy.lineTerminator}`;
 }

--- a/packages/fleet-admiral/src/agent-runtime/reminder-router.ts
+++ b/packages/fleet-admiral/src/agent-runtime/reminder-router.ts
@@ -18,17 +18,48 @@ const LINE_BREAK_PATTERN = /[\r\n]/;
 // Windows crossterm reads INPUT_RECORD rather than bracketed paste, then Codex suppresses Enter during its paste burst window.
 const WINDOWS_CONPTY_SUBMIT_DELAY_MS = 250;
 
+export interface DelayedPtyWriter {
+  // sessionKey가 있고 지연 청크가 포함되면 같은 키의 이전 제출이 끝난 뒤 순차 실행한다.
+  enqueue(sessionKey: string | undefined, write: (data: string) => void, chunks: readonly PtyInputChunk[]): void;
+}
+
+// 세션별 지연 제출을 직렬화하는 공유 primitive. Windows 지연 경로에서 같은 세션으로 두 입력
+// (carrier 리마인더/rename 주입)이 250ms 지연 창 안에 도착하면 텍스트가 뒤섞이고(textA textB)
+// CR이 결합/공백 제출되므로, 이전 제출의 종결자(CR)까지 flush된 뒤 다음 입력의 첫 write가
+// 시작되도록 체인한다. 리마인더와 rename이 같은 인스턴스를 공유해야 상호 직렬화된다.
+export function createDelayedPtyWriter(): DelayedPtyWriter {
+  const submitTails = new Map<string, Promise<void>>();
+
+  return {
+    enqueue(sessionKey, write, chunks) {
+      // 지연 청크만 직렬화한다. 동기 단일 write 경로는 즉시 flush되어 인터리브가 불가능하므로
+      // 세션 키가 있어도 기존 동기 동작을 그대로 유지한다.
+      const hasDelay = chunks.some((chunk) => chunk.submitDelayMs !== undefined);
+      if (!hasDelay || sessionKey === undefined) {
+        void writeChunksWithDelay(write, chunks);
+        return;
+      }
+
+      const prev = submitTails.get(sessionKey) ?? Promise.resolve();
+      const tail = prev.then(() => writeChunksWithDelay(write, chunks)).catch(() => {});
+      submitTails.set(sessionKey, tail);
+      void tail.then(() => {
+        if (submitTails.get(sessionKey) === tail) submitTails.delete(sessionKey);
+      });
+    },
+  };
+}
+
 export function createCarrierResultReminderRouter(deps: {
   readonly streamRegister: (handler: (event: CarrierJobStreamEvent) => void) => () => void;
   readonly resolveSink: (event: CarrierJobStreamEvent) => PtyWriteSink | undefined;
   readonly resolvePolicy?: (event: CarrierJobStreamEvent) => CliMessagePolicy;
   readonly resolveSessionKey?: (event: CarrierJobStreamEvent) => string | undefined;
+  // rename 주입 등 다른 지연 경로와 세션 단위로 함께 직렬화하려면 host가 공유 writer를 주입한다.
+  readonly writer?: DelayedPtyWriter;
   readonly platform?: NodeJS.Platform;
 }): () => void {
-  // 세션별 지연 제출 직렬화 tail. Windows 지연 경로에서 같은 세션으로 두 리마인더가 250ms
-  // 지연 창 안에 도착하면 텍스트가 뒤섞이고(textA textB) CR이 결합/공백 제출되므로, 이전
-  // 제출의 종결자(CR)까지 flush된 뒤 다음 리마인더의 첫 write가 시작되도록 체인한다.
-  const submitTails = new Map<string, Promise<void>>();
+  const writer = deps.writer ?? createDelayedPtyWriter();
 
   return deps.streamRegister((event) => {
     if (event.type !== "job:finalized") return;
@@ -43,23 +74,7 @@ export function createCarrierResultReminderRouter(deps: {
     // host가 활성 프로파일의 messagePolicy를 제공하면 그대로 적용한다. 미제공 시 기본 정책.
     const policy = deps.resolvePolicy?.(event) ?? {};
     const chunks = formatCarrierResultReminderMessage(policy, reminder, deps.platform);
-    const write = (data: string) => sink.write(data);
-
-    // 지연 청크(Windows conpty 경로)만 직렬화한다. 동기 단일 write 경로는 즉시 flush되어
-    // 인터리브가 불가능하므로, 세션 키가 있어도 기존 동기 동작을 그대로 유지한다.
-    const key = deps.resolveSessionKey?.(event);
-    const hasDelay = chunks.some((chunk) => chunk.submitDelayMs !== undefined);
-    if (!hasDelay || key === undefined) {
-      void writeChunksWithDelay(write, chunks);
-      return;
-    }
-
-    const prev = submitTails.get(key) ?? Promise.resolve();
-    const tail = prev.then(() => writeChunksWithDelay(write, chunks)).catch(() => {});
-    submitTails.set(key, tail);
-    void tail.then(() => {
-      if (submitTails.get(key) === tail) submitTails.delete(key);
-    });
+    writer.enqueue(deps.resolveSessionKey?.(event), (data) => sink.write(data), chunks);
   });
 }
 

--- a/packages/fleet-admiral/src/agent-runtime/reminder-router.ts
+++ b/packages/fleet-admiral/src/agent-runtime/reminder-router.ts
@@ -1,12 +1,13 @@
 import type { CarrierJobStreamEvent } from "@dotobokuri/fleet-carriers";
 
-import type { CliMessagePolicy } from "../agent-cli/types.js";
+import type { CliMessagePolicy, PtyInputChunk } from "../agent-cli/types.js";
 
 export interface PtyWriteSink {
   write(data: string): void;
 }
 
 const DEFAULT_BRACKETED_PASTE = false;
+const DEFAULT_CONPTY_PASTE_BURST = false;
 const DEFAULT_LINE_TERMINATOR = "\r";
 const DEFAULT_MULTILINE_STRATEGY = "literal";
 const BRACKETED_PASTE_START = "\x1b[200~";
@@ -14,11 +15,14 @@ const BRACKETED_PASTE_END = "\x1b[201~";
 const C1_BRACKETED_PASTE_END = "\x9B201~";
 const CONTROL_CHARS_EXCEPT_INPUT_WHITESPACE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F\x80-\x9F]/g;
 const LINE_BREAK_PATTERN = /[\r\n]/;
+// Windows crossterm reads INPUT_RECORD rather than bracketed paste, then Codex suppresses Enter during its paste burst window.
+const WINDOWS_CONPTY_SUBMIT_DELAY_MS = 250;
 
 export function createCarrierResultReminderRouter(deps: {
   readonly streamRegister: (handler: (event: CarrierJobStreamEvent) => void) => () => void;
   readonly resolveSink: (event: CarrierJobStreamEvent) => PtyWriteSink | undefined;
   readonly resolvePolicy?: (event: CarrierJobStreamEvent) => CliMessagePolicy;
+  readonly platform?: NodeJS.Platform;
 }): () => void {
   return deps.streamRegister((event) => {
     if (event.type !== "job:finalized") return;
@@ -32,9 +36,7 @@ export function createCarrierResultReminderRouter(deps: {
 
     // host가 활성 프로파일의 messagePolicy를 제공하면 그대로 적용한다. 미제공 시 기본 정책.
     const policy = deps.resolvePolicy?.(event) ?? {};
-    for (const chunk of formatCarrierResultReminderMessage(policy, reminder)) {
-      sink.write(chunk);
-    }
+    writeChunksWithDelay((data) => sink.write(data), formatCarrierResultReminderMessage(policy, reminder, deps.platform));
   });
 }
 
@@ -50,26 +52,64 @@ export function sanitizeCarrierResultReminder(text: string): string {
 export function formatCarrierResultReminderMessage(
   policy: CliMessagePolicy,
   text: string,
-): string[] {
+  platform: NodeJS.Platform = process.platform,
+): PtyInputChunk[] {
   const resolvedPolicy = resolveMessagePolicy(policy);
-  return [applyMessagePolicy(text, resolvedPolicy)];
+  return applyMessagePolicy(text, resolvedPolicy, platform);
 }
 
 function resolveMessagePolicy(policy: CliMessagePolicy): Required<CliMessagePolicy> {
   return {
     bracketedPaste: policy.bracketedPaste ?? DEFAULT_BRACKETED_PASTE,
+    conptyPasteBurst: policy.conptyPasteBurst ?? DEFAULT_CONPTY_PASTE_BURST,
     lineTerminator: policy.lineTerminator ?? DEFAULT_LINE_TERMINATOR,
     multilineStrategy: policy.multilineStrategy ?? DEFAULT_MULTILINE_STRATEGY,
   };
 }
 
-function applyMessagePolicy(text: string, policy: Required<CliMessagePolicy>): string {
+function applyMessagePolicy(
+  text: string,
+  policy: Required<CliMessagePolicy>,
+  platform: NodeJS.Platform,
+): PtyInputChunk[] {
   const usePasteMode = policy.bracketedPaste || (policy.multilineStrategy === "paste-mode" && LINE_BREAK_PATTERN.test(text));
-  const body = usePasteMode ? `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}` : text;
 
-  // paste 블록과 제출 종결자(CR)를 반드시 하나의 PTY write로 내보낸다. 둘을 별도 write로
-  // 쪼개면 Windows ConPTY의 Codex TUI가 뒤따르는 CR을 Enter로 인식하지 못해, 붙여넣은
-  // 리마인더가 프롬프트에 남고 제출되지 않는다. 단일 원자적 write는 하나의 입력 레코드로
-  // 전달되어 안정적으로 제출되며, macOS/유닉스 PTY 동작에는 영향이 없다.
-  return `${body}${policy.lineTerminator}`;
+  if (policy.conptyPasteBurst && platform === "win32" && usePasteMode) {
+    return [
+      { data: text },
+      { data: policy.lineTerminator, submitDelayMs: WINDOWS_CONPTY_SUBMIT_DELAY_MS },
+    ];
+  }
+
+  return [{
+    data: usePasteMode
+      ? `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}${policy.lineTerminator}`
+      : `${text}${policy.lineTerminator}`,
+  }];
+}
+
+function writeChunksWithDelay(write: (data: string) => void, chunks: readonly PtyInputChunk[]): void {
+  let index = 0;
+
+  const writeNext = (): void => {
+    const chunk = chunks[index++];
+    if (!chunk) return;
+
+    const commit = () => {
+      try {
+        write(chunk.data);
+      } catch {
+        // Sessions may close before a deferred submit reaches the host PTY.
+      }
+      writeNext();
+    };
+
+    if (chunk.submitDelayMs === undefined) {
+      commit();
+    } else {
+      setTimeout(commit, chunk.submitDelayMs);
+    }
+  };
+
+  writeNext();
 }

--- a/packages/fleet-admiral/src/index.ts
+++ b/packages/fleet-admiral/src/index.ts
@@ -20,6 +20,7 @@ export {
   type CodexCommandResult,
   type CodexPluginRegistrationCommand,
   type FleetHookExec,
+  type PtyInputChunk,
 } from "./agent-cli/types.js";
 
 // Agent CLI 프로파일/레지스트리 해석기

--- a/packages/fleet-admiral/src/index.ts
+++ b/packages/fleet-admiral/src/index.ts
@@ -60,7 +60,9 @@ export {
 // Carrier result reminder 주입 종단
 export {
   createCarrierResultReminderRouter,
+  createDelayedPtyWriter,
   formatCarrierResultReminderMessage,
   sanitizeCarrierResultReminder,
+  type DelayedPtyWriter,
   type PtyWriteSink,
 } from "./agent-runtime/reminder-router.js";

--- a/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 
 import * as Admiral from "../src/index.js";
+import { buildHostShellCommand, escapeTomlBasicString } from "../src/agent-cli/builders/toml.js";
 import { injectAgentCliProfile } from "../src/agent-cli/injection.js";
 import { createAgentCliPlugin } from "../src/agent-cli/plugin/index.js";
 import type { AgentCliProfile, FleetHookExec } from "../src/agent-cli/types.js";
@@ -93,8 +94,12 @@ describe("agent CLI session resume and capture hooks", () => {
       cwd: root,
       env: { CODEX_HOME: codexHome, HOME: root },
     });
+    const captureSessionHookExec = hookExec("node", ["console.js", "hook", "capture-session", "codex"]);
+    const expectedCaptureCommand = escapeTomlBasicString(
+      buildHostShellCommand([captureSessionHookExec.command, ...captureSessionHookExec.args]),
+    );
     const injected = await injectAgentCliProfile(profile, baseInjectOptions(root, {
-      captureSessionHookExec: hookExec("node", ["console.js", "hook", "capture-session", "codex"]),
+      captureSessionHookExec,
       resumeSessionId: "codex-session-456",
     }));
     const profileName = injected.args[injected.args.indexOf("--profile") + 1];
@@ -111,7 +116,7 @@ describe("agent CLI session resume and capture hooks", () => {
     expect(injected.args).not.toContain("--dangerously-bypass-hook-trust");
     expect(toml).toContain("[features]\nhooks = true");
     expect(toml).toContain("[hooks]\n");
-    expect(toml).toContain('UserPromptSubmit = [{ hooks = [{ type = "command", command = "\'node\' \'console.js\' \'hook\' \'capture-session\' \'codex\'" }] }]');
+    expect(toml).toContain(`UserPromptSubmit = [{ hooks = [{ type = "command", command = "${expectedCaptureCommand}" }] }]`);
     expect(toml).not.toContain("args =");
   });
 
@@ -188,6 +193,9 @@ describe("agent CLI session resume and capture hooks", () => {
       env: { CODEX_HOME: codexHome, HOME: root },
     });
     const captureSessionHookExec = hookExec("/opt/fleet node", ["console path.js", "hook", "capture-session", "codex"]);
+    const expectedCaptureCommand = escapeTomlBasicString(
+      buildHostShellCommand([captureSessionHookExec.command, ...captureSessionHookExec.args]),
+    );
     const injected = await injectAgentCliProfile(profile, baseInjectOptions(root, {
       captureSessionHookExec,
     }));
@@ -202,7 +210,7 @@ describe("agent CLI session resume and capture hooks", () => {
     expect(injected.args).not.toContain("--dangerously-bypass-hook-trust");
     expect(toml).toContain("[features]\nhooks = true");
     expect(toml).toContain("[hooks]\n");
-    expect(toml).toContain('UserPromptSubmit = [{ hooks = [{ type = "command", command = "\'/opt/fleet node\' \'console path.js\' \'hook\' \'capture-session\' \'codex\'" }] }]');
+    expect(toml).toContain(`UserPromptSubmit = [{ hooks = [{ type = "command", command = "${expectedCaptureCommand}" }] }]`);
     expect(toml).not.toContain("args =");
     expect(pluginJson.hooks).toBeUndefined();
     expect(pluginJson.version).toMatch(/^0\.0\.0\+[0-9a-f]{12}$/);

--- a/packages/fleet-admiral/tests/reminder-router.test.ts
+++ b/packages/fleet-admiral/tests/reminder-router.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { CarrierJobStreamEvent } from "@dotobokuri/fleet-carriers";
 
@@ -101,14 +101,51 @@ describe("carrier result reminder router", () => {
     expect(sanitizeCarrierResultReminder(`a\x1b[201~b\x9B201~c`)).toBe("abc");
   });
 
-  it("folds the submit terminator into a single atomic paste chunk", () => {
-    expect(formatCarrierResultReminderMessage({ bracketedPaste: true, lineTerminator: "\n" }, "hello")).toEqual([
-      "\x1b[200~hello\x1b[201~\n",
+  it("returns formatter chunks in write order", () => {
+    expect(formatCarrierResultReminderMessage({ bracketedPaste: true, lineTerminator: "\n" }, "hello", "darwin")).toEqual([
+      { data: "\x1b[200~hello\x1b[201~\n" },
     ]);
-    expect(formatCarrierResultReminderMessage({ multilineStrategy: "paste-mode" }, "a\nb")).toEqual([
-      "\x1b[200~a\nb\x1b[201~\r",
+    expect(formatCarrierResultReminderMessage({ multilineStrategy: "paste-mode" }, "a\nb", "darwin")).toEqual([
+      { data: "\x1b[200~a\nb\x1b[201~\r" },
     ]);
-    expect(formatCarrierResultReminderMessage({ lineTerminator: "\n" }, "hello")).toEqual(["hello\n"]);
+    expect(formatCarrierResultReminderMessage({ lineTerminator: "\n" }, "hello", "darwin")).toEqual([{ data: "hello\n" }]);
+  });
+
+  it("uses a delayed bare submit for ConPTY paste bursts on Windows", () => {
+    const policy = { bracketedPaste: true, conptyPasteBurst: true, lineTerminator: "\r", multilineStrategy: "paste-mode" as const };
+    const text = "line 1\nline 2";
+
+    expect(formatCarrierResultReminderMessage(policy, text, "win32")).toEqual([
+      { data: text },
+      { data: "\r", submitDelayMs: 250 },
+    ]);
+  });
+
+  it("writes the ConPTY submit after its delay without blocking finalized events", () => {
+    vi.useFakeTimers();
+    try {
+      const writes: string[] = [];
+      const handlers: Array<(event: CarrierJobStreamEvent) => void> = [];
+      createCarrierResultReminderRouter({
+        platform: "win32",
+        streamRegister(handler) {
+          handlers.push(handler);
+          return () => undefined;
+        },
+        resolveSink: () => createArraySink(writes),
+        resolvePolicy: () => ({ bracketedPaste: true, conptyPasteBurst: true, lineTerminator: "\r", multilineStrategy: "paste-mode" }),
+      });
+
+      handlers[0]?.(finalizedEvent("line 1\nline 2"));
+
+      expect(writes).toEqual(["line 1\nline 2"]);
+      vi.advanceTimersByTime(249);
+      expect(writes).toEqual(["line 1\nline 2"]);
+      vi.advanceTimersByTime(1);
+      expect(writes).toEqual(["line 1\nline 2", "\r"]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("quietly drops when no sink resolves", () => {

--- a/packages/fleet-admiral/tests/reminder-router.test.ts
+++ b/packages/fleet-admiral/tests/reminder-router.test.ts
@@ -4,8 +4,10 @@ import type { CarrierJobStreamEvent } from "@dotobokuri/fleet-carriers";
 
 import {
   createCarrierResultReminderRouter,
+  createDelayedPtyWriter,
   formatCarrierResultReminderMessage,
   sanitizeCarrierResultReminder,
+  type PtyInputChunk,
   type PtyWriteSink,
 } from "../src/index.js";
 
@@ -178,6 +180,47 @@ describe("carrier result reminder router", () => {
 
       await vi.advanceTimersByTimeAsync(250);
       expect(writes).toEqual(["A", "\r", "B", "\r"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shares one delayed writer so reminder and rename on the same session serialize", async () => {
+    vi.useFakeTimers();
+    try {
+      const writes: string[] = [];
+      const writer = createDelayedPtyWriter();
+      const delayed = (text: string): PtyInputChunk[] => [{ data: text }, { data: "\r", submitDelayMs: 250 }];
+
+      // 서로 다른 소스(리마인더/rename)라도 같은 세션 키를 공유하면 순차 제출된다.
+      writer.enqueue("session-1", (data) => writes.push(data), delayed("reminder"));
+      writer.enqueue("session-1", (data) => writes.push(data), delayed("/rename X"));
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(writes).toEqual(["reminder"]);
+      await vi.advanceTimersByTimeAsync(250);
+      expect(writes).toEqual(["reminder", "\r", "/rename X"]);
+      await vi.advanceTimersByTimeAsync(250);
+      expect(writes).toEqual(["reminder", "\r", "/rename X", "\r"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not serialize delayed submits across different session keys", async () => {
+    vi.useFakeTimers();
+    try {
+      const writes: string[] = [];
+      const writer = createDelayedPtyWriter();
+      const delayed = (text: string): PtyInputChunk[] => [{ data: text }, { data: "\r", submitDelayMs: 250 }];
+
+      writer.enqueue("a", (data) => writes.push(data), delayed("A"));
+      writer.enqueue("b", (data) => writes.push(data), delayed("B"));
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(writes).toEqual(["A", "B"]);
+      await vi.advanceTimersByTimeAsync(250);
+      expect(writes).toEqual(["A", "B", "\r", "\r"]);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/fleet-admiral/tests/reminder-router.test.ts
+++ b/packages/fleet-admiral/tests/reminder-router.test.ts
@@ -50,7 +50,7 @@ describe("carrier result reminder router", () => {
 
     handlers[0]?.(finalizedEvent("done"));
 
-    expect(writes).toEqual(["\x1b[200~done\x1b[201~", "\r"]);
+    expect(writes).toEqual(["\x1b[200~done\x1b[201~\r"]);
   });
 
   it("ignores finalized events without a string systemReminder", () => {
@@ -101,14 +101,12 @@ describe("carrier result reminder router", () => {
     expect(sanitizeCarrierResultReminder(`a\x1b[201~b\x9B201~c`)).toBe("abc");
   });
 
-  it("returns formatter chunks in write order", () => {
+  it("folds the submit terminator into a single atomic paste chunk", () => {
     expect(formatCarrierResultReminderMessage({ bracketedPaste: true, lineTerminator: "\n" }, "hello")).toEqual([
-      "\x1b[200~hello\x1b[201~",
-      "\n",
+      "\x1b[200~hello\x1b[201~\n",
     ]);
     expect(formatCarrierResultReminderMessage({ multilineStrategy: "paste-mode" }, "a\nb")).toEqual([
-      "\x1b[200~a\nb\x1b[201~",
-      "\r",
+      "\x1b[200~a\nb\x1b[201~\r",
     ]);
     expect(formatCarrierResultReminderMessage({ lineTerminator: "\n" }, "hello")).toEqual(["hello\n"]);
   });

--- a/packages/fleet-admiral/tests/reminder-router.test.ts
+++ b/packages/fleet-admiral/tests/reminder-router.test.ts
@@ -148,6 +148,41 @@ describe("carrier result reminder router", () => {
     }
   });
 
+  it("serializes delayed ConPTY submits per session so concurrent reminders do not interleave", async () => {
+    vi.useFakeTimers();
+    try {
+      const writes: string[] = [];
+      const handlers: Array<(event: CarrierJobStreamEvent) => void> = [];
+      createCarrierResultReminderRouter({
+        platform: "win32",
+        streamRegister(handler) {
+          handlers.push(handler);
+          return () => undefined;
+        },
+        resolveSink: () => createArraySink(writes),
+        resolvePolicy: () => ({ bracketedPaste: true, conptyPasteBurst: true, lineTerminator: "\r", multilineStrategy: "paste-mode" }),
+        resolveSessionKey: () => "session-1",
+      });
+
+      // 같은 세션으로 두 리마인더가 지연 창 안에 연달아 도착.
+      handlers[0]?.(finalizedEvent("A"));
+      handlers[0]?.(finalizedEvent("B"));
+
+      // A의 텍스트만 먼저 기록되고, B는 A의 제출(CR)이 끝날 때까지 대기한다.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(writes).toEqual(["A"]);
+
+      // A의 CR이 flush된 뒤에야 B의 텍스트가 이어진다(인터리브 방지).
+      await vi.advanceTimersByTimeAsync(250);
+      expect(writes).toEqual(["A", "\r", "B"]);
+
+      await vi.advanceTimersByTimeAsync(250);
+      expect(writes).toEqual(["A", "\r", "B", "\r"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("quietly drops when no sink resolves", () => {
     const handlers: Array<(event: CarrierJobStreamEvent) => void> = [];
     createCarrierResultReminderRouter({

--- a/runtime/fleet-cli/src/app.ts
+++ b/runtime/fleet-cli/src/app.ts
@@ -161,6 +161,8 @@ export async function runApp(options: RunAppOptions = {}): Promise<void> {
       };
     },
     resolvePolicy: () => missionControl.getActiveProfile()?.messagePolicy ?? {},
+    // 활성 child는 단일하므로 상수 키로 지연 제출을 직렬화한다(동시 도착 리마인더 뒤섞임 방지).
+    resolveSessionKey: () => (missionControl.getActiveProfile() === undefined ? undefined : "cli-active-child"),
   });
   ptyManager = createTuiPtyManager({
     fleetPty: missionBridge.ptyApi,

--- a/runtime/fleet-cli/src/controls/input/programmatic.ts
+++ b/runtime/fleet-cli/src/controls/input/programmatic.ts
@@ -1,3 +1,5 @@
+import type { PtyInputChunk } from "@dotobokuri/fleet-admiral";
+
 import type { PtyHost } from "../types.js";
 
 export interface ProgrammaticInputProfile {
@@ -6,6 +8,7 @@ export interface ProgrammaticInputProfile {
 
 export interface CliMessagePolicy {
   readonly bracketedPaste?: boolean;
+  readonly conptyPasteBurst?: boolean;
   readonly lineTerminator?: string;
   readonly multilineStrategy?: "literal" | "paste-mode";
 }
@@ -15,6 +18,7 @@ export interface ProgrammaticInput {
     text: string,
     opts?: {
       readonly bracketedPaste?: boolean;
+      readonly conptyPasteBurst?: boolean;
       readonly lineTerminator?: string;
       readonly multilineStrategy?: "literal" | "paste-mode";
     },
@@ -24,17 +28,23 @@ export interface ProgrammaticInput {
 }
 
 const DEFAULT_BRACKETED_PASTE = false;
+const DEFAULT_CONPTY_PASTE_BURST = false;
 const DEFAULT_LINE_TERMINATOR = "\r";
 const DEFAULT_MULTILINE_STRATEGY = "literal";
 const BRACKETED_PASTE_START = "\x1b[200~";
 const BRACKETED_PASTE_END = "\x1b[201~";
 const LINE_BREAK_PATTERN = /[\r\n]/;
+// Windows crossterm reads INPUT_RECORD rather than bracketed paste, then Codex suppresses Enter during its paste burst window.
+const WINDOWS_CONPTY_SUBMIT_DELAY_MS = 250;
 
-export function createProgrammaticInput(ptyHost: PtyHost, profile: ProgrammaticInputProfile): ProgrammaticInput {
+export function createProgrammaticInput(
+  ptyHost: PtyHost,
+  profile: ProgrammaticInputProfile,
+  platform: NodeJS.Platform = process.platform,
+): ProgrammaticInput {
   return {
     sendMessage(text, opts) {
-      const policy = resolvePolicy(profile, opts);
-      ptyHost.write(applyMessagePolicy(text, policy));
+      writeChunksWithDelay((data) => ptyHost.write(data), formatProgrammaticInputMessage(resolvePolicy(profile, opts), text, platform));
     },
 
     sendKeys(data) {
@@ -43,8 +53,7 @@ export function createProgrammaticInput(ptyHost: PtyHost, profile: ProgrammaticI
 
     sendCommand(line) {
       assertSingleLineCommand(line);
-      const policy = resolvePolicy(profile);
-      ptyHost.write(applyMessagePolicy(line, policy));
+      writeChunksWithDelay((data) => ptyHost.write(data), formatProgrammaticInputMessage(resolvePolicy(profile), line, platform));
     },
   };
 }
@@ -53,26 +62,72 @@ function resolvePolicy(
   profile: ProgrammaticInputProfile,
   opts: {
     readonly bracketedPaste?: boolean;
+    readonly conptyPasteBurst?: boolean;
     readonly lineTerminator?: string;
     readonly multilineStrategy?: "literal" | "paste-mode";
   } = {},
 ): Required<CliMessagePolicy> {
   return {
     bracketedPaste: opts.bracketedPaste ?? profile.messagePolicy?.bracketedPaste ?? DEFAULT_BRACKETED_PASTE,
+    conptyPasteBurst: opts.conptyPasteBurst ?? profile.messagePolicy?.conptyPasteBurst ?? DEFAULT_CONPTY_PASTE_BURST,
     lineTerminator: opts.lineTerminator ?? profile.messagePolicy?.lineTerminator ?? DEFAULT_LINE_TERMINATOR,
     multilineStrategy: opts.multilineStrategy ?? profile.messagePolicy?.multilineStrategy ?? DEFAULT_MULTILINE_STRATEGY,
   };
 }
 
-function applyMessagePolicy(text: string, policy: Required<CliMessagePolicy>): string {
-  const usePasteMode = policy.bracketedPaste || (policy.multilineStrategy === "paste-mode" && LINE_BREAK_PATTERN.test(text));
-  const body = usePasteMode ? `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}` : text;
+export function formatProgrammaticInputMessage(
+  policy: Required<CliMessagePolicy>,
+  text: string,
+  platform: NodeJS.Platform = process.platform,
+): PtyInputChunk[] {
+  return applyMessagePolicy(text, policy, platform);
+}
 
-  // paste 블록과 제출 종결자(CR)를 반드시 하나의 PTY write로 내보낸다. 둘을 별도 write로
-  // 쪼개면 Windows ConPTY의 Codex TUI가 뒤따르는 CR을 Enter로 인식하지 못해, 붙여넣은
-  // 텍스트가 프롬프트에 남고 제출되지 않는다. 단일 원자적 write는 하나의 입력 레코드로
-  // 전달되어 안정적으로 제출되며, macOS/유닉스 PTY 동작에는 영향이 없다.
-  return `${body}${policy.lineTerminator}`;
+function applyMessagePolicy(
+  text: string,
+  policy: Required<CliMessagePolicy>,
+  platform: NodeJS.Platform,
+): PtyInputChunk[] {
+  const usePasteMode = policy.bracketedPaste || (policy.multilineStrategy === "paste-mode" && LINE_BREAK_PATTERN.test(text));
+
+  if (policy.conptyPasteBurst && platform === "win32" && usePasteMode) {
+    return [
+      { data: text },
+      { data: policy.lineTerminator, submitDelayMs: WINDOWS_CONPTY_SUBMIT_DELAY_MS },
+    ];
+  }
+
+  return [{
+    data: usePasteMode
+      ? `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}${policy.lineTerminator}`
+      : `${text}${policy.lineTerminator}`,
+  }];
+}
+
+function writeChunksWithDelay(write: (data: string) => void, chunks: readonly PtyInputChunk[]): void {
+  let index = 0;
+
+  const writeNext = (): void => {
+    const chunk = chunks[index++];
+    if (!chunk) return;
+
+    const commit = () => {
+      try {
+        write(chunk.data);
+      } catch {
+        // Sessions may close before a deferred submit reaches the host PTY.
+      }
+      writeNext();
+    };
+
+    if (chunk.submitDelayMs === undefined) {
+      commit();
+    } else {
+      setTimeout(commit, chunk.submitDelayMs);
+    }
+  };
+
+  writeNext();
 }
 
 function assertSingleLineCommand(line: string): void {

--- a/runtime/fleet-cli/src/controls/input/programmatic.ts
+++ b/runtime/fleet-cli/src/controls/input/programmatic.ts
@@ -23,11 +23,6 @@ export interface ProgrammaticInput {
   readonly sendCommand: (line: string) => void;
 }
 
-interface AppliedMessagePolicy {
-  readonly payload: string;
-  readonly submit?: string;
-}
-
 const DEFAULT_BRACKETED_PASTE = false;
 const DEFAULT_LINE_TERMINATOR = "\r";
 const DEFAULT_MULTILINE_STRATEGY = "literal";
@@ -39,8 +34,7 @@ export function createProgrammaticInput(ptyHost: PtyHost, profile: ProgrammaticI
   return {
     sendMessage(text, opts) {
       const policy = resolvePolicy(profile, opts);
-      const appliedPolicy = applyMessagePolicy(text, policy);
-      writeAppliedMessagePolicy(ptyHost, appliedPolicy);
+      ptyHost.write(applyMessagePolicy(text, policy));
     },
 
     sendKeys(data) {
@@ -50,8 +44,7 @@ export function createProgrammaticInput(ptyHost: PtyHost, profile: ProgrammaticI
     sendCommand(line) {
       assertSingleLineCommand(line);
       const policy = resolvePolicy(profile);
-      const appliedPolicy = applyMessagePolicy(line, policy);
-      writeAppliedMessagePolicy(ptyHost, appliedPolicy);
+      ptyHost.write(applyMessagePolicy(line, policy));
     },
   };
 }
@@ -71,28 +64,15 @@ function resolvePolicy(
   };
 }
 
-function applyMessagePolicy(
-  text: string,
-  policy: Required<CliMessagePolicy>,
-): AppliedMessagePolicy {
+function applyMessagePolicy(text: string, policy: Required<CliMessagePolicy>): string {
   const usePasteMode = policy.bracketedPaste || (policy.multilineStrategy === "paste-mode" && LINE_BREAK_PATTERN.test(text));
+  const body = usePasteMode ? `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}` : text;
 
-  if (!usePasteMode) {
-    return { payload: `${text}${policy.lineTerminator}` };
-  }
-
-  return {
-    payload: `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}`,
-    submit: policy.lineTerminator,
-  };
-}
-
-function writeAppliedMessagePolicy(ptyHost: PtyHost, appliedPolicy: AppliedMessagePolicy): void {
-  ptyHost.write(appliedPolicy.payload);
-
-  if (appliedPolicy.submit !== undefined && appliedPolicy.submit.length > 0) {
-    ptyHost.write(appliedPolicy.submit);
-  }
+  // paste 블록과 제출 종결자(CR)를 반드시 하나의 PTY write로 내보낸다. 둘을 별도 write로
+  // 쪼개면 Windows ConPTY의 Codex TUI가 뒤따르는 CR을 Enter로 인식하지 못해, 붙여넣은
+  // 텍스트가 프롬프트에 남고 제출되지 않는다. 단일 원자적 write는 하나의 입력 레코드로
+  // 전달되어 안정적으로 제출되며, macOS/유닉스 PTY 동작에는 영향이 없다.
+  return `${body}${policy.lineTerminator}`;
 }
 
 function assertSingleLineCommand(line: string): void {

--- a/runtime/fleet-cli/tests/agent-cli/catalog.test.ts
+++ b/runtime/fleet-cli/tests/agent-cli/catalog.test.ts
@@ -56,6 +56,18 @@ describe("agent CLI catalog", () => {
     });
   });
 
+  it("enables the Codex ConPTY paste-burst workaround", async () => {
+    const env = createEnvWithBins();
+    const codex = await resolveAgentCliProfile(env, "/tmp", { cliId: "codex" });
+
+    expect(codex.messagePolicy).toEqual({
+      bracketedPaste: true,
+      conptyPasteBurst: true,
+      lineTerminator: "\r",
+      multilineStrategy: "paste-mode",
+    });
+  });
+
   it("does not mutate process.env while creating profiles", async () => {
     const env = createEnvWithBins();
     const before = { ...process.env };

--- a/runtime/fleet-cli/tests/carrier-reminder-parity.test.ts
+++ b/runtime/fleet-cli/tests/carrier-reminder-parity.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   createCarrierResultReminderRouter,
@@ -7,9 +7,10 @@ import {
 } from "@dotobokuri/fleet-admiral";
 
 import { createProgrammaticInput, type PtyHost } from "../src/controls/index.js";
+import { formatProgrammaticInputMessage, type CliMessagePolicy as ProgrammaticCliMessagePolicy } from "../src/controls/input/programmatic.js";
 
 describe("carrier reminder encoding parity", () => {
-  it("matches legacy programmatic input chunks for bracketed paste profiles", () => {
+  it("matches programmatic input chunks for bracketed paste profiles", () => {
     const policy: CliMessagePolicy = {
       bracketedPaste: true,
       lineTerminator: "\r",
@@ -17,27 +18,60 @@ describe("carrier reminder encoding parity", () => {
     };
     const text = "<system-reminder>\n[carrier:result]\nready\n</system-reminder>";
 
-    expect(formatCarrierResultReminderMessage(policy, text)).toEqual(writeLegacyProgrammaticMessage(policy, text));
+    expect(formatCarrierResultReminderMessage(policy, text, "darwin")).toEqual(formatProgrammaticMessage(policy, text, "darwin"));
   });
 
-  it("matches legacy programmatic input chunks for paste-mode multiline profiles", () => {
+  it("matches programmatic input chunks for paste-mode multiline profiles", () => {
     const policy: CliMessagePolicy = {
       lineTerminator: "\n",
       multilineStrategy: "paste-mode",
     };
     const text = "line 1\nline 2";
 
-    expect(formatCarrierResultReminderMessage(policy, text)).toEqual(writeLegacyProgrammaticMessage(policy, text));
+    expect(formatCarrierResultReminderMessage(policy, text, "darwin")).toEqual(formatProgrammaticMessage(policy, text, "darwin"));
   });
 
-  it("matches legacy programmatic input chunks for literal single-line profiles", () => {
+  it("matches programmatic input chunks for literal single-line profiles", () => {
     const policy: CliMessagePolicy = {
       lineTerminator: "\r",
       multilineStrategy: "literal",
     };
     const text = "single line";
 
-    expect(formatCarrierResultReminderMessage(policy, text)).toEqual(writeLegacyProgrammaticMessage(policy, text));
+    expect(formatCarrierResultReminderMessage(policy, text, "darwin")).toEqual(formatProgrammaticMessage(policy, text, "darwin"));
+  });
+
+  it("matches Windows ConPTY paste-burst chunks", () => {
+    const policy: CliMessagePolicy = {
+      bracketedPaste: true,
+      conptyPasteBurst: true,
+      lineTerminator: "\r",
+      multilineStrategy: "paste-mode",
+    };
+    const text = "line 1\nline 2";
+
+    expect(formatCarrierResultReminderMessage(policy, text, "win32")).toEqual(formatProgrammaticMessage(policy, text, "win32"));
+  });
+
+  it("delays programmatic Windows ConPTY submission", () => {
+    vi.useFakeTimers();
+    try {
+      const writes: string[] = [];
+      const policy: CliMessagePolicy = {
+        bracketedPaste: true,
+        conptyPasteBurst: true,
+        lineTerminator: "\r",
+        multilineStrategy: "paste-mode",
+      };
+
+      createProgrammaticInput(createWriteOnlyPtyHost(writes), { messagePolicy: policy }, "win32").sendMessage("line 1\nline 2");
+
+      expect(writes).toEqual(["line 1\nline 2"]);
+      vi.advanceTimersByTime(250);
+      expect(writes).toEqual(["line 1\nline 2", "\r"]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("writes encoded chunks through the two-pane sink", () => {
@@ -55,7 +89,7 @@ describe("carrier reminder encoding parity", () => {
       systemReminder: "alpha\nbeta",
       type: "job:finalized" as const,
     };
-    const expected = writeLegacyProgrammaticMessage(policy, event.systemReminder);
+    const expected = writeProgrammaticMessage(policy, event.systemReminder);
 
     const disposeTwoPane = createCarrierResultReminderRouter({
       streamRegister(handler) {
@@ -72,10 +106,23 @@ describe("carrier reminder encoding parity", () => {
   });
 });
 
-function writeLegacyProgrammaticMessage(policy: CliMessagePolicy, text: string): string[] {
+function formatProgrammaticMessage(policy: CliMessagePolicy, text: string, platform: NodeJS.Platform) {
+  return formatProgrammaticInputMessage(resolveProgrammaticPolicy(policy), text, platform);
+}
+
+function writeProgrammaticMessage(policy: CliMessagePolicy, text: string): string[] {
   const writes: string[] = [];
   createProgrammaticInput(createWriteOnlyPtyHost(writes), { messagePolicy: policy }).sendMessage(text);
   return writes;
+}
+
+function resolveProgrammaticPolicy(policy: CliMessagePolicy): Required<ProgrammaticCliMessagePolicy> {
+  return {
+    bracketedPaste: policy.bracketedPaste ?? false,
+    conptyPasteBurst: policy.conptyPasteBurst ?? false,
+    lineTerminator: policy.lineTerminator ?? "\r",
+    multilineStrategy: policy.multilineStrategy ?? "literal",
+  };
 }
 
 function createWriteOnlyPtyHost(writes: string[]): PtyHost {

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -690,7 +690,7 @@ describe("console static and terminal ticket boundary", () => {
     runtime.emit({ type: "job:finalized", jobId: "missing-origin", status: "done", finishedAt: 1, summary: "missing", systemReminder: "drop me" });
     runtime.emit({ type: "job:finalized", jobId: "job-a", status: "done", finishedAt: 2, summary: "done", systemReminder: "line 1\nline 2\x1b[201~\x07" });
 
-    expect(ptys.get(first.sessionId)?.writes).toEqual(["\x1b[200~line 1\nline 2\x1b[201~", "\r"]);
+    expect(ptys.get(first.sessionId)?.writes).toEqual(["\x1b[200~line 1\nline 2\x1b[201~\r"]);
     expect(ptys.get(second.sessionId)?.writes).toEqual([]);
 
     runtime.emit({ type: "track:text", jobId: "job-b", originSessionId: second.sessionId, trackId: "t1", text: "progress" });
@@ -700,7 +700,7 @@ describe("console static and terminal ticket boundary", () => {
 
     expect(deleted.status).toBe(200);
     expect(ptys.get(second.sessionId)?.writes).toEqual([]);
-    expect(ptys.get(first.sessionId)?.writes).toEqual(["\x1b[200~line 1\nline 2\x1b[201~", "\r"]);
+    expect(ptys.get(first.sessionId)?.writes).toEqual(["\x1b[200~line 1\nline 2\x1b[201~\r"]);
   });
 
   it.skip("keeps carrier reminder payloads out of browser snapshots and SSE frames", async () => {

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import path from "node:path";
 import process from "node:process";
 
-import { createCarrierResultReminderRouter, createFleetAgentRuntimeLifecycle, formatCarrierResultReminderMessage, getAgentCliMetadata, parseAgentCliId, sanitizeCarrierResultReminder, type AgentCliId } from "@dotobokuri/fleet-admiral";
+import { createCarrierResultReminderRouter, createFleetAgentRuntimeLifecycle, formatCarrierResultReminderMessage, getAgentCliMetadata, parseAgentCliId, sanitizeCarrierResultReminder, type AgentCliId, type PtyInputChunk } from "@dotobokuri/fleet-admiral";
 import { getCarrierConfig, resolveAgentCliType } from "@dotobokuri/fleet-carriers";
 import type { GlobalOptionsService } from "@dotobokuri/core-infra";
 import { getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
@@ -480,9 +480,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     const safeLabel = sanitizeCarrierResultReminder(label.replace(/[\r\n\t]+/g, " ")).trim();
     if (safeLabel.length === 0) return;
     const policy = terminalRuntime.getMessagePolicy(sessionId) ?? {};
-    for (const chunk of formatCarrierResultReminderMessage(policy, `${renameCommand} ${safeLabel}`)) {
-      terminalRuntime.write(sessionId, chunk);
-    }
+    writeChunksWithDelay((data) => terminalRuntime.write(sessionId, data), formatCarrierResultReminderMessage(policy, `${renameCommand} ${safeLabel}`));
   }
 
   function injectOperation(operation: OperationNode): AgentTerminalSessionInfo {
@@ -591,6 +589,32 @@ function resolveCarrierEventOrigin(event: { readonly jobId: string; readonly typ
   const knownOrigin = jobOriginById.get(event.jobId);
   if (event.type === "job:finalized") queueMicrotask(() => jobOriginById.delete(event.jobId));
   return knownOrigin ?? null;
+}
+
+function writeChunksWithDelay(write: (data: string) => void, chunks: readonly PtyInputChunk[]): void {
+  let index = 0;
+
+  const writeNext = (): void => {
+    const chunk = chunks[index++];
+    if (!chunk) return;
+
+    const commit = () => {
+      try {
+        write(chunk.data);
+      } catch {
+        // Sessions may close before a deferred submit reaches the host PTY.
+      }
+      writeNext();
+    };
+
+    if (chunk.submitDelayMs === undefined) {
+      commit();
+    } else {
+      setTimeout(commit, chunk.submitDelayMs);
+    }
+  };
+
+  writeNext();
 }
 
 function readPayloadString(payload: Record<string, unknown>, key: string): string {

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -104,6 +104,8 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       const sessionId = resolveCarrierEventOrigin(event as { readonly jobId: string; readonly type: string; readonly originSessionId?: string }, jobOriginById);
       return sessionId ? terminalRuntime.getMessagePolicy(sessionId) ?? {} : {};
     },
+    // 세션별 지연 제출 직렬화 키: 같은 터미널 세션으로 동시 도착한 리마인더가 뒤섞이지 않도록 한다.
+    resolveSessionKey: (event) => resolveCarrierEventOrigin(event as { readonly jobId: string; readonly type: string; readonly originSessionId?: string }, jobOriginById) ?? undefined,
   });
   const unsubscribeRename = ctx.host.events.subscribe(OPERATION_RENAMED_EVENT_CHANNEL, (payload) => {
     if (!isOperationRenamedEvent(payload)) return;

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import path from "node:path";
 import process from "node:process";
 
-import { createCarrierResultReminderRouter, createFleetAgentRuntimeLifecycle, formatCarrierResultReminderMessage, getAgentCliMetadata, parseAgentCliId, sanitizeCarrierResultReminder, type AgentCliId, type PtyInputChunk } from "@dotobokuri/fleet-admiral";
+import { createCarrierResultReminderRouter, createDelayedPtyWriter, createFleetAgentRuntimeLifecycle, formatCarrierResultReminderMessage, getAgentCliMetadata, parseAgentCliId, sanitizeCarrierResultReminder, type AgentCliId } from "@dotobokuri/fleet-admiral";
 import { getCarrierConfig, resolveAgentCliType } from "@dotobokuri/fleet-carriers";
 import type { GlobalOptionsService } from "@dotobokuri/core-infra";
 import { getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
@@ -94,8 +94,11 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     if (!sessionId) return;
     observability.appendTerminalRuntimeEvent(sessionId, withSignatureCli(event, runtime.carrierRuntime.registry));
   });
+  // carrier 리마인더와 rename 주입이 세션 단위로 함께 직렬화되도록 공유 writer를 사용한다.
+  const reminderWriter = createDelayedPtyWriter();
   const unsubscribeReminder = createCarrierResultReminderRouter({
     streamRegister: runtime.carrierRuntime.jobs.streaming.register,
+    writer: reminderWriter,
     resolveSink: (event) => {
       const sessionId = resolveCarrierEventOrigin(event as { readonly jobId: string; readonly type: string; readonly originSessionId?: string }, jobOriginById);
       return sessionId ? { write: (data) => terminalRuntime.write(sessionId, data) } : undefined;
@@ -482,7 +485,8 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     const safeLabel = sanitizeCarrierResultReminder(label.replace(/[\r\n\t]+/g, " ")).trim();
     if (safeLabel.length === 0) return;
     const policy = terminalRuntime.getMessagePolicy(sessionId) ?? {};
-    writeChunksWithDelay((data) => terminalRuntime.write(sessionId, data), formatCarrierResultReminderMessage(policy, `${renameCommand} ${safeLabel}`));
+    // 리마인더와 동일한 세션 키/writer로 직렬화해 rename+리마인더 인터리브를 막는다.
+    reminderWriter.enqueue(sessionId, (data) => terminalRuntime.write(sessionId, data), formatCarrierResultReminderMessage(policy, `${renameCommand} ${safeLabel}`));
   }
 
   function injectOperation(operation: OperationNode): AgentTerminalSessionInfo {
@@ -591,32 +595,6 @@ function resolveCarrierEventOrigin(event: { readonly jobId: string; readonly typ
   const knownOrigin = jobOriginById.get(event.jobId);
   if (event.type === "job:finalized") queueMicrotask(() => jobOriginById.delete(event.jobId));
   return knownOrigin ?? null;
-}
-
-function writeChunksWithDelay(write: (data: string) => void, chunks: readonly PtyInputChunk[]): void {
-  let index = 0;
-
-  const writeNext = (): void => {
-    const chunk = chunks[index++];
-    if (!chunk) return;
-
-    const commit = () => {
-      try {
-        write(chunk.data);
-      } catch {
-        // Sessions may close before a deferred submit reaches the host PTY.
-      }
-      writeNext();
-    };
-
-    if (chunk.submitDelayMs === undefined) {
-      commit();
-    } else {
-      setTimeout(commit, chunk.submitDelayMs);
-    }
-  };
-
-  writeNext();
 }
 
 function readPayloadString(payload: Record<string, unknown>, key: string): string {


### PR DESCRIPTION
## Summary
- Windows ConPTY에서 Codex TUI로 주입하는 carrier-result 리마인더가 프롬프트에 남고 제출되지 않던 문제를 수정합니다. Windows의 crossterm은 bracketed paste를 `Event::Paste`로 받지 못하고, Codex의 PasteBurst가 버스트 윈도우(~180ms) 안에 도착한 CR을 리터럴 개행으로 흡수해 제출을 막습니다. 따라서 Windows(win32 + `conptyPasteBurst` 정책)에서는 마커 없이 순수 텍스트를 보낸 뒤 ~250ms 지연 후 CR을 별도 write로 제출합니다. 멀티라인은 PasteBurst가 내부 개행을 흡수해 보존됩니다.
- Unix/macOS 및 비대상 CLI 경로는 바이트 단위로 무변경입니다.
- 부수적으로 Codex 훅 명령을 플랫폼-인지 `buildHostShellCommand`로 라우팅하고 session-resume 테스트를 호스트 셸 인용에 정합화합니다.

## Type of Change
- [x] fix — bug fix

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-admiral test` — reminder-router, session-resume 통과
- [x] `pnpm --filter @dotobokuri/fleet-cli` — carrier-reminder-parity + agent-cli/catalog 15/15
- [x] 전체 그래프 빌드(desktop 제외) 타입체크 통과 (EXIT=0)
- [x] Windows Codex 실장비 동작: 사용자 확인 "정상동작"

## Changelog
- [x] Added `.changelog.d/pr-263.md` — fleet-cli / fleet-plugin `Fixed` 항목, 영문+한글(ko) 병기, `compile-changelog-fragments.mjs --check` 통과.