### PR TITLE
fix(fleet-admiral): restore Claude auto-name hook

### DIFF
--- a/.changelog.d/pr-305.md
+++ b/.changelog.d/pr-305.md
@@ -1,0 +1,4 @@
+### fleet-core
+#### Fixed
+- [fleet-admiral] Auto-name Claude Console panels from the first prompt before provider summaries refresh them.
+  ko: Claude Console 패널 이름을 첫 프롬프트로 자동 지정한 뒤 provider summary로 갱신합니다.

--- a/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
@@ -26,9 +26,8 @@ export function renderAssetPluginRoot(
 }
 
 function claudeHooks(options: CreateAgentCliPluginOptions): unknown {
-  // UserPromptSubmit: 세션 캡처 + 턴 시작 신호를 같은 이벤트에 건다(배열 순서대로 실행).
-  // 자동 작명은 Codex 고정 프로필 전용이며 Claude plugin hooks에는 렌더하지 않는다.
-  const userPromptSubmitExecs = [options.captureSessionHookExec, options.turnStartHookExec]
+  // UserPromptSubmit: 세션 캡처 → 턴 시작 → 자동 작명 순서로 같은 이벤트에 렌더한다.
+  const userPromptSubmitExecs = [options.captureSessionHookExec, options.turnStartHookExec, options.autoNameHookExec]
     .filter((exec): exec is FleetHookExec => exec !== undefined);
   // Stop: 턴 종료 신호.
   const stopExecs = [options.turnEndHookExec]

--- a/packages/fleet-admiral/src/agent-cli/plugin/types.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/types.ts
@@ -21,7 +21,7 @@ export interface CreateAgentCliPluginOptions {
   // 입력 대기(AskUserQuestion의 PreToolUse · permission/idle/elicitation Notification) 신호를 호스트로
   // 알리는 hook. AskUserQuestion은 Notification 훅을 발화하지 않으므로 두 이벤트 경로로 건다. Claude 전용.
   readonly inputWaitingHookExec?: FleetHookExec;
-  // 작전명 자동 작명(UserPromptSubmit)을 위해 prompt를 호스트로 전달하는 hook. Codex 고정 프로필에만 와이어링된다.
+  // 작전명 자동 작명(UserPromptSubmit)을 위해 prompt를 호스트로 전달하는 hook. Claude/Codex 양쪽에 와이어링된다.
   readonly autoNameHookExec?: FleetHookExec;
   readonly onCleanup?: (cleanup: () => void) => void;
   readonly rootDir?: string;

--- a/packages/fleet-admiral/tests/agent-cli-plugin-marketplace.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-plugin-marketplace.test.ts
@@ -129,7 +129,7 @@ describe("agent CLI plugin marketplace rendering", () => {
     ]);
   });
 
-  it("wires capture and turn-start, but not auto-name, onto Claude UserPromptSubmit in order", async () => {
+  it("wires capture, turn-start, and auto-name onto Claude UserPromptSubmit in order", async () => {
     const root = mkdtempSync(path.join(os.tmpdir(), "fleet-admiral-plugin-uphooks-"));
     tempDirs.push(root);
     const dataDir = path.join(root, "data");
@@ -151,7 +151,7 @@ describe("agent CLI plugin marketplace rendering", () => {
       readonly hooks: Record<string, ReadonlyArray<{ readonly hooks: ReadonlyArray<{ readonly args: readonly string[] }> }>>;
     };
     const userPromptSubmit = hooksJson.hooks.UserPromptSubmit?.[0]?.hooks.map((hook) => hook.args[2]);
-    expect(userPromptSubmit).toEqual(["capture-session", "turn-start"]);
+    expect(userPromptSubmit).toEqual(["capture-session", "turn-start", "auto-name"]);
     expect(hooksJson.hooks.Stop?.[0]?.hooks.map((hook) => hook.args[2])).toEqual(["turn-end"]);
   });
 


### PR DESCRIPTION
## Summary
- Restore the Claude `UserPromptSubmit` auto-name hook so Console panel names update from the first prompt, matching Codex.
- Preserve the existing turn-end provider summary refresh and user rename precedence.

## Test Plan
- [x] Fleet Admiral marketplace hook test (`10 passed`)
- [x] Fleet Admiral TypeScript typecheck
- [x] `git diff --check`

## Changelog
- [x] Added `.changelog.d/pr-305.md`.
- [x] Added adjacent English and Korean summaries under the `fleet-core` / `Fixed` grouping.
- [x] Validated all fragments with `node scripts/compile-changelog-fragments.mjs --check`.
