### PR TITLE
feat(repository): add Full Workspace expanded mode to the rail panel

### DIFF
--- a/.changelog.d/pr-356.md
+++ b/.changelog.d/pr-356.md
@@ -1,0 +1,6 @@
+### fleet-plugin
+
+#### Added
+
+- [fleet-console] Add a Full Workspace expanded mode to the Repository rail panel: a workspace toggle widens the panel in place and shows a persistent source tree (repository discovery, worktrees, branches, tags, stashes), an always-visible commit graph, and a bottom commit detail dock with file list and diff, while the compact panel keeps its existing layout.
+  ko: Repository 레일 패널에 Full Workspace 확장 모드를 추가합니다. 워크스페이스 토글로 패널이 제자리에서 넓게 확장되어 상시 소스 트리(저장소 검색, 워크트리, 브랜치, 태그, 스태시), 상주 커밋 그래프, 파일 목록과 diff를 담은 하단 커밋 상세 도크를 표시하며, 축소 상태의 패널은 기존 레이아웃을 유지합니다.

--- a/runtime/fleet-plugins/repository/client/history-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/history-panel.tsx
@@ -101,16 +101,17 @@ interface HistoryPanelProps {
   readonly wipFiles: readonly DiffFileEntry[];
   readonly workspace?: boolean;
   readonly workspaceMain?: ReactNode;
+  readonly workspaceMainVisible?: boolean;
   readonly onInspectorOpenChange?: (open: boolean) => void;
   readonly onClearRef?: () => void;
   readonly onWip?: () => void;
 }
 
