### PR TITLE
perf(file-explorer): bound Linux directory watching

### DIFF
--- a/.changelog.d/pr-326.md
+++ b/.changelog.d/pr-326.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] Keep File Explorer responsive on Linux by watching only opened directories.
+  ko: Linux에서 열린 디렉터리만 감시하여 File Explorer가 멈추지 않고 반응하도록 합니다.

--- a/runtime/fleet-plugins/file-explorer/server/handlers.ts
+++ b/runtime/fleet-plugins/file-explorer/server/handlers.ts
@@ -38,6 +38,7 @@ export async function handleFilesList(
 
   try {
     const result = await listTheaterContents(theaterPath, relPath);
+    await watcherRegistry.trackDirectory(rawTheaterId, theaterPath, result.relativePath);
     ctx.host.http.writeJson(res, 200, result);
   } catch (error) {
     if (error instanceof FolderBrowserError) {

--- a/runtime/fleet-plugins/file-explorer/server/handlers.ts
+++ b/runtime/fleet-plugins/file-explorer/server/handlers.ts
@@ -38,7 +38,7 @@ export async function handleFilesList(
 
   try {
     const result = await listTheaterContents(theaterPath, relPath);
-    await watcherRegistry.trackDirectory(rawTheaterId, theaterPath, result.relativePath);
+    await watcherRegistry.trackDirectory(rawTheaterId, theaterPath, relPath);
     ctx.host.http.writeJson(res, 200, result);
   } catch (error) {
     if (error instanceof FolderBrowserError) {

--- a/runtime/fleet-plugins/file-explorer/server/watcher.ts
+++ b/runtime/fleet-plugins/file-explorer/server/watcher.ts
@@ -31,6 +31,7 @@ interface WatcherEntry {
   readonly theaterPath: string;
   readonly recursive: boolean;
   readonly watchers: Map<string, WatcherHandle>;
+  readonly identityChecks: Map<string, () => void>;
   readonly pendingDirectories: Set<string>;
   readonly subscribers: Set<WatchChangeCallback>;
   readonly stateSubscribers: Set<WatchStateCallback>;
@@ -84,6 +85,7 @@ export function createWatcherRegistry(
       try { watcher.close(); } catch { /* already closed */ }
     }
     entry.watchers.clear();
+    entry.identityChecks.clear();
     entry.pendingDirectories.clear();
   }
 
@@ -132,6 +134,7 @@ export function createWatcherRegistry(
     let identityCheckRunning = false;
     let identityCheckRequested = false;
     let activeWatcher: WatcherHandle | null = null;
+    const lexicalWatchPath = path.resolve(entry.theaterPath, watchKey);
 
     const checkDirectoryIdentity = async (expectedWatcher: WatcherHandle): Promise<void> => {
       identityCheckRequested = true;
@@ -143,7 +146,8 @@ export function createWatcherRegistry(
           identityCheckRequested = false;
           let replaced = false;
           try {
-            const stats = await fs.promises.stat(watchPath);
+            // lexical path를 따라가야 symlink 삭제·retarget도 검출한다.
+            const stats = await fs.promises.stat(lexicalWatchPath);
             replaced = stats.dev !== watchIdentity.device || stats.ino !== watchIdentity.inode;
           } catch (error) {
             // ENOENT만 감시 경로 소멸의 확실한 증거로 취급한다.
@@ -155,6 +159,7 @@ export function createWatcherRegistry(
           if (!replaced) continue;
 
           entry.watchers.delete(watchKey);
+          entry.identityChecks.delete(watchKey);
           entry.pendingDirectories.add(watchKey);
           try { expectedWatcher.close(); } catch { /* already closed */ }
           await rearmPendingDirectories(theaterId, entry);
@@ -172,8 +177,12 @@ export function createWatcherRegistry(
 
       // Linux fs.watch는 내부 항목 변경에도 "rename" 이벤트를 발생시킨다.
       // 동기 I/O 없이 경로가 소멸되었거나 identity가 교체된 경우에만 rearm한다.
-      if (!entry.recursive && watchKey !== "" && event === "rename" && watchIdentity) {
-        void checkDirectoryIdentity(currentWatcher);
+      if (!entry.recursive && event === "rename") {
+        if (watchKey !== "" && watchIdentity) void checkDirectoryIdentity(currentWatcher);
+        if (filename) {
+          const changedChildKey = path.join(watchKey, filename);
+          entry.identityChecks.get(changedChildKey)?.();
+        }
       }
       if (!entry.recursive && entry.pendingDirectories.size > 0) {
         void rearmPendingDirectories(theaterId, entry);
@@ -181,11 +190,18 @@ export function createWatcherRegistry(
     });
     activeWatcher = watcher;
     entry.watchers.set(watchKey, watcher);
+    if (watchIdentity) {
+      entry.identityChecks.set(watchKey, () => {
+        const currentWatcher = activeWatcher;
+        if (currentWatcher) void checkDirectoryIdentity(currentWatcher);
+      });
+    }
 
     watcher.on("error", () => {
       if (entry.watchers.get(watchKey) !== watcher) return;
       try { watcher.close(); } catch { /* already closed */ }
       entry.watchers.delete(watchKey);
+      entry.identityChecks.delete(watchKey);
 
       if (watchKey === "") {
         closeEntry(entry);
@@ -241,6 +257,7 @@ export function createWatcherRegistry(
       theaterPath,
       recursive: platform !== "linux",
       watchers: new Map(),
+      identityChecks: new Map(),
       pendingDirectories: new Set(),
       subscribers: new Set([onChange]),
       stateSubscribers: new Set([onState]),

--- a/runtime/fleet-plugins/file-explorer/server/watcher.ts
+++ b/runtime/fleet-plugins/file-explorer/server/watcher.ts
@@ -124,6 +124,17 @@ export function createWatcherRegistry(
     }
   }
 
+  function invalidateWatcherTree(entry: WatcherEntry, watchKey: string): void {
+    const descendantPrefix = watchKey + path.sep;
+    for (const [candidateKey, candidateWatcher] of entry.watchers) {
+      if (candidateKey !== watchKey && !candidateKey.startsWith(descendantPrefix)) continue;
+      entry.watchers.delete(candidateKey);
+      entry.identityChecks.delete(candidateKey);
+      entry.pendingDirectories.add(candidateKey);
+      try { candidateWatcher.close(); } catch { /* already closed */ }
+    }
+  }
+
   function startWatcher(
     theaterId: string,
     entry: WatcherEntry,
@@ -158,10 +169,8 @@ export function createWatcherRegistry(
           if (entry.watchers.get(watchKey) !== expectedWatcher) return;
           if (!replaced) continue;
 
-          entry.watchers.delete(watchKey);
-          entry.identityChecks.delete(watchKey);
-          entry.pendingDirectories.add(watchKey);
-          try { expectedWatcher.close(); } catch { /* already closed */ }
+          // 부모가 교체되면 이전 inode를 보는 하위 watcher도 함께 무효화한다.
+          invalidateWatcherTree(entry, watchKey);
           await rearmPendingDirectories(theaterId, entry);
           return;
         }

--- a/runtime/fleet-plugins/file-explorer/server/watcher.ts
+++ b/runtime/fleet-plugins/file-explorer/server/watcher.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 
 // fs.FSWatcher 중 레지스트리가 실제로 쓰는 최소 계약 — 테스트 mock이 이 형태만 만족하면 된다
 export interface WatcherHandle {
@@ -23,10 +24,12 @@ export interface WatcherRegistry {
     onChange: WatchChangeCallback,
     onState: WatchStateCallback,
   ): () => void;
+  trackDirectory(theaterId: string, theaterPath: string, relativePath: string): Promise<void>;
 }
 
 interface WatcherEntry {
-  readonly watcher: WatcherHandle;
+  readonly recursive: boolean;
+  readonly watchers: Map<string, WatcherHandle>;
   readonly subscribers: Set<WatchChangeCallback>;
   readonly stateSubscribers: Set<WatchStateCallback>;
   subscriberCount: number;
@@ -35,6 +38,7 @@ interface WatcherEntry {
 
 // 서버 측 debounce 간격 — 이벤트 폭풍 흡수
 const DEBOUNCE_MS = 200;
+const LINUX_DIRECTORY_WATCH_CAP = 1_024;
 
 // 기본 싱글턴 레지스트리 — handlers.ts에서 사용 (함수 선언 호이스팅에 의존)
 export const watcherRegistry: WatcherRegistry = createWatcherRegistry();
@@ -43,8 +47,58 @@ export function createWatcherRegistry(
   watcherFactory: WatcherFactory = (p, opts, cb) =>
     fs.watch(p, opts, (ev, fn) => cb(ev, typeof fn === "string" ? fn : null)),
   debounceMs = DEBOUNCE_MS,
+  platform: NodeJS.Platform = process.platform,
 ): WatcherRegistry {
   const entries = new Map<string, WatcherEntry>();
+
+  function scheduleChange(entry: WatcherEntry, relDir: string): void {
+    const pending = entry.debounceTimers.get(relDir);
+    if (pending) clearTimeout(pending);
+    entry.debounceTimers.set(
+      relDir,
+      setTimeout(() => {
+        entry.debounceTimers.delete(relDir);
+        for (const sub of entry.subscribers) sub(relDir);
+      }, debounceMs),
+    );
+  }
+
+  function closeEntry(entry: WatcherEntry): void {
+    for (const timer of entry.debounceTimers.values()) clearTimeout(timer);
+    entry.debounceTimers.clear();
+    for (const watcher of entry.watchers.values()) {
+      try { watcher.close(); } catch { /* already closed */ }
+    }
+    entry.watchers.clear();
+  }
+
+  function startWatcher(
+    theaterId: string,
+    entry: WatcherEntry,
+    watchKey: string,
+    watchPath: string,
+  ): void {
+    const watcher = watcherFactory(watchPath, { recursive: entry.recursive }, (_, filename) => {
+      scheduleChange(entry, entry.recursive ? computeRelDir(filename) : watchKey);
+    });
+    entry.watchers.set(watchKey, watcher);
+
+    watcher.on("error", () => {
+      if (entry.watchers.get(watchKey) !== watcher) return;
+      try { watcher.close(); } catch { /* already closed */ }
+      entry.watchers.delete(watchKey);
+
+      if (watchKey === "") {
+        closeEntry(entry);
+        if (entries.get(theaterId) === entry) entries.delete(theaterId);
+      } else {
+        const pending = entry.debounceTimers.get(watchKey);
+        if (pending) clearTimeout(pending);
+        entry.debounceTimers.delete(watchKey);
+      }
+      for (const notify of entry.stateSubscribers) notify("degraded");
+    });
+  }
 
   function makeUnsubscribe(
     theaterId: string,
@@ -60,8 +114,7 @@ export function createWatcherRegistry(
       entry.stateSubscribers.delete(onState);
       entry.subscriberCount--;
       if (entry.subscriberCount <= 0) {
-        for (const t of entry.debounceTimers.values()) clearTimeout(t);
-        entry.watcher.close();
+        closeEntry(entry);
         // error 이후 교체된 새 entry를 지우지 않도록 동일 entry일 때만 제거한다
         if (entries.get(theaterId) === entry) entries.delete(theaterId);
       }
@@ -83,51 +136,76 @@ export function createWatcherRegistry(
       return makeUnsubscribe(theaterId, onChange, onState, existing);
     }
 
-    const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
-    const subscribers = new Set<WatchChangeCallback>();
-    const stateSubscribers = new Set<WatchStateCallback>();
+    const entry: WatcherEntry = {
+      // Linux의 recursive fs.watch fallback은 구독 시 전체 트리를 동기 순회한다.
+      // 대신 root와 실제로 조회된 디렉터리만 개별 비재귀 watcher로 추적한다.
+      recursive: platform !== "linux",
+      watchers: new Map(),
+      subscribers: new Set([onChange]),
+      stateSubscribers: new Set([onState]),
+      subscriberCount: 1,
+      debounceTimers: new Map(),
+    };
 
-    let watcher: WatcherHandle;
     try {
-      watcher = watcherFactory(theaterPath, { recursive: true }, (_, filename) => {
-        const relDir = computeRelDir(filename);
-        const pending = debounceTimers.get(relDir);
-        if (pending) clearTimeout(pending);
-        debounceTimers.set(
-          relDir,
-          setTimeout(() => {
-            debounceTimers.delete(relDir);
-            for (const sub of subscribers) sub(relDir);
-          }, debounceMs),
-        );
-      });
+      startWatcher(theaterId, entry, "", theaterPath);
     } catch {
       // fs.watch 미지원 플랫폼: graceful degrade — 감시 불가 상태만 알리고 연결 유지
       onState("degraded");
       return () => {};
     }
 
-    const entry: WatcherEntry = { watcher, subscribers, stateSubscribers, subscriberCount: 1, debounceTimers };
-
-    // 감시 런타임 오류(감시 대상 삭제 등): unhandled 'error'로 프로세스가 죽지 않도록
-    // 구독자 전원에게 degrade를 알리고 watcher를 정리한다. SSE 연결 자체는 유지된다.
-    watcher.on("error", () => {
-      for (const t of debounceTimers.values()) clearTimeout(t);
-      debounceTimers.clear();
-      try { watcher.close(); } catch { /* 이미 닫힌 경우 무시 */ }
-      // 교체된 새 entry를 지우지 않도록 동일 entry일 때만 제거한다
-      if (entries.get(theaterId) === entry) entries.delete(theaterId);
-      for (const notify of stateSubscribers) notify("degraded");
-    });
-
     entries.set(theaterId, entry);
-    subscribers.add(onChange);
-    stateSubscribers.add(onState);
     onState("watching");
     return makeUnsubscribe(theaterId, onChange, onState, entry);
   }
 
-  return { subscribe };
+  async function trackDirectory(theaterId: string, theaterPath: string, relativePath: string): Promise<void> {
+    const entry = entries.get(theaterId);
+    if (!entry || entry.recursive || relativePath === "" || entry.watchers.has(relativePath)) return;
+    if (entry.watchers.size >= LINUX_DIRECTORY_WATCH_CAP) {
+      for (const notify of entry.stateSubscribers) notify("degraded");
+      return;
+    }
+
+    const targetPath = await resolveTrackedDirectory(theaterPath, relativePath);
+    if (!targetPath) return;
+
+    // realpath 대기 중 구독이 끝났거나 같은 디렉터리가 먼저 등록됐을 수 있다.
+    if (
+      entries.get(theaterId) !== entry
+      || entry.watchers.has(relativePath)
+      || entry.watchers.size >= LINUX_DIRECTORY_WATCH_CAP
+    ) return;
+    try {
+      startWatcher(theaterId, entry, relativePath, targetPath);
+    } catch {
+      for (const notify of entry.stateSubscribers) notify("degraded");
+    }
+  }
+
+  return { subscribe, trackDirectory };
+}
+
+async function resolveTrackedDirectory(theaterPath: string, relativePath: string): Promise<string | null> {
+  const resolvedRoot = path.resolve(theaterPath);
+  const targetPath = path.resolve(resolvedRoot, relativePath);
+  if (!isWithinRoot(targetPath, resolvedRoot)) return null;
+
+  try {
+    const [realRoot, realTarget] = await Promise.all([
+      fs.promises.realpath(theaterPath),
+      fs.promises.realpath(targetPath),
+    ]);
+    return isWithinRoot(realTarget, realRoot) ? realTarget : null;
+  } catch {
+    return null;
+  }
+}
+
+function isWithinRoot(candidate: string, root: string): boolean {
+  const normalizedRoot = root.endsWith(path.sep) ? root : root + path.sep;
+  return candidate === root || candidate.startsWith(normalizedRoot);
 }
 
 function computeRelDir(filename: string | null): string {

--- a/runtime/fleet-plugins/file-explorer/server/watcher.ts
+++ b/runtime/fleet-plugins/file-explorer/server/watcher.ts
@@ -36,6 +36,8 @@ interface WatcherEntry {
   readonly stateSubscribers: Set<WatchStateCallback>;
   subscriberCount: number;
   readonly debounceTimers: Map<string, ReturnType<typeof setTimeout>>;
+  rearmRunning: boolean;
+  rearmRequested: boolean;
 }
 
 interface DirectoryIdentity {
@@ -86,26 +88,37 @@ export function createWatcherRegistry(
   }
 
   async function rearmPendingDirectories(theaterId: string, entry: WatcherEntry): Promise<void> {
-    for (const relativePath of entry.pendingDirectories) {
-      const target = await resolveTrackedDirectory(entry.theaterPath, relativePath);
-      if (!target) continue;
+    entry.rearmRequested = true;
+    if (entry.rearmRunning) return;
+    entry.rearmRunning = true;
 
-      // resolve 대기 중 구독이 끝났거나 다른 이벤트가 먼저 watcher를 복구했을 수 있다.
-      if (
-        entries.get(theaterId) !== entry
-        || !entry.pendingDirectories.has(relativePath)
-        || entry.watchers.has(relativePath)
-        || entry.watchers.size >= LINUX_DIRECTORY_WATCH_CAP
-      ) continue;
+    try {
+      while (entry.rearmRequested) {
+        entry.rearmRequested = false;
+        for (const relativePath of entry.pendingDirectories) {
+          const target = await resolveTrackedDirectory(entry.theaterPath, relativePath);
+          if (!target) continue;
 
-      try {
-        startWatcher(theaterId, entry, relativePath, target.path, target.identity);
-        entry.pendingDirectories.delete(relativePath);
-        // 재생성 자체는 상위 watcher가 감지하므로 새 디렉터리 내용을 다시 조회하도록 알린다.
-        scheduleChange(entry, relativePath);
-      } catch {
-        for (const notify of entry.stateSubscribers) notify("degraded");
+          // resolve 대기 중 구독이 끝났거나 다른 이벤트가 먼저 watcher를 복구했을 수 있다.
+          if (
+            entries.get(theaterId) !== entry
+            || !entry.pendingDirectories.has(relativePath)
+            || entry.watchers.has(relativePath)
+            || entry.watchers.size >= LINUX_DIRECTORY_WATCH_CAP
+          ) continue;
+
+          try {
+            startWatcher(theaterId, entry, relativePath, target.path, target.identity);
+            entry.pendingDirectories.delete(relativePath);
+            // 재생성 자체는 상위 watcher가 감지하므로 새 디렉터리 내용을 다시 조회하도록 알린다.
+            scheduleChange(entry, relativePath);
+          } catch {
+            for (const notify of entry.stateSubscribers) notify("degraded");
+          }
+        }
       }
+    } finally {
+      entry.rearmRunning = false;
     }
   }
 
@@ -233,6 +246,8 @@ export function createWatcherRegistry(
       stateSubscribers: new Set([onState]),
       subscriberCount: 1,
       debounceTimers: new Map(),
+      rearmRunning: false,
+      rearmRequested: false,
     };
 
     try {

--- a/runtime/fleet-plugins/file-explorer/server/watcher.ts
+++ b/runtime/fleet-plugins/file-explorer/server/watcher.ts
@@ -38,6 +38,16 @@ interface WatcherEntry {
   readonly debounceTimers: Map<string, ReturnType<typeof setTimeout>>;
 }
 
+interface DirectoryIdentity {
+  readonly device: number;
+  readonly inode: number;
+}
+
+interface TrackedDirectory {
+  readonly path: string;
+  readonly identity: DirectoryIdentity;
+}
+
 // 서버 측 debounce 간격 — 이벤트 폭풍 흡수
 const DEBOUNCE_MS = 200;
 const LINUX_DIRECTORY_WATCH_CAP = 1_024;
@@ -77,8 +87,8 @@ export function createWatcherRegistry(
 
   async function rearmPendingDirectories(theaterId: string, entry: WatcherEntry): Promise<void> {
     for (const relativePath of entry.pendingDirectories) {
-      const targetPath = await resolveTrackedDirectory(entry.theaterPath, relativePath);
-      if (!targetPath) continue;
+      const target = await resolveTrackedDirectory(entry.theaterPath, relativePath);
+      if (!target) continue;
 
       // resolve 대기 중 구독이 끝났거나 다른 이벤트가 먼저 watcher를 복구했을 수 있다.
       if (
@@ -89,7 +99,7 @@ export function createWatcherRegistry(
       ) continue;
 
       try {
-        startWatcher(theaterId, entry, relativePath, targetPath);
+        startWatcher(theaterId, entry, relativePath, target.path, target.identity);
         entry.pendingDirectories.delete(relativePath);
         // 재생성 자체는 상위 watcher가 감지하므로 새 디렉터리 내용을 다시 조회하도록 알린다.
         scheduleChange(entry, relativePath);
@@ -104,19 +114,53 @@ export function createWatcherRegistry(
     entry: WatcherEntry,
     watchKey: string,
     watchPath: string,
+    watchIdentity?: DirectoryIdentity,
   ): void {
+    let identityCheckRunning = false;
+    let identityCheckRequested = false;
     let activeWatcher: WatcherHandle | null = null;
+
+    const checkDirectoryIdentity = async (expectedWatcher: WatcherHandle): Promise<void> => {
+      identityCheckRequested = true;
+      if (identityCheckRunning || !watchIdentity) return;
+      identityCheckRunning = true;
+
+      try {
+        while (identityCheckRequested) {
+          identityCheckRequested = false;
+          let replaced = false;
+          try {
+            const stats = await fs.promises.stat(watchPath);
+            replaced = stats.dev !== watchIdentity.device || stats.ino !== watchIdentity.inode;
+          } catch (error) {
+            // ENOENT만 감시 경로 소멸의 확실한 증거로 취급한다.
+            replaced = (error as NodeJS.ErrnoException).code === "ENOENT";
+          }
+
+          // stat 대기 중 구독이 끝났거나 watcher가 이미 교체될 수 있다.
+          if (entry.watchers.get(watchKey) !== expectedWatcher) return;
+          if (!replaced) continue;
+
+          entry.watchers.delete(watchKey);
+          entry.pendingDirectories.add(watchKey);
+          try { expectedWatcher.close(); } catch { /* already closed */ }
+          await rearmPendingDirectories(theaterId, entry);
+          return;
+        }
+      } finally {
+        identityCheckRunning = false;
+      }
+    };
+
     const watcher = watcherFactory(watchPath, { recursive: entry.recursive }, (event, filename) => {
       const currentWatcher = activeWatcher;
       if (!currentWatcher || entry.watchers.get(watchKey) !== currentWatcher) return;
       scheduleChange(entry, entry.recursive ? computeRelDir(filename) : watchKey);
 
-      // Linux watcher는 inode를 추적하므로 디렉터리 교체 후 새 inode를 보지 못한다.
-      // rename 시 등록을 비우고 상위 watcher 이벤트에서 새 inode를 다시 찾는다.
-      if (!entry.recursive && watchKey !== "" && event === "rename") {
-        entry.watchers.delete(watchKey);
-        entry.pendingDirectories.add(watchKey);
-        try { currentWatcher.close(); } catch { /* already closed */ }
+      // Linux fs.watch는 내부 항목 변경에도 "rename" 이벤트를 발생시킨다.
+      // 동기 I/O 없이 경로가 소멸되었거나 identity가 교체된 경우에만 rearm한다.
+      if (!entry.recursive && watchKey !== "" && event === "rename" && watchIdentity) {
+        void checkDirectoryIdentity(currentWatcher);
       }
       if (!entry.recursive && entry.pendingDirectories.size > 0) {
         void rearmPendingDirectories(theaterId, entry);
@@ -212,8 +256,8 @@ export function createWatcherRegistry(
       return;
     }
 
-    const targetPath = await resolveTrackedDirectory(theaterPath, relativePath);
-    if (!targetPath) return;
+    const target = await resolveTrackedDirectory(theaterPath, relativePath);
+    if (!target) return;
 
     // realpath 대기 중 구독이 끝났거나 같은 디렉터리가 먼저 등록됐을 수 있다.
     if (
@@ -222,7 +266,7 @@ export function createWatcherRegistry(
       || entry.watchers.size >= LINUX_DIRECTORY_WATCH_CAP
     ) return;
     try {
-      startWatcher(theaterId, entry, relativePath, targetPath);
+      startWatcher(theaterId, entry, relativePath, target.path, target.identity);
       entry.pendingDirectories.delete(relativePath);
     } catch {
       for (const notify of entry.stateSubscribers) notify("degraded");
@@ -232,7 +276,10 @@ export function createWatcherRegistry(
   return { subscribe, trackDirectory };
 }
 
-async function resolveTrackedDirectory(theaterPath: string, relativePath: string): Promise<string | null> {
+async function resolveTrackedDirectory(
+  theaterPath: string,
+  relativePath: string,
+): Promise<TrackedDirectory | null> {
   const resolvedRoot = path.resolve(theaterPath);
   const targetPath = path.resolve(resolvedRoot, relativePath);
   if (!isWithinRoot(targetPath, resolvedRoot)) return null;
@@ -242,7 +289,13 @@ async function resolveTrackedDirectory(theaterPath: string, relativePath: string
       fs.promises.realpath(theaterPath),
       fs.promises.realpath(targetPath),
     ]);
-    return isWithinRoot(realTarget, realRoot) ? realTarget : null;
+    if (!isWithinRoot(realTarget, realRoot)) return null;
+    const stats = await fs.promises.stat(realTarget);
+    if (!stats.isDirectory()) return null;
+    return {
+      path: realTarget,
+      identity: { device: stats.dev, inode: stats.ino },
+    };
   } catch {
     return null;
   }

--- a/runtime/fleet-plugins/file-explorer/server/watcher.ts
+++ b/runtime/fleet-plugins/file-explorer/server/watcher.ts
@@ -28,8 +28,10 @@ export interface WatcherRegistry {
 }
 
 interface WatcherEntry {
+  readonly theaterPath: string;
   readonly recursive: boolean;
   readonly watchers: Map<string, WatcherHandle>;
+  readonly pendingDirectories: Set<string>;
   readonly subscribers: Set<WatchChangeCallback>;
   readonly stateSubscribers: Set<WatchStateCallback>;
   subscriberCount: number;
@@ -70,6 +72,31 @@ export function createWatcherRegistry(
       try { watcher.close(); } catch { /* already closed */ }
     }
     entry.watchers.clear();
+    entry.pendingDirectories.clear();
+  }
+
+  async function rearmPendingDirectories(theaterId: string, entry: WatcherEntry): Promise<void> {
+    for (const relativePath of entry.pendingDirectories) {
+      const targetPath = await resolveTrackedDirectory(entry.theaterPath, relativePath);
+      if (!targetPath) continue;
+
+      // resolve 대기 중 구독이 끝났거나 다른 이벤트가 먼저 watcher를 복구했을 수 있다.
+      if (
+        entries.get(theaterId) !== entry
+        || !entry.pendingDirectories.has(relativePath)
+        || entry.watchers.has(relativePath)
+        || entry.watchers.size >= LINUX_DIRECTORY_WATCH_CAP
+      ) continue;
+
+      try {
+        startWatcher(theaterId, entry, relativePath, targetPath);
+        entry.pendingDirectories.delete(relativePath);
+        // 재생성 자체는 상위 watcher가 감지하므로 새 디렉터리 내용을 다시 조회하도록 알린다.
+        scheduleChange(entry, relativePath);
+      } catch {
+        for (const notify of entry.stateSubscribers) notify("degraded");
+      }
+    }
   }
 
   function startWatcher(
@@ -85,10 +112,14 @@ export function createWatcherRegistry(
       scheduleChange(entry, entry.recursive ? computeRelDir(filename) : watchKey);
 
       // Linux watcher는 inode를 추적하므로 디렉터리 교체 후 새 inode를 보지 못한다.
-      // rename 시 등록을 비워 다음 성공적인 folder list가 새 watcher를 만들게 한다.
+      // rename 시 등록을 비우고 상위 watcher 이벤트에서 새 inode를 다시 찾는다.
       if (!entry.recursive && watchKey !== "" && event === "rename") {
         entry.watchers.delete(watchKey);
+        entry.pendingDirectories.add(watchKey);
         try { currentWatcher.close(); } catch { /* already closed */ }
+      }
+      if (!entry.recursive && entry.pendingDirectories.size > 0) {
+        void rearmPendingDirectories(theaterId, entry);
       }
     });
     activeWatcher = watcher;
@@ -150,8 +181,10 @@ export function createWatcherRegistry(
     const entry: WatcherEntry = {
       // Linux의 recursive fs.watch fallback은 구독 시 전체 트리를 동기 순회한다.
       // 대신 root와 실제로 조회된 디렉터리만 개별 비재귀 watcher로 추적한다.
+      theaterPath,
       recursive: platform !== "linux",
       watchers: new Map(),
+      pendingDirectories: new Set(),
       subscribers: new Set([onChange]),
       stateSubscribers: new Set([onState]),
       subscriberCount: 1,
@@ -190,6 +223,7 @@ export function createWatcherRegistry(
     ) return;
     try {
       startWatcher(theaterId, entry, relativePath, targetPath);
+      entry.pendingDirectories.delete(relativePath);
     } catch {
       for (const notify of entry.stateSubscribers) notify("degraded");
     }

--- a/runtime/fleet-plugins/file-explorer/server/watcher.ts
+++ b/runtime/fleet-plugins/file-explorer/server/watcher.ts
@@ -78,9 +78,20 @@ export function createWatcherRegistry(
     watchKey: string,
     watchPath: string,
   ): void {
-    const watcher = watcherFactory(watchPath, { recursive: entry.recursive }, (_, filename) => {
+    let activeWatcher: WatcherHandle | null = null;
+    const watcher = watcherFactory(watchPath, { recursive: entry.recursive }, (event, filename) => {
+      const currentWatcher = activeWatcher;
+      if (!currentWatcher || entry.watchers.get(watchKey) !== currentWatcher) return;
       scheduleChange(entry, entry.recursive ? computeRelDir(filename) : watchKey);
+
+      // Linux watcher는 inode를 추적하므로 디렉터리 교체 후 새 inode를 보지 못한다.
+      // rename 시 등록을 비워 다음 성공적인 folder list가 새 watcher를 만들게 한다.
+      if (!entry.recursive && watchKey !== "" && event === "rename") {
+        entry.watchers.delete(watchKey);
+        try { currentWatcher.close(); } catch { /* already closed */ }
+      }
     });
+    activeWatcher = watcher;
     entry.watchers.set(watchKey, watcher);
 
     watcher.on("error", () => {

--- a/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
@@ -431,6 +431,62 @@ describe("createWatcherRegistry", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "Linux 내부 심볼릭 링크가 retarget되면 새 target으로 watcher를 rearm한다",
+    async () => {
+      const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-file-watch-"));
+      const firstTarget = path.join(tempRoot, "packages", "first");
+      const secondTarget = path.join(tempRoot, "packages", "second");
+      const linkPath = path.join(tempRoot, "link");
+      fs.mkdirSync(firstTarget, { recursive: true });
+      fs.mkdirSync(secondTarget, { recursive: true });
+      fs.symlinkSync(firstTarget, linkPath);
+      const callbacks = new Map<string, (event: string, filename: string | null) => void>();
+      const closes = new Map<string, ReturnType<typeof vi.fn>>();
+      const mockFactory: WatcherFactory = vi.fn().mockImplementation((watchPath, _options, callback) => {
+        const close = vi.fn();
+        callbacks.set(watchPath, callback);
+        closes.set(watchPath, close);
+        return { close, on: vi.fn() };
+      });
+      const registry = createWatcherRegistry(mockFactory, 50, "linux");
+      const onChange = vi.fn();
+
+      try {
+        const unsub = registry.subscribe("t1", tempRoot, onChange, () => {});
+        await registry.trackDirectory("t1", tempRoot, "link");
+        const realFirstTarget = fs.realpathSync(firstTarget);
+        const realSecondTarget = fs.realpathSync(secondTarget);
+        const staleCallback = callbacks.get(realFirstTarget)!;
+
+        fs.unlinkSync(linkPath);
+        fs.symlinkSync(secondTarget, linkPath);
+        callbacks.get(tempRoot)!("rename", "link");
+
+        await vi.waitFor(() => expect(closes.get(realFirstTarget)).toHaveBeenCalledOnce());
+        await vi.waitFor(() => expect(mockFactory).toHaveBeenCalledTimes(3));
+        expect(mockFactory).toHaveBeenLastCalledWith(
+          realSecondTarget,
+          { recursive: false },
+          expect.any(Function),
+        );
+
+        vi.advanceTimersByTime(100);
+        onChange.mockClear();
+        staleCallback("change", "stale.ts");
+        vi.advanceTimersByTime(100);
+        expect(onChange).not.toHaveBeenCalled();
+
+        callbacks.get(realSecondTarget)!("change", "fresh.ts");
+        vi.advanceTimersByTime(100);
+        expect(onChange).toHaveBeenCalledWith("link");
+        unsub();
+      } finally {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("Linux 하위 watcher error는 root 감시를 유지하고 다음 조회에서 복구한다", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-file-watch-"));
     fs.mkdirSync(path.join(tempRoot, "src"));

--- a/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
@@ -394,6 +394,42 @@ describe("createWatcherRegistry", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "Linux에서는 내부 심볼릭 링크의 client path로 변경을 알린다",
+    async () => {
+      const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-file-watch-"));
+      const targetPath = path.join(tempRoot, "packages", "app");
+      const linkPath = path.join(tempRoot, "link");
+      fs.mkdirSync(targetPath, { recursive: true });
+      fs.symlinkSync(targetPath, linkPath);
+      const callbacks = new Map<string, (event: string, filename: string | null) => void>();
+      const mockFactory: WatcherFactory = vi.fn().mockImplementation((watchPath, _options, callback) => {
+        callbacks.set(watchPath, callback);
+        return { close: vi.fn(), on: vi.fn() };
+      });
+      const registry = createWatcherRegistry(mockFactory, 50, "linux");
+      const onChange = vi.fn();
+
+      try {
+        const unsub = registry.subscribe("t1", tempRoot, onChange, () => {});
+        await registry.trackDirectory("t1", tempRoot, "link");
+
+        const realTargetPath = fs.realpathSync(targetPath);
+        expect(mockFactory).toHaveBeenLastCalledWith(
+          realTargetPath,
+          { recursive: false },
+          expect.any(Function),
+        );
+        callbacks.get(realTargetPath)!("change", "file.ts");
+        vi.advanceTimersByTime(100);
+        expect(onChange).toHaveBeenCalledWith("link");
+        unsub();
+      } finally {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("Linux 하위 watcher error는 root 감시를 유지하고 다음 조회에서 복구한다", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-file-watch-"));
     fs.mkdirSync(path.join(tempRoot, "src"));

--- a/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
@@ -465,7 +465,7 @@ describe("createWatcherRegistry", () => {
     }
   });
 
-  it("Linux 하위 디렉터리 rename 후 다음 조회에서 watcher를 재등록한다", async () => {
+  it("Linux 하위 디렉터리가 나중에 재생성되면 상위 이벤트에서 watcher를 복구한다", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-file-watch-"));
     const childPath = path.join(tempRoot, "src");
     fs.mkdirSync(childPath);
@@ -491,9 +491,18 @@ describe("createWatcherRegistry", () => {
       vi.advanceTimersByTime(100);
       expect(onChange).toHaveBeenCalledWith("src");
 
+      onChange.mockClear();
       fs.mkdirSync(childPath);
-      await registry.trackDirectory("t1", tempRoot, "src");
-      expect(mockFactory).toHaveBeenCalledTimes(3);
+      callbacks[0]!("rename", "src");
+      await vi.waitFor(() => expect(mockFactory).toHaveBeenCalledTimes(3));
+
+      vi.advanceTimersByTime(100);
+      expect(onChange).toHaveBeenCalledWith("src");
+
+      onChange.mockClear();
+      callbacks[2]!("change", "file.ts");
+      vi.advanceTimersByTime(100);
+      expect(onChange).toHaveBeenCalledWith("src");
       unsub();
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });

--- a/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
@@ -510,6 +510,57 @@ describe("createWatcherRegistry", () => {
     }
   });
 
+  it("Linux pending 디렉터리 rearm 스캔을 중첩 실행하지 않는다", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-file-watch-"));
+    const childPath = path.join(tempRoot, "src");
+    fs.mkdirSync(childPath);
+    const callbacks: Array<(event: string, filename: string | null) => void> = [];
+    const closes: Array<ReturnType<typeof vi.fn>> = [];
+    const mockFactory: WatcherFactory = vi.fn().mockImplementation((_watchPath, _options, callback) => {
+      const close = vi.fn();
+      callbacks.push(callback);
+      closes.push(close);
+      return { close, on: vi.fn() };
+    });
+    const registry = createWatcherRegistry(mockFactory, 50, "linux");
+
+    try {
+      const unsub = registry.subscribe("t1", tempRoot, () => {}, () => {});
+      await registry.trackDirectory("t1", tempRoot, "src");
+      const nativeRealpath = fs.promises.realpath.bind(fs.promises);
+      let releaseMissingPath: () => void = () => {};
+      const missingPathGate = new Promise<void>((resolve) => { releaseMissingPath = resolve; });
+      let targetAttempts = 0;
+      const missingError = Object.assign(new Error("missing"), { code: "ENOENT" });
+      const realpathSpy = vi.spyOn(fs.promises, "realpath").mockImplementation(async (candidate) => {
+        if (String(candidate) === childPath) {
+          targetAttempts++;
+          if (targetAttempts === 1) await missingPathGate;
+          throw missingError;
+        }
+        return nativeRealpath(candidate);
+      });
+
+      fs.rmSync(childPath, { recursive: true });
+      callbacks[1]!("rename", "src");
+      await vi.waitFor(() => expect(closes[1]).toHaveBeenCalledOnce());
+      await vi.waitFor(() => expect(targetAttempts).toBe(1));
+
+      // 처음 스캔이 대기 중일 때 이벤트 폭주는 후속 스캔 하나로 합쳐져야 한다.
+      for (let index = 0; index < 10; index++) callbacks[0]!("rename", "src");
+      expect(targetAttempts).toBe(1);
+
+      releaseMissingPath();
+      await vi.waitFor(() => expect(targetAttempts).toBe(2));
+      expect(realpathSpy).toHaveBeenCalledTimes(4);
+
+      realpathSpy.mockRestore();
+      unsub();
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("Linux 하위 watcher에서 일반 파일 rename은 watcher를 닫지 않는다", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-file-watch-"));
     const childPath = path.join(tempRoot, "src");

--- a/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
@@ -1,7 +1,15 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { WatcherFactory } from "../server/watcher.js";
 import { createWatcherRegistry } from "../server/watcher.js";
+
+function createNativeWatcherRegistry(factory: WatcherFactory, debounceMs?: number) {
+  return createWatcherRegistry(factory, debounceMs, "darwin");
+}
 
 describe("createWatcherRegistry", () => {
   beforeEach(() => {
@@ -14,7 +22,7 @@ describe("createWatcherRegistry", () => {
   it("첫 구독자가 watcher를 생성한다", () => {
     const mockClose = vi.fn();
     const mockFactory: WatcherFactory = vi.fn().mockReturnValue({ close: mockClose, on: vi.fn() });
-    const registry = createWatcherRegistry(mockFactory);
+    const registry = createNativeWatcherRegistry(mockFactory);
 
     const unsub = registry.subscribe("t1", "/path", () => {}, () => {});
     expect(mockFactory).toHaveBeenCalledOnce();
@@ -24,7 +32,7 @@ describe("createWatcherRegistry", () => {
 
   it("두 번째 구독자는 기존 watcher를 재사용한다", () => {
     const mockFactory: WatcherFactory = vi.fn().mockReturnValue({ close: vi.fn(), on: vi.fn() });
-    const registry = createWatcherRegistry(mockFactory);
+    const registry = createNativeWatcherRegistry(mockFactory);
 
     const unsub1 = registry.subscribe("t1", "/path", () => {}, () => {});
     const unsub2 = registry.subscribe("t1", "/path", () => {}, () => {});
@@ -37,7 +45,7 @@ describe("createWatcherRegistry", () => {
   it("마지막 구독자 해제 시 watcher.close()를 호출한다", () => {
     const mockClose = vi.fn();
     const mockFactory: WatcherFactory = vi.fn().mockReturnValue({ close: mockClose, on: vi.fn() });
-    const registry = createWatcherRegistry(mockFactory);
+    const registry = createNativeWatcherRegistry(mockFactory);
 
     const unsub1 = registry.subscribe("t1", "/path", () => {}, () => {});
     const unsub2 = registry.subscribe("t1", "/path", () => {}, () => {});
@@ -54,7 +62,7 @@ describe("createWatcherRegistry", () => {
       watchCb = cb;
       return { close: vi.fn(), on: vi.fn() };
     });
-    const registry = createWatcherRegistry(mockFactory, 50);
+    const registry = createNativeWatcherRegistry(mockFactory, 50);
 
     const onChange1 = vi.fn();
     const onChange2 = vi.fn();
@@ -77,7 +85,7 @@ describe("createWatcherRegistry", () => {
       watchCb = cb;
       return { close: vi.fn(), on: vi.fn() };
     });
-    const registry = createWatcherRegistry(mockFactory, 100);
+    const registry = createNativeWatcherRegistry(mockFactory, 100);
 
     const onChange = vi.fn();
     const unsub = registry.subscribe("t1", "/path", onChange, () => {});
@@ -100,7 +108,7 @@ describe("createWatcherRegistry", () => {
       watchCb = cb;
       return { close: vi.fn(), on: vi.fn() };
     });
-    const registry = createWatcherRegistry(mockFactory, 50);
+    const registry = createNativeWatcherRegistry(mockFactory, 50);
 
     const onChange = vi.fn();
     const unsub = registry.subscribe("t1", "/path", onChange, () => {});
@@ -120,7 +128,7 @@ describe("createWatcherRegistry", () => {
     const mockFactory: WatcherFactory = vi.fn().mockImplementation(() => {
       throw new Error("ENOSYS: function not implemented");
     });
-    const registry = createWatcherRegistry(mockFactory);
+    const registry = createNativeWatcherRegistry(mockFactory);
 
     const onState = vi.fn();
     const unsub = registry.subscribe("t1", "/path", () => {}, onState);
@@ -131,7 +139,7 @@ describe("createWatcherRegistry", () => {
 
   it("첫 구독자는 watching, 추가 구독자도 watching 상태를 받는다", () => {
     const mockFactory: WatcherFactory = vi.fn().mockReturnValue({ close: vi.fn(), on: vi.fn() });
-    const registry = createWatcherRegistry(mockFactory);
+    const registry = createNativeWatcherRegistry(mockFactory);
 
     const onState1 = vi.fn();
     const onState2 = vi.fn();
@@ -151,7 +159,7 @@ describe("createWatcherRegistry", () => {
       watchCb = cb;
       return { close: vi.fn(), on: vi.fn() };
     });
-    const registry = createWatcherRegistry(mockFactory, 50);
+    const registry = createNativeWatcherRegistry(mockFactory, 50);
 
     const onChange = vi.fn();
     const unsub = registry.subscribe("t1", "/path", onChange, () => {});
@@ -169,7 +177,7 @@ describe("createWatcherRegistry", () => {
       watchCb = cb;
       return { close: vi.fn(), on: vi.fn() };
     });
-    const registry = createWatcherRegistry(mockFactory, 50);
+    const registry = createNativeWatcherRegistry(mockFactory, 50);
 
     const onChange = vi.fn();
     const unsub = registry.subscribe("t1", "/path", onChange, () => {});
@@ -184,7 +192,7 @@ describe("createWatcherRegistry", () => {
   it("unsub를 두 번 호출해도 watcher.close()는 한 번만 호출된다", () => {
     const mockClose = vi.fn();
     const mockFactory: WatcherFactory = vi.fn().mockReturnValue({ close: mockClose, on: vi.fn() });
-    const registry = createWatcherRegistry(mockFactory);
+    const registry = createNativeWatcherRegistry(mockFactory);
 
     const unsub = registry.subscribe("t1", "/path", () => {}, () => {});
     unsub();
@@ -199,7 +207,7 @@ describe("createWatcherRegistry", () => {
       watchCb = cb;
       return { close: vi.fn(), on: vi.fn() };
     });
-    const registry = createWatcherRegistry(mockFactory, 50);
+    const registry = createNativeWatcherRegistry(mockFactory, 50);
 
     const onChange = vi.fn();
     const unsub = registry.subscribe("t1", "/path", onChange, () => {});
@@ -225,7 +233,7 @@ describe("createWatcherRegistry", () => {
         }),
       };
     });
-    const registry = createWatcherRegistry(mockFactory);
+    const registry = createNativeWatcherRegistry(mockFactory);
 
     const unsubOld = registry.subscribe("t1", "/path", () => {}, vi.fn());
     errorCbs[0]!(new Error("EPERM"));
@@ -252,7 +260,7 @@ describe("createWatcherRegistry", () => {
         if (event === "error") errorCb = cb;
       }),
     });
-    const registry = createWatcherRegistry(mockFactory);
+    const registry = createNativeWatcherRegistry(mockFactory);
 
     const onState1 = vi.fn();
     const onState2 = vi.fn();
@@ -278,7 +286,7 @@ describe("createWatcherRegistry", () => {
       callCount++;
       return { close: callCount === 1 ? mockClose1 : mockClose2, on: vi.fn() };
     });
-    const registry = createWatcherRegistry(mockFactory);
+    const registry = createNativeWatcherRegistry(mockFactory);
 
     const unsub1 = registry.subscribe("t1", "/path1", () => {}, () => {});
     const unsub2 = registry.subscribe("t2", "/path2", () => {}, () => {});
@@ -291,5 +299,145 @@ describe("createWatcherRegistry", () => {
 
     unsub2();
     expect(mockClose2).toHaveBeenCalledOnce();
+  });
+
+  it("Linux에서는 root를 비재귀 watcher로 즉시 구독한다", () => {
+    const mockFactory: WatcherFactory = vi.fn().mockReturnValue({ close: vi.fn(), on: vi.fn() });
+    const registry = createWatcherRegistry(mockFactory, 50, "linux");
+
+    const unsub = registry.subscribe("t1", "/path", () => {}, () => {});
+
+    expect(mockFactory).toHaveBeenCalledWith("/path", { recursive: false }, expect.any(Function));
+    unsub();
+  });
+
+  it("Linux에서는 조회된 하위 디렉터리만 비재귀 watcher로 추가한다", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-file-watch-"));
+    const childPath = path.join(tempRoot, "src");
+    fs.mkdirSync(childPath);
+    const closes: Array<ReturnType<typeof vi.fn>> = [];
+    const callbacks = new Map<string, (event: string, filename: string | null) => void>();
+    const mockFactory: WatcherFactory = vi.fn().mockImplementation((watchPath, _options, callback) => {
+      const close = vi.fn();
+      closes.push(close);
+      callbacks.set(watchPath, callback);
+      return { close, on: vi.fn() };
+    });
+    const registry = createWatcherRegistry(mockFactory, 50, "linux");
+    const onChange = vi.fn();
+
+    try {
+      const unsub = registry.subscribe("t1", tempRoot, onChange, () => {});
+      await registry.trackDirectory("t1", tempRoot, "src");
+      await registry.trackDirectory("t1", tempRoot, "src");
+
+      expect(mockFactory).toHaveBeenCalledTimes(2);
+      expect(mockFactory).toHaveBeenLastCalledWith(
+        fs.realpathSync(childPath),
+        { recursive: false },
+        expect.any(Function),
+      );
+
+      callbacks.get(fs.realpathSync(childPath))!("change", "file.ts");
+      vi.advanceTimersByTime(100);
+      expect(onChange).toHaveBeenCalledWith("src");
+
+      unsub();
+      expect(closes).toHaveLength(2);
+      expect(closes.every((close) => close.mock.calls.length === 1)).toBe(true);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("Linux에서는 theater 밖으로 해석되는 디렉터리를 감시하지 않는다", async () => {
+    const tempParent = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-file-watch-"));
+    const tempRoot = path.join(tempParent, "theater");
+    const outsidePath = path.join(tempParent, "outside");
+    fs.mkdirSync(tempRoot);
+    fs.mkdirSync(outsidePath);
+    const mockFactory: WatcherFactory = vi.fn().mockReturnValue({ close: vi.fn(), on: vi.fn() });
+    const registry = createWatcherRegistry(mockFactory, 50, "linux");
+
+    try {
+      const unsub = registry.subscribe("t1", tempRoot, () => {}, () => {});
+      await registry.trackDirectory("t1", tempRoot, "../outside");
+
+      expect(mockFactory).toHaveBeenCalledOnce();
+      unsub();
+    } finally {
+      fs.rmSync(tempParent, { recursive: true, force: true });
+    }
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "Linux에서는 theater 밖을 가리키는 심볼릭 링크를 감시하지 않는다",
+    async () => {
+      const tempParent = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-file-watch-"));
+      const tempRoot = path.join(tempParent, "theater");
+      const outsidePath = path.join(tempParent, "outside");
+      fs.mkdirSync(tempRoot);
+      fs.mkdirSync(outsidePath);
+      fs.symlinkSync(outsidePath, path.join(tempRoot, "linked-outside"));
+      const mockFactory: WatcherFactory = vi.fn().mockReturnValue({ close: vi.fn(), on: vi.fn() });
+      const registry = createWatcherRegistry(mockFactory, 50, "linux");
+
+      try {
+        const unsub = registry.subscribe("t1", tempRoot, () => {}, () => {});
+        await registry.trackDirectory("t1", tempRoot, "linked-outside");
+
+        expect(mockFactory).toHaveBeenCalledOnce();
+        unsub();
+      } finally {
+        fs.rmSync(tempParent, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("Linux 하위 watcher error는 root 감시를 유지하고 다음 조회에서 복구한다", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-file-watch-"));
+    fs.mkdirSync(path.join(tempRoot, "src"));
+    const errorCallbacks: Array<(error: Error) => void> = [];
+    const closes: Array<ReturnType<typeof vi.fn>> = [];
+    const mockFactory: WatcherFactory = vi.fn().mockImplementation(() => {
+      const close = vi.fn();
+      closes.push(close);
+      return {
+        close,
+        on: vi.fn().mockImplementation((event: string, callback: (error: Error) => void) => {
+          if (event === "error") errorCallbacks.push(callback);
+        }),
+      };
+    });
+    const registry = createWatcherRegistry(mockFactory, 50, "linux");
+    const onState = vi.fn();
+
+    try {
+      const unsub = registry.subscribe("t1", tempRoot, () => {}, onState);
+      await registry.trackDirectory("t1", tempRoot, "src");
+      errorCallbacks[1]!(new Error("EPERM"));
+
+      expect(closes[0]).not.toHaveBeenCalled();
+      expect(closes[1]).toHaveBeenCalledOnce();
+      expect(onState).toHaveBeenCalledWith("degraded");
+
+      await registry.trackDirectory("t1", tempRoot, "src");
+      expect(mockFactory).toHaveBeenCalledTimes(3);
+      unsub();
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("재귀 watcher 플랫폼에서는 하위 디렉터리 조회가 watcher를 늘리지 않는다", async () => {
+    const mockFactory: WatcherFactory = vi.fn().mockReturnValue({ close: vi.fn(), on: vi.fn() });
+    const registry = createNativeWatcherRegistry(mockFactory);
+    const unsub = registry.subscribe("t1", "/path", () => {}, () => {});
+
+    await registry.trackDirectory("t1", "/path", "src");
+
+    expect(mockFactory).toHaveBeenCalledOnce();
+    expect(mockFactory).toHaveBeenCalledWith("/path", { recursive: true }, expect.any(Function));
+    unsub();
   });
 });

--- a/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
@@ -740,6 +740,52 @@ describe("createWatcherRegistry", () => {
     }
   });
 
+  it("Linux 부모 디렉터리가 교체되면 하위 watcher도 함께 rearm한다", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-file-watch-"));
+    const childPath = path.join(tempRoot, "src");
+    const nestedPath = path.join(childPath, "nested");
+    const movedPath = path.join(tempRoot, "moved");
+    fs.mkdirSync(nestedPath, { recursive: true });
+    const callbacks: Array<(event: string, filename: string | null) => void> = [];
+    const closes: Array<ReturnType<typeof vi.fn>> = [];
+    const mockFactory: WatcherFactory = vi.fn().mockImplementation((_watchPath, _options, callback) => {
+      const close = vi.fn();
+      callbacks.push(callback);
+      closes.push(close);
+      return { close, on: vi.fn() };
+    });
+    const registry = createWatcherRegistry(mockFactory, 50, "linux");
+    const onChange = vi.fn();
+
+    try {
+      const unsub = registry.subscribe("t1", tempRoot, onChange, () => {});
+      await registry.trackDirectory("t1", tempRoot, "src");
+      await registry.trackDirectory("t1", tempRoot, path.join("src", "nested"));
+      const staleNestedCallback = callbacks[2]!;
+
+      fs.renameSync(childPath, movedPath);
+      fs.mkdirSync(nestedPath, { recursive: true });
+      callbacks[1]!("rename", "src");
+
+      await vi.waitFor(() => expect(closes[1]).toHaveBeenCalledOnce());
+      expect(closes[2]).toHaveBeenCalledOnce();
+      await vi.waitFor(() => expect(mockFactory).toHaveBeenCalledTimes(5));
+
+      vi.advanceTimersByTime(100);
+      onChange.mockClear();
+      staleNestedCallback("change", "stale.ts");
+      vi.advanceTimersByTime(100);
+      expect(onChange).not.toHaveBeenCalled();
+
+      callbacks[4]!("change", "fresh.ts");
+      vi.advanceTimersByTime(100);
+      expect(onChange).toHaveBeenCalledWith(path.join("src", "nested"));
+      unsub();
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("재귀 watcher 플랫폼에서는 하위 디렉터리 조회가 watcher를 늘리지 않는다", async () => {
     const mockFactory: WatcherFactory = vi.fn().mockReturnValue({ close: vi.fn(), on: vi.fn() });
     const registry = createNativeWatcherRegistry(mockFactory);

--- a/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
@@ -429,6 +429,41 @@ describe("createWatcherRegistry", () => {
     }
   });
 
+  it("Linux 하위 디렉터리 rename 후 다음 조회에서 watcher를 재등록한다", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-file-watch-"));
+    const childPath = path.join(tempRoot, "src");
+    fs.mkdirSync(childPath);
+    const callbacks: Array<(event: string, filename: string | null) => void> = [];
+    const closes: Array<ReturnType<typeof vi.fn>> = [];
+    const mockFactory: WatcherFactory = vi.fn().mockImplementation((_watchPath, _options, callback) => {
+      const close = vi.fn();
+      callbacks.push(callback);
+      closes.push(close);
+      return { close, on: vi.fn() };
+    });
+    const registry = createWatcherRegistry(mockFactory, 50, "linux");
+    const onChange = vi.fn();
+
+    try {
+      const unsub = registry.subscribe("t1", tempRoot, onChange, () => {});
+      await registry.trackDirectory("t1", tempRoot, "src");
+      fs.rmSync(childPath, { recursive: true });
+      callbacks[1]!("rename", "src");
+
+      expect(closes[0]).not.toHaveBeenCalled();
+      expect(closes[1]).toHaveBeenCalledOnce();
+      vi.advanceTimersByTime(100);
+      expect(onChange).toHaveBeenCalledWith("src");
+
+      fs.mkdirSync(childPath);
+      await registry.trackDirectory("t1", tempRoot, "src");
+      expect(mockFactory).toHaveBeenCalledTimes(3);
+      unsub();
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("재귀 watcher 플랫폼에서는 하위 디렉터리 조회가 watcher를 늘리지 않는다", async () => {
     const mockFactory: WatcherFactory = vi.fn().mockReturnValue({ close: vi.fn(), on: vi.fn() });
     const registry = createNativeWatcherRegistry(mockFactory);

--- a/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/watcher.test.ts
@@ -16,6 +16,7 @@ describe("createWatcherRegistry", () => {
     vi.useFakeTimers();
   });
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
@@ -487,7 +488,7 @@ describe("createWatcherRegistry", () => {
       callbacks[1]!("rename", "src");
 
       expect(closes[0]).not.toHaveBeenCalled();
-      expect(closes[1]).toHaveBeenCalledOnce();
+      await vi.waitFor(() => expect(closes[1]).toHaveBeenCalledOnce());
       vi.advanceTimersByTime(100);
       expect(onChange).toHaveBeenCalledWith("src");
 
@@ -503,6 +504,129 @@ describe("createWatcherRegistry", () => {
       callbacks[2]!("change", "file.ts");
       vi.advanceTimersByTime(100);
       expect(onChange).toHaveBeenCalledWith("src");
+      unsub();
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("Linux 하위 watcher에서 일반 파일 rename은 watcher를 닫지 않는다", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-file-watch-"));
+    const childPath = path.join(tempRoot, "src");
+    fs.mkdirSync(childPath);
+    const callbacks: Array<(event: string, filename: string | null) => void> = [];
+    const closes: Array<ReturnType<typeof vi.fn>> = [];
+    const mockFactory: WatcherFactory = vi.fn().mockImplementation((_watchPath, _options, callback) => {
+      const close = vi.fn();
+      callbacks.push(callback);
+      closes.push(close);
+      return { close, on: vi.fn() };
+    });
+    const registry = createWatcherRegistry(mockFactory, 50, "linux");
+    const onChange = vi.fn();
+
+    try {
+      const unsub = registry.subscribe("t1", tempRoot, onChange, () => {});
+      await registry.trackDirectory("t1", tempRoot, "src");
+      const directoryStats = await fs.promises.stat(childPath);
+      let resolveFirstStat: (stats: fs.Stats) => void = () => {};
+      const firstStat = new Promise<fs.Stats>((resolve) => { resolveFirstStat = resolve; });
+      const statSpy = vi.spyOn(fs.promises, "stat")
+        .mockImplementationOnce(() => firstStat)
+        .mockResolvedValue(directoryStats);
+
+      // src 내부 rename 폭주는 검사를 직렬화하고 src watcher를 유지해야 한다.
+      callbacks[1]!("rename", "file.ts");
+      callbacks[1]!("rename", "other.ts");
+      callbacks[1]!("rename", "third.ts");
+
+      expect(statSpy).toHaveBeenCalledOnce();
+      resolveFirstStat(directoryStats);
+      await vi.waitFor(() => expect(statSpy).toHaveBeenCalledTimes(2));
+      await statSpy.mock.results[1]!.value;
+      await Promise.resolve();
+      expect(closes[1]).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(100);
+      expect(onChange).toHaveBeenCalledWith("src");
+
+      statSpy.mockRestore();
+      unsub();
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("Linux identity 확인이 ENOENT 외 오류로 실패하면 watcher를 유지한다", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-file-watch-"));
+    const childPath = path.join(tempRoot, "src");
+    fs.mkdirSync(childPath);
+    const callbacks: Array<(event: string, filename: string | null) => void> = [];
+    const closes: Array<ReturnType<typeof vi.fn>> = [];
+    const mockFactory: WatcherFactory = vi.fn().mockImplementation((_watchPath, _options, callback) => {
+      const close = vi.fn();
+      callbacks.push(callback);
+      closes.push(close);
+      return { close, on: vi.fn() };
+    });
+    const registry = createWatcherRegistry(mockFactory, 50, "linux");
+
+    try {
+      const unsub = registry.subscribe("t1", tempRoot, () => {}, () => {});
+      await registry.trackDirectory("t1", tempRoot, "src");
+      const accessError = Object.assign(new Error("denied"), { code: "EACCES" });
+      const statSpy = vi.spyOn(fs.promises, "stat").mockRejectedValueOnce(accessError);
+
+      callbacks[1]!("rename", "file.ts");
+
+      expect(statSpy).toHaveBeenCalledOnce();
+      await statSpy.mock.results[0]!.value.catch(() => undefined);
+      await Promise.resolve();
+      expect(closes[1]).not.toHaveBeenCalled();
+
+      statSpy.mockRestore();
+      unsub();
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("Linux 하위 디렉터리가 다른 inode로 교체되면 watcher를 rearm한다", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-file-watch-"));
+    const childPath = path.join(tempRoot, "src");
+    const replacementPath = path.join(tempRoot, "replacement");
+    fs.mkdirSync(childPath);
+    fs.mkdirSync(replacementPath);
+    const callbacks: Array<(event: string, filename: string | null) => void> = [];
+    const closes: Array<ReturnType<typeof vi.fn>> = [];
+    const mockFactory: WatcherFactory = vi.fn().mockImplementation((_watchPath, _options, callback) => {
+      const close = vi.fn();
+      callbacks.push(callback);
+      closes.push(close);
+      return { close, on: vi.fn() };
+    });
+    const registry = createWatcherRegistry(mockFactory, 50, "linux");
+    const onChange = vi.fn();
+
+    try {
+      const unsub = registry.subscribe("t1", tempRoot, onChange, () => {});
+      await registry.trackDirectory("t1", tempRoot, "src");
+
+      // 경로는 계속 존재하지만 다른 inode로 교체되면 기존 watcher는 무효하다.
+      fs.renameSync(replacementPath, childPath);
+      callbacks[1]!("rename", "src");
+
+      expect(closes[0]).not.toHaveBeenCalled();
+      await vi.waitFor(() => expect(closes[1]).toHaveBeenCalledOnce());
+      await vi.waitFor(() => expect(mockFactory).toHaveBeenCalledTimes(3));
+
+      vi.advanceTimersByTime(100);
+      expect(onChange).toHaveBeenCalledWith("src");
+
+      onChange.mockClear();
+      callbacks[2]!("change", "file.ts");
+      vi.advanceTimersByTime(100);
+      expect(onChange).toHaveBeenCalledWith("src");
+
       unsub();
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- avoid Linux recursive `fs.watch` startup traversal that blocks Fleet Console
- watch the Theater root and listed directories non-recursively with containment and resource limits
- preserve recursive watcher behavior on Windows and macOS

## Test Plan
- [x] `pnpm --filter @fleet-plugins/file-explorer test`
- [x] `pnpm --filter @fleet-plugins/file-explorer typecheck`
- [x] `pnpm --filter @fleet-plugins/file-explorer build`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Linux watcher latency and live-event probe
- [x] Isolated Fleet Console browser E2E
- [x] `.changelog.d/pr-326.md` has valid grouped syntax and bilingual summaries
- [x] `node scripts/compile-changelog-fragments.mjs --check`