### PR TITLE
feat(console): add opacity presets to the Float over Map rail panel

### DIFF
--- a/.changelog.d/pr-367.md
+++ b/.changelog.d/pr-367.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Added
+- [fleet-console] Add Solid/90/75/60 opacity presets to the Float over Map rail panel head so the floating panel background can let the Map show through while panel content stays opaque; the choice persists across sessions.
+  ko: Float over Map 레일 패널 헤드에 Solid/90/75/60 불투명도 프리셋을 추가해, 패널 콘텐츠는 불투명하게 유지하면서 플로팅 패널 배경 아래의 Map이 비쳐 보이도록 하고 선택을 세션 간에 유지합니다.

--- a/runtime/fleet-console/core/client/src/rail/rail-store.ts
+++ b/runtime/fleet-console/core/client/src/rail/rail-store.ts
@@ -5,12 +5,16 @@ interface RailStore {
   readonly railChromeExpanded: boolean;
   readonly panelExtraWidth: number;
   readonly panelBehavior: "push" | "overlay";
+  readonly overlayAlpha: RailOverlayAlpha;
 }
+
+export type RailOverlayAlpha = 100 | 90 | 75 | 60;
 
 type Listener = () => void;
 const PREFS_ACTIVE_PANEL = "fleet-console.rail.activePanelId";
 const PREFS_CHROME_EXPANDED = "fleet-console.rail.chromeExpanded";
 const PREFS_PANEL_BEHAVIOR = "fleet-console.rail.panelBehavior";
