### PR TITLE
feat(repository): add collapsible sections to the workspace tree

### DIFF
--- a/.changelog.d/pr-365.md
+++ b/.changelog.d/pr-365.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Added
+- [fleet-console] Collapse and expand Repository panel workspace tree sections, with Tags and Stashes folded by default and fold state kept in memory only.
+  ko: Repository 패널 워크스페이스 트리 섹션을 접고 펼 수 있습니다. Tags와 Stashes는 기본 접힘이며 접기 상태는 메모리에만 유지됩니다.

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -374,8 +374,9 @@ interface WorkspaceTreeProps {
   readonly onRef: (ref: string) => void;
 }
 
-function WorkspaceTree({ repos, reposError, reposTruncated, scanDepth, worktrees, worktreesError, refs, refsError, changedFiles, selectedRel, source, refFilter, onRepository, onScanDepth, onRetryRepos, onRetryWorktrees, onRetryRefs, onSource, onRef }: WorkspaceTreeProps) {
+export function WorkspaceTree({ repos, reposError, reposTruncated, scanDepth, worktrees, worktreesError, refs, refsError, changedFiles, selectedRel, source, refFilter, onRepository, onScanDepth, onRetryRepos, onRetryWorktrees, onRetryRefs, onSource, onRef }: WorkspaceTreeProps) {
   const [query, setQuery] = useState("");
+  const [collapsedSections, setCollapsedSections] = useState(() => new Set(["tags", "stashes"]));
   const rootRepos = repos.filter((repo) => repo.kind === "root").sort((a, b) => a.name.localeCompare(b.name));
   const nestedRepos = repos.filter((repo) => repo.kind === "nested");
   const nestedTree = buildRepoTree(nestedRepos);
@@ -395,7 +396,20 @@ function WorkspaceTree({ repos, reposError, reposTruncated, scanDepth, worktrees
   });
   const sectionHeader = (id: (typeof sections)[number]["id"]) => {
     const section = sections.find((item) => item.id === id)!;
-    return <div className="repository-ws-section-head"><span>{section.label}</span><i>{section.count}</i></div>;
+    const collapsed = collapsedSections.has(id);
+    return <button type="button" className="repository-ws-section-head" aria-expanded={!collapsed} onClick={() => {
+      setCollapsedSections((current) => {
+        const next = new Set(current);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      });
+    }}>
+      <svg className="repository-folder-chevron" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+        <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+      <span>{section.label}</span><i>{section.count}</i>
+    </button>;
   };
   const refRows = (refSource: RefSource) => buildRefListGroups(refSource, refs).map((group) => <div key={group.label ?? refSource} className="repository-ws-ref-group">
     {group.label && <span className="repository-ws-ref-subhead">{group.label}</span>}
@@ -409,26 +423,28 @@ function WorkspaceTree({ repos, reposError, reposTruncated, scanDepth, worktrees
       if (first) onRepository(first);
     }} />
     <div className="repository-ws-tree-scroll">
-      <section className="repository-ws-section">{sectionHeader("context")}
-        {reposError ? <WorkspaceTreeError label="Unable to load repositories" onRetry={onRetryRepos} /> : <>
+      <section className={`repository-ws-section${collapsedSections.has("context") ? " is-collapsed" : ""}`}>{sectionHeader("context")}
+        {!collapsedSections.has("context") && (reposError ? <WorkspaceTreeError label="Unable to load repositories" onRetry={onRetryRepos} /> : <>
           {rootMatches.map((repo) => <RepoLeafRow key={repo.relPath} repo={repo} depth={0} selectedRel={selectedRel} onRepository={onRepository} />)}
           {query ? nestedMatches.map((repo) => <RepoLeafRow key={repo.relPath} repo={repo} depth={0} selectedRel={selectedRel} onRepository={onRepository} />) : <RepoTreeChildren node={nestedTree} depth={0} selectedRel={selectedRel} onRepository={onRepository} />}
           {query && matchedCount === 0 && <div className="repository-empty-row">No matching repositories</div>}
+        </>)}
+      </section>
+      <section className={`repository-ws-section${collapsedSections.has("working") ? " is-collapsed" : ""}`}>{sectionHeader("working")}
+        {!collapsedSections.has("working") && <>
+          <button type="button" className={`repository-ws-tree-row${source === "history" ? " is-active" : ""}`} onClick={() => onSource("history")}><SourceIcon source="history" /><span>History</span></button>
+          <button type="button" className={`repository-ws-tree-row${source === "changes" ? " is-active" : ""}`} onClick={() => onSource("changes")}><SourceIcon source="changes" /><span>Changes</span><i>{changesCount}</i></button>
+          <button type="button" className={`repository-ws-tree-row${source === "compare" ? " is-active" : ""}`} onClick={() => onSource("compare")}><SourceIcon source="compare" /><span>Compare</span></button>
         </>}
       </section>
-      <section className="repository-ws-section">{sectionHeader("working")}
-        <button type="button" className={`repository-ws-tree-row${source === "history" ? " is-active" : ""}`} onClick={() => onSource("history")}><SourceIcon source="history" /><span>History</span></button>
-        <button type="button" className={`repository-ws-tree-row${source === "changes" ? " is-active" : ""}`} onClick={() => onSource("changes")}><SourceIcon source="changes" /><span>Changes</span><i>{changesCount}</i></button>
-        <button type="button" className={`repository-ws-tree-row${source === "compare" ? " is-active" : ""}`} onClick={() => onSource("compare")}><SourceIcon source="compare" /><span>Compare</span></button>
+      <section className={`repository-ws-section${collapsedSections.has("worktrees") ? " is-collapsed" : ""}`}>{sectionHeader("worktrees")}
+        {!collapsedSections.has("worktrees") && (worktreesError ? <WorkspaceTreeError label="Unable to load worktrees" onRetry={onRetryWorktrees} /> : worktrees.map((worktree) => <button type="button" key={worktree.relPath} className={`repository-ws-tree-row${worktree.relPath === selectedRel ? " is-current" : ""}`} title={worktree.relPath} onClick={() => onRepository(worktree)}><SourceIcon source="worktrees" /><span>{worktree.name}</span>{worktree.current && <i>HEAD</i>}</button>))}
       </section>
-      <section className="repository-ws-section">{sectionHeader("worktrees")}
-        {worktreesError ? <WorkspaceTreeError label="Unable to load worktrees" onRetry={onRetryWorktrees} /> : worktrees.map((worktree) => <button type="button" key={worktree.relPath} className={`repository-ws-tree-row${worktree.relPath === selectedRel ? " is-current" : ""}`} title={worktree.relPath} onClick={() => onRepository(worktree)}><SourceIcon source="worktrees" /><span>{worktree.name}</span>{worktree.current && <i>HEAD</i>}</button>)}
+      <section className={`repository-ws-section${collapsedSections.has("branches") ? " is-collapsed" : ""}`}>{sectionHeader("branches")}
+        {!collapsedSections.has("branches") && (refsError ? <WorkspaceTreeError label="Unable to load refs" onRetry={onRetryRefs} /> : refRows("branches"))}
       </section>
-      <section className="repository-ws-section">{sectionHeader("branches")}
-        {refsError ? <WorkspaceTreeError label="Unable to load refs" onRetry={onRetryRefs} /> : refRows("branches")}
-      </section>
-      <section className="repository-ws-section">{sectionHeader("tags")}{!refsError && refRows("tags")}</section>
-      <section className="repository-ws-section">{sectionHeader("stashes")}{!refsError && refRows("stashes")}</section>
+      <section className={`repository-ws-section${collapsedSections.has("tags") ? " is-collapsed" : ""}`}>{sectionHeader("tags")}{!collapsedSections.has("tags") && !refsError && refRows("tags")}</section>
+      <section className={`repository-ws-section${collapsedSections.has("stashes") ? " is-collapsed" : ""}`}>{sectionHeader("stashes")}{!collapsedSections.has("stashes") && !refsError && refRows("stashes")}</section>
     </div>
   </aside>;
 }

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1066,10 +1066,29 @@
   align-items: center;
   gap: 6px;
   padding: 3px 10px;
+  width: 100%;
+  border: 0;
+  background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 9.5px;
   letter-spacing: .14em;
+  cursor: pointer;
+  text-align: left;
+}
+
+.repository-ws-section-head:hover {
+  background: color-mix(in oklch, var(--ink-fog) 9%, transparent);
+  color: var(--text-secondary);
+}
+
+.repository-ws-section-head:focus-visible {
+  outline: 1px solid var(--brass);
+  outline-offset: -1px;
+}
+
+.repository-ws-section.is-collapsed .repository-folder-chevron {
+  transform: rotate(-90deg);
 }
 
 .repository-ws-section-head i {

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -107,6 +107,34 @@ describe("Repository design grammar", () => {
     }
   });
 
+  it("keeps workspace section header buttons within the interaction grammar", () => {
+    const sectionHead = blockOf(".repository-ws-section-head");
+    expect(sectionHead).toContain("display: flex");
+    expect(sectionHead).toContain("width: 100%");
+    expect(sectionHead).toContain("border: 0");
+    expect(sectionHead).toContain("background: transparent");
+    expect(sectionHead).toContain("color: var(--text-tertiary)");
+    expect(sectionHead).toContain("font-family: var(--font-mono)");
+    expect(sectionHead).toContain("cursor: pointer");
+    expect(sectionHead).toContain("text-align: left");
+
+    const sectionHeadHover = blockOf(".repository-ws-section-head:hover");
+    expect(sectionHeadHover).toContain("background: color-mix(in oklch, var(--ink-fog) 9%, transparent)");
+    expect(sectionHeadHover).toContain("color: var(--text-secondary)");
+
+    const sectionHeadFocus = blockOf(".repository-ws-section-head:focus-visible");
+    expect(sectionHeadFocus).toContain("outline: 1px solid var(--brass)");
+    expect(sectionHeadFocus).toContain("outline-offset: -1px");
+
+    const chevrons = blocksOf(".repository-folder-chevron");
+    expect(chevrons[0]).toContain("width: 11px");
+    expect(chevrons[0]).toContain("height: 11px");
+    expect(chevrons[0]).toContain("color: var(--ink-fog)");
+    expect(chevrons[0]).toContain("transition: transform var(--duration-base) var(--ease-spring)");
+    expect(chevrons.some((body) => body.includes("transition-duration: 0.01ms"))).toBe(true);
+    expect(blockOf(".repository-ws-section.is-collapsed .repository-folder-chevron")).toContain("transform: rotate(-90deg)");
+  });
+
   it("retires legacy compare ref select chrome", () => {
     expect(css).not.toMatch(/\.repository-compare-select\b/);
   });

--- a/runtime/fleet-plugins/repository/tests/workspace-tree-sections.test.ts
+++ b/runtime/fleet-plugins/repository/tests/workspace-tree-sections.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+
+import type { ReactElement, ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hookHarness = vi.hoisted(() => {
+  let cursor = 0;
+  let values: unknown[] = [];
+  return {
+    beginRender(): void {
+      cursor = 0;
+    },
+    reset(): void {
+      cursor = 0;
+      values = [];
+    },
+    useState<T>(initial: T | (() => T)): [T, (next: T | ((current: T) => T)) => void] {
+      const index = cursor++;
+      if (!(index in values)) values[index] = typeof initial === "function" ? (initial as () => T)() : initial;
+      return [
+        values[index] as T,
+        (next) => {
+          const current = values[index] as T;
+          values[index] = typeof next === "function" ? (next as (value: T) => T)(current) : next;
+        },
+      ];
+    },
+  };
+});
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return { ...actual, useState: hookHarness.useState };
+});
+
+import { WorkspaceTree } from "../client/rail-panel.js";
+
+type ElementProps = Record<string, unknown> & { readonly children?: ReactNode };
+
+function isElement(node: ReactNode): node is ReactElement<ElementProps> {
+  return typeof node === "object" && node !== null && "type" in node && "props" in node;
+}
+
+function childrenOf(node: ReactNode): readonly ReactNode[] {
+  if (!isElement(node)) return [];
+  const children = node.props.children;
+  return Array.isArray(children) ? children : [children];
+}
+
+function elementsByClass(node: ReactNode, className: string): ReactElement<ElementProps>[] {
+  const matches: ReactElement<ElementProps>[] = [];
+  if (isElement(node)) {
+    if (typeof node.props.className === "string" && node.props.className.split(" ").includes(className)) matches.push(node);
+    for (const child of childrenOf(node)) matches.push(...elementsByClass(child, className));
+  } else if (Array.isArray(node)) {
+    for (const child of node) matches.push(...elementsByClass(child, className));
+  }
+  return matches;
+}
+
+function textOf(node: ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textOf).join("");
+  return childrenOf(node).map(textOf).join("");
+}
+
+function renderWorkspaceTree(): ReactElement<ElementProps> {
+  hookHarness.beginRender();
+  return WorkspaceTree({
+    repos: [{ relPath: ".", name: "fleet-harness", branch: "canary", kind: "root" }],
+    reposError: false,
+    reposTruncated: false,
+    scanDepth: 3,
+    worktrees: [{ relPath: ".fleet/worktrees/topic", name: "topic", branch: "topic", current: false }],
+    worktreesError: false,
+    refs: {
+      branches: [{ label: "canary", ref: "refs/heads/canary", current: true }],
+      remotes: [],
+      tags: [{ label: "v1.0.0", ref: "refs/tags/v1.0.0", current: false }],
+      stashes: [{ name: "stash@{0}", subject: "WIP" }],
+    },
+    refsError: false,
+    changedFiles: { kind: "ok", files: [] },
+    selectedRel: ".",
+    source: "history",
+    refFilter: null,
+    onRepository: vi.fn(),
+    onScanDepth: vi.fn(),
+    onRetryRepos: vi.fn(),
+    onRetryWorktrees: vi.fn(),
+    onRetryRefs: vi.fn(),
+    onSource: vi.fn(),
+    onRef: vi.fn(),
+  });
+}
+
+function sectionState(tree: ReactElement<ElementProps>): Map<string, { readonly expanded: boolean; readonly count: string; readonly hasBody: boolean; readonly toggle: () => void }> {
+  return new Map(elementsByClass(tree, "repository-ws-section").map((section) => {
+    const [header, ...body] = childrenOf(section);
+    if (!isElement(header) || header.type !== "button") throw new Error("Expected a section header button");
+    const label = textOf(childrenOf(header)[1]).toLowerCase();
+    const toggle = header.props.onClick;
+    if (typeof toggle !== "function") throw new Error(`Missing toggle for ${label}`);
+    return [label, {
+      expanded: header.props["aria-expanded"] === true,
+      count: textOf(childrenOf(header)[2]),
+      hasBody: body.some((child) => child !== false && child !== null && child !== undefined),
+      toggle: toggle as () => void,
+    }];
+  }));
+}
+
+beforeEach(() => hookHarness.reset());
+
+describe("WorkspaceTree section collapse", () => {
+  it("starts with tags and stashes collapsed while preserving every count badge", () => {
+    const state = sectionState(renderWorkspaceTree());
+    expect([...state.keys()]).toEqual(["context", "working", "worktrees", "branches", "tags", "stashes"]);
+    expect(Object.fromEntries([...state].map(([id, section]) => [id, section.expanded]))).toEqual({
+      context: true,
+      working: true,
+      worktrees: true,
+      branches: true,
+      tags: false,
+      stashes: false,
+    });
+    expect(Object.fromEntries([...state].map(([id, section]) => [id, section.count]))).toEqual({
+      context: "1",
+      working: "0",
+      worktrees: "1",
+      branches: "1",
+      tags: "1",
+      stashes: "1",
+    });
+    expect(state.get("tags")?.hasBody).toBe(false);
+    expect(state.get("stashes")?.hasBody).toBe(false);
+  });
+
+  it("toggles expanded state and conditionally renders section bodies", () => {
+    const initial = sectionState(renderWorkspaceTree());
+    initial.get("tags")?.toggle();
+    initial.get("context")?.toggle();
+    initial.get("working")?.toggle();
+
+    const toggled = sectionState(renderWorkspaceTree());
+    expect(toggled.get("tags")).toMatchObject({ expanded: true, hasBody: true, count: "1" });
+    expect(toggled.get("context")).toMatchObject({ expanded: false, hasBody: false, count: "1" });
+    expect(toggled.get("working")).toMatchObject({ expanded: false, hasBody: false, count: "0" });
+  });
+});


