### PR TITLE
fix(console): preserve panel rename input width

### DIFF
--- a/.changelog.d/pr-296.md
+++ b/.changelog.d/pr-296.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Keep in-panel names visible while editing them.
+  ko: 패널 안에서 이름을 편집할 때 입력 중인 내용을 정상적으로 표시합니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2918,7 +2918,7 @@
 
 .canvas-operation-identity-input {
   flex: 1 1 auto;
-  width: 0;
+  width: min(28ch, 34vw);
   padding: 3px 6px;
   border: 1px solid color-mix(in oklch, var(--brass) 68%, transparent);
   border-radius: var(--radius-sm);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -403,6 +403,9 @@ describe("Instrument core design contract", () => {
     expect(components).toContain(".canvas-operation-identity-name,");
     expect(components).toContain("font-family: var(--font-body);");
     expect(components).toContain("font-size: calc(var(--font-body-size) * 0.86);");
+    const identityInputBlock = components.match(/^\.canvas-operation-identity-input \{\n  flex: 1 1 auto;[^}]*\}/m)?.[0] ?? "";
+    expect(identityInputBlock).toContain("width: min(28ch, 34vw);");
+    expect(identityInputBlock).not.toContain("width: 0;");
     expect(components).toContain("top: calc(-1 * var(--space-3));");
     expect(components).toContain("border-radius: 999px;");
     expect(components).toContain("background: var(--ink-mid);");


### PR DESCRIPTION
## Summary

- Give the in-panel rename input a bounded non-zero width so typed names remain visible beside the panel controls.
- Add a design-contract regression assertion that rejects the previous zero-width rule.

## Test Plan

- [x] `pnpm --dir runtime/fleet-console exec vitest run tests/operation-frame-identity.test.ts tests/instrument-design-contract.test.ts` — 29 tests passed.
- [x] `pnpm --dir runtime/fleet-console exec tsc --noEmit -p core/client/tsconfig.json`
- [x] `pnpm --dir runtime/fleet-console exec vite build --config core/client/vite.config.ts`
- [x] Isolated Console E2E: typed `in-panel typing` remained fully visible at 219.125px; Enter commit and Escape cancel passed; no page or console errors.

## Changelog

- [x] Added `.changelog.d/pr-296.md`.
- [x] Validated grouped bilingual fragment syntax with `node scripts/compile-changelog-fragments.mjs --check`.

## Notes

- The full package build could not complete in the fresh worktree because unrelated workspace package dependency links were unavailable; the changed client production bundle and isolated runtime scenario were verified directly.
