### PR TITLE
feat(console): auto-hide command band in fullscreen

### DIFF
--- a/.changelog.d/pr-282.md
+++ b/.changelog.d/pr-282.md
@@ -1,0 +1,9 @@
+### fleet-console
+#### Added
+- [fleet-console] Auto-hide the command band in fullscreen with edge, keyboard, pin, and reduced-motion controls.
+  ko: 전체 화면에서 명령 밴드를 자동으로 숨기고 가장자리, 키보드, 고정, 모션 감소 제어를 지원합니다.
+
+### fleet-desktop
+#### Added
+- [fleet-console] Relay native window fullscreen state so Console chrome follows Desktop fullscreen.
+  ko: 네이티브 창의 전체 화면 상태를 전달해 Console 크롬이 Desktop 전체 화면을 따르도록 합니다.

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { useCallback, useEffect, useRef, useState, type CSSProperties, type FocusEvent } from "react";
 
 import { fetchOperations, renameOperation } from "../api.js";
 import { commandBandRenameCommitTarget, railPathContextDeckOpenAfterCommandBandToggle, shouldCloseCommandBandContextDeck } from "./command-band-guards.js";
@@ -12,6 +12,7 @@ import { theaterInitials } from "../sidebar/operations-side-bar.js";
 import { setSideBarCollapsed, useSideBarState } from "../sidebar/operations-side-bar-store.js";
 import { hydrateOperations, toggleOperationSearch } from "../store.js";
 import { useInlineRename } from "../use-inline-rename.js";
+import { useFullscreenCommandBand } from "./use-fullscreen-command-band.js";
 
 interface NavigatorWithUserAgentData extends Navigator {
   readonly userAgentData?: {
@@ -42,8 +43,17 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
   const pathContext = useRailPathContextStore();
   const contextTriggerRef = useRef<HTMLButtonElement>(null);
   const contextDeckRef = useRef<HTMLDivElement>(null);
+  const commandBandRef = useRef<HTMLElement>(null);
+  const edgeRevealRef = useRef<HTMLButtonElement>(null);
+  const pointerWithinRef = useRef({ edge: false, band: false });
   const renameTargetOperationIdRef = useRef<string | null>(null);
   const [contextDeckOpen, setContextDeckOpen] = useState(false);
+  const canAutoHide = useCallback(() => {
+    const activeElement = document.activeElement;
+    const focusWithin = activeElement instanceof Node && (commandBandRef.current?.contains(activeElement) || edgeRevealRef.current?.contains(activeElement));
+    return !focusWithin && !pointerWithinRef.current.edge && !pointerWithinRef.current.band;
+  }, []);
+  const fullscreen = useFullscreenCommandBand(canAutoHide);
   const rename = useInlineRename({
     currentTitle: activeOperation?.title ?? "",
     onCommit: (title) => {
@@ -100,8 +110,63 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
     rename.begin();
   };
 
+  const hideAfterInteractionLeaves = () => {
+    if (canAutoHide()) fullscreen.hideAfterLeave();
+  };
+
+  const handleInteractionBlur = (event: FocusEvent<HTMLElement>) => {
+    const nextTarget = event.relatedTarget;
+    if ((!(nextTarget instanceof Node) || (!commandBandRef.current?.contains(nextTarget) && !edgeRevealRef.current?.contains(nextTarget))) && !pointerWithinRef.current.edge && !pointerWithinRef.current.band) {
+      fullscreen.hideAfterLeave();
+    }
+  };
+
+  const handleEdgePointerEnter = () => {
+    pointerWithinRef.current.edge = true;
+    fullscreen.reveal();
+  };
+
+  const handleEdgePointerLeave = () => {
+    pointerWithinRef.current.edge = false;
+    hideAfterInteractionLeaves();
+  };
+
+  const handleBandPointerEnter = () => {
+    pointerWithinRef.current.band = true;
+    fullscreen.reveal();
+  };
+
+  const handleBandPointerLeave = () => {
+    pointerWithinRef.current.band = false;
+    hideAfterInteractionLeaves();
+  };
+
+  const commandBandHidden = fullscreen.isFullscreen && !fullscreen.isVisible;
+
   return (
-    <header className={`command-band${operationsViewVisible ? " is-operations" : " is-utility"}`} style={{ "--command-band-left-width": `${sideBar.width}px`, "--command-band-right-width": `${rightRailWidth}px` } as CSSProperties}>
+    <>
+      <button
+        ref={edgeRevealRef}
+        type="button"
+        className={`command-band-edge-reveal${fullscreen.isFullscreen ? " is-fullscreen" : ""}`}
+        aria-label="Show command band"
+        onPointerEnter={handleEdgePointerEnter}
+        onPointerLeave={handleEdgePointerLeave}
+        onFocus={fullscreen.reveal}
+        onBlur={handleInteractionBlur}
+        onKeyDown={(event) => { if (event.key === "Tab") fullscreen.reveal(); }}
+      />
+      <header
+        ref={commandBandRef}
+        className={`command-band${operationsViewVisible ? " is-operations" : " is-utility"}${fullscreen.isFullscreen ? " is-fullscreen" : ""}${fullscreen.isVisible ? " is-revealed" : ""}`}
+        style={{ "--command-band-left-width": `${sideBar.width}px`, "--command-band-right-width": `${rightRailWidth}px` } as CSSProperties}
+        aria-hidden={commandBandHidden || undefined}
+        inert={commandBandHidden || undefined}
+        onPointerEnter={handleBandPointerEnter}
+        onPointerLeave={handleBandPointerLeave}
+        onFocus={fullscreen.reveal}
+        onBlur={handleInteractionBlur}
+      >
       <div className={`command-band-left${operationsViewVisible && sideBar.collapsed ? " is-collapsed" : ""}`}>
         <FleetBrandHome className="command-band-brand" />
         {operationsViewVisible ? <button type="button" className="command-band-button command-band-sidebar-toggle" onClick={() => setSideBarCollapsed(!sideBar.collapsed)} aria-label={`${sideBar.collapsed ? "Expand sidebar" : "Collapse sidebar"} (${sideBarShortcut})`} title={`${sideBar.collapsed ? "Expand sidebar" : "Collapse sidebar"} (${sideBarShortcut})`}>
@@ -126,11 +191,15 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
         </div></> : null}
       </div>
       <div className="command-band-right">
+        {fullscreen.isFullscreen ? <button type="button" className="command-band-button command-band-pin" onClick={fullscreen.togglePin} aria-label="Pin command band" aria-pressed={fullscreen.isPinned} title={fullscreen.isPinned ? "Unpin command band" : "Pin command band"}>
+          <PinIcon />
+        </button> : null}
         {operationsViewVisible ? <button type="button" className="command-band-button command-band-rail-toggle" onClick={toggleRailChrome} aria-label={`${railChromeExpanded ? "Collapse Activity Rail" : "Expand Activity Rail"} (${railShortcut})`} title={`${railChromeExpanded ? "Collapse Activity Rail" : "Expand Activity Rail"} (${railShortcut})`}>
           <PanelToggleIcon side="right" />
         </button> : null}
       </div>
-    </header>
+      </header>
+    </>
   );
 }
 
@@ -151,6 +220,10 @@ function PanelToggleIcon({ side }: { readonly side: "left" | "right" }) {
       <path d={side === "left" ? "M6.4 3v10" : "M9.6 3v10"} stroke="currentColor" strokeWidth="1.3" />
     </svg>
   );
+}
+
+function PinIcon() {
+  return <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M5 2.5h6M6.2 2.5v3l2.1 2.1v1H7.1V13.5l.9 1M9.8 2.5v3L7.7 7.6v1h1.2V13.5L8 14.5" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" /></svg>;
 }
 
 function PathContextIcon() {

--- a/runtime/fleet-console/core/client/src/components/use-fullscreen-command-band.ts
+++ b/runtime/fleet-console/core/client/src/components/use-fullscreen-command-band.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import { useDesktopFullscreenSnapshot } from "../desktop-fullscreen.js";
+
+const DISPLAY_MODE_FULLSCREEN_QUERY = "(display-mode: fullscreen)";
+const INITIAL_REVEAL_MS = 480;
+const LEAVE_REVEAL_MS = 480;
+const ALWAYS_ALLOW_HIDE = () => true;
+
+function isDisplayModeFullscreen(): boolean {
+  return typeof window !== "undefined" && window.matchMedia(DISPLAY_MODE_FULLSCREEN_QUERY).matches;
+}
+
+/**
+ * Owns only the renderer fullscreen lifecycle. Pointer and focus containment
+ * stay with the command-band DOM, where the edge control and band refs exist.
+ */
+export function useFullscreenCommandBand(canHide: () => boolean = ALWAYS_ALLOW_HIDE) {
+  const nativeFullscreen = useDesktopFullscreenSnapshot();
+  const [displayModeFullscreen, setDisplayModeFullscreen] = useState(isDisplayModeFullscreen);
+  const desktopShell = typeof document !== "undefined" && document.documentElement.dataset.desktopShell === "true";
+  const fullscreen = displayModeFullscreen || (desktopShell && nativeFullscreen);
+  const fullscreenRef = useRef(fullscreen);
+  fullscreenRef.current = fullscreen;
+  const pinnedRef = useRef(false);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [isFullscreen, setIsFullscreen] = useState(fullscreen);
+  const [isVisible, setIsVisible] = useState(true);
+  const [isPinned, setIsPinned] = useState(false);
+
+  const clearHideTimer = useCallback(() => {
+    if (hideTimerRef.current !== null) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+  }, []);
+
+  const hideAfter = useCallback((delay: number) => {
+    clearHideTimer();
+    if (!fullscreenRef.current || pinnedRef.current) return;
+    hideTimerRef.current = setTimeout(() => {
+      hideTimerRef.current = null;
+      if (fullscreenRef.current && !pinnedRef.current && canHide()) setIsVisible(false);
+    }, delay);
+  }, [canHide, clearHideTimer]);
+
+  const reveal = useCallback(() => {
+    clearHideTimer();
+    if (fullscreenRef.current) setIsVisible(true);
+  }, [clearHideTimer]);
+
+  const hideAfterLeave = useCallback(() => hideAfter(LEAVE_REVEAL_MS), [hideAfter]);
+
+  const togglePin = useCallback(() => {
+    const next = !pinnedRef.current;
+    pinnedRef.current = next;
+    setIsPinned(next);
+    if (next) {
+      clearHideTimer();
+      setIsVisible(true);
+    }
+  }, [clearHideTimer]);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(DISPLAY_MODE_FULLSCREEN_QUERY);
+    const syncDisplayMode = () => setDisplayModeFullscreen(mediaQuery.matches);
+    syncDisplayMode();
+    mediaQuery.addEventListener("change", syncDisplayMode);
+    return () => mediaQuery.removeEventListener("change", syncDisplayMode);
+  }, []);
+
+  useLayoutEffect(() => {
+    clearHideTimer();
+    setIsFullscreen(fullscreen);
+    setIsVisible(true);
+    if (fullscreen && !pinnedRef.current) hideAfter(INITIAL_REVEAL_MS);
+    return clearHideTimer;
+  }, [clearHideTimer, fullscreen, hideAfter]);
+
+  return { isFullscreen, isVisible, isPinned, reveal, hideAfterLeave, togglePin };
+}

--- a/runtime/fleet-console/core/client/src/desktop-fullscreen.ts
+++ b/runtime/fleet-console/core/client/src/desktop-fullscreen.ts
@@ -1,0 +1,34 @@
+import { useSyncExternalStore } from "react";
+
+type Listener = () => void;
+
+let snapshot = false;
+const listeners = new Set<Listener>();
+
+export function useDesktopFullscreenSnapshot(): boolean {
+  return useSyncExternalStore(subscribe, getDesktopFullscreenSnapshot, getDesktopFullscreenSnapshot);
+}
+
+export function getDesktopFullscreenSnapshot(): boolean {
+  return snapshot;
+}
+
+export function applyDesktopFullscreenSnapshot(value: unknown): void {
+  snapshot = isDesktopFullscreenSnapshot(value) ? value.fullscreen : false;
+  for (const listener of listeners) listener();
+}
+
+export function resetDesktopFullscreenSnapshot(): void {
+  applyDesktopFullscreenSnapshot({ fullscreen: false });
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function isDesktopFullscreenSnapshot(value: unknown): value is { readonly fullscreen: boolean } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const entry = value as Record<string, unknown>;
+  return Object.keys(entry).length === 1 && typeof entry.fullscreen === "boolean";
+}

--- a/runtime/fleet-console/core/client/src/operations-sse.ts
+++ b/runtime/fleet-console/core/client/src/operations-sse.ts
@@ -1,4 +1,5 @@
 import { fetchObserverStatus, fetchOperations } from "./api.js";
+import { applyDesktopFullscreenSnapshot, resetDesktopFullscreenSnapshot } from "./desktop-fullscreen.js";
 import { applyObserverStatus, applyOperationUpdate, getState, hydrateOperations } from "./store.js";
 import type { OperationNode } from "./types.js";
 
@@ -30,6 +31,15 @@ export function connectOperationsSse(): void {
     refreshObserverStatus();
   });
 
