### PR TITLE
fix(fleet-wiki): preserve safe migration symlinks

### DIFF
--- a/packages/fleet-wiki/src/workspace-resolver.ts
+++ b/packages/fleet-wiki/src/workspace-resolver.ts
@@ -89,7 +89,7 @@ function resolveLocked(workspace: WikiWorkspace, hooks?: WikiWorkspaceResolverTe
 }
 
 type TreeState = "missing" | "empty" | "content" | "unsafe";
-function inspectTree(target: string, regularRootIsContent = false): TreeState {
+function inspectTree(target: string, regularRootIsContent = false, treeRoot = target): TreeState {
   let stat: fs.Stats;
   try { stat = fs.lstatSync(target); } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing";
@@ -100,10 +100,16 @@ function inspectTree(target: string, regularRootIsContent = false): TreeState {
   if (nodeKind === "file") return regularRootIsContent ? "content" : "unsafe";
   let content = false;
   for (const entry of fs.readdirSync(target, { withFileTypes: true })) {
-    if (entry.isSymbolicLink() || (!entry.isDirectory() && !entry.isFile())) return "unsafe";
+    const entryPath = path.join(target, entry.name);
+    if (entry.isSymbolicLink()) {
+      if (readSafeFileSymlink(treeRoot, entryPath) === null) return "unsafe";
+      content = true;
+      continue;
+    }
+    if (!entry.isDirectory() && !entry.isFile()) return "unsafe";
     if (entry.isFile()) content = true;
     if (entry.isDirectory()) {
-      const nested = inspectTree(path.join(target, entry.name));
+      const nested = inspectTree(entryPath, false, treeRoot);
       if (nested === "unsafe") return "unsafe";
       if (nested === "content") content = true;
     }
@@ -127,17 +133,49 @@ function readMarker(markerPath: string): MigrationMarker | null {
   return record as unknown as MigrationMarker;
 }
 
-function copyTree(source: string, destination: string, hooks?: WikiWorkspaceResolverTestHooks): void {
+function copyTree(source: string, destination: string, hooks?: WikiWorkspaceResolverTestHooks, sourceRoot = source): void {
   fs.mkdirSync(destination, { recursive: true });
   for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
     const from = path.join(source, entry.name); const to = path.join(destination, entry.name);
     const stat = fs.lstatSync(from);
+    if (stat.isSymbolicLink()) {
+      const target = readSafeFileSymlink(sourceRoot, from);
+      if (target === null) throw new Error("Unsafe Fleet Wiki legacy source state");
+      fs.symlinkSync(target, to, "file");
+      continue;
+    }
     const nodeKind = classifyWikiWorkspaceNodeForTest(stat);
     if (nodeKind === "unsafe") throw new Error("Unsafe Fleet Wiki legacy source state");
-    if (nodeKind === "directory") copyTree(from, to, hooks);
+    if (nodeKind === "directory") copyTree(from, to, hooks, sourceRoot);
     else { hooks?.beforeCopyFile?.(from, to); fs.copyFileSync(from, to); syncFile(to); }
   }
   syncDirectory(destination);
+}
+
+function readSafeFileSymlink(treeRoot: string, linkPath: string): string | null {
+  const target = fs.readlinkSync(linkPath);
+  if (path.posix.isAbsolute(target) || path.win32.isAbsolute(target)) return null;
+  const lexicalRoot = path.resolve(treeRoot);
+  const lexicalTarget = path.resolve(path.dirname(linkPath), target);
+  if (!isWithinRoot(lexicalRoot, lexicalTarget)) return null;
+  let canonicalRoot: string;
+  let canonicalTarget: string;
+  let targetStat: fs.Stats;
+  try {
+    canonicalRoot = fs.realpathSync(treeRoot);
+    canonicalTarget = fs.realpathSync(linkPath);
+    targetStat = fs.statSync(linkPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  if (!isWithinRoot(canonicalRoot, canonicalTarget) || !targetStat.isFile()) return null;
+  return target;
+}
+
+function isWithinRoot(root: string, target: string): boolean {
+  const relative = path.relative(root, target);
+  return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
 }
 
 /** Test-only direct-module seam for the lstat branch; absent from the package-root barrel. */

--- a/packages/fleet-wiki/tests/wiki-workspace-resolver.test.ts
+++ b/packages/fleet-wiki/tests/wiki-workspace-resolver.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, readlink, rm, symlink, writeFile } from "node:fs/promises";
 import * as fs from "node:fs";
 import { execFileSync } from "node:child_process";
 import net from "node:net";
@@ -54,6 +54,29 @@ describe("createWikiWorkspaceResolver", () => {
     await expect(readFile(path.join(paths.wikiDir, "entry.md"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("preserves contained relative file symlinks without dereferencing or changing the source", async () => {
+    const { cwd, workspace, resolver } = await fixture();
+    const source = path.join(cwd, ".fleet", "knowledge");
+    await mkdir(path.join(source, "schema"), { recursive: true });
+    await writeFile(path.join(source, "AGENTS.md"), "root doctrine\n");
+    await writeFile(path.join(source, "schema", "AGENTS.md"), "schema doctrine\n");
+    await symlink("AGENTS.md", path.join(source, "CLAUDE.md"));
+    await symlink("AGENTS.md", path.join(source, "schema", "CLAUDE.md"));
+
+    const paths = resolver.resolve(cwd);
+    for (const relative of ["CLAUDE.md", path.join("schema", "CLAUDE.md")]) {
+      const sourceLink = path.join(source, relative);
+      const destinationLink = path.join(paths.root, relative);
+      expect((await lstat(destinationLink)).isSymbolicLink()).toBe(true);
+      await expect(readlink(destinationLink)).resolves.toBe("AGENTS.md");
+      expect((await lstat(sourceLink)).isSymbolicLink()).toBe(true);
+      await expect(readlink(sourceLink)).resolves.toBe("AGENTS.md");
+    }
+    await expect(readFile(path.join(paths.root, "CLAUDE.md"), "utf8")).resolves.toBe("root doctrine\n");
+    await expect(readFile(path.join(paths.schemaDir, "CLAUDE.md"), "utf8")).resolves.toBe("schema doctrine\n");
+    expect(resolver.resolve(cwd)).toMatchObject({ root: paths.root });
+  });
+
   it("leaves a destination regular file entirely untouched and does not create a marker", async () => {
     const { cwd, workspace, resolver } = await fixture();
     await mkdir(path.join(cwd, ".fleet", "knowledge"), { recursive: true });
@@ -84,11 +107,15 @@ describe("createWikiWorkspaceResolver", () => {
     const stagingFile = path.join(workspace, `knowledge.migrating-${transactionId}`, "wiki", "entry.md");
     await mkdir(path.dirname(stagingFile), { recursive: true });
     await writeFile(stagingFile, "staged");
+    await writeFile(path.join(workspace, `knowledge.migrating-${transactionId}`, "AGENTS.md"), "staged doctrine");
+    await symlink("AGENTS.md", path.join(workspace, `knowledge.migrating-${transactionId}`, "CLAUDE.md"));
     await writeFile(path.join(workspace, "knowledge.migrated.json"), JSON.stringify({ version: 1, outcome: "copied", transactionId, completedAt: "2026-07-17T00:00:00.000Z" }));
     await mkdir(path.join(cwd, ".fleet", "knowledge"), { recursive: true });
     await writeFile(path.join(cwd, ".fleet", "knowledge", "legacy.md"), "must not copy");
     const paths = resolver.resolve(cwd);
     await expect(readFile(path.join(paths.wikiDir, "entry.md"), "utf8")).resolves.toBe("staged");
+    expect((await lstat(path.join(paths.root, "CLAUDE.md"))).isSymbolicLink()).toBe(true);
+    await expect(readlink(path.join(paths.root, "CLAUDE.md"))).resolves.toBe("AGENTS.md");
     await expect(readFile(path.join(paths.root, "legacy.md"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
@@ -164,6 +191,41 @@ describe("createWikiWorkspaceResolver", () => {
     await mkdir(path.join(workspace, "knowledge"), { recursive: true });
     await symlink(path.join(cwd, "missing"), path.join(workspace, "knowledge", "unsafe"));
     expect(() => resolver.resolve(cwd)).toThrow(/Unsafe/);
+  });
+
+  it("rejects absolute, escaping, dangling, and directory symlinks before creating migration artifacts", async () => {
+    const absolute = await fixture();
+    const absoluteSource = path.join(absolute.cwd, ".fleet", "knowledge");
+    await mkdir(absoluteSource, { recursive: true });
+    await writeFile(path.join(absoluteSource, "target.md"), "target");
+    await symlink(path.join(absoluteSource, "target.md"), path.join(absoluteSource, "absolute.md"));
+    expect(() => absolute.resolver.resolve(absolute.cwd)).toThrow(/Unsafe/);
+
+    const escaping = await fixture();
+    const escapingSource = path.join(escaping.cwd, ".fleet", "knowledge");
+    const outside = path.join(escaping.cwd, "outside.md");
+    await mkdir(escapingSource, { recursive: true });
+    await writeFile(outside, "outside");
+    await symlink(path.relative(escapingSource, outside), path.join(escapingSource, "escaping.md"));
+    expect(() => escaping.resolver.resolve(escaping.cwd)).toThrow(/Unsafe/);
+
+    const dangling = await fixture();
+    const danglingSource = path.join(dangling.cwd, ".fleet", "knowledge");
+    await mkdir(danglingSource, { recursive: true });
+    await symlink("missing.md", path.join(danglingSource, "dangling.md"));
+    expect(() => dangling.resolver.resolve(dangling.cwd)).toThrow(/Unsafe/);
+
+    const directory = await fixture();
+    const directorySource = path.join(directory.cwd, ".fleet", "knowledge");
+    await mkdir(path.join(directorySource, "docs"), { recursive: true });
+    await writeFile(path.join(directorySource, "docs", "entry.md"), "entry");
+    await symlink("docs", path.join(directorySource, "docs-link"));
+    expect(() => directory.resolver.resolve(directory.cwd)).toThrow(/Unsafe/);
+
+    for (const state of [absolute, escaping, dangling, directory]) {
+      await expect(readFile(path.join(state.workspace, "knowledge.migrated.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+      expect(fs.readdirSync(state.workspace).some((name) => name.startsWith("knowledge.migrating-"))).toBe(false);
+    }
   });
 
   it("leaves no marker or destination after a copy failure, then safely retries from rebuilt staging", async () => {

--- a/runtime/fleet-console/tests/codex-wiki-storage-parity.test.ts
+++ b/runtime/fleet-console/tests/codex-wiki-storage-parity.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { access, lstat, mkdtemp, mkdir, readFile, readdir, readlink, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -29,6 +29,8 @@ describe("Console and injected Wiki tools share Theater-root storage", () => {
     const nestedSource = path.join(fixture.theaterA, "nested", ".fleet", "knowledge");
     await writeEntry(source, ROOT_ENTRY, "Root Console entry", "migrated root body");
     await writeEntry(nestedSource, NESTED_DECOY, "Nested decoy", "must never migrate");
+    await writeFile(path.join(source, "AGENTS.md"), "Fleet Wiki doctrine\n");
+    await symlink("AGENTS.md", path.join(source, "CLAUDE.md"));
     const sourceBytes = await snapshot(source);
 
     const theater = await registerTheater(fixture.endpoint, fixture.theaterA);
@@ -56,6 +58,9 @@ describe("Console and injected Wiki tools share Theater-root storage", () => {
 
     const destination = path.join(workspace.path, "knowledge");
     expect(await readFile(path.join(destination, "wiki", `${ROOT_ENTRY}.md`), "utf8")).toContain("migrated root body");
+    expect((await lstat(path.join(destination, "CLAUDE.md"))).isSymbolicLink()).toBe(true);
+    await expect(readlink(path.join(destination, "CLAUDE.md"))).resolves.toBe("AGENTS.md");
+    await expect(readlink(path.join(source, "CLAUDE.md"))).resolves.toBe("AGENTS.md");
     await expect(access(path.join(destination, "wiki", `${NESTED_DECOY}.md`))).rejects.toMatchObject({ code: "ENOENT" });
     expect(await snapshot(source)).toEqual(sourceBytes);
     expect(JSON.parse(await readFile(path.join(workspace.path, "knowledge.migrated.json"), "utf8"))).toMatchObject({ version: 1, outcome: "copied" });


### PR DESCRIPTION
## Summary

- Preserve safe workspace-internal relative file symlinks during one-time Fleet Wiki migration without dereferencing or deleting the source.
- Keep absolute, escaping, dangling, directory, and special nodes fail-closed while preserving copy-only and destination-wins behavior.
- Cover the resolver and Console integration paths with the real `CLAUDE.md -> AGENTS.md` knowledge-tree shape.

## Type of Change

- [ ] feat — new feature or carrier capability
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- [x] `packages/fleet-wiki`
- [x] `runtime/fleet-console` tests

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-wiki test` (21 files, 202 tests)
- [x] `pnpm --filter @dotobokuri/fleet-wiki typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console... build`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/codex-wiki-storage-parity.test.ts` (2 tests)
- [x] Real-browser E2E using an isolated Console data root and `/Users/sbluemin/workspace/fleet-harness` as the Theater; both symlinks were preserved, source/destination digests matched, and a second Codex click did not recopy.

## Changelog

- [x] Applied the `no-changelog` label intentionally: this corrects the still-unreleased theater-wide Wiki migration already described by `.changelog.d/pr-291.md`; a separate `Fixed` entry would duplicate an unshipped behavior.

## Related Issues / PRs

- Follow-up to #291.

## Notes for Reviewers

The full Console typecheck still reproduces the same client CSS/`virtual:fleet-plugins` declaration failure on clean `canary`; the modified package typecheck, topological build, targeted Console integration, and live browser path pass.
