### PR TITLE
feat(core-unified-agent): expand opencode-go/cursor ACP models

### DIFF
--- a/.changelog.d/pr-340.md
+++ b/.changelog.d/pr-340.md
@@ -1,0 +1,4 @@
+### fleet-core
+#### Changed
+- [core-unified-agent] Refresh the OpenCode Go and Cursor Agent model catalogs from the live CLIs: OpenCode Go lists 11 current-generation models with `opencode-go/deepseek-v4-flash` as the default, and Cursor Agent covers 90 models via 29 effort-expanded registry entries; superseded generations are retired.
+  ko: OpenCode Go와 Cursor Agent 모델 카탈로그를 실제 CLI 기준으로 갱신합니다. OpenCode Go는 `opencode-go/deepseek-v4-flash` 기본 모델과 11개 현세대 모델을 제공하고, Cursor Agent는 effort 확장 레지스트리 29개 엔트리로 90개 모델을 지원하며 구세대 모델은 퇴역합니다.

--- a/packages/core-unified-agent/models.json
+++ b/packages/core-unified-agent/models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-07-20T00:00:00Z",
+  "updatedAt": "2026-07-21T00:00:00Z",
   "providers": {
     "claude": {
       "name": "Claude Code",
@@ -45,15 +45,19 @@
     },
     "opencode-go": {
       "name": "OpenCode Go",
-      "defaultModel": "opencode-go/glm-5.1",
+      "defaultModel": "opencode-go/deepseek-v4-flash",
       "models": [
         { "modelId": "opencode-go/deepseek-v4-flash", "name": "DeepSeek V4 Flash", "effort": { "supported": false } },
         { "modelId": "opencode-go/deepseek-v4-pro", "name": "DeepSeek V4 Pro", "effort": { "supported": false } },
-        { "modelId": "opencode-go/glm-5", "name": "GLM-5", "effort": { "supported": false } },
-        { "modelId": "opencode-go/glm-5.1", "name": "GLM-5.1", "effort": { "supported": false } },
         { "modelId": "opencode-go/glm-5.2", "name": "GLM-5.2", "effort": { "supported": false } },
-        { "modelId": "opencode-go/kimi-k2.6", "name": "Kimi K2.6 (3x limits)", "effort": { "supported": false } },
-        { "modelId": "opencode-go/kimi-k2.7-code", "name": "Kimi K2.7 Code", "effort": { "supported": false } }
+        { "modelId": "opencode-go/grok-4.5", "name": "Grok 4.5", "effort": { "supported": false } },
+        { "modelId": "opencode-go/kimi-k3", "name": "Kimi K3", "effort": { "supported": false } },
+        { "modelId": "opencode-go/kimi-k2.7-code", "name": "Kimi K2.7 Code", "effort": { "supported": false } },
+        { "modelId": "opencode-go/mimo-v2.5", "name": "MiMo V2.5", "effort": { "supported": false } },
+        { "modelId": "opencode-go/mimo-v2.5-pro", "name": "MiMo V2.5 Pro", "effort": { "supported": false } },
+        { "modelId": "opencode-go/minimax-m3", "name": "MiniMax M3", "effort": { "supported": false } },
+        { "modelId": "opencode-go/qwen3.7-max", "name": "Qwen3.7 Max", "effort": { "supported": false } },
+        { "modelId": "opencode-go/qwen3.7-plus", "name": "Qwen3.7 Plus", "effort": { "supported": false } }
       ]
     },
     "cursor": {
@@ -61,14 +65,34 @@
       "defaultModel": "auto",
       "models": [
         { "modelId": "auto", "name": "Auto", "effort": { "supported": false } },
-        { "modelId": "composer-2.5-fast", "name": "Composer 2.5 Fast", "description": "Cursor Composer 2.5 (fast variant, default upstream)", "effort": { "supported": false } },
-        { "modelId": "composer-2.5", "name": "Composer 2.5", "description": "Cursor Composer 2.5 (standard variant)", "effort": { "supported": false } },
+        { "modelId": "composer-2.5", "name": "Composer 2.5", "effort": { "supported": false } },
+        { "modelId": "composer-2.5-fast", "name": "Composer 2.5 Fast", "effort": { "supported": false } },
+        { "modelId": "gpt-5.6-sol", "name": "GPT-5.6 Sol", "spawnModelTemplate": "gpt-5.6-sol-{effort}", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max"], "default": "medium" } },
+        { "modelId": "gpt-5.6-sol-fast", "name": "GPT-5.6 Sol Fast", "spawnModelTemplate": "gpt-5.6-sol-{effort}-fast", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max"], "default": "medium" } },
+        { "modelId": "gpt-5.6-sol-none", "name": "GPT-5.6 Sol None", "effort": { "supported": false } },
+        { "modelId": "gpt-5.6-sol-none-fast", "name": "GPT-5.6 Sol None Fast", "effort": { "supported": false } },
+        { "modelId": "gpt-5.6-luna", "name": "GPT-5.6 Luna", "spawnModelTemplate": "gpt-5.6-luna-{effort}", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max"], "default": "medium" } },
+        { "modelId": "gpt-5.6-luna-fast", "name": "GPT-5.6 Luna Fast", "spawnModelTemplate": "gpt-5.6-luna-{effort}-fast", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max"], "default": "medium" } },
+        { "modelId": "gpt-5.6-luna-none", "name": "GPT-5.6 Luna None", "effort": { "supported": false } },
+        { "modelId": "gpt-5.6-luna-none-fast", "name": "GPT-5.6 Luna None Fast", "effort": { "supported": false } },
+        { "modelId": "gpt-5.6-terra", "name": "GPT-5.6 Terra", "spawnModelTemplate": "gpt-5.6-terra-{effort}", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max"], "default": "medium" } },
+        { "modelId": "gpt-5.6-terra-fast", "name": "GPT-5.6 Terra Fast", "spawnModelTemplate": "gpt-5.6-terra-{effort}-fast", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max"], "default": "medium" } },
+        { "modelId": "gpt-5.6-terra-none", "name": "GPT-5.6 Terra None", "effort": { "supported": false } },
+        { "modelId": "gpt-5.6-terra-none-fast", "name": "GPT-5.6 Terra None Fast", "effort": { "supported": false } },
+        { "modelId": "cursor-grok-4.5", "name": "Cursor Grok 4.5", "spawnModelTemplate": "cursor-grok-4.5-{effort}", "effort": { "supported": true, "levels": ["low", "medium", "high"], "default": "high" } },
+        { "modelId": "cursor-grok-4.5-fast", "name": "Cursor Grok 4.5 Fast", "spawnModelTemplate": "cursor-grok-4.5-{effort}-fast", "effort": { "supported": true, "levels": ["low", "medium", "high"], "default": "high" } },
+        { "modelId": "claude-opus-4-8", "name": "Claude Opus 4.8", "spawnModelTemplate": "claude-opus-4-8-{effort}", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max"], "default": "high" } },
+        { "modelId": "claude-opus-4-8-fast", "name": "Claude Opus 4.8 Fast", "spawnModelTemplate": "claude-opus-4-8-{effort}-fast", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max"], "default": "high" } },
+        { "modelId": "claude-opus-4-8-thinking", "name": "Claude Opus 4.8 Thinking", "spawnModelTemplate": "claude-opus-4-8-thinking-{effort}", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max"], "default": "xhigh" } },
+        { "modelId": "claude-opus-4-8-thinking-fast", "name": "Claude Opus 4.8 Thinking Fast", "spawnModelTemplate": "claude-opus-4-8-thinking-{effort}-fast", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max"], "default": "xhigh" } },
+        { "modelId": "claude-sonnet-5", "name": "Claude Sonnet 5", "spawnModelTemplate": "claude-sonnet-5-{effort}", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max"], "default": "high" } },
+        { "modelId": "claude-sonnet-5-thinking", "name": "Claude Sonnet 5 Thinking", "spawnModelTemplate": "claude-sonnet-5-thinking-{effort}", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max"], "default": "xhigh" } },
+        { "modelId": "claude-fable-5", "name": "Claude Fable 5", "description": "NO ZDR per cursor-agent model list", "spawnModelTemplate": "claude-fable-5-{effort}", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max"], "default": "high" } },
+        { "modelId": "claude-fable-5-thinking", "name": "Claude Fable 5 Thinking", "description": "NO ZDR per cursor-agent model list", "spawnModelTemplate": "claude-fable-5-thinking-{effort}", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max"], "default": "xhigh" } },
         { "modelId": "gemini-3.1-pro", "name": "Gemini 3.1 Pro", "effort": { "supported": false } },
-        { "modelId": "gemini-3-flash", "name": "Gemini 3 Flash", "effort": { "supported": false } },
         { "modelId": "gemini-3.5-flash", "name": "Gemini 3.5 Flash", "effort": { "supported": false } },
         { "modelId": "kimi-k2.7-code", "name": "Kimi K2.7 Code", "effort": { "supported": false } },
-        { "modelId": "glm-5.2", "name": "GLM 5.2", "spawnModelTemplate": "glm-5.2-{effort}", "effort": { "supported": true, "levels": ["high", "max"], "default": "max" } },
-        { "modelId": "claude-opus-4-8-thinking", "name": "Claude Opus 4.8 Thinking", "spawnModelTemplate": "claude-opus-4-8-thinking-{effort}", "effort": { "supported": true, "levels": ["low", "medium", "high", "xhigh", "max"], "default": "xhigh" } }
+        { "modelId": "glm-5.2", "name": "GLM 5.2", "spawnModelTemplate": "glm-5.2-{effort}", "effort": { "supported": true, "levels": ["high", "max"], "default": "max" } }
       ]
     }
   }

--- a/packages/core-unified-agent/tests/e2e/opencode.test.ts
+++ b/packages/core-unified-agent/tests/e2e/opencode.test.ts
@@ -21,7 +21,7 @@ import type { CliType } from '../../src/config/CliConfigs.js';
 const CLI = 'opencode';
 const installed = isCliInstalled(CLI);
 const OPEN_CODE_PROVIDERS = [
-  { cli: 'opencode-go', label: 'OpenCode Go', defaultModel: 'opencode-go/glm-5.1' },
+  { cli: 'opencode-go', label: 'OpenCode Go', defaultModel: 'opencode-go/deepseek-v4-flash' },
 ] as const satisfies readonly { cli: CliType; label: string; defaultModel: string }[];
 const defaultModelProbes = Object.fromEntries(
   OPEN_CODE_PROVIDERS.map((provider) => [

--- a/packages/core-unified-agent/tests/unit/ModelRegistry.test.ts
+++ b/packages/core-unified-agent/tests/unit/ModelRegistry.test.ts
@@ -90,14 +90,34 @@ describe('ModelRegistry', () => {
     expect(provider.defaultModel).toBe('auto');
     expect(modelIds).toEqual([
       'auto',
-      'composer-2.5-fast',
       'composer-2.5',
+      'composer-2.5-fast',
+      'gpt-5.6-sol',
+      'gpt-5.6-sol-fast',
+      'gpt-5.6-sol-none',
+      'gpt-5.6-sol-none-fast',
+      'gpt-5.6-luna',
+      'gpt-5.6-luna-fast',
+      'gpt-5.6-luna-none',
+      'gpt-5.6-luna-none-fast',
+      'gpt-5.6-terra',
+      'gpt-5.6-terra-fast',
+      'gpt-5.6-terra-none',
+      'gpt-5.6-terra-none-fast',
+      'cursor-grok-4.5',
+      'cursor-grok-4.5-fast',
+      'claude-opus-4-8',
+      'claude-opus-4-8-fast',
+      'claude-opus-4-8-thinking',
+      'claude-opus-4-8-thinking-fast',
+      'claude-sonnet-5',
+      'claude-sonnet-5-thinking',
+      'claude-fable-5',
+      'claude-fable-5-thinking',
       'gemini-3.1-pro',
-      'gemini-3-flash',
       'gemini-3.5-flash',
       'kimi-k2.7-code',
       'glm-5.2',
-      'claude-opus-4-8-thinking',
     ]);
   });
 
@@ -105,6 +125,13 @@ describe('ModelRegistry', () => {
     expect(resolveCursorSpawnModel('glm-5.2')).toBe('glm-5.2-max');
     expect(resolveCursorSpawnModel('glm-5.2', 'high')).toBe('glm-5.2-high');
     expect(resolveCursorSpawnModel('glm-5.2', 'invalid')).toBe('glm-5.2-max');
+  });
+
+  it('Cursor spawnModelTemplate은 effort로 실제 cursor-agent CLI 모델 ID를 조립한다', () => {
+    expect(resolveCursorSpawnModel('gpt-5.6-sol')).toBe('gpt-5.6-sol-medium');
+    expect(resolveCursorSpawnModel('gpt-5.6-sol', 'max')).toBe('gpt-5.6-sol-max');
+    expect(resolveCursorSpawnModel('claude-opus-4-8-thinking-fast', 'low')).toBe('claude-opus-4-8-thinking-low-fast');
+    expect(resolveCursorSpawnModel('cursor-grok-4.5-fast')).toBe('cursor-grok-4.5-high-fast');
   });
 
   it('effort 지원 spawnModelTemplate은 {effort} 플레이스홀더를 포함해야 한다', () => {

--- a/packages/core-unified-agent/tests/unit/UnifiedCursorAgentClient.test.ts
+++ b/packages/core-unified-agent/tests/unit/UnifiedCursorAgentClient.test.ts
@@ -49,13 +49,13 @@ describe('UnifiedCursorAgentClient', () => {
       };
     };
 
-    await client.setModel('gemini-3-flash');
+    await client.setModel('gemini-3.5-flash');
 
     expect(capturedOptions).toHaveLength(1);
     expect(capturedOptions[0]).toMatchObject({
       cli: 'cursor',
       cwd: '/tmp/workspace',
-      model: 'gemini-3-flash',
+      model: 'gemini-3.5-flash',
       systemPrompt: '시스템 지침',
       env: { CURSOR_TEST_ENV: '1' },
       clientInfo: { name: 'unit-test', version: '1.0.0' },
@@ -78,7 +78,7 @@ describe('UnifiedCursorAgentClient', () => {
     internals.currentConnectOptions = {
       cli: 'cursor',
       cwd: '/tmp/workspace',
-      model: 'gemini-3-flash',
+      model: 'gemini-3.5-flash',
       effort: 'high',
     };
 
@@ -111,7 +111,7 @@ describe('UnifiedCursorAgentClient', () => {
     internals.currentConnectOptions = {
       cli: 'cursor',
       cwd: '/tmp/workspace',
-      model: 'gemini-3-flash',
+      model: 'gemini-3.5-flash',
       effort: 'invalid',
     };
 
@@ -156,9 +156,9 @@ describe('UnifiedCursorAgentClient', () => {
       };
     };
 
-    await client.setConfigOption('model', 'gemini-3-flash');
+    await client.setConfigOption('model', 'gemini-3.5-flash');
 
-    expect(capturedModels).toEqual(['gemini-3-flash']);
+    expect(capturedModels).toEqual(['gemini-3.5-flash']);
   });
 
   it('setConfigOption("model")은 Composer 2.5 모델로 재연결한다', async () => {
@@ -270,7 +270,7 @@ describe('UnifiedCursorAgentClient', () => {
     internals.currentConnectOptions = {
       cli: 'cursor',
       cwd: '/tmp/workspace',
-      model: 'gemini-3-flash',
+      model: 'gemini-3.5-flash',
     };
 
     client.connect = async (): Promise<ConnectResult> => {
@@ -333,7 +333,7 @@ describe('UnifiedCursorAgentClient', () => {
 
     client.connect = async (options: UnifiedClientOptions): Promise<ConnectResult> => {
       capturedOptions.push(options);
-      if (options.model === 'gemini-3-flash') {
+      if (options.model === 'gemini-3.5-flash') {
         throw new Error('spawn failed');
       }
       return {
@@ -343,12 +343,12 @@ describe('UnifiedCursorAgentClient', () => {
       };
     };
 
-    await expect(client.setModel('gemini-3-flash')).rejects.toThrow(
+    await expect(client.setModel('gemini-3.5-flash')).rejects.toThrow(
       '[cursor] 모델 변경 실패로 이전 연결을 복구했습니다. 모델 변경 오류: spawn failed',
     );
 
     expect(capturedOptions).toHaveLength(2);
-    expect(capturedOptions[0]).toMatchObject({ model: 'gemini-3-flash' });
+    expect(capturedOptions[0]).toMatchObject({ model: 'gemini-3.5-flash' });
     expect(capturedOptions[1]).toMatchObject({
       model: 'glm-5.2',
       effort: 'high',


### PR DESCRIPTION
## Summary
- Refresh the `opencode-go` and `cursor` provider catalogs in `packages/core-unified-agent/models.json` from the live CLIs (opencode 1.18.3 `opencode models`, cursor-agent 2026.07.17 `--list-models`), filtered to current-generation models.
- `opencode-go`: 11 models, default moves to `opencode-go/deepseek-v4-flash`; retires `glm-5`, `glm-5.1`, `kimi-k2.6`, `minimax-m2.7`, `qwen3.6-plus`.
- `cursor`: 29 registry entries covering 90 CLI models via `spawnModelTemplate` effort expansion (`-fast` as separate template entries, `none`-tier as literal models); retires `gemini-3-flash` and superseded generations. Defaults stay on `auto`; thinking absorbed into template entries like the existing `claude-opus-4-8-thinking`.

## Test Plan
- [x] `corepack pnpm lint` (core-unified-agent)
- [x] `corepack pnpm typecheck:test`
- [x] `corepack pnpm build`
- [x] `corepack pnpm vitest run tests/unit` — 164/165 (sole failure: pre-existing flaky `CodexAppServerConnection.lifecycle > disconnect가 프로세스를 종료한다`, failing identically on base)
- [x] Model-list + spawn-template unit assertions synced; retired-model reference grep clean
- [x] Changelog fragment `.changelog.d/pr-340.md` — grouped syntax, bilingual summaries, `compile-changelog-fragments.mjs --check` passed