### PR TITLE
feat(console): show carrier request blocks in stream details

### DIFF
--- a/.changelog.d/pr-303.md
+++ b/.changelog.d/pr-303.md
@@ -1,7 +1,7 @@
 ### fleet-console
 #### Added
-- [fleet-console] Add Request and Activity tabs to Stream Deck Details with exact Request Block rendering.
-  ko: Stream Deck Details에 Request와 Activity 탭을 추가하고 Request Block 원문을 정확히 표시합니다.
+- [fleet-console] Add Request and Activity tabs to Stream Deck Details with browser-safe Request Block rendering.
+  ko: Stream Deck Details에 Request와 Activity 탭을 추가하고 브라우저 보안 경계를 지키며 Request Block을 표시합니다.
 
 ### fleet-plugin
 #### Added

--- a/.changelog.d/pr-303.md
+++ b/.changelog.d/pr-303.md
@@ -1,0 +1,14 @@
+### fleet-console
+#### Added
+- [fleet-console] Add Request and Activity tabs to Stream Deck Details with exact Request Block rendering.
+  ko: Stream Deck Details에 Request와 Activity 탭을 추가하고 Request Block 원문을 정확히 표시합니다.
+
+### fleet-plugin
+#### Added
+- [fleet-console] Preserve Carrier request observations through Terminal Agent snapshots and reloads.
+  ko: Terminal Agent 스냅샷과 다시 불러오기를 거쳐도 Carrier 요청 관찰 정보를 보존합니다.
+
+### fleet-core
+#### Added
+- [fleet-carriers] Emit structured request observations without changing executor input or model usage.
+  ko: 실행기 입력이나 모델 사용량을 변경하지 않고 구조화된 요청 관찰 정보를 전달합니다.

--- a/packages/fleet-carriers/src/dispatch/prompt.ts
+++ b/packages/fleet-carriers/src/dispatch/prompt.ts
@@ -281,7 +281,7 @@ function readTag(source: string, start: number): ReadTagResult {
     cursor++;
   }
   const nameStart = cursor;
-  while (cursor < source.length && /[A-Za-z0-9_:-]/.test(source[cursor]!)) cursor++;
+  while (cursor < source.length && /[A-Za-z0-9_.:-]/.test(source[cursor]!)) cursor++;
   if (cursor === nameStart) return { token: undefined, next: start + 1 };
   const name = source.slice(nameStart, cursor);
   let quote: string | undefined;

--- a/packages/fleet-carriers/src/dispatch/prompt.ts
+++ b/packages/fleet-carriers/src/dispatch/prompt.ts
@@ -7,7 +7,7 @@
 
 import type { AuthEnvResolver } from "@dotobokuri/core-agent";
 import type { WorkspaceChangeScanner } from "../jobs/workspace-manifest.js";
