### PR TITLE
fix(console): base command band progression on viewport

### DIFF
--- a/.changelog.d/pr-302.md
+++ b/.changelog.d/pr-302.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Keep Command Band progressive behavior tied to the viewport when resizing the Activity Rail.
+  ko: Activity Rail 크기를 조절해도 Command Band의 progressive 동작이 화면 폭만 따르도록 유지합니다.

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -6,7 +6,7 @@ import { FleetBrandHome } from "./side-bar-brand-foot.js";
 import { useConsoleState } from "../hooks/use-store.js";
 import { putRailPathContext } from "../rail/path-context-api.js";
 import { PathContextDeck } from "../rail/path-context-deck.js";
-import { mutateRailPathContext, setRailPathContextDeckOpen, toggleRailChrome, useRailChromeExpanded, useRailPathContextStore, useRightRailWidth } from "../rail/rail-store.js";
+import { mutateRailPathContext, setRailPathContextDeckOpen, toggleRailChrome, useRailChromeExpanded, useRailPathContextStore } from "../rail/rail-store.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
 import { setSideBarCollapsed, useSideBarState } from "../sidebar/operations-side-bar-store.js";
@@ -30,7 +30,6 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
   const registry = usePluginRegistry();
   const sideBar = useSideBarState();
   const railChromeExpanded = useRailChromeExpanded();
-  const rightRailWidth = useRightRailWidth();
   const modLabel = resolveModLabel();
   const sideBarShortcut = `${modLabel}${modLabel === "⌘" ? "" : "+"}B`;
   const railShortcut = `${modLabel}${modLabel === "⌘" ? "⌥" : "+Alt+"}B`;
@@ -240,7 +239,7 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
       <header
         ref={commandBandRef}
         className={`command-band${operationsViewVisible ? " is-operations" : " is-utility"}${fullscreen.isFullscreen ? " is-fullscreen" : ""}${fullscreen.isVisible ? " is-revealed" : ""}`}
-        style={{ "--command-band-left-width": `${sideBar.width}px`, "--command-band-right-width": `${rightRailWidth}px` } as CSSProperties}
+        style={{ "--command-band-left-width": `${sideBar.width}px` } as CSSProperties}
         aria-hidden={commandBandHidden || undefined}
         inert={commandBandHidden || undefined}
         onPointerEnter={handleBandPointerEnter}

