### PR TITLE
feat(repository): switch path context from worktree rows

### DIFF
--- a/.changelog.d/pr-294.md
+++ b/.changelog.d/pr-294.md
@@ -8,6 +8,8 @@
 #### Added
 - [fleet-console] Add a read-only refs endpoint listing local and remote branches, tags, stashes, and worktrees with current markers.
   ko: 로컬·원격 브랜치, 태그, 스태시, 워크트리를 current 마커와 함께 나열하는 읽기 전용 refs 엔드포인트를 추가합니다.
+- [fleet-console] Switch the theater path context by selecting a worktree row in the Repository panel.
+  ko: Repository 패널의 워크트리 행을 선택해 theater path context를 전환합니다.
 
 ### fleet-console
 #### Changed

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -103,19 +103,20 @@ export function RightRail({ theaterId, api }: RightRailProps) {
     document.addEventListener("pointerup", onUp);
   }, []);
 
-  const ctx: RailPanelContext = useMemo(() => ({
-    theaterId,
-    pathContext: pathContext ?? ROOT_PATH_CONTEXT,
-    api,
-    requestExtraWidth: (px: number | null) => {
-      if (activeId !== null) requestRailPanelExtraWidth(activeId, px);
-    },
-  }), [theaterId, pathContext, api, activeId]);
-
   const selectPathContext = useCallback((relPath: string | null) => {
     if (!theaterId) return;
     void mutateRailPathContext(theaterId, (signal) => putRailPathContext(theaterId, relPath, signal));
   }, [theaterId]);