+  source.addEventListener("desktop:fullscreen", (e) => {
+    const msg = e as MessageEvent<string>;
+    try {
+      applyDesktopFullscreenSnapshot(JSON.parse(msg.data));
+    } catch {
+      resetDesktopFullscreenSnapshot();
+    }
+  });
+
   source.onopen = () => {
     reconnectDelayMs = 1_000;
     refreshObserverStatus();
@@ -37,6 +47,7 @@ export function connectOperationsSse(): void {
 
   source.onerror = () => {
     source.close();
+    resetDesktopFullscreenSnapshot();
     reconnectHandle = setTimeout(() => {
       reconnectHandle = null;
       reconnectDelayMs = Math.min(reconnectDelayMs * 2, MAX_RECONNECT_DELAY_MS);

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -29,6 +29,42 @@
   background: var(--surface-band);
 }
 
+.command-band.is-fullscreen {
+  position: fixed;
+  inset: 0 0 auto;
+  z-index: 40;
+  width: 100%;
+  transform: translateY(-100%);
+  transition: transform var(--duration-base) var(--ease-glide);
+}
+
+.command-band.is-fullscreen.is-revealed { transform: translateY(0); }
+
+.command-band.is-fullscreen[aria-hidden="true"] { pointer-events: none; }
+
+.command-band-edge-reveal {
+  display: none;
+}
+
+.command-band-edge-reveal.is-fullscreen {
+  display: block;
+  position: fixed;
+  inset: 0 0 auto;
+  z-index: 41;
+  width: 100%;
+  height: 8px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+body:has([aria-modal="true"]:not([hidden])) .command-band.is-fullscreen,
+body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscreen {
+  visibility: hidden;
+  pointer-events: none;
+}
+
 .command-band.is-utility {
   grid-template-columns: auto minmax(0, 1fr) auto;
 }
@@ -243,6 +279,10 @@ html[data-desktop-shell="true"] .command-band input {
   -webkit-app-region: no-drag;
 }
 
+html[data-desktop-shell="true"] .command-band-edge-reveal {
+  -webkit-app-region: no-drag;
+}
+
 html[data-desktop-shell="true"][data-desktop-platform="darwin"] .command-band-left {
   padding-inline-start: 88px;
 }
@@ -274,4 +314,6 @@ html[data-desktop-shell="true"][data-desktop-platform="darwin"] .command-band-le
   .command-band-left {
     transition: none !important;
   }
+
+  .command-band.is-fullscreen { transition: none !important; }
 }

--- a/runtime/fleet-console/core/host/api-catalog.ts
+++ b/runtime/fleet-console/core/host/api-catalog.ts
@@ -1,3 +1,4 @@
+import { DESKTOP_FULLSCREEN_API_CATALOG } from "./desktop-fullscreen-routes.js";
 import { DESKTOP_THEME_API_CATALOG } from "./desktop-theme-routes.js";
 import { GLOBAL_SETTINGS_API_CATALOG } from "./global-settings-routes.js";
 import { PLUGIN_SETTINGS_API_CATALOG } from "./plugin-settings-routes.js";
@@ -18,6 +19,7 @@ const compareApiCatalogEntries = (left: ApiCatalogEntry, right: ApiCatalogEntry)
 export function buildApiCatalog(): ApiCatalogEntry[] {
   return [
     ...SERVER_API_CATALOG,
+    ...DESKTOP_FULLSCREEN_API_CATALOG,
     ...DESKTOP_THEME_API_CATALOG,
     ...GLOBAL_SETTINGS_API_CATALOG,
     ...PLUGIN_SETTINGS_API_CATALOG,

--- a/runtime/fleet-console/core/host/desktop-fullscreen-routes.ts
+++ b/runtime/fleet-console/core/host/desktop-fullscreen-routes.ts
@@ -1,0 +1,49 @@
+import type http from "node:http";
+
+import type { ApiCatalogEntry } from "./api-catalog.js";
+import { DESKTOP_FULLSCREEN_PATH, isDesktopFullscreenSnapshot } from "./desktop-fullscreen.js";
+
+interface DesktopFullscreenRouteDeps {
+  readonly getFullscreen: () => boolean;
+  readonly isAuthorized: (req: http.IncomingMessage) => boolean;
+  readonly readJsonBody: <T>(req: http.IncomingMessage) => Promise<T | null>;
+  readonly setFullscreen: (fullscreen: boolean) => void;
+  readonly writeJson: (res: http.ServerResponse, status: number, body: unknown) => void;
+  readonly writeNoContent: (res: http.ServerResponse) => void;
+}
+
+interface DesktopFullscreenRouteContext {
+  readonly req: http.IncomingMessage;
+  readonly res: http.ServerResponse;
+  readonly pathname: string;
+}
+
+export const DESKTOP_FULLSCREEN_API_CATALOG: readonly ApiCatalogEntry[] = [{
+  method: "PUT",
+  path: DESKTOP_FULLSCREEN_PATH,
+  summary: "Update the ephemeral Desktop native fullscreen snapshot.",
+  category: "Desktop",
+  gate: "origin-strict",
+}];
+
+export function createDesktopFullscreenRouter(deps: DesktopFullscreenRouteDeps): (context: DesktopFullscreenRouteContext) => Promise<boolean> {
+  return async ({ req, res, pathname }) => {
+    if (pathname !== DESKTOP_FULLSCREEN_PATH) return false;
+    if (req.method !== "PUT") {
+      deps.writeJson(res, 405, { error: "Method not allowed" });
+      return true;
+    }
+    if (!deps.isAuthorized(req)) {
+      deps.writeJson(res, 401, { error: "unauthorized" });
+      return true;
+    }
+    const body = await deps.readJsonBody<unknown>(req);
+    if (!isDesktopFullscreenSnapshot(body)) {
+      deps.writeJson(res, 400, { error: "invalid_desktop_fullscreen" });
+      return true;
+    }
+    if (deps.getFullscreen() !== body.fullscreen) deps.setFullscreen(body.fullscreen);
+    deps.writeNoContent(res);
+    return true;
+  };
+}

--- a/runtime/fleet-console/core/host/desktop-fullscreen.ts
+++ b/runtime/fleet-console/core/host/desktop-fullscreen.ts
@@ -1,0 +1,14 @@
+export const DESKTOP_FULLSCREEN_PATH = "/api/v1/desktop/fullscreen";
+export const DESKTOP_FULLSCREEN_EVENT = "desktop:fullscreen";
+
+export interface DesktopFullscreenSnapshot {
+  readonly fullscreen: boolean;
+}
+
+export const desktopFullscreenSnapshot = (fullscreen: boolean): DesktopFullscreenSnapshot => ({ fullscreen });
+
+export function isDesktopFullscreenSnapshot(value: unknown): value is DesktopFullscreenSnapshot {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const entry = value as Record<string, unknown>;
+  return Object.keys(entry).length === 1 && typeof entry.fullscreen === "boolean";
+}

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -10,6 +10,8 @@ import type { ConsoleHealth, ConsoleObserverStatus, ConsoleTheaterFolderListResp
 import { createCodexWorkspaceContextRouter } from "./codex/context-routes.js";
 import { createCodexGateway } from "./codex/gateway.js";
 import { createConsoleSettingsStore, type ConsoleThemeId } from "./console-settings.js";
+import { DESKTOP_FULLSCREEN_EVENT, desktopFullscreenSnapshot } from "./desktop-fullscreen.js";
+import { createDesktopFullscreenRouter } from "./desktop-fullscreen-routes.js";
 import { DESKTOP_THEME_EVENT, desktopThemeSnapshot } from "./desktop-theme.js";
 import { createDesktopThemeRouter } from "./desktop-theme-routes.js";
 import { createConsoleDurableStateStore, emptyDurableConsoleState, type DurableConsoleState } from "./durable-state.js";
@@ -303,6 +305,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   const pluginEventListeners = new Map<string, Set<(payload: unknown) => void>>();
   const operationSseSubscribers = new Set<http.ServerResponse>();
   const desktopThemeSseSubscribers = new Set<http.ServerResponse>();
+  let desktopFullscreen = false;
   let unsubscribeUpdateCheckChanges = updateCheck.onChange?.(() => {
     broadcastUpdateAvailable();
   }) ?? null;
@@ -482,6 +485,17 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       });
     },
   });
+  const desktopFullscreenRouter = createDesktopFullscreenRouter({
+    getFullscreen: () => desktopFullscreen,
+    isAuthorized: isExactConsoleOrigin,
+    readJsonBody,
+    setFullscreen: (fullscreen) => {
+      desktopFullscreen = fullscreen;
+      broadcastDesktopFullscreenChanged();
+    },
+    writeJson,
+    writeNoContent,
+  });
   const pluginSettingsRouter = createPluginSettingsRouter({
     consoleSettingsStore,
     isAuthorized: isTerminalAuthorized,
@@ -534,6 +548,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
         "Connection": "keep-alive",
       }));
       res.write(":connected\n\n");
+      res.write(encodeSseData(DESKTOP_FULLSCREEN_EVENT, desktopFullscreenSnapshot(desktopFullscreen)));
       operationSseSubscribers.add(res);
       res.on("close", () => {
         operationSseSubscribers.delete(res);
@@ -555,7 +570,10 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     if (await systemFontsRouter(ctx)) return true;
     return globalSettingsRouter(ctx);
   });
-  routeRegistry.register("/api/v1/desktop", desktopThemeRouter);
+  routeRegistry.register("/api/v1/desktop", async (context) => {
+    if (await desktopFullscreenRouter(context)) return true;
+    return desktopThemeRouter(context);
+  });
   routeRegistry.register("/plugin-runtime", handlePluginRuntimeRoute);
 
   function handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
@@ -1072,6 +1090,12 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     }
   }
 
