### PR TITLE
feat(console): defer Analyst artifacts pane until first artifact

### DIFF
--- a/.changelog.d/pr-331.md
+++ b/.changelog.d/pr-331.md
@@ -1,0 +1,11 @@
+### fleet-console
+#### Added
+- [fleet-console] Companion panels can declare a hidden-by-default slot, and plugins can toggle per-panel visibility through the render context while the canvas animates slot changes with a reduced-motion cutoff.
+  ko: Companion 패널이 기본 숨김 슬롯을 선언할 수 있고, 플러그인이 렌더 컨텍스트로 패널별 표시 여부를 전환하며, 캔버스는 슬롯 변화를 모션 최소화 설정을 존중하는 전환으로 애니메이트합니다.
+
+### fleet-plugin
+#### Changed
+- [fleet-console] Session Analyst now opens with two panes and reveals the Artifacts pane on its own only when the analyst publishes the first artifact, instead of always reserving a third empty slot.
+  ko: Session Analyst가 이제 2개 pane으로 열리고, 항상 비어 있는 세 번째 슬롯을 예약하는 대신 분석가가 첫 artifact를 발행할 때에만 Artifacts pane이 스스로 나타납니다.
+- [fleet-console] An ARTIFACTS edge chip on the chat pane opens or hides the Artifacts pane, shows the artifact count, pulses on new arrivals while hidden, and stops auto-opening after a manual close until the artifacts are cleared.
+  ko: 채팅 pane의 ARTIFACTS 엣지 칩으로 Artifacts pane을 여닫을 수 있으며, artifact 개수를 표시하고 숨김 중 새 artifact가 오면 펄스로 알리며, 수동으로 닫은 뒤에는 artifact가 비워질 때까지 자동 오픈하지 않습니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
@@ -50,6 +50,7 @@ type Listener = () => void;
 type FocusLayerState =
   | { readonly mode: "maximized"; readonly operationId: string }
   | { readonly mode: "companion"; readonly operationId: string; readonly returnTo: "underlay" | "maximized" };
+type CompanionPanelVisibilityOverrides = Record<string, Readonly<Record<string, boolean>>>;
 
 const STORAGE_KEY_PREFIX = "fleet-console.canvas.";
 const FORMATION_LAYOUT_STORAGE_KEY = "fleet-console.formation-layout";
