### PR TITLE
feat(fleet-wiki): make Codex knowledge theater-wide

### DIFF
--- a/.changelog.d/pr-291.md
+++ b/.changelog.d/pr-291.md
@@ -1,0 +1,19 @@
+### fleet-cli
+#### Changed
+- [fleet-cli] Resolve Wiki tools and knowledge counts from each project's durable workspace.
+  ko: 프로젝트별 영구 워크스페이스에서 Wiki 도구와 지식 개수를 확인합니다.
+
+### fleet-console
+#### Changed
+- [fleet-console] Provide theater-wide Codex knowledge per project with copy-only on-demand migration from legacy `.fleet/knowledge`.
+  ko: 기존 `.fleet/knowledge`를 삭제하지 않고 온디맨드로 복사 마이그레이션하며 프로젝트별 theater-wide Codex 지식을 제공합니다.
+
+### fleet-plugin
+#### Changed
+- [fleet-console] Route Terminal agent Wiki tools to the same per-project durable workspace.
+  ko: Terminal 에이전트의 Wiki 도구를 동일한 프로젝트별 영구 워크스페이스로 연결합니다.
+
+### fleet-core
+#### Added
+- [fleet-wiki] Add a host-injected Wiki workspace resolver with one-time copy migration.
+  ko: 호스트가 주입하는 Wiki 워크스페이스 resolver와 1회 복사 마이그레이션을 추가합니다.

--- a/packages/fleet-wiki/src/agent-specs.ts
+++ b/packages/fleet-wiki/src/agent-specs.ts
@@ -13,6 +13,8 @@ import { buildPatchQueueToolConfig } from "./tools/patch-queue.js";
 import { buildQueryToolConfig } from "./tools/query.js";
 import { buildReadToolConfig } from "./tools/read.js";
 import { buildResolveToolConfig } from "./tools/resolve.js";
+import type { MemoryPaths } from "./types.js";
+import type { WikiWorkspaceResolver } from "./workspace-resolver.js";
 
 interface WikiAgentToolConfig {
   readonly name: string;
@@ -26,7 +28,7 @@ interface WikiAgentToolConfig {
     params: Record<string, unknown>,
     signal: AbortSignal | undefined,
     onUpdate: unknown,
-    ctx: { cwd: string },
+    ctx: { cwd: string; paths?: MemoryPaths },
   ): Promise<{ content: Array<{ type: "text"; text: string }>; details?: Record<string, unknown> }>;
 }
 
