### PR TITLE
feat(console): move analyst selector strip outside the composer

### DIFF
--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
@@ -56,7 +56,7 @@ describe("Session Analyst Evidence Pulse", () => {
     vi.unstubAllGlobals();
   });
 
-  it("renders the initial settings and prompt as one compact composer row", () => {
+  it("renders the initial settings beside and outside the prompt surface", () => {
     storeState = {
       ...initialAnalysisState,
       catalog,
@@ -67,10 +67,14 @@ describe("Session Analyst Evidence Pulse", () => {
     const { container, root } = renderPanel();
     const composer = container.querySelector(".session-analyst__composer")!;
     const surface = composer.querySelector(".session-analyst__composer-surface")!;
+    const selectorStrip = composer.querySelector(".session-analyst__selector-strip")!;
 
     expect(container.querySelector(".session-analyst__chat-pane")?.classList.contains("is-initial")).toBe(true);
     expect(composer.classList.contains("is-initial")).toBe(true);
-    expect(surface.querySelectorAll("select")).toHaveLength(3);
+    expect(selectorStrip.parentElement).toBe(composer);
+    expect(selectorStrip.nextElementSibling).toBe(surface);
+    expect(surface.querySelector(".session-analyst__selector-strip")).toBeNull();
+    expect(selectorStrip.querySelectorAll("select")).toHaveLength(3);
     expect(surface.querySelector("textarea")?.rows).toBe(1);
     expect(surface.querySelector(".session-analyst__send")?.getAttribute("aria-label")).toBe("Send");
     expect(container.querySelector(".session-analyst__composer-meta")).toBeNull();
@@ -390,6 +394,7 @@ describe("Session Analyst Evidence Pulse", () => {
     const { container, root } = renderPanel();
     const textarea = container.querySelector("textarea")!;
     const palette = container.querySelector('[role="listbox"]')!;
+    expect(palette.parentElement).toBe(container.querySelector(".session-analyst__composer"));
     expect(textarea.getAttribute("role")).toBe("combobox");
     expect(textarea.getAttribute("aria-expanded")).toBe("true");
     expect(textarea.getAttribute("aria-controls")).toBe(palette.id);

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
@@ -238,12 +238,12 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
               ))}
             </div>
           ) : null}
+          {!hasInteracted ? <div className="session-analyst__selector-strip" aria-label="Initial analysis settings">
+            <span className="session-analyst__select"><select aria-label="Analysis CLI" disabled={state.started || !state.catalog} value={state.cliId} onChange={(event) => dispatch({ type: "select-cli", cliId: event.target.value })}>{state.catalog?.clis.map((item) => <option key={item.cliId} value={item.cliId} disabled={!item.available}>{item.label}</option>)}</select></span>
+            <span className="session-analyst__select"><select aria-label="Analysis model" disabled={state.started || !model} value={state.model} onChange={(event) => dispatch({ type: "select-model", model: event.target.value })}>{cli?.models.map((item) => <option key={item.id} value={item.id}>{item.label}</option>)}</select></span>
+            <span className="session-analyst__select"><select aria-label="Analysis effort" disabled={state.started || !model || !model.effortLevels.length} value={state.effort} onChange={(event) => dispatch({ type: "select-effort", effort: event.target.value })}>{model?.effortLevels.length ? model.effortLevels.map((item) => <option key={item} value={item}>{item}</option>) : <option value="">n/a</option>}</select></span>
+          </div> : null}
           <div className="session-analyst__composer-surface">
-            {!hasInteracted ? <div className="session-analyst__selector-strip" aria-label="Initial analysis settings">
-              <span className="session-analyst__select"><select aria-label="Analysis CLI" disabled={state.started || !state.catalog} value={state.cliId} onChange={(event) => dispatch({ type: "select-cli", cliId: event.target.value })}>{state.catalog?.clis.map((item) => <option key={item.cliId} value={item.cliId} disabled={!item.available}>{item.label}</option>)}</select></span>
-              <span className="session-analyst__select"><select aria-label="Analysis model" disabled={state.started || !model} value={state.model} onChange={(event) => dispatch({ type: "select-model", model: event.target.value })}>{cli?.models.map((item) => <option key={item.id} value={item.id}>{item.label}</option>)}</select></span>
-              <span className="session-analyst__select"><select aria-label="Analysis effort" disabled={state.started || !model || !model.effortLevels.length} value={state.effort} onChange={(event) => dispatch({ type: "select-effort", effort: event.target.value })}>{model?.effortLevels.length ? model.effortLevels.map((item) => <option key={item} value={item}>{item}</option>) : <option value="">n/a</option>}</select></span>
-            </div> : null}
             <label className="session-analyst__sr-only" htmlFor={`analysis-${context.operationId}`}>Ask about this session</label>
             <textarea
               ref={textareaRef}

--- a/runtime/fleet-plugins/terminal/client/agent/analysis.css
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis.css
@@ -137,10 +137,10 @@
 .session-analyst__receipt { display: flex; align-items: center; gap: var(--space-2); min-height: 34px; flex: none; margin-top: 15px; border-left: 2px solid var(--text-tertiary); background: var(--surface-glass-strong); padding: 0 var(--space-3); color: var(--text-tertiary); font: 10px/1.3 var(--font-mono); animation: analyst-receipt-settle var(--duration-base) var(--ease-glide) both; }
 
 .session-analyst__composer { position: relative; min-width: 0; background: transparent; }
-.session-analyst__composer.is-initial { flex: none; margin-top: 12px; padding: 0; }
+.session-analyst__composer.is-initial { display: flex; align-items: flex-end; gap: var(--space-2); flex: none; margin-top: 12px; padding: 0; }
 .session-analyst__composer.is-docked { padding: 10px 14px 14px; }
 .session-analyst__composer.is-docking { animation: analyst-composer-dock var(--duration-slow) var(--ease-glide) both; }
-.session-analyst__composer-surface { position: relative; display: flex; align-items: flex-end; gap: 7px; min-width: 0; min-height: 48px; overflow: hidden; border: 1px solid var(--hairline-strong); border-radius: 24px; background: color-mix(in oklch, var(--ink-mid) 86%, var(--ink-deep)); padding: 5px 6px 5px 9px; box-shadow: inset 0 1px 0 color-mix(in oklch, white 4%, transparent); transition: border-color var(--duration-base) var(--ease-glide), background var(--duration-base) var(--ease-glide); }
+.session-analyst__composer-surface { position: relative; display: flex; align-items: flex-end; gap: 7px; min-width: 0; min-height: 48px; flex: 1; overflow: hidden; border: 1px solid var(--hairline-strong); border-radius: 24px; background: color-mix(in oklch, var(--ink-mid) 86%, var(--ink-deep)); padding: 5px 6px 5px 9px; box-shadow: inset 0 1px 0 color-mix(in oklch, white 4%, transparent); transition: border-color var(--duration-base) var(--ease-glide), background var(--duration-base) var(--ease-glide); }
 .session-analyst__composer-surface:focus-within { border-color: color-mix(in oklch, var(--aurora) 48%, var(--hairline-strong)); }
 .session-analyst__composer textarea { display: block; box-sizing: border-box; width: auto; min-width: 3rem; min-height: 36px; height: 36px; max-height: calc(1.5em * 6 + 16px); flex: 1 1 auto; resize: none; overflow-x: hidden; overflow-y: hidden; white-space: pre-wrap; border: 0; outline: 0; background: transparent; color: var(--text-primary); padding: 8px 6px; font: 12.5px/1.5 var(--font-body); transition: opacity var(--duration-base) var(--ease-glide); }
 .session-analyst__composer textarea::placeholder { color: color-mix(in oklch, var(--text-tertiary) 62%, transparent); }
@@ -209,6 +209,12 @@
 @keyframes analyst-artifact-count-pulse { 0%, 100% { transform: scale(1); } 45% { transform: scale(1.32); } }
 @keyframes analyst-author-slide { from { transform: translateX(-100%); } to { transform: translateX(294%); } }
 @keyframes analyst-authoring-breathe { 0%, 100% { opacity: .5; } 50% { opacity: 1; } }
+
+/* 스트립+입력 나란히 배치는 셀렉터 3종(≈271px)과 최소 입력 폭을 함께 수용할 때만 유효 — 좁으면 스트립을 위로 쌓는다. */
+@container (max-width: 33rem) {
+  .session-analyst__composer.is-initial { flex-wrap: wrap; }
+  .session-analyst__composer.is-initial .session-analyst__composer-surface { flex-basis: 100%; }
+}
 
 @container (max-width: 24rem) {
   .session-analyst__suggestions { grid-template-columns: 1fr; }

--- a/runtime/fleet-plugins/terminal/client/agent/analysis.css
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis.css
@@ -151,7 +151,9 @@
 .session-analyst__slash button small { color: var(--text-tertiary); font-size: 10.5px; }
 .session-analyst__slash button:is(.is-selected, :hover) { background: color-mix(in oklch, var(--aurora) 10%, transparent); color: var(--text-primary); }
 .session-analyst__composer-hint { padding: 6px 4px 0; color: var(--text-tertiary); font: 500 9.5px/1.4 var(--font-mono); }
-.session-analyst__selector-strip { display: flex; align-items: center; min-width: 0; flex: 0 1 auto; overflow: hidden; border: 1px solid var(--hairline); border-radius: 999px; background: color-mix(in oklch, var(--ink-veil) 45%, var(--ink-deep)); transition: opacity var(--duration-base) var(--ease-glide); }
+.session-analyst__selector-strip { display: flex; align-items: center; min-width: 0; flex: 0 1 auto; overflow: hidden; border: 1px solid var(--hairline); border-radius: 999px; background: color-mix(in oklch, var(--ink-veil) 45%, var(--ink-deep)); transition: opacity var(--duration-base) var(--ease-glide), border-color var(--duration-base) var(--ease-glide); }
+/* 스트립이 composer-surface 밖으로 나온 뒤에도 키보드 포커스 큐가 유지되도록 동일한 focus-within 병더 문법을 적용한다. */
+.session-analyst__selector-strip:focus-within { border-color: color-mix(in oklch, var(--aurora) 48%, var(--hairline-strong)); }
 .session-analyst__select { position: relative; display: inline-flex; min-width: 0; }
 .session-analyst__select + .session-analyst__select::before { content: ""; position: absolute; inset: 9px auto 9px 0; width: 1px; background: var(--hairline); }
 .session-analyst__select::after { content: "⌄"; position: absolute; right: 6px; top: 50%; transform: translateY(-55%); color: var(--text-tertiary); font-size: 9px; pointer-events: none; }


### PR DESCRIPTION
## Summary
- CLI/모델/추론강도 셀렉터 스트립을 composer 서피스 밖으로 이동해 입력 필드가 pill 전폭을 회복합니다(스트립이 pill 안에서 textarea를 압박하던 문제).
- 넓은 pane(≥33rem)에서는 사용자 확정 방향대로 스트립이 입력박스 왼쪽에 나란히 배치되고, 좁은 pane에서는 스트립이 위로 쌓여 입력 폭을 보존합니다.
- no-changelog: PR #344(미릴리스) 기능의 레이아웃 조정으로, 기존 pending fragment의 주장을 바꾸지 않습니다.

## Test Plan
- [x] `@fleet-plugins/terminal` vitest 326 passed (스트립 위치 구조 단언 갱신)
- [x] `typecheck` + `build` (tsc) green
- [x] design contract test 16/16
- [x] 격리 콘솔 실브라우저: 471px pane stacked(스트립 271px 위·입력 435px 아래), 600px pane side-by-side(스트립 271px 좌·입력 285px 우) 실측