### PR TITLE
feat(repository): add discovery bar and land selections in history

### DIFF
--- a/.changelog.d/pr-349.md
+++ b/.changelog.d/pr-349.md
@@ -1,0 +1,7 @@
+### fleet-plugin
+#### Added
+- [fleet-console] The Repository panel's Repositories source gains a discovery bar: fuzzy search with highlighted matches, Enter to open the first hit, and a scan-depth stepper with the result count in one row.
+  ko: Repository 패널의 Repositories 소스에 디스커버리 바가 추가됩니다: 일치 글자가 강조되는 fuzzy 검색, Enter로 첫 결과 열기, 스캔 깊이 스테퍼와 결과 건수가 한 줄에 놓입니다.
+#### Changed
+- [fleet-console] Selecting a repository or worktree now lands in History, matching how branch and tag picks already navigate; the bottom scan-depth footer is retired.
+  ko: 저장소나 워크트리를 선택하면 브랜치·태그 선택과 동일하게 History로 이동하며, 하단 스캔 깊이 푸터는 제거됩니다.

--- a/runtime/fleet-plugins/repository/client/fuzzy.ts
+++ b/runtime/fleet-plugins/repository/client/fuzzy.ts
@@ -1,0 +1,18 @@
+// 대소문자 무시 탐욕(greedy) subsequence 매칭. 인덱스는 Array.from(text) 기준 code-point 단위 —
+// 렌더러도 같은 단위로 순회해야 surrogate pair가 깨지지 않는다. 매칭 실패 시 null, 빈 질의는 빈 배열.
+export function fuzzyMatch(query: string, text: string): readonly number[] | null {
+  const queryChars = Array.from(query.toLowerCase());
+  const textChars = Array.from(text);
+  const matches: number[] = [];
+  let fromIndex = 0;
+  for (const character of queryChars) {
+    let found = -1;
+    for (let index = fromIndex; index < textChars.length; index += 1) {
+      if (textChars[index]!.toLowerCase() === character) { found = index; break; }
+    }
+    if (found < 0) return null;
+    matches.push(found);
+    fromIndex = found + 1;
+  }
+  return matches;
+}

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -257,7 +257,9 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   }, [ctx.theaterId, repoRel]);
   const handleSelectRepository = useCallback((next: { readonly relPath: string }) => {
     const decision = resolveRepositorySelection(ctx.theaterId, repoRel, next.relPath);
-    if (!decision.transition) { setSource(decision.landing); return; }
+    // 동일 컨텍스트 재선택도 "이 체크아웃의 History" 착지다 — 이전 branch/tag refFilter·텍스트 필터가
+    // 남아 스코프된 로그와 WIP 숨김을 보여주지 않게 착지 전에 걷어낸다(전환 경로와 동일한 정리).
+    if (!decision.transition) { setRefFilter(null); setFilterText(""); setSource(decision.landing); return; }
     transitionRepository(next.relPath, true, decision.landing);
   }, [ctx.theaterId, repoRel, setSource, transitionRepository]);
   const handleCloseHunk = useCallback(() => clearSelectedFile(), []);

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -6,6 +6,7 @@ import type { DiffFileEntry, DiffFileMode, DiffListResult, RepoCandidate, ReposR
 import "./repository.css";
 import { ChangedFiles, type ChangedFilesState } from "./changed-files.js";
 import { CompareView } from "./compare-view.js";
+import { fuzzyMatch } from "./fuzzy.js";
 import { buildRepoTree, compressRepoFolder, countRepos, type RepoTreeNode } from "./repo-tree.js";
 import { clearSelectedFile, setSelectedFile, type SelectedFile, useSelectedFile } from "./repository-view-store.js";
 import { HunkView } from "./hunk-view.js";
@@ -103,7 +104,7 @@ function RepositoryPanel({ ctx }: RepositoryPanelProps) {
   return <RepositoryPanelBody key={ctx.theaterId} ctx={ctx} />;
 }
 
-type Source = "repositories" | "worktrees" | "changes" | "history" | "compare" | "branches" | "tags" | "stashes";
+export type Source = "repositories" | "worktrees" | "changes" | "history" | "compare" | "branches" | "tags" | "stashes";
 type RefSource = Exclude<Source, "repositories" | "worktrees" | "changes" | "history" | "compare">;
 export type RepositoryRefItem = { label: string; ref: string; current: boolean };
 export type RepositoryStash = { name: string; subject: string };
@@ -111,6 +112,12 @@ export type RepositoryRefs = { branches: RepositoryRefItem[]; remotes: Repositor
 export type RepositoryRefRow = { key: string; source: RefSource; primary: string; sub?: string; ref: string | null; current: boolean };
 export type RepositoryRefGroup = { label?: "LOCAL" | "REMOTES"; rows: RepositoryRefRow[] };
 type Refs = RepositoryRefs;
+
+// 사용자 제스처 선택의 착지 결정 — 컨텍스트 전환 여부와 무관하게 History로 착지한다(refs 선택과 동일 문법).
+export function resolveRepositorySelection(theaterId: string | null, currentRel: string, nextRel: string): { readonly transition: boolean; readonly landing: Source } {
+  if (!theaterId || nextRel === currentRel) return { transition: false, landing: "history" };
+  return { transition: true, landing: "history" };
+}
 
 export function isRemoteHeadRef(ref: string): boolean {
   return /^refs\/remotes\/[^/]+\/HEAD$/.test(ref);
@@ -161,7 +168,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
     setSourceState(next);
     saveRepositorySource(next);
   }, []);
-  const transitionRepository = useCallback((nextRepoRel: string, persist: boolean) => {
+  const transitionRepository = useCallback((nextRepoRel: string, persist: boolean, landing: Source = "changes") => {
     if (!ctx.theaterId) return;
     if (persist) saveRepositoryRel(ctx.theaterId, nextRepoRel);
     clearSelectedFile();
@@ -173,7 +180,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
     setRefs({ branches: [], remotes: [], tags: [], stashes: [] });
     repoRelRef.current = nextRepoRel;
     setRepoRel(nextRepoRel);
-    setSource("changes");
+    setSource(landing);
   }, [ctx.theaterId, setSource]);
   useEffect(() => {
     if (!ctx.theaterId) return;
@@ -249,8 +256,9 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
     if (ctx.theaterId) setSelectedFile(entry, ctx.theaterId, repoRel);
   }, [ctx.theaterId, repoRel]);
   const handleSelectRepository = useCallback((next: { readonly relPath: string }) => {
-    if (!ctx.theaterId || next.relPath === repoRel) { setSource("changes"); return; }
-    transitionRepository(next.relPath, true);
+    const decision = resolveRepositorySelection(ctx.theaterId, repoRel, next.relPath);
+    if (!decision.transition) { setSource(decision.landing); return; }
+    transitionRepository(next.relPath, true, decision.landing);
   }, [ctx.theaterId, repoRel, setSource, transitionRepository]);
   const handleCloseHunk = useCallback(() => clearSelectedFile(), []);
   const handleViewMode = useCallback((next: ViewMode) => {
@@ -312,24 +320,44 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
 function SourceIcon({ source }: { readonly source: Source }) { const path = source === "repositories" ? "M3 5h12v9H3zM5 3h8v2" : source === "worktrees" ? "M5 3v12M5 6h7M5 12h7" : source === "changes" ? "M3 4h12M3 9h12M3 14h12" : source === "history" ? "M4 4v10h10M7 7h6v5" : source === "compare" ? "M5.5 3v9M3 9.5l2.5 2.5L8 9.5M12.5 15V6M10 8.5L12.5 6L15 8.5" : source === "branches" ? "M5 3v12M5 6h7M5 12h7" : source === "tags" ? "M3 4h8l4 4-7 7-5-5z" : "M4 5h10v9H4zM6 3h6"; return <svg viewBox="0 0 18 18" aria-hidden="true"><path d={path} fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" /></svg>; }
 function SourceNav({ source, refs, repos, worktrees, onSource }: { readonly source: Source; readonly refs: Refs; readonly repos: readonly RepoCandidate[]; readonly worktrees: readonly WorktreeCandidate[]; readonly onSource: (source: Source) => void }) { const button = (id: Source, label: string, count?: number) => <button key={id} type="button" aria-label={label} aria-current={source === id ? "page" : undefined} onClick={() => onSource(id)}><SourceIcon source={id} /><span>{label}</span>{count !== undefined && <i>{count}</i>}</button>; return <nav className="repository-source-nav" aria-label="Repository sources"><b>CONTEXT</b>{button("repositories", "Repositories", repos.length)}{button("worktrees", "Worktrees", worktrees.length)}<b>WORKING</b>{button("changes", "Changes")}{button("history", "History")}{button("compare", "Compare")}<b>REFS</b>{button("branches", "Branches", refs.branches.length + refs.remotes.filter((item) => !isRemoteHeadRef(item.ref)).length)}{button("tags", "Tags", refs.tags.length)}{button("stashes", "Stashes", refs.stashes.length)}</nav>; }
 function RepoList({ repos, selectedRel, onRepository, scanDepth, onScanDepth, truncated }: { readonly repos: readonly RepoCandidate[]; readonly selectedRel: string; readonly onRepository: (repo: RepoCandidate) => void; readonly scanDepth: number; readonly onScanDepth: (depth: number) => void; readonly truncated: boolean }) {
+  const [query, setQuery] = useState("");
   // 루트 저장소는 컨텍스트 복귀 affordance이므로 트리 밖 THIS THEATER 그룹에 고정한다.
   // (repos.ts 주석의 의도 — nested 저장소로 진입해도 루트로 되돌아오는 진입점이 필요.)
   const rootRepos = repos.filter((repo) => repo.kind === "root").sort((a, b) => a.name.localeCompare(b.name));
   const nestedRepos = repos.filter((repo) => repo.kind === "nested");
   const nestedTree = buildRepoTree(nestedRepos);
-  const groups: readonly { readonly key: string; readonly label: "THIS THEATER" | "NESTED"; readonly render: () => ReactNode }[] = [
+  const matchRepository = (repo: RepoCandidate) => {
+    const nameMatch = fuzzyMatch(query, repo.name);
+    const match = nameMatch ?? fuzzyMatch(query, repo.relPath);
+    return match === null ? null : { repo, nameMatch: nameMatch ?? undefined };
+  };
+  const rootMatches = query ? rootRepos.map(matchRepository).filter((match) => match !== null) : [];
+  const nestedMatches = query ? nestedRepos.map(matchRepository).filter((match) => match !== null) : [];
+  const matchedCount = rootMatches.length + nestedMatches.length;
+  const groups: readonly { readonly key: string; readonly label: "THIS THEATER" | "NESTED"; readonly render: () => ReactNode }[] = query ? [
+    ...(rootMatches.length > 0 ? [{ key: "root", label: "THIS THEATER" as const, render: () => <>{rootMatches.map(({ repo, nameMatch }) => <RepoLeafRow key={repo.relPath} repo={repo} depth={0} selectedRel={selectedRel} onRepository={onRepository} nameMatch={nameMatch} />)}</> }] : []),
+    ...(nestedMatches.length > 0 ? [{ key: "nested", label: "NESTED" as const, render: () => <>{nestedMatches.map(({ repo, nameMatch }) => <RepoLeafRow key={repo.relPath} repo={repo} depth={0} selectedRel={selectedRel} onRepository={onRepository} nameMatch={nameMatch} />)}</> }] : []),
+  ] : [
     ...(rootRepos.length > 0 ? [{ key: "root", label: "THIS THEATER" as const, render: () => <>{rootRepos.map((repo) => <RepoLeafRow key={repo.relPath} repo={repo} depth={0} selectedRel={selectedRel} onRepository={onRepository} />)}</> }] : []),
     ...(nestedRepos.length > 0 ? [{ key: "nested", label: "NESTED" as const, render: () => <RepoTreeChildren node={nestedTree} depth={0} selectedRel={selectedRel} onRepository={onRepository} /> }] : []),
   ];
   return <div className="repository-scan-pane">
-    <div className="repository-ref-list">{groups.map((group) => <div key={group.key} className="repository-ref-group"><b className="repository-ref-group-label">{group.label}</b>{group.render()}</div>)}</div>
-    <div className="repository-scan-foot">
-      <label htmlFor="repository-scan-depth">Depth</label>
-      <select id="repository-scan-depth" className="repository-scan-depth" value={scanDepth} onChange={(event) => onScanDepth(Number.parseInt(event.target.value, 10))}>
-        {Array.from({ length: SCAN_DEPTH_MAX - SCAN_DEPTH_MIN + 1 }, (_, index) => SCAN_DEPTH_MIN + index).map((depth) => <option key={depth} value={depth}>{depth}</option>)}
-      </select>
-      <span className="repository-scan-count">{repos.length} found{truncated ? " · limit reached" : ""}</span>
+    <div className="repository-discovery">
+      <input type="text" className="repository-filter-input" placeholder="Find repositories…" aria-label="Find repositories" value={query} onChange={(event) => setQuery(event.target.value)} onKeyDown={(event) => {
+        // 한글 IME 조합 확정 Enter가 첫 결과를 오선택하지 않게 조합 중에는 무시한다.
+        if (event.key !== "Enter" || event.nativeEvent.isComposing) return;
+        const firstMatch = rootMatches[0] ?? nestedMatches[0];
+        if (firstMatch) onRepository(firstMatch.repo);
+      }} />
+      {query ? <button type="button" className="repository-filter-clear" aria-label="Clear search" onClick={() => setQuery("")}>✕</button> : null}
+      <span className="repository-discovery-depth">Depth
+        <button type="button" className="repository-depth-step" aria-label="Scan shallower" disabled={scanDepth <= SCAN_DEPTH_MIN} onClick={() => onScanDepth(scanDepth - 1)}>−</button>
+        <output className="repository-depth-value">{scanDepth}</output>
+        <button type="button" className="repository-depth-step" aria-label="Scan deeper" disabled={scanDepth >= SCAN_DEPTH_MAX} onClick={() => onScanDepth(scanDepth + 1)}>+</button>
+      </span>
+      <span className="repository-scan-count">{query ? `${matchedCount} of ${repos.length}` : `${repos.length} found${truncated ? " · limit reached" : ""}`}</span>
     </div>
+    <div className="repository-ref-list">{groups.map((group) => <div key={group.key} className="repository-ref-group"><b className="repository-ref-group-label">{group.label}</b>{group.render()}</div>)}{query && matchedCount === 0 ? <div className="repository-empty-row">No matching repositories</div> : null}</div>
   </div>;
 }
 
@@ -366,22 +394,22 @@ function RepoTreeFolder({ dirKey, node, depth, selectedRel, onRepository }: { re
   </div>;
 }
 
-function RepoLeafRow({ repo, depth, selectedRel, onRepository }: { readonly repo: RepoCandidate; readonly depth: number } & RepoTreeCommonProps) {
+function RepoLeafRow({ repo, depth, selectedRel, onRepository, nameMatch }: { readonly repo: RepoCandidate; readonly depth: number; readonly nameMatch?: readonly number[] } & RepoTreeCommonProps) {
   // 저장소 리프 아이콘을 폴더 아이콘 컬럼(padding-left 12 + chevron 12 + gap 6 = 30) 아래에 정렬한다.
   const indent = depth * 16 + 30;
   return <button type="button" title={repo.relPath} className={`repository-ref-row${repo.relPath === selectedRel ? " is-current" : ""}`} style={{ paddingLeft: `${indent}px` }} onClick={() => onRepository(repo)}>
     <SourceIcon source="repositories" />
-    <span className="repository-ref-name">{repo.name}{repo.relPath === selectedRel && " ✓"}</span>
+    <span className="repository-ref-name">{nameMatch ? Array.from(repo.name).map((character, index) => nameMatch.includes(index) ? <b key={index} className="repository-ref-hl">{character}</b> : character) : repo.name}</span>{repo.relPath === selectedRel && <span className="repository-ref-mark">✓</span>}
     {repo.branch && <span className="repository-ref-sub">{repo.branch}</span>}
   </button>;
 }
-function WorktreeList({ worktrees, onWorktree }: { readonly worktrees: readonly WorktreeCandidate[]; readonly onWorktree: (worktree: WorktreeCandidate) => void }) { return <div className="repository-ref-list">{worktrees.map((worktree) => <button type="button" key={worktree.relPath} title={worktree.relPath} className={`repository-ref-row${worktree.current ? " is-current" : ""}`} onClick={() => onWorktree(worktree)}><SourceIcon source="worktrees" /><span className="repository-ref-name">{worktree.name}{worktree.current && " ✓"}</span>{worktree.branch && <span className="repository-ref-sub">{worktree.branch}</span>}</button>)}</div>; }
+function WorktreeList({ worktrees, onWorktree }: { readonly worktrees: readonly WorktreeCandidate[]; readonly onWorktree: (worktree: WorktreeCandidate) => void }) { return <div className="repository-ref-list">{worktrees.map((worktree) => <button type="button" key={worktree.relPath} title={worktree.relPath} className={`repository-ref-row${worktree.current ? " is-current" : ""}`} onClick={() => onWorktree(worktree)}><SourceIcon source="worktrees" /><span className="repository-ref-name">{worktree.name}</span>{worktree.current && <span className="repository-ref-mark">✓</span>}{worktree.branch && <span className="repository-ref-sub">{worktree.branch}</span>}</button>)}</div>; }
 function RefList({ source, refs, onRef }: { readonly source: Source; readonly refs: Refs; readonly onRef: (ref: string) => void }) {
   if (source === "repositories" || source === "worktrees" || source === "changes" || source === "history" || source === "compare") return null;
   return <div className="repository-ref-list">{buildRefListGroups(source, refs).map((group) => <div key={group.label ?? source} className="repository-ref-group">{group.label && <b className="repository-ref-group-label">{group.label}</b>}{group.rows.map((row) => {
     return <button type="button" key={row.key} className={`repository-ref-row${row.current ? " is-current" : ""}`} disabled={row.ref === null} onClick={() => {
       if (row.ref) onRef(row.ref);
-    }}><SourceIcon source={row.source} /><span className="repository-ref-name">{row.primary}{row.current && " ✓"}</span>{row.sub && <span className="repository-ref-sub">{row.sub}</span>}</button>;
+    }}><SourceIcon source={row.source} /><span className="repository-ref-name">{row.primary}</span>{row.current && <span className="repository-ref-mark">✓</span>}{row.sub && <span className="repository-ref-sub">{row.sub}</span>}</button>;
   })}</div>)}</div>;
 }
 

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -159,6 +159,9 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   const [compareFileOpen, setCompareFileOpen] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>(readViewMode);
   const [filterText, setFilterText] = useState("");
+  // 동일 컨텍스트 재착지는 repoRel key가 안 바뀌어 History 패널이 리마운트되지 않는다 —
+  // epoch를 key에 섞어 전환 착지와 동일한 초기 상태(로컬 필터·선택·스크롤)로 재설정한다.
+  const [historyLandingEpoch, setHistoryLandingEpoch] = useState(0);
   const selectedFile = useSelectedFile(ctx.theaterId ?? null, repoRel);
   const [listPaneWidth, setListPaneWidth] = useState(readListPaneWidth);
   const listPaneWidthRef = useRef(listPaneWidth);
@@ -257,9 +260,9 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   }, [ctx.theaterId, repoRel]);
   const handleSelectRepository = useCallback((next: { readonly relPath: string }) => {
     const decision = resolveRepositorySelection(ctx.theaterId, repoRel, next.relPath);
-    // 동일 컨텍스트 재선택도 "이 체크아웃의 History" 착지다 — 이전 branch/tag refFilter·텍스트 필터가
-    // 남아 스코프된 로그와 WIP 숨김을 보여주지 않게 착지 전에 걷어낸다(전환 경로와 동일한 정리).
-    if (!decision.transition) { setRefFilter(null); setFilterText(""); setSource(decision.landing); return; }
+    // 동일 컨텍스트 재선택도 "이 체크아웃의 History" 착지다 — refFilter를 걷어내고 History 패널을
+    // epoch 리마운트해 전환 착지와 동일한 초기 상태로 만든다(스코프된 로그·WIP 숨김 잔존 방지).
+    if (!decision.transition) { setRefFilter(null); setHistoryLandingEpoch((value) => value + 1); setSource(decision.landing); return; }
     transitionRepository(next.relPath, true, decision.landing);
   }, [ctx.theaterId, repoRel, setSource, transitionRepository]);
   const handleCloseHunk = useCallback(() => clearSelectedFile(), []);
@@ -305,7 +308,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
     <div className="repository-unified"><div className={`repository-identity${repoRel ? " is-subcontext" : ""}`}><RepositoryIcon /><strong>{selectedRepo?.name ?? "Repository"}</strong>{selectedRepo?.branch && <span>{selectedRepo.branch}</span>}</div><div className="repository-unified-body"><SourceNav source={source} refs={refs} repos={repos} worktrees={worktrees} onSource={setSource} /><div className="repository-source-content">
       {source === "repositories" ? reposError ? <div className="history-error">Unable to load repositories<button type="button" className="repository-refresh-btn" onClick={() => setReposRetry((value) => value + 1)}>Retry</button></div> : <RepoList repos={repos} selectedRel={repoRel} onRepository={handleSelectRepository} scanDepth={scanDepth} onScanDepth={setScanDepth} truncated={reposTruncated} /> : null}
       {source === "worktrees" ? worktreesError ? <div className="history-error">Unable to load worktrees<button type="button" className="repository-refresh-btn" onClick={() => setWorktreesRetry((value) => value + 1)}>Retry</button></div> : <WorktreeList worktrees={worktrees} onWorktree={handleSelectRepository} /> : null}
-      <div className="repository-source-fill" hidden={source !== "history"}><HistoryPanel key={`${ctx.theaterId ?? ""}:${repoRel}`} ctx={ctx} repoRel={repoRel} active={source === "history"} refFilter={refFilter} wipFiles={wipFiles} onInspectorOpenChange={setHistoryInspectorOpen} onClearRef={() => setRefFilter(null)} onWip={() => setSource("changes")} /></div>
+      <div className="repository-source-fill" hidden={source !== "history"}><HistoryPanel key={`${ctx.theaterId ?? ""}:${repoRel}:${historyLandingEpoch}`} ctx={ctx} repoRel={repoRel} active={source === "history"} refFilter={refFilter} wipFiles={wipFiles} onInspectorOpenChange={setHistoryInspectorOpen} onClearRef={() => setRefFilter(null)} onWip={() => setSource("changes")} /></div>
       <div className="repository-source-fill" hidden={source !== "compare"}><CompareView key={`${ctx.theaterId ?? ""}:${repoRel}`} ctx={ctx} repoRel={repoRel} refs={refs} refsError={refsError} onRetryRefs={() => setRefsRetry((value) => value + 1)} onFileOpenChange={setCompareFileOpen} /></div>
       {source !== "repositories" && source !== "worktrees" && source !== "changes" && source !== "history" && source !== "compare" ? refsError ? <div className="history-error">Unable to load refs<button type="button" className="repository-refresh-btn" onClick={() => setRefsRetry((value) => value + 1)}>Retry</button></div> : <RefList source={source} refs={refs} onRef={(ref) => { setRefFilter(ref); setSource("history"); }} /> : null}
       <div hidden={source !== "changes"} ref={rootRef} className={`repository-root${selectedFile ? " has-hunk" : ""}${isDragging ? " is-dragging" : ""}`} style={selectedFile ? { gridTemplateColumns: buildDiffGridTemplate(listPaneWidth) } : undefined}>

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -998,15 +998,15 @@
 .repository-source-content { flex: 1; min-width: 0; min-height: 0; }
 /* 숨김-마운트 래퍼가 높이 문맥을 끊으면 history-root의 height:100%가 내용 높이로 풀려 내부 스크롤이 죽는다 */
 .repository-source-fill { height: 100%; min-height: 0; }
-/* 목록은 스크롤되고 스캔 푸터는 하단에 고정된다 */
+/* Discovery bar는 목록 위에 고정되고 저장소 목록만 스크롤된다. */
 .repository-scan-pane { display: flex; flex-direction: column; min-height: 0; height: 100%; }
 .repository-scan-pane > .repository-ref-list { flex: 1; min-height: 0; overflow-y: auto; align-content: start; }
-.repository-scan-foot { display: flex; align-items: center; gap: 8px; flex: none; padding: 7px 10px; border-top: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--surface-band) 72%, transparent); }
-.repository-scan-foot label { color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; letter-spacing: .12em; text-transform: uppercase; }
-/* appearance:none으로 UA 기본 select 크롬을 걷어내고 필터 입력과 같은 시각 등급으로 맞춘다 */
-.repository-scan-depth { appearance: none; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: color-mix(in oklch, var(--ink-abyss) 35%, transparent); color: var(--ink-spectral); font-family: var(--font-mono); font-size: 12px; padding: 2px 6px; outline: none; cursor: pointer; transition: border-color var(--duration-fast) var(--ease-glide); }
-.repository-scan-depth:hover { border-color: var(--surface-rim-strong); }
-.repository-scan-depth:focus-visible { border-color: var(--brass); }
+.repository-discovery { display: flex; align-items: center; gap: 8px; flex: none; padding: 6px 10px; border-bottom: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--surface-band) 55%, transparent); }
+.repository-discovery-depth { display: inline-flex; align-items: center; gap: 3px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 9.5px; letter-spacing: .1em; text-transform: uppercase; }
+.repository-depth-step { border: 0; background: none; color: var(--text-tertiary); cursor: pointer; font-family: var(--font-mono); font-size: 12px; padding: 0 3px; }
+.repository-depth-step:hover:not(:disabled) { color: var(--text-primary); }
+.repository-depth-step:disabled { opacity: .4; cursor: default; }
+.repository-depth-value { border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); padding: 0 6px; color: var(--ink-spectral); font-family: var(--font-mono); font-size: 11px; }
 .repository-scan-count { margin-left: auto; min-width: 0; overflow: hidden; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
 .repository-ref-list { padding: var(--space-2); display: grid; gap: 2px; }
 .repository-ref-group { display: grid; gap: 2px; }
@@ -1018,6 +1018,10 @@
 .repository-ref-row.is-current:hover { color: var(--text-primary); }
 .repository-ref-row svg { width: 13px; height: 13px; flex: none; opacity: .85; }
 .repository-ref-name { min-width: 0; overflow: hidden; font-size: 12.5px; font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }
+/* 현재 체크아웃 마크 = 위치 채널 */
+.repository-ref-mark { flex: none; color: var(--brass); font-size: 11px; }
+/* 매칭 글자 = 포커스 채널(brass) */
+.repository-ref-hl { color: var(--brass); font-weight: 700; }
 .repository-ref-sub { margin-left: auto; color: var(--text-tertiary); flex: none; font-family: var(--font-mono); font-size: 10px; }
 .repository-ref-row.is-current .repository-ref-sub { color: var(--brass); }
 .repository-wip-row, .repository-ref-chip { border: 0; background: transparent; color: var(--text-secondary); font: inherit; text-align: left; padding: 7px 10px; }
@@ -1031,7 +1035,7 @@
 /* ── Compare 뷰 ── */
 .repository-compare { display: grid; grid-template-rows: auto minmax(0, 1fr); height: 100%; min-height: 0; }
 .repository-compare-controls { display: flex; align-items: center; gap: 6px; padding: 7px 10px; border-bottom: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--surface-band) 55%, transparent); }
