### PR TITLE
fix(fleet-console): preserve close button focus ring

### DIFF
--- a/.changelog.d/pr-293.md
+++ b/.changelog.d/pr-293.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Keep the in-panel Close button focus ring fully visible.
+  ko: 인패널 닫기 버튼의 포커스 링이 우측에서 잘리지 않고 완전히 보이도록 합니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3213,6 +3213,10 @@
     opacity var(--duration-base) var(--ease-spring);
 }
 
+.canvas-operation-window-controls > .canvas-operation-icon-button:last-child {
+  margin-inline-end: var(--space-1);
+}
+
 .canvas-operation-controls-divider {
   flex: none;
   width: 1px;

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -414,6 +414,8 @@ describe("Instrument core design contract", () => {
     const windowControlsBlock = components.match(/\.canvas-operation-window-controls \{[^}]*\}/)?.[0] ?? "";
     expect(windowControlsBlock).toContain("overflow-x: clip;");
     expect(windowControlsBlock).toContain("overflow-y: visible;");
+    const windowControlsLastButtonBlock = components.match(/\.canvas-operation-window-controls > \.canvas-operation-icon-button:last-child \{[^}]*\}/)?.[0] ?? "";
+    expect(windowControlsLastButtonBlock).toContain("margin-inline-end: var(--space-1);");
     expect(components).toContain(".operations-canvas.is-glance .canvas-operation-glance-hud {");
     // armed-close는 hover 전개 규칙(0-4-0)과 같은 특이도의 후순위여야 Close? 라벨이 잘리지 않는다.
     expect(components).toContain(".canvas-operation .canvas-operation-window-controls .canvas-operation-icon-button.is-armed-close {");


### PR DESCRIPTION
## Summary
- Preserve the right-side focus ring of the in-panel Close control by reserving trailing space inside the clipped control strip.
- Keep the collapsed width and overflow animation behavior covered by the Console design contract.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/instrument-design-contract.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Headless Console verification: keyboard `:focus-visible`, `clippedBy=0`, `collapsedWidth=0`, and no page errors or unhandled rejections.

## Changelog
- [x] Added `.changelog.d/pr-293.md`.
- [x] Fragment uses `fleet-console / Fixed` with adjacent English and Korean summaries.
- [x] `node scripts/compile-changelog-fragments.mjs --check` passes.