+
+  const ctx: RailPanelContext = useMemo(() => ({
+    theaterId,
+    pathContext: pathContext ?? ROOT_PATH_CONTEXT,
+    selectPathContext,
+    api,
+    requestExtraWidth: (px: number | null) => {
+      if (activeId !== null) requestRailPanelExtraWidth(activeId, px);
+    },
+  }), [theaterId, pathContext, selectPathContext, api, activeId]);
 
   return (
     <div

--- a/runtime/fleet-console/sdk/rail/types.ts
+++ b/runtime/fleet-console/sdk/rail/types.ts
@@ -11,6 +11,8 @@ export interface RailPathContext {
 export interface RailPanelContext {
   readonly theaterId: string | null;
   readonly pathContext: RailPathContext;
+  /** deck 선택과 동일 경로로 path context를 전환한다. */
+  readonly selectPathContext?: (relPath: string | null) => void;
   readonly api: ClientApiCapability;
   readonly requestExtraWidth?: (px: number | null) => void;
 }

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -65,11 +65,11 @@ function RepositoryPanel({ ctx }: RepositoryPanelProps) {
 
 type Source = "changes" | "history" | "branches" | "tags" | "stashes" | "worktrees";
 type RefSource = Exclude<Source, "changes" | "history">;
-export type RepositoryWorktree = { name: string; branch: string | null; current: boolean };
+export type RepositoryWorktree = { name: string; branch: string | null; current: boolean; contextRelPath: string | null };
 export type RepositoryRefItem = { label: string; ref: string; current: boolean };
 export type RepositoryStash = { name: string; subject: string };
 export type RepositoryRefs = { branches: RepositoryRefItem[]; remotes: RepositoryRefItem[]; tags: RepositoryRefItem[]; stashes: RepositoryStash[]; worktrees: RepositoryWorktree[] };
-export type RepositoryRefRow = { key: string; source: RefSource; primary: string; sub?: string; ref: string | null; current: boolean };
+export type RepositoryRefRow = { key: string; source: RefSource; primary: string; sub?: string; ref: string | null; current: boolean; contextRelPath?: string | null };
 export type RepositoryRefGroup = { label?: "LOCAL" | "REMOTES"; rows: RepositoryRefRow[] };
 type Refs = RepositoryRefs;
 
@@ -87,7 +87,15 @@ export function buildRefListGroups(source: RefSource, refs: RepositoryRefs): Rep
   }
   if (source === "tags") return [{ rows: refRows(refs.tags, "tags") }];
   if (source === "stashes") return [{ rows: refs.stashes.map((item) => ({ key: item.name, source, primary: item.subject || item.name, sub: item.name, ref: null, current: false })) }];
-  return [{ rows: refs.worktrees.map((item) => ({ key: item.name, source, primary: item.branch ?? item.name, ...(item.branch && item.branch !== item.name ? { sub: item.name } : {}), ref: null, current: item.current })) }];
+  return [{ rows: refs.worktrees.map((item) => ({ key: item.name, source, primary: item.branch ?? item.name, ...(item.branch && item.branch !== item.name ? { sub: item.name } : {}), ref: null, current: item.current, contextRelPath: item.contextRelPath })) }];
+}
+
+export function isWorktreePathContextSelectable(selectPathContext: RailPanelContext["selectPathContext"], contextRelPath: string | null | undefined): boolean {
+  return selectPathContext !== undefined && contextRelPath !== null && contextRelPath !== undefined;
+}
+
+export function worktreePathContextRelPath(contextRelPath: string): string | null {
+  return contextRelPath === "" ? null : contextRelPath;
 }
 function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   const [source, setSourceState] = useState<Source>(readRepositorySource);
@@ -180,7 +188,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   return (
     <div className="repository-unified"><SourceNav source={source} refs={refs} onSource={setSource} onRef={(ref) => { setRefFilter(ref); setSource("history"); }} /><div className="repository-source-content">
       <div className="repository-source-fill" hidden={source !== "history"}><HistoryPanel ctx={ctx} active={source === "history"} refFilter={refFilter} wipFiles={wipFiles} onInspectorOpenChange={setHistoryInspectorOpen} onClearRef={() => setRefFilter(null)} onWip={() => setSource("changes")} /></div>
-      {source !== "changes" && source !== "history" ? refsError ? <div className="history-error">Unable to load refs<button type="button" className="repository-refresh-btn" onClick={() => setRefsRetry((value) => value + 1)}>Retry</button></div> : <RefList source={source} refs={refs} onRef={(ref) => { setRefFilter(ref); setSource("history"); }} /> : null}
+      {source !== "changes" && source !== "history" ? refsError ? <div className="history-error">Unable to load refs<button type="button" className="repository-refresh-btn" onClick={() => setRefsRetry((value) => value + 1)}>Retry</button></div> : <RefList source={source} refs={refs} onRef={(ref) => { setRefFilter(ref); setSource("history"); }} selectPathContext={ctx.selectPathContext} /> : null}
       <div hidden={source !== "changes"} ref={rootRef} className={`repository-root${selectedFile ? " has-hunk" : ""}${isDragging ? " is-dragging" : ""}`} style={selectedFile ? { gridTemplateColumns: buildDiffGridTemplate(listPaneWidth) } : undefined}>
       {selectedFile && hunkMode ? <div className="repository-hunk-pane"><div className="repository-hunk-head"><span>{selectedFile.entry.path}</span><button type="button" onClick={handleCloseHunk}>✕</button></div><HunkView ctx={ctx} file={selectedFile.entry} mode={hunkMode} subPath={selectedFile.subPath} /></div> : null}
       {selectedFile ? <div className="repository-divider" onPointerDown={handleDividerDown} aria-hidden="true" /> : null}
@@ -194,9 +202,15 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
 
 function SourceIcon({ source }: { readonly source: Source }) { const path = source === "changes" ? "M3 4h12M3 9h12M3 14h12" : source === "history" ? "M4 4v10h10M7 7h6v5" : source === "branches" ? "M5 3v12M5 6h7M5 12h7" : source === "tags" ? "M3 4h8l4 4-7 7-5-5z" : source === "stashes" ? "M4 5h10v9H4zM6 3h6" : "M3 5h5l1 2h6v7H3z"; return <svg viewBox="0 0 18 18" aria-hidden="true"><path d={path} fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" /></svg>; }
 function SourceNav({ source, refs, onSource }: { readonly source: Source; readonly refs: Refs; readonly onSource: (source: Source) => void; readonly onRef: (ref: string) => void }) { const button = (id: Source, label: string, count?: number) => <button key={id} type="button" aria-label={label} aria-current={source === id ? "page" : undefined} onClick={() => onSource(id)}><SourceIcon source={id} /><span>{label}</span>{count !== undefined && <i>{count}</i>}</button>; return <nav className="repository-source-nav" aria-label="Repository sources"><b>WORKING</b>{button("changes", "Changes")}{button("history", "History")}<b>REFS</b>{button("branches", "Branches", refs.branches.length + refs.remotes.filter((item) => !isRemoteHeadRef(item.ref)).length)}{button("tags", "Tags", refs.tags.length)}{button("stashes", "Stashes", refs.stashes.length)}{button("worktrees", "Worktrees", refs.worktrees.length)}</nav>; }
-function RefList({ source, refs, onRef }: { readonly source: Source; readonly refs: Refs; readonly onRef: (ref: string) => void }) {
+function RefList({ source, refs, onRef, selectPathContext }: { readonly source: Source; readonly refs: Refs; readonly onRef: (ref: string) => void; readonly selectPathContext: RailPanelContext["selectPathContext"] }) {
   if (source === "changes" || source === "history") return null;
-  return <div className="repository-ref-list">{buildRefListGroups(source, refs).map((group) => <div key={group.label ?? source} className="repository-ref-group">{group.label && <b className="repository-ref-group-label">{group.label}</b>}{group.rows.map((row) => <button type="button" key={row.key} className={`repository-ref-row${row.current ? " is-current" : ""}`} disabled={row.ref === null} onClick={() => { if (row.ref) onRef(row.ref); }}><SourceIcon source={row.source} /><span className="repository-ref-name">{row.primary}{row.current && " ✓"}</span>{row.sub && <span className="repository-ref-sub">{row.sub}</span>}</button>)}</div>)}</div>;
+  return <div className="repository-ref-list">{buildRefListGroups(source, refs).map((group) => <div key={group.label ?? source} className="repository-ref-group">{group.label && <b className="repository-ref-group-label">{group.label}</b>}{group.rows.map((row) => {
+    const worktreeSelectable = row.source === "worktrees" && isWorktreePathContextSelectable(selectPathContext, row.contextRelPath);
+    return <button type="button" key={row.key} className={`repository-ref-row${row.current ? " is-current" : ""}`} disabled={row.source === "worktrees" ? !worktreeSelectable : row.ref === null} onClick={() => {
+      if (row.ref) onRef(row.ref);
+      else if (worktreeSelectable && selectPathContext && typeof row.contextRelPath === "string") selectPathContext(worktreePathContextRelPath(row.contextRelPath));
+    }}><SourceIcon source={row.source} /><span className="repository-ref-name">{row.primary}{row.current && " ✓"}</span>{row.sub && <span className="repository-ref-sub">{row.sub}</span>}</button>;
+  })}</div>)}</div>;
 }
 
 function RepositoryIcon() {

--- a/runtime/fleet-plugins/repository/server/refs.ts
+++ b/runtime/fleet-plugins/repository/server/refs.ts
@@ -24,16 +24,34 @@ async function readStashes(gitCwd: string): Promise<string> {
     throw error;
   }
 }
-export async function parseWorktrees(stdout: string, currentWorktreePath: string): Promise<readonly { name: string; branch: string | null; current: boolean }[]> {
+export interface ParseWorktreesDeps {
+  readonly realpath?: (path: string) => Promise<string>;
+}
+
+export async function parseWorktrees(stdout: string, currentWorktreePath: string, theaterPath: string, deps: ParseWorktreesDeps = {}): Promise<readonly { name: string; branch: string | null; current: boolean; contextRelPath: string | null }[]> {
   const records = stdout.split("\n\n").map((record) => record.split("\n"));
-  const normalizedCurrent = currentWorktreePath ? await fs.realpath(currentWorktreePath).catch(() => currentWorktreePath) : "";
+  const realpath = deps.realpath ?? fs.realpath;
+  const normalizedCurrent = currentWorktreePath ? await realpath(currentWorktreePath).catch(() => currentWorktreePath) : "";
+  const realTheaterPath = await realpath(theaterPath).catch(() => null);
   return Promise.all(records.flatMap((record) => {
     const rawPath = record.find((line) => line.startsWith("worktree "))?.slice(9);
     if (!rawPath) return [];
     const branchRef = record.find((line) => line.startsWith("branch "))?.slice(7) ?? null;
     const branch = branchRef?.startsWith("refs/heads/") ? branchRef.slice(11) : null;
     return [{ rawPath, name: path.basename(rawPath) || "worktree", branch }];
-  }).map(async ({ rawPath, ...item }) => ({ ...item, current: normalizedCurrent !== "" && (await fs.realpath(rawPath).catch(() => rawPath)) === normalizedCurrent })));
+  }).map(async ({ rawPath, ...item }) => {
+    const realWorktreePath = await realpath(rawPath).catch(() => null);
+    const currentPath = realWorktreePath ?? rawPath;
+    const contextRelPath = realTheaterPath !== null && realWorktreePath !== null && isWithinTheater(realWorktreePath, realTheaterPath)
+      ? path.relative(realTheaterPath, realWorktreePath).split(path.sep).join("/")
+      : null;
+    return { ...item, current: normalizedCurrent !== "" && currentPath === normalizedCurrent, contextRelPath };
+  }));
+}
+
+function isWithinTheater(candidate: string, theaterPath: string): boolean {
+  const normalizedTheaterPath = theaterPath.endsWith(path.sep) ? theaterPath : `${theaterPath}${path.sep}`;
+  return candidate === theaterPath || candidate.startsWith(normalizedTheaterPath);
 }
 
 /** Browser-safe, read-only ref inventory. Never return worktree filesystem paths. */
@@ -60,7 +78,7 @@ export async function handleRepositoryRefs(req: http.IncomingMessage, res: http.
     ctx.host.http.writeJson(res, 200, {
       branches: parseRefItems(local.stdout, current), remotes: parseRefItems(remote.stdout, current), tags: parseRefItems(tags.stdout, current),
       stashes: lines(stashes).map((line) => { const [name, subject = ""] = line.split("\0"); return { name, subject }; }),
-      worktrees: await parseWorktrees(worktrees.stdout, currentWorktreePath),
+      worktrees: await parseWorktrees(worktrees.stdout, currentWorktreePath, theaterPath),
     });
   } catch (error) {
     if (error instanceof GitExecutorError && error.code === "no_git_repo") { ctx.host.http.writeJson(res, 200, { branches: [], remotes: [], tags: [], stashes: [], worktrees: [] }); return; }

--- a/runtime/fleet-plugins/repository/tests/repository-panel-state.test.ts
+++ b/runtime/fleet-plugins/repository/tests/repository-panel-state.test.ts
@@ -29,7 +29,22 @@ describe("Repository panel state contracts", () => {
     ]);
   });
 
-  it("renders browser-safe worktree names and current marker without paths", async () => {
-    expect(await parseWorktrees("worktree /private/repo\nHEAD 123\nbranch refs/heads/main\n\nworktree /private/other\nHEAD 456\n", "/private/repo")).toEqual([{ name: "repo", branch: "main", current: true }, { name: "other", branch: null, current: false }]);
+  it("renders browser-safe worktree names, current marker, and theater-relative context", async () => {
+    const realpaths = new Map([
+      ["/private/repo", "/real/repo"],
+      ["/private/repo/.fleet/worktrees/topic", "/real/repo/.fleet/worktrees/topic"],
+      ["/private/other", "/real/other"],
+    ]);
+    const realpath = async (value: string): Promise<string> => {
+      const resolved = realpaths.get(value);
+      if (!resolved) throw new Error("missing");
+      return resolved;
+    };
+
+    expect(await parseWorktrees("worktree /private/repo\nHEAD 123\nbranch refs/heads/main\n\nworktree /private/repo/.fleet/worktrees/topic\nHEAD 456\nbranch refs/heads/topic\n\nworktree /private/other\nHEAD 789\n", "/private/repo", "/private/repo", { realpath })).toEqual([
+      { name: "repo", branch: "main", current: true, contextRelPath: "" },
+      { name: "topic", branch: "topic", current: false, contextRelPath: ".fleet/worktrees/topic" },
+      { name: "other", branch: null, current: false, contextRelPath: null },
+    ]);
   });
 });

--- a/runtime/fleet-plugins/repository/tests/repository-ref-list.test.ts
+++ b/runtime/fleet-plugins/repository/tests/repository-ref-list.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildRefListGroups, isRemoteHeadRef } from "../client/rail-panel.js";
+import { buildRefListGroups, isRemoteHeadRef, isWorktreePathContextSelectable, worktreePathContextRelPath } from "../client/rail-panel.js";
 
 describe("Repository ref list rows", () => {
   it("excludes symbolic remote HEAD refs from the REMOTES group", () => {
@@ -25,7 +25,7 @@ describe("Repository ref list rows", () => {
     const refs = {
       branches: [], remotes: [], tags: [],
       stashes: [{ name: "stash@{0}", subject: "WIP: preserve selection" }, { name: "stash@{1}", subject: "" }],
-      worktrees: [{ name: "repository-ref-list-polish", branch: "repository-ref-list-polish", current: true }, { name: "detached", branch: null, current: false }, { name: "worktree-dir", branch: "topic", current: false }],
+      worktrees: [{ name: "repository-ref-list-polish", branch: "repository-ref-list-polish", current: true, contextRelPath: "" }, { name: "detached", branch: null, current: false, contextRelPath: null }, { name: "worktree-dir", branch: "topic", current: false, contextRelPath: ".fleet/worktrees/topic" }],
     };
 
     expect(buildRefListGroups("stashes", refs)[0]?.rows).toEqual([
@@ -33,9 +33,20 @@ describe("Repository ref list rows", () => {
       { key: "stash@{1}", source: "stashes", primary: "stash@{1}", sub: "stash@{1}", ref: null, current: false },
     ]);
     expect(buildRefListGroups("worktrees", refs)[0]?.rows).toEqual([
-      { key: "repository-ref-list-polish", source: "worktrees", primary: "repository-ref-list-polish", ref: null, current: true },
-      { key: "detached", source: "worktrees", primary: "detached", ref: null, current: false },
-      { key: "worktree-dir", source: "worktrees", primary: "topic", sub: "worktree-dir", ref: null, current: false },
+      { key: "repository-ref-list-polish", source: "worktrees", primary: "repository-ref-list-polish", ref: null, current: true, contextRelPath: "" },
+      { key: "detached", source: "worktrees", primary: "detached", ref: null, current: false, contextRelPath: null },
+      { key: "worktree-dir", source: "worktrees", primary: "topic", sub: "worktree-dir", ref: null, current: false, contextRelPath: ".fleet/worktrees/topic" },
     ]);
+  });
+
+  it("enables only selectable worktrees and maps the theater root to the deck root", () => {
+    const selectPathContext = () => undefined;
+
+    expect(isWorktreePathContextSelectable(selectPathContext, "")).toBe(true);
+    expect(isWorktreePathContextSelectable(selectPathContext, ".fleet/worktrees/topic")).toBe(true);
+    expect(isWorktreePathContextSelectable(selectPathContext, null)).toBe(false);
+    expect(isWorktreePathContextSelectable(undefined, ".fleet/worktrees/topic")).toBe(false);
+    expect(worktreePathContextRelPath("")).toBeNull();
+    expect(worktreePathContextRelPath(".fleet/worktrees/topic")).toBe(".fleet/worktrees/topic");
   });
 });


### PR DESCRIPTION
## Summary
- Repository 패널 Worktrees 행이 무반응이던 것을 수정합니다 — 행 클릭이 pathAware deck과 동일 경로로 theater path context를 전환합니다(루트 행은 theater-wide 컨텍스트로 복귀).
- `RailPanelContext`에 옵션 `selectPathContext` 능력을 추가하고(rail 호스트의 기존 deck 뮤테이션 콜백 재사용), refs API의 워크트리 레코드에 theater-상대 `contextRelPath`(root=`""`, 외부 워크트리=`null`→비활성)를 추가했습니다. 절대경로는 DTO에 노출하지 않습니다.

## Test Plan
- [x] `@fleet-plugins/repository` vitest 122/122(+1: contextRelPath root/내부/외부·행 활성/매핑) · typecheck · build green
- [x] `@dotobokuri/fleet-console` build green
- [x] 격리 콘솔 실브라우저: 워크트리 행 클릭 → deck 라벨 fleet-harness→repository-worktree-select 전환·패널 리마운트, 워크트리 컨텍스트에서 current ✓ 이동, 루트 행 클릭 → fleet-harness 복귀 왕복 실증
- [x] Changelog: 미릴리스 pr-294.md에 폴드(Release Baseline 독트린) — `compile-changelog-fragments.mjs --check` 통과