### PR TITLE
feat(console): expand Session Analyst composer input surface

### DIFF
--- a/.changelog.d/pr-344.md
+++ b/.changelog.d/pr-344.md
@@ -1,0 +1,10 @@
+### fleet-plugin
+#### Added
+- [fleet-console] The Session Analyst composer grows with the question up to six rows instead of clipping everything past one line, and the draft now lives in the per-operation analysis store so it survives closing and reopening the panel.
+  ko: Session Analyst composer가 질문에 따라 최대 6행까지 자동으로 늘어나 한 줄을 넘는 내용이 잘리지 않으며, 작성 중인 draft가 per-operation 분석 store에 보관되어 패널을 닫았다 열어도 유지됩니다.
+- [fleet-console] Questions can be queued while the analyst is working: Enter stacks the question as a cancellable QUEUED chip, queued questions fire in FIFO order when each run completes, and Stop or Reset clears the queue.
+  ko: 분석가가 작업 중에도 질문을 큐에 쌓을 수 있습니다: Enter가 질문을 취소 가능한 QUEUED 칩으로 적재하고, 각 실행이 완료되면 FIFO 순서로 자동 전송되며, Stop이나 Reset은 큐를 비웁니다.
+- [fleet-console] Follow-up suggestion chips (Go deeper, Check for intent drift, Turn this into an artifact, What is the agent doing now?) appear after every completed answer so the analyst's capabilities stay discoverable past the first question.
+  ko: 답변이 완료될 때마다 후속 제안 칩(Go deeper, Check for intent drift, Turn this into an artifact, What is the agent doing now?)이 표시되어 첫 질문 이후에도 분석가의 기능을 계속 발견할 수 있습니다.
+- [fleet-console] Typing "/" in the composer opens an analysis command palette (/now /drift /brief /risks /timeline) with keyboard navigation, IME-safe guards, and combobox ARIA wiring; choosing a command fills the composer with its template question.
+  ko: composer에 "/"를 입력하면 키보드 낸비게이션·IME 안전 가드·combobox ARIA 연결을 갖춘 분석 명령 팔레트(/now /drift /brief /risks /timeline)가 열리며, 명령을 고륩면 템플릿 질문이 composer에 채워집니다.

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
@@ -3,7 +3,7 @@
 import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { initialAnalysisState, type AnalysisState } from "./analysis-state.js";
