### PR TITLE
feat(console): resolve provider session titles

### DIFF
--- a/.changelog.d/pr-277.md
+++ b/.changelog.d/pr-277.md
@@ -1,0 +1,14 @@
+### fleet-console
+#### Changed
+- [fleet-console] Name Operations from provider session identity metadata while preserving Console user rename precedence.
+  ko: provider 세션 identity 메타데이터로 Operation 이름을 지정하고 Console 사용자 이름 변경 우선순위를 유지합니다.
+
+### fleet-plugin
+#### Changed
+- [fleet-console] Keep provider session identity markers server-only and refresh titles safely across turns and session replacement.
+  ko: provider 세션 identity marker를 서버 전용으로 유지하고 턴과 세션 교체 사이에서 제목을 안전하게 갱신합니다.
+
+### fleet-core
+#### Changed
+- [core-unified-agent] Bind provider-neutral session identity resolvers at Agent CLI launch while preserving Codex prompt auto-naming.
+  ko: Agent CLI 실행 시 provider 중립 session identity resolver를 결합하고 Codex prompt auto-name을 유지합니다.

--- a/packages/core-unified-agent/package.json
+++ b/packages/core-unified-agent/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.2.1",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.212",
     "@dotobokuri/core-process": "workspace:*",
     "picocolors": "^1.1.1",
     "zod": "^4.3.6"

--- a/packages/core-unified-agent/src/client/SessionIdentityResolver.ts
+++ b/packages/core-unified-agent/src/client/SessionIdentityResolver.ts
@@ -1,0 +1,125 @@
+import type { SDKSessionInfo } from '@anthropic-ai/claude-agent-sdk';
+import { CLI_BACKENDS } from '../config/CliConfigs.js';
+import { CodexAppServerConnection } from '../connection/CodexAppServerConnection.js';
+
+const SESSION_IDENTITY_TIMEOUT_MS = 5_000;
+
+/** Opaque, provider-neutral runtime contract for resolving an existing session title. */
+export interface SessionIdentityResolver {
+  resolve(providerSessionId: string): Promise<string | null>;
+}
+
+/** Spawn-time provider specialization used to construct an opaque resolver. */
+export interface SessionIdentityResolverOptions {
+  provider: 'claude' | 'codex';
+  cwd: string;
+  /** Spawn-resolved executable, for example a profile-specific CLI binary. */
+  command?: string;
+  /** Spawn-resolved arguments that must precede Codex's app-server arguments. */
+  commandPrefixArgs?: readonly string[];
+  /** Complete app-server argument list for isolated tests or custom callers. */
+  args?: string[];
+  env?: Record<string, string | undefined>;
+}
+
+/**
+ * Creates the provider-specific identity adapter once at launch. Consumers retain
+ * only SessionIdentityResolver and must not branch on provider after launch.
+ */
+export function createSessionIdentityResolver(
+  options: SessionIdentityResolverOptions,
+): SessionIdentityResolver {
+  const cwd = options.cwd;
+  if (options.provider === 'claude') {
+    return {
+      resolve: (sessionId) => withIdentityTimeout(
+        async () => {
+          const { getSessionInfo } = await import('@anthropic-ai/claude-agent-sdk');
+          const info: SDKSessionInfo | undefined = await getSessionInfo(sessionId, { dir: cwd });
+          if (!info) {
+            return null;
+          }
+          const customTitle = normalizeTitle(info.customTitle);
+          if (customTitle) {
+            return customTitle;
+          }
+          const summary = normalizeTitle(info.summary);
+          return summary && summary !== normalizeTitle(info.firstPrompt) ? summary : null;
+        },
+      ),
+    };
+  }
+
+  const backend = CLI_BACKENDS.codex;
+  const command = options.command ?? backend.cliCommand;
+  const args = options.args
+    ? [...options.args]
+    : [...(options.commandPrefixArgs ?? []), ...(backend.appServerArgs ?? [])];
+  const env = options.env;
+  return {
+    resolve: (sessionId) => {
+      let connection: CodexAppServerConnection | null = null;
+      return withIdentityTimeout(
+        async () => {
+          connection = new CodexAppServerConnection({
+            command,
+            args,
+            cwd,
+            env,
+            requestTimeout: SESSION_IDENTITY_TIMEOUT_MS,
+            initTimeout: SESSION_IDENTITY_TIMEOUT_MS,
+          });
+          let rejectConnectionFailure: (error: Error) => void = () => {};
+          const connectionFailure = new Promise<never>((_, reject) => {
+            rejectConnectionFailure = reject;
+          });
+          const errorListener = (error: Error) => rejectConnectionFailure(error);
+          // Keep this listener for the short-lived connection. Removing it before
+          // or during child termination would recreate EventEmitter's fatal error
+          // window for late spawn/protocol failures.
+          connection.on('error', errorListener);
+          try {
+            return await Promise.race([
+              (async () => {
+                await connection!.connect({ skipThreadStart: true });
+                const response = await connection!.readThread(sessionId);
+                return normalizeTitle(response.thread.name);
+              })(),
+              connectionFailure,
+            ]);
+          } finally {
+            await connection.disconnect().catch(() => {});
+          }
+        },
+        () => {
+          void connection?.disconnect().catch(() => {});
+        },
+      );
+    },
+  };
+}
+
+function normalizeTitle(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim().replace(/\s+/g, ' ');
+  return normalized || null;
+}
+
+function withIdentityTimeout(
+  resolve: () => Promise<string | null>,
+  onTimeout?: () => void,
+): Promise<string | null> {
+  const settled = Promise.resolve().then(resolve).catch(() => null);
+  return new Promise((complete) => {
+    const timer = setTimeout(() => {
+      onTimeout?.();
+      complete(null);
+    }, SESSION_IDENTITY_TIMEOUT_MS);
+    void settled.then((value) => {
+      clearTimeout(timer);
+      complete(value);
+    });
+  });
+}

