### PR TITLE
feat(console): unify operation identity and quiet the chrome palette

### DIFF
--- a/.changelog.d/pr-307.md
+++ b/.changelog.d/pr-307.md
@@ -1,0 +1,11 @@
+### fleet-console
+#### Changed
+- [fleet-console] Move operation identity color from the panel border to a left spine and nameplate mark, reserving borders and glows for status signals, with an 8-tone palette that retunes per theme, a named tone picker shared across the accent popover and context menus, identity dots on the minimap, and automatic mapping of previously saved accent and group color keys.
+  ko: Operation 정체성 색을 패널 보더에서 좌측 스파인과 명판 마크로 옮기고 보더·글로우는 상태 신호 전용으로 되돌립니다. 테마별로 재조율되는 8톤 팔레트, 악센트 팝오버·컨텍스트 메뉴가 공유하는 이름 있는 톤 피커, 미니맵 정체성 도트를 도입하고 기존에 저장된 악센트·그룹 색 키는 자동 매핑합니다.
+- [fleet-console] Quiet the chrome color language: environment and info badges drop signal colors for neutral ink, the stream follow button becomes a brass outline action, the minimap loses its always-on brass glow and radar rings, carrier captain colors join the theme-tuned identity palette with distinct tones per captain, and buttons across settings, What's New, and menus converge on one control grammar with tokenized heights and radii.
+  ko: 크롬 색 언어를 침묵시킵니다: 환경·정보 뱃지가 신호색 대신 중립 잉크를 쓰고, 스트림 팔로우 버튼은 brass 윤곽 액션으로 바뀌며, 미니맵의 상시 brass 발광·레이더 링이 사라지고, 캐리어 captain 색은 캡틴별로 구분되는 테마 연동 정체성 팔레트로 편입되며, 설정·What's New·메뉴의 버튼이 토큰화된 높이·radius의 단일 컨트롤 문법으로 수렴합니다.
+
+### fleet-plugin
+#### Changed
+- [fleet-console] Conform repository, skills, and terminal carrier surfaces to the neutral badge and unified control grammar: branch and worktree badges drop signal colors, captain dots lose their glow, and plugin buttons adopt the shared mono uppercase control style.
+  ko: repository·skills·terminal carrier 표면을 중립 뱃지·통일 컨트롤 문법에 정합합니다: 브랜치·워크트리 뱃지가 신호색을 내려놓고, captain 도트의 글로우가 제거되며, 플러그인 버튼이 공용 mono 대문자 컨트롤 스타일을 따릅니다.

--- a/runtime/fleet-console/core/client/src/canvas/accent-popover.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/accent-popover.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useLayoutEffect, useState, type CSSProperties } from "react";
 import { createPortal } from "react-dom";
 
