### PR TITLE
feat(console): command band theater/operation switcher dropdowns

### DIFF
--- a/.changelog.d/pr-339.md
+++ b/.changelog.d/pr-339.md
@@ -1,0 +1,7 @@
+### fleet-console
+#### Added
+- [fleet-console] Switch the active Theater and Operation directly from the command band breadcrumb: each segment opens an anchored dropdown listing every Theater (with operation counts and Add Theater) or the active Theater's operations (with Rename and New Operation rows), with full keyboard navigation and viewport-aware positioning.
+  ko: command band 브레드크럼에서 활성 Theater와 Operation을 바로 전환합니다: 각 세그먼트가 전체 Theater 목록(Operation 수·Add Theater 포함) 또는 활성 Theater의 Operation 목록(Rename·New Operation 행 포함)을 담은 앵커드 드롭다운을 열며, 키보드 내비게이션과 viewport 인식 배치를 지원합니다.
+#### Fixed
+- [fleet-console] The command band breadcrumb no longer shows an operation from a different Theater after switching Theaters from the sidebar; it now offers a Select operation trigger instead.
+  ko: 사이드바에서 Theater를 전환한 뒤 command band 브레드크럼이 다른 Theater의 Operation을 표시하던 문제를 수정하고, 대신 Select operation 트리거를 제공합니다.

--- a/runtime/fleet-console/core/client/src/components/command-band-guards.ts
+++ b/runtime/fleet-console/core/client/src/components/command-band-guards.ts
@@ -1,3 +1,17 @@
+import type { OperationNode } from "../types.js";
+
 export function commandBandRenameCommitTarget(capturedOperationId: string | null, activeOperationId: string | null): string | null {
   return capturedOperationId !== null && capturedOperationId === activeOperationId ? capturedOperationId : null;
+}
+
+// Theater만 전환하면(setActiveTheater) activeOperationId가 남는다 — 브레드크럼은
+// 활성 Theater 소속 Operation만 신뢰한다(표시 가드, state는 건드리지 않는다).
+export function commandBandActiveOperation(
+  operations: readonly OperationNode[],
+  activeOperationId: string | null,
+  activeTheaterId: string | null,
+): OperationNode | null {
+  if (activeOperationId === null || activeTheaterId === null) return null;
+  const operation = operations.find((candidate) => candidate.id === activeOperationId) ?? null;
+  return operation !== null && operation.theaterId === activeTheaterId ? operation : null;
 }

--- a/runtime/fleet-console/core/client/src/components/command-band-guards.ts
+++ b/runtime/fleet-console/core/client/src/components/command-band-guards.ts
@@ -15,3 +15,23 @@ export function commandBandActiveOperation(
   const operation = operations.find((candidate) => candidate.id === activeOperationId) ?? null;
   return operation !== null && operation.theaterId === activeTheaterId ? operation : null;
 }
+
+// Tab 등으로 포커스가 스위처 래퍼(트리거+메뉴) 밖으로 나가면 메뉴를 닫는다.
+// relatedTarget null(창 블러·비포커서블 클릭)도 닫는다 — 바깥 pointerdown 경로와 멱등.
+export function commandBandSwitcherFocusLeft(wrapper: HTMLElement, relatedTarget: EventTarget | null): boolean {
+  return !(relatedTarget instanceof Node && wrapper.contains(relatedTarget));
+}
+
+// 포털 없는 밴드 내 absolute 메뉴의 left(래퍼 좌표계)를 viewport gutter 안으로 clamp한다.
+// 우측 초과를 먼저 안으로 끌어들이고, 좌측 하한(gutter)이 최종 우선한다.
+export function commandBandMenuClampedLeft(
+  desiredLeft: number,
+  wrapperViewportLeft: number,
+  menuWidth: number,
+  viewportWidth: number,
+  gutter = 12,
+): number {
+  const maxLeft = viewportWidth - gutter - menuWidth - wrapperViewportLeft;
+  const minLeft = gutter - wrapperViewportLeft;
+  return Math.max(minLeft, Math.min(desiredLeft, maxLeft));
+}

--- a/runtime/fleet-console/core/client/src/components/command-band-guards.ts
+++ b/runtime/fleet-console/core/client/src/components/command-band-guards.ts
@@ -1,7 +1,23 @@
-import type { OperationNode } from "../types.js";
+import { flattenGroupedOrder } from "../store.js";
+import type { OperationGroup, OperationNode } from "../types.js";
 
 export function commandBandRenameCommitTarget(capturedOperationId: string | null, activeOperationId: string | null): string | null {
   return capturedOperationId !== null && capturedOperationId === activeOperationId ? capturedOperationId : null;
+}
+
+// Operation 메뉴는 사이드바·Alt+←/→와 동일한 그룹 인식 순서를 미러한다. collapsedGroups는
+// 넘기지 않는다 — 스위처 메뉴는 접힌 그룹의 Operation도 도달 가능해야 한다(순서만 미러, 가시성 미러 아님).
+export function commandBandTheaterOperations(
+  operations: readonly OperationNode[],
+  groups: readonly OperationGroup[],
+  activeTheaterId: string | null,
+  operationOrder: readonly string[],
+): readonly OperationNode[] {
+  return flattenGroupedOrder(
+    operations.filter((operation) => operation.theaterId === activeTheaterId),
+    groups.filter((group) => group.theaterId === activeTheaterId),
+    operationOrder,
+  );
 }
 
 // Theater만 전환하면(setActiveTheater) activeOperationId가 남는다 — 브레드크럼은

