### PR TITLE
fix(console): flatten theater split control and re-dock formation cluster

### DIFF
--- a/.changelog.d/pr-357.md
+++ b/.changelog.d/pr-357.md
@@ -2,5 +2,5 @@
 #### Changed
 - [fleet-console] Replace the sidebar Add Theater chrome row with a quiet New Theater ghost row at the end of the Theater list, matching Theater row grammar with a dashed anchor that wakes in brass on hover and focus.
   ko: 사이드바 상단 Add Theater 크롬 행을 제거하고, Theater 목록 말미에 hover/focus 시 brass로 각성하는 dashed 앵커의 New Theater ghost 행을 Theater 행 문법 그대로 추가합니다.
-- [fleet-console] Move the Reset view and Formation layout toggles from the sidebar to the command band left cluster, so they stay reachable while Formation view is active and no longer appear on utility routes such as Settings.
-  ko: Reset view와 Formation 레이아웃 토글을 사이드바에서 command band 좌측 클러스터로 이전하여 Formation view 활성 중에도 항상 접근 가능하고 Settings 같은 utility route에는 노출되지 않습니다.
+- [fleet-console] Move the Reset view and Formation layout toggles from the sidebar to a command band cluster docked just right of the sidebar edge, so they stay reachable while Formation view is active and no longer appear on utility routes such as Settings.
+  ko: Reset view와 Formation 레이아웃 토글을 사이드바에서 사이드바 경계 바로 우측의 command band 클러스터로 이전하여 Formation view 활성 중에도 항상 접근 가능하고 Settings 같은 utility route에는 노출되지 않습니다.

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -325,14 +325,14 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
         <button type="button" className="command-band-button command-band-search" onClick={toggleOperationSearch} aria-label="Search sessions" title="Search sessions (⌘K)">
           <SearchIcon />
         </button>
-        {operationsViewVisible ? <div className="command-band-formation-group" role="group" aria-label="Formation view">
-          <button type="button" className="command-band-formation-toggle command-band-formation-seg" onClick={() => animateViewportTo({ x: 0, y: 0, zoom: 1 })} disabled={state.activeTheaterId === null} aria-label="Reset canvas view" title="Reset canvas view"><ResetViewIcon /></button>
-          <span className="command-band-formation-divider" aria-hidden="true" />
-          <button type="button" className="command-band-formation-toggle command-band-formation-seg" onClick={() => selectFormationLayout("grid")} disabled={state.activeTheaterId === null} aria-pressed={formationView && formationLayout === "grid"} aria-label="Formation view — Grid layout" title="Formation view — Grid layout"><FormationGridIcon /></button>
-          <button type="button" className="command-band-formation-toggle command-band-formation-seg" onClick={() => selectFormationLayout("columns")} disabled={state.activeTheaterId === null} aria-pressed={formationView && formationLayout === "columns"} aria-label="Formation view — Columns layout" title="Formation view — Columns layout"><FormationColumnsIcon /></button>
-          <button type="button" className="command-band-formation-toggle command-band-formation-seg" onClick={() => selectFormationLayout("rows")} disabled={state.activeTheaterId === null} aria-pressed={formationView && formationLayout === "rows"} aria-label="Formation view — Rows layout" title="Formation view — Rows layout"><FormationRowsIcon /></button>
-        </div> : null}
       </div>
