### PR TITLE
fix(fleet-console): preserve inactive Theater sidebar hierarchy

### DIFF
--- a/.changelog.d/pr-275.md
+++ b/.changelog.d/pr-275.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Changed
+- [fleet-console] Show complete Operations and Groups for inactive Theaters while preserving Group collapse state.
+  ko: 비활성 Theater에서도 전체 Operations와 Group을 표시하고 Group 접힘 상태를 유지합니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
@@ -99,6 +99,11 @@ export function getSnapshot(): CanvasState {
   return state;
 }
 
+// 비활성 Theater의 사이드바는 현재 캔버스를 전환하지 않고, 해당 Theater에 저장된 표시 상태만 읽는다.
+export function getTheaterCanvasSnapshot(theaterId: string): CanvasState {
+  return activeTheaterId === theaterId ? state : readStoredState(theaterId);
+}
+
 export function getMaximizedOperationId(): string | null {
   return maximizedOperationId;
 }
@@ -157,6 +162,23 @@ export function toggleGroupCollapsed(groupId: string): void {
     ? state.collapsedGroups.filter((id) => id !== groupId)
     : [...state.collapsedGroups, groupId];
   setState({ collapsedGroups: collapsed });
+}
+
+// 비활성 Theater의 그룹 접힘은 해당 Theater 저장소에만 즉시 반영한다. 현재 캔버스 전환이나 다른
+// Theater의 저장 예약에는 관여하지 않아, 사이드바 표시 조작이 잘못된 캔버스를 바꾸지 않게 한다.
+export function toggleTheaterGroupCollapsed(theaterId: string, groupId: string): void {
+  if (activeTheaterId === theaterId) {
+    toggleGroupCollapsed(groupId);
+    return;
+  }
+  const theaterState = readStoredState(theaterId);
+  const collapsedGroups = theaterState.collapsedGroups.includes(groupId)
+    ? theaterState.collapsedGroups.filter((id) => id !== groupId)
+    : [...theaterState.collapsedGroups, groupId];
+  writeStoredState(theaterId, { ...theaterState, collapsedGroups });
+  // 현재 Theater 값은 바꾸지 않되 구독 컴포넌트가 비활성 Theater 스냅샷을 다시 읽게 한다.
+  state = { ...state };
+  emit();
 }
 
 export function useCollapsedGroups(): readonly string[] {

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -11,7 +11,7 @@ import { DirectoryBrowserModal } from "../components/directory-browser-modal.js"
 import { useConsoleState } from "../hooks/use-store.js";
 import { GroupContextMenu } from "../canvas/group-context-menu.js";
 import { operationAccentFromNode, resolveAccentColor } from "../canvas/operation-accent.js";
-import { selectFormationLayout, setOperationOrder, toggleGroupCollapsed, useCanvasState, useCollapsedGroups, useFormationLayout, useFormationView } from "../canvas/canvas-store.js";
+import { getTheaterCanvasSnapshot, selectFormationLayout, setOperationOrder, toggleGroupCollapsed, toggleTheaterGroupCollapsed, useCanvasState, useCollapsedGroups, useFormationLayout, useFormationView } from "../canvas/canvas-store.js";
 import { sortOperationsByOrder } from "../store.js";
 import { SideBarBrandFoot } from "../components/side-bar-brand-foot.js";
 import { applyVisibleReorder, groupDropIndexFromPoint, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderGroupIds, reorderWithinSegment, type DropSectionInfo } from "./operations-side-bar-hit-test.js";
@@ -112,10 +112,12 @@ interface TheaterSectionHeaderProps {
   readonly onContextMenu: (anchor: DOMRect) => void;
 }
 
-interface TheaterPeekSectionProps {
+interface TheaterInactiveSectionProps {
   readonly theater: TheaterInfo;
   readonly entries: readonly SideBarEntry[];
   readonly groups: readonly OperationGroup[];
+  readonly collapsedGroups: ReadonlySet<string>;
+  readonly operationAccent: Readonly<Record<string, string>>;
   readonly operationCount: number;
   readonly collapsed: boolean;
   readonly onSelectTheater: (theaterId: string) => void;
@@ -139,8 +141,6 @@ const CLOSE_ARM_DURATION_MS = 1500;
 const DRAG_THRESHOLD_PX = 6;
 const AUTO_SCROLL_EDGE_PX = 34;
 const AUTO_SCROLL_STEP_PX = 18;
-const PEEK_CHIP_LIMIT = 4;
-
 export function OperationsSideBar({
   theaters,
   activeTheaterId,
@@ -523,11 +523,12 @@ export function OperationsSideBar({
           const theaterOperationCount = operations.filter((operation) => operation.theaterId === theater.id).length;
           const theaterCollapsed = collapsedTheaters.includes(theater.id);
           if (!isActiveTheater) {
-            const peekEntries = buildTheaterEntries({
+            const theaterCanvas = getTheaterCanvasSnapshot(theater.id);
+            const inactiveEntries = buildTheaterEntries({
               theaterId: theater.id,
               operations,
-              operationOrder: canvas.operationOrder,
-              minimizedSet,
+              operationOrder: theaterCanvas.operationOrder,
+              minimizedSet: new Set(theaterCanvas.minimized),
               // 비활성 Theater의 칩은 캔버스에 없으므로 활성(brass/aria-current) 표시 대상이 아니다(Codex P3).
               activeOperationId: null,
               operationNotifications,
@@ -536,11 +537,13 @@ export function OperationsSideBar({
               renderKindIcon,
             });
             return (
-              <TheaterPeekSection
+              <TheaterInactiveSection
                 key={theater.id}
                 theater={theater}
-                entries={theaterCollapsed ? [] : peekEntries}
+                entries={theaterCollapsed ? [] : inactiveEntries}
                 groups={groups.filter((group) => group.theaterId === theater.id)}
+                collapsedGroups={new Set(theaterCanvas.collapsedGroups)}
+                operationAccent={theaterCanvas.operationAccent}
                 operationCount={theaterOperationCount}
                 collapsed={theaterCollapsed}
                 onSelectTheater={onSelectTheater}
@@ -908,10 +911,12 @@ function TheaterSectionHeader({
   );
 }
 
-function TheaterPeekSection({
+function TheaterInactiveSection({
   theater,
   entries,
   groups,
+  collapsedGroups,
+  operationAccent,
   operationCount,
   collapsed,
   onSelectTheater,
@@ -920,22 +925,11 @@ function TheaterPeekSection({
   onOpenActions,
   onOpenLaunch,
   onContextMenu,
-}: TheaterPeekSectionProps) {
-  // peek에서도 활성 섹션과 같은 그룹 구조를 유지한다 — 총 칩 수만 PEEK_CHIP_LIMIT로 제한하고,
-  // 잘려나간 수는 "+N more"로 알린다(그룹 소속이 안 보이는 착시를 막는다).
+}: TheaterInactiveSectionProps) {
   const sections = groupOperations(entries, groups, []);
-  let remaining = PEEK_CHIP_LIMIT;
-  let truncated = 0;
-  const visibleSections: typeof sections = [];
-  for (const section of sections) {
-    if (section.entries.length === 0) continue;
-    const take = section.entries.slice(0, Math.max(0, remaining));
-    truncated += section.entries.length - take.length;
-    remaining -= take.length;
-    if (take.length > 0) visibleSections.push({ ...section, entries: take });
-  }
+  const hasCustomGroups = sections.some((section) => section.group !== null);
   return (
-    <li className="side-bar-theater-section side-bar-theater-section--peek" data-theater-id={theater.id}>
+    <li className="side-bar-theater-section" data-theater-id={theater.id}>
       <TheaterSectionHeader
         theater={theater}
         operationCount={operationCount}
@@ -947,50 +941,67 @@ function TheaterPeekSection({
         onOpenLaunch={onOpenLaunch}
         onContextMenu={onContextMenu}
       />
-      {visibleSections.length > 0 ? (
-        <ol className="side-bar-peek-chips" aria-label={`${theater.label} preview operations`}>
-          {visibleSections.map((section) => {
+      {!collapsed && sections.length > 0 ? (
+        <ol className="side-bar-theater-groups" aria-label={`${theater.label} operations`}>
+          {sections.map((section) => {
+            const isCollapsed = section.groupId !== null && collapsedGroups.has(section.groupId);
             const grpColor = section.group ? resolveAccentColor(section.group.color) : null;
             return (
               <li
                 key={section.groupId ?? "__ungrouped__"}
-                className={section.groupId ? "side-bar-group-section side-bar-group-section--peek" : "side-bar-ungrouped-section"}
+                className={section.groupId ? "side-bar-group-section" : "side-bar-ungrouped-section"}
                 style={grpColor ? ({ "--grp-color": grpColor } as CSSProperties) : undefined}
               >
                 {section.group ? (
-                  <div className="side-bar-peek-group-label" aria-label={`Group ${section.group.name}`}>
-                    <span>{section.group.name}</span>
-                    <span className="side-bar-peek-group-count">{section.entries.length}</span>
+                  <OperationsSideBarGroupHeader
+                    group={section.group}
+                    count={section.entries.length}
+                    collapsed={isCollapsed}
+                    dragging={false}
+                    dragOffsetY={0}
+                    dropTarget={false}
+                    onToggle={(groupId) => toggleTheaterGroupCollapsed(theater.id, groupId)}
+                    onContextMenu={() => {}}
+                    onPointerDragStart={() => {}}
+                  />
+                ) : hasCustomGroups && section.entries.length > 0 ? (
+                  <div className="side-bar-ungrouped-label" aria-label="Ungrouped operations">
+                    <span>Ungrouped</span>
                   </div>
                 ) : null}
-                <ol className="side-bar-group-chips" aria-label={section.group ? section.group.name : "Ungrouped"}>
-                  {section.entries.map((entry, index) => (
-                    <OperationsSideBarChip
-                      key={entry.operation.id}
-                      entry={entry}
-                      index={index}
-                      isCloseArmed={false}
-                      accentValue={null}
-                      dragging={false}
-                      dragOffsetY={0}
-                      dropTarget={false}
-                      preview
-                      onArmClose={() => {}}
-                      onDisarmClose={() => {}}
-                      onClose={() => {}}
-                      onMinimize={() => {}}
-                      onFocus={onFocus}
-                      onKeyboardMove={() => {}}
-                      onPointerDragStart={() => {}}
-                      onOpenAccent={() => {}}
-                      onRename={() => {}}
-                    />
-                  ))}
-                </ol>
+                {!isCollapsed ? (
+                  <ol className="side-bar-group-chips" aria-label={section.group ? section.group.name : "Ungrouped"}>
+                    {section.entries.map((entry, index) => {
+                      const accentKey = operationAccent[entry.operation.id] ?? operationAccentFromNode(entry.operation);
+                      const accentValue = accentKey ? resolveAccentColor(accentKey) : null;
+                      return (
+                        <OperationsSideBarChip
+                          key={entry.operation.id}
+                          entry={entry}
+                          index={index}
+                          isCloseArmed={false}
+                          accentValue={accentValue}
+                          dragging={false}
+                          dragOffsetY={0}
+                          dropTarget={false}
+                          preview
+                          onArmClose={() => {}}
+                          onDisarmClose={() => {}}
+                          onClose={() => {}}
+                          onMinimize={() => {}}
+                          onFocus={onFocus}
+                          onKeyboardMove={() => {}}
+                          onPointerDragStart={() => {}}
+                          onOpenAccent={() => {}}
+                          onRename={() => {}}
+                        />
+                      );
+                    })}
+                  </ol>
+                ) : null}
               </li>
             );
           })}
-          {truncated > 0 ? <li className="side-bar-peek-more">+{truncated} more</li> : null}
         </ol>
       ) : null}
     </li>

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2035,8 +2035,7 @@
 }
 
 .side-bar-theater-section,
-.side-bar-theater-groups,
-.side-bar-peek-chips {
+.side-bar-theater-groups {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -2053,15 +2052,6 @@
   border-top: 1px solid var(--surface-rim);
   border-bottom: 1px solid var(--surface-rim);
   background: transparent;
-}
-
-.side-bar-theater-section--peek {
-  opacity: 0.62;
-}
-
-.side-bar-theater-section--peek:hover,
-.side-bar-theater-section--peek:focus-within {
-  opacity: 0.9;
 }
 
 .side-bar-theater-header {
@@ -2171,49 +2161,10 @@
   outline: none;
 }
 
-.side-bar-theater-groups,
-.side-bar-peek-chips {
+.side-bar-theater-groups {
   display: flex;
   flex-direction: column;
   gap: 2px;
-}
-
-.side-bar-peek-chips .side-bar-chip {
-  pointer-events: auto;
-}
-
-/* peek 섹션의 그룹 라벨 — 활성 그룹 헤더의 축약형(비인터랙티브, 색 레일은 side-bar-group-section 공유).
-   과거 '유령 세로선' 보고의 진범은 그룹 레일이 아니라 컴포지팅 심(위 contain:paint로 격납)이었다. */
-.side-bar-peek-group-label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-  padding: 2px 6px 2px 4px;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--ink-fog);
-}
-
-.side-bar-peek-group-label span:first-child {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.side-bar-peek-group-count {
-  color: var(--ink-rim);
-}
-
-.side-bar-peek-more {
-  list-style: none;
-  padding: 2px 6px;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  color: var(--ink-rim);
 }
 
 /* 베이스 .theater-menu의 left/right:0(구 GNB 240px 컨테이너 전제)을 해제 —

--- a/runtime/fleet-console/tests/canvas-store.test.ts
+++ b/runtime/fleet-console/tests/canvas-store.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { calculateGridSlots, clearFormationView, clearMaximizedOperationId, getFormationLayout, getFormationView, getMaximizedOperationId, getSnapshot, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, selectFormationLayout, setFormationLayout, setMaximizedOperationId, setOperationAccent, setOperationGeometry, setOperationOrder, toggleFormationView, type OperationGeometry } from "../core/client/src/canvas/canvas-store.js";
+import { calculateGridSlots, clearFormationView, clearMaximizedOperationId, getFormationLayout, getFormationView, getMaximizedOperationId, getSnapshot, getTheaterCanvasSnapshot, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, selectFormationLayout, setFormationLayout, setMaximizedOperationId, setOperationAccent, setOperationGeometry, setOperationOrder, toggleFormationView, toggleTheaterGroupCollapsed, type OperationGeometry } from "../core/client/src/canvas/canvas-store.js";
 
 const GEOMETRY: OperationGeometry = { x: 0, y: 0, width: 100, height: 100, zIndex: 0 };
 
@@ -125,6 +125,41 @@ describe("canvas store", () => {
     loadForTheater("theater-b");
     expect(getSnapshot().minimized).toEqual([]);
     expect(getSnapshot().operations["op-b"]).toMatchObject({ x: 96, y: 144 });
+  });
+
+  it("reads and toggles collapsed groups for an inactive Theater without changing the loaded canvas", () => {
+    window.localStorage.setItem("fleet-console.canvas.theater-b", JSON.stringify({
+      viewport: { x: 0, y: 0, zoom: 1 },
+      operations: { "op-b": GEOMETRY },
+      operationOrder: ["op-b"],
+      operationAccent: { "op-b": "rose" },
+      minimized: ["op-b"],
+      collapsedGroups: ["group-b"],
+    }));
+
+    setOperationOrder(["op-a"]);
+    expect(getTheaterCanvasSnapshot("theater-b")).toMatchObject({
+      operationOrder: ["op-b"],
+      operationAccent: { "op-b": "rose" },
+      minimized: ["op-b"],
+      collapsedGroups: ["group-b"],
+    });
+
+    toggleTheaterGroupCollapsed("theater-b", "group-b");
+
+    expect(getSnapshot().operationOrder).toEqual(["op-a"]);
+    expect(getTheaterCanvasSnapshot("theater-b").collapsedGroups).toEqual([]);
+  });
+
+  it("restores each Theater's collapsed groups across A → B → A", () => {
+    toggleTheaterGroupCollapsed("theater-a", "group-a");
+
+    loadForTheater("theater-b");
+    toggleTheaterGroupCollapsed("theater-b", "group-b");
+    expect(getSnapshot().collapsedGroups).toEqual(["group-b"]);
+
+    loadForTheater("theater-a");
+    expect(getSnapshot().collapsedGroups).toEqual(["group-a"]);
   });
 
   it("keeps maximize-docked Operations minimized when entering open-panel Formation", () => {

--- a/runtime/fleet-console/tests/operations-side-bar-inactive-theater.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-inactive-theater.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { loadForTheater } from "../core/client/src/canvas/canvas-store.js";
+import { OperationsSideBar } from "../core/client/src/sidebar/operations-side-bar.js";
+import { setSideBarCollapsed, setTheaterCollapsed } from "../core/client/src/sidebar/operations-side-bar-store.js";
+import type { OperationGroup, OperationNode, TheaterInfo } from "../core/client/src/types.js";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  window.localStorage.clear();
+  setSideBarCollapsed(false);
+  setTheaterCollapsed("theater-a", false);
+  setTheaterCollapsed("theater-b", false);
+  loadForTheater("theater-a");
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  loadForTheater(null);
+});
+
+describe("inactive Theater sidebar hierarchy", () => {
+  it("renders every stored Operation in its group and ungrouped sections without a more summary", () => {
+    const onFocus = vi.fn();
+    writeTheaterBSnapshot();
+    renderSideBar(onFocus);
+
+    const inactive = findInactiveSection();
+    expect(inactive.querySelectorAll("[data-side-bar-chip-id]")).toHaveLength(6);
+    expect(inactive.querySelectorAll(".side-bar-group-section [data-side-bar-chip-id]")).toHaveLength(5);
+    expect(Array.from(inactive.querySelectorAll<HTMLElement>("[data-side-bar-chip-id]")).map((chip) => chip.dataset.sideBarChipId)).toEqual([
+      "op-b-5", "op-b-4", "op-b-3", "op-b-2", "op-b-1", "op-b-free",
+    ]);
+    expect(inactive.querySelector('[data-side-bar-chip-id="op-b-5"]')?.className).toContain("side-bar-chip--minimized");
+    expect(inactive.querySelector<HTMLElement>('[data-side-bar-chip-id="op-b-5"]')?.style.getPropertyValue("--user-accent")).not.toBe("");
+    expect(inactive.querySelector(".side-bar-ungrouped-label")?.textContent).toContain("Ungrouped");
+    expect(inactive.textContent).not.toContain("more");
+    expect(inactive.querySelector(".side-bar-group-header")).not.toBeNull();
+
+    act(() => inactive.querySelector<HTMLElement>('[data-side-bar-chip-id="op-b-5"]')?.click());
+    expect(onFocus).toHaveBeenCalledWith("op-b-5");
+  });
+
+  it("displays and toggles the inactive Theater's persisted collapsed group state", () => {
+    writeTheaterBSnapshot(["group-b"]);
+    renderSideBar();
+
+    const inactive = findInactiveSection();
+    const toggle = inactive.querySelector<HTMLButtonElement>('[aria-label="Expand group Bridge crew"]');
+    expect(toggle).not.toBeNull();
+    expect(inactive.querySelectorAll(".side-bar-group-section [data-side-bar-chip-id]")).toHaveLength(0);
+
+    act(() => toggle?.click());
+
+    expect(inactive.querySelector<HTMLButtonElement>('[aria-label="Collapse group Bridge crew"]')).not.toBeNull();
+    expect(inactive.querySelectorAll(".side-bar-group-section [data-side-bar-chip-id]")).toHaveLength(5);
+    expect(JSON.parse(window.localStorage.getItem("fleet-console.canvas.theater-b") ?? "{}").collapsedGroups).toEqual([]);
+  });
+
+  it("hides inactive Group headers and Operations when the Theater section is collapsed", () => {
+    writeTheaterBSnapshot();
+    setTheaterCollapsed("theater-b", true);
+    renderSideBar();
+
+    const inactive = findInactiveSection();
+    expect(inactive.querySelector(".side-bar-group-header")).toBeNull();
+    expect(inactive.querySelector("[data-side-bar-chip-id]")).toBeNull();
+  });
+});
+
+function renderSideBar(onFocus = vi.fn()): void {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  act(() => root?.render(createElement(MemoryRouter, null, createElement(OperationsSideBar, {
+    theaters: [makeTheater("theater-a", "Alpha"), makeTheater("theater-b", "Bravo")],
+    activeTheaterId: "theater-a",
+    operations: [makeOperation("op-a", "theater-a"), ...THEATER_B_OPERATIONS],
+    groups: [GROUP_B],
+    minimized: [],
+    activeOperationId: "op-a",
+    operationNotifications: {},
+    catalog: [],
+    canLaunch: true,
+    addingTheater: false,
+    theaterError: null,
+    renderKindIcon: () => null,
+    onLaunchKind: () => {},
+    onResetView: () => {},
+    onClose: () => {},
+    onMinimize: () => {},
+    onFocus,
+    onSetAccent: () => {},
+    onRename: () => {},
+    onSetGroupId: () => {},
+    onCreateGroup: () => {},
+    onSetGroupColor: () => {},
+    onRenameGroup: () => {},
+    onReorderGroups: () => {},
+    onUngroupAll: () => {},
+    onSelectTheater: () => {},
+    onAddTheater: () => {},
+    onCancelAddTheater: () => {},
+    onForgetTheater: () => {},
+  }))));
+}
+
+function findInactiveSection(): HTMLElement {
+  const inactive = container?.querySelector<HTMLElement>('[data-theater-id="theater-b"]');
+  if (!inactive) throw new Error("Missing inactive Theater section");
+  return inactive;
+}
+
+function writeTheaterBSnapshot(collapsedGroups: readonly string[] = []): void {
+  window.localStorage.setItem("fleet-console.canvas.theater-b", JSON.stringify({
+    viewport: { x: 0, y: 0, zoom: 1 },
+    operations: Object.fromEntries(THEATER_B_OPERATIONS.map((operation) => [operation.id, { x: 0, y: 0, width: 640, height: 400, zIndex: 0 }])),
+    operationOrder: ["op-b-5", "op-b-4", "op-b-3", "op-b-2", "op-b-1", "op-b-free"],
+    operationAccent: { "op-b-5": "rose" },
+    minimized: ["op-b-5"],
+    collapsedGroups,
+  }));
+}
+
+function makeTheater(id: string, label: string): TheaterInfo {
+  return { id, label, createdAt: "2026-01-01T00:00:00.000Z", lastOpenedAt: "2026-01-01T00:00:00.000Z", hasWiki: false, activeAdmiralCount: 0 };
+}
+
+function makeOperation(id: string, theaterId: string, groupId: string | null = null): OperationNode {
+  return {
+    id,
+    theaterId,
+    type: "shell",
+    pluginId: "terminal",
+    title: id,
+    payload: {},
+    geometry: null,
+    groupId,
+    ts: { createdAt: 1, updatedAt: 1 },
+  };
+}
+
+const GROUP_B: OperationGroup = { id: "group-b", name: "Bridge crew", color: "blue", order: 0, theaterId: "theater-b", createdAt: 1 };
+const THEATER_B_OPERATIONS = [
+  makeOperation("op-b-1", "theater-b", "group-b"),
+  makeOperation("op-b-2", "theater-b", "group-b"),
+  makeOperation("op-b-3", "theater-b", "group-b"),
+  makeOperation("op-b-4", "theater-b", "group-b"),
+  makeOperation("op-b-5", "theater-b", "group-b"),
+  makeOperation("op-b-free", "theater-b"),
+];

--- a/runtime/fleet-console/vitest.config.ts
+++ b/runtime/fleet-console/vitest.config.ts
@@ -19,6 +19,6 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.{ts,tsx}"],
   },
 });


### PR DESCRIPTION
## Summary

- Render every inactive Theater Operation and Group without peek truncation or faded preview styling.
- Preserve each Theater's group collapse, Operation order, minimized, and accent state while keeping inactive Operation actions focus-only.
- Add collected component and canvas-store regressions for full hierarchy and Theater switching.

## Type of Change

- [ ] feat — new feature or carrier capability
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- [x] `runtime/fleet-console`
- [ ] Documentation (README / SETUP / AGENTS.md)

## Test Plan

- [x] `vitest run tests/canvas-store.test.ts tests/operations-side-bar-inactive-theater.test.tsx tests/operations-side-bar-group.test.ts` — 3 files, 71 tests passed
- [x] `tsc --noEmit -p core/client/tsconfig.json`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Headed isolated Console E2E: 6 inactive Operations, Group/Ungrouped hierarchy, collapse/expand, reload, and Theater round trip

## Changelog

- [x] Added `.changelog.d/pr-275.md`.
- [x] Validated grouped syntax, bilingual summaries, and fragment compilation.

## Notes for Reviewers

- Inactive Operation chips intentionally remain focus-only; destructive and canvas-local actions still require their Theater to be active.
- The package-wide `typecheck` baseline fails unchanged on `canary` for CSS side-effect and `virtual:fleet-plugins` declarations; the changed client TypeScript surface passes its dedicated config.