### PR TITLE
feat(fleet-console): add local channel chip and environment popover

### DIFF
--- a/.changelog.d/pr-290.md
+++ b/.changelog.d/pr-290.md
@@ -1,0 +1,6 @@
+### fleet-console
+#### Added
+- [fleet-console] Show a Local channel chip in the Command Band on development-channel consoles, with an Environment popover that reveals the console version, port, data root, and runtime lock paths with copy buttons; production channels render no indicator.
+  ko: 개발 채널 콘솔의 Command Band에 Local 칩을 표시하고, 콘솔 버전·포트·데이터 루트·런타임 lock 경로를 Copy 버튼과 함께 보여주는 Environment 팝오버를 추가합니다. 프로덕션 채널에는 어떤 표시도 렌더되지 않습니다.
+- [fleet-console] Desktop shells add a derived Desktop data path row to the Environment popover, and macOS Desktop abbreviates the chip label to Local to fit beside the window controls.
+  ko: Desktop 셸에서는 Environment 팝오버에 파생 Desktop data 경로 행이 추가되고, macOS Desktop은 창 컨트롤 옆에 맞도록 칩 라벨을 Local로 축약합니다.

--- a/runtime/fleet-console/AGENTS.md
+++ b/runtime/fleet-console/AGENTS.md
@@ -29,6 +29,7 @@
 - Core browser APIs do not use bearer, admin, MCP, or session tokens. Loopback is not authorization: preserve route-specific Host and Origin gates.
 - Terminal WebSocket is the sole ticketed browser transport: an Origin-authorized HTTP route issues a short-lived one-use ticket consumed by the upgrade. Do not generalize that ticket into browser bearer authentication.
 - Provider session identities, transcripts, and raw filesystem paths may remain in sensitive server-side state but must not enter ordinary core or built-in browser DTOs, browser-visible logs, streams, or static assets.
+- Local-channel environment diagnostics invoked only by an explicit user action may return the Console's own data-root and runtime-lock paths.
 - Filesystem access requires lexical validation followed by containment checks on resolved real paths. Git revision input must reject option-like arguments even when no shell is used.
 - Shared markdown and Mermaid output must remain sanitized before DOM insertion; Mermaid stays strict with HTML labels disabled, and renderer-supplied bind functions are never executed.
 - The Console server is the sole durable-state writer. Development and published channels intentionally use separate data roots; an explicit Console-directory override relocates runtime and durable data together. Restored Operations are dormant until explicitly relaunched.

