### PR TITLE
fix(console): stabilize carrier reminder submission

### DIFF
--- a/.changelog.d/pr-353.md
+++ b/.changelog.d/pr-353.md
@@ -1,0 +1,14 @@
+### fleet-core
+#### Changed
+- [fleet-admiral] Hosts can now split PTY message text from its submit key with an optional delivery delay while existing callers retain their current behavior.
+  ko: 호스트는 이제 선택적 전달 지연으로 PTY 메시지 텍스트와 제출 키를 분리할 수 있으며 기존 호출자의 동작은 그대로 유지됩니다.
+
+### fleet-console
+#### Fixed
+- [fleet-console] Carrier completion System Reminder messages now submit reliably when multiple jobs finish close together while browser payload redaction remains intact.
+  ko: 여러 작업이 비슷한 시점에 완료되어도 Carrier 완료 System Reminder 메시지가 안정적으로 제출되며 브라우저 payload redaction은 그대로 유지됩니다.
+
+### fleet-plugin
+#### Fixed
+- [fleet-console] The Terminal plugin serializes delayed System Reminder input and cancels stale submits when a PTY session closes or a write fails.
+  ko: Terminal 플러그인은 지연된 System Reminder 입력을 직렬화하고 PTY 세션이 닫히거나 쓰기에 실패하면 오래된 제출을 취소합니다.

--- a/packages/fleet-admiral/src/agent-runtime/reminder-router.ts
+++ b/packages/fleet-admiral/src/agent-runtime/reminder-router.ts
@@ -3,7 +3,7 @@ import type { CarrierJobStreamEvent } from "@dotobokuri/fleet-carriers";
 import type { CliMessagePolicy, PtyInputChunk } from "../agent-cli/types.js";
 
 export interface PtyWriteSink {
-  write(data: string): void;
+  write(data: string): boolean | void;
 }
 
 const DEFAULT_BRACKETED_PASTE = false;
@@ -18,17 +18,33 @@ const LINE_BREAK_PATTERN = /[\r\n]/;
 // Windows crossterm reads INPUT_RECORD rather than bracketed paste, then Codex suppresses Enter during its paste burst window.
 const WINDOWS_CONPTY_SUBMIT_DELAY_MS = 250;
 
