### PR TITLE
fix(plans): bind storage to host workspace

### DIFF
--- a/.changelog.d/pr-295.md
+++ b/.changelog.d/pr-295.md
@@ -1,0 +1,21 @@
+### fleet-cli
+#### Fixed
+- [fleet-cli] Keep Fleet Plan storage bound to the invocation workspace while Carriers run in worktrees.
+  ko: 캐리어가 워크트리에서 실행되어도 Fleet Plan 저장소를 최초 실행 워크스페이스에 유지합니다.
+
+### fleet-console
+#### Fixed
+- [fleet-console] Keep Fleet Plans visible in the active Theater when Agents run from Carrier worktrees.
+  ko: 에이전트가 캐리어 워크트리에서 실행되어도 Fleet Plan을 활성 Theater에서 계속 확인할 수 있습니다.
+
+### fleet-plugin
+#### Fixed
+- [fleet-console] Bind Terminal Agent Plan storage to its server-resolved Theater without exposing filesystem paths to the browser.
+  ko: 파일시스템 경로를 브라우저에 노출하지 않고 Terminal Agent의 Plan 저장소를 서버가 해석한 Theater에 바인딩합니다.
+
+### fleet-core
+#### Fixed
+- [core-agent] Carry immutable server-only bindings through dedicated and one-shot MCP sessions.
+  ko: 불변 서버 전용 바인딩을 전용 MCP 세션과 일회성 MCP 세션 모두에 전달합니다.
+- [fleet-plans] Require hosts to bind Plan storage explicitly instead of deriving it from the execution directory.
+  ko: Plan 저장소를 실행 디렉터리에서 추론하지 않고 호스트가 명시적으로 바인딩하도록 합니다.

--- a/packages/core-agent/src/executor-port.ts
+++ b/packages/core-agent/src/executor-port.ts
@@ -1,7 +1,7 @@
 import type { McpServerConfig } from "@dotobokuri/core-unified-agent";
 
 import type { McpRouterRuntime } from "./mcp-router.js";
