### PR TITLE
feat(fleet-console): support Kimi provider default model selection

### DIFF
--- a/.changelog.d/pr-328.md
+++ b/.changelog.d/pr-328.md
@@ -1,0 +1,12 @@
+### fleet-plugin
+#### Added
+- [fleet-console] Add a Kimi provider default model and effort selection to Settings for Kimi, applied to newly launched Kimi sessions that carry no explicit carrier model.
+  ko: Settings for Kimi에 Kimi 프로바이더 기본 모델·effort 선택을 추가하여, 캐리어 모델을 명시하지 않은 새 Kimi 세션에 적용합니다.
+
+### fleet-core
+#### Added
+- [core-agent] [core-infra] [fleet-admiral] [fleet-carriers] Derive the Kimi launch environment (model slots including fable, subagent model, auto-compact window, and effort level) from the selected provider default model, used only when no per-carrier model is set.
+  ko: 선택한 프로바이더 기본 모델에서 Kimi 런치 환경(fable 포함 모델 슬롯, 서브에이전트 모델, auto-compact 윈도우, effort 레벨)을 파생하며, 캐리어별 모델이 없을 때만 사용합니다.
+#### Changed
+- [core-unified-agent] Align the Kimi model registry with the official Kimi Code docs: K3 effort levels low/high/max with a high default, the fable tier mapping, and per-model context windows.
+  ko: Kimi 모델 레지스트리를 공식 Kimi Code 문서에 맞춥니다 — K3 effort low/high/max(기본 high), fable 티어 매핑, 모델별 컨텍스트 윈도우.

--- a/packages/core-agent/src/internal/executor-engine.ts
+++ b/packages/core-agent/src/internal/executor-engine.ts
@@ -45,7 +45,7 @@ export interface ExecuteOptions {
   readonly reservedExternalMcpServerIds?: readonly string[];
 }
 
-export type AuthEnvResolver = (cli: CliType) => Promise<Record<string, string>>;
+export type AuthEnvResolver = (cli: CliType, context?: { readonly model?: string; readonly effort?: string }) => Promise<Record<string, string>>;
 
 export type ExecResult = {
   responseText: string;
@@ -353,7 +353,10 @@ async function buildConnectOptions(cli: CliType, cwd: string, overrides: { model
   if (overrides.promptIdleTimeout !== undefined) options.promptIdleTimeout = overrides.promptIdleTimeout;
   if (systemPrompt) options.systemPrompt = systemPrompt;
   if (mcpServers) options.mcpServers = mcpServers;
-  const env = await authEnvResolver(cli);
+  const env = await authEnvResolver(cli, {
+    ...(overrides.model ? { model: overrides.model } : {}),
+    ...(overrides.effort ? { effort: overrides.effort } : {}),
+  });
   if (Object.keys(env).length) options.env = env;
   return options;
 }

--- a/packages/core-infra/src/data-dir/settings/store.ts
+++ b/packages/core-infra/src/data-dir/settings/store.ts
@@ -57,19 +57,37 @@ export function sanitizeGlobalOptionsData(value: unknown): GlobalOptionsValidati
     return { data: createEmptyGlobalOptionsData(), changed: true };
   }
 
+  const kimiModel = sanitizeKimiModel(value.kimiModel);
   const data: GlobalOptionsData = {
     version: GLOBAL_OPTIONS_VERSION,
     ...(typeof value.enableMetaphor === "boolean" ? { enableMetaphor: value.enableMetaphor } : {}),
     ...(value.codexLaunchMode === "acp" || value.codexLaunchMode === "app-server"
       ? { codexLaunchMode: value.codexLaunchMode }
       : {}),
+    ...(kimiModel ? { kimiModel } : {}),
   };
-  const allowedKeys = new Set(["version", "enableMetaphor", "codexLaunchMode"]);
+  const allowedKeys = new Set(["version", "enableMetaphor", "codexLaunchMode", "kimiModel"]);
   const changed = Object.keys(value).some((key) => !allowedKeys.has(key)) ||
     ("enableMetaphor" in value && typeof value.enableMetaphor !== "boolean") ||
-    ("codexLaunchMode" in value && value.codexLaunchMode !== "acp" && value.codexLaunchMode !== "app-server");
+    ("codexLaunchMode" in value && value.codexLaunchMode !== "acp" && value.codexLaunchMode !== "app-server") ||
+    ("kimiModel" in value && kimiModel === undefined);
 
   return { data, changed };
+}
+
+function sanitizeKimiModel(
+  value: unknown,
+): { readonly model: string; readonly effort?: string } | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  if (typeof value.model !== "string" || value.model.length === 0) {
+    return undefined;
+  }
+  return {
+    model: value.model,
+    ...(typeof value.effort === "string" ? { effort: value.effort } : {}),
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/core-infra/src/data-dir/settings/types.ts
+++ b/packages/core-infra/src/data-dir/settings/types.ts
@@ -2,6 +2,7 @@ export interface GlobalOptionsData {
   readonly version: 1;
   readonly enableMetaphor?: boolean;
   readonly codexLaunchMode?: 'acp' | 'app-server';
+  readonly kimiModel?: { readonly model: string; readonly effort?: string };
 }
 
 export interface GlobalOptionsValidationResult {

--- a/packages/core-infra/tests/data-dir-settings-store.test.ts
+++ b/packages/core-infra/tests/data-dir-settings-store.test.ts
@@ -74,6 +74,66 @@ describe("data-dir settings store", () => {
     });
   });
 