-export function HistoryPanel({ ctx, repoRel, active = true, refFilter = null, wipFiles, workspace = false, workspaceMain, onInspectorOpenChange, onClearRef, onWip }: HistoryPanelProps) {
-  return <HistoryPanelBody key={`${ctx.theaterId ?? ""}:${repoRel}`} ctx={ctx} repoRel={repoRel} active={active} refFilter={refFilter} wipFiles={wipFiles} workspace={workspace} workspaceMain={workspaceMain} onInspectorOpenChange={onInspectorOpenChange} onClearRef={onClearRef} onWip={onWip} />;
+export function HistoryPanel({ ctx, repoRel, active = true, refFilter = null, wipFiles, workspace = false, workspaceMain, workspaceMainVisible = false, onInspectorOpenChange, onClearRef, onWip }: HistoryPanelProps) {
+  return <HistoryPanelBody key={`${ctx.theaterId ?? ""}:${repoRel}`} ctx={ctx} repoRel={repoRel} active={active} refFilter={refFilter} wipFiles={wipFiles} workspace={workspace} workspaceMain={workspaceMain} workspaceMainVisible={workspaceMainVisible} onInspectorOpenChange={onInspectorOpenChange} onClearRef={onClearRef} onWip={onWip} />;
 }
 
-function HistoryPanelBody({ ctx, repoRel, active, refFilter, wipFiles, workspace, workspaceMain, onInspectorOpenChange, onClearRef, onWip }: Required<Pick<HistoryPanelProps, "active" | "ctx" | "refFilter" | "repoRel" | "wipFiles" | "workspace">> & Pick<HistoryPanelProps, "workspaceMain" | "onInspectorOpenChange" | "onClearRef" | "onWip">) {
+function HistoryPanelBody({ ctx, repoRel, active, refFilter, wipFiles, workspace, workspaceMain, workspaceMainVisible, onInspectorOpenChange, onClearRef, onWip }: Required<Pick<HistoryPanelProps, "active" | "ctx" | "refFilter" | "repoRel" | "wipFiles" | "workspace" | "workspaceMainVisible">> & Pick<HistoryPanelProps, "workspaceMain" | "onInspectorOpenChange" | "onClearRef" | "onWip">) {
   const [state, setState] = useState<LoadState>({ kind: "loading" });
   const [target, setTarget] = useState<CommitTarget | null>(null);
   const [filterText, setFilterText] = useState("");
@@ -185,11 +186,11 @@ function HistoryPanelBody({ ctx, repoRel, active, refFilter, wipFiles, workspace
     ? workspace ? buildWorkspaceDockTemplate(dockHeight) : buildHistoryStackTemplate(logHeight)
     : undefined;
   return <div ref={rootRef} className={`history-root${workspace ? " repository-ws-history" : ""}${isDragging ? " is-dragging" : ""}`} style={stackTemplate ? { gridTemplateRows: stackTemplate } : undefined}>
-    <div className="history-list-pane" hidden={workspace && workspaceMain !== undefined}>
+    <div className="history-list-pane" hidden={workspace && workspaceMainVisible}>
       <div className="history-toolbar"><div className="history-filter"><input className="history-filter-input" placeholder="Filter…" value={filterText} onChange={(event) => setFilterText(event.target.value)} />{filterText && <button type="button" className="history-filter-clear" onClick={() => setFilterText("")}>✕</button>}</div>{refFilter && <button type="button" className="repository-ref-chip" onClick={onClearRef}>{refFilter} ✕</button>}{state.kind === "ok" && <span className="history-count">{filterText ? `${visible.length}/${state.commits.length}` : state.commits.length}</span>}</div>
       <div className="history-list">{showWip && <button type="button" className="repository-wip-row" onClick={onWip}>Uncommitted changes <span>{wip.files} files · +{wip.additions} −{wip.deletions}</span></button>}{state.kind === "loading" && <div className="history-empty">Loading…</div>}{state.kind === "error" && <div className="history-error">{state.message}<button type="button" className="repository-refresh-btn" onClick={() => setRefreshToken((value) => value + 1)}>Retry</button></div>}{state.kind === "ok" && state.commits.length === 0 && <div className="history-empty">No history</div>}{state.kind === "ok" && state.commits.length > 0 && visible.length === 0 && <div className="history-empty">No matching items</div>}{state.kind === "ok" && layout && visible.map((entry, index) => <CommitRow key={entry.fullHash} entry={entry} checkouts={state.checkouts} selected={target?.fullHash === entry.fullHash} graphNode={layout.nodes[index]!} onSelect={(selected) => setTarget({ fullHash: selected.fullHash, entry: selected })} />)}{state.kind === "ok" && (state.truncated || state.commits.length >= 200) && <div className="history-truncated">History capped at 200 commits.</div>}</div>
     </div>
-    {workspaceMain !== undefined && <div className="repository-ws-main">{workspaceMain}</div>}
+    {workspaceMain !== undefined && <div className="repository-ws-main" hidden={!workspaceMainVisible}>{workspaceMain}</div>}
     {target && <><div className="history-divider history-divider--horizontal" role="separator" aria-orientation="horizontal" aria-label={workspace ? "Resize commit detail dock" : "Resize commit log"} onPointerDown={handleDivider} /><div className="history-detail-pane"><CommitInspector ctx={ctx} repoRel={repoRel} target={target} workspace={workspace} onSelectCommit={setTarget} onClose={() => setTarget(null)} /></div></>}
   </div>;
 }

--- a/runtime/fleet-plugins/repository/client/history-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/history-panel.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
-import type { RailPanelContext, RailPanelDescriptor } from "@fleet-console/sdk/rail";
+import type { RailPanelContext } from "@fleet-console/sdk/rail";
 
 import type { CommitResult, DiffFileEntry, LogCommitEntry, LogResult, WorktreeCheckout } from "../server/types.js";
 import { FileRow } from "./changed-files.js";
@@ -10,13 +10,13 @@ import { layoutGraph } from "./graph-layout.js";
 import { HunkView } from "./hunk-view.js";
 import { formatCommitTime, refBadges } from "./log-parse.js";
 import { DIFF_DIVIDER_WIDTH, HISTORY_DETAIL_PANE_MIN_HEIGHT, HISTORY_LOG_PANE_MIN_HEIGHT, buildHistoryStackTemplate, buildInspectorChangesGridTemplate, buildInspectorDetailsGridTemplate, clampSplitPaneSize, installPointerDragLifecycle } from "./rail-layout.js";
+import { buildWorkspaceDockTemplate, clampWorkspaceDockHeight, readWorkspaceDockHeight, saveWorkspaceDockHeight } from "./workspace-layout.js";
 
 type LoadState = { readonly kind: "loading" } | { readonly kind: "ok"; readonly commits: readonly LogCommitEntry[]; readonly checkouts: readonly WorktreeCheckout[]; readonly truncated: boolean } | { readonly kind: "error"; readonly message: string };
 type CommitTarget = { readonly fullHash: string; readonly entry?: LogCommitEntry };
 type InspectorState = { readonly kind: "loading" } | { readonly kind: "ok"; readonly result: CommitResult } | { readonly kind: "error"; readonly message: string };
 type FilesViewMode = "list" | "tree";
 
-const EXTENDED_EXTRA_WIDTH = 400;
 const PREFS_LOG_PANE_HEIGHT = "fleet-console.history.logHeight";
 const PREFS_HEADER_HEIGHT = "fleet-console.history.headerHeight";
 const PREFS_FILE_LIST_WIDTH = "fleet-console.history.fileListWidth";
@@ -42,7 +42,7 @@ function CommitRow({ entry, checkouts, selected, graphNode, onSelect }: { readon
   return <button type="button" className={`history-commit-row${selected ? " is-selected" : ""}${entry.onHead ? "" : " is-off-head"}`} onClick={() => onSelect(entry)}><span className="history-commit-subject">{entry.subject}</span><span className="history-commit-sha">{entry.shortHash}</span><span className="history-commit-time">{formatCommitTime(entry.authorAt)}</span><span className="history-commit-badges">{badges.map((badge) => { const checkout = badge.kind === "branch" ? checkouts.find((item) => item.branch === badge.label) : null; return <span key={`${badge.kind}:${badge.label}`} className={`history-badge history-badge--${badge.kind}`}>{checkout && <CheckoutIcon current={checkout.isCurrent} />}{badge.label}</span>; })}{detached && <span className="history-badge history-badge--worktree"><CheckoutIcon current={detached.isCurrent} />detached</span>}</span><span className="history-graph-gutter" aria-hidden="true"><GraphGutter node={graphNode} /></span></button>;
 }
 
-function CommitInspector({ ctx, repoRel, target, onSelectCommit, onClose }: { readonly ctx: RailPanelContext; readonly repoRel: string; readonly target: CommitTarget; readonly onSelectCommit: (target: CommitTarget) => void; readonly onClose: () => void }) {
+function CommitInspector({ ctx, repoRel, target, workspace, onSelectCommit, onClose }: { readonly ctx: RailPanelContext; readonly repoRel: string; readonly target: CommitTarget; readonly workspace: boolean; readonly onSelectCommit: (target: CommitTarget) => void; readonly onClose: () => void }) {
   const [state, setState] = useState<InspectorState>({ kind: "loading" }); const [tab, setTab] = useState<"details" | "changes">("details"); const [selectedPath, setSelectedPath] = useState<string | null>(null); const [copied, setCopied] = useState(false);
   const [headerHeight, setHeaderHeight] = useState(() => readSize(PREFS_HEADER_HEIGHT, HEADER_DEFAULT_HEIGHT)); const [fileListWidth, setFileListWidth] = useState(() => readSize(PREFS_FILE_LIST_WIDTH, FILE_LIST_DEFAULT_WIDTH));
   const [filesView, setFilesView] = useState<FilesViewMode>(readFilesViewMode);
@@ -51,27 +51,133 @@ function CommitInspector({ ctx, repoRel, target, onSelectCommit, onClose }: { re
   useEffect(() => { let cancelled = false; setState({ kind: "loading" }); ctx.api.fetch("repository", "commit", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ theaterId: ctx.theaterId, repoRel, ref: target.fullHash }) }).then(async (response) => { if (!response.ok) throw new Error((await response.json() as { readonly error?: string }).error ?? "git_failed"); return response.json() as Promise<CommitResult>; }).then((result) => { if (!cancelled) { setState({ kind: "ok", result }); setSelectedPath(result.files[0]?.path ?? null); } }).catch((error: unknown) => { if (!cancelled) setState({ kind: "error", message: error instanceof Error ? error.message : "unknown" }); }); return () => { cancelled = true; }; }, [ctx.api, ctx.theaterId, repoRel, target.fullHash]);
   useEffect(() => () => disposeRef.current?.(), []);
   const startDrag = useCallback((event: React.PointerEvent<HTMLDivElement>, axis: "x" | "y") => { event.preventDefault(); const container = axis === "y" ? detailsRef.current : changesRef.current; if (!container) return; const start = axis === "y" ? headerHeightRef.current : fileListWidthRef.current; const startPointer = axis === "y" ? event.clientY : event.clientX; const size = axis === "y" ? container.getBoundingClientRect().height : container.getBoundingClientRect().width; disposeRef.current?.(); disposeRef.current = installPointerDragLifecycle({ documentTarget: document, windowTarget: window, onMove: (moveEvent) => { const move = moveEvent as PointerEvent; const next = clampSplitPaneSize(start, (axis === "y" ? move.clientY : move.clientX) - startPointer, size, 120, 120); if (next !== null) { if (axis === "y") { headerHeightRef.current = next; setHeaderHeight(next); } else { fileListWidthRef.current = next; setFileListWidth(next); } } }, onFinish: () => { const value = axis === "y" ? headerHeightRef.current : fileListWidthRef.current; try { localStorage.setItem(axis === "y" ? PREFS_HEADER_HEIGHT : PREFS_FILE_LIST_WIDTH, String(value)); } catch { /* ignore */ } disposeRef.current = null; } }); }, []);
-  const content = state.kind === "loading" ? <div className="history-inspector-empty">Loading commit…</div> : state.kind === "error" ? <div className="history-inspector-empty history-inspector-error">{state.message}</div> : (() => { const { meta, files } = state.result; const selectedFile = files.find((file) => file.path === selectedPath) ?? files[0] ?? null; const additions = files.reduce((sum, file) => sum + file.additions, 0); const deletions = files.reduce((sum, file) => sum + file.deletions, 0); const entry = target.entry; const chooseFile = (file: DiffFileEntry, showChanges: boolean) => { setSelectedPath(file.path); if (showChanges) setTab("changes"); }; const chooseFilesView = (next: FilesViewMode) => { setFilesView(next); try { localStorage.setItem(PREFS_FILES_VIEW, next); } catch { /* ignore */ } }; const copySha = () => { const copiedPromise = navigator.clipboard?.writeText(target.fullHash); if (!copiedPromise) return; void copiedPromise.then(() => { setCopied(true); window.setTimeout(() => setCopied(false), 1200); }).catch(() => undefined); }; return tab === "details" ? <div ref={detailsRef} className="history-details-tab" style={{ gridTemplateRows: buildInspectorDetailsGridTemplate(headerHeight) }}><CommitHeader meta={meta} entry={entry} fullHash={target.fullHash} copied={copied} onCopy={copySha} onParent={(full) => onSelectCommit({ fullHash: full })} /><div className="history-divider history-divider--horizontal" onPointerDown={(event) => startDrag(event, "y")} /><CommitFiles files={files} selectedPath={selectedPath} additions={additions} deletions={deletions} viewMode={filesView} onViewMode={chooseFilesView} onSelect={(file) => chooseFile(file, true)} /></div> : <div className="history-changes-tab"><div ref={changesRef} className="history-changes-columns" style={{ gridTemplateColumns: buildInspectorChangesGridTemplate(fileListWidth) }}><CommitFiles files={files} selectedPath={selectedPath} additions={additions} deletions={deletions} viewMode={filesView} onViewMode={chooseFilesView} onSelect={(file) => chooseFile(file, false)} /><div className="history-divider" onPointerDown={(event) => startDrag(event, "x")} />{selectedFile ? <div className="history-file-diff"><div className="history-file-repository-head"><span title={selectedFile.path}>{selectedFile.path}</span><div><button type="button" aria-label="Previous file" disabled={files.indexOf(selectedFile) === 0} onClick={() => chooseFile(files[files.indexOf(selectedFile) - 1]!, false)}>‹</button><button type="button" aria-label="Next file" disabled={files.indexOf(selectedFile) === files.length - 1} onClick={() => chooseFile(files[files.indexOf(selectedFile) + 1]!, false)}>›</button></div></div><HunkView ctx={ctx} repoRel={repoRel} file={selectedFile} mode="unified" commit={commit} /></div> : <div className="history-inspector-empty">No changed files</div>}</div></div>; })();
-  return <div className="history-inspector" onKeyDown={(event) => { if (isInspectorDismissKey(event.key)) { event.preventDefault(); onClose(); } }}><div className="history-segmented"><button type="button" aria-pressed={tab === "details"} onClick={() => setTab("details")}>Details</button><button type="button" aria-pressed={tab === "changes"} onClick={() => setTab("changes")}>Changes {state.kind === "ok" && <span>{state.result.files.length}</span>}</button><button type="button" className="history-detail-close history-inspector-close" aria-label="Close inspector" title="Close inspector" onClick={onClose}>✕</button></div>{content}</div>;
+  const content = state.kind === "loading" ? <div className="history-inspector-empty">Loading commit…</div> : state.kind === "error" ? <div className="history-inspector-empty history-inspector-error">{state.message}</div> : (() => {
+    const { meta, files } = state.result;
+    const selectedFile = files.find((file) => file.path === selectedPath) ?? files[0] ?? null;
+    const additions = files.reduce((sum, file) => sum + file.additions, 0);
+    const deletions = files.reduce((sum, file) => sum + file.deletions, 0);
+    const entry = target.entry;
+    const chooseFile = (file: DiffFileEntry, showChanges: boolean) => {
+      setSelectedPath(file.path);
+      if (showChanges) setTab("changes");
+    };
+    const chooseFilesView = (next: FilesViewMode) => {
+      setFilesView(next);
+      try { localStorage.setItem(PREFS_FILES_VIEW, next); } catch { /* ignore */ }
+    };
+    const copySha = () => {
+      const copiedPromise = navigator.clipboard?.writeText(target.fullHash);
+      if (!copiedPromise) return;
+      void copiedPromise.then(() => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1200);
+      }).catch(() => undefined);
+    };
+    if (workspace) {
+      return <div className="repository-ws-dock">
+        <CommitFiles files={files} selectedPath={selectedPath} additions={additions} deletions={deletions} viewMode={filesView} onViewMode={chooseFilesView} onSelect={(file) => chooseFile(file, false)} />
+        <div className="repository-ws-dock-main">
+          <div className="repository-ws-dock-meta">
+            <CommitHeader meta={meta} entry={entry} fullHash={target.fullHash} copied={copied} onCopy={copySha} onParent={(full) => onSelectCommit({ fullHash: full })} />
+            <button type="button" className="history-detail-close repository-ws-dock-close" aria-label="Close inspector" title="Close inspector" onClick={onClose}>✕</button>
+          </div>
+          {selectedFile ? <div className="history-file-diff"><div className="history-file-repository-head"><span title={selectedFile.path}>{selectedFile.path}</span><div><button type="button" aria-label="Previous file" disabled={files.indexOf(selectedFile) === 0} onClick={() => chooseFile(files[files.indexOf(selectedFile) - 1]!, false)}>‹</button><button type="button" aria-label="Next file" disabled={files.indexOf(selectedFile) === files.length - 1} onClick={() => chooseFile(files[files.indexOf(selectedFile) + 1]!, false)}>›</button></div></div><HunkView ctx={ctx} repoRel={repoRel} file={selectedFile} mode="unified" commit={commit} /></div> : <div className="history-inspector-empty">No changed files</div>}
+        </div>
+      </div>;
+    }
+    return tab === "details" ? <div ref={detailsRef} className="history-details-tab" style={{ gridTemplateRows: buildInspectorDetailsGridTemplate(headerHeight) }}><CommitHeader meta={meta} entry={entry} fullHash={target.fullHash} copied={copied} onCopy={copySha} onParent={(full) => onSelectCommit({ fullHash: full })} /><div className="history-divider history-divider--horizontal" onPointerDown={(event) => startDrag(event, "y")} /><CommitFiles files={files} selectedPath={selectedPath} additions={additions} deletions={deletions} viewMode={filesView} onViewMode={chooseFilesView} onSelect={(file) => chooseFile(file, true)} /></div> : <div className="history-changes-tab"><div ref={changesRef} className="history-changes-columns" style={{ gridTemplateColumns: buildInspectorChangesGridTemplate(fileListWidth) }}><CommitFiles files={files} selectedPath={selectedPath} additions={additions} deletions={deletions} viewMode={filesView} onViewMode={chooseFilesView} onSelect={(file) => chooseFile(file, false)} /><div className="history-divider" onPointerDown={(event) => startDrag(event, "x")} />{selectedFile ? <div className="history-file-diff"><div className="history-file-repository-head"><span title={selectedFile.path}>{selectedFile.path}</span><div><button type="button" aria-label="Previous file" disabled={files.indexOf(selectedFile) === 0} onClick={() => chooseFile(files[files.indexOf(selectedFile) - 1]!, false)}>‹</button><button type="button" aria-label="Next file" disabled={files.indexOf(selectedFile) === files.length - 1} onClick={() => chooseFile(files[files.indexOf(selectedFile) + 1]!, false)}>›</button></div></div><HunkView ctx={ctx} repoRel={repoRel} file={selectedFile} mode="unified" commit={commit} /></div> : <div className="history-inspector-empty">No changed files</div>}</div></div>;
+  })();
+  return <div className={`history-inspector${workspace ? " repository-ws-inspector" : ""}`} onKeyDown={(event) => { if (isInspectorDismissKey(event.key)) { event.preventDefault(); onClose(); } }}>{workspace ? content : <><div className="history-segmented"><button type="button" aria-pressed={tab === "details"} onClick={() => setTab("details")}>Details</button><button type="button" aria-pressed={tab === "changes"} onClick={() => setTab("changes")}>Changes {state.kind === "ok" && <span>{state.result.files.length}</span>}</button><button type="button" className="history-detail-close history-inspector-close" aria-label="Close inspector" title="Close inspector" onClick={onClose}>✕</button></div>{content}</>}</div>;
 }
 
 function CommitHeader({ meta, entry, fullHash, copied, onCopy, onParent }: { readonly meta: CommitResult["meta"]; readonly entry?: LogCommitEntry; readonly fullHash: string; readonly copied: boolean; readonly onCopy: () => void; readonly onParent: (full: string) => void }) { return <div className="history-inspector-head"><div className="history-inspector-subject">{meta.subject}</div>{meta.body && <pre className="history-inspector-message">{meta.body}</pre>}<div className="history-author"><span className="history-avatar">{initials(meta.authorName)}</span><span><b>{meta.authorName}</b><small>{meta.authorEmail}</small></span><time title={new Date(meta.authorAt * 1000).toLocaleString()}>{entry?.relTime ?? formatCommitTime(meta.authorAt)}</time></div><div className="history-inspector-ids"><button type="button" className={`history-sha-copy${copied ? " is-copied" : ""}`} onClick={onCopy}>{fullHash}<span>{copied ? "copied" : "copy"}</span></button>{meta.parents.map((parent) => <button type="button" className="history-parent" key={parent.full} onClick={() => onParent(parent.full)}>parent {parent.short}</button>)}</div>{entry && <div className="history-ref-chips">{refBadges(entry).map((badge) => <span key={`${badge.kind}:${badge.label}`} className={`history-badge history-badge--${badge.kind}`}>{badge.label}</span>)}</div>}</div>; }
 function CommitFiles({ files, selectedPath, additions, deletions, viewMode, onViewMode, onSelect }: { readonly files: readonly DiffFileEntry[]; readonly selectedPath: string | null; readonly additions: number; readonly deletions: number; readonly viewMode: FilesViewMode; readonly onViewMode: (mode: FilesViewMode) => void; readonly onSelect: (file: DiffFileEntry) => void }) { return <section className="history-commit-files"><div className="history-files-title"><span className="history-files-label">Changed files</span><span className="history-files-stats">{files.length} <i>+{additions}</i> <em>−{deletions}</em></span><div className="repository-view-toggle history-files-view-toggle"><button type="button" className={`repository-toggle-btn${viewMode === "list" ? " is-active" : ""}`} title="List view" aria-label="List view" aria-pressed={viewMode === "list"} onClick={() => onViewMode("list")}><svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><line x1="2" y1="3.5" x2="12" y2="3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" /><line x1="2" y1="7" x2="12" y2="7" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" /><line x1="2" y1="10.5" x2="12" y2="10.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" /></svg></button><button type="button" className={`repository-toggle-btn${viewMode === "tree" ? " is-active" : ""}`} title="Tree view" aria-label="Tree view" aria-pressed={viewMode === "tree"} onClick={() => onViewMode("tree")}><svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><rect x="1" y="1" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /><rect x="9" y="1" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /><rect x="1" y="9" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /><rect x="9" y="9" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /></svg></button></div></div><div className="history-files-scroll">{viewMode === "tree" ? <DiffTreeView files={files} selectedPath={selectedPath} onSelect={onSelect} /> : files.map((file) => <FileRow key={file.path} entry={file} isSelected={file.path === selectedPath} onSelect={onSelect} />)}</div></section>; }
 
-export function HistoryPanel({ ctx, repoRel, active = true, refFilter = null, wipFiles, onInspectorOpenChange, onClearRef, onWip }: { readonly ctx: RailPanelContext; readonly repoRel: string; readonly active?: boolean; readonly refFilter?: string | null; readonly wipFiles: readonly DiffFileEntry[]; readonly onInspectorOpenChange?: (open: boolean) => void; readonly onClearRef?: () => void; readonly onWip?: () => void }) { return <HistoryPanelBody key={`${ctx.theaterId ?? ""}:${repoRel}`} ctx={ctx} repoRel={repoRel} active={active} refFilter={refFilter} wipFiles={wipFiles} onInspectorOpenChange={onInspectorOpenChange} onClearRef={onClearRef} onWip={onWip} />; }
-function HistoryPanelBody({ ctx, repoRel, active, refFilter, wipFiles, onInspectorOpenChange, onClearRef, onWip }: { readonly ctx: RailPanelContext; readonly repoRel: string; readonly active: boolean; readonly refFilter: string | null; readonly wipFiles: readonly DiffFileEntry[]; readonly onInspectorOpenChange?: (open: boolean) => void; readonly onClearRef?: () => void; readonly onWip?: () => void }) {
-  const [state, setState] = useState<LoadState>({ kind: "loading" }); const [target, setTarget] = useState<CommitTarget | null>(null); const [filterText, setFilterText] = useState(""); const [refreshToken, setRefreshToken] = useState(0); const [logHeight, setLogHeight] = useState(readLogPaneHeight); const [isDragging, setIsDragging] = useState(false); const rootRef = useRef<HTMLDivElement>(null); const dragDisposeRef = useRef<(() => void) | null>(null); const logHeightRef = useRef(logHeight);
+interface HistoryPanelProps {
+  readonly ctx: RailPanelContext;
+  readonly repoRel: string;
+  readonly active?: boolean;
+  readonly refFilter?: string | null;
+  readonly wipFiles: readonly DiffFileEntry[];
+  readonly workspace?: boolean;
+  readonly workspaceMain?: ReactNode;
+  readonly onInspectorOpenChange?: (open: boolean) => void;
+  readonly onClearRef?: () => void;
+  readonly onWip?: () => void;
+}
+
+export function HistoryPanel({ ctx, repoRel, active = true, refFilter = null, wipFiles, workspace = false, workspaceMain, onInspectorOpenChange, onClearRef, onWip }: HistoryPanelProps) {
+  return <HistoryPanelBody key={`${ctx.theaterId ?? ""}:${repoRel}`} ctx={ctx} repoRel={repoRel} active={active} refFilter={refFilter} wipFiles={wipFiles} workspace={workspace} workspaceMain={workspaceMain} onInspectorOpenChange={onInspectorOpenChange} onClearRef={onClearRef} onWip={onWip} />;
+}
+
+function HistoryPanelBody({ ctx, repoRel, active, refFilter, wipFiles, workspace, workspaceMain, onInspectorOpenChange, onClearRef, onWip }: Required<Pick<HistoryPanelProps, "active" | "ctx" | "refFilter" | "repoRel" | "wipFiles" | "workspace">> & Pick<HistoryPanelProps, "workspaceMain" | "onInspectorOpenChange" | "onClearRef" | "onWip">) {
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+  const [target, setTarget] = useState<CommitTarget | null>(null);
+  const [filterText, setFilterText] = useState("");
+  const [refreshToken, setRefreshToken] = useState(0);
+  const [logHeight, setLogHeight] = useState(readLogPaneHeight);
+  const [dockHeight, setDockHeight] = useState(readWorkspaceDockHeight);
+  const [isDragging, setIsDragging] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const dragDisposeRef = useRef<(() => void) | null>(null);
+  const logHeightRef = useRef(logHeight);
+  const dockHeightRef = useRef(dockHeight);
   useEffect(() => { setTarget(null); }, [refFilter]);
   // 숨은 마운트는 상태 보존용일 뿐이므로, 첫 활성화 전에는 log 조회 비용을 지불하지 않는다
   const [everActive, setEverActive] = useState(active);
   useEffect(() => { if (active) setEverActive(true); }, [active]);
   useEffect(() => { if (!everActive) return; if (!ctx.theaterId) { setState({ kind: "ok", commits: [], checkouts: [], truncated: false }); return; } let cancelled = false; setState({ kind: "loading" }); ctx.api.fetch("repository", "log", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ theaterId: ctx.theaterId, repoRel, ...(refFilter ? { ref: refFilter } : {}) }) }).then(async (response) => { if (!response.ok) throw new Error((await response.json() as { readonly error?: string }).error ?? "git_failed"); return response.json() as Promise<LogResult>; }).then((data) => { if (!cancelled) setState({ kind: "ok", commits: data.commits, checkouts: data.checkouts, truncated: data.truncated ?? false }); }).catch((error: unknown) => { if (!cancelled) setState({ kind: "error", message: error instanceof Error ? error.message : "unknown" }); }); return () => { cancelled = true; }; }, [ctx.api, ctx.theaterId, everActive, refreshToken, refFilter, repoRel]);
   useEffect(() => { onInspectorOpenChange?.(active && target !== null); }, [active, onInspectorOpenChange, target]); useEffect(() => () => dragDisposeRef.current?.(), []);
-  const handleDivider = useCallback((event: React.PointerEvent<HTMLDivElement>) => { event.preventDefault(); const root = rootRef.current; if (!root) return; const start = logHeightRef.current; const startY = event.clientY; const height = root.getBoundingClientRect().height; dragDisposeRef.current?.(); setIsDragging(true); dragDisposeRef.current = installPointerDragLifecycle({ documentTarget: document, windowTarget: window, onMove: (moveEvent) => { const next = clampSplitPaneSize(start, (moveEvent as PointerEvent).clientY - startY, height, HISTORY_LOG_PANE_MIN_HEIGHT, HISTORY_DETAIL_PANE_MIN_HEIGHT, DIFF_DIVIDER_WIDTH); if (next !== null) { logHeightRef.current = next; setLogHeight(next); } }, onFinish: () => { try { localStorage.setItem(PREFS_LOG_PANE_HEIGHT, String(logHeightRef.current)); } catch { /* ignore */ } setIsDragging(false); dragDisposeRef.current = null; } }); }, []);
+  const handleDivider = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const root = rootRef.current;
+    if (!root) return;
+    const start = workspace ? dockHeightRef.current : logHeightRef.current;
+    const startY = event.clientY;
+    const height = root.getBoundingClientRect().height;
+    dragDisposeRef.current?.();
+    setIsDragging(true);
+    dragDisposeRef.current = installPointerDragLifecycle({
+      documentTarget: document,
+      windowTarget: window,
+      onMove: (moveEvent) => {
+        const delta = (moveEvent as PointerEvent).clientY - startY;
+        const next = workspace
+          ? clampWorkspaceDockHeight(start, delta, height)
+          : clampSplitPaneSize(start, delta, height, HISTORY_LOG_PANE_MIN_HEIGHT, HISTORY_DETAIL_PANE_MIN_HEIGHT, DIFF_DIVIDER_WIDTH);
+        if (next === null) return;
+        if (workspace) {
+          dockHeightRef.current = next;
+          setDockHeight(next);
+        } else {
+          logHeightRef.current = next;
+          setLogHeight(next);
+        }
+      },
+      onFinish: () => {
+        if (workspace) saveWorkspaceDockHeight(dockHeightRef.current);
+        else {
+          try { localStorage.setItem(PREFS_LOG_PANE_HEIGHT, String(logHeightRef.current)); } catch { /* ignore */ }
+        }
+        setIsDragging(false);
+        dragDisposeRef.current = null;
+      },
+    });
+  }, [workspace]);
   const visible = useMemo(() => state.kind === "ok" ? filterHistoryCommits(state.commits, filterText) : [], [filterText, state]); const layout = state.kind === "ok" ? layoutGraph(visible) : null;
   const wip = useMemo(() => aggregateWip(wipFiles), [wipFiles]);
   const showWip = shouldShowWip(wip, filterText, refFilter);
-  return <div ref={rootRef} className={`history-root${isDragging ? " is-dragging" : ""}`} style={target ? { gridTemplateRows: buildHistoryStackTemplate(logHeight) } : undefined}><div className="history-list-pane"><div className="history-toolbar"><div className="history-filter"><input className="history-filter-input" placeholder="Filter…" value={filterText} onChange={(event) => setFilterText(event.target.value)} />{filterText && <button type="button" className="history-filter-clear" onClick={() => setFilterText("")}>✕</button>}</div>{refFilter && <button type="button" className="repository-ref-chip" onClick={onClearRef}>{refFilter} ✕</button>}{state.kind === "ok" && <span className="history-count">{filterText ? `${visible.length}/${state.commits.length}` : state.commits.length}</span>}</div><div className="history-list">{showWip && <button type="button" className="repository-wip-row" onClick={onWip}>Uncommitted changes <span>{wip.files} files · +{wip.additions} −{wip.deletions}</span></button>}{state.kind === "loading" && <div className="history-empty">Loading…</div>}{state.kind === "error" && <div className="history-error">{state.message}<button type="button" className="repository-refresh-btn" onClick={() => setRefreshToken((value) => value + 1)}>Retry</button></div>}{state.kind === "ok" && state.commits.length === 0 && <div className="history-empty">No history</div>}{state.kind === "ok" && state.commits.length > 0 && visible.length === 0 && <div className="history-empty">No matching items</div>}{state.kind === "ok" && layout && visible.map((entry, index) => <CommitRow key={entry.fullHash} entry={entry} checkouts={state.checkouts} selected={target?.fullHash === entry.fullHash} graphNode={layout.nodes[index]!} onSelect={(selected) => setTarget({ fullHash: selected.fullHash, entry: selected })} />)}{state.kind === "ok" && (state.truncated || state.commits.length >= 200) && <div className="history-truncated">History capped at 200 commits.</div>}</div></div>{target && <><div className="history-divider history-divider--horizontal" role="separator" aria-orientation="horizontal" aria-label="Resize commit log" onPointerDown={handleDivider} /><div className="history-detail-pane"><CommitInspector ctx={ctx} repoRel={repoRel} target={target} onSelectCommit={setTarget} onClose={() => setTarget(null)} /></div></>}</div>;
+  const stackTemplate = target
+    ? workspace ? buildWorkspaceDockTemplate(dockHeight) : buildHistoryStackTemplate(logHeight)
+    : undefined;
+  return <div ref={rootRef} className={`history-root${workspace ? " repository-ws-history" : ""}${isDragging ? " is-dragging" : ""}`} style={stackTemplate ? { gridTemplateRows: stackTemplate } : undefined}>
+    <div className="history-list-pane" hidden={workspace && workspaceMain !== undefined}>
+      <div className="history-toolbar"><div className="history-filter"><input className="history-filter-input" placeholder="Filter…" value={filterText} onChange={(event) => setFilterText(event.target.value)} />{filterText && <button type="button" className="history-filter-clear" onClick={() => setFilterText("")}>✕</button>}</div>{refFilter && <button type="button" className="repository-ref-chip" onClick={onClearRef}>{refFilter} ✕</button>}{state.kind === "ok" && <span className="history-count">{filterText ? `${visible.length}/${state.commits.length}` : state.commits.length}</span>}</div>
+      <div className="history-list">{showWip && <button type="button" className="repository-wip-row" onClick={onWip}>Uncommitted changes <span>{wip.files} files · +{wip.additions} −{wip.deletions}</span></button>}{state.kind === "loading" && <div className="history-empty">Loading…</div>}{state.kind === "error" && <div className="history-error">{state.message}<button type="button" className="repository-refresh-btn" onClick={() => setRefreshToken((value) => value + 1)}>Retry</button></div>}{state.kind === "ok" && state.commits.length === 0 && <div className="history-empty">No history</div>}{state.kind === "ok" && state.commits.length > 0 && visible.length === 0 && <div className="history-empty">No matching items</div>}{state.kind === "ok" && layout && visible.map((entry, index) => <CommitRow key={entry.fullHash} entry={entry} checkouts={state.checkouts} selected={target?.fullHash === entry.fullHash} graphNode={layout.nodes[index]!} onSelect={(selected) => setTarget({ fullHash: selected.fullHash, entry: selected })} />)}{state.kind === "ok" && (state.truncated || state.commits.length >= 200) && <div className="history-truncated">History capped at 200 commits.</div>}</div>
+    </div>
+    {workspaceMain !== undefined && <div className="repository-ws-main">{workspaceMain}</div>}
+    {target && <><div className="history-divider history-divider--horizontal" role="separator" aria-orientation="horizontal" aria-label={workspace ? "Resize commit detail dock" : "Resize commit log"} onPointerDown={handleDivider} /><div className="history-detail-pane"><CommitInspector ctx={ctx} repoRel={repoRel} target={target} workspace={workspace} onSelectCommit={setTarget} onClose={() => setTarget(null)} /></div></>}
+  </div>;
 }
 function readLogPaneHeight(): number { return readSize(PREFS_LOG_PANE_HEIGHT, LOG_PANE_DEFAULT_HEIGHT, HISTORY_LOG_PANE_MIN_HEIGHT); }
 function readFilesViewMode(): FilesViewMode { try { const value = localStorage.getItem(PREFS_FILES_VIEW); if (value === "list" || value === "tree") return value; } catch { /* ignore */ } return "list"; }

