### PR TITLE
fix(fleet-admiral): restore Codex multiline input on Windows

### DIFF
--- a/.agents/skills/console-e2e/SKILL.md
+++ b/.agents/skills/console-e2e/SKILL.md
@@ -9,6 +9,8 @@ Test the Console as a browser product. Keep Electron and native-shell claims out
 
 ## Load the browser contract
 
+Record the test host OS/architecture before choosing an agent-browser binary. If the host is Windows ARM64, the native wrapper is unavailable, or the result depends on platform-specific input behavior, read [the platform automation reference](references/platform-automation.md) completely before running browser commands. Never silently substitute an unofficial binary or report an emulated automation client as native ARM64 evidence.
+
 Before browser commands, load the installed CLI workflow:
 
 ```bash

--- a/.agents/skills/console-e2e/references/platform-automation.md
+++ b/.agents/skills/console-e2e/references/platform-automation.md
@@ -1,0 +1,62 @@
+# Console E2E platform automation
+
+Use this reference when agent-browser availability or the behavior under test depends on the host OS, CPU architecture, keyboard path, PTY, or renderer.
+
+## Select the automation binary
+
+Record these separately before testing:
+
+- test host OS and architecture;
+- agent-browser binary OS and architecture;
+- browser engine and headed/headless mode;
+- product layers actually exercised, such as Console, xterm.js, node-pty, ConPTY, and the child CLI.
+
+Prefer the official native agent-browser binary matching the host. If the package wrapper fails, preserve the error as environment evidence before applying a supported fallback.
+
+### Windows ARM64 fallback
+
+agent-browser may publish `win32-x64` without `win32-arm64`. Windows ARM64 can run the official x64 binary through OS emulation. Use the exact version already placed in the npm npx cache and download only its matching official GitHub release asset.
+
+```powershell
+# This expected failure also populates the npx cache when the package is absent.
+npx --yes agent-browser skills get core --full
+
+$packages = Get-ChildItem "$env:LOCALAPPDATA\npm-cache\_npx" -Directory |
+  ForEach-Object { Join-Path $_.FullName "node_modules\agent-browser" } |
+  Where-Object { Test-Path (Join-Path $_ "package.json") }
+$packageRoot = $packages |
+  Sort-Object { (Get-Item (Join-Path $_ "package.json")).LastWriteTimeUtc } -Descending |
+  Select-Object -First 1
+if (-not $packageRoot) { throw "agent-browser package not found in the npx cache" }
+
+$version = (Get-Content -Raw (Join-Path $packageRoot "package.json") | ConvertFrom-Json).version
+$toolDir = Join-Path $env:TEMP "fleet-agent-browser-$version-$PID"
+New-Item -ItemType Directory -Force -Path $toolDir | Out-Null
+gh release download "v$version" -R vercel-labs/agent-browser `
+  -p "agent-browser-win32-x64.exe" -D $toolDir
+
+$env:AGENT_BROWSER_SKILLS_DIR = Join-Path $packageRoot "skill-data"
+$ab = Join-Path $toolDir "agent-browser-win32-x64.exe"
+& $ab skills get core --full
+& $ab skills get dogfood
+```
+
+Use `& $ab ...` for every subsequent command. If Windows x64 emulation cannot execute the official binary, stop and report the environment block. Do not rename an x64 binary to appear ARM64, use a third-party build, or replace agent-browser while claiming the `console-e2e` workflow ran.
+
+Keep the binary in an owned temporary directory. After closing the owned browser session, remove only that verified directory when evidence retention does not require it.
+
+## Interpret the evidence correctly
+
+An x64 agent-browser running under Windows ARM64 emulation is a valid CDP automation client. It can exercise a real Windows Console, browser DOM, xterm.js, node-pty, ConPTY, and child CLI path. Its architecture does not establish the architecture of Chrome, Node.js, node-pty, or the child process; record those separately when they matter.
+
+`press` and `keyboard` commands create CDP keyboard events, not physical scan-code input. They are valid evidence for browser event handling and downstream PTY behavior once the application receives the event. They do not prove:
+
+- physical keyboard layout or IME hardware behavior;
+- native menu accelerators or OS-level hotkeys;
+- architecture-specific browser or native-module behavior unless those processes were independently identified.
+
+For a keyboard defect, report both the automated boundary and any remaining manual check. Example:
+
+> Windows ARM64 host; official win32-x64 agent-browser ran under Windows emulation. Headed CDP input exercised Console → xterm.js → node-pty/ConPTY → child CLI. Physical-keyboard scan-code behavior remains unverified.
+
+Never shorten this to “native Windows ARM64 agent-browser verification.”

