### PR TITLE
fix(console): restore legibility of minimized sidebar chip names

### DIFF
--- a/.changelog.d/pr-318.md
+++ b/.changelog.d/pr-318.md
@@ -1,0 +1,6 @@
+### fleet-console
+
+#### Fixed
+
+- [fleet-console] Restore legibility of minimized sidebar Operation names, which stacked a dim color with 55% opacity and fell below WCAG contrast; minimized names now use a dedicated readable ink tier and clear WCAG AA across all three themes.
+  ko: 최소화된 사이드바 Operation 이름이 흐린 색에 55% 불투명도를 겹쳐 WCAG 대비 아래로 떨어지던 문제를 수정합니다. 이제 전용 판독 잉크 티어를 사용해 세 테마 모두 WCAG AA를 충족합니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2444,13 +2444,15 @@
   color: color-mix(in oklch, var(--brass) 88%, var(--ink-spectral));
 }
 
-/* minimized: 반투명 + 이름 흐림 */
-.side-bar-chip--minimized {
-  opacity: 0.55;
+/* minimized: 이름은 판독 가능한 --ink-muted 티어로 유지하고 "치워둠" 신호는 아이콘 감쇠로만
+   전달한다. 예전의 칩 전체 opacity(색 × 투명도 이중 감쇠)는 이름 대비를 WCAG 하한 아래로
+   무너뜨렸다(instrument 1.84:1). 위계: active brass › 기본 ink-spectral › 최소화 ink-muted. */
+.side-bar-chip--minimized .side-bar-chip-name {
+  color: var(--ink-muted);
 }
 
-.side-bar-chip--minimized .side-bar-chip-name {
-  color: var(--ink-fog);
+.side-bar-chip--minimized .side-bar-chip-op-icon {
+  opacity: 0.62;
 }
 
 /* drop-target: 드래그 위치 표시 */

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -13,6 +13,8 @@
   --ink-veil: oklch(23.5% 0.02 245);
   --ink-rim: oklch(29% 0.018 245);
   --ink-fog: oklch(52% 0.012 245);
+  /* --ink-muted: minimized 등 "치워둔" 항목의 이름 티어 — ink-fog보다 밝아 판독 하한을 넘고, ink-spectral보다 어두워 기본 비활성과 구분된다. */
+  --ink-muted: oklch(64% 0.012 245);
   --ink-spectral: oklch(70% 0.012 245);
   --ink-pearl: oklch(94% 0.008 90);
 
@@ -142,6 +144,7 @@
   --ink-veil: oklch(36% 0.035 248);
   --ink-rim: oklch(48% 0.03 248);
   --ink-fog: oklch(70% 0.02 248);
+  --ink-muted: oklch(75% 0.02 248);
   --ink-spectral: oklch(82% 0.018 90);
   --ink-pearl: oklch(96% 0.012 88);
 
@@ -194,6 +197,7 @@
   --ink-veil: oklch(33% 0.006 252);
   --ink-rim: oklch(45% 0.005 252);
   --ink-fog: oklch(67% 0.005 250);
+  --ink-muted: oklch(72% 0.005 250);
   --ink-spectral: oklch(81% 0.004 250);
   --ink-pearl: oklch(95% 0.003 250);
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -323,6 +323,7 @@ describe("Instrument core design contract", () => {
     expect(theme).toContain(':root[data-theme="instrument"]');
     expect(base).toContain("--ink-abyss: oklch(13% 0.014 245);");
     expect(base).toContain("--brass: oklch(80% 0.085 78);");
+    expect(base).toContain("--ink-muted: oklch(64% 0.012 245);");
     expect(base).toContain("--aurora: oklch(77% 0.085 200);");
     expect(base).toContain("--coral: oklch(68% 0.13 25);");
     expect(base).toContain("--warn: oklch(75% 0.08 90);");
@@ -333,6 +334,8 @@ describe("Instrument core design contract", () => {
     expect(theme).toContain(':root[data-theme="maritime"]');
     expect(theme).toContain(':root[data-theme="carbon"]');
     expect(theme).toContain("--brass: oklch(78% 0.13 75);");
+    expect(theme).toContain("--ink-muted: oklch(75% 0.02 248);");
+    expect(theme).toContain("--ink-muted: oklch(72% 0.005 250);");
     expect(theme.match(/^:root \{/gm)).toHaveLength(1);
     // Legacy 테마 블록은 팔레트 토큰만 — 모든 선언이 승인된 색 토큰 화이트리스트에 속해야 하며
     // 형상(radius/space)·배경 연출(grain/pseudo)·타이포(font) 오버라이드는 진입 불가.
@@ -389,6 +392,9 @@ describe("Instrument core design contract", () => {
     expect(chip).toContain('if (visual === "awaiting") return "tenant-beacon is-awaiting"');
     expect(chip).not.toContain("is-attention");
     expect(components).toContain(".side-bar-chip:focus-within .side-bar-chip-close");
+    expect(components).toContain(".side-bar-chip--minimized .side-bar-chip-name {\n  color: var(--ink-muted);");
+    expect(components).toContain(".side-bar-chip--minimized .side-bar-chip-op-icon {\n  opacity: 0.62;");
+    expect(components).not.toMatch(/\.side-bar-chip--minimized \{[^}]*opacity/);
 
     expect(minimap).not.toContain("is-plugin");
     expect(components).not.toContain(".canvas-minimap-operation.is-plugin");


### PR DESCRIPTION
## Summary
- 좌측 사이드바의 **최소화(minimized) Operation 칩** 이름이 흐린 `--ink-fog` 색 위에 칩 전체 `opacity: 0.55`를 겹쳐(이중 감쇠) WCAG 대비가 3:1도 못 넘겼습니다(instrument 1.84:1, maritime 2.65, carbon 2.57 — 실측).
- 전용 골격 텍스트 토큰 `--ink-muted`를 신설(테마별 재조율)해 최소화 이름에 적용하고, 칩 전체 opacity는 제거해 "치워둠" 신호를 Operation 아이콘(`opacity: 0.62`)으로만 전달합니다. 세 테마 모두 WCAG AA를 통과(5.73 / 6.51 / 6.45)하며 `active(brass) › 기본(ink-spectral) › 최소화(ink-muted)` 위계는 유지됩니다.
- 디자인 계약 테스트를 동반 갱신해 `--ink-muted` 3테마 값과 이중 감쇠 opacity의 부재를 잠급니다.

## Test Plan
- [ ] Changelog fragment `.changelog.d/pr-<n>.md` (PR 번호 배정 대기)
- [x] `pnpm --filter @dotobokuri/fleet-console build` — green (tsc)
- [x] Design contract test `instrument-design-contract.test.ts` — 13/13 pass
- [x] 헤디드 3테마 재측정(격리 콘솔): 최소화 이름 대비 instrument 5.73 / maritime 6.51 / carbon 6.45 (모두 AA ≥ 4.5)
- [x] Sentinel 리뷰 — PASS (Critical/High 0)