### PR TITLE
feat(console): render agent responses as markdown

### DIFF
--- a/.changelog.d/pr-317.md
+++ b/.changelog.d/pr-317.md
@@ -1,0 +1,13 @@
+### fleet-console
+
+#### Changed
+
+- [fleet-console] Render Fleet Wiki Cowork assistant replies as compact Markdown with streamed updates, code blocks, and diagrams.
+  ko: Fleet Wiki Cowork 어시스턴트 응답을 스트리밍 업데이트, 코드 블록, 다이어그램을 지원하는 compact Markdown으로 렌더링합니다.
+
+### fleet-plugin
+
+#### Changed
+
+- [fleet-console] Render Session Analyst assistant replies as selectable compact Markdown while keeping user prompts plain.
+  ko: Session Analyst 어시스턴트 응답을 선택 가능한 compact Markdown으로 렌더링하면서 사용자 프롬프트는 일반 텍스트로 유지합니다.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -638,6 +638,9 @@ importers:
       '@fleet-console/font-picker':
         specifier: workspace:*
         version: link:../../fleet-console/font-picker
+      '@fleet-console/markdown':
+        specifier: workspace:*
+        version: link:../../fleet-console/markdown
       '@fleet-console/sdk':
         specifier: workspace:*
         version: link:../../fleet-console/sdk

--- a/runtime/fleet-console/core/client/src/codex/cowork-controller.ts
+++ b/runtime/fleet-console/core/client/src/codex/cowork-controller.ts
@@ -31,6 +31,7 @@ type RevisionOutcome = "idle" | "running" | "complete" | "stopped";
 
 const SETTINGS_KEY = "fleet.codex.cowork.settings";
 const BATCH_INSTRUCTION = "Revise the draft to address every saved annotation. Preserve unrelated content and summarize the changes.";
