### PR TITLE
fix(console): multiplex Session Analyst streams

### DIFF
--- a/.changelog.d/pr-359.md
+++ b/.changelog.d/pr-359.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] Keep Session Analyst responsive across multiple Operations by sharing one browser event stream.
+  ko: 하나의 브라우저 이벤트 스트림을 공유해 여러 Operation에서 Session Analyst가 계속 응답하도록 합니다.

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-api.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-api.ts
@@ -4,6 +4,26 @@ import { parseAnalysisCatalog, parseAnalysisError, parseAnalysisEvent, type Anal
 
 export class AnalysisApiError extends Error { constructor(readonly code: string, message: string) { super(message); } }
 const base = (operationId: string) => `analysis/${encodeURIComponent(operationId)}`;
+const GLOBAL_STREAM_URL = "/plugins/terminal/analysis/stream";
+const SESSION_NOT_FOUND: AnalysisEvent = { type: "error", error: { code: "analysis_session_not_found", message: "Analysis session was not found." } };
+const RECREATE_BASE_DELAY_MS = 250;
+const RECREATE_MAX_DELAY_MS = 4_000;
+
+type OperationListener = (event: AnalysisEvent) => void;
+interface OperationRecord {
+  listeners: Set<OperationListener>;
+  confirmedEpoch: number | null;
+}
+
+let physicalSource: EventSource | null = null;
+let physicalSourceId = 0;
+let rosterEpoch = 0;
+let lastRoster = new Set<string>();
+let rosterFresh = false;
+let pendingRecreateTimer: ReturnType<typeof setTimeout> | null = null;
+let recreateDelayMs = RECREATE_BASE_DELAY_MS;
+const operations = new Map<string, OperationRecord>();
+
 export function analysisArtifactUrl(artifactId: string, theme: ConsoleTheme, canvas: string, foreground: string): string {
   const query = new URLSearchParams({ theme, canvas, foreground });
   return `/plugins/terminal/analysis/artifacts/${encodeURIComponent(artifactId)}?${query.toString()}`;
@@ -33,9 +53,192 @@ export async function clearAnalysisArtifacts(api: ClientApiCapability, operation
   const response = await fetchOrThrow(api, `${base(operationId)}/artifacts`, { method: "DELETE" });
   if (!response.ok) throw errorFrom(response.status, await response.json().catch(() => null));
 }
-export function subscribeAnalysis(api: ClientApiCapability, operationId: string, onEvent: (event: AnalysisEvent) => void): () => void {
-  return api.subscribe("terminal", `${base(operationId)}/stream`, (message) => { try { const event = parseAnalysisEvent(JSON.parse(message.data)); if (event) onEvent(event); } catch {} });
+
+export function subscribeAnalysis(_api: ClientApiCapability, operationId: string, onEvent: (event: AnalysisEvent) => void): () => void {
+  return subscribeOperation(operationId, onEvent);
 }
+
+export function resetAnalysisStreamHubForTests(): void {
+  cancelPendingRecreate();
+  markRosterStale();
+  physicalSource?.close();
+  physicalSource = null;
+  physicalSourceId = 0;
+  rosterEpoch = 0;
+  lastRoster = new Set();
+  resetRecreateBackoff();
+  operations.clear();
+}
+
+function subscribeOperation(operationId: string, listener: OperationListener): () => void {
+  let record = operations.get(operationId);
+  if (!record) {
+    record = { listeners: new Set(), confirmedEpoch: null };
+    operations.set(operationId, record);
+  }
+  record.listeners.add(listener);
+  ensurePhysicalSource();
+  queueMicrotask(() => {
+    if (!record!.listeners.has(listener)) return;
+    if (physicalSource?.readyState !== EventSource.OPEN) return;
+    if (!rosterFresh || !lastRoster.has(operationId)) return;
+    if (record!.confirmedEpoch !== null) return;
+    record!.confirmedEpoch = rosterEpoch;
+    listener({ type: "connected" });
+  });
+  return () => {
+    record!.listeners.delete(listener);
+    if (record!.listeners.size === 0) operations.delete(operationId);
+    closePhysicalIfIdle();
+  };
+}
+
+function hasSubscribers(): boolean {
+  for (const record of operations.values()) {
+    if (record.listeners.size > 0) return true;
+  }
+  return false;
+}
+
+function markRosterStale(): void {
+  rosterFresh = false;
+}
+
+function resetRecreateBackoff(): void {
+  recreateDelayMs = RECREATE_BASE_DELAY_MS;
+}
+
+function cancelPendingRecreate(): void {
+  if (pendingRecreateTimer === null) return;
+  clearTimeout(pendingRecreateTimer);
+  pendingRecreateTimer = null;
+}
+
+function closePhysicalIfIdle(): void {
+  if (hasSubscribers()) return;
+  cancelPendingRecreate();
+  markRosterStale();
+  physicalSource?.close();
+  physicalSource = null;
+  resetRecreateBackoff();
+}
+
+function replacePhysicalSource(): void {
+  cancelPendingRecreate();
+  markRosterStale();
+  physicalSource?.close();
+  physicalSourceId += 1;
+  const sourceId = physicalSourceId;
+  const source = new EventSource(GLOBAL_STREAM_URL);
+  physicalSource = source;
+  bindSourceHandlers(source, sourceId);
+}
+
+function ensurePhysicalSource(): void {
+  if (physicalSource && physicalSource.readyState !== EventSource.CLOSED) return;
+  if (physicalSource?.readyState === EventSource.CLOSED) {
+    if (hasSubscribers()) scheduleBoundedRecreate();
+    return;
+  }
+  replacePhysicalSource();
+}
+
+function bindSourceHandlers(source: EventSource, sourceId: number): void {
+  source.onmessage = (message) => {
+    if (physicalSource !== source || physicalSourceId !== sourceId) return;
+    if (typeof message.data === "string") dispatchWirePayload(message.data, sourceId);
+  };
+  source.onerror = () => {
+    if (physicalSource !== source || physicalSourceId !== sourceId) return;
+    markRosterStale();
+    if (source.readyState === EventSource.CONNECTING) return;
+    if (source.readyState === EventSource.CLOSED && hasSubscribers()) scheduleBoundedRecreate();
+  };
+}
+
+function scheduleBoundedRecreate(): void {
+  if (pendingRecreateTimer !== null) return;
+  const delay = recreateDelayMs;
+  recreateDelayMs = Math.min(recreateDelayMs * 2, RECREATE_MAX_DELAY_MS);
+  pendingRecreateTimer = setTimeout(() => {
+    pendingRecreateTimer = null;
+    if (!hasSubscribers()) return;
+    if (physicalSource !== null && physicalSource.readyState !== EventSource.CLOSED) return;
+    replacePhysicalSource();
+  }, delay);
+}
+
+function dispatchToOperation(operationId: string, event: AnalysisEvent): void {
+  const record = operations.get(operationId);
+  if (!record) return;
+  for (const listener of record.listeners) listener(event);
+}
+
+function applyRoster(operationIds: readonly string[], sourceId: number): void {
+  if (physicalSourceId !== sourceId) return;
+  const rosterSet = new Set(operationIds);
+  for (const [operationId, record] of operations) {
+    if (record.confirmedEpoch !== null && !rosterSet.has(operationId)) {
+      dispatchToOperation(operationId, SESSION_NOT_FOUND);
+      record.confirmedEpoch = null;
+    }
+  }
+  rosterEpoch += 1;
+  lastRoster = rosterSet;
+  rosterFresh = true;
+  resetRecreateBackoff();
+  for (const operationId of operationIds) {
+    const record = operations.get(operationId);
+    if (!record) continue;
+    record.confirmedEpoch = rosterEpoch;
+    dispatchToOperation(operationId, { type: "connected" });
+  }
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: ReadonlySet<string>): boolean {
+  const actual = Object.keys(value);
+  return actual.length === keys.size && actual.every((key) => keys.has(key));
+}
+
+function parseConnectedFrame(payload: Record<string, unknown>): readonly string[] | null {
+  if (!hasExactKeys(payload, new Set(["type", "operationIds"]))) return null;
+  if (payload.type !== "connected") return null;
+  if (!Array.isArray(payload.operationIds)) return null;
+  for (const value of payload.operationIds) {
+    if (typeof value !== "string") return null;
+  }
+  return payload.operationIds as string[];
+}
+
+function parseEventFrame(payload: Record<string, unknown>): { readonly operationId: string; readonly event: AnalysisEvent } | null {
+  if (!hasExactKeys(payload, new Set(["type", "operationId", "event"]))) return null;
+  if (payload.type !== "event") return null;
+  if (typeof payload.operationId !== "string") return null;
+  if (!payload.event || typeof payload.event !== "object" || Array.isArray(payload.event)) return null;
+  const event = parseAnalysisEvent(payload.event);
+  if (!event) return null;
+  return { operationId: payload.operationId, event };
+}
+
+function dispatchWirePayload(raw: string, sourceId: number): void {
+  if (physicalSourceId !== sourceId) return;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return;
+  const payload = parsed as Record<string, unknown>;
+  const connected = parseConnectedFrame(payload);
+  if (connected) {
+    applyRoster(connected, sourceId);
+    return;
+  }
+  const eventFrame = parseEventFrame(payload);
+  if (eventFrame) dispatchToOperation(eventFrame.operationId, eventFrame.event);
+}
+
 async function request(api: ClientApiCapability, path: string, body: Record<string, string>, signal?: AbortSignal): Promise<void> {
   const response = await fetchOrThrow(api, path, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body), ...(signal ? { signal } : {}) });
   if (!response.ok) throw errorFrom(response.status, await response.json().catch(() => null));

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-store.test.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-store.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
 import type { ClientApiCapability } from "@fleet-console/sdk/plugin";
 
+import { resetAnalysisStreamHubForTests, subscribeAnalysis } from "./analysis-api.js";
 import { disposeAnalysisStore, getAnalysisStore } from "./analysis-store.js";
 
 const CATALOG_BODY = JSON.stringify({ clis: [{ cliId: "claude", label: "Claude", available: true, defaultModel: "sonnet", models: [{ id: "sonnet", label: "Sonnet", effortLevels: ["high"], defaultEffort: "high" }] }] });
@@ -8,68 +9,134 @@ const CATALOG_BODY = JSON.stringify({ clis: [{ cliId: "claude", label: "Claude",
 interface StreamHarness {
   readonly api: ClientApiCapability;
   readonly fetch: ReturnType<typeof vi.fn>;
-  readonly emit: (payload: unknown) => void;
-  readonly emitLate: (payload: unknown) => void;
+  readonly subscribe: ReturnType<typeof vi.fn>;
+  readonly emitRoster: (operationIds: readonly string[]) => void;
+  readonly replaceRoster: (operationIds: readonly string[]) => void;
+  readonly emit: (operationId: string, payload: unknown) => void;
+  readonly emitLate: (operationId: string, payload: unknown) => void;
+  readonly deliverRaw: (raw: string) => void;
   readonly streamReady: () => boolean;
+  readonly streamOpen: () => boolean;
   readonly unsubscribeCount: () => number;
+  readonly eventSourceCount: () => number;
+}
+
+class TestEventSource {
+  static instances: TestEventSource[] = [];
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+  readonly url: string;
+  readyState = TestEventSource.CONNECTING;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onerror: (() => void) | null = null;
+  constructor(url: string) {
+    this.url = url;
+    TestEventSource.instances.push(this);
+  }
+  close(): void { this.readyState = TestEventSource.CLOSED; }
+  open(): void { this.readyState = TestEventSource.OPEN; }
+  deliver(data: string): void {
+    if (this.readyState !== TestEventSource.OPEN) return;
+    this.onmessage?.({ data } as MessageEvent<string>);
+  }
+  triggerError(): void { this.onerror?.(); }
 }
 
 function createHarness(onPath?: (path: string, init?: RequestInit) => Response | Promise<Response> | null): StreamHarness {
-  let stream: ((event: MessageEvent<string>) => void) | null = null;
-  let lastStream: ((event: MessageEvent<string>) => void) | null = null;
+  TestEventSource.instances = [];
+  const activeOperations = new Set<string>();
   let unsubscribeCount = 0;
   const fetch = vi.fn(async (_pluginId: string, path: string, init?: RequestInit) => {
     const override = onPath?.(path, init);
     if (override) return override;
     return new Response(path === "analysis/catalog" ? CATALOG_BODY : "{}", { status: 200, headers: { "Content-Type": "application/json" } });
   });
-  const api = {
-    fetch,
-    subscribe: (_pluginId: string, _path: string, listener: (event: MessageEvent<string>) => void) => {
-      stream = listener;
-      lastStream = listener;
-      return () => {
-        if (stream === listener) stream = null;
-        unsubscribeCount += 1;
-      };
-    },
-    resync: vi.fn(),
-  } satisfies ClientApiCapability;
+  const subscribe = vi.fn((_pluginId: string, _path: string, _listener: (event: MessageEvent<string>) => void) => {
+    return () => { unsubscribeCount += 1; };
+  });
+  const api = { fetch, subscribe, resync: vi.fn() } satisfies ClientApiCapability;
+  const deliverRoster = () => {
+    const source = TestEventSource.instances.at(-1);
+    source?.open();
+    source?.deliver(JSON.stringify({
+      type: "connected",
+      operationIds: [...activeOperations].sort(),
+    }));
+  };
   return {
     api,
     fetch,
-    emit: (payload) => stream?.({ data: JSON.stringify(payload) } as MessageEvent<string>),
-    emitLate: (payload) => lastStream?.({ data: JSON.stringify(payload) } as MessageEvent<string>),
-    streamReady: () => stream !== null,
+    subscribe,
+    emitRoster: (operationIds) => {
+      for (const operationId of operationIds) activeOperations.add(operationId);
+      deliverRoster();
+    },
+    replaceRoster: (operationIds) => {
+      activeOperations.clear();
+      for (const operationId of operationIds) activeOperations.add(operationId);
+      deliverRoster();
+    },
+    emit: (operationId, payload) => {
+      const source = TestEventSource.instances.at(-1);
+      source?.open();
+      source?.deliver(JSON.stringify({ type: "event", operationId, event: payload }));
+    },
+    emitLate: (operationId, payload) => {
+      const source = TestEventSource.instances.at(-1);
+      source?.open();
+      source?.deliver(JSON.stringify({ type: "event", operationId, event: payload }));
+    },
+    deliverRaw: (raw) => {
+      const source = TestEventSource.instances.at(-1);
+      source?.open();
+      source?.deliver(raw);
+    },
+    streamReady: () => TestEventSource.instances.length > 0,
+    streamOpen: () => TestEventSource.instances.some((instance) => instance.readyState === TestEventSource.OPEN),
     unsubscribeCount: () => unsubscribeCount,
+    eventSourceCount: () => TestEventSource.instances.length,
   };
 }
 
-async function sendWithConnected(store: ReturnType<typeof getAnalysisStore>, harness: StreamHarness, text: string): Promise<void> {
+afterEach(() => {
+  resetAnalysisStreamHubForTests();
+  TestEventSource.instances = [];
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+async function sendWithConnected(store: ReturnType<typeof getAnalysisStore>, harness: StreamHarness, operationId: string, text: string): Promise<void> {
   const pending = store.send(text);
   await vi.waitFor(() => expect(harness.streamReady()).toBe(true));
-  harness.emit({ type: "connected" });
+  harness.emitRoster([operationId]);
   await pending;
 }
 
 describe("per-operation analysis store", () => {
+  beforeEach(() => {
+    vi.stubGlobal("EventSource", TestEventSource);
+  });
+
   it("shares state, gates the first message on the connected frame, and survives companion unmount", async () => {
     const harness = createHarness();
-    const first = getAnalysisStore("operation-store-share", harness.api);
-    const second = getAnalysisStore("operation-store-share", harness.api);
+    const operationId = "operation-store-share";
+    const first = getAnalysisStore(operationId, harness.api);
+    const second = getAnalysisStore(operationId, harness.api);
     await vi.waitFor(() => expect(first.getSnapshot().cliId).toBe("claude"));
 
     expect(second).toBe(first);
     first.dispatch({ type: "set-draft", draft: "Survives panel collapse" });
-    await sendWithConnected(first, harness, "Review this session");
+    await sendWithConnected(first, harness, operationId, "Review this session");
     expect(harness.fetch.mock.calls.map((call) => call[1])).toEqual([
       "analysis/catalog",
       "analysis/operation-store-share/start",
       "analysis/operation-store-share/message",
     ]);
-    harness.emit({ type: "chunk", text: "Looks good" });
+    expect(harness.subscribe).not.toHaveBeenCalled();
+    harness.emit(operationId, { type: "chunk", text: "Looks good" });
     expect(second.getSnapshot().entries.at(-1)).toEqual({ role: "analyst", text: "Looks good" });
-    harness.emit({ type: "complete" });
+    harness.emit(operationId, { type: "complete" });
     expect(first.getSnapshot().busy).toBe(false);
 
     // EXIT only unmounts companions, so the shared conversation and server session remain alive.
@@ -86,37 +153,39 @@ describe("per-operation analysis store", () => {
 
   it("automatically sends queued questions in FIFO order after each completion", async () => {
     const harness = createHarness();
-    const store = getAnalysisStore("operation-store-queue", harness.api);
+    const operationId = "operation-store-queue";
+    const store = getAnalysisStore(operationId, harness.api);
     await vi.waitFor(() => expect(store.getSnapshot().cliId).toBe("claude"));
-    await sendWithConnected(store, harness, "Initial question");
+    await sendWithConnected(store, harness, operationId, "Initial question");
     store.dispatch({ type: "queue-push", text: "First queued" });
     store.dispatch({ type: "queue-push", text: "Second queued" });
 
-    harness.emit({ type: "complete" });
+    harness.emit(operationId, { type: "complete" });
     await vi.waitFor(() => expect(store.getSnapshot()).toMatchObject({ busy: true, queue: ["Second queued"] }));
     expect(messageBodies(harness)).toEqual(["Initial question", "First queued"]);
 
-    harness.emit({ type: "complete" });
+    harness.emit(operationId, { type: "complete" });
     await vi.waitFor(() => expect(store.getSnapshot()).toMatchObject({ busy: true, queue: [] }));
     expect(messageBodies(harness)).toEqual(["Initial question", "First queued", "Second queued"]);
 
-    harness.emit({ type: "complete" });
-    disposeAnalysisStore("operation-store-queue");
+    harness.emit(operationId, { type: "complete" });
+    disposeAnalysisStore(operationId);
   });
 
   it("clears queued questions on stop and never fires them from late completion", async () => {
     const harness = createHarness();
-    const store = getAnalysisStore("operation-store-queue-stop", harness.api);
+    const operationId = "operation-store-queue-stop";
+    const store = getAnalysisStore(operationId, harness.api);
     await vi.waitFor(() => expect(store.getSnapshot().cliId).toBe("claude"));
-    await sendWithConnected(store, harness, "Initial question");
+    await sendWithConnected(store, harness, operationId, "Initial question");
     store.dispatch({ type: "queue-push", text: "Must not fire" });
 
     await store.stop();
     expect(store.getSnapshot().queue).toEqual([]);
-    harness.emitLate({ type: "complete" });
+    harness.emitLate(operationId, { type: "complete" });
     await Promise.resolve();
     expect(messageBodies(harness)).toEqual(["Initial question"]);
-    disposeAnalysisStore("operation-store-queue-stop");
+    disposeAnalysisStore(operationId);
   });
 
   it("rolls back started when the start request fails so selectors reopen", async () => {
@@ -139,15 +208,16 @@ describe("per-operation analysis store", () => {
     const harness = createHarness((path) => path.endsWith("/start")
       ? new Response(JSON.stringify({ error: { code: "analysis_session_exists", message: "Analysis session already exists." } }), { status: 409, headers: { "Content-Type": "application/json" } })
       : null);
-    const store = getAnalysisStore("operation-store-adopt", harness.api);
+    const operationId = "operation-store-adopt";
+    const store = getAnalysisStore(operationId, harness.api);
     await vi.waitFor(() => expect(store.getSnapshot().cliId).toBe("claude"));
 
-    await sendWithConnected(store, harness, "Continue the analysis");
+    await sendWithConnected(store, harness, operationId, "Continue the analysis");
     expect(store.getSnapshot().error).toBeNull();
     expect(store.getSnapshot().started).toBe(true);
-    expect(harness.fetch.mock.calls.some((call) => call[1] === "analysis/operation-store-adopt/message")).toBe(true);
-    harness.emit({ type: "complete" });
-    disposeAnalysisStore("operation-store-adopt");
+    expect(harness.fetch.mock.calls.some((call) => call[1] === `analysis/${operationId}/message`)).toBe(true);
+    harness.emit(operationId, { type: "complete" });
+    disposeAnalysisStore(operationId);
   });
 
   it("drops a missing session after message failure and restarts from start on the next send", async () => {
@@ -156,37 +226,38 @@ describe("per-operation analysis store", () => {
       if (!path.endsWith("/message") || messageCount++ > 0) return null;
       return new Response(JSON.stringify({ error: { code: "analysis_session_not_found", message: "Analysis session was not found." } }), { status: 404, headers: { "Content-Type": "application/json" } });
     });
-    const store = getAnalysisStore("operation-store-message-lost", harness.api);
+    const operationId = "operation-store-message-lost";
+    const store = getAnalysisStore(operationId, harness.api);
     await vi.waitFor(() => expect(store.getSnapshot().cliId).toBe("claude"));
 
-    await sendWithConnected(store, harness, "First attempt");
+    await sendWithConnected(store, harness, operationId, "First attempt");
     expect(store.getSnapshot()).toMatchObject({ started: false, busy: false, error: "Analysis session ended — send again to restart." });
-    expect(harness.streamReady()).toBe(false);
-    expect(harness.unsubscribeCount()).toBe(1);
+    expect(harness.streamOpen()).toBe(false);
 
-    await sendWithConnected(store, harness, "Second attempt");
+    await sendWithConnected(store, harness, operationId, "Second attempt");
     const paths = harness.fetch.mock.calls.map((call) => call[1]);
     expect(paths.filter((path) => path.endsWith("/start"))).toHaveLength(2);
     expect(paths.filter((path) => path.endsWith("/message"))).toHaveLength(2);
     expect(store.getSnapshot().started).toBe(true);
-    harness.emit({ type: "complete" });
-    disposeAnalysisStore("operation-store-message-lost");
+    harness.emit(operationId, { type: "complete" });
+    disposeAnalysisStore(operationId);
   });
 
   it("stops through the endpoint, preserves output, rejects late events, and starts fresh on the next send", async () => {
     const harness = createHarness();
-    const store = getAnalysisStore("operation-store-stop", harness.api);
+    const operationId = "operation-store-stop";
+    const store = getAnalysisStore(operationId, harness.api);
     await vi.waitFor(() => expect(store.getSnapshot().cliId).toBe("claude"));
 
-    await sendWithConnected(store, harness, "First analysis");
-    harness.emit({ type: "tool", title: "wiki_read", status: "running" });
-    harness.emit({ type: "chunk", text: "Confirmed answer" });
-    harness.emit({ type: "artifact", artifact: { id: "artifact-1", title: "Evidence", html: "<p>evidence</p>", createdAt: 1 } });
+    await sendWithConnected(store, harness, operationId, "First analysis");
+    harness.emit(operationId, { type: "tool", title: "wiki_read", status: "running" });
+    harness.emit(operationId, { type: "chunk", text: "Confirmed answer" });
+    harness.emit(operationId, { type: "artifact", artifact: { id: "artifact-1", title: "Evidence", html: "<p>evidence</p>", createdAt: 1 } });
     const beforeStop = store.getSnapshot();
 
     await store.stop();
-    expect(harness.fetch.mock.calls.map((call) => call[1])).toContain("analysis/operation-store-stop/stop");
-    expect(harness.unsubscribeCount()).toBe(1);
+    expect(harness.fetch.mock.calls.map((call) => call[1])).toContain(`analysis/${operationId}/stop`);
+    expect(harness.streamOpen()).toBe(false);
     expect(store.getSnapshot()).toMatchObject({
       started: false,
       busy: false,
@@ -196,35 +267,36 @@ describe("per-operation analysis store", () => {
       latestActivity: { kind: "writing" },
     });
 
-    harness.emitLate({ type: "chunk", text: " late output" });
-    harness.emitLate({ type: "artifact", artifact: { id: "late", title: "Late", html: "<p>late</p>", createdAt: 2 } });
-    harness.emitLate({ type: "complete" });
+    harness.emitLate(operationId, { type: "chunk", text: " late output" });
+    harness.emitLate(operationId, { type: "artifact", artifact: { id: "late", title: "Late", html: "<p>late</p>", createdAt: 2 } });
+    harness.emitLate(operationId, { type: "complete" });
     expect(store.getSnapshot()).toMatchObject({ phase: "stopped", entries: beforeStop.entries, artifacts: beforeStop.artifacts });
 
-    await sendWithConnected(store, harness, "Fresh analysis");
+    await sendWithConnected(store, harness, operationId, "Fresh analysis");
     const paths = harness.fetch.mock.calls.map((call) => call[1]);
     expect(paths.filter((path) => path.endsWith("/start"))).toHaveLength(2);
     expect(paths.filter((path) => path.endsWith("/message"))).toHaveLength(2);
     expect(store.getSnapshot()).toMatchObject({ started: true, busy: true, phase: "starting" });
-    harness.emit({ type: "complete" });
-    disposeAnalysisStore("operation-store-stop");
+    harness.emit(operationId, { type: "complete" });
+    disposeAnalysisStore(operationId);
   });
 
   it("stops the server before reset, clears shared history and artifacts, and rejects late events", async () => {
     const harness = createHarness();
-    const store = getAnalysisStore("operation-store-reset", harness.api);
+    const operationId = "operation-store-reset";
+    const store = getAnalysisStore(operationId, harness.api);
     await vi.waitFor(() => expect(store.getSnapshot().cliId).toBe("claude"));
 
-    await sendWithConnected(store, harness, "Review this session");
-    harness.emit({ type: "chunk", text: "Confirmed answer" });
-    harness.emit({ type: "artifact", artifact: { id: "artifact-1", title: "Evidence", html: "<p>evidence</p>", createdAt: 1 } });
-    harness.emit({ type: "complete" });
+    await sendWithConnected(store, harness, operationId, "Review this session");
+    harness.emit(operationId, { type: "chunk", text: "Confirmed answer" });
+    harness.emit(operationId, { type: "artifact", artifact: { id: "artifact-1", title: "Evidence", html: "<p>evidence</p>", createdAt: 1 } });
+    harness.emit(operationId, { type: "complete" });
 
     await store.reset();
     const resetPaths = harness.fetch.mock.calls.map((call) => call[1]);
-    expect(resetPaths).toContain("analysis/operation-store-reset/stop");
-    expect(resetPaths).toContain("analysis/operation-store-reset/artifacts");
-    expect(resetPaths.indexOf("analysis/operation-store-reset/artifacts")).toBeGreaterThan(resetPaths.indexOf("analysis/operation-store-reset/stop"));
+    expect(resetPaths).toContain(`analysis/${operationId}/stop`);
+    expect(resetPaths).toContain(`analysis/${operationId}/artifacts`);
+    expect(resetPaths.indexOf(`analysis/${operationId}/artifacts`)).toBeGreaterThan(resetPaths.indexOf(`analysis/${operationId}/stop`));
     expect(store.getSnapshot()).toMatchObject({
       cliId: "claude",
       model: "sonnet",
@@ -238,10 +310,10 @@ describe("per-operation analysis store", () => {
       error: null,
     });
 
-    harness.emitLate({ type: "chunk", text: "late output" });
-    harness.emitLate({ type: "artifact", artifact: { id: "late", title: "Late", html: "<p>late</p>", createdAt: 2 } });
+    harness.emitLate(operationId, { type: "chunk", text: "late output" });
+    harness.emitLate(operationId, { type: "artifact", artifact: { id: "late", title: "Late", html: "<p>late</p>", createdAt: 2 } });
     expect(store.getSnapshot()).toMatchObject({ phase: "idle", entries: [], artifacts: [] });
-    disposeAnalysisStore("operation-store-reset");
+    disposeAnalysisStore(operationId);
   });
 
   it("clears server artifacts on idle reset and completes when the clear fails", async () => {
@@ -265,9 +337,10 @@ describe("per-operation analysis store", () => {
       : null);
     const store = getAnalysisStore("operation-store-reset-fail", harness.api);
     await vi.waitFor(() => expect(store.getSnapshot().cliId).toBe("claude"));
-    await sendWithConnected(store, harness, "Review this session");
-    harness.emit({ type: "chunk", text: "Keep this answer" });
-    harness.emit({ type: "artifact", artifact: { id: "artifact-1", title: "Keep this", html: "<p>keep</p>", createdAt: 1 } });
+    const operationId = "operation-store-reset-fail";
+    await sendWithConnected(store, harness, operationId, "Review this session");
+    harness.emit(operationId, { type: "chunk", text: "Keep this answer" });
+    harness.emit(operationId, { type: "artifact", artifact: { id: "artifact-1", title: "Keep this", html: "<p>keep</p>", createdAt: 1 } });
 
     await expect(store.reset()).rejects.toThrow("Process did not stop.");
     expect(store.getSnapshot()).toMatchObject({
@@ -329,39 +402,41 @@ describe("per-operation analysis store", () => {
       });
     });
     const first = getAnalysisStore("operation-store-dispose-during-start", harness.api);
+    const operationId = "operation-store-dispose-during-start";
     await vi.waitFor(() => expect(first.getSnapshot().cliId).toBe("claude"));
 
     const firstSend = first.send("Review this session");
     await vi.waitFor(() => expect(harness.fetch.mock.calls.some((call) => call[1].endsWith("/start"))).toBe(true));
-    disposeAnalysisStore("operation-store-dispose-during-start");
+    disposeAnalysisStore(operationId);
     expect(firstStartSignal?.aborted).toBe(true);
-    const replacement = getAnalysisStore("operation-store-dispose-during-start", harness.api);
+    const replacement = getAnalysisStore(operationId, harness.api);
     expect(replacement).not.toBe(first);
     await vi.waitFor(() => expect(replacement.getSnapshot().cliId).toBe("claude"));
     const replacementSend = replacement.send("Start fresh");
     await firstSend;
     await vi.waitFor(() => expect(harness.streamReady()).toBe(true));
-    harness.emit({ type: "connected" });
+    harness.emitRoster([operationId]);
     await replacementSend;
 
     const paths = harness.fetch.mock.calls.map((call) => call[1]);
-    const stopIndex = paths.indexOf("analysis/operation-store-dispose-during-start/stop");
+    const stopIndex = paths.indexOf(`analysis/${operationId}/stop`);
     expect(paths.filter((path) => path.endsWith("/start"))).toHaveLength(2);
-    expect(stopIndex).toBeGreaterThan(paths.indexOf("analysis/operation-store-dispose-during-start/start"));
-    expect(stopIndex).toBeLessThan(paths.lastIndexOf("analysis/operation-store-dispose-during-start/start"));
+    expect(stopIndex).toBeGreaterThan(paths.indexOf(`analysis/${operationId}/start`));
+    expect(stopIndex).toBeLessThan(paths.lastIndexOf(`analysis/${operationId}/start`));
     expect(paths.filter((path) => path.endsWith("/message"))).toHaveLength(1);
     expect(requestOrder).toEqual(["start-1", "abort-1", "stop", "start-2"]);
-    harness.emit({ type: "complete" });
-    disposeAnalysisStore("operation-store-dispose-during-start");
+    harness.emit(operationId, { type: "complete" });
+    disposeAnalysisStore(operationId);
   });
 
   it("reports stop failure without leaving the store busy or subscribed", async () => {
     const harness = createHarness((path) => path.endsWith("/stop")
       ? new Response(JSON.stringify({ error: { code: "analysis_stop_failed", message: "Process did not stop." } }), { status: 500, headers: { "Content-Type": "application/json" } })
       : null);
-    const store = getAnalysisStore("operation-store-stop-fail", harness.api);
+    const operationId = "operation-store-stop-fail";
+    const store = getAnalysisStore(operationId, harness.api);
     await vi.waitFor(() => expect(store.getSnapshot().cliId).toBe("claude"));
-    await sendWithConnected(store, harness, "Review this session");
+    await sendWithConnected(store, harness, operationId, "Review this session");
 
     await store.stop();
     expect(store.getSnapshot()).toMatchObject({
@@ -370,17 +445,18 @@ describe("per-operation analysis store", () => {
       phase: "error",
       error: "Stop failed: Process did not stop.",
     });
-    expect(harness.streamReady()).toBe(false);
-    disposeAnalysisStore("operation-store-stop-fail");
+    expect(harness.streamOpen()).toBe(false);
+    disposeAnalysisStore(operationId);
   });
 
   it("waits for Stop to settle before starting the next fresh session", async () => {
     let resolveStop!: (response: Response) => void;
     const stopResponse = new Promise<Response>((resolve) => { resolveStop = resolve; });
     const harness = createHarness((path) => path.endsWith("/stop") ? stopResponse : null);
-    const store = getAnalysisStore("operation-store-stop-then-send", harness.api);
+    const operationId = "operation-store-stop-then-send";
+    const store = getAnalysisStore(operationId, harness.api);
     await vi.waitFor(() => expect(store.getSnapshot().cliId).toBe("claude"));
-    await sendWithConnected(store, harness, "First analysis");
+    await sendWithConnected(store, harness, operationId, "First analysis");
 
     const stopping = store.stop();
     const restarting = store.send("Fresh analysis");
@@ -390,28 +466,182 @@ describe("per-operation analysis store", () => {
     resolveStop(new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } }));
     await stopping;
     await vi.waitFor(() => expect(harness.streamReady()).toBe(true));
-    harness.emit({ type: "connected" });
+    harness.emitRoster([operationId]);
     await restarting;
     expect(harness.fetch.mock.calls.map((call) => call[1]).filter((path) => path.endsWith("/start"))).toHaveLength(2);
-    harness.emit({ type: "complete" });
-    disposeAnalysisStore("operation-store-stop-then-send");
+    harness.emit(operationId, { type: "complete" });
+    disposeAnalysisStore(operationId);
   });
 
   it("unsubscribes after an analysis_exited stream event and restarts on the next send", async () => {
     const harness = createHarness();
-    const store = getAnalysisStore("operation-store-stream-lost", harness.api);
+    const operationId = "operation-store-stream-lost";
+    const store = getAnalysisStore(operationId, harness.api);
     await vi.waitFor(() => expect(store.getSnapshot().cliId).toBe("claude"));
 
-    await sendWithConnected(store, harness, "First attempt");
-    harness.emit({ type: "error", error: { code: "analysis_exited", message: "Process exited." } });
+    await sendWithConnected(store, harness, operationId, "First attempt");
+    harness.emit(operationId, { type: "error", error: { code: "analysis_exited", message: "Process exited." } });
     expect(store.getSnapshot()).toMatchObject({ started: false, busy: false, error: "Analysis session ended — send again to restart." });
-    expect(harness.streamReady()).toBe(false);
-    expect(harness.unsubscribeCount()).toBe(1);
+    expect(harness.streamOpen()).toBe(false);
 
-    await sendWithConnected(store, harness, "Second attempt");
+    await sendWithConnected(store, harness, operationId, "Second attempt");
     expect(harness.fetch.mock.calls.map((call) => call[1]).filter((path) => path.endsWith("/start"))).toHaveLength(2);
-    harness.emit({ type: "complete" });
-    disposeAnalysisStore("operation-store-stream-lost");
+    harness.emit(operationId, { type: "complete" });
+    disposeAnalysisStore(operationId);
+  });
+
+  it("shares one physical EventSource across six capability-distinct stores", async () => {
+    const harness = createHarness();
+    const operationIds = Array.from({ length: 6 }, (_value, index) => `operation-store-multiplex-${index}`);
+    const apis = operationIds.map((_operationId, index) => ({ ...harness.api, marker: index }));
+    const stores = operationIds.map((operationId, index) => getAnalysisStore(operationId, apis[index]!));
+    await Promise.all(stores.map((store) => vi.waitFor(() => expect(store.getSnapshot().cliId).toBe("claude"))));
+    await Promise.all(stores.map((store, index) => sendWithConnected(store, harness, operationIds[index]!, `Question ${index}`)));
+    expect(harness.eventSourceCount()).toBe(1);
+    expect(TestEventSource.instances[0]?.url).toBe("/plugins/terminal/analysis/stream");
+    expect(harness.subscribe).not.toHaveBeenCalled();
+    harness.emit(operationIds[0]!, { type: "chunk", text: "alpha" });
+    harness.emit(operationIds[5]!, { type: "chunk", text: "zeta" });
+    expect(stores[0]!.getSnapshot().entries.at(-1)).toEqual({ role: "analyst", text: "alpha" });
+    expect(stores[5]!.getSnapshot().entries.at(-1)).toEqual({ role: "analyst", text: "zeta" });
+    expect(stores[1]!.getSnapshot().entries.filter((entry) => entry.role === "analyst")).toHaveLength(0);
+    disposeAnalysisStore(operationIds[0]!);
+    expect(harness.streamOpen()).toBe(true);
+    for (const operationId of operationIds.slice(1)) disposeAnalysisStore(operationId);
+    expect(harness.streamOpen()).toBe(false);
+  });
+
+  it("rejects only confirmed subscriptions missing from a reconnect roster", async () => {
+    const harness = createHarness();
+    const kept = "operation-store-reconnect-kept";
+    const lost = "operation-store-reconnect-lost";
+    const pending = "operation-store-reconnect-pending";
+    const keptStore = getAnalysisStore(kept, harness.api);
+    const lostStore = getAnalysisStore(lost, harness.api);
+    await vi.waitFor(() => expect(keptStore.getSnapshot().cliId).toBe("claude"));
+    await sendWithConnected(keptStore, harness, kept, "Keep me");
+    await sendWithConnected(lostStore, harness, lost, "Lose me");
+    const pendingEvents: unknown[] = [];
+    const unsubscribePending = subscribeAnalysis(harness.api, pending, (event) => { pendingEvents.push(event); });
+    harness.replaceRoster([kept]);
+    expect(lostStore.getSnapshot().error).toBe("Analysis session ended — send again to restart.");
+    expect(keptStore.getSnapshot().error).toBeNull();
+    expect(pendingEvents.some((event) => (event as { type?: string }).type === "error")).toBe(false);
+    unsubscribePending();
+    disposeAnalysisStore(kept);
+    disposeAnalysisStore(lost);
+  });
+
+  it("ignores malformed connected frames without evicting confirmed sessions", async () => {
+    const harness = createHarness();
+    const operationId = "operation-store-malformed-roster";
+    const store = getAnalysisStore(operationId, harness.api);
+    await vi.waitFor(() => expect(store.getSnapshot().cliId).toBe("claude"));
+    await sendWithConnected(store, harness, operationId, "Stay connected");
+    harness.deliverRaw(JSON.stringify({ type: "connected", operationIds: [operationId, 1] }));
+    expect(store.getSnapshot()).toMatchObject({ started: true, error: null });
+    disposeAnalysisStore(operationId);
+  });
+
+  it("does not infer session loss from CONNECTING transport errors", async () => {
+    const harness = createHarness();
+    const operationId = "operation-store-connecting-error";
+    const store = getAnalysisStore(operationId, harness.api);
+    await vi.waitFor(() => expect(store.getSnapshot().cliId).toBe("claude"));
+    const pending = store.send("Hold connection");
+    await vi.waitFor(() => expect(harness.streamReady()).toBe(true));
+    const source = TestEventSource.instances[0]!;
+    expect(source.readyState).toBe(TestEventSource.CONNECTING);
+    source.triggerError();
+    expect(harness.eventSourceCount()).toBe(1);
+    harness.emitRoster([operationId]);
+    await pending;
+    expect(store.getSnapshot().error).toBeNull();
+    harness.emit(operationId, { type: "complete" });
+    disposeAnalysisStore(operationId);
+  });
+
+  it("recovers from fatal CLOSED sources with one pending timer per close and identity-safe callbacks", async () => {
+    vi.useFakeTimers();
+    const harness = createHarness();
+    const operationId = "operation-store-fatal-reconnect";
+    const store = getAnalysisStore(operationId, harness.api);
+    await vi.waitFor(() => expect(store.getSnapshot().cliId).toBe("claude"));
+    const pending = store.send("Need stream");
+    await vi.waitFor(() => expect(harness.streamReady()).toBe(true));
+
+    const first = TestEventSource.instances[0]!;
+    first.readyState = TestEventSource.CLOSED;
+    first.triggerError();
+    first.triggerError();
+    expect(harness.eventSourceCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(harness.eventSourceCount()).toBe(2);
+
+    const staleCallback = first.onmessage;
+    first.open();
+    staleCallback?.({ data: JSON.stringify({ type: "connected", operationIds: ["wrong-operation"] }) } as MessageEvent<string>);
+    expect(store.getSnapshot().error).toBeNull();
+
+    const second = TestEventSource.instances[1]!;
+    second.open();
+    harness.emitRoster([operationId]);
+    await pending;
+
+    second.readyState = TestEventSource.CLOSED;
+    second.triggerError();
+    expect(harness.eventSourceCount()).toBe(2);
+    await vi.advanceTimersByTimeAsync(250);
+    expect(harness.eventSourceCount()).toBe(3);
+
+    const third = TestEventSource.instances[2]!;
+    third.open();
+    harness.emit(operationId, { type: "complete" });
+    disposeAnalysisStore(operationId);
+    vi.useRealTimers();
+  });
+});
+
+describe("analysis stream hub reconnect delays", () => {
+  beforeEach(() => {
+    vi.stubGlobal("EventSource", TestEventSource);
+  });
+
+  it("uses bounded exponential recreation delays for consecutive CLOSED failures without roster frames", async () => {
+    vi.useFakeTimers();
+    const api = { fetch: vi.fn(), subscribe: vi.fn(), resync: vi.fn() } satisfies ClientApiCapability;
+    const expectedDelays = [250, 500, 1000, 2000, 4000, 4000] as const;
+    const unsubscribe = subscribeAnalysis(api, "operation-hub-backoff", () => {});
+
+    expect(TestEventSource.instances).toHaveLength(1);
+    expect(TestEventSource.instances[0]?.readyState).toBe(TestEventSource.CONNECTING);
+
+    let sourceCount = 1;
+    for (const [index, delay] of expectedDelays.entries()) {
+      const source = TestEventSource.instances.at(-1)!;
+      source.readyState = TestEventSource.CLOSED;
+      source.triggerError();
+      if (index === 0) source.triggerError();
+      expect(TestEventSource.instances).toHaveLength(sourceCount);
+      await vi.advanceTimersByTimeAsync(delay - 1);
+      expect(TestEventSource.instances).toHaveLength(sourceCount);
+      await vi.advanceTimersByTimeAsync(1);
+      sourceCount += 1;
+      expect(TestEventSource.instances).toHaveLength(sourceCount);
+      expect(TestEventSource.instances.at(-1)?.readyState).toBe(TestEventSource.CONNECTING);
+    }
+
+    const pending = TestEventSource.instances.at(-1)!;
+    pending.readyState = TestEventSource.CLOSED;
+    pending.triggerError();
+    await vi.advanceTimersByTimeAsync(3999);
+    expect(TestEventSource.instances).toHaveLength(sourceCount);
+    unsubscribe();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(TestEventSource.instances).toHaveLength(sourceCount);
+
+    vi.useRealTimers();
   });
 });
 

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-registry.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-registry.ts
@@ -4,12 +4,16 @@ export const MAX_ANALYSIS_ARTIFACTS = 32;
 // Active artifacts remain available; stopped-session history is bounded process-wide.
 export const MAX_STOPPED_ANALYSIS_ARTIFACTS = 256;
 type Subscriber = (event: AnalysisEvent) => void;
+type GlobalSubscriber = (operationId: string, event: AnalysisEvent) => void;
+type RosterSubscriber = (operationIds: readonly string[]) => void;
 type Entry = { readonly session: AnalysisSession; readonly subscribers: Set<Subscriber>; starting: boolean; messaging: boolean; stopped: boolean; disposePromise?: Promise<void> };
 type StoredArtifact = { readonly operationId: string; readonly html: string };
 
 export class AnalysisRegistry {
   private readonly entries = new Map<string, Entry>();
   private readonly artifacts = new Map<string, StoredArtifact>();
+  private readonly globalSubscribers = new Set<GlobalSubscriber>();
+  private readonly rosterSubscribers = new Set<RosterSubscriber>();
 
   async start(operationId: string, create: (onEvent: (event: AnalysisEvent) => void) => AnalysisSession): Promise<"started" | "stopped" | "exists"> {
     if (this.entries.has(operationId)) return "exists";
@@ -17,7 +21,7 @@ export class AnalysisRegistry {
     const session = create((event) => {
       if (!entry || entry.stopped) return;
       if (event.type === "artifact") this.storeArtifact(operationId, event.artifact.id, event.artifact.html);
-      for (const subscriber of entry.subscribers) subscriber(event);
+      this.publish(operationId, event);
       if (event.type === "error" && event.error.code === "analysis_exited") void this.stopEntry(operationId, entry);
     });
     entry = { session, subscribers: new Set(), starting: true, messaging: false, stopped: false };
@@ -25,19 +29,22 @@ export class AnalysisRegistry {
     try {
       await session.start();
       if (this.entries.get(operationId) !== entry || entry.stopped) {
+        entry.starting = false;
         await this.disposeEntry(entry);
         return "stopped";
       }
+      entry.starting = false;
+      this.notifyRoster();
       return "started";
     }
     catch (error) {
       if (this.entries.get(operationId) === entry) this.entries.delete(operationId);
       entry.stopped = true;
+      entry.starting = false;
       entry.subscribers.clear();
       await this.disposeEntry(entry);
       throw error;
     }
-    finally { entry.starting = false; }
   }
 
   async message(operationId: string, text: string): Promise<"accepted" | "not_found" | "busy"> {
@@ -46,7 +53,7 @@ export class AnalysisRegistry {
     if (entry.starting || entry.messaging) return "busy";
     entry.messaging = true;
     void entry.session.send(text).catch(() => {
-      for (const subscriber of entry.subscribers) subscriber({ type: "error", error: { code: "analysis_error", message: "Analysis request failed." } });
+      this.publish(operationId, { type: "error", error: { code: "analysis_error", message: "Analysis request failed." } });
     }).finally(() => { entry.messaging = false; });
     return "accepted";
   }
@@ -56,6 +63,23 @@ export class AnalysisRegistry {
     if (!entry || entry.stopped) return null;
     entry.subscribers.add(subscriber);
     return () => entry.subscribers.delete(subscriber);
+  }
+
+  subscribeAll(subscriber: GlobalSubscriber): () => void {
+    this.globalSubscribers.add(subscriber);
+    return () => this.globalSubscribers.delete(subscriber);
+  }
+
+  subscribeRoster(subscriber: RosterSubscriber): () => void {
+    this.rosterSubscribers.add(subscriber);
+    return () => this.rosterSubscribers.delete(subscriber);
+  }
+
+  activeOperationIds(): readonly string[] {
+    return [...this.entries.entries()]
+      .filter(([, entry]) => !entry.stopped && !entry.starting)
+      .map(([operationId]) => operationId)
+      .sort();
   }
 
   async stop(operationId: string): Promise<boolean> {
@@ -74,12 +98,26 @@ export class AnalysisRegistry {
     }
   }
 
+  private publish(operationId: string, event: AnalysisEvent): void {
+    const entry = this.entries.get(operationId);
+    if (entry && !entry.stopped) {
+      for (const subscriber of entry.subscribers) subscriber(event);
+    }
+    for (const subscriber of this.globalSubscribers) subscriber(operationId, event);
+  }
+
+  private notifyRoster(): void {
+    const operationIds = this.activeOperationIds();
+    for (const subscriber of this.rosterSubscribers) subscriber(operationIds);
+  }
+
   private async stopEntry(operationId: string, entry: Entry): Promise<boolean> {
     if (this.entries.get(operationId) !== entry) return false;
     this.entries.delete(operationId);
     entry.stopped = true;
     entry.subscribers.clear();
     this.pruneStoppedArtifacts();
+    this.notifyRoster();
     await this.disposeEntry(entry);
     return true;
   }

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-registry.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-registry.ts
@@ -53,6 +53,7 @@ export class AnalysisRegistry {
     if (entry.starting || entry.messaging) return "busy";
     entry.messaging = true;
     void entry.session.send(text).catch(() => {
+      if (this.entries.get(operationId) !== entry || entry.stopped) return;
       this.publish(operationId, { type: "error", error: { code: "analysis_error", message: "Analysis request failed." } });
     }).finally(() => { entry.messaging = false; });
     return "accepted";

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
@@ -10,7 +10,7 @@ vi.mock("@dotobokuri/fleet-analyst", () => ({ AnalystSession: class {} }));
 
 import { AnalysisRegistry, MAX_ANALYSIS_ARTIFACTS, MAX_STOPPED_ANALYSIS_ARTIFACTS } from "./analysis-registry.js";
 import { ANALYSIS_ARTIFACT_CSP, registerAnalysisRoutes } from "./analysis-routes.js";
-import { ANALYSIS_ERROR_CODES, buildAnalysisCatalog, isAnalysisSelection, isMessageBody, type AnalystCliId } from "./analysis-types.js";
+import { ANALYSIS_ERROR_CODES, buildAnalysisCatalog, isAnalysisSelection, isMessageBody, type AnalysisEvent, type AnalystCliId } from "./analysis-types.js";
 
 describe("Session Analyst server contract", () => {
   it("maps detected binaries to a non-sensitive authoritative catalog and rejects stale selections", () => {
@@ -601,6 +601,7 @@ describe("Session Analyst server contract", () => {
     registerAnalysisRoutes(router.ctx as never, { detect });
     const requests = [
       ["GET", "/api/v1/plugins/terminal/analysis/catalog"],
+      ["GET", "/api/v1/plugins/terminal/analysis/stream"],
       ["GET", "/api/v1/plugins/terminal/analysis/op/ready"],
       ["POST", "/api/v1/plugins/terminal/analysis/op/start"],
       ["POST", "/api/v1/plugins/terminal/analysis/op/message"],
@@ -617,6 +618,172 @@ describe("Session Analyst server contract", () => {
     expect(router.responses).toHaveLength(requests.length);
     expect(router.responses).toEqual(requests.map(() => ({ status: 403, body: { error: { code: "analysis_catalog_invalid", message: "Analysis request is not accepted by this host." } } })));
     expect(detect).not.toHaveBeenCalled();
+  });
+
+  it("routes registry publications through subscribeAll with operation isolation", async () => {
+    const registry = new AnalysisRegistry();
+    const received: Array<{ operationId: string; event: unknown }> = [];
+    const unsubscribe = registry.subscribeAll((operationId, event) => { received.push({ operationId, event }); });
+    const sessions = ["op-a", "op-b"].map((operationId) => {
+      let emit: ((event: AnalysisEvent) => void) | undefined;
+      return { operationId, emitRef: () => emit, start: registry.start(operationId, (onEvent) => { emit = onEvent; return { start: async () => undefined, send: async () => undefined, dispose: async () => undefined } as never; }) };
+    });
+    await Promise.all(sessions.map((session) => session.start));
+    sessions[0]!.emitRef()?.({ type: "chunk", text: "alpha" });
+    sessions[1]!.emitRef()?.({ type: "chunk", text: "beta" });
+    expect(received).toEqual([
+      { operationId: "op-a", event: { type: "chunk", text: "alpha" } },
+      { operationId: "op-b", event: { type: "chunk", text: "beta" } },
+    ]);
+    unsubscribe();
+    await registry.dispose();
+  });
+
+  it("lists active operation ids in deterministic code-unit lexicographic order", async () => {
+    const registry = new AnalysisRegistry();
+    for (const operationId of ["op-z", "op2", "op10", "Op-a"]) {
+      await registry.start(operationId, () => ({ start: async () => undefined, send: async () => undefined, dispose: async () => undefined }) as never);
+    }
+    expect(registry.activeOperationIds()).toEqual(["Op-a", "op-z", "op10", "op2"]);
+    expect(registry.activeOperationIds()).not.toEqual(["Op-a", "op-z", "op2", "op10"]);
+    await registry.dispose();
+  });
+
+  it("writes a sorted connected roster and operation-isolated global event envelopes", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "analysis-global-stream-"));
+    const transcriptPath = join(dir, "captured.jsonl");
+    await writeFile(transcriptPath, "{}\n");
+    const router = createRouterHarness(true);
+    const emitters = new Map<string, (event: AnalysisEvent) => void>();
+    registerAnalysisRoutes(router.ctx as never, {
+      detect: async () => [{ id: "claude", displayName: "Claude Code", available: true, version: null }],
+      modelsFor: () => ({ defaultModel: "model-b", models: [{ modelId: "model-b", name: "Model B", effort: { supported: false } }] }) as never,
+      readCapture: () => ({ provider: "claude", sessionId: "private", capturedAt: "now", transcriptPath }),
+      createSession: ((options: { onEvent: (event: AnalysisEvent) => void; capturePath?: string }) => {
+        emitters.set(options.capturePath ?? "default", options.onEvent);
+        return { start: async () => undefined, send: async () => undefined, dispose: async () => undefined };
+      }) as never,
+    });
+
+    await router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", { cliId: "claude", model: "model-b" });
+    const response = await router.call("GET", "/api/v1/plugins/terminal/analysis/stream");
+    expect(response.writes[0]).toBe(`data: ${JSON.stringify({ type: "connected", operationIds: ["op"] })}\n\n`);
+    emitters.values().next().value?.({ type: "chunk", text: "isolated" });
+    await vi.waitFor(() => expect(response.writes.at(-1)).toBe(`data: ${JSON.stringify({ type: "event", operationId: "op", event: { type: "chunk", text: "isolated" } })}\n\n`));
+  });
+
+  it("excludes pending starts from activeOperationIds until session.start settles", async () => {
+    const registry = new AnalysisRegistry();
+    let resolveStart!: () => void;
+    const pending = registry.start("op-pending", () => ({
+      start: () => new Promise<void>((resolve) => { resolveStart = resolve; }),
+      send: async () => undefined,
+      dispose: async () => undefined,
+    }) as never);
+    expect(registry.activeOperationIds()).toEqual([]);
+    resolveStart();
+    await pending;
+    expect(registry.activeOperationIds()).toEqual(["op-pending"]);
+    await registry.dispose();
+  });
+
+  it("removes failed starts from activeOperationIds snapshots", async () => {
+    const registry = new AnalysisRegistry();
+    await expect(registry.start("op-fail", () => ({
+      start: async () => { throw new Error("start failed"); },
+      send: async () => undefined,
+      dispose: async () => undefined,
+    }) as never)).rejects.toThrow("start failed");
+    expect(registry.activeOperationIds()).toEqual([]);
+  });
+
+  it("publishes roster add and remove updates to global stream subscribers", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "analysis-global-roster-"));
+    const transcriptPath = join(dir, "captured.jsonl");
+    await writeFile(transcriptPath, "{}\n");
+    const router = createRouterHarness(true);
+    registerAnalysisRoutes(router.ctx as never, {
+      detect: async () => [{ id: "claude", displayName: "Claude Code", available: true, version: null }],
+      modelsFor: () => ({ defaultModel: "model-b", models: [{ modelId: "model-b", name: "Model B", effort: { supported: false } }] }) as never,
+      readCapture: () => ({ provider: "claude", sessionId: "private", capturedAt: "now", transcriptPath }),
+      createSession: () => ({ start: async () => undefined, send: async () => undefined, dispose: async () => undefined }) as never,
+    });
+    const response = await router.call("GET", "/api/v1/plugins/terminal/analysis/stream");
+    expect(response.writes[0]).toBe(`data: ${JSON.stringify({ type: "connected", operationIds: [] })}\n\n`);
+    await router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", { cliId: "claude", model: "model-b" });
+    await vi.waitFor(() => expect(response.writes.at(-1)).toBe(`data: ${JSON.stringify({ type: "connected", operationIds: ["op"] })}\n\n`));
+    await router.call("POST", "/api/v1/plugins/terminal/analysis/op/stop", {});
+    await vi.waitFor(() => expect(response.writes.at(-1)).toBe(`data: ${JSON.stringify({ type: "connected", operationIds: [] })}\n\n`));
+  });
+
+  it("routes generic send rejection through the global event envelope", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "analysis-global-error-"));
+    const transcriptPath = join(dir, "captured.jsonl");
+    await writeFile(transcriptPath, "{}\n");
+    const router = createRouterHarness(true);
+    registerAnalysisRoutes(router.ctx as never, {
+      detect: async () => [{ id: "claude", displayName: "Claude Code", available: true, version: null }],
+      modelsFor: () => ({ defaultModel: "model-b", models: [{ modelId: "model-b", name: "Model B", effort: { supported: false } }] }) as never,
+      readCapture: () => ({ provider: "claude", sessionId: "private", capturedAt: "now", transcriptPath }),
+      createSession: () => ({
+        start: async () => undefined,
+        send: async () => { throw new Error("/Users/alice/private token"); },
+        dispose: async () => undefined,
+      }) as never,
+    });
+    await router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", { cliId: "claude", model: "model-b" });
+    const response = await router.call("GET", "/api/v1/plugins/terminal/analysis/stream");
+    await router.call("POST", "/api/v1/plugins/terminal/analysis/op/message", { text: "review" });
+    await vi.waitFor(() => expect(response.writes.at(-1)).toBe(`data: ${JSON.stringify({
+      type: "event",
+      operationId: "op",
+      event: { type: "error", error: { code: "analysis_error", message: "Analysis request failed." } },
+    })}\n\n`));
+    expect(JSON.stringify(response.writes)).not.toContain("/Users/alice/private");
+  });
+
+  it("routes analysis_exited through the global event envelope before cleanup", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "analysis-global-exited-"));
+    const transcriptPath = join(dir, "captured.jsonl");
+    await writeFile(transcriptPath, "{}\n");
+    const router = createRouterHarness(true);
+    let emit: ((event: AnalysisEvent) => void) | undefined;
+    const dispose = vi.fn(async () => undefined);
+    registerAnalysisRoutes(router.ctx as never, {
+      detect: async () => [{ id: "claude", displayName: "Claude Code", available: true, version: null }],
+      modelsFor: () => ({ defaultModel: "model-b", models: [{ modelId: "model-b", name: "Model B", effort: { supported: false } }] }) as never,
+      readCapture: () => ({ provider: "claude", sessionId: "private", capturedAt: "now", transcriptPath }),
+      createSession: ((options: { onEvent: typeof emit }) => {
+        emit = options.onEvent;
+        return { start: async () => undefined, send: async () => undefined, dispose };
+      }) as never,
+    });
+    await router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", { cliId: "claude", model: "model-b" });
+    const response = await router.call("GET", "/api/v1/plugins/terminal/analysis/stream");
+    emit?.({ type: "error", error: { code: "analysis_exited", message: "exited" } });
+    const eventWrite = `data: ${JSON.stringify({
+      type: "event",
+      operationId: "op",
+      event: { type: "error", error: { code: "analysis_exited", message: "exited" } },
+    })}\n\n`;
+    await vi.waitFor(() => expect(response.writes).toContain(eventWrite));
+    await vi.waitFor(() => expect(dispose).toHaveBeenCalledOnce());
+  });
+
+  it("publishes analysis_exited through subscribeAll before the session is released", async () => {
+    const registry = new AnalysisRegistry();
+    const received: unknown[] = [];
+    registry.subscribeAll((_operationId, event) => { received.push(event); });
+    let emit: ((event: AnalysisEvent) => void) | undefined;
+    const dispose = vi.fn(async () => undefined);
+    await registry.start("op", (onEvent) => {
+      emit = onEvent;
+      return { start: async () => undefined, send: async () => undefined, dispose } as never;
+    });
+    emit?.({ type: "error", error: { code: "analysis_exited", message: "exited" } });
+    await vi.waitFor(() => expect(dispose).toHaveBeenCalledOnce());
+    expect(received).toEqual([{ type: "error", error: { code: "analysis_exited", message: "exited" } }]);
+    await expect(registry.message("op", "hello")).resolves.toBe("not_found");
   });
 });
 

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
@@ -76,6 +76,8 @@ describe("Session Analyst server contract", () => {
       "session 123e4567-e89b-42d3-a456-426614174000",
     ];
     const events: unknown[] = [];
+    const globalEvents: unknown[] = [];
+    const unsubscribeAll = registry.subscribeAll((operationId, event) => globalEvents.push({ operationId, event }));
     await registry.start("op", () => ({
       start: async () => undefined,
       send: async () => { throw new Error(rejectionDetails.join(" ")); },
@@ -88,10 +90,49 @@ describe("Session Analyst server contract", () => {
       type: "error",
       error: { code: "analysis_error", message: "Analysis request failed." },
     }]));
+    expect(globalEvents).toEqual([{
+      operationId: "op",
+      event: {
+        type: "error",
+        error: { code: "analysis_error", message: "Analysis request failed." },
+      },
+    }]);
     const exposed = JSON.stringify(events);
     for (const detail of rejectionDetails) expect(exposed).not.toContain(detail);
 
     unsubscribe?.();
+    unsubscribeAll();
+    await registry.stop("op");
+  });
+
+  it("drops a send rejection from a stopped session after the same operation restarts", async () => {
+    const registry = new AnalysisRegistry();
+    let rejectOldSend: ((reason?: unknown) => void) | undefined;
+    const globalEvents: unknown[] = [];
+    const newEntryEvents: unknown[] = [];
+    const unsubscribeAll = registry.subscribeAll((operationId, event) => globalEvents.push({ operationId, event }));
+
+    await registry.start("op", () => ({
+      start: async () => undefined,
+      send: () => new Promise<void>((_resolve, reject) => { rejectOldSend = reject; }),
+      dispose: async () => undefined,
+    }) as never);
+    await expect(registry.message("op", "old request")).resolves.toBe("accepted");
+    await expect(registry.stop("op")).resolves.toBe(true);
+    await expect(registry.start("op", () => ({
+      start: async () => undefined,
+      send: async () => undefined,
+      dispose: async () => undefined,
+    }) as never)).resolves.toBe("started");
+    const unsubscribeNewEntry = registry.subscribe("op", (event) => newEntryEvents.push(event));
+
+    rejectOldSend?.(new Error("old session failed"));
+    await Promise.resolve();
+    expect(globalEvents).toEqual([]);
+    expect(newEntryEvents).toEqual([]);
+
+    unsubscribeNewEntry?.();
+    unsubscribeAll();
     await registry.stop("op");
   });
 

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
@@ -50,6 +50,7 @@ export function registerAnalysisRoutes(ctx: FleetPluginServerContext, deps: Anal
     }
     const path = pathname.slice(`${ctx.basePath}/analysis`.length) || "/";
     if (path === "/catalog") return handleCatalog(ctx, req, res, catalog);
+    if (path === "/stream") return handleGlobalStream(ctx, req, res, registry);
     const artifactMatch = path.match(/^\/artifacts\/([^/]+)$/);
     if (artifactMatch) return handleArtifact(ctx, req, res, decodeURIComponent(artifactMatch[1] ?? ""), registry);
     const clearArtifactsMatch = path.match(/^\/([^/]+)\/artifacts$/);
@@ -395,6 +396,29 @@ async function handleMessage(ctx: FleetPluginServerContext, req: http.IncomingMe
   if (result === "not_found") writeError(ctx, res, 404, ANALYSIS_ERROR_CODES.sessionNotFound, "Analysis session was not found.");
   else if (result === "busy") writeError(ctx, res, 409, ANALYSIS_ERROR_CODES.sessionBusy, "Analysis session is busy.");
   else ctx.host.http.writeJson(res, 200, { accepted: true });
+  return true;
+}
+
+function handleGlobalStream(ctx: FleetPluginServerContext, req: http.IncomingMessage, res: http.ServerResponse, registry: AnalysisRegistry): boolean {
+  if (req.method !== "GET") return methodNotAllowed(ctx, res);
+  let closed = false;
+  const write = (data: string) => { if (!closed && !res.writableEnded && !res.destroyed) res.write(data); };
+  const writeRoster = (operationIds: readonly string[]) => {
+    write(`data: ${JSON.stringify({ type: "connected", operationIds: [...operationIds] })}\n\n`);
+  };
+  res.writeHead(200, securityHeaders({ "Content-Type": "text/event-stream", "Cache-Control": "no-store", Connection: "keep-alive" }));
+  writeRoster(registry.activeOperationIds());
+  const unsubscribeEvents = registry.subscribeAll((operationId, event) => {
+    write(`data: ${JSON.stringify({ type: "event", operationId, event })}\n\n`);
+  });
+  const unsubscribeRoster = registry.subscribeRoster((operationIds) => writeRoster(operationIds));
+  const keepalive = setInterval(() => write(": keepalive\n\n"), 30_000);
+  req.on("close", () => {
+    closed = true;
+    clearInterval(keepalive);
+    unsubscribeEvents();
+    unsubscribeRoster();
+  });
   return true;
 }
 


### PR DESCRIPTION
## Summary

- Multiplex Session Analyst traffic over one shared EventSource instead of keeping one long-lived connection per Operation.
- Publish operation-tagged events and active-session rosters while preserving per-Operation isolation, lifecycle behavior, and the legacy stream endpoint.
- Prevent browser connection-slot starvation from blocking Operation switching and the ANALYZE catalog after multiple sessions.

## Type of Change

- [ ] feat — new feature or carrier capability
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- [x] `runtime/fleet-plugins/terminal`
- [ ] Documentation (README / SETUP / AGENTS.md)

## Test Plan

- [x] `pnpm --filter @fleet-plugins/terminal test` — 357/357
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `pnpm --filter @fleet-plugins/terminal build`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/operations-boot-minimization.integration.test.ts` — 27/27
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Isolated browser: six logical Analyst subscriptions used one physical EventSource; Theater and catalog requests remained responsive.
- [x] `git diff --check`

## Changelog

- [x] Added `.changelog.d/pr-359.md`.
- [x] Fragment uses the `fleet-plugin` / `Fixed` grouped schema.
- [x] English and Korean summaries are bilingual and compiler-validated.

## Notes for Reviewers

The legacy per-Operation SSE route remains available for stale clients. The new client path does not fall back to it, which keeps the browser connection count bounded.