--- a/.agents/skills/desktop-e2e/SKILL.md
+++ b/.agents/skills/desktop-e2e/SKILL.md
@@ -19,6 +19,8 @@ State the target OS and lane before testing. Never claim Windows/Linux native re
 
 ## Load Electron automation
 
+Record the automation client and target Electron OS/architecture separately. If the host is Windows ARM64, the native agent-browser wrapper is unavailable, or the claim is platform-specific, read [the platform automation reference](references/platform-automation.md) completely before launching Electron or connecting CDP. Never infer the Electron or packaged-artifact architecture from the agent-browser binary.
+
 ```bash
 ab() {
   if command -v agent-browser >/dev/null 2>&1; then agent-browser "$@";

--- a/.agents/skills/desktop-e2e/references/platform-automation.md
+++ b/.agents/skills/desktop-e2e/references/platform-automation.md
@@ -1,0 +1,65 @@
+# Desktop E2E platform automation
+
+Use this reference when the automation client or Desktop claim depends on OS, CPU architecture, native UI, packaging, signing, keyboard input, or CDP availability.
+
+## Separate client and target architecture
+
+Record these as independent facts:
+
+- host OS and architecture;
+- agent-browser binary OS and architecture;
+- Electron executable and packaged artifact architecture;
+- Console sidecar, Node.js, and native-module architecture when relevant;
+- lane tested: Shell/CDP, Native, Runtime, or Package.
+
+The agent-browser binary is only the CDP client. Its architecture never proves the architecture of Electron, the Console sidecar, a packaged artifact, or a native dependency.
+
+### Windows ARM64 fallback
+
+If the installed agent-browser wrapper reports `No binary found for win32-arm64`, use the matching official `win32-x64` release binary through Windows ARM64 x64 emulation:
+
+```powershell
+# Preserve this expected failure as environment evidence and populate the npx cache.
+npx --yes agent-browser skills get core --full
+
+$packages = Get-ChildItem "$env:LOCALAPPDATA\npm-cache\_npx" -Directory |
+  ForEach-Object { Join-Path $_.FullName "node_modules\agent-browser" } |
+  Where-Object { Test-Path (Join-Path $_ "package.json") }
+$packageRoot = $packages |
+  Sort-Object { (Get-Item (Join-Path $_ "package.json")).LastWriteTimeUtc } -Descending |
+  Select-Object -First 1
+if (-not $packageRoot) { throw "agent-browser package not found in the npx cache" }
+
+$version = (Get-Content -Raw (Join-Path $packageRoot "package.json") | ConvertFrom-Json).version
+$toolDir = Join-Path $env:TEMP "fleet-agent-browser-$version-$PID"
+New-Item -ItemType Directory -Force -Path $toolDir | Out-Null
+gh release download "v$version" -R vercel-labs/agent-browser `
+  -p "agent-browser-win32-x64.exe" -D $toolDir
+
+$env:AGENT_BROWSER_SKILLS_DIR = Join-Path $packageRoot "skill-data"
+$ab = Join-Path $toolDir "agent-browser-win32-x64.exe"
+& $ab skills get core --full
+& $ab skills get electron
+& $ab skills get dogfood
+```
+
+Use `& $ab ...` for all CDP commands. If Windows cannot execute the official x64 asset, mark the Shell/CDP lane blocked. Do not use an unofficial ARM64 build or a different browser tool while reporting that `desktop-e2e` ran.
+
+## Lane-specific evidence
+
+An emulated x64 CDP client can validly connect to an ARM64 or x64 Electron instance because CDP is a protocol boundary. It can verify renderer URL, sandbox globals, Console handoff, DOM state, browser errors, and screenshots.
+
+It cannot by itself verify:
+
+- native menus, tray, dialogs, single-instance focus, or physical keyboard accelerators;
+- Electron, ASAR, installer, or native-module architecture;
+- Authenticode, signing, or release trust;
+- physical IME and scan-code behavior.
+
+Use Playwright Electron, platform-native inspection, package verification, or a manual headed check for those claims. A CDP `press` is not native accelerator evidence. Record artifact architecture from the package output or executable metadata, not from agent-browser.
+
+Report the fallback explicitly. Example:
+
+> Windows ARM64 host; official win32-x64 agent-browser ran under Windows emulation for the Shell/CDP lane. Electron and package architecture were verified separately. Native menu and physical-keyboard behavior remain unverified.
+
+Never call this a native ARM64 agent-browser run. Close the owned session and Electron process first, then remove only the verified temporary tool directory when it is no longer needed.

