### PR TITLE
fix(diff): fill History inspector height

### DIFF
--- a/.changelog.d/pr-278.md
+++ b/.changelog.d/pr-278.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] Keep History commit details and changed-file scrolling within the full inspector height.
+  ko: History 커밋 상세와 변경 파일 스크롤이 inspector 전체 높이를 사용하도록 수정합니다.

--- a/runtime/fleet-plugins/diff/client/diff.css
+++ b/runtime/fleet-plugins/diff/client/diff.css
@@ -850,7 +850,7 @@
   grid-row: 1;
   grid-column: 1;
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
   border-right: 1px solid var(--surface-rim);
   background: color-mix(in oklch, var(--ink-deep) 70%, transparent);
 }


### PR DESCRIPTION
## Summary
- make the segmented History inspector fill the available detail pane height
- keep changed-file and diff scrolling at the bottom of their own content regions

## Test Plan
- [x] `pnpm --filter @fleet-plugins/diff test -- tests/rail-layout.test.ts tests/history-panel-state.test.ts`
- [x] `pnpm --filter @fleet-plugins/diff typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] headed Console verification at 1440x1600 and 1180x1950
- [x] add and validate `.changelog.d/pr-278.md`
