### PR TITLE
feat(console): sidebar group identity via spine, mark, and wash

### DIFF
--- a/.changelog.d/pr-335.md
+++ b/.changelog.d/pr-335.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Changed
+- [fleet-console] Paint sidebar group identity through the full spine, mark, and wash grammar: a persistent color dot and tinted header (stronger when collapsed) plus a faint group-zone wash, while the 3px left rail stays unchanged.
+  ko: 사이드바 그룹 정체성을 spine·mark·wash 전체 문법으로 표현합니다. 색상 dot과 헤더 틴트(접힘 시 강화), 은은한 그룹 존 워시를 추가하며 기존 3px 좌측 레일은 그대로 유지합니다.

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-group-header.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-group-header.tsx
@@ -30,6 +30,7 @@ export function OperationsSideBarGroupHeader({
   const grpColor = resolveAccentColor(group.color);
   const headerClassName = [
     "side-bar-group-header",
+    collapsed ? "side-bar-group-header--collapsed" : "",
     dragging ? "side-bar-group-header--dragging" : "",
     dropTarget ? "side-bar-group-header--drop-target" : "",
   ].filter(Boolean).join(" ");
@@ -77,6 +78,7 @@ export function OperationsSideBarGroupHeader({
       >
         <CollapseArrow collapsed={collapsed} />
       </button>
+      <span className="side-bar-group-header__dot" aria-hidden="true" />
       <span className="side-bar-group-header__name">{group.name}</span>
       <span className="side-bar-group-header__count" aria-label={`${count} operations`}>{count}</span>
     </div>

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2748,7 +2748,8 @@
   flex-direction: column;
 }
 
-/* 연속 좌측 레일 — group section 전체 관통 (ungrouped 제외) */
+/* 연속 좌측 레일 + 존 워시 — group section 전체 관통 (ungrouped 제외).
+   레일(3px 직사각형)은 불변 계약: 우측 모서리만 둥글려 워시가 레일 형상을 건드리지 않는다. */
 .side-bar-group-section {
   position: relative;
   list-style: none;
@@ -2756,7 +2757,10 @@
   flex-direction: column;
   margin-left: var(--space-1);
   padding-left: var(--space-1);
+  padding-bottom: 4px;
   border-left: 3px solid var(--grp-color, transparent);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  background: color-mix(in oklch, var(--grp-color, transparent) 4%, transparent);
 }
 
 .side-bar-group-section--drop-before::before,
@@ -2804,14 +2808,20 @@
   margin: 2px var(--space-1) 0 0;
   border-radius: var(--radius-md);
   user-select: none;
-  /* 그룹 정체성은 도트+레일만 소유한다 — 헤더 배경·글자는 중립 잉크로 침묵. */
-  background: transparent;
+  /* 그룹 정체성 = 스파인(레일) + 마크(도트) + 워시 — 헤더는 --grp-color 9% 워시(접힘 시 12%),
+     카운트만 정체성 틴트를 받고 보더는 상태 채널 소유로 남는다. 색 없는 그룹은 transparent 폴백으로 중립. */
+  background: color-mix(in oklch, var(--grp-color, transparent) 9%, transparent);
   cursor: grab;
   transition:
     background var(--duration-fast) var(--ease-spring),
     border-color var(--duration-fast) var(--ease-spring),
     box-shadow var(--duration-fast) var(--ease-spring),
     transform var(--duration-fast) var(--ease-spring);
+}
+
+/* 접힌 그룹은 헤더가 유일한 신호면이므로 워시를 강화한다. */
+.side-bar-group-header--collapsed {
+  background: color-mix(in oklch, var(--grp-color, transparent) 12%, transparent);
 }
 
 .side-bar-group-header--drop-target,
@@ -2899,18 +2909,16 @@
   text-align: right;
 }
 
-/* two-state 그룹 헤더: 색상 dot만 표시 */
-.side-bar-group-header--rail {
-  justify-content: center;
-  padding: 4px 0;
-  margin: 2px 0 0;
-  cursor: pointer;
+.side-bar-group-header[style*="--grp-color"] .side-bar-group-header__count {
+  color: color-mix(in oklch, var(--grp-color) 65%, var(--ink-pearl));
 }
 
+/* 그룹 마크 — 헤더 화살표와 이름 사이의 정체성 도트. */
 .side-bar-group-header__dot {
   display: block;
-  width: 6px;
-  height: 6px;
+  flex: none;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   background: var(--grp-color, var(--ink-fog));
 }


### PR DESCRIPTION
## Summary
- 사이드바 그룹 정체성을 기존 3px 좌측 레일 단일 채널에서 제품 독트린의 전체 문법(spine + mark + wash)으로 확장: 헤더에 7px 정체성 dot(접힘 상태에서도 유지) + 헤더 wash 9%(접힘 시 12%) + 섹션 존 wash 4% + 카운트 틴트 65%.
- 좌측 레일(`border-left: 3px solid var(--grp-color, transparent)`)은 사용자 결정에 따라 바이트 단위 불변 — 폭·반경·색·위치 변경 없음(섹션 border-radius는 우측 모서리만 적용해 레일 직사각형 형상 보존).
- 미배선이던 dead CSS(`--rail` 헤더 variant)를 제거하고 `__dot`을 실제 요소로 부활; 모든 색상은 `--id-*` 토큰 위 `var()`/`color-mix`만 사용해 3개 테마(Instrument/Maritime/Carbon)가 함께 재조율.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` green
- [x] `vitest run tests/instrument-design-contract.test.ts` 14/14 green (계약 갱신 불필요 — 기존 그룹 규칙 미고정 확인)
- [x] `pnpm --filter @dotobokuri/fleet-console test` — clean base 대비 동일한 선존 실패 10건(desktop_resource_root_invalid 환경 이슈), 회귀 0
- [x] Sentinel QA 리뷰 PASS (Critical/High/Medium/Low 0건, 관련 테스트 77/77)
- [x] 격리 인스턴스 실측: 시드 그룹 4개 기준 dot/wash/zone computed 값 일치(레일 3px 불변, 헤더 9%/12%, 존 4%, dot 7px), 펼침·접힘·3테마 스크린샷 시안 대조 완료
- [x] `.changelog.d/pr-335.md` — grouped syntax, bilingual summaries, `compile-changelog-fragments.mjs --check` OK (4 entries)