+import { analysisReducer, initialAnalysisState, type AnalysisAction, type AnalysisState } from "./analysis-state.js";
 
 const { installDiagramHydratorSpy, renderMarkdownSpy } = vi.hoisted(() => ({
   installDiagramHydratorSpy: vi.fn(),
@@ -23,11 +23,16 @@ vi.mock("@fleet-console/markdown/core", async (importOriginal) => {
 vi.mock("@fleet-console/markdown/mermaid", () => ({ installDiagramHydrator: installDiagramHydratorSpy }));
 
 let storeState: AnalysisState;
+let rerenderStore = () => {};
 const send = vi.fn(async () => undefined);
 const stop = vi.fn(async () => undefined);
 const reset = vi.fn(async () => undefined);
+const dispatch = vi.fn((action: AnalysisAction) => {
+  storeState = analysisReducer(storeState, action);
+  rerenderStore();
+});
 vi.mock("./analysis-store.js", () => ({
-  useAnalysisStore: () => ({ state: storeState, dispatch: vi.fn(), send, stop, reset }),
+  useAnalysisStore: () => ({ state: storeState, dispatch, send, stop, reset }),
 }));
 
 import { AnalystChatPanel } from "./analysis-chat-panel.js";
@@ -39,6 +44,7 @@ describe("Session Analyst Evidence Pulse", () => {
     send.mockClear();
     stop.mockClear();
     reset.mockClear();
+    dispatch.mockClear();
     renderMarkdownSpy.mockClear();
     installDiagramHydratorSpy.mockReset();
   });
@@ -93,10 +99,10 @@ describe("Session Analyst Evidence Pulse", () => {
     expect(container.querySelector(".session-analyst__pulse")?.textContent).toContain("Using wiki_read");
     expect(container.querySelector(".session-analyst__pulse")?.textContent).toContain("Tool status: running");
     expect(container.querySelector(".session-analyst__chat ol")?.classList.contains("is-dimmed")).toBe(false);
-    expect(container.querySelector("textarea")?.disabled).toBe(true);
+    expect(container.querySelector("textarea")?.disabled).toBe(false);
     expect(container.querySelectorAll("select")).toHaveLength(0);
     expect(container.querySelectorAll(".session-analyst__stop")).toHaveLength(1);
-    expect(container.querySelectorAll(".session-analyst__send")).toHaveLength(1);
+    expect(container.querySelectorAll(".session-analyst__send")).toHaveLength(2);
     expect(container.querySelector(".session-analyst__stop")?.getAttribute("aria-label")).toBe("Stop");
     expect(container.querySelector(".session-analyst__stop")?.textContent).toBe("");
     expect((container.querySelector('[aria-label="Reset Session Analyst"]') as HTMLButtonElement).disabled).toBe(false);
@@ -285,6 +291,132 @@ describe("Session Analyst Evidence Pulse", () => {
     container.remove();
   });
 
+  it("renders follow-up chips after completion and sends their exact prompts", async () => {
+    storeState = {
+      ...initialAnalysisState,
+      started: true,
+      phase: "complete",
+      entries: [{ role: "analyst", text: "Answer" }],
+    };
+    const { container, root } = renderPanel();
+    const followups = container.querySelector(".session-analyst__followups")!;
+    expect(followups.textContent).toContain("FOLLOW UP");
+    expect(followups.querySelectorAll("button")).toHaveLength(4);
+
+    const deeper = [...followups.querySelectorAll("button")].find((button) => button.textContent?.includes("Go deeper"))!;
+    await act(async () => deeper.click());
+    expect(send).toHaveBeenCalledWith("Go deeper on your previous answer with more evidence citations.");
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders cancellable queued questions and keeps the composer enabled while busy", () => {
+    storeState = {
+      ...initialAnalysisState,
+      started: true,
+      busy: true,
+      phase: "reasoning",
+      entries: [{ role: "user", text: "Initial" }],
+      queue: ["First queued", "Second queued"],
+    };
+    const { container, root } = renderPanel();
+    expect(container.querySelector(".session-analyst__queue")?.getAttribute("aria-live")).toBe("polite");
+    expect(container.querySelectorAll(".session-analyst__queue-item")).toHaveLength(2);
+    expect(container.textContent).toContain("Enter queues the question — it fires when the analyst is ready");
+    expect(container.querySelector("textarea")?.disabled).toBe(false);
+
+    const textarea = container.querySelector("textarea")!;
+    setTextareaValue(textarea, "Queued from composer");
+    act(() => textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })));
+    expect(storeState.queue).toEqual(["First queued", "Second queued", "Queued from composer"]);
+    expect(storeState.draft).toBe("");
+    expect(send).not.toHaveBeenCalled();
+
+    act(() => (container.querySelector('[aria-label="Cancel queued question 1"]') as HTMLButtonElement).click());
+    expect(storeState.queue).toEqual(["Second queued", "Queued from composer"]);
+    expect(container.querySelectorAll(".session-analyst__queue-item")).toHaveLength(2);
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("filters slash commands and replaces the draft on keyboard and mouse selection", () => {
+    storeState = { ...initialAnalysisState, draft: "/dr" };
+    const { container, root } = renderPanel();
+    const textarea = container.querySelector("textarea")!;
+    const palette = container.querySelector('[role="listbox"]')!;
+    expect(textarea.getAttribute("role")).toBe("combobox");
+    expect(textarea.getAttribute("aria-expanded")).toBe("true");
+    expect(textarea.getAttribute("aria-controls")).toBe(palette.id);
+    expect(palette.querySelectorAll('[role="option"]')).toHaveLength(1);
+    expect(palette.textContent).toContain("/drift");
+    expect(textarea.getAttribute("aria-activedescendant")).toBe("analysis-chat-test-slash-drift");
+    expect(palette.querySelector('[role="option"]')?.id).toBe("analysis-chat-test-slash-drift");
+
+    act(() => textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })));
+    expect(storeState.draft).toBe("Review this session for intent drift against my stated goals.");
+    expect(send).not.toHaveBeenCalled();
+    expect(container.querySelector('[role="listbox"]')).toBeNull();
+
+    setTextareaValue(textarea, "/");
+    const timeline = [...container.querySelectorAll<HTMLElement>('[role="option"]')].find((option) => option.textContent?.includes("/timeline"))!;
+    act(() => timeline.click());
+    expect(storeState.draft).toBe("Walk me through how this session unfolded.");
+    expect(send).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("leaves slash navigation and the draft unchanged during IME composition", () => {
+    storeState = { ...initialAnalysisState, draft: "/" };
+    const { container, root } = renderPanel();
+    const textarea = container.querySelector("textarea")!;
+    const initialActiveOption = textarea.getAttribute("aria-activedescendant");
+
+    for (const key of ["ArrowDown", "ArrowUp", "Enter", "Escape"]) {
+      act(() => textarea.dispatchEvent(new KeyboardEvent("keydown", {
+        key,
+        isComposing: true,
+        bubbles: true,
+        cancelable: true,
+      })));
+      expect(storeState.draft).toBe("/");
+      expect(textarea.getAttribute("aria-activedescendant")).toBe(initialActiveOption);
+      expect(textarea.getAttribute("aria-expanded")).toBe("true");
+    }
+    expect(send).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("recalculates composer height when its textarea is resized", () => {
+    let triggerResize = () => {};
+    const disconnect = vi.fn();
+    vi.stubGlobal("ResizeObserver", class {
+      constructor(callback: ResizeObserverCallback) {
+        triggerResize = () => callback([], this as unknown as ResizeObserver);
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() { disconnect(); }
+    });
+    storeState = { ...initialAnalysisState, draft: "A durable draft that wraps after the panel narrows" };
+    const { container, root } = renderPanel();
+    const textarea = container.querySelector("textarea")!;
+    Object.defineProperty(textarea, "scrollHeight", { configurable: true, value: 166 });
+
+    act(() => triggerResize());
+    expect(Number.parseFloat(textarea.style.height)).toBe(112.5);
+    expect(textarea.style.overflowY).toBe("auto");
+
+    act(() => root.unmount());
+    expect(disconnect).toHaveBeenCalledOnce();
+    container.remove();
+  });
+
   it("follows the latest streamed analyst content when chat overflows", () => {
     storeState = {
       ...initialAnalysisState,
@@ -392,7 +524,8 @@ function renderPanel() {
   const container = document.createElement("div");
   document.body.append(container);
   const root = createRoot(container);
-  act(() => root.render(createElement(AnalystChatPanel, { context: { operationId: "chat-test" } as never })));
+  rerenderStore = () => root.render(createElement(AnalystChatPanel, { context: { operationId: "chat-test" } as never }));
+  act(() => rerenderStore());
   return { container, root };
 }
 

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
@@ -13,12 +13,26 @@ const SUGGESTIONS = [
   { icon: "▲", tone: "coral", text: "Flag anything I should review" },
   { icon: "≡", tone: "brass", text: "Draft a handoff brief" },
 ] as const;
+const FOLLOW_UPS = [
+  { icon: "◈", tone: "aurora", label: "Go deeper on the last answer", text: "Go deeper on your previous answer with more evidence citations." },
+  { icon: "▲", tone: "coral", label: "Check for intent drift", text: "Review this session for intent drift against my stated goals." },
+  { icon: "≡", tone: "brass", label: "Turn this into an artifact", text: "Turn your previous answer into a published artifact." },
+  { icon: "●", tone: "aurora", label: "What is the agent doing now?", text: "What is the agent doing right now?" },
+] as const;
+const SLASH_COMMANDS = [
+  { command: "/now", description: "Current state — what the agent is doing right now", template: "What is the agent doing right now?" },
+  { command: "/drift", description: "Intent drift review against settled goals", template: "Review this session for intent drift against my stated goals." },
+  { command: "/brief", description: "Handoff brief as an artifact", template: "Draft a handoff brief and publish it as an artifact." },
+  { command: "/risks", description: "Flag anything that needs review", template: "Flag anything I should review before this work continues." },
+  { command: "/timeline", description: "How the session unfolded, end to end", template: "Walk me through how this session unfolded." },
+] as const;
 const STREAM_RENDER_DELAY_MS = 32;
 export const ANALYST_ARTIFACTS_COMPANION_ID = "session-analyst-artifacts";
 
 export function AnalystChatPanel({ context }: { readonly context: OperationRenderContext }) {
   const { state, dispatch, send, stop, reset } = useAnalysisStore(context);
-  const [draft, setDraft] = React.useState("");
+  const [slashSelection, setSlashSelection] = React.useState(0);
+  const [slashDismissed, setSlashDismissed] = React.useState(false);
   const cli = state.catalog?.clis.find((item) => item.cliId === state.cliId);
   const model = cli?.models.find((item) => item.id === state.model);
   const hasInteracted = state.entries.length > 0;
@@ -32,7 +46,15 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
   const [countPulseRevision, setCountPulseRevision] = React.useState(0);
   const artifactsChipRef = React.useRef<HTMLButtonElement>(null);
   const chatRef = React.useRef<HTMLElement>(null);
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
   const latestEntry = state.entries.at(-1);
+  const slashMatches = state.draft.startsWith("/")
+    ? SLASH_COMMANDS.filter((item) => item.command.toLowerCase().startsWith(state.draft.toLowerCase()))
+    : [];
+  const slashOpen = !slashDismissed && slashMatches.length > 0;
+  const slashListboxId = `analysis-${context.operationId}-slash-listbox`;
+  const slashOptionId = (command: string) => `analysis-${context.operationId}-slash-${command.slice(1)}`;
+  const activeSlashOption = slashOpen ? slashMatches[Math.min(slashSelection, slashMatches.length - 1)] : undefined;
   // 첫 상호작용이 이 마운트에서 발생했을 때만 도킹 모션을 붙인다. 클래스를 계속
   // 유지하면 뒤따르는 connected/chunk 렌더가 진행 중인 CSS 애니메이션을 끊지 않는다.
   const interactedAtMount = React.useRef(hasInteracted).current;
@@ -42,6 +64,18 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
     if (!chat || !hasInteracted) return;
     chat.scrollTop = chat.scrollHeight;
   }, [hasInteracted, latestEntry?.text, state.entries.length, state.latestActivity, state.phase]);
+  React.useLayoutEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    resizeAnalysisTextarea(textarea);
+  }, [state.draft]);
+  React.useLayoutEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => resizeAnalysisTextarea(textarea));
+    observer.observe(textarea);
+    return () => observer.disconnect();
+  }, []);
   React.useEffect(() => {
     const chat = chatRef.current;
     if (chat) installDiagramHydrator(chat);
@@ -66,11 +100,24 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
     }
     if (artifactCount > previousCount && artifactsHidden) setCountPulseRevision((revision) => revision + 1);
   }, [artifactCount, artifactsHidden, dispatch, setCompanionPanelVisible, state.artifactsAutoOpenArmed, supportsCompanionVisibility]);
-  const submit = async (text: string) => {
+  const submit = async (text: string, clearDraft: boolean) => {
     const trimmed = text.trim();
-    if (!trimmed || state.busy) return;
-    setDraft("");
+    if (!trimmed) return;
+    if (state.busy) {
+      dispatch({ type: "queue-push", text: trimmed });
+      if (clearDraft) dispatch({ type: "set-draft", draft: "" });
+      return;
+    }
+    if (clearDraft) dispatch({ type: "set-draft", draft: "" });
     await send(trimmed);
+  };
+  const selectSlashCommand = (index: number) => {
+    const selected = slashMatches[index];
+    if (!selected) return;
+    dispatch({ type: "set-draft", draft: selected.template });
+    setSlashDismissed(true);
+    setSlashSelection(0);
+    window.requestAnimationFrame(() => textareaRef.current?.focus());
   };
   const handleTranscriptClick = React.useCallback((event: React.MouseEvent<HTMLOListElement>) => {
     const button = (event.target as HTMLElement).closest<HTMLElement>('[data-action="copy-code"]');
@@ -103,7 +150,7 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
           <span className="session-analyst-handle__label">ARTIFACTS</span>
         </button>
       ) : null}
-      <PanelHeader state={state} onReset={() => { void reset().then(() => setDraft("")).catch(() => {}); }} />
+      <PanelHeader state={state} onReset={() => { void reset().catch(() => {}); }} />
       <div className="session-analyst__workspace">
         <section ref={chatRef} className="session-analyst__chat" aria-live="polite" aria-busy={state.busy}>
           {hasInteracted ? (
@@ -125,7 +172,7 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
               </header>
               <div className="session-analyst__suggestions">
                 {SUGGESTIONS.map((suggestion) => (
-                  <button type="button" key={suggestion.text} onClick={() => void submit(suggestion.text)}>
+                  <button type="button" key={suggestion.text} onClick={() => void submit(suggestion.text, false)}>
                     <span className="session-analyst__suggestion-icon" data-tone={suggestion.tone} aria-hidden="true">{suggestion.icon}</span>
                     {suggestion.text}
                   </button>
@@ -135,7 +182,51 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
           )}
           {state.phase !== "idle" ? <EvidencePulse state={state} /> : null}
         </section>
-        <form className={`session-analyst__composer ${hasInteracted ? "is-docked" : "is-initial"}${animateDock ? " is-docking" : ""}${state.busy ? " is-working" : ""}`} aria-busy={state.busy} onSubmit={(event) => { event.preventDefault(); void submit(draft); }}>
+        {state.queue.length > 0 ? (
+          <div className="session-analyst__queue" aria-live="polite">
+            {state.queue.map((text, index) => (
+              <div className="session-analyst__queue-item" key={`${text}-${index}`}>
+                <span className="session-analyst__queue-tag">QUEUED</span>
+                <span className="session-analyst__queue-text">{text}</span>
+                <button type="button" aria-label={`Cancel queued question ${index + 1}`} onClick={() => dispatch({ type: "queue-cancel", index })}>✕</button>
+              </div>
+            ))}
+          </div>
+        ) : null}
+        {state.phase === "complete" && !state.busy && hasInteracted ? (
+          <div className="session-analyst__followups">
+            <span className="session-analyst__followups-label">FOLLOW UP</span>
+            <div className="session-analyst__followups-row">
+              {FOLLOW_UPS.map((item) => (
+                <button type="button" key={item.label} onClick={() => void submit(item.text, false)}>
+                  <span className="session-analyst__suggestion-icon" data-tone={item.tone} aria-hidden="true">{item.icon}</span>
+                  {item.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : null}
+        <form className={`session-analyst__composer ${hasInteracted ? "is-docked" : "is-initial"}${animateDock ? " is-docking" : ""}${state.busy ? " is-working" : ""}`} aria-busy={state.busy} onSubmit={(event) => { event.preventDefault(); void submit(state.draft, true); }}>
+          {slashOpen ? (
+            <div id={slashListboxId} className="session-analyst__slash" role="listbox" aria-label="Analysis commands">
+              <span className="session-analyst__slash-heading">Analysis commands</span>
+              {slashMatches.map((item, index) => (
+                <button
+                  type="button"
+                  id={slashOptionId(item.command)}
+                  role="option"
+                  aria-selected={index === slashSelection}
+                  className={index === slashSelection ? "is-selected" : undefined}
+                  key={item.command}
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => selectSlashCommand(index)}
+                >
+                  <span>{item.command}</span>
+                  <small>{item.description}</small>
+                </button>
+              ))}
+            </div>
+          ) : null}
           <div className="session-analyst__composer-surface">
             {!hasInteracted ? <div className="session-analyst__selector-strip" aria-label="Initial analysis settings">
               <span className="session-analyst__select"><select aria-label="Analysis CLI" disabled={state.started || !state.catalog} value={state.cliId} onChange={(event) => dispatch({ type: "select-cli", cliId: event.target.value })}>{state.catalog?.clis.map((item) => <option key={item.cliId} value={item.cliId} disabled={!item.available}>{item.label}</option>)}</select></span>
@@ -144,32 +235,73 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
             </div> : null}
             <label className="session-analyst__sr-only" htmlFor={`analysis-${context.operationId}`}>Ask about this session</label>
             <textarea
+              ref={textareaRef}
               id={`analysis-${context.operationId}`}
+              role="combobox"
+              aria-expanded={slashOpen}
+              aria-controls={slashListboxId}
+              aria-activedescendant={activeSlashOption ? slashOptionId(activeSlashOption.command) : undefined}
               rows={1}
-              placeholder="Ask about the session…"
-              value={draft}
-              onChange={(event) => setDraft(event.target.value)}
+              placeholder="Ask about the session… (/ for commands)"
+              value={state.draft}
+              onChange={(event) => {
+                dispatch({ type: "set-draft", draft: event.target.value });
+                setSlashSelection(0);
+                setSlashDismissed(false);
+              }}
               onKeyDown={(event) => {
+                if (slashOpen && !event.nativeEvent.isComposing) {
+                  if (event.key === "ArrowDown") {
+                    event.preventDefault();
+                    setSlashSelection((selection) => (selection + 1) % slashMatches.length);
+                    return;
+                  }
+                  if (event.key === "ArrowUp") {
+                    event.preventDefault();
+                    setSlashSelection((selection) => (selection - 1 + slashMatches.length) % slashMatches.length);
+                    return;
+                  }
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    selectSlashCommand(Math.min(slashSelection, slashMatches.length - 1));
+                    return;
+                  }
+                  if (event.key === "Escape") {
+                    event.preventDefault();
+                    setSlashDismissed(true);
+                    return;
+                  }
+                }
                 if (event.key !== "Enter" || event.shiftKey || event.nativeEvent.isComposing) return;
                 event.preventDefault();
-                void submit(draft);
+                void submit(state.draft, true);
               }}
-              disabled={state.busy}
             />
             {state.busy ? (
               <button type="button" className="session-analyst__send session-analyst__stop" aria-label="Stop" onClick={() => void stop()}>
                 <span aria-hidden="true" />
               </button>
-            ) : (
-              <button type="submit" className="session-analyst__send" aria-label="Send" disabled={!draft.trim()}>
-                <svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" aria-hidden="true"><path d="M6 10 V2 M2.5 5.5 L6 2 l3.5 3.5" /></svg>
-              </button>
-            )}
+            ) : null}
+            <button type="submit" className="session-analyst__send" aria-label={state.busy ? "Queue question" : "Send"} disabled={!state.draft.trim()}>
+              <svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" aria-hidden="true"><path d="M6 10 V2 M2.5 5.5 L6 2 l3.5 3.5" /></svg>
+            </button>
           </div>
+          {state.busy ? <div className="session-analyst__composer-hint">Enter queues the question — it fires when the analyst is ready</div> : null}
         </form>
       </div>
     </section>
   );
+}
+
+function resizeAnalysisTextarea(textarea: HTMLTextAreaElement): void {
+  textarea.style.height = "auto";
+  const style = window.getComputedStyle(textarea);
+  const lineHeight = Number.parseFloat(style.lineHeight) || 18.75;
+  const verticalPadding = (Number.parseFloat(style.paddingTop) || 0) + (Number.parseFloat(style.paddingBottom) || 0);
+  const maxHeight = (lineHeight * 6) + verticalPadding;
+  const nextHeight = Math.max(36, Math.min(textarea.scrollHeight, maxHeight));
+  textarea.style.height = `${nextHeight}px`;
+  textarea.style.overflowY = textarea.scrollHeight > maxHeight ? "auto" : "hidden";
 }
 
 const AnalystMarkdownResponse = React.memo(function AnalystMarkdownResponse({ text, streaming }: { readonly text: string; readonly streaming: boolean }) {
@@ -218,7 +350,7 @@ function copyCodeToClipboard(button: HTMLElement, code: string): void {
 }
 
 function PanelHeader({ state, onReset }: { readonly state: AnalysisState; readonly onReset: () => void }) {
-  const canReset = state.started || state.phase !== "idle" || state.entries.length > 0 || state.artifacts.length > 0;
+  const canReset = state.started || state.phase !== "idle" || state.draft.length > 0 || state.queue.length > 0 || state.entries.length > 0 || state.artifacts.length > 0;
   return (
     <header className="session-analyst__panel-head">
       <span className="session-analyst__panel-mark" aria-hidden="true">✳</span>

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-state.test.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-state.test.ts
@@ -27,6 +27,8 @@ describe("shared analysis store reducer", () => {
       started: true,
       busy: true,
       phase: "writing" as const,
+      draft: "Unsent question",
+      queue: ["Queued question"],
       entries: [{ role: "user" as const, text: "Review this" }],
       artifacts: [{ id: "artifact", title: "Artifact", html: "<p>artifact</p>", createdAt: 1 }],
       error: "old error",
@@ -39,10 +41,31 @@ describe("shared analysis store reducer", () => {
       started: false,
       busy: false,
       phase: "idle",
+      draft: "",
+      queue: [],
       entries: [],
       artifacts: [],
       error: null,
     });
+  });
+
+  it("persists drafts and supports cancellable FIFO queue state", () => {
+    const drafted = analysisReducer(initialAnalysisState, { type: "set-draft", draft: "Keep this question" });
+    const first = analysisReducer(drafted, { type: "queue-push", text: "First" });
+    const second = analysisReducer(first, { type: "queue-push", text: "Second" });
+    expect(second).toMatchObject({ draft: "Keep this question", queue: ["First", "Second"] });
+
+    const cancelled = analysisReducer(second, { type: "queue-cancel", index: 0 });
+    expect(cancelled.queue).toEqual(["Second"]);
+    expect(analysisReducer(cancelled, { type: "queue-clear" }).queue).toEqual([]);
+  });
+
+  it("clears queued questions on stop and error endings", () => {
+    const queued = { ...initialAnalysisState, started: true, busy: true, queue: ["Do not fire"] };
+    expect(analysisReducer(queued, { type: "stopped", now: 2_000 }).queue).toEqual([]);
+    expect(analysisReducer(queued, { type: "error", message: "Failed", now: 2_000 }).queue).toEqual([]);
+    expect(analysisReducer(queued, { type: "session-lost", now: 2_000 }).queue).toEqual([]);
+    expect(analysisReducer(queued, { type: "start-failed", message: "Failed", now: 2_000 }).queue).toEqual([]);
   });
 
   it("advances activity only from observed events and never stores thought content", () => {

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-state.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-state.ts
@@ -16,6 +16,8 @@ export interface AnalysisState {
   readonly cliId: string;
   readonly model: string;
   readonly effort: string;
+  readonly draft: string;
+  readonly queue: readonly string[];
   readonly started: boolean;
   readonly busy: boolean;
   readonly phase: AnalysisPhase;
@@ -34,6 +36,8 @@ export const initialAnalysisState: AnalysisState = {
   cliId: "",
   model: "",
   effort: "",
+  draft: "",
+  queue: [],
   started: false,
   busy: false,
   phase: "idle",
@@ -52,6 +56,10 @@ export type AnalysisAction =
   | { readonly type: "select-cli"; readonly cliId: string }
   | { readonly type: "select-model"; readonly model: string }
   | { readonly type: "select-effort"; readonly effort: string }
+  | { readonly type: "set-draft"; readonly draft: string }
+  | { readonly type: "queue-push"; readonly text: string }
+  | { readonly type: "queue-cancel"; readonly index: number }
+  | { readonly type: "queue-clear" }
   | { readonly type: "sending"; readonly started: boolean; readonly text: string; readonly now: number }
   | { readonly type: "event"; readonly event: AnalysisEvent; readonly now: number }
   | { readonly type: "error"; readonly message: string; readonly now: number }
@@ -78,6 +86,13 @@ export function analysisReducer(state: AnalysisState, action: AnalysisAction): A
     return { ...state, model: action.model, effort: model?.defaultEffort ?? model?.effortLevels[0] ?? "" };
   }
   if (action.type === "select-effort" && !state.started) return { ...state, effort: action.effort };
+  if (action.type === "set-draft") return { ...state, draft: action.draft };
+  if (action.type === "queue-push") return { ...state, queue: [...state.queue, action.text] };
+  if (action.type === "queue-cancel") {
+    if (action.index < 0 || action.index >= state.queue.length) return state;
+    return { ...state, queue: state.queue.filter((_, index) => index !== action.index) };
+  }
+  if (action.type === "queue-clear") return state.queue.length > 0 ? { ...state, queue: [] } : state;
   if (action.type === "sending") return {
     ...state,
     started: state.started || action.started,
@@ -93,7 +108,7 @@ export function analysisReducer(state: AnalysisState, action: AnalysisAction): A
   if (action.type === "error") return endWithError(state, action.message, action.now);
   if (action.type === "session-lost") return { ...endWithError(state, "Analysis session ended — send again to restart.", action.now), started: false };
   if (action.type === "start-failed") return { ...endWithError(state, action.message, action.now), started: false };
-  if (action.type === "stopped") return { ...state, started: false, busy: false, phase: "stopped", runEndedAt: action.now, error: null };
+  if (action.type === "stopped") return { ...state, queue: [], started: false, busy: false, phase: "stopped", runEndedAt: action.now, error: null };
   if (action.type === "stop-failed") return { ...endWithError(state, `Stop failed: ${action.message}`, action.now), started: false };
   if (action.type === "reset") {
     const catalog = state.catalog;
@@ -136,7 +151,7 @@ function resolveInitialSelection(catalog: AnalysisCatalog): Pick<AnalysisState, 
 }
 
 function endWithError(state: AnalysisState, message: string, now: number): AnalysisState {
-  return { ...state, busy: false, phase: "error", runEndedAt: now, error: message };
+  return { ...state, queue: [], busy: false, phase: "error", runEndedAt: now, error: message };
 }
 
 function appendAnalystChunk(entries: readonly AnalysisEntry[], text: string): readonly AnalysisEntry[] {

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-store.test.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-store.test.ts
@@ -60,6 +60,7 @@ describe("per-operation analysis store", () => {
     await vi.waitFor(() => expect(first.getSnapshot().cliId).toBe("claude"));
 
     expect(second).toBe(first);
+    first.dispatch({ type: "set-draft", draft: "Survives panel collapse" });
     await sendWithConnected(first, harness, "Review this session");
     expect(harness.fetch.mock.calls.map((call) => call[1])).toEqual([
       "analysis/catalog",
@@ -74,12 +75,48 @@ describe("per-operation analysis store", () => {
     // EXIT only unmounts companions, so the shared conversation and server session remain alive.
     await Promise.resolve();
     expect(getAnalysisStore("operation-store-share", harness.api)).toBe(first);
+    expect(first.getSnapshot().draft).toBe("Survives panel collapse");
     expect(harness.fetch.mock.calls.some((call) => call[1] === "analysis/operation-store-share/stop")).toBe(false);
     expect(first.getSnapshot().entries.length).toBeGreaterThan(0);
 
     // Operation close owns disposal and server-session cleanup.
     disposeAnalysisStore("operation-store-share");
     await vi.waitFor(() => expect(harness.fetch.mock.calls.some((call) => call[1] === "analysis/operation-store-share/stop")).toBe(true));
+  });
+
+  it("automatically sends queued questions in FIFO order after each completion", async () => {
+    const harness = createHarness();
+    const store = getAnalysisStore("operation-store-queue", harness.api);
+    await vi.waitFor(() => expect(store.getSnapshot().cliId).toBe("claude"));
+    await sendWithConnected(store, harness, "Initial question");
+    store.dispatch({ type: "queue-push", text: "First queued" });
+    store.dispatch({ type: "queue-push", text: "Second queued" });
+
+    harness.emit({ type: "complete" });
+    await vi.waitFor(() => expect(store.getSnapshot()).toMatchObject({ busy: true, queue: ["Second queued"] }));
+    expect(messageBodies(harness)).toEqual(["Initial question", "First queued"]);
+
+    harness.emit({ type: "complete" });
+    await vi.waitFor(() => expect(store.getSnapshot()).toMatchObject({ busy: true, queue: [] }));
+    expect(messageBodies(harness)).toEqual(["Initial question", "First queued", "Second queued"]);
+
+    harness.emit({ type: "complete" });
+    disposeAnalysisStore("operation-store-queue");
+  });
+
+  it("clears queued questions on stop and never fires them from late completion", async () => {
+    const harness = createHarness();
+    const store = getAnalysisStore("operation-store-queue-stop", harness.api);
+    await vi.waitFor(() => expect(store.getSnapshot().cliId).toBe("claude"));
+    await sendWithConnected(store, harness, "Initial question");
+    store.dispatch({ type: "queue-push", text: "Must not fire" });
+
+    await store.stop();
+    expect(store.getSnapshot().queue).toEqual([]);
+    harness.emitLate({ type: "complete" });
+    await Promise.resolve();
+    expect(messageBodies(harness)).toEqual(["Initial question"]);
+    disposeAnalysisStore("operation-store-queue-stop");
   });
 
   it("rolls back started when the start request fails so selectors reopen", async () => {
@@ -377,3 +414,9 @@ describe("per-operation analysis store", () => {
     disposeAnalysisStore("operation-store-stream-lost");
   });
 });
+
+function messageBodies(harness: StreamHarness): string[] {
+  return harness.fetch.mock.calls
+    .filter((call) => String(call[1]).endsWith("/message"))
+    .map((call) => JSON.parse(String((call[2] as RequestInit | undefined)?.body)).text as string);
+}

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-store.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-store.ts
@@ -121,7 +121,12 @@ function createAnalysisStore(operationId: string, api: ClientApiCapability): Ana
         return;
       }
       if (event.type === "complete" || event.type === "error") disarmWatchdog();
+      const queued = event.type === "complete" ? state.queue[0] : undefined;
       dispatch({ type: "event", event, now: Date.now() });
+      if (queued !== undefined && !state.busy && !disposed && generation === streamGeneration) {
+        dispatch({ type: "queue-cancel", index: 0 });
+        void store.send(queued);
+      }
     });
     await Promise.race([connected, new Promise<void>((resolve) => setTimeout(resolve, CONNECT_WAIT_MS))]);
   };

--- a/runtime/fleet-plugins/terminal/client/agent/analysis.css
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis.css
@@ -27,7 +27,7 @@
 .session-analyst__chat-pane[data-phase="complete"] .session-analyst__panel-state i { background: var(--positive); box-shadow: 0 0 0 4px var(--positive-glow); }
 .session-analyst__chat-pane[data-phase="error"] .session-analyst__panel-state i { background: var(--coral); box-shadow: 0 0 0 4px var(--coral-glow); }
 
-.session-analyst__workspace { display: grid; grid-template-rows: minmax(0, 1fr) auto; min-width: 0; min-height: 0; overflow: hidden; background: transparent; }
+.session-analyst__workspace { display: grid; grid-template-rows: minmax(0, 1fr) auto auto auto; min-width: 0; min-height: 0; overflow: hidden; background: transparent; }
 .session-analyst__chat-pane.is-initial .session-analyst__workspace { display: flex; flex-direction: column; justify-content: center; overflow: auto; padding: 22px 18px; }
 .session-analyst__chat { overflow: auto; min-height: 0; display: flex; flex-direction: column; padding: 22px 18px; background: transparent; }
 .session-analyst__chat-pane.is-initial .session-analyst__chat { flex: none; overflow: visible; padding: 0; }
@@ -45,6 +45,19 @@
 .session-analyst__suggestion-icon[data-tone="coral"] { color: var(--coral); }
 .session-analyst__suggestion-icon[data-tone="brass"] { color: var(--brass); }
 .session-analyst__chat-pane :is(button, select) { user-select: none; }
+
+.session-analyst__queue { display: grid; gap: 6px; padding: 0 14px var(--space-2); }
+.session-analyst__queue-item { display: flex; align-items: center; gap: var(--space-2); min-width: 0; border: 1px dashed color-mix(in oklch, var(--aurora) 40%, var(--hairline)); border-radius: var(--radius-md); background: color-mix(in oklch, var(--aurora) 5%, var(--ink-deep)); padding: 7px 10px; color: var(--text-secondary); font-size: 11.5px; animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
+.session-analyst__queue-tag { flex: none; border: 1px solid color-mix(in oklch, var(--aurora) 45%, transparent); border-radius: 999px; color: var(--aurora); padding: 3px 7px; font: 700 8.5px/1 var(--font-mono); letter-spacing: .12em; }
+.session-analyst__queue-text { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.session-analyst__queue-item button { flex: none; border: 0; background: transparent; color: var(--text-tertiary); padding: 2px; font-size: 13px; line-height: 1; cursor: pointer; transition: color var(--duration-base) var(--ease-glide); }
+.session-analyst__queue-item button:hover { color: var(--coral); }
+
+.session-analyst__followups { display: grid; gap: var(--space-2); padding: 0 14px var(--space-2); animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
+.session-analyst__followups-label { color: var(--text-tertiary); font: 600 9px/1 var(--font-mono); letter-spacing: .14em; }
+.session-analyst__followups-row { display: flex; flex-wrap: wrap; gap: var(--space-2); }
+.session-analyst__followups-row button { display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--hairline); border-radius: 999px; background: var(--ink-mid); color: var(--text-secondary); padding: 7px 12px; font: 550 11.5px/1.2 var(--font-body); cursor: pointer; transition: border-color var(--duration-base) var(--ease-glide), color var(--duration-base) var(--ease-glide), transform var(--duration-base) var(--ease-glide); }
+.session-analyst__followups-row button:hover { border-color: color-mix(in oklch, var(--aurora) 45%, var(--hairline)); color: var(--text-primary); transform: translateY(-1px); }
 
 .session-analyst__chat > ol { display: grid; gap: 15px; align-content: start; padding: 0; margin: 0; list-style: none; user-select: text; cursor: text; }
 .session-analyst__message { padding: 11px 15px; border-radius: 18px; white-space: pre-wrap; line-height: 1.55; font-size: 12.5px; }
@@ -103,10 +116,17 @@
 .session-analyst__composer.is-initial { flex: none; margin-top: 12px; padding: 0; }
 .session-analyst__composer.is-docked { padding: 10px 14px 14px; }
 .session-analyst__composer.is-docking { animation: analyst-composer-dock var(--duration-slow) var(--ease-glide) both; }
-.session-analyst__composer-surface { position: relative; display: flex; align-items: center; gap: 7px; min-width: 0; min-height: 48px; overflow: hidden; border: 1px solid var(--hairline-strong); border-radius: 24px; background: color-mix(in oklch, var(--ink-mid) 86%, var(--ink-deep)); padding: 5px 6px 5px 9px; box-shadow: inset 0 1px 0 color-mix(in oklch, white 4%, transparent); transition: border-color var(--duration-base) var(--ease-glide), background var(--duration-base) var(--ease-glide); }
+.session-analyst__composer-surface { position: relative; display: flex; align-items: flex-end; gap: 7px; min-width: 0; min-height: 48px; overflow: hidden; border: 1px solid var(--hairline-strong); border-radius: 24px; background: color-mix(in oklch, var(--ink-mid) 86%, var(--ink-deep)); padding: 5px 6px 5px 9px; box-shadow: inset 0 1px 0 color-mix(in oklch, white 4%, transparent); transition: border-color var(--duration-base) var(--ease-glide), background var(--duration-base) var(--ease-glide); }
 .session-analyst__composer-surface:focus-within { border-color: color-mix(in oklch, var(--aurora) 48%, var(--hairline-strong)); }
-.session-analyst__composer textarea { display: block; box-sizing: border-box; width: auto; min-width: 3rem; min-height: 36px; height: 36px; flex: 1 1 auto; resize: none; overflow-x: auto; overflow-y: hidden; white-space: pre; border: 0; outline: 0; background: transparent; color: var(--text-primary); padding: 8px 6px; font: 12.5px/1.5 var(--font-body); transition: opacity var(--duration-base) var(--ease-glide); }
+.session-analyst__composer textarea { display: block; box-sizing: border-box; width: auto; min-width: 3rem; min-height: 36px; height: 36px; max-height: calc(1.5em * 6 + 16px); flex: 1 1 auto; resize: none; overflow-x: hidden; overflow-y: hidden; white-space: pre-wrap; border: 0; outline: 0; background: transparent; color: var(--text-primary); padding: 8px 6px; font: 12.5px/1.5 var(--font-body); transition: opacity var(--duration-base) var(--ease-glide); }
 .session-analyst__composer textarea::placeholder { color: color-mix(in oklch, var(--text-tertiary) 62%, transparent); }
+.session-analyst__slash { position: absolute; z-index: 5; right: 14px; bottom: calc(100% - 4px); left: 14px; overflow: hidden; border: 1px solid var(--hairline-strong); border-radius: var(--radius-md); background: var(--surface-pillar); box-shadow: var(--shadow-floating); animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
+.session-analyst__slash-heading { display: block; border-bottom: 1px solid var(--hairline); padding: 8px 12px 6px; color: var(--text-tertiary); font: 600 9px/1 var(--font-mono); letter-spacing: .14em; text-transform: uppercase; }
+.session-analyst__slash button { display: flex; align-items: baseline; gap: var(--space-3); width: 100%; border: 0; background: transparent; color: var(--text-secondary); padding: 9px 12px; text-align: left; cursor: pointer; font: 500 12px/1.3 var(--font-body); }
+.session-analyst__slash button > span { min-width: 76px; color: var(--aurora); font: 700 11px/1 var(--font-mono); }
+.session-analyst__slash button small { color: var(--text-tertiary); font-size: 10.5px; }
+.session-analyst__slash button:is(.is-selected, :hover) { background: color-mix(in oklch, var(--aurora) 10%, transparent); color: var(--text-primary); }
+.session-analyst__composer-hint { padding: 6px 4px 0; color: var(--text-tertiary); font: 500 9.5px/1.4 var(--font-mono); }
 .session-analyst__selector-strip { display: flex; align-items: center; min-width: 0; flex: 0 1 auto; overflow: hidden; border: 1px solid var(--hairline); border-radius: 999px; background: color-mix(in oklch, var(--ink-veil) 45%, var(--ink-deep)); transition: opacity var(--duration-base) var(--ease-glide); }
 .session-analyst__select { position: relative; display: inline-flex; min-width: 0; }
 .session-analyst__select + .session-analyst__select::before { content: ""; position: absolute; inset: 9px auto 9px 0; width: 1px; background: var(--hairline); }
@@ -118,7 +138,7 @@
 .session-analyst__send:disabled { opacity: .42; cursor: default; }
 .session-analyst__stop span { width: 8px; height: 8px; border-radius: 2px; background: currentColor; }
 .session-analyst__composer.is-working .session-analyst__composer-surface { border-color: color-mix(in oklch, var(--aurora) 30%, var(--surface-rim-strong)); background: color-mix(in oklch, var(--aurora) 6%, var(--surface-glass-strong)); box-shadow: inset 0 1px 0 color-mix(in oklch, var(--aurora) 10%, transparent); }
-.session-analyst__composer.is-working textarea { opacity: .58; color: var(--text-secondary); -webkit-text-fill-color: var(--text-secondary); }
+.session-analyst__composer.is-working textarea { opacity: 1; color: var(--text-primary); -webkit-text-fill-color: var(--text-primary); }
 .session-analyst__composer.is-working textarea::placeholder { color: var(--text-tertiary); -webkit-text-fill-color: var(--text-tertiary); }
 .session-analyst__composer.is-working .session-analyst__selector-strip { opacity: .34; }
 .session-analyst__sr-only { position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
@@ -172,6 +192,8 @@
   .session-analyst__chat { padding: 16px 12px; }
   .session-analyst__chat-pane.is-initial .session-analyst__workspace { padding: 16px 12px; }
   .session-analyst__composer.is-docked { padding: 8px 10px 10px; }
+  .session-analyst__queue, .session-analyst__followups { padding-right: 10px; padding-left: 10px; }
+  .session-analyst__slash { right: 10px; left: 10px; }
   .session-analyst__composer-surface { gap: 4px; padding-left: 6px; }
   .session-analyst__select select { max-width: 4.65rem; padding-right: 14px; padding-left: 7px; }
   .session-analyst__select::after { right: 4px; }
@@ -179,8 +201,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .session-analyst-handle, .session-analyst__suggestions button, .session-analyst__composer-surface, .session-analyst__composer textarea, .session-analyst__selector-strip, .session-analyst__artifact-count, .session-analyst__artifact-count i { transition: none; }
+  .session-analyst-handle, .session-analyst__suggestions button, .session-analyst__followups-row button, .session-analyst__queue-item button, .session-analyst__composer-surface, .session-analyst__composer textarea, .session-analyst__selector-strip, .session-analyst__artifact-count, .session-analyst__artifact-count i { transition: none; }
   .session-analyst-handle:hover { transform: translateY(-50%); }
-  .session-analyst__suggestions button:hover { transform: none; }
-  .session-analyst__pulse-scan, .session-analyst__composer.is-working .session-analyst__composer-surface::before, .session-analyst__pulse-orbit::after, .session-analyst__pulse, .session-analyst__pulse-copy strong, .session-analyst__receipt, .session-analyst__message--analyst, .session-analyst__composer.is-docking, .session-analyst__artifact-menu, .session-analyst-handle__count.is-pulsing { animation: none; }
+  .session-analyst__suggestions button:hover, .session-analyst__followups-row button:hover { transform: none; }
+  .session-analyst__pulse-scan, .session-analyst__composer.is-working .session-analyst__composer-surface::before, .session-analyst__pulse-orbit::after, .session-analyst__pulse, .session-analyst__pulse-copy strong, .session-analyst__receipt, .session-analyst__message--analyst, .session-analyst__queue-item, .session-analyst__followups, .session-analyst__slash, .session-analyst__composer.is-docking, .session-analyst__artifact-menu, .session-analyst-handle__count.is-pulsing { animation: none; }
 }


### PR DESCRIPTION
## Summary
- Session Analyst composer가 최대 6행까지 자동 성장하고, 작성 중인 질문(draft)이 per-operation store로 승격되어 패널을 닫았다 열어도 유지됩니다.
- 분석 중에도 composer가 활성 상태를 유지하며 Enter는 질문을 큐에 적재합니다. 완료 시 FIFO로 자동 전송되고, 항목별 취소·Stop/Reset 시 큐 해제가 가능합니다.
- 답변 완료 후 follow-up 칩 4종(Go deeper / intent drift / artifact / what now)과 "/" slash 명령 팔레트(/now /drift /brief /risks /timeline)를 추가했습니다.

## Test Plan
- [x] `@fleet-plugins/terminal` vitest 312 passed (리듀서 큐/draft, store FIFO 자동 발사, 칩/팔레트/IME 회귀)
- [x] `typecheck` + `build` (tsc) green
- [x] design contract test 15/15
- [x] 격리 콘솔 실브라우저 검증: autogrow·draft 생존(EXIT↔재오픈)·큐 자동 발사·slash 필터/선택·follow-up 칩, 실분석 2회 완주
- [x] `.changelog.d/pr-344.md` — 프래그먼트 문법·이중언어·compiler `--check` 검증 완료