--- a/runtime/fleet-plugins/repository/client/history-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/history-panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 import type { RailPanelContext } from "@fleet-console/sdk/rail";
 
@@ -10,7 +10,7 @@ import { layoutGraph } from "./graph-layout.js";
 import { HunkView } from "./hunk-view.js";
 import { formatCommitTime, refBadges } from "./log-parse.js";
 import { DIFF_DIVIDER_WIDTH, HISTORY_DETAIL_PANE_MIN_HEIGHT, HISTORY_LOG_PANE_MIN_HEIGHT, buildHistoryStackTemplate, buildInspectorChangesGridTemplate, buildInspectorDetailsGridTemplate, clampSplitPaneSize, installPointerDragLifecycle } from "./rail-layout.js";
-import { buildWorkspaceDockTemplate, clampWorkspaceDockHeight, readWorkspaceDockHeight, saveWorkspaceDockHeight } from "./workspace-layout.js";
+import { buildWorkspaceDockTemplate, clampWorkspaceDockHeight, normalizeWorkspaceDockHeight, readWorkspaceDockHeight, saveWorkspaceDockHeight } from "./workspace-layout.js";
 
 type LoadState = { readonly kind: "loading" } | { readonly kind: "ok"; readonly commits: readonly LogCommitEntry[]; readonly checkouts: readonly WorktreeCheckout[]; readonly truncated: boolean } | { readonly kind: "error"; readonly message: string };
 type CommitTarget = { readonly fullHash: string; readonly entry?: LogCommitEntry };
