### PR TITLE
fix(wiki): fix Windows fsync EPERM and normalize output paths

### DIFF
--- a/.changelog.d/pr-324.md
+++ b/.changelog.d/pr-324.md
@@ -1,0 +1,6 @@
+### fleet-core
+#### Fixed
+- [fleet-wiki] Fix the wiki workspace migration failing on Windows with an EPERM fsync error on a read-only file descriptor, which blocked every wiki tool.
+  ko: Windows에서 읽기 전용 파일 디스크립터의 fsync가 EPERM으로 실패해 모든 위키 도구를 막던 위키 워크스페이스 마이그레이션 오류를 수정합니다.
+- [fleet-wiki] Normalize wiki_read source and related entry paths to forward slashes on Windows, matching the store index convention.
+  ko: Windows에서 wiki_read의 source 및 related 항목 경로를 정슬래시로 정규화하여 store 인덱스 규약과 일치시킵니다.

--- a/packages/fleet-wiki/src/tools/read.ts
+++ b/packages/fleet-wiki/src/tools/read.ts
@@ -1,5 +1,3 @@
-import path from "node:path";
-
 import { wrapWikiEntryBoundary, wrapWikiRawSourceBoundary, FLEET_WIKI_BOUNDARY_GUIDELINES } from "../boundaries.js";
 import { dedupeStrings, estimateTokens } from "../internal-utils.js";
 import { extractWikiLinks } from "../links.js";
@@ -184,7 +182,7 @@ async function buildReadEntryResult(
     rawSourceRef: entry.rawSourceRef,
     rawSourceRefs,
     source: {
-      path: path.join("wiki", `${entry.id}.md`),
+      path: `wiki/${entry.id}.md`,
       rawSourceRef: entry.rawSourceRef,
       rawSourceRefs,
     },
@@ -323,7 +321,7 @@ function buildRelatedEntries(entry: WikiEntry, graph: LinkGraph): WikiReadRelate
     deduped.set(candidate.id, {
       id: relatedEntry.id,
       title: relatedEntry.title,
-      path: path.join("wiki", `${relatedEntry.id}.md`),
+      path: `wiki/${relatedEntry.id}.md`,
       reason: candidate.reason,
     });
   }

--- a/packages/fleet-wiki/src/workspace-resolver.ts
+++ b/packages/fleet-wiki/src/workspace-resolver.ts
@@ -20,6 +20,7 @@ interface MigrationMarker { version: 1; outcome: "copied"; transactionId: string
 const STAGING_PREFIX = "knowledge.migrating-";
 const MARKER_NAME = "knowledge.migrated.json";
 const MARKER_TEMP_REGEXP = /^knowledge\.migrated\.json\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.tmp$/i;
+const IGNORED_FSYNC_ERROR_CODES = new Set(["EPERM", "EINVAL", "ENOSYS"]);
 
 /** Host-injected canonical-workspace gate; fleet-wiki intentionally knows no host package. */
 export function createWikiWorkspaceResolver(deps: WikiWorkspaceResolverDependencies): WikiWorkspaceResolver {
@@ -223,10 +224,19 @@ function writeAtomic(target: string, contents: string): void {
   syncFile(temporary);
   fs.renameSync(temporary, target);
 }
-function syncFile(target: string): void { const fd = fs.openSync(target, "r"); try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); } }
+function fsyncBestEffort(fd: number): void {
+  try {
+    fs.fsyncSync(fd);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (typeof code !== "string" || !IGNORED_FSYNC_ERROR_CODES.has(code)) throw error;
+  }
+}
+
+function syncFile(target: string): void { const fd = fs.openSync(target, "r"); try { fsyncBestEffort(fd); } finally { fs.closeSync(fd); } }
 function syncDirectory(target: string): void {
   if (!shouldSyncDirectoryForTest(process.platform)) return;
-  const fd = fs.openSync(target, "r"); try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+  const fd = fs.openSync(target, "r"); try { fsyncBestEffort(fd); } finally { fs.closeSync(fd); }
 }
 
 /** Test-only direct-module seam for the platform-specific directory fsync policy; absent from the package-root barrel. */