-import { OPERATION_ACCENTS } from "./operation-accent.js";
+import { OPERATION_ACCENTS, normalizeAccentKey } from "./operation-accent.js";
 
 interface AccentPopoverProps {
   // 트리거(인디케이터) 인디케이터의 뷰포트 기준 rect. 열린 시점에 캡처해 넘긴다.
@@ -12,8 +12,53 @@ interface AccentPopoverProps {
 }
 
 const POPOVER_GAP = 8;
-// 팝업 카드의 추정 높이(None 행 + 2행 그리드). 트리거 아래로 띄울지 위로 뒤집을지 판단에만 쓴다.
-const POPOVER_ESTIMATED_HEIGHT = 120;
+// 팝업 카드의 추정 높이(None 행 + 8톤 리스트). 트리거 아래로 띄울지 위로 뒤집을지 판단에만 쓴다.
+const POPOVER_ESTIMATED_HEIGHT = 268;
+
+// 정체성 톤 선택 리스트 — 팝오버·칩 메뉴·그룹 메뉴 3곳이 공유하는 단일 피커 표면.
+// 스와치 그리드 대신 "플래그 + 이름" 행으로, 색이 아니라 이름으로도 고를 수 있게 한다.
+export function AccentToneList({
+  accentKey,
+  includeNone,
+  onSelect,
+}: {
+  readonly accentKey: string | null;
+  readonly includeNone: boolean;
+  readonly onSelect: (accentKey: string | null) => void;
+}) {
+  const activeKey = normalizeAccentKey(accentKey);
+  return (
+    <>
+      {includeNone ? (
+        <button
+          type="button"
+          className="accent-tone-row accent-tone-row--clear"
+          role="menuitem"
+          aria-label="No accent"
+          aria-pressed={activeKey === null}
+          onClick={() => onSelect(null)}
+        >
+          <span className="accent-tone-flag accent-tone-flag--none" aria-hidden="true" />
+          <span className="accent-tone-name">None</span>
+        </button>
+      ) : null}
+      {OPERATION_ACCENTS.map((accent) => (
+        <button
+          key={accent.key}
+          type="button"
+          className="accent-tone-row"
+          role="menuitem"
+          aria-label={accent.label}
+          aria-pressed={activeKey === accent.key}
+          onClick={() => onSelect(accent.key)}
+        >
+          <span className="accent-tone-flag" style={{ background: accent.color }} aria-hidden="true" />
+          <span className="accent-tone-name">{accent.label}</span>
+        </button>
+      ))}
+    </>
+  );
+}
 
 export function AccentPopover({ anchor, accentKey, onSelect, onClose }: AccentPopoverProps) {
   const [style, setStyle] = useState<CSSProperties | undefined>(undefined);
@@ -55,30 +100,7 @@ export function AccentPopover({ anchor, accentKey, onSelect, onClose }: AccentPo
     <div className="accent-popover-overlay" role="presentation" onPointerDown={onClose}>
       {style ? (
         <div className="accent-popover-card" role="menu" aria-label="Accent" style={style} onPointerDown={(event) => event.stopPropagation()}>
-          <button
-            type="button"
-            className="accent-popover-swatch accent-popover-swatch--clear"
-            role="menuitem"
-            aria-label="No accent"
-            aria-pressed={accentKey === null}
-            onClick={() => choose(null)}
-          >
-            <span />
-            None
-          </button>
-          {OPERATION_ACCENTS.map((accent) => (
-            <button
-              key={accent.key}
-              type="button"
-              className="accent-popover-swatch"
-              role="menuitem"
-              aria-label={accent.label}
-              aria-pressed={accentKey === accent.key}
-              onClick={() => choose(accent.key)}
-            >
-              <span style={{ background: accent.color }} />
-            </button>
-          ))}
+          <AccentToneList accentKey={accentKey} includeNone onSelect={choose} />
         </div>
       ) : null}
     </div>,

--- a/runtime/fleet-console/core/client/src/canvas/canvas-minimap.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-minimap.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import { useEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react";
 
 import { useFormationView, type CanvasViewport, type OperationGeometry } from "./canvas-store.js";
 import type { CanvasPoint } from "./coordinates.js";
@@ -11,6 +11,8 @@ interface PluginOperationEntry {
 interface CanvasMinimapProps {
   readonly operations: Record<string, OperationGeometry>;
   readonly pluginOperations: Record<string, PluginOperationEntry>;
+  // Operation id → 정체성 색(resolveAccentColor 결과). 블립 좌상단 정체성 도트로만 칠한다.
+  readonly accents?: Record<string, string>;
   readonly viewport: CanvasViewport;
   readonly canvasSize: { readonly width: number; readonly height: number };
   // 미니맵의 한 지점을 캔버스 중앙으로 가져오도록 뷰포트를 옮긴다(world 좌표).
@@ -32,7 +34,7 @@ const MINIMAP_PADDING = 12;
 const WORLD_MARGIN = 220;
 const RADAR_COLLAPSED_STORAGE_KEY = "fleet-console.map.radarCollapsed";
 
-export function CanvasMinimap({ operations, pluginOperations, viewport, canvasSize, onJump }: CanvasMinimapProps) {
+export function CanvasMinimap({ operations, pluginOperations, accents, viewport, canvasSize, onJump }: CanvasMinimapProps) {
   const innerRef = useRef<HTMLDivElement | null>(null);
   const draggingRef = useRef(false);
   const collapsedBeforeFormationRef = useRef<boolean | null>(null);
@@ -173,7 +175,13 @@ export function CanvasMinimap({ operations, pluginOperations, viewport, canvasSi
           <div
             key={r.id}
             className="canvas-minimap-operation"
-            style={{ left: miniLeft(r.x), top: miniTop(r.y), width: Math.max(2, r.width * scale), height: Math.max(2, r.height * scale) }}
+            style={{
+              left: miniLeft(r.x),
+              top: miniTop(r.y),
+              width: Math.max(2, r.width * scale),
+              height: Math.max(2, r.height * scale),
+              ...(accents?.[r.id] ? { "--user-accent": accents[r.id] } : {}),
+            } as CSSProperties}
           />
         ))}
         <div

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -12,6 +12,7 @@ import type { ConsoleState, OperationNode } from "../types.js";
 import { calculateGridSlots, animateViewportTo, claimTopZIndex, clearCompanionOperationId, clearMaximizedOperationId, focusOperation, getSnapshot as getCanvasSnapshot, minimizeOperation, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, setViewport, useCanvasState, useCompanionOperationId, useFormationLayout, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "./canvas-store.js";
 import { CanvasContextMenu } from "./canvas-context-menu.js";
 import { CanvasMinimap } from "./canvas-minimap.js";
+import { resolveAccentColor } from "./operation-accent.js";
 import { CanvasGrid } from "./canvas-grid.js";
 import { OperationFrame } from "./operation-frame.js";
 import { RubberBand } from "./rubber-band.js";
@@ -309,6 +310,11 @@ export function OperationsCanvas({
           theaterId: operation.theaterId,
           geometry: canvas.operations[operation.id] ?? operation.geometry ?? ensurePluginGeometry(operation),
         }]))}
+        accents={Object.fromEntries(theaterOperations.flatMap((operation) => {
+          const accentKey = canvas.operationAccent[operation.id] ?? operationAccentFromNode(operation);
+          const color = accentKey ? resolveAccentColor(accentKey) : null;
+          return color ? [[operation.id, color] as const] : [];
+        }))}
         viewport={canvas.viewport}
         canvasSize={canvasSize}
         onJump={(center) => setViewport({

--- a/runtime/fleet-console/core/client/src/canvas/group-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/group-context-menu.tsx
@@ -2,7 +2,8 @@ import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties } from
 import { createPortal } from "react-dom";
 
 import type { OperationGroup, OperationNode } from "../types.js";
-import { OPERATION_ACCENTS, resolveAccentColor } from "./operation-accent.js";
+import { AccentToneList } from "./accent-popover.js";
+import { resolveAccentColor } from "./operation-accent.js";
 
 export interface GroupContextMenuChipActions {
   readonly onSetAccent: (key: string | null) => void;
@@ -35,7 +36,7 @@ type GroupContextMenuProps =
     };
 
 const POPOVER_GAP = 8;
-const POPOVER_ESTIMATED_HEIGHT = 260;
+const POPOVER_ESTIMATED_HEIGHT = 320;
 
 export function GroupContextMenu(props: GroupContextMenuProps) {
   const { anchor, onClose } = props;
@@ -171,32 +172,11 @@ function ChipMenuContent({
       )}
       <div className="group-context-menu-divider" aria-hidden="true" />
       <div className="group-context-menu-section-label">Accent</div>
-      <button
-        type="button"
-        className="accent-popover-swatch accent-popover-swatch--clear"
-        role="menuitem"
-        aria-label="No accent"
-        aria-pressed={accentKey === null}
-        onClick={() => { actions.onSetAccent(null); onClose(); }}
-      >
-        <span />
-        None
-      </button>
-      <div className="group-context-menu-swatches">
-        {OPERATION_ACCENTS.map((accent) => (
-          <button
-            key={accent.key}
-            type="button"
-            className="accent-popover-swatch"
-            role="menuitem"
-            aria-label={accent.label}
-            aria-pressed={accentKey === accent.key}
-            onClick={() => { actions.onSetAccent(accent.key); onClose(); }}
-          >
-            <span style={{ background: accent.color }} />
-          </button>
-        ))}
-      </div>
+      <AccentToneList
+        accentKey={accentKey}
+        includeNone
+        onSelect={(key) => { actions.onSetAccent(key); onClose(); }}
+      />
     </>
   );
 }
@@ -223,23 +203,16 @@ function GroupHeaderMenuContent({
 
   return (
     <>
-      {/* 그룹 색은 durable 스키마상 16색 중 하나로 필수다(무색 그룹 미지원). None 항목은 제공하지 않는다. */}
+      {/* 그룹 색은 durable 스키마상 팔레트 키 중 하나로 필수다(무색 그룹 미지원). None 항목은 제공하지 않는다. */}
       <div className="group-context-menu-section-label">Color</div>
-      <div className="group-context-menu-swatches">
-        {OPERATION_ACCENTS.map((accent) => (
-          <button
-            key={accent.key}
-            type="button"
-            className="accent-popover-swatch"
-            role="menuitem"
-            aria-label={accent.label}
-            aria-pressed={group.color === accent.key}
-            onClick={() => { actions.onSetColor(accent.key); onClose(); }}
-          >
-            <span style={{ background: accent.color }} />
-          </button>
-        ))}
-      </div>
+      <AccentToneList
+        accentKey={group.color}
+        includeNone={false}
+        onSelect={(key) => {
+          if (key) actions.onSetColor(key);
+          onClose();
+        }}
+      />
       <div className="group-context-menu-divider" aria-hidden="true" />
       <div className="group-context-menu-section-label">Rename</div>
       <input

--- a/runtime/fleet-console/core/client/src/canvas/operation-accent.ts
+++ b/runtime/fleet-console/core/client/src/canvas/operation-accent.ts
@@ -6,29 +6,46 @@ export interface AccentOption {
   readonly color: string;
 }
 
-// 16색 큐레이션 팔레트 — hue 휠 전체(빨강/노랑/초록 포함). accent는 fill 채널 단독 소유이고 시스템 신호는
-// border/링/beacon/glow가 맡으므로, 신호색과 hue가 겹쳐도 채널 분리로 상태와 혼동되지 않는다(낮은 chroma 틴트).
+// 8톤 정체성 팔레트 — theme.css의 --id-* 토큰을 참조해 테마별 채도 봉투를 그대로 추종한다.
+// 정체성은 스파인·명판 마크·틱·도트 채널만 소유하고, 보더/링/beacon/glow는 상태 신호 전용이다.
 export const OPERATION_ACCENTS: readonly AccentOption[] = [
-  { key: "red", label: "Red", color: "oklch(70% 0.12 25)" },
-  { key: "orange", label: "Orange", color: "oklch(73% 0.12 50)" },
-  { key: "amber", label: "Amber", color: "oklch(78% 0.11 70)" },
-  { key: "yellow", label: "Yellow", color: "oklch(84% 0.11 95)" },
-  { key: "lime", label: "Lime", color: "oklch(81% 0.12 120)" },
-  { key: "green", label: "Green", color: "oklch(74% 0.12 145)" },
-  { key: "emerald", label: "Emerald", color: "oklch(73% 0.10 165)" },
-  { key: "teal", label: "Teal", color: "oklch(74% 0.09 185)" },
-  { key: "cyan", label: "Cyan", color: "oklch(76% 0.09 205)" },
-  { key: "sky", label: "Sky", color: "oklch(74% 0.10 230)" },
-  { key: "blue", label: "Blue", color: "oklch(70% 0.11 255)" },
-  { key: "indigo", label: "Indigo", color: "oklch(68% 0.11 278)" },
-  { key: "violet", label: "Violet", color: "oklch(70% 0.11 300)" },
-  { key: "purple", label: "Purple", color: "oklch(70% 0.12 320)" },
-  { key: "magenta", label: "Magenta", color: "oklch(71% 0.12 340)" },
-  { key: "rose", label: "Rose", color: "oklch(72% 0.11 5)" },
+  { key: "crimson", label: "Crimson", color: "var(--id-crimson)" },
+  { key: "amber", label: "Amber", color: "var(--id-amber)" },
+  { key: "moss", label: "Moss", color: "var(--id-moss)" },
+  { key: "teal", label: "Teal", color: "var(--id-teal)" },
+  { key: "cerulean", label: "Cerulean", color: "var(--id-cerulean)" },
+  { key: "indigo", label: "Indigo", color: "var(--id-indigo)" },
+  { key: "plum", label: "Plum", color: "var(--id-plum)" },
+  { key: "rose", label: "Rose", color: "var(--id-rose)" },
 ] as const;
 
+// 구 16키 → 8톤 매핑(hue 최근접). durable 스키마는 불변 — 저장된 구키는 읽기 시점에 변환되고,
+// 새 선택은 8톤 키로 저장된다. 미지 키는 null(accent 없음)로 폴백한다.
+const LEGACY_ACCENT_KEYS: Readonly<Record<string, string>> = {
+  red: "crimson",
+  orange: "amber",
+  yellow: "amber",
+  lime: "moss",
+  green: "moss",
+  emerald: "teal",
+  cyan: "teal",
+  sky: "cerulean",
+  blue: "cerulean",
+  violet: "plum",
+  purple: "plum",
+  magenta: "rose",
+};
+
+export function normalizeAccentKey(accentKey: string | null | undefined): string | null {
+  if (typeof accentKey !== "string" || accentKey.length === 0) return null;
+  if (OPERATION_ACCENTS.some((accent) => accent.key === accentKey)) return accentKey;
+  return LEGACY_ACCENT_KEYS[accentKey] ?? null;
+}
+
 export function resolveAccentColor(accentKey: string): string | null {
-  return OPERATION_ACCENTS.find((accent) => accent.key === accentKey)?.color ?? null;
+  const normalized = normalizeAccentKey(accentKey);
+  if (!normalized) return null;
+  return OPERATION_ACCENTS.find((accent) => accent.key === normalized)?.color ?? null;
 }
 
 export function operationAccentFromNode(operation: OperationNode): string | null {

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -72,7 +72,8 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
       restoreIdentityFocusRef.current = true;
     },
   });
-  // 사용자 accent는 패널 전체 외곽선을 소유한다. status 비콘 채널은 별도로 유지한다.
+  // 사용자 accent(정체성)는 좌측 스파인과 명판 마크만 소유한다.
+  // 패널 보더/글로우/비콘은 상태 채널(brass 포커스·aurora 대기·coral 위험) 전용이다.
   const accentColor = accentKey ? resolveAccentColor(accentKey) : null;
   const className = [
     "canvas-operation",
@@ -291,6 +292,7 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
       tabIndex={focusLayerTarget ? -1 : undefined}
       inert={minimized || renderHidden ? true : undefined}
     >
+      {accentColor ? <span className="canvas-operation-spine" aria-hidden="true" /> : null}
       {!maximized && !interactionDisabled ? (
         <div
           className="canvas-operation-drag-edge"
@@ -310,6 +312,7 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
         onPointerCancel={endDrag}
         data-canvas-blocker
       >
+        {accentColor ? <span className="canvas-operation-id-mark" aria-hidden="true" /> : null}
         {rename.renaming ? (
           <input
             ref={rename.inputRef}

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -1786,22 +1786,24 @@
   line-height: 1.4;
 }
 
-/* 우하단 캔버스 미니맵 — 해군 레이더 스코프. 심해 글래스 위에 동심 링/그리드 텍스처를 깔고
-   현재 뷰포트를 발광 브래스 렌즈로 표시한다(브래스="보는 곳", 아우로라="살아있는 셸"). */
+/* 우하단 캔버스 미니맵 — 침묵하는 계기. 크롬은 중립 헤어라인으로 소등하고,
+   brass는 위치 채널(뷰포트 렌즈·hover/focus)에서만 발화한다. */
 .canvas-minimap {
   position: absolute;
   right: var(--space-4);
   bottom: var(--space-4);
   z-index: 14;
-  border: 1px solid color-mix(in oklch, var(--brass) 30%, var(--surface-rim));
+  border: 1px solid var(--surface-rim);
   border-radius: var(--radius-lg);
-  background:
-    radial-gradient(130% 100% at 50% 0%, color-mix(in oklch, var(--brass) 9%, transparent), transparent 62%),
-    color-mix(in oklch, var(--surface-glass) 60%, color-mix(in oklch, var(--ink-deep) 72%, transparent));
-  box-shadow:
-    var(--shadow-floating),
-    inset 0 1px 0 color-mix(in oklch, var(--brass) 24%, transparent);
+  background: color-mix(in oklch, var(--surface-glass) 60%, color-mix(in oklch, var(--ink-deep) 72%, transparent));
+  box-shadow: var(--shadow-floating);
   overflow: hidden;
+  transition: border-color var(--duration-fast) var(--ease-spring);
+}
+
+.canvas-minimap:hover,
+.canvas-minimap:focus-within {
+  border-color: color-mix(in oklch, var(--brass) 30%, var(--surface-rim));
 }
 
 /* 계기 캡션 — JetBrains Mono 대문자 트래킹. */
@@ -1815,7 +1817,7 @@
   font-weight: 700;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: color-mix(in oklch, var(--brass-bright) 78%, var(--ink-fog));
+  color: var(--ink-fog);
   pointer-events: none;
 }
 
@@ -1830,26 +1832,12 @@
     linear-gradient(150deg, color-mix(in oklch, var(--ink-deep) 38%, transparent), transparent 70%);
 }
 
-/* 동심 레이더 링(구조 장식=브래스). */
-.canvas-minimap-inner::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: repeating-radial-gradient(
-    circle at 50% 50%,
-    transparent 0 15px,
-    color-mix(in oklch, var(--brass) 11%, transparent) 15px 16px
-  );
-  opacity: 0.55;
-  pointer-events: none;
-}
-
-/* 미세 그리드 점 — 캔버스 그리드와 동일 언어(아우로라). */
+/* 미세 그리드 점 — 상시 장식은 중립 잉크만. 신호색(aurora) 상시 점등 금지. */
 .canvas-minimap-inner::after {
   content: "";
   position: absolute;
   inset: 0;
-  background-image: radial-gradient(circle, color-mix(in oklch, var(--aurora) 16%, transparent) 0.5px, transparent 1px);
+  background-image: radial-gradient(circle, color-mix(in oklch, var(--ink-fog) 16%, transparent) 0.5px, transparent 1px);
   background-size: 13px 13px;
   opacity: 0.32;
   pointer-events: none;
@@ -1863,6 +1851,18 @@
   background: color-mix(in oklch, var(--ink-spectral) 17%, transparent);
   border: 1px solid color-mix(in oklch, var(--ink-fog) 38%, transparent);
   box-shadow: 0 0 7px color-mix(in oklch, var(--ink-rim) 36%, transparent);
+}
+
+/* 정체성 도트 — 패널 스파인과 같은 --user-accent 채널을 원거리 식별 표면으로 확장한다. */
+.canvas-minimap-operation[style*="--user-accent"]::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--user-accent);
 }
 
 /* 현재 뷰포트 렌즈 — '지금 보고 있는 곳' 발광 브래스 스코프. */
@@ -1887,19 +1887,19 @@
   z-index: 4;
   display: grid;
   place-items: center;
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--surface-glass) 78%, var(--ink-deep));
-  color: var(--brass);
+  color: var(--ink-fog);
   transition:
     color var(--duration-fast) var(--ease-spring),
     border-color var(--duration-fast) var(--ease-spring),
     background var(--duration-fast) var(--ease-spring);
 }
 
-/* 접힌 Map — 우하단 단일 Map 아이콘 버튼. */
+/* 접힌 Map — 우하단 단일 Map 아이콘 버튼. 휴지 상태는 중립, brass는 hover/focus에서만. */
 .canvas-minimap-fab {
   position: absolute;
   right: var(--space-4);
@@ -1907,15 +1907,13 @@
   z-index: 14;
   display: grid;
   place-items: center;
-  width: 36px;
-  height: 36px;
-  border: 1px solid color-mix(in oklch, var(--brass) 30%, var(--surface-rim));
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--surface-rim);
   border-radius: var(--radius-lg);
-  background:
-    radial-gradient(130% 100% at 50% 0%, color-mix(in oklch, var(--brass) 9%, transparent), transparent 62%),
-    color-mix(in oklch, var(--surface-glass) 60%, color-mix(in oklch, var(--ink-deep) 72%, transparent));
-  color: var(--brass);
-  box-shadow: var(--shadow-anchor);
+  background: color-mix(in oklch, var(--surface-glass) 60%, color-mix(in oklch, var(--ink-deep) 72%, transparent));
+  color: var(--ink-fog);
+  box-shadow: var(--shadow-floating);
   transition:
     color var(--duration-fast) var(--ease-spring),
     border-color var(--duration-fast) var(--ease-spring),
@@ -2070,10 +2068,30 @@
   border-color: var(--brass);
 }
 
-/* Map에서는 사용자 accent가 active/status 여부와 무관하게 패널 전체 외곽선을 소유한다.
-   fill과 status 비콘에는 누출하지 않는다. */
-.operations-canvas .canvas-operation[style*="--user-accent"] {
-  border-color: var(--user-accent);
+/* Map에서 사용자 accent(정체성)는 좌측 스파인·명판 마크·명판 워시만 소유한다.
+   패널 보더/글로우/비콘은 상태 채널(brass 포커스·aurora 대기·coral 위험) 전용으로 남는다. */
+.canvas-operation-spine {
+  position: absolute;
+  top: 10px;
+  bottom: 10px;
+  left: 0;
+  z-index: 5;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
+  background: var(--user-accent);
+  pointer-events: none;
+}
+
+.canvas-operation-id-mark {
+  flex: none;
+  width: 8px;
+  height: 14px;
+  border-radius: 2px;
+  background: var(--user-accent);
+}
+
+.canvas-operation[style*="--user-accent"] .canvas-operation-titlebar {
+  background: color-mix(in oklch, var(--user-accent) 10%, var(--ink-mid));
 }
 
 /* 진행 중 캐리어 스트림을 패널 바깥 아래에 floating으로 띄우는 dock. left/top/width는 패널 geometry를
@@ -2453,16 +2471,16 @@
   }
 }
 
-/* User-selected identity stays a small static side tick; brass focus and
-   aurora/warn status continue to own their existing channels. */
+/* User-selected identity stays a small static side spine (same 3px grammar as the
+   canvas panel spine); brass focus and aurora/warn status continue to own their channels. */
 .side-bar-chip[style*="--user-accent"]::before {
   content: "";
   position: absolute;
   top: 7px;
   bottom: 7px;
   left: 0;
-  width: 2px;
-  border-radius: 0 var(--radius-xs) var(--radius-xs) 0;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
   background: var(--user-accent);
   pointer-events: none;
 }
@@ -2752,7 +2770,8 @@
   margin: 2px var(--space-1) 0 0;
   border-radius: var(--radius-md);
   user-select: none;
-  background: color-mix(in oklch, var(--grp-color, transparent) 14%, transparent);
+  /* 그룹 정체성은 도트+레일만 소유한다 — 헤더 배경·글자는 중립 잉크로 침묵. */
+  background: transparent;
   cursor: grab;
   transition:
     background var(--duration-fast) var(--ease-spring),
@@ -2762,7 +2781,7 @@
 }
 
 .side-bar-group-header--drop-target {
-  background: color-mix(in oklch, var(--brass) 12%, var(--grp-color, transparent));
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
   box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass) 34%, transparent);
 }
 