-export interface DelayedPtyWriter {
-  // sessionKey가 있고 지연 청크가 포함되면 같은 키의 이전 제출이 끝난 뒤 순차 실행한다.
-  enqueue(sessionKey: string | undefined, write: (data: string) => void, chunks: readonly PtyInputChunk[]): void;
+export interface PtyMessageDeliveryOptions {
+  readonly submitDelayMs?: number;
 }
 
-// 세션별 지연 제출을 직렬화하는 공유 primitive. Windows 지연 경로에서 같은 세션으로 두 입력
+export interface DelayedPtyWriter {
+  // sessionKey가 있고 지연 청크가 포함되면 같은 키의 이전 제출이 끝난 뒤 순차 실행한다.
+  enqueue(sessionKey: string | undefined, write: (data: string) => boolean | void, chunks: readonly PtyInputChunk[]): void;
+  cancel(sessionKey: string): void;
+  cancelAll(): void;
+}
+
+// 세션별 지연 제출을 직렬화하는 공유 primitive. 같은 세션으로 두 입력
 // (carrier 리마인더/rename 주입)이 250ms 지연 창 안에 도착하면 텍스트가 뒤섞이고(textA textB)
 // CR이 결합/공백 제출되므로, 이전 제출의 종결자(CR)까지 flush된 뒤 다음 입력의 첫 write가
 // 시작되도록 체인한다. 리마인더와 rename이 같은 인스턴스를 공유해야 상호 직렬화된다.
 export function createDelayedPtyWriter(): DelayedPtyWriter {
   const submitTails = new Map<string, Promise<void>>();
+  const pendingControllers = new Map<string, Set<AbortController>>();
+
+  const cancel = (sessionKey: string): void => {
+    const controllers = pendingControllers.get(sessionKey);
+    if (controllers) {
+      for (const controller of controllers) controller.abort();
+    }
+    pendingControllers.delete(sessionKey);
+    submitTails.delete(sessionKey);
+  };
 
   return {
     enqueue(sessionKey, write, chunks) {
@@ -40,12 +56,22 @@ export function createDelayedPtyWriter(): DelayedPtyWriter {
         return;
       }
 
+      const controller = new AbortController();
+      const controllers = pendingControllers.get(sessionKey) ?? new Set<AbortController>();
+      controllers.add(controller);
+      pendingControllers.set(sessionKey, controllers);
       const prev = submitTails.get(sessionKey) ?? Promise.resolve();
-      const tail = prev.then(() => writeChunksWithDelay(write, chunks)).catch(() => {});
+      const tail = prev.then(() => writeChunksWithDelay(write, chunks, controller.signal)).catch(() => {});
       submitTails.set(sessionKey, tail);
       void tail.then(() => {
+        controllers.delete(controller);
+        if (pendingControllers.get(sessionKey) === controllers && controllers.size === 0) pendingControllers.delete(sessionKey);
         if (submitTails.get(sessionKey) === tail) submitTails.delete(sessionKey);
       });
+    },
+    cancel,
+    cancelAll() {
+      for (const sessionKey of [...pendingControllers.keys()]) cancel(sessionKey);
     },
   };
 }
@@ -57,6 +83,8 @@ export function createCarrierResultReminderRouter(deps: {
   readonly resolveSessionKey?: (event: CarrierJobStreamEvent) => string | undefined;
   // rename 주입 등 다른 지연 경로와 세션 단위로 함께 직렬화하려면 host가 공유 writer를 주입한다.
   readonly writer?: DelayedPtyWriter;
+  // host 전용 전송 정책. 미지정 시 기존 formatter 바이트와 제출 타이밍을 유지한다.
+  readonly delivery?: PtyMessageDeliveryOptions;
   readonly platform?: NodeJS.Platform;
 }): () => void {
   const writer = deps.writer ?? createDelayedPtyWriter();
@@ -73,7 +101,7 @@ export function createCarrierResultReminderRouter(deps: {
 
     // host가 활성 프로파일의 messagePolicy를 제공하면 그대로 적용한다. 미제공 시 기본 정책.
     const policy = deps.resolvePolicy?.(event) ?? {};
-    const chunks = formatCarrierResultReminderMessage(policy, reminder, deps.platform);
+    const chunks = formatCarrierResultReminderMessage(policy, reminder, deps.platform, deps.delivery);
     writer.enqueue(deps.resolveSessionKey?.(event), (data) => sink.write(data), chunks);
   });
 }
@@ -91,9 +119,10 @@ export function formatCarrierResultReminderMessage(
   policy: CliMessagePolicy,
   text: string,
   platform: NodeJS.Platform = process.platform,
+  delivery: PtyMessageDeliveryOptions = {},
 ): PtyInputChunk[] {
   const resolvedPolicy = resolveMessagePolicy(policy);
-  return applyMessagePolicy(text, resolvedPolicy, platform);
+  return applyMessagePolicy(text, resolvedPolicy, platform, delivery);
 }
 
 function resolveMessagePolicy(policy: CliMessagePolicy): Required<CliMessagePolicy> {
@@ -109,10 +138,24 @@ function applyMessagePolicy(
   text: string,
   policy: Required<CliMessagePolicy>,
   platform: NodeJS.Platform,
+  delivery: PtyMessageDeliveryOptions,
 ): PtyInputChunk[] {
   const usePasteMode = policy.bracketedPaste || (policy.multilineStrategy === "paste-mode" && LINE_BREAK_PATTERN.test(text));
+  const useConptyPasteBurst = policy.conptyPasteBurst && platform === "win32" && usePasteMode;
+  const payload = useConptyPasteBurst
+    ? text
+    : usePasteMode
+      ? `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}`
+      : text;
 
-  if (policy.conptyPasteBurst && platform === "win32" && usePasteMode) {
+  if (delivery.submitDelayMs !== undefined) {
+    return [
+      { data: payload },
+      { data: policy.lineTerminator, submitDelayMs: delivery.submitDelayMs },
+    ];
+  }
+
+  if (useConptyPasteBurst) {
     return [
       { data: text },
       { data: policy.lineTerminator, submitDelayMs: WINDOWS_CONPTY_SUBMIT_DELAY_MS },
@@ -120,39 +163,40 @@ function applyMessagePolicy(
   }
 
   return [{
-    data: usePasteMode
-      ? `${BRACKETED_PASTE_START}${text}${BRACKETED_PASTE_END}${policy.lineTerminator}`
-      : `${text}${policy.lineTerminator}`,
+    data: `${payload}${policy.lineTerminator}`,
   }];
 }
 
-function writeChunksWithDelay(write: (data: string) => void, chunks: readonly PtyInputChunk[]): Promise<void> {
+async function writeChunksWithDelay(
+  write: (data: string) => boolean | void,
+  chunks: readonly PtyInputChunk[],
+  signal?: AbortSignal,
+): Promise<void> {
+  for (const chunk of chunks) {
+    if (signal?.aborted) return;
+    if (chunk.submitDelayMs !== undefined) {
+      await waitForDelay(chunk.submitDelayMs, signal);
+      if (signal?.aborted) return;
+    }
+    try {
+      if (write(chunk.data) === false) return;
+    } catch {
+      // Sessions may close before a deferred submit reaches the host PTY.
+      return;
+    }
+  }
+}
+
+function waitForDelay(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve();
   return new Promise((resolve) => {
-    let index = 0;
+    const timer = setTimeout(finish, delayMs);
+    signal?.addEventListener("abort", finish, { once: true });
 
-    const writeNext = (): void => {
-      const chunk = chunks[index++];
-      if (!chunk) {
-        resolve();
-        return;
-      }
-
-      const commit = () => {
-        try {
-          write(chunk.data);
-        } catch {
-          // Sessions may close before a deferred submit reaches the host PTY.
-        }
-        writeNext();
-      };
-
-      if (chunk.submitDelayMs === undefined) {
-        commit();
-      } else {
-        setTimeout(commit, chunk.submitDelayMs);
-      }
-    };
-
-    writeNext();
+    function finish(): void {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", finish);
+      resolve();
+    }
   });
 }

--- a/packages/fleet-admiral/src/index.ts
+++ b/packages/fleet-admiral/src/index.ts
@@ -81,5 +81,6 @@ export {
   formatCarrierResultReminderMessage,
   sanitizeCarrierResultReminder,
   type DelayedPtyWriter,
+  type PtyMessageDeliveryOptions,
   type PtyWriteSink,
 } from "./agent-runtime/reminder-router.js";

--- a/packages/fleet-admiral/tests/reminder-router.test.ts
+++ b/packages/fleet-admiral/tests/reminder-router.test.ts
@@ -55,6 +55,32 @@ describe("carrier result reminder router", () => {
     expect(writes).toEqual(["\x1b[200~done\x1b[201~\r"]);
   });
 
+  it("applies an opt-in host delivery policy without changing the CLI profile", async () => {
+    vi.useFakeTimers();
+    try {
+      const writes: string[] = [];
+      const handlers: Array<(event: CarrierJobStreamEvent) => void> = [];
+      createCarrierResultReminderRouter({
+        streamRegister(handler) {
+          handlers.push(handler);
+          return () => undefined;
+        },
+        resolveSink: () => createArraySink(writes),
+        resolvePolicy: () => ({ bracketedPaste: true, lineTerminator: "\r" }),
+        resolveSessionKey: () => "session-1",
+        delivery: { submitDelayMs: 250 },
+      });
+
+      handlers[0]?.(finalizedEvent("done"));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(writes).toEqual(["\x1b[200~done\x1b[201~"]);
+      await vi.advanceTimersByTimeAsync(250);
+      expect(writes).toEqual(["\x1b[200~done\x1b[201~", "\r"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("ignores finalized events without a string systemReminder", () => {
     let resolveCount = 0;
     const handlers: Array<(event: CarrierJobStreamEvent) => void> = [];
@@ -113,6 +139,18 @@ describe("carrier result reminder router", () => {
     expect(formatCarrierResultReminderMessage({ lineTerminator: "\n" }, "hello", "darwin")).toEqual([{ data: "hello\n" }]);
   });
 
+  it("splits payload and submit only when the host opts into delayed delivery", () => {
+    const policy = { bracketedPaste: true, lineTerminator: "\r", multilineStrategy: "paste-mode" as const };
+
+    expect(formatCarrierResultReminderMessage(policy, "hello", "darwin")).toEqual([
+      { data: "\x1b[200~hello\x1b[201~\r" },
+    ]);
+    expect(formatCarrierResultReminderMessage(policy, "hello", "darwin", { submitDelayMs: 250 })).toEqual([
+      { data: "\x1b[200~hello\x1b[201~" },
+      { data: "\r", submitDelayMs: 250 },
+    ]);
+  });
+
   it("uses a delayed bare submit for ConPTY paste bursts on Windows", () => {
     const policy = { bracketedPaste: true, conptyPasteBurst: true, lineTerminator: "\r", multilineStrategy: "paste-mode" as const };
     const text = "line 1\nline 2";
@@ -123,7 +161,7 @@ describe("carrier result reminder router", () => {
     ]);
   });
 
-  it("writes the ConPTY submit after its delay without blocking finalized events", () => {
+  it("writes the ConPTY submit after its delay without blocking finalized events", async () => {
     vi.useFakeTimers();
     try {
       const writes: string[] = [];
@@ -141,9 +179,9 @@ describe("carrier result reminder router", () => {
       handlers[0]?.(finalizedEvent("line 1\nline 2"));
 
       expect(writes).toEqual(["line 1\nline 2"]);
-      vi.advanceTimersByTime(249);
+      await vi.advanceTimersByTimeAsync(249);
       expect(writes).toEqual(["line 1\nline 2"]);
-      vi.advanceTimersByTime(1);
+      await vi.advanceTimersByTimeAsync(1);
       expect(writes).toEqual(["line 1\nline 2", "\r"]);
     } finally {
       vi.useRealTimers();
@@ -193,8 +231,8 @@ describe("carrier result reminder router", () => {
       const delayed = (text: string): PtyInputChunk[] => [{ data: text }, { data: "\r", submitDelayMs: 250 }];
 
       // 서로 다른 소스(리마인더/rename)라도 같은 세션 키를 공유하면 순차 제출된다.
-      writer.enqueue("session-1", (data) => writes.push(data), delayed("reminder"));
-      writer.enqueue("session-1", (data) => writes.push(data), delayed("/rename X"));
+      writer.enqueue("session-1", (data) => { writes.push(data); }, delayed("reminder"));
+      writer.enqueue("session-1", (data) => { writes.push(data); }, delayed("/rename X"));
 
       await vi.advanceTimersByTimeAsync(0);
       expect(writes).toEqual(["reminder"]);
@@ -214,13 +252,96 @@ describe("carrier result reminder router", () => {
       const writer = createDelayedPtyWriter();
       const delayed = (text: string): PtyInputChunk[] => [{ data: text }, { data: "\r", submitDelayMs: 250 }];
 
-      writer.enqueue("a", (data) => writes.push(data), delayed("A"));
-      writer.enqueue("b", (data) => writes.push(data), delayed("B"));
+      writer.enqueue("a", (data) => { writes.push(data); }, delayed("A"));
+      writer.enqueue("b", (data) => { writes.push(data); }, delayed("B"));
 
       await vi.advanceTimersByTimeAsync(0);
       expect(writes).toEqual(["A", "B"]);
       await vi.advanceTimersByTimeAsync(250);
       expect(writes).toEqual(["A", "B", "\r", "\r"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops a queued message when a PTY write returns false or throws", async () => {
+    vi.useFakeTimers();
+    try {
+      const writer = createDelayedPtyWriter();
+      const writes: string[] = [];
+      const chunks: PtyInputChunk[] = [{ data: "payload" }, { data: "\r", submitDelayMs: 250 }];
+
+      writer.enqueue("false-session", (data) => {
+        writes.push(data);
+        return false;
+      }, chunks);
+      writer.enqueue("throw-session", (data) => {
+        writes.push(data);
+        throw new Error("closed");
+      }, chunks);
+
+      await vi.advanceTimersByTimeAsync(500);
+      expect(writes).toEqual(["payload", "payload"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels pending and queued writes for one session", async () => {
+    vi.useFakeTimers();
+    try {
+      const writer = createDelayedPtyWriter();
+      const writes: string[] = [];
+      const delayed = (text: string): PtyInputChunk[] => [{ data: text }, { data: "\r", submitDelayMs: 250 }];
+
+      writer.enqueue("session-1", (data) => { writes.push(data); }, delayed("A"));
+      writer.enqueue("session-1", (data) => { writes.push(data); }, delayed("B"));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(writes).toEqual(["A"]);
+
+      writer.cancel("session-1");
+      await vi.advanceTimersByTimeAsync(500);
+      expect(writes).toEqual(["A"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("allows a fresh enqueue after cancellation", async () => {
+    vi.useFakeTimers();
+    try {
+      const writer = createDelayedPtyWriter();
+      const writes: string[] = [];
+      const delayed = (text: string): PtyInputChunk[] => [{ data: text }, { data: "\r", submitDelayMs: 250 }];
+
+      writer.enqueue("session-1", (data) => { writes.push(data); }, delayed("stale"));
+      await vi.advanceTimersByTimeAsync(0);
+      writer.cancel("session-1");
+      writer.enqueue("session-1", (data) => { writes.push(data); }, delayed("fresh"));
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(writes).toEqual(["stale", "fresh"]);
+      await vi.advanceTimersByTimeAsync(250);
+      expect(writes).toEqual(["stale", "fresh", "\r"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels pending writes across all sessions", async () => {
+    vi.useFakeTimers();
+    try {
+      const writer = createDelayedPtyWriter();
+      const writes: string[] = [];
+      const delayed = (text: string): PtyInputChunk[] => [{ data: text }, { data: "\r", submitDelayMs: 250 }];
+
+      writer.enqueue("a", (data) => { writes.push(data); }, delayed("A"));
+      writer.enqueue("b", (data) => { writes.push(data); }, delayed("B"));
+      await vi.advanceTimersByTimeAsync(0);
+      writer.cancelAll();
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(writes).toEqual(["A", "B"]);
     } finally {
       vi.useRealTimers();
     }

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -24,6 +24,8 @@ import { createPluginTerminalUpgradeHandler } from "../../fleet-plugins/terminal
 
 const fleetAdmiralMock = vi.hoisted(() => ({
   agentRuntimeQueue: [] as unknown[],
+  esbuildExternals: [] as string[][],
+  externalizeForReminderFixture: false,
   resolveProfile: null as null | ((...args: readonly unknown[]) => unknown),
 }));
 
@@ -35,6 +37,22 @@ vi.mock("@dotobokuri/fleet-admiral", async (importOriginal) => {
       fleetAdmiralMock.agentRuntimeQueue.shift() ?? actual.createFleetAgentRuntimeLifecycle(deps),
     resolveAgentCliProfile: (...args: Parameters<typeof actual.resolveAgentCliProfile>) =>
       fleetAdmiralMock.resolveProfile?.(...args) ?? actual.resolveAgentCliProfile(...args),
+  };
+});
+
+vi.mock("esbuild", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("esbuild")>();
+  return {
+    ...actual,
+    build: (options: Parameters<typeof actual.build>[0]) => {
+      if (!fleetAdmiralMock.externalizeForReminderFixture) {
+        fleetAdmiralMock.esbuildExternals.push([...(options.external ?? [])]);
+        return actual.build(options);
+      }
+      const external = [...(options.external ?? []), "@dotobokuri/fleet-admiral"];
+      fleetAdmiralMock.esbuildExternals.push(external);
+      return actual.build({ ...options, external });
+    },
   };
 });
 
@@ -80,8 +98,10 @@ let previousStaticIndex: string | null | undefined;
 const CONSOLE_PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 afterEach(async () => {
+  fleetAdmiralMock.externalizeForReminderFixture = false;
   for (const server of servers.splice(0)) await server.stop();
   fleetAdmiralMock.agentRuntimeQueue.length = 0;
+  fleetAdmiralMock.esbuildExternals.length = 0;
   fleetAdmiralMock.resolveProfile = null;
   delete (globalThis as { __fleetTerminalLaunch?: unknown }).__fleetTerminalLaunch;
   delete (globalThis as { __fleetTerminalStartShell?: unknown }).__fleetTerminalStartShell;
@@ -728,6 +748,7 @@ describe("console static and terminal ticket boundary", () => {
   });
 
   it("cleans stale plugin bundles on startup and this run's bundles on server stop", async () => {
+    const buildCallOffset = fleetAdmiralMock.esbuildExternals.length;
     const pluginPackage = createPluginPackageRoot({
       demoRoutes: "export function register() {}",
       demoRoutesFile: "routes.ts",
@@ -741,9 +762,12 @@ describe("console static and terminal ticket boundary", () => {
       },
     });
     const cacheDir = path.join(fixture.carrierStoreDir, "console", "plugin-cache");
+    const fixtureBuildExternals = fleetAdmiralMock.esbuildExternals.slice(buildCallOffset);
 
     expect(fs.existsSync(path.join(cacheDir, "fleet-console-plugin-crashed"))).toBe(false);
     expect(fs.readdirSync(cacheDir).filter((entry) => entry.startsWith("fleet-console-plugin-"))).not.toEqual([]);
+    expect(fixtureBuildExternals).toHaveLength(1);
+    expect(fixtureBuildExternals[0]).not.toContain("@dotobokuri/fleet-admiral");
 
     await fixture.server.stop();
 
@@ -819,13 +843,13 @@ describe("console static and terminal ticket boundary", () => {
     expect(runtime.cleanup).not.toHaveBeenCalled();
   });
 
-  it.skip("injects finalized carrier reminders only into the originating live terminal session", async () => {
+  it("serializes finalized carrier reminders in their originating live terminal session and cancels submit on deletion", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-reminder-"));
     tempDirs.push(dir);
     const runtime = createFakeConsoleRuntime([], []);
+    fleetAdmiralMock.agentRuntimeQueue.push(runtime);
     const ptys = new Map<string, TerminalPtyHandle & { readonly writes: string[] }>();
-    const fixture = await startFixture({
-      agentRuntime: runtime as never,
+    const fixture = await startReminderFixture({
       terminalLaunch: async (cwd, context) => ({
         bin: "mock",
         args: [],
@@ -842,35 +866,57 @@ describe("console static and terminal ticket boundary", () => {
         return pty;
       },
     });
+    expect(fleetAdmiralMock.externalizeForReminderFixture).toBe(false);
     const headers = { "Content-Type": "application/json" };
-    const first = await createTerminalSession(fixture, headers, dir);
-    const second = await createTerminalSession(fixture, headers, dir);
+    const theater = await createTheater(fixture, dir);
+    const first = await createAgentTerminalSession(fixture, theater.id, headers);
+    const second = await createAgentTerminalSession(fixture, theater.id, headers);
+    expect(fleetAdmiralMock.agentRuntimeQueue).toEqual([]);
 
     runtime.emit({ type: "track:text", jobId: "job-a", originSessionId: first.sessionId, trackId: "t1", text: "progress" });
+    runtime.emit({ type: "track:text", jobId: "job-a2", originSessionId: first.sessionId, trackId: "t1", text: "progress" });
+    runtime.emit({ type: "track:text", jobId: "job-b", originSessionId: second.sessionId, trackId: "t1", text: "progress" });
     runtime.emit({ type: "track:text", jobId: "job-a", originSessionId: first.sessionId, trackId: "t1", text: "ignored", systemReminder: "not-final" });
     runtime.emit({ type: "job:finalized", jobId: "missing-origin", status: "done", finishedAt: 1, summary: "missing", systemReminder: "drop me" });
-    runtime.emit({ type: "job:finalized", jobId: "job-a", status: "done", finishedAt: 2, summary: "done", systemReminder: "line 1\nline 2\x1b[201~\x07" });
+    runtime.emit({ type: "job:finalized", jobId: "job-a", status: "done", finishedAt: 2, summary: "done", systemReminder: "first\x1b[201~\x07" });
+    runtime.emit({ type: "job:finalized", jobId: "job-a2", status: "done", finishedAt: 3, summary: "done", systemReminder: "second" });
+    runtime.emit({ type: "job:finalized", jobId: "job-b", status: "done", finishedAt: 4, summary: "done", systemReminder: "other" });
 
-    expect(ptys.get(first.sessionId)?.writes).toEqual(["\x1b[200~line 1\nline 2\x1b[201~\r"]);
-    expect(ptys.get(second.sessionId)?.writes).toEqual([]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(ptys.get(first.sessionId)?.writes).toEqual(["\x1b[200~first\x1b[201~"]);
+    expect(ptys.get(second.sessionId)?.writes).toEqual(["\x1b[200~other\x1b[201~"]);
 
-    runtime.emit({ type: "track:text", jobId: "job-b", originSessionId: second.sessionId, trackId: "t1", text: "progress" });
-    const deleted = await fetch(`${fixture.endpoint}terminal/sessions/${encodeURIComponent(second.sessionId)}`, { method: "DELETE" });
-    runtime.emit({ type: "job:finalized", jobId: "job-b", status: "done", finishedAt: 3, summary: "done", systemReminder: "after delete" });
-    runtime.emit({ type: "job:finalized", jobId: "job-c", originSessionId: "unknown", status: "done", finishedAt: 4, summary: "done", systemReminder: "unknown" });
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(ptys.get(first.sessionId)?.writes).toEqual(["\x1b[200~first\x1b[201~", "\r", "\x1b[200~second\x1b[201~"]);
+    expect(ptys.get(second.sessionId)?.writes).toEqual(["\x1b[200~other\x1b[201~", "\r"]);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(ptys.get(first.sessionId)?.writes).toEqual(["\x1b[200~first\x1b[201~", "\r", "\x1b[200~second\x1b[201~", "\r"]);
+
+    runtime.emit({ type: "track:text", jobId: "job-delete", originSessionId: second.sessionId, trackId: "t1", text: "progress" });
+    runtime.emit({ type: "job:finalized", jobId: "job-delete", status: "done", finishedAt: 5, summary: "done", systemReminder: "delete-before-submit" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const deleted = await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions/${encodeURIComponent(second.sessionId)}`, { method: "DELETE" });
+    runtime.emit({ type: "job:finalized", jobId: "job-after-delete", originSessionId: second.sessionId, status: "done", finishedAt: 6, summary: "done", systemReminder: "after delete" });
+    runtime.emit({ type: "job:finalized", jobId: "job-unknown", originSessionId: "unknown", status: "done", finishedAt: 7, summary: "done", systemReminder: "unknown" });
+    await new Promise((resolve) => setTimeout(resolve, 300));
 
     expect(deleted.status).toBe(200);
-    expect(ptys.get(second.sessionId)?.writes).toEqual([]);
-    expect(ptys.get(first.sessionId)?.writes).toEqual(["\x1b[200~line 1\nline 2\x1b[201~\r"]);
+    expect(ptys.get(second.sessionId)?.writes).toEqual([
+      "\x1b[200~other\x1b[201~",
+      "\r",
+      "\x1b[200~delete-before-submit\x1b[201~",
+    ]);
+    expect(ptys.get(first.sessionId)?.writes).toEqual(["\x1b[200~first\x1b[201~", "\r", "\x1b[200~second\x1b[201~", "\r"]);
   });
 
-  it.skip("keeps carrier reminder payloads out of browser snapshots and SSE frames", async () => {
+  it("keeps carrier reminder payloads out of browser snapshots and SSE frames", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-reminder-browser-"));
     tempDirs.push(dir);
     const runtime = createFakeConsoleRuntime([], []);
+    fleetAdmiralMock.agentRuntimeQueue.push(runtime);
     const secret = "server-only-system-reminder-secret";
-    const fixture = await startFixture({
-      agentRuntime: runtime as never,
+    const fixture = await startReminderFixture({
       terminalLaunch: async (cwd, context) => ({
         bin: "mock",
         args: [],
@@ -883,15 +929,19 @@ describe("console static and terminal ticket boundary", () => {
       }),
       terminalStartShell: () => createRecordingPty(),
     });
-    const session = await createTerminalSession(fixture, { "Content-Type": "application/json" }, dir);
+    expect(fleetAdmiralMock.externalizeForReminderFixture).toBe(false);
+    const headers = { "Content-Type": "application/json" };
+    const theater = await createTheater(fixture, dir);
+    const session = await createAgentTerminalSession(fixture, theater.id, headers);
+    expect(fleetAdmiralMock.agentRuntimeQueue).toEqual([]);
 
     runtime.emit({ type: "track:text", jobId: "job-secret", originSessionId: session.sessionId, trackId: "t1", text: "visible" });
     runtime.emit({ type: "job:finalized", jobId: "job-secret", status: "done", finishedAt: 1, summary: "done", systemReminder: secret });
 
-    const terminalSessions = await getJson<unknown>(`${fixture.endpoint}terminal/sessions`);
-    const observerTenants = await getJson<unknown>(`${fixture.endpoint}observer/tenants`);
-    const observerJobs = await getJson<unknown>(`${fixture.endpoint}observer/jobs`);
-    const sse = await readObserverChunk(fixture);
+    const terminalSessions = await getJson<unknown>(`${fixture.endpoint}plugins/terminal/agent/sessions`);
+    const observerTenants = await getJson<unknown>(`${fixture.endpoint}plugins/terminal/agent/tenants`);
+    const observerJobs = await getJson<unknown>(`${fixture.endpoint}plugins/terminal/agent/jobs`);
+    const sse = await readObserverChunk(fixture, "plugins/terminal/agent/events");
     const serialized = JSON.stringify({ terminalSessions, observerTenants, observerJobs, sse });
 
     expect(serialized).not.toContain("systemReminder");
@@ -2602,6 +2652,15 @@ describe("observer theater order", () => {
   });
 });
 
+async function startReminderFixture(options: Parameters<typeof startFixture>[0] = {}): Promise<ServerFixture> {
+  fleetAdmiralMock.externalizeForReminderFixture = true;
+  try {
+    return await startFixture(options);
+  } finally {
+    fleetAdmiralMock.externalizeForReminderFixture = false;
+  }
+}
+
 async function startFixture(options: {
   readonly agentRuntime?: ConsoleServerDeps["agentRuntime"];
   readonly agentCliDetector?: ConsoleServerDeps["agentCliDetector"];
@@ -2692,6 +2751,16 @@ async function createTerminalSession(fixture: ServerFixture, headers: Record<str
     method: "POST",
     headers,
     body: JSON.stringify({ folderGrantId: grant.folderGrantId, cliId: "claude" }),
+  });
+  expect(created.status).toBe(200);
+  return created.json() as Promise<{ readonly sessionId: string }>;
+}
+
+async function createAgentTerminalSession(fixture: ServerFixture, theaterId: string, headers: Record<string, string>): Promise<{ readonly sessionId: string }> {
+  const created = await fetch(`${fixture.endpoint}plugins/terminal/agent/sessions`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ theaterId, cliId: "claude" }),
   });
   expect(created.status).toBe(200);
   return created.json() as Promise<{ readonly sessionId: string }>;
@@ -2812,9 +2881,9 @@ async function getJson<T>(url: string): Promise<T> {
   return response.json() as Promise<T>;
 }
 
-async function readObserverChunk(fixture: ServerFixture): Promise<string> {
+async function readObserverChunk(fixture: ServerFixture, pathname = "observer/events"): Promise<string> {
   const controller = new AbortController();
-  const response = await fetch(`${fixture.endpoint}observer/events`, { signal: controller.signal });
+  const response = await fetch(`${fixture.endpoint}${pathname}`, { signal: controller.signal });
   const chunk = new TextDecoder().decode((await response.body!.getReader().read()).value);
   controller.abort();
   return chunk;

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -42,6 +42,7 @@ interface AgentRouteDeps {
 }
 
 const AGENT_OPERATION_TYPE = "agent";
+const CONSOLE_PTY_MESSAGE_DELIVERY = { submitDelayMs: 250 } as const;
 const OPERATION_RENAMED_EVENT_CHANNEL = "operation:renamed";
 const TERMINAL_PLUGIN_ID = "terminal";
 
@@ -120,6 +121,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
   const unsubscribeReminder = createCarrierResultReminderRouter({
     streamRegister: runtime.carrierRuntime.jobs.streaming.register,
     writer: reminderWriter,
+    delivery: CONSOLE_PTY_MESSAGE_DELIVERY,
     resolveSink: (event) => {
       const sessionId = resolveCarrierEventOrigin(event as { readonly jobId: string; readonly type: string; readonly originSessionId?: string }, jobOriginById);
       return sessionId ? { write: (data) => terminalRuntime.write(sessionId, data) } : undefined;
@@ -478,6 +480,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
   }
 
   async function handleExit(operationId: string): Promise<void> {
+    reminderWriter.cancel(operationId);
     pendingRuntimeSessions.delete(operationId);
     const providerSession = readProviderSessionCapture(operationId, { capturesDir: ctx.host.paths.capturesDir }) ?? readProviderSession(ctx.host.operations.get(operationId)?.payload);
     if (providerSession) {
@@ -495,6 +498,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
   }
 
   function removeSession(sessionId: string): void {
+    reminderWriter.cancel(sessionId);
     terminalRuntime.terminate(sessionId);
     pendingRuntimeSessions.delete(sessionId);
     observability.removeTerminalSession(sessionId);
@@ -503,6 +507,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
   }
 
   async function cleanup(): Promise<void> {
+    reminderWriter.cancelAll();
     unsubscribeRename();
     unsubscribeReminder();
     unsubscribeStream();
@@ -560,7 +565,11 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     if (safeLabel.length === 0) return;
     const policy = terminalRuntime.getMessagePolicy(sessionId) ?? {};
     // 리마인더와 동일한 세션 키/writer로 직렬화해 rename+리마인더 인터리브를 막는다.
-    reminderWriter.enqueue(sessionId, (data) => terminalRuntime.write(sessionId, data), formatCarrierResultReminderMessage(policy, `${renameCommand} ${safeLabel}`));
+    reminderWriter.enqueue(
+      sessionId,
+      (data) => terminalRuntime.write(sessionId, data),
+      formatCarrierResultReminderMessage(policy, `${renameCommand} ${safeLabel}`, process.platform, CONSOLE_PTY_MESSAGE_DELIVERY),
+    );
   }
 
   function injectOperation(operation: OperationNode): AgentTerminalSessionInfo {


### PR DESCRIPTION
## Summary
- Split Console carrier-completion reminder payloads from delayed submit input and serialize delivery per terminal session.
- Cancel queued submits on PTY write failure, session exit or deletion, and plugin cleanup.
- Restore production-route coverage for concurrent completions and reminder redaction without changing fleet-cli or adding submit hooks.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-admiral exec vitest run tests/reminder-router.test.ts` — 19 passed
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/server.test.ts -t "carrier reminder|cleans stale plugin bundles"` — 3 passed
- [x] `pnpm --filter @dotobokuri/fleet-cli exec vitest run tests/carrier-reminder-parity.test.ts` — 6 passed
- [x] Admiral, Terminal, and Console typecheck/build
- [x] Sentinel review and follow-up re-review — no findings
- [x] Attempted the full Console server suite — 60 passed, 19 skipped, and one pre-existing `issues Theater-bound dedicated MCP sessions...` failure reproduced unchanged on canary

## Changelog
- [x] Added `.changelog.d/pr-353.md`
- [x] Grouped product syntax and adjacent bilingual summaries validated
- [x] `node scripts/compile-changelog-fragments.mjs --check`