--- a/runtime/fleet-console/core/client/src/api.ts
+++ b/runtime/fleet-console/core/client/src/api.ts
@@ -1,4 +1,4 @@
-import type { ConsoleUpdateApplyAcceptedResponse, OperationGroup, OperationNode, ObserverStatus, ReleaseNoteItem, ReleaseNoteProduct, ReleaseNoteSection, ReleaseNotes, ReleaseNotesLocale, ReleaseNotesResponse, TheaterBootstrap, TheaterInfo } from "./types.js";
+import type { ConsoleEnvironmentDiagnostics, ConsoleUpdateApplyAcceptedResponse, OperationGroup, OperationNode, ObserverStatus, ReleaseNoteItem, ReleaseNoteProduct, ReleaseNoteSection, ReleaseNotes, ReleaseNotesLocale, ReleaseNotesResponse, TheaterBootstrap, TheaterInfo } from "./types.js";
 
 export interface TheaterFolderListEntry {
   readonly name: string;
@@ -109,6 +109,12 @@ export async function fetchObserverStatus(theaterId: string | null, signal?: Abo
   const response = await fetch(`/api/v1/status${suffix}`, { signal });
   await assertOk(response);
   return assertObserverStatus(await response.json(), response.status);
+}
+
+export async function fetchConsoleEnvironment(signal?: AbortSignal): Promise<ConsoleEnvironmentDiagnostics> {
+  const response = await fetch("/api/v1/environment", { cache: "no-store", signal });
+  await assertOk(response);
+  return assertConsoleEnvironmentDiagnostics(await response.json(), response.status);
 }
 
 export async function fetchReleaseNotes(options: ReleaseNotesFetchOptions = {}): Promise<ReleaseNotesResponse> {
@@ -394,6 +400,22 @@ function assertObserverStatus(value: unknown, status: number): ObserverStatus {
     portHonored: payload.portHonored,
     wikiServerStatus: payload.wikiServerStatus,
   };
+}
+
+function assertConsoleEnvironmentDiagnostics(value: unknown, status: number): ConsoleEnvironmentDiagnostics {
+  const payload = value as Partial<ConsoleEnvironmentDiagnostics>;
+  if (
+    !payload
+    || payload.channel !== "local"
+    || typeof payload.version !== "string"
+    || typeof payload.effectivePort !== "number"
+    || typeof payload.dataDir !== "string"
+    || typeof payload.lockFile !== "string"
+    || Object.keys(payload).length !== 5
+  ) {
+    throw new ApiError(status, "Invalid environment response");
+  }
+  return payload as ConsoleEnvironmentDiagnostics;
 }
 
 function assertConsoleUpdateApplyAccepted(value: unknown, status: number): ConsoleUpdateApplyAcceptedResponse {

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -169,6 +169,10 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
       >
       <div className={`command-band-left${operationsViewVisible && sideBar.collapsed ? " is-collapsed" : ""}`}>
         <FleetBrandHome className="command-band-brand" />
+        {state.channel === "local" ? <button type="button" className="command-band-local-chip" aria-haspopup="dialog" aria-expanded={false}>
+          <span className="command-band-local-dot" aria-hidden="true" />
+          Local
+        </button> : null}
         {operationsViewVisible ? <button type="button" className="command-band-button command-band-sidebar-toggle" onClick={() => setSideBarCollapsed(!sideBar.collapsed)} aria-label={`${sideBar.collapsed ? "Expand sidebar" : "Collapse sidebar"} (${sideBarShortcut})`} title={`${sideBar.collapsed ? "Expand sidebar" : "Collapse sidebar"} (${sideBarShortcut})`}>
           <PanelToggleIcon side="left" />
         </button> : null}

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -146,11 +146,6 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
     contextTriggerRef.current?.focus();
   };
 
-  const closeEnvironment = () => {
-    setEnvironmentOpen(false);
-    environmentTriggerRef.current?.focus();
-  };
-
   const copyEnvironmentValue = (value: string) => {
     void navigator.clipboard.writeText(value).then(() => setCopiedValue(value)).catch(() => setEnvironmentError("Unable to copy value."));
   };

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -56,6 +56,7 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
   const [environmentError, setEnvironmentError] = useState<string | null>(null);
   const [environmentLoading, setEnvironmentLoading] = useState(false);
   const [copiedValue, setCopiedValue] = useState<string | null>(null);
+  const desktopShell = typeof document !== "undefined" && document.documentElement.dataset.desktopShell === "true";
   const canAutoHide = useCallback(() => {
     const activeElement = document.activeElement;
     const focusWithin = activeElement instanceof Node && (commandBandRef.current?.contains(activeElement) || edgeRevealRef.current?.contains(activeElement));
@@ -235,9 +236,9 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
         {state.channel === "local" ? <div className="command-band-environment">
           <button ref={environmentTriggerRef} type="button" className="command-band-local-chip" aria-haspopup="dialog" aria-expanded={environmentOpen} onClick={() => setEnvironmentOpen((open) => !open)}>
           <span className="command-band-local-dot" aria-hidden="true" />
-          Local
+          {desktopShell ? "Local · Desktop" : "Local"}
           </button>
-          {environmentOpen ? <div ref={environmentPopoverRef}><EnvironmentPopover environment={environment} error={environmentError} loading={environmentLoading} copiedValue={copiedValue} onCopy={copyEnvironmentValue} /></div> : null}
+          {environmentOpen ? <div ref={environmentPopoverRef}><EnvironmentPopover environment={environment} error={environmentError} loading={environmentLoading} copiedValue={copiedValue} desktopShell={desktopShell} onCopy={copyEnvironmentValue} /></div> : null}
         </div> : null}
         {operationsViewVisible ? <button type="button" className="command-band-button command-band-sidebar-toggle" onClick={() => setSideBarCollapsed(!sideBar.collapsed)} aria-label={`${sideBar.collapsed ? "Expand sidebar" : "Collapse sidebar"} (${sideBarShortcut})`} title={`${sideBar.collapsed ? "Expand sidebar" : "Collapse sidebar"} (${sideBarShortcut})`}>
           <PanelToggleIcon side="left" />
@@ -278,10 +279,11 @@ interface EnvironmentPopoverProps {
   readonly error: string | null;
   readonly loading: boolean;
   readonly copiedValue: string | null;
+  readonly desktopShell: boolean;
   readonly onCopy: (value: string) => void;
 }
 
-function EnvironmentPopover({ environment, error, loading, copiedValue, onCopy }: EnvironmentPopoverProps) {
+function EnvironmentPopover({ environment, error, loading, copiedValue, desktopShell, onCopy }: EnvironmentPopoverProps) {
   if (loading) return <div className="command-band-environment-popover" role="dialog" aria-label="Environment">Loading environment details…</div>;
   if (error) return <div className="command-band-environment-popover" role="dialog" aria-label="Environment">{error}</div>;
   if (!environment) return null;
@@ -291,6 +293,7 @@ function EnvironmentPopover({ environment, error, loading, copiedValue, onCopy }
     ["Reachable on", `127.0.0.1:${environment.effectivePort}`],
     ["Data root", environment.dataDir],
     ["Runtime lock", environment.lockFile],
+    ...(desktopShell ? [["Desktop data", `${environment.dataDir}/desktop`] as [string, string]] : []),
   ];
   return <div className="command-band-environment-popover" role="dialog" aria-label="Environment">
     <div className="command-band-environment-title">Environment</div>

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -57,7 +57,20 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
   const [environmentLoading, setEnvironmentLoading] = useState(false);
   const [copiedValue, setCopiedValue] = useState<string | null>(null);
   const [copyFailedValue, setCopyFailedValue] = useState<string | null>(null);
+  // 열림/닫힘 전환 시 이벤트 핸들러에서 동기 호출한다 — open effect(폐기 후 fetch)는 paint 뒤에 돌므로
+  // 여기서 지우지 않으면 재오픈 첫 프레임에 이전 절대경로가 그대로 렌더된다.
+  const discardEnvironmentState = () => {
+    setEnvironment(null);
+    setEnvironmentError(null);
+    setEnvironmentLoading(false);
+    setCopiedValue(null);
+    setCopyFailedValue(null);
+  };
   const desktopShell = typeof document !== "undefined" && document.documentElement.dataset.desktopShell === "true";
+  // darwin Desktop은 traffic-light 인셋(88px)이 첫 트랙을 잠식해 전체 라벨이 사이드바 경계를 넘는다.
+  // Desktop 앱 안에서는 Desktop임이 자명하므로 칩은 "Local"로 축약하고, Desktop 구분은 팝오버의
+  // Desktop data 행이 유지한다(대원수 재가).
+  const desktopChipLabel = typeof document !== "undefined" && document.documentElement.dataset.desktopPlatform === "darwin" ? "Local" : "Local · Desktop";
   const canAutoHide = useCallback(() => {
     const activeElement = document.activeElement;
     const focusWithin = activeElement instanceof Node && (commandBandRef.current?.contains(activeElement) || edgeRevealRef.current?.contains(activeElement));
@@ -116,10 +129,12 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
       const target = event.target;
       if (!(target instanceof Node) || environmentTriggerRef.current?.contains(target) || environmentPopoverRef.current?.contains(target)) return;
       setEnvironmentOpen(false);
+      discardEnvironmentState();
     };
     const closeOnEscape = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
       setEnvironmentOpen(false);
+      discardEnvironmentState();
       environmentTriggerRef.current?.focus();
     };
     document.addEventListener("pointerdown", closeOnPointer);
@@ -135,6 +150,7 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
     setEnvironmentOpen(false);
     setEnvironment(null);
     setEnvironmentError(null);
+    setEnvironmentLoading(false);
     setCopiedValue(null);
     setCopyFailedValue(null);
   }, [state.channel]);
@@ -235,9 +251,9 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
       <div className={`command-band-left${operationsViewVisible && sideBar.collapsed ? " is-collapsed" : ""}`}>
         <FleetBrandHome className="command-band-brand" />
         {state.channel === "local" ? <div className="command-band-environment">
-          <button ref={environmentTriggerRef} type="button" className="command-band-local-chip" aria-haspopup="dialog" aria-expanded={environmentOpen} onClick={() => setEnvironmentOpen((open) => !open)}>
+          <button ref={environmentTriggerRef} type="button" className="command-band-local-chip" aria-haspopup="dialog" aria-expanded={environmentOpen} onClick={() => { discardEnvironmentState(); setEnvironmentOpen((open) => !open); }}>
           <span className="command-band-local-dot" aria-hidden="true" />
-          {desktopShell ? "Local · Desktop" : "Local"}
+          <span className="command-band-local-chip-label">{desktopShell ? desktopChipLabel : "Local"}</span>
           </button>
           {environmentOpen ? <div ref={environmentPopoverRef}><EnvironmentPopover environment={environment} error={environmentError} loading={environmentLoading} copiedValue={copiedValue} copyFailedValue={copyFailedValue} desktopShell={desktopShell} onCopy={copyEnvironmentValue} /></div> : null}
         </div> : null}

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type CSSProperties, type FocusEvent } from "react";
 
-import { fetchOperations, renameOperation } from "../api.js";
+import { fetchConsoleEnvironment, fetchOperations, renameOperation } from "../api.js";
 import { commandBandRenameCommitTarget, railPathContextDeckOpenAfterCommandBandToggle, shouldCloseCommandBandContextDeck } from "./command-band-guards.js";
 import { FleetBrandHome } from "./side-bar-brand-foot.js";
 import { useConsoleState } from "../hooks/use-store.js";
@@ -11,6 +11,7 @@ import { usePluginRegistry } from "../plugin-registry.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
 import { setSideBarCollapsed, useSideBarState } from "../sidebar/operations-side-bar-store.js";
 import { hydrateOperations, toggleOperationSearch } from "../store.js";
+import type { ConsoleEnvironmentDiagnostics } from "../types.js";
 import { useInlineRename } from "../use-inline-rename.js";
 import { useFullscreenCommandBand } from "./use-fullscreen-command-band.js";
 
@@ -43,11 +44,18 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
   const pathContext = useRailPathContextStore();
   const contextTriggerRef = useRef<HTMLButtonElement>(null);
   const contextDeckRef = useRef<HTMLDivElement>(null);
+  const environmentTriggerRef = useRef<HTMLButtonElement>(null);
+  const environmentPopoverRef = useRef<HTMLDivElement>(null);
   const commandBandRef = useRef<HTMLElement>(null);
   const edgeRevealRef = useRef<HTMLButtonElement>(null);
   const pointerWithinRef = useRef({ edge: false, band: false });
   const renameTargetOperationIdRef = useRef<string | null>(null);
   const [contextDeckOpen, setContextDeckOpen] = useState(false);
+  const [environmentOpen, setEnvironmentOpen] = useState(false);
+  const [environment, setEnvironment] = useState<ConsoleEnvironmentDiagnostics | null>(null);
+  const [environmentError, setEnvironmentError] = useState<string | null>(null);
+  const [environmentLoading, setEnvironmentLoading] = useState(false);
+  const [copiedValue, setCopiedValue] = useState<string | null>(null);
   const canAutoHide = useCallback(() => {
     const activeElement = document.activeElement;
     const focusWithin = activeElement instanceof Node && (commandBandRef.current?.contains(activeElement) || edgeRevealRef.current?.contains(activeElement));
@@ -83,12 +91,67 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
   }, [contextDeckOpen]);
 
   useEffect(() => {
+    if (!environmentOpen) return;
+    const controller = new AbortController();
+    setEnvironment(null);
+    setEnvironmentError(null);
+    setEnvironmentLoading(true);
+    fetchConsoleEnvironment(controller.signal)
+      .then(setEnvironment)
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        setEnvironmentError(error instanceof Error ? error.message : "Unable to load environment details.");
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setEnvironmentLoading(false);
+      });
+    return () => controller.abort();
+  }, [environmentOpen]);
+
+  useEffect(() => {
+    if (!environmentOpen) return;
+    const closeOnPointer = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node) || environmentTriggerRef.current?.contains(target) || environmentPopoverRef.current?.contains(target)) return;
+      setEnvironmentOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setEnvironmentOpen(false);
+      environmentTriggerRef.current?.focus();
+    };
+    document.addEventListener("pointerdown", closeOnPointer);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closeOnPointer);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [environmentOpen]);
+
+  useEffect(() => {
+    if (state.channel === "local") return;
+    setEnvironmentOpen(false);
+    setEnvironment(null);
+    setEnvironmentError(null);
+    setCopiedValue(null);
+  }, [state.channel]);
+
+  useEffect(() => {
     if (shouldCloseCommandBandContextDeck(contextDeckOpen, pathContext.isPathContextDeckOpen)) setContextDeckOpen(false);
   }, [contextDeckOpen, pathContext.isPathContextDeckOpen]);
 
   const closeContextDeck = () => {
     setContextDeckOpen(false);
     contextTriggerRef.current?.focus();
+  };
+
+  const closeEnvironment = () => {
+    setEnvironmentOpen(false);
+    environmentTriggerRef.current?.focus();
+  };
+
+  const copyEnvironmentValue = (value: string) => {
+    void navigator.clipboard.writeText(value).then(() => setCopiedValue(value)).catch(() => setEnvironmentError("Unable to copy value."));
   };
 
   // 밴드 데크는 로컬 상태만 사용한다 — 공유 open 플래그를 세우면 path-aware 레일 패널의