+  function broadcastDesktopFullscreenChanged(): void {
+    if (operationSseSubscribers.size === 0) return;
+    const data = encodeSseData(DESKTOP_FULLSCREEN_EVENT, desktopFullscreenSnapshot(desktopFullscreen));
+    for (const res of operationSseSubscribers) res.write(data);
+  }
+
   function broadcastDesktopThemeChanged(theme: ConsoleThemeId): void {
     if (desktopThemeSseSubscribers.size === 0) return;
     const data = encodeSseData(DESKTOP_THEME_EVENT, desktopThemeSnapshot(theme));
@@ -1364,6 +1388,11 @@ async function readJsonBody<T>(req: http.IncomingMessage): Promise<T | null> {
 function writeJson(res: http.ServerResponse, status: number, body: unknown): void {
   res.writeHead(status, withSecurityHeaders({ "Content-Type": "application/json" }));
   res.end(JSON.stringify(body));
+}
+
+function writeNoContent(res: http.ServerResponse): void {
+  res.writeHead(204, withSecurityHeaders({}));
+  res.end();
 }
 
 function writeJavaScript(res: http.ServerResponse, status: number, body: string): void {

--- a/runtime/fleet-console/tests/desktop-fullscreen-routes.test.ts
+++ b/runtime/fleet-console/tests/desktop-fullscreen-routes.test.ts
@@ -1,0 +1,83 @@
+import type http from "node:http";
+
+import { describe, expect, it } from "vitest";
+
+import { DESKTOP_FULLSCREEN_PATH } from "../core/host/desktop-fullscreen.js";
+import { createDesktopFullscreenRouter, DESKTOP_FULLSCREEN_API_CATALOG } from "../core/host/desktop-fullscreen-routes.js";
+
+describe("desktop fullscreen route", () => {
+  it("declares the visual-only PUT endpoint as origin-strict", () => {
+    expect(DESKTOP_FULLSCREEN_API_CATALOG).toEqual([expect.objectContaining({ method: "PUT", path: DESKTOP_FULLSCREEN_PATH, gate: "origin-strict" })]);
+  });
+
+  it("accepts only an exact boolean snapshot and is idempotent", async () => {
+    const harness = createHarness();
+
+    await expect(harness.router({ req: request("PUT", { fullscreen: true }), res: response(), pathname: DESKTOP_FULLSCREEN_PATH })).resolves.toBe(true);
+    expect(harness.fullscreen).toBe(true);
+    expect(harness.sets).toEqual([true]);
+    expect(harness.emptyWrites).toBe(1);
+
+    await harness.router({ req: request("PUT", { fullscreen: true }), res: response(), pathname: DESKTOP_FULLSCREEN_PATH });
+    expect(harness.sets).toEqual([true]);
+    expect(harness.emptyWrites).toBe(2);
+  });
+
+  it.each([
+    undefined,
+    {},
+    { fullscreen: "true" },
+    { fullscreen: true, extra: false },
+    { fullscreen: false, extra: undefined },
+  ])("rejects non-exact JSON snapshots: %j", async (body) => {
+    const harness = createHarness();
+    await harness.router({ req: request("PUT", body), res: response(), pathname: DESKTOP_FULLSCREEN_PATH });
+    expect(harness.writes).toEqual([{ status: 400, body: { error: "invalid_desktop_fullscreen" } }]);
+    expect(harness.sets).toEqual([]);
+  });
+
+  it("requires exact-origin authorization and rejects every other method", async () => {
+    const unauthorized = createHarness(false);
+    await unauthorized.router({ req: request("PUT", { fullscreen: true }), res: response(), pathname: DESKTOP_FULLSCREEN_PATH });
+    expect(unauthorized.writes).toEqual([{ status: 401, body: { error: "unauthorized" } }]);
+
+    const method = createHarness();
+    await method.router({ req: request("GET"), res: response(), pathname: DESKTOP_FULLSCREEN_PATH });
+    expect(method.writes).toEqual([{ status: 405, body: { error: "Method not allowed" } }]);
+    await expect(method.router({ req: request("PUT", { fullscreen: false }), res: response(), pathname: "/api/v1/desktop/other" })).resolves.toBe(false);
+  });
+});
+
+function createHarness(authorized = true) {
+  let fullscreen = false;
+  const sets: boolean[] = [];
+  const writes: { status: number; body: unknown }[] = [];
+  let emptyWrites = 0;
+  const router = createDesktopFullscreenRouter({
+    getFullscreen: () => fullscreen,
+    isAuthorized: () => authorized,
+    readJsonBody: async <T>() => requestBody as T | null,
+    setFullscreen: (next) => { fullscreen = next; sets.push(next); },
+    writeJson: (_res, status, body) => { writes.push({ status, body }); },
+    writeNoContent: () => { emptyWrites += 1; },
+  });
+  let requestBody: unknown = null;
+  return {
+    get fullscreen() { return fullscreen; },
+    get emptyWrites() { return emptyWrites; },
+    router: async (context: { readonly req: http.IncomingMessage; readonly res: http.ServerResponse; readonly pathname: string }) => {
+      requestBody = (context.req as http.IncomingMessage & { readonly body?: unknown }).body ?? null;
+      return router(context);
+    },
+    sets,
+    writes,
+  };
+}
+
+function request(method: string, body?: unknown): http.IncomingMessage {
+  return { method, body } as http.IncomingMessage & { readonly body?: unknown };
+}
+
+function response(): http.ServerResponse {
+  return {} as http.ServerResponse;
+}

--- a/runtime/fleet-console/tests/desktop-fullscreen-store.test.ts
+++ b/runtime/fleet-console/tests/desktop-fullscreen-store.test.ts
@@ -1,0 +1,17 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { applyDesktopFullscreenSnapshot, getDesktopFullscreenSnapshot, resetDesktopFullscreenSnapshot } from "../core/client/src/desktop-fullscreen.js";
+
+afterEach(resetDesktopFullscreenSnapshot);
+
+describe("desktop fullscreen client snapshot", () => {
+  it("defaults false and fails closed for malformed SSE payloads", () => {
+    expect(getDesktopFullscreenSnapshot()).toBe(false);
+    applyDesktopFullscreenSnapshot({ fullscreen: true });
+    expect(getDesktopFullscreenSnapshot()).toBe(true);
+    for (const payload of [{ fullscreen: "true" }, { fullscreen: true, extra: false }, null, []]) {
+      applyDesktopFullscreenSnapshot(payload);
+      expect(getDesktopFullscreenSnapshot()).toBe(false);
+    }
+  });
+});

--- a/runtime/fleet-console/tests/fullscreen-command-band.test.ts
+++ b/runtime/fleet-console/tests/fullscreen-command-band.test.ts
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+
+import { act, createElement, StrictMode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useFullscreenCommandBand } from "../core/client/src/components/use-fullscreen-command-band.js";
+import { applyDesktopFullscreenSnapshot, resetDesktopFullscreenSnapshot } from "../core/client/src/desktop-fullscreen.js";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+let mediaQuery: TestMediaQuery;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mediaQuery = new TestMediaQuery(false);
+  vi.stubGlobal("matchMedia", vi.fn().mockReturnValue(mediaQuery));
+  resetDesktopFullscreenSnapshot();
+  delete document.documentElement.dataset.desktopShell;
+  document.body.replaceChildren();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  resetDesktopFullscreenSnapshot();
+  delete document.documentElement.dataset.desktopShell;
+});
+
+describe("useFullscreenCommandBand", () => {
+  it("honors the initial display-mode media-query state and hides after the initial reveal", () => {
+    mediaQuery.setMatches(true);
+    renderProbe();
+
+    expect(attribute(band(), "data-fullscreen")).toBe("true");
+    expect(attribute(band(), "data-visible")).toBe("true");
+    act(() => vi.advanceTimersByTime(480));
+    expect(attribute(band(), "data-visible")).toBe("false");
+    expect(attribute(band(), "aria-hidden")).toBe("true");
+    expect(band().hasAttribute("inert")).toBe(true);
+  });
+
+  it("restores synchronously on fullscreen exit and clears the pending initial hide", () => {
+    renderProbe();
+    act(() => mediaQuery.setMatches(true));
+    expect(attribute(band(), "data-fullscreen")).toBe("true");
+    act(() => mediaQuery.setMatches(false));
+
+    expect(attribute(band(), "data-fullscreen")).toBe("false");
+    expect(attribute(band(), "data-visible")).toBe("true");
+    expect(band().hasAttribute("aria-hidden")).toBe(false);
+    act(() => vi.advanceTimersByTime(480));
+    expect(attribute(band(), "data-visible")).toBe("true");
+  });
+
+  it("uses native fullscreen only for an explicitly marked Desktop shell", () => {
+    renderProbe();
+    act(() => applyDesktopFullscreenSnapshot({ fullscreen: true }));
+    expect(attribute(band(), "data-fullscreen")).toBe("false");
+
+    document.documentElement.dataset.desktopShell = "true";
+    act(() => applyDesktopFullscreenSnapshot({ fullscreen: false }));
+    act(() => applyDesktopFullscreenSnapshot({ fullscreen: true }));
+    expect(attribute(band(), "data-fullscreen")).toBe("true");
+    act(() => vi.advanceTimersByTime(480));
+    expect(attribute(band(), "data-visible")).toBe("false");
+
+    act(() => applyDesktopFullscreenSnapshot({ fullscreen: false }));
+    expect(attribute(band(), "data-fullscreen")).toBe("false");
+    expect(attribute(band(), "data-visible")).toBe("true");
+  });
+
+  it("reveals on edge focus, retains focus safely, and hides 480ms after focus leaves", () => {
+    mediaQuery.setMatches(true);
+    renderProbe();
+    act(() => vi.advanceTimersByTime(480));
+
+    act(() => edge().focus());
+    expect(attribute(band(), "data-visible")).toBe("true");
+    act(() => vi.advanceTimersByTime(480));
+    expect(attribute(band(), "data-visible")).toBe("true");
+
+    act(() => firstControl().focus());
+    expect(document.activeElement).toBe(firstControl());
+    act(() => outside().focus());
+    act(() => vi.advanceTimersByTime(479));
+    expect(attribute(band(), "data-visible")).toBe("true");
+    act(() => vi.advanceTimersByTime(1));
+    expect(attribute(band(), "data-visible")).toBe("false");
+  });
+
+  it("reveals on pointer entry and honors the session-local pin", () => {
+    mediaQuery.setMatches(true);
+    renderProbe();
+    act(() => vi.advanceTimersByTime(480));
+
+    act(() => edge().dispatchEvent(new Event("pointerover", { bubbles: true })));
+    expect(attribute(band(), "data-visible")).toBe("true");
+    act(() => pin().click());
+    expect(attribute(pin(), "aria-pressed")).toBe("true");
+    act(() => edge().dispatchEvent(new Event("pointerout", { bubbles: true })));
+    act(() => vi.advanceTimersByTime(480));
+    expect(attribute(band(), "data-visible")).toBe("true");
+
+    act(() => pin().click());
+    expect(attribute(pin(), "aria-pressed")).toBe("false");
+    act(() => edge().dispatchEvent(new Event("pointerout", { bubbles: true })));
+    act(() => vi.advanceTimersByTime(480));
+    expect(attribute(band(), "data-visible")).toBe("false");
+  });
+
+  it("does not hide while the interaction guard reports focus or pointer containment", () => {
+    mediaQuery.setMatches(true);
+    let canHide = false;
+    act(() => root!.render(createElement(FullscreenBandProbe, { canHide: () => canHide } as never)));
+
+    act(() => vi.advanceTimersByTime(480));
+    expect(attribute(band(), "data-visible")).toBe("true");
+
+    canHide = true;
+    act(() => edge().dispatchEvent(new Event("pointerout", { bubbles: true })));
+    act(() => vi.advanceTimersByTime(480));
+    expect(attribute(band(), "data-visible")).toBe("false");
+  });
+
+  it("cleans media listeners and timers across StrictMode remounts", () => {
+    mediaQuery.setMatches(true);
+    act(() => root!.render(createElement(StrictMode, null, createElement(FullscreenBandProbe))));
+
+    expect(mediaQuery.added).toBe(2);
+    expect(mediaQuery.removed).toBe(1);
+    expect(vi.getTimerCount()).toBe(1);
+    act(() => root!.unmount());
+    root = null;
+    expect(mediaQuery.removed).toBe(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+function renderProbe(): void {
+  act(() => root!.render(createElement(FullscreenBandProbe)));
+}
+
+function FullscreenBandProbe(props?: { readonly canHide?: () => boolean }) {
+  const canHide = props?.canHide;
+  const fullscreen = useFullscreenCommandBand(canHide);
+  const hidden = fullscreen.isFullscreen && !fullscreen.isVisible;
+  return createElement(
+    "div",
+    null,
+    createElement("button", {
+      "data-edge": "true",
+      onFocus: fullscreen.reveal,
+      onPointerEnter: fullscreen.reveal,
+      onPointerLeave: fullscreen.hideAfterLeave,
+    }),
+    createElement(
+      "header",
+      {
+        "data-band": "true",
+        "data-fullscreen": String(fullscreen.isFullscreen),
+        "data-visible": String(fullscreen.isVisible),
+        "aria-hidden": hidden || undefined,
+        inert: hidden || undefined,
+        onFocus: fullscreen.reveal,
+        onBlur: fullscreen.hideAfterLeave,
+      },
+      createElement("button", { "data-first-control": "true" }),
+      createElement("button", { "data-pin": "true", "aria-pressed": fullscreen.isPinned, onClick: fullscreen.togglePin }),
+    ),
+    createElement("button", { "data-outside": "true" }),
+  );
+}
+
+function band(): HTMLElement {
+  return document.querySelector<HTMLElement>("[data-band]")!;
+}
+
+function edge(): HTMLButtonElement {
+  return document.querySelector<HTMLButtonElement>("[data-edge]")!;
+}
+
+function firstControl(): HTMLButtonElement {
+  return document.querySelector<HTMLButtonElement>("[data-first-control]")!;
+}
+
+function pin(): HTMLButtonElement {
+  return document.querySelector<HTMLButtonElement>("[data-pin]")!;
+}
+
+function outside(): HTMLButtonElement {
+  return document.querySelector<HTMLButtonElement>("[data-outside]")!;
+}
+
+function attribute(element: Element, name: string): string | null {
+  return element.getAttribute(name);
+}
+
+class TestMediaQuery {
+  matches: boolean;
+  added = 0;
+  removed = 0;
+  private readonly listeners = new Set<(event: MediaQueryListEvent) => void>();
+
+  constructor(matches: boolean) {
+    this.matches = matches;
+  }
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject | null): void {
+    if (type !== "change" || typeof listener !== "function") return;
+    this.added += 1;
+    this.listeners.add(listener as (event: MediaQueryListEvent) => void);
+  }
+
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject | null): void {
+    if (type !== "change" || typeof listener !== "function") return;
+    this.removed += 1;
+    this.listeners.delete(listener as (event: MediaQueryListEvent) => void);
+  }
+
+  setMatches(matches: boolean): void {
+    this.matches = matches;
+    const event = { matches, media: "(display-mode: fullscreen)" } as MediaQueryListEvent;
+    for (const listener of this.listeners) listener(event);
+  }
+}

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -208,6 +208,20 @@ describe("Instrument core design contract", () => {
     expect(layout).toContain(".command-band-context-separator {");
     expect(layout).toContain(".command-band-theater-cluster {");
     expect(layout).not.toContain("--command-band-carrier");
+    expect(commandBand).toContain("useFullscreenCommandBand");
+    expect(commandBand).toContain('className={`command-band-edge-reveal${fullscreen.isFullscreen ? " is-fullscreen" : ""}`}');
+    expect(commandBand).toContain('aria-label="Show command band"');
+    expect(commandBand).toContain('aria-pressed={fullscreen.isPinned}');
+    expect(commandBand).toContain("inert={commandBandHidden || undefined}");
+    expect(commandBand).toContain("onKeyDown={(event) => { if (event.key === \"Tab\") fullscreen.reveal(); }}");
+    expect(layout).toContain(".command-band.is-fullscreen {");
+    expect(layout).toContain("position: fixed;");
+    expect(layout).toContain("transform: translateY(-100%);");
+    expect(layout).toContain("transition: transform var(--duration-base) var(--ease-glide);");
+    expect(layout).toContain(".command-band-edge-reveal.is-fullscreen {");
+    expect(layout).toContain("height: 8px;");
+    expect(layout).toContain('html[data-desktop-shell="true"] .command-band-edge-reveal {');
+    expect(layout).toContain('body:has([aria-modal="true"]:not([hidden])) .command-band.is-fullscreen,');
   });
 
   it("keeps long What's new content inside the scrollable body without shrinking controls", () => {

--- a/runtime/fleet-console/tests/operations-sse.test.ts
+++ b/runtime/fleet-console/tests/operations-sse.test.ts
@@ -2,11 +2,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   applyObserverStatus: vi.fn(),
+  applyDesktopFullscreenSnapshot: vi.fn(),
   applyOperationUpdate: vi.fn(),
   fetchObserverStatus: vi.fn(),
   fetchOperations: vi.fn(),
   getState: vi.fn(),
   hydrateOperations: vi.fn(),
+  resetDesktopFullscreenSnapshot: vi.fn(),
 }));
 
 vi.mock("../core/client/src/api.js", () => ({
@@ -21,6 +23,11 @@ vi.mock("../core/client/src/store.js", () => ({
   hydrateOperations: mocks.hydrateOperations,
 }));
 
+vi.mock("../core/client/src/desktop-fullscreen.js", () => ({
+  applyDesktopFullscreenSnapshot: mocks.applyDesktopFullscreenSnapshot,
+  resetDesktopFullscreenSnapshot: mocks.resetDesktopFullscreenSnapshot,
+}));
+
 import { connectOperationsSse } from "../core/client/src/operations-sse.js";
 
 class TestEventSource {
@@ -28,13 +35,13 @@ class TestEventSource {
 
   onerror: (() => void) | null = null;
   onopen: (() => void) | null = null;
-  private readonly listeners = new Map<string, (() => void)[]>();
+  private readonly listeners = new Map<string, ((event: Event) => void)[]>();
 
   constructor(_url: string) {
     TestEventSource.instances.push(this);
   }
 
-  addEventListener(type: string, listener: () => void): void {
+  addEventListener(type: string, listener: (event: Event) => void): void {
     const registered = this.listeners.get(type) ?? [];
     registered.push(listener);
     this.listeners.set(type, registered);
@@ -42,8 +49,8 @@ class TestEventSource {
 
   close(): void {}
 
-  emit(type: string): void {
-    for (const listener of this.listeners.get(type) ?? []) listener();
+  emit(type: string, data?: string): void {
+    for (const listener of this.listeners.get(type) ?? []) listener({ data } as MessageEvent<string>);
   }
 
   open(): void {
@@ -55,11 +62,13 @@ describe("operations SSE update availability", () => {
   afterEach(() => {
     TestEventSource.instances = [];
     mocks.applyObserverStatus.mockReset();
+    mocks.applyDesktopFullscreenSnapshot.mockReset();
     mocks.applyOperationUpdate.mockReset();
     mocks.fetchObserverStatus.mockReset();
     mocks.fetchOperations.mockReset();
     mocks.getState.mockReset();
     mocks.hydrateOperations.mockReset();
+    mocks.resetDesktopFullscreenSnapshot.mockReset();
     vi.unstubAllGlobals();
   });
 
@@ -111,5 +120,21 @@ describe("operations SSE update availability", () => {
 
     await vi.waitFor(() => expect(mocks.fetchObserverStatus).toHaveBeenCalledTimes(2));
     await vi.waitFor(() => expect(mocks.applyObserverStatus).toHaveBeenLastCalledWith(currentStatus));
+  });
+
+  it("strictly applies Desktop fullscreen frames and resets malformed frames or SSE loss", () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("EventSource", TestEventSource);
+    mocks.getState.mockReturnValue({ activeTheaterId: null });
+
+    connectOperationsSse();
+    TestEventSource.instances[0]?.emit("desktop:fullscreen", JSON.stringify({ fullscreen: true }));
+    expect(mocks.applyDesktopFullscreenSnapshot).toHaveBeenCalledWith({ fullscreen: true });
+
+    TestEventSource.instances[0]?.emit("desktop:fullscreen", "{not-json");
+    expect(mocks.resetDesktopFullscreenSnapshot).toHaveBeenCalledOnce();
+    TestEventSource.instances[0]?.onerror?.();
+    expect(mocks.resetDesktopFullscreenSnapshot).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
   });
 });

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { initStore, resetStoreForTests } from "@dotobokuri/fleet-carriers";
 
 import type { ConsoleLockPayload } from "../core/host/api-types.js";
+import { DESKTOP_FULLSCREEN_EVENT, DESKTOP_FULLSCREEN_PATH } from "../core/host/desktop-fullscreen.js";
 import { DESKTOP_THEME_EVENTS_PATH, DESKTOP_THEME_PATH } from "../core/host/desktop-theme.js";
 import { createConsoleLock } from "../core/host/lock.js";
 import { createConsoleObservabilityStore } from "../../fleet-plugins/terminal/server/agent-api/observability-store.js";
@@ -80,6 +82,49 @@ afterEach(async () => {
 });
 
 describe("console terminal observability", () => {
+  it("owns an exact-origin ephemeral Desktop fullscreen snapshot and relays it through operations SSE", async () => {
+    const fixture = await startFixture();
+    const origin = new URL(fixture.endpoint).origin;
+    const url = new URL(DESKTOP_FULLSCREEN_PATH.slice(1), fixture.endpoint);
+
+    const missing = await fetch(url, { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ fullscreen: true }) });
+    expect(missing.status).toBe(401);
+    const foreign = await fetch(url, { method: "PUT", headers: { Origin: "http://127.0.0.1:9999", "Content-Type": "application/json" }, body: JSON.stringify({ fullscreen: true }) });
+    expect(foreign.status).toBe(401);
+    expect(await putWithHost(url, origin, "localhost:1", { fullscreen: true })).toBe(403);
+    const wrongMethod = await fetch(url, { method: "POST", headers: { Origin: origin, "Content-Type": "application/json" }, body: JSON.stringify({ fullscreen: true }) });
+    expect(wrongMethod.status).toBe(405);
+    const invalidJson = await fetch(url, { method: "PUT", headers: { Origin: origin, "Content-Type": "application/json" }, body: "{not-json" });
+    expect(invalidJson.status).toBe(400);
+    const malformed = await fetch(url, { method: "PUT", headers: { Origin: origin, "Content-Type": "application/json" }, body: JSON.stringify({ fullscreen: true, extra: false }) });
+    expect(malformed.status).toBe(400);
+
+    const put = await fetch(url, { method: "PUT", headers: { Origin: origin, "Content-Type": "application/json" }, body: JSON.stringify({ fullscreen: true }) });
+    expect(put.status).toBe(204);
+    const stream = await fetch(new URL("api/v1/operations/events", fixture.endpoint));
+    const reader = stream.body!.getReader();
+    const readFullscreen = createDesktopFullscreenSseReader(reader);
+    expect(await readFullscreen()).toEqual({ fullscreen: true });
+
+    const update = await fetch(url, { method: "PUT", headers: { Origin: origin, "Content-Type": "application/json" }, body: JSON.stringify({ fullscreen: false }) });
+    expect(update.status).toBe(204);
+    expect(await readFullscreen()).toEqual({ fullscreen: false });
+    const finalTrue = await fetch(url, { method: "PUT", headers: { Origin: origin, "Content-Type": "application/json" }, body: JSON.stringify({ fullscreen: true }) });
+    expect(finalTrue.status).toBe(204);
+    expect(await readFullscreen()).toEqual({ fullscreen: true });
+    await reader.cancel();
+
+    await fixture.server.stop();
+    const restartDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-desktop-fullscreen-restart-"));
+    tempDirs.push(restartDir);
+    const restartedServer = createConsoleServer({ port: 0, version: "test", dataDir: fixture.carrierStoreDir });
+    servers.push(restartedServer);
+    const restartedEndpoint = await restartedServer.start({ dir: restartDir, lockFile: path.join(restartDir, "console.lock") });
+    const restartedStream = await fetch(`${restartedEndpoint}api/v1/operations/events`);
+    const restartedReader = restartedStream.body!.getReader();
+    expect(await createDesktopFullscreenSseReader(restartedReader)()).toEqual({ fullscreen: false });
+    await restartedReader.cancel();
+  }, 15_000);
   it("requires the exact Console Origin for Desktop theme snapshot and SSE routes", async () => {
     const fixture = await startFixture();
     const origin = new URL(fixture.endpoint).origin;
@@ -2588,4 +2633,45 @@ function makeWikiEntryMd(id: string): string {
     "---",
     "Test content",
   ].join("\n");
+}
+
+function createDesktopFullscreenSseReader(reader: ReadableStreamDefaultReader<Uint8Array>): () => Promise<{ readonly fullscreen: boolean }> {
+  const decoder = new TextDecoder();
+  let buffered = "";
+  return async () => {
+    while (true) {
+      const frames = buffered.split(/\r?\n\r?\n/u);
+      buffered = frames.pop() ?? "";
+      for (const frame of frames) {
+        const event = new RegExp(`event: ${DESKTOP_FULLSCREEN_EVENT}\\ndata: (\\{[^\\n]+\\})`).exec(frame);
+        if (event?.[1]) return JSON.parse(event[1]) as { readonly fullscreen: boolean };
+      }
+      const result = await readSseChunk(reader);
+      if (result.done) throw new Error("desktop_fullscreen_sse_closed");
+      buffered += decoder.decode(result.value, { stream: true });
+    }
+  };
+}
+
+async function readSseChunk(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<ReadableStreamReadResult<Uint8Array>> {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      reader.read(),
+      new Promise<never>((_resolve, reject) => { timeout = setTimeout(() => reject(new Error("desktop_fullscreen_sse_timeout")), 1_000); }),
+    ]);
+  } finally {
+    if (timeout !== null) clearTimeout(timeout);
+  }
+}
+
+function putWithHost(url: URL, origin: string, host: string, body: unknown): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const request = http.request(url, { method: "PUT", headers: { Host: host, Origin: origin, "Content-Type": "application/json" } }, (response) => {
+      response.resume();
+      response.on("end", () => resolve(response.statusCode ?? 0));
+    });
+    request.on("error", reject);
+    request.end(JSON.stringify(body));
+  });
 }

--- a/runtime/fleet-desktop/src/desktop-fullscreen-sync.ts
+++ b/runtime/fleet-desktop/src/desktop-fullscreen-sync.ts
@@ -1,0 +1,185 @@
+import type { BrowserWindow, WebContents } from "electron";
+
+const DESKTOP_FULLSCREEN_PATH = "/api/v1/desktop/fullscreen";
+const MAX_TRANSIENT_ATTEMPTS = 3;
+const REQUEST_TIMEOUT_MS = 1_000;
+
+export interface DesktopFullscreenWindow extends Pick<BrowserWindow, "isFullScreen"> {
+  on(event: "enter-full-screen" | "leave-full-screen", listener: () => void): this;
+  removeListener(event: "enter-full-screen" | "leave-full-screen", listener: () => void): this;
+  readonly webContents: Pick<WebContents, "on" | "removeListener">;
+}
+
+export interface DesktopFullscreenSynchronizer {
+  activate(origin: string): void;
+  reset(origin: string): void;
+  resync(): void;
+  stop(): void;
+}
+
+export interface DesktopFullscreenSynchronizerDeps {
+  readonly fetch?: typeof fetch;
+  readonly requestTimeoutMs?: number;
+  readonly setTimeout?: (callback: () => void, delay: number) => ReturnType<typeof setTimeout>;
+  readonly clearTimeout?: (timer: ReturnType<typeof setTimeout>) => void;
+}
+
+/**
+ * Tracks the native BrowserWindow state from creation, but does not publish
+ * until a verified Console origin has completed handoff or pairing.
+ */
+export function createDesktopFullscreenSynchronizer(
+  window: DesktopFullscreenWindow,
+  deps: DesktopFullscreenSynchronizerDeps = {},
+): DesktopFullscreenSynchronizer {
+  const fetchFor = deps.fetch ?? globalThis.fetch;
+  const requestTimeoutMs = deps.requestTimeoutMs ?? REQUEST_TIMEOUT_MS;
+  const schedule = deps.setTimeout ?? globalThis.setTimeout;
+  const cancelSchedule = deps.clearTimeout ?? globalThis.clearTimeout;
+  let nativeFullscreen = window.isFullScreen();
+  let activeOrigin: string | null = null;
+  let unsupported = false;
+  let activePublication: { readonly origin: string; readonly fullscreen: boolean } | null = null;
+  let publishPending = false;
+  let stopped = false;
+  const originTails = new Map<string, Promise<void>>();
+  const activeControllers = new Map<string, Set<AbortController>>();
+
+  const enqueue = <T>(origin: string, action: () => Promise<T>): Promise<T> => {
+    const previous = originTails.get(origin) ?? Promise.resolve();
+    const scheduled = previous.catch(() => undefined).then(action);
+    const tail = scheduled.then(() => undefined, () => undefined);
+    originTails.set(origin, tail);
+    void tail.finally(() => {
+      if (originTails.get(origin) === tail) originTails.delete(origin);
+    });
+    return scheduled;
+  };
+
+  const publishWithRetry = async (origin: string, fullscreen: boolean, shouldStop: () => boolean): Promise<boolean> => {
+    for (let attempt = 0; attempt < MAX_TRANSIENT_ATTEMPTS; attempt += 1) {
+      if (shouldStop()) return false;
+      const controller = new AbortController();
+      const controllers = activeControllers.get(origin) ?? new Set<AbortController>();
+      controllers.add(controller);
+      activeControllers.set(origin, controllers);
+      let timeout: ReturnType<typeof setTimeout> | null = null;
+      try {
+        const request = fetchFor(new URL(DESKTOP_FULLSCREEN_PATH, `${origin}/`).toString(), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json", Origin: origin },
+          body: JSON.stringify({ fullscreen }),
+          signal: controller.signal,
+        });
+        void request.catch(() => undefined);
+        const response = await Promise.race([
+          request,
+          new Promise<never>((_resolve, reject) => {
+            timeout = schedule(() => {
+              controller.abort();
+              reject(new Error("desktop_fullscreen_request_timeout"));
+            }, requestTimeoutMs);
+          }),
+        ]);
+        if (response.status === 404 || response.status === 405) return true;
+        if (response.ok) return false;
+      } catch {
+        // Timeout and abort are transient unless a newer state or stop supersedes this attempt.
+      } finally {
+        if (timeout !== null) cancelSchedule(timeout);
+        controllers.delete(controller);
+        if (controllers.size === 0) activeControllers.delete(origin);
+      }
+    }
+    return false;
+  };
+
+  const abortRequestsExcept = (origin: string) => {
+    for (const [requestOrigin, controllers] of activeControllers) {
+      if (requestOrigin === origin) continue;
+      for (const controller of controllers) controller.abort();
+    }
+  };
+
+  const abortAllRequests = () => {
+    for (const controllers of activeControllers.values()) {
+      for (const controller of controllers) controller.abort();
+    }
+  };
+
+  const publishCurrent = () => {
+    if (stopped || !activeOrigin || unsupported) return;
+    if (activePublication?.origin === activeOrigin) {
+      publishPending = true;
+      return;
+    }
+    const origin = activeOrigin;
+    const fullscreen = nativeFullscreen;
+    publishPending = false;
+    const publication = { origin, fullscreen };
+    activePublication = publication;
+    void enqueue(origin, () => publishWithRetry(origin, fullscreen, () => stopped || activeOrigin !== origin || nativeFullscreen !== fullscreen))
+      .then((legacy) => {
+        if (activeOrigin === origin && legacy) unsupported = true;
+      })
+      .finally(() => {
+        if (activePublication !== publication) return;
+        activePublication = null;
+        if (!stopped && activeOrigin === origin && !unsupported && (publishPending || nativeFullscreen !== fullscreen)) publishCurrent();
+      });
+  };
+
+  const updateNativeFullscreen = () => {
+    nativeFullscreen = window.isFullScreen();
+    publishPending = true;
+    publishCurrent();
+  };
+
+  const resync = () => {
+    nativeFullscreen = window.isFullScreen();
+    publishPending = true;
+    publishCurrent();
+  };
+
+  window.on("enter-full-screen", updateNativeFullscreen);
+  window.on("leave-full-screen", updateNativeFullscreen);
+  window.webContents.on("did-finish-load", resync);
+
+  return {
+    activate(origin: string): void {
+      const nextOrigin = normalizeConsoleOrigin(origin);
+      if (activeOrigin !== nextOrigin) abortRequestsExcept(nextOrigin);
+      activeOrigin = nextOrigin;
+      unsupported = false;
+      resync();
+    },
+    reset(origin: string): void {
+      const target = normalizeConsoleOrigin(origin);
+      void enqueue(target, () => publishWithRetry(target, false, () => stopped));
+    },
+    resync,
+    stop(): void {
+      stopped = true;
+      activeOrigin = null;
+      abortAllRequests();
+      window.removeListener("enter-full-screen", updateNativeFullscreen);
+      window.removeListener("leave-full-screen", updateNativeFullscreen);
+      window.webContents.removeListener("did-finish-load", resync);
+    },
+  };
+}
+
+function normalizeConsoleOrigin(origin: string): string {
+  const parsed = new URL(origin);
+  if (
+    parsed.protocol !== "http:"
+    || parsed.hostname !== "127.0.0.1"
+    || !parsed.port
+    || parsed.pathname !== "/"
+    || parsed.search
+    || parsed.hash
+    || parsed.username
+    || parsed.password
+  ) throw new Error("desktop_fullscreen_origin_invalid");
+  return parsed.origin;
+}

--- a/runtime/fleet-desktop/src/launch-controller.ts
+++ b/runtime/fleet-desktop/src/launch-controller.ts
@@ -13,6 +13,7 @@ export interface LaunchControllerDependencies {
   readonly createWindow: () => Promise<LaunchWindow>;
   readonly handoffOrigin: (origin: string) => void;
   readonly synchronizeTheme?: (origin: string) => Promise<void>;
+  readonly synchronizeFullscreen?: (origin: string) => void | Promise<void>;
   readonly onConsoleLoaded?: () => void;
   readonly pushEntry: (contents: EntryPageWebContents, snapshot: EntryPageSnapshot) => Promise<void>;
   readonly startOrAdopt: () => Promise<string>;
@@ -56,6 +57,7 @@ export function createLaunchController(dependencies: LaunchControllerDependencie
         await window.loadURL(consoleUrl);
         if (!window.isDestroyed?.()) window.webContents.navigationHistory.clear();
       }
+      if (!window.isDestroyed?.()) await dependencies.synchronizeFullscreen?.(origin);
       if (!window.isDestroyed?.()) dependencies.onConsoleLoaded?.();
       return window;
     },

--- a/runtime/fleet-desktop/src/main.ts
+++ b/runtime/fleet-desktop/src/main.ts
@@ -17,6 +17,7 @@ import { createPairingModal } from "./pairing-modal.js";
 import { createRuntimePairing } from "./runtime-pairing.js";
 import { createDesktopLogger, describeError, type DesktopLogger } from "./logging.js";
 import { createDesktopThemeSynchronizer } from "./desktop-theme-sync.js";
+import { createDesktopFullscreenSynchronizer } from "./desktop-fullscreen-sync.js";
 import { installApplicationMenu } from "./menu.js";
 import { resolveDesktopResourcePaths } from "./resource-paths.js";
 import { createConsoleInstallerDependencies, installConsole, reconcileConsoleInstallations, repairConsoleNativeExecutables } from "./runtime/console-installer.js";
@@ -84,6 +85,7 @@ async function boot(): Promise<void> {
       },
     })
     : null;
+  let fullscreenSynchronizer: ReturnType<typeof createDesktopFullscreenSynchronizer> | null = null;
   let refreshNativeUpdateActions: (() => void) | null = null;
   const zoomState = createZoomState(path.join(app.getPath("userData"), "desktop-state.json"));
   const controls = createConsoleControls({ zoomState, refreshNativeActions: () => refreshNativeUpdateActions?.() });
@@ -92,7 +94,12 @@ async function boot(): Promise<void> {
       createWindow: async () => {
         const createdWindow = createSecureWindow(BrowserWindow, { iconPath: desktopResources.iconPath, platform: process.platform });
         window = createdWindow;
-        createdWindow.once("closed", () => themeSynchronizer?.stop());
+        fullscreenSynchronizer = createDesktopFullscreenSynchronizer(createdWindow);
+        createdWindow.once("closed", () => {
+          themeSynchronizer?.stop();
+          fullscreenSynchronizer?.stop();
+          fullscreenSynchronizer = null;
+        });
         controls.attachWindow(createdWindow);
         lifecycle.attachWindow(createdWindow);
         policy = applyWindowPolicy(createdWindow.webContents, async (external) => shell.openExternal(external));
@@ -107,6 +114,7 @@ async function boot(): Promise<void> {
         controls.handoffStarted();
       },
       synchronizeTheme: async (origin) => { await themeSynchronizer?.start(origin); },
+      synchronizeFullscreen: (origin) => fullscreenSynchronizer?.activate(origin),
       onConsoleLoaded: () => controls.onConsoleLoaded(),
       onFirstRunFailure: async () => showFirstRunFailure(),
       onWindowReady: (push) => { pushRuntimeProgress = push; },
@@ -117,6 +125,7 @@ async function boot(): Promise<void> {
   }, () => supervisor.stop());
   const pairing = createRuntimePairing({
     notifier: createPairingNotifier(Notification, { showMessageBox: (options) => dialog.showMessageBox(options) }),
+    fullscreenSynchronizer: () => fullscreenSynchronizer,
     themeSynchronizer,
     modal: createPairingModal({ BrowserWindow, pairingPagePath: desktopResources.pairingPagePath }),
   });

--- a/runtime/fleet-desktop/src/runtime-pairing.ts
+++ b/runtime/fleet-desktop/src/runtime-pairing.ts
@@ -1,6 +1,7 @@
 import type { BrowserWindow, WebContents } from "electron";
 
 import type { DesktopThemeSynchronizer } from "./desktop-theme-sync.js";
+import type { DesktopFullscreenSynchronizer } from "./desktop-fullscreen-sync.js";
 import type { PairingModal } from "./pairing-modal.js";
 import type { WindowPolicy } from "./window-policy.js";
 
@@ -26,6 +27,7 @@ export interface RuntimePairingNotifier {
 export interface RuntimePairingDependencies {
   readonly fetch?: typeof fetch;
   readonly notifier: RuntimePairingNotifier | null;
+  readonly fullscreenSynchronizer?: () => DesktopFullscreenSynchronizer | null;
   readonly themeSynchronizer: DesktopThemeSynchronizer | null;
   readonly modal: PairingModal;
   readonly timeoutMs?: number;
@@ -93,6 +95,8 @@ export function createRuntimePairing(dependencies: RuntimePairingDependencies): 
       committed = true;
       dependencies.themeSynchronizer?.stop();
       await dependencies.themeSynchronizer?.start(target.origin);
+      dependencies.fullscreenSynchronizer?.()?.activate(target.origin);
+      if (previousOrigin && previousOrigin !== target.origin) dependencies.fullscreenSynchronizer?.()?.reset(previousOrigin);
       window.webContents.navigationHistory.clear();
       dependencies.notifier?.show({ title: "Fleet Console connected", body: `Connected to ${target.origin}.`, type: "info" });
     } catch (error) {
@@ -103,7 +107,9 @@ export function createRuntimePairing(dependencies: RuntimePairingDependencies): 
       }
       if (committed && previousOrigin) {
         try { await dependencies.themeSynchronizer?.start(previousOrigin); } catch { /* rollback feedback must not hide the original failure */ }
+        dependencies.fullscreenSynchronizer?.()?.activate(previousOrigin);
       }
+      dependencies.fullscreenSynchronizer?.()?.resync();
       notifyFailure(dependencies.notifier, error);
     }
   };

--- a/runtime/fleet-desktop/tests/desktop-fullscreen-sync.test.ts
+++ b/runtime/fleet-desktop/tests/desktop-fullscreen-sync.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createDesktopFullscreenSynchronizer } from "../src/desktop-fullscreen-sync.js";
+
+afterEach(() => vi.useRealTimers());
+
+describe("Desktop fullscreen synchronizer", () => {
+  it("publishes only after activation with the exact origin and JSON request", async () => {
+    const window = createWindow(false);
+    const fetch = vi.fn(async () => new Response(null, { status: 204 }));
+    const synchronizer = createDesktopFullscreenSynchronizer(window as never, { fetch });
+
+    window.emit("enter-full-screen", true);
+    expect(fetch).not.toHaveBeenCalled();
+    synchronizer.activate("http://127.0.0.1:4310");
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    expect(fetch).toHaveBeenCalledWith("http://127.0.0.1:4310/api/v1/desktop/fullscreen", expect.objectContaining({
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Origin: "http://127.0.0.1:4310" },
+      body: JSON.stringify({ fullscreen: true }),
+      signal: expect.any(AbortSignal),
+    }));
+    synchronizer.stop();
+  });
+
+  it("serializes rapid native transitions so the newest state is published last", async () => {
+    const window = createWindow(false);
+    let resolveEnter: (() => void) | undefined;
+    const fetch = vi.fn((_url: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) => {
+      if (init?.body === JSON.stringify({ fullscreen: true })) return new Promise<Response>((resolve) => { resolveEnter = () => resolve(new Response(null, { status: 204 })); });
+      return Promise.resolve(new Response(null, { status: 204 }));
+    });
+    const synchronizer = createDesktopFullscreenSynchronizer(window as never, { fetch });
+    synchronizer.activate("http://127.0.0.1:4310");
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+
+    window.emit("enter-full-screen", true);
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    window.emit("leave-full-screen", false);
+    resolveEnter?.();
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(3));
+    expect(fetch.mock.calls.map(([, init]) => init?.body)).toEqual([
+      JSON.stringify({ fullscreen: false }),
+      JSON.stringify({ fullscreen: true }),
+      JSON.stringify({ fullscreen: false }),
+    ]);
+    synchronizer.stop();
+  });
+
+  it("queues a previous-origin reset after its unresolved publication while the new origin proceeds", async () => {
+    const window = createWindow(true);
+    let resolveOldTrue: (() => void) | undefined;
+    const fetch = vi.fn((url: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) => {
+      if (String(url).startsWith("http://127.0.0.1:4310") && init?.body === JSON.stringify({ fullscreen: true })) {
+        return new Promise<Response>((resolve) => { resolveOldTrue = () => resolve(new Response(null, { status: 204 })); });
+      }
+      return Promise.resolve(new Response(null, { status: 204 }));
+    });
+    const synchronizer = createDesktopFullscreenSynchronizer(window as never, { fetch });
+    synchronizer.activate("http://127.0.0.1:4310");
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+
+    synchronizer.activate("http://127.0.0.1:4311");
+    synchronizer.reset("http://127.0.0.1:4310");
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    expect(String(fetch.mock.calls[1]?.[0]).startsWith("http://127.0.0.1:4311")).toBe(true);
+    expect(fetch.mock.calls[1]?.[1]?.body).toBe(JSON.stringify({ fullscreen: true }));
+
+    resolveOldTrue?.();
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(3));
+    const oldOriginBodies = fetch.mock.calls
+      .filter(([url]) => String(url).startsWith("http://127.0.0.1:4310"))
+      .map(([, init]) => init?.body);
+    expect(oldOriginBodies).toEqual([JSON.stringify({ fullscreen: true }), JSON.stringify({ fullscreen: false })]);
+    synchronizer.stop();
+  });
+
+  it.each([404, 405])("treats %i as unsupported until the next activation", async (status) => {
+    const window = createWindow(false);
+    const fetch = vi.fn(async () => new Response(null, { status }));
+    const synchronizer = createDesktopFullscreenSynchronizer(window as never, { fetch });
+    synchronizer.activate("http://127.0.0.1:4310");
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    window.emit("enter-full-screen", true);
+    await Promise.resolve();
+    expect(fetch).toHaveBeenCalledOnce();
+
+    synchronizer.activate("http://127.0.0.1:4311");
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    synchronizer.stop();
+  });
+
+  it("retries transient transport failures in a bounded sequence and resyncs after reload", async () => {
+    const window = createWindow(true);
+    const fetch = vi.fn()
+      .mockRejectedValueOnce(new TypeError("offline"))
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const synchronizer = createDesktopFullscreenSynchronizer(window as never, { fetch });
+    synchronizer.activate("http://127.0.0.1:4310");
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(3));
+
+    window.finishLoad();
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(4));
+    synchronizer.stop();
+  });
+
+  it("times out hanging requests and bounds their transient retries", async () => {
+    vi.useFakeTimers();
+    const window = createWindow(true);
+    const signals: AbortSignal[] = [];
+    const fetch = vi.fn((_url: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) => {
+      signals.push(init!.signal!);
+      return new Promise<Response>(() => undefined);
+    });
+    const synchronizer = createDesktopFullscreenSynchronizer(window as never, { fetch, requestTimeoutMs: 10 });
+    synchronizer.activate("http://127.0.0.1:4310");
+    await vi.advanceTimersByTimeAsync(30);
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(signals.every((signal) => signal.aborted)).toBe(true);
+    synchronizer.stop();
+  });
+
+  it("aborts a hanging old-origin request so a new origin publishes immediately", async () => {
+    const window = createWindow(true);
+    let oldSignal: AbortSignal | undefined;
+    const fetch = vi.fn((url: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) => {
+      if (String(url).startsWith("http://127.0.0.1:4310")) {
+        oldSignal = init?.signal ?? undefined;
+        return new Promise<Response>((_resolve, reject) => oldSignal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true }));
+      }
+      return Promise.resolve(new Response(null, { status: 204 }));
+    });
+    const synchronizer = createDesktopFullscreenSynchronizer(window as never, { fetch });
+    synchronizer.activate("http://127.0.0.1:4310");
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    synchronizer.activate("http://127.0.0.1:4311");
+
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    expect(oldSignal?.aborted).toBe(true);
+    expect(String(fetch.mock.calls[1]?.[0]).startsWith("http://127.0.0.1:4311")).toBe(true);
+    synchronizer.stop();
+  });
+
+  it("aborts outstanding work on stop and does not publish afterward", async () => {
+    const window = createWindow(true);
+    let signal: AbortSignal | undefined;
+    const fetch = vi.fn((_url: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) => {
+      signal = init?.signal ?? undefined;
+      return new Promise<Response>((_resolve, reject) => signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true }));
+    });
+    const synchronizer = createDesktopFullscreenSynchronizer(window as never, { fetch });
+    synchronizer.activate("http://127.0.0.1:4310");
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    synchronizer.stop();
+    await vi.waitFor(() => expect(signal?.aborted).toBe(true));
+    window.emit("leave-full-screen", false);
+    await Promise.resolve();
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("does not infer maximize because only native fullscreen listeners are attached", () => {
+    const window = createWindow(false);
+    const synchronizer = createDesktopFullscreenSynchronizer(window as never, { fetch: vi.fn() });
+    expect(window.windowEvents).toEqual(["enter-full-screen", "leave-full-screen"]);
+    synchronizer.stop();
+  });
+});
+
+function createWindow(initialFullscreen: boolean) {
+  let fullscreen = initialFullscreen;
+  const windowListeners = new Map<string, () => void>();
+  const contentsListeners = new Map<string, () => void>();
+  return {
+    windowEvents: [] as string[],
+    isFullScreen: () => fullscreen,
+    on(event: string, listener: () => void) {
+      this.windowEvents.push(event);
+      windowListeners.set(event, listener);
+      return this;
+    },
+    removeListener(event: string) {
+      windowListeners.delete(event);
+      return this;
+    },
+    webContents: {
+      on(event: string, listener: () => void) { contentsListeners.set(event, listener); },
+      removeListener(event: string) { contentsListeners.delete(event); },
+    },
+    emit(event: "enter-full-screen" | "leave-full-screen", next: boolean) {
+      fullscreen = next;
+      windowListeners.get(event)?.();
+    },
+    finishLoad() { contentsListeners.get("did-finish-load")?.(); },
+  };
+}

