### PR TITLE
fix(terminal): copy local selections to clipboard

### DIFF
--- a/.changelog.d/pr-267.md
+++ b/.changelog.d/pr-267.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] Copy local terminal selections to the clipboard after mouse dragging.
+  ko: 마우스 드래그 후 로컬 터미널 선택 내용을 클립보드에 복사합니다.

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-copy-on-select.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-copy-on-select.ts
@@ -1,0 +1,93 @@
+interface Disposable {
+  readonly dispose: () => void;
+}
+
+interface TerminalSelectionSource {
+  readonly getSelection: () => string;
+  readonly onSelectionChange: (listener: () => void) => Disposable;
+}
+
+interface EventTargetLike {
+  readonly addEventListener: (type: string, listener: EventListener, options?: boolean | AddEventListenerOptions) => void;
+  readonly removeEventListener: (type: string, listener: EventListener, options?: boolean | EventListenerOptions) => void;
+}
+
+interface ClipboardWriter {
+  readonly writeText: (text: string) => Promise<void>;
+}
+
+export interface TerminalCopyOnSelectOptions {
+  readonly terminal: TerminalSelectionSource;
+  readonly selectionTarget: EventTargetLike;
+  readonly windowTarget: EventTargetLike;
+  readonly clipboard?: ClipboardWriter;
+}
+
+export interface TerminalCopyOnSelectController {
+  readonly dispose: () => void;
+}
+
+/**
+ * Copies xterm selections after the gesture that changed them completes.
+ *
+ * xterm 6 publishes its selection update from document mouseup before the
+ * window mouseup listener runs, so reading the selection there captures the
+ * completed drag without interfering with xterm's own mouse handling.
+ */
+export function createTerminalCopyOnSelect({
+  terminal,
+  selectionTarget,
+  windowTarget,
+  clipboard,
+}: TerminalCopyOnSelectOptions): TerminalCopyOnSelectController {
+  let disposed = false;
+  let primaryGestureActive = false;
+  let selectionDirty = false;
+
+  const cancelGesture = () => {
+    primaryGestureActive = false;
+    selectionDirty = false;
+  };
+  const onMouseDown = (event: Event) => {
+    if (!isPrimaryMouseButton(event)) return;
+    primaryGestureActive = true;
+    selectionDirty = false;
+  };
+  const onSelectionChange = () => {
+    if (primaryGestureActive) selectionDirty = true;
+  };
+  const onMouseUp = (event: Event) => {
+    const shouldCopy = primaryGestureActive && selectionDirty && isPrimaryMouseButton(event);
+    cancelGesture();
+    if (!shouldCopy) return;
+
+    const selection = terminal.getSelection();
+    if (!selection || !clipboard) return;
+    try {
+      void clipboard.writeText(selection).catch(() => undefined);
+    } catch {
+      // Clipboard access is best-effort; selection must remain usable if it is blocked.
+    }
+  };
+
+  const selectionSubscription = terminal.onSelectionChange(onSelectionChange);
+  selectionTarget.addEventListener("mousedown", onMouseDown, true);
+  windowTarget.addEventListener("mouseup", onMouseUp);
+  windowTarget.addEventListener("blur", cancelGesture);
+
+  return {
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      cancelGesture();
+      selectionSubscription.dispose();
+      selectionTarget.removeEventListener("mousedown", onMouseDown, true);
+      windowTarget.removeEventListener("mouseup", onMouseUp);
+      windowTarget.removeEventListener("blur", cancelGesture);
+    },
+  };
+}
+
+function isPrimaryMouseButton(event: Event): boolean {
+  return (event as { readonly button?: unknown }).button === 0;
+}

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef, useState, type CSSProperties } from "react";
 
 import { createImeShiftEnterHandler } from "./ime-shift-enter.js";
 import { createTerminalConnection, type TerminalConnection } from "./terminal-connection.js";
+import { createTerminalCopyOnSelect } from "./terminal-copy-on-select.js";
 import { TERMINAL_OPTIONS } from "./terminal-options.js";
 import { useTerminalPrefs } from "./terminal-prefs-store.js";
 import { createTerminalScrollFollow, type TerminalScrollFollowController } from "./terminal-scroll-follow.js";
@@ -164,6 +165,12 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
       terminal.loadAddon(fitAddon);
       terminal.open(container);
       syncTerminalViewportBackground(container, terminalTheme);
+      const copyOnSelect = createTerminalCopyOnSelect({
+        terminal,
+        selectionTarget: container,
+        windowTarget: window,
+        clipboard: navigator.clipboard,
+      });
       terminal.loadAddon(new Unicode11Addon());
       terminal.unicode.activeVersion = "11";
 
@@ -252,6 +259,7 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
         imeEventTarget.removeEventListener("focusout", imeHandler.onCompositionCancel);
         imeHandler.dispose();
         connection.dispose();
+        copyOnSelect.dispose();
         scrollGesture.dispose();
         outputScheduler.dispose();
         scrollFollow.dispose();