--- a/runtime/fleet-console/core/client/src/components/command-band-switcher.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band-switcher.tsx
@@ -1,0 +1,185 @@
+import { Fragment, useEffect, type CSSProperties, type KeyboardEvent, type RefObject } from "react";
+
+import { theaterInitials } from "../sidebar/operations-side-bar.js";
+import type { OperationNode, TheaterInfo } from "../types.js";
+
+export type CommandBandSwitcherMenu = "theater" | "operation";
+
+interface CommandBandMenuEntry {
+  readonly key: string;
+  readonly role: "menuitemradio" | "menuitem";
+  readonly label: string;
+  readonly checked?: boolean;
+  readonly mark?: string;
+  readonly meta?: string | null;
+  readonly action?: boolean;
+  readonly disabled?: boolean;
+  readonly onSelect: () => void;
+}
+
+interface CommandBandMenuProps {
+  readonly menuLabel: string;
+  readonly sections: readonly (readonly CommandBandMenuEntry[])[];
+  readonly emptyNote?: string | null;
+  readonly style?: CSSProperties;
+  readonly containerRef: RefObject<HTMLDivElement | null>;
+}
+
+interface CommandBandTheaterMenuProps {
+  readonly theaters: readonly TheaterInfo[];
+  readonly operations: readonly OperationNode[];
+  readonly activeTheaterId: string | null;
+  readonly addingTheater: boolean;
+  readonly onSelectTheater: (theaterId: string) => void;
+  readonly onAddTheater: () => void;
+  readonly containerRef: RefObject<HTMLDivElement | null>;
+}
+
+interface CommandBandOperationMenuProps {
+  // 활성 Theater 소속 Operation만, 사이드바 표시 순서로 정렬해 전달한다.
+  readonly operations: readonly OperationNode[];
+  readonly activeOperationId: string | null;
+  readonly theaterLabel: string;
+  readonly onSelectOperation: (operationId: string) => void;
+  readonly onRenameOperation: (() => void) | null;
+  readonly onNewOperation: () => void;
+  readonly style?: CSSProperties;
+  readonly containerRef: RefObject<HTMLDivElement | null>;
+}
+
+export function CommandBandTheaterMenu({ theaters, operations, activeTheaterId, addingTheater, onSelectTheater, onAddTheater, containerRef }: CommandBandTheaterMenuProps) {
+  const sections: readonly (readonly CommandBandMenuEntry[])[] = [
+    theaters.map((theater) => {
+      const count = operations.filter((operation) => operation.theaterId === theater.id).length;
+      return {
+        key: theater.id,
+        role: "menuitemradio" as const,
+        label: theater.label,
+        checked: theater.id === activeTheaterId,
+        mark: theaterInitials(theater.label),
+        meta: `${count} ${count === 1 ? "op" : "ops"}`,
+        onSelect: () => onSelectTheater(theater.id),
+      };
+    }),
+    [{
+      key: "__add-theater__",
+      role: "menuitem" as const,
+      label: "Add Theater…",
+      action: true,
+      disabled: addingTheater,
+      onSelect: onAddTheater,
+    }],
+  ];
+  return <CommandBandMenu menuLabel="Switch Theater" sections={sections} containerRef={containerRef} />;
+}
+
+export function CommandBandOperationMenu({ operations, activeOperationId, theaterLabel, onSelectOperation, onRenameOperation, onNewOperation, style, containerRef }: CommandBandOperationMenuProps) {
+  const sections: readonly (readonly CommandBandMenuEntry[])[] = [
+    operations.map((operation) => ({
+      key: operation.id,
+      role: "menuitemradio" as const,
+      label: operation.title,
+      checked: operation.id === activeOperationId,
+      meta: operationCliLabel(operation),
+      onSelect: () => onSelectOperation(operation.id),
+    })),
+    [
+      ...(onRenameOperation !== null ? [{
+        key: "__rename-operation__",
+        role: "menuitem" as const,
+        label: "Rename current operation…",
+        onSelect: onRenameOperation,
+      }] : []),
+      {
+        key: "__new-operation__",
+        role: "menuitem" as const,
+        label: `New Operation in ${theaterLabel}…`,
+        action: true,
+        onSelect: onNewOperation,
+      },
+    ],
+  ];
+  return (
+    <CommandBandMenu
+      menuLabel="Switch operation"
+      sections={sections}
+      emptyNote={operations.length === 0 ? "No operations in this Theater" : null}
+      style={style}
+      containerRef={containerRef}
+    />
+  );
+}
+
+function CommandBandMenu({ menuLabel, sections, emptyNote, style, containerRef }: CommandBandMenuProps) {
+  const menuItems = () => Array.from(containerRef.current?.querySelectorAll<HTMLButtonElement>(".command-band-menu-item:not(:disabled)") ?? []);
+
+  useEffect(() => {
+    const items = menuItems();
+    (items.find((item) => item.getAttribute("aria-checked") === "true") ?? items[0])?.focus();
+    // 열림 시 1회 — 활성(체크) 행으로 초기 포커스.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "ArrowDown" && event.key !== "ArrowUp" && event.key !== "Home" && event.key !== "End") return;
+    const items = menuItems();
+    if (items.length === 0) return;
+    event.preventDefault();
+    const current = items.findIndex((item) => item === document.activeElement);
+    const next = event.key === "Home"
+      ? 0
+      : event.key === "End"
+        ? items.length - 1
+        : event.key === "ArrowDown"
+          ? (current + 1) % items.length
+          : current <= 0 ? items.length - 1 : current - 1;
+    items[next]?.focus();
+  };
+
+  const renderedSections = sections.filter((section) => section.length > 0);
+  return (
+    <div ref={containerRef} className="command-band-menu" role="menu" aria-label={menuLabel} style={style} onKeyDown={handleKeyDown}>
+      {emptyNote ? <p className="command-band-menu-empty">{emptyNote}</p> : null}
+      {renderedSections.map((section, sectionIndex) => (
+        <Fragment key={section[0]?.key ?? sectionIndex}>
+          {sectionIndex > 0 || emptyNote ? <div className="command-band-menu-divider" aria-hidden="true" /> : null}
+          {section.map((entry) => (
+            <button
+              key={entry.key}
+              type="button"
+              role={entry.role}
+              aria-checked={entry.role === "menuitemradio" ? entry.checked === true : undefined}
+              className={`command-band-menu-item${entry.checked ? " is-active" : ""}${entry.action ? " command-band-menu-action" : ""}`}
+              disabled={entry.disabled}
+              onClick={entry.onSelect}
+            >
+              <span className="command-band-menu-check" aria-hidden="true">{entry.checked ? <MenuCheckIcon /> : null}</span>
+              {entry.mark !== undefined ? <span className="command-band-theater-mark" aria-hidden="true">{entry.mark}</span> : null}
+              <span className="command-band-menu-label">{entry.label}</span>
+              {entry.meta ? <span className="command-band-menu-meta">{entry.meta}</span> : null}
+            </button>
+          ))}
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+
+export function CommandBandTriggerCaret() {
+  return (
+    <span className="command-band-trigger-caret" aria-hidden="true">
+      <svg viewBox="0 0 10 10"><path d="M2 3.5 5 6.5 8 3.5" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" /></svg>
+    </span>
+  );
+}
+
+function MenuCheckIcon() {
+  return <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3.5 8.5 6.5 11.5 12.5 4.5" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" /></svg>;
+}
+
+function operationCliLabel(operation: OperationNode): string | null {
+  const cliLabel = operation.payload.cliLabel;
+  if (typeof cliLabel === "string") return cliLabel;
+  const cliId = operation.payload.cliId;
+  return typeof cliId === "string" ? cliId : null;
+}

--- a/runtime/fleet-console/core/client/src/components/command-band-switcher.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band-switcher.tsx
@@ -32,6 +32,7 @@ interface CommandBandTheaterMenuProps {
   readonly addingTheater: boolean;
   readonly onSelectTheater: (theaterId: string) => void;
   readonly onAddTheater: () => void;
+  readonly style?: CSSProperties;
   readonly containerRef: RefObject<HTMLDivElement | null>;
 }
 
@@ -47,7 +48,7 @@ interface CommandBandOperationMenuProps {
   readonly containerRef: RefObject<HTMLDivElement | null>;
 }
 
-export function CommandBandTheaterMenu({ theaters, operations, activeTheaterId, addingTheater, onSelectTheater, onAddTheater, containerRef }: CommandBandTheaterMenuProps) {
+export function CommandBandTheaterMenu({ theaters, operations, activeTheaterId, addingTheater, onSelectTheater, onAddTheater, style, containerRef }: CommandBandTheaterMenuProps) {
   const sections: readonly (readonly CommandBandMenuEntry[])[] = [
     theaters.map((theater) => {
       const count = operations.filter((operation) => operation.theaterId === theater.id).length;
@@ -70,7 +71,7 @@ export function CommandBandTheaterMenu({ theaters, operations, activeTheaterId, 
       onSelect: onAddTheater,
     }],
   ];
-  return <CommandBandMenu menuLabel="Switch Theater" sections={sections} containerRef={containerRef} />;
+  return <CommandBandMenu menuLabel="Switch Theater" sections={sections} style={style} containerRef={containerRef} />;
 }
 
 export function CommandBandOperationMenu({ operations, activeOperationId, theaterLabel, onSelectOperation, onRenameOperation, onNewOperation, style, containerRef }: CommandBandOperationMenuProps) {

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProp
 
 import { fetchConsoleEnvironment, fetchOperations, renameOperation } from "../api.js";
 import { useCanvasState } from "../canvas/canvas-store.js";
-import { commandBandActiveOperation, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft } from "./command-band-guards.js";
+import { commandBandActiveOperation, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "./command-band-guards.js";
 import { CommandBandOperationMenu, CommandBandTheaterMenu, CommandBandTriggerCaret, type CommandBandSwitcherMenu } from "./command-band-switcher.js";
 import { FleetBrandHome } from "./side-bar-brand-foot.js";
 import { useConsoleState } from "../hooks/use-store.js";
@@ -10,7 +10,7 @@ import { toggleRailChrome, useRailChromeExpanded } from "../rail/rail-store.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
 import { setSideBarCollapsed, useSideBarState } from "../sidebar/operations-side-bar-store.js";
-import { focusOperation, hydrateOperations, requestSideBarAddTheater, requestSideBarTheaterLaunch, setActiveTheater, sortOperationsByOrder, toggleOperationSearch } from "../store.js";
+import { focusOperation, hydrateOperations, requestSideBarAddTheater, requestSideBarTheaterLaunch, setActiveTheater, toggleOperationSearch } from "../store.js";
 import type { ConsoleEnvironmentDiagnostics } from "../types.js";
 import { useInlineRename } from "../use-inline-rename.js";
 import { useFullscreenCommandBand } from "./use-fullscreen-command-band.js";
@@ -249,10 +249,7 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
     requestSideBarTheaterLaunch(activeTheater.id);
   };
 
-  const theaterOperations = sortOperationsByOrder(
-    state.operations.filter((operation) => operation.theaterId === state.activeTheaterId),
-    canvas.operationOrder,
-  );
+  const theaterOperations = commandBandTheaterOperations(state.operations, state.groups, state.activeTheaterId, canvas.operationOrder);
 
   const hideAfterInteractionLeaves = () => {
     if (canAutoHide()) fullscreen.hideAfterLeave();

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProp
 
 import { fetchConsoleEnvironment, fetchOperations, renameOperation } from "../api.js";
 import { useCanvasState } from "../canvas/canvas-store.js";
-import { commandBandActiveOperation, commandBandRenameCommitTarget } from "./command-band-guards.js";
+import { commandBandActiveOperation, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft } from "./command-band-guards.js";
 import { CommandBandOperationMenu, CommandBandTheaterMenu, CommandBandTriggerCaret, type CommandBandSwitcherMenu } from "./command-band-switcher.js";
 import { FleetBrandHome } from "./side-bar-brand-foot.js";
 import { useConsoleState } from "../hooks/use-store.js";
@@ -49,9 +49,10 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
   const renameTargetOperationIdRef = useRef<string | null>(null);
   const theaterTriggerRef = useRef<HTMLButtonElement>(null);
   const operationTriggerRef = useRef<HTMLButtonElement>(null);
+  const switcherRef = useRef<HTMLDivElement>(null);
   const switcherMenuRef = useRef<HTMLDivElement>(null);
   const [switcherMenu, setSwitcherMenu] = useState<CommandBandSwitcherMenu | null>(null);
-  const [operationMenuLeft, setOperationMenuLeft] = useState(0);
+  const [switcherMenuLeft, setSwitcherMenuLeft] = useState(0);
   const [environmentOpen, setEnvironmentOpen] = useState(false);
   const [environment, setEnvironment] = useState<ConsoleEnvironmentDiagnostics | null>(null);
   const [environmentError, setEnvironmentError] = useState<string | null>(null);
@@ -78,10 +79,17 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
     return !focusWithin && !pointerWithinRef.current.edge && !pointerWithinRef.current.band;
   }, []);
   const fullscreen = useFullscreenCommandBand(canAutoHide);
+  // 브레드크럼 표시 대상(P0 가드 결과) 기준으로 판정한다 — activeOperationId가 그대로여도
+  // Theater 전환으로 Operation 세그먼트가 숨으면 숨은 rename이 살아남아 복귀 시 스테일 draft가 부활한다.
+  const displayedOperationId = activeOperation?.id ?? null;
+  // 커밋 판정은 ref로 읽는다 — Theater 전환 렌더가 input을 언마운트하며 동기로 blur 커밋을
+  // 쏘는데, 이때 클로저의 이전 렌더 state는 여전히 일치해 스테일 draft가 커밋된다(실브라우저 재현).
+  const displayedOperationIdRef = useRef<string | null>(null);
+  displayedOperationIdRef.current = displayedOperationId;
   const rename = useInlineRename({
     currentTitle: activeOperation?.title ?? "",
     onCommit: (title) => {
-      const operationId = commandBandRenameCommitTarget(renameTargetOperationIdRef.current, state.activeOperationId);
+      const operationId = commandBandRenameCommitTarget(renameTargetOperationIdRef.current, displayedOperationIdRef.current);
       renameTargetOperationIdRef.current = null;
       if (!operationId) return;
       void renameOperation(operationId, title).then(() => fetchOperations(null)).then(hydrateOperations).catch(() => {});
@@ -89,11 +97,11 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
   });
 
   useEffect(() => {
-    if (!rename.renaming || commandBandRenameCommitTarget(renameTargetOperationIdRef.current, state.activeOperationId)) return;
-    // 활성 패널이 바뀌면 이전 초안을 버려 다른 Operation으로 이름이 넘어가지 않게 한다.
+    if (!rename.renaming || commandBandRenameCommitTarget(renameTargetOperationIdRef.current, displayedOperationId)) return;
+    // 표시 대상이 어긋나면(패널 전환·Theater 전환 포함) 이전 초안을 버려 이름이 넘어가지 않게 한다.
     renameTargetOperationIdRef.current = null;
     rename.cancel();
-  }, [rename, state.activeOperationId]);
+  }, [rename, displayedOperationId]);
 
   useEffect(() => {
     if (!environmentOpen) return;
@@ -162,10 +170,20 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
     setSwitcherMenu(null);
   }, [state.activeTheaterId, state.activeOperationId]);
 
-  // Operation 메뉴는 자기 트리거 아래 정렬 — 스위처 래퍼(offsetParent) 기준 좌표를 열림 시점에 실측한다.
+  // Operation 메뉴는 자기 트리거 아래 정렬(래퍼 offsetLeft), Theater 메뉴는 좌단 기준 —
+  // 어느 쪽이든 좁은 viewport에서 우측이 화면을 넘지 않도록 실측 clamp하고 resize 시 재측정한다.
   useLayoutEffect(() => {
-    if (switcherMenu !== "operation") return;
-    setOperationMenuLeft(operationTriggerRef.current?.offsetLeft ?? 0);
+    if (switcherMenu === null) return;
+    const measure = () => {
+      const wrapper = switcherRef.current;
+      const menu = switcherMenuRef.current;
+      if (!wrapper || !menu) return;
+      const desiredLeft = switcherMenu === "operation" ? operationTriggerRef.current?.offsetLeft ?? 0 : 0;
+      setSwitcherMenuLeft(commandBandMenuClampedLeft(desiredLeft, wrapper.getBoundingClientRect().left, menu.getBoundingClientRect().width, window.innerWidth));
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
   }, [switcherMenu]);
 
   useEffect(() => {
@@ -197,6 +215,13 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
     setEnvironmentOpen(false);
     discardEnvironmentState();
     setSwitcherMenu((open) => (open === menu ? null : menu));
+  };
+
+  // Tab 등으로 포커스가 스위처 밖으로 나가면 메뉴를 닫는다 — 포커스는 자연 Tab 대상에 남기고
+  // 트리거 복귀는 Escape 전용으로 유지한다.
+  const handleSwitcherFocusOut = (event: FocusEvent<HTMLDivElement>) => {
+    if (switcherMenu === null || !commandBandSwitcherFocusLeft(event.currentTarget, event.relatedTarget)) return;
+    setSwitcherMenu(null);
   };
 
   const selectTheaterFromMenu = (theaterId: string) => {
@@ -303,7 +328,7 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
         </button>
       </div>
       <div className="command-band-center">
-        {operationsViewVisible && activeTheater ? <div className="command-band-switcher">
+        {operationsViewVisible && activeTheater ? <div ref={switcherRef} className="command-band-switcher" onBlur={handleSwitcherFocusOut}>
           <div className="command-band-theater-cluster" aria-label={`Active Theater: ${activeTheater.label}`}>
             <button
               ref={theaterTriggerRef}
@@ -354,6 +379,7 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
             addingTheater={state.addingTheater}
             onSelectTheater={selectTheaterFromMenu}
             onAddTheater={addTheaterFromMenu}
+            style={{ left: switcherMenuLeft }}
             containerRef={switcherMenuRef}
           /> : null}
           {switcherMenu === "operation" ? <CommandBandOperationMenu
@@ -363,7 +389,7 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
             onSelectOperation={selectOperationFromMenu}
             onRenameOperation={activeOperation ? beginRename : null}
             onNewOperation={launchOperationFromMenu}
-            style={{ left: operationMenuLeft }}
+            style={{ left: switcherMenuLeft }}
             containerRef={switcherMenuRef}
           /> : null}
         </div> : null}

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -1,14 +1,16 @@
-import { useCallback, useEffect, useRef, useState, type CSSProperties, type FocusEvent } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type FocusEvent } from "react";
 
 import { fetchConsoleEnvironment, fetchOperations, renameOperation } from "../api.js";
-import { commandBandRenameCommitTarget } from "./command-band-guards.js";
+import { useCanvasState } from "../canvas/canvas-store.js";
+import { commandBandActiveOperation, commandBandRenameCommitTarget } from "./command-band-guards.js";
+import { CommandBandOperationMenu, CommandBandTheaterMenu, CommandBandTriggerCaret, type CommandBandSwitcherMenu } from "./command-band-switcher.js";
 import { FleetBrandHome } from "./side-bar-brand-foot.js";
 import { useConsoleState } from "../hooks/use-store.js";
 import { toggleRailChrome, useRailChromeExpanded } from "../rail/rail-store.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
 import { setSideBarCollapsed, useSideBarState } from "../sidebar/operations-side-bar-store.js";
-import { hydrateOperations, toggleOperationSearch } from "../store.js";
+import { focusOperation, hydrateOperations, requestSideBarAddTheater, requestSideBarTheaterLaunch, setActiveTheater, sortOperationsByOrder, toggleOperationSearch } from "../store.js";
 import type { ConsoleEnvironmentDiagnostics } from "../types.js";
 import { useInlineRename } from "../use-inline-rename.js";
 import { useFullscreenCommandBand } from "./use-fullscreen-command-band.js";
@@ -31,8 +33,9 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
   const modLabel = resolveModLabel();
   const sideBarShortcut = `${modLabel}${modLabel === "⌘" ? "" : "+"}B`;
   const railShortcut = `${modLabel}${modLabel === "⌘" ? "⌥" : "+Alt+"}B`;
+  const canvas = useCanvasState();
   const activeTheater = state.theaters.find((theater) => theater.id === state.activeTheaterId) ?? null;
-  const activeOperation = state.operations.find((operation) => operation.id === state.activeOperationId) ?? null;
+  const activeOperation = commandBandActiveOperation(state.operations, state.activeOperationId, state.activeTheaterId);
   const activePlugin = activeOperation ? registry.plugins.find((plugin) => plugin.id === activeOperation.pluginId) : null;
   const activeCliId = typeof activeOperation?.payload.cliId === "string" ? activeOperation.payload.cliId : null;
   const activeCliLabel = typeof activeOperation?.payload.cliLabel === "string" ? activeOperation.payload.cliLabel : activeCliId;
@@ -44,6 +47,11 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
   const edgeRevealRef = useRef<HTMLButtonElement>(null);
   const pointerWithinRef = useRef({ edge: false, band: false });
   const renameTargetOperationIdRef = useRef<string | null>(null);
+  const theaterTriggerRef = useRef<HTMLButtonElement>(null);
+  const operationTriggerRef = useRef<HTMLButtonElement>(null);
+  const switcherMenuRef = useRef<HTMLDivElement>(null);
+  const [switcherMenu, setSwitcherMenu] = useState<CommandBandSwitcherMenu | null>(null);
+  const [operationMenuLeft, setOperationMenuLeft] = useState(0);
   const [environmentOpen, setEnvironmentOpen] = useState(false);
   const [environment, setEnvironment] = useState<ConsoleEnvironmentDiagnostics | null>(null);
   const [environmentError, setEnvironmentError] = useState<string | null>(null);
@@ -128,6 +136,39 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
   }, [environmentOpen]);
 
   useEffect(() => {
+    if (switcherMenu === null) return;
+    const triggerRef = switcherMenu === "theater" ? theaterTriggerRef : operationTriggerRef;
+    const closeOnPointer = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node) || triggerRef.current?.contains(target) || switcherMenuRef.current?.contains(target)) return;
+      setSwitcherMenu(null);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setSwitcherMenu(null);
+      triggerRef.current?.focus();
+    };
+    document.addEventListener("pointerdown", closeOnPointer);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closeOnPointer);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [switcherMenu]);
+
+  // 메뉴 열림 중 사이드바 등 외부 경로로 활성 Theater/Operation이 바뀌면 메뉴를 닫는다.
+  // (메뉴 내 선택은 상태 변경 전에 동기적으로 닫으므로 여기서는 no-op이다.)
+  useEffect(() => {
+    setSwitcherMenu(null);
+  }, [state.activeTheaterId, state.activeOperationId]);
+
+  // Operation 메뉴는 자기 트리거 아래 정렬 — 스위처 래퍼(offsetParent) 기준 좌표를 열림 시점에 실측한다.
+  useLayoutEffect(() => {
+    if (switcherMenu !== "operation") return;
+    setOperationMenuLeft(operationTriggerRef.current?.offsetLeft ?? 0);
+  }, [switcherMenu]);
+
+  useEffect(() => {
     if (state.channel === "local") return;
     setEnvironmentOpen(false);
     setEnvironment(null);
@@ -147,9 +188,46 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
 
   const beginRename = () => {
     if (!activeOperation) return;
+    setSwitcherMenu(null);
     renameTargetOperationIdRef.current = activeOperation.id;
     rename.begin();
   };
+
+  const toggleSwitcherMenu = (menu: CommandBandSwitcherMenu) => {
+    setEnvironmentOpen(false);
+    discardEnvironmentState();
+    setSwitcherMenu((open) => (open === menu ? null : menu));
+  };
+
+  const selectTheaterFromMenu = (theaterId: string) => {
+    setSwitcherMenu(null);
+    theaterTriggerRef.current?.focus();
+    if (theaterId !== state.activeTheaterId) setActiveTheater(theaterId);
+  };
+
+  const selectOperationFromMenu = (operationId: string) => {
+    setSwitcherMenu(null);
+    operationTriggerRef.current?.focus();
+    focusOperation(operationId);
+  };
+
+  const addTheaterFromMenu = () => {
+    setSwitcherMenu(null);
+    theaterTriggerRef.current?.focus();
+    requestSideBarAddTheater();
+  };
+
+  const launchOperationFromMenu = () => {
+    if (!activeTheater) return;
+    setSwitcherMenu(null);
+    operationTriggerRef.current?.focus();
+    requestSideBarTheaterLaunch(activeTheater.id);
+  };
+
+  const theaterOperations = sortOperationsByOrder(
+    state.operations.filter((operation) => operation.theaterId === state.activeTheaterId),
+    canvas.operationOrder,
+  );
 
   const hideAfterInteractionLeaves = () => {
     if (canAutoHide()) fullscreen.hideAfterLeave();
@@ -211,7 +289,7 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
       <div className={`command-band-left${operationsViewVisible && sideBar.collapsed ? " is-collapsed" : ""}`}>
         <FleetBrandHome className="command-band-brand" />
         {state.channel === "local" ? <div className="command-band-environment">
-          <button ref={environmentTriggerRef} type="button" className="command-band-local-chip" aria-haspopup="dialog" aria-expanded={environmentOpen} onClick={() => { discardEnvironmentState(); setEnvironmentOpen((open) => !open); }}>
+          <button ref={environmentTriggerRef} type="button" className="command-band-local-chip" aria-haspopup="dialog" aria-expanded={environmentOpen} onClick={() => { setSwitcherMenu(null); discardEnvironmentState(); setEnvironmentOpen((open) => !open); }}>
           <span className="command-band-local-dot" aria-hidden="true" />
           <span className="command-band-local-chip-label">{desktopShell ? desktopChipLabel : "Local"}</span>
           </button>
@@ -225,13 +303,69 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
         </button>
       </div>
       <div className="command-band-center">
-        {operationsViewVisible && activeTheater ? <div className="command-band-theater-cluster" aria-label={`Active Theater: ${activeTheater.label}`}>
-          <span className="command-band-theater-segment"><span className="command-band-theater-mark">{theaterInitials(activeTheater.label)}</span>{activeTheater.label}</span>
-          {activeOperation ? <>
+        {operationsViewVisible && activeTheater ? <div className="command-band-switcher">
+          <div className="command-band-theater-cluster" aria-label={`Active Theater: ${activeTheater.label}`}>
+            <button
+              ref={theaterTriggerRef}
+              type="button"
+              className={`command-band-theater-segment command-band-segment-trigger${switcherMenu === "theater" ? " is-open" : ""}`}
+              aria-haspopup="menu"
+              aria-expanded={switcherMenu === "theater"}
+              title="Switch Theater"
+              onClick={() => toggleSwitcherMenu("theater")}
+            >
+              <span className="command-band-theater-mark">{theaterInitials(activeTheater.label)}</span>
+              <span className="command-band-segment-label">{activeTheater.label}</span>
+              <CommandBandTriggerCaret />
+            </button>
             <span className="command-band-theater-separator" aria-hidden="true">›</span>
-            {rename.renaming ? <input ref={rename.inputRef} className="command-band-rename-input" value={rename.draftTitle} aria-label={`${activeOperation.title} 이름 변경`} onChange={(event) => rename.setDraftTitle(event.target.value)} onKeyDown={rename.handleKeyDown} onBlur={rename.handleBlur} /> : <button type="button" className="command-band-operation-name" onDoubleClick={beginRename} title="Double-click to rename">{activeOperation.title}</button>}
-            {activeCliLabel ? <span className="command-band-operation-attribute" title={activeKind?.title ?? activeCliLabel}>{activeOperationIcon ? <span className="command-band-operation-kind" aria-hidden="true">{activeOperationIcon}</span> : null}{activeCliLabel}</span> : null}
-          </> : null}
+            {activeOperation ? <>
+              {rename.renaming ? <input ref={rename.inputRef} className="command-band-rename-input" value={rename.draftTitle} aria-label={`${activeOperation.title} 이름 변경`} onChange={(event) => rename.setDraftTitle(event.target.value)} onKeyDown={rename.handleKeyDown} onBlur={rename.handleBlur} /> : <button
+                ref={operationTriggerRef}
+                type="button"
+                className={`command-band-operation-name command-band-segment-trigger${switcherMenu === "operation" ? " is-open" : ""}`}
+                aria-haspopup="menu"
+                aria-expanded={switcherMenu === "operation"}
+                title="Switch operation — double-click to rename"
+                onClick={() => toggleSwitcherMenu("operation")}
+                onDoubleClick={beginRename}
+              >
+                <span className="command-band-segment-label">{activeOperation.title}</span>
+                <CommandBandTriggerCaret />
+              </button>}
+              {activeCliLabel ? <span className="command-band-operation-attribute" title={activeKind?.title ?? activeCliLabel}>{activeOperationIcon ? <span className="command-band-operation-kind" aria-hidden="true">{activeOperationIcon}</span> : null}{activeCliLabel}</span> : null}
+            </> : <button
+              ref={operationTriggerRef}
+              type="button"
+              className={`command-band-operation-placeholder command-band-segment-trigger${switcherMenu === "operation" ? " is-open" : ""}`}
+              aria-haspopup="menu"
+              aria-expanded={switcherMenu === "operation"}
+              title="Select operation"
+              onClick={() => toggleSwitcherMenu("operation")}
+            >
+              <span className="command-band-segment-label">Select operation…</span>
+              <CommandBandTriggerCaret />
+            </button>}
+          </div>
+          {switcherMenu === "theater" ? <CommandBandTheaterMenu
+            theaters={state.theaters}
+            operations={state.operations}
+            activeTheaterId={state.activeTheaterId}
+            addingTheater={state.addingTheater}
+            onSelectTheater={selectTheaterFromMenu}
+            onAddTheater={addTheaterFromMenu}
+            containerRef={switcherMenuRef}
+          /> : null}
+          {switcherMenu === "operation" ? <CommandBandOperationMenu
+            operations={theaterOperations}
+            activeOperationId={activeOperation?.id ?? null}
+            theaterLabel={activeTheater.label}
+            onSelectOperation={selectOperationFromMenu}
+            onRenameOperation={activeOperation ? beginRename : null}
+            onNewOperation={launchOperationFromMenu}
+            style={{ left: operationMenuLeft }}
+            containerRef={switcherMenuRef}
+          /> : null}
         </div> : null}
       </div>
       <div className="command-band-right">

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -12,7 +12,7 @@ import { useConsoleState } from "../hooks/use-store.js";
 import { GroupContextMenu } from "../canvas/group-context-menu.js";
 import { operationAccentFromNode, resolveAccentColor } from "../canvas/operation-accent.js";
 import { getTheaterCanvasSnapshot, selectFormationLayout, setOperationOrder, toggleGroupCollapsed, toggleTheaterGroupCollapsed, useCanvasState, useCollapsedGroups, useFormationLayout, useFormationView } from "../canvas/canvas-store.js";
-import { sortOperationsByOrder } from "../store.js";
+import { consumeSideBarAddTheater, consumeSideBarTheaterLaunch, sortOperationsByOrder } from "../store.js";
 import { SideBarBrandFoot } from "../components/side-bar-brand-foot.js";
 import { applyVisibleReorder, groupDropIndexFromPoint, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderGroupIds, reorderTheaterIds, reorderWithinSegment, theaterDropIndexFromPoint, type DropSectionInfo } from "./operations-side-bar-hit-test.js";
 import { OperationsSideBarChip, type SideBarEntry } from "./operations-side-bar-chip.js";
@@ -220,7 +220,7 @@ export function OperationsSideBar({
   const [sideBarResizing, setSideBarResizing] = useState(false);
   const collapsedGroups = useCollapsedGroups();
   const collapsedTheaters = useCollapsedTheaters();
-  const { operationStatus } = useConsoleState();
+  const { operationStatus, pendingSideBarAddTheater, pendingSideBarTheaterLaunch } = useConsoleState();
 
   useLayoutEffect(() => {
     if (!previousCollapsedRef.current && collapsed) focusCommandBandToggleWhenPanelContainsActiveElement(rootRef.current, ".command-band-sidebar-toggle");
@@ -536,16 +536,61 @@ export function OperationsSideBar({
     returnFocus?.focus();
   }, [activeContextMenu]);
 
-  const openTheaterLaunchMenu = (event: MouseEvent<HTMLButtonElement>, theaterId: string) => {
-    event.stopPropagation();
+  const openTheaterLaunchMenuAt = (anchor: DOMRect, theaterId: string) => {
     if (theaterId !== activeTheaterId) onSelectTheater(theaterId);
     setActiveContextMenu(null);
-    const rect = event.currentTarget.getBoundingClientRect();
     setNewMenu({
-      anchor: { x: rect.right + 8, y: rect.top },
+      anchor: { x: anchor.right + 8, y: anchor.top },
       viewportBounds: { width: window.innerWidth, height: window.innerHeight },
     });
   };
+
+  const openTheaterLaunchMenu = (event: MouseEvent<HTMLButtonElement>, theaterId: string) => {
+    event.stopPropagation();
+    openTheaterLaunchMenuAt(event.currentTarget.getBoundingClientRect(), theaterId);
+  };
+
+  // 커맨드 밴드 "Add Theater…" 요청 소비 — 접힘을 풀고 Theater 브라우저를 연다.
+  useEffect(() => {
+    if (!pendingSideBarAddTheater) return;
+    consumeSideBarAddTheater();
+    if (collapsed) setSideBarCollapsed(false);
+    openTheaterBrowser();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingSideBarAddTheater]);
+
+  // 커맨드 밴드 "New Operation in X…" 요청 소비 — 해당 Theater의 New Operation 버튼을 앵커로 launch 메뉴를 연다.
+  useEffect(() => {
+    const theaterId = pendingSideBarTheaterLaunch;
+    if (theaterId === null) return;
+    if (collapsed) {
+      // 신호는 유지한다 — 펼침 재렌더 후 이 effect가 다시 돌며 앵커를 실측한다.
+      setSideBarCollapsed(false);
+      return;
+    }
+    if (!theaters.some((theater) => theater.id === theaterId)) {
+      consumeSideBarTheaterLaunch();
+      return;
+    }
+    // consume은 실측 시점에 한다 — 여기서 먼저 소비하면 deps 변경 cleanup이 아래 타이머를 즉시 취소한다.
+    const openAtLaunchButton = () => {
+      consumeSideBarTheaterLaunch();
+      const section = Array.from(rootRef.current?.querySelectorAll<HTMLElement>("[data-theater-id]") ?? [])
+        .find((candidate) => candidate.dataset.theaterId === theaterId);
+      const button = section?.querySelector<HTMLButtonElement>(".side-bar-theater-launch-btn");
+      if (!button) return;
+      openTheaterLaunchMenuAt(button.getBoundingClientRect(), theaterId);
+    };
+    // 접힘 해제 직후에는 width 200ms 전환이 진행 중이라 즉시 실측하면 앵커가 왼쪽으로 틀어진다 — 전환 종료 후 실측.
+    const settled = rootRef.current !== null && Math.abs(rootRef.current.getBoundingClientRect().width - width) <= 1;
+    if (settled) {
+      openAtLaunchButton();
+      return;
+    }
+    const timer = window.setTimeout(openAtLaunchButton, 220);
+    return () => window.clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingSideBarTheaterLaunch, collapsed]);
 
   const toggleTheaterSectionCollapsed = (theaterId: string) => {
     setTheaterCollapsed(theaterId, !collapsedTheaters.includes(theaterId));
@@ -1013,7 +1058,7 @@ function TheaterSectionHeader({
           </button>
           <button
             type="button"
-            className="side-bar-theater-row-btn"
+            className="side-bar-theater-row-btn side-bar-theater-launch-btn"
             aria-label={`New Operation in ${theater.label}`}
             title={`New Operation in ${theater.label}`}
             onClick={(event) => onOpenLaunch(event, theater.id)}

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -76,6 +76,8 @@ let state: ConsoleState = {
   bootstrapped: false,
   pendingOperationFocus: null,
   keyboardFocusRequest: null,
+  pendingSideBarAddTheater: false,
+  pendingSideBarTheaterLaunch: null,
   operationNotifications: {},
   notificationPreferences: readStoredNotificationPreferences(),
   codexReader: null,
@@ -308,6 +310,26 @@ export function focusOperation(operationId: string): void {
 export function consumeOperationFocus(): void {
   if (state.pendingOperationFocus === null) return;
   setState({ pendingOperationFocus: null });
+}
+
+// 커맨드 밴드 → 사이드바 단방향 요청 신호 — 사이드바가 effect로 소비(consume)한다.
+// pendingOperationFocus/consumeOperationFocus와 같은 request/consume 계약.
+export function requestSideBarAddTheater(): void {
+  setState({ pendingSideBarAddTheater: true });
+}
+
+export function consumeSideBarAddTheater(): void {
+  if (!state.pendingSideBarAddTheater) return;
+  setState({ pendingSideBarAddTheater: false });
+}
+
+export function requestSideBarTheaterLaunch(theaterId: string): void {
+  setState({ pendingSideBarTheaterLaunch: theaterId });
+}
+
+export function consumeSideBarTheaterLaunch(): void {
+  if (state.pendingSideBarTheaterLaunch === null) return;
+  setState({ pendingSideBarTheaterLaunch: null });
 }
 
 export function requestOperationKeyboardFocus(operationId: string): void {

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -339,6 +339,164 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 .command-band-operation-kind { display: flex; align-items: center; line-height: 0; }
 .command-band-operation-kind svg { display: block; width: 13px; height: 13px; }
 
+/* ===== Command Band 세그먼트 드롭다운 전환기 — 메뉴 문법은 components.css .theater-menu 계열의 밴드 스코프 미러 ===== */
+.command-band-switcher {
+  position: relative;
+  display: flex;
+  min-width: 0;
+}
+
+.command-band-segment-trigger {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  padding: 2px 6px;
+  border-radius: var(--radius-xs);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-spring), color var(--duration-fast) var(--ease-spring);
+}
+
+.command-band-segment-trigger:hover,
+.command-band-segment-trigger:focus-visible,
+.command-band-segment-trigger.is-open {
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  outline: none;
+}
+
+.command-band-segment-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.command-band-trigger-caret {
+  display: grid;
+  place-items: center;
+  flex: none;
+  color: var(--ink-fog);
+  opacity: 0;
+  transition: opacity var(--duration-fast) var(--ease-spring);
+}
+
+.command-band-trigger-caret svg { display: block; width: 10px; height: 10px; }
+
+.command-band-segment-trigger:hover .command-band-trigger-caret,
+.command-band-segment-trigger:focus-visible .command-band-trigger-caret,
+.command-band-segment-trigger.is-open .command-band-trigger-caret {
+  opacity: 0.75;
+}
+
+.command-band-operation-placeholder {
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.command-band-menu {
+  position: absolute;
+  z-index: 45;
+  top: calc(100% + var(--space-2));
+  left: 0;
+  min-width: 236px;
+  max-width: min(340px, calc(100vw - 24px));
+  max-height: min(60vh, 420px);
+  overflow-y: auto;
+  padding: var(--space-2);
+  border: 1px solid var(--surface-rim-strong);
+  border-radius: var(--radius-lg);
+  background: color-mix(in oklch, var(--ink-deep) 60%, var(--surface-pillar));
+  box-shadow: var(--shadow-floating);
+}
+
+.command-band-menu-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2);
+  border-radius: var(--radius-sm);
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-align: left;
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring);
+}
+
+.command-band-menu-item:hover:not(:disabled),
+.command-band-menu-item:focus-visible {
+  color: var(--ink-pearl);
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  outline: none;
+}
+
+.command-band-menu-item.is-active {
+  color: var(--brass-bright);
+}
+
+.command-band-menu-action {
+  color: var(--brass-bright);
+}
+
+.command-band-menu-action:disabled {
+  color: color-mix(in oklch, var(--brass-bright) 45%, transparent);
+  background: transparent;
+  cursor: wait;
+}
+
+.command-band-menu-check {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 14px;
+  height: 14px;
+  color: var(--brass);
+}
+
+.command-band-menu-check svg {
+  display: block;
+  width: 13px;
+  height: 13px;
+}
+
+.command-band-menu-item .command-band-theater-mark { flex: none; }
+
+.command-band-menu-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.command-band-menu-meta {
+  margin-left: auto;
+  padding-left: var(--space-2);
+  flex: none;
+  color: color-mix(in oklch, var(--ink-fog) 70%, transparent);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.command-band-menu-divider {
+  height: 1px;
+  margin: var(--space-2) var(--space-1);
+  background: var(--surface-rim);
+}
+
+.command-band-menu-empty {
+  margin: 0;
+  padding: var(--space-2);
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+}
+
 /* window-policy.ts와 합의한 44px 밴드/76px 신호등 인셋 — 변경 시 데스크톱 셸과 동기한다. */
 html[data-desktop-shell="true"] .command-band {
   -webkit-app-region: drag;

--- a/runtime/fleet-console/core/client/src/types.ts
+++ b/runtime/fleet-console/core/client/src/types.ts
@@ -203,6 +203,8 @@ export interface ConsoleState {
   readonly bootstrapped: boolean;
   readonly pendingOperationFocus: string | null;
   readonly keyboardFocusRequest: { readonly operationId: string; readonly requestId: number } | null;
+  readonly pendingSideBarAddTheater: boolean;
+  readonly pendingSideBarTheaterLaunch: string | null;
   readonly operationNotifications: Readonly<Record<string, OperationNotification>>;
   readonly notificationPreferences: NotificationPreferences;
   readonly codexReader: CodexReaderRequest | null;

--- a/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
+++ b/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
@@ -414,6 +414,8 @@ const CANVAS_STATE: ConsoleState = {
   bootstrapped: true,
   pendingOperationFocus: null,
   keyboardFocusRequest: null,
+  pendingSideBarAddTheater: false,
+  pendingSideBarTheaterLaunch: null,
   operationNotifications: {},
   notificationPreferences: { globalMute: false, dnd: false, mutedTheaterIds: {} },
   codexReader: null,

--- a/runtime/fleet-console/tests/command-band-switcher.test.tsx
+++ b/runtime/fleet-console/tests/command-band-switcher.test.tsx
@@ -1,0 +1,261 @@
+// @vitest-environment jsdom
+
+import { act, createElement, createRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CommandBandOperationMenu, CommandBandTheaterMenu } from "../core/client/src/components/command-band-switcher.js";
+import { OperationsSideBar } from "../core/client/src/sidebar/operations-side-bar.js";
+import { setSideBarCollapsed } from "../core/client/src/sidebar/operations-side-bar-store.js";
+import {
+  consumeSideBarAddTheater,
+  consumeSideBarTheaterLaunch,
+  getState,
+  requestSideBarAddTheater,
+  requestSideBarTheaterLaunch,
+} from "../core/client/src/store.js";
+import type { OperationNode, TheaterInfo } from "../core/client/src/types.js";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  window.localStorage.clear();
+  setSideBarCollapsed(false);
+  consumeSideBarAddTheater();
+  consumeSideBarTheaterLaunch();
+  // DirectoryBrowserModal은 열리는 즉시 폴더 목록을 fetch한다 — 테스트에서는 pending 상태로 고정한다.
+  vi.stubGlobal("fetch", vi.fn(() => new Promise(() => {})));
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  vi.unstubAllGlobals();
+});
+
+describe("side bar request signals", () => {
+  it("stores and consumes the Add Theater request", () => {
+    expect(getState().pendingSideBarAddTheater).toBe(false);
+    requestSideBarAddTheater();
+    expect(getState().pendingSideBarAddTheater).toBe(true);
+    consumeSideBarAddTheater();
+    expect(getState().pendingSideBarAddTheater).toBe(false);
+  });
+
+  it("stores and consumes the Theater launch request", () => {
+    expect(getState().pendingSideBarTheaterLaunch).toBeNull();
+    requestSideBarTheaterLaunch("theater-b");
+    expect(getState().pendingSideBarTheaterLaunch).toBe("theater-b");
+    consumeSideBarTheaterLaunch();
+    expect(getState().pendingSideBarTheaterLaunch).toBeNull();
+  });
+});
+
+describe("CommandBandTheaterMenu", () => {
+  it("lists every Theater with mark, ops meta, and checked active row plus the Add Theater action", () => {
+    const onSelectTheater = vi.fn();
+    renderMenu(createElement(CommandBandTheaterMenu, {
+      theaters: [makeTheater("theater-a", "fleet-harness"), makeTheater("theater-b", "Bravo")],
+      operations: [makeOperation("op-1", "theater-a"), makeOperation("op-2", "theater-a"), makeOperation("op-3", "theater-b")],
+      activeTheaterId: "theater-a",
+      addingTheater: false,
+      onSelectTheater,
+      onAddTheater: vi.fn(),
+      containerRef: createRef<HTMLDivElement>(),
+    }));
+
+    const menu = document.querySelector<HTMLElement>('[role="menu"][aria-label="Switch Theater"]');
+    expect(menu).not.toBeNull();
+    const radios = Array.from(menu?.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]') ?? []);
+    expect(radios).toHaveLength(2);
+    expect(radios[0]?.getAttribute("aria-checked")).toBe("true");
+    expect(radios[0]?.className).toContain("is-active");
+    expect(radios[0]?.querySelector(".command-band-theater-mark")?.textContent).toBe("FH");
+    expect(radios[0]?.querySelector(".command-band-menu-meta")?.textContent).toBe("2 ops");
+    expect(radios[1]?.getAttribute("aria-checked")).toBe("false");
+    expect(radios[1]?.querySelector(".command-band-menu-meta")?.textContent).toBe("1 op");
+    const action = menu?.querySelector<HTMLButtonElement>(".command-band-menu-action");
+    expect(action?.textContent).toContain("Add Theater…");
+    expect(menu?.querySelector(".command-band-menu-divider")).not.toBeNull();
+
+    act(() => radios[1]?.click());
+    expect(onSelectTheater).toHaveBeenCalledWith("theater-b");
+  });
+
+  it("moves focus with arrow keys and starts from the checked row", () => {
+    renderMenu(createElement(CommandBandTheaterMenu, {
+      theaters: [makeTheater("theater-a", "Alpha"), makeTheater("theater-b", "Bravo")],
+      operations: [],
+      activeTheaterId: "theater-b",
+      addingTheater: false,
+      onSelectTheater: vi.fn(),
+      onAddTheater: vi.fn(),
+      containerRef: createRef<HTMLDivElement>(),
+    }));
+
+    const menu = document.querySelector<HTMLElement>('[role="menu"]');
+    const items = Array.from(menu?.querySelectorAll<HTMLButtonElement>(".command-band-menu-item") ?? []);
+    expect(document.activeElement).toBe(items[1]);
+
+    act(() => {
+      menu?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    });
+    expect(document.activeElement).toBe(items[2]);
+
+    act(() => {
+      menu?.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }));
+    });
+    expect(document.activeElement).toBe(items[0]);
+
+    act(() => {
+      menu?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
+    });
+    expect(document.activeElement).toBe(items[2]);
+  });
+});
+
+describe("CommandBandOperationMenu", () => {
+  it("lists active-Theater Operations with CLI meta plus Rename and New Operation rows", () => {
+    const onSelectOperation = vi.fn();
+    const onRenameOperation = vi.fn();
+    renderMenu(createElement(CommandBandOperationMenu, {
+      operations: [
+        { ...makeOperation("op-1", "theater-a"), payload: { cliLabel: "Claude Code" } },
+        makeOperation("op-2", "theater-a"),
+      ],
+      activeOperationId: "op-1",
+      theaterLabel: "Alpha",
+      onSelectOperation,
+      onRenameOperation,
+      onNewOperation: vi.fn(),
+      containerRef: createRef<HTMLDivElement>(),
+    }));
+
+    const menu = document.querySelector<HTMLElement>('[role="menu"][aria-label="Switch operation"]');
+    const radios = Array.from(menu?.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]') ?? []);
+    expect(radios).toHaveLength(2);
+    expect(radios[0]?.getAttribute("aria-checked")).toBe("true");
+    expect(radios[0]?.querySelector(".command-band-menu-meta")?.textContent).toBe("Claude Code");
+    const actionItems = Array.from(menu?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]') ?? []);
+    expect(actionItems.map((item) => item.textContent)).toEqual(["Rename current operation…", "New Operation in Alpha…"]);
+
+    act(() => radios[1]?.click());
+    expect(onSelectOperation).toHaveBeenCalledWith("op-2");
+    act(() => actionItems[0]?.click());
+    expect(onRenameOperation).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the Rename row without an active Operation and notes an empty Theater", () => {
+    renderMenu(createElement(CommandBandOperationMenu, {
+      operations: [],
+      activeOperationId: null,
+      theaterLabel: "Alpha",
+      onSelectOperation: vi.fn(),
+      onRenameOperation: null,
+      onNewOperation: vi.fn(),
+      containerRef: createRef<HTMLDivElement>(),
+    }));
+
+    const menu = document.querySelector<HTMLElement>('[role="menu"]');
+    expect(menu?.querySelector(".command-band-menu-empty")?.textContent).toBe("No operations in this Theater");
+    const actionItems = Array.from(menu?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]') ?? []);
+    expect(actionItems.map((item) => item.textContent)).toEqual(["New Operation in Alpha…"]);
+  });
+});
+
+describe("side bar signal consumption", () => {
+  it("consumes the Add Theater request by expanding the side bar and opening the Theater browser", () => {
+    setSideBarCollapsed(true);
+    renderSideBar();
+    expect(document.querySelector(".directory-browser-overlay")).toBeNull();
+
+    act(() => requestSideBarAddTheater());
+
+    expect(getState().pendingSideBarAddTheater).toBe(false);
+    expect(container?.querySelector('[data-sidebar-state="expanded"]')).not.toBeNull();
+    expect(document.querySelector(".directory-browser-overlay")).not.toBeNull();
+  });
+
+  it("consumes the Theater launch request by opening the launch menu at the Theater's New Operation button", async () => {
+    const onSelectTheater = vi.fn();
+    renderSideBar(onSelectTheater);
+    expect(document.querySelector(".canvas-context-menu-head")).toBeNull();
+
+    act(() => requestSideBarTheaterLaunch("theater-b"));
+
+    // jsdom 기하는 항상 0이라 width 전환 미정착 경로(220ms 지연 실측)를 탄다. consume도 실측 시점에 일어난다.
+    await act(() => new Promise((resolve) => setTimeout(resolve, 240)));
+    expect(getState().pendingSideBarTheaterLaunch).toBeNull();
+    expect(document.querySelector(".canvas-context-menu-head")).not.toBeNull();
+    expect(onSelectTheater).toHaveBeenCalledWith("theater-b");
+  });
+});
+
+function renderMenu(element: ReturnType<typeof createElement>): void {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  act(() => root?.render(element));
+}
+
+function renderSideBar(onSelectTheater = vi.fn()): void {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  act(() => root?.render(createElement(MemoryRouter, null, createElement(OperationsSideBar, {
+    theaters: [makeTheater("theater-a", "Alpha"), makeTheater("theater-b", "Bravo")],
+    activeTheaterId: "theater-a",
+    operations: [makeOperation("op-a", "theater-a"), makeOperation("op-b", "theater-b")],
+    groups: [],
+    minimized: [],
+    activeOperationId: "op-a",
+    operationNotifications: {},
+    catalog: [],
+    canLaunch: true,
+    addingTheater: false,
+    theaterError: null,
+    renderKindIcon: () => null,
+    onLaunchKind: () => {},
+    onResetView: () => {},
+    onClose: () => {},
+    onMinimize: () => {},
+    onFocus: () => {},
+    onSetAccent: () => {},
+    onRename: () => {},
+    onSetGroupId: () => {},
+    onCreateGroup: () => {},
+    onSetGroupColor: () => {},
+    onRenameGroup: () => {},
+    onReorderGroups: () => {},
+    onReorderTheaters: () => {},
+    onUngroupAll: () => {},
+    onSelectTheater,
+    onAddTheater: () => {},
+    onCancelAddTheater: () => {},
+    onForgetTheater: () => {},
+  }))));
+}
+
+function makeTheater(id: string, label: string): TheaterInfo {
+  return { id, label, createdAt: "2026-01-01T00:00:00.000Z", lastOpenedAt: "2026-01-01T00:00:00.000Z", hasWiki: false, activeAdmiralCount: 0 };
+}
+
+function makeOperation(id: string, theaterId: string): OperationNode {
+  return {
+    id,
+    theaterId,
+    type: "shell",
+    pluginId: "terminal",
+    title: id,
+    payload: {},
+    geometry: null,
+    ts: { createdAt: 1, updatedAt: 1 },
+  };
+}

--- a/runtime/fleet-console/tests/command-band-v2-guards.test.ts
+++ b/runtime/fleet-console/tests/command-band-v2-guards.test.ts
@@ -2,8 +2,8 @@
 
 import { describe, expect, it } from "vitest";
 
-import { commandBandActiveOperation, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft } from "../core/client/src/components/command-band-guards.js";
-import type { OperationNode } from "../core/client/src/types.js";
+import { commandBandActiveOperation, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "../core/client/src/components/command-band-guards.js";
+import type { OperationGroup, OperationNode } from "../core/client/src/types.js";
 
 describe("Command Band v2 guards", () => {
   it("does not commit a previous Operation draft after another panel becomes active", () => {
@@ -87,6 +87,36 @@ describe("Command Band menu viewport clamp", () => {
 
   it("prioritizes the left gutter when the menu is wider than the viewport", () => {
     expect(commandBandMenuClampedLeft(0, 20, 500, 480)).toBe(12 - 20);
+  });
+});
+
+describe("Command Band operation menu ordering", () => {
+  const grouped = (id: string, theaterId: string, groupId: string | null): OperationNode => ({
+    ...makeOperation(id, theaterId),
+    ...(groupId !== null ? { groupId } : {}),
+  });
+  const makeGroup = (id: string, theaterId: string, order: number): OperationGroup => ({
+    id,
+    theaterId,
+    name: id,
+    color: "crimson",
+    order,
+    createdAt: order,
+  });
+
+  it("mirrors the grouped sidebar order, not the flat operationOrder", () => {
+    // flat 순서상 g2 소속 op-b가 앞서지만, 사이드바는 그룹 순서(g1 먼저)로 평탄화한다.
+    const operations = [grouped("op-b", "t1", "g2"), grouped("op-a", "t1", "g1"), grouped("op-c", "t1", null)];
+    const groups = [makeGroup("g1", "t1", 0), makeGroup("g2", "t1", 1)];
+    const ids = commandBandTheaterOperations(operations, groups, "t1", ["op-b", "op-a", "op-c"]).map((op) => op.id);
+    expect(ids).toEqual(["op-a", "op-b", "op-c"]);
+  });
+
+  it("keeps every active-theater operation reachable and excludes other theaters", () => {
+    const operations = [grouped("op-a", "t1", "g1"), grouped("op-x", "t2", null)];
+    const groups = [makeGroup("g1", "t1", 0), makeGroup("g9", "t2", 0)];
+    const ids = commandBandTheaterOperations(operations, groups, "t1", []).map((op) => op.id);
+    expect(ids).toEqual(["op-a"]);
   });
 });
 

--- a/runtime/fleet-console/tests/command-band-v2-guards.test.ts
+++ b/runtime/fleet-console/tests/command-band-v2-guards.test.ts
@@ -2,7 +2,8 @@
 
 import { describe, expect, it } from "vitest";
 
-import { commandBandRenameCommitTarget } from "../core/client/src/components/command-band-guards.js";
+import { commandBandActiveOperation, commandBandRenameCommitTarget } from "../core/client/src/components/command-band-guards.js";
+import type { OperationNode } from "../core/client/src/types.js";
 
 describe("Command Band v2 guards", () => {
   it("does not commit a previous Operation draft after another panel becomes active", () => {
@@ -14,3 +15,38 @@ describe("Command Band v2 guards", () => {
     expect(commandBandRenameCommitTarget(capturedOperationId, activeOperationId)).toBeNull();
   });
 });
+
+describe("Command Band active Operation display guard", () => {
+  const operations: readonly OperationNode[] = [
+    makeOperation("op-a", "theater-a"),
+    makeOperation("op-b", "theater-b"),
+  ];
+
+  it("returns the active Operation when it belongs to the active Theater", () => {
+    expect(commandBandActiveOperation(operations, "op-a", "theater-a")?.id).toBe("op-a");
+  });
+
+  it("hides a stale Operation after switching to another Theater", () => {
+    // setActiveTheater는 activeOperationId를 지우지 않는다 — 타 Theater op는 표시하지 않는다.
+    expect(commandBandActiveOperation(operations, "op-b", "theater-a")).toBeNull();
+  });
+
+  it("returns null without an active Theater or Operation", () => {
+    expect(commandBandActiveOperation(operations, null, "theater-a")).toBeNull();
+    expect(commandBandActiveOperation(operations, "op-a", null)).toBeNull();
+    expect(commandBandActiveOperation(operations, "op-gone", "theater-a")).toBeNull();
+  });
+});
+
+function makeOperation(id: string, theaterId: string): OperationNode {
+  return {
+    id,
+    theaterId,
+    type: "shell",
+    pluginId: "terminal",
+    title: id,
+    payload: {},
+    geometry: null,
+    ts: { createdAt: 1, updatedAt: 1 },
+  };
+}

--- a/runtime/fleet-console/tests/command-band-v2-guards.test.ts
+++ b/runtime/fleet-console/tests/command-band-v2-guards.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { commandBandActiveOperation, commandBandRenameCommitTarget } from "../core/client/src/components/command-band-guards.js";
+import { commandBandActiveOperation, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft } from "../core/client/src/components/command-band-guards.js";
 import type { OperationNode } from "../core/client/src/types.js";
 
 describe("Command Band v2 guards", () => {
@@ -35,6 +35,58 @@ describe("Command Band active Operation display guard", () => {
     expect(commandBandActiveOperation(operations, null, "theater-a")).toBeNull();
     expect(commandBandActiveOperation(operations, "op-a", null)).toBeNull();
     expect(commandBandActiveOperation(operations, "op-gone", "theater-a")).toBeNull();
+  });
+});
+
+describe("Command Band rename cancel follows the displayed Operation", () => {
+  const operations: readonly OperationNode[] = [makeOperation("op-a", "theater-a")];
+
+  it("keeps the draft while the captured Operation is still displayed", () => {
+    const displayed = commandBandActiveOperation(operations, "op-a", "theater-a");
+    expect(commandBandRenameCommitTarget("op-a", displayed?.id ?? null)).toBe("op-a");
+  });
+
+  it("drops the draft when a Theater switch hides the captured Operation even though activeOperationId is unchanged", () => {
+    // setActiveTheater는 activeOperationId를 유지한다 — 표시 대상(P0 가드) 기준으로는 어긋나야 취소된다.
+    const displayed = commandBandActiveOperation(operations, "op-a", "theater-b");
+    expect(displayed).toBeNull();
+    expect(commandBandRenameCommitTarget("op-a", displayed?.id ?? null)).toBeNull();
+  });
+});
+
+describe("Command Band switcher focusout close decision", () => {
+  it("stays open while focus moves within the wrapper and closes when it leaves or vanishes", () => {
+    const wrapper = document.createElement("div");
+    const inside = document.createElement("button");
+    wrapper.append(inside);
+    const outside = document.createElement("button");
+    document.body.append(wrapper, outside);
+
+    expect(commandBandSwitcherFocusLeft(wrapper, inside)).toBe(false);
+    expect(commandBandSwitcherFocusLeft(wrapper, outside)).toBe(true);
+    // relatedTarget null = 창 블러/비포커서블 클릭 — 메뉴를 남기지 않는다.
+    expect(commandBandSwitcherFocusLeft(wrapper, null)).toBe(true);
+
+    wrapper.remove();
+    outside.remove();
+  });
+});
+
+describe("Command Band menu viewport clamp", () => {
+  it("keeps the desired left when the menu already fits", () => {
+    expect(commandBandMenuClampedLeft(40, 300, 236, 1440)).toBe(40);
+  });
+
+  it("pulls an overflowing menu inside the right gutter (sentinel 480px measurements)", () => {
+    // Theater 메뉴: wrapper left 292, width 236 → viewport 우측 468(=480-12)에 정렬.
+    expect(commandBandMenuClampedLeft(0, 292, 236, 480)).toBe(-60);
+    expect(292 + commandBandMenuClampedLeft(0, 292, 236, 480) + 236).toBe(480 - 12);
+    // Operation 메뉴: 트리거 offsetLeft 98(viewport 390), width 274 → right 664가 468로 당겨진다.
+    expect(292 + commandBandMenuClampedLeft(98, 292, 274, 480) + 274).toBe(480 - 12);
+  });
+
+  it("prioritizes the left gutter when the menu is wider than the viewport", () => {
+    expect(commandBandMenuClampedLeft(0, 20, 500, 480)).toBe(12 - 20);
   });
 });
 

--- a/runtime/fleet-console/tests/operation-search-focus.test.tsx
+++ b/runtime/fleet-console/tests/operation-search-focus.test.tsx
@@ -52,6 +52,8 @@ beforeEach(() => {
     operationSearchOpen: true,
     pendingOperationFocus: null,
     keyboardFocusRequest: null,
+    pendingSideBarAddTheater: false,
+    pendingSideBarTheaterLaunch: null,
   });
 
   root = createRoot(container);

--- a/runtime/fleet-console/tests/operation-search.test.ts
+++ b/runtime/fleet-console/tests/operation-search.test.ts
@@ -57,6 +57,8 @@ function makeState(operations: readonly OperationNode[], theaters: readonly Thea
     bootstrapped: false,
     pendingOperationFocus: null,
     keyboardFocusRequest: null,
+    pendingSideBarAddTheater: false,
+    pendingSideBarTheaterLaunch: null,
     operationNotifications: {},
     notificationPreferences: { globalMute: false, dnd: false, mutedTheaterIds: {} },
     codexReader: null,

--- a/runtime/fleet-console/tests/reduce.test.ts
+++ b/runtime/fleet-console/tests/reduce.test.ts
@@ -71,6 +71,8 @@ function makeConsoleSnap(patch: Partial<ConsoleState> = {}): ConsoleState {
     bootstrapped: true,
     pendingOperationFocus: null,
     keyboardFocusRequest: null,
+    pendingSideBarAddTheater: false,
+    pendingSideBarTheaterLaunch: null,
     operationNotifications: {},
     notificationPreferences: { globalMute: false, dnd: false, mutedTheaterIds: {} },
     ...patch,


### PR DESCRIPTION
## Summary
- command band 브레드크럼의 Theater/Operation 세그먼트를 드롭다운 트리거로 승격 — Theater 메뉴(전체 Theater+op 수+Add Theater…)와 Operation 메뉴(활성 Theater 소속 op+Rename…+New Operation…)를 기존 `.theater-menu` 문법의 앵커드 메뉴로 제공하고, 선택은 기존 `setActiveTheater`/`focusOperation` 프리미티브를 재사용.
- 스테일 브레드크럼 결함 수정: Theater만 전환해도 남아 있던 타 Theater Operation 표시를 `commandBandActiveOperation` 표시 가드로 차단하고, 표시할 Operation이 없으면 "Select operation…" 플레이스홀더 트리거를 렌더.
- Add Theater…/New Operation… 행은 신규 request/consume 스토어 신호(`pendingSideBarAddTheater`/`pendingSideBarTheaterLaunch`)로 사이드바에 위임 — 접힘 상태면 자동 펼침 후 기존 Theater 브라우저/launch 메뉴를 연다. 리뷰 반영: Tab 이탈 시 메뉴 닫힘, 좁은 viewport 메뉴 clamp(+resize 재측정), Theater 전환 중 진행 rename 취소 및 표시 대상 기준 커밋 가드.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` green (tsup+vite)
- [x] 표적 vitest green: command-band-switcher(8)·command-band-v2-guards(가드/포커스/clamp 신규 포함)·command-band-focus·fullscreen-command-band·instrument-design-contract(무변경)·reduce·operation-search(+focus)·canvas-minimap-formation·operations-side-bar 계열
- [x] 격리 콘솔(agent-browser headless) 실측: 스테일 브레드크럼 소멸, Theater 메뉴 키보드 선택(↓/Enter), Operation 선택→dormant 복원, Escape/바깥클릭/Tab 이탈 닫힘+포커스 규약, 더블클릭 리네임 보존+Enter 커밋, 접힘 사이드바에서 Add Theater/New Operation 신호 소비, 480px viewport 메뉴 clamp(right=468=viewport−gutter), 콘솔 에러 0
- [x] Changelog: `.changelog.d/pr-339.md` — grouped 문법·EN/ko 병기·`node scripts/compile-changelog-fragments.mjs --check` 통과