-import type { CarrierMetadata, RequestBlock } from "./types.js";
+import type { CarrierMetadata, CarrierRequest, RequestBlock } from "./types.js";
 
 /** 검증 성공 결과 */
 export interface RequiredBlockValidationOk {
@@ -86,20 +86,28 @@ export function validateRequiredRequestBlocks(
   request: string,
   carrierId: string,
 ): RequiredBlockValidationResult {
+  return validateParsedRequiredRequestBlocks(meta, parseCarrierRequest(meta, request), carrierId);
+}
+
+/** Validate a request structure already parsed by the dispatch path. */
+export function validateParsedRequiredRequestBlocks(
+  meta: CarrierMetadata,
+  parsed: CarrierRequest,
+  carrierId: string,
+): RequiredBlockValidationResult {
   const required = meta.requestBlocks.filter((b) => b.required);
   if (required.length === 0) return { ok: true };
 
   const missing: string[] = [];
   const details: string[] = [];
 
+  const parsedByTag = new Map(parsed.blocks.map((block) => [block.tag, block]));
   for (const block of required) {
-    const escaped = escapeRegExp(block.tag);
-    const regex = new RegExp(`<${escaped}(?:\\s[^>]*)?>([\\s\\S]*?)</${escaped}>`);
-    const match = regex.exec(request);
-    if (!match) {
+    const observed = parsedByTag.get(block.tag);
+    if (!observed?.present) {
       missing.push(block.tag);
       details.push(`<${block.tag}> (missing closing tag)`);
-    } else if (!match[1]?.trim()) {
+    } else if (!observed.body.trim()) {
       missing.push(block.tag);
       details.push(`<${block.tag}> (empty body)`);
     }
@@ -130,7 +138,145 @@ export function formatRequestBlocksGuide(meta: CarrierMetadata): string[] {
   });
 }
 
-/** 정규식 특수문자를 이스케이프합니다 */
-function escapeRegExp(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+/**
+ * Produce the observer request structure without modifying the executor input.
+ * Only the first balanced top-level instance of each configured tag is selected.
+ */
+export function parseCarrierRequest(meta: CarrierMetadata | undefined, request: string): CarrierRequest {
+  const selected = new Map<string, ParsedBlock>();
+  const configured = new Set(meta?.requestBlocks.map((block) => block.tag) ?? []);
+  const stack: OpenTag[] = [];
+  let capture: OpenConfiguredTag | undefined;
+
+  for (let cursor = 0; cursor < request.length;) {
+    const read = readTag(request, cursor);
+    cursor = read.next;
+    const token = read.token;
+    if (!token) continue;
+
+    if (capture) {
+      // Once a top-level configured block starts, all other tags are literal body text.
+      // Only same-name nesting changes the boundary of that block.
+      if (token.name === capture.name && !token.selfClosing) {
+        if (token.closing) {
+          capture.depth--;
+          if (capture.depth === 0) {
+            if (capture.select) {
+              selected.set(token.name, {
+                start: capture.start,
+                end: token.end,
+                body: request.slice(capture.contentStart, token.start),
+              });
+            }
+            capture = undefined;
+          }
+        } else {
+          capture.depth++;
+        }
+      }
+      continue;
+    }
+
+    if (token.selfClosing) continue;
+    if (!token.closing) {
+      if (stack.length === 0 && configured.has(token.name)) {
+        capture = {
+          name: token.name,
+          start: token.start,
+          contentStart: token.end,
+          depth: 1,
+          select: !selected.has(token.name),
+        };
+      } else {
+        stack.push({ name: token.name });
+      }
+      continue;
+    }
+    const opened = stack.at(-1);
+    if (!opened || opened.name !== token.name) continue;
+    stack.pop();
+  }
+
+  const blocks = (meta?.requestBlocks ?? []).map((block) => {
+    const parsed = selected.get(block.tag);
+    return { ...block, present: parsed !== undefined, body: parsed?.body ?? "" };
+  });
+  const ranges = [...selected.values()].sort((left, right) => left.start - right.start);
+  let additional = "";
+  let cursor = 0;
+  for (const range of ranges) {
+    additional += request.slice(cursor, range.start);
+    cursor = range.end;
+  }
+  additional += request.slice(cursor);
+  return { blocks, additional };
+}
+
+interface ParsedBlock {
+  start: number;
+  end: number;
+  body: string;
+}
+
+interface OpenTag {
+  name: string;
+}
+
+interface OpenConfiguredTag {
+  name: string;
+  start: number;
+  contentStart: number;
+  depth: number;
+  select: boolean;
+}
+
+interface RequestTag {
+  name: string;
+  start: number;
+  end: number;
+  closing: boolean;
+  selfClosing: boolean;
+}
+
+interface ReadTagResult {
+  token: RequestTag | undefined;
+  next: number;
+}
+
+/** Read a permissive XML-like tag while preserving every non-selected character verbatim. */
+function readTag(source: string, start: number): ReadTagResult {
+  if (source[start] !== "<") return { token: undefined, next: start + 1 };
+  let cursor = start + 1;
+  let closing = false;
+  if (source[cursor] === "/") {
+    closing = true;
+    cursor++;
+  }
+  const nameStart = cursor;
+  while (cursor < source.length && /[A-Za-z0-9_:-]/.test(source[cursor]!)) cursor++;
+  if (cursor === nameStart) return { token: undefined, next: start + 1 };
+  const name = source.slice(nameStart, cursor);
+  let quote: string | undefined;
+  for (; cursor < source.length; cursor++) {
+    const character = source[cursor]!;
+    if (quote) {
+      if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character === ">") {
+      const beforeClose = source.slice(start, cursor).trimEnd();
+      return { token: { name, start, end: cursor + 1, closing, selfClosing: !closing && beforeClose.endsWith("/") }, next: cursor + 1 };
+    }
+    if (character === "<") {
+      // A later tag-like prefix terminates this malformed opener. Resume at it so
+      // repeated unterminated prefixes each scan only their own span.
+      return { token: undefined, next: cursor };
+    }
+  }
+  // No later prefix remains, so the inspected suffix cannot yield another tag.
+  return { token: undefined, next: source.length };
 }

--- a/packages/fleet-carriers/src/dispatch/prompt.ts
+++ b/packages/fleet-carriers/src/dispatch/prompt.ts
@@ -144,8 +144,10 @@ export function formatRequestBlocksGuide(meta: CarrierMetadata): string[] {
  */
 export function parseCarrierRequest(meta: CarrierMetadata | undefined, request: string): CarrierRequest {
   const selected = new Map<string, ParsedBlock>();
+  const candidates: ParsedBlockCandidate[] = [];
   const configured = new Set(meta?.requestBlocks.map((block) => block.tag) ?? []);
   const stack: OpenTag[] = [];
+  const openedTags: OpenTag[] = [];
   let capture: OpenConfiguredTag | undefined;
 
   for (let cursor = 0; cursor < request.length;) {
@@ -161,13 +163,13 @@ export function parseCarrierRequest(meta: CarrierMetadata | undefined, request: 
         if (token.closing) {
           capture.depth--;
           if (capture.depth === 0) {
-            if (capture.select) {
-              selected.set(token.name, {
-                start: capture.start,
-                end: token.end,
-                body: request.slice(capture.contentStart, token.start),
-              });
-            }
+            candidates.push({
+              name: token.name,
+              start: capture.start,
+              end: token.end,
+              body: request.slice(capture.contentStart, token.start),
+              ancestor: capture.ancestor,
+            });
             capture = undefined;
           }
         } else {
@@ -179,22 +181,40 @@ export function parseCarrierRequest(meta: CarrierMetadata | undefined, request: 
 
     if (token.selfClosing) continue;
     if (!token.closing) {
-      if (stack.length === 0 && configured.has(token.name)) {
+      if (configured.has(token.name)) {
         capture = {
           name: token.name,
           start: token.start,
           contentStart: token.end,
           depth: 1,
-          select: !selected.has(token.name),
+          ancestor: stack.at(-1),
         };
       } else {
-        stack.push({ name: token.name });
+        const opened: OpenTag = {
+          name: token.name,
+          parent: stack.at(-1),
+          balanced: false,
+          insideBalanced: false,
+        };
+        openedTags.push(opened);
+        stack.push(opened);
       }
       continue;
     }
     const opened = stack.at(-1);
     if (!opened || opened.name !== token.name) continue;
+    opened.balanced = true;
     stack.pop();
+  }
+
+  // 실제로 닫힌 비설정 래퍼에 감싸지 않은 설정 블록은 최상위로 취급한다.
+  // 부모 링크를 사용해 잘못된 긴 접두사와 후보가 많아도 2차 순회를 선형으로 유지한다.
+  for (const opened of openedTags) {
+    opened.insideBalanced = opened.balanced || (opened.parent?.insideBalanced ?? false);
+  }
+  for (const candidate of candidates) {
+    if (candidate.ancestor?.insideBalanced || selected.has(candidate.name)) continue;
+    selected.set(candidate.name, candidate);
   }
 
   const blocks = (meta?.requestBlocks ?? []).map((block) => {
@@ -218,8 +238,16 @@ interface ParsedBlock {
   body: string;
 }
 
+interface ParsedBlockCandidate extends ParsedBlock {
+  name: string;
+  ancestor: OpenTag | undefined;
+}
+
 interface OpenTag {
   name: string;
+  parent: OpenTag | undefined;
+  balanced: boolean;
+  insideBalanced: boolean;
 }
 
 interface OpenConfiguredTag {
@@ -227,7 +255,7 @@ interface OpenConfiguredTag {
   start: number;
   contentStart: number;
   depth: number;
-  select: boolean;
+  ancestor: OpenTag | undefined;
 }
 
 interface RequestTag {

--- a/packages/fleet-carriers/src/dispatch/taskforce.ts
+++ b/packages/fleet-carriers/src/dispatch/taskforce.ts
@@ -10,7 +10,7 @@ import type { AgentToolCtx, ExecResult, OneShotExecution, OneShotReady } from "@
 import type { CarrierJobStatus as StoredCarrierJobStatus } from "../jobs/types.js";
 import type { JobPermitAccepted } from "../jobs/lifecycle.js";
 import type { CarrierDispatchServices } from "../index.js";
-import type { CarrierJobStatus, TrackMeta, TrackStatus } from "./types.js";
+import type { CarrierJobStatus, CarrierRequest, TrackMeta, TrackStatus } from "./types.js";
 
 import {
   CLI_DISPLAY_NAMES,
@@ -32,7 +32,7 @@ import {
   toTrackFinalStatus,
   type CarrierRegistry,
 } from "./framework.js";
-import { buildCarrierSystemPrompt, validateRequiredRequestBlocks } from "./prompt.js";
+import { buildCarrierSystemPrompt, validateParsedRequiredRequestBlocks } from "./prompt.js";
 import type { CarrierToolSpecDeps } from "./prompt.js";
 import {
   getConfiguredTaskForceBackends,
@@ -92,6 +92,8 @@ export interface TaskForceLaunchOptions {
   registry: CarrierRegistry;
   carrierId: string;
   request: string;
+  /** Single observer parse shared by every backend begin event. */
+  parsedRequest: CarrierRequest;
   label: string;
   startedAt: number;
   toolName: `carrier_${string}`;
@@ -108,7 +110,7 @@ export interface TaskForceLaunchOptions {
 const taskForceStateStore = new Map<string, TaskForceState>();
 
 export async function launchTaskForceJob(options: TaskForceLaunchOptions): Promise<ReturnType<typeof launchResponseResult>> {
-  const { registry, carrierId, request, label, startedAt, toolName, ctx, cwd, deps, services, resumeContextId } = options;
+  const { registry, carrierId, request, parsedRequest, label, startedAt, toolName, ctx, cwd, deps, services, resumeContextId } = options;
   const requestKey = buildTaskForceRequestKey(carrierId, request);
 
   assertRegisteredCarrier(registry, carrierId);
@@ -117,9 +119,9 @@ export async function launchTaskForceJob(options: TaskForceLaunchOptions): Promi
   // 필수 request-block 검증은 carrier_dispatch와 동일한 hard-error 타이밍을 유지합니다.
   const carrierConfig = getRegisteredCarrierConfig(registry, carrierId);
   if (carrierConfig?.carrierMetadata) {
-    const blockValidation = validateRequiredRequestBlocks(
+    const blockValidation = validateParsedRequiredRequestBlocks(
       carrierConfig.carrierMetadata,
-      request,
+      parsedRequest,
       carrierId,
     );
     if (!blockValidation.ok) {
@@ -264,6 +266,7 @@ export async function launchTaskForceJob(options: TaskForceLaunchOptions): Promi
       originSessionId: ctx.sessionLabel,
       trackId: backend.trackId,
       startedAt: execStartedAt,
+      request: parsedRequest,
       requestPreview: request.trim().split(/\r?\n/, 1)[0],
     });
   }

--- a/packages/fleet-carriers/src/dispatch/tool-spec.ts
+++ b/packages/fleet-carriers/src/dispatch/tool-spec.ts
@@ -45,7 +45,8 @@ import {
 import {
   buildCarrierSystemPrompt,
   formatRequestBlocksGuide,
-  validateRequiredRequestBlocks,
+  parseCarrierRequest,
+  validateParsedRequiredRequestBlocks,
   type CarrierToolSpecDeps,
 } from "./prompt.js";
 import {
@@ -245,10 +246,12 @@ export function buildCarrierDispatchToolSpec(registry: CarrierRegistry, deps: Ca
       }
 
       const metadata = config.carrierMetadata;
+      // This observer snapshot is computed once; executeOneShot still receives request verbatim.
+      const parsedRequest = parseCarrierRequest(metadata, request);
 
       // 필수 request-block 검증
       if (metadata) {
-        const blockValidation = validateRequiredRequestBlocks(metadata, request, carrierId);
+        const blockValidation = validateParsedRequiredRequestBlocks(metadata, parsedRequest, carrierId);
         if (!blockValidation.ok) {
           return launchResponseResult({
             job_id: jobId,
@@ -263,6 +266,7 @@ export function buildCarrierDispatchToolSpec(registry: CarrierRegistry, deps: Ca
           registry,
           carrierId,
           request,
+          parsedRequest,
           label,
           startedAt: t0,
           toolName,
@@ -383,6 +387,7 @@ export function buildCarrierDispatchToolSpec(registry: CarrierRegistry, deps: Ca
         originSessionId: ctx.sessionLabel,
         trackId: carrierId,
         startedAt: Date.now(),
+        request: parsedRequest,
         requestPreview: request.trim().split(/\r?\n/, 1)[0],
       });
       completionStarted = true;

--- a/packages/fleet-carriers/src/dispatch/types.ts
+++ b/packages/fleet-carriers/src/dispatch/types.ts
@@ -30,6 +30,24 @@ export interface RequestBlock {
   required: boolean;
 }
 
+/** Lossless observer-only rendering of one configured request block. */
+export interface CarrierRequestBlock {
+  tag: string;
+  hint: string;
+  required: boolean;
+  present: boolean;
+  /** Exact, untrimmed text between the selected opening and closing tags. */
+  body: string;
+}
+
+/** Lossless observer-only rendering of a Carrier dispatch request. */
+export interface CarrierRequest {
+  /** Configured blocks in CarrierMetadata.requestBlocks order. */
+  blocks: CarrierRequestBlock[];
+  /** Every source character not belonging to a selected configured block. */
+  additional: string;
+}
+
 /**
  * Carrier 메타데이터 — 2-Tier 구조
  *
@@ -177,6 +195,9 @@ export type CarrierJobStreamEvent = { readonly originSessionId?: string } & (
     jobId: string;
     trackId: string;
     startedAt?: number;
+    /** Exact local parse of the original executor request for observers. */
+    request?: CarrierRequest;
+    /** @deprecated Compatibility preview; observers must use request instead. */
     requestPreview?: string;
   }
   | {

--- a/packages/fleet-carriers/tests/dispatch/framework.test.ts
+++ b/packages/fleet-carriers/tests/dispatch/framework.test.ts
@@ -699,6 +699,39 @@ describe("carrier_dispatch taskforce stream metadata", () => {
     ]);
   });
 
+  it("emits one identical lossless request structure for every Task Force backend", async () => {
+    const claudeModel = firstModel("claude");
+    const codexModel = firstModel("codex");
+    updateTaskForceModelSelection("ohio", "claude", { model: claudeModel, effort: firstEffort("claude", claudeModel) });
+    updateTaskForceModelSelection("ohio", "codex", { model: codexModel, effort: firstEffort("codex", codexModel) });
+    const registry = createCarrierRegistry();
+    registerCarrier(registry, createConfigWithBlocks("ohio", "Ohio"));
+    const events: CarrierJobStreamEvent[] = [];
+    const unregister = registerStreamHandler(registry, (event) => events.push(event));
+    const request = "outside <objective>  exact /tmp/fake & <script>literal</script>  </objective><task_refs>W1</task_refs><task_refs>duplicate</task_refs>";
+
+    await buildCarrierDispatchToolSpec(registry, testDeps).execute({ carrier_id: "ohio", label: "Request observer", request }, {
+      cwd: "/tmp",
+      toolCallId: "taskforce-request-observer",
+    });
+    unregister();
+
+    const begins = events.filter((event) => event.type === "track:begin");
+    expect(begins).toHaveLength(2);
+    for (const begin of begins) {
+      expect(begin.request).toEqual({
+        blocks: [
+          { tag: "task_refs", hint: "Assigned TaskRefs.", required: true, present: true, body: "W1" },
+          { tag: "objective", hint: "Optional goal restatement.", required: false, present: true, body: "  exact /tmp/fake & <script>literal</script>  " },
+        ],
+        additional: "outside <task_refs>duplicate</task_refs>",
+      });
+    }
+    expect(begins[0]!.request).toBe(begins[1]!.request);
+    expect(executeOneShot).toHaveBeenCalledTimes(2);
+    for (const [options] of vi.mocked(executeOneShot).mock.calls) expect(options.request).toBe(request);
+  });
+
   it("builds one fresh one-shot handle per Task Force backend with its own scope", async () => {
     const claudeModel = firstModel("claude");
     const codexModel = firstModel("codex");
@@ -811,6 +844,48 @@ describe("carrier_dispatch taskforce stream metadata", () => {
     expect(JSON.stringify(result.details)).toContain("not-a-real-model");
     expect(events.some((event) => event.type === "job:registered")).toBe(false);
     expect(executeOneShot).not.toHaveBeenCalled();
+  });
+});
+
+describe("carrier_dispatch request observer", () => {
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-dispatch-request-observer-"));
+    initStore(tempDir);
+    mockOneShotResolved();
+  });
+
+  afterEach(() => {
+    vi.mocked(executeOneShot).mockReset();
+    resetStoreForTests();
+    if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  });
+
+  it("emits the exact parsed request without changing the single executor request or call count", async () => {
+    const registry = createCarrierRegistry();
+    registerCarrier(registry, createConfigWithBlocks("ohio", "Ohio"));
+    const events: CarrierJobStreamEvent[] = [];
+    const unregister = registerStreamHandler(registry, (event) => events.push(event));
+    const request = "lead <task_refs source=\"host\"> W1 </task_refs> free <unknown>x</unknown>";
+
+    await buildCarrierDispatchToolSpec(registry, testDeps).execute({ carrier_id: "ohio", label: "Request observer", request }, {
+      cwd: "/tmp",
+      toolCallId: "single-request-observer",
+    });
+    unregister();
+
+    const begin = events.find((event) => event.type === "track:begin");
+    expect(begin?.type).toBe("track:begin");
+    if (begin?.type !== "track:begin") throw new Error("Single begin event was not emitted.");
+    expect(begin.request).toEqual({
+      blocks: [
+        { tag: "task_refs", hint: "Assigned TaskRefs.", required: true, present: true, body: " W1 " },
+        { tag: "objective", hint: "Optional goal restatement.", required: false, present: false, body: "" },
+      ],
+      additional: "lead  free <unknown>x</unknown>",
+    });
+    expect(executeOneShot).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(executeOneShot).mock.calls[0]![0].request).toBe(request);
   });
 });
 

--- a/packages/fleet-carriers/tests/dispatch/prompt.test.ts
+++ b/packages/fleet-carriers/tests/dispatch/prompt.test.ts
@@ -110,6 +110,20 @@ describe("parseCarrierRequest", () => {
     expect(parsed.additional).toBe("before <unknown><objective>nested</objective></unknown><objective>unterminated");
   });
 
+  it.each([
+    ["unmatched prose markup", "use <draft> wording <task_refs>W1</task_refs>", "use <draft> wording "],
+    ["generic-looking literals", "Foo<T> <task_refs>W1</task_refs>", "Foo<T> "],
+  ])("preserves %s before a later configured block", (_case, request, additional) => {
+    expect(validateRequiredRequestBlocks(META, request, "ohio")).toEqual({ ok: true });
+    expect(parseCarrierRequest(META, request)).toEqual({
+      blocks: [
+        { tag: "task_refs", hint: "Assigned TaskRefs.", required: true, present: true, body: "W1" },
+        { tag: "objective", hint: "Optional goal restatement.", required: false, present: false, body: "" },
+      ],
+      additional,
+    });
+  });
+
   it("places a blockless request entirely in Additional without transforming sensitive-shaped literals", () => {
     const request = "  /tmp/fake & token=sk-not-redacted <script>literal</script>\n";
 

--- a/packages/fleet-carriers/tests/dispatch/prompt.test.ts
+++ b/packages/fleet-carriers/tests/dispatch/prompt.test.ts
@@ -124,6 +124,20 @@ describe("parseCarrierRequest", () => {
     });
   });
 
+  it("parses and validates configured tags containing dots", () => {
+    const meta: CarrierMetadata = {
+      ...META,
+      requestBlocks: [{ tag: "foo.bar", required: true, hint: "Dot-containing tag." }],
+    };
+    const request = "before <foo.bar source=\"test\"> ok </foo.bar> after";
+
+    expect(validateRequiredRequestBlocks(meta, request, "custom")).toEqual({ ok: true });
+    expect(parseCarrierRequest(meta, request)).toEqual({
+      blocks: [{ tag: "foo.bar", required: true, hint: "Dot-containing tag.", present: true, body: " ok " }],
+      additional: "before  after",
+    });
+  });
+
   it("places a blockless request entirely in Additional without transforming sensitive-shaped literals", () => {
     const request = "  /tmp/fake & token=sk-not-redacted <script>literal</script>\n";
 

--- a/packages/fleet-carriers/tests/dispatch/prompt.test.ts
+++ b/packages/fleet-carriers/tests/dispatch/prompt.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import type { CarrierMetadata } from "../../src/index.js";
-import { KIROV_METADATA, formatRequestBlocksGuide, validateRequiredRequestBlocks } from "../../src/index.js";
+import type { CarrierMetadata, CarrierRequest } from "../../src/index.js";
+import { KIROV_METADATA, formatRequestBlocksGuide, parseCarrierRequest, validateParsedRequiredRequestBlocks, validateRequiredRequestBlocks } from "../../src/index.js";
 
 const META: CarrierMetadata = {
   category: "operations",
@@ -24,6 +24,18 @@ describe("validateRequiredRequestBlocks", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("validates a dispatch-owned parsed request without reparsing raw text", () => {
+    const parsed: CarrierRequest = {
+      blocks: [
+        { tag: "task_refs", hint: "Assigned TaskRefs.", required: true, present: true, body: "workspace:plan#W1-A-T1" },
+        { tag: "objective", hint: "Optional goal restatement.", required: false, present: false, body: "" },
+      ],
+      additional: "literal observer residual",
+    };
+
+    expect(validateParsedRequiredRequestBlocks(META, parsed, "ohio")).toEqual({ ok: true });
+  });
+
   it("echoes the full request-block contract in the rejection error", () => {
     const result = validateRequiredRequestBlocks(META, "do the thing", "ohio");
 
@@ -42,6 +54,13 @@ describe("validateRequiredRequestBlocks", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toContain("(empty body)");
+  });
+
+  it("accepts a required top-level block whose body contains unbalanced literal markup", () => {
+    const request = "<task_refs>Use <unknown> literally</task_refs>";
+
+    expect(validateRequiredRequestBlocks(META, request, "ohio")).toEqual({ ok: true });
+    expect(parseCarrierRequest(META, request).blocks[0]).toMatchObject({ present: true, body: "Use <unknown> literally" });
   });
 
   it("rejects a Kirov dispatch without its required plan_id", () => {
@@ -64,5 +83,48 @@ describe("formatRequestBlocksGuide", () => {
 
   it("returns no lines for blockless metadata", () => {
     expect(formatRequestBlocksGuide({ ...META, requestBlocks: [] })).toEqual([]);
+  });
+});
+
+describe("parseCarrierRequest", () => {
+  it("keeps configured metadata order and removes only first balanced top-level recognized blocks", () => {
+    const request = "prefix <objective source=\"host\">  exact <unknown>x</unknown> & <script>literal</script>  </objective> middle <task_refs>first</task_refs><task_refs>duplicate</task_refs> tail";
+
+    expect(parseCarrierRequest(META, request)).toEqual({
+      blocks: [
+        { tag: "task_refs", hint: "Assigned TaskRefs.", required: true, present: true, body: "first" },
+        { tag: "objective", hint: "Optional goal restatement.", required: false, present: true, body: "  exact <unknown>x</unknown> & <script>literal</script>  " },
+      ],
+      additional: "prefix  middle <task_refs>duplicate</task_refs> tail",
+    });
+  });
+
+  it("distinguishes missing and explicitly empty blocks while preserving malformed and nested markup", () => {
+    const request = "before <task_refs></task_refs><unknown><objective>nested</objective></unknown><objective>unterminated";
+    const parsed = parseCarrierRequest(META, request);
+
+    expect(parsed.blocks).toEqual([
+      { tag: "task_refs", hint: "Assigned TaskRefs.", required: true, present: true, body: "" },
+      { tag: "objective", hint: "Optional goal restatement.", required: false, present: false, body: "" },
+    ]);
+    expect(parsed.additional).toBe("before <unknown><objective>nested</objective></unknown><objective>unterminated");
+  });
+
+  it("places a blockless request entirely in Additional without transforming sensitive-shaped literals", () => {
+    const request = "  /tmp/fake & token=sk-not-redacted <script>literal</script>\n";
+
+    expect(parseCarrierRequest({ ...META, requestBlocks: [] }, request)).toEqual({ blocks: [], additional: request });
+  });
+
+  it("handles repeated unterminated tag prefixes without rescanning their suffixes", () => {
+    const request = "<unknown".repeat(2_000);
+
+    expect(parseCarrierRequest(META, request)).toEqual({
+      blocks: [
+        { tag: "task_refs", hint: "Assigned TaskRefs.", required: true, present: false, body: "" },
+        { tag: "objective", hint: "Optional goal restatement.", required: false, present: false, body: "" },
+      ],
+      additional: request,
+    });
   });
 });

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -1622,6 +1622,11 @@
   display: none;
 }
 
+.operations-canvas:has(.job-overlay) .canvas-minimap,
+.operations-canvas:has(.job-overlay) .canvas-minimap-fab {
+  display: none;
+}
+
 /* 순정 셸 패널 — Operation과 구별되도록 띠바에 아우로라(살아있는 것) 톤의 옅은 강조를 준다. */
 .canvas-operation--shell .canvas-operation-titlebar {
   background: color-mix(in oklch, var(--aurora) 9%, color-mix(in oklch, var(--ink-deep) 28%, transparent));
@@ -5029,6 +5034,40 @@
   box-shadow: var(--shadow-floating);
 }
 
+.job-overlay-tabs {
+  display: flex;
+  flex: none;
+  min-width: 0;
+  gap: var(--space-1);
+  padding: var(--space-4) calc(var(--space-6) + 42px) 0 var(--space-6);
+  border-bottom: 1px solid var(--surface-rim);
+}
+
+.job-overlay-tabs [role="tab"] {
+  min-width: 0;
+  padding: var(--space-2) var(--space-3);
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.job-overlay-tabs [role="tab"][aria-selected="true"] {
+  border-bottom-color: var(--brass-bright);
+  color: var(--brass-bright);
+}
+
+.job-overlay-tabs [role="tab"]:focus-visible,
+.job-overlay-close:focus-visible {
+  outline: 2px solid var(--aurora);
+  outline-offset: 2px;
+}
+
 .job-overlay-close {
   position: absolute;
   top: var(--space-3);
@@ -5075,6 +5114,63 @@
   flex-direction: column;
   gap: var(--space-5);
 }
+
+.job-overlay-panel[hidden] { display: none; }
+
+.request-details,
+.request-details-blocks {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.request-details-block,
+.request-details-unavailable {
+  min-width: 0;
+  margin: 0;
+  padding: var(--space-4);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-lg);
+  background: color-mix(in oklch, var(--surface-glass-strong) 76%, transparent);
+}
+
+.request-details-block-head {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.request-details-tag,
+.request-details-required,
+.request-details-presence {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+}
+
+.request-details-tag { color: var(--brass-bright); }
+.request-details-hint { min-width: 0; color: var(--ink-spectral); font-size: 12px; }
+.request-details-required { color: var(--ink-fog); }
+.request-details-presence { color: var(--aurora); }
+.request-details-presence.is-missing { color: var(--coral); }
+.request-details-block pre {
+  min-width: 0;
+  margin: var(--space-3) 0 0;
+  overflow-wrap: anywhere;
+  color: var(--ink-spectral);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.65;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.request-details-unavailable { color: var(--ink-fog); }
 
 .job-overlay-card > .follow-button {
   right: var(--space-6);

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -19,6 +19,7 @@ import { loadModelAuth, signInModel, signOutModel, useModelAuthStore } from "./m
 import type { ModelAuthProviderState } from "./model-auth-api.js";
 import { loadSystemPromptSettings, setSystemPromptSettingsField, useSystemPromptSettingsStore } from "./settings-store.js";
 import { isTerminalJobStatus } from "./reduce.js";
+import { RequestDetails } from "./request-details.js";
 import { applySessionUpdate, hydrateAgentClis, removeSession, selectSession, sessionJobs, useAgentState } from "./store.js";
 import type { AgentCliStatus, JobView, SessionInfo, TrackView } from "./types.js";
 
@@ -182,6 +183,15 @@ function usePinnedScrollLocal(resetKey: unknown, contentKey: unknown): PinnedScr
   return { containerRef, pinned, jumpToLatest };
 }
 
+function getTabbableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>("button, summary, [href], input, select, textarea, [tabindex]"))
+    .filter((element) => {
+      if (element.tabIndex < 0 || element.hidden || element.closest("[hidden]") || element.matches(":disabled")) return false;
+      const style = window.getComputedStyle(element);
+      return style.display !== "none" && style.visibility !== "hidden" && element.getClientRects().length > 0;
+    });
+}
+
 function useDockExpanded(): [boolean, (next: boolean) => void] {
   // 기본값 접힘(false). 펼치면 "true" 저장, 접으면 키 제거.
   const [expanded, setExpandedState] = React.useState(() => {
@@ -226,8 +236,10 @@ function AgentOperationView({ context }: { readonly context: OperationRenderCont
   const state = useAgentState();
   const session = state.sessions[context.operationId] ?? sessionFromOperation(context);
   const [modalOpen, setModalOpen] = React.useState(false);
+  const [detailTab, setDetailTab] = React.useState<"request" | "activity">("request");
   const [modalJobIds, setModalJobIds] = React.useState<readonly string[]>([]);
   const [retainedJobs, setRetainedJobs] = React.useState<readonly RetainedJob[]>([]);
+  const detailTabsId = React.useId();
   const closeButtonRef = React.useRef<HTMLButtonElement>(null);
   const overlayRef = React.useRef<HTMLDivElement>(null);
   const detailBtnRef = React.useRef<HTMLButtonElement | null>(null);
@@ -237,7 +249,9 @@ function AgentOperationView({ context }: { readonly context: OperationRenderCont
   const activeJobs = jobs.filter((job) => !isTerminalJobStatus(job.status));
   const dockJobs = mergeDockJobs(activeJobs, jobs, retainedJobs);
   const modalJobs = selectJobsByIds(jobs, modalJobIds);
-  const modalResetKey = String(modalOpen);
+  // Activity 패널은 Request-first 모달을 연 뒤에야 ref를 가진다. 탭 전환도
+  // scroll listener/바닥 reset의 mount lifecycle로 취급한다.
+  const modalResetKey = `${modalOpen}:${detailTab}`;
   const modalContentKey = modalJobs.map((job) => `${job.jobId}:${job.lastEventId}`).join(",");
   const modalScroll = usePinnedScrollLocal(modalResetKey, modalContentKey);
 
@@ -273,14 +287,34 @@ function AgentOperationView({ context }: { readonly context: OperationRenderCont
 
   const openModal = React.useCallback(() => {
     setModalJobIds(dockJobs.map((job) => job.jobId));
+    setDetailTab("request");
     setModalOpen(true);
   }, [dockJobs]);
 
-  // [M2] paint 전 동기 포커스 이동으로 순간 배경 포커스 잔류 방지
+  const selectDetailTab = React.useCallback((tab: "request" | "activity") => {
+    setDetailTab(tab);
+  }, []);
+
+  const handleDetailTabKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLButtonElement>) => {
+    const tabs = ["request", "activity"] as const;
+    const currentIndex = tabs.indexOf(detailTab);
+    let nextIndex: number | undefined;
+    if (event.key === "ArrowLeft") nextIndex = (currentIndex + tabs.length - 1) % tabs.length;
+    if (event.key === "ArrowRight") nextIndex = (currentIndex + 1) % tabs.length;
+    if (event.key === "Home") nextIndex = 0;
+    if (event.key === "End") nextIndex = tabs.length - 1;
+    if (nextIndex === undefined) return;
+    event.preventDefault();
+    const nextTab = tabs[nextIndex];
+    setDetailTab(nextTab);
+    document.getElementById(`${detailTabsId}-${nextTab}`)?.focus();
+  }, [detailTab, detailTabsId]);
+
+  // Details 클릭을 받는 canvas 핸들러가 모두 끝난 뒤 Close로 포커스를 회수한다.
   React.useLayoutEffect(() => {
-    if (modalOpen) {
-      closeButtonRef.current?.focus();
-    }
+    if (!modalOpen) return;
+    const frame = window.requestAnimationFrame(() => closeButtonRef.current?.focus());
+    return () => window.cancelAnimationFrame(frame);
   }, [modalOpen]);
 
   // Escape 키로 모달 닫기 + focus trap — capture phase로 전역 단축키보다 먼저 처리한다.
@@ -293,14 +327,9 @@ function AgentOperationView({ context }: { readonly context: OperationRenderCont
         return;
       }
       if (event.key === "Tab") {
-        // [L3] querySelector 대신 overlayRef로 방어성 강화
         const overlay = overlayRef.current;
         if (!overlay) return;
-        const focusable = Array.from(
-          overlay.querySelectorAll<HTMLElement>(
-            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-          )
-        ).filter((el) => !el.hasAttribute("disabled"));
+        const focusable = getTabbableElements(overlay);
         const first = focusable[0];
         const last = focusable[focusable.length - 1];
         if (event.shiftKey && document.activeElement === first) {
@@ -344,14 +373,17 @@ function AgentOperationView({ context }: { readonly context: OperationRenderCont
           <button type="button" className="job-overlay-scrim" aria-label="Close" tabIndex={-1} onClick={closeModal} />
           <div className="job-overlay-card">
             <button ref={closeButtonRef} type="button" className="job-overlay-close" aria-label="Close" onClick={closeModal}>×</button>
-            <div ref={modalScroll.containerRef} className="job-overlay-body" tabIndex={-1}>
-              {modalJobs.length === 0 ? (
-                <p className="job-overlay-empty">No active streams.</p>
-              ) : (
-                modalJobs.map((job) => <JobDetailContent key={job.jobId} job={job} />)
-              )}
+            <div className="job-overlay-tabs" role="tablist" aria-label="Carrier stream details">
+              <button id={`${detailTabsId}-request`} type="button" role="tab" aria-selected={detailTab === "request"} aria-controls={`${detailTabsId}-request-panel`} tabIndex={detailTab === "request" ? 0 : -1} onClick={() => selectDetailTab("request")} onKeyDown={handleDetailTabKeyDown}>Request</button>
+              <button id={`${detailTabsId}-activity`} type="button" role="tab" aria-selected={detailTab === "activity"} aria-controls={`${detailTabsId}-activity-panel`} tabIndex={detailTab === "activity" ? 0 : -1} onClick={() => selectDetailTab("activity")} onKeyDown={handleDetailTabKeyDown}>Activity</button>
             </div>
-            {!modalScroll.pinned ? (
+            <div id={`${detailTabsId}-request-panel`} className="job-overlay-body job-overlay-panel" role="tabpanel" aria-labelledby={`${detailTabsId}-request`} hidden={detailTab !== "request"} tabIndex={detailTab === "request" ? 0 : -1}>
+              {modalJobs.length === 0 ? <p className="job-overlay-empty">No active streams.</p> : modalJobs.map((job) => <RequestDetails key={job.jobId} job={job} />)}
+            </div>
+            <div id={`${detailTabsId}-activity-panel`} ref={detailTab === "activity" ? modalScroll.containerRef : undefined} className="job-overlay-body job-overlay-panel" role="tabpanel" aria-labelledby={`${detailTabsId}-activity`} hidden={detailTab !== "activity"} tabIndex={detailTab === "activity" ? 0 : -1}>
+              {modalJobs.length === 0 ? <p className="job-overlay-empty">No active streams.</p> : modalJobs.map((job) => <JobDetailContent key={job.jobId} job={job} />)}
+            </div>
+            {detailTab === "activity" && !modalScroll.pinned ? (
               <button type="button" className="follow-button" onClick={modalScroll.jumpToLatest}>
                 ↓ Follow
               </button>

--- a/runtime/fleet-plugins/terminal/client/agent/reduce.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/reduce.ts
@@ -1,4 +1,4 @@
-import type { JobView, ObservedEvent, SnapshotJob, TrackToolCall, TrackView } from "./types.js";
+import type { JobView, ObservedEvent, RequestBlockView, RequestView, SnapshotJob, TrackToolCall, TrackView } from "./types.js";
 
 interface TrackMetaPayload {
   readonly trackId?: string;
@@ -16,7 +16,7 @@ const ACTIVE_JOB_STATUS = "active";
 const TERMINAL_JOB_STATUSES = new Set(["done", "error", "aborted"]);
 
 export function reduceSnapshotJob(tenantId: string, snapshot: SnapshotJob): JobView {
-  let job = createEmptyJob(tenantId, snapshot.jobId, snapshot.updatedAt);
+  let job = adoptRequest(createEmptyJob(tenantId, snapshot.jobId, snapshot.updatedAt), snapshot.request);
   for (const event of snapshot.events) job = applyEvent(job, event);
   if (TERMINAL_JOB_STATUSES.has(snapshot.status) && !TERMINAL_JOB_STATUSES.has(job.status)) {
     job = { ...job, status: snapshot.status };
@@ -45,7 +45,7 @@ export function applyEvent(job: JobView, observed: ObservedEvent): JobView {
         error: readString(payload.error),
       };
     case "track:begin":
-      return mutateTrack(base, payload, observed.id, (track) => ({
+      return mutateTrack(adoptRequest(base, payload.request), payload, observed.id, (track) => ({
         ...track,
         startedAt: readNumber(payload.startedAt) ?? observed.at,
         requestPreview: readString(payload.requestPreview),
@@ -92,6 +92,32 @@ export function applyEvent(job: JobView, observed: ObservedEvent): JobView {
     default:
       return base;
   }
+}
+
+function adoptRequest(job: JobView, value: unknown): JobView {
+  if (job.request) return job;
+  const request = readRequest(value);
+  return request ? { ...job, request } : job;
+}
+
+function readRequest(value: unknown): RequestView | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const request = value as Record<string, unknown>;
+  if (!Array.isArray(request.blocks) || typeof request.additional !== "string") return undefined;
+  const blocks: RequestBlockView[] = [];
+  for (const value of request.blocks) {
+    if (typeof value !== "object" || value === null) return undefined;
+    const block = value as Record<string, unknown>;
+    if (
+      typeof block.tag !== "string"
+      || typeof block.hint !== "string"
+      || typeof block.required !== "boolean"
+      || typeof block.present !== "boolean"
+      || typeof block.body !== "string"
+    ) return undefined;
+    blocks.push({ tag: block.tag, hint: block.hint, required: block.required, present: block.present, body: block.body });
+  }
+  return { blocks, additional: request.additional };
 }
 
 export function createEmptyJob(tenantId: string, jobId: string, at: number): JobView {

--- a/runtime/fleet-plugins/terminal/client/agent/request-details.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/request-details.tsx
@@ -1,0 +1,44 @@
+import { React } from "@fleet-console/sdk/plugin/browser";
+
+import type { JobView, RequestBlockView } from "./types.js";
+
+export function RequestDetails({ job }: { readonly job: JobView }) {
+  const request = job.request;
+  return (
+    <section className="request-details" aria-label={`Request for ${job.label ?? job.jobId}`}>
+      <div className="job-overlay-head">
+        <span className="job-overlay-kicker">{job.status}</span>
+        <strong>{job.label ?? job.jobId}</strong>
+      </div>
+      {!request ? <p className="request-details-unavailable">Request unavailable for this legacy job.</p> : (
+        <div className="request-details-blocks">
+          {request.blocks.map((block, index) => <RequestBlock key={`${block.tag}-${index}`} block={block} />)}
+          {request.additional.trim().length > 0 ? (
+            <section className="request-details-block request-details-additional" aria-label="Additional request">
+              <header className="request-details-block-head">
+                <span className="request-details-tag">Additional</span>
+                <span className="request-details-presence">residual</span>
+              </header>
+              <pre>{request.additional}</pre>
+            </section>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function RequestBlock({ block }: { readonly block: RequestBlockView }) {
+  const presence = block.present ? (block.body.length === 0 ? "present · empty" : "present") : (block.required ? "missing · required" : "missing · optional");
+  return (
+    <section className="request-details-block" aria-label={`${block.tag} ${presence}`}>
+      <header className="request-details-block-head">
+        <span className="request-details-tag">{block.tag}</span>
+        <span className="request-details-hint">{block.hint}</span>
+        <span className="request-details-required">{block.required ? "required" : "optional"}</span>
+        <span className={`request-details-presence ${block.present ? "is-present" : "is-missing"}`}>{presence}</span>
+      </header>
+      {block.present ? <pre>{block.body}</pre> : null}
+    </section>
+  );
+}

--- a/runtime/fleet-plugins/terminal/client/agent/types.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/types.ts
@@ -74,6 +74,8 @@ export interface SnapshotJob {
   readonly jobId: string;
   readonly status: string;
   readonly updatedAt: number;
+  /** First valid request retained at the snapshot level when begin events expire. */
+  readonly request?: RequestView;
   readonly events: readonly ObservedEvent[];
 }
 
@@ -90,6 +92,19 @@ export interface TrackToolCall {
   readonly input?: unknown;
   readonly output?: unknown;
   readonly status?: string;
+}
+
+export interface RequestBlockView {
+  readonly tag: string;
+  readonly hint: string;
+  readonly required: boolean;
+  readonly present: boolean;
+  readonly body: string;
+}
+
+export interface RequestView {
+  readonly blocks: readonly RequestBlockView[];
+  readonly additional: string;
 }
 
 export interface TrackView {
@@ -127,6 +142,8 @@ export interface JobView {
   readonly finishedAt?: number;
   readonly summary?: string;
   readonly error?: string;
+  /** First valid observer-only request emitted by a job track. */
+  readonly request?: RequestView;
   readonly trackOrder: readonly string[];
   readonly tracks: Readonly<Record<string, TrackView>>;
   readonly lastEventId: number;

--- a/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
@@ -93,6 +93,7 @@ const JOB_EVENT_LIMIT = 200;
 const TENANT_FINALIZED_JOB_LIMIT = 100;
 const TENANT_JOB_LIMIT = 200;
 const EVENT_TEXT_RETENTION_LIMIT = 8_192;
+const REDACTED_REQUEST_PATH = "[redacted path]";
 
 export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreDeps = {}) {
   const now = deps.now ?? Date.now;
@@ -658,10 +659,117 @@ function normalizeRequest(value: unknown): AgentObservedRequest | undefined {
       hint: block.hint,
       required: block.required,
       present: block.present,
-      body: block.body,
+      body: redactRequestPaths(block.body),
     });
   }
-  return { blocks, additional: request.additional };
+  return { blocks, additional: redactRequestPaths(request.additional) };
+}
+
+function redactRequestPaths(value: string): string {
+  let copyStart = 0;
+  let cursor = 0;
+  const parts: string[] = [];
+  // URL과 경로로 판정한 구간은 끝까지 건너뛰어 입력과 결과 조립을 각각 한 번의 선형 순회로 제한한다.
+  while (cursor < value.length) {
+    const ordinaryUrlEnd = readOrdinaryUrlEnd(value, cursor);
+    if (ordinaryUrlEnd !== undefined) {
+      cursor = ordinaryUrlEnd;
+      continue;
+    }
+    const pathEnd = readFilesystemPathEnd(value, cursor);
+    if (pathEnd === undefined) {
+      cursor += 1;
+      continue;
+    }
+    parts.push(value.slice(copyStart, cursor), REDACTED_REQUEST_PATH);
+    copyStart = pathEnd;
+    cursor = pathEnd;
+  }
+  if (parts.length === 0) return value;
+  parts.push(value.slice(copyStart));
+  return parts.join("");
+}
+
+function readOrdinaryUrlEnd(value: string, start: number): number | undefined {
+  if (!isAsciiLetter(value[start]) || (start > 0 && isUriSchemeCharacter(value[start - 1]))) return undefined;
+  let cursor = start + 1;
+  while (cursor < value.length && isUriSchemeCharacter(value[cursor])) cursor += 1;
+  if (value[cursor] !== ":" || value[cursor + 1] !== "/" || value[cursor + 2] !== "/") return undefined;
+  if (value.slice(start, cursor).toLowerCase() === "file") return undefined;
+  cursor += 3;
+  while (cursor < value.length && !isPathTerminator(value[cursor])) cursor += 1;
+  return cursor;
+}
+
+function readFilesystemPathEnd(value: string, start: number): number | undefined {
+  const previous = start > 0 ? value[start - 1] : undefined;
+  const boundary = start === 0 || isPathBoundary(previous);
+  if (
+    boundary
+    && value.slice(start, start + 7).toLowerCase() === "file://"
+  ) return scanPathEnd(value, start, start + 7, previous);
+
+  if (
+    boundary
+    && isAsciiLetter(value[start])
+    && value[start + 1] === ":"
+    && (value[start + 2] === "/" || value[start + 2] === "\\")
+  ) return scanPathEnd(value, start, start + 3, previous);
+
+  if (
+    boundary
+    && value[start] === "\\"
+    && value[start + 1] === "\\"
+    && value[start + 2] !== undefined
+    && !isPathTerminator(value[start + 2])
+  ) return scanPathEnd(value, start, start + 2, previous);
+
+  if (
+    boundary
+    && value[start] === "/"
+    && value[start + 1] !== undefined
+    && value[start + 1] !== "/"
+    && !isPathTerminator(value[start + 1])
+  ) return scanPathEnd(value, start, start + 1, previous);
+
+  return undefined;
+}
+
+function scanPathEnd(value: string, start: number, minimumEnd: number, previous: string | undefined): number {
+  const quote = previous === "\"" || previous === "'" || previous === "`" ? previous : undefined;
+  let cursor = minimumEnd;
+  while (cursor < value.length) {
+    const character = value[cursor];
+    if (quote ? character === quote || character === "\n" || character === "\r" : isPathTerminator(character)) break;
+    cursor += 1;
+  }
+  if (quote) return cursor;
+  while (cursor > minimumEnd && ".,;:!?)]}".includes(value[cursor - 1]!)) cursor -= 1;
+  return Math.max(cursor, start + 1);
+}
+
+function isPathBoundary(value: string | undefined): boolean {
+  return value !== undefined
+    && value !== "<"
+    && value !== "/"
+    && value !== "\\"
+    && value !== "."
+    && value !== "~"
+    && value !== "_"
+    && !isAsciiLetter(value)
+    && !(value >= "0" && value <= "9");
+}
+
+function isPathTerminator(value: string | undefined): boolean {
+  return value === undefined || /\s/.test(value) || value === "<" || value === ">" || value === "\"" || value === "'" || value === "`" || value === "|";
+}
+
+function isAsciiLetter(value: string | undefined): boolean {
+  return value !== undefined && ((value >= "A" && value <= "Z") || (value >= "a" && value <= "z"));
+}
+
+function isUriSchemeCharacter(value: string | undefined): boolean {
+  return value !== undefined && (isAsciiLetter(value) || (value >= "0" && value <= "9") || value === "+" || value === "-" || value === ".");
 }
 
 function clampText(value: unknown): string | undefined {

--- a/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
@@ -727,7 +727,7 @@ function readFilesystemPathEnd(value: string, start: number): number | undefined
   if (boundary && value[start] === "~") {
     let separator = start + 1;
     while (separator < value.length && isHomeUserCharacter(value[separator])) separator += 1;
-    if (value[separator] === "/") return scanPathEnd(value, start, separator + 1, previous);
+    if (value[separator] === "/" || value[separator] === "\\") return scanPathEnd(value, start, separator + 1, previous);
   }
 
   if (

--- a/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
@@ -8,6 +8,7 @@ import type {
   AgentLabelSource,
   AgentObservedEvent,
   AgentObservedJob,
+  AgentObservedRequest,
   AgentObservedWorkspace,
   AgentObserverTruncation,
   AgentProviderSession,
@@ -473,10 +474,12 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
     const state = getTenantJobState(tenantId);
     const previous = state.jobs.get(event.jobId);
     const status = inferStatus(event.type, event.event, previous?.status);
+    const request = previous?.request ?? (event.type === "track:begin" ? normalizeRequest(event.event.request) : undefined);
     state.jobs.set(event.jobId, {
       jobId: event.jobId,
       status,
       updatedAt: event.at,
+      ...(request ? { request } : {}),
       events: [...(previous?.events ?? []), event].slice(-JOB_EVENT_LIMIT),
     });
     if (event.type === "job:finalized") {
@@ -571,13 +574,17 @@ function normalizeEventPayload(event: unknown): Record<string, unknown> {
         summary: safeString(obj.summary),
       };
     case "track:begin":
+      {
+        const request = normalizeRequest(obj.request);
       return {
         type: "track:begin",
         jobId: safeString(obj.jobId),
         trackId: safeString(obj.trackId),
         startedAt: safeOptionalNumber(obj.startedAt),
+        ...(request ? { request } : {}),
         requestPreview: safeOptionalString(obj.requestPreview),
       };
+      }
     case "track:status":
       return {
         type: "track:status",
@@ -628,6 +635,33 @@ function normalizeEventPayload(event: unknown): Record<string, unknown> {
     default:
       return { type: safeString(obj.type) || "event" };
   }
+}
+
+function normalizeRequest(value: unknown): AgentObservedRequest | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const request = value as Record<string, unknown>;
+  if (!Array.isArray(request.blocks) || typeof request.additional !== "string") return undefined;
+
+  const blocks: AgentObservedRequest["blocks"][number][] = [];
+  for (const value of request.blocks) {
+    if (typeof value !== "object" || value === null) return undefined;
+    const block = value as Record<string, unknown>;
+    if (
+      typeof block.tag !== "string"
+      || typeof block.hint !== "string"
+      || typeof block.required !== "boolean"
+      || typeof block.present !== "boolean"
+      || typeof block.body !== "string"
+    ) return undefined;
+    blocks.push({
+      tag: block.tag,
+      hint: block.hint,
+      required: block.required,
+      present: block.present,
+      body: block.body,
+    });
+  }
+  return { blocks, additional: request.additional };
 }
 
 function clampText(value: unknown): string | undefined {

--- a/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
@@ -583,7 +583,7 @@ function normalizeEventPayload(event: unknown): Record<string, unknown> {
         trackId: safeString(obj.trackId),
         startedAt: safeOptionalNumber(obj.startedAt),
         ...(request ? { request } : {}),
-        requestPreview: safeOptionalString(obj.requestPreview),
+        requestPreview: typeof obj.requestPreview === "string" ? redactRequestPaths(obj.requestPreview) : undefined,
       };
       }
     case "track:status":

--- a/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
@@ -740,6 +740,14 @@ function readFilesystemPathEnd(value: string, start: number): number | undefined
   }
 
   if (
+    explicitBoundary
+    && value[start] === "/"
+    && value[start + 1] === "/"
+    && value[start + 2] !== undefined
+    && !isPathTerminator(value[start + 2])
+  ) return scanPathEnd(value, start, start + 2, previous);
+
+  if (
     boundary
     && value[start] === "/"
     && value[start + 1] !== undefined

--- a/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
@@ -704,27 +704,36 @@ function readOrdinaryUrlEnd(value: string, start: number): number | undefined {
 function readFilesystemPathEnd(value: string, start: number): number | undefined {
   const previous = start > 0 ? value[start - 1] : undefined;
   const boundary = start === 0 || isPathBoundary(previous);
+  const explicitBoundary = boundary || previous === "<";
   if (
-    boundary
+    explicitBoundary
     && value.slice(start, start + 7).toLowerCase() === "file://"
   ) return scanPathEnd(value, start, start + 7, previous);
 
   if (
-    boundary
+    explicitBoundary
     && isAsciiLetter(value[start])
     && value[start + 1] === ":"
     && (value[start + 2] === "/" || value[start + 2] === "\\")
   ) return scanPathEnd(value, start, start + 3, previous);
 
   if (
-    boundary
+    explicitBoundary
     && value[start] === "\\"
     && value[start + 1] === "\\"
     && value[start + 2] !== undefined
     && !isPathTerminator(value[start + 2])
   ) return scanPathEnd(value, start, start + 2, previous);
 
-  if (boundary && value[start] === "~") {
+  if (
+    explicitBoundary
+    && value[start] === "\\"
+    && value[start + 1] !== undefined
+    && value[start + 1] !== "\\"
+    && !isPathTerminator(value[start + 1])
+  ) return scanPathEnd(value, start, start + 1, previous);
+
+  if (explicitBoundary && value[start] === "~") {
     let separator = start + 1;
     while (separator < value.length && isHomeUserCharacter(value[separator])) separator += 1;
     if (value[separator] === "/" || value[separator] === "\\") return scanPathEnd(value, start, separator + 1, previous);

--- a/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
@@ -724,6 +724,12 @@ function readFilesystemPathEnd(value: string, start: number): number | undefined
     && !isPathTerminator(value[start + 2])
   ) return scanPathEnd(value, start, start + 2, previous);
 
+  if (boundary && value[start] === "~") {
+    let separator = start + 1;
+    while (separator < value.length && isHomeUserCharacter(value[separator])) separator += 1;
+    if (value[separator] === "/") return scanPathEnd(value, start, separator + 1, previous);
+  }
+
   if (
     boundary
     && value[start] === "/"
@@ -766,6 +772,10 @@ function isPathTerminator(value: string | undefined): boolean {
 
 function isAsciiLetter(value: string | undefined): boolean {
   return value !== undefined && ((value >= "A" && value <= "Z") || (value >= "a" && value <= "z"));
+}
+
+function isHomeUserCharacter(value: string | undefined): boolean {
+  return value !== undefined && (isAsciiLetter(value) || (value >= "0" && value <= "9") || value === "_" || value === "." || value === "-");
 }
 
 function isUriSchemeCharacter(value: string | undefined): boolean {

--- a/runtime/fleet-plugins/terminal/server/agent-api/types.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/types.ts
@@ -82,7 +82,22 @@ export interface AgentObservedJob {
   readonly jobId: string;
   readonly status: string;
   readonly updatedAt: number;
+  /** First valid observer-only request, retained beyond the event window. */
+  readonly request?: AgentObservedRequest;
   readonly events: readonly AgentObservedEvent[];
+}
+
+export interface AgentObservedRequestBlock {
+  readonly tag: string;
+  readonly hint: string;
+  readonly required: boolean;
+  readonly present: boolean;
+  readonly body: string;
+}
+
+export interface AgentObservedRequest {
+  readonly blocks: readonly AgentObservedRequestBlock[];
+  readonly additional: string;
 }
 
 export interface AgentObserverTruncation {

--- a/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
@@ -132,11 +132,12 @@ describe("agent observability DTO boundary", () => {
       "POSIX=/Users/alice/project/file.ts",
       "drive=C:\\Users\\Alice\\project\\file.ts",
       "forward=D:/work/project/file.ts",
-      "keep=https://example.com/a/b?next=/tmp I/O HTTP/2 <unknown>literal</unknown>",
+      "home=~/repo/file.ts user=~alice/repo/file.ts",
+      "keep=~ ~alice https://example.com/~alice/repo I/O HTTP/2 <unknown>literal</unknown>",
     ].join("\n");
     const secondBody = "UNC=\\\\server\\share\\folder\\file.txt file=file:///Users/alice/project/file.ts XML=<root>/etc/fleet</root>";
-    const additional = "before /opt/fleet/bin after; wrapped=(/srv/app), label:/var/lib/fleet remote=https://example.org/x/y file://server/share/private.txt\n";
-    const requestPreview = "<objective>Inspect /Users/alice/app C:\\Users\\Alice\\app \\\\server\\share\\app file:///Users/alice/app; keep https://example.com/a/b I/O HTTP/2</objective>";
+    const additional = "before /opt/fleet/bin after; wrapped=(/srv/app), label:/var/lib/fleet homes=~/repo ~alice/repo remote=https://example.org/x/y file://server/share/private.txt\n";
+    const requestPreview = "<objective>Inspect /Users/alice/app C:\\Users\\Alice\\app \\\\server\\share\\app file:///Users/alice/app ~/repo/file.ts ~alice/repo/file.ts; keep ~ ~alice https://example.com/~alice/repo I/O HTTP/2</objective>";
     const request = {
       blocks: [
         { tag: "objective", hint: "Goal", required: true, present: true, body },
@@ -166,17 +167,18 @@ describe("agent observability DTO boundary", () => {
             "POSIX=[redacted path]",
             "drive=[redacted path]",
             "forward=[redacted path]",
-            "keep=https://example.com/a/b?next=/tmp I/O HTTP/2 <unknown>literal</unknown>",
+            "home=[redacted path] user=[redacted path]",
+            "keep=~ ~alice https://example.com/~alice/repo I/O HTTP/2 <unknown>literal</unknown>",
           ].join("\n"),
         },
         { tag: "context", hint: "Context", required: false, present: true, body: "UNC=[redacted path] file=[redacted path] XML=<root>[redacted path]</root>" },
       ],
-      additional: "before [redacted path] after; wrapped=([redacted path]), label:[redacted path] remote=https://example.org/x/y [redacted path]\n",
+      additional: "before [redacted path] after; wrapped=([redacted path]), label:[redacted path] homes=[redacted path] [redacted path] remote=https://example.org/x/y [redacted path]\n",
     };
     const events = store.listEvents("session-a");
     const jobs = store.listJobs("session-a");
     const serialized = JSON.stringify({ jobs, events, liveFrames });
-    const observedPreview = "<objective>Inspect [redacted path] [redacted path] [redacted path] [redacted path]; keep https://example.com/a/b I/O HTTP/2</objective>";
+    const observedPreview = "<objective>Inspect [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path]; keep ~ ~alice https://example.com/~alice/repo I/O HTTP/2</objective>";
     expect(producerInput).toEqual(originalProducerInput);
     expect(events[0]?.event.request).toEqual(observedRequest);
     expect(events[0]?.event.requestPreview).toBe(observedPreview);
@@ -194,6 +196,8 @@ describe("agent observability DTO boundary", () => {
       "/opt/fleet/bin",
       "/srv/app",
       "/var/lib/fleet",
+      "~/repo/file.ts",
+      "~alice/repo/file.ts",
       "file://server/share/private.txt",
     ]) expect(serialized).not.toContain(rawPath);
   });

--- a/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
@@ -136,6 +136,7 @@ describe("agent observability DTO boundary", () => {
     ].join("\n");
     const secondBody = "UNC=\\\\server\\share\\folder\\file.txt file=file:///Users/alice/project/file.ts XML=<root>/etc/fleet</root>";
     const additional = "before /opt/fleet/bin after; wrapped=(/srv/app), label:/var/lib/fleet remote=https://example.org/x/y file://server/share/private.txt\n";
+    const requestPreview = "<objective>Inspect /Users/alice/app C:\\Users\\Alice\\app \\\\server\\share\\app file:///Users/alice/app; keep https://example.com/a/b I/O HTTP/2</objective>";
     const request = {
       blocks: [
         { tag: "objective", hint: "Goal", required: true, present: true, body },
@@ -143,11 +144,16 @@ describe("agent observability DTO boundary", () => {
       ],
       additional,
     };
-    const producerInput = structuredClone(request);
+    const producerInput = {
+      type: "track:begin",
+      jobId: "job-a",
+      trackId: "track-a",
+      request,
+      requestPreview,
+    };
+    const originalProducerInput = structuredClone(producerInput);
 
-    store.appendTerminalRuntimeEvent("session-a", {
-      type: "track:begin", jobId: "job-a", trackId: "track-a", request,
-    }, 2_000);
+    store.appendTerminalRuntimeEvent("session-a", producerInput, 2_000);
 
     const observedRequest = {
       blocks: [
@@ -168,11 +174,16 @@ describe("agent observability DTO boundary", () => {
       additional: "before [redacted path] after; wrapped=([redacted path]), label:[redacted path] remote=https://example.org/x/y [redacted path]\n",
     };
     const events = store.listEvents("session-a");
-    const serialized = JSON.stringify({ jobs: store.listJobs("session-a"), events, liveFrames });
-    expect(request).toEqual(producerInput);
+    const jobs = store.listJobs("session-a");
+    const serialized = JSON.stringify({ jobs, events, liveFrames });
+    const observedPreview = "<objective>Inspect [redacted path] [redacted path] [redacted path] [redacted path]; keep https://example.com/a/b I/O HTTP/2</objective>";
+    expect(producerInput).toEqual(originalProducerInput);
     expect(events[0]?.event.request).toEqual(observedRequest);
-    expect(store.listJobs("session-a")[0]?.request).toEqual(observedRequest);
+    expect(events[0]?.event.requestPreview).toBe(observedPreview);
+    expect(jobs[0]?.request).toEqual(observedRequest);
+    expect(jobs[0]?.events[0]?.event.requestPreview).toBe(observedPreview);
     expect((liveFrames[0] as { event: Record<string, unknown> }).event.request).toEqual(observedRequest);
+    expect((liveFrames[0] as { event: Record<string, unknown> }).event.requestPreview).toBe(observedPreview);
     for (const rawPath of [
       "/Users/alice/project/file.ts",
       "C:\\Users\\Alice\\project\\file.ts",

--- a/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
@@ -134,12 +134,13 @@ describe("agent observability DTO boundary", () => {
       "forward=D:/work/project/file.ts",
       "home=~/repo/file.ts user=~alice/repo/file.ts",
       "winhome=~\\repo\\file.ts winuser=~alice\\repo\\file.ts",
+      "slashunc=//server/share/private.txt",
       "angle=<file:///Users/alice/angle> <C:\\Users\\Alice\\angle> <~/angle> <~alice\\angle> <\\\\server\\share\\angle> <\\Users\\Alice\\angle> rooted=\\Users\\Alice\\repo",
       "single=\\alpha keep=~ ~alice https://example.com/~alice/repo <https://example.com/a/b> I/O HTTP/2 <unknown>literal</unknown>",
     ].join("\n");
     const secondBody = "UNC=\\\\server\\share\\folder\\file.txt file=file:///Users/alice/project/file.ts XML=<root>/etc/fleet</root>";
-    const additional = "before /opt/fleet/bin after; wrapped=(/srv/app), label:/var/lib/fleet homes=~/repo ~alice/repo ~\\repo ~alice\\repo angles=<file:///opt/angle> <D:\\work\\angle> <~\\angle> rooted=\\Windows\\System32 single=\\alpha remote=https://example.org/x/y file://server/share/private.txt\n";
-    const requestPreview = "<objective>Inspect /Users/alice/app C:\\Users\\Alice\\app \\\\server\\share\\app file:///Users/alice/app ~/repo/file.ts ~alice/repo/file.ts ~\\repo\\file.ts ~alice\\repo\\file.ts angles=<file:///Users/alice/autolink> <C:\\Users\\Alice\\autolink> <~/autolink> <~alice\\autolink> <\\Users\\Alice\\autolink> single=\\alpha; keep ~ ~alice https://example.com/~alice/repo <https://example.com/a/b> I/O HTTP/2</objective>";
+    const additional = "before /opt/fleet/bin after; wrapped=(/srv/app), label:/var/lib/fleet homes=~/repo ~alice/repo ~\\repo ~alice\\repo angles=<file:///opt/angle> <D:\\work\\angle> <~\\angle> rooted=\\Windows\\System32 single=\\alpha slashunc=//server/share/additional.txt remote=https://example.org/x/y file://server/share/private.txt\n";
+    const requestPreview = "<objective>Inspect /Users/alice/app C:\\Users\\Alice\\app \\\\server\\share\\app //server/share/preview.txt file:///Users/alice/app ~/repo/file.ts ~alice/repo/file.ts ~\\repo\\file.ts ~alice\\repo\\file.ts angles=<file:///Users/alice/autolink> <C:\\Users\\Alice\\autolink> <~/autolink> <~alice\\autolink> <\\Users\\Alice\\autolink> single=\\alpha; keep ~ ~alice https://example.com/~alice/repo <https://example.com/a/b> I/O HTTP/2</objective>";
     const request = {
       blocks: [
         { tag: "objective", hint: "Goal", required: true, present: true, body },
@@ -171,18 +172,19 @@ describe("agent observability DTO boundary", () => {
             "forward=[redacted path]",
             "home=[redacted path] user=[redacted path]",
             "winhome=[redacted path] winuser=[redacted path]",
+            "slashunc=[redacted path]",
             "angle=<[redacted path]> <[redacted path]> <[redacted path]> <[redacted path]> <[redacted path]> <[redacted path]> rooted=[redacted path]",
             "single=[redacted path] keep=~ ~alice https://example.com/~alice/repo <https://example.com/a/b> I/O HTTP/2 <unknown>literal</unknown>",
           ].join("\n"),
         },
         { tag: "context", hint: "Context", required: false, present: true, body: "UNC=[redacted path] file=[redacted path] XML=<root>[redacted path]</root>" },
       ],
-      additional: "before [redacted path] after; wrapped=([redacted path]), label:[redacted path] homes=[redacted path] [redacted path] [redacted path] [redacted path] angles=<[redacted path]> <[redacted path]> <[redacted path]> rooted=[redacted path] single=[redacted path] remote=https://example.org/x/y [redacted path]\n",
+      additional: "before [redacted path] after; wrapped=([redacted path]), label:[redacted path] homes=[redacted path] [redacted path] [redacted path] [redacted path] angles=<[redacted path]> <[redacted path]> <[redacted path]> rooted=[redacted path] single=[redacted path] slashunc=[redacted path] remote=https://example.org/x/y [redacted path]\n",
     };
     const events = store.listEvents("session-a");
     const jobs = store.listJobs("session-a");
     const serialized = JSON.stringify({ jobs, events, liveFrames });
-    const observedPreview = "<objective>Inspect [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] angles=<[redacted path]> <[redacted path]> <[redacted path]> <[redacted path]> <[redacted path]> single=[redacted path]; keep ~ ~alice https://example.com/~alice/repo <https://example.com/a/b> I/O HTTP/2</objective>";
+    const observedPreview = "<objective>Inspect [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] angles=<[redacted path]> <[redacted path]> <[redacted path]> <[redacted path]> <[redacted path]> single=[redacted path]; keep ~ ~alice https://example.com/~alice/repo <https://example.com/a/b> I/O HTTP/2</objective>";
     expect(producerInput).toEqual(originalProducerInput);
     expect(events[0]?.event.request).toEqual(observedRequest);
     expect(events[0]?.event.requestPreview).toBe(observedPreview);
@@ -208,6 +210,9 @@ describe("agent observability DTO boundary", () => {
       "C:\\Users\\Alice\\angle",
       "\\Users\\Alice\\repo",
       "\\alpha",
+      "//server/share/private.txt",
+      "//server/share/additional.txt",
+      "//server/share/preview.txt",
       "file:///Users/alice/autolink",
       "file://server/share/private.txt",
     ]) expect(serialized).not.toContain(rawPath);

--- a/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
@@ -82,7 +82,7 @@ describe("agent observability DTO boundary", () => {
     expect(serialized).not.toContain("private prompt");
   });
 
-  it("preserves only the exact declared request fields in snapshots and subscribed frames", () => {
+  it("preserves only declared request fields while redacting paths in snapshots and subscribed frames", () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-agent-request-"));
     tempDirs.push(cwd);
     const store = createConsoleObservabilityStore({ workspaceHash: () => "theater-a" });
@@ -91,6 +91,7 @@ describe("agent observability DTO boundary", () => {
     const liveFrames: unknown[] = [];
     store.subscribeAll((event) => liveFrames.push(event));
     const body = " \n/path/with spaces\ntoken-like=sk_live_123\n<unknown>&<script>x</script>\n";
+    const observedBody = " \n[redacted path] spaces\ntoken-like=sk_live_123\n<unknown>&<script>x</script>\n";
     const additional = "outside <unknown> & <script>literal</script>";
     store.appendTerminalRuntimeEvent("session-a", {
       type: "track:begin",
@@ -109,7 +110,7 @@ describe("agent observability DTO boundary", () => {
     const events = store.listEvents("session-a");
     const serialized = JSON.stringify({ jobs: store.listJobs("session-a"), events, liveFrames });
     expect(events[0]?.event.request).toEqual({
-      blocks: [{ tag: "objective", hint: "Goal", required: true, present: true, body }],
+      blocks: [{ tag: "objective", hint: "Goal", required: true, present: true, body: observedBody }],
       additional,
     });
     expect((liveFrames[0] as { event: Record<string, unknown> }).event.request).toEqual(events[0]?.event.request);
@@ -117,6 +118,73 @@ describe("agent observability DTO boundary", () => {
     expect(serialized).not.toContain("mcp-token-secret");
     expect(serialized).not.toContain("private prompt");
     expect(serialized).not.toContain("\"ticket\"");
+  });
+
+  it("redacts filesystem paths without changing ordinary slash text or producer input", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-agent-request-paths-"));
+    tempDirs.push(cwd);
+    const store = createConsoleObservabilityStore({ workspaceHash: () => "theater-a" });
+    store.createPendingTerminalSession({ sessionId: "session-a", cwd, createdAt: 1_000 });
+    store.registerTerminalRuntimeSession({ sessionId: "session-a", label: "Claude", mcpToolCount: 0 });
+    const liveFrames: unknown[] = [];
+    store.subscribeAll((event) => liveFrames.push(event));
+    const body = [
+      "POSIX=/Users/alice/project/file.ts",
+      "drive=C:\\Users\\Alice\\project\\file.ts",
+      "forward=D:/work/project/file.ts",
+      "keep=https://example.com/a/b?next=/tmp I/O HTTP/2 <unknown>literal</unknown>",
+    ].join("\n");
+    const secondBody = "UNC=\\\\server\\share\\folder\\file.txt file=file:///Users/alice/project/file.ts XML=<root>/etc/fleet</root>";
+    const additional = "before /opt/fleet/bin after; wrapped=(/srv/app), label:/var/lib/fleet remote=https://example.org/x/y file://server/share/private.txt\n";
+    const request = {
+      blocks: [
+        { tag: "objective", hint: "Goal", required: true, present: true, body },
+        { tag: "context", hint: "Context", required: false, present: true, body: secondBody },
+      ],
+      additional,
+    };
+    const producerInput = structuredClone(request);
+
+    store.appendTerminalRuntimeEvent("session-a", {
+      type: "track:begin", jobId: "job-a", trackId: "track-a", request,
+    }, 2_000);
+
+    const observedRequest = {
+      blocks: [
+        {
+          tag: "objective",
+          hint: "Goal",
+          required: true,
+          present: true,
+          body: [
+            "POSIX=[redacted path]",
+            "drive=[redacted path]",
+            "forward=[redacted path]",
+            "keep=https://example.com/a/b?next=/tmp I/O HTTP/2 <unknown>literal</unknown>",
+          ].join("\n"),
+        },
+        { tag: "context", hint: "Context", required: false, present: true, body: "UNC=[redacted path] file=[redacted path] XML=<root>[redacted path]</root>" },
+      ],
+      additional: "before [redacted path] after; wrapped=([redacted path]), label:[redacted path] remote=https://example.org/x/y [redacted path]\n",
+    };
+    const events = store.listEvents("session-a");
+    const serialized = JSON.stringify({ jobs: store.listJobs("session-a"), events, liveFrames });
+    expect(request).toEqual(producerInput);
+    expect(events[0]?.event.request).toEqual(observedRequest);
+    expect(store.listJobs("session-a")[0]?.request).toEqual(observedRequest);
+    expect((liveFrames[0] as { event: Record<string, unknown> }).event.request).toEqual(observedRequest);
+    for (const rawPath of [
+      "/Users/alice/project/file.ts",
+      "C:\\Users\\Alice\\project\\file.ts",
+      "D:/work/project/file.ts",
+      "\\\\server\\share\\folder\\file.txt",
+      "file:///Users/alice/project/file.ts",
+      "/etc/fleet",
+      "/opt/fleet/bin",
+      "/srv/app",
+      "/var/lib/fleet",
+      "file://server/share/private.txt",
+    ]) expect(serialized).not.toContain(rawPath);
   });
 
   it("narrows malformed request DTOs without manufacturing request content", () => {
@@ -133,7 +201,7 @@ describe("agent observability DTO boundary", () => {
     expect(event?.event).not.toHaveProperty("request");
   });
 
-  it("retains the first exact request in a job snapshot after its begin event expires", () => {
+  it("retains the first normalized request in a job snapshot after its begin event expires", () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-agent-request-retention-"));
     tempDirs.push(cwd);
     const store = createConsoleObservabilityStore({ workspaceHash: () => "theater-a" });
@@ -153,10 +221,14 @@ describe("agent observability DTO boundary", () => {
     }
 
     const snapshot = store.listJobs("session-a")[0];
+    const observedRequest = {
+      ...request,
+      blocks: [{ ...request.blocks[0], body: "  [redacted path]\nsk-live\n<script>literal</script>  " }],
+    };
     expect(snapshot?.events).toHaveLength(200);
     expect(snapshot?.events.some((event) => event.type === "track:begin")).toBe(false);
-    expect(snapshot?.request).toEqual(request);
-    expect(reduceSnapshotJob("session-a", snapshot!).request).toEqual(request);
+    expect(snapshot?.request).toEqual(observedRequest);
+    expect(reduceSnapshotJob("session-a", snapshot!).request).toEqual(observedRequest);
   });
 
   it("assigns globally monotonic observed ids across terminal sessions", () => {

--- a/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
@@ -133,11 +133,12 @@ describe("agent observability DTO boundary", () => {
       "drive=C:\\Users\\Alice\\project\\file.ts",
       "forward=D:/work/project/file.ts",
       "home=~/repo/file.ts user=~alice/repo/file.ts",
+      "winhome=~\\repo\\file.ts winuser=~alice\\repo\\file.ts",
       "keep=~ ~alice https://example.com/~alice/repo I/O HTTP/2 <unknown>literal</unknown>",
     ].join("\n");
     const secondBody = "UNC=\\\\server\\share\\folder\\file.txt file=file:///Users/alice/project/file.ts XML=<root>/etc/fleet</root>";
-    const additional = "before /opt/fleet/bin after; wrapped=(/srv/app), label:/var/lib/fleet homes=~/repo ~alice/repo remote=https://example.org/x/y file://server/share/private.txt\n";
-    const requestPreview = "<objective>Inspect /Users/alice/app C:\\Users\\Alice\\app \\\\server\\share\\app file:///Users/alice/app ~/repo/file.ts ~alice/repo/file.ts; keep ~ ~alice https://example.com/~alice/repo I/O HTTP/2</objective>";
+    const additional = "before /opt/fleet/bin after; wrapped=(/srv/app), label:/var/lib/fleet homes=~/repo ~alice/repo ~\\repo ~alice\\repo remote=https://example.org/x/y file://server/share/private.txt\n";
+    const requestPreview = "<objective>Inspect /Users/alice/app C:\\Users\\Alice\\app \\\\server\\share\\app file:///Users/alice/app ~/repo/file.ts ~alice/repo/file.ts ~\\repo\\file.ts ~alice\\repo\\file.ts; keep ~ ~alice https://example.com/~alice/repo I/O HTTP/2</objective>";
     const request = {
       blocks: [
         { tag: "objective", hint: "Goal", required: true, present: true, body },
@@ -168,17 +169,18 @@ describe("agent observability DTO boundary", () => {
             "drive=[redacted path]",
             "forward=[redacted path]",
             "home=[redacted path] user=[redacted path]",
+            "winhome=[redacted path] winuser=[redacted path]",
             "keep=~ ~alice https://example.com/~alice/repo I/O HTTP/2 <unknown>literal</unknown>",
           ].join("\n"),
         },
         { tag: "context", hint: "Context", required: false, present: true, body: "UNC=[redacted path] file=[redacted path] XML=<root>[redacted path]</root>" },
       ],
-      additional: "before [redacted path] after; wrapped=([redacted path]), label:[redacted path] homes=[redacted path] [redacted path] remote=https://example.org/x/y [redacted path]\n",
+      additional: "before [redacted path] after; wrapped=([redacted path]), label:[redacted path] homes=[redacted path] [redacted path] [redacted path] [redacted path] remote=https://example.org/x/y [redacted path]\n",
     };
     const events = store.listEvents("session-a");
     const jobs = store.listJobs("session-a");
     const serialized = JSON.stringify({ jobs, events, liveFrames });
-    const observedPreview = "<objective>Inspect [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path]; keep ~ ~alice https://example.com/~alice/repo I/O HTTP/2</objective>";
+    const observedPreview = "<objective>Inspect [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path]; keep ~ ~alice https://example.com/~alice/repo I/O HTTP/2</objective>";
     expect(producerInput).toEqual(originalProducerInput);
     expect(events[0]?.event.request).toEqual(observedRequest);
     expect(events[0]?.event.requestPreview).toBe(observedPreview);
@@ -198,6 +200,8 @@ describe("agent observability DTO boundary", () => {
       "/var/lib/fleet",
       "~/repo/file.ts",
       "~alice/repo/file.ts",
+      "~\\repo\\file.ts",
+      "~alice\\repo\\file.ts",
       "file://server/share/private.txt",
     ]) expect(serialized).not.toContain(rawPath);
   });

--- a/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
@@ -134,11 +134,12 @@ describe("agent observability DTO boundary", () => {
       "forward=D:/work/project/file.ts",
       "home=~/repo/file.ts user=~alice/repo/file.ts",
       "winhome=~\\repo\\file.ts winuser=~alice\\repo\\file.ts",
-      "keep=~ ~alice https://example.com/~alice/repo I/O HTTP/2 <unknown>literal</unknown>",
+      "angle=<file:///Users/alice/angle> <C:\\Users\\Alice\\angle> <~/angle> <~alice\\angle> <\\\\server\\share\\angle> <\\Users\\Alice\\angle> rooted=\\Users\\Alice\\repo",
+      "single=\\alpha keep=~ ~alice https://example.com/~alice/repo <https://example.com/a/b> I/O HTTP/2 <unknown>literal</unknown>",
     ].join("\n");
     const secondBody = "UNC=\\\\server\\share\\folder\\file.txt file=file:///Users/alice/project/file.ts XML=<root>/etc/fleet</root>";
-    const additional = "before /opt/fleet/bin after; wrapped=(/srv/app), label:/var/lib/fleet homes=~/repo ~alice/repo ~\\repo ~alice\\repo remote=https://example.org/x/y file://server/share/private.txt\n";
-    const requestPreview = "<objective>Inspect /Users/alice/app C:\\Users\\Alice\\app \\\\server\\share\\app file:///Users/alice/app ~/repo/file.ts ~alice/repo/file.ts ~\\repo\\file.ts ~alice\\repo\\file.ts; keep ~ ~alice https://example.com/~alice/repo I/O HTTP/2</objective>";
+    const additional = "before /opt/fleet/bin after; wrapped=(/srv/app), label:/var/lib/fleet homes=~/repo ~alice/repo ~\\repo ~alice\\repo angles=<file:///opt/angle> <D:\\work\\angle> <~\\angle> rooted=\\Windows\\System32 single=\\alpha remote=https://example.org/x/y file://server/share/private.txt\n";
+    const requestPreview = "<objective>Inspect /Users/alice/app C:\\Users\\Alice\\app \\\\server\\share\\app file:///Users/alice/app ~/repo/file.ts ~alice/repo/file.ts ~\\repo\\file.ts ~alice\\repo\\file.ts angles=<file:///Users/alice/autolink> <C:\\Users\\Alice\\autolink> <~/autolink> <~alice\\autolink> <\\Users\\Alice\\autolink> single=\\alpha; keep ~ ~alice https://example.com/~alice/repo <https://example.com/a/b> I/O HTTP/2</objective>";
     const request = {
       blocks: [
         { tag: "objective", hint: "Goal", required: true, present: true, body },
@@ -170,17 +171,18 @@ describe("agent observability DTO boundary", () => {
             "forward=[redacted path]",
             "home=[redacted path] user=[redacted path]",
             "winhome=[redacted path] winuser=[redacted path]",
-            "keep=~ ~alice https://example.com/~alice/repo I/O HTTP/2 <unknown>literal</unknown>",
+            "angle=<[redacted path]> <[redacted path]> <[redacted path]> <[redacted path]> <[redacted path]> <[redacted path]> rooted=[redacted path]",
+            "single=[redacted path] keep=~ ~alice https://example.com/~alice/repo <https://example.com/a/b> I/O HTTP/2 <unknown>literal</unknown>",
           ].join("\n"),
         },
         { tag: "context", hint: "Context", required: false, present: true, body: "UNC=[redacted path] file=[redacted path] XML=<root>[redacted path]</root>" },
       ],
-      additional: "before [redacted path] after; wrapped=([redacted path]), label:[redacted path] homes=[redacted path] [redacted path] [redacted path] [redacted path] remote=https://example.org/x/y [redacted path]\n",
+      additional: "before [redacted path] after; wrapped=([redacted path]), label:[redacted path] homes=[redacted path] [redacted path] [redacted path] [redacted path] angles=<[redacted path]> <[redacted path]> <[redacted path]> rooted=[redacted path] single=[redacted path] remote=https://example.org/x/y [redacted path]\n",
     };
     const events = store.listEvents("session-a");
     const jobs = store.listJobs("session-a");
     const serialized = JSON.stringify({ jobs, events, liveFrames });
-    const observedPreview = "<objective>Inspect [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path]; keep ~ ~alice https://example.com/~alice/repo I/O HTTP/2</objective>";
+    const observedPreview = "<objective>Inspect [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] [redacted path] angles=<[redacted path]> <[redacted path]> <[redacted path]> <[redacted path]> <[redacted path]> single=[redacted path]; keep ~ ~alice https://example.com/~alice/repo <https://example.com/a/b> I/O HTTP/2</objective>";
     expect(producerInput).toEqual(originalProducerInput);
     expect(events[0]?.event.request).toEqual(observedRequest);
     expect(events[0]?.event.requestPreview).toBe(observedPreview);
@@ -202,6 +204,11 @@ describe("agent observability DTO boundary", () => {
       "~alice/repo/file.ts",
       "~\\repo\\file.ts",
       "~alice\\repo\\file.ts",
+      "/Users/alice/angle",
+      "C:\\Users\\Alice\\angle",
+      "\\Users\\Alice\\repo",
+      "\\alpha",
+      "file:///Users/alice/autolink",
       "file://server/share/private.txt",
     ]) expect(serialized).not.toContain(rawPath);
   });

--- a/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import { reduceSnapshotJob } from "../client/agent/reduce.js";
 import { createConsoleObservabilityStore } from "../server/agent-api/observability-store.js";
 
 const tempDirs: string[] = [];
@@ -79,6 +80,83 @@ describe("agent observability DTO boundary", () => {
     expect(serialized).not.toContain("terminal-ticket-secret");
     expect(serialized).not.toContain("mcp-token-secret");
     expect(serialized).not.toContain("private prompt");
+  });
+
+  it("preserves only the exact declared request fields in snapshots and subscribed frames", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-agent-request-"));
+    tempDirs.push(cwd);
+    const store = createConsoleObservabilityStore({ workspaceHash: () => "theater-a" });
+    store.createPendingTerminalSession({ sessionId: "session-a", cwd, createdAt: 1_000 });
+    store.registerTerminalRuntimeSession({ sessionId: "session-a", label: "Claude", mcpToolCount: 0 });
+    const liveFrames: unknown[] = [];
+    store.subscribeAll((event) => liveFrames.push(event));
+    const body = " \n/path/with spaces\ntoken-like=sk_live_123\n<unknown>&<script>x</script>\n";
+    const additional = "outside <unknown> & <script>literal</script>";
+    store.appendTerminalRuntimeEvent("session-a", {
+      type: "track:begin",
+      jobId: "job-a",
+      trackId: "track-a",
+      request: {
+        blocks: [{ tag: "objective", hint: "Goal", required: true, present: true, body, providerSession: "ignored" }],
+        additional,
+        ticket: "ignored",
+      },
+      providerSession: "provider-session-secret",
+      token: "mcp-token-secret",
+      prompt: "private prompt",
+    }, 2_000);
+
+    const events = store.listEvents("session-a");
+    const serialized = JSON.stringify({ jobs: store.listJobs("session-a"), events, liveFrames });
+    expect(events[0]?.event.request).toEqual({
+      blocks: [{ tag: "objective", hint: "Goal", required: true, present: true, body }],
+      additional,
+    });
+    expect((liveFrames[0] as { event: Record<string, unknown> }).event.request).toEqual(events[0]?.event.request);
+    expect(serialized).not.toContain("provider-session-secret");
+    expect(serialized).not.toContain("mcp-token-secret");
+    expect(serialized).not.toContain("private prompt");
+    expect(serialized).not.toContain("\"ticket\"");
+  });
+
+  it("narrows malformed request DTOs without manufacturing request content", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-agent-request-invalid-"));
+    tempDirs.push(cwd);
+    const store = createConsoleObservabilityStore({ workspaceHash: () => "theater-a" });
+    store.createPendingTerminalSession({ sessionId: "session-a", cwd, createdAt: 1_000 });
+    store.registerTerminalRuntimeSession({ sessionId: "session-a", label: "Claude", mcpToolCount: 0 });
+    store.appendTerminalRuntimeEvent("session-a", {
+      type: "track:begin", jobId: "job-a", trackId: "track-a", request: { blocks: "not-an-array", additional: 4 },
+    });
+
+    const event = store.listEvents("session-a")[0];
+    expect(event?.event).not.toHaveProperty("request");
+  });
+
+  it("retains the first exact request in a job snapshot after its begin event expires", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-agent-request-retention-"));
+    tempDirs.push(cwd);
+    const store = createConsoleObservabilityStore({ workspaceHash: () => "theater-a" });
+    store.createPendingTerminalSession({ sessionId: "session-a", cwd, createdAt: 1_000 });
+    store.registerTerminalRuntimeSession({ sessionId: "session-a", label: "Claude", mcpToolCount: 0 });
+    const request = {
+      blocks: [{ tag: "objective", hint: "Goal", required: true, present: true, body: "  /tmp/fake\nsk-live\n<script>literal</script>  " }],
+      additional: "<unknown>&outside",
+    };
+    const malformed = store.appendTerminalRuntimeEvent("session-a", {
+      type: "track:begin", jobId: "job-a", trackId: "track-a", request: { blocks: [null], additional: "must not poison" },
+    }, 1_999);
+    expect(malformed?.event).not.toHaveProperty("request");
+    store.appendTerminalRuntimeEvent("session-a", { type: "track:begin", jobId: "job-a", trackId: "track-a", request }, 2_000);
+    for (let index = 0; index < 200; index++) {
+      store.appendTerminalRuntimeEvent("session-a", { type: "track:text", jobId: "job-a", trackId: "track-a", text: String(index) }, 2_001 + index);
+    }
+
+    const snapshot = store.listJobs("session-a")[0];
+    expect(snapshot?.events).toHaveLength(200);
+    expect(snapshot?.events.some((event) => event.type === "track:begin")).toBe(false);
+    expect(snapshot?.request).toEqual(request);
+    expect(reduceSnapshotJob("session-a", snapshot!).request).toEqual(request);
   });
 
   it("assigns globally monotonic observed ids across terminal sessions", () => {

--- a/runtime/fleet-plugins/terminal/tests/reduce.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/reduce.test.ts
@@ -56,6 +56,51 @@ describe("agent reducer streaming invariants", () => {
     expect(snapshotJob).toEqual(liveJob);
   });
 
+  it("preserves the first valid job request across live and replay Task Force track begins", () => {
+    const request = {
+      blocks: [{ tag: "objective", hint: "Goal", required: true, present: true, body: "  /tmp/a\nsk-live\n<script>literal</script>  " }],
+      additional: "<unknown>&outside",
+    };
+    const events = [
+      makeEvent(1, "track:begin", { trackId: "carrier-a", request }),
+      makeEvent(2, "track:begin", { trackId: "carrier-b", request: { blocks: [], additional: "must not replace" } }),
+      makeEvent(3, "track:text", { trackId: "carrier-a", text: "Activity remains a delta" }),
+    ] as const;
+    const replay = reduceSnapshotJob("tenant-1", { jobId: "job-1", status: "active", updatedAt: 1_003, events });
+    const live = events.reduce((job, event) => applyEvent(job, event), createEmptyJob("tenant-1", "job-1", 1_000));
+
+    expect(replay).toEqual(live);
+    expect(live.request).toEqual(request);
+    expect(live.tracks["carrier-a"]?.text).toBe("Activity remains a delta");
+    expect(live.tracks["carrier-a"]?.sentTextLength).toBe("Activity remains a delta".length);
+  });
+
+  it("seeds a valid snapshot request before replay and rejects malformed legacy snapshot data", () => {
+    const request = {
+      blocks: [{ tag: "objective", hint: "Goal", required: true, present: true, body: " exact <unknown> & <script>literal</script> " }],
+      additional: "outside",
+    };
+    const snapshot = { jobId: "job-1", status: "active", updatedAt: 1_002, request, events: [
+      makeEvent(2, "track:text", { trackId: "carrier-b", text: "Activity remains a delta" }),
+    ] } as const;
+    expect(reduceSnapshotJob("tenant-1", snapshot).request).toEqual(request);
+
+    const malformed = { ...snapshot, request: { blocks: [null], additional: "outside" } } as unknown as typeof snapshot;
+    expect(reduceSnapshotJob("tenant-1", malformed).request).toBeUndefined();
+  });
+
+  it("ignores malformed or legacy request payloads without adding request token usage", () => {
+    let job = createEmptyJob("tenant-1", "job-1", 1_000);
+    job = applyEvent(job, makeEvent(1, "track:begin", { trackId: "t1" }));
+    job = applyEvent(job, makeEvent(2, "track:begin", { trackId: "t2", request: { blocks: [null], additional: "bad" } }));
+    job = applyEvent(job, makeEvent(3, "track:begin", { trackId: "t3", request: { blocks: [], additional: "valid second" } }));
+
+    expect(job.request).toEqual({ blocks: [], additional: "valid second" });
+    expect(job.tracks.t1?.sentTextLength).toBe(0);
+    expect(job.tracks.t2?.sentTextLength).toBe(0);
+    expect(job.tracks.t1?.sentThoughtLength).toBe(0);
+  });
+
   it("tracks sentTextLength separately from retained text", () => {
     let job = createEmptyJob("tenant-1", "job-1", 1_000);
     job = applyEvent(job, makeEvent(1, "track:text", { trackId: "t1", text: "tail", textLength: 12_000 }));

--- a/runtime/fleet-plugins/terminal/tests/request-details.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/request-details.test.ts
@@ -1,0 +1,54 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
+
+import { RequestDetails } from "../client/agent/request-details.js";
+import type { JobView } from "../client/agent/types.js";
+
+function makeJob(): JobView {
+  return {
+    jobId: "job-1", tenantId: "tenant-1", label: "Task Force", status: "active", updatedAt: 1, trackOrder: ["a", "b"], tracks: {}, lastEventId: 1,
+    request: {
+      blocks: [
+        { tag: "objective", hint: "Goal", required: true, present: true, body: "  /tmp/fake & <script>literal</script>  " },
+        { tag: "constraints", hint: "Boundaries", required: false, present: false, body: "" },
+        { tag: "output", hint: "Deliverable", required: false, present: true, body: "" },
+      ],
+      additional: "<unknown>keep & every character</unknown>",
+    },
+    recentEvents: [],
+  };
+}
+
+describe("RequestDetails", () => {
+  it("renders the contract order, presence states, and Additional exactly once per job", () => {
+    const html = renderToStaticMarkup(createElement(RequestDetails, { job: makeJob() }));
+    expect(html.indexOf("objective")).toBeLessThan(html.indexOf("constraints"));
+    expect(html.indexOf("constraints")).toBeLessThan(html.indexOf("output"));
+    expect(html).toContain("missing · optional");
+    expect(html).toContain("present · empty");
+    expect(html).toContain("Additional");
+    expect(html.match(/class="request-details"/g)).toHaveLength(1);
+  });
+
+  it("uses React text escaping for script-shaped, ampersand, and unknown-tag request text", () => {
+    const html = renderToStaticMarkup(createElement(RequestDetails, { job: makeJob() }));
+    expect(html).toContain("&lt;script&gt;literal&lt;/script&gt;");
+    expect(html).toContain("&amp;");
+    expect(html).toContain("&lt;unknown&gt;keep &amp; every character&lt;/unknown&gt;");
+    expect(html).not.toContain("<script>");
+  });
+
+  it("omits Additional when the residual contains only whitespace", () => {
+    const job = makeJob();
+    const request = { ...job.request!, additional: "\n  \t" };
+    const html = renderToStaticMarkup(createElement(RequestDetails, { job: { ...job, request } }));
+    expect(html).not.toContain("Additional");
+    expect(html).not.toContain("residual");
+  });
+
+  it("labels legacy jobs as unavailable", () => {
+    const job = { ...makeJob(), request: undefined };
+    expect(renderToStaticMarkup(createElement(RequestDetails, { job }))).toContain("Request unavailable for this legacy job.");
+  });
+});


### PR DESCRIPTION
## Summary

- Parse the original Carrier dispatch request locally and retain it across observer snapshots without changing executor input or model usage.
- Add Request and Activity tabs to Stream Deck Details, rendering configured Request Blocks in contract order and preserving raw text.
- Keep legacy fallbacks, accessible focus behavior, Activity follow state, responsive layout, and omit whitespace-only Additional sections.

## Test Plan

- [x] Carrier parser/framework tests: 43 passed
- [x] Terminal observability/reducer/request-details tests: 23 passed
- [x] Carrier and Terminal typecheck/build
- [x] Console design contract tests: 13 passed
- [x] Console production build: 2072 modules
- [x] Core boundary and git diff checks
- [x] Headed browser verification for exact rendering, escaping, tabs, focus, follow, stacking, and responsive overflow

## Changelog

- [x] Added .changelog.d/pr-303.md.
- [x] Grouped entries by product and Added section with adjacent English and Korean summaries.
- [x] Validated the complete fragment set with the changelog compiler.

## Notes for Reviewers

- The external carrier_dispatch input schema is unchanged.
- Raw request disclosure in the built-in Console observer is intentional for this feature; no request brief or additional model call is introduced.