@@ -74,6 +75,7 @@ const EMPTY_STATE: CanvasState = { viewport: DEFAULT_VIEWPORT, operations: {}, o
 
 const listeners = new Set<Listener>();
 const focusLayerListeners = new Set<Listener>();
+const companionPanelVisibilityListeners = new Set<Listener>();
 const formationViewListeners = new Set<Listener>();
 const formationLayoutListeners = new Set<Listener>();
 const focusLayersByTheater = new Map<string, FocusLayerState>();
@@ -83,6 +85,7 @@ let saveTimer: number | null = null;
 let state: CanvasState = EMPTY_STATE;
 let focusLayer: FocusLayerState | null = null;
 let focusLayerRevision = 0;
+let companionPanelVisibilityOverrides: CompanionPanelVisibilityOverrides = {};
 let formationView = false;
 let formationLayout = readStoredFormationLayout();
 // 줌 보간 루프가 향하는 목표 viewport. 즉시 이동(pan/focus/load)은 이 값을 current와 동기화해 잔여 보간을 무효화한다.
@@ -150,6 +153,25 @@ export function useMaximizedOperationId(): string | null {
 
 export function useCompanionOperationId(): string | null {
   return useSyncExternalStore(subscribeFocusLayer, getCompanionOperationId, getCompanionOperationId);
+}
+
+export function getCompanionPanelVisibilityOverrides(operationId: string): Readonly<Record<string, boolean>> {
+  return companionPanelVisibilityOverrides[operationId] ?? {};
+}
+
+export function useCompanionPanelVisibilityOverrides(operationId: string | null): Readonly<Record<string, boolean>> {
+  const snapshot = useSyncExternalStore(subscribeCompanionPanelVisibility, getCompanionPanelVisibilitySnapshot, getCompanionPanelVisibilitySnapshot);
+  return operationId === null ? {} : snapshot[operationId] ?? {};
+}
+
+export function setCompanionPanelVisible(operationId: string, companionPanelId: string, visible: boolean): void {
+  const current = companionPanelVisibilityOverrides[operationId] ?? {};
+  if (current[companionPanelId] === visible) return;
+  companionPanelVisibilityOverrides = {
+    ...companionPanelVisibilityOverrides,
+    [operationId]: { ...current, [companionPanelId]: visible },
+  };
+  emitCompanionPanelVisibility();
 }
 
 export function useFormationView(): boolean {
@@ -499,6 +521,8 @@ export function clearMaximizedOperationId(): void {
 }
 
 export function setCompanionOperationId(operationId: string): void {
+  // ANALYZE 진입마다 descriptor 기본 가시성에서 다시 시작하고, 플러그인이 현재 artifact 상태로 보정한다.
+  clearCompanionPanelVisibilityOverrides(operationId);
   const returnTo = focusLayer?.mode === "companion"
     ? focusLayer.returnTo
     : focusLayer?.mode === "maximized" ? "maximized" : "underlay";
@@ -507,6 +531,11 @@ export function setCompanionOperationId(operationId: string): void {
 }
 
 function setFocusLayer(nextFocusLayer: FocusLayerState): void {
+  // companion 대상이 다른 레이어로 교체되는 전이(retarget·maximize)도 이전 대상의
+  // 가시성 오버라이드를 정리한다 — Theater 전환 보존은 이 함수를 타지 않는다.
+  if (focusLayer?.mode === "companion" && !(nextFocusLayer.mode === "companion" && nextFocusLayer.operationId === focusLayer.operationId)) {
+    clearCompanionPanelVisibilityOverrides(focusLayer.operationId);
+  }
   const minimized = state.minimized.filter((sessionId) => sessionId !== nextFocusLayer.operationId);
   const minimizedChanged = !stringArraysEqual(state.minimized, minimized);
   const focusLayerChanged = !focusLayersEqual(focusLayer, nextFocusLayer);
@@ -529,13 +558,16 @@ export function clearCompanionOperationId(): void {
     if (focusLayer) focusLayersByTheater.set(activeTheaterId, focusLayer);
     else focusLayersByTheater.delete(activeTheaterId);
   }
+  clearCompanionPanelVisibilityOverrides(closingLayer.operationId);
   emitFocusLayer();
 }
 
 export function forceDropCompanionOperationId(): void {
   if (focusLayer?.mode !== "companion") return;
+  const closingOperationId = focusLayer.operationId;
   focusLayer = null;
   if (activeTheaterId) focusLayersByTheater.delete(activeTheaterId);
+  clearCompanionPanelVisibilityOverrides(closingOperationId);
   emitFocusLayer();
 }
 
@@ -623,6 +655,29 @@ function subscribeFocusLayer(listener: Listener): () => void {
   return () => {
     focusLayerListeners.delete(listener);
   };
+}
+
+function subscribeCompanionPanelVisibility(listener: Listener): () => void {
+  companionPanelVisibilityListeners.add(listener);
+  return () => {
+    companionPanelVisibilityListeners.delete(listener);
+  };
+}
+
+function getCompanionPanelVisibilitySnapshot(): CompanionPanelVisibilityOverrides {
+  return companionPanelVisibilityOverrides;
+}
+
+function emitCompanionPanelVisibility(): void {
+  for (const listener of companionPanelVisibilityListeners) listener();
+}
+
+function clearCompanionPanelVisibilityOverrides(operationId: string): void {
+  if (!(operationId in companionPanelVisibilityOverrides)) return;
+  const remaining = { ...companionPanelVisibilityOverrides };
+  delete remaining[operationId];
+  companionPanelVisibilityOverrides = remaining;
+  emitCompanionPanelVisibility();
 }
 
 function emitFormationView(): void {

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -9,7 +9,7 @@ import { flattenGroupedOrder, hydrateOperations, setActiveOperation } from "../s
 import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import type { ConsoleState, OperationNode } from "../types.js";
-import { calculateGridSlots, animateViewportTo, claimTopZIndex, clearCompanionOperationId, clearMaximizedOperationId, focusOperation, forceDropCompanionOperationId, getSnapshot as getCanvasSnapshot, minimizeOperation, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, setViewport, useCanvasState, useCompanionOperationId, useFormationLayout, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "./canvas-store.js";
+import { calculateGridSlots, animateViewportTo, claimTopZIndex, clearCompanionOperationId, clearMaximizedOperationId, focusOperation, forceDropCompanionOperationId, getSnapshot as getCanvasSnapshot, minimizeOperation, restoreOperation, setCompanionOperationId, setCompanionPanelVisible, setMaximizedOperationId, setOperationGeometry, setViewport, useCanvasState, useCompanionOperationId, useCompanionPanelVisibilityOverrides, useFormationLayout, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "./canvas-store.js";
 import { CanvasContextMenu } from "./canvas-context-menu.js";
 import { CanvasMinimap } from "./canvas-minimap.js";
 import { resolveAccentColor } from "./operation-accent.js";
@@ -50,6 +50,8 @@ interface PluginOperationRendererProps {
   readonly onGeometryChange: (geometry: OperationGeometry) => void;
   readonly onRequestCompanions: (open: boolean) => void;
   readonly companionsOpen: boolean;
+  readonly hiddenCompanionPanelIds: readonly string[];
+  readonly onSetCompanionPanelVisible: (companionPanelId: string, visible: boolean) => void;
   readonly render: (context: OperationRenderContext) => unknown;
 }
 
@@ -77,6 +79,7 @@ export function OperationsCanvas({
   const formationView = useFormationView();
   const maximizedOperationId = useMaximizedOperationId();
   const companionOperationId = useCompanionOperationId();
+  const companionPanelVisibilityOverrides = useCompanionPanelVisibilityOverrides(companionOperationId);
   const lastValidCompanionRef = useRef<{ readonly operation: OperationNode; readonly descriptor: OperationKindDescriptor } | null>(null);
   const minimized = useMinimized();
   const activePluginOperationId = state.activeOperationId;
@@ -157,6 +160,8 @@ export function OperationsCanvas({
   const companionOperation = currentCompanionOperation ?? preservedCompanion?.operation;
   const companionDescriptor = currentCompanionDescriptor ?? preservedCompanion?.descriptor;
   const companionPanels = companionDescriptor?.companions ?? [];
+  const visibleCompanionPanels = companionPanels.filter((panel) => companionPanelVisibilityOverrides[panel.id] ?? !panel.defaultHidden);
+  const hiddenCompanionPanelIds = companionPanels.filter((panel) => !visibleCompanionPanels.includes(panel)).map((panel) => panel.id);
   const panelCompanion = companionOperation && companionPanels.length > 0 ? companionOperation.id : null;
   const currentPanelCompanion = currentCompanionOperation && currentCompanionDescriptor?.companions?.length ? currentCompanionOperation.id : null;
   const pluginOperations = companionOperation && !theaterOperations.some((operation) => operation.id === companionOperation.id)
@@ -184,7 +189,7 @@ export function OperationsCanvas({
   // 최대화 시에는 net scale 1(기본 줌)로 렌더한다 — 현재 배율과 무관하게 터미널이 선명하게 그려진다.
   const effectiveZoom = panelMaximized || panelCompanion || formationView ? 1 : canvas.viewport.zoom;
   const topPanelZIndex = maxOperationZIndex(canvas.operations) + 1;
-  const companionSlotCount = companionPanels.length + 1;
+  const companionSlotCount = visibleCompanionPanels.length + 1;
 
   return (
     <main
@@ -238,8 +243,9 @@ export function OperationsCanvas({
             minimized: minimizedSet.has(operation.id),
             maximized: operationMaximized,
             companion: operationCompanion,
-            companions: operationCompanion ? companionPanels : [],
-            companionGeometries: operationCompanion ? companionPanels.map((_, index) => companionGeometryFor(canvasSize, index + 1, companionSlotCount, topPanelZIndex)) : [],
+            companions: operationCompanion ? visibleCompanionPanels : [],
+            companionGeometries: operationCompanion ? visibleCompanionPanels.map((_, index) => companionGeometryFor(canvasSize, index + 1, companionSlotCount, topPanelZIndex)) : [],
+            hiddenCompanionPanelIds: operationCompanion ? hiddenCompanionPanelIds : [],
             formation: formationView,
             focusLayerHidden,
             onRenderHiddenFocus: () => {
@@ -452,6 +458,7 @@ function renderPluginOperation(operation: OperationNode, options: {
   readonly companion: boolean;
   readonly companions: readonly CompanionPanelDescriptor[];
   readonly companionGeometries: readonly OperationGeometry[];
+  readonly hiddenCompanionPanelIds: readonly string[];
   readonly formation: boolean;
   readonly focusLayerHidden: boolean;
   readonly onRenderHiddenFocus: () => void;
@@ -477,6 +484,9 @@ function renderPluginOperation(operation: OperationNode, options: {
       setActiveOperation(operation.id);
       setCompanionOperationId(operation.id);
     } else clearCompanionOperationId();
+  };
+  const onSetCompanionPanelVisible = (companionPanelId: string, visible: boolean) => {
+    setCompanionPanelVisible(operation.id, companionPanelId, visible);
   };
   return (
     <Fragment key={operation.id}>
@@ -517,6 +527,8 @@ function renderPluginOperation(operation: OperationNode, options: {
             onGeometryChange={options.onGeometryChange}
             onRequestCompanions={onRequestCompanions}
             companionsOpen={options.companion}
+            hiddenCompanionPanelIds={options.hiddenCompanionPanelIds}
+            onSetCompanionPanelVisible={onSetCompanionPanelVisible}
             render={descriptor.render}
           />
         </PluginErrorBoundary>
@@ -536,6 +548,8 @@ function renderPluginOperation(operation: OperationNode, options: {
               onGeometryChange={options.onGeometryChange}
               onRequestCompanions={onRequestCompanions}
               companionsOpen={options.companion}
+              hiddenCompanionPanelIds={options.hiddenCompanionPanelIds}
+              onSetCompanionPanelVisible={onSetCompanionPanelVisible}
               render={companion.render}
             />
           </PluginErrorBoundary>
@@ -558,6 +572,8 @@ function PluginOperationRenderer({
   onGeometryChange,
   onRequestCompanions,
   companionsOpen,
+  hiddenCompanionPanelIds,
+  onSetCompanionPanelVisible,
   render,
 }: PluginOperationRendererProps) {
   return render({
@@ -584,6 +600,8 @@ function PluginOperationRenderer({
     onGeometryChange,
     onRequestCompanions,
     companionsOpen,
+    hiddenCompanionPanelIds,
+    onSetCompanionPanelVisible,
   }) as ReactNode;
 }
 

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -1970,6 +1970,13 @@
   min-height: 0;
 }
 
+/* companion 슬롯 수 변경만 부드럽게 재배치한다 — 일반 Map 드래그에는 위치 transition을 노출하지 않는다. */
+.operations-canvas.is-companion-layout .canvas-operation {
+  transition:
+    left var(--duration-slow) var(--ease-glide),
+    width var(--duration-slow) var(--ease-glide);
+}
+
 .canvas-operation.is-minimized {
   visibility: hidden;
   pointer-events: none;
@@ -2010,6 +2017,22 @@
 .canvas-companion-frame {
   display: flex;
   flex-direction: column;
+  animation: companion-frame-enter var(--duration-slow) var(--ease-glide) both;
+}
+
+@keyframes companion-frame-enter {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .operations-canvas.is-companion-layout .canvas-operation {
+    transition: none;
+  }
+
+  .canvas-companion-frame {
+    animation: none;
+  }
 }
 
 .canvas-companion-caption {

--- a/runtime/fleet-console/sdk/plugin/types.ts
+++ b/runtime/fleet-console/sdk/plugin/types.ts
@@ -105,6 +105,7 @@ export interface CompanionPanelDescriptor {
   readonly id: string;
   readonly title: string;
   readonly hideCaption?: boolean;
+  readonly defaultHidden?: boolean;
   readonly render: (context: OperationRenderContext) => unknown;
 }
 
@@ -142,6 +143,10 @@ export interface OperationRenderContext extends OperationContext {
   /** Requests host-owned companion panels without exposing Canvas implementation to plugins. */
   readonly onRequestCompanions?: (open: boolean) => void;
   readonly companionsOpen?: boolean;
+  /** Host-owned effective companion visibility; `undefined` denotes a host without per-panel visibility support. */
+  readonly hiddenCompanionPanelIds?: readonly string[];
+  /** Requests a volatile host-owned visibility override for one companion panel. */
+  readonly onSetCompanionPanelVisible?: (companionPanelId: string, visible: boolean) => void;
 }
 
 export interface FleetPluginManifest {

--- a/runtime/fleet-console/tests/canvas-store.test.ts
+++ b/runtime/fleet-console/tests/canvas-store.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { calculateGridSlots, clearCompanionOperationId, clearFormationView, clearMaximizedOperationId, forceDropCompanionOperationId, getCompanionOperationId, getFormationLayout, getFormationView, getMaximizedOperationId, getSnapshot, getTheaterCanvasSnapshot, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, selectFormationLayout, setCompanionOperationId, setFormationLayout, setMaximizedOperationId, setOperationAccent, setOperationGeometry, setOperationOrder, setState, toggleFormationView, toggleTheaterGroupCollapsed, type OperationGeometry } from "../core/client/src/canvas/canvas-store.js";
+import { calculateGridSlots, clearCompanionOperationId, clearFormationView, clearMaximizedOperationId, forceDropCompanionOperationId, getCompanionOperationId, getCompanionPanelVisibilityOverrides, getFormationLayout, getFormationView, getMaximizedOperationId, getSnapshot, getTheaterCanvasSnapshot, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, selectFormationLayout, setCompanionOperationId, setCompanionPanelVisible, setFormationLayout, setMaximizedOperationId, setOperationAccent, setOperationGeometry, setOperationOrder, setState, toggleFormationView, toggleTheaterGroupCollapsed, type OperationGeometry } from "../core/client/src/canvas/canvas-store.js";
 
 const GEOMETRY: OperationGeometry = { x: 0, y: 0, width: 100, height: 100, zIndex: 0 };
 
@@ -37,6 +37,41 @@ afterEach(() => {
 });
 
 describe("canvas store", () => {
+  it("keeps companion visibility overrides per Operation and resets them on Analyze entry", () => {
+    setCompanionPanelVisible("op-a", "artifacts", true);
+    setCompanionPanelVisible("op-b", "artifacts", false);
+
+    expect(getCompanionPanelVisibilityOverrides("op-a")).toEqual({ artifacts: true });
+    expect(getCompanionPanelVisibilityOverrides("op-b")).toEqual({ artifacts: false });
+
+    setCompanionOperationId("op-a");
+    expect(getCompanionPanelVisibilityOverrides("op-a")).toEqual({});
+    expect(getCompanionPanelVisibilityOverrides("op-b")).toEqual({ artifacts: false });
+  });
+
+  it("clears companion visibility overrides on normal Exit and force-drop", () => {
+    setCompanionOperationId("op-a");
+    setCompanionPanelVisible("op-a", "artifacts", true);
+    clearCompanionOperationId();
+    expect(getCompanionPanelVisibilityOverrides("op-a")).toEqual({});
+
+    setCompanionOperationId("op-b");
+    setCompanionPanelVisible("op-b", "artifacts", false);
+    forceDropCompanionOperationId();
+    expect(getCompanionPanelVisibilityOverrides("op-b")).toEqual({});
+  });
+
+  it("clears the previous companion target's overrides on retarget and maximize replacement", () => {
+    setCompanionOperationId("op-a");
+    setCompanionPanelVisible("op-a", "artifacts", true);
+    setCompanionOperationId("op-b");
+    expect(getCompanionPanelVisibilityOverrides("op-a")).toEqual({});
+
+    setCompanionPanelVisible("op-b", "artifacts", true);
+    setMaximizedOperationId("op-c");
+    expect(getCompanionPanelVisibilityOverrides("op-b")).toEqual({});
+  });
+
   it("captures Map underlay once, retargets without mutating it, and exits to Map", () => {
     setOperationGeometry("op-a", { ...GEOMETRY, x: 48, y: 72 });
     setOperationGeometry("op-b", { ...GEOMETRY });

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-artifacts-chip.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-artifacts-chip.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OperationRenderContext } from "@fleet-console/sdk/plugin";
+
+import { analysisReducer, initialAnalysisState, type AnalysisAction, type AnalysisState } from "./analysis-state.js";
+
+vi.mock("@fleet-console/markdown/core", () => ({ renderMarkdown: (text: string) => ({ html: text }) }));
+vi.mock("@fleet-console/markdown/mermaid", () => ({ installDiagramHydrator: vi.fn() }));
+
+let storeState: AnalysisState;
+const dispatch = vi.fn((action: AnalysisAction) => {
+  storeState = analysisReducer(storeState, action);
+});
+vi.mock("./analysis-store.js", () => ({
+  useAnalysisStore: () => ({
+    state: storeState,
+    dispatch: (action: AnalysisAction) => dispatch(action),
+    send: vi.fn(async () => undefined),
+    stop: vi.fn(async () => undefined),
+    reset: vi.fn(async () => undefined),
+  }),
+}));
+
+import { ANALYST_ARTIFACTS_COMPANION_ID, AnalystChatPanel } from "./analysis-chat-panel.js";
+
+describe("Session Analyst Artifacts chip", () => {
+  beforeEach(() => {
+    storeState = initialAnalysisState;
+    dispatch.mockClear();
+  });
+
+  it("re-arms the analysis store when artifacts are cleared or the session resets", () => {
+    const disarmed = { ...withArtifacts(1), artifactsAutoOpenArmed: false };
+    expect(analysisReducer(disarmed, { type: "clear-artifacts" })).toMatchObject({
+      artifacts: [],
+      artifactsAutoOpenArmed: true,
+    });
+    expect(analysisReducer(disarmed, { type: "reset" }).artifactsAutoOpenArmed).toBe(true);
+  });
+
+  it("stays absent on older hosts and renders the waiting contract on supporting hosts", () => {
+    const legacy = mountPanel({ operationId: "op-a" } as OperationRenderContext);
+    expect(legacy.container.querySelector('[aria-label="Open Artifacts"]')).toBeNull();
+    legacy.unmount();
+
+    const setVisible = vi.fn();
+    const supported = mountPanel(contextWithVisibility([ANALYST_ARTIFACTS_COMPANION_ID], setVisible));
+    const chip = supported.container.querySelector<HTMLButtonElement>('[aria-label="Open Artifacts"]')!;
+    expect(chip.disabled).toBe(false);
+    expect(chip.classList.contains("is-waiting")).toBe(true);
+    expect(chip.title).toBe("Artifacts the analyst publishes appear here");
+    expect(chip.getAttribute("aria-pressed")).toBe("false");
+    expect(chip.getAttribute("aria-disabled")).toBe("true");
+    expect(chip.tabIndex).toBe(-1);
+    expect(chip.querySelector(".session-analyst-handle__chev")?.textContent).toBe("»");
+    expect(chip.querySelector(".session-analyst-handle__count")).toBeNull();
+    expect(setVisible).not.toHaveBeenCalled();
+    supported.unmount();
+  });
+
+  it("auto-opens on the first artifact, then disarms after a user hide and pulses later counts", () => {
+    const setVisible = vi.fn();
+    const mounted = mountPanel(contextWithVisibility([ANALYST_ARTIFACTS_COMPANION_ID], setVisible));
+
+    storeState = withArtifacts(1);
+    mounted.render(contextWithVisibility([ANALYST_ARTIFACTS_COMPANION_ID], setVisible));
+    expect(setVisible).toHaveBeenLastCalledWith(ANALYST_ARTIFACTS_COMPANION_ID, true);
+
+    mounted.render(contextWithVisibility([], setVisible));
+    const visibleChip = mounted.container.querySelector<HTMLButtonElement>('[aria-label="Hide Artifacts"]')!;
+    expect(visibleChip.getAttribute("aria-pressed")).toBe("true");
+    expect(visibleChip.querySelector(".session-analyst-handle__chev")?.textContent).toBe("«");
+    act(() => visibleChip.click());
+    expect(setVisible).toHaveBeenLastCalledWith(ANALYST_ARTIFACTS_COMPANION_ID, false);
+    expect(storeState.artifactsAutoOpenArmed).toBe(false);
+
+    setVisible.mockClear();
+    mounted.render(contextWithVisibility([ANALYST_ARTIFACTS_COMPANION_ID], setVisible));
+    storeState = withArtifacts(2);
+    mounted.render(contextWithVisibility([ANALYST_ARTIFACTS_COMPANION_ID], setVisible));
+    expect(setVisible).not.toHaveBeenCalled();
+    const count = mounted.container.querySelector(".session-analyst-handle__count")!;
+    expect(count.textContent).toBe("2");
+    expect(count.classList.contains("is-pulsing")).toBe(true);
+    mounted.unmount();
+  });
+
+  it("preserves a user disarm across a chat-panel remount", () => {
+    const setVisible = vi.fn();
+    storeState = withArtifacts(1);
+    const mounted = mountPanel(contextWithVisibility([], setVisible));
+    const visibleChip = mounted.container.querySelector<HTMLButtonElement>('[aria-label="Hide Artifacts"]')!;
+    act(() => visibleChip.click());
+    expect(storeState.artifactsAutoOpenArmed).toBe(false);
+    mounted.unmount();
+
+    setVisible.mockClear();
+    const returned = mountPanel(contextWithVisibility([ANALYST_ARTIFACTS_COMPANION_ID], setVisible));
+    expect(setVisible).not.toHaveBeenCalled();
+    expect(returned.container.querySelector(".session-analyst-handle__count")?.textContent).toBe("1");
+    returned.unmount();
+  });
+
+  it("closes and re-arms at zero, and opens immediately when remounted with stored artifacts", () => {
+    const setVisible = vi.fn();
+    storeState = { ...withArtifacts(1), artifactsAutoOpenArmed: false };
+    const mounted = mountPanel(contextWithVisibility([], setVisible));
+
+    storeState = { ...initialAnalysisState, artifactsAutoOpenArmed: false };
+    mounted.render(contextWithVisibility([], setVisible));
+    expect(setVisible).toHaveBeenLastCalledWith(ANALYST_ARTIFACTS_COMPANION_ID, false);
+    expect(storeState.artifactsAutoOpenArmed).toBe(true);
+
+    setVisible.mockClear();
+    mounted.render(contextWithVisibility([ANALYST_ARTIFACTS_COMPANION_ID], setVisible));
+    storeState = withArtifacts(1);
+    mounted.render(contextWithVisibility([ANALYST_ARTIFACTS_COMPANION_ID], setVisible));
+    expect(setVisible).toHaveBeenLastCalledWith(ANALYST_ARTIFACTS_COMPANION_ID, true);
+    mounted.unmount();
+
+    setVisible.mockClear();
+    const reopened = mountPanel(contextWithVisibility([ANALYST_ARTIFACTS_COMPANION_ID], setVisible));
+    expect(setVisible).toHaveBeenLastCalledWith(ANALYST_ARTIFACTS_COMPANION_ID, true);
+    reopened.unmount();
+  });
+
+  it("returns focus from a cleared Artifacts pane to the waiting chip", () => {
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    const setVisible = vi.fn();
+    storeState = withArtifacts(1);
+    const mounted = mountPanel(contextWithVisibility([], setVisible));
+    const artifactsPane = document.createElement("section");
+    artifactsPane.className = "session-analyst__artifacts";
+    const focusedControl = document.createElement("button");
+    artifactsPane.append(focusedControl);
+    document.body.append(artifactsPane);
+    focusedControl.focus();
+
+    storeState = initialAnalysisState;
+    mounted.render(contextWithVisibility([], setVisible));
+
+    expect(setVisible).toHaveBeenLastCalledWith(ANALYST_ARTIFACTS_COMPANION_ID, false);
+    expect(document.activeElement).toBe(mounted.container.querySelector('[aria-label="Open Artifacts"]'));
+    artifactsPane.remove();
+    mounted.unmount();
+    vi.unstubAllGlobals();
+  });
+});
+
+function withArtifacts(count: number): AnalysisState {
+  return {
+    ...initialAnalysisState,
+    artifacts: Array.from({ length: count }, (_, index) => ({
+      id: `artifact-${index}`,
+      title: `Artifact ${index}`,
+      html: `<p>${index}</p>`,
+      createdAt: index,
+    })),
+  };
+}
+
+function contextWithVisibility(hiddenCompanionPanelIds: readonly string[], onSetCompanionPanelVisible: (companionPanelId: string, visible: boolean) => void): OperationRenderContext {
+  return { operationId: "op-a", hiddenCompanionPanelIds, onSetCompanionPanelVisible } as OperationRenderContext;
+}
+
+function mountPanel(initialContext: OperationRenderContext): {
+  readonly container: HTMLDivElement;
+  readonly render: (context: OperationRenderContext) => void;
+  readonly unmount: () => void;
+} {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root: Root = createRoot(container);
+  const render = (context: OperationRenderContext) => {
+    act(() => root.render(createElement(AnalystChatPanel, { context })));
+  };
+  render(initialContext);
+  return {
+    container,
+    render,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
@@ -14,6 +14,7 @@ const SUGGESTIONS = [
   { icon: "≡", tone: "brass", text: "Draft a handoff brief" },
 ] as const;
 const STREAM_RENDER_DELAY_MS = 32;
+export const ANALYST_ARTIFACTS_COMPANION_ID = "session-analyst-artifacts";
 
 export function AnalystChatPanel({ context }: { readonly context: OperationRenderContext }) {
   const { state, dispatch, send, stop, reset } = useAnalysisStore(context);
@@ -21,6 +22,15 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
   const cli = state.catalog?.clis.find((item) => item.cliId === state.cliId);
   const model = cli?.models.find((item) => item.id === state.model);
   const hasInteracted = state.entries.length > 0;
+  const artifactCount = state.artifacts.length;
+  const hiddenCompanionPanelIds = context.hiddenCompanionPanelIds;
+  const setCompanionPanelVisible = context.onSetCompanionPanelVisible;
+  const supportsCompanionVisibility = hiddenCompanionPanelIds !== undefined && setCompanionPanelVisible !== undefined;
+  const artifactsHidden = hiddenCompanionPanelIds?.includes(ANALYST_ARTIFACTS_COMPANION_ID) ?? false;
+  const artifactsVisible = artifactCount > 0 && !artifactsHidden;
+  const previousArtifactCountRef = React.useRef(0);
+  const [countPulseRevision, setCountPulseRevision] = React.useState(0);
+  const artifactsChipRef = React.useRef<HTMLButtonElement>(null);
   const chatRef = React.useRef<HTMLElement>(null);
   const latestEntry = state.entries.at(-1);
   // 첫 상호작용이 이 마운트에서 발생했을 때만 도킹 모션을 붙인다. 클래스를 계속
@@ -36,6 +46,26 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
     const chat = chatRef.current;
     if (chat) installDiagramHydrator(chat);
   }, []);
+  React.useEffect(() => {
+    const previousCount = previousArtifactCountRef.current;
+    previousArtifactCountRef.current = artifactCount;
+    if (!supportsCompanionVisibility || !setCompanionPanelVisible) return;
+    if (artifactCount === 0) {
+      if (!state.artifactsAutoOpenArmed) dispatch({ type: "artifacts-chip-rearm" });
+      if (!artifactsHidden) {
+        const returnFocusToChip = document.activeElement instanceof Element
+          && document.activeElement.closest(".session-analyst__artifacts") !== null;
+        setCompanionPanelVisible(ANALYST_ARTIFACTS_COMPANION_ID, false);
+        if (returnFocusToChip) window.requestAnimationFrame(() => artifactsChipRef.current?.focus());
+      }
+      return;
+    }
+    if (previousCount === 0 && artifactsHidden && state.artifactsAutoOpenArmed) {
+      setCompanionPanelVisible(ANALYST_ARTIFACTS_COMPANION_ID, true);
+      return;
+    }
+    if (artifactCount > previousCount && artifactsHidden) setCountPulseRevision((revision) => revision + 1);
+  }, [artifactCount, artifactsHidden, dispatch, setCompanionPanelVisible, state.artifactsAutoOpenArmed, supportsCompanionVisibility]);
   const submit = async (text: string) => {
     const trimmed = text.trim();
     if (!trimmed || state.busy) return;
@@ -52,6 +82,27 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
 
   return (
     <section className={`session-analyst__chat-pane ${hasInteracted ? "has-interacted" : "is-initial"}`} aria-label="Session Analyst chat" data-phase={state.phase}>
+      {supportsCompanionVisibility ? (
+        <button
+          ref={artifactsChipRef}
+          type="button"
+          className={`session-analyst-handle session-analyst-handle--artifacts${artifactCount === 0 ? " is-waiting" : ""}`}
+          aria-label={artifactsVisible ? "Hide Artifacts" : "Open Artifacts"}
+          aria-pressed={artifactsVisible}
+          aria-disabled={artifactCount === 0}
+          tabIndex={artifactCount === 0 ? -1 : undefined}
+          title={artifactCount === 0 ? "Artifacts the analyst publishes appear here" : undefined}
+          onClick={() => {
+            if (!setCompanionPanelVisible || artifactCount === 0) return;
+            if (artifactsVisible) dispatch({ type: "artifacts-chip-disarm" });
+            setCompanionPanelVisible(ANALYST_ARTIFACTS_COMPANION_ID, !artifactsVisible);
+          }}
+        >
+          <span className="session-analyst-handle__chev" aria-hidden="true">{artifactsVisible ? "«" : "»"}</span>
+          {artifactCount > 0 ? <span key={countPulseRevision} className={`session-analyst-handle__count${countPulseRevision > 0 ? " is-pulsing" : ""}`}>{artifactCount}</span> : null}
+          <span className="session-analyst-handle__label">ARTIFACTS</span>
+        </button>
+      ) : null}
       <PanelHeader state={state} onReset={() => { void reset().then(() => setDraft("")).catch(() => {}); }} />
       <div className="session-analyst__workspace">
         <section ref={chatRef} className="session-analyst__chat" aria-live="polite" aria-busy={state.busy}>

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-panel.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-panel.test.tsx
@@ -52,20 +52,18 @@ describe("Session Analyst contract", () => {
   });
   it("registers the two companion chips on the Agent operation kind", () => {
     const source = readFileSync(new URL("./index.tsx", import.meta.url), "utf8");
-    const companions = [...source.matchAll(/\{ id: "([^"]+)", title: "([^"]+)"/g)].map((match) => ({ id: match[1], title: match[2] }));
-    expect(companions).toMatchInlineSnapshot(`
-      [
-        {
-          "id": "session-analyst-chat",
-          "title": "Session Analyst",
-        },
-        {
-          "id": "session-analyst-artifacts",
-          "title": "Artifacts",
-        },
-      ]
-    `);
+    const chat = readFileSync(new URL("./analysis-chat-panel.tsx", import.meta.url), "utf8");
+    expect(source).toContain('{ id: "session-analyst-chat", title: "Session Analyst"');
+    expect(source).toContain('{ id: ANALYST_ARTIFACTS_COMPANION_ID, title: "Artifacts", hideCaption: true, defaultHidden: true');
+    expect(chat).toContain('export const ANALYST_ARTIFACTS_COMPANION_ID = "session-analyst-artifacts";');
     expect(source.match(/hideCaption: true/g)).toHaveLength(2);
+    expect(source.match(/defaultHidden: true/g)).toHaveLength(1);
     expect(source).toContain("context.onRequestCompanions?.(!context.companionsOpen)");
+    expect(source).toContain("previousCompanionsOpenRef");
+    // dispose 경합에서 orphan store를 만들지 않도록 re-arm은 조회 전용 API만 사용한다.
+    expect(source).toContain("rearmAnalysisArtifacts(context.operationId)");
+    expect(source).not.toContain("getAnalysisStore");
+    const storeSource = readFileSync(new URL("./analysis-store.ts", import.meta.url), "utf8");
+    expect(storeSource).toContain('stores.get(operationId)?.dispatch({ type: "artifacts-chip-rearm" });');
   });
 });

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-state.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-state.ts
@@ -25,6 +25,7 @@ export interface AnalysisState {
   readonly entries: readonly AnalysisEntry[];
   readonly tools: readonly { readonly title: string; readonly status: string }[];
   readonly artifacts: readonly AnalysisArtifact[];
+  readonly artifactsAutoOpenArmed: boolean;
   readonly error: string | null;
 }
 
@@ -42,6 +43,7 @@ export const initialAnalysisState: AnalysisState = {
   entries: [],
   tools: [],
   artifacts: [],
+  artifactsAutoOpenArmed: true,
   error: null,
 };
 
@@ -58,7 +60,9 @@ export type AnalysisAction =
   | { readonly type: "stopped"; readonly now: number }
   | { readonly type: "stop-failed"; readonly message: string; readonly now: number }
   | { readonly type: "reset" }
-  | { readonly type: "clear-artifacts" };
+  | { readonly type: "clear-artifacts" }
+  | { readonly type: "artifacts-chip-disarm" }
+  | { readonly type: "artifacts-chip-rearm" };
 
 export function analysisReducer(state: AnalysisState, action: AnalysisAction): AnalysisState {
   if (action.type === "catalog") {
@@ -95,7 +99,9 @@ export function analysisReducer(state: AnalysisState, action: AnalysisAction): A
     const catalog = state.catalog;
     return catalog ? { ...initialAnalysisState, catalog, ...resolveInitialSelection(catalog) } : initialAnalysisState;
   }
-  if (action.type === "clear-artifacts") return { ...state, artifacts: [] };
+  if (action.type === "clear-artifacts") return { ...state, artifacts: [], artifactsAutoOpenArmed: true };
+  if (action.type === "artifacts-chip-disarm") return state.artifactsAutoOpenArmed ? { ...state, artifactsAutoOpenArmed: false } : state;
+  if (action.type === "artifacts-chip-rearm") return state.artifactsAutoOpenArmed ? state : { ...state, artifactsAutoOpenArmed: true };
   if (action.type !== "event") return state;
 
   const event = action.event;

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-store.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-store.ts
@@ -43,6 +43,11 @@ export function disposeAnalysisStore(operationId: string): void {
   stores.get(operationId)?.dispose();
 }
 
+// re-arm 전용 조회 API — dispose된 Operation의 store를 재생성하지 않아야 한다(orphan 방지).
+export function rearmAnalysisArtifacts(operationId: string): void {
+  stores.get(operationId)?.dispatch({ type: "artifacts-chip-rearm" });
+}
+
 const CONNECT_WAIT_MS = 2_000;
 const RESPONSE_TIMEOUT_MS = 120_000;
 

--- a/runtime/fleet-plugins/terminal/client/agent/analysis.css
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis.css
@@ -3,11 +3,13 @@
 .session-analyst-handle:hover { transform: translate(-2px, -50%); background: color-mix(in oklch, var(--ink-mid) 72%, var(--ink-deep)); color: var(--text-secondary); box-shadow: inset 2px 0 0 color-mix(in oklch, var(--aurora) 32%, transparent); }
 .session-analyst-handle__chev { font-size: 13px; line-height: 1; }
 .session-analyst-handle__label { writing-mode: vertical-rl; font-size: 8.5px; font-weight: 600; letter-spacing: .18em; }
+.session-analyst-handle__count { display: grid; place-items: center; min-width: 16px; min-height: 16px; border-radius: 999px; background: color-mix(in oklch, var(--aurora) 16%, transparent); color: var(--aurora); font: 700 9px/1 var(--font-mono); }
+.session-analyst-handle__count.is-pulsing { animation: analyst-artifact-count-pulse var(--duration-slow) var(--ease-glide); }
 .session-analyst-handle.is-waiting { opacity: .45; border-color: var(--hairline); color: var(--text-tertiary); cursor: default; box-shadow: none; }
 .session-analyst-handle.is-waiting:hover { transform: translateY(-50%); background: var(--ink-deep); }
 .session-analyst-handle:focus-visible, .session-analyst__chat-pane button:focus-visible, .session-analyst__artifacts button:focus-visible { outline: 2px solid var(--aurora); outline-offset: 2px; }
 
-.session-analyst__chat-pane { container-type: inline-size; box-sizing: border-box; display: grid; grid-template-columns: minmax(0, 1fr); grid-template-rows: auto minmax(0, 1fr); width: 100%; height: 100%; min-width: 0; min-height: 0; color: var(--text-primary); overflow: hidden; background: var(--surface-pillar); }
+.session-analyst__chat-pane { container-type: inline-size; position: relative; box-sizing: border-box; display: grid; grid-template-columns: minmax(0, 1fr); grid-template-rows: auto minmax(0, 1fr); width: 100%; height: 100%; min-width: 0; min-height: 0; color: var(--text-primary); overflow: hidden; background: var(--surface-pillar); }
 .session-analyst__panel-head { display: flex; align-items: center; gap: 11px; min-height: 72px; flex: none; border-bottom: 1px solid var(--hairline); padding: 12px 14px; background: color-mix(in oklch, var(--surface-glass-strong) 82%, var(--surface-pillar)); }
 .session-analyst__panel-mark { display: grid; place-items: center; width: 38px; height: 38px; flex: none; border: 1px solid color-mix(in oklch, var(--aurora) 45%, var(--hairline)); border-radius: 12px; color: var(--aurora); background: var(--aurora-glow); font-size: 16px; }
 .session-analyst__panel-copy { display: grid; min-width: 0; gap: 3px; }
@@ -160,6 +162,7 @@
 @keyframes analyst-stage-enter { from { opacity: .2; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
 @keyframes analyst-receipt-settle { from { opacity: 0; transform: translateY(-3px); } to { opacity: 1; transform: translateY(0); } }
 @keyframes analyst-composer-dock { from { opacity: .72; transform: translateY(-7rem); } to { opacity: 1; transform: translateY(0); } }
+@keyframes analyst-artifact-count-pulse { 0%, 100% { transform: scale(1); } 45% { transform: scale(1.32); } }
 
 @container (max-width: 24rem) {
   .session-analyst__suggestions { grid-template-columns: 1fr; }
@@ -179,5 +182,5 @@
   .session-analyst-handle, .session-analyst__suggestions button, .session-analyst__composer-surface, .session-analyst__composer textarea, .session-analyst__selector-strip, .session-analyst__artifact-count, .session-analyst__artifact-count i { transition: none; }
   .session-analyst-handle:hover { transform: translateY(-50%); }
   .session-analyst__suggestions button:hover { transform: none; }
-  .session-analyst__pulse-scan, .session-analyst__composer.is-working .session-analyst__composer-surface::before, .session-analyst__pulse-orbit::after, .session-analyst__pulse, .session-analyst__pulse-copy strong, .session-analyst__receipt, .session-analyst__message--analyst, .session-analyst__composer.is-docking, .session-analyst__artifact-menu { animation: none; }
+  .session-analyst__pulse-scan, .session-analyst__composer.is-working .session-analyst__composer-surface::before, .session-analyst__pulse-orbit::after, .session-analyst__pulse, .session-analyst__pulse-copy strong, .session-analyst__receipt, .session-analyst__message--analyst, .session-analyst__composer.is-docking, .session-analyst__artifact-menu, .session-analyst-handle__count.is-pulsing { animation: none; }
 }

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -11,9 +11,9 @@ import { CURATED_TERMINAL_FONTS, DEFAULT_TERMINAL_FONT, TERMINAL_FONT_SIZE_RANGE
 import { useTerminalPrefs, setInstalledTerminalFont, setTerminalRenderer, setTerminalFont, setTerminalFontSize } from "../shared/terminal-prefs-store.js";
 import type { TerminalFontSettings, TerminalRenderer } from "../shared/types.js";
 import { AnalystArtifactsPanel } from "./analysis-artifacts-panel.js";
-import { AnalystChatPanel } from "./analysis-chat-panel.js";
+import { ANALYST_ARTIFACTS_COMPANION_ID, AnalystChatPanel } from "./analysis-chat-panel.js";
 import { fetchAnalysisReady } from "./analysis-api.js";
-import { disposeAnalysisStore } from "./analysis-store.js";
+import { disposeAnalysisStore, rearmAnalysisArtifacts } from "./analysis-store.js";
 import "./analysis.css";
 
 import { createAgentSession, fetchAgentCliState, resumeAgentSession, terminateAgentSession } from "./api.js";
@@ -86,7 +86,7 @@ export const agentOperationKind = defineOperationKind({
   canOpenCompanions: ({ api, operation }) => fetchAnalysisReady(api, operation.id),
   companions: [
     { id: "session-analyst-chat", title: "Session Analyst", hideCaption: true, render: (context) => <AnalystChatPanel context={context} /> },
-    { id: "session-analyst-artifacts", title: "Artifacts", hideCaption: true, render: (context) => <AnalystArtifactsPanel context={context} /> },
+    { id: ANALYST_ARTIFACTS_COMPANION_ID, title: "Artifacts", hideCaption: true, defaultHidden: true, render: (context) => <AnalystArtifactsPanel context={context} /> },
   ],
 });
 
@@ -305,7 +305,17 @@ function AgentOperationView({ context }: { readonly context: OperationRenderCont
   const overlayRef = React.useRef<HTMLDivElement>(null);
   const detailBtnRef = React.useRef<HTMLButtonElement | null>(null);
   const previousActiveJobIdsRef = React.useRef<ReadonlySet<string>>(new Set());
+  // 초기값 true: 닫힘 상태로 마운트해도 첫 effect가 re-arm한다(force-drop과 동시 언마운트로
+  // EXIT 전이를 관찰하지 못한 경우 복구). Theater 복귀는 companionsOpen=true 마운트라 disarm이 보존된다.
+  const previousCompanionsOpenRef = React.useRef(true);
   const analysisReady = useAnalysisReady(context);
+
+  React.useEffect(() => {
+    const companionsOpen = context.companionsOpen ?? false;
+    const wasOpen = previousCompanionsOpenRef.current;
+    previousCompanionsOpenRef.current = companionsOpen;
+    if (wasOpen && !companionsOpen) rearmAnalysisArtifacts(context.operationId);
+  }, [context.companionsOpen, context.operationId]);
 
   const jobs = sessionJobs(session);
   const activeJobs = jobs.filter((job) => !isTerminalJobStatus(job.status));


### PR DESCRIPTION
## Summary
- Session Analyst(ANALYZE)가 이제 2슬롯(세션+채팅)으로 열리고, Artifacts companion은 `defaultHidden` 디스크립터로 기본 숨김 처리됩니다. 빈 "No artifacts yet" pane이 작업면 1/3을 상시 점유하던 문제를 해소합니다.
- 첫 artifact SSE 이벤트(0→1 전이)에서만 Artifacts 슬롯이 자동 오픈되며, 채팅 pane 우측 엣지에 ANALYZE 핸들 문법을 미러한 ARTIFACTS 칩(aurora 카운트 배지·1회 펄스)이 추가됩니다. 사용자가 칩으로 닫으면 auto-open은 count가 0으로 돌아올 때까지 disarm됩니다(강제 재오픈 금지).
- SDK `OperationRenderContext`에 `hiddenCompanionPanelIds`/`onSetCompanionPanelVisible`을 additive optional로 추가하고, canvas store가 per-operation 휘발성 가시성 오버라이드를 소유합니다(ANALYZE 진입·EXIT·retarget 시 정리). 슬롯 전환은 companion 레이아웃 한정 transition으로 애니메이트되고 `prefers-reduced-motion`에서 단락됩니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal test` — 295 passed (신규 chip 동작 테스트 포함: auto-open/disarm/pulse/재마운트/왕복)
- [x] `pnpm --filter @fleet-plugins/terminal typecheck && build`
- [x] `tsc --noEmit -p core/client/tsconfig.json` (fleet-console client)
- [x] `vitest run tests/canvas-store.test.ts tests/instrument-design-contract.test.ts` — 50 passed (가시성 오버라이드 격리/리셋/정리 계약 포함)
- [x] 격리 콘솔 실브라우저 e2e: ANALYZE → 2슬롯(473/473 균등)+dim 칩(aria 계약 일치)·artifacts pane 미마운트·EXIT 왕복 무결·페이지 오류 0
- [x] Changelog: `.changelog.d/pr-331.md` — grouped product/section 문법, 영/한 병기, `compile-changelog-fragments.mjs --check` 통과