### PR TITLE
feat(plans): add live progress, click-through nav, and list commands

### DIFF
--- a/.changelog.d/pr-298.md
+++ b/.changelog.d/pr-298.md
@@ -1,0 +1,8 @@
+### fleet-console
+#### Added
+- [fleet-console] Plans panel updates live: the list, progress bars, and the open plan reader refresh automatically when plan files change, with a one-shot pulse on changed rows.
+  ko: Plans 패널이 실시간으로 갱신됩니다. 플랜 파일이 바뀌면 목록·진행률·열린 리더가 자동 새로고침되고 변경된 행이 1회 펄스합니다.
+- [fleet-console] Plans wave and lane chips jump to their section in the plan document, and the plan list supports ArrowUp/ArrowDown, Enter, and Escape keyboard navigation.
+  ko: Plans 웨이브·레인 칩을 누르면 문서의 해당 섹션으로 이동하며, 플랜 목록이 ArrowUp/ArrowDown·Enter·Escape 키보드 탐색을 지원합니다.
+- [fleet-console] Plans list gains search, ALL/IN PROGRESS/COMPLETE status filters, a REFRESH action, and per-plan relative-path copy.
+  ko: Plans 목록에 검색, ALL/IN PROGRESS/COMPLETE 상태 필터, REFRESH 동작, 플랜별 상대 경로 복사가 추가됩니다.

--- a/runtime/fleet-console/core/client/src/rail/plans-events.ts
+++ b/runtime/fleet-console/core/client/src/rail/plans-events.ts
@@ -1,0 +1,14 @@
+const PLANS_CHANGED_EVENT = "plans-changed";
+
+/** Connects a Theater-scoped, payload-free invalidation channel. */
+export function subscribeToPlanChanges(theaterId: string, onInvalidate: () => void): () => void {
+  const source = new EventSource(`/api/v1/plans/events?theaterId=${encodeURIComponent(theaterId)}`);
+  source.addEventListener(PLANS_CHANGED_EVENT, () => {
+    // The event is only an invalidation signal. Do not trust or parse its payload.
+    onInvalidate();
+  });
+  // Native EventSource reconnects when appropriate; 404 and network failures leave
+  // the existing manual refresh path available without changing panel state.
+  source.onerror = () => undefined;
+  return () => source.close();
+}