@@ -2784,7 +2803,7 @@
   background: transparent;
   border: none;
   cursor: pointer;
-  color: var(--grp-color, var(--ink-fog));
+  color: var(--ink-fog);
   border-radius: var(--radius-sm);
   transition: color var(--duration-fast) var(--ease-spring);
 }
@@ -2829,7 +2848,7 @@
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: color-mix(in oklch, var(--grp-color, var(--ink-fog)) 92%, var(--ink-pearl));
+  color: var(--ink-spectral);
 }
 
 .side-bar-group-header__count {
@@ -3155,13 +3174,6 @@
   background: var(--surface-rim);
 }
 
-.group-context-menu-swatches {
-  display: grid;
-  grid-template-columns: repeat(8, 24px);
-  gap: 4px;
-  padding: 2px 4px 4px;
-}
-
 /* ── Accent Popover ─────────────────────────────────────────────────────────────── */
 
 .accent-popover-overlay {
@@ -3173,63 +3185,67 @@
 .accent-popover-card {
   position: fixed;
   z-index: 1;
-  display: grid;
-  /* 16색을 8열 2행으로 — clear(None) 행은 전체 폭을 차지한다. */
-  grid-template-columns: repeat(8, 24px);
-  gap: 6px;
-  padding: 8px;
+  display: flex;
+  /* 8톤을 "플래그 + 이름" 세로 리스트로 — 색이 아니라 이름으로도 고를 수 있다. */
+  flex-direction: column;
+  gap: 2px;
+  min-width: 176px;
+  padding: 6px;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--surface-glass-strong) 88%, var(--ink-deep));
   box-shadow: var(--shadow-anchor);
 }
 
