### PR TITLE
fix(fleet-console): skip minimized panels in Alt navigation

### DIFF
--- a/.changelog.d/pr-274.md
+++ b/.changelog.d/pr-274.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Keep Alt+Left and Alt+Right navigation within non-minimized panels.
+  ko: Alt+Left와 Alt+Right 탐색이 최소화되지 않은 패널 안에서만 이동하도록 수정했습니다.

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -14,7 +14,7 @@ import { RightRail } from "../rail/right-rail.js";
 import { OperationsSideBar } from "../sidebar/operations-side-bar.js";
 import { CodexReadingSheet } from "../components/codex-reading-sheet.js";
 import { shouldHandleOperationsKeyboardShortcut } from "../components/keyboard-shortcuts-dialog.js";
-import { beginAddTheater, cancelAddTheater, compareOperationCreatedAt, completeAddTheater, consumeOperationFocus, failAddTheater, flattenGroupedOrder, focusOperation, getState, hydrateGroups, hydrateOperations, nextOperationId, removeTheater, setActiveOperation, setActiveTheater, sortOperationsByOrder } from "../store.js";
+import { beginAddTheater, cancelAddTheater, compareOperationCreatedAt, completeAddTheater, consumeOperationFocus, failAddTheater, focusCycleOperationIds, focusOperation, getState, hydrateGroups, hydrateOperations, nextOperationId, removeTheater, setActiveOperation, setActiveTheater, sortOperationsByOrder } from "../store.js";
 import type { ConsoleState, OperationNode } from "../types.js";
 
 const STABLE_RAIL_API: ClientApiCapability = createHostCapabilities().api;
@@ -73,12 +73,13 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       // Alt 순환 순서를 Left SideBar 표시 순서(비-collapsed 그룹 order → 그룹 내 operationOrder → ungrouped)와 정확히 일치시킨다.
       const snapshot = stateRef.current;
       const canvas = getCanvasSnapshot();
-      const order = flattenGroupedOrder(
+      const order = focusCycleOperationIds(
         snapshot.operations.filter((operation) => operation.theaterId === snapshot.activeTheaterId),
         snapshot.groups.filter((g) => g.theaterId === snapshot.activeTheaterId),
         canvas.operationOrder,
         canvas.collapsedGroups,
-      ).map((operation) => operation.id);
+        canvas.minimized,
+      );
       if (order.length === 0) return;
       event.preventDefault();
       event.stopImmediatePropagation();

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -78,7 +78,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
         snapshot.groups.filter((g) => g.theaterId === snapshot.activeTheaterId),
         canvas.operationOrder,
         canvas.collapsedGroups,
-        canvas.minimized,
+        maximizedRef.current === null ? canvas.minimized : [],
       );
       event.preventDefault();
       event.stopImmediatePropagation();

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -80,9 +80,9 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
         canvas.collapsedGroups,
         canvas.minimized,
       );
-      if (order.length === 0) return;
       event.preventDefault();
       event.stopImmediatePropagation();
+      if (order.length === 0) return;
       const currentId = maximizedRef.current ?? stateRef.current.activeOperationId;
       const nextId = nextOperationId(order, currentId, event.key === "ArrowRight" ? 1 : -1);
       if (!nextId) return;

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -366,6 +366,20 @@ export function flattenGroupedOrder(
   ];
 }
 
+// Alt+←/→는 SideBar 가시 순서를 따르되, 캔버스에서 최소화된 Operation은 순환 대상에서 제외한다.
+export function focusCycleOperationIds(
+  operations: readonly OperationNode[],
+  groups: readonly OperationGroup[],
+  operationOrder: readonly string[],
+  collapsedGroups: readonly string[],
+  minimized: readonly string[],
+): readonly string[] {
+  const minimizedIds = new Set(minimized);
+  return flattenGroupedOrder(operations, groups, operationOrder, collapsedGroups)
+    .filter((operation) => !minimizedIds.has(operation.id))
+    .map((operation) => operation.id);
+}
+
 export function compareOperationCreatedAt(left: OperationNode, right: OperationNode): number {
   return left.ts.createdAt - right.ts.createdAt || left.id.localeCompare(right.id);
 }