@@ -169,10 +232,13 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
       >
       <div className={`command-band-left${operationsViewVisible && sideBar.collapsed ? " is-collapsed" : ""}`}>
         <FleetBrandHome className="command-band-brand" />
-        {state.channel === "local" ? <button type="button" className="command-band-local-chip" aria-haspopup="dialog" aria-expanded={false}>
+        {state.channel === "local" ? <div className="command-band-environment">
+          <button ref={environmentTriggerRef} type="button" className="command-band-local-chip" aria-haspopup="dialog" aria-expanded={environmentOpen} onClick={() => setEnvironmentOpen((open) => !open)}>
           <span className="command-band-local-dot" aria-hidden="true" />
           Local
-        </button> : null}
+          </button>
+          {environmentOpen ? <div ref={environmentPopoverRef}><EnvironmentPopover environment={environment} error={environmentError} loading={environmentLoading} copiedValue={copiedValue} onCopy={copyEnvironmentValue} /></div> : null}
+        </div> : null}
         {operationsViewVisible ? <button type="button" className="command-band-button command-band-sidebar-toggle" onClick={() => setSideBarCollapsed(!sideBar.collapsed)} aria-label={`${sideBar.collapsed ? "Expand sidebar" : "Collapse sidebar"} (${sideBarShortcut})`} title={`${sideBar.collapsed ? "Expand sidebar" : "Collapse sidebar"} (${sideBarShortcut})`}>
           <PanelToggleIcon side="left" />
         </button> : null}
