### PR TITLE
feat(console): add Reduce panel motion toggle to Settings General

### DIFF
--- a/.changelog.d/pr-343.md
+++ b/.changelog.d/pr-343.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Added
+- [fleet-console] Add a "Reduce panel motion" toggle to Settings > General. Off (default) follows the operating system's Reduce Motion setting as before; on suppresses all panel animations (open, move, minimize, and restore). Stored server-side with Console settings.
+  ko: Settings > General에 "Reduce panel motion" 토글을 추가합니다. 꺼짐(기본)은 기존처럼 운영체제의 동작 줄이기 설정을 따르고, 켜짐은 패널 애니메이션(열기, 이동, 최소화, 복원)을 모두 끕니다. Console 설정과 함께 서버에 저장됩니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-store.ts
@@ -1,5 +1,7 @@
 import { useSyncExternalStore } from "react";
 
+import { getGlobalSettingsStoreState } from "../global-settings-store.js";
+
 export interface OperationGeometry {
   readonly x: number;
   readonly y: number;
@@ -747,6 +749,10 @@ function cancelZoomTween(): void {
 export function prefersReducedMotion(): boolean {
   if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export function panelMotionSuppressed(): boolean {
+  return getGlobalSettingsStoreState().state?.reducePanelMotion === true || prefersReducedMotion();
 }
 
 function scheduleSave(): void {

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -9,7 +9,7 @@ import { flattenGroupedOrder, hydrateOperations, setActiveOperation } from "../s
 import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import type { ConsoleState, OperationNode } from "../types.js";
-import { calculateGridSlots, animateViewportTo, claimTopZIndex, clearCompanionOperationId, clearMaximizedOperationId, focusOperation, forceDropCompanionOperationId, getSnapshot as getCanvasSnapshot, minimizeOperation, prefersReducedMotion, restoreOperation, setCompanionOperationId, setCompanionPanelVisible, setMaximizedOperationId, setOperationGeometry, setViewport, useCanvasState, useCompanionOperationId, useCompanionPanelVisibilityOverrides, useFormationLayout, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "./canvas-store.js";
+import { calculateGridSlots, animateViewportTo, claimTopZIndex, clearCompanionOperationId, clearMaximizedOperationId, focusOperation, forceDropCompanionOperationId, getSnapshot as getCanvasSnapshot, minimizeOperation, panelMotionSuppressed, restoreOperation, setCompanionOperationId, setCompanionPanelVisible, setMaximizedOperationId, setOperationGeometry, setViewport, useCanvasState, useCompanionOperationId, useCompanionPanelVisibilityOverrides, useFormationLayout, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "./canvas-store.js";
 import { escapeSelectorValue, playMinimizeFlight } from "./panel-motion.js";
 import { CanvasContextMenu } from "./canvas-context-menu.js";
 import { CanvasMinimap } from "./canvas-minimap.js";
@@ -189,7 +189,7 @@ export function OperationsCanvas({
   const formationSlotByOperationId = new Map(formationOperationIds.map((operationId, index) => [operationId, formationSlots[index]!]));
   // Formation 진입·레이아웃 전환 시 슬롯 순서 stagger — 윈도우 리사이즈 재배치에는 적용하지 않는다.
   useEffect(() => {
-    if (!formationView || prefersReducedMotion()) return;
+    if (!formationView || panelMotionSuppressed()) return;
     const root = canvasRef.current;
     if (!root) return;
     const frames = formationOperationIds

--- a/runtime/fleet-console/core/client/src/canvas/panel-motion.ts
+++ b/runtime/fleet-console/core/client/src/canvas/panel-motion.ts
@@ -1,4 +1,4 @@
-import { prefersReducedMotion } from "./canvas-store.js";
+import { panelMotionSuppressed } from "./canvas-store.js";
 
 // 존재 전환 안무 — 최소화/복원 시 패널과 사이드바 칩 사이를 잇는 고스트 flight.
 // 상태 커밋을 지연·블로킹하지 않는 fire-and-forget 연출 레이어다.
@@ -17,7 +17,7 @@ interface FlightTiming {
 // 양 끝점이 실제로 보일 때만 난다 — 접힌 사이드바의 칩이나 focus layer 뒤 히든 피어는
 // visibility:hidden이어도 rect가 유효해, 가드 없이는 보이지 않는 지점에서 고스트가 나타난다.
 export function playMinimizeFlight(operationId: string): void {
-  if (typeof document === "undefined" || prefersReducedMotion()) return;
+  if (typeof document === "undefined" || panelMotionSuppressed()) return;
   const panel = panelElement(operationId);
   if (!isVisiblyRendered(panel)) return;
   const from = panel.getBoundingClientRect();
@@ -31,7 +31,7 @@ export function playMinimizeFlight(operationId: string): void {
 // 복원 flight: 상태 커밋 지점에서 호출한다 — 칩 rect를 즉시 캡처하고,
 // 다음 프레임에 패널 rect를 조회해 칩→패널로 역방향 flight. 패널 본체 페이드인은 CSS 소유.
 export function playRestoreFlight(operationId: string): void {
-  if (typeof document === "undefined" || prefersReducedMotion()) return;
+  if (typeof document === "undefined" || panelMotionSuppressed()) return;
   const chip = chipElement(operationId);
   if (!isVisiblyRendered(chip)) return;
   const from = chip.getBoundingClientRect();

--- a/runtime/fleet-console/core/client/src/global-settings-api.ts
+++ b/runtime/fleet-console/core/client/src/global-settings-api.ts
@@ -41,6 +41,7 @@ function assertGlobalSettingsState(value: unknown, status: number): GlobalSettin
     !payload
     || (payload.consolePortMode !== "dynamic" && payload.consolePortMode !== "static")
     || (payload.consoleStaticPort !== null && !isValidConsoleStaticPort(payload.consoleStaticPort))
+    || typeof payload.reducePanelMotion !== "boolean"
     || (payload.theme !== "instrument" && payload.theme !== "maritime" && payload.theme !== "carbon")
     || !isConsoleLanguagePreference(payload.language)
   ) {
@@ -49,6 +50,7 @@ function assertGlobalSettingsState(value: unknown, status: number): GlobalSettin
   return {
     consolePortMode: payload.consolePortMode,
     consoleStaticPort: payload.consoleStaticPort,
+    reducePanelMotion: payload.reducePanelMotion,
     theme: payload.theme,
     uiFont: normalizeUiFont(payload.uiFont),
     language: payload.language,

--- a/runtime/fleet-console/core/client/src/main.tsx
+++ b/runtime/fleet-console/core/client/src/main.tsx
@@ -21,7 +21,7 @@ import "./styles/layout.css";
 import "./styles/components.css";
 import { App } from "./app.js";
 import { fetchGlobalSettingsState } from "./global-settings-api.js";
-import { hydrateGlobalSettings } from "./global-settings-store.js";
+import { getGlobalSettingsStoreState, hydrateGlobalSettings, subscribe as subscribeGlobalSettings } from "./global-settings-store.js";
 import { connectOperationsSse } from "./operations-sse.js";
 import { loadPluginRegistry, PluginRegistryProvider } from "./plugin-registry.js";
 import { applyDesktopShellMarker, setActiveTheme, setActiveUiFont } from "./store.js";
@@ -52,6 +52,15 @@ globalThis.__fleetConsoleRuntime__ = {
 
 setActiveTheme("instrument");
 applyDesktopShellMarker();
+
+const syncReducePanelMotionClass = () => {
+  document.documentElement.classList.toggle(
+    "reduce-panel-motion",
+    getGlobalSettingsStoreState().state?.reducePanelMotion === true,
+  );
+};
+subscribeGlobalSettings(syncReducePanelMotionClass);
+syncReducePanelMotionClass();
 
 try {
   const settings = await fetchGlobalSettingsState();

--- a/runtime/fleet-console/core/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/core/client/src/pages/global-settings.tsx
@@ -370,6 +370,7 @@ function GeneralSettingsCard({
       {state ? (
         <>
           <ConsolePortSettings state={state} saving={saving} consoleState={consoleState} />
+          <PanelMotionSettings state={state} saving={saving} />
           <LanguageSettings state={state} saving={saving} />
         </>
       ) : (
@@ -377,6 +378,26 @@ function GeneralSettingsCard({
       )}
       <p className="global-settings-foot">Changes apply to newly launched sessions. Running sessions keep their current configuration until relaunched.</p>
     </section>
+  );
+}
+
+function PanelMotionSettings({ state, saving }: { readonly state: GlobalSettingsState; readonly saving: boolean }) {
+  return (
+    <div className="global-settings-row">
+      <div className="global-settings-row-text">
+        <p className="global-settings-resp-title">Panel Motion</p>
+        <p className="global-settings-help">Stop panel animations when panels open, move, minimize, and restore. When off, your operating system's Reduce Motion setting is followed.</p>
+      </div>
+      <button
+        type="button"
+        aria-pressed={state.reducePanelMotion}
+        className={`global-settings-toggle ${state.reducePanelMotion ? "is-on" : ""}`}
+        disabled={saving}
+        onClick={() => void setGlobalSettingsField("reducePanelMotion", !state.reducePanelMotion)}
+      >
+        Reduce panel motion
+      </button>
+    </div>
   );
 }
 

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2081,6 +2081,16 @@
   }
 }
 
+.reduce-panel-motion .canvas-operation,
+.reduce-panel-motion .canvas-operation.is-minimized {
+  transition: none;
+}
+
+.reduce-panel-motion .canvas-companion-frame,
+.reduce-panel-motion .side-bar-chip.is-arrival-pulse {
+  animation: none;
+}
+
 @media (prefers-reduced-motion: reduce) {
   /* is-minimized(0,2,0)는 .canvas-operation(0,1,0)보다 특이도가 높아 별도 명시가 필요하다 —
      글로벌 캐치올은 transition-duration만 줄이고 visibility의 transition-delay는 못 끊는다. */

--- a/runtime/fleet-console/core/client/src/types.ts
+++ b/runtime/fleet-console/core/client/src/types.ts
@@ -125,6 +125,7 @@ export interface OperationNode {
 export interface GlobalSettingsState {
   readonly consolePortMode: "dynamic" | "static";
   readonly consoleStaticPort: number | null;
+  readonly reducePanelMotion: boolean;
   readonly theme: ThemeId;
   readonly uiFont: UiFontSettings;
   readonly language: ConsoleLanguagePreference;

--- a/runtime/fleet-console/core/host/console-settings.ts
+++ b/runtime/fleet-console/core/host/console-settings.ts
@@ -18,6 +18,7 @@ export interface ConsoleGeneralSettings {
   readonly consolePortMode?: "dynamic" | "static";
   readonly consoleStaticPort?: number;
   readonly language?: "auto" | "en" | "ko";
+  readonly reducePanelMotion?: boolean;
   readonly theme?: ConsoleThemeId;
   readonly uiFont?: UiFontSettings;
 }
@@ -105,6 +106,9 @@ function readConsoleGeneralSettings(value: unknown): ConsoleGeneralSettings | nu
   const language = value.language === "auto" || value.language === "en" || value.language === "ko"
     ? value.language
     : undefined;
+  const reducePanelMotion = typeof value.reducePanelMotion === "boolean"
+    ? value.reducePanelMotion
+    : undefined;
   const theme = value.theme === "instrument" || value.theme === "maritime" || value.theme === "carbon"
     ? value.theme
     : undefined;
@@ -113,6 +117,7 @@ function readConsoleGeneralSettings(value: unknown): ConsoleGeneralSettings | nu
     ...(consolePortMode !== undefined ? { consolePortMode } : {}),
     ...(consoleStaticPort !== undefined ? { consoleStaticPort } : {}),
     ...(language !== undefined ? { language } : {}),
+    ...(reducePanelMotion !== undefined ? { reducePanelMotion } : {}),
     ...(theme !== undefined ? { theme } : {}),
     ...(uiFont !== undefined ? { uiFont } : {}),
   };

--- a/runtime/fleet-console/core/host/global-settings-routes.ts
+++ b/runtime/fleet-console/core/host/global-settings-routes.ts
@@ -24,6 +24,7 @@ interface GlobalSettingsBody {
   readonly consolePortMode?: unknown;
   readonly consoleStaticPort?: unknown;
   readonly language?: unknown;
+  readonly reducePanelMotion?: boolean;
   readonly theme?: unknown;
   readonly uiFont?: unknown;
 }
@@ -101,6 +102,10 @@ async function mutateGlobalSettings(
     deps.writeJson(res, 400, { error: "invalid_language" });
     return;
   }
+  if (body.reducePanelMotion !== undefined && typeof body.reducePanelMotion !== "boolean") {
+    deps.writeJson(res, 400, { error: "invalid_reduce_panel_motion" });
+    return;
+  }
   if (body.theme !== undefined && body.theme !== "instrument" && body.theme !== "maritime" && body.theme !== "carbon") {
     deps.writeJson(res, 400, { error: "invalid_theme" });
     return;
@@ -118,6 +123,7 @@ async function mutateGlobalSettings(
       ...(body.consolePortMode === "dynamic" || body.consolePortMode === "static" ? { consolePortMode: body.consolePortMode } : {}),
       ...(isValidConsoleStaticPort(body.consoleStaticPort) ? { consoleStaticPort: body.consoleStaticPort } : {}),
       ...(body.language === "auto" || body.language === "en" || body.language === "ko" ? { language: body.language } : {}),
+      ...(typeof body.reducePanelMotion === "boolean" ? { reducePanelMotion: body.reducePanelMotion } : {}),
       ...(theme !== undefined ? { theme } : {}),
       ...(isUiFontSettings(body.uiFont) ? { uiFont: body.uiFont } : {}),
     },
@@ -134,6 +140,7 @@ function toGlobalSettingsState(data: ConsoleSettingsData): GlobalSettingsState {
     consolePortMode: general.consolePortMode ?? "dynamic",
     consoleStaticPort: general.consoleStaticPort ?? null,
     language: general.language ?? "auto",
+    reducePanelMotion: general.reducePanelMotion ?? false,
     theme: general.theme ?? "instrument",
     uiFont: general.uiFont ?? DEFAULT_UI_FONT_SETTINGS,
   };

--- a/runtime/fleet-console/core/host/global-settings-types.ts
+++ b/runtime/fleet-console/core/host/global-settings-types.ts
@@ -7,6 +7,7 @@ export interface GlobalSettingsState {
   readonly consolePortMode: "dynamic" | "static";
   readonly consoleStaticPort: number | null;
   readonly language: "auto" | "en" | "ko";
+  readonly reducePanelMotion: boolean;
   readonly theme: ConsoleThemeId;
   readonly uiFont: UiFontSettings;
 }

--- a/runtime/fleet-console/tests/console-settings.test.ts
+++ b/runtime/fleet-console/tests/console-settings.test.ts
@@ -154,6 +154,11 @@ describe("sanitizeConsoleSettingsData", () => {
     expect(sanitizeConsoleSettingsData({ version: 1, general: { language: "ja" } })).toEqual({ version: 1, general: {}, plugins: {} });
   });
 
+  it("accepts boolean reducePanelMotion values and drops invalid values", () => {
+    expect(sanitizeConsoleSettingsData({ version: 1, general: { reducePanelMotion: true } })).toEqual({ version: 1, general: { reducePanelMotion: true }, plugins: {} });
+    expect(sanitizeConsoleSettingsData({ version: 1, general: { reducePanelMotion: "true" } })).toEqual({ version: 1, general: {}, plugins: {} });
+  });
+
   it("accepts minimum valid port boundary", () => {
     expect(sanitizeConsoleSettingsData({
       version: 1,

--- a/runtime/fleet-console/tests/global-settings-api.test.ts
+++ b/runtime/fleet-console/tests/global-settings-api.test.ts
@@ -4,7 +4,7 @@ import { ApiError } from "../core/client/src/api.js";
 import { fetchGlobalSettingsState, updateGlobalSettings } from "../core/client/src/global-settings-api.js";
 
 const originalFetch = globalThis.fetch;
-const SETTINGS = { consolePortMode: "dynamic", consoleStaticPort: null, theme: "instrument", uiFont: { source: "builtin", id: "manrope", size: 14 }, language: "auto" } as const;
+const SETTINGS = { consolePortMode: "dynamic", consoleStaticPort: null, reducePanelMotion: false, theme: "instrument", uiFont: { source: "builtin", id: "manrope", size: 14 }, language: "auto" } as const;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
@@ -29,6 +29,16 @@ describe("global settings client transport", () => {
     }));
   });
 
+  it("requires and sends the reducePanelMotion preference", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ state: { ...SETTINGS, reducePanelMotion: true } })));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(updateGlobalSettings({ reducePanelMotion: true })).resolves.toEqual({ state: { ...SETTINGS, reducePanelMotion: true } });
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/settings/global", expect.objectContaining({
+      body: JSON.stringify({ reducePanelMotion: true }),
+    }));
+  });
+
   it("accepts and sends each supported theme", async () => {
     for (const theme of ["instrument", "maritime", "carbon"] as const) {
       const state = { ...SETTINGS, theme };
@@ -48,6 +58,12 @@ describe("global settings client transport", () => {
 
   it("rejects missing or invalid language values", async () => {
     globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({ ...SETTINGS, language: "ja" }))) as typeof fetch;
+
+    await expect(fetchGlobalSettingsState()).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it("rejects missing or invalid reducePanelMotion values", async () => {
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({ ...SETTINGS, reducePanelMotion: "false" }))) as typeof fetch;
 
     await expect(fetchGlobalSettingsState()).rejects.toBeInstanceOf(ApiError);
   });

--- a/runtime/fleet-console/tests/global-settings-routes.test.ts
+++ b/runtime/fleet-console/tests/global-settings-routes.test.ts
@@ -24,15 +24,15 @@ describe("global settings routes", () => {
     const harness = createRouterHarness({ general: {} });
     const handled = await harness.router({ req: req("GET"), res: res(), pathname: "/api/v1/settings/global" });
     expect(handled).toBe(true);
-    expect(harness.writes).toEqual([{ status: 200, body: { consolePortMode: "dynamic", consoleStaticPort: null, language: "auto", theme: "instrument", uiFont: { source: "builtin", id: "manrope", size: 14 } } }]);
+    expect(harness.writes).toEqual([{ status: 200, body: { consolePortMode: "dynamic", consoleStaticPort: null, language: "auto", reducePanelMotion: false, theme: "instrument", uiFont: { source: "builtin", id: "manrope", size: 14 } } }]);
     expect(harness.writes[0]?.body).not.toHaveProperty("version");
     expect(harness.writes[0]?.body).not.toHaveProperty("general");
   });
 
   it("GET /global-settings/state reflects stored values", async () => {
-    const harness = createRouterHarness({ general: { consolePortMode: "static", consoleStaticPort: 9000, language: "ko", theme: "maritime", uiFont: { source: "builtin", id: "source-code-pro", size: 14 } } });
+    const harness = createRouterHarness({ general: { consolePortMode: "static", consoleStaticPort: 9000, language: "ko", reducePanelMotion: true, theme: "maritime", uiFont: { source: "builtin", id: "source-code-pro", size: 14 } } });
     await harness.router({ req: req("GET"), res: res(), pathname: "/api/v1/settings/global" });
-    expect(harness.writes[0]).toEqual({ status: 200, body: { consolePortMode: "static", consoleStaticPort: 9000, language: "ko", theme: "maritime", uiFont: { source: "builtin", id: "source-code-pro", size: 14 } } });
+    expect(harness.writes[0]).toEqual({ status: 200, body: { consolePortMode: "static", consoleStaticPort: 9000, language: "ko", reducePanelMotion: true, theme: "maritime", uiFont: { source: "builtin", id: "source-code-pro", size: 14 } } });
   });
 
   it("GET /global-settings/state rejects non-GET methods with 405", async () => {
@@ -45,7 +45,7 @@ describe("global settings routes", () => {
     const harness = createRouterHarness({ authorized: true, body: { consolePortMode: "static", consoleStaticPort: 8080, theme: "instrument", uiFont: { source: "builtin", id: "jetbrains-mono", size: 14 } } });
     const handled = await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/api/v1/settings/global" });
     expect(handled).toBe(true);
-    expect(harness.writes[0]).toEqual({ status: 200, body: { state: { consolePortMode: "static", consoleStaticPort: 8080, language: "auto", theme: "instrument", uiFont: { source: "builtin", id: "jetbrains-mono", size: 14 } } } });
+    expect(harness.writes[0]).toEqual({ status: 200, body: { state: { consolePortMode: "static", consoleStaticPort: 8080, language: "auto", reducePanelMotion: false, theme: "instrument", uiFont: { source: "builtin", id: "jetbrains-mono", size: 14 } } } });
     expect(harness.currentGeneral()).toMatchObject({ consolePortMode: "static", consoleStaticPort: 8080, theme: "instrument", uiFont: { source: "builtin", id: "jetbrains-mono", size: 14 } });
   });
 
@@ -91,7 +91,7 @@ describe("global settings routes", () => {
     for (const theme of ["instrument", "maritime", "carbon"] as const) {
       const harness = createRouterHarness({ authorized: true, body: { theme } });
       await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/api/v1/settings/global" });
-      expect(harness.writes[0]).toEqual({ status: 200, body: { state: { consolePortMode: "dynamic", consoleStaticPort: null, language: "auto", theme, uiFont: { source: "builtin", id: "manrope", size: 14 } } } });
+      expect(harness.writes[0]).toEqual({ status: 200, body: { state: { consolePortMode: "dynamic", consoleStaticPort: null, language: "auto", reducePanelMotion: false, theme, uiFont: { source: "builtin", id: "manrope", size: 14 } } } });
       expect(harness.currentGeneral()).toMatchObject({ theme });
     }
   });
@@ -117,7 +117,7 @@ describe("global settings routes", () => {
       general: { consolePortMode: "static", consoleStaticPort: 8080, language: "en", theme: "instrument", uiFont: { source: "builtin", id: "source-code-pro", size: 14 } },
     });
     await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/api/v1/settings/global" });
-    expect(harness.writes[0]?.body).toEqual({ state: { consolePortMode: "static", consoleStaticPort: 8080, language: "en", theme: "instrument", uiFont: { source: "builtin", id: "source-code-pro", size: 14 } } });
+    expect(harness.writes[0]?.body).toEqual({ state: { consolePortMode: "static", consoleStaticPort: 8080, language: "en", reducePanelMotion: false, theme: "instrument", uiFont: { source: "builtin", id: "source-code-pro", size: 14 } } });
     expect(harness.currentGeneral()).toEqual({ consolePortMode: "static", consoleStaticPort: 8080, language: "en", theme: "instrument", uiFont: { source: "builtin", id: "source-code-pro", size: 14 } });
   });
 
@@ -145,7 +145,7 @@ describe("global settings routes", () => {
   it("PUT /global-settings stores a static console port", async () => {
     const harness = createRouterHarness({ authorized: true, body: { consolePortMode: "static", consoleStaticPort: 8080 } });
     await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/api/v1/settings/global" });
-    expect(harness.writes[0]).toEqual({ status: 200, body: { state: { consolePortMode: "static", consoleStaticPort: 8080, language: "auto", theme: "instrument", uiFont: { source: "builtin", id: "manrope", size: 14 } } } });
+    expect(harness.writes[0]).toEqual({ status: 200, body: { state: { consolePortMode: "static", consoleStaticPort: 8080, language: "auto", reducePanelMotion: false, theme: "instrument", uiFont: { source: "builtin", id: "manrope", size: 14 } } } });
   });
 
   it("PUT /global-settings rejects an out-of-range static port with 400", async () => {
@@ -193,7 +193,7 @@ describe("global settings routes", () => {
   it("PUT /global-settings stores language and preserves sibling general and plugin settings", async () => {
     const harness = createRouterHarness({ authorized: true, body: { language: "ko" }, general: { consolePortMode: "static", consoleStaticPort: 8080, theme: "instrument" }, plugins: { terminal: { fontSize: 14 } } });
     await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/api/v1/settings/global" });
-    expect(harness.writes[0]).toEqual({ status: 200, body: { state: { consolePortMode: "static", consoleStaticPort: 8080, language: "ko", theme: "instrument", uiFont: { source: "builtin", id: "manrope", size: 14 } } } });
+    expect(harness.writes[0]).toEqual({ status: 200, body: { state: { consolePortMode: "static", consoleStaticPort: 8080, language: "ko", reducePanelMotion: false, theme: "instrument", uiFont: { source: "builtin", id: "manrope", size: 14 } } } });
     expect(harness.currentData()).toEqual({ version: 1, general: { consolePortMode: "static", consoleStaticPort: 8080, language: "ko", theme: "instrument" }, plugins: { terminal: { fontSize: 14 } } });
   });
 
@@ -201,6 +201,20 @@ describe("global settings routes", () => {
     const harness = createRouterHarness({ authorized: true, body: { language: "fr" } });
     await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/api/v1/settings/global" });
     expect(harness.writes[0]?.body).toEqual({ error: "invalid_language" });
+    expect(harness.updateCalls).toBe(0);
+  });
+
+  it("PUT /global-settings stores reducePanelMotion and preserves sibling general and plugin settings", async () => {
+    const harness = createRouterHarness({ authorized: true, body: { reducePanelMotion: true }, general: { language: "ko", theme: "instrument" }, plugins: { terminal: { fontSize: 14 } } });
+    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/api/v1/settings/global" });
+    expect(harness.writes[0]).toEqual({ status: 200, body: { state: { consolePortMode: "dynamic", consoleStaticPort: null, language: "ko", reducePanelMotion: true, theme: "instrument", uiFont: { source: "builtin", id: "manrope", size: 14 } } } });
+    expect(harness.currentData()).toEqual({ version: 1, general: { language: "ko", reducePanelMotion: true, theme: "instrument" }, plugins: { terminal: { fontSize: 14 } } });
+  });
+
+  it("PUT /global-settings rejects a non-boolean reducePanelMotion with 400", async () => {
+    const harness = createRouterHarness({ authorized: true, body: { reducePanelMotion: "true" } });
+    await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/api/v1/settings/global" });
+    expect(harness.writes[0]?.body).toEqual({ error: "invalid_reduce_panel_motion" });
     expect(harness.updateCalls).toBe(0);
   });
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -155,6 +155,13 @@ describe("Instrument core design contract", () => {
     const reducedMotionBlock = components.slice(components.indexOf("@media (prefers-reduced-motion: reduce)"));
     expect(reducedMotionBlock).toMatch(/\.canvas-operation,\s*\.canvas-operation\.is-minimized \{\s*transition: none;\s*\}/);
     expect(reducedMotionBlock).toMatch(/\.canvas-companion-frame \{\s*animation: none;\s*\}/);
+    const explicitReducedMotionStart = components.indexOf(".reduce-panel-motion .canvas-operation,");
+    const explicitReducedMotionBlock = components.slice(
+      explicitReducedMotionStart,
+      components.indexOf("@media (prefers-reduced-motion: reduce)", explicitReducedMotionStart),
+    );
+    expect(explicitReducedMotionBlock).toMatch(/\.reduce-panel-motion \.canvas-operation,\s*\.reduce-panel-motion \.canvas-operation\.is-minimized \{\s*transition: none;\s*\}/);
+    expect(explicitReducedMotionBlock).toMatch(/\.reduce-panel-motion \.canvas-companion-frame,\s*\.reduce-panel-motion \.side-bar-chip\.is-arrival-pulse \{\s*animation: none;\s*\}/);
     // (d) 존재 전환 keyframe은 panel-enter로 일반화 — companion 전용 명칭은 퇴역하고 실제 사용까지 고정한다.
     expect(components).toContain("@keyframes panel-enter");
     expect(components).toContain("animation: panel-enter var(--duration-slow) var(--ease-glide) both;");

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -67,7 +67,10 @@ vi.mock("../core/client/src/components/keyboard-shortcuts-dialog.js", () => ({ i
 vi.mock("../core/client/src/components/operation-search.js", () => ({ OperationSearch: () => null }));
 vi.mock("../core/client/src/components/toast.js", () => ({ Toast: () => null }));
 vi.mock("../core/client/src/components/whatsnew-modal.js", () => ({ WhatsNewModal: () => null }));
-vi.mock("../core/client/src/global-settings-store.js", () => ({ useGlobalSettingsStore: () => ({ state: null }) }));
+vi.mock("../core/client/src/global-settings-store.js", () => ({
+  getGlobalSettingsStoreState: () => ({ state: null }),
+  useGlobalSettingsStore: () => ({ state: null }),
+}));
 vi.mock("../core/client/src/operations-sse.js", () => ({ refreshObserverStatus: vi.fn() }));
 vi.mock("../core/client/src/pages/global-settings.js", () => ({ GlobalSettings: () => createElement("div", { "data-route": "settings" }) }));
 vi.mock("../core/client/src/plugin-capabilities.js", () => ({ createHostCapabilities: () => ({ api: {} }) }));


### PR DESCRIPTION
## Summary
- Settings > General에 "Reduce panel motion" 토글 추가 (서버 영속 `reducePanelMotion`, 기본 false, 마이그레이션 없음 — `language` 프리시던스)
- off(기본) = OS `prefers-reduced-motion` 추종 = 현행 동작 무회귀 / on = 패널 모션 레이어 전면 차단 (geometry transition · minimize/restore flight · Formation stagger · companion panel-enter · chip arrival pulse)
- 적용 경로: `reduce-panel-motion` 루트 클래스(CSS) + `panelMotionSuppressed()` JS 가드(panel-motion.ts flight · canvas.tsx stagger)

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` green
- [x] 설정 관련 vitest 통과 (sanitize · PUT roundtrip · 타입 거부 · 클라이언트 transport · 디자인 계약) — `server.test.ts` 1건 실패는 베이스에서도 동일한 선존 실패
- [x] 격리 인스턴스 실브라우저 양방향 실측: ON → `.canvas-operation` computed `transition: none` + 루트 클래스 + API 영속, OFF+리로드 → `0.36s glide` 복원
- [x] Sentinel 코드 리뷰 PASS (C/H/M/L 0건)
- [x] Changelog: `.changelog.d/pr-343.md` (grouped syntax, bilingual, `compile-changelog-fragments.mjs --check` OK)