### PR TITLE
fix(console): skip minimized panels in Alt navigation

### DIFF
--- a/.changelog.d/pr-345.md
+++ b/.changelog.d/pr-345.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Keep Alt+Left and Alt+Right navigation from selecting or restoring minimized Operation panels while Session Analyst, maximized, or Formation views are active.
+  ko: Session Analyst, maximized 또는 Formation view가 활성화된 동안 Alt+Left와 Alt+Right 탐색이 최소화된 Operation 패널을 선택하거나 복원하지 않도록 수정했습니다.

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -79,7 +79,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
         snapshot.groups.filter((g) => g.theaterId === snapshot.activeTheaterId),
         canvas.operationOrder,
         canvas.collapsedGroups,
-        getCompanionOperationId() === null && getMaximizedOperationId() === null ? canvas.minimized : [],
+        canvas.minimized,
       );
       event.preventDefault();
       event.stopImmediatePropagation();
@@ -87,15 +87,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       const currentId = getCompanionOperationId() ?? getMaximizedOperationId() ?? stateRef.current.activeOperationId;
       const nextId = nextOperationId(order, currentId, event.key === "ArrowRight" ? 1 : -1);
       if (!nextId) return;
-      void routeOperationFocus(nextId, registry.operationKinds, STABLE_RAIL_API, focusRequestEpochRef, () => {
-        // 모두 최소화된 부팅 상태의 폴백 대상은 store 포커스보다 먼저 복원한다. 그렇지 않으면 Canvas의
-        // "최소화된 active id 제거" effect가 pending focus 복원보다 앞서 실행되어 활성 표시를 지운다.
-        if (canvas.minimized.includes(nextId)) {
-          playRestoreFlight(nextId);
-          restoreOperation(nextId);
-        }
-        focusOperation(nextId);
-      });
+      void routeOperationFocus(nextId, registry.operationKinds, STABLE_RAIL_API, focusRequestEpochRef, () => focusOperation(nextId));
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -421,8 +421,7 @@ export function flattenGroupedOrder(
   ];
 }
 