@@ -128,6 +128,20 @@ function HistoryPanelBody({ ctx, repoRel, active, refFilter, wipFiles, workspace
   useEffect(() => { if (active) setEverActive(true); }, [active]);
   useEffect(() => { if (!everActive) return; if (!ctx.theaterId) { setState({ kind: "ok", commits: [], checkouts: [], truncated: false }); return; } let cancelled = false; setState({ kind: "loading" }); ctx.api.fetch("repository", "log", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ theaterId: ctx.theaterId, repoRel, ...(refFilter ? { ref: refFilter } : {}) }) }).then(async (response) => { if (!response.ok) throw new Error((await response.json() as { readonly error?: string }).error ?? "git_failed"); return response.json() as Promise<LogResult>; }).then((data) => { if (!cancelled) setState({ kind: "ok", commits: data.commits, checkouts: data.checkouts, truncated: data.truncated ?? false }); }).catch((error: unknown) => { if (!cancelled) setState({ kind: "error", message: error instanceof Error ? error.message : "unknown" }); }); return () => { cancelled = true; }; }, [ctx.api, ctx.theaterId, everActive, refreshToken, refFilter, repoRel]);
   useEffect(() => { onInspectorOpenChange?.(active && target !== null); }, [active, onInspectorOpenChange, target]); useEffect(() => () => dragDisposeRef.current?.(), []);
