### PR TITLE
fix(terminal): align artifact canvas with Console theme

### DIFF
--- a/.changelog.d/pr-315.md
+++ b/.changelog.d/pr-315.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] Keep Session Analyst artifact canvases aligned with the active Console theme.
+  ko: Session Analyst 아티팩트 캔버스가 활성 Console 테마를 따르도록 수정했습니다.

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-api.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-api.ts
@@ -1,10 +1,13 @@
-import type { ClientApiCapability } from "@fleet-console/sdk/plugin";
+import type { ClientApiCapability, ConsoleTheme } from "@fleet-console/sdk/plugin";
 import { ApiError } from "@fleet-console/sdk/operations/browser";
 import { parseAnalysisCatalog, parseAnalysisError, parseAnalysisEvent, type AnalysisCatalog, type AnalysisError, type AnalysisEvent } from "./analysis-types.js";
 
 export class AnalysisApiError extends Error { constructor(readonly code: string, message: string) { super(message); } }
 const base = (operationId: string) => `analysis/${encodeURIComponent(operationId)}`;
-export const analysisArtifactUrl = (artifactId: string): string => `/plugins/terminal/analysis/artifacts/${encodeURIComponent(artifactId)}`;
+export function analysisArtifactUrl(artifactId: string, theme: ConsoleTheme, canvas: string, foreground: string): string {
+  const query = new URLSearchParams({ theme, canvas, foreground });
+  return `/plugins/terminal/analysis/artifacts/${encodeURIComponent(artifactId)}?${query.toString()}`;
+}
 
 export async function fetchAnalysisCatalog(api: ClientApiCapability): Promise<AnalysisCatalog> {
   const response = await fetchOrThrow(api, "analysis/catalog");

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-artifact.test.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-artifact.test.ts
@@ -1,10 +1,12 @@
 // @vitest-environment jsdom
 
-import { act, createElement } from "react";
-import { createRoot } from "react-dom/client";
-import { describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+
+import type { ConsoleTheme, OperationRenderContext } from "@fleet-console/sdk/plugin";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./analysis-store.js", () => ({
   useAnalysisStore: () => ({
@@ -19,21 +21,61 @@ vi.mock("./analysis-store.js", () => ({
 
 import { AnalystArtifactsPanel } from "./analysis-artifacts-panel.js";
 
+const THEMES = ["instrument", "maritime", "carbon"] as const satisfies readonly ConsoleTheme[];
+
+function operationContext(theme: ConsoleTheme, fetch = vi.fn(async () => new Response(null, { status: 200 }))): OperationRenderContext {
+  return { theme, operationId: "op/id", api: { fetch } } as never;
+}
+
+function artifactUrl(frame: HTMLIFrameElement): URL {
+  return new URL(frame.getAttribute("src") ?? "", "http://console.test");
+}
+
+afterEach(() => {
+  document.documentElement.style.removeProperty("--ink-veil");
+  document.documentElement.style.removeProperty("--ink-pearl");
+});
+
 describe("artifact frame", () => {
-  it("loads the artifact route with scripts in an opaque-origin sandbox", () => {
+  it("loads the server artifact route with scripts in an opaque-origin sandbox", () => {
     const panel = readFileSync(resolve("client/agent/analysis-artifacts-panel.tsx"), "utf8");
     expect(panel).toContain('sandbox="allow-scripts"');
     expect(panel).not.toContain("allow-same-origin");
     expect(panel).not.toContain("safeArtifactSrcdoc");
     expect(panel).not.toContain("srcDoc=");
-    expect(panel).toContain("src={analysisArtifactUrl(artifact.id)}");
+    expect(panel).toContain("src={analysisArtifactUrl(artifact.id, theme, canvas, foreground)}");
   });
+
+  it("includes the active theme and exact computed Console canvas tokens for all themes", () => {
+    document.documentElement.style.setProperty("--ink-veil", "oklch(23.5% 0.02 245)");
+    document.documentElement.style.setProperty("--ink-pearl", "oklch(94% 0.008 90)");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    for (const theme of THEMES) {
+      act(() => root.render(createElement(AnalystArtifactsPanel, { context: operationContext(theme) })));
+      const url = artifactUrl(container.querySelector("iframe")!);
+      expect(url.pathname).toBe("/plugins/terminal/analysis/artifacts/artifact-late");
+      expect(Object.fromEntries(url.searchParams)).toEqual({
+        theme,
+        canvas: "oklch(23.5% 0.02 245)",
+        foreground: "oklch(94% 0.008 90)",
+      });
+    }
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
   it("opens a creation-ordered header listbox and keeps one selected preview", () => {
+    document.documentElement.style.setProperty("--ink-veil", "rgb(11, 12, 13)");
+    document.documentElement.style.setProperty("--ink-pearl", "rgb(241, 242, 243)");
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root = createRoot(container);
     const fetch = vi.fn(async () => new Response(JSON.stringify({ cleared: true }), { status: 200, headers: { "Content-Type": "application/json" } }));
-    act(() => root.render(createElement(AnalystArtifactsPanel, { context: { operationId: "op/id", api: { fetch } } as never })));
+    act(() => root.render(createElement(AnalystArtifactsPanel, { context: operationContext("instrument", fetch) })));
 
     const trigger = container.querySelector<HTMLButtonElement>(".session-analyst__artifact-count")!;
     expect(trigger.textContent).toBe("2 items");
@@ -46,30 +88,54 @@ describe("artifact frame", () => {
     act(() => trigger.click());
     const options = [...container.querySelectorAll('[role="option"]')];
     expect(trigger.getAttribute("aria-expanded")).toBe("true");
-    expect(container.querySelector('[role="listbox"]')).not.toBeNull();
     expect(options.map((option) => option.querySelector("strong")?.textContent)).toEqual(["Early artifact", "Later artifact"]);
     expect(options.map((option) => option.getAttribute("aria-selected"))).toEqual(["false", "true"]);
     expect(options.every((option) => option.querySelector("time")?.hasAttribute("datetime"))).toBe(true);
 
-    // 목록에서 선택하면 해당 문서가 전체 뷰로 렌더되고 popover는 닫힌다.
     act(() => (options[0] as HTMLButtonElement).click());
-    expect(container.querySelector("iframe")?.title).toBe("Early artifact");
+    const iframe = container.querySelector("iframe")!;
+    expect(iframe.title).toBe("Early artifact");
     expect(trigger.getAttribute("aria-expanded")).toBe("false");
-    expect(container.querySelector('[role="listbox"]')).toBeNull();
-
-    const iframe = container.querySelector("iframe");
-    expect(iframe?.getAttribute("sandbox")).toBe("allow-scripts");
-    expect(iframe?.getAttribute("src")).toBe("/plugins/terminal/analysis/artifacts/artifact-early");
-    act(() => iframe?.dispatchEvent(new Event("load", { bubbles: true })));
-    expect(container.querySelector("iframe")).toBe(iframe);
-    expect(container.querySelector('[role="alert"]')).toBeNull();
-
-    act(() => iframe?.dispatchEvent(new Event("load", { bubbles: true })));
+    expect(iframe.getAttribute("sandbox")).toBe("allow-scripts");
+    const url = artifactUrl(iframe);
+    expect(url.pathname).toBe("/plugins/terminal/analysis/artifacts/artifact-early");
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      theme: "instrument",
+      canvas: "rgb(11, 12, 13)",
+      foreground: "rgb(241, 242, 243)",
+    });
+    act(() => iframe.dispatchEvent(new Event("load", { bubbles: true })));
     expect(container.querySelector("iframe")).toBe(iframe);
     expect(container.querySelector('[role="alert"]')).toBeNull();
 
     act(() => container.querySelector<HTMLButtonElement>(".session-analyst__clear")?.click());
     expect(fetch).toHaveBeenCalledWith("terminal", "analysis/op%2Fid/artifacts", { method: "DELETE" });
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("regenerates the artifact URL when the Console theme canvas changes", () => {
+    document.documentElement.style.setProperty("--ink-veil", "rgb(31, 32, 33)");
+    document.documentElement.style.setProperty("--ink-pearl", "rgb(221, 222, 223)");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => root.render(createElement(AnalystArtifactsPanel, { context: operationContext("maritime") })));
+    const maritimeUrl = container.querySelector("iframe")?.getAttribute("src") ?? "";
+
+    document.documentElement.style.setProperty("--ink-veil", "rgb(41, 42, 43)");
+    document.documentElement.style.setProperty("--ink-pearl", "rgb(211, 212, 213)");
+    act(() => root.render(createElement(AnalystArtifactsPanel, { context: operationContext("carbon") })));
+    const carbonUrl = container.querySelector("iframe")?.getAttribute("src") ?? "";
+
+    expect(carbonUrl).not.toBe(maritimeUrl);
+    expect(Object.fromEntries(new URL(carbonUrl, "http://console.test").searchParams)).toEqual({
+      theme: "carbon",
+      canvas: "rgb(41, 42, 43)",
+      foreground: "rgb(211, 212, 213)",
+    });
 
     act(() => root.unmount());
     container.remove();

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-artifacts-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-artifacts-panel.tsx
@@ -1,4 +1,4 @@
-import type { OperationRenderContext } from "@fleet-console/sdk/plugin";
+import type { ConsoleTheme, OperationRenderContext } from "@fleet-console/sdk/plugin";
 import { React } from "@fleet-console/sdk/plugin/browser";
 import type { AnalysisArtifact } from "./analysis-types.js";
 
@@ -67,19 +67,22 @@ export function AnalystArtifactsPanel({ context }: { readonly context: Operation
         <div className="session-analyst__artifacts-empty"><strong>No artifacts yet</strong>Artifacts the analyst publishes will appear here.</div>
       ) : (
         <div className="session-analyst__artifact-content">
-          {active ? <ActiveArtifact key={active.id} artifact={active} /> : null}
+          {active ? <ActiveArtifact key={active.id} artifact={active} theme={context.theme} /> : null}
         </div>
       )}
     </section>
   );
 }
 
-function ActiveArtifact({ artifact }: { readonly artifact: AnalysisArtifact }) {
+function ActiveArtifact({ artifact, theme }: { readonly artifact: AnalysisArtifact; readonly theme: ConsoleTheme }) {
   if (!artifact.id) return null;
+  const consoleStyle = getComputedStyle(document.documentElement);
+  const canvas = consoleStyle.getPropertyValue("--ink-veil").trim() || "Canvas";
+  const foreground = consoleStyle.getPropertyValue("--ink-pearl").trim() || "CanvasText";
   return (
     <article aria-label="Selected artifact preview">
       <header><span className="session-analyst__artifact-title">{artifact.title}</span><ArtifactTime createdAt={artifact.createdAt} /></header>
-      <iframe title={artifact.title} src={analysisArtifactUrl(artifact.id)} sandbox="allow-scripts" />
+      <iframe title={artifact.title} src={analysisArtifactUrl(artifact.id, theme, canvas, foreground)} sandbox="allow-scripts" />
     </article>
   );
 }

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-panel.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-panel.test.tsx
@@ -29,7 +29,7 @@ describe("Session Analyst contract", () => {
     expect(artifacts).toContain('sandbox="allow-scripts"');
     expect(artifacts).not.toContain("allow-same-origin");
     expect(artifacts).not.toContain("srcDoc=");
-    expect(artifacts).toContain("src={analysisArtifactUrl(artifact.id)}");
+    expect(artifacts).toContain("src={analysisArtifactUrl(artifact.id, theme, canvas, foreground)}");
     expect(css).toContain("prefers-reduced-motion: reduce");
     expect(css).toContain("var(--aurora)");
     expect(css).toContain("var(--positive)");

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { EventEmitter } from "node:events";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -331,6 +332,9 @@ describe("Session Analyst server contract", () => {
     expect(response.body).toContain('<html data-theme="carbon" style="background-color:oklch(33% 0.006 252)!important;background-image:none!important;color:oklch(95% 0.003 250)!important;min-height:100%!important;color-scheme:dark!important;">');
     expect(response.body).toContain(`<body style="background-color:oklch(33% 0.006 252)!important;background-image:none!important;color:oklch(95% 0.003 250)!important;min-height:100%!important;color-scheme:dark!important;margin:0!important;">${html}</body>`);
     expect(response.body).toContain("<script>globalThis.__artifactRan = true</script>");
+    const fragmentDocument = new DOMParser().parseFromString(response.body, "text/html");
+    expect(fragmentDocument.documentElement.getAttribute("data-theme")).toBe("carbon");
+    expect(fragmentDocument.body.querySelector("main")?.textContent).toBe("ArtifactglobalThis.__artifactRan = true");
     expect(response.headers).toMatchObject({
       "Content-Type": "text/html; charset=utf-8",
       "Content-Security-Policy": ANALYSIS_ARTIFACT_CSP,
@@ -377,16 +381,39 @@ describe("Session Analyst server contract", () => {
       }) as never,
     });
     await router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", { cliId: "claude", model: "model-b" });
-    const hostileHtml = '<!doctype html><html style="background:white!important"><head><style>html,body{background:linear-gradient(white,white)!important;color:white!important;min-height:1px!important;color-scheme:light!important}</style></head><body><script>globalThis.__artifactRan=true</script><main>Artifact</main></body></html>';
+    const hostileHtml = `<!doctype html><html lang="en" class='artifact-root' data-note="quoted > value" data-theme="artifact" style='scrollbar-gutter:stable;background-color:white!important'><head><style>html,body{background:linear-gradient(white,white)!important;color:white!important;min-height:1px!important;color-scheme:light!important}</style></head><body class="artifact-body" aria-label='Artifact > body' data-layout="report" style='display:grid;padding:24px;font-family:"Artifact Serif";--artifact-label:"alpha;beta";letter-spacing:.1em;margin:40px;background-color:hotpink!important;background-image:linear-gradient(white,white)!important;color:white!important;min-height:1px!important;color-scheme:light!important'><script>globalThis.__artifactRan=true</script><main>Artifact</main></body></html>`;
     emit?.({ type: "artifact", artifact: { id: "hostile", title: "Hostile", html: hostileHtml, createdAt: new Date(0).toISOString() } });
 
     for (const theme of ["instrument", "maritime", "carbon"] as const) {
-      const path = `/api/v1/plugins/terminal/analysis/artifacts/hostile?theme=${theme}&canvas=${encodeURIComponent("oklch(23.5% 0.02 245)")}&foreground=${encodeURIComponent("oklch(94% 0.008 90)")}`;
+      const path = `/api/v1/plugins/terminal/analysis/artifacts/hostile?theme=${theme}&canvas=${encodeURIComponent("#123456")}&foreground=${encodeURIComponent("#f0f0f0")}`;
       const response = await router.call("GET", path);
       expect(response.status).toBe(200);
-      expect(response.body).toContain(`<html data-theme="${theme}" style="background-color:oklch(23.5% 0.02 245)!important;background-image:none!important;color:oklch(94% 0.008 90)!important;min-height:100%!important;color-scheme:dark!important;">`);
-      expect(response.body).toContain(hostileHtml);
-      expect(response.body.indexOf("background-image:none!important")).toBeLessThan(response.body.indexOf("linear-gradient"));
+      const document = new DOMParser().parseFromString(response.body, "text/html");
+      expect(document.documentElement.getAttribute("data-theme")).toBe(theme);
+      expect(document.documentElement).toMatchObject({ lang: "en", className: "artifact-root" });
+      expect(document.documentElement.getAttribute("data-note")).toBe("quoted > value");
+      expect(document.body).toMatchObject({ className: "artifact-body" });
+      expect(document.body.getAttribute("aria-label")).toBe("Artifact > body");
+      expect(document.body.getAttribute("data-layout")).toBe("report");
+      expect(document.documentElement.style.scrollbarGutter).toBe("stable");
+      expect(document.body.style.display).toBe("grid");
+      expect(document.body.style.padding).toBe("24px");
+      expect(document.body.style.fontFamily).toBe('"Artifact Serif"');
+      expect(document.body.style.getPropertyValue("--artifact-label")).toBe('"alpha;beta"');
+      expect(document.body.style.letterSpacing).toBe("0.1em");
+      expect(document.documentElement.style.getPropertyValue("background-color")).toBe("rgb(18, 52, 86)");
+      expect(document.body.style.getPropertyValue("background-color")).toBe("rgb(18, 52, 86)");
+      expect(document.body.style.getPropertyValue("background-image")).toBe("none");
+      expect(document.body.style.getPropertyValue("color")).toBe("rgb(240, 240, 240)");
+      expect(document.body.style.getPropertyValue("min-height")).toBe("100%");
+      expect(document.body.style.getPropertyValue("color-scheme")).toBe("dark");
+      expect(document.body.style.getPropertyValue("margin")).toBe("0px");
+      for (const property of ["background-color", "background-image", "color", "min-height", "color-scheme", "margin"]) {
+        expect(document.body.style.getPropertyPriority(property)).toBe("important");
+      }
+      expect(document.querySelector("script")?.textContent).toContain("globalThis.__artifactRan=true");
+      expect(response.body.match(/<html\b/gi)).toHaveLength(1);
+      expect(response.body.match(/<body\b/gi)).toHaveLength(1);
     }
   });
 
@@ -413,9 +440,12 @@ describe("Session Analyst server contract", () => {
     const response = await router.call("GET", path);
 
     expect(response.status).toBe(200);
-    expect(response.body).toContain('<html data-theme="instrument" style="background-color:Canvas!important;background-image:none!important;color:CanvasText!important;');
+    const document = new DOMParser().parseFromString(response.body, "text/html");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("instrument");
+    expect(document.documentElement.style.getPropertyValue("background-color")).toBe("canvas");
+    expect(document.documentElement.style.getPropertyValue("color")).toBe("canvastext");
     expect(response.body).not.toContain("globalThis.injected");
-    expect(response.body).not.toContain("onload=");
+    expect(document.documentElement.hasAttribute("onload")).toBe(false);
   });
 
   it("host-gates artifact documents and returns 404 for unknown ids", async () => {

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
@@ -325,9 +325,12 @@ describe("Session Analyst server contract", () => {
     const html = "<main>Artifact<script>globalThis.__artifactRan = true</script></main>";
     emit?.({ type: "artifact", artifact: { id: "artifact/id", title: "Artifact", html, createdAt: new Date(0).toISOString() } });
 
-    const response = await router.call("GET", "/api/v1/plugins/terminal/analysis/artifacts/artifact%2Fid");
+    const response = await router.call("GET", "/api/v1/plugins/terminal/analysis/artifacts/artifact%2Fid?theme=carbon&canvas=oklch%2833%25%200.006%20252%29&foreground=oklch%2895%25%200.003%20250%29");
 
-    expect(response).toMatchObject({ status: 200, body: html, ended: true });
+    expect(response).toMatchObject({ status: 200, ended: true });
+    expect(response.body).toContain('<html data-theme="carbon" style="background-color:oklch(33% 0.006 252)!important;background-image:none!important;color:oklch(95% 0.003 250)!important;min-height:100%!important;color-scheme:dark!important;">');
+    expect(response.body).toContain(`<body style="background-color:oklch(33% 0.006 252)!important;background-image:none!important;color:oklch(95% 0.003 250)!important;min-height:100%!important;color-scheme:dark!important;margin:0!important;">${html}</body>`);
+    expect(response.body).toContain("<script>globalThis.__artifactRan = true</script>");
     expect(response.headers).toMatchObject({
       "Content-Type": "text/html; charset=utf-8",
       "Content-Security-Policy": ANALYSIS_ARTIFACT_CSP,
@@ -343,7 +346,9 @@ describe("Session Analyst server contract", () => {
 
     await router.call("POST", "/api/v1/plugins/terminal/analysis/op/stop", {});
     const afterStop = await router.call("GET", "/api/v1/plugins/terminal/analysis/artifacts/artifact%2Fid");
-    expect(afterStop).toMatchObject({ status: 200, body: html, ended: true });
+    expect(afterStop).toMatchObject({ status: 200, ended: true });
+    expect(afterStop.body).toContain(html);
+    expect(afterStop.body).toContain('<html data-theme="instrument" style="background-color:Canvas!important;');
 
     await router.call("DELETE", "/api/v1/plugins/terminal/analysis/op/artifacts");
     await router.call("GET", "/api/v1/plugins/terminal/analysis/artifacts/artifact%2Fid");
@@ -354,6 +359,63 @@ describe("Session Analyst server contract", () => {
     router.emitOperationDeleted({ operationId: "op", pluginId: "terminal" });
     await router.call("GET", "/api/v1/plugins/terminal/analysis/artifacts/deleted-artifact");
     expect(router.responses.at(-1)).toMatchObject({ status: 404, body: { error: { message: "Analysis artifact was not found." } } });
+  });
+
+  it("wraps hostile artifact CSS with a validated host-owned canvas for every Console theme", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "analysis-artifact-theme-route-"));
+    const transcriptPath = join(dir, "captured.jsonl");
+    await writeFile(transcriptPath, "{}\n");
+    const router = createRouterHarness(true);
+    let emit: ((event: { type: "artifact"; artifact: { id: string; title: string; html: string; createdAt: string } }) => void) | undefined;
+    registerAnalysisRoutes(router.ctx as never, {
+      detect: async () => [{ id: "claude", displayName: "Claude Code", available: true, version: null }],
+      modelsFor: () => ({ defaultModel: "model-b", models: [{ modelId: "model-b", name: "Model B", effort: { supported: false } }] }) as never,
+      readCapture: () => ({ provider: "claude", sessionId: "private", capturedAt: "now", transcriptPath }),
+      createSession: ((options: { onEvent: typeof emit }) => {
+        emit = options.onEvent;
+        return { start: async () => undefined, send: async () => undefined, dispose: async () => undefined };
+      }) as never,
+    });
+    await router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", { cliId: "claude", model: "model-b" });
+    const hostileHtml = '<!doctype html><html style="background:white!important"><head><style>html,body{background:linear-gradient(white,white)!important;color:white!important;min-height:1px!important;color-scheme:light!important}</style></head><body><script>globalThis.__artifactRan=true</script><main>Artifact</main></body></html>';
+    emit?.({ type: "artifact", artifact: { id: "hostile", title: "Hostile", html: hostileHtml, createdAt: new Date(0).toISOString() } });
+
+    for (const theme of ["instrument", "maritime", "carbon"] as const) {
+      const path = `/api/v1/plugins/terminal/analysis/artifacts/hostile?theme=${theme}&canvas=${encodeURIComponent("oklch(23.5% 0.02 245)")}&foreground=${encodeURIComponent("oklch(94% 0.008 90)")}`;
+      const response = await router.call("GET", path);
+      expect(response.status).toBe(200);
+      expect(response.body).toContain(`<html data-theme="${theme}" style="background-color:oklch(23.5% 0.02 245)!important;background-image:none!important;color:oklch(94% 0.008 90)!important;min-height:100%!important;color-scheme:dark!important;">`);
+      expect(response.body).toContain(hostileHtml);
+      expect(response.body.indexOf("background-image:none!important")).toBeLessThan(response.body.indexOf("linear-gradient"));
+    }
+  });
+
+  it("falls back instead of embedding hostile, invalid, or overlong theme canvas inputs", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "analysis-artifact-input-route-"));
+    const transcriptPath = join(dir, "captured.jsonl");
+    await writeFile(transcriptPath, "{}\n");
+    const router = createRouterHarness(true);
+    let emit: ((event: { type: "artifact"; artifact: { id: string; title: string; html: string; createdAt: string } }) => void) | undefined;
+    registerAnalysisRoutes(router.ctx as never, {
+      detect: async () => [{ id: "claude", displayName: "Claude Code", available: true, version: null }],
+      modelsFor: () => ({ defaultModel: "model-b", models: [{ modelId: "model-b", name: "Model B", effort: { supported: false } }] }) as never,
+      readCapture: () => ({ provider: "claude", sessionId: "private", capturedAt: "now", transcriptPath }),
+      createSession: ((options: { onEvent: typeof emit }) => {
+        emit = options.onEvent;
+        return { start: async () => undefined, send: async () => undefined, dispose: async () => undefined };
+      }) as never,
+    });
+    await router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", { cliId: "claude", model: "model-b" });
+    emit?.({ type: "artifact", artifact: { id: "safe", title: "Safe", html: "<p>safe</p>", createdAt: new Date(0).toISOString() } });
+    const hostile = 'red!important;"><script>globalThis.injected=true</script>';
+    const path = `/api/v1/plugins/terminal/analysis/artifacts/safe?theme=${encodeURIComponent('carbon" onload="alert(1)')}&canvas=${encodeURIComponent(hostile)}&foreground=${encodeURIComponent("x".repeat(101))}`;
+
+    const response = await router.call("GET", path);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toContain('<html data-theme="instrument" style="background-color:Canvas!important;background-image:none!important;color:CanvasText!important;');
+    expect(response.body).not.toContain("globalThis.injected");
+    expect(response.body).not.toContain("onload=");
   });
 
   it("host-gates artifact documents and returns 404 for unknown ids", async () => {
@@ -439,7 +501,8 @@ function createRouterHarness(initialHostAllowance: boolean) {
       let responseStatus: number | undefined;
       let responseHeaders: Record<string, string> = {};
       let responseBody = "";
-      const req = Object.assign(new EventEmitter(), { method, headers: { "content-type": "application/json", ...headers }, socket: { localPort: 4444 }, body });
+      const url = new URL(pathname, "http://fleet.test");
+      const req = Object.assign(new EventEmitter(), { method, url: `${url.pathname}${url.search}`, headers: { "content-type": "application/json", ...headers }, socket: { localPort: 4444 }, body });
       const res = Object.assign(new EventEmitter(), {
         writableEnded: false,
         destroyed: false,
@@ -447,7 +510,7 @@ function createRouterHarness(initialHostAllowance: boolean) {
         write: (data: string) => { writes.push(data); },
         end: (data?: string) => { if (data) responseBody += data; ended = true; },
       });
-      await handler?.({ req, res, pathname });
+      await handler?.({ req, res, pathname: url.pathname });
       return { writes, get ended() { return ended; }, get status() { return responseStatus; }, get headers() { return responseHeaders; }, get body() { return responseBody; } };
     },
   };

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
@@ -15,6 +15,8 @@ import { readProviderSessionCapture } from "./session-capture.js";
 const AGENT_OPERATION_TYPE = "agent";
 const OPERATION_DELETED_EVENT_CHANNEL = "operation:deleted";
 export const ANALYSIS_ARTIFACT_CSP = "sandbox allow-scripts; default-src 'self' data: blob: https: http:; script-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: https: http:; style-src 'self' 'unsafe-inline' data: blob: https: http:; img-src 'self' data: blob: https: http:; font-src 'self' data: blob: https: http:; connect-src *; frame-src 'self' data: blob: https: http:; media-src 'self' data: blob: https: http:; worker-src 'self' data: blob:; frame-ancestors 'self'";
+const ANALYSIS_ARTIFACT_THEMES = new Set(["instrument", "maritime", "carbon"]);
+const SAFE_ARTIFACT_COLOR = /^(?:#[\da-f]{3,8}|(?:rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch)\([\d.e%+\-/, ]{1,96}\)|Canvas|CanvasText)$/i;
 
 type AnalysisRouteDeps = {
   readonly detect?: () => ReturnType<ReturnType<typeof createDefaultAgentCliDetector>["detect"]>;
@@ -83,8 +85,25 @@ function handleArtifact(ctx: FleetPluginServerContext, req: http.IncomingMessage
     return true;
   }
   res.writeHead(200, artifactHeaders());
-  res.end(html);
+  res.end(artifactDocument(html, req.url));
   return true;
+}
+
+function artifactDocument(html: string, requestUrl: string | undefined): string {
+  const query = new URL(requestUrl ?? "/", "http://fleet.invalid").searchParams;
+  const theme = safeArtifactTheme(query.get("theme"));
+  const canvas = safeArtifactColor(query.get("canvas"), "Canvas");
+  const foreground = safeArtifactColor(query.get("foreground"), "CanvasText");
+  const canvasStyle = `background-color:${canvas}!important;background-image:none!important;color:${foreground}!important;min-height:100%!important;color-scheme:dark!important;`;
+  return `<!doctype html><html data-theme="${theme}" style="${canvasStyle}"><head></head><body style="${canvasStyle}margin:0!important;">${html}</body></html>`;
+}
+
+function safeArtifactTheme(value: string | null): string {
+  return value !== null && ANALYSIS_ARTIFACT_THEMES.has(value) ? value : "instrument";
+}
+
+function safeArtifactColor(value: string | null, fallback: "Canvas" | "CanvasText"): string {
+  return value !== null && value.length <= 100 && SAFE_ARTIFACT_COLOR.test(value) ? value : fallback;
 }
 
 function handleClearArtifacts(ctx: FleetPluginServerContext, req: http.IncomingMessage, res: http.ServerResponse, operationId: string, registry: AnalysisRegistry): boolean {

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
@@ -17,6 +17,8 @@ const OPERATION_DELETED_EVENT_CHANNEL = "operation:deleted";
 export const ANALYSIS_ARTIFACT_CSP = "sandbox allow-scripts; default-src 'self' data: blob: https: http:; script-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: https: http:; style-src 'self' 'unsafe-inline' data: blob: https: http:; img-src 'self' data: blob: https: http:; font-src 'self' data: blob: https: http:; connect-src *; frame-src 'self' data: blob: https: http:; media-src 'self' data: blob: https: http:; worker-src 'self' data: blob:; frame-ancestors 'self'";
 const ANALYSIS_ARTIFACT_THEMES = new Set(["instrument", "maritime", "carbon"]);
 const SAFE_ARTIFACT_COLOR = /^(?:#[\da-f]{3,8}|(?:rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch)\([\d.e%+\-/, ]{1,96}\)|Canvas|CanvasText)$/i;
+const ARTIFACT_CANVAS_STYLE_PROPERTIES = new Set(["background-color", "background-image", "color", "min-height", "color-scheme"]);
+const ARTIFACT_BODY_CANVAS_STYLE_PROPERTIES = new Set([...ARTIFACT_CANVAS_STYLE_PROPERTIES, "margin"]);
 
 type AnalysisRouteDeps = {
   readonly detect?: () => ReturnType<ReturnType<typeof createDefaultAgentCliDetector>["detect"]>;
@@ -95,7 +97,197 @@ function artifactDocument(html: string, requestUrl: string | undefined): string 
   const canvas = safeArtifactColor(query.get("canvas"), "Canvas");
   const foreground = safeArtifactColor(query.get("foreground"), "CanvasText");
   const canvasStyle = `background-color:${canvas}!important;background-image:none!important;color:${foreground}!important;min-height:100%!important;color-scheme:dark!important;`;
+  const documentTags = findArtifactDocumentTags(html);
+  if (documentTags) {
+    const htmlTag = withArtifactAttribute(withArtifactAttribute(documentTags.htmlTag.source, "data-theme", theme), "style", canvasStyle, ARTIFACT_CANVAS_STYLE_PROPERTIES);
+    const bodyTag = withArtifactAttribute(documentTags.bodyTag.source, "style", `${canvasStyle}margin:0!important;`, ARTIFACT_BODY_CANVAS_STYLE_PROPERTIES);
+    return `${html.slice(0, documentTags.htmlTag.start)}${htmlTag}${html.slice(documentTags.htmlTag.end, documentTags.bodyTag.start)}${bodyTag}${html.slice(documentTags.bodyTag.end)}`;
+  }
   return `<!doctype html><html data-theme="${theme}" style="${canvasStyle}"><head></head><body style="${canvasStyle}margin:0!important;">${html}</body></html>`;
+}
+
+type HtmlStartTag = { readonly start: number; readonly end: number; readonly source: string };
+
+function findArtifactDocumentTags(html: string): { readonly htmlTag: HtmlStartTag; readonly bodyTag: HtmlStartTag } | null {
+  let index = html.charCodeAt(0) === 0xfeff ? 1 : 0;
+  while (index < html.length) {
+    while (/\s/.test(html[index] ?? "")) index += 1;
+    if (html.startsWith("<!--", index)) {
+      const commentEnd = html.indexOf("-->", index + 4);
+      if (commentEnd < 0) return null;
+      index = commentEnd + 3;
+      continue;
+    }
+    if (html[index] === "<" && (html[index + 1] === "!" || html[index + 1] === "?")) {
+      const declarationEnd = findHtmlTagEnd(html, index + 2);
+      if (declarationEnd < 0) return null;
+      index = declarationEnd;
+      continue;
+    }
+    break;
+  }
+
+  const htmlTag = readHtmlStartTag(html, index);
+  if (!htmlTag || htmlTag.name !== "html") return null;
+  index = htmlTag.tag.end;
+  while (index < html.length) {
+    const tagStart = html.indexOf("<", index);
+    if (tagStart < 0) return null;
+    if (html.startsWith("<!--", tagStart)) {
+      const commentEnd = html.indexOf("-->", tagStart + 4);
+      if (commentEnd < 0) return null;
+      index = commentEnd + 3;
+      continue;
+    }
+    const tag = readHtmlStartTag(html, tagStart);
+    if (!tag) {
+      const tagEnd = findHtmlTagEnd(html, tagStart + 1);
+      if (tagEnd < 0) return null;
+      index = tagEnd;
+      continue;
+    }
+    if (tag.name === "body") return { htmlTag: htmlTag.tag, bodyTag: tag.tag };
+    index = tag.tag.end;
+    if (tag.name === "script" || tag.name === "style" || tag.name === "title" || tag.name === "textarea") {
+      const closeStart = html.toLowerCase().indexOf(`</${tag.name}`, index);
+      if (closeStart < 0) return null;
+      const closeEnd = findHtmlTagEnd(html, closeStart + tag.name.length + 2);
+      if (closeEnd < 0) return null;
+      index = closeEnd;
+    }
+  }
+  return null;
+}
+
+function readHtmlStartTag(html: string, start: number): { readonly name: string; readonly tag: HtmlStartTag } | null {
+  if (html[start] !== "<" || html[start + 1] === "/" || html[start + 1] === "!" || html[start + 1] === "?") return null;
+  let nameEnd = start + 1;
+  while (/[A-Za-z0-9:-]/.test(html[nameEnd] ?? "")) nameEnd += 1;
+  if (nameEnd === start + 1 || !/[\s/>]/.test(html[nameEnd] ?? "")) return null;
+  const end = findHtmlTagEnd(html, nameEnd);
+  if (end < 0) return null;
+  return { name: html.slice(start + 1, nameEnd).toLowerCase(), tag: { start, end, source: html.slice(start, end) } };
+}
+
+function findHtmlTagEnd(html: string, from: number): number {
+  let quote = "";
+  for (let index = from; index < html.length; index += 1) {
+    const character = html[index] ?? "";
+    if (quote) {
+      if (character === quote) quote = "";
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === ">") {
+      return index + 1;
+    }
+  }
+  return -1;
+}
+
+function withArtifactAttribute(tag: string, attributeName: "data-theme" | "style", value: string, replacedStyleProperties?: ReadonlySet<string>): string {
+  const replacements: Array<{ start: number; end: number; value: string }> = [];
+  let index = 1;
+  while (/[A-Za-z0-9:-]/.test(tag[index] ?? "")) index += 1;
+  while (index < tag.length - 1) {
+    while (/\s/.test(tag[index] ?? "")) index += 1;
+    if (tag[index] === "/" || tag[index] === ">") break;
+    const nameStart = index;
+    while (!/[\s=/>]/.test(tag[index] ?? ">")) index += 1;
+    const nameEnd = index;
+    while (/\s/.test(tag[index] ?? "")) index += 1;
+    let attributeEnd = nameEnd;
+    let currentValue = "";
+    if (tag[index] === "=") {
+      index += 1;
+      while (/\s/.test(tag[index] ?? "")) index += 1;
+      const quote = tag[index] === '"' || tag[index] === "'" ? tag[index++] : "";
+      const valueStart = index;
+      if (quote) {
+        while (index < tag.length - 1 && tag[index] !== quote) index += 1;
+        currentValue = tag.slice(valueStart, index);
+        if (tag[index] === quote) index += 1;
+      } else {
+        while (!/[\s>]/.test(tag[index] ?? ">")) index += 1;
+        currentValue = tag.slice(valueStart, index);
+      }
+      attributeEnd = index;
+    }
+    if (tag.slice(nameStart, nameEnd).toLowerCase() === attributeName) {
+      const preservedStyle = replacedStyleProperties ? withoutArtifactCanvasDeclarations(currentValue, replacedStyleProperties) : "";
+      const nextValue = replacedStyleProperties && preservedStyle.length > 0
+        ? `${preservedStyle}${preservedStyle.trimEnd().endsWith(";") ? "" : ";"}${value}`
+        : value;
+      replacements.push({ start: nameStart, end: attributeEnd, value: `${tag.slice(nameStart, nameEnd)}="${nextValue.replaceAll('"', "&quot;")}"` });
+    }
+  }
+  if (replacements.length === 0) {
+    const insertAt = tag.search(/\s*\/?\s*>$/);
+    return `${tag.slice(0, insertAt)} ${attributeName}="${value}"${tag.slice(insertAt)}`;
+  }
+  let result = tag;
+  for (const replacement of replacements.reverse()) {
+    result = `${result.slice(0, replacement.start)}${replacement.value}${result.slice(replacement.end)}`;
+  }
+  return result;
+}
+
+function withoutArtifactCanvasDeclarations(style: string, replacedProperties: ReadonlySet<string>): string {
+  let result = "";
+  let segmentStart = 0;
+  let quote = "";
+  let escaped = false;
+  let comment = false;
+  let nesting = 0;
+  for (let index = 0; index <= style.length; index += 1) {
+    const character = style[index] ?? "";
+    const next = style[index + 1] ?? "";
+    const encodedQuote = readHtmlEncodedQuote(style, index);
+    if (comment) {
+      if (character === "*" && next === "/") { comment = false; index += 1; }
+      continue;
+    }
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === quote) quote = "";
+      else if (encodedQuote?.quote === quote) { quote = ""; index += encodedQuote.length - 1; }
+      continue;
+    }
+    if (character === "/" && next === "*") { comment = true; index += 1; continue; }
+    if (character === '"' || character === "'") { quote = character; continue; }
+    if (encodedQuote) { quote = encodedQuote.quote; index += encodedQuote.length - 1; continue; }
+    if (character === "(" || character === "[" || character === "{") { nesting += 1; continue; }
+    if (character === ")" || character === "]" || character === "}") { nesting = Math.max(0, nesting - 1); continue; }
+    if ((character === ";" && nesting === 0) || index === style.length) {
+      const segmentEnd = character === ";" ? index + 1 : index;
+      const segment = style.slice(segmentStart, segmentEnd);
+      if (!replacedProperties.has(cssDeclarationName(segment))) result += segment;
+      segmentStart = segmentEnd;
+    }
+  }
+  return result;
+}
+
+function cssDeclarationName(declaration: string): string {
+  let comment = false;
+  for (let index = 0; index < declaration.length; index += 1) {
+    if (comment) {
+      if (declaration[index] === "*" && declaration[index + 1] === "/") { comment = false; index += 1; }
+    } else if (declaration[index] === "/" && declaration[index + 1] === "*") {
+      comment = true;
+      index += 1;
+    } else if (declaration[index] === ":") {
+      return declaration.slice(0, index).replace(/\/\*[\s\S]*?\*\//g, "").trim().toLowerCase();
+    }
+  }
+  return "";
+}
+
+function readHtmlEncodedQuote(value: string, index: number): { readonly quote: string; readonly length: number } | null {
+  const match = value.slice(index).match(/^&(?:quot|#0*34|#x0*22);/i);
+  if (match) return { quote: '"', length: match[0].length };
+  const apostropheMatch = value.slice(index).match(/^&(?:apos|#0*39|#x0*27);/i);
+  return apostropheMatch ? { quote: "'", length: apostropheMatch[0].length } : null;
 }
 
 function safeArtifactTheme(value: string | null): string {


### PR DESCRIPTION
## Summary
- Apply the active Console theme and canvas tokens to sanitized Session Analyst artifact documents.
- Keep the iframe root canvas host-owned even when generated CSS tries to repaint `html` or `body`.
- Preserve the existing CSP, sanitizer, size cap, and empty sandbox while adding cascade and rerender coverage.

## Type of Change
- [x] fix — bug fix

## Scope
- [x] `runtime/fleet-plugins/terminal/client/agent`

## Test Plan
- [x] `pnpm exec vitest run client/agent/analysis-artifact.test.ts`
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Isolated Console E2E with Claude Code and Codex CLI GPT-5.6-Terra/medium across Instrument, Maritime, and Carbon

## Changelog
- [x] Added `.changelog.d/pr-315.md`.
- [x] Uses the `fleet-plugin` / `Fixed` grouped format with adjacent English and Korean summaries.
- [x] `node scripts/compile-changelog-fragments.mjs --check`