### PR TITLE
feat(console): replace native selects with shared SDK Select listbox

### DIFF
--- a/.changelog.d/pr-354.md
+++ b/.changelog.d/pr-354.md
@@ -1,0 +1,9 @@
+### fleet-console
+#### Added
+- [fleet-console] Add shared Select and useSelect listbox primitives to the SDK react browser surface with token-styled themed popups.
+  ko: SDK react 브라우저 표면에 토큰 스타일 테마 팝업을 갖춘 공용 Select와 useSelect 리스트박스 프리미티브를 추가합니다.
+#### Changed
+- [fleet-console] Replace all native <select> dropdowns across Console settings, What's New, and Cowork with the shared themed Select for readable dark-theme popups.
+  ko: Console 설정, What's New, Cowork의 네이티브 <select> 드롭다운을 공용 테마 Select로 교체하여 다크 테마 팝업 가독성을 개선합니다.
+- [fleet-console] Replace native <select> dropdowns in Terminal carrier, model, effort, and Task Force settings, the Session Analyst composer, and Repository compare and depth controls with the shared themed Select.
+  ko: Terminal 캐리어, 모델, effort, Task Force 설정과 Session Analyst 컴포저, Repository 비교 및 depth 컨트롤의 네이티브 <select>를 공용 테마 Select로 교체합니다.

--- a/.changelog.d/pr-354.md
+++ b/.changelog.d/pr-354.md
@@ -5,5 +5,5 @@
 #### Changed
 - [fleet-console] Replace all native <select> dropdowns across Console settings, What's New, and Cowork with the shared themed Select for readable dark-theme popups.
   ko: Console 설정, What's New, Cowork의 네이티브 <select> 드롭다운을 공용 테마 Select로 교체하여 다크 테마 팝업 가독성을 개선합니다.
-- [fleet-console] Replace native <select> dropdowns in Terminal carrier, model, effort, and Task Force settings, the Session Analyst composer, and Repository compare and depth controls with the shared themed Select.
-  ko: Terminal 캐리어, 모델, effort, Task Force 설정과 Session Analyst 컴포저, Repository 비교 및 depth 컨트롤의 네이티브 <select>를 공용 테마 Select로 교체합니다.
+- [fleet-console] Replace native <select> dropdowns in Terminal carrier, model, effort, and Task Force settings, the Session Analyst composer, and Repository compare controls with the shared themed Select.
+  ko: Terminal 캐리어, 모델, effort, Task Force 설정과 Session Analyst 컴포저, Repository 비교 컨트롤의 네이티브 <select>를 공용 테마 Select로 교체합니다.

--- a/examples/plugins/notes/README.md
+++ b/examples/plugins/notes/README.md
@@ -9,3 +9,29 @@ Sample external Fleet Console client plugin.
 External plugins run in the host Node process and share the browser origin; see `runtime/fleet-console/AGENTS.md` for the trust model and safety guards.
 
 To test the external discovery path, copy this directory to `~/.fleet/plugins/notes` in an isolated HOME and restart the console.
+
+## Using `Select`
+
+`@fleet-console/sdk/react/browser` exports a controlled `Select` component and a `useSelect` hook:
+
+```tsx
+import { Select, type SelectOption } from "@fleet-console/sdk/react/browser";
+
+const VIEW_OPTIONS: SelectOption[] = [
+  { value: "list",  label: "List"  },
+  { value: "grid",  label: "Grid"  },
+  { value: "table", label: "Table", disabled: true },
+];
+
+function ViewToggle() {
+  const [view, setView] = React.useState("list");
+  return <Select value={view} options={VIEW_OPTIONS} onChange={setView} label="View" />;
+}
+```
+
+**Ownership:** The plugin owns `value`, `options`, and `onChange`. Selection state, persistence, and any domain-specific value translation belong to the plugin; the component only renders.
+
+- **Disabled options** — set `disabled: true` on a `SelectOption` to make that entry unselectable without removing it from the list.
+- **Compact variant** — pass `compact` to render a narrower trigger and a right-aligned popup suited to toolbars or inline controls.
+- **CSS** — do not import `.fc-select*` styles. They are host-owned and applied automatically through the Console runtime; importing them separately will produce duplicate and possibly conflicting rules.
+- **`useSelect`** — the documented escape hatch for bespoke shells that need listbox behavior without the default `<Select>` markup. Use `Select` by default; reach for `useSelect` only when the standard markup cannot accommodate your shell structure. Available types: `UseSelectOptions`, `UseSelectResult`.

