### PR TITLE
feat(console): add panel motion layer with minimize choreography

### DIFF
--- a/.changelog.d/pr-336.md
+++ b/.changelog.d/pr-336.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Changed
+- [fleet-console] Panel transitions now share one motion layer: Formation switches, maximize, and restore glide smoothly, minimize fades toward its sidebar chip with a ghost flight and an arrival pulse, and Formation entry staggers panel placement. All motion honors reduced-motion preferences.
+  ko: 패널 전환이 하나의 공통 모션 레이어를 공유합니다. Formation 전환·최대화·복원이 부드럽게 미끄러지고, 최소화는 사이드바 칩을 향한 고스트 비행과 도착 맥동으로 사라지며, Formation 진입은 패널 배치를 순차 등장시킵니다. 모든 모션은 reduced-motion 설정을 존중합니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
@@ -744,7 +744,7 @@ function cancelZoomTween(): void {
   zoomRaf = null;
 }
 
-function prefersReducedMotion(): boolean {
+export function prefersReducedMotion(): boolean {
   if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -9,7 +9,8 @@ import { flattenGroupedOrder, hydrateOperations, setActiveOperation } from "../s
 import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import type { ConsoleState, OperationNode } from "../types.js";
-import { calculateGridSlots, animateViewportTo, claimTopZIndex, clearCompanionOperationId, clearMaximizedOperationId, focusOperation, forceDropCompanionOperationId, getSnapshot as getCanvasSnapshot, minimizeOperation, restoreOperation, setCompanionOperationId, setCompanionPanelVisible, setMaximizedOperationId, setOperationGeometry, setViewport, useCanvasState, useCompanionOperationId, useCompanionPanelVisibilityOverrides, useFormationLayout, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "./canvas-store.js";
+import { calculateGridSlots, animateViewportTo, claimTopZIndex, clearCompanionOperationId, clearMaximizedOperationId, focusOperation, forceDropCompanionOperationId, getSnapshot as getCanvasSnapshot, minimizeOperation, prefersReducedMotion, restoreOperation, setCompanionOperationId, setCompanionPanelVisible, setMaximizedOperationId, setOperationGeometry, setViewport, useCanvasState, useCompanionOperationId, useCompanionPanelVisibilityOverrides, useFormationLayout, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "./canvas-store.js";
+import { escapeSelectorValue, playMinimizeFlight } from "./panel-motion.js";
 import { CanvasContextMenu } from "./canvas-context-menu.js";
 import { CanvasMinimap } from "./canvas-minimap.js";
 import { resolveAccentColor } from "./operation-accent.js";
@@ -186,6 +187,24 @@ export function OperationsCanvas({
   ).filter((operation) => !minimizedSet.has(operation.id)).map((operation) => operation.id);
   const formationSlots = formationView ? calculateGridSlots({ x: 0, y: 0, width: canvasSize.width, height: canvasSize.height }, formationOperationIds.length, undefined, undefined, undefined, undefined, formationLayout) : [];
   const formationSlotByOperationId = new Map(formationOperationIds.map((operationId, index) => [operationId, formationSlots[index]!]));
+  // Formation 진입·레이아웃 전환 시 슬롯 순서 stagger — 윈도우 리사이즈 재배치에는 적용하지 않는다.
+  useEffect(() => {
+    if (!formationView || prefersReducedMotion()) return;
+    const root = canvasRef.current;
+    if (!root) return;
+    const frames = formationOperationIds
+      .map((operationId) => root.querySelector<HTMLElement>(`.canvas-operation[data-operation-id="${escapeSelectorValue(operationId)}"]`))
+      .filter((element): element is HTMLElement => element !== null);
+    // geometry 전용 CSS 변수 채널 — inline transition-delay는 존재 전환의 per-property 지연을 덮어쓴다.
+    frames.forEach((element, index) => { element.style.setProperty("--panel-stagger-delay", `${index * 40}ms`); });
+    const clear = () => { for (const element of frames) element.style.removeProperty("--panel-stagger-delay"); };
+    const timer = window.setTimeout(clear, 600 + frames.length * 40);
+    return () => {
+      window.clearTimeout(timer);
+      clear();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formationView, formationLayout]);
   // 최대화 시에는 net scale 1(기본 줌)로 렌더한다 — 현재 배율과 무관하게 터미널이 선명하게 그려진다.
   const effectiveZoom = panelMaximized || panelCompanion || formationView ? 1 : canvas.viewport.zoom;
   const topPanelZIndex = maxOperationZIndex(canvas.operations) + 1;
@@ -269,6 +288,7 @@ export function OperationsCanvas({
             },
             onMinimize: () => {
               if (state.activeOperationId === operation.id) setActiveOperation(null);
+              playMinimizeFlight(operation.id);
               minimizeOperation(operation.id);
             },
             onMaximize: () => {

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -61,6 +61,7 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
   const restoreIdentityFocusRef = useRef(false);
   const [accentAnchor, setAccentAnchor] = useState<DOMRect | null>(null);
   const [isCloseArmed, setIsCloseArmed] = useState(false);
+  const [dragging, setDragging] = useState(false);
   const displayTitle = operation.title;
   const rename = useInlineRename({
     currentTitle: operation.title,
@@ -81,6 +82,7 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
     minimized ? "is-minimized" : "",
     maximized ? "is-maximized" : "",
     topEdge ? "is-top-edge" : "",
+    dragging ? "is-dragging" : "",
     frameStatusClass(status),
   ].filter(Boolean).join(" ");
 
@@ -125,6 +127,22 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
     }, CLOSE_ARM_DURATION_MS);
   };
 
+  // 드래그/리사이즈 도중 캡처 대상(드래그 에지·리사이즈 핸들)이 언마운트되는 상태 전환에서는
+  // pointerup/pointercancel이 도달하지 않아 is-dragging이 잔존하고 공통 모션 transition이 영구 차단된다.
+  useEffect(() => {
+    if (!maximized && !interactionDisabled && !minimized) return;
+    dragRef.current = null;
+    resizeRef.current = null;
+    setDragging(false);
+  }, [maximized, interactionDisabled, minimized]);
+
+  const abortPointerManipulation = () => {
+    if (!dragRef.current && !resizeRef.current) return;
+    dragRef.current = null;
+    resizeRef.current = null;
+    setDragging(false);
+  };
+
   const beginDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
     disarmClose();
     if (maximized || interactionDisabled) return;
@@ -133,6 +151,7 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
     event.stopPropagation();
     onActivate();
     dragRef.current = { pointerId: event.pointerId, startX: event.clientX, startY: event.clientY, geometry, latest: geometry };
+    setDragging(true);
     event.currentTarget.setPointerCapture(event.pointerId);
   };
 
@@ -154,6 +173,7 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
   const endDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (maximized || interactionDisabled) {
       dragRef.current = null;
+      setDragging(false);
       return;
     }
     const drag = dragRef.current;
@@ -161,6 +181,7 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
     event.preventDefault();
     event.stopPropagation();
     dragRef.current = null;
+    setDragging(false);
     event.currentTarget.releasePointerCapture(event.pointerId);
     onGeometryCommit(drag.latest);
   };
@@ -171,6 +192,7 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
     event.stopPropagation();
     onActivate();
     resizeRef.current = { direction, pointerId: event.pointerId, startX: event.clientX, startY: event.clientY, geometry, latest: geometry };
+    setDragging(true);
     event.currentTarget.setPointerCapture(event.pointerId);
   };
 
@@ -188,6 +210,7 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
   const endResize = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (maximized || interactionDisabled) {
       resizeRef.current = null;
+      setDragging(false);
       return;
     }
     const resize = resizeRef.current;
@@ -195,6 +218,7 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
     event.preventDefault();
     event.stopPropagation();
     resizeRef.current = null;
+    setDragging(false);
     event.currentTarget.releasePointerCapture(event.pointerId);
     onGeometryCommit(resize.latest);
   };
@@ -286,6 +310,7 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
       style={frameStyle}
       onPointerDown={onActivate}
       data-canvas-operation
+      data-operation-id={operation.id}
       data-focus-layer-target={focusLayerTarget ? "true" : undefined}
       aria-label={`Operation ${displayTitle}`}
       aria-hidden={renderHidden || undefined}
@@ -300,6 +325,7 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
           onPointerMove={updateDrag}
           onPointerUp={endDrag}
           onPointerCancel={endDrag}
+          onLostPointerCapture={abortPointerManipulation}
           data-canvas-blocker
           aria-hidden="true"
         />
@@ -310,6 +336,7 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
         onPointerMove={updateDrag}
         onPointerUp={endDrag}
         onPointerCancel={endDrag}
+        onLostPointerCapture={abortPointerManipulation}
         data-canvas-blocker
       >
         {accentColor ? <span className="canvas-operation-id-mark" aria-hidden="true" /> : null}
@@ -382,6 +409,7 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
           onPointerMove={updateResize}
           onPointerUp={endResize}
           onPointerCancel={endResize}
+          onLostPointerCapture={abortPointerManipulation}
           data-canvas-blocker
           aria-hidden="true"
         />

--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -58,6 +58,7 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
   const dragRef = useRef<DragState | null>(null);
   const resizeRef = useRef<ResizeState | null>(null);
   const closeArmTimeoutRef = useRef<number | null>(null);
+  const lastVisibleGeometryRef = useRef(geometry);
   const restoreIdentityFocusRef = useRef(false);
   const [accentAnchor, setAccentAnchor] = useState<DOMRect | null>(null);
   const [isCloseArmed, setIsCloseArmed] = useState(false);
@@ -291,13 +292,19 @@ export function OperationFrame({ operation, active, geometry, zoom, status, mini
     rename.handleKeyDown(event);
   };
 
+  // 최소화 커밋과 동시에 formation slot·maximize·companion 레이아웃이 해제되면 라이브 geometry가
+  // 저장된 map 좌표로 회귀해, 페이드로 가시가 유지되는 동안 패널이 엉뚱한 위치에서 사라진다 —
+  // 마지막 가시 geometry를 동결해 사라진 자리에서 페이드하고, 복원은 그 자리에서 목표 슬롯으로 미끄러진다.
+  if (!minimized) lastVisibleGeometryRef.current = geometry;
+  const effectiveGeometry = minimized ? lastVisibleGeometryRef.current : geometry;
+
   // 패널 좌표·크기를 정수 픽셀로 스냅해 패널·내부 xterm 캔버스 원점을 정수 픽셀에 정렬한다(서브픽셀 번짐 제거).
   const frameStyle = {
-    left: Math.round(geometry.x),
-    top: Math.round(geometry.y),
-    width: Math.round(geometry.width),
-    height: Math.round(geometry.height),
-    zIndex: geometry.zIndex,
+    left: Math.round(effectiveGeometry.x),
+    top: Math.round(effectiveGeometry.y),
+    width: Math.round(effectiveGeometry.width),
+    height: Math.round(effectiveGeometry.height),
+    zIndex: effectiveGeometry.zIndex,
     // Focus Layer peer는 xterm ResizeObserver가 기존 컨테이너 크기를 계속 보게 레이아웃을 보존한다.
     ...(renderHidden ? { visibility: "hidden", pointerEvents: "none" } : {}),
     ...(accentColor ? { "--user-accent": accentColor } : {}),

--- a/runtime/fleet-console/core/client/src/canvas/panel-motion.ts
+++ b/runtime/fleet-console/core/client/src/canvas/panel-motion.ts
@@ -1,0 +1,125 @@
+import { prefersReducedMotion } from "./canvas-store.js";
+
+// 존재 전환 안무 — 최소화/복원 시 패널과 사이드바 칩 사이를 잇는 고스트 flight.
+// 상태 커밋을 지연·블로킹하지 않는 fire-and-forget 연출 레이어다.
+
+const ARRIVAL_PULSE_DURATION_MS = 600;
+const FALLBACK_DURATION_MS = 360;
+const FALLBACK_EASING = "cubic-bezier(0.4, 0.14, 0.2, 1)";
+
+interface FlightTiming {
+  readonly duration: number;
+  readonly easing: string;
+}
+
+// 최소화 flight: 상태 커밋 직전에 호출한다 — 패널 rect를 즉시 캡처하고,
+// 커밋 후 다음 프레임에 칩 rect를 조회해 패널→칩으로 고스트를 날린다.
+export function playMinimizeFlight(operationId: string): void {
+  if (typeof document === "undefined" || prefersReducedMotion()) return;
+  const from = panelRect(operationId);
+  if (!from) return;
+  window.requestAnimationFrame(() => {
+    const chip = chipElement(operationId);
+    const to = chip?.getBoundingClientRect();
+    if (!chip || !to) return;
+    flyGhost(from, to, () => pulseChip(chip));
+  });
+}
+
+// 복원 flight: 상태 커밋 지점에서 호출한다 — 칩 rect를 즉시 캡처하고,
+// 다음 프레임에 패널 rect를 조회해 칩→패널로 역방향 flight. 패널 본체 페이드인은 CSS 소유.
+export function playRestoreFlight(operationId: string): void {
+  if (typeof document === "undefined" || prefersReducedMotion()) return;
+  const from = chipElement(operationId)?.getBoundingClientRect();
+  if (!from) return;
+  window.requestAnimationFrame(() => {
+    const to = panelRect(operationId);
+    if (!to) return;
+    flyGhost(from, to);
+  });
+}
+
+function panelRect(operationId: string): DOMRect | null {
+  const panel = document.querySelector<HTMLElement>(`.canvas-operation[data-operation-id="${escapeSelectorValue(operationId)}"]`);
+  return panel?.getBoundingClientRect() ?? null;
+}
+
+function chipElement(operationId: string): HTMLElement | null {
+  return document.querySelector<HTMLElement>(`[data-side-bar-chip-id="${escapeSelectorValue(operationId)}"]`);
+}
+
+// jsdom 등 CSS 전역이 없는 환경 폴백 — 속성값 셀렉터의 인용부호·역슬래시만 이스케이프하면 충분하다.
+export function escapeSelectorValue(value: string): string {
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") return CSS.escape(value);
+  return value.replace(/["\\]/g, "\\$&");
+}
+
+function flyGhost(from: DOMRect, to: DOMRect, onArrive?: () => void): void {
+  if (from.width <= 0 || from.height <= 0 || to.width <= 0 || to.height <= 0) return;
+  const ghost = document.createElement("div");
+  ghost.className = "panel-motion-ghost";
+  ghost.setAttribute("aria-hidden", "true");
+  ghost.style.left = `${from.left}px`;
+  ghost.style.top = `${from.top}px`;
+  ghost.style.width = `${from.width}px`;
+  ghost.style.height = `${from.height}px`;
+  if (typeof ghost.animate !== "function") return;
+  document.body.appendChild(ghost);
+  const { duration, easing } = flightTiming();
+  // idempotent cleanup + fallback 타이머 — finish/cancel이 오지 않는 부분 WAAPI 구현이나
+  // animate() 예외에서도 고스트가 DOM에 잔존하지 않게 상한을 둔다.
+  let settled = false;
+  let guardTimer: number | null = null;
+  const finish = (arrived: boolean) => {
+    if (settled) return;
+    settled = true;
+    if (guardTimer !== null) window.clearTimeout(guardTimer);
+    ghost.remove();
+    if (arrived) onArrive?.();
+  };
+  let animation: Animation;
+  try {
+    animation = ghost.animate(
+      [
+        { transform: "translate(0, 0) scale(1, 1)", opacity: 0.9 },
+        {
+          transform: `translate(${to.left - from.left}px, ${to.top - from.top}px) scale(${to.width / from.width}, ${to.height / from.height})`,
+          opacity: 0,
+        },
+      ],
+      { duration, easing },
+    );
+  } catch {
+    finish(false);
+    return;
+  }
+  guardTimer = window.setTimeout(() => finish(true), duration + 120);
+  animation.onfinish = () => finish(true);
+  animation.oncancel = () => finish(false);
+}
+
+function pulseChip(chip: HTMLElement): void {
+  chip.classList.add("is-arrival-pulse");
+  window.setTimeout(() => chip.classList.remove("is-arrival-pulse"), ARRIVAL_PULSE_DURATION_MS);
+}
+
+// duration/easing은 테마 토큰(--duration-slow/--ease-glide)을 우선 읽고, 실패 시 토큰 정의와 같은 값으로 폴백한다.
+function flightTiming(): FlightTiming {
+  try {
+    const styles = getComputedStyle(document.documentElement);
+    return {
+      duration: parseDurationMs(styles.getPropertyValue("--duration-slow")) ?? FALLBACK_DURATION_MS,
+      easing: styles.getPropertyValue("--ease-glide").trim() || FALLBACK_EASING,
+    };
+  } catch {
+    return { duration: FALLBACK_DURATION_MS, easing: FALLBACK_EASING };
+  }
+}
+
+function parseDurationMs(value: string): number | null {
+  const trimmed = value.trim();
+  const match = /^(\d+(?:\.\d+)?)(ms|s)$/.exec(trimmed);
+  if (!match) return null;
+  const amount = Number.parseFloat(match[1]!);
+  return match[2] === "s" ? amount * 1000 : amount;
+}

--- a/runtime/fleet-console/core/client/src/canvas/panel-motion.ts
+++ b/runtime/fleet-console/core/client/src/canvas/panel-motion.ts
@@ -14,15 +14,17 @@ interface FlightTiming {
 
 // 최소화 flight: 상태 커밋 직전에 호출한다 — 패널 rect를 즉시 캡처하고,
 // 커밋 후 다음 프레임에 칩 rect를 조회해 패널→칩으로 고스트를 날린다.
+// 양 끝점이 실제로 보일 때만 난다 — 접힌 사이드바의 칩이나 focus layer 뒤 히든 피어는
+// visibility:hidden이어도 rect가 유효해, 가드 없이는 보이지 않는 지점에서 고스트가 나타난다.
 export function playMinimizeFlight(operationId: string): void {
   if (typeof document === "undefined" || prefersReducedMotion()) return;
-  const from = panelRect(operationId);
-  if (!from) return;
+  const panel = panelElement(operationId);
+  if (!isVisiblyRendered(panel)) return;
+  const from = panel.getBoundingClientRect();
   window.requestAnimationFrame(() => {
     const chip = chipElement(operationId);
-    const to = chip?.getBoundingClientRect();
-    if (!chip || !to) return;
-    flyGhost(from, to, () => pulseChip(chip));
+    if (!isVisiblyRendered(chip)) return;
+    flyGhost(from, chip.getBoundingClientRect(), () => pulseChip(chip));
   });
 }
 
@@ -30,22 +32,29 @@ export function playMinimizeFlight(operationId: string): void {
 // 다음 프레임에 패널 rect를 조회해 칩→패널로 역방향 flight. 패널 본체 페이드인은 CSS 소유.
 export function playRestoreFlight(operationId: string): void {
   if (typeof document === "undefined" || prefersReducedMotion()) return;
-  const from = chipElement(operationId)?.getBoundingClientRect();
-  if (!from) return;
+  const chip = chipElement(operationId);
+  if (!isVisiblyRendered(chip)) return;
+  const from = chip.getBoundingClientRect();
   window.requestAnimationFrame(() => {
-    const to = panelRect(operationId);
-    if (!to) return;
-    flyGhost(from, to);
+    const panel = panelElement(operationId);
+    if (!isVisiblyRendered(panel)) return;
+    flyGhost(from, panel.getBoundingClientRect());
   });
 }
 
-function panelRect(operationId: string): DOMRect | null {
-  const panel = document.querySelector<HTMLElement>(`.canvas-operation[data-operation-id="${escapeSelectorValue(operationId)}"]`);
-  return panel?.getBoundingClientRect() ?? null;
+function panelElement(operationId: string): HTMLElement | null {
+  return document.querySelector<HTMLElement>(`.canvas-operation[data-operation-id="${escapeSelectorValue(operationId)}"]`);
 }
 
 function chipElement(operationId: string): HTMLElement | null {
   return document.querySelector<HTMLElement>(`[data-side-bar-chip-id="${escapeSelectorValue(operationId)}"]`);
+}
+
+function isVisiblyRendered(element: HTMLElement | null): element is HTMLElement {
+  if (!element) return false;
+  const rect = element.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return false;
+  return getComputedStyle(element).visibility !== "hidden";
 }
 
 // jsdom 등 CSS 전역이 없는 환경 폴백 — 속성값 셀렉터의 인용부호·역슬래시만 이스케이프하면 충분하다.

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -7,6 +7,7 @@ import type { ClientApiCapability, FleetClientPlugin, OperationKindDescriptor } 
 import { addTheater, createGroup, deleteGroup, fetchGroups, fetchOperations, fetchTheaters, forgetTheater, issueTheaterFolderGrant, patchOperation, patchTheaterOrder, renameOperation, updateGroup, ApiError } from "../api.js";
 import { animateViewportTo, claimTopZIndex, ensureDefaultGeometry, focusOperation as focusCanvasOperation, forceDropCompanionOperationId, getCompanionOperationId, getFocusLayerRevision, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useCompanionOperationId, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
 import { screenToCanvas, type CanvasPoint } from "../canvas/coordinates.js";
+import { playMinimizeFlight, playRestoreFlight } from "../canvas/panel-motion.js";
 import { OperationsCanvas } from "../canvas/canvas.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
@@ -89,7 +90,10 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       void routeOperationFocus(nextId, registry.operationKinds, STABLE_RAIL_API, focusRequestEpochRef, () => {
         // 모두 최소화된 부팅 상태의 폴백 대상은 store 포커스보다 먼저 복원한다. 그렇지 않으면 Canvas의
         // "최소화된 active id 제거" effect가 pending focus 복원보다 앞서 실행되어 활성 표시를 지운다.
-        if (canvas.minimized.includes(nextId)) restoreOperation(nextId);
+        if (canvas.minimized.includes(nextId)) {
+          playRestoreFlight(nextId);
+          restoreOperation(nextId);
+        }
         focusOperation(nextId);
       });
     };
@@ -122,7 +126,9 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
     const snapshot = getCanvasSnapshot();
     const geometry = snapshot.operations[operationId] ?? operation.geometry ?? ensurePluginGeometry(operation);
     if (!snapshot.operations[operationId]) setOperationGeometry(operationId, geometry);
+    const wasMinimized = snapshot.minimized.includes(operationId);
     // 복원과 활성화를 같은 동기 실행에서 끝내 Canvas의 최소화-active 정리 effect보다 먼저 상태를 확정한다.
+    if (wasMinimized) playRestoreFlight(operationId);
     restoreOperation(operationId);
     setActiveOperation(operationId);
     const viewportSize = viewportSizeFor(bodyRef.current);
@@ -180,6 +186,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
 
   const handleMinimize = useCallback((operationId: string) => {
     if (stateRef.current.activeOperationId === operationId) setActiveOperation(null);
+    playMinimizeFlight(operationId);
     minimizeOperation(operationId);
   }, []);
 
@@ -397,6 +404,7 @@ async function routeOperationFocus(operationId: string, operationKinds: readonly
     if (operation && (!descriptor || !descriptor.companions?.length || !canOpenCompanions)) {
       forceDropCompanionOperationId();
       if (getFormationView()) {
+        if (getCanvasSnapshot().minimized.includes(operationId)) playRestoreFlight(operationId);
         restoreOperation(operationId);
         setActiveOperation(operationId);
         requestOperationKeyboardFocus(operationId);
@@ -418,6 +426,7 @@ async function routeOperationFocus(operationId: string, operationKinds: readonly
     return;
   }
   if (getFormationView()) {
+    if (getCanvasSnapshot().minimized.includes(operationId)) playRestoreFlight(operationId);
     restoreOperation(operationId);
     setActiveOperation(operationId);
     requestOperationKeyboardFocus(operationId);

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2082,7 +2082,10 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .canvas-operation {
+  /* is-minimized(0,2,0)는 .canvas-operation(0,1,0)보다 특이도가 높아 별도 명시가 필요하다 —
+     글로벌 캐치올은 transition-duration만 줄이고 visibility의 transition-delay는 못 끊는다. */
+  .canvas-operation,
+  .canvas-operation.is-minimized {
     transition: none;
   }
 

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -1961,6 +1961,23 @@
   border-radius: var(--radius-lg);
   background: var(--ink-mid);
   box-shadow: var(--shadow-soft);
+  /* 공통 geometry 모션 레이어 — formation/최대화/companion/복원의 재배치가 같은 물리로 움직인다.
+     visibility는 0s 즉시(복원·focus layer 즉시 표시), 최소화 시에만 is-minimized가 지연을 소유한다.
+     --panel-stagger-delay는 formation stagger 전용 채널로 geometry 4속성에만 걸린다 —
+     inline transition-delay는 존재 전환(opacity/visibility)의 per-property 지연까지 덮어쓰므로 금지. */
+  transition:
+    left var(--duration-slow) var(--ease-glide) var(--panel-stagger-delay, 0s),
+    top var(--duration-slow) var(--ease-glide) var(--panel-stagger-delay, 0s),
+    width var(--duration-slow) var(--ease-glide) var(--panel-stagger-delay, 0s),
+    height var(--duration-slow) var(--ease-glide) var(--panel-stagger-delay, 0s),
+    opacity var(--duration-base) var(--ease-glide),
+    transform var(--duration-base) var(--ease-glide),
+    visibility 0s linear 0s;
+}
+
+/* 드래그·리사이즈 조작 중에는 포인터 추적이 즉답해야 한다 — rail.css is-dragging 선례. */
+.canvas-operation.is-dragging {
+  transition: none;
 }
 
 /* Formation 슬롯은 계산값이 규약이다 — 320×200 CSS 최소값이 슬롯을 이기면 좁은 캔버스·다패널에서 겹침이 생긴다. */
@@ -1970,16 +1987,22 @@
   min-height: 0;
 }
 
-/* companion 슬롯 수 변경만 부드럽게 재배치한다 — 일반 Map 드래그에는 위치 transition을 노출하지 않는다. */
-.operations-canvas.is-companion-layout .canvas-operation {
-  transition:
-    left var(--duration-slow) var(--ease-glide),
-    width var(--duration-slow) var(--ease-glide);
-}
-
+/* 최소화 = fade+scale 존재 전환. visibility만 duration-base 뒤로 지연해(사이드바 is-closed 선례)
+   페이드아웃이 끝난 뒤 히트테스트에서 빠진다. 복원은 베이스 규칙의 visibility 0s로 즉시 나타나
+   opacity/transform이 페이드인한다. PTY 보존(visibility 기반 DOM 유지) 시맨틱은 그대로다. */
 .canvas-operation.is-minimized {
+  opacity: 0;
+  transform: scale(0.96);
   visibility: hidden;
   pointer-events: none;
+  transition:
+    left var(--duration-slow) var(--ease-glide),
+    top var(--duration-slow) var(--ease-glide),
+    width var(--duration-slow) var(--ease-glide),
+    height var(--duration-slow) var(--ease-glide),
+    opacity var(--duration-base) var(--ease-glide),
+    transform var(--duration-base) var(--ease-glide),
+    visibility 0s linear var(--duration-base);
 }
 
 /* 최대화: 패널이 캔버스(col2)를 가장자리까지 채운다.
@@ -2017,20 +2040,61 @@
 .canvas-companion-frame {
   display: flex;
   flex-direction: column;
-  animation: companion-frame-enter var(--duration-slow) var(--ease-glide) both;
+  animation: panel-enter var(--duration-slow) var(--ease-glide) both;
 }
 
-@keyframes companion-frame-enter {
+@keyframes panel-enter {
   from { opacity: 0; }
   to { opacity: 1; }
 }
 
+/* 고스트 오버레이 — 최소화/복원 flight의 콘텐츠 없는 대역. transient overlay 계층(40):
+   캔버스 위·모달 오버레이(60) 아래, toast/dropup과 같은 층. */
+.panel-motion-ghost {
+  position: fixed;
+  z-index: 40;
+  border: 1px solid var(--hairline-strong);
+  border-radius: var(--radius-md);
+  background: var(--surface-glass);
+  pointer-events: none;
+  transform-origin: 0 0;
+  will-change: transform, opacity;
+}
+
+/* 최소화 flight 도착 맥동 — brass(위치/포커스 채널) 1회. 칩 루트 한정:
+   accent(::before)·spine에는 animation 금지(정체성 채널 계약). */
+.side-bar-chip.is-arrival-pulse {
+  animation: side-bar-chip-arrival-pulse 0.6s var(--ease-glide) 1;
+}
+
+@keyframes side-bar-chip-arrival-pulse {
+  0% {
+    border-color: color-mix(in oklch, var(--brass) 55%, transparent);
+    box-shadow: 0 0 0 0 color-mix(in oklch, var(--brass) 40%, transparent);
+  }
+  55% {
+    box-shadow: 0 0 0 6px color-mix(in oklch, var(--brass) 12%, transparent);
+  }
+  100% {
+    border-color: transparent;
+    box-shadow: 0 0 0 10px transparent;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .operations-canvas.is-companion-layout .canvas-operation {
+  .canvas-operation {
     transition: none;
   }
 
   .canvas-companion-frame {
+    animation: none;
+  }
+
+  .side-bar-chip.is-arrival-pulse {
+    animation: none;
+  }
+
+  .panel-motion-ghost {
     animation: none;
   }
 }

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -130,6 +130,40 @@ describe("Instrument core design contract", () => {
     expect(accentSources).not.toMatch(/--op-accent|--chip-accent/);
   });
 
+  it("pins the shared panel motion layer and existence choreography grammar", () => {
+    const components = source("styles/components.css");
+    // (a) 공통 모션 레이어의 duration/easing은 토큰 표기만 — 리터럴 ms 진입 금지.
+    const baseBlock = components.match(/^\.canvas-operation \{[^}]*\}/m)?.[0] ?? "";
+    // stagger는 geometry 4속성 전용 CSS 변수 채널로만 흐른다 — inline transition-delay는
+    // 존재 전환(opacity/visibility)의 per-property 지연을 덮어쓰므로 그 진입 자체를 봉인한다.
+    for (const property of ["left", "top", "width", "height"]) {
+      expect(baseBlock).toContain(`${property} var(--duration-slow) var(--ease-glide) var(--panel-stagger-delay, 0s)`);
+    }
+    expect(baseBlock).toContain("opacity var(--duration-base) var(--ease-glide),");
+    expect(baseBlock).toContain("transform var(--duration-base) var(--ease-glide),");
+    expect(baseBlock).not.toContain("opacity var(--duration-base) var(--ease-glide) var(--panel-stagger-delay");
+    expect(baseBlock).toContain("visibility 0s linear 0s");
+    expect(baseBlock).not.toMatch(/\d+ms/);
+    const minimizedBlock = components.match(/\.canvas-operation\.is-minimized \{[^}]*\}/)?.[0] ?? "";
+    expect(minimizedBlock).toContain("visibility 0s linear var(--duration-base)");
+    expect(minimizedBlock).not.toMatch(/\d+ms/);
+    // (b) 드래그·리사이즈 조작 중에는 공통 transition을 통째로 끊는다.
+    const draggingBlock = components.match(/\.canvas-operation\.is-dragging \{[^}]*\}/)?.[0] ?? "";
+    expect(draggingBlock).toContain("transition: none;");
+    // (c) components.css의 reduced-motion 통합 블록이 캔버스 패널·companion 프레임을 커버한다.
+    expect(components).toMatch(
+      /@media \(prefers-reduced-motion: reduce\) \{\s*\.canvas-operation \{\s*transition: none;\s*\}\s*\.canvas-companion-frame \{\s*animation: none;\s*\}/,
+    );
+    // (d) 존재 전환 keyframe은 panel-enter로 일반화 — companion 전용 명칭은 퇴역하고 실제 사용까지 고정한다.
+    expect(components).toContain("@keyframes panel-enter");
+    expect(components).toContain("animation: panel-enter var(--duration-slow) var(--ease-glide) both;");
+    expect(components).not.toContain("companion-frame-enter");
+    // (e) 안무 표면(칩 도착 맥동·고스트)도 reduced-motion 블록 안에서 무효화된다.
+    const reducedMotionBlock = components.slice(components.indexOf("@media (prefers-reduced-motion: reduce)"));
+    expect(reducedMotionBlock).toContain(".side-bar-chip.is-arrival-pulse {");
+    expect(reducedMotionBlock).toContain(".panel-motion-ghost {");
+  });
+
   it("collapses sidebar chip actions out of layout until hover or focus-within", () => {
     const components = source("styles/components.css");
     const restingActions = components.match(/\.side-bar-chip-close,\n\.side-bar-chip-minimize \{[^}]*\}/)?.[0] ?? "";

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -151,15 +151,15 @@ describe("Instrument core design contract", () => {
     const draggingBlock = components.match(/\.canvas-operation\.is-dragging \{[^}]*\}/)?.[0] ?? "";
     expect(draggingBlock).toContain("transition: none;");
     // (c) components.css의 reduced-motion 통합 블록이 캔버스 패널·companion 프레임을 커버한다.
-    expect(components).toMatch(
-      /@media \(prefers-reduced-motion: reduce\) \{\s*\.canvas-operation \{\s*transition: none;\s*\}\s*\.canvas-companion-frame \{\s*animation: none;\s*\}/,
-    );
+    // is-minimized(0,2,0)는 .canvas-operation(0,1,0)을 이기므로 반드시 블록 안에 함께 명시된다.
+    const reducedMotionBlock = components.slice(components.indexOf("@media (prefers-reduced-motion: reduce)"));
+    expect(reducedMotionBlock).toMatch(/\.canvas-operation,\s*\.canvas-operation\.is-minimized \{\s*transition: none;\s*\}/);
+    expect(reducedMotionBlock).toMatch(/\.canvas-companion-frame \{\s*animation: none;\s*\}/);
     // (d) 존재 전환 keyframe은 panel-enter로 일반화 — companion 전용 명칭은 퇴역하고 실제 사용까지 고정한다.
     expect(components).toContain("@keyframes panel-enter");
     expect(components).toContain("animation: panel-enter var(--duration-slow) var(--ease-glide) both;");
     expect(components).not.toContain("companion-frame-enter");
     // (e) 안무 표면(칩 도착 맥동·고스트)도 reduced-motion 블록 안에서 무효화된다.
-    const reducedMotionBlock = components.slice(components.indexOf("@media (prefers-reduced-motion: reduce)"));
     expect(reducedMotionBlock).toContain(".side-bar-chip.is-arrival-pulse {");
     expect(reducedMotionBlock).toContain(".panel-motion-ghost {");
   });


### PR DESCRIPTION
## Summary
- companion(ANALYZE) 레이아웃에만 있던 geometry transition을 `.canvas-operation` 공통 모션 레이어로 승격 — formation 전환·최대화/복원·companion 재배치가 동일한 360ms `--ease-glide` 물리로 움직입니다. 드래그/리사이즈 중에는 `is-dragging`이 transition을 차단하고, 조작 중 상태 전환으로 캡처 대상이 언마운트되어도 lifecycle cleanup이 잔존을 방지합니다.
- 최소화/복원을 존재 전환 안무로: 패널 fade+scale(visibility는 페이드 종료 후 차단) + 사이드바 칩으로의 고스트 flight(WAAPI, 콘텐츠 없는 대역) + 도착 칩 brass 1회 맥동. 사이드바 minimize·패널 헤더·키보드 순환·formation 포커스 복원 4개 진입점 모두 연결. formation 진입은 슬롯 순서 40ms stagger(geometry 전용 `--panel-stagger-delay` CSS 변수 채널 — 존재 전환의 per-property 지연을 보존).
- `companion-frame-enter` keyframe을 `panel-enter`로 일반화, reduced-motion 통합 블록(캔버스 패널·companion·맥동·고스트) 추가, instrument design contract에 모션 그램마 핀 신설.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` green
- [x] `typecheck` — canary 선존 10건 유지, 신규 0건
- [x] `test` — 신규 contract 핀 포함 green (선존 flaky `server.test.ts` 워커 타임아웃 1건은 순정 canary 재현 확인)
- [x] console-e2e 격리 실측: formation/최대화 보간(21~22 중간 상태), 복원 페이드인(0→1, 220ms), 최소화 flight ghost+칩 맥동, 드래그 중 transition none·해제 복귀, 드래그 중 최대화 인터럽트 시 is-dragging 정리, stagger CSS 변수(0/40/80/120ms) 및 스태거 창 내 최소화 페이드 보존
- [x] Changelog: `.changelog.d/pr-336.md` — grouped fragment 문법·이중언어 요약·`compile-changelog-fragments.mjs --check` 검증 완료
