### PR TITLE
feat(console): regroup the sidebar by live operation status

### DIFF
--- a/.changelog.d/pr-361.md
+++ b/.changelog.d/pr-361.md
@@ -1,0 +1,11 @@
+### fleet-console
+
+#### Added
+
+- [fleet-console] Add a theater-row status-axis toggle (Alt+S) that regroups the sidebar into AWAITING INPUT / RUNNING / IDLE / DORMANT sections while keeping group identity via the operation spine and a group mark dot; the mode is session-only and always reopens on the group axis.
+  ko: Theater 행에 상태축 전환 토글(Alt+S)을 추가해 사이드바를 AWAITING INPUT / RUNNING / IDLE / DORMANT 섹션으로 재편성하고, Operation spine과 그룹 mark 도트로 그룹 정체성을 유지합니다. 이 모드는 세션 한정이며 다시 열면 항상 그룹 축으로 시작합니다.
+
+#### Changed
+
+- [fleet-console] Replace the theater-row operation count with the status toggle, absorb the collapse chevron into the row click gesture, and merge the actions and new-operation buttons into a single split control.
+  ko: Theater 행의 Operation 갯수 표시를 상태 토글로 대체하고, 접기 chevron을 행 클릭 제스처로 흡수했으며, 액션과 새 Operation 버튼을 하나의 split 컨트롤로 병합했습니다.

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -13,10 +13,10 @@ import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { RightRail } from "../rail/right-rail.js";
 import { OperationsSideBar } from "../sidebar/operations-side-bar.js";
-import { toggleSideBarStatusAxis } from "../sidebar/operations-side-bar-store.js";
+import { getSideBarStatusAxis, toggleSideBarStatusAxis } from "../sidebar/operations-side-bar-store.js";
 import { CodexReadingSheet } from "../components/codex-reading-sheet.js";
 import { shouldHandleOperationsKeyboardShortcut } from "../components/keyboard-shortcuts-dialog.js";
-import { beginAddTheater, cancelAddTheater, compareOperationCreatedAt, completeAddTheater, consumeOperationFocus, failAddTheater, focusCycleOperationIds, focusOperation, getState, hydrateGroups, hydrateOperations, hydrateTheaters, nextOperationId, removeTheater, requestOperationKeyboardFocus, setActiveOperation, setActiveTheater, sortOperationsByOrder } from "../store.js";
+import { beginAddTheater, cancelAddTheater, compareOperationCreatedAt, completeAddTheater, consumeOperationFocus, failAddTheater, focusCycleOperationIds, focusOperation, getState, hydrateGroups, hydrateOperations, hydrateTheaters, nextOperationId, removeTheater, requestOperationKeyboardFocus, setActiveOperation, setActiveTheater, sortOperationsByOrder, statusCycleOperationIds } from "../store.js";
 import type { ConsoleState, OperationNode } from "../types.js";
 
 const STABLE_RAIL_API: ClientApiCapability = createHostCapabilities().api;
@@ -81,13 +81,17 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       // Alt 순환 순서를 Left SideBar 표시 순서(비-collapsed 그룹 order → 그룹 내 operationOrder → ungrouped)와 정확히 일치시킨다.
       const snapshot = stateRef.current;
       const canvas = getCanvasSnapshot();
-      const order = focusCycleOperationIds(
-        snapshot.operations.filter((operation) => operation.theaterId === snapshot.activeTheaterId),
-        snapshot.groups.filter((g) => g.theaterId === snapshot.activeTheaterId),
-        canvas.operationOrder,
-        canvas.collapsedGroups,
-        canvas.minimized,
-      );
+      const theaterOperations = snapshot.operations.filter((operation) => operation.theaterId === snapshot.activeTheaterId);
+      // STATUS 축에서는 사이드바 가시 순서가 상태 섹션 순서이므로 순환도 같은 순서를 따른다.
+      const order = getSideBarStatusAxis()
+        ? statusCycleOperationIds(theaterOperations, canvas.operationOrder, snapshot.operationStatus, canvas.minimized)
+        : focusCycleOperationIds(
+            theaterOperations,
+            snapshot.groups.filter((g) => g.theaterId === snapshot.activeTheaterId),
+            canvas.operationOrder,
+            canvas.collapsedGroups,
+            canvas.minimized,
+          );
       event.preventDefault();
       event.stopImmediatePropagation();
       if (order.length === 0) return;

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -13,6 +13,7 @@ import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { RightRail } from "../rail/right-rail.js";
 import { OperationsSideBar } from "../sidebar/operations-side-bar.js";
+import { toggleSideBarStatusAxis } from "../sidebar/operations-side-bar-store.js";
 import { CodexReadingSheet } from "../components/codex-reading-sheet.js";
 import { shouldHandleOperationsKeyboardShortcut } from "../components/keyboard-shortcuts-dialog.js";
 import { beginAddTheater, cancelAddTheater, compareOperationCreatedAt, completeAddTheater, consumeOperationFocus, failAddTheater, focusCycleOperationIds, focusOperation, getState, hydrateGroups, hydrateOperations, hydrateTheaters, nextOperationId, removeTheater, requestOperationKeyboardFocus, setActiveOperation, setActiveTheater, sortOperationsByOrder } from "../store.js";
@@ -56,7 +57,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
     void fetchOperationCatalog().then(setCatalog).catch(() => {});
   }, [state.activeTheaterId]);
 
-  // Alt+←/→는 SideBar 가시 순서로 포커스를 순환하고, Alt+F는 같은 capture/editable 가드 정책을 공유한다.
+  // Alt+←/→는 SideBar 가시 순서로 포커스를 순환하고, Alt+F/Alt+S는 같은 capture/editable 가드 정책을 공유한다.
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
       if (!shouldHandleOperationsKeyboardShortcut()) return;
@@ -64,6 +65,12 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       const active = document.activeElement;
       if (active instanceof HTMLElement && active.matches("input, textarea, [contenteditable='true']") && !active.closest(".xterm")) return;
       // macOS의 Option+문자는 합성 문자를 내보내므로(event.key가 "©"/"ƒ") 물리 키 기준인 event.code로 판별한다.