--- a/runtime/fleet-console/core/client/src/rail/rail-store.ts
+++ b/runtime/fleet-console/core/client/src/rail/rail-store.ts
@@ -12,7 +12,6 @@ interface RailPathContextState {
 interface RailStore {
   readonly activeRailPanelId: string | null;
   readonly railChromeExpanded: boolean;
-  readonly rightRailWidth: number;
   readonly panelExtraWidth: number;
   readonly pathContextTheaterId: string | null;
   readonly pathContext: RailPathContext | null;
@@ -40,7 +39,6 @@ let activePathGeneration = 0;
 let store: RailStore = {
   activeRailPanelId: readStoredPanelId(),
   railChromeExpanded: readStoredChromeExpanded(),
-  rightRailWidth: 44,
   panelExtraWidth: 0,
   pathContextTheaterId: null,
   pathContext: null,
@@ -92,12 +90,6 @@ export function setRailChromeExpanded(expanded: boolean): void {
 
 export function toggleRailChrome(): void {
   setRailChromeExpanded(!store.railChromeExpanded);
-}
-
-export function setRightRailWidth(width: number): void {
-  const next = Number.isFinite(width) ? Math.max(0, width) : 0;
-  if (store.rightRailWidth === next) return;
-  setStore({ ...store, rightRailWidth: next });
 }
 
 export function requestRailPanelExtraWidth(panelId: string, px: number | null): void {
@@ -175,10 +167,6 @@ export function useActiveRailPanelId(): string | null {
 
 export function useRailChromeExpanded(): boolean {
   return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).railChromeExpanded;
-}
-
-export function useRightRailWidth(): number {
-  return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).rightRailWidth;
 }
 
 export function useRailPanelExtraWidth(): number {

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -9,7 +9,7 @@ import { focusCommandBandToggleWhenPanelContainsActiveElement } from "../compone
 import { fetchRailPathContext, putRailPathContext } from "./path-context-api.js";
 import { getState, subscribe } from "../store.js";
 import { PathContextDeck } from "./path-context-deck.js";
-import { canRenderPathAwarePanelBody, closeRailPanel, hydrateRailPathContext, mutateRailPathContext, requestRailPanelExtraWidth, selectRailPathContextTheater, setRailPathContextDeckOpen, setRightRailWidth, toggleRailPanel, useActiveRailPanelId, useRailChromeExpanded, useRailPanelExtraWidth, useRailPathContextStore } from "./rail-store.js";
+import { canRenderPathAwarePanelBody, closeRailPanel, hydrateRailPathContext, mutateRailPathContext, requestRailPanelExtraWidth, selectRailPathContextTheater, setRailPathContextDeckOpen, toggleRailPanel, useActiveRailPanelId, useRailChromeExpanded, useRailPanelExtraWidth, useRailPathContextStore } from "./rail-store.js";
 import { useRailPanels } from "./rail-registry.js";
 import { useCodexSplitExtraWidth } from "./use-codex-split-extra-width.js";
 
@@ -54,19 +54,6 @@ export function RightRail({ theaterId, api }: RightRailProps) {
   const [panelWidth, setPanelWidthState] = useState(readStoredPanelWidth);
   const panelWidthRef = useRef(panelWidth);
   const [isDragging, setIsDragging] = useState(false);
-
-  useLayoutEffect(() => {
-    const root = rootRef.current;
-    if (!root) return;
-    const publishWidth = () => setRightRailWidth(root.getBoundingClientRect().width);
-    publishWidth();
-    const observer = new ResizeObserver(publishWidth);
-    observer.observe(root);
-    return () => {
-      observer.disconnect();
-      setRightRailWidth(0);
-    };
-  }, []);
 
   useLayoutEffect(() => {
     if (previousRailChromeExpandedRef.current && !railChromeExpanded) focusCommandBandToggleWhenPanelContainsActiveElement(rootRef.current, ".command-band-rail-toggle");

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -21,7 +21,7 @@
 
 .command-band {
   display: grid;
-  grid-template-columns: minmax(var(--command-band-left-width, 280px), 1fr) minmax(0, max-content) minmax(var(--command-band-right-width, 44px), 1fr);
+  grid-template-columns: minmax(var(--command-band-left-width, 280px), 1fr) minmax(0, max-content) minmax(44px, 1fr);
   flex: none;
   height: var(--chrome-band-height);
   min-height: var(--chrome-band-height);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -172,9 +172,7 @@ describe("Instrument core design contract", () => {
     expect(components).toContain(".side-bar-formation-group {");
     expect(components).toContain("border-left: 1px solid var(--surface-rim);");
     expect(commandBand).toContain('"--command-band-left-width": `${sideBar.width}px`');
-    expect(commandBand).toContain("useRightRailWidth");
-    expect(commandBand).toContain('"--command-band-right-width": `${rightRailWidth}px`');
-    expect(layout).toContain("grid-template-columns: minmax(var(--command-band-left-width, 280px), 1fr) minmax(0, max-content) minmax(var(--command-band-right-width, 44px), 1fr);");
+    expect(layout).toContain("grid-template-columns: minmax(var(--command-band-left-width, 280px), 1fr) minmax(0, max-content) minmax(44px, 1fr);");
     expect(layout).toContain("width: var(--command-band-left-width, 280px);");
     const commandBandCenterBlock = layout.match(/\.command-band-center \{[^}]*\}/)?.[0] ?? "";
     const commandBandRightBlocks = [...layout.matchAll(/\.command-band-right \{[^}]*\}/g)].map((match) => match[0]);
@@ -183,9 +181,12 @@ describe("Instrument core design contract", () => {
     expect(commandBandRightBlocks.some((block) => block.includes("justify-content: flex-end;"))).toBe(true);
     const rightRail = source("rail/right-rail.tsx");
     const railStore = source("rail/rail-store.ts");
-    expect(rightRail).toContain("new ResizeObserver(publishWidth)");
-    expect(rightRail).toContain("setRightRailWidth(root.getBoundingClientRect().width)");
-    expect(railStore).toContain("export function useRightRailWidth(): number");
+    for (const legacyRightRailCoupling of ["rightRailWidth", "setRightRailWidth", "useRightRailWidth", "--command-band-right-width"]) {
+      expect(commandBand).not.toContain(legacyRightRailCoupling);
+      expect(rightRail).not.toContain(legacyRightRailCoupling);
+      expect(railStore).not.toContain(legacyRightRailCoupling);
+    }
+    expect(rightRail).not.toContain("ResizeObserver");
     expect(layout).toContain('html[data-desktop-shell="true"] .command-band {');
     // 브랜드 홈(a)·rename(input)까지 no-drag — button만 겨냥하면 데스크톱 드래그 영역이 클릭을 삼킨다.
     expect(layout).toContain('html[data-desktop-shell="true"] .command-band button,');


### PR DESCRIPTION
## Summary

Make Command Band progressive layout depend on the viewport instead of the rendered RightRail width. The layout now reserves the fixed 44px right chrome track and removes the obsolete rail-width observer/store coupling.

## Type of Change

- [ ] feat — new feature or carrier capability
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- [x] `runtime/fleet-console`

## Test Plan

- [x] `instrument-design-contract.test.ts` and `rail-store.test.ts` — 41 tests passed
- [x] `tsc --noEmit -p core/client/tsconfig.json`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Real-browser geometry: at 1600px, RightRail 356→853→356px kept center delta at -0.0078125px; at 900px, progressive shift was 109.4140625px
- [x] No browser errors, rejected requests, or console errors during the geometry run

## Changelog

- [x] Added `.changelog.d/pr-302.md`.
- [x] Fragment section is `Fixed`.
- [x] Fragment bullets are English/Korean and use `[fleet-console]`.

## Related Issues / PRs

None.

## Notes for Reviewers

The branch starts before the latest `canary` path-context commits. Their `right-rail.tsx` change is in the context-construction block; this PR removes only the independent rendered-width observer/import coupling. Mergeability is checked before merge.