-/* .repository-scan-depth와 동일한 UA 크롬 제거·시각 등급 */
+/* UA 기본 select 크롬을 걷어내고 필터 입력과 같은 시각 등급으로 맞춘다. */
 .repository-compare-select { flex: 1; min-width: 0; appearance: none; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: color-mix(in oklch, var(--ink-abyss) 35%, transparent); color: var(--ink-spectral); font-family: var(--font-mono); font-size: 12px; padding: 3px 6px; outline: none; cursor: pointer; text-overflow: ellipsis; transition: border-color var(--duration-fast) var(--ease-glide); }
 .repository-compare-select:hover { border-color: var(--surface-rim-strong); }
 .repository-compare-select:focus-visible { border-color: var(--brass); }

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -87,18 +87,21 @@ describe("Repository design grammar", () => {
   it("uses core surface tokens for panel material", () => {
     expect(css).not.toContain("background: var(--ink-deep)");
 
-    for (const selector of [".repository-toolbar", ".repository-plugin-toolbar", ".history-toolbar", ".repository-compare-controls", ".repository-line-file-label"]) {
+    for (const selector of [".repository-toolbar", ".repository-plugin-toolbar", ".history-toolbar", ".repository-compare-controls", ".repository-line-file-label", ".repository-discovery"]) {
       expect(blockOf(selector), selector).toContain("var(--surface-band) 55%");
     }
-    for (const selector of [".repository-identity", ".repository-source-nav", ".repository-scan-foot"]) {
+    for (const selector of [".repository-identity", ".repository-source-nav"]) {
       expect(blockOf(selector), selector).toContain("var(--surface-band) 72%");
     }
+    expect(css).not.toContain(".repository-scan-foot");
+    expect(blockOf(".repository-ref-mark")).toContain("var(--brass)");
+    expect(blockOf(".repository-ref-hl")).toContain("var(--brass)");
     // .history-detail-pane은 스택 레이아웃 재선언 포함 2개 규칙 — background를 선언하는 모든 규칙이 glass를 소비해야 한다.
     const detailPanes = blocksOf(".history-detail-pane").filter((body) => body.includes("background"));
     expect(detailPanes.length).toBeGreaterThanOrEqual(2);
     for (const body of detailPanes) expect(body).toContain("var(--surface-glass) 70%");
 
-    for (const selector of [".repository-filter-input", ".history-filter-input", ".repository-scan-depth", ".repository-compare-select", ".repository-view-toggle"]) {
+    for (const selector of [".repository-filter-input", ".history-filter-input", ".repository-compare-select", ".repository-view-toggle"]) {
       expect(blockOf(selector), selector).toContain("var(--ink-abyss) 35%");
     }
   });

--- a/runtime/fleet-plugins/repository/tests/fuzzy.test.ts
+++ b/runtime/fleet-plugins/repository/tests/fuzzy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { fuzzyMatch } from "../client/fuzzy.js";
+
+describe("fuzzyMatch", () => {
+  it("greedily matches a subsequence", () => {
+    expect(fuzzyMatch("plg", "examples/plugin-demo")).toEqual([4, 5, 12]);
+  });
+
+  it("ignores letter casing", () => {
+    expect(fuzzyMatch("FH", "fleet-harness")).toEqual([0, 6]);
+  });
+
+  it("returns null when the subsequence is absent", () => {
+    expect(fuzzyMatch("xyz", "fleet-harness")).toBeNull();
+  });
+
+  it("returns no indices for an empty query", () => {
+    expect(fuzzyMatch("", "anything")).toEqual([]);
+  });
+
+  it("returns increasing indices whose characters match the query", () => {
+    const text = "packages/core-agent";
+    const indices = fuzzyMatch("core", text);
+    expect(indices).not.toBeNull();
+    expect(indices!.every((index, position) => position === 0 || index > indices![position - 1]!)).toBe(true);
+    expect(indices!.map((index) => text[index]).join("").toLowerCase()).toBe("core");
+  });
+
+  it("returns code-point indices for surrogate pairs", () => {
+    expect(fuzzyMatch("😀", "😀repo")).toEqual([0]);
+    expect(fuzzyMatch("r", "😀repo")).toEqual([1]);
+  });
+});

--- a/runtime/fleet-plugins/repository/tests/repository-navigation-contract.test.ts
+++ b/runtime/fleet-plugins/repository/tests/repository-navigation-contract.test.ts
@@ -1,0 +1,26 @@
+import fs from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+import { resolveRepositorySelection } from "../client/rail-panel.js";
+
+const source = await fs.readFile(new URL("../client/rail-panel.tsx", import.meta.url), "utf8");
+
+describe("Repository navigation landing contract", () => {
+  it("lands a repeated selection in history without a transition", () => {
+    expect(resolveRepositorySelection("theater-1", "repo-a", "repo-a")).toEqual({ transition: false, landing: "history" });
+  });
+
+  it("lands a different repository or worktree in history through a transition", () => {
+    expect(resolveRepositorySelection("theater-1", "repo-a", "repo-b")).toEqual({ transition: true, landing: "history" });
+  });
+
+  it("does not transition without a theater", () => {
+    expect(resolveRepositorySelection(null, "repo-a", "repo-b")).toEqual({ transition: false, landing: "history" });
+  });
+
+  it("keeps automatic context recovery landing in changes", () => {
+    expect(source).toContain('landing: Source = "changes"');
+    expect(source).toContain("setSource(landing)");
+  });
+});


### PR DESCRIPTION
## Summary
- Repository 패널 Repositories 소스의 하단 scan-depth 푸터를 폐지하고, 목록 상단 한 줄의 **Discovery bar**로 통합 (사용자 재가 D): fuzzy 검색(subsequence 매칭 + 일치 글자 brass 하이라이트 + Enter=첫 매칭 선택, IME 조합 가드) + Depth 스테퍼(1–8, localStorage 영속 유지) + 결과 건수(`N of M`).
- repo/worktree 선택이 **History로 착지**하도록 통일 (사용자 재가 E) — refs(branch/tag) 선택이 이미 쓰는 문법과 동일화. 자동 컨텍스트 복구 경로(worktrees 400 폴백·restore 동기화)는 기존 Changes 착지 유지. History의 "Uncommitted changes" WIP 행이 Changes 진입점을 보존.
- 현재 체크아웃 "✓"를 전용 `repository-ref-mark` span(brass 위치 채널)으로 분리 — repo/worktree/ref 행 공통.
- 신설 `fuzzy.ts`는 code-point 단위 인덱스 계약(surrogate pair 안전), 착지 결정은 `resolveRepositorySelection` 순수 함수로 추출해 동작 검증.
- Sentinel 리뷰 반영: IME 조합 Enter 가드(M), code-point 통일(L), 착지 계약 동작 테스트화(L). 검색 중 트리 접힘 상태 리셋(L)은 신기능 내부 뉘앙스로 판단해 미반영(후속 polish 후보).

## Test Plan
- [x] `pnpm --filter @fleet-plugins/repository typecheck` / `build` — 통과
- [x] `pnpm --filter @fleet-plugins/repository test` — 243/243 통과 (fuzzy 6케이스·navigation-contract 4케이스·design-grammar 확장 포함)
- [x] 격리 콘솔 헤디드 QA — fuzzy 하이라이트·`N of M` 카운트·빈 상태·클리어·Depth 스테퍼(localStorage `4` 영속 실측)·행 클릭/Enter → History 착지(200 커밋 렌더 확인)·WIP 행 보존
- [x] Sentinel 리뷰 — Critical/High 0건, Medium 1·Low 2 반영, Low 1 사유 기각
- [x] Changelog: `.changelog.d/pr-349.md` — 프래그먼트 문법·이중언어 요약·검증 완료