--- a/runtime/fleet-console/tests/operation-focus.test.ts
+++ b/runtime/fleet-console/tests/operation-focus.test.ts
@@ -69,17 +69,4 @@ describe("nextOperationId — Alt+←/→ focus cycle", () => {
     expect(nextOperationId(order, "group-1-visible", -1)).toBe("ungrouped-visible");
   });
 
-  it("keeps the maximized panel as the only Alt+Arrow target", () => {
-    const order = focusCycleOperationIds(
-      [makeOperation("maximized"), makeOperation("minimized-a"), makeOperation("minimized-b")],
-      [],
-      ["maximized", "minimized-a", "minimized-b"],
-      [],
-      ["minimized-a", "minimized-b"],
-    );
-
-    expect(order).toEqual(["maximized"]);
-    expect(nextOperationId(order, "maximized", 1)).toBe("maximized");
-    expect(nextOperationId(order, "maximized", -1)).toBe("maximized");
-  });
 });

--- a/runtime/fleet-console/tests/operation-focus.test.ts
+++ b/runtime/fleet-console/tests/operation-focus.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, it } from "vitest";
 
-import { nextOperationId } from "../core/client/src/store.js";
+import { focusCycleOperationIds, nextOperationId } from "../core/client/src/store.js";
+import type { OperationGroup, OperationNode } from "../core/client/src/types.js";
+
+function makeOperation(id: string, groupId: string | null = null, createdAt = 1): OperationNode {
+  return {
+    id,
+    theaterId: "theater",
+    type: "shell",
+    pluginId: "terminal",
+    title: id,
+    payload: {},
+    geometry: null,
+    groupId,
+    ts: { createdAt, updatedAt: createdAt },
+  };
+}
+
+function makeGroup(id: string, order: number): OperationGroup {
+  return { id, name: id, color: "blue", order, theaterId: "theater", createdAt: order };
+}
 
 describe("nextOperationId — Alt+←/→ focus cycle", () => {
   const order = ["a", "b", "c"];
@@ -27,5 +46,40 @@ describe("nextOperationId — Alt+←/→ focus cycle", () => {
     expect(nextOperationId(["solo"], "solo", 1)).toBe("solo");
     expect(nextOperationId(["solo"], "solo", -1)).toBe("solo");
     expect(nextOperationId([], "a", 1)).toBeNull();
+  });
+
+  it("excludes minimized panels while preserving grouped and collapsed SideBar order", () => {
+    const order = focusCycleOperationIds(
+      [
+        makeOperation("group-2-visible", "group-2", 1),
+        makeOperation("group-1-minimized", "group-1", 2),
+        makeOperation("group-1-visible", "group-1", 3),
+        makeOperation("collapsed-visible", "collapsed", 4),
+        makeOperation("ungrouped-minimized", null, 5),
+        makeOperation("ungrouped-visible", null, 6),
+      ],
+      [makeGroup("group-1", 1), makeGroup("group-2", 2), makeGroup("collapsed", 3)],
+      ["group-2-visible", "group-1-minimized", "group-1-visible", "collapsed-visible", "ungrouped-minimized", "ungrouped-visible"],
+      ["collapsed"],
+      ["group-1-minimized", "ungrouped-minimized"],
+    );
+
+    expect(order).toEqual(["group-1-visible", "group-2-visible", "ungrouped-visible"]);
+    expect(nextOperationId(order, "group-1-visible", 1)).toBe("group-2-visible");
+    expect(nextOperationId(order, "group-1-visible", -1)).toBe("ungrouped-visible");
+  });
+
+  it("keeps the maximized panel as the only Alt+Arrow target", () => {
+    const order = focusCycleOperationIds(
+      [makeOperation("maximized"), makeOperation("minimized-a"), makeOperation("minimized-b")],
+      [],
+      ["maximized", "minimized-a", "minimized-b"],
+      [],
+      ["minimized-a", "minimized-b"],
+    );
+
+    expect(order).toEqual(["maximized"]);
+    expect(nextOperationId(order, "maximized", 1)).toBe("maximized");
+    expect(nextOperationId(order, "maximized", -1)).toBe("maximized");
   });
 });

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -14,6 +14,9 @@ const apiMocks = vi.hoisted(() => ({
   fetchOperations: vi.fn(),
   fetchGroups: vi.fn(),
 }));