-import type { AgentToolSpec } from "./types.js";
+import type { AgentServerBindings, AgentToolSpec } from "./types.js";
 
 export interface ExecutorMcpRouterRuntime {
   readonly name: string;
@@ -28,6 +28,7 @@ export interface ExecutorMcpSessionRequest {
   readonly specs: readonly AgentToolSpec[];
   readonly cwd: string;
   readonly signal?: AbortSignal;
+  readonly serverBindings?: AgentServerBindings;
 }
 
 export interface ExecutorMcpSession {

--- a/packages/core-agent/src/executor-session-manager.ts
+++ b/packages/core-agent/src/executor-session-manager.ts
@@ -8,7 +8,7 @@ import {
   type McpRouterRuntime,
   registerExecutorSessionTools,
 } from "./mcp-router.js";
-import type { AgentToolSpec } from "./types.js";
+import { snapshotAgentServerBindings, type AgentServerBindings, type AgentToolSpec } from "./types.js";
 
 export interface ExecutorServerEndpoint {
   readonly name: string;
@@ -23,6 +23,7 @@ export interface ExecutorSessionRequest {
   readonly label: string;
   readonly cwd: string;
   readonly signal?: AbortSignal;
+  readonly serverBindings?: AgentServerBindings;
 }
 
 export interface ExecutorServerToken {
@@ -42,6 +43,7 @@ export interface CoreExecutorMcpSessionRequest {
   readonly specs: readonly AgentToolSpec[];
   readonly cwd: string;
   readonly signal?: AbortSignal;
+  readonly serverBindings?: AgentServerBindings;
 }
 
 export interface ExecutorSessionManager {
@@ -66,6 +68,7 @@ interface ActiveSession {
   readonly tokens: readonly ExecutorServerToken[];
   readonly cwd: string;
   readonly signal?: AbortSignal;
+  readonly serverBindings?: AgentServerBindings;
 }
 
 const DEFAULT_TOOL_TIMEOUT_SECONDS = 1800;
@@ -115,10 +118,12 @@ function createExecutorMcpSession(
   assertNonEmptyExecutorTools(request.serverName, request.specs);
 
   const token = crypto.randomUUID();
+  const serverBindings = snapshotAgentServerBindings(request.serverBindings);
   registerExecutorSessionTools(runtime.runtime, token, [...request.specs]);
   installExecutorToolCallRouter(runtime.runtime, token, {
     cwd,
     signal: request.signal,
+    serverBindings,
   });
 
   return runtime.runtime.server.start().then((url) => ({
@@ -161,13 +166,19 @@ function issueSessionToken(
   }
 
   const tokens: ExecutorServerToken[] = [];
+  const serverBindings = snapshotAgentServerBindings(request.serverBindings);
   try {
     for (const { name, runtime } of deps.runtimes) {
       const tools = runtime.registry.getAllAgentTools();
       assertNonEmptyExecutorTools(name, tools);
       const token = crypto.randomUUID();
       registerExecutorSessionTools(runtime, token, tools);
-      installExecutorToolCallRouter(runtime, token, { cwd, sessionLabel: label, signal: request.signal });
+      installExecutorToolCallRouter(runtime, token, {
+        cwd,
+        sessionLabel: label,
+        signal: request.signal,
+        serverBindings,
+      });
       tokens.push({ name, token });
     }
   } catch (error) {
@@ -179,6 +190,7 @@ function issueSessionToken(
     tokens,
     cwd,
     signal: request.signal,
+    serverBindings,
   });
   return tokens;
 }

--- a/packages/core-agent/src/index.ts
+++ b/packages/core-agent/src/index.ts
@@ -1,4 +1,5 @@
 export type {
+  AgentServerBindings,
   AgentToolCtx,
   AgentToolSpec,
   JsonRpcPayload,
@@ -82,6 +83,9 @@ export type {
   GlobalPackageUpdaterReport,
   GlobalPackageVersionResolver,
 } from "./global-package-updater.js";
+export {
+  snapshotAgentServerBindings,
+} from "./types.js";
 export {
   cleanupExecutorSession,
   installExecutorToolCallRouter,

--- a/packages/core-agent/src/internal/executor-engine.ts
+++ b/packages/core-agent/src/internal/executor-engine.ts
@@ -21,7 +21,7 @@ import {
 } from "../mcp-router.js";
 import { executorMcpRuntimeProviderRuntime, executorPortRuntime, type ExecutorMcpSession } from "../executor-port.js";
 import { resolveBuiltinExternalMcpServers } from "../external-mcp.js";
-import type { TrackStatus } from "../types.js";
+import { snapshotAgentServerBindings, type AgentServerBindings, type TrackStatus } from "../types.js";
 import { applyPostConnectConfig } from "./post-connect.js";
 
 export interface ExecuteOptions {
@@ -29,6 +29,7 @@ export interface ExecuteOptions {
   readonly authEnvResolver: AuthEnvResolver;
   readonly request: string;
   readonly cwd: string;
+  readonly serverBindings?: AgentServerBindings;
   readonly resumeSessionId?: string;
   readonly scopeId?: string;
   readonly model?: string;
@@ -77,6 +78,7 @@ const MAX_TOOL_CALLS_TO_KEEP = 30;
 
 export function engineExecuteOneShot(opts: ExecuteOptions): OneShotExecution {
   assertAuthEnvResolver(opts.authEnvResolver);
+  const serverBindings = snapshotAgentServerBindings(opts.serverBindings);
   let client: IUnifiedAgentClient | undefined;
   let activeMcpTokens: readonly ExecutorMcpSessionToken[] | undefined;
   let promptStarted = false;
@@ -141,7 +143,13 @@ export function engineExecuteOneShot(opts: ExecuteOptions): OneShotExecution {
       };
       client.on("error", onProviderError);
       if (aborted) throw new Error("Aborted");
-      const mcpSetup = await raceProviderFailure(setupExecutorMcp(opts.cwd, opts.signal, opts.scopeId, opts.reservedExternalMcpServerIds));
+      const mcpSetup = await raceProviderFailure(setupExecutorMcp(
+        opts.cwd,
+        opts.signal,
+        opts.scopeId,
+        opts.reservedExternalMcpServerIds,
+        serverBindings,
+      ));
       activeMcpTokens = mcpSetup?.tokens;
       if (aborted) throw new Error("Aborted");
       const model = opts.model ?? getProviderModels(opts.cliType).defaultModel;
@@ -154,7 +162,13 @@ export function engineExecuteOneShot(opts: ExecuteOptions): OneShotExecution {
       if (opts.resumeSessionId) connectOpts.sessionId = opts.resumeSessionId;
       const connectResult = await raceAbort(raceProviderFailure(client.connect(connectOpts)), opts.signal);
       await raceProviderFailure(applyResolvedEffort(client, opts.cliType, model, effort));
-      if (activeMcpTokens) installActiveExecutorToolCallRouter(activeMcpTokens, { cwd: opts.cwd, signal: opts.signal });
+      if (activeMcpTokens) {
+        installActiveExecutorToolCallRouter(activeMcpTokens, {
+          cwd: opts.cwd,
+          signal: opts.signal,
+          serverBindings,
+        });
+      }
       sessionId = connectResult.session?.sessionId ?? client.getConnectionInfo().sessionId ?? undefined;
       const protocol = client.getConnectionInfo().protocol ?? connectResult.protocol;
       if (!sessionId || !protocol) throw new Error("Provider readiness did not expose a session identity and protocol.");
@@ -275,14 +289,23 @@ function cleanupExecutorSessions(tokens: readonly ExecutorMcpSessionToken[]): vo
   }
 }
 
-function installActiveExecutorToolCallRouter(tokens: readonly ExecutorMcpSessionToken[], ctx: { cwd: string; signal?: AbortSignal }): void {
+function installActiveExecutorToolCallRouter(
+  tokens: readonly ExecutorMcpSessionToken[],
+  ctx: { cwd: string; signal?: AbortSignal; serverBindings?: AgentServerBindings },
+): void {
   for (const { serverName, token } of tokens) {
     const runtime = executorMcpRuntimeProviderRuntime.getExecutorMcpRouterRuntimes().find((entry) => entry.name === serverName)?.runtime;
     if (runtime) installExecutorToolCallRouter(runtime, token, ctx);
   }
 }
 
-async function setupExecutorMcp(cwd: string, signal?: AbortSignal, scopeId?: string, reservedIds: readonly string[] = []): Promise<ExecutorMcpSetup | null> {
+async function setupExecutorMcp(
+  cwd: string,
+  signal?: AbortSignal,
+  scopeId?: string,
+  reservedIds: readonly string[] = [],
+  serverBindings?: AgentServerBindings,
+): Promise<ExecutorMcpSetup | null> {
   if (signal?.aborted) return null;
   const tokens: ExecutorMcpSessionToken[] = [];
   const mcpServers: McpServerConfig[] = [];
@@ -292,7 +315,13 @@ async function setupExecutorMcp(cwd: string, signal?: AbortSignal, scopeId?: str
       const specs = executorPortRuntime.getExecutorMcpTools(name, scopeId);
       if (!specs.length) continue;
       if (provider.createExecutorMcpSession) {
-        const session = await provider.createExecutorMcpSession({ serverName: name, specs, cwd, signal });
+        const session = await provider.createExecutorMcpSession({
+          serverName: name,
+          specs,
+          cwd,
+          signal,
+          serverBindings,
+        });
         tokens.push({ serverName: name, token: session.token, session });
         mcpServers.push(session.mcpServer);
       } else {

--- a/packages/core-agent/src/mcp-router.ts
+++ b/packages/core-agent/src/mcp-router.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 
 import type { McpToolRegistry } from "./tool-registry.js";
 import type { McpToolSnapshotStore } from "./tool-snapshot.js";
-import type { AgentToolSpec, McpCallToolResult, McpTool } from "./types.js";
+import type { AgentServerBindings, AgentToolSpec, McpCallToolResult, McpTool } from "./types.js";
 
 export type ToolCallArrivedCallback = (
   toolName: string,
@@ -33,11 +33,17 @@ export function specToMcpTool(spec: AgentToolSpec): McpTool {
 export function installExecutorToolCallRouter(
   runtime: McpRouterRuntime,
   sessionToken: string,
-  ctx: { cwd: string; sessionLabel?: string; signal?: AbortSignal },
+  ctx: { cwd: string; sessionLabel?: string; signal?: AbortSignal; serverBindings?: AgentServerBindings },
 ): void {
   runtime.server.setOnToolCallArrived(sessionToken, (toolName, args) => {
     const toolCallId = crypto.randomUUID();
-    void runtime.registry.invoke(toolName, args, { cwd: ctx.cwd, sessionLabel: ctx.sessionLabel, toolCallId, signal: ctx.signal })
+    void runtime.registry.invoke(toolName, args, {
+      cwd: ctx.cwd,
+      sessionLabel: ctx.sessionLabel,
+      toolCallId,
+      signal: ctx.signal,
+      serverBindings: ctx.serverBindings,
+    })
       .then((result) => runtime.server.resolveNextToolCall(sessionToken, toolCallId, result))
       .catch((err) => {
         runtime.server.resolveNextToolCall(sessionToken, toolCallId, {

--- a/packages/core-agent/src/tool-registry.ts
+++ b/packages/core-agent/src/tool-registry.ts
@@ -98,6 +98,7 @@ export function createMcpToolRegistry(): McpToolRegistry {
         sessionLabel: ctx?.sessionLabel,
         toolCallId: ctx?.toolCallId,
         signal: ctx?.signal,
+        serverBindings: ctx?.serverBindings,
       };
 
       const spec = primaryToolSpecs.get(name);

--- a/packages/core-agent/src/types.ts
+++ b/packages/core-agent/src/types.ts
@@ -3,11 +3,21 @@ export interface McpCallToolResult {
   isError: boolean;
 }
 
+/** Server-owned string values that are available only while invoking local MCP tools. */
+export type AgentServerBindings = Readonly<Record<string, string>>;
+
+export function snapshotAgentServerBindings(
+  bindings: AgentServerBindings | undefined,
+): AgentServerBindings | undefined {
+  return bindings === undefined ? undefined : Object.freeze({ ...bindings });
+}
+
 export interface AgentToolCtx {
   readonly cwd: string;
   readonly sessionLabel?: string;
   readonly toolCallId?: string;
   readonly signal?: AbortSignal;
+  readonly serverBindings?: AgentServerBindings;
 }
 
 export interface AgentToolSpec {

--- a/packages/core-agent/tests/executor-oneshot.test.ts
+++ b/packages/core-agent/tests/executor-oneshot.test.ts
@@ -8,7 +8,12 @@ vi.mock("@dotobokuri/core-unified-agent", async (importOriginal) => {
   return { ...actual, UnifiedAgent: { ...actual.UnifiedAgent, build: buildMock }, getEffort: () => ({ supported: false }), getProviderModels: () => ({ defaultModel: "fake-model" }) };
 });
 const { executeOneShot } = await import("../src/index.js");
-const { executorMcpRuntimeProviderRuntime, executorPortRuntime } = await import("../src/executor-port.js");
+const {
+  createMcpToolRegistry,
+  createMcpToolSnapshotStore,
+  executorMcpRuntimeProviderRuntime,
+  executorPortRuntime,
+} = await import("../src/index.js");
 
 class FakeClient extends EventEmitter implements IUnifiedAgentClient {
   readonly connectCalls: UnifiedClientOptions[] = [];
@@ -104,5 +109,60 @@ describe("executeOneShot", () => {
     } finally {
       warn.mockRestore();
     }
+  });
+  it("snapshots server bindings for one-shot MCP tools without adding them to provider options", async () => {
+    const registry = createMcpToolRegistry();
+    const snapshotStore = createMcpToolSnapshotStore();
+    let handler: ((name: string, args: Record<string, unknown>) => string) | null = null;
+    const resolveNextToolCall = vi.fn();
+    const seen: Array<{ cwd: string; workspace: string | undefined; frozen: boolean }> = [];
+    registry.registerExecutorTool({
+      id: "oneshot_binding_probe",
+      tag: "oneshot_binding_probe",
+      title: "probe",
+      description: "probe",
+      promptSnippet: "probe",
+      whenToUse: [],
+      whenNotToUse: [],
+      usageGuidelines: [],
+      parameters: {},
+      async execute(_args, ctx) {
+        seen.push({
+          cwd: ctx.cwd,
+          workspace: ctx.serverBindings?.workspace,
+          frozen: Object.isFrozen(ctx.serverBindings),
+        });
+        return "ok";
+      },
+    });
+    const runtime = {
+      registry,
+      snapshotStore,
+      server: {
+        start: async () => "http://127.0.0.1:1/mcp",
+        setOnToolCallArrived: (_token: string, callback: typeof handler) => { handler = callback; },
+        resolveNextToolCall,
+        clearPendingForSession: vi.fn(),
+      },
+    };
+    executorPortRuntime.register({
+      getScopeExternalMcpServerIds: () => [],
+      getExecutorMcpTools: () => [registry.getExecutorMcpToolsForScope()[0]!],
+    });
+    executorMcpRuntimeProviderRuntime.register({ getExecutorMcpRouterRuntimes: () => [{ name: "tools", runtime }] });
+    const callerBindings: Record<string, string> = { workspace: "/server-workspace" };
+    const execution = executeOneShot(options("bound", {
+      cwd: "/execution-worktree",
+      serverBindings: callerBindings,
+    }));
+    callerBindings.workspace = "/mutated-caller-value";
+
+    await execution.readiness;
+    handler!("oneshot_binding_probe", {});
+    await vi.waitFor(() => expect(resolveNextToolCall).toHaveBeenCalledTimes(1));
+    expect(seen).toEqual([{ cwd: "/execution-worktree", workspace: "/server-workspace", frozen: true }]);
+    expect(clients[0]!.connectCalls[0]).not.toHaveProperty("serverBindings");
+    expect(clients[0]!.connectCalls[0]!.env).toBeUndefined();
+    await execution.abort();
   });
 });

--- a/packages/core-agent/tests/mcp-jsonrpc.test.ts
+++ b/packages/core-agent/tests/mcp-jsonrpc.test.ts
@@ -175,6 +175,44 @@ describe("executor session manager", () => {
     expect(seenSessionLabels).toEqual(["terminal-a"]);
     manager.cleanup();
   });
+
+  it("dedicated sessions freeze a caller binding snapshot independently of execution cwd", async () => {
+    const registry = createMcpToolRegistry();
+    const snapshotStore = createMcpToolSnapshotStore();
+    const server = createInProcessMcpServer({ toolSnapshotStore: snapshotStore });
+    activeServers.push(server);
+    const runtime: McpRouterRuntime = { registry, server, snapshotStore };
+    const seen: Array<{ cwd: string; bindings: Record<string, string> | undefined; frozen: boolean }> = [];
+    registry.registerAgentTool({
+      ...makeToolSpec("binding_snapshot_probe"),
+      async execute(_args, ctx) {
+        seen.push({ cwd: ctx.cwd, bindings: ctx.serverBindings, frozen: Object.isFrozen(ctx.serverBindings) });
+        return "ok";
+      },
+    });
+    const manager = createExecutorSessionManager({ runtimes: [{ name: "tools", runtime }] });
+    const callerBindings: Record<string, string> = { workspace: "/server-workspace" };
+    const tokens = manager.issueSessionToken({
+      label: "bound-session",
+      cwd: "/execution-worktree",
+      serverBindings: callerBindings,
+    });
+    callerBindings.workspace = "/mutated-caller-value";
+
+    await postJsonRpc(await server.start(), tokens[0]!.token, {
+      jsonrpc: "2.0",
+      id: "call",
+      method: "tools/call",
+      params: { name: "binding_snapshot_probe", arguments: {} },
+    });
+
+    expect(seen).toEqual([{
+      cwd: "/execution-worktree",
+      bindings: { workspace: "/server-workspace" },
+      frozen: true,
+    }]);
+    manager.cleanup();
+  });
 });
 
 function makeToolSpec(id: string): AgentToolSpec {

--- a/packages/core-agent/tests/registry-router.test.ts
+++ b/packages/core-agent/tests/registry-router.test.ts
@@ -4,6 +4,7 @@ import {
   cleanupExecutorSession,
   createMcpToolRegistry,
   createMcpToolSnapshotStore,
+  installExecutorToolCallRouter,
   registerExecutorSessionTools,
 } from "../src/index.js";
 import type { AgentToolSpec, McpRouterRuntime } from "../src/index.js";
@@ -128,5 +129,37 @@ describe("executor MCP router", () => {
     expect(routerRuntime.snapshotStore.getToolsForSession(token).length).toBeGreaterThan(0);
     cleanupExecutorSession(routerRuntime, token);
     expect(routerRuntime.snapshotStore.getToolsForSession(token)).toHaveLength(0);
+  });
+
+  it("direct router invokes tools with its server-only bindings while preserving cwd", async () => {
+    const seen: Array<{ cwd: string; bindings: Record<string, string> | undefined; frozen: boolean }> = [];
+    routerRuntime.registry.registerAgentTool({
+      ...makeToolSpec("binding_probe", () => "ok"),
+      async execute(_args, ctx) {
+        seen.push({
+          cwd: ctx.cwd,
+          bindings: ctx.serverBindings,
+          frozen: Object.isFrozen(ctx.serverBindings),
+        });
+        return "ok";
+      },
+    });
+    const arrived = vi.fn();
+    const resolve = vi.fn();
+    routerRuntime.server.setOnToolCallArrived = (_token, callback) => {
+      arrived.mockImplementation(callback ?? (() => ""));
+    };
+    routerRuntime.server.resolveNextToolCall = resolve;
+    const bindings = Object.freeze({ workspace: "/server-only" });
+
+    installExecutorToolCallRouter(routerRuntime, "router-binding", {
+      cwd: "/execution-cwd",
+      serverBindings: bindings,
+    });
+    const toolCallId = arrived("binding_probe", {});
+    await vi.waitFor(() => expect(resolve).toHaveBeenCalledTimes(1));
+
+    expect(toolCallId).toEqual(expect.any(String));
+    expect(seen).toEqual([{ cwd: "/execution-cwd", bindings: { workspace: "/server-only" }, frozen: true }]);
   });
 });

--- a/packages/fleet-admiral/src/agent-cli/injection.ts
+++ b/packages/fleet-admiral/src/agent-cli/injection.ts
@@ -3,6 +3,7 @@ import { chmodSync, closeSync, constants, lstatSync, mkdirSync, mkdtempSync, ope
 import os from "node:os";
 import path from "node:path";
 
+import type { AgentServerBindings } from "@dotobokuri/core-agent";
 import { getFleetDataDir } from "@dotobokuri/core-infra/data-dir";
 
 import { buildClaudeNativeArgs } from "./builders/claude.js";
@@ -24,6 +25,8 @@ export interface InjectAgentCliProfileOptions {
   readonly dataDir?: string;
   readonly dedicatedMcpSession: DedicatedMcpSession;
   readonly mcpSessionLabel?: string;
+  /** Server-only values forwarded exclusively to the dedicated MCP session. */
+  readonly serverBindings?: AgentServerBindings;
   readonly enableMetaphor?: boolean;
   readonly captureSessionHookExec?: FleetHookExec;
   // 턴 시작(UserPromptSubmit)·턴 종료(Stop) 신호 hook. host가 빌드해 주입하며 claude/codex 양쪽에 와이어링된다.
@@ -58,7 +61,7 @@ interface CodexProfileHookExecs {
 
 interface DedicatedMcpSession {
   getEndpoint(): Promise<ExecutorEndpoint>;
-  issueSessionToken(request: { readonly label: string; readonly cwd: string; readonly signal?: AbortSignal }): readonly ExecutorServerToken[] | Promise<readonly ExecutorServerToken[]>;
+  issueSessionToken(request: { readonly label: string; readonly cwd: string; readonly signal?: AbortSignal; readonly serverBindings?: AgentServerBindings }): readonly ExecutorServerToken[] | Promise<readonly ExecutorServerToken[]>;
   releaseSessionToken(label: string): void;
 }
 
@@ -90,7 +93,11 @@ export async function injectAgentCliProfile(
   const enableMetaphor = options.enableMetaphor ?? false;
   const endpoint = await options.dedicatedMcpSession.getEndpoint();
   const tokenLabel = options.mcpSessionLabel ?? `agent:${profile.id}:${crypto.randomUUID()}`;
-  const tokens = await options.dedicatedMcpSession.issueSessionToken({ cwd: profile.cwd, label: tokenLabel });
+  const tokens = await options.dedicatedMcpSession.issueSessionToken({
+    cwd: profile.cwd,
+    label: tokenLabel,
+    serverBindings: options.serverBindings,
+  });
   const mcpServers = buildAgentCliMcpServerConfigs(endpoint.servers, tokens);
   const doctrine = options.buildSystemPrompt(enableMetaphor);
   const tempCleanups: Array<() => void> = [];

--- a/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import type { AgentServerBindings } from "@dotobokuri/core-agent";
 import * as Admiral from "../src/index.js";
 import { buildHostShellCommand, buildPowerShellCommand, escapeTomlBasicString } from "../src/agent-cli/builders/toml.js";
 import { injectAgentCliProfile } from "../src/agent-cli/injection.js";
@@ -14,9 +15,10 @@ import { createAgentCliPlugin } from "../src/agent-cli/plugin/index.js";
 import type { AgentCliProfile, FleetHookExec } from "../src/agent-cli/types.js";
 
 interface TestDedicatedMcpSession {
+  readonly issuedRequests: Array<{ readonly label: string; readonly cwd: string; readonly serverBindings?: AgentServerBindings }>;
   readonly releasedLabels: string[];
   getEndpoint(): Promise<{ readonly servers: readonly { readonly name: string; readonly url: string }[] }>;
-  issueSessionToken(request: { readonly label: string; readonly cwd: string }): readonly { readonly name: string; readonly token: string }[];
+  issueSessionToken(request: { readonly label: string; readonly cwd: string; readonly serverBindings?: AgentServerBindings }): readonly { readonly name: string; readonly token: string }[];
   releaseSessionToken(label: string): void;
 }
 
@@ -45,6 +47,35 @@ afterEach(() => {
 });
 
 describe("agent CLI session resume and capture hooks", () => {
+  it("forwards server bindings only to the dedicated MCP session", async () => {
+    const root = createTempRoot("fleet-admiral-server-bindings-");
+    const serverBindings = { "test.workspace": "/theater-root" };
+    const dedicatedMcpSession = createDedicatedMcpSession();
+    const profile = baseProfile("claude", {
+      args: [],
+      cwd: root,
+      env: { HOME: root },
+    });
+
+    const injected = await injectAgentCliProfile(profile, baseInjectOptions(root, {
+      dedicatedMcpSession,
+      serverBindings,
+    }));
+
+    expect(dedicatedMcpSession.issuedRequests).toEqual([
+      expect.objectContaining({ cwd: root, serverBindings }),
+    ]);
+    expect(injected).not.toHaveProperty("serverBindings");
+    expect(injected.args.join("\n")).not.toContain(serverBindings["test.workspace"]);
+    expect(Object.values(injected.env).join("\n")).not.toContain(serverBindings["test.workspace"]);
+    const systemPromptFile = injected.args[injected.args.indexOf("--append-system-prompt-file") + 1];
+    expect(readFileSync(systemPromptFile ?? "", "utf8")).not.toContain(serverBindings["test.workspace"]);
+    expect(readTextFilesRecursively(path.join(root, "data")).join("\n")).not.toContain(serverBindings["test.workspace"]);
+
+    injected.cleanup?.();
+    expect(dedicatedMcpSession.releasedLabels).toHaveLength(1);
+  });
+
   it("defaults metaphor off and forwards explicit opt-in to the prompt builder", async () => {
     const observed: boolean[] = [];
 
@@ -392,6 +423,7 @@ function baseInjectOptions(
     readonly dedicatedMcpSession?: TestDedicatedMcpSession;
     readonly enableMetaphor?: boolean;
     readonly resumeSessionId?: string;
+    readonly serverBindings?: AgentServerBindings;
     readonly turnEndHookExec?: FleetHookExec;
     readonly turnStartHookExec?: FleetHookExec;
   } = {},
@@ -405,6 +437,7 @@ function baseInjectOptions(
     ...(overrides.captureSessionHookExec ? { captureSessionHookExec: overrides.captureSessionHookExec } : {}),
     ...(overrides.enableMetaphor === undefined ? {} : { enableMetaphor: overrides.enableMetaphor }),
     ...(overrides.resumeSessionId ? { resumeSessionId: overrides.resumeSessionId } : {}),
+    ...(overrides.serverBindings ? { serverBindings: overrides.serverBindings } : {}),
     ...(overrides.turnEndHookExec ? { turnEndHookExec: overrides.turnEndHookExec } : {}),
     ...(overrides.turnStartHookExec ? { turnStartHookExec: overrides.turnStartHookExec } : {}),
     withMarketplaceLock: async (_target, fn) => fn(),
@@ -417,21 +450,31 @@ function createDedicatedMcpSession(
     readonly tokens?: readonly { readonly name: string; readonly token: string }[];
   } = {},
 ): TestDedicatedMcpSession {
+  const issuedRequests: Array<{ readonly label: string; readonly cwd: string; readonly serverBindings?: AgentServerBindings }> = [];
   const releasedLabels: string[] = [];
   const servers = options.servers ?? [{ name: "fleet", url: "http://127.0.0.1:48123/mcp" }];
   const tokens = options.tokens ?? [{ name: "fleet", token: "token-123" }];
   return {
+    issuedRequests,
     releasedLabels,
     async getEndpoint() {
       return { servers };
     },
-    issueSessionToken() {
+    issueSessionToken(request) {
+      issuedRequests.push(request);
       return tokens;
     },
     releaseSessionToken(label: string) {
       releasedLabels.push(label);
     },
   };
+}
+
+function readTextFilesRecursively(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    return entry.isDirectory() ? readTextFilesRecursively(entryPath) : [readFileSync(entryPath, "utf8")];
+  });
 }
 
 function hookExec(command: string, args: readonly string[]): FleetHookExec {

--- a/packages/fleet-carriers/src/dispatch/taskforce.ts
+++ b/packages/fleet-carriers/src/dispatch/taskforce.ts
@@ -181,6 +181,7 @@ export async function launchTaskForceJob(options: TaskForceLaunchOptions): Promi
       cliType: cliType as CliType,
       request,
       cwd,
+      serverBindings: ctx.serverBindings,
       model: modelInfo.model,
       effort: modelInfo.effort,
       resumeSessionId: claim.resumeSessions?.get(cliType),

--- a/packages/fleet-carriers/src/dispatch/tool-spec.ts
+++ b/packages/fleet-carriers/src/dispatch/tool-spec.ts
@@ -314,6 +314,7 @@ export function buildCarrierDispatchToolSpec(registry: CarrierRegistry, deps: Ca
         cliType: trackModelInfo.cliType,
         request,
         cwd,
+        serverBindings: ctx.serverBindings,
         model: trackModelInfo.model,
         effort: trackModelInfo.effort,
         resumeSessionId: claim.resumeSessions?.get(trackModelInfo.cliType),

--- a/packages/fleet-carriers/tests/dispatch/oneshot-sessions.test.ts
+++ b/packages/fleet-carriers/tests/dispatch/oneshot-sessions.test.ts
@@ -205,6 +205,36 @@ describe("single dispatch context resume", () => {
     expect(details(resumed).context_id).toBe(contextId);
   });
 
+  it("forwards server bindings unchanged through nested-cwd fresh and resumed launches", async () => {
+    runtime = createCarrierRuntime();
+    registerCarrier(runtime.registry, createConfig("ohio", "Ohio"));
+    vi.mocked(executeOneShot).mockImplementation((opts) => resolvedHandle(opts.cliType as CliType));
+    const tool = runtime.buildDispatchToolSpec(deps);
+    const serverBindings = Object.freeze({ plan_workspace: "/theater" });
+    const nestedCarrierCwd = "/theater/.fleet/worktrees/topic";
+
+    const first = await tool.execute(
+      { carrier_id: "ohio", label: "Nested first", request: "Run." },
+      { cwd: nestedCarrierCwd, toolCallId: "nested-single-1", serverBindings },
+    );
+    const contextId = details(first).context_id;
+    await vi.waitFor(() => expect(runtime!.dispatchContexts.size).toBe(1));
+
+    await tool.execute(
+      { carrier_id: "ohio", label: "Nested resume", request: "Continue.", resume_context_id: contextId },
+      { cwd: nestedCarrierCwd, toolCallId: "nested-single-2", serverBindings },
+    );
+
+    const calls = vi.mocked(executeOneShot).mock.calls.map(([options]) => options);
+    expect(calls).toHaveLength(2);
+    for (const options of calls) {
+      expect(options.cwd).toBe(nestedCarrierCwd);
+      expect(options.serverBindings).toBe(serverBindings);
+    }
+    expect(calls[0]!.resumeSessionId).toBeUndefined();
+    expect(calls[1]!.resumeSessionId).toBe("session-claude");
+  });
+
   it("rejects a second in-flight dispatch that reuses the same resume_context_id", async () => {
     runtime = createCarrierRuntime();
     registerCarrier(runtime.registry, createConfig("ohio", "Ohio"));
@@ -406,6 +436,38 @@ describe("Task Force context barrier and resume", () => {
     expect(claudeResume?.resumeSessionId).toBe("session-claude");
     expect(codexResume?.resumeSessionId).toBe("session-codex");
     expect(details(resumed).context_id).toBe(contextId);
+  });
+
+  it("forwards server bindings unchanged to every nested-cwd Task Force backend on fresh and resumed launches", async () => {
+    runtime = createCarrierRuntime();
+    registerCarrier(runtime.registry, createConfig("ohio", "Ohio"));
+    configureTaskForce("ohio");
+    vi.mocked(executeOneShot).mockImplementation((opts) => resolvedHandle(opts.cliType as CliType));
+    const tool = runtime.buildDispatchToolSpec(deps);
+    const serverBindings = Object.freeze({ plan_workspace: "/theater" });
+    const nestedCarrierCwd = "/theater/.fleet/worktrees/topic";
+
+    const first = await tool.execute(
+      { carrier_id: "ohio", label: "Nested Task Force first", request: "Run." },
+      { cwd: nestedCarrierCwd, toolCallId: "nested-taskforce-1", serverBindings },
+    );
+    const contextId = details(first).context_id;
+    await vi.waitFor(() => expect(runtime!.dispatchContexts.size).toBe(1));
+
+    await tool.execute(
+      { carrier_id: "ohio", label: "Nested Task Force resume", request: "Continue.", resume_context_id: contextId },
+      { cwd: nestedCarrierCwd, toolCallId: "nested-taskforce-2", serverBindings },
+    );
+
+    const calls = vi.mocked(executeOneShot).mock.calls.map(([options]) => options);
+    expect(calls).toHaveLength(4);
+    for (const options of calls) {
+      expect(options.cwd).toBe(nestedCarrierCwd);
+      expect(options.serverBindings).toBe(serverBindings);
+    }
+    const resumedCalls = calls.slice(2);
+    expect(resumedCalls.find((options) => options.cliType === "claude")?.resumeSessionId).toBe("session-claude");
+    expect(resumedCalls.find((options) => options.cliType === "codex")?.resumeSessionId).toBe("session-codex");
   });
 
   it("rolls back every prepared Task Force resource when readiness confirmation rejects a resumed binding", async () => {

--- a/packages/fleet-plans/src/agent-specs.ts
+++ b/packages/fleet-plans/src/agent-specs.ts
@@ -1,6 +1,7 @@
 import type { AgentToolSpec, McpCallToolResult } from "@dotobokuri/core-agent";
 import { Type } from "typebox";
 
+import { resolvePlanWorkspaceBinding } from "./bindings.js";
 import { buildPlanExecutionView } from "./execution-view.js";
 import { formatPlanRef, parseTaskRef } from "./references.js";
 import {
@@ -142,7 +143,7 @@ function buildPlanWriteSpec(deps: PlanToolSpecDeps): AgentToolSpec {
     ],
     guardrails: [
       "Kirov-only mutation surface.",
-      "The tool computes WorkspaceDir from executor cwd and never accepts a caller path.",
+      "Storage comes only from a host-bound Plan workspace; missing or invalid bindings fail closed before Plan storage mutation.",
     ],
     parameters: Type.Object({
       plan_id: Type.String({ minLength: 1, maxLength: 128, pattern: PLAN_ID_PATTERN }),
@@ -153,7 +154,8 @@ function buildPlanWriteSpec(deps: PlanToolSpecDeps): AgentToolSpec {
         const input = asRecord(args);
         const planId = requiredString(input.plan_id, "plan_id");
         const markdown = requiredContent(input.markdown, "markdown");
-        const result = writePlanMarkdown(deps.dataDir, ctx.cwd, planId, markdown);
+        const workspace = resolvePlanWorkspaceBinding(deps.dataDir, ctx.serverBindings);
+        const result = writePlanMarkdown(deps.dataDir, workspace.cwd, planId, markdown);
         const payload = {
           ok: result.written,
           tool: "plan_write",

--- a/packages/fleet-plans/src/bindings.ts
+++ b/packages/fleet-plans/src/bindings.ts
@@ -1,0 +1,35 @@
+import type { AgentServerBindings } from "@dotobokuri/core-agent";
+import {
+  ensureWorkspaceDirectory,
+  resolveWorkspaceDirectoryByName,
+  type WorkspaceDirectory,
+} from "@dotobokuri/core-infra/workspace-dir";
+
+const PLAN_WORKSPACE_BINDING_KEY = "fleet-plans.workspace-ref";
+
+/**
+ * Creates the server-only Plan storage binding for a host-selected workspace.
+ * The workspace is ensured before the binding is handed to an Agent session.
+ */
+export function createPlanWorkspaceServerBindings(
+  dataDir: string,
+  workspaceRoot: string,
+): AgentServerBindings {
+  const workspace = ensureWorkspaceDirectory(dataDir, workspaceRoot);
+  return Object.freeze({ [PLAN_WORKSPACE_BINDING_KEY]: workspace.name });
+}
+
+export function resolvePlanWorkspaceBinding(
+  dataDir: string,
+  bindings: AgentServerBindings | undefined,
+): WorkspaceDirectory {
+  const workspaceRef = bindings?.[PLAN_WORKSPACE_BINDING_KEY];
+  if (typeof workspaceRef !== "string" || !workspaceRef.trim()) {
+    throw new Error("plan_write requires a host-bound Plan workspace");
+  }
+  try {
+    return resolveWorkspaceDirectoryByName(dataDir, workspaceRef);
+  } catch {
+    throw new Error("plan_write requires a valid host-bound Plan workspace");
+  }
+}

--- a/packages/fleet-plans/src/index.ts
+++ b/packages/fleet-plans/src/index.ts
@@ -4,6 +4,7 @@ export {
   type PlanToolSpecDeps,
   type PlanToolSpecs,
 } from "./agent-specs.js";
+export { createPlanWorkspaceServerBindings } from "./bindings.js";
 export { lintPlanMarkdown, normalizePlanMarkdown } from "./lint.js";
 export {
   assertPlanId,

--- a/packages/fleet-plans/src/store.ts
+++ b/packages/fleet-plans/src/store.ts
@@ -52,7 +52,7 @@ interface PlanLocation {
 
 export function writePlanMarkdown(
   dataDir: string,
-  cwd: string,
+  workspaceRoot: string,
   planId: string,
   markdown: string,
 ): PlanWriteResult {
@@ -60,13 +60,13 @@ export function writePlanMarkdown(
   assertPlanSize(markdown);
   const normalized = normalizePlanMarkdown(markdown);
   const lint = lintPlanMarkdown(normalized);
-  const resolvedWorkspace = resolveWorkspaceDirectory(dataDir, cwd);
+  const resolvedWorkspace = resolveWorkspaceDirectory(dataDir, workspaceRoot);
   const planRef = formatPlanRef(resolvedWorkspace.name, planId);
   if (!lint.valid) {
     return { lint, planRef, written: false };
   }
 
-  const workspace = ensureWorkspaceDirectory(dataDir, cwd);
+  const workspace = ensureWorkspaceDirectory(dataDir, workspaceRoot);
   const location = ensurePlanLocation(workspace, planId);
   withDirectoryLock({ lockDir: location.lockDir }, () => {
     assertSafePlanFile(location.filePath);

--- a/packages/fleet-plans/tests/agent-specs.test.ts
+++ b/packages/fleet-plans/tests/agent-specs.test.ts
@@ -1,10 +1,11 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
 import { FLEET_PLAN_TOOL_IDS, getPlanToolSpecs } from "../src/agent-specs.js";
+import { createPlanWorkspaceServerBindings } from "../src/bindings.js";
 import { buildMultiWavePlan, buildValidPlan } from "./fixtures.js";
 
 const cleanupPaths: string[] = [];
@@ -27,12 +28,14 @@ describe("Fleet Plan agent specs", () => {
     cleanupPaths.push(root);
     const cwd = path.join(root, "repo");
     mkdirSync(cwd, { recursive: true });
-    const specs = getPlanToolSpecs({ dataDir: path.join(root, "data") });
+    const dataDir = path.join(root, "data");
+    const specs = getPlanToolSpecs({ dataDir });
+    const serverBindings = createPlanWorkspaceServerBindings(dataDir, cwd);
 
     const write = await specs.write.execute({
       plan_id: "tool-plan",
       markdown: buildValidPlan(),
-    }, { cwd });
+    }, { cwd, serverBindings });
     const planRef = (write as { plan_ref: string }).plan_ref;
     const taskRefs = ["W1-A-T1", "W1-A-T2", "W1-A-T3"].map((id) => `${planRef}#${id}`);
     const fullRead = await specs.read.execute({ plan_ref: planRef }, { cwd });
@@ -79,9 +82,11 @@ describe("Fleet Plan agent specs", () => {
     cleanupPaths.push(root);
     const cwd = path.join(root, "repo");
     mkdirSync(cwd, { recursive: true });
-    const specs = getPlanToolSpecs({ dataDir: path.join(root, "data") });
-    const first = await specs.write.execute({ plan_id: "first-plan", markdown: buildValidPlan() }, { cwd });
-    const second = await specs.write.execute({ plan_id: "second-plan", markdown: buildValidPlan() }, { cwd });
+    const dataDir = path.join(root, "data");
+    const specs = getPlanToolSpecs({ dataDir });
+    const serverBindings = createPlanWorkspaceServerBindings(dataDir, cwd);
+    const first = await specs.write.execute({ plan_id: "first-plan", markdown: buildValidPlan() }, { cwd, serverBindings });
+    const second = await specs.write.execute({ plan_id: "second-plan", markdown: buildValidPlan() }, { cwd, serverBindings });
     const firstRef = (first as { plan_ref: string }).plan_ref;
     const secondRef = (second as { plan_ref: string }).plan_ref;
 
@@ -109,7 +114,8 @@ describe("Fleet Plan agent specs", () => {
     const dataDir = path.join(root, "data");
     mkdirSync(cwd, { recursive: true });
     const specs = getPlanToolSpecs({ dataDir });
-    const write = await specs.write.execute({ plan_id: "corrupt-plan", markdown: buildValidPlan() }, { cwd });
+    const serverBindings = createPlanWorkspaceServerBindings(dataDir, cwd);
+    const write = await specs.write.execute({ plan_id: "corrupt-plan", markdown: buildValidPlan() }, { cwd, serverBindings });
     const planRef = (write as { plan_ref: string }).plan_ref;
     const workspaceRef = planRef.slice(0, planRef.lastIndexOf(":"));
     writeFileSync(path.join(dataDir, "workspaces", workspaceRef, "plans", "corrupt-plan.md"), "# Objective\n\nCorrupt\n");
@@ -125,8 +131,10 @@ describe("Fleet Plan agent specs", () => {
     cleanupPaths.push(root);
     const cwd = path.join(root, "repo");
     mkdirSync(cwd, { recursive: true });
-    const specs = getPlanToolSpecs({ dataDir: path.join(root, "data") });
-    const write = await specs.write.execute({ plan_id: "multi-wave", markdown: buildMultiWavePlan() }, { cwd });
+    const dataDir = path.join(root, "data");
+    const specs = getPlanToolSpecs({ dataDir });
+    const serverBindings = createPlanWorkspaceServerBindings(dataDir, cwd);
+    const write = await specs.write.execute({ plan_id: "multi-wave", markdown: buildMultiWavePlan() }, { cwd, serverBindings });
     const planRef = (write as { plan_ref: string }).plan_ref;
     await specs.markTasks.execute({
       task_refs: ["W1-A-T1", "W1-A-T2", "W1-A-T3"].map((id) => `${planRef}#${id}`),
@@ -158,11 +166,13 @@ describe("Fleet Plan agent specs", () => {
     cleanupPaths.push(root);
     const cwd = path.join(root, "repo");
     mkdirSync(cwd, { recursive: true });
-    const specs = getPlanToolSpecs({ dataDir: path.join(root, "data") });
+    const dataDir = path.join(root, "data");
+    const specs = getPlanToolSpecs({ dataDir });
+    const serverBindings = createPlanWorkspaceServerBindings(dataDir, cwd);
     const write = await specs.write.execute({
       plan_id: "tool-plan",
       markdown: buildValidPlan(),
-    }, { cwd });
+    }, { cwd, serverBindings });
     const planRef = (write as { plan_ref: string }).plan_ref;
     const taskRefs = ["W1-A-T1", "W1-A-T2", "W1-A-T3"].map((id) => `${planRef}#${id}`);
 
@@ -181,5 +191,46 @@ describe("Fleet Plan agent specs", () => {
       ready_for_host_verification: true,
       implementation_verified: false,
     }));
+  });
+
+  it("writes through the host-bound workspace rather than the tool cwd and fails closed without it", async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "fleet-plan-tools-"));
+    cleanupPaths.push(root);
+    const workspaceRoot = path.join(root, "theater");
+    const toolCwd = path.join(workspaceRoot, ".fleet", "worktrees", "topic");
+    const dataDir = path.join(root, "data");
+    mkdirSync(toolCwd, { recursive: true });
+    const specs = getPlanToolSpecs({ dataDir });
+    const serverBindings = createPlanWorkspaceServerBindings(dataDir, workspaceRoot);
+
+    const written = await specs.write.execute({ plan_id: "bound-plan", markdown: buildValidPlan() }, { cwd: toolCwd, serverBindings });
+
+    expect(Object.values(serverBindings)).not.toContain(workspaceRoot);
+    expect(written).toEqual(expect.objectContaining({ ok: true, plan_ref: expect.stringMatching(/:bound-plan$/) }));
+    expect((written as { plan_ref: string }).plan_ref).toContain(workspaceRoot.replace(/[^a-zA-Z0-9]/g, "-"));
+    expect(existsSync(path.join(dataDir, "workspaces", toolCwd.replace(/[^a-zA-Z0-9]/g, "-")))).toBe(false);
+  });
+
+  it("rejects missing, empty, and malformed Plan bindings before creating storage", async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "fleet-plan-tools-"));
+    cleanupPaths.push(root);
+    const toolCwd = path.join(root, "worktree");
+    const dataDir = path.join(root, "data");
+    mkdirSync(toolCwd, { recursive: true });
+    const specs = getPlanToolSpecs({ dataDir });
+
+    for (const serverBindings of [
+      undefined,
+      Object.freeze({}),
+      Object.freeze({ "fleet-plans.workspace-ref": "" }),
+      Object.freeze({ "fleet-plans.workspace-ref": "  " }),
+      Object.freeze({ "fleet-plans.workspace-ref": "not/a-workspace-ref" }),
+      Object.freeze({ "fleet-plans.workspace-ref": "nonexistent-workspace-ref" }),
+    ]) {
+      const result = await specs.write.execute({ plan_id: "missing-binding", markdown: buildValidPlan() }, { cwd: toolCwd, serverBindings });
+      expect(result).toEqual(expect.objectContaining({ isError: true }));
+      expect(JSON.stringify(result)).toContain("host-bound Plan workspace");
+      expect(existsSync(dataDir)).toBe(false);
+    }
   });
 });

--- a/packages/fleet-plans/tests/store.test.ts
+++ b/packages/fleet-plans/tests/store.test.ts
@@ -21,17 +21,17 @@ afterEach(() => {
 
 describe("Fleet Plan store", () => {
   it("rejects filename-shaped or ambiguous Plan identities", () => {
-    const { cwd, dataDir } = makePaths();
+    const { workspaceRoot, dataDir } = makePaths();
 
     for (const planId of ["plan.md", "plan..v2", "plan."]) {
-      expect(() => writePlanMarkdown(dataDir, cwd, planId, buildValidPlan()))
+      expect(() => writePlanMarkdown(dataDir, workspaceRoot, planId, buildValidPlan()))
         .toThrow(/Invalid plan id/);
     }
   });
 
-  it("writes by cwd and reads the Plan through its cross-workspace PlanRef", () => {
-    const { cwd, dataDir } = makePaths();
-    const result = writePlanMarkdown(dataDir, cwd, "workspace-plan-mcp", buildValidPlan());
+  it("writes by host-bound workspace root and reads the Plan through its cross-workspace PlanRef", () => {
+    const { workspaceRoot, dataDir } = makePaths();
+    const result = writePlanMarkdown(dataDir, workspaceRoot, "workspace-plan-mcp", buildValidPlan());
 
     expect(result.written).toBe(true);
     expect(result.planRef).toMatch(/:workspace-plan-mcp$/);
@@ -41,26 +41,26 @@ describe("Fleet Plan store", () => {
   });
 
   it("preserves an existing valid Plan when replacement lint fails", () => {
-    const { cwd, dataDir } = makePaths();
-    const first = writePlanMarkdown(dataDir, cwd, "safe-plan", buildValidPlan());
-    const invalid = writePlanMarkdown(dataDir, cwd, "safe-plan", "# Objective\n\nIncomplete\n");
+    const { workspaceRoot, dataDir } = makePaths();
+    const first = writePlanMarkdown(dataDir, workspaceRoot, "safe-plan", buildValidPlan());
+    const invalid = writePlanMarkdown(dataDir, workspaceRoot, "safe-plan", "# Objective\n\nIncomplete\n");
 
     expect(invalid.written).toBe(false);
     expect(readPlanMarkdown(dataDir, first.planRef).markdown).toBe(buildValidPlan());
   });
 
   it("does not create workspace storage when initial Markdown lint fails", () => {
-    const { cwd, dataDir } = makePaths();
+    const { workspaceRoot, dataDir } = makePaths();
 
-    const invalid = writePlanMarkdown(dataDir, cwd, "invalid-plan", "# Objective\n\nIncomplete\n");
+    const invalid = writePlanMarkdown(dataDir, workspaceRoot, "invalid-plan", "# Objective\n\nIncomplete\n");
 
     expect(invalid.written).toBe(false);
     expect(existsSync(dataDir)).toBe(false);
   });
 
   it("reads externally corrupted Markdown with blocking lint diagnostics", () => {
-    const { cwd, dataDir } = makePaths();
-    const written = writePlanMarkdown(dataDir, cwd, "corrupt-plan", buildValidPlan());
+    const { workspaceRoot, dataDir } = makePaths();
+    const written = writePlanMarkdown(dataDir, workspaceRoot, "corrupt-plan", buildValidPlan());
     const workspaceName = written.planRef.slice(0, written.planRef.lastIndexOf(":"));
     const planPath = path.join(dataDir, "workspaces", workspaceName, "plans", "corrupt-plan.md");
     writeFileSync(planPath, "# Objective\n\nCorrupted\n");
@@ -72,8 +72,8 @@ describe("Fleet Plan store", () => {
   });
 
   it("marks only same-Lane TaskRefs and keeps the operation idempotent", () => {
-    const { cwd, dataDir } = makePaths();
-    const written = writePlanMarkdown(dataDir, cwd, "mark-plan", buildValidPlan());
+    const { workspaceRoot, dataDir } = makePaths();
+    const written = writePlanMarkdown(dataDir, workspaceRoot, "mark-plan", buildValidPlan());
     const refs = ["W1-A-T1", "W1-A-T2", "W1-A-T3"].map((id) => `${written.planRef}#${id}`);
 
     const first = markPlanTasksComplete(dataDir, refs);
@@ -92,8 +92,8 @@ describe("Fleet Plan store", () => {
 
   it("rejects a symlinked Plan file", () => {
     if (process.platform === "win32") return;
-    const { root, cwd, dataDir } = makePaths();
-    const written = writePlanMarkdown(dataDir, cwd, "unsafe-plan", buildValidPlan());
+    const { root, workspaceRoot, dataDir } = makePaths();
+    const written = writePlanMarkdown(dataDir, workspaceRoot, "unsafe-plan", buildValidPlan());
     const workspaceName = written.planRef.slice(0, written.planRef.lastIndexOf(":"));
     const planPath = path.join(dataDir, "workspaces", workspaceName, "plans", "unsafe-plan.md");
     const outside = path.join(root, "outside.md");
@@ -105,8 +105,8 @@ describe("Fleet Plan store", () => {
 
   it("rejects a symlinked Plans directory for reads and writes", () => {
     if (process.platform === "win32") return;
-    const { root, cwd, dataDir } = makePaths();
-    const written = writePlanMarkdown(dataDir, cwd, "unsafe-directory", buildValidPlan());
+    const { root, workspaceRoot, dataDir } = makePaths();
+    const written = writePlanMarkdown(dataDir, workspaceRoot, "unsafe-directory", buildValidPlan());
     const workspaceName = written.planRef.slice(0, written.planRef.lastIndexOf(":"));
     const plansPath = path.join(dataDir, "workspaces", workspaceName, "plans");
     const outside = path.join(root, "outside-plans");
@@ -115,15 +115,15 @@ describe("Fleet Plan store", () => {
     symlinkSync(outside, plansPath, "dir");
 
     expect(() => readPlanMarkdown(dataDir, written.planRef)).toThrow(/directory not found or unsafe/);
-    expect(() => writePlanMarkdown(dataDir, cwd, "another-plan", buildValidPlan())).toThrow(/Unsafe Fleet directory/);
+    expect(() => writePlanMarkdown(dataDir, workspaceRoot, "another-plan", buildValidPlan())).toThrow(/Unsafe Fleet directory/);
   });
 });
 
-function makePaths(): { cwd: string; dataDir: string; root: string } {
+function makePaths(): { dataDir: string; root: string; workspaceRoot: string } {
   const root = mkdtempSync(path.join(os.tmpdir(), "fleet-plans-"));
   cleanupPaths.push(root);
-  const cwd = path.join(root, "repo");
+  const workspaceRoot = path.join(root, "repo");
   const dataDir = path.join(root, "data");
-  mkdirSync(cwd, { recursive: true });
-  return { cwd, dataDir, root };
+  mkdirSync(workspaceRoot, { recursive: true });
+  return { dataDir, root, workspaceRoot };
 }

--- a/runtime/fleet-cli/src/app.ts
+++ b/runtime/fleet-cli/src/app.ts
@@ -8,6 +8,7 @@ import {
   resolveAgentCliId,
   resolveAgentCliProfile,
 } from "@dotobokuri/fleet-admiral";
+import { createPlanWorkspaceServerBindings } from "@dotobokuri/fleet-plans";
 
 import {
   assertInputContract,
@@ -73,10 +74,12 @@ export function createMissionControlProfileConfig(
 }
 
 export async function runApp(options: RunAppOptions = {}): Promise<void> {
+  const invocationCwd = resolveInvocationCwd();
   const argvOptions = options.argvOptions ?? createRunAppArgOptions(options);
   const runtimeLifecycle = createFleetRuntimeLifecycle();
   const agentCliCleanupCallbacks = new Set<() => void>();
   const runtime = await runtimeLifecycle.start();
+  const planServerBindings = createFleetCliPlanServerBindings(runtime.dataDir, invocationCwd);
   const sessionOptionsRuntime = createSessionOptionsRuntime({
     argv: argvOptions,
     defaults: {
@@ -101,7 +104,6 @@ export async function runApp(options: RunAppOptions = {}): Promise<void> {
   const buildSystemPrompt = createSystemPromptBuilder({
     carrierRuntime: runtime.carrierRuntime,
   }).build;
-  const invocationCwd = resolveInvocationCwd();
   const missionControlProfileConfig = createMissionControlProfileConfig({
     authService: runtime.infraServices.authService,
     env: process.env,
@@ -123,6 +125,7 @@ export async function runApp(options: RunAppOptions = {}): Promise<void> {
         dedicatedMcpSession: runtime.dedicatedMcpSession,
         enableMetaphor: (launchOptions ?? sessionOptionsRuntime.getDraft()).enableMetaphor,
         onCleanup: (cleanup) => agentCliCleanupCallbacks.add(cleanup),
+        serverBindings: planServerBindings,
         withMarketplaceLock: withFleetMarketplaceLock,
       }),
     loadedCounts: discoverMissionControlCounts({ dataDir: runtime.dataDir, invocationCwd }),
@@ -264,6 +267,11 @@ function createRunAppArgOptions(options: RunAppOptions): FleetCliOptions {
 
 function resolveInvocationCwd(): string {
   return process.env.INIT_CWD || process.cwd();
+}
+
+/** Creates the immutable Plan storage identity captured by this Fleet CLI process. */
+export function createFleetCliPlanServerBindings(dataDir: string, invocationCwd: string) {
+  return createPlanWorkspaceServerBindings(dataDir, invocationCwd);
 }
 
 function stopApp(

--- a/runtime/fleet-cli/tests/app-plan-workspace-binding.test.ts
+++ b/runtime/fleet-cli/tests/app-plan-workspace-binding.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  createPlanWorkspaceServerBindings: vi.fn(),
+  injectAgentCliProfile: vi.fn(),
+  missionControlOptions: undefined as undefined | {
+    readonly injectProfile: (profile: { readonly cwd: string }) => Promise<unknown>;
+  },
+}));
+
+vi.mock("@dotobokuri/fleet-admiral", () => ({
+  createCarrierResultReminderRouter: () => () => {},
+  createSystemPromptBuilder: () => ({ build: () => "Fleet test prompt" }),
+  getAgentCliMetadata: () => [],
+  getDefaultAgentCliId: () => "codex",
+  injectAgentCliProfile: harness.injectAgentCliProfile,
+  parseAgentCliId: (value: string) => value,
+  resolveAgentCliId: () => "codex",
+  resolveAgentCliProfile: () => ({}),
+}));
+
+vi.mock("@dotobokuri/fleet-plans", () => ({
+  createPlanWorkspaceServerBindings: harness.createPlanWorkspaceServerBindings,
+}));
+
+vi.mock("../src/controls/index.js", () => ({
+  assertInputContract: () => {},
+  createCursorPolicySync: () => () => {},
+  createDedicatedMouseRouter: () => () => {},
+  createInputKeybindingConfig: () => ({}),
+  createInputRouter: () => ({ route: () => {} }),
+  createPtyHost: () => ({ kill: () => {}, write: () => {} }),
+  createRenderScheduler: () => () => {},
+  createTuiPtyManager: () => ({
+    getCurrentRequest: () => ({ fleetRows: 1 }),
+    requestResize: () => {},
+  }),
+  KITTY_DISABLE: "",
+  KITTY_ENABLE: "",
+}));
+
+vi.mock("../src/agent-cli/host-hooks.js", () => ({
+  runCodexCommand: () => ({}),
+  withFleetMarketplaceLock: <T>(_target: string, operation: () => T): T => operation(),
+}));
+
+vi.mock("../src/mission-control/controller.js", () => ({
+  createMissionControlController: (options: typeof harness.missionControlOptions) => {
+    harness.missionControlOptions = options;
+    return {
+      component: {},
+      dispose: () => {},
+      getActiveProfile: () => undefined,
+      hasActivePanel: () => false,
+      ptyHost: { kill: () => {}, write: () => {} },
+      ptyView: { maxRows: 1 },
+      setRelease: () => {},
+      writeChildInput: () => {},
+    };
+  },
+}));
+
+vi.mock("../src/mission-control/loaded-counts.js", () => ({ discoverMissionControlCounts: () => ({}) }));
+vi.mock("../src/mission-control/options/runtime.js", () => ({
+  createSessionOptionsRuntime: () => ({
+    getDraft: () => ({ enableMetaphor: false }),
+    getResolved: () => ({ values: { cliId: "codex" } }),
+  }),
+}));
+vi.mock("../src/mission-bridge/controller.js", () => ({
+  createMissionBridgeController: () => ({ component: {}, dispose: () => {}, ptyApi: { dispatchMouse: () => {} }, start: () => {} }),
+}));
+vi.mock("../src/release.js", () => ({ readFleetCliRelease: () => ({ version: "test" }) }));
+vi.mock("../src/runtime/runtime.js", () => ({
+  createFleetRuntimeLifecycle: () => ({
+    shutdown: async () => {},
+    start: async () => ({
+      carrierRuntime: { jobs: { streaming: { register: () => () => {} } } },
+      dataDir: "/fleet-data",
+      dedicatedMcpSession: {},
+      infraServices: { authService: {}, globalOptionsService: {} },
+    }),
+  }),
+}));
+vi.mock("../src/tui/input-stream.js", () => ({ attachInputStream: () => () => {} }));
+vi.mock("../src/tui/renderer.js", () => ({
+  LocalTui: class {
+    readonly columns = 80;
+    readonly rows = 24;
+    addInputListener(): void {}
+    refreshSize(): void {}
+    setChildren(): void {}
+    start(): void {}
+    stop(): void {}
+  },
+}));
+vi.mock("../src/update/check.js", () => ({ checkForUpdate: async () => undefined }));
+
+import { runApp } from "../src/app.js";
+
+describe("Fleet CLI Plan workspace binding", () => {
+  const originalInitCwd = process.env.INIT_CWD;
+
+  afterEach(() => {
+    harness.createPlanWorkspaceServerBindings.mockReset();
+    harness.injectAgentCliProfile.mockReset();
+    harness.missionControlOptions = undefined;
+    if (originalInitCwd === undefined) {
+      delete process.env.INIT_CWD;
+    } else {
+      process.env.INIT_CWD = originalInitCwd;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("passes the initial invocation binding through the production runApp injection callback", async () => {
+    const invocationCwd = "/theater";
+    const nestedCarrierCwd = "/theater/.fleet/worktrees/carrier-topic";
+    const serverBindings = Object.freeze({ "fleet-plans.workspace-ref": "opaque-workspace-id" });
+    const processEvents: Array<string | symbol> = [];
+    const stdoutEvents: Array<string | symbol> = [];
+    process.env.INIT_CWD = invocationCwd;
+    harness.createPlanWorkspaceServerBindings.mockReturnValue(serverBindings);
+    harness.injectAgentCliProfile.mockImplementation(async (profile: { readonly cwd: string }) => profile);
+    vi.spyOn(process, "on").mockImplementation(((event: string | symbol) => {
+      processEvents.push(event);
+      return process;
+    }) as never);
+    vi.spyOn(process.stdout, "on").mockImplementation(((event: string | symbol) => {
+      stdoutEvents.push(event);
+      return process.stdout;
+    }) as never);
+
+    await runApp({ cursorSync: false });
+    await harness.missionControlOptions!.injectProfile({ cwd: nestedCarrierCwd });
+
+    expect(harness.createPlanWorkspaceServerBindings).toHaveBeenCalledOnce();
+    expect(harness.createPlanWorkspaceServerBindings).toHaveBeenCalledWith("/fleet-data", invocationCwd);
+    expect(Object.values(serverBindings)).not.toContain(invocationCwd);
+    expect(harness.injectAgentCliProfile).toHaveBeenCalledWith(
+      { cwd: nestedCarrierCwd },
+      expect.objectContaining({ serverBindings }),
+    );
+    expect(stdoutEvents).toEqual(["resize"]);
+    expect(processEvents).toEqual([
+      "SIGWINCH",
+      "SIGTERM",
+      "SIGHUP",
+      "uncaughtException",
+      "unhandledRejection",
+      "exit",
+    ]);
+  });
+});

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -155,6 +155,27 @@ describe("createDefaultTerminalLaunchResolver", () => {
     });
   });
 
+  it("forwards host-only bindings to dedicated MCP without changing the selected execution cwd", async () => {
+    const runtime = createFakeRuntime(() => undefined);
+    const bindings = Object.freeze({ "fleet-plans.workspace-ref": "opaque-workspace" });
+    const resolveProfile = vi.fn(async (env: NodeJS.ProcessEnv, cwd: string) => ({ ...baseProfile, cwd, env: { ...env } }));
+    const injectProfile = vi.fn(async (profile: AgentCliProfile) => profile);
+    const resolve = createDefaultTerminalLaunchResolver({
+      cwd: "/work",
+      env: { PATH: "/bin" } as NodeJS.ProcessEnv,
+      agentRuntime: runtime as never,
+      injectProfile: injectProfile as never,
+      resolveProfile: resolveProfile as never,
+      resolveServerBindings: (context) => context?.theaterId === "theater-a" ? bindings : undefined,
+    });
+
+    const spec = await resolve("/work/.fleet/worktrees/topic", { sessionId: "session-a", theaterId: "theater-a" });
+
+    expect(spec.cwd).toBe("/work/.fleet/worktrees/topic");
+    expect(injectProfile).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({ serverBindings: bindings }));
+    expect(JSON.stringify(spec)).not.toContain("opaque-workspace");
+  });
+
   it("passes a selected Agent CLI id to fleet-admiral profile resolution", async () => {
     const runtime = createFakeRuntime(() => undefined);
     const resolveProfile = vi.fn(async (env: NodeJS.ProcessEnv, cwd: string) => ({ ...baseProfile, id: "codex" as const, label: "Codex", cwd, env: { ...env } }));

--- a/runtime/fleet-console/tests/plans-security.test.ts
+++ b/runtime/fleet-console/tests/plans-security.test.ts
@@ -7,6 +7,7 @@ import type http from "node:http";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { ensureWorkspaceDirectory } from "@dotobokuri/core-infra/workspace-dir";
+import { createPlanWorkspaceServerBindings, getPlanToolSpecs } from "@dotobokuri/fleet-plans";
 
 import { createPlansRouter } from "../core/host/plans/routes.js";
 
@@ -133,6 +134,83 @@ describe("Plans handlers — security", () => {
     const nestedRead = createContext({ theaterId: "theater", name: "nested.md" }, () => theaterPath);
     await handlePlansRead({ method: "POST" } as http.IncomingMessage, {} as http.ServerResponse, nestedRead.ctx);
     expect(nestedRead.responses).toEqual([{ status: 404, body: { error: "not_found" } }]);
+  });
+
+  it("shows a Plan written from a Carrier worktree through the active Theater routes", async () => {
+    const carrierCwd = path.join(theaterPath, ".fleet", "worktrees", "carrier-topic");
+    await fs.promises.mkdir(carrierCwd, { recursive: true });
+    const specs = getPlanToolSpecs({ dataDir: fleetDataDir });
+    const serverBindings = createPlanWorkspaceServerBindings(fleetDataDir, theaterPath);
+    const markdown = `# Objective
+
+Keep the Plan visible from its active Theater.
+
+# File Ownership
+
+- W1-A owns plans/**
+
+# Execution Topology
+
+- Execution mode: Sequential
+- Shared mutable resources: Theater PlanStore
+
+# Waves
+
+## Wave 1 — Theater visibility
+
+### Lane W1-A — Theater Plan binding
+
+- Exact write set:
+  - plans/**
+- Read dependencies:
+  - Not applicable
+- Dependency/start condition: Theater root resolved
+- Eligible concurrent lanes: none
+- Integration gate: Theater routes return the Plan
+- Handoff: Theater-visible Plan
+- Rollback unit: Plan fixture
+- Implementation summary:
+  - [ ] W1-A-T1 — Write the Theater-bound Plan
+- Verification/static checks:
+  - plan lint
+- Escalation triggers: Theater binding unavailable
+
+# Dispatch Manifest
+
+- Full-plan Ohio invocation: unavailable; dispatch explicit same-Lane TaskRefs only
+- Lane W1-A — exact write set, dependencies, gate, handoff, and rollback from W1-A
+
+# QA Gates
+
+- The Theater list and read routes return the written Plan.
+
+# Acceptance Criteria
+
+- A Carrier worktree write resolves to the Theater PlanStore.
+
+# Documentation Updates
+
+- No documentation update required.
+
+# Final Review Loop
+
+- Verify the Theater route response contains the Plan.
+`;
+
+    const written = await specs.write.execute({
+      plan_id: "theater-bound",
+      markdown,
+    }, { cwd: carrierCwd, serverBindings });
+    const list = createContext({ theaterId: "theater" }, () => theaterPath);
+    const read = createContext({ theaterId: "theater", name: "theater-bound.md" }, () => theaterPath);
+    await handlePlansList({ method: "POST" } as http.IncomingMessage, {} as http.ServerResponse, list.ctx);
+    await handlePlansRead({ method: "POST" } as http.IncomingMessage, {} as http.ServerResponse, read.ctx);
+
+    expect(written).toMatchObject({ ok: true });
+    expect((list.responses[0] as { readonly body: { readonly plans: Array<{ readonly name: string }> } }).body.plans).toEqual(expect.arrayContaining([expect.objectContaining({ name: "theater-bound.md" })]));
+    expect(read.responses).toEqual([expect.objectContaining({ status: 200, body: expect.objectContaining({ markdown }) })]);
+    expect(JSON.stringify({ list: list.responses, read: read.responses })).not.toContain(carrierCwd);
+    expect(JSON.stringify({ list: list.responses, read: read.responses })).not.toContain("fleet-plans.workspace-ref");
   });
 
   it("rejects legacy or path-shaped Plan scope before Theater lookup", async () => {

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { initStore, resetStoreForTests } from "@dotobokuri/fleet-carriers";
+import { ensureWorkspaceDirectory } from "@dotobokuri/core-infra/workspace-dir";
 
 import type { ConsoleLockPayload } from "../core/host/api-types.js";
 import { DESKTOP_FULLSCREEN_EVENT, DESKTOP_FULLSCREEN_PATH } from "../core/host/desktop-fullscreen.js";
@@ -18,11 +19,12 @@ import type { AgentCliDetector } from "../../fleet-plugins/terminal/server/agent
 import { workspaceHash } from "../core/host/theater.js";
 import { TheaterRegistry } from "../core/host/theaters.js";
 import { WorkspaceRegistry } from "../core/host/codex/workspaces.js";
-import type { TerminalLaunchSpec, TerminalPtyHandle } from "../../fleet-plugins/terminal/server/shared/terminal-types.js";
+import type { TerminalLaunchContext, TerminalLaunchSpec, TerminalPtyHandle } from "../../fleet-plugins/terminal/server/shared/terminal-types.js";
 import { createPluginTerminalUpgradeHandler } from "../../fleet-plugins/terminal/server/shared/ws.js";
 
 const fleetAdmiralMock = vi.hoisted(() => ({
   agentRuntimeQueue: [] as unknown[],
+  resolveProfile: null as null | ((...args: readonly unknown[]) => unknown),
 }));
 
 vi.mock("@dotobokuri/fleet-admiral", async (importOriginal) => {
@@ -31,6 +33,8 @@ vi.mock("@dotobokuri/fleet-admiral", async (importOriginal) => {
     ...actual,
     createFleetAgentRuntimeLifecycle: (deps: Parameters<typeof actual.createFleetAgentRuntimeLifecycle>[0]) =>
       fleetAdmiralMock.agentRuntimeQueue.shift() ?? actual.createFleetAgentRuntimeLifecycle(deps),
+    resolveAgentCliProfile: (...args: Parameters<typeof actual.resolveAgentCliProfile>) =>
+      fleetAdmiralMock.resolveProfile?.(...args) ?? actual.resolveAgentCliProfile(...args),
   };
 });
 
@@ -45,6 +49,9 @@ interface ServerFixture {
 
 interface FakeConsoleRuntime {
   readonly carrierRuntime: {
+    readonly registry: {
+      getState(): { readonly registeredOrder: readonly string[] };
+    };
     readonly jobs: {
       readonly streaming: {
         register(callback: (event: unknown) => void): () => void;
@@ -52,7 +59,8 @@ interface FakeConsoleRuntime {
     };
   };
   readonly dedicatedMcpSession: {
-    issueSessionToken(request: { readonly label: string; readonly cwd: string }): readonly { readonly name: string; readonly token: string }[];
+    getEndpoint(): Promise<{ readonly servers: readonly { readonly name: string; readonly url: string }[] }>;
+    issueSessionToken(request: { readonly label: string; readonly cwd: string; readonly serverBindings?: Readonly<Record<string, string>> }): readonly { readonly name: string; readonly token: string }[];
     releaseSessionToken(label: string): void;
   };
   readonly mcpRegistry: {
@@ -74,6 +82,7 @@ const CONSOLE_PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta
 afterEach(async () => {
   for (const server of servers.splice(0)) await server.stop();
   fleetAdmiralMock.agentRuntimeQueue.length = 0;
+  fleetAdmiralMock.resolveProfile = null;
   delete (globalThis as { __fleetTerminalLaunch?: unknown }).__fleetTerminalLaunch;
   delete (globalThis as { __fleetTerminalStartShell?: unknown }).__fleetTerminalStartShell;
   resetStoreForTests();
@@ -1408,6 +1417,117 @@ describe("console static and terminal ticket boundary", () => {
     expect(state.operations[0]?.payload?.providerSession).toMatchObject({ provider: "claude", sessionId: "provider-session-secret" });
   });
 
+  it("keeps the active Theater identity server-side across initial and resumed Agent launch", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-plan-binding-"));
+    tempDirs.push(dir);
+    const contexts: Array<TerminalLaunchContext | undefined> = [];
+    const ptys: ExitablePty[] = [];
+    const fixture = await startFixture({
+      terminalLaunch: async (cwd, context) => {
+        contexts.push(context);
+        return createMockLaunch(cwd, context);
+      },
+      terminalStartShell: () => {
+        const pty = createExitablePty();
+        ptys.push(pty);
+        return pty;
+      },
+    });
+    const theater = await createTheater(fixture, dir);
+    const created = await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions`, {
+      method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ theaterId: theater.id, cliId: "claude" }),
+    });
+    const { sessionId } = await created.json() as { readonly sessionId: string };
+    await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions/${sessionId}/capture`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${fixture.lock.token}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ provider: "claude", input: JSON.stringify({ session_id: "provider-session-a" }) }),
+    });
+    ptys[0]!.emitExit();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const resumed = await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions/${sessionId}/resume`, { method: "POST" });
+
+    expect(resumed.status).toBe(200);
+    expect(contexts).toHaveLength(2);
+    for (const context of contexts) {
+      expect(context).toEqual(expect.objectContaining({ operationId: sessionId, theaterId: theater.id }));
+    }
+    expect(JSON.stringify(contexts)).not.toContain(dir);
+    expect(JSON.stringify(contexts)).not.toContain("serverBindings");
+  });
+
+  it("issues Theater-bound dedicated MCP sessions from the real Agent Operation resolver on launch and resume", async () => {
+    const theaterRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-plan-binding-theater-"));
+    const carrierWorktree = path.join(theaterRoot, ".fleet", "worktrees", "carrier-topic");
+    fs.mkdirSync(carrierWorktree, { recursive: true });
+    tempDirs.push(theaterRoot);
+    const theaterRealpath = fs.realpathSync.native(theaterRoot);
+    const theaterId = workspaceHash(theaterRealpath);
+    const tokenRequests: Array<{ readonly label: string; readonly cwd: string; readonly serverBindings?: Readonly<Record<string, string>> }> = [];
+    const runtime = createFakeConsoleRuntime([], [], tokenRequests);
+    fleetAdmiralMock.agentRuntimeQueue.push(runtime);
+    fleetAdmiralMock.resolveProfile = async (_env, cwd) => ({
+      id: "claude" as const,
+      label: "Claude Code",
+      bin: "/bin/claude",
+      args: [],
+      cwd: String(cwd),
+      env: { PATH: "/bin", TERM: "xterm-256color" },
+      messagePolicy: { bracketedPaste: true, multilineStrategy: "paste-mode" },
+      terminalName: "xterm-256color",
+    });
+    const fixture = await startFixture({
+      beforeCreateServer: ({ carrierStoreDir }) => {
+        const consoleDir = path.join(carrierStoreDir, "console");
+        fs.mkdirSync(consoleDir, { recursive: true });
+        fs.writeFileSync(path.join(consoleDir, "state.json"), JSON.stringify({
+          version: 2,
+          theaters: [{ id: theaterId, path: theaterRoot, realpath: theaterRealpath, label: path.basename(theaterRoot), registeredAt: "2026-07-18T00:00:00.000Z", lastOpenedAt: "2026-07-18T00:00:00.000Z" }],
+          operations: [{
+            id: "resume-session",
+            theaterId,
+            type: "agent",
+            pluginId: "terminal",
+            title: "Carrier",
+            payload: { cwd: carrierWorktree, cliId: "claude", providerSession: { provider: "claude", sessionId: "provider-session-a", capturedAt: "2026-07-18T00:00:00.000Z" } },
+            geometry: null,
+            state: {},
+            ts: { createdAt: 1, updatedAt: 1 },
+          }],
+        }));
+      },
+      terminalStartShell: () => createFakePty(),
+    });
+    expect(fleetAdmiralMock.agentRuntimeQueue).toEqual([]);
+
+    const created = await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ theaterId, cliId: "claude" }),
+    });
+    const initial = await created.json() as { readonly sessionId: string };
+    const resumed = await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions/resume-session/resume`, { method: "POST" });
+    const operations = await getJson<unknown>(`${fixture.endpoint}api/v1/operations`);
+    const sessions = await getJson<unknown>(`${fixture.endpoint}plugins/terminal/agent/sessions`);
+    const expectedBinding = ensureWorkspaceDirectory(fixture.carrierStoreDir, theaterRealpath).name;
+    const marketplaceRoot = path.join(fixture.carrierStoreDir, "marketplace");
+    const serialized = JSON.stringify({ operations, sessions });
+
+    expect(created.status).toBe(200);
+    expect(resumed.status).toBe(200);
+    expect(tokenRequests).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: initial.sessionId, cwd: theaterRealpath, serverBindings: { "fleet-plans.workspace-ref": expectedBinding } }),
+      expect.objectContaining({ label: "resume-session", cwd: carrierWorktree, serverBindings: { "fleet-plans.workspace-ref": expectedBinding } }),
+    ]));
+    expect(fs.existsSync(path.join(marketplaceRoot, "plugins"))).toBe(true);
+    expect(fs.realpathSync.native(marketplaceRoot).startsWith(`${fs.realpathSync.native(fixture.carrierStoreDir)}${path.sep}`)).toBe(true);
+    expect(marketplaceRoot.startsWith(`${os.homedir()}${path.sep}`)).toBe(false);
+    expect(serialized).not.toContain(theaterRoot);
+    expect(serialized).not.toContain(carrierWorktree);
+    expect(serialized).not.toContain(expectedBinding);
+    expect(runtime.cleanup).not.toHaveBeenCalled();
+  });
+
   it("acknowledges, deduplicates, persists, and sanitizes deferred provider identity refreshes", async () => {
     const deferred = createDeferred<string | null>();
     const resolverInputs: string[] = [];
@@ -2351,7 +2471,7 @@ async function startFixture(options: {
   readonly agentRuntime?: ConsoleServerDeps["agentRuntime"];
   readonly agentCliDetector?: ConsoleServerDeps["agentCliDetector"];
   readonly beforeCreateServer?: (paths: { readonly carrierStoreDir: string }) => void;
-  readonly terminalLaunch?: (cwd?: string, context?: { readonly sessionId?: string; readonly cliId?: string; readonly resumeSessionId?: string }) => Promise<TerminalLaunchSpec>;
+  readonly terminalLaunch?: (cwd?: string, context?: TerminalLaunchContext) => Promise<TerminalLaunchSpec>;
   readonly terminalStartShell?: (launch: TerminalLaunchSpec) => TerminalPtyHandle;
   readonly release?: ConsoleServerDeps["release"];
   readonly updateApply?: ConsoleServerDeps["updateApply"];
@@ -2500,10 +2620,17 @@ async function fetchWithBlockedPortRetry(request: (fixture: ServerFixture) => Pr
   throw lastError;
 }
 
-function createFakeConsoleRuntime(issuedLabels: string[], releasedLabels: string[]): FakeConsoleRuntime {
+function createFakeConsoleRuntime(
+  issuedLabels: string[],
+  releasedLabels: string[],
+  tokenRequests: Array<{ readonly label: string; readonly cwd: string; readonly serverBindings?: Readonly<Record<string, string>> }> = [],
+): FakeConsoleRuntime {
   const handlers = new Set<(event: unknown) => void>();
   return {
     carrierRuntime: {
+      registry: {
+        getState: () => ({ registeredOrder: [] }),
+      },
       jobs: {
         streaming: {
           register(callback) {
@@ -2514,8 +2641,10 @@ function createFakeConsoleRuntime(issuedLabels: string[], releasedLabels: string
       },
     },
     dedicatedMcpSession: {
+      getEndpoint: async () => ({ servers: [{ name: "fleet-tools", url: "http://127.0.0.1/fleet-tools" }] }),
       issueSessionToken(request) {
         issuedLabels.push(request.label);
+        tokenRequests.push(request);
         return [{ name: "fleet-tools", token: `token-${request.label}` }];
       },
       releaseSessionToken(label) {

--- a/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
-import { resolvePathBinary } from "@dotobokuri/core-agent";
+import { resolvePathBinary, type AgentServerBindings } from "@dotobokuri/core-agent";
 import { createSessionIdentityResolver } from "@dotobokuri/core-unified-agent";
 import {
   createSystemPromptBuilder,
@@ -36,6 +36,8 @@ export interface TerminalLaunchResolverDeps {
   readonly onRuntimeSessionStart?: (session: ConsoleRuntimeSessionInfo) => void;
   readonly resolveProfile?: typeof resolveAgentCliProfile;
   readonly createSessionIdentityResolver?: typeof createSessionIdentityResolver;
+  /** Resolves host-owned MCP bindings from the in-memory launch context only. */
+  readonly resolveServerBindings?: (context: TerminalLaunchContext | undefined) => AgentServerBindings | undefined;
 }
 
 export interface ConsoleRuntimeSessionInfo {
@@ -100,6 +102,7 @@ export function createAgentTerminalLaunchResolver(deps: TerminalLaunchResolverDe
       cliId: context?.cliId,
       createSessionIdentityResolver: resolveSessionIdentityResolver,
       resumeSessionId: context?.resumeSessionId,
+      serverBindings: deps.resolveServerBindings?.(context),
       sessionId,
     });
   };
@@ -137,6 +140,7 @@ async function createAgentCliLaunchSpec(options: {
   readonly onRuntimeSessionStart?: (session: ConsoleRuntimeSessionInfo) => void;
   readonly resolveProfile: typeof resolveAgentCliProfile;
   readonly resumeSessionId?: string;
+  readonly serverBindings?: AgentServerBindings;
   readonly sessionId: string;
 }): Promise<TerminalLaunchSpec> {
   const cleanupStack: Array<() => void | Promise<void>> = [];
@@ -164,6 +168,7 @@ async function createAgentCliLaunchSpec(options: {
       autoNameHookExec: buildConsoleAutoNameHookCommand(options.hookEntry),
       onCleanup: (cleanup) => cleanupStack.push(cleanup),
       resumeSessionId: options.resumeSessionId,
+      serverBindings: options.serverBindings,
       withMarketplaceLock: withConsoleMarketplaceLock,
       mcpSessionLabel: options.sessionId,
     } as Parameters<typeof injectAgentCliProfile>[1] & { readonly mcpSessionLabel: string });

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import process from "node:process";
 
 import { createCarrierResultReminderRouter, createDelayedPtyWriter, createFleetAgentRuntimeLifecycle, formatCarrierResultReminderMessage, getAgentCliAuthStatuses, getAgentCliMetadata, parseAgentCliId, sanitizeCarrierResultReminder, type AgentCliId } from "@dotobokuri/fleet-admiral";
-import { getPlanToolSpecs } from "@dotobokuri/fleet-plans";
+import { createPlanWorkspaceServerBindings, getPlanToolSpecs } from "@dotobokuri/fleet-plans";
 import { getCarrierConfig, resolveAgentCliType } from "@dotobokuri/fleet-carriers";
 import { ensureWorkspaceDirectory, withDirectoryLock, type AuthService, type GlobalOptionsService } from "@dotobokuri/core-infra";
 import { createWikiWorkspaceResolver, getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
@@ -96,7 +96,16 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
   const jobOriginById = new Map<string, string>();
   const launchResolver = createAgentTerminalLaunchResolver({
     agentRuntime: runtime,
+    dataDir: ctx.host.paths.fleetDataDir,
     infraServices: deps,
+    resolveServerBindings: (launchContext) => {
+      const operationId = launchContext?.operationId;
+      if (!operationId) return undefined;
+      const operation = ctx.host.operations.get(operationId);
+      if (!operation || operation.pluginId !== ctx.pluginId || operation.type !== AGENT_OPERATION_TYPE) return undefined;
+      const theaterRoot = ctx.host.paths.resolveTheaterPath(operation.theaterId);
+      return theaterRoot ? createPlanWorkspaceServerBindings(ctx.host.paths.fleetDataDir, theaterRoot) : undefined;
+    },
     onRuntimeSessionStart: (session) => {
       pendingRuntimeSessions.set(session.sessionId, session);
     },
@@ -457,7 +466,15 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     const operation = ctx.host.operations.get(operationId);
     const cliId = typeof operation?.payload.cliId === "string" ? operation.payload.cliId : undefined;
     const providerSession = readProviderSession(operation?.payload)?.sessionId;
-    return launchResolver(cwd, { sessionId: operationId, operationId, operationType: AGENT_OPERATION_TYPE, pluginId: ctx.pluginId, cliId, resumeSessionId: providerSession });
+    return launchResolver(cwd, {
+      sessionId: operationId,
+      operationId,
+      operationType: AGENT_OPERATION_TYPE,
+      pluginId: ctx.pluginId,
+      ...(operation?.theaterId ? { theaterId: operation.theaterId } : {}),
+      ...(cliId ? { cliId } : {}),
+      ...(providerSession ? { resumeSessionId: providerSession } : {}),
+    });
   }
 
   async function handleExit(operationId: string): Promise<void> {

--- a/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
@@ -19,6 +19,7 @@ export interface TerminalLaunchContext {
   readonly operationId?: string;
   readonly operationType?: string;
   readonly pluginId?: string;
+  /** Opaque server-owned Theater identity; never a browser path or Plan binding. */
   readonly theaterId?: string;
   readonly kind?: "fleet" | "shell";
   readonly cliId?: string;


### PR DESCRIPTION
## Summary

- Propagate immutable server-only bindings through dedicated and one-shot MCP sessions and Carrier dispatches.
- Bind Fleet CLI Plan storage to the initial invocation root and Console Agent Operations to the server-resolved active Theater.
- Make `plan_write` fail closed when its host-bound workspace binding is missing or invalid.

## Type of Change

- [x] fix — bug fix

## Test Plan

- [x] `git diff --check origin/canary`
- [x] Scoped static and production-wiring review — PASS
- [ ] Package Vitest/typecheck — not run because this dedicated worktree has no installed dependencies and the worktree workflow prohibits dependency installation

## Changelog

- [x] Added `.changelog.d/pr-295.md`
- [x] Used grouped product/section syntax with adjacent bilingual summaries
- [x] `node scripts/compile-changelog-fragments.mjs --check`

## Notes for Reviewers

- The binding remains server-only and opaque to Agent CLI arguments, environment, prompts, Console DTOs, and browser-visible state.
- The execution cwd remains the Carrier worktree; only Plan storage authority is bound to the host-selected workspace.