### PR TITLE
feat(console): add Session Analyst live artifact authoring card

### DIFF
--- a/.changelog.d/pr-347.md
+++ b/.changelog.d/pr-347.md
@@ -1,0 +1,7 @@
+### fleet-plugin
+#### Added
+- [fleet-console] Show a live authoring card in the Session Analyst chat while an artifact is being generated, resolving into a published card with an Open in Artifacts action.
+  ko: Session Analyst 채팅에 아티팩트 생성 중 라이브 저작 카드를 표시하고, 게시 완료 시 Open in Artifacts 동작이 있는 완료 카드로 전환합니다.
+#### Fixed
+- [fleet-console] Keep the Session Analyst chat pane free of horizontal scrolling at narrow widths by scrolling wide markdown content inside its own block.
+  ko: 좁은 폭에서 넓은 마크다운 콘텐츠가 자체 블록 안에서 스크롤되도록 하여 Session Analyst 채팅 패널의 가로 스크롤을 제거합니다.

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
@@ -3,6 +3,8 @@
 import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OperationRenderContext } from "@fleet-console/sdk/plugin";
+import type { AnalysisEvent } from "./analysis-types.js";
 import { analysisReducer, initialAnalysisState, type AnalysisAction, type AnalysisState } from "./analysis-state.js";
 
 const { installDiagramHydratorSpy, renderMarkdownSpy } = vi.hoisted(() => ({
@@ -35,7 +37,7 @@ vi.mock("./analysis-store.js", () => ({
   useAnalysisStore: () => ({ state: storeState, dispatch, send, stop, reset }),
 }));
 
-import { AnalystChatPanel } from "./analysis-chat-panel.js";
+import { ANALYST_ARTIFACTS_COMPANION_ID, AnalystChatPanel } from "./analysis-chat-panel.js";
 
 const catalog = { clis: [{ cliId: "codex", label: "Codex", available: true, defaultModel: "gpt", models: [{ id: "gpt", label: "GPT", effortLevels: ["medium"], defaultEffort: "medium" }] }] };
 
@@ -107,6 +109,48 @@ describe("Session Analyst Evidence Pulse", () => {
     expect(container.querySelector(".session-analyst__stop")?.textContent).toBe("");
     expect((container.querySelector('[aria-label="Reset Session Analyst"]') as HTMLButtonElement).disabled).toBe(false);
     expect(container.textContent).not.toContain("private chain of thought");
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("shows live artifact authoring, publishes the completion card, and opens Artifacts", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const setCompanionPanelVisible = vi.fn();
+    const context = {
+      operationId: "chat-test",
+      hiddenCompanionPanelIds: [ANALYST_ARTIFACTS_COMPANION_ID],
+      onSetCompanionPanelVisible: setCompanionPanelVisible,
+    } as OperationRenderContext;
+    storeState = analysisReducer(initialAnalysisState, { type: "sending", started: true, text: "Publish this", now: Date.now() });
+    const { container, root } = renderPanel(context);
+
+    emit({ type: "tool", title: "mcp__session_analyst__publish_artifact", status: "pending" });
+    const authoring = container.querySelector<HTMLElement>(".session-analyst__author-card.is-authoring")!;
+    expect(authoring.hasAttribute("aria-live")).toBe(false);
+    expect(authoring.textContent).toContain("Publishing an artifact");
+    expect(authoring.textContent).toContain("The analyst is authoring artifact content. It opens in Artifacts when it lands.");
+    expect(authoring.previousElementSibling?.classList.contains("session-analyst__transcript")).toBe(true);
+    expect(authoring.nextElementSibling?.classList.contains("session-analyst__pulse")).toBe(true);
+    const handle = container.querySelector<HTMLButtonElement>(".session-analyst-handle--artifacts")!;
+    expect(handle.classList.contains("is-authoring")).toBe(true);
+    expect(handle.querySelector(".session-analyst-handle__count")?.textContent).toBe("…");
+    expect(handle.title).toBe("The analyst is authoring an artifact…");
+
+    act(() => vi.advanceTimersByTime(2_100));
+    expect(authoring.querySelector(".session-analyst__author-time")?.textContent).toBe("2s");
+
+    emit({ type: "artifact", artifact: { id: "artifact", title: "Session brief", html: "<p>brief</p>", createdAt: Date.now() } });
+    const done = container.querySelector<HTMLElement>(".session-analyst__author-card.is-done")!;
+    expect(done.textContent).toContain("Artifact published — Session brief");
+    expect(done.querySelector(".session-analyst__author-time")?.textContent).toBe("2s");
+    expect(done.querySelector(".session-analyst__author-sub")).toBeNull();
+    expect(done.querySelector(".session-analyst__author-track")).toBeNull();
+
+    setCompanionPanelVisible.mockClear();
+    act(() => (done.querySelector(".session-analyst__author-open") as HTMLButtonElement).click());
+    expect(setCompanionPanelVisible).toHaveBeenCalledWith(ANALYST_ARTIFACTS_COMPANION_ID, true);
 
     act(() => root.unmount());
     container.remove();
@@ -520,13 +564,17 @@ describe("Session Analyst Evidence Pulse", () => {
   });
 });
 
-function renderPanel() {
+function renderPanel(context: OperationRenderContext = { operationId: "chat-test" } as OperationRenderContext) {
   const container = document.createElement("div");
   document.body.append(container);
   const root = createRoot(container);
-  rerenderStore = () => root.render(createElement(AnalystChatPanel, { context: { operationId: "chat-test" } as never }));
+  rerenderStore = () => root.render(createElement(AnalystChatPanel, { context }));
   act(() => rerenderStore());
   return { container, root };
+}
+
+function emit(event: AnalysisEvent): void {
+  act(() => dispatch({ type: "event", event, now: Date.now() }));
 }
 
 function setTextareaValue(textarea: HTMLTextAreaElement, value: string): void {

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
@@ -42,6 +42,7 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
   const supportsCompanionVisibility = hiddenCompanionPanelIds !== undefined && setCompanionPanelVisible !== undefined;
   const artifactsHidden = hiddenCompanionPanelIds?.includes(ANALYST_ARTIFACTS_COMPANION_ID) ?? false;
   const artifactsVisible = artifactCount > 0 && !artifactsHidden;
+  const artifactAuthoring = state.artifactAuthoring !== null && artifactCount === 0;
   const previousArtifactCountRef = React.useRef(0);
   const [countPulseRevision, setCountPulseRevision] = React.useState(0);
   const artifactsChipRef = React.useRef<HTMLButtonElement>(null);
@@ -63,7 +64,7 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
     const chat = chatRef.current;
     if (!chat || !hasInteracted) return;
     chat.scrollTop = chat.scrollHeight;
-  }, [hasInteracted, latestEntry?.text, state.entries.length, state.latestActivity, state.phase]);
+  }, [hasInteracted, latestEntry?.text, state.entries.length, state.latestActivity, state.phase, state.artifactAuthoring, state.artifactPublished]);
   React.useLayoutEffect(() => {
     const textarea = textareaRef.current;
     if (!textarea) return;
@@ -133,12 +134,12 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
         <button
           ref={artifactsChipRef}
           type="button"
-          className={`session-analyst-handle session-analyst-handle--artifacts${artifactCount === 0 ? " is-waiting" : ""}`}
+          className={`session-analyst-handle session-analyst-handle--artifacts${artifactCount === 0 ? " is-waiting" : ""}${artifactAuthoring ? " is-authoring" : ""}`}
           aria-label={artifactsVisible ? "Hide Artifacts" : "Open Artifacts"}
           aria-pressed={artifactsVisible}
           aria-disabled={artifactCount === 0}
           tabIndex={artifactCount === 0 ? -1 : undefined}
-          title={artifactCount === 0 ? "Artifacts the analyst publishes appear here" : undefined}
+          title={artifactAuthoring ? "The analyst is authoring an artifact…" : artifactCount === 0 ? "Artifacts the analyst publishes appear here" : undefined}
           onClick={() => {
             if (!setCompanionPanelVisible || artifactCount === 0) return;
             if (artifactsVisible) dispatch({ type: "artifacts-chip-disarm" });
@@ -147,6 +148,7 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
         >
           <span className="session-analyst-handle__chev" aria-hidden="true">{artifactsVisible ? "«" : "»"}</span>
           {artifactCount > 0 ? <span key={countPulseRevision} className={`session-analyst-handle__count${countPulseRevision > 0 ? " is-pulsing" : ""}`}>{artifactCount}</span> : null}
+          {artifactAuthoring ? <span className="session-analyst-handle__count">…</span> : null}
           <span className="session-analyst-handle__label">ARTIFACTS</span>
         </button>
       ) : null}
@@ -180,6 +182,15 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
               </div>
             </div>
           )}
+          {/* 기존 EvidencePulse가 진행 상태를 낭독하므로 카드에는 별도 live region을 두지 않는다. */}
+          {state.artifactAuthoring || state.artifactPublished ? (
+            <ArtifactAuthorCard
+              state={state}
+              onOpen={supportsCompanionVisibility && setCompanionPanelVisible
+                ? () => setCompanionPanelVisible(ANALYST_ARTIFACTS_COMPANION_ID, true)
+                : undefined}
+            />
+          ) : null}
           {state.phase !== "idle" ? <EvidencePulse state={state} /> : null}
         </section>
         {state.queue.length > 0 ? (
@@ -361,6 +372,35 @@ function PanelHeader({ state, onReset }: { readonly state: AnalysisState; readon
   );
 }
 
+function ArtifactAuthorCard({ state, onOpen }: { readonly state: AnalysisState; readonly onOpen?: () => void }) {
+  const authoringElapsedMs = useArtifactAuthoringElapsedMs(state.artifactAuthoring?.startedAt ?? null);
+  if (state.artifactAuthoring) {
+    return (
+      <div className="session-analyst__author-card is-authoring">
+        <div className="session-analyst__author-head">
+          <span className="session-analyst__author-sigil" aria-hidden="true">✳</span>
+          <strong className="session-analyst__author-title">Publishing an artifact</strong>
+          <time className="session-analyst__author-time">{formatElapsed(authoringElapsedMs)}</time>
+        </div>
+        <p className="session-analyst__author-sub">The analyst is authoring artifact content. It opens in Artifacts when it lands.</p>
+        <div className="session-analyst__author-track" aria-hidden="true"><span /></div>
+      </div>
+    );
+  }
+  const published = state.artifactPublished;
+  if (!published) return null;
+  return (
+    <div className="session-analyst__author-card is-done">
+      <div className="session-analyst__author-head">
+        <span className="session-analyst__author-sigil" aria-hidden="true">◆</span>
+        <strong className="session-analyst__author-title">Artifact published — {published.artifact.title}</strong>
+        {published.durationMs === null ? null : <time className="session-analyst__author-time">{formatElapsed(published.durationMs)}</time>}
+        {onOpen ? <button type="button" className="session-analyst__author-open" onClick={onOpen}>Open in Artifacts</button> : null}
+      </div>
+    </div>
+  );
+}
+
 function EvidencePulse({ state }: { readonly state: AnalysisState }) {
   const elapsedMs = useElapsedMs(state);
   const elapsed = formatElapsed(elapsedMs);
@@ -416,6 +456,17 @@ function useElapsedMs(state: AnalysisState): number {
   }, [state.busy, state.runStartedAt]);
   if (state.runStartedAt === null) return 0;
   return Math.max(0, (state.runEndedAt ?? now) - state.runStartedAt);
+}
+
+function useArtifactAuthoringElapsedMs(startedAt: number | null): number {
+  const [now, setNow] = React.useState(() => Date.now());
+  React.useEffect(() => {
+    if (startedAt === null) return;
+    setNow(Date.now());
+    const timer = setInterval(() => setNow(Date.now()), 1_000);
+    return () => clearInterval(timer);
+  }, [startedAt]);
+  return startedAt === null ? 0 : Math.max(0, now - startedAt);
 }
 
 function formatElapsed(elapsedMs: number): string {

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-state.test.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-state.test.ts
@@ -99,6 +99,74 @@ describe("shared analysis store reducer", () => {
     expect(analysisReducer(stopped, { type: "clear-artifacts" }).artifacts).toEqual([]);
   });
 
+  it("tracks publish_artifact authoring and transitions to a timed published artifact", () => {
+    const sent = analysisReducer(initialAnalysisState, { type: "sending", started: true, text: "Publish this", now: 1_000 });
+    const authoring = analysisReducer(sent, {
+      type: "event",
+      event: { type: "tool", title: "mcp__session_analyst__publish_artifact", status: "PENDING" },
+      now: 2_000,
+    });
+    expect(authoring).toMatchObject({ artifactAuthoring: { startedAt: 2_000 }, artifactPublished: null });
+
+    const stillAuthoring = analysisReducer(authoring, {
+      type: "event",
+      event: { type: "tool", title: "codex__publish_artifact", status: "in_progress" },
+      now: 3_000,
+    });
+    expect(stillAuthoring.artifactAuthoring).toEqual({ startedAt: 2_000 });
+
+    const artifact = { id: "artifact", title: "Evidence", html: "<p>evidence</p>", createdAt: 1 };
+    const published = analysisReducer(stillAuthoring, { type: "event", event: { type: "artifact", artifact }, now: 5_500 });
+    expect(published).toMatchObject({
+      artifactAuthoring: null,
+      artifactPublished: { artifact, durationMs: 3_500 },
+    });
+  });
+
+  it("ignores non-matching tools and clears authoring at run boundaries", () => {
+    const baseline = { ...initialAnalysisState, artifactAuthoring: { startedAt: 1_000 } };
+    const unrelated = analysisReducer(baseline, {
+      type: "event",
+      event: { type: "tool", title: "wiki_read", status: "pending" },
+      now: 2_000,
+    });
+    expect(unrelated.artifactAuthoring).toEqual({ startedAt: 1_000 });
+
+    const artifact = { id: "artifact", title: "Evidence", html: "<p>evidence</p>", createdAt: 1 };
+    const published = { ...baseline, artifactPublished: { artifact, durationMs: 2_000 } };
+    expect(analysisReducer(published, { type: "sending", started: false, text: "Again", now: 4_000 })).toMatchObject({ artifactAuthoring: null, artifactPublished: null });
+    expect(analysisReducer(published, { type: "reset" })).toMatchObject({ artifactAuthoring: null, artifactPublished: null });
+    expect(analysisReducer(published, { type: "stopped", now: 4_000 })).toMatchObject({ artifactAuthoring: null, artifactPublished: { artifact, durationMs: 2_000 } });
+    expect(analysisReducer(published, { type: "error", message: "Failed", now: 4_000 })).toMatchObject({ artifactAuthoring: null, artifactPublished: { artifact, durationMs: 2_000 } });
+  });
+
+  it("returns a published card to authoring when the same turn republishes", () => {
+    const artifact = { id: "artifact", title: "First", html: "<p>first</p>", createdAt: 1 };
+    const published = { ...initialAnalysisState, artifactPublished: { artifact, durationMs: 2_000 } };
+    const authoring = analysisReducer(published, {
+      type: "event",
+      event: { type: "tool", title: "publish_artifact", status: "in_progress" },
+      now: 8_000,
+    });
+    expect(authoring).toMatchObject({ artifactAuthoring: { startedAt: 8_000 }, artifactPublished: null });
+  });
+
+  it("ends authoring when the turn completes without an artifact event", () => {
+    const authoring = { ...initialAnalysisState, busy: true, artifactAuthoring: { startedAt: 1_000 } };
+    const completed = analysisReducer(authoring, { type: "event", event: { type: "complete" }, now: 5_000 });
+    expect(completed).toMatchObject({ phase: "complete", busy: false, artifactAuthoring: null, artifactPublished: null });
+  });
+
+  it("clears the published card together with cleared artifacts", () => {
+    const artifact = { id: "artifact", title: "Evidence", html: "<p>evidence</p>", createdAt: 1 };
+    const published = {
+      ...initialAnalysisState,
+      artifacts: [artifact],
+      artifactPublished: { artifact, durationMs: 2_000 },
+    };
+    expect(analysisReducer(published, { type: "clear-artifacts" })).toMatchObject({ artifacts: [], artifactPublished: null });
+  });
+
   it("keeps only the newest per-operation artifact working set", () => {
     let state = initialAnalysisState;
     for (let index = 0; index <= MAX_ANALYSIS_ARTIFACTS; index += 1) {

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-state.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-state.ts
@@ -27,6 +27,8 @@ export interface AnalysisState {
   readonly entries: readonly AnalysisEntry[];
   readonly tools: readonly { readonly title: string; readonly status: string }[];
   readonly artifacts: readonly AnalysisArtifact[];
+  readonly artifactAuthoring: { readonly startedAt: number } | null;
+  readonly artifactPublished: { readonly artifact: AnalysisArtifact; readonly durationMs: number | null } | null;
   readonly artifactsAutoOpenArmed: boolean;
   readonly error: string | null;
 }
@@ -47,6 +49,8 @@ export const initialAnalysisState: AnalysisState = {
   entries: [],
   tools: [],
   artifacts: [],
+  artifactAuthoring: null,
+  artifactPublished: null,
   artifactsAutoOpenArmed: true,
   error: null,
 };
@@ -103,18 +107,21 @@ export function analysisReducer(state: AnalysisState, action: AnalysisAction): A
     runEndedAt: null,
     error: null,
     tools: [],
+    artifactAuthoring: null,
+    artifactPublished: null,
     entries: [...state.entries, { role: "user", text: action.text }],
   };
   if (action.type === "error") return endWithError(state, action.message, action.now);
   if (action.type === "session-lost") return { ...endWithError(state, "Analysis session ended — send again to restart.", action.now), started: false };
   if (action.type === "start-failed") return { ...endWithError(state, action.message, action.now), started: false };
-  if (action.type === "stopped") return { ...state, queue: [], started: false, busy: false, phase: "stopped", runEndedAt: action.now, error: null };
+  if (action.type === "stopped") return { ...state, queue: [], started: false, busy: false, phase: "stopped", runEndedAt: action.now, artifactAuthoring: null, error: null };
   if (action.type === "stop-failed") return { ...endWithError(state, `Stop failed: ${action.message}`, action.now), started: false };
   if (action.type === "reset") {
     const catalog = state.catalog;
     return catalog ? { ...initialAnalysisState, catalog, ...resolveInitialSelection(catalog) } : initialAnalysisState;
   }
-  if (action.type === "clear-artifacts") return { ...state, artifacts: [], artifactsAutoOpenArmed: true };
+  // Clear는 완료 카드도 함께 걷는다 — 삭제된 artifact를 여는 CTA가 남으면 안 된다.
+  if (action.type === "clear-artifacts") return { ...state, artifacts: [], artifactPublished: null, artifactsAutoOpenArmed: true };
   if (action.type === "artifacts-chip-disarm") return state.artifactsAutoOpenArmed ? { ...state, artifactsAutoOpenArmed: false } : state;
   if (action.type === "artifacts-chip-rearm") return state.artifactsAutoOpenArmed ? state : { ...state, artifactsAutoOpenArmed: true };
   if (action.type !== "event") return state;
@@ -126,14 +133,25 @@ export function analysisReducer(state: AnalysisState, action: AnalysisAction): A
   if (event.type === "chunk") return { ...state, phase: "writing", latestActivity: { kind: "writing" }, entries: appendAnalystChunk(state.entries, event.text) };
   // Thought content is deliberately neither stored nor rendered; only the observed event advances the phase.
   if (event.type === "thought") return { ...state, phase: "reasoning", latestActivity: { kind: "reasoning" } };
-  if (event.type === "tool") return {
+  if (event.type === "tool") {
+    const status = event.status.toLowerCase();
+    const isArtifactAuthoring = event.title.toLowerCase().includes("publish_artifact") && (status === "pending" || status === "in_progress");
+    return {
+      ...state,
+      phase: "tool",
+      latestActivity: { kind: "tool", title: event.title, status: event.status },
+      tools: [...state.tools.filter((tool) => tool.title !== event.title), { title: event.title, status: event.status }],
+      ...(isArtifactAuthoring ? { artifactAuthoring: state.artifactAuthoring ?? { startedAt: action.now }, artifactPublished: null } : {}),
+    };
+  }
+  if (event.type === "artifact") return {
     ...state,
-    phase: "tool",
-    latestActivity: { kind: "tool", title: event.title, status: event.status },
-    tools: [...state.tools.filter((tool) => tool.title !== event.title), { title: event.title, status: event.status }],
+    artifacts: [event.artifact, ...state.artifacts.filter((artifact) => artifact.id !== event.artifact.id)].slice(0, MAX_ANALYSIS_ARTIFACTS),
+    artifactPublished: { artifact: event.artifact, durationMs: state.artifactAuthoring ? action.now - state.artifactAuthoring.startedAt : null },
+    artifactAuthoring: null,
   };
-  if (event.type === "artifact") return { ...state, artifacts: [event.artifact, ...state.artifacts.filter((artifact) => artifact.id !== event.artifact.id)].slice(0, MAX_ANALYSIS_ARTIFACTS) };
-  if (event.type === "complete") return { ...state, busy: false, phase: "complete", runEndedAt: action.now, error: null };
+  // artifact 이벤트 없이 턴이 끝나면(툴 거부·실패) 저작 카드가 영구히 남지 않도록 함께 종료한다.
+  if (event.type === "complete") return { ...state, busy: false, phase: "complete", runEndedAt: action.now, artifactAuthoring: null, error: null };
   return endWithError(state, event.error.message, action.now);
 }
 
@@ -151,7 +169,7 @@ function resolveInitialSelection(catalog: AnalysisCatalog): Pick<AnalysisState, 
 }
 
 function endWithError(state: AnalysisState, message: string, now: number): AnalysisState {
-  return { ...state, queue: [], busy: false, phase: "error", runEndedAt: now, error: message };
+  return { ...state, queue: [], busy: false, phase: "error", runEndedAt: now, artifactAuthoring: null, error: message };
 }
 
 function appendAnalystChunk(entries: readonly AnalysisEntry[], text: string): readonly AnalysisEntry[] {

--- a/runtime/fleet-plugins/terminal/client/agent/analysis.css
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis.css
@@ -7,6 +7,8 @@
 .session-analyst-handle__count.is-pulsing { animation: analyst-artifact-count-pulse var(--duration-slow) var(--ease-glide); }
 .session-analyst-handle.is-waiting { opacity: .45; border-color: var(--hairline); color: var(--text-tertiary); cursor: default; box-shadow: none; }
 .session-analyst-handle.is-waiting:hover { transform: translateY(-50%); background: var(--ink-deep); }
+.session-analyst-handle--artifacts.is-authoring { opacity: 1; color: var(--aurora); }
+.session-analyst-handle--artifacts.is-authoring .session-analyst-handle__count { border: 1px dashed var(--aurora); animation: analyst-authoring-breathe 1.4s var(--ease-glide) infinite; }
 .session-analyst-handle:focus-visible, .session-analyst__chat-pane button:focus-visible, .session-analyst__artifacts button:focus-visible { outline: 2px solid var(--aurora); outline-offset: 2px; }
 
 .session-analyst__chat-pane { container-type: inline-size; position: relative; box-sizing: border-box; display: grid; grid-template-columns: minmax(0, 1fr); grid-template-rows: auto minmax(0, 1fr); width: 100%; height: 100%; min-width: 0; min-height: 0; color: var(--text-primary); overflow: hidden; background: var(--surface-pillar); }
@@ -29,7 +31,7 @@
 
 .session-analyst__workspace { display: grid; grid-template-rows: minmax(0, 1fr) auto auto auto; min-width: 0; min-height: 0; overflow: hidden; background: transparent; }
 .session-analyst__chat-pane.is-initial .session-analyst__workspace { display: flex; flex-direction: column; justify-content: center; overflow: auto; padding: 22px 18px; }
-.session-analyst__chat { overflow: auto; min-height: 0; display: flex; flex-direction: column; padding: 22px 18px; background: transparent; }
+.session-analyst__chat { overflow-x: hidden; overflow-y: auto; min-height: 0; display: flex; flex-direction: column; padding: 22px 18px; background: transparent; }
 .session-analyst__chat-pane.is-initial .session-analyst__chat { flex: none; overflow: visible; padding: 0; }
 .session-analyst__hero-wrap { margin: auto 0; display: grid; gap: var(--space-4); }
 .session-analyst__chat-pane.is-initial .session-analyst__hero-wrap { margin: 0; }
@@ -60,7 +62,9 @@
 .session-analyst__followups-row button:hover { border-color: color-mix(in oklch, var(--aurora) 45%, var(--hairline)); color: var(--text-primary); transform: translateY(-1px); }
 
 .session-analyst__chat > ol { display: grid; gap: 15px; align-content: start; padding: 0; margin: 0; list-style: none; user-select: text; cursor: text; }
-.session-analyst__message { padding: 11px 15px; border-radius: 18px; white-space: pre-wrap; line-height: 1.55; font-size: 12.5px; }
+/* Flex column 자식의 min-width:auto가 Markdown 고유 폭을 채팅 컨테이너로 전파하지 않게 한다. */
+.session-analyst__transcript { min-width: 0; }
+.session-analyst__message { min-width: 0; padding: 11px 15px; border-radius: 18px; white-space: pre-wrap; overflow-wrap: anywhere; line-height: 1.55; font-size: 12.5px; }
 .session-analyst__message--user { background: color-mix(in oklch, var(--ink-veil) 70%, var(--ink-mid)); color: var(--text-primary); justify-self: end; max-width: 90%; }
 .session-analyst__message--analyst { position: relative; max-width: 100%; border: 0; border-radius: 0; background: transparent; color: var(--text-secondary); padding: 6px 4px 6px 28px; animation: analyst-answer-rise var(--duration-base) var(--ease-glide) both; }
 .session-analyst__message--analyst::before { content: "✳"; position: absolute; left: 2px; top: 7px; color: var(--aurora); }
@@ -74,10 +78,13 @@
   --font-size-title-md: 15px;
   --font-size-display-md: 17px;
   --font-size-display-lg: 18px;
-  max-inline-size: none;
+  min-width: 0;
+  max-width: 100%;
+  max-inline-size: 100%;
   margin: 0;
   color: var(--text-secondary);
   line-height: 1.58;
+  overflow-wrap: anywhere;
   white-space: normal;
 }
 .session-analyst__response.markdown-body > * + * { margin-top: var(--space-3); }
@@ -89,10 +96,27 @@
 .session-analyst__response.markdown-body :is(ul, ol) { margin-bottom: var(--space-3); padding-left: var(--space-5); }
 .session-analyst__response.markdown-body li + li { margin-top: var(--space-1); }
 .session-analyst__response.markdown-body table { margin-block: var(--space-3); font-size: 10px; }
+.session-analyst__response table { display: block; max-width: 100%; overflow-x: auto; }
 .session-analyst__response.markdown-body table :is(th, td) { padding: var(--space-2) var(--space-3); }
 .session-analyst__response.markdown-body :is(blockquote, .code-block, .diagram-block) { margin-block: var(--space-3); }
 .session-analyst__response.markdown-body blockquote { padding: var(--space-2) var(--space-3); }
+.session-analyst__response .code-block { min-width: 0; max-width: 100%; }
 .session-analyst__response.markdown-body .code-block code { padding: var(--space-3); }
+.session-analyst__response .code-block code { display: block; max-width: 100%; overflow-x: auto; }
+
+.session-analyst__author-card { min-width: 0; flex: none; margin-top: 15px; overflow: hidden; border: 1px solid var(--hairline); border-radius: var(--radius-md); background: var(--ink-deep); padding: var(--space-3); animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
+.session-analyst__author-card.is-authoring { border-color: color-mix(in oklch, var(--aurora) 35%, var(--hairline)); background: color-mix(in oklch, var(--aurora) 6%, var(--ink-deep)); }
+.session-analyst__author-head { display: flex; align-items: center; gap: var(--space-2); min-width: 0; }
+.session-analyst__author-sigil { flex: none; color: var(--aurora); font-size: 13px; line-height: 1; }
+.session-analyst__author-title { min-width: 0; flex: 1; overflow-wrap: anywhere; color: var(--text-primary); font-size: 12px; line-height: 1.35; }
+.session-analyst__author-time { flex: none; color: var(--aurora); font: 600 10px/1.3 var(--font-mono); }
+.session-analyst__author-sub { margin: var(--space-2) 0 0 21px; color: var(--text-tertiary); font-size: 10px; line-height: 1.4; }
+.session-analyst__author-track { height: 3px; margin: var(--space-3) 0 0 21px; overflow: hidden; border-radius: 2px; background: color-mix(in oklch, var(--aurora) 14%, var(--ink-mid)); }
+.session-analyst__author-track span { display: block; width: 34%; height: 100%; border-radius: inherit; background: var(--aurora); animation: analyst-author-slide 1.5s var(--ease-glide) infinite; }
+.session-analyst__author-card.is-done { border-color: color-mix(in oklch, var(--positive) 45%, var(--hairline)); background: color-mix(in oklch, var(--positive) 7%, var(--ink-deep)); }
+.session-analyst__author-card.is-done :is(.session-analyst__author-sigil, .session-analyst__author-time, .session-analyst__author-open) { color: var(--positive); }
+.session-analyst__author-open { flex: none; border: 1px solid color-mix(in oklch, var(--positive) 45%, var(--hairline)); border-radius: 999px; background: color-mix(in oklch, var(--positive) 4%, var(--ink-deep)); padding: 5px 9px; font: 600 9px/1 var(--font-mono); white-space: nowrap; cursor: pointer; }
+.session-analyst__author-open:hover { background: color-mix(in oklch, var(--positive) 10%, transparent); }
 
 .session-analyst__pulse { position: relative; min-height: 92px; flex: none; margin-top: 15px; overflow: hidden; border: 1px solid color-mix(in oklch, var(--aurora) 35%, var(--hairline)); border-radius: var(--radius-md); background: color-mix(in oklch, var(--aurora) 6%, var(--ink-deep)); padding: var(--space-3); animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
 .session-analyst__pulse-scan, .session-analyst__composer.is-working .session-analyst__composer-surface::before { content: ""; position: absolute; z-index: 1; inset: 0 0 auto; height: 2px; background: linear-gradient(90deg, transparent, var(--aurora), transparent); background-size: 200% 100%; animation: analyst-aurora-scan 1.6s linear infinite; }
@@ -183,6 +207,8 @@
 @keyframes analyst-receipt-settle { from { opacity: 0; transform: translateY(-3px); } to { opacity: 1; transform: translateY(0); } }
 @keyframes analyst-composer-dock { from { opacity: .72; transform: translateY(-7rem); } to { opacity: 1; transform: translateY(0); } }
 @keyframes analyst-artifact-count-pulse { 0%, 100% { transform: scale(1); } 45% { transform: scale(1.32); } }
+@keyframes analyst-author-slide { from { transform: translateX(-100%); } to { transform: translateX(294%); } }
+@keyframes analyst-authoring-breathe { 0%, 100% { opacity: .5; } 50% { opacity: 1; } }
 
 @container (max-width: 24rem) {
   .session-analyst__suggestions { grid-template-columns: 1fr; }
@@ -204,5 +230,5 @@
   .session-analyst-handle, .session-analyst__suggestions button, .session-analyst__followups-row button, .session-analyst__queue-item button, .session-analyst__composer-surface, .session-analyst__composer textarea, .session-analyst__selector-strip, .session-analyst__artifact-count, .session-analyst__artifact-count i { transition: none; }
   .session-analyst-handle:hover { transform: translateY(-50%); }
   .session-analyst__suggestions button:hover, .session-analyst__followups-row button:hover { transform: none; }
-  .session-analyst__pulse-scan, .session-analyst__composer.is-working .session-analyst__composer-surface::before, .session-analyst__pulse-orbit::after, .session-analyst__pulse, .session-analyst__pulse-copy strong, .session-analyst__receipt, .session-analyst__message--analyst, .session-analyst__queue-item, .session-analyst__followups, .session-analyst__slash, .session-analyst__composer.is-docking, .session-analyst__artifact-menu, .session-analyst-handle__count.is-pulsing { animation: none; }
+  .session-analyst__pulse-scan, .session-analyst__composer.is-working .session-analyst__composer-surface::before, .session-analyst__pulse-orbit::after, .session-analyst__pulse, .session-analyst__pulse-copy strong, .session-analyst__receipt, .session-analyst__message--analyst, .session-analyst__queue-item, .session-analyst__followups, .session-analyst__slash, .session-analyst__composer.is-docking, .session-analyst__artifact-menu, .session-analyst-handle__count.is-pulsing, .session-analyst-handle--artifacts.is-authoring .session-analyst-handle__count, .session-analyst__author-card, .session-analyst__author-track span { animation: none; }
 }


### PR DESCRIPTION
## Summary
- Session Analyst 채팅에 라이브 저작 카드를 추가합니다. publish_artifact 툴 인자 생성 구간(실측: 29.7초 아티팩트 턴 중 20.7초가 무피드백)에 저작 중 카드와 경과시간을 표시하고, artifact 도착 시 제목·소요시간·"Open in Artifacts" 버튼이 있는 완료 카드로 전환하며, 저작 중에는 ARTIFACTS 핸들을 예열합니다. 클라이언트 전용 — 서버/이벤트 계약 불변.
- 아티팩트 없이 턴이 끝나면 저작 카드를 정리하고, Clear artifacts 시 완료 카드도 함께 걷습니다.
- 좁은 companion 슬롯(실측 301px)에서 넓은 마크다운(테이블·코드블록·비분절 토큰)이 채팅 패널에 가로 스크롤을 만들던 문제를 해소합니다: 콘텐츠는 자체 블록 안에서 스크롤/줄바꿈하고 채팅 컨테이너는 가로로 넘치지 않습니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal test` — 326 tests pass (reducer 전이·카드 렌더·Open 버튼·핸들 예열 신규 테스트 포함)
- [x] `pnpm --filter @fleet-plugins/terminal build` (tsc)
- [x] `pnpm --filter @dotobokuri/fleet-console build` (design contract 포함)
- [x] `pnpm --dir runtime/fleet-console exec vitest run tests/instrument-design-contract.test.ts` — 16 tests pass
- [x] 격리 콘솔 + 실제 Claude CLI e2e 실측: 저작 카드 표출→done 전환→Open 버튼 재오픈 확인, 3-pane 301px에서 chat scrollWidth == clientWidth (가로 스크롤 0)
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] `git diff --check`

## Changelog
- [x] Added bilingual `.changelog.d/pr-347.md`
