### PR TITLE
fix(console): preserve canvas state across panel focus

### DIFF
--- a/.changelog.d/pr-281.md
+++ b/.changelog.d/pr-281.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Preserve the underlying Map or Formation state when focusing, restoring, or minimizing a panel.
+  ko: 패널을 최대화해 포커스하거나 복원 또는 최소화할 때 기존 Map 또는 Formation 상태를 보존합니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
@@ -452,9 +452,10 @@ export function focusOperation(sessionId: string, viewportSize: CanvasViewportSi
 }
 
 export function setMaximizedOperationId(operationId: string): void {
-  clearFormationView();
   if (activeTheaterId) maximizedOperationIdsByTheater.set(activeTheaterId, operationId);
-  const minimized = minimizedForMaximizedOperation(operationId);
+  // 최대화는 underlay(Map 또는 Formation)를 바꾸지 않는 렌더 전용 포커스 레이어다.
+  // 대상만 실제 최소화 목록에서 꺼내 보이게 하고, peer의 실제 최소화 상태는 그대로 둔다.
+  const minimized = state.minimized.filter((sessionId) => sessionId !== operationId);
   const minimizedChanged = !stringArraysEqual(state.minimized, minimized);
   const maximizedChanged = maximizedOperationId !== operationId;
   if (maximizedChanged) maximizedOperationId = operationId;
@@ -565,10 +566,6 @@ function saveMaximizedOperationForActiveTheater(): void {
   } else {
     maximizedOperationIdsByTheater.delete(activeTheaterId);
   }
-}
-
-function minimizedForMaximizedOperation(operationId: string): readonly string[] {
-  return Object.keys(state.operations).filter((sessionId) => sessionId !== operationId);
 }
 
 function stringArraysEqual(left: readonly string[], right: readonly string[]): boolean {

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -163,6 +163,7 @@ export function OperationsCanvas({
       onWheel={interaction.onWheel}
       onContextMenu={handleContextMenu}
       ref={canvasRef}
+      tabIndex={-1}
     >
       <CanvasGrid viewport={canvas.viewport} />
       <div
@@ -178,6 +179,8 @@ export function OperationsCanvas({
         {pluginOperations.map((operation) => {
           const baseGeometry = canvas.operations[operation.id] ?? operation.geometry ?? ensurePluginGeometry(operation);
           const operationMaximized = panelMaximized === operation.id;
+          // focus layer는 peer를 실제 최소화하지 않고, mount를 보존한 채 렌더만 감춘다.
+          const focusLayerHidden = panelMaximized !== null && !operationMaximized;
           const formationSlot = formationSlotByOperationId.get(operation.id);
           const frameGeometry = operationMaximized
             ? maximizedGeometryFor(canvasSize, topPanelZIndex)
@@ -197,6 +200,15 @@ export function OperationsCanvas({
             minimized: minimizedSet.has(operation.id),
             maximized: operationMaximized,
             formation: formationView,
+            focusLayerHidden,
+            onRenderHiddenFocus: () => {
+              const focusTarget = canvasRef.current?.querySelector<HTMLElement>("[data-focus-layer-target='true']");
+              if (focusTarget) {
+                focusTarget.focus();
+                return;
+              }
+              canvasRef.current?.focus();
+            },
             accentKey: canvas.operationAccent[operation.id] ?? operationAccentFromNode(operation),
             onActivate: () => {
               setActiveOperation(operation.id);
@@ -375,6 +387,8 @@ function renderPluginOperation(operation: OperationNode, options: {
   readonly minimized: boolean;
   readonly maximized: boolean;
   readonly formation: boolean;
+  readonly focusLayerHidden: boolean;
+  readonly onRenderHiddenFocus: () => void;
   readonly topEdge: boolean;
   readonly accentKey: string | null;
   readonly onActivate: () => void;
@@ -403,7 +417,9 @@ function renderPluginOperation(operation: OperationNode, options: {
       minimized={options.minimized}
       maximized={options.maximized}
       topEdge={options.topEdge}
-      interactionDisabled={options.formation}
+      renderHidden={options.focusLayerHidden}
+      focusLayerTarget={options.maximized}
+      interactionDisabled={options.formation || options.focusLayerHidden}
       accentKey={options.accentKey}
       onActivate={options.onActivate}
       onClose={options.onClose}
@@ -413,6 +429,7 @@ function renderPluginOperation(operation: OperationNode, options: {
       onSetAccent={options.onSetAccent}
       onGeometryChange={options.onGeometryChange}
       onGeometryCommit={options.onGeometryCommit}
+      onRenderHiddenFocus={options.onRenderHiddenFocus}
     >
       <PluginErrorBoundary fallback={<div className="fc-plugin-error">Plugin operation failed to render.</div>}>
         <PluginOperationRenderer

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type ReactNode, type WheelEvent as ReactWheelEvent } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type ReactNode, type WheelEvent as ReactWheelEvent } from "react";
 
 import type { OperationNode, OperationGeometry } from "@fleet-console/sdk/operations";
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
@@ -16,6 +16,8 @@ interface OperationFrameProps {
   readonly status?: OperationActivity;
   readonly minimized?: boolean;
   readonly maximized?: boolean;
+  readonly renderHidden?: boolean;
+  readonly focusLayerTarget?: boolean;
   readonly topEdge?: boolean;
   readonly interactionDisabled?: boolean;
   readonly accentKey?: string | null;
@@ -28,6 +30,7 @@ interface OperationFrameProps {
   readonly onSetAccent?: (accentKey: string | null) => void;
   readonly onGeometryChange: (geometry: OperationGeometry) => void;
   readonly onGeometryCommit: (geometry: OperationGeometry) => void;
+  readonly onRenderHiddenFocus?: () => void;
 }
 
 interface DragState {
@@ -49,7 +52,7 @@ const MIN_OPERATION_WIDTH = 320;
 const MIN_OPERATION_HEIGHT = 200;
 const CLOSE_ARM_DURATION_MS = 1500;
 
-export function OperationFrame({ operation, active, geometry, zoom, status, minimized = false, maximized = false, topEdge = false, interactionDisabled = false, accentKey = null, children, onActivate, onClose, onMinimize, onMaximize, onRename, onSetAccent, onGeometryChange, onGeometryCommit }: OperationFrameProps) {
+export function OperationFrame({ operation, active, geometry, zoom, status, minimized = false, maximized = false, renderHidden = false, focusLayerTarget = false, topEdge = false, interactionDisabled = false, accentKey = null, children, onActivate, onClose, onMinimize, onMaximize, onRename, onSetAccent, onGeometryChange, onGeometryCommit, onRenderHiddenFocus }: OperationFrameProps) {
   const operationRef = useRef<HTMLElement | null>(null);
   const identityTriggerRef = useRef<HTMLButtonElement | null>(null);
   const dragRef = useRef<DragState | null>(null);
@@ -90,6 +93,16 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
     const frame = window.requestAnimationFrame(() => identityTriggerRef.current?.focus());
     return () => window.cancelAnimationFrame(frame);
   }, [rename.renaming]);
+
+  // focus layer가 현재 포커스를 담은 peer를 숨길 때는 body로 흘려보내지 않고 새 전면 frame(없으면 Canvas)으로 옮긴다.
+  useLayoutEffect(() => {
+    if (!renderHidden || typeof document === "undefined") return;
+    // AccentPopover는 document.body에 포털되지만 frame이 소유한다. 열린 peer는 포커스 위치와 무관하게
+    // 먼저 닫고, 메뉴 내부에 있던 포커스도 전면 frame/Canvas로 명시적으로 넘긴다.
+    const hadAccentPopover = accentAnchor !== null;
+    if (hadAccentPopover) setAccentAnchor(null);
+    if (hadAccentPopover || operationRef.current?.contains(document.activeElement)) onRenderHiddenFocus?.();
+  }, [accentAnchor, renderHidden, onRenderHiddenFocus]);
 
   const clearCloseArmTimer = () => {
     if (closeArmTimeoutRef.current === null) return;
@@ -260,6 +273,7 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
     width: Math.round(geometry.width),
     height: Math.round(geometry.height),
     zIndex: geometry.zIndex,
+    ...(renderHidden ? { display: "none" } : {}),
     ...(accentColor ? { "--user-accent": accentColor } : {}),
   } as CSSProperties;
 
@@ -270,8 +284,11 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
       style={frameStyle}
       onPointerDown={onActivate}
       data-canvas-operation
+      data-focus-layer-target={focusLayerTarget ? "true" : undefined}
       aria-label={`Operation ${displayTitle}`}
-      inert={minimized ? true : undefined}
+      tabIndex={focusLayerTarget ? -1 : undefined}
+      hidden={renderHidden || undefined}
+      inert={minimized || renderHidden ? true : undefined}
     >
       {!maximized && !interactionDisabled ? (
         <div

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -273,7 +273,8 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
     width: Math.round(geometry.width),
     height: Math.round(geometry.height),
     zIndex: geometry.zIndex,
-    ...(renderHidden ? { display: "none" } : {}),
+    // Focus Layer peer는 xterm ResizeObserver가 기존 컨테이너 크기를 계속 보게 레이아웃을 보존한다.
+    ...(renderHidden ? { visibility: "hidden", pointerEvents: "none" } : {}),
     ...(accentColor ? { "--user-accent": accentColor } : {}),
   } as CSSProperties;
 
@@ -286,8 +287,8 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
       data-canvas-operation
       data-focus-layer-target={focusLayerTarget ? "true" : undefined}
       aria-label={`Operation ${displayTitle}`}
+      aria-hidden={renderHidden || undefined}
       tabIndex={focusLayerTarget ? -1 : undefined}
-      hidden={renderHidden || undefined}
       inert={minimized || renderHidden ? true : undefined}
     >
       {!maximized && !interactionDisabled ? (

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -86,14 +86,14 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       const currentId = maximizedRef.current ?? stateRef.current.activeOperationId;
       const nextId = nextOperationId(order, currentId, event.key === "ArrowRight" ? 1 : -1);
       if (!nextId) return;
-      if (formationRef.current) {
-        restoreOperation(nextId);
-        setActiveOperation(nextId);
-        return;
-      }
       if (maximizedRef.current) {
         setActiveOperation(nextId);
         setMaximizedOperationId(nextId);
+        return;
+      }
+      if (formationRef.current) {
+        restoreOperation(nextId);
+        setActiveOperation(nextId);
         return;
       }
       focusOperation(nextId);
@@ -121,12 +121,6 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
   useEffect(() => {
     const operationId = state.pendingOperationFocus;
     if (operationId === null) return;
-    if (formationView) {
-      restoreOperation(operationId);
-      setActiveOperation(operationId);
-      consumeOperationFocus();
-      return;
-    }
     // 최대화 뷰 유지: theater 전환 effect(loadForTheater, 위쪽 effect)가 먼저 실행되어
     // 도착 Theater의 최대화 상태를 복원한 뒤이므로, 여기서 getMaximizedOperationId()는 도착 Theater 기준값이다.
     // 최대화 중이면 최대화 대상만 목적지 op로 교체한다 — handleFocus·Alt+←/→와 동일 정책.
@@ -135,11 +129,17 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       consumeOperationFocus();
       return;
     }
+    if (getFormationView()) {
+      restoreOperation(operationId);
+      setActiveOperation(operationId);
+      consumeOperationFocus();
+      return;
+    }
     clearMaximizedOperationId();
     const viewportSize = viewportSizeFor(bodyRef.current);
     if (viewportSize) focusCanvasOperation(operationId, viewportSize);
     consumeOperationFocus();
-  }, [formationView, state.pendingOperationFocus]);
+  }, [state.pendingOperationFocus]);
 
   const canLaunch = !!state.activeTheaterId && !state.addingTheater;
   const theaterOperations = (state.operations ?? []).filter((op) => op.theaterId === state.activeTheaterId);
@@ -177,17 +177,17 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       focusOperation(operationId);
       return;
     }
+    // 포커스 레이어가 활성화되어 있으면 같은 대상도 이 경로에서 끝낸다. 대상이 바뀔 때만 레이어를 전환한다.
+    // Alt+←/→ 순환(operations.tsx:73-76)과 동일 정책. getMaximizedOperationId()는 store 스냅샷에서 live로 읽으므로 [] deps 유지 가능.
+    const currentMaximized = getMaximizedOperationId();
+    if (currentMaximized !== null) {
+      setActiveOperation(operationId);
+      if (currentMaximized !== operationId) setMaximizedOperationId(operationId);
+      return;
+    }
     if (getFormationView()) {
       restoreOperation(operationId);
       setActiveOperation(operationId);
-      return;
-    }
-    // 최대화 중인 패널이 있고 클릭 대상이 다른 op면 최대화 패널을 전환하고 끝낸다.
-    // Alt+←/→ 순환(operations.tsx:73-76)과 동일 정책. getMaximizedOperationId()는 store 스냅샷에서 live로 읽으므로 [] deps 유지 가능.
-    const currentMaximized = getMaximizedOperationId();
-    if (currentMaximized !== null && currentMaximized !== operationId) {
-      setActiveOperation(operationId);
-      setMaximizedOperationId(operationId);
       return;
     }
     const snapshot = getCanvasSnapshot();
@@ -428,7 +428,7 @@ async function launchViaPlugin(
   if (!newOperationId) return;
   // 최대화 패널이 떠 있는 상태에서 새 Operation을 만들면 최대화를 유지하고 새 패널을 최대화 대상으로 승계한다.
   // focusOperation은 pendingOperationFocus 경로로 clearMaximizedOperationId를 부르므로(최대화 해제), 최대화 중에는 호출하지 않는다.
-  // handleFocus(operations.tsx)·Alt+←/→ 순환과 동일 정책으로, setMaximizedOperationId가 나머지 패널을 최소화해 새 패널만 전면화한다.
+  // handleFocus(operations.tsx)·Alt+←/→ 순환과 동일 정책으로, 새 패널로 렌더 전용 포커스 레이어를 승계한다.
   //
   // 단, 비동기 launch 동안 사용자가 다른 Theater로 전환했을 수 있다. getMaximizedOperationId/setMaximizedOperationId는
   // canvas 스토어가 로드한 Theater 기준으로 동작하므로, 그 로드된 Theater가 launch 시점 Theater와 같을 때만 승계해야 한다.
@@ -437,7 +437,7 @@ async function launchViaPlugin(
   // 갱신되어, A→B→A 왕복 시 store는 A인데 canvas는 아직 B인 desync 창이 생기기 때문이다.
   const stillOnLaunchTheater = getLoadedTheaterId() === theaterId;
   // fetchOperations 실패(.catch)로 hydrate가 누락되면 store에 newOperationId가 없다. 이때 승계하면
-  // setMaximizedOperationId가 기존 패널을 전부 최소화하지만 새 id는 캔버스에 없어 빈 화면이 박제된다.
+  // 존재하지 않는 포커스 대상을 가리켜 빈 화면이 박제된다.
   // hydrate된 경우에만 승계하고, 아니면 focusOperation(op 부재 시 안전하게 no-op)으로 기존 최대화 패널을 그대로 둔다.
   const operationHydrated = getState().operations.some((operation) => operation.id === newOperationId);
   if (stillOnLaunchTheater && operationHydrated && getMaximizedOperationId() !== null) {

--- a/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
+++ b/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
@@ -165,7 +165,7 @@ describe("CanvasMinimap collapse behavior", () => {
     expect(document.querySelector('[aria-label="Open Map"]')).not.toBeNull();
   });
 
-  it("keeps peer frames mounted but non-rendered and moves focus into the focus layer", () => {
+  it("keeps peer frames mounted with geometry but visually and interactively absent in the focus layer", () => {
     renderOperationsCanvas();
     const peer = document.querySelector<HTMLElement>('[aria-label="Operation Peer"]');
     const peerIdentity = document.querySelector<HTMLButtonElement>('[aria-label="Rename operation Peer"]');
@@ -181,8 +181,12 @@ describe("CanvasMinimap collapse behavior", () => {
     });
 
     expect(document.querySelector('[aria-label="Operation Peer"]')).toBe(peer);
-    expect(peer?.hidden).toBe(true);
-    expect(getComputedStyle(peer!).display).toBe("none");
+    expect(peer?.hidden).toBe(false);
+    expect(getComputedStyle(peer!).visibility).toBe("hidden");
+    expect(getComputedStyle(peer!).pointerEvents).toBe("none");
+    expect(Number.parseFloat(getComputedStyle(peer!).width)).toBeGreaterThan(0);
+    expect(Number.parseFloat(getComputedStyle(peer!).height)).toBeGreaterThan(0);
+    expect(peer?.getAttribute("aria-hidden")).toBe("true");
     expect(peer?.hasAttribute("inert")).toBe(true);
     const focusedFrame = document.querySelector<HTMLElement>('[aria-label="Operation Minimap boundary"]');
     expect(focusedFrame?.hidden).toBe(false);

--- a/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
+++ b/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
@@ -10,7 +10,13 @@ import { clearFormationView, clearMaximizedOperationId, getSnapshot, loadForThea
 import type { ConsoleState, OperationNode } from "../core/client/src/types.js";
 
 vi.mock("../core/client/src/plugin-registry.js", () => ({
-  usePluginRegistry: () => ({ plugins: [], operationKinds: [], settingsSections: [], notificationKinds: [], railPanels: [] }),
+  usePluginRegistry: () => ({
+    plugins: [],
+    operationKinds: [{ pluginId: "test-plugin", type: "shell", title: "Test", render: ({ operationId }: { readonly operationId: string }) => createElement("div", { "data-plugin-operation": operationId }) }],
+    settingsSections: [],
+    notificationKinds: [],
+    railPanels: [],
+  }),
 }));
 
 let root: Root | null = null;
@@ -51,7 +57,10 @@ beforeEach(() => {
   clearMaximizedOperationId();
   setState({
     viewport: { x: 0, y: 0, zoom: 1 },
-    operations: { operation: { x: 0, y: 0, width: 320, height: 200, zIndex: 1 } },
+    operations: {
+      operation: { x: 0, y: 0, width: 320, height: 200, zIndex: 1 },
+      peer: { x: 360, y: 40, width: 320, height: 200, zIndex: 2 },
+    },
   });
   container = document.createElement("div");
   document.body.appendChild(container);
@@ -156,6 +165,57 @@ describe("CanvasMinimap collapse behavior", () => {
     expect(document.querySelector('[aria-label="Open Map"]')).not.toBeNull();
   });
 
+  it("keeps peer frames mounted but non-rendered and moves focus into the focus layer", () => {
+    renderOperationsCanvas();
+    const peer = document.querySelector<HTMLElement>('[aria-label="Operation Peer"]');
+    const peerIdentity = document.querySelector<HTMLButtonElement>('[aria-label="Rename operation Peer"]');
+    expect(peer).not.toBeNull();
+    expect(peerIdentity).not.toBeNull();
+    expect(peer?.hidden).toBe(false);
+    peerIdentity?.focus();
+    expect(document.activeElement).toBe(peerIdentity);
+
+    act(() => {
+      toggleFormationView();
+      setMaximizedOperationId("operation");
+    });
+
+    expect(document.querySelector('[aria-label="Operation Peer"]')).toBe(peer);
+    expect(peer?.hidden).toBe(true);
+    expect(getComputedStyle(peer!).display).toBe("none");
+    expect(peer?.hasAttribute("inert")).toBe(true);
+    const focusedFrame = document.querySelector<HTMLElement>('[aria-label="Operation Minimap boundary"]');
+    expect(focusedFrame?.hidden).toBe(false);
+    expect(document.activeElement).toBe(focusedFrame);
+    expect(getSnapshot().minimized).toEqual([]);
+
+    act(() => clearMaximizedOperationId());
+
+    expect(peer?.hidden).toBe(false);
+    expect(getSnapshot().minimized).toEqual([]);
+  });
+
+  it("closes a hidden peer's portaled accent menu and transfers its menu focus", () => {
+    renderOperationsCanvas();
+    const peerAccent = document.querySelector<HTMLButtonElement>('[aria-label="Set accent for operation Peer"]');
+    expect(peerAccent).not.toBeNull();
+
+    act(() => peerAccent!.click());
+
+    const menuItem = document.querySelector<HTMLButtonElement>('[role="menuitem"]');
+    expect(menuItem).not.toBeNull();
+    menuItem?.focus();
+    expect(document.activeElement).toBe(menuItem);
+
+    act(() => setMaximizedOperationId("operation"));
+
+    expect(document.querySelector('[role="menu"]')).toBeNull();
+    expect(document.querySelector(".accent-popover-overlay")).toBeNull();
+    const focusedFrame = document.querySelector<HTMLElement>('[aria-label="Operation Minimap boundary"]');
+    expect(document.activeElement).toBe(focusedFrame);
+    expect(document.querySelector<HTMLElement>('[aria-label="Operation Peer"]')?.contains(document.activeElement)).toBe(false);
+  });
+
   it("moves the canvas viewport when the mounted minimap receives pointer navigation", () => {
     renderOperationsCanvas();
     const inner = document.querySelector<HTMLDivElement>(".canvas-minimap-inner");
@@ -186,6 +246,13 @@ const OPERATION: OperationNode = {
   ts: { createdAt: 0, updatedAt: 0 },
 };
 
+const PEER_OPERATION: OperationNode = {
+  ...OPERATION,
+  id: "peer",
+  title: "Peer",
+  geometry: { x: 360, y: 40, width: 320, height: 200, zIndex: 2 },
+};
+
 const CANVAS_STATE: ConsoleState = {
   connection: "connecting",
   connectionError: null,
@@ -198,7 +265,7 @@ const CANVAS_STATE: ConsoleState = {
   effectivePort: 0,
   portHonored: true,
   theaters: [],
-  operations: [OPERATION],
+  operations: [OPERATION, PEER_OPERATION],
   operationsHydrated: true,
   groups: [],
   activeTheaterId: "minimap-boundary",

--- a/runtime/fleet-console/tests/canvas-store.test.ts
+++ b/runtime/fleet-console/tests/canvas-store.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { calculateGridSlots, clearFormationView, clearMaximizedOperationId, getFormationLayout, getFormationView, getMaximizedOperationId, getSnapshot, getTheaterCanvasSnapshot, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, selectFormationLayout, setFormationLayout, setMaximizedOperationId, setOperationAccent, setOperationGeometry, setOperationOrder, toggleFormationView, toggleTheaterGroupCollapsed, type OperationGeometry } from "../core/client/src/canvas/canvas-store.js";
+import { calculateGridSlots, clearFormationView, clearMaximizedOperationId, getFormationLayout, getFormationView, getMaximizedOperationId, getSnapshot, getTheaterCanvasSnapshot, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, selectFormationLayout, setFormationLayout, setMaximizedOperationId, setOperationAccent, setOperationGeometry, setOperationOrder, setState, toggleFormationView, toggleTheaterGroupCollapsed, type OperationGeometry } from "../core/client/src/canvas/canvas-store.js";
 
 const GEOMETRY: OperationGeometry = { x: 0, y: 0, width: 100, height: 100, zIndex: 0 };
 
@@ -60,26 +60,52 @@ describe("canvas store", () => {
     expect(getMaximizedOperationId()).toBe("op-a");
   });
 
-  it("minimizes non-maximized Operations when a panel is maximized", () => {
+  it("keeps the actual minimized list and Formation under a render-only focus layer", () => {
     setOperationGeometry("op-a", { ...GEOMETRY });
     setOperationGeometry("op-b", { ...GEOMETRY });
     setOperationGeometry("op-c", { ...GEOMETRY });
+    minimizeOperation("op-a");
+    const viewport = { x: 48, y: 72, zoom: 0.8 };
+    const operations = getSnapshot().operations;
+    setState({ viewport });
+    toggleFormationView();
 
     setMaximizedOperationId("op-b");
 
     expect(getMaximizedOperationId()).toBe("op-b");
-    expect(getSnapshot().minimized).toEqual(["op-a", "op-c"]);
+    expect(getFormationView()).toBe(true);
+    expect(getSnapshot().minimized).toEqual(["op-a"]);
+    expect(getSnapshot().viewport).toEqual(viewport);
+    expect(getSnapshot().operations).toEqual(operations);
+
+    clearMaximizedOperationId();
+
+    expect(getFormationView()).toBe(true);
+    expect(getSnapshot().minimized).toEqual(["op-a"]);
   });
 
-  it("restores a minimized Operation when it becomes maximized", () => {
+  it("removes only the focused Operation from the actual minimized list", () => {
     setOperationGeometry("op-a", { ...GEOMETRY });
     setOperationGeometry("op-b", { ...GEOMETRY });
+    minimizeOperation("op-a");
     minimizeOperation("op-b");
 
     setMaximizedOperationId("op-b");
 
     expect(getMaximizedOperationId()).toBe("op-b");
     expect(getSnapshot().minimized).toEqual(["op-a"]);
+  });
+
+  it("minimizes only the focused Operation and clears its focus layer", () => {
+    setOperationGeometry("op-a", { ...GEOMETRY });
+    setOperationGeometry("op-b", { ...GEOMETRY });
+    minimizeOperation("op-a");
+    setMaximizedOperationId("op-b");
+
+    minimizeOperation("op-b");
+
+    expect(getMaximizedOperationId()).toBeNull();
+    expect(getSnapshot().minimized).toEqual(["op-a", "op-b"]);
   });
 
   it("minimizes boot panels without changing their stored geometry", () => {
@@ -162,17 +188,17 @@ describe("canvas store", () => {
     expect(getSnapshot().collapsedGroups).toEqual(["group-a"]);
   });
 
-  it("keeps maximize-docked Operations minimized when entering open-panel Formation", () => {
+  it("keeps Formation and actual minimized Operations when focusing a panel", () => {
     setOperationGeometry("op-a", { ...GEOMETRY });
     setOperationGeometry("op-b", { ...GEOMETRY });
     setOperationGeometry("op-c", { ...GEOMETRY });
+    minimizeOperation("op-a");
+    toggleFormationView();
     setMaximizedOperationId("op-b");
 
-    toggleFormationView();
-
     expect(getFormationView()).toBe(true);
-    expect(getMaximizedOperationId()).toBeNull();
-    expect(getSnapshot().minimized).toEqual(["op-a", "op-c"]);
+    expect(getMaximizedOperationId()).toBe("op-b");
+    expect(getSnapshot().minimized).toEqual(["op-a"]);
   });
 
   it("keeps manually minimized Operations minimized when entering Formation", () => {

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -5,7 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getMaximizedOperationId, getSnapshot, loadForTheater, restoreOperation, setMaximizedOperationId, setOperationGeometry } from "../core/client/src/canvas/canvas-store.js";
+import { clearFormationView, clearMaximizedOperationId, getFormationView, getMaximizedOperationId, getSnapshot, loadForTheater, restoreOperation, setMaximizedOperationId, setOperationGeometry, setViewport, toggleFormationView } from "../core/client/src/canvas/canvas-store.js";
 import { focusOperation, getState, hydrateOperations, setState } from "../core/client/src/store.js";
 import type { OperationNode, TheaterBootstrap } from "../core/client/src/types.js";
 
@@ -16,6 +16,9 @@ const apiMocks = vi.hoisted(() => ({
 }));
 const keyboardShortcutMocks = vi.hoisted(() => ({
   shouldHandleOperationsKeyboardShortcut: vi.fn(),
+}));
+const sideBarMocks = vi.hoisted(() => ({
+  onFocus: null as null | ((operationId: string) => void),
 }));
 
 vi.mock("../core/client/src/api.js", () => ({
@@ -56,7 +59,12 @@ vi.mock("../core/client/src/rail/rail-store.js", () => ({ toggleRailChrome: vi.f
 vi.mock("../core/client/src/rail/right-rail.js", () => ({ RightRail: () => null }));
 vi.mock("../core/client/src/release-notes-fetch.js", () => ({ abortReleaseNotesFetch: vi.fn(), requestReleaseNotes: vi.fn() }));
 vi.mock("../core/client/src/sidebar/operations-side-bar-store.js", () => ({ getSideBarState: () => ({ collapsed: false }), setSideBarCollapsed: vi.fn() }));
-vi.mock("../core/client/src/sidebar/operations-side-bar.js", () => ({ OperationsSideBar: () => null }));
+vi.mock("../core/client/src/sidebar/operations-side-bar.js", () => ({
+  OperationsSideBar: ({ onFocus }: { readonly onFocus: (operationId: string) => void }) => {
+    sideBarMocks.onFocus = onFocus;
+    return null;
+  },
+}));
 vi.mock("../core/client/src/whatsnew-i18n.js", () => ({ resolveReleaseNotesLocale: () => "en" }));
 
 let root: Root | null = null;
@@ -68,6 +76,9 @@ beforeEach(() => {
   document.body.replaceChildren();
   window.localStorage.clear();
   window.history.replaceState({}, "", "/operations");
+  loadForTheater("theater-a");
+  clearMaximizedOperationId();
+  clearFormationView();
   loadForTheater(null);
   setState({ activeOperationId: null, activeTheaterId: null, groups: [], operations: [], operationsHydrated: false, theaters: [] });
   container = document.createElement("div");
@@ -75,10 +86,18 @@ beforeEach(() => {
   root = createRoot(container);
   apiMocks.fetchGroups.mockResolvedValue([]);
   keyboardShortcutMocks.shouldHandleOperationsKeyboardShortcut.mockReturnValue(false);
+  sideBarMocks.onFocus = null;
 });
 
 afterEach(() => {
   act(() => root?.unmount());
+  loadForTheater("theater-a");
+  clearMaximizedOperationId();
+  clearFormationView();
+  loadForTheater("theater-b");
+  clearMaximizedOperationId();
+  clearFormationView();
+  loadForTheater(null);
   container?.remove();
   root = null;
   container = null;
@@ -190,7 +209,7 @@ describe("Operations boot minimization", () => {
     expect(getSnapshot().minimized).toEqual(["initial"]);
   });
 
-  it("advances the maximized Operation with Alt+Arrow", async () => {
+  it("advances the focus layer with Alt+Arrow while preserving Formation", async () => {
     const operations = deferred<readonly OperationNode[]>();
     const theaters = deferred<TheaterBootstrap>();
     apiMocks.fetchOperations.mockReturnValueOnce(operations.promise);
@@ -206,10 +225,12 @@ describe("Operations boot minimization", () => {
       await Promise.resolve();
     });
     await act(async () => {
+      toggleFormationView();
       setMaximizedOperationId("first");
       await Promise.resolve();
     });
     expect(getMaximizedOperationId()).toBe("first");
+    expect(getFormationView()).toBe(true);
     expect(getSnapshot().minimized).toEqual(["second"]);
 
     keyboardShortcutMocks.shouldHandleOperationsKeyboardShortcut.mockReturnValue(true);
@@ -222,7 +243,107 @@ describe("Operations boot minimization", () => {
     expect(event.defaultPrevented).toBe(true);
     expect(getState().activeOperationId).toBe("second");
     expect(getMaximizedOperationId()).toBe("second");
-    expect(getSnapshot().minimized).toEqual(["first"]);
+    expect(getFormationView()).toBe(true);
+    expect(getSnapshot().minimized).toEqual([]);
+  });
+
+  it("switches pending focus through the active focus layer before Formation", async () => {
+    const operations = deferred<readonly OperationNode[]>();
+    const theaters = deferred<TheaterBootstrap>();
+    apiMocks.fetchOperations.mockReturnValueOnce(operations.promise);
+    apiMocks.fetchTheaterBootstrap.mockReturnValueOnce(theaters.promise);
+    const { App } = await import("../core/client/src/app.js");
+
+    await act(async () => {
+      root!.render(createElement(BrowserRouter, null, createElement(App)));
+    });
+    await act(async () => {
+      operations.resolve([operation("first"), operation("second")]);
+      theaters.resolve({ theaters: [theater()] });
+      await Promise.resolve();
+    });
+    await act(async () => {
+      toggleFormationView();
+      setMaximizedOperationId("first");
+      focusOperation("second");
+      await Promise.resolve();
+    });
+
+    expect(getState().activeOperationId).toBe("second");
+    expect(getMaximizedOperationId()).toBe("second");
+    expect(getFormationView()).toBe(true);
+    expect(getSnapshot().minimized).toEqual([]);
+  });
+
+  it("keeps a same-target sidebar selection in the focus layer without changing Map geometry", async () => {
+    const operations = deferred<readonly OperationNode[]>();
+    const theaters = deferred<TheaterBootstrap>();
+    apiMocks.fetchOperations.mockReturnValueOnce(operations.promise);
+    apiMocks.fetchTheaterBootstrap.mockReturnValueOnce(theaters.promise);
+    const { App } = await import("../core/client/src/app.js");
+
+    await act(async () => {
+      root!.render(createElement(BrowserRouter, null, createElement(App)));
+    });
+    await act(async () => {
+      operations.resolve([operation("first")]);
+      theaters.resolve({ theaters: [theater()] });
+      await Promise.resolve();
+    });
+    await act(async () => {
+      setViewport({ x: 48, y: 72, zoom: 0.8 });
+      setMaximizedOperationId("first");
+    });
+    const viewport = getSnapshot().viewport;
+    const geometry = getSnapshot().operations.first;
+    expect(sideBarMocks.onFocus).not.toBeNull();
+
+    await act(async () => {
+      sideBarMocks.onFocus?.("first");
+      await Promise.resolve();
+    });
+
+    expect(getMaximizedOperationId()).toBe("first");
+    expect(getSnapshot().viewport).toEqual(viewport);
+    expect(getSnapshot().operations.first).toEqual(geometry);
+  });
+
+  it("uses the destination Theater's live Formation state for pending focus", async () => {
+    const operations = deferred<readonly OperationNode[]>();
+    const theaters = deferred<TheaterBootstrap>();
+    apiMocks.fetchOperations.mockReturnValueOnce(operations.promise);
+    apiMocks.fetchTheaterBootstrap.mockReturnValueOnce(theaters.promise);
+    const { App } = await import("../core/client/src/app.js");
+
+    await act(async () => {
+      root!.render(createElement(BrowserRouter, null, createElement(App)));
+    });
+    await act(async () => {
+      operations.resolve([operation("a1", 1, "theater-a"), operation("b1", 1, "theater-b")]);
+      theaters.resolve({ theaters: [theater(), theater("theater-b", "Theater B")] });
+      await Promise.resolve();
+    });
+    const destinationViewport = { x: 144, y: 96, zoom: 0.7 };
+    let destinationGeometry: ReturnType<typeof getSnapshot>["operations"][string] | undefined;
+    await act(async () => {
+      loadForTheater("theater-b");
+      setOperationGeometry("b1", { x: 32, y: 64, width: 640, height: 400, zIndex: 3 });
+      setViewport(destinationViewport);
+      toggleFormationView();
+      destinationGeometry = getSnapshot().operations.b1;
+      loadForTheater("theater-a");
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      focusOperation("b1");
+      await Promise.resolve();
+    });
+
+    expect(getState().activeTheaterId).toBe("theater-b");
+    expect(getFormationView()).toBe(true);
+    expect(getSnapshot().viewport).toEqual(destinationViewport);
+    expect(getSnapshot().operations.b1).toEqual(destinationGeometry);
   });
 
   it("minimizes a second Theater's existing panels on first in-session view, surfacing only the selected panel", async () => {


### PR DESCRIPTION
## PR Title

fix(console): preserve canvas state across panel focus

## Summary

Keeps panel maximize as a render-only Focus Layer over the existing Map or Formation state. Restore now reveals the exact underlying layout, while Minimize affects only the focused panel; mounted peers, viewport, geometry, minimization, keyboard focus, and Theater transitions remain intact.

## Type of Change

- [ ] feat — new feature or carrier capability
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- [ ] `extensions/core`
- [ ] `extensions/fleet` (Admiral / Bridge / Carriers)
- [ ] `extensions/boot`
- [ ] `extensions/diagnostics`
- [ ] `extensions/metaphor`
- [ ] `packages/unified-agent`
- [ ] `bin/` or root tooling
- [ ] Documentation (README / SETUP / AGENTS.md)

Fleet Console canvas, operation frame, operations page, and regression tests.

## Test Plan

- [x] `pnpm exec vitest run tests/canvas-store.test.ts tests/operations-boot-minimization.integration.test.ts tests/canvas-minimap-formation.test.ts` (39 passed)
- [x] `pnpm exec tsc --noEmit -p core/client/tsconfig.json`
- [x] `pnpm build`
- [x] Headed isolated Console E2E: Formation maximize/Restore/Minimize, Alt+Arrow focus switching, stable mounts, computed hiding, and AccentPopover focus handoff
- [x] Headed isolated live-xterm E2E after review fix: hidden peer retained its 433x1117 frame and 400x1088 xterm screen while inert, aria-hidden, pointer-inaccessible, and focus-free; page errors and unhandled rejections were 0
- [ ] Full `pnpm test`: 85/86 files completed with 791 passed and 21 skipped; the unrelated `codex-security-routes.test.ts` worker exceeded its existing 4 GB heap limit
- [ ] Full `pnpm typecheck`: blocked by existing CSS side-effect import and `virtual:fleet-plugins` declaration errors; the scoped Console client TypeScript check passed

## Changelog

- [x] Added `.changelog.d/pr-281.md` in the required follow-up commit.
- [x] Fragment section is `Fixed`.
- [x] Fragment uses the allowed `[fleet-console]` component tag.
- [x] `node scripts/compile-changelog-fragments.mjs --check` (18 entries validated)

## Related Issues / PRs

None.

## Notes for Reviewers

The Focus Layer is intentionally render-only: it does not replace or reset the Map/Formation state. Hidden peer panels stay mounted with their layout geometry intact so terminal ResizeObserver fitting cannot collapse PTY dimensions, while visibility, pointer, focus, and accessibility are suppressed. Portal-owned focus is handed to the newly visible panel before the peer is hidden.