+      if (event.code === "KeyS" && !event.shiftKey) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        toggleSideBarStatusAxis();
+        return;
+      }
       if (event.code === "KeyF" && !event.shiftKey) {
         event.preventDefault();
         event.stopImmediatePropagation();

--- a/runtime/fleet-console/core/client/src/shortcuts-catalog.ts
+++ b/runtime/fleet-console/core/client/src/shortcuts-catalog.ts
@@ -32,6 +32,7 @@ export const SHORTCUT_GROUPS: readonly ShortcutGroup[] = [
     entries: [
       { combos: [["Alt", "←"], ["Alt", "→"]], description: "Focus the previous / next Operation" },
       { combos: [["Alt", "F"]], description: "Toggle Formation view" },
+      { combos: [["Alt", "S"]], description: "Sort the sidebar by operation status" },
       { combos: [["Drag"]], description: "Pan the operations map" },
       { combos: [["Shift", "Drag"]], description: "Draw a new Operation terminal" },
       { combos: [["Space", "Drag"]], description: "Pan even while a terminal has focus" },

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -20,6 +20,9 @@ interface SideBarChipProps {
   readonly index: number;
   readonly isCloseArmed: boolean;
   readonly accentValue: string | null;
+  readonly groupMark?: { readonly name: string; readonly color: string } | null;
+  readonly statusLanded?: boolean;
+  readonly reorderEnabled?: boolean;
   readonly dragging: boolean;
   readonly dragOffsetY: number;
   readonly dropTarget: boolean;
@@ -41,6 +44,9 @@ export function OperationsSideBarChip({
   index,
   isCloseArmed,
   accentValue,
+  groupMark = null,
+  statusLanded = false,
+  reorderEnabled = true,
   dragging,
   dragOffsetY,
   dropTarget,
@@ -63,6 +69,7 @@ export function OperationsSideBarChip({
     "side-bar-chip",
     active ? "side-bar-chip--active" : "",
     minimized ? "side-bar-chip--minimized" : "",
+    statusLanded ? "side-bar-chip--status-landed" : "",
     dragging ? "side-bar-chip--dragging" : "",
     dropTarget ? "side-bar-chip--drop-target" : "",
   ].filter(Boolean).join(" ");
@@ -104,6 +111,7 @@ export function OperationsSideBarChip({
   return (
     <li
       data-side-bar-chip-id={operation.id}
+      data-reorder-enabled={reorderEnabled ? "true" : "false"}
       className={chipClassName}
       role="button"
       tabIndex={0}
@@ -116,14 +124,14 @@ export function OperationsSideBarChip({
       onFocus={() => {
         if (!isCloseArmed) onDisarmClose();
       }}
-      onPointerDown={(event) => onPointerDragStart(event, operation.id)}
+      onPointerDown={reorderEnabled ? (event) => onPointerDragStart(event, operation.id) : undefined}
       onPointerUp={() => {
         if (dragging) suppressClickRef.current = true;
       }}
       onKeyDown={(event) => {
         if (event.target !== event.currentTarget) return;
         // 재배치: Alt+Shift+↑/↓ — shift 없는 Alt+↑/↓는 operations의 Operation 순환이 가져간다.
-        if (!preview && event.altKey && event.shiftKey && (event.key === "ArrowUp" || event.key === "ArrowDown")) {
+        if (!preview && reorderEnabled && event.altKey && event.shiftKey && (event.key === "ArrowUp" || event.key === "ArrowDown")) {
           event.preventDefault();
           onKeyboardMove(operation.id, event.key === "ArrowUp" ? -1 : 1);
           return;
@@ -156,6 +164,14 @@ export function OperationsSideBarChip({
       )}
       {notificationCount > 0 ? (
         <span className="side-bar-chip-count">{notificationCount}</span>
+      ) : null}
+      {groupMark ? (
+        <span
+          className="side-bar-chip-group-mark"
+          title={groupMark.name}
+          aria-label={`Group ${groupMark.name}`}
+          style={{ "--group-mark": groupMark.color } as CSSProperties}
+        />
       ) : null}
       <span
         className={`side-bar-chip-status ${chipStatusClass(status)}`}

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
@@ -13,12 +13,16 @@ const DEFAULT_WIDTH = MIN_EXPANDED_PX;
 
 const sideBarListeners = new Set<() => void>();
 const collapsedTheaterListeners = new Set<() => void>();
+const statusAxisListeners = new Set<() => void>();
 
 let sideBarState: SideBarState = {
   width: readInitialWidth(),
   collapsed: readInitialCollapsed(),
 };
 let collapsedTheaterIds = readInitialCollapsedTheaters();
+// STATUS 축은 의도적으로 세션 메모리에만 둔다. localStorage나 durable canvas state에
+// 합류시키지 않아 새 페이지 로드마다 GROUP 축(false)에서 시작한다.
+let statusAxis = false;
 
 export function useSideBarState(): SideBarState {
   return useSyncExternalStore(subscribeSideBarState, getSideBarState, getSideBarState);
@@ -26,6 +30,10 @@ export function useSideBarState(): SideBarState {
 
 export function useCollapsedTheaters(): readonly string[] {
   return useSyncExternalStore(subscribeCollapsedTheaters, getCollapsedTheatersSnapshot, getCollapsedTheatersSnapshot);
+}
+
+export function useSideBarStatusAxis(): boolean {
+  return useSyncExternalStore(subscribeStatusAxis, getSideBarStatusAxis, getSideBarStatusAxis);
 }
 
 export function setSideBarWidth(width: number): void {
@@ -58,6 +66,25 @@ export function setTheaterCollapsed(theaterId: string, collapsed: boolean): void
     if (typeof window !== "undefined") localStorage.setItem(STORAGE_KEY_THEATER_COLLAPSED, JSON.stringify(next));
   } catch { /* ignore */ }
   notifyCollapsedTheaterListeners();
+}
+
+export function setSideBarStatusAxis(active: boolean): void {
+  if (statusAxis === active) return;
+  statusAxis = active;
+  for (const listener of statusAxisListeners) listener();
+}
+
+export function toggleSideBarStatusAxis(): void {
+  setSideBarStatusAxis(!statusAxis);
+}
+
+export function getSideBarStatusAxis(): boolean {
+  return statusAxis;
+}
+
+export function subscribeStatusAxis(listener: () => void): () => void {
+  statusAxisListeners.add(listener);
+  return () => statusAxisListeners.delete(listener);
 }
 
 function getMaxPx(): number {

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -17,7 +17,7 @@ import { SideBarBrandFoot } from "../components/side-bar-brand-foot.js";
 import { applyVisibleReorder, groupDropIndexFromPoint, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderGroupIds, reorderTheaterIds, reorderWithinSegment, theaterDropIndexFromPoint, type DropSectionInfo } from "./operations-side-bar-hit-test.js";
 import { OperationsSideBarChip, type SideBarEntry } from "./operations-side-bar-chip.js";
 import { OperationsSideBarGroupHeader } from "./operations-side-bar-group-header.js";
-import { setSideBarCollapsed, setSideBarWidth, setTheaterCollapsed, useCollapsedTheaters, useSideBarState } from "./operations-side-bar-store.js";
+import { setSideBarCollapsed, setSideBarWidth, setTheaterCollapsed, toggleSideBarStatusAxis, useCollapsedTheaters, useSideBarState, useSideBarStatusAxis } from "./operations-side-bar-store.js";
 import { resolveOperationLaunchKind } from "./resolve-launch-kind.js";
 
 interface OperationsSideBarProps {
@@ -114,14 +114,17 @@ interface TheaterEntryBuildInput {
 
 interface TheaterSectionHeaderProps {
   readonly theater: TheaterInfo;
-  readonly operationCount: number;
   readonly active: boolean;
   readonly collapsed: boolean;
+  readonly statusAxis: boolean;
+  readonly statusActionsOpen: boolean;
+  readonly showStatusLiveTick: boolean;
   readonly dragging: boolean;
   readonly dropTarget: boolean;
   readonly dragOffsetY: number;
   readonly onSelectTheater: (theaterId: string) => void;
   readonly onToggleCollapsed: (theaterId: string) => void;
+  readonly onToggleStatusAxis: () => void;
   readonly onOpenActions: (anchor: DOMRect, returnFocus?: HTMLButtonElement | null) => void;
   readonly onOpenLaunch: (event: MouseEvent<HTMLButtonElement>, theaterId: string) => void;
   readonly onContextMenu: (anchor: DOMRect) => void;
@@ -134,8 +137,11 @@ interface TheaterInactiveSectionProps {
   readonly groups: readonly OperationGroup[];
   readonly collapsedGroups: ReadonlySet<string>;
   readonly operationAccent: Readonly<Record<string, string>>;
-  readonly operationCount: number;
   readonly collapsed: boolean;
+  readonly statusAxis: boolean;
+  readonly statusActionsOpen: boolean;
+  readonly showStatusLiveTick: boolean;
+  readonly statusLandingIds: ReadonlySet<string>;
   readonly dragging: boolean;
   readonly dropBefore: boolean;
   readonly dropAfter: boolean;
@@ -143,6 +149,7 @@ interface TheaterInactiveSectionProps {
   readonly onSelectTheater: (theaterId: string) => void;
   readonly onFocus: (operationId: string) => void;
   readonly onToggleCollapsed: (theaterId: string) => void;
+  readonly onToggleStatusAxis: () => void;
   readonly onOpenActions: (anchor: DOMRect, returnFocus?: HTMLButtonElement | null) => void;
   readonly onOpenLaunch: (event: MouseEvent<HTMLButtonElement>, theaterId: string) => void;
   readonly onContextMenu: (anchor: DOMRect) => void;
@@ -162,6 +169,22 @@ const CLOSE_ARM_DURATION_MS = 1500;
 const DRAG_THRESHOLD_PX = 6;
 const AUTO_SCROLL_EDGE_PX = 34;
 const AUTO_SCROLL_STEP_PX = 18;
+const STATUS_LANDING_DURATION_MS = 500;
+
+type SideBarStatus = OperationActivity;
+
+interface StatusSection {
+  readonly status: SideBarStatus;
+  readonly label: "AWAITING INPUT" | "RUNNING" | "IDLE" | "DORMANT";
+  readonly entries: readonly SideBarEntry[];
+}
+
+const STATUS_SECTION_ORDER: readonly Omit<StatusSection, "entries">[] = [
+  { status: "awaiting", label: "AWAITING INPUT" },
+  { status: "running", label: "RUNNING" },
+  { status: "idle", label: "IDLE" },
+  { status: "dormant", label: "DORMANT" },
+];
 export function OperationsSideBar({
   theaters,
   activeTheaterId,
@@ -198,12 +221,16 @@ export function OperationsSideBar({
   const chipsRef = useRef<HTMLOListElement | null>(null);
   const sideBar = useSideBarState();
   const { width, collapsed } = sideBar;
+  const statusAxis = useSideBarStatusAxis();
   const previousCollapsedRef = useRef(collapsed);
   const canvas = useCanvasState();
   const formationLayout = useFormationLayout();
   const formationView = useFormationView();
   const closeArmTimeoutRef = useRef<number | null>(null);
+  const statusLandingTimeoutRef = useRef<number | null>(null);
+  const previousOperationStatusRef = useRef<ReadonlyMap<string, SideBarStatus>>(new Map());
   const [armedCloseId, setArmedCloseId] = useState<string | null>(null);
+  const [statusLandingIds, setStatusLandingIds] = useState<ReadonlySet<string>>(new Set());
   const [drag, setDrag] = useState<DragState | null>(null);
   const dragRef = useRef<DragState | null>(null);
   const entriesRef = useRef<SideBarEntry[]>([]);
@@ -244,12 +271,16 @@ export function OperationsSideBar({
     };
   });
   const groupedSections = groupOperations(allEntries, activeGroups, canvas.operationOrder);
+  const statusSections = groupOperationsByStatus(allEntries);
   const hasCustomGroups = groupedSections.some((section) => section.group !== null);
   const orderedGroupIds = groupedSections.flatMap((section) => section.groupId ? [section.groupId] : []);
   const visibleEntries = groupedSections.flatMap((section) =>
     collapsedGroupSet.has(section.groupId ?? "") ? [] : section.entries,
   );
   const currentOrder = allEntries.map((entry) => entry.operation.id);
+  const statusSignature = operations
+    .map((operation) => `${operation.id}:${normalizeOperationStatus(operationStatus[operation.id])}`)
+    .join("\0");
 
   const clearCloseArmTimer = useCallback(() => {
     if (closeArmTimeoutRef.current === null) return;
@@ -282,6 +313,39 @@ export function OperationsSideBar({
     disarmClose();
   }, [armedCloseId, allEntries, disarmClose]);
 
+  useEffect(() => {
+    const nextStatuses = new Map(
+      operations.map((operation) => [operation.id, normalizeOperationStatus(operationStatus[operation.id])] as const),
+    );
+    const previousStatuses = previousOperationStatusRef.current;
+    previousOperationStatusRef.current = nextStatuses;
+    if (!statusAxis) {
+      if (statusLandingTimeoutRef.current !== null) window.clearTimeout(statusLandingTimeoutRef.current);
+      statusLandingTimeoutRef.current = null;
+      setStatusLandingIds((current) => current.size === 0 ? current : new Set());
+      return;
+    }
+    const movedIds = operations
+      .filter((operation) => {
+        const previous = previousStatuses.get(operation.id);
+        return previous !== undefined && previous !== nextStatuses.get(operation.id);
+      })
+      .map((operation) => operation.id);
+    if (movedIds.length === 0) return;
+    if (statusLandingTimeoutRef.current !== null) window.clearTimeout(statusLandingTimeoutRef.current);
+    setStatusLandingIds(new Set(movedIds));
+    statusLandingTimeoutRef.current = window.setTimeout(() => {
+      statusLandingTimeoutRef.current = null;
+      setStatusLandingIds(new Set());
+    }, STATUS_LANDING_DURATION_MS);
+  // statusSignature is the stable primitive dependency for the operation/status map assembled above.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusAxis, statusSignature]);
+
+  useEffect(() => () => {
+    if (statusLandingTimeoutRef.current !== null) window.clearTimeout(statusLandingTimeoutRef.current);
+  }, []);
+
   // 팔레트 "New Operation" 커맨드 요청을 소비해 ＋New 버튼과 동일한 launch 오버레이를 그 버튼 앵커 위치에 연다.
   useEffect(() => {
     if (!launchMenuRequest) return;
@@ -309,6 +373,7 @@ export function OperationsSideBar({
     : null;
 
   const keyboardMove = (operationId: string, direction: -1 | 1) => {
+    if (statusAxis) return;
     const index = visibleEntries.findIndex((e) => e.operation.id === operationId);
     if (index === -1) return;
     const targetIndex = Math.max(0, Math.min(visibleEntries.length - 1, index + direction));
@@ -343,6 +408,10 @@ export function OperationsSideBar({
     dragRef.current = next;
     setDrag(next);
   };
+
+  useEffect(() => {
+    if (statusAxis && dragRef.current?.kind === "chip") updateDrag(null);
+  }, [statusAxis]);
 
   // drag 시작(pointerId가 생김)에만 window 리스너 3개를 등록하고, drag 종료 시 정확히 3개 해제한다.
   const dragPointerId = drag?.pointerId ?? null;
@@ -432,6 +501,7 @@ export function OperationsSideBar({
   }, [dragPointerId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const beginPointerDrag = (event: ReactPointerEvent<HTMLLIElement>, operationId: string) => {
+    if (statusAxis) return;
     if (event.button !== 0) return;
     if (event.target instanceof Element && event.target.closest("button")) return;
     setActiveContextMenu(null);
@@ -637,7 +707,9 @@ export function OperationsSideBar({
       <ol className="operations-side-bar-chips" ref={chipsRef} aria-label="Operations">
         {theaters.map((theater, theaterIndex) => {
           const isActiveTheater = theater.id === activeTheaterId;
-          const theaterOperationCount = operations.filter((operation) => operation.theaterId === theater.id).length;
+          const theaterOperations = operations.filter((operation) => operation.theaterId === theater.id);
+          const showStatusLiveTick = !statusAxis && hasAwaitingOperation(theaterOperations, operationStatus);
+          const statusActionsOpen = activeContextMenu?.kind === "theater" && activeContextMenu.theaterId === theater.id;
           const theaterCollapsed = collapsedTheaters.includes(theater.id);
           const isTheaterDragging = drag?.kind === "theater" && drag.sourceTheaterId === theater.id && drag.dragging;
           const theaterDragOffsetY = isTheaterDragging && drag?.kind === "theater" ? drag.currentY - drag.startY : 0;
@@ -672,8 +744,11 @@ export function OperationsSideBar({
                 groups={groups.filter((group) => group.theaterId === theater.id)}
                 collapsedGroups={new Set(theaterCanvas.collapsedGroups)}
                 operationAccent={theaterCanvas.operationAccent}
-                operationCount={theaterOperationCount}
                 collapsed={theaterCollapsed}
+                statusAxis={statusAxis}
+                statusActionsOpen={statusActionsOpen}
+                showStatusLiveTick={showStatusLiveTick}
+                statusLandingIds={statusLandingIds}
                 dragging={isTheaterDragging}
                 dropBefore={theaterDropBefore}
                 dropAfter={theaterDropAfter}
@@ -681,6 +756,7 @@ export function OperationsSideBar({
                 onSelectTheater={onSelectTheater}
                 onFocus={onFocus}
                 onToggleCollapsed={toggleTheaterSectionCollapsed}
+                onToggleStatusAxis={toggleSideBarStatusAxis}
                 onOpenActions={(anchor, returnFocus) => {
                   setNewMenu(null);
                   setActiveContextMenu({ kind: "theater", theaterId: theater.id, anchor, returnFocus });
@@ -706,14 +782,17 @@ export function OperationsSideBar({
             >
               <TheaterSectionHeader
                 theater={theater}
-                operationCount={theaterOperationCount}
                 active
                 collapsed={theaterCollapsed}
+                statusAxis={statusAxis}
+                statusActionsOpen={statusActionsOpen}
+                showStatusLiveTick={showStatusLiveTick}
                 dragging={isTheaterDragging}
                 dropTarget={theaterDropBefore}
                 dragOffsetY={theaterDragOffsetY}
                 onSelectTheater={onSelectTheater}
                 onToggleCollapsed={toggleTheaterSectionCollapsed}
+                onToggleStatusAxis={toggleSideBarStatusAxis}
                 onOpenActions={(anchor, returnFocus) => {
                   setNewMenu(null);
                   setActiveContextMenu({ kind: "theater", theaterId: theater.id, anchor, returnFocus });
@@ -727,7 +806,50 @@ export function OperationsSideBar({
               />
               {!theaterCollapsed ? (
               <ol className="side-bar-theater-groups" aria-label={`${theater.label} operations`}>
-                {groupedSections.map((section) => {
+                {statusAxis ? statusSections.map((section) => (
+                  <li
+                    key={section.status}
+                    className={`side-bar-status-section side-bar-status-section--${section.status}`}
+                  >
+                    <div className={`side-bar-status-header side-bar-status-header--${section.status}`}>
+                      <span className="side-bar-status-header__dot" aria-hidden="true" />
+                      <span className="side-bar-status-header__label">{section.label}</span>
+                      <span className="side-bar-status-header__count">{section.entries.length}</span>
+                    </div>
+                    <ol className="side-bar-group-chips" aria-label={`${section.label} operations`}>
+                      {section.entries.map((entry) => {
+                        const globalIndex = allEntries.indexOf(entry);
+                        const accentKey = canvas.operationAccent[entry.operation.id] ?? operationAccentFromNode(entry.operation);
+                        const accentValue = accentKey ? resolveAccentColor(accentKey) : null;
+                        const groupMark = resolveEntryGroupMark(entry, activeGroups);
+                        return (
+                          <OperationsSideBarChip
+                            key={entry.operation.id}
+                            entry={entry}
+                            index={globalIndex}
+                            isCloseArmed={armedCloseId === entry.operation.id}
+                            accentValue={accentValue}
+                            groupMark={groupMark}
+                            statusLanded={statusLandingIds.has(entry.operation.id)}
+                            reorderEnabled={false}
+                            dragging={false}
+                            dragOffsetY={0}
+                            dropTarget={false}
+                            onArmClose={armClose}
+                            onDisarmClose={disarmClose}
+                            onClose={onClose}
+                            onMinimize={onMinimize}
+                            onFocus={onFocus}
+                            onKeyboardMove={keyboardMove}
+                            onPointerDragStart={beginPointerDrag}
+                            onOpenAccent={(operationId, anchor) => setActiveContextMenu({ kind: "chip", operationId, anchor })}
+                            onRename={onRename}
+                          />
+                        );
+                      })}
+                    </ol>
+                  </li>
+                )) : groupedSections.map((section) => {
           const isCollapsed = section.groupId !== null && collapsedGroupSet.has(section.groupId);
           const grpColor = section.group ? resolveAccentColor(section.group.color) : null;
           const sectionStyle = grpColor ? ({ "--grp-color": grpColor } as CSSProperties) : undefined;
@@ -945,6 +1067,36 @@ export function groupOperations(
   return [...sections, ungrouped];
 }
 
+export function groupOperationsByStatus(entries: readonly SideBarEntry[]): StatusSection[] {
+  return STATUS_SECTION_ORDER.flatMap(({ status, label }) => {
+    const members = entries.filter((entry) => normalizeOperationStatus(entry.status) === status);
+    return members.length > 0 ? [{ status, label, entries: members }] : [];
+  });
+}
+
+export function hasAwaitingOperation(
+  operations: readonly OperationNode[],
+  operationStatus: Readonly<Record<string, OperationActivity>>,
+): boolean {
+  return operations.some((operation) => operationStatus[operation.id] === "awaiting");
+}
+
+function normalizeOperationStatus(status: OperationActivity | undefined): SideBarStatus {
+  return status ?? "idle";
+}
+
+function resolveEntryGroupMark(
+  entry: SideBarEntry,
+  groups: readonly OperationGroup[],
+): { readonly name: string; readonly color: string } | null {
+  const groupId = entry.operation.groupId;
+  if (!groupId) return null;
+  const group = groups.find((candidate) => candidate.id === groupId);
+  if (!group) return null;
+  const color = resolveAccentColor(group.color);
+  return color ? { name: group.name, color } : null;
+}
+
 function buildTheaterEntries({
   theaterId,
   operations,
@@ -975,14 +1127,17 @@ function buildTheaterEntries({
 
 function TheaterSectionHeader({
   theater,
-  operationCount,
   active,
   collapsed,
+  statusAxis,
+  statusActionsOpen,
+  showStatusLiveTick,
   dragging,
   dropTarget,
   dragOffsetY,
   onSelectTheater,
   onToggleCollapsed,
+  onToggleStatusAxis,
   onOpenActions,
   onOpenLaunch,
   onContextMenu,
@@ -1003,11 +1158,11 @@ function TheaterSectionHeader({
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    // 중첩 행 컨트롤(∨/⋯/＋)에서 버블된 Enter/Space를 가로채면 버튼 키보드 활성화가 죽는다(Codex P2).
+    // 중첩 행 컨트롤(status/+ /caret)에서 버블된 Enter/Space를 가로채면 버튼 키보드 활성화가 죽는다.
     if (event.target !== event.currentTarget) return;
     if (event.key !== "Enter" && event.key !== " ") return;
     event.preventDefault();
-    onSelectTheater(theater.id);
+    activateOrToggle();
   };
 
   const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -1019,12 +1174,23 @@ function TheaterSectionHeader({
     if (dragging) suppressClickRef.current = true;
   };
 
+  // 행 클릭은 ▾ 버튼을 흡수한 단일 제스처다. 비활성 Theater는 먼저 선택만 하고(접힌 채 전환되는
+  // 사고 방지), 이미 활성인 Theater에서만 접기/펼치기를 토글한다.
+  const activateOrToggle = () => {
+    if (!active) {
+      onSelectTheater(theater.id);
+      if (collapsed) onToggleCollapsed(theater.id);
+      return;
+    }
+    onToggleCollapsed(theater.id);
+  };
+
   const select = () => {
     if (suppressClickRef.current) {
       suppressClickRef.current = false;
       return;
     }
-    onSelectTheater(theater.id);
+    activateOrToggle();
   };
 
   return (
@@ -1040,46 +1206,51 @@ function TheaterSectionHeader({
       onPointerUp={handlePointerUp}
       aria-current={active ? "true" : undefined}
       aria-expanded={!collapsed}
-      title={theater.label}
+      title={collapsed ? `Expand ${theater.label}` : `Collapse ${theater.label}`}
     >
       <span className="side-bar-theater-anchor" aria-hidden="true">{theaterInitials(theater.label)}</span>
       <span className="side-bar-theater-name">{theater.label}</span>
-      <span className="side-bar-theater-count">{operationCount}</span>
-      <span className="side-bar-theater-row-controls" aria-label={`${theater.label} controls`}>
+      <ChevronIcon collapsed={collapsed} />
+      <span className="side-bar-theater-row-controls" role="group" aria-label={`${theater.label} controls`}>
+        <button
+          type="button"
+          className="side-bar-status-axis-toggle"
+          aria-label="Sort by status"
+          aria-pressed={statusAxis}
+          title="Sort by status (Alt+S)"
+          onClick={(event) => {
+            event.stopPropagation();
+            onToggleStatusAxis();
+          }}
+        >
+          <StatusListIcon />
+          {showStatusLiveTick ? <span className="side-bar-status-axis-live-tick" aria-hidden="true" /> : null}
+        </button>
+        <span className="side-bar-theater-split-control" role="group" aria-label={`${theater.label} operation controls`}>
           <button
             type="button"
-            className="side-bar-theater-row-btn side-bar-theater-collapse-btn"
-            aria-label={collapsed ? `Expand ${theater.label}` : `Collapse ${theater.label}`}
-            aria-expanded={!collapsed}
-            title={collapsed ? "Expand" : "Collapse"}
-            onClick={(event) => {
-              event.stopPropagation();
-              onToggleCollapsed(theater.id);
-            }}
-          >
-            <ChevronIcon collapsed={collapsed} />
-          </button>
-          <button
-            type="button"
-            className="side-bar-theater-row-btn"
-            aria-label="Theater actions"
-            title="Theater actions"
-            onClick={(event) => {
-              event.stopPropagation();
-              onOpenActions(event.currentTarget.getBoundingClientRect(), event.currentTarget);
-            }}
-          >
-            <MoreIcon />
-          </button>
-          <button
-            type="button"
-            className="side-bar-theater-row-btn side-bar-theater-launch-btn"
+            className="side-bar-theater-row-btn side-bar-theater-launch-btn side-bar-theater-split-plus"
             aria-label={`New Operation in ${theater.label}`}
             title={`New Operation in ${theater.label}`}
             onClick={(event) => onOpenLaunch(event, theater.id)}
           >
             <PlusIcon />
           </button>
+          <button
+            type="button"
+            className="side-bar-theater-row-btn side-bar-theater-split-caret"
+            aria-label="Theater actions"
+            aria-haspopup="menu"
+            aria-expanded={statusActionsOpen}
+            title="Theater actions"
+            onClick={(event) => {
+              event.stopPropagation();
+              onOpenActions(event.currentTarget.getBoundingClientRect(), event.currentTarget);
+            }}
+          >
+            <CaretIcon />
+          </button>
+        </span>
       </span>
     </div>
   );
@@ -1091,8 +1262,11 @@ function TheaterInactiveSection({
   groups,
   collapsedGroups,
   operationAccent,
-  operationCount,
   collapsed,
+  statusAxis,
+  statusActionsOpen,
+  showStatusLiveTick,
+  statusLandingIds,
   dragging,
   dropBefore,
   dropAfter,
@@ -1100,12 +1274,14 @@ function TheaterInactiveSection({
   onSelectTheater,
   onFocus,
   onToggleCollapsed,
+  onToggleStatusAxis,
   onOpenActions,
   onOpenLaunch,
   onContextMenu,
   onPointerDragStart,
 }: TheaterInactiveSectionProps) {
   const sections = groupOperations(entries, groups, []);
+  const statusSections = groupOperationsByStatus(entries);
   const hasCustomGroups = sections.some((section) => section.group !== null);
   return (
     <li
@@ -1118,22 +1294,67 @@ function TheaterInactiveSection({
     >
       <TheaterSectionHeader
         theater={theater}
-        operationCount={operationCount}
         active={false}
         collapsed={collapsed}
+        statusAxis={statusAxis}
+        statusActionsOpen={statusActionsOpen}
+        showStatusLiveTick={showStatusLiveTick}
         dragging={dragging}
         dropTarget={dropBefore}
         dragOffsetY={dragOffsetY}
         onSelectTheater={onSelectTheater}
         onToggleCollapsed={onToggleCollapsed}
+        onToggleStatusAxis={onToggleStatusAxis}
         onOpenActions={onOpenActions}
         onOpenLaunch={onOpenLaunch}
         onContextMenu={onContextMenu}
         onPointerDragStart={onPointerDragStart}
       />
-      {!collapsed && sections.length > 0 ? (
+      {!collapsed && (statusAxis ? statusSections.length : sections.length) > 0 ? (
         <ol className="side-bar-theater-groups" aria-label={`${theater.label} operations`}>
-          {sections.map((section) => {
+          {statusAxis ? statusSections.map((section) => (
+            <li
+              key={section.status}
+              className={`side-bar-status-section side-bar-status-section--${section.status}`}
+            >
+              <div className={`side-bar-status-header side-bar-status-header--${section.status}`}>
+                <span className="side-bar-status-header__dot" aria-hidden="true" />
+                <span className="side-bar-status-header__label">{section.label}</span>
+                <span className="side-bar-status-header__count">{section.entries.length}</span>
+              </div>
+              <ol className="side-bar-group-chips" aria-label={`${section.label} operations`}>
+                {section.entries.map((entry, index) => {
+                  const accentKey = operationAccent[entry.operation.id] ?? operationAccentFromNode(entry.operation);
+                  const accentValue = accentKey ? resolveAccentColor(accentKey) : null;
+                  return (
+                    <OperationsSideBarChip
+                      key={entry.operation.id}
+                      entry={entry}
+                      index={index}
+                      isCloseArmed={false}
+                      accentValue={accentValue}
+                      groupMark={resolveEntryGroupMark(entry, groups)}
+                      statusLanded={statusLandingIds.has(entry.operation.id)}
+                      reorderEnabled={false}
+                      dragging={false}
+                      dragOffsetY={0}
+                      dropTarget={false}
+                      preview
+                      onArmClose={() => {}}
+                      onDisarmClose={() => {}}
+                      onClose={() => {}}
+                      onMinimize={() => {}}
+                      onFocus={onFocus}
+                      onKeyboardMove={() => {}}
+                      onPointerDragStart={() => {}}
+                      onOpenAccent={() => {}}
+                      onRename={() => {}}
+                    />
+                  );
+                })}
+              </ol>
+            </li>
+          )) : sections.map((section) => {
             const isCollapsed = section.groupId !== null && collapsedGroups.has(section.groupId);
             const grpColor = section.group ? resolveAccentColor(section.group.color) : null;
             return (
@@ -1310,22 +1531,29 @@ function autoScrollSideBar(clientY: number, chipsElement: HTMLOListElement | nul
 
 function ChevronIcon({ collapsed }: { readonly collapsed: boolean }) {
   return (
-    <svg viewBox="0 0 16 16" aria-hidden="true">
-      {collapsed ? (
-        <path d="M6 3.8 10.2 8 6 12.2" fill="none" stroke="currentColor" strokeWidth="1.45" strokeLinecap="round" strokeLinejoin="round" />
-      ) : (
-        <path d="M3.8 6 8 10.2 12.2 6" fill="none" stroke="currentColor" strokeWidth="1.45" strokeLinecap="round" strokeLinejoin="round" />
-      )}
+    <svg className={`side-bar-theater-chevron${collapsed ? " is-collapsed" : ""}`} viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M3.8 6 8 10.2 12.2 6" fill="none" stroke="currentColor" strokeWidth="1.45" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 }
 
-function MoreIcon() {
+function StatusListIcon() {
   return (
     <svg viewBox="0 0 16 16" aria-hidden="true">
-      <circle cx="3.5" cy="8" r="1.1" fill="currentColor" />
-      <circle cx="8" cy="8" r="1.1" fill="currentColor" />
-      <circle cx="12.5" cy="8" r="1.1" fill="currentColor" />
+      <circle cx="4" cy="4" r="1.5" fill="currentColor" />
+      <path d="M8 4h5.5" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <circle cx="4" cy="8" r="1.5" fill="currentColor" />
+      <path d="M8 8h5.5" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <circle cx="4" cy="12" r="1.5" fill="currentColor" />
+      <path d="M8 12h5.5" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function CaretIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="m5.2 6.6 2.8 2.8 2.8-2.8" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 }

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -1192,6 +1192,7 @@ function TheaterSectionHeader({
 
   // 행 클릭은 ▾ 버튼을 흡수한 단일 제스처다. 비활성 Theater는 선택만 하고(영속 접힘 선호를
   // 건드리지 않는다), 이미 활성인 Theater에서만 접기/펼치기를 토글한다.
+  // 행 title도 이 결과와 일치시킨다: 비활성 행은 "Switch to …", 활성 행만 Expand/Collapse를 광고한다.
   const activateOrToggle = () => {
     if (!active) {
       onSelectTheater(theater.id);
@@ -1221,7 +1222,7 @@ function TheaterSectionHeader({
       onPointerUp={handlePointerUp}
       aria-current={active ? "true" : undefined}
       aria-expanded={!collapsed}
-      title={collapsed ? `Expand ${theater.label}` : `Collapse ${theater.label}`}
+      title={active ? (collapsed ? `Expand ${theater.label}` : `Collapse ${theater.label}`) : `Switch to ${theater.label}`}
     >
       <span className="side-bar-theater-anchor" aria-hidden="true">{theaterInitials(theater.label)}</span>
       <span className="side-bar-theater-name">{theater.label}</span>

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -227,7 +227,7 @@ export function OperationsSideBar({
   const formationLayout = useFormationLayout();
   const formationView = useFormationView();
   const closeArmTimeoutRef = useRef<number | null>(null);
-  const statusLandingTimeoutRef = useRef<number | null>(null);
+  const statusLandingTimeoutsRef = useRef<Set<number>>(new Set());
   const previousOperationStatusRef = useRef<ReadonlyMap<string, SideBarStatus>>(new Map());
   const [armedCloseId, setArmedCloseId] = useState<string | null>(null);
   const [statusLandingIds, setStatusLandingIds] = useState<ReadonlySet<string>>(new Set());
@@ -272,6 +272,12 @@ export function OperationsSideBar({
   });
   const groupedSections = groupOperations(allEntries, activeGroups, canvas.operationOrder);
   const statusSections = groupOperationsByStatus(allEntries);
+  // STATUS 축 렌더는 entry/그룹 조회가 칩마다 반복되므로 O(n²)를 피해 Map으로 한 번만 인덱싱한다.
+  const entryIndexById = new Map(allEntries.map((entry, index) => [entry.operation.id, index] as const));
+  const groupMarkByGroupId = new Map(activeGroups.map((group) => {
+    const color = resolveAccentColor(group.color);
+    return [group.id, color ? { name: group.name, color } : null] as const;
+  }));
   const hasCustomGroups = groupedSections.some((section) => section.group !== null);
   const orderedGroupIds = groupedSections.flatMap((section) => section.groupId ? [section.groupId] : []);
   const visibleEntries = groupedSections.flatMap((section) =>
@@ -320,8 +326,8 @@ export function OperationsSideBar({
     const previousStatuses = previousOperationStatusRef.current;
     previousOperationStatusRef.current = nextStatuses;
     if (!statusAxis) {
-      if (statusLandingTimeoutRef.current !== null) window.clearTimeout(statusLandingTimeoutRef.current);
-      statusLandingTimeoutRef.current = null;
+      for (const timeoutId of statusLandingTimeoutsRef.current) window.clearTimeout(timeoutId);
+      statusLandingTimeoutsRef.current.clear();
       setStatusLandingIds((current) => current.size === 0 ? current : new Set());
       return;
     }
@@ -332,18 +338,28 @@ export function OperationsSideBar({
       })
       .map((operation) => operation.id);
     if (movedIds.length === 0) return;
-    if (statusLandingTimeoutRef.current !== null) window.clearTimeout(statusLandingTimeoutRef.current);
-    setStatusLandingIds(new Set(movedIds));
-    statusLandingTimeoutRef.current = window.setTimeout(() => {
-      statusLandingTimeoutRef.current = null;
-      setStatusLandingIds(new Set());
+    // 이동 배치별 독립 타이머: 기존 flash를 취소하지 않고 병합했다가 이 배치의 ID만 만료시킨다.
+    setStatusLandingIds((current) => {
+      const next = new Set(current);
+      for (const id of movedIds) next.add(id);
+      return next;
+    });
+    const timeoutId = window.setTimeout(() => {
+      statusLandingTimeoutsRef.current.delete(timeoutId);
+      setStatusLandingIds((current) => {
+        const next = new Set(current);
+        for (const id of movedIds) next.delete(id);
+        return next.size === current.size ? current : next;
+      });
     }, STATUS_LANDING_DURATION_MS);
+    statusLandingTimeoutsRef.current.add(timeoutId);
   // statusSignature is the stable primitive dependency for the operation/status map assembled above.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [statusAxis, statusSignature]);
 
   useEffect(() => () => {
-    if (statusLandingTimeoutRef.current !== null) window.clearTimeout(statusLandingTimeoutRef.current);
+    for (const timeoutId of statusLandingTimeoutsRef.current) window.clearTimeout(timeoutId);
+    statusLandingTimeoutsRef.current.clear();
   }, []);
 
   // 팔레트 "New Operation" 커맨드 요청을 소비해 ＋New 버튼과 동일한 launch 오버레이를 그 버튼 앵커 위치에 연다.
@@ -818,10 +834,10 @@ export function OperationsSideBar({
                     </div>
                     <ol className="side-bar-group-chips" aria-label={`${section.label} operations`}>
                       {section.entries.map((entry) => {
-                        const globalIndex = allEntries.indexOf(entry);
+                        const globalIndex = entryIndexById.get(entry.operation.id) ?? 0;
                         const accentKey = canvas.operationAccent[entry.operation.id] ?? operationAccentFromNode(entry.operation);
                         const accentValue = accentKey ? resolveAccentColor(accentKey) : null;
-                        const groupMark = resolveEntryGroupMark(entry, activeGroups);
+                        const groupMark = entry.operation.groupId ? groupMarkByGroupId.get(entry.operation.groupId) ?? null : null;
                         return (
                           <OperationsSideBarChip
                             key={entry.operation.id}
@@ -1174,12 +1190,11 @@ function TheaterSectionHeader({
     if (dragging) suppressClickRef.current = true;
   };
 
-  // 행 클릭은 ▾ 버튼을 흡수한 단일 제스처다. 비활성 Theater는 먼저 선택만 하고(접힌 채 전환되는
-  // 사고 방지), 이미 활성인 Theater에서만 접기/펼치기를 토글한다.
+  // 행 클릭은 ▾ 버튼을 흡수한 단일 제스처다. 비활성 Theater는 선택만 하고(영속 접힘 선호를
+  // 건드리지 않는다), 이미 활성인 Theater에서만 접기/펼치기를 토글한다.
   const activateOrToggle = () => {
     if (!active) {
       onSelectTheater(theater.id);
-      if (collapsed) onToggleCollapsed(theater.id);
       return;
     }
     onToggleCollapsed(theater.id);

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -435,6 +435,25 @@ export function focusCycleOperationIds(
     .map((operation) => operation.id);
 }
 
+// STATUS 축의 Alt+←/→ 순환 순서: 사이드바 STATUS 섹션의 가시 순서와 동일하게
+// awaiting → running → idle → dormant 랭크로 안정 정렬한다(랭크 내부는 operationOrder 순서 유지).
+// STATUS 축은 그룹 접힘이 없으므로 collapsedGroups는 적용하지 않는다.
+const STATUS_CYCLE_RANK: Readonly<Record<OperationActivity, number>> = { awaiting: 0, running: 1, idle: 2, dormant: 3 };
+
+export function statusCycleOperationIds(
+  operations: readonly OperationNode[],
+  operationOrder: readonly string[],
+  operationStatus: Readonly<Record<string, OperationActivity>>,
+  minimized: readonly string[],
+): readonly string[] {
+  const minimizedIds = new Set(minimized);
+  const rank = (operation: OperationNode): number => STATUS_CYCLE_RANK[operationStatus[operation.id] ?? "idle"];
+  return [...sortOperationsByOrder(operations, operationOrder)]
+    .sort((left, right) => rank(left) - rank(right))
+    .filter((operation) => !minimizedIds.has(operation.id))
+    .map((operation) => operation.id);
+}
+
 export function compareOperationCreatedAt(left: OperationNode, right: OperationNode): number {
   return left.ts.createdAt - right.ts.createdAt || left.id.localeCompare(right.id);
 }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2442,38 +2442,98 @@
 }
 
 .side-bar-theater-name {
+  flex: 1;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.side-bar-theater-count {
+.side-bar-theater-chevron {
   flex: none;
-  margin-left: auto;
+  width: 12px;
+  height: 12px;
   color: var(--ink-fog);
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  font-variant-numeric: tabular-nums;
+  transition: transform 0.15s ease;
+}
+
+.side-bar-theater-chevron.is-collapsed {
+  transform: rotate(-90deg);
 }
 
 .side-bar-theater-row-controls {
   display: flex;
   align-items: center;
   flex: none;
-  gap: 1px;
+  gap: var(--space-1);
   margin-left: 2px;
+}
+
+.side-bar-status-axis-toggle {
+  position: relative;
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--ink-fog);
+  cursor: pointer;
+}
+
+.side-bar-status-axis-toggle svg {
+  display: block;
+  width: 14px;
+  height: 14px;
+}
+
+.side-bar-status-axis-toggle:hover {
+  border-color: var(--hairline-strong);
+  color: var(--ink-pearl);
+}
+
+.side-bar-status-axis-toggle[aria-pressed="true"] {
+  border-color: var(--hairline-strong);
+  background: var(--ink-veil);
+  color: var(--brass);
+}
+
+.side-bar-status-axis-toggle:focus-visible {
+  outline: 2px solid var(--aurora);
+  outline-offset: 1px;
+}
+
+.side-bar-status-axis-live-tick {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--aurora);
+  animation: aurora-pulse 1.8s infinite;
+}
+
+.side-bar-theater-split-control {
+  display: flex;
+  flex: none;
+  height: 24px;
+  overflow: hidden;
+  border: 1px solid var(--hairline);
+  border-radius: 6px;
 }
 
 .side-bar-theater-row-btn {
   display: grid;
   place-items: center;
   flex: none;
-  width: 20px;
-  height: 20px;
+  height: 22px;
   padding: 0;
-  border: 1px solid transparent;
-  border-radius: var(--radius-xs);
+  border: 0;
+  border-radius: 0;
   background: transparent;
   color: var(--ink-fog);
   cursor: pointer;
@@ -2483,6 +2543,15 @@
     color var(--duration-fast) var(--ease-spring);
 }
 
+.side-bar-theater-split-plus {
+  width: 24px;
+}
+
+.side-bar-theater-split-caret {
+  width: 16px;
+  border-left: 1px solid var(--hairline);
+}
+
 .side-bar-theater-row-btn svg {
   width: 13px;
   height: 13px;
@@ -2490,10 +2559,13 @@
 
 .side-bar-theater-row-btn:hover,
 .side-bar-theater-row-btn:focus-visible {
-  background: color-mix(in oklch, var(--ink-pearl) 9%, transparent);
-  border-color: color-mix(in oklch, var(--ink-fog) 24%, transparent);
+  background: var(--ink-veil);
   color: var(--ink-pearl);
-  outline: none;
+}
+
+.side-bar-theater-row-btn:focus-visible {
+  outline: 2px solid var(--aurora);
+  outline-offset: -2px;
 }
 
 .side-bar-theater-groups {
@@ -2687,6 +2759,26 @@
   background: var(--ink-fog);
 }
 
+/* STATUS 축의 그룹 mark는 identity 채널만 사용한다. 그룹의 resolveAccentColor(--id-*) 값은
+   기존 operation spine과 독립된 7px mark로만 표시하고 status beacon 신호면을 덮지 않는다. */
+.side-bar-chip-group-mark {
+  display: block;
+  flex: none;
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--group-mark);
+}
+
+.side-bar-chip--status-landed {
+  animation: side-bar-status-land 0.5s ease-out;
+}
+
+@keyframes side-bar-status-land {
+  from { background: var(--aurora-glow); }
+  to { background: transparent; }
+}
+
 .side-bar-chip-status.is-live {
   background: var(--aurora);
   box-shadow: 0 0 7px var(--aurora-glow);
@@ -2810,10 +2902,77 @@
   .side-bar-chip-status.is-live {
     animation: none;
   }
+
+  .side-bar-chip--status-landed {
+    animation: none;
+  }
 }
 
 
 /* ── Group Section Layout ──────────────────────────────────────────────────────── */
+
+/* STATUS 축의 3px border는 identity가 아니라 OperationActivity 신호 채널이다.
+   idle/dormant는 tenant beacon의 현행 토큰을 그대로 공유한다. */
+.side-bar-status-section {
+  --status-color: transparent;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  margin-left: var(--space-1);
+  margin-bottom: 6px;
+  border-left: 3px solid var(--status-color);
+}
+
+.side-bar-status-section--awaiting {
+  --status-color: var(--aurora);
+}
+
+.side-bar-status-section--running {
+  --status-color: var(--warn);
+}
+
+.side-bar-status-section--idle {
+  --status-color: var(--positive);
+}
+
+.side-bar-status-section--dormant {
+  --status-color: color-mix(in oklch, var(--brass) 55%, var(--ink-rim));
+}
+
+.side-bar-status-header {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 12px;
+  background: color-mix(in oklch, var(--status-color) 8%, transparent);
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.side-bar-status-header__dot {
+  display: block;
+  flex: none;
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--status-color);
+}
+
+.side-bar-status-header--awaiting .side-bar-status-header__dot {
+  animation: aurora-pulse 1.8s infinite;
+}
+
+.side-bar-status-header__count {
+  flex: none;
+  min-width: 14px;
+  margin-left: auto;
+  color: color-mix(in oklch, var(--status-color) 65%, var(--ink-pearl));
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
 
 .side-bar-ungrouped-section {
   list-style: none;
@@ -2947,6 +3106,15 @@
   .side-bar-group-header,
   .side-bar-theater-header {
     transition: none;
+  }
+
+  .side-bar-theater-chevron {
+    transition: none;
+  }
+
+  .side-bar-status-axis-live-tick,
+  .side-bar-status-header--awaiting .side-bar-status-header__dot {
+    animation: none;
   }
 
   .side-bar-group-header--dragging,

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -313,6 +313,34 @@ describe("Instrument core design contract", () => {
     expect(store).toContain("setMaximizedOperationId");
   });
 
+  it("pins the non-durable STATUS regroup signal and identity channel grammar", () => {
+    const operations = source("pages/operations.tsx");
+    const sidebar = source("sidebar/operations-side-bar.tsx");
+    const sideBarStore = source("sidebar/operations-side-bar-store.ts");
+    const chip = source("sidebar/operations-side-bar-chip.tsx");
+    const components = source("styles/components.css");
+
+    expect(operations).toContain('event.code === "KeyS" && !event.shiftKey');
+    expect(operations).toContain("toggleSideBarStatusAxis();");
+    expect(sidebar).toContain('title="Sort by status (Alt+S)"');
+    expect(sidebar).toContain("groupOperationsByStatus(allEntries)");
+    expect(sidebar).toContain("if (statusAxis) return;");
+    expect(chip).toContain("reorderEnabled && event.altKey && event.shiftKey");
+    expect(sideBarStore).toContain("let statusAxis = false;");
+    expect(sideBarStore).not.toContain("STORAGE_KEY_STATUS");
+    expect(sideBarStore).not.toContain("fleet-console.operations.status");
+
+    // Doctrine: status-section border/dot/count are signal-owned, while the chip group mark
+    // consumes only resolveAccentColor identity values and never repaints the status beacon.
+    expect(sidebar).toContain("resolveEntryGroupMark(entry, activeGroups)");
+    expect(components).toContain("--status-color: var(--positive);");
+    expect(components).toContain("--status-color: color-mix(in oklch, var(--brass) 55%, var(--ink-rim));");
+    expect(components).toContain("border-left: 3px solid var(--status-color);");
+    expect(components).toContain("background: var(--group-mark);");
+    expect(components).toContain(".side-bar-status-axis-live-tick,");
+    expect(components).toContain(".side-bar-status-header--awaiting .side-bar-status-header__dot {");
+  });
+
   it("pins the selectable Right Rail panel behavior contract", () => {
     const rail = source("styles/rail.css");
     const rightRail = source("rail/right-rail.tsx");

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -332,7 +332,7 @@ describe("Instrument core design contract", () => {
 
     // Doctrine: status-section border/dot/count are signal-owned, while the chip group mark
     // consumes only resolveAccentColor identity values and never repaints the status beacon.
-    expect(sidebar).toContain("resolveEntryGroupMark(entry, activeGroups)");
+    expect(sidebar).toContain("groupMarkByGroupId.get(entry.operation.groupId)");
     expect(components).toContain("--status-color: var(--positive);");
     expect(components).toContain("--status-color: color-mix(in oklch, var(--brass) 55%, var(--ink-rim));");
     expect(components).toContain("border-left: 3px solid var(--status-color);");

--- a/runtime/fleet-console/tests/operation-focus.test.ts
+++ b/runtime/fleet-console/tests/operation-focus.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { focusCycleOperationIds, getState, nextOperationId, requestOperationKeyboardFocus, setState } from "../core/client/src/store.js";
+import { focusCycleOperationIds, getState, nextOperationId, requestOperationKeyboardFocus, setState, statusCycleOperationIds } from "../core/client/src/store.js";
 import type { OperationGroup, OperationNode } from "../core/client/src/types.js";
 
 function makeOperation(id: string, groupId: string | null = null, createdAt = 1): OperationNode {
@@ -101,5 +101,39 @@ describe("Operation keyboard focus requests", () => {
 
     requestOperationKeyboardFocus("other-operation");
     expect(getState().keyboardFocusRequest).toEqual({ operationId: "other-operation", requestId: 3 });
+  });
+});
+
+describe("statusCycleOperationIds — STATUS 축 Alt+←/→ 순환", () => {
+  it("orders by awaiting → running → idle → dormant, keeping operationOrder inside each rank and ignoring group collapse", () => {
+    const operations = [
+      makeOperation("idle-late", null, 1),
+      makeOperation("running-1", "collapsed-group", 2),
+      makeOperation("awaiting-1", "collapsed-group", 3),
+      makeOperation("idle-early", null, 4),
+      makeOperation("dormant-1", null, 5),
+    ];
+    const order = statusCycleOperationIds(
+      operations,
+      ["idle-early", "idle-late", "running-1", "awaiting-1", "dormant-1"],
+      { "running-1": "running", "awaiting-1": "awaiting", "dormant-1": "dormant" },
+      [],
+    );
+    // 사이드바 STATUS 섹션과 동일한 가시 순서: 접힌 그룹 소속이어도 제외되지 않는다.
+    expect(order).toEqual(["awaiting-1", "running-1", "idle-early", "idle-late", "dormant-1"]);
+  });
+
+  it("drops minimized operations and treats missing status as idle", () => {
+    const operations = [
+      makeOperation("plain", null, 1),
+      makeOperation("minimized-awaiting", null, 2),
+    ];
+    const order = statusCycleOperationIds(
+      operations,
+      ["plain", "minimized-awaiting"],
+      { "minimized-awaiting": "awaiting" },
+      ["minimized-awaiting"],
+    );
+    expect(order).toEqual(["plain"]);
   });
 });

--- a/runtime/fleet-console/tests/operations-side-bar-group.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-group.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
+import type { OperationActivity } from "@fleet-console/sdk/plugin";
 
 import { applyVisibleReorder, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderWithinSegment, type DropSectionInfo } from "../core/client/src/sidebar/operations-side-bar-hit-test.js";
-import { groupOperations, theaterInitials } from "../core/client/src/sidebar/operations-side-bar.js";
+import { groupOperations, groupOperationsByStatus, hasAwaitingOperation, theaterInitials } from "../core/client/src/sidebar/operations-side-bar.js";
 import type { SideBarEntry } from "../core/client/src/sidebar/operations-side-bar-chip.js";
 import type { OperationGroup, OperationNode } from "../core/client/src/types.js";
 
@@ -20,12 +21,13 @@ function makeNode(id: string, groupId?: string | null): OperationNode {
   };
 }
 
-function makeEntry(id: string, groupId?: string | null): SideBarEntry {
+function makeEntry(id: string, groupId?: string | null, status?: OperationActivity): SideBarEntry {
   return {
     operation: makeNode(id, groupId),
     active: false,
     minimized: false,
     notificationCount: 0,
+    status,
     icon: null,
   };
 }
@@ -285,6 +287,45 @@ describe("groupOperations", () => {
     const sections = groupOperations(entries, groups, []);
     expect(sections[sections.length - 1]?.groupId).toBeNull();
     expect(sections[sections.length - 1]?.entries).toHaveLength(0);
+  });
+});
+
+describe("groupOperationsByStatus", () => {
+  it("renders only non-empty sections in the literal status order and treats a missing key as idle", () => {
+    const entries = [
+      makeEntry("idle-missing"),
+      makeEntry("dormant", null, "dormant"),
+      makeEntry("awaiting", null, "awaiting"),
+      makeEntry("running", null, "running"),
+      makeEntry("idle-explicit", null, "idle"),
+    ];
+
+    const sections = groupOperationsByStatus(entries);
+
+    expect(sections.map((section) => [section.status, section.label])).toEqual([
+      ["awaiting", "AWAITING INPUT"],
+      ["running", "RUNNING"],
+      ["idle", "IDLE"],
+      ["dormant", "DORMANT"],
+    ]);
+    expect(sections[2]?.entries.map((entry) => entry.operation.id)).toEqual(["idle-missing", "idle-explicit"]);
+  });
+
+  it("preserves the incoming sortOperationsByOrder sequence inside each status section", () => {
+    const sections = groupOperationsByStatus([
+      makeEntry("running-second", null, "running"),
+      makeEntry("awaiting", null, "awaiting"),
+      makeEntry("running-first", null, "running"),
+    ]);
+
+    expect(sections.find((section) => section.status === "running")?.entries.map((entry) => entry.operation.id))
+      .toEqual(["running-second", "running-first"]);
+  });
+
+  it("detects the GROUP-axis live tick only for an explicit awaiting status", () => {
+    const operations = [makeNode("a"), makeNode("b")];
+    expect(hasAwaitingOperation(operations, { a: "running", b: "awaiting" })).toBe(true);
+    expect(hasAwaitingOperation(operations, { a: "running" })).toBe(false);
   });
 });
 

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -142,19 +142,32 @@ describe("OperationsSideBar STATUS axis", () => {
     expect(required<HTMLElement>(".side-bar-theater-header").getAttribute("aria-expanded")).toBe("false");
     expect(window.localStorage.getItem("fleet-console.operations.theater-collapsed")).toBe('["theater-a"]');
   });
+
+  it("selects an inactive Theater on row click without mutating its persisted collapse preference", () => {
+    setTheaterCollapsed("theater-a", true);
+    const onSelectTheater = vi.fn();
+    renderSideBar([makeOperation("only", null)], [], onSelectTheater, "theater-other");
+
+    act(() => required<HTMLElement>(".side-bar-theater-header").click());
+
+    expect(onSelectTheater).toHaveBeenCalledWith("theater-a");
+    // 비활성 클릭=선택만 — 접힘 영속 키는 그대로 남는다.
+    expect(window.localStorage.getItem("fleet-console.operations.theater-collapsed")).toBe('["theater-a"]');
+  });
 });
 
 function renderSideBar(
   operations: readonly OperationNode[],
   groups: readonly OperationGroup[] = [],
   onSelectTheater = vi.fn(),
+  activeTheaterId: string = THEATER.id,
 ): void {
   container = document.createElement("div");
   document.body.append(container);
   root = createRoot(container);
   act(() => root?.render(createElement(MemoryRouter, null, createElement(OperationsSideBar, {
     theaters: [THEATER],
-    activeTheaterId: THEATER.id,
+    activeTheaterId,
     operations,
     groups,
     minimized: [],

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -1,0 +1,226 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getSnapshot, loadForTheater, setOperationOrder } from "../core/client/src/canvas/canvas-store.js";
+import { OperationsSideBar } from "../core/client/src/sidebar/operations-side-bar.js";
+import { setSideBarCollapsed, setSideBarStatusAxis, setTheaterCollapsed } from "../core/client/src/sidebar/operations-side-bar-store.js";
+import { setState as setConsoleState } from "../core/client/src/store.js";
+import type { OperationGroup, OperationNode, TheaterInfo } from "../core/client/src/types.js";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  window.localStorage.clear();
+  setSideBarCollapsed(false);
+  setSideBarStatusAxis(false);
+  setTheaterCollapsed("theater-a", false);
+  loadForTheater("theater-a");
+  setConsoleState({ operationStatus: {} });
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  setSideBarStatusAxis(false);
+  setConsoleState({ operationStatus: {} });
+  loadForTheater(null);
+});
+
+describe("OperationsSideBar STATUS axis", () => {
+  it("toggles from GROUP to ordered status sections, hides the live tick, and keeps group identity marks", () => {
+    const operations = [
+      makeOperation("idle", null),
+      makeOperation("running", "group-a"),
+      makeOperation("awaiting", "group-a", "rose"),
+      makeOperation("dormant", null),
+    ];
+    setOperationOrder(operations.map((operation) => operation.id));
+    setConsoleState({
+      operationStatus: {
+        running: "running",
+        awaiting: "awaiting",
+        dormant: "dormant",
+      },
+    });
+    renderSideBar(operations, [GROUP_A]);
+
+    const toggle = required<HTMLButtonElement>(".side-bar-status-axis-toggle");
+    expect(toggle.getAttribute("aria-pressed")).toBe("false");
+    expect(toggle.title).toBe("Sort by status (Alt+S)");
+    expect(toggle.querySelector(".side-bar-status-axis-live-tick")).not.toBeNull();
+    expect(container?.querySelector(".side-bar-group-header")).not.toBeNull();
+
+    act(() => toggle.click());
+
+    expect(toggle.getAttribute("aria-pressed")).toBe("true");
+    expect(toggle.querySelector(".side-bar-status-axis-live-tick")).toBeNull();
+    expect(Array.from(container?.querySelectorAll(".side-bar-status-header__label") ?? []).map((node) => node.textContent)).toEqual([
+      "AWAITING INPUT",
+      "RUNNING",
+      "IDLE",
+      "DORMANT",
+    ]);
+    expect(container?.querySelector(".side-bar-group-header")).toBeNull();
+    expect(required<HTMLElement>('[data-side-bar-chip-id="awaiting"]').style.getPropertyValue("--user-accent")).toBe("var(--id-rose)");
+    expect(required<HTMLElement>('[data-side-bar-chip-id="awaiting"] .side-bar-chip-group-mark').title).toBe("Alpha crew");
+    expect(container?.querySelector('[data-side-bar-chip-id="idle"] .side-bar-chip-group-mark')).toBeNull();
+    expect(required<HTMLElement>('[data-side-bar-chip-id="awaiting"]').dataset.reorderEnabled).toBe("false");
+  });
+
+  it("keeps keyboard reordering disabled in STATUS and unchanged in GROUP", () => {
+    const operations = [
+      makeOperation("first", null),
+      makeOperation("second", null),
+    ];
+    setOperationOrder(["first", "second"]);
+    setConsoleState({ operationStatus: { first: "running", second: "running" } });
+    setSideBarStatusAxis(true);
+    renderSideBar(operations);
+
+    const first = required<HTMLElement>('[data-side-bar-chip-id="first"]');
+    act(() => first.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      altKey: true,
+      shiftKey: true,
+      bubbles: true,
+    })));
+
+    expect(getSnapshot().operationOrder).toEqual(["first", "second"]);
+
+    act(() => required<HTMLButtonElement>(".side-bar-status-axis-toggle").click());
+    const groupFirst = required<HTMLElement>('[data-side-bar-chip-id="first"]');
+    act(() => groupFirst.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      altKey: true,
+      shiftKey: true,
+      bubbles: true,
+    })));
+
+    expect(getSnapshot().operationOrder).toEqual(["second", "first"]);
+  });
+
+  it("flashes a chip once when a live status change moves it between sections", () => {
+    const operations = [makeOperation("moving", null)];
+    setConsoleState({ operationStatus: { moving: "running" } });
+    setSideBarStatusAxis(true);
+    renderSideBar(operations);
+
+    expect(required<HTMLElement>('[data-side-bar-chip-id="moving"]').className).not.toContain("side-bar-chip--status-landed");
+
+    act(() => setConsoleState({ operationStatus: { moving: "awaiting" } }));
+
+    expect(required<HTMLElement>('[data-side-bar-chip-id="moving"]').className).toContain("side-bar-chip--status-landed");
+    expect(required<HTMLElement>(".side-bar-status-header__label").textContent).toBe("AWAITING INPUT");
+  });
+
+  it("uses the Theater name row for persisted collapse and exposes the split control accessibility contract", () => {
+    const onSelectTheater = vi.fn();
+    renderSideBar([makeOperation("only", null)], [], onSelectTheater);
+
+    expect(container?.querySelector(".side-bar-theater-count")).toBeNull();
+    expect(container?.querySelector(".side-bar-theater-collapse-btn")).toBeNull();
+    expect(required<HTMLButtonElement>(".side-bar-theater-split-plus").getAttribute("aria-label")).toBe("New Operation in Alpha");
+    const caret = required<HTMLButtonElement>(".side-bar-theater-split-caret");
+    expect(caret.getAttribute("aria-haspopup")).toBe("menu");
+    expect(caret.getAttribute("aria-expanded")).toBe("false");
+
+    act(() => required<HTMLElement>(".side-bar-theater-header").click());
+
+    // 활성 Theater 행 클릭은 접기 토글만 수행한다 — 재선택하지 않는다.
+    // (비활성 Theater 클릭은 선택만 하고 접기 상태를 건드리지 않는 것이 행 제스처 계약이다.)
+    expect(onSelectTheater).not.toHaveBeenCalled();
+    expect(required<HTMLElement>(".side-bar-theater-header").getAttribute("aria-expanded")).toBe("false");
+    expect(window.localStorage.getItem("fleet-console.operations.theater-collapsed")).toBe('["theater-a"]');
+  });
+});
+
+function renderSideBar(
+  operations: readonly OperationNode[],
+  groups: readonly OperationGroup[] = [],
+  onSelectTheater = vi.fn(),
+): void {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  act(() => root?.render(createElement(MemoryRouter, null, createElement(OperationsSideBar, {
+    theaters: [THEATER],
+    activeTheaterId: THEATER.id,
+    operations,
+    groups,
+    minimized: [],
+    activeOperationId: null,
+    operationNotifications: {},
+    catalog: [],
+    canLaunch: true,
+    addingTheater: false,
+    theaterError: null,
+    renderKindIcon: () => null,
+    onLaunchKind: () => {},
+    onResetView: () => {},
+    onClose: () => {},
+    onMinimize: () => {},
+    onFocus: () => {},
+    onSetAccent: () => {},
+    onRename: () => {},
+    onSetGroupId: () => {},
+    onCreateGroup: () => {},
+    onSetGroupColor: () => {},
+    onRenameGroup: () => {},
+    onReorderGroups: () => {},
+    onReorderTheaters: () => {},
+    onUngroupAll: () => {},
+    onSelectTheater,
+    onAddTheater: () => {},
+    onCancelAddTheater: () => {},
+    onForgetTheater: () => {},
+  }))));
+}
+
+function required<T extends Element>(selector: string): T {
+  const element = container?.querySelector<T>(selector);
+  if (!element) throw new Error(`Missing ${selector}`);
+  return element;
+}
+
+function makeOperation(id: string, groupId: string | null, accent?: string): OperationNode {
+  return {
+    id,
+    theaterId: THEATER.id,
+    type: "shell",
+    pluginId: "terminal",
+    title: id,
+    payload: {},
+    geometry: null,
+    groupId,
+    accent,
+    ts: { createdAt: 1, updatedAt: 1 },
+  };
+}
+
+const THEATER: TheaterInfo = {
+  id: "theater-a",
+  label: "Alpha",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  lastOpenedAt: "2026-01-01T00:00:00.000Z",
+  hasWiki: false,
+  activeAdmiralCount: 0,
+};
+
+const GROUP_A: OperationGroup = {
+  id: "group-a",
+  name: "Alpha crew",
+  color: "blue",
+  order: 0,
+  theaterId: THEATER.id,
+  createdAt: 1,
+};

--- a/runtime/fleet-console/tests/operations-side-bar-store.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-store.test.ts
@@ -43,6 +43,24 @@ describe("two-state SideBar store", () => {
     expect(listener).not.toHaveBeenCalled();
     unsubscribe();
   });
+
+  it("keeps the STATUS axis in memory only and starts a fresh module in GROUP mode", async () => {
+    const store = await loadStore();
+    const listener = vi.fn();
+    const unsubscribe = store.subscribeStatusAxis(listener);
+
+    expect(store.getSideBarStatusAxis()).toBe(false);
+    store.toggleSideBarStatusAxis();
+
+    expect(store.getSideBarStatusAxis()).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.length).toBe(0);
+
+    vi.resetModules();
+    const reloadedStore = await loadStore();
+    expect(reloadedStore.getSideBarStatusAxis()).toBe(false);
+    unsubscribe();
+  });
 });
 
 async function loadStore() {


### PR DESCRIPTION
## Summary
- Theater 행의 Operation 갯수 표시를 제거하고 그 자리에 상태축 전환 아이콘 버튼(Alt+S)을 배치했습니다. 누르면 좌측 사이드바가 AWAITING INPUT → RUNNING → IDLE → DORMANT 상태 섹션으로 재편성되고, 각 칩은 그룹 spine과 7px 그룹 mark로 소속 그룹 시인성을 유지합니다.
- 상태축은 의도적으로 비영속(in-memory)입니다 — 리로드 시 항상 GROUP 축으로 시작하며, GROUP 축에서 awaiting 세션이 생기면 토글 버튼 모서리에 aurora live-tick이 점등됩니다. STATUS 축에서는 드래그/키보드 재배치가 비활성화되어 수동 정렬 SSoT(canvas.operationOrder)와 충돌하지 않습니다.
- Theater 행 컨트롤을 통합했습니다: 접기 전용 ▾ 버튼을 제거하고 행 클릭 제스처(활성=접기 토글, 비활성=선택만)로 흡수, ⋯과 +는 [ + | caret ] split 컨트롤 하나로 병합했습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] 사이드바 타깃 vitest 4 files 77 tests green (status-axis 신규 테스트 포함: 축 전환, 비영속, live-tick, 그룹 mark, 재배치 차단, Theater 제스처 계약)
- [x] 격리 인스턴스 헤디드 실브라우저 검증: STATUS 재편성, 리로드 후 GROUP 복귀(localStorage 무기록), split caret 메뉴, 접기 제스처
- [x] Changelog fragment `.changelog.d/pr-361.md` 추가 — 문법·이중언어 요약·`compile-changelog-fragments.mjs --check` 검증 완료
