### PR TITLE
fix(fleet-carriers): remove dispatch concurrency limit

### DIFF
--- a/.changelog.d/pr-287.md
+++ b/.changelog.d/pr-287.md
@@ -1,0 +1,4 @@
+### fleet-core
+#### Removed
+- [fleet-carriers] Remove the process-wide concurrency limit from Carrier dispatches.
+  ko: 캐리어 dispatch의 프로세스 전역 동시 실행 제한을 제거합니다.

--- a/packages/fleet-carriers/src/dispatch/taskforce.ts
+++ b/packages/fleet-carriers/src/dispatch/taskforce.ts
@@ -165,10 +165,6 @@ export async function launchTaskForceJob(options: TaskForceLaunchOptions): Promi
     carrierIds: [carrierId],
     signal: ctx.signal,
   });
-  if (!launch.accepted) {
-    releaseDispatchLease(services?.dispatchContexts, claim.lease);
-    return launch.response;
-  }
 
   const state = initTaskForceState(carrierId, requestKey, activeBackends);
 

--- a/packages/fleet-carriers/src/dispatch/tool-spec.ts
+++ b/packages/fleet-carriers/src/dispatch/tool-spec.ts
@@ -305,10 +305,6 @@ export function buildCarrierDispatchToolSpec(registry: CarrierRegistry, deps: Ca
         carrierIds: [carrierId],
         signal: ctx.signal,
       });
