### PR TITLE
feat(console): add Float over Map overlay mode to the right rail

### DIFF
--- a/.changelog.d/pr-341.md
+++ b/.changelog.d/pr-341.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Added
+- [fleet-console] Add a "Float over Map" pill toggle to the right rail panel head that switches rail panels between the default push layout and an overlay mode where the panel floats over the Map without resizing it; the choice persists across sessions.
+  ko: 우측 레일 패널 헤더에 "Float over Map" 필 토글을 추가해 레일 패널을 기본 Push 레이아웃과 Map 크기 변경 없이 패널이 위에 떠 있는 Overlay 모드 사이에서 전환할 수 있으며, 선택이 세션 간에 유지됩니다.

--- a/runtime/fleet-console/core/client/src/rail/rail-store.ts
+++ b/runtime/fleet-console/core/client/src/rail/rail-store.ts
@@ -4,17 +4,20 @@ interface RailStore {
   readonly activeRailPanelId: string | null;
   readonly railChromeExpanded: boolean;
   readonly panelExtraWidth: number;
+  readonly panelBehavior: "push" | "overlay";
 }
 
 type Listener = () => void;
 const PREFS_ACTIVE_PANEL = "fleet-console.rail.activePanelId";
 const PREFS_CHROME_EXPANDED = "fleet-console.rail.chromeExpanded";
