### PR TITLE
fix(repository): straighten the active source-nav mark

### DIFF
--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -989,8 +989,11 @@
 /* --surface-deep은 어느 테마에도 정의된 적 없는 토큰이라 이 선언은 계속 무효였다(배경 투명).
    정체 스트립과 같은 테마 재질을 이어받도록 --surface-band를 소비한다. */
 .repository-source-nav { width: 148px; flex: none; display: flex; flex-direction: column; gap: 2px; padding: 8px 6px; border-right: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--surface-band) 72%, transparent); }
-.repository-source-nav button, .repository-source-nav span { min-height: 28px; padding: 5px 8px; border: 0; border-radius: var(--radius-xs); background: transparent; color: var(--text-secondary); text-align: left; font: inherit; font-size: 12px; }
-.repository-source-nav button[aria-current="page"] { color: var(--text-primary); background: color-mix(in oklch, var(--ink-fog) 10%, transparent); box-shadow: inset 2px 0 0 var(--brass); }
+.repository-source-nav button, .repository-source-nav span { position: relative; min-height: 28px; padding: 5px 8px; border: 0; border-radius: var(--radius-xs); background: transparent; color: var(--text-secondary); text-align: left; font: inherit; font-size: 12px; }
+.repository-source-nav button[aria-current="page"] { color: var(--text-primary); background: color-mix(in oklch, var(--ink-fog) 10%, transparent); }
+/* 활성 마크는 identity 스파인과 동일한 직선 전고 사각 띠 — inset shadow는 칩 라운드를 따라 휘므로
+   ::before를 나브 좌측 에지(패딩 6px 밖)에 그려 형태를 통일한다. */
+.repository-source-nav button[aria-current="page"]::before { content: ""; position: absolute; top: 0; bottom: 0; left: -6px; width: 2px; background: var(--brass); }
 .repository-source-nav button:disabled, .repository-source-nav span { color: var(--text-tertiary); }
 .repository-source-nav b { padding: 8px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; letter-spacing: .12em; }
 .repository-source-nav svg { width: 14px; height: 14px; flex: none; }

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -78,7 +78,11 @@ describe("Repository design grammar", () => {
     const activeNav = blockOf('.repository-source-nav button[aria-current="page"]');
     expect(activeNav).toContain("var(--text-primary)");
     expect(activeNav).toContain("var(--ink-fog) 10%");
-    expect(activeNav).toContain("inset 2px 0 0 var(--brass)");
+    // 활성 마크는 칩 라운드에 말리는 inset shadow가 아니라 identity 스파인과 같은 직선 사각 띠여야 한다.
+    expect(activeNav).not.toContain("inset 2px 0 0 var(--brass)");
+    const activeNavMark = blockOf('.repository-source-nav button[aria-current="page"]::before');
+    expect(activeNavMark).toContain("width: 2px");
+    expect(activeNavMark).toContain("var(--brass)");
 
     expect(blockOf(".history-badge--tag")).not.toContain("var(--brass)");
     expect(blockOf(".history-badge--head")).toContain("var(--brass)");


### PR DESCRIPTION
## Summary
- 소스 내비 활성 마크가 inset box-shadow라 칩의 6px 라운드를 따라 휘어 "(" 형태로 읽혔음 — identity 스트립의 직선 전고(全高) 스파인과 형태 불일치 (사용자 피드백).
- 마크를 `::before` 2px 사각 띠로 교체해 나브 좌측 에지에 그림 — identity 스파인과 동일한 형태로 통일. 워시·텍스트 채널은 무변경.
- `design-grammar.test.ts`가 새 형태를 핀(inset shadow 부재 + ::before 마크 존재).

## Test Plan
- [x] `pnpm --filter @fleet-plugins/repository typecheck` / `build` — 통과
- [x] `pnpm --filter @fleet-plugins/repository test` — 245/245 통과
- [x] 격리 콘솔 헤디드 확인 — computed ::before 2px·brass·top 0·나브 에지, box-shadow 제거, 스크린샷 대조
- [x] Changelog: no-changelog — 미릴리스 PR#346 형태의 교정으로 `pr-346.md` 서술이 계속 유효