--- a/packages/fleet-wiki/tests/wiki-drydock.test.ts
+++ b/packages/fleet-wiki/tests/wiki-drydock.test.ts
@@ -495,8 +495,8 @@ describe("wiki drydock", () => {
 
     const report = await runDryDock(paths);
 
-    expect(report.issues.some((issue) => issue.code === "conflict_unresolved" && issue.path.endsWith(`${created.meta.id}/meta.json`))).toBe(true);
-    expect(report.issues.some((issue) => issue.code === "unresolved_conflict" && issue.path.endsWith("broken/meta.json"))).toBe(true);
+    expect(report.issues.some((issue) => issue.code === "conflict_unresolved" && issue.path.endsWith(path.join(created.meta.id, "meta.json")))).toBe(true);
+    expect(report.issues.some((issue) => issue.code === "unresolved_conflict" && issue.path.endsWith(path.join("broken", "meta.json")))).toBe(true);
   });
 
   it("emits semantic warning and info codes without failing ok when no error exists", async () => {

--- a/packages/fleet-wiki/tests/wiki-store.test.ts
+++ b/packages/fleet-wiki/tests/wiki-store.test.ts
@@ -74,7 +74,7 @@ describe("wiki store", () => {
       { ref: "raw/2026-04-26-alpha-source-aaaaaaaa.md", title: "Alpha Source", hash: "aaaaaaaa" },
       { ref: "raw/2026-04-26-alpha-source-bbbbbbbb.md", title: undefined, hash: undefined },
     ]);
-    expect(index.alpha?.path).toBe(path.join("wiki", "alpha.md"));
+    expect(index.alpha?.path).toBe("wiki/alpha.md");
     expect(index.alpha?.type).toBe("decision");
     expect(index.alpha?.status).toBe("current");
     expect(index.alpha?.confidence).toBe("high");

--- a/packages/fleet-wiki/tests/wiki-workspace-resolver.test.ts
+++ b/packages/fleet-wiki/tests/wiki-workspace-resolver.test.ts
@@ -4,7 +4,15 @@ import { execFileSync } from "node:child_process";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    fsyncSync: vi.fn(actual.fsyncSync),
+  };
+});
 
 import {
   createWikiWorkspaceResolver,
@@ -39,6 +47,25 @@ async function fixture(hooks?: TestHooks) {
 }
 
 describe("createWikiWorkspaceResolver", () => {
+  it("tolerates EPERM from fsync during migration (Windows read-only handle)", async () => {
+    const { cwd, workspace, resolver } = await fixture();
+    const sourceFile = path.join(cwd, ".fleet", "knowledge", "wiki", "entry.md");
+    await mkdir(path.dirname(sourceFile), { recursive: true });
+    await writeFile(sourceFile, "legacy\n");
+    const spy = vi.mocked(fs.fsyncSync).mockImplementation(() => {
+      const error = new Error("EPERM: operation not permitted, fsync") as NodeJS.ErrnoException;
+      error.code = "EPERM";
+      throw error;
+    });
+    try {
+      const paths = resolver.resolve(cwd);
+      await expect(readFile(path.join(paths.wikiDir, "entry.md"), "utf8")).resolves.toBe("legacy\n");
+      expect(JSON.parse(await readFile(path.join(workspace, "knowledge.migrated.json"), "utf8")).outcome).toBe("copied");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it("copies root legacy content once through durable sibling storage without changing the source", async () => {
     const { cwd, workspace, resolver } = await fixture();
     const sourceFile = path.join(cwd, ".fleet", "knowledge", "wiki", "entry.md");


### PR DESCRIPTION
## Summary
- Windows에서 wiki workspace 마이그레이션이 읽기 전용 파일 디스크립터의 `fsync`(EPERM)로 실패하던 문제를 수정합니다. Windows의 `fsync`는 `FlushFileBuffers`를 호출하며 쓰기 권한 있는 핸들을 요구하므로, 읽기 전용 핸들에서 EPERM이 발생했습니다. best-effort fsync(`EPERM`/`EINVAL`/`ENOSYS` 무시)로 전환했습니다 — `core-infra`의 원자쓰기 패턴과 동일하며, 의존성 경계상 fleet-wiki는 자체 헬퍼를 유지합니다. Linux/macOS의 fsync 내구성은 그대로 보존됩니다.
- `wiki_read`의 출력 경로(source/related)를 정슬래시 논리 경로로 정규화합니다(store 인덱스 규약과 일치). Windows에서 `path.join`으로 역슬래시가 새던 문제를 교정합니다.
- 기존에 Windows에서 실패하던 경로 구분자 관련 테스트(store 인덱스 경로, drydock conflict issue 경로)를 이식성 있게 수정합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-wiki typecheck` / `build` / `test` — 232 passed, 2 skipped (Windows ARM64에서 실측)
- [x] EPERM fsync를 모킹한 마이그레이션 회귀 테스트 추가 (전 플랫폼 회귀 방지)
- [x] console-e2e: 격리 Console에서 레거시 `.fleet/knowledge` seed → `GET /console/codex` **200**(수정 전 게이트웨이 500), 마이그레이션 목적지 정상 생성, EPERM 로그 없음
- [ ] Changelog: `.changelog.d/pr-<number>.md` (PR 번호 배정 후 추가)