+const PREFS_PANEL_BEHAVIOR = "fleet-console.rail.panelBehavior";
 const PREFS_REPOSITORY_SOURCE = "fleet-console.repository.source";
 const listeners = new Set<Listener>();
 let store: RailStore = {
   activeRailPanelId: readStoredPanelId(),
   railChromeExpanded: readStoredChromeExpanded(),
   panelExtraWidth: 0,
+  panelBehavior: readStoredPanelBehavior(),
 };
 
 export function subscribeRailStore(listener: Listener): () => void {
@@ -59,6 +62,16 @@ export function toggleRailChrome(): void {
   setRailChromeExpanded(!store.railChromeExpanded);
 }
 
+export function setRailPanelBehavior(behavior: "push" | "overlay"): void {
+  if (store.panelBehavior === behavior) return;
+  setStore({ ...store, panelBehavior: behavior });
+  saveStoredPanelBehavior(behavior);
+}
+
+export function toggleRailPanelBehavior(): void {
+  setRailPanelBehavior(store.panelBehavior === "push" ? "overlay" : "push");
+}
+
 export function requestRailPanelExtraWidth(panelId: string, px: number | null): void {
   if (panelId !== store.activeRailPanelId) return;
   const raw = (px === null || !Number.isFinite(px)) ? 0 : px;
@@ -80,6 +93,10 @@ export function useRailPanelExtraWidth(): number {
   return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).panelExtraWidth;
 }
 
+export function useRailPanelBehavior(): "push" | "overlay" {
+  return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).panelBehavior;
+}
+
 function readStoredPanelId(): string | null {
   try {
     const stored = localStorage.getItem(PREFS_ACTIVE_PANEL);
@@ -98,6 +115,13 @@ function readStoredChromeExpanded(): boolean {
   try { return localStorage.getItem(PREFS_CHROME_EXPANDED) !== "0"; } catch { return true; }
 }
 
+function readStoredPanelBehavior(): "push" | "overlay" {
+  try {
+    const stored = localStorage.getItem(PREFS_PANEL_BEHAVIOR);
+    return stored === "overlay" || stored === "push" ? stored : "push";
+  } catch { return "push"; }
+}
+
 function saveStoredPanelId(id: string | null): void {
   try {
     if (id === null) localStorage.removeItem(PREFS_ACTIVE_PANEL);
@@ -107,6 +131,10 @@ function saveStoredPanelId(id: string | null): void {
 
 function saveStoredChromeExpanded(expanded: boolean): void {
   try { localStorage.setItem(PREFS_CHROME_EXPANDED, expanded ? "1" : "0"); } catch { /* ignore */ }
+}
+
+function saveStoredPanelBehavior(behavior: "push" | "overlay"): void {
+  try { localStorage.setItem(PREFS_PANEL_BEHAVIOR, behavior); } catch { /* ignore */ }
 }
 
 function setStore(next: RailStore): void {

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -7,7 +7,7 @@ import "../styles/rail.css";
 import { BUILT_IN_RAIL_PANELS } from "./built-in-panels.js";
 import { focusCommandBandToggleWhenPanelContainsActiveElement } from "../components/command-band-focus.js";
 import { getState, subscribe } from "../store.js";
-import { closeRailPanel, requestRailPanelExtraWidth, toggleRailPanel, useActiveRailPanelId, useRailChromeExpanded, useRailPanelExtraWidth } from "./rail-store.js";
+import { closeRailPanel, requestRailPanelExtraWidth, toggleRailPanel, toggleRailPanelBehavior, useActiveRailPanelId, useRailChromeExpanded, useRailPanelBehavior, useRailPanelExtraWidth } from "./rail-store.js";
 import { useRailPanels } from "./rail-registry.js";
 import { useCodexSplitExtraWidth } from "./use-codex-split-extra-width.js";
 
@@ -41,6 +41,7 @@ export function RightRail({ theaterId, api }: RightRailProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const activeId = useActiveRailPanelId();
   const railChromeExpanded = useRailChromeExpanded();
+  const panelBehavior = useRailPanelBehavior();
   const previousRailChromeExpandedRef = useRef(railChromeExpanded);
   const pluginPanels = useRailPanels();
   const builtInPanels = BUILT_IN_RAIL_PANELS;
@@ -97,17 +98,14 @@ export function RightRail({ theaterId, api }: RightRailProps) {
   return (
     <div
       ref={rootRef}
-      className={`right-rail${hasPanel ? " is-open" : ""}${railChromeExpanded ? " is-expanded" : " is-closed"}${isDragging ? " is-dragging" : ""}`}
+      className={`right-rail${hasPanel ? " is-open" : ""}${railChromeExpanded ? " is-expanded" : " is-closed"}${isDragging ? " is-dragging" : ""}${panelBehavior === "overlay" ? " is-overlay" : ""}`}
       data-rail-chrome={railChromeExpanded ? "expanded" : "closed"}
       role="complementary"
       aria-label="Activity Rail"
       inert={!railChromeExpanded}
       style={{ "--right-rail-panel-width": `${hasPanel ? panelWidth + extraWidth : 0}px` } as CSSProperties}
     >
-      <div
-        className="right-rail-panel-slot"
-        style={hasPanel ? { width: panelWidth + extraWidth } : undefined}
-      >
+      <div className="right-rail-panel-slot">
         {hasPanel && (
           <div
             className="right-rail-resize-handle"
@@ -116,7 +114,7 @@ export function RightRail({ theaterId, api }: RightRailProps) {
           />
         )}
         {activePanel && (
-          <RailPanelContent activePanel={activePanel} activeId={activeId} ctx={ctx} />
+          <RailPanelContent activePanel={activePanel} activeId={activeId} ctx={ctx} panelBehavior={panelBehavior} />
         )}
       </div>
       <nav className="right-rail-icons" aria-label="Activity tools">
@@ -140,16 +138,26 @@ interface RailPanelContentProps {
   readonly activePanel: RailPanelDescriptor;
   readonly activeId: string | null;
   readonly ctx: RailPanelContext;
+  readonly panelBehavior: "push" | "overlay";
 }
 
 // 패널 본문은 무거운 플러그인 콘텐츠(파일 트리·diff·Codex)를 렌더한다. 리사이즈 드래그가
 // 매 프레임 RightRail을 재렌더해도 이 본문이 함께 재렌더되면 끊김이 생기므로, 폭과 무관한
-// (activePanel·ctx·activeId) props로 memo해 드래그 중 본문 재렌더를 건너뛴다(좌측 SideBar처럼 가벼운 부분만 재렌더).
-const RailPanelContent = memo(function RailPanelContent({ activePanel, activeId, ctx }: RailPanelContentProps) {
+// (activePanel·ctx·activeId·panelBehavior) props로 memo해 드래그 중 본문 재렌더를 건너뛴다(좌측 SideBar처럼 가벼운 부분만 재렌더).
+const RailPanelContent = memo(function RailPanelContent({ activePanel, activeId, ctx, panelBehavior }: RailPanelContentProps) {
   return (
     <>
       <div className="right-rail-panel-head">
         <span className="right-rail-panel-title">{activePanel.title}</span>
+        <button
+          className={`right-rail-float-toggle${panelBehavior === "overlay" ? " is-active" : ""}`}
+          type="button"
+          aria-pressed={panelBehavior === "overlay"}
+          aria-label="Float panel over the Map"
+          onClick={toggleRailPanelBehavior}
+        >
+          Float over Map
+        </button>
         <button
           className="right-rail-close-btn"
           type="button"

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -12,6 +12,7 @@
   width: calc(44px + var(--right-rail-panel-width, 0px));
   height: 100%;
   min-height: 0;
+  position: relative;
   z-index: var(--z-rail);
   /* Glass 부유 카드 — 144df6c 이전 독립 ALERTS 도크의 함교 계기판 질감을 계승한다:
      우상단 brass 코너 조명 + glass 본체, 부유 그림자, 단일 blur 레이어.
@@ -29,6 +30,11 @@
   transition: width 200ms ease, border-color 200ms ease, visibility 0s linear 0s;
 }
 
+.right-rail.is-overlay {
+  width: 44px;
+  overflow: visible;
+}
+
 /* ── 패널 슬롯 ─────────────────────────────────────────────────────
    overflow:hidden + width 전환으로 spring 펼침/접힘을 구현한다.
    min-width는 애니메이션 중 내부 레이아웃 흔들림을 방지한다.        */
@@ -44,7 +50,22 @@
 }
 
 .right-rail.is-open .right-rail-panel-slot {
-  width: 312px;
+  width: var(--right-rail-panel-width, 312px);
+}
+
+.right-rail.is-overlay .right-rail-panel-slot {
+  position: absolute;
+  right: 44px;
+  top: 0;
+  bottom: 0;
+  width: var(--right-rail-panel-width, 0px);
+  background:
+    radial-gradient(130% 60% at 100% 0%, color-mix(in oklch, var(--brass) 7%, transparent), transparent 56%),
+    color-mix(in oklch, var(--surface-glass-strong) 92%, var(--ink-deep));
+  border-left: 1px solid var(--surface-rim);
+  /* Near-achromatic depth shadow is a sanctioned raw-literal exception. */
+  box-shadow: -24px 0 48px -24px oklch(0% 0 0 / 70%);
+  border-radius: var(--radius-lg) 0 0 var(--radius-lg);
 }
 
 .right-rail-panel-head {
@@ -69,6 +90,39 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.right-rail-float-toggle {
+  flex: none;
+  padding: 4px 8px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--surface-rim-strong);
+  background: transparent;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color 140ms, background 140ms, border-color 140ms;
+}
+
+.right-rail-float-toggle:hover {
+  color: var(--ink-pearl);
+  background: var(--ink-veil);
+}
+
+.right-rail-float-toggle.is-active {
+  color: var(--brass);
+  background: var(--brass-glow);
+  border-color: color-mix(in oklch, var(--brass) 45%, transparent);
+}
+
+/* 활성 hover는 brass 채널을 유지한 채 테두리만 강화한다(비활성 hover의 veil 덮기 방지). */
+.right-rail-float-toggle.is-active:hover {
+  color: var(--brass);
+  background: var(--brass-glow);
+  border-color: color-mix(in oklch, var(--brass) 70%, transparent);
 }
 
 .right-rail-close-btn {
@@ -229,7 +283,8 @@
     transition: none !important;
   }
 
-  .right-rail-ico {
+  .right-rail-ico,
+  .right-rail-float-toggle {
     transition-duration: 0.01ms !important;
   }
 }

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -202,6 +202,16 @@ describe("Instrument core design contract", () => {
     expect(store).toContain("setMaximizedOperationId");
   });
 
+  it("pins the selectable Right Rail panel behavior contract", () => {
+    const rail = source("styles/rail.css");
+    const rightRail = source("rail/right-rail.tsx");
+    const railStore = source("rail/rail-store.ts");
+    expect(rail).toContain(".right-rail.is-overlay");
+    expect(rightRail).toContain("useRailPanelBehavior");
+    expect(rightRail).toContain("right-rail-float-toggle");
+    expect(railStore).toContain("fleet-console.rail.panelBehavior");
+  });
+
   it("pins the Command Band and closed-chrome contracts", () => {
     const app = source("app.tsx");
     const commandBand = source("components/command-band.tsx");

--- a/runtime/fleet-console/tests/rail-store.test.ts
+++ b/runtime/fleet-console/tests/rail-store.test.ts
@@ -167,3 +167,48 @@ describe("rail chrome state", () => {
     expect(getRailStoreSnapshot()).toMatchObject({ activeRailPanelId: null, railChromeExpanded: true });
   });
 });
+
+describe("rail panel behavior", () => {
+  function stubPanelBehaviorStorage(initial: string | null = null) {
+    const values = new Map<string, string>();
+    if (initial !== null) values.set("fleet-console.rail.panelBehavior", initial);
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+      removeItem: (key: string) => values.delete(key),
+    });
+    return values;
+  }
+
+  it("defaults to push", async () => {
+    stubPanelBehaviorStorage();
+    const { getRailStoreSnapshot } = await freshStore();
+    expect(getRailStoreSnapshot().panelBehavior).toBe("push");
+  });
+
+  it("toggles from push to overlay and back", async () => {
+    stubPanelBehaviorStorage();
+    const { getRailStoreSnapshot, toggleRailPanelBehavior } = await freshStore();
+    toggleRailPanelBehavior();
+    expect(getRailStoreSnapshot().panelBehavior).toBe("overlay");
+    toggleRailPanelBehavior();
+    expect(getRailStoreSnapshot().panelBehavior).toBe("push");
+  });
+
+  it("persists and restores the selected behavior", async () => {
+    const values = stubPanelBehaviorStorage();
+    const { setRailPanelBehavior } = await freshStore();
+    setRailPanelBehavior("overlay");
+    expect(values.get("fleet-console.rail.panelBehavior")).toBe("overlay");
+
+    vi.resetModules();
+    const restored = await freshStore();
+    expect(restored.getRailStoreSnapshot().panelBehavior).toBe("overlay");
+  });
+
+  it("falls back to push for an unknown stored value", async () => {
+    stubPanelBehaviorStorage("floating");
+    const { getRailStoreSnapshot } = await freshStore();
+    expect(getRailStoreSnapshot().panelBehavior).toBe("push");
+  });
+});


### PR DESCRIPTION
## Summary
- 우측 레일 패널이 그리드 실열을 차지해 Map이 패널 폭만큼 줄어드는 문제(실측 956→644px, 기본 312px 패널 @1280px 창)에 대해, 사용자가 선택할 수 있는 패널 동작(Push ⇄ Overlay)을 추가합니다.
- 선택 진입점은 레일 패널 헤더의 **"Float over Map" 필 토글 단독**입니다(확정 시안 B안 · Rail switch only — Settings 진입점 없음). Overlay 모드에서는 레일 외곽이 44px 아이콘 스트립으로 축소되고 패널 슬롯이 기존 `--z-rail` 레이어 위에 동일 glass 카드로 부유하여 Map이 전폭을 유지합니다.
- 선택은 `fleet-console.rail.panelBehavior`(localStorage, push 폴 back)로 영속하며, 리사이즈 드래그·extraWidth·패널 전환·⌘⌥B 크롬 토글은 두 모드에서 동일하게 동작합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` green
- [x] `tests/rail-store.test.ts` — panelBehavior 기본값/토글 왕복/영속·복원/폴 back 4종 추가, 40/40 green
- [x] `tests/instrument-design-contract.test.ts` — 신규 문법 핀(`.right-rail.is-overlay`, `useRailPanelBehavior`, `right-rail-float-toggle`, localStorage 키) 추가, green
- [x] console-e2e 실측: push 644px ⇄ pill 토글 → overlay 956px(rail 44px·슬롯 absolute right:44px)·localStorage 영속·리로드 후 양방향 복원·에러 0건
- [x] `.changelog.d/pr-341.md` — 프래그먼트 문법·이중언어 요약·컴파일러 검증(`compile-changelog-fragments.mjs --check`) 완료