@@ -54,22 +56,15 @@ export const FLEET_WIKI_AGENT_TOOL_IDS = [
 // Functions
 // ═══════════════════════════════════════
 
-export function getWikiToolSpecs(): AgentToolSpec[] {
+export function getWikiToolSpecs(resolver?: WikiWorkspaceResolver): AgentToolSpec[] {
   return [
-    buildWikiBriefingSpec(),
-    buildWikiDryDockSpec(),
-    buildWikiIngestSpec(),
-    buildWikiOrientSpec(),
-    buildWikiPatchEditSpec(),
-    buildWikiPatchQueueSpec(),
-    buildWikiCompileSourceSpec(),
-    buildWikiQuerySpec(),
-    buildWikiReadSpec(),
-    buildWikiResolveSpec(),
+    buildWikiBriefingSpec(resolver), buildWikiDryDockSpec(resolver), buildWikiIngestSpec(resolver),
+    buildWikiOrientSpec(resolver), buildWikiPatchEditSpec(resolver), buildWikiPatchQueueSpec(resolver),
+    buildWikiCompileSourceSpec(resolver), buildWikiQuerySpec(resolver), buildWikiReadSpec(resolver), buildWikiResolveSpec(resolver),
   ];
 }
 
-function buildWikiBriefingSpec(): AgentToolSpec {
+function buildWikiBriefingSpec(resolver?: WikiWorkspaceResolver): AgentToolSpec {
   return buildWikiToolSpec(buildBriefingToolConfig(), {
     whenToUse: [
       "Discover wiki entries by topic, tag, or keyword before deciding which to read in full",
@@ -79,10 +74,10 @@ function buildWikiBriefingSpec(): AgentToolSpec {
       "Full entry body content is needed — use wiki_read instead",
       "Compact context-pack synthesis across multiple entries is needed — use wiki_resolve instead",
     ],
-  });
+  }, resolver);
 }
 
-function buildWikiDryDockSpec(): AgentToolSpec {
+function buildWikiDryDockSpec(resolver?: WikiWorkspaceResolver): AgentToolSpec {
   return buildWikiToolSpec(buildDryDockToolConfig(), {
     whenToUse: [
       "Audit wiki repository health: frontmatter, broken links, queue conflicts, and semantic issues",
@@ -91,10 +86,10 @@ function buildWikiDryDockSpec(): AgentToolSpec {
     whenNotToUse: [
       "Goal is content retrieval or search — drydock performs diagnostics only, no content is returned",
     ],
-  });
+  }, resolver);
 }
 
-function buildWikiIngestSpec(): AgentToolSpec {
+function buildWikiIngestSpec(resolver?: WikiWorkspaceResolver): AgentToolSpec {
   return buildWikiToolSpec(buildIngestToolConfig(), {
     whenToUse: [
       "Stage durable Fleet Wiki knowledge as an approval-gated pending patch with captured raw source",
@@ -104,10 +99,10 @@ function buildWikiIngestSpec(): AgentToolSpec {
       "Only reading or searching existing wiki context is needed — use wiki_briefing, wiki_read, or wiki_resolve",
       "The user has not approved staging wiki changes for this task",
     ],
-  });
+  }, resolver);
 }
 
-function buildWikiOrientSpec(): AgentToolSpec {
+function buildWikiOrientSpec(resolver?: WikiWorkspaceResolver): AgentToolSpec {
   return buildWikiToolSpec(buildOrientToolConfig(), {
     whenToUse: [
       "Start a wiki-aware task by checking schema, index, recent log, queue count, and drydock status",
@@ -117,10 +112,10 @@ function buildWikiOrientSpec(): AgentToolSpec {
       "A specific entry ID is already known and full content is needed — use wiki_read instead",
       "Only staging a patch is needed and current wiki context is already understood — use wiki_ingest instead",
     ],
-  });
+  }, resolver);
 }
 
-function buildWikiPatchEditSpec(): AgentToolSpec {
+function buildWikiPatchEditSpec(resolver?: WikiWorkspaceResolver): AgentToolSpec {
   return buildWikiToolSpec(buildPatchEditToolConfig(), {
     whenToUse: [
       "A pending Fleet Wiki patch needs a small exact body or metadata correction before approval",
@@ -130,10 +125,10 @@ function buildWikiPatchEditSpec(): AgentToolSpec {
       "The patch has already been approved or rejected",
       "The desired change requires approving wiki content — use wiki_patch_queue for approval",
     ],
-  });
+  }, resolver);
 }
 
-function buildWikiPatchQueueSpec(): AgentToolSpec {
+function buildWikiPatchQueueSpec(resolver?: WikiWorkspaceResolver): AgentToolSpec {
   return buildWikiToolSpec(buildPatchQueueToolConfig(), {
     whenToUse: [
       "Pending Fleet Wiki patches need human approval or rejection",
@@ -143,10 +138,10 @@ function buildWikiPatchQueueSpec(): AgentToolSpec {
       "New wiki content needs to be staged — use wiki_ingest instead",
       "Existing approved wiki content needs to be read — use wiki_read instead",
     ],
-  });
+  }, resolver);
 }
 
-function buildWikiCompileSourceSpec(): AgentToolSpec {
+function buildWikiCompileSourceSpec(resolver?: WikiWorkspaceResolver): AgentToolSpec {
   return buildWikiToolSpec(buildCompileSourceToolConfig(), {
     whenToUse: [
       "A single source needs to be split into multiple proposed wiki page patches",
@@ -156,10 +151,10 @@ function buildWikiCompileSourceSpec(): AgentToolSpec {
       "Only one wiki entry needs to be staged — use wiki_ingest instead",
       "Pending patches need approval or rejection — use wiki_patch_queue instead",
     ],
-  });
+  }, resolver);
 }
 
-function buildWikiQuerySpec(): AgentToolSpec {
+function buildWikiQuerySpec(resolver?: WikiWorkspaceResolver): AgentToolSpec {
   return buildWikiToolSpec(buildQueryToolConfig(), {
     whenToUse: [
       "Answer a wiki-grounded question with evidence context and citations",
@@ -169,10 +164,10 @@ function buildWikiQuerySpec(): AgentToolSpec {
       "The task requires final approval of pending patches — use the host-side approval flow instead",
       "Only a ranked list of candidate entries is needed — use wiki_briefing instead",
     ],
-  });
+  }, resolver);
 }
 
-function buildWikiReadSpec(): AgentToolSpec {
+function buildWikiReadSpec(resolver?: WikiWorkspaceResolver): AgentToolSpec {
   return buildWikiToolSpec(buildReadToolConfig(), {
     whenToUse: [
       "Fetch full body, link graph, or raw source for one or more specific wiki entry IDs",
@@ -182,10 +177,10 @@ function buildWikiReadSpec(): AgentToolSpec {
       "Entry IDs are unknown — run wiki_briefing first to discover matching entries",
       "Compact multi-entry context pack is needed — use wiki_resolve instead",
     ],
-  });
+  }, resolver);
 }
 
-function buildWikiResolveSpec(): AgentToolSpec {
+function buildWikiResolveSpec(resolver?: WikiWorkspaceResolver): AgentToolSpec {
   return buildWikiToolSpec(buildResolveToolConfig(), {
     whenToUse: [
       "Compact context pack needed combining briefing and read results for a query topic",
@@ -195,12 +190,13 @@ function buildWikiResolveSpec(): AgentToolSpec {
       "Full entry body with link graph or raw source is needed — use wiki_read instead",
       "Only a ranked hit list without content is needed — use wiki_briefing instead",
     ],
-  });
+  }, resolver);
 }
 
 function buildWikiToolSpec(
   config: WikiAgentToolConfig,
   usage: Pick<AgentToolSpec, "whenToUse" | "whenNotToUse">,
+  resolver?: WikiWorkspaceResolver,
 ): AgentToolSpec {
   return {
     id: config.name,
@@ -218,7 +214,7 @@ function buildWikiToolSpec(
         args as Record<string, unknown>,
         ctx.signal,
         undefined,
-        { cwd: ctx.cwd },
+        { cwd: ctx.cwd, paths: resolver ? await resolver.resolve(ctx.cwd) : undefined },
       );
       return { content, isError: false };
     },

--- a/packages/fleet-wiki/src/index.ts
+++ b/packages/fleet-wiki/src/index.ts
@@ -1,4 +1,10 @@
 export { FLEET_WIKI_AGENT_TOOL_IDS, getWikiToolSpecs } from "./agent-specs.js";
+export { createWikiWorkspaceResolver } from "./workspace-resolver.js";
+export type {
+  WikiWorkspace,
+  WikiWorkspaceResolver,
+  WikiWorkspaceResolverDependencies,
+} from "./workspace-resolver.js";
 
 export * from "./boundaries.js";
 export * from "./briefing.js";

--- a/packages/fleet-wiki/src/paths.ts
+++ b/packages/fleet-wiki/src/paths.ts
@@ -17,7 +17,11 @@ import { ensureWorkspaceDoctrine, ensureWorkspaceSchema } from "./schema.js";
 import type { MemoryPaths } from "./types.js";
 
 export function resolveMemoryPaths(cwd: string): MemoryPaths {
-  const root = path.join(cwd, KNOWLEDGE_ROOT_DIRNAME);
+  return createMemoryPaths(path.join(cwd, KNOWLEDGE_ROOT_DIRNAME));
+}
+
+/** Build paths for an already-selected knowledge root. */
+export function createMemoryPaths(root: string): MemoryPaths {
   return {
     root,
     rawDir: path.join(root, RAW_DIRNAME),
@@ -28,6 +32,11 @@ export function resolveMemoryPaths(cwd: string): MemoryPaths {
     conflictsDir: path.join(root, CONFLICTS_DIRNAME),
     indexFile: path.join(root, INDEX_FILENAME),
   };
+}
+
+/** Retains direct-library callers while registered tools receive injected paths. */
+export function resolveToolMemoryPaths(ctx: { cwd: string; paths?: MemoryPaths }): MemoryPaths {
+  return ctx.paths ?? resolveMemoryPaths(ctx.cwd);
 }
 
 export async function ensureMemoryRoot(paths: MemoryPaths): Promise<void> {

--- a/packages/fleet-wiki/src/tools/briefing.ts
+++ b/packages/fleet-wiki/src/tools/briefing.ts
@@ -1,6 +1,6 @@
 import { FLEET_WIKI_BOUNDARY_GUIDELINES } from "../boundaries.js";
 import { briefingQuery } from "../briefing.js";
-import { resolveMemoryPaths } from "../paths.js";
+import { resolveToolMemoryPaths } from "../paths.js";
 import {
   WIKI_BRIEFING_DESCRIPTION,
   WIKI_BRIEFING_GUIDELINES,
@@ -21,9 +21,9 @@ export function buildBriefingToolConfig() {
       params: Record<string, unknown>,
       _signal: AbortSignal | undefined,
       _onUpdate: unknown,
-      ctx: { cwd: string },
+      ctx: { cwd: string; paths?: import("../types.js").MemoryPaths },
     ) {
-      const hits = await briefingQuery(resolveMemoryPaths(ctx.cwd), {
+      const hits = await briefingQuery(resolveToolMemoryPaths(ctx), {
         topic: typeof params.topic === "string" ? params.topic : undefined,
         tags: Array.isArray(params.tags) ? params.tags.map(String) : undefined,
         limit: typeof params.limit === "number" ? params.limit : undefined,

--- a/packages/fleet-wiki/src/tools/compile-source.ts
+++ b/packages/fleet-wiki/src/tools/compile-source.ts
@@ -7,7 +7,7 @@ import { extractWikiLinks } from "../links.js";
 import { appendLog } from "../log.js";
 import { buildPatchSetId, writePatchSet } from "../patch-set.js";
 import { enqueuePatch } from "../patch.js";
-import { resolveMemoryPaths } from "../paths.js";
+import { resolveMemoryPaths, resolveToolMemoryPaths } from "../paths.js";
 import {
   WIKI_COMPILE_SOURCE_DESCRIPTION,
   WIKI_COMPILE_SOURCE_GUIDELINES,
@@ -107,10 +107,10 @@ export function buildCompileSourceToolConfig() {
       params: Record<string, unknown>,
       _signal: AbortSignal | undefined,
       _onUpdate: unknown,
-      ctx: { cwd: string },
+      ctx: { cwd: string; paths?: import("../types.js").MemoryPaths },
     ) {
       const now = new Date().toISOString();
-      const paths = resolveMemoryPaths(ctx.cwd);
+      const paths = resolveToolMemoryPaths(ctx);
       const input = normalizeCompileSourceInput(params as WikiCompileSourceInput);
       const output = input.mode === "stage"
         ? await stageSourceCompile(input, paths, now)

--- a/packages/fleet-wiki/src/tools/drydock.ts
+++ b/packages/fleet-wiki/src/tools/drydock.ts
@@ -1,5 +1,5 @@
 import { runDryDock } from "../drydock.js";
-import { resolveMemoryPaths } from "../paths.js";
+import { resolveToolMemoryPaths } from "../paths.js";
 import {
   WIKI_DRYDOCK_DESCRIPTION,
   WIKI_DRYDOCK_GUIDELINES,
@@ -20,9 +20,9 @@ export function buildDryDockToolConfig() {
       params: Record<string, unknown>,
       _signal: AbortSignal | undefined,
       _onUpdate: unknown,
-      ctx: { cwd: string },
+      ctx: { cwd: string; paths?: import("../types.js").MemoryPaths },
     ) {
-      const report = await runDryDock(resolveMemoryPaths(ctx.cwd), { fix: params.fix === true });
+      const report = await runDryDock(resolveToolMemoryPaths(ctx), { fix: params.fix === true });
       return {
         content: [{ type: "text" as const, text: JSON.stringify(report, null, 2) }],
         details: {},

--- a/packages/fleet-wiki/src/tools/ingest.ts
+++ b/packages/fleet-wiki/src/tools/ingest.ts
@@ -4,7 +4,7 @@ import { createConflict } from "../conflicts.js";
 import { mergeRawSourceRefs, normalizeComparableText } from "../internal-utils.js";
 import { appendLog } from "../log.js";
 import { enqueuePatch } from "../patch.js";
-import { resolveMemoryPaths } from "../paths.js";
+import { resolveMemoryPaths, resolveToolMemoryPaths } from "../paths.js";
 import { ensureWorkspaceSchema, inferTemplateIdFromTarget, scanTemplates, validateTemplateCompliance } from "../schema.js";
 import {
   WIKI_INGEST_DESCRIPTION,
@@ -97,10 +97,10 @@ export function buildIngestToolConfig() {
       params: Record<string, unknown>,
       _signal: AbortSignal | undefined,
       _onUpdate: unknown,
-      ctx: { cwd: string },
+      ctx: { cwd: string; paths?: import("../types.js").MemoryPaths },
     ) {
       const now = new Date().toISOString();
-      const paths = resolveMemoryPaths(ctx.cwd);
+      const paths = resolveToolMemoryPaths(ctx);
       const input = parseIngestParams(params);
       const plan = await planIngest(input, paths, now);
       const result = await stageIngestPlan(plan, paths);

--- a/packages/fleet-wiki/src/tools/orient.ts
+++ b/packages/fleet-wiki/src/tools/orient.ts
@@ -4,7 +4,7 @@ import { FLEET_WIKI_BOUNDARY_GUIDELINES, wrapWikiEntryBoundary } from "../bounda
 import { runDryDock } from "../drydock.js";
 import { formatLogEntry, parseLog } from "../log.js";
 import { listQueue } from "../patch.js";
-import { getIndexMarkdownFile, resolveMemoryPaths } from "../paths.js";
+import { getIndexMarkdownFile, resolveMemoryPaths, resolveToolMemoryPaths } from "../paths.js";
 import {
   WIKI_ORIENT_DESCRIPTION,
   WIKI_ORIENT_GUIDELINES,
@@ -59,10 +59,10 @@ export function buildOrientToolConfig() {
       params: Record<string, unknown>,
       _signal: AbortSignal | undefined,
       _onUpdate: unknown,
-      ctx: { cwd: string },
+      ctx: { cwd: string; paths?: import("../types.js").MemoryPaths },
     ) {
       const input = normalizeInput(params);
-      const paths = resolveMemoryPaths(ctx.cwd);
+      const paths = resolveToolMemoryPaths(ctx);
       await ensureWorkspaceSchema(paths);
 
       const pendingQueueCount = await loadPendingQueueCount(paths);

--- a/packages/fleet-wiki/src/tools/patch-edit.ts
+++ b/packages/fleet-wiki/src/tools/patch-edit.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { PATCH_FILENAME, PATCH_META_FILENAME } from "../constants.js";
 import { appendLog } from "../log.js";
 import { assertSafeQueueId, parsePatch, rewriteQueuedPatch, serializePatch } from "../patch.js";
-import { resolveMemoryPaths } from "../paths.js";
+import { resolveMemoryPaths, resolveToolMemoryPaths } from "../paths.js";
 import {
   WIKI_PATCH_EDIT_DESCRIPTION,
   WIKI_PATCH_EDIT_GUIDELINES,
@@ -80,9 +80,9 @@ export function buildPatchEditToolConfig() {
       params: Record<string, unknown>,
       _signal: AbortSignal | undefined,
       _onUpdate: unknown,
-      ctx: { cwd: string },
+      ctx: { cwd: string; paths?: import("../types.js").MemoryPaths },
     ) {
-      const paths = resolveMemoryPaths(ctx.cwd);
+      const paths = resolveToolMemoryPaths(ctx);
       const input = parsePatchEditParams(params);
       const result = await editQueuedPatch(input, paths);
       return {

--- a/packages/fleet-wiki/src/tools/patch-queue.ts
+++ b/packages/fleet-wiki/src/tools/patch-queue.ts
@@ -1,6 +1,6 @@
 import { listConflicts } from "../conflicts.js";
 import { approvePatch, approvePatchSet, listQueue, rejectPatch, resolveQueueSelection, showQueue } from "../patch.js";
-import { resolveMemoryPaths } from "../paths.js";
+import { resolveToolMemoryPaths } from "../paths.js";
 import {
   WIKI_PATCH_QUEUE_DESCRIPTION,
   WIKI_PATCH_QUEUE_GUIDELINES,
@@ -21,9 +21,9 @@ export function buildPatchQueueToolConfig() {
       params: Record<string, unknown>,
       _signal: AbortSignal | undefined,
       _onUpdate: unknown,
-      ctx: { cwd: string },
+      ctx: { cwd: string; paths?: import("../types.js").MemoryPaths },
     ) {
-      const paths = resolveMemoryPaths(ctx.cwd);
+      const paths = resolveToolMemoryPaths(ctx);
       const action = String(params.action ?? "list");
 
       if (action === "list") {

--- a/packages/fleet-wiki/src/tools/query.ts
+++ b/packages/fleet-wiki/src/tools/query.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import { dedupeStrings, truncateSummary } from "../internal-utils.js";
 import { enqueuePatch } from "../patch.js";
-import { resolveMemoryPaths } from "../paths.js";
+import { resolveMemoryPaths, resolveToolMemoryPaths } from "../paths.js";
 import {
   WIKI_QUERY_DESCRIPTION,
   WIKI_QUERY_GUIDELINES,
@@ -81,9 +81,9 @@ export function buildQueryToolConfig() {
       params: Record<string, unknown>,
       _signal: AbortSignal | undefined,
       _onUpdate: unknown,
-      ctx: { cwd: string },
+      ctx: { cwd: string; paths?: import("../types.js").MemoryPaths },
     ) {
-      const paths = resolveMemoryPaths(ctx.cwd);
+      const paths = resolveToolMemoryPaths(ctx);
       const input = normalizeQueryInput(params as unknown as WikiQueryInput);
       const resolvePayload = await resolveWikiContext({
         query: input.question,

--- a/packages/fleet-wiki/src/tools/read.ts
+++ b/packages/fleet-wiki/src/tools/read.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { wrapWikiEntryBoundary, wrapWikiRawSourceBoundary, FLEET_WIKI_BOUNDARY_GUIDELINES } from "../boundaries.js";
 import { dedupeStrings, estimateTokens } from "../internal-utils.js";
 import { extractWikiLinks } from "../links.js";
-import { resolveMemoryPaths } from "../paths.js";
+import { resolveToolMemoryPaths } from "../paths.js";
 import {
   WIKI_READ_DESCRIPTION,
   WIKI_READ_GUIDELINES,
@@ -68,10 +68,10 @@ export function buildReadToolConfig() {
       params: Record<string, unknown>,
       _signal: AbortSignal | undefined,
       _onUpdate: unknown,
-      ctx: { cwd: string },
+      ctx: { cwd: string; paths?: import("../types.js").MemoryPaths },
     ) {
       const input = normalizeReadInput(params);
-      const paths = resolveMemoryPaths(ctx.cwd);
+      const paths = resolveToolMemoryPaths(ctx);
       const graph = await buildLinkGraph(paths);
       const entries: Array<WikiReadEntryResult | WikiReadMissingResult> = [];
 

--- a/packages/fleet-wiki/src/tools/resolve.ts
+++ b/packages/fleet-wiki/src/tools/resolve.ts
@@ -3,7 +3,7 @@ import { briefingQuery } from "../briefing.js";
 import { readClaims } from "../claims.js";
 import { dedupeStrings, estimateTokens } from "../internal-utils.js";
 import { extractWikiLinks } from "../links.js";
-import { resolveMemoryPaths } from "../paths.js";
+import { resolveToolMemoryPaths } from "../paths.js";
 import {
   WIKI_RESOLVE_DESCRIPTION,
   WIKI_RESOLVE_GUIDELINES,
@@ -90,10 +90,10 @@ export function buildResolveToolConfig() {
       params: Record<string, unknown>,
       _signal: AbortSignal | undefined,
       _onUpdate: unknown,
-      ctx: { cwd: string },
+      ctx: { cwd: string; paths?: import("../types.js").MemoryPaths },
     ) {
       const input = normalizeResolveInput(params);
-      const paths = resolveMemoryPaths(ctx.cwd);
+      const paths = resolveToolMemoryPaths(ctx);
       const payload = await resolveWikiContext(input, paths);
       if (input.format === "markdown_pack") {
         return {

--- a/packages/fleet-wiki/src/workspace-resolver.ts
+++ b/packages/fleet-wiki/src/workspace-resolver.ts
@@ -1,0 +1,180 @@
+import * as fs from "node:fs";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+import { createMemoryPaths } from "./paths.js";
+import type { MemoryPaths } from "./types.js";
+
+export interface WikiWorkspace { readonly cwd: string; readonly path: string; }
+export interface WikiWorkspaceResolverDependencies {
+  ensureWorkspace(cwd: string): WikiWorkspace;
+  withMigrationLock<T>(workspace: WikiWorkspace, operation: () => T): T;
+}
+export interface WikiWorkspaceResolver { resolve(cwd: string): MemoryPaths; }
+interface WikiWorkspaceResolverTestHooks {
+  beforeMigrationCommit?(): void;
+  beforeCopyFile?(source: string, destination: string): void;
+}
+interface MigrationMarker { version: 1; outcome: "copied"; transactionId: string; completedAt: string; }
+
+const STAGING_PREFIX = "knowledge.migrating-";
+const MARKER_NAME = "knowledge.migrated.json";
+
+/** Host-injected canonical-workspace gate; fleet-wiki intentionally knows no host package. */
+export function createWikiWorkspaceResolver(deps: WikiWorkspaceResolverDependencies): WikiWorkspaceResolver {
+  return createResolver(deps);
+}
+
+/** Test-only module seam; intentionally absent from the package-root barrel. */
+export function createWikiWorkspaceResolverForTest(
+  deps: WikiWorkspaceResolverDependencies,
+  hooks: WikiWorkspaceResolverTestHooks,
+): WikiWorkspaceResolver {
+  return createResolver(deps, hooks);
+}
+
+function createResolver(
+  deps: WikiWorkspaceResolverDependencies,
+  hooks?: WikiWorkspaceResolverTestHooks,
+): WikiWorkspaceResolver {
+  return { resolve: (cwd) => {
+    const workspace = deps.ensureWorkspace(cwd);
+    return deps.withMigrationLock(workspace, () => resolveLocked(workspace, hooks));
+  } };
+}
+
+function resolveLocked(workspace: WikiWorkspace, hooks?: WikiWorkspaceResolverTestHooks): MemoryPaths {
+  const destination = path.join(workspace.path, "knowledge");
+  const source = path.join(workspace.cwd, ".fleet", "knowledge");
+  const markerPath = path.join(workspace.path, MARKER_NAME);
+  const destinationState = inspectTree(destination, true);
+  // Destination content wins before source or control state is inspected.
+  if (destinationState === "content") return createMemoryPaths(destination);
+  if (destinationState === "unsafe") throw new Error("Unsafe Fleet Wiki destination state");
+
+  const marker = readMarker(markerPath);
+  const stagingEntries = inspectReservedControlState(workspace.path);
+  if (marker) {
+    const staging = path.join(workspace.path, `${STAGING_PREFIX}${marker.transactionId}`);
+    const stagingState = inspectTree(staging);
+    if (stagingState === "content") {
+      removeEmptyDirectories(destination);
+      fs.renameSync(staging, destination);
+      syncDirectory(workspace.path);
+    } else if (stagingState !== "missing") throw new Error("Unsafe Fleet Wiki migration staging state");
+    return createMemoryPaths(destination);
+  }
+
+  const sourceState = inspectTree(source);
+  if (sourceState === "unsafe") throw new Error("Unsafe Fleet Wiki legacy source state");
+  removePriorStaging(workspace.path, stagingEntries);
+  if (sourceState !== "content") return createMemoryPaths(destination);
+  removeEmptyDirectories(destination);
+  const transactionId = randomUUID();
+  const staging = path.join(workspace.path, `${STAGING_PREFIX}${transactionId}`);
+  copyTree(source, staging, hooks);
+  if (inspectTree(staging) !== "content") throw new Error("Invalid Fleet Wiki migration staging result");
+  syncDirectory(staging);
+  hooks?.beforeMigrationCommit?.();
+  const rechecked = inspectTree(destination, true);
+  if (rechecked === "content") throw new Error("Fleet Wiki destination race detected");
+  if (rechecked === "unsafe") throw new Error("Unsafe Fleet Wiki destination race");
+  writeAtomic(markerPath, `${JSON.stringify({ version: 1, outcome: "copied", transactionId, completedAt: new Date().toISOString() } satisfies MigrationMarker)}\n`);
+  syncDirectory(workspace.path);
+  removeEmptyDirectories(destination);
+  fs.renameSync(staging, destination);
+  syncDirectory(workspace.path);
+  return createMemoryPaths(destination);
+}
+
+type TreeState = "missing" | "empty" | "content" | "unsafe";
+function inspectTree(target: string, regularRootIsContent = false): TreeState {
+  let stat: fs.Stats;
+  try { stat = fs.lstatSync(target); } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing";
+    throw error;
+  }
+  const nodeKind = classifyWikiWorkspaceNodeForTest(stat);
+  if (nodeKind === "unsafe") return "unsafe";
+  if (nodeKind === "file") return regularRootIsContent ? "content" : "unsafe";
+  let content = false;
+  for (const entry of fs.readdirSync(target, { withFileTypes: true })) {
+    if (entry.isSymbolicLink() || (!entry.isDirectory() && !entry.isFile())) return "unsafe";
+    if (entry.isFile()) content = true;
+    if (entry.isDirectory()) {
+      const nested = inspectTree(path.join(target, entry.name));
+      if (nested === "unsafe") return "unsafe";
+      if (nested === "content") content = true;
+    }
+  }
+  return content ? "content" : "empty";
+}
+
+function readMarker(markerPath: string): MigrationMarker | null {
+  let stat: fs.Stats;
+  try { stat = fs.lstatSync(markerPath); } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  if (!stat.isFile() || stat.isSymbolicLink()) throw new Error("Unsafe Fleet Wiki migration marker");
+  let value: unknown;
+  try { value = JSON.parse(fs.readFileSync(markerPath, "utf8")); } catch { throw new Error("Invalid Fleet Wiki migration marker"); }
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Invalid Fleet Wiki migration marker");
+  const record = value as Record<string, unknown>;
+  if (record.version !== 1 || record.outcome !== "copied" || typeof record.transactionId !== "string"
+    || !/^[0-9a-f-]{36}$/i.test(record.transactionId) || typeof record.completedAt !== "string") throw new Error("Invalid Fleet Wiki migration marker");
+  return record as unknown as MigrationMarker;
+}
+
+function copyTree(source: string, destination: string, hooks?: WikiWorkspaceResolverTestHooks): void {
+  fs.mkdirSync(destination, { recursive: true });
+  for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+    const from = path.join(source, entry.name); const to = path.join(destination, entry.name);
+    const stat = fs.lstatSync(from);
+    const nodeKind = classifyWikiWorkspaceNodeForTest(stat);
+    if (nodeKind === "unsafe") throw new Error("Unsafe Fleet Wiki legacy source state");
+    if (nodeKind === "directory") copyTree(from, to, hooks);
+    else { hooks?.beforeCopyFile?.(from, to); fs.copyFileSync(from, to); syncFile(to); }
+  }
+  syncDirectory(destination);
+}
+
+/** Test-only direct-module seam for the lstat branch; absent from the package-root barrel. */
+export function classifyWikiWorkspaceNodeForTest(stat: fs.Stats): "file" | "directory" | "unsafe" {
+  if (stat.isSymbolicLink()) return "unsafe";
+  if (stat.isFile()) return "file";
+  if (stat.isDirectory()) return "directory";
+  return "unsafe";
+}
+
+function removeEmptyDirectories(target: string): void {
+  const state = inspectTree(target, true);
+  if (state === "missing") return;
+  if (state === "unsafe") throw new Error("Unsafe Fleet Wiki destination state");
+  if (state === "empty") fs.rmSync(target, { recursive: true, force: false });
+}
+
+function removePriorStaging(workspacePath: string, stagingEntries: readonly string[]): void {
+  for (const name of stagingEntries) fs.rmSync(path.join(workspacePath, name), { recursive: true, force: false });
+}
+
+function inspectReservedControlState(workspacePath: string): string[] {
+  const stagingEntries: string[] = [];
+  for (const entry of fs.readdirSync(workspacePath, { withFileTypes: true })) {
+    if (entry.name.startsWith(`${MARKER_NAME}.`)) throw new Error("Unsafe Fleet Wiki migration marker control state");
+    if (!entry.name.startsWith(STAGING_PREFIX)) continue;
+    if (!/^[0-9a-f-]{36}$/i.test(entry.name.slice(STAGING_PREFIX.length)) || entry.isSymbolicLink() || !entry.isDirectory()) throw new Error("Unsafe Fleet Wiki migration staging state");
+    if (inspectTree(path.join(workspacePath, entry.name)) === "unsafe") throw new Error("Unsafe Fleet Wiki migration staging state");
+    stagingEntries.push(entry.name);
+  }
+  return stagingEntries;
+}
+
+function writeAtomic(target: string, contents: string): void {
+  const temporary = `${target}.${randomUUID()}.tmp`;
+  fs.writeFileSync(temporary, contents, { mode: 0o600 });
+  syncFile(temporary);
+  fs.renameSync(temporary, target);
+}
+function syncFile(target: string): void { const fd = fs.openSync(target, "r"); try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); } }
+function syncDirectory(target: string): void { const fd = fs.openSync(target, "r"); try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); } }

--- a/packages/fleet-wiki/src/workspace-resolver.ts
+++ b/packages/fleet-wiki/src/workspace-resolver.ts
@@ -19,6 +19,7 @@ interface MigrationMarker { version: 1; outcome: "copied"; transactionId: string
 
 const STAGING_PREFIX = "knowledge.migrating-";
 const MARKER_NAME = "knowledge.migrated.json";
+const MARKER_TEMP_REGEXP = /^knowledge\.migrated\.json\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.tmp$/i;
 
 /** Host-injected canonical-workspace gate; fleet-wiki intentionally knows no host package. */
 export function createWikiWorkspaceResolver(deps: WikiWorkspaceResolverDependencies): WikiWorkspaceResolver {
@@ -161,7 +162,15 @@ function removePriorStaging(workspacePath: string, stagingEntries: readonly stri
 function inspectReservedControlState(workspacePath: string): string[] {
   const stagingEntries: string[] = [];
   for (const entry of fs.readdirSync(workspacePath, { withFileTypes: true })) {
-    if (entry.name.startsWith(`${MARKER_NAME}.`)) throw new Error("Unsafe Fleet Wiki migration marker control state");
+    if (entry.name.startsWith(`${MARKER_NAME}.`)) {
+      const residuePath = path.join(workspacePath, entry.name);
+      const residue = fs.lstatSync(residuePath);
+      if (MARKER_TEMP_REGEXP.test(entry.name) && residue.isFile() && !residue.isSymbolicLink()) {
+        fs.unlinkSync(residuePath);
+        continue;
+      }
+      throw new Error("Unsafe Fleet Wiki migration marker control state");
+    }
     if (!entry.name.startsWith(STAGING_PREFIX)) continue;
     if (!/^[0-9a-f-]{36}$/i.test(entry.name.slice(STAGING_PREFIX.length)) || entry.isSymbolicLink() || !entry.isDirectory()) throw new Error("Unsafe Fleet Wiki migration staging state");
     if (inspectTree(path.join(workspacePath, entry.name)) === "unsafe") throw new Error("Unsafe Fleet Wiki migration staging state");
@@ -177,4 +186,10 @@ function writeAtomic(target: string, contents: string): void {
   fs.renameSync(temporary, target);
 }
 function syncFile(target: string): void { const fd = fs.openSync(target, "r"); try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); } }
-function syncDirectory(target: string): void { const fd = fs.openSync(target, "r"); try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); } }
+function syncDirectory(target: string): void {
+  if (!shouldSyncDirectoryForTest(process.platform)) return;
+  const fd = fs.openSync(target, "r"); try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+}
+
+/** Test-only direct-module seam for the platform-specific directory fsync policy; absent from the package-root barrel. */
+export function shouldSyncDirectoryForTest(platform: NodeJS.Platform): boolean { return platform !== "win32"; }

--- a/packages/fleet-wiki/tests/wiki-agent-specs.test.ts
+++ b/packages/fleet-wiki/tests/wiki-agent-specs.test.ts
@@ -1,0 +1,80 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { FLEET_WIKI_AGENT_TOOL_IDS, getWikiToolSpecs } from "../src/agent-specs.js";
+import * as publicApi from "../src/index.js";
+import { createMemoryPaths } from "../src/paths.js";
+import { buildBriefingToolConfig } from "../src/tools/briefing.js";
+import { buildCompileSourceToolConfig } from "../src/tools/compile-source.js";
+import { buildDryDockToolConfig } from "../src/tools/drydock.js";
+import { buildIngestToolConfig } from "../src/tools/ingest.js";
+import { buildOrientToolConfig } from "../src/tools/orient.js";
+import { buildPatchEditToolConfig } from "../src/tools/patch-edit.js";
+import { buildPatchQueueToolConfig } from "../src/tools/patch-queue.js";
+import { buildQueryToolConfig } from "../src/tools/query.js";
+import { buildReadToolConfig } from "../src/tools/read.js";
+import { buildResolveToolConfig } from "../src/tools/resolve.js";
+
+const BODY = "A durable test entry. ".repeat(12);
+
+describe("Wiki agent specs", () => {
+  it("exports only the production resolver factory through the package root", () => {
+    expect(publicApi.createWikiWorkspaceResolver).toBeTypeOf("function");
+    expect("createWikiWorkspaceResolverForTest" in publicApi).toBe(false);
+  });
+
+  it("preserves every schema and resolves once before each of the ten domain tools", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "fleet-wiki-agent-specs-"));
+    const paths = createMemoryPaths(path.join(root, "knowledge"));
+    const expectedParameters = [
+      buildBriefingToolConfig(), buildDryDockToolConfig(), buildIngestToolConfig(), buildOrientToolConfig(),
+      buildPatchEditToolConfig(), buildPatchQueueToolConfig(), buildCompileSourceToolConfig(), buildQueryToolConfig(),
+      buildReadToolConfig(), buildResolveToolConfig(),
+    ].map((config) => config.parameters);
+    let calls = 0;
+    const specs = getWikiToolSpecs({ resolve: () => { calls += 1; return paths; } });
+    expect(specs.map((spec) => spec.id)).toEqual(FLEET_WIKI_AGENT_TOOL_IDS);
+    expect(specs.map((spec) => spec.parameters)).toEqual(expectedParameters);
+    const context = { cwd: "/theater", signal: undefined } as never;
+    const invoke = async (id: string, args: Record<string, unknown>) => {
+      const before = calls;
+      const result = await specs.find((spec) => spec.id === id)!.execute(args, context);
+      expect(calls).toBe(before + 1);
+      expect(isTextToolResult(result)).toBe(true);
+      if (!isTextToolResult(result)) throw new Error(`${id} returned an invalid tool result`);
+      expect(result.isError).toBe(false);
+      return JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+    };
+    try {
+      await invoke("wiki_briefing", {});
+      await invoke("wiki_drydock", {});
+      const ingest = await invoke("wiki_ingest", { id: "entry", title: "Entry", body: BODY, tags: [], source: BODY });
+      await invoke("wiki_orient", {});
+      await invoke("wiki_patch_edit", { patch_id: ingest.patch_id, title: "Edited" });
+      await invoke("wiki_patch_queue", { action: "list" });
+      await invoke("wiki_compile_source", { source: BODY, mode: "preview" });
+      await invoke("wiki_query", { question: "What is entry?" });
+      await invoke("wiki_read", { ids: ["entry"] });
+      await invoke("wiki_resolve", { query: "entry" });
+      expect(calls).toBe(FLEET_WIKI_AGENT_TOOL_IDS.length);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+function isTextToolResult(value: unknown): value is {
+  isError: boolean;
+  content: Array<{ type: "text"; text: string }>;
+} {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.isError === "boolean"
+    && Array.isArray(record.content)
+    && record.content.length > 0
+    && record.content.every((item) => typeof item === "object" && item !== null
+      && (item as Record<string, unknown>).type === "text"
+      && typeof (item as Record<string, unknown>).text === "string");
+}

--- a/packages/fleet-wiki/tests/wiki-workspace-resolver.test.ts
+++ b/packages/fleet-wiki/tests/wiki-workspace-resolver.test.ts
@@ -1,0 +1,205 @@
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import * as fs from "node:fs";
+import { execFileSync } from "node:child_process";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createWikiWorkspaceResolver,
+  createWikiWorkspaceResolverForTest,
+  classifyWikiWorkspaceNodeForTest,
+  type WikiWorkspaceResolverDependencies,
+} from "../src/workspace-resolver.js";
+
+const roots: string[] = [];
+afterEach(async () => { await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true }))); });
+
+interface TestHooks {
+  beforeMigrationCommit?(): void;
+  beforeCopyFile?(source: string, destination: string): void;
+}
+
+async function fixture(hooks?: TestHooks) {
+  const root = await mkdtemp(process.platform === "darwin" ? "/tmp/fwr-" : path.join(os.tmpdir(), "fleet-wiki-resolver-"));
+  roots.push(root);
+  const cwd = path.join(root, "theater");
+  const workspace = path.join(root, "data", "workspaces", "theater");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(workspace, { recursive: true });
+  const dependencies: WikiWorkspaceResolverDependencies = {
+    ensureWorkspace: () => ({ cwd, path: workspace }),
+    withMigrationLock: (_workspace, operation) => operation(),
+  };
+  return { cwd, workspace, resolver: hooks
+    ? createWikiWorkspaceResolverForTest(dependencies, hooks)
+    : createWikiWorkspaceResolver(dependencies) };
+}
+
+describe("createWikiWorkspaceResolver", () => {
+  it("copies root legacy content once through durable sibling storage without changing the source", async () => {
+    const { cwd, workspace, resolver } = await fixture();
+    const sourceFile = path.join(cwd, ".fleet", "knowledge", "wiki", "entry.md");
+    await mkdir(path.dirname(sourceFile), { recursive: true });
+    await writeFile(sourceFile, "legacy\n");
+    const paths = await resolver.resolve(cwd);
+    expect(paths.root).toBe(path.join(workspace, "knowledge"));
+    await expect(readFile(path.join(paths.wikiDir, "entry.md"), "utf8")).resolves.toBe("legacy\n");
+    await expect(readFile(sourceFile, "utf8")).resolves.toBe("legacy\n");
+    expect(JSON.parse(await readFile(path.join(workspace, "knowledge.migrated.json"), "utf8")).outcome).toBe("copied");
+    await rm(paths.root, { recursive: true });
+    await resolver.resolve(cwd);
+    await expect(readFile(path.join(paths.wikiDir, "entry.md"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("leaves a destination regular file entirely untouched and does not create a marker", async () => {
+    const { cwd, workspace, resolver } = await fixture();
+    await mkdir(path.join(cwd, ".fleet", "knowledge"), { recursive: true });
+    await writeFile(path.join(cwd, ".fleet", "knowledge", "legacy.md"), "legacy");
+    await mkdir(path.join(workspace, "knowledge", "schema"), { recursive: true });
+    await writeFile(path.join(workspace, "knowledge", "schema", "wiki-schema.md"), "destination");
+    await resolver.resolve(cwd);
+    await expect(readFile(path.join(workspace, "knowledge", "schema", "wiki-schema.md"), "utf8")).resolves.toBe("destination");
+    await expect(readFile(path.join(workspace, "knowledge.migrated.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("makes destination content a total no-op before malformed marker or staging control inspection", async () => {
+    const { cwd, workspace, resolver } = await fixture();
+    await mkdir(path.join(cwd, ".fleet", "knowledge"), { recursive: true });
+    await writeFile(path.join(workspace, "knowledge"), "already durable");
+    await writeFile(path.join(workspace, "knowledge.migrated.json"), "not json");
+    await symlink(path.join(cwd, "missing"), path.join(workspace, "knowledge.migrating-not-a-uuid"));
+    expect(resolver.resolve(cwd)).toMatchObject({ root: path.join(workspace, "knowledge") });
+    await expect(readFile(path.join(workspace, "knowledge"), "utf8")).resolves.toBe("already durable");
+  });
+
+  it("recovers only a marker-referenced staged copy and never re-copies after marker recovery", async () => {
+    const { cwd, workspace, resolver } = await fixture();
+    const transactionId = "11111111-1111-4111-8111-111111111111";
+    const stagingFile = path.join(workspace, `knowledge.migrating-${transactionId}`, "wiki", "entry.md");
+    await mkdir(path.dirname(stagingFile), { recursive: true });
+    await writeFile(stagingFile, "staged");
+    await writeFile(path.join(workspace, "knowledge.migrated.json"), JSON.stringify({ version: 1, outcome: "copied", transactionId, completedAt: "2026-07-17T00:00:00.000Z" }));
+    await mkdir(path.join(cwd, ".fleet", "knowledge"), { recursive: true });
+    await writeFile(path.join(cwd, ".fleet", "knowledge", "legacy.md"), "must not copy");
+    const paths = resolver.resolve(cwd);
+    await expect(readFile(path.join(paths.wikiDir, "entry.md"), "utf8")).resolves.toBe("staged");
+    await expect(readFile(path.join(paths.root, "legacy.md"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rebuilds valid pre-marker staging but fails closed for unsafe source, marker, and staging state", async () => {
+    const { cwd, workspace, resolver } = await fixture();
+    const stale = path.join(workspace, "knowledge.migrating-22222222-2222-4222-8222-222222222222");
+    await mkdir(stale, { recursive: true });
+    await writeFile(path.join(stale, "old.md"), "old");
+    await mkdir(path.join(cwd, ".fleet", "knowledge"), { recursive: true });
+    await writeFile(path.join(cwd, ".fleet", "knowledge", "fresh.md"), "fresh");
+    const paths = resolver.resolve(cwd);
+    await expect(readFile(path.join(paths.root, "fresh.md"), "utf8")).resolves.toBe("fresh");
+
+    const unsafe = await fixture();
+    await mkdir(path.join(unsafe.cwd, ".fleet", "knowledge"), { recursive: true });
+    await symlink(path.join(unsafe.cwd, "missing"), path.join(unsafe.cwd, ".fleet", "knowledge", "link"));
+    expect(() => unsafe.resolver.resolve(unsafe.cwd)).toThrow(/Unsafe/);
+
+    const malformed = await fixture();
+    await mkdir(path.join(malformed.workspace, "knowledge.migrating-bad"), { recursive: true });
+    expect(() => malformed.resolver.resolve(malformed.cwd)).toThrow(/Unsafe/);
+
+    const marker = await fixture();
+    await symlink(path.join(marker.cwd, "missing"), path.join(marker.workspace, "knowledge.migrated.json"));
+    expect(() => marker.resolver.resolve(marker.cwd)).toThrow(/Unsafe/);
+  });
+
+  it("fails closed when destination content appears after staging", async () => {
+    let workspace = "";
+    const state = await fixture({ beforeMigrationCommit: () => {
+      fs.mkdirSync(path.join(workspace, "knowledge"), { recursive: true });
+      fs.writeFileSync(path.join(workspace, "knowledge", "racer.md"), "racer");
+    } });
+    workspace = state.workspace;
+    await mkdir(path.join(state.cwd, ".fleet", "knowledge"), { recursive: true });
+    await writeFile(path.join(state.cwd, ".fleet", "knowledge", "legacy.md"), "legacy");
+    expect(() => state.resolver.resolve(state.cwd)).toThrow(/race/i);
+    await expect(readFile(path.join(workspace, "knowledge", "racer.md"), "utf8")).resolves.toBe("racer");
+  });
+
+  it("allows empty source and destination without artifacts, while unsafe nodes fail closed", async () => {
+    const { cwd, workspace, resolver } = await fixture();
+    expect(resolver.resolve(cwd)).toMatchObject({ root: path.join(workspace, "knowledge") });
+    await expect(readFile(path.join(workspace, "knowledge.migrated.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    await mkdir(path.join(workspace, "knowledge"), { recursive: true });
+    await symlink(path.join(cwd, "missing"), path.join(workspace, "knowledge", "unsafe"));
+    expect(() => resolver.resolve(cwd)).toThrow(/Unsafe/);
+  });
+
+  it("leaves no marker or destination after a copy failure, then safely retries from rebuilt staging", async () => {
+    const failed = await fixture({ beforeCopyFile: () => { throw new Error("copy failed"); } });
+    const sourceFile = path.join(failed.cwd, ".fleet", "knowledge", "nested", "entry.md");
+    await mkdir(path.dirname(sourceFile), { recursive: true });
+    await writeFile(sourceFile, "source bytes\n");
+    expect(() => failed.resolver.resolve(failed.cwd)).toThrow(/copy failed/);
+    await expect(readFile(sourceFile, "utf8")).resolves.toBe("source bytes\n");
+    await expect(readFile(path.join(failed.workspace, "knowledge", "nested", "entry.md"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(path.join(failed.workspace, "knowledge.migrated.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    expect(fs.readdirSync(failed.workspace).some((name) => name.startsWith("knowledge.migrating-"))).toBe(true);
+
+    const retry = createWikiWorkspaceResolver({
+      ensureWorkspace: () => ({ cwd: failed.cwd, path: failed.workspace }),
+      withMigrationLock: (_workspace, operation) => operation(),
+    });
+    const paths = retry.resolve(failed.cwd);
+    await expect(readFile(path.join(paths.root, "nested", "entry.md"), "utf8")).resolves.toBe("source bytes\n");
+    expect(JSON.parse(await readFile(path.join(failed.workspace, "knowledge.migrated.json"), "utf8")).outcome).toBe("copied");
+  });
+
+  it.skipIf(process.platform === "win32")("fails closed for FIFO and Unix socket nodes in every migration position", async () => {
+    const source = await fixture();
+    const sourceFifo = path.join(source.cwd, ".fleet", "knowledge");
+    await mkdir(path.dirname(sourceFifo), { recursive: true });
+    execFileSync("mkfifo", [sourceFifo]);
+    expect(() => source.resolver.resolve(source.cwd)).toThrow(/Unsafe/);
+
+    const destination = await fixture();
+    const destinationSocket = await listenUnixSocket(path.join(destination.workspace, "knowledge"));
+    try {
+      expect(fs.lstatSync(path.join(destination.workspace, "knowledge")).isSocket()).toBe(true);
+      expect(classifyWikiWorkspaceNodeForTest(fs.lstatSync(path.join(destination.workspace, "knowledge")))).toBe("unsafe");
+      expect(() => destination.resolver.resolve(destination.cwd)).toThrow(/Unsafe/);
+    } finally { await closeServer(destinationSocket); }
+
+    const staging = await fixture();
+    execFileSync("mkfifo", [path.join(staging.workspace, "knowledge.migrating-33333333-3333-4333-8333-333333333333")]);
+    expect(() => staging.resolver.resolve(staging.cwd)).toThrow(/Unsafe/);
+
+    const marker = await fixture();
+    const markerSocket = await listenUnixSocket(path.join(marker.workspace, "knowledge.migrated.json"));
+    try {
+      expect(() => marker.resolver.resolve(marker.cwd)).toThrow(/Unsafe/);
+    } finally { await closeServer(markerSocket); }
+
+    const control = await fixture();
+    execFileSync("mkfifo", [path.join(control.workspace, "knowledge.migrated.json.interrupted")]);
+    expect(() => control.resolver.resolve(control.cwd)).toThrow(/Unsafe/);
+  });
+
+  it.skipIf(process.platform === "win32" || !fs.existsSync("/dev/null"))("classifies an existing character device as unsafe without privileges", () => {
+    const device = fs.lstatSync("/dev/null");
+    expect(device.isCharacterDevice()).toBe(true);
+    expect(classifyWikiWorkspaceNodeForTest(device)).toBe("unsafe");
+  });
+});
+
+async function listenUnixSocket(socketPath: string): Promise<net.Server> {
+  const server = net.createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => resolve());
+  });
+  return server;
+}
+
+async function closeServer(server: net.Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+}

--- a/packages/fleet-wiki/tests/wiki-workspace-resolver.test.ts
+++ b/packages/fleet-wiki/tests/wiki-workspace-resolver.test.ts
@@ -10,6 +10,7 @@ import {
   createWikiWorkspaceResolver,
   createWikiWorkspaceResolverForTest,
   classifyWikiWorkspaceNodeForTest,
+  shouldSyncDirectoryForTest,
   type WikiWorkspaceResolverDependencies,
 } from "../src/workspace-resolver.js";
 
@@ -69,9 +70,12 @@ describe("createWikiWorkspaceResolver", () => {
     await mkdir(path.join(cwd, ".fleet", "knowledge"), { recursive: true });
     await writeFile(path.join(workspace, "knowledge"), "already durable");
     await writeFile(path.join(workspace, "knowledge.migrated.json"), "not json");
+    const temporary = path.join(workspace, "knowledge.migrated.json.33333333-3333-4333-8333-333333333333.tmp");
+    await writeFile(temporary, "interrupted marker write");
     await symlink(path.join(cwd, "missing"), path.join(workspace, "knowledge.migrating-not-a-uuid"));
     expect(resolver.resolve(cwd)).toMatchObject({ root: path.join(workspace, "knowledge") });
     await expect(readFile(path.join(workspace, "knowledge"), "utf8")).resolves.toBe("already durable");
+    await expect(readFile(temporary, "utf8")).resolves.toBe("interrupted marker write");
   });
 
   it("recovers only a marker-referenced staged copy and never re-copies after marker recovery", async () => {
@@ -110,6 +114,34 @@ describe("createWikiWorkspaceResolver", () => {
     const marker = await fixture();
     await symlink(path.join(marker.cwd, "missing"), path.join(marker.workspace, "knowledge.migrated.json"));
     expect(() => marker.resolver.resolve(marker.cwd)).toThrow(/Unsafe/);
+  });
+
+  it("removes only exact regular marker-write residue before retrying the migration", async () => {
+    const { cwd, workspace, resolver } = await fixture();
+    const sourceFile = path.join(cwd, ".fleet", "knowledge", "wiki", "entry.md");
+    const temporary = path.join(workspace, "knowledge.migrated.json.44444444-4444-4444-8444-444444444444.tmp");
+    await mkdir(path.dirname(sourceFile), { recursive: true });
+    await writeFile(sourceFile, "legacy\n");
+    await writeFile(temporary, "interrupted marker write");
+
+    const paths = resolver.resolve(cwd);
+    await expect(readFile(path.join(paths.wikiDir, "entry.md"), "utf8")).resolves.toBe("legacy\n");
+    await expect(readFile(temporary, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(sourceFile, "utf8")).resolves.toBe("legacy\n");
+  });
+
+  it("fails closed for malformed or unsafe marker temp controls", async () => {
+    const malformed = await fixture();
+    await writeFile(path.join(malformed.workspace, "knowledge.migrated.json.not-a-uuid.tmp"), "not resolver-owned");
+    expect(() => malformed.resolver.resolve(malformed.cwd)).toThrow(/Unsafe/);
+
+    const symlinked = await fixture();
+    await symlink(path.join(symlinked.cwd, "missing"), path.join(symlinked.workspace, "knowledge.migrated.json.55555555-5555-4555-8555-555555555555.tmp"));
+    expect(() => symlinked.resolver.resolve(symlinked.cwd)).toThrow(/Unsafe/);
+
+    const directory = await fixture();
+    await mkdir(path.join(directory.workspace, "knowledge.migrated.json.66666666-6666-4666-8666-666666666666.tmp"));
+    expect(() => directory.resolver.resolve(directory.cwd)).toThrow(/Unsafe/);
   });
 
   it("fails closed when destination content appears after staging", async () => {
@@ -180,7 +212,7 @@ describe("createWikiWorkspaceResolver", () => {
     } finally { await closeServer(markerSocket); }
 
     const control = await fixture();
-    execFileSync("mkfifo", [path.join(control.workspace, "knowledge.migrated.json.interrupted")]);
+    execFileSync("mkfifo", [path.join(control.workspace, "knowledge.migrated.json.77777777-7777-4777-8777-777777777777.tmp")]);
     expect(() => control.resolver.resolve(control.cwd)).toThrow(/Unsafe/);
   });
 
@@ -188,6 +220,12 @@ describe("createWikiWorkspaceResolver", () => {
     const device = fs.lstatSync("/dev/null");
     expect(device.isCharacterDevice()).toBe(true);
     expect(classifyWikiWorkspaceNodeForTest(device)).toBe("unsafe");
+  });
+
+  it("skips directory fsync only on Windows", () => {
+    expect(shouldSyncDirectoryForTest("win32")).toBe(false);
+    expect(shouldSyncDirectoryForTest("darwin")).toBe(true);
+    expect(shouldSyncDirectoryForTest("linux")).toBe(true);
   });
 });
 

--- a/runtime/fleet-cli/src/app.ts
+++ b/runtime/fleet-cli/src/app.ts
@@ -125,7 +125,7 @@ export async function runApp(options: RunAppOptions = {}): Promise<void> {
         onCleanup: (cleanup) => agentCliCleanupCallbacks.add(cleanup),
         withMarketplaceLock: withFleetMarketplaceLock,
       }),
-    loadedCounts: discoverMissionControlCounts({ invocationCwd }),
+    loadedCounts: discoverMissionControlCounts({ dataDir: runtime.dataDir, invocationCwd }),
     onExitFleet: () => stop(),
     onRenderRequest: () => {
       ptyManager?.requestResize("programmatic");

--- a/runtime/fleet-cli/src/mission-control/loaded-counts.ts
+++ b/runtime/fleet-cli/src/mission-control/loaded-counts.ts
@@ -1,8 +1,9 @@
-import { existsSync, readdirSync, statSync, type Dirent } from "node:fs";
+import { lstatSync, readdirSync, type Dirent } from "node:fs";
 import { join } from "node:path";
 
+import { findWorkspaceDirectory } from "@dotobokuri/core-infra";
 import { DEFAULT_CARRIER_COUNT } from "@dotobokuri/fleet-carriers";
-import { resolveMemoryPaths } from "@dotobokuri/fleet-wiki";
+import { createMemoryPaths } from "@dotobokuri/fleet-wiki";
 
 export interface MissionControlCounts {
   readonly carriers: number;
@@ -11,6 +12,7 @@ export interface MissionControlCounts {
 }
 
 export interface DiscoverMissionControlCountsOptions {
+  readonly dataDir: string;
   readonly invocationCwd: string;
 }
 
@@ -18,7 +20,10 @@ const WIKI_INDEX_FILENAME = "index.md";
 const QUEUE_PATCH_FILENAME = "patch.md";
 
 export function discoverMissionControlCounts(options: DiscoverMissionControlCountsOptions): MissionControlCounts {
-  const paths = resolveMemoryPaths(options.invocationCwd);
+  const workspace = findExistingWorkspace(options);
+  if (!workspace) return emptyCounts();
+  const paths = createMemoryPaths(join(workspace.path, "knowledge"));
+  if (!isSafeDirectory(paths.root)) return emptyCounts();
   return {
     carriers: DEFAULT_CARRIER_COUNT,
     queuedPatches: countQueuedPatches(paths.queueDir),
@@ -26,7 +31,20 @@ export function discoverMissionControlCounts(options: DiscoverMissionControlCoun
   };
 }
 
+function findExistingWorkspace(options: DiscoverMissionControlCountsOptions) {
+  try {
+    return findWorkspaceDirectory(options.dataDir, options.invocationCwd);
+  } catch {
+    return null;
+  }
+}
+
+function emptyCounts(): MissionControlCounts {
+  return { carriers: DEFAULT_CARRIER_COUNT, queuedPatches: 0, wikiEntries: 0 };
+}
+
 function countQueuedPatches(queueDir: string): number {
+  if (!isSafeDirectory(queueDir)) return 0;
   let entries: Dirent[];
   try {
     entries = readdirSync(queueDir, { withFileTypes: true });
@@ -39,7 +57,7 @@ function countQueuedPatches(queueDir: string): number {
       continue;
     }
     const patchPath = join(queueDir, entry.name, QUEUE_PATCH_FILENAME);
-    if (existsSync(patchPath) && statSync(patchPath).isFile()) {
+    if (isSafeFile(patchPath)) {
       count += 1;
     }
   }
@@ -47,6 +65,7 @@ function countQueuedPatches(queueDir: string): number {
 }
 
 function countMarkdownFilesRecursively(dir: string, isWikiRoot: boolean): number {
+  if (!isSafeDirectory(dir)) return 0;
   let count = 0;
   let entries: Dirent[];
   try {
@@ -69,4 +88,22 @@ function countMarkdownFilesRecursively(dir: string, isWikiRoot: boolean): number
     count += 1;
   }
   return count;
+}
+
+function isSafeDirectory(target: string): boolean {
+  try {
+    const stat = lstatSync(target);
+    return stat.isDirectory() && !stat.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+function isSafeFile(target: string): boolean {
+  try {
+    const stat = lstatSync(target);
+    return stat.isFile() && !stat.isSymbolicLink();
+  } catch {
+    return false;
+  }
 }

--- a/runtime/fleet-cli/src/runtime/runtime.ts
+++ b/runtime/fleet-cli/src/runtime/runtime.ts
@@ -1,12 +1,14 @@
+import path from "node:path";
+
 import type { ExecutorSessionManager, McpToolRegistry } from "@dotobokuri/core-agent";
 import {
 	createFleetAgentRuntimeLifecycle,
 	type FleetAgentRuntimeLifecycle,
 } from "@dotobokuri/fleet-admiral";
 import type { CarrierRuntime } from "@dotobokuri/fleet-carriers";
-import { createInfraServices, type InfraServices } from "@dotobokuri/core-infra";
+import { createInfraServices, ensureWorkspaceDirectory, withDirectoryLock, type InfraServices } from "@dotobokuri/core-infra";
 import { getFleetDataDir } from "@dotobokuri/core-infra/data-dir";
-import { getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
+import { createWikiWorkspaceResolver, getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
 import { getPlanToolSpecs } from "@dotobokuri/fleet-plans";
 
 import { reconcileRuntimeState } from "./reconciliation.js";
@@ -62,6 +64,13 @@ async function startRuntime(deps: FleetRuntimeLifecycleDeps): Promise<StartedRun
 	const dataDir = deps.dataDir ?? getFleetDataDir();
 	const infraServices = createInfraServices();
 	const planTools = getPlanToolSpecs({ dataDir });
+	const wikiWorkspaceResolver = createWikiWorkspaceResolver({
+		ensureWorkspace: (cwd) => ensureWorkspaceDirectory(dataDir, cwd),
+		withMigrationLock: (workspace, operation) => withDirectoryLock(
+			{ lockDir: path.join(workspace.path, "knowledge.migration.lock") },
+			operation,
+		),
+	});
 	const agentRuntime = createFleetAgentRuntimeLifecycle({
 		...(deps.dataDir ? { dataDir: deps.dataDir } : {}),
 		authService: infraServices.authService,
@@ -70,7 +79,7 @@ async function startRuntime(deps: FleetRuntimeLifecycleDeps): Promise<StartedRun
 			console.error("[fleet-cli] Failed to start MCP server", error);
 		},
 		workspaceChangeScanner: createWorkspaceChangeScanner(),
-		wikiToolSpecs: getWikiToolSpecs(),
+		wikiToolSpecs: getWikiToolSpecs(wikiWorkspaceResolver),
 		extraAgentTools: [planTools.read, planTools.verify],
 		extraExecutorTools: [
 			{ spec: planTools.write, options: { allowedScopes: [] } },

--- a/runtime/fleet-cli/tests/agent-wiki-mcp.test.ts
+++ b/runtime/fleet-cli/tests/agent-wiki-mcp.test.ts
@@ -13,6 +13,8 @@ import {
   executorMcpRuntimeProviderRuntime,
   executorPortRuntime,
 } from "@dotobokuri/core-agent";
+import { ensureWorkspaceDirectory } from "@dotobokuri/core-infra";
+import { getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
 import { createFleetRuntimeLifecycle, type FleetRuntimeLifecycle } from "../src/runtime/runtime.js";
 
 interface McpToolListResponse {
@@ -92,6 +94,11 @@ describe("fleet-cli agent CLI MCP registration", () => {
     for (const toolId of EXPECTED_HOST_PLAN_TOOL_IDS) {
       expect(fleetToolNames.has(toolId)).toBe(true);
     }
+    expect(
+      runtime.mcpRegistry[0]!.getAllAgentTools()
+        .filter((spec) => EXPECTED_WIKI_TOOL_IDS.includes(spec.id as typeof EXPECTED_WIKI_TOOL_IDS[number]))
+        .map((spec) => ({ id: spec.id, parameters: spec.parameters })),
+    ).toEqual(getWikiToolSpecs().map((spec) => ({ id: spec.id, parameters: spec.parameters })));
     expect(fleetToolNames.size).toBe(
       EXPECTED_CARRIER_TOOL_IDS.length + EXPECTED_WIKI_TOOL_IDS.length + EXPECTED_HOST_PLAN_TOOL_IDS.length,
     );
@@ -148,6 +155,34 @@ describe("fleet-cli agent CLI MCP registration", () => {
     expect(systemPrompt).toContain('<fleet section="standing-orders"');
     expect(systemPrompt).not.toContain('<fleet section="tool-guide"');
     expect(roughTokens).toBeLessThanOrEqual(8_500);
+  });
+
+  it("migrates root legacy Wiki knowledge into the runtime data directory on first tool use", async () => {
+    const dataDir = mkdtempSync(path.join(os.tmpdir(), "fleet-wiki-data-"));
+    const invocationCwd = mkdtempSync(path.join(os.tmpdir(), "fleet-wiki-project-"));
+    try {
+      mkdirSync(path.join(invocationCwd, ".fleet", "knowledge", "wiki"), { recursive: true });
+      writeFileSync(
+        path.join(invocationCwd, ".fleet", "knowledge", "wiki", "legacy.md"),
+        "---\nid: legacy\ntitle: Legacy\n---\nDurable legacy knowledge.\n",
+        { encoding: "utf8" },
+      );
+      lifecycle = createFleetRuntimeLifecycle({ dataDir });
+      const runtime = await lifecycle.start();
+
+      const result = await runtime.mcpRegistry[0]!.invoke("wiki_orient", {}, { cwd: invocationCwd });
+      const workspace = ensureWorkspaceDirectory(dataDir, invocationCwd);
+      const destinationEntry = path.join(workspace.path, "knowledge", "wiki", "legacy.md");
+
+      expect(result.isError).toBe(false);
+      expect(readFileSync(destinationEntry, "utf8")).toContain("Durable legacy knowledge.");
+      expect(existsSync(path.join(workspace.path, "knowledge.migrated.json"))).toBe(true);
+      expect(readFileSync(path.join(invocationCwd, ".fleet", "knowledge", "wiki", "legacy.md"), "utf8"))
+        .toContain("Durable legacy knowledge.");
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+      rmSync(invocationCwd, { recursive: true, force: true });
+    }
   });
 
   it("injects rendered plugin paths, child env, Claude agents, and cleanup", async () => {

--- a/runtime/fleet-cli/tests/loaded-counts.test.ts
+++ b/runtime/fleet-cli/tests/loaded-counts.test.ts
@@ -1,0 +1,88 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ensureWorkspaceDirectory } from "@dotobokuri/core-infra";
+import { discoverMissionControlCounts } from "../src/mission-control/loaded-counts.js";
+
+const temporaryPaths: string[] = [];
+
+describe("discoverMissionControlCounts", () => {
+  afterEach(() => {
+    for (const temporaryPath of temporaryPaths.splice(0)) {
+      rmSync(temporaryPath, { recursive: true, force: true });
+    }
+  });
+
+  it("returns zero Wiki counts for a missing workspace without creating durable storage", () => {
+    const invocationCwd = temporaryDirectory("fleet-count-project-");
+    const dataParent = temporaryDirectory("fleet-count-parent-");
+    const dataDir = path.join(dataParent, "data");
+
+    expect(discoverMissionControlCounts({ dataDir, invocationCwd })).toEqual({
+      carriers: 8,
+      queuedPatches: 0,
+      wikiEntries: 0,
+    });
+    expect(existsSync(dataDir)).toBe(false);
+    expect(existsSync(path.join(invocationCwd, ".fleet", "knowledge"))).toBe(false);
+  });
+
+  it("counts only populated workspace-backed Wiki knowledge", () => {
+    const invocationCwd = temporaryDirectory("fleet-count-project-");
+    const dataDir = temporaryDirectory("fleet-count-data-");
+    const workspace = ensureWorkspaceDirectory(dataDir, invocationCwd);
+    writeFile(path.join(workspace.path, "knowledge", "wiki", "index.md"), "# Index\n");
+    writeFile(path.join(workspace.path, "knowledge", "wiki", "entry.md"), "# Entry\n");
+    writeFile(path.join(workspace.path, "knowledge", "wiki", "nested", "child.md"), "# Child\n");
+    writeFile(path.join(workspace.path, "knowledge", "queue", "pending", "patch.md"), "# Patch\n");
+    writeFile(path.join(workspace.path, "knowledge", "queue", "_sets", "ignored", "patch.md"), "# Ignored\n");
+
+    expect(discoverMissionControlCounts({ dataDir, invocationCwd })).toEqual({
+      carriers: 8,
+      queuedPatches: 1,
+      wikiEntries: 2,
+    });
+  });
+
+  it("fails closed for an unsafe workspace Wiki destination", () => {
+    const invocationCwd = temporaryDirectory("fleet-count-project-");
+    const dataDir = temporaryDirectory("fleet-count-data-");
+    const outside = temporaryDirectory("fleet-count-outside-");
+    const workspace = ensureWorkspaceDirectory(dataDir, invocationCwd);
+    writeFile(path.join(outside, "wiki", "entry.md"), "# Outside\n");
+    rmSync(path.join(workspace.path, "knowledge"), { recursive: true, force: true });
+    symlinkSync(outside, path.join(workspace.path, "knowledge"));
+
+    expect(discoverMissionControlCounts({ dataDir, invocationCwd })).toEqual({
+      carriers: 8,
+      queuedPatches: 0,
+      wikiEntries: 0,
+    });
+  });
+
+  it("ignores root legacy knowledge before the first Wiki tool use", () => {
+    const invocationCwd = temporaryDirectory("fleet-count-project-");
+    const dataDir = temporaryDirectory("fleet-count-data-");
+    writeFile(path.join(invocationCwd, ".fleet", "knowledge", "wiki", "legacy.md"), "# Legacy\n");
+
+    expect(discoverMissionControlCounts({ dataDir, invocationCwd })).toEqual({
+      carriers: 8,
+      queuedPatches: 0,
+      wikiEntries: 0,
+    });
+    expect(existsSync(path.join(dataDir, "workspaces"))).toBe(false);
+  });
+});
+
+function temporaryDirectory(prefix: string): string {
+  const directory = mkdtempSync(path.join(os.tmpdir(), prefix));
+  temporaryPaths.push(directory);
+  return directory;
+}
+
+function writeFile(target: string, contents: string): void {
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, contents, { encoding: "utf8" });
+}

--- a/runtime/fleet-console/core/client/src/rail/codex-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/codex-panel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import type { RailPanelDescriptor, RailPathContext } from "@fleet-console/sdk/rail";
+import type { RailPanelDescriptor } from "@fleet-console/sdk/rail";
 
 import { useConsoleState } from "../hooks/use-store.js";
 import {
@@ -28,13 +28,13 @@ export const codexPanel: RailPanelDescriptor = {
   id: "codex",
   title: "Codex",
   icon: () => <CodexIcon />,
-  pathAware: true,
-  render: (ctx) => <CodexRailPanel theaterId={ctx.theaterId} pathContext={ctx.pathContext} />,
+  pathAware: false,
+  render: (ctx) => <CodexRailPanel theaterId={ctx.theaterId} />,
 };
 
 // ─── Components ───────────────────────────────────────────────────────────────
 
-function CodexRailPanel({ theaterId, pathContext }: { readonly theaterId: string | null; readonly pathContext: RailPathContext }) {
+function CodexRailPanel({ theaterId }: { readonly theaterId: string | null }) {
   const state = useConsoleState();
   const navRef = useRef<HTMLDivElement>(null);
   const readRef = useRef<HTMLDivElement>(null);
@@ -47,7 +47,7 @@ function CodexRailPanel({ theaterId, pathContext }: { readonly theaterId: string
   const expanded = state.codexReaderExpanded;
   const activeTheater = state.theaters.find((t) => t.id === state.activeTheaterId) ?? null;
   const hasTheaters = state.theaters.length > 0;
-  const contextKey = `${theaterId ?? ""}\u0000${pathContext.relPath ?? ""}`;
+  const contextKey = theaterId ?? "";
   const workspaceId = workspace?.contextKey === contextKey && workspace.hasWiki ? workspace.id : null;
   const shouldMountCodex = workspaceId !== null;
 
@@ -61,7 +61,7 @@ function CodexRailPanel({ theaterId, pathContext }: { readonly theaterId: string
       }`
     : null;
 
-  // 컨텍스트 변경 시 이전 reader가 새 workspace에서 잠시 보이지 않도록 먼저 닫는다.
+  // Theater 변경 시 이전 reader가 새 workspace에서 잠시 보이지 않도록 먼저 닫는다.
   useEffect(() => {
     latestContextKeyRef.current = contextKey;
     closeCodexReader();
@@ -69,16 +69,16 @@ function CodexRailPanel({ theaterId, pathContext }: { readonly theaterId: string
       setWorkspace({ contextKey, hasWiki: false, id: null });
       return;
     }
-    void resolveCodexWorkspace(theaterId, pathContext.relPath).then((result) => {
+    void resolveCodexWorkspace(theaterId).then((result) => {
       if (latestContextKeyRef.current !== contextKey) return;
       setWorkspace({ contextKey, ...result });
     }).catch(() => {
       if (latestContextKeyRef.current !== contextKey) return;
       setWorkspace({ contextKey, hasWiki: false, id: null });
     });
-  }, [contextKey, pathContext.relPath, theaterId]);
+  }, [contextKey, theaterId]);
 
-  // 위키 없음이 확정된 경우에만 singleton을 정리한다. 다음 context를 해석하는 동안에는
+  // 위키 없음이 확정된 경우에만 singleton을 정리한다. 다음 Theater를 해석하는 동안에는
   // destroy+remount하지 않고, 기존 host를 새 navigator 컨테이너로 relocate한다.
   useEffect(() => {
     if (workspace?.contextKey === contextKey && !workspace.hasWiki) teardownCodex();
@@ -102,7 +102,7 @@ function CodexRailPanel({ theaterId, pathContext }: { readonly theaterId: string
     };
   }, [shouldMountCodex, workspaceId, hasReader]);
 
-  // context 해석으로 결정된 workspace 전환 시 navigator 데이터 소스를 바꾼다.
+  // Theater 해석으로 결정된 workspace 전환 시 navigator 데이터 소스를 바꾼다.
   useEffect(() => {
     if (shouldMountCodex && workspaceId) {
       setNavigatorTheater(workspaceId);
@@ -136,7 +136,7 @@ function CodexRailPanel({ theaterId, pathContext }: { readonly theaterId: string
   }, [hasReader]);
 
   if (!shouldMountCodex) {
-    return <CodexEmpty activeTheater={activeTheater} contextLabel={pathContext.label} hasTheaters={hasTheaters} />;
+    return <CodexEmpty activeTheater={activeTheater} hasTheaters={hasTheaters} />;
   }
 
   if (!hasReader) {
@@ -175,11 +175,9 @@ function CodexRailPanel({ theaterId, pathContext }: { readonly theaterId: string
 
 function CodexEmpty({
   activeTheater,
-  contextLabel,
   hasTheaters,
 }: {
   readonly activeTheater: { readonly label: string } | null;
-  readonly contextLabel: string;
   readonly hasTheaters: boolean;
 }) {
   if (!hasTheaters) {
@@ -194,17 +192,17 @@ function CodexEmpty({
   return (
     <section className="codex-empty-state">
       <p className="codex-empty-eyebrow">Codex unavailable</p>
-      <h1>{contextLabel || activeTheater?.label || "This context"}</h1>
-      <p>This selected context does not have Fleet Wiki data mounted.</p>
+      <h1>{activeTheater?.label || "This Theater"}</h1>
+      <p>Fleet Wiki data could not be loaded for this Theater.</p>
     </section>
   );
 }
 
-async function resolveCodexWorkspace(theaterId: string, relPath: string | null): Promise<Omit<CodexWorkspaceState, "contextKey">> {
+async function resolveCodexWorkspace(theaterId: string): Promise<Omit<CodexWorkspaceState, "contextKey">> {
   const response = await fetch(`/api/v1/theaters/${encodeURIComponent(theaterId)}/codex-workspace`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ relPath }),
+    body: JSON.stringify({}),
   });
   if (!response.ok) throw new Error("codex_workspace_unavailable");
   return assertCodexWorkspace(await response.json());

--- a/runtime/fleet-console/core/host/codex/context-routes.ts
+++ b/runtime/fleet-console/core/host/codex/context-routes.ts
@@ -1,6 +1,5 @@
 import type http from "node:http";
 
-import { TheaterPathContextError } from "../theater-path-context.js";
 import type { TheaterRegistration } from "../theaters.js";
 import type { CodexWorkspaceResolution } from "./gateway.js";
 
@@ -10,7 +9,7 @@ export interface CodexWorkspaceContextRouteDeps {
   readonly getTheater: (theaterId: string) => TheaterRegistration | null;
   readonly isAuthorized: (req: http.IncomingMessage) => boolean;
   readonly readJsonBody: <T>(req: http.IncomingMessage) => Promise<T | null>;
-  readonly resolveWorkspace: (theaterId: string, theaterRoot: string, relPath: string | null) => Promise<CodexWorkspaceResolution>;
+  readonly resolveWorkspace: (theaterId: string, theaterRoot: string) => Promise<CodexWorkspaceResolution>;
   readonly writeJson: (res: http.ServerResponse, status: number, body: unknown) => void;
 }
 
@@ -18,10 +17,6 @@ export interface CodexWorkspaceContextRouteContext {
   readonly req: http.IncomingMessage;
   readonly res: http.ServerResponse;
   readonly pathname: string;
-}
-
-interface ResolveWorkspaceBody {
-  readonly relPath?: unknown;
 }
 
 // ─── functions ─────────────────────────────────────────────────────────────
@@ -45,29 +40,23 @@ export function createCodexWorkspaceContextRouter(
       deps.writeJson(res, 401, { error: "unauthorized" });
       return true;
     }
-    const body = await deps.readJsonBody<ResolveWorkspaceBody>(req);
+    const body = await deps.readJsonBody<unknown>(req);
     if (!isResolveWorkspaceBody(body)) {
       deps.writeJson(res, 400, { error: "invalid_request" });
       return true;
     }
     try {
-      deps.writeJson(res, 200, await deps.resolveWorkspace(theater.id, theater.realpath, body.relPath));
+      deps.writeJson(res, 200, await deps.resolveWorkspace(theater.id, theater.realpath));
     } catch (error) {
-      writePathError(res, deps, error);
+      deps.writeJson(res, 500, { error: "internal_error" });
     }
     return true;
   };
 }
 
-function isResolveWorkspaceBody(value: ResolveWorkspaceBody | null): value is ResolveWorkspaceBody & { readonly relPath: string | null } {
+function isResolveWorkspaceBody(value: unknown): value is Record<string, never> {
   return typeof value === "object"
     && value !== null
-    && Object.keys(value).length === 1
-    && (value.relPath === null || typeof value.relPath === "string");
-}
-
-function writePathError(res: http.ServerResponse, deps: CodexWorkspaceContextRouteDeps, error: unknown): void {
-  if (!(error instanceof TheaterPathContextError)) throw error;
-  const status = error.code === "not_found" ? 404 : error.code === "forbidden" ? 403 : 400;
-  deps.writeJson(res, status, { error: error.code });
+    && !Array.isArray(value)
+    && Object.keys(value).length === 0;
 }

--- a/runtime/fleet-console/core/host/codex/gateway.ts
+++ b/runtime/fleet-console/core/host/codex/gateway.ts
@@ -3,18 +3,20 @@ import os from "node:os";
 import type { NetworkInterfaceInfo } from "node:os";
 import net from "node:net";
 
+import type { MemoryPaths, WikiWorkspaceResolver } from "@dotobokuri/fleet-wiki";
+
 import { handleApiRequest } from "./routes.js";
 import type { AllowedAccessSets } from "./types.js";
 import { WorkspaceRegistry } from "./workspaces.js";
 import type { WorkspaceRegistration } from "./workspaces.js";
 import { withSecurityHeaders } from "../security-headers.js";
-import { resolveTheaterPathContext } from "../theater-path-context.js";
 
 interface CodexGatewayDeps {
   readonly cwd: string;
   readonly host: string;
   readonly version: string;
   readonly getPort: () => number;
+  readonly wikiWorkspaceResolver: WikiWorkspaceResolver;
 }
 
 interface ParsedHostHeader {
@@ -36,7 +38,7 @@ export interface CodexGateway {
   handle(request: IncomingMessage, response: ServerResponse): Promise<boolean>;
   listWorkspaceRegistrations(): readonly WorkspaceRegistration[];
   registerWorkspace(cwd: string, lastOpenedAt?: string, ownerTheaterId?: string): Promise<WorkspaceRegistration>;
-  resolveWorkspaceForPath(theaterId: string, theaterRoot: string, relPath: string | null): Promise<CodexWorkspaceResolution>;
+  resolveWorkspaceForTheater(theaterId: string, theaterRoot: string): Promise<CodexWorkspaceResolution>;
   unregisterTheaterWorkspaces(theaterId: string): void;
 }
 
@@ -99,10 +101,17 @@ export function createCodexGateway(deps: CodexGatewayDeps): CodexGateway {
     const workspace = selected.workspace ?? await ensureInitialWorkspace();
     const originalUrl = request.url;
     if (selected.rewrittenUrl) request.url = selected.rewrittenUrl;
+    let paths: MemoryPaths;
+    try {
+      paths = deps.wikiWorkspaceResolver.resolve(workspace.realpath);
+    } catch {
+      sendJson(response, 500, { error: "internal_error" });
+      return true;
+    }
     const handled = await handleApiRequest(request, response, {
       cwd: workspace.cwd,
-      knowledgeRoot: workspace.paths.root,
-      paths: workspace.paths,
+      knowledgeRoot: paths.root,
+      paths,
       host: deps.host,
       port,
       workspaceId: workspace.id,
@@ -134,21 +143,13 @@ export function createCodexGateway(deps: CodexGatewayDeps): CodexGateway {
     return workspace;
   }
 
-  async function resolveWorkspaceForPath(
+  async function resolveWorkspaceForTheater(
     theaterId: string,
     theaterRoot: string,
-    relPath: string | null,
   ): Promise<CodexWorkspaceResolution> {
-    const pathContext = await resolveTheaterPathContext(theaterRoot, relPath);
-    try {
-      const workspace = await registerWorkspace(pathContext.realPath, undefined, theaterId);
-      return { hasWiki: true, id: workspace.id };
-    } catch (error) {
-      if (error instanceof Error && error.message === "knowledge_root_missing") {
-        return { hasWiki: false, id: null };
-      }
-      throw error;
-    }
+    const workspace = await registerWorkspace(theaterRoot, undefined, theaterId);
+    deps.wikiWorkspaceResolver.resolve(workspace.realpath);
+    return { hasWiki: true, id: workspace.id };
   }
 
   function unregisterWorkspace(id: string): boolean {
@@ -176,7 +177,7 @@ export function createCodexGateway(deps: CodexGatewayDeps): CodexGateway {
     handle,
     listWorkspaceRegistrations: () => workspaces.listRegistrations(),
     registerWorkspace,
-    resolveWorkspaceForPath,
+    resolveWorkspaceForTheater,
     unregisterTheaterWorkspaces,
   };
 }

--- a/runtime/fleet-console/core/host/codex/workspaces.ts
+++ b/runtime/fleet-console/core/host/codex/workspaces.ts
@@ -1,8 +1,4 @@
-import { stat } from "node:fs/promises";
 import path from "node:path";
-
-import { resolveMemoryPaths as resolveFleetWikiMemoryPaths } from "@dotobokuri/fleet-wiki";
-import type { MemoryPaths } from "@dotobokuri/fleet-wiki";
 
 import type { WorkspaceMetadata } from "./api-types.js";
 import { canonicalizeTheaterPath, workspaceHash } from "../theater.js";
@@ -12,7 +8,6 @@ export interface WorkspaceRegistration {
   cwd: string;
   realpath: string;
   label: string;
-  paths: MemoryPaths;
   registeredAt: string;
   lastOpenedAt: string;
 }
@@ -24,10 +19,6 @@ export class WorkspaceRegistry {
   async register(cwdInput: string, lastOpenedAt?: string): Promise<WorkspaceRegistration> {
     const cwd = path.resolve(cwdInput);
     const real = await canonicalizeTheaterPath(cwd);
-    const paths = resolveFleetWikiMemoryPaths(real);
-    if (!(await directoryExists(paths.root))) {
-      throw new Error("knowledge_root_missing");
-    }
     const id = workspaceHash(real);
     const now = new Date().toISOString();
     const existing = this.#items.get(id);
@@ -39,7 +30,6 @@ export class WorkspaceRegistry {
       cwd,
       realpath: real,
       label: path.basename(cwd),
-      paths,
       registeredAt: existing?.registeredAt ?? now,
       // 복원 경로는 durable lastOpenedAt을 그대로 보존해 재시작 후에도 워크스페이스 최근성
       // 순서(MRU·listRegistrations 동순위 처리)가 durable 상태와 일치하게 한다. 일반 등록은 now.
@@ -86,12 +76,4 @@ export function toMetadata(item: WorkspaceRegistration): WorkspaceMetadata {
     lastOpenedAt: item.lastOpenedAt,
     urlPath: `/console/codex/w/${encodeURIComponent(item.id)}/`,
   };
-}
-
-async function directoryExists(dirPath: string): Promise<boolean> {
-  try {
-    return (await stat(dirPath)).isDirectory();
-  } catch {
-    return false;
-  }
 }

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -3,7 +3,8 @@ import fs from "node:fs";
 import http from "node:http";
 import path from "node:path";
 
-import { createInfraServices, getFleetDataDir } from "@dotobokuri/core-infra";
+import { createInfraServices, ensureWorkspaceDirectory, getFleetDataDir, withDirectoryLock } from "@dotobokuri/core-infra";
+import { createWikiWorkspaceResolver } from "@dotobokuri/fleet-wiki";
 
 import { buildApiCatalog, type ApiCatalogEntry } from "./api-catalog.js";
 import type { ConsoleHealth, ConsoleObserverStatus, ConsoleTheaterFolderListResponse, ConsoleTheaterInfo, ConsoleUpdateApplyAcceptedResponse, ConsoleUpdateApplyError } from "./api-types.js";
@@ -290,11 +291,21 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   const durablePaths = createConsoleDataPaths({ fleetDataDir: deps.dataDir });
   const durableStateStore = createConsoleDurableStateStore({ paths: durablePaths });
   const consoleSettingsStore = createConsoleSettingsStore({ paths: durablePaths });
+  const wikiWorkspaceResolver = createWikiWorkspaceResolver({
+    ensureWorkspace: (cwd) => {
+      const workspace = ensureWorkspaceDirectory(fleetDataDir, cwd);
+      return { cwd: workspace.cwd, path: workspace.path };
+    },
+    withMigrationLock: (workspace, operation) => withDirectoryLock({
+      lockDir: path.join(workspace.path, "knowledge.migration.lock"),
+    }, operation),
+  });
   const codex = createCodexGateway({
     cwd: deps.codexCwd ?? process.cwd(),
     host,
     version,
     getPort: () => lockHandle?.payload.port ?? port,
+    wikiWorkspaceResolver,
   });
   const routeRegistry = new RouteRegistry();
   const upgradeRegistry = new UpgradeRegistry();
@@ -525,7 +536,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     getTheater: (theaterId) => theaters.get(theaterId),
     isAuthorized: isTerminalAuthorized,
     readJsonBody,
-    resolveWorkspace: (theaterId, theaterRoot, relPath) => codex.resolveWorkspaceForPath(theaterId, theaterRoot, relPath),
+    resolveWorkspace: (theaterId, theaterRoot) => codex.resolveWorkspaceForTheater(theaterId, theaterRoot),
     writeJson,
   });
   const operationsRouter = createOperationsRouter({
@@ -778,17 +789,9 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       return;
     }
     const theater = await theaters.register(cwd);
-    let hasWiki = false;
-    try {
-      await codex.registerWorkspace(theater.realpath, undefined, theater.id);
-      hasWiki = true;
-    } catch (error) {
-      if (!(error instanceof Error && error.message === "knowledge_root_missing")) {
-        console.warn(`[fleet-console] Codex workspace registration skipped for Theater ${theater.id}: ${error instanceof Error ? error.message : String(error)}`);
-      }
-    }
+    await codex.registerWorkspace(theater.realpath, undefined, theater.id);
     persistDurableState();
-    writeJson(res, 200, toTheaterInfo(theater, hasWiki));
+    writeJson(res, 200, toTheaterInfo(theater, true));
   }
 
   async function handleObserverTheaterItem(req: http.IncomingMessage, res: http.ServerResponse, theaterId: string): Promise<void> {
@@ -944,7 +947,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   }
 
   function listTheaterInfos(): readonly ConsoleTheaterInfo[] {
-    return theaters.list().map((theater) => toTheaterInfo(theater, codex.getWorkspace(theater.id) !== null));
+    return theaters.list().map((theater) => toTheaterInfo(theater, true));
   }
 
   function toTheaterInfo(theater: TheaterRegistration, hasWiki: boolean): ConsoleTheaterInfo {
@@ -1025,10 +1028,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       operations.replace([]);
       operations.replaceGroups([]);
     }
-    // Codex WorkspaceRegistry는 인메모리라 재시작 시 비워진다. hasWiki 판정이 이 레지스트리에
-    // 의존하므로(getWorkspace !== null), 복원된 Theater를 재등록하지 않으면 위키가 있는 Theater도
-    // hasWiki=false가 되어 Console 재실행마다 Codex(Wiki)가 마운트되지 않는다. POST 추가 경로와
-    // 대칭으로 복원 Theater의 워크스페이스를 best-effort 재등록한다.
+    // Codex WorkspaceRegistry는 인메모리이므로 durable Theater를 메타데이터만 복원한다.
     await restoreCodexWorkspaces();
   }
 
@@ -1059,14 +1059,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     // 심볼릭 타깃이 바뀐 경우 theater.id와 다른 workspaceHash로 등록되어 hasWiki 판정이 깨진다.
     const ordered = [...theaters.list()].sort((left, right) => left.lastOpenedAt.localeCompare(right.lastOpenedAt));
     for (const theater of ordered) {
-      try {
-        await codex.registerWorkspace(theater.realpath, theater.lastOpenedAt, theater.id);
-      } catch (error) {
-        // 위키 지식 루트가 없는 Theater는 Codex 미보유 상태가 정상이므로 조용히 건너뛴다.
-        if (!(error instanceof Error && error.message === "knowledge_root_missing")) {
-          console.warn(`[fleet-console] Codex workspace restore skipped for Theater ${theater.id}: ${error instanceof Error ? error.message : String(error)}`);
-        }
-      }
+      await codex.registerWorkspace(theater.realpath, theater.lastOpenedAt, theater.id);
     }
   }
 

--- a/runtime/fleet-console/tests/codex-path-context.test.ts
+++ b/runtime/fleet-console/tests/codex-path-context.test.ts
@@ -1,153 +1,97 @@
-import { mkdtemp, mkdir, realpath, rm, symlink } from "node:fs/promises";
+import { mkdtemp, mkdir, realpath, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import { createMemoryPaths } from "@dotobokuri/fleet-wiki";
+import type { MemoryPaths, WikiWorkspaceResolver } from "@dotobokuri/fleet-wiki";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createCodexWorkspaceContextRouter } from "../core/host/codex/context-routes.js";
 import { createCodexGateway } from "../core/host/codex/gateway.js";
-import { TheaterPathContextError } from "../core/host/theater-path-context.js";
 import { workspaceHash } from "../core/host/theater.js";
-
-// ─── constants ─────────────────────────────────────────────────────────────
 
 const WORKSPACE_ID = "0123456789ab";
 
-// ─── helpers ───────────────────────────────────────────────────────────────
-
-async function createKnowledgeRoot(dir: string): Promise<void> {
-  await mkdir(path.join(dir, ".fleet", "knowledge", "wiki"), { recursive: true });
-}
-
-function createGateway() {
-  return createCodexGateway({
-    cwd: process.cwd(),
-    host: "127.0.0.1",
-    version: "0.0.0",
-    getPort: () => 0,
-  });
-}
-
-// ─── tests ─────────────────────────────────────────────────────────────────
-
-describe("Codex workspace path-context resolution", () => {
+describe("Codex Theater-root workspace resolution", () => {
   let tmpDir = "";
   let theaterRoot = "";
+  let resolve: ReturnType<typeof vi.fn<(cwd: string) => MemoryPaths>>;
 
   beforeEach(async () => {
     tmpDir = await mkdtemp(path.join(os.tmpdir(), "fleet-codex-context-"));
     theaterRoot = path.join(tmpDir, "theater");
     await mkdir(theaterRoot);
+    resolve = vi.fn((cwd: string) => createMemoryPaths(path.join(cwd, "fleet-data", "knowledge")));
   });
 
   afterEach(async () => {
     await rm(tmpDir, { recursive: true, force: true });
   });
 
-  it("does not fall back to a Theater-root wiki when the selected directory has none", async () => {
-    const selectedDir = path.join(theaterRoot, "without-wiki");
-    await Promise.all([createKnowledgeRoot(theaterRoot), mkdir(selectedDir)]);
+  function createGateway() {
+    const wikiWorkspaceResolver: WikiWorkspaceResolver = { resolve };
+    return createCodexGateway({
+      cwd: theaterRoot,
+      host: "127.0.0.1",
+      version: "0.0.0",
+      getPort: () => 0,
+      wikiWorkspaceResolver,
+    });
+  }
 
-    const result = await createGateway().resolveWorkspaceForPath("theater", theaterRoot, "without-wiki");
-
-    expect(result).toEqual({ hasWiki: false, id: null });
-  });
-
-  it("registers a selected wiki workspace idempotently using its canonical realpath hash", async () => {
-    const selectedDir = path.join(theaterRoot, "workspace");
-    await createKnowledgeRoot(selectedDir);
+  it("registers the canonical Theater root and resolves it through the injected gate", async () => {
     const gateway = createGateway();
+    const result = await gateway.resolveWorkspaceForTheater("theater", theaterRoot);
 
-    const [first, second] = await Promise.all([
-      gateway.resolveWorkspaceForPath("theater", theaterRoot, "workspace"),
-      gateway.resolveWorkspaceForPath("theater", theaterRoot, "workspace"),
-    ]);
-
-    expect(first).toEqual({ hasWiki: true, id: workspaceHash(await realpath(selectedDir)) });
-    expect(second).toEqual(first);
+    expect(result).toEqual({ hasWiki: true, id: workspaceHash(await realpath(theaterRoot)) });
+    expect(resolve).toHaveBeenCalledWith(await realpath(theaterRoot));
     expect(gateway.listWorkspaceRegistrations()).toHaveLength(1);
   });
 
-  it("rejects absolute paths, traversal, and symlink escapes before workspace registration", async () => {
-    const outsideDir = path.join(tmpDir, "outside");
-    await mkdir(outsideDir);
-    await symlink(outsideDir, path.join(theaterRoot, "escape"));
+  it("does not create storage while registration metadata is restored", async () => {
     const gateway = createGateway();
+    await gateway.registerWorkspace(theaterRoot, "2026-07-17T00:00:00.000Z", "theater");
 
-    await expect(gateway.resolveWorkspaceForPath("theater", theaterRoot, "/tmp")).rejects.toMatchObject({ code: "invalid_path" });
-    await expect(gateway.resolveWorkspaceForPath("theater", theaterRoot, "../outside")).rejects.toMatchObject({ code: "invalid_path" });
-    await expect(gateway.resolveWorkspaceForPath("theater", theaterRoot, "escape")).rejects.toMatchObject({ code: "forbidden" });
-    expect(gateway.listWorkspaceRegistrations()).toHaveLength(0);
+    expect(resolve).not.toHaveBeenCalled();
   });
 
-  it("unregisters nested workspaces when their owner Theater is forgotten", async () => {
-    const selectedDir = path.join(theaterRoot, "workspace");
-    await createKnowledgeRoot(selectedDir);
+  it("forgets only the registered Theater-root workspace", async () => {
     const gateway = createGateway();
-    const resolved = await gateway.resolveWorkspaceForPath("theater-a", theaterRoot, "workspace");
+    const resolved = await gateway.resolveWorkspaceForTheater("theater-a", theaterRoot);
 
     gateway.unregisterTheaterWorkspaces("theater-a");
 
     expect(resolved.id).not.toBeNull();
     expect(gateway.getWorkspace(resolved.id!)).toBeNull();
   });
-
-  it("keeps a nested workspace while another Theater still owns it", async () => {
-    const selectedDir = path.join(theaterRoot, "workspace");
-    await createKnowledgeRoot(selectedDir);
-    const gateway = createGateway();
-    const first = await gateway.resolveWorkspaceForPath("theater-a", theaterRoot, "workspace");
-    const second = await gateway.resolveWorkspaceForPath("theater-b", theaterRoot, "workspace");
-
-    gateway.unregisterTheaterWorkspaces("theater-a");
-
-    expect(first).toEqual(second);
-    expect(first.id).not.toBeNull();
-    expect(gateway.getWorkspace(first.id!)).not.toBeNull();
-    gateway.unregisterTheaterWorkspaces("theater-b");
-    expect(gateway.getWorkspace(first.id!)).toBeNull();
-  });
 });
 
-describe("Codex workspace path-context route", () => {
-  it("returns only the workspace id and hasWiki after resolving the Theater context", async () => {
+describe("Codex Theater-root workspace route", () => {
+  function routerFor(body: unknown, resolveWorkspace = vi.fn().mockResolvedValue({ hasWiki: true, id: WORKSPACE_ID })) {
     const writeJson = vi.fn();
-    const resolveWorkspace = vi.fn().mockResolvedValue({ hasWiki: true, id: WORKSPACE_ID });
     const router = createCodexWorkspaceContextRouter({
       getTheater: () => ({ id: "theater", path: "/tmp/theater", realpath: "/tmp/theater", label: "theater", registeredAt: "1", lastOpenedAt: "1", pathContext: null }),
       isAuthorized: () => true,
-      readJsonBody: async <T>() => ({ relPath: "workspace" } as T),
+      readJsonBody: async <T>() => body as T,
       resolveWorkspace,
       writeJson,
     });
+    return { router, resolveWorkspace, writeJson };
+  }
 
-    await router({
-      req: { method: "POST" } as never,
-      res: {} as never,
-      pathname: "/api/v1/theaters/theater/codex-workspace",
-    });
+  it("accepts exactly an empty object and returns a path-free DTO", async () => {
+    const { router, resolveWorkspace, writeJson } = routerFor({});
+    await router({ req: { method: "POST" } as never, res: {} as never, pathname: "/api/v1/theaters/theater/codex-workspace" });
 
-    expect(resolveWorkspace).toHaveBeenCalledWith("theater", "/tmp/theater", "workspace");
+    expect(resolveWorkspace).toHaveBeenCalledWith("theater", "/tmp/theater");
     expect(writeJson).toHaveBeenLastCalledWith(expect.anything(), 200, { hasWiki: true, id: WORKSPACE_ID });
   });
 
-  it("maps common resolver containment failures without exposing a path", async () => {
-    const writeJson = vi.fn();
-    const router = createCodexWorkspaceContextRouter({
-      getTheater: () => ({ id: "theater", path: "/tmp/theater", realpath: "/tmp/theater", label: "theater", registeredAt: "1", lastOpenedAt: "1", pathContext: null }),
-      isAuthorized: () => true,
-      readJsonBody: async <T>() => ({ relPath: "escape" } as T),
-      resolveWorkspace: async () => { throw new TheaterPathContextError("forbidden"); },
-      writeJson,
-    });
+  it.each([null, [], { relPath: null }, { relPath: "nested" }, { unknown: true }])("rejects non-empty or non-object request bodies", async (body) => {
+    const { router, resolveWorkspace, writeJson } = routerFor(body);
+    await router({ req: { method: "POST" } as never, res: {} as never, pathname: "/api/v1/theaters/theater/codex-workspace" });
 
-    await router({
-      req: { method: "POST" } as never,
-      res: {} as never,
-      pathname: "/api/v1/theaters/theater/codex-workspace",
-    });
-
-    expect(writeJson).toHaveBeenLastCalledWith(expect.anything(), 403, { error: "forbidden" });
-    expect(JSON.stringify(writeJson.mock.calls)).not.toContain("/tmp/theater");
+    expect(resolveWorkspace).not.toHaveBeenCalled();
+    expect(writeJson).toHaveBeenLastCalledWith(expect.anything(), 400, { error: "invalid_request" });
   });
 });

--- a/runtime/fleet-console/tests/codex-queue-actions.test.ts
+++ b/runtime/fleet-console/tests/codex-queue-actions.test.ts
@@ -2,6 +2,7 @@ import { access, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promise
 import os from "node:os";
 import path from "node:path";
 
+import { resolveWorkspaceDirectory } from "@dotobokuri/core-infra";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { startCodexTestServer } from "./codex-test-server.js";
@@ -11,6 +12,7 @@ let server: CodexTestServer | null = null;
 let baseUrl = "";
 let serverPort = 0;
 let tempDir = "";
+let fleetDataDir = "";
 
 const PENDING_PATCH_ID = "2026-05-04T10-00-00-000Z-aabbccdd";
 const ARCHIVE_PATCH_ID = "2026-05-04T09-00-00-000Z-11223344";
@@ -42,6 +44,7 @@ describe("queue POST actions", () => {
       patchIds: [PENDING_PATCH_ID],
     }), "utf8");
     const lockPath = path.join(tempDir, "server.lock");
+    fleetDataDir = path.join(path.dirname(lockPath), "fleet-data");
     server = await startCodexTestServer({ cwd: tempDir, lockPath, port: 0, host: "127.0.0.1" });
     const lock = JSON.parse(await readFile(lockPath, "utf8")) as { port: number };
     serverPort = lock.port;
@@ -95,7 +98,7 @@ describe("queue POST actions", () => {
     expect(data.ok).toBe(true);
     expect(data.meta.status).toBe("accepted");
     // patch should now be in archive
-    const archivePath = path.join(tempDir, ".fleet", "knowledge", "archive", PENDING_PATCH_ID, "meta.json");
+    const archivePath = durableArchiveMetaPath(PENDING_PATCH_ID);
     await expect(access(archivePath)).resolves.not.toThrow();
   });
 
@@ -157,7 +160,7 @@ describe("queue POST actions", () => {
     const data = await response.json() as { ok: boolean; meta: { status: string } };
     expect(data.ok).toBe(true);
     expect(data.meta.status).toBe("rejected");
-    const archivePath = path.join(tempDir, ".fleet", "knowledge", "archive", PENDING_PATCH_ID, "meta.json");
+    const archivePath = durableArchiveMetaPath(PENDING_PATCH_ID);
     await expect(access(archivePath)).resolves.not.toThrow();
   });
 
@@ -215,7 +218,7 @@ describe("queue POST actions", () => {
     expect(statuses[0]).toBe(200);
     expect(statuses[1]).toBe(409);
     // archive에 정확히 한 개만 이동
-    const archivePath = path.join(tempDir, ".fleet", "knowledge", "archive", PENDING_PATCH_ID, "meta.json");
+    const archivePath = durableArchiveMetaPath(PENDING_PATCH_ID);
     await expect(access(archivePath)).resolves.not.toThrow();
   });
 
@@ -227,6 +230,11 @@ describe("queue POST actions", () => {
     expect(data.patchSet?.members[0]?.id).toBe(PENDING_PATCH_ID);
   });
 });
+
+function durableArchiveMetaPath(patchId: string): string {
+  const workspace = resolveWorkspaceDirectory(fleetDataDir, tempDir);
+  return path.join(workspace.path, "knowledge", "archive", patchId, "meta.json");
+}
 
 async function writeEntry(wikiDir: string, id: string, title: string, body: string): Promise<void> {
   await writeFile(

--- a/runtime/fleet-console/tests/codex-wiki-storage-parity.test.ts
+++ b/runtime/fleet-console/tests/codex-wiki-storage-parity.test.ts
@@ -1,0 +1,227 @@
+import { access, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ensureWorkspaceDirectory, resolveWorkspaceDirectory, withDirectoryLock } from "@dotobokuri/core-infra";
+import { createWikiWorkspaceResolver, getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createConsoleServer, type ConsoleServer } from "../core/host/server.js";
+
+const ROOT_ENTRY = "root-console-entry";
+const NESTED_DECOY = "nested-legacy-decoy";
+const STAGED_ENTRY = "approval-gated-stage";
+const CONSOLE_PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("Console and injected Wiki tools share Theater-root storage", () => {
+  const roots: string[] = [];
+  const servers: ConsoleServer[] = [];
+
+  afterEach(async () => {
+    for (const server of servers.splice(0)) await server.stop();
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  it("migrates only root legacy knowledge on an authorized POST and exposes it to approval-gated tools", async () => {
+    const fixture = await createFixture(roots, servers);
+    const source = path.join(fixture.theaterA, ".fleet", "knowledge");
+    const nestedSource = path.join(fixture.theaterA, "nested", ".fleet", "knowledge");
+    await writeEntry(source, ROOT_ENTRY, "Root Console entry", "migrated root body");
+    await writeEntry(nestedSource, NESTED_DECOY, "Nested decoy", "must never migrate");
+    const sourceBytes = await snapshot(source);
+
+    const theater = await registerTheater(fixture.endpoint, fixture.theaterA);
+    const workspace = resolveWorkspaceDirectory(fixture.fleetDataDir, fixture.theaterA);
+    await expect(access(workspace.path)).rejects.toMatchObject({ code: "ENOENT" });
+
+    // Durable registration restore must retain availability without initializing Wiki storage.
+    await fixture.server.stop();
+    const restarted = await startServer(fixture.fleetDataDir, fixture.theaterA, fixture.root, servers);
+    fixture.endpoint = restarted.endpoint;
+    fixture.server = restarted.server;
+    await expect(access(workspace.path)).rejects.toMatchObject({ code: "ENOENT" });
+
+    const response = await fetch(`${fixture.endpoint}api/v1/theaters/${encodeURIComponent(theater.id)}/codex-workspace`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(response.status).toBe(200);
+    const dto = await response.json() as Record<string, unknown>;
+    expect(dto).toEqual({ hasWiki: true, id: theater.id });
+    expect(Object.keys(dto).sort()).toEqual(["hasWiki", "id"]);
+    expect(dto.id).toMatch(/^[0-9a-f]{12}$/);
+    assertPathFree(JSON.stringify(dto), fixture);
+
+    const destination = path.join(workspace.path, "knowledge");
+    expect(await readFile(path.join(destination, "wiki", `${ROOT_ENTRY}.md`), "utf8")).toContain("migrated root body");
+    await expect(access(path.join(destination, "wiki", `${NESTED_DECOY}.md`))).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await snapshot(source)).toEqual(sourceBytes);
+    expect(JSON.parse(await readFile(path.join(workspace.path, "knowledge.migrated.json"), "utf8"))).toMatchObject({ version: 1, outcome: "copied" });
+    expect((await readdir(workspace.path)).filter((name) => name.startsWith("knowledge.migrating-"))).toEqual([]);
+
+    const resolver = createResolver(fixture.fleetDataDir);
+    const readResult = await runTool(resolver, "wiki_read", fixture.theaterA, { ids: [ROOT_ENTRY] });
+    expect(JSON.stringify(readResult)).toContain("migrated root body");
+
+    const staged = await runTool(resolver, "wiki_ingest", fixture.theaterA, {
+      id: STAGED_ENTRY,
+      title: "Approval gated stage",
+      body: "This is staged through the Wiki tool and requires approval. ".repeat(4),
+      tags: [],
+      source: "approval gated source",
+    });
+    expect(staged.ok).toBe(true);
+    expect(staged.patch_id).toMatch(/^[0-9]{4}-/);
+    const drydock = await fetch(`${fixture.endpoint}console/codex/w/${theater.id}/api/drydock`);
+    expect(drydock.status).toBe(200);
+    const drydockText = await drydock.text();
+    expect(drydockText).toContain(String(staged.patch_id));
+    expect(drydockText).toContain("pending");
+    assertPathFree(drydockText, fixture);
+  }, 20_000);
+
+  it("uses the same gate for direct/MRU access, keeps Theaters isolated, and never re-copies after a marker", async () => {
+    const fixture = await createFixture(roots, servers);
+    const sourceA = path.join(fixture.theaterA, ".fleet", "knowledge");
+    const sourceB = path.join(fixture.theaterB, ".fleet", "knowledge");
+    await writeEntry(sourceA, "theater-a-entry", "Theater A", "A body");
+    await writeEntry(sourceB, "theater-b-entry", "Theater B", "B body");
+    const theaterA = await registerTheater(fixture.endpoint, fixture.theaterA);
+    const theaterB = await registerTheater(fixture.endpoint, fixture.theaterB);
+    const workspaceB = resolveWorkspaceDirectory(fixture.fleetDataDir, fixture.theaterB);
+
+    // B is MRU: unprefixed direct Codex access, rather than the POST route, starts migration.
+    const direct = await fetch(`${fixture.endpoint}console/codex/api/entry/theater-b-entry`);
+    expect(direct.status).toBe(200);
+    const directText = await direct.text();
+    expect(directText).toContain("B body");
+    assertPathFree(directText, fixture);
+    expect(await readFile(path.join(workspaceB.path, "knowledge", "wiki", "theater-b-entry.md"), "utf8")).toContain("B body");
+
+    const prefixedA = await fetch(`${fixture.endpoint}console/codex/w/${theaterA.id}/api/entry/theater-a-entry`);
+    expect(prefixedA.status).toBe(200);
+    expect(await prefixedA.text()).toContain("A body");
+
+    await fixture.server.stop();
+    const restarted = await startServer(fixture.fleetDataDir, fixture.theaterA, fixture.root, servers);
+    fixture.endpoint = restarted.endpoint;
+    fixture.server = restarted.server;
+    const afterRestart = await fetch(`${fixture.endpoint}console/codex/api/entry/theater-b-entry`);
+    expect(afterRestart.status).toBe(200);
+    expect(await afterRestart.text()).toContain("B body");
+
+    const forgotten = await fetch(`${fixture.endpoint}api/v1/theaters/${theaterB.id}`, { method: "DELETE" });
+    expect(forgotten.status).toBe(200);
+    const mruAfterForget = await fetch(`${fixture.endpoint}console/codex/api/entry/theater-a-entry`);
+    expect(mruAfterForget.status).toBe(200);
+    expect(await mruAfterForget.text()).toContain("A body");
+
+    await rm(path.join(workspaceB.path, "knowledge"), { recursive: true, force: true });
+    expect(await readFile(path.join(workspaceB.path, "knowledge.migrated.json"), "utf8")).toContain('"outcome":"copied"');
+    const reRegisteredB = await registerTheater(fixture.endpoint, fixture.theaterB);
+    const empty = await fetch(`${fixture.endpoint}api/v1/theaters/${reRegisteredB.id}/codex-workspace`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(empty.status).toBe(200);
+    expect(await empty.json()).toEqual({ hasWiki: true, id: theaterB.id });
+    await expect(access(path.join(workspaceB.path, "knowledge", "wiki", "theater-b-entry.md"))).rejects.toMatchObject({ code: "ENOENT" });
+
+    // A real Wiki use lazily initializes the empty destination but the marker still forbids a legacy re-copy.
+    await runTool(createResolver(fixture.fleetDataDir), "wiki_orient", fixture.theaterB, {});
+    await expect(access(path.join(workspaceB.path, "knowledge", "wiki", "theater-b-entry.md"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(access(path.join(workspaceB.path, "knowledge", "schema", "wiki-schema.md"))).resolves.toBeUndefined();
+  }, 20_000);
+});
+
+async function createFixture(roots: string[], servers: ConsoleServer[]): Promise<{ root: string; fleetDataDir: string; theaterA: string; theaterB: string; endpoint: string; server: ConsoleServer }> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "fleet-console-wiki-parity-"));
+  roots.push(root);
+  const fleetDataDir = path.join(root, "fleet-data");
+  const theaterA = path.join(root, "theater-a");
+  const theaterB = path.join(root, "theater-b");
+  await Promise.all([mkdir(fleetDataDir), mkdir(theaterA), mkdir(theaterB)]);
+  const started = await startServer(fleetDataDir, theaterA, root, servers);
+  return { root, fleetDataDir, theaterA, theaterB, ...started };
+}
+
+async function startServer(fleetDataDir: string, codexCwd: string, root: string, servers: ConsoleServer[]): Promise<{ endpoint: string; server: ConsoleServer }> {
+  const server = createConsoleServer({
+    host: "127.0.0.1",
+    port: 0,
+    version: "test",
+    codexCwd,
+    dataDir: fleetDataDir,
+    release: { channel: "local", version: "test", packageRoot: CONSOLE_PACKAGE_ROOT },
+  });
+  servers.push(server);
+  const lockRoot = await mkdtemp(path.join(root, "lock-"));
+  const endpoint = await server.start({ dir: lockRoot, lockFile: path.join(lockRoot, "console.lock") });
+  return { endpoint, server };
+}
+
+async function registerTheater(endpoint: string, cwd: string): Promise<{ id: string }> {
+  const grant = await fetch(`${endpoint}api/v1/theaters/folder-grants`, {
+    method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ path: cwd }),
+  });
+  expect(grant.status).toBe(200);
+  const { folderGrantId } = await grant.json() as { folderGrantId: string };
+  const created = await fetch(`${endpoint}api/v1/theaters`, {
+    method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ folderGrantId }),
+  });
+  expect(created.status).toBe(200);
+  return created.json() as Promise<{ id: string }>;
+}
+
+function createResolver(fleetDataDir: string) {
+  return createWikiWorkspaceResolver({
+    ensureWorkspace: (cwd) => {
+      const workspace = ensureWorkspaceDirectory(fleetDataDir, cwd);
+      return { cwd: workspace.cwd, path: workspace.path };
+    },
+    withMigrationLock: (workspace, operation) => withDirectoryLock({ lockDir: path.join(workspace.path, "knowledge.migration.lock") }, operation),
+  });
+}
+
+async function runTool(resolver: ReturnType<typeof createResolver>, id: string, cwd: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const spec = getWikiToolSpecs(resolver).find((candidate) => candidate.id === id);
+  if (!spec) throw new Error(`Missing Wiki tool: ${id}`);
+  const result = await spec.execute(args, { cwd, signal: undefined } as never);
+  if (!isTextToolResult(result)) throw new Error(`Invalid Wiki tool result: ${id}`);
+  expect(result.isError).toBe(false);
+  return JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+}
+
+function isTextToolResult(value: unknown): value is { isError: boolean; content: Array<{ type: "text"; text: string }> } {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.isError === "boolean"
+    && Array.isArray(record.content)
+    && record.content.length > 0
+    && record.content.every((item) => typeof item === "object" && item !== null
+      && (item as Record<string, unknown>).type === "text"
+      && typeof (item as Record<string, unknown>).text === "string");
+}
+
+async function writeEntry(root: string, id: string, title: string, body: string): Promise<void> {
+  const wiki = path.join(root, "wiki");
+  await mkdir(wiki, { recursive: true });
+  await writeFile(path.join(wiki, `${id}.md`), [
+    "---", `id: \"${id}\"`, `title: \"${title}\"`, "tags: []", 'created: "2026-07-18T00:00:00.000Z"', 'updated: "2026-07-18T00:00:00.000Z"', "version: 1", "---", "", body, "",
+  ].join("\n"), "utf8");
+}
+
+async function snapshot(root: string): Promise<Record<string, string>> {
+  const entries = await readdir(root, { recursive: true, withFileTypes: true });
+  const files = entries.filter((entry) => entry.isFile()).map((entry) => path.join(entry.parentPath, entry.name)).sort();
+  return Object.fromEntries(await Promise.all(files.map(async (file) => [path.relative(root, file), await readFile(file, "utf8")] as const)));
+}
+
+function assertPathFree(body: string, fixture: { fleetDataDir: string; theaterA: string; theaterB: string }): void {
+  for (const value of [fixture.fleetDataDir, fixture.theaterA, fixture.theaterB, "knowledge.migrating-", "knowledge.migrated.json", "workspaces"]) {
+    expect(body).not.toContain(value);
+  }
+}

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -1109,17 +1109,15 @@ describe("console static and terminal ticket boundary", () => {
     expect(remaining.theaters.find((entry) => entry.id === theater.id)).toBeUndefined();
   });
 
-  it("unregisters an on-demand nested Codex workspace when its Theater is forgotten", async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-codex-forget-nested-"));
-    const nestedDir = path.join(dir, "nested");
+  it("opens an empty Theater-root Codex workspace on demand and forgets it", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-codex-forget-root-"));
     tempDirs.push(dir);
-    createWikiRoot(nestedDir);
     const fixture = await startFixture();
     const theater = await createTheater(fixture, dir);
     const resolved = await fetch(`${fixture.endpoint}api/v1/theaters/${encodeURIComponent(theater.id)}/codex-workspace`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ relPath: "nested" }),
+      body: JSON.stringify({}),
     });
     const workspace = await resolved.json() as { readonly id: string | null; readonly hasWiki: boolean };
     expect(workspace).toMatchObject({ hasWiki: true });
@@ -1134,7 +1132,7 @@ describe("console static and terminal ticket boundary", () => {
     expect(afterForget.status).toBe(404);
   });
 
-  it("keeps a nested Codex workspace while another Theater owns the same directory", async () => {
+  it("keeps a separately registered nested Theater after its parent is forgotten", async () => {
     const parentDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-codex-shared-parent-"));
     const nestedDir = path.join(parentDir, "nested");
     tempDirs.push(parentDir);
@@ -1142,10 +1140,10 @@ describe("console static and terminal ticket boundary", () => {
     const fixture = await startFixture();
     const parentTheater = await createTheater(fixture, parentDir);
     const nestedTheater = await createTheater(fixture, nestedDir);
-    const resolved = await fetch(`${fixture.endpoint}api/v1/theaters/${encodeURIComponent(parentTheater.id)}/codex-workspace`, {
+    const resolved = await fetch(`${fixture.endpoint}api/v1/theaters/${encodeURIComponent(nestedTheater.id)}/codex-workspace`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ relPath: "nested" }),
+      body: JSON.stringify({}),
     });
     const workspace = await resolved.json() as { readonly id: string | null; readonly hasWiki: boolean };
     expect(workspace).toMatchObject({ hasWiki: true, id: nestedTheater.id });
@@ -1962,7 +1960,7 @@ describe("console static and terminal ticket boundary", () => {
     expect(payload).toMatchObject({
       id: workspaceHash(fs.realpathSync.native(dir)),
       label: path.basename(dir),
-      hasWiki: false,
+      hasWiki: true,
       activeAdmiralCount: 0,
     });
     expect(typeof payload.createdAt).toBe("string");

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -5,8 +5,8 @@ import process from "node:process";
 import { createCarrierResultReminderRouter, createDelayedPtyWriter, createFleetAgentRuntimeLifecycle, formatCarrierResultReminderMessage, getAgentCliAuthStatuses, getAgentCliMetadata, parseAgentCliId, sanitizeCarrierResultReminder, type AgentCliId } from "@dotobokuri/fleet-admiral";
 import { getPlanToolSpecs } from "@dotobokuri/fleet-plans";
 import { getCarrierConfig, resolveAgentCliType } from "@dotobokuri/fleet-carriers";
-import type { AuthService, GlobalOptionsService } from "@dotobokuri/core-infra";
-import { getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
+import { ensureWorkspaceDirectory, withDirectoryLock, type AuthService, type GlobalOptionsService } from "@dotobokuri/core-infra";
+import { createWikiWorkspaceResolver, getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
 import type { OperationLaunchKind, OperationNode, OperationPatchInput } from "@fleet-console/sdk/operations";
 import { registerRouter } from "@fleet-console/sdk/plugin/node";
 import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
@@ -70,6 +70,7 @@ export function buildAgentLaunchKindBackfillPatch(operation: AgentLaunchKindBack
 
 function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: TerminalRuntime, deps: AgentRouteDeps) {
   const planTools = getPlanToolSpecs({ dataDir: ctx.host.paths.fleetDataDir });
+  const wikiToolSpecs = createTerminalWikiToolSpecs(ctx.host.paths.fleetDataDir);
   const runtime = createFleetAgentRuntimeLifecycle({
     authService: deps.authService,
     dataDir: ctx.host.paths.fleetDataDir,
@@ -78,7 +79,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       console.error("[fleet-console] Failed to start MCP server", error);
     },
     workspaceChangeScanner: createWorkspaceChangeScanner(),
-    wikiToolSpecs: getWikiToolSpecs(),
+    wikiToolSpecs,
     extraAgentTools: [planTools.read, planTools.verify],
     extraExecutorTools: [
       { spec: planTools.write, options: { allowedScopes: [] } },
@@ -594,6 +595,17 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     ctx.host.http.writeJson(res, 401, { error: "Unauthorized" });
     return true;
   }
+}
+
+export function createTerminalWikiToolSpecs(fleetDataDir: string) {
+  const resolver = createWikiWorkspaceResolver({
+    ensureWorkspace: (cwd) => ensureWorkspaceDirectory(fleetDataDir, cwd),
+    withMigrationLock: (workspace, operation) => withDirectoryLock(
+      { lockDir: path.join(workspace.path, "knowledge.migration.lock") },
+      operation,
+    ),
+  });
+  return getWikiToolSpecs(resolver);
 }
 
 function toOperationPayload(existing: Record<string, unknown> | undefined, cwd: string, session: AgentTerminalSessionInfo, providerSession?: ProviderSession, providerTitle?: AgentProviderTitleMarker): Record<string, unknown> {

--- a/runtime/fleet-plugins/terminal/tests/agent-wiki-storage.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-wiki-storage.test.ts
@@ -1,0 +1,79 @@
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { ensureWorkspaceDirectory } from "@dotobokuri/core-infra";
+import { FLEET_WIKI_AGENT_TOOL_IDS, getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
+import { describe, expect, it } from "vitest";
+
+import { createTerminalWikiToolSpecs } from "../server/agent.js";
+
+const BODY = "A durable Terminal Wiki entry. ".repeat(12);
+
+describe("Terminal agent Wiki storage composition", () => {
+  it("registers the unchanged catalog while a representative write resolves the Theater-root durable store", async () => {
+    await withFixture(async ({ fleetDataDir, theaterRoot }) => {
+      const sourceFile = path.join(theaterRoot, ".fleet", "knowledge", "legacy.md");
+      const legacy = "legacy source remains immutable\n";
+      await mkdir(path.dirname(sourceFile), { recursive: true });
+      await writeFile(sourceFile, legacy);
+
+      const specs = createTerminalWikiToolSpecs(fleetDataDir);
+      const bareSpecs = getWikiToolSpecs();
+      expect(specs.map((spec) => spec.id)).toEqual(FLEET_WIKI_AGENT_TOOL_IDS);
+      expect(specs.map((spec) => spec.parameters)).toEqual(bareSpecs.map((spec) => spec.parameters));
+
+      await invoke(specs, "wiki_ingest", {
+        id: "terminal-entry", title: "Terminal entry", body: BODY, tags: [], source: BODY,
+      }, theaterRoot);
+
+      const workspace = ensureWorkspaceDirectory(fleetDataDir, theaterRoot);
+      const knowledge = path.join(workspace.path, "knowledge");
+      expect(await readFile(sourceFile, "utf8")).toBe(legacy);
+      expect(await readFile(path.join(knowledge, "legacy.md"), "utf8")).toBe(legacy);
+      expect(await readdir(path.join(knowledge, "queue"))).toHaveLength(1);
+    });
+  });
+
+  it("keeps an empty store available until a tool actually resolves it", async () => {
+    await withFixture(async ({ fleetDataDir }) => {
+      expect(createTerminalWikiToolSpecs(fleetDataDir).map((spec) => spec.id)).toEqual(FLEET_WIKI_AGENT_TOOL_IDS);
+      await expect(stat(fleetDataDir)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
+  it("treats an existing destination regular file as a migration no-op", async () => {
+    await withFixture(async ({ fleetDataDir, theaterRoot }) => {
+      const sourceFile = path.join(theaterRoot, ".fleet", "knowledge", "legacy.md");
+      await mkdir(path.dirname(sourceFile), { recursive: true });
+      await writeFile(sourceFile, "legacy must not merge\n");
+      const workspace = ensureWorkspaceDirectory(fleetDataDir, theaterRoot);
+      const blockingFile = path.join(workspace.path, "knowledge", "schema", "wiki-schema.md");
+      await mkdir(path.dirname(blockingFile), { recursive: true });
+      await writeFile(blockingFile, "destination wins\n");
+
+      await invoke(createTerminalWikiToolSpecs(fleetDataDir), "wiki_orient", {}, theaterRoot);
+
+      expect(await readFile(blockingFile, "utf8")).toBe("destination wins\n");
+      await expect(readFile(path.join(workspace.path, "knowledge", "legacy.md"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+});
+
+async function invoke(specs: ReturnType<typeof createTerminalWikiToolSpecs>, id: string, args: Record<string, unknown>, cwd: string): Promise<void> {
+  const spec = specs.find((candidate) => candidate.id === id);
+  if (!spec) throw new Error(`Missing ${id}`);
+  const result = await spec.execute(args, { cwd });
+  expect(result).toMatchObject({ isError: false });
+}
+
+async function withFixture(run: (fixture: { fleetDataDir: string; theaterRoot: string }) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "terminal-agent-wiki-storage-"));
+  try {
+    const theaterRoot = path.join(root, "theater");
+    await mkdir(theaterRoot);
+    await run({ fleetDataDir: path.join(root, "fleet-data"), theaterRoot });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Summary

- Store each Theater's Codex Wiki in its canonical Fleet workspace while keeping an empty Codex available.
- Copy legacy Theater-root `.fleet/knowledge` on first real Codex or Wiki use only when the destination has no knowledge; the source remains unchanged.
- Route Console, Terminal, and Fleet CLI Wiki access through the shared `fleet-wiki` resolver without changing MCP tool contracts.

## Type of Change

- [x] feat — new feature or carrier capability
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Test Plan

- [x] Fleet Wiki full suite — 21 files, 194 tests passed
- [x] Terminal full suite — 22 files, 198 tests passed
- [x] Fleet CLI targeted Wiki and loaded-count tests — 2 files, 10 tests passed
- [x] Console Codex workspace/path/server tests — 68 tests passed
- [x] Console parity, queue, and security tests — 64 tests passed
- [x] Fleet Wiki, Terminal, Fleet CLI, and Console client typechecks passed
- [x] `git diff --check`

## Changelog

- [x] Added `.changelog.d/pr-291.md` with grouped entries for every release-facing product.
- [x] English summaries are ASCII-only and each has an adjacent Korean summary.
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 32 entries validated.

## Notes for Reviewers

- Theater registration and durable restore remain metadata-only and do not trigger migration.
- Migration is copy-only and fail-closed; an existing destination is a total no-op and the legacy source is never deleted or rewritten.
- Console host typecheck still reports the same 10 CSS/virtual-module environment errors reproduced on `canary`; touched surfaces report no new type errors.