--- a/packages/core-unified-agent/src/connection/CodexAppServerConnection.ts
+++ b/packages/core-unified-agent/src/connection/CodexAppServerConnection.ts
@@ -32,6 +32,8 @@ import type {
   CodexReasoningSummaryTextDeltaNotification,
   CodexReasoningTextDeltaNotification,
   CodexThreadArchiveResponse,
+  CodexThreadReadParams,
+  CodexThreadReadResponse,
   CodexThreadResumeResponse,
   CodexThreadStartResponse,
   CodexTurnCompletedNotification,
@@ -310,6 +312,17 @@ export class CodexAppServerConnection extends BaseConnection {
     this.turnId = null;
     this.setState('ready');
     return response;
+  }
+
+  /** Reads existing thread metadata without resuming it or loading its turns. */
+  async readThread(threadId: string): Promise<CodexThreadReadResponse> {
+    return this.sendRequest<CodexThreadReadResponse>(
+      CODEX_METHODS.THREAD_READ,
+      {
+        threadId,
+        includeTurns: false,
+      } satisfies CodexThreadReadParams,
+    );
   }
 
   async sendMessage(

--- a/packages/core-unified-agent/src/index.ts
+++ b/packages/core-unified-agent/src/index.ts
@@ -50,6 +50,11 @@ export type {
 // === 연결 모듈 ===
 export { BaseConnection, type BaseConnectionOptions } from './connection/BaseConnection.js';
 export { AcpConnection, createIdleTimeoutRace, type AcpConnectionOptions, type AcpConnectionEventMap } from './connection/AcpConnection.js';
+export {
+  createSessionIdentityResolver,
+  type SessionIdentityResolver,
+  type SessionIdentityResolverOptions,
+} from './client/SessionIdentityResolver.js';
 
 // === CLI 감지 ===
 export { CliDetector } from './detector/CliDetector.js';

--- a/packages/core-unified-agent/src/types/codex-app-server.ts
+++ b/packages/core-unified-agent/src/types/codex-app-server.ts
@@ -60,6 +60,20 @@ export interface CodexThreadResumeResponse {
   thread: CodexThreadInfo;
 }
 
+export interface CodexThreadReadParams {
+  threadId: string;
+  includeTurns: boolean;
+}
+
+/** Metadata returned by the stable `thread/read` method. */
+export interface CodexThreadReadResponse {
+  thread: CodexThreadInfo & {
+    name?: string | null;
+    /** Deliberately distinct from name: it is not an identity fallback. */
+    preview?: string | null;
+  };
+}
+
 export interface CodexThreadArchiveParams {
   threadId: string;
 }
@@ -334,6 +348,7 @@ export const CODEX_METHODS = {
   INITIALIZE: 'initialize',
   THREAD_START: 'thread/start',
   THREAD_RESUME: 'thread/resume',
+  THREAD_READ: 'thread/read',
   THREAD_ARCHIVE: 'thread/archive',
   TURN_START: 'turn/start',
   TURN_INTERRUPT: 'turn/interrupt',

--- a/packages/core-unified-agent/tests/unit/CodexAppServerConnection.lifecycle.test.ts
+++ b/packages/core-unified-agent/tests/unit/CodexAppServerConnection.lifecycle.test.ts
@@ -82,6 +82,24 @@ describe('CodexAppServerConnection lifecycle', () => {
     expect(readOutgoingMethods(child)).toEqual(['initialize', 'thread/start', 'thread/resume']);
   });
 
+  it('thread/read는 resume 없이 turns를 제외하고 요청한다', async () => {
+    await establishSession(connection, child);
+
+    const readPromise = connection.readThread('thread-read');
+    expect(lastOutgoingMessage(child)).toMatchObject({
+      method: 'thread/read',
+      params: { threadId: 'thread-read', includeTurns: false },
+    });
+    child.stdout.emit('data', `${jsonRpcResult(3, {
+      thread: { id: 'thread-read', name: 'Provider title', preview: 'ignored' },
+    })}\n`);
+
+    await expect(readPromise).resolves.toEqual({
+      thread: { id: 'thread-read', name: 'Provider title', preview: 'ignored' },
+    });
+    expect(readOutgoingMethods(child)).not.toContain('thread/resume');
+  });
+
   it('initialize → thread/start → turn/completed까지 연결 lifecycle을 처리한다', async () => {
     const promptComplete = vi.fn();
     connection.on('promptComplete', promptComplete);

--- a/packages/core-unified-agent/tests/unit/SessionIdentityResolver.enoent.test.ts
+++ b/packages/core-unified-agent/tests/unit/SessionIdentityResolver.enoent.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.unmock('../../src/connection/CodexAppServerConnection.js');
+
+const { createSessionIdentityResolver } = await import('../../src/client/SessionIdentityResolver.js');
+
+describe('SessionIdentityResolver real Codex spawn failure', () => {
+  const uncaughtExceptions: Error[] = [];
+  const unhandledRejections: unknown[] = [];
+  const onUncaughtException = (error: Error) => uncaughtExceptions.push(error);
+  const onUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason);
+
+  afterEach(() => {
+    process.off('uncaughtException', onUncaughtException);
+    process.off('unhandledRejection', onUnhandledRejection);
+    uncaughtExceptions.length = 0;
+    unhandledRejections.length = 0;
+  });
+
+  it('fails closed for an impossible absolute executable without process-level errors', async () => {
+    process.on('uncaughtException', onUncaughtException);
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    const result = await createSessionIdentityResolver({
+      provider: 'codex',
+      cwd: process.cwd(),
+      command: '/definitely-missing/fleet-codex-identity-reader',
+    }).resolve('codex-thread-that-does-not-matter');
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(result).toBeNull();
+    expect(uncaughtExceptions).toEqual([]);
+    expect(unhandledRejections).toEqual([]);
+  });
+});

--- a/packages/core-unified-agent/tests/unit/SessionIdentityResolver.test.ts
+++ b/packages/core-unified-agent/tests/unit/SessionIdentityResolver.test.ts
@@ -1,0 +1,149 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getSessionInfo: vi.fn(),
+  connection: null as any,
+}));
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  getSessionInfo: mocks.getSessionInfo,
+}));
+
+vi.mock('../../src/connection/CodexAppServerConnection.js', () => ({
+  CodexAppServerConnection: vi.fn(() => mocks.connection),
+}));
+
+const { createSessionIdentityResolver } = await import('../../src/client/SessionIdentityResolver.js');
+const { CodexAppServerConnection } = await import('../../src/connection/CodexAppServerConnection.js');
+
+describe('SessionIdentityResolver', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.connection = Object.assign(new EventEmitter(), {
+      connect: vi.fn().mockResolvedValue(undefined),
+      readThread: vi.fn().mockResolvedValue({ thread: { id: 'codex-1', name: '  Codex title  ' } }),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses Claude customTitle before summary and passes cwd to the official SDK', async () => {
+    mocks.getSessionInfo.mockResolvedValue({
+      customTitle: '  User-set title  ',
+      summary: 'Summary',
+      firstPrompt: 'Prompt',
+    });
+
+    await expect(createSessionIdentityResolver({ provider: 'claude', cwd: '/work' }).resolve('claude-1'))
+      .resolves.toBe('User-set title');
+    expect(mocks.getSessionInfo).toHaveBeenCalledWith('claude-1', { dir: '/work' });
+  });
+
+  it('rejects Claude summary when its normalized form is the first prompt', async () => {
+    mocks.getSessionInfo.mockResolvedValue({
+      summary: '  same   prompt ',
+      firstPrompt: 'same prompt',
+    });
+
+    await expect(createSessionIdentityResolver({ provider: 'claude', cwd: '/work' }).resolve('claude-1'))
+      .resolves.toBeNull();
+  });
+
+  it('returns null for malformed or empty Claude metadata', async () => {
+    mocks.getSessionInfo.mockResolvedValue({ summary: '   ', firstPrompt: 'Prompt' });
+    await expect(createSessionIdentityResolver({ provider: 'claude', cwd: '/work' }).resolve('claude-1'))
+      .resolves.toBeNull();
+    mocks.getSessionInfo.mockResolvedValue(undefined);
+    await expect(createSessionIdentityResolver({ provider: 'claude', cwd: '/work' }).resolve('claude-2'))
+      .resolves.toBeNull();
+  });
+
+  it('preserves the resolved Codex executable and prefix before app-server arguments', async () => {
+    const resolver = createSessionIdentityResolver({
+      provider: 'codex',
+      cwd: '/work',
+      command: '/profiles/team/bin/codex',
+      commandPrefixArgs: ['--profile', 'team'],
+    });
+
+    await expect(resolver.resolve('codex-1')).resolves.toBe('Codex title');
+    expect(CodexAppServerConnection).toHaveBeenCalledWith(expect.objectContaining({
+      command: '/profiles/team/bin/codex',
+      args: ['--profile', 'team', 'app-server', '--listen', 'stdio://'],
+      cwd: '/work',
+    }));
+    expect(mocks.connection?.connect).toHaveBeenCalledWith({ skipThreadStart: true });
+    expect(mocks.connection?.readThread).toHaveBeenCalledWith('codex-1');
+    expect(mocks.connection?.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('selects the provider once and never re-branches while resolving', async () => {
+    const options = { provider: 'codex' as const, cwd: '/work' };
+    const resolver = createSessionIdentityResolver(options);
+    (options as { provider: 'claude' | 'codex' }).provider = 'claude';
+
+    await expect(resolver.resolve('codex-1')).resolves.toBe('Codex title');
+    expect(mocks.getSessionInfo).not.toHaveBeenCalled();
+    expect(mocks.connection?.readThread).toHaveBeenCalledWith('codex-1');
+  });
+
+  it('retains explicit complete args for isolated callers', async () => {
+    await createSessionIdentityResolver({
+      provider: 'codex',
+      cwd: '/work',
+      commandPrefixArgs: ['--ignored-prefix'],
+      args: ['app-server', '--test-stdio'],
+    }).resolve('codex-1');
+
+    expect(CodexAppServerConnection).toHaveBeenCalledWith(expect.objectContaining({
+      args: ['app-server', '--test-stdio'],
+    }));
+  });
+
+  it('explicitly ignores a Codex preview without a name', async () => {
+    mocks.connection?.readThread.mockResolvedValue({
+      thread: { id: 'codex-1', preview: 'Preview must not become a title' },
+    });
+
+    await expect(createSessionIdentityResolver({ provider: 'codex', cwd: '/work' }).resolve('codex-1'))
+      .resolves.toBeNull();
+  });
+
+  it('fails closed and cleans up when the resolved Codex executable is missing', async () => {
+    mocks.connection.connect.mockRejectedValue(new Error('spawn ENOENT'));
+
+    await expect(createSessionIdentityResolver({ provider: 'codex', cwd: '/work' }).resolve('codex-1'))
+      .resolves.toBeNull();
+    expect(mocks.connection.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles emitted Codex app-server errors without an uncaught EventEmitter exception', async () => {
+    mocks.connection.readThread.mockImplementation(() => new Promise(() => {}));
+    const result = createSessionIdentityResolver({ provider: 'codex', cwd: '/work' }).resolve('codex-1');
+    await vi.waitFor(() => expect(mocks.connection.connect).toHaveBeenCalled());
+
+    expect(() => mocks.connection.emit('error', new Error('app-server unavailable'))).not.toThrow();
+    await expect(result).resolves.toBeNull();
+    expect(mocks.connection.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('times out, starts Codex cleanup, and absorbs late completion failures', async () => {
+    vi.useFakeTimers();
+    mocks.connection?.readThread.mockImplementation(() => new Promise(() => {}));
+    const result = createSessionIdentityResolver({ provider: 'codex', cwd: '/work' }).resolve('codex-1');
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(result).resolves.toBeNull();
+    expect(() => mocks.connection.emit('error', new Error('late termination error'))).not.toThrow();
+    expect(mocks.connection?.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('is available from the package root export', async () => {
+    const root = await import('../../src/index.js');
+    expect(root.createSessionIdentityResolver).toBe(createSessionIdentityResolver);
+  });
+});

--- a/packages/fleet-admiral/src/agent-cli/injection.ts
+++ b/packages/fleet-admiral/src/agent-cli/injection.ts
@@ -31,7 +31,7 @@ export interface InjectAgentCliProfileOptions {
   readonly turnEndHookExec?: FleetHookExec;
   // 입력 대기(AskUserQuestion PreToolUse · 입력 대기 Notification) 신호 hook. Claude 전용 와이어링.
   readonly inputWaitingHookExec?: FleetHookExec;
-  // 작전명 자동 작명(UserPromptSubmit) hook. host가 빌드해 주입하며 claude/codex 양쪽에 와이어링된다.
+  // 작전명 자동 작명(UserPromptSubmit) hook. host가 빌드해 주입하며 Codex 고정 프로필에만 와이어링된다.
   readonly autoNameHookExec?: FleetHookExec;
   readonly codexCommandRunner?: (command: CodexPluginRegistrationCommand) => CodexCommandResult;
   readonly onCleanup?: (cleanup: () => void) => void;

--- a/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
@@ -26,8 +26,9 @@ export function renderAssetPluginRoot(
 }
 
 function claudeHooks(options: CreateAgentCliPluginOptions): unknown {
-  // UserPromptSubmit: 세션 캡처 + 턴 시작 + 자동 작명 신호를 같은 이벤트에 함께 건다(배열 순서대로 실행).
-  const userPromptSubmitExecs = [options.captureSessionHookExec, options.turnStartHookExec, options.autoNameHookExec]
+  // UserPromptSubmit: 세션 캡처 + 턴 시작 신호를 같은 이벤트에 건다(배열 순서대로 실행).
+  // 자동 작명은 Codex 고정 프로필 전용이며 Claude plugin hooks에는 렌더하지 않는다.
+  const userPromptSubmitExecs = [options.captureSessionHookExec, options.turnStartHookExec]
     .filter((exec): exec is FleetHookExec => exec !== undefined);
   // Stop: 턴 종료 신호.
   const stopExecs = [options.turnEndHookExec]

--- a/packages/fleet-admiral/src/agent-cli/plugin/types.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/types.ts
@@ -21,7 +21,7 @@ export interface CreateAgentCliPluginOptions {
   // 입력 대기(AskUserQuestion의 PreToolUse · permission/idle/elicitation Notification) 신호를 호스트로
   // 알리는 hook. AskUserQuestion은 Notification 훅을 발화하지 않으므로 두 이벤트 경로로 건다. Claude 전용.
   readonly inputWaitingHookExec?: FleetHookExec;
-  // 작전명 자동 작명(UserPromptSubmit)을 위해 prompt를 호스트로 전달하는 hook. claude/codex 양쪽에 와이어링된다.
+  // 작전명 자동 작명(UserPromptSubmit)을 위해 prompt를 호스트로 전달하는 hook. Codex 고정 프로필에만 와이어링된다.
   readonly autoNameHookExec?: FleetHookExec;
   readonly onCleanup?: (cleanup: () => void) => void;
   readonly rootDir?: string;

--- a/packages/fleet-admiral/tests/agent-cli-plugin-marketplace.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-plugin-marketplace.test.ts
@@ -129,7 +129,7 @@ describe("agent CLI plugin marketplace rendering", () => {
     ]);
   });
 
-  it("wires capture, turn-start, and auto-name hooks onto Claude UserPromptSubmit in order", async () => {
+  it("wires capture and turn-start, but not auto-name, onto Claude UserPromptSubmit in order", async () => {
     const root = mkdtempSync(path.join(os.tmpdir(), "fleet-admiral-plugin-uphooks-"));
     tempDirs.push(root);
     const dataDir = path.join(root, "data");
@@ -151,7 +151,8 @@ describe("agent CLI plugin marketplace rendering", () => {
       readonly hooks: Record<string, ReadonlyArray<{ readonly hooks: ReadonlyArray<{ readonly args: readonly string[] }> }>>;
     };
     const userPromptSubmit = hooksJson.hooks.UserPromptSubmit?.[0]?.hooks.map((hook) => hook.args[2]);
-    expect(userPromptSubmit).toEqual(["capture-session", "turn-start", "auto-name"]);
+    expect(userPromptSubmit).toEqual(["capture-session", "turn-start"]);
+    expect(hooksJson.hooks.Stop?.[0]?.hooks.map((hook) => hook.args[2])).toEqual(["turn-end"]);
   });
 
   it("prunes legacy Cursor plugin artifacts without generating new ones", async () => {

--- a/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
@@ -223,6 +223,33 @@ describe("agent CLI session resume and capture hooks", () => {
     expect(pluginJson.version).toMatch(/^0\.0\.0\+[0-9a-f]{12}$/);
   });
 
+  it("keeps Codex capture, turn-start, auto-name, and turn-end hooks in order", async () => {
+    const root = createTempRoot("fleet-admiral-codex-all-hooks-");
+    const codexHome = path.join(root, "codex-home");
+    const hookExecs = [
+      hookExec("capture", ["session"]),
+      hookExec("turn-start", []),
+      hookExec("auto-name", []),
+      hookExec("turn-end", []),
+    ];
+    const profile = baseProfile("codex", {
+      args: [],
+      cwd: root,
+      env: { CODEX_HOME: codexHome, HOME: root },
+    });
+
+    await injectAgentCliProfile(profile, baseInjectOptions(root, {
+      autoNameHookExec: hookExecs[2],
+      captureSessionHookExec: hookExecs[0],
+      turnEndHookExec: hookExecs[3],
+      turnStartHookExec: hookExecs[1],
+    }));
+
+    const toml = readFileSync(path.join(codexHome, "fleet.config.toml"), "utf8");
+    expect(readTomlBasicStringValues(toml, "command")).toEqual(hookExecs.map((exec) =>
+      buildHostShellCommand([exec.command, ...exec.args])));
+  });
+
   it.skipIf(process.platform !== "win32")("writes and executes a PowerShell-safe command_windows override for every Codex hook", async () => {
     const root = createTempRoot("fleet-admiral-codex-windows-hooks-");
     const codexHome = path.join(root, "codex-home");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       '@agentclientprotocol/sdk':
         specifier: ^1.2.1
         version: 1.2.1(zod@4.4.1)
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.3.212
+        version: 0.3.212(@anthropic-ai/sdk@0.112.1(zod@4.4.1))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(zod@4.4.1)
       '@dotobokuri/core-process':
         specifier: workspace:*
         version: link:../core-process
@@ -219,6 +222,9 @@ importers:
 
   runtime/fleet-console:
     dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.3.212
+        version: 0.3.212(@anthropic-ai/sdk@0.112.1(zod@4.4.1))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(zod@4.4.1)
       '@dotobokuri/core-agent':
         specifier: workspace:*
         version: link:../../packages/core-agent
@@ -627,6 +633,67 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.212':
+    resolution: {integrity: sha512-t9t5fP94XNslh5hIWlmwE0F7hrhEpnbzM6ddF9qjqyO3zT6XZQ3U/fT2wuM8WYdSpyAsOO+3WiABe1buzNVQbA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.212':
+    resolution: {integrity: sha512-0dgxPaf0+9lpOOpKYRXPtcXridq27QjhLFz/7UjVANy7roqcojdnwX4Wpjf8hII/URPkjLH+9PlAgZT3Ml1YIg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.212':
+    resolution: {integrity: sha512-oeQr+cQk65eost/O+ZAROQkME0o3affxfLiRWpJjb/focycvA3Z/Z1vI3z6QL+bswMcEGsHp88cXBLoDYC0nNQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.212':
+    resolution: {integrity: sha512-laU4i0eN5yq/H/utAfHKDjyugjvSnFuAfMhHYv8idF7PQxl+6YDahDd4gqVPdIifcZvrAsi1HXfpdKayYv6dJg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.212':
+    resolution: {integrity: sha512-MYs7C9UOqhwWv4GgEbGdD37BUp8C8ff6WPDupFHW6/html2wK0DAei72sWjTghoEiUJUlRcxay1nxPCiwB9w1A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.212':
+    resolution: {integrity: sha512-sUELD4LP2JLQeFZdven/7NPWS6/TIlE8aNwQJBj8+8RNF4XketoKUbmRdIBO6q8YpXFGn+4DVzirb+Cz6DIbuA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.212':
+    resolution: {integrity: sha512-fCtzLDJHy8jO4oaK/GC971f3npRWSdVhzDbh2uOQeqsWnHpGnHkxpUVBa7fVeEW5oTvXlRATgjDODjO+3CVLIg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.212':
+    resolution: {integrity: sha512-2DCQL7ZfzpoGo4kCzu+jqOifPOKUe+Zc6OgTiSDvatz/JGWxs0kV3jOTTjtxGCCUKpdKnflRjHzOHFjIKjODxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.3.212':
+    resolution: {integrity: sha512-BSowuUv7+EoeBo36oZbSox8uyY3dqyMLFolAoMyKW3uqAfZLDV8MpvjDsv+WDE+OGCkuWK60JIqfhyPhctGTgg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
+      zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.112.1':
+    resolution: {integrity: sha512-vPRhHWxG9gIDyI9anVET2tBkmMBOXyTpIFvQgUVveiAV0ihmQgBYzQHb/s9+pZ/FxprSWcQnj15YnRfPxOIEmg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@asamuzakjp/css-color@4.1.2':
     resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
 
@@ -718,6 +785,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
@@ -1029,6 +1100,12 @@ packages:
   '@fontsource-variable/source-code-pro@5.2.7':
     resolution: {integrity: sha512-kZ0VNwnhvSA7vu5MaiO52eicQ4zC+k+8HBLZb+1js0MK/RngLy25NEUFB1y/AKd0ZMwru88T433QBcFf9m/huw==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
@@ -1065,6 +1142,16 @@ packages:
 
   '@mermaid-js/parser@1.1.0':
     resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -1232,6 +1319,9 @@ packages:
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1517,6 +1607,10 @@ packages:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -1525,6 +1619,14 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
@@ -1599,6 +1701,10 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -1638,6 +1744,10 @@ packages:
     peerDependencies:
       esbuild: '>=0.18'
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   bytestreamjs@2.0.1:
     resolution: {integrity: sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==}
     engines: {node: '>=6.0.0'}
@@ -1656,6 +1766,10 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001799:
@@ -1764,8 +1878,28 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -1773,6 +1907,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cose-base@1.0.3:
     resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
@@ -2008,6 +2146,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -2039,6 +2181,9 @@ packages:
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -2069,6 +2214,10 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -2122,12 +2271,27 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -2140,8 +2304,21 @@ packages:
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
+  express-rate-limit@8.6.0:
+    resolution: {integrity: sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -2167,6 +2344,10 @@ packages:
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
@@ -2176,6 +2357,14 @@ packages:
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -2295,6 +2484,10 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
+  hono@4.12.30:
+    resolution: {integrity: sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -2305,6 +2498,10 @@ packages:
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -2320,6 +2517,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -2345,12 +2546,23 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -2382,6 +2594,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -2423,8 +2638,15 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
@@ -2517,6 +2739,14 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   mermaid@11.14.0:
     resolution: {integrity: sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==}
 
@@ -2524,9 +2754,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -2591,6 +2829,10 @@ packages:
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-abi@3.92.0:
     resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
     engines: {node: '>=10'}
@@ -2633,12 +2875,20 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2657,6 +2907,10 @@ packages:
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
@@ -2667,6 +2921,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2689,6 +2946,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -2768,6 +3029,10 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -2782,9 +3047,21 @@ packages:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
 
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -2884,6 +3161,10 @@ packages:
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
@@ -2926,12 +3207,23 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
 
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2940,6 +3232,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2981,9 +3289,16 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -3103,6 +3418,10 @@ packages:
     resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
@@ -3117,6 +3436,9 @@ packages:
 
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
@@ -3159,6 +3481,10 @@ packages:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typebox@1.1.34:
     resolution: {integrity: sha512-V0fM5W5DTXlEMDxqtX1dQ25HR1RQ11DPUVrIup4sJi1yQtIyI30SHfxBy/HjXKL1CtUqc5or2igA/wa/v4hMKQ==}
 
@@ -3197,6 +3523,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unzipper@0.12.5:
     resolution: {integrity: sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==}
 
@@ -3215,6 +3545,10 @@ packages:
   uuid@11.1.1:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -3499,6 +3833,11 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod@4.4.1:
     resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
 
@@ -3514,6 +3853,52 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.2
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.212':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.212':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.212':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.212':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.212':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.212':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.212':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.212':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.3.212(@anthropic-ai/sdk@0.112.1(zod@4.4.1))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(zod@4.4.1)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.112.1(zod@4.4.1)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.1)
+      zod: 4.4.1
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.212
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.212
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.212
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.212
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.212
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.212
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.212
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.212
+
+  '@anthropic-ai/sdk@0.112.1(zod@4.4.1)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.1
 
   '@asamuzakjp/css-color@4.1.2':
     dependencies:
@@ -3642,6 +4027,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.29.7':
     dependencies:
@@ -3914,6 +4301,10 @@ snapshots:
 
   '@fontsource-variable/source-code-pro@5.2.7': {}
 
+  '@hono/node-server@1.19.14(hono@4.12.30)':
+    dependencies:
+      hono: 4.12.30
+
   '@iconify/types@2.0.0': {}
 
   '@iconify/utils@3.1.3':
@@ -3961,6 +4352,28 @@ snapshots:
   '@mermaid-js/parser@1.1.0':
     dependencies:
       langium: 4.2.3
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.1)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.30)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.6.0(express@5.2.1)
+      hono: 4.12.30
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.1
+      zod-to-json-schema: 3.25.2(zod@4.4.1)
+    transitivePeerDependencies:
+      - supports-color
 
   '@noble/hashes@1.4.0': {}
 
@@ -4066,6 +4479,8 @@ snapshots:
     optional: true
 
   '@sindresorhus/is@4.6.0': {}
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4435,9 +4850,18 @@ snapshots:
 
   abbrev@4.0.0: {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv@8.20.0:
     dependencies:
@@ -4543,6 +4967,20 @@ snapshots:
 
   bluebird@3.7.2: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolean@3.2.0:
     optional: true
 
@@ -4606,6 +5044,8 @@ snapshots:
       esbuild: 0.27.7
       load-tsconfig: 0.2.5
 
+  bytes@3.1.2: {}
+
   bytestreamjs@2.0.1: {}
 
   cac@6.7.14: {}
@@ -4626,6 +5066,11 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001799: {}
 
@@ -4719,11 +5164,26 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cose-base@1.0.3:
     dependencies:
@@ -4992,6 +5452,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   detect-libc@2.1.2:
     optional: true
 
@@ -5032,6 +5494,8 @@ snapshots:
   duplexer2@0.1.4:
     dependencies:
       readable-stream: 2.3.8
+
+  ee-first@1.1.1: {}
 
   ejs@3.1.10:
     dependencies:
@@ -5100,6 +5564,8 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
+  encodeurl@2.0.0: {}
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
@@ -5165,12 +5631,22 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@4.0.0:
     optional: true
 
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  etag@1.8.1: {}
+
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
 
   expand-template@2.0.3:
     optional: true
@@ -5179,7 +5655,50 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
+  express-rate-limit@8.6.0(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   fast-deep-equal@3.1.3: {}
+
+  fast-sha256@1.3.0: {}
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -5201,6 +5720,17 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
       magic-string: 0.30.21
@@ -5216,6 +5746,10 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0:
     optional: true
@@ -5364,6 +5898,8 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
+  hono@4.12.30: {}
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -5375,6 +5911,14 @@ snapshots:
       - '@noble/hashes'
 
   http-cache-semantics@4.2.0: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -5399,6 +5943,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1:
     optional: true
 
@@ -5418,9 +5966,15 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   isarray@1.0.0: {}
 
@@ -5441,6 +5995,8 @@ snapshots:
       picocolors: 1.1.1
 
   jiti@2.7.0: {}
+
+  jose@6.2.3: {}
 
   joycon@3.1.1: {}
 
@@ -5515,7 +6071,14 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
+
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stringify-safe@5.0.1:
     optional: true
@@ -5596,6 +6159,10 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   mermaid@11.14.0:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
@@ -5622,9 +6189,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@2.6.0: {}
 
@@ -5683,6 +6256,8 @@ snapshots:
   napi-build-utils@2.0.0:
     optional: true
 
+  negotiator@1.0.0: {}
+
   node-abi@3.92.0:
     dependencies:
       semver: 7.7.4
@@ -5727,10 +6302,16 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-inspect@1.13.4: {}
+
   object-keys@1.1.1:
     optional: true
 
   obug@2.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -5748,11 +6329,15 @@ snapshots:
     dependencies:
       entities: 8.0.0
 
+  parseurl@1.3.3: {}
+
   path-data-parser@0.1.0: {}
 
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -5765,6 +6350,8 @@ snapshots:
   picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -5855,6 +6442,11 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -5868,7 +6460,21 @@ snapshots:
 
   pvutils@1.1.5: {}
 
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   quick-lru@5.1.1: {}
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -6000,6 +6606,16 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rw@1.3.3: {}
 
   safe-buffer@5.1.2: {}
@@ -6030,18 +6646,73 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
     optional: true
 
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@2.7.2: {}
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -6079,7 +6750,14 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   stat-mode@1.0.0: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -6213,6 +6891,8 @@ snapshots:
 
   tmp@0.2.7: {}
 
+  toidentifier@1.0.1: {}
+
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.30
@@ -6226,6 +6906,8 @@ snapshots:
   truncate-utf8-bytes@1.0.2:
     dependencies:
       utf8-byte-length: 1.0.5
+
+  ts-algebra@2.0.0: {}
 
   ts-dedent@2.2.0: {}
 
@@ -6304,6 +6986,12 @@ snapshots:
   type-fest@0.13.1:
     optional: true
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typebox@1.1.34: {}
 
   typescript@6.0.2: {}
@@ -6325,6 +7013,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   unzipper@0.12.5:
     dependencies:
       bluebird: 3.7.2
@@ -6344,6 +7034,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@11.1.1: {}
+
+  vary@1.1.2: {}
 
   vite-node@3.2.4(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
@@ -6693,5 +7385,9 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.1):
+    dependencies:
+      zod: 4.4.1
 
   zod@4.4.1: {}

--- a/runtime/fleet-console/package.json
+++ b/runtime/fleet-console/package.json
@@ -53,6 +53,7 @@
     "verify:desktop-protocol": "node verify-desktop-protocol-compatibility.mjs"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.212",
     "@dotobokuri/core-agent": "workspace:*",
     "@dotobokuri/core-process": "workspace:*",
     "@dotobokuri/core-unified-agent": "workspace:*",

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -296,6 +296,38 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(cleanup).toHaveBeenCalledTimes(1);
     expect(runtimeCleanup).not.toHaveBeenCalled();
   });
+
+  it("binds one opaque provider identity resolver during Agent CLI launch", async () => {
+    const createResolver = vi.fn(() => ({ resolve: async () => null }));
+    const resolve = createDefaultTerminalLaunchResolver({
+      cwd: "/work",
+      env: { PATH: "/bin" } as NodeJS.ProcessEnv,
+      agentRuntime: createFakeRuntime() as never,
+      injectProfile: (async (profile: AgentCliProfile) => profile) as never,
+      resolveProfile: (async () => ({ ...baseProfile, id: "codex", bin: "/custom/codex-wrapper", binPrefixArgs: ["--wrapper-prefix"] })) as never,
+      createSessionIdentityResolver: createResolver as never,
+    });
+
+    const spec = await resolve("/work", { sessionId: "session-a", cliId: "claude" });
+
+    expect(spec.sessionIdentityResolver).toMatchObject({ resolve: expect.any(Function) });
+    expect(createResolver).toHaveBeenCalledWith(expect.objectContaining({
+      provider: "codex",
+      command: "/custom/codex-wrapper",
+      commandPrefixArgs: ["--wrapper-prefix"],
+      cwd: "/work",
+    }));
+  });
+
+  it("does not bind an identity resolver for an explicit shell override", async () => {
+    const resolve = createDefaultTerminalLaunchResolver({
+      cwd: "/work",
+      env: { FLEET_TERMINAL_CMD: "bash -l" } as NodeJS.ProcessEnv,
+    });
+
+    const spec = await resolve("/work");
+    expect(spec.sessionIdentityResolver).toBeUndefined();
+  });
 });
 
 describe("resolveUseConptyDll", () => {

--- a/runtime/fleet-console/tests/operations.test.ts
+++ b/runtime/fleet-console/tests/operations.test.ts
@@ -46,6 +46,7 @@ describe("operations platform", () => {
         cwd: "/secret",
         canonicalCwd: "/secret",
         providerSession: { sessionId: "provider-secret" },
+        providerTitle: { source: "provider" },
         ticket: "ticket-secret",
         token: "token-secret",
         transcriptPath: "/secret/transcript.jsonl",
@@ -91,7 +92,7 @@ describe("operations platform", () => {
         Object.assign(res, { status, payload });
       },
       persist: () => {},
-      getPluginSensitiveFields: (pluginId) => (pluginId === "terminal" ? ["pluginSecret"] : []),
+      getPluginSensitiveFields: (pluginId) => (pluginId === "terminal" ? ["pluginSecret", "providerTitle"] : []),
     });
 
     const list = await dispatch(router, "GET", "/api/v1/operations");
@@ -101,12 +102,13 @@ describe("operations platform", () => {
       type: "agent",
       pluginId: "terminal",
       title: "Created",
-      payload: { pluginSecret: "created-secret", visible: "created" },
+      payload: { pluginSecret: "created-secret", providerTitle: { source: "provider" }, visible: "created" },
     };
     const created = await dispatch(router, "POST", "/api/v1/operations");
     requestBody = {
       payload: {
         pluginSecret: "patched-secret",
+        providerTitle: { source: "provider" },
         visible: "patched",
       },
     };
@@ -119,6 +121,7 @@ describe("operations platform", () => {
     expect(serialized).not.toContain("a-secret");
     expect(serialized).not.toContain("created-secret");
     expect(serialized).not.toContain("patched-secret");
+    expect(serialized).not.toContain("providerTitle");
   });
 
   it("sets, preserves, and clears operation accent through PATCH", async () => {

--- a/runtime/fleet-console/tests/published-manifest.test.ts
+++ b/runtime/fleet-console/tests/published-manifest.test.ts
@@ -10,6 +10,7 @@ describe("published Console manifest", () => {
       private: true,
       dependencies: {
         "node-pty": "^1.0.0",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.212",
         ws: "^8.18.0",
         "font-list": "^2.1.0",
         "@fleet-console/desktop-protocol": "workspace:*",
@@ -28,6 +29,6 @@ describe("published Console manifest", () => {
       expect(Object.values(entries).some((value) => typeof value === "string" && value.startsWith("workspace:"))).toBe(false);
     }
     expect(manifest.devDependencies).toEqual({ typescript: "^6.0.2" });
-    expect(manifest.dependencies).toEqual({ "node-pty": "^1.0.0", ws: "^8.18.0", "font-list": "^2.1.0" });
+    expect(manifest.dependencies).toEqual({ "node-pty": "^1.0.0", "@anthropic-ai/claude-agent-sdk": "^0.3.212", ws: "^8.18.0", "font-list": "^2.1.0" });
   });
 });

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -1207,7 +1207,7 @@ describe("console static and terminal ticket boundary", () => {
     expect(bootstrap.theaters.find((entry) => entry.id === theater.id)?.hasWiki).toBe(true);
   });
 
-  it.skip("rehydrates durable state as dormant without starting PTYs and merges capture files server-side", async () => {
+  it("rehydrates durable provider titles as dormant without starting PTYs", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-rehydrate-"));
     tempDirs.push(dir);
     const realpath = fs.realpathSync.native(dir);
@@ -1219,7 +1219,7 @@ describe("console static and terminal ticket boundary", () => {
         const capturesDir = path.join(consoleDir, "captures");
         fs.mkdirSync(capturesDir, { recursive: true });
         fs.writeFileSync(path.join(consoleDir, "state.json"), JSON.stringify({
-          version: 1,
+          version: 2,
           theaters: [{
             id: theaterId,
             path: dir,
@@ -1229,13 +1229,23 @@ describe("console static and terminal ticket boundary", () => {
             lastOpenedAt: "2026-06-16T00:00:01.000Z",
           }],
           operations: [{
-            sessionId: "session-a",
+            id: "session-a",
             theaterId,
-            cwd: dir,
-            cwdLabel: path.basename(dir),
-            cliId: "claude",
-            cliLabel: "Claude",
-            createdAt: 1_000,
+            title: "Durable provider title",
+            pluginId: "terminal",
+            type: "agent",
+            payload: {
+              cwd: dir,
+              cliId: "claude",
+              cliLabel: "Claude",
+              providerTitle: { source: "provider" },
+              providerSession: {
+                provider: "claude",
+                sessionId: "provider-session-secret",
+                capturedAt: "2026-06-16T00:00:02.000Z",
+              },
+            },
+            ts: { createdAt: 1_000, updatedAt: 1_000 },
           }],
         }));
         fs.writeFileSync(path.join(capturesDir, "session-a.json"), JSON.stringify({
@@ -1253,19 +1263,21 @@ describe("console static and terminal ticket boundary", () => {
     });
 
     const theaters = await getJson<{ readonly theaters: readonly Record<string, unknown>[] }>(`${fixture.endpoint}api/v1/theaters`);
-    const sessions = await getJson<{ readonly sessions: readonly Record<string, unknown>[] }>(`${fixture.endpoint}terminal/sessions`);
-    const state = JSON.parse(fs.readFileSync(path.join(fixture.carrierStoreDir, "console", "state.json"), "utf8")) as { readonly operations: ReadonlyArray<{ readonly providerSession?: unknown }> };
+    const sessions = await getJson<{ readonly sessions: readonly Record<string, unknown>[] }>(`${fixture.endpoint}plugins/terminal/agent/sessions`);
+    const state = JSON.parse(fs.readFileSync(path.join(fixture.carrierStoreDir, "console", "state.json"), "utf8")) as { readonly operations: ReadonlyArray<{ readonly title?: unknown; readonly payload?: { readonly providerSession?: unknown; readonly providerTitle?: unknown } }> };
     const serialized = JSON.stringify({ theaters, sessions });
 
     expect(startedShells).toEqual([]);
     expect(theaters.theaters[0]).toMatchObject({ id: theaterId, label: path.basename(dir) });
     expect(sessions.sessions[0]).toMatchObject({ sessionId: "session-a", status: "dormant", resumeAvailable: true });
-    expect(state.operations[0]?.providerSession).toMatchObject({ provider: "claude", sessionId: "provider-session-secret" });
-    expect(fs.existsSync(path.join(fixture.carrierStoreDir, "console", "captures", "session-a.json"))).toBe(false);
+    expect(sessions.sessions[0]).toMatchObject({ label: "Durable provider title" });
+    expect(state.operations[0]?.payload?.providerSession).toMatchObject({ provider: "claude", sessionId: "provider-session-secret" });
+    expect(state.operations[0]).toMatchObject({ title: "Durable provider title", payload: { providerTitle: { source: "provider" } } });
     expect(serialized).not.toContain(dir);
     expect(serialized).not.toContain("provider-session-secret");
     expect(serialized).not.toContain("transcript");
     expect(serialized).not.toContain("providerSession");
+    expect(serialized).not.toContain("providerTitle");
   });
 
   it("captures provider sessions through the session-scoped hook endpoint before exit persistence", async () => {
@@ -1325,6 +1337,188 @@ describe("console static and terminal ticket boundary", () => {
     const state = JSON.parse(fs.readFileSync(path.join(fixture.carrierStoreDir, "console", "state.json"), "utf8")) as { readonly operations: ReadonlyArray<{ readonly payload?: { readonly providerSession?: unknown } }> };
 
     expect(state.operations[0]?.payload?.providerSession).toMatchObject({ provider: "claude", sessionId: "provider-session-secret" });
+  });
+
+  it("acknowledges, deduplicates, persists, and sanitizes deferred provider identity refreshes", async () => {
+    const deferred = createDeferred<string | null>();
+    const resolverInputs: string[] = [];
+    const fixture = await startFixture({
+      terminalLaunch: async (cwd) => ({
+        bin: "mock", args: [], cwd: cwd ?? "/", env: {},
+        sessionIdentityResolver: {
+          resolve: async (providerSessionId) => {
+            resolverInputs.push(providerSessionId);
+            return deferred.promise;
+          },
+        },
+      }),
+      terminalStartShell: () => createMockPty(),
+    });
+    const theaterDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-identity-"));
+    tempDirs.push(theaterDir);
+    const theater = await createTheater(fixture, theaterDir);
+    const created = await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions`, {
+      method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ theaterId: theater.id, cliId: "claude" }),
+    });
+    const { sessionId } = await created.json() as { readonly sessionId: string };
+    const headers = { authorization: `Bearer ${fixture.lock.token}`, "Content-Type": "application/json" };
+    await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions/${sessionId}/capture`, {
+      method: "POST", headers, body: JSON.stringify({ provider: "claude", input: JSON.stringify({ session_id: "provider-only-id" }) }),
+    });
+    await fetch(`${fixture.endpoint}api/v1/operations/${sessionId}`, {
+      method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ payload: { sentinelUnknown: "preserve-me", labelSource: "auto", providerTitle: { source: "stale" }, providerSession: { provider: "claude", sessionId: "provider-only-id", capturedAt: "2026-01-01T00:00:00.000Z" } } }),
+    });
+
+    const end = await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions/${sessionId}/turn`, { method: "POST", headers, body: JSON.stringify({ phase: "end" }) });
+    const duplicate = await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions/${sessionId}/turn`, { method: "POST", headers, body: JSON.stringify({ phase: "end" }) });
+    expect(await end.json()).toEqual({ ok: true });
+    expect(await duplicate.json()).toEqual({ ok: true });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(resolverInputs).toEqual(["provider-only-id"]);
+
+    const controller = new AbortController();
+    const events = await fetch(`${fixture.endpoint}api/v1/operations/events`, { signal: controller.signal });
+    const reader = events.body!.getReader();
+    deferred.resolve("Provider title");
+    const decoder = new TextDecoder();
+    let eventFrame = "";
+    for (let index = 0; index < 2 && !eventFrame.includes("event: operation:changed"); index += 1) {
+      eventFrame += decoder.decode((await reader.read()).value);
+    }
+    controller.abort();
+    await reader.cancel().catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(resolverInputs).toEqual(["provider-only-id", "provider-only-id"]);
+    const state = JSON.parse(fs.readFileSync(path.join(fixture.carrierStoreDir, "console", "state.json"), "utf8")) as { readonly operations: ReadonlyArray<{ readonly title?: string; readonly payload?: Record<string, unknown> }> };
+    const list = await getJson<{ readonly operations: ReadonlyArray<{ readonly id: string; readonly title: string; readonly payload: Record<string, unknown> }> }>(`${fixture.endpoint}api/v1/operations`);
+    const item = await getJson<{ readonly operation: { readonly payload: Record<string, unknown> } }>(`${fixture.endpoint}api/v1/operations/${sessionId}`);
+
+    expect(state.operations[0]).toMatchObject({ title: "Provider title", payload: { providerTitle: { source: "provider" }, sentinelUnknown: "preserve-me" } });
+    expect(state.operations[0]?.payload).not.toHaveProperty("labelSource");
+    expect(list.operations.find((operation) => operation.id === sessionId)?.title).toBe("Provider title");
+    expect(JSON.stringify([list, item])).not.toContain("providerTitle");
+    expect(JSON.stringify([list, item])).not.toContain("provider-only-id");
+    expect(eventFrame).toContain("event: operation:changed");
+    expect(eventFrame).toContain("Provider title");
+    expect(eventFrame).not.toContain("providerTitle");
+    expect(eventFrame).not.toContain("provider-only-id");
+  });
+
+  it("keeps a racing user rename authoritative", async () => {
+    const deferred = createDeferred<string | null>();
+    const fixture = await startFixture({
+      terminalLaunch: async (cwd) => ({
+        bin: "mock", args: [], cwd: cwd ?? "/", env: {},
+        sessionIdentityResolver: { resolve: async () => deferred.promise },
+      }),
+      terminalStartShell: () => createMockPty(),
+    });
+    const theaterDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-identity-race-"));
+    tempDirs.push(theaterDir);
+    const theater = await createTheater(fixture, theaterDir);
+    const created = await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions`, {
+      method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ theaterId: theater.id, cliId: "claude" }),
+    });
+    const { sessionId } = await created.json() as { readonly sessionId: string };
+    const headers = { authorization: `Bearer ${fixture.lock.token}`, "Content-Type": "application/json" };
+    await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions/${sessionId}/capture`, {
+      method: "POST", headers, body: JSON.stringify({ provider: "claude", input: JSON.stringify({ session_id: "provider-race-id" }) }),
+    });
+    const end = await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions/${sessionId}/turn`, { method: "POST", headers, body: JSON.stringify({ phase: "end" }) });
+    expect(await end.json()).toEqual({ ok: true });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const renamed = await fetch(`${fixture.endpoint}api/v1/operations/${sessionId}`, {
+      method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ title: "Operator title" }),
+    });
+    expect(renamed.status).toBe(200);
+    deferred.resolve("Late provider title");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const state = JSON.parse(fs.readFileSync(path.join(fixture.carrierStoreDir, "console", "state.json"), "utf8")) as { readonly operations: ReadonlyArray<{ readonly title?: string; readonly payload?: Record<string, unknown> }> };
+    expect(state.operations[0]).toMatchObject({ title: "Operator title" });
+    expect(state.operations[0]?.payload).not.toHaveProperty("providerTitle");
+  });
+
+  it("drops a stale provider-session result and refreshes the replacement session", async () => {
+    const first = createDeferred<string | null>();
+    const resolverInputs: string[] = [];
+    const fixture = await startFixture({
+      terminalLaunch: async (cwd) => ({
+        bin: "mock", args: [], cwd: cwd ?? "/", env: {},
+        sessionIdentityResolver: { resolve: async (providerSessionId) => {
+          resolverInputs.push(providerSessionId);
+          return providerSessionId === "provider-old" ? first.promise : "Replacement title";
+        } },
+      }),
+      terminalStartShell: () => createMockPty(),
+    });
+    const theaterDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-identity-replace-"));
+    tempDirs.push(theaterDir);
+    const theater = await createTheater(fixture, theaterDir);
+    const created = await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions`, {
+      method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ theaterId: theater.id, cliId: "claude" }),
+    });
+    const { sessionId } = await created.json() as { readonly sessionId: string };
+    const headers = { authorization: `Bearer ${fixture.lock.token}`, "Content-Type": "application/json" };
+    for (const providerSessionId of ["provider-old", "provider-new"]) {
+      await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions/${sessionId}/capture`, {
+        method: "POST", headers, body: JSON.stringify({ provider: "claude", input: JSON.stringify({ session_id: providerSessionId }) }),
+      });
+      if (providerSessionId === "provider-old") {
+        await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions/${sessionId}/turn`, { method: "POST", headers, body: JSON.stringify({ phase: "end" }) });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+    }
+    first.resolve("Stale title");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const stale = JSON.parse(fs.readFileSync(path.join(fixture.carrierStoreDir, "console", "state.json"), "utf8")) as { readonly operations: ReadonlyArray<{ readonly title?: string }> };
+    expect(stale.operations[0]?.title).not.toBe("Stale title");
+    await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions/${sessionId}/turn`, { method: "POST", headers, body: JSON.stringify({ phase: "end" }) });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const state = JSON.parse(fs.readFileSync(path.join(fixture.carrierStoreDir, "console", "state.json"), "utf8")) as { readonly operations: ReadonlyArray<{ readonly title?: string }> };
+    expect(resolverInputs).toEqual(["provider-old", "provider-new"]);
+    expect(state.operations[0]?.title).toBe("Replacement title");
+  });
+
+  it("keeps turn-end successful when the launch-bound resolver rejects or returns null", async () => {
+    let call = 0;
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      const fixture = await startFixture({
+        terminalLaunch: async (cwd) => ({
+          bin: "mock", args: [], cwd: cwd ?? "/", env: {},
+          sessionIdentityResolver: { resolve: async () => {
+            call += 1;
+            if (call === 1) throw new Error("identity failed");
+            return null;
+          } },
+        }),
+        terminalStartShell: () => createMockPty(),
+      });
+      const theaterDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-identity-noop-"));
+      tempDirs.push(theaterDir);
+      const theater = await createTheater(fixture, theaterDir);
+      const created = await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions`, {
+        method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ theaterId: theater.id, cliId: "claude" }),
+      });
+      const { sessionId } = await created.json() as { readonly sessionId: string };
+      const headers = { authorization: `Bearer ${fixture.lock.token}`, "Content-Type": "application/json" };
+      await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions/${sessionId}/capture`, {
+        method: "POST", headers, body: JSON.stringify({ provider: "claude", input: JSON.stringify({ session_id: "provider-noop-id" }) }),
+      });
+      for (let index = 0; index < 2; index += 1) {
+        const response = await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions/${sessionId}/turn`, { method: "POST", headers, body: JSON.stringify({ phase: "end" }) });
+        expect(await response.json()).toEqual({ ok: true });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      const state = JSON.parse(fs.readFileSync(path.join(fixture.carrierStoreDir, "console", "state.json"), "utf8")) as { readonly operations: ReadonlyArray<{ readonly payload?: Record<string, unknown> }> };
+      expect(call).toBe(2);
+      expect(state.operations[0]?.payload).not.toHaveProperty("providerTitle");
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
   });
 
   it("persists captured provider sessions as dormant operation payloads on server stop", async () => {
@@ -1998,7 +2192,7 @@ describe("console static and terminal ticket boundary", () => {
     let destroyed = 0;
     const handler = createPluginTerminalUpgradeHandler({
       tickets: { consume: () => null },
-      sessions: { canAttach: () => true, createSession: async () => undefined, attach: async () => undefined, getSessionMessagePolicy: () => undefined, getSessionRenameCommand: () => undefined, terminate: () => false, stop: async () => undefined, writeToSession: () => false },
+      sessions: { canAttach: () => true, createSession: async () => undefined, attach: async () => undefined, getSessionMessagePolicy: () => undefined, getSessionRenameCommand: () => undefined, resolveSessionIdentity: async () => null, terminate: () => false, stop: async () => undefined, writeToSession: () => false },
       isAuthorized: () => true,
     });
 
@@ -2032,6 +2226,7 @@ describe("console static and terminal ticket boundary", () => {
         attach: async () => undefined,
         getSessionMessagePolicy: () => undefined,
         getSessionRenameCommand: () => undefined,
+        resolveSessionIdentity: async () => null,
         terminate: () => false,
         stop: async () => undefined,
         writeToSession: () => false,

--- a/runtime/fleet-console/tests/session-manager.test.ts
+++ b/runtime/fleet-console/tests/session-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createTerminalSessionManager } from "../../fleet-plugins/terminal/server/shared/session-manager.js";
 import type { TerminalPtyDataDisposable, TerminalPtyHandle, TerminalSocket, TerminalSocketData } from "../../fleet-plugins/terminal/server/shared/terminal-types.js";
@@ -133,6 +133,40 @@ describe("terminal session manager", () => {
         resumeSessionId: "provider-session-a",
       },
     }]);
+  });
+
+  it("retains and invokes only the opaque launch-bound identity resolver", async () => {
+    const resolve = vi.fn(async (providerSessionId: string) => `identity:${providerSessionId}`);
+    const manager = createTerminalSessionManager({
+      launch: async (cwd) => ({
+        bin: "mock", args: [], cwd: cwd ?? "/", env: {},
+        sessionIdentityResolver: { resolve },
+      }),
+      startShell: () => createMockPty(),
+    });
+
+    await manager.createSession({ sessionId: "session-a", cwd: "/a" });
+    await expect(manager.resolveSessionIdentity("session-a", "provider-a")).resolves.toBe("identity:provider-a");
+    await expect(manager.resolveSessionIdentity("missing", "provider-a")).resolves.toBeNull();
+    expect(resolve).toHaveBeenCalledWith("provider-a");
+  });
+
+  it("drops an identity result that completes after session teardown", async () => {
+    const deferred = createDeferred<string | null>();
+    const manager = createTerminalSessionManager({
+      launch: async (cwd) => ({
+        bin: "mock", args: [], cwd: cwd ?? "/", env: {},
+        sessionIdentityResolver: { resolve: () => deferred.promise },
+      }),
+      startShell: () => createMockPty(),
+    });
+
+    await manager.createSession({ sessionId: "session-a", cwd: "/a" });
+    const title = manager.resolveSessionIdentity("session-a", "provider-a");
+    manager.terminate("session-a");
+    deferred.resolve("late title");
+
+    await expect(title).resolves.toBeNull();
   });
 
   it("stops a session that finishes launching while server shutdown is waiting", async () => {

--- a/runtime/fleet-plugins/terminal/plugin.json
+++ b/runtime/fleet-plugins/terminal/plugin.json
@@ -7,6 +7,7 @@
     "cwd",
     "canonicalCwd",
     "providerSession",
+    "providerTitle",
     "transcriptPath",
     "token",
     "ticket",

--- a/runtime/fleet-plugins/terminal/routes.ts
+++ b/runtime/fleet-plugins/terminal/routes.ts
@@ -11,7 +11,7 @@ import { createTerminalRuntime } from "./server/shared/index.js";
 import { registerShellRoutes } from "./server/shell.js";
 
 const TERMINAL_PLUGIN_ID = "terminal";
-const TERMINAL_SENSITIVE_FIELDS = ["cwd", "canonicalCwd", "providerSession", "transcriptPath", "token", "ticket", "prompt", "persona", "toolAllowlist"] as const;
+const TERMINAL_SENSITIVE_FIELDS = ["cwd", "canonicalCwd", "providerSession", "providerTitle", "transcriptPath", "token", "ticket", "prompt", "persona", "toolAllowlist"] as const;
 const SHELL_LAUNCH_KIND = { id: "shell", type: "shell", title: "Shell" } as const satisfies OperationLaunchKind;
 const OPERATION_DELETED_EVENT_CHANNEL = "operation:deleted";
 

--- a/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
@@ -6,6 +6,7 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 import { resolvePathBinary } from "@dotobokuri/core-agent";
+import { createSessionIdentityResolver } from "@dotobokuri/core-unified-agent";
 import {
   createSystemPromptBuilder,
   injectAgentCliProfile,
@@ -34,6 +35,7 @@ export interface TerminalLaunchResolverDeps {
   readonly injectProfile?: typeof injectAgentCliProfile;
   readonly onRuntimeSessionStart?: (session: ConsoleRuntimeSessionInfo) => void;
   readonly resolveProfile?: typeof resolveAgentCliProfile;
+  readonly createSessionIdentityResolver?: typeof createSessionIdentityResolver;
 }
 
 export interface ConsoleRuntimeSessionInfo {
@@ -65,6 +67,7 @@ export function createAgentTerminalLaunchResolver(deps: TerminalLaunchResolverDe
   const agentRuntime = deps.agentRuntime;
   const injectProfile = deps.injectProfile ?? injectAgentCliProfile;
   const resolveProfile = deps.resolveProfile ?? resolveAgentCliProfile;
+  const resolveSessionIdentityResolver = deps.createSessionIdentityResolver ?? createSessionIdentityResolver;
   const hookEntry: ConsoleHookCommandEntry = { entryPath, execPath, ...(tsxLoaderPath ? { tsxLoaderPath } : {}) };
 
   return async (selectedCwd, context) => {
@@ -95,6 +98,7 @@ export function createAgentTerminalLaunchResolver(deps: TerminalLaunchResolverDe
       onRuntimeSessionStart: deps.onRuntimeSessionStart,
       resolveProfile,
       cliId: context?.cliId,
+      createSessionIdentityResolver: resolveSessionIdentityResolver,
       resumeSessionId: context?.resumeSessionId,
       sessionId,
     });
@@ -123,6 +127,7 @@ function hasHookEntryExtension(entryPath: string): boolean {
 async function createAgentCliLaunchSpec(options: {
   readonly agentRuntime?: FleetAgentRuntimeLifecycle;
   readonly cliId?: string;
+  readonly createSessionIdentityResolver: typeof createSessionIdentityResolver;
   readonly cwd: string;
   readonly dataDir: string;
   readonly env: NodeJS.ProcessEnv;
@@ -168,11 +173,18 @@ async function createAgentCliLaunchSpec(options: {
       mcpToolCount: countMcpTools(agentRuntime),
       sessionId: options.sessionId,
     });
+    const sessionIdentityResolver = options.createSessionIdentityResolver({
+      provider: injectedProfile.id,
+      command: injectedProfile.bin,
+      commandPrefixArgs: injectedProfile.binPrefixArgs,
+      cwd: injectedProfile.cwd,
+      env: injectedProfile.env,
+    });
     return toLaunchSpec(injectedProfile, createOnceCleanup(async () => {
       for (const cleanup of [...cleanupStack].reverse()) {
         await cleanup();
       }
-    }));
+    }), sessionIdentityResolver);
   } catch (error) {
     for (const cleanup of [...cleanupStack].reverse()) {
       try {
@@ -185,7 +197,7 @@ async function createAgentCliLaunchSpec(options: {
   }
 }
 
-function toLaunchSpec(profile: AgentCliProfile, cleanup: () => Promise<void>): TerminalLaunchSpec {
+function toLaunchSpec(profile: AgentCliProfile, cleanup: () => Promise<void>, sessionIdentityResolver: TerminalLaunchSpec["sessionIdentityResolver"]): TerminalLaunchSpec {
   return {
     args: [...profile.args],
     bin: profile.bin,
@@ -194,6 +206,7 @@ function toLaunchSpec(profile: AgentCliProfile, cleanup: () => Promise<void>): T
     env: { ...profile.env },
     messagePolicy: profile.messagePolicy,
     renameCommand: profile.renameCommand,
+    sessionIdentityResolver,
     terminalName: profile.terminalName,
   };
 }

--- a/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
@@ -11,6 +11,7 @@ import type {
   AgentObservedWorkspace,
   AgentObserverTruncation,
   AgentProviderSession,
+  AgentProviderTitleMarker,
   AgentSessionAttentionEvent,
   AgentSessionStatus,
   AgentSessionUpdatedEvent,
@@ -52,6 +53,7 @@ interface PendingTerminalSessionState {
   readonly cwdLabel: string;
   label?: string;
   labelSource?: AgentLabelSource;
+  providerTitle?: AgentProviderTitleMarker;
   autoNamePromptSeen?: boolean;
   cliId?: string;
   cliLabel?: string;
@@ -68,6 +70,11 @@ interface PendingTerminalSessionState {
 type DormantOperationInput = AgentDurableOperation;
 
 interface AutoNameTerminalSessionResult {
+  readonly session: AgentTerminalSessionInfo;
+  readonly renamed: boolean;
+}
+
+interface ProviderIdentityTerminalSessionResult {
   readonly session: AgentTerminalSessionInfo;
   readonly renamed: boolean;
 }
@@ -233,6 +240,7 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
       cwdLabel: path.basename(operation.cwd) || operation.cwd,
       label: operation.label,
       labelSource: operation.labelSource,
+      providerTitle: operation.providerTitle,
       cliId: operation.cliId,
       cliLabel: operation.cliLabel,
       createdAt: operation.createdAt,
@@ -256,6 +264,7 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
       cwd: session.cwd,
       ...(session.label ? { label: session.label } : {}),
       ...(session.labelSource ? { labelSource: session.labelSource } : {}),
+      ...(session.providerTitle ? { providerTitle: session.providerTitle } : {}),
       ...(session.cliId ? { cliId: session.cliId } : {}),
       ...(session.cliLabel ? { cliLabel: session.cliLabel } : {}),
       createdAt: session.createdAt,
@@ -310,21 +319,23 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
       // 다음 프롬프트부터 자동 작명이 재활성화되게 한다.
       delete session.label;
       delete session.labelSource;
+      delete session.providerTitle;
     } else {
       session.label = label;
       session.labelSource = "user";
+      delete session.providerTitle;
     }
     return toTerminalSessionInfo(session);
   }
 
-  // 자동 작명: 사용자 수동 라벨(labelSource "user")이 없는 세션의 첫 유효 프롬프트에만 적용한다.
+  // 자동 작명: 사용자 수동 또는 provider 라벨이 없는 세션의 첫 유효 프롬프트에만 적용한다.
   // labelSource 미설정 레거시 세션은 label 유무로 보수 해석해 기존 사용자 라벨을 보호한다.
   // 처리 여부는 패널의 인메모리 상태에만 남기며 durable operation에는 포함하지 않는다.
   function autoNameTerminalSession(sessionId: string, label: string | null): AutoNameTerminalSessionResult | null {
     const session = terminalSessionsById.get(sessionId);
     if (!session) return null;
     const effectiveSource: AgentLabelSource | undefined = session.labelSource ?? (session.label ? "user" : undefined);
-    if (effectiveSource === "user" || session.autoNamePromptSeen) {
+    if (effectiveSource === "user" || session.providerTitle || session.autoNamePromptSeen) {
       return { session: toTerminalSessionInfo(session), renamed: false };
     }
     const next = label?.trim().slice(0, 200) ?? "";
@@ -335,6 +346,27 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
     if (next === session.label) return { session: toTerminalSessionInfo(session), renamed: false };
     session.label = next;
     session.labelSource = "auto";
+    return { session: toTerminalSessionInfo(session), renamed: true };
+  }
+
+  // Provider metadata may replace default, auto, or a prior provider title, but
+  // never a manual/legacy title. Its provenance remains durable server-only.
+  function applyTerminalSessionProviderIdentity(sessionId: string, rawLabel: string | null): ProviderIdentityTerminalSessionResult | null {
+    const session = terminalSessionsById.get(sessionId);
+    if (!session) return null;
+    const label = rawLabel?.trim().slice(0, 200) ?? "";
+    if (label.length === 0) return { session: toTerminalSessionInfo(session), renamed: false };
+
+    const isLegacyOrUserTitle = session.labelSource === "user"
+      || (!session.labelSource && !session.providerTitle && Boolean(session.label));
+    if (isLegacyOrUserTitle) return { session: toTerminalSessionInfo(session), renamed: false };
+    if (session.label === label && session.providerTitle) {
+      return { session: toTerminalSessionInfo(session), renamed: false };
+    }
+
+    session.label = label;
+    delete session.labelSource;
+    session.providerTitle = { source: "provider" };
     return { session: toTerminalSessionInfo(session), renamed: true };
   }
 
@@ -395,6 +427,7 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
     notifySessionUpdated,
     renameTerminalSession,
     autoNameTerminalSession,
+    applyTerminalSessionProviderIdentity,
     subscribe,
     subscribeAll,
     updateTerminalSessionProviderSession,

--- a/runtime/fleet-plugins/terminal/server/agent-api/types.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/types.ts
@@ -12,6 +12,12 @@ export type AgentAttentionReason =
 
 export type AgentLabelSource = "user" | "auto";
 
+// Provider-derived titles are durable server state. Keep this separate from
+// AgentLabelSource because that union is projected into browser session DTOs.
+export interface AgentProviderTitleMarker {
+  readonly source: "provider";
+}
+
 export interface AgentProviderSession {
   readonly provider: "claude" | "codex";
   readonly sessionId: string;
@@ -26,6 +32,7 @@ export interface AgentDurableOperation {
   readonly cwd: string;
   readonly label?: string;
   readonly labelSource?: AgentLabelSource;
+  readonly providerTitle?: AgentProviderTitleMarker;
   readonly cliId?: string;
   readonly cliLabel?: string;
   readonly createdAt: number;

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -21,7 +21,7 @@ import { captureSession, readProviderSessionCapture, unlinkProviderSessionCaptur
 import { createAgentTerminalLaunchResolver, type ConsoleRuntimeSessionInfo } from "./agent-api/launch.js";
 import { createConsoleObservabilityStore } from "./agent-api/observability-store.js";
 import { writeAggregateObserverEvents } from "./agent-api/observability-routes.js";
-import type { AgentTerminalSessionInfo, AgentLabelSource } from "./agent-api/types.js";
+import type { AgentProviderTitleMarker, AgentTerminalSessionInfo, AgentLabelSource } from "./agent-api/types.js";
 type SessionCreateBody = { readonly cliId?: unknown; readonly theaterId?: unknown };
 type HookTurnBody = { readonly phase?: unknown };
 type HookAttentionBody = { readonly input?: unknown; readonly reason?: unknown };
@@ -82,6 +82,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
   });
   const detector = createDefaultAgentCliDetector();
   const pendingRuntimeSessions = new Map<string, ConsoleRuntimeSessionInfo>();
+  const identityRefreshes = new Map<string, { running: boolean; queued: boolean }>();
   const jobOriginById = new Map<string, string>();
   const launchResolver = createAgentTerminalLaunchResolver({
     agentRuntime: runtime,
@@ -124,7 +125,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
         // 빈 리네임(reset)이면 updated.label이 비므로 title도 기본 표시명(cwdLabel=basename)으로 되돌린다.
         // core PATCH의 빈 title은 기존 title로 normalize되어 사용자 옛 이름이 남기 때문에, 여기서 명시적으로 복원한다.
         // 이 patch는 store.patch(HTTP 미경유)라 operation:renamed를 재발행하지 않아 구독 루프를 만들지 않는다.
-        ctx.host.operations.patch(payload.operationId, { title: updated.label ?? updated.cwdLabel, payload: toOperationPayload(cwd, updated, providerSession) });
+        ctx.host.operations.patch(payload.operationId, { title: updated.label ?? updated.cwdLabel, payload: toOperationPayload(operation.payload, cwd, updated, providerSession) });
       }
     }
     injectRenameCommand(payload.operationId, payload.title);
@@ -275,7 +276,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       type: AGENT_OPERATION_TYPE,
       pluginId: ctx.pluginId,
       title: session.label ?? path.basename(cwd),
-      payload: toOperationPayload(cwd, session),
+      payload: toOperationPayload(undefined, cwd, session),
       createdAt: session.createdAt,
     });
     try {
@@ -294,7 +295,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
         ? observability.registerTerminalRuntimeSession(runtimeSession) ?? session
         : observability.updateTerminalSessionStatus(sessionId, "terminal-only") ?? session;
       observability.notifySessionUpdated(created);
-      ctx.host.operations.patch(sessionId, { payload: toOperationPayload(cwd, created) });
+      ctx.host.operations.patch(sessionId, { payload: toOperationPayload(ctx.host.operations.get(sessionId)?.payload, cwd, created, undefined, observability.getDurableOperation(sessionId)?.providerTitle) });
       ctx.host.http.writeJson(res, 200, created);
     } catch {
       pendingRuntimeSessions.delete(sessionId);
@@ -338,7 +339,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       pendingRuntimeSessions.delete(sessionId);
       const resumed = runtimeSession ? observability.registerTerminalRuntimeSession(runtimeSession) ?? starting : observability.updateTerminalSessionStatus(sessionId, "terminal-only") ?? starting;
       observability.notifySessionUpdated(resumed);
-      ctx.host.operations.patch(sessionId, { payload: toOperationPayload(cwd, resumed, providerSession) });
+      ctx.host.operations.patch(sessionId, { payload: toOperationPayload(node.payload, cwd, resumed, providerSession, observability.getDurableOperation(sessionId)?.providerTitle) });
       ctx.host.http.writeJson(res, 200, resumed);
     } catch {
       pendingRuntimeSessions.delete(sessionId);
@@ -365,6 +366,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     }
     observability.notifySessionUpdated(updated);
     ctx.host.http.writeJson(res, 200, { ok: true });
+    if (turnState === "ended") scheduleIdentityRefresh(sessionId);
     return true;
   }
 
@@ -456,7 +458,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       if (dormant) {
         observability.notifySessionUpdated(dormant);
         const exitCwd = readPayloadString(ctx.host.operations.get(operationId)?.payload ?? {}, "cwd") ?? "";
-        ctx.host.operations.patch(operationId, { payload: toOperationPayload(exitCwd, dormant, providerSession) });
+        ctx.host.operations.patch(operationId, { payload: toOperationPayload(ctx.host.operations.get(operationId)?.payload, exitCwd, dormant, providerSession, observability.getDurableOperation(operationId)?.providerTitle) });
       }
     } else {
       observability.removeTerminalSession(operationId);
@@ -479,6 +481,49 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     await runtime.cleanup();
   }
 
+  function scheduleIdentityRefresh(sessionId: string): void {
+    const state = identityRefreshes.get(sessionId);
+    if (state?.running) {
+      state.queued = true;
+      return;
+    }
+    const operation = ctx.host.operations.get(sessionId);
+    const providerSessionId = readProviderSession(operation?.payload)?.sessionId;
+    if (!providerSessionId) {
+      identityRefreshes.delete(sessionId);
+      return;
+    }
+    const next = state ?? { running: false, queued: false };
+    next.running = true;
+    identityRefreshes.set(sessionId, next);
+    void terminalRuntime.resolveSessionIdentity(sessionId, providerSessionId)
+      .then((title) => {
+        const current = ctx.host.operations.get(sessionId);
+        if (!title || !current || readProviderSession(current.payload)?.sessionId !== providerSessionId) return;
+        const applied = observability.applyTerminalSessionProviderIdentity(sessionId, title);
+        if (!applied?.renamed) return;
+        observability.notifySessionUpdated(applied.session);
+        const operation = ctx.host.operations.get(sessionId);
+        if (!operation || readProviderSession(operation.payload)?.sessionId !== providerSessionId) return;
+        const cwd = readPayloadString(operation.payload, "cwd") || applied.session.cwdLabel;
+        const providerSession = readProviderSession(operation.payload);
+        ctx.host.operations.patch(sessionId, {
+          title: applied.session.label ?? applied.session.cwdLabel,
+          payload: toOperationPayload(operation.payload, cwd, applied.session, providerSession, observability.getDurableOperation(sessionId)?.providerTitle),
+        });
+      })
+      .catch(() => {})
+      .finally(() => {
+        next.running = false;
+        if (next.queued) {
+          next.queued = false;
+          scheduleIdentityRefresh(sessionId);
+        } else {
+          identityRefreshes.delete(sessionId);
+        }
+      });
+  }
+
   function injectRenameCommand(sessionId: string, label: string | undefined): void {
     if (!label) return;
     const renameCommand = terminalRuntime.getRenameCommand(sessionId);
@@ -492,11 +537,16 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
 
   function injectOperation(operation: OperationNode): AgentTerminalSessionInfo {
     const cwd = readPayloadString(operation.payload, "cwd") ?? ctx.host.paths.resolveTheaterPath(operation.theaterId) ?? "";
+    const providerTitle = readProviderTitle(operation.payload);
     return observability.injectDormantOperation({
       sessionId: operation.id,
       theaterId: operation.theaterId,
       cwd,
-      ...(readPayloadString(operation.payload, "labelSource") ? { label: operation.title, labelSource: readPayloadString(operation.payload, "labelSource") as AgentLabelSource } : {}),
+      ...(providerTitle
+        ? { label: operation.title, providerTitle }
+        : readPayloadString(operation.payload, "labelSource")
+          ? { label: operation.title, labelSource: readPayloadString(operation.payload, "labelSource") as AgentLabelSource }
+          : {}),
       ...(readPayloadString(operation.payload, "cliId") ? { cliId: readPayloadString(operation.payload, "cliId")! } : {}),
       ...(readPayloadString(operation.payload, "cliLabel") ? { cliLabel: readPayloadString(operation.payload, "cliLabel")! } : {}),
       createdAt: operation.ts.createdAt,
@@ -511,7 +561,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       if (!providerSession || observability.getTerminalSessionInfo(operation.id)) continue;
       const dormant = injectOperation(operation);
       const cwd = readPayloadString(operation.payload, "cwd") || (ctx.host.paths.resolveTheaterPath(operation.theaterId) ?? "");
-      ctx.host.operations.patch(operation.id, { payload: { ...operation.payload, ...toOperationPayload(cwd, dormant, providerSession) } });
+      ctx.host.operations.patch(operation.id, { payload: toOperationPayload(operation.payload, cwd, dormant, providerSession, observability.getDurableOperation(operation.id)?.providerTitle) });
     }
   }
 
@@ -536,14 +586,20 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
   }
 }
 
-function toOperationPayload(cwd: string, session: AgentTerminalSessionInfo, providerSession?: ProviderSession): Record<string, unknown> {
+function toOperationPayload(existing: Record<string, unknown> | undefined, cwd: string, session: AgentTerminalSessionInfo, providerSession?: ProviderSession, providerTitle?: AgentProviderTitleMarker): Record<string, unknown> {
+  const payload = { ...(existing ?? {}) };
+  for (const key of ["cwd", "cliId", "launchKindId", "cliLabel", "providerSession", "labelSource", "providerTitle"]) {
+    delete payload[key];
+  }
   return {
+    ...payload,
     cwd,
     ...(session.cliId ? { cliId: session.cliId } : {}),
     ...(session.cliId ? { launchKindId: session.cliId } : {}),
     ...(session.cliLabel ? { cliLabel: session.cliLabel } : {}),
     ...(providerSession ? { providerSession } : {}),
     ...(session.labelSource ? { labelSource: session.labelSource } : {}),
+    ...(providerTitle ? { providerTitle } : {}),
   };
 }
 
@@ -585,6 +641,14 @@ function readProviderSession(value: Record<string, unknown> | undefined): Provid
     ...(typeof candidate.transcriptPath === "string" ? { transcriptPath: candidate.transcriptPath } : {}),
     ...(typeof candidate.source === "string" ? { source: candidate.source } : {}),
   };
+}
+
+function readProviderTitle(value: Record<string, unknown> | undefined): AgentProviderTitleMarker | undefined {
+  const marker = value?.providerTitle;
+  if (!marker || typeof marker !== "object" || Array.isArray(marker)) return undefined;
+  const candidate = marker as Record<string, unknown>;
+  if (candidate.source !== "provider" || Object.keys(candidate).length !== 1) return undefined;
+  return { source: "provider" };
 }
 
 function resolveCarrierEventOrigin(event: { readonly jobId: string; readonly type: string; readonly originSessionId?: string }, jobOriginById: Map<string, string>): string | null {

--- a/runtime/fleet-plugins/terminal/server/shared/runtime.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/runtime.ts
@@ -17,6 +17,7 @@ export interface TerminalRuntime {
   terminate(operationId: string): boolean;
   getMessagePolicy(operationId: string): CliMessagePolicy | undefined;
   getRenameCommand(operationId: string): string | undefined;
+  resolveSessionIdentity(operationId: string, providerSessionId: string): Promise<string | null>;
   onExit(callback: (operationId: string) => void | Promise<void>): () => void;
   registerLaunchResolver(operationType: string, resolver: TerminalLaunchResolver): () => void;
   stop(): Promise<void>;
@@ -56,6 +57,7 @@ export function createTerminalRuntime(ctx: FleetPluginServerContext): TerminalRu
     terminate: (operationId) => sessions.terminate(operationId),
     getMessagePolicy: (operationId) => sessions.getSessionMessagePolicy(operationId),
     getRenameCommand: (operationId) => sessions.getSessionRenameCommand(operationId),
+    resolveSessionIdentity: (operationId, providerSessionId) => sessions.resolveSessionIdentity(operationId, providerSessionId),
     onExit: (callback) => {
       terminalExitListeners.add(callback);
       return () => terminalExitListeners.delete(callback);

--- a/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
@@ -1,6 +1,7 @@
 import { closeSync, fstatSync, readdirSync } from "node:fs";
 
 import type { CliMessagePolicy } from "@dotobokuri/fleet-admiral";
+import type { SessionIdentityResolver } from "@dotobokuri/core-unified-agent";
 
 import { startTerminalShell, type TerminalLaunchResolver } from "./pty.js";
 import type { TerminalPtyHandle, TerminalSessionManager, TerminalSocket, TerminalSocketData, TerminalTicketContext } from "./terminal-types.js";
@@ -24,6 +25,7 @@ interface TerminalSession {
   readonly cleanup?: () => void | Promise<void>;
   readonly messagePolicy?: CliMessagePolicy;
   readonly renameCommand?: string;
+  readonly sessionIdentityResolver?: SessionIdentityResolver;
   activeSocket: TerminalSocket | null;
   cols: number;
   rows: number;
@@ -104,6 +106,20 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     return sessions.get(sessionId)?.renameCommand;
   }
 
+  async function resolveSessionIdentity(sessionId: string, providerSessionId: string): Promise<string | null> {
+    const session = sessions.get(sessionId);
+    const resolver = session?.sessionIdentityResolver;
+    if (!resolver) return null;
+    try {
+      const title = await resolver.resolve(providerSessionId);
+      // A detached reader may complete after PTY teardown. Do not let it revive
+      // or mutate a removed/replaced Terminal session.
+      return sessions.get(sessionId) === session ? title : null;
+    } catch {
+      return null;
+    }
+  }
+
   function writeToSession(sessionId: string, data: string): boolean {
     const session = sessions.get(sessionId);
     if (!session || typeof session.pty.write !== "function") return false;
@@ -174,6 +190,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
       cleanup: launch.cleanup,
       messagePolicy: launch.messagePolicy,
       renameCommand: launch.renameCommand,
+      sessionIdentityResolver: launch.sessionIdentityResolver,
       activeSocket: null,
       cols: DEFAULT_COLS,
       rows: DEFAULT_ROWS,
@@ -279,7 +296,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     }
   }
 
-  return { canAttach, createSession, attach, getSessionMessagePolicy, getSessionRenameCommand, terminate, stop, writeToSession };
+  return { canAttach, createSession, attach, getSessionMessagePolicy, getSessionRenameCommand, resolveSessionIdentity, terminate, stop, writeToSession };
 }
 
 async function runLaunchCleanup(cleanup: (() => void | Promise<void>) | undefined): Promise<void> {

--- a/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
@@ -1,4 +1,5 @@
 import type { CliMessagePolicy } from "@dotobokuri/fleet-admiral";
+import type { SessionIdentityResolver } from "@dotobokuri/core-unified-agent";
 
 export interface TerminalLaunchSpec {
   readonly bin: string;
@@ -8,6 +9,8 @@ export interface TerminalLaunchSpec {
   readonly env: NodeJS.ProcessEnv;
   readonly messagePolicy?: CliMessagePolicy;
   readonly renameCommand?: string;
+  /** Spawn-time selected opaque provider identity reader; never browser-visible. */
+  readonly sessionIdentityResolver?: SessionIdentityResolver;
   readonly terminalName?: string;
 }
 
@@ -69,6 +72,7 @@ export interface TerminalSessionManager {
   attach(socket: TerminalSocket, context: TerminalTicketContext): Promise<void>;
   getSessionMessagePolicy(sessionId: string): CliMessagePolicy | undefined;
   getSessionRenameCommand(sessionId: string): string | undefined;
+  resolveSessionIdentity(sessionId: string, providerSessionId: string): Promise<string | null>;
   terminate(sessionId: string): boolean;
   stop(): Promise<void>;
   writeToSession(sessionId: string, data: string): boolean;

--- a/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
@@ -101,3 +101,64 @@ describe("agent observability DTO boundary", () => {
     expect(b?.id).toBe(2);
   });
 });
+
+describe("agent operation title precedence", () => {
+  function createStore() {
+    return createConsoleObservabilityStore({ workspaceHash: () => "theater-a" });
+  }
+
+  function createSession(store: ReturnType<typeof createStore>, sessionId = "session-a") {
+    store.createPendingTerminalSession({ sessionId, cwd: "/workspace/project", createdAt: 1_000 });
+  }
+
+  it("applies default, auto, provider, refreshed provider, then user precedence", () => {
+    const store = createStore();
+    createSession(store);
+
+    expect(store.autoNameTerminalSession("session-a", "Prompt title")).toMatchObject({ renamed: true, session: { label: "Prompt title", labelSource: "auto" } });
+    expect(store.applyTerminalSessionProviderIdentity("session-a", "Provider title")).toMatchObject({ renamed: true, session: { label: "Provider title" } });
+    expect(store.getDurableOperation("session-a")).toMatchObject({ providerTitle: { source: "provider" } });
+    expect(store.applyTerminalSessionProviderIdentity("session-a", "Refreshed title")).toMatchObject({ renamed: true, session: { label: "Refreshed title" } });
+    expect(store.renameTerminalSession("session-a", "Manual title")).toMatchObject({ label: "Manual title", labelSource: "user" });
+    expect(store.applyTerminalSessionProviderIdentity("session-a", "Ignored provider title")).toMatchObject({ renamed: false, session: { label: "Manual title", labelSource: "user" } });
+    expect(store.getDurableOperation("session-a")?.providerTitle).toBeUndefined();
+  });
+
+  it("protects conservatively interpreted legacy titles and refuses auto-name after provider identity", () => {
+    const store = createStore();
+    store.injectDormantOperation({ sessionId: "legacy", theaterId: "theater-a", cwd: "/workspace/project", label: "Legacy title", createdAt: 1_000 });
+    expect(store.applyTerminalSessionProviderIdentity("legacy", "Provider title")).toMatchObject({ renamed: false, session: { label: "Legacy title" } });
+
+    createSession(store);
+    store.applyTerminalSessionProviderIdentity("session-a", "Provider title");
+    expect(store.autoNameTerminalSession("session-a", "Prompt title")).toMatchObject({ renamed: false, session: { label: "Provider title" } });
+  });
+
+  it("clears user and provider provenance on empty rename, and ignores malformed or duplicate provider titles", () => {
+    const store = createStore();
+    createSession(store);
+    expect(store.applyTerminalSessionProviderIdentity("session-a", "  Provider title  ")).toMatchObject({ renamed: true, session: { label: "Provider title" } });
+    expect(store.applyTerminalSessionProviderIdentity("session-a", "Provider title")).toMatchObject({ renamed: false });
+    expect(store.applyTerminalSessionProviderIdentity("session-a", "   ")).toMatchObject({ renamed: false });
+    expect(store.renameTerminalSession("session-a", "")).toMatchObject({ label: undefined, labelSource: undefined });
+    expect(store.getDurableOperation("session-a")?.providerTitle).toBeUndefined();
+
+    expect(store.applyTerminalSessionProviderIdentity("session-a", `  ${"x".repeat(201)}  `)?.session.label).toBe("x".repeat(200));
+  });
+
+  it("rehydrates provider provenance without exposing it in browser session DTOs", () => {
+    const store = createStore();
+    const session = store.injectDormantOperation({
+      sessionId: "session-a",
+      theaterId: "theater-a",
+      cwd: "/workspace/project",
+      label: "Provider title",
+      providerTitle: { source: "provider" },
+      createdAt: 1_000,
+    });
+
+    expect(store.applyTerminalSessionProviderIdentity("session-a", "Refreshed title")).toMatchObject({ renamed: true, session: { label: "Refreshed title" } });
+    expect(JSON.stringify(session)).not.toContain("providerTitle");
+    expect(store.getDurableOperation("session-a")).toMatchObject({ label: "Refreshed title", providerTitle: { source: "provider" } });
+  });
+});

--- a/scripts/pack-fleet-console-manifest.mjs
+++ b/scripts/pack-fleet-console-manifest.mjs
@@ -6,7 +6,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PKG_PATH = path.resolve(__dirname, "../runtime/fleet-console/package.json");
 const BACKUP_PATH = path.resolve(__dirname, "../runtime/fleet-console/.package.json.prepack-backup");
 const TEMP_PATH = path.resolve(__dirname, "../runtime/fleet-console/.package.json.prepack-tmp");
-const EXTERNAL_DEP_NAMES = ["node-pty", "ws", "font-list"];
+const EXTERNAL_DEP_NAMES = ["node-pty", "ws", "font-list", "@anthropic-ai/claude-agent-sdk"];
 
 if (process.argv[1] !== undefined && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   const action = process.argv[2];


### PR DESCRIPTION
## Summary
- Bind provider-neutral session identity resolvers at Agent CLI spawn time.
- Remove Claude prompt auto-name hooks while preserving Codex prompt auto-name and resolving official provider session titles.
- Keep provider identity provenance server-only with safe refresh, rename precedence, and Console coverage.

## Test Plan
- [x] Core resolver/lifecycle focused tests (23 passed)
- [x] Console identity race/payload tests (4 passed)
- [x] Core lint and test typecheck
- [x] Terminal typecheck
- [x] Core, Admiral, Terminal, and Console builds
- [x] Sentinel changed-code re-review (0 findings)
- [x] Headed Console E2E with real Claude and Codex prompts
- [x] `.changelog.d/pr-277.md` added with bilingual grouped entries
- [x] Changelog fragment syntax validated with `node scripts/compile-changelog-fragments.mjs --check`

## Notes
- The full Core suite has one unrelated external live-model response-length assertion failure.
- Console aggregate typecheck retains existing client CSS and `virtual:fleet-plugins` declaration baseline errors.