### PR TITLE
fix(console): activate target Operation on first palette navigation

### DIFF
--- a/.changelog.d/pr-329.md
+++ b/.changelog.d/pr-329.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Activate the selected Operation on the first command palette navigation after a reload, so its panel surfaces and accepts typing instead of only leaving the minimized state.
+  ko: 새로고침 후 커맨드 팔레트로 처음 이동해도 선택한 Operation이 활성화되어, 최소화만 풀린 채 무반응으로 남지 않고 패널이 떠오르며 바로 입력할 수 있습니다.

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -116,17 +116,27 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
     minimizeOperations(bootOperationIds.filter((id) => !protectedIds.has(id)));
   }, [claimBootPanelMinimization, operationOrder, state.activeTheaterId, state.operationsHydrated]);
 
+  const focusMapOperation = useCallback((operationId: string) => {
+    const operation = stateRef.current.operations.find((candidate) => candidate.id === operationId);
+    if (!operation) return;
+    const snapshot = getCanvasSnapshot();
+    const geometry = snapshot.operations[operationId] ?? operation.geometry ?? ensurePluginGeometry(operation);
+    if (!snapshot.operations[operationId]) setOperationGeometry(operationId, geometry);
+    // 복원과 활성화를 같은 동기 실행에서 끝내 Canvas의 최소화-active 정리 effect보다 먼저 상태를 확정한다.
+    restoreOperation(operationId);
+    setActiveOperation(operationId);
+    const viewportSize = viewportSizeFor(bodyRef.current);
+    if (viewportSize) focusCanvasOperation(operationId, viewportSize);
+  }, []);
+
   // 검색·ALERTS 등에서 들어온 일회성 이동 요청을 처리한다.
   useEffect(() => {
     const operationId = state.pendingOperationFocus;
     if (operationId === null) return;
     // loadForTheater effect가 먼저 도착 Theater의 focus layer와 Formation underlay를 복원한다.
-    void routeOperationFocus(operationId, registry.operationKinds, STABLE_RAIL_API, focusRequestEpochRef, () => {
-      const viewportSize = viewportSizeFor(bodyRef.current);
-      if (viewportSize) focusCanvasOperation(operationId, viewportSize);
-    });
+    void routeOperationFocus(operationId, registry.operationKinds, STABLE_RAIL_API, focusRequestEpochRef, () => focusMapOperation(operationId));
     consumeOperationFocus();
-  }, [registry.operationKinds, state.pendingOperationFocus]);
+  }, [focusMapOperation, registry.operationKinds, state.pendingOperationFocus]);
 
   const canLaunch = !!state.activeTheaterId && !state.addingTheater;
   const theaterOperations = (state.operations ?? []).filter((op) => op.theaterId === state.activeTheaterId);
@@ -165,16 +175,8 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       focusOperation(operationId);
       return;
     }