-// Alt+←/→는 비최소화 Operation을 우선 순환한다. 단, 부팅 직후처럼 모두 최소화되어 후보가 없으면
-// SideBar 가시 순서로 폴백해 탐색 방향 끝의 Operation을 다시 표면화할 수 있게 한다.
+// Alt+←/→는 SideBar 가시 순서를 따르되, 캔버스에서 최소화된 Operation은 순환 대상에서 제외한다.
 export function focusCycleOperationIds(
   operations: readonly OperationNode[],
   groups: readonly OperationGroup[],
@@ -431,9 +430,9 @@ export function focusCycleOperationIds(
   minimized: readonly string[],
 ): readonly string[] {
   const minimizedIds = new Set(minimized);
-  const visibleOperations = flattenGroupedOrder(operations, groups, operationOrder, collapsedGroups);
-  const focusableOperations = visibleOperations.filter((operation) => !minimizedIds.has(operation.id));
-  return (focusableOperations.length > 0 ? focusableOperations : visibleOperations).map((operation) => operation.id);
+  return flattenGroupedOrder(operations, groups, operationOrder, collapsedGroups)
+    .filter((operation) => !minimizedIds.has(operation.id))
+    .map((operation) => operation.id);
 }
 
 export function compareOperationCreatedAt(left: OperationNode, right: OperationNode): number {

--- a/runtime/fleet-console/tests/operation-focus.test.ts
+++ b/runtime/fleet-console/tests/operation-focus.test.ts
@@ -69,7 +69,7 @@ describe("nextOperationId — Alt+←/→ focus cycle", () => {
     expect(nextOperationId(order, "group-1-visible", -1)).toBe("ungrouped-visible");
   });
 
-  it("falls back to SideBar order when every visible operation is minimized", () => {
+  it("returns no targets when every visible operation is minimized", () => {
     const order = focusCycleOperationIds(
       [
         makeOperation("grouped", "group", 1),
@@ -82,9 +82,9 @@ describe("nextOperationId — Alt+←/→ focus cycle", () => {
       ["grouped", "collapsed", "ungrouped"],
     );
 
-    expect(order).toEqual(["grouped", "ungrouped"]);
-    expect(nextOperationId(order, null, 1)).toBe("grouped");
-    expect(nextOperationId(order, null, -1)).toBe("ungrouped");
+    expect(order).toEqual([]);
+    expect(nextOperationId(order, null, 1)).toBeNull();
+    expect(nextOperationId(order, null, -1)).toBeNull();
   });
 
 });

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -210,7 +210,7 @@ describe("Operations boot minimization", () => {
     expect(getSnapshot().operations).toHaveProperty("launched");
   });
 
-  it("restores the only minimized panel with Alt+Arrow", async () => {
+  it("consumes Alt+Arrow without restoring or activating when every panel is minimized", async () => {
     const operations = deferred<readonly OperationNode[]>();
     const theaters = deferred<TheaterBootstrap>();
     apiMocks.fetchOperations.mockReturnValueOnce(operations.promise);
@@ -226,6 +226,7 @@ describe("Operations boot minimization", () => {
       await Promise.resolve();
     });
     expect(getSnapshot().minimized).toEqual(["initial"]);
+    expect(getState().activeOperationId).toBeNull();
 
     keyboardShortcutMocks.shouldHandleOperationsKeyboardShortcut.mockReturnValue(true);
     const event = new KeyboardEvent("keydown", { key: "ArrowLeft", altKey: true, cancelable: true });
@@ -235,8 +236,9 @@ describe("Operations boot minimization", () => {
     });
 
     expect(event.defaultPrevented).toBe(true);
-    expect(getState().activeOperationId).toBe("initial");
-    expect(getSnapshot().minimized).toEqual([]);
+    expect(getState().activeOperationId).toBeNull();
+    expect(getState().keyboardFocusRequest).toBeNull();
+    expect(getSnapshot().minimized).toEqual(["initial"]);
   });
 
   it("restores and activates a minimized Operation before pending Map focus moves the viewport", async () => {
@@ -265,7 +267,7 @@ describe("Operations boot minimization", () => {
     expect(getState().keyboardFocusRequest).toEqual({ operationId: "initial", requestId: 1 });
   });
 
-  it("advances the focus layer with Alt+Arrow while preserving Formation", async () => {
+  it("skips minimized peers while maximized", async () => {
     const operations = deferred<readonly OperationNode[]>();
     const theaters = deferred<TheaterBootstrap>();
     apiMocks.fetchOperations.mockReturnValueOnce(operations.promise);
@@ -276,16 +278,42 @@ describe("Operations boot minimization", () => {
       root!.render(createElement(BrowserRouter, null, createElement(App)));
     });
     await act(async () => {
-      operations.resolve([operation("first"), operation("second")]);
+      operations.resolve([operation("first"), operation("second"), operation("third")]);
       theaters.resolve({ theaters: [theater()] });
       await Promise.resolve();
     });
     await act(async () => {
-      toggleFormationView();
+      restoreOperation("third");
       setMaximizedOperationId("first");
       await Promise.resolve();
     });
     expect(getMaximizedOperationId()).toBe("first");
+    expect(getFormationView()).toBe(false);
+    expect(getSnapshot().minimized).toEqual(["second"]);
+
+    keyboardShortcutMocks.shouldHandleOperationsKeyboardShortcut.mockReturnValue(true);
+    const event = new KeyboardEvent("keydown", { key: "ArrowRight", altKey: true, cancelable: true });
+    await act(async () => {
+      window.dispatchEvent(event);
+      await Promise.resolve();
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(getState().activeOperationId).toBe("third");
+    expect(getMaximizedOperationId()).toBe("third");
+    expect(getFormationView()).toBe(false);
+    expect(getSnapshot().minimized).toEqual(["second"]);
+  });
+
+  it("skips minimized peers while Formation is active", async () => {
+    await bootApp([operation("first"), operation("second"), operation("third")]);
+    await act(async () => {
+      restoreOperation("first");
+      restoreOperation("third");
+      setActiveOperation("first");
+      toggleFormationView();
+      await Promise.resolve();
+    });
     expect(getFormationView()).toBe(true);
     expect(getSnapshot().minimized).toEqual(["second"]);
 
@@ -297,10 +325,9 @@ describe("Operations boot minimization", () => {
     });
 
     expect(event.defaultPrevented).toBe(true);
-    expect(getState().activeOperationId).toBe("second");
-    expect(getMaximizedOperationId()).toBe("second");
+    expect(getState().activeOperationId).toBe("third");
     expect(getFormationView()).toBe(true);
-    expect(getSnapshot().minimized).toEqual([]);
+    expect(getSnapshot().minimized).toEqual(["second"]);
   });
 
   it("switches pending focus through the active focus layer before Formation", async () => {
@@ -655,15 +682,18 @@ describe("Operations boot minimization", () => {
     expect(getCompanionOperationId()).toBeNull();
   });
 
-  it("retargets Analyze with Alt+Arrow before Maximized and Formation", async () => {
-    registryMocks.operationKinds = [companionKind(() => true)];
-    await bootApp([operation("first"), operation("second")]);
+  it("retargets Analyze with Alt+Arrow to a non-minimized peer while preserving minimized peers", async () => {
+    const canOpenCompanions = vi.fn(() => true);
+    registryMocks.operationKinds = [companionKind(canOpenCompanions)];
+    await bootApp([operation("first"), operation("second"), operation("third")]);
     await act(async () => {
       toggleFormationView();
+      restoreOperation("third");
       setMaximizedOperationId("first");
       setCompanionOperationId("first");
       await Promise.resolve();
     });
+    expect(getSnapshot().minimized).toEqual(["second"]);
 
     keyboardShortcutMocks.shouldHandleOperationsKeyboardShortcut.mockReturnValue(true);
     const event = new KeyboardEvent("keydown", { key: "ArrowRight", altKey: true, cancelable: true });
@@ -673,9 +703,12 @@ describe("Operations boot minimization", () => {
     });
 
     expect(event.defaultPrevented).toBe(true);
-    expect(getCompanionOperationId()).toBe("second");
+    expect(canOpenCompanions).toHaveBeenCalledOnce();
+    expect(getCompanionOperationId()).toBe("third");
+    expect(getState().activeOperationId).toBe("third");
     expect(getMaximizedOperationId()).toBeNull();
     expect(getFormationView()).toBe(true);
+    expect(getSnapshot().minimized).toEqual(["second"]);
   });
 
   it("retargets Analyze through pending focus using the destination Theater's layer", async () => {


### PR DESCRIPTION
## Summary

- exclude minimized operations from Alt+Left/Right focus navigation in every focus layer
- preserve minimized state while Session Analyst, maximized, or Formation views retarget focus
- keep explicit SideBar restoration behavior unchanged

## Test Plan

- [x] `pnpm --dir runtime/fleet-console exec vitest run tests/operation-focus.test.ts tests/operations-boot-minimization.integration.test.ts` (34 tests)
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Headless Fleet Console E2E: with Session Analyst open, `Alt+Right` skipped a minimized Shell panel and focused the next visible Codex panel; `Alt+Left` returned to the first panel while Shell remained minimized and inert; repeated after reload
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `git diff --check`

## Changelog

- [x] Added bilingual `.changelog.d/pr-345.md`

## Baseline Note

The full Fleet Console Vitest run still has the pre-existing `server.test.ts:1582` failure and two worker OOM errors. The exact failing server test reproduces unchanged on clean `canary`; this PR does not modify that surface.