-.accent-popover-swatch {
-  display: grid;
-  place-items: center;
-  width: 24px;
-  height: 24px;
+/* 정체성 톤 행 — 팝오버·칩 메뉴·그룹 메뉴가 공유하는 단일 피커 문법. */
+.accent-tone-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 5px 9px;
   cursor: pointer;
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
   background: transparent;
+  text-align: left;
 }
 
-/* clear(None)는 색이 아니라 해제 동작이라 색 그리드와 분리해 전체 폭 행으로 둔다. */
-.accent-popover-swatch--clear {
-  grid-column: 1 / -1;
-  width: auto;
-  height: 22px;
-  gap: 6px;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--ink-rim);
-  grid-auto-flow: column;
-  justify-content: start;
-}
-
-.accent-popover-swatch:hover,
-.accent-popover-swatch:focus-visible,
-.accent-popover-swatch[aria-pressed="true"] {
-  border-color: color-mix(in oklch, var(--ink-fog) 38%, var(--surface-rim));
+.accent-tone-row:hover,
+.accent-tone-row:focus-visible {
+  border-color: color-mix(in oklch, var(--ink-fog) 20%, transparent);
   background: color-mix(in oklch, var(--ink-spectral) 8%, transparent);
   outline: none;
 }
 
-.accent-popover-swatch span {
-  display: block;
-  width: 14px;
-  height: 14px;
-  border: 1px solid color-mix(in oklch, var(--ink-fog) 34%, transparent);
-  border-radius: 999px;
+.accent-tone-row[aria-pressed="true"] {
+  border-color: color-mix(in oklch, var(--brass) 55%, var(--surface-rim));
+  background: var(--brass-glow);
 }
 
-.accent-popover-swatch--clear span {
-  background:
-    linear-gradient(135deg, transparent 44%, color-mix(in oklch, var(--ink-rim) 82%, transparent) 46% 54%, transparent 56%),
-    color-mix(in oklch, var(--ink-spectral) 8%, transparent);
+.accent-tone-flag {
+  flex: none;
+  width: 8px;
+  height: 14px;
+  border-radius: 2px;
+}
+
+.accent-tone-flag--none {
+  border: 1px solid var(--ink-rim);
+  background: transparent;
+}
+
+.accent-tone-name {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-spectral);
+}
+
+.accent-tone-row--clear .accent-tone-name {
+  color: var(--ink-fog);
 }
 
 .canvas-operation-job-count {

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -14,12 +14,13 @@
   overflow: hidden;
 }
 
+/* 상단 헤어라인 장식 — 단일 hue(brass)만. 이중색(brass→aurora) 그라디언트는 신호 어휘를 오염시킨다. */
 .stage::before {
   content: "";
   position: absolute;
   inset: 0 0 auto;
   height: 1px;
-  background: linear-gradient(90deg, transparent, var(--brass), var(--aurora), transparent);
+  background: linear-gradient(90deg, transparent, color-mix(in oklch, var(--brass) 62%, transparent), transparent);
   pointer-events: none;
 }
 
@@ -688,15 +689,16 @@
   grid-template-columns: minmax(0, 1fr);
 }
 
+/* 정보 뱃지 — 신호색(aurora) 금지. 중립 잉크 + 헤어라인으로 침묵한다. */
 .new-badge {
   display: inline-flex;
   align-items: center;
   margin-left: var(--space-2);
   padding: 2px 7px;
-  border: 1px solid var(--aurora-glow);
-  border-radius: 999px;
-  background: var(--aurora-glow);
-  color: var(--aurora);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--ink-spectral) 6%, transparent);
+  color: var(--ink-spectral);
   font-family: var(--font-mono);
   font-size: 9px;
   font-weight: 700;
@@ -1357,7 +1359,7 @@
   align-items: center;
   justify-content: center;
   gap: 9px;
-  min-height: 38px;
+  min-height: 34px;
   padding: 6px var(--space-3);
   border: 0;
   border-radius: var(--radius-xs);
@@ -1490,8 +1492,8 @@
 
 .workspace-add-button {
   display: grid;
-  width: 30px;
-  height: 30px;
+  width: 28px;
+  height: 28px;
   place-items: center;
   /* Theater 박스(theater-trigger)와 같은 글라스 웰 + 중립 헤어라인 + 브래스 아이콘 언어를 공유한다. */
   border: 1px solid var(--surface-rim);
@@ -2223,8 +2225,8 @@
   display: grid;
   place-items: center;
   flex: none;
-  width: 30px;
-  height: 30px;
+  width: 28px;
+  height: 28px;
   padding: 0;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
@@ -2328,7 +2330,7 @@
   flex: none;
   width: 18px;
   height: 18px;
-  border-radius: 5px;
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--brass) 16%, transparent);
   color: var(--brass-bright);
   font-family: var(--font-mono);
