### PR TITLE
feat(console): persist Session Analyst language and engine selection

### DIFF
--- a/.changelog.d/pr-364.md
+++ b/.changelog.d/pr-364.md
@@ -1,0 +1,16 @@
+### fleet-plugin
+#### Added
+- [fleet-console] Session Analyst now follows the console Language setting: panel copy and analysis answers render in English or Korean, with "auto" resolving from the browser language.
+  ko: Session Analyst가 콘솔 Language 설정을 따라 패널 문구와 분석 답변을 영어/한국어로 제공하며, "auto"는 브라우저 언어로 해석됩니다.
+- [fleet-console] Session Analyst CLI/Model/Effort selections now persist across reloads and restarts; Reset restores the saved default instead of the catalog guess, and the selectors stay locked while a reset is in flight.
+  ko: Session Analyst의 CLI/Model/Effort 선택이 리로드와 재시작 후에도 유지되며, Reset은 catalog 추정값 대신 저장된 기본값을 복원하고 초기화 중에는 셀렉터가 잠깁니다.
+
+### fleet-console
+#### Added
+- [fleet-console] The console Language setting (Settings > General) now also drives Session Analyst, delivering the resolved locale to plugins through the operation render context.
+  ko: 콘솔 Language 설정(Settings → General)이 이제 Session Analyst에도 적용되며, 해석된 로케일이 operation render context를 통해 플러그인에 전달됩니다.
+
+### fleet-core
+#### Added
+- [fleet-analyst] Analyst sessions accept a response-language option and append a Korean response-language directive to the system prompt when Korean is selected.
+  ko: Analyst 세션이 응답 언어 옵션을 받아들이고, 한국어 선택 시 시스템 프롬프트에 한국어 응답 지시문을 추가합니다.

--- a/packages/fleet-analyst/src/prompt.ts
+++ b/packages/fleet-analyst/src/prompt.ts
@@ -33,3 +33,14 @@ Lead with the conclusion and keep chat answers to 120 words or fewer. For a stru
 # Tone
 
 Be calm and specific. Do not encourage or apologize.`;
+
+export const ANALYST_KOREAN_LANGUAGE_INSTRUCTION = `
+
+# Language
+Write every user-facing response in Korean (한국어): answers, follow-up suggestions, artifact titles, and artifact body text. Keep code, commands, file paths, identifiers, and protocol tokens in their original form.`;
+
+export function resolveAnalystSystemPrompt(language?: "en" | "ko"): string {
+  return language === "ko"
+    ? `${ANALYST_SYSTEM_PROMPT}${ANALYST_KOREAN_LANGUAGE_INSTRUCTION}`
+    : ANALYST_SYSTEM_PROMPT;
+}

--- a/packages/fleet-analyst/src/session.ts
+++ b/packages/fleet-analyst/src/session.ts
@@ -16,7 +16,7 @@ import {
   type AcpPermissionResponse,
   type IUnifiedAgentClient,
 } from "@dotobokuri/core-unified-agent";
-import { ANALYST_SYSTEM_PROMPT } from "./prompt.js";
+import { resolveAnalystSystemPrompt } from "./prompt.js";
 import { ANALYST_TOOL_IDS, AnalystTools } from "./tools.js";
 import { redactTranscriptString } from "./transcript-indexer.js";
 import type { AnalystSessionOptions } from "./types.js";
@@ -63,7 +63,7 @@ export class AnalystSession {
     }
     this.bridge(client);
     try {
-      await client.connect({ cwd: this.options.cwd, model: this.options.model, effort: this.options.effort, autoApprove: true, fsAccess: false, yoloMode: true, strictMcp: this.options.cliId === "claude" || this.options.cliId === "claude-kimi", systemPrompt: ANALYST_SYSTEM_PROMPT, mcpServers: [{ type: "http", name: ANALYST_MCP_SERVER, url, headers: [{ name: "Authorization", value: `Bearer ${this.token}` }] }] });
+      await client.connect({ cwd: this.options.cwd, model: this.options.model, effort: this.options.effort, autoApprove: true, fsAccess: false, yoloMode: true, strictMcp: this.options.cliId === "claude" || this.options.cliId === "claude-kimi", systemPrompt: resolveAnalystSystemPrompt(this.options.language), mcpServers: [{ type: "http", name: ANALYST_MCP_SERVER, url, headers: [{ name: "Authorization", value: `Bearer ${this.token}` }] }] });
     } catch (error) {
       if (this.disposed) await (this.disposeFlight ?? Promise.resolve());
       else await client.disconnect().catch(() => undefined);

--- a/packages/fleet-analyst/src/types.ts
+++ b/packages/fleet-analyst/src/types.ts
@@ -28,4 +28,9 @@ export type AnalystEvent =
 
 export interface TranscriptIndexerOptions { readonly maxReadBytes?: number; }
 export interface SessionToolOptions { readonly capturePath: string; readonly cwd: string; readonly onEvent?: (event: AnalystEvent) => void; }
-export interface AnalystSessionOptions extends SessionToolOptions { readonly cliId: "claude" | "claude-kimi" | "codex" | "opencode-go" | "cursor"; readonly model: string; readonly effort?: string; }
+export interface AnalystSessionOptions extends SessionToolOptions {
+  readonly cliId: "claude" | "claude-kimi" | "codex" | "opencode-go" | "cursor";
+  readonly model: string;
+  readonly effort?: string;
+  readonly language?: "en" | "ko";
+}

--- a/packages/fleet-analyst/tests/prompt.test.ts
+++ b/packages/fleet-analyst/tests/prompt.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from "vitest";
 
-import { ANALYST_SYSTEM_PROMPT } from "../src/prompt.js";
+import { ANALYST_KOREAN_LANGUAGE_INSTRUCTION, ANALYST_SYSTEM_PROMPT, resolveAnalystSystemPrompt } from "../src/prompt.js";
 
 it("snapshots the approved observer, evidence, and artifact contract", () => {
   expect({
@@ -72,4 +72,12 @@ it("snapshots the approved observer, evidence, and artifact contract", () => {
       "visibleArtifact": true,
     }
   `);
+});
+
+it("adds the exact approved Korean output instruction only for Korean sessions", () => {
+  const instruction = "\n\n# Language\nWrite every user-facing response in Korean (한국어): answers, follow-up suggestions, artifact titles, and artifact body text. Keep code, commands, file paths, identifiers, and protocol tokens in their original form.";
+  expect(ANALYST_KOREAN_LANGUAGE_INSTRUCTION).toBe(instruction);
+  expect(resolveAnalystSystemPrompt("ko")).toBe(`${ANALYST_SYSTEM_PROMPT}${instruction}`);
+  expect(resolveAnalystSystemPrompt("en")).toBe(ANALYST_SYSTEM_PROMPT);
+  expect(resolveAnalystSystemPrompt()).toBe(ANALYST_SYSTEM_PROMPT);
 });

--- a/packages/fleet-analyst/tests/session.test.ts
+++ b/packages/fleet-analyst/tests/session.test.ts
@@ -43,6 +43,25 @@ it.each([
   await session.dispose();
 });
 
