### PR TITLE
feat(console): group Terminal settings under a new General section

### DIFF
--- a/.changelog.d/pr-310.md
+++ b/.changelog.d/pr-310.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Changed
+- [fleet-console] Group the Terminal plugin settings into a new General section holding Metaphor, Terminal Font, and Terminal Renderer, and rename the Kimi sign-in card to Settings for Kimi, moving it below Agent CLI Available.
+  ko: Terminal 플러그인 설정을 새 General 섹션으로 묶어 Metaphor, Terminal Font, Terminal Renderer를 담고, Kimi 로그인 카드를 Settings for Kimi로 개칭해 Agent CLI Available 아래로 옮깁니다.

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -89,6 +89,12 @@ export const agentOperationKind = defineOperationKind({
   ],
 });
 
+export const generalSettingsSection = defineSettingsSection({
+  id: "general",
+  title: "General",
+  render: () => <GeneralSection />,
+});
+
 export const agentSettingsSection = defineSettingsSection({
   id: "agent-cli",
   title: "Agent CLI",
@@ -110,7 +116,7 @@ export const agentEndedNotification = defineNotificationKind({
 export const agentPlugin = definePlugin({
   id: "terminal",
   operationKinds: [agentOperationKind],
-  settingsSections: [agentSettingsSection],
+  settingsSections: [generalSettingsSection, agentSettingsSection],
   notificationKinds: [agentAttentionNotification, agentEndedNotification],
   install: (ctx) => installAgentPlugin(ctx),
   closeOperation: async (operationId) => {
@@ -595,10 +601,23 @@ function DockRow({ track, job, multiJob, singleTrack }: DockRowProps) {
   );
 }
 
+function GeneralSection() {
+  const { renderer: terminalRenderer, font: terminalFont } = useTerminalPrefs();
+
+  // 카드를 Fragment로 직접 반환한다. 카드 간 간격은 호스트의 .global-settings-detail(그리드 gap)이
+  // 제공하므로, 플러그인은 자체 래퍼로 감싸 그 간격을 가로채지 않는다(간격은 호스트 소관).
+  return (
+    <>
+      <SystemPromptSettingsBlock />
+      <TerminalFontSettingsCard terminalFont={terminalFont} />
+      <TerminalRendererCard terminalRenderer={terminalRenderer} />
+    </>
+  );
+}
+
 function AgentCliSection() {
   const [clis, setClis] = React.useState<readonly AgentCliStatus[]>([]);
   const [error, setError] = React.useState<string | null>(null);
-  const { renderer: terminalRenderer, font: terminalFont } = useTerminalPrefs();
   const settings = useSystemPromptSettingsStore();
 
   React.useEffect(() => {
@@ -611,12 +630,18 @@ function AgentCliSection() {
     return () => abort.abort();
   }, []);
 
+  // Codex launch mode 토글은 system prompt 설정(codexLaunchMode)에 의존하므로, Metaphor 카드가
+  // General 섹션으로 분리된 지금은 이 섹션에서도 설정을 로드해야 토글이 채워진다.
+  React.useEffect(() => {
+    const controller = new AbortController();
+    void loadSystemPromptSettings(controller.signal);
+    return () => controller.abort();
+  }, []);
+
   // 카드를 Fragment로 직접 반환한다. 카드 간 간격은 호스트의 .global-settings-detail(그리드 gap)이
   // 제공하므로, 플러그인은 자체 래퍼로 감싸 그 간격을 가로채지 않는다(간격은 호스트 소관).
   return (
     <>
-      <SystemPromptSettingsBlock />
-      <ModelAuthBlock />
       <section className="global-settings-card" aria-label="Agent CLI Available">
         <div className="agent-cli-head">
           <p className="global-settings-resp-title">Agent CLI Available</p>
@@ -638,8 +663,7 @@ function AgentCliSection() {
         <p className="global-settings-help">Codex launch mode controls the unified-agent carrier protocol for new Codex sessions; it does not affect the interactive Codex TUI in terminal panels.</p>
         <p className="global-settings-foot">Install or update a CLI, then reopen this page to re-check availability.</p>
       </section>
-      <TerminalFontSettingsCard terminalFont={terminalFont} />
-      <TerminalRendererCard terminalRenderer={terminalRenderer} />
+      <ModelAuthBlock />
     </>
   );
 }
@@ -656,7 +680,7 @@ function ModelAuthBlock() {
   return (
     <section className="global-settings-card" aria-label="Model sign-in">
       <div className="model-auth-head">
-        <p className="global-settings-resp-title">Kimi Sign-in</p>
+        <p className="global-settings-resp-title">Settings for Kimi</p>
         <p className="global-settings-help">
           Register a Kimi API key to run carriers and terminal sessions through Claude Code against the Kimi endpoint.
           The key is validated and stored locally, and is never returned to the browser.

--- a/runtime/fleet-plugins/terminal/client/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/index.tsx
@@ -1,6 +1,6 @@
 import { definePlugin } from "@fleet-console/sdk/plugin/browser";
 
-import { agentAttentionNotification, agentOperationKind, agentPlugin, agentSettingsSection } from "./agent/index.js";
+import { agentAttentionNotification, agentOperationKind, agentPlugin, agentSettingsSection, generalSettingsSection } from "./agent/index.js";
 import { carrierSettingsSection } from "./carriers/section.js";
 import { globalShellPanel } from "./global-shell/rail-panel.js";
 import { shellOperationKind, shellPlugin } from "./shell/index.js";
@@ -14,7 +14,7 @@ const AGENT_OPERATION_TYPES = new Set(["agent"]);
 export const terminalPlugin = definePlugin({
   id: "terminal",
   operationKinds: [shellOperationKind, agentOperationKind],
-  settingsSections: [agentSettingsSection, carrierSettingsSection],
+  settingsSections: [generalSettingsSection, agentSettingsSection, carrierSettingsSection],
   notificationKinds: [agentAttentionNotification],
   railPanels: [globalShellPanel],
   install: (ctx) => { void preloadSymbolsNerdFontMono(); connectTerminalSettings(ctx.settings); return agentPlugin.install?.(ctx); },
@@ -35,7 +35,7 @@ export const terminalPlugin = definePlugin({
 });
 
 export const operationKinds = [shellOperationKind, agentOperationKind] as const;
-export const settingsSections = [agentSettingsSection, carrierSettingsSection] as const;
+export const settingsSections = [generalSettingsSection, agentSettingsSection, carrierSettingsSection] as const;
 export const notificationKinds = [agentAttentionNotification] as const;
 export const plugins = [terminalPlugin] as const;
 


### PR DESCRIPTION
## Summary
- Terminal 플러그인 설정에 새 **General** 섹션을 만들고 **Metaphor · Terminal Font · Terminal Renderer** 세 항목을 이동. 네비 순서는 General → Agent CLI → Carriers.
- **Kimi Sign-in** 카드를 **Settings for Kimi**로 개칭하고 **Agent CLI Available 아래**로 재배치.
- Metaphor 분리로 인한 회귀 방지: Agent CLI 섹션에서도 system prompt 설정을 로드해 **Codex launch mode 토글**이 계속 채워지도록 함.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal typecheck` — exit 0
- [x] `pnpm --filter @fleet-plugins/terminal test` — 258/258 통과
- [x] 모노레포 전체 빌드 성공, 콘솔 dist 번들에 재구성 반영 확인
- [ ] 헤디드 육안 확인 (Settings → Plugins → Terminal → General / Agent CLI)

## Changelog
- [x] `.changelog.d/pr-310.md` 추가 — fleet-plugin / Changed, 이중언어 요약, `compile-changelog-fragments --check` 통과