@@ -4536,6 +4538,7 @@
   }
 }
 
+/* 스트림 팔로우 — 원색 solid 필 금지. Action 문법(primary: brass 윤곽 고스트)으로 발화한다. */
 .follow-button {
   position: absolute;
   right: var(--space-6);
@@ -4543,13 +4546,16 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  padding: 8px var(--space-4);
-  border-radius: 999px;
-  background: var(--aurora);
-  color: var(--ink-abyss);
-  box-shadow: 0 12px 32px -16px var(--aurora);
-  font-size: 10.5px;
-  font-weight: 800;
+  min-height: 28px;
+  padding: 5px var(--space-3);
+  border: 1px solid color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
+  border-radius: var(--radius-xs);
+  background: color-mix(in oklch, var(--brass) 14%, var(--ink-deep));
+  color: var(--brass-bright);
+  box-shadow: var(--shadow-floating);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   transition: transform var(--duration-fast) var(--ease-spring);
@@ -4678,7 +4684,7 @@
   gap: var(--space-2);
   min-width: 0;
   width: 100%;
-  height: 32px;
+  height: 34px;
   /* sigil+label을 박스 중앙에 두고, caret은 우측에 절대배치하므로 좌우 패딩을 caret 폭만큼 대칭으로 확보한다. */
   padding: 0 calc(var(--space-2) + 14px);
   /* 휴지 상태는 GNB의 조용한 언어에 맞춰 중립 헤어라인 + 살짝 가라앉은 글라스 웰로 둔다 — 발광하지 않는 계기판 필드. */
@@ -5566,8 +5572,9 @@
   border-color: color-mix(in oklch, var(--warn) 44%, var(--surface-rim));
 }
 
+/* 정보 토스트는 상태가 아니다 — 중립 림으로 둔다(신호 보더는 error/warn만). */
 .app-toast--info {
-  border-color: color-mix(in oklch, var(--aurora) 40%, var(--surface-rim));
+  border-color: var(--surface-rim-strong);
 }
 
 .app-toast-dot {
@@ -5620,8 +5627,8 @@
 .app-toast-close {
   display: grid;
   place-items: center;
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   flex: none;
   margin: -2px -4px 0 auto;
   border-radius: var(--radius-xs);
@@ -6196,7 +6203,7 @@
 }
 
 .directory-browser-jump-button {
-  min-height: 36px;
+  min-height: 34px;
   padding: 0 var(--space-4);
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
@@ -6412,7 +6419,7 @@
 }
 
 .directory-browser-button {
-  min-height: 36px;
+  min-height: 34px;
   padding: 0 var(--space-4);
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
@@ -6721,7 +6728,7 @@ body:has([aria-modal="true"]:not([hidden])) .codex-edge-handle {
   align-items: center;
   justify-content: center;
   width: 30px;
-  height: 30px;
+  height: 28px;
   border-radius: var(--radius-md);
   border: 1px solid transparent;
   background: transparent;
@@ -6921,7 +6928,7 @@ body[data-codex-side="true"] .command-card {
 
 .whatsnew-version-selector select,
 .whatsnew-refresh {
-  min-height: 38px;
+  min-height: 34px;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--ink-mid) 72%, transparent);
@@ -7011,8 +7018,10 @@ body[data-codex-side="true"] .command-card {
   background: color-mix(in oklch, var(--ink-mid) 62%, transparent);
   color: var(--ink-fog);
   font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 760;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
   white-space: nowrap;
 }
 
@@ -7079,14 +7088,14 @@ body[data-codex-side="true"] .command-card {
   align-items: center;
   justify-content: center;
   min-width: 32px;
-  min-height: 38px;
+  min-height: 34px;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--ink-mid) 72%, transparent);
   color: var(--brass);
   font-family: var(--font-mono);
-  font-size: 14px;
-  font-weight: 760;
+  font-size: 12px;
+  font-weight: 700;
   line-height: 1;
 }
 
@@ -7210,7 +7219,7 @@ body[data-codex-side="true"] .command-card {
 }
 
 .whatsnew-done {
-  min-height: 38px;
+  min-height: 34px;
   padding: 0 18px;
   border: 1px solid color-mix(in oklch, var(--brass) 36%, transparent);
   border-radius: var(--radius-sm);
@@ -7773,7 +7782,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   flex: none;
   width: 16px;
   height: 16px;
-  border-radius: 4.5px;
+  border-radius: var(--radius-xs);
 }
 
 .brand-foot-wordmark {
@@ -7803,6 +7812,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   cursor: default;
 }
 
+/* 업데이트 준비됨 = 완료 상태 신호(positive). 정보 뱃지가 아니라 실제 상태만 색을 갖는다. */
 .brand-foot-version-dot {
   position: absolute;
   top: 3px;
@@ -7810,20 +7820,21 @@ body[data-codex-reading="true"] .operations-side-bar {
   width: 5px;
   height: 5px;
   border-radius: 50%;
-  background: var(--aurora);
+  background: var(--positive);
 }
 
+/* 대기 중 업데이트 안내는 정보다 — 중립 잉크. 진행(live)=warn, 실패(error)=coral만 신호로 발화. */
 .brand-foot-update {
   padding: 3px 8px;
-  border: 1px solid color-mix(in oklch, var(--warn) 42%, transparent);
-  border-radius: 999px;
-  background: color-mix(in oklch, var(--warn) 10%, transparent);
-  color: var(--warn);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--ink-spectral) 6%, transparent);
+  color: var(--ink-spectral);
   font-size: 10.5px;
   font-weight: 760;
 }
 
-.brand-foot-update--live { border-color: color-mix(in oklch, var(--aurora) 42%, transparent); background: color-mix(in oklch, var(--aurora) 10%, transparent); color: var(--aurora); }
+.brand-foot-update--live { border-color: color-mix(in oklch, var(--warn) 42%, transparent); background: color-mix(in oklch, var(--warn) 10%, transparent); color: var(--warn); }
 .brand-foot-update--blocked { border-color: var(--surface-rim); background: transparent; color: var(--ink-fog); }
 .brand-foot-update--error { border-color: color-mix(in oklch, var(--coral) 42%, transparent); background: color-mix(in oklch, var(--coral) 10%, transparent); color: var(--coral); }
 .brand-foot-update:disabled { cursor: default; opacity: 0.75; }
@@ -7838,8 +7849,8 @@ body[data-codex-reading="true"] .operations-side-bar {
 .brand-foot-more {
   display: grid;
   place-items: center;
-  width: 26px;
-  height: 26px;
+  width: 24px;
+  height: 24px;
   border-radius: var(--radius-xs);
   color: var(--ink-fog);
 }
@@ -7851,7 +7862,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   display: flex;
   align-items: center;
   gap: 4px;
-  height: 26px;
+  height: 24px;
   padding: 0 6px;
   border-radius: var(--radius-xs);
   color: var(--ink-fog);
@@ -7902,6 +7913,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   left: 0;
 }
 
+/* 메뉴 항목은 theater-menu-item과 같은 mono 대문자 문법을 쓴다 — 콘솔 메뉴 단일 방언. */
 .brand-foot-dropup-menu button {
   display: flex;
   align-items: center;
@@ -7909,7 +7921,11 @@ body[data-codex-reading="true"] .operations-side-bar {
   padding: 7px 10px;
   border-radius: var(--radius-xs);
   color: var(--ink-spectral);
-  font-size: 12.5px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
   text-align: left;
 }
 
@@ -7962,7 +7978,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 .keyboard-shortcuts-group dl > div { display: grid; grid-template-columns: minmax(130px, auto) 1fr; gap: 12px; padding: 4px; color: var(--ink-spectral); font-size: 12px; }
 .keyboard-shortcuts-group dt { color: var(--ink-fog); }
 .keyboard-shortcuts-group dd { margin: 0; }
-.keyboard-shortcuts-group kbd { margin-right: 3px; padding: 1px 4px; border: 1px solid var(--surface-rim); border-radius: 4px; color: var(--ink-pearl); font-family: var(--font-mono); font-size: 10px; }
+.keyboard-shortcuts-group kbd { margin-right: 3px; padding: 1px 4px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); color: var(--ink-pearl); font-family: var(--font-mono); font-size: 10px; }
 
 /* v5: 비-Operations 라우트의 복귀 링크 — GNB 부재 보완 */
 .page-back-link {

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -124,17 +124,17 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   letter-spacing: 0.01em;
 }
 
