### PR TITLE
feat(console): modernize carrier stream deck and details view

### DIFF
--- a/.changelog.d/pr-352.md
+++ b/.changelog.d/pr-352.md
@@ -1,0 +1,8 @@
+### fleet-plugin
+#### Changed
+- [fleet-console] The agent panel's carrier stream strip becomes an ambient capsule: stacked captain dots, a live scan line, a per-track segment meter, and the latest output line with elapsed time and token estimate.
+  ko: 에이전트 패널의 캐리어 스트림 스트립이 앰비언트 캡슐로 바뀝니다: 겹쳐 쌓이는 캡틴 도트, 라이브 scan line, 트랙별 세그먼트 미터, 그리고 최신 출력 라인이 경과 시간·토큰 추정과 함께 표시됩니다.
+- [fleet-console] The expanded stream deck lists a phase card per carrier track - an identity spine, live phase verbs such as Reasoning, Using a tool, and Writing, and a one-line preview replace the log rows.
+  ko: 펼친 스트림덱은 캐리어 트랙마다 phase 카드를 표시합니다 - 정체성 스파인, Reasoning·Using·Writing 같은 라이브 동사형 상태, 한 줄 프리뷰가 로그 행을 대체합니다.
+- [fleet-console] The Details Activity tab renders carrier output as streamed markdown with tool status chips that name their target, replacing the raw text dump; thinking stays behind a collapsible fold and completed jobs still clear after the short retention window.
+  ko: Details의 Activity 탭이 캐리어 출력을 스트리밍 마크다운으로 렌더하고 대상이 표기된 도구 상태 칩을 보여주어 원문 텍스트 덤프를 대체합니다; thinking은 접이식 폴드 뒤에 유지되고 완료된 job은 기존처럼 짧은 잔존 후 사라집니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3932,7 +3932,7 @@
 }
 
 .track-card--ok {
-  border-color: color-mix(in oklch, var(--brass) 28%, var(--surface-rim));
+  border-color: color-mix(in oklch, var(--positive) 28%, var(--surface-rim));
 }
 
 .track-card--bad {
@@ -3994,10 +3994,10 @@
   gap: var(--space-2);
   padding-bottom: var(--space-2);
   border-bottom: 1px dashed var(--surface-rim);
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   cursor: pointer;
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.1em;
   list-style: none;
@@ -4027,44 +4027,10 @@
   word-break: break-word;
 }
 
-/* text: 주 출력 — 또렷 */
-.track-card-text {
+/* markdown-body가 출력 타이포·블록 문법을 소유하며, 카드에서는 크기만 조정한다. */
+.track-card-output {
   margin: var(--space-3) 0 0;
-}
-
-.track-card-text pre {
-  margin: var(--space-1) 0 0;
-  color: var(--ink-spectral);
-  font-family: var(--font-mono);
-  font-size: 12px;
-  line-height: 1.65;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-/* 섹션 레이블 ("thinking" / "output") */
-.track-card-section-label {
-  display: block;
-  color: var(--ink-rim);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.track-card-section-label--output {
-  color: color-mix(in oklch, var(--brass) 60%, var(--ink-rim));
-}
-
-/* aurora 스트림 캐럿 — live 트랙 text 끝에 표시 */
-.track-card-caret {
-  display: inline-block;
-  width: 2px;
-  height: 1em;
-  margin-left: 1px;
-  background: var(--aurora);
-  vertical-align: text-bottom;
-  animation: caret-blink 1.1s step-end infinite;
+  font-size: 13px;
 }
 
 /* 에러 블록 — coral */
@@ -4082,36 +4048,62 @@
   word-break: break-word;
 }
 
-/* tools 목록 — 모노 brass 점 */
+/* 도구 활동: 상태 도트 + 대상 요약 칩 */
 .track-card-tools {
   display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
+  flex-wrap: wrap;
+  gap: var(--space-2);
   margin: var(--space-3) 0 0;
-  padding: 0;
-  list-style: none;
 }
 
-.track-card-tools li {
-  display: flex;
+.track-card-tool-chip {
+  display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  color: var(--ink-fog);
   font-family: var(--font-mono);
   font-size: 11px;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-xs);
+  padding: 3px 9px;
+  background: var(--surface-glass);
+  color: var(--text-secondary);
 }
 
-.track-card-tools li::before {
+.track-card-tool-chip strong {
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+.track-card-tool-chip > span {
+  max-width: 60ch;
+  overflow: hidden;
+  color: var(--text-tertiary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.track-card-tool-chip i {
   flex: none;
-  width: 4px;
-  height: 4px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
-  background: var(--brass);
-  content: "";
+  background: var(--aurora);
+}
+
+.track-card-tool-chip.is-live i {
+  animation: aurora-pulse 1.4s ease-in-out infinite;
+}
+
+.track-card-tool-chip.is-done i {
+  background: var(--positive);
+}
+
+.track-card-tool-chip.is-error i {
+  background: var(--coral);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .track-card-caret {
+  .track-card-tool-chip.is-live i {
     animation: none;
     opacity: 1;
   }
@@ -4378,23 +4370,49 @@
   max-height: 100%;
   display: flex;
   flex-direction: column;
-  border-top: 1px solid color-mix(in oklch, var(--aurora) 30%, var(--surface-rim));
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
-  /* 불투명 표면 도트린: backdrop blur 금지(instrument-design-contract). 오버레이 구분은
-     surface-glass-strong 불투명 배경 + floating shadow로만 확보한다. */
-  background: color-mix(in oklch, var(--aurora) 6%, var(--surface-glass-strong));
-  box-shadow: var(--shadow-floating);
-  overflow: hidden;
+  border: 0;
+  background: transparent;
 }
 
-/* 스트립: 기본 상태 단일 행 계기판 — 펄스닷 · 캐리어명 · 최신 라인 · meta · 그립 · Details */
+/* 스트립 자체가 불투명 캡슐 표면을 소유한다. backdrop blur 금지(instrument-design-contract). */
 .job-dock-strip {
+  position: relative;
   flex: none;
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  width: 100%;
+  max-width: calc(100% - 2 * var(--space-4));
+  margin-inline: auto;
   padding: var(--space-1) var(--space-3);
   min-height: 30px;
+  overflow: hidden;
+  border: 1px solid var(--surface-rim-strong);
+  border-radius: var(--radius-pill); /* 상태 캡슐 예외: theme.css radius doctrine */
+  background: var(--surface-glass-strong);
+  box-shadow: var(--shadow-floating);
+}
+
+.job-dock-strip::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--positive);
+  opacity: 0.6;
+}
+
+.job-dock-strip.is-live::before {
+  background: linear-gradient(90deg, transparent, var(--aurora), transparent);
+  opacity: 1;
+  animation: job-dock-scan 1.8s linear infinite;
+}
+
+.job-dock-strip.is-error::before {
+  background: var(--coral);
+  opacity: 1;
 }
 
 /* aurora 라이브 펄스닷 */
@@ -4423,7 +4441,7 @@
   }
 }
 
-/* 캐리어명: 스트립 고정폭, 캡틴 식별은 작은 dot/tag 채널에만 둔다. */
+/* 캐리어명: 캡틴 식별은 작은 dot/tag 채널에만 둔다. */
 .job-dock-carrier {
   display: inline-flex;
   align-items: center;
@@ -4439,12 +4457,23 @@
   color: var(--ink-spectral);
 }
 
+.job-dock-captain-stack {
+  display: inline-flex;
+  align-items: center;
+  padding-left: 4px;
+}
+
 .job-dock-captain-dot {
   flex: none;
-  width: 8px;
-  height: 8px;
+  width: 10px;
+  height: 10px;
+  border: 2px solid var(--surface-glass-strong);
   border-radius: 50%;
   background: var(--captain-nimitz);
+}
+
+.job-dock-captain-stack .job-dock-captain-dot {
+  margin-left: -4px;
 }
 
 .job-dock-captain-dot[data-captain="nimitz"] { background: var(--captain-nimitz); }
@@ -4464,6 +4493,31 @@
   text-overflow: ellipsis;
   color: var(--ink-spectral);
 }
+
+.job-dock-carrier > .job-dock-captain-tag:last-child:not(:first-child) {
+  flex: none;
+}
+
+.job-dock-seg {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex: none;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 9px;
+}
+
+.job-dock-seg > i {
+  width: 10px;
+  height: 4px;
+  border-radius: var(--radius-pill); /* 상태 미터 예외: theme.css radius doctrine */
+  background: var(--ink-rim);
+}
+
+.job-dock-seg > i[data-tone="live"] { background: var(--aurora); }
+.job-dock-seg > i[data-tone="done"] { background: var(--positive); }
+.job-dock-seg > i[data-tone="error"] { background: var(--coral); }
 
 /* 스트립 최신 라인: 가변폭 ellipsis, 접힘 상태에서만 가시 */
 .job-dock-strip-line {
@@ -4534,24 +4588,30 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  width: 100%;
+  max-width: calc(100% - 2 * var(--space-4));
+  margin-inline: auto;
   min-height: 0;
-  border-top: 1px solid var(--surface-rim);
+  border: 0;
+  background: transparent;
 }
 
 .job-dock-body-wrap.is-collapsed {
   display: none;
 }
 
-/* 바디: 스크롤 가능한 트랙 행 스택, 하단 고정 여백 제거.
-   flex:1 1 auto + min-height:0으로 좁은 패널에서 200px 미만으로 수축하며 내부 스크롤한다. */
+/* 바디: 스크롤 가능한 phase 카드 스택. 도크는 패널보다 높을 수 없고 body만 수축한다. */
 .job-dock-body {
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
-  max-height: 200px;
-  padding: var(--space-1) var(--space-3) var(--space-2);
+  max-height: 240px;
+  padding: var(--space-2) 0;
   display: flex;
   flex-direction: column;
+  gap: var(--space-2);
+  border: 0;
+  background: transparent;
 }
 
 /* follow 버튼 도크 스코프 오버라이드 — 바디 상하 여백에 맞게 위치 조정 */
@@ -4559,21 +4619,33 @@
   bottom: var(--space-2);
 }
 
-/* 트랙 행: 단일 flex 행 — [이름(조건부)] + 상태 + 최신 라인 */
-.job-dock-row {
-  display: flex;
+/* phase 카드: 정체성 spine + who/phase/preview/meta + 상태 ornament */
+.job-dock-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: var(--space-1) var(--space-3);
   align-items: center;
-  gap: var(--space-2);
-  min-height: 22px;
-  overflow: hidden;
+  padding: var(--space-2) var(--space-3);
+  background: var(--surface-glass-strong);
+  border: 1px solid var(--surface-rim);
+  border-left: 3px solid transparent;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-floating);
 }
 
