### PR TITLE
fix(fleet-console): restore Alt navigation from minimized state

### DIFF
--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -96,6 +96,9 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
         setActiveOperation(nextId);
         return;
       }
+      // 모두 최소화된 부팅 상태의 폴백 대상은 store 포커스보다 먼저 복원한다. 그렇지 않으면 Canvas의
+      // "최소화된 active id 제거" effect가 pending focus 복원보다 앞서 실행되어 활성 표시를 지운다.
+      if (canvas.minimized.includes(nextId)) restoreOperation(nextId);
       focusOperation(nextId);
     };
     window.addEventListener("keydown", handler, true);

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -366,7 +366,8 @@ export function flattenGroupedOrder(
   ];
 }
 
-// Alt+←/→는 SideBar 가시 순서를 따르되, 캔버스에서 최소화된 Operation은 순환 대상에서 제외한다.
+// Alt+←/→는 비최소화 Operation을 우선 순환한다. 단, 부팅 직후처럼 모두 최소화되어 후보가 없으면
+// SideBar 가시 순서로 폴백해 탐색 방향 끝의 Operation을 다시 표면화할 수 있게 한다.
 export function focusCycleOperationIds(
   operations: readonly OperationNode[],
   groups: readonly OperationGroup[],
@@ -375,9 +376,9 @@ export function focusCycleOperationIds(
   minimized: readonly string[],
 ): readonly string[] {
   const minimizedIds = new Set(minimized);
-  return flattenGroupedOrder(operations, groups, operationOrder, collapsedGroups)
-    .filter((operation) => !minimizedIds.has(operation.id))
-    .map((operation) => operation.id);
+  const visibleOperations = flattenGroupedOrder(operations, groups, operationOrder, collapsedGroups);
+  const focusableOperations = visibleOperations.filter((operation) => !minimizedIds.has(operation.id));
+  return (focusableOperations.length > 0 ? focusableOperations : visibleOperations).map((operation) => operation.id);
 }
 
 export function compareOperationCreatedAt(left: OperationNode, right: OperationNode): number {

--- a/runtime/fleet-console/tests/operation-focus.test.ts
+++ b/runtime/fleet-console/tests/operation-focus.test.ts
@@ -69,4 +69,22 @@ describe("nextOperationId — Alt+←/→ focus cycle", () => {
     expect(nextOperationId(order, "group-1-visible", -1)).toBe("ungrouped-visible");
   });
 
+  it("falls back to SideBar order when every visible operation is minimized", () => {
+    const order = focusCycleOperationIds(
+      [
+        makeOperation("grouped", "group", 1),
+        makeOperation("collapsed", "collapsed", 2),
+        makeOperation("ungrouped", null, 3),
+      ],
+      [makeGroup("group", 1), makeGroup("collapsed", 2)],
+      ["grouped", "collapsed", "ungrouped"],
+      ["collapsed"],
+      ["grouped", "collapsed", "ungrouped"],
+    );
+
+    expect(order).toEqual(["grouped", "ungrouped"]);
+    expect(nextOperationId(order, null, 1)).toBe("grouped");
+    expect(nextOperationId(order, null, -1)).toBe("ungrouped");
+  });
+
 });

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -180,7 +180,7 @@ describe("Operations boot minimization", () => {
     expect(getSnapshot().operations).toHaveProperty("launched");
   });
 
-  it("consumes Alt+Arrow without restoring a minimized panel", async () => {
+  it("restores the only minimized panel with Alt+Arrow", async () => {
     const operations = deferred<readonly OperationNode[]>();
     const theaters = deferred<TheaterBootstrap>();
     apiMocks.fetchOperations.mockReturnValueOnce(operations.promise);
@@ -205,8 +205,8 @@ describe("Operations boot minimization", () => {
     });
 
     expect(event.defaultPrevented).toBe(true);
-    expect(getState().activeOperationId).toBeNull();
-    expect(getSnapshot().minimized).toEqual(["initial"]);
+    expect(getState().activeOperationId).toBe("initial");
+    expect(getSnapshot().minimized).toEqual([]);
   });
 
   it("advances the focus layer with Alt+Arrow while preserving Formation", async () => {


### PR DESCRIPTION
## Summary

- Restore Alt+Left and Alt+Right navigation when every Operation starts minimized.
- Keep minimized Operations out of the focus cycle while any visible panel remains available.
- Restore the all-minimized fallback target before applying focus so Canvas cleanup cannot clear the active Operation.

## Type of Change

- [ ] feat — new feature or carrier capability
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- [x] `runtime/fleet-console`

## Test Plan

- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @dotobokuri/fleet-console exec vitest run tests/operation-focus.test.ts tests/operations-boot-minimization.integration.test.ts` (14 tests)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] Windows ARM64 headed E2E: verified both Alt+Right and Alt+Left from the all-minimized boot state
- [ ] Full Console typecheck — currently blocked by pre-existing CSS side-effect import and `virtual:fleet-plugins` declaration errors outside this diff

## Changelog

- [x] Applied the `no-changelog` label intentionally: this corrects behavior introduced by unreleased PR #274, whose pending fragment already owns the release note.
- [ ] Fragment `section:` is one of `Added`, `Changed`, `Fixed`, `Removed`, or `Breaking Changes`.
- [ ] Fragment bullets use an allowed scope tag.

## Related Issues / PRs

References #274

## Notes for Reviewers

The focused keyboard path was exercised through a headed browser on Windows ARM64 emulation. Physical hardware scan-code behavior remains outside automated coverage.