### PR TITLE
fix(console): preserve views around Session Analyze

### DIFF
--- a/.agents/skills/git-worktree/SKILL.md
+++ b/.agents/skills/git-worktree/SKILL.md
@@ -64,12 +64,16 @@ Create or remove a Fleet git worktree safely, without mutating unrelated files, 
    - Treat `<abs-worktree-path>` as the required cwd for all subsequent commands in the task.
    - Do not continue issuing repository commands from the parent checkout unless the user explicitly redirects.
 
-8. **Report in Korean**:
+8. **Install dependencies inside the worktree**:
+   - From `<abs-worktree-path>`, run `pnpm install --frozen-lockfile` before reporting create-mode completion.
+   - If installation fails, stop immediately and report the command failure. Do not report the worktree as ready and do not proceed to Carrier dispatch.
+
+9. **Report in Korean**:
    - Worktree path.
    - Branch name and base branch.
    - Confirmation that cwd is now fixed to the worktree absolute path.
+   - Confirmation that `pnpm install --frozen-lockfile` completed successfully inside the worktree.
    - Suggested next steps.
-   - Note that dependency installation (`pnpm install`) is intentionally not part of this skill; the user runs it manually if needed.
 
 ### Remove Mode
 
@@ -125,7 +129,7 @@ Create or remove a Fleet git worktree safely, without mutating unrelated files, 
 
 - Do not force the base to `main` or `master`; reject those bases by default.
 - Do not remove the main checkout under any circumstance.
-- Do not run `pnpm install`, `npm install`, or any other dependency installer as part of this skill; dependency setup is out of scope.
+- Do not symlink, bind-mount, or otherwise reuse `node_modules` from another checkout. Install dependencies inside the active worktree with `pnpm install --frozen-lockfile`.
 - Do not create helper scripts; execute commands directly through the `Bash` tool.
 - Do not silently route free-form extra text outside the two lifecycle modes. Interpret it into `create` or `remove`, then allow changes only within that mode's workflow.
 - Do not overwrite an existing worktree path or branch. If the path or branch already exists, stop and report.
@@ -139,5 +143,5 @@ Create or remove a Fleet git worktree safely, without mutating unrelated files, 
 - **Nimitz** — consult before proceeding with any non-standard `<base-branch>` request. This is especially important when the requested base changes branch policy or release flow.
 - **Stop and report** — when a worktree path or branch is already present or in use. Do not resolve collisions autonomously.
 - Skip carrier delegation for clean create/remove operations that follow the standard `origin/canary` path and have no conflict or policy issue.
-- **Carrier edits inside the new worktree** — after `create`, when you delegate file edits to a carrier (`carrier_dispatch`), pass the **absolute worktree path** as the dispatch `cwd` argument so the carrier's CLI spawns inside this worktree and its repo-relative paths resolve here. If you omit `cwd`, the carrier's cwd defaults to the **main checkout** (not this worktree), so omitting it for worktree work risks editing the main checkout — always set `cwd` for worktree delegation. The carrier can run `build`/`typecheck` inside the worktree only if dependencies are installed there (`pnpm install`); otherwise the Admiral verifies inside the worktree. After each return run `git -C <main-checkout> status --short` to confirm the main checkout stayed clean, and treat the carrier's reported `workspaceChanges` (window-approx) as unreliable — trust the real `git status`.
+- **Carrier edits inside the new worktree** — after `create`, when you delegate file edits to a carrier (`carrier_dispatch`), pass the **absolute worktree path** as the dispatch `cwd` argument so the carrier's CLI spawns inside this worktree and its repo-relative paths resolve here. If you omit `cwd`, the carrier's cwd defaults to the **main checkout** (not this worktree), so omitting it for worktree work risks editing the main checkout — always set `cwd` for worktree delegation. Before dispatch, confirm `pnpm install --frozen-lockfile` succeeded in this worktree, identify every target package, and run each package's declared `typecheck` and `build` scripts from this worktree. If either preflight script is absent or fails, stop and report instead of dispatching. After each return run `git -C <main-checkout> status --short` to confirm the main checkout stayed clean, and treat the carrier's reported `workspaceChanges` (window-approx) as unreliable — trust the real `git status`.
 - **Fleet Plans are worktree-independent** — plans live under the Fleet data directory and are addressed by PlanRef/TaskRef, so never copy a Plan into a new git worktree. Pass the original fully qualified TaskRefs to Ohio; their workspace component resolves the authoritative Plan even when Ohio executes from another cwd.

