### PR TITLE
fix(console): space nameplate window controls to clear focus rings

### DIFF
--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3200,6 +3200,9 @@
   display: flex;
   align-items: center;
   flex: none;
+  /* 버튼 focus/hover 링이 outline 2px + offset 2px로 보더 밖 4px까지 나온다 —
+     gap이 그보다 좁으면 이웃 칩과 링이 겹쳐 외곽선이 이중으로 보인다. */
+  gap: var(--space-2);
   max-width: 0;
   overflow: hidden;
   opacity: 0;
@@ -3213,13 +3216,15 @@
   flex: none;
   width: 1px;
   height: var(--space-3);
-  margin: 0 var(--space-1) 0 var(--space-2);
+  /* 좌측만 보정: titlebar gap(space-1)과 합쳐 beacon–divider 간격을 버튼 간 gap(space-2)과 맞춘다. */
+  margin: 0 0 0 var(--space-1);
   background: var(--hairline-strong);
 }
 
 .canvas-operation:hover .canvas-operation-window-controls,
 .canvas-operation-titlebar:focus-within .canvas-operation-window-controls {
-  max-width: calc(var(--space-3) * 10);
+  /* gap(2×8px) + armed "Close?" 확장폭까지 수용해야 한다 — 120px에서는 armed 상태가 잘린다. */
+  max-width: calc(var(--space-3) * 12);
   opacity: 1;
   pointer-events: auto;
 }


### PR DESCRIPTION
## Summary
- PR #276 명판 전환 때 윈도우 컨트롤 버튼들이 `.canvas-operation-window-controls` 컨테이너로 중첩되면서 버튼 간 gap이 유실 — 1px 칩 보더가 이중선으로 충돌하고 focus/hover 링(outline 2px + offset 2px)이 이웃 버튼을 침범하는 시각 회귀를 수정합니다.
- 컨테이너에 `gap: var(--space-2)`(8px) 복원, divider 마진 정돈, armed "Close?" 확장폭(≈128px)이 잘리지 않도록 전개 캡을 120→144px 상향.

## Test Plan
- [x] `corepack pnpm --filter @dotobokuri/fleet-console test` — 86 files, 793 passed / 21 skipped
- [x] `corepack pnpm --filter @dotobokuri/fleet-console build`
- [x] 격리 실브라우저 실측 — 버튼 간 8px·armed "Close?" 51px 비클립·컨테이너 128px < 144px 캡·링 겹침 해소 스크린샷
- [x] Changelog: `no-changelog` — #276 fragment가 미릴리스라 출하된 적 없는 동작의 보정(릴리스 베이스라인 규칙), pr-276.md의 사용자-가시 주장 불변