### PR TITLE
refactor(terminal): restyle carriers settings as chip strip and card

### DIFF
--- a/.changelog.d/pr-270.md
+++ b/.changelog.d/pr-270.md
@@ -5,8 +5,8 @@
 
 ### fleet-plugin
 #### Added
-- [fleet-console] Host the Carriers settings section in the Terminal plugin with the two-pane Captain roster, runtime editor, Task Force editing, and draft SAVE and DISCARD semantics.
-  ko: Terminal 플러그인이 2-페인 Captain 로스터, 런타임 편집기, Task Force 편집, 드래프트 SAVE·DISCARD 의미론을 갖춘 Carriers 설정 섹션을 제공합니다.
+- [fleet-console] Host the Carriers settings section in the Terminal plugin as a Captain chip strip with a single detail card that follows the Settings column rhythm, including the runtime editor, Task Force editing, and draft SAVE and DISCARD semantics.
+  ko: Terminal 플러그인이 Settings 컬럼 리듬을 따르는 Captain 칩 스트립과 단일 상세 카드 구성으로 런타임 편집기, Task Force 편집, 드래프트 SAVE·DISCARD 의미론을 갖춘 Carriers 설정 섹션을 제공합니다.
 #### Fixed
 - [fleet-console] Make the Terminal agent runtime follow the Console data directory override when reading Carrier state.
   ko: Terminal agent runtime이 Carrier 상태를 읽을 때 Console 데이터 디렉터리 오버라이드를 따르도록 수정합니다.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,6 +601,12 @@ importers:
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.17)
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.7(react@19.2.7)
       typescript:
         specifier: ^6.0.2
         version: 6.0.3

--- a/runtime/fleet-plugins/terminal/client/carriers/section.tsx
+++ b/runtime/fleet-plugins/terminal/client/carriers/section.tsx
@@ -108,9 +108,6 @@ function CarrierSettingsSection() {
             onSelect={() => selectCarrierSettingsCarrier(carrier.carrierId)}
           />
         ))}