--- a/.changelog.d/pr-319.md
+++ b/.changelog.d/pr-319.md
@@ -1,0 +1,9 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Keep Session Analyze active while switching Operations and restore the previous Map, Formation, or maximized view on exit.
+  ko: Session Analyze에서 Operation을 전환해도 분석 화면을 유지하고, 종료하면 이전 Map, Formation 또는 패널 최대화 화면을 복원합니다.
+
+### fleet-core
+#### Changed
+- [fleet-admiral] Install frozen dependencies inside new worktrees and require package typecheck and build preflight before Carrier dispatch.
+  ko: 새 worktree 내부에 고정된 의존성을 설치하고 Carrier 위임 전에 패키지 typecheck와 build 사전 검증을 요구합니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
@@ -47,11 +47,9 @@ export interface GridSlotGeometry {
 export type FormationLayout = "grid" | "columns" | "rows";
 
 type Listener = () => void;
-type FocusLayerMode = "maximized" | "companion";
-interface FocusLayerState {
-  readonly mode: FocusLayerMode;
-  readonly operationId: string;
-}
+type FocusLayerState =
+  | { readonly mode: "maximized"; readonly operationId: string }
+  | { readonly mode: "companion"; readonly operationId: string; readonly returnTo: "underlay" | "maximized" };
 
 const STORAGE_KEY_PREFIX = "fleet-console.canvas.";
 const FORMATION_LAYOUT_STORAGE_KEY = "fleet-console.formation-layout";
@@ -115,6 +113,11 @@ export function getMaximizedOperationId(): string | null {
 
 export function getCompanionOperationId(): string | null {
   return focusLayer?.mode === "companion" ? focusLayer.operationId : null;
+}
+
+export function getTheaterCompanionOperationId(theaterId: string): string | null {
+  const layer = activeTheaterId === theaterId ? focusLayer : focusLayersByTheater.get(theaterId) ?? null;
+  return layer?.mode === "companion" ? layer.operationId : null;
 }
 
 export function getFormationView(): boolean {
@@ -301,7 +304,7 @@ export function calculateGridSlots(
 export function minimizeOperation(sessionId: string): void {
   if (state.minimized.includes(sessionId)) return;
   if (getMaximizedOperationId() === sessionId) clearMaximizedOperationId();
-  if (getCompanionOperationId() === sessionId) clearCompanionOperationId();
+  if (getCompanionOperationId() === sessionId) forceDropCompanionOperationId();
   setState({ minimized: [...state.minimized, sessionId] });
 }
 
@@ -322,7 +325,7 @@ export function minimizeOperations(sessionIds: readonly string[]): void {
   const maximizedOperationId = getMaximizedOperationId();
   const companionOperationId = getCompanionOperationId();
   if (maximizedOperationId && minimized.includes(maximizedOperationId)) clearMaximizedOperationId();
-  if (companionOperationId && minimized.includes(companionOperationId)) clearCompanionOperationId();
+  if (companionOperationId && minimized.includes(companionOperationId)) forceDropCompanionOperationId();
   setState({ minimized });
 }
 
@@ -419,7 +422,7 @@ export function pruneOperations(validSessionIds: readonly string[]): void {
   if (maximizedOperationId && (!valid.has(maximizedOperationId) || minimized.includes(maximizedOperationId))) clearMaximizedOperationId();
   // companion은 목록 부재만으로 즉시 정리하지 않는다 — ops 푸시 레이스로 일시 부재가 흔하며,
   // 지속 부재의 정리는 캔버스 렌더 측 유예 효과가 소유한다. 최소화는 사용자 확정 액션이라 즉시 닫는다.
-  if (companionOperationId && minimized.includes(companionOperationId)) clearCompanionOperationId();
+  if (companionOperationId && minimized.includes(companionOperationId)) forceDropCompanionOperationId();
   if (changed || minimizedChanged || orderChanged || accentChanged) {
     setState({ operations, minimized, operationOrder, operationAccent });
   }
@@ -491,9 +494,10 @@ export function clearMaximizedOperationId(): void {
 }
 
 export function setCompanionOperationId(operationId: string): void {
-  if (activeTheaterId && focusLayersByTheater.get(activeTheaterId)?.mode === "maximized") focusLayersByTheater.delete(activeTheaterId);
-  clearFormationView();
-  const nextFocusLayer = { mode: "companion", operationId } as const;
+  const returnTo = focusLayer?.mode === "companion"
+    ? focusLayer.returnTo
+    : focusLayer?.mode === "maximized" ? "maximized" : "underlay";
+  const nextFocusLayer = { mode: "companion", operationId, returnTo } as const;
   setFocusLayer(nextFocusLayer);
 }
 
@@ -502,24 +506,51 @@ function setFocusLayer(nextFocusLayer: FocusLayerState): void {
   const minimizedChanged = !stringArraysEqual(state.minimized, minimized);
   const focusLayerChanged = !focusLayersEqual(focusLayer, nextFocusLayer);
   if (focusLayerChanged) focusLayer = nextFocusLayer;
+  if (focusLayerChanged && activeTheaterId) focusLayersByTheater.set(activeTheaterId, nextFocusLayer);
   if (minimizedChanged) setState({ minimized });
   if (focusLayerChanged) emitFocusLayer();
 }
 
 export function clearCompanionOperationId(): void {
   if (focusLayer?.mode !== "companion") return;
+  const closingLayer = focusLayer;
+  const canRestoreMaximized = closingLayer.returnTo === "maximized"
+    && closingLayer.operationId in state.operations
+    && !state.minimized.includes(closingLayer.operationId);
+  focusLayer = canRestoreMaximized
+    ? { mode: "maximized", operationId: closingLayer.operationId }
+    : null;
+  if (activeTheaterId) {
+    if (focusLayer) focusLayersByTheater.set(activeTheaterId, focusLayer);
+    else focusLayersByTheater.delete(activeTheaterId);
+  }
+  emitFocusLayer();
+}
+
+export function forceDropCompanionOperationId(): void {
+  if (focusLayer?.mode !== "companion") return;
   focusLayer = null;
+  if (activeTheaterId) focusLayersByTheater.delete(activeTheaterId);
   emitFocusLayer();
 }
 
 export function toggleFormationView(): void {
   if (!activeTheaterId) return;
+  if (getCompanionOperationId() !== null) {
+    forceDropCompanionOperationId();
+    if (!formationView) {
+      formationViewsByTheater.set(activeTheaterId, true);
+      formationView = true;
+      emitFormationView();
+    }
+    return;
+  }
   if (formationView) {
     clearFormationView();
     return;
   }
   clearMaximizedOperationId();
-  clearCompanionOperationId();
+  forceDropCompanionOperationId();
   formationViewsByTheater.set(activeTheaterId, true);
   formationView = true;
   emitFormationView();
@@ -527,6 +558,16 @@ export function toggleFormationView(): void {
 
 export function selectFormationLayout(layout: FormationLayout): void {
   if (!activeTheaterId) return;
+  if (getCompanionOperationId() !== null) {
+    setFormationLayout(layout);
+    forceDropCompanionOperationId();
+    if (!formationView) {
+      formationViewsByTheater.set(activeTheaterId, true);
+      formationView = true;
+      emitFormationView();
+    }
+    return;
+  }
   if (formationView && formationLayout === layout) {
     clearFormationView();
     return;
@@ -534,7 +575,7 @@ export function selectFormationLayout(layout: FormationLayout): void {
   setFormationLayout(layout);
   if (!formationView) {
     clearMaximizedOperationId();
-    clearCompanionOperationId();
+    forceDropCompanionOperationId();
     formationViewsByTheater.set(activeTheaterId, true);
     formationView = true;
     emitFormationView();
@@ -606,7 +647,9 @@ function saveFocusLayerForActiveTheater(): void {
 }
 
 function focusLayersEqual(left: FocusLayerState | null, right: FocusLayerState | null): boolean {
-  return left?.mode === right?.mode && left?.operationId === right?.operationId;
+  return left?.mode === right?.mode
+    && left?.operationId === right?.operationId
+    && (left?.mode !== "companion" || right?.mode !== "companion" || left.returnTo === right.returnTo);
 }
 
 function stringArraysEqual(left: readonly string[], right: readonly string[]): boolean {

--- a/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
@@ -82,6 +82,7 @@ let activeTheaterId: string | null = null;
 let saveTimer: number | null = null;
 let state: CanvasState = EMPTY_STATE;
 let focusLayer: FocusLayerState | null = null;
+let focusLayerRevision = 0;
 let formationView = false;
 let formationLayout = readStoredFormationLayout();
 // 줌 보간 루프가 향하는 목표 viewport. 즉시 이동(pan/focus/load)은 이 값을 current와 동기화해 잔여 보간을 무효화한다.
@@ -113,6 +114,10 @@ export function getMaximizedOperationId(): string | null {
 
 export function getCompanionOperationId(): string | null {
   return focusLayer?.mode === "companion" ? focusLayer.operationId : null;
+}
+
+export function getFocusLayerRevision(): number {
+  return focusLayerRevision;
 }
 
 export function getTheaterCompanionOperationId(theaterId: string): string | null {
@@ -637,6 +642,7 @@ function getCollapsedGroupsSnapshot(): readonly string[] {
 }
 
 function emitFocusLayer(): void {
+  focusLayerRevision += 1;
   for (const listener of focusLayerListeners) listener();
 }
 

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -9,7 +9,7 @@ import { flattenGroupedOrder, hydrateOperations, setActiveOperation } from "../s
 import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import type { ConsoleState, OperationNode } from "../types.js";
-import { calculateGridSlots, animateViewportTo, claimTopZIndex, clearCompanionOperationId, clearMaximizedOperationId, focusOperation, getSnapshot as getCanvasSnapshot, minimizeOperation, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, setViewport, useCanvasState, useCompanionOperationId, useFormationLayout, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "./canvas-store.js";
+import { calculateGridSlots, animateViewportTo, claimTopZIndex, clearCompanionOperationId, clearMaximizedOperationId, focusOperation, forceDropCompanionOperationId, getSnapshot as getCanvasSnapshot, minimizeOperation, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, setViewport, useCanvasState, useCompanionOperationId, useFormationLayout, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "./canvas-store.js";
 import { CanvasContextMenu } from "./canvas-context-menu.js";
 import { CanvasMinimap } from "./canvas-minimap.js";
 import { resolveAccentColor } from "./operation-accent.js";
@@ -168,7 +168,7 @@ export function OperationsCanvas({
     // 레이아웃이 즉시 닫히지 않도록 부재가 지속될 때만 정리한다(복귀 시 cleanup으로 취소).
     const timer = setTimeout(() => {
       lastValidCompanionRef.current = null;
-      clearCompanionOperationId();
+      forceDropCompanionOperationId();
     }, 1_500);
     return () => clearTimeout(timer);
   }, [companionOperationId, currentPanelCompanion]);
@@ -254,7 +254,7 @@ export function OperationsCanvas({
             onClose: () => {
               if (state.activeOperationId === operation.id) setActiveOperation(null);
               if (panelMaximized === operation.id) clearMaximizedOperationId();
-              if (panelCompanion === operation.id) clearCompanionOperationId();
+              if (panelCompanion === operation.id) forceDropCompanionOperationId();
               onClose(operation.id);
             },
             onMinimize: () => {

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -352,6 +352,7 @@ async function routeOperationFocus(operationId: string, operationKinds: readonly
   const currentCompanionOperationId = getCompanionOperationId();
   if (currentCompanionOperationId !== null) {
     const operation = getState().operations.find((candidate) => candidate.id === operationId);
+    const operationWasMinimized = getCanvasSnapshot().minimized.includes(operationId);
     const descriptor = operation && operationKinds.find((kind) => kind.pluginId === operation.pluginId && kind.type === operation.type);
     let canOpenCompanions = true;
     if (operation && descriptor?.companions?.length && descriptor.canOpenCompanions) {
@@ -360,9 +361,10 @@ async function routeOperationFocus(operationId: string, operationKinds: readonly
       } catch {
         canOpenCompanions = false;
       }
-      // readiness 확인 중 사용자가 Exit·다른 Operation·다른 Theater로 이동했으면 오래된 결과를 버린다.
+      // readiness 확인 중 사용자가 Exit·다른 Operation·다른 Theater로 이동하거나 대상을 새로 숨겼으면 오래된 결과를 버린다.
       const liveOperation = getState().operations.find((candidate) => candidate.id === operationId);
-      if (requestEpochRef.current !== requestEpoch || getFocusLayerRevision() !== focusLayerRevision || getCompanionOperationId() !== currentCompanionOperationId || getLoadedTheaterId() !== operation.theaterId || !liveOperation || liveOperation.pluginId !== operation.pluginId || liveOperation.type !== operation.type || liveOperation.theaterId !== operation.theaterId) return;
+      const operationWasHidden = !operationWasMinimized && getCanvasSnapshot().minimized.includes(operationId);
+      if (requestEpochRef.current !== requestEpoch || getFocusLayerRevision() !== focusLayerRevision || getCompanionOperationId() !== currentCompanionOperationId || getLoadedTheaterId() !== operation.theaterId || operationWasHidden || !liveOperation || liveOperation.pluginId !== operation.pluginId || liveOperation.type !== operation.type || liveOperation.theaterId !== operation.theaterId) return;
     }
     if (operation && (!descriptor || !descriptor.companions?.length || !canOpenCompanions)) {
       forceDropCompanionOperationId();

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -5,7 +5,7 @@ import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 import type { ClientApiCapability, FleetClientPlugin, OperationKindDescriptor } from "@fleet-console/sdk/plugin";
 
 import { addTheater, createGroup, deleteGroup, fetchGroups, fetchOperations, forgetTheater, issueTheaterFolderGrant, patchOperation, renameOperation, updateGroup, ApiError } from "../api.js";
-import { animateViewportTo, claimTopZIndex, ensureDefaultGeometry, focusOperation as focusCanvasOperation, forceDropCompanionOperationId, getCompanionOperationId, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useCompanionOperationId, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
+import { animateViewportTo, claimTopZIndex, clearFormationView, ensureDefaultGeometry, focusOperation as focusCanvasOperation, forceDropCompanionOperationId, getCompanionOperationId, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useCompanionOperationId, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
 import { screenToCanvas, type CanvasPoint } from "../canvas/coordinates.js";
 import { OperationsCanvas } from "../canvas/canvas.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
@@ -351,6 +351,7 @@ function routeOperationFocus(operationId: string, operationKinds: readonly Opera
     const descriptor = operation && operationKinds.find((kind) => kind.pluginId === operation.pluginId && kind.type === operation.type);
     if (descriptor && !descriptor.companions?.length) {
       forceDropCompanionOperationId();
+      clearFormationView();
       focusMap();
       return;
     }

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -351,6 +351,10 @@ async function routeOperationFocus(operationId: string, operationKinds: readonly
   const focusLayerRevision = getFocusLayerRevision();
   const currentCompanionOperationId = getCompanionOperationId();
   if (currentCompanionOperationId !== null) {
+    if (currentCompanionOperationId === operationId) {
+      setActiveOperation(operationId);
+      return;
+    }
     const operation = getState().operations.find((candidate) => candidate.id === operationId);
     const operationWasMinimized = getCanvasSnapshot().minimized.includes(operationId);
     const descriptor = operation && operationKinds.find((kind) => kind.pluginId === operation.pluginId && kind.type === operation.type);

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -43,6 +43,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
     [state.operations, state.activeTheaterId],
   );
   const stateRef = useRef(state);
+  const focusRequestEpochRef = useRef(0);
   stateRef.current = state;
 
   useEffect(() => {
@@ -85,7 +86,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       const currentId = getCompanionOperationId() ?? getMaximizedOperationId() ?? stateRef.current.activeOperationId;
       const nextId = nextOperationId(order, currentId, event.key === "ArrowRight" ? 1 : -1);
       if (!nextId) return;
-      void routeOperationFocus(nextId, registry.operationKinds, STABLE_RAIL_API, () => {
+      void routeOperationFocus(nextId, registry.operationKinds, STABLE_RAIL_API, focusRequestEpochRef, () => {
         // 모두 최소화된 부팅 상태의 폴백 대상은 store 포커스보다 먼저 복원한다. 그렇지 않으면 Canvas의
         // "최소화된 active id 제거" effect가 pending focus 복원보다 앞서 실행되어 활성 표시를 지운다.
         if (canvas.minimized.includes(nextId)) restoreOperation(nextId);
@@ -120,7 +121,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
     const operationId = state.pendingOperationFocus;
     if (operationId === null) return;
     // loadForTheater effect가 먼저 도착 Theater의 focus layer와 Formation underlay를 복원한다.
-    void routeOperationFocus(operationId, registry.operationKinds, STABLE_RAIL_API, () => {
+    void routeOperationFocus(operationId, registry.operationKinds, STABLE_RAIL_API, focusRequestEpochRef, () => {
       const viewportSize = viewportSizeFor(bodyRef.current);
       if (viewportSize) focusCanvasOperation(operationId, viewportSize);
     });
@@ -163,7 +164,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       focusOperation(operationId);
       return;
     }
-    void routeOperationFocus(operationId, registry.operationKinds, STABLE_RAIL_API, () => {
+    void routeOperationFocus(operationId, registry.operationKinds, STABLE_RAIL_API, focusRequestEpochRef, () => {
       const snapshot = getCanvasSnapshot();
       const geometry = snapshot.operations[operationId] ?? operation.geometry ?? ensurePluginGeometry(operation);
       if (!snapshot.operations[operationId]) setOperationGeometry(operationId, geometry);
@@ -345,7 +346,8 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
 }
 
 // 모든 사용자 포커스 진입점은 현재 로드된 Theater의 live 표시 상태만으로 같은 순서를 적용한다.
-async function routeOperationFocus(operationId: string, operationKinds: readonly OperationKindDescriptor[], api: ClientApiCapability, focusMap: () => void): Promise<void> {
+async function routeOperationFocus(operationId: string, operationKinds: readonly OperationKindDescriptor[], api: ClientApiCapability, requestEpochRef: { current: number }, focusMap: () => void): Promise<void> {
+  const requestEpoch = ++requestEpochRef.current;
   const currentCompanionOperationId = getCompanionOperationId();
   if (currentCompanionOperationId !== null) {
     const operation = getState().operations.find((candidate) => candidate.id === operationId);
@@ -358,7 +360,7 @@ async function routeOperationFocus(operationId: string, operationKinds: readonly
         canOpenCompanions = false;
       }
       // readiness 확인 중 사용자가 Exit·다른 Operation·다른 Theater로 이동했으면 오래된 결과를 버린다.
-      if (getCompanionOperationId() !== currentCompanionOperationId || getLoadedTheaterId() !== operation.theaterId) return;
+      if (requestEpochRef.current !== requestEpoch || getCompanionOperationId() !== currentCompanionOperationId || getLoadedTheaterId() !== operation.theaterId) return;
     }
     if (descriptor && (!descriptor.companions?.length || !canOpenCompanions)) {
       forceDropCompanionOperationId();

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -363,7 +363,7 @@ async function routeOperationFocus(operationId: string, operationKinds: readonly
       // readiness 확인 중 사용자가 Exit·다른 Operation·다른 Theater로 이동했으면 오래된 결과를 버린다.
       if (requestEpochRef.current !== requestEpoch || getFocusLayerRevision() !== focusLayerRevision || getCompanionOperationId() !== currentCompanionOperationId || getLoadedTheaterId() !== operation.theaterId) return;
     }
-    if (descriptor && (!descriptor.companions?.length || !canOpenCompanions)) {
+    if (operation && (!descriptor || !descriptor.companions?.length || !canOpenCompanions)) {
       forceDropCompanionOperationId();
       clearFormationView();
       focusMap();

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -364,7 +364,7 @@ async function routeOperationFocus(operationId: string, operationKinds: readonly
       // readiness 확인 중 사용자가 Exit·다른 Operation·다른 Theater로 이동하거나 대상을 새로 숨겼으면 오래된 결과를 버린다.
       const liveOperation = getState().operations.find((candidate) => candidate.id === operationId);
       const operationWasHidden = !operationWasMinimized && getCanvasSnapshot().minimized.includes(operationId);
-      if (requestEpochRef.current !== requestEpoch || getFocusLayerRevision() !== focusLayerRevision || getCompanionOperationId() !== currentCompanionOperationId || getLoadedTheaterId() !== operation.theaterId || operationWasHidden || !liveOperation || liveOperation.pluginId !== operation.pluginId || liveOperation.type !== operation.type || liveOperation.theaterId !== operation.theaterId) return;
+      if (requestEpochRef.current !== requestEpoch || getFocusLayerRevision() !== focusLayerRevision || getCompanionOperationId() !== currentCompanionOperationId || getLoadedTheaterId() !== operation.theaterId || operationWasHidden || closingOperationIds.has(operationId) || !liveOperation || liveOperation.pluginId !== operation.pluginId || liveOperation.type !== operation.type || liveOperation.theaterId !== operation.theaterId) return;
     }
     if (operation && (!descriptor || !descriptor.companions?.length || !canOpenCompanions)) {
       forceDropCompanionOperationId();

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -5,7 +5,7 @@ import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 import type { ClientApiCapability, FleetClientPlugin } from "@fleet-console/sdk/plugin";
 
 import { addTheater, createGroup, deleteGroup, fetchGroups, fetchOperations, forgetTheater, issueTheaterFolderGrant, patchOperation, renameOperation, updateGroup, ApiError } from "../api.js";
-import { animateViewportTo, claimTopZIndex, clearMaximizedOperationId, ensureDefaultGeometry, focusOperation as focusCanvasOperation, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, restoreOperation, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
+import { animateViewportTo, claimTopZIndex, ensureDefaultGeometry, focusOperation as focusCanvasOperation, forceDropCompanionOperationId, getCompanionOperationId, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useCompanionOperationId, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
 import { screenToCanvas, type CanvasPoint } from "../canvas/coordinates.js";
 import { OperationsCanvas } from "../canvas/canvas.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
@@ -31,6 +31,7 @@ interface OperationsProps {
 export function Operations({ state, claimBootPanelMinimization }: OperationsProps) {
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const maximizedOperationId = useMaximizedOperationId();
+  const companionOperationId = useCompanionOperationId();
   const formationView = useFormationView();
   const minimized = useMinimized();
   const registry = usePluginRegistry();
@@ -55,8 +56,6 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
 
   // Alt+←/→는 SideBar 가시 순서로 포커스를 순환하고, Alt+F는 같은 capture/editable 가드 정책을 공유한다.
   useEffect(() => {
-    const maximizedRef = { current: maximizedOperationId };
-    const formationRef = { current: formationView };
     const handler = (event: KeyboardEvent) => {
       if (!shouldHandleOperationsKeyboardShortcut()) return;
       if (!event.altKey || event.metaKey || event.ctrlKey) return;
@@ -78,32 +77,24 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
         snapshot.groups.filter((g) => g.theaterId === snapshot.activeTheaterId),
         canvas.operationOrder,
         canvas.collapsedGroups,
-        maximizedRef.current === null ? canvas.minimized : [],
+        getCompanionOperationId() === null && getMaximizedOperationId() === null ? canvas.minimized : [],
       );
       event.preventDefault();
       event.stopImmediatePropagation();
       if (order.length === 0) return;
-      const currentId = maximizedRef.current ?? stateRef.current.activeOperationId;
+      const currentId = getCompanionOperationId() ?? getMaximizedOperationId() ?? stateRef.current.activeOperationId;
       const nextId = nextOperationId(order, currentId, event.key === "ArrowRight" ? 1 : -1);
       if (!nextId) return;
-      if (maximizedRef.current) {
-        setActiveOperation(nextId);
-        setMaximizedOperationId(nextId);
-        return;
-      }
-      if (formationRef.current) {
-        restoreOperation(nextId);
-        setActiveOperation(nextId);
-        return;
-      }
-      // 모두 최소화된 부팅 상태의 폴백 대상은 store 포커스보다 먼저 복원한다. 그렇지 않으면 Canvas의
-      // "최소화된 active id 제거" effect가 pending focus 복원보다 앞서 실행되어 활성 표시를 지운다.
-      if (canvas.minimized.includes(nextId)) restoreOperation(nextId);
-      focusOperation(nextId);
+      routeOperationFocus(nextId, () => {
+        // 모두 최소화된 부팅 상태의 폴백 대상은 store 포커스보다 먼저 복원한다. 그렇지 않으면 Canvas의
+        // "최소화된 active id 제거" effect가 pending focus 복원보다 앞서 실행되어 활성 표시를 지운다.
+        if (canvas.minimized.includes(nextId)) restoreOperation(nextId);
+        focusOperation(nextId);
+      });
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, [formationView, maximizedOperationId]);
+  }, [companionOperationId, formationView, maximizedOperationId]);
 
   useEffect(() => {
     for (const operationId of operationOrder) ensureDefaultGeometry(operationId);
@@ -116,31 +107,23 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
     const bootOperationIds = claimBootPanelMinimization(state.activeTheaterId);
     if (bootOperationIds === null) return;
     // 선택으로 진입한 경우(pendingOperationFocus) 그 패널은 최소화에서 제외해 곧바로 표면화한다 — 선택한 패널만 하나씩 노출.
-    const focusId = stateRef.current.pendingOperationFocus;
-    minimizeOperations(focusId ? bootOperationIds.filter((id) => id !== focusId) : bootOperationIds);
+    const protectedIds = new Set([
+      stateRef.current.pendingOperationFocus,
+      getCompanionOperationId(),
+      getMaximizedOperationId(),
+    ].filter((id): id is string => id !== null));
+    minimizeOperations(bootOperationIds.filter((id) => !protectedIds.has(id)));
   }, [claimBootPanelMinimization, operationOrder, state.activeTheaterId, state.operationsHydrated]);
 
   // 검색·ALERTS 등에서 들어온 일회성 이동 요청을 처리한다.
   useEffect(() => {
     const operationId = state.pendingOperationFocus;
     if (operationId === null) return;
-    // 최대화 뷰 유지: theater 전환 effect(loadForTheater, 위쪽 effect)가 먼저 실행되어
-    // 도착 Theater의 최대화 상태를 복원한 뒤이므로, 여기서 getMaximizedOperationId()는 도착 Theater 기준값이다.
-    // 최대화 중이면 최대화 대상만 목적지 op로 교체한다 — handleFocus·Alt+←/→와 동일 정책.
-    if (getMaximizedOperationId() !== null) {
-      setMaximizedOperationId(operationId);
-      consumeOperationFocus();
-      return;
-    }
-    if (getFormationView()) {
-      restoreOperation(operationId);
-      setActiveOperation(operationId);
-      consumeOperationFocus();
-      return;
-    }
-    clearMaximizedOperationId();
-    const viewportSize = viewportSizeFor(bodyRef.current);
-    if (viewportSize) focusCanvasOperation(operationId, viewportSize);
+    // loadForTheater effect가 먼저 도착 Theater의 focus layer와 Formation underlay를 복원한다.
+    routeOperationFocus(operationId, () => {
+      const viewportSize = viewportSizeFor(bodyRef.current);
+      if (viewportSize) focusCanvasOperation(operationId, viewportSize);
+    });
     consumeOperationFocus();
   }, [state.pendingOperationFocus]);
 
@@ -180,26 +163,15 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       focusOperation(operationId);
       return;
     }
-    // 포커스 레이어가 활성화되어 있으면 같은 대상도 이 경로에서 끝낸다. 대상이 바뀔 때만 레이어를 전환한다.
-    // Alt+←/→ 순환(operations.tsx:73-76)과 동일 정책. getMaximizedOperationId()는 store 스냅샷에서 live로 읽으므로 [] deps 유지 가능.
-    const currentMaximized = getMaximizedOperationId();
-    if (currentMaximized !== null) {
-      setActiveOperation(operationId);
-      if (currentMaximized !== operationId) setMaximizedOperationId(operationId);
-      return;
-    }
-    if (getFormationView()) {
+    routeOperationFocus(operationId, () => {
+      const snapshot = getCanvasSnapshot();
+      const geometry = snapshot.operations[operationId] ?? operation.geometry ?? ensurePluginGeometry(operation);
+      if (!snapshot.operations[operationId]) setOperationGeometry(operationId, geometry);
       restoreOperation(operationId);
       setActiveOperation(operationId);
-      return;
-    }
-    const snapshot = getCanvasSnapshot();
-    const geometry = snapshot.operations[operationId] ?? operation.geometry ?? ensurePluginGeometry(operation);
-    if (!snapshot.operations[operationId]) setOperationGeometry(operationId, geometry);
-    restoreOperation(operationId);
-    setActiveOperation(operationId);
-    const viewportSize = viewportSizeFor(bodyRef.current);
-    if (viewportSize) focusCanvasOperation(operationId, viewportSize);
+      const viewportSize = viewportSizeFor(bodyRef.current);
+      if (viewportSize) focusCanvasOperation(operationId, viewportSize);
+    });
   }, []);
 
   const handleMinimize = useCallback((operationId: string) => {
@@ -280,6 +252,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
 
   const handleClose = useCallback((operationId: string) => {
     if (closingOperationIds.has(operationId)) return;
+    if (getCompanionOperationId() === operationId) forceDropCompanionOperationId();
     closingOperationIds.add(operationId);
     const pluginId = stateRef.current.operations.find((op) => op.id === operationId)?.pluginId;
     const plugin = (pluginId ? registry.plugins.find((p) => p.id === pluginId) : null) ?? null;
@@ -371,6 +344,26 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
   );
 }
 
+// 모든 사용자 포커스 진입점은 현재 로드된 Theater의 live 표시 상태만으로 같은 순서를 적용한다.
+function routeOperationFocus(operationId: string, focusMap: () => void): void {
+  if (getCompanionOperationId() !== null) {
+    setActiveOperation(operationId);
+    setCompanionOperationId(operationId);
+    return;
+  }
+  if (getMaximizedOperationId() !== null) {
+    setActiveOperation(operationId);
+    setMaximizedOperationId(operationId);
+    return;
+  }
+  if (getFormationView()) {
+    restoreOperation(operationId);
+    setActiveOperation(operationId);
+    return;
+  }
+  focusMap();
+}
+
 function sortedTheaterOperations(state: ConsoleState): readonly OperationNode[] {
   return state.operations
     .filter((operation) => operation.theaterId === state.activeTheaterId)
@@ -443,6 +436,8 @@ async function launchViaPlugin(
   // 존재하지 않는 포커스 대상을 가리켜 빈 화면이 박제된다.
   // hydrate된 경우에만 승계하고, 아니면 focusOperation(op 부재 시 안전하게 no-op)으로 기존 최대화 패널을 그대로 둔다.
   const operationHydrated = getState().operations.some((operation) => operation.id === newOperationId);
+  // Analyze는 명시적인 사용자 focus만 따라간다. 새 Operation 생성은 열린 분석 대상을 승계하지 않는다.
+  if (getTheaterCompanionOperationId(theaterId) !== null) return;
   if (stillOnLaunchTheater && operationHydrated && getMaximizedOperationId() !== null) {
     setActiveOperation(newOperationId);
     setMaximizedOperationId(newOperationId);

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -5,7 +5,7 @@ import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 import type { ClientApiCapability, FleetClientPlugin, OperationKindDescriptor } from "@fleet-console/sdk/plugin";
 
 import { addTheater, createGroup, deleteGroup, fetchGroups, fetchOperations, forgetTheater, issueTheaterFolderGrant, patchOperation, renameOperation, updateGroup, ApiError } from "../api.js";
-import { animateViewportTo, claimTopZIndex, clearFormationView, ensureDefaultGeometry, focusOperation as focusCanvasOperation, forceDropCompanionOperationId, getCompanionOperationId, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useCompanionOperationId, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
+import { animateViewportTo, claimTopZIndex, clearFormationView, ensureDefaultGeometry, focusOperation as focusCanvasOperation, forceDropCompanionOperationId, getCompanionOperationId, getFocusLayerRevision, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useCompanionOperationId, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
 import { screenToCanvas, type CanvasPoint } from "../canvas/coordinates.js";
 import { OperationsCanvas } from "../canvas/canvas.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
@@ -348,6 +348,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
 // 모든 사용자 포커스 진입점은 현재 로드된 Theater의 live 표시 상태만으로 같은 순서를 적용한다.
 async function routeOperationFocus(operationId: string, operationKinds: readonly OperationKindDescriptor[], api: ClientApiCapability, requestEpochRef: { current: number }, focusMap: () => void): Promise<void> {
   const requestEpoch = ++requestEpochRef.current;
+  const focusLayerRevision = getFocusLayerRevision();
   const currentCompanionOperationId = getCompanionOperationId();
   if (currentCompanionOperationId !== null) {
     const operation = getState().operations.find((candidate) => candidate.id === operationId);
@@ -360,7 +361,7 @@ async function routeOperationFocus(operationId: string, operationKinds: readonly
         canOpenCompanions = false;
       }
       // readiness 확인 중 사용자가 Exit·다른 Operation·다른 Theater로 이동했으면 오래된 결과를 버린다.
-      if (requestEpochRef.current !== requestEpoch || getCompanionOperationId() !== currentCompanionOperationId || getLoadedTheaterId() !== operation.theaterId) return;
+      if (requestEpochRef.current !== requestEpoch || getFocusLayerRevision() !== focusLayerRevision || getCompanionOperationId() !== currentCompanionOperationId || getLoadedTheaterId() !== operation.theaterId) return;
     }
     if (descriptor && (!descriptor.companions?.length || !canOpenCompanions)) {
       forceDropCompanionOperationId();

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -361,7 +361,8 @@ async function routeOperationFocus(operationId: string, operationKinds: readonly
         canOpenCompanions = false;
       }
       // readiness 확인 중 사용자가 Exit·다른 Operation·다른 Theater로 이동했으면 오래된 결과를 버린다.
-      if (requestEpochRef.current !== requestEpoch || getFocusLayerRevision() !== focusLayerRevision || getCompanionOperationId() !== currentCompanionOperationId || getLoadedTheaterId() !== operation.theaterId) return;
+      const liveOperation = getState().operations.find((candidate) => candidate.id === operationId);
+      if (requestEpochRef.current !== requestEpoch || getFocusLayerRevision() !== focusLayerRevision || getCompanionOperationId() !== currentCompanionOperationId || getLoadedTheaterId() !== operation.theaterId || !liveOperation || liveOperation.pluginId !== operation.pluginId || liveOperation.type !== operation.type || liveOperation.theaterId !== operation.theaterId) return;
     }
     if (operation && (!descriptor || !descriptor.companions?.length || !canOpenCompanions)) {
       forceDropCompanionOperationId();

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -85,7 +85,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       const currentId = getCompanionOperationId() ?? getMaximizedOperationId() ?? stateRef.current.activeOperationId;
       const nextId = nextOperationId(order, currentId, event.key === "ArrowRight" ? 1 : -1);
       if (!nextId) return;
-      routeOperationFocus(nextId, registry.operationKinds, () => {
+      void routeOperationFocus(nextId, registry.operationKinds, STABLE_RAIL_API, () => {
         // 모두 최소화된 부팅 상태의 폴백 대상은 store 포커스보다 먼저 복원한다. 그렇지 않으면 Canvas의
         // "최소화된 active id 제거" effect가 pending focus 복원보다 앞서 실행되어 활성 표시를 지운다.
         if (canvas.minimized.includes(nextId)) restoreOperation(nextId);
@@ -120,7 +120,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
     const operationId = state.pendingOperationFocus;
     if (operationId === null) return;
     // loadForTheater effect가 먼저 도착 Theater의 focus layer와 Formation underlay를 복원한다.
-    routeOperationFocus(operationId, registry.operationKinds, () => {
+    void routeOperationFocus(operationId, registry.operationKinds, STABLE_RAIL_API, () => {
       const viewportSize = viewportSizeFor(bodyRef.current);
       if (viewportSize) focusCanvasOperation(operationId, viewportSize);
     });
@@ -163,7 +163,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       focusOperation(operationId);
       return;
     }
-    routeOperationFocus(operationId, registry.operationKinds, () => {
+    void routeOperationFocus(operationId, registry.operationKinds, STABLE_RAIL_API, () => {
       const snapshot = getCanvasSnapshot();
       const geometry = snapshot.operations[operationId] ?? operation.geometry ?? ensurePluginGeometry(operation);
       if (!snapshot.operations[operationId]) setOperationGeometry(operationId, geometry);
@@ -345,11 +345,22 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
 }
 
 // 모든 사용자 포커스 진입점은 현재 로드된 Theater의 live 표시 상태만으로 같은 순서를 적용한다.
-function routeOperationFocus(operationId: string, operationKinds: readonly OperationKindDescriptor[], focusMap: () => void): void {
-  if (getCompanionOperationId() !== null) {
+async function routeOperationFocus(operationId: string, operationKinds: readonly OperationKindDescriptor[], api: ClientApiCapability, focusMap: () => void): Promise<void> {
+  const currentCompanionOperationId = getCompanionOperationId();
+  if (currentCompanionOperationId !== null) {
     const operation = getState().operations.find((candidate) => candidate.id === operationId);
     const descriptor = operation && operationKinds.find((kind) => kind.pluginId === operation.pluginId && kind.type === operation.type);
-    if (descriptor && !descriptor.companions?.length) {
+    let canOpenCompanions = true;
+    if (operation && descriptor?.companions?.length && descriptor.canOpenCompanions) {
+      try {
+        canOpenCompanions = await descriptor.canOpenCompanions({ api, operation });
+      } catch {
+        canOpenCompanions = false;
+      }
+      // readiness 확인 중 사용자가 Exit·다른 Operation·다른 Theater로 이동했으면 오래된 결과를 버린다.
+      if (getCompanionOperationId() !== currentCompanionOperationId || getLoadedTheaterId() !== operation.theaterId) return;
+    }
+    if (descriptor && (!descriptor.companions?.length || !canOpenCompanions)) {
       forceDropCompanionOperationId();
       clearFormationView();
       focusMap();

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -161,6 +161,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
     const operation = stateRef.current.operations.find((candidate) => candidate.id === operationId);
     if (!operation) return;
     if (operation.theaterId !== stateRef.current.activeTheaterId) {
+      focusRequestEpochRef.current += 1;
       focusOperation(operationId);
       return;
     }
@@ -366,9 +367,10 @@ async function routeOperationFocus(operationId: string, operationKinds: readonly
         canOpenCompanions = false;
       }
       // readiness 확인 중 사용자가 Exit·다른 Operation·다른 Theater로 이동하거나 대상을 새로 숨겼으면 오래된 결과를 버린다.
-      const liveOperation = getState().operations.find((candidate) => candidate.id === operationId);
+      const liveState = getState();
+      const liveOperation = liveState.operations.find((candidate) => candidate.id === operationId);
       const operationWasHidden = !operationWasMinimized && getCanvasSnapshot().minimized.includes(operationId);
-      if (requestEpochRef.current !== requestEpoch || getFocusLayerRevision() !== focusLayerRevision || getCompanionOperationId() !== currentCompanionOperationId || getLoadedTheaterId() !== operation.theaterId || operationWasHidden || closingOperationIds.has(operationId) || !liveOperation || liveOperation.pluginId !== operation.pluginId || liveOperation.type !== operation.type || liveOperation.theaterId !== operation.theaterId) return;
+      if (requestEpochRef.current !== requestEpoch || getFocusLayerRevision() !== focusLayerRevision || getCompanionOperationId() !== currentCompanionOperationId || liveState.activeTheaterId !== operation.theaterId || getLoadedTheaterId() !== operation.theaterId || operationWasHidden || closingOperationIds.has(operationId) || !liveOperation || liveOperation.pluginId !== operation.pluginId || liveOperation.type !== operation.type || liveOperation.theaterId !== operation.theaterId) return;
     }
     if (operation && (!descriptor || !descriptor.companions?.length || !canOpenCompanions)) {
       forceDropCompanionOperationId();

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 
 import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console/sdk/operations";
 import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
-import type { ClientApiCapability, FleetClientPlugin } from "@fleet-console/sdk/plugin";
+import type { ClientApiCapability, FleetClientPlugin, OperationKindDescriptor } from "@fleet-console/sdk/plugin";
 
 import { addTheater, createGroup, deleteGroup, fetchGroups, fetchOperations, forgetTheater, issueTheaterFolderGrant, patchOperation, renameOperation, updateGroup, ApiError } from "../api.js";
 import { animateViewportTo, claimTopZIndex, ensureDefaultGeometry, focusOperation as focusCanvasOperation, forceDropCompanionOperationId, getCompanionOperationId, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useCompanionOperationId, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
@@ -85,7 +85,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       const currentId = getCompanionOperationId() ?? getMaximizedOperationId() ?? stateRef.current.activeOperationId;
       const nextId = nextOperationId(order, currentId, event.key === "ArrowRight" ? 1 : -1);
       if (!nextId) return;
-      routeOperationFocus(nextId, () => {
+      routeOperationFocus(nextId, registry.operationKinds, () => {
         // 모두 최소화된 부팅 상태의 폴백 대상은 store 포커스보다 먼저 복원한다. 그렇지 않으면 Canvas의
         // "최소화된 active id 제거" effect가 pending focus 복원보다 앞서 실행되어 활성 표시를 지운다.
         if (canvas.minimized.includes(nextId)) restoreOperation(nextId);
@@ -94,7 +94,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, [companionOperationId, formationView, maximizedOperationId]);
+  }, [companionOperationId, formationView, maximizedOperationId, registry.operationKinds]);
 
   useEffect(() => {
     for (const operationId of operationOrder) ensureDefaultGeometry(operationId);
@@ -120,12 +120,12 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
     const operationId = state.pendingOperationFocus;
     if (operationId === null) return;
     // loadForTheater effect가 먼저 도착 Theater의 focus layer와 Formation underlay를 복원한다.
-    routeOperationFocus(operationId, () => {
+    routeOperationFocus(operationId, registry.operationKinds, () => {
       const viewportSize = viewportSizeFor(bodyRef.current);
       if (viewportSize) focusCanvasOperation(operationId, viewportSize);
     });
     consumeOperationFocus();
-  }, [state.pendingOperationFocus]);
+  }, [registry.operationKinds, state.pendingOperationFocus]);
 
   const canLaunch = !!state.activeTheaterId && !state.addingTheater;
   const theaterOperations = (state.operations ?? []).filter((op) => op.theaterId === state.activeTheaterId);
@@ -163,7 +163,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       focusOperation(operationId);
       return;
     }
-    routeOperationFocus(operationId, () => {
+    routeOperationFocus(operationId, registry.operationKinds, () => {
       const snapshot = getCanvasSnapshot();
       const geometry = snapshot.operations[operationId] ?? operation.geometry ?? ensurePluginGeometry(operation);
       if (!snapshot.operations[operationId]) setOperationGeometry(operationId, geometry);
@@ -172,7 +172,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       const viewportSize = viewportSizeFor(bodyRef.current);
       if (viewportSize) focusCanvasOperation(operationId, viewportSize);
     });
-  }, []);
+  }, [registry.operationKinds]);
 
   const handleMinimize = useCallback((operationId: string) => {
     if (stateRef.current.activeOperationId === operationId) setActiveOperation(null);
@@ -345,8 +345,15 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
 }
 
 // 모든 사용자 포커스 진입점은 현재 로드된 Theater의 live 표시 상태만으로 같은 순서를 적용한다.
-function routeOperationFocus(operationId: string, focusMap: () => void): void {
+function routeOperationFocus(operationId: string, operationKinds: readonly OperationKindDescriptor[], focusMap: () => void): void {
   if (getCompanionOperationId() !== null) {
+    const operation = getState().operations.find((candidate) => candidate.id === operationId);
+    const descriptor = operation && operationKinds.find((kind) => kind.pluginId === operation.pluginId && kind.type === operation.type);
+    if (descriptor && !descriptor.companions?.length) {
+      forceDropCompanionOperationId();
+      focusMap();
+      return;
+    }
     setActiveOperation(operationId);
     setCompanionOperationId(operationId);
     return;

--- a/runtime/fleet-console/sdk/plugin/types.ts
+++ b/runtime/fleet-console/sdk/plugin/types.ts
@@ -93,6 +93,12 @@ export interface OperationKindDescriptor {
   readonly subtitle?: (operation: OperationNode) => string | undefined;
   readonly render?: (context: OperationRenderContext) => ReactNode;
   readonly companions?: readonly CompanionPanelDescriptor[];
+  readonly canOpenCompanions?: (context: OperationCompanionAvailabilityContext) => boolean | Promise<boolean>;
+}
+
+export interface OperationCompanionAvailabilityContext {
+  readonly api: ClientApiCapability;
+  readonly operation: OperationNode;
 }
 
 export interface CompanionPanelDescriptor {

--- a/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
+++ b/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OperationsCanvas } from "../core/client/src/canvas/canvas.js";
 import { CanvasMinimap } from "../core/client/src/canvas/canvas-minimap.js";
-import { clearCompanionOperationId, clearFormationView, clearMaximizedOperationId, getCompanionOperationId, getSnapshot, loadForTheater, setMaximizedOperationId, setState, toggleFormationView } from "../core/client/src/canvas/canvas-store.js";
+import { clearCompanionOperationId, clearFormationView, clearMaximizedOperationId, getCompanionOperationId, getFormationView, getMaximizedOperationId, getSnapshot, loadForTheater, minimizeOperation, setMaximizedOperationId, setState, toggleFormationView } from "../core/client/src/canvas/canvas-store.js";
 import type { ConsoleState, OperationNode } from "../core/client/src/types.js";
 
 vi.mock("../core/client/src/plugin-registry.js", () => ({
@@ -246,12 +246,47 @@ describe("CanvasMinimap collapse behavior", () => {
     expect(getCompanionOperationId()).toBeNull();
   });
 
+  it("renders Analyze over Formation and restores the preserved Formation layout on Exit", () => {
+    renderOperationsCanvas();
+    const targetBody = document.querySelector<HTMLElement>('[data-plugin-operation="operation"]');
+    act(() => toggleFormationView());
+    expect(document.querySelector(".operations-canvas")?.classList.contains("is-formation-view")).toBe(true);
+
+    act(() => targetBody?.click());
+    expect(getCompanionOperationId()).toBe("operation");
+    expect(getFormationView()).toBe(true);
+    expect(document.querySelector(".operations-canvas")?.classList.contains("is-companion-layout")).toBe(true);
+
+    act(() => targetBody?.click());
+    expect(getCompanionOperationId()).toBeNull();
+    expect(getFormationView()).toBe(true);
+    expect(document.querySelector(".operations-canvas")?.classList.contains("is-formation-view")).toBe(true);
+  });
+
+  it("restores Maximized on explicit Exit but force-drops it when the target is minimized", () => {
+    renderOperationsCanvas();
+    const targetBody = document.querySelector<HTMLElement>('[data-plugin-operation="operation"]');
+    act(() => setMaximizedOperationId("operation"));
+    act(() => targetBody?.click());
+    expect(getCompanionOperationId()).toBe("operation");
+
+    act(() => targetBody?.click());
+    expect(getMaximizedOperationId()).toBe("operation");
+    expect(document.querySelector(".operations-canvas")?.classList.contains("is-panel-maximized")).toBe(true);
+
+    act(() => targetBody?.click());
+    act(() => minimizeOperation("operation"));
+    expect(getCompanionOperationId()).toBeNull();
+    expect(getMaximizedOperationId()).toBeNull();
+  });
+
   it("keeps the companion layout and frames during the missing-operation grace period", () => {
     vi.useFakeTimers();
     try {
       renderOperationsCanvas();
       const targetFrame = document.querySelector<HTMLElement>('[aria-label="Operation Minimap boundary"]');
       const targetBody = document.querySelector<HTMLElement>('[data-plugin-operation="operation"]');
+      act(() => setMaximizedOperationId("operation"));
       act(() => targetBody?.click());
 
       renderOperationsCanvas({ ...CANVAS_STATE, operations: [PEER_OPERATION] });
@@ -268,6 +303,7 @@ describe("CanvasMinimap collapse behavior", () => {
 
       act(() => vi.advanceTimersByTime(1));
       expect(getCompanionOperationId()).toBeNull();
+      expect(getMaximizedOperationId()).toBeNull();
       expect(document.querySelector(".operations-canvas")?.classList.contains("is-companion-layout")).toBe(false);
       expect(document.querySelector('[aria-label="Operation Minimap boundary"]')).toBeNull();
       expect(document.querySelectorAll(".canvas-companion-frame")).toHaveLength(0);

--- a/runtime/fleet-console/tests/canvas-store.test.ts
+++ b/runtime/fleet-console/tests/canvas-store.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { calculateGridSlots, clearCompanionOperationId, clearFormationView, clearMaximizedOperationId, getCompanionOperationId, getFormationLayout, getFormationView, getMaximizedOperationId, getSnapshot, getTheaterCanvasSnapshot, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, selectFormationLayout, setCompanionOperationId, setFormationLayout, setMaximizedOperationId, setOperationAccent, setOperationGeometry, setOperationOrder, setState, toggleFormationView, toggleTheaterGroupCollapsed, type OperationGeometry } from "../core/client/src/canvas/canvas-store.js";
+import { calculateGridSlots, clearCompanionOperationId, clearFormationView, clearMaximizedOperationId, forceDropCompanionOperationId, getCompanionOperationId, getFormationLayout, getFormationView, getMaximizedOperationId, getSnapshot, getTheaterCanvasSnapshot, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, selectFormationLayout, setCompanionOperationId, setFormationLayout, setMaximizedOperationId, setOperationAccent, setOperationGeometry, setOperationOrder, setState, toggleFormationView, toggleTheaterGroupCollapsed, type OperationGeometry } from "../core/client/src/canvas/canvas-store.js";
 
 const GEOMETRY: OperationGeometry = { x: 0, y: 0, width: 100, height: 100, zIndex: 0 };
 
@@ -37,19 +37,17 @@ afterEach(() => {
 });
 
 describe("canvas store", () => {
-  it("enters companion layout without mutating Map state and restores a minimized target", () => {
+  it("captures Map underlay once, retargets without mutating it, and exits to Map", () => {
     setOperationGeometry("op-a", { ...GEOMETRY, x: 48, y: 72 });
     setOperationGeometry("op-b", { ...GEOMETRY });
     minimizeOperation("op-a");
     const viewport = { x: 24, y: 36, zoom: 0.75 };
     setState({ viewport });
     const operations = getSnapshot().operations;
-    toggleFormationView();
-    setMaximizedOperationId("op-b");
-
     setCompanionOperationId("op-a");
+    setCompanionOperationId("op-b");
 
-    expect(getCompanionOperationId()).toBe("op-a");
+    expect(getCompanionOperationId()).toBe("op-b");
     expect(getMaximizedOperationId()).toBeNull();
     expect(getFormationView()).toBe(false);
     expect(getSnapshot().minimized).toEqual([]);
@@ -59,6 +57,86 @@ describe("canvas store", () => {
     clearCompanionOperationId();
     expect(getSnapshot().viewport).toEqual(viewport);
     expect(getSnapshot().operations).toEqual(operations);
+  });
+
+  it("preserves Formation as the underlay across retarget and normal Exit", () => {
+    setOperationGeometry("op-a", { ...GEOMETRY });
+    setOperationGeometry("op-b", { ...GEOMETRY, x: 120 });
+    const operations = getSnapshot().operations;
+    toggleFormationView();
+
+    setCompanionOperationId("op-a");
+    setCompanionOperationId("op-b");
+
+    expect(getFormationView()).toBe(true);
+    expect(getCompanionOperationId()).toBe("op-b");
+    clearCompanionOperationId();
+    expect(getFormationView()).toBe(true);
+    expect(getSnapshot().operations).toEqual(operations);
+  });
+
+  it("restores Maximized around the latest valid retarget on normal Exit", () => {
+    setOperationGeometry("op-a", { ...GEOMETRY });
+    setOperationGeometry("op-b", { ...GEOMETRY });
+    setMaximizedOperationId("op-a");
+
+    setCompanionOperationId("op-a");
+    setCompanionOperationId("op-b");
+    clearCompanionOperationId();
+
+    expect(getCompanionOperationId()).toBeNull();
+    expect(getMaximizedOperationId()).toBe("op-b");
+  });
+
+  it("does not restore Maximized after minimize, removal, or an explicit replacement", () => {
+    setOperationGeometry("op-a", { ...GEOMETRY });
+    setOperationGeometry("op-b", { ...GEOMETRY });
+    setMaximizedOperationId("op-a");
+    setCompanionOperationId("op-a");
+    setCompanionOperationId("op-b");
+    minimizeOperation("op-b");
+    expect(getCompanionOperationId()).toBeNull();
+    expect(getMaximizedOperationId()).toBeNull();
+
+    setMaximizedOperationId("op-a");
+    setCompanionOperationId("op-a");
+    pruneOperations([]);
+    clearCompanionOperationId();
+    expect(getMaximizedOperationId()).toBeNull();
+
+    setOperationGeometry("op-a", { ...GEOMETRY });
+    setMaximizedOperationId("op-a");
+    setCompanionOperationId("op-a");
+    setMaximizedOperationId("op-b");
+    expect(getCompanionOperationId()).toBeNull();
+    expect(getMaximizedOperationId()).toBe("op-b");
+  });
+
+  it("force-drops Analyze without restoring", () => {
+    setOperationGeometry("op-a", { ...GEOMETRY });
+    setMaximizedOperationId("op-a");
+    setCompanionOperationId("op-a");
+    forceDropCompanionOperationId();
+    expect(getMaximizedOperationId()).toBeNull();
+
+  });
+
+  it("keeps Formation active when same or different layout explicitly replaces Analyze", () => {
+    setOperationGeometry("op-a", { ...GEOMETRY });
+    toggleFormationView();
+    expect(getFormationLayout()).toBe("grid");
+
+    setCompanionOperationId("op-a");
+    selectFormationLayout("grid");
+    expect(getCompanionOperationId()).toBeNull();
+    expect(getFormationView()).toBe(true);
+    expect(getFormationLayout()).toBe("grid");
+
+    setCompanionOperationId("op-a");
+    selectFormationLayout("columns");
+    expect(getCompanionOperationId()).toBeNull();
+    expect(getFormationView()).toBe(true);
+    expect(getFormationLayout()).toBe("columns");
   });
 
   it("clears companion layout when maximize or Formation takes ownership", () => {
@@ -85,7 +163,9 @@ describe("canvas store", () => {
     expect(getCompanionOperationId()).toBeNull();
   });
 
-  it("keeps companionOperationId through a same-theater reload and restores it per Theater", () => {
+  it("keeps companion target and return mode scoped independently per Theater", () => {
+    setOperationGeometry("op-a", { ...GEOMETRY });
+    setMaximizedOperationId("op-a");
     setCompanionOperationId("op-a");
     // ops 동기화가 loadForTheater를 같은 Theater로 다시 불러도 열린 분석 레이아웃은 보존되어야 한다.
     loadForTheater("theater-a");
@@ -93,13 +173,19 @@ describe("canvas store", () => {
 
     loadForTheater("theater-b");
     expect(getCompanionOperationId()).toBeNull();
+    setOperationGeometry("op-b", { ...GEOMETRY });
+    toggleFormationView();
+    setCompanionOperationId("op-b");
 
     loadForTheater("theater-a");
     expect(getCompanionOperationId()).toBe("op-a");
-
     clearCompanionOperationId();
-    loadForTheater("theater-a");
-    expect(getCompanionOperationId()).toBeNull();
+    expect(getMaximizedOperationId()).toBe("op-a");
+
+    loadForTheater("theater-b");
+    expect(getCompanionOperationId()).toBe("op-b");
+    clearCompanionOperationId();
+    expect(getFormationView()).toBe(true);
   });
 
   it("restores maximizedOperationId independently for each Theater", () => {

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -414,6 +414,26 @@ describe("Operations boot minimization", () => {
     expect(getSnapshot().minimized).not.toContain("second");
   });
 
+  it("falls back to Map when an Analyze retarget has no registered descriptor", async () => {
+    await bootApp([operation("first"), operation("second")]);
+    await act(async () => {
+      toggleFormationView();
+      setCompanionOperationId("first");
+      minimizeOperation("second");
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      sideBarMocks.onFocus?.("second");
+      await Promise.resolve();
+    });
+
+    expect(getCompanionOperationId()).toBeNull();
+    expect(getFormationView()).toBe(false);
+    expect(getState().activeOperationId).toBe("second");
+    expect(getSnapshot().minimized).not.toContain("second");
+  });
+
   it("applies only the latest asynchronous Analyze retarget", async () => {
     const secondReady = deferred<boolean>();
     const thirdReady = deferred<boolean>();
@@ -479,6 +499,7 @@ describe("Operations boot minimization", () => {
   });
 
   it("retargets Analyze with Alt+Arrow before Maximized and Formation", async () => {
+    registryMocks.operationKinds = [companionKind(() => true)];
     await bootApp([operation("first"), operation("second")]);
     await act(async () => {
       toggleFormationView();
@@ -501,6 +522,7 @@ describe("Operations boot minimization", () => {
   });
 
   it("retargets Analyze through pending focus using the destination Theater's layer", async () => {
+    registryMocks.operationKinds = [companionKind(() => true)];
     await bootApp(
       [operation("a1", 1, "theater-a"), operation("b1", 1, "theater-b"), operation("b2", 2, "theater-b")],
       [theater(), theater("theater-b", "Theater B")],

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -444,6 +444,27 @@ describe("Operations boot minimization", () => {
     expect(getCompanionOperationId()).toBe("third");
   });
 
+  it("discards an asynchronous retarget after Analyze exits and reopens", async () => {
+    const secondReady = deferred<boolean>();
+    registryMocks.operationKinds = [companionKind(() => secondReady.promise)];
+    await bootApp([operation("first"), operation("second")]);
+    await act(async () => {
+      setCompanionOperationId("first");
+      await Promise.resolve();
+    });
+
+    act(() => sideBarMocks.onFocus?.("second"));
+    await act(async () => {
+      clearCompanionOperationId();
+      setCompanionOperationId("first");
+      secondReady.resolve(true);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getCompanionOperationId()).toBe("first");
+  });
+
   it("force-drops Analyze immediately when Sidebar closes its target", async () => {
     await bootApp([operation("first")]);
     await act(async () => {

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -513,6 +513,34 @@ describe("Operations boot minimization", () => {
     expect(getState().activeOperationId).not.toBe("second");
   });
 
+  it("discards an asynchronous Analyze retarget while its destination is closing", async () => {
+    const secondReady = deferred<boolean>();
+    const closeRefresh = deferred<readonly OperationNode[]>();
+    registryMocks.operationKinds = [companionKind(() => secondReady.promise)];
+    await bootApp([operation("first"), operation("second")]);
+    await act(async () => {
+      setCompanionOperationId("first");
+      await Promise.resolve();
+    });
+
+    act(() => sideBarMocks.onFocus?.("second"));
+    apiMocks.fetchOperations.mockReturnValueOnce(closeRefresh.promise);
+    act(() => sideBarMocks.onClose?.("second"));
+    await act(async () => {
+      secondReady.resolve(true);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getState().operations.some((candidate) => candidate.id === "second")).toBe(true);
+    expect(getCompanionOperationId()).toBe("first");
+
+    await act(async () => {
+      closeRefresh.resolve([operation("first")]);
+      await vi.waitFor(() => expect(getState().operations.some((candidate) => candidate.id === "second")).toBe(false));
+    });
+  });
+
   it("discards an asynchronous Analyze retarget after its destination is minimized", async () => {
     const secondReady = deferred<boolean>();
     registryMocks.operationKinds = [companionKind(() => secondReady.promise)];

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -647,6 +647,35 @@ describe("Operations boot minimization", () => {
     expect(getMaximizedOperationId()).toBe("b2");
   });
 
+  it("discards an asynchronous Analyze retarget when a newer focus changes Theater", async () => {
+    const secondReady = deferred<boolean>();
+    const canOpenCompanions = vi.fn(() => secondReady.promise);
+    registryMocks.operationKinds = [companionKind(canOpenCompanions)];
+    await bootApp(
+      [operation("first"), operation("second"), operation("b1", 1, "theater-b")],
+      [theater(), theater("theater-b", "Theater B")],
+    );
+    await act(async () => {
+      setCompanionOperationId("first");
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      sideBarMocks.onFocus?.("second");
+      await Promise.resolve();
+      sideBarMocks.onFocus?.("b1");
+      expect(getState().activeTheaterId).toBe("theater-b");
+      secondReady.resolve(true);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(canOpenCompanions).toHaveBeenCalledOnce();
+    expect(getState().activeTheaterId).toBe("theater-b");
+    expect(getTheaterCompanionOperationId("theater-a")).toBe("first");
+    expect(getCompanionOperationId()).toBeNull();
+  });
+
   it("does not retarget Analyze when launch starts with it open", async () => {
     const launch = deferred<{ readonly id: string }>();
     registryMocks.plugins = [{ id: "terminal", launch: vi.fn(() => launch.promise) }];

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -485,6 +485,31 @@ describe("Operations boot minimization", () => {
     expect(getCompanionOperationId()).toBe("first");
   });
 
+  it("discards an asynchronous Analyze retarget after its destination closes", async () => {
+    const secondReady = deferred<boolean>();
+    registryMocks.operationKinds = [companionKind(() => secondReady.promise)];
+    await bootApp([operation("first"), operation("second")]);
+    await act(async () => {
+      setCompanionOperationId("first");
+      await Promise.resolve();
+    });
+
+    act(() => sideBarMocks.onFocus?.("second"));
+    apiMocks.fetchOperations.mockResolvedValue([operation("first")]);
+    await act(async () => {
+      sideBarMocks.onClose?.("second");
+      await vi.waitFor(() => expect(getState().operations.some((candidate) => candidate.id === "second")).toBe(false));
+    });
+    await act(async () => {
+      secondReady.resolve(true);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getCompanionOperationId()).toBe("first");
+    expect(getState().activeOperationId).not.toBe("second");
+  });
+
   it("force-drops Analyze immediately when Sidebar closes its target", async () => {
     await bootApp([operation("first")]);
     await act(async () => {

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -5,7 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { clearFormationView, clearMaximizedOperationId, getFormationView, getMaximizedOperationId, getSnapshot, loadForTheater, restoreOperation, setMaximizedOperationId, setOperationGeometry, setViewport, toggleFormationView } from "../core/client/src/canvas/canvas-store.js";
+import { clearCompanionOperationId, clearFormationView, clearMaximizedOperationId, getCompanionOperationId, getFormationView, getMaximizedOperationId, getSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, setViewport, toggleFormationView } from "../core/client/src/canvas/canvas-store.js";
 import { focusOperation, getState, hydrateOperations, setState } from "../core/client/src/store.js";
 import type { OperationNode, TheaterBootstrap } from "../core/client/src/types.js";
 
@@ -19,7 +19,12 @@ const keyboardShortcutMocks = vi.hoisted(() => ({
 }));
 const sideBarMocks = vi.hoisted(() => ({
   onFocus: null as null | ((operationId: string) => void),
+  onClose: null as null | ((operationId: string) => void),
 }));
+const canvasMocks = vi.hoisted(() => ({
+  onLaunchAtGeometry: null as null | ((pluginId: string, kind: { readonly type: string; readonly title: string }, geometry: { readonly x: number; readonly y: number; readonly width: number; readonly height: number; readonly zIndex: number }) => void),
+}));
+const registryMocks = vi.hoisted(() => ({ plugins: [] as Array<Record<string, unknown>> }));
 
 vi.mock("../core/client/src/api.js", () => ({
   ...apiMocks,
@@ -42,7 +47,12 @@ vi.mock("../core/client/src/api.js", () => ({
 }));
 
 vi.mock("@fleet-console/sdk/operations/browser", () => ({ fetchOperationCatalog: vi.fn().mockResolvedValue([]) }));
-vi.mock("../core/client/src/canvas/canvas.js", () => ({ OperationsCanvas: () => null }));
+vi.mock("../core/client/src/canvas/canvas.js", () => ({
+  OperationsCanvas: ({ onLaunchAtGeometry }: { readonly onLaunchAtGeometry: NonNullable<typeof canvasMocks.onLaunchAtGeometry> }) => {
+    canvasMocks.onLaunchAtGeometry = onLaunchAtGeometry;
+    return null;
+  },
+}));
 vi.mock("../core/client/src/components/codex-reading-sheet.js", () => ({ CodexReadingSheet: () => null }));
 vi.mock("../core/client/src/components/command-band.js", () => ({ CommandBand: () => null }));
 vi.mock("../core/client/src/components/commissioning-overlay.js", () => ({ CommissioningOverlay: () => null }));
@@ -54,14 +64,15 @@ vi.mock("../core/client/src/global-settings-store.js", () => ({ useGlobalSetting
 vi.mock("../core/client/src/operations-sse.js", () => ({ refreshObserverStatus: vi.fn() }));
 vi.mock("../core/client/src/pages/global-settings.js", () => ({ GlobalSettings: () => createElement("div", { "data-route": "settings" }) }));
 vi.mock("../core/client/src/plugin-capabilities.js", () => ({ createHostCapabilities: () => ({ api: {} }) }));
-vi.mock("../core/client/src/plugin-registry.js", () => ({ usePluginRegistry: () => ({ plugins: [], operationKinds: [], settingsSections: [], notificationKinds: [], railPanels: [] }) }));
+vi.mock("../core/client/src/plugin-registry.js", () => ({ usePluginRegistry: () => ({ plugins: registryMocks.plugins, operationKinds: [], settingsSections: [], notificationKinds: [], railPanels: [] }) }));
 vi.mock("../core/client/src/rail/rail-store.js", () => ({ toggleRailChrome: vi.fn() }));
 vi.mock("../core/client/src/rail/right-rail.js", () => ({ RightRail: () => null }));
 vi.mock("../core/client/src/release-notes-fetch.js", () => ({ abortReleaseNotesFetch: vi.fn(), requestReleaseNotes: vi.fn() }));
 vi.mock("../core/client/src/sidebar/operations-side-bar-store.js", () => ({ getSideBarState: () => ({ collapsed: false }), setSideBarCollapsed: vi.fn() }));
 vi.mock("../core/client/src/sidebar/operations-side-bar.js", () => ({
-  OperationsSideBar: ({ onFocus }: { readonly onFocus: (operationId: string) => void }) => {
+  OperationsSideBar: ({ onClose, onFocus }: { readonly onClose: (operationId: string) => void; readonly onFocus: (operationId: string) => void }) => {
     sideBarMocks.onFocus = onFocus;
+    sideBarMocks.onClose = onClose;
     return null;
   },
 }));
@@ -78,6 +89,7 @@ beforeEach(() => {
   window.history.replaceState({}, "", "/operations");
   loadForTheater("theater-a");
   clearMaximizedOperationId();
+  clearCompanionOperationId();
   clearFormationView();
   loadForTheater(null);
   setState({ activeOperationId: null, activeTheaterId: null, groups: [], operations: [], operationsHydrated: false, theaters: [] });
@@ -87,14 +99,19 @@ beforeEach(() => {
   apiMocks.fetchGroups.mockResolvedValue([]);
   keyboardShortcutMocks.shouldHandleOperationsKeyboardShortcut.mockReturnValue(false);
   sideBarMocks.onFocus = null;
+  sideBarMocks.onClose = null;
+  canvasMocks.onLaunchAtGeometry = null;
+  registryMocks.plugins = [];
 });
 
 afterEach(() => {
   act(() => root?.unmount());
   loadForTheater("theater-a");
+  clearCompanionOperationId();
   clearMaximizedOperationId();
   clearFormationView();
   loadForTheater("theater-b");
+  clearCompanionOperationId();
   clearMaximizedOperationId();
   clearFormationView();
   loadForTheater(null);
@@ -346,6 +363,158 @@ describe("Operations boot minimization", () => {
     expect(getSnapshot().operations.b1).toEqual(destinationGeometry);
   });
 
+  it("retargets Analyze through sidebar focus and surfaces a minimized target", async () => {
+    await bootApp([operation("first"), operation("second")]);
+    await act(async () => {
+      setCompanionOperationId("first");
+      minimizeOperation("second");
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      sideBarMocks.onFocus?.("second");
+      await Promise.resolve();
+    });
+
+    expect(getCompanionOperationId()).toBe("second");
+    expect(getState().activeOperationId).toBe("second");
+    expect(getSnapshot().minimized).not.toContain("second");
+  });
+
+  it("force-drops Analyze immediately when Sidebar closes its target", async () => {
+    await bootApp([operation("first")]);
+    await act(async () => {
+      setCompanionOperationId("first");
+      await Promise.resolve();
+    });
+    apiMocks.fetchOperations.mockResolvedValue([]);
+
+    act(() => sideBarMocks.onClose?.("first"));
+
+    expect(getCompanionOperationId()).toBeNull();
+  });
+
+  it("retargets Analyze with Alt+Arrow before Maximized and Formation", async () => {
+    await bootApp([operation("first"), operation("second")]);
+    await act(async () => {
+      toggleFormationView();
+      setMaximizedOperationId("first");
+      setCompanionOperationId("first");
+      await Promise.resolve();
+    });
+
+    keyboardShortcutMocks.shouldHandleOperationsKeyboardShortcut.mockReturnValue(true);
+    const event = new KeyboardEvent("keydown", { key: "ArrowRight", altKey: true, cancelable: true });
+    await act(async () => {
+      window.dispatchEvent(event);
+      await Promise.resolve();
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(getCompanionOperationId()).toBe("second");
+    expect(getMaximizedOperationId()).toBeNull();
+    expect(getFormationView()).toBe(true);
+  });
+
+  it("retargets Analyze through pending focus using the destination Theater's layer", async () => {
+    await bootApp(
+      [operation("a1", 1, "theater-a"), operation("b1", 1, "theater-b"), operation("b2", 2, "theater-b")],
+      [theater(), theater("theater-b", "Theater B")],
+    );
+    await act(async () => {
+      loadForTheater("theater-b");
+      setOperationGeometry("b1", { x: 0, y: 0, width: 640, height: 400, zIndex: 1 });
+      setOperationGeometry("b2", { x: 40, y: 40, width: 640, height: 400, zIndex: 2 });
+      setMaximizedOperationId("b1");
+      setCompanionOperationId("b1");
+      loadForTheater("theater-a");
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      focusOperation("b2");
+      await Promise.resolve();
+    });
+
+    expect(getState().activeTheaterId).toBe("theater-b");
+    expect(getCompanionOperationId()).toBe("b2");
+    clearCompanionOperationId();
+    expect(getMaximizedOperationId()).toBe("b2");
+  });
+
+  it("does not retarget Analyze when launch starts with it open", async () => {
+    const launch = deferred<{ readonly id: string }>();
+    registryMocks.plugins = [{ id: "terminal", launch: vi.fn(() => launch.promise) }];
+    await bootApp([operation("first")]);
+    await act(async () => {
+      setCompanionOperationId("first");
+      await Promise.resolve();
+    });
+    apiMocks.fetchOperations.mockResolvedValue([operation("first"), operation("launched", 2)]);
+
+    await act(async () => {
+      canvasMocks.onLaunchAtGeometry?.("terminal", { type: "shell", title: "Shell" }, { x: 0, y: 0, width: 640, height: 400, zIndex: 2 });
+      launch.resolve({ id: "launched" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getCompanionOperationId()).toBe("first");
+  });
+
+  it("uses live completion state when Analyze opens during an in-flight launch", async () => {
+    const launch = deferred<{ readonly id: string }>();
+    registryMocks.plugins = [{ id: "terminal", launch: vi.fn(() => launch.promise) }];
+    await bootApp([operation("first")]);
+    apiMocks.fetchOperations.mockResolvedValue([operation("first"), operation("launched", 2)]);
+
+    await act(async () => {
+      canvasMocks.onLaunchAtGeometry?.("terminal", { type: "shell", title: "Shell" }, { x: 0, y: 0, width: 640, height: 400, zIndex: 2 });
+      await Promise.resolve();
+    });
+    await act(async () => {
+      setCompanionOperationId("first");
+      launch.resolve({ id: "launched" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getCompanionOperationId()).toBe("first");
+  });
+
+  it("keeps the destination Theater active and preserves the launch Theater Analyze target", async () => {
+    const launch = deferred<{ readonly id: string }>();
+    registryMocks.plugins = [{ id: "terminal", launch: vi.fn(() => launch.promise) }];
+    await bootApp(
+      [operation("a1", 1, "theater-a"), operation("b1", 1, "theater-b")],
+      [theater(), theater("theater-b", "Theater B")],
+    );
+    await act(async () => {
+      setCompanionOperationId("a1");
+      canvasMocks.onLaunchAtGeometry?.("terminal", { type: "shell", title: "Shell" }, { x: 0, y: 0, width: 640, height: 400, zIndex: 2 });
+      await Promise.resolve();
+    });
+    await act(async () => {
+      focusOperation("b1");
+      await Promise.resolve();
+    });
+    apiMocks.fetchOperations.mockResolvedValue([
+      operation("a1", 1, "theater-a"),
+      operation("launched", 2, "theater-a"),
+      operation("b1", 1, "theater-b"),
+    ]);
+
+    await act(async () => {
+      launch.resolve({ id: "launched" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getState().activeTheaterId).toBe("theater-b");
+    expect(getTheaterCompanionOperationId("theater-a")).toBe("a1");
+    expect(getCompanionOperationId()).toBeNull();
+  });
+
   it("minimizes a second Theater's existing panels on first in-session view, surfacing only the selected panel", async () => {
     const operations = deferred<readonly OperationNode[]>();
     const theaters = deferred<TheaterBootstrap>();
@@ -393,6 +562,22 @@ async function navigateTo(pathname: string): Promise<void> {
   await act(async () => {
     window.history.pushState({}, "", pathname);
     window.dispatchEvent(new PopStateEvent("popstate"));
+    await Promise.resolve();
+  });
+}
+
+async function bootApp(operationsList: readonly OperationNode[], theaterList = [theater()]): Promise<void> {
+  const operations = deferred<readonly OperationNode[]>();
+  const theaters = deferred<TheaterBootstrap>();
+  apiMocks.fetchOperations.mockReturnValueOnce(operations.promise);
+  apiMocks.fetchTheaterBootstrap.mockReturnValueOnce(theaters.promise);
+  const { App } = await import("../core/client/src/app.js");
+  await act(async () => {
+    root!.render(createElement(BrowserRouter, null, createElement(App)));
+  });
+  await act(async () => {
+    operations.resolve(operationsList);
+    theaters.resolve({ theaters: theaterList });
     await Promise.resolve();
   });
 }

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -21,6 +21,7 @@ const keyboardShortcutMocks = vi.hoisted(() => ({
 const sideBarMocks = vi.hoisted(() => ({
   onFocus: null as null | ((operationId: string) => void),
   onClose: null as null | ((operationId: string) => void),
+  onMinimize: null as null | ((operationId: string) => void),
 }));
 const canvasMocks = vi.hoisted(() => ({
   onLaunchAtGeometry: null as null | ((pluginId: string, kind: { readonly type: string; readonly title: string }, geometry: { readonly x: number; readonly y: number; readonly width: number; readonly height: number; readonly zIndex: number }) => void),
@@ -74,9 +75,10 @@ vi.mock("../core/client/src/rail/right-rail.js", () => ({ RightRail: () => null 
 vi.mock("../core/client/src/release-notes-fetch.js", () => ({ abortReleaseNotesFetch: vi.fn(), requestReleaseNotes: vi.fn() }));
 vi.mock("../core/client/src/sidebar/operations-side-bar-store.js", () => ({ getSideBarState: () => ({ collapsed: false }), setSideBarCollapsed: vi.fn() }));
 vi.mock("../core/client/src/sidebar/operations-side-bar.js", () => ({
-  OperationsSideBar: ({ onClose, onFocus }: { readonly onClose: (operationId: string) => void; readonly onFocus: (operationId: string) => void }) => {
+  OperationsSideBar: ({ onClose, onFocus, onMinimize }: { readonly onClose: (operationId: string) => void; readonly onFocus: (operationId: string) => void; readonly onMinimize: (operationId: string) => void }) => {
     sideBarMocks.onFocus = onFocus;
     sideBarMocks.onClose = onClose;
+    sideBarMocks.onMinimize = onMinimize;
     return null;
   },
 }));
@@ -104,6 +106,7 @@ beforeEach(() => {
   keyboardShortcutMocks.shouldHandleOperationsKeyboardShortcut.mockReturnValue(false);
   sideBarMocks.onFocus = null;
   sideBarMocks.onClose = null;
+  sideBarMocks.onMinimize = null;
   canvasMocks.onLaunchAtGeometry = null;
   registryMocks.plugins = [];
   registryMocks.operationKinds = [];
@@ -508,6 +511,28 @@ describe("Operations boot minimization", () => {
 
     expect(getCompanionOperationId()).toBe("first");
     expect(getState().activeOperationId).not.toBe("second");
+  });
+
+  it("discards an asynchronous Analyze retarget after its destination is minimized", async () => {
+    const secondReady = deferred<boolean>();
+    registryMocks.operationKinds = [companionKind(() => secondReady.promise)];
+    await bootApp([operation("first"), operation("second")]);
+    await act(async () => {
+      setCompanionOperationId("first");
+      restoreOperation("second");
+      await Promise.resolve();
+    });
+
+    act(() => sideBarMocks.onFocus?.("second"));
+    act(() => sideBarMocks.onMinimize?.("second"));
+    await act(async () => {
+      secondReady.resolve(true);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getCompanionOperationId()).toBe("first");
+    expect(getSnapshot().minimized).toContain("second");
   });
 
   it("force-drops Analyze immediately when Sidebar closes its target", async () => {

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -3,6 +3,7 @@
 import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import type { OperationKindDescriptor } from "@fleet-console/sdk/plugin";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { clearCompanionOperationId, clearFormationView, clearMaximizedOperationId, getCompanionOperationId, getFormationView, getMaximizedOperationId, getSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, setViewport, toggleFormationView } from "../core/client/src/canvas/canvas-store.js";
@@ -24,7 +25,10 @@ const sideBarMocks = vi.hoisted(() => ({
 const canvasMocks = vi.hoisted(() => ({
   onLaunchAtGeometry: null as null | ((pluginId: string, kind: { readonly type: string; readonly title: string }, geometry: { readonly x: number; readonly y: number; readonly width: number; readonly height: number; readonly zIndex: number }) => void),
 }));
-const registryMocks = vi.hoisted(() => ({ plugins: [] as Array<Record<string, unknown>> }));
+const registryMocks = vi.hoisted(() => ({
+  plugins: [] as Array<Record<string, unknown>>,
+  operationKinds: [] as OperationKindDescriptor[],
+}));
 
 vi.mock("../core/client/src/api.js", () => ({
   ...apiMocks,
@@ -64,7 +68,7 @@ vi.mock("../core/client/src/global-settings-store.js", () => ({ useGlobalSetting
 vi.mock("../core/client/src/operations-sse.js", () => ({ refreshObserverStatus: vi.fn() }));
 vi.mock("../core/client/src/pages/global-settings.js", () => ({ GlobalSettings: () => createElement("div", { "data-route": "settings" }) }));
 vi.mock("../core/client/src/plugin-capabilities.js", () => ({ createHostCapabilities: () => ({ api: {} }) }));
-vi.mock("../core/client/src/plugin-registry.js", () => ({ usePluginRegistry: () => ({ plugins: registryMocks.plugins, operationKinds: [], settingsSections: [], notificationKinds: [], railPanels: [] }) }));
+vi.mock("../core/client/src/plugin-registry.js", () => ({ usePluginRegistry: () => ({ plugins: registryMocks.plugins, operationKinds: registryMocks.operationKinds, settingsSections: [], notificationKinds: [], railPanels: [] }) }));
 vi.mock("../core/client/src/rail/rail-store.js", () => ({ toggleRailChrome: vi.fn() }));
 vi.mock("../core/client/src/rail/right-rail.js", () => ({ RightRail: () => null }));
 vi.mock("../core/client/src/release-notes-fetch.js", () => ({ abortReleaseNotesFetch: vi.fn(), requestReleaseNotes: vi.fn() }));
@@ -102,6 +106,7 @@ beforeEach(() => {
   sideBarMocks.onClose = null;
   canvasMocks.onLaunchAtGeometry = null;
   registryMocks.plugins = [];
+  registryMocks.operationKinds = [];
 });
 
 afterEach(() => {
@@ -364,6 +369,8 @@ describe("Operations boot minimization", () => {
   });
 
   it("retargets Analyze through sidebar focus and surfaces a minimized target", async () => {
+    const canOpenCompanions = vi.fn().mockResolvedValue(true);
+    registryMocks.operationKinds = [companionKind(canOpenCompanions)];
     await bootApp([operation("first"), operation("second")]);
     await act(async () => {
       setCompanionOperationId("first");
@@ -374,9 +381,35 @@ describe("Operations boot minimization", () => {
     await act(async () => {
       sideBarMocks.onFocus?.("second");
       await Promise.resolve();
+      await Promise.resolve();
     });
 
+    expect(canOpenCompanions).toHaveBeenCalledOnce();
     expect(getCompanionOperationId()).toBe("second");
+    expect(getState().activeOperationId).toBe("second");
+    expect(getSnapshot().minimized).not.toContain("second");
+  });
+
+  it("falls back to Map when an Analyze retarget is not ready", async () => {
+    const canOpenCompanions = vi.fn().mockResolvedValue(false);
+    registryMocks.operationKinds = [companionKind(canOpenCompanions)];
+    await bootApp([operation("first"), operation("second")]);
+    await act(async () => {
+      toggleFormationView();
+      setCompanionOperationId("first");
+      minimizeOperation("second");
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      sideBarMocks.onFocus?.("second");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(canOpenCompanions).toHaveBeenCalledOnce();
+    expect(getCompanionOperationId()).toBeNull();
+    expect(getFormationView()).toBe(false);
     expect(getState().activeOperationId).toBe("second");
     expect(getSnapshot().minimized).not.toContain("second");
   });
@@ -588,6 +621,16 @@ function deferred<Value>() {
     resolve = next;
   });
   return { promise, resolve };
+}
+
+function companionKind(canOpenCompanions: NonNullable<OperationKindDescriptor["canOpenCompanions"]>): OperationKindDescriptor {
+  return {
+    pluginId: "terminal",
+    type: "shell",
+    title: "Shell",
+    companions: [{ id: "analysis", title: "Analysis", render: () => null }],
+    canOpenCompanions,
+  };
 }
 
 function theater(id = "theater-a", label = "Theater A") {

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -414,6 +414,36 @@ describe("Operations boot minimization", () => {
     expect(getSnapshot().minimized).not.toContain("second");
   });
 
+  it("applies only the latest asynchronous Analyze retarget", async () => {
+    const secondReady = deferred<boolean>();
+    const thirdReady = deferred<boolean>();
+    const canOpenCompanions = vi.fn(({ operation: target }: { readonly operation: OperationNode }) => target.id === "second" ? secondReady.promise : thirdReady.promise);
+    registryMocks.operationKinds = [companionKind(canOpenCompanions)];
+    await bootApp([operation("first"), operation("second"), operation("third")]);
+    await act(async () => {
+      setCompanionOperationId("first");
+      await Promise.resolve();
+    });
+
+    act(() => {
+      sideBarMocks.onFocus?.("second");
+      sideBarMocks.onFocus?.("third");
+    });
+    await act(async () => {
+      secondReady.resolve(true);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(getCompanionOperationId()).toBe("first");
+
+    await act(async () => {
+      thirdReady.resolve(true);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(getCompanionOperationId()).toBe("third");
+  });
+
   it("force-drops Analyze immediately when Sidebar closes its target", async () => {
     await bootApp([operation("first")]);
     await act(async () => {

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -393,6 +393,27 @@ describe("Operations boot minimization", () => {
     expect(getSnapshot().minimized).not.toContain("second");
   });
 
+  it("keeps the current Analyze target without revalidating readiness", async () => {
+    const canOpenCompanions = vi.fn().mockResolvedValue(false);
+    registryMocks.operationKinds = [companionKind(canOpenCompanions)];
+    await bootApp([operation("first")]);
+    await act(async () => {
+      toggleFormationView();
+      setCompanionOperationId("first");
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      sideBarMocks.onFocus?.("first");
+      await Promise.resolve();
+    });
+
+    expect(canOpenCompanions).not.toHaveBeenCalled();
+    expect(getCompanionOperationId()).toBe("first");
+    clearCompanionOperationId();
+    expect(getFormationView()).toBe(true);
+  });
+
   it("falls back to Map when an Analyze retarget is not ready", async () => {
     const canOpenCompanions = vi.fn().mockResolvedValue(false);
     registryMocks.operationKinds = [companionKind(canOpenCompanions)];

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-ready.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-ready.test.tsx
@@ -86,6 +86,16 @@ describe("Session Analyst readiness handle", () => {
     const api = createApi(vi.fn().mockRejectedValue(new Error("offline")));
     await expect(fetchAnalysisReady(api, OPERATION_ID)).resolves.toBe(false);
   });
+
+  it("exposes transcript readiness to host companion retargets", async () => {
+    const fetch = vi.fn().mockResolvedValue(readyResponse(false));
+    const canOpenCompanions = agentOperationKind.canOpenCompanions;
+    if (!canOpenCompanions) throw new Error("Agent companion readiness gate must exist.");
+
+    await expect(Promise.resolve(canOpenCompanions({ api: createApi(fetch), operation: operation() }))).resolves.toBe(false);
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(fetch.mock.calls[0]?.[1]).toBe(`analysis/${OPERATION_ID}/ready`);
+  });
 });
 
 async function renderLiveOperation(fetch: ReturnType<typeof vi.fn>): Promise<void> {
@@ -121,7 +131,23 @@ function createApi(fetch: ReturnType<typeof vi.fn>): ClientApiCapability {
 }
 
 function createContext(api: ClientApiCapability, onRequestCompanions = vi.fn()): OperationRenderContext {
-  const operation = {
+  return {
+    operationId: OPERATION_ID,
+    theaterId: "theater",
+    pluginId: "terminal",
+    type: "agent",
+    operation: operation(),
+    api,
+    active: true,
+    zoom: 1,
+    theme: "instrument",
+    companionsOpen: false,
+    onRequestCompanions,
+  } as unknown as OperationRenderContext;
+}
+
+function operation() {
+  return {
     id: OPERATION_ID,
     pluginId: "terminal",
     type: "agent",
@@ -130,19 +156,6 @@ function createContext(api: ClientApiCapability, onRequestCompanions = vi.fn()):
     payload: {},
     ts: { createdAt: 1, updatedAt: 1 },
   };
-  return {
-    operationId: OPERATION_ID,
-    theaterId: "theater",
-    pluginId: "terminal",
-    type: "agent",
-    operation,
-    api,
-    active: true,
-    zoom: 1,
-    theme: "instrument",
-    companionsOpen: false,
-    onRequestCompanions,
-  } as unknown as OperationRenderContext;
 }
 
 function readyResponse(ready: boolean): Response {

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -83,6 +83,7 @@ export const agentOperationKind = defineOperationKind({
   title: "Agent",
   subtitle: (operation) => readPayloadString(operation.payload, "cliLabel") ?? undefined,
   render: (context) => <AgentOperationView context={context} />,
+  canOpenCompanions: ({ api, operation }) => fetchAnalysisReady(api, operation.id),
   companions: [
     { id: "session-analyst-chat", title: "Session Analyst", hideCaption: true, render: (context) => <AnalystChatPanel context={context} /> },
     { id: "session-analyst-artifacts", title: "Artifacts", hideCaption: true, render: (context) => <AnalystArtifactsPanel context={context} /> },


### PR DESCRIPTION
## Summary

- Keep Session Analyze as a retargetable focus layer so Sidebar, keyboard, and cross-Theater Operation navigation continue to work while analysis is open.
- Restore the prior Map, Formation, or maximized context on explicit Exit Analyze, while invalidation paths force-drop the layer without restoring stale state.
- Respect plugin-owned companion readiness when retargeting, falling back to a visible Map focus for unsupported or unready Operations.
- Make new worktrees install frozen dependencies locally and require package build/typecheck preflight before Carrier dispatch.

## Type of Change

- [x] fix — bug fix
- [ ] feat — new feature or carrier capability
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- [x] `runtime/fleet-console`
- [x] `runtime/fleet-plugins/terminal`
- [x] `.agents/skills/git-worktree`

## Test Plan

- [x] `pnpm install --frozen-lockfile`
- [x] Console targeted Vitest suite — 3 files, 68 tests passed
- [x] Terminal readiness Vitest suite — 1 file, 5 tests passed
- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit -p core/client/tsconfig.json`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `pnpm --filter @fleet-plugins/terminal build`
- [ ] `pnpm --filter @dotobokuri/fleet-console typecheck` — existing clean-base failures for CSS side-effect imports and `virtual:fleet-plugins`
- [x] `uv run --with pyyaml python /Users/sbluemin/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/git-worktree`
- [x] Real-browser E2E: Analyze retarget and Exit restoration for Map, Formation, and maximized contexts; no browser errors, rejected promises, or socket errors
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `git diff --check`

## Changelog

- [x] Added `.changelog.d/pr-319.md` with adjacent English/Korean entries for `fleet-console` and `fleet-core`.

## Product Context Record

- B option is authoritative: Analyze is an overlay in the existing focus-layer model, not a new state machine.
- Explicit Exit restores the current target into the captured underlay mode; minimize, close, removal, grace expiry, or explicit view replacement force-drop Analyze.
- Operation navigation retargets Analyze only when the destination supports companions and is ready; otherwise it must reveal the selected Operation through Map focus.
- The worktree skill must not rely on another checkout's `node_modules`.
- Review amendment (2026-07-19 user directive): only findings that simultaneously violate the original acceptance criteria, are reproducible as regressions, and are caused by this PR diff are fixed in-PR; all others are split into follow-up issues.


