### PR TITLE
fix(console): focus target Operation terminal after palette navigation

### DIFF
--- a/.changelog.d/pr-327.md
+++ b/.changelog.d/pr-327.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Move keyboard focus to the target Operation terminal after command palette navigation, so it accepts typing right away instead of leaving focus on the previously focused control.
+  ko: 커맨드 팔레트로 Operation을 이동하면 대상 터미널이 곧바로 키보드 포커스를 받아, 이전에 눌렀던 컨트롤에 포커스가 남지 않고 즉시 입력할 수 있습니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -39,6 +39,7 @@ interface ContextMenuRequest {
 
 interface PluginOperationRendererProps {
   readonly active: boolean;
+  readonly keyboardFocusRequestId?: number;
   readonly capabilities: ReturnType<typeof createHostCapabilities>;
   readonly geometry: OperationGeometry;
   readonly operation: OperationNode;
@@ -225,6 +226,9 @@ export function OperationsCanvas({
             && canvas.viewport.y + frameGeometry.y * effectiveZoom < TITLEBAR_OUTSET_PX * effectiveZoom;
           return renderPluginOperation(operation, {
             active: activePluginOperationId === operation.id,
+            keyboardFocusRequestId: state.keyboardFocusRequest?.operationId === operation.id
+              ? state.keyboardFocusRequest.requestId
+              : 0,
             geometry: frameGeometry,
             topEdge,
             operationKindRegistry,
@@ -437,6 +441,7 @@ function operationAccentFromNode(operation: OperationNode): string | null {
 
 function renderPluginOperation(operation: OperationNode, options: {
   readonly active: boolean;
+  readonly keyboardFocusRequestId: number;
   readonly geometry: OperationGeometry;
   readonly operationKindRegistry: readonly OperationKindDescriptor[];
   readonly status?: OperationActivity;
@@ -501,6 +506,7 @@ function renderPluginOperation(operation: OperationNode, options: {
         <PluginErrorBoundary fallback={<div className="fc-plugin-error">Plugin operation failed to render.</div>}>
           <PluginOperationRenderer
             active={options.active}
+            keyboardFocusRequestId={options.keyboardFocusRequestId}
             capabilities={capabilities}
             geometry={geometry}
             operation={operation}
@@ -541,6 +547,7 @@ function renderPluginOperation(operation: OperationNode, options: {
 
 function PluginOperationRenderer({
   active,
+  keyboardFocusRequestId,
   capabilities,
   geometry,
   operation,
@@ -561,6 +568,7 @@ function PluginOperationRenderer({
     operation,
     geometry,
     active,
+    ...(keyboardFocusRequestId === undefined ? {} : { keyboardFocusRequestId }),
     zoom: viewportZoom,
     theme,
     api: capabilities.api,

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -59,6 +59,8 @@ export function OperationSearch({ state }: OperationSearchProps) {
   if (!state.operationSearchOpen) return null;
 
   const selectEntry = (operationId: string) => {
+    // 선택은 대상 Operation으로 키보드 포커스를 넘기므로 닫힘 cleanup이 이전 UI 포커스를 되찾지 않게 한다.
+    previousFocusRef.current = null;
     // 최대화 해제는 이동 경로(operations.tsx의 pendingOperationFocus 소비)에 위임한다 — 최대화 중이면 유지·교체.
     focusOperation(operationId);
     navigate("/operations");

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -14,7 +14,7 @@ import { RightRail } from "../rail/right-rail.js";
 import { OperationsSideBar } from "../sidebar/operations-side-bar.js";
 import { CodexReadingSheet } from "../components/codex-reading-sheet.js";
 import { shouldHandleOperationsKeyboardShortcut } from "../components/keyboard-shortcuts-dialog.js";
-import { beginAddTheater, cancelAddTheater, compareOperationCreatedAt, completeAddTheater, consumeOperationFocus, failAddTheater, focusCycleOperationIds, focusOperation, getState, hydrateGroups, hydrateOperations, hydrateTheaters, nextOperationId, removeTheater, setActiveOperation, setActiveTheater, sortOperationsByOrder } from "../store.js";
+import { beginAddTheater, cancelAddTheater, compareOperationCreatedAt, completeAddTheater, consumeOperationFocus, failAddTheater, focusCycleOperationIds, focusOperation, getState, hydrateGroups, hydrateOperations, hydrateTheaters, nextOperationId, removeTheater, requestOperationKeyboardFocus, setActiveOperation, setActiveTheater, sortOperationsByOrder } from "../store.js";
 import type { ConsoleState, OperationNode } from "../types.js";
 
 const STABLE_RAIL_API: ClientApiCapability = createHostCapabilities().api;
@@ -373,6 +373,7 @@ async function routeOperationFocus(operationId: string, operationKinds: readonly
   if (currentCompanionOperationId !== null) {
     if (currentCompanionOperationId === operationId) {
       setActiveOperation(operationId);
+      requestOperationKeyboardFocus(operationId);
       return;
     }
     const operation = getState().operations.find((candidate) => candidate.id === operationId);
@@ -396,26 +397,32 @@ async function routeOperationFocus(operationId: string, operationKinds: readonly
       if (getFormationView()) {
         restoreOperation(operationId);
         setActiveOperation(operationId);
+        requestOperationKeyboardFocus(operationId);
         return;
       }
       focusMap();
+      requestOperationKeyboardFocus(operationId);
       return;
     }
     setActiveOperation(operationId);
     setCompanionOperationId(operationId);
+    requestOperationKeyboardFocus(operationId);
     return;
   }
   if (getMaximizedOperationId() !== null) {
     setActiveOperation(operationId);
     setMaximizedOperationId(operationId);
+    requestOperationKeyboardFocus(operationId);
     return;
   }
   if (getFormationView()) {
     restoreOperation(operationId);
     setActiveOperation(operationId);
+    requestOperationKeyboardFocus(operationId);
     return;
   }
   focusMap();
+  requestOperationKeyboardFocus(operationId);
 }
 
 function sortedTheaterOperations(state: ConsoleState): readonly OperationNode[] {

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -75,6 +75,7 @@ let state: ConsoleState = {
   onboardingOpen: false,
   bootstrapped: false,
   pendingOperationFocus: null,
+  keyboardFocusRequest: null,
   operationNotifications: {},
   notificationPreferences: readStoredNotificationPreferences(),
   codexReader: null,
@@ -302,12 +303,20 @@ export function focusOperation(operationId: string): void {
     pendingOperationFocus: operationId,
     operationNotifications: removeNotificationForOperation(state.operationNotifications, operationId),
   });
-  window.dispatchEvent(new CustomEvent("fleet-console:focus-operation", { detail: { operationId } }));
 }
 
 export function consumeOperationFocus(): void {
   if (state.pendingOperationFocus === null) return;
   setState({ pendingOperationFocus: null });
+}
+
+export function requestOperationKeyboardFocus(operationId: string): void {
+  setState({
+    keyboardFocusRequest: {
+      operationId,
+      requestId: (state.keyboardFocusRequest?.requestId ?? 0) + 1,
+    },
+  });
 }
 
 export function nextOperationId(order: readonly string[], currentId: string | null, delta: number): string | null {

--- a/runtime/fleet-console/core/client/src/types.ts
+++ b/runtime/fleet-console/core/client/src/types.ts
@@ -202,6 +202,7 @@ export interface ConsoleState {
   readonly onboardingOpen: boolean;
   readonly bootstrapped: boolean;
   readonly pendingOperationFocus: string | null;
+  readonly keyboardFocusRequest: { readonly operationId: string; readonly requestId: number } | null;
   readonly operationNotifications: Readonly<Record<string, OperationNotification>>;
   readonly notificationPreferences: NotificationPreferences;
   readonly codexReader: CodexReaderRequest | null;

--- a/runtime/fleet-console/sdk/plugin/types.ts
+++ b/runtime/fleet-console/sdk/plugin/types.ts
@@ -117,6 +117,13 @@ export interface OperationContext {
 
 export interface OperationRenderContext extends OperationContext {
   readonly active: boolean;
+  /**
+   * Requests DOM keyboard focus for the current Operation's primary body.
+   * This is not canvas position, active state, or persistent state: a changed value means a new focus request.
+   * `undefined` denotes an older host and `0` denotes no request; consumers must only detect change, not compare order.
+   * Plugins cannot increment this host-owned value themselves.
+   */
+  readonly keyboardFocusRequestId?: number;
   readonly geometry: OperationGeometry;
   readonly operation: OperationNode;
   readonly zoom: number;

--- a/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
+++ b/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
@@ -16,10 +16,10 @@ vi.mock("../core/client/src/plugin-registry.js", () => ({
       pluginId: "test-plugin",
       type: "shell",
       title: "Test",
-      render: ({ operationId, companionsOpen, onRequestCompanions }: { readonly operationId: string; readonly companionsOpen?: boolean; readonly onRequestCompanions?: (open: boolean) => void }) => createElement("button", { "data-plugin-operation": operationId, "data-companions-open": String(companionsOpen), onClick: () => onRequestCompanions?.(!companionsOpen) }, "Toggle companions"),
+      render: ({ operationId, companionsOpen, keyboardFocusRequestId, onRequestCompanions }: { readonly operationId: string; readonly companionsOpen?: boolean; readonly keyboardFocusRequestId?: number; readonly onRequestCompanions?: (open: boolean) => void }) => createElement("button", { "data-plugin-operation": operationId, "data-companions-open": String(companionsOpen), "data-keyboard-focus-request": keyboardFocusRequestId, onClick: () => onRequestCompanions?.(!companionsOpen) }, "Toggle companions"),
       companions: [
-        { id: "chat", title: "Chat", render: ({ companionsOpen }: { readonly companionsOpen?: boolean }) => createElement("div", { "data-test-companion": "chat", "data-companions-open": String(companionsOpen) }) },
-        { id: "artifacts", title: "Artifacts", hideCaption: true, render: ({ companionsOpen }: { readonly companionsOpen?: boolean }) => createElement("div", { "data-test-companion": "artifacts", "data-companions-open": String(companionsOpen) }) },
+        { id: "chat", title: "Chat", render: ({ companionsOpen, keyboardFocusRequestId }: { readonly companionsOpen?: boolean; readonly keyboardFocusRequestId?: number }) => createElement("div", { "data-test-companion": "chat", "data-companions-open": String(companionsOpen), "data-keyboard-focus-request": keyboardFocusRequestId }) },
+        { id: "artifacts", title: "Artifacts", hideCaption: true, render: ({ companionsOpen, keyboardFocusRequestId }: { readonly companionsOpen?: boolean; readonly keyboardFocusRequestId?: number }) => createElement("div", { "data-test-companion": "artifacts", "data-companions-open": String(companionsOpen), "data-keyboard-focus-request": keyboardFocusRequestId }) },
       ],
     }],
     settingsSections: [],
@@ -211,10 +211,16 @@ describe("CanvasMinimap collapse behavior", () => {
   });
 
   it("passes the companion callback through render context and restores Map geometry on exit", () => {
-    renderOperationsCanvas();
+    renderOperationsCanvas({
+      ...CANVAS_STATE,
+      keyboardFocusRequest: { operationId: "operation", requestId: 7 },
+    });
     const targetFrame = document.querySelector<HTMLElement>('[aria-label="Operation Minimap boundary"]');
     const targetBody = document.querySelector<HTMLElement>('[data-plugin-operation="operation"]');
     const peer = document.querySelector<HTMLElement>('[aria-label="Operation Peer"]');
+
+    expect(targetBody?.getAttribute("data-keyboard-focus-request")).toBe("7");
+    expect(document.querySelector('[data-plugin-operation="peer"]')?.getAttribute("data-keyboard-focus-request")).toBe("0");
 
     act(() => targetBody?.click());
 
@@ -222,6 +228,7 @@ describe("CanvasMinimap collapse behavior", () => {
     expect(document.querySelector(".operations-canvas")?.classList.contains("is-companion-layout")).toBe(true);
     expect(document.querySelectorAll(".canvas-companion-frame")).toHaveLength(2);
     expect(document.querySelectorAll('[data-test-companion][data-companions-open="true"]')).toHaveLength(2);
+    expect([...document.querySelectorAll('[data-test-companion]')].every((element) => !element.hasAttribute("data-keyboard-focus-request"))).toBe(true);
     expect(document.querySelector('[data-plugin-operation="operation"]')).toBe(targetBody);
     expect(getComputedStyle(peer!).visibility).toBe("hidden");
     expect(Number.parseFloat(targetFrame?.style.width ?? "0")).toBeCloseTo((900 - 16) / 3, 0);
@@ -406,6 +413,7 @@ const CANVAS_STATE: ConsoleState = {
   onboardingOpen: false,
   bootstrapped: true,
   pendingOperationFocus: null,
+  keyboardFocusRequest: null,
   operationNotifications: {},
   notificationPreferences: { globalMute: false, dnd: false, mutedTheaterIds: {} },
   codexReader: null,

--- a/runtime/fleet-console/tests/operation-focus.test.ts
+++ b/runtime/fleet-console/tests/operation-focus.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { focusCycleOperationIds, nextOperationId } from "../core/client/src/store.js";
+import { focusCycleOperationIds, getState, nextOperationId, requestOperationKeyboardFocus, setState } from "../core/client/src/store.js";
 import type { OperationGroup, OperationNode } from "../core/client/src/types.js";
 
 function makeOperation(id: string, groupId: string | null = null, createdAt = 1): OperationNode {
@@ -87,4 +87,19 @@ describe("nextOperationId — Alt+←/→ focus cycle", () => {
     expect(nextOperationId(order, null, -1)).toBe("ungrouped");
   });
 
+});
+
+describe("Operation keyboard focus requests", () => {
+  it("increments exactly once per request, including repeated requests for the same Operation", () => {
+    setState({ keyboardFocusRequest: null });
+
+    requestOperationKeyboardFocus("same-operation");
+    expect(getState().keyboardFocusRequest).toEqual({ operationId: "same-operation", requestId: 1 });
+
+    requestOperationKeyboardFocus("same-operation");
+    expect(getState().keyboardFocusRequest).toEqual({ operationId: "same-operation", requestId: 2 });
+
+    requestOperationKeyboardFocus("other-operation");
+    expect(getState().keyboardFocusRequest).toEqual({ operationId: "other-operation", requestId: 3 });
+  });
 });

--- a/runtime/fleet-console/tests/operation-search-focus.test.tsx
+++ b/runtime/fleet-console/tests/operation-search-focus.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OperationSearch } from "../core/client/src/components/operation-search.js";
+import { useConsoleState } from "../core/client/src/hooks/use-store.js";
+import { setState } from "../core/client/src/store.js";
+
+let container: HTMLDivElement | null = null;
+let previousFocus: HTMLButtonElement | null = null;
+let root: Root | null = null;
+let scrollIntoViewDescriptor: PropertyDescriptor | undefined;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  window.localStorage.clear();
+  scrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollIntoView");
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", { configurable: true, value: vi.fn() });
+
+  previousFocus = document.createElement("button");
+  previousFocus.textContent = "Previous control";
+  container = document.createElement("div");
+  document.body.append(previousFocus, container);
+  previousFocus.focus();
+
+  setState({
+    activeTheaterId: "theater-a",
+    activeOperationId: null,
+    theaters: [{
+      id: "theater-a",
+      label: "Theater A",
+      createdAt: "2026-07-20T00:00:00.000Z",
+      lastOpenedAt: "2026-07-20T00:00:00.000Z",
+      hasWiki: false,
+      activeAdmiralCount: 0,
+    }],
+    operations: [{
+      id: "operation-a",
+      theaterId: "theater-a",
+      type: "shell",
+      pluginId: "terminal",
+      title: "Operation A",
+      payload: {},
+      geometry: null,
+      ts: { createdAt: 1, updatedAt: 1 },
+    }],
+    operationSearchOpen: true,
+    pendingOperationFocus: null,
+    keyboardFocusRequest: null,
+  });
+
+  root = createRoot(container);
+  act(() => root!.render(createElement(MemoryRouter, null, createElement(SearchHarness))));
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  if (scrollIntoViewDescriptor) {
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", scrollIntoViewDescriptor);
+  } else {
+    Reflect.deleteProperty(HTMLElement.prototype, "scrollIntoView");
+  }
+  document.body.replaceChildren();
+  root = null;
+  container = null;
+  previousFocus = null;
+  vi.restoreAllMocks();
+});
+
+describe("Operation search focus handoff", () => {
+  it("does not restore the previous focus after selecting an Operation", () => {
+    const restoreFocus = vi.spyOn(previousFocus!, "focus");
+    const result = document.querySelector<HTMLButtonElement>('[role="option"]');
+    expect(result).not.toBeNull();
+
+    act(() => result!.click());
+
+    expect(restoreFocus).not.toHaveBeenCalled();
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it("restores the previous focus after Escape cancellation", () => {
+    const restoreFocus = vi.spyOn(previousFocus!, "focus");
+    const input = document.querySelector<HTMLInputElement>("#operation-search-input");
+    expect(input).not.toBeNull();
+
+    act(() => input!.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })));
+
+    expect(restoreFocus).toHaveBeenCalledOnce();
+    expect(document.activeElement).toBe(previousFocus);
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+  });
+});
+
+function SearchHarness() {
+  return createElement(OperationSearch, { state: useConsoleState() });
+}

--- a/runtime/fleet-console/tests/operation-search.test.ts
+++ b/runtime/fleet-console/tests/operation-search.test.ts
@@ -56,6 +56,7 @@ function makeState(operations: readonly OperationNode[], theaters: readonly Thea
     onboardingOpen: false,
     bootstrapped: false,
     pendingOperationFocus: null,
+    keyboardFocusRequest: null,
     operationNotifications: {},
     notificationPreferences: { globalMute: false, dnd: false, mutedTheaterIds: {} },
     codexReader: null,

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -100,7 +100,7 @@ beforeEach(() => {
   clearCompanionOperationId();
   clearFormationView();
   loadForTheater(null);
-  setState({ activeOperationId: null, activeTheaterId: null, groups: [], operations: [], operationsHydrated: false, theaters: [] });
+  setState({ activeOperationId: null, activeTheaterId: null, groups: [], keyboardFocusRequest: null, operations: [], operationsHydrated: false, theaters: [] });
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -506,6 +506,7 @@ describe("Operations boot minimization", () => {
       await Promise.resolve();
     });
     expect(getCompanionOperationId()).toBe("first");
+    expect(getState().keyboardFocusRequest).toBeNull();
 
     await act(async () => {
       thirdReady.resolve(true);
@@ -513,6 +514,7 @@ describe("Operations boot minimization", () => {
       await Promise.resolve();
     });
     expect(getCompanionOperationId()).toBe("third");
+    expect(getState().keyboardFocusRequest).toEqual({ operationId: "third", requestId: 1 });
   });
 
   it("discards an asynchronous retarget after Analyze exits and reopens", async () => {

--- a/runtime/fleet-console/tests/reduce.test.ts
+++ b/runtime/fleet-console/tests/reduce.test.ts
@@ -70,6 +70,7 @@ function makeConsoleSnap(patch: Partial<ConsoleState> = {}): ConsoleState {
     onboardingOpen: false,
     bootstrapped: true,
     pendingOperationFocus: null,
+    keyboardFocusRequest: null,
     operationNotifications: {},
     notificationPreferences: { globalMute: false, dnd: false, mutedTheaterIds: {} },
     ...patch,

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -427,6 +427,7 @@ function AgentOperationView({ context }: { readonly context: OperationRenderCont
         ticketPath={AGENT_TICKET_PATH}
         wsPath={TERMINAL_WS_PATH}
         active={context.active}
+        keyboardFocusRequestId={context.keyboardFocusRequestId}
         zoom={context.zoom}
         theme={context.theme}
         onExit={() => removeSession(session.sessionId)}

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -23,6 +23,7 @@ export interface TerminalSurfaceProps {
   readonly onExit?: () => void;
   // 이 터미널이 활성(선택)으로 전환될 때 마우스 클릭 없이 키보드 포커스를 잡아준다(Map 검색 이동 등).
   readonly active?: boolean;
+  readonly keyboardFocusRequestId?: number;
   // 맵 캔버스의 줌 배율(viewport.zoom). 캔버스 외 셸 패널 사용처는 기본 1.
   // 캔버스가 부모에 transform:scale(zoom)을 걸면 xterm의 마우스 셀 좌표 계산이 scale을 보정하지 못해
   // zoom≠1에서 커서/선택 위치가 어긋난다(분자=scale 반영 화면거리, 분모=scale 미반영 cellWidth). 이를
@@ -114,7 +115,7 @@ const CARBON_TERMINAL_THEME: ITheme = {
   brightWhite: "oklch(95% 0.003 250)",
 };
 
-export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "instrument", onExit, active, zoom = 1 }: TerminalSurfaceProps) {
+export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "instrument", onExit, active, keyboardFocusRequestId, zoom = 1 }: TerminalSurfaceProps) {
   const activeTheme = theme;
   const { renderer: terminalRenderer, font: terminalFontSettings } = useTerminalPrefs();
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -138,6 +139,8 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
   // 터미널 인스턴스는 심볼 폰트 선대기 때문에 비동기로 생성된다. 같은 커밋에서 이미 실행된
   // WebGL/테마/폰트 effect는 null 터미널을 보고 건너뛰므로, 생성 완료를 epoch로 알려 재실행시킨다.
   const [mountedTerminalEpoch, setMountedTerminalEpoch] = useState(0);
+  // 포커스 요청은 xterm 생성만으로는 충분하지 않고 입력 transport가 시작된 뒤에 처리해야 한다.
+  const [inputReadyEpoch, setInputReadyEpoch] = useState(0);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -250,6 +253,7 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
         if (disposed) return;
         fitResizeAndRefresh();
         connection.start();
+        setInputReadyEpoch((epoch) => epoch + 1);
         // 마운트(셸 열기·세션 전환) 직후 xterm에 포커스를 줘 마우스 클릭 없이 바로 입력되게 한다.
         // 단, Map의 비활성 패널(active===false)은 건너뛴다 — 여러 패널이 마운트되며 포커스를 다투지 않게 한다.
         // 단일 셸 터미널(active===undefined)은 기존대로 포커스한다.
@@ -301,14 +305,15 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
     };
   }, [operationId, ticketPath, wsPath]);
 
-  // 활성 전환 시(예: Map 검색으로 이동·확대된 직후) 이미 마운트된 xterm에 포커스를 다시 주고
-  // 기존 contract대로 bottom following을 명시적으로 재개한다. 비활성 전환에서는 scheduler 속도만 낮춘다.
+  // 활성 전환 시 이미 마운트된 xterm에 포커스를 다시 주고 기존 contract대로 bottom following을 재개한다.
+  // keyboard request는 동일 Operation 재선택 시 active 불변을, input-ready epoch는 비동기 마운트 갭을 대응한다.
+  // 비활성 전환에서는 scheduler 속도만 낮추며 focus 요청도 소비하지 않는다.
   useEffect(() => {
     outputSchedulerRef.current?.setActive(active !== false);
     if (!active) return;
     terminalRef.current?.focus();
     scrollFollowRef.current?.resumeFollowing();
-  }, [active]);
+  }, [active, keyboardFocusRequestId, inputReadyEpoch]);
 
   // Renderer changes only attach/detach the WebGL addon; the live terminal and websocket stay intact.
   useEffect(() => {

--- a/runtime/fleet-plugins/terminal/client/shell/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/shell/index.tsx
@@ -42,6 +42,7 @@ function ShellOperationView({ context }: { readonly context: OperationRenderCont
     <TerminalSurface
       operationId={context.operationId}
       active={context.active}
+      keyboardFocusRequestId={context.keyboardFocusRequestId}
       zoom={context.zoom}
       ticketPath={SHELL_TICKET_PATH}
       wsPath={SHELL_WS_PATH}

--- a/runtime/fleet-plugins/terminal/tests/terminal-surface-focus.test.tsx
+++ b/runtime/fleet-plugins/terminal/tests/terminal-surface-focus.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const terminalMocks = vi.hoisted(() => ({
+  focus: vi.fn(),
+  resumeFollowing: vi.fn(),
+  setActive: vi.fn(),
+  start: vi.fn(),
+  waitForSymbols: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class Terminal {
+    readonly buffer = { active: { baseY: 0, viewportY: 0 } };
+    readonly cols = 80;
+    readonly rows = 24;
+    readonly unicode = { activeVersion: "" };
+    readonly options: Record<string, unknown> = {};
+    readonly focus = terminalMocks.focus;
+    attachCustomKeyEventHandler() {}
+    dispose() {}
+    getSelection() { return ""; }
+    input() {}
+    loadAddon() {}
+    onData() { return { dispose() {} }; }
+    open() {}
+    refresh() {}
+    scrollToBottom() {}
+    scrollToLine() {}
+    write(_data: Uint8Array, callback?: () => void) { callback?.(); }
+  },
+}));
+vi.mock("@xterm/addon-fit", () => ({ FitAddon: class FitAddon { fit() {} } }));
+vi.mock("@xterm/addon-unicode11", () => ({ Unicode11Addon: class Unicode11Addon {} }));
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: class WebglAddon {
+    dispose() {}
+    onContextLoss() {}
+  },
+}));
+vi.mock("../client/shared/ime-shift-enter.js", () => ({
+  createImeShiftEnterHandler: () => ({
+    dispose() {},
+    handleKeyEvent: () => true,
+    onCompositionCancel() {},
+    onCompositionEnd() {},
+    onCompositionStart() {},
+  }),
+}));
+vi.mock("../client/shared/symbols-font.js", () => ({ waitForSymbolsNerdFontMono: terminalMocks.waitForSymbols }));
+vi.mock("../client/shared/terminal-connection.js", () => ({
+  createTerminalConnection: () => ({ dispose() {}, resize() {}, start: terminalMocks.start }),
+}));
+vi.mock("../client/shared/terminal-copy-on-select.js", () => ({
+  createTerminalCopyOnSelect: () => ({ dispose() {} }),
+}));
+vi.mock("../client/shared/terminal-prefs-store.js", () => ({
+  useTerminalPrefs: () => ({ renderer: "dom", font: { family: "monospace", size: 14 } }),
+}));
+vi.mock("../client/shared/terminal-scroll-follow.js", () => ({
+  createTerminalScrollFollow: () => ({
+    dispose() {},
+    preserveAfterGeometryChange: (action: () => void) => action(),
+    recordUserViewportChange() {},
+    restoreAfterOutputParsing() {},
+    resumeFollowing: terminalMocks.resumeFollowing,
+  }),
+}));
+vi.mock("../client/shared/windows-selection-copy.js", () => ({
+  createWindowsSelectionCopyHandler: () => ({ handleKeyEvent: () => true }),
+}));
+
+import { TerminalSurface } from "../client/shared/terminal-surface.js";
+
+let container: HTMLDivElement | null = null;
+let fontsDescriptor: PropertyDescriptor | undefined;
+let resizeObserverDescriptor: PropertyDescriptor | undefined;
+let root: Root | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  terminalMocks.focus.mockClear();
+  terminalMocks.resumeFollowing.mockClear();
+  terminalMocks.setActive.mockClear();
+  terminalMocks.start.mockClear();
+  terminalMocks.waitForSymbols.mockReset();
+  terminalMocks.waitForSymbols.mockResolvedValue();
+  fontsDescriptor = Object.getOwnPropertyDescriptor(document, "fonts");
+  Object.defineProperty(document, "fonts", {
+    configurable: true,
+    value: { ready: Promise.resolve() },
+  });
+  resizeObserverDescriptor = Object.getOwnPropertyDescriptor(globalThis, "ResizeObserver");
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    configurable: true,
+    value: class ResizeObserver {
+      disconnect() {}
+      observe() {}
+    },
+  });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  if (fontsDescriptor) {
+    Object.defineProperty(document, "fonts", fontsDescriptor);
+  } else {
+    Reflect.deleteProperty(document, "fonts");
+  }
+  if (resizeObserverDescriptor) {
+    Object.defineProperty(globalThis, "ResizeObserver", resizeObserverDescriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, "ResizeObserver");
+  }
+  container?.remove();
+  container = null;
+  root = null;
+});
+
+describe("TerminalSurface keyboard focus requests", () => {
+  it("defers a pre-mount focus request until the terminal input transport is ready", async () => {
+    const symbolsReady = deferred<void>();
+    const documentFontsReady = deferred<void>();
+    const callOrder: string[] = [];
+    terminalMocks.waitForSymbols.mockReturnValueOnce(symbolsReady.promise);
+    terminalMocks.start.mockImplementation(() => callOrder.push("start"));
+    terminalMocks.focus.mockImplementation(() => callOrder.push("focus"));
+    Object.defineProperty(document, "fonts", {
+      configurable: true,
+      value: { ready: documentFontsReady.promise },
+    });
+
+    await renderSurface(true, 1);
+    await renderSurface(true, 2);
+    expect(terminalMocks.focus).not.toHaveBeenCalled();
+
+    await resolveAndFlush(symbolsReady);
+
+    expect(terminalMocks.start).not.toHaveBeenCalled();
+    expect(terminalMocks.focus).not.toHaveBeenCalled();
+
+    await resolveAndFlush(documentFontsReady);
+
+    expect(callOrder[0]).toBe("start");
+    // One call is the mount fallback and one proves the queued request survived via inputReadyEpoch.
+    expect(terminalMocks.focus).toHaveBeenCalledTimes(2);
+  });
+
+  it("refocuses when only keyboardFocusRequestId changes while active stays true", async () => {
+    await renderSurface(true, 1);
+    const focusCallsAfterMount = terminalMocks.focus.mock.calls.length;
+
+    await renderSurface(true, 2);
+
+    expect(terminalMocks.focus).toHaveBeenCalledTimes(focusCallsAfterMount + 1);
+    expect(terminalMocks.resumeFollowing).toHaveBeenCalled();
+  });
+
+  it("does not focus when keyboardFocusRequestId changes while inactive", async () => {
+    await renderSurface(false, 1);
+    expect(terminalMocks.focus).not.toHaveBeenCalled();
+
+    await renderSurface(false, 2);
+
+    expect(terminalMocks.focus).not.toHaveBeenCalled();
+  });
+});
+
+async function renderSurface(active: boolean, keyboardFocusRequestId: number): Promise<void> {
+  await act(async () => {
+    root!.render(createElement(TerminalSurface, {
+      operationId: "operation-a",
+      ticketPath: "/ticket",
+      wsPath: "/terminal",
+      active,
+      keyboardFocusRequestId,
+    }));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T | PromiseLike<T>) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>["resolve"];
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+async function resolveAndFlush(gate: Deferred<void>): Promise<void> {
+  await act(async () => {
+    gate.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}


### PR DESCRIPTION
## Summary

- cmd+K/ctrl+K 커맨드 팔레트로 Operation을 이동해도 대상 터미널이 키보드 포커스를 받지 못해 바로 타이핑할 수 없던 문제를 고칩니다. 팔레트가 닫힐 때 이유를 가리지 않고 이전 포커스를 되돌리던 동작과, 터미널이 포커스를 되찾는 effect가 비동기 xterm 마운트와 `active` 불변 상황을 감지하지 못하던 갭이 겹친 결과였습니다.
- core가 `OperationRenderContext.keyboardFocusRequestId`(optional)로 포커스 인계를 명시 전달합니다. 요청은 `routeOperationFocus`의 성공 종료 지점에서만 발행되어, 패널 복원과 Formation/Map 전환이 끝난 뒤에 소비됩니다. 팔레트뿐 아니라 사이드바 칩·Alt 순환·Alerts 이동도 같은 신호를 공유합니다.
- 팔레트는 **선택** 경로에서만 포커스 복원을 억제하고, ESC·스크림 취소는 WAI-ARIA Dialog 규범대로 이전 포커스를 그대로 복원합니다.
- 터미널 focus effect는 요청 id와 함께 `connection.start()` 이후 오르는 input-ready epoch를 구독합니다. 인스턴스 생성 시점(`mountedTerminalEpoch`)에 포커스를 걸면 입력 transport가 열리기 전이라 첫 타건이 유실될 수 있습니다.
- 구독자가 없던 `fleet-console:focus-operation` window 이벤트를 제거했습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run` (타깃 6 파일) — 68 tests 통과
- [x] terminal 플러그인 자체 러너 — 31 files, 282 tests 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` 통과
- [x] 헤드리스 실측(agent-browser, 격리 Console): 버튼에 포커스가 있는 상태에서 팔레트로 이동 시 터미널 도달 — 같은 Operation 재선택 5ms, 다른 Operation 3ms (수정 전에는 3ms만에 원래 버튼으로 되돌아가 영구히 머무름)
- [x] ESC 취소 시 이전 버튼으로 2ms 복원 — 접근성 회귀 없음
- [x] Changelog fragment — `.changelog.d/pr-327.md` (제품/섹션 문법, 이중언어 요약, `compile-changelog-fragments.mjs --check` 검증 완료)

## Notes

- typecheck 실패 10건은 canary baseline과 동일한 선존 문제이며 이번 변경 파일과 무관합니다(stash 대조로 개수·파일 일치 확인).
- 새로고침 직후 활성 Operation이 없는 상태에서의 첫 팔레트 이동이 Operation을 활성화하지 못하는 별개의 선존 결함을 발견했습니다. baseline에서도 동일 재현되어 별건 PR로 분리하기로 했습니다.
- Alt+←/→ 순환에서 포커스 요청이 두 번 발행되는 점을 QA가 지적했으나, 원인인 route 이중 실행이 선존 구조이고 `focus()`가 멱등이라 이번 스코프에서 제외했습니다.
- WebSocket open 이전 입력 버퍼링 부재는 선존 결함으로 분류해 제외했습니다. 이번 변경은 포커스 시점만 입력 준비 이후로 되돌립니다.