### PR TITLE
feat(console): pin status-axis sections, add collapse and group pills

### DIFF
--- a/.changelog.d/pr-366.md
+++ b/.changelog.d/pr-366.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Changed
+- [fleet-console] Pin all four Sort by Status sections with per-section collapse toggles (empty sections stay dimmed and collapsed), replace group color dots with group name pills in the status axis, and switch the Theater actions icon to an ellipsis.
+  ko: Sort by Status의 4개 상태 섹션을 항상 표시하고 상태별 접기를 지원하며(빈 섹션은 흐리게 기본 접힘), 상태축의 그룹 색 dot를 그룹 이름 pill로 바꾸고 Theater actions 아이콘을 ellipsis로 교체합니다.

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -13,7 +13,7 @@ import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { RightRail } from "../rail/right-rail.js";
 import { OperationsSideBar } from "../sidebar/operations-side-bar.js";
-import { getSideBarStatusAxis, toggleSideBarStatusAxis } from "../sidebar/operations-side-bar-store.js";
+import { getSideBarStatusAxis, getSideBarStatusSectionCollapsed, toggleSideBarStatusAxis } from "../sidebar/operations-side-bar-store.js";
 import { CodexReadingSheet } from "../components/codex-reading-sheet.js";
 import { shouldHandleOperationsKeyboardShortcut } from "../components/keyboard-shortcuts-dialog.js";
 import { beginAddTheater, cancelAddTheater, compareOperationCreatedAt, completeAddTheater, consumeOperationFocus, failAddTheater, focusCycleOperationIds, focusOperation, getState, hydrateGroups, hydrateOperations, hydrateTheaters, nextOperationId, removeTheater, requestOperationKeyboardFocus, setActiveOperation, setActiveTheater, sortOperationsByOrder, statusCycleOperationIds } from "../store.js";
@@ -84,7 +84,14 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       const theaterOperations = snapshot.operations.filter((operation) => operation.theaterId === snapshot.activeTheaterId);
       // STATUS 축에서는 사이드바 가시 순서가 상태 섹션 순서이므로 순환도 같은 순서를 따른다.
       const order = getSideBarStatusAxis()