+const keyboardShortcutMocks = vi.hoisted(() => ({
+  shouldHandleOperationsKeyboardShortcut: vi.fn(),
+}));
 
 vi.mock("../core/client/src/api.js", () => ({
   ...apiMocks,
@@ -40,7 +43,7 @@ vi.mock("../core/client/src/canvas/canvas.js", () => ({ OperationsCanvas: () => 
 vi.mock("../core/client/src/components/codex-reading-sheet.js", () => ({ CodexReadingSheet: () => null }));
 vi.mock("../core/client/src/components/command-band.js", () => ({ CommandBand: () => null }));
 vi.mock("../core/client/src/components/commissioning-overlay.js", () => ({ CommissioningOverlay: () => null }));
-vi.mock("../core/client/src/components/keyboard-shortcuts-dialog.js", () => ({ isKeyboardShortcutsModalOpen: () => false, shouldHandleOperationsKeyboardShortcut: () => false }));
+vi.mock("../core/client/src/components/keyboard-shortcuts-dialog.js", () => ({ isKeyboardShortcutsModalOpen: () => false, shouldHandleOperationsKeyboardShortcut: keyboardShortcutMocks.shouldHandleOperationsKeyboardShortcut }));
 vi.mock("../core/client/src/components/operation-search.js", () => ({ OperationSearch: () => null }));
 vi.mock("../core/client/src/components/toast.js", () => ({ Toast: () => null }));
 vi.mock("../core/client/src/components/whatsnew-modal.js", () => ({ WhatsNewModal: () => null }));
@@ -71,6 +74,7 @@ beforeEach(() => {
   document.body.appendChild(container);
   root = createRoot(container);
   apiMocks.fetchGroups.mockResolvedValue([]);
+  keyboardShortcutMocks.shouldHandleOperationsKeyboardShortcut.mockReturnValue(false);
 });
 
 afterEach(() => {
@@ -155,6 +159,35 @@ describe("Operations boot minimization", () => {
     expect(getSnapshot().minimized).toEqual(["initial"]);
     expect(getSnapshot().operations).toHaveProperty("initial");
     expect(getSnapshot().operations).toHaveProperty("launched");
+  });
+
+  it("consumes Alt+Arrow without restoring a minimized panel", async () => {
+    const operations = deferred<readonly OperationNode[]>();
+    const theaters = deferred<TheaterBootstrap>();
+    apiMocks.fetchOperations.mockReturnValueOnce(operations.promise);
+    apiMocks.fetchTheaterBootstrap.mockReturnValueOnce(theaters.promise);
+    const { App } = await import("../core/client/src/app.js");
+
+    await act(async () => {
+      root!.render(createElement(BrowserRouter, null, createElement(App)));
+    });
+    await act(async () => {
+      operations.resolve([operation("initial")]);
+      theaters.resolve({ theaters: [theater()] });
+      await Promise.resolve();
+    });
+    expect(getSnapshot().minimized).toEqual(["initial"]);
+
+    keyboardShortcutMocks.shouldHandleOperationsKeyboardShortcut.mockReturnValue(true);
+    const event = new KeyboardEvent("keydown", { key: "ArrowLeft", altKey: true, cancelable: true });
+    await act(async () => {
+      window.dispatchEvent(event);
+      await Promise.resolve();
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(getState().activeOperationId).toBeNull();
+    expect(getSnapshot().minimized).toEqual(["initial"]);
   });
 
   it("minimizes a second Theater's existing panels on first in-session view, surfacing only the selected panel", async () => {

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -5,7 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getSnapshot, loadForTheater, restoreOperation, setOperationGeometry } from "../core/client/src/canvas/canvas-store.js";
+import { getMaximizedOperationId, getSnapshot, loadForTheater, restoreOperation, setMaximizedOperationId, setOperationGeometry } from "../core/client/src/canvas/canvas-store.js";
 import { focusOperation, getState, hydrateOperations, setState } from "../core/client/src/store.js";
 import type { OperationNode, TheaterBootstrap } from "../core/client/src/types.js";
 
@@ -188,6 +188,41 @@ describe("Operations boot minimization", () => {
     expect(event.defaultPrevented).toBe(true);
     expect(getState().activeOperationId).toBeNull();
     expect(getSnapshot().minimized).toEqual(["initial"]);
+  });
+
+  it("advances the maximized Operation with Alt+Arrow", async () => {
+    const operations = deferred<readonly OperationNode[]>();
+    const theaters = deferred<TheaterBootstrap>();
+    apiMocks.fetchOperations.mockReturnValueOnce(operations.promise);
+    apiMocks.fetchTheaterBootstrap.mockReturnValueOnce(theaters.promise);
+    const { App } = await import("../core/client/src/app.js");
+
+    await act(async () => {
+      root!.render(createElement(BrowserRouter, null, createElement(App)));
+    });
+    await act(async () => {
+      operations.resolve([operation("first"), operation("second")]);
+      theaters.resolve({ theaters: [theater()] });
+      await Promise.resolve();
+    });
+    await act(async () => {
+      setMaximizedOperationId("first");
+      await Promise.resolve();
+    });
+    expect(getMaximizedOperationId()).toBe("first");
+    expect(getSnapshot().minimized).toEqual(["second"]);
+
+    keyboardShortcutMocks.shouldHandleOperationsKeyboardShortcut.mockReturnValue(true);
+    const event = new KeyboardEvent("keydown", { key: "ArrowRight", altKey: true, cancelable: true });
+    await act(async () => {
+      window.dispatchEvent(event);
+      await Promise.resolve();
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(getState().activeOperationId).toBe("second");
+    expect(getMaximizedOperationId()).toBe("second");
+    expect(getSnapshot().minimized).toEqual(["first"]);
   });
 
   it("minimizes a second Theater's existing panels on first in-session view, surfacing only the selected panel", async () => {


### PR DESCRIPTION
## Summary
- Restrict `Alt+Left` and `Alt+Right` focus cycling to non-minimized Fleet Console panels.
- Preserve grouped SideBar ordering while preventing minimized panels from being restored by keyboard navigation.
- Add regression coverage for minimized, collapsed-group, and maximized-panel cases.

## Type of Change
- [x] fix — bug fix

## Scope
- [x] `runtime/fleet-console`

## Test Plan
- [x] `pnpm --dir runtime/fleet-console exec vitest run tests/operation-focus.test.ts tests/store-flatten-grouped-order.test.ts` — 17 passed
- [x] `pnpm --dir runtime/fleet-console exec tsc --noEmit -p core/client/tsconfig.json`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Headed Console E2E — `Panel A`/`Panel B` cycle in both directions while minimized `Panel C` stays hidden; browser errors and console remain empty
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 6 entries validated

## Changelog
- [x] Added `.changelog.d/pr-274.md`.
- [x] Fragment uses the `fleet-console` / `Fixed` grouped syntax.
- [x] English and Korean summaries are adjacent and compiler validation passes.

## Notes for Reviewers
- The full Console suite reported 760 passed, 22 skipped, and one worktree-only `launch.test.ts` path assertion caused by symlinked dependencies. The same test passed from the main `canary` checkout.
- The package-level typecheck currently reports existing CSS side-effect and `virtual:fleet-plugins` declaration errors on both the branch worktree and `canary`; the directly affected client TypeScript project passes.
