### PR TITLE
feat(repository): tree-view Repositories and color-channel doctrine

### DIFF
--- a/.changelog.d/pr-332.md
+++ b/.changelog.d/pr-332.md
@@ -1,0 +1,10 @@
+### fleet-plugin
+#### Changed
+- [fleet-console] Show the Repositories list as a collapsible directory tree of nested repositories, sorted alphabetically with single-child folders compressed, while the Theater root stays pinned on top.
+  ko: Repositories 목록을 중첩 저장소의 디렉터리 트리로 표시하고, 알파벳 정렬과 단일 자식 폴터 압축·접힘을 지원하며 Theater 루트는 상단에 고정합니다.
+- [fleet-console] Retune the Repository panel palette to the design channels: history graph lanes and diff syntax highlighting use the theme-tuned identity tones, and decorative signal-color accents are removed.
+  ko: Repository 패널 색상을 디자인 채널에 맞게 재조율합니다. 히스토리 그래프 레인과 diff 구문 강조에 테마별로 조율된 정체성 톤을 쓰고 장식용 신호색을 제거합니다.
+
+#### Fixed
+- [fleet-console] Unify Repository panel borders on the rim token so edges keep the same weight in the Maritime and Carbon themes, and restore the history tab transition that an undefined easing token had disabled.
+  ko: Repository 패널 테두리를 rim 토큰으로 통일해 Maritime·Carbon 테마에서도 같은 굵기를 유지하고, 정의되지 않은 이징 토큰 때문에 꺼져 있던 히스토리 탭 전환 효과를 복원합니다.

--- a/runtime/fleet-plugins/repository/client/graph-gutter.tsx
+++ b/runtime/fleet-plugins/repository/client/graph-gutter.tsx
@@ -15,15 +15,17 @@ const LANE_WIDTH = 12;
 const ROW_HEIGHT = 28;
 const NODE_R = 3;
 const HEAD_RING_R = 5;
+// 장식적 구분 채도는 --id-* 정체성 봉투에서만 가져온다 — 테마별 재조율·상태 신호와
+// 혼동할 수 없어야 한다. 신호 토큰(warn/positive/aurora) 순환은 상태 채널을 침범하므로 폐기.
 const LANE_COLORS = [
-  "var(--brass)",
-  "var(--aurora)",
-  "var(--warn)",
-  "var(--positive)",
-  "color-mix(in oklch, var(--brass) 70%, var(--aurora))",
-  "color-mix(in oklch, var(--aurora) 70%, var(--positive))",
-  "color-mix(in oklch, var(--warn) 72%, var(--brass))",
-  "color-mix(in oklch, var(--ink-spectral) 76%, var(--aurora))",
+  "var(--id-cerulean)",
+  "var(--id-plum)",
+  "var(--id-amber)",
+  "var(--id-teal)",
+  "var(--id-moss)",
+  "var(--id-indigo)",
+  "var(--id-rose)",
+  "var(--id-crimson)",
 ] as const;
 
 // ─── helpers ─────────────────────────────────────────────────────────────────

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 
 import type { RailPanelContext, RailPanelDescriptor } from "@fleet-console/sdk/rail";
 
 import type { DiffFileEntry, DiffFileMode, DiffListResult, RepoCandidate, ReposResult, WorktreeCandidate, WorktreesResult } from "../server/types.js";
 import "./repository.css";
 import { ChangedFiles, type ChangedFilesState } from "./changed-files.js";
+import { buildRepoTree, countRepos, type RepoTreeNode } from "./repo-tree.js";
 import { clearSelectedFile, setSelectedFile, type SelectedFile, useSelectedFile } from "./repository-view-store.js";
 import { HunkView } from "./hunk-view.js";
 import { HistoryPanel } from "./history-panel.js";