-      if (!launch.accepted) {
-        releaseDispatchLease(services?.dispatchContexts, claim.lease);
-        return launch.response;
-      }
 
       const carrierConfig = getRegisteredCarrierConfig(registry, carrierId);
       const handle = executeOneShot({

--- a/packages/fleet-carriers/src/index.ts
+++ b/packages/fleet-carriers/src/index.ts
@@ -144,7 +144,7 @@ export const jobs = {
   acquireJobPermit: jobLifecycle.acquireJobPermit,
   getActiveBackgroundJobCount: jobLifecycle.getActiveBackgroundJobCount,
   onActiveJobCountChange: jobLifecycle.onActiveJobCountChange,
-  resetJobConcurrencyForTest: jobLifecycle.resetJobConcurrencyForTest,
+  resetJobTrackingForTest: jobLifecycle.resetJobTrackingForTest,
   streaming: {
     register: dispatchFramework.registerStreamHandler,
     unregister: dispatchFramework.unregisterStreamHandler,

--- a/packages/fleet-carriers/src/jobs/lifecycle.ts
+++ b/packages/fleet-carriers/src/jobs/lifecycle.ts
@@ -4,10 +4,8 @@ import { createJobArchive, finalizeJobArchive } from "./archive.js";
 import { detachJobArchive } from "./archive.js";
 import { putJobSummary } from "./summary-cache.js";
 
-interface GuardState {
+interface JobTrackingState {
   activeJobs: Map<string, CarrierJobRecord>;
-  activeCarrierJobs: Map<string, Set<string>>;
-  maxDetachedJobs: number;
   activeJobCountCallbacks: Array<(count: number) => void>;
 }
 
@@ -20,12 +18,7 @@ export interface JobPermitAccepted {
   release: (finished?: Partial<Pick<CarrierJobRecord, "status" | "error" | "finishedAt">>) => void;
 }
 
-export interface JobPermitRejected {
-  accepted: false;
-  error: "concurrency limit";
-}
-
-export type JobPermit = JobPermitAccepted | JobPermitRejected;
+export type JobPermit = JobPermitAccepted;
 
 export interface JobCancelRegistry {
   registerJobAbortController(jobId: string, controller: AbortController): void;
@@ -47,12 +40,7 @@ export interface DetachedJobAccepted {
   signal: AbortSignal;
 }
 
-export interface DetachedJobRejected {
-  accepted: false;
-  response: ReturnType<typeof launchResponseResult>;
-}
-
-export type DetachedJobLaunch = DetachedJobAccepted | DetachedJobRejected;
+export type DetachedJobLaunch = DetachedJobAccepted;
 
 export interface StartDetachedJobOptions {
   jobKind: CarrierJobKind;
@@ -78,27 +66,16 @@ export interface RollbackRejectedDetachedJobOptions {
   abort?: () => void | Promise<void>;
 }
 
-const DEFAULT_MAX_DETACHED_JOBS = 5;
-const guardState: GuardState = {
+const jobTrackingState: JobTrackingState = {
   activeJobs: new Map(),
-  activeCarrierJobs: new Map(),
-  maxDetachedJobs: DEFAULT_MAX_DETACHED_JOBS,
   activeJobCountCallbacks: [],
 };
 
 const defaultJobCancelRegistry = createJobCancelRegistry();
 
-export function acquireJobPermit(record: CarrierJobRecord): JobPermit {
-  const state = getGuardState();
-  if (state.activeJobs.size >= state.maxDetachedJobs) {
-    return { accepted: false, error: "concurrency limit" };
-  }
+export function acquireJobPermit(record: CarrierJobRecord): JobPermitAccepted {
+  const state = getJobTrackingState();
   state.activeJobs.set(record.jobId, record);
-  for (const carrierId of record.carriers) {
-    const activeSet = state.activeCarrierJobs.get(carrierId) ?? new Set<string>();
-    activeSet.add(record.jobId);
-    state.activeCarrierJobs.set(carrierId, activeSet);
-  }
   notifyActiveJobCountChange(state);
   return {
     accepted: true,
@@ -110,17 +87,9 @@ export function releaseJobPermit(
   jobId: string,
   finished: Partial<Pick<CarrierJobRecord, "status" | "error" | "finishedAt">> = {},
 ): void {
-  const state = getGuardState();
+  const state = getJobTrackingState();
   const record = state.activeJobs.get(jobId);
   if (!record) return;
-  for (const carrierId of record.carriers) {
-    const activeSet = state.activeCarrierJobs.get(carrierId);
-    if (!activeSet) continue;
-    activeSet.delete(jobId);
-    if (activeSet.size === 0) {
-      state.activeCarrierJobs.delete(carrierId);
-    }
-  }
   record.status = finished.status ?? record.status;
   record.error = finished.error ?? record.error;
   record.finishedAt = finished.finishedAt ?? Date.now();
@@ -129,19 +98,19 @@ export function releaseJobPermit(
 }
 
 export function getActiveJob(jobId: string): CarrierJobRecord | null {
-  return getGuardState().activeJobs.get(jobId) ?? null;
+  return getJobTrackingState().activeJobs.get(jobId) ?? null;
 }
 
 export function listActiveJobs(): CarrierJobRecord[] {
-  return [...getGuardState().activeJobs.values()].sort((a, b) => b.startedAt - a.startedAt);
+  return [...getJobTrackingState().activeJobs.values()].sort((a, b) => b.startedAt - a.startedAt);
 }
 
 export function getActiveBackgroundJobCount(): number {
-  return getGuardState().activeJobs.size;
+  return getJobTrackingState().activeJobs.size;
 }
 
 export function onActiveJobCountChange(callback: (count: number) => void): () => void {
-  const state = getGuardState();
+  const state = getJobTrackingState();
   state.activeJobCountCallbacks.push(callback);
   return () => {
     const index = state.activeJobCountCallbacks.indexOf(callback);
@@ -149,15 +118,9 @@ export function onActiveJobCountChange(callback: (count: number) => void): () =>
   };
 }
 
-export function configureDetachedJobCap(maxDetachedJobs: number): void {
-  getGuardState().maxDetachedJobs = maxDetachedJobs;
-}
-
-export function resetJobConcurrencyForTest(): void {
-  const state = getGuardState();
+export function resetJobTrackingForTest(): void {
+  const state = getJobTrackingState();
   state.activeJobs.clear();
-  state.activeCarrierJobs.clear();
-  state.maxDetachedJobs = DEFAULT_MAX_DETACHED_JOBS;
   state.activeJobCountCallbacks = [];
 }
 
@@ -270,11 +233,6 @@ export function startDetachedJob(options: StartDetachedJobOptions): DetachedJobL
     startedAt: options.startedAt,
     carriers: options.carrierIds,
   });
-  if (!permit.accepted) {
-    const response = launchResponseResult({ job_id: jobId, accepted: false, error: permit.error });
-    return { accepted: false, response };
-  }
-
   createJobArchive(jobId, options.startedAt);
   const jobController = new AbortController();
   registerJobAbortController(jobId, jobController);
@@ -302,13 +260,13 @@ export async function rollbackRejectedDetachedJob(options: RollbackRejectedDetac
   }
 }
 
-function notifyActiveJobCountChange(state: GuardState): void {
+function notifyActiveJobCountChange(state: JobTrackingState): void {
   const count = state.activeJobs.size;
   for (const callback of state.activeJobCountCallbacks) {
     try { callback(count); } catch { /* ignore listener failures */ }
   }
 }
 
-function getGuardState(): GuardState {
-  return guardState;
+function getJobTrackingState(): JobTrackingState {
+  return jobTrackingState;
 }

--- a/packages/fleet-carriers/tests/carrier-job-shared.test.ts
+++ b/packages/fleet-carriers/tests/carrier-job-shared.test.ts
@@ -10,11 +10,10 @@ import {
 } from "../src/jobs/archive.js";
 import {
   acquireJobPermit,
-  configureDetachedJobCap,
   getActiveJob,
   listActiveJobs,
   rollbackRejectedDetachedJob,
-  resetJobConcurrencyForTest,
+  resetJobTrackingForTest,
 } from "../src/jobs/lifecycle.js";
 import {
   cancelJob,
@@ -51,7 +50,7 @@ import * as jobBarrel from "../src/index.js";
 beforeEach(() => {
   resetJobArchivesForTest();
   resetJobSummaryCacheForTest();
-  resetJobConcurrencyForTest();
+  resetJobTrackingForTest();
   resetJobCancelRegistryForTest();
 });
 
@@ -474,47 +473,22 @@ describe("summary LRU cache", () => {
   });
 });
 
-describe("concurrency guard", () => {
-  it("accepts multiple active jobs for the same carrier", () => {
-    const first = acquireJobPermit(buildRecord("sortie:1", ["genesis"]));
-    expect(first.accepted).toBe(true);
+describe("active job tracking", () => {
+  it("tracks active jobs without a global cap", () => {
+    const permits = Array.from({ length: 10 }, (_, index) =>
+      acquireJobPermit(buildRecord(`sortie:${index}`, ["genesis"])),
+    );
 
-    const second = acquireJobPermit(buildRecord("sortie:2", ["genesis"]));
-    expect(second.accepted).toBe(true);
+    expect(permits.every((permit) => permit.accepted)).toBe(true);
+    expect(listActiveJobs()).toHaveLength(10);
 
-    if (first.accepted) first.release({ status: "done", finishedAt: 2000 });
-    expect(listActiveJobs().map((job) => job.jobId)).toEqual(["sortie:2"]);
-
-    if (second.accepted) second.release({ status: "done", finishedAt: 2001 });
+    permits.forEach((permit, index) => permit.release({ status: "done", finishedAt: 2000 + index }));
     expect(listActiveJobs()).toEqual([]);
   });
 
-  it("rejects the sixth detached job by global cap", () => {
-    configureDetachedJobCap(5);
-    for (let i = 0; i < 5; i++) {
-      expect(acquireJobPermit(buildRecord(`sortie:${i}`, [`carrier-${i}`])).accepted).toBe(true);
-    }
-
-    expect(acquireJobPermit(buildRecord("sortie:6", ["carrier-6"]))).toEqual({
-      accepted: false,
-      error: "concurrency limit",
-    });
-  });
-
-  it("keeps the global cap as the only concurrency rejection path", () => {
-    configureDetachedJobCap(1);
-    expect(acquireJobPermit(buildRecord("sortie:1", ["genesis"])).accepted).toBe(true);
-
-    expect(acquireJobPermit(buildRecord("sortie:2", ["genesis"]))).toEqual({
-      accepted: false,
-      error: "concurrency limit",
-    });
-  });
-
-  it("releases carrier and global permits", () => {
+  it("releases active job tracking", () => {
     const permit = acquireJobPermit(buildRecord("sortie:1", ["genesis"]));
-    expect(permit.accepted).toBe(true);
-    if (permit.accepted) permit.release({ status: "done", finishedAt: 2000 });
+    permit.release({ status: "done", finishedAt: 2000 });
 
     expect(listActiveJobs()).toEqual([]);
     expect(acquireJobPermit(buildRecord("sortie:2", ["genesis"])).accepted).toBe(true);

--- a/packages/fleet-carriers/tests/dispatch/codex-acp-stderr.e2e.test.ts
+++ b/packages/fleet-carriers/tests/dispatch/codex-acp-stderr.e2e.test.ts
@@ -18,7 +18,7 @@ import {
   registerCarrier,
   resetJobArchivesForTest,
   resetJobCancelRegistryForTest,
-  resetJobConcurrencyForTest,
+  resetJobTrackingForTest,
   resetJobSummaryCacheForTest,
   resetStoreForTests,
   type CarrierConfig,
@@ -50,14 +50,14 @@ describe("carrier_jobs Codex ACP stderr diagnostics e2e", () => {
     });
     resetJobArchivesForTest();
     resetJobSummaryCacheForTest();
-    resetJobConcurrencyForTest();
+    resetJobTrackingForTest();
     resetJobCancelRegistryForTest();
   });
 
   afterEach(async () => {
     resetJobArchivesForTest();
     resetJobSummaryCacheForTest();
-    resetJobConcurrencyForTest();
+    resetJobTrackingForTest();
     resetJobCancelRegistryForTest();
     resetStoreForTests();
     if (tempDir) {

--- a/packages/fleet-carriers/tests/dispatch/oneshot-sessions.test.ts
+++ b/packages/fleet-carriers/tests/dispatch/oneshot-sessions.test.ts
@@ -12,7 +12,7 @@ import {
   getJobSummary,
   registerCarrier,
   resetJobCancelRegistryForTest,
-  resetJobConcurrencyForTest,
+  resetJobTrackingForTest,
   resetStoreForTests,
   updateTaskForceModelSelection,
   type CarrierConfig,
@@ -95,7 +95,7 @@ afterEach(async () => {
   await runtime?.cleanup();
   runtime = null;
   vi.mocked(executeOneShot).mockReset();
-  resetJobConcurrencyForTest();
+  resetJobTrackingForTest();
   resetJobCancelRegistryForTest();
   resetStoreForTests();
   if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Remove the process-wide detached Carrier job limit and its concurrency rejection path.
- Preserve active job tracking, cancellation, result routing, and completion cleanup.
- Add regression coverage proving jobs continue beyond the former global limit.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-carriers exec vitest run tests/carrier-job-shared.test.ts tests/dispatch/framework.test.ts tests/dispatch/oneshot-sessions.test.ts` (80 passed)
- [x] `pnpm --filter @dotobokuri/fleet-carriers typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-carriers build`
- [x] `git diff --check`
- [ ] Full package suite: 172/174 passed; the existing `codex-acp-stderr.e2e` environment failures remain unchanged.

## Changelog
- [x] Added `.changelog.d/pr-287.md` with `fleet-core / Removed` grouping.
- [x] Added adjacent ASCII English and Hangul Korean summaries.
- [x] Validated all fragments with `node scripts/compile-changelog-fragments.mjs --check`.
