### PR TITLE
fix(repository): align REFS list visuals with the approved design

### DIFF
--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -64,9 +64,31 @@ function RepositoryPanel({ ctx }: RepositoryPanelProps) {
 }
 
 type Source = "changes" | "history" | "branches" | "tags" | "stashes" | "worktrees";
-type RepositoryWorktree = { name: string; branch: string | null; current: boolean };
-type RefItem = { label: string; ref: string; current: boolean };
-type Refs = { branches: RefItem[]; remotes: RefItem[]; tags: RefItem[]; stashes: { name: string; subject: string }[]; worktrees: RepositoryWorktree[] };
+type RefSource = Exclude<Source, "changes" | "history">;
+export type RepositoryWorktree = { name: string; branch: string | null; current: boolean };
+export type RepositoryRefItem = { label: string; ref: string; current: boolean };
+export type RepositoryStash = { name: string; subject: string };
+export type RepositoryRefs = { branches: RepositoryRefItem[]; remotes: RepositoryRefItem[]; tags: RepositoryRefItem[]; stashes: RepositoryStash[]; worktrees: RepositoryWorktree[] };
+export type RepositoryRefRow = { key: string; source: RefSource; primary: string; sub?: string; ref: string | null; current: boolean };
+export type RepositoryRefGroup = { label?: "LOCAL" | "REMOTES"; rows: RepositoryRefRow[] };
+type Refs = RepositoryRefs;
+
+export function isRemoteHeadRef(ref: string): boolean {
+  return /^refs\/remotes\/[^/]+\/HEAD$/.test(ref);
+}
+
+export function buildRefListGroups(source: RefSource, refs: RepositoryRefs): RepositoryRefGroup[] {
+  const refRows = (items: readonly RepositoryRefItem[], rowSource: "branches" | "tags"): RepositoryRefRow[] => items.map((item) => ({ key: item.ref, source: rowSource, primary: item.label, ref: item.ref, current: item.current }));
+  if (source === "branches") {
+    return [
+      { label: "LOCAL", rows: refRows(refs.branches, "branches") },
+      { label: "REMOTES", rows: refRows(refs.remotes.filter((item) => !isRemoteHeadRef(item.ref)), "branches") },
+    ];
+  }
+  if (source === "tags") return [{ rows: refRows(refs.tags, "tags") }];
+  if (source === "stashes") return [{ rows: refs.stashes.map((item) => ({ key: item.name, source, primary: item.subject || item.name, sub: item.name, ref: null, current: false })) }];
+  return [{ rows: refs.worktrees.map((item) => ({ key: item.name, source, primary: item.branch ?? item.name, ...(item.branch && item.branch !== item.name ? { sub: item.name } : {}), ref: null, current: item.current })) }];
+}
 function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   const [source, setSourceState] = useState<Source>(readRepositorySource);
   const [refFilter, setRefFilter] = useState<string | null>(null);
