### PR TITLE
feat(console): make the empty operations map actionable

### DIFF
--- a/.changelog.d/pr-369.md
+++ b/.changelog.d/pr-369.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Changed
+- [fleet-console] Turn the empty Operations map into an actionable surface with standing-by operation chips, a New Operation button, and shortcut hints.
+  ko: 빈 Operations 맵을 대기 중 Operation 칩, New Operation 버튼, 단축키 힌트가 있는 행동 가능한 표면으로 바꿉니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -5,7 +5,7 @@ import type { CompanionPanelDescriptor, ConsoleTheme, FleetClientPlugin, Operati
 
 import { fetchOperations } from "../api.js";
 import { isBlockingDialogOpen } from "../blocking-dialog.js";
-import { flattenGroupedOrder, hydrateOperations, setActiveOperation } from "../store.js";
+import { flattenGroupedOrder, hydrateOperations, requestOperationLaunchMenu, setActiveOperation } from "../store.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { useGlobalSettingsStore } from "../global-settings-store.js";
@@ -18,6 +18,7 @@ import { CanvasMinimap } from "./canvas-minimap.js";
 import { resolveAccentColor } from "./operation-accent.js";
 import { CanvasGrid } from "./canvas-grid.js";
 import { OperationFrame } from "./operation-frame.js";
+import { hasVisibleCanvasContent, OperationsCanvasEmptyState } from "./operations-canvas-empty-state.js";
 import { RubberBand } from "./rubber-band.js";
 import { useCanvasInteraction } from "./use-canvas-interaction.js";
 import { screenToCanvas, type CanvasPoint, type CanvasRect } from "./coordinates.js";
@@ -59,7 +60,6 @@ interface PluginOperationRendererProps {
   readonly render: (context: OperationRenderContext) => unknown;
 }
 
-const EMPTY_GUIDE = "Shift-drag to create a Shell. Right-click for actions. Drag to pan; scroll to zoom.";
 const DEFAULT_SHELL_WIDTH = 560;
 const DEFAULT_SHELL_HEIGHT = 360;
 /* components.css의 .canvas-operation-titlebar top(-1 * --space-3)과 짝을 이루는 상수. */
@@ -173,7 +173,7 @@ export function OperationsCanvas({
   const pluginOperations = companionOperation && !theaterOperations.some((operation) => operation.id === companionOperation.id)
     ? [...theaterOperations, companionOperation]
     : theaterOperations;
-  const hasContent = pluginOperations.length > 0;
+  const hasContent = hasVisibleCanvasContent(pluginOperations, minimizedSet);
   useEffect(() => {
     if (companionOperationId === null || currentPanelCompanion !== null) return;
     // ops 푸시 직후 대상 Operation이 목록에서 일시적으로 빠지는 레이스가 있어, 방금 연 분석
@@ -321,10 +321,14 @@ export function OperationsCanvas({
         })}
       </div>
       {!hasContent ? (
-        <div className="operations-canvas-empty" data-canvas-blocker>
-          <span className="operations-canvas-empty-mark" aria-hidden="true" />
-          <p>{state.activeTheaterId ? EMPTY_GUIDE : "Add a Theater from the sidebar to start operations."}</p>
-        </div>
+        <OperationsCanvasEmptyState
+          activeTheaterId={state.activeTheaterId}
+          theaterLabel={state.theaters.find((theater) => theater.id === state.activeTheaterId)?.label ?? state.activeTheaterId ?? ""}
+          operations={theaterOperations}
+          canLaunch={canLaunch}
+          onOpenOperation={onFocus}
+          onNewOperation={requestOperationLaunchMenu}
+        />
       ) : null}
       {interaction.rubberBand ? <RubberBand rect={interaction.rubberBand} viewport={canvas.viewport} /> : null}
       {contextMenu ? (

--- a/runtime/fleet-console/core/client/src/canvas/operations-canvas-empty-state.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operations-canvas-empty-state.tsx
@@ -1,0 +1,80 @@
+import type { OperationNode } from "../types.js";
+
+interface OperationsCanvasEmptyStateProps {
+  readonly activeTheaterId: string | null;
+  readonly theaterLabel: string;
+  readonly operations: readonly OperationNode[];
+  readonly canLaunch: boolean;
+  readonly onOpenOperation: (operationId: string) => void;
+  readonly onNewOperation: () => void;
+}
+
+const EMPTY_GUIDE = "Shift-drag to create a Shell. Right-click for actions. Drag to pan; scroll to zoom.";
+
+export function hasVisibleCanvasContent(operations: readonly OperationNode[], minimizedOperationIds: ReadonlySet<string>): boolean {
+  return operations.some((operation) => !minimizedOperationIds.has(operation.id));
+}
+
+export function OperationsCanvasEmptyState({
+  activeTheaterId,
+  theaterLabel,
+  operations,
+  canLaunch,
+  onOpenOperation,
+  onNewOperation,
+}: OperationsCanvasEmptyStateProps) {
+  if (!activeTheaterId) {
+    return (
+      <div className="operations-canvas-empty" data-canvas-blocker>
+        <span className="operations-canvas-empty-mark" aria-hidden="true" />
+        <p>Add a Theater from the sidebar to start operations.</p>
+      </div>
+    );
+  }
+
+  const standbyOperations = [...operations]
+    .sort((left, right) => right.ts.updatedAt - left.ts.updatedAt)
+    .slice(0, 2);
+  const operationCount = operations.length;
+
+  return (
+    <div className="operations-canvas-empty" data-canvas-blocker>
+      {operationCount > 0 ? (
+        <>
+          <p className="operations-canvas-empty-ghost">
+            {operationCount} {operationCount === 1 ? "operation" : "operations"} standing by
+          </p>
+          <div className="operations-canvas-empty-standby">
+            {standbyOperations.map((operation) => (
+              <button
+                key={operation.id}
+                type="button"
+                className="operations-canvas-empty-standby-chip"
+                aria-label={`Open operation ${operation.title}`}
+                onClick={() => onOpenOperation(operation.id)}
+              >
+                <span className="operations-canvas-empty-standby-title">{operation.title}</span>
+                <span className="operations-canvas-empty-standby-open" aria-hidden="true">OPEN</span>
+              </button>
+            ))}
+          </div>
+        </>
+      ) : (
+        <p className="operations-canvas-empty-headline">Launch your first operation</p>
+      )}
+      <button
+        type="button"
+        className="operations-canvas-empty-new"
+        aria-label={`New Operation in ${theaterLabel}`}
+        disabled={!canLaunch}
+        onClick={onNewOperation}
+      >
+        + New Operation
+      </button>
+      <p className="operations-canvas-empty-hints">
+        <kbd>⌘K</kbd> Search <span aria-hidden="true">·</span> <kbd>Alt+F</kbd> Formation <span aria-hidden="true">·</span> <kbd>Alt+S</kbd> Status board
+      </p>
+      <p className="operations-canvas-empty-guide">{EMPTY_GUIDE}</p>
+    </div>
+  );
+}

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3924,18 +3924,128 @@
   z-index: 5;
   display: grid;
   gap: var(--space-3);
-  max-width: 420px;
+  box-sizing: border-box;
+  width: min(460px, calc(100% - var(--space-10)));
   padding: var(--space-4);
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-lg);
   background: color-mix(in oklch, var(--surface-glass) 82%, var(--ink-deep));
   color: var(--ink-spectral);
   box-shadow: var(--shadow-soft);
+  pointer-events: none;
 }
 
 .operations-canvas-empty p {
   margin: 0;
   line-height: 1.55;
+}
+
+.operations-canvas-empty-ghost {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.operations-canvas-empty-headline {
+  color: var(--text-primary);
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.operations-canvas-empty-standby {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.operations-canvas-empty-standby-chip,
+.operations-canvas-empty-new {
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.operations-canvas-empty-standby-chip {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: 9px var(--space-3);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--surface-glass) 76%, transparent);
+  color: var(--text-secondary);
+  font: inherit;
+  text-align: left;
+}
+
+.operations-canvas-empty-standby-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.operations-canvas-empty-standby-open {
+  flex: none;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.operations-canvas-empty-new {
+  justify-self: start;
+  padding: 8px var(--space-3);
+  border: 1px solid color-mix(in oklch, var(--brass) 42%, var(--surface-rim));
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--brass) 10%, var(--surface-glass));
+  color: var(--brass-bright);
+  font: 700 11px/1.2 var(--font-mono);
+}
+
+.operations-canvas-empty-standby-chip:hover,
+.operations-canvas-empty-new:hover:not(:disabled) {
+  border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim));
+  background: color-mix(in oklch, var(--brass) 13%, var(--surface-glass));
+  color: var(--brass-bright);
+}
+
+.operations-canvas-empty-standby-chip:focus-visible,
+.operations-canvas-empty-new:focus-visible {
+  outline: 2px solid color-mix(in oklch, var(--brass) 58%, transparent);
+  outline-offset: 2px;
+}
+
+.operations-canvas-empty-new:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.operations-canvas-empty-hints {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-tertiary);
+  font-size: 10px;
+}
+
+.operations-canvas-empty-hints kbd {
+  padding: 2px 5px;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--ink-deep) 80%, transparent);
+  color: var(--text-secondary);
+  font: 700 9px/1.2 var(--font-mono);
+}
+
+.operations-canvas-empty-guide {
+  color: var(--text-tertiary);
+  font-size: 9px;
 }
 
 .operations-canvas-empty-mark {

--- a/runtime/fleet-console/tests/operations-canvas-empty-state.test.tsx
+++ b/runtime/fleet-console/tests/operations-canvas-empty-state.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { hasVisibleCanvasContent, OperationsCanvasEmptyState } from "../core/client/src/canvas/operations-canvas-empty-state.js";
+import type { OperationNode } from "../core/client/src/types.js";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("Operations Canvas empty state", () => {
+  it("treats a Theater with only minimized Operations as empty canvas content", () => {
+    const operations = [operation("first", "First", 1), operation("second", "Second", 2)];
+
+    expect(hasVisibleCanvasContent(operations, new Set(["first", "second"]))).toBe(false);
+    expect(hasVisibleCanvasContent(operations, new Set(["first"]))).toBe(true);
+  });
+
+  it("keeps the no-Theater guidance as the only message", () => {
+    renderEmptyState({ activeTheaterId: null, operations: [] });
+
+    expect(container?.textContent).toBe("Add a Theater from the sidebar to start operations.");
+    expect(container?.querySelector("[data-canvas-blocker]")).not.toBeNull();
+    expect(container?.querySelector("button")).toBeNull();
+  });
+
+  it("offers the launch action and shortcuts when the Theater has no Operations", () => {
+    const onNewOperation = vi.fn();
+    renderEmptyState({ activeTheaterId: "theater-a", operations: [], onNewOperation });
+
+    expect(container?.querySelector(".operations-canvas-empty-headline")?.textContent).toBe("Launch your first operation");
+    expect(container?.querySelector(".operations-canvas-empty-ghost")).toBeNull();
+    expect(container?.querySelector(".operations-canvas-empty-hints")?.textContent).toBe("⌘K Search · Alt+F Formation · Alt+S Status board");
+    expect(container?.querySelector(".operations-canvas-empty-guide")?.textContent).toBe("Shift-drag to create a Shell. Right-click for actions. Drag to pan; scroll to zoom.");
+
+    const launch = container?.querySelector<HTMLButtonElement>('[aria-label="New Operation in Alpha"]');
+    expect(launch?.textContent).toBe("+ New Operation");
+    act(() => launch?.click());
+    expect(onNewOperation).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the two most recently updated standby Operations and opens the selected one", () => {
+    const onOpenOperation = vi.fn();
+    renderEmptyState({
+      activeTheaterId: "theater-a",
+      operations: [
+        operation("old", "Old watch", 10),
+        operation("newest", "Newest watch", 30),
+        operation("middle", "Middle watch", 20),
+      ],
+      onOpenOperation,
+    });
+
+    expect(container?.querySelector(".operations-canvas-empty-ghost")?.textContent).toBe("3 operations standing by");
+    const chips = Array.from(container?.querySelectorAll<HTMLButtonElement>(".operations-canvas-empty-standby-chip") ?? []);
+    expect(chips).toHaveLength(2);
+    expect(chips.map((chip) => chip.getAttribute("aria-label"))).toEqual([
+      "Open operation Newest watch",
+      "Open operation Middle watch",
+    ]);
+    expect(chips.map((chip) => chip.querySelector(".operations-canvas-empty-standby-open")?.textContent)).toEqual(["OPEN", "OPEN"]);
+
+    act(() => chips[1]?.click());
+    expect(onOpenOperation).toHaveBeenCalledWith("middle");
+  });
+
+  it("uses the singular standby copy for one Operation", () => {
+    renderEmptyState({
+      activeTheaterId: "theater-a",
+      operations: [operation("solo", "Solo", 1)],
+    });
+
+    expect(container?.querySelector(".operations-canvas-empty-ghost")?.textContent).toBe("1 operation standing by");
+  });
+});
+
+function renderEmptyState({
+  activeTheaterId,
+  operations,
+  onOpenOperation = vi.fn(),
+  onNewOperation = vi.fn(),
+}: {
+  readonly activeTheaterId: string | null;
+  readonly operations: readonly OperationNode[];
+  readonly onOpenOperation?: (operationId: string) => void;
+  readonly onNewOperation?: () => void;
+}): void {
+  act(() => root?.render(createElement(OperationsCanvasEmptyState, {
+    activeTheaterId,
+    theaterLabel: "Alpha",
+    operations,
+    canLaunch: true,
+    onOpenOperation,
+    onNewOperation,
+  })));
+}
+
+function operation(id: string, title: string, updatedAt: number): OperationNode {
+  return {
+    id,
+    theaterId: "theater-a",
+    type: "shell",
+    pluginId: "terminal",
+    title,
+    payload: {},
+    geometry: null,
+    ts: { createdAt: updatedAt, updatedAt },
+  };
+}


### PR DESCRIPTION
## Summary
- 창이 0개인 Operations 맵의 빈 상태를 행동 가능한 표면으로 확장합니다: standby Operation이 있으면 "N operations standing by" + 최근 2개 바로 열기 칩(OPEN), 없으면 "Launch your first operation" 헤드라인, Theater 미선택 시 기존 안내 유지.
- `+ New Operation` CTA(launch 메뉴 오픈)와 단축키 힌트(⌘K/Alt+F/Alt+S)를 상주시키고, 기존 제스처 안내 문구는 보조 라인으로 강등합니다.
- 판정 기준을 "가시 창 0"(`hasVisibleCanvasContent`)으로 정정: 복원된 Operation은 전부 최소화 상태로 마운트되므로 종전 `length > 0` 판정으로는 빈 캔버스에서 empty state가 영원히 도달 불가였습니다(격리 인스턴스 실측으로 확정).
- 실측 근거: Operation 4개 보유 Theater에서도 부팅 직후 맵에 행동 affordance 0개 — 2026-07-25 product-proposal I-2 승인분.

## Test Plan
- [x] 신규 vitest 5건(3분기·가시성 판정·최신 2개 정렬·CTA/칩 액션·단복수 문구) green
- [x] `@dotobokuri/fleet-console` build/typecheck green
- [x] 격리 콘솔 실브라우저 검증: 부팅 standby 분기, 칩→창 오픈/포커스, 전체 최소화 시 복귀, CTA→launch 메뉴 — 전부 통과(스크린샷 증거)
- [x] sentinel 리뷰 클린 PASS(겹침·캔버스 제스처 통과·정렬 안정성·⌘K 표기 선례 확인)
- [x] Changelog: `.changelog.d/pr-369.md` 추가 완료 (fragment 문법·EN/KO 병기·`--check` 검증 통과)