+const STREAM_RENDER_DELAY_MS = 32;
 
 /**
  * 리딩 뷰 인라인 Cowork 증강 — 별도 화면 전환 없이 엔트리 문서 위에서 동작한다.
@@ -46,6 +47,9 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
   let settings = readSettings();
   let annotations: AnnotationCard[] = [];
   let reply = "";
+  let renderedReplyText = "";
+  let renderedReplyHtml = "";
+  let revisionRenderTimer: number | null = null;
   let revisionInstruction = "";
   let revisionOutcome: RevisionOutcome = "idle";
   let revisionCollapsed = false;
@@ -162,19 +166,44 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
       ${hasContent ? `<div class="cowork-revision-content" aria-hidden="${revisionCollapsed}"><div class="cowork-revision-content-inner">
         ${revisionInstruction || reply ? `<div class="cowork-revision-body">
           ${revisionInstruction ? `<p class="cowork-revision-instruction">${escapeHtml(revisionInstruction)}</p>` : ""}
-          ${reply ? `<div class="cowork-revision-output-scroll"><p class="cowork-revision-output">${escapeHtml(reply)}</p></div>` : ""}
+          ${reply ? `<div class="cowork-revision-output-scroll"><div class="cowork-revision-output markdown-body">${renderedReplyHtml}</div></div>` : ""}
         </div>` : ""}
         ${running ? '<footer class="cowork-revision-status" role="status" aria-live="polite"><i aria-hidden="true"></i><span><strong>Writing revision</strong></span></footer>' : ""}
       </div></div>` : ""}
     </section>`;
   };
 
+  const cancelRevisionRender = () => {
+    if (revisionRenderTimer !== null) window.clearTimeout(revisionRenderTimer);
+    revisionRenderTimer = null;
+  };
+
+  const renderReplyMarkdown = () => {
+    if (renderedReplyText === reply) return;
+    renderedReplyText = reply;
+    renderedReplyHtml = reply ? renderMarkdown(reply).html : "";
+  };
+
   const patchRevisionOutput = () => {
+    renderReplyMarkdown();
     const output = dockZone.querySelector<HTMLElement>(".cowork-revision-output");
     if (!output) { renderDock(); return; }
-    output.textContent = reply;
+    output.innerHTML = renderedReplyHtml;
     const scroll = output.closest<HTMLElement>(".cowork-revision-output-scroll");
     if (scroll) scroll.scrollTop = scroll.scrollHeight;
+  };
+
+  const scheduleRevisionOutput = () => {
+    if (revisionRenderTimer !== null) return;
+    revisionRenderTimer = window.setTimeout(() => {
+      revisionRenderTimer = null;
+      if (!disposed) patchRevisionOutput();
+    }, STREAM_RENDER_DELAY_MS);
+  };
+
+  const flushRevisionOutput = () => {
+    cancelRevisionRender();
+    renderReplyMarkdown();
   };
 
   // 스트리밍 중 동일 마크업 재구축은 등장 애니메이션 재시작(깜빡임)을 유발하므로,
@@ -347,11 +376,12 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
       if (event.type === "transcript" && event.text && session?.state === "running") {
         reply = revisionOutcome === "running" ? reply + event.text : event.text;
         revisionOutcome = "running";
-        patchRevisionOutput();
+        scheduleRevisionOutput();
         return;
       }
       // 도구 호출 상세는 사용자에게 출력하지 않는다 — 러닝 상태는 일반 문구로만 표시.
       if (event.type === "done") {
+        flushRevisionOutput();
         // 제출 전에 취소된 지연 생성 요청은 뒤늦은 이벤트로 완료 처리하지 않는다.
         if (!promptAttempt?.cancelled || promptAttempt.submitted) {
           const completedObservedRun = wasRunning || awaitingResult || revisionOutcome === "stopped" || !!reply || !!revisionInstruction;
@@ -365,6 +395,7 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
         }
       }
       if (event.type === "error" || (event.type === "session" && wasRunning && session?.state !== "running")) {
+        flushRevisionOutput();
         revisionOutcome = "stopped";
         awaitingResult = false;
         annotations = annotations.map(card => card.status === "sent" ? { ...card, status: "pending" } : card);
@@ -414,7 +445,10 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
     promptAttempt = attempt;
     promptPending = true;
     annotations = outgoing.map(card => ({ ...card, status: "sent" }));
+    cancelRevisionRender();
     reply = "";
+    renderedReplyText = "";
+    renderedReplyHtml = "";
     revisionInstruction = localInstruction;
     revisionOutcome = "running";
     revisionCollapsed = false;
@@ -463,7 +497,10 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
     unsubscribe = null;
     lastEventId = 0;
     annotations = [];
+    cancelRevisionRender();
     reply = "";
+    renderedReplyText = "";
+    renderedReplyHtml = "";
     revisionInstruction = "";
     revisionOutcome = "idle";
     revisionCollapsed = false;
@@ -543,7 +580,15 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
   };
 
   const onClick = (event: MouseEvent) => {
-    const target = event.target instanceof Element ? event.target.closest<HTMLElement>("[data-cowork-action]") : null;
+    if (!(event.target instanceof Element)) return;
+    const copyButton = event.target.closest<HTMLElement>('[data-action="copy-code"]');
+    if (copyButton) {
+      const code = copyButton.closest("pre")?.getAttribute("data-code");
+      if (!code) return;
+      copyCodeToClipboard(copyButton, code);
+      return;
+    }
+    const target = event.target.closest<HTMLElement>("[data-cowork-action]");
     if (!target) return;
     const action = target.dataset.coworkAction;
     if (action === "comment") { composerOpen = true; renderAnchor(); }
@@ -641,6 +686,7 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
   return {
     destroy() {
       disposed = true;
+      cancelRevisionRender();
       unsubscribe?.();
       options.article.removeEventListener("mouseup", onMouseUp);
       options.article.removeEventListener("mousedown", onMouseDown);
@@ -663,6 +709,18 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
 
 function select(label: string, name: string, values: readonly string[], current: string): string {
   return `<label class="cowork-selector"><span>${label}</span><select name="${name}" ${values.length ? "" : "disabled"}>${values.map(value => `<option value="${escapeAttribute(value)}" ${value === current ? "selected" : ""}>${escapeHtml(value)}</option>`).join("")}</select></label>`;
+}
+function copyCodeToClipboard(button: HTMLElement, code: string): void {
+  const clipboard = navigator.clipboard;
+  if (!clipboard) return;
+  let write: Promise<void>;
+  try { write = clipboard.writeText(code); } catch { return; }
+  const original = button.textContent;
+  void write.then(() => {
+    if (!button.isConnected) return;
+    button.textContent = "Copied";
+    window.setTimeout(() => { if (button.isConnected) button.textContent = original; }, 1_200);
+  }).catch(() => undefined);
 }
 // 소스 라인이 아닌 "렌더된 문서" 관점의 diff — 변경 블록은 하이라이트, 삭제 블록은
 // 흐림+취소선으로 문서 흐름 안에 표시된다.

--- a/runtime/fleet-console/core/client/src/codex/cowork-controller.ts
+++ b/runtime/fleet-console/core/client/src/codex/cowork-controller.ts
@@ -557,6 +557,10 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
   };
 
   const onKeyDown = (event: KeyboardEvent) => {
+    if (event.target instanceof Element && event.target.closest(".cowork-revision-output")) {
+      event.stopPropagation();
+      return;
+    }
     if (event.key === "Escape") {
       if (selection || composerOpen) { selection = null; composerOpen = false; renderAnchor(); }
       else if (panelOpen || configOpen || confirmAction) { panelOpen = false; configOpen = false; confirmAction = null; renderDock(); }
@@ -646,6 +650,10 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
 
   const onInput = (event: Event) => {
     const target = event.target;
+    if (target instanceof Element && target.closest(".cowork-revision-output")) {
+      event.stopPropagation();
+      return;
+    }
     if (target instanceof HTMLInputElement && target.name === "prompt") { promptText = target.value; return; }
     if (target instanceof HTMLTextAreaElement && target.dataset.coworkComment) {
       const id = target.dataset.coworkComment;
@@ -655,6 +663,10 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
 
   const onChange = (event: Event) => {
     const target = event.target;
+    if (target instanceof Element && target.closest(".cowork-revision-output")) {
+      event.stopPropagation();
+      return;
+    }
     if (target instanceof HTMLSelectElement && ["cli", "model", "effort"].includes(target.name)) {
       // CLI가 바뀌면 이전 CLI의 model/effort는 무효 — 리셋해야 새 CLI의 기본 목록을 받는다.
       settings = target.name === "cli"

--- a/runtime/fleet-console/core/client/src/codex/cowork-controller.ts
+++ b/runtime/fleet-console/core/client/src/codex/cowork-controller.ts
@@ -588,6 +588,7 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
       copyCodeToClipboard(copyButton, code);
       return;
     }
+    if (event.target.closest(".cowork-revision-output")) return;
     const target = event.target.closest<HTMLElement>("[data-cowork-action]");
     if (!target) return;
     const action = target.dataset.coworkAction;

--- a/runtime/fleet-console/core/client/src/codex/cowork-controller.ts
+++ b/runtime/fleet-console/core/client/src/codex/cowork-controller.ts
@@ -581,6 +581,8 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
 
   const onClick = (event: MouseEvent) => {
     if (!(event.target instanceof Element)) return;
+    const revisionOutput = event.target.closest(".cowork-revision-output");
+    if (revisionOutput) event.stopPropagation();
     const copyButton = event.target.closest<HTMLElement>('[data-action="copy-code"]');
     if (copyButton) {
       const code = copyButton.closest("pre")?.getAttribute("data-code");
@@ -588,7 +590,7 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
       copyCodeToClipboard(copyButton, code);
       return;
     }
-    if (event.target.closest(".cowork-revision-output")) return;
+    if (revisionOutput) return;
     const target = event.target.closest<HTMLElement>("[data-cowork-action]");
     if (!target) return;
     const action = target.dataset.coworkAction;

--- a/runtime/fleet-console/core/client/src/codex/styles/components.css
+++ b/runtime/fleet-console/core/client/src/codex/styles/components.css
@@ -2471,7 +2471,38 @@ kbd {
 .cowork-revision-body { display: grid; gap: var(--space-3); padding: var(--space-3) var(--space-4); }
 .cowork-revision-instruction { justify-self: end; max-width: 82%; margin: 0; border-radius: 15px 15px 4px 15px; background: var(--ink-mid); color: var(--ink-pearl); padding: var(--space-2) var(--space-3); font-size: var(--font-size-xs); overflow-wrap: anywhere; }
 .cowork-revision-output-scroll { max-height: 220px; overflow: auto; }
-.cowork-revision-output { position: relative; min-height: 2.5rem; margin: 0; padding-left: calc(var(--space-4) + var(--space-2)); color: var(--ink-fog); font-size: var(--font-size-sm); line-height: 1.58; white-space: pre-wrap; overflow-wrap: anywhere; }
+.cowork-revision-output.markdown-body {
+  --font-size-2xs: 9px;
+  --font-size-xs: 10px;
+  --font-size-sm: 11px;
+  --font-size-lg: 12px;
+  --font-size-code: 11.5px;
+  --font-size-body: 12.5px;
+  --font-size-title-md: 15px;
+  --font-size-display-md: 17px;
+  --font-size-display-lg: 18px;
+  position: relative;
+  min-height: 2.5rem;
+  max-inline-size: none;
+  margin: 0;
+  padding-left: calc(var(--space-4) + var(--space-2));
+  color: var(--ink-fog);
+  line-height: 1.58;
+  overflow-wrap: anywhere;
+}
+.cowork-revision-output.markdown-body > * + * { margin-top: var(--space-3); }
+.cowork-revision-output.markdown-body > :first-child { margin-top: 0; }
+.cowork-revision-output.markdown-body > :last-child { margin-bottom: 0; }
+.cowork-revision-output.markdown-body :is(h1, h2, h3, h4) { margin-top: var(--space-4); scroll-margin-top: 0; }
+.cowork-revision-output.markdown-body h2 { padding-left: var(--space-3); }
+.cowork-revision-output.markdown-body p { margin-bottom: var(--space-3); }
+.cowork-revision-output.markdown-body :is(ul, ol) { margin-bottom: var(--space-3); padding-left: var(--space-5); }
+.cowork-revision-output.markdown-body li + li { margin-top: var(--space-1); }
+.cowork-revision-output.markdown-body table { margin-block: var(--space-3); font-size: 10px; }
+.cowork-revision-output.markdown-body table :is(th, td) { padding: var(--space-2) var(--space-3); }
+.cowork-revision-output.markdown-body :is(blockquote, .code-block, .diagram-block) { margin-block: var(--space-3); }
+.cowork-revision-output.markdown-body blockquote { padding: var(--space-2) var(--space-3); }
+.cowork-revision-output.markdown-body .code-block code { padding: var(--space-3); }
 .cowork-revision-output::before { content: "✳"; position: absolute; left: 1px; top: 1px; color: var(--aurora); }
 .cowork-revision-status { display: flex; align-items: center; gap: var(--space-2); border-top: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--aurora) 5%, var(--ink-deep)); padding: var(--space-2) var(--space-3); }
 .cowork-revision-status i { position: relative; width: 16px; height: 16px; flex: none; border: 1px solid var(--aurora); border-radius: 50%; animation: cowork-revision-pulse 1.4s var(--ease-glide) infinite; }

--- a/runtime/fleet-console/tests/codex-cowork-ui.test.ts
+++ b/runtime/fleet-console/tests/codex-cowork-ui.test.ts
@@ -541,6 +541,13 @@ describe("Cowork inline copilot", () => {
     vi.stubGlobal("navigator", { clipboard: { writeText } });
     const onApplied = vi.fn();
     const { article, body } = host();
+    const reader = document.createElement("div");
+    article.replaceWith(reader);
+    reader.append(article);
+    const ancestorRouter = vi.fn((event: MouseEvent) => event.target instanceof Element
+      ? event.target.closest<HTMLElement>("[data-drydock-action]")?.dataset.drydockAction
+      : undefined);
+    reader.addEventListener("click", ancestorRouter);
     const controller = mountCoworkInline({ theaterId: "theater", entryId: "entry", title: "Entry", article, body, onApplied });
     await vi.waitFor(() => expect(article.querySelector(".cowork-chip")?.textContent).toContain("1"));
 
@@ -556,6 +563,8 @@ describe("Cowork inline copilot", () => {
       '<button type="button" data-cowork-action="discard-arm">Arm discard</button>',
       '<button type="button" data-cowork-action="apply-confirm">Apply directly</button>',
       '<button type="button" data-cowork-action="discard-confirm">Discard directly</button>',
+      '<button type="button" data-drydock-action="approve">Approve through reader</button>',
+      '<a href="#reader-link">Open safe link</a>',
       "```ts",
       "const safeCopy = true;",
       "```",
@@ -565,10 +574,15 @@ describe("Cowork inline copilot", () => {
     listeners.get("done")?.(new MessageEvent("done", { data: JSON.stringify({ type: "done" }), lastEventId: "5" }));
 
     const output = article.querySelector<HTMLElement>(".cowork-revision-output")!;
+    ancestorRouter.mockClear();
     for (const action of ["apply-arm", "discard-arm", "apply-confirm", "discard-confirm"]) {
       output.querySelector<HTMLButtonElement>(`[data-cowork-action="${action}"]`)!.click();
       expect(article.querySelector(".cowork-review.is-confirm")).toBeNull();
     }
+    output.querySelector<HTMLButtonElement>('[data-drydock-action="approve"]')!.click();
+    const link = output.querySelector<HTMLAnchorElement>('a[href="#reader-link"]')!;
+    expect(link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }))).toBe(true);
+    expect(ancestorRouter).not.toHaveBeenCalled();
     await Promise.resolve();
     const requestUrls = fetchMock.mock.calls.map(call => String(call[0]));
     expect(requestUrls.some(url => url.endsWith("/apply"))).toBe(false);
@@ -580,8 +594,9 @@ describe("Cowork inline copilot", () => {
     copy.click();
     await vi.waitFor(() => expect(copy.textContent).toBe("Copied"));
     expect(writeText).toHaveBeenCalledWith(code);
+    expect(ancestorRouter).not.toHaveBeenCalled();
 
     controller.destroy();
-    article.remove();
+    reader.remove();
   });
 });

--- a/runtime/fleet-console/tests/codex-cowork-ui.test.ts
+++ b/runtime/fleet-console/tests/codex-cowork-ui.test.ts
@@ -525,4 +525,63 @@ describe("Cowork inline copilot", () => {
     controller.destroy();
     article.remove();
   });
+
+  it("isolates Markdown output from Cowork actions while preserving code copy", async () => {
+    const listeners = new Map<string, EventListener>();
+    class FakeEventSource { addEventListener(type: string, listener: EventListener) { listeners.set(type, listener); } close() {} }
+    vi.stubGlobal("EventSource", FakeEventSource);
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/cowork/entries/")) return new Response(JSON.stringify(sessionDto()));
+      if (url.includes("/options")) return new Response(JSON.stringify({ clis: ["codex"], models: ["gpt"], efforts: ["medium"] }));
+      return new Response(JSON.stringify(sessionDto()));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const writeText = vi.fn(async () => undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const onApplied = vi.fn();
+    const { article, body } = host();
+    const controller = mountCoworkInline({ theaterId: "theater", entryId: "entry", title: "Entry", article, body, onApplied });
+    await vi.waitFor(() => expect(article.querySelector(".cowork-chip")?.textContent).toContain("1"));
+
+    const input = article.querySelector<HTMLInputElement>(".cowork-dock-input")!;
+    input.value = "Review hostile output";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    article.querySelector<HTMLElement>('[data-cowork-action="send"]')!.click();
+    await vi.waitFor(() => expect(fetchMock.mock.calls.map(call => String(call[0])).some(url => url.endsWith("/prompt"))).toBe(true));
+
+    listeners.get("session")?.(new MessageEvent("session", { data: JSON.stringify({ type: "session", session: sessionDto({ state: "running" }) }), lastEventId: "3" }));
+    const hostileMarkdown = [
+      '<button type="button" data-cowork-action="apply-arm">Arm apply</button>',
+      '<button type="button" data-cowork-action="discard-arm">Arm discard</button>',
+      '<button type="button" data-cowork-action="apply-confirm">Apply directly</button>',
+      '<button type="button" data-cowork-action="discard-confirm">Discard directly</button>',
+      "```ts",
+      "const safeCopy = true;",
+      "```",
+    ].join("\n\n");
+    listeners.get("transcript")?.(new MessageEvent("transcript", { data: JSON.stringify({ type: "transcript", text: hostileMarkdown }), lastEventId: "4" }));
+    await vi.waitFor(() => expect(article.querySelectorAll(".cowork-revision-output [data-cowork-action]")).toHaveLength(4));
+    listeners.get("done")?.(new MessageEvent("done", { data: JSON.stringify({ type: "done" }), lastEventId: "5" }));
+
+    const output = article.querySelector<HTMLElement>(".cowork-revision-output")!;
+    for (const action of ["apply-arm", "discard-arm", "apply-confirm", "discard-confirm"]) {
+      output.querySelector<HTMLButtonElement>(`[data-cowork-action="${action}"]`)!.click();
+      expect(article.querySelector(".cowork-review.is-confirm")).toBeNull();
+    }
+    await Promise.resolve();
+    const requestUrls = fetchMock.mock.calls.map(call => String(call[0]));
+    expect(requestUrls.some(url => url.endsWith("/apply"))).toBe(false);
+    expect(requestUrls.some(url => url.endsWith("/close"))).toBe(false);
+    expect(onApplied).not.toHaveBeenCalled();
+
+    const copy = output.querySelector<HTMLButtonElement>('[data-action="copy-code"]')!;
+    const code = copy.closest("pre")?.getAttribute("data-code");
+    copy.click();
+    await vi.waitFor(() => expect(copy.textContent).toBe("Copied"));
+    expect(writeText).toHaveBeenCalledWith(code);
+
+    controller.destroy();
+    article.remove();
+  });
 });

--- a/runtime/fleet-console/tests/codex-cowork-ui.test.ts
+++ b/runtime/fleet-console/tests/codex-cowork-ui.test.ts
@@ -544,10 +544,10 @@ describe("Cowork inline copilot", () => {
     const reader = document.createElement("div");
     article.replaceWith(reader);
     reader.append(article);
-    const ancestorRouter = vi.fn((event: MouseEvent) => event.target instanceof Element
+    const ancestorRouter = vi.fn((event: Event) => event.target instanceof Element
       ? event.target.closest<HTMLElement>("[data-drydock-action]")?.dataset.drydockAction
       : undefined);
-    reader.addEventListener("click", ancestorRouter);
+    for (const type of ["click", "input", "change", "keydown"]) reader.addEventListener(type, ancestorRouter);
     const controller = mountCoworkInline({ theaterId: "theater", entryId: "entry", title: "Entry", article, body, onApplied });
     await vi.waitFor(() => expect(article.querySelector(".cowork-chip")?.textContent).toContain("1"));
 
@@ -564,6 +564,8 @@ describe("Cowork inline copilot", () => {
       '<button type="button" data-cowork-action="apply-confirm">Apply directly</button>',
       '<button type="button" data-cowork-action="discard-confirm">Discard directly</button>',
       '<button type="button" data-drydock-action="approve">Approve through reader</button>',
+      '<input name="prompt" value="Injected prompt" data-drydock-action="prompt">',
+      '<select name="cli" data-drydock-action="settings"><option value="hostile" selected>Hostile CLI</option></select>',
       '<a href="#reader-link">Open safe link</a>',
       "```ts",
       "const safeCopy = true;",
@@ -571,9 +573,26 @@ describe("Cowork inline copilot", () => {
     ].join("\n\n");
     listeners.get("transcript")?.(new MessageEvent("transcript", { data: JSON.stringify({ type: "transcript", text: hostileMarkdown }), lastEventId: "4" }));
     await vi.waitFor(() => expect(article.querySelectorAll(".cowork-revision-output [data-cowork-action]")).toHaveLength(4));
-    listeners.get("done")?.(new MessageEvent("done", { data: JSON.stringify({ type: "done" }), lastEventId: "5" }));
+    listeners.get("done")?.(new MessageEvent("done", { data: JSON.stringify({ type: "done", session: sessionDto({ state: "idle" }) }), lastEventId: "5" }));
 
-    const output = article.querySelector<HTMLElement>(".cowork-revision-output")!;
+    let output = article.querySelector<HTMLElement>(".cowork-revision-output")!;
+    ancestorRouter.mockClear();
+    const requestCountBeforeHostileEvents = fetchMock.mock.calls.length;
+    const settingsBeforeHostileEvents = localStorage.getItem("fleet.codex.cowork.settings");
+    const hostilePrompt = output.querySelector<HTMLInputElement>('input[name="prompt"]')!;
+    hostilePrompt.value = "Mutate and submit";
+    expect(hostilePrompt.dispatchEvent(new Event("input", { bubbles: true, cancelable: true }))).toBe(true);
+    const hostileCli = output.querySelector<HTMLSelectElement>('select[name="cli"]')!;
+    expect(hostileCli.dispatchEvent(new Event("change", { bubbles: true, cancelable: true }))).toBe(true);
+    expect(hostilePrompt.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }))).toBe(true);
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    expect(fetchMock.mock.calls).toHaveLength(requestCountBeforeHostileEvents);
+    expect(localStorage.getItem("fleet.codex.cowork.settings")).toBe(settingsBeforeHostileEvents);
+    expect(ancestorRouter).not.toHaveBeenCalled();
+
+    article.querySelector<HTMLButtonElement>('[data-cowork-action="toggle-panel"]')!.click();
+    expect(article.querySelector<HTMLInputElement>(".cowork-dock-input")?.value).toBe("");
+    output = article.querySelector<HTMLElement>(".cowork-revision-output")!;
     ancestorRouter.mockClear();
     for (const action of ["apply-arm", "discard-arm", "apply-confirm", "discard-confirm"]) {
       output.querySelector<HTMLButtonElement>(`[data-cowork-action="${action}"]`)!.click();

--- a/runtime/fleet-console/tests/codex-cowork-ui.test.ts
+++ b/runtime/fleet-console/tests/codex-cowork-ui.test.ts
@@ -1,10 +1,26 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { diffDraftLines } from "../core/client/src/codex/cowork-diff.js";
 import { mountCoworkInline } from "../core/client/src/codex/cowork-controller.js";
 import { renderMarkdown } from "@fleet-console/markdown/core";
 
-afterEach(() => vi.unstubAllGlobals());
+const { renderMarkdownSpy } = vi.hoisted(() => ({ renderMarkdownSpy: vi.fn() }));
+vi.mock("@fleet-console/markdown/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@fleet-console/markdown/core")>();
+  return {
+    ...actual,
+    renderMarkdown: (...args: Parameters<typeof actual.renderMarkdown>) => {
+      renderMarkdownSpy(...args);
+      return actual.renderMarkdown(...args);
+    },
+  };
+});
+
+beforeEach(() => renderMarkdownSpy.mockClear());
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
 
 const DRAFT = "---\nid: entry\ntitle: Entry\ntags: [\"test\"]\ncreated: now\nupdated: now\nversion: 1\n---\n# Entry\n\nReadable text.";
 const BASE_DRAFT = "---\nid: entry\ntitle: Entry\ntags: [\"test\"]\ncreated: now\nupdated: now\nversion: 1\n---\n# Entry\n\nOriginal text.";
@@ -392,7 +408,7 @@ describe("Cowork inline copilot", () => {
     article.remove();
   });
 
-  it("keeps an escaped live revision stream visible through completion", async () => {
+  it("coalesces a sanitized Markdown revision stream and reports code copy truthfully through completion", async () => {
     const listeners = new Map<string, EventListener>();
     class FakeEventSource { addEventListener(type: string, listener: EventListener) { listeners.set(type, listener); } close() {} }
     vi.stubGlobal("EventSource", FakeEventSource);
@@ -403,6 +419,9 @@ describe("Cowork inline copilot", () => {
       return new Response(JSON.stringify(sessionDto()));
     });
     vi.stubGlobal("fetch", fetchMock);
+    let resolveCopy!: () => void;
+    const writeText = vi.fn(() => new Promise<void>((resolve) => { resolveCopy = resolve; }));
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
     const { article, body } = host();
 
     const controller = mountCoworkInline({ theaterId: "theater", entryId: "entry", title: "Entry", article, body, onApplied: vi.fn() });
@@ -416,7 +435,9 @@ describe("Cowork inline copilot", () => {
     await vi.waitFor(() => expect(fetchMock.mock.calls.map(call => String(call[0])).some(url => url.endsWith("/prompt"))).toBe(true));
 
     listeners.get("session")?.(new MessageEvent("session", { data: JSON.stringify({ type: "session", session: sessionDto({ state: "running" }) }), lastEventId: "3" }));
-    listeners.get("transcript")?.(new MessageEvent("transcript", { data: JSON.stringify({ type: "transcript", text: "<img src=x onerror=alert(1)>Visible & safe" }), lastEventId: "4" }));
+    listeners.get("transcript")?.(new MessageEvent("transcript", { data: JSON.stringify({ type: "transcript", text: "<img src=x onerror=alert(1)>\n\n**Visible & safe**\n\n```ts\nconst answer = 42;\n```\n\n```js\nconst missing = true;\n```\n\n```sh\nfalse\n```" }), lastEventId: "4" }));
+
+    await vi.waitFor(() => expect(article.querySelector(".cowork-revision-output strong")?.textContent).toBe("Visible & safe"));
 
     const stream = article.querySelector<HTMLElement>(".cowork-revision-stream")!;
     const output = stream.querySelector<HTMLElement>(".cowork-revision-output")!;
@@ -431,8 +452,28 @@ describe("Cowork inline copilot", () => {
     expect(stream.querySelector(".cowork-revision-instruction strong")).toBeNull();
     expect(outputScroll).not.toBeNull();
     expect(outputScroll?.contains(instruction)).toBe(false);
-    expect(output.textContent).toBe("<img src=x onerror=alert(1)>Visible & safe");
-    expect(output.querySelector("img")).toBeNull();
+    expect(output.classList.contains("markdown-body")).toBe(true);
+    expect(output.querySelector("strong")?.textContent).toBe("Visible & safe");
+    expect(output.querySelector("img")?.getAttribute("src")).toBe("x");
+    expect(output.querySelector("img")?.hasAttribute("onerror")).toBe(false);
+    const responseRenderCount = () => renderMarkdownSpy.mock.calls.filter(([text]) => String(text).includes("Visible & safe")).length;
+    expect(responseRenderCount()).toBe(1);
+    const [copy, missing, rejecting] = [...output.querySelectorAll<HTMLButtonElement>('[data-action="copy-code"]')];
+    const code = copy!.closest("pre")?.getAttribute("data-code");
+    copy!.click();
+    expect(writeText).toHaveBeenCalledWith(code);
+    expect(copy!.textContent).toBe("Copy");
+    resolveCopy();
+    await vi.waitFor(() => expect(copy!.textContent).toBe("Copied"));
+
+    vi.stubGlobal("navigator", {});
+    missing!.click();
+    expect(missing!.textContent).toBe("Copy");
+
+    vi.stubGlobal("navigator", { clipboard: { writeText: vi.fn(() => Promise.reject(new Error("denied"))) } });
+    rejecting!.click();
+    await Promise.resolve();
+    expect(rejecting!.textContent).toBe("Copy");
     expect(body.classList.contains("is-cowork-running")).toBe(true);
     expect(article.querySelectorAll(".cowork-stop")).toHaveLength(1);
     expect(article.querySelectorAll(".cowork-send")).toHaveLength(1);
@@ -454,22 +495,29 @@ describe("Cowork inline copilot", () => {
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
     expect(stream.querySelector(".cowork-revision-content")?.getAttribute("aria-hidden")).toBe("false");
 
-    listeners.get("transcript")?.(new MessageEvent("transcript", { data: JSON.stringify({ type: "transcript", text: " continuation" }), lastEventId: "5" }));
+    for (let index = 0; index < 12; index += 1) {
+      listeners.get("transcript")?.(new MessageEvent("transcript", { data: JSON.stringify({ type: "transcript", text: ` part-${index}` }), lastEventId: String(5 + index) }));
+    }
     expect(article.querySelector(".cowork-revision-stream")).toBe(stream);
-    expect(output.textContent).toBe("<img src=x onerror=alert(1)>Visible & safe continuation");
+    expect(output.textContent).toContain("Visible & safe");
+    expect(responseRenderCount()).toBe(1);
 
-    listeners.get("tool")?.(new MessageEvent("tool", { data: JSON.stringify({ type: "tool", text: "wiki_draft_read · running" }), lastEventId: "6" }));
+    listeners.get("tool")?.(new MessageEvent("tool", { data: JSON.stringify({ type: "tool", text: "wiki_draft_read · running" }), lastEventId: "17" }));
     expect(article.querySelector(".cowork-revision-stream")?.textContent).not.toContain("wiki_draft_read");
 
     article.querySelector<HTMLButtonElement>('[data-cowork-action="toggle-revision"]')!.click();
-    listeners.get("done")?.(new MessageEvent("done", { data: JSON.stringify({ type: "done" }), lastEventId: "7" }));
+    listeners.get("done")?.(new MessageEvent("done", { data: JSON.stringify({ type: "done" }), lastEventId: "18" }));
     const completed = article.querySelector<HTMLElement>(".cowork-revision-stream")!;
     expect(completed.classList.contains("is-complete")).toBe(true);
     expect(completed.classList.contains("is-collapsed")).toBe(true);
     expect(completed.textContent).toContain("Revision complete");
     expect(completed.querySelector(".cowork-revision-status")).toBeNull();
     expect(completed.querySelector('[data-cowork-action="toggle-revision"]')?.getAttribute("aria-expanded")).toBe("false");
-    expect(completed.querySelector(".cowork-revision-output")?.textContent).toBe("<img src=x onerror=alert(1)>Visible & safe continuation");
+    expect(completed.querySelector(".cowork-revision-output strong")?.textContent).toBe("Visible & safe");
+    expect(completed.querySelector(".cowork-revision-output")?.textContent).toContain("part-11");
+    expect(responseRenderCount()).toBe(2);
+    await new Promise((resolve) => window.setTimeout(resolve, 60));
+    expect(responseRenderCount()).toBe(2);
     expect(body.classList.contains("is-cowork-running")).toBe(false);
     expect(article.querySelector(".cowork-stop")).toBeNull();
     expect(article.querySelector('[data-cowork-action="send"]')).not.toBeNull();

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
@@ -2,8 +2,25 @@
 
 import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { initialAnalysisState, type AnalysisState } from "./analysis-state.js";
+
+const { installDiagramHydratorSpy, renderMarkdownSpy } = vi.hoisted(() => ({
+  installDiagramHydratorSpy: vi.fn(),
+  renderMarkdownSpy: vi.fn(),
+}));
+
+vi.mock("@fleet-console/markdown/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@fleet-console/markdown/core")>();
+  return {
+    ...actual,
+    renderMarkdown: (...args: Parameters<typeof actual.renderMarkdown>) => {
+      renderMarkdownSpy(...args);
+      return actual.renderMarkdown(...args);
+    },
+  };
+});
+vi.mock("@fleet-console/markdown/mermaid", () => ({ installDiagramHydrator: installDiagramHydratorSpy }));
 
 let storeState: AnalysisState;
 const send = vi.fn(async () => undefined);
@@ -22,6 +39,13 @@ describe("Session Analyst Evidence Pulse", () => {
     send.mockClear();
     stop.mockClear();
     reset.mockClear();
+    renderMarkdownSpy.mockClear();
+    installDiagramHydratorSpy.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
   it("renders the initial settings and prompt as one compact composer row", () => {
@@ -48,7 +72,7 @@ describe("Session Analyst Evidence Pulse", () => {
     container.remove();
   });
 
-  it("dims inactive surfaces while keeping one Stop and event-truthful tool activity visible", () => {
+  it("keeps the transcript fully visible with one Stop and event-truthful tool activity", () => {
     storeState = {
       ...initialAnalysisState,
       catalog,
@@ -68,7 +92,7 @@ describe("Session Analyst Evidence Pulse", () => {
     expect(container.querySelector(".session-analyst__panel-state")?.textContent).toBe("Analyzing");
     expect(container.querySelector(".session-analyst__pulse")?.textContent).toContain("Using wiki_read");
     expect(container.querySelector(".session-analyst__pulse")?.textContent).toContain("Tool status: running");
-    expect(container.querySelector(".session-analyst__chat ol")?.classList.contains("is-dimmed")).toBe(true);
+    expect(container.querySelector(".session-analyst__chat ol")?.classList.contains("is-dimmed")).toBe(false);
     expect(container.querySelector("textarea")?.disabled).toBe(true);
     expect(container.querySelectorAll("select")).toHaveLength(0);
     expect(container.querySelectorAll(".session-analyst__stop")).toHaveLength(1);
@@ -77,6 +101,136 @@ describe("Session Analyst Evidence Pulse", () => {
     expect(container.querySelector(".session-analyst__stop")?.textContent).toBe("");
     expect((container.querySelector('[aria-label="Reset Session Analyst"]') as HTMLButtonElement).disabled).toBe(false);
     expect(container.textContent).not.toContain("private chain of thought");
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders only analyst responses as sanitized compact Markdown and reports code copy truthfully", async () => {
+    let resolveCopy!: () => void;
+    const writeText = vi.fn(() => new Promise<void>((resolve) => { resolveCopy = resolve; }));
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    storeState = {
+      ...initialAnalysisState,
+      started: true,
+      phase: "complete",
+      entries: [
+        { role: "user", text: "Keep **this prompt** <em>verbatim</em>" },
+        { role: "analyst", text: "**Visible answer** <img src=x onerror=alert(1)>\n\n```ts\nconst answer = 42;\n```\n\n```js\nconst missing = true;\n```\n\n```sh\nfalse\n```" },
+      ],
+    };
+    const { container, root } = renderPanel();
+    const user = container.querySelector<HTMLElement>(".session-analyst__message--user")!;
+    const response = container.querySelector<HTMLElement>(".session-analyst__response.markdown-body")!;
+
+    expect(user.textContent).toBe("Keep **this prompt** <em>verbatim</em>");
+    expect(user.querySelector("strong, em")).toBeNull();
+    expect(response.querySelector("strong")?.textContent).toBe("Visible answer");
+    expect(response.querySelector("img")?.getAttribute("src")).toBe("x");
+    expect(response.querySelector("img")?.hasAttribute("onerror")).toBe(false);
+
+    const [copy, missing, rejecting] = [...response.querySelectorAll<HTMLButtonElement>('[data-action="copy-code"]')];
+    const code = copy!.closest("pre")?.getAttribute("data-code");
+    act(() => copy!.click());
+    expect(writeText).toHaveBeenCalledWith(code);
+    expect(copy!.textContent).toBe("Copy");
+    await act(async () => { resolveCopy(); await Promise.resolve(); });
+    expect(copy!.textContent).toBe("Copied");
+
+    vi.stubGlobal("navigator", {});
+    act(() => missing!.click());
+    expect(missing!.textContent).toBe("Copy");
+
+    vi.stubGlobal("navigator", { clipboard: { writeText: vi.fn(() => Promise.reject(new Error("denied"))) } });
+    act(() => rejecting!.click());
+    await act(async () => { await Promise.resolve(); });
+    expect(rejecting!.textContent).toBe("Copy");
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("keeps ordered and nested Markdown lists semantic inside the transcript root", () => {
+    storeState = {
+      ...initialAnalysisState,
+      started: true,
+      phase: "complete",
+      entries: [{ role: "analyst", text: "1. First\n2. Second\n\n   - Nested detail" }],
+    };
+    const { container, root } = renderPanel();
+    const transcript = container.querySelector<HTMLOListElement>(".session-analyst__chat > ol.session-analyst__transcript")!;
+    const response = transcript.querySelector<HTMLElement>(".session-analyst__response")!;
+    const ordered = response.querySelector<HTMLOListElement>("ol")!;
+
+    expect(transcript).not.toBe(ordered);
+    expect(ordered.children).toHaveLength(2);
+    expect(ordered.querySelector("ul li")?.textContent).toBe("Nested detail");
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("coalesces rapid Markdown chunks, commits the latest final output, and memoizes completion", () => {
+    vi.useFakeTimers();
+    storeState = {
+      ...initialAnalysisState,
+      started: true,
+      busy: true,
+      phase: "writing",
+      latestActivity: { kind: "writing" },
+      entries: [
+        { role: "user", text: "Stream this" },
+        { role: "analyst", text: "Rapid start" },
+      ],
+    };
+    const { container, root } = renderPanel();
+    const responseRenderCount = () => renderMarkdownSpy.mock.calls.filter(([text]) => String(text).startsWith("Rapid start")).length;
+    expect(responseRenderCount()).toBe(1);
+
+    for (let index = 0; index < 20; index += 1) {
+      storeState = { ...storeState, entries: [storeState.entries[0]!, { role: "analyst", text: `Rapid start chunk-${index}` }] };
+      act(() => root.render(createElement(AnalystChatPanel, { context: { operationId: "chat-test" } as never })));
+    }
+    expect(responseRenderCount()).toBe(1);
+    act(() => vi.advanceTimersByTime(32));
+    expect(responseRenderCount()).toBe(2);
+    expect(container.querySelector(".session-analyst__response")?.textContent).toContain("chunk-19");
+
+    for (let index = 20; index < 28; index += 1) {
+      storeState = { ...storeState, entries: [storeState.entries[0]!, { role: "analyst", text: `Rapid start chunk-${index}` }] };
+      act(() => root.render(createElement(AnalystChatPanel, { context: { operationId: "chat-test" } as never })));
+    }
+    const finalText = "Rapid start chunk-27\n\n**Final output**";
+    storeState = { ...storeState, busy: false, phase: "complete", entries: [storeState.entries[0]!, { role: "analyst", text: finalText }] };
+    act(() => root.render(createElement(AnalystChatPanel, { context: { operationId: "chat-test" } as never })));
+    expect(responseRenderCount()).toBe(3);
+    expect(container.querySelector(".session-analyst__response strong")?.textContent).toBe("Final output");
+
+    act(() => vi.advanceTimersByTime(100));
+    storeState = { ...storeState, latestActivity: { kind: "reasoning" }, runEndedAt: 123 };
+    act(() => root.render(createElement(AnalystChatPanel, { context: { operationId: "chat-test" } as never })));
+    expect(responseRenderCount()).toBe(3);
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("installs the public diagram hydrator on the transcript root", () => {
+    installDiagramHydratorSpy.mockImplementation((root: ParentNode) => {
+      for (const block of root.querySelectorAll<HTMLElement>('[data-diagram-state="pending"]')) block.dataset.diagramState = "rendered";
+    });
+    storeState = {
+      ...initialAnalysisState,
+      started: true,
+      phase: "complete",
+      entries: [{ role: "analyst", text: "```mermaid\ngraph TD\n  A --> B\n```" }],
+    };
+    const { container, root } = renderPanel();
+    const chat = container.querySelector<HTMLElement>(".session-analyst__chat")!;
+    const diagram = chat.querySelector<HTMLElement>(".diagram-block")!;
+
+    expect(installDiagramHydratorSpy).toHaveBeenCalledWith(chat);
+    expect(diagram.dataset.diagramState).toBe("rendered");
 
     act(() => root.unmount());
     container.remove();

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
@@ -1,5 +1,8 @@
 import { React } from "@fleet-console/sdk/plugin/browser";
 import type { OperationRenderContext } from "@fleet-console/sdk/plugin";
+import { renderMarkdown } from "@fleet-console/markdown/core";
+import { installDiagramHydrator } from "@fleet-console/markdown/mermaid";
+import "@fleet-console/markdown/styles.css";
 
 import type { AnalysisActivity, AnalysisState } from "./analysis-state.js";
 import { useAnalysisStore } from "./analysis-store.js";
@@ -10,6 +13,7 @@ const SUGGESTIONS = [
   { icon: "▲", tone: "coral", text: "Flag anything I should review" },
   { icon: "≡", tone: "brass", text: "Draft a handoff brief" },
 ] as const;
+const STREAM_RENDER_DELAY_MS = 32;
 
 export function AnalystChatPanel({ context }: { readonly context: OperationRenderContext }) {
   const { state, dispatch, send, stop, reset } = useAnalysisStore(context);
@@ -28,12 +32,23 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
     if (!chat || !hasInteracted) return;
     chat.scrollTop = chat.scrollHeight;
   }, [hasInteracted, latestEntry?.text, state.entries.length, state.latestActivity, state.phase]);
+  React.useEffect(() => {
+    const chat = chatRef.current;
+    if (chat) installDiagramHydrator(chat);
+  }, []);
   const submit = async (text: string) => {
     const trimmed = text.trim();
     if (!trimmed || state.busy) return;
     setDraft("");
     await send(trimmed);
   };
+  const handleTranscriptClick = React.useCallback((event: React.MouseEvent<HTMLOListElement>) => {
+    const button = (event.target as HTMLElement).closest<HTMLElement>('[data-action="copy-code"]');
+    if (!button) return;
+    const code = button.closest("pre")?.getAttribute("data-code");
+    if (!code) return;
+    copyCodeToClipboard(button, code);
+  }, []);
 
   return (
     <section className={`session-analyst__chat-pane ${hasInteracted ? "has-interacted" : "is-initial"}`} aria-label="Session Analyst chat" data-phase={state.phase}>
@@ -41,9 +56,13 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
       <div className="session-analyst__workspace">
         <section ref={chatRef} className="session-analyst__chat" aria-live="polite" aria-busy={state.busy}>
           {hasInteracted ? (
-            <ol className={state.busy ? "is-dimmed" : undefined}>
+            <ol className="session-analyst__transcript" onClick={handleTranscriptClick}>
               {state.entries.map((entry, index) => (
-                <li className={`session-analyst__message session-analyst__message--${entry.role}`} key={`${entry.role}-${index}`}>{entry.text}</li>
+                <li className={`session-analyst__message session-analyst__message--${entry.role}`} key={`${entry.role}-${index}`}>
+                  {entry.role === "analyst"
+                    ? <AnalystMarkdownResponse text={entry.text} streaming={state.busy && index === state.entries.length - 1} />
+                    : entry.text}
+                </li>
               ))}
             </ol>
           ) : (
@@ -100,6 +119,51 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
       </div>
     </section>
   );
+}
+
+const AnalystMarkdownResponse = React.memo(function AnalystMarkdownResponse({ text, streaming }: { readonly text: string; readonly streaming: boolean }) {
+  const latestText = React.useRef(text);
+  const renderedText = React.useRef(streaming ? text : "");
+  const renderTimer = React.useRef<number | null>(null);
+  const [streamedHtml, setStreamedHtml] = React.useState(() => streaming ? renderMarkdown(text).html : "");
+  latestText.current = text;
+
+  const completedHtml = React.useMemo(() => streaming ? null : renderMarkdown(text).html, [streaming, text]);
+
+  React.useEffect(() => {
+    if (!streaming) {
+      if (renderTimer.current !== null) window.clearTimeout(renderTimer.current);
+      renderTimer.current = null;
+      return;
+    }
+    if (renderedText.current === text || renderTimer.current !== null) return;
+    renderTimer.current = window.setTimeout(() => {
+      renderTimer.current = null;
+      const nextText = latestText.current;
+      if (nextText === renderedText.current) return;
+      renderedText.current = nextText;
+      setStreamedHtml(renderMarkdown(nextText).html);
+    }, STREAM_RENDER_DELAY_MS);
+  }, [streaming, text]);
+
+  React.useEffect(() => () => {
+    if (renderTimer.current !== null) window.clearTimeout(renderTimer.current);
+  }, []);
+
+  return <div className="session-analyst__response markdown-body" dangerouslySetInnerHTML={{ __html: completedHtml ?? streamedHtml }} />;
+});
+
+function copyCodeToClipboard(button: HTMLElement, code: string): void {
+  const clipboard = navigator.clipboard;
+  if (!clipboard) return;
+  let write: Promise<void>;
+  try { write = clipboard.writeText(code); } catch { return; }
+  const original = button.textContent;
+  void write.then(() => {
+    if (!button.isConnected) return;
+    button.textContent = "Copied";
+    window.setTimeout(() => { if (button.isConnected) button.textContent = original; }, 1_200);
+  }).catch(() => undefined);
 }
 
 function PanelHeader({ state, onReset }: { readonly state: AnalysisState; readonly onReset: () => void }) {

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-panel.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-panel.test.tsx
@@ -36,6 +36,12 @@ describe("Session Analyst contract", () => {
     expect(css).toContain("var(--coral)");
     expect(css).toContain(".session-analyst__composer-surface:focus-within");
     expect(css).toContain(".session-analyst__composer.is-working .session-analyst__composer-surface");
+    expect(css).toContain("user-select: text");
+    expect(css).toContain(":is(button, select) { user-select: none; }");
+    expect(css).not.toContain(":is(button, a)");
+    expect(css).toContain(".session-analyst__chat > ol {");
+    expect(css).not.toMatch(/\.session-analyst__chat ol\s*\{/);
+    expect(css).not.toContain(".session-analyst__chat ol.is-dimmed");
     expect(css).toContain("var(--surface-glass-strong)");
     expect(css).not.toContain("background: color-mix(in oklch, var(--ink-mid) 60%, black)");
     expect(css).not.toContain(".session-analyst__chat-pane textarea:focus-visible");

--- a/runtime/fleet-plugins/terminal/client/agent/analysis.css
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis.css
@@ -42,13 +42,42 @@
 .session-analyst__suggestion-icon[data-tone="aurora"] { color: var(--aurora); }
 .session-analyst__suggestion-icon[data-tone="coral"] { color: var(--coral); }
 .session-analyst__suggestion-icon[data-tone="brass"] { color: var(--brass); }
+.session-analyst__chat-pane :is(button, select) { user-select: none; }
 
-.session-analyst__chat ol { display: grid; gap: 15px; align-content: start; padding: 0; margin: 0; list-style: none; transition: opacity var(--duration-base) var(--ease-glide), filter var(--duration-base) var(--ease-glide); }
-.session-analyst__chat ol.is-dimmed { opacity: .34; filter: saturate(.45); }
+.session-analyst__chat > ol { display: grid; gap: 15px; align-content: start; padding: 0; margin: 0; list-style: none; user-select: text; cursor: text; }
 .session-analyst__message { padding: 11px 15px; border-radius: 18px; white-space: pre-wrap; line-height: 1.55; font-size: 12.5px; }
 .session-analyst__message--user { background: color-mix(in oklch, var(--ink-veil) 70%, var(--ink-mid)); color: var(--text-primary); justify-self: end; max-width: 90%; }
 .session-analyst__message--analyst { position: relative; max-width: 100%; border: 0; border-radius: 0; background: transparent; color: var(--text-secondary); padding: 6px 4px 6px 28px; animation: analyst-answer-rise var(--duration-base) var(--ease-glide) both; }
 .session-analyst__message--analyst::before { content: "✳"; position: absolute; left: 2px; top: 7px; color: var(--aurora); }
+.session-analyst__response.markdown-body {
+  --font-size-2xs: 9px;
+  --font-size-xs: 10px;
+  --font-size-sm: 11px;
+  --font-size-lg: 12px;
+  --font-size-code: 11.5px;
+  --font-size-body: 12.5px;
+  --font-size-title-md: 15px;
+  --font-size-display-md: 17px;
+  --font-size-display-lg: 18px;
+  max-inline-size: none;
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.58;
+  white-space: normal;
+}
+.session-analyst__response.markdown-body > * + * { margin-top: var(--space-3); }
+.session-analyst__response.markdown-body > :first-child { margin-top: 0; }
+.session-analyst__response.markdown-body > :last-child { margin-bottom: 0; }
+.session-analyst__response.markdown-body :is(h1, h2, h3, h4) { margin-top: var(--space-4); scroll-margin-top: 0; }
+.session-analyst__response.markdown-body h2 { padding-left: var(--space-3); }
+.session-analyst__response.markdown-body p { margin-bottom: var(--space-3); }
+.session-analyst__response.markdown-body :is(ul, ol) { margin-bottom: var(--space-3); padding-left: var(--space-5); }
+.session-analyst__response.markdown-body li + li { margin-top: var(--space-1); }
+.session-analyst__response.markdown-body table { margin-block: var(--space-3); font-size: 10px; }
+.session-analyst__response.markdown-body table :is(th, td) { padding: var(--space-2) var(--space-3); }
+.session-analyst__response.markdown-body :is(blockquote, .code-block, .diagram-block) { margin-block: var(--space-3); }
+.session-analyst__response.markdown-body blockquote { padding: var(--space-2) var(--space-3); }
+.session-analyst__response.markdown-body .code-block code { padding: var(--space-3); }
 
 .session-analyst__pulse { position: relative; min-height: 92px; flex: none; margin-top: 15px; overflow: hidden; border: 1px solid color-mix(in oklch, var(--aurora) 35%, var(--hairline)); border-radius: var(--radius-md); background: color-mix(in oklch, var(--aurora) 6%, var(--ink-deep)); padding: var(--space-3); animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
 .session-analyst__pulse-scan, .session-analyst__composer.is-working .session-analyst__composer-surface::before { content: ""; position: absolute; z-index: 1; inset: 0 0 auto; height: 2px; background: linear-gradient(90deg, transparent, var(--aurora), transparent); background-size: 200% 100%; animation: analyst-aurora-scan 1.6s linear infinite; }
@@ -147,7 +176,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .session-analyst-handle, .session-analyst__suggestions button, .session-analyst__chat ol, .session-analyst__composer-surface, .session-analyst__composer textarea, .session-analyst__selector-strip, .session-analyst__artifact-count, .session-analyst__artifact-count i { transition: none; }
+  .session-analyst-handle, .session-analyst__suggestions button, .session-analyst__composer-surface, .session-analyst__composer textarea, .session-analyst__selector-strip, .session-analyst__artifact-count, .session-analyst__artifact-count i { transition: none; }
   .session-analyst-handle:hover { transform: translateY(-50%); }
   .session-analyst__suggestions button:hover { transform: none; }
   .session-analyst__pulse-scan, .session-analyst__composer.is-working .session-analyst__composer-surface::before, .session-analyst__pulse-orbit::after, .session-analyst__pulse, .session-analyst__pulse-copy strong, .session-analyst__receipt, .session-analyst__message--analyst, .session-analyst__composer.is-docking, .session-analyst__artifact-menu { animation: none; }

--- a/runtime/fleet-plugins/terminal/package.json
+++ b/runtime/fleet-plugins/terminal/package.json
@@ -29,6 +29,7 @@
     "@dotobokuri/fleet-wiki": "workspace:*",
     "@dotobokuri/fleet-plans": "workspace:*",
     "@fleet-console/font-picker": "workspace:*",
+    "@fleet-console/markdown": "workspace:*",
     "@fleet-console/sdk": "workspace:*",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-unicode11": "^0.9.0",


### PR DESCRIPTION
## Summary

- Render Session Analyst assistant responses as selectable compact Markdown while keeping user prompts plain.
- Reuse the shared Markdown and Mermaid pipeline for Wiki Cowork assistant replies without consumer-level network or media restrictions.
- Coalesce streaming renders and show code-copy success only after the clipboard write succeeds.

## Type of Change

- [x] feat — new feature or carrier capability
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- [ ] `extensions/core`
- [ ] `extensions/fleet` (Admiral / Bridge / Carriers)
- [ ] `extensions/boot`
- [ ] `extensions/diagnostics`
- [ ] `extensions/metaphor`
- [ ] `packages/unified-agent`
- [ ] `bin/` or root tooling
- [ ] Documentation (README / SETUP / AGENTS.md)
- [x] Fleet Console and Terminal plugin UI

## Test Plan

- [x] `pnpm --filter @fleet-plugins/terminal exec vitest run client/agent/analysis-chat-panel.test.tsx client/agent/analysis-panel.test.tsx client/agent/analysis-state.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/codex-cowork-ui.test.ts tests/instrument-design-contract.test.ts`
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `pnpm check:core-boundary`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Real-browser verification of selection, nested lists, streaming visibility, and Mermaid hydration
- [x] User completed manual Console testing

## Changelog

- [x] Added `.changelog.d/pr-317.md`.
- [x] Fragment sections use `Changed`.
- [x] Fragment bullets are bilingual and use the allowed `[fleet-console]` tag.

## Notes for Reviewers

The absence of consumer-level URL, image, or source restrictions is intentional product policy. Both surfaces reuse the trusted shared `@fleet-console/markdown` sanitizer and renderer as-is.