+      {operationsViewVisible ? <div className="command-band-formation-group" role="group" aria-label="Formation view">
+        <button type="button" className="command-band-formation-toggle command-band-formation-seg" onClick={() => animateViewportTo({ x: 0, y: 0, zoom: 1 })} disabled={state.activeTheaterId === null} aria-label="Reset canvas view" title="Reset canvas view"><ResetViewIcon /></button>
+        <span className="command-band-formation-divider" aria-hidden="true" />
+        <button type="button" className="command-band-formation-toggle command-band-formation-seg" onClick={() => selectFormationLayout("grid")} disabled={state.activeTheaterId === null} aria-pressed={formationView && formationLayout === "grid"} aria-label="Formation view — Grid layout" title="Formation view — Grid layout"><FormationGridIcon /></button>
+        <button type="button" className="command-band-formation-toggle command-band-formation-seg" onClick={() => selectFormationLayout("columns")} disabled={state.activeTheaterId === null} aria-pressed={formationView && formationLayout === "columns"} aria-label="Formation view — Columns layout" title="Formation view — Columns layout"><FormationColumnsIcon /></button>
+        <button type="button" className="command-band-formation-toggle command-band-formation-seg" onClick={() => selectFormationLayout("rows")} disabled={state.activeTheaterId === null} aria-pressed={formationView && formationLayout === "rows"} aria-label="Formation view — Rows layout" title="Formation view — Rows layout"><FormationRowsIcon /></button>
+      </div> : null}
       <div className="command-band-center">
         {operationsViewVisible && activeTheater ? <div ref={switcherRef} className="command-band-switcher" onBlur={handleSwitcherFocusOut}>
           <div className="command-band-theater-cluster" aria-label={`Active Theater: ${activeTheater.label}`}>

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2481,9 +2481,6 @@
   display: flex;
   flex: none;
   height: 24px;
-  overflow: hidden;
-  border: 1px solid var(--hairline);
-  border-radius: 6px;
 }
 
 .side-bar-theater-row-btn {
@@ -2509,7 +2506,6 @@
 
 .side-bar-theater-split-caret {
   width: 16px;
-  border-left: 1px solid var(--hairline);
 }
 
 .side-bar-theater-row-btn svg {

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -20,6 +20,7 @@
 }
 
 .command-band {
+  position: relative;
   display: grid;
   grid-template-columns: minmax(var(--command-band-left-width, 280px), 1fr) minmax(0, max-content) minmax(44px, 1fr);
   flex: none;
@@ -78,9 +79,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 }
 
 .command-band-left {
-  /* 사이드바 폭에 정렬하되, Formation 클러스터 등 내용이 초과하면 좌측 1fr 트랙으로 확장해 중앙 침범을 막는다. */
-  width: fit-content;
-  min-width: var(--command-band-left-width, 280px);
+  width: var(--command-band-left-width, 280px);
   gap: var(--space-1);
   padding-inline: var(--space-2);
   border-right: 1px solid var(--surface-rim);
@@ -272,6 +271,10 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 }
 
 .command-band-formation-group {
+  position: absolute;
+  left: calc(var(--command-band-left-width, 280px) + var(--space-2));
+  top: 50%;
+  transform: translateY(-50%);
   display: flex;
   flex: none;
   align-items: center;

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -374,7 +374,8 @@ describe("Instrument core design contract", () => {
     expect(commandBand).toContain("onClick={toggleOperationSearch}");
     expect(commandBand).toContain('className="command-band-button command-band-rail-toggle"');
     expect(commandBand).toContain("onClick={toggleRailChrome}");
-    expect(commandBand).toContain('{operationsViewVisible ? <div className="command-band-formation-group" role="group" aria-label="Formation view">');
+    expect(commandBand).toContain(`      </div>
+      {operationsViewVisible ? <div className="command-band-formation-group" role="group" aria-label="Formation view">`);
     expect(commandBand).toContain('aria-label="Reset canvas view"');
     expect(commandBand).toContain("<ResetViewIcon />");
     expect(commandBand).toContain("onClick={() => animateViewportTo({ x: 0, y: 0, zoom: 1 })}");
@@ -401,11 +402,12 @@ describe("Instrument core design contract", () => {
     expect(components).not.toContain(".side-bar-formation-group {");
     expect(components).not.toContain(".side-bar-theater-add-btn {");
     expect(layout).toContain(".command-band-formation-group {");
+    expect(layout).toContain("left: calc(var(--command-band-left-width, 280px) + var(--space-2));");
     expect(layout).toContain(".command-band-formation-group .command-band-formation-seg + .command-band-formation-seg {");
     expect(layout).toContain("border-left: 1px solid var(--surface-rim);");
     expect(commandBand).toContain('"--command-band-left-width": `${sideBar.width}px`');
     expect(layout).toContain("grid-template-columns: minmax(var(--command-band-left-width, 280px), 1fr) minmax(0, max-content) minmax(44px, 1fr);");
-    expect(layout).toContain("min-width: var(--command-band-left-width, 280px);");
+    expect(layout).toContain("width: var(--command-band-left-width, 280px);");
     const commandBandCenterBlock = layout.match(/\.command-band-center \{[^}]*\}/)?.[0] ?? "";
     const commandBandRightBlocks = [...layout.matchAll(/\.command-band-right \{[^}]*\}/g)].map((match) => match[0]);
     expect(commandBandCenterBlock).toContain("justify-content: center;");


### PR DESCRIPTION
## Summary
- PR#357 후속 사용자 피드백 3건 반영입니다.
- 사이드바 Theater 헤더의 [+|⌄] split 컨트롤에서 raised 보더/라운드를 제거해 이웃 플랫 row 버튼(⌄, ≣)과 문법을 통일했습니다.
- command-band 좌측 세그먼트를 고정폭(`--command-band-left-width`)으로 복원해 사이드바 위로 돌출(318px>280px)하며 겹쳐 보이던 문제를 해소했습니다.
- Reset/Formation 클러스터를 좌측 글래스 세그먼트(검색 영역) 밖으로 이동 — 사이드바 경계 바로 우측, 캔버스 위 밴드 선두에 절대배치했습니다. `operationsViewVisible` 게이팅은 유지됩니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` green
- [x] `instrument-design-contract.test.ts` 20/20 (배치·고정폭 단언 동반 갱신)
- [x] 격리 헤디드 실측: split 플랫(border 0), 세그먼트 280px 정렬, 클러스터 x=288 밴드 선두 배치, Settings 라우트 클러스터 부재, 페이지 에러 0
- [ ] Changelog fragment: PR 번호 배정 후 추가