--- a/.changelog.d/pr-266.md
+++ b/.changelog.d/pr-266.md
@@ -1,0 +1,4 @@
+### fleet-core
+#### Fixed
+- [fleet-admiral] Restore multiline input for Codex sessions on Windows.
+  ko: Windows의 Codex 세션에서 여러 줄 입력을 다시 사용할 수 있습니다.

--- a/packages/fleet-admiral/src/agent-cli/codex/codex.ts
+++ b/packages/fleet-admiral/src/agent-cli/codex/codex.ts
@@ -8,7 +8,13 @@ export const codexCli: AgentCliDefinition = {
   async createProfile(options: AgentCliProfileOptions) {
     const { bin, prefixArgs } = resolveBinary("codex", "CODEX_BIN", options.env);
     return {
-      args: [...prefixArgs, ...buildResumeArgs(options.resumeSessionId), "--no-alt-screen", ...buildModelArgs(options.model)],
+      args: [
+        ...prefixArgs,
+        ...buildResumeArgs(options.resumeSessionId),
+        ...buildCodexPlatformArgs(process.platform),
+        "--no-alt-screen",
+        ...buildModelArgs(options.model),
+      ],
       bin,
       binPrefixArgs: prefixArgs,
       cwd: options.cwd,
@@ -27,6 +33,14 @@ export const codexCli: AgentCliDefinition = {
     };
   },
 };
+
+const WINDOWS_EDITOR_NEWLINE_OVERRIDE =
+  "tui.keymap.editor.insert_newline=['ctrl-j','ctrl-m','enter','shift-enter','alt-enter','ctrl-enter']";
+
+// ConPTY exposes LF from Fleet's Shift+Enter handler as Ctrl+Enter to Codex's Windows input reader.
+export function buildCodexPlatformArgs(platform: NodeJS.Platform): string[] {
+  return platform === "win32" ? ["-c", WINDOWS_EDITOR_NEWLINE_OVERRIDE] : [];
+}
 
 function buildResumeArgs(resumeSessionId: string | undefined): string[] {
   return resumeSessionId === undefined ? [] : ["resume", resumeSessionId];

--- a/packages/fleet-admiral/tests/agent-cli-codex.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-codex.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCodexPlatformArgs } from "../src/agent-cli/codex/codex.js";
+
+describe("Codex Agent CLI profile", () => {
+  it("adds Ctrl+Enter to the session-local editor newline keymap on Windows", () => {
+    expect(buildCodexPlatformArgs("win32")).toEqual([
+      "-c",
+      "tui.keymap.editor.insert_newline=['ctrl-j','ctrl-m','enter','shift-enter','alt-enter','ctrl-enter']",
+    ]);
+  });
+
+  it.each(["darwin", "linux"] satisfies NodeJS.Platform[])("does not override the editor newline keymap on %s", (platform) => {
+    expect(buildCodexPlatformArgs(platform)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Restore multiline input for Codex on Windows by applying a session-local TUI newline keymap compatible with Fleet's ConPTY input path.
- Add regression coverage for Windows-only argument selection without changing macOS or Linux behavior.
- Document the official Windows ARM64 x64-emulation fallback and evidence limits for Console and Desktop E2E automation.

## Type of Change

- [ ] feat — new feature or carrier capability
- [x] fix — bug fix
- [x] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- [x] Fleet Admiral Codex CLI activation
- [x] Console and Desktop E2E skills

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-admiral exec vitest run tests/agent-cli-codex.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-admiral typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-admiral build`
- [x] Validate both E2E skills with `quick_validate.py`
- [x] Exercise the official agent-browser win32-x64 fallback on a Windows ARM64 host
- [ ] Full fleet-admiral suite: 55/56 pass; existing CRLF-sensitive `carrier-contracts-skill.test.ts` fails on Windows

## Changelog

- [x] Added `.changelog.d/pr-266.md` after PR-number assignment.
- [x] Validated bilingual fragment syntax with `node scripts/compile-changelog-fragments.mjs --check`.

## Notes for Reviewers

The agent-browser fallback is explicitly reported as an official x64 automation client running under Windows ARM64 emulation. It is not presented as native ARM64 evidence.