-    void routeOperationFocus(operationId, registry.operationKinds, STABLE_RAIL_API, focusRequestEpochRef, () => {
-      const snapshot = getCanvasSnapshot();
-      const geometry = snapshot.operations[operationId] ?? operation.geometry ?? ensurePluginGeometry(operation);
-      if (!snapshot.operations[operationId]) setOperationGeometry(operationId, geometry);
-      restoreOperation(operationId);
-      setActiveOperation(operationId);
-      const viewportSize = viewportSizeFor(bodyRef.current);
-      if (viewportSize) focusCanvasOperation(operationId, viewportSize);
-    });
-  }, [registry.operationKinds]);
+    void routeOperationFocus(operationId, registry.operationKinds, STABLE_RAIL_API, focusRequestEpochRef, () => focusMapOperation(operationId));
+  }, [focusMapOperation, registry.operationKinds]);
 
   const handleMinimize = useCallback((operationId: string) => {
     if (stateRef.current.activeOperationId === operationId) setActiveOperation(null);

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -6,8 +6,8 @@ import { BrowserRouter } from "react-router-dom";
 import type { OperationKindDescriptor } from "@fleet-console/sdk/plugin";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { clearCompanionOperationId, clearFormationView, clearMaximizedOperationId, getCompanionOperationId, getFormationView, getMaximizedOperationId, getSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, setViewport, toggleFormationView } from "../core/client/src/canvas/canvas-store.js";
-import { focusOperation, getState, hydrateOperations, setState } from "../core/client/src/store.js";
+import { clearCompanionOperationId, clearFormationView, clearMaximizedOperationId, getCompanionOperationId, getFormationView, getMaximizedOperationId, getSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, setViewport, subscribe as subscribeCanvas, toggleFormationView } from "../core/client/src/canvas/canvas-store.js";
+import { focusOperation, getState, hydrateOperations, setActiveOperation, setState } from "../core/client/src/store.js";
 import type { OperationNode, TheaterBootstrap } from "../core/client/src/types.js";
 
 const apiMocks = vi.hoisted(() => ({
@@ -234,6 +234,32 @@ describe("Operations boot minimization", () => {
     expect(event.defaultPrevented).toBe(true);
     expect(getState().activeOperationId).toBe("initial");
     expect(getSnapshot().minimized).toEqual([]);
+  });
+
+  it("restores and activates a minimized Operation before pending Map focus moves the viewport", async () => {
+    await bootApp([operation("initial")]);
+    expect(getSnapshot().minimized).toEqual(["initial"]);
+
+    const initialViewport = getSnapshot().viewport;
+    const activeIdsAtViewportChange: Array<string | null> = [];
+    const unsubscribe = subscribeCanvas(() => {
+      if (getSnapshot().viewport !== initialViewport) activeIdsAtViewportChange.push(getState().activeOperationId);
+    });
+    try {
+      await act(async () => {
+        focusOperation("initial");
+        // 자식 Canvas effect가 부모의 pending focus effect보다 먼저 활성 ID를 지우는 실제 순서를 재현한다.
+        setActiveOperation(null);
+        await Promise.resolve();
+      });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(getSnapshot().minimized).toEqual([]);
+    expect(getState().activeOperationId).toBe("initial");
+    expect(activeIdsAtViewportChange.at(-1)).toBe("initial");
+    expect(getState().keyboardFocusRequest).toEqual({ operationId: "initial", requestId: 1 });
   });
 
   it("advances the focus layer with Alt+Arrow while preserving Formation", async () => {


### PR DESCRIPTION
## Summary

- 새로고침 직후 커맨드 팔레트로 Operation을 **처음** 선택하면 패널의 최소화만 풀리고 활성화되지 않아, 패널이 무반응이고 터미널에 타이핑할 수 없던 문제를 고칩니다. 두 번째 이동부터는 이미 복원된 상태라 정상이었습니다.
- 원인은 effect 실행 순서입니다. React는 자식 effect를 부모보다 먼저 실행하므로, canvas의 "활성 Operation이 최소화 상태면 활성 해제" effect가 `pendingOperationFocus`를 소비하는 부모 effect보다 먼저 돌아 `activeOperationId`를 지웁니다. 팔레트 경로는 그 이후 콜백에서야 최소화를 풀었기 때문에 활성 상태를 잃은 뒤였습니다. 사이드바 칩 경로는 복원과 활성화를 한 동기 실행에서 끝내 영향이 없었습니다.
- `focusMapOperation` 공통 헬퍼를 추출해 `pendingOperationFocus` 경로와 사이드바 칩 경로가 모두 이를 거치도록 통일했습니다. 두 경로의 비대칭이 실제 결함이었습니다.
- canvas의 정리 effect는 건드리지 않았습니다. "최소화된 Operation이 활성으로 남으면 안 된다"는 규칙 자체는 옳습니다.

## Test Plan

- [x] `tests/operations-boot-minimization.integration.test.ts` 외 타깃 3파일 — 35 tests 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` 통과
- [x] typecheck — 선존 실패 10건 그대로, 신규 0건
- [x] 헤드리스 실측(격리 Console): 리로드 직후 패널은 `canvas-operation is-minimized` + `visibility:hidden` 상태. 수정 전에는 팔레트 선택 후 `canvas-operation`(활성 클래스 없음)으로 최소화만 풀리고 `focusin` 0건·`activeElement`가 `BODY`. 수정 후에는 `canvas-operation is-active` + `visible` + 6ms에 xterm으로 focusin
- [x] 회귀: 두 번째 팔레트 이동 4ms 정상, 사이드바 칩 경로 정상(활성·복원·터미널 포커스)
- [x] Changelog fragment — `.changelog.d/pr-329.md` (제품/섹션 문법, 이중언어 요약, `compile-changelog-fragments.mjs --check` 검증 완료)

## Notes

- PR #327의 후속입니다. 그 PR에서 발견했으나 canary baseline에서도 동일 재현되는 선존 결함으로 확인되어 별건으로 분리한 건입니다.
- 수정 전에 가설의 예측(첫 선택에서 "최소화 해제는 되지만 활성화는 안 됨")을 실측으로 먼저 확인한 뒤 구현했습니다.