### PR TITLE
fix(fleet-desktop): avoid quit-time destroyed window error

### DIFF
--- a/runtime/fleet-desktop/e2e/desktop-shell.spec.ts
+++ b/runtime/fleet-desktop/e2e/desktop-shell.spec.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-import { _electron as electron, test, expect } from "playwright/test";
+import { _electron as electron, test, expect, type ElectronApplication } from "playwright/test";
 
 const enabled = process.env.FLEET_DESKTOP_E2E === "1";
 
@@ -87,6 +87,40 @@ test.describe("unpackaged desktop shell", () => {
       expect(new URL(window.url()).pathname).toMatch(/^\/console\//);
     } finally {
       await app.close();
+    }
+  });
+
+  test("quits through the product lifecycle without uncaught main-process exceptions", async () => {
+    const main = process.env.FLEET_DESKTOP_E2E_MAIN;
+    const nodePath = process.env.FLEET_CONSOLE_NODE_PATH;
+    test.skip(!main || !nodePath, "FLEET_DESKTOP_E2E_MAIN and FLEET_CONSOLE_NODE_PATH are required.");
+    let app: ElectronApplication | undefined;
+    let exited = false;
+    const uncaughtMarker = "[fleet-desktop-e2e] uncaughtException:";
+    let stderr = "";
+    try {
+      app = await electron.launch({ args: [path.resolve(main)], env: { ...process.env, FLEET_CONSOLE_NODE_PATH: nodePath } });
+      const appProcess = app.process();
+      appProcess.stderr?.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+      const exit = new Promise<number | null>((resolve, reject) => {
+        appProcess.once("exit", (code) => resolve(code));
+        appProcess.once("error", reject);
+      });
+      const window = await app.firstWindow();
+      await expect(window).toHaveURL(/\/console\//);
+
+      await app.evaluate(({ app }) => {
+        process.once("uncaughtException", (error) => {
+          process.stderr.write(`[fleet-desktop-e2e] uncaughtException: ${error.stack ?? error.message}\n`);
+        });
+        app.quit();
+      });
+
+      await expect(exit).resolves.toBe(0);
+      exited = true;
+      expect(stderr).not.toContain(uncaughtMarker);
+    } finally {
+      if (app && !exited) await app.close();
     }
   });
 });