-        <button type="button" className="terminal-carriers-action-button terminal-carriers-strip-refresh" disabled={settings.loading} onClick={() => void loadCarrierSettings()}>
-          Refresh
-        </button>
       </div>
 
       {activeCarrier && settings.options && activeCli ? (
@@ -156,10 +153,6 @@ function CarrierSettingsSection() {
                 <div className="terminal-carriers-captain-role">{activeCarrier.role}</div>
               </div>
               <div className="terminal-carriers-detail-actions">
-                <div className="terminal-carriers-cli-badge">
-                  <span className="ind" aria-hidden="true" />
-                  {activeCarrier.cliType}
-                </div>
                 <div className={`terminal-carriers-save-status ${saveStatus === "saved" ? "is-positive" : ""}`} role="status" aria-live="polite">
                   {saveStatus === "saving" || isSavingAll ? "Saving…" : saveStatus === "saved" ? "Saved ✓" : ""}
                 </div>
@@ -169,6 +162,9 @@ function CarrierSettingsSection() {
                   </button>
                   <button type="button" className={`terminal-carriers-action-button ${dirty ? "is-dirty" : ""}`} disabled={!dirty || isSavingAll} onClick={handleDiscard}>
                     Discard
+                  </button>
+                  <button type="button" className="terminal-carriers-action-button terminal-carriers-detail-refresh" disabled={settings.loading} onClick={() => void loadCarrierSettings()}>
+                    Refresh
                   </button>
                 </div>
               </div>
@@ -227,6 +223,10 @@ function CarrierSettingsSection() {
       ) : (
         <section className="global-settings-card terminal-carriers-card">
           <p className="terminal-carriers-empty">Select a carrier.</p>
+          {/* 선택된 함장이 없어도 로스터 재조회 경로는 남겨 둔다. */}
+          <button type="button" className="terminal-carriers-action-button" disabled={settings.loading} onClick={() => void loadCarrierSettings()}>
+            Refresh
+          </button>
         </section>
       )}
     </>

--- a/runtime/fleet-plugins/terminal/client/carriers/section.tsx
+++ b/runtime/fleet-plugins/terminal/client/carriers/section.tsx
@@ -96,7 +96,7 @@ function CarrierSettingsSection() {
     <>
       {settings.error ? <p className="terminal-carriers-error" role="alert">{settings.error}</p> : null}
 
-      <div className="terminal-carriers-strip" aria-label="Carrier list">
+      <div className="terminal-carriers-strip" role="group" aria-label="Carrier list">
         {settings.loading && !settings.state ? <p className="terminal-carriers-empty">Loading carrier settings.</p> : null}
         {settings.state && settings.state.carriers.length === 0 ? <p className="terminal-carriers-empty">No carriers registered.</p> : null}
         {settings.state?.carriers.map((carrier) => (
@@ -124,6 +124,7 @@ function CarrierSettingsSection() {
                       <input
                         id="carrier-display-name"
                         className="terminal-carriers-input terminal-carriers-name-input"
+                        aria-label="Display name"
                         value={settings.draft.displayName}
                         maxLength={DISPLAY_NAME_MAX_LENGTH}
                         onChange={(event) => updateCarrierSettingsDraft({ displayName: event.target.value })}

--- a/runtime/fleet-plugins/terminal/client/carriers/section.tsx
+++ b/runtime/fleet-plugins/terminal/client/carriers/section.tsx
@@ -93,51 +93,28 @@ function CarrierSettingsSection() {
   }
 
   return (
-    <section className="terminal-carriers-page">
-      <section className="terminal-carriers-hero" aria-labelledby="terminal-carriers-title">
-        <div>
-          <p className="bridge-kicker">Configure Carrier settings</p>
-          <h2 id="terminal-carriers-title">Carrier Settings</h2>
-        </div>
-        <div className="terminal-carriers-hero-actions">
-          <div className={`terminal-carriers-save-status ${saveStatus === "saved" ? "is-positive" : ""}`} role="status" aria-live="polite">
-            {saveStatus === "saving" || isSavingAll ? "Saving…" : saveStatus === "saved" ? "Saved ✓" : ""}
-          </div>
-          {activeCarrier ? (
-            <div className="terminal-carriers-save-actions">
-              <button type="button" className={`terminal-carriers-action-button ${dirty ? "is-dirty" : ""}`} disabled={!dirty || isSavingAll} onClick={() => void handleSave()}>
-                Save
-              </button>
-              <button type="button" className={`terminal-carriers-action-button ${dirty ? "is-dirty" : ""}`} disabled={!dirty || isSavingAll} onClick={handleDiscard}>
-                Discard
-              </button>
-            </div>
-          ) : null}
-          <button type="button" className="terminal-carriers-action-button terminal-carriers-hero-refresh" disabled={settings.loading} onClick={() => void loadCarrierSettings()}>
-            Refresh
-          </button>
-        </div>
-      </section>
-
+    <>
       {settings.error ? <p className="terminal-carriers-error" role="alert">{settings.error}</p> : null}
 
-      <section className="terminal-carriers-grid">
-        <div className="terminal-carriers-list" aria-label="Carrier list">
-          {settings.loading && !settings.state ? <p className="terminal-carriers-empty">Loading carrier settings.</p> : null}
-          {settings.state && settings.state.carriers.length === 0 ? <p className="terminal-carriers-empty">No carriers registered.</p> : null}
-          {settings.state?.carriers.map((carrier) => (
-            <CarrierRow
-              key={carrier.carrierId}
-              carrier={carrier}
-              active={carrier.carrierId === settings.activeCarrierId}
-              minBackends={settings.options?.taskForceConstraints.minBackends ?? 2}
-              onSelect={() => selectCarrierSettingsCarrier(carrier.carrierId)}
-            />
-          ))}
-        </div>
+      <div className="terminal-carriers-strip" aria-label="Carrier list">
+        {settings.loading && !settings.state ? <p className="terminal-carriers-empty">Loading carrier settings.</p> : null}
+        {settings.state && settings.state.carriers.length === 0 ? <p className="terminal-carriers-empty">No carriers registered.</p> : null}
+        {settings.state?.carriers.map((carrier) => (
+          <CarrierChip
+            key={carrier.carrierId}
+            carrier={carrier}
+            active={carrier.carrierId === settings.activeCarrierId}
+            minBackends={settings.options?.taskForceConstraints.minBackends ?? 2}
+            onSelect={() => selectCarrierSettingsCarrier(carrier.carrierId)}
+          />
+        ))}
+        <button type="button" className="terminal-carriers-action-button terminal-carriers-strip-refresh" disabled={settings.loading} onClick={() => void loadCarrierSettings()}>
+          Refresh
+        </button>
+      </div>
 
-        {activeCarrier && settings.options && activeCli ? (
-          <div key={activeCarrier.carrierId} className="terminal-carriers-detail" style={getCaptainColorStyle(activeCarrier.carrierId)}>
+      {activeCarrier && settings.options && activeCli ? (
+        <section key={activeCarrier.carrierId} className="global-settings-card terminal-carriers-card" style={getCaptainColorStyle(activeCarrier.carrierId)}>
             <div className="terminal-carriers-detail-head">
               <div className="terminal-carriers-detail-title-block">
                 <div className="terminal-carriers-captain-id"><span>Captain</span> · {activeCarrier.carrierId.toUpperCase()}</div>
@@ -177,9 +154,22 @@ function CarrierSettingsSection() {
                 </div>
                 <div className="terminal-carriers-captain-role">{activeCarrier.role}</div>
               </div>
-              <div className="terminal-carriers-cli-badge">
-                <span className="ind" aria-hidden="true" />
-                {activeCarrier.cliType}
+              <div className="terminal-carriers-detail-actions">
+                <div className="terminal-carriers-cli-badge">
+                  <span className="ind" aria-hidden="true" />
+                  {activeCarrier.cliType}
+                </div>
+                <div className={`terminal-carriers-save-status ${saveStatus === "saved" ? "is-positive" : ""}`} role="status" aria-live="polite">
+                  {saveStatus === "saving" || isSavingAll ? "Saving…" : saveStatus === "saved" ? "Saved ✓" : ""}
+                </div>
+                <div className="terminal-carriers-save-actions">
+                  <button type="button" className={`terminal-carriers-action-button ${dirty ? "is-dirty" : ""}`} disabled={!dirty || isSavingAll} onClick={() => void handleSave()}>
+                    Save
+                  </button>
+                  <button type="button" className={`terminal-carriers-action-button ${dirty ? "is-dirty" : ""}`} disabled={!dirty || isSavingAll} onClick={handleDiscard}>
+                    Discard
+                  </button>
+                </div>
               </div>
             </div>
 
@@ -232,29 +222,23 @@ function CarrierSettingsSection() {
                 onRowsChange={setTaskForceRows}
               />
             </div>
-          </div>
-        ) : (
-          <div className="terminal-carriers-detail">
-            <p className="terminal-carriers-empty">Select a carrier.</p>
-          </div>
-        )}
-      </section>
-    </section>
+        </section>
+      ) : (
+        <section className="global-settings-card terminal-carriers-card">
+          <p className="terminal-carriers-empty">Select a carrier.</p>
+        </section>
+      )}
+    </>
   );
 }
 
-function CarrierRow({ carrier, active, minBackends, onSelect }: { readonly carrier: CarrierSettingsCarrier; readonly active: boolean; readonly minBackends: number; readonly onSelect: () => void }) {
+function CarrierChip({ carrier, active, minBackends, onSelect }: { readonly carrier: CarrierSettingsCarrier; readonly active: boolean; readonly minBackends: number; readonly onSelect: () => void }) {
   const tfReady = carrier.taskForceBackendCount >= minBackends;
   return (
-    <button type="button" className={`terminal-carriers-row ${active ? "is-active" : ""}`} style={getCaptainColorStyle(carrier.carrierId)} onClick={onSelect}>
+    <button type="button" className={`terminal-carriers-chip ${active ? "is-active" : ""}`} aria-pressed={active} style={getCaptainColorStyle(carrier.carrierId)} onClick={onSelect}>
       <span className="terminal-carriers-captain-dot" aria-hidden="true" />
-      <span className="terminal-carriers-row-text">
-        <span className="terminal-carriers-row-name">{carrier.displayName}</span>
-        <span className="terminal-carriers-row-role">{carrier.role}</span>
-      </span>
-      <span className="terminal-carriers-row-live" aria-hidden="true">
-        <span className={`terminal-carriers-live-dot ${tfReady ? "is-live" : ""}`} />
-      </span>
+      <span className="terminal-carriers-chip-name">{carrier.displayName}</span>
+      {tfReady ? <span className="terminal-carriers-live-dot is-live" aria-hidden="true" /> : null}
     </button>
   );
 }

--- a/runtime/fleet-plugins/terminal/client/carriers/styles.css
+++ b/runtime/fleet-plugins/terminal/client/carriers/styles.css
@@ -41,6 +41,7 @@
 .terminal-carriers-strip {
   display: flex;
   align-items: center;
+  justify-content: center;
   flex-wrap: wrap;
   gap: 14px;
   width: 100%;
@@ -117,8 +118,9 @@
   animation: aurora-pulse 1.8s ease-in-out infinite;
 }
 
-.terminal-carriers-strip-refresh {
-  margin-left: auto;
+/* 순서: SAVE, DISCARD, (조금 간격) REFRESH */
+.terminal-carriers-detail-refresh {
+  margin-left: var(--space-3);
 }
 
 .terminal-carriers-card {
@@ -208,29 +210,6 @@
 
 .terminal-carriers-name-line.is-editing {
   max-width: min(100%, 640px);
-}
-
-.terminal-carriers-cli-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 14px;
-  border: 1px solid var(--surface-rim-strong);
-  border-radius: 999px;
-  background: color-mix(in oklch, var(--ink-mid) 70%, transparent);
-  color: var(--ink-spectral);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 500;
-  white-space: nowrap;
-}
-
-.terminal-carriers-cli-badge .ind {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--cap-color);
-  box-shadow: 0 0 8px var(--cap-color);
 }
 
 .terminal-carriers-body {

--- a/runtime/fleet-plugins/terminal/client/carriers/styles.css
+++ b/runtime/fleet-plugins/terminal/client/carriers/styles.css
@@ -111,8 +111,7 @@
   box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--ink-fog) 18%, transparent);
 }
 
-.terminal-carriers-live-dot.is-live,
-.terminal-carriers-toggle.is-on::before {
+.terminal-carriers-live-dot.is-live {
   background: var(--aurora);
   box-shadow: 0 0 10px var(--aurora-glow);
   animation: aurora-pulse 1.8s ease-in-out infinite;
@@ -295,8 +294,6 @@
   line-height: 1.55;
 }
 
-.terminal-carriers-inline,
-.terminal-carriers-button-stack,
 .terminal-carriers-tf-actions {
   display: flex;
   align-items: center;
@@ -376,9 +373,7 @@
   box-shadow: 0 0 0 2px color-mix(in oklch, var(--brass) 18%, transparent);
 }
 
-.terminal-carriers-button,
 .terminal-carriers-ghost-button,
-.terminal-carriers-toggle,
 .terminal-carriers-icon-button,
 .terminal-carriers-tf-toggle {
   display: inline-flex;
@@ -402,25 +397,19 @@
     transform var(--duration-fast) var(--ease-spring);
 }
 
-.terminal-carriers-button:hover:not(:disabled),
 .terminal-carriers-ghost-button:hover:not(:disabled),
-.terminal-carriers-toggle:hover:not(:disabled),
 .terminal-carriers-icon-button:hover:not(:disabled),
 .terminal-carriers-tf-toggle:hover:not(:disabled) {
   background: color-mix(in oklch, var(--brass) 8%, transparent);
   color: var(--ink-pearl);
 }
 
-.terminal-carriers-button.is-active,
-.terminal-carriers-toggle.is-on,
 .terminal-carriers-tf-toggle[aria-expanded="true"] {
   background: color-mix(in oklch, var(--brass) 12%, transparent);
   color: var(--brass-bright);
 }
 
-.terminal-carriers-button:active:not(:disabled),
 .terminal-carriers-ghost-button:active:not(:disabled),
-.terminal-carriers-toggle:active:not(:disabled),
 .terminal-carriers-icon-button:active:not(:disabled),
 .terminal-carriers-tf-toggle:active:not(:disabled) {
   background: color-mix(in oklch, var(--brass) 16%, transparent);
@@ -428,9 +417,7 @@
   transform: translateY(1px);
 }
 
-.terminal-carriers-button:disabled,
 .terminal-carriers-ghost-button:disabled,
-.terminal-carriers-toggle:disabled,
 .terminal-carriers-icon-button:disabled,
 .terminal-carriers-tf-toggle:disabled {
   cursor: not-allowed;
@@ -455,30 +442,6 @@
   stroke-width: 1.7;
 }
 
-.terminal-carriers-toggle {
-  gap: 8px;
-  min-width: 84px;
-}
-
-.terminal-carriers-toggle::before {
-  content: "";
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--ink-rim);
-}
-
-.terminal-carriers-toggle.is-on {
-  color: var(--aurora);
-}
-
-.terminal-carriers-action-cell {
-  display: flex;
-  align-items: end;
-  height: 100%;
-}
-
-.terminal-carriers-toggle-row,
 .terminal-carriers-section-head {
   display: flex;
   align-items: flex-start;
@@ -619,8 +582,6 @@
 @container carriers-card (max-width: 560px) {
   .terminal-carriers-detail-head,
   .terminal-carriers-section-head,
-  .terminal-carriers-inline,
-  .terminal-carriers-button-stack,
   .terminal-carriers-tf-actions {
     align-items: stretch;
     flex-direction: column;

--- a/runtime/fleet-plugins/terminal/client/carriers/styles.css
+++ b/runtime/fleet-plugins/terminal/client/carriers/styles.css
@@ -1,38 +1,3 @@
-.terminal-carriers-page {
-  display: grid;
-  align-content: start;
-  gap: var(--space-5);
-  /* Settings 콘텐츠 컬럼 안에 살므로 뷰포트(100vw)가 아닌 부모 폭을 따른다. */
-  width: 100%;
-  max-width: 1440px;
-  /* 반응형 스택은 뷰포트가 아닌 실컨테이너 폭 기준 — 폭이 부모 주도라 inline-size 컨테인먼트가 안전하다. */
-  container-type: inline-size;
-  container-name: carriers-page;
-  /* 셸의 minmax(0,1fr) 행 안에서 페이지 자체가 스크롤 컨테이너가 된다. */
-  min-height: 0;
-  height: 100%;
-  margin: 0 auto;
-  padding: var(--space-5) 0 var(--space-10);
-  overflow-y: auto;
-  overscroll-behavior: contain;
-}
-
-.terminal-carriers-hero {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: var(--space-4);
-  padding: var(--space-4) 0 var(--space-2);
-}
-
-.terminal-carriers-hero-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  flex: none;
-}
-
-/* hero 액션 버튼 — GNB nav 버튼 어휘(idle/hover/active/pressed). 평소 muted, 변경(dirty) 시 brass 하이라이트. */
 .terminal-carriers-action-button {
   display: inline-flex;
   align-items: center;
@@ -73,57 +38,33 @@
   cursor: not-allowed;
 }
 
-/* 순서: SAVE, DISCARD, (조금 간격) REFRESH */
-.terminal-carriers-hero-refresh {
-  margin-left: var(--space-4);
-}
-
-.terminal-carriers-hero h2 {
-  margin: 0;
-  color: var(--ink-pearl);
-  font-family: var(--font-body);
-  font-size: clamp(42px, 6vw, 72px);
-  font-weight: 300;
-  letter-spacing: -0.03em;
-  line-height: 0.95;
-}
-
-.terminal-carriers-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
-  gap: var(--space-6);
-  align-items: start;
-}
-
-.terminal-carriers-list {
-  position: sticky;
-  top: var(--space-2);
-  align-self: start;
+.terminal-carriers-strip {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 14px;
+  width: 100%;
+  min-width: 0;
   padding: 8px;
-  /* 함장 수가 뷰포트를 넘으면 리스트 자체가 스크롤한다. */
-  max-height: calc(100dvh - 132px);
-  overflow-y: auto;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xl);
   background: var(--surface-glass);
   box-shadow: var(--shadow-soft);
 }
 
-.terminal-carriers-row {
-  display: flex;
+.terminal-carriers-chip {
+  display: inline-flex;
   align-items: center;
-  gap: 14px;
-  width: 100%;
+  gap: 8px;
   min-width: 0;
-  padding: 14px 16px;
+  padding: 8px 12px;
   border: 1px solid transparent;
-  border-radius: var(--radius-md);
+  border-radius: 999px;
   background: transparent;
-  color: inherit;
-  text-align: left;
+  color: var(--ink-spectral);
+  font-family: var(--font-body);
+  font-size: 14px;
+  font-weight: 500;
   transition:
     color var(--duration-fast) var(--ease-spring),
     border-color var(--duration-fast) var(--ease-spring),
@@ -132,21 +73,13 @@
     transform var(--duration-fast) var(--ease-spring);
 }
 
-.terminal-carriers-row:nth-child(1) { animation-delay: 0ms; }
-.terminal-carriers-row:nth-child(2) { animation-delay: 40ms; }
-.terminal-carriers-row:nth-child(3) { animation-delay: 80ms; }
-.terminal-carriers-row:nth-child(4) { animation-delay: 120ms; }
-.terminal-carriers-row:nth-child(5) { animation-delay: 160ms; }
-.terminal-carriers-row:nth-child(6) { animation-delay: 200ms; }
-.terminal-carriers-row:nth-child(7) { animation-delay: 240ms; }
-.terminal-carriers-row:nth-child(8) { animation-delay: 280ms; }
-
-.terminal-carriers-row:hover {
+.terminal-carriers-chip:hover {
+  color: var(--ink-pearl);
   background: color-mix(in oklch, var(--ink-mid) 72%, transparent);
   transform: translateX(2px);
 }
 
-.terminal-carriers-row.is-active {
+.terminal-carriers-chip.is-active {
   border-color: color-mix(in oklch, var(--brass) 30%, transparent);
   background: var(--surface-glass-strong);
   box-shadow: var(--shadow-anchor);
@@ -161,50 +94,11 @@
   box-shadow: 0 0 10px var(--cap-color);
 }
 
-.terminal-carriers-row-text {
-  display: flex;
+.terminal-carriers-chip-name {
   min-width: 0;
-  flex: 1;
-  flex-direction: column;
-  gap: 1px;
-}
-
-.terminal-carriers-row-name {
   overflow: hidden;
-  color: var(--ink-spectral);
-  font-family: var(--font-body);
-  font-size: 20px;
-  font-weight: 400;
-  letter-spacing: -0.01em;
   text-overflow: ellipsis;
   white-space: nowrap;
-  transition: color var(--duration-fast) var(--ease-spring);
-}
-
-.terminal-carriers-row:hover .terminal-carriers-row-name,
-.terminal-carriers-row.is-active .terminal-carriers-row-name {
-  color: var(--ink-pearl);
-}
-
-.terminal-carriers-row-role {
-  overflow: hidden;
-  color: var(--ink-fog);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  letter-spacing: 0.06em;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  transition: color var(--duration-fast) var(--ease-spring);
-}
-
-.terminal-carriers-row.is-active .terminal-carriers-row-role {
-  color: var(--brass-bright);
-}
-
-.terminal-carriers-row-live {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
 }
 
 .terminal-carriers-live-dot {
@@ -224,18 +118,18 @@
   animation: aurora-pulse 1.8s ease-in-out infinite;
 }
 
-.terminal-carriers-detail {
-  position: relative;
-  min-height: 420px;
-  overflow: hidden;
-  padding: 36px;
-  border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-xl);
-  background: var(--surface-glass);
-  box-shadow: var(--shadow-soft);
+.terminal-carriers-strip-refresh {
+  margin-left: auto;
 }
 
-.terminal-carriers-detail::before {
+.terminal-carriers-card {
+  position: relative;
+  overflow: hidden;
+  container-type: inline-size;
+  container-name: carriers-card;
+}
+
+.terminal-carriers-card::before {
   content: "";
   position: absolute;
   top: 0;
@@ -249,9 +143,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 24px;
-  flex-wrap: wrap;
-  margin-bottom: 28px;
+  gap: var(--space-5);
 }
 
 .terminal-carriers-detail-title-block {
@@ -284,10 +176,19 @@
   margin: 0 0 8px;
   color: var(--ink-pearl);
   font-family: var(--font-body);
-  font-size: clamp(40px, 5.6vw, 64px);
+  font-size: 32px;
   font-weight: 300;
   letter-spacing: -0.03em;
   line-height: 1;
+}
+
+.terminal-carriers-detail-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  flex: none;
 }
 
 .terminal-carriers-captain-role {
@@ -337,18 +238,18 @@
   display: grid;
   /* 암시 열은 content-min으로 트랙을 뚫으므로 항상 수축 가능해야 한다. */
   grid-template-columns: minmax(0, 1fr);
-  gap: 24px;
+  gap: var(--space-5);
 }
 
 .terminal-carriers-mission {
-  padding: 20px 24px;
+  padding: var(--space-4) var(--space-5);
   border-left: 2px solid var(--cap-color);
   border-radius: 0 var(--radius-md) var(--radius-md) 0;
   background: color-mix(in oklch, var(--ink-deep) 70%, transparent);
   color: var(--ink-spectral);
   font-family: var(--font-body);
   font-style: italic;
-  font-size: 22px;
+  font-size: 18px;
   font-weight: 300;
   letter-spacing: -0.005em;
   line-height: 1.45;
@@ -459,7 +360,7 @@
   min-height: 54px;
   color: var(--ink-pearl);
   font-family: var(--font-body);
-  font-size: clamp(32px, 4.5vw, 52px);
+  font-size: 30px;
   font-weight: 300;
   letter-spacing: -0.03em;
 }
@@ -706,32 +607,17 @@
   line-height: 1.5;
 }
 
-@container carriers-page (max-width: 1120px) {
-  .terminal-carriers-runtime-grid,
+/* Model·Effort와 Task Force 행의 최소 컨트롤 폭이 겹치기 전에 카드 내부에서 한 열로 전환한다. */
+@container carriers-card (max-width: 640px) {
+  .terminal-carriers-runtime-row--model,
   .terminal-carriers-tf-item {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 
-@container carriers-page (max-width: 880px) {
-  .terminal-carriers-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .terminal-carriers-list {
-    position: static;
-    flex-flow: row wrap;
-  }
-
-  .terminal-carriers-row {
-    flex: 1 1 190px;
-  }
-}
-
-@container carriers-page (max-width: 720px) {
-  .terminal-carriers-hero,
+/* 헤드 액션의 최소 터치 폭을 보장하려면 560px 아래에서 제목과 액션을 분리해야 한다. */
+@container carriers-card (max-width: 560px) {
   .terminal-carriers-detail-head,
-  .terminal-carriers-toggle-row,
   .terminal-carriers-section-head,
   .terminal-carriers-inline,
   .terminal-carriers-button-stack,
@@ -740,15 +626,12 @@
     flex-direction: column;
   }
 
-  .terminal-carriers-hero-actions {
-    flex-wrap: wrap;
+  .terminal-carriers-detail-actions {
+    align-items: stretch;
+    justify-content: flex-start;
   }
 
   .terminal-carriers-save-status {
     text-align: left;
-  }
-
-  .terminal-carriers-detail {
-    padding: var(--space-6);
   }
 }

--- a/runtime/fleet-plugins/terminal/package.json
+++ b/runtime/fleet-plugins/terminal/package.json
@@ -39,6 +39,8 @@
   "devDependencies": {
     "@types/node": "^24.10.0",
     "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.0.0",
+    "react-dom": "^19.0.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.5"
   }

--- a/runtime/fleet-plugins/terminal/tests/carrier-settings-client.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/carrier-settings-client.test.ts
@@ -1,5 +1,10 @@
-import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import type { Root } from "../../../fleet-console/node_modules/@types/react-dom/client.d.ts";
+// terminal은 react-dom을 런타임 의존성으로 노출하지 않으므로, 테스트만 Console의 설치본을 사용한다.
+// @ts-expect-error -- test-only relative runtime import has no package export declaration.
+import { createRoot } from "../../../fleet-console/node_modules/react-dom/client.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { fetchCarrierSettingsState } from "../client/carriers/api.js";
@@ -23,8 +28,49 @@ const options = {
   cliTypes: [{ id: "codex", displayName: "Codex", defaultModel: "gpt-5", models: [{ modelId: "gpt-5", name: "GPT-5" }] }],
   taskForceConstraints: { minBackends: 2 },
 };
+const captainIds = ["nimitz", "kirov", "genesis", "ohio", "sentinel", "vanguard", "tempest", "chronicle"] as const;
+const interactiveOptions = {
+  cliTypes: [{
+    id: "codex",
+    displayName: "Codex",
+    defaultModel: "gpt-5",
+    models: [
+      { modelId: "gpt-5", name: "GPT-5" },
+      { modelId: "gpt-5-mini", name: "GPT-5 mini" },
+    ],
+  }],
+  taskForceConstraints: { minBackends: 2 },
+};
+const interactiveState = {
+  generation: 2,
+  carriers: captainIds.map((carrierId, index) => ({
+    carrierId,
+    displayName: carrierId[0]!.toUpperCase() + carrierId.slice(1),
+    sourceDisplayName: carrierId[0]!.toUpperCase() + carrierId.slice(1),
+    role: `Role ${index + 1}`,
+    roleDescription: `Mission ${index + 1}`,
+    slot: index + 1,
+    cliType: "codex",
+    defaultCliType: "codex",
+    model: "gpt-5",
+    taskForceBackendCount: carrierId === "nimitz" ? 2 : 0,
+    taskforce: { backends: [] },
+  })),
+};
+const emptyState = { generation: 3, carriers: [] };
 
-afterEach(() => vi.unstubAllGlobals());
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  vi.unstubAllGlobals();
+});
 
 describe("Terminal Carrier Settings client", () => {
   it("uses the plugin endpoint and rejects sensitive response fields", async () => {
@@ -57,17 +103,77 @@ describe("Terminal Carrier Settings client", () => {
     expect(carrierSettingsSection.title).toBe("Carriers");
   });
 
-  it("defines the Option B chip strip and single-card markup contract", async () => {
-    const source = await readFile(resolve(process.cwd(), "client/carriers/section.tsx"), "utf8");
+  it("renders and operates the Captain chip strip with a single detail card", async () => {
+    let nextState = interactiveState;
+    vi.stubGlobal("fetch", vi.fn((input: string) => Promise.resolve(new Response(JSON.stringify(
+      input.endsWith("/options") ? interactiveOptions : nextState,
+    ), { status: 200 }))));
+    await loadCarrierSettings();
+    selectCarrierSettingsCarrier("nimitz");
+    await renderCarrierSettings();
 
-    expect(source).toContain('className="terminal-carriers-strip"');
-    expect(source).toContain('className={`terminal-carriers-chip ${active ? "is-active" : ""}`} aria-pressed={active}');
-    expect(source).toContain('className="global-settings-card terminal-carriers-card"');
-    expect(source).toContain('key={activeCarrier.carrierId}');
-    expect(source).toContain('aria-label="Edit display name"');
-    expect(source).toContain('role="status" aria-live="polite"');
-    expect(source).not.toContain("terminal-carriers-page");
-    expect(source).not.toContain("terminal-carriers-grid");
-    expect(source).not.toContain("terminal-carriers-row");
+    const strip = container!.querySelector<HTMLElement>('[role="group"][aria-label="Carrier list"]');
+    const chips = [...container!.querySelectorAll<HTMLButtonElement>(".terminal-carriers-chip")];
+    expect(strip).not.toBeNull();
+    expect(chips).toHaveLength(8);
+    expect(chips[0]?.getAttribute("aria-pressed")).toBe("true");
+    expect(chips.slice(1).every((chip) => chip.getAttribute("aria-pressed") === "false")).toBe(true);
+    expect(chips[0]?.querySelector(".terminal-carriers-live-dot.is-live")).not.toBeNull();
+
+    const ohioChip = chips.find((chip) => chip.textContent?.includes("Ohio"));
+    if (!ohioChip) throw new Error("Ohio chip must render.");
+    await act(async () => ohioChip.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(ohioChip.getAttribute("aria-pressed")).toBe("true");
+    expect(container!.querySelector(".terminal-carriers-card")?.textContent).toContain("Captain · OHIO");
+
+    const editName = container!.querySelector<HTMLButtonElement>('[aria-label="Edit display name"]');
+    if (!editName) throw new Error("Display-name edit button must render.");
+    await act(async () => editName.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(container!.querySelector('[aria-label="Display name"]')).not.toBeNull();
+    const cancelNameEdit = container!.querySelector<HTMLButtonElement>('[aria-label="Cancel display name edit"]');
+    if (!cancelNameEdit) throw new Error("Display-name cancel button must render.");
+    await act(async () => cancelNameEdit.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+    const model = container!.querySelector<HTMLSelectElement>("#carrier-model");
+    if (!model) throw new Error("Carrier model select must render.");
+    model.value = "gpt-5-mini";
+    await act(async () => model.dispatchEvent(new Event("change", { bubbles: true })));
+    const save = actionButton("Save");
+    const discard = actionButton("Discard");
+    expect(save.classList.contains("is-dirty")).toBe(true);
+    expect(discard.classList.contains("is-dirty")).toBe(true);
+    expect(save.disabled).toBe(false);
+    expect(discard.disabled).toBe(false);
+
+    await act(async () => discard.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(model.value).toBe("gpt-5");
+    expect(actionButton("Save").disabled).toBe(true);
+    expect(actionButton("Discard").disabled).toBe(true);
+    expect(container!.querySelector(".terminal-carriers-page, .terminal-carriers-grid, .terminal-carriers-row")).toBeNull();
+
+    nextState = emptyState;
+    await act(async () => loadCarrierSettings());
+    expect(strip?.textContent).toContain("No carriers registered.");
+    expect(container!.querySelector(".terminal-carriers-card")?.textContent).toContain("Select a carrier.");
   });
 });
+
+async function renderCarrierSettings(): Promise<void> {
+  const render = carrierSettingsSection.render;
+  if (!render) throw new Error("Carrier Settings section must render.");
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(createElement(() => render()));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function actionButton(label: string): HTMLButtonElement {
+  const button = [...container!.querySelectorAll<HTMLButtonElement>(".terminal-carriers-save-actions button")]
+    .find((item) => item.textContent === label);
+  if (!button) throw new Error(`${label} action must render.`);
+  return button;
+}

--- a/runtime/fleet-plugins/terminal/tests/carrier-settings-client.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/carrier-settings-client.test.ts
@@ -1,10 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, createElement } from "react";
-import type { Root } from "../../../fleet-console/node_modules/@types/react-dom/client.d.ts";
-// terminal은 react-dom을 런타임 의존성으로 노출하지 않으므로, 테스트만 Console의 설치본을 사용한다.
-// @ts-expect-error -- test-only relative runtime import has no package export declaration.
-import { createRoot } from "../../../fleet-console/node_modules/react-dom/client.js";
+import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { fetchCarrierSettingsState } from "../client/carriers/api.js";

--- a/runtime/fleet-plugins/terminal/tests/carrier-settings-client.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/carrier-settings-client.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { fetchCarrierSettingsState } from "../client/carriers/api.js";
@@ -53,5 +55,19 @@ describe("Terminal Carrier Settings client", () => {
   it("exports the reserved Settings section identity", () => {
     expect(carrierSettingsSection.id).toBe("carriers");
     expect(carrierSettingsSection.title).toBe("Carriers");
+  });
+
+  it("defines the Option B chip strip and single-card markup contract", async () => {
+    const source = await readFile(resolve(process.cwd(), "client/carriers/section.tsx"), "utf8");
+
+    expect(source).toContain('className="terminal-carriers-strip"');
+    expect(source).toContain('className={`terminal-carriers-chip ${active ? "is-active" : ""}`} aria-pressed={active}');
+    expect(source).toContain('className="global-settings-card terminal-carriers-card"');
+    expect(source).toContain('key={activeCarrier.carrierId}');
+    expect(source).toContain('aria-label="Edit display name"');
+    expect(source).toContain('role="status" aria-live="polite"');
+    expect(source).not.toContain("terminal-carriers-page");
+    expect(source).not.toContain("terminal-carriers-grid");
+    expect(source).not.toContain("terminal-carriers-row");
   });
 });


### PR DESCRIPTION
## Summary
- Settings › Plugins › Terminal › Carriers 섹션을 2-페인 마스터-디테일(자체 히어로·자체 스크롤)에서 Captain 칩 스트립 + 단일 `global-settings-card` 상세 카드로 재구성해, 형제 Settings 섹션들과 동일한 단일 컬럼 카드 리듬으로 합류시킵니다. 드래프트 의미론(dirty 게이팅 Save/Discard, Refresh, displayName 편집, carrierId 기준 remount)은 그대로 보존됩니다.
- 반응형 분기를 페이지 컨테이너 기준에서 카드 컨테이너(`carriers-card` 640/560px) 기준으로 재산정하고, 뷰포트 단위(vw) 잔재를 제거했습니다. Sentinel 검수 반영으로 접근성 2건(displayName 입력 `aria-label`, 칩 스트립 `role="group"`)과 TSX 소비자가 없는 고아 CSS 셀렉터 6종을 정리했습니다.
- 클라이언트 테스트를 소스 문자열 검사에서 jsdom + `react-dom/client` 렌더 기반 상호작용 테스트(칩 선택 전환, dirty→Save/Discard 전이, Discard 복원, 빈 상태 폴백)로 격상하고, react-dom을 terminal 패키지의 선언된 devDependency로 소비합니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal test` — 20 files, 184 tests passed
- [x] `pnpm --filter @fleet-plugins/terminal typecheck` — passed
- [x] 루트 `pnpm build`(tsc 포함) — passed
- [x] 실브라우저(격리 콘솔 + headless Chrome): 1512/1100/760/580px 캡처 — 칩 스트립·카드 리듬·컨테이너 쿼리 스택 정상, dirty→Save 왕복 "Saved ✓"·Task Force 펼침 확인
- [x] Changelog: `no-changelog` 분류 — 이 리워크는 미릴리스 프래그먼트(`.changelog.d/pr-270.md`)에 기재된 섹션의 재설계이므로, Release Baseline 규약(`.changelog.d/AGENTS.md`)에 따라 독립 항목 대신 pending pr-270 항목을 최종 칩 스트립 형상으로 갱신했습니다(`c9cd42c78`, `node scripts/compile-changelog-fragments.mjs --check` 통과)
