### PR TITLE
fix(console): preserve Formation on Analyze fallback

### DIFF
--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -5,7 +5,7 @@ import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 import type { ClientApiCapability, FleetClientPlugin, OperationKindDescriptor } from "@fleet-console/sdk/plugin";
 
 import { addTheater, createGroup, deleteGroup, fetchGroups, fetchOperations, forgetTheater, issueTheaterFolderGrant, patchOperation, renameOperation, updateGroup, ApiError } from "../api.js";
-import { animateViewportTo, claimTopZIndex, clearFormationView, ensureDefaultGeometry, focusOperation as focusCanvasOperation, forceDropCompanionOperationId, getCompanionOperationId, getFocusLayerRevision, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useCompanionOperationId, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
+import { animateViewportTo, claimTopZIndex, ensureDefaultGeometry, focusOperation as focusCanvasOperation, forceDropCompanionOperationId, getCompanionOperationId, getFocusLayerRevision, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useCompanionOperationId, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
 import { screenToCanvas, type CanvasPoint } from "../canvas/coordinates.js";
 import { OperationsCanvas } from "../canvas/canvas.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
@@ -374,7 +374,11 @@ async function routeOperationFocus(operationId: string, operationKinds: readonly
     }
     if (operation && (!descriptor || !descriptor.companions?.length || !canOpenCompanions)) {
       forceDropCompanionOperationId();
-      clearFormationView();
+      if (getFormationView()) {
+        restoreOperation(operationId);
+        setActiveOperation(operationId);
+        return;
+      }
       focusMap();
       return;
     }

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -376,6 +376,7 @@ describe("Operations boot minimization", () => {
     registryMocks.operationKinds = [companionKind(canOpenCompanions)];
     await bootApp([operation("first"), operation("second")]);
     await act(async () => {
+      toggleFormationView();
       setCompanionOperationId("first");
       minimizeOperation("second");
       await Promise.resolve();
@@ -389,6 +390,7 @@ describe("Operations boot minimization", () => {
 
     expect(canOpenCompanions).toHaveBeenCalledOnce();
     expect(getCompanionOperationId()).toBe("second");
+    expect(getFormationView()).toBe(true);
     expect(getState().activeOperationId).toBe("second");
     expect(getSnapshot().minimized).not.toContain("second");
   });
@@ -414,7 +416,7 @@ describe("Operations boot minimization", () => {
     expect(getFormationView()).toBe(true);
   });
 
-  it("falls back to Map when an Analyze retarget is not ready", async () => {
+  it("exits Analyze and keeps Formation when an Analyze retarget is not ready", async () => {
     const canOpenCompanions = vi.fn().mockResolvedValue(false);
     registryMocks.operationKinds = [companionKind(canOpenCompanions)];
     await bootApp([operation("first"), operation("second")]);
@@ -433,12 +435,12 @@ describe("Operations boot minimization", () => {
 
     expect(canOpenCompanions).toHaveBeenCalledOnce();
     expect(getCompanionOperationId()).toBeNull();
-    expect(getFormationView()).toBe(false);
+    expect(getFormationView()).toBe(true);
     expect(getState().activeOperationId).toBe("second");
     expect(getSnapshot().minimized).not.toContain("second");
   });
 
-  it("falls back to Map when an Analyze retarget has no registered descriptor", async () => {
+  it("exits Analyze and keeps Formation when the retarget has no registered descriptor", async () => {
     await bootApp([operation("first"), operation("second")]);
     await act(async () => {
       toggleFormationView();
@@ -452,6 +454,29 @@ describe("Operations boot minimization", () => {
       await Promise.resolve();
     });
 
+    expect(getCompanionOperationId()).toBeNull();
+    expect(getFormationView()).toBe(true);
+    expect(getState().activeOperationId).toBe("second");
+    expect(getSnapshot().minimized).not.toContain("second");
+  });
+
+  it("falls back to Map when an Analyze retarget is not ready outside Formation", async () => {
+    const canOpenCompanions = vi.fn().mockResolvedValue(false);
+    registryMocks.operationKinds = [companionKind(canOpenCompanions)];
+    await bootApp([operation("first"), operation("second")]);
+    await act(async () => {
+      setCompanionOperationId("first");
+      minimizeOperation("second");
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      sideBarMocks.onFocus?.("second");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(canOpenCompanions).toHaveBeenCalledOnce();
     expect(getCompanionOperationId()).toBeNull();
     expect(getFormationView()).toBe(false);
     expect(getState().activeOperationId).toBe("second");


### PR DESCRIPTION
## Summary

- Keep Formation active when Session Analyze cannot retarget to the selected Operation.
- Exit only the Analyze focus layer, then restore and activate the selected Operation inside the existing Formation underlay.
- Preserve ready Analyze retargeting and the non-Formation Map fallback.

## Test Plan

- [x] `pnpm --dir runtime/fleet-console exec vitest run tests/operations-boot-minimization.integration.test.ts` — 25 tests passed
- [x] `pnpm --dir runtime/fleet-console build`
- [x] Real-browser E2E — ready retarget keeps Analyze + Formation; unready retarget exits Analyze and keeps Formation; 0 browser errors/rejections
- [x] `git diff --check`
- [ ] `pnpm --dir runtime/fleet-console typecheck` — existing canary failures for CSS side-effect imports and `virtual:fleet-plugins`; unrelated to this diff

## Changelog

- [x] `no-changelog` — this corrects the still-unreleased behavior already described by `.changelog.d/pr-319.md`; a second release note would duplicate the same user-facing claim.

## Product Context Record

- Original acceptance: with two Operations in Formation, enter Analyze on one and select the other from the Sidebar without losing Formation.
- Ready targets retarget Analyze and keep Formation.
- Unready or unsupported targets exit Analyze, restore and activate the target, and keep Formation because the target is already visible in that underlay.
- Outside Formation, the existing Map fallback remains supported.
- Analyze remains an overlay in the existing focus-layer model; no new state machine or readiness behavior is introduced.
- Excluded: unrelated client typecheck baseline fixes, refactors, and changes to other focus-layer transitions.
- Review gate: fix a finding in this PR only when it violates the original acceptance criteria, is reproducible as a regression, and is caused by this diff; split all other findings into follow-up issues.