-/* 행 이름: 멀티잡=캡틴색, 단일잡+멀티트랙=무채색, 단일잡+단일트랙=생략 — 긴 이름은 잘라 상태·라인을 보호 */
-.job-dock-row-name {
+.job-dock-card[data-captain="nimitz"] { border-left-color: var(--captain-nimitz); }
+.job-dock-card[data-captain="kirov"] { border-left-color: var(--captain-kirov); }
+.job-dock-card[data-captain="genesis"] { border-left-color: var(--captain-genesis); }
+.job-dock-card[data-captain="ohio"] { border-left-color: var(--captain-ohio); }
+.job-dock-card[data-captain="sentinel"] { border-left-color: var(--captain-sentinel); }
+.job-dock-card[data-captain="vanguard"] { border-left-color: var(--captain-vanguard); }
+.job-dock-card[data-captain="tempest"] { border-left-color: var(--captain-tempest); }
+.job-dock-card[data-captain="chronicle"] { border-left-color: var(--captain-chronicle); }
+
+.job-dock-card-who {
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
-  flex: none;
   max-width: 12em;
   overflow: hidden;
   white-space: nowrap;
@@ -4584,36 +4656,73 @@
   color: var(--ink-spectral);
 }
 
-/* 행 상태: 9.5px mono uppercase, 라이브 시 aurora */
-.job-dock-row-status {
+.job-dock-card-copy {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.job-dock-card-phase {
   flex: none;
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: 10px;
   font-weight: 700;
-  color: var(--ink-fog);
+  color: var(--aurora);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   white-space: nowrap;
 }
 
-.job-dock-row-status--live {
-  color: var(--aurora);
-}
+.job-dock-card[data-tone="done"] .job-dock-card-phase { color: var(--positive); }
+.job-dock-card[data-tone="error"] .job-dock-card-phase { color: var(--coral); }
 
-.job-dock-row-status--error {
-  color: var(--coral);
-}
-
-/* 행 최신 라인: 가변폭 ellipsis + aurora 캐럿 */
-.job-dock-row-line {
+.job-dock-card-line {
   flex: 1;
   min-width: 0;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.job-dock-card-meta {
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--ink-spectral);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.job-dock-card-bar {
+  position: relative;
+  grid-column: 1 / -1;
+  height: 2px;
+  overflow: hidden;
+  border-radius: var(--radius-pill); /* 상태 미터 예외: theme.css radius doctrine */
+  background: var(--ink-rim);
+}
+
+.job-dock-card-bar > i {
+  position: absolute;
+  inset: 0 auto 0 0;
+}
+
+.job-dock-card[data-tone="live"] .job-dock-card-bar > i {
+  width: 34%;
+  background: linear-gradient(90deg, transparent, var(--aurora), transparent);
+  animation: job-dock-scan 1.8s linear infinite;
+}
+
+.job-dock-card[data-tone="done"] .job-dock-card-bar > i {
+  width: 100%;
+  background: var(--positive);
+  opacity: 0.5;
+}
+
+.job-dock-card[data-tone="error"] .job-dock-card-bar > i {
+  width: 100%;
+  background: var(--coral);
 }
 
 .thinking-chip {
@@ -4623,18 +4732,6 @@
   font-size: 10px;
   font-style: italic;
   white-space: nowrap;
-}
-
-/* 요청 라벨: 단일 잡 펼침 첫 행, 디밍 mono 10.5px */
-.job-dock-row-label {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  color: var(--ink-fog);
 }
 
 /* aurora 스트림 캐럿 */
@@ -4648,7 +4745,14 @@
   animation: caret-blink 1s step-start infinite;
 }
 
+@keyframes job-dock-scan {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(320%); }
+}
+
 @media (prefers-reduced-motion: reduce) {
+  .job-dock-strip.is-live::before,
+  .job-dock-card[data-tone="live"] .job-dock-card-bar > i,
   .job-dock-caret {
     animation: none;
     opacity: 1;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5405,6 +5405,13 @@
   gap: var(--space-5);
 }
 
+/* ResizeObserver 래퍼 — body의 직접-자식 flex 레이아웃을 승계해 head/tracks·복수 job 간격 계약을 유지한다. */
+.job-overlay-panel-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
 .job-overlay-panel[hidden] { display: none; }
 
 .request-details,

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
@@ -1,11 +1,11 @@
 import { React } from "@fleet-console/sdk/plugin/browser";
 import type { OperationRenderContext } from "@fleet-console/sdk/plugin";
-import { renderMarkdown } from "@fleet-console/markdown/core";
 import { installDiagramHydrator } from "@fleet-console/markdown/mermaid";
 import "@fleet-console/markdown/styles.css";
 
 import type { AnalysisActivity, AnalysisState } from "./analysis-state.js";
 import { useAnalysisStore } from "./analysis-store.js";
+import { StreamedMarkdown } from "./streamed-markdown.js";
 
 const SUGGESTIONS = [
   { icon: "◈", tone: "aurora", text: "Walk me through how this session unfolded" },
@@ -26,7 +26,6 @@ const SLASH_COMMANDS = [
   { command: "/risks", description: "Flag anything that needs review", template: "Flag anything I should review before this work continues." },
   { command: "/timeline", description: "How the session unfolded, end to end", template: "Walk me through how this session unfolded." },
 ] as const;
-const STREAM_RENDER_DELAY_MS = 32;
 export const ANALYST_ARTIFACTS_COMPANION_ID = "session-analyst-artifacts";
 
 export function AnalystChatPanel({ context }: { readonly context: OperationRenderContext }) {
@@ -160,7 +159,7 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
               {state.entries.map((entry, index) => (
                 <li className={`session-analyst__message session-analyst__message--${entry.role}`} key={`${entry.role}-${index}`}>
                   {entry.role === "analyst"
-                    ? <AnalystMarkdownResponse text={entry.text} streaming={state.busy && index === state.entries.length - 1} />
+                    ? <StreamedMarkdown className="session-analyst__response markdown-body" text={entry.text} streaming={state.busy && index === state.entries.length - 1} />
                     : entry.text}
                 </li>
               ))}
@@ -314,38 +313,6 @@ function resizeAnalysisTextarea(textarea: HTMLTextAreaElement): void {
   textarea.style.height = `${nextHeight}px`;
   textarea.style.overflowY = textarea.scrollHeight > maxHeight ? "auto" : "hidden";
 }
-
-const AnalystMarkdownResponse = React.memo(function AnalystMarkdownResponse({ text, streaming }: { readonly text: string; readonly streaming: boolean }) {
-  const latestText = React.useRef(text);
-  const renderedText = React.useRef(streaming ? text : "");
-  const renderTimer = React.useRef<number | null>(null);
-  const [streamedHtml, setStreamedHtml] = React.useState(() => streaming ? renderMarkdown(text).html : "");
-  latestText.current = text;
-
-  const completedHtml = React.useMemo(() => streaming ? null : renderMarkdown(text).html, [streaming, text]);
-
-  React.useEffect(() => {
-    if (!streaming) {
-      if (renderTimer.current !== null) window.clearTimeout(renderTimer.current);
-      renderTimer.current = null;
-      return;
-    }
-    if (renderedText.current === text || renderTimer.current !== null) return;
-    renderTimer.current = window.setTimeout(() => {
-      renderTimer.current = null;
-      const nextText = latestText.current;
-      if (nextText === renderedText.current) return;
-      renderedText.current = nextText;
-      setStreamedHtml(renderMarkdown(nextText).html);
-    }, STREAM_RENDER_DELAY_MS);
-  }, [streaming, text]);
-
-  React.useEffect(() => () => {
-    if (renderTimer.current !== null) window.clearTimeout(renderTimer.current);
-  }, []);
-
-  return <div className="session-analyst__response markdown-body" dangerouslySetInnerHTML={{ __html: completedHtml ?? streamedHtml }} />;
-});
 
 function copyCodeToClipboard(button: HTMLElement, code: string): void {
   const clipboard = navigator.clipboard;

--- a/runtime/fleet-plugins/terminal/client/agent/helpers.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/helpers.ts
@@ -11,6 +11,11 @@ export interface DockTail {
   readonly thinking: boolean;
 }
 
+export interface TrackPhase {
+  readonly label: string;
+  readonly tone: "live" | "done" | "error";
+}
+
 const CAPTAIN_IDS = new Set(["nimitz", "kirov", "genesis", "ohio", "sentinel", "vanguard", "tempest", "chronicle"]);
 const BACKEND_CLIS = new Set(["claude", "claude-kimi", "codex", "opencode-go", "cursor"]);
 
@@ -64,6 +69,30 @@ export function isDockTrackLive(jobStatus: string, trackStatus: string): boolean
   // 종결 잡(잔존 표시 포함)의 트랙은 track:finalized가 누락돼 stale 라이브 상태로 남아도
   // 라이브로 취급하지 않는다 — 완료/에러 잡이 잔존 중 라이브 캐럿·aurora 신호를 얻는 것 방지.
   return !isTerminalJobStatus(jobStatus) && isTrackLive(trackStatus);
+}
+
+export function deriveTrackPhase(track: TrackView, jobStatus: string): TrackPhase {
+  if (isTrackError(track.status) || jobStatus === "error") return { label: "Error", tone: "error" };
+  if (track.status === "aborted" || jobStatus === "aborted") return { label: "Aborted", tone: "error" };
+  if (track.status === "done" || jobStatus === "done") return { label: "Done", tone: "done" };
+
+  const lastTool = track.tools.at(-1);
+  if (lastTool && lastTool.status !== "done" && lastTool.status !== "error") {
+    return { label: `Using ${lastTool.name ?? "tool"}`, tone: "live" };
+  }
+  if (track.text.length > 0) return { label: "Writing", tone: "live" };
+  if (track.thought.length > 0) return { label: "Reasoning", tone: "live" };
+  return { label: "Working", tone: "live" };
+}
+
+export function describeToolTarget(input: unknown): string | null {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) return null;
+  const record = input as Record<string, unknown>;
+  for (const key of ["file_path", "path", "file", "command", "query", "url", "pattern"] as const) {
+    const value = record[key];
+    if (typeof value === "string") return value.slice(0, 60);
+  }
+  return null;
 }
 
 export function resolveDockRowStatusLabel(trackStatus: string, jobStatus: string): string {

--- a/runtime/fleet-plugins/terminal/client/agent/helpers.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/helpers.ts
@@ -72,9 +72,12 @@ export function isDockTrackLive(jobStatus: string, trackStatus: string): boolean
 }
 
 export function deriveTrackPhase(track: TrackView, jobStatus: string): TrackPhase {
-  if (isTrackError(track.status) || jobStatus === "error") return { label: "Error", tone: "error" };
-  if (track.status === "aborted" || jobStatus === "aborted") return { label: "Aborted", tone: "error" };
-  if (track.status === "done" || jobStatus === "done") return { label: "Done", tone: "done" };
+  if (isTrackError(track.status)) return { label: "Error", tone: "error" };
+  if (track.status === "aborted") return { label: "Aborted", tone: "error" };
+  if (track.status === "done") return { label: "Done", tone: "done" };
+  if (jobStatus === "error") return { label: "Error", tone: "error" };
+  if (jobStatus === "aborted") return { label: "Aborted", tone: "error" };
+  if (jobStatus === "done") return { label: "Done", tone: "done" };
 
   const lastTool = track.tools.at(-1);
   if (lastTool && lastTool.status !== "done" && lastTool.status !== "error") {

--- a/runtime/fleet-plugins/terminal/client/agent/helpers.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/helpers.ts
@@ -80,12 +80,20 @@ export function deriveTrackPhase(track: TrackView, jobStatus: string): TrackPhas
   if (jobStatus === "done") return { label: "Done", tone: "done" };
 
   const lastTool = track.tools.at(-1);
-  if (lastTool && lastTool.status !== "done" && lastTool.status !== "error") {
+  if (lastTool && resolveToolTone(lastTool.status) === "live") {
     return { label: `Using ${lastTool.name ?? "tool"}`, tone: "live" };
   }
   if (track.text.length > 0) return { label: "Writing", tone: "live" };
   if (track.thought.length > 0) return { label: "Reasoning", tone: "live" };
   return { label: "Working", tone: "live" };
+}
+
+// 도구 status 종결 판정의 단일 지점 — ACP 계열 런타임은 completed/failed를, 내부 경로는 done/error를 쓴다.
+// phase 도출과 Details 칩이 같은 판정을 공유해야 "Using" 잔류/칩 톤 분열이 생기지 않는다.
+export function resolveToolTone(status: string | undefined): "done" | "error" | "live" {
+  if (status === "done" || status === "completed") return "done";
+  if (status === "error" || status === "failed") return "error";
+  return "live";
 }
 
 export function describeToolTarget(input: unknown): string | null {

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -58,6 +58,7 @@ interface DockRowProps {
 
 interface PinnedScrollLocal {
   readonly containerRef: React.RefObject<HTMLDivElement | null>;
+  readonly contentRef: React.RefObject<HTMLDivElement | null>;
   readonly pinned: boolean;
   readonly jumpToLatest: () => void;
 }
@@ -158,6 +159,7 @@ function installAgentPlugin(ctx: PluginInstallContext): () => void {
 // core를 import하지 않고 pin-to-bottom 패턴을 플러그인 로컬로 복제한다.
 function usePinnedScrollLocal(resetKey: unknown, contentKey: unknown): PinnedScrollLocal {
   const containerRef = React.useRef<HTMLDivElement | null>(null);
+  const contentRef = React.useRef<HTMLDivElement | null>(null);
   const pinnedRef = React.useRef(true);
   const [pinned, setPinned] = React.useState(true);
 
@@ -192,6 +194,18 @@ function usePinnedScrollLocal(resetKey: unknown, contentKey: unknown): PinnedScr
     container.scrollTop = container.scrollHeight;
   }, [contentKey]);
 
+  React.useEffect(() => {
+    if (typeof ResizeObserver === "undefined") return;
+    const container = containerRef.current;
+    const content = contentRef.current;
+    if (!container || !content) return;
+    const observer = new ResizeObserver(() => {
+      if (pinned) container.scrollTop = container.scrollHeight;
+    });
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [pinned, resetKey]);
+
   const jumpToLatest = React.useCallback(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -200,7 +214,7 @@ function usePinnedScrollLocal(resetKey: unknown, contentKey: unknown): PinnedScr
     updatePinned(true);
   }, [updatePinned]);
 
-  return { containerRef, pinned, jumpToLatest };
+  return { containerRef, contentRef, pinned, jumpToLatest };
 }
 
 function getTabbableElements(container: HTMLElement): HTMLElement[] {
@@ -459,7 +473,9 @@ function AgentOperationView({ context }: { readonly context: OperationRenderCont
               {modalJobs.length === 0 ? <p className="job-overlay-empty">No active streams.</p> : modalJobs.map((job) => <RequestDetails key={job.jobId} job={job} />)}
             </div>
             <div id={`${detailTabsId}-activity-panel`} ref={detailTab === "activity" ? modalScroll.containerRef : undefined} className="job-overlay-body job-overlay-panel" role="tabpanel" aria-labelledby={`${detailTabsId}-activity`} hidden={detailTab !== "activity"} tabIndex={detailTab === "activity" ? 0 : -1}>
-              {modalJobs.length === 0 ? <p className="job-overlay-empty">No active streams.</p> : modalJobs.map((job) => <JobDetailContent key={job.jobId} job={job} />)}
+              <div className="job-overlay-panel-content" ref={modalScroll.contentRef}>
+                {modalJobs.length === 0 ? <p className="job-overlay-empty">No active streams.</p> : modalJobs.map((job) => <JobDetailContent key={job.jobId} job={job} />)}
+              </div>
             </div>
             {detailTab === "activity" && !modalScroll.pinned ? (
               <button type="button" className="follow-button" onClick={modalScroll.jumpToLatest}>
@@ -945,6 +961,7 @@ function JobDetailContent({ job }: { readonly job: JobView }) {
 
 function TrackCard({ track, jobStatus }: { readonly track: TrackView; readonly jobStatus: string }) {
   const modifier = trackCardModifier(track.status, jobStatus);
+  const phase = deriveTrackPhase(track, jobStatus);
   // 칩 텍스트도 modifier와 같은 해석에서 파생 — 종결 잡의 미종결 트랙이 coral 카드에
   // raw "stream" 라벨을 다는 표기 분열을 막는다(라이브 트랙은 자기 상태 그대로).
   const statusLabel = resolveDockRowStatusLabel(track.status, jobStatus);
@@ -963,7 +980,7 @@ function TrackCard({ track, jobStatus }: { readonly track: TrackView; readonly j
         </details>
       ) : null}
       {track.text ? (
-        <StreamedMarkdown className="track-card-output markdown-body" text={track.text} streaming={!isTerminalJobStatus(track.status)} />
+        <StreamedMarkdown className="track-card-output markdown-body" text={track.text} streaming={phase.tone === "live"} />
       ) : null}
       {track.error ? (
         <div className="track-card-error" role="group" aria-label="Error">{track.error}</div>

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -200,11 +200,12 @@ function usePinnedScrollLocal(resetKey: unknown, contentKey: unknown): PinnedScr
     const content = contentRef.current;
     if (!container || !content) return;
     const observer = new ResizeObserver(() => {
-      if (pinned) container.scrollTop = container.scrollHeight;
+      // pinnedRef 직독 — 예약된 콜백이 렌더 시점 pinned를 읽으면 사용자의 unpin을 하단 재고정으로 되돌린다.
+      if (pinnedRef.current) container.scrollTop = container.scrollHeight;
     });
     observer.observe(content);
     return () => observer.disconnect();
-  }, [pinned, resetKey]);
+  }, [resetKey]);
 
   const jumpToLatest = React.useCallback(() => {
     const container = containerRef.current;

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -20,7 +20,7 @@ import { fetchCarrierSettingsOptions } from "../carriers/api.js";
 import type { CarrierSettingsCliOption } from "../../shared/carrier-settings-types.js";
 import { createAgentSession, fetchAgentCliState, resumeAgentSession, terminateAgentSession } from "./api.js";
 import { startAgentConnection } from "./connection.js";
-import { deriveTrackPhase, describeToolTarget, formatElapsedDuration, formatTokenEstimate, estimateJobTokens, getDockTailText, isDockTrackLive, isTrackError, mergeDockJobs, mergeJobIds, pruneRetainedJobs, resolveDockRowStatusLabel, resolveJobSignature, resolveCarrierCaptain, retainCompletedJobs, selectJobsByIds } from "./helpers.js";
+import { deriveTrackPhase, describeToolTarget, formatElapsedDuration, formatTokenEstimate, estimateJobTokens, getDockTailText, isDockTrackLive, isTrackError, mergeDockJobs, mergeJobIds, pruneRetainedJobs, resolveDockRowStatusLabel, resolveJobSignature, resolveCarrierCaptain, resolveToolTone, retainCompletedJobs, selectJobsByIds } from "./helpers.js";
 import type { RetainedJob } from "./helpers.js";
 import { loadModelAuth, signInModel, signOutModel, useModelAuthStore } from "./model-auth-store.js";
 import type { ModelAuthProviderState } from "./model-auth-api.js";
@@ -990,11 +990,7 @@ function TrackCard({ track, jobStatus }: { readonly track: TrackView; readonly j
         <div className="track-card-tools" role="list" aria-label="Tools">
           {track.tools.map((tool) => {
             const target = describeToolTarget(tool.input);
-            const tone = tool.status === "done" || tool.status === "completed"
-              ? "is-done"
-              : tool.status === "error" || tool.status === "failed"
-                ? "is-error"
-                : "is-live";
+            const tone = `is-${resolveToolTone(tool.status)}`;
             return (
               <span key={tool.id} className={`track-card-tool-chip ${tone}`} role="listitem">
                 <i aria-hidden="true" />

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -20,13 +20,14 @@ import { fetchCarrierSettingsOptions } from "../carriers/api.js";
 import type { CarrierSettingsCliOption } from "../../shared/carrier-settings-types.js";
 import { createAgentSession, fetchAgentCliState, resumeAgentSession, terminateAgentSession } from "./api.js";
 import { startAgentConnection } from "./connection.js";
-import { formatElapsedDuration, formatTokenEstimate, estimateJobTokens, getDockTailText, isDockTrackLive, isTrackError, mergeDockJobs, mergeJobIds, pruneRetainedJobs, resolveDockRowStatusLabel, resolveJobSignature, resolveCarrierCaptain, retainCompletedJobs, selectJobsByIds } from "./helpers.js";
+import { deriveTrackPhase, describeToolTarget, formatElapsedDuration, formatTokenEstimate, estimateJobTokens, getDockTailText, isDockTrackLive, isTrackError, mergeDockJobs, mergeJobIds, pruneRetainedJobs, resolveDockRowStatusLabel, resolveJobSignature, resolveCarrierCaptain, retainCompletedJobs, selectJobsByIds } from "./helpers.js";
 import type { RetainedJob } from "./helpers.js";
 import { loadModelAuth, signInModel, signOutModel, useModelAuthStore } from "./model-auth-store.js";
 import type { ModelAuthProviderState } from "./model-auth-api.js";
 import { loadSystemPromptSettings, setSystemPromptSettingsField, useSystemPromptSettingsStore } from "./settings-store.js";
 import { isTerminalJobStatus } from "./reduce.js";
 import { RequestDetails } from "./request-details.js";
+import { StreamedMarkdown } from "./streamed-markdown.js";
 import { applySessionUpdate, hydrateAgentClis, removeSession, selectSession, sessionJobs, useAgentState } from "./store.js";
 import type { AgentCliStatus, JobView, SessionInfo, TrackView } from "./types.js";
 
@@ -53,8 +54,6 @@ interface RendererOption {
 interface DockRowProps {
   readonly track: TrackView;
   readonly job: JobView;
-  readonly multiJob: boolean;
-  readonly singleTrack: boolean;
 }
 
 interface PinnedScrollLocal {
@@ -489,7 +488,6 @@ function StreamDock({
   const totalTokens = activeJobs.reduce((sum, job) => sum + estimateJobTokens(job), 0);
   const tokenLabel = formatTokenEstimate(totalTokens);
 
-  const captain = activeJobs.length === 1 && primaryJob ? resolveCarrierCaptain(primaryJob.ownerCarrierId) : undefined;
   const jobLabel = activeJobs.length === 1 && primaryJob ? primaryJob.label : undefined;
 
   const carrierLabel = activeJobs.length > 1
@@ -513,14 +511,35 @@ function StreamDock({
     job.status === "error" || job.trackOrder.some((trackId) => isTrackError(job.tracks[trackId]?.status ?? ""))
   );
   const dotClassName = hasActiveJob ? "job-dock-dot" : hasError ? "job-dock-dot job-dock-dot--error" : "job-dock-dot job-dock-dot--idle";
+  const stripTone = hasError ? "is-error" : hasActiveJob ? "is-live" : "is-complete";
+  const ownerCaptains = [...new Set(activeJobs.map((job) => resolveCarrierCaptain(job.ownerCarrierId)).filter((id): id is string => Boolean(id)))];
+  const visibleCaptains = ownerCaptains.slice(0, 4);
+  const hiddenCaptainCount = Math.max(0, ownerCaptains.length - visibleCaptains.length);
+  const deckTracks = activeJobs.flatMap((job) => job.trackOrder.flatMap((trackId) => {
+    const track = job.tracks[trackId];
+    return track ? [{ job, track }] : [];
+  }));
+  const visibleDeckTracks = deckTracks.slice(0, 6);
+  const hiddenTrackCount = Math.max(0, deckTracks.length - visibleDeckTracks.length);
 
   return (
     <div className="job-dock">
-      <div className="job-dock-strip">
+      <div className={`job-dock-strip ${stripTone}`}>
         <span className={dotClassName} aria-hidden="true" />
         <span className="job-dock-carrier" title={jobLabel}>
-          {captain ? <span className="job-dock-captain-dot" data-captain={captain} aria-hidden="true" /> : null}
+          {visibleCaptains.length > 0 ? (
+            <span className="job-dock-captain-stack" aria-hidden="true">
+              {visibleCaptains.map((captain) => <span key={captain} className="job-dock-captain-dot" data-captain={captain} />)}
+            </span>
+          ) : null}
           <span className="job-dock-captain-tag">{carrierLabel}</span>
+          {hiddenCaptainCount > 0 ? <span className="job-dock-captain-tag">+{hiddenCaptainCount}</span> : null}
+        </span>
+        <span className="job-dock-seg" aria-hidden="true">
+          {visibleDeckTracks.map(({ job, track }) => (
+            <i key={`${job.jobId}:${track.trackId}`} data-tone={dockSegmentTone(track, job.status)} />
+          ))}
+          {hiddenTrackCount > 0 ? <span>+{hiddenTrackCount}</span> : null}
         </span>
         <span className="job-dock-strip-line" style={expanded ? { display: "none" } : undefined} aria-hidden="true">
           {tail.thinking ? <span className="thinking-chip">thinking…</span> : tail.text}
@@ -550,14 +569,7 @@ function StreamDock({
       </div>
       <div className={`job-dock-body-wrap${expanded ? "" : " is-collapsed"}`}>
         <div ref={containerRef} className="job-dock-body" tabIndex={-1}>
-          {activeJobs.length === 1 && jobLabel ? (
-            <div className="job-dock-row">
-              <span className="job-dock-row-label">{jobLabel}</span>
-            </div>
-          ) : null}
           {activeJobs.map((job) => {
-            const multiJob = activeJobs.length > 1;
-            const singleTrack = !multiJob && job.trackOrder.length === 1;
             return job.trackOrder.map((trackId) => {
               const track = job.tracks[trackId];
               return track ? (
@@ -565,8 +577,6 @@ function StreamDock({
                   key={`${job.jobId}:${trackId}`}
                   track={track}
                   job={job}
-                  multiJob={multiJob}
-                  singleTrack={singleTrack}
                 />
               ) : null;
             });
@@ -582,36 +592,28 @@ function StreamDock({
   );
 }
 
-function DockRow({ track, job, multiJob, singleTrack }: DockRowProps) {
+function DockRow({ track, job }: DockRowProps) {
   const isLive = isDockTrackLive(job.status, track.status);
   const tailOutput = getLastLine(track.text);
   const displayLine = tailOutput;
   const showThinking = !displayLine && isLive && Boolean(track.thought);
-  const activeTool = isLive ? getActiveToolName(track) : undefined;
-  const statusLabel = resolveDockRowStatusLabel(track.status, job.status);
-
-  // 멀티잡=캡틴색, 단일잡+멀티트랙=무채색, 단일잡+단일트랙=생략
-  const showName = multiJob || !singleTrack;
-  const nameCaptain = multiJob ? resolveCarrierCaptain(job.ownerCarrierId) : undefined;
+  const captain = resolveCarrierCaptain(job.ownerCarrierId);
+  const phase = deriveTrackPhase(track, job.status);
+  const elapsed = useElapsed(track.startedAt ?? job.startedAt, track.finishedAt ?? job.finishedAt);
 
   return (
-    <div className="job-dock-row">
-      {showName ? (
-        <span className="job-dock-row-name">
-          {nameCaptain ? <span className="job-dock-captain-dot" data-captain={nameCaptain} aria-hidden="true" /> : null}
-          <span className="job-dock-captain-tag">{track.displayName}</span>
-        </span>
-      ) : null}
-      <span className={`job-dock-row-status${isLive ? " job-dock-row-status--live" : ""}${isTrackError(statusLabel) ? " job-dock-row-status--error" : ""}`}>
-        {statusLabel}{activeTool ? ` · ${activeTool}` : ""}
+    <div className="job-dock-card" data-captain={captain} data-tone={phase.tone}>
+      <span className="job-dock-card-who">
+        {captain ? <span className="job-dock-captain-dot" data-captain={captain} aria-hidden="true" /> : null}
+        <span className="job-dock-captain-tag">{track.displayName}</span>
       </span>
-      {displayLine ? (
-        <span className="job-dock-row-line">
-          {displayLine}
-          {isLive ? <span className="job-dock-caret" aria-hidden="true" /> : null}
-        </span>
-      ) : null}
-      {showThinking ? <span className="thinking-chip">thinking…</span> : null}
+      <span className="job-dock-card-copy">
+        <span className="job-dock-card-phase">{phase.label}</span>
+        {displayLine ? <span className="job-dock-card-line">{displayLine}</span> : null}
+        {showThinking ? <span className="thinking-chip">thinking…</span> : null}
+      </span>
+      <span className="job-dock-card-meta">{elapsed}</span>
+      <span className="job-dock-card-bar" aria-hidden="true"><i /></span>
     </div>
   );
 }
@@ -943,7 +945,6 @@ function JobDetailContent({ job }: { readonly job: JobView }) {
 
 function TrackCard({ track, jobStatus }: { readonly track: TrackView; readonly jobStatus: string }) {
   const modifier = trackCardModifier(track.status, jobStatus);
-  const isLive = modifier === "track-card--live";
   // 칩 텍스트도 modifier와 같은 해석에서 파생 — 종결 잡의 미종결 트랙이 coral 카드에
   // raw "stream" 라벨을 다는 표기 분열을 막는다(라이브 트랙은 자기 상태 그대로).
   const statusLabel = resolveDockRowStatusLabel(track.status, jobStatus);
@@ -962,18 +963,29 @@ function TrackCard({ track, jobStatus }: { readonly track: TrackView; readonly j
         </details>
       ) : null}
       {track.text ? (
-        <div className="track-card-text" role="group" aria-label="Output">
-          <span className="track-card-section-label track-card-section-label--output" aria-hidden="true">output</span>
-          <pre>{track.text}{isLive ? <span className="track-card-caret" aria-hidden="true" /> : null}</pre>
-        </div>
+        <StreamedMarkdown className="track-card-output markdown-body" text={track.text} streaming={!isTerminalJobStatus(track.status)} />
       ) : null}
       {track.error ? (
         <div className="track-card-error" role="group" aria-label="Error">{track.error}</div>
       ) : null}
       {track.tools.length > 0 ? (
-        <ul className="track-card-tools">
-          {track.tools.map((tool) => <li key={tool.id}>{tool.name ?? tool.id}</li>)}
-        </ul>
+        <div className="track-card-tools" role="list" aria-label="Tools">
+          {track.tools.map((tool) => {
+            const target = describeToolTarget(tool.input);
+            const tone = tool.status === "done" || tool.status === "completed"
+              ? "is-done"
+              : tool.status === "error" || tool.status === "failed"
+                ? "is-error"
+                : "is-live";
+            return (
+              <span key={tool.id} className={`track-card-tool-chip ${tone}`} role="listitem">
+                <i aria-hidden="true" />
+                <strong>{tool.name ?? tool.id}</strong>
+                {target ? <span>{target}</span> : null}
+              </span>
+            );
+          })}
+        </div>
       ) : null}
     </article>
   );
@@ -1012,18 +1024,18 @@ function readPayloadNumber(payload: Record<string, unknown>, key: string): numbe
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
-function getActiveToolName(track: TrackView): string | undefined {
-  const tool = track.tools.find(
-    (t) => t.status !== "completed" && t.status !== "failed" && t.status !== "error"
-  );
-  return tool ? (tool.name ?? tool.id) : undefined;
-}
-
 function getLastLine(text: string): string {
   const trimmed = text.trim();
   if (!trimmed) return "";
   const lines = trimmed.split("\n");
   return lines[lines.length - 1]?.trim() ?? "";
+}
+
+function dockSegmentTone(track: TrackView, jobStatus: string): "live" | "done" | "error" | undefined {
+  const status = resolveDockRowStatusLabel(track.status, jobStatus);
+  if (isTrackError(status) || status === "aborted") return "error";
+  if (status === "done") return "done";
+  return isDockTrackLive(jobStatus, track.status) ? "live" : undefined;
 }
 
 function TerminalFontSettingsCard({ terminalFont }: { readonly terminalFont: TerminalFontSettings }) {

--- a/runtime/fleet-plugins/terminal/client/agent/streamed-markdown.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/streamed-markdown.tsx
@@ -1,0 +1,44 @@
+import { renderMarkdown } from "@fleet-console/markdown/core";
+import { React } from "@fleet-console/sdk/plugin/browser";
+
+const STREAM_RENDER_DELAY_MS = 32;
+
+export const StreamedMarkdown = React.memo(function StreamedMarkdown({
+  text,
+  streaming,
+  className,
+}: {
+  readonly text: string;
+  readonly streaming: boolean;
+  readonly className?: string;
+}) {
+  const latestText = React.useRef(text);
+  const renderedText = React.useRef(streaming ? text : "");
+  const renderTimer = React.useRef<number | null>(null);
+  const [streamedHtml, setStreamedHtml] = React.useState(() => streaming ? renderMarkdown(text).html : "");
+  latestText.current = text;
+
+  const completedHtml = React.useMemo(() => streaming ? null : renderMarkdown(text).html, [streaming, text]);
+
+  React.useEffect(() => {
+    if (!streaming) {
+      if (renderTimer.current !== null) window.clearTimeout(renderTimer.current);
+      renderTimer.current = null;
+      return;
+    }
+    if (renderedText.current === text || renderTimer.current !== null) return;
+    renderTimer.current = window.setTimeout(() => {
+      renderTimer.current = null;
+      const nextText = latestText.current;
+      if (nextText === renderedText.current) return;
+      renderedText.current = nextText;
+      setStreamedHtml(renderMarkdown(nextText).html);
+    }, STREAM_RENDER_DELAY_MS);
+  }, [streaming, text]);
+
+  React.useEffect(() => () => {
+    if (renderTimer.current !== null) window.clearTimeout(renderTimer.current);
+  }, []);
+
+  return <div className={className} dangerouslySetInnerHTML={{ __html: completedHtml ?? streamedHtml }} />;
+});

--- a/runtime/fleet-plugins/terminal/tests/agent-streaming-banner.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-streaming-banner.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { pruneOrphanStreamingOperations } from "../client/agent/connection.js";
-import { formatElapsedDuration, formatTokenEstimate, estimateJobTokens, getDockTailText, isDockTrackLive, isTrackError, isTrackLive, mergeDockJobs, mergeJobIds, pruneRetainedJobs, resolveDockRowStatusLabel, resolveJobSignature, resolveCarrierCaptain, retainCompletedJobs, selectJobsByIds } from "../client/agent/helpers.js";
+import { deriveTrackPhase, describeToolTarget, formatElapsedDuration, formatTokenEstimate, estimateJobTokens, getDockTailText, isDockTrackLive, isTrackError, isTrackLive, mergeDockJobs, mergeJobIds, pruneRetainedJobs, resolveDockRowStatusLabel, resolveJobSignature, resolveCarrierCaptain, retainCompletedJobs, selectJobsByIds } from "../client/agent/helpers.js";
 import { applyEvent, createEmptyJob, isTerminalJobStatus } from "../client/agent/reduce.js";
 import type { JobView } from "../client/agent/types.js";
 import type { OperationNode } from "@fleet-console/sdk/operations";
@@ -217,6 +217,84 @@ describe("isDockTrackLive (잡 종결 게이트 라이브 판정)", () => {
     expect(isDockTrackLive("done", "stream")).toBe(false);
     expect(isDockTrackLive("error", "active")).toBe(false);
     expect(isDockTrackLive("active", "done")).toBe(false);
+  });
+});
+
+describe("deriveTrackPhase (phase 카드 상태)", () => {
+  function makeTrack(overrides: Partial<JobView["tracks"][string]> = {}): JobView["tracks"][string] {
+    return {
+      trackId: "track-1",
+      displayName: "Carrier",
+      status: "stream",
+      lastEventId: 1,
+      text: "",
+      thought: "",
+      sentTextLength: 0,
+      sentThoughtLength: 0,
+      tools: [],
+      ...overrides,
+    };
+  }
+
+  it.each([
+    ["error", "active", { label: "Error", tone: "error" }],
+    ["stream", "error", { label: "Error", tone: "error" }],
+    ["aborted", "active", { label: "Aborted", tone: "error" }],
+    ["stream", "aborted", { label: "Aborted", tone: "error" }],
+    ["done", "active", { label: "Done", tone: "done" }],
+    ["stream", "done", { label: "Done", tone: "done" }],
+  ] as const)("track=%s job=%s의 종결 phase를 도출한다", (trackStatus, jobStatus, expected) => {
+    expect(deriveTrackPhase(makeTrack({ status: trackStatus }), jobStatus)).toEqual(expected);
+  });
+
+  it("마지막 미종결 도구를 출력보다 우선하고 이름이 없으면 tool로 폴백한다", () => {
+    expect(deriveTrackPhase(makeTrack({
+      text: "partial output",
+      thought: "hidden reasoning",
+      tools: [
+        { id: "done", name: "read", status: "done" },
+        { id: "live", status: "running" },
+      ],
+    }), "active")).toEqual({ label: "Using tool", tone: "live" });
+  });
+
+  it("완료된 마지막 도구는 건너뛰고 Writing을 Reasoning보다 우선한다", () => {
+    expect(deriveTrackPhase(makeTrack({
+      text: "partial output",
+      thought: "hidden reasoning",
+      tools: [{ id: "done", name: "read", status: "done" }],
+    }), "active")).toEqual({ label: "Writing", tone: "live" });
+  });
+
+  it("output 없이 thought가 있으면 Reasoning, 둘 다 없으면 Working이다", () => {
+    expect(deriveTrackPhase(makeTrack({ thought: "hidden reasoning" }), "active")).toEqual({ label: "Reasoning", tone: "live" });
+    expect(deriveTrackPhase(makeTrack(), "active")).toEqual({ label: "Working", tone: "live" });
+  });
+
+  it("종결 상태가 라이브 activity보다 항상 우선한다", () => {
+    expect(deriveTrackPhase(makeTrack({
+      status: "done",
+      text: "output",
+      tools: [{ id: "live", name: "write", status: "running" }],
+    }), "active")).toEqual({ label: "Done", tone: "done" });
+    expect(deriveTrackPhase(makeTrack({ status: "done" }), "error")).toEqual({ label: "Error", tone: "error" });
+  });
+});
+
+describe("describeToolTarget (도구 대상 요약)", () => {
+  it("승인된 키 우선순위에서 첫 string 값을 선택한다", () => {
+    expect(describeToolTarget({ pattern: "later", command: "pnpm test", path: "src/index.ts", file_path: "src/main.ts" })).toBe("src/main.ts");
+    expect(describeToolTarget({ path: 42, file: "fallback.ts" })).toBe("fallback.ts");
+  });
+
+  it("대상을 60자로 절단한다", () => {
+    expect(describeToolTarget({ query: "q".repeat(75) })).toBe("q".repeat(60));
+  });
+
+  it("object가 아니거나 string 대상 키가 없으면 null이다", () => {
+    expect(describeToolTarget(null)).toBeNull();
+    expect(describeToolTarget(["file.ts"])).toBeNull();
+    expect(describeToolTarget({ path: false, other: "ignored" })).toBeNull();
   });
 });
 

--- a/runtime/fleet-plugins/terminal/tests/agent-streaming-banner.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-streaming-banner.test.ts
@@ -247,6 +247,21 @@ describe("deriveTrackPhase (phase 카드 상태)", () => {
     expect(deriveTrackPhase(makeTrack({ status: trackStatus }), jobStatus)).toEqual(expected);
   });
 
+  it("혼합 결과에서는 resolveDockRowStatusLabel 계약과 같이 트랙 종결 상태를 job 오류보다 우선한다", () => {
+    const track = makeTrack({ status: "done" });
+    expect(resolveDockRowStatusLabel(track.status, "error")).toBe("done");
+    expect(deriveTrackPhase(track, "error")).toEqual({ label: "Done", tone: "done" });
+  });
+
+  it("err 트랙은 error tone이고 종결 job의 stale stream 트랙은 job 상태로 폴백한다", () => {
+    const errorPhase = deriveTrackPhase(makeTrack({ status: "err" }), "active");
+    const staleTrackPhase = deriveTrackPhase(makeTrack({ status: "stream" }), "done");
+    expect(errorPhase).toEqual({ label: "Error", tone: "error" });
+    expect(errorPhase.tone === "live").toBe(false);
+    expect(staleTrackPhase).toEqual({ label: "Done", tone: "done" });
+    expect(staleTrackPhase.tone === "live").toBe(false);
+  });
+
   it("마지막 미종결 도구를 출력보다 우선하고 이름이 없으면 tool로 폴백한다", () => {
     expect(deriveTrackPhase(makeTrack({
       text: "partial output",
@@ -277,7 +292,7 @@ describe("deriveTrackPhase (phase 카드 상태)", () => {
       text: "output",
       tools: [{ id: "live", name: "write", status: "running" }],
     }), "active")).toEqual({ label: "Done", tone: "done" });
-    expect(deriveTrackPhase(makeTrack({ status: "done" }), "error")).toEqual({ label: "Error", tone: "error" });
+    expect(deriveTrackPhase(makeTrack({ status: "done" }), "error")).toEqual({ label: "Done", tone: "done" });
   });
 });
 

--- a/runtime/fleet-plugins/terminal/tests/agent-streaming-banner.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-streaming-banner.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { pruneOrphanStreamingOperations } from "../client/agent/connection.js";
-import { deriveTrackPhase, describeToolTarget, formatElapsedDuration, formatTokenEstimate, estimateJobTokens, getDockTailText, isDockTrackLive, isTrackError, isTrackLive, mergeDockJobs, mergeJobIds, pruneRetainedJobs, resolveDockRowStatusLabel, resolveJobSignature, resolveCarrierCaptain, retainCompletedJobs, selectJobsByIds } from "../client/agent/helpers.js";
+import { deriveTrackPhase, describeToolTarget, resolveToolTone, formatElapsedDuration, formatTokenEstimate, estimateJobTokens, getDockTailText, isDockTrackLive, isTrackError, isTrackLive, mergeDockJobs, mergeJobIds, pruneRetainedJobs, resolveDockRowStatusLabel, resolveJobSignature, resolveCarrierCaptain, retainCompletedJobs, selectJobsByIds } from "../client/agent/helpers.js";
 import { applyEvent, createEmptyJob, isTerminalJobStatus } from "../client/agent/reduce.js";
 import type { JobView } from "../client/agent/types.js";
 import type { OperationNode } from "@fleet-console/sdk/operations";
@@ -260,6 +260,20 @@ describe("deriveTrackPhase (phase 카드 상태)", () => {
     expect(errorPhase.tone === "live").toBe(false);
     expect(staleTrackPhase).toEqual({ label: "Done", tone: "done" });
     expect(staleTrackPhase.tone === "live").toBe(false);
+  });
+
+  it("ACP 어휘(completed/failed)의 마지막 도구도 종결로 취급해 Using에 잔류하지 않는다", () => {
+    expect(deriveTrackPhase(makeTrack({
+      tools: [{ id: "acp-done", name: "read", status: "completed" }],
+    }), "active")).toEqual({ label: "Working", tone: "live" });
+    expect(deriveTrackPhase(makeTrack({
+      text: "partial output",
+      tools: [{ id: "acp-failed", name: "edit", status: "failed" }],
+    }), "active")).toEqual({ label: "Writing", tone: "live" });
+    expect(resolveToolTone("completed")).toBe("done");
+    expect(resolveToolTone("failed")).toBe("error");
+    expect(resolveToolTone("in_progress")).toBe("live");
+    expect(resolveToolTone(undefined)).toBe("live");
   });
 
   it("마지막 미종결 도구를 출력보다 우선하고 이름이 없으면 tool로 폴백한다", () => {


### PR DESCRIPTION
## Summary
- 인패널 캐리어 스트림덱 스트립을 앰비언트 캡슐로 재구성합니다: 캡틴 도트 스택, 라이브 aurora scan line, 트랙별 세그먼트 미터, 최신 출력 라인·경과·토큰 추정을 한 캡슐에 담습니다.
- 덱 확장 바디의 로그 행을 phase 카드로 교체합니다: 캐리어 정체성 스파인(캡틴 8색) + 동사형 상태(Reasoning / Using \<tool\> / Writing) + 라이브 프리뷰 + 진행 오너먼트.
- Details 모달 Activity 탭을 대화형 읽기 표면으로 재구성합니다: 32ms 스로틀 스트리밍 마크다운(`@fleet-console/markdown/core` sanitize 경유), 대상 파일이 붙은 도구 상태 칩, 재스타일된 thinking 폴드. 완료 수명주기는 현행 유지(4초 리텐션 후 소실), thinking 원문의 스트립 비노출 계약 불변.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal test` — 32 files / 341 tests pass (phase·tool-target helper 단위 테스트 포함)
- [x] `pnpm --filter @dotobokuri/fleet-console build` pass
- [x] `vitest run tests/instrument-design-contract.test.ts` — 16 pass (디자인 계약 무변경 준수)
- [x] 격리 콘솔 + 합성 스트림 헤디드 실측: 캡슐 스트립·phase 카드·대화형 Activity·완료 4초 후 소실, 페이지 에러 0
- [x] Changelog: `.changelog.d/pr-352.md` — 프래그먼트 문법·이중언어 요약·`compile-changelog-fragments.mjs --check` 검증 완료
