### PR TITLE
fix(terminal): copy Windows selections with Ctrl+Shift+C

### DIFF
--- a/.changelog.d/pr-268.md
+++ b/.changelog.d/pr-268.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] Copy selected terminal text on Windows with Ctrl+Shift+C without opening browser DevTools or interrupting the active CLI.
+  ko: Windows에서 선택한 터미널 텍스트를 브라우저 DevTools 실행이나 활성 CLI 중단 없이 Ctrl+Shift+C로 복사합니다.

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -12,6 +12,7 @@ import { createTerminalCopyOnSelect } from "./terminal-copy-on-select.js";
 import { TERMINAL_OPTIONS } from "./terminal-options.js";
 import { useTerminalPrefs } from "./terminal-prefs-store.js";
 import { createTerminalScrollFollow, type TerminalScrollFollowController } from "./terminal-scroll-follow.js";
+import { createWindowsSelectionCopyHandler } from "./windows-selection-copy.js";
 import { waitForSymbolsNerdFontMono } from "./symbols-font.js";
 
 export interface TerminalSurfaceProps {
@@ -183,7 +184,14 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
       imeEventTarget.addEventListener("compositionstart", imeHandler.onCompositionStart);
       imeEventTarget.addEventListener("compositionend", imeHandler.onCompositionEnd);
       imeEventTarget.addEventListener("focusout", imeHandler.onCompositionCancel);
-      terminal.attachCustomKeyEventHandler(imeHandler.handleKeyEvent);
+      const windowsSelectionCopyHandler = createWindowsSelectionCopyHandler({
+        getPlatform: () => navigator.platform,
+        getSelection: () => terminal.getSelection(),
+        writeText: (text) => navigator.clipboard.writeText(text),
+      });
+      terminal.attachCustomKeyEventHandler((event) => (
+        windowsSelectionCopyHandler.handleKeyEvent(event) && imeHandler.handleKeyEvent(event)
+      ));
 
       const scrollFollow = createTerminalScrollFollow({
         getViewport: () => terminal.buffer.active,

--- a/runtime/fleet-plugins/terminal/client/shared/windows-selection-copy.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/windows-selection-copy.ts
@@ -1,0 +1,55 @@
+export interface WindowsSelectionCopyKeyEvent {
+  readonly altKey: boolean;
+  readonly code?: string;
+  readonly ctrlKey: boolean;
+  readonly key: string;
+  readonly metaKey: boolean;
+  readonly preventDefault?: () => void;
+  readonly repeat?: boolean;
+  readonly shiftKey: boolean;
+  readonly stopPropagation?: () => void;
+  readonly type: string;
+}
+
+export interface WindowsSelectionCopyDependencies {
+  readonly getPlatform: () => string;
+  readonly getSelection: () => string;
+  readonly writeText: (text: string) => Promise<void>;
+}
+
+export interface WindowsSelectionCopyHandler {
+  // Compatible with attachCustomKeyEventHandler: false blocks xterm handling, true passes through.
+  readonly handleKeyEvent: (event: WindowsSelectionCopyKeyEvent) => boolean;
+}
+
+export function createWindowsSelectionCopyHandler({
+  getPlatform,
+  getSelection,
+  writeText,
+}: WindowsSelectionCopyDependencies): WindowsSelectionCopyHandler {
+  return {
+    handleKeyEvent(event) {
+      if (!isWindowsCopyShortcut(event, getPlatform())) return true;
+
+      // Returning false blocks PTY input; these calls also cancel the browser DevTools shortcut.
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      const selection = getSelection();
+      if (selection && !event.repeat) {
+        // Clipboard permission can be denied at runtime; consume the rejection so it does not become unhandled.
+        void writeText(selection).catch(() => {});
+      }
+      return false;
+    },
+  };
+}
+
+function isWindowsCopyShortcut(event: WindowsSelectionCopyKeyEvent, platform: string): boolean {
+  return event.type === "keydown"
+    && /^win/i.test(platform)
+    && event.ctrlKey
+    && event.shiftKey
+    && !event.altKey
+    && !event.metaKey
+    && (event.code === "KeyC" || event.key.toLowerCase() === "c");
+}

--- a/runtime/fleet-plugins/terminal/tests/windows-selection-copy.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/windows-selection-copy.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createWindowsSelectionCopyHandler,
+  type WindowsSelectionCopyKeyEvent,
+} from "../client/shared/windows-selection-copy.js";
+
+function makeKey(overrides: Partial<WindowsSelectionCopyKeyEvent> = {}): WindowsSelectionCopyKeyEvent {
+  return {
+    altKey: false,
+    ctrlKey: true,
+    key: "C",
+    metaKey: false,
+    shiftKey: true,
+    type: "keydown",
+    ...overrides,
+  };
+}
+
+function createHandler({
+  platform = "Win32",
+  selection = "selected terminal text",
+  writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined),
+}: {
+  platform?: string;
+  selection?: string;
+  writeText?: ReturnType<typeof vi.fn<(text: string) => Promise<void>>>;
+} = {}) {
+  return {
+    handler: createWindowsSelectionCopyHandler({
+      getPlatform: () => platform,
+      getSelection: () => selection,
+      writeText,
+    }),
+    writeText,
+  };
+}
+
+describe("createWindowsSelectionCopyHandler", () => {
+  it("copies selected xterm text for Windows Ctrl+Shift+C and consumes the event", () => {
+    const { handler, writeText } = createHandler();
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+
+    expect(handler.handleKeyEvent(makeKey({ preventDefault, stopPropagation }))).toBe(false);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(stopPropagation).toHaveBeenCalledOnce();
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(writeText).toHaveBeenCalledWith("selected terminal text");
+  });
+
+  it("consumes Windows Ctrl+Shift+C without copying when there is no selection", () => {
+    const { handler, writeText } = createHandler({ selection: "" });
+
+    expect(handler.handleKeyEvent(makeKey())).toBe(false);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("copies only on keydown, without a keyup duplicate", () => {
+    const { handler, writeText } = createHandler();
+
+    expect(handler.handleKeyEvent(makeKey())).toBe(false);
+    expect(handler.handleKeyEvent(makeKey({ type: "keyup" }))).toBe(true);
+    expect(writeText).toHaveBeenCalledOnce();
+  });
+
+  it("consumes a repeated shortcut keydown without copying again", () => {
+    const { handler, writeText } = createHandler();
+
+    handler.handleKeyEvent(makeKey());
+    expect(handler.handleKeyEvent(makeKey({ repeat: true }))).toBe(false);
+    expect(writeText).toHaveBeenCalledOnce();
+  });
+
+  it("passes through the shortcut on non-Windows platforms", () => {
+    const { handler, writeText } = createHandler({ platform: "MacIntel" });
+
+    expect(handler.handleKeyEvent(makeKey())).toBe(true);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("passes macOS Cmd+C through unchanged", () => {
+    const { handler, writeText } = createHandler({ platform: "MacIntel" });
+
+    expect(handler.handleKeyEvent(makeKey({ ctrlKey: false, key: "c", metaKey: true, shiftKey: false }))).toBe(true);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { altKey: true },
+    { metaKey: true },
+    { shiftKey: false },
+    { ctrlKey: false },
+    { key: "V", code: "KeyV" },
+  ])("passes through modifier or key mismatches: %o", (overrides) => {
+    const { handler, writeText } = createHandler();
+
+    expect(handler.handleKeyEvent(makeKey(overrides))).toBe(true);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("passes ordinary Ctrl+C through to the PTY", () => {
+    const { handler, writeText } = createHandler();
+
+    expect(handler.handleKeyEvent(makeKey({ key: "c", shiftKey: false }))).toBe(true);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("handles clipboard rejection without leaking it", async () => {
+    const writeText = vi.fn<(text: string) => Promise<void>>().mockRejectedValue(new Error("denied"));
+    const { handler } = createHandler({ writeText });
+
+    expect(handler.handleKeyEvent(makeKey())).toBe(false);
+    await Promise.resolve();
+    expect(writeText).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- copy selected xterm text with `Ctrl+Shift+C` on Windows
- prevent the browser DevTools shortcut from opening while the terminal handles the copy
- preserve ordinary `Ctrl+C`, macOS shortcuts, and the existing IME key handler

## Test Plan
- [x] `pnpm --dir runtime/fleet-plugins/terminal exec vitest run tests/windows-selection-copy.test.ts tests/ime-shift-enter.test.ts tests/terminal-copy-on-select.test.ts`
- [x] `pnpm --dir runtime/fleet-plugins/terminal typecheck`
- [x] Fleet Console production build
- [x] Fleet Desktop build
- [x] Native Windows Chrome: selected terminal text copied by `Ctrl+Shift+C` without opening DevTools
- [x] Native Windows Chrome: ordinary `Ctrl+C` still interrupts the active PTY command

## Changelog
- [x] Added `.changelog.d/pr-268.md`