-        ? statusCycleOperationIds(theaterOperations, canvas.operationOrder, snapshot.operationStatus, canvas.minimized)
+        ? statusCycleOperationIds(
+            theaterOperations,
+            canvas.operationOrder,
+            snapshot.operationStatus,
+            canvas.minimized,
+            (status) => snapshot.activeTheaterId !== null
+              && getSideBarStatusSectionCollapsed(snapshot.activeTheaterId, status, false),
+          )
         : focusCycleOperationIds(
             theaterOperations,
             snapshot.groups.filter((g) => g.theaterId === snapshot.activeTheaterId),

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -21,6 +21,7 @@ interface SideBarChipProps {
   readonly isCloseArmed: boolean;
   readonly accentValue: string | null;
   readonly groupMark?: { readonly name: string; readonly color: string } | null;
+  readonly statusAxis?: boolean;
   readonly statusLanded?: boolean;
   readonly reorderEnabled?: boolean;
   readonly dragging: boolean;
@@ -45,6 +46,7 @@ export function OperationsSideBarChip({
   isCloseArmed,
   accentValue,
   groupMark = null,
+  statusAxis = false,
   statusLanded = false,
   reorderEnabled = true,
   dragging,
@@ -165,7 +167,16 @@ export function OperationsSideBarChip({
       {notificationCount > 0 ? (
         <span className="side-bar-chip-count">{notificationCount}</span>
       ) : null}
-      {groupMark ? (
+      {groupMark && statusAxis && !preview ? (
+        <span
+          className="side-bar-chip-group-pill"
+          title={groupMark.name}
+          aria-label={`Group ${groupMark.name}`}
+          style={{ "--group-mark": groupMark.color } as CSSProperties}
+        >
+          {groupMark.name}
+        </span>
+      ) : groupMark && !statusAxis ? (
         <span
           className="side-bar-chip-group-mark"
           title={groupMark.name}
@@ -173,12 +184,14 @@ export function OperationsSideBarChip({
           style={{ "--group-mark": groupMark.color } as CSSProperties}
         />
       ) : null}
-      <span
-        className={`side-bar-chip-status ${chipStatusClass(status)}`}
-        role="img"
-        aria-label={chipStatusLabel(status)}
-        title={chipStatusLabel(status)}
-      />
+      {!statusAxis ? (
+        <span
+          className={`side-bar-chip-status ${chipStatusClass(status)}`}
+          role="img"
+          aria-label={chipStatusLabel(status)}
+          title={chipStatusLabel(status)}
+        />
+      ) : null}
       {!preview && !minimized ? (
         <button
           type="button"

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -66,6 +66,10 @@ export function OperationsSideBarChip({
   const suppressClickRef = useRef(false);
   const { operation, active, minimized, notificationCount, status } = entry;
   const title = displayTitle(operation);
+  const groupContext = statusAxis && groupMark ? ` in group ${groupMark.name}` : "";
+  const chipAriaLabel = active
+    ? `${title}${groupContext} (focused)`
+    : `Focus operation ${title}${groupContext}`;
   const rename = useInlineRename({ currentTitle: title, onCommit: (next) => onRename(operation.id, next), onBegin: onDisarmClose });
   const chipClassName = [
     "side-bar-chip",
@@ -117,7 +121,7 @@ export function OperationsSideBarChip({
       className={chipClassName}
       role="button"
       tabIndex={0}
-      aria-label={active ? `${title} (focused)` : `Focus operation ${title}`}
+      aria-label={chipAriaLabel}
       aria-current={active ? "true" : undefined}
       title={preview ? "Click to open in its Theater" : active ? "Focused · double-click to rename · right-click to set accent" : "Click to focus · double-click to rename · right-click to set accent"}
       style={chipStyle}
@@ -171,7 +175,7 @@ export function OperationsSideBarChip({
         <span
           className="side-bar-chip-group-pill"
           title={groupMark.name}
-          aria-label={`Group ${groupMark.name}`}
+          aria-hidden="true"
           style={{ "--group-mark": groupMark.color } as CSSProperties}
         >
           {groupMark.name}

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
@@ -1,4 +1,4 @@
-import { useSyncExternalStore } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 interface SideBarState {
   readonly width: number;
@@ -46,9 +46,12 @@ export function useSideBarStatusAxis(): boolean {
 export function useSideBarStatusSectionCollapsed(
   theaterId: string,
   status: SideBarStatus,
-  entries: readonly unknown[],
+  empty: boolean,
 ): boolean {
-  const getSnapshot = () => getSideBarStatusSectionCollapsed(theaterId, status, entries);
+  const getSnapshot = useCallback(
+    () => getSideBarStatusSectionCollapsed(theaterId, status, empty),
+    [theaterId, status, empty],
+  );
   return useSyncExternalStore(subscribeStatusSectionCollapse, getSnapshot, getSnapshot);
 }
 
@@ -106,21 +109,21 @@ export function subscribeStatusAxis(listener: () => void): () => void {
 export function getSideBarStatusSectionCollapsed(
   theaterId: string,
   status: SideBarStatus,
-  entries: readonly unknown[],
+  empty: boolean,
 ): boolean {
   const key = statusSectionKey(theaterId, status);
   if (userCollapsedStatusSections.has(key)) return true;
   if (userExpandedStatusSections.has(key)) return false;
-  return entries.length === 0;
+  return empty;
 }
 
 export function toggleSideBarStatusSectionCollapsed(
   theaterId: string,
   status: SideBarStatus,
-  entries: readonly unknown[],
+  empty: boolean,
 ): void {
   const key = statusSectionKey(theaterId, status);
-  if (getSideBarStatusSectionCollapsed(theaterId, status, entries)) {
+  if (getSideBarStatusSectionCollapsed(theaterId, status, empty)) {
     userCollapsedStatusSections = new Set(userCollapsedStatusSections);
     userCollapsedStatusSections.delete(key);
     userExpandedStatusSections = new Set(userExpandedStatusSections).add(key);
@@ -135,6 +138,11 @@ export function toggleSideBarStatusSectionCollapsed(
 export function subscribeStatusSectionCollapse(listener: () => void): () => void {
   statusSectionCollapseListeners.add(listener);
   return () => statusSectionCollapseListeners.delete(listener);
+}
+
+export function resetSideBarStatusSectionCollapseForTests(): void {
+  userCollapsedStatusSections = new Set();
+  userExpandedStatusSections = new Set();
 }
 
 function statusSectionKey(theaterId: string, status: SideBarStatus): string {

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
@@ -14,6 +14,7 @@ const DEFAULT_WIDTH = MIN_EXPANDED_PX;
 const sideBarListeners = new Set<() => void>();
 const collapsedTheaterListeners = new Set<() => void>();
 const statusAxisListeners = new Set<() => void>();
+const statusSectionCollapseListeners = new Set<() => void>();
 
 let sideBarState: SideBarState = {
   width: readInitialWidth(),
@@ -23,6 +24,12 @@ let collapsedTheaterIds = readInitialCollapsedTheaters();
 // STATUS 축은 의도적으로 세션 메모리에만 둔다. localStorage나 durable canvas state에
 // 합류시키지 않아 새 페이지 로드마다 GROUP 축(false)에서 시작한다.
 let statusAxis = false;
+// STATUS 섹션 접힘도 같은 비영속 축이다. 빈 섹션의 기본 접힘과 사용자가 명시한
+// 접기/펼치기를 구분하려고 두 집합을 유지하며 localStorage에는 기록하지 않는다.
+let userCollapsedStatusSections = new Set<string>();
+let userExpandedStatusSections = new Set<string>();
+
+export type SideBarStatus = "awaiting" | "running" | "idle" | "dormant";
 
 export function useSideBarState(): SideBarState {
   return useSyncExternalStore(subscribeSideBarState, getSideBarState, getSideBarState);
@@ -34,6 +41,15 @@ export function useCollapsedTheaters(): readonly string[] {
 
 export function useSideBarStatusAxis(): boolean {
   return useSyncExternalStore(subscribeStatusAxis, getSideBarStatusAxis, getSideBarStatusAxis);
+}
+
+export function useSideBarStatusSectionCollapsed(
+  theaterId: string,
+  status: SideBarStatus,
+  entries: readonly unknown[],
+): boolean {
+  const getSnapshot = () => getSideBarStatusSectionCollapsed(theaterId, status, entries);
+  return useSyncExternalStore(subscribeStatusSectionCollapse, getSnapshot, getSnapshot);
 }
 
 export function setSideBarWidth(width: number): void {
@@ -85,6 +101,44 @@ export function getSideBarStatusAxis(): boolean {
 export function subscribeStatusAxis(listener: () => void): () => void {
   statusAxisListeners.add(listener);
   return () => statusAxisListeners.delete(listener);
+}
+
+export function getSideBarStatusSectionCollapsed(
+  theaterId: string,
+  status: SideBarStatus,
+  entries: readonly unknown[],
+): boolean {
+  const key = statusSectionKey(theaterId, status);
+  if (userCollapsedStatusSections.has(key)) return true;
+  if (userExpandedStatusSections.has(key)) return false;
+  return entries.length === 0;
+}
+
+export function toggleSideBarStatusSectionCollapsed(
+  theaterId: string,
+  status: SideBarStatus,
+  entries: readonly unknown[],
+): void {
+  const key = statusSectionKey(theaterId, status);
+  if (getSideBarStatusSectionCollapsed(theaterId, status, entries)) {
+    userCollapsedStatusSections = new Set(userCollapsedStatusSections);
+    userCollapsedStatusSections.delete(key);
+    userExpandedStatusSections = new Set(userExpandedStatusSections).add(key);
+  } else {
+    userExpandedStatusSections = new Set(userExpandedStatusSections);
+    userExpandedStatusSections.delete(key);
+    userCollapsedStatusSections = new Set(userCollapsedStatusSections).add(key);
+  }
+  for (const listener of statusSectionCollapseListeners) listener();
+}
+
+export function subscribeStatusSectionCollapse(listener: () => void): () => void {
+  statusSectionCollapseListeners.add(listener);
+  return () => statusSectionCollapseListeners.delete(listener);
+}
+
+function statusSectionKey(theaterId: string, status: SideBarStatus): string {
+  return `${theaterId}:${status}`;
 }
 
 function getMaxPx(): number {

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -17,7 +17,18 @@ import { SideBarBrandFoot } from "../components/side-bar-brand-foot.js";
 import { applyVisibleReorder, groupDropIndexFromPoint, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderGroupIds, reorderTheaterIds, reorderWithinSegment, theaterDropIndexFromPoint, type DropSectionInfo } from "./operations-side-bar-hit-test.js";
 import { OperationsSideBarChip, type SideBarEntry } from "./operations-side-bar-chip.js";
 import { OperationsSideBarGroupHeader } from "./operations-side-bar-group-header.js";
-import { setSideBarCollapsed, setSideBarWidth, setTheaterCollapsed, toggleSideBarStatusAxis, useCollapsedTheaters, useSideBarState, useSideBarStatusAxis } from "./operations-side-bar-store.js";
+import {
+  setSideBarCollapsed,
+  setSideBarWidth,
+  setTheaterCollapsed,
+  toggleSideBarStatusAxis,
+  toggleSideBarStatusSectionCollapsed,
+  useCollapsedTheaters,
+  useSideBarState,
+  useSideBarStatusAxis,
+  useSideBarStatusSectionCollapsed,
+  type SideBarStatus,
+} from "./operations-side-bar-store.js";
 import { resolveOperationLaunchKind } from "./resolve-launch-kind.js";
 
 interface OperationsSideBarProps {
@@ -170,8 +181,6 @@ const AUTO_SCROLL_EDGE_PX = 34;
 const AUTO_SCROLL_STEP_PX = 18;
 const STATUS_LANDING_DURATION_MS = 500;
 
-type SideBarStatus = OperationActivity;
-
 interface StatusSection {
   readonly status: SideBarStatus;
   readonly label: "AWAITING INPUT" | "RUNNING" | "IDLE" | "DORMANT";
@@ -184,6 +193,61 @@ const STATUS_SECTION_ORDER: readonly Omit<StatusSection, "entries">[] = [
   { status: "idle", label: "IDLE" },
   { status: "dormant", label: "DORMANT" },
 ];
+
+function StatusSectionSlot({
+  theaterId,
+  section,
+  children,
+}: {
+  readonly theaterId: string;
+  readonly section: StatusSection;
+  readonly children: ReactNode;
+}) {
+  const collapsed = useSideBarStatusSectionCollapsed(theaterId, section.status, section.entries);
+  const empty = section.entries.length === 0;
+  return (
+    <li
+      className={[
+        "side-bar-status-section",
+        `side-bar-status-section--${section.status}`,
+        empty ? "side-bar-status-section--empty" : "",
+      ].filter(Boolean).join(" ")}
+    >
+      <div className={`side-bar-status-header side-bar-status-header--${section.status}`}>
+        <button
+          type="button"
+          className="side-bar-status-header__toggle"
+          onClick={() => toggleSideBarStatusSectionCollapsed(theaterId, section.status, section.entries)}
+          aria-expanded={!collapsed}
+          aria-label={`${collapsed ? "Expand" : "Collapse"} section ${section.label}`}
+          title={collapsed ? "Expand" : "Collapse"}
+        >
+          <StatusSectionCollapseArrow collapsed={collapsed} />
+        </button>
+        <span className="side-bar-status-header__dot" aria-hidden="true" />
+        <span className="side-bar-status-header__label">{section.label}</span>
+        <span className="side-bar-status-header__count">{section.entries.length}</span>
+      </div>
+      {!collapsed ? (
+        <ol className="side-bar-group-chips" aria-label={`${section.label} operations`}>
+          {empty ? <li className="side-bar-status-empty-hint">No operations</li> : children}
+        </ol>
+      ) : null}
+    </li>
+  );
+}
+
+function StatusSectionCollapseArrow({ collapsed }: { readonly collapsed: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 12 12"
+      aria-hidden="true"
+      className={`side-bar-status-header__arrow${collapsed ? " is-collapsed" : ""}`}
+    >
+      <path d="M3 5l3 3 3-3" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
 export function OperationsSideBar({
   theaters,
   activeTheaterId,
@@ -809,48 +873,43 @@ export function OperationsSideBar({
               {!theaterCollapsed ? (
               <ol className="side-bar-theater-groups" aria-label={`${theater.label} operations`}>
                 {statusAxis ? statusSections.map((section) => (
-                  <li
+                  <StatusSectionSlot
                     key={section.status}
-                    className={`side-bar-status-section side-bar-status-section--${section.status}`}
+                    theaterId={theater.id}
+                    section={section}
                   >
-                    <div className={`side-bar-status-header side-bar-status-header--${section.status}`}>
-                      <span className="side-bar-status-header__dot" aria-hidden="true" />
-                      <span className="side-bar-status-header__label">{section.label}</span>
-                      <span className="side-bar-status-header__count">{section.entries.length}</span>
-                    </div>
-                    <ol className="side-bar-group-chips" aria-label={`${section.label} operations`}>
-                      {section.entries.map((entry) => {
-                        const globalIndex = entryIndexById.get(entry.operation.id) ?? 0;
-                        const accentKey = canvas.operationAccent[entry.operation.id] ?? operationAccentFromNode(entry.operation);
-                        const accentValue = accentKey ? resolveAccentColor(accentKey) : null;
-                        const groupMark = entry.operation.groupId ? groupMarkByGroupId.get(entry.operation.groupId) ?? null : null;
-                        return (
-                          <OperationsSideBarChip
-                            key={entry.operation.id}
-                            entry={entry}
-                            index={globalIndex}
-                            isCloseArmed={armedCloseId === entry.operation.id}
-                            accentValue={accentValue}
-                            groupMark={groupMark}
-                            statusLanded={statusLandingIds.has(entry.operation.id)}
-                            reorderEnabled={false}
-                            dragging={false}
-                            dragOffsetY={0}
-                            dropTarget={false}
-                            onArmClose={armClose}
-                            onDisarmClose={disarmClose}
-                            onClose={onClose}
-                            onMinimize={onMinimize}
-                            onFocus={onFocus}
-                            onKeyboardMove={keyboardMove}
-                            onPointerDragStart={beginPointerDrag}
-                            onOpenAccent={(operationId, anchor) => setActiveContextMenu({ kind: "chip", operationId, anchor })}
-                            onRename={onRename}
-                          />
-                        );
-                      })}
-                    </ol>
-                  </li>
+                    {section.entries.map((entry) => {
+                      const globalIndex = entryIndexById.get(entry.operation.id) ?? 0;
+                      const accentKey = canvas.operationAccent[entry.operation.id] ?? operationAccentFromNode(entry.operation);
+                      const accentValue = accentKey ? resolveAccentColor(accentKey) : null;
+                      const groupMark = entry.operation.groupId ? groupMarkByGroupId.get(entry.operation.groupId) ?? null : null;
+                      return (
+                        <OperationsSideBarChip
+                          key={entry.operation.id}
+                          entry={entry}
+                          index={globalIndex}
+                          isCloseArmed={armedCloseId === entry.operation.id}
+                          accentValue={accentValue}
+                          groupMark={groupMark}
+                          statusAxis
+                          statusLanded={statusLandingIds.has(entry.operation.id)}
+                          reorderEnabled={false}
+                          dragging={false}
+                          dragOffsetY={0}
+                          dropTarget={false}
+                          onArmClose={armClose}
+                          onDisarmClose={disarmClose}
+                          onClose={onClose}
+                          onMinimize={onMinimize}
+                          onFocus={onFocus}
+                          onKeyboardMove={keyboardMove}
+                          onPointerDragStart={beginPointerDrag}
+                          onOpenAccent={(operationId, anchor) => setActiveContextMenu({ kind: "chip", operationId, anchor })}
+                          onRename={onRename}
+                        />
+                      );
+                    })}
+                  </StatusSectionSlot>
                 )) : groupedSections.map((section) => {
           const isCollapsed = section.groupId !== null && collapsedGroupSet.has(section.groupId);
           const grpColor = section.group ? resolveAccentColor(section.group.color) : null;
@@ -1060,10 +1119,11 @@ export function groupOperations(
 }
 
 export function groupOperationsByStatus(entries: readonly SideBarEntry[]): StatusSection[] {
-  return STATUS_SECTION_ORDER.flatMap(({ status, label }) => {
-    const members = entries.filter((entry) => normalizeOperationStatus(entry.status) === status);
-    return members.length > 0 ? [{ status, label, entries: members }] : [];
-  });
+  return STATUS_SECTION_ORDER.map(({ status, label }) => ({
+    status,
+    label,
+    entries: entries.filter((entry) => normalizeOperationStatus(entry.status) === status),
+  }));
 }
 
 export function hasAwaitingOperation(
@@ -1240,7 +1300,7 @@ function TheaterSectionHeader({
               onOpenActions(event.currentTarget.getBoundingClientRect(), event.currentTarget);
             }}
           >
-            <CaretIcon />
+            <TheaterActionsIcon />
           </button>
         </span>
       </span>
@@ -1305,47 +1365,42 @@ function TheaterInactiveSection({
       {!collapsed && (statusAxis ? statusSections.length : sections.length) > 0 ? (
         <ol className="side-bar-theater-groups" aria-label={`${theater.label} operations`}>
           {statusAxis ? statusSections.map((section) => (
-            <li
+            <StatusSectionSlot
               key={section.status}
-              className={`side-bar-status-section side-bar-status-section--${section.status}`}
+              theaterId={theater.id}
+              section={section}
             >
-              <div className={`side-bar-status-header side-bar-status-header--${section.status}`}>
-                <span className="side-bar-status-header__dot" aria-hidden="true" />
-                <span className="side-bar-status-header__label">{section.label}</span>
-                <span className="side-bar-status-header__count">{section.entries.length}</span>
-              </div>
-              <ol className="side-bar-group-chips" aria-label={`${section.label} operations`}>
-                {section.entries.map((entry, index) => {
-                  const accentKey = operationAccent[entry.operation.id] ?? operationAccentFromNode(entry.operation);
-                  const accentValue = accentKey ? resolveAccentColor(accentKey) : null;
-                  return (
-                    <OperationsSideBarChip
-                      key={entry.operation.id}
-                      entry={entry}
-                      index={index}
-                      isCloseArmed={false}
-                      accentValue={accentValue}
-                      groupMark={resolveEntryGroupMark(entry, groups)}
-                      statusLanded={statusLandingIds.has(entry.operation.id)}
-                      reorderEnabled={false}
-                      dragging={false}
-                      dragOffsetY={0}
-                      dropTarget={false}
-                      preview
-                      onArmClose={() => {}}
-                      onDisarmClose={() => {}}
-                      onClose={() => {}}
-                      onMinimize={() => {}}
-                      onFocus={onFocus}
-                      onKeyboardMove={() => {}}
-                      onPointerDragStart={() => {}}
-                      onOpenAccent={() => {}}
-                      onRename={() => {}}
-                    />
-                  );
-                })}
-              </ol>
-            </li>
+              {section.entries.map((entry, index) => {
+                const accentKey = operationAccent[entry.operation.id] ?? operationAccentFromNode(entry.operation);
+                const accentValue = accentKey ? resolveAccentColor(accentKey) : null;
+                return (
+                  <OperationsSideBarChip
+                    key={entry.operation.id}
+                    entry={entry}
+                    index={index}
+                    isCloseArmed={false}
+                    accentValue={accentValue}
+                    groupMark={resolveEntryGroupMark(entry, groups)}
+                    statusAxis
+                    statusLanded={statusLandingIds.has(entry.operation.id)}
+                    reorderEnabled={false}
+                    dragging={false}
+                    dragOffsetY={0}
+                    dropTarget={false}
+                    preview
+                    onArmClose={() => {}}
+                    onDisarmClose={() => {}}
+                    onClose={() => {}}
+                    onMinimize={() => {}}
+                    onFocus={onFocus}
+                    onKeyboardMove={() => {}}
+                    onPointerDragStart={() => {}}
+                    onOpenAccent={() => {}}
+                    onRename={() => {}}
+                  />
+                );
+              })}
+            </StatusSectionSlot>
           )) : sections.map((section) => {
             const isCollapsed = section.groupId !== null && collapsedGroups.has(section.groupId);
             const grpColor = section.group ? resolveAccentColor(section.group.color) : null;
@@ -1542,10 +1597,12 @@ function StatusListIcon() {
   );
 }
 
-function CaretIcon() {
+function TheaterActionsIcon() {
   return (
     <svg viewBox="0 0 16 16" aria-hidden="true">
-      <path d="m5.2 6.6 2.8 2.8 2.8-2.8" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <circle cx="3.2" cy="8" r="1.35" fill="currentColor" />
+      <circle cx="8" cy="8" r="1.35" fill="currentColor" />
+      <circle cx="12.8" cy="8" r="1.35" fill="currentColor" />
     </svg>
   );
 }

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -203,8 +203,8 @@ function StatusSectionSlot({
   readonly section: StatusSection;
   readonly children: ReactNode;
 }) {
-  const collapsed = useSideBarStatusSectionCollapsed(theaterId, section.status, section.entries);
   const empty = section.entries.length === 0;
+  const collapsed = useSideBarStatusSectionCollapsed(theaterId, section.status, empty);
   return (
     <li
       className={[
@@ -217,7 +217,7 @@ function StatusSectionSlot({
         <button
           type="button"
           className="side-bar-status-header__toggle"
-          onClick={() => toggleSideBarStatusSectionCollapsed(theaterId, section.status, section.entries)}
+          onClick={() => toggleSideBarStatusSectionCollapsed(theaterId, section.status, empty)}
           aria-expanded={!collapsed}
           aria-label={`${collapsed ? "Expand" : "Collapse"} section ${section.label}`}
           title={collapsed ? "Expand" : "Collapse"}

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -437,7 +437,7 @@ export function focusCycleOperationIds(
 
 // STATUS 축의 Alt+←/→ 순환 순서: 사이드바 STATUS 섹션의 가시 순서와 동일하게
 // awaiting → running → idle → dormant 랭크로 안정 정렬한다(랭크 내부는 operationOrder 순서 유지).
-// STATUS 축은 그룹 접힘이 없으므로 collapsedGroups는 적용하지 않는다.
+// 그룹 접힘은 적용하지 않되, 상태 섹션 접힘 predicate로 사이드바에서 숨은 Operation을 제외한다.
 const STATUS_CYCLE_RANK: Readonly<Record<OperationActivity, number>> = { awaiting: 0, running: 1, idle: 2, dormant: 3 };
 
 export function statusCycleOperationIds(
@@ -445,12 +445,14 @@ export function statusCycleOperationIds(
   operationOrder: readonly string[],
   operationStatus: Readonly<Record<string, OperationActivity>>,
   minimized: readonly string[],
+  isStatusSectionCollapsed: (status: OperationActivity) => boolean,
 ): readonly string[] {
   const minimizedIds = new Set(minimized);
-  const rank = (operation: OperationNode): number => STATUS_CYCLE_RANK[operationStatus[operation.id] ?? "idle"];
+  const status = (operation: OperationNode): OperationActivity => operationStatus[operation.id] ?? "idle";
+  const rank = (operation: OperationNode): number => STATUS_CYCLE_RANK[status(operation)];
   return [...sortOperationsByOrder(operations, operationOrder)]
     .sort((left, right) => rank(left) - rank(right))
-    .filter((operation) => !minimizedIds.has(operation.id))
+    .filter((operation) => !minimizedIds.has(operation.id) && !isStatusSectionCollapsed(status(operation)))
     .map((operation) => operation.id);
 }
 

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2716,8 +2716,8 @@
   background: var(--ink-fog);
 }
 
-/* STATUS 축의 그룹 mark는 identity 채널만 사용한다. 그룹의 resolveAccentColor(--id-*) 값은
-   기존 operation spine과 독립된 7px mark로만 표시하고 status beacon 신호면을 덮지 않는다. */
+/* 그룹 mark와 STATUS 축 pill은 identity 채널만 사용한다. 그룹의 resolveAccentColor(--id-*) 값은
+   기존 operation spine과 독립된 mark/pill로만 표시하고 signal 색을 identity에 재사용하지 않는다. */
 .side-bar-chip-group-mark {
   display: block;
   flex: none;
@@ -2725,6 +2725,23 @@
   height: 7px;
   border-radius: 999px;
   background: var(--group-mark);
+}
+
+.side-bar-chip-group-pill {
+  flex: none;
+  max-width: 88px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 2px 7px;
+  border: 1px solid color-mix(in oklch, var(--group-mark) 34%, transparent);
+  border-radius: 999px;
+  color: color-mix(in oklch, var(--group-mark) 85%, var(--ink-pearl));
+  background: color-mix(in oklch, var(--group-mark) 13%, transparent);
 }
 
 .side-bar-chip--status-landed {
@@ -2900,13 +2917,48 @@
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 7px 12px;
+  padding: 7px 12px 7px 8px;
   background: color-mix(in oklch, var(--status-color) 8%, transparent);
   color: var(--ink-fog);
   font-family: var(--font-mono);
   font-size: 10.5px;
   font-weight: 700;
   letter-spacing: 0.12em;
+}
+
+.side-bar-status-section--empty .side-bar-status-header {
+  opacity: 0.55;
+}
+
+.side-bar-status-header__toggle {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--ink-fog);
+  border-radius: var(--radius-sm);
+  transition: color var(--duration-fast) var(--ease-spring);
+}
+
+.side-bar-status-header__toggle:hover,
+.side-bar-status-header__toggle:focus-visible {
+  color: var(--ink-spectral);
+  outline: none;
+}
+
+.side-bar-status-header__arrow {
+  width: 12px;
+  height: 12px;
+  transition: transform var(--duration-fast) var(--ease-spring);
+}
+
+.side-bar-status-header__arrow.is-collapsed {
+  transform: rotate(-90deg);
 }
 
 .side-bar-status-header__dot {
@@ -2916,6 +2968,10 @@
   height: 7px;
   border-radius: 999px;
   background: var(--status-color);
+}
+
+.side-bar-status-section--empty .side-bar-status-header__dot {
+  opacity: 0.4;
 }
 
 .side-bar-status-header--awaiting .side-bar-status-header__dot {
@@ -2929,6 +2985,14 @@
   color: color-mix(in oklch, var(--status-color) 65%, var(--ink-pearl));
   font-variant-numeric: tabular-nums;
   text-align: right;
+}
+
+.side-bar-status-empty-hint {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-style: italic;
+  color: var(--ink-muted);
+  padding: 6px 12px 8px 27px;
 }
 
 .side-bar-ungrouped-section {
@@ -3080,6 +3144,10 @@
   }
 
   .side-bar-group-header__arrow {
+    transition: none;
+  }
+
+  .side-bar-status-header__arrow {
     transition: none;
   }
 }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2978,6 +2978,12 @@
   animation: aurora-pulse 1.8s infinite;
 }
 
+/* 빈 섹션은 주의 신호를 낼 상태가 없으므로 awaiting pulse도 끈다 — count 0에서
+   맥동하는 dot은 "대기 입력이 있다"는 거짓 신호가 된다(명시도 우위로 pulse 규칙을 덮는다). */
+.side-bar-status-section--empty .side-bar-status-header--awaiting .side-bar-status-header__dot {
+  animation: none;
+}
+
 .side-bar-status-header__count {
   flex: none;
   min-width: 14px;

--- a/runtime/fleet-console/tests/operation-focus.test.ts
+++ b/runtime/fleet-console/tests/operation-focus.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  getSideBarStatusSectionCollapsed,
+  resetSideBarStatusSectionCollapseForTests,
+  toggleSideBarStatusSectionCollapsed,
+} from "../core/client/src/sidebar/operations-side-bar-store.js";
 import { focusCycleOperationIds, getState, nextOperationId, requestOperationKeyboardFocus, setState, statusCycleOperationIds } from "../core/client/src/store.js";
 import type { OperationGroup, OperationNode } from "../core/client/src/types.js";
 
@@ -118,6 +123,7 @@ describe("statusCycleOperationIds — STATUS 축 Alt+←/→ 순환", () => {
       ["idle-early", "idle-late", "running-1", "awaiting-1", "dormant-1"],
       { "running-1": "running", "awaiting-1": "awaiting", "dormant-1": "dormant" },
       [],
+      () => false,
     );
     // 사이드바 STATUS 섹션과 동일한 가시 순서: 접힌 그룹 소속이어도 제외되지 않는다.
     expect(order).toEqual(["awaiting-1", "running-1", "idle-early", "idle-late", "dormant-1"]);
@@ -133,7 +139,42 @@ describe("statusCycleOperationIds — STATUS 축 Alt+←/→ 순환", () => {
       ["plain", "minimized-awaiting"],
       { "minimized-awaiting": "awaiting" },
       ["minimized-awaiting"],
+      () => false,
     );
     expect(order).toEqual(["plain"]);
+  });
+
+  it("excludes explicitly collapsed status sections, restores them when expanded, and leaves GROUP cycling unchanged", () => {
+    resetSideBarStatusSectionCollapseForTests();
+    const operations = [
+      makeOperation("awaiting"),
+      makeOperation("running"),
+      makeOperation("idle"),
+    ];
+    const operationOrder = operations.map((operation) => operation.id);
+    const operationStatus = { awaiting: "awaiting", running: "running" } as const;
+    const statusOrder = () => statusCycleOperationIds(
+      operations,
+      operationOrder,
+      operationStatus,
+      [],
+      (status) => getSideBarStatusSectionCollapsed("theater", status, false),
+    );
+
+    try {
+      expect(statusOrder()).toEqual(["awaiting", "running", "idle"]);
+
+      toggleSideBarStatusSectionCollapsed("theater", "running", false);
+
+      expect(statusOrder()).toEqual(["awaiting", "idle"]);
+      expect(focusCycleOperationIds(operations, [], operationOrder, [], []))
+        .toEqual(["awaiting", "running", "idle"]);
+
+      toggleSideBarStatusSectionCollapsed("theater", "running", false);
+
+      expect(statusOrder()).toEqual(["awaiting", "running", "idle"]);
+    } finally {
+      resetSideBarStatusSectionCollapseForTests();
+    }
   });
 });

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -37,7 +37,7 @@ afterEach(() => {
 });
 
 describe("OperationsSideBar STATUS axis", () => {
-  it("toggles from GROUP to ordered status sections, hides the live tick, and keeps group identity marks", () => {
+  it("toggles from GROUP to ordered status sections, hides the live tick, and renders group identity pills without row beacons", () => {
     const operations = [
       makeOperation("idle", null),
       makeOperation("running", "group-a"),
@@ -72,9 +72,55 @@ describe("OperationsSideBar STATUS axis", () => {
     ]);
     expect(container?.querySelector(".side-bar-group-header")).toBeNull();
     expect(required<HTMLElement>('[data-side-bar-chip-id="awaiting"]').style.getPropertyValue("--user-accent")).toBe("var(--id-rose)");
-    expect(required<HTMLElement>('[data-side-bar-chip-id="awaiting"] .side-bar-chip-group-mark').title).toBe("Alpha crew");
-    expect(container?.querySelector('[data-side-bar-chip-id="idle"] .side-bar-chip-group-mark')).toBeNull();
+    const pill = required<HTMLElement>('[data-side-bar-chip-id="awaiting"] .side-bar-chip-group-pill');
+    expect(pill.title).toBe("Alpha crew");
+    expect(pill.getAttribute("aria-label")).toBe("Group Alpha crew");
+    expect(pill.textContent).toBe("Alpha crew");
+    expect(pill.style.getPropertyValue("--group-mark")).toBe("var(--id-cerulean)");
+    expect(container?.querySelector('[data-side-bar-chip-id="awaiting"] .side-bar-chip-group-mark')).toBeNull();
+    expect(container?.querySelector('[data-side-bar-chip-id="awaiting"] .side-bar-chip-status')).toBeNull();
+    expect(container?.querySelector('[data-side-bar-chip-id="idle"] .side-bar-chip-group-pill')).toBeNull();
     expect(required<HTMLElement>('[data-side-bar-chip-id="awaiting"]').dataset.reorderEnabled).toBe("false");
+  });
+
+  it("pins all four slots, defaults empty sections collapsed, and toggles empty and occupied sections independently", () => {
+    setConsoleState({ operationStatus: { only: "running" } });
+    setSideBarStatusAxis(true);
+    renderSideBar([makeOperation("only", null)]);
+
+    const sections = Array.from(container?.querySelectorAll<HTMLElement>(".side-bar-status-section") ?? []);
+    expect(sections).toHaveLength(4);
+    expect(sections.map((section) => section.querySelector(".side-bar-status-header__count")?.textContent)).toEqual(["0", "1", "0", "0"]);
+
+    const awaiting = required<HTMLElement>(".side-bar-status-section--awaiting");
+    expect(awaiting.className).toContain("side-bar-status-section--empty");
+    const awaitingToggle = required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Expand section AWAITING INPUT"]');
+    expect(awaitingToggle.getAttribute("aria-expanded")).toBe("false");
+    expect(awaiting.querySelector(".side-bar-status-empty-hint")).toBeNull();
+
+    act(() => awaitingToggle.click());
+
+    expect(required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Collapse section AWAITING INPUT"]').title).toBe("Collapse");
+    expect(required<HTMLElement>(".side-bar-status-section--awaiting .side-bar-status-empty-hint").textContent).toBe("No operations");
+
+    const runningToggle = required<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Collapse section RUNNING"]');
+    expect(runningToggle.getAttribute("aria-expanded")).toBe("true");
+    act(() => runningToggle.click());
+    expect(required<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Expand section RUNNING"]').title).toBe("Expand");
+    expect(container?.querySelector('[data-side-bar-chip-id="only"]')).toBeNull();
+    act(() => required<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Expand section RUNNING"]').click());
+    expect(container?.querySelector('[data-side-bar-chip-id="only"]')).not.toBeNull();
+  });
+
+  it("suppresses both group pills and status beacons in inactive Theater preview chips", () => {
+    setConsoleState({ operationStatus: { preview: "awaiting" } });
+    setSideBarStatusAxis(true);
+    renderSideBar([makeOperation("preview", "group-a")], [GROUP_A], vi.fn(), "theater-other");
+
+    const preview = required<HTMLElement>('[data-side-bar-chip-id="preview"]');
+    expect(preview.querySelector(".side-bar-chip-group-pill")).toBeNull();
+    expect(preview.querySelector(".side-bar-chip-group-mark")).toBeNull();
+    expect(preview.querySelector(".side-bar-chip-status")).toBeNull();
   });
 
   it("keeps keyboard reordering disabled in STATUS and unchanged in GROUP", () => {
@@ -133,6 +179,8 @@ describe("OperationsSideBar STATUS axis", () => {
     const caret = required<HTMLButtonElement>(".side-bar-theater-split-caret");
     expect(caret.getAttribute("aria-haspopup")).toBe("menu");
     expect(caret.getAttribute("aria-expanded")).toBe("false");
+    expect(caret.querySelectorAll("circle")).toHaveLength(3);
+    expect(caret.querySelector("path")).toBeNull();
 
     act(() => required<HTMLElement>(".side-bar-theater-header").click());
 

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -7,7 +7,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getSnapshot, loadForTheater, setOperationOrder } from "../core/client/src/canvas/canvas-store.js";
 import { OperationsSideBar } from "../core/client/src/sidebar/operations-side-bar.js";
-import { setSideBarCollapsed, setSideBarStatusAxis, setTheaterCollapsed } from "../core/client/src/sidebar/operations-side-bar-store.js";
+import {
+  resetSideBarStatusSectionCollapseForTests,
+  setSideBarCollapsed,
+  setSideBarStatusAxis,
+  setTheaterCollapsed,
+} from "../core/client/src/sidebar/operations-side-bar-store.js";
 import { setState as setConsoleState } from "../core/client/src/store.js";
 import type { OperationGroup, OperationNode, TheaterInfo } from "../core/client/src/types.js";
 
@@ -21,7 +26,9 @@ beforeEach(() => {
   window.localStorage.clear();
   setSideBarCollapsed(false);
   setSideBarStatusAxis(false);
+  resetSideBarStatusSectionCollapseForTests();
   setTheaterCollapsed("theater-a", false);
+  setTheaterCollapsed("theater-b", false);
   loadForTheater("theater-a");
   setConsoleState({ operationStatus: {} });
 });
@@ -32,6 +39,7 @@ afterEach(() => {
   root = null;
   container = null;
   setSideBarStatusAxis(false);
+  resetSideBarStatusSectionCollapseForTests();
   setConsoleState({ operationStatus: {} });
   loadForTheater(null);
 });
@@ -74,9 +82,12 @@ describe("OperationsSideBar STATUS axis", () => {
     expect(required<HTMLElement>('[data-side-bar-chip-id="awaiting"]').style.getPropertyValue("--user-accent")).toBe("var(--id-rose)");
     const pill = required<HTMLElement>('[data-side-bar-chip-id="awaiting"] .side-bar-chip-group-pill');
     expect(pill.title).toBe("Alpha crew");
-    expect(pill.getAttribute("aria-label")).toBe("Group Alpha crew");
+    expect(pill.getAttribute("aria-hidden")).toBe("true");
+    expect(pill.getAttribute("aria-label")).toBeNull();
     expect(pill.textContent).toBe("Alpha crew");
     expect(pill.style.getPropertyValue("--group-mark")).toBe("var(--id-cerulean)");
+    expect(required<HTMLElement>('[data-side-bar-chip-id="awaiting"]').getAttribute("aria-label"))
+      .toBe("Focus operation awaiting in group Alpha crew");
     expect(container?.querySelector('[data-side-bar-chip-id="awaiting"] .side-bar-chip-group-mark')).toBeNull();
     expect(container?.querySelector('[data-side-bar-chip-id="awaiting"] .side-bar-chip-status')).toBeNull();
     expect(container?.querySelector('[data-side-bar-chip-id="idle"] .side-bar-chip-group-pill')).toBeNull();
@@ -110,6 +121,49 @@ describe("OperationsSideBar STATUS axis", () => {
     expect(container?.querySelector('[data-side-bar-chip-id="only"]')).toBeNull();
     act(() => required<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Expand section RUNNING"]').click());
     expect(container?.querySelector('[data-side-bar-chip-id="only"]')).not.toBeNull();
+  });
+
+  it("keeps an explicit empty-section expansion when an Operation enters and leaves again", () => {
+    setSideBarStatusAxis(true);
+    renderSideBar([]);
+
+    act(() => required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Expand section AWAITING INPUT"]').click());
+    expect(required<HTMLElement>(".side-bar-status-section--awaiting .side-bar-status-empty-hint").textContent).toBe("No operations");
+
+    act(() => setConsoleState({ operationStatus: { arriving: "awaiting" } }));
+    rerenderSideBar([makeOperation("arriving", null)]);
+
+    expect(required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Collapse section AWAITING INPUT"]').getAttribute("aria-expanded")).toBe("true");
+    expect(container?.querySelector('[data-side-bar-chip-id="arriving"]')).not.toBeNull();
+
+    act(() => setConsoleState({ operationStatus: {} }));
+    rerenderSideBar([]);
+
+    expect(required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Collapse section AWAITING INPUT"]').getAttribute("aria-expanded")).toBe("true");
+    expect(required<HTMLElement>(".side-bar-status-section--awaiting .side-bar-status-empty-hint").textContent).toBe("No operations");
+  });
+
+  it("isolates the same status collapse toggle by Theater key", () => {
+    const operations = [
+      makeOperation("alpha-running", null),
+      makeOperation("bravo-running", null, undefined, THEATER_B.id),
+    ];
+    setConsoleState({ operationStatus: { "alpha-running": "running", "bravo-running": "running" } });
+    setSideBarStatusAxis(true);
+    renderSideBar(operations, [], vi.fn(), THEATER.id, [THEATER, THEATER_B]);
+
+    const alpha = required<HTMLElement>(`[data-theater-id="${THEATER.id}"]`);
+    const bravo = required<HTMLElement>(`[data-theater-id="${THEATER_B.id}"]`);
+    act(() => alpha.querySelector<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Collapse section RUNNING"]')?.click());
+
+    expect(alpha.querySelector('[data-side-bar-chip-id="alpha-running"]')).toBeNull();
+    expect(bravo.querySelector('[data-side-bar-chip-id="bravo-running"]')).not.toBeNull();
+    expect(bravo.querySelector('.side-bar-status-section--running [aria-label="Collapse section RUNNING"]')).not.toBeNull();
+
+    act(() => bravo.querySelector<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Collapse section RUNNING"]')?.click());
+
+    expect(alpha.querySelector('.side-bar-status-section--running [aria-label="Expand section RUNNING"]')).not.toBeNull();
+    expect(bravo.querySelector('.side-bar-status-section--running [aria-label="Expand section RUNNING"]')).not.toBeNull();
   });
 
   it("suppresses both group pills and status beacons in inactive Theater preview chips", () => {
@@ -209,12 +263,32 @@ function renderSideBar(
   groups: readonly OperationGroup[] = [],
   onSelectTheater = vi.fn(),
   activeTheaterId: string = THEATER.id,
+  theaters: readonly TheaterInfo[] = [THEATER],
 ): void {
   container = document.createElement("div");
   document.body.append(container);
   root = createRoot(container);
-  act(() => root?.render(createElement(MemoryRouter, null, createElement(OperationsSideBar, {
-    theaters: [THEATER],
+  act(() => root?.render(sideBarElement(operations, groups, onSelectTheater, activeTheaterId, theaters)));
+}
+
+function rerenderSideBar(
+  operations: readonly OperationNode[],
+  groups: readonly OperationGroup[] = [],
+  activeTheaterId: string = THEATER.id,
+  theaters: readonly TheaterInfo[] = [THEATER],
+): void {
+  act(() => root?.render(sideBarElement(operations, groups, vi.fn(), activeTheaterId, theaters)));
+}
+
+function sideBarElement(
+  operations: readonly OperationNode[],
+  groups: readonly OperationGroup[],
+  onSelectTheater: (theaterId: string) => void,
+  activeTheaterId: string,
+  theaters: readonly TheaterInfo[],
+) {
+  return createElement(MemoryRouter, null, createElement(OperationsSideBar, {
+    theaters,
     activeTheaterId,
     operations,
     groups,
@@ -244,7 +318,7 @@ function renderSideBar(
     onAddTheater: () => {},
     onCancelAddTheater: () => {},
     onForgetTheater: () => {},
-  }))));
+  }));
 }
 
 function required<T extends Element>(selector: string): T {
@@ -253,10 +327,10 @@ function required<T extends Element>(selector: string): T {
   return element;
 }
 
-function makeOperation(id: string, groupId: string | null, accent?: string): OperationNode {
+function makeOperation(id: string, groupId: string | null, accent?: string, theaterId: string = THEATER.id): OperationNode {
   return {
     id,
-    theaterId: THEATER.id,
+    theaterId,
     type: "shell",
     pluginId: "terminal",
     title: id,
@@ -275,6 +349,12 @@ const THEATER: TheaterInfo = {
   lastOpenedAt: "2026-01-01T00:00:00.000Z",
   hasWiki: false,
   activeAdmiralCount: 0,
+};
+
+const THEATER_B: TheaterInfo = {
+  ...THEATER,
+  id: "theater-b",
+  label: "Bravo",
 };
 
 const GROUP_A: OperationGroup = {

--- a/runtime/fleet-console/tests/operations-side-bar-store.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-store.test.ts
@@ -61,6 +61,34 @@ describe("two-state SideBar store", () => {
     expect(reloadedStore.getSideBarStatusAxis()).toBe(false);
     unsubscribe();
   });
+
+  it("derives per-Theater STATUS collapse from empty sections and keeps explicit overrides in memory only", async () => {
+    const store = await loadStore();
+    const listener = vi.fn();
+    const unsubscribe = store.subscribeStatusSectionCollapse(listener);
+    const empty: readonly unknown[] = [];
+    const occupied: readonly unknown[] = [{}];
+
+    expect(store.getSideBarStatusSectionCollapsed("theater-a", "awaiting", empty)).toBe(true);
+    expect(store.getSideBarStatusSectionCollapsed("theater-a", "running", occupied)).toBe(false);
+
+    store.toggleSideBarStatusSectionCollapsed("theater-a", "awaiting", empty);
+    expect(store.getSideBarStatusSectionCollapsed("theater-a", "awaiting", empty)).toBe(false);
+    expect(store.getSideBarStatusSectionCollapsed("theater-a", "awaiting", occupied)).toBe(false);
+
+    store.toggleSideBarStatusSectionCollapsed("theater-a", "awaiting", occupied);
+    expect(store.getSideBarStatusSectionCollapsed("theater-a", "awaiting", empty)).toBe(true);
+    expect(store.getSideBarStatusSectionCollapsed("theater-b", "awaiting", occupied)).toBe(false);
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(window.localStorage.length).toBe(0);
+
+    vi.resetModules();
+    const reloadedStore = await loadStore();
+    expect(reloadedStore.getSideBarStatusSectionCollapsed("theater-a", "awaiting", empty)).toBe(true);
+    expect(reloadedStore.getSideBarStatusSectionCollapsed("theater-a", "awaiting", occupied)).toBe(false);
+    unsubscribe();
+  });
 });
 
 async function loadStore() {

--- a/runtime/fleet-console/tests/operations-side-bar-store.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-store.test.ts
@@ -66,27 +66,25 @@ describe("two-state SideBar store", () => {
     const store = await loadStore();
     const listener = vi.fn();
     const unsubscribe = store.subscribeStatusSectionCollapse(listener);
-    const empty: readonly unknown[] = [];
-    const occupied: readonly unknown[] = [{}];
 
-    expect(store.getSideBarStatusSectionCollapsed("theater-a", "awaiting", empty)).toBe(true);
-    expect(store.getSideBarStatusSectionCollapsed("theater-a", "running", occupied)).toBe(false);
+    expect(store.getSideBarStatusSectionCollapsed("theater-a", "awaiting", true)).toBe(true);
+    expect(store.getSideBarStatusSectionCollapsed("theater-a", "running", false)).toBe(false);
 
-    store.toggleSideBarStatusSectionCollapsed("theater-a", "awaiting", empty);
-    expect(store.getSideBarStatusSectionCollapsed("theater-a", "awaiting", empty)).toBe(false);
-    expect(store.getSideBarStatusSectionCollapsed("theater-a", "awaiting", occupied)).toBe(false);
+    store.toggleSideBarStatusSectionCollapsed("theater-a", "awaiting", true);
+    expect(store.getSideBarStatusSectionCollapsed("theater-a", "awaiting", true)).toBe(false);
+    expect(store.getSideBarStatusSectionCollapsed("theater-a", "awaiting", false)).toBe(false);
 
-    store.toggleSideBarStatusSectionCollapsed("theater-a", "awaiting", occupied);
-    expect(store.getSideBarStatusSectionCollapsed("theater-a", "awaiting", empty)).toBe(true);
-    expect(store.getSideBarStatusSectionCollapsed("theater-b", "awaiting", occupied)).toBe(false);
+    store.toggleSideBarStatusSectionCollapsed("theater-a", "awaiting", false);
+    expect(store.getSideBarStatusSectionCollapsed("theater-a", "awaiting", true)).toBe(true);
+    expect(store.getSideBarStatusSectionCollapsed("theater-b", "awaiting", false)).toBe(false);
 
     expect(listener).toHaveBeenCalledTimes(2);
     expect(window.localStorage.length).toBe(0);
 
     vi.resetModules();
     const reloadedStore = await loadStore();
-    expect(reloadedStore.getSideBarStatusSectionCollapsed("theater-a", "awaiting", empty)).toBe(true);
-    expect(reloadedStore.getSideBarStatusSectionCollapsed("theater-a", "awaiting", occupied)).toBe(false);
+    expect(reloadedStore.getSideBarStatusSectionCollapsed("theater-a", "awaiting", true)).toBe(true);
+    expect(reloadedStore.getSideBarStatusSectionCollapsed("theater-a", "awaiting", false)).toBe(false);
     unsubscribe();
   });
 });


### PR DESCRIPTION
## Summary
- Sort by Status 모드를 고정 4슬롯 보드로 전환: AWAITING INPUT / RUNNING / IDLE / DORMANT 섹션이 비어 있어도 항상 표시되고, 빈 섹션은 dimmed + 기본 접힘(`No operations` 힌트)으로 동작합니다.
- 상태별 접기 토글을 추가합니다(그룹축 헤더와 동일한 chevron 문법, 상태는 세션 메모리만 — statusAxis의 기존 비영속 계약 준수).
- 상태축에서 그룹 소속 표시를 7px 색 dot에서 그룹명 pill(`--id-*` mark+wash)로 교체하고 행 내 상태 beacon을 억제해 dot 혼동을 제거합니다. 그룹명은 칩 accessible name에도 포함됩니다.
- Theater actions 메뉴 트리거 아이콘을 collapse chevron과 중복되던 caret에서 수평 ellipsis로 교체합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` green
- [x] 관련 6개 vitest 스위트 91/91 green (status-axis / store / chip-status / group / inactive-theater / design-contract)
- [x] 격리 인스턴스(FLEET_CONSOLE_DIR) 실브라우저 실측: 4슬롯 상시 표시·빈 섹션 기본 접힘·개별 접기·pill·beacon 억제·ellipsis 아이콘 동작 확인
- [x] Changelog: `.changelog.d/pr-366.md` — 그룹형 문법·이중언어 요약·`compile-changelog-fragments --check` 통과