### PR TITLE
fix(fleet-console): restore panel control focus rings

### DIFF
--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3204,7 +3204,8 @@
      gap이 그보다 좁으면 이웃 칩과 링이 겹쳐 외곽선이 이중으로 보인다. */
   gap: var(--space-2);
   max-width: 0;
-  overflow: hidden;
+  overflow-x: clip;
+  overflow-y: visible;
   opacity: 0;
   pointer-events: none;
   transition:

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -411,6 +411,9 @@ describe("Instrument core design contract", () => {
     expect(components).toContain("color-mix(in oklch, var(--brass) 62%, var(--ink-rim))");
     expect(components).toContain(".canvas-operation-window-controls {");
     expect(components).toContain("max-width: 0;");
+    const windowControlsBlock = components.match(/\.canvas-operation-window-controls \{[^}]*\}/)?.[0] ?? "";
+    expect(windowControlsBlock).toContain("overflow-x: clip;");
+    expect(windowControlsBlock).toContain("overflow-y: visible;");
     expect(components).toContain(".operations-canvas.is-glance .canvas-operation-glance-hud {");
     // armed-close는 hover 전개 규칙(0-4-0)과 같은 특이도의 후순위여야 Close? 라벨이 잘리지 않는다.
     expect(components).toContain(".canvas-operation .canvas-operation-window-controls .canvas-operation-icon-button.is-armed-close {");


### PR DESCRIPTION
## Summary
- preserve horizontal clipping for collapsed panel window controls
- restore the full vertical focus and hover ring around expanded controls
- add a regression contract for axis-specific overflow behavior

## Test Plan
- [x] `vitest run tests/instrument-design-contract.test.ts --config vitest.config.ts` — 13 tests passed
- [x] `corepack pnpm --filter @dotobokuri/fleet-console build`
- [x] isolated Console browser probe — collapsed width 0, expanded overflow `clip/visible`, no page errors
- [x] `git diff --check`

## Changelog
- [x] `no-changelog` — correction to the unreleased panel nameplate behavior already described by `.changelog.d/pr-276.md`
