### PR TITLE
fix(console): remove Session Analyst session cap

### DIFF
--- a/.changelog.d/pr-325.md
+++ b/.changelog.d/pr-325.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] Remove the Session Analyst session cap while preserving each Analyst until its Operation closes.
+  ko: Session Analyst 세션 상한을 제거하고 각 Analyst를 해당 Operation 종료 시까지 유지합니다.

--- a/runtime/fleet-console/core/host/operations/routes.ts
+++ b/runtime/fleet-console/core/host/operations/routes.ts
@@ -10,8 +10,8 @@ export interface OperationsRouterDeps {
   readonly readJsonBody: <T>(req: http.IncomingMessage) => Promise<T | null>;
   readonly writeJson: (res: http.ServerResponse, status: number, payload: unknown) => void;
   readonly persist: () => void;
+  readonly deleteOperation: (id: string) => boolean;
   readonly publishRenameEvent?: (event: OperationRenameEvent) => void;
-  readonly publishDeleteEvent?: (event: OperationDeleteEvent) => void;
   readonly broadcastOperationChanged?: (node: OperationNode) => void;
   readonly subscribeOperationSse?: (res: http.ServerResponse) => void;
   readonly getPluginSensitiveFields?: (pluginId: string) => readonly string[];
@@ -26,12 +26,6 @@ type OperationRenameEvent = {
   readonly type: string;
   readonly title: string;
   readonly previousTitle: string;
-};
-
-type OperationDeleteEvent = {
-  readonly operationId: string;
-  readonly pluginId: string;
-  readonly type: string;
 };
 
 type CreateOperationBody = Partial<OperationCreateInput>;
@@ -142,18 +136,7 @@ async function handleItem(req: http.IncomingMessage, res: http.ServerResponse, i
     return;
   }
   if (req.method === "DELETE") {
-    const existing = deps.store.get(id);
-    const deleted = deps.store.delete(id);
-    if (deleted) {
-      deps.persist();
-      if (existing) {
-        deps.publishDeleteEvent?.({
-          operationId: existing.id,
-          pluginId: existing.pluginId,
-          type: existing.type,
-        });
-      }
-    }
+    const deleted = deps.deleteOperation(id);
     deps.writeJson(res, deleted ? 200 : 404, deleted ? { ok: true } : { error: "operation_not_found" });
     return;
   }

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -303,6 +303,21 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   const pluginEventListeners = new Map<string, Set<(payload: unknown) => void>>();
   const operationSseSubscribers = new Set<http.ServerResponse>();
   const desktopThemeSseSubscribers = new Set<http.ServerResponse>();
+  function publishPluginEvent(channel: string, payload: unknown): void {
+    for (const listener of pluginEventListeners.get(channel) ?? []) listener(payload);
+  }
+  // 모든 호스트 삭제 진입점은 삭제 성공 뒤 영속화와 단일 수명주기 발행을 이 경계에서 완료한다.
+  function deleteOperation(operationId: string): boolean {
+    const operation = operations.get(operationId);
+    if (!operation || !operations.delete(operationId)) return false;
+    persistDurableState();
+    publishPluginEvent(OPERATION_DELETED_EVENT_CHANNEL, {
+      operationId: operation.id,
+      pluginId: operation.pluginId,
+      type: operation.type,
+    });
+    return true;
+  }
   let desktopFullscreen = false;
   let unsubscribeUpdateCheckChanges = updateCheck.onChange?.(() => {
     broadcastUpdateAvailable();
@@ -327,11 +342,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
         }
         return operation;
       },
-      delete: (id) => {
-        const deleted = operations.delete(id);
-        if (deleted) persistDurableState();
-        return deleted;
-      },
+      delete: deleteOperation,
       registerOperationType: (type) => {
         pluginOperationTypes.add(type);
         return () => {
@@ -363,9 +374,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       },
     },
     events: {
-      publish: (channel, payload) => {
-        for (const listener of pluginEventListeners.get(channel) ?? []) listener(payload);
-      },
+      publish: publishPluginEvent,
       subscribe: (channel, listener) => {
         const listeners = pluginEventListeners.get(channel) ?? new Set<(payload: unknown) => void>();
         listeners.add(listener);
@@ -551,13 +560,13 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     readJsonBody,
     writeJson,
     persist: persistDurableState,
+    deleteOperation,
     getPluginSensitiveFields: (pluginId) => [
       ...(pluginHost.sensitiveFieldsByPluginId.get(pluginId) ?? []),
       ...(pluginPayloadSanitizers.get(pluginId) ?? []),
     ],
     resolveLaunchCatalog: resolveOperationCatalog,
     publishRenameEvent: (event) => pluginHostCapabilities.events.publish(OPERATION_RENAMED_EVENT_CHANNEL, event),
-    publishDeleteEvent: (event) => pluginHostCapabilities.events.publish(OPERATION_DELETED_EVENT_CHANNEL, event),
     broadcastOperationChanged,
     subscribeOperationSse: (res) => {
       res.writeHead(200, withSecurityHeaders({
@@ -833,14 +842,8 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     // Theater를 잊을 때 그 Theater가 소유한 root·nested Codex 워크스페이스를 모두 해제한다.
     // 다른 Theater가 같은 workspace id를 소유하면 등록을 유지한다.
     codex.unregisterTheaterWorkspaces(theaterId);
-    for (const operation of operations.listByTheater(theaterId)) {
-      pluginHostCapabilities.events.publish(OPERATION_DELETED_EVENT_CHANNEL, {
-        operationId: operation.id,
-        pluginId: operation.pluginId,
-        type: operation.type,
-      });
-    }
-    operations.deleteByTheater(theaterId);
+    for (const operation of operations.listByTheater(theaterId)) deleteOperation(operation.id);
+    operations.deleteGroupsByTheater(theaterId);
     persistDurableState();
     writeJson(res, 200, { ok: true });
   }

--- a/runtime/fleet-console/tests/operations.test.ts
+++ b/runtime/fleet-console/tests/operations.test.ts
@@ -92,6 +92,7 @@ describe("operations platform", () => {
         Object.assign(res, { status, payload });
       },
       persist: () => {},
+      deleteOperation: (id) => store.delete(id),
       getPluginSensitiveFields: (pluginId) => (pluginId === "terminal" ? ["pluginSecret", "providerTitle"] : []),
     });
 
@@ -136,6 +137,7 @@ describe("operations platform", () => {
         Object.assign(res, { status, payload });
       },
       persist: () => {},
+      deleteOperation: (id) => store.delete(id),
     });
 
     requestBody = { accent: "blue" };
@@ -169,6 +171,7 @@ describe("operations platform", () => {
         Object.assign(res, { status, payload });
       },
       persist: () => {},
+      deleteOperation: (id) => store.delete(id),
       resolveLaunchCatalog: async () => ({
         plugins: [
           {

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -596,6 +596,81 @@ describe("console static and terminal ticket boundary", () => {
     expect(await response.json()).toEqual({ terminal: false });
   });
 
+  it("publishes one authoritative deletion event for plugin, Core, and Theater deletion paths", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-operation-delete-events-"));
+    tempDirs.push(dir);
+    const pluginPackage = createPluginPackageRoot({
+      demoRoutes: [
+        "export function register(ctx) {",
+        "  const events = [];",
+        "  ctx.host.events.subscribe('operation:deleted', (payload) => {",
+        "    events.push({ payload, operationPresent: ctx.host.operations.get(payload.operationId) !== null });",
+        "  });",
+        "  ctx.registerRouter('delete-operation', async ({ req, res }) => {",
+        "    const body = await ctx.host.http.readJsonBody(req);",
+        "    const deleted = typeof body?.operationId === 'string' && ctx.host.operations.delete(body.operationId);",
+        "    ctx.host.http.writeJson(res, 200, { deleted });",
+        "    return true;",
+        "  });",
+        "  ctx.registerRouter('deletion-events', async ({ res }) => {",
+        "    ctx.host.http.writeJson(res, 200, { events });",
+        "    return true;",
+        "  });",
+        "}",
+      ].join("\n"),
+    });
+    const fixture = await startFixture({ release: pluginPackage.release });
+    const theater = await createTheater(fixture, dir);
+    const pluginDeleted = await createOperation(fixture, theater.id, { type: "demo", pluginId: "demo" });
+
+    const pluginDelete = await fetch(`${fixture.endpoint}plugins/demo/delete-operation`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ operationId: pluginDeleted.id }),
+    });
+    const pluginRepeat = await fetch(`${fixture.endpoint}plugins/demo/delete-operation`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ operationId: pluginDeleted.id }),
+    });
+    const pluginMissing = await fetch(`${fixture.endpoint}plugins/demo/delete-operation`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ operationId: "missing-operation" }),
+    });
+    expect(await pluginDelete.json()).toEqual({ deleted: true });
+    expect(await pluginRepeat.json()).toEqual({ deleted: false });
+    expect(await pluginMissing.json()).toEqual({ deleted: false });
+
+    const coreDeleted = await createOperation(fixture, theater.id, { type: "agent", pluginId: "terminal" });
+    const coreDelete = await fetch(`${fixture.endpoint}api/v1/operations/${encodeURIComponent(coreDeleted.id)}`, { method: "DELETE" });
+    const coreRepeat = await fetch(`${fixture.endpoint}api/v1/operations/${encodeURIComponent(coreDeleted.id)}`, { method: "DELETE" });
+    const coreMissing = await fetch(`${fixture.endpoint}api/v1/operations/missing-operation`, { method: "DELETE" });
+    expect(coreDelete.status).toBe(200);
+    expect(coreRepeat.status).toBe(404);
+    expect(coreMissing.status).toBe(404);
+
+    const theaterDeletedA = await createOperation(fixture, theater.id, { type: "demo-a", pluginId: "demo" });
+    const theaterDeletedB = await createOperation(fixture, theater.id, { type: "demo-b", pluginId: "demo" });
+    const theaterDelete = await fetch(`${fixture.endpoint}api/v1/theaters/${encodeURIComponent(theater.id)}`, { method: "DELETE" });
+    const theaterRepeat = await fetch(`${fixture.endpoint}api/v1/theaters/${encodeURIComponent(theater.id)}`, { method: "DELETE" });
+    expect(theaterDelete.status).toBe(200);
+    expect(theaterRepeat.status).toBe(200);
+
+    const response = await fetch(`${fixture.endpoint}plugins/demo/deletion-events`);
+    const body = await response.json() as { readonly events: ReadonlyArray<{ readonly payload: { readonly operationId: string; readonly pluginId: string; readonly type: string }; readonly operationPresent: boolean }> };
+    expect(body.events).toHaveLength(4);
+    expect(body.events).toEqual(expect.arrayContaining([
+      { payload: { operationId: pluginDeleted.id, pluginId: "demo", type: "demo" }, operationPresent: false },
+      { payload: { operationId: coreDeleted.id, pluginId: "terminal", type: "agent" }, operationPresent: false },
+      { payload: { operationId: theaterDeletedA.id, pluginId: "demo", type: "demo-a" }, operationPresent: false },
+      { payload: { operationId: theaterDeletedB.id, pluginId: "demo", type: "demo-b" }, operationPresent: false },
+    ]));
+    for (const operationId of [pluginDeleted.id, coreDeleted.id, theaterDeletedA.id, theaterDeletedB.id]) {
+      expect(body.events.filter((event) => event.payload.operationId === operationId)).toHaveLength(1);
+    }
+  });
+
   it("serves plugin runtime manifest and shims through core routes", async () => {
     const fixture = await startFixture();
 

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-api.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-api.ts
@@ -26,7 +26,7 @@ export async function fetchAnalysisReady(api: ClientApiCapability, operationId: 
     return false;
   }
 }
-export async function startAnalysis(api: ClientApiCapability, operationId: string, input: { readonly cliId: string; readonly model: string; readonly effort: string }): Promise<void> { await request(api, `${base(operationId)}/start`, input); }
+export async function startAnalysis(api: ClientApiCapability, operationId: string, input: { readonly cliId: string; readonly model: string; readonly effort: string }, signal?: AbortSignal): Promise<void> { await request(api, `${base(operationId)}/start`, input, signal); }
 export async function sendAnalysisMessage(api: ClientApiCapability, operationId: string, text: string): Promise<void> { await request(api, `${base(operationId)}/message`, { text }); }
 export async function stopAnalysis(api: ClientApiCapability, operationId: string): Promise<void> { await request(api, `${base(operationId)}/stop`, {}); }
 export async function clearAnalysisArtifacts(api: ClientApiCapability, operationId: string): Promise<void> {
@@ -36,8 +36,8 @@ export async function clearAnalysisArtifacts(api: ClientApiCapability, operation
 export function subscribeAnalysis(api: ClientApiCapability, operationId: string, onEvent: (event: AnalysisEvent) => void): () => void {
   return api.subscribe("terminal", `${base(operationId)}/stream`, (message) => { try { const event = parseAnalysisEvent(JSON.parse(message.data)); if (event) onEvent(event); } catch {} });
 }
-async function request(api: ClientApiCapability, path: string, body: Record<string, string>): Promise<void> {
-  const response = await fetchOrThrow(api, path, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+async function request(api: ClientApiCapability, path: string, body: Record<string, string>, signal?: AbortSignal): Promise<void> {
+  const response = await fetchOrThrow(api, path, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body), ...(signal ? { signal } : {}) });
   if (!response.ok) throw errorFrom(response.status, await response.json().catch(() => null));
 }
 // SDK api.fetch는 non-2xx에서 본문을 ApiError.body로 실어 throw한다 — 동결 오류 DTO를 복원해 코드 기반 분기를 가능하게 한다.

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-ready.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-ready.test.tsx
@@ -10,10 +10,12 @@ vi.mock("../shared/index.js", () => ({
 }));
 
 import { fetchAnalysisReady } from "./analysis-api.js";
-import { agentOperationKind } from "./index.js";
+import { disposeAnalysisStore, getAnalysisStore } from "./analysis-store.js";
+import { agentOperationKind, agentPlugin } from "./index.js";
 import { applySessionUpdate, removeSession } from "./store.js";
 
 const OPERATION_ID = "analysis-ready-operation";
+const CATALOG_BODY = JSON.stringify({ clis: [{ cliId: "claude", label: "Claude", available: true, defaultModel: "sonnet", models: [{ id: "sonnet", label: "Sonnet", effortLevels: [] }] }] });
 let container: HTMLDivElement | null = null;
 let root: Root | null = null;
 
@@ -21,11 +23,13 @@ let root: Root | null = null;
 
 afterEach(() => {
   act(() => root?.unmount());
+  disposeAnalysisStore(OPERATION_ID);
   removeSession(OPERATION_ID);
   container?.remove();
   root = null;
   container = null;
   vi.useRealTimers();
+  vi.unstubAllGlobals();
 });
 
 describe("Session Analyst readiness handle", () => {
@@ -82,6 +86,60 @@ describe("Session Analyst readiness handle", () => {
     expect(fetch.mock.calls[0]?.[1]).toBe(`analysis/${OPERATION_ID}/ready`);
   });
 
+  it("closes and reopens companions without stopping or replacing the Analyst session", async () => {
+    const fetch = vi.fn(async (_pluginId: string, path: string) => new Response(
+      path === "analysis/catalog" ? CATALOG_BODY : path.endsWith("/ready") ? JSON.stringify({ ready: true }) : "{}",
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ));
+    const api = createApi(fetch);
+    const store = getAnalysisStore(OPERATION_ID, api);
+    store.dispatch({ type: "sending", started: true, text: "Remember this conversation", now: 1 });
+    store.dispatch({ type: "event", event: { type: "chunk", text: "Retained answer" }, now: 2 });
+    store.dispatch({ type: "event", event: { type: "complete" }, now: 3 });
+    const onRequestCompanions = vi.fn();
+    await renderOperation(fetch, "live", onRequestCompanions, true);
+
+    expect(analystHandle().textContent).toContain("EXIT");
+    act(() => analystHandle().click());
+
+    expect(onRequestCompanions).toHaveBeenCalledWith(false);
+    expect(fetch.mock.calls.some((call) => call[1] === `analysis/${OPERATION_ID}/stop`)).toBe(false);
+
+    onRequestCompanions.mockClear();
+    await renderOperation(fetch, "live", onRequestCompanions, false);
+    await vi.waitFor(() => expect(analystHandle().disabled).toBe(false));
+    expect(analystHandle().textContent).toContain("ANALYZE");
+    act(() => analystHandle().click());
+
+    expect(onRequestCompanions).toHaveBeenCalledWith(true);
+    expect(getAnalysisStore(OPERATION_ID, api)).toBe(store);
+    expect(store.getSnapshot().entries).toEqual([
+      { role: "user", text: "Remember this conversation" },
+      { role: "analyst", text: "Retained answer" },
+    ]);
+    expect(fetch.mock.calls.some((call) => call[1] === `analysis/${OPERATION_ID}/stop`)).toBe(false);
+  });
+
+  it("disposing through Operation close POSTs stop and replaces the store", async () => {
+    const fetch = vi.fn(async (_pluginId: string, path: string) => new Response(
+      path === "analysis/catalog" ? CATALOG_BODY : "{}",
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ));
+    const api = createApi(fetch);
+    const store = getAnalysisStore(OPERATION_ID, api);
+    const terminateFetch = vi.fn(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", terminateFetch);
+    const closeOperation = agentPlugin.closeOperation;
+    if (!closeOperation) throw new Error("Agent Operation close handler must exist.");
+
+    await closeOperation(OPERATION_ID);
+
+    await vi.waitFor(() => expect(fetch.mock.calls.some((call) => call[1] === `analysis/${OPERATION_ID}/stop`)).toBe(true));
+    expect(terminateFetch).toHaveBeenCalledWith(`/plugins/terminal/agent/sessions/${OPERATION_ID}`, expect.objectContaining({ method: "DELETE" }));
+    expect(fetch).toHaveBeenCalledWith("terminal", `analysis/${OPERATION_ID}/stop`, expect.objectContaining({ method: "POST", body: "{}" }));
+    expect(getAnalysisStore(OPERATION_ID, api)).not.toBe(store);
+  });
+
   it("treats readiness request failures as not ready", async () => {
     const api = createApi(vi.fn().mockRejectedValue(new Error("offline")));
     await expect(fetchAnalysisReady(api, OPERATION_ID)).resolves.toBe(false);
@@ -102,25 +160,27 @@ async function renderLiveOperation(fetch: ReturnType<typeof vi.fn>): Promise<voi
   await renderOperation(fetch, "live");
 }
 
-async function renderOperation(fetch: ReturnType<typeof vi.fn>, status: "live" | "dormant", onRequestCompanions = vi.fn()): Promise<void> {
-  applySessionUpdate({
-    sessionId: OPERATION_ID,
-    terminalSessionId: OPERATION_ID,
-    cwdLabel: "Workspace",
-    label: "Ready test",
-    status,
-    turnState: "none",
-    createdAt: 1,
-    theaterId: "theater",
-    resumeAvailable: true,
-  });
-  container = document.createElement("div");
-  document.body.append(container);
-  root = createRoot(container);
+async function renderOperation(fetch: ReturnType<typeof vi.fn>, status: "live" | "dormant", onRequestCompanions = vi.fn(), companionsOpen = false): Promise<void> {
+  if (!container) {
+    container = document.createElement("div");
+    document.body.append(container);
+  }
+  root ??= createRoot(container);
   const render = agentOperationKind.render;
   if (!render) throw new Error("Agent operation renderer must exist.");
   await act(async () => {
-    root?.render(render(createContext(createApi(fetch), onRequestCompanions)) as React.ReactNode);
+    applySessionUpdate({
+      sessionId: OPERATION_ID,
+      terminalSessionId: OPERATION_ID,
+      cwdLabel: "Workspace",
+      label: "Ready test",
+      status,
+      turnState: "none",
+      createdAt: 1,
+      theaterId: "theater",
+      resumeAvailable: true,
+    });
+    root?.render(render(createContext(createApi(fetch), onRequestCompanions, companionsOpen)) as React.ReactNode);
     await Promise.resolve();
     await Promise.resolve();
   });
@@ -130,7 +190,7 @@ function createApi(fetch: ReturnType<typeof vi.fn>): ClientApiCapability {
   return { fetch, subscribe: () => () => undefined, resync: vi.fn() } as ClientApiCapability;
 }
 
-function createContext(api: ClientApiCapability, onRequestCompanions = vi.fn()): OperationRenderContext {
+function createContext(api: ClientApiCapability, onRequestCompanions = vi.fn(), companionsOpen = false): OperationRenderContext {
   return {
     operationId: OPERATION_ID,
     theaterId: "theater",
@@ -141,7 +201,7 @@ function createContext(api: ClientApiCapability, onRequestCompanions = vi.fn()):
     active: true,
     zoom: 1,
     theme: "instrument",
-    companionsOpen: false,
+    companionsOpen,
     onRequestCompanions,
   } as unknown as OperationRenderContext;
 }

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-store.test.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-store.test.ts
@@ -14,12 +14,12 @@ interface StreamHarness {
   readonly unsubscribeCount: () => number;
 }
 
-function createHarness(onPath?: (path: string) => Response | Promise<Response> | null): StreamHarness {
+function createHarness(onPath?: (path: string, init?: RequestInit) => Response | Promise<Response> | null): StreamHarness {
   let stream: ((event: MessageEvent<string>) => void) | null = null;
   let lastStream: ((event: MessageEvent<string>) => void) | null = null;
   let unsubscribeCount = 0;
-  const fetch = vi.fn(async (_pluginId: string, path: string) => {
-    const override = onPath?.(path);
+  const fetch = vi.fn(async (_pluginId: string, path: string, init?: RequestInit) => {
+    const override = onPath?.(path, init);
     if (override) return override;
     return new Response(path === "analysis/catalog" ? CATALOG_BODY : "{}", { status: 200, headers: { "Content-Type": "application/json" } });
   });
@@ -267,14 +267,29 @@ describe("per-operation analysis store", () => {
     disposeAnalysisStore("operation-store-reset-during-start");
   });
 
-  it("waits for an in-flight start before disposal stops it and lets a fresh store restart", async () => {
-    let resolveStart!: (response: Response) => void;
+  it("aborts a stalled start before disposal stops it and orders a replacement start after teardown", async () => {
     let startCount = 0;
-    const firstStartResponse = new Promise<Response>((resolve) => { resolveStart = resolve; });
-    const harness = createHarness((path) => {
+    let firstStartSignal: AbortSignal | undefined;
+    const requestOrder: string[] = [];
+    const harness = createHarness((path, init) => {
+      if (path.endsWith("/stop")) {
+        requestOrder.push("stop");
+        return null;
+      }
       if (!path.endsWith("/start")) return null;
       startCount += 1;
-      return startCount === 1 ? firstStartResponse : null;
+      if (startCount > 1) {
+        requestOrder.push("start-2");
+        return null;
+      }
+      requestOrder.push("start-1");
+      firstStartSignal = init?.signal ?? undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        firstStartSignal?.addEventListener("abort", () => {
+          requestOrder.push("abort-1");
+          reject(new DOMException("Analysis start aborted.", "AbortError"));
+        }, { once: true });
+      });
     });
     const first = getAnalysisStore("operation-store-dispose-during-start", harness.api);
     await vi.waitFor(() => expect(first.getSnapshot().cliId).toBe("claude"));
@@ -282,28 +297,23 @@ describe("per-operation analysis store", () => {
     const firstSend = first.send("Review this session");
     await vi.waitFor(() => expect(harness.fetch.mock.calls.some((call) => call[1].endsWith("/start"))).toBe(true));
     disposeAnalysisStore("operation-store-dispose-during-start");
+    expect(firstStartSignal?.aborted).toBe(true);
     const replacement = getAnalysisStore("operation-store-dispose-during-start", harness.api);
     expect(replacement).not.toBe(first);
     await vi.waitFor(() => expect(replacement.getSnapshot().cliId).toBe("claude"));
     const replacementSend = replacement.send("Start fresh");
-    await Promise.resolve();
-
-    let paths = harness.fetch.mock.calls.map((call) => call[1]);
-    expect(paths.filter((path) => path.endsWith("/start"))).toHaveLength(1);
-    expect(paths.some((path) => path.endsWith("/stop"))).toBe(false);
-
-    resolveStart(new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } }));
     await firstSend;
     await vi.waitFor(() => expect(harness.streamReady()).toBe(true));
     harness.emit({ type: "connected" });
     await replacementSend;
 
-    paths = harness.fetch.mock.calls.map((call) => call[1]);
+    const paths = harness.fetch.mock.calls.map((call) => call[1]);
     const stopIndex = paths.indexOf("analysis/operation-store-dispose-during-start/stop");
     expect(paths.filter((path) => path.endsWith("/start"))).toHaveLength(2);
     expect(stopIndex).toBeGreaterThan(paths.indexOf("analysis/operation-store-dispose-during-start/start"));
     expect(stopIndex).toBeLessThan(paths.lastIndexOf("analysis/operation-store-dispose-during-start/start"));
     expect(paths.filter((path) => path.endsWith("/message"))).toHaveLength(1);
+    expect(requestOrder).toEqual(["start-1", "abort-1", "stop", "start-2"]);
     harness.emit({ type: "complete" });
     disposeAnalysisStore("operation-store-dispose-during-start");
   });

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-store.test.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-store.test.ts
@@ -71,13 +71,13 @@ describe("per-operation analysis store", () => {
     harness.emit({ type: "complete" });
     expect(first.getSnapshot().busy).toBe(false);
 
-    // EXIT(모든 companion unmount)은 store를 건드리지 않으므로 대화·서버 세션을 보존해야 한다.
+    // EXIT only unmounts companions, so the shared conversation and server session remain alive.
     await Promise.resolve();
     expect(getAnalysisStore("operation-store-share", harness.api)).toBe(first);
     expect(harness.fetch.mock.calls.some((call) => call[1] === "analysis/operation-store-share/stop")).toBe(false);
     expect(first.getSnapshot().entries.length).toBeGreaterThan(0);
 
-    // Operation 종료 경로만 서버 세션을 정리한다.
+    // Operation close owns disposal and server-session cleanup.
     disposeAnalysisStore("operation-store-share");
     await vi.waitFor(() => expect(harness.fetch.mock.calls.some((call) => call[1] === "analysis/operation-store-share/stop")).toBe(true));
   });
@@ -265,6 +265,47 @@ describe("per-operation analysis store", () => {
     expect(paths.some((path) => path.endsWith("/message"))).toBe(false);
     expect(store.getSnapshot()).toMatchObject({ started: false, busy: false, phase: "idle", entries: [], artifacts: [] });
     disposeAnalysisStore("operation-store-reset-during-start");
+  });
+
+  it("waits for an in-flight start before disposal stops it and lets a fresh store restart", async () => {
+    let resolveStart!: (response: Response) => void;
+    let startCount = 0;
+    const firstStartResponse = new Promise<Response>((resolve) => { resolveStart = resolve; });
+    const harness = createHarness((path) => {
+      if (!path.endsWith("/start")) return null;
+      startCount += 1;
+      return startCount === 1 ? firstStartResponse : null;
+    });
+    const first = getAnalysisStore("operation-store-dispose-during-start", harness.api);
+    await vi.waitFor(() => expect(first.getSnapshot().cliId).toBe("claude"));
+
+    const firstSend = first.send("Review this session");
+    await vi.waitFor(() => expect(harness.fetch.mock.calls.some((call) => call[1].endsWith("/start"))).toBe(true));
+    disposeAnalysisStore("operation-store-dispose-during-start");
+    const replacement = getAnalysisStore("operation-store-dispose-during-start", harness.api);
+    expect(replacement).not.toBe(first);
+    await vi.waitFor(() => expect(replacement.getSnapshot().cliId).toBe("claude"));
+    const replacementSend = replacement.send("Start fresh");
+    await Promise.resolve();
+
+    let paths = harness.fetch.mock.calls.map((call) => call[1]);
+    expect(paths.filter((path) => path.endsWith("/start"))).toHaveLength(1);
+    expect(paths.some((path) => path.endsWith("/stop"))).toBe(false);
+
+    resolveStart(new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } }));
+    await firstSend;
+    await vi.waitFor(() => expect(harness.streamReady()).toBe(true));
+    harness.emit({ type: "connected" });
+    await replacementSend;
+
+    paths = harness.fetch.mock.calls.map((call) => call[1]);
+    const stopIndex = paths.indexOf("analysis/operation-store-dispose-during-start/stop");
+    expect(paths.filter((path) => path.endsWith("/start"))).toHaveLength(2);
+    expect(stopIndex).toBeGreaterThan(paths.indexOf("analysis/operation-store-dispose-during-start/start"));
+    expect(stopIndex).toBeLessThan(paths.lastIndexOf("analysis/operation-store-dispose-during-start/start"));
+    expect(paths.filter((path) => path.endsWith("/message"))).toHaveLength(1);
+    harness.emit({ type: "complete" });
+    disposeAnalysisStore("operation-store-dispose-during-start");
   });
 
   it("reports stop failure without leaving the store busy or subscribed", async () => {

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-store.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-store.ts
@@ -23,6 +23,7 @@ interface AnalysisStoreBinding {
 }
 
 const stores = new Map<string, AnalysisStore>();
+const disposalFlights = new Map<string, Promise<void>>();
 
 export function useAnalysisStore(context: OperationRenderContext): AnalysisStoreBinding {
   const store = getAnalysisStore(context.operationId, context.api);
@@ -121,11 +122,25 @@ function createAnalysisStore(operationId: string, api: ClientApiCapability): Ana
 
   const dispose = () => {
     if (disposed) return;
+    const previousDisposal = disposalFlights.get(operationId);
+    const pendingReset = resetFlight;
+    const pendingStop = stopFlight;
+    const pendingStart = startFlight;
     disposed = true;
     stores.delete(operationId);
     invalidateRun();
     listeners.clear();
-    if (state.started) void stopAnalysis(api, operationId).catch(() => {});
+    const flight = (async () => {
+      if (previousDisposal) await previousDisposal;
+      if (pendingReset) await pendingReset.catch(() => {});
+      if (pendingStop) await pendingStop.catch(() => {});
+      if (pendingStart) await pendingStart.catch(() => {});
+      await stopAnalysis(api, operationId);
+    })().catch(() => {});
+    disposalFlights.set(operationId, flight);
+    void flight.finally(() => {
+      if (disposalFlights.get(operationId) === flight) disposalFlights.delete(operationId);
+    });
   };
 
   const store: AnalysisStore = {
@@ -136,6 +151,8 @@ function createAnalysisStore(operationId: string, api: ClientApiCapability): Ana
     },
     dispatch,
     send: async (text) => {
+      const previousDisposal = disposalFlights.get(operationId);
+      if (previousDisposal) await previousDisposal;
       if (resetFlight) {
         try { await resetFlight; } catch { return; }
       }

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-store.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-store.ts
@@ -52,6 +52,7 @@ function createAnalysisStore(operationId: string, api: ClientApiCapability): Ana
   let unsubscribe: (() => void) | null = null;
   let watchdog: ReturnType<typeof setTimeout> | null = null;
   let startFlight: Promise<void> | null = null;
+  let startController: AbortController | null = null;
   let stopFlight: Promise<void> | null = null;
   let resetFlight: Promise<void> | null = null;
   let streamGeneration = 0;
@@ -126,15 +127,17 @@ function createAnalysisStore(operationId: string, api: ClientApiCapability): Ana
     const pendingReset = resetFlight;
     const pendingStop = stopFlight;
     const pendingStart = startFlight;
+    const pendingStartController = startController;
     disposed = true;
     stores.delete(operationId);
     invalidateRun();
     listeners.clear();
+    pendingStartController?.abort();
     const flight = (async () => {
       if (previousDisposal) await previousDisposal;
+      if (pendingStart) await pendingStart.catch(() => {});
       if (pendingReset) await pendingReset.catch(() => {});
       if (pendingStop) await pendingStop.catch(() => {});
-      if (pendingStart) await pendingStart.catch(() => {});
       await stopAnalysis(api, operationId);
     })().catch(() => {});
     disposalFlights.set(operationId, flight);
@@ -164,7 +167,9 @@ function createAnalysisStore(operationId: string, api: ClientApiCapability): Ana
       const selection = { cliId: state.cliId, model: state.model, effort: state.effort };
       dispatch({ type: "sending", started: starting, text: trimmed, now: Date.now() });
       if (starting) {
-        const flight = startAnalysis(api, operationId, selection);
+        const controller = new AbortController();
+        const flight = startAnalysis(api, operationId, selection, controller.signal);
+        startController = controller;
         startFlight = flight;
         try {
           await flight;
@@ -177,6 +182,7 @@ function createAnalysisStore(operationId: string, api: ClientApiCapability): Ana
             return;
           }
         } finally {
+          if (startController === controller) startController = null;
           if (startFlight === flight) startFlight = null;
         }
         if (disposed || generation !== runGeneration || !state.started) return;

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-registry.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-registry.ts
@@ -1,9 +1,8 @@
 import type { AnalysisEvent, AnalysisSession } from "./analysis-types.js";
 
-export const MAX_ANALYSIS_SESSIONS = 4;
 export const MAX_ANALYSIS_ARTIFACTS = 32;
-// Keep twice the maximum active working set (4 sessions × 32 artifacts) while bounding stopped history.
-export const MAX_TOTAL_ARTIFACTS = MAX_ANALYSIS_SESSIONS * MAX_ANALYSIS_ARTIFACTS * 2;
+// Active artifacts remain available; stopped-session history is bounded process-wide.
+export const MAX_STOPPED_ANALYSIS_ARTIFACTS = 256;
 type Subscriber = (event: AnalysisEvent) => void;
 type Entry = { readonly session: AnalysisSession; readonly subscribers: Set<Subscriber>; starting: boolean; messaging: boolean; stopped: boolean; disposePromise?: Promise<void> };
 type StoredArtifact = { readonly operationId: string; readonly html: string };
@@ -12,9 +11,8 @@ export class AnalysisRegistry {
   private readonly entries = new Map<string, Entry>();
   private readonly artifacts = new Map<string, StoredArtifact>();
 
-  async start(operationId: string, create: (onEvent: (event: AnalysisEvent) => void) => AnalysisSession): Promise<"started" | "stopped" | "exists" | "limit"> {
+  async start(operationId: string, create: (onEvent: (event: AnalysisEvent) => void) => AnalysisSession): Promise<"started" | "stopped" | "exists"> {
     if (this.entries.has(operationId)) return "exists";
-    if (this.entries.size >= MAX_ANALYSIS_SESSIONS) return "limit";
     let entry: Entry | undefined;
     const session = create((event) => {
       if (!entry || entry.stopped) return;
@@ -81,6 +79,7 @@ export class AnalysisRegistry {
     this.entries.delete(operationId);
     entry.stopped = true;
     entry.subscribers.clear();
+    this.pruneStoppedArtifacts();
     await this.disposeEntry(entry);
     return true;
   }
@@ -99,16 +98,19 @@ export class AnalysisRegistry {
         break;
       }
     }
-    while (this.artifacts.size > MAX_TOTAL_ARTIFACTS) {
-      let oldestInactiveArtifactId: string | undefined;
-      for (const [storedArtifactId, artifact] of this.artifacts) {
-        if (!this.entries.has(artifact.operationId)) {
-          oldestInactiveArtifactId = storedArtifactId;
-          break;
-        }
-      }
-      if (!oldestInactiveArtifactId) break;
-      this.artifacts.delete(oldestInactiveArtifactId);
+    this.pruneStoppedArtifacts();
+  }
+
+  private pruneStoppedArtifacts(): void {
+    let stoppedArtifactCount = 0;
+    for (const artifact of this.artifacts.values()) {
+      if (!this.entries.has(artifact.operationId)) stoppedArtifactCount += 1;
+    }
+    for (const [artifactId, artifact] of this.artifacts) {
+      if (stoppedArtifactCount <= MAX_STOPPED_ANALYSIS_ARTIFACTS) break;
+      if (this.entries.has(artifact.operationId)) continue;
+      this.artifacts.delete(artifactId);
+      stoppedArtifactCount -= 1;
     }
   }
 

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@dotobokuri/fleet-analyst", () => ({ AnalystSession: class {} }));
 
-import { AnalysisRegistry, MAX_ANALYSIS_ARTIFACTS, MAX_ANALYSIS_SESSIONS, MAX_TOTAL_ARTIFACTS } from "./analysis-registry.js";
+import { AnalysisRegistry, MAX_ANALYSIS_ARTIFACTS, MAX_STOPPED_ANALYSIS_ARTIFACTS } from "./analysis-registry.js";
 import { ANALYSIS_ARTIFACT_CSP, registerAnalysisRoutes } from "./analysis-routes.js";
 import { ANALYSIS_ERROR_CODES, buildAnalysisCatalog, isAnalysisSelection, isMessageBody, type AnalystCliId } from "./analysis-types.js";
 
@@ -47,24 +47,24 @@ describe("Session Analyst server contract", () => {
     expect(ANALYSIS_ERROR_CODES.transcriptMissing).toBe("analysis_transcript_missing");
   });
 
-  it("caps sessions, serializes messages, and disposes idempotently", async () => {
+  it("starts more than four distinct sessions, serializes messages, and disposes idempotently", async () => {
     const registry = new AnalysisRegistry();
     let resolveTurn: (() => void) | undefined;
-    const sessions = Array.from({ length: MAX_ANALYSIS_SESSIONS }, () => ({
+    const sessions = Array.from({ length: 6 }, () => ({
       start: async () => undefined,
       send: () => new Promise<void>((resolve) => { resolveTurn = resolve; }),
       dispose: async () => undefined,
     }));
-    for (let index = 0; index < MAX_ANALYSIS_SESSIONS; index += 1) {
+    for (let index = 0; index < sessions.length; index += 1) {
       await expect(registry.start(`op-${index}`, () => sessions[index]! as never)).resolves.toBe("started");
     }
-    await expect(registry.start("overflow", () => sessions[0]! as never)).resolves.toBe("limit");
     await expect(registry.message("op-0", "hello")).resolves.toBe("accepted");
     await expect(registry.message("op-0", "again")).resolves.toBe("busy");
     resolveTurn?.();
     await Promise.resolve();
     await expect(registry.stop("op-0")).resolves.toBe(true);
     await expect(registry.stop("op-0")).resolves.toBe(false);
+    await registry.dispose();
   });
 
   it("streams a generic analysis_error without exposing send rejection details", async () => {
@@ -159,7 +159,7 @@ describe("Session Analyst server contract", () => {
   it("bounds stopped artifact history process-wide by evicting the oldest inactive artifacts", async () => {
     const registry = new AnalysisRegistry();
     const artifactIds: string[] = [];
-    const operationCount = Math.floor(MAX_TOTAL_ARTIFACTS / MAX_ANALYSIS_ARTIFACTS) + 1;
+    const operationCount = Math.floor(MAX_STOPPED_ANALYSIS_ARTIFACTS / MAX_ANALYSIS_ARTIFACTS) + 1;
 
     for (let operationIndex = 0; operationIndex < operationCount; operationIndex += 1) {
       const emit = await startArtifactSession(registry, `stopped-op-${operationIndex}`);
@@ -171,7 +171,7 @@ describe("Session Analyst server contract", () => {
       await registry.stop(`stopped-op-${operationIndex}`);
     }
 
-    expect(artifactIds.filter((artifactId) => registry.artifactHtml(artifactId) !== null)).toHaveLength(MAX_TOTAL_ARTIFACTS);
+    expect(artifactIds.filter((artifactId) => registry.artifactHtml(artifactId) !== null)).toHaveLength(MAX_STOPPED_ANALYSIS_ARTIFACTS);
     expect(registry.artifactHtml("stopped-0-0")).toBeNull();
     expect(registry.artifactHtml(`stopped-0-${MAX_ANALYSIS_ARTIFACTS - 1}`)).toBeNull();
     expect(registry.artifactHtml("stopped-1-0")).toBe("<p>stopped-1-0</p>");
@@ -183,7 +183,7 @@ describe("Session Analyst server contract", () => {
     const artifactIds = ["active-artifact"];
     const emitActive = await startArtifactSession(registry, "active-op");
     emitArtifact(emitActive, "active-artifact");
-    const stoppedOperationCount = Math.floor(MAX_TOTAL_ARTIFACTS / MAX_ANALYSIS_ARTIFACTS) + 1;
+    const stoppedOperationCount = Math.floor(MAX_STOPPED_ANALYSIS_ARTIFACTS / MAX_ANALYSIS_ARTIFACTS) + 1;
 
     for (let operationIndex = 0; operationIndex < stoppedOperationCount; operationIndex += 1) {
       const operationId = `history-op-${operationIndex}`;
@@ -197,7 +197,7 @@ describe("Session Analyst server contract", () => {
     }
 
     expect(registry.artifactHtml("active-artifact")).toBe("<p>active-artifact</p>");
-    expect(artifactIds.filter((artifactId) => registry.artifactHtml(artifactId) !== null)).toHaveLength(MAX_TOTAL_ARTIFACTS);
+    expect(artifactIds.filter((artifactId) => registry.artifactHtml(artifactId) !== null)).toHaveLength(MAX_STOPPED_ANALYSIS_ARTIFACTS + 1);
     expect(registry.artifactHtml("history-0-0")).toBeNull();
     await registry.dispose();
   });
@@ -313,13 +313,14 @@ describe("Session Analyst server contract", () => {
     await writeFile(transcriptPath, "{}\n");
     const router = createRouterHarness(true);
     let emit: ((event: { type: "artifact"; artifact: { id: string; title: string; html: string; createdAt: string } }) => void) | undefined;
+    const dispose = vi.fn(async () => undefined);
     registerAnalysisRoutes(router.ctx as never, {
       detect: async () => [{ id: "claude", displayName: "Claude Code", available: true, version: null }],
       modelsFor: () => ({ defaultModel: "model-b", models: [{ modelId: "model-b", name: "Model B", effort: { supported: false } }] }) as never,
       readCapture: () => ({ provider: "claude", sessionId: "private", capturedAt: "now", transcriptPath }),
       createSession: ((options: { onEvent: typeof emit }) => {
         emit = options.onEvent;
-        return { start: async () => undefined, send: async () => undefined, dispose: async () => undefined };
+        return { start: async () => undefined, send: async () => undefined, dispose };
       }) as never,
     });
     await router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", { cliId: "claude", model: "model-b" });
@@ -353,6 +354,8 @@ describe("Session Analyst server contract", () => {
     expect(afterStop).toMatchObject({ status: 200, ended: true });
     expect(afterStop.body).toContain(html);
     expect(afterStop.body).toContain('<html data-theme="instrument" style="background-color:Canvas!important;');
+    expect(dispose).toHaveBeenCalledOnce();
+    dispose.mockClear();
 
     await router.call("DELETE", "/api/v1/plugins/terminal/analysis/op/artifacts");
     await router.call("GET", "/api/v1/plugins/terminal/analysis/artifacts/artifact%2Fid");
@@ -361,6 +364,7 @@ describe("Session Analyst server contract", () => {
     await router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", { cliId: "claude", model: "model-b" });
     emit?.({ type: "artifact", artifact: { id: "deleted-artifact", title: "Deleted artifact", html, createdAt: new Date(0).toISOString() } });
     router.emitOperationDeleted({ operationId: "op", pluginId: "terminal" });
+    await vi.waitFor(() => expect(dispose).toHaveBeenCalledOnce());
     await router.call("GET", "/api/v1/plugins/terminal/analysis/artifacts/deleted-artifact");
     expect(router.responses.at(-1)).toMatchObject({ status: 404, body: { error: { message: "Analysis artifact was not found." } } });
   });

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
@@ -250,6 +250,35 @@ describe("Session Analyst server contract", () => {
     expect(router.responses.at(-1)).toMatchObject({ status: 404, body: { error: { code: "analysis_session_not_found" } } });
   });
 
+  it("reports deletion-owned 404 when disposal rejects a pending start", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "analysis-pending-delete-rejection-"));
+    const transcriptPath = join(dir, "captured.jsonl");
+    await writeFile(transcriptPath, "{}\n");
+    const router = createRouterHarness(true);
+    let rejectStart!: (error: Error) => void;
+    const dispose = vi.fn(async () => { rejectStart(new Error("disposed during start")); });
+    const createSession = vi.fn(() => ({
+      start: () => new Promise<void>((_resolve, reject) => { rejectStart = reject; }),
+      send: async () => undefined,
+      dispose,
+    }));
+    registerAnalysisRoutes(router.ctx as never, {
+      detect: async () => [{ id: "claude", displayName: "Claude Code", available: true, version: null }],
+      modelsFor: () => ({ defaultModel: "model-b", models: [{ modelId: "model-b", name: "Model B", effort: { supported: false } }] }) as never,
+      readCapture: () => ({ provider: "claude", sessionId: "private", capturedAt: "now", transcriptPath }),
+      createSession: createSession as never,
+    });
+
+    const starting = router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", { cliId: "claude", model: "model-b" });
+    await vi.waitFor(() => expect(createSession).toHaveBeenCalledOnce());
+    router.deleteOperation();
+    router.emitOperationDeleted({ operationId: "op", pluginId: "terminal", type: "agent" });
+    await starting;
+
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(router.responses.at(-1)).toMatchObject({ status: 404, body: { error: { code: "analysis_session_not_found" } } });
+  });
+
   it("does not register a session when its Operation is deleted before the final start check", async () => {
     const dir = await mkdtemp(join(tmpdir(), "analysis-pre-registration-delete-"));
     const transcriptPath = join(dir, "captured.jsonl");

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
@@ -277,6 +277,35 @@ describe("Session Analyst server contract", () => {
     expect(createSession).not.toHaveBeenCalled();
   });
 
+  it("does not register a session when its Operation is deleted and recreated with the same id during start preparation", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "analysis-same-id-recreation-"));
+    const transcriptPath = join(dir, "captured.jsonl");
+    await writeFile(transcriptPath, "{}\n");
+    const router = createRouterHarness(true);
+    const statuses = [{ id: "claude", displayName: "Claude Code", available: true, version: null }] as const;
+    let resolveDetect!: (value: typeof statuses) => void;
+    const detection = new Promise<typeof statuses>((resolve) => { resolveDetect = resolve; });
+    const detect = vi.fn(() => detection);
+    const createSession = vi.fn(() => ({ start: async () => undefined, send: async () => undefined, dispose: async () => undefined }));
+    registerAnalysisRoutes(router.ctx as never, {
+      detect,
+      modelsFor: () => ({ defaultModel: "model-b", models: [{ modelId: "model-b", name: "Model B", effort: { supported: false } }] }) as never,
+      readCapture: () => ({ provider: "claude", sessionId: "private", capturedAt: "now", transcriptPath }),
+      createSession: createSession as never,
+    });
+
+    const starting = router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", { cliId: "claude", model: "model-b" });
+    await vi.waitFor(() => expect(detect).toHaveBeenCalledOnce());
+    router.deleteOperation();
+    router.emitOperationDeleted({ operationId: "op", pluginId: "terminal", type: "agent" });
+    router.recreateOperation();
+    resolveDetect(statuses);
+    await starting;
+
+    expect(router.responses.at(-1)).toMatchObject({ status: 404, body: { error: { code: "analysis_session_not_found" } } });
+    expect(createSession).not.toHaveBeenCalled();
+  });
+
   it("reports analysis as not ready when no provider capture exists", async () => {
     const router = createRouterHarness(true);
     registerAnalysisRoutes(router.ctx as never, { readCapture: () => null });
@@ -566,8 +595,8 @@ function createRouterHarness(initialHostAllowance: boolean) {
   let handler: ((context: { req: EventEmitter & { method: string; headers: Record<string, string>; socket: { localPort: number } }; res: EventEmitter; pathname: string }) => Promise<boolean>) | undefined;
   let operationDeletedHandler: ((payload: unknown) => void) | undefined;
   const responses: Array<{ status: number; body: unknown }> = [];
-  const state = { allowHost: initialHostAllowance, operationPresent: true };
   const operation = { id: "op", pluginId: "terminal", type: "agent", theaterId: "theater", payload: {}, ts: { createdAt: 0, updatedAt: 0 } };
+  const state = { allowHost: initialHostAllowance, operationPresent: true, operation };
   const ctx = {
     pluginId: "terminal", basePath: "/api/v1/plugins/terminal",
     registerRouter: (_path: string, registered: typeof handler) => { handler = registered; },
@@ -577,7 +606,7 @@ function createRouterHarness(initialHostAllowance: boolean) {
         isTerminalAuthorized: (req: { headers: Record<string, string> }) => req.headers.origin !== "https://evil.example",
       },
       http: { writeJson: (_res: EventEmitter, status: number, body: unknown) => responses.push({ status, body }), readJsonBody: async (req: EventEmitter & { body?: unknown }) => req.body ?? null },
-      operations: { get: (id: string) => state.operationPresent && id === "op" ? operation : null },
+      operations: { get: (id: string) => state.operationPresent && id === "op" ? state.operation : null },
       paths: { capturesDir: "/capture", resolveTheaterPath: () => "/theater" },
       events: { subscribe: (_channel: string, subscriber: (payload: unknown) => void) => { operationDeletedHandler = subscriber; return () => { operationDeletedHandler = undefined; }; } }, lifecycle: { registerCleanup: () => () => undefined },
     },
@@ -586,6 +615,10 @@ function createRouterHarness(initialHostAllowance: boolean) {
     ctx, responses,
     get allowHost() { return state.allowHost; }, set allowHost(value: boolean) { state.allowHost = value; },
     deleteOperation() { state.operationPresent = false; },
+    recreateOperation() {
+      state.operation = { ...operation, theaterId: "replacement-theater", ts: { createdAt: 1, updatedAt: 1 } };
+      state.operationPresent = true;
+    },
     emitOperationDeleted(payload: unknown) { operationDeletedHandler?.(payload); },
     async call(method: string, pathname: string, body?: unknown, headers: Record<string, string> = {}) {
       const writes: string[] = [];

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
@@ -220,6 +220,63 @@ describe("Session Analyst server contract", () => {
     expect(createSession).toHaveBeenCalledWith(expect.objectContaining({ effort: undefined }));
   });
 
+  it("disposes a registry entry when its Operation is deleted during pending start", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "analysis-pending-delete-"));
+    const transcriptPath = join(dir, "captured.jsonl");
+    await writeFile(transcriptPath, "{}\n");
+    const router = createRouterHarness(true);
+    let resolveStart!: () => void;
+    const dispose = vi.fn(async () => undefined);
+    const createSession = vi.fn(() => ({
+      start: () => new Promise<void>((resolve) => { resolveStart = resolve; }),
+      send: async () => undefined,
+      dispose,
+    }));
+    registerAnalysisRoutes(router.ctx as never, {
+      detect: async () => [{ id: "claude", displayName: "Claude Code", available: true, version: null }],
+      modelsFor: () => ({ defaultModel: "model-b", models: [{ modelId: "model-b", name: "Model B", effort: { supported: false } }] }) as never,
+      readCapture: () => ({ provider: "claude", sessionId: "private", capturedAt: "now", transcriptPath }),
+      createSession: createSession as never,
+    });
+
+    const starting = router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", { cliId: "claude", model: "model-b" });
+    await vi.waitFor(() => expect(createSession).toHaveBeenCalledOnce());
+    router.deleteOperation();
+    router.emitOperationDeleted({ operationId: "op", pluginId: "terminal", type: "agent" });
+    await vi.waitFor(() => expect(dispose).toHaveBeenCalledOnce());
+    resolveStart();
+    await starting;
+
+    expect(router.responses.at(-1)).toMatchObject({ status: 404, body: { error: { code: "analysis_session_not_found" } } });
+  });
+
+  it("does not register a session when its Operation is deleted before the final start check", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "analysis-pre-registration-delete-"));
+    const transcriptPath = join(dir, "captured.jsonl");
+    await writeFile(transcriptPath, "{}\n");
+    const router = createRouterHarness(true);
+    const statuses = [{ id: "claude", displayName: "Claude Code", available: true, version: null }] as const;
+    let resolveDetect!: (value: typeof statuses) => void;
+    const detection = new Promise<typeof statuses>((resolve) => { resolveDetect = resolve; });
+    const detect = vi.fn(() => detection);
+    const createSession = vi.fn(() => ({ start: async () => undefined, send: async () => undefined, dispose: async () => undefined }));
+    registerAnalysisRoutes(router.ctx as never, {
+      detect,
+      modelsFor: () => ({ defaultModel: "model-b", models: [{ modelId: "model-b", name: "Model B", effort: { supported: false } }] }) as never,
+      readCapture: () => ({ provider: "claude", sessionId: "private", capturedAt: "now", transcriptPath }),
+      createSession: createSession as never,
+    });
+
+    const starting = router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", { cliId: "claude", model: "model-b" });
+    await vi.waitFor(() => expect(detect).toHaveBeenCalledOnce());
+    router.deleteOperation();
+    resolveDetect(statuses);
+    await starting;
+
+    expect(router.responses.at(-1)).toMatchObject({ status: 404, body: { error: { code: "analysis_session_not_found" } } });
+    expect(createSession).not.toHaveBeenCalled();
+  });
+
   it("reports analysis as not ready when no provider capture exists", async () => {
     const router = createRouterHarness(true);
     registerAnalysisRoutes(router.ctx as never, { readCapture: () => null });
@@ -509,7 +566,7 @@ function createRouterHarness(initialHostAllowance: boolean) {
   let handler: ((context: { req: EventEmitter & { method: string; headers: Record<string, string>; socket: { localPort: number } }; res: EventEmitter; pathname: string }) => Promise<boolean>) | undefined;
   let operationDeletedHandler: ((payload: unknown) => void) | undefined;
   const responses: Array<{ status: number; body: unknown }> = [];
-  const state = { allowHost: initialHostAllowance };
+  const state = { allowHost: initialHostAllowance, operationPresent: true };
   const operation = { id: "op", pluginId: "terminal", type: "agent", theaterId: "theater", payload: {}, ts: { createdAt: 0, updatedAt: 0 } };
   const ctx = {
     pluginId: "terminal", basePath: "/api/v1/plugins/terminal",
@@ -520,7 +577,7 @@ function createRouterHarness(initialHostAllowance: boolean) {
         isTerminalAuthorized: (req: { headers: Record<string, string> }) => req.headers.origin !== "https://evil.example",
       },
       http: { writeJson: (_res: EventEmitter, status: number, body: unknown) => responses.push({ status, body }), readJsonBody: async (req: EventEmitter & { body?: unknown }) => req.body ?? null },
-      operations: { get: (id: string) => id === "op" ? operation : null },
+      operations: { get: (id: string) => state.operationPresent && id === "op" ? operation : null },
       paths: { capturesDir: "/capture", resolveTheaterPath: () => "/theater" },
       events: { subscribe: (_channel: string, subscriber: (payload: unknown) => void) => { operationDeletedHandler = subscriber; return () => { operationDeletedHandler = undefined; }; } }, lifecycle: { registerCleanup: () => () => undefined },
     },
@@ -528,6 +585,7 @@ function createRouterHarness(initialHostAllowance: boolean) {
   return {
     ctx, responses,
     get allowHost() { return state.allowHost; }, set allowHost(value: boolean) { state.allowHost = value; },
+    deleteOperation() { state.operationPresent = false; },
     emitOperationDeleted(payload: unknown) { operationDeletedHandler?.(payload); },
     async call(method: string, pathname: string, body?: unknown, headers: Record<string, string> = {}) {
       const writes: string[] = [];

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
@@ -347,7 +347,6 @@ async function handleStart(ctx: FleetPluginServerContext, req: http.IncomingMess
   try {
     const result = await registry.start(operation.id, (onEvent) => createSession({ cliId: body.cliId, model: body.model, effort: body.effort || undefined, cwd, capturePath: transcriptPath, onEvent: (event: AnalystEvent) => onEvent(toBrowserEvent(event)) }));
     if (result === "exists") writeError(ctx, res, 409, ANALYSIS_ERROR_CODES.sessionExists, "Analysis session already exists.");
-    else if (result === "limit") writeError(ctx, res, 429, ANALYSIS_ERROR_CODES.sessionLimit, "Analysis session limit reached.");
     else if (result === "stopped") writeError(ctx, res, 404, ANALYSIS_ERROR_CODES.sessionNotFound, "Analysis session was stopped before it started.");
     else ctx.host.http.writeJson(res, 200, { started: true });
   } catch {

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
@@ -344,6 +344,10 @@ async function handleStart(ctx: FleetPluginServerContext, req: http.IncomingMess
     writeError(ctx, res, 404, ANALYSIS_ERROR_CODES.sessionNotFound, "Analysis operation was not found.");
     return true;
   }
+  if (!getAgentOperation(ctx, operation.id)) {
+    writeError(ctx, res, 404, ANALYSIS_ERROR_CODES.sessionNotFound, "Analysis operation was not found.");
+    return true;
+  }
   try {
     const result = await registry.start(operation.id, (onEvent) => createSession({ cliId: body.cliId, model: body.model, effort: body.effort || undefined, cwd, capturePath: transcriptPath, onEvent: (event: AnalystEvent) => onEvent(toBrowserEvent(event)) }));
     if (result === "exists") writeError(ctx, res, 409, ANALYSIS_ERROR_CODES.sessionExists, "Analysis session already exists.");

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
@@ -371,7 +371,8 @@ async function handleStart(ctx: FleetPluginServerContext, req: http.IncomingMess
     else if (result === "stopped") writeError(ctx, res, 404, ANALYSIS_ERROR_CODES.sessionNotFound, "Analysis session was stopped before it started.");
     else ctx.host.http.writeJson(res, 200, { started: true });
   } catch {
-    writeError(ctx, res, 503, ANALYSIS_ERROR_CODES.catalogInvalid, "Analysis session could not start.");
+    if (deletionMarker.deleted) writeError(ctx, res, 404, ANALYSIS_ERROR_CODES.sessionNotFound, "Analysis session was stopped before it started.");
+    else writeError(ctx, res, 503, ANALYSIS_ERROR_CODES.catalogInvalid, "Analysis session could not start.");
   }
   return true;
 }

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
@@ -27,6 +27,11 @@ type AnalysisRouteDeps = {
   readonly readCapture?: typeof readProviderSessionCapture;
 };
 
+type InFlightStartDeletionMarker = {
+  readonly operationId: string;
+  deleted: boolean;
+};
+
 export function registerAnalysisRoutes(ctx: FleetPluginServerContext, deps: AnalysisRouteDeps = {}): void {
   const registry = new AnalysisRegistry();
   const detect = deps.detect ?? createDefaultAgentCliDetector().detect;
@@ -34,6 +39,7 @@ export function registerAnalysisRoutes(ctx: FleetPluginServerContext, deps: Anal
   const readCapture = deps.readCapture ?? readProviderSessionCapture;
   const createSession = deps.createSession ?? ((options) => new AnalystSession(options));
   const catalog = async (): Promise<AnalysisCatalog> => buildAnalysisCatalog(await detect(), modelsFor);
+  const inFlightStartDeletionMarkers = new Set<InFlightStartDeletionMarker>();
 
   registerRouter(ctx, "analysis", async ({ req, res, pathname }) => {
     // The socket's bound local port is the only trustworthy expected Host port.
@@ -58,7 +64,15 @@ export function registerAnalysisRoutes(ctx: FleetPluginServerContext, deps: Anal
       return true;
     }
     if (action === "ready") return handleReady(ctx, req, res, operation, readCapture);
-    if (action === "start") return handleStart(ctx, req, res, operation, registry, catalog, readCapture, createSession);
+    if (action === "start") {
+      const deletionMarker: InFlightStartDeletionMarker = { operationId, deleted: false };
+      inFlightStartDeletionMarkers.add(deletionMarker);
+      try {
+        return await handleStart(ctx, req, res, operation, registry, catalog, readCapture, createSession, deletionMarker);
+      } finally {
+        inFlightStartDeletionMarkers.delete(deletionMarker);
+      }
+    }
     if (action === "message") return handleMessage(ctx, req, res, operationId, registry);
     if (action === "stream") return handleStream(ctx, req, res, operationId, registry);
     return handleStop(ctx, req, res, operationId, registry);
@@ -66,6 +80,9 @@ export function registerAnalysisRoutes(ctx: FleetPluginServerContext, deps: Anal
 
   const unsubscribeDelete = ctx.host.events.subscribe(OPERATION_DELETED_EVENT_CHANNEL, (payload) => {
     if (isOperationDeletedEvent(payload) && payload.pluginId === ctx.pluginId) {
+      for (const marker of inFlightStartDeletionMarkers) {
+        if (marker.operationId === payload.operationId) marker.deleted = true;
+      }
       registry.clearArtifacts(payload.operationId);
       void registry.stop(payload.operationId);
     }
@@ -320,7 +337,7 @@ async function handleReady(ctx: FleetPluginServerContext, req: http.IncomingMess
   return true;
 }
 
-async function handleStart(ctx: FleetPluginServerContext, req: http.IncomingMessage, res: http.ServerResponse, operation: OperationNode, registry: AnalysisRegistry, catalog: () => Promise<AnalysisCatalog>, readCapture: typeof readProviderSessionCapture, createSession: (options: ConstructorParameters<typeof AnalystSession>[0]) => AnalystSession): Promise<boolean> {
+async function handleStart(ctx: FleetPluginServerContext, req: http.IncomingMessage, res: http.ServerResponse, operation: OperationNode, registry: AnalysisRegistry, catalog: () => Promise<AnalysisCatalog>, readCapture: typeof readProviderSessionCapture, createSession: (options: ConstructorParameters<typeof AnalystSession>[0]) => AnalystSession, deletionMarker: InFlightStartDeletionMarker): Promise<boolean> {
   if (req.method !== "POST") return methodNotAllowed(ctx, res);
   if (!isJsonRequest(req)) return unsupportedMediaType(ctx, res);
   const body = await ctx.host.http.readJsonBody(req);
@@ -344,7 +361,7 @@ async function handleStart(ctx: FleetPluginServerContext, req: http.IncomingMess
     writeError(ctx, res, 404, ANALYSIS_ERROR_CODES.sessionNotFound, "Analysis operation was not found.");
     return true;
   }
-  if (!getAgentOperation(ctx, operation.id)) {
+  if (deletionMarker.deleted || !getAgentOperation(ctx, operation.id)) {
     writeError(ctx, res, 404, ANALYSIS_ERROR_CODES.sessionNotFound, "Analysis operation was not found.");
     return true;
   }

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-types.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-types.ts
@@ -5,7 +5,6 @@ export const ANALYSIS_ERROR_CODES = {
   captureMissing: "analysis_capture_missing",
   transcriptMissing: "analysis_transcript_missing",
   catalogInvalid: "analysis_catalog_invalid",
-  sessionLimit: "analysis_session_limit",
   sessionExists: "analysis_session_exists",
   sessionNotFound: "analysis_session_not_found",
   sessionBusy: "analysis_session_busy",


### PR DESCRIPTION
## Summary

- Remove the global four-session cap and `analysis_session_limit` failure from Session Analyst.
- Preserve each Operation's Analyst session when the companion panel is closed and reopened.
- Dispose Analyst sessions only with their owning Operation while bounding stopped artifact history.

## Type of Change

- [x] fix — bug fix

## Scope

- [x] `runtime/fleet-plugins/terminal`

## Test Plan

- [x] `pnpm --filter @fleet-plugins/terminal test` — 30 files, 282 tests passed
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `pnpm --filter @fleet-plugins/terminal build`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Headed Console E2E with Codex CLI: EXIT sent no stop, reopen retained the same response without a new start, Operation close disposed the Analyst session

## Changelog

- [x] Added `.changelog.d/pr-325.md`.
- [x] Validated grouped syntax, ASCII English, adjacent Hangul `ko:` summary, and the allowed `[fleet-console]` tag.
- [x] `node scripts/compile-changelog-fragments.mjs --check`

## Notes for Reviewers

Product intent is explicit: toggling the Session Analyst companion panel preserves the session; closing the owning Operation is the only disposal boundary.