@@ -205,6 +271,32 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
       </header>
     </>
   );
+}
+
+interface EnvironmentPopoverProps {
+  readonly environment: ConsoleEnvironmentDiagnostics | null;
+  readonly error: string | null;
+  readonly loading: boolean;
+  readonly copiedValue: string | null;
+  readonly onCopy: (value: string) => void;
+}
+
+function EnvironmentPopover({ environment, error, loading, copiedValue, onCopy }: EnvironmentPopoverProps) {
+  if (loading) return <div className="command-band-environment-popover" role="dialog" aria-label="Environment">Loading environment details…</div>;
+  if (error) return <div className="command-band-environment-popover" role="dialog" aria-label="Environment">{error}</div>;
+  if (!environment) return null;
+  const rows: readonly [string, string][] = [
+    ["Channel", environment.channel],
+    ["Version", environment.version],
+    ["Reachable on", `127.0.0.1:${environment.effectivePort}`],
+    ["Data root", environment.dataDir],
+    ["Runtime lock", environment.lockFile],
+  ];
+  return <div className="command-band-environment-popover" role="dialog" aria-label="Environment">
+    <div className="command-band-environment-title">Environment</div>
+    {rows.map(([label, value]) => <div key={label} className="command-band-environment-row"><span>{label}</span><code>{value}</code><button type="button" onClick={() => onCopy(value)}>{copiedValue === value ? "Copied" : "Copy"}</button></div>)}
+    <div className="command-band-environment-footer">Development and published channels keep separate data roots.</div>
+  </div>;
 }
 
 function resolveModLabel(): string {

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -56,6 +56,7 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
   const [environmentError, setEnvironmentError] = useState<string | null>(null);
   const [environmentLoading, setEnvironmentLoading] = useState(false);
   const [copiedValue, setCopiedValue] = useState<string | null>(null);
+  const [copyFailedValue, setCopyFailedValue] = useState<string | null>(null);
   const desktopShell = typeof document !== "undefined" && document.documentElement.dataset.desktopShell === "true";
   const canAutoHide = useCallback(() => {
     const activeElement = document.activeElement;
@@ -135,6 +136,7 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
     setEnvironment(null);
     setEnvironmentError(null);
     setCopiedValue(null);
+    setCopyFailedValue(null);
   }, [state.channel]);
 
   useEffect(() => {
@@ -147,7 +149,11 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
   };
 
   const copyEnvironmentValue = (value: string) => {
-    void navigator.clipboard.writeText(value).then(() => setCopiedValue(value)).catch(() => setEnvironmentError("Unable to copy value."));
+    // 복사 실패는 해당 버튼의 인라인 상태로만 알린다 — environmentError는 fetch 실패 전용이며
+    // 세팅하면 팝오버 전체가 에러 화면으로 대체되어 진단 값 자체를 볼 수 없게 된다.
+    void navigator.clipboard.writeText(value)
+      .then(() => { setCopiedValue(value); setCopyFailedValue(null); })
+      .catch(() => { setCopyFailedValue(value); setCopiedValue(null); });
   };
 
   // 밴드 데크는 로컬 상태만 사용한다 — 공유 open 플래그를 세우면 path-aware 레일 패널의
@@ -233,7 +239,7 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
           <span className="command-band-local-dot" aria-hidden="true" />
           {desktopShell ? "Local · Desktop" : "Local"}
           </button>
-          {environmentOpen ? <div ref={environmentPopoverRef}><EnvironmentPopover environment={environment} error={environmentError} loading={environmentLoading} copiedValue={copiedValue} desktopShell={desktopShell} onCopy={copyEnvironmentValue} /></div> : null}
+          {environmentOpen ? <div ref={environmentPopoverRef}><EnvironmentPopover environment={environment} error={environmentError} loading={environmentLoading} copiedValue={copiedValue} copyFailedValue={copyFailedValue} desktopShell={desktopShell} onCopy={copyEnvironmentValue} /></div> : null}
         </div> : null}
         {operationsViewVisible ? <button type="button" className="command-band-button command-band-sidebar-toggle" onClick={() => setSideBarCollapsed(!sideBar.collapsed)} aria-label={`${sideBar.collapsed ? "Expand sidebar" : "Collapse sidebar"} (${sideBarShortcut})`} title={`${sideBar.collapsed ? "Expand sidebar" : "Collapse sidebar"} (${sideBarShortcut})`}>
           <PanelToggleIcon side="left" />
@@ -274,11 +280,12 @@ interface EnvironmentPopoverProps {
   readonly error: string | null;
   readonly loading: boolean;
   readonly copiedValue: string | null;
+  readonly copyFailedValue: string | null;
   readonly desktopShell: boolean;
   readonly onCopy: (value: string) => void;
 }
 
-function EnvironmentPopover({ environment, error, loading, copiedValue, desktopShell, onCopy }: EnvironmentPopoverProps) {
+function EnvironmentPopover({ environment, error, loading, copiedValue, copyFailedValue, desktopShell, onCopy }: EnvironmentPopoverProps) {
   if (loading) return <div className="command-band-environment-popover" role="dialog" aria-label="Environment">Loading environment details…</div>;
   if (error) return <div className="command-band-environment-popover" role="dialog" aria-label="Environment">{error}</div>;
   if (!environment) return null;
@@ -292,7 +299,7 @@ function EnvironmentPopover({ environment, error, loading, copiedValue, desktopS
   ];
   return <div className="command-band-environment-popover" role="dialog" aria-label="Environment">
     <div className="command-band-environment-title">Environment</div>
-    {rows.map(([label, value]) => <div key={label} className="command-band-environment-row"><span>{label}</span><code>{value}</code><button type="button" onClick={() => onCopy(value)}>{copiedValue === value ? "Copied" : "Copy"}</button></div>)}
+    {rows.map(([label, value]) => <div key={label} className="command-band-environment-row"><span>{label}</span><code>{value}</code><button type="button" onClick={() => onCopy(value)}>{copiedValue === value ? "Copied" : copyFailedValue === value ? "Copy failed" : "Copy"}</button></div>)}
     <div className="command-band-environment-footer">Development and published channels keep separate data roots.</div>
   </div>;
 }

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -41,6 +41,7 @@ let whatsNewSeenVersionMemo: string | null = null;
 let state: ConsoleState = {
   connection: "connecting",
   connectionError: null,
+  channel: "unknown",
   // The SDK ConsoleTheme union matches ThemeId; the selected theme passes
   // through to the plugin context unchanged.
   activeTheme: DEFAULT_THEME,
@@ -112,6 +113,7 @@ export function setActiveUiFont(uiFont: UiFontSettings): void {
 
 export function applyObserverStatus(status: ObserverStatus): void {
   setState({
+    channel: status.channel,
     version: status.version,
     updateAvailable: status.updateAvailable,
     latestVersion: status.latestVersion ?? null,

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -157,6 +157,49 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   box-shadow: 0 0 7px var(--warn-glow);
 }
 
+.command-band-environment { position: relative; }
+
+.command-band-environment-popover {
+  position: absolute;
+  z-index: 45;
+  top: calc(100% + 8px);
+  left: 0;
+  width: min(430px, calc(100vw - 24px));
+  padding: var(--space-3);
+  border: 1px solid color-mix(in oklch, var(--warn) 35%, var(--surface-rim));
+  border-radius: var(--radius-md);
+  background: var(--surface-band);
+  box-shadow: 0 12px 30px color-mix(in oklch, var(--ink-deep) 70%, transparent);
+  color: var(--ink-pearl);
+  font-size: 11px;
+}
+
+.command-band-environment-title {
+  margin-bottom: var(--space-2);
+  color: var(--warn);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.command-band-environment-row {
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr) auto;
+  gap: var(--space-2);
+  align-items: center;
+  padding-block: 5px;
+  border-top: 1px solid var(--surface-rim);
+}
+
+.command-band-environment-row span { color: var(--ink-fog); }
+.command-band-environment-row code { overflow: hidden; color: var(--ink-pearl); font-family: var(--font-mono); text-overflow: ellipsis; white-space: nowrap; }
+.command-band-environment-row button { padding: 2px 5px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: var(--surface-glass); color: var(--warn); font: inherit; cursor: pointer; }
+.command-band-environment-row button:hover,
+.command-band-environment-row button:focus-visible { border-color: var(--warn); outline: none; }
+.command-band-environment-footer { margin-top: var(--space-2); color: var(--ink-fog); font-size: 10px; }
+
 .command-band-center {
   justify-content: center;
   gap: var(--space-3);

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -124,6 +124,39 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   letter-spacing: 0.01em;
 }
 
+.command-band-local-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: none;
+  padding: 4px 7px;
+  border: 1px solid color-mix(in oklch, var(--warn) 45%, var(--surface-rim));
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--warn-glow) 72%, var(--surface-glass));
+  box-shadow: 0 0 12px var(--warn-glow);
+  color: var(--warn);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.command-band-local-chip:hover,
+.command-band-local-chip:focus-visible {
+  border-color: var(--warn);
+  background: color-mix(in oklch, var(--warn-glow) 100%, var(--surface-glass));
+  outline: none;
+}
+
+.command-band-local-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--warn);
+  box-shadow: 0 0 7px var(--warn-glow);
+}
+
 .command-band-center {
   justify-content: center;
   gap: var(--space-3);

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -216,6 +216,18 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 .command-band-environment-row button:focus-visible { border-color: var(--warn); outline: none; }
 .command-band-environment-footer { margin-top: var(--space-2); color: var(--ink-fog); font-size: 10px; }
 
+/* 좁은 뷰에서는 칩 앵커(x≈80~160) + 520px 폭이 우측을 벗어나 Copy 버튼이 잘린다 —
+   앵커 대신 viewport gutter에 고정해 전체 행이 항상 화면 안에 남게 한다. */
+@media (max-width: 640px) {
+  .command-band-environment-popover {
+    position: fixed;
+    top: 52px;
+    left: 12px;
+    right: 12px;
+    width: auto;
+  }
+}
+
 .command-band-center {
   justify-content: center;
   gap: var(--space-3);

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -164,7 +164,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   z-index: 45;
   top: calc(100% + 8px);
   left: 0;
-  width: min(430px, calc(100vw - 24px));
+  width: min(520px, calc(100vw - 24px));
   padding: var(--space-3);
   border: 1px solid color-mix(in oklch, var(--warn) 35%, var(--surface-rim));
   border-radius: var(--radius-md);
@@ -188,13 +188,14 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   display: grid;
   grid-template-columns: 92px minmax(0, 1fr) auto;
   gap: var(--space-2);
-  align-items: center;
+  align-items: start;
   padding-block: 5px;
   border-top: 1px solid var(--surface-rim);
 }
 
 .command-band-environment-row span { color: var(--ink-fog); }
-.command-band-environment-row code { overflow: hidden; color: var(--ink-pearl); font-family: var(--font-mono); text-overflow: ellipsis; white-space: nowrap; }
+/* 경로 값은 진단 목적상 전문이 보여야 한다 — 말줄임 대신 줄바꿈으로 전체를 노출한다. */
+.command-band-environment-row code { color: var(--ink-pearl); font-family: var(--font-mono); overflow-wrap: anywhere; word-break: break-all; }
 .command-band-environment-row button { padding: 2px 5px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: var(--surface-glass); color: var(--warn); font: inherit; cursor: pointer; }
 .command-band-environment-row button:hover,
 .command-band-environment-row button:focus-visible { border-color: var(--warn); outline: none; }

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -149,6 +149,21 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   outline: none;
 }
 
+.command-band-local-chip-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* macOS Desktop은 traffic-light 인셋(좌측 88px)이 첫 트랙 폭을 잠식하므로
+   local 칩을 컴팩트하게 줄여 사이드바 경계(280px) 침범을 막는다. */
+:root[data-desktop-shell="true"][data-desktop-platform="darwin"] .command-band-local-chip {
+  gap: 4px;
+  padding-inline: 5px;
+  letter-spacing: 0.02em;
+  min-width: 0;
+}
+
 .command-band-local-dot {
   width: 5px;
   height: 5px;

--- a/runtime/fleet-console/core/client/src/types.ts
+++ b/runtime/fleet-console/core/client/src/types.ts
@@ -66,6 +66,14 @@ export interface ObserverStatus {
   readonly wikiServerStatus: "available" | "unavailable" | "unknown";
 }
 
+export interface ConsoleEnvironmentDiagnostics {
+  readonly channel: "local";
+  readonly version: string;
+  readonly effectivePort: number;
+  readonly dataDir: string;
+  readonly lockFile: string;
+}
+
 export type ConsoleUpdateApplyError =
   | "console_not_ready"
   | "local_channel"

--- a/runtime/fleet-console/core/client/src/types.ts
+++ b/runtime/fleet-console/core/client/src/types.ts
@@ -160,6 +160,7 @@ export type CodexReaderRequest =
 export interface ConsoleState {
   readonly connection: ConnectionState;
   readonly connectionError: string | null;
+  readonly channel: ObserverStatus["channel"];
   readonly activeTheme: ConsoleTheme;
   readonly version: string;
   readonly updateAvailable: boolean;

--- a/runtime/fleet-console/core/host/api-types.ts
+++ b/runtime/fleet-console/core/host/api-types.ts
@@ -86,6 +86,14 @@ export interface ConsoleObserverStatus {
   readonly wikiServerStatus: ConsoleObserverWikiServerStatus;
 }
 
+export interface ConsoleEnvironmentDiagnostics {
+  readonly channel: "local";
+  readonly version: string;
+  readonly effectivePort: number;
+  readonly dataDir: string;
+  readonly lockFile: string;
+}
+
 export interface ConsoleObserverTheatersResponse {
   readonly theaters: readonly ConsoleTheaterInfo[];
   readonly agentClis?: readonly ConsoleAgentCliMetadata[];

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { createInfraServices, getFleetDataDir } from "@dotobokuri/core-infra";
 
 import { buildApiCatalog, type ApiCatalogEntry } from "./api-catalog.js";
-import type { ConsoleHealth, ConsoleObserverStatus, ConsoleTheaterFolderListResponse, ConsoleTheaterInfo, ConsoleUpdateApplyAcceptedResponse, ConsoleUpdateApplyError } from "./api-types.js";
+import type { ConsoleEnvironmentDiagnostics, ConsoleHealth, ConsoleObserverStatus, ConsoleTheaterFolderListResponse, ConsoleTheaterInfo, ConsoleUpdateApplyAcceptedResponse, ConsoleUpdateApplyError } from "./api-types.js";
 import { createCodexWorkspaceContextRouter } from "./codex/context-routes.js";
 import { createCodexGateway } from "./codex/gateway.js";
 import { createConsoleSettingsStore, type ConsoleThemeId } from "./console-settings.js";
@@ -607,6 +607,10 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       handleStatus(req, res);
       return;
     }
+    if (pathname === "/api/v1/environment") {
+      handleEnvironmentDiagnostics(req, res);
+      return;
+    }
     if (pathname === "/api/v1/theaters") {
       runAsyncHandler(handleObserverTheaters(req, res), res);
       return;
@@ -841,6 +845,34 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       return;
     }
     writeJson(res, 200, { version, routes: buildApiCatalog() });
+  }
+
+  function handleEnvironmentDiagnostics(req: http.IncomingMessage, res: http.ServerResponse): void {
+    if (channel !== "local") {
+      writeJson(res, 404, { error: "not_found" });
+      return;
+    }
+    if (req.method !== "GET") {
+      writeJson(res, 405, { error: "Method not allowed" });
+      return;
+    }
+    if (!isAllowedTerminalOrigin(req, lockHandle?.payload.port ?? port)) {
+      writeJson(res, 401, { error: "unauthorized" });
+      return;
+    }
+    if (!activeLockFile) {
+      writeJson(res, 503, { error: "console_not_ready" });
+      return;
+    }
+    const payload: ConsoleEnvironmentDiagnostics = {
+      channel: "local",
+      version,
+      effectivePort: portState.effectivePort,
+      dataDir: durablePaths.dir,
+      lockFile: activeLockFile,
+    };
+    res.setHeader("Cache-Control", "no-store");
+    writeJson(res, 200, payload);
   }
 
   async function handleObserverReleaseNotes(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {

--- a/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
+++ b/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
@@ -260,6 +260,7 @@ const PEER_OPERATION: OperationNode = {
 const CANVAS_STATE: ConsoleState = {
   connection: "connecting",
   connectionError: null,
+  channel: "unknown",
   activeTheme: "maritime",
   version: "test",
   updateAvailable: false,

--- a/runtime/fleet-console/tests/observer-status-store.test.ts
+++ b/runtime/fleet-console/tests/observer-status-store.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { applyObserverStatus, getState } from "../core/client/src/store.js";
+import type { ObserverStatus } from "../core/client/src/types.js";
+
+function status(channel: ObserverStatus["channel"]): ObserverStatus {
+  return {
+    workspaces: 0,
+    version: "1.0.0",
+    channel,
+    updateAvailable: false,
+    port: 0,
+    portMode: "dynamic",
+    requestedPort: null,
+    effectivePort: 0,
+    portHonored: true,
+    wikiServerStatus: "unknown",
+  };
+}
+
+describe("observer status store", () => {
+  it("preserves local, stable, and unknown channels", () => {
+    expect(getState().channel).toBe("unknown");
+    for (const channel of ["local", "stable", "unknown"] as const) {
+      applyObserverStatus(status(channel));
+      expect(getState().channel).toBe(channel);
+    }
+  });
+});

--- a/runtime/fleet-console/tests/operation-search.test.ts
+++ b/runtime/fleet-console/tests/operation-search.test.ts
@@ -24,6 +24,7 @@ function makeState(operations: readonly OperationNode[], theaters: readonly Thea
   return {
     connection: "connecting",
     connectionError: null,
+    channel: "unknown",
     activeTheme: "maritime",
     version: "1.8.0",
     updateAvailable: false,

--- a/runtime/fleet-console/tests/reduce.test.ts
+++ b/runtime/fleet-console/tests/reduce.test.ts
@@ -38,6 +38,7 @@ function makeConsoleSnap(patch: Partial<ConsoleState> = {}): ConsoleState {
   return {
     connection: "live",
     connectionError: null,
+    channel: "unknown",
     activeTheme: "maritime",
     version: "1.8.0",
     updateAvailable: false,

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -97,7 +97,7 @@ describe("console terminal observability", () => {
       channel: "local",
       version: "test",
       effectivePort: fixture.lock.port,
-      dataDir: path.join(fixture.carrierStoreDir, "console-local"),
+      dataDir: path.join(fixture.carrierStoreDir, "console"),
       lockFile: fixture.lockFile,
     });
     expect((await fetch(url)).status).toBe(200);

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -82,6 +82,32 @@ afterEach(async () => {
 });
 
 describe("console terminal observability", () => {
+  it("serves local environment diagnostics only through the loopback Host and allowed Origin", async () => {
+    const fixture = await startFixture({ release: { channel: "local", version: "test", packageRoot: CONSOLE_PACKAGE_ROOT } });
+    const url = new URL("api/v1/environment", fixture.endpoint);
+    const origin = new URL(fixture.endpoint).origin;
+
+    expect(await requestWithHost(url, origin, "localhost:1", "GET")).toBe(403);
+    const foreign = await fetch(url, { headers: { Origin: "http://127.0.0.1:9999" } });
+    expect(foreign.status).toBe(401);
+    const exact = await fetch(url, { headers: { Origin: origin } });
+    expect(exact.status).toBe(200);
+    expect(exact.headers.get("cache-control")).toBe("no-store");
+    await expect(exact.json()).resolves.toEqual({
+      channel: "local",
+      version: "test",
+      effectivePort: fixture.lock.port,
+      dataDir: path.join(fixture.carrierStoreDir, "console-local"),
+      lockFile: fixture.lockFile,
+    });
+    expect((await fetch(url)).status).toBe(200);
+  });
+
+  it("does not expose environment diagnostics from stable Console", async () => {
+    const fixture = await startFixture({ release: { channel: "stable", version: "test", packageRoot: CONSOLE_PACKAGE_ROOT } });
+    expect((await fetch(`${fixture.endpoint}api/v1/environment`)).status).toBe(404);
+  });
+
   it("owns an exact-origin ephemeral Desktop fullscreen snapshot and relays it through operations SSE", async () => {
     const fixture = await startFixture();
     const origin = new URL(fixture.endpoint).origin;
@@ -2666,12 +2692,16 @@ async function readSseChunk(reader: ReadableStreamDefaultReader<Uint8Array>): Pr
 }
 
 function putWithHost(url: URL, origin: string, host: string, body: unknown): Promise<number> {
+  return requestWithHost(url, origin, host, "PUT", body);
+}
+
+function requestWithHost(url: URL, origin: string, host: string, method: string, body?: unknown): Promise<number> {
   return new Promise((resolve, reject) => {
-    const request = http.request(url, { method: "PUT", headers: { Host: host, Origin: origin, "Content-Type": "application/json" } }, (response) => {
+    const request = http.request(url, { method, headers: { Host: host, Origin: origin, "Content-Type": "application/json" } }, (response) => {
       response.resume();
       response.on("end", () => resolve(response.statusCode ?? 0));
     });
     request.on("error", reject);
-    request.end(JSON.stringify(body));
+    request.end(body === undefined ? undefined : JSON.stringify(body));
   });
 }


### PR DESCRIPTION
## Summary
- local(개발) 채널에서만 Command Band에 `--warn` 톤 LOCAL 칩을 점등해 개발환경임을 상시 인지시킵니다. stable에서는 칩·팝오버 DOM 자체가 생성되지 않아 프로덕션 크롬은 변하지 않습니다.
- 칩 클릭 시 Environment 팝오버가 local 전용 `GET /api/v1/environment`(Host/Origin 게이트·`Cache-Control: no-store`·stable 404)를 명시적으로 조회해 channel/version/port/data root/runtime lock을 Copy 버튼과 함께 보여줍니다. 응답은 캐시·로깅 없이 오픈마다 재조회합니다.
- Desktop 셸(`data-desktop-shell`)에서는 팝오버에 `Desktop data`(`dataDir + "/desktop"`, 클라이언트 파생) 행이 추가되며, macOS Desktop은 traffic-light 인셋으로 인해 칩 라벨을 `Local`로 축약합니다. 서버는 owner provenance로 분기하지 않고 desktop-protocol/fleet-desktop은 무변경입니다.
- fleet-console AGENTS.md Security 섹션에 "local 채널 + 명시적 사용자 요청의 environment 진단 응답만 Console 자신의 data-root·runtime-lock 경로 반환 가능"이라는 좁은 예외 1문장을 추가했습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` green
- [x] 신규 계약 테스트: `/api/v1/environment` Host 403·foreign Origin 401·absent/exact Origin 200·stable 404·no-store·정확 5필드 shape, store channel 보존(local/stable/unknown)
- [x] typecheck 오류 수 베이스라인(10) 유지 — 신규 회귀 0
- [x] headed console-e2e 수용 검증: 초기 로드 env fetch 0·오픈당 1회 fetch·Escape/외부클릭 닫힘·포커스 복귀·copy 성공/실패 격리·재오픈 stale 플래시 0(12프레임 샘플링)·darwin Desktop 라벨 축약 후 사이드바 경계 내(273≤280)·550px 좁은 뷰 Copy 버튼 가시
- [x] Sentinel 보안·정확성 리뷰 2회(본리뷰 FAIL→4건 수정, 델타 재리뷰 PASS)
- 알려진 환경 결함: `codex-security-routes.test.ts`는 이 개발 머신에서 베이스 커밋에서도 동일하게 fork worker 행업(변경 무관)

## Changelog
- [x] `.changelog.d/pr-290.md` — 그룹형 문법(`### fleet-console` / `#### Added`)·영한 병기·`node scripts/compile-changelog-fragments.mjs --check` 통과(30 entries OK)