@@ -171,8 +193,11 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
 }
 
 function SourceIcon({ source }: { readonly source: Source }) { const path = source === "changes" ? "M3 4h12M3 9h12M3 14h12" : source === "history" ? "M4 4v10h10M7 7h6v5" : source === "branches" ? "M5 3v12M5 6h7M5 12h7" : source === "tags" ? "M3 4h8l4 4-7 7-5-5z" : source === "stashes" ? "M4 5h10v9H4zM6 3h6" : "M3 5h5l1 2h6v7H3z"; return <svg viewBox="0 0 18 18" aria-hidden="true"><path d={path} fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" /></svg>; }
-function SourceNav({ source, refs, onSource }: { readonly source: Source; readonly refs: Refs; readonly onSource: (source: Source) => void; readonly onRef: (ref: string) => void }) { const button = (id: Source, label: string, count?: number) => <button key={id} type="button" aria-label={label} aria-current={source === id ? "page" : undefined} onClick={() => onSource(id)}><SourceIcon source={id} /><span>{label}</span>{count !== undefined && <i>{count}</i>}</button>; return <nav className="repository-source-nav" aria-label="Repository sources"><b>WORKING</b>{button("changes", "Changes")}{button("history", "History")}<b>REFS</b>{button("branches", "Branches", refs.branches.length + refs.remotes.length)}{button("tags", "Tags", refs.tags.length)}{button("stashes", "Stashes", refs.stashes.length)}{button("worktrees", "Worktrees", refs.worktrees.length)}</nav>; }
-function RefList({ source, refs, onRef }: { readonly source: Source; readonly refs: Refs; readonly onRef: (ref: string) => void }) { const rows = source === "branches" ? [...refs.branches, ...refs.remotes] : source === "tags" ? refs.tags : source === "stashes" ? refs.stashes.map((item) => ({ label: `${item.name} ${item.subject}`, ref: "", current: false })) : refs.worktrees.map((item) => ({ label: item.branch ?? item.name, ref: "", current: item.current })); return <div className="repository-ref-list">{rows.map((row) => <button type="button" key={row.ref || row.label} className={row.current ? "is-current" : ""} disabled={!row.ref} onClick={() => onRef(row.ref)}>{row.label}{row.current && " ✓"}</button>)}</div>; }
+function SourceNav({ source, refs, onSource }: { readonly source: Source; readonly refs: Refs; readonly onSource: (source: Source) => void; readonly onRef: (ref: string) => void }) { const button = (id: Source, label: string, count?: number) => <button key={id} type="button" aria-label={label} aria-current={source === id ? "page" : undefined} onClick={() => onSource(id)}><SourceIcon source={id} /><span>{label}</span>{count !== undefined && <i>{count}</i>}</button>; return <nav className="repository-source-nav" aria-label="Repository sources"><b>WORKING</b>{button("changes", "Changes")}{button("history", "History")}<b>REFS</b>{button("branches", "Branches", refs.branches.length + refs.remotes.filter((item) => !isRemoteHeadRef(item.ref)).length)}{button("tags", "Tags", refs.tags.length)}{button("stashes", "Stashes", refs.stashes.length)}{button("worktrees", "Worktrees", refs.worktrees.length)}</nav>; }
+function RefList({ source, refs, onRef }: { readonly source: Source; readonly refs: Refs; readonly onRef: (ref: string) => void }) {
+  if (source === "changes" || source === "history") return null;
+  return <div className="repository-ref-list">{buildRefListGroups(source, refs).map((group) => <div key={group.label ?? source} className="repository-ref-group">{group.label && <b className="repository-ref-group-label">{group.label}</b>}{group.rows.map((row) => <button type="button" key={row.key} className={`repository-ref-row${row.current ? " is-current" : ""}`} disabled={row.ref === null} onClick={() => { if (row.ref) onRef(row.ref); }}><SourceIcon source={row.source} /><span className="repository-ref-name">{row.primary}{row.current && " ✓"}</span>{row.sub && <span className="repository-ref-sub">{row.sub}</span>}</button>)}</div>)}</div>;
+}
 
 function RepositoryIcon() {
   return <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><rect x="2" y="4" width="6" height="1.5" rx="0.5" fill="currentColor" opacity="0.5" /><rect x="2" y="7" width="10" height="1.5" rx="0.5" fill="currentColor" /><rect x="2" y="10" width="8" height="1.5" rx="0.5" fill="currentColor" opacity="0.5" /><rect x="2" y="13" width="12" height="1.5" rx="0.5" fill="currentColor" /></svg>;

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -961,8 +961,18 @@
 /* 숨김-마운트 래퍼가 높이 문맥을 끊으면 history-root의 height:100%가 내용 높이로 풀려 내부 스크롤이 죽는다 */
 .repository-source-fill { height: 100%; min-height: 0; }
 .repository-ref-list { padding: var(--space-2); display: grid; gap: 2px; }
-.repository-ref-list button, .repository-wip-row, .repository-ref-chip { border: 0; background: transparent; color: var(--text-secondary); font: inherit; text-align: left; padding: 7px 10px; }
-.repository-ref-list .is-current, .repository-wip-row { color: var(--brass); }
+.repository-ref-group { display: grid; gap: 2px; }
+.repository-ref-group-label { padding: 8px 10px 2px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 9.5px; font-weight: 400; letter-spacing: .18em; text-transform: uppercase; }
+.repository-ref-row { display: flex; align-items: center; gap: 9px; width: 100%; border: 0; border-radius: var(--radius-xs); background: transparent; color: var(--text-secondary); cursor: pointer; font: inherit; text-align: left; padding: 7px 10px; transition: color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide); }
+.repository-ref-row:hover { background: var(--ink-mid); color: var(--text-primary); }
+.repository-ref-row:disabled { cursor: default; }
+.repository-ref-row.is-current { color: var(--brass); }
+.repository-ref-row.is-current:hover { color: var(--brass); }
+.repository-ref-row svg { width: 13px; height: 13px; flex: none; opacity: .85; }
+.repository-ref-name { min-width: 0; overflow: hidden; font-size: 12.5px; font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }
+.repository-ref-sub { margin-left: auto; color: var(--text-tertiary); flex: none; font-family: var(--font-mono); font-size: 10px; }
+.repository-wip-row, .repository-ref-chip { border: 0; background: transparent; color: var(--text-secondary); font: inherit; text-align: left; padding: 7px 10px; }
+.repository-wip-row { color: var(--brass); }
 .repository-wip-row { width: 100%; border-bottom: 1px dashed var(--hairline); }
 .repository-wip-row span { float: right; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; }
 @container (max-width: 420px) { .repository-source-nav { width: 44px; } .repository-source-nav button { display: grid; place-items: center; padding: 5px; } .repository-source-nav button span, .repository-source-nav button i, .repository-source-nav b { display: none; } }

--- a/runtime/fleet-plugins/repository/tests/repository-ref-list.test.ts
+++ b/runtime/fleet-plugins/repository/tests/repository-ref-list.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { buildRefListGroups, isRemoteHeadRef } from "../client/rail-panel.js";
+
+describe("Repository ref list rows", () => {
+  it("excludes symbolic remote HEAD refs from the REMOTES group", () => {
+    const refs = {
+      branches: [{ label: "main", ref: "refs/heads/main", current: true }],
+      remotes: [
+        { label: "origin", ref: "refs/remotes/origin/HEAD", current: false },
+        { label: "origin/main", ref: "refs/remotes/origin/main", current: false },
+      ],
+      tags: [], stashes: [], worktrees: [],
+    };
+
+    expect(isRemoteHeadRef("refs/remotes/origin/HEAD")).toBe(true);
+    expect(isRemoteHeadRef("refs/remotes/origin/main")).toBe(false);
+    expect(buildRefListGroups("branches", refs)).toEqual([
+      { label: "LOCAL", rows: [{ key: "refs/heads/main", source: "branches", primary: "main", ref: "refs/heads/main", current: true }] },
+      { label: "REMOTES", rows: [{ key: "refs/remotes/origin/main", source: "branches", primary: "origin/main", ref: "refs/remotes/origin/main", current: false }] },
+    ]);
+  });
+
+  it("maps stash and worktree primary and secondary labels", () => {
+    const refs = {
+      branches: [], remotes: [], tags: [],
+      stashes: [{ name: "stash@{0}", subject: "WIP: preserve selection" }, { name: "stash@{1}", subject: "" }],
+      worktrees: [{ name: "repository-ref-list-polish", branch: "repository-ref-list-polish", current: true }, { name: "detached", branch: null, current: false }, { name: "worktree-dir", branch: "topic", current: false }],
+    };
+
+    expect(buildRefListGroups("stashes", refs)[0]?.rows).toEqual([
+      { key: "stash@{0}", source: "stashes", primary: "WIP: preserve selection", sub: "stash@{0}", ref: null, current: false },
+      { key: "stash@{1}", source: "stashes", primary: "stash@{1}", sub: "stash@{1}", ref: null, current: false },
+    ]);
+    expect(buildRefListGroups("worktrees", refs)[0]?.rows).toEqual([
+      { key: "repository-ref-list-polish", source: "worktrees", primary: "repository-ref-list-polish", ref: null, current: true },
+      { key: "detached", source: "worktrees", primary: "detached", ref: null, current: false },
+      { key: "worktree-dir", source: "worktrees", primary: "topic", sub: "worktree-dir", ref: null, current: false },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Repository 패널 REFS 리스트를 승인 시안에 맞춥니다: LOCAL/REMOTES 그룹 헤더, 행별 소스 아이콘, 콤팩트 타이포(12.5px semibold + mono sub), 호버 피드백, brass current ✓.
- `origin/HEAD` 심볼릭 remote가 "origin" 유령 행으로 노출되던 것을 목록·카운트 모두에서 제외합니다.
- Stash 행은 subject 우선(+`stash@{n}` sub), Worktree 행은 브랜치 표기(+체크아웃 이름 sub)로 정리했습니다.

## Test Plan
- [x] `@fleet-plugins/repository` vitest 121/121(+2: remote HEAD 필터·라벨 매핑) · typecheck · build green
- [x] `@dotobokuri/fleet-console` build green
- [x] 격리 콘솔 실브라우저 검증: LOCAL/REMOTES 헤더, 13/13 행 아이콘, 12.5px/600 타이포, `origin` 유령 행 부재, `canary ✓`
- [x] Changelog: `no-changelog` — 미릴리스 PR#294 프래그먼트(pr-294.md)가 기술한 동작의 보정이므로 독립 엔트리를 내지 않음(Release Baseline 독트린)