+/* 환경 표시는 상태가 아니라 정보다 — warn 신호·글로우 금지, 중립 잉크 필로 침묵한다. */
 .command-band-local-chip {
   display: inline-flex;
   align-items: center;
   gap: 5px;
   flex: none;
   padding: 4px 7px;
-  border: 1px solid color-mix(in oklch, var(--warn) 45%, var(--surface-rim));
-  border-radius: 999px;
-  background: color-mix(in oklch, var(--warn-glow) 72%, var(--surface-glass));
-  box-shadow: 0 0 12px var(--warn-glow);
-  color: var(--warn);
+  border: 1px solid var(--surface-rim-strong);
+  border-radius: var(--radius-pill);
+  background: var(--surface-glass);
+  color: var(--ink-spectral);
   font-family: var(--font-mono);
   font-size: 9px;
   font-weight: 700;
@@ -144,8 +144,8 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 
 .command-band-local-chip:hover,
 .command-band-local-chip:focus-visible {
-  border-color: var(--warn);
-  background: color-mix(in oklch, var(--warn-glow) 100%, var(--surface-glass));
+  border-color: color-mix(in oklch, var(--ink-fog) 55%, var(--surface-rim));
+  background: var(--surface-glass-strong);
   outline: none;
 }
 
@@ -168,8 +168,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   width: 5px;
   height: 5px;
   border-radius: 50%;
-  background: var(--warn);
-  box-shadow: 0 0 7px var(--warn-glow);
+  background: var(--ink-fog);
 }
 
 .command-band-environment { position: relative; }
@@ -181,7 +180,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   left: 0;
   width: min(520px, calc(100vw - 24px));
   padding: var(--space-3);
-  border: 1px solid color-mix(in oklch, var(--warn) 35%, var(--surface-rim));
+  border: 1px solid var(--surface-rim-strong);
   border-radius: var(--radius-md);
   background: var(--surface-band);
   box-shadow: 0 12px 30px color-mix(in oklch, var(--ink-deep) 70%, transparent);
@@ -191,7 +190,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 
 .command-band-environment-title {
   margin-bottom: var(--space-2);
-  color: var(--warn);
+  color: var(--ink-pearl);
   font-family: var(--font-mono);
   font-size: 10px;
   font-weight: 700;
@@ -211,9 +210,9 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 .command-band-environment-row span { color: var(--ink-fog); }
 /* 경로 값은 진단 목적상 전문이 보여야 한다 — 말줄임 대신 줄바꿈으로 전체를 노출한다. */
 .command-band-environment-row code { color: var(--ink-pearl); font-family: var(--font-mono); overflow-wrap: anywhere; word-break: break-all; }
-.command-band-environment-row button { padding: 2px 5px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: var(--surface-glass); color: var(--warn); font: inherit; cursor: pointer; }
+.command-band-environment-row button { padding: 2px 5px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: var(--surface-glass); color: var(--ink-spectral); font: inherit; cursor: pointer; }
 .command-band-environment-row button:hover,
-.command-band-environment-row button:focus-visible { border-color: var(--warn); outline: none; }
+.command-band-environment-row button:focus-visible { border-color: color-mix(in oklch, var(--ink-fog) 55%, var(--surface-rim)); outline: none; }
 .command-band-environment-footer { margin-top: var(--space-2); color: var(--ink-fog); font-size: 10px; }
 
 /* 좁은 뷰에서는 칩 앵커(x≈80~160) + 520px 폭이 우측을 벗어나 Copy 버튼이 잘린다 —
@@ -250,7 +249,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   height: 28px;
   padding: 0;
   border: 1px solid transparent;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--ink-fog);
   cursor: pointer;
@@ -291,7 +290,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 
 .command-band-theater-mark {
   padding: 1px 4px;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   background: var(--brass-glow);
   color: var(--brass);
   font-size: 9px;
@@ -330,7 +329,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   gap: 4px;
   flex: none;
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-fog) 10%, transparent);
   color: var(--ink-fog);
   font-family: var(--font-mono);
@@ -355,10 +354,13 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   gap: 6px;
   padding: 5px 9px;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-xs);
   color: var(--ink-spectral);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 10.5px;
+  font-weight: 650;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .command-band-context-trigger:hover,

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -255,7 +255,7 @@
 }
 
 .rail-context-badge--root { color: var(--brass); }
-.rail-context-badge--worktree { color: var(--aurora); }
+.rail-context-badge--worktree { color: var(--ink-spectral); }
 
 .rail-context-tree-row {
   position: relative;

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -177,7 +177,6 @@
   --hairline: oklch(36% 0.035 248);
   --hairline-strong: oklch(48% 0.03 248);
 
-  /* Maritime 봉투: 유리질 고채도 골격 → 정체성 톤도 C≈0.085로 동반 상승. */
   --id-crimson: oklch(74% 0.09 25);
   --id-amber: oklch(78% 0.088 70);
   --id-moss: oklch(76% 0.085 140);
@@ -230,7 +229,6 @@
   --hairline: oklch(33% 0.006 252);
   --hairline-strong: oklch(45% 0.005 252);
 
-  /* Carbon 봉투: 무채색 골격 → 정체성 톤은 C≈0.05로 절제. */
   --id-crimson: oklch(72% 0.052 25);
   --id-amber: oklch(76% 0.05 70);
   --id-moss: oklch(74% 0.048 140);

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -46,14 +46,27 @@
   --carrier-opencode-go: oklch(76% 0.12 184);
   --carrier-cursor: oklch(72% 0.13 238);
   --carrier-taskforce: oklch(78% 0.12 216);
-  --captain-nimitz: #d4af37;
-  --captain-kirov: #e8a854;
-  --captain-genesis: #ff6b6b;
-  --captain-ohio: #a78bfa;
-  --captain-sentinel: #fb7185;
-  --captain-vanguard: #5fd673;
-  --captain-tempest: #3dd5f3;
-  --captain-chronicle: #3dd5f3;
+  /* 정체성 톤(--id-*) — Operation accent·그룹색·captain 식별이 공유하는 8톤.
+     각 테마의 채도 봉투를 따라 재조율된다(Instrument C≈0.06). 신호색(brass/aurora/warn/coral)과
+     hue가 이웃한 crimson/amber는 채도를 낮춰 상태 신호와 혼동되지 않게 한다. */
+  --id-crimson: oklch(72% 0.065 25);
+  --id-amber: oklch(76% 0.062 70);
+  --id-moss: oklch(74% 0.06 140);
+  --id-teal: oklch(74% 0.058 190);
+  --id-cerulean: oklch(73% 0.062 235);
+  --id-indigo: oklch(71% 0.065 278);
+  --id-plum: oklch(72% 0.065 318);
+  --id-rose: oklch(73% 0.06 350);
+
+  /* captain 식별은 --id-* 8톤에 1:1 배정한다 — raw hex 금지, 테마 연동, 중복 없음. */
+  --captain-nimitz: var(--id-amber);
+  --captain-kirov: var(--id-plum);
+  --captain-genesis: var(--id-crimson);
+  --captain-ohio: var(--id-indigo);
+  --captain-sentinel: var(--id-rose);
+  --captain-vanguard: var(--id-moss);
+  --captain-tempest: var(--id-teal);
+  --captain-chronicle: var(--id-cerulean);
 
   --surface-glass: var(--ink-deep);
   --surface-glass-strong: var(--ink-mid);
@@ -78,6 +91,8 @@
   --radius-md: 10px;
   --radius-lg: 10px;
   --radius-xl: 10px;
+  /* 999px는 도트·비콘·상태 캡슐 전용 — 컨트롤(버튼/칩)에는 쓰지 않는다. */
+  --radius-pill: 999px;
 
   --space-1: 4px;
   --space-2: 8px;
@@ -161,6 +176,16 @@
 
   --hairline: oklch(36% 0.035 248);
   --hairline-strong: oklch(48% 0.03 248);
+
+  /* Maritime 봉투: 유리질 고채도 골격 → 정체성 톤도 C≈0.085로 동반 상승. */
+  --id-crimson: oklch(74% 0.09 25);
+  --id-amber: oklch(78% 0.088 70);
+  --id-moss: oklch(76% 0.085 140);
+  --id-teal: oklch(76% 0.082 190);
+  --id-cerulean: oklch(75% 0.088 235);
+  --id-indigo: oklch(73% 0.09 278);
+  --id-plum: oklch(74% 0.09 318);
+  --id-rose: oklch(75% 0.085 350);
 }
 
 :root[data-theme="carbon"] {
@@ -204,6 +229,16 @@
 
   --hairline: oklch(33% 0.006 252);
   --hairline-strong: oklch(45% 0.005 252);
+
+  /* Carbon 봉투: 무채색 골격 → 정체성 톤은 C≈0.05로 절제. */
+  --id-crimson: oklch(72% 0.052 25);
+  --id-amber: oklch(76% 0.05 70);
+  --id-moss: oklch(74% 0.048 140);
+  --id-teal: oklch(74% 0.047 190);
+  --id-cerulean: oklch(73% 0.05 235);
+  --id-indigo: oklch(71% 0.052 278);
+  --id-plum: oklch(72% 0.052 318);
+  --id-rose: oklch(73% 0.05 350);
 }
 
 *,