+  // 저장된 dock 높이는 현재 컨테이너 기준으로 정규화해 축소된 창에서 주 영역이 잘리지 않게 한다(저장값 자체는 보존).
+  useLayoutEffect(() => {
+    if (!workspace || target === null) return;
+    const root = rootRef.current;
+    if (!root) return;
+    const normalize = () => {
+      const next = normalizeWorkspaceDockHeight(dockHeightRef.current, root.getBoundingClientRect().height);
+      if (next !== dockHeightRef.current) { dockHeightRef.current = next; setDockHeight(next); }
+    };
+    normalize();
+    const observer = new ResizeObserver(normalize);
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, [workspace, target]);
   const handleDivider = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     event.preventDefault();
     const root = rootRef.current;

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -331,13 +331,18 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
     </div>
   </div>;
   const compareView = <CompareView key={`${ctx.theaterId ?? ""}:${repoRel}`} ctx={ctx} repoRel={repoRel} refs={refs} refsError={refsError} onRetryRefs={() => setRefsRetry((value) => value + 1)} onFileOpenChange={setCompareFileOpen} />;
-  const workspaceMain = source === "changes" ? changesView : source === "compare" ? compareView : undefined;
+  // 컴팩트 레이아웃과 동일하게 Changes/Compare를 hidden으로 상시 마운트해 섹션 전환에도 내부 상태를 보존한다.
+  const workspaceMainVisible = source === "changes" || source === "compare";
+  const workspaceMain = <>
+    <div className="repository-source-fill" hidden={source !== "changes"}>{changesView}</div>
+    <div className="repository-source-fill" hidden={source !== "compare"}>{compareView}</div>
+  </>;
   return (
     <div className={`repository-unified${isWorkspace ? " is-workspace" : ""}`}>
       <div className={`repository-identity${repoRel ? " is-subcontext" : ""}`}><RepositoryIcon /><strong>{selectedRepo?.name ?? "Repository"}</strong>{selectedRepo?.branch && <span>{selectedRepo.branch}</span>}<button type="button" className="repository-ws-toggle" aria-label={isWorkspace ? "Collapse workspace" : "Expand workspace"} title={isWorkspace ? "Collapse workspace" : "Expand workspace"} onClick={toggleWorkspace}><WorkspaceToggleIcon expanded={isWorkspace} /></button></div>
       {isWorkspace ? <div className="repository-ws-layout">
         <WorkspaceTree repos={repos} reposError={reposError} reposTruncated={reposTruncated} scanDepth={scanDepth} worktrees={worktrees} worktreesError={worktreesError} refs={refs} refsError={refsError} changedFiles={changedFiles} selectedRel={repoRel} source={source} refFilter={refFilter} onRepository={handleSelectRepository} onScanDepth={setScanDepth} onRetryRepos={() => setReposRetry((value) => value + 1)} onRetryWorktrees={() => setWorktreesRetry((value) => value + 1)} onRetryRefs={() => setRefsRetry((value) => value + 1)} onSource={setSource} onRef={(ref) => { setRefFilter(ref); setSource("history"); }} />
-        <HistoryPanel key={`${ctx.theaterId ?? ""}:${repoRel}:${historyLandingEpoch}`} ctx={ctx} repoRel={repoRel} active refFilter={refFilter} wipFiles={wipFiles} workspace workspaceMain={workspaceMain} onInspectorOpenChange={setHistoryInspectorOpen} onClearRef={() => setRefFilter(null)} onWip={() => setSource("changes")} />
+        <HistoryPanel key={`${ctx.theaterId ?? ""}:${repoRel}:${historyLandingEpoch}`} ctx={ctx} repoRel={repoRel} active refFilter={refFilter} wipFiles={wipFiles} workspace workspaceMain={workspaceMain} workspaceMainVisible={workspaceMainVisible} onInspectorOpenChange={setHistoryInspectorOpen} onClearRef={() => setRefFilter(null)} onWip={() => setSource("changes")} />
       </div> : <div className="repository-unified-body"><SourceNav source={source} refs={refs} repos={repos} worktrees={worktrees} onSource={setSource} /><div className="repository-source-content">
         {source === "repositories" ? reposError ? <div className="history-error">Unable to load repositories<button type="button" className="repository-refresh-btn" onClick={() => setReposRetry((value) => value + 1)}>Retry</button></div> : <RepoList repos={repos} selectedRel={repoRel} onRepository={handleSelectRepository} scanDepth={scanDepth} onScanDepth={setScanDepth} truncated={reposTruncated} /> : null}
         {source === "worktrees" ? worktreesError ? <div className="history-error">Unable to load worktrees<button type="button" className="repository-refresh-btn" onClick={() => setWorktreesRetry((value) => value + 1)}>Retry</button></div> : <WorktreeList worktrees={worktrees} onWorktree={handleSelectRepository} /> : null}

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -12,6 +12,7 @@ import { clearSelectedFile, setSelectedFile, type SelectedFile, useSelectedFile 
 import { HunkView } from "./hunk-view.js";
 import { HistoryPanel } from "./history-panel.js";
 import { DIFF_DIVIDER_WIDTH, HUNK_PANE_MIN_WIDTH, buildDiffGridTemplate, clampListPaneWidth } from "./rail-layout.js";
+import { buildWorkspaceTreeSections, calculateWorkspaceExtraWidth, readWorkspaceMode, saveWorkspaceMode } from "./workspace-layout.js";
 
 type ViewMode = "list" | "tree";
 
@@ -150,6 +151,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   const [repoRel, setRepoRel] = useState(() => ctx.theaterId ? readStoredRepositoryRel(ctx.theaterId) : "");
   const repoRelRef = useRef(repoRel);
   const [source, setSourceState] = useState<Source>(readRepositorySource);
+  const [isWorkspace, setIsWorkspace] = useState(readWorkspaceMode);
   const [refFilter, setRefFilter] = useState<string | null>(null);
   const [refs, setRefs] = useState<Refs>({ branches: [], remotes: [], tags: [], stashes: [] });
   const [refsError, setRefsError] = useState(false); const [refsRetry, setRefsRetry] = useState(0);
@@ -170,6 +172,13 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   const setSource = useCallback((next: Source) => {
     setSourceState(next);
     saveRepositorySource(next);
+  }, []);
+  const toggleWorkspace = useCallback(() => {
+    setIsWorkspace((value) => {
+      const next = !value;
+      saveWorkspaceMode(next);
+      return next;
+    });
   }, []);
   const transitionRepository = useCallback((nextRepoRel: string, persist: boolean, landing: Source = "changes") => {
     if (!ctx.theaterId) return;
@@ -296,34 +305,157 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   }, []);
 
   useLayoutEffect(() => {
+    if (isWorkspace) {
+      const requestWorkspaceWidth = () => ctx.requestExtraWidth?.(calculateWorkspaceExtraWidth(window.innerWidth));
+      requestWorkspaceWidth();
+      window.addEventListener("resize", requestWorkspaceWidth);
+      return () => {
+        window.removeEventListener("resize", requestWorkspaceWidth);
+        ctx.requestExtraWidth?.(null);
+      };
+    }
     ctx.requestExtraWidth?.((source === "changes" && selectedFile) || (source === "history" && historyInspectorOpen) || (source === "compare" && compareFileOpen) ? EXTENDED_EXTRA_WIDTH : null);
     return () => ctx.requestExtraWidth?.(null);
-  }, [ctx.requestExtraWidth, selectedFile, source, historyInspectorOpen, compareFileOpen]);
+  }, [ctx.requestExtraWidth, selectedFile, source, historyInspectorOpen, compareFileOpen, isWorkspace]);
 
   const hunkMode = selectedFile ? getHunkMode(selectedFile) : null;
   const retryChangedFiles = useCallback(() => setChangedFilesRetry((value) => value + 1), []);
   const wipFiles = changedFiles.kind === "ok" ? changedFiles.files : [];
   const selectedRepo = repos.find((repo) => repo.relPath === repoRel) ?? worktrees.find((worktree) => worktree.relPath === repoRel);
+  const changesView = <div ref={rootRef} className={`repository-root${selectedFile ? " has-hunk" : ""}${isDragging ? " is-dragging" : ""}`} style={selectedFile ? { gridTemplateColumns: buildDiffGridTemplate(listPaneWidth) } : undefined}>
+    {selectedFile && hunkMode ? <div className="repository-hunk-pane"><div className="repository-hunk-head"><span>{selectedFile.entry.path}</span><button type="button" onClick={handleCloseHunk}>✕</button></div><HunkView ctx={ctx} repoRel={repoRel} file={selectedFile.entry} mode={hunkMode} /></div> : null}
+    {selectedFile ? <div className="repository-divider" onPointerDown={handleDividerDown} aria-hidden="true" /> : null}
+    <div className="repository-list-pane">
+      <div className="repository-toolbar"><div className="repository-filter"><input type="text" className="repository-filter-input" placeholder="Filter…" aria-label="Filter changed files" value={filterText} onChange={(event) => setFilterText(event.target.value)} />{filterText ? <button type="button" className="repository-filter-clear" aria-label="Clear filter" onClick={() => setFilterText("")}>✕</button> : null}</div><div className="repository-view-toggle"><button type="button" className={`repository-toggle-btn${viewMode === "list" ? " is-active" : ""}`} title="List view" aria-pressed={viewMode === "list"} onClick={() => handleViewMode("list")}><svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><line x1="2" y1="3.5" x2="12" y2="3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" /><line x1="2" y1="7" x2="12" y2="7" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" /><line x1="2" y1="10.5" x2="12" y2="10.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" /></svg></button><button type="button" className={`repository-toggle-btn${viewMode === "tree" ? " is-active" : ""}`} title="Tree view" aria-pressed={viewMode === "tree"} onClick={() => handleViewMode("tree")}><svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><rect x="1" y="1" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /><rect x="9" y="1" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /><rect x="1" y="9" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /><rect x="9" y="9" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /></svg></button></div></div>
+      <ChangedFiles state={changedFiles} onRetry={retryChangedFiles} viewMode={viewMode} selectedPath={selectedFile?.entry.path ?? null} onSelect={handleSelectFile} filterText={filterText} />
+    </div>
+  </div>;
+  const compareView = <CompareView key={`${ctx.theaterId ?? ""}:${repoRel}`} ctx={ctx} repoRel={repoRel} refs={refs} refsError={refsError} onRetryRefs={() => setRefsRetry((value) => value + 1)} onFileOpenChange={setCompareFileOpen} />;
+  const workspaceMain = source === "changes" ? changesView : source === "compare" ? compareView : undefined;
   return (
-    <div className="repository-unified"><div className={`repository-identity${repoRel ? " is-subcontext" : ""}`}><RepositoryIcon /><strong>{selectedRepo?.name ?? "Repository"}</strong>{selectedRepo?.branch && <span>{selectedRepo.branch}</span>}</div><div className="repository-unified-body"><SourceNav source={source} refs={refs} repos={repos} worktrees={worktrees} onSource={setSource} /><div className="repository-source-content">
-      {source === "repositories" ? reposError ? <div className="history-error">Unable to load repositories<button type="button" className="repository-refresh-btn" onClick={() => setReposRetry((value) => value + 1)}>Retry</button></div> : <RepoList repos={repos} selectedRel={repoRel} onRepository={handleSelectRepository} scanDepth={scanDepth} onScanDepth={setScanDepth} truncated={reposTruncated} /> : null}
-      {source === "worktrees" ? worktreesError ? <div className="history-error">Unable to load worktrees<button type="button" className="repository-refresh-btn" onClick={() => setWorktreesRetry((value) => value + 1)}>Retry</button></div> : <WorktreeList worktrees={worktrees} onWorktree={handleSelectRepository} /> : null}
-      <div className="repository-source-fill" hidden={source !== "history"}><HistoryPanel key={`${ctx.theaterId ?? ""}:${repoRel}:${historyLandingEpoch}`} ctx={ctx} repoRel={repoRel} active={source === "history"} refFilter={refFilter} wipFiles={wipFiles} onInspectorOpenChange={setHistoryInspectorOpen} onClearRef={() => setRefFilter(null)} onWip={() => setSource("changes")} /></div>
-      <div className="repository-source-fill" hidden={source !== "compare"}><CompareView key={`${ctx.theaterId ?? ""}:${repoRel}`} ctx={ctx} repoRel={repoRel} refs={refs} refsError={refsError} onRetryRefs={() => setRefsRetry((value) => value + 1)} onFileOpenChange={setCompareFileOpen} /></div>
-      {source !== "repositories" && source !== "worktrees" && source !== "changes" && source !== "history" && source !== "compare" ? refsError ? <div className="history-error">Unable to load refs<button type="button" className="repository-refresh-btn" onClick={() => setRefsRetry((value) => value + 1)}>Retry</button></div> : <RefList source={source} refs={refs} onRef={(ref) => { setRefFilter(ref); setSource("history"); }} /> : null}
-      <div hidden={source !== "changes"} ref={rootRef} className={`repository-root${selectedFile ? " has-hunk" : ""}${isDragging ? " is-dragging" : ""}`} style={selectedFile ? { gridTemplateColumns: buildDiffGridTemplate(listPaneWidth) } : undefined}>
-      {selectedFile && hunkMode ? <div className="repository-hunk-pane"><div className="repository-hunk-head"><span>{selectedFile.entry.path}</span><button type="button" onClick={handleCloseHunk}>✕</button></div><HunkView ctx={ctx} repoRel={repoRel} file={selectedFile.entry} mode={hunkMode} /></div> : null}
-      {selectedFile ? <div className="repository-divider" onPointerDown={handleDividerDown} aria-hidden="true" /> : null}
-      <div className="repository-list-pane">
-        <div className="repository-toolbar"><div className="repository-filter"><input type="text" className="repository-filter-input" placeholder="Filter…" aria-label="Filter changed files" value={filterText} onChange={(event) => setFilterText(event.target.value)} />{filterText ? <button type="button" className="repository-filter-clear" aria-label="Clear filter" onClick={() => setFilterText("")}>✕</button> : null}</div><div className="repository-view-toggle"><button type="button" className={`repository-toggle-btn${viewMode === "list" ? " is-active" : ""}`} title="List view" aria-pressed={viewMode === "list"} onClick={() => handleViewMode("list")}><svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><line x1="2" y1="3.5" x2="12" y2="3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" /><line x1="2" y1="7" x2="12" y2="7" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" /><line x1="2" y1="10.5" x2="12" y2="10.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" /></svg></button><button type="button" className={`repository-toggle-btn${viewMode === "tree" ? " is-active" : ""}`} title="Tree view" aria-pressed={viewMode === "tree"} onClick={() => handleViewMode("tree")}><svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><rect x="1" y="1" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /><rect x="9" y="1" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /><rect x="1" y="9" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /><rect x="9" y="9" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /></svg></button></div></div>
-        <ChangedFiles state={changedFiles} onRetry={retryChangedFiles} viewMode={viewMode} selectedPath={selectedFile?.entry.path ?? null} onSelect={handleSelectFile} filterText={filterText} />
-      </div>
-      </div></div></div></div>
+    <div className={`repository-unified${isWorkspace ? " is-workspace" : ""}`}>
+      <div className={`repository-identity${repoRel ? " is-subcontext" : ""}`}><RepositoryIcon /><strong>{selectedRepo?.name ?? "Repository"}</strong>{selectedRepo?.branch && <span>{selectedRepo.branch}</span>}<button type="button" className="repository-ws-toggle" aria-label={isWorkspace ? "Collapse workspace" : "Expand workspace"} title={isWorkspace ? "Collapse workspace" : "Expand workspace"} onClick={toggleWorkspace}><WorkspaceToggleIcon expanded={isWorkspace} /></button></div>
+      {isWorkspace ? <div className="repository-ws-layout">
+        <WorkspaceTree repos={repos} reposError={reposError} reposTruncated={reposTruncated} scanDepth={scanDepth} worktrees={worktrees} worktreesError={worktreesError} refs={refs} refsError={refsError} changedFiles={changedFiles} selectedRel={repoRel} source={source} refFilter={refFilter} onRepository={handleSelectRepository} onScanDepth={setScanDepth} onRetryRepos={() => setReposRetry((value) => value + 1)} onRetryWorktrees={() => setWorktreesRetry((value) => value + 1)} onRetryRefs={() => setRefsRetry((value) => value + 1)} onSource={setSource} onRef={(ref) => { setRefFilter(ref); setSource("history"); }} />
+        <HistoryPanel key={`${ctx.theaterId ?? ""}:${repoRel}:${historyLandingEpoch}`} ctx={ctx} repoRel={repoRel} active refFilter={refFilter} wipFiles={wipFiles} workspace workspaceMain={workspaceMain} onInspectorOpenChange={setHistoryInspectorOpen} onClearRef={() => setRefFilter(null)} onWip={() => setSource("changes")} />
+      </div> : <div className="repository-unified-body"><SourceNav source={source} refs={refs} repos={repos} worktrees={worktrees} onSource={setSource} /><div className="repository-source-content">
+        {source === "repositories" ? reposError ? <div className="history-error">Unable to load repositories<button type="button" className="repository-refresh-btn" onClick={() => setReposRetry((value) => value + 1)}>Retry</button></div> : <RepoList repos={repos} selectedRel={repoRel} onRepository={handleSelectRepository} scanDepth={scanDepth} onScanDepth={setScanDepth} truncated={reposTruncated} /> : null}
+        {source === "worktrees" ? worktreesError ? <div className="history-error">Unable to load worktrees<button type="button" className="repository-refresh-btn" onClick={() => setWorktreesRetry((value) => value + 1)}>Retry</button></div> : <WorktreeList worktrees={worktrees} onWorktree={handleSelectRepository} /> : null}
+        <div className="repository-source-fill" hidden={source !== "history"}><HistoryPanel key={`${ctx.theaterId ?? ""}:${repoRel}:${historyLandingEpoch}`} ctx={ctx} repoRel={repoRel} active={source === "history"} refFilter={refFilter} wipFiles={wipFiles} onInspectorOpenChange={setHistoryInspectorOpen} onClearRef={() => setRefFilter(null)} onWip={() => setSource("changes")} /></div>
+        <div className="repository-source-fill" hidden={source !== "compare"}>{compareView}</div>
+        {source !== "repositories" && source !== "worktrees" && source !== "changes" && source !== "history" && source !== "compare" ? refsError ? <div className="history-error">Unable to load refs<button type="button" className="repository-refresh-btn" onClick={() => setRefsRetry((value) => value + 1)}>Retry</button></div> : <RefList source={source} refs={refs} onRef={(ref) => { setRefFilter(ref); setSource("history"); }} /> : null}
+        <div className="repository-source-fill" hidden={source !== "changes"}>{changesView}</div>
+      </div></div>}
+    </div>
   );
+}
+
+interface WorkspaceTreeProps {
+  readonly repos: readonly RepoCandidate[];
+  readonly reposError: boolean;
+  readonly reposTruncated: boolean;
+  readonly scanDepth: number;
+  readonly worktrees: readonly WorktreeCandidate[];
+  readonly worktreesError: boolean;
+  readonly refs: Refs;
+  readonly refsError: boolean;
+  readonly changedFiles: ChangedFilesState;
+  readonly selectedRel: string;
+  readonly source: Source;
+  readonly refFilter: string | null;
+  readonly onRepository: (repo: RepoCandidate | WorktreeCandidate) => void;
+  readonly onScanDepth: (depth: number) => void;
+  readonly onRetryRepos: () => void;
+  readonly onRetryWorktrees: () => void;
+  readonly onRetryRefs: () => void;
+  readonly onSource: (source: Source) => void;
+  readonly onRef: (ref: string) => void;
+}
+
+function WorkspaceTree({ repos, reposError, reposTruncated, scanDepth, worktrees, worktreesError, refs, refsError, changedFiles, selectedRel, source, refFilter, onRepository, onScanDepth, onRetryRepos, onRetryWorktrees, onRetryRefs, onSource, onRef }: WorkspaceTreeProps) {
+  const [query, setQuery] = useState("");
+  const rootRepos = repos.filter((repo) => repo.kind === "root").sort((a, b) => a.name.localeCompare(b.name));
+  const nestedRepos = repos.filter((repo) => repo.kind === "nested");
+  const nestedTree = buildRepoTree(nestedRepos);
+  const matchRepository = (repo: RepoCandidate) => fuzzyMatch(query, repo.name) ?? fuzzyMatch(query, repo.relPath);
+  const rootMatches = query ? rootRepos.filter((repo) => matchRepository(repo) !== null) : rootRepos;
+  const nestedMatches = query ? nestedRepos.filter((repo) => matchRepository(repo) !== null) : nestedRepos;
+  const matchedCount = rootMatches.length + nestedMatches.length;
+  const branchCount = refs.branches.length + refs.remotes.filter((item) => !isRemoteHeadRef(item.ref)).length;
+  const changesCount = changedFiles.kind === "ok" ? changedFiles.files.length : 0;
+  const sections = buildWorkspaceTreeSections({
+    context: repos.length,
+    changes: changesCount,
+    worktrees: worktrees.length,
+    branches: branchCount,
+    tags: refs.tags.length,
+    stashes: refs.stashes.length,
+  });
+  const sectionHeader = (id: (typeof sections)[number]["id"]) => {
+    const section = sections.find((item) => item.id === id)!;
+    return <div className="repository-ws-section-head"><span>{section.label}</span><i>{section.count}</i></div>;
+  };
+  const refRows = (refSource: RefSource) => buildRefListGroups(refSource, refs).map((group) => <div key={group.label ?? refSource} className="repository-ws-ref-group">
+    {group.label && <span className="repository-ws-ref-subhead">{group.label}</span>}
+    {group.rows.map((row) => <button type="button" key={row.key} className={`repository-ws-tree-row${row.current ? " is-current" : ""}${source === "history" && row.ref === refFilter ? " is-active" : ""}`} disabled={row.ref === null} onClick={() => row.ref && onRef(row.ref)}>
+      <SourceIcon source={row.source} /><span>{row.primary}</span>{row.current && <i>HEAD</i>}{row.sub && <i>{row.sub}</i>}
+    </button>)}
+  </div>);
+  return <aside className="repository-ws-tree">
+    <RepositoryDiscovery query={query} onQuery={setQuery} totalCount={repos.length} matchedCount={matchedCount} scanDepth={scanDepth} onScanDepth={onScanDepth} truncated={reposTruncated} onEnter={() => {
+      const first = rootMatches[0] ?? nestedMatches[0];
+      if (first) onRepository(first);
+    }} />
+    <div className="repository-ws-tree-scroll">
+      <section className="repository-ws-section">{sectionHeader("context")}
+        {reposError ? <WorkspaceTreeError label="Unable to load repositories" onRetry={onRetryRepos} /> : <>
+          {rootMatches.map((repo) => <RepoLeafRow key={repo.relPath} repo={repo} depth={0} selectedRel={selectedRel} onRepository={onRepository} />)}
+          {query ? nestedMatches.map((repo) => <RepoLeafRow key={repo.relPath} repo={repo} depth={0} selectedRel={selectedRel} onRepository={onRepository} />) : <RepoTreeChildren node={nestedTree} depth={0} selectedRel={selectedRel} onRepository={onRepository} />}
+          {query && matchedCount === 0 && <div className="repository-empty-row">No matching repositories</div>}
+        </>}
+      </section>
+      <section className="repository-ws-section">{sectionHeader("working")}
+        <button type="button" className={`repository-ws-tree-row${source === "history" ? " is-active" : ""}`} onClick={() => onSource("history")}><SourceIcon source="history" /><span>History</span></button>
+        <button type="button" className={`repository-ws-tree-row${source === "changes" ? " is-active" : ""}`} onClick={() => onSource("changes")}><SourceIcon source="changes" /><span>Changes</span><i>{changesCount}</i></button>
+        <button type="button" className={`repository-ws-tree-row${source === "compare" ? " is-active" : ""}`} onClick={() => onSource("compare")}><SourceIcon source="compare" /><span>Compare</span></button>
+      </section>
+      <section className="repository-ws-section">{sectionHeader("worktrees")}
+        {worktreesError ? <WorkspaceTreeError label="Unable to load worktrees" onRetry={onRetryWorktrees} /> : worktrees.map((worktree) => <button type="button" key={worktree.relPath} className={`repository-ws-tree-row${worktree.relPath === selectedRel ? " is-current" : ""}`} title={worktree.relPath} onClick={() => onRepository(worktree)}><SourceIcon source="worktrees" /><span>{worktree.name}</span>{worktree.current && <i>HEAD</i>}</button>)}
+      </section>
+      <section className="repository-ws-section">{sectionHeader("branches")}
+        {refsError ? <WorkspaceTreeError label="Unable to load refs" onRetry={onRetryRefs} /> : refRows("branches")}
+      </section>
+      <section className="repository-ws-section">{sectionHeader("tags")}{!refsError && refRows("tags")}</section>
+      <section className="repository-ws-section">{sectionHeader("stashes")}{!refsError && refRows("stashes")}</section>
+    </div>
+  </aside>;
+}
+
+function WorkspaceTreeError({ label, onRetry }: { readonly label: string; readonly onRetry: () => void }) {
+  return <div className="repository-ws-tree-error"><span>{label}</span><button type="button" onClick={onRetry}>Retry</button></div>;
+}
+
+function WorkspaceToggleIcon({ expanded }: { readonly expanded: boolean }) {
+  return <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">{expanded ? <><path d="M6 2v4H2M10 14v-4h4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" /><path d="M2.5 5.5L6 2M13.5 10.5L10 14" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" /></> : <><path d="M2 6V2h4M14 10v4h-4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" /><path d="M5.5 2.5L2 6M10.5 13.5L14 10" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" /></>}</svg>;
 }
 
 function SourceIcon({ source }: { readonly source: Source }) { const path = source === "repositories" ? "M3 5h12v9H3zM5 3h8v2" : source === "worktrees" ? "M5 3v12M5 6h7M5 12h7" : source === "changes" ? "M3 4h12M3 9h12M3 14h12" : source === "history" ? "M4 4v10h10M7 7h6v5" : source === "compare" ? "M5.5 3v9M3 9.5l2.5 2.5L8 9.5M12.5 15V6M10 8.5L12.5 6L15 8.5" : source === "branches" ? "M5 3v12M5 6h7M5 12h7" : source === "tags" ? "M3 4h8l4 4-7 7-5-5z" : "M4 5h10v9H4zM6 3h6"; return <svg viewBox="0 0 18 18" aria-hidden="true"><path d={path} fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" /></svg>; }
 function SourceNav({ source, refs, repos, worktrees, onSource }: { readonly source: Source; readonly refs: Refs; readonly repos: readonly RepoCandidate[]; readonly worktrees: readonly WorktreeCandidate[]; readonly onSource: (source: Source) => void }) { const button = (id: Source, label: string, count?: number) => <button key={id} type="button" aria-label={label} aria-current={source === id ? "page" : undefined} onClick={() => onSource(id)}><SourceIcon source={id} /><span>{label}</span>{count !== undefined && <i>{count}</i>}</button>; return <nav className="repository-source-nav" aria-label="Repository sources"><b>CONTEXT</b>{button("repositories", "Repositories", repos.length)}{button("worktrees", "Worktrees", worktrees.length)}<b>WORKING</b>{button("changes", "Changes")}{button("history", "History")}{button("compare", "Compare")}<b>REFS</b>{button("branches", "Branches", refs.branches.length + refs.remotes.filter((item) => !isRemoteHeadRef(item.ref)).length)}{button("tags", "Tags", refs.tags.length)}{button("stashes", "Stashes", refs.stashes.length)}</nav>; }
+function RepositoryDiscovery({ query, onQuery, totalCount, matchedCount, scanDepth, onScanDepth, truncated, onEnter }: { readonly query: string; readonly onQuery: (query: string) => void; readonly totalCount: number; readonly matchedCount: number; readonly scanDepth: number; readonly onScanDepth: (depth: number) => void; readonly truncated: boolean; readonly onEnter: () => void }) {
+  return <div className="repository-discovery">
+    <input type="text" className="repository-filter-input" placeholder="Find repositories…" aria-label="Find repositories" value={query} onChange={(event) => onQuery(event.target.value)} onKeyDown={(event) => {
+      if (event.key !== "Enter" || event.nativeEvent.isComposing) return;
+      onEnter();
+    }} />
+    {query ? <button type="button" className="repository-filter-clear" aria-label="Clear search" onClick={() => onQuery("")}>✕</button> : null}
+    <span className="repository-discovery-depth">Depth
+      <button type="button" className="repository-depth-step" aria-label="Scan shallower" disabled={scanDepth <= SCAN_DEPTH_MIN} onClick={() => onScanDepth(scanDepth - 1)}>−</button>
+      <output className="repository-depth-value">{scanDepth}</output>
+      <button type="button" className="repository-depth-step" aria-label="Scan deeper" disabled={scanDepth >= SCAN_DEPTH_MAX} onClick={() => onScanDepth(scanDepth + 1)}>+</button>
+    </span>
+    <span className="repository-scan-count">{query ? `${matchedCount} of ${totalCount}` : `${totalCount} found${truncated ? " · limit reached" : ""}`}</span>
+  </div>;
+}
 function RepoList({ repos, selectedRel, onRepository, scanDepth, onScanDepth, truncated }: { readonly repos: readonly RepoCandidate[]; readonly selectedRel: string; readonly onRepository: (repo: RepoCandidate) => void; readonly scanDepth: number; readonly onScanDepth: (depth: number) => void; readonly truncated: boolean }) {
   const [query, setQuery] = useState("");
   // 루트 저장소는 컨텍스트 복귀 affordance이므로 트리 밖 THIS THEATER 그룹에 고정한다.
@@ -347,21 +479,10 @@ function RepoList({ repos, selectedRel, onRepository, scanDepth, onScanDepth, tr
     ...(nestedRepos.length > 0 ? [{ key: "nested", label: "NESTED" as const, render: () => <RepoTreeChildren node={nestedTree} depth={0} selectedRel={selectedRel} onRepository={onRepository} /> }] : []),
   ];
   return <div className="repository-scan-pane">
-    <div className="repository-discovery">
-      <input type="text" className="repository-filter-input" placeholder="Find repositories…" aria-label="Find repositories" value={query} onChange={(event) => setQuery(event.target.value)} onKeyDown={(event) => {
-        // 한글 IME 조합 확정 Enter가 첫 결과를 오선택하지 않게 조합 중에는 무시한다.
-        if (event.key !== "Enter" || event.nativeEvent.isComposing) return;
-        const firstMatch = rootMatches[0] ?? nestedMatches[0];
-        if (firstMatch) onRepository(firstMatch.repo);
-      }} />
-      {query ? <button type="button" className="repository-filter-clear" aria-label="Clear search" onClick={() => setQuery("")}>✕</button> : null}
-      <span className="repository-discovery-depth">Depth
-        <button type="button" className="repository-depth-step" aria-label="Scan shallower" disabled={scanDepth <= SCAN_DEPTH_MIN} onClick={() => onScanDepth(scanDepth - 1)}>−</button>
-        <output className="repository-depth-value">{scanDepth}</output>
-        <button type="button" className="repository-depth-step" aria-label="Scan deeper" disabled={scanDepth >= SCAN_DEPTH_MAX} onClick={() => onScanDepth(scanDepth + 1)}>+</button>
-      </span>
-      <span className="repository-scan-count">{query ? `${matchedCount} of ${repos.length}` : `${repos.length} found${truncated ? " · limit reached" : ""}`}</span>
-    </div>
+    <RepositoryDiscovery query={query} onQuery={setQuery} totalCount={repos.length} matchedCount={matchedCount} scanDepth={scanDepth} onScanDepth={onScanDepth} truncated={truncated} onEnter={() => {
+      const firstMatch = rootMatches[0] ?? nestedMatches[0];
+      if (firstMatch) onRepository(firstMatch.repo);
+    }} />
     <div className="repository-ref-list">{groups.map((group) => <div key={group.key} className="repository-ref-group"><b className="repository-ref-group-label">{group.label}</b>{group.render()}</div>)}{query && matchedCount === 0 ? <div className="repository-empty-row">No matching repositories</div> : null}</div>
   </div>;
 }

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1035,6 +1035,296 @@
 /* hidden 속성은 UA display:none이라 .repository-root의 display:grid에 진다 — 소스 상호 배제 가드 */
 .repository-unified [hidden] { display: none !important; }
 
+/* Expanded Repository workspace: the rail-owned panel widens without changing compact presentation. */
+.repository-identity .repository-ws-toggle {
+  display: inline-grid;
+  width: 26px;
+  height: 26px;
+  margin-left: auto;
+  padding: 5px;
+  place-items: center;
+  flex: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-xs);
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  transition: color var(--duration-base) var(--ease-spring), background var(--duration-base) var(--ease-spring), border-color var(--duration-base) var(--ease-spring);
+}
+
+.repository-identity .repository-ws-toggle:hover {
+  border-color: var(--surface-rim);
+  background: color-mix(in oklch, var(--ink-fog) 9%, transparent);
+  color: var(--text-primary);
+}
+
+.repository-unified.is-workspace .repository-ws-toggle {
+  color: var(--brass);
+}
+
+.repository-ws-layout {
+  display: grid;
+  grid-template-columns: 222px minmax(0, 1fr);
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
+}
+
+.repository-ws-tree {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  border-right: 1px solid var(--surface-rim);
+  background: color-mix(in oklch, var(--surface-band) 72%, transparent);
+}
+
+.repository-ws-tree .repository-discovery {
+  gap: 5px;
+  padding: 6px;
+}
+
+.repository-ws-tree .repository-discovery .repository-filter-input {
+  min-width: 52px;
+}
+
+.repository-ws-tree .repository-scan-count {
+  display: none;
+}
+
+.repository-ws-tree-scroll {
+  min-height: 0;
+  padding: 4px 0 10px;
+  overflow-y: auto;
+}
+
+.repository-ws-section {
+  margin-top: 7px;
+}
+
+.repository-ws-section-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: .14em;
+}
+
+.repository-ws-section-head i {
+  margin-left: auto;
+  color: var(--ink-fog);
+  font-style: normal;
+  letter-spacing: 0;
+}
+
+.repository-ws-tree-row {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  min-height: 26px;
+  padding: 4px 10px 4px 18px;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  transition: color var(--duration-base) var(--ease-spring), background var(--duration-base) var(--ease-spring);
+}
+
+.repository-ws-tree-row:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--ink-fog) 9%, transparent);
+  color: var(--text-primary);
+}
+
+.repository-ws-tree-row.is-active {
+  background: color-mix(in oklch, var(--brass) 7%, transparent);
+  color: var(--text-primary);
+  box-shadow: inset 2px 0 0 var(--brass);
+}
+
+.repository-ws-tree-row.is-current {
+  color: var(--text-primary);
+}
+
+.repository-ws-tree-row:disabled {
+  cursor: default;
+  color: var(--text-tertiary);
+}
+
+.repository-ws-tree-row > svg {
+  width: 13px;
+  height: 13px;
+  flex: none;
+  opacity: .85;
+}
+
+.repository-ws-tree-row > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.repository-ws-tree-row > i {
+  margin-left: auto;
+  overflow: hidden;
+  color: var(--text-tertiary);
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-style: normal;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.repository-ws-tree-row.is-current > i {
+  color: var(--brass);
+}
+
+.repository-ws-ref-group {
+  display: grid;
+}
+
+.repository-ws-ref-subhead {
+  padding: 4px 10px 2px 20px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 8.5px;
+  letter-spacing: .12em;
+}
+
+.repository-ws-tree-error {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px 5px 18px;
+  color: var(--coral);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.repository-ws-tree-error button {
+  margin-left: auto;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-xs);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font: inherit;
+}
+
+.repository-ws-tree .repository-ref-row,
+.repository-ws-tree .repository-folder-row {
+  min-height: 26px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.repository-ws-history {
+  min-width: 0;
+  min-height: 0;
+}
+
+.repository-ws-history > .history-list-pane,
+.repository-ws-main {
+  grid-row: 1;
+  grid-column: 1;
+  min-width: 0;
+  min-height: 0;
+}
+
+.repository-ws-main {
+  overflow: hidden;
+}
+
+.repository-ws-main > .repository-root,
+.repository-ws-main > .repository-compare {
+  height: 100%;
+}
+
+.repository-ws-history > .history-detail-pane {
+  grid-row: 3;
+  background: var(--surface-glass);
+}
+
+.repository-ws-history > .history-divider {
+  grid-row: 2;
+}
+
+.repository-ws-inspector {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr);
+}
+
+.repository-ws-dock {
+  display: grid;
+  grid-template-columns: 250px minmax(0, 1fr);
+  min-width: 0;
+  min-height: 0;
+}
+
+.repository-ws-dock > .history-commit-files {
+  border-right: 1px solid var(--surface-rim);
+}
+
+.repository-ws-dock-main {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.repository-ws-dock-meta {
+  position: relative;
+  max-height: 104px;
+  overflow: hidden;
+  border-bottom: 1px solid var(--surface-rim);
+}
+
+.repository-ws-dock-meta .history-inspector-head {
+  max-height: 104px;
+  padding: 9px 42px 8px 12px;
+  border-bottom: 0;
+}
+
+.repository-ws-dock-meta .history-inspector-message {
+  display: none;
+}
+
+.repository-ws-dock-meta .history-author {
+  margin-top: 5px;
+}
+
+.repository-ws-dock-meta .history-avatar {
+  display: none;
+}
+
+.repository-ws-dock-meta .history-inspector-ids,
+.repository-ws-dock-meta .history-ref-chips {
+  margin-top: 5px;
+}
+
+.repository-ws-dock-close {
+  position: absolute;
+  top: 5px;
+  right: 7px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .repository-identity .repository-ws-toggle,
+  .repository-ws-tree-row {
+    transition-duration: .01ms;
+  }
+}
+
 /* ── Compare 뷰 ── */
 .repository-compare { display: grid; grid-template-rows: auto minmax(0, 1fr); height: 100%; min-height: 0; }
 .repository-compare-controls { display: flex; align-items: center; gap: 6px; padding: 7px 10px; border-bottom: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--surface-band) 55%, transparent); }

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1244,8 +1244,8 @@
   overflow: hidden;
 }
 