--- a/runtime/fleet-desktop/e2e/desktop-shell.spec.ts
+++ b/runtime/fleet-desktop/e2e/desktop-shell.spec.ts
@@ -102,8 +102,8 @@ test.describe("unpackaged desktop shell", () => {
       app = await electron.launch({ args: [path.resolve(main)], env: { ...process.env, FLEET_CONSOLE_NODE_PATH: nodePath } });
       const appProcess = app.process();
       appProcess.stderr?.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
-      const exit = new Promise<number | null>((resolve, reject) => {
-        appProcess.once("exit", (code) => resolve(code));
+      const close = new Promise<number | null>((resolve, reject) => {
+        appProcess.once("close", (code) => resolve(code));
         appProcess.once("error", reject);
       });
       const window = await app.firstWindow();
@@ -116,7 +116,7 @@ test.describe("unpackaged desktop shell", () => {
         app.quit();
       });
 
-      await expect(exit).resolves.toBe(0);
+      await expect(close).resolves.toBe(0);
       exited = true;
       expect(stderr).not.toContain(uncaughtMarker);
     } finally {

--- a/runtime/fleet-desktop/src/desktop-fullscreen-sync.ts
+++ b/runtime/fleet-desktop/src/desktop-fullscreen-sync.ts
@@ -36,6 +36,7 @@ export function createDesktopFullscreenSynchronizer(
   const requestTimeoutMs = deps.requestTimeoutMs ?? REQUEST_TIMEOUT_MS;
   const schedule = deps.setTimeout ?? globalThis.setTimeout;
   const cancelSchedule = deps.clearTimeout ?? globalThis.clearTimeout;
+  const webContents = window.webContents;
   let nativeFullscreen = window.isFullScreen();
   let activeOrigin: string | null = null;
   let unsupported = false;
@@ -143,7 +144,7 @@ export function createDesktopFullscreenSynchronizer(
 
   window.on("enter-full-screen", updateNativeFullscreen);
   window.on("leave-full-screen", updateNativeFullscreen);
-  window.webContents.on("did-finish-load", resync);
+  webContents.on("did-finish-load", resync);
 
   return {
     activate(origin: string): void {
@@ -159,12 +160,13 @@ export function createDesktopFullscreenSynchronizer(
     },
     resync,
     stop(): void {
+      if (stopped) return;
       stopped = true;
       activeOrigin = null;
       abortAllRequests();
       window.removeListener("enter-full-screen", updateNativeFullscreen);
       window.removeListener("leave-full-screen", updateNativeFullscreen);
-      window.webContents.removeListener("did-finish-load", resync);
+      webContents.removeListener("did-finish-load", resync);
     },
   };
 }

--- a/runtime/fleet-desktop/tests/desktop-fullscreen-sync.test.ts
+++ b/runtime/fleet-desktop/tests/desktop-fullscreen-sync.test.ts
@@ -160,6 +160,17 @@ describe("Desktop fullscreen synchronizer", () => {
     expect(fetch).toHaveBeenCalledOnce();
   });
 
+  it("stops idempotently after BrowserWindow destruction without reading webContents again", () => {
+    const window = createWindow(false);
+    const synchronizer = createDesktopFullscreenSynchronizer(window as never, { fetch: vi.fn() });
+
+    window.destroy();
+    expect(() => {
+      synchronizer.stop();
+      synchronizer.stop();
+    }).not.toThrow();
+  });
+
   it("does not infer maximize because only native fullscreen listeners are attached", () => {
     const window = createWindow(false);
     const synchronizer = createDesktopFullscreenSynchronizer(window as never, { fetch: vi.fn() });
@@ -170,8 +181,13 @@ describe("Desktop fullscreen synchronizer", () => {
 
 function createWindow(initialFullscreen: boolean) {
   let fullscreen = initialFullscreen;
+  let destroyed = false;
   const windowListeners = new Map<string, () => void>();
   const contentsListeners = new Map<string, () => void>();
+  const webContents = {
+    on(event: string, listener: () => void) { contentsListeners.set(event, listener); },
+    removeListener(event: string) { contentsListeners.delete(event); },
+  };
   return {
     windowEvents: [] as string[],
     isFullScreen: () => fullscreen,
@@ -184,14 +200,15 @@ function createWindow(initialFullscreen: boolean) {
       windowListeners.delete(event);
       return this;
     },
-    webContents: {
-      on(event: string, listener: () => void) { contentsListeners.set(event, listener); },
-      removeListener(event: string) { contentsListeners.delete(event); },
+    get webContents() {
+      if (destroyed) throw new TypeError("Object has been destroyed");
+      return webContents;
     },
     emit(event: "enter-full-screen" | "leave-full-screen", next: boolean) {
       fullscreen = next;
       windowListeners.get(event)?.();
     },
     finishLoad() { contentsListeners.get("did-finish-load")?.(); },
+    destroy() { destroyed = true; },
   };
 }


### PR DESCRIPTION
## Summary

- Keep the fullscreen synchronizer's WebContents teardown handle stable after BrowserWindow destruction.
- Add unit and headed Electron regression coverage for the real `app.quit()` lifecycle and uncaught main-process errors.
- Preserve the Windows close/theme teardown contract by static code inspection; Windows live execution remains unverified.

## Type of Change

- [x] fix — bug fix

## Scope

- [x] `runtime/fleet-desktop`

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-desktop exec vitest run tests/desktop-fullscreen-sync.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-desktop typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-desktop build`
- [x] Headed macOS arm64 Electron E2E invokes product `app.quit()` and exits cleanly without an uncaught marker.
- [x] Windows `win32` close guard and theme/fullscreen teardown paths reviewed statically.
- [ ] Windows live native verification — unverified, requires Windows.

## Changelog

- [x] `no-changelog` — this corrects the unreleased fullscreen relay already described by `.changelog.d/pr-282.md`.