--- a/runtime/fleet-console/core/host/durable-state.ts
+++ b/runtime/fleet-console/core/host/durable-state.ts
@@ -36,11 +36,13 @@ const STATE_VERSION = 2;
 const STATE_LOCK_DIR_NAME = "state.lock";
 const STATE_LOCK_OWNER_FILE_NAME = "owner.json";
 const STATE_TEMP_PREFIX = ".state.";
-// 그룹 색상 키 화이트리스트 — 16색 accent 팔레트(operation-accent.ts)와 동일 키만 durable에 허용한다.
+// 그룹 색상 키 화이트리스트 — 8톤 정체성 팔레트(operation-accent.ts)와 동일 키를 durable에 허용한다.
+// 구 16키는 기존 durable state 하위호환용으로만 남는다(클라이언트가 읽기 시점에 8톤으로 매핑).
 const VALID_GROUP_COLOR_KEYS = new Set([
-  "red", "orange", "amber", "yellow", "lime", "green",
-  "emerald", "teal", "cyan", "sky", "blue", "indigo",
-  "violet", "purple", "magenta", "rose",
+  "crimson", "amber", "moss", "teal", "cerulean", "indigo", "plum", "rose",
+  "red", "orange", "yellow", "lime", "green",
+  "emerald", "cyan", "sky", "blue",
+  "violet", "purple", "magenta",
 ]);
 
 export function createConsoleDurableStateStore(deps: CreateConsoleDurableStateStoreDeps = {}): DurableJsonStore<DurableConsoleState> {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -76,27 +76,39 @@ describe("Instrument core design contract", () => {
     expect(css).toContain(":focus-visible");
   });
 
-  it("keeps user accents functional through panel perimeters and sidebar side ticks", () => {
+  it("keeps user identity on the spine+mark grammar and off the state border channel", () => {
     const frame = source("canvas/operation-frame.tsx");
     const chip = source("sidebar/operations-side-bar-chip.tsx");
     const components = source("styles/components.css");
-    const panelAccentSelector = '.operations-canvas .canvas-operation[style*="--user-accent"]';
-    const panelAccentBlock = components.match(/\.operations-canvas \.canvas-operation\[style\*="--user-accent"\] \{[^}]*\}/)?.[0] ?? "";
+    const spineBlock = components.match(/\.canvas-operation-spine \{[^}]*\}/)?.[0] ?? "";
+    const markBlock = components.match(/\.canvas-operation-id-mark \{[^}]*\}/)?.[0] ?? "";
+    const washBlock = components.match(/\.canvas-operation\[style\*="--user-accent"\] \.canvas-operation-titlebar \{[^}]*\}/)?.[0] ?? "";
     const chipAccentBlock = components.match(/\.side-bar-chip\[style\*="--user-accent"\]::before \{[^}]*\}/)?.[0] ?? "";
+    const minimapDotBlock = components.match(/\.canvas-minimap-operation\[style\*="--user-accent"\]::after \{[^}]*\}/)?.[0] ?? "";
     const accentSources = [frame, chip, components].join("\n");
 
     expect(frame).toContain('{ "--user-accent": accentColor }');
+    expect(frame).toContain('className="canvas-operation-spine"');
+    expect(frame).toContain('className="canvas-operation-id-mark"');
     expect(chip).toContain('{ "--user-accent": accentValue }');
-    expect(panelAccentBlock).toContain("border-color: var(--user-accent);");
-    expect(panelAccentBlock).not.toMatch(/background|box-shadow|animation/);
-    expect(components.indexOf(panelAccentSelector)).toBeGreaterThan(components.indexOf(".canvas-operation.is-running.is-active"));
-    expect(chipAccentBlock).toContain("width: 2px;");
+    // 정체성은 보더 채널을 소유하지 않는다 — 보더는 상태(brass/aurora/coral) 전용.
+    expect(components).not.toContain("border-color: var(--user-accent)");
+    expect(spineBlock).toContain("width: 3px;");
+    expect(spineBlock).toContain("background: var(--user-accent);");
+    expect(spineBlock).toContain("pointer-events: none;");
+    expect(spineBlock).not.toMatch(/animation|box-shadow/);
+    expect(markBlock).toContain("width: 8px;");
+    expect(markBlock).toContain("height: 14px;");
+    expect(markBlock).toContain("background: var(--user-accent);");
+    expect(washBlock).toContain("color-mix(in oklch, var(--user-accent) 10%, var(--ink-mid))");
+    expect(chipAccentBlock).toContain("width: 3px;");
     expect(chipAccentBlock).toContain("top: 7px;");
     expect(chipAccentBlock).toContain("bottom: 7px;");
     expect(chipAccentBlock).toContain("background: var(--user-accent);");
     expect(chipAccentBlock).toContain("pointer-events: none;");
     expect(chipAccentBlock).not.toMatch(/animation/);
-    expect(components.match(/var\(--user-accent\)/g)).toHaveLength(2);
+    expect(minimapDotBlock).toContain("background: var(--user-accent);");
+    expect(components.match(/var\(--user-accent\)/g)).toHaveLength(5);
     expect(accentSources).not.toMatch(/--op-accent|--chip-accent/);
   });
 
@@ -330,7 +342,7 @@ describe("Instrument core design contract", () => {
       const declarations = block.match(/^\s{2}[^\n:]+:/gm) ?? [];
       expect(declarations.length).toBeGreaterThan(0);
       for (const declaration of declarations) {
-        expect(declaration.trim()).toMatch(/^--(?:ink|brass|aurora|coral|warn|positive|canvas|surface|hairline|text)[a-z-]*:$/);
+        expect(declaration.trim()).toMatch(/^--(?:ink|brass|aurora|coral|warn|positive|canvas|surface|hairline|text|id)[a-z-]*:$/);
       }
     }
     expect(theme).not.toMatch(/body::(?:before|after)/);

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -441,8 +441,8 @@
   flex-shrink: 0;
   padding: 4px 12px;
   font-size: 11px;
-  color: var(--warn);
-  background: color-mix(in oklch, var(--warn) 12%, transparent);
+  color: var(--ink-fog);
+  background: color-mix(in oklch, var(--ink-fog) 8%, transparent);
   border-bottom: 1px solid var(--surface-rim);
   font-family: var(--font-mono);
 }
@@ -781,9 +781,9 @@
 }
 
 .history-badge--branch {
-  color: var(--aurora);
-  border: 1px solid color-mix(in oklch, var(--aurora) 45%, transparent);
-  background: color-mix(in oklch, var(--aurora) 10%, transparent);
+  color: var(--ink-spectral);
+  border: 1px solid color-mix(in oklch, var(--ink-fog) 45%, transparent);
+  background: color-mix(in oklch, var(--ink-fog) 10%, transparent);
 }
 
 .history-badge--remote {
@@ -792,8 +792,8 @@
 }
 
 .history-badge--worktree {
-  color: var(--aurora);
-  border: 1px dashed color-mix(in oklch, var(--aurora) 50%, transparent);
+  color: var(--ink-spectral);
+  border: 1px dashed color-mix(in oklch, var(--ink-fog) 60%, transparent);
 }
 
 .history-commit-subject,
