### PR TITLE
feat(terminal): auto-save carrier settings

### DIFF
--- a/.changelog.d/pr-342.md
+++ b/.changelog.d/pr-342.md
@@ -1,0 +1,6 @@
+### fleet-plugin
+#### Changed
+- [fleet-console] Carrier settings now save on change instead of per-carrier Save/Discard: Runtime CLI/model/effort, display name, and Task Force row edits persist immediately, CLI switches commit as one atomic update, and Task Force backend removal requires a two-step confirm that warns when the removal would deactivate the Task Force.
+  ko: 캐리어 설정이 캐리어별 Save/Discard 대신 변경 즉시 저장됩니다. Runtime CLI/모델/effort·표시 이름·Task Force 행 편집이 즉시 반영되고, CLI 전환은 하나의 원자적 갱신으로 커밋되며, Task Force 백엔드 제거는 제거 시 Task Force가 비활성화될 때 경고하는 2단계 확인을 거칩니다.
+- [fleet-console] Switching carrier chips no longer discards unsaved edits, because carrier settings hold no draft state.
+  ko: 캐리어 설정이 draft 상태를 갖지 않으므로, 캐리어 칩 전환 시 저장하지 않은 편집이 사라지지 않습니다.

--- a/runtime/fleet-plugins/terminal/client/carriers/section.tsx
+++ b/runtime/fleet-plugins/terminal/client/carriers/section.tsx
@@ -2,25 +2,23 @@ import { useEffect, useState, type CSSProperties } from "react";
 import { defineSettingsSection } from "@fleet-console/sdk/settings/browser";
 
 import {
+  getCarrierSettingsStoreState,
   loadCarrierSettings,
-  resetCarrierSettingsDraft,
-  saveCarrierAll,
+  removeTaskForceBackend,
+  saveCarrierPatch,
+  saveTaskForceBackend,
   selectCarrierSettingsCarrier,
-  updateCarrierSettingsDraft,
-  updateCarrierSettingsTaskForceDraft,
   useCarrierSettingsStore,
 } from "./store.js";
 import type { CarrierSettingsCarrier, CarrierSettingsCliOption, CarrierSettingsModelOption } from "../../shared/carrier-settings-types.js";
 
 type CaptainColorStyle = CSSProperties & { "--cap-color": string };
 type SaveStatus = "idle" | "saving" | "saved";
