### PR TITLE
feat(console): add command mode to the operation search palette

### DIFF
--- a/.changelog.d/pr-338.md
+++ b/.changelog.d/pr-338.md
@@ -1,0 +1,6 @@
+### fleet-console
+
+#### Added
+
+- [fleet-console] Typing > in the command palette switches it to a command mode that runs curated Console actions from the keyboard: switch theater, launch a new Operation, open rail panels, toggle the rail or sidebar, switch theme, and open Settings, keyboard shortcuts, or What's new.
+  ko: 커맨드 팔레트에서 >를 입력하면 커맨드 모드로 전환되어 Theater 전환, 새 Operation 실행, rail 패널 열기, rail·사이드바 토글, 테마 전환, Settings·키보드 단축키·What's new 열기를 키보드로 실행합니다.

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 
 import { fetchGroups, fetchOperations, fetchTheaterBootstrap } from "./api.js";
 import { CommandBand } from "./components/command-band.js";
 import { CommissioningOverlay } from "./components/commissioning-overlay.js";
+import { KeyboardShortcutsDialog } from "./components/keyboard-shortcuts-dialog.js";
 import { OperationSearch } from "./components/operation-search.js";
 import { Toast } from "./components/toast.js";
 import { WhatsNewModal } from "./components/whatsnew-modal.js";
@@ -14,9 +15,10 @@ import { createHostCapabilities } from "./plugin-capabilities.js";
 import { usePluginRegistry } from "./plugin-registry.js";
 import { GlobalSettings } from "./pages/global-settings.js";
 import { Operations } from "./pages/operations.js";
+import { BUILT_IN_RAIL_PANELS } from "./rail/built-in-panels.js";
 import { toggleRailChrome } from "./rail/rail-store.js";
 import { refreshObserverStatus } from "./operations-sse.js";
