### PR TITLE
fix(desktop): open terminal HTTP links externally

### DIFF
--- a/.changelog.d/pr-264.md
+++ b/.changelog.d/pr-264.md
@@ -1,0 +1,9 @@
+### fleet-desktop
+#### Fixed
+- [fleet-console] Open terminal HTTP and HTTPS links in the external browser while blocking non-web schemes.
+  ko: 터미널의 HTTP 및 HTTPS 링크를 외부 브라우저에서 열고 웹이 아닌 스킴은 차단합니다.
+
+### fleet-plugin
+#### Fixed
+- [fleet-console] Pass validated OSC 8 destinations in the initial browser request while preserving the navigation warning.
+  ko: 탐색 경고를 유지하면서 검증된 OSC 8 목적지를 최초 브라우저 요청에 전달합니다.

--- a/runtime/fleet-desktop/e2e/desktop-shell.spec.ts
+++ b/runtime/fleet-desktop/e2e/desktop-shell.spec.ts
@@ -59,4 +59,34 @@ test.describe("unpackaged desktop shell", () => {
       await app.close();
     }
   });
+
+  test("hands HTTP links to the external browser broker", async () => {
+    const main = process.env.FLEET_DESKTOP_E2E_MAIN;
+    const nodePath = process.env.FLEET_CONSOLE_NODE_PATH;
+    test.skip(!main || !nodePath, "FLEET_DESKTOP_E2E_MAIN and FLEET_CONSOLE_NODE_PATH are required.");
+    const app = await electron.launch({ args: [path.resolve(main)], env: { ...process.env, FLEET_CONSOLE_NODE_PATH: nodePath } });
+    try {
+      const window = await app.firstWindow();
+      await expect(window).toHaveURL(/\/console\//);
+      await app.evaluate(({ shell }) => {
+        const probe = globalThis as typeof globalThis & { __fleetOpenExternalUrls?: string[] };
+        probe.__fleetOpenExternalUrls = [];
+        shell.openExternal = async (url) => { probe.__fleetOpenExternalUrls?.push(url); };
+      });
+
+      await window.evaluate(() => {
+        window.open("http://127.0.0.1:4173/preview", "_blank");
+        window.open("https://fleet.example/docs", "_blank");
+        window.open("file:///tmp/secret", "_blank");
+      });
+
+      await expect.poll(() => app.evaluate(() => {
+        const probe = globalThis as typeof globalThis & { __fleetOpenExternalUrls?: string[] };
+        return probe.__fleetOpenExternalUrls ?? [];
+      })).toEqual(["http://127.0.0.1:4173/preview", "https://fleet.example/docs"]);
+      expect(new URL(window.url()).pathname).toMatch(/^\/console\//);
+    } finally {
+      await app.close();
+    }
+  });
 });

--- a/runtime/fleet-desktop/src/window-policy.ts
+++ b/runtime/fleet-desktop/src/window-policy.ts
@@ -46,7 +46,7 @@ export function applyWindowPolicy(contents: WebContents, originOrOpenExternal: s
     if (!consoleOrigin || (!isAllowedConsoleUrl(url, consoleOrigin) && (!pendingConsoleOrigin || !isAllowedConsoleUrl(url, pendingConsoleOrigin)))) event.preventDefault();
   });
   contents.setWindowOpenHandler(({ url }) => {
-    if (consoleOrigin && isHttpsUrl(url)) void openExternal(url);
+    if (consoleOrigin && isHttpUrl(url)) void openExternal(url);
     return { action: "deny" };
   });
   contents.session.setPermissionRequestHandler((_wc, permission, callback, details) => callback(Boolean(consoleOrigin) && permission === "clipboard-sanitized-write" && hasExactOrigin(details.requestingUrl, consoleOrigin ?? "")));