-
-interface CarrierSettingsDraftView {
-  readonly cliType: string;
-  readonly model: string;
-  readonly effort: string;
-  readonly displayName: string;
-  readonly taskforce: Readonly<Record<string, { readonly model: string; readonly effort: string }>>;
+interface RuntimePendingSelections {
+  readonly carrierId?: string;
+  readonly cli?: string;
+  readonly model?: string;
+  readonly effort?: string;
 }
 
 const DISPLAY_NAME_MAX_LENGTH = 50;
@@ -45,14 +43,16 @@ export const carrierSettingsSection = defineSettingsSection({
 function CarrierSettingsSection() {
   const settings = useCarrierSettingsStore();
   const activeCarrier = settings.state?.carriers.find((carrier) => carrier.carrierId === settings.activeCarrierId) ?? null;
-  const activeCli = settings.options?.cliTypes.find((cli) => cli.id === settings.draft.cliType) ?? null;
-  const activeModel = activeCli?.models.find((model) => model.modelId === settings.draft.model) ?? null;
   const [editingDisplayName, setEditingDisplayName] = useState(false);
-  const [taskForceRows, setTaskForceRows] = useState<readonly string[]>([]);
+  const [displayName, setDisplayName] = useState("");
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
-  const isSavingAll = settings.savingActionId === "save-all";
-  const dirty = activeCarrier ? hasCarrierDraftChanges(activeCarrier, settings.draft, taskForceRows) : false;
-  const taskForceConfigKey = activeCarrier?.taskforce.backends.map((backend) => `${backend.cliType}:${backend.model}:${backend.effort ?? ""}`).join("|") ?? "";
+  const [pendingSelections, setPendingSelections] = useState<RuntimePendingSelections>({});
+  const activePendingSelections = pendingSelections.carrierId === activeCarrier?.carrierId ? pendingSelections : {};
+  const selectedCliType = activePendingSelections.cli ?? activeCarrier?.cliType;
+  const activeCli = settings.options?.cliTypes.find((cli) => cli.id === selectedCliType) ?? null;
+  const selectedModel = activePendingSelections.model ?? activeCarrier?.model;
+  const activeModel = activeCli?.models.find((model) => model.modelId === selectedModel) ?? null;
+  const isSaving = settings.savingActionId !== null;
 
   useEffect(() => {
     const controller = new AbortController();
@@ -62,9 +62,10 @@ function CarrierSettingsSection() {
 
   useEffect(() => {
     setEditingDisplayName(false);
-    setTaskForceRows(activeCarrier?.taskforce.backends.map((backend) => backend.cliType) ?? []);
+    setDisplayName(activeCarrier?.displayName ?? "");
     setSaveStatus("idle");
-  }, [activeCarrier?.carrierId, taskForceConfigKey]);
+    setPendingSelections({});
+  }, [activeCarrier?.carrierId]);
 
   useEffect(() => {
     if (saveStatus !== "saved") return;
@@ -72,24 +73,70 @@ function CarrierSettingsSection() {
     return () => window.clearTimeout(timeout);
   }, [saveStatus]);
 
-  function handleDiscard(): void {
-    if (!activeCarrier) return;
-    resetCarrierSettingsDraft();
-    setTaskForceRows(activeCarrier.taskforce.backends.map((backend) => backend.cliType));
-    setEditingDisplayName(false);
-    setSaveStatus("idle");
+  async function runCarrierSave(operation: () => Promise<boolean>): Promise<boolean> {
+    const carrierId = getCarrierSettingsStoreState().activeCarrierId;
+    setSaveStatus("saving");
+    const saved = await operation();
+    if (getCarrierSettingsStoreState().activeCarrierId === carrierId) {
+      setPendingSelections({});
+      setSaveStatus(saved ? "saved" : "idle");
+    }
+    return saved;
   }
 
-  async function handleSave(): Promise<void> {
-    if (!activeCarrier) return;
-    setSaveStatus("saving");
-    const saved = await saveCarrierAll(buildDesiredTaskForce(taskForceRows, settings.draft.taskforce));
-    if (!saved) {
-      setSaveStatus("idle");
-      return;
-    }
+  async function commitDisplayName(): Promise<void> {
+    if (!activeCarrier || isSaving) return;
     setEditingDisplayName(false);
-    setSaveStatus("saved");
+    if (displayName === activeCarrier.displayName) return;
+    await runCarrierSave(() => saveCarrierPatch({ displayName }));
+  }
+
+  function cancelDisplayName(): void {
+    setDisplayName(activeCarrier?.displayName ?? "");
+    setEditingDisplayName(false);
+  }
+
+  async function handleCliChange(cliType: string): Promise<void> {
+    const cli = settings.options?.cliTypes.find((item) => item.id === cliType);
+    const model = cli?.models.find((item) => item.modelId === cli.defaultModel) ?? cli?.models[0] ?? null;
+    if (!activeCarrier || !cli || !model) return;
+    setPendingSelections({
+      carrierId: activeCarrier.carrierId,
+      cli: cliType,
+      model: model.modelId,
+      effort: model.effort?.default ?? "",
+    });
+    await runCarrierSave(() => saveCarrierPatch({
+      cli: cliType,
+      model: {
+        model: model.modelId,
+        ...(model.effort?.default ? { effort: model.effort.default } : {}),
+      },
+    }));
+  }
+
+  async function handleModelChange(modelId: string): Promise<void> {
+    if (!activeCarrier) return;
+    // 모델 전환 시 effort는 신 모델 기본값으로 리셋한다. 구 effort를 유지하면 effort 미지원/레벨 불일치
+    // 모델에서 서버 readSelection이 400을 반환한다(구 draft 흐름의 리셋 동작과 동일 계약).
+    const nextModel = activeCli?.models.find((model) => model.modelId === modelId) ?? null;
+    setPendingSelections({
+      carrierId: activeCarrier.carrierId,
+      model: modelId,
+      effort: nextModel?.effort?.default ?? "",
+    });
+    await runCarrierSave(() => saveCarrierPatch({
+      model: {
+        model: modelId,
+        ...(nextModel?.effort?.default ? { effort: nextModel.effort.default } : {}),
+      },
+    }));
+  }
+
+  async function handleEffortChange(effort: string): Promise<void> {
+    if (!activeCarrier) return;
+    setPendingSelections({ carrierId: activeCarrier.carrierId, effort });
+    await runCarrierSave(() => saveCarrierPatch({ model: { model: activeCarrier.model, effort } }));
   }
 
   return (
@@ -122,27 +169,37 @@ function CarrierSettingsSection() {
                         id="carrier-display-name"
                         className="terminal-carriers-input terminal-carriers-name-input"
                         aria-label="Display name"
-                        value={settings.draft.displayName}
+                        value={displayName}
                         maxLength={DISPLAY_NAME_MAX_LENGTH}
-                        onChange={(event) => updateCarrierSettingsDraft({ displayName: event.target.value })}
+                        disabled={isSaving}
+                        onChange={(event) => setDisplayName(event.target.value)}
+                        onBlur={(event) => {
+                          const next = event.relatedTarget;
+                          if (next instanceof HTMLElement && next.closest("[data-display-name-action]")) return;
+                          void commitDisplayName();
+                        }}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") {
+                            event.preventDefault();
+                            void commitDisplayName();
+                          } else if (event.key === "Escape") {
+                            event.preventDefault();
+                            cancelDisplayName();
+                          }
+                        }}
                       />
-                      <button type="button" className="terminal-carriers-icon-button" aria-label="Save display name" disabled={isSavingAll} onClick={() => {
-                        setEditingDisplayName(false);
-                      }}>
+                      <button type="button" className="terminal-carriers-icon-button" data-display-name-action aria-label="Save display name" disabled={isSaving} onClick={() => void commitDisplayName()}>
                         <CheckIcon />
                       </button>
-                      <button type="button" className="terminal-carriers-icon-button" aria-label="Cancel display name edit" onClick={() => {
-                        updateCarrierSettingsDraft({ displayName: activeCarrier.displayName });
-                        setEditingDisplayName(false);
-                      }}>
+                      <button type="button" className="terminal-carriers-icon-button" data-display-name-action aria-label="Cancel display name edit" onClick={cancelDisplayName}>
                         <CloseIcon />
                       </button>
                     </>
                   ) : (
                     <>
                       <h3 className="terminal-carriers-captain-name">{activeCarrier.displayName}</h3>
-                      <button type="button" className="terminal-carriers-icon-button" aria-label="Edit display name" onClick={() => {
-                        updateCarrierSettingsDraft({ displayName: activeCarrier.displayName });
+                      <button type="button" className="terminal-carriers-icon-button" aria-label="Edit display name" disabled={isSaving} onClick={() => {
+                        setDisplayName(activeCarrier.displayName);
                         setEditingDisplayName(true);
                       }}>
                         <PencilIcon />
@@ -154,16 +211,10 @@ function CarrierSettingsSection() {
               </div>
               <div className="terminal-carriers-detail-actions">
                 <div className={`terminal-carriers-save-status ${saveStatus === "saved" ? "is-positive" : ""}`} role="status" aria-live="polite">
-                  {saveStatus === "saving" || isSavingAll ? "Saving…" : saveStatus === "saved" ? "Saved ✓" : ""}
+                  {saveStatus === "saving" ? "Saving…" : saveStatus === "saved" ? "Saved ✓" : ""}
                 </div>
                 <div className="terminal-carriers-save-actions">
-                  <button type="button" className={`terminal-carriers-action-button ${dirty ? "is-dirty" : ""}`} disabled={!dirty || isSavingAll} onClick={() => void handleSave()}>
-                    Save
-                  </button>
-                  <button type="button" className={`terminal-carriers-action-button ${dirty ? "is-dirty" : ""}`} disabled={!dirty || isSavingAll} onClick={handleDiscard}>
-                    Discard
-                  </button>
-                  <button type="button" className="terminal-carriers-action-button terminal-carriers-detail-refresh" disabled={settings.loading} onClick={() => void loadCarrierSettings()}>
+                  <button type="button" className="terminal-carriers-action-button terminal-carriers-detail-refresh" disabled={settings.loading || isSaving} onClick={() => void loadCarrierSettings()}>
                     Refresh
                   </button>
                 </div>
@@ -185,8 +236,9 @@ function CarrierSettingsSection() {
                       <select
                         id="carrier-cli"
                         className="terminal-carriers-select"
-                        value={settings.draft.cliType}
-                        onChange={(event) => handleCliDraftChange(event.target.value, settings.options?.cliTypes ?? [])}
+                        value={activePendingSelections.cli ?? activeCarrier.cliType}
+                        disabled={isSaving}
+                        onChange={(event) => void handleCliChange(event.target.value)}
                       >
                         {settings.options.cliTypes.map((cli) => <option key={cli.id} value={cli.id}>{cli.displayName}</option>)}
                       </select>
@@ -197,14 +249,16 @@ function CarrierSettingsSection() {
                       id="carrier-model"
                       label="Model"
                       models={activeCli.models}
-                      value={settings.draft.model}
-                      onChange={(modelId) => handleModelDraftChange(activeCli, modelId)}
+                      value={activePendingSelections.model ?? activeCarrier.model}
+                      disabled={isSaving}
+                      onChange={(modelId) => void handleModelChange(modelId)}
                     />
                     <EffortSelect
                       id="carrier-effort"
                       model={activeModel}
-                      value={settings.draft.effort}
-                      onChange={(effort) => updateCarrierSettingsDraft({ effort })}
+                      value={activePendingSelections.effort ?? activeCarrier.effort ?? ""}
+                      disabled={isSaving}
+                      onChange={(effort) => void handleEffortChange(effort)}
                     />
                   </div>
                 </div>
@@ -216,8 +270,7 @@ function CarrierSettingsSection() {
                   cliOptions={settings.options.cliTypes}
                   minBackends={settings.options.taskForceConstraints.minBackends}
                   savingActionId={settings.savingActionId}
-                  rows={taskForceRows}
-                  onRowsChange={setTaskForceRows}
+                  stateGeneration={settings.state?.generation ?? 0}
                 />
               ) : null}
             </div>
@@ -281,25 +334,108 @@ function TaskForcePanel({
   cliOptions,
   minBackends,
   savingActionId,
-  rows,
-  onRowsChange,
+  stateGeneration,
 }: {
   readonly carrier: CarrierSettingsCarrier;
   readonly cliOptions: readonly CarrierSettingsCliOption[];
   readonly minBackends: number;
   readonly savingActionId: string | null;
-  readonly rows: readonly string[];
-  readonly onRowsChange: (rows: readonly string[]) => void;
+  readonly stateGeneration: number;
 }) {
-  const settings = useCarrierSettingsStore();
   // 구성된 백엔드가 있으면 기본 펼침, 없으면 접힘. detail이 carrierId로 remount되어 캐리어별로 재초기화된다.
   const configuredCount = carrier.taskforce.backends.length;
   const [expanded, setExpanded] = useState(configuredCount > 0);
   const [addOpen, setAddOpen] = useState(false);
   const [addCliType, setAddCliType] = useState("");
+  const [armedCliType, setArmedCliType] = useState<string | null>(null);
+  const [rowStatuses, setRowStatuses] = useState<Readonly<Record<string, SaveStatus>>>({});
+  const [pendingSelections, setPendingSelections] = useState<Readonly<Record<string, string>>>({});
   const active = carrier.taskforce.backends.length >= minBackends;
-  const availableCliOptions = cliOptions.filter((cli) => !rows.includes(cli.id));
+  const availableCliOptions = cliOptions.filter((cli) => !carrier.taskforce.backends.some((backend) => backend.cliType === cli.id));
   const selectedAddCliType = addCliType || availableCliOptions[0]?.id || "";
+  const isSaving = savingActionId !== null;
+
+  useEffect(() => {
+    setArmedCliType(null);
+  }, [stateGeneration]);
+
+  useEffect(() => {
+    if (!armedCliType) return;
+    const clearArmForDifferentControl = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element) || !target.closest(`[data-remove-cli="${armedCliType}"]`)) setArmedCliType(null);
+    };
+    document.addEventListener("click", clearArmForDifferentControl, true);
+    return () => document.removeEventListener("click", clearArmForDifferentControl, true);
+  }, [armedCliType]);
+
+  useEffect(() => {
+    const savedCliTypes = Object.entries(rowStatuses)
+      .filter(([, status]) => status === "saved")
+      .map(([cliType]) => cliType);
+    if (savedCliTypes.length === 0) return;
+    const timeout = window.setTimeout(() => {
+      setRowStatuses((current) => {
+        const next = { ...current };
+        for (const cliType of savedCliTypes) next[cliType] = "idle";
+        return next;
+      });
+    }, SAVE_FEEDBACK_DURATION_MS);
+    return () => window.clearTimeout(timeout);
+  }, [rowStatuses]);
+
+  async function saveBackend(
+    cliType: string,
+    model: string,
+    effort: string,
+    pending: Readonly<Record<string, string>> = {},
+  ): Promise<boolean> {
+    const carrierId = carrier.carrierId;
+    setPendingSelections((current) => ({ ...current, ...pending }));
+    setRowStatuses((current) => ({ ...current, [cliType]: "saving" }));
+    const saved = await saveTaskForceBackend(cliType, {
+      model,
+      ...(effort ? { effort } : {}),
+    });
+    if (getCarrierSettingsStoreState().activeCarrierId === carrierId) {
+      setPendingSelections({});
+      setRowStatuses((current) => ({ ...current, [cliType]: saved ? "saved" : "idle" }));
+      if (saved) setArmedCliType(null);
+    }
+    return saved;
+  }
+
+  async function handleBackendModelChange(cli: CarrierSettingsCliOption, modelId: string): Promise<void> {
+    const backend = carrier.taskforce.backends.find((item) => item.cliType === cli.id);
+    if (!backend) return;
+    // Runtime과 동일 계약: 모델 전환 시 effort는 신 모델 기본값으로 리셋(서버 readSelection 400 방지).
+    const nextModel = cli.models.find((item) => item.modelId === modelId) ?? null;
+    const effort = nextModel?.effort?.default ?? "";
+    await saveBackend(cli.id, modelId, effort, {
+      [`tf:${cli.id}:model`]: modelId,
+      [`tf:${cli.id}:effort`]: effort,
+    });
+  }
+
+  async function handleBackendEffortChange(cliType: string, model: string, effort: string): Promise<void> {
+    await saveBackend(cliType, model, effort, { [`tf:${cliType}:effort`]: effort });
+  }
+
+  async function handleRemove(cliType: string): Promise<void> {
+    if (armedCliType !== cliType) {
+      setArmedCliType(cliType);
+      return;
+    }
+    const carrierId = carrier.carrierId;
+    setRowStatuses((current) => ({ ...current, [cliType]: "saving" }));
+    const removed = await removeTaskForceBackend(cliType);
+    if (getCarrierSettingsStoreState().activeCarrierId === carrierId) {
+      setPendingSelections({});
+      setRowStatuses((current) => ({ ...current, [cliType]: removed ? "saved" : "idle" }));
+      if (removed) setArmedCliType(null);
+    }
+  }
+
   return (
     <div className={`terminal-carriers-control-group terminal-carriers-control-group--taskforce ${expanded ? "is-expanded" : ""}`}>
       <div className="terminal-carriers-section-head">
@@ -319,24 +455,39 @@ function TaskForcePanel({
       </div>
       {expanded ? (
       <div className="terminal-carriers-tf-list">
-        {rows.length === 0 ? <p className="terminal-carriers-tf-empty">No Task Force backend drafted.</p> : null}
-        {rows.map((cliType) => {
-          const cli = cliOptions.find((item) => item.id === cliType);
+        {carrier.taskforce.backends.length === 0 ? <p className="terminal-carriers-tf-empty">No Task Force backend configured.</p> : null}
+        {carrier.taskforce.backends.map((backend) => {
+          const cli = cliOptions.find((item) => item.id === backend.cliType);
           if (!cli) return null;
-          const draft = settings.draft.taskforce[cli.id] ?? { model: cli.defaultModel, effort: "" };
-          const model = cli.models.find((item) => item.modelId === draft.model) ?? cli.models[0] ?? null;
-          const active = carrier.taskforce.backends.some((backend) => backend.cliType === cli.id);
+          const modelValue = pendingSelections[`tf:${cli.id}:model`] ?? backend.model;
+          const effortValue = pendingSelections[`tf:${cli.id}:effort`] ?? backend.effort ?? "";
+          const model = cli.models.find((item) => item.modelId === modelValue) ?? cli.models[0] ?? null;
+          const rowStatus = rowStatuses[cli.id] ?? "idle";
+          const armed = armedCliType === cli.id;
+          const removeLabel = carrier.taskforce.backends.length - 1 < minBackends
+            ? "Confirm — TF deactivates"
+            : "Confirm remove";
           return (
-            <div className={`terminal-carriers-tf-item ${active ? "is-active" : ""}`} key={cli.id}>
+            <div className="terminal-carriers-tf-item is-active" key={cli.id}>
               <div className="terminal-carriers-tf-title">
                 <span className={`terminal-carriers-live-dot ${active ? "is-live" : ""}`} aria-hidden="true" />
                 <strong>{cli.displayName}</strong>
+                <span className={`terminal-carriers-tf-status ${rowStatus === "saved" ? "is-positive" : ""}`} role="status" aria-live="polite">
+                  {rowStatus === "saving" ? "Saving…" : rowStatus === "saved" ? "Saved ✓" : ""}
+                </span>
               </div>
-              <ModelSelect id={`tf-${cli.id}-model`} label="Model" models={cli.models} value={draft.model} onChange={(modelId) => handleTaskForceModelDraftChange(cli, modelId)} />
-              <EffortSelect id={`tf-${cli.id}-effort`} model={model} value={draft.effort} onChange={(effort) => updateCarrierSettingsTaskForceDraft(cli.id, { effort })} />
+              <ModelSelect id={`tf-${cli.id}-model`} label="Model" models={cli.models} value={modelValue} disabled={isSaving} onChange={(modelId) => void handleBackendModelChange(cli, modelId)} />
+              <EffortSelect id={`tf-${cli.id}-effort`} model={model} value={effortValue} disabled={isSaving} onChange={(effort) => void handleBackendEffortChange(cli.id, modelValue, effort)} />
               <div className="terminal-carriers-tf-actions">
-                <button type="button" className="terminal-carriers-ghost-button" disabled={savingActionId === "save-all"} onClick={() => onRowsChange(rows.filter((item) => item !== cli.id))}>
-                  Remove
+                <button
+                  type="button"
+                  className={`terminal-carriers-ghost-button terminal-carriers-tf-remove ${armed ? "is-armed" : ""}`}
+                  data-remove-cli={cli.id}
+                  aria-label={armed ? `Confirm removal of ${cli.displayName} backend` : undefined}
+                  disabled={isSaving}
+                  onClick={() => void handleRemove(cli.id)}
+                >
+                  {armed ? removeLabel : "Remove"}
                 </button>
               </div>
             </div>
@@ -344,11 +495,11 @@ function TaskForcePanel({
         })}
         <div className="terminal-carriers-tf-add-row">
           {addOpen && availableCliOptions.length > 0 ? (
-            <select className="terminal-carriers-select terminal-carriers-tf-add-select" value={selectedAddCliType} onChange={(event) => setAddCliType(event.target.value)} aria-label="Task Force CLI to add">
+            <select className="terminal-carriers-select terminal-carriers-tf-add-select" value={selectedAddCliType} disabled={isSaving} onChange={(event) => setAddCliType(event.target.value)} aria-label="Task Force CLI to add">
               {availableCliOptions.map((cli) => <option key={cli.id} value={cli.id}>{cli.displayName}</option>)}
             </select>
           ) : null}
-          <button type="button" className="terminal-carriers-ghost-button" disabled={availableCliOptions.length === 0 || savingActionId === "save-all"} onClick={() => {
+          <button type="button" className="terminal-carriers-ghost-button" disabled={availableCliOptions.length === 0 || isSaving} onClick={() => {
             if (!addOpen) {
               setAddOpen(true);
               return;
@@ -357,10 +508,11 @@ function TaskForcePanel({
             const cli = cliOptions.find((item) => item.id === cliType);
             const model = cli?.models.find((item) => item.modelId === cli.defaultModel) ?? cli?.models[0] ?? null;
             if (!cli || !model) return;
-            updateCarrierSettingsTaskForceDraft(cli.id, { model: model.modelId, effort: model.effort?.default ?? "" });
-            onRowsChange(rows.includes(cli.id) ? rows : [...rows, cli.id]);
-            setAddCliType("");
-            setAddOpen(false);
+            void saveBackend(cli.id, model.modelId, model.effort?.default ?? "").then((saved) => {
+              if (!saved) return;
+              setAddCliType("");
+              setAddOpen(false);
+            });
           }}>
             Add
           </button>
@@ -369,66 +521,6 @@ function TaskForcePanel({
       ) : null}
     </div>
   );
-}
-
-function handleCliDraftChange(cliType: string, cliOptions: readonly CarrierSettingsCliOption[]): void {
-  const cli = cliOptions.find((item) => item.id === cliType);
-  const model = cli?.models.find((item) => item.modelId === cli.defaultModel) ?? cli?.models[0] ?? null;
-  updateCarrierSettingsDraft({
-    cliType,
-    model: model?.modelId ?? "",
-    effort: model?.effort?.default ?? "",
-  });
-}
-
-function handleModelDraftChange(cli: CarrierSettingsCliOption, modelId: string): void {
-  const model = cli.models.find((item) => item.modelId === modelId);
-  updateCarrierSettingsDraft({
-    model: modelId,
-    effort: model?.effort?.default ?? "",
-  });
-}
-
-function handleTaskForceModelDraftChange(cli: CarrierSettingsCliOption, modelId: string): void {
-  const model = cli.models.find((item) => item.modelId === modelId);
-  updateCarrierSettingsTaskForceDraft(cli.id, {
-    model: modelId,
-    effort: model?.effort?.default ?? "",
-  });
-}
-
-function hasCarrierDraftChanges(carrier: CarrierSettingsCarrier, draft: CarrierSettingsDraftView, rows: readonly string[]): boolean {
-  if (draft.displayName !== carrier.displayName) return true;
-  if (draft.cliType !== carrier.cliType) return true;
-  if (draft.model !== carrier.model) return true;
-  if ((draft.effort || "") !== (carrier.effort || "")) return true;
-  return hasTaskForceChanges(carrier, rows, draft.taskforce);
-}
-
-function hasTaskForceChanges(carrier: CarrierSettingsCarrier, rows: readonly string[], draft: Readonly<Record<string, { readonly model: string; readonly effort: string }>>): boolean {
-  if (rows.length !== carrier.taskforce.backends.length) return true;
-  const rowSet = new Set(rows);
-  for (const backend of carrier.taskforce.backends) {
-    if (!rowSet.has(backend.cliType)) return true;
-    const selection = draft[backend.cliType];
-    if (!selection) return true;
-    if (selection.model !== backend.model) return true;
-    if ((selection.effort || "") !== (backend.effort || "")) return true;
-  }
-  return false;
-}
-
-function buildDesiredTaskForce(rows: readonly string[], draft: CarrierSettingsDraftView["taskforce"]): readonly { readonly cliType: string; readonly model: string; readonly effort?: string }[] {
-  return rows
-    .map((cliType) => {
-      const selection = draft[cliType];
-      return selection ? {
-        cliType,
-        model: selection.model,
-        ...(selection.effort ? { effort: selection.effort } : {}),
-      } : null;
-    })
-    .filter((backend): backend is { readonly cliType: string; readonly model: string; readonly effort?: string } => backend !== null);
 }
 
 function getCaptainColorStyle(carrierId: string): CaptainColorStyle {

--- a/runtime/fleet-plugins/terminal/client/carriers/store.ts
+++ b/runtime/fleet-plugins/terminal/client/carriers/store.ts
@@ -7,20 +7,17 @@ import {
   patchCarrier,
   setCarrierTaskForceBackend,
 } from "./api.js";
-import type { CarrierSettingsCarrier, CarrierSettingsOptions, CarrierSettingsState } from "../../shared/carrier-settings-types.js";
+import type { CarrierSettingsOptions, CarrierSettingsState } from "../../shared/carrier-settings-types.js";
 
-interface CarrierSettingsDraft {
-  readonly cliType: string;
-  readonly model: string;
-  readonly effort: string;
-  readonly displayName: string;
-  readonly taskforce: Readonly<Record<string, { readonly model: string; readonly effort: string }>>;
-}
-
-export interface CarrierSettingsTaskForceSaveInput {
-  readonly cliType: string;
+interface ModelSelection {
   readonly model: string;
   readonly effort?: string;
+}
+
+export interface CarrierSettingsPatch {
+  readonly cli?: string;
+  readonly model?: ModelSelection;
+  readonly displayName?: string;
 }
 
 interface CarrierSettingsStoreState {
@@ -28,20 +25,11 @@ interface CarrierSettingsStoreState {
   readonly state: CarrierSettingsState | null;
   readonly options: CarrierSettingsOptions | null;
   readonly activeCarrierId: string | null;
-  readonly draft: CarrierSettingsDraft;
   readonly savingActionId: string | null;
   readonly error: string | null;
 }
 
 type Listener = () => void;
-
-const EMPTY_DRAFT: CarrierSettingsDraft = {
-  cliType: "",
-  model: "",
-  effort: "",
-  displayName: "",
-  taskforce: {},
-};
 
 const listeners = new Set<Listener>();
 let snapshot: CarrierSettingsStoreState = {
@@ -49,7 +37,6 @@ let snapshot: CarrierSettingsStoreState = {
   state: null,
   options: null,
   activeCarrierId: null,
-  draft: EMPTY_DRAFT,
   savingActionId: null,
   error: null,
 };
@@ -84,72 +71,37 @@ export async function loadCarrierSettings(signal?: AbortSignal): Promise<void> {
 }
 
 export function selectCarrierSettingsCarrier(carrierId: string): void {
-  const carrier = snapshot.state?.carriers.find((item) => item.carrierId === carrierId);
   setSnapshot({
     activeCarrierId: carrierId,
-    draft: carrier ? buildDraft(carrier, snapshot.options) : snapshot.draft,
     error: null,
   });
 }
 
-export function updateCarrierSettingsDraft(patch: Partial<CarrierSettingsDraft>): void {
-  setSnapshot({ draft: { ...snapshot.draft, ...patch }, error: null });
-}
-
-export function updateCarrierSettingsTaskForceDraft(cliType: string, patch: { readonly model?: string; readonly effort?: string }): void {
-  const current = snapshot.draft.taskforce[cliType] ?? { model: "", effort: "" };
-  setSnapshot({
-    draft: {
-      ...snapshot.draft,
-      taskforce: {
-        ...snapshot.draft.taskforce,
-        [cliType]: { ...current, ...patch },
-      },
-    },
-    error: null,
-  });
-}
-
-export function resetCarrierSettingsDraft(): void {
+export async function saveCarrierPatch(patch: CarrierSettingsPatch): Promise<boolean> {
   const carrier = getActiveCarrier();
-  if (!carrier) return;
-  setSnapshot({ draft: buildDraft(carrier, snapshot.options), error: null });
+  if (!carrier || snapshot.savingActionId !== null) return false;
+  return runMutation("carrier-patch", () => patchCarrier(carrier.carrierId, patch));
 }
 
-export async function saveCarrierAll(desiredTaskForce: readonly CarrierSettingsTaskForceSaveInput[]): Promise<boolean> {
+export async function saveTaskForceBackend(cliType: string, selection: ModelSelection): Promise<boolean> {
   const carrier = getActiveCarrier();
-  if (!carrier) return false;
-  return runMutation("save-all", async () => {
-    const draft = snapshot.draft;
-    let latestState: CarrierSettingsState | null = null;
-    if (draft.displayName !== carrier.displayName) {
-      latestState = (await patchCarrier(carrier.carrierId, { displayName: draft.displayName })).state;
-    }
-    const cliChanged = draft.cliType !== carrier.cliType;
-    if (cliChanged) {
-      latestState = (await patchCarrier(carrier.carrierId, { cli: draft.cliType })).state;
-    }
-    // CLI 변경 시 patchCarrier({ cli }) 가 대상 CLI에 저장돼 있던 이전 선택을 복원할 수 있다.
-    // 변경 전(구 CLI) carrier와의 모델 비교만으로 PATCH를 건너뛰면, 신 CLI 기본값이 구 CLI
-    // 모델과 우연히 같을 때 복원된 선택이 draft와 다르게 저장된다. CLI가 바뀌었으면 항상
-    // draft 모델을 명시 전송해 사용자가 본 draft 선택이 우선되게 한다.
-    if (cliChanged || draft.model !== carrier.model || (draft.effort || "") !== (carrier.effort || "")) {
-      latestState = (await patchCarrier(carrier.carrierId, { model: selectionFromDraft(draft) })).state;
-    }
-    latestState = await saveTaskForceForCarrier(carrier, desiredTaskForce, latestState);
-    return { state: latestState ?? await fetchCarrierSettingsState() };
-  });
+  if (!carrier || snapshot.savingActionId !== null) return false;
+  return runMutation(`taskforce-save:${cliType}`, () => setCarrierTaskForceBackend(carrier.carrierId, cliType, selection));
 }
 
-function hydrateCarrierSettings(state: CarrierSettingsState, options: CarrierSettingsOptions): void {
+export async function removeTaskForceBackend(cliType: string): Promise<boolean> {
+  const carrier = getActiveCarrier();
+  if (!carrier || snapshot.savingActionId !== null) return false;
+  return runMutation(`taskforce-remove:${cliType}`, () => deleteCarrierTaskForceBackend(carrier.carrierId, cliType));
+}
+
+export function hydrateCarrierSettings(state: CarrierSettingsState, options: CarrierSettingsOptions): void {
   const activeCarrierId = resolveActiveCarrierId(state, snapshot.activeCarrierId);
-  const carrier = state.carriers.find((item) => item.carrierId === activeCarrierId) ?? null;
   setSnapshot({
     loading: false,
     state,
     options,
     activeCarrierId,
-    draft: carrier ? buildDraft(carrier, options) : snapshot.draft,
     error: null,
   });
 }
@@ -162,67 +114,16 @@ async function runMutation(actionId: string, operation: () => Promise<{ readonly
     setSnapshot({ savingActionId: null });
     return true;
   } catch (error) {
-    setSnapshot({ savingActionId: null, error: toErrorMessage(error) });
+    const message = toErrorMessage(error);
+    setSnapshot({ error: message });
+    await loadCarrierSettings();
+    setSnapshot({ savingActionId: null, error: message });
     return false;
   }
 }
 
-function buildDraft(carrier: CarrierSettingsCarrier, options: CarrierSettingsOptions | null): CarrierSettingsDraft {
-  const taskforce = Object.fromEntries(
-    (options?.cliTypes ?? []).map((cli) => {
-      const backend = carrier.taskforce.backends.find((item) => item.cliType === cli.id);
-      return [cli.id, {
-        model: backend?.model ?? cli.defaultModel,
-        effort: backend?.effort ?? defaultEffortForModel(cli.id, backend?.model ?? cli.defaultModel, options) ?? "",
-      }];
-    }),
-  );
-  return {
-    cliType: carrier.cliType,
-    model: carrier.model,
-    effort: carrier.effort ?? "",
-    displayName: carrier.displayName,
-    taskforce,
-  };
-}
-
-function defaultEffortForModel(cliType: string, modelId: string, options: CarrierSettingsOptions | null): string | null {
-  const cli = options?.cliTypes.find((item) => item.id === cliType);
-  const model = cli?.models.find((item) => item.modelId === modelId);
-  return model?.effort?.default ?? null;
-}
-
-function selectionFromDraft(draft: CarrierSettingsDraft): { readonly model: string; readonly effort?: string } {
-  return {
-    model: draft.model,
-    ...(draft.effort ? { effort: draft.effort } : {}),
-  };
-}
-
-function getActiveCarrier(): CarrierSettingsCarrier | null {
+function getActiveCarrier() {
   return snapshot.state?.carriers.find((carrier) => carrier.carrierId === snapshot.activeCarrierId) ?? null;
-}
-
-async function saveTaskForceForCarrier(
-  carrier: CarrierSettingsCarrier,
-  desired: readonly CarrierSettingsTaskForceSaveInput[],
-  latestState: CarrierSettingsState | null,
-): Promise<CarrierSettingsState | null> {
-  const desiredCliTypes = new Set(desired.map((backend) => backend.cliType));
-  for (const backend of carrier.taskforce.backends) {
-    if (!desiredCliTypes.has(backend.cliType)) {
-      latestState = (await deleteCarrierTaskForceBackend(carrier.carrierId, backend.cliType)).state;
-    }
-  }
-  for (const backend of desired) {
-    const current = carrier.taskforce.backends.find((item) => item.cliType === backend.cliType);
-    if (current && current.model === backend.model && (current.effort || "") === (backend.effort || "")) continue;
-    latestState = (await setCarrierTaskForceBackend(carrier.carrierId, backend.cliType, {
-      model: backend.model,
-      ...(backend.effort ? { effort: backend.effort } : {}),
-    })).state;
-  }
-  return latestState;
 }
 
 function resolveActiveCarrierId(state: CarrierSettingsState, activeCarrierId: string | null): string | null {

--- a/runtime/fleet-plugins/terminal/client/carriers/styles.css
+++ b/runtime/fleet-plugins/terminal/client/carriers/styles.css
@@ -28,12 +28,6 @@
   transform: translateY(1px);
 }
 
-/* 변경사항 있을 때(dirty) Save/Discard를 brass로 하이라이트 — GNB active와 동일 어휘. */
-.terminal-carriers-action-button.is-dirty {
-  color: var(--brass-bright);
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
-}
-
 .terminal-carriers-action-button:disabled {
   color: var(--ink-rim);
   cursor: not-allowed;
@@ -118,11 +112,6 @@
   background: var(--aurora);
   box-shadow: 0 0 10px var(--aurora-glow);
   animation: aurora-pulse 1.8s ease-in-out infinite;
-}
-
-/* 순서: SAVE, DISCARD, (조금 간격) REFRESH */
-.terminal-carriers-detail-refresh {
-  margin-left: var(--space-3);
 }
 
 .terminal-carriers-card {
@@ -507,6 +496,28 @@
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.terminal-carriers-tf-status {
+  margin-left: auto;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.terminal-carriers-tf-status.is-positive {
+  color: var(--positive);
+}
+
+.terminal-carriers-tf-remove {
+  border: 1px solid transparent;
+}
+
+.terminal-carriers-tf-remove.is-armed {
+  border-color: color-mix(in oklch, var(--coral) 55%, var(--surface-rim));
+  background: color-mix(in oklch, var(--coral) 10%, transparent);
+  color: var(--coral);
 }
 
 .terminal-carriers-tf-add-row,

--- a/runtime/fleet-plugins/terminal/tests/carrier-settings-client.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/carrier-settings-client.test.ts
@@ -8,9 +8,8 @@ import { fetchCarrierSettingsState } from "../client/carriers/api.js";
 import {
   getCarrierSettingsStoreState,
   loadCarrierSettings,
-  resetCarrierSettingsDraft,
+  saveCarrierPatch,
   selectCarrierSettingsCarrier,
-  updateCarrierSettingsDraft,
 } from "../client/carriers/store.js";
 import { carrierSettingsSection } from "../client/carriers/section.js";
 
@@ -27,15 +26,26 @@ const options = {
 };
 const captainIds = ["nimitz", "kirov", "genesis", "ohio", "sentinel", "vanguard", "tempest", "chronicle"] as const;
 const interactiveOptions = {
-  cliTypes: [{
-    id: "codex",
-    displayName: "Codex",
-    defaultModel: "gpt-5",
-    models: [
-      { modelId: "gpt-5", name: "GPT-5" },
-      { modelId: "gpt-5-mini", name: "GPT-5 mini" },
-    ],
-  }],
+  cliTypes: [
+    {
+      id: "codex",
+      displayName: "Codex",
+      defaultModel: "gpt-5",
+      models: [
+        { modelId: "gpt-5", name: "GPT-5" },
+        { modelId: "gpt-5-mini", name: "GPT-5 mini" },
+      ],
+    },
+    {
+      id: "claude",
+      displayName: "Claude",
+      defaultModel: "sonnet",
+      models: [
+        { modelId: "sonnet", name: "Sonnet", effort: { levels: ["low", "high"], default: "high" } },
+        { modelId: "haiku", name: "Haiku", effort: { levels: ["low", "high"], default: "low" } },
+      ],
+    },
+  ],
   taskForceConstraints: { minBackends: 2 },
 };
 const interactiveState = {
@@ -85,7 +95,7 @@ describe("Terminal Carrier Settings client", () => {
     await expect(fetchCarrierSettingsState()).rejects.toThrow("restricted field");
   });
 
-  it("loads, selects, drafts, and discards Carrier edits", async () => {
+  it("loads and selects Carrier settings without draft state", async () => {
     vi.stubGlobal("fetch", vi.fn()
       .mockResolvedValueOnce(new Response(JSON.stringify(state), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify(options), { status: 200 })));
@@ -93,10 +103,8 @@ describe("Terminal Carrier Settings client", () => {
     await loadCarrierSettings();
     expect(getCarrierSettingsStoreState().activeCarrierId).toBe("kirov");
     selectCarrierSettingsCarrier("kirov");
-    updateCarrierSettingsDraft({ displayName: "Draft Kirov" });
-    expect(getCarrierSettingsStoreState().draft.displayName).toBe("Draft Kirov");
-    resetCarrierSettingsDraft();
-    expect(getCarrierSettingsStoreState().draft.displayName).toBe("Kirov");
+    expect(getCarrierSettingsStoreState().activeCarrierId).toBe("kirov");
+    expect(getCarrierSettingsStoreState()).not.toHaveProperty("draft");
   });
 
   it("exports the reserved Settings section identity", () => {
@@ -138,27 +146,193 @@ describe("Terminal Carrier Settings client", () => {
     if (!cancelNameEdit) throw new Error("Display-name cancel button must render.");
     await act(async () => cancelNameEdit.dispatchEvent(new MouseEvent("click", { bubbles: true })));
 
-    const model = container!.querySelector<HTMLSelectElement>("#carrier-model");
-    if (!model) throw new Error("Carrier model select must render.");
-    model.value = "gpt-5-mini";
-    await act(async () => model.dispatchEvent(new Event("change", { bubbles: true })));
-    const save = actionButton("Save");
-    const discard = actionButton("Discard");
-    expect(save.classList.contains("is-dirty")).toBe(true);
-    expect(discard.classList.contains("is-dirty")).toBe(true);
-    expect(save.disabled).toBe(false);
-    expect(discard.disabled).toBe(false);
-
-    await act(async () => discard.dispatchEvent(new MouseEvent("click", { bubbles: true })));
-    expect(model.value).toBe("gpt-5");
-    expect(actionButton("Save").disabled).toBe(true);
-    expect(actionButton("Discard").disabled).toBe(true);
+    expect(actionButton("Refresh")).not.toBeNull();
+    expect(container!.textContent).not.toContain("Discard");
+    expect(actionButtonOrNull("Save")).toBeNull();
     expect(container!.querySelector(".terminal-carriers-page, .terminal-carriers-grid, .terminal-carriers-row")).toBeNull();
 
     nextState = emptyState;
     await act(async () => loadCarrierSettings());
     expect(strip?.textContent).toContain("No carriers registered.");
     expect(container!.querySelector(".terminal-carriers-card")?.textContent).toContain("Select a carrier.");
+  });
+
+  it("PATCHes a model change immediately", async () => {
+    const fetch = installInteractiveFetch();
+    await loadCarrierSettings();
+    selectCarrierSettingsCarrier("nimitz");
+    await renderCarrierSettings();
+
+    const model = requiredSelect("#carrier-model");
+    model.value = "gpt-5-mini";
+    await act(async () => model.dispatchEvent(new Event("change", { bubbles: true })));
+    await waitForRequest(fetch, "PATCH");
+
+    expect(mutationCalls(fetch)).toEqual([
+      expect.objectContaining({
+        url: "/api/v1/plugins/terminal/carriers/nimitz",
+        method: "PATCH",
+        body: { model: { model: "gpt-5-mini" } },
+      }),
+    ]);
+  });
+
+  it("PATCHes CLI with its default model and effort atomically", async () => {
+    const fetch = installInteractiveFetch();
+    await loadCarrierSettings();
+    selectCarrierSettingsCarrier("nimitz");
+    await renderCarrierSettings();
+
+    const cli = requiredSelect("#carrier-cli");
+    cli.value = "claude";
+    await act(async () => cli.dispatchEvent(new Event("change", { bubbles: true })));
+    await waitForRequest(fetch, "PATCH");
+
+    expect(mutationCalls(fetch)).toEqual([
+      expect.objectContaining({
+        method: "PATCH",
+        body: { cli: "claude", model: { model: "sonnet", effort: "high" } },
+      }),
+    ]);
+  });
+
+  it("does not settle CLI feedback onto a carrier selected mid-mutation", async () => {
+    const mutation = deferred<Response>();
+    const fetch = installDelayedMutationFetch(mutation);
+    await loadCarrierSettings();
+    selectCarrierSettingsCarrier("nimitz");
+    await renderCarrierSettings();
+
+    const cli = requiredSelect("#carrier-cli");
+    cli.value = "claude";
+    await act(async () => cli.dispatchEvent(new Event("change", { bubbles: true })));
+    expect(cli.value).toBe("claude");
+
+    const kirov = [...container!.querySelectorAll<HTMLButtonElement>(".terminal-carriers-chip")]
+      .find((chip) => chip.textContent?.includes("Kirov"));
+    if (!kirov) throw new Error("Kirov chip must render.");
+    await act(async () => kirov.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(requiredSelect("#carrier-cli").value).toBe("codex");
+
+    await act(async () => {
+      mutation.resolve(jsonResponse({ state: interactiveState }));
+      await vi.waitFor(() => expect(getCarrierSettingsStoreState().savingActionId).toBeNull());
+    });
+
+    expect(mutationCalls(fetch)).toEqual([
+      expect.objectContaining({
+        url: "/api/v1/plugins/terminal/carriers/nimitz",
+        method: "PATCH",
+        body: { cli: "claude", model: { model: "sonnet", effort: "high" } },
+      }),
+    ]);
+    expect(container!.querySelector(".terminal-carriers-save-status")?.textContent).toBe("");
+    expect(requiredSelect("#carrier-cli").value).toBe("codex");
+  });
+
+  it("keeps a pending model selected and reverts it after mutation failure", async () => {
+    const mutation = deferred<Response>();
+    installDelayedMutationFetch(mutation);
+    await loadCarrierSettings();
+    selectCarrierSettingsCarrier("nimitz");
+    await renderCarrierSettings();
+
+    const model = requiredSelect("#carrier-model");
+    model.value = "gpt-5-mini";
+    await act(async () => model.dispatchEvent(new Event("change", { bubbles: true })));
+    expect(model.value).toBe("gpt-5-mini");
+    expect(model.disabled).toBe(true);
+
+    await act(async () => {
+      mutation.resolve(new Response(JSON.stringify({ error: "mutation failed" }), { status: 500 }));
+      await vi.waitFor(() => expect(getCarrierSettingsStoreState().savingActionId).toBeNull());
+    });
+
+    expect(requiredSelect("#carrier-model").value).toBe("gpt-5");
+    expect(getCarrierSettingsStoreState().error).toBe("mutation failed");
+  });
+
+  it("PUTs a Task Force row model change immediately", async () => {
+    const fetch = installInteractiveFetch();
+    await loadCarrierSettings();
+    selectCarrierSettingsCarrier("nimitz");
+    await renderCarrierSettings();
+
+    const model = requiredSelect("#tf-codex-model");
+    model.value = "gpt-5-mini";
+    await act(async () => model.dispatchEvent(new Event("change", { bubbles: true })));
+    await waitForRequest(fetch, "PUT");
+
+    expect(mutationCalls(fetch)).toEqual([
+      expect.objectContaining({
+        url: "/api/v1/plugins/terminal/carriers/nimitz/taskforce/codex",
+        method: "PUT",
+        body: { model: "gpt-5-mini" },
+      }),
+    ]);
+  });
+
+  it("resets effort to the new model default on Task Force row model change", async () => {
+    const fetch = installInteractiveFetch();
+    await loadCarrierSettings();
+    selectCarrierSettingsCarrier("nimitz");
+    await renderCarrierSettings();
+
+    const model = requiredSelect("#tf-claude-model");
+    model.value = "haiku";
+    await act(async () => model.dispatchEvent(new Event("change", { bubbles: true })));
+    await waitForRequest(fetch, "PUT");
+
+    expect(mutationCalls(fetch)).toEqual([
+      expect.objectContaining({
+        url: "/api/v1/plugins/terminal/carriers/nimitz/taskforce/claude",
+        method: "PUT",
+        body: { model: "haiku", effort: "low" },
+      }),
+    ]);
+  });
+
+  it("arms Task Force removal before DELETE and warns at the activation boundary", async () => {
+    const fetch = installInteractiveFetch();
+    await loadCarrierSettings();
+    selectCarrierSettingsCarrier("nimitz");
+    await renderCarrierSettings();
+
+    const remove = container!.querySelector<HTMLButtonElement>('[data-remove-cli="codex"]');
+    if (!remove) throw new Error("Task Force remove button must render.");
+    await act(async () => remove.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(remove.textContent).toBe("Confirm — TF deactivates");
+    expect(remove.classList.contains("is-armed")).toBe(true);
+    expect(remove.getAttribute("aria-label")).toBe("Confirm removal of Codex backend");
+    expect(mutationCalls(fetch)).toHaveLength(0);
+
+    await act(async () => remove.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    await waitForRequest(fetch, "DELETE");
+    expect(mutationCalls(fetch)).toEqual([
+      expect.objectContaining({
+        url: "/api/v1/plugins/terminal/carriers/nimitz/taskforce/codex",
+        method: "DELETE",
+      }),
+    ]);
+  });
+
+  it("surfaces a failed mutation and reloads server state", async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(state))
+      .mockResolvedValueOnce(jsonResponse(options))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: "mutation failed" }), { status: 500 }))
+      .mockResolvedValueOnce(jsonResponse(state))
+      .mockResolvedValueOnce(jsonResponse(options));
+    vi.stubGlobal("fetch", fetch);
+    await loadCarrierSettings();
+
+    await expect(saveCarrierPatch({ displayName: "Broken" })).resolves.toBe(false);
+    expect(getCarrierSettingsStoreState().error).toBe("mutation failed");
+    expect(fetch).toHaveBeenCalledTimes(5);
+    expect(fetch.mock.calls.slice(-2).map(([input]) => input)).toEqual([
+      "/api/v1/plugins/terminal/carriers",
+      "/api/v1/plugins/terminal/carriers/options",
+    ]);
   });
 });
 
@@ -176,8 +350,69 @@ async function renderCarrierSettings(): Promise<void> {
 }
 
 function actionButton(label: string): HTMLButtonElement {
-  const button = [...container!.querySelectorAll<HTMLButtonElement>(".terminal-carriers-save-actions button")]
-    .find((item) => item.textContent === label);
+  const button = actionButtonOrNull(label);
   if (!button) throw new Error(`${label} action must render.`);
   return button;
+}
+
+function actionButtonOrNull(label: string): HTMLButtonElement | null {
+  return [...container!.querySelectorAll<HTMLButtonElement>(".terminal-carriers-save-actions button")]
+    .find((item) => item.textContent === label) ?? null;
+}
+
+function requiredSelect(selector: string): HTMLSelectElement {
+  const select = container!.querySelector<HTMLSelectElement>(selector);
+  if (!select) throw new Error(`${selector} select must render.`);
+  return select;
+}
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), { status: 200 });
+}
+
+function installInteractiveFetch() {
+  const fetch = vi.fn((input: string, init?: RequestInit) => {
+    if (init?.method && init.method !== "GET") return Promise.resolve(jsonResponse({ state: interactiveState }));
+    return Promise.resolve(jsonResponse(input.endsWith("/options") ? interactiveOptions : interactiveState));
+  });
+  vi.stubGlobal("fetch", fetch);
+  return fetch;
+}
+
+function installDelayedMutationFetch(mutation: Promise<Response>) {
+  const fetch = vi.fn((input: string, init?: RequestInit) => {
+    if (init?.method && init.method !== "GET") return mutation;
+    return Promise.resolve(jsonResponse(input.endsWith("/options") ? interactiveOptions : interactiveState));
+  });
+  vi.stubGlobal("fetch", fetch);
+  return fetch;
+}
+
+function deferred<T>(): Promise<T> & { resolve(value: T): void } {
+  let resolvePromise: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return Object.assign(promise, { resolve: resolvePromise });
+}
+
+function mutationCalls(fetch: ReturnType<typeof vi.fn>): Array<{ readonly url: string; readonly method: string; readonly body: unknown }> {
+  return fetch.mock.calls.flatMap((call) => {
+    const input = call[0] as string;
+    const init = call[1] as RequestInit | undefined;
+    if (!init?.method || init.method === "GET") return [];
+    return [{
+      url: input,
+      method: init.method,
+      body: init.body ? JSON.parse(String(init.body)) as unknown : undefined,
+    }];
+  });
+}
+
+async function waitForRequest(fetch: ReturnType<typeof vi.fn>, method: string, count = 1): Promise<void> {
+  await act(async () => {
+    await vi.waitFor(() => {
+      expect(mutationCalls(fetch).filter((call) => call.method === method)).toHaveLength(count);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Settings > Terminal > Carriers의 캐리어별 Save/Discard 드래프트를 전면 Auto-save로 전환 — Runtime(CLI/Model/Effort)·Display name·Task Force 편집이 즉시 저장되고, 칩 전환 시 미저장 편집이 조용히 소실되던 결함도 함께 제거
- Task Force Remove는 2-step ARM으로 보호하고, 제거 시 Task Force가 비활성화되는 경계에서는 `Confirm — TF deactivates`로 명시 경고
- CLI 변경은 단일 원자적 PATCH(cli+model), 모델 변경은 신 모델 기본 effort로 리셋, 비행 중 셀렉트는 낙관적 펜딩값 유지, 저장 피드백은 시작한 캐리어에만 표기

## Test Plan
- [x] `@fleet-plugins/terminal` typecheck / build / test (311건) 통과
- [x] 격리 콘솔 실브라우저 실측: 모델 변경 즉시 PATCH + Saved ✓, ARM 2단계 + 비활성 경고, Add 즉시 PUT, CLI 변경 단일 PATCH 원자성, 비행 중 칩 전환 시 타 캐리어 무오염
- [x] Sentinel 코드 리뷰 2패스 (초기 High 1/Medium 1/Low 1 → 수정 후 PASS)
- [x] Changelog: `.changelog.d/pr-342.md` — fleet-plugin/Changed 2건, 이중언어, `compile-changelog-fragments --check` 통과