@@ -307,9 +308,17 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
 function SourceIcon({ source }: { readonly source: Source }) { const path = source === "repositories" ? "M3 5h12v9H3zM5 3h8v2" : source === "worktrees" ? "M5 3v12M5 6h7M5 12h7" : source === "changes" ? "M3 4h12M3 9h12M3 14h12" : source === "history" ? "M4 4v10h10M7 7h6v5" : source === "branches" ? "M5 3v12M5 6h7M5 12h7" : source === "tags" ? "M3 4h8l4 4-7 7-5-5z" : "M4 5h10v9H4zM6 3h6"; return <svg viewBox="0 0 18 18" aria-hidden="true"><path d={path} fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" /></svg>; }
 function SourceNav({ source, refs, repos, worktrees, onSource }: { readonly source: Source; readonly refs: Refs; readonly repos: readonly RepoCandidate[]; readonly worktrees: readonly WorktreeCandidate[]; readonly onSource: (source: Source) => void }) { const button = (id: Source, label: string, count?: number) => <button key={id} type="button" aria-label={label} aria-current={source === id ? "page" : undefined} onClick={() => onSource(id)}><SourceIcon source={id} /><span>{label}</span>{count !== undefined && <i>{count}</i>}</button>; return <nav className="repository-source-nav" aria-label="Repository sources"><b>CONTEXT</b>{button("repositories", "Repositories", repos.length)}{button("worktrees", "Worktrees", worktrees.length)}<b>WORKING</b>{button("changes", "Changes")}{button("history", "History")}<b>REFS</b>{button("branches", "Branches", refs.branches.length + refs.remotes.filter((item) => !isRemoteHeadRef(item.ref)).length)}{button("tags", "Tags", refs.tags.length)}{button("stashes", "Stashes", refs.stashes.length)}</nav>; }
 function RepoList({ repos, selectedRel, onRepository, scanDepth, onScanDepth, truncated }: { readonly repos: readonly RepoCandidate[]; readonly selectedRel: string; readonly onRepository: (repo: RepoCandidate) => void; readonly scanDepth: number; readonly onScanDepth: (depth: number) => void; readonly truncated: boolean }) {
-  const groups = (["root", "nested"] as const).map((kind) => ({ kind, label: kind === "root" ? "THIS THEATER" : "NESTED", repos: repos.filter((repo) => repo.kind === kind) })).filter((group) => group.repos.length > 0);
+  // 루트 저장소는 컨텍스트 복귀 affordance이므로 트리 밖 THIS THEATER 그룹에 고정한다.
+  // (repos.ts 주석의 의도 — nested 저장소로 진입해도 루트로 되돌아오는 진입점이 필요.)
+  const rootRepos = repos.filter((repo) => repo.kind === "root").sort((a, b) => a.name.localeCompare(b.name));
+  const nestedRepos = repos.filter((repo) => repo.kind === "nested");
+  const nestedTree = buildRepoTree(nestedRepos);
+  const groups: readonly { readonly key: string; readonly label: "THIS THEATER" | "NESTED"; readonly render: () => ReactNode }[] = [
+    ...(rootRepos.length > 0 ? [{ key: "root", label: "THIS THEATER" as const, render: () => <>{rootRepos.map((repo) => <RepoLeafRow key={repo.relPath} repo={repo} depth={0} selectedRel={selectedRel} onRepository={onRepository} />)}</> }] : []),
+    ...(nestedRepos.length > 0 ? [{ key: "nested", label: "NESTED" as const, render: () => <RepoTreeChildren node={nestedTree} depth={0} selectedRel={selectedRel} onRepository={onRepository} /> }] : []),
+  ];
   return <div className="repository-scan-pane">
-    <div className="repository-ref-list">{groups.map((group) => <div key={group.kind} className="repository-ref-group"><b className="repository-ref-group-label">{group.label}</b>{group.repos.map((repo) => <button type="button" key={repo.relPath} title={repo.relPath} className={`repository-ref-row${repo.relPath === selectedRel ? " is-current" : ""}`} onClick={() => onRepository(repo)}><SourceIcon source="repositories" /><span className="repository-ref-name">{repo.name}{repo.relPath === selectedRel && " ✓"}</span>{repo.branch && <span className="repository-ref-sub">{repo.branch}</span>}</button>)}</div>)}</div>
+    <div className="repository-ref-list">{groups.map((group) => <div key={group.key} className="repository-ref-group"><b className="repository-ref-group-label">{group.label}</b>{group.render()}</div>)}</div>
     <div className="repository-scan-foot">
       <label htmlFor="repository-scan-depth">Depth</label>
       <select id="repository-scan-depth" className="repository-scan-depth" value={scanDepth} onChange={(event) => onScanDepth(Number.parseInt(event.target.value, 10))}>
@@ -318,6 +327,56 @@ function RepoList({ repos, selectedRel, onRepository, scanDepth, onScanDepth, tr
       <span className="repository-scan-count">{repos.length} found{truncated ? " · limit reached" : ""}</span>
     </div>
   </div>;
+}
+
+interface RepoTreeCommonProps {
+  readonly selectedRel: string;
+  readonly onRepository: (repo: RepoCandidate) => void;
+}
+
+function RepoTreeChildren({ node, depth, selectedRel, onRepository }: { readonly node: RepoTreeNode; readonly depth: number } & RepoTreeCommonProps) {
+  return <>
+    {Object.entries(node.dirs).map(([key, child]) => <RepoTreeFolder key={key} dirKey={key} node={child} depth={depth} selectedRel={selectedRel} onRepository={onRepository} />)}
+    {node.repos.map((repo) => <RepoLeafRow key={repo.relPath} repo={repo} depth={depth} selectedRel={selectedRel} onRepository={onRepository} />)}
+  </>;
+}
+
+function RepoTreeFolder({ dirKey, node, depth, selectedRel, onRepository }: { readonly dirKey: string; readonly node: RepoTreeNode; readonly depth: number } & RepoTreeCommonProps) {
+  const [collapsed, setCollapsed] = useState(false);
+  const handleToggle = useCallback(() => setCollapsed((value) => !value), []);
+  // VS Code 스타일: 자식 디렉터리 하나 + 저장소 없음 체인을 "a/b" 한 노드로 압축한다 (DiffTreeFolder 미러).
+  let label = dirKey;
+  let resolvedNode = node;
+  while (Object.keys(resolvedNode.dirs).length === 1 && resolvedNode.repos.length === 0) {
+    const onlyKey = Object.keys(resolvedNode.dirs)[0]!;
+    label += "/" + onlyKey;
+    resolvedNode = resolvedNode.dirs[onlyKey]!;
+  }
+  const indent = depth * 16 + 12;
+  const total = countRepos(resolvedNode);
+  return <div className={`repository-folder${collapsed ? " is-collapsed" : ""}`}>
+    <button type="button" className="repository-folder-row" style={{ paddingLeft: `${indent}px`, gridTemplateColumns: "12px 15px 1fr auto" }} onClick={handleToggle} aria-expanded={!collapsed}>
+      <svg className="repository-folder-chevron" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+        <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+      <svg className="repository-folder-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <path d="M2 4a1 1 0 011-1h3l1.2 1.2H13a1 1 0 011 1V12a1 1 0 01-1 1H3a1 1 0 01-1-1V4z" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" />
+      </svg>
+      <span className="repository-folder-name">{label}</span>
+      <span className="repository-folder-count">{total}</span>
+    </button>
+    {!collapsed && <RepoTreeChildren node={resolvedNode} depth={depth + 1} selectedRel={selectedRel} onRepository={onRepository} />}
+  </div>;
+}
+
+function RepoLeafRow({ repo, depth, selectedRel, onRepository }: { readonly repo: RepoCandidate; readonly depth: number } & RepoTreeCommonProps) {
+  // 저장소 리프 아이콘을 폴더 아이콘 컬럼(padding-left 12 + chevron 12 + gap 6 = 30) 아래에 정렬한다.
+  const indent = depth * 16 + 30;
+  return <button type="button" title={repo.relPath} className={`repository-ref-row${repo.relPath === selectedRel ? " is-current" : ""}`} style={{ paddingLeft: `${indent}px` }} onClick={() => onRepository(repo)}>
+    <SourceIcon source="repositories" />
+    <span className="repository-ref-name">{repo.name}{repo.relPath === selectedRel && " ✓"}</span>
+    {repo.branch && <span className="repository-ref-sub">{repo.branch}</span>}
+  </button>;
 }
 function WorktreeList({ worktrees, onWorktree }: { readonly worktrees: readonly WorktreeCandidate[]; readonly onWorktree: (worktree: WorktreeCandidate) => void }) { return <div className="repository-ref-list">{worktrees.map((worktree) => <button type="button" key={worktree.relPath} title={worktree.relPath} className={`repository-ref-row${worktree.current ? " is-current" : ""}`} onClick={() => onWorktree(worktree)}><SourceIcon source="worktrees" /><span className="repository-ref-name">{worktree.name}{worktree.current && " ✓"}</span>{worktree.branch && <span className="repository-ref-sub">{worktree.branch}</span>}</button>)}</div>; }
 function RefList({ source, refs, onRef }: { readonly source: Source; readonly refs: Refs; readonly onRef: (ref: string) => void }) {

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -5,7 +5,7 @@ import type { RailPanelContext, RailPanelDescriptor } from "@fleet-console/sdk/r
 import type { DiffFileEntry, DiffFileMode, DiffListResult, RepoCandidate, ReposResult, WorktreeCandidate, WorktreesResult } from "../server/types.js";
 import "./repository.css";
 import { ChangedFiles, type ChangedFilesState } from "./changed-files.js";
-import { buildRepoTree, countRepos, type RepoTreeNode } from "./repo-tree.js";
+import { buildRepoTree, compressRepoFolder, countRepos, type RepoTreeNode } from "./repo-tree.js";
 import { clearSelectedFile, setSelectedFile, type SelectedFile, useSelectedFile } from "./repository-view-store.js";
 import { HunkView } from "./hunk-view.js";
 import { HistoryPanel } from "./history-panel.js";
@@ -344,14 +344,7 @@ function RepoTreeChildren({ node, depth, selectedRel, onRepository }: { readonly
 function RepoTreeFolder({ dirKey, node, depth, selectedRel, onRepository }: { readonly dirKey: string; readonly node: RepoTreeNode; readonly depth: number } & RepoTreeCommonProps) {
   const [collapsed, setCollapsed] = useState(false);
   const handleToggle = useCallback(() => setCollapsed((value) => !value), []);
-  // VS Code 스타일: 자식 디렉터리 하나 + 저장소 없음 체인을 "a/b" 한 노드로 압축한다 (DiffTreeFolder 미러).
-  let label = dirKey;
-  let resolvedNode = node;
-  while (Object.keys(resolvedNode.dirs).length === 1 && resolvedNode.repos.length === 0) {
-    const onlyKey = Object.keys(resolvedNode.dirs)[0]!;
-    label += "/" + onlyKey;
-    resolvedNode = resolvedNode.dirs[onlyKey]!;
-  }
+  const { label, node: resolvedNode } = compressRepoFolder(dirKey, node);
   const indent = depth * 16 + 12;
   const total = countRepos(resolvedNode);
   return <div className={`repository-folder${collapsed ? " is-collapsed" : ""}`}>

--- a/runtime/fleet-plugins/repository/client/repo-tree.ts
+++ b/runtime/fleet-plugins/repository/client/repo-tree.ts
@@ -7,6 +7,15 @@ export interface RepoTreeNode {
   repos: RepoCandidate[];
 }
 
+// "__proto__" 같은 유효한 디렉터리명이 상속 프로퍼티와 충돌하지 않도록 null-prototype 사전을 쓴다.
+function createDirs(): { [key: string]: RepoTreeNode } {
+  return Object.create(null) as { [key: string]: RepoTreeNode };
+}
+
+function createNode(): RepoTreeNode {
+  return { dirs: createDirs(), repos: [] };
+}
+
 // ─── buildRepoTree ───────────────────────────────────────────────────────────
 
 /**
@@ -16,16 +25,18 @@ export interface RepoTreeNode {
  * (repository-tree.tsx의 buildDiffTree와 같은 관용구.)
  * 각 노드의 dirs·repos는 알파벳(localeCompare)으로 정렬한다 —
  * 스캔 DFS 순 그대로 노출하면 사용자가 위치를 예측하기 어렵다.
+ * 서버 relPath는 path.relative 결과라 OS 종속 구분자를 쓴다 — 세그먼트 분해에만
+ * `\`→`/` 정규화 복사본을 쓰고, RepoCandidate 원본은 변형하지 않는다(선택/전환 계약).
  */
 export function buildRepoTree(repos: readonly RepoCandidate[]): RepoTreeNode {
-  const root: RepoTreeNode = { dirs: {}, repos: [] };
+  const root = createNode();
   for (const repo of repos) {
-    const parts = repo.relPath.split("/").filter((segment) => segment.length > 0);
+    const parts = repo.relPath.replaceAll("\\", "/").split("/").filter((segment) => segment.length > 0);
     if (parts.length === 0) continue;
     parts.pop();
     let node = root;
     for (const part of parts) {
-      if (!node.dirs[part]) node.dirs[part] = { dirs: {}, repos: [] };
+      if (!node.dirs[part]) node.dirs[part] = createNode();
       node = node.dirs[part]!;
     }
     node.repos.push(repo);
@@ -37,11 +48,28 @@ export function buildRepoTree(repos: readonly RepoCandidate[]): RepoTreeNode {
 function sortNode(node: RepoTreeNode): void {
   node.repos.sort((a, b) => a.name.localeCompare(b.name));
   const entries = Object.entries(node.dirs).sort(([a], [b]) => a.localeCompare(b));
-  node.dirs = {};
+  node.dirs = createDirs();
   for (const [key, child] of entries) {
     sortNode(child);
     node.dirs[key] = child;
   }
+}
+
+// ─── compressRepoFolder ──────────────────────────────────────────────────────
+
+/**
+ * VS Code 스타일 폴더 압축: 자식 디렉터리 하나 + 저장소 없음 체인을
+ * "a/b" 한 라벨로 합쳐 최종 노드와 함께 돌려준다 (DiffTreeFolder 미러).
+ */
+export function compressRepoFolder(dirKey: string, node: RepoTreeNode): { label: string; node: RepoTreeNode } {
+  let label = dirKey;
+  let resolved = node;
+  while (Object.keys(resolved.dirs).length === 1 && resolved.repos.length === 0) {
+    const onlyKey = Object.keys(resolved.dirs)[0]!;
+    label += "/" + onlyKey;
+    resolved = resolved.dirs[onlyKey]!;
+  }
+  return { label, node: resolved };
 }
 
 // ─── countRepos ──────────────────────────────────────────────────────────────

--- a/runtime/fleet-plugins/repository/client/repo-tree.ts
+++ b/runtime/fleet-plugins/repository/client/repo-tree.ts
@@ -1,0 +1,53 @@
+import type { RepoCandidate } from "../server/types.js";
+
+// ─── types ───────────────────────────────────────────────────────────────────
+
+export interface RepoTreeNode {
+  dirs: { [key: string]: RepoTreeNode };
+  repos: RepoCandidate[];
+}
+
+// ─── buildRepoTree ───────────────────────────────────────────────────────────
+
+/**
+ * nested 저장소의 relPath를 디렉터리 세그먼트로 분해해 트리를 구성한다.
+ * 각 저장소는 자신의 relPath 마지막 세그먼트가 곧 자기 디렉터리이므로,
+ * pop 후 나머지 상위 세그먼트만 dirs 체인으로 만들고 리프에 저장소를 담는다.
+ * (repository-tree.tsx의 buildDiffTree와 같은 관용구.)
+ * 각 노드의 dirs·repos는 알파벳(localeCompare)으로 정렬한다 —
+ * 스캔 DFS 순 그대로 노출하면 사용자가 위치를 예측하기 어렵다.
+ */
+export function buildRepoTree(repos: readonly RepoCandidate[]): RepoTreeNode {
+  const root: RepoTreeNode = { dirs: {}, repos: [] };
+  for (const repo of repos) {
+    const parts = repo.relPath.split("/").filter((segment) => segment.length > 0);
+    if (parts.length === 0) continue;
+    parts.pop();
+    let node = root;
+    for (const part of parts) {
+      if (!node.dirs[part]) node.dirs[part] = { dirs: {}, repos: [] };
+      node = node.dirs[part]!;
+    }
+    node.repos.push(repo);
+  }
+  sortNode(root);
+  return root;
+}
+
+function sortNode(node: RepoTreeNode): void {
+  node.repos.sort((a, b) => a.name.localeCompare(b.name));
+  const entries = Object.entries(node.dirs).sort(([a], [b]) => a.localeCompare(b));
+  node.dirs = {};
+  for (const [key, child] of entries) {
+    sortNode(child);
+    node.dirs[key] = child;
+  }
+}
+
+// ─── countRepos ──────────────────────────────────────────────────────────────
+
+export function countRepos(node: RepoTreeNode): number {
+  let total = node.repos.length;
+  for (const child of Object.values(node.dirs)) total += countRepos(child);
+  return total;
+}

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -613,7 +613,7 @@
 
 /* ── @@ 요약 라벨 행 ── */
 .repository-line-hunk-label {
-  background: color-mix(in oklch, var(--aurora) 8%, transparent);
+  background: color-mix(in oklch, var(--ink-fog) 8%, transparent);
 }
 
 .repository-line-label {

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -410,7 +410,7 @@
 .repository-folder-icon {
   width: 15px;
   height: 15px;
-  color: var(--brass-deep);
+  color: var(--ink-fog);
 }
 
 .repository-folder-name {
@@ -420,6 +420,13 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.repository-folder-count {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--text-tertiary);
+  padding-left: 8px;
 }
 
 /* ── 기타 공통 ── */
@@ -569,10 +576,11 @@
   color: var(--coral);
 }
 
-.repository-token-keyword { color: var(--aurora); }
-.repository-token-string,
-.repository-token-number { color: var(--warn); }
-.repository-token-type { color: var(--brass); }
+/* 구문강조도 장식적 구분 — --id-* 정체성 봉투에서만 가져와 상태 신호(warn/positive)와 격리한다 */
+.repository-token-keyword { color: var(--id-cerulean); }
+.repository-token-string { color: var(--id-moss); }
+.repository-token-number { color: var(--id-amber); }
+.repository-token-type { color: var(--id-plum); }
 .repository-token-comment { color: var(--ink-fog); font-style: italic; }
 .repository-token-punctuation { color: var(--ink-fog); }
 
@@ -924,7 +932,7 @@
 .history-commit-badges { grid-column: 5; max-width: 168px; }
 .history-inspector { display: grid; grid-template-rows: auto minmax(0, 1fr); height: 100%; min-height: 0; }
 .history-segmented { display: flex; gap: 4px; padding: 8px 12px; border-bottom: 1px solid var(--surface-rim); }
-.history-segmented button { flex: 1; border: 1px solid transparent; border-radius: var(--radius-sm); background: none; color: var(--ink-fog); cursor: pointer; font-family: var(--font-mono); font-size: 11px; letter-spacing: .06em; padding: 6px; transition: color var(--duration-fast) var(--ease-standard), background var(--duration-fast) var(--ease-standard); }
+.history-segmented button { flex: 1; border: 1px solid transparent; border-radius: var(--radius-sm); background: none; color: var(--ink-fog); cursor: pointer; font-family: var(--font-mono); font-size: 11px; letter-spacing: .06em; padding: 6px; transition: color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide); }
 .history-segmented button[aria-pressed="true"] { border-color: color-mix(in oklch, var(--brass) 40%, transparent); background: color-mix(in oklch, var(--brass) 12%, transparent); color: var(--ink-spectral); }
 .history-segmented span { color: var(--ink-fog); font-size: 9px; }
 .history-segmented .history-inspector-close { flex: 0 0 auto; width: 28px; min-width: 28px; height: 28px; padding: 0; border-color: transparent; }
@@ -937,7 +945,7 @@
 .history-author > span:nth-child(2) { display: grid; gap: 1px; }
 .history-author b { font-weight: 500; }.history-author small, .history-author time { color: var(--ink-fog); font-family: var(--font-mono); font-size: 10.5px; }
 .history-author time { margin-left: auto; }
-.history-avatar { display: grid; width: 24px; height: 24px; place-items: center; border-radius: 50%; background: color-mix(in oklch, var(--brass) 32%, var(--ink-veil)); color: var(--ink-pearl); font-family: var(--font-mono); font-size: 10px; font-weight: 700; }
+.history-avatar { display: grid; width: 24px; height: 24px; place-items: center; border-radius: 50%; background: color-mix(in oklch, var(--ink-fog) 24%, var(--ink-veil)); color: var(--ink-spectral); font-family: var(--font-mono); font-size: 10px; font-weight: 700; }
 .history-inspector-ids, .history-ref-chips { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 10px; }
 .history-sha-copy, .history-parent { border-radius: var(--radius-sm); background: none; cursor: pointer; font-family: var(--font-mono); font-size: 10.5px; padding: 3px 8px; }
 .history-sha-copy { border: 1px solid var(--surface-rim); color: var(--ink-spectral); }.history-sha-copy span { color: var(--ink-fog); margin-left: 7px; }.history-sha-copy.is-copied { border-color: var(--positive); color: var(--positive); }
@@ -946,14 +954,14 @@
 .history-files-title { display: flex; gap: 8px; align-items: center; padding: 8px 14px; border-bottom: 1px solid var(--surface-rim); color: var(--ink-fog); font-family: var(--font-mono); font-size: 10.5px; letter-spacing: .1em; text-transform: uppercase; }.history-files-stats { margin-left: auto; letter-spacing: 0; }.history-files-title i { color: var(--positive); font-style: normal; }.history-files-title em { color: var(--coral); font-style: normal; }.history-files-view-toggle { margin-left: 0; }
 .history-files-scroll { min-height: 0; overflow: auto; }.history-commit-files .repository-file-row { padding-left: 14px; }
 .history-changes-tab { min-height: 0; overflow: hidden; }.history-changes-columns { display: grid; min-height: 0; height: 100%; }.history-changes-columns > .history-commit-files { border-right: 1px solid var(--surface-rim); }
-.history-file-diff { display: grid; grid-template-rows: auto minmax(0, 1fr); min-width: 0; overflow: hidden; }.history-file-repository-head { display: flex; align-items: center; gap: 8px; min-width: 0; padding: 7px 12px; border-bottom: 1px solid var(--surface-rim); color: var(--aurora); font-family: var(--font-mono); font-size: 11px; }.history-file-repository-head > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }.history-file-repository-head > div { display: flex; gap: 2px; margin-left: auto; }.history-file-repository-head button { width: 22px; height: 22px; border: 1px solid var(--surface-rim); border-radius: var(--radius-sm); background: none; color: var(--ink-fog); cursor: pointer; }.history-file-repository-head button:disabled { cursor: default; opacity: .4; }
+.history-file-diff { display: grid; grid-template-rows: auto minmax(0, 1fr); min-width: 0; overflow: hidden; }.history-file-repository-head { display: flex; align-items: center; gap: 8px; min-width: 0; padding: 7px 12px; border-bottom: 1px solid var(--surface-rim); color: var(--ink-fog); font-family: var(--font-mono); font-size: 11px; }.history-file-repository-head > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }.history-file-repository-head > div { display: flex; gap: 2px; margin-left: auto; }.history-file-repository-head button { width: 22px; height: 22px; border: 1px solid var(--surface-rim); border-radius: var(--radius-sm); background: none; color: var(--ink-fog); cursor: pointer; }.history-file-repository-head button:disabled { cursor: default; opacity: .4; }
 .history-inspector-empty { padding: 16px; color: var(--ink-fog); font-family: var(--font-mono); font-size: 12px; }.history-inspector-error { color: var(--coral); }
 @container (max-width: 610px) { .history-commit-badges, .history-commit-time { display: none; } }
 @container (max-width: 430px) { .history-commit-sha { display: none; } .history-commit-row { grid-template-columns: auto minmax(96px, 1fr); } }
 @media (prefers-reduced-motion: reduce) { .history-segmented button { transition-duration: .01ms; } }
 /* Repository sources mirror the approved unified explorer. */
 .repository-unified { display: flex; flex-direction: column; min-width: 0; min-height: 0; height: 100%; container-type: inline-size; }
-.repository-identity { display: flex; align-items: center; gap: 8px; min-height: 34px; padding: 7px 12px; border-bottom: 1px solid var(--hairline); background: var(--ink-deep); color: var(--text-secondary); }
+.repository-identity { display: flex; align-items: center; gap: 8px; min-height: 34px; padding: 7px 12px; border-bottom: 1px solid var(--surface-rim); background: var(--ink-deep); color: var(--text-secondary); }
 .repository-identity.is-subcontext { box-shadow: inset 2px 0 0 var(--brass); }
 .repository-identity svg { width: 15px; height: 15px; flex: none; opacity: .85; }
 .repository-identity strong { min-width: 0; overflow: hidden; color: var(--text-primary); font-size: 12.5px; font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }
@@ -963,7 +971,7 @@
 .repository-unified-body { display: flex; min-width: 0; min-height: 0; flex: 1; }
 /* --surface-deep은 어느 테마에도 정의된 적 없는 토큰이라 이 선언은 계속 무효였다(배경 투명).
    정체 스트립과 같은 표면이어야 하므로 의도됐던 값인 --ink-deep으로 확정한다. */
-.repository-source-nav { width: 148px; flex: none; display: flex; flex-direction: column; gap: 2px; padding: 8px 6px; border-right: 1px solid var(--hairline); background: var(--ink-deep); }
+.repository-source-nav { width: 148px; flex: none; display: flex; flex-direction: column; gap: 2px; padding: 8px 6px; border-right: 1px solid var(--surface-rim); background: var(--ink-deep); }
 .repository-source-nav button, .repository-source-nav span { min-height: 28px; padding: 5px 8px; border: 0; border-radius: var(--radius-xs); background: transparent; color: var(--text-secondary); text-align: left; font: inherit; font-size: 12px; }
 .repository-source-nav button[aria-current="page"] { color: var(--brass); background: color-mix(in oklch, var(--brass) 12%, transparent); }
 .repository-source-nav button:disabled, .repository-source-nav span { color: var(--text-tertiary); }
@@ -976,7 +984,7 @@
 /* 목록은 스크롤되고 스캔 푸터는 하단에 고정된다 */
 .repository-scan-pane { display: flex; flex-direction: column; min-height: 0; height: 100%; }
 .repository-scan-pane > .repository-ref-list { flex: 1; min-height: 0; overflow-y: auto; align-content: start; }
-.repository-scan-foot { display: flex; align-items: center; gap: 8px; flex: none; padding: 7px 10px; border-top: 1px solid var(--hairline); background: var(--ink-deep); }
+.repository-scan-foot { display: flex; align-items: center; gap: 8px; flex: none; padding: 7px 10px; border-top: 1px solid var(--surface-rim); background: var(--ink-deep); }
 .repository-scan-foot label { color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; letter-spacing: .12em; text-transform: uppercase; }
 /* appearance:none으로 UA 기본 select 크롬을 걷어내고 필터 입력과 같은 시각 등급으로 맞춘다 */
 .repository-scan-depth { appearance: none; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: color-mix(in oklch, var(--ink-deep) 30%, transparent); color: var(--ink-spectral); font-family: var(--font-mono); font-size: 12px; padding: 2px 6px; outline: none; cursor: pointer; transition: border-color var(--duration-fast) var(--ease-glide); }
@@ -987,7 +995,7 @@
 .repository-ref-group { display: grid; gap: 2px; }
 .repository-ref-group-label { padding: 8px 10px 2px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 9.5px; font-weight: 400; letter-spacing: .18em; text-transform: uppercase; }
 .repository-ref-row { display: flex; align-items: center; gap: 9px; width: 100%; border: 0; border-radius: var(--radius-xs); background: transparent; color: var(--text-secondary); cursor: pointer; font: inherit; text-align: left; padding: 7px 10px; transition: color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide); }
-.repository-ref-row:hover { background: var(--ink-mid); color: var(--text-primary); }
+.repository-ref-row:hover { background: color-mix(in oklch, var(--ink-fog) 9%, transparent); color: var(--text-primary); }
 .repository-ref-row:disabled { cursor: default; }
 .repository-ref-row.is-current { color: var(--brass); }
 .repository-ref-row.is-current:hover { color: var(--brass); }
@@ -996,7 +1004,7 @@
 .repository-ref-sub { margin-left: auto; color: var(--text-tertiary); flex: none; font-family: var(--font-mono); font-size: 10px; }
 .repository-wip-row, .repository-ref-chip { border: 0; background: transparent; color: var(--text-secondary); font: inherit; text-align: left; padding: 7px 10px; }
 .repository-wip-row { color: var(--brass); }
-.repository-wip-row { width: 100%; border-bottom: 1px dashed var(--hairline); }
+.repository-wip-row { width: 100%; border-bottom: 1px dashed var(--surface-rim); }
 .repository-wip-row span { float: right; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; }
 @container (max-width: 420px) { .repository-source-nav { width: 44px; } .repository-source-nav button { display: grid; place-items: center; padding: 5px; } .repository-source-nav button span, .repository-source-nav button i, .repository-source-nav b { display: none; } }
 /* hidden 속성은 UA display:none이라 .repository-root의 display:grid에 진다 — 소스 상호 배제 가드 */

--- a/runtime/fleet-plugins/repository/tests/repository-repo-tree.test.ts
+++ b/runtime/fleet-plugins/repository/tests/repository-repo-tree.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { buildRepoTree, countRepos } from "../client/repo-tree.js";
+import type { RepoCandidate } from "../server/types.js";
+
+function repo(relPath: string, name?: string): RepoCandidate {
+  return { relPath, name: name ?? relPath.split("/").pop() ?? relPath, branch: "main", kind: "nested" };
+}
+
+describe("buildRepoTree", () => {
+  it("returns empty tree for no repos", () => {
+    const tree = buildRepoTree([]);
+    expect(tree.dirs).toEqual({});
+    expect(tree.repos).toEqual([]);
+    expect(countRepos(tree)).toBe(0);
+  });
+
+  it("places single-segment repos at the root", () => {
+    const tree = buildRepoTree([repo("alpha"), repo("beta")]);
+    expect(Object.keys(tree.dirs)).toEqual([]);
+    expect(tree.repos.map((item) => item.relPath)).toEqual(["alpha", "beta"]);
+  });
+
+  it("nests repos under their parent directory segments", () => {
+    const tree = buildRepoTree([repo("packages/foo"), repo("packages/bar"), repo("apps/web")]);
+    expect(Object.keys(tree.dirs).sort()).toEqual(["apps", "packages"]);
+    expect(tree.dirs.packages!.repos.map((item) => item.relPath)).toEqual(["packages/bar", "packages/foo"]);
+    expect(tree.dirs.apps!.repos.map((item) => item.relPath)).toEqual(["apps/web"]);
+    expect(countRepos(tree)).toBe(3);
+  });
+
+  it("sorts directories then repos alphabetically at each node", () => {
+    const tree = buildRepoTree([repo("z/one"), repo("a/two"), repo("m/three"), repo("solo")]);
+    expect(Object.keys(tree.dirs)).toEqual(["a", "m", "z"]);
+    expect(tree.repos.map((item) => item.relPath)).toEqual(["solo"]);
+  });
+
+  it("sorts repos within a node by name (localeCompare)", () => {
+    const tree = buildRepoTree([
+      { relPath: "root/zeta", name: "zeta", branch: "main", kind: "nested" },
+      { relPath: "root/alpha", name: "alpha", branch: "main", kind: "nested" },
+      { relPath: "root/mid", name: "mid", branch: "main", kind: "nested" },
+    ]);
+    expect(tree.dirs.root!.repos.map((item) => item.name)).toEqual(["alpha", "mid", "zeta"]);
+  });
+
+  it("keeps single-child chains uncompressed in the pure tree (compression is a UI concern)", () => {
+    const tree = buildRepoTree([repo("a/b/c/leaf")]);
+    expect(Object.keys(tree.dirs)).toEqual(["a"]);
+    expect(Object.keys(tree.dirs.a!.dirs)).toEqual(["b"]);
+    expect(Object.keys(tree.dirs.a!.dirs.b!.dirs)).toEqual(["c"]);
+    expect(tree.dirs.a!.dirs.b!.dirs.c!.repos.map((item) => item.relPath)).toEqual(["a/b/c/leaf"]);
+  });
+
+  it("counts nested repos recursively", () => {
+    const tree = buildRepoTree([repo("a/b/one"), repo("a/b/two"), repo("a/three"), repo("solo")]);
+    expect(countRepos(tree)).toBe(4);
+    expect(countRepos(tree.dirs.a!)).toBe(3);
+    expect(countRepos(tree.dirs.a!.dirs.b!)).toBe(2);
+  });
+
+  it("filters empty path segments and skips repos with only-empty paths", () => {
+    const tree = buildRepoTree([repo(""), repo("/foo"), repo("bar/")]);
+    // "" ignored; "/foo" → after filter=["foo"], pop→[], repo at root name "foo"
+    // "bar/" → after filter=["bar"], pop→[], repo at root name ""
+    expect(Object.keys(tree.dirs)).toEqual([]);
+    expect(tree.repos.map((item) => item.relPath).sort()).toEqual(["/foo", "bar/"]);
+  });
+});

--- a/runtime/fleet-plugins/repository/tests/repository-repo-tree.test.ts
+++ b/runtime/fleet-plugins/repository/tests/repository-repo-tree.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildRepoTree, countRepos } from "../client/repo-tree.js";
+import { buildRepoTree, compressRepoFolder, countRepos } from "../client/repo-tree.js";
 import type { RepoCandidate } from "../server/types.js";
 
 function repo(relPath: string, name?: string): RepoCandidate {
@@ -65,5 +65,59 @@ describe("buildRepoTree", () => {
     // "bar/" → after filter=["bar"], pop→[], repo at root name ""
     expect(Object.keys(tree.dirs)).toEqual([]);
     expect(tree.repos.map((item) => item.relPath).sort()).toEqual(["/foo", "bar/"]);
+  });
+
+  it("splits Windows-style backslash relPaths into segments without mutating the original relPath", () => {
+    const tree = buildRepoTree([repo("packages\\foo", "foo"), repo("packages\\deep\\bar", "bar")]);
+    expect(Object.keys(tree.dirs)).toEqual(["packages"]);
+    expect(tree.dirs.packages!.repos.map((item) => item.relPath)).toEqual(["packages\\foo"]);
+    expect(Object.keys(tree.dirs.packages!.dirs)).toEqual(["deep"]);
+    expect(tree.dirs.packages!.dirs.deep!.repos.map((item) => item.relPath)).toEqual(["packages\\deep\\bar"]);
+  });
+
+  it("handles reserved property names as directory segments", () => {
+    const tree = buildRepoTree([repo("__proto__/one"), repo("constructor/two"), repo("toString/three")]);
+    expect(Object.keys(tree.dirs)).toEqual(["__proto__", "constructor", "toString"]);
+    expect(tree.dirs["__proto__"]!.repos.map((item) => item.relPath)).toEqual(["__proto__/one"]);
+    expect(tree.dirs["constructor"]!.repos.map((item) => item.relPath)).toEqual(["constructor/two"]);
+    expect(tree.dirs["toString"]!.repos.map((item) => item.relPath)).toEqual(["toString/three"]);
+    expect(countRepos(tree)).toBe(3);
+  });
+
+  it("does not pollute Object.prototype when a segment is __proto__", () => {
+    const tree = buildRepoTree([repo("__proto__/one")]);
+    expect(({} as Record<string, unknown>)["one"]).toBeUndefined();
+    expect(Object.getPrototypeOf(tree.dirs)).toBeNull();
+  });
+});
+
+describe("compressRepoFolder", () => {
+  it("returns the folder unchanged when it holds repos or multiple child dirs", () => {
+    const tree = buildRepoTree([repo("packages/foo"), repo("packages/nested/bar")]);
+    const { label, node } = compressRepoFolder("packages", tree.dirs.packages!);
+    expect(label).toBe("packages");
+    expect(node).toBe(tree.dirs.packages!);
+  });
+
+  it("compresses a single-child repo-less chain into one label", () => {
+    const tree = buildRepoTree([repo("a/b/c/leaf")]);
+    const { label, node } = compressRepoFolder("a", tree.dirs.a!);
+    expect(label).toBe("a/b/c");
+    expect(node).toBe(tree.dirs.a!.dirs.b!.dirs.c!);
+    expect(node.repos.map((item) => item.relPath)).toEqual(["a/b/c/leaf"]);
+  });
+
+  it("stops compressing at a node that owns repos", () => {
+    const tree = buildRepoTree([repo("a/b/mid"), repo("a/b/c/leaf")]);
+    const { label, node } = compressRepoFolder("a", tree.dirs.a!);
+    expect(label).toBe("a/b");
+    expect(node).toBe(tree.dirs.a!.dirs.b!);
+    expect(countRepos(node)).toBe(2);
+  });
+
+  it("compresses deep chains across many levels", () => {
+    const tree = buildRepoTree([repo("v/w/x/y/z/leaf")]);
+    const { label } = compressRepoFolder("v", tree.dirs.v!);
+    expect(label).toBe("v/w/x/y/z");
   });
 });


### PR DESCRIPTION
## Summary
- Repositories 소스를 디렉토리 트리로 전환: nested 저장소를 relPath 기준 폴터 트리(압축·알파벳 정렬·세션 한정 접힘)로 표시하고, 루트 저장소는 THIS THEATER에 고정
- 색 채널 독트린 복원: 그래프 레인·구문강조를 --id-* 정체성 봉투로 이전, 장식용 aurora/brass 제거, 본더 --surface-rim 통일, hover ink-fog 9% wash 통일, 사장 토큰 --ease-standard 제거
- Sentinel 리뷰 반영: Windows 구분자 정규화, null-prototype 디렉터리 사전, 압축 순수 helper 추출, @@ 라벨 aurora 잔존 정리

## Test Plan
- [x] pnpm --filter @fleet-plugins/repository typecheck / test (191) / build
- [x] 격리 콘솔 3테마(Instrument/Maritime/Carbon) 트리·History·Changes 스크린샷 실측
- [x] 폴터 접힘·Depth 변경(1↔3) 인터랙션 실측
- [x] Changelog fragment — .changelog.d/pr-332.md (bilingual, compiler check OK)