@@ -65,6 +65,6 @@ export function applyWindowPolicy(contents: WebContents, originOrOpenExternal: s
 }
 
 export function isAllowedConsoleUrl(url: string, origin: string): boolean { try { const parsed = new URL(url); return parsed.origin === origin && parsed.pathname.startsWith("/console/"); } catch { return false; } }
-function isHttpsUrl(url: string): boolean { try { return new URL(url).protocol === "https:"; } catch { return false; } }
+function isHttpUrl(url: string): boolean { try { return ["http:", "https:"].includes(new URL(url).protocol); } catch { return false; } }
 function hasExactOrigin(url: string, origin: string): boolean { try { return new URL(url).origin === origin; } catch { return false; } }
 function isLoopbackOrigin(origin: string): boolean { try { const parsed = new URL(origin); return parsed.protocol === "http:" && (parsed.hostname === "127.0.0.1" || parsed.hostname === "[::1]"); } catch { return false; } }

--- a/runtime/fleet-desktop/tests/window-policy.test.ts
+++ b/runtime/fleet-desktop/tests/window-policy.test.ts
@@ -66,15 +66,19 @@ describe("secure window policy", () => {
     expect(committed).not.toHaveBeenCalled();
   });
 
-  it("blocks popups and navigation while brokering HTTPS links only", async () => {
+  it("blocks popups and navigation while brokering HTTP links only", async () => {
     const listeners = new Map<string, (...args: never[]) => unknown>();
     const openExternal = vi.fn(async () => undefined);
     const contents = { on: vi.fn((name: string, listener: (...args: never[]) => unknown) => listeners.set(name, listener)), setWindowOpenHandler: vi.fn(), session: { setPermissionRequestHandler: vi.fn() } };
     applyWindowPolicy(contents as never, "http://127.0.0.1:4310", openExternal);
     const handler = contents.setWindowOpenHandler.mock.calls[0]![0] as ({ url }: { url: string }) => { action: string };
     expect(handler({ url: "https://fleet.example/docs" })).toEqual({ action: "deny" });
+    expect(handler({ url: "http://127.0.0.1:4173/preview" })).toEqual({ action: "deny" });
     expect(handler({ url: "file:///tmp/secret" })).toEqual({ action: "deny" });
-    await vi.waitFor(() => expect(openExternal).toHaveBeenCalledWith("https://fleet.example/docs"));
+    expect(handler({ url: "javascript:alert('unsafe')" })).toEqual({ action: "deny" });
+    await vi.waitFor(() => expect(openExternal).toHaveBeenCalledTimes(2));
+    expect(openExternal).toHaveBeenNthCalledWith(1, "https://fleet.example/docs");
+    expect(openExternal).toHaveBeenNthCalledWith(2, "http://127.0.0.1:4173/preview");
     const preventDefault = vi.fn();
     (listeners.get("will-navigate") as ((event: { preventDefault(): void }, url: string) => void))({ preventDefault }, "https://evil.example/");
     expect(preventDefault).toHaveBeenCalledOnce();

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-options.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-options.ts
@@ -1,3 +1,21 @@
+type OpenWindow = (url: string, target: string, features: string) => unknown;
+type ConfirmNavigation = (url: string) => boolean;
+
+export function createTerminalLinkHandler(openWindow: OpenWindow, confirmNavigation: ConfirmNavigation) {
+  return {
+    activate(_event: MouseEvent, text: string): void {
+      try {
+        const url = new URL(text);
+        if (url.protocol !== "http:" && url.protocol !== "https:") return;
+        if (!confirmNavigation(url.href)) return;
+        openWindow(url.href, "_blank", "noopener,noreferrer");
+      } catch {
+        // Ignore malformed OSC 8 links emitted by terminal applications.
+      }
+    },
+  };
+}
+
 export const TERMINAL_OPTIONS = {
   // Unicode11Addon은 terminal.unicode(proposed API)를 사용하므로 이 옵션이 true여야 한다.
   // false이면 addon.activate()가 "must set allowProposedApi" 오류를 던져 터미널 마운트가 깨진다.
@@ -7,5 +25,11 @@ export const TERMINAL_OPTIONS = {
   convertEol: false,
   cursorBlink: true,
   cursorStyle: "block" as const,
+  // xterm's default OSC 8 handler opens about:blank first and assigns the URL later.
+  // Sandboxed Desktop correctly denies that blank popup, so pass the validated URL in the initial request.
+  linkHandler: createTerminalLinkHandler(
+    (url, target, features) => window.open(url, target, features),
+    (url) => window.confirm(`Do you want to navigate to ${url}?\n\nWARNING: This link could potentially be dangerous`),
+  ),
   lineHeight: 1,
 };

--- a/runtime/fleet-plugins/terminal/tests/terminal-options.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-options.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { TERMINAL_OPTIONS } from "../client/shared/terminal-options.js";
+import { createTerminalLinkHandler, TERMINAL_OPTIONS } from "../client/shared/terminal-options.js";
 
 describe("TERMINAL_OPTIONS", () => {
   it("preserves raw PTY LF semantics for fullscreen TUI applications", () => {
@@ -9,5 +9,41 @@ describe("TERMINAL_OPTIONS", () => {
 
   it("keeps proposed APIs enabled for the Unicode11 addon", () => {
     expect(TERMINAL_OPTIONS.allowProposedApi).toBe(true);
+  });
+
+  it("opens OSC 8 HTTP links with the URL in the initial popup request", () => {
+    const openWindow = vi.fn();
+    const confirmNavigation = vi.fn(() => true);
+    const handler = createTerminalLinkHandler(openWindow, confirmNavigation);
+
+    handler.activate({} as MouseEvent, "http://127.0.0.1:4173/preview");
+    handler.activate({} as MouseEvent, "https://fleet.example/docs");
+
+    expect(openWindow).toHaveBeenNthCalledWith(1, "http://127.0.0.1:4173/preview", "_blank", "noopener,noreferrer");
+    expect(openWindow).toHaveBeenNthCalledWith(2, "https://fleet.example/docs", "_blank", "noopener,noreferrer");
+    expect(confirmNavigation).toHaveBeenNthCalledWith(1, "http://127.0.0.1:4173/preview");
+    expect(confirmNavigation).toHaveBeenNthCalledWith(2, "https://fleet.example/docs");
+  });
+
+  it("rejects non-web and malformed OSC 8 links", () => {
+    const openWindow = vi.fn();
+    const confirmNavigation = vi.fn(() => true);
+    const handler = createTerminalLinkHandler(openWindow, confirmNavigation);
+
+    handler.activate({} as MouseEvent, "file:///tmp/secret");
+    handler.activate({} as MouseEvent, "javascript:alert('unsafe')");
+    handler.activate({} as MouseEvent, "not a url");
+
+    expect(openWindow).not.toHaveBeenCalled();
+    expect(confirmNavigation).not.toHaveBeenCalled();
+  });
+
+  it("does not open an OSC 8 link when navigation is declined", () => {
+    const openWindow = vi.fn();
+    const handler = createTerminalLinkHandler(openWindow, () => false);
+
+    handler.activate({} as MouseEvent, "https://fleet.example/docs");
+
+    expect(openWindow).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- pass validated OSC 8 HTTP(S) URLs in the terminal's initial popup request
- broker HTTP and HTTPS links through the Desktop external-browser policy
- preserve the navigation warning and reject non-web schemes

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal test`
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-desktop test`
- [x] `pnpm --filter @dotobokuri/fleet-desktop typecheck`
- [x] headed Desktop shell E2E
- [x] actual Claude terminal OSC 8 link opens the expected Chrome URL

## Changelog
- [x] Added `.changelog.d/pr-264.md`
- [x] Bilingual grouped fragment syntax validated
- [x] `node scripts/compile-changelog-fragments.mjs --check`