-import { hydrateGroups, hydrateInitialOperations, hydrateOperations, hydrateTheaterBootstrap, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
+import { closeKeyboardShortcuts, hydrateGroups, hydrateInitialOperations, hydrateOperations, hydrateTheaterBootstrap, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
 import { abortReleaseNotesFetch, requestReleaseNotes } from "./release-notes-fetch.js";
 import { getSideBarState, setSideBarCollapsed } from "./sidebar/operations-side-bar-store.js";
 import { resolveReleaseNotesLocale } from "./whatsnew-i18n.js";
@@ -35,6 +37,12 @@ export function App() {
   const releaseNotesLocale = resolveReleaseNotesLocale(globalSettings.state?.language ?? "auto");
   const pathname = location.pathname;
   const operationsViewVisible = pathname.startsWith("/operations");
+  // 팔레트 커맨드 모드의 "Open panel" 목록 — RightRail과 동일한 빌트인+플러그인 합성 순서를 미러한다.
+  const paletteRailPanels = useMemo(
+    () => [...BUILT_IN_RAIL_PANELS, ...registry.railPanels.filter((panel) => (panel.side ?? "right") === "right")]
+      .map((panel) => ({ id: panel.id, title: panel.title })),
+    [registry.railPanels],
+  );
 
   // 세션 중 각 Theater를 처음 여는 시점에 한 번, 그 Theater의 "부팅 시점에 이미 존재하던" 패널 집합을 최소화 대상으로 반환한다.
   // App boot의 활성 Theater뿐 아니라 이후 선택·전환으로 처음 진입하는 Theater도 깨끗하게 열려, 선택한 패널만 하나씩 표면화된다.
@@ -116,7 +124,8 @@ export function App() {
           <Route path="*" element={<Navigate to="/operations" replace />} />
         </Routes>
       </main>
-      <OperationSearch state={state} />
+      <OperationSearch state={state} railPanels={paletteRailPanels} />
+      {state.keyboardShortcutsOpen ? <KeyboardShortcutsDialog onClose={closeKeyboardShortcuts} /> : null}
       <WhatsNewModal state={state} />
       <CommissioningOverlay state={state} />
       <Toast

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 
 import { fetchGroups, fetchOperations, fetchTheaterBootstrap } from "./api.js";
@@ -102,6 +102,20 @@ export function App() {
     void requestReleaseNotes({ locale: releaseNotesLocale });
     return abortReleaseNotesFetch;
   }, [releaseNotesLocale]);
+
+  const shortcutsReturnFocusRef = useRef<HTMLElement | null>(null);
+
+  // 단축키 다이얼로그가 열리는 시점의 포커스 요소를 캡처해 닫힐 때 복원한다(Help 메뉴 trigger 복원과 등가).
+  // 다이얼로그 자체의 focus effect(passive)보다 먼저 돌도록 layout effect로 캡처한다.
+  useLayoutEffect(() => {
+    if (state.keyboardShortcutsOpen) {
+      shortcutsReturnFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      return;
+    }
+    const target = shortcutsReturnFocusRef.current;
+    shortcutsReturnFocusRef.current = null;
+    if (target?.isConnected) target.focus();
+  }, [state.keyboardShortcutsOpen]);
 
   useEffect(() => {
     return installConsoleGlobalShortcuts({

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -109,12 +109,17 @@ export function App() {
   // 단축키 다이얼로그가 열리는 시점의 포커스 요소를 캡처해 닫힐 때 복원한다(Help 메뉴 trigger 복원과 등가).
   // 다이얼로그 자체의 focus effect(passive)보다 먼저 돌도록 layout effect로 캡처한다.
   useLayoutEffect(() => {
-    if (state.keyboardShortcutsOpen) {
-      // 팔레트처럼 자신이 닫히며 여는 표면은 opener를 채널로 넘긴다 — 그 경우 activeElement는 이미 제거 중이다.
-      shortcutsReturnFocusRef.current = takeKeyboardShortcutsReturnFocus()
-        ?? (document.activeElement instanceof HTMLElement ? document.activeElement : null);
-      return;
-    }
+    if (!state.keyboardShortcutsOpen) return;
+    // 팔레트처럼 자신이 닫히며 여는 표면은 opener를 채널로 넘긴다 — 그 경우 activeElement는 이미 제거 중이다.
+    // 캡처는 다이얼로그의 focus effect보다 선행해야 하므로 layout effect로 남긴다.
+    shortcutsReturnFocusRef.current = takeKeyboardShortcutsReturnFocus()
+      ?? (document.activeElement instanceof HTMLElement ? document.activeElement : null);
+  }, [state.keyboardShortcutsOpen]);
+
+  // 복원은 passive effect로 — 다이얼로그의 passive cleanup이 .console-shell inert를 걷어낸 뒤에 돌아야
+  // 실브라우저에서 inert 조상 때문에 focus()가 무시되지 않는다(layout 단계에서는 아직 inert 상태).
+  useEffect(() => {
+    if (state.keyboardShortcutsOpen) return;
     const target = shortcutsReturnFocusRef.current;
     shortcutsReturnFocusRef.current = null;
     if (target?.isConnected) target.focus();

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -5,6 +5,7 @@ import { fetchGroups, fetchOperations, fetchTheaterBootstrap } from "./api.js";
 import { CommandBand } from "./components/command-band.js";
 import { CommissioningOverlay } from "./components/commissioning-overlay.js";
 import { KeyboardShortcutsDialog } from "./components/keyboard-shortcuts-dialog.js";
+import { takeKeyboardShortcutsReturnFocus } from "./keyboard-shortcuts-return-focus.js";
 import { OperationSearch } from "./components/operation-search.js";
 import { Toast } from "./components/toast.js";
 import { WhatsNewModal } from "./components/whatsnew-modal.js";
@@ -109,7 +110,9 @@ export function App() {
   // 다이얼로그 자체의 focus effect(passive)보다 먼저 돌도록 layout effect로 캡처한다.
   useLayoutEffect(() => {
     if (state.keyboardShortcutsOpen) {
-      shortcutsReturnFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      // 팔레트처럼 자신이 닫히며 여는 표면은 opener를 채널로 넘긴다 — 그 경우 activeElement는 이미 제거 중이다.
+      shortcutsReturnFocusRef.current = takeKeyboardShortcutsReturnFocus()
+        ?? (document.activeElement instanceof HTMLElement ? document.activeElement : null);
       return;
     }
     const target = shortcutsReturnFocusRef.current;

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -11,6 +11,7 @@ import {
   type PaletteCommandEntry,
   type PaletteRailPanelInfo,
 } from "../palette-commands.js";
+import { stashKeyboardShortcutsReturnFocus } from "../keyboard-shortcuts-return-focus.js";
 import { openRailPanel, setRailChromeExpanded, toggleRailChrome } from "../rail/rail-store.js";
 import { getSideBarState, setSideBarCollapsed } from "../sidebar/operations-side-bar-store.js";
 import {
@@ -153,6 +154,10 @@ export function OperationSearch({ state, railPanels }: OperationSearchProps) {
         break;
       }
       case "open-keyboard-shortcuts": {
+        // 팔레트가 닫히면서 다이얼로그가 열리므로, App 캡처 시점의 activeElement는 제거 중인 팔레트 내부다.
+        // 팔레트를 연 시점의 요소를 채널로 넘겨 다이얼로그 닫힘 시 그 요소로 복원되게 한다.
+        stashKeyboardShortcutsReturnFocus(previousFocusRef.current);
+        previousFocusRef.current = null;
         openKeyboardShortcuts();
         break;
       }

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -1,32 +1,67 @@
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
+import { setGlobalSettingsField } from "../global-settings-store.js";
 import { filterOperationSearchEntries, groupOperationSearchEntries, searchTokens } from "../operation-search.js";
-import { closeOperationSearch, focusOperation, operationSearchEntries } from "../store.js";
+import {
+  buildPaletteCommands,
+  commandModeQuery,
+  filterPaletteCommands,
+  isCommandModeInput,
+  type PaletteCommandEntry,
+  type PaletteRailPanelInfo,
+} from "../palette-commands.js";
+import { openRailPanel, setRailChromeExpanded, toggleRailChrome } from "../rail/rail-store.js";
+import { getSideBarState, setSideBarCollapsed } from "../sidebar/operations-side-bar-store.js";
+import {
+  closeOperationSearch,
+  focusOperation,
+  openKeyboardShortcuts,
+  openWhatsNew,
+  operationSearchEntries,
+  requestOperationLaunchMenu,
+  setActiveTheater,
+  setActiveTheme,
+} from "../store.js";
 import type { ConsoleState } from "../types.js";
 
 interface OperationSearchProps {
   readonly state: ConsoleState;
+  readonly railPanels: readonly PaletteRailPanelInfo[];
 }
 
 const FOCUSABLE_SELECTOR = "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])";
 const LISTBOX_ID = "operation-search-listbox";
 const UNASSIGNED_GROUP_KEY = "__unassigned__";
+const COMMAND_GROUP_HEADING_ID = "operation-search-heading-commands";
 
-export function OperationSearch({ state }: OperationSearchProps) {
+export function OperationSearch({ state, railPanels }: OperationSearchProps) {
   const navigate = useNavigate();
+  const location = useLocation();
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const cardRef = useRef<HTMLElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const resultRefs = useRef(new Map<string, HTMLButtonElement>());
+  const commandMode = isCommandModeInput(query);
   const entries = useMemo(() => operationSearchEntries(state), [state]);
   const filteredEntries = useMemo(() => filterOperationSearchEntries(entries, query), [entries, query]);
   const groups = useMemo(() => groupOperationSearchEntries(filteredEntries), [filteredEntries]);
-  const tokens = useMemo(() => searchTokens(query), [query]);
-  const clampedSelectedIndex = clampIndex(selectedIndex, filteredEntries.length);
-  const activeOptionId = filteredEntries[clampedSelectedIndex] ? operationOptionId(filteredEntries[clampedSelectedIndex].operationId) : undefined;
+  const commands = useMemo(() => buildPaletteCommands(state, railPanels), [state, railPanels]);
+  const filteredCommands = useMemo(
+    () => (commandMode ? filterPaletteCommands(commands, commandModeQuery(query)) : commands),
+    [commandMode, commands, query],
+  );
+  const tokens = useMemo(() => searchTokens(commandMode ? commandModeQuery(query) : query), [commandMode, query]);
+  const resultCount = commandMode ? filteredCommands.length : filteredEntries.length;
+  const clampedSelectedIndex = clampIndex(selectedIndex, resultCount);
+  const selectedResultKey = commandMode
+    ? filteredCommands[clampedSelectedIndex]?.commandId
+    : filteredEntries[clampedSelectedIndex]?.operationId;
+  const activeOptionId = selectedResultKey === undefined
+    ? undefined
+    : commandMode ? commandOptionId(selectedResultKey) : operationOptionId(selectedResultKey);
 
   useEffect(() => {
     if (!state.operationSearchOpen) return;
@@ -50,11 +85,9 @@ export function OperationSearch({ state }: OperationSearchProps) {
   }, [state.operationSearchOpen, query]);
 
   useEffect(() => {
-    if (!state.operationSearchOpen) return;
-    const selected = filteredEntries[clampedSelectedIndex];
-    if (!selected) return;
-    resultRefs.current.get(selected.operationId)?.scrollIntoView({ block: "nearest" });
-  }, [clampedSelectedIndex, filteredEntries, state.operationSearchOpen]);
+    if (!state.operationSearchOpen || selectedResultKey === undefined) return;
+    resultRefs.current.get(selectedResultKey)?.scrollIntoView({ block: "nearest" });
+  }, [selectedResultKey, state.operationSearchOpen]);
 
   if (!state.operationSearchOpen) return null;
 
@@ -67,6 +100,61 @@ export function OperationSearch({ state }: OperationSearchProps) {
     closeOperationSearch();
   };
 
+  const runCommand = (command: PaletteCommandEntry) => {
+    const action = command.action;
+    switch (action.kind) {
+      case "switch-theater": {
+        if (command.current) break;
+        // Theater 전환은 캔버스로 포커스 문맥을 넘기므로 selectEntry처럼 이전 포커스 복원을 억제한다.
+        previousFocusRef.current = null;
+        setActiveTheater(action.theaterId);
+        navigate("/operations");
+        break;
+      }
+      case "new-operation": {
+        previousFocusRef.current = null;
+        if (!location.pathname.startsWith("/operations")) navigate("/operations");
+        requestOperationLaunchMenu();
+        break;
+      }
+      case "open-rail-panel": {
+        openRailPanel(action.panelId);
+        setRailChromeExpanded(true);
+        break;
+      }
+      case "toggle-rail": {
+        toggleRailChrome();
+        break;
+      }
+      case "toggle-sidebar": {
+        setSideBarCollapsed(!getSideBarState().collapsed);
+        break;
+      }
+      case "switch-theme": {
+        if (command.current) break;
+        const previousTheme = state.activeTheme;
+        setActiveTheme(action.theme);
+        void setGlobalSettingsField("theme", action.theme).then((saved) => {
+          if (!saved) setActiveTheme(previousTheme);
+        });
+        break;
+      }
+      case "open-settings": {
+        navigate("/settings");
+        break;
+      }
+      case "open-keyboard-shortcuts": {
+        openKeyboardShortcuts();
+        break;
+      }
+      case "whats-new": {
+        openWhatsNew();
+        break;
+      }
+    }
+    closeOperationSearch();
+  };
+
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
     if (event.key === "Escape") {
       event.preventDefault();
@@ -75,10 +163,17 @@ export function OperationSearch({ state }: OperationSearchProps) {
     }
     if (event.key === "ArrowDown" || event.key === "ArrowUp") {
       event.preventDefault();
-      setSelectedIndex((current) => clampIndex(current + (event.key === "ArrowDown" ? 1 : -1), filteredEntries.length));
+      setSelectedIndex((current) => clampIndex(current + (event.key === "ArrowDown" ? 1 : -1), resultCount));
       return;
     }
     if (event.key === "Enter") {
+      if (commandMode) {
+        const selected = filteredCommands[clampedSelectedIndex];
+        if (!selected) return;
+        event.preventDefault();
+        runCommand(selected);
+        return;
+      }
       const selected = filteredEntries[clampedSelectedIndex];
       if (!selected) return;
       event.preventDefault();
@@ -97,7 +192,7 @@ export function OperationSearch({ state }: OperationSearchProps) {
         className="operation-search-card"
         role="dialog"
         aria-modal="true"
-        aria-label="Operation quick search"
+        aria-label={commandMode ? "Console commands" : "Operation quick search"}
         tabIndex={-1}
         onKeyDown={handleKeyDown}
       >
@@ -109,7 +204,7 @@ export function OperationSearch({ state }: OperationSearchProps) {
             type="search"
             value={query}
             onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search Operations across Theaters"
+            placeholder="Search Operations — type > for commands"
             autoComplete="off"
             role="combobox"
             aria-expanded={true}
@@ -120,8 +215,37 @@ export function OperationSearch({ state }: OperationSearchProps) {
           />
           <kbd>esc</kbd>
         </div>
-        <div id={LISTBOX_ID} className="operation-search-results" role="listbox" aria-label="Operation results">
-          {groups.length > 0 ? groups.map((group) => {
+        <div id={LISTBOX_ID} className="operation-search-results" role="listbox" aria-label={commandMode ? "Command results" : "Operation results"}>
+          {commandMode ? (filteredCommands.length > 0 ? (
+            <section className="operation-search-section" role="group" aria-labelledby={COMMAND_GROUP_HEADING_ID}>
+              <h2 id={COMMAND_GROUP_HEADING_ID} className="operation-search-section-heading">Commands</h2>
+              {filteredCommands.map((command, index) => {
+                const active = index === clampedSelectedIndex;
+                return (
+                  <button
+                    id={commandOptionId(command.commandId)}
+                    key={command.commandId}
+                    ref={(node) => {
+                      if (node) resultRefs.current.set(command.commandId, node);
+                      else resultRefs.current.delete(command.commandId);
+                    }}
+                    type="button"
+                    className={`operation-search-result ${active ? "is-active" : ""}`}
+                    role="option"
+                    aria-selected={active}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                    onClick={() => runCommand(command)}
+                  >
+                    <span className="operation-search-command-glyph" aria-hidden="true">›</span>
+                    <span className="operation-search-result-text">
+                      <strong>{highlightText(command.label, tokens)}</strong>
+                    </span>
+                    {command.current ? <span className="operation-search-theater">current</span> : null}
+                  </button>
+                );
+              })}
+            </section>
+          ) : <p className="operation-search-empty">No matching commands.</p>) : groups.length > 0 ? groups.map((group) => {
             const headingId = operationGroupHeadingId(group.theaterId);
             return (
             <section className="operation-search-section" key={group.theaterId ?? UNASSIGNED_GROUP_KEY} role="group" aria-labelledby={headingId}>
@@ -176,6 +300,10 @@ function operationGroupHeadingId(theaterId: string | null): string {
 
 function operationOptionId(operationId: string): string {
   return `operation-search-option-${domIdPart(operationId)}`;
+}
+
+function commandOptionId(commandId: string): string {
+  return `operation-search-command-${domIdPart(commandId)}`;
 }
 
 function domIdPart(value: string): string {

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -118,15 +118,22 @@ export function OperationSearch({ state, railPanels }: OperationSearchProps) {
         break;
       }
       case "open-rail-panel": {
+        // rail·사이드바는 operations 페이지에만 마운트되므로 다른 경로에서는 먼저 이동한다.
+        if (!location.pathname.startsWith("/operations")) navigate("/operations");
         openRailPanel(action.panelId);
         setRailChromeExpanded(true);
         break;
       }
       case "toggle-rail": {
+        if (!location.pathname.startsWith("/operations")) navigate("/operations");
+        // 닫힘 cleanup의 포커스 복원 타깃을 command-band의 rail 토글로 재지정한다(미발견 시 복원 억제).
+        previousFocusRef.current = document.querySelector<HTMLElement>(".command-band-rail-toggle");
         toggleRailChrome();
         break;
       }
       case "toggle-sidebar": {
+        if (!location.pathname.startsWith("/operations")) navigate("/operations");
+        previousFocusRef.current = document.querySelector<HTMLElement>(".command-band-sidebar-toggle");
         setSideBarCollapsed(!getSideBarState().collapsed);
         break;
       }
@@ -140,6 +147,8 @@ export function OperationSearch({ state, railPanels }: OperationSearchProps) {
         break;
       }
       case "open-settings": {
+        // 라우트 전환으로 이전 포커스 요소가 unmount되므로 복원을 억제한다(switch-theater와 동일).
+        previousFocusRef.current = null;
         navigate("/settings");
         break;
       }

--- a/runtime/fleet-console/core/client/src/components/whatsnew-modal.tsx
+++ b/runtime/fleet-console/core/client/src/components/whatsnew-modal.tsx
@@ -71,7 +71,8 @@ export function WhatsNewModal({ state }: WhatsNewModalProps) {
   const whatsNewSuppressed =
     !state.bootstrapped ||
     state.onboardingOpen ||
-    state.operationSearchOpen;
+    state.operationSearchOpen ||
+    state.keyboardShortcutsOpen;
   if (state.whatsNewOpen && !whatsNewSuppressed && returnFocusRef.current === null) {
     returnFocusRef.current = document.activeElement as HTMLElement | null;
   }

--- a/runtime/fleet-console/core/client/src/keyboard-shortcuts-return-focus.ts
+++ b/runtime/fleet-console/core/client/src/keyboard-shortcuts-return-focus.ts
@@ -1,0 +1,15 @@
+// 팔레트처럼 "자신이 닫히면서" 단축키 다이얼로그를 여는 표면이, 다이얼로그가 닫힐 때 복원할
+// 원래 포커스 요소를 App에 넘기는 1회성 채널. 여는 시점의 document.activeElement는 이미
+// 제거 중인 표면 내부 요소라 App 캡처만으로는 opener를 알 수 없다.
+// (core 클라이언트 단일 번들 내부 전용 — 호스트/플러그인 번들 경계를 넘지 않는다.)
+let target: HTMLElement | null = null;
+
+export function stashKeyboardShortcutsReturnFocus(element: HTMLElement | null): void {
+  target = element;
+}
+
+export function takeKeyboardShortcutsReturnFocus(): HTMLElement | null {
+  const taken = target;
+  target = null;
+  return taken;
+}

--- a/runtime/fleet-console/core/client/src/palette-commands.ts
+++ b/runtime/fleet-console/core/client/src/palette-commands.ts
@@ -1,0 +1,118 @@
+import { searchTokens } from "./operation-search.js";
+import type { ConsoleState, ThemeId } from "./types.js";
+
+export interface PaletteRailPanelInfo {
+  readonly id: string;
+  readonly title: string;
+}
+
+export type PaletteCommandAction =
+  | { readonly kind: "switch-theater"; readonly theaterId: string }
+  | { readonly kind: "new-operation" }
+  | { readonly kind: "open-rail-panel"; readonly panelId: string }
+  | { readonly kind: "toggle-rail" }
+  | { readonly kind: "toggle-sidebar" }
+  | { readonly kind: "switch-theme"; readonly theme: ThemeId }
+  | { readonly kind: "open-settings" }
+  | { readonly kind: "open-keyboard-shortcuts" }
+  | { readonly kind: "whats-new" };
+
+export interface PaletteCommandEntry {
+  readonly commandId: string;
+  readonly label: string;
+  readonly current: boolean;
+  readonly action: PaletteCommandAction;
+}
+
+export const PALETTE_THEMES: readonly { readonly id: ThemeId; readonly label: string }[] = [
+  { id: "instrument", label: "Instrument" },
+  { id: "maritime", label: "Maritime" },
+  { id: "carbon", label: "Carbon" },
+];
+
+export function isCommandModeInput(value: string): boolean {
+  return value.startsWith(">");
+}
+
+export function commandModeQuery(value: string): string {
+  return value.slice(1);
+}
+
+export function buildPaletteCommands(current: ConsoleState, railPanels: readonly PaletteRailPanelInfo[]): readonly PaletteCommandEntry[] {
+  const commands: PaletteCommandEntry[] = [];
+  const activeTheater = current.theaters.find((theater) => theater.id === current.activeTheaterId) ?? null;
+  for (const theater of current.theaters) {
+    commands.push({
+      commandId: `switch-theater:${theater.id}`,
+      label: `Switch theater: ${theater.label}`,
+      current: theater.id === current.activeTheaterId,
+      action: { kind: "switch-theater", theaterId: theater.id },
+    });
+  }
+  if (activeTheater) {
+    commands.push({
+      commandId: "new-operation",
+      label: `New Operation in ${activeTheater.label}`,
+      current: false,
+      action: { kind: "new-operation" },
+    });
+  }
+  for (const panel of railPanels) {
+    commands.push({
+      commandId: `open-rail-panel:${panel.id}`,
+      label: `Open panel: ${panel.title}`,
+      current: false,
+      action: { kind: "open-rail-panel", panelId: panel.id },
+    });
+  }
+  commands.push({
+    commandId: "toggle-rail",
+    label: "Toggle Activity Rail",
+    current: false,
+    action: { kind: "toggle-rail" },
+  });
+  commands.push({
+    commandId: "toggle-sidebar",
+    label: "Toggle sidebar",
+    current: false,
+    action: { kind: "toggle-sidebar" },
+  });
+  for (const theme of PALETTE_THEMES) {
+    commands.push({
+      commandId: `switch-theme:${theme.id}`,
+      label: `Switch theme: ${theme.label}`,
+      current: theme.id === current.activeTheme,
+      action: { kind: "switch-theme", theme: theme.id },
+    });
+  }
+  commands.push({
+    commandId: "open-settings",
+    label: "Open Settings",
+    current: false,
+    action: { kind: "open-settings" },
+  });
+  commands.push({
+    commandId: "open-keyboard-shortcuts",
+    label: "Open keyboard shortcuts",
+    current: false,
+    action: { kind: "open-keyboard-shortcuts" },
+  });
+  if (current.releaseNotes.length > 0) {
+    commands.push({
+      commandId: "whats-new",
+      label: "What's new",
+      current: false,
+      action: { kind: "whats-new" },
+    });
+  }
+  return commands;
+}
+
+export function filterPaletteCommands(commands: readonly PaletteCommandEntry[], query: string): readonly PaletteCommandEntry[] {
+  const tokens = searchTokens(query);
+  if (tokens.length === 0) return commands;
+  return commands.filter((command) => {
+    const haystack = command.label.toLocaleLowerCase();
+    return tokens.every((token) => haystack.includes(token));
+  });
+}

--- a/runtime/fleet-console/core/client/src/rail/rail-store.ts
+++ b/runtime/fleet-console/core/client/src/rail/rail-store.ts
@@ -38,6 +38,11 @@ export function toggleRailPanel(id: string): void {
   saveStoredPanelId(next);
 }
 
+// Ensure-open: 이미 활성인 패널은 유지하고, 아니면 선택한다(toggleRailPanel과 달리 절대 닫지 않는다).
+export function openRailPanel(id: string): void {
+  setActiveRailPanel(id);
+}
+
 export function closeRailPanel(): void {
   if (store.activeRailPanelId === null) return;
   setStore({ ...store, activeRailPanelId: null, panelExtraWidth: 0 });

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -12,7 +12,7 @@ import { useConsoleState } from "../hooks/use-store.js";
 import { GroupContextMenu } from "../canvas/group-context-menu.js";
 import { operationAccentFromNode, resolveAccentColor } from "../canvas/operation-accent.js";
 import { getTheaterCanvasSnapshot, selectFormationLayout, setOperationOrder, toggleGroupCollapsed, toggleTheaterGroupCollapsed, useCanvasState, useCollapsedGroups, useFormationLayout, useFormationView } from "../canvas/canvas-store.js";
-import { consumeSideBarAddTheater, consumeSideBarTheaterLaunch, sortOperationsByOrder } from "../store.js";
+import { consumeOperationLaunchMenu, consumeSideBarAddTheater, consumeSideBarTheaterLaunch, sortOperationsByOrder } from "../store.js";
 import { SideBarBrandFoot } from "../components/side-bar-brand-foot.js";
 import { applyVisibleReorder, groupDropIndexFromPoint, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderGroupIds, reorderTheaterIds, reorderWithinSegment, theaterDropIndexFromPoint, type DropSectionInfo } from "./operations-side-bar-hit-test.js";
 import { OperationsSideBarChip, type SideBarEntry } from "./operations-side-bar-chip.js";
@@ -220,7 +220,7 @@ export function OperationsSideBar({
   const [sideBarResizing, setSideBarResizing] = useState(false);
   const collapsedGroups = useCollapsedGroups();
   const collapsedTheaters = useCollapsedTheaters();
-  const { operationStatus, pendingSideBarAddTheater, pendingSideBarTheaterLaunch } = useConsoleState();
+  const { operationStatus, pendingSideBarAddTheater, pendingSideBarTheaterLaunch, launchMenuRequest } = useConsoleState();
 
   useLayoutEffect(() => {
     if (!previousCollapsedRef.current && collapsed) focusCommandBandToggleWhenPanelContainsActiveElement(rootRef.current, ".command-band-sidebar-toggle");
@@ -281,6 +281,21 @@ export function OperationsSideBar({
     if (allEntries.some((entry) => entry.operation.id === armedCloseId)) return;
     disarmClose();
   }, [armedCloseId, allEntries, disarmClose]);
+
+  // 팔레트 "New Operation" 커맨드 요청을 소비해 ＋New 버튼과 동일한 launch 오버레이를 그 버튼 앵커 위치에 연다.
+  useEffect(() => {
+    if (!launchMenuRequest) return;
+    consumeOperationLaunchMenu();
+    const launchButton = rootRef.current?.querySelector<HTMLButtonElement>(
+      '.side-bar-theater-section--active .side-bar-theater-row-btn[aria-label^="New Operation in"]',
+    );
+    const rect = launchButton?.getBoundingClientRect();
+    setActiveContextMenu(null);
+    setNewMenu({
+      anchor: rect ? { x: rect.right + 8, y: rect.top } : { x: 16, y: 64 },
+      viewportBounds: { width: window.innerWidth, height: window.innerHeight },
+    });
+  }, [launchMenuRequest]);
 
 
   const contextMenuOperation = activeContextMenu?.kind === "chip"

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -78,6 +78,8 @@ let state: ConsoleState = {
   keyboardFocusRequest: null,
   pendingSideBarAddTheater: false,
   pendingSideBarTheaterLaunch: null,
+  launchMenuRequest: null,
+  keyboardShortcutsOpen: false,
   operationNotifications: {},
   notificationPreferences: readStoredNotificationPreferences(),
   codexReader: null,
@@ -339,6 +341,26 @@ export function requestOperationKeyboardFocus(operationId: string): void {
       requestId: (state.keyboardFocusRequest?.requestId ?? 0) + 1,
     },
   });
+}
+
+// 팔레트 "New Operation" 커맨드가 사이드바의 ＋New launch 오버레이를 열도록 요청한다(keyboardFocusRequest 패턴 미러).
+export function requestOperationLaunchMenu(): void {
+  setState({ launchMenuRequest: { requestId: (state.launchMenuRequest?.requestId ?? 0) + 1 } });
+}
+
+export function consumeOperationLaunchMenu(): void {
+  if (state.launchMenuRequest === null) return;
+  setState({ launchMenuRequest: null });
+}
+
+export function openKeyboardShortcuts(): void {
+  if (state.keyboardShortcutsOpen) return;
+  setState({ keyboardShortcutsOpen: true });
+}
+
+export function closeKeyboardShortcuts(): void {
+  if (!state.keyboardShortcutsOpen) return;
+  setState({ keyboardShortcutsOpen: false });
 }
 
 export function nextOperationId(order: readonly string[], currentId: string | null, delta: number): string | null {

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5980,6 +5980,18 @@
   color: var(--brass-bright);
 }
 
+.operation-search-command-glyph {
+  flex: none;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  line-height: 1;
+}
+
+.operation-search-result.is-active .operation-search-command-glyph {
+  color: var(--brass-bright);
+}
+
 .operation-search-empty {
   margin: 0;
   padding: var(--space-5) var(--space-4);

--- a/runtime/fleet-console/core/client/src/types.ts
+++ b/runtime/fleet-console/core/client/src/types.ts
@@ -205,6 +205,8 @@ export interface ConsoleState {
   readonly keyboardFocusRequest: { readonly operationId: string; readonly requestId: number } | null;
   readonly pendingSideBarAddTheater: boolean;
   readonly pendingSideBarTheaterLaunch: string | null;
+  readonly launchMenuRequest: { readonly requestId: number } | null;
+  readonly keyboardShortcutsOpen: boolean;
   readonly operationNotifications: Readonly<Record<string, OperationNotification>>;
   readonly notificationPreferences: NotificationPreferences;
   readonly codexReader: CodexReaderRequest | null;

--- a/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
+++ b/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
@@ -416,6 +416,8 @@ const CANVAS_STATE: ConsoleState = {
   keyboardFocusRequest: null,
   pendingSideBarAddTheater: false,
   pendingSideBarTheaterLaunch: null,
+  launchMenuRequest: null,
+  keyboardShortcutsOpen: false,
   operationNotifications: {},
   notificationPreferences: { globalMute: false, dnd: false, mutedTheaterIds: {} },
   codexReader: null,

--- a/runtime/fleet-console/tests/operation-search-focus.test.tsx
+++ b/runtime/fleet-console/tests/operation-search-focus.test.tsx
@@ -2,7 +2,7 @@
 
 import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OperationSearch } from "../core/client/src/components/operation-search.js";
@@ -86,6 +86,33 @@ describe("Operation search focus handoff", () => {
     expect(document.querySelector('[role="dialog"]')).toBeNull();
   });
 
+  it("navigates to /operations before opening a rail panel command from another route", () => {
+    // 커맨드 모드의 open-rail-panel은 rail이 operations 페이지에만 마운트되므로 다른 경로에서 먼저 이동해야 한다.
+    act(() => root!.render(createElement(
+      MemoryRouter,
+      { key: "settings-route", initialEntries: ["/settings"] },
+      createElement(SearchHarness),
+      createElement(LocationProbe),
+    )));
+    expect(observedPathname).toBe("/settings");
+
+    const input = document.querySelector<HTMLInputElement>("#operation-search-input");
+    expect(input).not.toBeNull();
+    const setInputValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+    act(() => {
+      setInputValue.call(input, ">open panel alerts");
+      input!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const commandOption = document.querySelector<HTMLButtonElement>('[role="option"]');
+    expect(commandOption?.textContent).toContain("Open panel: Alerts");
+
+    act(() => commandOption!.click());
+
+    expect(observedPathname).toBe("/operations");
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+  });
+
   it("restores the previous focus after Escape cancellation", () => {
     const restoreFocus = vi.spyOn(previousFocus!, "focus");
     const input = document.querySelector<HTMLInputElement>("#operation-search-input");
@@ -100,5 +127,12 @@ describe("Operation search focus handoff", () => {
 });
 
 function SearchHarness() {
-  return createElement(OperationSearch, { state: useConsoleState(), railPanels: [] });
+  return createElement(OperationSearch, { state: useConsoleState(), railPanels: [{ id: "alerts", title: "Alerts" }] });
+}
+
+let observedPathname = "";
+
+function LocationProbe() {
+  observedPathname = useLocation().pathname;
+  return null;
 }

--- a/runtime/fleet-console/tests/operation-search-focus.test.tsx
+++ b/runtime/fleet-console/tests/operation-search-focus.test.tsx
@@ -100,5 +100,5 @@ describe("Operation search focus handoff", () => {
 });
 
 function SearchHarness() {
-  return createElement(OperationSearch, { state: useConsoleState() });
+  return createElement(OperationSearch, { state: useConsoleState(), railPanels: [] });
 }

--- a/runtime/fleet-console/tests/operation-search-focus.test.tsx
+++ b/runtime/fleet-console/tests/operation-search-focus.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OperationSearch } from "../core/client/src/components/operation-search.js";
+import { takeKeyboardShortcutsReturnFocus } from "../core/client/src/keyboard-shortcuts-return-focus.js";
 import { useConsoleState } from "../core/client/src/hooks/use-store.js";
 import { setState } from "../core/client/src/store.js";
 
@@ -110,6 +111,25 @@ describe("Operation search focus handoff", () => {
     act(() => commandOption!.click());
 
     expect(observedPathname).toBe("/operations");
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it("hands the palette opener to the keyboard shortcuts return-focus channel", () => {
+    // 팔레트 경유로 다이얼로그를 열면 App 캡처 시점의 activeElement가 제거 중인 팔레트 내부라,
+    // 팔레트를 연 시점의 요소를 채널로 전달해야 닫힘 시 그 요소로 복원된다.
+    const input = document.querySelector<HTMLInputElement>("#operation-search-input");
+    const setInputValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+    act(() => {
+      setInputValue.call(input, ">keyboard");
+      input!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const commandOption = document.querySelector<HTMLButtonElement>('[role="option"]');
+    expect(commandOption?.textContent).toContain("Open keyboard shortcuts");
+
+    act(() => commandOption!.click());
+
+    expect(takeKeyboardShortcutsReturnFocus()).toBe(previousFocus);
     expect(document.querySelector('[role="dialog"]')).toBeNull();
   });
 

--- a/runtime/fleet-console/tests/operation-search.test.ts
+++ b/runtime/fleet-console/tests/operation-search.test.ts
@@ -59,6 +59,8 @@ function makeState(operations: readonly OperationNode[], theaters: readonly Thea
     keyboardFocusRequest: null,
     pendingSideBarAddTheater: false,
     pendingSideBarTheaterLaunch: null,
+    launchMenuRequest: null,
+    keyboardShortcutsOpen: false,
     operationNotifications: {},
     notificationPreferences: { globalMute: false, dnd: false, mutedTheaterIds: {} },
     codexReader: null,

--- a/runtime/fleet-console/tests/palette-commands.test.ts
+++ b/runtime/fleet-console/tests/palette-commands.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPaletteCommands,
+  commandModeQuery,
+  filterPaletteCommands,
+  isCommandModeInput,
+} from "../core/client/src/palette-commands.js";
+import type { ConsoleState, TheaterInfo } from "../core/client/src/types.js";
+
+const THEATER_ALPHA: TheaterInfo = { id: "theater-alpha", label: "Alpha Harbor", createdAt: "2026-07-20T00:00:00.000Z", lastOpenedAt: "2026-07-20T00:00:00.000Z", hasWiki: false, activeAdmiralCount: 0 };
+const THEATER_BETA: TheaterInfo = { id: "theater-beta", label: "Beta Dock", createdAt: "2026-07-20T00:00:00.000Z", lastOpenedAt: "2026-07-20T00:00:00.000Z", hasWiki: false, activeAdmiralCount: 0 };
+
+function makeState(patch: Partial<ConsoleState> = {}): ConsoleState {
+  return {
+    connection: "connecting",
+    connectionError: null,
+    channel: "unknown",
+    activeTheme: "instrument",
+    version: "1.30.0",
+    updateAvailable: false,
+    latestVersion: null,
+    portMode: "dynamic",
+    requestedPort: null,
+    effectivePort: 0,
+    portHonored: true,
+    theaters: [THEATER_ALPHA, THEATER_BETA],
+    operations: [],
+    operationsHydrated: true,
+    groups: [],
+    activeTheaterId: "theater-alpha",
+    activeOperationId: null,
+    operationStatus: {},
+    addingTheater: false,
+    theaterError: null,
+    operationsViewActive: false,
+    operationSearchOpen: false,
+    whatsNewOpen: false,
+    releaseNotes: [],
+    releaseNotesLoading: false,
+    releaseNotesError: null,
+    releaseNotesSourceRef: null,
+    releaseNotesFetchedAt: null,
+    releaseNotesStale: false,
+    automaticWhatsNewVersion: null,
+    selectedReleaseNoteKey: null,
+    onboardingOpen: false,
+    bootstrapped: true,
+    pendingOperationFocus: null,
+    keyboardFocusRequest: null,
+    launchMenuRequest: null,
+    keyboardShortcutsOpen: false,
+    operationNotifications: {},
+    notificationPreferences: { globalMute: false, dnd: false, mutedTheaterIds: {} },
+    codexReader: null,
+    codexReaderExpanded: false,
+    ...patch,
+  };
+}
+
+const RAIL_PANELS = [
+  { id: "alerts", title: "Alerts" },
+  { id: "repository", title: "Repository" },
+];
+
+describe("palette command mode parsing", () => {
+  it("enters command mode only when the input starts with >", () => {
+    expect(isCommandModeInput(">")).toBe(true);
+    expect(isCommandModeInput(">theme")).toBe(true);
+    expect(isCommandModeInput("")).toBe(false);
+    expect(isCommandModeInput("bridge > watch")).toBe(false);
+  });
+
+  it("strips only the leading > from the command query", () => {
+    expect(commandModeQuery(">theme carbon")).toBe("theme carbon");
+    expect(commandModeQuery(">")).toBe("");
+    expect(commandModeQuery("> switch >")).toBe(" switch >");
+  });
+});
+
+describe("buildPaletteCommands", () => {
+  it("derives Theater, panel, toggle, theme, and navigation commands from state", () => {
+    const commands = buildPaletteCommands(makeState(), RAIL_PANELS);
+    expect(commands.map((command) => command.commandId)).toEqual([
+      "switch-theater:theater-alpha",
+      "switch-theater:theater-beta",
+      "new-operation",
+      "open-rail-panel:alerts",
+      "open-rail-panel:repository",
+      "toggle-rail",
+      "toggle-sidebar",
+      "switch-theme:instrument",
+      "switch-theme:maritime",
+      "switch-theme:carbon",
+      "open-settings",
+      "open-keyboard-shortcuts",
+    ]);
+    expect(commands.find((command) => command.commandId === "new-operation")?.label).toBe("New Operation in Alpha Harbor");
+    expect(commands.find((command) => command.commandId === "open-rail-panel:repository")?.label).toBe("Open panel: Repository");
+  });
+
+  it("marks the active Theater and active theme as current", () => {
+    const commands = buildPaletteCommands(makeState({ activeTheme: "carbon" }), []);
+    const currents = commands.filter((command) => command.current).map((command) => command.commandId);
+    expect(currents).toEqual(["switch-theater:theater-alpha", "switch-theme:carbon"]);
+  });
+
+  it("omits New Operation without an active Theater and What's new without release notes", () => {
+    const commands = buildPaletteCommands(makeState({ activeTheaterId: null }), []);
+    expect(commands.some((command) => command.commandId === "new-operation")).toBe(false);
+    expect(commands.some((command) => command.commandId === "whats-new")).toBe(false);
+  });
+
+  it("includes What's new when release notes are loaded", () => {
+    const commands = buildPaletteCommands(makeState({
+      releaseNotes: [{ version: "1.30.0", date: "2026-07-20", sections: [], localizationFallback: false }],
+    }), []);
+    expect(commands.some((command) => command.commandId === "whats-new")).toBe(true);
+  });
+});
+
+describe("filterPaletteCommands", () => {
+  it("matches case-insensitive AND tokens against the command label", () => {
+    const commands = buildPaletteCommands(makeState(), RAIL_PANELS);
+    expect(filterPaletteCommands(commands, "switch beta").map((command) => command.commandId)).toEqual(["switch-theater:theater-beta"]);
+    expect(filterPaletteCommands(commands, "THEME").map((command) => command.commandId)).toEqual([
+      "switch-theme:instrument",
+      "switch-theme:maritime",
+      "switch-theme:carbon",
+    ]);
+    expect(filterPaletteCommands(commands, "theme beta")).toEqual([]);
+    expect(filterPaletteCommands(commands, "")).toEqual(commands);
+    expect(filterPaletteCommands(commands, "   ")).toEqual(commands);
+  });
+});

--- a/runtime/fleet-console/tests/reduce.test.ts
+++ b/runtime/fleet-console/tests/reduce.test.ts
@@ -73,6 +73,8 @@ function makeConsoleSnap(patch: Partial<ConsoleState> = {}): ConsoleState {
     keyboardFocusRequest: null,
     pendingSideBarAddTheater: false,
     pendingSideBarTheaterLaunch: null,
+    launchMenuRequest: null,
+    keyboardShortcutsOpen: false,
     operationNotifications: {},
     notificationPreferences: { globalMute: false, dnd: false, mutedTheaterIds: {} },
     ...patch,


### PR DESCRIPTION
## Summary
- ⌘K 팔레트에 **커맨드 모드**를 추가합니다: 입력을 `>`로 시작하면 큐레이션된 콘솔 액션(Theater 전환·New Operation·rail 패널 열기·rail/사이드바 토글·테마 전환·Settings·단축키 안내·What's new)을 키보드로 필터·실행합니다. `>` 없는 기존 Operations 검색은 무변경입니다.
- `palette-commands.ts` 순수 모듈(모드 파싱·커맨드 도출·토큰 필터)과 discriminated-union 액션으로 구성되고, 실행은 기존 store 핸들러를 재사용합니다. "New Operation"은 `launchMenuRequest` store 요청(keyboardFocusRequest 패턴 미러)으로 사이드바의 ＋New launch 오버레이를 동일 앵커에 엽니다.
- rail/사이드바/패널 커맨드는 비-operations 경로에서 `/operations`로 선이동해 항상 가시 효과를 보장하고, collapse류는 command-band 토글로 포커스를 이관하며, 단축키 다이얼로그는 opener 포커스를 복원합니다(Help 메뉴 경로와 등가).

## Test Plan
- [x] 타깃 스위트 green: palette-commands 7 + operation-search/focus(.tsx) + instrument-design-contract 포함 27/27, `build` green (typecheck 선존 TS2882 10건 외 신규 0)
- [x] 격리 콘솔 헤디드 실측: 17커맨드 렌더·테마 전환+서버 영속·패널 오픈·launch 오버레이 앵커·`/settings`발 커맨드 navigate·검색 모드 무회귀·브라우저 오류 0
- [x] Changelog: `.changelog.d/pr-338.md` 추가 완료 (grouped 문법·이중언어 요약·`compile-changelog-fragments.mjs --check` 통과)