### PR DESCRIPTION
## Summary
- Repository 패널 workspace tree의 6개 섹션(CONTEXT/WORKING/WORKTREES/BRANCHES/TAGS/STASHES) 헤더를 `button[aria-expanded]` + 기존 folder chevron 문법의 접기/펼치기 토글로 전환
- TAGS·STASHES는 기본 접힘(실측: 태그 122행이 트리 스크롤의 ~86% 점유), 접기 상태는 in-memory만 사용(비영속 계약), 접힌 상태에서도 카운트 배지 상시 표시
- 디자인 문법은 기존 토큰만 사용(hover `ink-fog` wash, focus-visible `brass` outline, chevron 회전 + reduced-motion 단락), `design-grammar` 계약 테스트 동반 갱신

## Test Plan
- [x] `pnpm --filter @fleet-plugins/repository test` (260 passed — 기본 접힘 상태/토글/카운트 유지 신규 컴포넌트 테스트 포함)
- [x] `pnpm --filter @fleet-plugins/repository typecheck` / `build`
- [x] 실브라우저 QA(격리 인스턴스, fleet-harness Theater): 기본 접힘·클릭 토글·키보드 Enter 왕복·brass 포커스 링·리로드 시 기본값 복귀 확인
- [x] `.changelog.d/pr-365.md` — fragment syntax·이중언어 요약·`compile-changelog-fragments.mjs --check` 검증 완료