--- a/runtime/fleet-console/core/client/src/rail/plans-events.ts
+++ b/runtime/fleet-console/core/client/src/rail/plans-events.ts
@@ -6,13 +6,26 @@ export function subscribeToPlanChanges(theaterId: string, onInvalidate: () => vo
   let source: EventSource | null = null;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let unsubscribed = false;
+  let initialAttempt = true;
 
   const connect = () => {
+    // 게이트 기준은 "최초 open"이 아니라 "최초 소스의 첫 open"이다 — 최초 연결이 404로
+    // open 없이 실패한 뒤의 재연결 open을 최초 open으로 오인하면 안 된다.
+    const isInitialSource = initialAttempt;
+    initialAttempt = false;
+    let opens = 0;
     source = new EventSource(`/api/v1/plans/events?theaterId=${encodeURIComponent(theaterId)}`);
     source.addEventListener(PLANS_CHANGED_EVENT, () => {
       // The event is only an invalidation signal. Do not trust or parse its payload.
       onInvalidate();
     });
+    // 최초 소스의 첫 open은 mount fetch와 중복이라 건너뛴다. 그 외의 open은 전부 재연결이며
+    // (native retry든 30초 백오프 재생성이든) 스트림 부재 동안 놓친 변경 — 예: 첫 plans
+    // 디렉터리 생성 — 을 refetch 한 번으로 복구한다.
+    source.onopen = () => {
+      opens += 1;
+      if (!(isInitialSource && opens === 1)) onInvalidate();
+    };
     source.onerror = () => {
       if (source?.readyState !== EventSource.CLOSED || reconnectTimer !== null) return;
       reconnectTimer = setTimeout(() => {

--- a/runtime/fleet-console/core/client/src/rail/plans-events.ts
+++ b/runtime/fleet-console/core/client/src/rail/plans-events.ts
@@ -1,14 +1,31 @@
 const PLANS_CHANGED_EVENT = "plans-changed";
+const PLANS_RECONNECT_DELAY_MS = 30_000;
 
 /** Connects a Theater-scoped, payload-free invalidation channel. */
 export function subscribeToPlanChanges(theaterId: string, onInvalidate: () => void): () => void {
-  const source = new EventSource(`/api/v1/plans/events?theaterId=${encodeURIComponent(theaterId)}`);
-  source.addEventListener(PLANS_CHANGED_EVENT, () => {
-    // The event is only an invalidation signal. Do not trust or parse its payload.
-    onInvalidate();
-  });
-  // Native EventSource reconnects when appropriate; 404 and network failures leave
-  // the existing manual refresh path available without changing panel state.
-  source.onerror = () => undefined;
-  return () => source.close();
+  let source: EventSource | null = null;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let unsubscribed = false;
+
+  const connect = () => {
+    source = new EventSource(`/api/v1/plans/events?theaterId=${encodeURIComponent(theaterId)}`);
+    source.addEventListener(PLANS_CHANGED_EVENT, () => {
+      // The event is only an invalidation signal. Do not trust or parse its payload.
+      onInvalidate();
+    });
+    source.onerror = () => {
+      if (source?.readyState !== EventSource.CLOSED || reconnectTimer !== null) return;
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        if (!unsubscribed) connect();
+      }, PLANS_RECONNECT_DELAY_MS);
+    };
+  };
+
+  connect();
+  return () => {
+    unsubscribed = true;
+    if (reconnectTimer !== null) clearTimeout(reconnectTimer);
+    source?.close();
+  };
 }

--- a/runtime/fleet-console/core/client/src/rail/plans-events.ts
+++ b/runtime/fleet-console/core/client/src/rail/plans-events.ts
@@ -28,6 +28,9 @@ export function subscribeToPlanChanges(theaterId: string, onInvalidate: () => vo
     };
     source.onerror = () => {
       if (source?.readyState !== EventSource.CLOSED || reconnectTimer !== null) return;
+      // 치명 종료는 스트림 부재 구간의 변경을 이미 놓쳤다는 뜻이다 — 즉시 한 번 refetch해
+      // 삭제된 plans 디렉터리가 빈 목록으로 수렴하게 하고, 백오프 후 재연결한다.
+      if (!unsubscribed) onInvalidate();
       reconnectTimer = setTimeout(() => {
         reconnectTimer = null;
         if (!unsubscribed) connect();

--- a/runtime/fleet-console/core/client/src/rail/plans-helpers.ts
+++ b/runtime/fleet-console/core/client/src/rail/plans-helpers.ts
@@ -36,6 +36,13 @@ export function normalizePlanHeading(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
 
+// 파서는 lane heading에서 "Lane " 접두사를 제거해 저장하지만 렌더된 h3 텍스트에는 남아 있다 —
+// 양쪽 모두 접두사를 벗겨 동일 기준으로 비교한다.
+export function planLaneHeadingMatches(renderedHeading: string, laneHeading: string): boolean {
+  const strip = (value: string) => normalizePlanHeading(value).replace(/^lane\s+/i, "");
+  return strip(renderedHeading) === strip(laneHeading);
+}
+
 export function formatRelativeTime(updatedAt: string, now = Date.now()): string {
   const timestamp = Date.parse(updatedAt);
   if (!Number.isFinite(timestamp)) return "Unknown";

--- a/runtime/fleet-console/core/client/src/rail/plans-helpers.ts
+++ b/runtime/fleet-console/core/client/src/rail/plans-helpers.ts
@@ -8,6 +8,34 @@ export interface TaskCountLike {
   readonly tasksTotal: number;
 }
 
+export type PlanStatusFilter = "all" | "in-progress" | "complete";
+
+export interface PlanListFilterLike extends TaskCountLike {
+  readonly name: string;
+  readonly title: string;
+}
+
+export function filterPlans<T extends PlanListFilterLike>(plans: readonly T[], query: string, status: PlanStatusFilter): readonly T[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  return plans.filter((plan) => {
+    const matchesQuery = normalizedQuery === ""
+      || plan.name.toLocaleLowerCase().includes(normalizedQuery)
+      || plan.title.toLocaleLowerCase().includes(normalizedQuery);
+    if (!matchesQuery) return false;
+    if (status === "all") return true;
+    if (plan.tasksTotal <= 0) return false;
+    return status === "complete" ? plan.tasksDone >= plan.tasksTotal : plan.tasksDone < plan.tasksTotal;
+  });
+}
+
+export function planListSignature(plan: PlanListFilterLike & { readonly updatedAt: string; readonly executionMode: string | null; readonly waveCount: number; readonly sizeBytes: number }): string {
+  return [plan.name, plan.title, plan.executionMode ?? "", plan.waveCount, plan.tasksDone, plan.tasksTotal, plan.updatedAt, plan.sizeBytes].join("\u0000");
+}
+
+export function normalizePlanHeading(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
 export function formatRelativeTime(updatedAt: string, now = Date.now()): string {
   const timestamp = Date.parse(updatedAt);
   if (!Number.isFinite(timestamp)) return "Unknown";

--- a/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
@@ -81,6 +81,7 @@ function PlansPanelBody(ctx: RailPanelContext) {
   const listRequestRef = useRef(0);
   const readerRequestRef = useRef(0);
   const listSignaturesRef = useRef<Map<string, string> | null>(null);
+  const readerStateRef = useRef<PlanReaderState>(readerState);
   const pulseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectedName = selectedPlan?.theaterId === theaterId ? selectedPlan.name : null;
 
@@ -92,7 +93,8 @@ function PlansPanelBody(ctx: RailPanelContext) {
       return;
     }
 
-    setListState({ kind: "loading" });
+    const isBackgroundRevalidation = listSignaturesRef.current !== null;
+    if (!isBackgroundRevalidation) setListState({ kind: "loading" });
     void fetchPlansList(theaterId).then((result) => {
       if (requestId !== listRequestRef.current) return;
       const nextSignatures = new Map(result.plans.map((plan) => [plan.name, planListSignature(plan)]));
@@ -107,8 +109,11 @@ function PlansPanelBody(ctx: RailPanelContext) {
       }
       listSignaturesRef.current = nextSignatures;
       setListState({ kind: "ready", plans: result.plans });
+      if (selectedName && previousSignatures?.get(selectedName) !== nextSignatures.get(selectedName)) {
+        setReaderRetry((attempt) => attempt + 1);
+      }
     }).catch(() => {
-      if (requestId === listRequestRef.current) setListState({ kind: "error" });
+      if (requestId === listRequestRef.current && !isBackgroundRevalidation) setListState({ kind: "error" });
     });
   }, [theaterId, listRetry]);
 
@@ -117,11 +122,22 @@ function PlansPanelBody(ctx: RailPanelContext) {
 
     if (!theaterId || !selectedName) return;
 
-    setReaderState({ kind: "loading" });
+    const isBackgroundRevalidation = readerStateRef.current.kind === "ready" && readerStateRef.current.plan.name === selectedName;
+    if (!isBackgroundRevalidation) {
+      readerStateRef.current = { kind: "loading" };
+      setReaderState({ kind: "loading" });
+    }
     void fetchPlanRead(theaterId, selectedName).then((result) => {
-      if (requestId === readerRequestRef.current) setReaderState({ kind: "ready", plan: result });
+      if (requestId === readerRequestRef.current) {
+        const nextState = { kind: "ready", plan: result } as const;
+        readerStateRef.current = nextState;
+        setReaderState(nextState);
+      }
     }).catch(() => {
-      if (requestId === readerRequestRef.current) setReaderState({ kind: "error" });
+      if (requestId === readerRequestRef.current && !isBackgroundRevalidation) {
+        readerStateRef.current = { kind: "error" };
+        setReaderState({ kind: "error" });
+      }
     });
   }, [readerRetry, selectedName, theaterId]);
 
@@ -129,7 +145,6 @@ function PlansPanelBody(ctx: RailPanelContext) {
     if (!theaterId) return;
     return subscribeToPlanChanges(theaterId, () => {
       setListRetry((attempt) => attempt + 1);
-      setReaderRetry((attempt) => attempt + 1);
     });
   }, [theaterId]);
 
@@ -148,7 +163,6 @@ function PlansPanelBody(ctx: RailPanelContext) {
   const handleClose = useCallback(() => setSelectedPlan(null), []);
   const refreshPlans = useCallback(() => {
     setListRetry((attempt) => attempt + 1);
-    setReaderRetry((attempt) => attempt + 1);
   }, []);
   const retryList = refreshPlans;
   const retryReader = useCallback(() => setReaderRetry((attempt) => attempt + 1), []);

--- a/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
@@ -189,7 +189,14 @@ function PlansPanelBody(ctx: RailPanelContext) {
   const handleSelect = useCallback((name: string) => {
     if (theaterId) setSelectedPlan({ theaterId, name });
   }, [theaterId]);
-  const handleClose = useCallback(() => setSelectedPlan(null), []);
+  // 닫힌 리더는 유지할 내용이 없다 — ref/상태를 함께 리셋해 같은 플랜 재열람이 background로
+  // 오분류되어 읽기 실패를 침묵시키는 일이 없게 한다(재열람은 항상 foreground).
+  const handleClose = useCallback(() => {
+    setSelectedPlan(null);
+    readerSignatureRef.current = null;
+    readerStateRef.current = { kind: "loading" };
+    setReaderState({ kind: "loading" });
+  }, []);
   const refreshPlans = useCallback(() => {
     listSurfaceFailureRef.current = true;
     setListRetry((attempt) => attempt + 1);

--- a/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
@@ -87,6 +87,8 @@ function PlansPanelBody(ctx: RailPanelContext) {
   const readerSignatureRef = useRef<string | null>(null);
   // 목록 갱신에서 선택 Plan이 사라졌을 때 세팅 — 다음 reader 조회 실패를 조용히 버리지 않고 error로 표면화한다.
   const readerForceRef = useRef(false);
+  // 수동 REFRESH에서 세팅 — 다음 목록 조회 실패를 background로 삼키지 않고 error로 표면화한다.
+  const listSurfaceFailureRef = useRef(false);
   const selectedNameRef = useRef<string | null>(null);
   const pulseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectedName = selectedPlan?.theaterId === theaterId ? selectedPlan.name : null;
@@ -104,6 +106,9 @@ function PlansPanelBody(ctx: RailPanelContext) {
     }
 
     const isBackgroundRevalidation = listSignaturesRef.current !== null;
+    // 수동 REFRESH는 background여도 실패를 침묵시키지 않는다 — 기존 행은 유지하되 실패 시 error를 표면화.
+    const surfaceFailure = listSurfaceFailureRef.current;
+    listSurfaceFailureRef.current = false;
     if (!isBackgroundRevalidation) setListState({ kind: "loading" });
     void fetchPlansList(theaterId).then((result) => {
       if (requestId !== listRequestRef.current) return;
@@ -131,7 +136,7 @@ function PlansPanelBody(ctx: RailPanelContext) {
         }
       }
     }).catch(() => {
-      if (requestId === listRequestRef.current && !isBackgroundRevalidation) setListState({ kind: "error" });
+      if (requestId === listRequestRef.current && (!isBackgroundRevalidation || surfaceFailure)) setListState({ kind: "error" });
     });
   }, [theaterId, listRetry]);
 
@@ -186,6 +191,7 @@ function PlansPanelBody(ctx: RailPanelContext) {
   }, [theaterId]);
   const handleClose = useCallback(() => setSelectedPlan(null), []);
   const refreshPlans = useCallback(() => {
+    listSurfaceFailureRef.current = true;
     setListRetry((attempt) => attempt + 1);
   }, []);
   const retryList = refreshPlans;

--- a/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
@@ -82,8 +82,18 @@ function PlansPanelBody(ctx: RailPanelContext) {
   const readerRequestRef = useRef(0);
   const listSignaturesRef = useRef<Map<string, string> | null>(null);
   const readerStateRef = useRef<PlanReaderState>(readerState);
+  // reader가 실제 반영한 목록 signature. 성공 시에만 갱신되므로 background read 실패는
+  // 다음 목록 갱신에서 signature 불일치로 다시 감지된다.
+  const readerSignatureRef = useRef<string | null>(null);
+  // 목록 갱신에서 선택 Plan이 사라졌을 때 세팅 — 다음 reader 조회 실패를 조용히 버리지 않고 error로 표면화한다.
+  const readerForceRef = useRef(false);
+  const selectedNameRef = useRef<string | null>(null);
   const pulseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectedName = selectedPlan?.theaterId === theaterId ? selectedPlan.name : null;
+
+  useEffect(() => {
+    selectedNameRef.current = selectedName;
+  }, [selectedName]);
 
   useEffect(() => {
     const requestId = ++listRequestRef.current;
@@ -109,8 +119,16 @@ function PlansPanelBody(ctx: RailPanelContext) {
       }
       listSignaturesRef.current = nextSignatures;
       setListState({ kind: "ready", plans: result.plans });
-      if (selectedName && previousSignatures?.get(selectedName) !== nextSignatures.get(selectedName)) {
-        setReaderRetry((attempt) => attempt + 1);
+      // 목록 갱신 완료 시점의 현재 선택(effect 시작 시점 클로저가 아닌)과 reader 반영분을 비교한다.
+      const currentSelection = selectedNameRef.current;
+      if (currentSelection) {
+        if (!nextSignatures.has(currentSelection)) {
+          readerSignatureRef.current = null;
+          readerForceRef.current = true;
+          setReaderRetry((attempt) => attempt + 1);
+        } else if (nextSignatures.get(currentSelection) !== readerSignatureRef.current) {
+          setReaderRetry((attempt) => attempt + 1);
+        }
       }
     }).catch(() => {
       if (requestId === listRequestRef.current && !isBackgroundRevalidation) setListState({ kind: "error" });
@@ -122,13 +140,19 @@ function PlansPanelBody(ctx: RailPanelContext) {
 
     if (!theaterId || !selectedName) return;
 
-    const isBackgroundRevalidation = readerStateRef.current.kind === "ready" && readerStateRef.current.plan.name === selectedName;
+    const forceSurface = readerForceRef.current;
+    readerForceRef.current = false;
+    const isBackgroundRevalidation = !forceSurface
+      && readerStateRef.current.kind === "ready"
+      && readerStateRef.current.plan.name === selectedName;
     if (!isBackgroundRevalidation) {
+      readerSignatureRef.current = null;
       readerStateRef.current = { kind: "loading" };
       setReaderState({ kind: "loading" });
     }
     void fetchPlanRead(theaterId, selectedName).then((result) => {
       if (requestId === readerRequestRef.current) {
+        readerSignatureRef.current = listSignaturesRef.current?.get(result.name) ?? null;
         const nextState = { kind: "ready", plan: result } as const;
         readerStateRef.current = nextState;
         setReaderState(nextState);

--- a/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
@@ -7,13 +7,15 @@ import type { RailPanelContext, RailPanelDescriptor } from "@fleet-console/sdk/r
 import "@fleet-console/markdown/styles.css";
 import { fetchPlanRead, fetchPlansList, type PlanListItem, type PlanReadResult } from "../api.js";
 import "./plans.css";
-import { formatRelativeTime, getLaneDispatchState, getProgressPercent, getWaveProgressState } from "./plans-helpers.js";
+import { filterPlans, formatRelativeTime, getLaneDispatchState, getProgressPercent, getWaveProgressState, normalizePlanHeading, planListSignature, type PlanStatusFilter } from "./plans-helpers.js";
+import { subscribeToPlanChanges } from "./plans-events.js";
 
 interface PlansListProps {
   readonly selectedName: string | null;
   readonly state: PlansListState;
   readonly onRetry: () => void;
   readonly onSelect: (name: string) => void;
+  readonly pulsedNames: ReadonlySet<string>;
 }
 
 interface PlanReaderProps {
@@ -75,42 +77,65 @@ function PlansPanelBody(ctx: RailPanelContext) {
   const [selectedPlan, setSelectedPlan] = useState<{ readonly theaterId: string; readonly name: string } | null>(null);
   const [listRetry, setListRetry] = useState(0);
   const [readerRetry, setReaderRetry] = useState(0);
+  const [pulsedNames, setPulsedNames] = useState<ReadonlySet<string>>(() => new Set());
+  const listRequestRef = useRef(0);
+  const readerRequestRef = useRef(0);
+  const listSignaturesRef = useRef<Map<string, string> | null>(null);
+  const pulseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectedName = selectedPlan?.theaterId === theaterId ? selectedPlan.name : null;
 
   useEffect(() => {
-    let cancelled = false;
-    setSelectedPlan(null);
-    setReaderState({ kind: "loading" });
+    const requestId = ++listRequestRef.current;
 
     if (!theaterId) {
       setListState({ kind: "no-theater" });
-      return () => { cancelled = true; };
+      return;
     }
 
     setListState({ kind: "loading" });
     void fetchPlansList(theaterId).then((result) => {
-      if (!cancelled) setListState({ kind: "ready", plans: result.plans });
+      if (requestId !== listRequestRef.current) return;
+      const nextSignatures = new Map(result.plans.map((plan) => [plan.name, planListSignature(plan)]));
+      const previousSignatures = listSignaturesRef.current;
+      if (previousSignatures) {
+        const changed = new Set(result.plans.filter((plan) => previousSignatures.get(plan.name) !== nextSignatures.get(plan.name)).map((plan) => plan.name));
+        if (changed.size > 0) {
+          if (pulseTimerRef.current) clearTimeout(pulseTimerRef.current);
+          setPulsedNames(changed);
+          pulseTimerRef.current = setTimeout(() => setPulsedNames(new Set()), 1_200);
+        }
+      }
+      listSignaturesRef.current = nextSignatures;
+      setListState({ kind: "ready", plans: result.plans });
     }).catch(() => {
-      if (!cancelled) setListState({ kind: "error" });
+      if (requestId === listRequestRef.current) setListState({ kind: "error" });
     });
-
-    return () => { cancelled = true; };
   }, [theaterId, listRetry]);
 
   useEffect(() => {
-    let cancelled = false;
+    const requestId = ++readerRequestRef.current;
 
-    if (!theaterId || !selectedName) return () => { cancelled = true; };
+    if (!theaterId || !selectedName) return;
 
     setReaderState({ kind: "loading" });
     void fetchPlanRead(theaterId, selectedName).then((result) => {
-      if (!cancelled) setReaderState({ kind: "ready", plan: result });
+      if (requestId === readerRequestRef.current) setReaderState({ kind: "ready", plan: result });
     }).catch(() => {
-      if (!cancelled) setReaderState({ kind: "error" });
+      if (requestId === readerRequestRef.current) setReaderState({ kind: "error" });
     });
-
-    return () => { cancelled = true; };
   }, [readerRetry, selectedName, theaterId]);
+
+  useEffect(() => {
+    if (!theaterId) return;
+    return subscribeToPlanChanges(theaterId, () => {
+      setListRetry((attempt) => attempt + 1);
+      setReaderRetry((attempt) => attempt + 1);
+    });
+  }, [theaterId]);
+
+  useEffect(() => () => {
+    if (pulseTimerRef.current) clearTimeout(pulseTimerRef.current);
+  }, []);
 
   useLayoutEffect(() => {
     requestExtraWidth?.(selectedName ? PLANS_EXTRA_WIDTH : null);
@@ -121,12 +146,18 @@ function PlansPanelBody(ctx: RailPanelContext) {
     if (theaterId) setSelectedPlan({ theaterId, name });
   }, [theaterId]);
   const handleClose = useCallback(() => setSelectedPlan(null), []);
-  const retryList = useCallback(() => setListRetry((attempt) => attempt + 1), []);
+  const refreshPlans = useCallback(() => {
+    setListRetry((attempt) => attempt + 1);
+    setReaderRetry((attempt) => attempt + 1);
+  }, []);
+  const retryList = refreshPlans;
   const retryReader = useCallback(() => setReaderRetry((attempt) => attempt + 1), []);
 
   return (
     <div className="plans-panel-shell">
-      <div className={`plans-root${selectedName ? " is-reader-open" : ""}`}>
+      <div className={`plans-root${selectedName ? " is-reader-open" : ""}`} onKeyDown={(event) => {
+        if (event.key === "Escape" && selectedName) handleClose();
+      }}>
         {selectedName && <PlanReader state={readerState} onClose={handleClose} onRetry={retryReader} />}
         {selectedName && <div className="plans-divider" aria-hidden="true" />}
         <PlansList
@@ -134,13 +165,18 @@ function PlansPanelBody(ctx: RailPanelContext) {
           state={listState}
           onRetry={retryList}
           onSelect={handleSelect}
+          pulsedNames={pulsedNames}
         />
       </div>
     </div>
   );
 }
 
-function PlansList({ selectedName, state, onRetry, onSelect }: PlansListProps) {
+function PlansList({ selectedName, state, onRetry, onSelect, pulsedNames }: PlansListProps) {
+  const [query, setQuery] = useState("");
+  const [status, setStatus] = useState<PlanStatusFilter>("all");
+  const [copiedName, setCopiedName] = useState<string | null>(null);
+  const rowRefs = useRef(new Map<string, HTMLButtonElement>());
   if (state.kind === "no-theater") {
     return <div className="plans-list-pane"><EmptyState>Select a Theater to browse plans.</EmptyState></div>;
   }
@@ -165,33 +201,64 @@ function PlansList({ selectedName, state, onRetry, onSelect }: PlansListProps) {
     );
   }
 
+  const visiblePlans = filterPlans(state.plans, query, status);
+  const moveFocus = (index: number, direction: -1 | 1) => {
+    const nextIndex = (index + direction + visiblePlans.length) % visiblePlans.length;
+    rowRefs.current.get(visiblePlans[nextIndex]?.name ?? "")?.focus();
+  };
+  const handleRowKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      moveFocus(index, event.key === "ArrowDown" ? 1 : -1);
+    }
+  };
+  const copyPlanPath = (event: React.MouseEvent<HTMLButtonElement>, name: string) => {
+    event.stopPropagation();
+    if (!navigator.clipboard) return;
+    void navigator.clipboard.writeText(`plans/${name}`).then(() => {
+      setCopiedName(name);
+      window.setTimeout(() => setCopiedName((current) => current === name ? null : current), 1_200);
+    }).catch(() => undefined);
+  };
+
   return (
     <div className="plans-list-pane">
+      <div className="plans-toolbar">
+        <label className="plans-search-label">
+          <span>Search plans</span>
+          <input className="plans-search" value={query} onChange={(event) => setQuery(event.target.value)} />
+        </label>
+        <div className="plans-filter-group" aria-label="Plan status">
+          {(["all", "in-progress", "complete"] as const).map((filter) => (
+            <button key={filter} type="button" className={`plans-filter${status === filter ? " is-active" : ""}`} aria-pressed={status === filter} onClick={() => setStatus(filter)}>
+              {filter === "all" ? "ALL" : filter === "in-progress" ? "IN PROGRESS" : "COMPLETE"}
+            </button>
+          ))}
+        </div>
+        <button type="button" className="plans-refresh" onClick={onRetry}>REFRESH</button>
+      </div>
       <div className="plans-list" aria-label="Plans">
-        {state.plans.map((plan) => {
+        {visiblePlans.length === 0 && <EmptyState>No matching plans.</EmptyState>}
+        {visiblePlans.map((plan, index) => {
           const progress = getProgressPercent(plan.tasksDone, plan.tasksTotal);
           const isComplete = progress === 100;
           return (
-            <button
+            <div
               key={plan.name}
-              type="button"
-              className={`plans-row${selectedName === plan.name ? " is-selected" : ""}`}
-              onClick={() => onSelect(plan.name)}
+              className={`plans-row${selectedName === plan.name ? " is-selected" : ""}${pulsedNames.has(plan.name) ? " is-pulsing" : ""}`}
             >
-              <span className="plans-row-name">{plan.name}</span>
-              <span className="plans-row-meta">
-                {plan.waveCount} waves · {plan.tasksDone}/{plan.tasksTotal} tasks · {formatRelativeTime(plan.updatedAt)}
-                {plan.executionMode === "parallel" ? " · parallel" : ""}
-              </span>
-              {progress !== null && (
-                <span className="plans-progress-track" aria-label={`${progress}% complete`}>
-                  <span
-                    className={`plans-progress-fill${isComplete ? " is-complete" : ""}`}
-                    style={{ width: `${progress}%` }}
-                  />
+              <button ref={(node) => { if (node) rowRefs.current.set(plan.name, node); else rowRefs.current.delete(plan.name); }} type="button" className="plans-row-select" onClick={() => onSelect(plan.name)} onKeyDown={(event) => handleRowKeyDown(event, index)}>
+                <span className="plans-row-name">{plan.name}</span>
+                <span className="plans-row-meta">
+                  {plan.waveCount} waves · {plan.tasksDone}/{plan.tasksTotal} tasks · {formatRelativeTime(plan.updatedAt)}
+                  {plan.executionMode === "parallel" ? " · parallel" : ""}
                 </span>
-              )}
-            </button>
+                {progress !== null && <span className="plans-progress-track" aria-label={`${progress}% complete`}><span className={`plans-progress-fill${isComplete ? " is-complete" : ""}`} style={{ width: `${progress}%` }} /></span>}
+              </button>
+              <button type="button" className="plans-copy" onClick={(event) => copyPlanPath(event, plan.name)} aria-label={copiedName === plan.name ? `Copied plans/${plan.name}` : `Copy plans/${plan.name}`}>
+                {copiedName === plan.name ? "COPIED" : "COPY"}
+              </button>
+            </div>
           );
         })}
       </div>
@@ -236,6 +303,21 @@ function PlanDocument({ plan, onClose }: PlanDocumentProps) {
     return doc.body.innerHTML;
   }, [plan.content]);
   const markdownRootRef = useRef<HTMLDivElement | null>(null);
+  const headingFlashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const jumpToHeading = useCallback((level: "h2" | "h3", heading: string) => {
+    const root = markdownRootRef.current;
+    if (!root) return;
+    const target = [...root.querySelectorAll(level)].find((element) => normalizePlanHeading(element.textContent ?? "") === normalizePlanHeading(heading));
+    if (!target) return;
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    target.scrollIntoView({ behavior: reducedMotion ? "auto" : "smooth", block: "start" });
+    target.classList.remove("plans-heading-flash");
+    void target.getBoundingClientRect();
+    target.classList.add("plans-heading-flash");
+    if (headingFlashTimerRef.current) clearTimeout(headingFlashTimerRef.current);
+    headingFlashTimerRef.current = setTimeout(() => target.classList.remove("plans-heading-flash"), 1_200);
+  }, []);
 
   // 공유 렌더러가 코드 블록에 주입하는 Copy 버튼(data-action="copy-code")을 위임 처리한다 — 준거: file-explorer.
   const handleCopyClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
@@ -263,6 +345,10 @@ function PlanDocument({ plan, onClose }: PlanDocumentProps) {
     return () => observer.disconnect();
   }, [html]);
 
+  useEffect(() => () => {
+    if (headingFlashTimerRef.current) clearTimeout(headingFlashTimerRef.current);
+  }, []);
+
   return (
     <div className="plans-reader-pane">
       <div className="plans-reader-head">
@@ -280,24 +366,24 @@ function PlanDocument({ plan, onClose }: PlanDocumentProps) {
           {plan.waves.map((wave, waveIndex) => {
             const progressState = getWaveProgressState(wave.tasksDone, wave.tasksTotal);
             return (
-              <span key={wave.index} className={`plans-wave is-${progressState}`}>
-                <span className="plans-wave-heading">{wave.heading}</span>
+              <div key={wave.index} className={`plans-wave is-${progressState}`}>
+                <button type="button" className="plans-wave-heading" onClick={() => jumpToHeading("h2", wave.heading)}>{wave.heading}</button>
                 {wave.tasksTotal > 0 && <span className="plans-wave-count">{wave.tasksDone}/{wave.tasksTotal}</span>}
                 {wave.lanes.length > 0 && (
-                  <span className="plans-lane-list">
+                  <div className="plans-lane-list">
                     {wave.lanes.map((lane, laneIndex) => {
                       const laneState = getLaneDispatchState(plan.waves, waveIndex, lane);
                       return (
-                        <span key={lane.id ?? `${wave.index}-${laneIndex}`} className={`plans-lane is-${laneState}`}>
-                          <span className="plans-lane-id">{lane.id ?? lane.heading}</span>
+                        <div key={lane.id ?? `${wave.index}-${laneIndex}`} className={`plans-lane is-${laneState}`}>
+                          <button type="button" className="plans-lane-id" onClick={() => jumpToHeading("h3", lane.heading)}>{lane.id ?? lane.heading}</button>
                           {lane.tasksTotal > 0 && <span className="plans-lane-count">{lane.tasksDone}/{lane.tasksTotal}</span>}
                           {laneState === "ready" && <span className="plans-lane-ready">READY</span>}
-                        </span>
+                        </div>
                       );
                     })}
-                  </span>
+                  </div>
                 )}
-              </span>
+              </div>
             );
           })}
         </div>

--- a/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
@@ -163,7 +163,10 @@ function PlansPanelBody(ctx: RailPanelContext) {
         setReaderState(nextState);
       }
     }).catch(() => {
-      if (requestId === readerRequestRef.current && !isBackgroundRevalidation) {
+      // background 재검증도 실패는 표면화한다 — 성공만 무깜빡임 교체 대상이며, 열린 리더가
+      // 읽기 불가(413 등)로 바뀐 사실을 낡은 본문으로 가리면 안 된다. loopback 특성상
+      // 일시 네트워크 실패로 인한 오탐 여지는 사실상 없다.
+      if (requestId === readerRequestRef.current) {
         readerStateRef.current = { kind: "error" };
         setReaderState({ kind: "error" });
       }

--- a/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
@@ -7,7 +7,7 @@ import type { RailPanelContext, RailPanelDescriptor } from "@fleet-console/sdk/r
 import "@fleet-console/markdown/styles.css";
 import { fetchPlanRead, fetchPlansList, type PlanListItem, type PlanReadResult } from "../api.js";
 import "./plans.css";
-import { filterPlans, formatRelativeTime, getLaneDispatchState, getProgressPercent, getWaveProgressState, normalizePlanHeading, planListSignature, type PlanStatusFilter } from "./plans-helpers.js";
+import { filterPlans, formatRelativeTime, getLaneDispatchState, getProgressPercent, getWaveProgressState, normalizePlanHeading, planLaneHeadingMatches, planListSignature, type PlanStatusFilter } from "./plans-helpers.js";
 import { subscribeToPlanChanges } from "./plans-events.js";
 
 interface PlansListProps {
@@ -346,7 +346,9 @@ function PlanDocument({ plan, onClose }: PlanDocumentProps) {
   const jumpToHeading = useCallback((level: "h2" | "h3", heading: string) => {
     const root = markdownRootRef.current;
     if (!root) return;
-    const target = [...root.querySelectorAll(level)].find((element) => normalizePlanHeading(element.textContent ?? "") === normalizePlanHeading(heading));
+    const target = [...root.querySelectorAll(level)].find((element) => level === "h3"
+      ? planLaneHeadingMatches(element.textContent ?? "", heading)
+      : normalizePlanHeading(element.textContent ?? "") === normalizePlanHeading(heading));
     if (!target) return;
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     target.scrollIntoView({ behavior: reducedMotion ? "auto" : "smooth", block: "start" });

--- a/runtime/fleet-console/core/client/src/rail/plans.css
+++ b/runtime/fleet-console/core/client/src/rail/plans.css
@@ -31,7 +31,7 @@
 }
 
 .plans-list-pane {
-  grid-template-rows: minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr);
 }
 
 .plans-root.is-reader-open .plans-list-pane {
@@ -54,20 +54,87 @@
   padding: 8px;
 }
 
+.plans-toolbar {
+  display: grid;
+  gap: 7px;
+  padding: 9px 10px;
+  border-bottom: 1px solid var(--surface-rim);
+  background: color-mix(in srgb, var(--surface-glass) 88%, transparent);
+}
+
+.plans-search-label {
+  display: grid;
+  gap: 4px;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.plans-search {
+  min-width: 0;
+  padding: 6px 7px;
+  background: color-mix(in srgb, var(--surface-rim) 32%, transparent);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  color: var(--ink-spectral);
+  font: inherit;
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.plans-filter-group { display: flex; flex-wrap: wrap; gap: 4px; }
+
+.plans-filter,
+.plans-refresh,
+.plans-copy {
+  padding: 4px 6px;
+  background: transparent;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  color: var(--ink-fog);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+}
+
+.plans-filter.is-active,
+.plans-refresh:hover,
+.plans-copy:hover {
+  border-color: color-mix(in srgb, var(--brass) 58%, var(--surface-rim));
+  color: var(--brass);
+}
+
+.plans-refresh { justify-self: start; }
+
 .plans-row {
   display: grid;
-  gap: 5px;
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) auto;
   margin: 0;
-  padding: 9px 10px;
+  padding: 0;
   width: 100%;
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
   color: var(--ink-spectral);
+  text-align: left;
+}
+
+.plans-row-select {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  padding: 9px 4px 9px 10px;
+  background: transparent;
+  border: 0;
+  color: inherit;
   cursor: pointer;
   text-align: left;
 }
+
+.plans-copy { align-self: center; margin-right: 7px; }
 
 .plans-row:hover {
   background: color-mix(in srgb, var(--brass) 9%, transparent);
@@ -78,9 +145,17 @@
   border-color: color-mix(in srgb, var(--brass) 48%, var(--surface-rim));
 }
 
-.plans-row:focus-visible,
+.plans-row.is-pulsing { animation: plans-row-pulse 1.2s ease-out; }
+
+.plans-row-select:focus-visible,
 .plans-close:focus-visible,
-.plans-retry:focus-visible {
+.plans-retry:focus-visible,
+.plans-filter:focus-visible,
+.plans-refresh:focus-visible,
+.plans-copy:focus-visible,
+.plans-search:focus-visible,
+.plans-wave-heading:focus-visible,
+.plans-lane-id:focus-visible {
   outline: 2px solid var(--brass);
   outline-offset: 2px;
 }
@@ -211,8 +286,15 @@
 }
 
 .plans-wave-heading {
+  padding: 0;
   overflow: hidden;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
   font-size: 11px;
+  text-align: left;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -244,9 +326,18 @@
 .plans-lane-id {
   overflow: hidden;
   max-width: 96px;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.plans-heading-flash { animation: plans-heading-flash 1.2s ease-out; }
 
 .plans-lane.is-complete {
   color: var(--positive);
@@ -332,4 +423,21 @@
 
 .plans-retry:hover {
   background: color-mix(in srgb, var(--coral) 18%, transparent);
+}
+
+@keyframes plans-row-pulse {
+  0% { background: color-mix(in srgb, var(--brass) 28%, transparent); }
+  100% { background: transparent; }
+}
+
+@keyframes plans-heading-flash {
+  0% { background: color-mix(in srgb, var(--brass) 30%, transparent); }
+  100% { background: transparent; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .plans-row.is-pulsing,
+  .plans-heading-flash {
+    animation: none;
+  }
 }

--- a/runtime/fleet-console/core/host/plans/plan-store.ts
+++ b/runtime/fleet-console/core/host/plans/plan-store.ts
@@ -82,6 +82,15 @@ export async function listPlansForWorkspace(dataDir: string, cwd: string): Promi
   return plans.sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
 }
 
+/**
+ * Resolves the Plans directory for server-side observation only.  A missing
+ * workspace or Plans directory is deliberately represented as null: readers
+ * and watchers must never create either as a side effect of a request.
+ */
+export function resolvePlansWatchDirectory(dataDir: string, cwd: string): string | null {
+  return resolvePlansRoot(dataDir, cwd, true)?.plansPath ?? null;
+}
+
 export function isValidPlanName(name: string): boolean {
   return PLAN_NAME_PATTERN.test(name) && !name.includes("..");
 }

--- a/runtime/fleet-console/core/host/plans/routes.ts
+++ b/runtime/fleet-console/core/host/plans/routes.ts
@@ -1,6 +1,6 @@
 import type http from "node:http";
 
-import { PlanStoreError, isValidPlanName, listPlansForWorkspace, readPlanForWorkspace } from "./plan-store.js";
+import { PlanStoreError, isValidPlanName, listPlansForWorkspace, readPlanForWorkspace, resolvePlansWatchDirectory } from "./plan-store.js";
 import { TheaterPathContextError, resolveTheaterPathContext } from "../theater-path-context.js";
 
 export interface PlansRouteDeps {
@@ -9,6 +9,7 @@ export interface PlansRouteDeps {
   readonly readJsonBody: <T>(req: http.IncomingMessage) => Promise<T | null>;
   readonly resolveTheaterPath: (theaterId: string) => string | null;
   readonly writeJson: (res: http.ServerResponse, status: number, body: unknown) => void;
+  readonly subscribeToChanges?: (res: http.ServerResponse, watchPath: string) => void;
 }
 
 interface PlansRouteContext {
@@ -36,8 +37,51 @@ export function createPlansRouter(deps: PlansRouteDeps): (context: PlansRouteCon
       await handlePlansRead(req, res, deps);
       return true;
     }
+    if (pathname === "/api/v1/plans/events") {
+      await handlePlansEvents(req, res, deps);
+      return true;
+    }
     return false;
   };
+}
+
+async function handlePlansEvents(req: http.IncomingMessage, res: http.ServerResponse, deps: PlansRouteDeps): Promise<void> {
+  if (req.method !== "GET") {
+    deps.writeJson(res, 405, { error: "Method not allowed" });
+    return;
+  }
+  if (!deps.isAuthorized(req)) {
+    deps.writeJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  const theaterId = readEventsTheaterId(req);
+  if (!theaterId) {
+    deps.writeJson(res, 400, { error: "invalid_request" });
+    return;
+  }
+  const theaterPath = deps.resolveTheaterPath(theaterId);
+  if (!theaterPath) {
+    deps.writeJson(res, 404, { error: "theater_not_found" });
+    return;
+  }
+  try {
+    const context = await resolveTheaterPathContext(theaterPath, null);
+    const watchPath = resolvePlansWatchDirectory(deps.dataDir, context.realPath);
+    if (!watchPath || !deps.subscribeToChanges) {
+      deps.writeJson(res, 404, { error: "not_found" });
+      return;
+    }
+    deps.subscribeToChanges(res, watchPath);
+  } catch (error) {
+    writePlanStoreError(res, deps, error);
+  }
+}
+
+function readEventsTheaterId(req: http.IncomingMessage): string | null {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const theaterIds = url.searchParams.getAll("theaterId");
+  if (theaterIds.length !== 1 || theaterIds[0] === "" || [...url.searchParams.keys()].some((key) => key !== "theaterId")) return null;
+  return theaterIds[0] ?? null;
 }
 
 async function handlePlansList(req: http.IncomingMessage, res: http.ServerResponse, deps: PlansRouteDeps): Promise<void> {

--- a/runtime/fleet-console/core/host/plans/routes.ts
+++ b/runtime/fleet-console/core/host/plans/routes.ts
@@ -6,6 +6,7 @@ import { TheaterPathContextError, resolveTheaterPathContext } from "../theater-p
 export interface PlansRouteDeps {
   readonly dataDir: string;
   readonly isAuthorized: (req: http.IncomingMessage) => boolean;
+  readonly isEventsAuthorized?: (req: http.IncomingMessage) => boolean;
   readonly readJsonBody: <T>(req: http.IncomingMessage) => Promise<T | null>;
   readonly resolveTheaterPath: (theaterId: string) => string | null;
   readonly writeJson: (res: http.ServerResponse, status: number, body: unknown) => void;
@@ -50,7 +51,7 @@ async function handlePlansEvents(req: http.IncomingMessage, res: http.ServerResp
     deps.writeJson(res, 405, { error: "Method not allowed" });
     return;
   }
-  if (!deps.isAuthorized(req)) {
+  if (!deps.isEventsAuthorized?.(req)) {
     deps.writeJson(res, 401, { error: "unauthorized" });
     return;
   }

--- a/runtime/fleet-console/core/host/plans/watcher.ts
+++ b/runtime/fleet-console/core/host/plans/watcher.ts
@@ -32,6 +32,7 @@ export const PLANS_WATCH_DEBOUNCE_MS = 200;
 export function createPlansWatcherRegistry(
   watcherFactory: PlansWatcherFactory = (watchPath, options, listener) => fs.watch(watchPath, options, listener),
   debounceMs = PLANS_WATCH_DEBOUNCE_MS,
+  directoryExists: (watchPath: string) => boolean = (watchPath) => fs.existsSync(watchPath),
 ): PlansWatcherRegistry {
   const entries = new Map<string, WatchEntry>();
 
@@ -65,6 +66,13 @@ export function createPlansWatcherRegistry(
     try {
       const watcher = watcherFactory(watchPath, { recursive: false }, () => {
         if (entry.closed) return;
+        // 감시 대상 디렉터리 자체가 삭제되면 fs.watch는 죽은 inode에 붙은 채 이후 이벤트를
+        // 놓친다 — 구독을 종료 전파해 SSE를 닫고, 클라이언트 재연결 경로가 재생성된
+        // 디렉터리로 새 워처를 붙이게 한다.
+        if (!directoryExists(watchPath)) {
+          closeEntry(watchPath, entry, true);
+          return;
+        }
         if (entry.timer) clearTimeout(entry.timer);
         entry.timer = setTimeout(() => {
           entry.timer = null;

--- a/runtime/fleet-console/core/host/plans/watcher.ts
+++ b/runtime/fleet-console/core/host/plans/watcher.ts
@@ -1,0 +1,85 @@
+import fs from "node:fs";
+
+export interface PlansWatcherHandle {
+  close(): void;
+  on(event: "error", listener: (error: Error) => void): unknown;
+}
+
+export type PlansWatcherFactory = (
+  watchPath: string,
+  options: { readonly recursive: boolean },
+  listener: (eventType: string, filename: string | Buffer | null) => void,
+) => PlansWatcherHandle;
+
+export interface PlansWatcherRegistry {
+  subscribe(watchPath: string, onChange: () => void): () => void;
+}
+
+interface WatchEntry {
+  readonly watcher: PlansWatcherHandle;
+  readonly subscribers: Set<() => void>;
+  timer: ReturnType<typeof setTimeout> | null;
+  closed: boolean;
+}
+
+export const PLANS_WATCH_DEBOUNCE_MS = 200;
+
+export function createPlansWatcherRegistry(
+  watcherFactory: PlansWatcherFactory = (watchPath, options, listener) => fs.watch(watchPath, options, listener),
+  debounceMs = PLANS_WATCH_DEBOUNCE_MS,
+): PlansWatcherRegistry {
+  const entries = new Map<string, WatchEntry>();
+
+  return {
+    subscribe(watchPath, onChange) {
+      let entry: WatchEntry | null | undefined = entries.get(watchPath);
+      if (!entry) {
+        entry = createEntry(watchPath);
+        if (!entry) return () => {};
+        entries.set(watchPath, entry);
+      }
+      entry.subscribers.add(onChange);
+      let unsubscribed = false;
+      return () => {
+        if (unsubscribed) return;
+        unsubscribed = true;
+        entry.subscribers.delete(onChange);
+        if (entry.subscribers.size !== 0) return;
+        closeEntry(watchPath, entry);
+      };
+    },
+  };
+
+  function createEntry(watchPath: string): WatchEntry | null {
+    const subscribers = new Set<() => void>();
+    let entry: WatchEntry;
+    try {
+      const watcher = watcherFactory(watchPath, { recursive: false }, () => {
+        if (entry.closed) return;
+        if (entry.timer) clearTimeout(entry.timer);
+        entry.timer = setTimeout(() => {
+          entry.timer = null;
+          for (const subscriber of entry.subscribers) subscriber();
+        }, debounceMs);
+      });
+      entry = { watcher, subscribers, timer: null, closed: false };
+      watcher.on("error", () => closeEntry(watchPath, entry));
+      return entry;
+    } catch {
+      return null;
+    }
+  }
+
+  function closeEntry(watchPath: string, entry: WatchEntry): void {
+    if (entry.closed) return;
+    entry.closed = true;
+    if (entry.timer) clearTimeout(entry.timer);
+    entry.timer = null;
+    try {
+      entry.watcher.close();
+    } catch {
+      // A platform watcher can already be closed when its error event arrives.
+    }
+    if (entries.get(watchPath) === entry) entries.delete(watchPath);
+  }
+}

--- a/runtime/fleet-console/core/host/plans/watcher.ts
+++ b/runtime/fleet-console/core/host/plans/watcher.ts
@@ -15,6 +15,11 @@ export interface PlansWatcherRegistry {
   subscribe(watchPath: string, onChange: () => void, onClose: () => void): () => void;
 }
 
+export interface PlansWatchDirectoryIdentity {
+  readonly dev: number;
+  readonly ino: number;
+}
+
 interface WatchSubscriber {
   readonly onChange: () => void;
   readonly onClose: () => void;
@@ -23,6 +28,7 @@ interface WatchSubscriber {
 interface WatchEntry {
   readonly watcher: PlansWatcherHandle;
   readonly subscribers: Set<WatchSubscriber>;
+  readonly identity: PlansWatchDirectoryIdentity | null;
   timer: ReturnType<typeof setTimeout> | null;
   closed: boolean;
 }
@@ -32,7 +38,14 @@ export const PLANS_WATCH_DEBOUNCE_MS = 200;
 export function createPlansWatcherRegistry(
   watcherFactory: PlansWatcherFactory = (watchPath, options, listener) => fs.watch(watchPath, options, listener),
   debounceMs = PLANS_WATCH_DEBOUNCE_MS,
-  directoryExists: (watchPath: string) => boolean = (watchPath) => fs.existsSync(watchPath),
+  directoryIdentity: (watchPath: string) => PlansWatchDirectoryIdentity | null = (watchPath) => {
+    try {
+      const stat = fs.statSync(watchPath);
+      return { dev: stat.dev, ino: stat.ino };
+    } catch {
+      return null;
+    }
+  },
 ): PlansWatcherRegistry {
   const entries = new Map<string, WatchEntry>();
 
@@ -66,10 +79,13 @@ export function createPlansWatcherRegistry(
     try {
       const watcher = watcherFactory(watchPath, { recursive: false }, () => {
         if (entry.closed) return;
-        // 감시 대상 디렉터리 자체가 삭제되면 fs.watch는 죽은 inode에 붙은 채 이후 이벤트를
-        // 놓친다 — 구독을 종료 전파해 SSE를 닫고, 클라이언트 재연결 경로가 재생성된
-        // 디렉터리로 새 워처를 붙이게 한다.
-        if (!directoryExists(watchPath)) {
+        // 감시 대상 디렉터리가 삭제·교체되면 fs.watch는 죽은 inode에 붙은 채 이후 이벤트를
+        // 놓친다. 빠른 rm -rf && mkdir 교체는 이벤트 도착 시점에 경로가 이미 다시 존재하므로
+        // 존재 여부가 아니라 watch 시점에 캡처한 dev/ino 아이덴티티와 비교해 판별한다 —
+        // 불일치·소실이면 구독을 종료 전파해 SSE를 닫고, 클라이언트 재연결 경로가
+        // 재생성된 디렉터리로 새 워처를 붙이게 한다.
+        const current = directoryIdentity(watchPath);
+        if (!current || entry.identity === null || current.dev !== entry.identity.dev || current.ino !== entry.identity.ino) {
           closeEntry(watchPath, entry, true);
           return;
         }
@@ -79,7 +95,7 @@ export function createPlansWatcherRegistry(
           for (const subscriber of entry.subscribers) subscriber.onChange();
         }, debounceMs);
       });
-      entry = { watcher, subscribers, timer: null, closed: false };
+      entry = { watcher, subscribers, identity: directoryIdentity(watchPath), timer: null, closed: false };
       watcher.on("error", () => closeEntry(watchPath, entry, true));
       return entry;
     } catch {

--- a/runtime/fleet-console/core/host/plans/watcher.ts
+++ b/runtime/fleet-console/core/host/plans/watcher.ts
@@ -12,12 +12,17 @@ export type PlansWatcherFactory = (
 ) => PlansWatcherHandle;
 
 export interface PlansWatcherRegistry {
-  subscribe(watchPath: string, onChange: () => void): () => void;
+  subscribe(watchPath: string, onChange: () => void, onClose: () => void): () => void;
+}
+
+interface WatchSubscriber {
+  readonly onChange: () => void;
+  readonly onClose: () => void;
 }
 
 interface WatchEntry {
   readonly watcher: PlansWatcherHandle;
-  readonly subscribers: Set<() => void>;
+  readonly subscribers: Set<WatchSubscriber>;
   timer: ReturnType<typeof setTimeout> | null;
   closed: boolean;
 }
@@ -31,19 +36,23 @@ export function createPlansWatcherRegistry(
   const entries = new Map<string, WatchEntry>();
 
   return {
-    subscribe(watchPath, onChange) {
+    subscribe(watchPath, onChange, onClose) {
       let entry: WatchEntry | null | undefined = entries.get(watchPath);
       if (!entry) {
         entry = createEntry(watchPath);
-        if (!entry) return () => {};
+        if (!entry) {
+          onClose();
+          return () => {};
+        }
         entries.set(watchPath, entry);
       }
-      entry.subscribers.add(onChange);
+      const subscriber = { onChange, onClose };
+      entry.subscribers.add(subscriber);
       let unsubscribed = false;
       return () => {
         if (unsubscribed) return;
         unsubscribed = true;
-        entry.subscribers.delete(onChange);
+        entry.subscribers.delete(subscriber);
         if (entry.subscribers.size !== 0) return;
         closeEntry(watchPath, entry);
       };
@@ -51,7 +60,7 @@ export function createPlansWatcherRegistry(
   };
 
   function createEntry(watchPath: string): WatchEntry | null {
-    const subscribers = new Set<() => void>();
+    const subscribers = new Set<WatchSubscriber>();
     let entry: WatchEntry;
     try {
       const watcher = watcherFactory(watchPath, { recursive: false }, () => {
@@ -59,18 +68,18 @@ export function createPlansWatcherRegistry(
         if (entry.timer) clearTimeout(entry.timer);
         entry.timer = setTimeout(() => {
           entry.timer = null;
-          for (const subscriber of entry.subscribers) subscriber();
+          for (const subscriber of entry.subscribers) subscriber.onChange();
         }, debounceMs);
       });
       entry = { watcher, subscribers, timer: null, closed: false };
-      watcher.on("error", () => closeEntry(watchPath, entry));
+      watcher.on("error", () => closeEntry(watchPath, entry, true));
       return entry;
     } catch {
       return null;
     }
   }
 
-  function closeEntry(watchPath: string, entry: WatchEntry): void {
+  function closeEntry(watchPath: string, entry: WatchEntry, notifySubscribers = false): void {
     if (entry.closed) return;
     entry.closed = true;
     if (entry.timer) clearTimeout(entry.timer);
@@ -81,5 +90,8 @@ export function createPlansWatcherRegistry(
       // A platform watcher can already be closed when its error event arrives.
     }
     if (entries.get(watchPath) === entry) entries.delete(watchPath);
+    if (notifySubscribers) {
+      for (const subscriber of entry.subscribers) subscriber.onClose();
+    }
   }
 }

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -250,9 +250,9 @@ export const SERVER_API_CATALOG: readonly ApiCatalogEntry[] = [
   {
     method: "GET",
     path: "/api/v1/plans/events",
-    summary: "Stream theater plan invalidations from the exact Console origin.",
+    summary: "Theater 실행 계획 변경 신호를 스트리밍합니다.",
     category: "Observer",
-    gate: "origin-strict",
+    gate: "origin-write",
   },
   {
     method: "POST",
@@ -529,7 +529,9 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   const plansRouter = createPlansRouter({
     dataDir: fleetDataDir,
     isAuthorized: isTerminalAuthorized,
-    isEventsAuthorized: isExactConsoleOrigin,
+    // events는 same-origin EventSource가 Origin 헤더를 보내지 않으므로 exact-Origin 게이트를 쓸 수 없다.
+    // list/read와 동일한 terminal Origin 게이트(무-Origin 허용·존재 시 정확 일치)를 적용한다.
+    isEventsAuthorized: isTerminalAuthorized,
     readJsonBody,
     resolveTheaterPath: (theaterId) => theaters.get(theaterId)?.realpath ?? null,
     writeJson,

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -248,6 +248,13 @@ export const SERVER_API_CATALOG: readonly ApiCatalogEntry[] = [
     gate: "origin-write",
   },
   {
+    method: "GET",
+    path: "/api/v1/plans/events",
+    summary: "Stream theater plan invalidations from the exact Console origin.",
+    category: "Observer",
+    gate: "origin-strict",
+  },
+  {
     method: "POST",
     path: "/api/v1/updates/apply",
     summary: "Request console update application.",
@@ -522,6 +529,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   const plansRouter = createPlansRouter({
     dataDir: fleetDataDir,
     isAuthorized: isTerminalAuthorized,
+    isEventsAuthorized: isExactConsoleOrigin,
     readJsonBody,
     resolveTheaterPath: (theaterId) => theaters.get(theaterId)?.realpath ?? null,
     writeJson,
@@ -532,9 +540,13 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
         "Connection": "keep-alive",
       }));
       res.write(":connected\n\n");
-      const unsubscribe = plansWatcherRegistry.subscribe(watchPath, () => {
-        res.write(encodeSseData("plans-changed", {}));
-      });
+      const unsubscribe = plansWatcherRegistry.subscribe(
+        watchPath,
+        () => {
+          res.write(encodeSseData("plans-changed", {}));
+        },
+        () => res.end(),
+      );
       let cleanedUp = false;
       const cleanup = () => {
         if (cleanedUp) return;

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -28,6 +28,7 @@ import { createOperationStore } from "./operations/store.js";
 import type { OperationNode } from "./operations/types.js";
 import { createConsoleDataPaths } from "./paths.js";
 import { createPlansRouter } from "./plans/routes.js";
+import { createPlansWatcherRegistry } from "./plans/watcher.js";
 import { createPluginClientAssets } from "./plugin-host/client-assets.js";
 import { createFleetPluginHost } from "./plugin-host/host.js";
 import type { FleetPluginHostCapabilities, OperationCatalogPlugin, OperationLaunchCatalogProvider, OperationLaunchKind } from "./plugin-host/types.js";
@@ -517,12 +518,32 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     systemFonts: deps.systemFonts ?? createSystemFontsService(),
     writeJson,
   });
+  const plansWatcherRegistry = createPlansWatcherRegistry();
   const plansRouter = createPlansRouter({
     dataDir: fleetDataDir,
     isAuthorized: isTerminalAuthorized,
     readJsonBody,
     resolveTheaterPath: (theaterId) => theaters.get(theaterId)?.realpath ?? null,
     writeJson,
+    subscribeToChanges: (res, watchPath) => {
+      res.writeHead(200, withSecurityHeaders({
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+      }));
+      res.write(":connected\n\n");
+      const unsubscribe = plansWatcherRegistry.subscribe(watchPath, () => {
+        res.write(encodeSseData("plans-changed", {}));
+      });
+      let cleanedUp = false;
+      const cleanup = () => {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        unsubscribe();
+      };
+      res.on("close", cleanup);
+      res.on("error", cleanup);
+    },
   });
   const theaterPathContextRouter = createTheaterPathContextRouter({
     getTheater: (theaterId) => theaters.get(theaterId),
@@ -634,7 +655,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       runAsyncHandler(handleTheaterFolderGrants(req, res), res);
       return;
     }
-    if (pathname === "/api/v1/plans/list" || pathname === "/api/v1/plans/read") {
+    if (pathname === "/api/v1/plans/list" || pathname === "/api/v1/plans/read" || pathname === "/api/v1/plans/events") {
       runAsyncBooleanHandler(plansRouter({ req, res, pathname }), res, () => false);
       return;
     }

--- a/runtime/fleet-console/tests/plans-events.test.ts
+++ b/runtime/fleet-console/tests/plans-events.test.ts
@@ -1,0 +1,160 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type http from "node:http";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ensureWorkspaceDirectory } from "@dotobokuri/core-infra/workspace-dir";
+
+import { createPlansRouter } from "../core/host/plans/routes.js";
+import { PLANS_WATCH_DEBOUNCE_MS, createPlansWatcherRegistry, type PlansWatcherHandle } from "../core/host/plans/watcher.js";
+import { encodeSseData } from "../core/host/sse.js";
+
+interface JsonResponse { readonly status: number; readonly body: unknown; }
+
+let tmpDir: string;
+let theaterPath: string;
+let dataDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "plans-events-"));
+  theaterPath = path.join(tmpDir, "theater");
+  dataDir = path.join(tmpDir, "fleet-data");
+  await fs.promises.mkdir(theaterPath);
+  await fs.promises.mkdir(path.join(ensureWorkspaceDirectory(dataDir, theaterPath).path, "plans"), { recursive: true });
+});
+
+afterEach(async () => {
+  await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  vi.useRealTimers();
+});
+
+describe("Plans events route", () => {
+  it("rejects wrong methods, unauthorized, malformed, and unknown Theater requests before subscription", async () => {
+    const subscribe = vi.fn();
+    const resolveTheaterPath = vi.fn((id: string) => id === "known" ? theaterPath : null);
+    const denied = createRouteContext({ subscribe, resolveTheaterPath, authorized: false });
+
+    await denied.router({ req: request("POST", "?theaterId=known"), res: {} as http.ServerResponse, pathname: "/api/v1/plans/events" });
+    await denied.router({ req: request("GET", "?theaterId=known"), res: {} as http.ServerResponse, pathname: "/api/v1/plans/events" });
+    expect(denied.responses).toEqual([{ status: 405, body: { error: "Method not allowed" } }, { status: 401, body: { error: "unauthorized" } }]);
+    expect(resolveTheaterPath).not.toHaveBeenCalled();
+    expect(subscribe).not.toHaveBeenCalled();
+
+    const malformed = createRouteContext({ subscribe, resolveTheaterPath, authorized: true });
+    for (const suffix of ["", "?theaterId=", "?theaterId=known&theaterId=other", "?theaterId=known&extra=value"]) {
+      await malformed.router({ req: request("GET", suffix), res: {} as http.ServerResponse, pathname: "/api/v1/plans/events" });
+    }
+    await malformed.router({ req: request("GET", "?theaterId=unknown"), res: {} as http.ServerResponse, pathname: "/api/v1/plans/events" });
+    expect(malformed.responses).toEqual([
+      { status: 400, body: { error: "invalid_request" } }, { status: 400, body: { error: "invalid_request" } },
+      { status: 400, body: { error: "invalid_request" } }, { status: 400, body: { error: "invalid_request" } },
+      { status: 404, body: { error: "theater_not_found" } },
+    ]);
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
+  it("opens an authorized valid Theater signal without serializing watch data", async () => {
+    const subscribe = vi.fn();
+    const { router, responses } = createRouteContext({ subscribe, resolveTheaterPath: () => theaterPath, authorized: true });
+    const response = {} as http.ServerResponse;
+
+    await router({ req: request("GET", "?theaterId=theater%20one"), res: response, pathname: "/api/v1/plans/events" });
+
+    expect(responses).toEqual([]);
+    expect(subscribe).toHaveBeenCalledOnce();
+    expect(subscribe.mock.calls[0]?.[0]).toBe(response);
+    expect(encodeSseData("plans-changed", {})).toBe("event: plans-changed\ndata: {}\n\n");
+  });
+});
+
+describe("Plans watcher registry", () => {
+  it("debounces a shared non-recursive watcher and releases it after the last idempotent close", () => {
+    vi.useFakeTimers();
+    const watcher = new FakeWatcher();
+    const factory = vi.fn((_path: string, _options: { readonly recursive: boolean }, listener: () => void) => {
+      watcher.listen(listener);
+      return watcher;
+    });
+    const registry = createPlansWatcherRegistry(factory);
+    const first = vi.fn();
+    const second = vi.fn();
+    const unsubscribeFirst = registry.subscribe("/safe/plans", first);
+    const unsubscribeSecond = registry.subscribe("/safe/plans", second);
+
+    expect(factory).toHaveBeenCalledOnce();
+    expect(factory).toHaveBeenCalledWith("/safe/plans", { recursive: false }, expect.any(Function));
+    watcher.change(); watcher.change(); watcher.change();
+    vi.advanceTimersByTime(PLANS_WATCH_DEBOUNCE_MS - 1);
+    expect(first).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledOnce();
+    unsubscribeFirst();
+    expect(watcher.close).not.toHaveBeenCalled();
+    unsubscribeSecond(); unsubscribeSecond();
+    expect(watcher.close).toHaveBeenCalledOnce();
+  });
+
+  it("contains runtime watcher errors, clears pending signals, and permits a fresh subscription", () => {
+    vi.useFakeTimers();
+    const firstWatcher = new FakeWatcher();
+    const secondWatcher = new FakeWatcher();
+    let calls = 0;
+    const factory = vi.fn((_path: string, _options: { readonly recursive: boolean }, listener: () => void) => {
+      const watcher = calls++ === 0 ? firstWatcher : secondWatcher;
+      watcher.listen(listener);
+      return watcher;
+    });
+    const registry = createPlansWatcherRegistry(factory);
+    const onChange = vi.fn();
+    const unsubscribe = registry.subscribe("/safe/plans", onChange);
+
+    firstWatcher.change(); firstWatcher.error();
+    vi.advanceTimersByTime(PLANS_WATCH_DEBOUNCE_MS);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(firstWatcher.close).toHaveBeenCalledOnce();
+    unsubscribe();
+    expect(firstWatcher.close).toHaveBeenCalledOnce();
+    const retry = registry.subscribe("/safe/plans", onChange);
+    expect(factory).toHaveBeenCalledTimes(2);
+    retry();
+    expect(secondWatcher.close).toHaveBeenCalledOnce();
+  });
+});
+
+function createRouteContext({ subscribe, resolveTheaterPath, authorized }: {
+  readonly subscribe: (res: http.ServerResponse, watchPath: string) => void;
+  readonly resolveTheaterPath: (id: string) => string | null;
+  readonly authorized: boolean;
+}) {
+  const responses: JsonResponse[] = [];
+  return {
+    responses,
+    router: createPlansRouter({
+      dataDir,
+      isAuthorized: () => authorized,
+      readJsonBody: async () => null,
+      resolveTheaterPath,
+      subscribeToChanges: subscribe,
+      writeJson: (_res, status, body) => responses.push({ status, body }),
+    }),
+  };
+}
+
+function request(method: string, suffix: string): http.IncomingMessage {
+  return { method, url: `/api/v1/plans/events${suffix}` } as http.IncomingMessage;
+}
+
+class FakeWatcher implements PlansWatcherHandle {
+  readonly close = vi.fn();
+  private changeListener: (() => void) | null = null;
+  private errorListener: ((error: Error) => void) | null = null;
+
+  on(_event: "error", listener: (error: Error) => void): unknown { this.errorListener = listener; return this; }
+  listen(listener: () => void): void { this.changeListener = listener; }
+  change(): void { this.changeListener?.(); }
+  error(): void { this.errorListener?.(new Error("watch failed")); }
+}

--- a/runtime/fleet-console/tests/plans-events.test.ts
+++ b/runtime/fleet-console/tests/plans-events.test.ts
@@ -82,7 +82,7 @@ describe("Plans watcher registry", () => {
       watcher.listen(listener);
       return watcher;
     });
-    const registry = createPlansWatcherRegistry(factory, PLANS_WATCH_DEBOUNCE_MS, () => true);
+    const registry = createPlansWatcherRegistry(factory, PLANS_WATCH_DEBOUNCE_MS, () => ({ dev: 1, ino: 1 }));
     const first = vi.fn();
     const second = vi.fn();
     const unsubscribeFirst = registry.subscribe("/safe/plans", first, vi.fn());
@@ -112,7 +112,7 @@ describe("Plans watcher registry", () => {
       watcher.listen(listener);
       return watcher;
     });
-    const registry = createPlansWatcherRegistry(factory, PLANS_WATCH_DEBOUNCE_MS, () => true);
+    const registry = createPlansWatcherRegistry(factory, PLANS_WATCH_DEBOUNCE_MS, () => ({ dev: 1, ino: 1 }));
     const onChange = vi.fn();
     const onClose = vi.fn();
     const unsubscribe = registry.subscribe("/safe/plans", onChange, onClose);
@@ -146,13 +146,36 @@ describe("Plans watcher registry", () => {
       watcher.listen(listener);
       return watcher;
     });
-    let exists = true;
-    const registry = createPlansWatcherRegistry(factory, PLANS_WATCH_DEBOUNCE_MS, () => exists);
+    let identity: { dev: number; ino: number } | null = { dev: 1, ino: 1 };
+    const registry = createPlansWatcherRegistry(factory, PLANS_WATCH_DEBOUNCE_MS, () => identity);
     const onChange = vi.fn();
     const onClose = vi.fn();
     registry.subscribe("/safe/plans", onChange, onClose);
 
-    exists = false;
+    identity = null;
+    watcher.change();
+    vi.advanceTimersByTime(PLANS_WATCH_DEBOUNCE_MS);
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(watcher.close).toHaveBeenCalledOnce();
+  });
+
+  it("closes the subscription when a fast directory swap changes the watched identity", () => {
+    vi.useFakeTimers();
+    const watcher = new FakeWatcher();
+    const factory = vi.fn((_path: string, _options: { readonly recursive: boolean }, listener: Parameters<PlansWatcherFactory>[2]) => {
+      watcher.listen(listener);
+      return watcher;
+    });
+    // rm -rf && mkdir 직후에는 경로가 다시 존재하지만 inode가 바뀐다 — 존재 여부만으로는 못 잡는 케이스.
+    let identity: { dev: number; ino: number } | null = { dev: 1, ino: 1 };
+    const registry = createPlansWatcherRegistry(factory, PLANS_WATCH_DEBOUNCE_MS, () => identity);
+    const onChange = vi.fn();
+    const onClose = vi.fn();
+    registry.subscribe("/safe/plans", onChange, onClose);
+
+    identity = { dev: 1, ino: 2 };
     watcher.change();
     vi.advanceTimersByTime(PLANS_WATCH_DEBOUNCE_MS);
 

--- a/runtime/fleet-console/tests/plans-events.test.ts
+++ b/runtime/fleet-console/tests/plans-events.test.ts
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ensureWorkspaceDirectory } from "@dotobokuri/core-infra/workspace-dir";
 
 import { createPlansRouter } from "../core/host/plans/routes.js";
-import { PLANS_WATCH_DEBOUNCE_MS, createPlansWatcherRegistry, type PlansWatcherHandle } from "../core/host/plans/watcher.js";
+import { PLANS_WATCH_DEBOUNCE_MS, createPlansWatcherRegistry, type PlansWatcherFactory, type PlansWatcherHandle } from "../core/host/plans/watcher.js";
 import { encodeSseData } from "../core/host/sse.js";
 
 interface JsonResponse { readonly status: number; readonly body: unknown; }
@@ -32,23 +32,26 @@ afterEach(async () => {
 });
 
 describe("Plans events route", () => {
-  it("rejects wrong methods, unauthorized, malformed, and unknown Theater requests before subscription", async () => {
+  it("requires the exact Console Origin before validating or subscribing to event requests", async () => {
     const subscribe = vi.fn();
     const resolveTheaterPath = vi.fn((id: string) => id === "known" ? theaterPath : null);
-    const denied = createRouteContext({ subscribe, resolveTheaterPath, authorized: false });
+    const eventOrigin = "http://127.0.0.1:4312";
+    const denied = createRouteContext({ subscribe, resolveTheaterPath, authorized: true, eventsAuthorized: (req) => req.headers.origin === eventOrigin });
 
-    await denied.router({ req: request("POST", "?theaterId=known"), res: {} as http.ServerResponse, pathname: "/api/v1/plans/events" });
     await denied.router({ req: request("GET", "?theaterId=known"), res: {} as http.ServerResponse, pathname: "/api/v1/plans/events" });
-    expect(denied.responses).toEqual([{ status: 405, body: { error: "Method not allowed" } }, { status: 401, body: { error: "unauthorized" } }]);
+    await denied.router({ req: request("GET", "?theaterId=known", "http://evil.example"), res: {} as http.ServerResponse, pathname: "/api/v1/plans/events" });
+    expect(denied.responses).toEqual([{ status: 401, body: { error: "unauthorized" } }, { status: 401, body: { error: "unauthorized" } }]);
     expect(resolveTheaterPath).not.toHaveBeenCalled();
     expect(subscribe).not.toHaveBeenCalled();
 
-    const malformed = createRouteContext({ subscribe, resolveTheaterPath, authorized: true });
+    const malformed = createRouteContext({ subscribe, resolveTheaterPath, authorized: true, eventsAuthorized: () => true });
+    await malformed.router({ req: request("POST", "?theaterId=known", eventOrigin), res: {} as http.ServerResponse, pathname: "/api/v1/plans/events" });
     for (const suffix of ["", "?theaterId=", "?theaterId=known&theaterId=other", "?theaterId=known&extra=value"]) {
-      await malformed.router({ req: request("GET", suffix), res: {} as http.ServerResponse, pathname: "/api/v1/plans/events" });
+      await malformed.router({ req: request("GET", suffix, eventOrigin), res: {} as http.ServerResponse, pathname: "/api/v1/plans/events" });
     }
-    await malformed.router({ req: request("GET", "?theaterId=unknown"), res: {} as http.ServerResponse, pathname: "/api/v1/plans/events" });
+    await malformed.router({ req: request("GET", "?theaterId=unknown", eventOrigin), res: {} as http.ServerResponse, pathname: "/api/v1/plans/events" });
     expect(malformed.responses).toEqual([
+      { status: 405, body: { error: "Method not allowed" } },
       { status: 400, body: { error: "invalid_request" } }, { status: 400, body: { error: "invalid_request" } },
       { status: 400, body: { error: "invalid_request" } }, { status: 400, body: { error: "invalid_request" } },
       { status: 404, body: { error: "theater_not_found" } },
@@ -58,10 +61,11 @@ describe("Plans events route", () => {
 
   it("opens an authorized valid Theater signal without serializing watch data", async () => {
     const subscribe = vi.fn();
-    const { router, responses } = createRouteContext({ subscribe, resolveTheaterPath: () => theaterPath, authorized: true });
+    const eventOrigin = "http://127.0.0.1:4312";
+    const { router, responses } = createRouteContext({ subscribe, resolveTheaterPath: () => theaterPath, authorized: true, eventsAuthorized: (req) => req.headers.origin === eventOrigin });
     const response = {} as http.ServerResponse;
 
-    await router({ req: request("GET", "?theaterId=theater%20one"), res: response, pathname: "/api/v1/plans/events" });
+    await router({ req: request("GET", "?theaterId=theater%20one", eventOrigin), res: response, pathname: "/api/v1/plans/events" });
 
     expect(responses).toEqual([]);
     expect(subscribe).toHaveBeenCalledOnce();
@@ -74,15 +78,15 @@ describe("Plans watcher registry", () => {
   it("debounces a shared non-recursive watcher and releases it after the last idempotent close", () => {
     vi.useFakeTimers();
     const watcher = new FakeWatcher();
-    const factory = vi.fn((_path: string, _options: { readonly recursive: boolean }, listener: () => void) => {
+    const factory = vi.fn((_path: string, _options: { readonly recursive: boolean }, listener: Parameters<PlansWatcherFactory>[2]) => {
       watcher.listen(listener);
       return watcher;
     });
     const registry = createPlansWatcherRegistry(factory);
     const first = vi.fn();
     const second = vi.fn();
-    const unsubscribeFirst = registry.subscribe("/safe/plans", first);
-    const unsubscribeSecond = registry.subscribe("/safe/plans", second);
+    const unsubscribeFirst = registry.subscribe("/safe/plans", first, vi.fn());
+    const unsubscribeSecond = registry.subscribe("/safe/plans", second, vi.fn());
 
     expect(factory).toHaveBeenCalledOnce();
     expect(factory).toHaveBeenCalledWith("/safe/plans", { recursive: false }, expect.any(Function));
@@ -103,32 +107,44 @@ describe("Plans watcher registry", () => {
     const firstWatcher = new FakeWatcher();
     const secondWatcher = new FakeWatcher();
     let calls = 0;
-    const factory = vi.fn((_path: string, _options: { readonly recursive: boolean }, listener: () => void) => {
+    const factory = vi.fn((_path: string, _options: { readonly recursive: boolean }, listener: Parameters<PlansWatcherFactory>[2]) => {
       const watcher = calls++ === 0 ? firstWatcher : secondWatcher;
       watcher.listen(listener);
       return watcher;
     });
     const registry = createPlansWatcherRegistry(factory);
     const onChange = vi.fn();
-    const unsubscribe = registry.subscribe("/safe/plans", onChange);
+    const onClose = vi.fn();
+    const unsubscribe = registry.subscribe("/safe/plans", onChange, onClose);
 
     firstWatcher.change(); firstWatcher.error();
     vi.advanceTimersByTime(PLANS_WATCH_DEBOUNCE_MS);
     expect(onChange).not.toHaveBeenCalled();
     expect(firstWatcher.close).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
     unsubscribe();
     expect(firstWatcher.close).toHaveBeenCalledOnce();
-    const retry = registry.subscribe("/safe/plans", onChange);
+    const retry = registry.subscribe("/safe/plans", onChange, vi.fn());
     expect(factory).toHaveBeenCalledTimes(2);
     retry();
     expect(secondWatcher.close).toHaveBeenCalledOnce();
   });
+
+  it("notifies the initial SSE subscriber when watcher creation fails", () => {
+    const registry = createPlansWatcherRegistry(() => { throw new Error("watch failed"); });
+    const onClose = vi.fn();
+
+    registry.subscribe("/safe/plans", vi.fn(), onClose);
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
 });
 
-function createRouteContext({ subscribe, resolveTheaterPath, authorized }: {
+function createRouteContext({ subscribe, resolveTheaterPath, authorized, eventsAuthorized }: {
   readonly subscribe: (res: http.ServerResponse, watchPath: string) => void;
   readonly resolveTheaterPath: (id: string) => string | null;
   readonly authorized: boolean;
+  readonly eventsAuthorized: (req: http.IncomingMessage) => boolean;
 }) {
   const responses: JsonResponse[] = [];
   return {
@@ -136,6 +152,7 @@ function createRouteContext({ subscribe, resolveTheaterPath, authorized }: {
     router: createPlansRouter({
       dataDir,
       isAuthorized: () => authorized,
+      isEventsAuthorized: eventsAuthorized,
       readJsonBody: async () => null,
       resolveTheaterPath,
       subscribeToChanges: subscribe,
@@ -144,17 +161,17 @@ function createRouteContext({ subscribe, resolveTheaterPath, authorized }: {
   };
 }
 
-function request(method: string, suffix: string): http.IncomingMessage {
-  return { method, url: `/api/v1/plans/events${suffix}` } as http.IncomingMessage;
+function request(method: string, suffix: string, origin?: string): http.IncomingMessage {
+  return { method, url: `/api/v1/plans/events${suffix}`, headers: origin ? { origin } : {} } as http.IncomingMessage;
 }
 
 class FakeWatcher implements PlansWatcherHandle {
   readonly close = vi.fn();
-  private changeListener: (() => void) | null = null;
+  private changeListener: Parameters<PlansWatcherFactory>[2] | null = null;
   private errorListener: ((error: Error) => void) | null = null;
 
   on(_event: "error", listener: (error: Error) => void): unknown { this.errorListener = listener; return this; }
-  listen(listener: () => void): void { this.changeListener = listener; }
-  change(): void { this.changeListener?.(); }
+  listen(listener: Parameters<PlansWatcherFactory>[2]): void { this.changeListener = listener; }
+  change(): void { this.changeListener?.("change", "plan.md"); }
   error(): void { this.errorListener?.(new Error("watch failed")); }
 }

--- a/runtime/fleet-console/tests/plans-events.test.ts
+++ b/runtime/fleet-console/tests/plans-events.test.ts
@@ -32,7 +32,7 @@ afterEach(async () => {
 });
 
 describe("Plans events route", () => {
-  it("requires the exact Console Origin before validating or subscribing to event requests", async () => {
+  it("applies the events authorization gate before validating or subscribing to event requests", async () => {
     const subscribe = vi.fn();
     const resolveTheaterPath = vi.fn((id: string) => id === "known" ? theaterPath : null);
     const eventOrigin = "http://127.0.0.1:4312";

--- a/runtime/fleet-console/tests/plans-events.test.ts
+++ b/runtime/fleet-console/tests/plans-events.test.ts
@@ -82,7 +82,7 @@ describe("Plans watcher registry", () => {
       watcher.listen(listener);
       return watcher;
     });
-    const registry = createPlansWatcherRegistry(factory);
+    const registry = createPlansWatcherRegistry(factory, PLANS_WATCH_DEBOUNCE_MS, () => true);
     const first = vi.fn();
     const second = vi.fn();
     const unsubscribeFirst = registry.subscribe("/safe/plans", first, vi.fn());
@@ -112,7 +112,7 @@ describe("Plans watcher registry", () => {
       watcher.listen(listener);
       return watcher;
     });
-    const registry = createPlansWatcherRegistry(factory);
+    const registry = createPlansWatcherRegistry(factory, PLANS_WATCH_DEBOUNCE_MS, () => true);
     const onChange = vi.fn();
     const onClose = vi.fn();
     const unsubscribe = registry.subscribe("/safe/plans", onChange, onClose);
@@ -137,6 +137,28 @@ describe("Plans watcher registry", () => {
     registry.subscribe("/safe/plans", vi.fn(), onClose);
 
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("closes the subscription instead of signaling when the watched directory disappears", () => {
+    vi.useFakeTimers();
+    const watcher = new FakeWatcher();
+    const factory = vi.fn((_path: string, _options: { readonly recursive: boolean }, listener: Parameters<PlansWatcherFactory>[2]) => {
+      watcher.listen(listener);
+      return watcher;
+    });
+    let exists = true;
+    const registry = createPlansWatcherRegistry(factory, PLANS_WATCH_DEBOUNCE_MS, () => exists);
+    const onChange = vi.fn();
+    const onClose = vi.fn();
+    registry.subscribe("/safe/plans", onChange, onClose);
+
+    exists = false;
+    watcher.change();
+    vi.advanceTimersByTime(PLANS_WATCH_DEBOUNCE_MS);
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(watcher.close).toHaveBeenCalledOnce();
   });
 });
 

--- a/runtime/fleet-console/tests/plans-helpers.test.ts
+++ b/runtime/fleet-console/tests/plans-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { filterPlans, formatRelativeTime, getLaneDispatchState, getProgressPercent, getWaveProgressState, isWaveSettled, normalizePlanHeading, planListSignature } from "../core/client/src/rail/plans-helpers.js";
+import { filterPlans, formatRelativeTime, getLaneDispatchState, getProgressPercent, getWaveProgressState, isWaveSettled, normalizePlanHeading, planLaneHeadingMatches, planListSignature } from "../core/client/src/rail/plans-helpers.js";
 
 const NOW = Date.UTC(2026, 6, 10, 0, 0, 0);
 
@@ -83,5 +83,12 @@ describe("Plans live-view helpers", () => {
     expect(planListSignature(plans[0]!)).not.toBe(planListSignature({ ...plans[0]!, tasksDone: 2 }));
     expect(normalizePlanHeading("  Wave 1\n  Build  ")).toBe("Wave 1 Build");
     expect(normalizePlanHeading("Lane W1-A")).toBe("Lane W1-A");
+  });
+
+  it("matches rendered lane headings whose Lane prefix the parser strips", () => {
+    expect(planLaneHeadingMatches("Lane W1-A \u2014 Build", "W1-A \u2014 Build")).toBe(true);
+    expect(planLaneHeadingMatches("lane  W1-A \u2014 Build", "W1-A \u2014 Build")).toBe(true);
+    expect(planLaneHeadingMatches("Lane W1-A \u2014 Build", "Lane W1-A \u2014 Build")).toBe(true);
+    expect(planLaneHeadingMatches("Lane W1-B \u2014 Build", "W1-A \u2014 Build")).toBe(false);
   });
 });

--- a/runtime/fleet-console/tests/plans-helpers.test.ts
+++ b/runtime/fleet-console/tests/plans-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { formatRelativeTime, getLaneDispatchState, getProgressPercent, getWaveProgressState, isWaveSettled } from "../core/client/src/rail/plans-helpers.js";
+import { filterPlans, formatRelativeTime, getLaneDispatchState, getProgressPercent, getWaveProgressState, isWaveSettled, normalizePlanHeading, planListSignature } from "../core/client/src/rail/plans-helpers.js";
 
 const NOW = Date.UTC(2026, 6, 10, 0, 0, 0);
 
@@ -61,5 +61,27 @@ describe("getLaneDispatchState", () => {
   it("keeps first-wave lanes ready and taskless lanes unmarked", () => {
     expect(getLaneDispatchState([wave(0, 2)], 0, wave(0, 2))).toBe("ready");
     expect(getLaneDispatchState([wave(0, 2)], 0, wave(0, 0))).toBe("none");
+  });
+});
+
+describe("Plans live-view helpers", () => {
+  const plans = [
+    { name: "alpha.md", title: "Alpha launch", tasksDone: 1, tasksTotal: 3, updatedAt: "2026-07-10T00:00:00.000Z", executionMode: "sequential" as const, waveCount: 1, sizeBytes: 10 },
+    { name: "bravo.md", title: "Bravo complete", tasksDone: 2, tasksTotal: 2, updatedAt: "2026-07-10T00:00:00.000Z", executionMode: "parallel" as const, waveCount: 2, sizeBytes: 20 },
+    { name: "notes.md", title: "Taskless notes", tasksDone: 0, tasksTotal: 0, updatedAt: "2026-07-10T00:00:00.000Z", executionMode: null, waveCount: 0, sizeBytes: 5 },
+  ];
+
+  it("filters name/title case-insensitively and classifies task-bearing status", () => {
+    expect(filterPlans(plans, "LAUNCH", "all").map((plan) => plan.name)).toEqual(["alpha.md"]);
+    expect(filterPlans(plans, "", "in-progress").map((plan) => plan.name)).toEqual(["alpha.md"]);
+    expect(filterPlans(plans, "", "complete").map((plan) => plan.name)).toEqual(["bravo.md"]);
+    expect(filterPlans(plans, "notes", "complete")).toEqual([]);
+  });
+
+  it("changes a row signature for material list changes and normalizes headings", () => {
+    expect(planListSignature(plans[0]!)).toBe(planListSignature({ ...plans[0]! }));
+    expect(planListSignature(plans[0]!)).not.toBe(planListSignature({ ...plans[0]!, tasksDone: 2 }));
+    expect(normalizePlanHeading("  Wave 1\n  Build  ")).toBe("Wave 1 Build");
+    expect(normalizePlanHeading("Lane W1-A")).toBe("Lane W1-A");
   });
 });

--- a/runtime/fleet-console/tests/plans-security.test.ts
+++ b/runtime/fleet-console/tests/plans-security.test.ts
@@ -171,6 +171,8 @@ Keep the Plan visible from its active Theater.
 - Rollback unit: Plan fixture
 - Implementation summary:
   - [ ] W1-A-T1 — Write the Theater-bound Plan
+  - [ ] W1-A-T2 — Verify the Theater route
+  - [ ] W1-A-T3 — Preserve the workspace binding
 - Verification/static checks:
   - plan lint
 - Escalation triggers: Theater binding unavailable
@@ -208,7 +210,7 @@ Keep the Plan visible from its active Theater.
 
     expect(written).toMatchObject({ ok: true });
     expect((list.responses[0] as { readonly body: { readonly plans: Array<{ readonly name: string }> } }).body.plans).toEqual(expect.arrayContaining([expect.objectContaining({ name: "theater-bound.md" })]));
-    expect(read.responses).toEqual([expect.objectContaining({ status: 200, body: expect.objectContaining({ markdown }) })]);
+    expect(read.responses).toEqual([expect.objectContaining({ status: 200, body: expect.objectContaining({ content: markdown }) })]);
     expect(JSON.stringify({ list: list.responses, read: read.responses })).not.toContain(carrierCwd);
     expect(JSON.stringify({ list: list.responses, read: read.responses })).not.toContain("fleet-plans.workspace-ref");
   });


### PR DESCRIPTION
## Summary
- Plans 레일 패널을 "상황실"로 개선: 워크스페이스 plans 디렉터리 fs.watch + Origin 게이트 SSE(`GET /api/v1/plans/events`, `plans-changed` 빈 payload 시그널, 200ms 디바운스)로 목록·열린 리더·웨이브 스트립이 자체 갱신되고 변경 행이 1회 펄스합니다. 갱신은 기존 ready 데이터를 유지하는 background revalidation이라 리더 깜빡임이 없습니다.
- 웨이브 칩/레인이 네이티브 버튼이 되어 클릭 시 본문 h2/h3 헤딩으로 점프+플래시하고, 목록에 ↑↓/Enter/Escape 키보드 내비를 추가했습니다(neutralizePlanDom 하드닝 불변).
- 목록 커맨드 표면 추가: 검색(name/title), ALL·IN PROGRESS·COMPLETE 상태 칩, REFRESH, 행별 `plans/<name>` 상대경로 복사. 선택 플랜이 디스크에서 삭제되면 리더가 조용히 낡는 대신 error 상태로 표면화됩니다.

## Test Plan
- [x] `corepack pnpm --filter @dotobokuri/fleet-console build` green
- [x] 타깃 vitest 33/33 green (plans-events·plans-helpers·plans-security·api-catalog) — plans-security 선존 fixture(lane task-count lint 미달)도 이 PR에서 수리
- [x] host tsc 신규 오류 0 (선존 CSS/virtual:fleet-plugins 10건만 잔존)
- [x] 격리 인스턴스 실브라우저 e2e: EventSource OPEN → 디스크 체크박스 플립 → 2.5s 내 목록·리더 동기 갱신, 리더 loading 깜빡임 0회(MutationObserver 감시), 웨이브 점프+플래시, 검색/필터/키보드, 플랜 삭제 시 리더 error 전환 확인
- [x] 전체 스위트 잔존 실패는 origin/canary 선존 server.test 1건(MCP sessions)뿐 — 베이스 코드 단독 실행으로 실증
- [x] Changelog: `.changelog.d/pr-298.md` — 그룹형 문법·이중언어 요약·`compile-changelog-fragments.mjs --check` 검증 완료

## Notes
- events 라우트는 list/read와 동일한 terminal Origin 게이트를 사용합니다. exact-Origin 강제는 same-origin EventSource가 Origin 헤더를 보내지 않아(실측: 401·readyState=2 자기차단) 채택하지 않았습니다.
