### PR TITLE
fix(console): stop the rail spring from replaying on behavior toggle

### DIFF
--- a/.changelog.d/pr-355.md
+++ b/.changelog.d/pr-355.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Stop the right rail from replaying its open/close spring when the "Float over Map" behavior is toggled; the panel now stays frozen and only the Map reflows, in both directions.
+  ko: "Float over Map" 동작 전환 시 우측 레일이 오픈/클로즈 스프링을 재생하던 문제를 수정하여, 이제 양방향 모두 패널이 그대로 유지되고 Map만 리플로됩니다.

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -43,6 +43,7 @@ export function RightRail({ theaterId, api }: RightRailProps) {
   const railChromeExpanded = useRailChromeExpanded();
   const panelBehavior = useRailPanelBehavior();
   const previousRailChromeExpandedRef = useRef(railChromeExpanded);
+  const previousPanelBehaviorRef = useRef(panelBehavior);
   const pluginPanels = useRailPanels();
   const builtInPanels = BUILT_IN_RAIL_PANELS;
   const allPanels = [...builtInPanels, ...pluginPanels];
@@ -55,11 +56,28 @@ export function RightRail({ theaterId, api }: RightRailProps) {
   const [panelWidth, setPanelWidthState] = useState(readStoredPanelWidth);
   const panelWidthRef = useRef(panelWidth);
   const [isDragging, setIsDragging] = useState(false);
+  const [isSwitching, setIsSwitching] = useState(false);
 
   useLayoutEffect(() => {
     if (previousRailChromeExpandedRef.current && !railChromeExpanded) focusCommandBandToggleWhenPanelContainsActiveElement(rootRef.current, ".command-band-rail-toggle");
     previousRailChromeExpandedRef.current = railChromeExpanded;
   }, [railChromeExpanded]);
+
+  useLayoutEffect(() => {
+    if (previousPanelBehaviorRef.current === panelBehavior) return;
+    previousPanelBehaviorRef.current = panelBehavior;
+    setIsSwitching(true);
+
+    let releaseFrame: number | null = null;
+    const paintedFrame = window.requestAnimationFrame(() => {
+      releaseFrame = window.requestAnimationFrame(() => setIsSwitching(false));
+    });
+
+    return () => {
+      window.cancelAnimationFrame(paintedFrame);
+      if (releaseFrame !== null) window.cancelAnimationFrame(releaseFrame);
+    };
+  }, [panelBehavior]);
 
   const handleResizeDragStart = useCallback((e: React.PointerEvent) => {
     e.preventDefault();
@@ -98,7 +116,7 @@ export function RightRail({ theaterId, api }: RightRailProps) {
   return (
     <div
       ref={rootRef}
-      className={`right-rail${hasPanel ? " is-open" : ""}${railChromeExpanded ? " is-expanded" : " is-closed"}${isDragging ? " is-dragging" : ""}${panelBehavior === "overlay" ? " is-overlay" : ""}`}
+      className={`right-rail${hasPanel ? " is-open" : ""}${railChromeExpanded ? " is-expanded" : " is-closed"}${isDragging ? " is-dragging" : ""}${isSwitching ? " is-switching" : ""}${panelBehavior === "overlay" ? " is-overlay" : ""}`}
       data-rail-chrome={railChromeExpanded ? "expanded" : "closed"}
       role="complementary"
       aria-label="Activity Rail"

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -35,6 +35,12 @@
   overflow: visible;
 }
 
+/* 패널 behavior 전환의 한 painted frame에만 드래그 억제 패턴과 같은 의도로
+   rail·slot transition을 끊어 규칙 세트 교체가 오픈/클로즈 모션을 재생하지 않게 한다. */
+.right-rail.is-switching, .right-rail.is-switching .right-rail-panel-slot {
+  transition: none !important;
+}
+
 /* ── 패널 슬롯 ─────────────────────────────────────────────────────
    overflow:hidden + width 전환으로 spring 펼침/접힘을 구현한다.
    min-width는 애니메이션 중 내부 레이아웃 흔들림을 방지한다.        */

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -318,8 +318,10 @@ describe("Instrument core design contract", () => {
     const rightRail = source("rail/right-rail.tsx");
     const railStore = source("rail/rail-store.ts");
     expect(rail).toContain(".right-rail.is-overlay");
+    expect(rail).toContain(".right-rail.is-switching");
     expect(rightRail).toContain("useRailPanelBehavior");
     expect(rightRail).toContain("right-rail-float-toggle");
+    expect(rightRail).toContain("is-switching");
     expect(railStore).toContain("fleet-console.rail.panelBehavior");
   });
 


### PR DESCRIPTION
## Summary
- "Float over Map" 토글 시 우측 레일이 오픈/클로즈 스프링을 재생하던 결함을 수정합니다(canary 실측: overlay→push 슬롯 312→0→311px, 6/6 재현). 원인은 모드 전환 시 슬롯의 규칙 세트가 통째로 교첣되어(absolute+var fallback ↔ in-flow is-open) 전이 엔진이 base `width: 0`에서 재시작하는 것으로, MutationObserver로 이중 렌더·DOM 교체·var 플리커가 아님을 확인했습니다.
- `panelBehavior` 변경 시(초기 마운트 제외) `is-switching` 클래스를 한 painted frame(double rAF)만 부여하고, 대응 규칙으로 `.right-rail`·슬롯에 `transition: none !important`를 강제해 모드 스왑을 원자화합니다(기존 `is-dragging` 억제 패턴 동일).
- 결과: 패널은 양방향 픽셀 동결, Map만 즉시 리플로. 패널 오픈/클로즈 스프링·리사이즈 드래그·⌘⌥B 크롬 토글 불변. #341 후속입니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` green
- [x] `tests/instrument-design-contract.test.ts` + `tests/rail-store.test.ts` 43/43 green (is-switching 핀 추가)
- [x] console-e2e 실측: 토글 6/6 슬롯 최종폭 동결(311/312)·매 전환 `is-switching` 관측·stage 644↔956 즉시 스냅·오픈 스프링 0→311 정상(13프레임)·페이지 에러 0건
- [x] `.changelog.d/pr-355.md` — 프래그먼트 문법·이중언어 요약·컴파일러 검증 완료