--- a/runtime/fleet-desktop/tests/launch-controller.test.ts
+++ b/runtime/fleet-desktop/tests/launch-controller.test.ts
@@ -102,6 +102,21 @@ describe("launch controller", () => {
     expect(order).toEqual(["origin", "theme", "handoff"]);
   });
 
+  it("activates native fullscreen publishing only after the Console handoff completes", async () => {
+    const order: string[] = [];
+    const window = { webContents: { executeJavaScript: vi.fn(async () => undefined), navigationHistory: { clear: vi.fn(() => order.push("history")) } }, show: vi.fn(), loadURL: vi.fn(async () => { order.push("handoff"); }) };
+    const controller = createLaunchController({
+      createWindow: vi.fn(async () => window),
+      pushEntry: vi.fn(async () => undefined),
+      startOrAdopt: vi.fn(async () => "http://127.0.0.1:4310/console/"),
+      handoffOrigin: vi.fn(() => order.push("origin")),
+      synchronizeFullscreen: vi.fn(() => { order.push("fullscreen"); }),
+    });
+
+    await controller.start();
+    expect(order).toEqual(["origin", "handoff", "history", "fullscreen"]);
+  });
+
   it("wires runtime progress, first-run failure Retry, and same-window handoff through the production launch graph", async () => {
     const snapshots: string[] = [];
     let progress: ((state: "checking" | "node" | "installing" | "offline" | "firstfail" | "starting" | "dev", detail?: string, progress?: number) => Promise<void>) | undefined;

--- a/runtime/fleet-desktop/tests/runtime-pairing.test.ts
+++ b/runtime/fleet-desktop/tests/runtime-pairing.test.ts
@@ -55,6 +55,34 @@ describe("runtime pairing", () => {
     expect(notifier.show).toHaveBeenCalledWith(expect.objectContaining({ type: "error" }));
   });
 
+  it("activates fullscreen publishing only after pairing commits, resets the prior origin, and republishes it on rollback", async () => {
+    const policy = { activateConsoleOrigin: vi.fn(), currentConsoleOrigin: vi.fn(() => "http://127.0.0.1:4000"), stageConsoleOrigin: vi.fn(), commitConsoleOrigin: vi.fn(), cancelPendingConsoleOrigin: vi.fn() };
+    const fullscreen = { activate: vi.fn(), reset: vi.fn(), resync: vi.fn(), stop: vi.fn() };
+    const pairing = createRuntimePairing({
+      notifier: { show: vi.fn() },
+      fullscreenSynchronizer: () => fullscreen,
+      themeSynchronizer: { stop: vi.fn(), start: vi.fn(async () => undefined) } as never,
+      modal: modalReturning(null),
+      fetch: async () => identityResponse(),
+    });
+
+    await pairing.switchTo("127.0.0.1:4310", runtimeWindow(vi.fn(async () => undefined)) as never, policy);
+    expect(fullscreen.activate).toHaveBeenCalledWith("http://127.0.0.1:4310");
+    expect(fullscreen.reset).toHaveBeenCalledWith("http://127.0.0.1:4000");
+
+    const rollbackFullscreen = { activate: vi.fn(), reset: vi.fn(), resync: vi.fn(), stop: vi.fn() };
+    const rollback = createRuntimePairing({
+      notifier: { show: vi.fn() },
+      fullscreenSynchronizer: () => rollbackFullscreen,
+      themeSynchronizer: { stop: vi.fn(), start: vi.fn().mockRejectedValueOnce(new Error("theme failed")).mockResolvedValueOnce(undefined) } as never,
+      modal: modalReturning(null),
+      fetch: async () => identityResponse(),
+    });
+    await rollback.switchTo("127.0.0.1:4310", runtimeWindow(vi.fn(async () => undefined)) as never, policy);
+    expect(rollbackFullscreen.activate).toHaveBeenCalledWith("http://127.0.0.1:4000");
+    expect(rollbackFullscreen.resync).toHaveBeenCalledOnce();
+  });
+
   it("serializes the Desktop modal prompt and sends its raw target through the existing verifier", async () => {
     let resolvePrompt: ((value: string | null) => void) | undefined;
     const modal = { prompt: vi.fn(() => new Promise<string | null>((resolve) => { resolvePrompt = resolve; })) };


### PR DESCRIPTION
## Summary
- Auto-hide the 44px Fleet Console command band after 480ms in browser fullscreen, with edge and keyboard reveal, session pinning, modal suppression, and reduced-motion behavior.
- Relay Electron `BrowserWindow` native fullscreen state through an origin-strict, ephemeral Console endpoint and existing operations SSE stream.
- Cover renderer accessibility, server authorization and restart behavior, Desktop pairing and rollback, request ordering, retries, and mixed-version fallback.

## Test Plan
- [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @dotobokuri/fleet-console test` — 811 passed, 21 skipped
- [x] `pnpm --filter @dotobokuri/fleet-desktop test` — 163 passed
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-desktop build`
- [x] `pnpm --filter @dotobokuri/fleet-desktop typecheck`
- [x] Headed browser fullscreen verification on macOS
- [x] Headed Electron native fullscreen verification on macOS
- [x] `.changelog.d/pr-282.md` includes validated bilingual `fleet-console` and `fleet-desktop` release notes
- [x] `node scripts/compile-changelog-fragments.mjs --check`

## Notes
- Windows and Linux use the same Electron `enter-full-screen` / `leave-full-screen` contract but were not available for headed native verification in this macOS environment.