-.repository-ws-main > .repository-root,
-.repository-ws-main > .repository-compare {
+.repository-ws-main .repository-source-fill > .repository-root,
+.repository-ws-main .repository-source-fill > .repository-compare {
   height: 100%;
 }
 

--- a/runtime/fleet-plugins/repository/client/workspace-layout.ts
+++ b/runtime/fleet-plugins/repository/client/workspace-layout.ts
@@ -30,29 +30,36 @@ export function calculateWorkspaceExtraWidth(innerWidth: number, baseWidth = WOR
   return Math.max(0, Math.min(1200, innerWidth - 400) - baseWidth);
 }
 
-export function readWorkspaceMode(storage: StorageLike = localStorage): boolean {
-  try { return storage.getItem(PREFS_WORKSPACE) === "1"; }
+export function readWorkspaceMode(storage?: StorageLike): boolean {
+  try { return (storage ?? globalThis.localStorage).getItem(PREFS_WORKSPACE) === "1"; }
   catch { return false; }
 }
 
-export function saveWorkspaceMode(enabled: boolean, storage: StorageLike = localStorage): void {
+export function saveWorkspaceMode(enabled: boolean, storage?: StorageLike): void {
   try {
-    if (enabled) storage.setItem(PREFS_WORKSPACE, "1");
-    else storage.removeItem(PREFS_WORKSPACE);
+    const target = storage ?? globalThis.localStorage;
+    if (enabled) target.setItem(PREFS_WORKSPACE, "1");
+    else target.removeItem(PREFS_WORKSPACE);
   } catch { /* best-effort preference */ }
 }
 
-export function readWorkspaceDockHeight(storage: StorageLike = localStorage): number {
+export function readWorkspaceDockHeight(storage?: StorageLike): number {
   try {
-    const value = Number.parseFloat(storage.getItem(PREFS_WORKSPACE_DOCK_HEIGHT) ?? "");
+    const value = Number.parseFloat((storage ?? globalThis.localStorage).getItem(PREFS_WORKSPACE_DOCK_HEIGHT) ?? "");
     if (Number.isFinite(value) && value >= WORKSPACE_DOCK_MIN_HEIGHT) return value;
   } catch { /* best-effort preference */ }
   return WORKSPACE_DOCK_DEFAULT_HEIGHT;
 }
 
-export function saveWorkspaceDockHeight(height: number, storage: StorageLike = localStorage): void {
-  try { storage.setItem(PREFS_WORKSPACE_DOCK_HEIGHT, String(height)); }
+export function saveWorkspaceDockHeight(height: number, storage?: StorageLike): void {
+  try { (storage ?? globalThis.localStorage).setItem(PREFS_WORKSPACE_DOCK_HEIGHT, String(height)); }
   catch { /* best-effort preference */ }
+}
+
+export function normalizeWorkspaceDockHeight(storedHeight: number, containerHeight: number): number {
+  const maximum = containerHeight - 180 - 4;
+  if (maximum <= WORKSPACE_DOCK_MIN_HEIGHT) return Math.max(0, maximum);
+  return Math.max(WORKSPACE_DOCK_MIN_HEIGHT, Math.min(maximum, storedHeight));
 }
 
 export function clampWorkspaceDockHeight(startHeight: number, pointerDeltaY: number, containerHeight: number): number | null {

--- a/runtime/fleet-plugins/repository/client/workspace-layout.ts
+++ b/runtime/fleet-plugins/repository/client/workspace-layout.ts
@@ -1,0 +1,77 @@
+export const WORKSPACE_BASE_WIDTH = 312;
+export const WORKSPACE_DOCK_DEFAULT_HEIGHT = 230;
+export const WORKSPACE_DOCK_MIN_HEIGHT = 160;
+
+export const PREFS_WORKSPACE = "fleet-console.repository.workspace";
+export const PREFS_WORKSPACE_DOCK_HEIGHT = "fleet-console.repository.workspace.dockHeight";
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export interface WorkspaceTreeCounts {
+  readonly context: number;
+  readonly changes: number;
+  readonly worktrees: number;
+  readonly branches: number;
+  readonly tags: number;
+  readonly stashes: number;
+}
+
+export type WorkspaceTreeSection = {
+  readonly id: "context" | "working" | "worktrees" | "branches" | "tags" | "stashes";
+  readonly label: "CONTEXT" | "WORKING" | "WORKTREES" | "BRANCHES" | "TAGS" | "STASHES";
+  readonly count: number;
+};
+
+export function calculateWorkspaceExtraWidth(innerWidth: number, baseWidth = WORKSPACE_BASE_WIDTH): number {
+  return Math.max(0, Math.min(1200, innerWidth - 400) - baseWidth);
+}
+
+export function readWorkspaceMode(storage: StorageLike = localStorage): boolean {
+  try { return storage.getItem(PREFS_WORKSPACE) === "1"; }
+  catch { return false; }
+}
+
+export function saveWorkspaceMode(enabled: boolean, storage: StorageLike = localStorage): void {
+  try {
+    if (enabled) storage.setItem(PREFS_WORKSPACE, "1");
+    else storage.removeItem(PREFS_WORKSPACE);
+  } catch { /* best-effort preference */ }
+}
+
+export function readWorkspaceDockHeight(storage: StorageLike = localStorage): number {
+  try {
+    const value = Number.parseFloat(storage.getItem(PREFS_WORKSPACE_DOCK_HEIGHT) ?? "");
+    if (Number.isFinite(value) && value >= WORKSPACE_DOCK_MIN_HEIGHT) return value;
+  } catch { /* best-effort preference */ }
+  return WORKSPACE_DOCK_DEFAULT_HEIGHT;
+}
+
+export function saveWorkspaceDockHeight(height: number, storage: StorageLike = localStorage): void {
+  try { storage.setItem(PREFS_WORKSPACE_DOCK_HEIGHT, String(height)); }
+  catch { /* best-effort preference */ }
+}
+
+export function clampWorkspaceDockHeight(startHeight: number, pointerDeltaY: number, containerHeight: number): number | null {
+  const maximum = containerHeight - 180 - 4;
+  if (maximum < WORKSPACE_DOCK_MIN_HEIGHT) return null;
+  return Math.max(WORKSPACE_DOCK_MIN_HEIGHT, Math.min(maximum, startHeight - pointerDeltaY));
+}
+
+export function buildWorkspaceDockTemplate(dockHeight: number): string {
+  return `minmax(180px, 1fr) 4px ${dockHeight}px`;
+}
+
+export function buildWorkspaceTreeSections(counts: WorkspaceTreeCounts): readonly WorkspaceTreeSection[] {
+  return [
+    { id: "context", label: "CONTEXT", count: counts.context },
+    { id: "working", label: "WORKING", count: counts.changes },
+    { id: "worktrees", label: "WORKTREES", count: counts.worktrees },
+    { id: "branches", label: "BRANCHES", count: counts.branches },
+    { id: "tags", label: "TAGS", count: counts.tags },
+    { id: "stashes", label: "STASHES", count: counts.stashes },
+  ];
+}

--- a/runtime/fleet-plugins/repository/tests/workspace-layout.test.ts
+++ b/runtime/fleet-plugins/repository/tests/workspace-layout.test.ts
@@ -6,6 +6,7 @@ import {
   WORKSPACE_DOCK_DEFAULT_HEIGHT,
   buildWorkspaceTreeSections,
   calculateWorkspaceExtraWidth,
+  normalizeWorkspaceDockHeight,
   readWorkspaceDockHeight,
   readWorkspaceMode,
   saveWorkspaceDockHeight,
@@ -51,6 +52,25 @@ describe("Repository workspace layout", () => {
 
     storage.setItem(PREFS_WORKSPACE_DOCK_HEIGHT, "12");
     expect(readWorkspaceDockHeight(storage)).toBe(WORKSPACE_DOCK_DEFAULT_HEIGHT);
+  });
+
+  it("falls back safely when the storage accessor itself throws", () => {
+    const throwing = {
+      get getItem(): never { throw new Error("denied"); },
+      get setItem(): never { throw new Error("denied"); },
+      get removeItem(): never { throw new Error("denied"); },
+    } as unknown as Parameters<typeof readWorkspaceMode>[0];
+    expect(readWorkspaceMode(throwing)).toBe(false);
+    expect(readWorkspaceDockHeight(throwing)).toBe(WORKSPACE_DOCK_DEFAULT_HEIGHT);
+    expect(() => saveWorkspaceMode(true, throwing)).not.toThrow();
+    expect(() => saveWorkspaceDockHeight(300, throwing)).not.toThrow();
+  });
+
+  it("normalizes a stored dock height against the current container", () => {
+    expect(normalizeWorkspaceDockHeight(800, 500)).toBe(316);
+    expect(normalizeWorkspaceDockHeight(230, 900)).toBe(230);
+    expect(normalizeWorkspaceDockHeight(100, 900)).toBe(160);
+    expect(normalizeWorkspaceDockHeight(800, 200)).toBe(16);
   });
 
   it("builds the fixed source-tree section order with source counts", () => {

--- a/runtime/fleet-plugins/repository/tests/workspace-layout.test.ts
+++ b/runtime/fleet-plugins/repository/tests/workspace-layout.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PREFS_WORKSPACE,
+  PREFS_WORKSPACE_DOCK_HEIGHT,
+  WORKSPACE_DOCK_DEFAULT_HEIGHT,
+  buildWorkspaceTreeSections,
+  calculateWorkspaceExtraWidth,
+  readWorkspaceDockHeight,
+  readWorkspaceMode,
+  saveWorkspaceDockHeight,
+  saveWorkspaceMode,
+} from "../client/workspace-layout.js";
+
+function memoryStorage() {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => { values.set(key, value); },
+    removeItem: (key: string) => { values.delete(key); },
+  };
+}
+
+describe("Repository workspace layout", () => {
+  it("persists expansion as 1 and removes the preference on collapse", () => {
+    const storage = memoryStorage();
+
+    expect(readWorkspaceMode(storage)).toBe(false);
+    saveWorkspaceMode(true, storage);
+    expect(storage.getItem(PREFS_WORKSPACE)).toBe("1");
+    expect(readWorkspaceMode(storage)).toBe(true);
+
+    saveWorkspaceMode(false, storage);
+    expect(storage.getItem(PREFS_WORKSPACE)).toBeNull();
+    expect(readWorkspaceMode(storage)).toBe(false);
+  });
+
+  it("calculates extra width from the capped viewport allowance and rail base", () => {
+    expect(calculateWorkspaceExtraWidth(600)).toBe(0);
+    expect(calculateWorkspaceExtraWidth(1440)).toBe(728);
+    expect(calculateWorkspaceExtraWidth(2000)).toBe(888);
+  });
+
+  it("persists the dock height and falls back for invalid values", () => {
+    const storage = memoryStorage();
+    expect(readWorkspaceDockHeight(storage)).toBe(WORKSPACE_DOCK_DEFAULT_HEIGHT);
+
+    saveWorkspaceDockHeight(284, storage);
+    expect(storage.getItem(PREFS_WORKSPACE_DOCK_HEIGHT)).toBe("284");
+    expect(readWorkspaceDockHeight(storage)).toBe(284);
+
+    storage.setItem(PREFS_WORKSPACE_DOCK_HEIGHT, "12");
+    expect(readWorkspaceDockHeight(storage)).toBe(WORKSPACE_DOCK_DEFAULT_HEIGHT);
+  });
+
+  it("builds the fixed source-tree section order with source counts", () => {
+    expect(buildWorkspaceTreeSections({
+      context: 3,
+      changes: 5,
+      worktrees: 2,
+      branches: 9,
+      tags: 4,
+      stashes: 1,
+    })).toEqual([
+      { id: "context", label: "CONTEXT", count: 3 },
+      { id: "working", label: "WORKING", count: 5 },
+      { id: "worktrees", label: "WORKTREES", count: 2 },
+      { id: "branches", label: "BRANCHES", count: 9 },
+      { id: "tags", label: "TAGS", count: 4 },
+      { id: "stashes", label: "STASHES", count: 1 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Repository 레일 패널에 Workspace 확장 모드를 추가합니다. 패널이 우측 레일 소속을 유지한 채 `ctx.requestExtraWidth`로 와이드 확장되고, 확장 상태에서는 좌측 소스 트리(재귀 저장소 discovery + CONTEXT/WORKING/WORKTREES/BRANCHES/TAGS/STASHES 상시 트리) · 중앙 커밋 그래프 상주 · 하단 커밋 상세 도크(파일 목록 + 메타 + diff)의 3-존 레이아웃을 렌더합니다.
- 비확장(기존 폭) 상태의 현행 source-nav UI는 무변경으로 보존하며, 확장 상태와 도크 높이는 localStorage로 영속됩니다.
- Sentinel QA 반영: storage 접근 예외 안전화(`globalThis.localStorage`를 try 내부에서 평가), 저장된 도크 높이를 현재 컨테이너 기준으로 정규화(ResizeObserver).

## Test Plan
- [x] `pnpm --filter @fleet-plugins/repository test` — 253 passed
- [x] `pnpm --filter @dotobokuri/fleet-console build` — green (typecheck는 선존 TS2882 실패로 build가 컴파일 게이트)
- [x] 격리 콘솔 헤디드 e2e — 확장(879px @1280 viewport)/축소/reload 복원/비확장 무회귀/페이지 에러 0
- [x] Changelog: `.changelog.d/pr-356.md` — 프래그먼트 문법·이중언어 요약·`compile-changelog-fragments.mjs --check` 검증 완료
