### PR TITLE
feat(console): add Theater drag-to-reorder with server-persisted order

### DIFF
--- a/.changelog.d/pr-323.md
+++ b/.changelog.d/pr-323.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Added
+- [fleet-console] Reorder Theaters by dragging their sidebar headers, persisting the manual order on the server.
+  ko: 사이드바 Theater 헤더를 드래그하여 순서를 바꾸고, 수동 정렬을 서버에 영속화합니다.

--- a/runtime/fleet-console/core/client/src/api.ts
+++ b/runtime/fleet-console/core/client/src/api.ts
@@ -92,11 +92,11 @@ export class ApiError extends Error {
   }
 }
 
-export async function fetchTheaters(signal?: AbortSignal): Promise<readonly TheaterInfo[]> {
+export async function fetchTheaters(signal?: AbortSignal | null): Promise<readonly TheaterInfo[]> {
   return (await fetchTheaterBootstrap(signal)).theaters;
 }
 
-export async function fetchTheaterBootstrap(signal?: AbortSignal): Promise<TheaterBootstrap> {
+export async function fetchTheaterBootstrap(signal?: AbortSignal | null): Promise<TheaterBootstrap> {
   const response = await fetch("/api/v1/theaters", { signal });
   await assertOk(response);
   const payload = (await response.json()) as { theaters?: unknown };
@@ -143,6 +143,17 @@ export async function addTheater(folderGrantId: string, signal?: AbortSignal): P
   await assertOk(response);
   const payload = await response.json() as unknown;
   return assertTheaterInfo(payload, response.status);
+}
+
+export async function patchTheaterOrder(theaterId: string, order: number, signal?: AbortSignal): Promise<TheaterInfo> {
+  const response = await fetch(`/api/v1/theaters/${encodeURIComponent(theaterId)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ order }),
+    signal,
+  });
+  await assertOk(response);
+  return assertTheaterInfo(await response.json(), response.status);
 }
 
 export async function listTheaterFolders(path: string | null, signal?: AbortSignal): Promise<TheaterFolderListResponse> {
@@ -367,7 +378,15 @@ function assertTheaterInfo(value: unknown, status: number): TheaterInfo {
   ) {
     throw new ApiError(status, "Invalid Theater response");
   }
-  return payload as TheaterInfo;
+  return {
+    id: payload.id,
+    label: payload.label,
+    createdAt: payload.createdAt,
+    lastOpenedAt: payload.lastOpenedAt,
+    ...(typeof payload.order === "number" && Number.isInteger(payload.order) && payload.order >= 0 ? { order: payload.order } : {}),
+    hasWiki: payload.hasWiki,
+    activeAdmiralCount: payload.activeAdmiralCount,
+  };
 }
 
 function assertObserverStatus(value: unknown, status: number): ObserverStatus {

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -281,6 +281,10 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       const folderGrantId = await issueTheaterFolderGrant(path);
       const result = await addTheater(folderGrantId);
       completeAddTheater(result);
+      // 서버 register()는 기존 order를 보존하므로, 이미 수동 정렬된 Theater를 재-오픈하면
+      // completeAddTheater의 낙관적 prepend가 저장된 위치와 어긋난다(Codex P2). 서버 순서로 재수화해
+      // "열어도 위치 고정" 계약을 지킨다. hydrate는 방금 활성화한 result.id 선택을 유지한다.
+      void fetchTheaters(null).then(hydrateTheaters).catch(() => {});
     } catch (error) {
       failAddTheater(error instanceof Error ? error.message : String(error));
     }

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -4,7 +4,7 @@ import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console
 import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 import type { ClientApiCapability, FleetClientPlugin, OperationKindDescriptor } from "@fleet-console/sdk/plugin";
 
-import { addTheater, createGroup, deleteGroup, fetchGroups, fetchOperations, forgetTheater, issueTheaterFolderGrant, patchOperation, renameOperation, updateGroup, ApiError } from "../api.js";
+import { addTheater, createGroup, deleteGroup, fetchGroups, fetchOperations, fetchTheaters, forgetTheater, issueTheaterFolderGrant, patchOperation, patchTheaterOrder, renameOperation, updateGroup, ApiError } from "../api.js";
 import { animateViewportTo, claimTopZIndex, ensureDefaultGeometry, focusOperation as focusCanvasOperation, forceDropCompanionOperationId, getCompanionOperationId, getFocusLayerRevision, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useCompanionOperationId, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
 import { screenToCanvas, type CanvasPoint } from "../canvas/coordinates.js";
 import { OperationsCanvas } from "../canvas/canvas.js";
@@ -14,7 +14,7 @@ import { RightRail } from "../rail/right-rail.js";
 import { OperationsSideBar } from "../sidebar/operations-side-bar.js";
 import { CodexReadingSheet } from "../components/codex-reading-sheet.js";
 import { shouldHandleOperationsKeyboardShortcut } from "../components/keyboard-shortcuts-dialog.js";
-import { beginAddTheater, cancelAddTheater, compareOperationCreatedAt, completeAddTheater, consumeOperationFocus, failAddTheater, focusCycleOperationIds, focusOperation, getState, hydrateGroups, hydrateOperations, nextOperationId, removeTheater, setActiveOperation, setActiveTheater, sortOperationsByOrder } from "../store.js";
+import { beginAddTheater, cancelAddTheater, compareOperationCreatedAt, completeAddTheater, consumeOperationFocus, failAddTheater, focusCycleOperationIds, focusOperation, getState, hydrateGroups, hydrateOperations, hydrateTheaters, nextOperationId, removeTheater, setActiveOperation, setActiveTheater, sortOperationsByOrder } from "../store.js";
 import type { ConsoleState, OperationNode } from "../types.js";
 
 const STABLE_RAIL_API: ClientApiCapability = createHostCapabilities().api;
@@ -243,6 +243,20 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       .catch(() => {});
   }, []);
 
+  const handleReorderTheaters = useCallback((orderedTheaterIds: readonly string[]) => {
+    const theaterById = new Map(stateRef.current.theaters.map((theater) => [theater.id, theater]));
+    const patches = orderedTheaterIds.flatMap((theaterId, order) => {
+      const theater = theaterById.get(theaterId);
+      if (!theater || theater.order === order) return [];
+      return [patchTheaterOrder(theaterId, order)];
+    });
+    if (patches.length === 0) return;
+    void Promise.allSettled(patches)
+      .then(() => fetchTheaters(null))
+      .then(hydrateTheaters)
+      .catch(() => {});
+  }, []);
+
   const handleUngroupAll = useCallback((groupId: string) => {
     void deleteGroup(groupId)
       .then(() => Promise.all([
@@ -320,6 +334,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
         onSetGroupColor={handleSetGroupColor}
         onRenameGroup={handleRenameGroup}
         onReorderGroups={handleReorderGroups}
+        onReorderTheaters={handleReorderTheaters}
         onUngroupAll={handleUngroupAll}
         onSelectTheater={setActiveTheater}
         onAddTheater={handleAddTheater}

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-hit-test.ts
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-hit-test.ts
@@ -78,6 +78,25 @@ export function groupDropIndexFromPoint(
   return orderedGroupIds.length;
 }
 
+export function theaterDropIndexFromPoint(
+  clientY: number,
+  orderedTheaterIds: readonly string[],
+  container: HTMLOListElement | null,
+  sourceTheaterId?: string,
+): number {
+  if (!container) return 0;
+  const theaterElements = Array.from(container.querySelectorAll<HTMLElement>("[data-theater-id]"));
+  for (const theaterEl of theaterElements) {
+    const id = theaterEl.dataset.theaterId;
+    if (!id || id === sourceTheaterId) continue;
+    const index = orderedTheaterIds.indexOf(id);
+    if (index === -1) continue;
+    const rect = theaterEl.getBoundingClientRect();
+    if (clientY <= rect.top + rect.height / 2) return index;
+  }
+  return orderedTheaterIds.length;
+}
+
 // cross-group 드롭용: sourceId를 allIds에서 제거하고 대상 segment의 dropIndex 위치에 삽입한다.
 // dropIndex = source가 없는 대상 entryIds 기준 타깃 슬롯; 보정 없음(source가 segment에 없음).
 // sourceId는 segment에 속하지 않으며, segment의 기존 순서는 allIds 내에서의 순서를 따른다.
@@ -152,6 +171,20 @@ export function reorderGroupIds(
   const adjusted = dropIndex > sourceIndex ? dropIndex - 1 : dropIndex;
   const bounded = Math.max(0, Math.min(adjusted, next.length));
   next.splice(bounded, 0, sourceGroupId);
+  return next;
+}
+
+export function reorderTheaterIds(
+  orderedTheaterIds: readonly string[],
+  sourceTheaterId: string,
+  dropIndex: number,
+): string[] {
+  const sourceIndex = orderedTheaterIds.indexOf(sourceTheaterId);
+  if (sourceIndex === -1) return [...orderedTheaterIds];
+  const next = orderedTheaterIds.filter((id) => id !== sourceTheaterId);
+  const adjusted = dropIndex > sourceIndex ? dropIndex - 1 : dropIndex;
+  const bounded = Math.max(0, Math.min(adjusted, next.length));
+  next.splice(bounded, 0, sourceTheaterId);
   return next;
 }
 

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -14,7 +14,7 @@ import { operationAccentFromNode, resolveAccentColor } from "../canvas/operation
 import { getTheaterCanvasSnapshot, selectFormationLayout, setOperationOrder, toggleGroupCollapsed, toggleTheaterGroupCollapsed, useCanvasState, useCollapsedGroups, useFormationLayout, useFormationView } from "../canvas/canvas-store.js";
 import { sortOperationsByOrder } from "../store.js";
 import { SideBarBrandFoot } from "../components/side-bar-brand-foot.js";
-import { applyVisibleReorder, groupDropIndexFromPoint, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderGroupIds, reorderWithinSegment, type DropSectionInfo } from "./operations-side-bar-hit-test.js";
+import { applyVisibleReorder, groupDropIndexFromPoint, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderGroupIds, reorderTheaterIds, reorderWithinSegment, theaterDropIndexFromPoint, type DropSectionInfo } from "./operations-side-bar-hit-test.js";
 import { OperationsSideBarChip, type SideBarEntry } from "./operations-side-bar-chip.js";
 import { OperationsSideBarGroupHeader } from "./operations-side-bar-group-header.js";
 import { setSideBarCollapsed, setSideBarWidth, setTheaterCollapsed, useCollapsedTheaters, useSideBarState } from "./operations-side-bar-store.js";
@@ -45,6 +45,7 @@ interface OperationsSideBarProps {
   readonly onSetGroupColor: (groupId: string, color: string | null) => void;
   readonly onRenameGroup: (groupId: string, name: string) => void;
   readonly onReorderGroups: (orderedGroupIds: readonly string[]) => void;
+  readonly onReorderTheaters: (orderedTheaterIds: readonly string[]) => void;
   readonly onUngroupAll: (groupId: string) => void;
   readonly onSelectTheater: (theaterId: string) => void;
   readonly onAddTheater: (path: string) => void;
@@ -86,7 +87,18 @@ interface GroupDragState {
   readonly dropIndex: number;
 }
 
-type DragState = ChipDragState | GroupDragState;
+interface TheaterDragState {
+  readonly kind: "theater";
+  readonly sourceTheaterId: string;
+  readonly pointerId: number;
+  readonly startX: number;
+  readonly startY: number;
+  readonly currentY: number;
+  readonly dragging: boolean;
+  readonly dropIndex: number;
+}
+
+type DragState = ChipDragState | GroupDragState | TheaterDragState;
 
 interface TheaterEntryBuildInput {
   readonly theaterId: string;
@@ -105,11 +117,15 @@ interface TheaterSectionHeaderProps {
   readonly operationCount: number;
   readonly active: boolean;
   readonly collapsed: boolean;
+  readonly dragging: boolean;
+  readonly dropTarget: boolean;
+  readonly dragOffsetY: number;
   readonly onSelectTheater: (theaterId: string) => void;
   readonly onToggleCollapsed: (theaterId: string) => void;
   readonly onOpenActions: (anchor: DOMRect, returnFocus?: HTMLButtonElement | null) => void;
   readonly onOpenLaunch: (event: MouseEvent<HTMLButtonElement>, theaterId: string) => void;
   readonly onContextMenu: (anchor: DOMRect) => void;
+  readonly onPointerDragStart: (event: ReactPointerEvent<HTMLDivElement>, theaterId: string) => void;
 }
 
 interface TheaterInactiveSectionProps {
@@ -120,12 +136,17 @@ interface TheaterInactiveSectionProps {
   readonly operationAccent: Readonly<Record<string, string>>;
   readonly operationCount: number;
   readonly collapsed: boolean;
+  readonly dragging: boolean;
+  readonly dropBefore: boolean;
+  readonly dropAfter: boolean;
+  readonly dragOffsetY: number;
   readonly onSelectTheater: (theaterId: string) => void;
   readonly onFocus: (operationId: string) => void;
   readonly onToggleCollapsed: (theaterId: string) => void;
   readonly onOpenActions: (anchor: DOMRect, returnFocus?: HTMLButtonElement | null) => void;
   readonly onOpenLaunch: (event: MouseEvent<HTMLButtonElement>, theaterId: string) => void;
   readonly onContextMenu: (anchor: DOMRect) => void;
+  readonly onPointerDragStart: (event: ReactPointerEvent<HTMLDivElement>, theaterId: string) => void;
 }
 
 interface TheaterActionsMenuProps {
@@ -166,6 +187,7 @@ export function OperationsSideBar({
   onSetGroupColor,
   onRenameGroup,
   onReorderGroups,
+  onReorderTheaters,
   onUngroupAll,
   onSelectTheater,
   onAddTheater,
@@ -188,8 +210,10 @@ export function OperationsSideBar({
   const currentOrderRef = useRef<string[]>([]);
   const dropSectionsRef = useRef<DropSectionInfo[]>([]);
   const orderedGroupIdsRef = useRef<string[]>([]);
+  const orderedTheaterIdsRef = useRef<string[]>([]);
   const onSetGroupIdRef = useRef(onSetGroupId);
   const onReorderGroupsRef = useRef(onReorderGroups);
+  const onReorderTheatersRef = useRef(onReorderTheaters);
   const [activeContextMenu, setActiveContextMenu] = useState<ActiveContextMenu | null>(null);
   const [newMenu, setNewMenu] = useState<NewMenuState | null>(null);
   const [browserOpen, setBrowserOpen] = useState(false);
@@ -294,8 +318,10 @@ export function OperationsSideBar({
     currentOrderRef.current = currentOrder;
     dropSectionsRef.current = dropSections;
     orderedGroupIdsRef.current = orderedGroupIds;
+    orderedTheaterIdsRef.current = theaters.map((theater) => theater.id);
     onSetGroupIdRef.current = onSetGroupId;
     onReorderGroupsRef.current = onReorderGroups;
+    onReorderTheatersRef.current = onReorderTheaters;
   });
 
   const updateDrag = (next: DragState | null) => {
@@ -325,6 +351,11 @@ export function OperationsSideBar({
         updateDrag({ ...current, currentY: event.clientY, dragging: true, dropIndex: dropTarget.index, dropGroupId: dropTarget.groupId });
         return;
       }
+      if (current.kind === "theater") {
+        const dropIndex = theaterDropIndexFromPoint(event.clientY, orderedTheaterIdsRef.current, chipsRef.current, current.sourceTheaterId);
+        updateDrag({ ...current, currentY: event.clientY, dragging: true, dropIndex });
+        return;
+      }
       const dropIndex = groupDropIndexFromPoint(event.clientY, orderedGroupIdsRef.current, chipsRef.current, current.sourceGroupId);
       updateDrag({ ...current, currentY: event.clientY, dragging: true, dropIndex });
     };
@@ -334,6 +365,13 @@ export function OperationsSideBar({
       const snap = dragRef.current;
       updateDrag(null);
       if (!snap?.dragging) return;
+
+      if (snap.kind === "theater") {
+        const nextTheaterIds = reorderTheaterIds(orderedTheaterIdsRef.current, snap.sourceTheaterId, snap.dropIndex);
+        if (nextTheaterIds.join("\0") === orderedTheaterIdsRef.current.join("\0")) return;
+        onReorderTheatersRef.current(nextTheaterIds);
+        return;
+      }
 
       if (snap.kind === "group") {
         const nextGroupIds = reorderGroupIds(orderedGroupIdsRef.current, snap.sourceGroupId, snap.dropIndex);
@@ -414,6 +452,25 @@ export function OperationsSideBar({
       currentY: event.clientY,
       dragging: false,
       dropIndex: orderedGroupIds.indexOf(groupId),
+    });
+  };
+
+  const beginTheaterPointerDrag = (event: ReactPointerEvent<HTMLDivElement>, theaterId: string) => {
+    if (event.button !== 0) return;
+    if (event.target instanceof Element && event.target.closest("button")) return;
+    const orderedTheaterIds = theaters.map((theater) => theater.id);
+    if (!orderedTheaterIds.includes(theaterId)) return;
+    setActiveContextMenu(null);
+    disarmClose();
+    updateDrag({
+      kind: "theater",
+      sourceTheaterId: theaterId,
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      currentY: event.clientY,
+      dragging: false,
+      dropIndex: orderedTheaterIds.indexOf(theaterId),
     });
   };
 
@@ -518,10 +575,21 @@ export function OperationsSideBar({
       {!collapsed && theaterError ? <p className="side-bar-theater-error">{theaterError}</p> : null}
 
       <ol className="operations-side-bar-chips" ref={chipsRef} aria-label="Operations">
-        {theaters.map((theater) => {
+        {theaters.map((theater, theaterIndex) => {
           const isActiveTheater = theater.id === activeTheaterId;
           const theaterOperationCount = operations.filter((operation) => operation.theaterId === theater.id).length;
           const theaterCollapsed = collapsedTheaters.includes(theater.id);
+          const isTheaterDragging = drag?.kind === "theater" && drag.sourceTheaterId === theater.id && drag.dragging;
+          const theaterDragOffsetY = isTheaterDragging && drag?.kind === "theater" ? drag.currentY - drag.startY : 0;
+          const theaterDropBefore = drag?.kind === "theater"
+            && drag.dragging
+            && drag.sourceTheaterId !== theater.id
+            && drag.dropIndex === theaterIndex;
+          const theaterDropAfter = drag?.kind === "theater"
+            && drag.dragging
+            && drag.sourceTheaterId !== theater.id
+            && theaterIndex === theaters.length - 1
+            && drag.dropIndex === theaters.length;
           if (!isActiveTheater) {
             const theaterCanvas = getTheaterCanvasSnapshot(theater.id);
             const inactiveEntries = buildTheaterEntries({
@@ -546,6 +614,10 @@ export function OperationsSideBar({
                 operationAccent={theaterCanvas.operationAccent}
                 operationCount={theaterOperationCount}
                 collapsed={theaterCollapsed}
+                dragging={isTheaterDragging}
+                dropBefore={theaterDropBefore}
+                dropAfter={theaterDropAfter}
+                dragOffsetY={theaterDragOffsetY}
                 onSelectTheater={onSelectTheater}
                 onFocus={onFocus}
                 onToggleCollapsed={toggleTheaterSectionCollapsed}
@@ -558,13 +630,18 @@ export function OperationsSideBar({
                   setNewMenu(null);
                   setActiveContextMenu({ kind: "theater", theaterId: theater.id, anchor });
                 }}
+                onPointerDragStart={beginTheaterPointerDrag}
               />
             );
           }
           return (
             <li
               key={theater.id}
-              className="side-bar-theater-section side-bar-theater-section--active"
+              className={[
+                "side-bar-theater-section side-bar-theater-section--active",
+                theaterDropBefore ? "side-bar-theater-section--drop-before" : "",
+                theaterDropAfter ? "side-bar-theater-section--drop-after" : "",
+              ].filter(Boolean).join(" ")}
               data-theater-id={theater.id}
             >
               <TheaterSectionHeader
@@ -572,6 +649,9 @@ export function OperationsSideBar({
                 operationCount={theaterOperationCount}
                 active
                 collapsed={theaterCollapsed}
+                dragging={isTheaterDragging}
+                dropTarget={theaterDropBefore}
+                dragOffsetY={theaterDragOffsetY}
                 onSelectTheater={onSelectTheater}
                 onToggleCollapsed={toggleTheaterSectionCollapsed}
                 onOpenActions={(anchor, returnFocus) => {
@@ -583,6 +663,7 @@ export function OperationsSideBar({
                   setNewMenu(null);
                   setActiveContextMenu({ kind: "theater", theaterId: theater.id, anchor });
                 }}
+                onPointerDragStart={beginTheaterPointerDrag}
               />
               {!theaterCollapsed ? (
               <ol className="side-bar-theater-groups" aria-label={`${theater.label} operations`}>
@@ -837,12 +918,25 @@ function TheaterSectionHeader({
   operationCount,
   active,
   collapsed,
+  dragging,
+  dropTarget,
+  dragOffsetY,
   onSelectTheater,
   onToggleCollapsed,
   onOpenActions,
   onOpenLaunch,
   onContextMenu,
+  onPointerDragStart,
 }: TheaterSectionHeaderProps) {
+  const suppressClickRef = useRef(false);
+  const headerClassName = [
+    "side-bar-theater-header",
+    active ? "is-active" : "",
+    dragging ? "side-bar-theater-header--dragging" : "",
+    dropTarget ? "side-bar-theater-header--drop-target" : "",
+  ].filter(Boolean).join(" ");
+  const headerStyle = dragging ? ({ "--drag-dy": `${Math.round(dragOffsetY)}px` } as CSSProperties) : undefined;
+
   const handleContextMenu = (event: MouseEvent<HTMLDivElement>) => {
     event.preventDefault();
     onContextMenu(event.currentTarget.getBoundingClientRect());
@@ -856,14 +950,34 @@ function TheaterSectionHeader({
     onSelectTheater(theater.id);
   };
 
+  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.target instanceof Element && event.target.closest("button")) return;
+    onPointerDragStart(event, theater.id);
+  };
+
+  const handlePointerUp = () => {
+    if (dragging) suppressClickRef.current = true;
+  };
+
+  const select = () => {
+    if (suppressClickRef.current) {
+      suppressClickRef.current = false;
+      return;
+    }
+    onSelectTheater(theater.id);
+  };
+
   return (
     <div
       role="button"
       tabIndex={0}
-      className={`side-bar-theater-header${active ? " is-active" : ""}`}
-      onClick={() => onSelectTheater(theater.id)}
+      className={headerClassName}
+      style={headerStyle}
+      onClick={select}
       onKeyDown={handleKeyDown}
       onContextMenu={handleContextMenu}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
       aria-current={active ? "true" : undefined}
       aria-expanded={!collapsed}
       title={theater.label}
@@ -919,27 +1033,43 @@ function TheaterInactiveSection({
   operationAccent,
   operationCount,
   collapsed,
+  dragging,
+  dropBefore,
+  dropAfter,
+  dragOffsetY,
   onSelectTheater,
   onFocus,
   onToggleCollapsed,
   onOpenActions,
   onOpenLaunch,
   onContextMenu,
+  onPointerDragStart,
 }: TheaterInactiveSectionProps) {
   const sections = groupOperations(entries, groups, []);
   const hasCustomGroups = sections.some((section) => section.group !== null);
   return (
-    <li className="side-bar-theater-section" data-theater-id={theater.id}>
+    <li
+      className={[
+        "side-bar-theater-section",
+        dropBefore ? "side-bar-theater-section--drop-before" : "",
+        dropAfter ? "side-bar-theater-section--drop-after" : "",
+      ].filter(Boolean).join(" ")}
+      data-theater-id={theater.id}
+    >
       <TheaterSectionHeader
         theater={theater}
         operationCount={operationCount}
         active={false}
         collapsed={collapsed}
+        dragging={dragging}
+        dropTarget={dropBefore}
+        dragOffsetY={dragOffsetY}
         onSelectTheater={onSelectTheater}
         onToggleCollapsed={onToggleCollapsed}
         onOpenActions={onOpenActions}
         onOpenLaunch={onOpenLaunch}
         onContextMenu={onContextMenu}
+        onPointerDragStart={onPointerDragStart}
       />
       {!collapsed && sections.length > 0 ? (
         <ol className="side-bar-theater-groups" aria-label={`${theater.label} operations`}>

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2274,6 +2274,7 @@
 }
 
 .side-bar-theater-section {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -2297,7 +2298,7 @@
   border-radius: 8px;
   background: transparent;
   color: var(--ink-fog);
-  cursor: pointer;
+  cursor: grab;
   font-family: var(--font-body);
   font-size: 12.5px;
   font-weight: 750;
@@ -2306,7 +2307,9 @@
   transition:
     background var(--duration-fast) var(--ease-spring),
     border-color var(--duration-fast) var(--ease-spring),
-    color var(--duration-fast) var(--ease-spring);
+    color var(--duration-fast) var(--ease-spring),
+    box-shadow var(--duration-fast) var(--ease-spring),
+    transform var(--duration-fast) var(--ease-spring);
   user-select: none;
 }
 
@@ -2734,7 +2737,9 @@
 }
 
 .side-bar-group-section--drop-before::before,
-.side-bar-group-section--drop-after::after {
+.side-bar-group-section--drop-after::after,
+.side-bar-theater-section--drop-before::before,
+.side-bar-theater-section--drop-after::after {
   content: "";
   position: absolute;
   left: 2px;
@@ -2747,11 +2752,13 @@
   z-index: 12;
 }
 
-.side-bar-group-section--drop-before::before {
+.side-bar-group-section--drop-before::before,
+.side-bar-theater-section--drop-before::before {
   top: -2px;
 }
 
-.side-bar-group-section--drop-after::after {
+.side-bar-group-section--drop-after::after,
+.side-bar-theater-section--drop-after::after {
   bottom: -2px;
 }
 
@@ -2784,12 +2791,14 @@
     transform var(--duration-fast) var(--ease-spring);
 }
 
-.side-bar-group-header--drop-target {
+.side-bar-group-header--drop-target,
+.side-bar-theater-header--drop-target {
   background: color-mix(in oklch, var(--brass) 12%, transparent);
   box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass) 34%, transparent);
 }
 
-.side-bar-group-header--dragging {
+.side-bar-group-header--dragging,
+.side-bar-theater-header--dragging {
   opacity: 0.88;
   transform: translateY(var(--drag-dy, 0)) scale(1.015);
   z-index: 20;
@@ -2829,11 +2838,13 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .side-bar-group-header {
+  .side-bar-group-header,
+  .side-bar-theater-header {
     transition: none;
   }
 
-  .side-bar-group-header--dragging {
+  .side-bar-group-header--dragging,
+  .side-bar-theater-header--dragging {
     transform: translateY(var(--drag-dy, 0));
   }
 

--- a/runtime/fleet-console/core/client/src/types.ts
+++ b/runtime/fleet-console/core/client/src/types.ts
@@ -44,6 +44,7 @@ export interface TheaterInfo {
   readonly label: string;
   readonly createdAt: string;
   readonly lastOpenedAt: string;
+  readonly order?: number;
   readonly hasWiki: boolean;
   readonly activeAdmiralCount: number;
 }

--- a/runtime/fleet-console/core/host/api-types.ts
+++ b/runtime/fleet-console/core/host/api-types.ts
@@ -49,6 +49,7 @@ export interface ConsoleTheaterInfo {
   readonly label: string;
   readonly createdAt: string;
   readonly lastOpenedAt: string;
+  readonly order?: number;
   readonly hasWiki: boolean;
   readonly activeAdmiralCount: number;
 }

--- a/runtime/fleet-console/core/host/durable-state.ts
+++ b/runtime/fleet-console/core/host/durable-state.ts
@@ -152,7 +152,16 @@ function sanitizeTheaterRegistration(value: unknown): TheaterRegistration | null
   const registeredAt = readNonEmptyString(value.registeredAt);
   const lastOpenedAt = readNonEmptyString(value.lastOpenedAt);
   if (!id || !theaterPath || !realpath || !label || !registeredAt || !lastOpenedAt) return null;
-  return { id, path: theaterPath, realpath, label, registeredAt, lastOpenedAt };
+  const order = readNonNegativeInteger(value.order);
+  return {
+    id,
+    path: theaterPath,
+    realpath,
+    label,
+    registeredAt,
+    lastOpenedAt,
+    ...(order !== null ? { order } : {}),
+  };
 }
 
 function sanitizeOperationNode(value: unknown): OperationNode | null {

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -74,6 +74,7 @@ export interface ConsoleServer {
 type TheaterFolderListBody = { readonly path?: unknown };
 type TheaterFolderGrantBody = { readonly path?: unknown };
 type CreateTheaterBody = { readonly folderGrantId?: unknown };
+type PatchTheaterBody = { readonly order?: unknown };
 type UpdateApplyBody = Record<string, unknown>;
 
 interface ConsolePortRuntimeState {
@@ -151,6 +152,13 @@ export const SERVER_API_CATALOG: readonly ApiCatalogEntry[] = [
     method: "POST",
     path: "/api/v1/theaters",
     summary: "새 Theater를 등록합니다.",
+    category: "Observer",
+    gate: "origin-write",
+  },
+  {
+    method: "PATCH",
+    path: "/api/v1/theaters/:theaterId",
+    summary: "Theater 표시 순서를 변경합니다.",
     category: "Observer",
     gate: "origin-write",
   },
@@ -796,12 +804,27 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   }
 
   async function handleObserverTheaterItem(req: http.IncomingMessage, res: http.ServerResponse, theaterId: string): Promise<void> {
-    if (req.method !== "DELETE") {
+    if (req.method !== "PATCH" && req.method !== "DELETE") {
       writeJson(res, 405, { error: "Method not allowed" });
       return;
     }
     if (!isTerminalAuthorized(req)) {
       writeJson(res, 401, { error: "unauthorized" });
+      return;
+    }
+    if (req.method === "PATCH") {
+      const body = await readJsonBody<PatchTheaterBody>(req);
+      if (!isPlainObject(body) || typeof body.order !== "number" || !Number.isInteger(body.order) || body.order < 0) {
+        writeJson(res, 400, { error: "invalid_theater_order" });
+        return;
+      }
+      const theater = theaters.setOrder(theaterId, body.order);
+      if (!theater) {
+        writeJson(res, 404, { error: "theater_not_found" });
+        return;
+      }
+      persistDurableState();
+      writeJson(res, 200, toTheaterInfo(theater, true));
       return;
     }
     // DELETE는 idempotent해야 한다 — Theater가 레지스트리에 이미 없어도(유령 항목이나 중복 forget) 목표 상태(부재)는
@@ -985,6 +1008,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       label: theater.label,
       createdAt: theater.registeredAt,
       lastOpenedAt: theater.lastOpenedAt,
+      ...(theater.order !== undefined ? { order: theater.order } : {}),
       hasWiki,
       activeAdmiralCount: operations.listByTheater(theater.id).filter((operation) => operation.pluginId === "terminal" && operation.type === "agent").length,
     };

--- a/runtime/fleet-console/core/host/theaters.ts
+++ b/runtime/fleet-console/core/host/theaters.ts
@@ -9,6 +9,7 @@ export interface TheaterRegistration {
   readonly label: string;
   readonly registeredAt: string;
   readonly lastOpenedAt: string;
+  readonly order?: number;
 }
 
 export class TheaterRegistry {
@@ -31,6 +32,7 @@ export class TheaterRegistry {
       label: theaterLabel(resolved),
       registeredAt: existing?.registeredAt ?? now,
       lastOpenedAt: now,
+      order: existing?.order,
     };
     this.#items.set(id, item);
     this.#mruId = id;
@@ -68,12 +70,27 @@ export class TheaterRegistry {
   }
 
   list(): readonly TheaterRegistration[] {
-    return [...this.#items.values()].sort((left, right) => right.lastOpenedAt.localeCompare(left.lastOpenedAt));
+    return [...this.#items.values()].sort((left, right) => {
+      if (left.order !== undefined && right.order !== undefined) return left.order - right.order;
+      if (left.order === undefined && right.order === undefined) return right.lastOpenedAt.localeCompare(left.lastOpenedAt);
+      return left.order === undefined ? -1 : 1;
+    });
+  }
+
+  setOrder(id: string, order: number): TheaterRegistration | null {
+    const existing = this.#items.get(id);
+    if (!existing) return null;
+    const updated: TheaterRegistration = { ...existing, order };
+    this.#items.set(id, updated);
+    return updated;
   }
 
   remove(id: string): boolean {
     const removed = this.#items.delete(id);
-    if (this.#mruId === id) this.#mruId = this.list()[0]?.id ?? null;
+    if (this.#mruId === id) {
+      this.#mruId = [...this.#items.values()]
+        .sort((left, right) => right.lastOpenedAt.localeCompare(left.lastOpenedAt))[0]?.id ?? null;
+    }
     return removed;
   }
 }

--- a/runtime/fleet-console/tests/api.test.ts
+++ b/runtime/fleet-console/tests/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { ApiError, applyConsoleUpdate, fetchReleaseNotes } from "../core/client/src/api.js";
+import { ApiError, applyConsoleUpdate, fetchReleaseNotes, fetchTheaters, patchTheaterOrder } from "../core/client/src/api.js";
 
 const originalFetch = globalThis.fetch;
 
@@ -10,6 +10,44 @@ afterEach(() => {
 });
 
 describe("client api parsing", () => {
+  it("PATCHes Theater order and carries valid optional order values", async () => {
+    const theater = {
+      id: "theater-a",
+      label: "Alpha",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastOpenedAt: "2026-01-02T00:00:00.000Z",
+      order: 2,
+      hasWiki: true,
+      activeAdmiralCount: 0,
+    };
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(theater)));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(patchTheaterOrder("theater/a", 2)).resolves.toEqual(theater);
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/theaters/theater%2Fa", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ order: 2 }),
+      signal: undefined,
+    });
+  });
+
+  it("keeps legacy Theater responses without order and ignores malformed optional order", async () => {
+    const theater = {
+      id: "theater-a",
+      label: "Alpha",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastOpenedAt: "2026-01-02T00:00:00.000Z",
+      hasWiki: false,
+      activeAdmiralCount: 0,
+    };
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({
+      theaters: [theater, { ...theater, id: "theater-b", order: -1 }],
+    }))) as typeof fetch;
+
+    await expect(fetchTheaters()).resolves.toEqual([theater, { ...theater, id: "theater-b" }]);
+  });
+
   it("requests update apply without browser-controlled package targets", async () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({ status: "accepted" }), { status: 202 }));
     globalThis.fetch = fetchMock as typeof fetch;

--- a/runtime/fleet-console/tests/durable-state.test.ts
+++ b/runtime/fleet-console/tests/durable-state.test.ts
@@ -27,6 +27,23 @@ describe("durable console state", () => {
     expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, pathContext: "../escape" }], operations: [] })).toMatchObject({ version: 2, theaters: [base] });
   });
 
+  it("round-trips optional Theater order without changing durable version", () => {
+    const base = { id: "t", path: "/work/proj", realpath: "/work/proj", label: "proj", registeredAt: "1", lastOpenedAt: "2" };
+
+    expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, order: 3 }], operations: [] })).toMatchObject({
+      version: 2,
+      theaters: [{ ...base, order: 3 }],
+    });
+    expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, order: -1 }], operations: [] })).toMatchObject({
+      version: 2,
+      theaters: [base],
+    });
+    expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, order: 1.5 }], operations: [] })).toMatchObject({
+      version: 2,
+      theaters: [base],
+    });
+  });
+
   it("migrates v1 flat session records into v2 OperationNodes", () => {
     const migrated = sanitizeDurableConsoleState({
       version: 1,

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -12,6 +12,7 @@ import type { OperationNode, TheaterBootstrap } from "../core/client/src/types.j
 
 const apiMocks = vi.hoisted(() => ({
   fetchTheaterBootstrap: vi.fn(),
+  fetchTheaters: vi.fn(),
   fetchOperations: vi.fn(),
   fetchGroups: vi.fn(),
 }));
@@ -47,6 +48,7 @@ vi.mock("../core/client/src/api.js", () => ({
   forgetTheater: vi.fn(),
   issueTheaterFolderGrant: vi.fn(),
   patchOperation: vi.fn(),
+  patchTheaterOrder: vi.fn(),
   renameOperation: vi.fn(),
   updateGroup: vi.fn(),
 }));

--- a/runtime/fleet-console/tests/operations-side-bar-hit-test.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-hit-test.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 
-import { dropIndexFromPoint, groupDropIndexFromPoint, reorderGroupIds } from "../core/client/src/sidebar/operations-side-bar-hit-test.js";
+import { dropIndexFromPoint, groupDropIndexFromPoint, reorderGroupIds, reorderTheaterIds, theaterDropIndexFromPoint } from "../core/client/src/sidebar/operations-side-bar-hit-test.js";
 
 describe("operations side bar reorder hit testing", () => {
   it("ignores the dragged source chip when resolving the drop index", () => {
@@ -78,6 +78,42 @@ describe("reorderGroupIds", () => {
   });
 });
 
+describe("theaterDropIndexFromPoint", () => {
+  it("uses Theater section midpoints and skips the dragged source Theater", () => {
+    const sections = document.createElement("ol");
+    sections.append(
+      createTheaterSection("t-a", 0, 40),
+      createTheaterSection("t-b", 40, 100),
+      createTheaterSection("t-c", 100, 150),
+    );
+
+    expect(theaterDropIndexFromPoint(70, ["t-a", "t-b", "t-c"], sections, "t-b")).toBe(2);
+  });
+
+  it("returns the final slot below all Theater sections", () => {
+    const sections = document.createElement("ol");
+    sections.append(createTheaterSection("t-a", 0, 40));
+
+    expect(theaterDropIndexFromPoint(100, ["t-a"], sections)).toBe(1);
+  });
+});
+
+describe("reorderTheaterIds", () => {
+  it("moves a Theater upward", () => {
+    expect(reorderTheaterIds(["t-a", "t-b", "t-c"], "t-c", 0)).toEqual(["t-c", "t-a", "t-b"]);
+  });
+
+  it("moves a Theater downward with source-inclusive drop index adjustment", () => {
+    expect(reorderTheaterIds(["t-a", "t-b", "t-c"], "t-a", 3)).toEqual(["t-b", "t-c", "t-a"]);
+  });
+
+  it("keeps a self-drop stable and clamps out-of-range slots", () => {
+    expect(reorderTheaterIds(["t-a", "t-b", "t-c"], "t-b", 1)).toEqual(["t-a", "t-b", "t-c"]);
+    expect(reorderTheaterIds(["t-a", "t-b", "t-c"], "t-b", -10)).toEqual(["t-b", "t-a", "t-c"]);
+    expect(reorderTheaterIds(["t-a", "t-b", "t-c"], "t-b", 99)).toEqual(["t-a", "t-c", "t-b"]);
+  });
+});
+
 function createChip(id: string, top: number, bottom: number): HTMLElement {
   const chip = document.createElement("li");
   chip.dataset.sideBarChipId = id;
@@ -98,6 +134,23 @@ function createChip(id: string, top: number, bottom: number): HTMLElement {
 function createGroupSection(id: string, top: number, bottom: number): HTMLElement {
   const section = document.createElement("li");
   section.dataset.dropZoneGroupId = id;
+  section.getBoundingClientRect = () => ({
+    x: 0,
+    y: top,
+    top,
+    left: 0,
+    right: 200,
+    bottom,
+    width: 200,
+    height: bottom - top,
+    toJSON: () => ({}),
+  });
+  return section;
+}
+
+function createTheaterSection(id: string, top: number, bottom: number): HTMLElement {
+  const section = document.createElement("li");
+  section.dataset.theaterId = id;
   section.getBoundingClientRect = () => ({
     x: 0,
     y: top,

--- a/runtime/fleet-console/tests/operations-side-bar-inactive-theater.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-inactive-theater.test.tsx
@@ -110,6 +110,7 @@ function renderSideBar(onFocus = vi.fn()): void {
     onSetGroupColor: () => {},
     onRenameGroup: () => {},
     onReorderGroups: () => {},
+    onReorderTheaters: () => {},
     onUngroupAll: () => {},
     onSelectTheater: () => {},
     onAddTheater: () => {},

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -2472,6 +2472,61 @@ describe("observer theater forget", () => {
   });
 });
 
+describe("observer theater order", () => {
+  it("authorizes, validates, persists, and restores Theater order PATCHes", async () => {
+    const theaterDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-order-theater-"));
+    tempDirs.push(theaterDir);
+    const fixture = await startFixture();
+    const theater = await createTheater(fixture, theaterDir);
+    const url = `${fixture.endpoint}api/v1/theaters/${encodeURIComponent(theater.id)}`;
+    const origin = new URL(fixture.endpoint).origin;
+
+    const unauthorized = await fetch(url, {
+      method: "PATCH",
+      headers: { Origin: "http://127.0.0.1:9999", "Content-Type": "application/json" },
+      body: JSON.stringify({ order: 1 }),
+    });
+    const invalid = await fetch(url, {
+      method: "PATCH",
+      headers: { Origin: origin, "Content-Type": "application/json" },
+      body: JSON.stringify({ order: -1 }),
+    });
+    const missing = await fetch(`${fixture.endpoint}api/v1/theaters/missing`, {
+      method: "PATCH",
+      headers: { Origin: origin, "Content-Type": "application/json" },
+      body: JSON.stringify({ order: 1 }),
+    });
+    const patched = await fetch(url, {
+      method: "PATCH",
+      headers: { Origin: origin, "Content-Type": "application/json" },
+      body: JSON.stringify({ order: 3 }),
+    });
+    const patchedBody = await patched.json() as { readonly id: string; readonly order?: number };
+    const listed = await getJson<{ readonly theaters: ReadonlyArray<{ readonly id: string; readonly order?: number }> }>(`${fixture.endpoint}api/v1/theaters`);
+    const statePath = path.join(fixture.carrierStoreDir, "console", "state.json");
+    const state = JSON.parse(fs.readFileSync(statePath, "utf8")) as { readonly version: number; readonly theaters: ReadonlyArray<{ readonly id: string; readonly order?: number }> };
+
+    expect(unauthorized.status).toBe(401);
+    expect(invalid.status).toBe(400);
+    expect(missing.status).toBe(404);
+    expect(patched.status).toBe(200);
+    expect(patchedBody).toMatchObject({ id: theater.id, order: 3 });
+    expect(listed.theaters.find((entry) => entry.id === theater.id)?.order).toBe(3);
+    expect(state.version).toBe(2);
+    expect(state.theaters.find((entry) => entry.id === theater.id)?.order).toBe(3);
+
+    await fixture.server.stop();
+    const restartDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-order-restart-"));
+    tempDirs.push(restartDir);
+    const restartedServer = createConsoleServer({ port: 0, version: "test", dataDir: fixture.carrierStoreDir });
+    servers.push(restartedServer);
+    const restartedEndpoint = await restartedServer.start({ dir: restartDir, lockFile: path.join(restartDir, "console.lock") });
+    const restored = await getJson<{ readonly theaters: ReadonlyArray<{ readonly id: string; readonly order?: number }> }>(`${restartedEndpoint}api/v1/theaters`);
+
+    expect(restored.theaters.find((entry) => entry.id === theater.id)?.order).toBe(3);
+  });
+});
+
 async function startFixture(options: {
   readonly agentRuntime?: ConsoleServerDeps["agentRuntime"];
   readonly agentCliDetector?: ConsoleServerDeps["agentCliDetector"];

--- a/runtime/fleet-console/tests/theaters.test.ts
+++ b/runtime/fleet-console/tests/theaters.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { TheaterRegistry, type TheaterRegistration } from "../core/host/theaters.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("TheaterRegistry order", () => {
+  it("preserves the legacy MRU order when no Theater has a manual order", () => {
+    const theaters = new TheaterRegistry();
+    theaters.restore([
+      registration("oldest", "2026-01-01T00:00:00.000Z"),
+      registration("latest", "2026-03-01T00:00:00.000Z"),
+      registration("middle", "2026-02-01T00:00:00.000Z"),
+    ]);
+
+    expect(theaters.list().map((theater) => theater.id)).toEqual(["latest", "middle", "oldest"]);
+  });
+
+  it("places unordered Theaters first by MRU and ordered Theaters by ascending order", () => {
+    const theaters = new TheaterRegistry();
+    theaters.restore([
+      registration("ordered-last", "2026-04-01T00:00:00.000Z", 4),
+      registration("unordered-old", "2026-01-01T00:00:00.000Z"),
+      registration("ordered-first", "2026-03-01T00:00:00.000Z", 1),
+      registration("unordered-new", "2026-02-01T00:00:00.000Z"),
+    ]);
+
+    expect(theaters.list().map((theater) => theater.id)).toEqual([
+      "unordered-new",
+      "unordered-old",
+      "ordered-first",
+      "ordered-last",
+    ]);
+  });
+
+  it("updates order immutably and preserves it when the Theater is registered again", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-theater-order-"));
+    tempDirs.push(dir);
+    const theaters = new TheaterRegistry();
+    const original = await theaters.register(dir);
+
+    const ordered = theaters.setOrder(original.id, 2);
+    const reopened = await theaters.register(dir);
+
+    expect(ordered).not.toBe(original);
+    expect(ordered?.order).toBe(2);
+    expect(reopened.order).toBe(2);
+    expect(theaters.setOrder("missing", 0)).toBeNull();
+  });
+
+  it("keeps MRU fallback based on lastOpenedAt when removing the active Theater", () => {
+    const theaters = new TheaterRegistry();
+    theaters.restore([
+      registration("ordered-first", "2026-01-01T00:00:00.000Z", 0),
+      registration("next-mru", "2026-02-01T00:00:00.000Z", 2),
+      registration("current-mru", "2026-03-01T00:00:00.000Z", 1),
+    ]);
+
+    expect(theaters.remove("current-mru")).toBe(true);
+    expect(theaters.list().map((theater) => theater.id)).toEqual(["ordered-first", "next-mru"]);
+    expect(theaters.getMru()?.id).toBe("next-mru");
+  });
+});
+
+function registration(id: string, lastOpenedAt: string, order?: number): TheaterRegistration {
+  return {
+    id,
+    path: `/work/${id}`,
+    realpath: `/work/${id}`,
+    label: id,
+    registeredAt: "2026-01-01T00:00:00.000Z",
+    lastOpenedAt,
+    ...(order !== undefined ? { order } : {}),
+  };
+}


### PR DESCRIPTION
## Summary
- 사이드바에서 **Theater를 드래그로 재정렬**할 수 있게 지원 — 기존 Group/Operation 드래그 그래머(window pointer 리스너, 브라스 드롭 인디케이터)를 Theater tier로 미러링. 활성/비활성 Theater 헤더 모두 드래그 가능.
- 순서는 **서버 영속** — `PATCH /api/v1/theaters/:id { order }`(Origin 게이트)로 저장하고, `TheaterRegistry.list()`가 `order` 오름차순 정렬. 한 번 수동 정렬하면 그 순서가 SSoT가 되어 Theater를 열어도 위치 고정(기존 MRU 자동정렬 대체).
- **하위호환 · 마이그레이션 없음** — `order`는 optional 필드. 기존 `state.json`에 order가 없으면 기존 MRU(`lastOpenedAt` 내림차순) 정렬로 폴백하며 `DurableConsoleState.version`은 2 그대로. 재등록 시 order 보존, `remove()`의 MRU 승계 보존.
- 클릭=Theater 선택은 그대로 유지(드래그는 `suppressClickRef`로 선택을 가로채지 않음).

## Test Plan
- [x] 유닛: theaters(정렬 폴백·재등록 보존·remove MRU), durable-state(order round-trip·invalid fallback·v2 유지), api(PATCH·optional order 파싱), hit-test(theaterDropIndexFromPoint·reorderTheaterIds), server(PATCH 인증·검증·영속·재시작) — 59/59 통과
- [x] `pnpm build` green (tsup + DTS + desktop-protocol verify + vite production)
- [x] typecheck: 변경 파일 신규 에러 0 (선존 인프라 에러 10건은 base와 동일)
- [x] 격리 콘솔 헤디드 e2e: 3 Theater 렌더·grab 커서·MRU 폴백·드래그 드롭 인디케이터·재정렬·서버+state.json 영속(version 2)·새로고침 유지·클릭≠드래그 선택 분리 — 콘솔 에러 0
- [ ] Changelog: `.changelog.d/pr-<number>.md` (PR 번호 배정 후 추가 예정)