+const PREFS_OVERLAY_ALPHA = "fleet-console.rail.overlayAlpha";
 const PREFS_REPOSITORY_SOURCE = "fleet-console.repository.source";
 const listeners = new Set<Listener>();
 let store: RailStore = {
@@ -18,6 +22,7 @@ let store: RailStore = {
   railChromeExpanded: readStoredChromeExpanded(),
   panelExtraWidth: 0,
   panelBehavior: readStoredPanelBehavior(),
+  overlayAlpha: readStoredOverlayAlpha(),
 };
 
 export function subscribeRailStore(listener: Listener): () => void {
@@ -72,6 +77,12 @@ export function toggleRailPanelBehavior(): void {
   setRailPanelBehavior(store.panelBehavior === "push" ? "overlay" : "push");
 }
 
+export function setRailOverlayAlpha(alpha: RailOverlayAlpha): void {
+  if (store.overlayAlpha === alpha) return;
+  setStore({ ...store, overlayAlpha: alpha });
+  saveStoredOverlayAlpha(alpha);
+}
+
 export function requestRailPanelExtraWidth(panelId: string, px: number | null): void {
   if (panelId !== store.activeRailPanelId) return;
   const raw = (px === null || !Number.isFinite(px)) ? 0 : px;
@@ -95,6 +106,10 @@ export function useRailPanelExtraWidth(): number {
 
 export function useRailPanelBehavior(): "push" | "overlay" {
   return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).panelBehavior;
+}
+
+export function useRailOverlayAlpha(): RailOverlayAlpha {
+  return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).overlayAlpha;
 }
 
 function readStoredPanelId(): string | null {
@@ -122,6 +137,14 @@ function readStoredPanelBehavior(): "push" | "overlay" {
   } catch { return "push"; }
 }
 
+function readStoredOverlayAlpha(): RailOverlayAlpha {
+  try {
+    const stored = localStorage.getItem(PREFS_OVERLAY_ALPHA);
+    if (stored === "90" || stored === "75" || stored === "60") return Number(stored) as RailOverlayAlpha;
+    return 100;
+  } catch { return 100; }
+}
+
 function saveStoredPanelId(id: string | null): void {
   try {
     if (id === null) localStorage.removeItem(PREFS_ACTIVE_PANEL);
@@ -135,6 +158,10 @@ function saveStoredChromeExpanded(expanded: boolean): void {
 
 function saveStoredPanelBehavior(behavior: "push" | "overlay"): void {
   try { localStorage.setItem(PREFS_PANEL_BEHAVIOR, behavior); } catch { /* ignore */ }
+}
+
+function saveStoredOverlayAlpha(alpha: RailOverlayAlpha): void {
+  try { localStorage.setItem(PREFS_OVERLAY_ALPHA, String(alpha)); } catch { /* ignore */ }
 }
 
 function setStore(next: RailStore): void {

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -7,7 +7,7 @@ import "../styles/rail.css";
 import { BUILT_IN_RAIL_PANELS } from "./built-in-panels.js";
 import { focusCommandBandToggleWhenPanelContainsActiveElement } from "../components/command-band-focus.js";
 import { getState, subscribe } from "../store.js";
-import { closeRailPanel, requestRailPanelExtraWidth, toggleRailPanel, toggleRailPanelBehavior, useActiveRailPanelId, useRailChromeExpanded, useRailPanelBehavior, useRailPanelExtraWidth } from "./rail-store.js";
+import { closeRailPanel, requestRailPanelExtraWidth, setRailOverlayAlpha, toggleRailPanel, toggleRailPanelBehavior, useActiveRailPanelId, useRailChromeExpanded, useRailOverlayAlpha, useRailPanelBehavior, useRailPanelExtraWidth, type RailOverlayAlpha } from "./rail-store.js";
 import { useRailPanels } from "./rail-registry.js";
 import { useCodexSplitExtraWidth } from "./use-codex-split-extra-width.js";
 
@@ -20,6 +20,12 @@ const MIN_PANEL_WIDTH = 240;
 const DEFAULT_PANEL_WIDTH = 312;
 const PREFS_PANEL_WIDTH = "fleet-console.rail.panelWidth";
 const FALLBACK_THEATER_LABEL = "Theater";
+const OVERLAY_ALPHA_PRESETS: readonly { readonly label: string; readonly value: RailOverlayAlpha }[] = [
+  { label: "Solid", value: 100 },
+  { label: "90", value: 90 },
+  { label: "75", value: 75 },
+  { label: "60", value: 60 },
+];
 
 function readStoredPanelWidth(): number {
   try {
@@ -42,6 +48,7 @@ export function RightRail({ theaterId, api }: RightRailProps) {
   const activeId = useActiveRailPanelId();
   const railChromeExpanded = useRailChromeExpanded();
   const panelBehavior = useRailPanelBehavior();
+  const overlayAlpha = useRailOverlayAlpha();
   const previousRailChromeExpandedRef = useRef(railChromeExpanded);
   const previousPanelBehaviorRef = useRef(panelBehavior);
   const pluginPanels = useRailPanels();
@@ -123,7 +130,12 @@ export function RightRail({ theaterId, api }: RightRailProps) {
       inert={!railChromeExpanded}
       style={{ "--right-rail-panel-width": `${hasPanel ? panelWidth + extraWidth : 0}px` } as CSSProperties}
     >
-      <div className="right-rail-panel-slot">
+      <div
+        className="right-rail-panel-slot"
+        style={panelBehavior === "overlay"
+          ? { "--right-rail-overlay-alpha": overlayAlpha / 100 } as CSSProperties
+          : undefined}
+      >
         {hasPanel && (
           <div
             className="right-rail-resize-handle"
@@ -132,7 +144,7 @@ export function RightRail({ theaterId, api }: RightRailProps) {
           />
         )}
         {activePanel && (
-          <RailPanelContent activePanel={activePanel} activeId={activeId} ctx={ctx} panelBehavior={panelBehavior} />
+          <RailPanelContent activePanel={activePanel} activeId={activeId} ctx={ctx} panelBehavior={panelBehavior} overlayAlpha={overlayAlpha} />
         )}
       </div>
       <nav className="right-rail-icons" aria-label="Activity tools">
@@ -157,12 +169,13 @@ interface RailPanelContentProps {
   readonly activeId: string | null;
   readonly ctx: RailPanelContext;
   readonly panelBehavior: "push" | "overlay";
+  readonly overlayAlpha: RailOverlayAlpha;
 }
 
 // 패널 본문은 무거운 플러그인 콘텐츠(파일 트리·diff·Codex)를 렌더한다. 리사이즈 드래그가
 // 매 프레임 RightRail을 재렌더해도 이 본문이 함께 재렌더되면 끊김이 생기므로, 폭과 무관한
-// (activePanel·ctx·activeId·panelBehavior) props로 memo해 드래그 중 본문 재렌더를 건너뛴다(좌측 SideBar처럼 가벼운 부분만 재렌더).
-const RailPanelContent = memo(function RailPanelContent({ activePanel, activeId, ctx, panelBehavior }: RailPanelContentProps) {
+// (activePanel·ctx·activeId·panelBehavior·overlayAlpha) props로 memo해 드래그 중 본문 재렌더를 건너뛴다(좌측 SideBar처럼 가벼운 부분만 재렌더).
+const RailPanelContent = memo(function RailPanelContent({ activePanel, activeId, ctx, panelBehavior, overlayAlpha }: RailPanelContentProps) {
   return (
     <>
       <div className="right-rail-panel-head">
@@ -176,6 +189,24 @@ const RailPanelContent = memo(function RailPanelContent({ activePanel, activeId,
         >
           Float over Map
         </button>
+        {panelBehavior === "overlay" ? (
+          <div className="right-rail-opacity-segments" role="group" aria-label="Panel opacity">
+            {OVERLAY_ALPHA_PRESETS.map((preset) => {
+              const isActive = preset.value === overlayAlpha;
+              return (
+                <button
+                  key={preset.value}
+                  className={`right-rail-opacity-segment${isActive ? " is-active" : ""}`}
+                  type="button"
+                  aria-pressed={isActive}
+                  onClick={() => setRailOverlayAlpha(preset.value)}
+                >
+                  {preset.label}
+                </button>
+              );
+            })}
+          </div>
+        ) : null}
         <button
           className="right-rail-close-btn"
           type="button"

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -180,6 +180,12 @@
   background: var(--brass-glow);
 }
 
+/* 활성 프리셋 위에서도 포커스가 구분되도록 inset 링을 쓴다 — 컨테이너의
+   overflow: hidden 바깥으로 나가지 않아 pill 클리핑과 충돌하지 않는다. */
+.right-rail-opacity-segment:focus-visible {
+  box-shadow: inset 0 0 0 1px var(--brass);
+}
+
 .right-rail-close-btn {
   position: absolute;
   top: 9px;

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -65,21 +65,33 @@
   top: 0;
   bottom: 0;
   width: var(--right-rail-panel-width, 0px);
-  background:
-    radial-gradient(130% 60% at 100% 0%, color-mix(in oklch, var(--brass) 7%, transparent), transparent 56%),
-    color-mix(in oklch, var(--surface-glass-strong) 92%, var(--ink-deep));
   border-left: 1px solid var(--surface-rim);
   /* Near-achromatic depth shadow is a sanctioned raw-literal exception. */
   box-shadow: -24px 0 48px -24px oklch(0% 0 0 / 70%);
   border-radius: var(--radius-lg) 0 0 var(--radius-lg);
 }
 
+.right-rail.is-overlay .right-rail-panel-slot::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  border-radius: inherit;
+  background:
+    radial-gradient(130% 60% at 100% 0%, color-mix(in oklch, var(--brass) 7%, transparent), transparent 56%),
+    color-mix(in oklch, var(--surface-glass-strong) 92%, var(--ink-deep));
+  opacity: var(--right-rail-overlay-alpha, 1);
+  pointer-events: none;
+}
+
 .right-rail-panel-head {
   position: relative;
+  z-index: 1;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 6px;
-  padding: 9px 10px;
+  padding: 9px 44px 9px 10px;
   border-bottom: 1px solid var(--surface-rim);
   min-height: 46px;
   min-width: 240px;
@@ -131,11 +143,50 @@
   border-color: color-mix(in oklch, var(--brass) 70%, transparent);
 }
 
+.right-rail-opacity-segments {
+  flex: none;
+  display: inline-flex;
+  overflow: hidden;
+  border: 1px solid var(--surface-rim-strong);
+  border-radius: var(--radius-pill);
+}
+
+.right-rail-opacity-segment {
+  padding: 4px 8px;
+  border: none;
+  border-left: 1px solid var(--surface-rim-strong);
+  background: transparent;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.right-rail-opacity-segment:first-child {
+  border-left: none;
+}
+
+.right-rail-opacity-segment:hover,
+.right-rail-opacity-segment:focus-visible {
+  color: var(--ink-pearl);
+  background: var(--ink-veil);
+  outline: none;
+}
+
+.right-rail-opacity-segment.is-active,
+.right-rail-opacity-segment.is-active:hover {
+  color: var(--brass);
+  background: var(--brass-glow);
+}
+
 .right-rail-close-btn {
+  position: absolute;
+  top: 9px;
+  right: 10px;
   width: 26px;
   height: 26px;
   flex: none;
-  margin-left: auto;
   display: inline-grid;
   place-items: center;
   border-radius: var(--radius-xs);
@@ -152,6 +203,8 @@
 }
 
 .right-rail-panel-body {
+  position: relative;
+  z-index: 1;
   overflow: hidden;
   min-height: 0;
   min-width: 240px;
@@ -226,11 +279,11 @@
   left: 0;
   top: 0;
   bottom: 0;
+  z-index: 2;
   width: 4px;
   cursor: col-resize;
   background: transparent;
   transition: background 140ms;
-  z-index: 1;
 }
 
 .right-rail-resize-handle:hover {

--- a/runtime/fleet-console/tests/rail-store.test.ts
+++ b/runtime/fleet-console/tests/rail-store.test.ts
@@ -212,3 +212,52 @@ describe("rail panel behavior", () => {
     expect(getRailStoreSnapshot().panelBehavior).toBe("push");
   });
 });
+
+describe("rail overlay alpha", () => {
+  function stubOverlayAlphaStorage(initial: string | null = null) {
+    const values = new Map<string, string>();
+    if (initial !== null) values.set("fleet-console.rail.overlayAlpha", initial);
+    const setItem = vi.fn((key: string, value: string) => values.set(key, value));
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem,
+      removeItem: (key: string) => values.delete(key),
+    });
+    return { values, setItem };
+  }
+
+  it("defaults to Solid (100) when no value is stored", async () => {
+    stubOverlayAlphaStorage();
+    const { getRailStoreSnapshot } = await freshStore();
+    expect(getRailStoreSnapshot().overlayAlpha).toBe(100);
+  });
+
+  it.each([
+    ["100", 100],
+    ["90", 90],
+    ["75", 75],
+    ["60", 60],
+  ] as const)("restores stored alpha %s", async (stored, expected) => {
+    stubOverlayAlphaStorage(stored);
+    const { getRailStoreSnapshot } = await freshStore();
+    expect(getRailStoreSnapshot().overlayAlpha).toBe(expected);
+  });
+
+  it("persists the selected alpha as an exact string", async () => {
+    const storage = stubOverlayAlphaStorage();
+    const { setRailOverlayAlpha } = await freshStore();
+    setRailOverlayAlpha(75);
+    expect(storage.values.get("fleet-console.rail.overlayAlpha")).toBe("75");
+    expect(storage.setItem).toHaveBeenCalledWith("fleet-console.rail.overlayAlpha", "75");
+
+    setRailOverlayAlpha(100);
+    expect(storage.values.get("fleet-console.rail.overlayAlpha")).toBe("100");
+    expect(storage.setItem).toHaveBeenCalledWith("fleet-console.rail.overlayAlpha", "100");
+  });
+
+  it.each(["0", "59", "74", "89", "101", "solid", "75.0"])("falls back to 100 for invalid stored value %s", async (stored) => {
+    stubOverlayAlphaStorage(stored);
+    const { getRailStoreSnapshot } = await freshStore();
+    expect(getRailStoreSnapshot().overlayAlpha).toBe(100);
+  });
+});

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../core/client/src/rail/built-in-panels.js", () => ({
+  BUILT_IN_RAIL_PANELS: [{
+    id: "plans",
+    title: "PLANS",
+    icon: "P",
+    render: () => null,
+  }],
+}));
+
+vi.mock("../core/client/src/rail/rail-registry.js", () => ({
+  useRailPanels: () => [],
+}));
+
+vi.mock("../core/client/src/rail/use-codex-split-extra-width.js", () => ({
+  useCodexSplitExtraWidth: () => 0,
+}));
+
+import { RightRail } from "../core/client/src/rail/right-rail.js";
+import {
+  getRailStoreSnapshot,
+  setActiveRailPanel,
+  setRailOverlayAlpha,
+  setRailPanelBehavior,
+} from "../core/client/src/rail/rail-store.js";
+
+let container: HTMLDivElement;
+let root: Root;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  window.localStorage.clear();
+  setActiveRailPanel("plans");
+  setRailPanelBehavior("push");
+  setRailOverlayAlpha(100);
+  container = document.createElement("div");
+  document.body.replaceChildren(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("Right Rail overlay opacity presets", () => {
+  it("renders no opacity group or alpha variable in push mode", () => {
+    renderRail();
+
+    expect(container.querySelector('[role="group"][aria-label="Panel opacity"]')).toBeNull();
+    expect(panelSlot().style.getPropertyValue("--right-rail-overlay-alpha")).toBe("");
+  });
+
+  it("renders the exact presets in overlay mode and applies selection to the slot background variable", () => {
+    setRailPanelBehavior("overlay");
+    renderRail();
+
+    const group = container.querySelector<HTMLElement>('[role="group"][aria-label="Panel opacity"]');
+    expect(group).not.toBeNull();
+    const buttons = Array.from(group!.querySelectorAll("button"));
+    expect(buttons.map((button) => button.textContent)).toEqual(["Solid", "90", "75", "60"]);
+    expect(buttons.map((button) => button.getAttribute("aria-pressed"))).toEqual(["true", "false", "false", "false"]);
+    expect(panelSlot().style.getPropertyValue("--right-rail-overlay-alpha")).toBe("1");
+
+    act(() => buttons[2]?.click());
+
+    expect(getRailStoreSnapshot().overlayAlpha).toBe(75);
+    expect(window.localStorage.getItem("fleet-console.rail.overlayAlpha")).toBe("75");
+    expect(buttons.map((button) => button.getAttribute("aria-pressed"))).toEqual(["false", "false", "true", "false"]);
+    expect(panelSlot().style.getPropertyValue("--right-rail-overlay-alpha")).toBe("0.75");
+  });
+});
+
+function renderRail(): void {
+  act(() => {
+    root.render(<RightRail theaterId={null} api={{} as never} />);
+  });
+}
+
+function panelSlot(): HTMLDivElement {
+  const slot = container.querySelector<HTMLDivElement>(".right-rail-panel-slot");
+  expect(slot).not.toBeNull();
+  return slot!;
+}


### PR DESCRIPTION
## Summary
- Float over Map 오버레이 패널의 배경 불투명도가 테마 고정값(Instrument 100% 불투명)이라 하단 Map이 완전히 가려지던 문제를 해소하기 위해, 패널 헤드에 **Solid · 90 · 75 · 60** 프리셋 세그먼트를 추가합니다 (제품 제안 검토 후 B안으로 확정).
- 투명도는 배경 레이어(`::before`)에만 적용되고 콘텐츠·테두리·그림자는 불투명을 유지합니다. 선택값은 `fleet-console.rail.overlayAlpha` localStorage에 영속되며 오버레이 모드에서만 컨트롤이 표시됩니다.
- 리뷰 대응으로 리사이즈 핸들 z-index 회귀(콘텐츠 레이어에 묻힘)를 수정하고, 세그먼트에 포커스 가시 스타일을 추가했습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` green
- [x] rail-store/right-rail/design-contract 집중 테스트 60건 통과 (신규 9건 포함)
- [x] 격리 인스턴스 실측: 4 프리셋 적용, reload 복원, overlay↔push 전환 시 컨트롤/CSS 변수 정리
- [x] 실드래그 회귀 검증(핸들 z-index), 페이지 에러 0건
- [x] 디자인 게이트: Solid/60 스크린샷 대조, 토큰(var()/color-mix) 일체감 확인
- [x] changelog fragment: `.changelog.d/pr-367.md` — grouped syntax, bilingual summaries, `compile-changelog-fragments.mjs --check` 통과