@@ -841,9 +841,9 @@
 }
 
 .history-truncated {
-  color: var(--warn);
+  color: var(--ink-fog);
   border-top: 1px solid var(--surface-rim);
-  background: color-mix(in oklch, var(--warn) 10%, transparent);
+  background: color-mix(in oklch, var(--ink-fog) 8%, transparent);
 }
 
 .history-detail-pane {
@@ -934,11 +934,11 @@
 .history-author > span:nth-child(2) { display: grid; gap: 1px; }
 .history-author b { font-weight: 500; }.history-author small, .history-author time { color: var(--ink-fog); font-family: var(--font-mono); font-size: 10.5px; }
 .history-author time { margin-left: auto; }
-.history-avatar { display: grid; width: 24px; height: 24px; place-items: center; border-radius: 50%; background: linear-gradient(135deg, var(--brass), var(--aurora)); color: var(--ink-deep); font-family: var(--font-mono); font-size: 10px; font-weight: 700; }
+.history-avatar { display: grid; width: 24px; height: 24px; place-items: center; border-radius: 50%; background: color-mix(in oklch, var(--brass) 32%, var(--ink-veil)); color: var(--ink-pearl); font-family: var(--font-mono); font-size: 10px; font-weight: 700; }
 .history-inspector-ids, .history-ref-chips { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 10px; }
 .history-sha-copy, .history-parent { border-radius: var(--radius-sm); background: none; cursor: pointer; font-family: var(--font-mono); font-size: 10.5px; padding: 3px 8px; }
 .history-sha-copy { border: 1px solid var(--surface-rim); color: var(--ink-spectral); }.history-sha-copy span { color: var(--ink-fog); margin-left: 7px; }.history-sha-copy.is-copied { border-color: var(--positive); color: var(--positive); }
-.history-parent { border: 1px solid color-mix(in oklch, var(--aurora) 40%, transparent); color: var(--aurora); }
+.history-parent { border: 1px solid var(--surface-rim); color: var(--ink-spectral); }
 .history-commit-files { display: grid; grid-template-rows: auto minmax(0, 1fr); min-height: 0; overflow: hidden; }
 .history-files-title { display: flex; gap: 8px; align-items: center; padding: 8px 14px; border-bottom: 1px solid var(--surface-rim); color: var(--ink-fog); font-family: var(--font-mono); font-size: 10.5px; letter-spacing: .1em; text-transform: uppercase; }.history-files-stats { margin-left: auto; letter-spacing: 0; }.history-files-title i { color: var(--positive); font-style: normal; }.history-files-title em { color: var(--coral); font-style: normal; }.history-files-view-toggle { margin-left: 0; }
 .history-files-scroll { min-height: 0; overflow: auto; }.history-commit-files .repository-file-row { padding-left: 14px; }

--- a/runtime/fleet-plugins/skills/client/skills.css
+++ b/runtime/fleet-plugins/skills/client/skills.css
@@ -24,9 +24,9 @@
   border-bottom: 2px solid transparent;
   color: var(--ink-fog);
   cursor: pointer;
-  font-family: inherit;
-  font-size: 0.6875rem;
-  font-weight: 600;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
   letter-spacing: 0.06em;
   line-height: 1;
   padding: var(--space-2) var(--space-3);
@@ -71,13 +71,13 @@
 .skills-scope-btn {
   background: none;
   border: none;
-  border-radius: calc(var(--radius-lg) - 2px);
+  border-radius: var(--radius-xs);
   color: var(--ink-fog);
   cursor: pointer;
   flex: 1;
-  font-family: inherit;
-  font-size: 0.6875rem;
-  font-weight: 600;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
   letter-spacing: 0.04em;
   padding: 4px var(--space-2);
   text-transform: uppercase;
@@ -186,8 +186,8 @@
 }
 
 .skills-card-scope-badge--global {
-  background: color-mix(in srgb, var(--aurora) 15%, transparent);
-  color: var(--aurora);
+  background: color-mix(in srgb, var(--ink-fog) 15%, transparent);
+  color: var(--ink-spectral);
 }
 
 .skills-card-meta {
@@ -214,12 +214,14 @@
 
 .skills-btn {
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-xs);
   cursor: pointer;
-  font-family: inherit;
-  font-size: 0.75rem;
-  font-weight: 600;
-  padding: 3px var(--space-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 4px var(--space-3);
   transition: background var(--duration-base), color var(--duration-base);
 }
 
@@ -427,12 +429,12 @@
 .skills-agent-chip {
   background: none;
   border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-xs);
   color: var(--ink-fog);
   cursor: pointer;
-  font-family: inherit;
-  font-size: 0.6875rem;
-  font-weight: 600;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
   letter-spacing: 0.04em;
   padding: 3px var(--space-2);
   text-transform: uppercase;

--- a/runtime/fleet-plugins/terminal/client/carriers/styles.css
+++ b/runtime/fleet-plugins/terminal/client/carriers/styles.css
@@ -1,12 +1,13 @@
 .terminal-carriers-action-button {
   display: inline-flex;
   align-items: center;
+  min-height: 34px;
   padding: 6px var(--space-3);
   border: 1px solid transparent;
   border-radius: var(--radius-xs);
   color: var(--ink-fog);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -58,14 +59,16 @@
   align-items: center;
   gap: 8px;
   min-width: 0;
-  padding: 8px 12px;
+  padding: 6px 12px;
   border: 1px solid transparent;
-  border-radius: 999px;
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--ink-spectral);
-  font-family: var(--font-body);
-  font-size: 14px;
-  font-weight: 500;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   transition:
     color var(--duration-fast) var(--ease-spring),
     border-color var(--duration-fast) var(--ease-spring),
@@ -92,7 +95,6 @@
   flex-shrink: 0;
   border-radius: 50%;
   background: var(--cap-color);
-  box-shadow: 0 0 10px var(--cap-color);
 }
 
 .terminal-carriers-chip-name {
@@ -133,11 +135,12 @@
 .terminal-carriers-card::before {
   content: "";
   position: absolute;
-  top: 0;
-  bottom: 0;
+  top: 10px;
+  bottom: 10px;
   left: 0;
   width: 3px;
-  background: linear-gradient(180deg, var(--cap-color, var(--brass)), transparent 80%);
+  border-radius: 0 3px 3px 0;
+  background: var(--cap-color, var(--brass));
 }
 
 .terminal-carriers-detail-head {
@@ -157,11 +160,11 @@
   align-items: center;
   gap: 8px;
   margin-bottom: 8px;
-  color: var(--cap-color, var(--brass-bright));
+  color: var(--ink-pearl);
   font-family: var(--font-mono);
   font-size: 10px;
   font-weight: 600;
-  letter-spacing: 0.2em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
 }
 
@@ -439,7 +442,7 @@
 .terminal-carriers-tf-toggle {
   align-items: center;
   gap: 9px;
-  min-height: 38px;
+  min-height: 34px;
   padding: 6px var(--space-3);
 }
 


### PR DESCRIPTION
## Summary
- Operation accent를 패널 보더에서 **좌측 스파인 3px + 명판 마크** 문법으로 이전하고, 보더/글로우/비콘은 상태 신호(brass/aurora/coral) 전용으로 환원. 팔레트는 테마별 채도 봉투로 재조율되는 8톤 `--id-*` 토큰으로 교체(구 16키는 읽기측 매핑, durable 스키마 불변). 피커 3곳은 이름 있는 톤 리스트 공용 컴포넌트로 통일, 그룹 헤더는 색 글자·틴트 폐지, 미니맵에 정체성 도트 신설.
- 신호색 헌장 적용: LOCAL 칩·NEW 뱃지·업데이트/브랜치·워크트리 뱃지·정보 토스트의 신호색 오용을 중립 잉크로 회수, follow-button의 원색 solid 필을 brass 고스트 Action으로 정합, 미니맵 상시 brass 소등(hover/focus 발화), 이중색 그라디언트 단일화, `--radius-pill` 미정의 결함 수정.
- captain 8종 raw hex를 `--id-*` 1:1 배정으로 편입(Tempest/Chronicle 중복 해소, 테마 연동), 컨트롤 방언(What's New·command band·skills·brand-foot·carriers)을 지배 패턴(mono 10px 700 uppercase·radius 6)으로 흡수하고 버튼 높이를 {24,28,34,44}로 스냅.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] fleet-console vitest — 디자인 계약 테스트를 새 스파인+마크 문법으로 갱신 포함 (server.test 1건·codex-security-routes 워커 크래시는 무수정 베이스에서 동일 재현되는 선존 이슈)
- [x] terminal(209)·repository(122)·skills(91) 플러그인 테스트
- [x] 격리 인스턴스 헤디드 실측 — 레거시 키 자동 매핑, 스파인·피커·미니맵 도트·captain 정비, Maritime/Carbon 토큰 재조율 확인
- [x] Changelog: `node scripts/compile-changelog-fragments.mjs --check` 통과

## Changelog
- [x] `.changelog.d/pr-307.md` — 제품/섹션 그룹 문법, 영·한 병기 요약, 검증 완료