--- a/runtime/fleet-console/core/client/src/codex/cowork-controller.ts
+++ b/runtime/fleet-console/core/client/src/codex/cowork-controller.ts
@@ -1,4 +1,6 @@
 import { renderMarkdown } from "@fleet-console/markdown/core";
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import {
   applyCowork, cancelCowork, closeCowork, CoworkRequestError, createCoworkSession,
   fetchCoworkOptions, peekCoworkEntrySession, promptCowork, subscribeCoworkEvents,
@@ -7,6 +9,7 @@ import {
 import type { CoworkAnnotationDto, CoworkOptionsResponse, CoworkSessionDto } from "./api.js";
 import { diffDraftBlocks, diffDraftLines } from "./cowork-diff.js";
 import type { DraftLine } from "./cowork-diff.js";
+import { CoworkSettingsSelect } from "./cowork-settings-select.js";
 import { entryPath } from "./router.js";
 import { escapeAttribute, escapeHtml } from "./utils/html.js";
 
@@ -69,6 +72,7 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
   let lastBodyKey = "published";
   let lastDockHtml: string | null = null;
   let diffMemo: { base: string; draft: string; lines: readonly DraftLine[] } | null = null;
+  let settingsSelectRoot: Root | null = null;
 
   // SSE 이벤트마다 LCS를 다시 돌리지 않도록 draft 쌍 기준으로 메모한다.
   const draftLines = (): readonly DraftLine[] => {
@@ -89,6 +93,51 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
   tip.hidden = true;
   options.article.classList.add("cowork-host");
   options.article.append(anchor, dockZone, tip);
+
+  const unmountSettingsSelect = () => {
+    settingsSelectRoot?.unmount();
+    settingsSelectRoot = null;
+  };
+
+  const mountSettingsSelectIfNeeded = () => {
+    if (!configOpen || disposed) return;
+    const host = dockZone.querySelector<HTMLElement>("[data-cowork-settings-host]");
+    if (!host) return;
+    if (!settingsSelectRoot) settingsSelectRoot = createRoot(host);
+    settingsSelectRoot.render(createElement(CoworkSettingsSelect, {
+      clis: optionsDto.clis,
+      models: optionsDto.models,
+      efforts: optionsDto.efforts,
+      cli: settings.cli,
+      model: settings.model,
+      effort: settings.effort,
+      onCliChange: (value) => handleSettingChange("cli", value),
+      onModelChange: (value) => handleSettingChange("model", value),
+      onEffortChange: (value) => handleSettingChange("effort", value),
+    }));
+  };
+
+  const handleSettingChange = (name: "cli" | "model" | "effort", value: string) => {
+    settings = name === "cli"
+      ? { cli: value, model: "", effort: "" }
+      : { ...settings, [name]: value };
+    saveSettings(settings);
+    if (!session) {
+      if (name !== "effort") void updateOptions().then(() => { renderDock(); }).catch(() => undefined);
+      else mountSettingsSelectIfNeeded();
+      return;
+    }
+    if (name !== "effort") {
+      void updateOptions()
+        .then(() => mutate(() => updateCoworkSettings(options.theaterId, session!.id, settings)))
+        .then(renderDock)
+        .catch((cause) => { error = cause instanceof Error ? cause.message : "Cowork request failed."; renderDock(); });
+    } else {
+      void mutate(() => updateCoworkSettings(options.theaterId, session!.id, settings))
+        .then(renderDock)
+        .catch(() => undefined);
+    }
+  };
 
   // ── 렌더 ────────────────────────────────────────────────────────────────────
 
@@ -152,6 +201,7 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
           : '<button type="button" class="cowork-send" data-cowork-action="send" aria-label="Send to AI">↑</button>'}
       </div>
       ${error ? `<p class="cowork-error" role="alert">${escapeHtml(error)}</p>` : ""}`);
+    mountSettingsSelectIfNeeded();
   };
 
   const renderRevisionStream = (running: boolean): string => {
@@ -210,6 +260,7 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
   // 실제 변경이 있을 때만 교체하고 포커스 중이던 입력은 복원한다.
   const setDockHtml = (html: string) => {
     if (html === lastDockHtml) return;
+    unmountSettingsSelect();
     lastDockHtml = html;
     const active = document.activeElement;
     const focusKey = active instanceof HTMLInputElement && active.name === "prompt" && dockZone.contains(active)
@@ -241,7 +292,7 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
 
   const renderConfig = () => `
     <div class="cowork-popover cowork-config" role="region" aria-label="Agent settings">
-      ${select("CLI", "cli", optionsDto.clis, settings.cli)}${select("Model", "model", optionsDto.models, settings.model)}${select("Effort", "effort", optionsDto.efforts, settings.effort)}
+      <div data-cowork-settings-host></div>
     </div>`;
 
   const renderReview = (changed: number) => {
@@ -667,25 +718,6 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
       event.stopPropagation();
       return;
     }
-    if (target instanceof HTMLSelectElement && ["cli", "model", "effort"].includes(target.name)) {
-      // CLI가 바뀌면 이전 CLI의 model/effort는 무효 — 리셋해야 새 CLI의 기본 목록을 받는다.
-      settings = target.name === "cli"
-        ? { cli: target.value, model: "", effort: "" }
-        : { ...settings, [target.name]: target.value };
-      saveSettings(settings);
-      if (!session) {
-        // 세션 전(dormant)에도 새 CLI의 목록은 즉시 갱신해 보여준다.
-        if (target.name !== "effort") void updateOptions().then(renderDock).catch(() => undefined);
-        return;
-      }
-      if (target.name !== "effort") {
-        void updateOptions()
-          .then(() => mutate(() => updateCoworkSettings(options.theaterId, session!.id, settings)))
-          .then(renderDock)
-          .catch(cause => { error = cause instanceof Error ? cause.message : "Cowork request failed."; renderDock(); });
-      } else void mutate(() => updateCoworkSettings(options.theaterId, session!.id, settings)).catch(() => undefined);
-      return;
-    }
     if (target instanceof HTMLTextAreaElement && target.dataset.coworkComment) void persistAnnotations().catch(() => undefined);
   };
 
@@ -702,6 +734,7 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
     destroy() {
       disposed = true;
       cancelRevisionRender();
+      unmountSettingsSelect();
       unsubscribe?.();
       options.article.removeEventListener("mouseup", onMouseUp);
       options.article.removeEventListener("mousedown", onMouseDown);
@@ -722,9 +755,6 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function select(label: string, name: string, values: readonly string[], current: string): string {
-  return `<label class="cowork-selector"><span>${label}</span><select name="${name}" ${values.length ? "" : "disabled"}>${values.map(value => `<option value="${escapeAttribute(value)}" ${value === current ? "selected" : ""}>${escapeHtml(value)}</option>`).join("")}</select></label>`;
-}
 function copyCodeToClipboard(button: HTMLElement, code: string): void {
   const clipboard = navigator.clipboard;
   if (!clipboard) return;

--- a/runtime/fleet-console/core/client/src/codex/cowork-settings-select.tsx
+++ b/runtime/fleet-console/core/client/src/codex/cowork-settings-select.tsx
@@ -1,0 +1,46 @@
+import { Select } from "@fleet-console/sdk/react/browser";
+
+export interface CoworkSettingsSelectProps {
+  readonly clis: readonly string[];
+  readonly models: readonly string[];
+  readonly efforts: readonly string[];
+  readonly cli: string;
+  readonly model: string;
+  readonly effort: string;
+  readonly onCliChange: (value: string) => void;
+  readonly onModelChange: (value: string) => void;
+  readonly onEffortChange: (value: string) => void;
+}
+
+function toOptions(values: readonly string[]) {
+  return values.map((value) => ({ value, label: value }));
+}
+
+export function CoworkSettingsSelect({
+  clis,
+  models,
+  efforts,
+  cli,
+  model,
+  effort,
+  onCliChange,
+  onModelChange,
+  onEffortChange,
+}: CoworkSettingsSelectProps) {
+  return (
+    <>
+      <div className="cowork-selector">
+        <span>CLI</span>
+        <Select label="CLI" value={cli} options={toOptions(clis)} onChange={onCliChange} disabled={!clis.length} compact />
+      </div>
+      <div className="cowork-selector">
+        <span>Model</span>
+        <Select label="Model" value={model} options={toOptions(models)} onChange={onModelChange} disabled={!models.length} compact />
+      </div>
+      <div className="cowork-selector">
+        <span>Effort</span>
+        <Select label="Effort" value={effort} options={toOptions(efforts)} onChange={onEffortChange} disabled={!efforts.length} compact />
+      </div>
+    </>
+  );
+}

--- a/runtime/fleet-console/core/client/src/codex/styles/components.css
+++ b/runtime/fleet-console/core/client/src/codex/styles/components.css
@@ -2353,7 +2353,7 @@ kbd {
 .cowork-x { border: 0; background: transparent; color: var(--ink-fog); cursor: pointer; font-size: var(--font-size-lg); line-height: 1; padding: 0 var(--space-1); }
 .cowork-x:hover { color: var(--ink-pearl); }
 .cowork-pill:focus-visible, .cowork-ghost:focus-visible, .cowork-solid:focus-visible, .cowork-x:focus-visible, .cowork-chip:focus-visible, .cowork-send:focus-visible,
-.cowork-dock-input:focus-visible, .cowork-composer textarea:focus-visible, .cowork-card textarea:focus-visible, .cowork-selector select:focus-visible {
+.cowork-dock-input:focus-visible, .cowork-composer textarea:focus-visible, .cowork-card textarea:focus-visible {
   outline: 2px solid var(--brass-bright);
   outline-offset: 2px;
 }
@@ -2661,15 +2661,6 @@ kbd {
 .cowork-config { display: flex; flex-wrap: wrap; gap: var(--space-2); width: auto; }
 .cowork-selector { display: grid; gap: var(--space-1); min-inline-size: 120px; }
 .cowork-selector span { color: var(--ink-fog); font-size: var(--font-size-2xs); font-weight: 600; }
-.cowork-selector select {
-  border: 1px solid var(--surface-rim);
-  border-radius: var(--radius-md);
-  background: color-mix(in oklch, var(--ink-abyss) 82%, transparent);
-  color: var(--ink-pearl);
-  font: inherit;
-  font-size: var(--font-size-sm);
-  padding: var(--space-1) var(--space-2);
-}
 
 /* AI 요약 카드 */
 .cowork-summary {

--- a/runtime/fleet-console/core/client/src/components/whatsnew-modal.tsx
+++ b/runtime/fleet-console/core/client/src/components/whatsnew-modal.tsx
@@ -81,6 +81,7 @@ export function WhatsNewModal({ state }: WhatsNewModalProps) {
   useEffect(() => {
     if (!state.whatsNewOpen || whatsNewSuppressed) return;
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (isSelectOwnedKeyEvent(event)) return;
       if (event.key === "Escape") {
         event.preventDefault();
         closeWhatsNew();
@@ -272,6 +273,12 @@ function ReleaseNoteItemView({ item }: { readonly item: ReleaseNoteItem }) {
 
 function releaseNoteKey(version: string, index: number): string {
   return `${version}:${index}`;
+}
+
+export function isSelectOwnedKeyEvent(event: KeyboardEvent): boolean {
+  const target = event.target instanceof Element ? event.target : null;
+  if (target?.closest(".fc-select__trigger, .fc-select__popup")) return true;
+  return document.querySelector(".fc-select__popup[data-open='true']") !== null;
 }
 
 function trapFocus(event: KeyboardEvent, container: HTMLElement | null): void {

--- a/runtime/fleet-console/core/client/src/components/whatsnew-modal.tsx
+++ b/runtime/fleet-console/core/client/src/components/whatsnew-modal.tsx
@@ -275,10 +275,26 @@ function releaseNoteKey(version: string, index: number): string {
   return `${version}:${index}`;
 }
 
+const SELECT_CLOSED_TRIGGER_OPEN_KEYS = new Set(["ArrowDown", "ArrowUp", "Enter", " "]);
+
+function isOpenSelectPopup(popup: Element | null): popup is HTMLElement {
+  return popup instanceof HTMLElement && popup.dataset.open === "true";
+}
+
 export function isSelectOwnedKeyEvent(event: KeyboardEvent): boolean {
   const target = event.target instanceof Element ? event.target : null;
-  if (target?.closest(".fc-select__trigger, .fc-select__popup")) return true;
-  return document.querySelector(".fc-select__popup[data-open='true']") !== null;
+  if (!target) return false;
+
+  if (target.closest('.fc-select__popup[data-open="true"]')) return true;
+
+  const trigger = target.closest(".fc-select__trigger");
+  if (trigger instanceof HTMLButtonElement) {
+    const controlsId = trigger.getAttribute("aria-controls");
+    if (controlsId && isOpenSelectPopup(document.getElementById(controlsId))) return true;
+    return SELECT_CLOSED_TRIGGER_OPEN_KEYS.has(event.key);
+  }
+
+  return false;
 }
 
 function trapFocus(event: KeyboardEvent, container: HTMLElement | null): void {

--- a/runtime/fleet-console/core/client/src/components/whatsnew-modal.tsx
+++ b/runtime/fleet-console/core/client/src/components/whatsnew-modal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
+import { Select } from "@fleet-console/sdk/react/browser";
 
 import { setGlobalSettingsField, useGlobalSettingsStore } from "../global-settings-store.js";
 import { requestReleaseNotes } from "../release-notes-fetch.js";
@@ -146,16 +147,19 @@ export function WhatsNewModal({ state }: WhatsNewModalProps) {
         </button>
         <div className="whatsnew-body">
           <div className="whatsnew-version-selector">
-            <select aria-label="Release version" value={selectedValue} onChange={(event) => selectReleaseNote(event.currentTarget.value)}>
-              {pageNotes.map((note, localIndex) => {
+            <Select
+              label="Release version"
+              className="whatsnew-version-select"
+              value={selectedValue}
+              onChange={selectReleaseNote}
+              options={pageNotes.map((note, localIndex) => {
                 const index = pageStart + localIndex;
-                return (
-                  <option key={releaseNoteKey(note.version, index)} value={releaseNoteKey(note.version, index)}>
-                    {note.version === "Unreleased" ? "Unreleased" : `v${note.version}`}{note.date ? ` · ${note.date}` : ""}
-                  </option>
-                );
+                return {
+                  value: releaseNoteKey(note.version, index),
+                  label: `${note.version === "Unreleased" ? "Unreleased" : `v${note.version}`}${note.date ? ` · ${note.date}` : ""}`,
+                };
               })}
-            </select>
+            />
             {pageCount > 1 ? (
               <div className="whatsnew-pagination">
                 <button type="button" className="whatsnew-page-button" onClick={() => goToReleasePage(-1)} disabled={currentPage === 0} aria-label="Newer versions">

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7609,7 +7609,6 @@ body[data-codex-side="true"] .command-card {
 }
 
 .fc-settings-toggle:focus-within .fc-settings-toggle__control,
-.fc-settings-select__control:focus,
 .fc-settings-field__control:focus {
   outline: 2px solid color-mix(in oklch, var(--brass) 70%, transparent);
   outline-offset: 2px;
@@ -7621,7 +7620,6 @@ body[data-codex-side="true"] .command-card {
   gap: var(--space-2);
 }
 
-.fc-settings-select__control,
 .fc-settings-field__control {
   width: 100%;
   min-height: 38px;
@@ -7631,13 +7629,6 @@ body[data-codex-side="true"] .command-card {
   color: var(--ink-pearl);
   font: inherit;
   letter-spacing: 0;
-}
-
-.fc-settings-select__control {
-  padding: 0 34px 0 12px;
-}
-
-.fc-settings-field__control {
   padding: 8px 12px;
 }
 

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -8237,3 +8237,73 @@ body[data-codex-reading="true"] .operations-side-bar {
 .page-back-link:focus-visible {
   color: var(--brass);
 }
+
+/* ── Shared SDK Select listbox grammar (Option B1) ─────────────────────────── */
+
+:root {
+  --z-select-popover: 40;
+}
+
+.fc-select {
+  position: relative; display: inline-block; min-width: 220px; text-align: left;
+}
+.fc-select__trigger {
+  width: 100%; min-height: 42px; display: flex; align-items: center; justify-content: space-between; gap: var(--space-2);
+  border: 1px solid var(--surface-rim); border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--ink-mid) 48%, transparent);
+  color: var(--ink-pearl); font: 600 13px/1.2 var(--font-body); padding: 0 13px; cursor: pointer;
+  box-shadow: inset 0 1px 0 color-mix(in oklch, var(--ink-pearl) 5%, transparent);
+  transition: border-color var(--duration-fast) var(--ease-glide);
+}
+.fc-select__trigger:hover { border-color: var(--surface-rim-strong); }
+.fc-select__trigger:focus-visible { outline: none; border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim)); }
+.fc-select__trigger[aria-expanded="true"] { border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim)); }
+.fc-select__trigger:disabled { opacity: 0.45; cursor: default; }
+.fc-select__caret { color: var(--text-tertiary); font-size: 11px; transition: transform var(--duration-fast) var(--ease-glide); }
+.fc-select__trigger[aria-expanded="true"] .fc-select__caret { transform: rotate(180deg); }
+.fc-select__popup {
+  position: absolute; z-index: var(--z-select-popover); inset-inline: 0; top: calc(100% + 6px);
+  margin: 0; padding: var(--space-1); list-style: none;
+  background: color-mix(in oklch, var(--ink-deep) 94%, transparent);
+  border: 1px solid var(--hairline); border-radius: var(--radius-md);
+  box-shadow: var(--shadow-floating);
+  max-height: 232px; overflow-y: auto;
+  opacity: 0; transform: translateY(-4px); pointer-events: none;
+  transition: opacity var(--duration-fast) var(--ease-glide), transform var(--duration-fast) var(--ease-glide);
+}
+.fc-select__popup[data-placement="up"] { top: auto; bottom: calc(100% + 6px); transform: translateY(4px); }
+.fc-select__popup[data-open="true"] { opacity: 1; transform: translateY(0); pointer-events: auto; }
+.fc-select__option {
+  display: flex; align-items: center; justify-content: space-between; gap: var(--space-2);
+  padding: 8px 10px; border-radius: var(--radius-xs);
+  color: var(--text-secondary); font: 500 13px/1.3 var(--font-body); cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide);
+}
+.fc-select__option[data-active="true"] { background: color-mix(in oklch, var(--brass) 12%, transparent); color: var(--text-primary); }
+.fc-select__option[aria-selected="true"] { color: var(--brass-bright); }
+.fc-select__option[aria-selected="true"]::after { content: "✓"; font-size: 11px; color: var(--brass-bright); }
+.fc-select__option[aria-disabled="true"] { color: var(--text-tertiary); cursor: default; font-style: italic; }
+.fc-select__option[aria-disabled="true"][data-active="true"] { background: transparent; color: var(--text-tertiary); }
+
+.fc-select--compact { min-width: 0; }
+.fc-select--compact .fc-select__trigger {
+  min-height: 0; border: 0; box-shadow: none; background: transparent;
+  font: 9px/1 var(--font-mono); color: var(--text-secondary); padding: 8px 16px 8px 10px;
+}
+.fc-select--compact .fc-select__popup { min-width: 160px; inset-inline: auto 0; }
+
+.reduce-panel-motion .fc-select__trigger,
+.reduce-panel-motion .fc-select__caret,
+.reduce-panel-motion .fc-select__popup,
+.reduce-panel-motion .fc-select__option {
+  transition: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fc-select__trigger,
+  .fc-select__caret,
+  .fc-select__popup,
+  .fc-select__option {
+    transition: none;
+  }
+}

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -8279,7 +8279,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   min-height: 0; border: 0; box-shadow: none; background: transparent;
   font: 9px/1 var(--font-mono); color: var(--text-secondary); padding: 8px 16px 8px 10px;
 }
-.fc-select--compact .fc-select__popup { min-width: 160px; inset-inline: auto 0; }
+.fc-select__popup--compact { min-width: 160px; }
 
 .reduce-panel-motion .fc-select__trigger,
 .reduce-panel-motion .fc-select__caret,

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7170,7 +7170,6 @@ body[data-codex-side="true"] .command-card {
   align-items: center;
 }
 
-.whatsnew-version-selector select,
 .whatsnew-refresh {
   min-height: 34px;
   border: 1px solid var(--surface-rim);
@@ -7223,9 +7222,8 @@ body[data-codex-side="true"] .command-card {
   font-size: var(--font-size-label-sm);
 }
 
-.whatsnew-version-selector select {
+.whatsnew-version-select {
   min-width: min(260px, 100%);
-  padding: 0 10px;
 }
 
 .whatsnew-refresh {

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -8279,7 +8279,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   min-height: 0; border: 0; box-shadow: none; background: transparent;
   font: 9px/1 var(--font-mono); color: var(--text-secondary); padding: 8px 16px 8px 10px;
 }
-.fc-select__popup--compact { min-width: 160px; }
+.fc-select__popup--compact { min-width: min(160px, calc(100vw - 16px)); }
 
 .reduce-panel-motion .fc-select__trigger,
 .reduce-panel-motion .fc-select__caret,

--- a/runtime/fleet-console/sdk/AGENTS.md
+++ b/runtime/fleet-console/sdk/AGENTS.md
@@ -10,6 +10,7 @@
 | `settings/`, `notifications/` | Configuration and notification capabilities |
 | `routing/`, `rail/` | Route and host-panel integration contracts |
 | `react/` | Stateless React authoring helpers |
+| `components/` | Shared browser UI primitives (controlled, host-styled) |
 
 ## Constraints
 

--- a/runtime/fleet-console/sdk/components/select.tsx
+++ b/runtime/fleet-console/sdk/components/select.tsx
@@ -13,10 +13,12 @@ export interface UseSelectOptions {
   readonly onChange: (next: string) => void;
   readonly disabled?: boolean;
   readonly id?: string;
+  readonly compact?: boolean;
 }
 
 export interface UseSelectResult {
   readonly isOpen: boolean;
+  readonly activeOptionId: string | undefined;
   readonly placement: "up" | "down";
   readonly rootRef: React.RefObject<HTMLDivElement | null>;
   readonly triggerRef: React.RefObject<HTMLButtonElement | null>;
@@ -50,6 +52,7 @@ export interface SelectProps extends UseSelectOptions {
 
 const POPUP_OFFSET_PX = 6;
 const POPUP_MAX_HEIGHT_PX = 232;
+const COMPACT_POPUP_MIN_WIDTH_PX = 160;
 const TYPEAHEAD_MS = 500;
 
 function enabledIndices(options: readonly SelectOption[]): readonly number[] {
@@ -60,13 +63,15 @@ function enabledIndices(options: readonly SelectOption[]): readonly number[] {
   return indices;
 }
 
-function computePopupStyle(trigger: DOMRect, placement: "up" | "down"): React.CSSProperties {
+function computePopupStyle(trigger: DOMRect, placement: "up" | "down", compact: boolean): React.CSSProperties {
+  const width = compact ? Math.max(COMPACT_POPUP_MIN_WIDTH_PX, trigger.width) : trigger.width;
+  const left = compact ? trigger.right - width : trigger.left;
   return placement === "down"
-    ? { position: "fixed", left: trigger.left, width: trigger.width, top: trigger.bottom + POPUP_OFFSET_PX }
+    ? { position: "fixed", left, width, top: trigger.bottom + POPUP_OFFSET_PX }
     : {
         position: "fixed",
-        left: trigger.left,
-        width: trigger.width,
+        left,
+        width,
         bottom: window.innerHeight - trigger.top + POPUP_OFFSET_PX,
       };
 }
@@ -88,6 +93,7 @@ export function useSelect({
   onChange,
   disabled = false,
   id,
+  compact = false,
 }: UseSelectOptions): UseSelectResult {
   const reactId = React.useId();
   const listboxId = id ?? `fc-select-${reactId.replace(/:/g, "")}`;
@@ -138,8 +144,8 @@ export function useSelect({
     const rect = trigger.getBoundingClientRect();
     const nextPlacement = resolvePlacement(rect);
     setPlacement(nextPlacement);
-    setPopupStyle(computePopupStyle(rect, nextPlacement));
-  }, []);
+    setPopupStyle(computePopupStyle(rect, nextPlacement, compact));
+  }, [compact]);
 
   const open = React.useCallback(
     (focusSelected = true) => {
@@ -254,6 +260,16 @@ export function useSelect({
 
   React.useEffect(() => () => clearTypeahead(), [clearTypeahead]);
 
+  React.useEffect(() => {
+    if (!isOpen || activeIndex < 0) return;
+    const optionId = optionIds[activeIndex];
+    if (!optionId) return;
+    const element = document.getElementById(optionId);
+    element?.scrollIntoView?.({ block: "nearest" });
+  }, [activeIndex, isOpen, optionIds]);
+
+  const activeOptionId = isOpen && activeIndex >= 0 ? optionIds[activeIndex] : undefined;
+
   const onTriggerKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLButtonElement>) => {
       if (isOpen) return;
@@ -292,6 +308,7 @@ export function useSelect({
 
   return {
     isOpen,
+    activeOptionId,
     placement,
     rootRef,
     triggerRef,
@@ -304,11 +321,13 @@ export function useSelect({
     triggerProps: {
       ref: triggerRef,
       type: "button",
+      role: "combobox",
       className: "fc-select__trigger",
       disabled,
       "aria-haspopup": "listbox",
       "aria-expanded": isOpen,
       "aria-controls": listboxId,
+      "aria-activedescendant": activeOptionId,
       onClick: onTriggerClick,
       onKeyDown: onTriggerKeyDown,
     },
@@ -316,11 +335,9 @@ export function useSelect({
       ref: popupRef,
       id: listboxId,
       role: "listbox",
-      tabIndex: -1,
-      className: "fc-select__popup",
+      className: compact ? "fc-select__popup fc-select__popup--compact" : "fc-select__popup",
       "data-open": isOpen ? "true" : "false",
       "data-placement": placement,
-      "aria-activedescendant": activeIndex >= 0 ? optionIds[activeIndex] : undefined,
       style: popupStyle,
     },
     getOptionProps,
@@ -338,7 +355,7 @@ export function Select({
   label,
   "aria-labelledby": ariaLabelledBy,
 }: SelectProps): React.ReactElement {
-  const select = useSelect({ value, options, onChange, disabled, id });
+  const select = useSelect({ value, options, onChange, disabled, id, compact });
   const selected = options.find((option) => option.value === value);
   const rootClassName = [
     select.rootProps.className,
@@ -348,28 +365,23 @@ export function Select({
     .filter(Boolean)
     .join(" ");
 
-  const trigger = (
-    <button
-      {...select.triggerProps}
-      aria-label={label && !ariaLabelledBy ? label : undefined}
-    >
-      <span className="fc-select__value">{selected?.label ?? ""}</span>
-      <span className="fc-select__caret" aria-hidden="true">
-        ⌄
-      </span>
-    </button>
-  );
+  const sharedLabelProps = ariaLabelledBy
+    ? { "aria-labelledby": ariaLabelledBy }
+    : label
+      ? { "aria-label": label }
+      : {};
 
   return (
-    <div
-      ref={select.rootRef}
-      className={rootClassName}
-      aria-labelledby={ariaLabelledBy}
-    >
-      {trigger}
+    <div ref={select.rootRef} className={rootClassName}>
+      <button {...select.triggerProps} {...sharedLabelProps}>
+        <span className="fc-select__value">{selected?.label ?? ""}</span>
+        <span className="fc-select__caret" aria-hidden="true">
+          ⌄
+        </span>
+      </button>
       {select.isOpen
         ? createPortal(
-            <ul {...select.listboxProps}>
+            <ul {...select.listboxProps} {...sharedLabelProps}>
               {options.map((option, index) => (
                 <li key={option.value} {...select.getOptionProps(index)}>
                   {option.label}

--- a/runtime/fleet-console/sdk/components/select.tsx
+++ b/runtime/fleet-console/sdk/components/select.tsx
@@ -1,0 +1,384 @@
+import * as React from "react";
+import { createPortal } from "react-dom";
+
+export interface SelectOption {
+  readonly value: string;
+  readonly label: string;
+  readonly disabled?: boolean;
+}
+
+export interface UseSelectOptions {
+  readonly value: string;
+  readonly options: readonly SelectOption[];
+  readonly onChange: (next: string) => void;
+  readonly disabled?: boolean;
+  readonly id?: string;
+}
+
+export interface UseSelectResult {
+  readonly isOpen: boolean;
+  readonly placement: "up" | "down";
+  readonly rootRef: React.RefObject<HTMLDivElement | null>;
+  readonly triggerRef: React.RefObject<HTMLButtonElement | null>;
+  readonly popupRef: React.RefObject<HTMLUListElement | null>;
+  readonly listboxId: string;
+  readonly rootProps: {
+    readonly ref: React.RefObject<HTMLDivElement | null>;
+    readonly className: string;
+  };
+  readonly triggerProps: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    readonly ref: React.RefObject<HTMLButtonElement | null>;
+  };
+  readonly listboxProps: React.HTMLAttributes<HTMLUListElement> & {
+    readonly ref: React.RefObject<HTMLUListElement | null>;
+    readonly style: React.CSSProperties;
+    readonly "data-open": "true" | "false";
+    readonly "data-placement": "up" | "down";
+  };
+  readonly getOptionProps: (index: number) => React.LiHTMLAttributes<HTMLLIElement> & {
+    readonly id: string;
+    readonly "data-active": "true" | "false";
+  };
+}
+
+export interface SelectProps extends UseSelectOptions {
+  readonly label?: string;
+  readonly compact?: boolean;
+  readonly className?: string;
+  readonly "aria-labelledby"?: string;
+}
+
+const POPUP_OFFSET_PX = 6;
+const POPUP_MAX_HEIGHT_PX = 232;
+const TYPEAHEAD_MS = 500;
+
+function enabledIndices(options: readonly SelectOption[]): readonly number[] {
+  const indices: number[] = [];
+  for (let index = 0; index < options.length; index += 1) {
+    if (!options[index]?.disabled) indices.push(index);
+  }
+  return indices;
+}
+
+function computePopupStyle(trigger: DOMRect, placement: "up" | "down"): React.CSSProperties {
+  return placement === "down"
+    ? { position: "fixed", left: trigger.left, width: trigger.width, top: trigger.bottom + POPUP_OFFSET_PX }
+    : {
+        position: "fixed",
+        left: trigger.left,
+        width: trigger.width,
+        bottom: window.innerHeight - trigger.top + POPUP_OFFSET_PX,
+      };
+}
+
+function resolvePlacement(trigger: DOMRect): "up" | "down" {
+  const spaceBelow = window.innerHeight - trigger.bottom - POPUP_OFFSET_PX;
+  const spaceAbove = trigger.top - POPUP_OFFSET_PX;
+  return spaceBelow < POPUP_MAX_HEIGHT_PX && spaceAbove > spaceBelow ? "up" : "down";
+}
+
+/**
+ * useSelect is the documented escape hatch for bespoke shells that need listbox
+ * behavior without the default Select markup. It holds only instance-local state —
+ * never module-scoped coordination.
+ */
+export function useSelect({
+  value,
+  options,
+  onChange,
+  disabled = false,
+  id,
+}: UseSelectOptions): UseSelectResult {
+  const reactId = React.useId();
+  const listboxId = id ?? `fc-select-${reactId.replace(/:/g, "")}`;
+  const optionIds = React.useMemo(
+    () => options.map((option, index) => `${listboxId}-option-${index}-${option.value}`),
+    [listboxId, options],
+  );
+
+  const rootRef = React.useRef<HTMLDivElement | null>(null);
+  const triggerRef = React.useRef<HTMLButtonElement | null>(null);
+  const popupRef = React.useRef<HTMLUListElement | null>(null);
+
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [activeIndex, setActiveIndex] = React.useState(-1);
+  const [placement, setPlacement] = React.useState<"up" | "down">("down");
+  const [popupStyle, setPopupStyle] = React.useState<React.CSSProperties>({});
+  const typeaheadRef = React.useRef("");
+  const typeaheadTimerRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const enabled = React.useMemo(() => enabledIndices(options), [options]);
+
+  const clearTypeahead = React.useCallback(() => {
+    typeaheadRef.current = "";
+    if (typeaheadTimerRef.current !== undefined) {
+      clearTimeout(typeaheadTimerRef.current);
+      typeaheadTimerRef.current = undefined;
+    }
+  }, []);
+
+  const close = React.useCallback(() => {
+    setIsOpen(false);
+    setActiveIndex(-1);
+    clearTypeahead();
+  }, [clearTypeahead]);
+
+  const commit = React.useCallback(
+    (nextValue: string) => {
+      onChange(nextValue);
+      close();
+      triggerRef.current?.focus();
+    },
+    [close, onChange],
+  );
+
+  const updatePopupPosition = React.useCallback(() => {
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+    const rect = trigger.getBoundingClientRect();
+    const nextPlacement = resolvePlacement(rect);
+    setPlacement(nextPlacement);
+    setPopupStyle(computePopupStyle(rect, nextPlacement));
+  }, []);
+
+  const open = React.useCallback(
+    (focusSelected = true) => {
+      if (disabled || isOpen) return;
+      setIsOpen(true);
+      const selectedIndex = options.findIndex((option) => option.value === value && !option.disabled);
+      if (focusSelected && selectedIndex >= 0) {
+        setActiveIndex(selectedIndex);
+      } else {
+        setActiveIndex(enabled[0] ?? -1);
+      }
+    },
+    [disabled, enabled, isOpen, options, value],
+  );
+
+  const move = React.useCallback(
+    (direction: 1 | -1) => {
+      if (!enabled.length) return;
+      const currentPosition = enabled.indexOf(activeIndex);
+      const base = currentPosition >= 0 ? currentPosition : direction > 0 ? -1 : 0;
+      const next = enabled[(base + direction + enabled.length) % enabled.length];
+      if (next !== undefined) setActiveIndex(next);
+    },
+    [activeIndex, enabled],
+  );
+
+  React.useLayoutEffect(() => {
+    if (!isOpen) return;
+    updatePopupPosition();
+    window.addEventListener("resize", updatePopupPosition);
+    window.addEventListener("scroll", updatePopupPosition, true);
+    return () => {
+      window.removeEventListener("resize", updatePopupPosition);
+      window.removeEventListener("scroll", updatePopupPosition, true);
+    };
+  }, [isOpen, updatePopupPosition]);
+
+  React.useEffect(() => {
+    if (!isOpen) return;
+
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (rootRef.current?.contains(target)) return;
+      if (popupRef.current?.contains(target)) return;
+      close();
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        close();
+        triggerRef.current?.focus();
+        return;
+      }
+      if (event.key === "Tab") {
+        close();
+        return;
+      }
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        move(1);
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        move(-1);
+        return;
+      }
+      if (event.key === "Home") {
+        event.preventDefault();
+        const first = enabled[0];
+        if (first !== undefined) setActiveIndex(first);
+        return;
+      }
+      if (event.key === "End") {
+        event.preventDefault();
+        const last = enabled.at(-1);
+        if (last !== undefined) setActiveIndex(last);
+        return;
+      }
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        event.stopPropagation();
+        const option = options[activeIndex];
+        if (option && !option.disabled) commit(option.value);
+        return;
+      }
+      if (event.key.length === 1 && /\S/u.test(event.key)) {
+        typeaheadRef.current += event.key.toLowerCase();
+        clearTimeout(typeaheadTimerRef.current);
+        typeaheadTimerRef.current = setTimeout(() => {
+          typeaheadRef.current = "";
+        }, TYPEAHEAD_MS);
+        const prefix = typeaheadRef.current;
+        const hit = enabled
+          .map((index) => options[index])
+          .find((option) => option?.label.toLowerCase().startsWith(prefix));
+        if (hit) {
+          const index = options.indexOf(hit);
+          if (index >= 0) setActiveIndex(index);
+        }
+      }
+    };
+
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [activeIndex, close, commit, enabled, isOpen, move, options]);
+
+  React.useEffect(() => () => clearTypeahead(), [clearTypeahead]);
+
+  const onTriggerKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (isOpen) return;
+      if (!["ArrowDown", "ArrowUp", "Enter", " "].includes(event.key)) return;
+      event.preventDefault();
+      open(event.key !== "ArrowDown");
+      if (event.key === "ArrowDown") move(1);
+    },
+    [isOpen, move, open],
+  );
+
+  const onTriggerClick = React.useCallback(() => {
+    if (disabled) return;
+    if (isOpen) close();
+    else open(true);
+  }, [close, disabled, isOpen, open]);
+
+  const getOptionProps = React.useCallback(
+    (index: number) => {
+      const option = options[index];
+      return {
+        id: optionIds[index] ?? `${listboxId}-option-${index}`,
+        role: "option" as const,
+        className: "fc-select__option",
+        "data-active": (activeIndex === index ? "true" : "false") as "true" | "false",
+        "aria-selected": option?.value === value,
+        "aria-disabled": option?.disabled ? true : undefined,
+        onPointerEnter: () => setActiveIndex(index),
+        onClick: () => {
+          if (option && !option.disabled) commit(option.value);
+        },
+      };
+    },
+    [activeIndex, commit, listboxId, optionIds, options, value],
+  );
+
+  return {
+    isOpen,
+    placement,
+    rootRef,
+    triggerRef,
+    popupRef,
+    listboxId,
+    rootProps: {
+      ref: rootRef,
+      className: "fc-select",
+    },
+    triggerProps: {
+      ref: triggerRef,
+      type: "button",
+      className: "fc-select__trigger",
+      disabled,
+      "aria-haspopup": "listbox",
+      "aria-expanded": isOpen,
+      "aria-controls": listboxId,
+      onClick: onTriggerClick,
+      onKeyDown: onTriggerKeyDown,
+    },
+    listboxProps: {
+      ref: popupRef,
+      id: listboxId,
+      role: "listbox",
+      tabIndex: -1,
+      className: "fc-select__popup",
+      "data-open": isOpen ? "true" : "false",
+      "data-placement": placement,
+      "aria-activedescendant": activeIndex >= 0 ? optionIds[activeIndex] : undefined,
+      style: popupStyle,
+    },
+    getOptionProps,
+  };
+}
+
+export function Select({
+  value,
+  options,
+  onChange,
+  disabled = false,
+  compact = false,
+  className,
+  id,
+  label,
+  "aria-labelledby": ariaLabelledBy,
+}: SelectProps): React.ReactElement {
+  const select = useSelect({ value, options, onChange, disabled, id });
+  const selected = options.find((option) => option.value === value);
+  const rootClassName = [
+    select.rootProps.className,
+    compact ? "fc-select--compact" : "",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const trigger = (
+    <button
+      {...select.triggerProps}
+      aria-label={label && !ariaLabelledBy ? label : undefined}
+    >
+      <span className="fc-select__value">{selected?.label ?? ""}</span>
+      <span className="fc-select__caret" aria-hidden="true">
+        ⌄
+      </span>
+    </button>
+  );
+
+  return (
+    <div
+      ref={select.rootRef}
+      className={rootClassName}
+      aria-labelledby={ariaLabelledBy}
+    >
+      {trigger}
+      {select.isOpen
+        ? createPortal(
+            <ul {...select.listboxProps}>
+              {options.map((option, index) => (
+                <li key={option.value} {...select.getOptionProps(index)}>
+                  {option.label}
+                </li>
+              ))}
+            </ul>,
+            document.body,
+          )
+        : null}
+    </div>
+  );
+}

--- a/runtime/fleet-console/sdk/components/select.tsx
+++ b/runtime/fleet-console/sdk/components/select.tsx
@@ -53,7 +53,12 @@ export interface SelectProps extends UseSelectOptions {
 const POPUP_OFFSET_PX = 6;
 const POPUP_MAX_HEIGHT_PX = 232;
 const COMPACT_POPUP_MIN_WIDTH_PX = 160;
+const VIEWPORT_MARGIN_PX = 8;
 const TYPEAHEAD_MS = 500;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
 
 function enabledIndices(options: readonly SelectOption[]): readonly number[] {
   const indices: number[] = [];
@@ -64,8 +69,12 @@ function enabledIndices(options: readonly SelectOption[]): readonly number[] {
 }
 
 function computePopupStyle(trigger: DOMRect, placement: "up" | "down", compact: boolean): React.CSSProperties {
-  const width = compact ? Math.max(COMPACT_POPUP_MIN_WIDTH_PX, trigger.width) : trigger.width;
-  const left = compact ? trigger.right - width : trigger.left;
+  const innerWidth = window.innerWidth;
+  const width = compact
+    ? Math.min(Math.max(COMPACT_POPUP_MIN_WIDTH_PX, trigger.width), innerWidth - VIEWPORT_MARGIN_PX * 2)
+    : Math.min(trigger.width, innerWidth - VIEWPORT_MARGIN_PX * 2);
+  const rawLeft = compact ? trigger.right - width : trigger.left;
+  const left = clamp(rawLeft, VIEWPORT_MARGIN_PX, innerWidth - width - VIEWPORT_MARGIN_PX);
   return placement === "down"
     ? { position: "fixed", left, width, top: trigger.bottom + POPUP_OFFSET_PX }
     : {

--- a/runtime/fleet-console/sdk/components/select.tsx
+++ b/runtime/fleet-console/sdk/components/select.tsx
@@ -69,19 +69,28 @@ function enabledIndices(options: readonly SelectOption[]): readonly number[] {
 }
 
 function computePopupStyle(trigger: DOMRect, placement: "up" | "down", compact: boolean): React.CSSProperties {
-  const innerWidth = window.innerWidth;
+  const margin = Math.max(0, VIEWPORT_MARGIN_PX);
+  const viewportWidth = Math.max(0, window.innerWidth);
+  const viewportHeight = Math.max(0, window.innerHeight);
+  const maxWidth = Math.max(0, viewportWidth - 2 * margin);
+  const triggerWidth = Math.max(0, trigger.width);
   const width = compact
-    ? Math.min(Math.max(COMPACT_POPUP_MIN_WIDTH_PX, trigger.width), innerWidth - VIEWPORT_MARGIN_PX * 2)
-    : Math.min(trigger.width, innerWidth - VIEWPORT_MARGIN_PX * 2);
+    ? Math.min(Math.max(COMPACT_POPUP_MIN_WIDTH_PX, triggerWidth), maxWidth)
+    : Math.min(triggerWidth, maxWidth);
   const rawLeft = compact ? trigger.right - width : trigger.left;
-  const left = clamp(rawLeft, VIEWPORT_MARGIN_PX, innerWidth - width - VIEWPORT_MARGIN_PX);
+  const left = clamp(rawLeft, margin, Math.max(margin, viewportWidth - width - margin));
   return placement === "down"
-    ? { position: "fixed", left, width, top: trigger.bottom + POPUP_OFFSET_PX }
+    ? {
+        position: "fixed",
+        left,
+        width,
+        top: Math.max(0, trigger.bottom + POPUP_OFFSET_PX),
+      }
     : {
         position: "fixed",
         left,
         width,
-        bottom: window.innerHeight - trigger.top + POPUP_OFFSET_PX,
+        bottom: Math.max(0, viewportHeight - trigger.top + POPUP_OFFSET_PX),
       };
 }
 

--- a/runtime/fleet-console/sdk/react/browser.tsx
+++ b/runtime/fleet-console/sdk/react/browser.tsx
@@ -15,6 +15,15 @@ const DEFAULT_PLUGIN_ERROR_FALLBACK = <div className="fc-plugin-error">Plugin fa
 export { React };
 export default React;
 
+export {
+  Select,
+  useSelect,
+  type SelectOption,
+  type SelectProps,
+  type UseSelectOptions,
+  type UseSelectResult,
+} from "../components/select.js";
+
 export class PluginErrorBoundary extends React.Component<PluginErrorBoundaryProps, PluginErrorBoundaryState> {
   readonly state: PluginErrorBoundaryState = { hasError: false };
 

--- a/runtime/fleet-console/sdk/settings/browser.tsx
+++ b/runtime/fleet-console/sdk/settings/browser.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { Select } from "../components/select.js";
 import type { SettingsSectionDescriptor } from "./types.js";
 
 export interface SettingsCardProps {
@@ -88,30 +89,25 @@ export function SettingsToggle({ checked, onChange, label, disabled = false }: S
 }
 
 export function SettingsSelect({ value, options, onChange, label, disabled = false }: SettingsSelectProps): React.ReactElement {
-  const id = React.useId();
-  const select = (
-    <select
-      id={id}
-      className="fc-settings-select__control"
+  const labelId = React.useId();
+  const selectOptions = options.map((option) => ({ value: option.value, label: option.label }));
+  const control = (
+    <Select
       value={value}
+      options={selectOptions}
+      onChange={onChange}
       disabled={disabled}
-      aria-label={label ? undefined : "Select setting"}
-      onChange={(event) => onChange(event.currentTarget.value)}
-    >
-      {options.map((option) => (
-        <option key={option.value} value={option.value}>
-          {option.label}
-        </option>
-      ))}
-    </select>
+      label={label ? undefined : "Select setting"}
+      aria-labelledby={label ? labelId : undefined}
+    />
   );
   return label ? (
-    <label className="fc-settings-select" htmlFor={id}>
-      <span className="fc-settings-select__label">{label}</span>
-      {select}
+    <label className="fc-settings-select">
+      <span className="fc-settings-select__label" id={labelId}>{label}</span>
+      {control}
     </label>
   ) : (
-    <div className="fc-settings-select">{select}</div>
+    <div className="fc-settings-select">{control}</div>
   );
 }
 

--- a/runtime/fleet-console/tests/codex-cowork-ui.test.ts
+++ b/runtime/fleet-console/tests/codex-cowork-ui.test.ts
@@ -325,17 +325,56 @@ describe("Cowork inline copilot", () => {
     await vi.waitFor(() => expect(article.querySelector(".cowork-chip")?.textContent).toContain("1"));
 
     article.querySelector<HTMLElement>('[data-cowork-action="toggle-config"]')?.click();
-    const cliSelect = article.querySelector<HTMLSelectElement>('select[name="cli"]')!;
-    cliSelect.value = "claude";
-    cliSelect.dispatchEvent(new Event("change", { bubbles: true }));
+    await vi.waitFor(() => expect(article.querySelectorAll(".fc-select__trigger")).toHaveLength(3));
+    const cliTrigger = article.querySelectorAll<HTMLButtonElement>(".fc-select__trigger")[0]!;
+    cliTrigger.click();
+    await vi.waitFor(() => expect(document.querySelector(".fc-select__popup")).not.toBeNull());
+    [...document.querySelectorAll<HTMLLIElement>(".fc-select__option")].find((option) => option.textContent === "claude")!.click();
 
     // 이전 CLI의 model을 들고 재조회하면 안 되고, 새 CLI의 목록으로 교체되어야 한다.
-    await vi.waitFor(() => expect(article.querySelector('select[name="model"]')?.innerHTML).toContain("opus"));
+    await vi.waitFor(() => expect(article.querySelectorAll<HTMLButtonElement>(".fc-select__trigger")[1]?.textContent).toContain("opus"));
     const claudeOptionsUrl = fetchMock.mock.calls.map(call => String(call[0])).find(url => url.includes("cli=claude"))!;
     expect(claudeOptionsUrl).not.toContain("model=");
-    expect(article.querySelector('select[name="effort"]')?.innerHTML).toContain("high");
+    expect(article.querySelectorAll<HTMLButtonElement>(".fc-select__trigger")[2]?.textContent).toContain("high");
 
     controller.destroy();
+    expect(document.querySelectorAll(".fc-select__popup")).toHaveLength(0);
+    article.remove();
+  });
+
+  it("unmounts the settings select island before dock HTML replacement and on destroy", async () => {
+    const listeners = new Map<string, EventListener>();
+    class FakeEventSource { addEventListener(type: string, listener: EventListener) { listeners.set(type, listener); } close() {} }
+    vi.stubGlobal("EventSource", FakeEventSource);
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/cowork/entries/")) return new Response(JSON.stringify({ error: "cowork_session_not_found" }), { status: 404 });
+      if (url.includes("/options")) return new Response(JSON.stringify({ clis: ["codex", "claude"], models: ["gpt"], efforts: ["medium"] }));
+      return new Response(JSON.stringify(sessionDto()));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { article, body } = host();
+
+    const controller = mountCoworkInline({ theaterId: "theater", entryId: "entry", title: "Entry", article, body, onApplied: vi.fn() });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    for (let index = 0; index < 3; index += 1) {
+      article.querySelector<HTMLElement>('[data-cowork-action="toggle-config"]')!.click();
+      await vi.waitFor(() => {
+        const open = article.querySelector(".cowork-config") !== null;
+        expect(article.querySelectorAll(".fc-select").length).toBe(open ? 3 : 0);
+        expect(article.querySelectorAll("[data-cowork-settings-host]").length).toBe(open ? 1 : 0);
+      });
+    }
+
+    expect(article.querySelectorAll(".fc-select__trigger")).toHaveLength(3);
+    article.querySelector<HTMLElement>('[data-cowork-action="toggle-panel"]')!.click();
+    await vi.waitFor(() => expect(article.querySelector(".cowork-config")).toBeNull());
+    expect(document.querySelectorAll(".fc-select__popup")).toHaveLength(0);
+
+    controller.destroy();
+    expect(article.querySelector(".cowork-dock-zone")).toBeNull();
+    expect(document.querySelectorAll(".fc-select")).toHaveLength(0);
     article.remove();
   });
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -29,7 +29,7 @@ const OWNED_SOURCES = [
 const FORBIDDEN_DECORATION = /radar-sweep|operations-radar|BACKGROUND_ANIMATION_STORAGE_KEY|PERIMETER_ANIMATION_STORAGE_KEY|Panel pulse|perimeter-orbit|notification-wake-pulse|AnchorIcon/;
 
 function source(path: string): string {
-  return fs.readFileSync(new URL(path, CLIENT_ROOT), "utf8");
+  return fs.readFileSync(new URL(path, CLIENT_ROOT), "utf8").replace(/\r\n/g, "\n");
 }
 
 function externalSource(path: URL): string {
@@ -533,5 +533,42 @@ describe("Instrument core design contract", () => {
     expect(source("styles/layout.css")).toContain("background: color-mix(in oklch, var(--ink-fog) 10%, transparent);");
     expect(commandBand).toContain('<rect x="1.75" y="3" width="12.5" height="10" rx="2.4"');
     expect(rail).toContain("width: 44px");
+  });
+
+  it("pins the shared SDK Select listbox grammar and stacking contract", () => {
+    const components = source("styles/components.css");
+    const rail = source("styles/rail.css");
+    const selectBlockStart = components.indexOf("/* ── Shared SDK Select listbox grammar");
+    expect(selectBlockStart).toBeGreaterThan(-1);
+    const selectBlock = components.slice(selectBlockStart);
+
+    expect(selectBlock).toContain("--z-select-popover: 40;");
+    expect(selectBlock).toContain(".fc-select__popup {");
+    expect(selectBlock).toContain("z-index: var(--z-select-popover);");
+    expect(selectBlock).toContain("border: 1px solid var(--surface-rim);");
+    expect(selectBlock).toContain("background: color-mix(in oklch, var(--ink-mid) 48%, transparent);");
+    expect(selectBlock).toContain("color: var(--ink-pearl);");
+    expect(selectBlock).toContain("font: 600 13px/1.2 var(--font-body);");
+    expect(selectBlock).toContain("padding: 0 13px;");
+    expect(selectBlock).toContain("box-shadow: inset 0 1px 0 color-mix(in oklch, var(--ink-pearl) 5%, transparent);");
+    expect(selectBlock).toContain("border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim));");
+    expect(selectBlock).toContain("background: color-mix(in oklch, var(--brass) 12%, transparent);");
+    expect(selectBlock).toContain('content: "✓";');
+    expect(selectBlock).toContain("font-style: italic;");
+    expect(selectBlock).toContain(".fc-select--compact .fc-select__trigger {");
+    expect(selectBlock).toContain("font: 9px/1 var(--font-mono);");
+    expect(selectBlock).toContain("padding: 8px 16px 8px 10px;");
+    expect(selectBlock).toMatch(/\.reduce-panel-motion \.fc-select__trigger,\s*\.reduce-panel-motion \.fc-select__caret,\s*\.reduce-panel-motion \.fc-select__popup,\s*\.reduce-panel-motion \.fc-select__option \{\s*transition: none;\s*\}/);
+    expect(selectBlock).toMatch(/@media \(prefers-reduced-motion: reduce\) \{\s*\.fc-select__trigger,\s*\.fc-select__caret,\s*\.fc-select__popup,\s*\.fc-select__option \{\s*transition: none;\s*\}\s*\}/);
+
+    expect(selectBlock).not.toMatch(/#[0-9a-f]{3,8}\b/i);
+    expect(selectBlock).not.toMatch(/\boklch\(/);
+    expect(selectBlock).not.toMatch(/\brgb\(/);
+
+    expect(rail).toContain("--z-rail: 10;");
+    expect(components).toContain(".group-context-menu-overlay {");
+    expect(components).toContain("z-index: 60;");
+    expect(Number("--z-rail: 10;".match(/\d+/)?.[0])).toBeLessThan(40);
+    expect(40).toBeLessThan(60);
   });
 });

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -676,7 +676,7 @@ describe("Instrument core design contract", () => {
     expect(selectBlock).toContain(".fc-select--compact .fc-select__trigger {");
     expect(selectBlock).toContain("font: 9px/1 var(--font-mono);");
     expect(selectBlock).toContain("padding: 8px 16px 8px 10px;");
-    expect(selectBlock).toContain(".fc-select__popup--compact { min-width: 160px; }");
+    expect(selectBlock).toContain(".fc-select__popup--compact { min-width: min(160px, calc(100vw - 16px)); }");
     expect(selectBlock).toMatch(/\.reduce-panel-motion \.fc-select__trigger,\s*\.reduce-panel-motion \.fc-select__caret,\s*\.reduce-panel-motion \.fc-select__popup,\s*\.reduce-panel-motion \.fc-select__option \{\s*transition: none;\s*\}/);
     expect(selectBlock).toMatch(/@media \(prefers-reduced-motion: reduce\) \{\s*\.fc-select__trigger,\s*\.fc-select__caret,\s*\.fc-select__popup,\s*\.fc-select__option \{\s*transition: none;\s*\}\s*\}/);
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -622,6 +622,7 @@ describe("Instrument core design contract", () => {
     expect(selectBlock).toContain(".fc-select--compact .fc-select__trigger {");
     expect(selectBlock).toContain("font: 9px/1 var(--font-mono);");
     expect(selectBlock).toContain("padding: 8px 16px 8px 10px;");
+    expect(selectBlock).toContain(".fc-select__popup--compact { min-width: 160px; }");
     expect(selectBlock).toMatch(/\.reduce-panel-motion \.fc-select__trigger,\s*\.reduce-panel-motion \.fc-select__caret,\s*\.reduce-panel-motion \.fc-select__popup,\s*\.reduce-panel-motion \.fc-select__option \{\s*transition: none;\s*\}/);
     expect(selectBlock).toMatch(/@media \(prefers-reduced-motion: reduce\) \{\s*\.fc-select__trigger,\s*\.fc-select__caret,\s*\.fc-select__popup,\s*\.fc-select__option \{\s*transition: none;\s*\}\s*\}/);
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1,8 +1,27 @@
 import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
+const CONSOLE_ROOT = new URL("../", import.meta.url);
 const CLIENT_ROOT = new URL("../core/client/src/", import.meta.url);
+const PRODUCT_SOURCE_ROOTS = [
+  new URL("core/client/src/", CONSOLE_ROOT),
+  new URL("sdk/", CONSOLE_ROOT),
+  new URL("../fleet-plugins/", CONSOLE_ROOT),
+] as const;
+const PRODUCT_SOURCE_SUFFIXES = [".ts", ".tsx"] as const;
+const PRODUCT_SOURCE_SKIP_DIR_NAMES = new Set([
+  "node_modules",
+  "dist",
+  "tests",
+  "test",
+  "__tests__",
+  "proposals",
+  "examples",
+]);
+const RAW_PRODUCT_SELECT = /<select(?:[\s>/]|$)/;
 const SKILLS_CSS_PATH = new URL("../../fleet-plugins/skills/client/skills.css", import.meta.url);
 const TERMINAL_AGENT_PATH = new URL("../../fleet-plugins/terminal/client/agent/index.tsx", import.meta.url);
 const SDK_RAIL_TYPES_PATH = new URL("../sdk/rail/types.ts", import.meta.url);
@@ -34,6 +53,46 @@ function source(path: string): string {
 
 function externalSource(path: URL): string {
   return fs.readFileSync(path, "utf8");
+}
+
+function listProductSourceFiles(root: URL): string[] {
+  const files: string[] = [];
+  const stack = [fileURLToPath(root)];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (PRODUCT_SOURCE_SKIP_DIR_NAMES.has(entry.name)) continue;
+        stack.push(path.join(current, entry.name));
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (entry.name.endsWith(".generated.ts")) continue;
+      if (!PRODUCT_SOURCE_SUFFIXES.some((suffix) => entry.name.endsWith(suffix))) continue;
+      files.push(path.join(current, entry.name));
+    }
+  }
+  return files.sort();
+}
+
+function findRawProductSelects(): Array<{ file: string; line: number; snippet: string }> {
+  const hits: Array<{ file: string; line: number; snippet: string }> = [];
+  for (const root of PRODUCT_SOURCE_ROOTS) {
+    for (const file of listProductSourceFiles(root)) {
+      const lines = fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n").split("\n");
+      for (let index = 0; index < lines.length; index += 1) {
+        const line = lines[index] ?? "";
+        if (RAW_PRODUCT_SELECT.test(line)) {
+          hits.push({
+            file: path.relative(fileURLToPath(CONSOLE_ROOT), file).replace(/\\/g, "/"),
+            line: index + 1,
+            snippet: line.trim(),
+          });
+        }
+      }
+    }
+  }
+  return hits;
 }
 
 describe("Instrument core design contract", () => {
@@ -533,6 +592,11 @@ describe("Instrument core design contract", () => {
     expect(source("styles/layout.css")).toContain("background: color-mix(in oklch, var(--ink-fog) 10%, transparent);");
     expect(commandBand).toContain('<rect x="1.75" y="3" width="12.5" height="10" rx="2.4"');
     expect(rail).toContain("width: 44px");
+  });
+
+  it("forbids native product selects in Console core, SDK, and built-in plugins", () => {
+    const hits = findRawProductSelects();
+    expect(hits, hits.map((hit) => `${hit.file}:${hit.line} ${hit.snippet}`).join("\n")).toEqual([]);
   });
 
   it("pins the shared SDK Select listbox grammar and stacking contract", () => {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 const CONSOLE_ROOT = new URL("../", import.meta.url);
@@ -21,7 +22,7 @@ const PRODUCT_SOURCE_SKIP_DIR_NAMES = new Set([
   "proposals",
   "examples",
 ]);
-const RAW_PRODUCT_SELECT = /<select(?:[\s>/]|$)/;
+const JSX_FACTORY_NAMES = new Set(["createElement", "jsx", "jsxs"]);
 const SKILLS_CSS_PATH = new URL("../../fleet-plugins/skills/client/skills.css", import.meta.url);
 const TERMINAL_AGENT_PATH = new URL("../../fleet-plugins/terminal/client/agent/index.tsx", import.meta.url);
 const SDK_RAIL_TYPES_PATH = new URL("../sdk/rail/types.ts", import.meta.url);
@@ -79,19 +80,63 @@ function findRawProductSelects(): Array<{ file: string; line: number; snippet: s
   const hits: Array<{ file: string; line: number; snippet: string }> = [];
   for (const root of PRODUCT_SOURCE_ROOTS) {
     for (const file of listProductSourceFiles(root)) {
-      const lines = fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n").split("\n");
-      for (let index = 0; index < lines.length; index += 1) {
-        const line = lines[index] ?? "";
-        if (RAW_PRODUCT_SELECT.test(line)) {
-          hits.push({
-            file: path.relative(fileURLToPath(CONSOLE_ROOT), file).replace(/\\/g, "/"),
-            line: index + 1,
-            snippet: line.trim(),
-          });
-        }
-      }
+      const text = fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n");
+      const sourceFile = ts.createSourceFile(
+        file,
+        text,
+        ts.ScriptTarget.Latest,
+        true,
+        file.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+      );
+      hits.push(...findRawProductSelectsInSourceFile(sourceFile, file, text));
     }
   }
+  return hits.sort((left, right) => left.file.localeCompare(right.file) || left.line - right.line);
+}
+
+function findRawProductSelectsInSourceFile(
+  sourceFile: ts.SourceFile,
+  filePath: string,
+  text: string,
+): Array<{ file: string; line: number; snippet: string }> {
+  const hits: Array<{ file: string; line: number; snippet: string }> = [];
+  const relativeFile = path.relative(fileURLToPath(CONSOLE_ROOT), filePath).replace(/\\/g, "/");
+  const lines = text.split("\n");
+
+  const recordHit = (node: ts.Node) => {
+    const line = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+    hits.push({
+      file: relativeFile,
+      line,
+      snippet: (lines[line - 1] ?? "").trim(),
+    });
+  };
+
+  const isSelectTagName = (name: ts.JsxTagNameExpression | undefined): boolean =>
+    name !== undefined && ts.isIdentifier(name) && name.text === "select";
+
+  const isSelectFactoryFirstArg = (expression: ts.Expression | undefined): boolean =>
+    expression !== undefined && ts.isStringLiteralLike(expression) && expression.text === "select";
+
+  const factoryName = (expression: ts.Expression): string | undefined => {
+    if (ts.isIdentifier(expression)) return expression.text;
+    if (ts.isPropertyAccessExpression(expression) && ts.isIdentifier(expression.name)) return expression.name.text;
+    return undefined;
+  };
+
+  const visit = (node: ts.Node) => {
+    if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+      if (isSelectTagName(node.tagName)) recordHit(node);
+    } else if (ts.isCallExpression(node)) {
+      const name = factoryName(node.expression);
+      if (name !== undefined && JSX_FACTORY_NAMES.has(name) && isSelectFactoryFirstArg(node.arguments[0])) {
+        recordHit(node);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
   return hits;
 }
 
@@ -597,6 +642,15 @@ describe("Instrument core design contract", () => {
   it("forbids native product selects in Console core, SDK, and built-in plugins", () => {
     const hits = findRawProductSelects();
     expect(hits, hits.map((hit) => `${hit.file}:${hit.line} ${hit.snippet}`).join("\n")).toEqual([]);
+  });
+
+  it("detects JSX and createElement native select factories with the AST scanner", () => {
+    const jsxText = '<select value="x" />\n<div><select /></div>';
+    const jsxSource = ts.createSourceFile("fixture.tsx", jsxText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+    const factoryText = 'createElement("select", { value: "x" });\nReact.createElement("select", null);';
+    const factorySource = ts.createSourceFile("fixture.ts", factoryText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+    expect(findRawProductSelectsInSourceFile(jsxSource, "fixture.tsx", jsxText).map((hit) => hit.line)).toEqual([1, 2]);
+    expect(findRawProductSelectsInSourceFile(factorySource, "fixture.ts", factoryText).map((hit) => hit.line)).toEqual([1, 2]);
   });
 
   it("pins the shared SDK Select listbox grammar and stacking contract", () => {

--- a/runtime/fleet-console/tests/sdk-select.test.tsx
+++ b/runtime/fleet-console/tests/sdk-select.test.tsx
@@ -64,6 +64,38 @@ function options(): HTMLLIElement[] {
   return Array.from(document.querySelectorAll<HTMLLIElement>(".fc-select__option"));
 }
 
+function expectFiniteNonNegativeGeometry(list: HTMLUListElement): void {
+  const left = Number.parseFloat(list.style.left);
+  const width = Number.parseFloat(list.style.width);
+  expect(Number.isFinite(left)).toBe(true);
+  expect(Number.isFinite(width)).toBe(true);
+  expect(left).toBeGreaterThanOrEqual(0);
+  expect(width).toBeGreaterThanOrEqual(0);
+  if (list.dataset.placement === "up") {
+    const bottom = Number.parseFloat(list.style.bottom);
+    expect(Number.isFinite(bottom)).toBe(true);
+    expect(bottom).toBeGreaterThanOrEqual(0);
+    return;
+  }
+  const top = Number.parseFloat(list.style.top);
+  expect(Number.isFinite(top)).toBe(true);
+  expect(top).toBeGreaterThanOrEqual(0);
+}
+
+function mockTriggerRect(button: HTMLButtonElement, rect: DOMRectInit & { width: number; height: number }): void {
+  vi.spyOn(button, "getBoundingClientRect").mockReturnValue({
+    x: rect.left ?? 0,
+    y: rect.top ?? 0,
+    width: rect.width,
+    height: rect.height,
+    top: rect.top ?? 0,
+    right: rect.right ?? ((rect.left ?? 0) + rect.width),
+    bottom: rect.bottom ?? ((rect.top ?? 0) + rect.height),
+    left: rect.left ?? 0,
+    toJSON: () => ({}),
+  });
+}
+
 beforeEach(() => {
   document.body.replaceChildren();
   vi.useFakeTimers();
@@ -341,6 +373,36 @@ describe("Select behavior", () => {
     expect(popup().style.width).toBe("384px");
     expect(Number.parseFloat(popup().style.left)).toBe(8);
   });
+
+  it.each([
+    { innerWidth: 0, compact: true, placement: "down" as const },
+    { innerWidth: 0, compact: false, placement: "down" as const },
+    { innerWidth: 0, compact: true, placement: "up" as const },
+    { innerWidth: 0, compact: false, placement: "up" as const },
+    { innerWidth: 10, compact: true, placement: "down" as const },
+    { innerWidth: 10, compact: false, placement: "down" as const },
+    { innerWidth: 10, compact: true, placement: "up" as const },
+    { innerWidth: 10, compact: false, placement: "up" as const },
+    { innerWidth: 100, compact: true, placement: "down" as const },
+    { innerWidth: 100, compact: false, placement: "down" as const },
+    { innerWidth: 100, compact: true, placement: "up" as const },
+    { innerWidth: 100, compact: false, placement: "up" as const },
+  ])(
+    "keeps $placement popup geometry finite and non-negative at innerWidth=$innerWidth compact=$compact",
+    ({ innerWidth, compact, placement }) => {
+      vi.spyOn(window, "innerWidth", "get").mockReturnValue(innerWidth);
+      vi.spyOn(window, "innerHeight", "get").mockReturnValue(300);
+      renderSelect({ compact });
+      const button = trigger();
+      mockTriggerRect(button, placement === "up"
+        ? { left: 12, top: 280, width: 60, height: 24, right: 72, bottom: 304 }
+        : { left: 12, top: 40, width: 60, height: 24, right: 72, bottom: 64 });
+      act(() => button.click());
+      const list = popup();
+      expect(list.dataset.placement).toBe(placement);
+      expectFiniteNonNegativeGeometry(list);
+    },
+  );
 });
 
 describe("SettingsSelect public contract", () => {

--- a/runtime/fleet-console/tests/sdk-select.test.tsx
+++ b/runtime/fleet-console/tests/sdk-select.test.tsx
@@ -66,6 +66,9 @@ function options(): HTMLLIElement[] {
 beforeEach(() => {
   document.body.replaceChildren();
   vi.useFakeTimers();
+  if (typeof HTMLElement.prototype.scrollIntoView !== "function") {
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+  }
 });
 
 afterEach(() => {
@@ -186,11 +189,14 @@ describe("Select behavior", () => {
     const { onChange } = renderSelect();
     act(() => trigger().click());
     const list = popup();
+    expect(trigger().getAttribute("role")).toBe("combobox");
     expect(trigger().getAttribute("aria-haspopup")).toBe("listbox");
     expect(trigger().getAttribute("aria-expanded")).toBe("true");
     expect(trigger().getAttribute("aria-controls")).toBe(list.id);
+    expect(trigger().getAttribute("aria-activedescendant")).toBeTruthy();
     expect(list.getAttribute("role")).toBe("listbox");
-    expect(list.getAttribute("aria-activedescendant")).toBeTruthy();
+    expect(list.getAttribute("aria-activedescendant")).toBeNull();
+    expect(list.getAttribute("tabindex")).toBeNull();
     for (const option of options()) {
       expect(option.getAttribute("role")).toBe("option");
       expect(option.hasAttribute("aria-selected")).toBe(true);
@@ -218,6 +224,62 @@ describe("Select behavior", () => {
     expect(options()).toHaveLength(2);
     expect(options()[1]?.getAttribute("aria-selected")).toBe("true");
   });
+
+  it("reflects external aria-labelledby on the trigger and listbox", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root?.render(
+        createElement("div", null, [
+          createElement("span", { id: "field-label", key: "label" }, "Default model"),
+          createElement(Select, {
+            key: "select",
+            value: "alpha",
+            options: BASE_OPTIONS,
+            onChange: vi.fn(),
+            "aria-labelledby": "field-label",
+          }),
+        ]),
+      );
+    });
+    act(() => trigger().click());
+    expect(trigger().getAttribute("aria-labelledby")).toBe("field-label");
+    expect(popup().getAttribute("aria-labelledby")).toBe("field-label");
+    expect(trigger().getAttribute("aria-label")).toBeNull();
+  });
+
+  it("scrolls the active option into view when navigation changes", () => {
+    const scrollIntoView = vi.fn();
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    renderSelect({ value: "alpha" });
+    act(() => trigger().click());
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    });
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+  });
+
+  it("applies compact popup modifier and right-aligns the portaled surface", () => {
+    renderSelect({ compact: true });
+    const button = trigger();
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({
+      x: 100,
+      y: 40,
+      width: 80,
+      height: 24,
+      top: 40,
+      right: 180,
+      bottom: 64,
+      left: 100,
+      toJSON: () => ({}),
+    });
+    act(() => button.click());
+    const list = popup();
+    expect(list.classList.contains("fc-select__popup--compact")).toBe(true);
+    expect(list.style.left).toBe(`${180 - 160}px`);
+    expect(list.style.width).toBe("160px");
+  });
 });
 
 describe("SettingsSelect public contract", () => {
@@ -242,10 +304,9 @@ describe("SettingsSelect public contract", () => {
     });
 
     const label = container.querySelector<HTMLSpanElement>(".fc-settings-select__label");
-    const selectRoot = container.querySelector<HTMLElement>(".fc-select");
     const trigger = container.querySelector<HTMLButtonElement>(".fc-select__trigger");
     expect(label?.textContent).toBe("Theme");
-    expect(selectRoot?.getAttribute("aria-labelledby")).toBe(label?.id);
+    expect(trigger?.getAttribute("aria-labelledby")).toBe(label?.id);
     expect(trigger?.textContent).toContain("Carbon");
 
     act(() => trigger?.click());

--- a/runtime/fleet-console/tests/sdk-select.test.tsx
+++ b/runtime/fleet-console/tests/sdk-select.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Select, type SelectOption } from "@fleet-console/sdk/react/browser";
 import { SettingsSelect } from "@fleet-console/sdk/settings/browser";
+import { isSelectOwnedKeyEvent } from "../core/client/src/components/whatsnew-modal.js";
 
 let root: Root | null = null;
 let container: HTMLDivElement | null = null;
@@ -336,5 +337,35 @@ describe("SettingsSelect public contract", () => {
     const trigger = container.querySelector<HTMLButtonElement>(".fc-select__trigger");
     expect(trigger?.getAttribute("aria-label")).toBe("Select setting");
     expect(trigger?.disabled).toBe(true);
+  });
+});
+
+describe("WhatsNew modal key capture", () => {
+  it("defers modal capture while Select owns listbox keys and lets Escape close the popup first", () => {
+    const modalStopped = vi.fn();
+    const modalHandler = (event: KeyboardEvent) => {
+      if (isSelectOwnedKeyEvent(event)) return;
+      event.stopImmediatePropagation();
+      modalStopped();
+    };
+    window.addEventListener("keydown", modalHandler, true);
+
+    try {
+      renderSelect();
+      act(() => trigger().click());
+      act(() => {
+        trigger().dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+      });
+      expect(document.querySelector(".fc-select__popup")).toBeNull();
+      expect(modalStopped).not.toHaveBeenCalled();
+
+      act(() => trigger().click());
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true }));
+      });
+      expect(modalStopped).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("keydown", modalHandler, true);
+    }
   });
 });

--- a/runtime/fleet-console/tests/sdk-select.test.tsx
+++ b/runtime/fleet-console/tests/sdk-select.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Select, type SelectOption } from "@fleet-console/sdk/react/browser";
+import { SettingsSelect } from "@fleet-console/sdk/settings/browser";
 
 let root: Root | null = null;
 let container: HTMLDivElement | null = null;
@@ -216,5 +217,63 @@ describe("Select behavior", () => {
     act(() => trigger().click());
     expect(options()).toHaveLength(2);
     expect(options()[1]?.getAttribute("aria-selected")).toBe("true");
+  });
+});
+
+describe("SettingsSelect public contract", () => {
+  it("keeps label association, disabled state, and onChange(next: string)", () => {
+    const onChange = vi.fn<(next: string) => void>();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root?.render(
+        createElement(SettingsSelect, {
+          label: "Theme",
+          value: "carbon",
+          disabled: false,
+          options: [
+            { value: "instrument", label: "Instrument" },
+            { value: "carbon", label: "Carbon" },
+          ],
+          onChange,
+        }),
+      );
+    });
+
+    const label = container.querySelector<HTMLSpanElement>(".fc-settings-select__label");
+    const selectRoot = container.querySelector<HTMLElement>(".fc-select");
+    const trigger = container.querySelector<HTMLButtonElement>(".fc-select__trigger");
+    expect(label?.textContent).toBe("Theme");
+    expect(selectRoot?.getAttribute("aria-labelledby")).toBe(label?.id);
+    expect(trigger?.textContent).toContain("Carbon");
+
+    act(() => trigger?.click());
+    act(() => {
+      [...document.querySelectorAll<HTMLLIElement>(".fc-select__option")]
+        .find((option) => option.textContent === "Instrument")
+        ?.click();
+    });
+    expect(onChange).toHaveBeenCalledWith("instrument");
+  });
+
+  it("uses the unlabeled fallback aria label", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root?.render(
+        createElement(SettingsSelect, {
+          value: "one",
+          options: [{ value: "one", label: "One" }],
+          onChange: vi.fn(),
+          disabled: true,
+        }),
+      );
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>(".fc-select__trigger");
+    expect(trigger?.getAttribute("aria-label")).toBe("Select setting");
+    expect(trigger?.disabled).toBe(true);
   });
 });

--- a/runtime/fleet-console/tests/sdk-select.test.tsx
+++ b/runtime/fleet-console/tests/sdk-select.test.tsx
@@ -6,7 +6,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Select, type SelectOption } from "@fleet-console/sdk/react/browser";
 import { SettingsSelect } from "@fleet-console/sdk/settings/browser";
-import { isSelectOwnedKeyEvent } from "../core/client/src/components/whatsnew-modal.js";
 
 let root: Root | null = null;
 let container: HTMLDivElement | null = null;
@@ -281,6 +280,66 @@ describe("Select behavior", () => {
     expect(list.style.left).toBe(`${180 - 160}px`);
     expect(list.style.width).toBe("160px");
   });
+
+  it("clamps compact popup left edge to the viewport margin", () => {
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(800);
+    renderSelect({ compact: true });
+    const button = trigger();
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 40,
+      width: 80,
+      height: 24,
+      top: 40,
+      right: 80,
+      bottom: 64,
+      left: 0,
+      toJSON: () => ({}),
+    });
+    act(() => button.click());
+    expect(Number.parseFloat(popup().style.left)).toBeGreaterThanOrEqual(8);
+    expect(popup().style.width).toBe("160px");
+  });
+
+  it("clamps compact popup right edge inside the viewport margin", () => {
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(800);
+    renderSelect({ compact: true });
+    const button = trigger();
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({
+      x: 710,
+      y: 40,
+      width: 80,
+      height: 24,
+      top: 40,
+      right: 790,
+      bottom: 64,
+      left: 710,
+      toJSON: () => ({}),
+    });
+    act(() => button.click());
+    expect(Number.parseFloat(popup().style.left)).toBeLessThanOrEqual(800 - 160 - 8);
+    expect(popup().style.width).toBe("160px");
+  });
+
+  it("caps default popup width to the viewport margin box", () => {
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(400);
+    renderSelect({ compact: false });
+    const button = trigger();
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({
+      x: 8,
+      y: 40,
+      width: 500,
+      height: 42,
+      top: 40,
+      right: 508,
+      bottom: 82,
+      left: 8,
+      toJSON: () => ({}),
+    });
+    act(() => button.click());
+    expect(popup().style.width).toBe("384px");
+    expect(Number.parseFloat(popup().style.left)).toBe(8);
+  });
 });
 
 describe("SettingsSelect public contract", () => {
@@ -337,35 +396,5 @@ describe("SettingsSelect public contract", () => {
     const trigger = container.querySelector<HTMLButtonElement>(".fc-select__trigger");
     expect(trigger?.getAttribute("aria-label")).toBe("Select setting");
     expect(trigger?.disabled).toBe(true);
-  });
-});
-
-describe("WhatsNew modal key capture", () => {
-  it("defers modal capture while Select owns listbox keys and lets Escape close the popup first", () => {
-    const modalStopped = vi.fn();
-    const modalHandler = (event: KeyboardEvent) => {
-      if (isSelectOwnedKeyEvent(event)) return;
-      event.stopImmediatePropagation();
-      modalStopped();
-    };
-    window.addEventListener("keydown", modalHandler, true);
-
-    try {
-      renderSelect();
-      act(() => trigger().click());
-      act(() => {
-        trigger().dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
-      });
-      expect(document.querySelector(".fc-select__popup")).toBeNull();
-      expect(modalStopped).not.toHaveBeenCalled();
-
-      act(() => trigger().click());
-      act(() => {
-        document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true }));
-      });
-      expect(modalStopped).not.toHaveBeenCalled();
-    } finally {
-      window.removeEventListener("keydown", modalHandler, true);
-    }
   });
 });

--- a/runtime/fleet-console/tests/sdk-select.test.tsx
+++ b/runtime/fleet-console/tests/sdk-select.test.tsx
@@ -1,0 +1,220 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Select, type SelectOption } from "@fleet-console/sdk/react/browser";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const BASE_OPTIONS: readonly SelectOption[] = [
+  { value: "alpha", label: "Alpha" },
+  { value: "beta", label: "Beta" },
+  { value: "gamma", label: "Gamma", disabled: true },
+  { value: "delta", label: "Delta" },
+];
+
+function renderSelect(
+  props: Partial<{
+    value: string;
+    options: readonly SelectOption[];
+    onChange: (next: string) => void;
+    disabled: boolean;
+    compact: boolean;
+  }> = {},
+): { onChange: ReturnType<typeof vi.fn<(next: string) => void>> } {
+  const onChange = vi.fn<(next: string) => void>();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(
+      createElement(Select, {
+        value: props.value ?? "alpha",
+        options: props.options ?? BASE_OPTIONS,
+        onChange: props.onChange ?? onChange,
+        disabled: props.disabled,
+        compact: props.compact,
+        label: "Test select",
+      }),
+    );
+  });
+  return { onChange: props.onChange ? (props.onChange as ReturnType<typeof vi.fn>) : onChange };
+}
+
+function trigger(): HTMLButtonElement {
+  const button = document.querySelector<HTMLButtonElement>(".fc-select__trigger");
+  if (!button) throw new Error("missing trigger");
+  return button;
+}
+
+function popup(): HTMLUListElement {
+  const list = document.querySelector<HTMLUListElement>(".fc-select__popup");
+  if (!list) throw new Error("missing popup");
+  return list;
+}
+
+function options(): HTMLLIElement[] {
+  return Array.from(document.querySelectorAll<HTMLLIElement>(".fc-select__option"));
+}
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  vi.useRealTimers();
+});
+
+describe("Select behavior", () => {
+  it("commits a controlled value on option click", () => {
+    const { onChange } = renderSelect();
+    act(() => trigger().click());
+    act(() => options()[1]?.click());
+    expect(onChange).toHaveBeenCalledWith("beta");
+    expect(trigger().textContent).toContain("Alpha");
+  });
+
+  it("wraps arrow navigation while skipping disabled options", () => {
+    renderSelect({ value: "delta" });
+    act(() => trigger().click());
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
+    });
+    const active = options().find((option) => option.dataset.active === "true");
+    expect(active?.textContent).toBe("Beta");
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
+    });
+    expect(options().find((option) => option.dataset.active === "true")?.textContent).toBe("Alpha");
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
+    });
+    expect(options().find((option) => option.dataset.active === "true")?.textContent).toBe("Delta");
+  });
+
+  it("jumps to first and last enabled options with Home and End", () => {
+    renderSelect({ value: "beta" });
+    act(() => trigger().click());
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+    });
+    expect(options().find((option) => option.dataset.active === "true")?.textContent).toBe("Delta");
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }));
+    });
+    expect(options().find((option) => option.dataset.active === "true")?.textContent).toBe("Alpha");
+  });
+
+  it("matches case-insensitive typeahead within 500 ms", () => {
+    renderSelect({ value: "alpha" });
+    act(() => trigger().click());
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "d", bubbles: true }));
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "e", bubbles: true }));
+    });
+    expect(options().find((option) => option.dataset.active === "true")?.textContent).toBe("Delta");
+    act(() => {
+      vi.advanceTimersByTime(500);
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "b", bubbles: true }));
+    });
+    expect(options().find((option) => option.dataset.active === "true")?.textContent).toBe("Beta");
+  });
+
+  it("portals the popup to document.body and removes it on close", () => {
+    renderSelect();
+    act(() => trigger().click());
+    const list = popup();
+    expect(list.parentElement).toBe(document.body);
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(document.querySelector(".fc-select__popup")).toBeNull();
+  });
+
+  it("flips upward when lower viewport space is insufficient", () => {
+    renderSelect();
+    const button = trigger();
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({
+      x: 12,
+      y: window.innerHeight - 20,
+      width: 180,
+      height: 42,
+      top: window.innerHeight - 20,
+      right: 192,
+      bottom: window.innerHeight + 22,
+      left: 12,
+      toJSON: () => ({}),
+    });
+    act(() => button.click());
+    expect(popup().dataset.placement).toBe("up");
+  });
+
+  it("closes on Escape, Tab, and outside pointerdown while returning focus", () => {
+    renderSelect();
+    act(() => trigger().click());
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(document.querySelector(".fc-select__popup")).toBeNull();
+    expect(document.activeElement).toBe(trigger());
+
+    act(() => trigger().click());
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+    });
+    expect(document.querySelector(".fc-select__popup")).toBeNull();
+
+    act(() => trigger().click());
+    act(() => {
+      document.body.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    });
+    expect(document.querySelector(".fc-select__popup")).toBeNull();
+  });
+
+  it("updates options dynamically and keeps complete ARIA state", () => {
+    const { onChange } = renderSelect();
+    act(() => trigger().click());
+    const list = popup();
+    expect(trigger().getAttribute("aria-haspopup")).toBe("listbox");
+    expect(trigger().getAttribute("aria-expanded")).toBe("true");
+    expect(trigger().getAttribute("aria-controls")).toBe(list.id);
+    expect(list.getAttribute("role")).toBe("listbox");
+    expect(list.getAttribute("aria-activedescendant")).toBeTruthy();
+    for (const option of options()) {
+      expect(option.getAttribute("role")).toBe("option");
+      expect(option.hasAttribute("aria-selected")).toBe(true);
+    }
+    expect(options()[2]?.getAttribute("aria-disabled")).toBe("true");
+
+    const nextOptions: readonly SelectOption[] = [
+      { value: "one", label: "One" },
+      { value: "two", label: "Two" },
+    ];
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    act(() => {
+      root?.render(
+        createElement(Select, {
+          value: "two",
+          options: nextOptions,
+          onChange,
+          label: "Test select",
+        }),
+      );
+    });
+    act(() => trigger().click());
+    expect(options()).toHaveLength(2);
+    expect(options()[1]?.getAttribute("aria-selected")).toBe("true");
+  });
+});

--- a/runtime/fleet-console/tests/sdk-select.test.tsx
+++ b/runtime/fleet-console/tests/sdk-select.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Select, type SelectOption } from "@fleet-console/sdk/react/browser";
 import { SettingsSelect } from "@fleet-console/sdk/settings/browser";
+import { isSelectOwnedKeyEvent } from "../core/client/src/components/whatsnew-modal.js";
 
 let root: Root | null = null;
 let container: HTMLDivElement | null = null;
@@ -396,5 +397,97 @@ describe("SettingsSelect public contract", () => {
     const trigger = container.querySelector<HTMLButtonElement>(".fc-select__trigger");
     expect(trigger?.getAttribute("aria-label")).toBe("Select setting");
     expect(trigger?.disabled).toBe(true);
+  });
+});
+
+describe("WhatsNew modal key capture", () => {
+  it("defers modal capture while Select owns listbox keys and lets Escape close the popup first", () => {
+    const modalStopped = vi.fn();
+    const modalHandler = (event: KeyboardEvent) => {
+      if (isSelectOwnedKeyEvent(event)) return;
+      event.stopImmediatePropagation();
+      modalStopped();
+    };
+    window.addEventListener("keydown", modalHandler, true);
+
+    try {
+      renderSelect();
+      act(() => trigger().click());
+      act(() => {
+        trigger().dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+      });
+      expect(document.querySelector(".fc-select__popup")).toBeNull();
+      expect(modalStopped).not.toHaveBeenCalled();
+
+      act(() => trigger().click());
+      act(() => {
+        trigger().dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true }));
+      });
+      expect(modalStopped).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("keydown", modalHandler, true);
+    }
+  });
+
+  it("lets a second Escape on a closed trigger reach the modal handler", () => {
+    renderSelect();
+    act(() => trigger().click());
+    act(() => {
+      trigger().dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+    });
+    expect(document.querySelector(".fc-select__popup")).toBeNull();
+
+    const event = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true });
+    Object.defineProperty(event, "target", { value: trigger() });
+    expect(isSelectOwnedKeyEvent(event)).toBe(false);
+  });
+
+  it("passes only open keys from a closed trigger and ignores unrelated open popups", () => {
+    const foreignPopup = document.createElement("ul");
+    foreignPopup.className = "fc-select__popup";
+    foreignPopup.dataset.open = "true";
+    document.body.appendChild(foreignPopup);
+
+    renderSelect();
+    const button = trigger();
+    button.focus();
+
+    const arrowDown = new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true });
+    Object.defineProperty(arrowDown, "target", { value: button });
+    expect(isSelectOwnedKeyEvent(arrowDown)).toBe(true);
+
+    const escape = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true });
+    Object.defineProperty(escape, "target", { value: button });
+    expect(isSelectOwnedKeyEvent(escape)).toBe(false);
+
+    foreignPopup.remove();
+  });
+
+  it("does not defer modal capture when focus sits on a closed trigger beside another open popup", () => {
+    const foreignPopup = document.createElement("ul");
+    foreignPopup.className = "fc-select__popup";
+    foreignPopup.dataset.open = "true";
+    document.body.appendChild(foreignPopup);
+
+    const modalStopped = vi.fn();
+    const modalHandler = (event: KeyboardEvent) => {
+      if (isSelectOwnedKeyEvent(event)) return;
+      event.stopImmediatePropagation();
+      modalStopped();
+    };
+    window.addEventListener("keydown", modalHandler, true);
+
+    try {
+      renderSelect();
+      const button = trigger();
+      button.focus();
+      act(() => {
+        button.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+      });
+      expect(modalStopped).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener("keydown", modalHandler, true);
+      foreignPopup.remove();
+    }
   });
 });

--- a/runtime/fleet-plugins/repository/client/compare-view.tsx
+++ b/runtime/fleet-plugins/repository/client/compare-view.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { Select, type SelectOption } from "@fleet-console/sdk/react/browser";
 import type { RailPanelContext } from "@fleet-console/sdk/rail";
 
 import type { CompareResult, DiffFileEntry } from "../server/types.js";
@@ -158,15 +159,25 @@ export function CompareView({ ctx, repoRel, refs, refsError = false, onRetryRefs
     });
   }, []);
 
-  const refOptions = (items: readonly RepositoryRefItem[]) => items.map((item) => <option key={item.ref} value={item.ref}>{item.label}</option>);
+  const headRefOptions = useMemo((): readonly SelectOption[] => {
+    const options: SelectOption[] = [];
+    if (showHeadOption) options.push({ value: "HEAD", label: "HEAD" });
+    for (const item of refs.branches) options.push({ value: item.ref, label: `LOCAL · ${item.label}` });
+    for (const item of remoteRefs) options.push({ value: item.ref, label: `REMOTES · ${item.label}` });
+    for (const item of refs.tags) options.push({ value: item.ref, label: `TAGS · ${item.label}` });
+    return options;
+  }, [refs.branches, refs.tags, remoteRefs, showHeadOption]);
+  const baseRefOptions = useMemo(
+    (): readonly SelectOption[] => [{ value: "", label: "Select base…", disabled: true }, ...headRefOptions],
+    [headRefOptions],
+  );
   const refSelect = (side: "base" | "head", value: string) => (
-    <select className="repository-compare-select" aria-label={side === "base" ? "Base ref" : "Head ref"} value={value} onChange={(event) => chooseRef(side, event.target.value)}>
-      {side === "base" && <option value="" disabled>Select base…</option>}
-      {showHeadOption && <option value="HEAD">HEAD</option>}
-      {refs.branches.length > 0 && <optgroup label="LOCAL">{refOptions(refs.branches)}</optgroup>}
-      {remoteRefs.length > 0 && <optgroup label="REMOTES">{refOptions(remoteRefs)}</optgroup>}
-      {refs.tags.length > 0 && <optgroup label="TAGS">{refOptions(refs.tags)}</optgroup>}
-    </select>
+    <Select
+      label={side === "base" ? "Base ref" : "Head ref"}
+      value={value}
+      options={side === "base" ? baseRefOptions : headRefOptions}
+      onChange={(next) => chooseRef(side, next)}
+    />
   );
 
   const canCompare = base !== "" && head !== "" && base !== head;

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1038,10 +1038,7 @@
 /* ── Compare 뷰 ── */
 .repository-compare { display: grid; grid-template-rows: auto minmax(0, 1fr); height: 100%; min-height: 0; }
 .repository-compare-controls { display: flex; align-items: center; gap: 6px; padding: 7px 10px; border-bottom: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--surface-band) 55%, transparent); }
-/* UA 기본 select 크롬을 걷어내고 필터 입력과 같은 시각 등급으로 맞춘다. */
-.repository-compare-select { flex: 1; min-width: 0; appearance: none; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: color-mix(in oklch, var(--ink-abyss) 35%, transparent); color: var(--ink-spectral); font-family: var(--font-mono); font-size: 12px; padding: 3px 6px; outline: none; cursor: pointer; text-overflow: ellipsis; transition: border-color var(--duration-fast) var(--ease-glide); }
-.repository-compare-select:hover { border-color: var(--surface-rim-strong); }
-.repository-compare-select:focus-visible { border-color: var(--brass); }
+.repository-compare-controls .fc-select { flex: 1; min-width: 0; }
 .repository-compare-arrow { flex: none; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 12px; }
 .repository-compare-run:disabled { opacity: .5; cursor: default; }
 .repository-compare-results { display: flex; flex-direction: column; }

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -105,13 +105,17 @@ describe("Repository design grammar", () => {
     expect(detailPanes.length).toBeGreaterThanOrEqual(2);
     for (const body of detailPanes) expect(body).toContain("var(--surface-glass) 70%");
 
-    for (const selector of [".repository-filter-input", ".history-filter-input", ".repository-scan-depth", ".repository-view-toggle"]) {
+    for (const selector of [".repository-filter-input", ".history-filter-input", ".repository-view-toggle"]) {
       expect(blockOf(selector), selector).toContain("var(--ink-abyss) 35%");
     }
   });
 
   it("retires legacy compare ref select chrome", () => {
     expect(css).not.toMatch(/\.repository-compare-select\b/);
+  });
+
+  it("retires legacy scan depth select chrome", () => {
+    expect(css).not.toMatch(/\.repository-scan-depth\b/);
   });
 
   it("keeps added and deleted rows monochromatic", () => {

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -105,9 +105,13 @@ describe("Repository design grammar", () => {
     expect(detailPanes.length).toBeGreaterThanOrEqual(2);
     for (const body of detailPanes) expect(body).toContain("var(--surface-glass) 70%");
 
-    for (const selector of [".repository-filter-input", ".history-filter-input", ".repository-compare-select", ".repository-view-toggle"]) {
+    for (const selector of [".repository-filter-input", ".history-filter-input", ".repository-scan-depth", ".repository-view-toggle"]) {
       expect(blockOf(selector), selector).toContain("var(--ink-abyss) 35%");
     }
+  });
+
+  it("retires legacy compare ref select chrome", () => {
+    expect(css).not.toMatch(/\.repository-compare-select\b/);
   });
 
   it("keeps added and deleted rows monochromatic", () => {

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
@@ -74,7 +74,10 @@ describe("Session Analyst Evidence Pulse", () => {
     expect(selectorStrip.parentElement).toBe(composer);
     expect(selectorStrip.nextElementSibling).toBe(surface);
     expect(surface.querySelector(".session-analyst__selector-strip")).toBeNull();
-    expect(selectorStrip.querySelectorAll("select")).toHaveLength(3);
+    expect(selectorStrip.querySelectorAll(".fc-select__trigger")).toHaveLength(3);
+    expect(selectorStrip.querySelector('[aria-label="Analysis CLI"]')).not.toBeNull();
+    expect(selectorStrip.querySelector('[aria-label="Analysis model"]')).not.toBeNull();
+    expect(selectorStrip.querySelector('[aria-label="Analysis effort"]')).not.toBeNull();
     expect(surface.querySelector("textarea")?.rows).toBe(1);
     expect(surface.querySelector(".session-analyst__send")?.getAttribute("aria-label")).toBe("Send");
     expect(container.querySelector(".session-analyst__composer-meta")).toBeNull();
@@ -107,6 +110,7 @@ describe("Session Analyst Evidence Pulse", () => {
     expect(container.querySelector(".session-analyst__chat ol")?.classList.contains("is-dimmed")).toBe(false);
     expect(container.querySelector("textarea")?.disabled).toBe(false);
     expect(container.querySelectorAll("select")).toHaveLength(0);
+    expect(container.querySelectorAll(".session-analyst__selector-strip .fc-select__trigger")).toHaveLength(0);
     expect(container.querySelectorAll(".session-analyst__stop")).toHaveLength(1);
     expect(container.querySelectorAll(".session-analyst__send")).toHaveLength(2);
     expect(container.querySelector(".session-analyst__stop")?.getAttribute("aria-label")).toBe("Stop");
@@ -517,6 +521,7 @@ describe("Session Analyst Evidence Pulse", () => {
     expect(container.querySelector(".session-analyst__panel-state")?.textContent).toBe("Complete");
     expect(composer.classList.contains("is-docked")).toBe(true);
     expect(container.querySelectorAll("select")).toHaveLength(0);
+    expect(container.querySelectorAll(".session-analyst__selector-strip .fc-select__trigger")).toHaveLength(0);
 
     storeState = { ...storeState, phase: "stopped", started: false, latestActivity: { kind: "tool", title: "wiki_read", status: "running" }, runEndedAt: 13_000 };
     act(() => root.render(createElement(AnalystChatPanel, { context: { operationId: "chat-test" } as never })));
@@ -525,6 +530,7 @@ describe("Session Analyst Evidence Pulse", () => {
     expect(container.querySelector(".session-analyst__composer")).toBe(composer);
     expect(container.querySelector(".session-analyst__composer")?.classList.contains("is-docked")).toBe(true);
     expect(container.querySelectorAll("select")).toHaveLength(0);
+    expect(container.querySelectorAll(".session-analyst__selector-strip .fc-select__trigger")).toHaveLength(0);
 
     act(() => root.unmount());
     container.remove();
@@ -540,7 +546,7 @@ describe("Session Analyst Evidence Pulse", () => {
     };
     const { container, root } = renderPanel();
     const composer = container.querySelector(".session-analyst__composer")!;
-    expect(container.querySelectorAll("select")).toHaveLength(3);
+    expect(container.querySelectorAll(".fc-select__trigger")).toHaveLength(3);
 
     storeState = {
       ...storeState,
@@ -557,6 +563,7 @@ describe("Session Analyst Evidence Pulse", () => {
     expect(composer.classList.contains("is-docked")).toBe(true);
     expect(composer.classList.contains("is-docking")).toBe(true);
     expect(container.querySelectorAll("select")).toHaveLength(0);
+    expect(container.querySelectorAll(".session-analyst__selector-strip .fc-select__trigger")).toHaveLength(0);
     expect(container.querySelector("textarea")?.rows).toBe(1);
     expect(container.querySelector(".session-analyst__send")?.getAttribute("aria-label")).toBe("Send");
 

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
@@ -259,7 +259,16 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
                 onChange={(nextModel) => dispatch({ type: "select-model", model: nextModel })}
               />
             </span>
-            <span className="session-analyst__select"><select aria-label="Analysis effort" disabled={state.started || !model || !model.effortLevels.length} value={state.effort} onChange={(event) => dispatch({ type: "select-effort", effort: event.target.value })}>{model?.effortLevels.length ? model.effortLevels.map((item) => <option key={item} value={item}>{item}</option>) : <option value="">n/a</option>}</select></span>
+            <span className="session-analyst__select">
+              <Select
+                compact
+                label="Analysis effort"
+                value={state.effort}
+                disabled={state.started || !model || !model.effortLevels.length}
+                options={model?.effortLevels.length ? model.effortLevels.map((item) => ({ value: item, label: item })) : [{ value: "", label: "n/a" }]}
+                onChange={(effort) => dispatch({ type: "select-effort", effort })}
+              />
+            </span>
           </div> : null}
           <div className="session-analyst__composer-surface">
             <label className="session-analyst__sr-only" htmlFor={`analysis-${context.operationId}`}>Ask about this session</label>

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
@@ -1,4 +1,5 @@
 import { React } from "@fleet-console/sdk/plugin/browser";
+import { Select } from "@fleet-console/sdk/react/browser";
 import type { OperationRenderContext } from "@fleet-console/sdk/plugin";
 import { installDiagramHydrator } from "@fleet-console/markdown/mermaid";
 import "@fleet-console/markdown/styles.css";
@@ -238,7 +239,16 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
             </div>
           ) : null}
           {!hasInteracted ? <div className="session-analyst__selector-strip" aria-label="Initial analysis settings">
-            <span className="session-analyst__select"><select aria-label="Analysis CLI" disabled={state.started || !state.catalog} value={state.cliId} onChange={(event) => dispatch({ type: "select-cli", cliId: event.target.value })}>{state.catalog?.clis.map((item) => <option key={item.cliId} value={item.cliId} disabled={!item.available}>{item.label}</option>)}</select></span>
+            <span className="session-analyst__select">
+              <Select
+                compact
+                label="Analysis CLI"
+                value={state.cliId}
+                disabled={state.started || !state.catalog}
+                options={state.catalog?.clis.map((item) => ({ value: item.cliId, label: item.label, disabled: !item.available })) ?? []}
+                onChange={(cliId) => dispatch({ type: "select-cli", cliId })}
+              />
+            </span>
             <span className="session-analyst__select"><select aria-label="Analysis model" disabled={state.started || !model} value={state.model} onChange={(event) => dispatch({ type: "select-model", model: event.target.value })}>{cli?.models.map((item) => <option key={item.id} value={item.id}>{item.label}</option>)}</select></span>
             <span className="session-analyst__select"><select aria-label="Analysis effort" disabled={state.started || !model || !model.effortLevels.length} value={state.effort} onChange={(event) => dispatch({ type: "select-effort", effort: event.target.value })}>{model?.effortLevels.length ? model.effortLevels.map((item) => <option key={item} value={item}>{item}</option>) : <option value="">n/a</option>}</select></span>
           </div> : null}

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
@@ -249,7 +249,16 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
                 onChange={(cliId) => dispatch({ type: "select-cli", cliId })}
               />
             </span>
-            <span className="session-analyst__select"><select aria-label="Analysis model" disabled={state.started || !model} value={state.model} onChange={(event) => dispatch({ type: "select-model", model: event.target.value })}>{cli?.models.map((item) => <option key={item.id} value={item.id}>{item.label}</option>)}</select></span>
+            <span className="session-analyst__select">
+              <Select
+                compact
+                label="Analysis model"
+                value={state.model}
+                disabled={state.started || !model}
+                options={cli?.models.map((item) => ({ value: item.id, label: item.label })) ?? []}
+                onChange={(nextModel) => dispatch({ type: "select-model", model: nextModel })}
+              />
+            </span>
             <span className="session-analyst__select"><select aria-label="Analysis effort" disabled={state.started || !model || !model.effortLevels.length} value={state.effort} onChange={(event) => dispatch({ type: "select-effort", effort: event.target.value })}>{model?.effortLevels.length ? model.effortLevels.map((item) => <option key={item} value={item}>{item}</option>) : <option value="">n/a</option>}</select></span>
           </div> : null}
           <div className="session-analyst__composer-surface">

--- a/runtime/fleet-plugins/terminal/client/agent/analysis.css
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis.css
@@ -156,9 +156,6 @@
 .session-analyst__selector-strip:focus-within { border-color: color-mix(in oklch, var(--aurora) 48%, var(--hairline-strong)); }
 .session-analyst__select { position: relative; display: inline-flex; min-width: 0; }
 .session-analyst__select + .session-analyst__select::before { content: ""; position: absolute; inset: 9px auto 9px 0; width: 1px; background: var(--hairline); }
-.session-analyst__select::after { content: "⌄"; position: absolute; right: 6px; top: 50%; transform: translateY(-55%); color: var(--text-tertiary); font-size: 9px; pointer-events: none; }
-.session-analyst__select select { min-width: 0; max-width: 6.5rem; appearance: none; -webkit-appearance: none; border: 0; outline: 0; background: transparent; color: var(--text-secondary); padding: 8px 18px 8px 10px; font: 9px/1 var(--font-mono); cursor: pointer; text-overflow: ellipsis; }
-.session-analyst__select select:disabled { cursor: default; }
 .session-analyst__send { display: grid; place-items: center; width: 38px; height: 38px; flex: none; margin-left: auto; border: 0; border-radius: 50%; background: color-mix(in oklch, var(--text-primary) 72%, var(--ink-mid)); color: var(--ink-abyss); cursor: pointer; }
 .session-analyst__send:hover:not(:disabled) { filter: brightness(1.08); }
 .session-analyst__send:disabled { opacity: .42; cursor: default; }
@@ -229,8 +226,6 @@
   .session-analyst__queue, .session-analyst__followups { padding-right: 10px; padding-left: 10px; }
   .session-analyst__slash { right: 10px; left: 10px; }
   .session-analyst__composer-surface { gap: 4px; padding-left: 6px; }
-  .session-analyst__select select { max-width: 4.65rem; padding-right: 14px; padding-left: 7px; }
-  .session-analyst__select::after { right: 4px; }
   .session-analyst__panel-head--artifacts .session-analyst__panel-copy { display: none; }
 }
 

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -4,6 +4,7 @@ import { fetchSystemFonts } from "@fleet-console/font-picker/system-fonts";
 import { defineNotificationKind } from "@fleet-console/sdk/notifications/browser";
 import { defineOperationKind } from "@fleet-console/sdk/plugin/browser";
 import { definePlugin, React } from "@fleet-console/sdk/plugin/browser";
+import { Select } from "@fleet-console/sdk/react/browser";
 import { defineSettingsSection } from "@fleet-console/sdk/settings/browser";
 import type { OperationRenderContext, PluginInstallContext } from "@fleet-console/sdk/plugin";
 import { TerminalSurface } from "../shared/index.js";
@@ -757,20 +758,18 @@ function ModelAuthBlock() {
         <div className="model-auth-row">
           <div className="terminal-carriers-runtime-row">
             <div className="terminal-carriers-field">
-              <label className="terminal-carriers-label" htmlFor="kimi-default-model">Default model</label>
-              <select
-                id="kimi-default-model"
-                className="terminal-carriers-select"
+              <span className="terminal-carriers-label" id="kimi-default-model-label">Default model</span>
+              <Select
+                aria-labelledby="kimi-default-model-label"
                 value={selectedModelId}
                 disabled={saving || !settings.state}
-                onChange={(event) => {
-                  const nextModel = kimiOptions.models.find((model) => model.modelId === event.target.value);
+                options={kimiOptions.models.map((model) => ({ value: model.modelId, label: model.name }))}
+                onChange={(nextModelId) => {
+                  const nextModel = kimiOptions.models.find((model) => model.modelId === nextModelId);
                   if (!nextModel) return;
                   saveKimiModel(nextModel.modelId, nextModel.effort ? (storedKimiModel?.effort ?? nextModel.effort.default) : undefined);
                 }}
-              >
-                {kimiOptions.models.map((model) => <option key={model.modelId} value={model.modelId}>{model.name}</option>)}
-              </select>
+              />
             </div>
             {selectedModel?.effort ? (
               <div className="terminal-carriers-field">

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -773,16 +773,14 @@ function ModelAuthBlock() {
             </div>
             {selectedModel?.effort ? (
               <div className="terminal-carriers-field">
-                <label className="terminal-carriers-label" htmlFor="kimi-default-effort">Default effort</label>
-                <select
-                  id="kimi-default-effort"
-                  className="terminal-carriers-select"
+                <span className="terminal-carriers-label" id="kimi-default-effort-label">Default effort</span>
+                <Select
+                  aria-labelledby="kimi-default-effort-label"
                   value={selectedEffort ?? selectedModel.effort.default}
                   disabled={saving || !settings.state}
-                  onChange={(event) => saveKimiModel(selectedModel.modelId, event.target.value)}
-                >
-                  {selectedModel.effort.levels.map((level) => <option key={level} value={level}>{level}</option>)}
-                </select>
+                  options={selectedModel.effort.levels.map((level) => ({ value: level, label: level }))}
+                  onChange={(effort) => saveKimiModel(selectedModel.modelId, effort)}
+                />
               </div>
             ) : null}
           </div>

--- a/runtime/fleet-plugins/terminal/client/carriers/section.tsx
+++ b/runtime/fleet-plugins/terminal/client/carriers/section.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type CSSProperties } from "react";
+import { Select } from "@fleet-console/sdk/react/browser";
 import { defineSettingsSection } from "@fleet-console/sdk/settings/browser";
 
 import {
@@ -232,16 +233,14 @@ function CarrierSettingsSection() {
                 <div className="terminal-carriers-runtime">
                   <div className="terminal-carriers-runtime-row terminal-carriers-runtime-row--cli">
                     <div className="terminal-carriers-field terminal-carriers-field--wide">
-                      <label className="terminal-carriers-label" htmlFor="carrier-cli">CLI</label>
-                      <select
-                        id="carrier-cli"
-                        className="terminal-carriers-select"
+                      <span className="terminal-carriers-label" id="carrier-cli-label">CLI</span>
+                      <Select
+                        aria-labelledby="carrier-cli-label"
                         value={activePendingSelections.cli ?? activeCarrier.cliType}
                         disabled={isSaving}
-                        onChange={(event) => void handleCliChange(event.target.value)}
-                      >
-                        {settings.options.cliTypes.map((cli) => <option key={cli.id} value={cli.id}>{cli.displayName}</option>)}
-                      </select>
+                        options={settings.options.cliTypes.map((cli) => ({ value: cli.id, label: cli.displayName }))}
+                        onChange={(cliType) => void handleCliChange(cliType)}
+                      />
                     </div>
                   </div>
                   <div className="terminal-carriers-runtime-row terminal-carriers-runtime-row--model">

--- a/runtime/fleet-plugins/terminal/client/carriers/section.tsx
+++ b/runtime/fleet-plugins/terminal/client/carriers/section.tsx
@@ -323,12 +323,17 @@ function EffortSelect({ id, model, value, disabled = false, onChange }: { readon
       </div>
     );
   }
+  const labelId = `${id}-label`;
   return (
     <div className="terminal-carriers-field">
-      <label className="terminal-carriers-label" htmlFor={id}>Effort</label>
-      <select id={id} className="terminal-carriers-select" value={value || model.effort.default} disabled={disabled} onChange={(event) => onChange(event.target.value)}>
-        {model.effort.levels.map((level) => <option key={level} value={level}>{level}</option>)}
-      </select>
+      <span className="terminal-carriers-label" id={labelId}>Effort</span>
+      <Select
+        aria-labelledby={labelId}
+        value={value || model.effort.default}
+        disabled={disabled}
+        options={model.effort.levels.map((level) => ({ value: level, label: level }))}
+        onChange={onChange}
+      />
     </div>
   );
 }

--- a/runtime/fleet-plugins/terminal/client/carriers/section.tsx
+++ b/runtime/fleet-plugins/terminal/client/carriers/section.tsx
@@ -504,9 +504,14 @@ function TaskForcePanel({
         })}
         <div className="terminal-carriers-tf-add-row">
           {addOpen && availableCliOptions.length > 0 ? (
-            <select className="terminal-carriers-select terminal-carriers-tf-add-select" value={selectedAddCliType} disabled={isSaving} onChange={(event) => setAddCliType(event.target.value)} aria-label="Task Force CLI to add">
-              {availableCliOptions.map((cli) => <option key={cli.id} value={cli.id}>{cli.displayName}</option>)}
-            </select>
+            <Select
+              className="terminal-carriers-tf-add-select"
+              label="Task Force CLI to add"
+              value={selectedAddCliType}
+              disabled={isSaving}
+              options={availableCliOptions.map((cli) => ({ value: cli.id, label: cli.displayName }))}
+              onChange={(cliId) => setAddCliType(cliId)}
+            />
           ) : null}
           <button type="button" className="terminal-carriers-ghost-button" disabled={availableCliOptions.length === 0 || isSaving} onClick={() => {
             if (!addOpen) {

--- a/runtime/fleet-plugins/terminal/client/carriers/section.tsx
+++ b/runtime/fleet-plugins/terminal/client/carriers/section.tsx
@@ -299,12 +299,17 @@ function CarrierChip({ carrier, active, minBackends, onSelect }: { readonly carr
 }
 
 function ModelSelect({ id, label, models, value, disabled = false, onChange }: { readonly id: string; readonly label: string; readonly models: readonly CarrierSettingsModelOption[]; readonly value: string; readonly disabled?: boolean; readonly onChange: (modelId: string) => void }) {
+  const labelId = `${id}-label`;
   return (
     <div className="terminal-carriers-field">
-      <label className="terminal-carriers-label" htmlFor={id}>{label}</label>
-      <select id={id} className="terminal-carriers-select" value={value} disabled={disabled} onChange={(event) => onChange(event.target.value)}>
-        {models.map((model) => <option key={model.modelId} value={model.modelId}>{model.name}</option>)}
-      </select>
+      <span className="terminal-carriers-label" id={labelId}>{label}</span>
+      <Select
+        aria-labelledby={labelId}
+        value={value}
+        disabled={disabled}
+        options={models.map((model) => ({ value: model.modelId, label: model.name }))}
+        onChange={onChange}
+      />
     </div>
   );
 }

--- a/runtime/fleet-plugins/terminal/client/carriers/styles.css
+++ b/runtime/fleet-plugins/terminal/client/carriers/styles.css
@@ -308,8 +308,7 @@
   grid-template-columns: minmax(0, 1.5fr) minmax(0, 0.85fr);
 }
 
-.terminal-carriers-input,
-.terminal-carriers-select {
+.terminal-carriers-input {
   width: 100%;
   min-height: 42px;
   border: 1px solid var(--surface-rim);
@@ -318,9 +317,6 @@
   color: var(--ink-pearl);
   font: 600 13px/1.2 var(--font-body);
   box-shadow: inset 0 1px 0 color-mix(in oklch, var(--ink-pearl) 5%, transparent);
-}
-
-.terminal-carriers-input {
   padding: 0 13px;
 }
 
@@ -333,12 +329,7 @@
   letter-spacing: -0.03em;
 }
 
-.terminal-carriers-select {
-  padding: 0 11px;
-}
-
-.terminal-carriers-input:focus,
-.terminal-carriers-select:focus {
+.terminal-carriers-input:focus {
   border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim));
   outline: none;
   box-shadow: 0 0 0 2px color-mix(in oklch, var(--brass) 18%, transparent);

--- a/runtime/fleet-plugins/terminal/tests/carrier-settings-client.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/carrier-settings-client.test.ts
@@ -163,9 +163,7 @@ describe("Terminal Carrier Settings client", () => {
     selectCarrierSettingsCarrier("nimitz");
     await renderCarrierSettings();
 
-    const model = requiredSelect("#carrier-model");
-    model.value = "gpt-5-mini";
-    await act(async () => model.dispatchEvent(new Event("change", { bubbles: true })));
+    await chooseSelectOption("#carrier-model", "GPT-5 mini");
     await waitForRequest(fetch, "PATCH");
 
     expect(mutationCalls(fetch)).toEqual([
@@ -183,9 +181,7 @@ describe("Terminal Carrier Settings client", () => {
     selectCarrierSettingsCarrier("nimitz");
     await renderCarrierSettings();
 
-    const cli = requiredSelect("#carrier-cli");
-    cli.value = "claude";
-    await act(async () => cli.dispatchEvent(new Event("change", { bubbles: true })));
+    await chooseSelectOption("#carrier-cli", "Claude");
     await waitForRequest(fetch, "PATCH");
 
     expect(mutationCalls(fetch)).toEqual([
@@ -203,16 +199,14 @@ describe("Terminal Carrier Settings client", () => {
     selectCarrierSettingsCarrier("nimitz");
     await renderCarrierSettings();
 
-    const cli = requiredSelect("#carrier-cli");
-    cli.value = "claude";
-    await act(async () => cli.dispatchEvent(new Event("change", { bubbles: true })));
-    expect(cli.value).toBe("claude");
+    await chooseSelectOption("#carrier-cli", "Claude");
+    expect(displayedSelectLabel("#carrier-cli")).toBe("Claude");
 
     const kirov = [...container!.querySelectorAll<HTMLButtonElement>(".terminal-carriers-chip")]
       .find((chip) => chip.textContent?.includes("Kirov"));
     if (!kirov) throw new Error("Kirov chip must render.");
     await act(async () => kirov.dispatchEvent(new MouseEvent("click", { bubbles: true })));
-    expect(requiredSelect("#carrier-cli").value).toBe("codex");
+    expect(displayedSelectLabel("#carrier-cli")).toBe("Codex");
 
     await act(async () => {
       mutation.resolve(jsonResponse({ state: interactiveState }));
@@ -227,7 +221,7 @@ describe("Terminal Carrier Settings client", () => {
       }),
     ]);
     expect(container!.querySelector(".terminal-carriers-save-status")?.textContent).toBe("");
-    expect(requiredSelect("#carrier-cli").value).toBe("codex");
+    expect(displayedSelectLabel("#carrier-cli")).toBe("Codex");
   });
 
   it("keeps a pending model selected and reverts it after mutation failure", async () => {
@@ -237,18 +231,16 @@ describe("Terminal Carrier Settings client", () => {
     selectCarrierSettingsCarrier("nimitz");
     await renderCarrierSettings();
 
-    const model = requiredSelect("#carrier-model");
-    model.value = "gpt-5-mini";
-    await act(async () => model.dispatchEvent(new Event("change", { bubbles: true })));
-    expect(model.value).toBe("gpt-5-mini");
-    expect(model.disabled).toBe(true);
+    await chooseSelectOption("#carrier-model", "GPT-5 mini");
+    expect(displayedSelectLabel("#carrier-model")).toBe("GPT-5 mini");
+    expect(requiredSelectTrigger("#carrier-model").disabled).toBe(true);
 
     await act(async () => {
       mutation.resolve(new Response(JSON.stringify({ error: "mutation failed" }), { status: 500 }));
       await vi.waitFor(() => expect(getCarrierSettingsStoreState().savingActionId).toBeNull());
     });
 
-    expect(requiredSelect("#carrier-model").value).toBe("gpt-5");
+    expect(displayedSelectLabel("#carrier-model")).toBe("GPT-5");
     expect(getCarrierSettingsStoreState().error).toBe("mutation failed");
   });
 
@@ -258,9 +250,7 @@ describe("Terminal Carrier Settings client", () => {
     selectCarrierSettingsCarrier("nimitz");
     await renderCarrierSettings();
 
-    const model = requiredSelect("#tf-codex-model");
-    model.value = "gpt-5-mini";
-    await act(async () => model.dispatchEvent(new Event("change", { bubbles: true })));
+    await chooseSelectOption("#tf-codex-model", "GPT-5 mini");
     await waitForRequest(fetch, "PUT");
 
     expect(mutationCalls(fetch)).toEqual([
@@ -278,9 +268,7 @@ describe("Terminal Carrier Settings client", () => {
     selectCarrierSettingsCarrier("nimitz");
     await renderCarrierSettings();
 
-    const model = requiredSelect("#tf-claude-model");
-    model.value = "haiku";
-    await act(async () => model.dispatchEvent(new Event("change", { bubbles: true })));
+    await chooseSelectOption("#tf-claude-model", "Haiku");
     await waitForRequest(fetch, "PUT");
 
     expect(mutationCalls(fetch)).toEqual([
@@ -360,10 +348,38 @@ function actionButtonOrNull(label: string): HTMLButtonElement | null {
     .find((item) => item.textContent === label) ?? null;
 }
 
-function requiredSelect(selector: string): HTMLSelectElement {
-  const select = container!.querySelector<HTMLSelectElement>(selector);
-  if (!select) throw new Error(`${selector} select must render.`);
-  return select;
+function selectLabelId(selector: string): string {
+  const baseId = selector.startsWith("#") ? selector.slice(1) : selector;
+  return `${baseId}-label`;
+}
+
+function requiredSelectTrigger(selector: string): HTMLButtonElement {
+  const labelId = selectLabelId(selector);
+  const root = container!.querySelector<HTMLElement>(`[aria-labelledby="${labelId}"]`);
+  if (!root) throw new Error(`${selector} select must render.`);
+  const trigger = root.querySelector<HTMLButtonElement>(".fc-select__trigger");
+  if (!trigger) throw new Error(`${selector} select trigger must render.`);
+  expect(trigger.getAttribute("aria-haspopup")).toBe("listbox");
+  return trigger;
+}
+
+function displayedSelectLabel(selector: string): string {
+  const labelId = selectLabelId(selector);
+  const root = container!.querySelector<HTMLElement>(`[aria-labelledby="${labelId}"]`);
+  return root?.querySelector(".fc-select__value")?.textContent?.trim() ?? "";
+}
+
+async function chooseSelectOption(selector: string, optionLabel: string): Promise<void> {
+  const trigger = requiredSelectTrigger(selector);
+  await act(async () => trigger.click());
+  const listboxId = trigger.getAttribute("aria-controls");
+  if (!listboxId) throw new Error(`${selector} trigger must expose aria-controls.`);
+  const listbox = document.getElementById(listboxId);
+  if (!listbox || listbox.getAttribute("role") !== "listbox") throw new Error(`${selector} listbox must open.`);
+  const option = [...listbox.querySelectorAll<HTMLLIElement>('[role="option"]')]
+    .find((item) => item.textContent?.trim() === optionLabel);
+  if (!option) throw new Error(`Option ${optionLabel} must render for ${selector}.`);
+  await act(async () => option.click());
 }
 
 function jsonResponse(payload: unknown): Response {

--- a/runtime/fleet-plugins/terminal/tests/carrier-settings-client.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/carrier-settings-client.test.ts
@@ -355,9 +355,8 @@ function selectLabelId(selector: string): string {
 
 function requiredSelectTrigger(selector: string): HTMLButtonElement {
   const labelId = selectLabelId(selector);
-  const root = container!.querySelector<HTMLElement>(`[aria-labelledby="${labelId}"]`);
-  if (!root) throw new Error(`${selector} select must render.`);
-  const trigger = root.querySelector<HTMLButtonElement>(".fc-select__trigger");
+  // ARIA 계약: 외부 라벨의 aria-labelledby는 트리거 본인이 소유한다(래퍼가 아님).
+  const trigger = container!.querySelector<HTMLButtonElement>(`.fc-select__trigger[aria-labelledby="${labelId}"]`);
   if (!trigger) throw new Error(`${selector} select trigger must render.`);
   expect(trigger.getAttribute("aria-haspopup")).toBe("listbox");
   return trigger;
@@ -365,8 +364,8 @@ function requiredSelectTrigger(selector: string): HTMLButtonElement {
 
 function displayedSelectLabel(selector: string): string {
   const labelId = selectLabelId(selector);
-  const root = container!.querySelector<HTMLElement>(`[aria-labelledby="${labelId}"]`);
-  return root?.querySelector(".fc-select__value")?.textContent?.trim() ?? "";
+  const trigger = container!.querySelector<HTMLElement>(`.fc-select__trigger[aria-labelledby="${labelId}"]`);
+  return trigger?.querySelector(".fc-select__value")?.textContent?.trim() ?? "";
 }
 
 async function chooseSelectOption(selector: string, optionLabel: string): Promise<void> {


### PR DESCRIPTION
## Summary
- OS 네이티브 `<select>`를 SDK 공용 `<Select>`/`useSelect`(ARIA select-only combobox, body portal, controlled)로 전수 교체 — 다크 테마에서 UA 팝업이 흰 텍스트 on 회색 배경으로 깨지던 시인성 결함 근본 해소 (Terminal 9, Repository Compare 1, What's New 1, Cowork 1, SDK SettingsSelect 1 = 13개소; Repository Scan Depth는 canary의 스테퍼 리디자인이 동일 결함을 선해결하여 리베이스에서 병합 제외)
- `@fleet-console/sdk/react/browser` 기등록 subpath 재수출(export map·shim 등록 파일 무수정), `.fc-select*` 문법은 core `components.css` 단독 소유(토큰 전용·3테마), 외부 플러그인도 shim으로 소비 가능
- 디자인 계약 테스트에 `.fc-select*` 핀 + 제품 표면 원시 `<select>` AST 스캐너 금지 추가, 외부 플러그인 소비 가이드 문서화

## Test Plan
- [x] SDK/Console/Plugins typecheck·build, 접촉 스위트 72/73 (1건은 canary 베이스라인 환경 이슈로 실증)
- [x] Sentinel 코드 리뷰 3라운드 (High 1 해소, Medium 6 전량 해소, 최종 PASS)
- [x] 실브라우저 QA 2라운드 (격리 Console, 키보드 계약·typeahead·disabled·상향 flip·3테마·Esc 체인·클리핑, diagnostics 0) — Windows ARM64 x64 에뮬레이션
- [x] canary #349–#353 리베이스 충돌 5건 양측 통합 해소 + 사후 검증 (repository/terminal/console, 잔여 실패 전부 canary 베이스라인 재현 확인)
- [x] Changelog: `.changelog.d/pr-354.md` (bilingual, compiler 검증 통과)