### PR TITLE
fix(console): render the sidebar idle status dot in green

### DIFF
--- a/.changelog.d/pr-358.md
+++ b/.changelog.d/pr-358.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Render the sidebar Operation status dot in green for idle panels, matching the panel header beacon.
+  ko: 완료(idle)된 패널의 사이드바 상태 dot을 패널 헤더 beacon과 동일한 초록색으로 표시합니다.

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -206,7 +206,7 @@ function chipStatusClass(status: OperationActivity | undefined): string {
   if (visual === "running") return "tenant-beacon is-turn-running";
   if (visual === "awaiting") return "tenant-beacon is-awaiting";
   if (visual === "dormant") return "tenant-beacon is-dormant";
-  return "is-idle";
+  return "tenant-beacon is-idle";
 }
 
 function chipStatusLabel(status: OperationActivity | undefined): string {

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2698,10 +2698,6 @@
   box-shadow: 0 0 6px var(--coral-glow);
 }
 
-.side-bar-chip-status.is-idle {
-  opacity: 0.5;
-}
-
 @keyframes side-bar-chip-status-pulse {
   0%, 100% { opacity: 0.55; }
   50% { opacity: 1; }

--- a/runtime/fleet-console/tests/operations-side-bar-chip-status.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-chip-status.test.ts
@@ -22,8 +22,8 @@ describe("OperationsSideBarChip activity status", () => {
     ["running", "tenant-beacon is-turn-running", "Running"],
     ["awaiting", "tenant-beacon is-awaiting", "Awaiting input"],
     ["dormant", "tenant-beacon is-dormant", "Dormant"],
-    ["idle", "is-idle", "Idle"],
-    [undefined, "is-idle", "Idle"],
+    ["idle", "tenant-beacon is-idle", "Idle"],
+    [undefined, "tenant-beacon is-idle", "Idle"],
   ] as const)("renders %s as the matching status class and accessible label", (status, expectedClass, expectedLabel) => {
     const statusDot = renderChip(status);
 


### PR DESCRIPTION
## Summary
- 완료(idle)된 패널의 좌측 사이드바 상태 dot이 패널 헤더 beacon과 달리 gray로 표시되던 결함 수정 — `chipStatusClass()` idle 반환값을 `tenant-beacon is-idle`로 통일해 패널과 동일한 green(`--positive`)으로 렌더
- gray + opacity 0.5를 주던 `.side-bar-chip-status.is-idle` 규칙 삭제(사이즈 6px는 `.side-bar-chip-status` base가 유지)
- 고정되어 있던 chip 상태 테스트 기대값 갱신

## Test Plan
- [x] `vitest run tests/operations-side-bar-chip-status.test.ts tests/instrument-design-contract.test.ts` — 24/24 통과
- [x] `pnpm --filter fleet-console build` — green
- [x] Sentinel 코드 리뷰 — PASS (finding 0)
- [x] console-e2e 실브라우저 실측 — idle 칩 dot computed `oklch(0.76 0.11 160)`(=`--positive` green), 6px, opacity 1, 스크린샷 확인
- [x] `.changelog.d/pr-358.md` — fragment 추가, `compile-changelog-fragments.mjs --check` 통과