+it("pins Korean output language in the provider system prompt at connect time", async () => {
+  const file = join(await mkdtemp(join(tmpdir(), "analyst-language-")), "capture.jsonl");
+  await writeFile(file, "");
+  const connect = vi.fn().mockResolvedValue(undefined);
+  const client = Object.assign(new EventEmitter(), {
+    connect,
+    cancelPrompt: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+  }) as unknown as IUnifiedAgentClient;
+  vi.spyOn(UnifiedAgent, "build").mockResolvedValue(client);
+  const session = new AnalystSession({ capturePath: file, cwd: process.cwd(), cliId: "claude", model: "test-model", language: "ko" });
+
+  await session.start();
+
+  const systemPrompt = connect.mock.calls[0]?.[0]?.systemPrompt as string;
+  expect(systemPrompt).toContain("\n\n# Language\nWrite every user-facing response in Korean (한국어): answers, follow-up suggestions, artifact titles, and artifact body text. Keep code, commands, file paths, identifiers, and protocol tokens in their original form.");
+  await session.dispose();
+});
+
 it("rejects sends before start and disposes idempotently", async () => {
   const session = new AnalystSession({
     capturePath: "/not-used-before-start.jsonl",

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -8,7 +8,9 @@ import { isBlockingDialogOpen } from "../blocking-dialog.js";
 import { flattenGroupedOrder, hydrateOperations, setActiveOperation } from "../store.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
+import { useGlobalSettingsStore } from "../global-settings-store.js";
 import type { ConsoleState, OperationNode } from "../types.js";
+import { resolveConsoleLanguage } from "../whatsnew-i18n.js";
 import { calculateGridSlots, animateViewportTo, claimTopZIndex, clearCompanionOperationId, clearMaximizedOperationId, focusOperation, forceDropCompanionOperationId, getSnapshot as getCanvasSnapshot, minimizeOperation, panelMotionSuppressed, restoreOperation, setCompanionOperationId, setCompanionPanelVisible, setMaximizedOperationId, setOperationGeometry, setViewport, useCanvasState, useCompanionOperationId, useCompanionPanelVisibilityOverrides, useFormationLayout, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "./canvas-store.js";
 import { escapeSelectorValue, playMinimizeFlight } from "./panel-motion.js";
 import { CanvasContextMenu } from "./canvas-context-menu.js";
@@ -45,6 +47,7 @@ interface PluginOperationRendererProps {
   readonly geometry: OperationGeometry;
   readonly operation: OperationNode;
   readonly theme: ConsoleTheme;
+  readonly language: "en" | "ko";
   readonly viewportZoom: number;
   readonly onActivate: () => void;
   readonly onClose: () => void;
@@ -86,6 +89,8 @@ export function OperationsCanvas({
   const activePluginOperationId = state.activeOperationId;
   const [contextMenu, setContextMenu] = useState<ContextMenuRequest | null>(null);
   const registry = usePluginRegistry();
+  const globalSettings = useGlobalSettingsStore();
+  const language = resolveConsoleLanguage(globalSettings.state?.language ?? "auto");
   const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
   const glanceVisible = useGlanceHold();
   const disabled = !state.activeTheaterId || state.addingTheater;
@@ -258,6 +263,7 @@ export function OperationsCanvas({
             operationKindRegistry,
             status: state.operationStatus[operation.id],
             theme: state.activeTheme,
+            language,
             viewportZoom: effectiveZoom,
             minimized: minimizedSet.has(operation.id),
             maximized: operationMaximized,
@@ -472,6 +478,7 @@ function renderPluginOperation(operation: OperationNode, options: {
   readonly operationKindRegistry: readonly OperationKindDescriptor[];
   readonly status?: OperationActivity;
   readonly theme: ConsoleTheme;
+  readonly language: "en" | "ko";
   readonly viewportZoom: number;
   readonly minimized: boolean;
   readonly maximized: boolean;
@@ -541,6 +548,7 @@ function renderPluginOperation(operation: OperationNode, options: {
             geometry={geometry}
             operation={operation}
             theme={options.theme}
+            language={options.language}
             viewportZoom={options.viewportZoom}
             onActivate={options.onActivate}
             onClose={options.onClose}
@@ -562,6 +570,7 @@ function renderPluginOperation(operation: OperationNode, options: {
               geometry={geometry}
               operation={operation}
               theme={options.theme}
+              language={options.language}
               viewportZoom={options.viewportZoom}
               onActivate={options.onActivate}
               onClose={options.onClose}
@@ -586,6 +595,7 @@ function PluginOperationRenderer({
   geometry,
   operation,
   theme,
+  language,
   viewportZoom,
   onActivate,
   onClose,
@@ -607,6 +617,7 @@ function PluginOperationRenderer({
     ...(keyboardFocusRequestId === undefined ? {} : { keyboardFocusRequestId }),
     zoom: viewportZoom,
     theme,
+    language,
     api: capabilities.api,
     lifecycle: capabilities.lifecycle,
     terminal: capabilities.terminal,

--- a/runtime/fleet-console/core/client/src/whatsnew-i18n.ts
+++ b/runtime/fleet-console/core/client/src/whatsnew-i18n.ts
@@ -1,8 +1,12 @@
 import type { ConsoleLanguagePreference, ReleaseNotesLocale } from "./types.js";
 
-// What's New UI 크롬(제목·버튼·헤딩 칩)은 영어 원형을 유지한다. 이 모듈은 릴리스 노트
-// "본문" 콘텐츠의 로케일 해석만 담당한다 — auto는 브라우저 언어에서 파생된다.
+// Global language preference의 해석 SSoT. What's New 본문과 plugin Operation context가
+// 같은 auto 규칙을 공유하며, What's New UI 크롬 자체의 번역 범위는 소비자가 결정한다.
 export function resolveReleaseNotesLocale(preference: ConsoleLanguagePreference, navigatorLanguage = readNavigatorLanguage()): ReleaseNotesLocale {
+  return resolveConsoleLanguage(preference, navigatorLanguage);
+}
+
+export function resolveConsoleLanguage(preference: ConsoleLanguagePreference, navigatorLanguage = readNavigatorLanguage()): ReleaseNotesLocale {
   if (preference === "en" || preference === "ko") return preference;
   return navigatorLanguage === "ko" || navigatorLanguage.startsWith("ko-") ? "ko" : "en";
 }

--- a/runtime/fleet-console/sdk/plugin/types.ts
+++ b/runtime/fleet-console/sdk/plugin/types.ts
@@ -129,6 +129,7 @@ export interface OperationRenderContext extends OperationContext {
   readonly operation: OperationNode;
   readonly zoom: number;
   readonly theme: ConsoleTheme;
+  readonly language?: "en" | "ko";
   readonly api: ClientApiCapability;
   readonly lifecycle: ClientLifecycleCapability;
   readonly terminal: ClientTerminalCapability;

--- a/runtime/fleet-console/tests/whatsnew-i18n.test.ts
+++ b/runtime/fleet-console/tests/whatsnew-i18n.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveReleaseNotesLocale } from "../core/client/src/whatsnew-i18n.js";
+import { resolveConsoleLanguage, resolveReleaseNotesLocale } from "../core/client/src/whatsnew-i18n.js";
 
 describe("What's New release-notes locale resolution", () => {
   it("resolves explicit preferences without consulting browser language", () => {
@@ -13,5 +13,10 @@ describe("What's New release-notes locale resolution", () => {
     expect(resolveReleaseNotesLocale("auto", "ko-KR")).toBe("ko");
     expect(resolveReleaseNotesLocale("auto", "en-US")).toBe("en");
     expect(resolveReleaseNotesLocale("auto", "")).toBe("en");
+  });
+
+  it("shares the same resolver with plugin operation context language", () => {
+    expect(resolveConsoleLanguage("auto", "ko-KR")).toBe("ko");
+    expect(resolveConsoleLanguage("auto", "ja-JP")).toBe("en");
   });
 });

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-api.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-api.ts
@@ -1,6 +1,6 @@
 import type { ClientApiCapability, ConsoleTheme } from "@fleet-console/sdk/plugin";
 import { ApiError } from "@fleet-console/sdk/operations/browser";
-import { parseAnalysisCatalog, parseAnalysisError, parseAnalysisEvent, type AnalysisCatalog, type AnalysisError, type AnalysisEvent } from "./analysis-types.js";
+import { parseAnalysisCatalog, parseAnalysisError, parseAnalysisEvent, type AnalysisCatalog, type AnalysisError, type AnalysisEvent, type AnalysisSelection } from "./analysis-types.js";
 
 export class AnalysisApiError extends Error { constructor(readonly code: string, message: string) { super(message); } }
 const base = (operationId: string) => `analysis/${encodeURIComponent(operationId)}`;
@@ -46,7 +46,7 @@ export async function fetchAnalysisReady(api: ClientApiCapability, operationId: 
     return false;
   }
 }
-export async function startAnalysis(api: ClientApiCapability, operationId: string, input: { readonly cliId: string; readonly model: string; readonly effort: string }, signal?: AbortSignal): Promise<void> { await request(api, `${base(operationId)}/start`, input, signal); }
+export async function startAnalysis(api: ClientApiCapability, operationId: string, input: AnalysisSelection & { readonly language?: "en" | "ko" }, signal?: AbortSignal): Promise<void> { await request(api, `${base(operationId)}/start`, input, signal); }
 export async function sendAnalysisMessage(api: ClientApiCapability, operationId: string, text: string): Promise<void> { await request(api, `${base(operationId)}/message`, { text }); }
 export async function stopAnalysis(api: ClientApiCapability, operationId: string): Promise<void> { await request(api, `${base(operationId)}/stop`, {}); }
 export async function clearAnalysisArtifacts(api: ClientApiCapability, operationId: string): Promise<void> {
@@ -239,7 +239,7 @@ function dispatchWirePayload(raw: string, sourceId: number): void {
   if (eventFrame) dispatchToOperation(eventFrame.operationId, eventFrame.event);
 }
 
-async function request(api: ClientApiCapability, path: string, body: Record<string, string>, signal?: AbortSignal): Promise<void> {
+async function request(api: ClientApiCapability, path: string, body: object, signal?: AbortSignal): Promise<void> {
   const response = await fetchOrThrow(api, path, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body), ...(signal ? { signal } : {}) });
   if (!response.ok) throw errorFrom(response.status, await response.json().catch(() => null));
 }

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-artifact.test.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-artifact.test.ts
@@ -23,8 +23,8 @@ import { AnalystArtifactsPanel } from "./analysis-artifacts-panel.js";
 
 const THEMES = ["instrument", "maritime", "carbon"] as const satisfies readonly ConsoleTheme[];
 
-function operationContext(theme: ConsoleTheme, fetch = vi.fn(async () => new Response(null, { status: 200 }))): OperationRenderContext {
-  return { theme, operationId: "op/id", api: { fetch } } as never;
+function operationContext(theme: ConsoleTheme, fetch = vi.fn(async () => new Response(null, { status: 200 })), language?: "en" | "ko"): OperationRenderContext {
+  return { theme, operationId: "op/id", api: { fetch }, language } as never;
 }
 
 function artifactUrl(frame: HTMLIFrameElement): URL {
@@ -110,6 +110,22 @@ describe("artifact frame", () => {
 
     act(() => container.querySelector<HTMLButtonElement>(".session-analyst__clear")?.click());
     expect(fetch).toHaveBeenCalledWith("terminal", "analysis/op%2Fid/artifacts", { method: "DELETE" });
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders Korean artifact chrome with one count suffix", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => root.render(createElement(AnalystArtifactsPanel, { context: operationContext("instrument", undefined, "ko") })));
+
+    const trigger = container.querySelector<HTMLButtonElement>(".session-analyst__artifact-count")!;
+    expect(container.querySelector(".session-analyst__panel-copy")?.textContent).toBe("아티팩트이 분석의 시각적 결과물");
+    expect(trigger.textContent).toBe("2 개");
+    expect(trigger.getAttribute("aria-label")).toBe("아티팩트 보기(2개)");
+    expect(container.querySelector('article[aria-label="선택한 아티팩트 미리보기"]')).not.toBeNull();
 
     act(() => root.unmount());
     container.remove();

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-artifacts-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-artifacts-panel.tsx
@@ -3,10 +3,12 @@ import { React } from "@fleet-console/sdk/plugin/browser";
 import type { AnalysisArtifact } from "./analysis-types.js";
 
 import { analysisArtifactUrl, clearAnalysisArtifacts } from "./analysis-api.js";
+import { analysisCopy, type AnalysisLanguage } from "./analysis-i18n.js";
 import { useAnalysisStore } from "./analysis-store.js";
 
 export function AnalystArtifactsPanel({ context }: { readonly context: OperationRenderContext }) {
   const { state, dispatch } = useAnalysisStore(context);
+  const language = context.language ?? "en";
   const artifacts = React.useMemo(() => [...state.artifacts].reverse(), [state.artifacts]);
   const newestId = state.artifacts[0]?.id ?? null;
   const [activeId, setActiveId] = React.useState<string | null>(null);
@@ -38,57 +40,57 @@ export function AnalystArtifactsPanel({ context }: { readonly context: Operation
   }, [count]);
 
   return (
-    <section className="session-analyst__artifacts" aria-label="Artifacts">
+    <section className="session-analyst__artifacts" aria-label={analysisCopy(language, "Artifacts")}>
       <header className="session-analyst__panel-head session-analyst__panel-head--artifacts">
         <span className="session-analyst__panel-mark session-analyst__panel-mark--artifact" aria-hidden="true">◇</span>
-        <span className="session-analyst__panel-copy"><strong>Artifacts</strong><small>Visual outputs from this analysis</small></span>
+        <span className="session-analyst__panel-copy"><strong>{analysisCopy(language, "Artifacts")}</strong><small>{analysisCopy(language, "Visual outputs from this analysis")}</small></span>
         <div className="session-analyst__artifact-list-shell" ref={listShell}>
-          <button type="button" className="session-analyst__artifact-count" aria-expanded={listOpen} aria-controls={listId} aria-haspopup="listbox" aria-label={`${listOpen ? "Hide" : "Show"} artifacts (${count} ${count === 1 ? "item" : "items"})`} onClick={() => setListOpen((open) => !open)} disabled={!count}>
-            <strong>{count}</strong>{" "}<span>{count === 1 ? "item" : "items"}</span><i aria-hidden="true" />
+          <button type="button" className="session-analyst__artifact-count" aria-expanded={listOpen} aria-controls={listId} aria-haspopup="listbox" aria-label={analysisCopy(language, listOpen ? "Hide artifacts ({count} {item/items})" : "Show artifacts ({count} {item/items})", { count, "item/items": count === 1 ? "item" : "items" })} onClick={() => setListOpen((open) => !open)} disabled={!count}>
+            <strong>{count}</strong>{" "}<span>{language === "ko" ? "개" : count === 1 ? "item" : "items"}</span><i aria-hidden="true" />
           </button>
           {listOpen ? (
-            <div className="session-analyst__artifact-menu" id={listId} role="listbox" aria-label="Published artifacts">
+            <div className="session-analyst__artifact-menu" id={listId} role="listbox" aria-label={analysisCopy(language, "Published artifacts")}>
               {artifacts.map((artifact) => {
                 const selected = artifact.id === active?.id;
                 return (
                   <button type="button" role="option" key={artifact.id} aria-selected={selected} className={selected ? "is-active" : undefined} title={artifact.title} onClick={() => { setActiveId(artifact.id); setListOpen(false); }}>
                     <span className="session-analyst__artifact-list-mark" aria-hidden="true">◇</span>
                     <strong>{artifact.title}</strong>
-                    <ArtifactTime createdAt={artifact.createdAt} />
+                    <ArtifactTime createdAt={artifact.createdAt} language={language} />
                   </button>
                 );
               })}
             </div>
           ) : null}
         </div>
-        <button type="button" className="session-analyst__clear" onClick={() => { setListOpen(false); dispatch({ type: "clear-artifacts" }); void clearAnalysisArtifacts(context.api, context.operationId).catch(() => {}); }} disabled={!count}>Clear</button>
+        <button type="button" className="session-analyst__clear" onClick={() => { setListOpen(false); dispatch({ type: "clear-artifacts" }); void clearAnalysisArtifacts(context.api, context.operationId).catch(() => {}); }} disabled={!count}>{analysisCopy(language, "Clear")}</button>
       </header>
       {count === 0 ? (
-        <div className="session-analyst__artifacts-empty"><strong>No artifacts yet</strong>Artifacts the analyst publishes will appear here.</div>
+        <div className="session-analyst__artifacts-empty"><strong>{analysisCopy(language, "No artifacts yet")}</strong>{analysisCopy(language, "Artifacts the analyst publishes will appear here.")}</div>
       ) : (
         <div className="session-analyst__artifact-content">
-          {active ? <ActiveArtifact key={active.id} artifact={active} theme={context.theme} /> : null}
+          {active ? <ActiveArtifact key={active.id} artifact={active} theme={context.theme} language={language} /> : null}
         </div>
       )}
     </section>
   );
 }
 
-function ActiveArtifact({ artifact, theme }: { readonly artifact: AnalysisArtifact; readonly theme: ConsoleTheme }) {
+function ActiveArtifact({ artifact, theme, language }: { readonly artifact: AnalysisArtifact; readonly theme: ConsoleTheme; readonly language: AnalysisLanguage }) {
   if (!artifact.id) return null;
   const consoleStyle = getComputedStyle(document.documentElement);
   const canvas = consoleStyle.getPropertyValue("--ink-veil").trim() || "Canvas";
   const foreground = consoleStyle.getPropertyValue("--ink-pearl").trim() || "CanvasText";
   return (
-    <article aria-label="Selected artifact preview">
-      <header><span className="session-analyst__artifact-title">{artifact.title}</span><ArtifactTime createdAt={artifact.createdAt} /></header>
+    <article aria-label={analysisCopy(language, "Selected artifact preview")}>
+      <header><span className="session-analyst__artifact-title">{artifact.title}</span><ArtifactTime createdAt={artifact.createdAt} language={language} /></header>
       <iframe title={artifact.title} src={analysisArtifactUrl(artifact.id, theme, canvas, foreground)} sandbox="allow-scripts" />
     </article>
   );
 }
 
-function ArtifactTime({ createdAt }: { readonly createdAt: number }) {
+function ArtifactTime({ createdAt, language }: { readonly createdAt: number; readonly language: AnalysisLanguage }) {
   const date = new Date(createdAt);
   const valid = Number.isFinite(date.getTime());
-  return <time dateTime={valid ? date.toISOString() : undefined}>{valid ? date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) : "Unknown time"}</time>;
+  return <time dateTime={valid ? date.toISOString() : undefined}>{valid ? date.toLocaleTimeString(language === "ko" ? "ko-KR" : "en", { hour: "2-digit", minute: "2-digit" }) : analysisCopy(language, "Unknown time")}</time>;
 }

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
@@ -87,6 +87,65 @@ describe("Session Analyst Evidence Pulse", () => {
     container.remove();
   });
 
+  it("switches panel copy live with context language and shows a fixed-slot save confirmation", async () => {
+    storeState = {
+      ...initialAnalysisState,
+      catalog,
+      cliId: "codex",
+      model: "gpt",
+      effort: "medium",
+      selectionSaved: true,
+    };
+    const koreanContext = { operationId: "chat-test", language: "ko" } as OperationRenderContext;
+    const { container, root } = renderPanel(koreanContext);
+    const saved = container.querySelector<HTMLElement>('[aria-live="polite"][aria-atomic="true"]')!;
+
+    expect(container.querySelector('[aria-label="Session Analyst 채팅"]')).not.toBeNull();
+    expect(container.querySelector(".session-analyst__hero h2")?.textContent).toBe("이 세션에 대해 물어보세요");
+    expect(container.querySelector('[aria-label="분석 CLI"]')).not.toBeNull();
+    expect(container.querySelector("textarea")?.placeholder).toBe("세션에 대해 질문하기… (/ 명령)");
+    expect(container.querySelector(".session-analyst__send")?.getAttribute("aria-label")).toBe("보내기");
+    expect(saved.textContent).toBe("저장됨");
+    expect(saved.style.inlineSize).toBe("5em");
+    expect(saved.style.opacity).toBe("1");
+    expect(saved.style.transition).toBe("opacity var(--duration-base) var(--ease-glide)");
+
+    const suggestion = [...container.querySelectorAll<HTMLButtonElement>(".session-analyst__suggestions button")]
+      .find((button) => button.textContent?.includes("에이전트가 지금 무엇을 하고 있어?"))!;
+    await act(async () => suggestion.click());
+    expect(send).toHaveBeenCalledWith("에이전트가 지금 무엇을 하고 있어?");
+
+    act(() => root.render(createElement(AnalystChatPanel, { context: { operationId: "chat-test", language: "en" } as OperationRenderContext })));
+    expect(container.querySelector('[aria-label="Session Analyst chat"]')).not.toBeNull();
+    expect(container.querySelector(".session-analyst__hero h2")?.textContent).toBe("Ask about this session");
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("disables every selection control while reset holds the selection lock and re-enables it after release", () => {
+    storeState = {
+      ...initialAnalysisState,
+      catalog,
+      cliId: "codex",
+      model: "gpt",
+      effort: "medium",
+      selectionLocked: true,
+    };
+    const { container, root } = renderPanel();
+    const selectionTriggers = () => [...container.querySelectorAll<HTMLButtonElement>(".session-analyst__selector-strip .fc-select__trigger")];
+
+    expect(selectionTriggers()).toHaveLength(3);
+    expect(selectionTriggers().every((trigger) => trigger.disabled)).toBe(true);
+
+    storeState = { ...storeState, selectionLocked: false };
+    act(() => rerenderStore());
+    expect(selectionTriggers().every((trigger) => !trigger.disabled)).toBe(true);
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
   it("keeps the transcript fully visible with one Stop and event-truthful tool activity", () => {
     storeState = {
       ...initialAnalysisState,
@@ -420,6 +479,40 @@ describe("Session Analyst Evidence Pulse", () => {
 
     act(() => root.unmount());
     container.remove();
+  });
+
+  it("localizes every slash command draft while preserving the English templates", () => {
+    const expected = {
+      en: {
+        "/now": "What is the agent doing right now?",
+        "/drift": "Review this session for intent drift against my stated goals.",
+        "/brief": "Draft a handoff brief and publish it as an artifact.",
+        "/risks": "Flag anything I should review before this work continues.",
+        "/timeline": "Walk me through how this session unfolded.",
+      },
+      ko: {
+        "/now": "에이전트가 지금 무엇을 하고 있어?",
+        "/drift": "내가 정한 목표와 비교해 이 세션의 의도 드리프트를 검토해 줘.",
+        "/brief": "인수인계 브리프 초안을 작성하고 아티팩트로 발행해 줘.",
+        "/risks": "이 작업을 계속하기 전에 내가 검토해야 할 항목을 짚어 줘.",
+        "/timeline": "이 세션이 어떻게 진행됐는지 정리해 줘",
+      },
+    } as const;
+
+    for (const language of ["en", "ko"] as const) {
+      storeState = { ...initialAnalysisState };
+      const { container, root } = renderPanel({ operationId: `chat-test-${language}`, language } as OperationRenderContext);
+      const textarea = container.querySelector("textarea")!;
+      for (const [command, draft] of Object.entries(expected[language])) {
+        setTextareaValue(textarea, command);
+        const option = container.querySelector<HTMLElement>('[role="option"]')!;
+        expect(option.textContent).toContain(command);
+        act(() => option.click());
+        expect(storeState.draft).toBe(draft);
+      }
+      act(() => root.unmount());
+      container.remove();
+    }
   });
 
   it("leaves slash navigation and the draft unchanged during IME composition", () => {

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
@@ -5,6 +5,7 @@ import { installDiagramHydrator } from "@fleet-console/markdown/mermaid";
 import "@fleet-console/markdown/styles.css";
 
 import type { AnalysisActivity, AnalysisState } from "./analysis-state.js";
+import { analysisCopy, translateAnalysisText, type AnalysisCopyKey, type AnalysisLanguage } from "./analysis-i18n.js";
 import { useAnalysisStore } from "./analysis-store.js";
 import { StreamedMarkdown } from "./streamed-markdown.js";
 
@@ -21,16 +22,22 @@ const FOLLOW_UPS = [
   { icon: "●", tone: "aurora", label: "What is the agent doing now?", text: "What is the agent doing right now?" },
 ] as const;
 const SLASH_COMMANDS = [
-  { command: "/now", description: "Current state — what the agent is doing right now", template: "What is the agent doing right now?" },
-  { command: "/drift", description: "Intent drift review against settled goals", template: "Review this session for intent drift against my stated goals." },
-  { command: "/brief", description: "Handoff brief as an artifact", template: "Draft a handoff brief and publish it as an artifact." },
-  { command: "/risks", description: "Flag anything that needs review", template: "Flag anything I should review before this work continues." },
-  { command: "/timeline", description: "How the session unfolded, end to end", template: "Walk me through how this session unfolded." },
-] as const;
+  { command: "/now", descriptionKey: "Current state — what the agent is doing right now", templateKey: "What is the agent doing right now?" },
+  { command: "/drift", descriptionKey: "Intent drift review against settled goals", templateKey: "Review this session for intent drift against my stated goals." },
+  { command: "/brief", descriptionKey: "Handoff brief as an artifact", templateKey: "Draft a handoff brief and publish it as an artifact." },
+  { command: "/risks", descriptionKey: "Flag anything that needs review", templateKey: "Flag anything I should review before this work continues." },
+  { command: "/timeline", descriptionKey: "How the session unfolded, end to end", templateKey: "Walk me through how this session unfolded." },
+] as const satisfies readonly {
+  readonly command: string;
+  readonly descriptionKey: AnalysisCopyKey;
+  readonly templateKey: AnalysisCopyKey;
+}[];
 export const ANALYST_ARTIFACTS_COMPANION_ID = "session-analyst-artifacts";
 
 export function AnalystChatPanel({ context }: { readonly context: OperationRenderContext }) {
   const { state, dispatch, send, stop, reset } = useAnalysisStore(context);
+  const language = context.language ?? "en";
+  const reducedMotion = usePrefersReducedMotion();
   const [slashSelection, setSlashSelection] = React.useState(0);
   const [slashDismissed, setSlashDismissed] = React.useState(false);
   const cli = state.catalog?.clis.find((item) => item.cliId === state.cliId);
@@ -115,7 +122,7 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
   const selectSlashCommand = (index: number) => {
     const selected = slashMatches[index];
     if (!selected) return;
-    dispatch({ type: "set-draft", draft: selected.template });
+    dispatch({ type: "set-draft", draft: analysisCopy(language, selected.templateKey) });
     setSlashDismissed(true);
     setSlashSelection(0);
     window.requestAnimationFrame(() => textareaRef.current?.focus());
@@ -125,21 +132,21 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
     if (!button) return;
     const code = button.closest("pre")?.getAttribute("data-code");
     if (!code) return;
-    copyCodeToClipboard(button, code);
-  }, []);
+    copyCodeToClipboard(button, code, language);
+  }, [language]);
 
   return (
-    <section className={`session-analyst__chat-pane ${hasInteracted ? "has-interacted" : "is-initial"}`} aria-label="Session Analyst chat" data-phase={state.phase}>
+    <section className={`session-analyst__chat-pane ${hasInteracted ? "has-interacted" : "is-initial"}`} aria-label={analysisCopy(language, "Session Analyst chat")} data-phase={state.phase}>
       {supportsCompanionVisibility ? (
         <button
           ref={artifactsChipRef}
           type="button"
           className={`session-analyst-handle session-analyst-handle--artifacts${artifactCount === 0 ? " is-waiting" : ""}${artifactAuthoring ? " is-authoring" : ""}`}
-          aria-label={artifactsVisible ? "Hide Artifacts" : "Open Artifacts"}
+          aria-label={analysisCopy(language, artifactsVisible ? "Hide Artifacts" : "Open Artifacts")}
           aria-pressed={artifactsVisible}
           aria-disabled={artifactCount === 0}
           tabIndex={artifactCount === 0 ? -1 : undefined}
-          title={artifactAuthoring ? "The analyst is authoring an artifact…" : artifactCount === 0 ? "Artifacts the analyst publishes appear here" : undefined}
+          title={artifactAuthoring ? analysisCopy(language, "The analyst is authoring an artifact…") : artifactCount === 0 ? analysisCopy(language, "Artifacts the analyst publishes appear here") : undefined}
           onClick={() => {
             if (!setCompanionPanelVisible || artifactCount === 0) return;
             if (artifactsVisible) dispatch({ type: "artifacts-chip-disarm" });
@@ -149,10 +156,10 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
           <span className="session-analyst-handle__chev" aria-hidden="true">{artifactsVisible ? "«" : "»"}</span>
           {artifactCount > 0 ? <span key={countPulseRevision} className={`session-analyst-handle__count${countPulseRevision > 0 ? " is-pulsing" : ""}`}>{artifactCount}</span> : null}
           {artifactAuthoring ? <span className="session-analyst-handle__count">…</span> : null}
-          <span className="session-analyst-handle__label">ARTIFACTS</span>
+          <span className="session-analyst-handle__label">{analysisCopy(language, "ARTIFACTS")}</span>
         </button>
       ) : null}
-      <PanelHeader state={state} onReset={() => { void reset().catch(() => {}); }} />
+      <PanelHeader state={state} language={language} onReset={() => { void reset().catch(() => {}); }} />
       <div className="session-analyst__workspace">
         <section ref={chatRef} className="session-analyst__chat" aria-live="polite" aria-busy={state.busy}>
           {hasInteracted ? (
@@ -169,14 +176,14 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
             <div className="session-analyst__hero-wrap">
               <header className="session-analyst__hero">
                 <span className="session-analyst__sigil" aria-hidden="true">✳</span>
-                <h2>Ask about this session</h2>
-                <p>Review, explain, and summarize this session — without affecting the host agent.</p>
+                <h2>{analysisCopy(language, "Ask about this session")}</h2>
+                <p>{analysisCopy(language, "Review, explain, and summarize this session — without affecting the host agent.")}</p>
               </header>
               <div className="session-analyst__suggestions">
                 {SUGGESTIONS.map((suggestion) => (
-                  <button type="button" key={suggestion.text} onClick={() => void submit(suggestion.text, false)}>
+                  <button type="button" key={suggestion.text} onClick={() => void submit(analysisCopy(language, suggestion.text), false)}>
                     <span className="session-analyst__suggestion-icon" data-tone={suggestion.tone} aria-hidden="true">{suggestion.icon}</span>
-                    {suggestion.text}
+                    {analysisCopy(language, suggestion.text)}
                   </button>
                 ))}
               </div>
@@ -186,32 +193,33 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
           {state.artifactAuthoring || state.artifactPublished ? (
             <ArtifactAuthorCard
               state={state}
+              language={language}
               onOpen={supportsCompanionVisibility && setCompanionPanelVisible
                 ? () => setCompanionPanelVisible(ANALYST_ARTIFACTS_COMPANION_ID, true)
                 : undefined}
             />
           ) : null}
-          {state.phase !== "idle" ? <EvidencePulse state={state} /> : null}
+          {state.phase !== "idle" ? <EvidencePulse state={state} language={language} /> : null}
         </section>
         {state.queue.length > 0 ? (
           <div className="session-analyst__queue" aria-live="polite">
             {state.queue.map((text, index) => (
               <div className="session-analyst__queue-item" key={`${text}-${index}`}>
-                <span className="session-analyst__queue-tag">QUEUED</span>
+                <span className="session-analyst__queue-tag">{analysisCopy(language, "QUEUED")}</span>
                 <span className="session-analyst__queue-text">{text}</span>
-                <button type="button" aria-label={`Cancel queued question ${index + 1}`} onClick={() => dispatch({ type: "queue-cancel", index })}>✕</button>
+                <button type="button" aria-label={analysisCopy(language, "Cancel queued question {index + 1}", { "index + 1": index + 1 })} onClick={() => dispatch({ type: "queue-cancel", index })}>✕</button>
               </div>
             ))}
           </div>
         ) : null}
         {state.phase === "complete" && !state.busy && hasInteracted ? (
           <div className="session-analyst__followups">
-            <span className="session-analyst__followups-label">FOLLOW UP</span>
+            <span className="session-analyst__followups-label">{analysisCopy(language, "FOLLOW UP")}</span>
             <div className="session-analyst__followups-row">
               {FOLLOW_UPS.map((item) => (
-                <button type="button" key={item.label} onClick={() => void submit(item.text, false)}>
+                <button type="button" key={item.label} onClick={() => void submit(analysisCopy(language, item.text), false)}>
                   <span className="session-analyst__suggestion-icon" data-tone={item.tone} aria-hidden="true">{item.icon}</span>
-                  {item.label}
+                  {analysisCopy(language, item.label)}
                 </button>
               ))}
             </div>
@@ -219,8 +227,8 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
         ) : null}
         <form className={`session-analyst__composer ${hasInteracted ? "is-docked" : "is-initial"}${animateDock ? " is-docking" : ""}${state.busy ? " is-working" : ""}`} aria-busy={state.busy} onSubmit={(event) => { event.preventDefault(); void submit(state.draft, true); }}>
           {slashOpen ? (
-            <div id={slashListboxId} className="session-analyst__slash" role="listbox" aria-label="Analysis commands">
-              <span className="session-analyst__slash-heading">Analysis commands</span>
+            <div id={slashListboxId} className="session-analyst__slash" role="listbox" aria-label={analysisCopy(language, "Analysis commands")}>
+              <span className="session-analyst__slash-heading">{analysisCopy(language, "Analysis commands")}</span>
               {slashMatches.map((item, index) => (
                 <button
                   type="button"
@@ -233,18 +241,18 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
                   onClick={() => selectSlashCommand(index)}
                 >
                   <span>{item.command}</span>
-                  <small>{item.description}</small>
+                  <small>{analysisCopy(language, item.descriptionKey)}</small>
                 </button>
               ))}
             </div>
           ) : null}
-          {!hasInteracted ? <div className="session-analyst__selector-strip" aria-label="Initial analysis settings">
+          {!hasInteracted ? <div className="session-analyst__selector-strip" aria-label={analysisCopy(language, "Initial analysis settings")}>
             <span className="session-analyst__select">
               <Select
                 compact
-                label="Analysis CLI"
+                label={analysisCopy(language, "Analysis CLI")}
                 value={state.cliId}
-                disabled={state.started || !state.catalog}
+                disabled={state.started || state.selectionLocked || !state.catalog}
                 options={state.catalog?.clis.map((item) => ({ value: item.cliId, label: item.label, disabled: !item.available })) ?? []}
                 onChange={(cliId) => dispatch({ type: "select-cli", cliId })}
               />
@@ -252,9 +260,9 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
             <span className="session-analyst__select">
               <Select
                 compact
-                label="Analysis model"
+                label={analysisCopy(language, "Analysis model")}
                 value={state.model}
-                disabled={state.started || !model}
+                disabled={state.started || state.selectionLocked || !model}
                 options={cli?.models.map((item) => ({ value: item.id, label: item.label })) ?? []}
                 onChange={(nextModel) => dispatch({ type: "select-model", model: nextModel })}
               />
@@ -262,16 +270,28 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
             <span className="session-analyst__select">
               <Select
                 compact
-                label="Analysis effort"
+                label={analysisCopy(language, "Analysis effort")}
                 value={state.effort}
-                disabled={state.started || !model || !model.effortLevels.length}
-                options={model?.effortLevels.length ? model.effortLevels.map((item) => ({ value: item, label: item })) : [{ value: "", label: "n/a" }]}
+                disabled={state.started || state.selectionLocked || !model || !model.effortLevels.length}
+                options={model?.effortLevels.length ? model.effortLevels.map((item) => ({ value: item, label: item })) : [{ value: "", label: analysisCopy(language, "n/a") }]}
                 onChange={(effort) => dispatch({ type: "select-effort", effort })}
               />
             </span>
+            <span
+              aria-live="polite"
+              aria-atomic="true"
+              style={{
+                display: "inline-block",
+                inlineSize: "5em",
+                flex: "none",
+                opacity: state.selectionSaved ? 1 : 0,
+                textAlign: "center",
+                transition: reducedMotion ? "none" : "opacity var(--duration-base) var(--ease-glide)",
+              }}
+            >{state.selectionSaved ? analysisCopy(language, "Saved") : ""}</span>
           </div> : null}
           <div className="session-analyst__composer-surface">
-            <label className="session-analyst__sr-only" htmlFor={`analysis-${context.operationId}`}>Ask about this session</label>
+            <label className="session-analyst__sr-only" htmlFor={`analysis-${context.operationId}`}>{analysisCopy(language, "Ask about this session")}</label>
             <textarea
               ref={textareaRef}
               id={`analysis-${context.operationId}`}
@@ -280,7 +300,7 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
               aria-controls={slashListboxId}
               aria-activedescendant={activeSlashOption ? slashOptionId(activeSlashOption.command) : undefined}
               rows={1}
-              placeholder="Ask about the session… (/ for commands)"
+              placeholder={analysisCopy(language, "Ask about the session… (/ for commands)")}
               value={state.draft}
               onChange={(event) => {
                 dispatch({ type: "set-draft", draft: event.target.value });
@@ -316,15 +336,15 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
               }}
             />
             {state.busy ? (
-              <button type="button" className="session-analyst__send session-analyst__stop" aria-label="Stop" onClick={() => void stop()}>
+              <button type="button" className="session-analyst__send session-analyst__stop" aria-label={analysisCopy(language, "Stop")} onClick={() => void stop()}>
                 <span aria-hidden="true" />
               </button>
             ) : null}
-            <button type="submit" className="session-analyst__send" aria-label={state.busy ? "Queue question" : "Send"} disabled={!state.draft.trim()}>
+            <button type="submit" className="session-analyst__send" aria-label={analysisCopy(language, state.busy ? "Queue question" : "Send")} disabled={!state.draft.trim()}>
               <svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" aria-hidden="true"><path d="M6 10 V2 M2.5 5.5 L6 2 l3.5 3.5" /></svg>
             </button>
           </div>
-          {state.busy ? <div className="session-analyst__composer-hint">Enter queues the question — it fires when the analyst is ready</div> : null}
+          {state.busy ? <div className="session-analyst__composer-hint">{analysisCopy(language, "Enter queues the question — it fires when the analyst is ready")}</div> : null}
         </form>
       </div>
     </section>
@@ -342,7 +362,7 @@ function resizeAnalysisTextarea(textarea: HTMLTextAreaElement): void {
   textarea.style.overflowY = textarea.scrollHeight > maxHeight ? "auto" : "hidden";
 }
 
-function copyCodeToClipboard(button: HTMLElement, code: string): void {
+function copyCodeToClipboard(button: HTMLElement, code: string, language: AnalysisLanguage): void {
   const clipboard = navigator.clipboard;
   if (!clipboard) return;
   let write: Promise<void>;
@@ -350,34 +370,34 @@ function copyCodeToClipboard(button: HTMLElement, code: string): void {
   const original = button.textContent;
   void write.then(() => {
     if (!button.isConnected) return;
-    button.textContent = "Copied";
+    button.textContent = analysisCopy(language, "Copied");
     window.setTimeout(() => { if (button.isConnected) button.textContent = original; }, 1_200);
   }).catch(() => undefined);
 }
 
-function PanelHeader({ state, onReset }: { readonly state: AnalysisState; readonly onReset: () => void }) {
+function PanelHeader({ state, language, onReset }: { readonly state: AnalysisState; readonly language: AnalysisLanguage; readonly onReset: () => void }) {
   const canReset = state.started || state.phase !== "idle" || state.draft.length > 0 || state.queue.length > 0 || state.entries.length > 0 || state.artifacts.length > 0;
   return (
     <header className="session-analyst__panel-head">
       <span className="session-analyst__panel-mark" aria-hidden="true">✳</span>
-      <span className="session-analyst__panel-copy"><strong>Session Analyst</strong><small>Read-only intelligence for this operation</small></span>
-      <button type="button" className="session-analyst__reset" aria-label="Reset Session Analyst" onClick={onReset} disabled={!canReset}>Reset</button>
-      <span className="session-analyst__panel-state"><i aria-hidden="true" />{headerState(state)}</span>
+      <span className="session-analyst__panel-copy"><strong>{analysisCopy(language, "Session Analyst")}</strong><small>{analysisCopy(language, "Read-only intelligence for this operation")}</small></span>
+      <button type="button" className="session-analyst__reset" aria-label={analysisCopy(language, "Reset Session Analyst")} onClick={onReset} disabled={!canReset}>{analysisCopy(language, "Reset")}</button>
+      <span className="session-analyst__panel-state"><i aria-hidden="true" />{headerState(state, language)}</span>
     </header>
   );
 }
 
-function ArtifactAuthorCard({ state, onOpen }: { readonly state: AnalysisState; readonly onOpen?: () => void }) {
+function ArtifactAuthorCard({ state, language, onOpen }: { readonly state: AnalysisState; readonly language: AnalysisLanguage; readonly onOpen?: () => void }) {
   const authoringElapsedMs = useArtifactAuthoringElapsedMs(state.artifactAuthoring?.startedAt ?? null);
   if (state.artifactAuthoring) {
     return (
       <div className="session-analyst__author-card is-authoring">
         <div className="session-analyst__author-head">
           <span className="session-analyst__author-sigil" aria-hidden="true">✳</span>
-          <strong className="session-analyst__author-title">Publishing an artifact</strong>
+          <strong className="session-analyst__author-title">{analysisCopy(language, "Publishing an artifact")}</strong>
           <time className="session-analyst__author-time">{formatElapsed(authoringElapsedMs)}</time>
         </div>
-        <p className="session-analyst__author-sub">The analyst is authoring artifact content. It opens in Artifacts when it lands.</p>
+        <p className="session-analyst__author-sub">{analysisCopy(language, "The analyst is authoring artifact content. It opens in Artifacts when it lands.")}</p>
         <div className="session-analyst__author-track" aria-hidden="true"><span /></div>
       </div>
     );
@@ -388,57 +408,60 @@ function ArtifactAuthorCard({ state, onOpen }: { readonly state: AnalysisState; 
     <div className="session-analyst__author-card is-done">
       <div className="session-analyst__author-head">
         <span className="session-analyst__author-sigil" aria-hidden="true">◆</span>
-        <strong className="session-analyst__author-title">Artifact published — {published.artifact.title}</strong>
+        <strong className="session-analyst__author-title">{analysisCopy(language, "Artifact published — {title}", { title: published.artifact.title })}</strong>
         {published.durationMs === null ? null : <time className="session-analyst__author-time">{formatElapsed(published.durationMs)}</time>}
-        {onOpen ? <button type="button" className="session-analyst__author-open" onClick={onOpen}>Open in Artifacts</button> : null}
+        {onOpen ? <button type="button" className="session-analyst__author-open" onClick={onOpen}>{analysisCopy(language, "Open in Artifacts")}</button> : null}
       </div>
     </div>
   );
 }
 
-function EvidencePulse({ state }: { readonly state: AnalysisState }) {
+function EvidencePulse({ state, language }: { readonly state: AnalysisState; readonly language: AnalysisLanguage }) {
   const elapsedMs = useElapsedMs(state);
   const elapsed = formatElapsed(elapsedMs);
-  const activity = activityLabel(state.latestActivity);
+  const activity = activityLabel(state.latestActivity, language);
   if (state.phase === "complete") return null;
   if (state.phase === "stopped") {
-    return <div className="session-analyst__receipt is-stopped" role="status">Stopped · last confirmed: {activity} · {elapsed}</div>;
+    return <div className="session-analyst__receipt is-stopped" role="status">{analysisCopy(language, "Stopped · last confirmed: {activity} · {elapsed}", { activity, elapsed })}</div>;
   }
   const isError = state.phase === "error";
-  const current = currentActivity(state.latestActivity);
+  const current = currentActivity(state.latestActivity, language);
   return (
     <div className={`session-analyst__pulse${isError ? " is-error" : ""}`} role={isError ? "alert" : "status"} aria-live={isError ? undefined : "polite"}>
       {!isError ? <span className="session-analyst__pulse-scan" aria-hidden="true" /> : null}
       <div className="session-analyst__pulse-main">
         <span className="session-analyst__pulse-orbit" aria-hidden="true" />
-        <span className="session-analyst__pulse-copy"><strong key={`${state.phase}-${current.label}`}>{isError ? state.error : current.label}</strong><small>{isError ? `Last confirmed activity: ${activity}` : current.note}</small></span>
+        <span className="session-analyst__pulse-copy"><strong key={`${state.phase}-${current.label}`}>{isError ? translateAnalysisText(language, state.error ?? "") : current.label}</strong><small>{isError ? language === "ko" ? activity : `Last confirmed activity: ${activity}` : current.note}</small></span>
         <time>{elapsed}</time>
       </div>
-      <span className="session-analyst__truth-mark">Last confirmed activity only</span>
+      <span className="session-analyst__truth-mark">{analysisCopy(language, "Last confirmed activity only")}</span>
     </div>
   );
 }
 
-function currentActivity(activity: AnalysisActivity | null): { readonly label: string; readonly note: string } {
-  if (!activity || activity.kind === "starting") return { label: "Starting analyst", note: activity?.connected ? "Analyst connection confirmed" : "Starting a new analysis session" };
-  if (activity.kind === "reasoning") return { label: "Reasoning over session", note: "Thought event received · content hidden" };
-  if (activity.kind === "tool") return { label: `Using ${activity.title}`, note: `Tool status: ${activity.status}` };
-  return { label: "Writing answer", note: "Answer chunk received" };
+function currentActivity(activity: AnalysisActivity | null, language: AnalysisLanguage): { readonly label: string; readonly note: string } {
+  if (!activity || activity.kind === "starting") return {
+    label: analysisCopy(language, "Starting analyst"),
+    note: analysisCopy(language, activity?.connected ? "Analyst connection confirmed" : "Starting a new analysis session"),
+  };
+  if (activity.kind === "reasoning") return { label: analysisCopy(language, "Reasoning over session"), note: analysisCopy(language, "Thought event received · content hidden") };
+  if (activity.kind === "tool") return { label: analysisCopy(language, "Using {title}", { title: activity.title }), note: analysisCopy(language, "Tool status: {status}", { status: activity.status }) };
+  return { label: analysisCopy(language, "Writing answer"), note: analysisCopy(language, "Answer chunk received") };
 }
 
-function activityLabel(activity: AnalysisActivity | null): string {
-  if (!activity || activity.kind === "starting") return "Starting analyst";
-  if (activity.kind === "reasoning") return "Reasoning over session";
-  if (activity.kind === "tool") return `Using ${activity.title} (${activity.status})`;
-  return "Writing answer";
+function activityLabel(activity: AnalysisActivity | null, language: AnalysisLanguage): string {
+  if (!activity || activity.kind === "starting") return analysisCopy(language, "Starting analyst");
+  if (activity.kind === "reasoning") return analysisCopy(language, "Reasoning over session");
+  if (activity.kind === "tool") return `${analysisCopy(language, "Using {title}", { title: activity.title })} (${activity.status})`;
+  return analysisCopy(language, "Writing answer");
 }
 
-function headerState(state: AnalysisState): string {
-  if (state.phase === "error") return "Needs attention";
-  if (state.busy) return "Analyzing";
-  if (state.phase === "complete") return "Complete";
-  if (state.phase === "stopped") return "Stopped";
-  return "Ready";
+function headerState(state: AnalysisState, language: AnalysisLanguage): string {
+  if (state.phase === "error") return analysisCopy(language, "Needs attention");
+  if (state.busy) return analysisCopy(language, "Analyzing");
+  if (state.phase === "complete") return analysisCopy(language, "Complete");
+  if (state.phase === "stopped") return analysisCopy(language, "Stopped");
+  return analysisCopy(language, "Ready");
 }
 
 function useElapsedMs(state: AnalysisState): number {
@@ -466,4 +489,16 @@ function useArtifactAuthoringElapsedMs(startedAt: number | null): number {
 
 function formatElapsed(elapsedMs: number): string {
   return `${Math.floor(elapsedMs / 1_000)}s`;
+}
+
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = React.useState(() => typeof window !== "undefined" && typeof window.matchMedia === "function" && window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+  React.useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReduced(query.matches);
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, []);
+  return reduced;
 }

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-i18n.test.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-i18n.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { ANALYSIS_COPY, analysisCopy } from "./analysis-i18n.js";
+
+describe("Session Analyst copy table", () => {
+  it("keeps complete English and Korean key pairs with approved placeholders", () => {
+    expect(Object.keys(ANALYSIS_COPY.en)).toEqual(Object.keys(ANALYSIS_COPY.ko));
+    expect(analysisCopy("ko", "Artifact published — {title}", { title: "세션 브리프" })).toBe("아티팩트 발행됨 — 세션 브리프");
+    expect(analysisCopy("ko", "Cancel queued question {index + 1}", { "index + 1": 2 })).toBe("대기 중인 질문 2 취소");
+    expect(analysisCopy("ko", "Show artifacts ({count} {item/items})", { count: 3, "item/items": "items" })).toBe("아티팩트 보기(3개)");
+  });
+
+  it("uses the host-confirmed Korean labels for send-related copy", () => {
+    expect(ANALYSIS_COPY.ko["Send"]).toBe("보내기");
+    expect(ANALYSIS_COPY.ko["Send a message in this session first"]).toContain("메시지를");
+    expect(ANALYSIS_COPY.ko["Analysis session ended — send again to restart."]).toContain("재시작합니다");
+  });
+
+  it("does not reinterpret placeholder-like text inside replacements", () => {
+    expect(analysisCopy("en", "Using {title}", {
+      title: "tool {status}",
+      status: "RUNNING",
+    })).toBe("Using tool {status}");
+  });
+});

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-i18n.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-i18n.ts
@@ -1,0 +1,123 @@
+export type AnalysisLanguage = "en" | "ko";
+
+const KOREAN_COPY = {
+  "Walk me through how this session unfolded": "이 세션이 어떻게 진행됐는지 정리해 줘",
+  "What is the agent doing right now?": "에이전트가 지금 무엇을 하고 있어?",
+  "Flag anything I should review": "내가 검토해야 할 항목을 짚어 줘",
+  "Draft a handoff brief": "인수인계 브리프 초안을 작성해 줘",
+  "Draft a handoff brief and publish it as an artifact.": "인수인계 브리프 초안을 작성하고 아티팩트로 발행해 줘.",
+  "Flag anything I should review before this work continues.": "이 작업을 계속하기 전에 내가 검토해야 할 항목을 짚어 줘.",
+  "Walk me through how this session unfolded.": "이 세션이 어떻게 진행됐는지 정리해 줘",
+  "Go deeper on the last answer": "이전 답변 더 깊게 파기",
+  "Go deeper on your previous answer with more evidence citations.": "이전 답변을 근거 인용을 늘려 더 깊게 분석해 줘.",
+  "Check for intent drift": "의도 드리프트 점검",
+  "Review this session for intent drift against my stated goals.": "내가 정한 목표와 비교해 이 세션의 의도 드리프트를 검토해 줘.",
+  "Turn this into an artifact": "아티팩트로 만들기",
+  "Turn your previous answer into a published artifact.": "이전 답변을 아티팩트로 발행해 줘.",
+  "What is the agent doing now?": "에이전트 현재 상태",
+  "Current state — what the agent is doing right now": "현재 상태 — 에이전트가 지금 하고 있는 일",
+  "Intent drift review against settled goals": "확정된 목표 대비 의도 드리프트 검토",
+  "Handoff brief as an artifact": "아티팩트로 남기는 인수인계 브리프",
+  "Flag anything that needs review": "검토가 필요한 항목 표시",
+  "How the session unfolded, end to end": "세션 진행 경과 전체 타임라인",
+  "Session Analyst chat": "Session Analyst 채팅",
+  "Hide Artifacts": "아티팩트 닫기",
+  "Open Artifacts": "아티팩트 열기",
+  "The analyst is authoring an artifact…": "분석가가 아티팩트를 작성하는 중…",
+  "Artifacts the analyst publishes appear here": "분석가가 발행한 아티팩트가 여기에 표시됩니다",
+  "ARTIFACTS": "아티팩트",
+  "Session Analyst": "Session Analyst",
+  "Read-only intelligence for this operation": "이 오퍼레이션의 읽기 전용 인텔리전스",
+  "Reset": "초기화",
+  "Reset Session Analyst": "Session Analyst 초기화",
+  "Ask about this session": "이 세션에 대해 물어보세요",
+  "Review, explain, and summarize this session — without affecting the host agent.": "호스트 에이전트에 영향을 주지 않고 세션을 검토·설명·요약합니다.",
+  "Publishing an artifact": "아티팩트 발행 중",
+  "The analyst is authoring artifact content. It opens in Artifacts when it lands.": "분석가가 아티팩트 내용을 작성하고 있습니다. 완료되면 아티팩트에서 열립니다.",
+  "Artifact published — {title}": "아티팩트 발행됨 — {title}",
+  "Open in Artifacts": "아티팩트에서 열기",
+  "Stopped · last confirmed: {activity} · {elapsed}": "중지됨 · 마지막 확인: {activity} · {elapsed}",
+  "Last confirmed activity only": "마지막으로 확인된 활동만 표시",
+  "Starting analyst": "분석가 시작 중",
+  "Analyst connection confirmed": "분석가 연결 확인됨",
+  "Starting a new analysis session": "새 분석 세션 시작 중",
+  "Reasoning over session": "세션 분석 추론 중",
+  "Thought event received · content hidden": "사고 이벤트 수신 · 내용 숨김",
+  "Using {title}": "{title} 사용 중",
+  "Tool status: {status}": "도구 상태: {status}",
+  "Writing answer": "답변 작성 중",
+  "Answer chunk received": "답변 청크 수신",
+  "Needs attention": "확인 필요",
+  "Analyzing": "분석 중",
+  "Complete": "완료",
+  "Stopped": "중지됨",
+  "Ready": "준비됨",
+  "QUEUED": "대기 중",
+  "Cancel queued question {index + 1}": "대기 중인 질문 {index + 1} 취소",
+  "FOLLOW UP": "후속 질문",
+  "Analysis commands": "분석 명령",
+  "Initial analysis settings": "초기 분석 설정",
+  "Analysis CLI": "분석 CLI",
+  "Analysis model": "분석 모델",
+  "Analysis effort": "분석 Effort",
+  "n/a": "n/a",
+  "Ask about the session… (/ for commands)": "세션에 대해 질문하기… (/ 명령)",
+  "Stop": "중지",
+  "Queue question": "질문 대기열 추가",
+  "Send": "보내기",
+  "Enter queues the question — it fires when the analyst is ready": "Enter로 질문을 대기시킵니다 — 분석가가 준비되면 실행됩니다",
+  "Copied": "복사됨",
+  "Artifacts": "아티팩트",
+  "Visual outputs from this analysis": "이 분석의 시각적 결과물",
+  "Hide artifacts ({count} {item/items})": "아티팩트 닫기({count}개)",
+  "Show artifacts ({count} {item/items})": "아티팩트 보기({count}개)",
+  "Published artifacts": "발행된 아티팩트",
+  "Clear": "지우기",
+  "No artifacts yet": "아직 아티팩트 없음",
+  "Artifacts the analyst publishes will appear here.": "분석가가 발행한 아티팩트가 여기에 표시됩니다.",
+  "Selected artifact preview": "선택한 아티팩트 미리보기",
+  "Unknown time": "시간 알 수 없음",
+  "Exit Session Analyst": "Session Analyst 닫기",
+  "Open Session Analyst": "Session Analyst 열기",
+  "Send a message in this session first": "먼저 이 세션에서 메시지를 보내세요",
+  "EXIT": "닫기",
+  "ANALYZE": "분석",
+  "Analysis response timed out.": "분석 응답 시간이 초과됐습니다.",
+  "Analysis session ended — send again to restart.": "분석 세션이 종료됐습니다 — 다시 보내면 재시작합니다.",
+  "Stop failed: {message}": "중지 실패: {message}",
+  "Reset failed: {message}": "초기화 실패: {message}",
+  "Analysis is unavailable.": "분석을 사용할 수 없습니다.",
+  "Saved": "저장됨",
+} as const;
+
+export type AnalysisCopyKey = keyof typeof KOREAN_COPY;
+
+const ENGLISH_COPY = Object.fromEntries(
+  Object.keys(KOREAN_COPY).map((key) => [key, key]),
+) as Record<AnalysisCopyKey, string>;
+
+export const ANALYSIS_COPY: Readonly<Record<AnalysisLanguage, Readonly<Record<AnalysisCopyKey, string>>>> = {
+  en: ENGLISH_COPY,
+  ko: KOREAN_COPY,
+};
+
+export function analysisCopy(
+  language: AnalysisLanguage,
+  key: AnalysisCopyKey,
+  placeholders: Readonly<Record<string, string | number>> = {},
+): string {
+  return ANALYSIS_COPY[language][key].replace(/{([^{}]+)}/g, (match, placeholder: string) => (
+    Object.hasOwn(placeholders, placeholder) ? String(placeholders[placeholder]) : match
+  ));
+}
+
+export function translateAnalysisText(language: AnalysisLanguage, message: string): string {
+  if (message.startsWith("Stop failed: ")) {
+    return analysisCopy(language, "Stop failed: {message}", { message: message.slice("Stop failed: ".length) });
+  }
+  if (message.startsWith("Reset failed: ")) {
+    return analysisCopy(language, "Reset failed: {message}", { message: message.slice("Reset failed: ".length) });
+  }
+  if (Object.hasOwn(KOREAN_COPY, message)) return analysisCopy(language, message as AnalysisCopyKey);
+  return message;
+}

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-panel.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-panel.test.tsx
@@ -20,7 +20,7 @@ describe("Session Analyst contract", () => {
     expect(chat).toContain("Starting analyst");
     expect(chat).toContain("Reasoning over session");
     expect(chat).toContain("Writing answer");
-    expect(chat.match(/aria-label="Stop"/g)).toHaveLength(1);
+    expect(chat.match(/analysisCopy\(language, "Stop"\)/g)).toHaveLength(1);
     expect(chat).toContain('className="session-analyst__send session-analyst__stop"');
     expect(chat).not.toContain("state.thinking");
     expect(artifacts).not.toContain("SANDBOXED HTML");

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-state.test.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-state.test.ts
@@ -11,6 +11,16 @@ describe("shared analysis store reducer", () => {
     expect(locked).toMatchObject({ started: true, busy: true, phase: "starting", runStartedAt: 1_000, runEndedAt: null });
   });
 
+  it("exposes the reset selection lock and preserves it until explicitly released", () => {
+    const selected = analysisReducer(initialAnalysisState, { type: "catalog", catalog });
+    const locked = analysisReducer(selected, { type: "selection-lock", locked: true });
+    expect(locked.selectionLocked).toBe(true);
+
+    const reset = analysisReducer(locked, { type: "reset" });
+    expect(reset.selectionLocked).toBe(true);
+    expect(analysisReducer(reset, { type: "selection-lock", locked: false }).selectionLocked).toBe(false);
+  });
+
   it("prefers Claude Sonnet at medium and restores that selection on reset", () => {
     const preferredCatalog = { clis: [
       { cliId: "codex", label: "Codex", available: true, defaultModel: "gpt", models: [{ id: "gpt", label: "GPT", effortLevels: ["high"], defaultEffort: "high" }] },
@@ -47,6 +57,52 @@ describe("shared analysis store reducer", () => {
       artifacts: [],
       error: null,
     });
+  });
+
+  it("hydrates persisted selection field by field and restores it on reset", () => {
+    const hydrationCatalog = { clis: [
+      { cliId: "claude", label: "Claude", available: true, defaultModel: "sonnet", models: [
+        { id: "sonnet", label: "Sonnet", effortLevels: ["low", "medium", "high"], defaultEffort: "medium" },
+        { id: "opus", label: "Opus", effortLevels: ["high"], defaultEffort: "high" },
+      ] },
+      { cliId: "codex", label: "Codex", available: true, defaultModel: "gpt", models: [
+        { id: "gpt", label: "GPT", effortLevels: [], defaultEffort: undefined },
+      ] },
+    ] };
+    const hydrated = analysisReducer(initialAnalysisState, {
+      type: "catalog",
+      catalog: hydrationCatalog,
+      selection: { cliId: "codex", model: "removed", effort: "high" },
+    });
+    expect(hydrated).toMatchObject({ cliId: "codex", model: "gpt", effort: "" });
+
+    const reset = analysisReducer({ ...hydrated, started: true, entries: [{ role: "user", text: "Question" }] }, {
+      type: "reset",
+      selection: { cliId: "claude", model: "opus", effort: "high" },
+    });
+    expect(reset).toMatchObject({ cliId: "claude", model: "opus", effort: "high", started: false, entries: [] });
+  });
+
+  it("falls back within a valid persisted CLI when its model was removed", () => {
+    const sharedModelCatalog = { clis: [
+      { cliId: "claude", label: "Claude", available: false, defaultModel: "sonnet", models: [
+        { id: "sonnet", label: "Sonnet", effortLevels: ["medium"], defaultEffort: "medium" },
+      ] },
+      { cliId: "codex", label: "Codex", available: true, defaultModel: "shared", models: [
+        { id: "shared", label: "Shared Codex", effortLevels: ["high"], defaultEffort: "high" },
+      ] },
+      { cliId: "cursor", label: "Cursor", available: true, defaultModel: "auto", models: [
+        { id: "shared", label: "Shared Cursor", effortLevels: ["high"], defaultEffort: "high" },
+        { id: "auto", label: "Auto", effortLevels: ["low", "medium"], defaultEffort: "low" },
+      ] },
+    ] };
+    const hydrated = analysisReducer(initialAnalysisState, {
+      type: "catalog",
+      catalog: sharedModelCatalog,
+      selection: { cliId: "cursor", model: "removed", effort: "high" },
+    });
+
+    expect(hydrated).toMatchObject({ cliId: "cursor", model: "auto", effort: "medium" });
   });
 
   it("persists drafts and supports cancellable FIFO queue state", () => {

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-state.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-state.ts
@@ -1,4 +1,4 @@
-import type { AnalysisArtifact, AnalysisCatalog, AnalysisEvent } from "./analysis-types.js";
+import type { AnalysisArtifact, AnalysisCatalog, AnalysisEvent, AnalysisSelection } from "./analysis-types.js";
 
 // Must match the server's MAX_ANALYSIS_ARTIFACTS per-operation cap.
 export const MAX_ANALYSIS_ARTIFACTS = 32;
@@ -30,6 +30,8 @@ export interface AnalysisState {
   readonly artifactAuthoring: { readonly startedAt: number } | null;
   readonly artifactPublished: { readonly artifact: AnalysisArtifact; readonly durationMs: number | null } | null;
   readonly artifactsAutoOpenArmed: boolean;
+  readonly selectionLocked: boolean;
+  readonly selectionSaved: boolean;
   readonly error: string | null;
 }
 
@@ -52,11 +54,13 @@ export const initialAnalysisState: AnalysisState = {
   artifactAuthoring: null,
   artifactPublished: null,
   artifactsAutoOpenArmed: true,
+  selectionLocked: false,
+  selectionSaved: false,
   error: null,
 };
 
 export type AnalysisAction =
-  | { readonly type: "catalog"; readonly catalog: AnalysisCatalog }
+  | { readonly type: "catalog"; readonly catalog: AnalysisCatalog; readonly selection?: AnalysisSelection | null }
   | { readonly type: "select-cli"; readonly cliId: string }
   | { readonly type: "select-model"; readonly model: string }
   | { readonly type: "select-effort"; readonly effort: string }
@@ -71,14 +75,17 @@ export type AnalysisAction =
   | { readonly type: "start-failed"; readonly message: string; readonly now: number }
   | { readonly type: "stopped"; readonly now: number }
   | { readonly type: "stop-failed"; readonly message: string; readonly now: number }
-  | { readonly type: "reset" }
+  | { readonly type: "reset"; readonly selection?: AnalysisSelection | null }
+  | { readonly type: "selection-lock"; readonly locked: boolean }
+  | { readonly type: "selection-saved" }
+  | { readonly type: "selection-saved-clear" }
   | { readonly type: "clear-artifacts" }
   | { readonly type: "artifacts-chip-disarm" }
   | { readonly type: "artifacts-chip-rearm" };
 
 export function analysisReducer(state: AnalysisState, action: AnalysisAction): AnalysisState {
   if (action.type === "catalog") {
-    return { ...state, catalog: action.catalog, ...resolveInitialSelection(action.catalog) };
+    return { ...state, catalog: action.catalog, ...resolvePersistedSelection(action.catalog, action.selection) };
   }
   if (action.type === "select-cli" && !state.started) {
     const cli = state.catalog?.clis.find((item) => item.cliId === action.cliId);
@@ -118,8 +125,13 @@ export function analysisReducer(state: AnalysisState, action: AnalysisAction): A
   if (action.type === "stop-failed") return { ...endWithError(state, `Stop failed: ${action.message}`, action.now), started: false };
   if (action.type === "reset") {
     const catalog = state.catalog;
-    return catalog ? { ...initialAnalysisState, catalog, ...resolveInitialSelection(catalog) } : initialAnalysisState;
+    return catalog
+      ? { ...initialAnalysisState, catalog, selectionLocked: state.selectionLocked, ...resolvePersistedSelection(catalog, action.selection) }
+      : { ...initialAnalysisState, selectionLocked: state.selectionLocked };
   }
+  if (action.type === "selection-lock") return state.selectionLocked === action.locked ? state : { ...state, selectionLocked: action.locked };
+  if (action.type === "selection-saved") return { ...state, selectionSaved: true };
+  if (action.type === "selection-saved-clear") return state.selectionSaved ? { ...state, selectionSaved: false } : state;
   // Clear는 완료 카드도 함께 걷는다 — 삭제된 artifact를 여는 CTA가 남으면 안 된다.
   if (action.type === "clear-artifacts") return { ...state, artifacts: [], artifactPublished: null, artifactsAutoOpenArmed: true };
   if (action.type === "artifacts-chip-disarm") return state.artifactsAutoOpenArmed ? { ...state, artifactsAutoOpenArmed: false } : state;
@@ -166,6 +178,29 @@ function resolveInitialSelection(catalog: AnalysisCatalog): Pick<AnalysisState, 
     ? "medium"
     : model?.defaultEffort ?? model?.effortLevels[0] ?? "";
   return { cliId: cli?.cliId ?? "", model: model?.id ?? "", effort };
+}
+
+function resolvePersistedSelection(catalog: AnalysisCatalog, selection?: AnalysisSelection | null): Pick<AnalysisState, "cliId" | "model" | "effort"> {
+  const fallback = resolveInitialSelection(catalog);
+  if (!selection) return fallback;
+  const persistedCli = catalog.clis.find((item) => item.cliId === selection.cliId && item.available);
+  const cli = persistedCli ?? catalog.clis.find((item) => item.cliId === fallback.cliId);
+  if (!cli) return fallback;
+  const fallbackModel = persistedCli
+    ? cli.models.find((item) => item.id === cli.defaultModel) ?? cli.models[0]
+    : cli.models.find((item) => item.id === fallback.model)
+      ?? cli.models.find((item) => item.id === cli.defaultModel)
+      ?? cli.models[0];
+  const persistedModel = cli.models.find((item) => item.id === selection.model);
+  const model = persistedModel ?? fallbackModel;
+  if (!model) return { cliId: cli.cliId, model: "", effort: "" };
+  const fallbackEffort = model.effortLevels.includes("medium")
+    ? "medium"
+    : model.defaultEffort ?? model.effortLevels[0] ?? "";
+  const effort = model.effortLevels.length === 0
+    ? (selection.effort === "" ? "" : fallbackEffort)
+    : (model.effortLevels.includes(selection.effort) ? selection.effort : fallbackEffort);
+  return { cliId: cli.cliId, model: model.id, effort };
 }
 
 function endWithError(state: AnalysisState, message: string, now: number): AnalysisState {

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-store.test.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
-import type { ClientApiCapability } from "@fleet-console/sdk/plugin";
+import type { ClientApiCapability, ClientSettingsCapability } from "@fleet-console/sdk/plugin";
 
 import { resetAnalysisStreamHubForTests, subscribeAnalysis } from "./analysis-api.js";
 import { disposeAnalysisStore, getAnalysisStore } from "./analysis-store.js";
@@ -149,6 +149,140 @@ describe("per-operation analysis store", () => {
     // Operation close owns disposal and server-session cleanup.
     disposeAnalysisStore("operation-store-share");
     await vi.waitFor(() => expect(harness.fetch.mock.calls.some((call) => call[1] === "analysis/operation-store-share/stop")).toBe(true));
+  });
+
+  it("hydrates, auto-saves with terminal sibling preservation, confirms the save, and resets to persisted selection", async () => {
+    const catalogBody = JSON.stringify({ clis: [{ cliId: "claude", label: "Claude", available: true, defaultModel: "sonnet", models: [
+      { id: "sonnet", label: "Sonnet", effortLevels: ["medium"], defaultEffort: "medium" },
+      { id: "opus", label: "Opus", effortLevels: ["high"], defaultEffort: "high" },
+    ] }] });
+    const harness = createHarness((path) => path === "analysis/catalog"
+      ? new Response(catalogBody, { status: 200, headers: { "Content-Type": "application/json" } })
+      : null);
+    let terminalRecord: Record<string, unknown> = {
+      font: { source: "curated", id: "jetbrains", customName: "", size: 16 },
+      analyst: { selection: { cliId: "claude", model: "opus", effort: "high" } },
+    };
+    const settings: ClientSettingsCapability = {
+      read: vi.fn(async () => terminalRecord),
+      write: vi.fn(async (_pluginId, value) => { terminalRecord = value; }),
+    };
+    const operationId = "operation-store-persisted-selection";
+    const store = getAnalysisStore(operationId, harness.api, settings, "ko");
+
+    await vi.waitFor(() => expect(store.getSnapshot()).toMatchObject({ cliId: "claude", model: "opus", effort: "high" }));
+    store.dispatch({ type: "select-model", model: "sonnet" });
+    await vi.waitFor(() => expect(settings.write).toHaveBeenCalledOnce());
+    expect(settings.write).toHaveBeenCalledWith("terminal", {
+      font: { source: "curated", id: "jetbrains", customName: "", size: 16 },
+      analyst: { selection: { cliId: "claude", model: "sonnet", effort: "medium" } },
+    });
+    expect(store.getSnapshot().selectionSaved).toBe(true);
+
+    store.dispatch({ type: "select-model", model: "opus" });
+    await vi.waitFor(() => expect(settings.write).toHaveBeenCalledTimes(2));
+    await store.reset();
+    expect(store.getSnapshot()).toMatchObject({ cliId: "claude", model: "opus", effort: "high", phase: "idle" });
+    disposeAnalysisStore(operationId);
+  });
+
+  it("ignores selection changes during reset and restores the completed persisted write", async () => {
+    const catalogBody = JSON.stringify({ clis: [{ cliId: "claude", label: "Claude", available: true, defaultModel: "sonnet", models: [
+      { id: "sonnet", label: "Sonnet", effortLevels: ["medium"], defaultEffort: "medium" },
+      { id: "opus", label: "Opus", effortLevels: ["high"], defaultEffort: "high" },
+    ] }] });
+    const harness = createHarness((path) => path === "analysis/catalog"
+      ? new Response(catalogBody, { status: 200, headers: { "Content-Type": "application/json" } })
+      : null);
+    let terminalRecord: Record<string, unknown> = {
+      analyst: { selection: { cliId: "claude", model: "opus", effort: "high" } },
+    };
+    let completeWrite!: () => void;
+    const settings: ClientSettingsCapability = {
+      read: vi.fn(async () => terminalRecord),
+      write: vi.fn((_pluginId, value) => new Promise<void>((resolve) => {
+        completeWrite = () => {
+          terminalRecord = value;
+          resolve();
+        };
+      })),
+    };
+    const operationId = "operation-store-reset-selection-fence";
+    const store = getAnalysisStore(operationId, harness.api, settings);
+    await vi.waitFor(() => expect(store.getSnapshot()).toMatchObject({ model: "opus", effort: "high" }));
+
+    store.dispatch({ type: "select-model", model: "sonnet" });
+    await vi.waitFor(() => expect(settings.write).toHaveBeenCalledOnce());
+    const resetting = store.reset();
+    expect(store.getSnapshot().selectionLocked).toBe(true);
+    store.dispatch({ type: "select-model", model: "opus" });
+    expect(store.getSnapshot()).toMatchObject({ model: "sonnet", effort: "medium" });
+
+    completeWrite();
+    await resetting;
+    expect(terminalRecord).toMatchObject({
+      analyst: { selection: { cliId: "claude", model: "sonnet", effort: "medium" } },
+    });
+    expect(store.getSnapshot()).toMatchObject({ model: "sonnet", effort: "medium", phase: "idle", selectionLocked: false });
+    disposeAnalysisStore(operationId);
+  });
+
+  it("hydrates a replacement only after the disposed store's selection write settles", async () => {
+    const catalogBody = JSON.stringify({ clis: [{ cliId: "claude", label: "Claude", available: true, defaultModel: "sonnet", models: [
+      { id: "sonnet", label: "Sonnet", effortLevels: ["medium"], defaultEffort: "medium" },
+      { id: "opus", label: "Opus", effortLevels: ["high"], defaultEffort: "high" },
+    ] }] });
+    const harness = createHarness((path) => path === "analysis/catalog"
+      ? new Response(catalogBody, { status: 200, headers: { "Content-Type": "application/json" } })
+      : null);
+    let terminalRecord: Record<string, unknown> = {
+      analyst: { selection: { cliId: "claude", model: "opus", effort: "high" } },
+    };
+    let completeWrite!: () => void;
+    const settings: ClientSettingsCapability = {
+      read: vi.fn(async () => terminalRecord),
+      write: vi.fn((_pluginId, value) => new Promise<void>((resolve) => {
+        completeWrite = () => {
+          terminalRecord = value;
+          resolve();
+        };
+      })),
+    };
+    const operationId = "operation-store-dispose-selection-fence";
+    const first = getAnalysisStore(operationId, harness.api, settings);
+    await vi.waitFor(() => expect(first.getSnapshot()).toMatchObject({ model: "opus", effort: "high" }));
+    first.dispatch({ type: "select-model", model: "sonnet" });
+    await vi.waitFor(() => expect(settings.write).toHaveBeenCalledOnce());
+
+    disposeAnalysisStore(operationId);
+    const replacement = getAnalysisStore(operationId, harness.api, settings);
+    expect(replacement).not.toBe(first);
+    expect(replacement.getSnapshot().catalog).toBeNull();
+
+    completeWrite();
+    await vi.waitFor(() => expect(replacement.getSnapshot()).toMatchObject({ model: "sonnet", effort: "medium" }));
+    expect(terminalRecord).toMatchObject({
+      analyst: { selection: { cliId: "claude", model: "sonnet", effort: "medium" } },
+    });
+    disposeAnalysisStore(operationId);
+  });
+
+  it("captures the resolved language in the start request", async () => {
+    const harness = createHarness();
+    const operationId = "operation-store-language";
+    const store = getAnalysisStore(operationId, harness.api, undefined, "ko");
+    await vi.waitFor(() => expect(store.getSnapshot().cliId).toBe("claude"));
+
+    await sendWithConnected(store, harness, operationId, "세션을 검토해 줘");
+    const start = harness.fetch.mock.calls.find((call) => String(call[1]).endsWith("/start"));
+    expect(JSON.parse(String((start?.[2] as RequestInit | undefined)?.body))).toEqual({
+      cliId: "claude",
+      model: "sonnet",
+      effort: "high",
+      language: "ko",
+    });
+    harness.emit(operationId, { type: "complete" });
+    disposeAnalysisStore(operationId);
   });
 
   it("automatically sends queued questions in FIFO order after each completion", async () => {

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-store.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-store.ts
@@ -1,8 +1,10 @@
 import { React } from "@fleet-console/sdk/plugin/browser";
-import type { ClientApiCapability, OperationRenderContext } from "@fleet-console/sdk/plugin";
+import type { ClientApiCapability, ClientSettingsCapability, OperationRenderContext } from "@fleet-console/sdk/plugin";
 
 import { AnalysisApiError, clearAnalysisArtifacts, fetchAnalysisCatalog, sendAnalysisMessage, startAnalysis, stopAnalysis, subscribeAnalysis } from "./analysis-api.js";
 import { analysisReducer, initialAnalysisState, type AnalysisAction, type AnalysisState } from "./analysis-state.js";
+import type { AnalysisSelection } from "./analysis-types.js";
+import { mergeTerminalSettingsRecord } from "../shared/terminal-prefs-store.js";
 
 export interface AnalysisStore {
   readonly getSnapshot: () => AnalysisState;
@@ -12,6 +14,7 @@ export interface AnalysisStore {
   readonly stop: () => Promise<void>;
   readonly reset: () => Promise<void>;
   readonly dispose: () => void;
+  readonly updateContext: (settings: ClientSettingsCapability | undefined, language: "en" | "ko" | undefined) => void;
 }
 
 interface AnalysisStoreBinding {
@@ -26,15 +29,18 @@ const stores = new Map<string, AnalysisStore>();
 const disposalFlights = new Map<string, Promise<void>>();
 
 export function useAnalysisStore(context: OperationRenderContext): AnalysisStoreBinding {
-  const store = getAnalysisStore(context.operationId, context.api);
+  const store = getAnalysisStore(context.operationId, context.api, context.settings, context.language);
   const state = React.useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
   return { state, dispatch: store.dispatch, send: store.send, stop: store.stop, reset: store.reset };
 }
 
-export function getAnalysisStore(operationId: string, api: ClientApiCapability): AnalysisStore {
+export function getAnalysisStore(operationId: string, api: ClientApiCapability, settings?: ClientSettingsCapability, language?: "en" | "ko"): AnalysisStore {
   const existing = stores.get(operationId);
-  if (existing) return existing;
-  const store = createAnalysisStore(operationId, api);
+  if (existing) {
+    existing.updateContext(settings, language);
+    return existing;
+  }
+  const store = createAnalysisStore(operationId, api, settings, language);
   stores.set(operationId, store);
   return store;
 }
@@ -51,8 +57,11 @@ export function rearmAnalysisArtifacts(operationId: string): void {
 const CONNECT_WAIT_MS = 2_000;
 const RESPONSE_TIMEOUT_MS = 120_000;
 
-function createAnalysisStore(operationId: string, api: ClientApiCapability): AnalysisStore {
+function createAnalysisStore(operationId: string, api: ClientApiCapability, initialSettings?: ClientSettingsCapability, initialLanguage?: "en" | "ko"): AnalysisStore {
   let state = initialAnalysisState;
+  let settingsCapability = initialSettings;
+  let language = initialLanguage;
+  let persistedSelection: AnalysisSelection | null = null;
   let disposed = false;
   let unsubscribe: (() => void) | null = null;
   let watchdog: ReturnType<typeof setTimeout> | null = null;
@@ -60,16 +69,48 @@ function createAnalysisStore(operationId: string, api: ClientApiCapability): Ana
   let startController: AbortController | null = null;
   let stopFlight: Promise<void> | null = null;
   let resetFlight: Promise<void> | null = null;
+  let selectionWriteFlight: Promise<void> = Promise.resolve();
+  let selectionWriteEpoch = 0;
+  let selectionSavedTimer: ReturnType<typeof setTimeout> | null = null;
   let streamGeneration = 0;
   let runGeneration = 0;
   const listeners = new Set<() => void>();
 
   const dispatch = (action: AnalysisAction) => {
     if (disposed) return;
+    const savesSelection = action.type === "select-cli" || action.type === "select-model" || action.type === "select-effort";
+    if (savesSelection && state.selectionLocked) return;
     const next = analysisReducer(state, action);
     if (next === state) return;
-    state = next;
+    if (savesSelection && selectionSavedTimer !== null) {
+      clearTimeout(selectionSavedTimer);
+      selectionSavedTimer = null;
+    }
+    state = savesSelection && next.selectionSaved ? { ...next, selectionSaved: false } : next;
     for (const listener of listeners) listener();
+    if (savesSelection) queueSelectionSave({ cliId: state.cliId, model: state.model, effort: state.effort });
+  };
+
+  const queueSelectionSave = (selection: AnalysisSelection) => {
+    const settings = settingsCapability;
+    if (!settings) return;
+    const epoch = ++selectionWriteEpoch;
+    selectionWriteFlight = selectionWriteFlight.then(async () => {
+      try {
+        await mergeTerminalSettingsRecord(settings, {
+          analyst: { selection },
+        });
+        persistedSelection = selection;
+        if (disposed || epoch !== selectionWriteEpoch) return;
+        dispatch({ type: "selection-saved" });
+        selectionSavedTimer = setTimeout(() => {
+          selectionSavedTimer = null;
+          dispatch({ type: "selection-saved-clear" });
+        }, 1_500);
+      } catch {
+        // best-effort — the current in-memory selection remains usable.
+      }
+    });
   };
 
   const disarmWatchdog = () => {
@@ -137,10 +178,12 @@ function createAnalysisStore(operationId: string, api: ClientApiCapability): Ana
     const pendingReset = resetFlight;
     const pendingStop = stopFlight;
     const pendingStart = startFlight;
+    const pendingSelectionWrite = selectionWriteFlight;
     const pendingStartController = startController;
     disposed = true;
     stores.delete(operationId);
     invalidateRun();
+    if (selectionSavedTimer !== null) clearTimeout(selectionSavedTimer);
     listeners.clear();
     pendingStartController?.abort();
     const flight = (async () => {
@@ -148,6 +191,7 @@ function createAnalysisStore(operationId: string, api: ClientApiCapability): Ana
       if (pendingStart) await pendingStart.catch(() => {});
       if (pendingReset) await pendingReset.catch(() => {});
       if (pendingStop) await pendingStop.catch(() => {});
+      await pendingSelectionWrite;
       await stopAnalysis(api, operationId);
     })().catch(() => {});
     disposalFlights.set(operationId, flight);
@@ -174,7 +218,9 @@ function createAnalysisStore(operationId: string, api: ClientApiCapability): Ana
       if (!trimmed || state.busy || disposed) return;
       const starting = !state.started;
       const generation = ++runGeneration;
-      const selection = { cliId: state.cliId, model: state.model, effort: state.effort };
+      // Output language belongs to the server session created by this start. Later global
+      // language changes update panel copy live, but apply to output only after reset/restart.
+      const selection = { cliId: state.cliId, model: state.model, effort: state.effort, ...(language ? { language } : {}) };
       dispatch({ type: "sending", started: starting, text: trimmed, now: Date.now() });
       if (starting) {
         const controller = new AbortController();
@@ -228,14 +274,16 @@ function createAnalysisStore(operationId: string, api: ClientApiCapability): Ana
     reset: async () => {
       if (resetFlight) return resetFlight;
       if (disposed) return;
+      dispatch({ type: "selection-lock", locked: true });
       const shouldStopServer = state.started || state.phase !== "idle" || state.entries.length > 0 || state.artifacts.length > 0;
       invalidateRun();
       const flight = (async () => {
         if (stopFlight) await stopFlight;
         if (startFlight) await startFlight.catch(() => {});
+        await selectionWriteFlight;
         if (shouldStopServer) await stopAnalysis(api, operationId);
         await clearAnalysisArtifacts(api, operationId).catch(() => {});
-        dispatch({ type: "reset" });
+        dispatch({ type: "reset", selection: persistedSelection });
       })().catch((error: unknown) => {
         dispatch({ type: "error", message: `Reset failed: ${failureMessage(error)}`, now: Date.now() });
         throw error;
@@ -245,16 +293,47 @@ function createAnalysisStore(operationId: string, api: ClientApiCapability): Ana
         await flight;
       } finally {
         if (resetFlight === flight) resetFlight = null;
+        dispatch({ type: "selection-lock", locked: false });
       }
     },
     dispose,
+    updateContext: (settings, nextLanguage) => {
+      if (settings) settingsCapability = settings;
+      language = nextLanguage;
+    },
   };
 
-  void fetchAnalysisCatalog(api)
-    .then((catalog) => dispatch({ type: "catalog", catalog }))
+  const previousDisposal = disposalFlights.get(operationId);
+  void (previousDisposal ?? Promise.resolve())
+    .then(() => Promise.all([fetchAnalysisCatalog(api), readPersistedSelection(settingsCapability)]))
+    .then(([catalog, selection]) => {
+      persistedSelection = selection;
+      dispatch({ type: "catalog", catalog, selection });
+    })
     .catch((error: unknown) => dispatch({ type: "error", message: failureMessage(error), now: Date.now() }));
 
   return store;
+}
+
+async function readPersistedSelection(settings: ClientSettingsCapability | undefined): Promise<AnalysisSelection | null> {
+  if (!settings) return null;
+  try {
+    const current = await settings.read("terminal");
+    if (!current) return null;
+    const analyst = record(current["analyst"]);
+    const selection = record(analyst["selection"]);
+    return typeof selection["cliId"] === "string"
+      && typeof selection["model"] === "string"
+      && typeof selection["effort"] === "string"
+      ? { cliId: selection["cliId"], model: selection["model"], effort: selection["effort"] }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
 }
 
 function failureMessage(error: unknown): string {

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-types.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-types.ts
@@ -14,6 +14,11 @@ export interface AnalysisCli {
 }
 
 export interface AnalysisCatalog { readonly clis: readonly AnalysisCli[]; }
+export interface AnalysisSelection {
+  readonly cliId: string;
+  readonly model: string;
+  readonly effort: string;
+}
 export interface AnalysisError { readonly code: string; readonly message: string; }
 export interface AnalysisArtifact { readonly id: string; readonly title: string; readonly html: string; readonly createdAt: number; }
 export type AnalysisEvent =

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -14,6 +14,7 @@ import type { TerminalFontSettings, TerminalRenderer } from "../shared/types.js"
 import { AnalystArtifactsPanel } from "./analysis-artifacts-panel.js";
 import { ANALYST_ARTIFACTS_COMPANION_ID, AnalystChatPanel } from "./analysis-chat-panel.js";
 import { fetchAnalysisReady } from "./analysis-api.js";
+import { analysisCopy } from "./analysis-i18n.js";
 import { disposeAnalysisStore, rearmAnalysisArtifacts } from "./analysis-store.js";
 import "./analysis.css";
 
@@ -296,17 +297,18 @@ function useAnalysisReady(context: OperationRenderContext): boolean {
 
 function SessionAnalystHandle({ context, ready }: { readonly context: OperationRenderContext; readonly ready: boolean }) {
   const companionsOpen = context.companionsOpen ?? false;
+  const language = context.language ?? "en";
   return (
     <button
       type="button"
       className={`session-analyst-handle${ready ? "" : " is-waiting"}`}
-      aria-label={companionsOpen ? "Exit Session Analyst" : "Open Session Analyst"}
+      aria-label={analysisCopy(language, companionsOpen ? "Exit Session Analyst" : "Open Session Analyst")}
       aria-pressed={companionsOpen}
       aria-disabled={!ready}
       disabled={!ready}
-      title={ready ? undefined : "Send a message in this session first"}
+      title={ready ? undefined : analysisCopy(language, "Send a message in this session first")}
       onClick={() => { if (ready) context.onRequestCompanions?.(!context.companionsOpen); }}
-    ><span className="session-analyst-handle__chev" aria-hidden="true">{companionsOpen ? "«" : "»"}</span><span className="session-analyst-handle__label">{companionsOpen ? "EXIT" : "ANALYZE"}</span></button>
+    ><span className="session-analyst-handle__chev" aria-hidden="true">{companionsOpen ? "«" : "»"}</span><span className="session-analyst-handle__label">{analysisCopy(language, companionsOpen ? "EXIT" : "ANALYZE")}</span></button>
   );
 }
 

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-prefs-store.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-prefs-store.ts
@@ -22,6 +22,7 @@ const listeners = new Set<Listener>();
 let state: TerminalPrefsState = initState();
 let settingsCapability: ClientSettingsCapability | null = null;
 let fontWriteEpoch = 0;
+let terminalSettingsWriteFlight: Promise<void> | null = null;
 
 export function migrateLegacyTerminalPrefs(): void {
   if (typeof window === "undefined") return;
@@ -133,14 +134,29 @@ async function hydrateFontFromServer(): Promise<void> {
 }
 
 async function pushFontToServer(font: TerminalFontSettings): Promise<void> {
-  if (!settingsCapability) return;
+  const settings = settingsCapability;
+  if (!settings) return;
   try {
-    await settingsCapability.write("terminal", {
+    await mergeTerminalSettingsRecord(settings, {
       font: { source: font.source, id: font.id, customName: font.customName, size: font.size },
     });
   } catch {
     // best-effort — write 실패 시 조용히 무시한다.
   }
+}
+
+export function mergeTerminalSettingsRecord(settings: ClientSettingsCapability, patch: Record<string, unknown>): Promise<void> {
+  const merge = async () => {
+    const current = await settings.read("terminal");
+    await settings.write("terminal", { ...(current ?? {}), ...patch });
+  };
+  const previous = terminalSettingsWriteFlight;
+  const write = previous ? previous.catch(() => undefined).then(merge) : merge();
+  terminalSettingsWriteFlight = write;
+  void write.finally(() => {
+    if (terminalSettingsWriteFlight === write) terminalSettingsWriteFlight = null;
+  }).catch(() => undefined);
+  return write;
 }
 
 function readStoredRenderer(): TerminalRenderer {

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
@@ -29,7 +29,9 @@ describe("Session Analyst server contract", () => {
     expect(modelsFor.mock.calls.map(([cliId]) => cliId)).toEqual(["claude", "claude-kimi", "codex", "opencode-go", "cursor"]);
     for (const cliId of ["claude", "claude-kimi", "codex", "opencode-go", "cursor"] as const) {
       expect(isAnalysisSelection(catalog, { cliId, model: "model-a", effort: "low" })).toBe(true);
+      expect(isAnalysisSelection(catalog, { cliId, model: "model-a", effort: "low", language: "ko" })).toBe(true);
     }
+    expect(isAnalysisSelection(catalog, { cliId: "claude", model: "model-a", effort: "low", language: "ja" })).toBe(false);
     expect(isAnalysisSelection(catalog, { cliId: "claude", model: "model-a" })).toBe(false);
     expect(isAnalysisSelection(catalog, { cliId: "claude", model: "removed", effort: "low" })).toBe(false);
 
@@ -256,9 +258,9 @@ describe("Session Analyst server contract", () => {
       createSession: createSession as never,
     });
 
-    await router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", { cliId: "claude", model: "model-b" });
+    await router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", { cliId: "claude", model: "model-b", language: "ko" });
     expect(router.responses.at(-1)).toMatchObject({ status: 200, body: { started: true } });
-    expect(createSession).toHaveBeenCalledWith(expect.objectContaining({ effort: undefined }));
+    expect(createSession).toHaveBeenCalledWith(expect.objectContaining({ effort: undefined, language: "ko" }));
   });
 
   it("disposes a registry entry when its Operation is deleted during pending start", async () => {

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
@@ -367,7 +367,7 @@ async function handleStart(ctx: FleetPluginServerContext, req: http.IncomingMess
     return true;
   }
   try {
-    const result = await registry.start(operation.id, (onEvent) => createSession({ cliId: body.cliId, model: body.model, effort: body.effort || undefined, cwd, capturePath: transcriptPath, onEvent: (event: AnalystEvent) => onEvent(toBrowserEvent(event)) }));
+    const result = await registry.start(operation.id, (onEvent) => createSession({ cliId: body.cliId, model: body.model, effort: body.effort || undefined, language: body.language, cwd, capturePath: transcriptPath, onEvent: (event: AnalystEvent) => onEvent(toBrowserEvent(event)) }));
     if (result === "exists") writeError(ctx, res, 409, ANALYSIS_ERROR_CODES.sessionExists, "Analysis session already exists.");
     else if (result === "stopped") writeError(ctx, res, 404, ANALYSIS_ERROR_CODES.sessionNotFound, "Analysis session was stopped before it started.");
     else ctx.host.http.writeJson(res, 200, { started: true });

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-types.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-types.ts
@@ -68,8 +68,8 @@ export function analysisError(code: AnalysisErrorCode, message: string): Analysi
   return { error: { code, message } };
 }
 
-export function isAnalysisSelection(catalog: AnalysisCatalog, value: unknown): value is { readonly cliId: AnalystCliId; readonly model: string; readonly effort?: string } {
-  if (!isRecord(value) || !hasExactKeys(value, ["cliId", "model", "effort"]) || typeof value.cliId !== "string" || typeof value.model !== "string" || (value.effort !== undefined && typeof value.effort !== "string")) return false;
+export function isAnalysisSelection(catalog: AnalysisCatalog, value: unknown): value is { readonly cliId: AnalystCliId; readonly model: string; readonly effort?: string; readonly language?: "en" | "ko" } {
+  if (!isRecord(value) || !hasExactKeys(value, ["cliId", "model", "effort", "language"]) || typeof value.cliId !== "string" || typeof value.model !== "string" || (value.effort !== undefined && typeof value.effort !== "string") || (value.language !== undefined && value.language !== "en" && value.language !== "ko")) return false;
   const cli = catalog.clis.find((candidate) => candidate.cliId === value.cliId);
   if (!cli?.available) return false;
   const model = cli.models.find((candidate) => candidate.id === value.model);

--- a/runtime/fleet-plugins/terminal/tests/terminal-prefs-store.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-prefs-store.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ClientSettingsCapability } from "@fleet-console/sdk/plugin";
 
-import { connectTerminalSettings, getTerminalPrefsSnapshot, migrateLegacyTerminalPrefs, setInstalledTerminalFont, setTerminalFont, setTerminalFontSize } from "../client/shared/terminal-prefs-store.js";
+import { connectTerminalSettings, getTerminalPrefsSnapshot, mergeTerminalSettingsRecord, migrateLegacyTerminalPrefs, setInstalledTerminalFont, setTerminalFont, setTerminalFontSize } from "../client/shared/terminal-prefs-store.js";
 
 const RENDERER_KEY = "fleet-plugin.terminal.renderer";
 const FONT_KEY = "fleet-plugin.terminal.font";
@@ -120,7 +120,7 @@ describe("connectTerminalSettings / server hydration", () => {
       serverValue: { font: { source: "curated", id: "jetbrains", customName: "", size: 16 } },
     });
     connectTerminalSettings(cap);
-    await vi.waitFor(() => cap.putCalls.length === 0 && getTerminalPrefsSnapshot().font.id === "jetbrains");
+    await vi.waitFor(() => expect(getTerminalPrefsSnapshot().font.id).toBe("jetbrains"));
     expect(getTerminalPrefsSnapshot().font.id).toBe("jetbrains");
     expect(store[FONT_KEY]).toBeUndefined();
   });
@@ -129,7 +129,7 @@ describe("connectTerminalSettings / server hydration", () => {
     store[FONT_KEY] = JSON.stringify({ source: "curated", id: "fira-code", customName: "", size: 15 });
     const cap = makeCapability({ serverValue: null });
     connectTerminalSettings(cap);
-    await vi.waitFor(() => cap.putCalls.length > 0);
+    await vi.waitFor(() => expect(cap.putCalls.length).toBeGreaterThan(0));
     expect(cap.putCalls[0]?.id).toBe("terminal");
     expect((cap.putCalls[0]?.value as { font?: { id?: string } }).font?.id).toBe("fira-code");
     expect(store[FONT_KEY]).toBeUndefined();
@@ -139,13 +139,13 @@ describe("connectTerminalSettings / server hydration", () => {
     store[FONT_KEY] = JSON.stringify({ source: "curated", id: "fira-code", customName: "", size: 15 });
     const cap = makeCapability({ serverValue: null });
     connectTerminalSettings(cap);
-    await vi.waitFor(() => cap.putCalls.length > 0);
+    await vi.waitFor(() => expect(cap.putCalls.length).toBeGreaterThan(0));
     const firstCallCount = cap.putCalls.length;
     // 서버에 이제 값이 있음 — 재연결 시 추가 PUT 없음
     const cap2 = makeCapability({ serverValue: { font: { source: "curated", id: "fira-code", customName: "", size: 15 } } });
     connectTerminalSettings(cap2);
     // 하이드레이션이 서버 값을 채택할 때까지 대기한 뒤 재시드 PUT이 없음을 단언한다.
-    await vi.waitFor(() => getTerminalPrefsSnapshot().font.id === "fira-code");
+    await vi.waitFor(() => expect(getTerminalPrefsSnapshot().font.id).toBe("fira-code"));
     await new Promise((r) => setTimeout(r, 10));
     expect(cap2.putCalls.length).toBe(0);
     // 첫 번째 캐파빌리티의 총 PUT은 1회여야 함
@@ -179,7 +179,7 @@ describe("connectTerminalSettings / server hydration", () => {
     connectTerminalSettings(cap);
     setInstalledTerminalFont("  MesloLGS NF\u0000  ");
     resolveRead({ font: { source: "curated", id: "jetbrains", customName: "", size: 12 } });
-    await vi.waitFor(() => getTerminalPrefsSnapshot().font.customName === "MesloLGS NF");
+    await vi.waitFor(() => expect(cap.putCalls.length).toBeGreaterThan(0));
     expect(getTerminalPrefsSnapshot().font).toMatchObject({ source: "custom", id: null, customName: "MesloLGS NF" });
     expect((cap.putCalls[0]?.value as { font?: unknown }).font).toEqual({ source: "custom", id: null, customName: "MesloLGS NF", size: getTerminalPrefsSnapshot().font.size });
   });
@@ -216,10 +216,10 @@ describe("connectTerminalSettings / server hydration", () => {
     const cap = makeCapability({ serverValue: null });
     connectTerminalSettings(cap);
     setTerminalFont("jetbrains");
-    await vi.waitFor(() => cap.putCalls.some((c) => {
+    await vi.waitFor(() => expect(cap.putCalls.some((c) => {
       const font = (c.value as { font?: { id?: string } }).font;
       return font?.id === "jetbrains";
-    }));
+    })).toBe(true));
     expect(cap.putCalls.some((c) => {
       const font = (c.value as { font?: { id?: string } }).font;
       return font?.id === "jetbrains";
@@ -231,10 +231,42 @@ describe("connectTerminalSettings / server hydration", () => {
     connectTerminalSettings(cap);
     setTerminalFontSize(17);
     setInstalledTerminalFont("  MesloLGS NF\u0000  ");
-    await vi.waitFor(() => cap.putCalls.some((call) => (call.value as { font?: { customName?: string } }).font?.customName === "MesloLGS NF"));
+    await vi.waitFor(() => expect(cap.putCalls.some((call) => (call.value as { font?: { customName?: string } }).font?.customName === "MesloLGS NF")).toBe(true));
     const installedWrite = cap.putCalls.find((call) => (call.value as { font?: { customName?: string } }).font?.customName === "MesloLGS NF");
     expect(installedWrite).toEqual({ id: "terminal", value: { font: { source: "custom", id: null, customName: "MesloLGS NF", size: 17 } } });
     expect(store[FONT_KEY]).toBeUndefined();
+  });
+
+  it("preserves the Analyst selection when writing font settings", async () => {
+    const selection = { cliId: "codex", model: "gpt-5", effort: "high" };
+    const cap = makeCapability({ serverValue: { analyst: { selection } } });
+    connectTerminalSettings(cap);
+    setTerminalFont("jetbrains");
+    await vi.waitFor(() => expect(cap.putCalls.some((call) => (call.value as { font?: { id?: string } }).font?.id === "jetbrains")).toBe(true));
+    expect(cap.putCalls.find((call) => (call.value as { font?: { id?: string } }).font?.id === "jetbrains")).toEqual({
+      id: "terminal",
+      value: {
+        analyst: { selection },
+        font: { source: "curated", id: "jetbrains", customName: "", size: getTerminalPrefsSnapshot().font.size },
+      },
+    });
+  });
+
+  it("serializes Terminal record merges so concurrent font and Analyst writes preserve both keys", async () => {
+    let record: Record<string, unknown> = {};
+    const settings: ClientSettingsCapability = {
+      read: async () => ({ ...record }),
+      write: async (_pluginId, value) => { record = value; },
+    };
+    const font = { source: "curated", id: "jetbrains", customName: "", size: 16 };
+    const analyst = { selection: { cliId: "codex", model: "gpt-5", effort: "high" } };
+
+    await Promise.all([
+      mergeTerminalSettingsRecord(settings, { font }),
+      mergeTerminalSettingsRecord(settings, { analyst }),
+    ]);
+
+    expect(record).toEqual({ font, analyst });
   });
 
   it("keeps the local fallback state when an installed-font server write fails", async () => {


### PR DESCRIPTION
## Summary
- Session Analyst가 콘솔 언어 설정(`general.language`)을 따라 패널 카피와 분석 출력을 한국어/영어로 제공합니다. `auto`는 Release Notes와 같은 `navigator.language` 규칙으로 해석되며, ko 세션은 시스템 프롬프트에 한국어 응답 지시문이 추가됩니다.
- CLI/Model/Effort 선택이 `plugins.terminal.analyst.selection`에 auto-save되어 리로드/재시작 후에도 유지됩니다. catalog 검증 + 필드별 fallback으로 퇴역 모델에 대응하고, Reset은 catalog 추측값이 아닌 저장된 기본값을 복원합니다.
- 터미널 플러그인 settings 쓰기가 직렬화된 read-modify-write로 바뀌어 font/analyst 키가 서로를 덮어쓰지 않습니다.

## Test Plan
- [x] 터미널 플러그인 테스트 374건 + fleet-analyst 30건 green, 3개 패키지 build green
- [x] 격리 인스턴스 e2e: ko 패널 카피/한국어 분석 출력, en 라이브 전환 양방향
- [x] e2e: 스트립 변경 → settings.json `analyst.selection` 기록 + `font` sibling 보존, 리로드 후 선택 유지, Reset → 저장된 기본값 복원
- [x] Sentinel QA 2회(구현 리뷰 + 수정분 재리뷰) PASS
- [x] `.changelog.d/pr-364.md` — fragment 문법·이중언어·컴파일러 검증 완료 (11 entries)