### PR TITLE
fix(console): prevent Plan reader retry starvation

### DIFF
--- a/.changelog.d/pr-360.md
+++ b/.changelog.d/pr-360.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Prevent Plan files from remaining stuck on Loading during live list refreshes.
+  ko: 실시간 목록 갱신 중 Plan 파일이 Loading 상태에 멈추는 문제를 수정합니다.

--- a/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
@@ -81,9 +81,11 @@ function PlansPanelBody(ctx: RailPanelContext) {
   const readerRequestRef = useRef(0);
   const listSignaturesRef = useRef<Map<string, string> | null>(null);
   const readerStateRef = useRef<PlanReaderState>(readerState);
-  // reader가 실제 반영한 목록 signature. 성공 시에만 갱신되므로 background read 실패는
-  // 다음 목록 갱신에서 signature 불일치로 다시 감지된다.
+  // reader가 요청했거나 실제 반영한 목록 signature. 요청 시작 시 예약해 동일 signature의
+  // 중복 목록 갱신이 요청을 supersede하지 않게 하고, 현재 요청 실패 시 해제해 재시도를 허용한다.
   const readerSignatureRef = useRef<string | null>(null);
+  // signature가 null인 삭제 확인 요청과 실패 후 재시도 가능한 상태를 구분한다.
+  const readerInFlightRef = useRef(false);
   // 목록 갱신에서 선택 Plan이 사라졌을 때 세팅 — 다음 reader 조회 실패를 조용히 버리지 않고 error로 표면화한다.
   const readerForceRef = useRef(false);
   // 수동 REFRESH에서 세팅 — 다음 목록 조회 실패를 background로 삼키지 않고 error로 표면화한다.
@@ -127,9 +129,11 @@ function PlansPanelBody(ctx: RailPanelContext) {
       const currentSelection = selectedNameRef.current;
       if (currentSelection) {
         if (!nextSignatures.has(currentSelection)) {
-          readerSignatureRef.current = null;
-          readerForceRef.current = true;
-          setReaderRetry((attempt) => attempt + 1);
+          if (readerSignatureRef.current !== null || !readerInFlightRef.current) {
+            readerSignatureRef.current = null;
+            readerForceRef.current = true;
+            setReaderRetry((attempt) => attempt + 1);
+          }
         } else if (nextSignatures.get(currentSelection) !== readerSignatureRef.current) {
           setReaderRetry((attempt) => attempt + 1);
         }
@@ -144,18 +148,20 @@ function PlansPanelBody(ctx: RailPanelContext) {
 
     if (!theaterId || !selectedName) return;
 
+    readerInFlightRef.current = true;
+    readerSignatureRef.current = listSignaturesRef.current?.get(selectedName) ?? null;
     const forceSurface = readerForceRef.current;
     readerForceRef.current = false;
     const isBackgroundRevalidation = !forceSurface
       && readerStateRef.current.kind === "ready"
       && readerStateRef.current.plan.name === selectedName;
     if (!isBackgroundRevalidation) {
-      readerSignatureRef.current = null;
       readerStateRef.current = { kind: "loading" };
       setReaderState({ kind: "loading" });
     }
     void fetchPlanRead(theaterId, selectedName).then((result) => {
       if (requestId === readerRequestRef.current) {
+        readerInFlightRef.current = false;
         readerSignatureRef.current = listSignaturesRef.current?.get(result.name) ?? null;
         const nextState = { kind: "ready", plan: result } as const;
         readerStateRef.current = nextState;
@@ -166,6 +172,8 @@ function PlansPanelBody(ctx: RailPanelContext) {
       // 읽기 불가(413 등)로 바뀐 사실을 낡은 본문으로 가리면 안 된다. loopback 특성상
       // 일시 네트워크 실패로 인한 오탐 여지는 사실상 없다.
       if (requestId === readerRequestRef.current) {
+        readerInFlightRef.current = false;
+        readerSignatureRef.current = null;
         readerStateRef.current = { kind: "error" };
         setReaderState({ kind: "error" });
       }
@@ -195,6 +203,7 @@ function PlansPanelBody(ctx: RailPanelContext) {
   // 오분류되어 읽기 실패를 침묵시키는 일이 없게 한다(재열람은 항상 foreground).
   const handleClose = useCallback(() => {
     setSelectedPlan(null);
+    readerInFlightRef.current = false;
     readerSignatureRef.current = null;
     readerStateRef.current = { kind: "loading" };
     setReaderState({ kind: "loading" });

--- a/runtime/fleet-console/tests/plans-panel.test.tsx
+++ b/runtime/fleet-console/tests/plans-panel.test.tsx
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PlanListItem, PlanReadResult } from "../core/client/src/api.js";
+
+const mocks = vi.hoisted(() => ({
+  fetchPlanRead: vi.fn(),
+  fetchPlansList: vi.fn(),
+  subscribeToPlanChanges: vi.fn(),
+}));
+
+vi.mock("../core/client/src/api.js", () => ({
+  fetchPlanRead: mocks.fetchPlanRead,
+  fetchPlansList: mocks.fetchPlansList,
+}));
+vi.mock("../core/client/src/rail/plans-events.js", () => ({
+  subscribeToPlanChanges: mocks.subscribeToPlanChanges,
+}));
+vi.mock("@fleet-console/markdown/core", () => ({
+  renderMarkdown: vi.fn((content: string) => ({ html: `<p>${content}</p>`, toc: [] })),
+}));
+vi.mock("@fleet-console/markdown/mermaid", () => ({
+  installDiagramHydrator: vi.fn(),
+}));
+
+import { plansPanel } from "../core/client/src/rail/plans-panel.js";
+
+let container: HTMLDivElement;
+let root: Root;
+let invalidatePlans: (() => void) | null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  invalidatePlans = null;
+  mocks.fetchPlanRead.mockReset();
+  mocks.fetchPlansList.mockReset();
+  mocks.subscribeToPlanChanges.mockReset();
+  mocks.subscribeToPlanChanges.mockImplementation((_theaterId: string, onInvalidate: () => void) => {
+    invalidatePlans = onInvalidate;
+    return vi.fn();
+  });
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("Plans panel reader revalidation", () => {
+  it("keeps a deferred foreground read when list invalidation returns the same signature", async () => {
+    const plan = listPlan();
+    const read = deferred<PlanReadResult>();
+    mocks.fetchPlansList.mockResolvedValue({ plans: [plan] });
+    mocks.fetchPlanRead.mockReturnValue(read.promise);
+
+    await renderPanel();
+    await selectPlan();
+    expect(mocks.fetchPlanRead).toHaveBeenCalledOnce();
+    expect(container.textContent).toContain("Loading plan…");
+
+    await invalidate();
+
+    expect(mocks.fetchPlanRead).toHaveBeenCalledOnce();
+    read.resolve(readPlan("Initial plan"));
+    await flush();
+    expect(container.textContent).toContain("Initial plan");
+    expect(container.textContent).not.toContain("Loading plan…");
+  });
+
+  it("replaces an in-flight read once for a changed signature and ignores its duplicate revalidation", async () => {
+    const initialRead = deferred<PlanReadResult>();
+    const replacementRead = deferred<PlanReadResult>();
+    mocks.fetchPlansList
+      .mockResolvedValueOnce({ plans: [listPlan()] })
+      .mockResolvedValue({ plans: [listPlan({ updatedAt: "2026-07-23T01:00:00.000Z" })] });
+    mocks.fetchPlanRead
+      .mockReturnValueOnce(initialRead.promise)
+      .mockReturnValueOnce(replacementRead.promise);
+
+    await renderPanel();
+    await selectPlan();
+    await invalidate();
+    expect(mocks.fetchPlanRead).toHaveBeenCalledTimes(2);
+
+    await invalidate();
+    expect(mocks.fetchPlanRead).toHaveBeenCalledTimes(2);
+
+    initialRead.resolve(readPlan("Stale plan"));
+    await flush();
+    expect(container.textContent).toContain("Loading plan…");
+    expect(container.textContent).not.toContain("Stale plan");
+
+    replacementRead.resolve(readPlan("Updated plan"));
+    await flush();
+    expect(container.textContent).toContain("Updated plan");
+  });
+
+  it("releases a failed reader reservation so the same signature can retry on later invalidation", async () => {
+    const failedRead = deferred<PlanReadResult>();
+    const retryRead = deferred<PlanReadResult>();
+    mocks.fetchPlansList.mockResolvedValue({ plans: [listPlan()] });
+    mocks.fetchPlanRead
+      .mockReturnValueOnce(failedRead.promise)
+      .mockReturnValueOnce(retryRead.promise);
+
+    await renderPanel();
+    await selectPlan();
+    failedRead.reject(new Error("read failed"));
+    await flush();
+    expect(container.textContent).toContain("Unable to load plan.");
+
+    await invalidate();
+    expect(mocks.fetchPlanRead).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain("Loading plan…");
+
+    retryRead.resolve(readPlan("Recovered plan"));
+    await flush();
+    expect(container.textContent).toContain("Recovered plan");
+  });
+
+  it("keeps one deletion read when duplicate invalidations report the selected Plan absent", async () => {
+    const initialRead = deferred<PlanReadResult>();
+    const deletionRead = deferred<PlanReadResult>();
+    const duplicateDeletionRead = deferred<PlanReadResult>();
+    mocks.fetchPlansList
+      .mockResolvedValueOnce({ plans: [listPlan()] })
+      .mockResolvedValue({ plans: [] });
+    mocks.fetchPlanRead
+      .mockReturnValueOnce(initialRead.promise)
+      .mockReturnValueOnce(deletionRead.promise)
+      .mockReturnValueOnce(duplicateDeletionRead.promise);
+
+    await renderPanel();
+    await selectPlan();
+    await invalidate();
+    expect(mocks.fetchPlanRead).toHaveBeenCalledTimes(2);
+
+    initialRead.resolve(readPlan("Deleted plan"));
+    await flush();
+    await invalidate();
+    expect(mocks.fetchPlanRead).toHaveBeenCalledTimes(2);
+
+    deletionRead.reject(new Error("plan deleted"));
+    await flush();
+    expect(container.textContent).toContain("Unable to load plan.");
+  });
+});
+
+async function renderPanel(): Promise<void> {
+  await act(async () => {
+    root.render(plansPanel.render({
+      theaterId: "theater-1",
+      pathContext: { kind: "root", relPath: null, label: "Theater" },
+      api: {} as never,
+      requestExtraWidth: vi.fn(),
+    }));
+  });
+  expect(invalidatePlans).not.toBeNull();
+  expect(container.querySelector(".plans-row-select")).not.toBeNull();
+}
+
+async function selectPlan(): Promise<void> {
+  await act(async () => {
+    container.querySelector<HTMLButtonElement>(".plans-row-select")?.click();
+  });
+}
+
+async function invalidate(): Promise<void> {
+  await act(async () => {
+    invalidatePlans?.();
+  });
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function listPlan(overrides: Partial<PlanListItem> = {}): PlanListItem {
+  return {
+    name: "alpha.md",
+    title: "Alpha",
+    executionMode: "sequential",
+    waveCount: 1,
+    tasksDone: 0,
+    tasksTotal: 1,
+    updatedAt: "2026-07-23T00:00:00.000Z",
+    sizeBytes: 100,
+    ...overrides,
+  };
+}
+
+function readPlan(title: string): PlanReadResult {
+  return {
+    name: "alpha.md",
+    title,
+    executionMode: "sequential",
+    updatedAt: "2026-07-23T01:00:00.000Z",
+    content: title,
+    waves: [],
+    tasksDone: 0,
+    tasksTotal: 1,
+  };
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((onResolve, onReject) => {
+    resolve = onResolve;
+    reject = onReject;
+  });
+  return { promise, resolve, reject };
+}


### PR DESCRIPTION
## Summary

- Prevent duplicate Plan list invalidations from repeatedly superseding the active reader request and leaving the reader on `Loading`.
- Preserve revalidation for changed, failed, and deleted Plans with deterministic component coverage.

## Type of Change

- [x] fix — bug fix

## Scope

- [x] `runtime/fleet-console` Plan reader state and tests

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/plans-panel.test.tsx tests/plans-events.test.ts tests/plans-helpers.test.ts tests/plans-parse.test.ts tests/plans-security.test.ts` — 46/46 passed
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `git diff --check`

## Changelog

- [x] Added `.changelog.d/pr-360.md`.
- [x] Used grouped `fleet-console` / `Fixed` syntax with adjacent English and Korean summaries.
- [x] Validated with `node scripts/compile-changelog-fragments.mjs --check`.

## Notes for Reviewers

- A pre-PR concurrency review reproduced a duplicate deletion-read race; the added in-flight marker and fourth regression test closed it, and follow-up review reported zero findings.