+  it("preserves valid kimi model selections and drops malformed shapes", () => {
+    expect(sanitizeGlobalOptionsData({
+      version: 1,
+      kimiModel: { model: "k3" },
+    })).toEqual({
+      changed: false,
+      data: {
+        version: 1,
+        kimiModel: { model: "k3" },
+      },
+    });
+    expect(sanitizeGlobalOptionsData({
+      version: 1,
+      kimiModel: { model: "k3[1m]", effort: "high" },
+    })).toEqual({
+      changed: false,
+      data: {
+        version: 1,
+        kimiModel: { model: "k3[1m]", effort: "high" },
+      },
+    });
+    expect(sanitizeGlobalOptionsData({
+      version: 1,
+      kimiModel: { model: 42, effort: "high" },
+    })).toEqual({
+      changed: true,
+      data: {
+        version: 1,
+      },
+    });
+    expect(sanitizeGlobalOptionsData({
+      version: 1,
+      kimiModel: { model: "" },
+    })).toEqual({
+      changed: true,
+      data: {
+        version: 1,
+      },
+    });
+    expect(sanitizeGlobalOptionsData({
+      version: 1,
+      kimiModel: "k3",
+    })).toEqual({
+      changed: true,
+      data: {
+        version: 1,
+      },
+    });
+    expect(sanitizeGlobalOptionsData({
+      version: 1,
+      kimiModel: { model: "k3", effort: 3 },
+    })).toEqual({
+      changed: false,
+      data: {
+        version: 1,
+        kimiModel: { model: "k3" },
+      },
+    });
+  });
+
   it("preserves valid codex launch modes and strips invalid values", () => {
     expect(sanitizeGlobalOptionsData({
       version: 1,

--- a/packages/core-unified-agent/models.json
+++ b/packages/core-unified-agent/models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-07-10T00:00:00Z",
+  "updatedAt": "2026-07-20T00:00:00Z",
   "providers": {
     "claude": {
       "name": "Claude Code",
@@ -19,15 +19,16 @@
       "name": "Kimi via Claude Code",
       "defaultModel": "kimi-for-coding",
       "models": [
-        { "modelId": "kimi-for-coding", "name": "Kimi for Coding", "description": "Available on every Kimi Code membership tier (262K context)", "effort": { "supported": false } },
-        { "modelId": "k3", "name": "Kimi K3", "description": "Available on Moderato and higher tiers (262K context)", "effort": { "supported": true, "levels": ["max"], "default": "max" } },
-        { "modelId": "k3[1m]", "name": "Kimi K3 [1M]", "description": "Available on Allegretto and higher tiers (1M context)", "effort": { "supported": true, "levels": ["max"], "default": "max" } },
-        { "modelId": "kimi-for-coding-highspeed", "name": "Kimi for Coding Highspeed", "description": "Available on Allegretto and higher tiers (262K context)", "effort": { "supported": false } }
+        { "modelId": "kimi-for-coding", "name": "Kimi for Coding", "description": "Available on every Kimi Code membership tier (262K context)", "effort": { "supported": false }, "contextWindow": 262144 },
+        { "modelId": "k3", "name": "Kimi K3", "description": "Available on Moderato and higher tiers (262K context)", "effort": { "supported": true, "levels": ["low", "high", "max"], "default": "high" }, "contextWindow": 262144 },
+        { "modelId": "k3[1m]", "name": "Kimi K3 [1M]", "description": "Available on Allegretto and higher tiers (1M context)", "effort": { "supported": true, "levels": ["low", "high", "max"], "default": "high" }, "contextWindow": 1048576 },
+        { "modelId": "kimi-for-coding-highspeed", "name": "Kimi for Coding Highspeed", "description": "Available on Allegretto and higher tiers (262K context)", "effort": { "supported": false }, "contextWindow": 262144 }
       ],
       "modelsMapping": {
         "haiku": "kimi-for-coding",
         "sonnet": "kimi-for-coding",
-        "opus": "kimi-for-coding"
+        "opus": "kimi-for-coding",
+        "fable": "kimi-for-coding"
       }
     },
     "codex": {

--- a/packages/core-unified-agent/src/index.ts
+++ b/packages/core-unified-agent/src/index.ts
@@ -36,6 +36,7 @@ export {
   getProviderModelIds,
   getEffort,
   getEffortLevels,
+  getModelContextWindow,
 } from './models/ModelRegistry.js';
 
 export type {

--- a/packages/core-unified-agent/src/models/ModelRegistry.ts
+++ b/packages/core-unified-agent/src/models/ModelRegistry.ts
@@ -143,6 +143,18 @@ export function getProviderModelsMapping(cli: CliType): ModelsMapping | null {
   return provider.modelsMapping ? structuredClone(provider.modelsMapping) : null;
 }
 
+/**
+ * 특정 CLI/모델의 컨텍스트 윈도우 크기를 반환합니다.
+ *
+ * @param cli - CLI 타입
+ * @param modelId - 모델 ID
+ * @returns 컨텍스트 윈도우 크기 (토큰, 미설정 시 null)
+ */
+export function getModelContextWindow(cli: CliType, modelId: string): number | null {
+  const model = findProviderModel(cli, modelId);
+  return model.contextWindow ?? null;
+}
+
 function findProviderModel(cli: CliType, modelId: string): ModelEntry {
   const provider = registry.providers[cli];
   if (!provider) {

--- a/packages/core-unified-agent/src/models/schemas.ts
+++ b/packages/core-unified-agent/src/models/schemas.ts
@@ -39,6 +39,8 @@ export const ModelEntrySchema = z.object({
   description: z.string().optional(),
   /** spawn 시 실제 CLI 모델 ID를 조립해야 하는 경우의 템플릿 */
   spawnModelTemplate: z.string().optional(),
+  /** 모델의 컨텍스트 윈도우 크기 (토큰) */
+  contextWindow: z.number().int().positive().optional(),
   /** 모델별 effort 설정 */
   effort: EffortSchema,
 }).check((ctx) => {

--- a/packages/core-unified-agent/tests/unit/ModelRegistry.test.ts
+++ b/packages/core-unified-agent/tests/unit/ModelRegistry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getProviderModels, resolveCursorSpawnModel } from '../../src/models/ModelRegistry.js';
+import { getModelContextWindow, getProviderModels, resolveCursorSpawnModel } from '../../src/models/ModelRegistry.js';
 import { ModelsRegistrySchema } from '../../src/models/schemas.js';
 
 describe('ModelRegistry', () => {
@@ -30,8 +30,16 @@ describe('ModelRegistry', () => {
     ]);
     expect(efforts['kimi-for-coding']).toEqual({ supported: false });
     expect(efforts['kimi-for-coding-highspeed']).toEqual({ supported: false });
-    expect(efforts.k3).toEqual({ supported: true, levels: ['max'], default: 'max' });
-    expect(efforts['k3[1m]']).toEqual({ supported: true, levels: ['max'], default: 'max' });
+    expect(efforts.k3).toEqual({ supported: true, levels: ['low', 'high', 'max'], default: 'high' });
+    expect(efforts['k3[1m]']).toEqual({ supported: true, levels: ['low', 'high', 'max'], default: 'high' });
+  });
+
+  it('Kimi via Claude Code 모델들은 컨텍스트 윈도우 크기를 노출한다', () => {
+    expect(getModelContextWindow('claude-kimi', 'kimi-for-coding')).toBe(262144);
+    expect(getModelContextWindow('claude-kimi', 'k3')).toBe(262144);
+    expect(getModelContextWindow('claude-kimi', 'k3[1m]')).toBe(1048576);
+    expect(getModelContextWindow('claude-kimi', 'kimi-for-coding-highspeed')).toBe(262144);
+    expect(getModelContextWindow('claude', 'opus')).toBeNull();
   });
 
   it('Codex 정적 모델 목록에 GPT-5.6 모델들과 기존 모델들을 포함한다', () => {

--- a/packages/fleet-admiral/src/agent-cli/auth.ts
+++ b/packages/fleet-admiral/src/agent-cli/auth.ts
@@ -10,6 +10,12 @@ import {
   type AuthValidationFailureStatus,
 } from "@dotobokuri/core-infra";
 
+import {
+  buildKimiModelEnv,
+  resolveKimiModelSelection,
+  type KimiModelSelection,
+} from "./kimi-model.js";
+
 export const KIMI_AUTH_PROVIDER_ID = "Claude Code with Moonshot Kimi";
 
 export const CLI_TO_AUTH_PROVIDER_ID: Partial<Record<CliType, string>> = {
@@ -24,6 +30,7 @@ export interface AgentCliAuthStatus {
 export async function resolveAgentCliAuthEnv(
   cli: CliType,
   authService: Pick<AuthService, "getApiKey"> | undefined,
+  selection?: KimiModelSelection,
 ): Promise<Record<string, string>> {
   if (cli !== "claude-kimi") return {};
   const token = await authService?.getApiKey(KIMI_AUTH_PROVIDER_ID);
@@ -34,6 +41,7 @@ export async function resolveAgentCliAuthEnv(
   }
   return {
     ...CLI_BACKENDS[cli].defaultEnv,
+    ...buildKimiModelEnv(selection ?? resolveKimiModelSelection(undefined)),
     ANTHROPIC_API_KEY: token,
   };
 }

--- a/packages/fleet-admiral/src/agent-cli/claude/factory.ts
+++ b/packages/fleet-admiral/src/agent-cli/claude/factory.ts
@@ -1,6 +1,7 @@
 import { createChildEnv, resolveBinary } from "@dotobokuri/core-agent";
 
 import { resolveAgentCliAuthEnv } from "../auth.js";
+import { resolveKimiModelSelection } from "../kimi-model.js";
 import type { AgentCliDefinition, AgentCliId, AgentCliProfileOptions } from "../types.js";
 
 interface ClaudeFamilyCliFactoryOptions {
@@ -16,7 +17,15 @@ export function createClaudeFamilyCliDefinition(
     label: options.label,
     async createProfile(profileOptions: AgentCliProfileOptions) {
       const { bin, prefixArgs } = resolveBinary("claude", "CLAUDE_BIN", profileOptions.env);
-      const authEnv = await resolveAgentCliAuthEnv(options.id, profileOptions.authService);
+      const authEnv = await resolveAgentCliAuthEnv(
+        options.id,
+        profileOptions.authService,
+        options.id === "claude-kimi"
+          ? (profileOptions.model
+            ? { model: profileOptions.model }
+            : resolveKimiModelSelection(profileOptions.globalOptionsService))
+          : undefined,
+      );
       const childEnv = createChildEnv(profileOptions.env, authEnv);
       if (options.id === "claude-kimi") {
         // Never forward an inherited Anthropic bearer token to Moonshot's endpoint.

--- a/packages/fleet-admiral/src/agent-cli/claude/factory.ts
+++ b/packages/fleet-admiral/src/agent-cli/claude/factory.ts
@@ -1,7 +1,7 @@
 import { createChildEnv, resolveBinary } from "@dotobokuri/core-agent";
 
 import { resolveAgentCliAuthEnv } from "../auth.js";
-import { resolveKimiModelSelection } from "../kimi-model.js";
+import { resolveKimiModelSelection, resolveKimiModelSelectionFromOverride } from "../kimi-model.js";
 import type { AgentCliDefinition, AgentCliId, AgentCliProfileOptions } from "../types.js";
 
 interface ClaudeFamilyCliFactoryOptions {
@@ -22,7 +22,9 @@ export function createClaudeFamilyCliDefinition(
         profileOptions.authService,
         options.id === "claude-kimi"
           ? (profileOptions.model
-            ? { model: profileOptions.model }
+            // 명시적 모델이 레지스트리에 없는 자유 형식이면 env는 레지스트리 기본값으로 두고
+            // --model 인자만 전달해 종전 동작을 보존한다(getModelContextWindow throw 방지).
+            ? resolveKimiModelSelectionFromOverride(profileOptions.model)
             : resolveKimiModelSelection(profileOptions.globalOptionsService))
           : undefined,
       );

--- a/packages/fleet-admiral/src/agent-cli/kimi-model.ts
+++ b/packages/fleet-admiral/src/agent-cli/kimi-model.ts
@@ -1,0 +1,92 @@
+/**
+ * Kimi(claude-kimi) 프로바이더 기본 모델 선택 해석
+ * 전역 설정(~/.fleet/settings.json의 kimiModel)과 레지스트리 기본값을 병합해
+ * claude-kimi 실행 env에 주입할 모델/effort를 결정합니다.
+ */
+
+import {
+  getEffort,
+  getEffortLevels,
+  getModelContextWindow,
+  getProviderModelIds,
+  getProviderModels,
+} from "@dotobokuri/core-unified-agent";
+
+export interface KimiModelSelection {
+  readonly model: string;
+  readonly effort?: string;
+}
+
+interface KimiGlobalOptionsLike {
+  load(): { kimiModel?: { model?: unknown; effort?: unknown } };
+}
+
+/**
+ * 전역 설정에 저장된 Kimi 기본 모델 선택을 해석합니다.
+ * 저장값이 없거나 유효하지 않으면 레지스트리 defaultModel(및 모델 기본 effort)로 폴백합니다.
+ */
+export function resolveKimiModelSelection(
+  globalOptionsService?: KimiGlobalOptionsLike,
+): KimiModelSelection {
+  let stored: { model?: unknown; effort?: unknown } | undefined;
+  try {
+    stored = globalOptionsService?.load().kimiModel;
+  } catch {
+    stored = undefined;
+  }
+  return resolveKimiModelSelectionFromOverride(
+    typeof stored?.model === "string" ? stored.model : undefined,
+    typeof stored?.effort === "string" ? stored.effort : undefined,
+  );
+}
+
+/**
+ * 명시적 모델/effort 오버라이드를 레지스트리 기준으로 검증해 선택을 조립합니다.
+ * 모델이 유효하지 않으면 레지스트리 defaultModel로, effort가 미지원/무효하면 모델 기본값으로 폴백합니다.
+ */
+export function resolveKimiModelSelectionFromOverride(
+  model?: string,
+  effort?: string,
+): KimiModelSelection {
+  const validIds = getProviderModelIds("claude-kimi");
+  const resolvedModel = model && validIds.includes(model)
+    ? model
+    : getProviderModels("claude-kimi").defaultModel;
+
+  const levels = getEffortLevels("claude-kimi", resolvedModel);
+  if (!levels) {
+    return { model: resolvedModel };
+  }
+  const effortConfig = getEffort("claude-kimi", resolvedModel);
+  const resolvedEffort = effort && levels.includes(effort)
+    ? effort
+    : (effortConfig.supported ? effortConfig.default : undefined);
+  return resolvedEffort
+    ? { model: resolvedModel, effort: resolvedEffort }
+    : { model: resolvedModel };
+}
+
+/**
+ * Kimi 모델 선택을 Claude Code 실행 env로 변환합니다.
+ * 공식 문서 기준으로 전 모델 슬롯을 선택 모델로 고정하고,
+ * 모델의 컨텍스트 윈도우에 맞춰 auto-compact/max-context 토큰을 설정합니다.
+ */
+export function buildKimiModelEnv(selection: KimiModelSelection): Record<string, string> {
+  const env: Record<string, string> = {
+    ANTHROPIC_MODEL: selection.model,
+    ANTHROPIC_DEFAULT_HAIKU_MODEL: selection.model,
+    ANTHROPIC_DEFAULT_SONNET_MODEL: selection.model,
+    ANTHROPIC_DEFAULT_OPUS_MODEL: selection.model,
+    ANTHROPIC_DEFAULT_FABLE_MODEL: selection.model,
+    CLAUDE_CODE_SUBAGENT_MODEL: selection.model,
+  };
+  const contextWindow = getModelContextWindow("claude-kimi", selection.model);
+  if (contextWindow !== null) {
+    env.CLAUDE_CODE_AUTO_COMPACT_WINDOW = String(contextWindow);
+    env.CLAUDE_CODE_MAX_CONTEXT_TOKENS = String(contextWindow);
+  }
+  if (selection.effort) {
+    env.CLAUDE_CODE_EFFORT_LEVEL = selection.effort;
+  }
+  return env;
+}

--- a/packages/fleet-admiral/src/agent-cli/registry.ts
+++ b/packages/fleet-admiral/src/agent-cli/registry.ts
@@ -1,3 +1,5 @@
+import type { GlobalOptionsData } from "@dotobokuri/core-infra";
+
 import { claudeCli } from "./claude/claude.js";
 import { claudeKimiCli } from "./claude/claude-kimi.js";
 import { codexCli } from "./codex/codex.js";
@@ -6,6 +8,7 @@ import type { AgentCliDefinition, AgentCliId, AgentCliProfile, AuthServiceLike }
 export interface ResolveAgentCliProfileOptions {
   readonly authService?: AuthServiceLike;
   readonly cliId?: string;
+  readonly globalOptionsService?: { load(): GlobalOptionsData };
   readonly model?: string;
   readonly resumeSessionId?: string;
 }
@@ -32,6 +35,7 @@ export async function resolveAgentCliProfile(
     authService: options.authService,
     cwd,
     env,
+    globalOptionsService: options.globalOptionsService,
     model: options.model,
     resumeSessionId: options.resumeSessionId,
   });

--- a/packages/fleet-admiral/src/agent-cli/types.ts
+++ b/packages/fleet-admiral/src/agent-cli/types.ts
@@ -1,3 +1,5 @@
+import type { GlobalOptionsData } from "@dotobokuri/core-infra";
+
 export type AgentCliId = "claude" | "claude-kimi" | "codex";
 
 export interface AuthServiceLike {
@@ -47,6 +49,7 @@ export interface AgentCliProfileOptions {
   readonly authService?: AuthServiceLike;
   readonly cwd: string;
   readonly env: NodeJS.ProcessEnv;
+  readonly globalOptionsService?: { load(): GlobalOptionsData };
   readonly model?: string;
   readonly resumeSessionId?: string;
 }

--- a/packages/fleet-admiral/src/agent-runtime/index.ts
+++ b/packages/fleet-admiral/src/agent-runtime/index.ts
@@ -21,12 +21,18 @@ import {
 	type WorkspaceChangeScanner,
 } from "@dotobokuri/fleet-carriers";
 
+import { getProviderModelIds } from "@dotobokuri/core-unified-agent";
+
 import {
 	FLEET_MCP_SERVER_NAME,
 	getExecutorMcpTools,
 	registerAgentToolDefaults,
 } from "../tools.js";
 import { resolveAgentCliAuthEnv } from "../agent-cli/auth.js";
+import {
+	resolveKimiModelSelection,
+	resolveKimiModelSelectionFromOverride,
+} from "../agent-cli/kimi-model.js";
 
 export interface FleetAgentRuntimeToolRegistration {
 	readonly spec: AgentToolSpec;
@@ -129,9 +135,14 @@ export function createAuthEnvResolver(
 	globalOptionsService: GlobalOptionsService | undefined,
 	authService?: AuthService,
 ): AuthEnvResolver {
-	return async (cli): Promise<Record<string, string>> => {
+	return async (cli, context): Promise<Record<string, string>> => {
 		if (cli === "claude-kimi") {
-			return resolveAgentCliAuthEnv(cli, authService);
+			// 명시적 모델 컨텍스트(캐리어별 선택)가 유효하면 우선 적용하고,
+			// 그렇지 않으면 전역 설정의 프로바이더 기본 모델을 사용한다.
+			const selection = context?.model && getProviderModelIds("claude-kimi").includes(context.model)
+				? resolveKimiModelSelectionFromOverride(context.model, context.effort)
+				: resolveKimiModelSelection(globalOptionsService);
+			return resolveAgentCliAuthEnv(cli, authService, selection);
 		}
 		if (cli !== "codex" || !globalOptionsService) return {};
 		try {

--- a/packages/fleet-admiral/src/index.ts
+++ b/packages/fleet-admiral/src/index.ts
@@ -33,6 +33,13 @@ export {
   type AgentCliAuthStatus,
 } from "./agent-cli/auth.js";
 
+// Kimi 프로바이더 기본 모델 선택 해석
+export {
+  buildKimiModelEnv,
+  resolveKimiModelSelection,
+  type KimiModelSelection,
+} from "./agent-cli/kimi-model.js";
+
 // Agent CLI 프로파일/레지스트리 해석기
 export {
   type AgentCliMetadata,

--- a/packages/fleet-admiral/tests/agent-cli-kimi-model.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-kimi-model.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildKimiModelEnv,
+  resolveKimiModelSelection,
+} from "../src/agent-cli/kimi-model.js";
+
+describe("resolveKimiModelSelection", () => {
+  it("설정 서비스가 없으면 레지스트리 기본 모델을 반환한다", () => {
+    expect(resolveKimiModelSelection(undefined)).toEqual({ model: "kimi-for-coding" });
+  });
+
+  it("저장된 유효한 모델/effort 선택을 반환한다", () => {
+    const selection = resolveKimiModelSelection({
+      load: () => ({ kimiModel: { model: "k3", effort: "max" } }),
+    });
+
+    expect(selection).toEqual({ model: "k3", effort: "max" });
+  });
+
+  it("저장된 모델이 유효하지 않으면 레지스트리 기본 모델로 폴백한다", () => {
+    const selection = resolveKimiModelSelection({
+      load: () => ({ kimiModel: { model: "not-a-model", effort: "high" } }),
+    });
+
+    expect(selection).toEqual({ model: "kimi-for-coding" });
+  });
+
+  it("effort 미지원 모델은 effort를 생략한다", () => {
+    const selection = resolveKimiModelSelection({
+      load: () => ({ kimiModel: { model: "kimi-for-coding-highspeed", effort: "high" } }),
+    });
+
+    expect(selection).toEqual({ model: "kimi-for-coding-highspeed" });
+  });
+
+  it("effort 지원 모델에 저장 effort가 없거나 무효하면 모델 기본 effort를 사용한다", () => {
+    expect(resolveKimiModelSelection({
+      load: () => ({ kimiModel: { model: "k3" } }),
+    })).toEqual({ model: "k3", effort: "high" });
+    expect(resolveKimiModelSelection({
+      load: () => ({ kimiModel: { model: "k3", effort: "ultra" } }),
+    })).toEqual({ model: "k3", effort: "high" });
+  });
+
+  it("설정 로드가 실패하면 레지스트리 기본 모델로 폴백한다", () => {
+    const selection = resolveKimiModelSelection({
+      load: () => {
+        throw new Error("settings unavailable");
+      },
+    });
+
+    expect(selection).toEqual({ model: "kimi-for-coding" });
+  });
+});
+
+describe("buildKimiModelEnv", () => {
+  it("모든 모델 슬롯을 선택 모델로 고정하고 262K 컨텍스트 env를 설정한다", () => {
+    expect(buildKimiModelEnv({ model: "kimi-for-coding" })).toEqual({
+      ANTHROPIC_MODEL: "kimi-for-coding",
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: "kimi-for-coding",
+      ANTHROPIC_DEFAULT_SONNET_MODEL: "kimi-for-coding",
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "kimi-for-coding",
+      ANTHROPIC_DEFAULT_FABLE_MODEL: "kimi-for-coding",
+      CLAUDE_CODE_SUBAGENT_MODEL: "kimi-for-coding",
+      CLAUDE_CODE_AUTO_COMPACT_WINDOW: "262144",
+      CLAUDE_CODE_MAX_CONTEXT_TOKENS: "262144",
+    });
+  });
+
+  it("k3[1m]은 1M 컨텍스트 env와 effort를 설정한다", () => {
+    expect(buildKimiModelEnv({ model: "k3[1m]", effort: "high" })).toEqual({
+      ANTHROPIC_MODEL: "k3[1m]",
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: "k3[1m]",
+      ANTHROPIC_DEFAULT_SONNET_MODEL: "k3[1m]",
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "k3[1m]",
+      ANTHROPIC_DEFAULT_FABLE_MODEL: "k3[1m]",
+      CLAUDE_CODE_SUBAGENT_MODEL: "k3[1m]",
+      CLAUDE_CODE_AUTO_COMPACT_WINDOW: "1048576",
+      CLAUDE_CODE_MAX_CONTEXT_TOKENS: "1048576",
+      CLAUDE_CODE_EFFORT_LEVEL: "high",
+    });
+  });
+});

--- a/packages/fleet-admiral/tests/agent-cli-kimi-model.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-kimi-model.test.ts
@@ -3,7 +3,18 @@ import { describe, expect, it } from "vitest";
 import {
   buildKimiModelEnv,
   resolveKimiModelSelection,
+  resolveKimiModelSelectionFromOverride,
 } from "../src/agent-cli/kimi-model.js";
+
+describe("resolveKimiModelSelectionFromOverride", () => {
+  it("유효한 명시 모델/effort를 그대로 반환한다", () => {
+    expect(resolveKimiModelSelectionFromOverride("k3[1m]", "max")).toEqual({ model: "k3[1m]", effort: "max" });
+  });
+
+  it("레지스트리에 없는 자유 형식 모델은 throw 없이 레지스트리 기본 모델로 폴백한다", () => {
+    expect(resolveKimiModelSelectionFromOverride("kimi-next-gen")).toEqual({ model: "kimi-for-coding" });
+  });
+});
 
 describe("resolveKimiModelSelection", () => {
   it("설정 서비스가 없으면 레지스트리 기본 모델을 반환한다", () => {

--- a/packages/fleet-admiral/tests/agent-runtime-auth-env.test.ts
+++ b/packages/fleet-admiral/tests/agent-runtime-auth-env.test.ts
@@ -32,6 +32,44 @@ describe("createAuthEnvResolver", () => {
 		});
 	});
 
+	it("Kimi carrier에는 전역 설정의 기본 모델 env를 주입한다", async () => {
+		const resolver = createAuthEnvResolver(
+			createServiceStub(() => ({ version: 1, kimiModel: { model: "k3", effort: "low" } })),
+			{
+				deleteApiKey: async () => false,
+				getApiKey: async () => "kimi-secret",
+				listProviderIds: async () => [],
+				setApiKey: async () => {},
+			},
+		);
+
+		await expect(resolver("claude-kimi")).resolves.toMatchObject({
+			ANTHROPIC_API_KEY: "kimi-secret",
+			ANTHROPIC_MODEL: "k3",
+			ANTHROPIC_DEFAULT_FABLE_MODEL: "k3",
+			CLAUDE_CODE_EFFORT_LEVEL: "low",
+			CLAUDE_CODE_MAX_CONTEXT_TOKENS: "262144",
+		});
+	});
+
+	it("유효한 명시적 모델 컨텍스트는 전역 설정보다 우선한다", async () => {
+		const resolver = createAuthEnvResolver(
+			createServiceStub(() => ({ version: 1, kimiModel: { model: "k3" } })),
+			{
+				deleteApiKey: async () => false,
+				getApiKey: async () => "kimi-secret",
+				listProviderIds: async () => [],
+				setApiKey: async () => {},
+			},
+		);
+
+		await expect(resolver("claude-kimi", { model: "k3[1m]" })).resolves.toMatchObject({
+			ANTHROPIC_MODEL: "k3[1m]",
+			CLAUDE_CODE_EFFORT_LEVEL: "high",
+			CLAUDE_CODE_MAX_CONTEXT_TOKENS: "1048576",
+		});
+	});
+
 	it("globalOptionsService가 없으면 아무것도 주입하지 않는다", async () => {
 		const resolver = createAuthEnvResolver(undefined);
 		await expect(resolver("codex")).resolves.toEqual({});

--- a/packages/fleet-carriers/src/store/models.ts
+++ b/packages/fleet-carriers/src/store/models.ts
@@ -3,6 +3,7 @@ import {
   getProviderModels,
   type CliType,
 } from "@dotobokuri/core-unified-agent";
+import { createGlobalOptionsStore } from "@dotobokuri/core-infra/data-dir/settings";
 import {
   sanitizeAgentCli,
   sanitizeAgentCliSelectionForCliType,
@@ -187,17 +188,41 @@ function resolveSelectionForCliType(
   const allowedModels = new Set(provider.models.map((model) => model.modelId));
   const defaultModelIsValid = !!defaults?.defaultModel && allowedModels.has(defaults.defaultModel);
   const storedModelIsValid = !!stored?.model && allowedModels.has(stored.model);
+  // 캐리어별/페르소나 기본 모델이 모두 없을 때만 프로바이더 기본 모델(전역 설정)을 참조합니다.
+  const providerDefault = storedModelIsValid || defaultModelIsValid
+    ? undefined
+    : readKimiProviderDefaultSelection(cliType, allowedModels);
   const model = storedModelIsValid
     ? stored!.model
     : defaultModelIsValid
       ? defaults!.defaultModel!
-      : provider.defaultModel;
+      : providerDefault?.model ?? provider.defaultModel;
   const modelEffort = getEffort(cliType, model);
   if (!modelEffort.supported) return { model };
   const effort = storedModelIsValid && stored?.effort && modelEffort.levels.includes(stored.effort)
     ? stored.effort
     : defaults?.defaultEffort && modelEffort.levels.includes(defaults.defaultEffort)
       ? defaults.defaultEffort
-      : modelEffort.default;
+      : providerDefault?.effort && modelEffort.levels.includes(providerDefault.effort)
+        ? providerDefault.effort
+        : modelEffort.default;
   return { model, effort };
+}
+
+/** 전역 설정(~/.fleet/settings.json)의 Kimi 프로바이더 기본 모델을 읽습니다. 오류/무효값은 undefined로 폴백합니다. */
+function readKimiProviderDefaultSelection(
+  cliType: CliType,
+  allowedModels: ReadonlySet<string>,
+): { readonly model: string; readonly effort?: string } | undefined {
+  if (cliType !== "claude-kimi") return undefined;
+  try {
+    const kimiModel = createGlobalOptionsStore().load().kimiModel;
+    if (!kimiModel || !allowedModels.has(kimiModel.model)) return undefined;
+    return {
+      model: kimiModel.model,
+      ...(typeof kimiModel.effort === "string" ? { effort: kimiModel.effort } : {}),
+    };
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/fleet-carriers/src/store/models.ts
+++ b/packages/fleet-carriers/src/store/models.ts
@@ -1,5 +1,3 @@
-import * as path from "node:path";
-
 import {
   getEffort,
   getProviderModels,
@@ -14,7 +12,7 @@ import {
   sanitizeGeneration,
   sanitizeTaskforce,
 } from "./sanitize.js";
-import { getCarriersFilePath, readRawCarriers, readRawCarriersOrDefaultStore, updateCarriers } from "./state-io.js";
+import { readRawCarriers, readRawCarriersOrDefaultStore, updateCarriers } from "./state-io.js";
 import type {
   AgentCliSelection,
   CarrierModelDefaults,
@@ -211,15 +209,16 @@ function resolveSelectionForCliType(
   return { model, effort };
 }
 
-/** 활성 store 디렉터리의 전역 설정(settings.json)에서 Kimi 프로바이더 기본 모델을 읽습니다. 오류/무효값은 undefined로 폴백합니다. */
+/** 기본 fleet 데이터 디렉터리의 전역 설정(settings.json)에서 Kimi 프로바이더 기본 모델을 읽습니다. 오류/무효값은 undefined로 폴백합니다. */
 function readKimiProviderDefaultSelection(
   cliType: CliType,
   allowedModels: ReadonlySet<string>,
 ): { readonly model: string; readonly effort?: string } | undefined {
   if (cliType !== "claude-kimi") return undefined;
   try {
-    // initStore(dir)로 재배치된 활성 데이터 디렉터리를 따라가도록 carriers store 경로에서 유도한다.
-    const kimiModel = createGlobalOptionsStore({ dataDir: path.dirname(getCarriersFilePath()) }).load().kimiModel;
+    // 전역 설정은 fleet-cli/모든 Console 채널이 공유하는 기본 fleet 데이터 디렉터리 기준이다
+    // (enableMetaphor/codexLaunchMode/auth.json과 동일 축). 채널 스코프는 carriers.json만 해당한다.
+    const kimiModel = createGlobalOptionsStore().load().kimiModel;
     if (!kimiModel || !allowedModels.has(kimiModel.model)) return undefined;
     return {
       model: kimiModel.model,

--- a/packages/fleet-carriers/src/store/models.ts
+++ b/packages/fleet-carriers/src/store/models.ts
@@ -1,3 +1,5 @@
+import * as path from "node:path";
+
 import {
   getEffort,
   getProviderModels,
@@ -12,7 +14,7 @@ import {
   sanitizeGeneration,
   sanitizeTaskforce,
 } from "./sanitize.js";
-import { readRawCarriers, readRawCarriersOrDefaultStore, updateCarriers } from "./state-io.js";
+import { getCarriersFilePath, readRawCarriers, readRawCarriersOrDefaultStore, updateCarriers } from "./state-io.js";
 import type {
   AgentCliSelection,
   CarrierModelDefaults,
@@ -209,14 +211,15 @@ function resolveSelectionForCliType(
   return { model, effort };
 }
 
-/** 전역 설정(~/.fleet/settings.json)의 Kimi 프로바이더 기본 모델을 읽습니다. 오류/무효값은 undefined로 폴백합니다. */
+/** 활성 store 디렉터리의 전역 설정(settings.json)에서 Kimi 프로바이더 기본 모델을 읽습니다. 오류/무효값은 undefined로 폴백합니다. */
 function readKimiProviderDefaultSelection(
   cliType: CliType,
   allowedModels: ReadonlySet<string>,
 ): { readonly model: string; readonly effort?: string } | undefined {
   if (cliType !== "claude-kimi") return undefined;
   try {
-    const kimiModel = createGlobalOptionsStore().load().kimiModel;
+    // initStore(dir)로 재배치된 활성 데이터 디렉터리를 따라가도록 carriers store 경로에서 유도한다.
+    const kimiModel = createGlobalOptionsStore({ dataDir: path.dirname(getCarriersFilePath()) }).load().kimiModel;
     if (!kimiModel || !allowedModels.has(kimiModel.model)) return undefined;
     return {
       model: kimiModel.model,

--- a/packages/fleet-carriers/tests/store/kimi-provider-default.test.ts
+++ b/packages/fleet-carriers/tests/store/kimi-provider-default.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../../src/index.js";
 
 // resolveSelectionForCliType의 Kimi 프로바이더 기본 모델 폴백 체인 검증.
-// 전역 설정(settings.json)은 활성 store 디렉터리 기준이라 HOME을 임시 디렉터리로 격리한다.
+// 전역 설정(settings.json)은 기본 fleet 데이터 디렉터리 기준(호스트·채널 공통)이라 HOME을 임시 디렉터리로 격리한다.
 describe("Kimi 프로바이더 기본 모델 폴백", () => {
   let tempHome: string | null = null;
   let savedHome: string | undefined;
@@ -107,15 +107,16 @@ describe("Kimi 프로바이더 기본 모델 폴백", () => {
     expect(states.ohio?.agentCli.codex).toEqual({ model: "gpt-5.6-sol", effort: "low" });
   });
 
-  it("initStore로 재배치된 store 디렉터리의 전역 설정을 사용한다", () => {
+  it("carriers store가 재배치돼도 전역 설정은 기본 fleet 디렉터리를 따른다", () => {
     const customDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-kimi-custom-"));
     try {
       initStore(customDir);
-      // 기본 디렉터리(HOME)에는 다른 값을 두고, 재배치된 디렉터리에 k3를 둔다.
-      writeSettingsJson({ version: 1, kimiModel: { model: "kimi-for-coding-highspeed" } });
+      // 전역 설정은 enableMetaphor/codexLaunchMode와 같은 축으로 호스트·채널 공통(기본 디렉터리)이다.
+      // 재배치된 디렉터리에 다른 값이 있어도 기본 디렉터리의 설정이 적용돼야 한다.
+      writeSettingsJson({ version: 1, kimiModel: { model: "k3", effort: "low" } });
       fs.writeFileSync(
         path.join(customDir, "settings.json"),
-        JSON.stringify({ version: 1, kimiModel: { model: "k3", effort: "low" } }),
+        JSON.stringify({ version: 1, kimiModel: { model: "kimi-for-coding-highspeed" } }),
         "utf-8",
       );
 

--- a/packages/fleet-carriers/tests/store/kimi-provider-default.test.ts
+++ b/packages/fleet-carriers/tests/store/kimi-provider-default.test.ts
@@ -4,12 +4,13 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  initStore,
   loadCarrierStates,
   resetStoreForTests,
 } from "../../src/index.js";
 
 // resolveSelectionForCliType의 Kimi 프로바이더 기본 모델 폴백 체인 검증.
-// 전역 설정(~/.fleet/settings.json)은 getFleetDataDir() 기준이라 HOME을 임시 디렉터리로 격리한다.
+// 전역 설정(settings.json)은 활성 store 디렉터리 기준이라 HOME을 임시 디렉터리로 격리한다.
 describe("Kimi 프로바이더 기본 모델 폴백", () => {
   let tempHome: string | null = null;
   let savedHome: string | undefined;
@@ -104,6 +105,27 @@ describe("Kimi 프로바이더 기본 모델 폴백", () => {
     const states = loadCarrierStates({ ohio: { cliType: "codex" } });
 
     expect(states.ohio?.agentCli.codex).toEqual({ model: "gpt-5.6-sol", effort: "low" });
+  });
+
+  it("initStore로 재배치된 store 디렉터리의 전역 설정을 사용한다", () => {
+    const customDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-kimi-custom-"));
+    try {
+      initStore(customDir);
+      // 기본 디렉터리(HOME)에는 다른 값을 두고, 재배치된 디렉터리에 k3를 둔다.
+      writeSettingsJson({ version: 1, kimiModel: { model: "kimi-for-coding-highspeed" } });
+      fs.writeFileSync(
+        path.join(customDir, "settings.json"),
+        JSON.stringify({ version: 1, kimiModel: { model: "k3", effort: "low" } }),
+        "utf-8",
+      );
+
+      const states = loadCarrierStates({ ohio: { cliType: "claude-kimi" } });
+
+      expect(states.ohio?.agentCli["claude-kimi"]).toEqual({ model: "k3", effort: "low" });
+    } finally {
+      resetStoreForTests();
+      fs.rmSync(customDir, { recursive: true, force: true });
+    }
   });
 
   function writeSettingsJson(value: unknown): void {

--- a/packages/fleet-carriers/tests/store/kimi-provider-default.test.ts
+++ b/packages/fleet-carriers/tests/store/kimi-provider-default.test.ts
@@ -1,0 +1,120 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  loadCarrierStates,
+  resetStoreForTests,
+} from "../../src/index.js";
+
+// resolveSelectionForCliType의 Kimi 프로바이더 기본 모델 폴백 체인 검증.
+// 전역 설정(~/.fleet/settings.json)은 getFleetDataDir() 기준이라 HOME을 임시 디렉터리로 격리한다.
+describe("Kimi 프로바이더 기본 모델 폴백", () => {
+  let tempHome: string | null = null;
+  let savedHome: string | undefined;
+
+  beforeEach(() => {
+    savedHome = process.env.HOME;
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-kimi-default-"));
+    process.env.HOME = tempHome;
+    resetStoreForTests();
+  });
+
+  afterEach(() => {
+    if (savedHome !== undefined) {
+      process.env.HOME = savedHome;
+    } else {
+      delete process.env.HOME;
+    }
+    resetStoreForTests();
+    if (tempHome) fs.rmSync(tempHome, { recursive: true, force: true });
+    tempHome = null;
+  });
+
+  it("캐리어별/페르소나 기본 모델이 없으면 전역 설정의 Kimi 기본 모델을 사용한다", () => {
+    writeSettingsJson({ version: 1, kimiModel: { model: "k3", effort: "low" } });
+
+    const states = loadCarrierStates({ ohio: { cliType: "claude-kimi" } });
+
+    expect(states.ohio?.agentCli["claude-kimi"]).toEqual({ model: "k3", effort: "low" });
+  });
+
+  it("전역 설정이 없으면 레지스트리 기본 모델로 폴백한다", () => {
+    const states = loadCarrierStates({ ohio: { cliType: "claude-kimi" } });
+
+    expect(states.ohio?.agentCli["claude-kimi"]).toEqual({ model: "kimi-for-coding" });
+  });
+
+  it("전역 설정 파일이 손상되면 레지스트리 기본 모델로 폴백한다", () => {
+    fs.mkdirSync(path.join(tempHome!, ".fleet"), { recursive: true });
+    fs.writeFileSync(path.join(tempHome!, ".fleet", "settings.json"), "{nope", "utf-8");
+
+    const states = loadCarrierStates({ ohio: { cliType: "claude-kimi" } });
+
+    expect(states.ohio?.agentCli["claude-kimi"]).toEqual({ model: "kimi-for-coding" });
+  });
+
+  it("전역 설정의 모델이 유효하지 않으면 레지스트리 기본 모델로 폴백한다", () => {
+    writeSettingsJson({ version: 1, kimiModel: { model: "not-a-real-model", effort: "high" } });
+
+    const states = loadCarrierStates({ ohio: { cliType: "claude-kimi" } });
+
+    expect(states.ohio?.agentCli["claude-kimi"]).toEqual({ model: "kimi-for-coding" });
+  });
+
+  it("effort 미지원 모델이 전역 설정에 저장되면 effort를 생략한다", () => {
+    writeSettingsJson({ version: 1, kimiModel: { model: "kimi-for-coding-highspeed", effort: "high" } });
+
+    const states = loadCarrierStates({ ohio: { cliType: "claude-kimi" } });
+
+    expect(states.ohio?.agentCli["claude-kimi"]).toEqual({ model: "kimi-for-coding-highspeed" });
+  });
+
+  it("유효한 캐리어별 선택은 전역 설정보다 우선한다", () => {
+    writeSettingsJson({ version: 1, kimiModel: { model: "k3", effort: "low" } });
+    writeCarriersJson({
+      _meta: { generation: 1 },
+      carriers: {
+        ohio: {
+          agentCliType: "claude-kimi",
+          agentCli: { "claude-kimi": { model: "k3[1m]", effort: "max" } },
+        },
+      },
+    });
+
+    const states = loadCarrierStates({ ohio: { cliType: "claude-kimi" } });
+
+    expect(states.ohio?.agentCli["claude-kimi"]).toEqual({ model: "k3[1m]", effort: "max" });
+  });
+
+  it("유효한 페르소나 기본 모델은 전역 설정보다 우선한다", () => {
+    writeSettingsJson({ version: 1, kimiModel: { model: "k3", effort: "low" } });
+
+    const states = loadCarrierStates({
+      ohio: { cliType: "claude-kimi", defaultModel: "k3[1m]", defaultEffort: "max" },
+    });
+
+    expect(states.ohio?.agentCli["claude-kimi"]).toEqual({ model: "k3[1m]", effort: "max" });
+  });
+
+  it("Kimi가 아닌 CLI는 전역 설정의 kimiModel을 무시한다", () => {
+    writeSettingsJson({ version: 1, kimiModel: { model: "k3", effort: "low" } });
+
+    const states = loadCarrierStates({ ohio: { cliType: "codex" } });
+
+    expect(states.ohio?.agentCli.codex).toEqual({ model: "gpt-5.6-sol", effort: "low" });
+  });
+
+  function writeSettingsJson(value: unknown): void {
+    const dir = path.join(tempHome!, ".fleet");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "settings.json"), JSON.stringify(value), "utf-8");
+  }
+
+  function writeCarriersJson(value: unknown): void {
+    const dir = path.join(tempHome!, ".fleet");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "carriers.json"), JSON.stringify(value), "utf-8");
+  }
+});

--- a/runtime/fleet-cli/src/app.ts
+++ b/runtime/fleet-cli/src/app.ts
@@ -34,7 +34,7 @@ import { discoverMissionControlCounts } from "./mission-control/loaded-counts.js
 import { createSessionOptionsRuntime } from "./mission-control/options/runtime.js";
 import type { SessionOptions } from "./mission-control/options/types.js";
 import type { CreateMissionControlControllerOptions } from "./mission-control/types.js";
-import type { AuthService } from "@dotobokuri/core-infra";
+import type { AuthService, GlobalOptionsService } from "@dotobokuri/core-infra";
 import { createMissionBridgeController } from "./mission-bridge/controller.js";
 import { readFleetCliRelease } from "./release.js";
 import { createFleetRuntimeLifecycle, type FleetRuntimeLifecycle } from "./runtime/runtime.js";
@@ -53,6 +53,7 @@ type ProcessFatalEvent = "uncaughtException" | "unhandledRejection";
 export interface CreateMissionControlProfileConfigOptions {
   readonly authService?: AuthService;
   readonly env: NodeJS.ProcessEnv;
+  readonly globalOptionsService?: GlobalOptionsService;
   readonly invocationCwd: string;
 }
 
@@ -68,6 +69,7 @@ export function createMissionControlProfileConfig(
       resolveAgentCliProfile(options.env, options.invocationCwd, {
         authService: options.authService,
         cliId: selectedCliId,
+        globalOptionsService: options.globalOptionsService,
         model: launchOptions?.model,
       }),
   };
@@ -107,6 +109,7 @@ export async function runApp(options: RunAppOptions = {}): Promise<void> {
   const missionControlProfileConfig = createMissionControlProfileConfig({
     authService: runtime.infraServices.authService,
     env: process.env,
+    globalOptionsService: runtime.infraServices.globalOptionsService,
     invocationCwd,
   });
   const release = readFleetCliRelease();

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -732,7 +732,7 @@ function ModelAuthBlock() {
                 id="kimi-default-model"
                 className="terminal-carriers-select"
                 value={selectedModelId}
-                disabled={saving}
+                disabled={saving || !settings.state}
                 onChange={(event) => {
                   const nextModel = kimiOptions.models.find((model) => model.modelId === event.target.value);
                   if (!nextModel) return;
@@ -749,7 +749,7 @@ function ModelAuthBlock() {
                   id="kimi-default-effort"
                   className="terminal-carriers-select"
                   value={selectedEffort ?? selectedModel.effort.default}
-                  disabled={saving}
+                  disabled={saving || !settings.state}
                   onChange={(event) => saveKimiModel(selectedModel.modelId, event.target.value)}
                 >
                   {selectedModel.effort.levels.map((level) => <option key={level} value={level}>{level}</option>)}

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -16,6 +16,8 @@ import { fetchAnalysisReady } from "./analysis-api.js";
 import { disposeAnalysisStore } from "./analysis-store.js";
 import "./analysis.css";
 
+import { fetchCarrierSettingsOptions } from "../carriers/api.js";
+import type { CarrierSettingsCliOption } from "../../shared/carrier-settings-types.js";
 import { createAgentSession, fetchAgentCliState, resumeAgentSession, terminateAgentSession } from "./api.js";
 import { startAgentConnection } from "./connection.js";
 import { formatElapsedDuration, formatTokenEstimate, estimateJobTokens, getDockTailText, isDockTrackLive, isTrackError, mergeDockJobs, mergeJobIds, pruneRetainedJobs, resolveDockRowStatusLabel, resolveJobSignature, resolveCarrierCaptain, retainCompletedJobs, selectJobsByIds } from "./helpers.js";
@@ -672,12 +674,40 @@ function AgentCliSection() {
 
 function ModelAuthBlock() {
   const store = useModelAuthStore();
+  const settings = useSystemPromptSettingsStore();
+  const [kimiOptions, setKimiOptions] = React.useState<CarrierSettingsCliOption | null>(null);
 
   React.useEffect(() => {
     const controller = new AbortController();
     void loadModelAuth(controller.signal);
     return () => controller.abort();
   }, []);
+
+  // 프로바이더 기본 모델 카탈로그는 Carriers 섹션과 같은 options 엔드포인트에서 가져온다.
+  React.useEffect(() => {
+    const controller = new AbortController();
+    void fetchCarrierSettingsOptions(controller.signal)
+      .then((options) => setKimiOptions(options.cliTypes.find((cli) => cli.id === "claude-kimi") ?? null))
+      .catch(() => undefined);
+    return () => controller.abort();
+  }, []);
+
+  // 현재 저장값은 terminal settings 스토어의 kimiModel 필드에서 읽는다.
+  React.useEffect(() => {
+    const controller = new AbortController();
+    void loadSystemPromptSettings(controller.signal);
+    return () => controller.abort();
+  }, []);
+
+  const storedKimiModel = settings.state?.kimiModel ?? null;
+  const selectedModelId = storedKimiModel?.model ?? kimiOptions?.defaultModel;
+  const selectedModel = kimiOptions?.models.find((model) => model.modelId === selectedModelId);
+  const selectedEffort = storedKimiModel?.effort ?? selectedModel?.effort?.default;
+  const saving = settings.savingField !== null;
+
+  const saveKimiModel = (model: string, effort?: string) => {
+    void setSystemPromptSettingsField("kimiModel", effort ? { model, effort } : { model });
+  };
 
   return (
     <section className="global-settings-card" aria-label="Model sign-in">
@@ -693,6 +723,43 @@ function ModelAuthBlock() {
       {store.state?.providers.map((provider) => (
         <ProviderRow key={provider.cli} provider={provider} busy={store.busyCli === provider.cli} />
       ))}
+      {kimiOptions && selectedModelId ? (
+        <div className="model-auth-row">
+          <div className="terminal-carriers-runtime-row">
+            <div className="terminal-carriers-field">
+              <label className="terminal-carriers-label" htmlFor="kimi-default-model">Default model</label>
+              <select
+                id="kimi-default-model"
+                className="terminal-carriers-select"
+                value={selectedModelId}
+                disabled={saving}
+                onChange={(event) => {
+                  const nextModel = kimiOptions.models.find((model) => model.modelId === event.target.value);
+                  if (!nextModel) return;
+                  saveKimiModel(nextModel.modelId, nextModel.effort ? (storedKimiModel?.effort ?? nextModel.effort.default) : undefined);
+                }}
+              >
+                {kimiOptions.models.map((model) => <option key={model.modelId} value={model.modelId}>{model.name}</option>)}
+              </select>
+            </div>
+            {selectedModel?.effort ? (
+              <div className="terminal-carriers-field">
+                <label className="terminal-carriers-label" htmlFor="kimi-default-effort">Default effort</label>
+                <select
+                  id="kimi-default-effort"
+                  className="terminal-carriers-select"
+                  value={selectedEffort ?? selectedModel.effort.default}
+                  disabled={saving}
+                  onChange={(event) => saveKimiModel(selectedModel.modelId, event.target.value)}
+                >
+                  {selectedModel.effort.levels.map((level) => <option key={level} value={level}>{level}</option>)}
+                </select>
+              </div>
+            ) : null}
+          </div>
+          <p className="global-settings-help">Used for Kimi sessions without an explicit carrier model. Applies to newly launched sessions.</p>
+        </div>
+      ) : null}
       <p className="global-settings-foot">Sign-in changes apply to newly launched sessions. Running sessions keep their current credentials until relaunched.</p>
     </section>
   );

--- a/runtime/fleet-plugins/terminal/client/agent/settings-api.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/settings-api.ts
@@ -1,13 +1,20 @@
 export type CodexLaunchMode = "acp" | "app-server";
 
+export interface KimiModelSetting {
+  readonly model: string;
+  readonly effort?: string;
+}
+
 export interface SystemPromptSettingsState {
   readonly enableMetaphor: boolean;
   readonly codexLaunchMode: CodexLaunchMode;
+  readonly kimiModel: KimiModelSetting | null;
 }
 
 export type SystemPromptSettingsUpdate =
   | { readonly enableMetaphor: boolean }
-  | { readonly codexLaunchMode: CodexLaunchMode };
+  | { readonly codexLaunchMode: CodexLaunchMode }
+  | { readonly kimiModel: KimiModelSetting };
 
 export class TerminalSettingsApiError extends Error {
   readonly status: number;
@@ -60,5 +67,18 @@ function assertSystemPromptSettingsState(value: unknown, status: number): System
   return {
     enableMetaphor: payload.enableMetaphor,
     codexLaunchMode: payload.codexLaunchMode,
+    kimiModel: assertKimiModelSetting(payload.kimiModel),
+  };
+}
+
+// kimiModel은 선택 필드다. null/부재는 null로, 형태가 깨진 값은 서버 계약 위반이지만
+// 읽기 경로에서는 설정 미저장과 동일하게 null로 폴백한다.
+function assertKimiModelSetting(value: unknown): KimiModelSetting | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as { model?: unknown; effort?: unknown };
+  if (typeof record.model !== "string" || record.model.length === 0) return null;
+  return {
+    model: record.model,
+    ...(typeof record.effort === "string" ? { effort: record.effort } : {}),
   };
 }

--- a/runtime/fleet-plugins/terminal/client/agent/settings-store.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/settings-store.ts
@@ -58,12 +58,16 @@ export async function setSystemPromptSettingsField<Field extends SystemPromptSet
 ): Promise<boolean> {
   const current = snapshot.state;
   if (!current) return false;
+  // kimiModel은 null(미설정) 값을 서버가 받지 않으므로 null 저장 요청은 무시한다.
+  if (field === "kimiModel" && value === null) return false;
   // 진행 중인 로드 응답이 이 저장 결과를 덮지 않도록 세대값을 올린다.
   loadGeneration += 1;
   const optimistic = { ...current, [field]: value };
   const update = field === "enableMetaphor"
     ? { enableMetaphor: optimistic.enableMetaphor }
-    : { codexLaunchMode: optimistic.codexLaunchMode };
+    : field === "codexLaunchMode"
+      ? { codexLaunchMode: optimistic.codexLaunchMode }
+      : { kimiModel: optimistic.kimiModel! };
   setSnapshot({ state: optimistic, savingField: field, error: null });
   try {
     const state = await saveSystemPromptSettings(update);

--- a/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
@@ -152,6 +152,7 @@ async function createAgentCliLaunchSpec(options: {
     const profile = await options.resolveProfile(options.env, options.cwd, {
       authService: options.infraServices.authService,
       cliId: options.cliId,
+      globalOptionsService: options.infraServices.globalOptionsService,
       resumeSessionId: options.resumeSessionId,
     });
     const globalSettings = readGlobalSettingsSnapshot(options.infraServices);

--- a/runtime/fleet-plugins/terminal/server/settings-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/settings-routes.ts
@@ -1,6 +1,7 @@
 import type http from "node:http";
 
 import type { GlobalOptionsData, GlobalOptionsService } from "@dotobokuri/core-infra";
+import { getEffortLevels, getProviderModelIds } from "@dotobokuri/core-unified-agent";
 import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 import { registerRouter } from "@fleet-console/sdk/plugin/node";
 
@@ -11,15 +12,18 @@ interface TerminalSettingsRouteDeps {
 interface TerminalSettingsBody {
   readonly enableMetaphor?: unknown;
   readonly codexLaunchMode?: unknown;
+  readonly kimiModel?: unknown;
 }
 
 type TerminalSettingsUpdate =
   | { readonly enableMetaphor: boolean }
-  | { readonly codexLaunchMode: "acp" | "app-server" };
+  | { readonly codexLaunchMode: "acp" | "app-server" }
+  | { readonly kimiModel: { readonly model: string; readonly effort?: string } };
 
 export interface TerminalSettingsState {
   readonly enableMetaphor: boolean;
   readonly codexLaunchMode: "acp" | "app-server";
+  readonly kimiModel: { readonly model: string; readonly effort?: string } | null;
 }
 
 export function registerTerminalSettingsRoutes(ctx: FleetPluginServerContext, deps: TerminalSettingsRouteDeps): void {
@@ -59,6 +63,7 @@ export function toTerminalSettingsState(data: GlobalOptionsData): TerminalSettin
   return {
     enableMetaphor: data.enableMetaphor ?? false,
     codexLaunchMode: data.codexLaunchMode ?? "app-server",
+    kimiModel: data.kimiModel ?? null,
   };
 }
 
@@ -69,7 +74,20 @@ function isTerminalSettingsBody(value: unknown): value is TerminalSettingsUpdate
   if (keys.length !== 1) return false;
   const body = value as TerminalSettingsBody;
   if (keys[0] === "enableMetaphor") return typeof body.enableMetaphor === "boolean";
-  return keys[0] === "codexLaunchMode" && (body.codexLaunchMode === "acp" || body.codexLaunchMode === "app-server");
+  if (keys[0] === "codexLaunchMode") return body.codexLaunchMode === "acp" || body.codexLaunchMode === "app-server";
+  return keys[0] === "kimiModel" && isKimiModelSetting(body.kimiModel);
+}
+
+// Kimi 프로바이더 기본 모델 설정 검증: 모델은 레지스트리 ID여야 하고,
+// effort는 모델이 effort를 지원할 때만 허용 레벨 내 값이어야 한다.
+function isKimiModelSetting(value: unknown): value is { readonly model: string; readonly effort?: string } {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as { model?: unknown; effort?: unknown };
+  if (typeof record.model !== "string" || !getProviderModelIds("claude-kimi").includes(record.model)) return false;
+  const levels = getEffortLevels("claude-kimi", record.model);
+  if (record.effort === undefined) return true;
+  if (!levels || typeof record.effort !== "string") return false;
+  return levels.includes(record.effort);
 }
 
 function isJsonRequest(req: http.IncomingMessage): boolean {

--- a/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
@@ -24,7 +24,7 @@ describe("terminal settings routes", () => {
       data: { version: 1, enableMetaphor: false },
     });
     await harness.handle({ req: req("GET"), res: res(), pathname: "/plugins/terminal/settings" });
-    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "app-server" } }]);
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "app-server", kimiModel: null } }]);
     expect(harness.writes[0]?.body).not.toHaveProperty("consolePortMode");
   });
 
@@ -33,7 +33,7 @@ describe("terminal settings routes", () => {
       data: { version: 1, enableMetaphor: false, codexLaunchMode: "acp" },
     });
     await harness.handle({ req: req("GET"), res: res(), pathname: "/plugins/terminal/settings" });
-    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "acp" } }]);
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "acp", kimiModel: null } }]);
     expect(harness.currentData()).toEqual({ version: 1, enableMetaphor: false, codexLaunchMode: "acp" });
   });
 
@@ -43,7 +43,7 @@ describe("terminal settings routes", () => {
       data: { version: 1, enableMetaphor: false, codexLaunchMode: "app-server" },
     });
     await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
-    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: true, codexLaunchMode: "app-server" } }]);
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: true, codexLaunchMode: "app-server", kimiModel: null } }]);
     expect(harness.currentData()).toEqual({ version: 1, enableMetaphor: true, codexLaunchMode: "app-server" });
   });
 
@@ -53,7 +53,7 @@ describe("terminal settings routes", () => {
       data: { version: 1, enableMetaphor: false },
     });
     await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
-    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "app-server" } }]);
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "app-server", kimiModel: null } }]);
     expect(harness.currentData()).toEqual({ version: 1, enableMetaphor: false, codexLaunchMode: "app-server" });
   });
 
@@ -63,7 +63,7 @@ describe("terminal settings routes", () => {
       data: { version: 1, enableMetaphor: false, codexLaunchMode: "app-server" },
     });
     await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
-    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "acp" } }]);
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "acp", kimiModel: null } }]);
     expect(harness.currentData()).toEqual({ version: 1, enableMetaphor: false, codexLaunchMode: "acp" });
   });
 
@@ -100,6 +100,55 @@ describe("terminal settings routes", () => {
     await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
     expect(harness.writes[0]?.status).toBe(400);
     expect(harness.updateCalls).toBe(0);
+  });
+
+  it("PUT /plugins/terminal/settings updates the Kimi default model in global options", async () => {
+    const harness = createRouteHarness({
+      body: { kimiModel: { model: "k3", effort: "max" } },
+      data: { version: 1, enableMetaphor: false },
+    });
+    await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "app-server", kimiModel: { model: "k3", effort: "max" } } }]);
+    expect(harness.currentData()).toEqual({ version: 1, enableMetaphor: false, kimiModel: { model: "k3", effort: "max" } });
+  });
+
+  it("PUT /plugins/terminal/settings accepts a Kimi default model without effort", async () => {
+    const harness = createRouteHarness({
+      body: { kimiModel: { model: "kimi-for-coding-highspeed" } },
+      data: { version: 1 },
+    });
+    await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
+    expect(harness.writes[0]?.status).toBe(200);
+    expect(harness.currentData()).toEqual({ version: 1, kimiModel: { model: "kimi-for-coding-highspeed" } });
+  });
+
+  it("PUT /plugins/terminal/settings rejects unknown Kimi models", async () => {
+    const harness = createRouteHarness({ body: { kimiModel: { model: "not-a-real-model" } } });
+    await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
+    expect(harness.writes[0]?.status).toBe(400);
+    expect(harness.updateCalls).toBe(0);
+  });
+
+  it("PUT /plugins/terminal/settings rejects effort for Kimi models without effort support", async () => {
+    const harness = createRouteHarness({ body: { kimiModel: { model: "kimi-for-coding", effort: "high" } } });
+    await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
+    expect(harness.writes[0]?.status).toBe(400);
+    expect(harness.updateCalls).toBe(0);
+  });
+
+  it("PUT /plugins/terminal/settings rejects effort levels the Kimi model does not support", async () => {
+    const harness = createRouteHarness({ body: { kimiModel: { model: "k3", effort: "ultra" } } });
+    await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
+    expect(harness.writes[0]?.status).toBe(400);
+    expect(harness.updateCalls).toBe(0);
+  });
+
+  it("GET /plugins/terminal/settings returns the stored Kimi default model", async () => {
+    const harness = createRouteHarness({
+      data: { version: 1, kimiModel: { model: "k3[1m]", effort: "high" } },
+    });
+    await harness.handle({ req: req("GET"), res: res(), pathname: "/plugins/terminal/settings" });
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, codexLaunchMode: "app-server", kimiModel: { model: "k3[1m]", effort: "high" } } }]);
   });
 
   it("PUT /plugins/terminal/settings enforces terminal-origin authorization", async () => {

--- a/runtime/fleet-plugins/terminal/tests/system-prompt-settings-api.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/system-prompt-settings-api.test.ts
@@ -10,14 +10,14 @@ describe("system prompt settings api", () => {
   it("loads Terminal prompt settings from the plugin route", async () => {
     const fetchMock = vi.fn(async () => jsonResponse({ enableMetaphor: false, codexLaunchMode: "acp" }));
     vi.stubGlobal("fetch", fetchMock);
-    await expect(fetchSystemPromptSettings()).resolves.toEqual({ enableMetaphor: false, codexLaunchMode: "acp" });
+    await expect(fetchSystemPromptSettings()).resolves.toEqual({ enableMetaphor: false, codexLaunchMode: "acp", kimiModel: null });
     expect(fetchMock).toHaveBeenCalledWith("/plugins/terminal/settings", { signal: undefined });
   });
 
   it("saves the prompt boolean to the plugin route", async () => {
     const fetchMock = vi.fn(async () => jsonResponse({ enableMetaphor: true, codexLaunchMode: "acp" }));
     vi.stubGlobal("fetch", fetchMock);
-    await expect(saveSystemPromptSettings({ enableMetaphor: true })).resolves.toEqual({ enableMetaphor: true, codexLaunchMode: "acp" });
+    await expect(saveSystemPromptSettings({ enableMetaphor: true })).resolves.toEqual({ enableMetaphor: true, codexLaunchMode: "acp", kimiModel: null });
     expect(fetchMock).toHaveBeenCalledWith("/plugins/terminal/settings", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -29,7 +29,7 @@ describe("system prompt settings api", () => {
   it("saves the Codex launch mode to the plugin route", async () => {
     const fetchMock = vi.fn(async () => jsonResponse({ enableMetaphor: false, codexLaunchMode: "app-server" }));
     vi.stubGlobal("fetch", fetchMock);
-    await expect(saveSystemPromptSettings({ codexLaunchMode: "app-server" })).resolves.toEqual({ enableMetaphor: false, codexLaunchMode: "app-server" });
+    await expect(saveSystemPromptSettings({ codexLaunchMode: "app-server" })).resolves.toEqual({ enableMetaphor: false, codexLaunchMode: "app-server", kimiModel: null });
     expect(fetchMock).toHaveBeenCalledWith("/plugins/terminal/settings", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -41,6 +41,40 @@ describe("system prompt settings api", () => {
   it("rejects responses missing a required settings field", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({ enableMetaphor: false })));
     await expect(fetchSystemPromptSettings()).rejects.toThrow("Invalid Terminal settings response");
+  });
+
+  it("loads the stored Kimi default model from the plugin route", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({
+      enableMetaphor: false,
+      codexLaunchMode: "app-server",
+      kimiModel: { model: "k3", effort: "low" },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(fetchSystemPromptSettings()).resolves.toEqual({
+      enableMetaphor: false,
+      codexLaunchMode: "app-server",
+      kimiModel: { model: "k3", effort: "low" },
+    });
+  });
+
+  it("saves the Kimi default model to the plugin route", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({
+      enableMetaphor: false,
+      codexLaunchMode: "app-server",
+      kimiModel: { model: "k3[1m]", effort: "high" },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(saveSystemPromptSettings({ kimiModel: { model: "k3[1m]", effort: "high" } })).resolves.toEqual({
+      enableMetaphor: false,
+      codexLaunchMode: "app-server",
+      kimiModel: { model: "k3[1m]", effort: "high" },
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/plugins/terminal/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kimiModel: { model: "k3[1m]", effort: "high" } }),
+      signal: undefined,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Settings → Agent CLI → Settings for Kimi에 프로바이더 기본 모델/effort 선택을 추가합니다. 명시적 캐리어 모델이 없는 claude-kimi 런치(캐리어 디스패치 폴리시상 모델 미지정 캐리어 + 대화형 터미널 세션)에 적용되며, 캐리어별 명시 선택은 계속 우선합니다.
- models.json을 공식 Kimi Code 문서 기준으로 정합화합니다: K3 계열 effort `low/high/max`(기본 `high`), `fable` 티어 매핑, 모델별 `contextWindow`.
- 런치 env를 선택 모델에서 파생합니다(`ANTHROPIC_MODEL`, 티어 변수+fable, `CLAUDE_CODE_SUBAGENT_MODEL`, `AUTO_COMPACT_WINDOW`/`MAX_CONTEXT_TOKENS`, `EFFORT_LEVEL`). `AuthEnvResolver`에 모델 컨텍스트를 추가해 캐리어 명시 모델과 env가 어긋나지 않게 합니다. 엔드포인트/인증(api.kimi.com/coding + ANTHROPIC_API_KEY)은 변경하지 않습니다.

## Test Plan
- [x] 패키지 빌드·typecheck 통과 (core-infra, core-unified-agent, core-agent, fleet-admiral, fleet-carriers, terminal)
- [x] 단위 테스트: core-infra 67, fleet-admiral 81, terminal 287, ModelRegistry 11, fleet-carriers 199+신규 8 통과 (기존 실패 3건은 base 대조 확인)
- [x] console-e2e 실측: 모델 선택→effort 연동→settings.json 영속화→리로드 유지 확인
- [x] Changelog: `.changelog.d/pr-328.md` — fragment syntax·이중 언어 요약·`compile-changelog-fragments.mjs --check` 검증 완료