--- a/runtime/fleet-plugins/terminal/tests/terminal-copy-on-select.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-copy-on-select.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createTerminalCopyOnSelect } from "../client/shared/terminal-copy-on-select.js";
+
+describe("createTerminalCopyOnSelect", () => {
+  it("ignores an empty selection", () => {
+    const harness = createHarness("");
+
+    harness.primaryDown();
+    harness.notifySelectionChange();
+    harness.primaryUp();
+
+    expect(harness.writeText).not.toHaveBeenCalled();
+  });
+
+  it("does not copy an unchanged selection after a primary gesture", () => {
+    const harness = createHarness("already selected");
+
+    harness.primaryDown();
+    harness.primaryUp();
+
+    expect(harness.writeText).not.toHaveBeenCalled();
+  });
+
+  it("ignores a secondary-button gesture even when the selection is non-empty", () => {
+    const harness = createHarness("selection");
+
+    harness.mouseDown(2);
+    harness.notifySelectionChange();
+    harness.mouseUp(2);
+
+    expect(harness.writeText).not.toHaveBeenCalled();
+  });
+
+  it("coalesces repeated selection notifications into one copy after mouseup", () => {
+    const harness = createHarness("selected text");
+
+    harness.primaryDown();
+    harness.notifySelectionChange();
+    harness.notifySelectionChange();
+    harness.primaryUp();
+
+    expect(harness.writeText).toHaveBeenCalledTimes(1);
+    expect(harness.writeText).toHaveBeenCalledWith("selected text");
+  });
+
+  it("cancels on blur and disposes its subscription and listeners", () => {
+    const harness = createHarness("selected text");
+
+    harness.primaryDown();
+    harness.notifySelectionChange();
+    harness.windowTarget.dispatchEvent(new Event("blur"));
+    harness.primaryUp();
+    expect(harness.writeText).not.toHaveBeenCalled();
+
+    harness.controller.dispose();
+    expect(harness.selectionSubscription.dispose).toHaveBeenCalledTimes(1);
+    harness.primaryDown();
+    harness.notifySelectionChange();
+    harness.primaryUp();
+    expect(harness.writeText).not.toHaveBeenCalled();
+  });
+
+  it("contains synchronous and asynchronous clipboard write failures", async () => {
+    const synchronousFailure = createHarness("selected text", () => {
+      throw new Error("blocked");
+    });
+    synchronousFailure.primaryDown();
+    synchronousFailure.notifySelectionChange();
+    expect(() => synchronousFailure.primaryUp()).not.toThrow();
+
+    const asynchronousFailure = createHarness("selected text", () => Promise.reject(new Error("blocked")));
+    asynchronousFailure.primaryDown();
+    asynchronousFailure.notifySelectionChange();
+    asynchronousFailure.primaryUp();
+    await Promise.resolve();
+    expect(asynchronousFailure.writeText).toHaveBeenCalledWith("selected text");
+  });
+});
+
+function createHarness(selection: string, write = () => Promise.resolve()): {
+  readonly controller: ReturnType<typeof createTerminalCopyOnSelect>;
+  readonly mouseDown: (button: number) => void;
+  readonly mouseUp: (button: number) => void;
+  readonly primaryDown: () => void;
+  readonly primaryUp: () => void;
+  readonly notifySelectionChange: () => void;
+  readonly selectionSubscription: { readonly dispose: ReturnType<typeof vi.fn> };
+  readonly windowTarget: EventTarget;
+  readonly writeText: ReturnType<typeof vi.fn>;
+} {
+  const selectionTarget = new EventTarget();
+  const windowTarget = new EventTarget();
+  const writeText = vi.fn(write);
+  let onSelectionChange: (() => void) | undefined;
+  const selectionSubscription = { dispose: vi.fn() };
+  const controller = createTerminalCopyOnSelect({
+    terminal: {
+      getSelection: () => selection,
+      onSelectionChange: (listener) => {
+        onSelectionChange = listener;
+        return selectionSubscription;
+      },
+    },
+    selectionTarget,
+    windowTarget,
+    clipboard: { writeText },
+  });
+  const mouseDown = (button: number) => dispatchMouse(selectionTarget, "mousedown", button);
+  const mouseUp = (button: number) => dispatchMouse(windowTarget, "mouseup", button);
+
+  return {
+    controller,
+    mouseDown,
+    mouseUp,
+    primaryDown: () => mouseDown(0),
+    primaryUp: () => mouseUp(0),
+    notifySelectionChange: () => onSelectionChange?.(),
+    selectionSubscription,
+    windowTarget,
+    writeText,
+  };
+}
+
+function dispatchMouse(target: EventTarget, type: "mousedown" | "mouseup", button: number): void {
+  const event = new Event(type);
+  Object.defineProperty(event, "button", { value: button });
+  target.dispatchEvent(event);
+}


### PR DESCRIPTION
## Summary
- Copy completed local xterm selections to the clipboard once per primary drag.
- Keep application-owned mouse handling unchanged while making mouse-off fallback selections useful.
- Cover empty selections, cancellation, disposal, repeated events, and clipboard failures.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal test -- terminal-copy-on-select.test.ts` (6 passed)
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console... build`
- [x] `pnpm --filter @dotobokuri/fleet-desktop build`
- [x] Manual Windows verification for xterm mouse-on and mouse-off drag-copy behavior
- [x] Full terminal suite checked (162 passed; 3 pre-existing Windows chmod expectation failures in `pty.test.ts`)
- [x] Added `.changelog.d/pr-267.md` with bilingual summaries and validated all fragments