### PR TITLE
fix(console): restore text legibility floor and unify control grammar

### DIFF
--- a/.changelog.d/pr-370.md
+++ b/.changelog.d/pr-370.md
@@ -1,0 +1,21 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Raise dimmed interface text to the readable tier in all three themes, so panel titles, section labels, metadata, and control captions meet the WCAG AA contrast floor instead of fading into the surface.
+  ko: 세 테마 모두에서 흐린 인터페이스 텍스트를 판독 가능한 단계로 올려, 패널 제목·섹션 라벨·메타데이터·컨트롤 문구가 배경에 묻히지 않고 WCAG AA 대비 기준을 충족합니다.
+- [fleet-console] Distinguish the four Operation status beacons by shape as well as color, so the state stays readable without relying on color perception.
+  ko: Operation 상태 비콘 4종을 색과 함께 모양으로도 구분해, 색 인지에 의존하지 않고 상태를 읽을 수 있습니다.
+- [fleet-console] Apply the intended font family and label sizes in the Codex reading sheet and navigator, which previously fell back to inherited values.
+  ko: Codex 읽기 시트와 내비게이터에서 상속값으로 흘러가던 글꼴과 라벨 크기가 의도한 값으로 표시됩니다.
+
+#### Changed
+- [fleet-console] Unify the control grammar with three font weights, two icon button sizes, and a shared button variant set, and return control and CTA labels to sentence case while keeping uppercase for structural section labels.
+  ko: 컨트롤 문법을 글자 굵기 3단계, 아이콘 버튼 2규격, 공용 버튼 변형 체계로 통일하고, 컨트롤·CTA 라벨은 문장형으로 되돌리되 대문자는 구조 섹션 라벨에만 남깁니다.
+- [fleet-console] Express de-emphasis by stepping text down a tier instead of fading it with transparency, so a dimmed label keeps its guaranteed contrast.
+  ko: 강조를 낮출 때 투명도로 흐리는 대신 텍스트 단계를 낮추도록 바꿔, 흐리게 표시한 라벨도 보장된 대비를 유지합니다.
+
+### fleet-plugin
+#### Fixed
+- [fleet-console] Raise dimmed text in the Repository, Skills, Files, and Session Analyst panels to the readable tier, and stop fading commit rows outside the checked-out branch below the contrast floor.
+  ko: Repository·Skills·Files·Session Analyst 패널의 흐린 텍스트를 판독 가능한 단계로 올리고, 체크아웃된 브랜치 밖 커밋 행이 대비 기준 아래로 흐려지던 문제를 해소합니다.
+- [fleet-console] Apply the intended font family to the Files panel tree labels, which previously fell back to an inherited value.
+  ko: Files 패널 트리 라벨이 상속값으로 흘러가던 글꼴을 의도한 값으로 표시합니다.

--- a/runtime/fleet-console/core/client/src/codex/styles/components.css
+++ b/runtime/fleet-console/core/client/src/codex/styles/components.css
@@ -10,7 +10,7 @@
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.18em;
   text-transform: uppercase;
 }
@@ -32,7 +32,7 @@
   border-radius: var(--radius-md);
   border: 1px solid var(--surface-rim);
   background: color-mix(in oklch, var(--ink-deep) 75%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: var(--font-size-lg);
   cursor: pointer;
   transition:
@@ -44,7 +44,7 @@
 .command-entry:hover {
   border-color: color-mix(in oklch, var(--brass) 45%, transparent);
   background: var(--ink-veil);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   transform: translateY(-1px);
 }
 
@@ -68,10 +68,10 @@ kbd {
   border-radius: 8px;
   background: var(--ink-abyss);
   border: 1px solid var(--surface-rim);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   letter-spacing: 0;
   line-height: 1;
 }
@@ -81,13 +81,13 @@ kbd {
   align-items: center;
   gap: var(--space-1);
   padding: var(--space-1) 10px;
-  border-radius: 999px;
+  border-radius: var(--radius-sm);
   background: var(--surface-glass);
   border: 1px solid var(--surface-rim);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.02em;
   line-height: 1;
 }
@@ -123,10 +123,10 @@ kbd {
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-body);
   font-size: var(--font-size-sm);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.06em;
   padding: 8px 10px;
   cursor: pointer;
@@ -137,7 +137,7 @@ kbd {
 }
 
 .nav-tab:hover {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   background: color-mix(in oklch, var(--ink-veil) 35%, transparent);
 }
 
@@ -164,10 +164,10 @@ kbd {
 .nav-section-label {
   margin: var(--space-5) 0 var(--space-2);
   padding: 0 var(--space-2);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.16em;
   text-transform: uppercase;
 }
@@ -187,10 +187,10 @@ kbd {
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: inherit;
   font-size: var(--font-size-md);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   letter-spacing: -0.005em;
   text-align: left;
   cursor: pointer;
@@ -218,9 +218,9 @@ kbd {
 .tag-group-button .count {
   font-family: var(--font-mono);
   font-size: var(--font-size-2xs);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.06em;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   background: color-mix(in oklch, var(--ink-mid) 70%, transparent);
   border: 1px solid var(--surface-rim);
   border-radius: 999px;
@@ -242,7 +242,7 @@ kbd {
   min-width: 0;
   padding: 9px 10px;
   border-radius: var(--radius-sm);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: var(--font-size-md);
   letter-spacing: -0.005em;
   line-height: 1.35;
@@ -279,14 +279,14 @@ kbd {
 
 .nav-entry:hover {
   background: color-mix(in oklch, var(--ink-veil) 40%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   transform: translateX(2px);
 }
 
 .nav-entry.active {
   background: color-mix(in oklch, var(--brass) 12%, transparent);
   color: var(--brass-bright);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
 }
 
 .nav-entry.active::before {
@@ -321,10 +321,10 @@ kbd {
   display: inline-flex;
   align-items: center;
   min-width: 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -345,7 +345,7 @@ kbd {
 }
 
 .breadcrumb a {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   text-decoration: none;
   transition: color var(--duration-fast) var(--ease-spring);
 }
@@ -355,17 +355,17 @@ kbd {
 }
 
 .breadcrumb span[aria-current="page"] {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .document h1 {
   margin: 0;
   font-family: var(--font-body);
-  font-weight: 400;
+  font-weight: var(--weight-regular);
   font-size: var(--font-size-display-2xl);
   letter-spacing: -0.025em;
   line-height: 1.02;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-variation-settings: "opsz" 144, "SOFT" 50;
 }
 
@@ -377,7 +377,7 @@ kbd {
 
 .lead {
   margin: 0;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-size: var(--font-size-title-lg);
   line-height: 1.6;
   letter-spacing: -0.005em;
@@ -398,7 +398,7 @@ kbd {
   border-radius: 999px;
   border: 1px solid var(--surface-rim);
   background: color-mix(in oklch, var(--ink-deep) 60%, transparent);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: var(--font-size-sm);
   letter-spacing: 0;
@@ -419,7 +419,7 @@ kbd {
   color: var(--brass-bright);
   font-family: var(--font-body);
   font-size: var(--font-size-lg);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: -0.005em;
   box-shadow: var(--shadow-anchor);
   transition:
@@ -462,7 +462,7 @@ kbd {
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.22em;
   text-transform: uppercase;
 }
@@ -471,7 +471,7 @@ kbd {
   display: block;
   min-width: 0;
   padding: 6px 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: var(--font-size-md);
   letter-spacing: -0.005em;
   line-height: 1.45;
@@ -483,13 +483,13 @@ kbd {
 
 .toc-panel a:hover,
 .toc-panel a.active {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   transform: translateX(2px);
 }
 
 .toc-panel a.active {
   color: var(--brass-bright);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
 }
 
 .toc-panel a.active::before {
@@ -507,7 +507,7 @@ kbd {
 .toc-panel .toc-level-3 {
   padding-left: var(--space-3);
   font-size: var(--font-size-compact);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .related-list {
@@ -521,7 +521,7 @@ kbd {
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.22em;
   text-transform: uppercase;
 }
@@ -559,10 +559,10 @@ kbd {
   overflow: hidden;
   font-family: var(--font-body);
   font-size: var(--font-size-body);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   letter-spacing: -0.01em;
   line-height: 1.25;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   word-break: break-word;
 }
 
@@ -591,7 +591,7 @@ kbd {
   display: block;
   min-width: 0;
   padding: 5px 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: var(--font-size-md);
   letter-spacing: -0.005em;
   line-height: 1.45;
@@ -603,7 +603,7 @@ kbd {
 }
 
 .queue-toc-link:hover {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   transform: translateX(2px);
 }
 
@@ -711,17 +711,17 @@ kbd {
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.22em;
   text-transform: uppercase;
 }
 
 .manifest-subtitle {
   margin: 0;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-body);
   font-size: var(--font-size-body);
-  font-weight: 400;
+  font-weight: var(--weight-regular);
   letter-spacing: -0.01em;
   font-variation-settings: "opsz" 16;
 }
@@ -735,7 +735,7 @@ kbd {
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-deep) 70%, transparent);
   border: 1px solid var(--surface-rim);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: var(--font-size-compact);
   letter-spacing: 0;
@@ -778,7 +778,7 @@ kbd {
 .loading {
   margin: 0;
   padding: var(--space-3) 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: var(--font-size-lg);
   letter-spacing: -0.005em;
 }
@@ -852,7 +852,7 @@ kbd {
   flex: 1;
   border: 0;
   background: transparent;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-size: var(--font-size-body);
   letter-spacing: -0.01em;
@@ -860,7 +860,7 @@ kbd {
 }
 
 #command-input::placeholder {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 #command-input:focus-visible {
@@ -886,7 +886,7 @@ kbd {
   border: 0;
   border-radius: var(--radius-md);
   background: transparent;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   cursor: pointer;
   padding: 11px var(--space-4);
   text-align: left;
@@ -939,7 +939,7 @@ kbd {
 
 .command-result.active {
   background: color-mix(in oklch, var(--brass) 12%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .command-result.active::before {
@@ -951,10 +951,10 @@ kbd {
   display: block;
   font-family: var(--font-body);
   font-size: var(--font-size-base);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   letter-spacing: -0.01em;
   line-height: 1.3;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -970,7 +970,7 @@ kbd {
 
 .command-result small {
   display: block;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   letter-spacing: 0.04em;
@@ -993,7 +993,7 @@ kbd {
   gap: var(--space-3);
   min-width: 0;
   padding: var(--space-3) var(--space-4) var(--space-2);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: var(--font-size-2xs);
   letter-spacing: 0.12em;
@@ -1039,12 +1039,11 @@ kbd {
   border-radius: var(--radius-md);
   border: 1px solid var(--surface-rim);
   background: var(--surface-glass);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  font-weight: 600;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.01em;
   text-decoration: none;
   transition:
     color var(--duration-fast) var(--ease-spring),
@@ -1090,9 +1089,9 @@ kbd {
   margin: 0;
   font-family: var(--font-mono);
   font-size: var(--font-size-title-xl);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   letter-spacing: 0;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   word-break: break-all;
   line-height: 1.25;
 }
@@ -1138,7 +1137,7 @@ kbd {
   border: 1px solid var(--surface-rim);
   background: var(--surface-pillar);
   box-shadow: var(--shadow-floating);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   padding: 11px 16px;
   font-size: var(--font-size-md);
   letter-spacing: -0.005em;
@@ -1162,7 +1161,7 @@ kbd {
   border-radius: var(--radius-sm);
   border: 1px solid var(--surface-rim);
   background: color-mix(in oklch, var(--ink-deep) 70%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
   transition:
     color var(--duration-fast) var(--ease-spring),
@@ -1194,7 +1193,7 @@ kbd {
   gap: var(--space-2);
   padding: 9px 10px;
   border-radius: var(--radius-sm);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: var(--font-size-md);
   letter-spacing: -0.005em;
   text-decoration: none;
@@ -1207,14 +1206,14 @@ kbd {
 
 .nav-drydock-link:hover {
   background: color-mix(in oklch, var(--ink-veil) 40%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   transform: translateX(2px);
 }
 
 .nav-drydock-link.active {
   background: color-mix(in oklch, var(--brass) 12%, transparent);
   color: var(--brass-bright);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
 }
 
 .nav-drydock-link.active::before {
@@ -1259,7 +1258,7 @@ kbd {
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: var(--font-size-2xs);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0;
   flex-shrink: 0;
 }
@@ -1277,15 +1276,15 @@ kbd {
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  font-weight: 600;
-  letter-spacing: 0.06em;
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.08em;
   line-height: 1;
   text-transform: uppercase;
 }
 
 .op-badge-glyph {
   font-size: var(--font-size-md);
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   line-height: 1;
 }
 
@@ -1313,7 +1312,7 @@ kbd {
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.22em;
   text-transform: uppercase;
 }
@@ -1322,10 +1321,10 @@ kbd {
   margin: 0;
   font-family: var(--font-body);
   font-size: var(--font-size-display-xl);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   letter-spacing: -0.02em;
   line-height: 1.1;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-variation-settings: "opsz" 60;
 }
 
@@ -1345,10 +1344,10 @@ kbd {
   gap: var(--space-2);
   border-radius: var(--radius-sm);
   padding: 7px 14px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-body);
   font-size: var(--font-size-sm);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.06em;
   text-decoration: none;
   transition:
@@ -1357,7 +1356,7 @@ kbd {
 }
 
 .queue-tab:hover {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   background: color-mix(in oklch, var(--ink-veil) 35%, transparent);
 }
 
@@ -1380,14 +1379,14 @@ kbd {
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: var(--font-size-2xs);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0;
 }
 
 .queue-badge--muted {
   background: var(--surface-glass);
   border-color: var(--surface-rim);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .queue-list {
@@ -1444,8 +1443,8 @@ kbd {
 .queue-row-target {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  font-weight: 600;
-  color: var(--ink-pearl);
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
   letter-spacing: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1455,7 +1454,7 @@ kbd {
 .queue-row-summary {
   font-family: var(--font-body);
   font-size: var(--font-size-sm);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   line-height: 1.4;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -1466,7 +1465,7 @@ kbd {
 .queue-row-meta {
   font-family: var(--font-mono);
   font-size: var(--font-size-2xs);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   letter-spacing: 0.04em;
   margin-top: 2px;
 }
@@ -1474,7 +1473,7 @@ kbd {
 .queue-empty {
   margin: 0;
   padding: var(--space-5) 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: var(--font-size-lg);
   font-family: var(--font-body);
   letter-spacing: -0.005em;
@@ -1512,7 +1511,7 @@ kbd {
 .queue-card-id {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   letter-spacing: 0.04em;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1530,7 +1529,7 @@ kbd {
 .queue-card-time {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   letter-spacing: 0.04em;
   flex-shrink: 0;
 }
@@ -1539,8 +1538,8 @@ kbd {
   margin: 0;
   font-family: var(--font-body);
   font-size: var(--font-size-lg);
-  font-weight: 500;
-  color: var(--ink-pearl);
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
   letter-spacing: -0.01em;
   line-height: 1.35;
   overflow: hidden;
@@ -1552,7 +1551,7 @@ kbd {
 .queue-card-target {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   letter-spacing: 0.04em;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1621,7 +1620,7 @@ kbd {
   margin: 0;
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   letter-spacing: 0.08em;
 }
 
@@ -1629,10 +1628,10 @@ kbd {
   margin: 0;
   font-family: var(--font-body);
   font-size: var(--font-size-display-lg);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   letter-spacing: -0.02em;
   line-height: 1.15;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-variation-settings: "opsz" 60;
 }
 
@@ -1663,10 +1662,10 @@ kbd {
 
 .queue-rail-subtitle {
   margin: 0;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-body);
   font-size: var(--font-size-body);
-  font-weight: 400;
+  font-weight: var(--weight-regular);
   letter-spacing: -0.01em;
   font-variation-settings: "opsz" 16;
 }
@@ -1674,7 +1673,7 @@ kbd {
 .queue-rail-hint {
   margin: 0;
   font-size: var(--font-size-sm);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   letter-spacing: -0.005em;
 }
 
@@ -1690,10 +1689,10 @@ kbd {
 .queue-dl-key {
   font-family: var(--font-mono);
   font-size: var(--font-size-2xs);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   white-space: nowrap;
   padding-top: 2px;
 }
@@ -1701,7 +1700,7 @@ kbd {
 .queue-dl-value {
   margin: 0;
   font-size: var(--font-size-md);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   min-width: 0;
   overflow-wrap: anywhere;
 }
@@ -1712,7 +1711,7 @@ kbd {
 }
 
 .queue-dl-muted {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .queue-dl-time {
@@ -1723,7 +1722,7 @@ kbd {
 
 .queue-dl-relative {
   font-size: var(--font-size-xs);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   letter-spacing: 0.04em;
 }
@@ -1743,7 +1742,7 @@ kbd {
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-deep) 70%, transparent);
   border: 1px solid var(--surface-rim);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: var(--font-size-sm);
   letter-spacing: 0;
@@ -1787,7 +1786,7 @@ kbd {
   border-radius: var(--radius-xs);
   border: 1px solid transparent;
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   letter-spacing: 0.04em;
@@ -1800,7 +1799,7 @@ kbd {
 }
 
 .queue-back-btn:hover {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   border-color: var(--surface-rim);
   background: var(--surface-glass);
 }
@@ -1815,7 +1814,7 @@ kbd {
 .queue-decision-confirm {
   margin: 0 0 var(--space-3) 0;
   font-size: var(--font-size-md);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-body);
 }
 
@@ -1823,7 +1822,7 @@ kbd {
   margin: 0;
   font-family: var(--font-mono);
   font-size: var(--font-size-sm);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.04em;
   padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-xs);
@@ -1859,7 +1858,7 @@ kbd {
   border-radius: var(--radius-xs);
   font-family: var(--font-mono);
   font-size: var(--font-size-sm);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.04em;
   cursor: pointer;
   transition:
@@ -1909,12 +1908,12 @@ kbd {
 .queue-action-btn--cancel {
   background: transparent;
   border: 1px solid var(--surface-rim);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .queue-action-btn--cancel:not(:disabled):hover {
   background: color-mix(in oklch, var(--ink-veil) 20%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .queue-reject-form {
@@ -1931,7 +1930,7 @@ kbd {
   background: var(--surface-glass);
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-size: var(--font-size-md);
   line-height: 1.5;
@@ -2074,7 +2073,7 @@ kbd {
 .chip-coral {
   background: color-mix(in oklch, var(--coral) 12%, transparent);
   border-color: color-mix(in oklch, var(--coral) 36%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .chip-stale {
@@ -2129,7 +2128,7 @@ kbd {
 
 .conflict-list-copy small,
 .patch-set-item-copy small {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
 }
@@ -2139,7 +2138,7 @@ kbd {
   white-space: pre-wrap;
   word-break: break-word;
   font-family: var(--font-mono);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .log-controls {
@@ -2151,8 +2150,8 @@ kbd {
 /* ─── Codex Navigator ─────────────────────────────────────────────────────── */
 
 .codex-nav-modes { display: grid; grid-template-columns: 1fr 1fr; gap: 4px; padding: 8px 10px 0; }
-.codex-nav-modes button { border: 0; border-bottom: 2px solid transparent; padding: 8px; background: transparent; color: var(--text-muted); cursor: pointer; }
-.codex-nav-modes button[aria-selected="true"] { border-bottom-color: var(--brass); color: var(--text); }
+.codex-nav-modes button { border: 0; border-bottom: 2px solid transparent; padding: 8px; background: transparent; color: var(--text-tertiary); cursor: pointer; }
+.codex-nav-modes button[aria-selected="true"] { border-bottom-color: var(--brass); color: var(--text-primary); }
 
 .codex-nav-search {
   display: flex;
@@ -2160,7 +2159,7 @@ kbd {
   gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--surface-rim);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .codex-nav-search-input {
@@ -2169,14 +2168,14 @@ kbd {
   background: transparent;
   border: none;
   outline: none;
-  color: var(--ink-spectral);
-  font-family: var(--font-ui);
-  font-size: var(--font-size-body-sm);
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 12px;
   padding: 0;
 }
 
 .codex-nav-search-input::placeholder {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .codex-nav-quick-row {
@@ -2194,16 +2193,16 @@ kbd {
   background: var(--surface-glass);
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
-  color: var(--ink-spectral);
-  font-family: var(--font-ui);
-  font-size: var(--font-size-label-sm);
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 11px;
   cursor: pointer;
   transition: background var(--duration-base) var(--ease-spring);
 }
 
 .codex-nav-quick:hover {
   background: color-mix(in oklch, var(--brass) 8%, var(--surface-glass));
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .codex-nav-quick .badge {
@@ -2217,7 +2216,7 @@ kbd {
   border-radius: 8px;
   color: var(--brass-bright);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   line-height: 1;
 }
 
@@ -2225,10 +2224,10 @@ kbd {
   padding: var(--space-2) var(--space-3) var(--space-1);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .codex-nav-entry {
@@ -2255,9 +2254,9 @@ kbd {
 }
 
 .codex-nav-entry .t {
-  font-family: var(--font-ui);
-  font-size: var(--font-size-body-sm);
-  color: var(--ink-spectral);
+  font-family: var(--font-body);
+  font-size: 12px;
+  color: var(--text-secondary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2272,7 +2271,7 @@ kbd {
 .codex-nav-entry .meta {
   font-family: var(--font-mono);
   font-size: 10px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2302,9 +2301,9 @@ kbd {
 .codex-nav-error,
 .codex-nav-empty {
   padding: var(--space-4) var(--space-3);
-  font-family: var(--font-ui);
-  font-size: var(--font-size-body-sm);
-  color: var(--ink-fog);
+  font-family: var(--font-body);
+  font-size: 12px;
+  color: var(--text-tertiary);
   text-align: center;
 }
 
@@ -2336,22 +2335,22 @@ kbd {
 .cowork-ghost,
 .cowork-solid {
   border: 0;
-  border-radius: 999px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  font-family: var(--font-ui);
-  font-size: var(--font-size-label-sm);
-  font-weight: 600;
+  font-family: var(--font-body);
+  font-size: 11px;
+  font-weight: var(--weight-medium);
   padding: var(--space-1) var(--space-3);
   transition: background var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide);
 }
-.cowork-ghost { background: transparent; color: var(--ink-fog); }
-.cowork-ghost:hover { background: color-mix(in oklch, var(--ink-pearl) 8%, transparent); color: var(--ink-pearl); }
+.cowork-ghost { background: transparent; color: var(--text-tertiary); }
+.cowork-ghost:hover { background: color-mix(in oklch, var(--ink-pearl) 8%, transparent); color: var(--text-primary); }
 .cowork-solid { background: var(--brass); color: var(--ink-abyss); }
 .cowork-solid:hover { background: var(--brass-bright); }
-.cowork-solid--danger { background: color-mix(in oklch, var(--coral) 80%, var(--ink-deep)); color: var(--ink-pearl); }
+.cowork-solid--danger { background: color-mix(in oklch, var(--coral) 80%, var(--ink-deep)); color: var(--text-primary); }
 .cowork-solid--danger:hover { background: var(--coral); }
-.cowork-x { border: 0; background: transparent; color: var(--ink-fog); cursor: pointer; font-size: var(--font-size-lg); line-height: 1; padding: 0 var(--space-1); }
-.cowork-x:hover { color: var(--ink-pearl); }
+.cowork-x { border: 0; background: transparent; color: var(--text-tertiary); cursor: pointer; font-size: var(--font-size-lg); line-height: 1; padding: 0 var(--space-1); }
+.cowork-x:hover { color: var(--text-primary); }
 .cowork-pill:focus-visible, .cowork-ghost:focus-visible, .cowork-solid:focus-visible, .cowork-x:focus-visible, .cowork-chip:focus-visible, .cowork-send:focus-visible,
 .cowork-dock-input:focus-visible, .cowork-composer textarea:focus-visible, .cowork-card textarea:focus-visible {
   outline: 2px solid var(--brass-bright);
@@ -2369,14 +2368,14 @@ kbd {
   align-items: center;
   gap: var(--space-1);
   border: 1px solid color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
-  border-radius: 999px;
+  border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--ink-veil) 96%, var(--brass));
   box-shadow: 0 2px 6px color-mix(in oklch, var(--ink-abyss) 45%, transparent), 0 12px 32px -8px color-mix(in oklch, var(--ink-abyss) 80%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   cursor: pointer;
-  font-family: var(--font-ui);
-  font-size: var(--font-size-label-sm);
-  font-weight: 600;
+  font-family: var(--font-body);
+  font-size: 11px;
+  font-weight: var(--weight-medium);
   padding: var(--space-1) var(--space-3);
   user-select: none;
   animation: cowork-pop var(--duration-fast) var(--ease-spring);
@@ -2401,7 +2400,7 @@ kbd {
   margin: 0;
   padding-left: var(--space-2);
   border-left: 2px solid var(--brass);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: var(--font-size-xs);
   font-style: italic;
   overflow-wrap: anywhere;
@@ -2414,13 +2413,13 @@ kbd {
   border: 0;
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-abyss) 82%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font: inherit;
   font-size: var(--font-size-sm);
   padding: var(--space-2);
   resize: none;
 }
-.cowork-composer textarea::placeholder { color: var(--ink-fog); }
+.cowork-composer textarea::placeholder { color: var(--text-tertiary); }
 .cowork-composer-actions { display: flex; justify-content: flex-end; gap: var(--space-1); }
 
 /* 도크 존 — 리딩 시트 스크롤포트 하단에 붙는 sticky 스택 */
@@ -2459,17 +2458,17 @@ kbd {
 .cowork-revision-head { display: flex; align-items: center; gap: var(--space-2); border-bottom: 1px solid var(--surface-rim); padding: var(--space-2) var(--space-3); }
 .cowork-revision-mark { display: grid; place-items: center; width: 28px; height: 28px; flex: none; border: 1px solid color-mix(in oklch, var(--aurora) 46%, var(--surface-rim)); border-radius: 9px; background: var(--aurora-glow); color: var(--aurora); }
 .cowork-revision-copy { display: grid; min-width: 0; gap: 2px; }
-.cowork-revision-head strong { color: var(--ink-pearl); font-size: var(--font-size-sm); }
-.cowork-revision-head small { color: var(--ink-fog); font: 600 var(--font-size-2xs)/1 var(--font-mono); letter-spacing: 0.08em; text-transform: uppercase; }
-.cowork-revision-toggle { display: grid; place-items: center; width: 28px; height: 28px; flex: none; margin-left: auto; border: 1px solid transparent; border-radius: 9px; background: transparent; color: var(--ink-fog); cursor: pointer; transition: border-color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide); }
-.cowork-revision-toggle:hover { border-color: var(--surface-rim); background: var(--surface-glass); color: var(--ink-pearl); }
+.cowork-revision-head strong { color: var(--text-primary); font-size: var(--font-size-sm); }
+.cowork-revision-head small { color: var(--text-tertiary); font-weight: var(--weight-medium); font-size: var(--font-size-2xs); line-height: 1; font-family: var(--font-mono); letter-spacing: 0.08em; text-transform: uppercase; }
+.cowork-revision-toggle { display: grid; place-items: center; width: 24px; height: 24px; flex: none; margin-left: auto; border: 1px solid transparent; border-radius: 9px; background: transparent; color: var(--text-tertiary); cursor: pointer; transition: border-color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide); }
+.cowork-revision-toggle:hover { border-color: var(--surface-rim); background: var(--surface-glass); color: var(--text-primary); }
 .cowork-revision-toggle span { width: 7px; height: 7px; border-right: 1.5px solid currentColor; border-bottom: 1.5px solid currentColor; transform: translateY(2px) rotate(-135deg); transition: transform var(--duration-base) var(--ease-glide); }
 .cowork-revision-stream.is-collapsed .cowork-revision-toggle span { transform: translateY(-2px) rotate(45deg); }
 .cowork-revision-content { display: grid; grid-template-rows: 1fr; opacity: 1; transition: grid-template-rows var(--duration-base) var(--ease-glide), opacity var(--duration-base) var(--ease-glide); }
 .cowork-revision-content-inner { min-height: 0; overflow: hidden; }
 .cowork-revision-stream.is-collapsed .cowork-revision-content { grid-template-rows: 0fr; opacity: 0; }
 .cowork-revision-body { display: grid; gap: var(--space-3); padding: var(--space-3) var(--space-4); }
-.cowork-revision-instruction { justify-self: end; max-width: 82%; margin: 0; border-radius: 15px 15px 4px 15px; background: var(--ink-mid); color: var(--ink-pearl); padding: var(--space-2) var(--space-3); font-size: var(--font-size-xs); overflow-wrap: anywhere; }
+.cowork-revision-instruction { justify-self: end; max-width: 82%; margin: 0; border-radius: 15px 15px 4px 15px; background: var(--ink-mid); color: var(--text-primary); padding: var(--space-2) var(--space-3); font-size: var(--font-size-xs); overflow-wrap: anywhere; }
 .cowork-revision-output-scroll { max-height: 220px; overflow: auto; }
 .cowork-revision-output.markdown-body {
   --font-size-2xs: 9px;
@@ -2486,7 +2485,7 @@ kbd {
   max-inline-size: none;
   margin: 0;
   padding-left: calc(var(--space-4) + var(--space-2));
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   line-height: 1.58;
   overflow-wrap: anywhere;
 }
@@ -2503,11 +2502,12 @@ kbd {
 .cowork-revision-output.markdown-body :is(blockquote, .code-block, .diagram-block) { margin-block: var(--space-3); }
 .cowork-revision-output.markdown-body blockquote { padding: var(--space-2) var(--space-3); }
 .cowork-revision-output.markdown-body .code-block code { padding: var(--space-3); }
+.cowork-revision-output.markdown-body .copy-code { font-size: 12px; }
 .cowork-revision-output::before { content: "✳"; position: absolute; left: 1px; top: 1px; color: var(--aurora); }
 .cowork-revision-status { display: flex; align-items: center; gap: var(--space-2); border-top: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--aurora) 5%, var(--ink-deep)); padding: var(--space-2) var(--space-3); }
 .cowork-revision-status i { position: relative; width: 16px; height: 16px; flex: none; border: 1px solid var(--aurora); border-radius: 50%; animation: cowork-revision-pulse 1.4s var(--ease-glide) infinite; }
 .cowork-revision-status i::after { content: ""; position: absolute; inset: 5px; border-radius: 50%; background: var(--aurora); box-shadow: 0 0 10px var(--aurora-glow); }
-.cowork-revision-status strong { color: var(--ink-pearl); font-size: var(--font-size-xs); }
+.cowork-revision-status strong { color: var(--text-primary); font-size: var(--font-size-xs); }
 .cowork-revision-stream.is-complete { border-color: color-mix(in oklch, var(--positive) 30%, var(--surface-rim)); }
 .cowork-revision-stream.is-stopped { border-color: var(--surface-rim-strong); }
 
@@ -2518,7 +2518,7 @@ kbd {
   gap: var(--space-1);
   width: min(560px, 100%);
   border: 1px solid var(--surface-rim-strong);
-  border-radius: 999px;
+  border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--ink-veil) 97%, var(--ink-deep));
   box-shadow: 0 2px 8px color-mix(in oklch, var(--ink-abyss) 50%, transparent), 0 20px 48px -12px color-mix(in oklch, var(--ink-abyss) 85%, transparent);
   overflow: hidden;
@@ -2543,18 +2543,18 @@ kbd {
   align-items: center;
   gap: var(--space-1);
   border: 0;
-  border-radius: 999px;
+  border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
-  font-family: var(--font-ui);
-  font-size: var(--font-size-label-sm);
-  font-weight: 600;
+  font-family: var(--font-body);
+  font-size: 11px;
+  font-weight: var(--weight-medium);
   padding: var(--space-1) var(--space-2);
   transition: background var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide);
 }
 .cowork-chip span { color: var(--brass-bright); }
-.cowork-chip:hover { background: color-mix(in oklch, var(--ink-pearl) 8%, transparent); color: var(--ink-pearl); }
+.cowork-chip:hover { background: color-mix(in oklch, var(--ink-pearl) 8%, transparent); color: var(--text-primary); }
 .cowork-chip.is-active { background: color-mix(in oklch, var(--brass) 16%, transparent); color: var(--brass-bright); }
 .cowork-chip--config { max-width: 12ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
@@ -2563,27 +2563,27 @@ kbd {
   min-width: 0;
   border: 0;
   background: transparent;
-  color: var(--ink-pearl);
-  font-family: var(--font-ui);
+  color: var(--text-primary);
+  font-family: var(--font-body);
   font-size: var(--font-size-sm);
   padding: var(--space-1);
 }
-.cowork-dock-input::placeholder { color: var(--ink-fog); }
+.cowork-dock-input::placeholder { color: var(--text-tertiary); }
 .cowork-dock-input:focus { outline: none; }
 
 .cowork-send {
   flex: 0 0 auto;
-  width: 30px;
-  height: 30px;
+  width: 32px;
+  height: 32px;
   display: grid;
   place-items: center;
   border: 0;
-  border-radius: 999px;
+  border-radius: var(--radius-sm);
   background: var(--brass);
   color: var(--ink-abyss);
   cursor: pointer;
   font-size: var(--font-size-sm);
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   transition: background var(--duration-fast) var(--ease-glide), transform var(--duration-fast) var(--ease-spring);
 }
 .cowork-send:hover { background: var(--brass-bright); transform: translateY(-1px); }
@@ -2600,11 +2600,11 @@ kbd {
   border-radius: 999px;
   background: color-mix(in oklch, var(--ink-veil) 94%, var(--brass));
   box-shadow: 0 12px 32px -10px color-mix(in oklch, var(--ink-abyss) 80%, transparent);
-  color: var(--ink-pearl);
-  font-size: var(--font-size-label-sm);
+  color: var(--text-primary);
+  font-size: 11px;
   padding: var(--space-1) var(--space-1) var(--space-1) var(--space-3);
 }
-.cowork-review-count { display: inline-flex; align-items: center; gap: var(--space-1); font-weight: 600; }
+.cowork-review-count { display: inline-flex; align-items: center; gap: var(--space-1); font-weight: var(--weight-medium); }
 .cowork-review-count i { width: 6px; height: 6px; border-radius: 50%; background: var(--brass-bright); }
 
 /* 팝오버(어노테이션 패널·에이전트 설정) */
@@ -2620,7 +2620,7 @@ kbd {
   box-shadow: 0 24px 48px -12px color-mix(in oklch, var(--ink-abyss) 85%, transparent);
   padding: var(--space-2);
 }
-.cowork-empty { margin: 0; color: var(--ink-fog); font-size: var(--font-size-sm); padding: var(--space-2); text-align: center; }
+.cowork-empty { margin: 0; color: var(--text-tertiary); font-size: var(--font-size-sm); padding: var(--space-2); text-align: center; }
 
 .cowork-card {
   display: grid;
@@ -2637,7 +2637,7 @@ kbd {
   margin: 0;
   padding-left: var(--space-2);
   border-left: 2px solid var(--brass);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: var(--font-size-xs);
   font-style: italic;
   overflow-wrap: anywhere;
@@ -2646,7 +2646,7 @@ kbd {
   border: 0;
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--ink-abyss) 78%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font: inherit;
   font-size: var(--font-size-sm);
   min-height: 40px;
@@ -2654,13 +2654,13 @@ kbd {
   resize: vertical;
 }
 .cowork-card footer { display: flex; align-items: center; justify-content: space-between; }
-.cowork-card-status { color: var(--ink-fog); font-size: var(--font-size-2xs); font-weight: 600; }
+.cowork-card-status { color: var(--text-tertiary); font-size: var(--font-size-2xs); font-weight: var(--weight-medium); }
 .cowork-card.is-sent .cowork-card-status { color: var(--aurora); }
 .cowork-card.is-done .cowork-card-status { color: var(--positive); }
 
 .cowork-config { display: flex; flex-wrap: wrap; gap: var(--space-2); width: auto; }
 .cowork-selector { display: grid; gap: var(--space-1); min-inline-size: 120px; }
-.cowork-selector span { color: var(--ink-fog); font-size: var(--font-size-2xs); font-weight: 600; }
+.cowork-selector span { color: var(--text-tertiary); font-size: var(--font-size-2xs); font-weight: var(--weight-medium); }
 
 /* AI 요약 카드 */
 .cowork-summary {
@@ -2672,7 +2672,7 @@ kbd {
   border-radius: var(--radius-lg);
   background: color-mix(in oklch, var(--ink-veil) 96%, var(--aurora));
   box-shadow: 0 16px 40px -12px color-mix(in oklch, var(--ink-abyss) 80%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-size: var(--font-size-sm);
   padding: var(--space-3);
 }
@@ -2704,7 +2704,7 @@ kbd {
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-veil) 97%, var(--ink-deep));
   box-shadow: 0 12px 32px -10px color-mix(in oklch, var(--ink-abyss) 80%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-size: var(--font-size-xs);
   line-height: 1.5;
   padding: var(--space-2) var(--space-3);

--- a/runtime/fleet-console/core/client/src/rail/plans.css
+++ b/runtime/fleet-console/core/client/src/rail/plans.css
@@ -65,9 +65,9 @@
 .plans-search-label {
   display: grid;
   gap: 4px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 9px;
+  font-size: 10px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -78,8 +78,11 @@
   background: color-mix(in srgb, var(--surface-rim) 32%, transparent);
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
-  color: var(--ink-spectral);
-  font: inherit;
+  color: var(--text-secondary);
+  font-weight: var(--weight-regular);
+  font-size: inherit;
+  line-height: inherit;
+  font-family: inherit;
   letter-spacing: normal;
   text-transform: none;
 }
@@ -93,7 +96,7 @@
   background: transparent;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
   font-family: var(--font-mono);
   font-size: 9px;
@@ -118,7 +121,7 @@
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   text-align: left;
 }
 
@@ -162,7 +165,7 @@
 
 .plans-row-name {
   overflow: hidden;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: 11px;
   text-overflow: ellipsis;
@@ -172,7 +175,7 @@
 .plans-row-meta,
 .plans-reader-meta,
 .plans-loading {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
   line-height: 1.4;
@@ -217,10 +220,10 @@
 .plans-reader-title {
   margin: 0;
   overflow: hidden;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-body);
   font-size: 17px;
-  font-weight: 580;
+  font-weight: var(--weight-medium);
   line-height: 1.2;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -237,14 +240,14 @@
   padding: 4px 6px;
   background: transparent;
   border: 1px solid transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 14px;
   line-height: 1;
 }
 
 .plans-close:hover {
   border-color: var(--surface-rim);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .plans-reader-body {
@@ -272,7 +275,7 @@
   padding: 5px 7px;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .plans-wave.is-complete {
@@ -292,7 +295,9 @@
   border: 0;
   color: inherit;
   cursor: pointer;
-  font: inherit;
+  font-weight: var(--weight-regular);
+  line-height: inherit;
+  font-family: inherit;
   font-size: 11px;
   text-align: left;
   text-overflow: ellipsis;
@@ -317,7 +322,7 @@
   display: flex;
   align-items: baseline;
   gap: 7px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 9.5px;
   line-height: 1.4;
@@ -331,7 +336,10 @@
   border: 0;
   color: inherit;
   cursor: pointer;
-  font: inherit;
+  font-weight: var(--weight-regular);
+  font-size: inherit;
+  line-height: inherit;
+  font-family: inherit;
   text-align: left;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -344,11 +352,11 @@
 }
 
 .plans-lane.is-blocked {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
 }
 
 .plans-lane.is-ready {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .plans-lane-ready {
@@ -361,7 +369,7 @@
   padding: 1px 7px;
   border: 1px dashed var(--surface-rim);
   border-radius: var(--radius-sm);
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
 }
@@ -371,7 +379,7 @@
   padding: 1px 7px;
   border: 1px solid var(--surface-rim-strong);
   border-radius: var(--radius-sm);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: 9px;
   letter-spacing: 0.14em;
@@ -397,13 +405,14 @@
 .plans-error-state {
   display: grid;
   gap: 7px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 12px;
   line-height: 1.5;
 }
 
 .plans-empty-detail {
-  color: color-mix(in srgb, var(--ink-fog) 74%, transparent);
+  /* 위계는 크기로 낸다 — 판독 티어를 알파로 희석하면 토큰이 지는 대비 계약이 무력화된다. */
+  color: var(--text-tertiary);
   font-size: 11px;
 }
 

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -72,6 +72,60 @@
   font-family: var(--font-mono);
 }
 
+/* Shared button variants — controls use compact radii; brass marks hover/focus location and coral remains danger-only. */
+.fc-btn {
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  font-weight: var(--weight-medium);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: 8px 14px;
+  cursor: pointer;
+  transition: background var(--duration-fast), border-color var(--duration-fast), color var(--duration-fast);
+}
+.fc-btn--primary {
+  background: var(--brass);
+  color: var(--ink-abyss);
+  font-weight: var(--weight-bold);
+}
+.fc-btn--secondary {
+  background: none;
+  border-color: var(--hairline-strong);
+  color: var(--text-primary);
+}
+.fc-btn--ghost {
+  background: none;
+  color: var(--text-tertiary);
+}
+.fc-btn--danger {
+  background: none;
+  border-color: color-mix(in oklch, var(--coral) 45%, transparent);
+  color: var(--coral);
+}
+
+.fc-btn--primary:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--brass) 86%, var(--text-primary));
+}
+
+.fc-btn--secondary:hover:not(:disabled) {
+  border-color: color-mix(in oklch, var(--brass) 45%, var(--hairline-strong));
+  background: color-mix(in oklch, var(--brass) 8%, transparent);
+}
+
+.fc-btn--ghost:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--brass) 8%, transparent);
+  color: var(--text-primary);
+}
+
+.fc-btn--danger:hover:not(:disabled) {
+  border-color: color-mix(in oklch, var(--coral) 64%, transparent);
+  background: color-mix(in oklch, var(--coral) 10%, transparent);
+}
+
+.fc-btn:focus-visible {
+  outline: 2px solid color-mix(in oklch, var(--brass) 48%, transparent);
+  outline-offset: 2px;
+}
 /* ===== Global Settings — 전역 옵션(시스템 프롬프트 주입 + 메타포) 표면 ===== */
 .global-settings-page {
   display: grid;
@@ -96,10 +150,10 @@
 
 .global-settings-hero h2 {
   margin: 0;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-size: clamp(42px, 6vw, 72px);
-  font-weight: 300;
+  font-weight: var(--weight-regular);
   letter-spacing: -0.03em;
   line-height: 0.95;
 }
@@ -110,7 +164,7 @@
   color: var(--aurora);
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -176,10 +230,10 @@
 
 .global-settings-nav-label {
   overflow: hidden;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-body);
   font-size: 20px;
-  font-weight: 400;
+  font-weight: var(--weight-regular);
   letter-spacing: -0.01em;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -188,15 +242,15 @@
 
 .global-settings-nav-item:hover .global-settings-nav-label,
 .global-settings-nav-item.is-active .global-settings-nav-label {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .global-settings-nav-eyebrow {
   overflow: hidden;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   text-overflow: ellipsis;
   white-space: nowrap;
   transition: color var(--duration-fast) var(--ease-spring);
@@ -212,7 +266,7 @@
   color: var(--brass);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.16em;
   text-transform: uppercase;
 }
@@ -229,10 +283,10 @@
 .global-settings-plugin-heading {
   margin: 0;
   padding: 0 var(--space-3);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
@@ -302,17 +356,17 @@
 
 .global-settings-resp-title {
   margin: 0;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.16em;
   text-transform: uppercase;
 }
 
 .global-settings-help {
   margin: 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.6;
@@ -322,7 +376,7 @@
   margin: 0;
   padding-top: var(--space-4);
   border-top: 1px solid color-mix(in oklch, var(--surface-rim) 40%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.55;
@@ -353,12 +407,10 @@
   border: 0;
   border-radius: var(--radius-xs);
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
   white-space: nowrap;
   transition:
     background var(--duration-fast) var(--ease-spring),
@@ -376,7 +428,7 @@
 
 .global-settings-toggle:hover:not(:disabled) {
   background: color-mix(in oklch, var(--brass) 8%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .global-settings-toggle.is-on {
@@ -439,10 +491,10 @@
 }
 
 .console-port-input-label {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
@@ -454,7 +506,7 @@
   border: 1px solid var(--surface-rim-strong);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--ink-deep) 86%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 14px;
   letter-spacing: 0.04em;
@@ -464,7 +516,7 @@
 }
 
 .console-port-input::placeholder {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
 }
 
 .console-port-input:focus {
@@ -484,7 +536,7 @@
 }
 
 .console-port-hint {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0.03em;
@@ -520,17 +572,17 @@
 
 .console-port-effective-label {
   margin: 0;
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 9px;
-  font-weight: 700;
+  font-size: 10px;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.16em;
   text-transform: uppercase;
 }
 
 .console-port-effective-value {
   margin: 0;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: 13px;
   letter-spacing: 0.04em;
@@ -549,7 +601,7 @@
   border: 1px solid color-mix(in oklch, var(--warn) 46%, transparent);
   border-radius: var(--radius-md);
   background: var(--warn-glow);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.6;
@@ -557,12 +609,12 @@
 
 .console-port-warning strong {
   color: var(--warn);
-  font-weight: 700;
+  font-weight: var(--weight-bold);
 }
 
 .console-port-note {
   margin: 0;
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.55;
@@ -597,12 +649,10 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--surface-glass-strong) 55%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-weight: var(--weight-medium);
   cursor: pointer;
   transition:
     color var(--duration-fast) var(--ease-spring),
@@ -612,12 +662,12 @@
 }
 
 .theme-card:hover:not(:disabled) {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   border-color: color-mix(in oklch, var(--brass) 40%, var(--surface-rim));
 }
 
 .theme-card.is-active {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   border-color: color-mix(in oklch, var(--brass) 70%, transparent);
   background: color-mix(in oklch, var(--brass) 12%, transparent);
   box-shadow: 0 0 0 1px color-mix(in oklch, var(--brass) 42%, transparent), var(--shadow-soft);
@@ -667,12 +717,10 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--surface-glass-strong) 55%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
   transition:
     border-color var(--duration-fast) var(--ease-spring),
     background var(--duration-fast) var(--ease-spring),
@@ -682,7 +730,7 @@
 .typography-reset:hover:not(:disabled) {
   border-color: color-mix(in oklch, var(--brass) 56%, var(--surface-rim));
   background: color-mix(in oklch, var(--brass) 10%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .global-settings-row.is-stack {
@@ -698,10 +746,10 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--ink-spectral) 6%, transparent);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 9px;
-  font-weight: 700;
+  font-size: 10px;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.14em;
   line-height: 1.2;
   text-transform: uppercase;
@@ -727,7 +775,7 @@
 }
 
 .current-readout .cr-label {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.14em;
@@ -735,10 +783,10 @@
 }
 
 .current-readout .cr-value {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 13px;
-  font-weight: 600;
+  font-weight: var(--weight-medium);
 }
 
 .current-readout .cr-value.is-ok {
@@ -750,7 +798,7 @@
 }
 
 .current-readout .cr-sep {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
 }
 
 .font-cards {
@@ -769,7 +817,7 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--surface-glass-strong) 70%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   text-align: left;
   cursor: pointer;
   transition:
@@ -801,9 +849,9 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--space-2);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-size: 13px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
 }
 
 .font-card .fc-check {
@@ -817,20 +865,20 @@
 }
 
 .font-card .fc-sample {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-size: 19px;
   letter-spacing: 0.01em;
   line-height: 1.25;
 }
 
 .font-card .fc-sample.is-custom {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-body);
   font-style: italic;
 }
 
 .font-card .fc-meta {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.05em;
@@ -839,7 +887,7 @@
 .font-card .fc-bundled {
   color: var(--positive);
   font-family: var(--font-mono);
-  font-size: 9px;
+  font-size: 10px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
 }
@@ -890,17 +938,17 @@
   border: 0;
   outline: none;
   background: transparent;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 13px;
 }
 
 .font-field input::placeholder {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
 }
 
 .font-field .field-icon {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 13px;
 }
@@ -957,7 +1005,7 @@
 }
 
 .size-label {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 12px;
 }
 
@@ -979,12 +1027,10 @@
   border: 0;
   border-radius: var(--radius-xs);
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
   white-space: nowrap;
   cursor: pointer;
   transition:
@@ -993,7 +1039,7 @@
 }
 
 .segmented-option:hover:not(.is-active) {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .segmented-option.is-active {
@@ -1023,10 +1069,10 @@
 }
 
 .model-auth-name {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.16em;
   text-transform: uppercase;
 }
@@ -1035,10 +1081,10 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -1074,14 +1120,14 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--surface-glass) 60%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 12px;
   letter-spacing: 0.04em;
 }
 
 .model-auth-input::placeholder {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
 }
 
 .model-auth-input:focus {
@@ -1109,12 +1155,10 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
   white-space: nowrap;
   cursor: pointer;
   transition:
@@ -1125,7 +1169,7 @@
 
 .model-auth-button:hover:not(:disabled) {
   background: color-mix(in oklch, var(--brass) 8%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .model-auth-button.is-primary {
@@ -1135,7 +1179,7 @@
 
 .model-auth-button.is-primary:hover:not(:disabled) {
   background: color-mix(in oklch, var(--brass) 14%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .model-auth-button:active:not(:disabled) {
@@ -1170,10 +1214,10 @@
 }
 
 .agent-cli-name {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 12px;
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.16em;
   text-transform: uppercase;
 }
@@ -1186,7 +1230,7 @@
 
 /* 버전은 데이터이므로 대문자 변환 없이 중립 ink로 표기한다. */
 .agent-cli-version {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0.04em;
@@ -1196,10 +1240,10 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -1255,10 +1299,10 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
@@ -1286,7 +1330,7 @@
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 800;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   line-height: 1.2;
 }
@@ -1294,7 +1338,7 @@
 .backend-api-path {
   min-width: 0;
   overflow-wrap: anywhere;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0.02em;
@@ -1303,7 +1347,7 @@
 /* 역할 설명문은 본문 UI 폰트(Manrope)로 — 식별자(method/path/gate=mono)와 타이포 위계를 분리한다. */
 .backend-api-summary {
   min-width: 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-body);
   font-size: 12px;
   line-height: 1.45;
@@ -1312,11 +1356,11 @@
 .backend-api-gate {
   min-width: 0;
   justify-self: end;
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.45;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
@@ -1364,12 +1408,10 @@
   border: 0;
   border-radius: var(--radius-xs);
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
   white-space: nowrap;
   cursor: pointer;
   transition:
@@ -1380,7 +1422,7 @@
 
 .settings-disclosure-toggle:hover:not(:disabled) {
   background: color-mix(in oklch, var(--brass) 8%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .settings-disclosure-toggle[aria-expanded="true"] {
@@ -1390,7 +1432,7 @@
 
 .settings-disclosure-toggle:active:not(:disabled) {
   background: color-mix(in oklch, var(--brass) 16%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   transform: translateY(1px);
 }
 
@@ -1431,18 +1473,20 @@
 /* awaiting — aurora(청록). 운영자 입력을 기다리는 살아있는 대기 신호(pulse). */
 .tenant-beacon.is-awaiting {
   background: var(--aurora);
-  box-shadow: 0 0 12px var(--aurora-glow);
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--aurora) 30%, transparent);
   animation: aurora-pulse 1.8s ease-in-out infinite;
 }
 
 .tenant-beacon.is-dormant {
-  background: color-mix(in oklch, var(--brass) 55%, var(--ink-rim));
-  box-shadow: 0 0 8px color-mix(in oklch, var(--brass) 30%, transparent);
+  background: none;
+  border: 1.5px solid color-mix(in oklch, var(--brass) 55%, var(--ink-rim));
+  box-sizing: border-box;
 }
 
 /* Agent CLI 턴 진행 중(캐리어 스트리밍 포함) — 노랑(--warn). aurora(awaiting 대기)와 구별한다. */
 .tenant-beacon.is-turn-running {
   background: var(--warn);
+  border-radius: 2px;
   box-shadow: 0 0 10px var(--warn-glow);
 }
 
@@ -1464,19 +1508,21 @@
 
 .status-dot--bad {
   background: var(--coral);
+  border-radius: 2px;
   box-shadow: 0 0 10px var(--coral-glow);
 }
 
 .status-dot--idle {
-  background: var(--ink-rim);
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--ink-fog) 20%, transparent);
+  background: none;
+  border: 1.5px solid var(--ink-rim);
+  box-sizing: border-box;
 }
 
 .job-summary-eyebrow {
   margin: 2px var(--space-2) var(--space-3);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
@@ -1492,8 +1538,8 @@
 
 .workspace-add-button {
   display: grid;
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   place-items: center;
   /* Theater 박스(theater-trigger)와 같은 글라스 웰 + 중립 헤어라인 + 브래스 아이콘 언어를 공유한다. */
   border: 1px solid var(--surface-rim);
@@ -1669,10 +1715,10 @@
 
 .canvas-context-menu-head-text strong {
   font-family: var(--font-body);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   font-size: 15px;
   letter-spacing: -0.01em;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   white-space: nowrap;
 }
 
@@ -1682,7 +1728,7 @@
   padding: var(--space-1) var(--space-2);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--brass);
@@ -1697,9 +1743,9 @@
 .canvas-context-menu-plugin {
   margin: var(--space-1) 0 0;
   padding: var(--space-1) var(--space-2) 0;
-  color: color-mix(in oklch, var(--brass) 72%, var(--ink-fog));
+  color: color-mix(in oklch, var(--brass) 72%, var(--text-tertiary));
   font-family: var(--font-mono);
-  font-size: 9px;
+  font-size: 10px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -1720,8 +1766,8 @@
   padding-left: var(--space-2);
   color: var(--brass);
   font-family: var(--font-mono);
-  font-size: 9.5px;
-  font-weight: 700;
+  font-size: 10px;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
@@ -1755,7 +1801,7 @@
 }
 
 .canvas-shortcuts-or {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 8.5px;
 }
@@ -1773,17 +1819,17 @@
   border: 1px solid var(--surface-rim);
   border-radius: 6px;
   background: color-mix(in oklch, var(--ink-deep) 80%, transparent);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   box-shadow: 0 1px 0 color-mix(in oklch, var(--ink-abyss) 70%, transparent);
   font-family: var(--font-mono);
   font-size: 9.5px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   line-height: 1.25;
 }
 
 .canvas-shortcuts-entry dd {
   margin: 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 11.5px;
   line-height: 1.4;
 }
@@ -1815,11 +1861,11 @@
   left: 12px;
   z-index: 3;
   font-family: var(--font-mono);
-  font-size: 9px;
-  font-weight: 700;
+  font-size: 10px;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   pointer-events: none;
 }
 
@@ -1894,7 +1940,7 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--surface-glass) 78%, var(--ink-deep));
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   transition:
     color var(--duration-fast) var(--ease-spring),
     border-color var(--duration-fast) var(--ease-spring),
@@ -1909,12 +1955,12 @@
   z-index: 14;
   display: grid;
   place-items: center;
-  width: 34px;
-  height: 34px;
+  width: 32px;
+  height: 32px;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-lg);
   background: color-mix(in oklch, var(--surface-glass) 60%, color-mix(in oklch, var(--ink-deep) 72%, transparent));
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   box-shadow: var(--shadow-floating);
   transition:
     color var(--duration-fast) var(--ease-spring),
@@ -2119,7 +2165,7 @@
   flex: none;
   padding: var(--space-3) var(--space-4) var(--space-1);
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: 10px;
   letter-spacing: 0.2em;
   text-transform: uppercase;
   color: var(--text-tertiary);
@@ -2298,11 +2344,11 @@
   border: 1px solid transparent;
   border-radius: 8px;
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: grab;
   font-family: var(--font-body);
   font-size: 12.5px;
-  font-weight: 750;
+  font-weight: var(--weight-bold);
   letter-spacing: normal;
   text-transform: none;
   transition:
@@ -2318,12 +2364,12 @@
 .side-bar-theater-header:focus-visible {
   background: var(--ink-deep);
   border-color: var(--surface-rim);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   outline: none;
 }
 
 .side-bar-theater-header.is-active {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   border-color: transparent;
   background: var(--ink-deep);
 }
@@ -2339,7 +2385,7 @@
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
 }
 
 .side-bar-ghost-theater-row {
@@ -2353,11 +2399,11 @@
   border: 0;
   border-radius: 8px;
   background: none;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
   font-family: var(--font-body);
   font-size: 12.5px;
-  font-weight: 750;
+  font-weight: var(--weight-bold);
   text-align: left;
 }
 
@@ -2370,7 +2416,7 @@
   border: 1px dashed var(--ink-rim);
   border-radius: var(--radius-xs);
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .side-bar-ghost-theater-anchor svg {
@@ -2380,7 +2426,7 @@
 
 .side-bar-ghost-theater-row:hover:not(:disabled) .side-bar-ghost-theater-label,
 .side-bar-ghost-theater-row:focus-visible .side-bar-ghost-theater-label {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .side-bar-ghost-theater-row:hover:not(:disabled) .side-bar-ghost-theater-anchor,
@@ -2413,7 +2459,7 @@
   flex: none;
   width: 12px;
   height: 12px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   transition: transform 0.15s ease;
 }
 
@@ -2440,7 +2486,7 @@
   border: 1px solid transparent;
   border-radius: 6px;
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
 }
 
@@ -2452,7 +2498,7 @@
 
 .side-bar-status-axis-toggle:hover {
   border-color: var(--hairline-strong);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .side-bar-status-axis-toggle[aria-pressed="true"] {
@@ -2493,7 +2539,7 @@
   border: 1px solid transparent;
   border-radius: 6px;
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
   transition:
     background var(--duration-fast) var(--ease-spring),
@@ -2517,7 +2563,7 @@
 .side-bar-theater-row-btn:hover,
 .side-bar-theater-row-btn:focus-visible {
   border-color: var(--hairline-strong);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .side-bar-theater-row-btn:focus-visible {
@@ -2573,7 +2619,7 @@
 }
 
 .side-bar-chip--active .side-bar-chip-name {
-  color: color-mix(in oklch, var(--brass) 88%, var(--ink-spectral));
+  color: color-mix(in oklch, var(--brass) 88%, var(--text-secondary));
 }
 
 /* minimized: 이름은 판독 가능한 --ink-muted 티어로 유지하고 "치워둠" 신호는 아이콘 감쇠로만
@@ -2653,7 +2699,7 @@
   justify-content: center;
   width: 16px;
   height: 16px;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .side-bar-chip-op-icon svg {
@@ -2669,8 +2715,8 @@
   text-overflow: ellipsis;
   font-family: var(--font-body);
   font-size: 13px;
-  font-weight: 700;
-  color: var(--ink-spectral);
+  font-weight: var(--weight-bold);
+  color: var(--text-secondary);
   opacity: 1;
   transition: opacity var(--duration-fast) var(--ease-spring);
 }
@@ -2682,10 +2728,10 @@
   border: 1px solid color-mix(in oklch, var(--brass) 44%, var(--surface-rim));
   border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-deep) 84%, var(--surface-glass));
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-size: 13px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   outline: none;
   box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--brass) 12%, transparent);
 }
@@ -2701,8 +2747,8 @@
   flex: none;
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 700;
-  color: var(--ink-fog);
+  font-weight: var(--weight-bold);
+  color: var(--text-tertiary);
   min-width: 16px;
   text-align: right;
 }
@@ -2735,12 +2781,12 @@
   white-space: nowrap;
   font-family: var(--font-mono);
   font-size: 9.5px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.04em;
   padding: 2px 7px;
   border: 1px solid color-mix(in oklch, var(--group-mark) 34%, transparent);
   border-radius: 999px;
-  color: color-mix(in oklch, var(--group-mark) 85%, var(--ink-pearl));
+  color: color-mix(in oklch, var(--group-mark) 85%, var(--text-primary));
   background: color-mix(in oklch, var(--group-mark) 13%, transparent);
 }
 
@@ -2797,6 +2843,9 @@
     color var(--duration-fast) var(--ease-spring);
 }
 
+/* 아이콘 버튼 2티어(24px 밀집 / 32px 일반)의 의도된 예외 — 칩 인라인 액션은 독립 버튼이 아니라
+   호버·포커스에서만 레이아웃에 펼쳐지는 초밀집 액션이라 20px를 유지한다. 24px로 올리면 armed
+   "Close?" 확장폭이 칩 최대폭 계약을 넘겨 잘린다. */
 .side-bar-chip:hover .side-bar-chip-close,
 .side-bar-chip:focus-within .side-bar-chip-close,
 .side-bar-chip:hover .side-bar-chip-minimize,
@@ -2807,7 +2856,7 @@
   padding: 0;
   margin-left: 0;
   border: 1px solid var(--surface-rim);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   background: color-mix(in oklch, var(--surface-glass) 58%, transparent);
   opacity: 1;
   pointer-events: auto;
@@ -2819,7 +2868,7 @@
 .side-bar-chip-minimize:focus-visible {
   background: color-mix(in oklch, var(--ink-spectral) 10%, transparent);
   border-color: color-mix(in oklch, var(--ink-fog) 30%, transparent);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   outline: none;
 }
 
@@ -2841,7 +2890,7 @@
   color: var(--coral);
   font-family: var(--font-body);
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   width: auto;
   height: 20px;
   padding: 0 6px;
@@ -2919,10 +2968,10 @@
   gap: 7px;
   padding: 7px 12px 7px 8px;
   background: color-mix(in oklch, var(--status-color) 8%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10.5px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.12em;
 }
 
@@ -2940,14 +2989,14 @@
   background: transparent;
   border: none;
   cursor: pointer;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   border-radius: var(--radius-sm);
   transition: color var(--duration-fast) var(--ease-spring);
 }
 
 .side-bar-status-header__toggle:hover,
 .side-bar-status-header__toggle:focus-visible {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   outline: none;
 }
 
@@ -2988,7 +3037,7 @@
   flex: none;
   min-width: 14px;
   margin-left: auto;
-  color: color-mix(in oklch, var(--status-color) 65%, var(--ink-pearl));
+  color: color-mix(in oklch, var(--status-color) 65%, var(--text-primary));
   font-variant-numeric: tabular-nums;
   text-align: right;
 }
@@ -3108,14 +3157,14 @@
   background: transparent;
   border: none;
   cursor: pointer;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   border-radius: var(--radius-sm);
   transition: color var(--duration-fast) var(--ease-spring);
 }
 
 .side-bar-group-header__toggle:hover,
 .side-bar-group-header__toggle:focus-visible {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   outline: none;
 }
 
@@ -3165,24 +3214,24 @@
   white-space: nowrap;
   font-family: var(--font-body);
   font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .side-bar-group-header__count {
   flex: none;
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 700;
-  color: var(--ink-fog);
+  font-weight: var(--weight-bold);
+  color: var(--text-tertiary);
   min-width: 14px;
   text-align: right;
 }
 
 .side-bar-group-header[style*="--grp-color"] .side-bar-group-header__count {
-  color: color-mix(in oklch, var(--grp-color) 65%, var(--ink-pearl));
+  color: color-mix(in oklch, var(--grp-color) 65%, var(--text-primary));
 }
 
 /* 그룹 마크 — 헤더 화살표와 이름 사이의 정체성 도트. */
@@ -3200,10 +3249,10 @@
   padding: 2px var(--space-1) 2px var(--space-2);
   font-family: var(--font-body);
   font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   opacity: 0.5;
 }
 
@@ -3246,7 +3295,7 @@
   min-height: 24px;
   padding: 3px var(--space-2) 3px var(--space-2);
   border: 1px solid var(--ink-rim);
-  border-radius: 999px;
+  border-radius: var(--radius-sm);
   overflow: visible;
   background: var(--ink-mid);
   box-shadow: var(--shadow-soft);
@@ -3271,7 +3320,7 @@
   min-width: 0;
   font-family: var(--font-body);
   font-size: calc(var(--font-body-size) * 0.86);
-  font-weight: 650;
+  font-weight: var(--weight-medium);
   line-height: 1;
 }
 
@@ -3281,7 +3330,7 @@
   padding: 3px 0;
   border: 0;
   border-radius: var(--radius-sm);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   background: transparent;
   cursor: text;
   text-overflow: ellipsis;
@@ -3345,7 +3394,7 @@
   padding: 0;
   cursor: pointer;
   border: 1px solid transparent;
-  border-radius: 999px;
+  border-radius: var(--radius-sm);
   background: transparent;
   transition:
     border-color var(--duration-fast) var(--ease-spring),
@@ -3386,11 +3435,11 @@
 
 .group-context-menu-section-label {
   font-family: var(--font-mono);
-  font-size: 9px;
-  font-weight: 700;
+  font-size: 10px;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   padding: 4px 6px 2px;
 }
 
@@ -3406,8 +3455,8 @@
   text-align: left;
   font-family: var(--font-body);
   font-size: 13px;
-  font-weight: 500;
-  color: var(--ink-spectral);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
   transition:
     background var(--duration-fast) var(--ease-spring),
     border-color var(--duration-fast) var(--ease-spring);
@@ -3422,11 +3471,11 @@
 
 .group-context-menu-item.is-selected {
   background: color-mix(in oklch, var(--brass) 10%, transparent);
-  color: color-mix(in oklch, var(--brass) 80%, var(--ink-spectral));
+  color: color-mix(in oklch, var(--brass) 80%, var(--text-secondary));
 }
 
 .group-context-menu-item--new {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-style: italic;
 }
 
@@ -3437,7 +3486,7 @@
 .group-context-menu-item--danger.is-armed {
   background: color-mix(in oklch, var(--coral) 12%, transparent);
   border-color: color-mix(in oklch, var(--coral) 30%, transparent);
-  font-weight: 700;
+  font-weight: var(--weight-bold);
 }
 
 .group-context-menu-item__dot {
@@ -3464,7 +3513,7 @@
 }
 
 .group-context-menu-item__new-label {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .group-context-menu-new-input {
@@ -3475,7 +3524,7 @@
   border: 1px solid color-mix(in oklch, var(--ink-fog) 30%, transparent);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--ink-spectral) 6%, transparent);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-body);
   font-size: 13px;
   outline: none;
@@ -3556,14 +3605,14 @@
 .accent-tone-name {
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .accent-tone-row--clear .accent-tone-name {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .canvas-operation-job-count {
@@ -3574,7 +3623,7 @@
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   line-height: 1;
 }
 
@@ -3669,7 +3718,7 @@
   height: 24px;
   padding: 0;
   border: 1px solid var(--surface-rim);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   background: color-mix(in oklch, var(--surface-glass) 58%, transparent);
   opacity: 1;
   pointer-events: auto;
@@ -3688,7 +3737,7 @@
   color: var(--coral);
   font-family: var(--font-body);
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   opacity: 1;
   pointer-events: auto;
   animation: chip-close-arm 1.5s linear forwards;
@@ -3730,7 +3779,7 @@
   background: color-mix(in oklch, var(--ink-deep) 94%, transparent);
   font-family: var(--font-body);
   font-size: calc(var(--font-body-size) * 0.97);
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   line-height: 1;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -3800,7 +3849,7 @@
   background:
     radial-gradient(circle at 50% 42%, color-mix(in oklch, var(--brass) 10%, transparent), transparent 34%),
     color-mix(in oklch, var(--ink-deep) 74%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   cursor: pointer;
 }
 
@@ -3815,7 +3864,7 @@
   color: var(--brass);
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 800;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.14em;
   text-align: center;
   text-transform: uppercase;
@@ -3828,9 +3877,9 @@
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--brass) 12%, var(--surface-glass));
   color: var(--brass-bright);
-  font-family: var(--font-ui);
+  font-family: var(--font-body);
   font-size: 13px;
-  font-weight: 800;
+  font-weight: var(--weight-bold);
   text-align: center;
   box-shadow: 0 0 18px color-mix(in oklch, var(--brass) 12%, transparent);
 }
@@ -3929,7 +3978,7 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-lg);
   background: color-mix(in oklch, var(--surface-glass) 82%, var(--ink-deep));
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   box-shadow: var(--shadow-soft);
 }
 
@@ -3953,7 +4002,7 @@
 }
 
 .theater-menu-new-group {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .theater-menu-new-group-input {
@@ -3998,11 +4047,11 @@
 .job-title {
   overflow: hidden;
   margin: 0;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-size: 22px;
   font-variation-settings: "opsz" 30;
-  font-weight: 560;
+  font-weight: var(--weight-medium);
   line-height: 1.15;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -4013,14 +4062,15 @@
   flex-wrap: wrap;
   gap: var(--space-2);
   margin: var(--space-1) 0 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 10px;
 }
 
 .job-status,
 .track-status {
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.12em;
+  font-size: 10px;
   text-transform: uppercase;
 }
 
@@ -4041,7 +4091,7 @@
 
 .job-status--idle,
 .track-status--idle {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .job-id {
@@ -4049,7 +4099,7 @@
   padding: 4px 10px;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 10px;
 }
 
@@ -4061,24 +4111,24 @@
   flex-direction: column;
   gap: var(--space-2);
   padding: var(--space-8);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   text-align: center;
 }
 
 .stage-idle h2 {
   margin: 0;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-size: 30px;
   font-variation-settings: "opsz" 44;
-  font-weight: 540;
+  font-weight: var(--weight-medium);
   line-height: 1.1;
 }
 
 .stage-idle p {
   max-width: 430px;
   margin: 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 13px;
 }
 
@@ -4101,7 +4151,7 @@
   align-items: center;
   gap: var(--space-2);
   margin: var(--space-2);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 11px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -4153,9 +4203,9 @@
   min-width: 0;
   margin: 0;
   overflow: hidden;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-size: 13px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -4165,10 +4215,10 @@
   padding: 2px var(--space-2);
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
@@ -4192,11 +4242,9 @@
   color: var(--text-tertiary);
   cursor: pointer;
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.1em;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
   list-style: none;
-  text-transform: uppercase;
 }
 
 .track-card-thinking > summary::-webkit-details-marker {
@@ -4213,7 +4261,7 @@
 
 .track-card-thought pre {
   margin: var(--space-1) 0 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
   font-style: italic;
@@ -4266,7 +4314,7 @@
 
 .track-card-tool-chip strong {
   color: var(--text-primary);
-  font-weight: 700;
+  font-weight: var(--weight-bold);
 }
 
 .track-card-tool-chip > span {
@@ -4314,9 +4362,9 @@
 .track-name {
   overflow: hidden;
   margin: 0;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-size: 13.5px;
-  font-weight: 720;
+  font-weight: var(--weight-bold);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -4326,14 +4374,14 @@
   padding: 2px 7px;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
-  color: var(--ink-fog);
-  font-size: 9.5px;
-  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  font-size: 10px;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .track-tag--dim {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   letter-spacing: 0.01em;
   text-transform: none;
 }
@@ -4346,7 +4394,7 @@
 
 .track-subtitle {
   margin: var(--space-2) 0 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 12px;
 }
 
@@ -4360,7 +4408,7 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--ink-deep) 78%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10.5px;
   line-height: 1.6;
@@ -4387,10 +4435,8 @@
   gap: var(--space-2);
   padding: 4px var(--space-2);
   border-radius: var(--radius-xs);
-  color: var(--ink-fog);
-  font-size: 10px;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+  color: var(--text-tertiary);
+  font-size: 12px;
   transition: color var(--duration-fast) var(--ease-spring);
 }
 
@@ -4412,7 +4458,7 @@
   border-left: 2px solid var(--brass);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--ink-deep) 82%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 11px;
   font-style: italic;
   line-height: 1.7;
@@ -4437,12 +4483,12 @@
   padding: 3px 10px;
   border: 1px solid var(--surface-rim);
   border-radius: 999px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 10px;
 }
 
 .tool-chip-glyph {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   font-size: 9px;
 }
 
@@ -4475,7 +4521,7 @@
 }
 
 .tool-chip--idle {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .tool-chip-title {
@@ -4487,7 +4533,7 @@
 
 .tool-chip-status {
   flex: none;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .track-output {
@@ -4506,7 +4552,7 @@
 .track-text {
   margin: 0;
   padding: var(--space-4);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-size: 11.5px;
   line-height: 1.72;
   letter-spacing: -0.01em;
@@ -4648,8 +4694,8 @@
   text-overflow: ellipsis;
   font-family: var(--font-body);
   font-size: 11.5px;
-  font-weight: 600;
-  color: var(--ink-spectral);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
 }
 
 .job-dock-captain-stack {
@@ -4685,7 +4731,7 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .job-dock-carrier > .job-dock-captain-tag:last-child:not(:first-child) {
@@ -4722,7 +4768,7 @@
   text-overflow: ellipsis;
   font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .job-dock-meta {
@@ -4732,7 +4778,7 @@
   gap: var(--space-2);
   font-family: var(--font-mono);
   font-size: 10px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 /* 접기/펼치기 그립 버튼 — brass(보는 곳/구조) */
@@ -4763,7 +4809,7 @@
   color: var(--brass);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.04em;
   cursor: pointer;
   transition:
@@ -4845,8 +4891,8 @@
   text-overflow: ellipsis;
   font-family: var(--font-body);
   font-size: 11px;
-  font-weight: 600;
-  color: var(--ink-spectral);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
 }
 
 .job-dock-card-copy {
@@ -4860,9 +4906,9 @@
   flex: none;
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   color: var(--aurora);
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   white-space: nowrap;
 }
@@ -4920,7 +4966,7 @@
 
 .thinking-chip {
   flex: none;
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
   font-style: italic;
@@ -4972,10 +5018,8 @@
   color: var(--brass-bright);
   box-shadow: var(--shadow-floating);
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
   transition: transform var(--duration-fast) var(--ease-spring);
 }
 
@@ -5000,11 +5044,9 @@
   width: 100%;
   gap: var(--space-2);
   padding: 10px var(--space-4);
-  color: var(--ink-fog);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  color: var(--text-tertiary);
+  font-size: 12px;
+  font-weight: var(--weight-bold);
   transition: color var(--duration-fast) var(--ease-spring);
 }
 
@@ -5039,7 +5081,7 @@
 
 .timeline-empty {
   padding: var(--space-2) 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 10.5px;
 }
 
@@ -5053,22 +5095,22 @@
 }
 
 .timeline-time {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 9.5px;
 }
 
 .timeline-type {
   overflow: hidden;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-size: 10px;
-  font-weight: 650;
+  font-weight: var(--weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .timeline-payload {
   overflow: hidden;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 9.5px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -5084,10 +5126,10 @@
 
 /* Theater 필드 캡션 — sidebar-eyebrow와 같은 모노 대문자 트래킹 라벨 언어를 그대로 빌려, 박스가 무엇인지 조용히 표기하며 시스템에 묶는다. */
 .theater-eyebrow {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 9px;
-  font-weight: 700;
+  font-size: 10px;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.16em;
   line-height: 1;
   text-align: center;
@@ -5109,12 +5151,10 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--surface-glass) 78%, var(--ink-deep));
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 10.5px;
-  font-weight: 650;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: var(--weight-medium);
   transition:
     color var(--duration-fast) var(--ease-spring),
     border-color var(--duration-fast) var(--ease-spring),
@@ -5124,7 +5164,7 @@
 /* hover/open에서만 brass로 리프트 — brass="지금 보고 있는 곳" 교리에 맞춘 상호작용 강조(투명 혼합으로 hue 오염 없이 순수 brass 유지). */
 .theater-trigger:hover,
 .theater-trigger.is-open {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   border-color: color-mix(in oklch, var(--brass) 45%, transparent);
   background: color-mix(in oklch, var(--brass) 12%, var(--surface-glass));
 }
@@ -5194,7 +5234,7 @@
   width: 100%;
   padding: var(--space-2);
   border-radius: var(--radius-sm);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0.04em;
@@ -5206,7 +5246,7 @@
 
 .theater-menu-item:hover:not(:disabled),
 .theater-menu-item:focus-visible {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   background: color-mix(in oklch, var(--brass) 12%, transparent);
 }
 
@@ -5255,7 +5295,7 @@
 .theater-menu-empty {
   margin: 0;
   padding: var(--space-2);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10.5px;
   letter-spacing: 0.04em;
@@ -5263,7 +5303,7 @@
 
 /* 미설치/미로그인 CLI 항목: 흐리게 표시하고 포인터를 막는다. */
 .operation-launch-menu-item:disabled {
-  color: color-mix(in oklch, var(--ink-fog) 45%, transparent);
+  color: color-mix(in oklch, var(--text-tertiary) 45%, transparent);
   cursor: not-allowed;
 }
 
@@ -5276,9 +5316,9 @@
   margin-left: auto;
   padding-left: var(--space-2);
   flex: none;
-  color: color-mix(in oklch, var(--ink-fog) 70%, transparent);
-  font-size: 9px;
-  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  font-size: 10px;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
@@ -5298,16 +5338,16 @@
   gap: var(--space-3);
   min-height: calc(100vh - 140px);
   padding: var(--space-10);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .codex-empty-state h1 {
   max-width: 720px;
   margin: 0;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-size: 44px;
-  font-weight: 520;
+  font-weight: var(--weight-medium);
   line-height: 1;
 }
 
@@ -5320,17 +5360,17 @@
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
 .bridge-kicker {
   margin: 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10.5px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.18em;
   text-transform: uppercase;
 }
@@ -5370,7 +5410,7 @@
   font-size: 11.5px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .terminal-status-dot {
@@ -5420,7 +5460,7 @@
   gap: var(--space-2);
   padding: 5px var(--space-2);
   border-radius: var(--radius-md);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   text-align: left;
   transition:
     background var(--duration-fast) var(--ease-spring),
@@ -5451,9 +5491,9 @@
 .terminal-job-line-label {
   flex: 0 1 auto;
   max-width: 28%;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-size: 11.5px;
-  font-weight: 640;
+  font-weight: var(--weight-medium);
 }
 
 .terminal-job-line.is-active .terminal-job-line-label {
@@ -5462,7 +5502,7 @@
 
 .terminal-job-line-stream {
   flex: 1 1 auto;
-  color: color-mix(in oklch, var(--aurora) 72%, var(--ink-fog));
+  color: color-mix(in oklch, var(--aurora) 72%, var(--text-tertiary));
   font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.01em;
@@ -5471,14 +5511,14 @@
 .terminal-job-line-meta {
   flex: 0 1 auto;
   max-width: 30%;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 9.5px;
   letter-spacing: 0.02em;
 }
 
 .terminal-job-line-sep {
   flex: 0 0 auto;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 10px;
 }
 
@@ -5532,12 +5572,10 @@
   border: 0;
   border-bottom: 2px solid transparent;
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 700;
-  letter-spacing: .08em;
-  text-transform: uppercase;
+  font-weight: var(--weight-bold);
 }
 
 .job-overlay-tabs [role="tab"][aria-selected="true"] {
@@ -5557,8 +5595,8 @@
   right: var(--space-3);
   z-index: 2;
   display: grid;
-  width: 34px;
-  height: 34px;
+  width: 32px;
+  height: 32px;
   place-items: center;
   border: 1px solid color-mix(in oklch, var(--brass) 42%, var(--surface-rim));
   border-radius: var(--radius-sm);
@@ -5638,21 +5676,21 @@
 .request-details-presence {
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 700;
-  letter-spacing: .07em;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .request-details-tag { color: var(--brass-bright); }
-.request-details-hint { min-width: 0; color: var(--ink-spectral); font-size: 12px; }
-.request-details-required { color: var(--ink-fog); }
+.request-details-hint { min-width: 0; color: var(--text-secondary); font-size: 12px; }
+.request-details-required { color: var(--text-tertiary); }
 .request-details-presence { color: var(--aurora); }
 .request-details-presence.is-missing { color: var(--coral); }
 .request-details-block pre {
   min-width: 0;
   margin: var(--space-3) 0 0;
   overflow-wrap: anywhere;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: 12px;
   line-height: 1.65;
@@ -5660,7 +5698,7 @@
   word-break: break-word;
 }
 
-.request-details-unavailable { color: var(--ink-fog); }
+.request-details-unavailable { color: var(--text-tertiary); }
 
 .job-overlay-card > .follow-button {
   right: var(--space-6);
@@ -5678,11 +5716,11 @@
 
 .job-overlay-kicker {
   font-family: var(--font-mono);
-  font-size: 9.5px;
-  font-weight: 700;
+  font-size: 10px;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .job-overlay-tracks {
@@ -5692,7 +5730,7 @@
 }
 
 .job-overlay-empty {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 13px;
   text-align: center;
   padding: var(--space-6);
@@ -5745,18 +5783,18 @@
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 780;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.18em;
   text-transform: uppercase;
 }
 
 .commissioning-header h2 {
   margin: 0;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-size: 52px;
   font-variation-settings: "opsz" 60;
-  font-weight: 560;
+  font-weight: var(--weight-medium);
   letter-spacing: 0;
   line-height: 0.98;
 }
@@ -5764,7 +5802,7 @@
 .commissioning-header p {
   max-width: 560px;
   margin: 0;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-size: 16px;
   line-height: 1.55;
 }
@@ -5816,7 +5854,7 @@
   box-shadow: var(--shadow-anchor);
   font-family: var(--font-mono);
   font-size: 12px;
-  font-weight: 820;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
 }
 
@@ -5839,18 +5877,18 @@
 
 .commissioning-step-body h3 {
   margin: 0;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-size: 22px;
   font-variation-settings: "opsz" 36;
-  font-weight: 560;
+  font-weight: var(--weight-medium);
   letter-spacing: 0;
 }
 
 .commissioning-step-body p {
   max-width: 620px;
   margin: 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 14px;
   line-height: 1.6;
 }
@@ -5862,9 +5900,7 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
   font-family: var(--font-mono);
-  font-weight: 780;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-weight: var(--weight-bold);
 }
 
 .commissioning-primary-action {
@@ -5876,7 +5912,7 @@
   padding: 0 var(--space-4);
   border-color: color-mix(in oklch, var(--aurora) 50%, var(--surface-rim));
   background: color-mix(in oklch, var(--aurora) 18%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   box-shadow: 0 0 0 1px color-mix(in oklch, var(--aurora) 14%, transparent), 0 0 20px -8px var(--aurora-glow);
   font-size: 11px;
   transition:
@@ -5900,7 +5936,7 @@
 }
 
 .commissioning-primary-action:disabled {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   cursor: not-allowed;
 }
 
@@ -5940,7 +5976,7 @@
 
 .commissioning-footer p {
   margin: 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 12px;
   line-height: 1.5;
 }
@@ -6035,14 +6071,14 @@
 
 .app-toast-title {
   margin: 0;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-size: 12.5px;
-  font-weight: 640;
+  font-weight: var(--weight-medium);
 }
 
 .app-toast-message {
   margin: 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.5;
@@ -6057,7 +6093,7 @@
   flex: none;
   margin: -2px -4px 0 auto;
   border-radius: var(--radius-xs);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 16px;
   line-height: 1;
   transition:
@@ -6066,7 +6102,7 @@
 }
 
 .app-toast-close:hover {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   background: color-mix(in oklch, var(--ink-fog) 14%, transparent);
 }
 
@@ -6119,14 +6155,14 @@
   border: 0;
   outline: 0;
   background: transparent;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-size: 17px;
   letter-spacing: 0;
 }
 
 #operation-search-input::placeholder {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 #operation-search-input:focus-visible {
@@ -6139,7 +6175,7 @@
   border: 1px solid color-mix(in oklch, var(--brass) 32%, var(--surface-rim));
   border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--surface-glass) 72%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.08em;
@@ -6167,10 +6203,10 @@
   min-width: 0;
   margin: 0;
   padding: var(--space-3) var(--space-4) var(--space-2);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 650;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.12em;
   line-height: 1;
   text-transform: uppercase;
@@ -6195,7 +6231,7 @@
   border: 0;
   border-radius: var(--radius-md);
   background: transparent;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   cursor: pointer;
   font-family: inherit;
   text-align: left;
@@ -6226,7 +6262,7 @@
 
 .operation-search-result.is-active {
   background: color-mix(in oklch, var(--brass) 12%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .operation-search-result.is-active::before {
@@ -6251,10 +6287,10 @@
   display: block;
   min-width: 0;
   overflow: hidden;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-size: 16px;
-  font-weight: 520;
+  font-weight: var(--weight-medium);
   letter-spacing: 0;
   line-height: 1.3;
   text-overflow: ellipsis;
@@ -6265,7 +6301,7 @@
   display: block;
   min-width: 0;
   overflow: hidden;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0.04em;
@@ -6279,7 +6315,7 @@
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: 11px;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   text-overflow: ellipsis;
   text-transform: uppercase;
   white-space: nowrap;
@@ -6296,7 +6332,7 @@
 
 .operation-search-command-glyph {
   flex: none;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 14px;
   line-height: 1;
@@ -6309,7 +6345,7 @@
 .operation-search-empty {
   margin: 0;
   padding: var(--space-5) var(--space-4);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 12px;
   letter-spacing: 0.04em;
@@ -6385,30 +6421,30 @@
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.2em;
   text-transform: uppercase;
 }
 
 .directory-browser-header h2 {
   margin: 0;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-size: 23px;
-  font-weight: 560;
+  font-weight: var(--weight-medium);
   letter-spacing: 0;
   line-height: 1.1;
 }
 
 .directory-browser-close {
   display: grid;
-  width: 34px;
-  height: 34px;
+  width: 32px;
+  height: 32px;
   place-items: center;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--surface-glass-strong) 82%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 18px;
   line-height: 1;
   transition: color var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide);
@@ -6429,7 +6465,7 @@
 
 .directory-browser-roots .directory-browser-kicker {
   flex: none;
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
 }
 
 .directory-browser-root-chips {
@@ -6446,10 +6482,10 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--ink-mid) 42%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   transition: color var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide);
 }
@@ -6466,7 +6502,7 @@
 }
 
 .directory-browser-root-chip:disabled {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   cursor: not-allowed;
 }
 
@@ -6490,7 +6526,7 @@
 
 .directory-browser-course-sep {
   margin: 0 1px;
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 12px;
 }
@@ -6502,7 +6538,7 @@
   border: 1px solid transparent;
   border-radius: var(--radius-xs);
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 12px;
   text-overflow: ellipsis;
@@ -6516,8 +6552,8 @@
 }
 
 .directory-browser-crumb.is-current {
-  color: var(--ink-pearl);
-  font-weight: 600;
+  color: var(--text-primary);
+  font-weight: var(--weight-medium);
   cursor: default;
 }
 
@@ -6549,7 +6585,7 @@
 .directory-browser-filter-glyph {
   display: grid;
   place-items: center;
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
 }
 
 .directory-browser-filter-glyph svg {
@@ -6563,13 +6599,13 @@
   height: 36px;
   border: 0;
   background: transparent;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 13px;
 }
 
 .directory-browser-filter-input::placeholder {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
 }
 
 .directory-browser-filter-input:focus {
@@ -6584,12 +6620,10 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-mid) 46%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
   transition: color var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide);
 }
 
@@ -6604,7 +6638,7 @@
 }
 
 .directory-browser-up:disabled {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   cursor: not-allowed;
 }
 
@@ -6623,14 +6657,14 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-deep) 46%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 12px;
   transition: border-color var(--duration-fast) var(--ease-glide), box-shadow var(--duration-fast) var(--ease-glide);
 }
 
 .directory-browser-jump-input::placeholder {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
 }
 
 .directory-browser-jump-input:focus {
@@ -6645,12 +6679,10 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-mid) 46%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-weight: var(--weight-bold);
   transition: color var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide);
 }
 
@@ -6660,7 +6692,7 @@
 }
 
 .directory-browser-jump-button:disabled {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   cursor: not-allowed;
 }
 
@@ -6698,7 +6730,7 @@
   padding: 9px var(--space-3);
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   cursor: pointer;
   transition: background var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide);
 }
@@ -6706,7 +6738,7 @@
 .directory-browser-sector-glyph {
   display: grid;
   place-items: center;
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   transition: color var(--duration-fast) var(--ease-glide);
 }
 
@@ -6723,7 +6755,7 @@
 }
 
 .directory-browser-sector-advance {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 15px;
   opacity: 0;
@@ -6735,7 +6767,7 @@
 .directory-browser-sector.is-active {
   border-color: color-mix(in oklch, var(--brass) 34%, transparent);
   background: color-mix(in oklch, var(--brass) 12%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .directory-browser-sector:hover .directory-browser-sector-glyph,
@@ -6751,14 +6783,14 @@
 }
 
 .directory-browser-sector.is-locked {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   cursor: not-allowed;
 }
 
 .directory-browser-sector.is-locked:hover {
   border-color: transparent;
   background: transparent;
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
 }
 
 .directory-browser-sector.is-locked .directory-browser-sector-glyph {
@@ -6769,7 +6801,7 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.08em;
@@ -6787,7 +6819,7 @@
   gap: var(--space-2);
   margin: 0;
   padding: var(--space-4) var(--space-3);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 12px;
 }
@@ -6808,7 +6840,7 @@
 .directory-browser-note {
   flex: none;
   margin: 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
 }
@@ -6834,15 +6866,15 @@
 .directory-browser-target-label {
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: 9px;
-  font-weight: 700;
+  font-size: 10px;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.18em;
   text-transform: uppercase;
 }
 
 .directory-browser-target-path {
   overflow: hidden;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 12px;
   text-overflow: ellipsis;
@@ -6861,12 +6893,10 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-mid) 46%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-weight: var(--weight-bold);
   transition: color var(--duration-fast) var(--ease-glide), border-color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide);
 }
 
@@ -6886,7 +6916,7 @@
 }
 
 .directory-browser-button:disabled {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   cursor: not-allowed;
 }
 
@@ -6978,7 +7008,7 @@
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.2em;
   text-transform: uppercase;
 }
@@ -6986,10 +7016,10 @@
 .codex-surface-title {
   margin: 0;
   overflow: hidden;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-size: 18px;
-  font-weight: 560;
+  font-weight: var(--weight-medium);
   line-height: 1.15;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -7003,7 +7033,7 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--surface-glass-strong) 82%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 17px;
   line-height: 1;
   transition:
@@ -7055,7 +7085,7 @@
   right: var(--space-4);
   bottom: var(--space-4);
   z-index: 34;
-  width: var(--codex-side-width, 460px);
+  width: 460px;
   max-width: calc(100vw - var(--space-8));
   pointer-events: none;
 }
@@ -7113,7 +7143,7 @@
   border-radius: var(--radius-lg) 0 0 var(--radius-lg);
   background: color-mix(in oklch, var(--surface-glass) 88%, var(--ink-deep));
   box-shadow: var(--shadow-floating);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
   transition: transform var(--duration-fast) var(--ease-spring),
     color var(--duration-fast) var(--ease-glide),
@@ -7146,9 +7176,7 @@ body:has([aria-modal="true"]:not([hidden])) .codex-edge-handle {
 
 .codex-edge-handle-label {
   font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
+  font-size: 12px;
   writing-mode: vertical-rl;
   text-orientation: mixed;
 }
@@ -7169,7 +7197,7 @@ body:has([aria-modal="true"]:not([hidden])) .codex-edge-handle {
   border-radius: var(--radius-md);
   border: 1px solid transparent;
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
   transition: color var(--duration-fast) var(--ease-glide),
     background var(--duration-fast) var(--ease-glide),
@@ -7183,7 +7211,7 @@ body:has([aria-modal="true"]:not([hidden])) .codex-edge-handle {
 
 .codex-pane-toggle:hover,
 .codex-pane-toggle:focus-visible {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   background: var(--surface-glass);
   border-color: var(--surface-rim);
   outline: none;
@@ -7199,7 +7227,7 @@ body:has([aria-modal="true"]:not([hidden])) .codex-edge-handle {
 /* ===== Side 모드 ⌘K 검색 국한 (항목③) — 전체 화면 모달을 Side 패널 영역으로 가둔다. ===== */
 body[data-codex-side="true"] .command-overlay {
   inset: var(--space-4) var(--space-4) var(--space-4) auto;
-  width: var(--codex-side-width, 460px);
+  width: 460px;
   max-width: calc(100vw - var(--space-8));
   padding: 0;
   place-items: stretch;
@@ -7265,10 +7293,10 @@ body[data-codex-side="true"] .command-card {
 
 .whatsnew-header h2 {
   margin: 0;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-size: clamp(32px, 4vw, 48px);
-  font-weight: 680;
+  font-weight: var(--weight-bold);
   line-height: 1;
   letter-spacing: 0;
 }
@@ -7284,16 +7312,16 @@ body[data-codex-side="true"] .command-card {
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: 12px;
-  font-weight: 800;
+  font-weight: var(--weight-bold);
   letter-spacing: 0;
 }
 
 .whatsnew-date {
   display: block;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 12px;
-  font-weight: 650;
+  font-weight: var(--weight-medium);
   letter-spacing: 0;
 }
 
@@ -7310,7 +7338,7 @@ body[data-codex-side="true"] .command-card {
   color: var(--warn);
   font-family: var(--font-mono);
   font-size: 12px;
-  font-weight: 750;
+  font-weight: var(--weight-bold);
   letter-spacing: 0;
 }
 
@@ -7320,15 +7348,15 @@ body[data-codex-side="true"] .command-card {
   right: 18px;
   display: grid;
   place-items: center;
-  width: 36px;
-  height: 36px;
+  width: 32px;
+  height: 32px;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--ink-mid) 72%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 15px;
-  font-weight: 800;
+  font-weight: var(--weight-bold);
   transition:
     border-color var(--duration-fast) var(--ease-glide),
     color var(--duration-fast) var(--ease-glide),
@@ -7368,10 +7396,10 @@ body[data-codex-side="true"] .command-card {
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--ink-mid) 72%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 12px;
-  font-weight: 760;
+  font-weight: var(--weight-bold);
   letter-spacing: 0;
 }
 
@@ -7390,9 +7418,9 @@ body[data-codex-side="true"] .command-card {
   border-radius: calc(var(--radius-md) - 2px);
   padding: 5px 7px;
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: var(--font-size-label-sm);
+  font-size: 11px;
   cursor: pointer;
 }
 
@@ -7410,9 +7438,9 @@ body[data-codex-side="true"] .command-card {
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-pill);
   padding: 2px 7px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: var(--font-size-label-sm);
+  font-size: 11px;
 }
 
 .whatsnew-version-select {
@@ -7451,12 +7479,10 @@ body[data-codex-side="true"] .command-card {
   border-radius: var(--radius-sm);
   padding: 0 10px;
   background: color-mix(in oklch, var(--ink-mid) 62%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
   white-space: nowrap;
 }
 
@@ -7469,7 +7495,7 @@ body[data-codex-side="true"] .command-card {
 .whatsnew-tab:hover,
 .whatsnew-tab:focus-visible {
   border-color: color-mix(in oklch, var(--brass) 60%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .whatsnew-overview {
@@ -7486,7 +7512,7 @@ body[data-codex-side="true"] .command-card {
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-mid) 54%, transparent);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   text-align: left;
 }
 
@@ -7499,15 +7525,15 @@ body[data-codex-side="true"] .command-card {
 .whatsnew-overview-count {
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 800;
+  font-weight: var(--weight-bold);
 }
 
 .whatsnew-overview-label { color: var(--brass-bright); }
-.whatsnew-overview-count { color: var(--ink-fog); }
+.whatsnew-overview-count { color: var(--text-tertiary); }
 .whatsnew-overview-summary {
   grid-column: 1 / -1;
   overflow: hidden;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -7530,7 +7556,7 @@ body[data-codex-side="true"] .command-card {
   color: var(--brass);
   font-family: var(--font-mono);
   font-size: 12px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   line-height: 1;
 }
 
@@ -7550,8 +7576,8 @@ body[data-codex-side="true"] .command-card {
   text-align: center;
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 760;
-  color: var(--ink-fog);
+  font-weight: var(--weight-bold);
+  color: var(--text-tertiary);
 }
 
 .whatsnew-section {
@@ -7578,8 +7604,8 @@ body[data-codex-side="true"] .command-card {
   color: var(--whatsnew-section-color);
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 850;
-  letter-spacing: 0;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
@@ -7592,10 +7618,10 @@ body[data-codex-side="true"] .command-card {
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--ink-mid) 72%, transparent);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 820;
+  font-weight: var(--weight-bold);
   letter-spacing: 0;
   vertical-align: middle;
 }
@@ -7605,7 +7631,7 @@ body[data-codex-side="true"] .command-card {
   gap: 10px;
   margin: 0;
   padding: 0 0 0 18px;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-size: 14px;
   line-height: 1.68;
 }
@@ -7662,9 +7688,7 @@ body[data-codex-side="true"] .command-card {
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: 12px;
-  font-weight: 800;
-  letter-spacing: 0;
-  text-transform: uppercase;
+  font-weight: var(--weight-bold);
 }
 
 .whatsnew-done:hover,
@@ -7690,17 +7714,17 @@ body[data-codex-side="true"] .command-card {
 
 .fc-settings-card__title {
   margin: 0;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-size: clamp(20px, 2vw, 28px);
-  font-weight: 650;
+  font-weight: var(--weight-medium);
   letter-spacing: 0;
   line-height: 1.05;
 }
 
 .fc-settings-card__desc {
   margin: 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 13px;
   letter-spacing: 0;
 }
@@ -7729,16 +7753,16 @@ body[data-codex-side="true"] .command-card {
 .fc-settings-toggle__label,
 .fc-settings-select__label,
 .fc-settings-field__label {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-size: 13px;
-  font-weight: 750;
+  font-weight: var(--weight-bold);
   letter-spacing: 0;
 }
 
 .fc-settings-row__hint,
 .fc-settings-field__hint {
   margin: 4px 0 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 12px;
   letter-spacing: 0;
 }
@@ -7752,7 +7776,7 @@ body[data-codex-side="true"] .command-card {
   display: inline-flex;
   align-items: center;
   gap: var(--space-3);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   cursor: pointer;
 }
 
@@ -7819,8 +7843,11 @@ body[data-codex-side="true"] .command-card {
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--ink-mid) 78%, transparent);
-  color: var(--ink-pearl);
-  font: inherit;
+  color: var(--text-primary);
+  font-weight: var(--weight-regular);
+  font-size: inherit;
+  line-height: inherit;
+  font-family: inherit;
   letter-spacing: 0;
   padding: 8px 12px;
 }
@@ -7838,9 +7865,9 @@ body[data-codex-side="true"] .command-card {
   border-color: color-mix(in oklch, var(--coral) 46%, transparent);
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--coral) 12%, var(--surface-glass));
-  color: color-mix(in oklch, var(--coral) 72%, var(--ink-pearl));
+  color: color-mix(in oklch, var(--coral) 72%, var(--text-primary));
   font-size: 13px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0;
 }
 
@@ -7975,17 +8002,17 @@ body[data-codex-side="true"] .command-card {
 .codex-reading-sheet-close {
   border: 1px solid var(--surface-rim);
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   border-radius: var(--radius-md);
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   display: grid;
   place-items: center;
   cursor: pointer;
 }
 
 .codex-reading-sheet-close:hover {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   border-color: var(--surface-rim-strong);
 }
 
@@ -8014,16 +8041,16 @@ body[data-codex-side="true"] .command-card {
 .codex-reading-sheet-toc .ti {
   display: block;
   padding: var(--space-1) 0 var(--space-1) var(--space-3);
-  font-family: var(--font-ui);
-  font-size: var(--font-size-label-sm);
-  color: var(--ink-fog);
+  font-family: var(--font-body);
+  font-size: 11px;
+  color: var(--text-tertiary);
   text-decoration: none;
   border-left: 2px solid transparent;
   transition: color var(--duration-base) var(--ease-spring);
 }
 
 .codex-reading-sheet-toc .ti:hover {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .codex-reading-sheet-toc .ti.active {
@@ -8036,9 +8063,9 @@ body[data-codex-side="true"] .command-card {
 }
 
 .codex-reading-sheet-toc .toc-empty {
-  font-family: var(--font-ui);
-  font-size: var(--font-size-label-sm);
-  color: var(--ink-fog);
+  font-family: var(--font-body);
+  font-size: 11px;
+  color: var(--text-tertiary);
   padding: var(--space-2);
 }
 
@@ -8046,16 +8073,16 @@ body[data-codex-side="true"] .command-card {
 .codex-reader-loading,
 .codex-reader-empty {
   padding: var(--space-6) var(--space-4);
-  font-family: var(--font-ui);
-  font-size: var(--font-size-body-sm);
-  color: var(--ink-fog);
+  font-family: var(--font-body);
+  font-size: 12px;
+  color: var(--text-tertiary);
   text-align: center;
 }
 
 .codex-reader-error {
   padding: var(--space-4) var(--space-4);
-  font-family: var(--font-ui);
-  font-size: var(--font-size-body-sm);
+  font-family: var(--font-body);
+  font-size: 12px;
   color: var(--coral);
 }
 
@@ -8196,7 +8223,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   gap: 7px;
   padding: 4px 8px 4px 5px;
   border-radius: var(--radius-xs);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .brand-foot-home:hover,
@@ -8214,7 +8241,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 .brand-foot-wordmark {
   font-family: var(--font-display);
   font-size: 13px;
-  font-weight: 640;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.01em;
 }
 
@@ -8222,7 +8249,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   position: relative;
   padding: 4px 8px;
   border-radius: var(--radius-xs);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10.5px;
 }
@@ -8230,7 +8257,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 .brand-foot-version:hover:not(:disabled),
 .brand-foot-version:focus-visible {
   background: var(--surface-glass);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .brand-foot-version:disabled {
@@ -8255,13 +8282,13 @@ body[data-codex-reading="true"] .operations-side-bar {
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--ink-spectral) 6%, transparent);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-size: 10.5px;
-  font-weight: 760;
+  font-weight: var(--weight-bold);
 }
 
 .brand-foot-update--live { border-color: color-mix(in oklch, var(--warn) 42%, transparent); background: color-mix(in oklch, var(--warn) 10%, transparent); color: var(--warn); }
-.brand-foot-update--blocked { border-color: var(--surface-rim); background: transparent; color: var(--ink-fog); }
+.brand-foot-update--blocked { border-color: var(--surface-rim); background: transparent; color: var(--text-tertiary); }
 .brand-foot-update--error { border-color: color-mix(in oklch, var(--coral) 42%, transparent); background: color-mix(in oklch, var(--coral) 10%, transparent); color: var(--coral); }
 .brand-foot-update:disabled { cursor: default; opacity: 0.75; }
 
@@ -8278,7 +8305,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   width: 24px;
   height: 24px;
   border-radius: var(--radius-xs);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .brand-foot-github-link svg,
@@ -8291,7 +8318,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   height: 24px;
   padding: 0 6px;
   border-radius: var(--radius-xs);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10.5px;
 }
@@ -8305,7 +8332,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 .brand-foot-more:hover,
 .brand-foot-more:focus-visible {
   background: var(--surface-glass);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .brand-foot-dropup {
@@ -8346,19 +8373,17 @@ body[data-codex-reading="true"] .operations-side-bar {
   gap: 8px;
   padding: 7px 10px;
   border-radius: var(--radius-xs);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 10.5px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
   text-align: left;
 }
 
 .brand-foot-dropup-menu button:hover,
 .brand-foot-dropup-menu button:focus-visible {
   background: var(--surface-pillar);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .brand-foot-dropup-menu svg { width: 13px; height: 13px; }
@@ -8371,7 +8396,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   min-height: 28px;
   padding: 5px 8px;
   border-radius: var(--radius-xs);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 12px;
 }
 
@@ -8386,31 +8411,31 @@ body[data-codex-reading="true"] .operations-side-bar {
 .brand-foot-system-trigger:hover,
 .brand-foot-system-trigger:focus-visible,
 .brand-foot-help-trigger:hover,
-.brand-foot-help-trigger:focus-visible { background: var(--surface-glass); color: var(--ink-pearl); }
+.brand-foot-help-trigger:focus-visible { background: var(--surface-glass); color: var(--text-primary); }
 .brand-foot-system-trigger svg, .brand-foot-help-trigger svg { width: 14px; height: 14px; }
 .brand-foot-menu-divider { height: 1px; margin: 4px 6px; background: var(--surface-rim); }
 .brand-foot-dropup-menu .brand-foot-update { width: calc(100% - 12px); margin: 2px 6px; text-align: left; }
 .brand-foot-help-dropup-menu .brand-foot-github { display: flex; align-items: center; padding: 2px 6px; }
-.brand-foot-github-version { margin-left: auto; color: var(--ink-fog); font-family: var(--font-mono); font-size: 10px; white-space: nowrap; }
+.brand-foot-github-version { margin-left: auto; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; white-space: nowrap; }
 
 .keyboard-shortcuts-scrim { position: fixed; inset: 0; z-index: 80; display: grid; place-items: center; background: color-mix(in oklch, var(--ink-abyss) 64%, transparent); }
 .keyboard-shortcuts-dialog { width: min(520px, calc(100vw - 48px)); max-height: min(680px, calc(100vh - 64px)); overflow: auto; padding: 12px; border: 1px solid var(--surface-rim-strong); border-radius: var(--radius-md); background: var(--ink-deep); box-shadow: var(--shadow-floating); outline: none; }
-.keyboard-shortcuts-dialog-head { display: flex; align-items: center; justify-content: space-between; padding: 2px 4px 10px; color: var(--ink-pearl); }
-.keyboard-shortcuts-dialog-head button { width: 26px; height: 26px; border-radius: var(--radius-xs); color: var(--ink-fog); }
-.keyboard-shortcuts-dialog-head button:hover { background: var(--surface-glass); color: var(--ink-pearl); }
+.keyboard-shortcuts-dialog-head { display: flex; align-items: center; justify-content: space-between; padding: 2px 4px 10px; color: var(--text-primary); }
+.keyboard-shortcuts-dialog-head button { width: 24px; height: 24px; border-radius: var(--radius-xs); color: var(--text-tertiary); }
+.keyboard-shortcuts-dialog-head button:hover { background: var(--surface-glass); color: var(--text-primary); }
 .keyboard-shortcuts-group { margin-top: 10px; padding-top: 8px; border-top: 1px solid var(--surface-rim); }
 .keyboard-shortcuts-group h3 { margin: 0 0 5px; color: var(--brass); font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; }
 .keyboard-shortcuts-group dl { margin: 0; }
-.keyboard-shortcuts-group dl > div { display: grid; grid-template-columns: minmax(130px, auto) 1fr; gap: 12px; padding: 4px; color: var(--ink-spectral); font-size: 12px; }
-.keyboard-shortcuts-group dt { color: var(--ink-fog); }
+.keyboard-shortcuts-group dl > div { display: grid; grid-template-columns: minmax(130px, auto) 1fr; gap: 12px; padding: 4px; color: var(--text-secondary); font-size: 12px; }
+.keyboard-shortcuts-group dt { color: var(--text-tertiary); }
 .keyboard-shortcuts-group dd { margin: 0; }
-.keyboard-shortcuts-group kbd { margin-right: 3px; padding: 1px 4px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); color: var(--ink-pearl); font-family: var(--font-mono); font-size: 10px; }
+.keyboard-shortcuts-group kbd { margin-right: 3px; padding: 1px 4px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); color: var(--text-primary); font-family: var(--font-mono); font-size: 10px; }
 
 /* v5: 비-Operations 라우트의 복귀 링크 — GNB 부재 보완 */
 .page-back-link {
   display: inline-block;
   margin-bottom: 6px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 12px;
   border-radius: var(--radius-xs);
 }
@@ -8433,7 +8458,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   width: 100%; min-height: 42px; display: flex; align-items: center; justify-content: space-between; gap: var(--space-2);
   border: 1px solid var(--surface-rim); border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-mid) 48%, transparent);
-  color: var(--ink-pearl); font: 600 13px/1.2 var(--font-body); padding: 0 13px; cursor: pointer;
+  color: var(--text-primary); font-weight: var(--weight-medium); font-size: 13px; line-height: 1.2; font-family: var(--font-body); padding: 0 13px; cursor: pointer;
   box-shadow: inset 0 1px 0 color-mix(in oklch, var(--ink-pearl) 5%, transparent);
   transition: border-color var(--duration-fast) var(--ease-glide);
 }
@@ -8458,7 +8483,7 @@ body[data-codex-reading="true"] .operations-side-bar {
 .fc-select__option {
   display: flex; align-items: center; justify-content: space-between; gap: var(--space-2);
   padding: 8px 10px; border-radius: var(--radius-xs);
-  color: var(--text-secondary); font: 500 13px/1.3 var(--font-body); cursor: pointer;
+  color: var(--text-secondary); font-weight: var(--weight-medium); font-size: 13px; line-height: 1.3; font-family: var(--font-body); cursor: pointer;
   transition: background var(--duration-fast) var(--ease-glide), color var(--duration-fast) var(--ease-glide);
 }
 .fc-select__option[data-active="true"] { background: color-mix(in oklch, var(--brass) 12%, transparent); color: var(--text-primary); }
@@ -8470,7 +8495,10 @@ body[data-codex-reading="true"] .operations-side-bar {
 .fc-select--compact { min-width: 0; }
 .fc-select--compact .fc-select__trigger {
   min-height: 0; border: 0; box-shadow: none; background: transparent;
-  font: 9px/1 var(--font-mono); color: var(--text-secondary); padding: 8px 16px 8px 10px;
+  font-weight: var(--weight-regular);
+  font-size: 9px;
+  line-height: 1;
+  font-family: var(--font-mono); color: var(--text-secondary); padding: 8px 16px 8px 10px;
 }
 .fc-select__popup--compact { min-width: min(160px, calc(100vw - 16px)); }
 

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -104,7 +104,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   gap: 7px;
   padding: 4px 8px 4px 5px;
   border-radius: var(--radius-xs);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .command-band-brand:hover,
@@ -121,7 +121,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 .command-band-brand .brand-foot-wordmark {
   font-family: var(--font-display);
   font-size: 13px;
-  font-weight: 640;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.01em;
 }
 
@@ -133,14 +133,13 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   flex: none;
   padding: 4px 7px;
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-pill);
+  border-radius: var(--radius-sm);
   background: var(--surface-glass);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.01em;
 }
 
 .command-band-local-chip:hover,
@@ -161,7 +160,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 :root[data-desktop-shell="true"][data-desktop-platform="darwin"] .command-band-local-chip {
   gap: 4px;
   padding-inline: 5px;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
   min-width: 0;
 }
 
@@ -185,16 +184,16 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   border-radius: var(--radius-md);
   background: var(--surface-band);
   box-shadow: 0 12px 30px color-mix(in oklch, var(--ink-deep) 70%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-size: 11px;
 }
 
 .command-band-environment-title {
   margin-bottom: var(--space-2);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -208,13 +207,13 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   border-top: 1px solid var(--surface-rim);
 }
 
-.command-band-environment-row span { color: var(--ink-fog); }
+.command-band-environment-row span { color: var(--text-tertiary); }
 /* 경로 값은 진단 목적상 전문이 보여야 한다 — 말줄임 대신 줄바꿈으로 전체를 노출한다. */
-.command-band-environment-row code { color: var(--ink-pearl); font-family: var(--font-mono); overflow-wrap: anywhere; word-break: break-all; }
-.command-band-environment-row button { padding: 2px 5px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: var(--surface-glass); color: var(--ink-spectral); font: inherit; cursor: pointer; }
+.command-band-environment-row code { color: var(--text-primary); font-family: var(--font-mono); overflow-wrap: anywhere; word-break: break-all; }
+.command-band-environment-row button { padding: 2px 5px; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); background: var(--surface-glass); color: var(--text-secondary); font-weight: var(--weight-regular); font-size: inherit; line-height: inherit; font-family: inherit; cursor: pointer; }
 .command-band-environment-row button:hover,
 .command-band-environment-row button:focus-visible { border-color: color-mix(in oklch, var(--ink-fog) 55%, var(--surface-rim)); outline: none; }
-.command-band-environment-footer { margin-top: var(--space-2); color: var(--ink-fog); font-size: 10px; }
+.command-band-environment-footer { margin-top: var(--space-2); color: var(--text-tertiary); font-size: 10px; }
 
 /* 좁은 뷰에서는 칩 앵커(x≈80~160) + 520px 폭이 우측을 벗어나 Copy 버튼이 잘린다 —
    앵커 대신 viewport gutter에 고정해 전체 행이 항상 화면 안에 남게 한다. */
@@ -246,13 +245,13 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   display: grid;
   place-items: center;
   flex: none;
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   padding: 0;
   border: 1px solid transparent;
   border-radius: var(--radius-xs);
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
   transition: background var(--duration-fast) var(--ease-spring), border-color var(--duration-fast) var(--ease-spring), color var(--duration-fast) var(--ease-spring);
 }
@@ -266,7 +265,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 .command-band-button:focus-visible {
   border-color: color-mix(in oklch, var(--ink-fog) 30%, transparent);
   background: color-mix(in oklch, var(--ink-spectral) 10%, transparent);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   outline: none;
 }
 
@@ -296,12 +295,12 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   display: grid;
   place-items: center;
   flex: none;
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   padding: 0;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .command-band-formation-toggle svg { display: block; width: 16px; height: 16px; }
@@ -310,7 +309,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 .command-band-formation-toggle:hover:not(:disabled),
 .command-band-formation-toggle:focus-visible {
   border-color: var(--hairline-strong);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .command-band-formation-toggle[aria-pressed="true"] {
@@ -334,7 +333,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   align-items: center;
   gap: 6px;
   min-width: 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
 }
@@ -348,15 +347,16 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   letter-spacing: 0.06em;
 }
 
-.command-band-theater-separator { color: var(--ink-fog); }
+.command-band-theater-separator { color: var(--text-tertiary); }
 
 .command-band-operation-name {
   min-width: 0;
   overflow: hidden;
-  color: var(--ink-pearl);
-  font: inherit;
+  color: var(--text-primary);
+  line-height: inherit;
+  font-family: inherit;
   font-size: 12px;
-  font-weight: 650;
+  font-weight: var(--weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -368,10 +368,11 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   border: 1px solid color-mix(in oklch, var(--brass) 48%, var(--surface-rim));
   border-radius: var(--radius-xs);
   background: var(--ink-deep);
-  color: var(--ink-pearl);
-  font: inherit;
+  color: var(--text-primary);
+  line-height: inherit;
+  font-family: inherit;
   font-size: 12px;
-  font-weight: 650;
+  font-weight: var(--weight-medium);
 }
 
 .command-band-operation-attribute {
@@ -382,7 +383,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   padding: 2px 6px;
   border-radius: var(--radius-xs);
   background: color-mix(in oklch, var(--ink-fog) 10%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 9.5px;
 }
@@ -426,7 +427,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   display: grid;
   place-items: center;
   flex: none;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   opacity: 0;
   transition: opacity var(--duration-fast) var(--ease-spring);
 }
@@ -440,7 +441,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 }
 
 .command-band-operation-placeholder {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
 }
@@ -468,7 +469,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   width: 100%;
   padding: var(--space-2);
   border-radius: var(--radius-sm);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0.04em;
@@ -480,7 +481,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 
 .command-band-menu-item:hover:not(:disabled),
 .command-band-menu-item:focus-visible {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   background: color-mix(in oklch, var(--brass) 12%, transparent);
   outline: none;
 }
@@ -527,8 +528,8 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   margin-left: auto;
   padding-left: var(--space-2);
   flex: none;
-  color: color-mix(in oklch, var(--ink-fog) 70%, transparent);
-  font-size: 9px;
+  color: var(--text-tertiary);
+  font-size: 10px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -542,7 +543,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 .command-band-menu-empty {
   margin: 0;
   padding: var(--space-2);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10.5px;
   letter-spacing: 0.04em;

--- a/runtime/fleet-console/core/client/src/styles/rail-alerts.css
+++ b/runtime/fleet-console/core/client/src/styles/rail-alerts.css
@@ -29,17 +29,17 @@
 .alerts-panel-tally-empty {
   font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
 }
 
 .alerts-panel-settings-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
+  width: 24px;
+  height: 24px;
   border-radius: var(--radius-sm);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   transition: background var(--duration-fast) var(--ease-glide),
     color var(--duration-fast) var(--ease-glide);
 }
@@ -73,7 +73,7 @@
   border-radius: 999px;
   font-family: var(--font-mono);
   font-size: 9px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   line-height: 14px;
   text-align: center;
   color: var(--ink-abyss);
@@ -112,7 +112,7 @@
   border-radius: 999px;
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   line-height: 1;
 }
 
@@ -144,7 +144,7 @@
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   text-align: center;
 }
 
@@ -181,7 +181,7 @@
   min-width: 0;
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.09em;
   color: var(--brass-bright);
@@ -200,8 +200,8 @@
   border-radius: 999px;
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 600;
-  color: var(--ink-spectral);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
   background: color-mix(in oklch, var(--ink-fog) 15%, transparent);
 }
 
@@ -257,8 +257,8 @@
 .notification-row-op {
   font-family: var(--font-body);
   font-size: 13px;
-  font-weight: 500;
-  color: var(--ink-pearl);
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -266,8 +266,8 @@
 
 .notification-row-state {
   font-family: var(--font-mono);
-  font-size: 9px;
-  font-weight: 600;
+  font-size: 10px;
+  font-weight: var(--weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.11em;
 }
@@ -285,11 +285,10 @@
   padding: 4px 11px;
   border-radius: var(--radius-xs);
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--ink-fog);
+  font-size: 12px;
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.01em;
+  color: var(--text-tertiary);
   border: 1px solid var(--surface-rim);
   transition: color var(--duration-fast) var(--ease-glide),
     border-color var(--duration-fast) var(--ease-glide),
@@ -317,11 +316,11 @@
 .notification-cluster-settings-eyebrow {
   margin: var(--space-1) 0 2px;
   font-family: var(--font-mono);
-  font-size: 9px;
-  font-weight: 600;
+  font-size: 10px;
+  font-weight: var(--weight-medium);
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
 }
 
 .notification-cluster-setting {
@@ -331,7 +330,7 @@
   padding: var(--space-1);
   border-radius: var(--radius-xs);
   font-size: 13px;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   cursor: pointer;
   transition: background var(--duration-fast) var(--ease-glide);
 }

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -104,7 +104,7 @@
   font-size: 11px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -113,7 +113,7 @@
 .right-rail-float-toggle {
   flex: none;
   padding: 4px 8px;
-  border-radius: var(--radius-pill);
+  border-radius: var(--radius-sm);
   border: 1px solid var(--surface-rim-strong);
   background: transparent;
   color: var(--text-tertiary);
@@ -126,7 +126,7 @@
 }
 
 .right-rail-float-toggle:hover {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   background: var(--ink-veil);
 }
 
@@ -148,7 +148,7 @@
   display: inline-flex;
   overflow: hidden;
   border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-pill);
+  border-radius: var(--radius-sm);
 }
 
 .right-rail-opacity-segment {
@@ -169,7 +169,7 @@
 
 .right-rail-opacity-segment:hover,
 .right-rail-opacity-segment:focus-visible {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   background: var(--ink-veil);
   outline: none;
 }
@@ -190,21 +190,21 @@
   position: absolute;
   top: 9px;
   right: 10px;
-  width: 26px;
-  height: 26px;
+  width: 24px;
+  height: 24px;
   flex: none;
   display: inline-grid;
   place-items: center;
   border-radius: var(--radius-xs);
   background: none;
   border: none;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
   transition: color 140ms, background 140ms;
 }
 
 .right-rail-close-btn:hover {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   background: var(--surface-glass);
 }
 
@@ -237,14 +237,14 @@
 }
 
 .right-rail-ico {
-  width: 34px;
-  height: 34px;
+  width: 32px;
+  height: 32px;
   display: inline-grid;
   place-items: center;
   border-radius: var(--radius-xs);
   background: none;
   border: 1px solid transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
   position: relative;
   font-size: 14px;
@@ -256,7 +256,7 @@
 
 .right-rail-ico:hover,
 .right-rail-ico:focus-visible {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   background: var(--surface-glass);
   outline: none;
 }

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -3,9 +3,13 @@
 
   --hairline: oklch(29% 0.018 245);
   --hairline-strong: oklch(37% 0.02 245);
+  /* 텍스트 3티어(--text-*)는 판독 계약을 지는 유일한 색 역할이다. 어느 테마에서든 본문 표면 위에서
+     WCAG 2.1 AA(본문 4.5:1, 큰 글자 3:1)를 넘어야 하며, 원료 잉크 티어(--ink-*)를 텍스트 색으로
+     직접 쓰면 그 계약이 통제되지 않는다. tertiary는 판독 하한 바로 위 티어다 — Instrument의
+     --ink-fog(L 52%)는 하한 아래여서 텍스트 역할로 쓸 수 없다. */
   --text-primary: oklch(94% 0.008 90);
   --text-secondary: oklch(70% 0.012 245);
-  --text-tertiary: oklch(52% 0.012 245);
+  --text-tertiary: oklch(64% 0.012 245);
 
   --ink-abyss: oklch(13% 0.014 245);
   --ink-deep: oklch(16.5% 0.016 245);
@@ -110,6 +114,13 @@
   --font-mono: "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
   --font-body-size: 14px;
 
+  /* 굵기는 3티어만 쓴다 — 가변 서체가 임의 축값을 허용한다고 해서 위계가 늘어나지는 않는다.
+     regular=본문, medium=강조·컨트롤 라벨, bold=제목·주요 액션. 세 티어 밖의 값은
+     같은 역할에 서로 다른 굵기를 흩뿌려 위계를 읽을 수 없게 만든다. */
+  --weight-regular: 400;
+  --weight-medium: 600;
+  --weight-bold: 700;
+
   --chrome-band-height: 44px;
 
   --ease-spring: cubic-bezier(0.16, 1, 0.3, 1);
@@ -133,6 +144,8 @@
 :root[data-theme="carbon"] {
   --text-primary: var(--ink-pearl);
   --text-secondary: var(--ink-spectral);
+  /* 두 테마의 --ink-fog(maritime L 70% / carbon L 67%)는 판독 하한 위에 있어 tertiary로 쓸 수 있다.
+     이 매핑은 우연이 아니라 계약이다 — 잉크 스케일을 재조율할 때 이 하한을 함께 확인할 것. */
   --text-tertiary: var(--ink-fog);
 }
 
@@ -250,7 +263,7 @@
 
 *::selection {
   background: var(--brass-glow);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 html,
@@ -265,7 +278,7 @@ body {
 
 html {
   background: var(--ink-abyss);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-feature-settings: "ss01", "cv11";
   -webkit-font-smoothing: antialiased;
@@ -275,10 +288,10 @@ html {
 body {
   overflow: hidden;
   background: var(--ink-abyss);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-body);
   font-size: var(--font-body-size);
-  font-weight: 400;
+  font-weight: var(--weight-regular);
   line-height: 1.55;
   letter-spacing: -0.005em;
 }

--- a/runtime/fleet-console/font-picker/styles.css
+++ b/runtime/fleet-console/font-picker/styles.css
@@ -1,5 +1,5 @@
 .fc-font-browser {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 /* auto-fit wraps the two panes to a single column when the picker's own width
@@ -26,8 +26,19 @@
 .fc-font-browser__preview-label,
 .fc-font-browser__row-meta,
 .fc-font-browser__row-status {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 0.78em;
+}
+
+/* 강조된 행은 배경이 밝아지므로 보조 텍스트도 한 티어 올린다 — tertiary를 그대로 두면
+   밝아진 표면 위에서 판독 하한 아래로 내려간다(instrument 4.46:1 / carbon 4.30:1). */
+.fc-font-browser__row:hover .fc-font-browser__row-meta,
+.fc-font-browser__row:hover .fc-font-browser__row-status,
+.fc-font-browser__row.is-active .fc-font-browser__row-meta,
+.fc-font-browser__row.is-active .fc-font-browser__row-status,
+.fc-font-browser__row[aria-selected="true"] .fc-font-browser__row-meta,
+.fc-font-browser__row[aria-selected="true"] .fc-font-browser__row-status {
+  color: var(--text-secondary);
 }
 
 .fc-font-browser__search {
@@ -37,7 +48,7 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs, 8px);
   background: color-mix(in oklab, var(--ink-abyss) 72%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .fc-font-browser__search:focus-visible,
@@ -63,7 +74,7 @@
   border: 0;
   border-radius: var(--radius-xs, 8px);
   background: transparent;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   text-align: left;
 }
 
@@ -86,13 +97,13 @@
 .fc-font-browser__preview { display: grid; align-content: start; gap: var(--space-3, 12px); }
 .fc-font-browser__preview-head,
 .fc-font-browser__size-control { display: flex; align-items: center; justify-content: space-between; gap: var(--space-2, 8px); }
-.fc-font-browser__availability { padding: 0.1em 0.55em; border: 1px solid var(--surface-rim-strong); border-radius: 999px; color: var(--ink-spectral); }
+.fc-font-browser__availability { padding: 0.1em 0.55em; border: 1px solid var(--surface-rim-strong); border-radius: 999px; color: var(--text-secondary); }
 .fc-font-browser__availability--unavailable { color: var(--warn); }
-.fc-font-browser__preview-copy { min-height: 5em; margin: 0; color: var(--ink-pearl); overflow-wrap: anywhere; }
-.fc-font-browser__stepper { min-width: 2.2em; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs, 8px); background: color-mix(in oklab, var(--surface-glass-strong) 78%, transparent); color: var(--ink-pearl); }
-.fc-font-browser__size-value { color: var(--ink-spectral); }
+.fc-font-browser__preview-copy { min-height: 5em; margin: 0; color: var(--text-primary); overflow-wrap: anywhere; }
+.fc-font-browser__stepper { min-width: 2.2em; border: 1px solid var(--surface-rim); border-radius: var(--radius-xs, 8px); background: color-mix(in oklab, var(--surface-glass-strong) 78%, transparent); color: var(--text-primary); }
+.fc-font-browser__size-value { color: var(--text-secondary); }
 .fc-font-browser__range { width: 100%; accent-color: var(--brass); }
-.fc-font-browser__state { margin: var(--space-2, 8px) 0; color: var(--ink-fog); }
+.fc-font-browser__state { margin: var(--space-2, 8px) 0; color: var(--text-tertiary); }
 .fc-font-browser__state--error { color: var(--coral); }
 
 @media (prefers-reduced-motion: reduce) {

--- a/runtime/fleet-console/markdown/styles.css
+++ b/runtime/fleet-console/markdown/styles.css
@@ -29,7 +29,7 @@
   min-width: 0;
   max-inline-size: clamp(60ch, 78ch, 78ch);
   margin-inline: auto;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-size: var(--font-size-body);
   line-height: 1.78;
   letter-spacing: -0.003em;
@@ -52,9 +52,9 @@
    최상위 헤딩 스타일이 필요하다. codex h2(display-md) 위 단계인 display-lg로 위계를 잡는다. */
 .markdown-body h1 {
   scroll-margin-top: var(--space-6);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   letter-spacing: -0.024em;
   font-variation-settings: "opsz" 72;
   font-size: var(--font-size-display-lg);
@@ -65,9 +65,9 @@
 .markdown-body h3,
 .markdown-body h4 {
   scroll-margin-top: var(--space-6);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   letter-spacing: -0.022em;
   font-variation-settings: "opsz" 60;
 }
@@ -97,7 +97,7 @@
   font-size: var(--font-size-title-md);
   line-height: 1.3;
   font-family: var(--font-body);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: -0.012em;
 }
 
@@ -105,22 +105,22 @@
   margin-top: var(--space-6);
   font-family: var(--font-body);
   font-size: var(--font-size-body);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   color: var(--brass-bright);
 }
 
 .markdown-body p,
 .markdown-body li {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .markdown-body strong {
-  color: var(--ink-pearl);
-  font-weight: 600;
+  color: var(--text-primary);
+  font-weight: var(--weight-medium);
 }
 
 .markdown-body em {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-style: italic;
 }
 
@@ -167,7 +167,7 @@
   border-left: 3px solid var(--brass);
   border-radius: 0 var(--radius-md) var(--radius-md) 0;
   background: color-mix(in oklch, var(--brass) 8%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-style: italic;
 }
 
@@ -197,7 +197,7 @@
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -205,7 +205,7 @@
 .markdown-body .frontmatter dd {
   margin: 0;
   min-width: 0;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-size: var(--font-size-lg);
   line-height: 1.6;
   overflow-wrap: anywhere;
@@ -231,9 +231,9 @@
   background: color-mix(in oklch, var(--ink-mid) 70%, transparent);
   color: var(--brass-bright);
   font-family: var(--font-body);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   font-size: var(--font-size-sm);
-  letter-spacing: 0.04em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
@@ -317,7 +317,7 @@
 .code-block-language {
   flex: 1;
   text-align: center;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   letter-spacing: 0.08em;
@@ -332,11 +332,11 @@
   border-radius: 8px;
   border: 1px solid color-mix(in oklch, var(--surface-rim) 70%, transparent);
   background: color-mix(in oklch, var(--ink-mid) 42%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  font-weight: 500;
-  letter-spacing: 0.04em;
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.01em;
   cursor: pointer;
   transition:
     color var(--duration-fast) var(--ease-spring),
@@ -357,7 +357,7 @@
   background: transparent;
   border: none;
   border-radius: 0;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: var(--font-size-code);
   line-height: 1.7;
@@ -407,8 +407,8 @@
   z-index: 2;
   color: var(--brass-bright);
   font-family: var(--font-mono);
-  font-size: var(--font-size-2xs);
-  font-weight: 600;
+  font-size: 10px;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.22em;
   text-transform: uppercase;
   pointer-events: none;
@@ -452,7 +452,7 @@
 
 :is(.diagram-block, .diagram-lightbox__viewport) svg .edgeLabel {
   background: transparent;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 :is(.diagram-block, .diagram-lightbox__viewport) svg .flowchart-link,
@@ -480,19 +480,19 @@
 }
 
 :is(.diagram-block, .diagram-lightbox__viewport) svg .slice {
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.04em;
   font-style: italic;
 }
 
 :is(.diagram-block, .diagram-lightbox__viewport) svg .pieTitleText {
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.12em;
   font-style: italic;
 }
 
 :is(.diagram-block, .diagram-lightbox__viewport) svg .legend text {
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.03em;
 }
 
@@ -552,7 +552,7 @@
   padding: var(--space-6);
   border: none;
   background: var(--ink-abyss);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .diagram-lightbox::backdrop {
@@ -586,7 +586,7 @@
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.2em;
   text-transform: uppercase;
 }
@@ -611,7 +611,7 @@
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.06em;
 }
 
@@ -637,7 +637,7 @@
   align-items: center;
   justify-content: center;
   min-width: 58px;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   background: color-mix(in oklch, var(--ink-abyss) 54%, transparent);
   border: 1px solid color-mix(in oklch, var(--surface-rim) 82%, transparent);
 }
@@ -652,9 +652,8 @@
   color: var(--brass-bright);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.01em;
   cursor: pointer;
   transition:
     background var(--duration-fast) var(--ease-spring),

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -12,6 +12,18 @@ const PRODUCT_SOURCE_ROOTS = [
   new URL("sdk/", CONSOLE_ROOT),
   new URL("../fleet-plugins/", CONSOLE_ROOT),
 ] as const;
+const CSS_SOURCE_ROOTS = [
+  new URL("core/client/src/", CONSOLE_ROOT),
+  new URL("../fleet-plugins/", CONSOLE_ROOT),
+] as const;
+const STANDALONE_CSS_SOURCES = [
+  new URL("markdown/styles.css", CONSOLE_ROOT),
+  new URL("font-picker/styles.css", CONSOLE_ROOT),
+] as const;
+const CSS_THEME_SOURCES = [
+  new URL("core/client/src/styles/theme.css", CONSOLE_ROOT),
+  new URL("core/client/src/codex/styles/theme.css", CONSOLE_ROOT),
+] as const;
 const PRODUCT_SOURCE_SUFFIXES = [".ts", ".tsx"] as const;
 const PRODUCT_SOURCE_SKIP_DIR_NAMES = new Set([
   "node_modules",
@@ -47,6 +59,34 @@ const OWNED_SOURCES = [
 ] as const;
 
 const FORBIDDEN_DECORATION = /radar-sweep|operations-radar|BACKGROUND_ANIMATION_STORAGE_KEY|PERIMETER_ANIMATION_STORAGE_KEY|Panel pulse|perimeter-orbit|notification-wake-pulse|AnchorIcon/;
+const RAW_TEXT_INK_TOKENS = /var\(\s*--ink-(?:fog|rim|spectral|pearl)\b/;
+const NUMERIC_FONT_WEIGHT = /^(?:[1-9]\d{0,2}|1000)\b/;
+const RUNTIME_CUSTOM_PROPERTY_ALLOWLIST = new Set([
+  // Canvas injects each frame's identity accent through TSX inline styles.
+  "--user-accent",
+  // Canvas injects stagger timing through CSSStyleDeclaration.setProperty at runtime.
+  "--panel-stagger-delay",
+  // Sidebar TSX injects its measured width for the shell layout.
+  "--side-bar-width",
+  // Sidebar TSX injects transient drag offsets for chips and group headers.
+  "--drag-dy",
+  // Sidebar TSX injects the persisted group tone used by group-scoped surfaces.
+  "--grp-color",
+  // Sidebar chip TSX injects the group marker tone for each rendered mark.
+  "--group-mark",
+  // What's New TSX injects each section's reveal delay.
+  "--whatsnew-delay",
+  // Command Band TSX injects the measured left sidebar width.
+  "--command-band-left-width",
+  // Right Rail TSX injects the current panel width.
+  "--right-rail-panel-width",
+  // Right Rail TSX injects the user-selected overlay opacity.
+  "--right-rail-overlay-alpha",
+  // Repository Rail TSX injects the user-resized workspace tree width.
+  "--ws-tree-width",
+  // Terminal Carriers TSX injects the selected captain identity tone.
+  "--cap-color",
+]);
 
 function source(path: string): string {
   return fs.readFileSync(new URL(path, CLIENT_ROOT), "utf8").replace(/\r\n/g, "\n");
@@ -74,6 +114,140 @@ function listProductSourceFiles(root: URL): string[] {
     }
   }
   return files.sort();
+}
+
+function listCssFiles(root: URL): string[] {
+  const files: string[] = [];
+  const stack = [fileURLToPath(root)];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        stack.push(path.join(current, entry.name));
+        continue;
+      }
+      if (entry.isFile() && entry.name.endsWith(".css")) files.push(path.join(current, entry.name));
+    }
+  }
+  return files.sort();
+}
+
+function listProductCssFiles(): string[] {
+  return [
+    ...CSS_SOURCE_ROOTS.flatMap(listCssFiles),
+    ...STANDALONE_CSS_SOURCES.map(fileURLToPath),
+  ].sort();
+}
+
+function consoleRelativePath(file: string): string {
+  return path.relative(fileURLToPath(CONSOLE_ROOT), file).replace(/\\/g, "/");
+}
+
+function maskCssCommentsAndStrings(css: string): string {
+  const masked = css.split("");
+  let state: "code" | "comment" | "string" = "code";
+  let quote = "";
+
+  for (let index = 0; index < css.length; index += 1) {
+    const current = css[index]!;
+    const next = css[index + 1];
+    if (state === "code" && current === "/" && next === "*") {
+      masked[index] = " ";
+      masked[index + 1] = " ";
+      state = "comment";
+      index += 1;
+      continue;
+    }
+    if (state === "comment") {
+      if (current === "*" && next === "/") {
+        masked[index] = " ";
+        masked[index + 1] = " ";
+        state = "code";
+        index += 1;
+      } else if (current !== "\n") {
+        masked[index] = " ";
+      }
+      continue;
+    }
+    if (state === "code" && (current === '"' || current === "'")) {
+      quote = current;
+      masked[index] = " ";
+      state = "string";
+      continue;
+    }
+    if (state === "string") {
+      if (current === "\\") {
+        masked[index] = " ";
+        if (next !== undefined && next !== "\n") {
+          masked[index + 1] = " ";
+          index += 1;
+        }
+      } else if (current === quote) {
+        masked[index] = " ";
+        state = "code";
+      } else if (current !== "\n") {
+        masked[index] = " ";
+      }
+    }
+  }
+
+  return masked.join("");
+}
+
+function maskFontFaceBlocks(css: string): string {
+  const masked = maskCssCommentsAndStrings(css);
+  const result = masked.split("");
+  const fontFace = /@font-face\b/gi;
+  let match: RegExpExecArray | null;
+  while ((match = fontFace.exec(masked)) !== null) {
+    const open = masked.indexOf("{", match.index);
+    if (open === -1) continue;
+    let depth = 0;
+    let close = open;
+    for (; close < masked.length; close += 1) {
+      if (masked[close] === "{") depth += 1;
+      if (masked[close] === "}") {
+        depth -= 1;
+        if (depth === 0) {
+          close += 1;
+          break;
+        }
+      }
+    }
+    for (let index = match.index; index < close; index += 1) {
+      if (result[index] !== "\n") result[index] = " ";
+    }
+    fontFace.lastIndex = close;
+  }
+  return result.join("");
+}
+
+function cssDeclarations(css: string, property: string): Array<{ index: number; value: string }> {
+  const declarations: Array<{ index: number; value: string }> = [];
+  const pattern = new RegExp(`(?:^|[;{])\\s*(${property})\\s*:\\s*([^;{}]*)`, "gim");
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(css)) !== null) {
+    declarations.push({
+      index: match.index + match[0].indexOf(match[1]!),
+      value: match[2]!.trim(),
+    });
+  }
+  return declarations;
+}
+
+function lineAt(text: string, index: number): number {
+  return text.slice(0, index).split("\n").length;
+}
+
+function customPropertyDefinitions(css: string): Set<string> {
+  const definitions = new Set<string>();
+  const masked = maskCssCommentsAndStrings(css);
+  const pattern = /(?:^|[;{])\s*(--[A-Za-z0-9_-]+)\s*:/gim;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(masked)) !== null) {
+    definitions.add(match[1]!);
+  }
+  return definitions;
 }
 
 function findRawProductSelects(): Array<{ file: string; line: number; snippet: string }> {
@@ -196,6 +370,64 @@ describe("Instrument core design contract", () => {
     expect(css).not.toMatch(/backdrop-filter|--op-accent|--chip-accent/);
     expect(css).toContain("background: var(--surface-glass)");
     expect(css).toContain(":focus-visible");
+  });
+
+  // 텍스트 3티어만 대비를 통제하므로 원료 잉크를 color에 직접 쓰면 판독 하한을 한곳에서 보장할 수 없다.
+  it("keeps text color on the semantic three-tier token grammar", () => {
+    const violations: string[] = [];
+    for (const file of listProductCssFiles()) {
+      const css = fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n");
+      const masked = maskCssCommentsAndStrings(css);
+      for (const declaration of cssDeclarations(masked, "color")) {
+        if (!RAW_TEXT_INK_TOKENS.test(declaration.value)) continue;
+        const line = lineAt(css, declaration.index);
+        violations.push(`${consoleRelativePath(file)}:${line} ${css.split("\n")[line - 1]!.trim()}`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  // 가변 서체도 위계는 3티어뿐이므로 임의 숫자 굵기가 흩어지면 같은 역할의 위계를 읽을 수 없다.
+  it("keeps product font weight on the regular, medium, and bold token tiers", () => {
+    const violations: string[] = [];
+    for (const file of listProductCssFiles()) {
+      const css = fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n");
+      const masked = maskFontFaceBlocks(css);
+      for (const declaration of cssDeclarations(masked, "font-weight")) {
+        if (!NUMERIC_FONT_WEIGHT.test(declaration.value)) continue;
+        const line = lineAt(css, declaration.index);
+        violations.push(`${consoleRelativePath(file)}:${line} ${css.split("\n")[line - 1]!.trim()}`);
+      }
+      for (const declaration of cssDeclarations(masked, "font")) {
+        const beforeLineHeight = declaration.value.split("/", 1)[0]!;
+        if (!/(?:^|\s)(?:[1-9]\d{0,2}|1000)(?=\s|$)/.test(beforeLineHeight)) continue;
+        const line = lineAt(css, declaration.index);
+        violations.push(`${consoleRelativePath(file)}:${line} ${css.split("\n")[line - 1]!.trim()}`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  // 미정의 var 참조는 조용히 무효화되어 의도와 다르게 상속되므로 정의 또는 명시된 런타임 주입이 필요하다.
+  it("requires every referenced custom property to have a CSS definition or runtime injection", () => {
+    const globallyDefined = new Set(
+      CSS_THEME_SOURCES.flatMap((theme) => [...customPropertyDefinitions(externalSource(theme))]),
+    );
+    const violations: string[] = [];
+    for (const file of listProductCssFiles()) {
+      const css = fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n");
+      const masked = maskCssCommentsAndStrings(css);
+      const defined = new Set([...globallyDefined, ...customPropertyDefinitions(css)]);
+      const reference = /var\(\s*(--[A-Za-z0-9_-]+)/g;
+      let match: RegExpExecArray | null;
+      while ((match = reference.exec(masked)) !== null) {
+        const name = match[1]!;
+        if (defined.has(name) || RUNTIME_CUSTOM_PROPERTY_ALLOWLIST.has(name)) continue;
+        const line = lineAt(css, match.index);
+        violations.push(`${consoleRelativePath(file)}:${line} ${name}`);
+      }
+    }
+    expect(violations).toEqual([]);
   });
 
   it("keeps user identity on the spine+mark grammar and off the state border channel", () => {
@@ -665,7 +897,7 @@ describe("Instrument core design contract", () => {
     expect(components).toContain("top: calc(-1 * var(--space-3));");
     expect(components).toContain("border-radius: 999px;");
     expect(components).toContain("background: var(--ink-mid);");
-    expect(components).toContain("color: var(--ink-spectral);");
+    expect(components).toContain("color: var(--text-secondary);");
     expect(components).toContain(".canvas-operation.is-active .canvas-operation-titlebar {");
     expect(components).toContain("color-mix(in oklch, var(--brass) 62%, var(--ink-rim))");
     expect(components).toContain(".canvas-operation-window-controls {");
@@ -727,8 +959,8 @@ describe("Instrument core design contract", () => {
     expect(selectBlock).toContain("z-index: var(--z-select-popover);");
     expect(selectBlock).toContain("border: 1px solid var(--surface-rim);");
     expect(selectBlock).toContain("background: color-mix(in oklch, var(--ink-mid) 48%, transparent);");
-    expect(selectBlock).toContain("color: var(--ink-pearl);");
-    expect(selectBlock).toContain("font: 600 13px/1.2 var(--font-body);");
+    expect(selectBlock).toContain("color: var(--text-primary);");
+    expect(selectBlock).toContain("font-weight: var(--weight-medium); font-size: 13px; line-height: 1.2; font-family: var(--font-body);");
     expect(selectBlock).toContain("padding: 0 13px;");
     expect(selectBlock).toContain("box-shadow: inset 0 1px 0 color-mix(in oklch, var(--ink-pearl) 5%, transparent);");
     expect(selectBlock).toContain("border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim));");
@@ -736,7 +968,9 @@ describe("Instrument core design contract", () => {
     expect(selectBlock).toContain('content: "✓";');
     expect(selectBlock).toContain("font-style: italic;");
     expect(selectBlock).toContain(".fc-select--compact .fc-select__trigger {");
-    expect(selectBlock).toContain("font: 9px/1 var(--font-mono);");
+    expect(selectBlock).toContain(
+      "font-weight: var(--weight-regular);\n  font-size: 9px;\n  line-height: 1;\n  font-family: var(--font-mono);",
+    );
     expect(selectBlock).toContain("padding: 8px 16px 8px 10px;");
     expect(selectBlock).toContain(".fc-select__popup--compact { min-width: min(160px, calc(100vw - 16px)); }");
     expect(selectBlock).toMatch(/\.reduce-panel-motion \.fc-select__trigger,\s*\.reduce-panel-motion \.fc-select__caret,\s*\.reduce-panel-motion \.fc-select__popup,\s*\.reduce-panel-motion \.fc-select__option \{\s*transition: none;\s*\}/);

--- a/runtime/fleet-plugins/file-explorer/client/explorer.css
+++ b/runtime/fleet-plugins/file-explorer/client/explorer.css
@@ -103,7 +103,7 @@
   flex: 1;
   font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -114,7 +114,7 @@
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 14px;
   line-height: 1;
   padding: 4px;
@@ -123,7 +123,7 @@
 }
 
 .fexp-viewer-close:hover {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .fexp-viewer-body {
@@ -136,7 +136,7 @@
   padding: 16px;
   font-family: var(--font-mono);
   font-size: 12px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .fexp-viewer-error {
@@ -168,7 +168,7 @@
   background: color-mix(in oklch, var(--ink-deep) 30%, transparent);
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: 12px;
   padding: 3px 8px;
@@ -185,7 +185,7 @@
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 12px;
   padding: 2px 4px;
   border-radius: var(--radius-xs);
@@ -194,7 +194,7 @@
 }
 
 .fexp-filter-clear:hover {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 /* ── 파일 트리 ── */
@@ -214,11 +214,11 @@
   text-align: left;
   font-family: var(--font-mono);
   font-size: 12px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .fexp-tree-up:hover {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .fexp-tree-row {
@@ -233,17 +233,17 @@
   cursor: pointer;
   text-align: left;
   font-size: 13px;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   transition: background 0.1s;
 }
 
 .fexp-tree-row:hover {
-  background: var(--surface-hover);
+  background: var(--surface-glass);
 }
 
 .fexp-tree-row.is-cur {
   color: var(--brass);
-  background: var(--surface-active);
+  background: var(--surface-glass-strong);
 }
 
 .fexp-tree-icon {
@@ -253,7 +253,7 @@
   justify-content: center;
   font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   width: 16px;
   height: 16px;
 }
@@ -273,14 +273,14 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-family: var(--font-ui);
+  font-family: var(--font-body);
   font-size: 13px;
 }
 
 .fexp-tree-spin {
   font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   animation: none;
 }
 
@@ -289,7 +289,7 @@
 .fexp-tree-error {
   padding: 16px 12px;
   font-size: 12px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .fexp-tree-error { color: var(--coral); }
@@ -329,7 +329,7 @@
   padding: 0 8px;
   text-align: right;
   user-select: none;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   vertical-align: top;
   border-right: 1px solid var(--surface-rim);
 }
@@ -337,19 +337,19 @@
 .fexp-line-code {
   padding: 0 12px;
   white-space: pre;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   vertical-align: top;
 }
 
 /* 구문강조 토큰 팔레트 */
-.syn-key  { color: var(--brass-bright, var(--brass)); font-weight: 500; }
+.syn-key  { color: var(--brass-bright, var(--brass)); font-weight: var(--weight-medium); }
 .syn-str  { color: var(--positive); }
 .syn-num  { color: var(--warn); }
-.syn-com  { color: var(--ink-fog); font-style: italic; }
+.syn-com  { color: var(--text-tertiary); font-style: italic; }
 .syn-fn   { color: var(--aurora); }
 .syn-tag  { color: var(--coral); }
 .syn-attr { color: var(--brass); }
-.syn-punct { color: var(--ink-fog); }
+.syn-punct { color: var(--text-tertiary); }
 
 /* ── 마크다운 뷰어 ── */
 .fexp-md-wrap {
@@ -372,7 +372,7 @@
   padding: 3px 8px;
   border: 1px dashed color-mix(in oklch, var(--ink-fog) 48%, transparent);
   border-radius: var(--radius-sm);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.4;
@@ -415,7 +415,7 @@
 .fexp-img-caption {
   font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   text-align: center;
 }
 
@@ -433,20 +433,20 @@
 
 .fexp-bin-glyph {
   font-size: 32px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .fexp-bin-name {
   font-family: var(--font-mono);
   font-size: 13px;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   margin: 0;
 }
 
 .fexp-bin-meta,
 .fexp-bin-hint {
   font-size: 12px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   margin: 0;
 }
 
@@ -456,7 +456,7 @@
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   padding: 2px 4px;
   border-radius: var(--radius-xs);
   line-height: 1;
@@ -466,7 +466,7 @@
 }
 
 .fexp-hidden-toggle:hover {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .fexp-hidden-toggle.is-active {
@@ -479,7 +479,7 @@
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 15px;
   padding: 2px 4px;
   border-radius: var(--radius-xs);
@@ -490,5 +490,5 @@
 }
 
 .fexp-refresh-btn:hover {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -89,7 +89,7 @@
   background: color-mix(in oklch, var(--ink-abyss) 35%, transparent);
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: 12px;
   padding: 3px 8px;
@@ -108,7 +108,7 @@
   background: none;
   border: none;
   border-radius: var(--radius-xs);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
   font-size: 12px;
   line-height: 1;
@@ -118,7 +118,7 @@
 
 .repository-filter-clear:hover,
 .history-filter-clear:hover {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .repository-plugin-toolbar {
@@ -137,7 +137,7 @@
   font-size: 10.5px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .repository-view-toggle {
@@ -152,19 +152,19 @@
 
 .repository-toggle-btn {
   width: 24px;
-  height: 22px;
+  height: 24px;
   display: inline-grid;
   place-items: center;
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   border-radius: 6px;
   transition: color 0.14s, background 0.14s;
 }
 
 .repository-toggle-btn:hover {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .repository-toggle-btn.is-active {
@@ -180,7 +180,7 @@
 .repository-sections-loading {
   padding: 16px 12px;
   font-size: 12px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
 }
 
@@ -204,12 +204,12 @@
 }
 
 .repository-notice-title {
-  color: var(--ink-spectral);
-  font-weight: 600;
+  color: var(--text-secondary);
+  font-weight: var(--weight-medium);
 }
 
 .repository-notice-body {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 /* ── 아코디언 섹션 ── */
@@ -238,7 +238,7 @@
   width: 12px;
   height: 12px;
   flex: none;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   transition: transform var(--duration-base) var(--ease-spring);
 }
 
@@ -256,17 +256,17 @@
   flex: 1;
   font-family: var(--font-mono);
   font-size: 10.5px;
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.13em;
   text-transform: uppercase;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .repository-count-badge {
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 600;
-  color: var(--ink-fog);
+  font-weight: var(--weight-medium);
+  color: var(--text-tertiary);
   background: color-mix(in oklch, var(--ink-fog) 16%, transparent);
   border-radius: 999px;
   padding: 1px 8px;
@@ -283,7 +283,7 @@
   padding: 8px 12px;
   font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 /* ── 파일 행 (리스트뷰 + 트리 리프 공유) ── */
@@ -315,7 +315,7 @@
 .repository-status-glyph {
   font-family: var(--font-mono);
   font-size: 11px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   text-align: center;
 }
 
@@ -337,7 +337,7 @@
 .repository-file-fn {
   font-family: var(--font-body);
   font-size: 13px;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -350,7 +350,7 @@
 .repository-file-dir {
   font-family: var(--font-mono);
   font-size: 12px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -395,7 +395,7 @@
 .repository-folder-chevron {
   width: 11px;
   height: 11px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   transition: transform var(--duration-base) var(--ease-spring);
 }
 
@@ -412,13 +412,13 @@
 .repository-folder-icon {
   width: 15px;
   height: 15px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .repository-folder-name {
   font-family: var(--font-body);
   font-size: 13px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -426,7 +426,7 @@
 
 .repository-folder-count {
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: 10px;
   color: var(--text-tertiary);
   padding-left: 8px;
 }
@@ -438,19 +438,19 @@
   border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: 11px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   padding: 3px 8px;
 }
 
 .repository-refresh-btn:hover {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .repository-truncated-badge {
   flex-shrink: 0;
   padding: 4px 12px;
   font-size: 11px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   background: color-mix(in oklch, var(--ink-fog) 8%, transparent);
   border-bottom: 1px solid var(--surface-rim);
   font-family: var(--font-mono);
@@ -474,7 +474,7 @@
   flex: 1;
   font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -486,7 +486,7 @@
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 14px;
   line-height: 1;
   min-width: 32px;
@@ -498,7 +498,7 @@
 }
 
 .repository-hunk-close:hover {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 /* ── Hunk 본문 ── */
@@ -512,7 +512,7 @@
   padding: 16px;
   font-family: var(--font-mono);
   font-size: 12px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .repository-hunk-error {
@@ -543,17 +543,17 @@
 .repository-line-code {
   padding: 0 12px;
   white-space: pre;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   vertical-align: top;
   width: 100%;
 }
 
 .repository-line-header .repository-line-code {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .repository-line-meta {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
 }
@@ -583,8 +583,8 @@
 .repository-token-string { color: var(--id-moss); }
 .repository-token-number { color: var(--id-amber); }
 .repository-token-type { color: var(--id-plum); }
-.repository-token-comment { color: var(--ink-fog); font-style: italic; }
-.repository-token-punctuation { color: var(--ink-fog); }
+.repository-token-comment { color: var(--text-tertiary); font-style: italic; }
+.repository-token-punctuation { color: var(--text-tertiary); }
 /* add/del 행은 단색으로 말하고 장식 구문색은 context 행에만 둔다. comment·punctuation은 ink-fog 무채색 계열이라 유지한다. */
 .repository-line-add .repository-token-keyword,
 .repository-line-add .repository-token-string,
@@ -601,7 +601,7 @@
 .repository-gutter {
   font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   text-align: right;
   padding: 0 6px 0 4px;
   white-space: nowrap;
@@ -633,7 +633,7 @@
   padding: 2px 10px;
   font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 /* ── 다중 파일 패치 파일 경계 행 ── */
@@ -647,7 +647,7 @@
 .repository-line-file-label td {
   font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   padding: 3px 10px;
 }
 
@@ -721,7 +721,7 @@
   padding: 1px 7px;
   border-radius: 999px;
   background: color-mix(in oklch, var(--ink-fog) 16%, transparent);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
   text-align: center;
@@ -759,12 +759,14 @@
   box-shadow: inset 2px 0 0 var(--brass);
 }
 
-/* 현재 체크아웃 브랜치에서 도달 불가능한 커밋은 본문만 감광 — 그래프/배지는 유지 */
+/* 현재 체크아웃 브랜치에서 도달 불가능한 커밋은 본문만 강등 — 그래프/배지는 유지.
+   강등은 opacity가 아니라 텍스트 티어로 표현한다: 색 × 투명도 이중 감쇠는 판독 하한을 지키는
+   토큰을 무력화한다(off-head 제목 실측 2.36:1). 티어 강등이면 하한이 그대로 보장된다. */
 .history-commit-row.is-off-head .history-commit-subject,
 .history-commit-row.is-off-head .history-commit-author,
 .history-commit-row.is-off-head .history-commit-sha,
 .history-commit-row.is-off-head .history-commit-time {
-  opacity: 0.45;
+  color: var(--text-tertiary);
 }
 
 .history-graph-gutter {
@@ -789,7 +791,7 @@
   padding: 0 5px;
   border-radius: 999px;
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: 10px;
   letter-spacing: 0.04em;
   line-height: 1.55;
 }
@@ -805,23 +807,23 @@
 }
 
 .history-badge--tag {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   border: 1px solid color-mix(in oklch, var(--ink-fog) 45%, transparent);
 }
 
 .history-badge--branch {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   border: 1px solid color-mix(in oklch, var(--ink-fog) 45%, transparent);
   background: color-mix(in oklch, var(--ink-fog) 10%, transparent);
 }
 
 .history-badge--remote {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   border: 1px dashed color-mix(in oklch, var(--ink-fog) 60%, transparent);
 }
 
 .history-badge--worktree {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   border: 1px dashed color-mix(in oklch, var(--ink-fog) 60%, transparent);
 }
 
@@ -831,7 +833,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-body);
   font-size: 12.5px;
 }
@@ -843,21 +845,21 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10.5px;
 }
 
 .history-commit-sha,
 .history-detail-sha {
-  color: color-mix(in oklch, var(--ink-spectral) 58%, transparent);
+  color: var(--text-tertiary);
 }
 
 .history-empty,
 .history-error,
 .history-truncated {
   padding: 14px 12px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
 }
@@ -870,7 +872,7 @@
 }
 
 .history-truncated {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   border-top: 1px solid var(--surface-rim);
   background: color-mix(in oklch, var(--ink-fog) 8%, transparent);
 }
@@ -906,12 +908,12 @@
   border: none;
   border-radius: var(--radius-sm);
   background: none;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
 }
 
 .history-detail-close:hover {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .history-detail-body {
@@ -943,30 +945,30 @@
 .history-commit-time { grid-column: 5; }
 .history-inspector { display: grid; grid-template-rows: auto minmax(0, 1fr); height: 100%; min-height: 0; }
 .history-segmented { display: flex; gap: 4px; padding: 8px 12px; border-bottom: 1px solid var(--surface-rim); }
-.history-segmented button { flex: 1; border: 1px solid transparent; border-radius: var(--radius-sm); background: none; color: var(--ink-fog); cursor: pointer; font-family: var(--font-mono); font-size: 11px; letter-spacing: .06em; padding: 6px; transition: color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide); }
-.history-segmented button[aria-pressed="true"] { border-color: color-mix(in oklch, var(--brass) 40%, transparent); background: color-mix(in oklch, var(--brass) 12%, transparent); color: var(--ink-spectral); }
-.history-segmented span { color: var(--ink-fog); font-size: 9px; }
-.history-segmented .history-inspector-close { flex: 0 0 auto; width: 28px; min-width: 28px; height: 28px; padding: 0; border-color: transparent; }
+.history-segmented button { flex: 1; border: 1px solid transparent; border-radius: var(--radius-sm); background: none; color: var(--text-tertiary); cursor: pointer; font-family: var(--font-mono); font-size: 11px; letter-spacing: .01em; padding: 6px; transition: color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide); }
+.history-segmented button[aria-pressed="true"] { border-color: color-mix(in oklch, var(--brass) 40%, transparent); background: color-mix(in oklch, var(--brass) 12%, transparent); color: var(--text-secondary); }
+.history-segmented span { color: var(--text-tertiary); font-size: 10px; }
+.history-segmented .history-inspector-close { flex: 0 0 auto; width: 24px; min-width: 24px; height: 24px; padding: 0; border-color: transparent; }
 .history-details-tab { display: grid; min-height: 0; overflow: hidden; }
 .history-divider--horizontal { width: auto; height: 4px; cursor: row-resize; touch-action: none; }
 .history-inspector-head { min-height: 0; overflow: auto; padding: 14px 16px; border-bottom: 1px solid var(--surface-rim); }
-.history-inspector-subject { color: var(--ink-spectral); font-size: 13.5px; font-weight: 600; line-height: 1.35; }
-.history-inspector-message { margin: 6px 0 0; color: var(--ink-fog); font-family: var(--font-mono); font-size: 11.5px; line-height: 1.5; white-space: pre-wrap; }
-.history-author { display: flex; align-items: center; gap: 8px; margin-top: 12px; color: var(--ink-spectral); font-size: 12px; }
+.history-inspector-subject { color: var(--text-secondary); font-size: 13.5px; font-weight: var(--weight-medium); line-height: 1.35; }
+.history-inspector-message { margin: 6px 0 0; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 11.5px; line-height: 1.5; white-space: pre-wrap; }
+.history-author { display: flex; align-items: center; gap: 8px; margin-top: 12px; color: var(--text-secondary); font-size: 12px; }
 .history-author > span:nth-child(2) { display: grid; gap: 1px; }
-.history-author b { font-weight: 500; }.history-author small, .history-author time { color: var(--ink-fog); font-family: var(--font-mono); font-size: 10.5px; }
+.history-author b { font-weight: var(--weight-medium); }.history-author small, .history-author time { color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10.5px; }
 .history-author time { margin-left: auto; }
-.history-avatar { display: grid; width: 24px; height: 24px; place-items: center; border-radius: 50%; background: color-mix(in oklch, var(--ink-fog) 24%, var(--ink-veil)); color: var(--ink-spectral); font-family: var(--font-mono); font-size: 10px; font-weight: 700; }
+.history-avatar { display: grid; width: 24px; height: 24px; place-items: center; border-radius: 50%; background: color-mix(in oklch, var(--ink-fog) 24%, var(--ink-veil)); color: var(--text-secondary); font-family: var(--font-mono); font-size: 10px; font-weight: var(--weight-bold); }
 .history-inspector-ids, .history-ref-chips { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 10px; }
 .history-sha-copy, .history-parent { border-radius: var(--radius-sm); background: none; cursor: pointer; font-family: var(--font-mono); font-size: 10.5px; padding: 3px 8px; }
-.history-sha-copy { border: 1px solid var(--surface-rim); color: var(--ink-spectral); }.history-sha-copy span { color: var(--ink-fog); margin-left: 7px; }.history-sha-copy.is-copied { border-color: var(--positive); color: var(--positive); }
-.history-parent { border: 1px solid var(--surface-rim); color: var(--ink-spectral); }
+.history-sha-copy { border: 1px solid var(--surface-rim); color: var(--text-secondary); }.history-sha-copy span { color: var(--text-tertiary); margin-left: 7px; }.history-sha-copy.is-copied { border-color: var(--positive); color: var(--positive); }
+.history-parent { border: 1px solid var(--surface-rim); color: var(--text-secondary); }
 .history-commit-files { display: grid; grid-template-rows: auto minmax(0, 1fr); min-height: 0; overflow: hidden; }
-.history-files-title { display: flex; gap: 8px; align-items: center; padding: 8px 14px; border-bottom: 1px solid var(--surface-rim); color: var(--ink-fog); font-family: var(--font-mono); font-size: 10.5px; letter-spacing: .1em; text-transform: uppercase; }.history-files-stats { margin-left: auto; letter-spacing: 0; }.history-files-title i { color: var(--positive); font-style: normal; }.history-files-title em { color: var(--coral); font-style: normal; }.history-files-view-toggle { margin-left: 0; }
+.history-files-title { display: flex; gap: 8px; align-items: center; padding: 8px 14px; border-bottom: 1px solid var(--surface-rim); color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10.5px; letter-spacing: .1em; text-transform: uppercase; }.history-files-stats { margin-left: auto; letter-spacing: 0; }.history-files-title i { color: var(--positive); font-style: normal; }.history-files-title em { color: var(--coral); font-style: normal; }.history-files-view-toggle { margin-left: 0; }
 .history-files-scroll { min-height: 0; overflow: auto; }.history-commit-files .repository-file-row { padding-left: 14px; }
 .history-changes-tab { min-height: 0; overflow: hidden; }.history-changes-columns { display: grid; min-height: 0; height: 100%; }.history-changes-columns > .history-commit-files { border-right: 1px solid var(--surface-rim); }
-.history-file-diff { display: grid; grid-template-rows: auto minmax(0, 1fr); min-width: 0; overflow: hidden; }.history-file-repository-head { display: flex; align-items: center; gap: 8px; min-width: 0; padding: 7px 12px; border-bottom: 1px solid var(--surface-rim); color: var(--ink-fog); font-family: var(--font-mono); font-size: 11px; }.history-file-repository-head > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }.history-file-repository-head > div { display: flex; gap: 2px; margin-left: auto; }.history-file-repository-head button { width: 22px; height: 22px; border: 1px solid var(--surface-rim); border-radius: var(--radius-sm); background: none; color: var(--ink-fog); cursor: pointer; }.history-file-repository-head button:disabled { cursor: default; opacity: .4; }
-.history-inspector-empty { padding: 16px; color: var(--ink-fog); font-family: var(--font-mono); font-size: 12px; }.history-inspector-error { color: var(--coral); }
+.history-file-diff { display: grid; grid-template-rows: auto minmax(0, 1fr); min-width: 0; overflow: hidden; }.history-file-repository-head { display: flex; align-items: center; gap: 8px; min-width: 0; padding: 7px 12px; border-bottom: 1px solid var(--surface-rim); color: var(--text-tertiary); font-family: var(--font-mono); font-size: 11px; }.history-file-repository-head > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }.history-file-repository-head > div { display: flex; gap: 2px; margin-left: auto; }.history-file-repository-head button { width: 24px; height: 24px; border: 1px solid var(--surface-rim); border-radius: var(--radius-sm); background: none; color: var(--text-tertiary); cursor: pointer; }.history-file-repository-head button:disabled { cursor: default; opacity: .4; }
+.history-inspector-empty { padding: 16px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 12px; }.history-inspector-error { color: var(--coral); }
 /* 진행형 축소 — 컨테이너(패널·트리 리사이즈)가 좁아질수록 시간 → sha → 뱃지 순으로 양보한다. */
 @container (max-width: 640px) { .history-commit-time { display: none; } .history-commit-row { grid-template-columns: auto auto minmax(96px, 1fr) 7ch; } }
 @container (max-width: 520px) { .history-commit-sha { display: none; } .history-commit-row { grid-template-columns: auto auto minmax(96px, 1fr); } }
@@ -977,36 +979,36 @@
 .repository-identity { display: flex; align-items: center; gap: 8px; min-height: 34px; padding: 7px 12px; border-bottom: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--surface-band) 72%, transparent); color: var(--text-secondary); }
 .repository-identity.is-subcontext { box-shadow: inset 2px 0 0 var(--brass); }
 .repository-identity svg { width: 15px; height: 15px; flex: none; opacity: .85; }
-.repository-identity strong { min-width: 0; overflow: hidden; color: var(--text-primary); font-size: 12.5px; font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }
+.repository-identity strong { min-width: 0; overflow: hidden; color: var(--text-primary); font-size: 12.5px; font-weight: var(--weight-medium); text-overflow: ellipsis; white-space: nowrap; }
 /* 브랜치는 정체의 일부라 이름 옆에 붙인다 — margin-left:auto로 밀면 넓은 레일에서 이름과의 연관이 끊긴다.
    brass는 location 채널이므로 "어느 체크아웃인가"를 칠하는 데 쓴다. */
 .repository-identity span { min-width: 0; overflow: hidden; color: var(--brass); flex: 0 1 auto; font-family: var(--font-mono); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
 /* 숨김-마운트 래퍼가 높이 문맥을 끊으면 history-root의 height:100%가 내용 높이로 풀려 내부 스크롤이 죽는다 */
 .repository-source-fill { height: 100%; min-height: 0; }
 .repository-discovery { display: flex; align-items: center; gap: 8px; flex: none; padding: 6px 10px; border-bottom: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--surface-band) 55%, transparent); }
-.repository-discovery-depth { display: inline-flex; align-items: center; gap: 3px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 9.5px; letter-spacing: .1em; text-transform: uppercase; }
+.repository-discovery-depth { display: inline-flex; align-items: center; gap: 3px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; letter-spacing: .1em; text-transform: uppercase; }
 .repository-depth-step { border: 0; background: none; color: var(--text-tertiary); cursor: pointer; font-family: var(--font-mono); font-size: 12px; padding: 0 3px; }
 .repository-depth-step:hover:not(:disabled) { color: var(--text-primary); }
 .repository-depth-step:disabled { opacity: .4; cursor: default; }
-.repository-depth-value { border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); padding: 0 6px; color: var(--ink-spectral); font-family: var(--font-mono); font-size: 11px; }
+.repository-depth-value { border: 1px solid var(--surface-rim); border-radius: var(--radius-xs); padding: 0 6px; color: var(--text-secondary); font-family: var(--font-mono); font-size: 11px; }
 .repository-scan-count { margin-left: auto; min-width: 0; overflow: hidden; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
 .repository-ref-list { padding: var(--space-2); display: grid; gap: 2px; }
 .repository-ref-group { display: grid; gap: 2px; }
-.repository-ref-group-label { padding: 8px 10px 2px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 9.5px; font-weight: 400; letter-spacing: .18em; text-transform: uppercase; }
-.repository-ref-row { display: flex; align-items: center; gap: 9px; width: 100%; border: 0; border-radius: var(--radius-xs); background: transparent; color: var(--text-secondary); cursor: pointer; font: inherit; text-align: left; padding: 7px 10px; transition: color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide); }
+.repository-ref-group-label { padding: 8px 10px 2px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; font-weight: var(--weight-regular); letter-spacing: .18em; text-transform: uppercase; }
+.repository-ref-row { display: flex; align-items: center; gap: 9px; width: 100%; border: 0; border-radius: var(--radius-xs); background: transparent; color: var(--text-secondary); cursor: pointer; font-style: inherit; font-variant: inherit; font-weight: var(--weight-regular); font-stretch: inherit; font-size: inherit; line-height: inherit; font-family: inherit; text-align: left; padding: 7px 10px; transition: color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide); }
 .repository-ref-row:hover { background: color-mix(in oklch, var(--ink-fog) 9%, transparent); color: var(--text-primary); }
 .repository-ref-row:disabled { cursor: default; }
 .repository-ref-row.is-current { color: var(--text-primary); }
 .repository-ref-row.is-current:hover { color: var(--text-primary); }
 .repository-ref-row svg { width: 13px; height: 13px; flex: none; opacity: .85; }
-.repository-ref-name { min-width: 0; overflow: hidden; font-size: 12.5px; font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }
+.repository-ref-name { min-width: 0; overflow: hidden; font-size: 12.5px; font-weight: var(--weight-medium); text-overflow: ellipsis; white-space: nowrap; }
 /* 현재 체크아웃 마크 = 위치 채널 */
 .repository-ref-mark { flex: none; color: var(--brass); font-size: 11px; }
 /* 매칭 글자 = 포커스 채널(brass) */
-.repository-ref-hl { color: var(--brass); font-weight: 700; }
+.repository-ref-hl { color: var(--brass); font-weight: var(--weight-bold); }
 .repository-ref-sub { margin-left: auto; color: var(--text-tertiary); flex: none; font-family: var(--font-mono); font-size: 10px; }
 .repository-ref-row.is-current .repository-ref-sub { color: var(--brass); }
-.repository-wip-row, .repository-ref-chip { border: 0; background: transparent; color: var(--text-secondary); font: inherit; text-align: left; padding: 7px 10px; }
+.repository-wip-row, .repository-ref-chip { border: 0; background: transparent; color: var(--text-secondary); font-style: inherit; font-variant: inherit; font-weight: var(--weight-regular); font-stretch: inherit; font-size: inherit; line-height: inherit; font-family: inherit; text-align: left; padding: 7px 10px; }
 .repository-wip-row { color: var(--brass); }
 .repository-wip-row { width: 100%; border-bottom: 1px dashed var(--surface-rim); }
 .repository-wip-row span { float: right; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; }
@@ -1071,7 +1073,7 @@
   background: transparent;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: 10px;
   letter-spacing: .14em;
   cursor: pointer;
   text-align: left;
@@ -1093,7 +1095,7 @@
 
 .repository-ws-section-head i {
   margin-left: auto;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-style: normal;
   letter-spacing: 0;
 }
@@ -1110,7 +1112,7 @@
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
-  font: inherit;
+  font-style: inherit; font-variant: inherit; font-weight: var(--weight-regular); font-stretch: inherit; font-size: inherit; line-height: inherit; font-family: inherit;
   font-size: 12px;
   text-align: left;
   transition: color var(--duration-base) var(--ease-spring), background var(--duration-base) var(--ease-spring);
@@ -1156,7 +1158,7 @@
   color: var(--text-tertiary);
   flex: none;
   font-family: var(--font-mono);
-  font-size: 9.5px;
+  font-size: 10px;
   font-style: normal;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1174,7 +1176,7 @@
   padding: 4px 10px 2px 20px;
   color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 8.5px;
+  font-size: 10px;
   letter-spacing: .12em;
 }
 
@@ -1195,7 +1197,7 @@
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
-  font: inherit;
+  font-style: inherit; font-variant: inherit; font-weight: var(--weight-regular); font-stretch: inherit; font-size: inherit; line-height: inherit; font-family: inherit;
 }
 
 .repository-ws-tree .repository-ref-row,

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -129,7 +129,7 @@ describe("Repository design grammar", () => {
     const chevrons = blocksOf(".repository-folder-chevron");
     expect(chevrons[0]).toContain("width: 11px");
     expect(chevrons[0]).toContain("height: 11px");
-    expect(chevrons[0]).toContain("color: var(--ink-fog)");
+    expect(chevrons[0]).toContain("color: var(--text-tertiary)");
     expect(chevrons[0]).toContain("transition: transform var(--duration-base) var(--ease-spring)");
     expect(chevrons.some((body) => body.includes("transition-duration: 0.01ms"))).toBe(true);
     expect(blockOf(".repository-ws-section.is-collapsed .repository-folder-chevron")).toContain("transform: rotate(-90deg)");

--- a/runtime/fleet-plugins/skills/client/skills.css
+++ b/runtime/fleet-plugins/skills/client/skills.css
@@ -22,19 +22,18 @@
   background: none;
   border: none;
   border-bottom: 2px solid transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.01em;
   line-height: 1;
   padding: var(--space-2) var(--space-3);
-  text-transform: uppercase;
   transition: color var(--duration-base), border-color var(--duration-base);
 }
 
-.skills-tab-btn:hover { color: var(--ink-spectral); }
+.skills-tab-btn:hover { color: var(--text-secondary); }
 
 .skills-tab-btn.is-active {
   border-bottom-color: var(--brass);
@@ -72,19 +71,18 @@
   background: none;
   border: none;
   border-radius: var(--radius-xs);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
   flex: 1;
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.01em;
   padding: 4px var(--space-2);
-  text-transform: uppercase;
   transition: background var(--duration-base), color var(--duration-base);
 }
 
-.skills-scope-btn:hover:not(:disabled) { color: var(--ink-spectral); }
+.skills-scope-btn:hover:not(:disabled) { color: var(--text-secondary); }
 
 .skills-scope-btn.is-active {
   background: color-mix(in srgb, var(--brass) 20%, transparent);
@@ -106,7 +104,7 @@
   background: color-mix(in srgb, var(--surface-glass) 40%, transparent);
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
-  color: var(--ink-body);
+  color: var(--text-primary);
   font-family: inherit;
   font-size: 0.8125rem;
   padding: var(--space-2) var(--space-3);
@@ -115,7 +113,7 @@
   flex-shrink: 0;
 }
 
-.skills-filter-input::placeholder { color: var(--ink-fog); }
+.skills-filter-input::placeholder { color: var(--text-tertiary); }
 
 .skills-filter-input:focus {
   outline: 2px solid var(--brass);
@@ -125,7 +123,7 @@
 /* ─── empty state ───────────────────────────────────────────────────────────── */
 
 .skills-empty-state {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 0.8125rem;
   padding: var(--space-4) var(--space-2);
   text-align: center;
@@ -160,11 +158,11 @@
 .skills-card-name-btn {
   background: none;
   border: none;
-  color: var(--ink-body);
+  color: var(--text-primary);
   cursor: pointer;
   font-family: inherit;
   font-size: 0.875rem;
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   padding: 0;
   text-align: left;
 }
@@ -174,7 +172,7 @@
 .skills-card-scope-badge {
   border-radius: var(--radius-sm);
   font-size: 0.625rem;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   padding: 2px 5px;
   text-transform: uppercase;
@@ -187,18 +185,18 @@
 
 .skills-card-scope-badge--global {
   background: color-mix(in srgb, var(--ink-fog) 15%, transparent);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .skills-card-meta {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 0.75rem;
 }
 
 .skills-card-agents { font-style: italic; }
 
 .skills-card-installs {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 0.75rem;
   margin-left: auto;
 }
@@ -217,22 +215,21 @@
   border-radius: var(--radius-xs);
   cursor: pointer;
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.01em;
   padding: 4px var(--space-3);
   transition: background var(--duration-base), color var(--duration-base);
 }
 
 .skills-btn--ghost {
   background: none;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .skills-btn--ghost:hover:not(:disabled) {
   background: color-mix(in srgb, var(--surface-glass) 60%, transparent);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
 }
 
 .skills-btn--ghost:disabled {
@@ -252,7 +249,7 @@
 
 .skills-btn--remove {
   background: none;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   margin-left: auto;
 }
 
@@ -291,7 +288,7 @@
 }
 
 .skills-dock-log-line {
-  color: var(--ink-body);
+  color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -348,10 +345,10 @@
 }
 
 .skills-dock-label {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   flex: 1;
   font-size: 0.78rem;
-  font-weight: 500;
+  font-weight: var(--weight-medium);
 }
 
 .skills-dock-label.is-ok { color: var(--positive); }
@@ -359,7 +356,7 @@
 .skills-dock-label.is-err { color: var(--coral); }
 
 .skills-dock-count {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: "JetBrains Mono Variable", monospace;
   font-size: 0.6875rem;
 }
@@ -367,14 +364,14 @@
 .skills-dock-dismiss {
   background: none;
   border: none;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
   font-size: 0.9rem;
   line-height: 1;
   padding: 0 2px;
 }
 
-.skills-dock-dismiss:hover { color: var(--ink-spectral); }
+.skills-dock-dismiss:hover { color: var(--text-secondary); }
 
 .skills-dock-dismiss:focus-visible {
   outline: 2px solid var(--brass);
@@ -388,7 +385,7 @@
   color: var(--coral);
   cursor: pointer;
   font-size: 0.6875rem;
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   padding: 2px 8px;
 }
 
@@ -398,7 +395,7 @@
 }
 
 .skills-dock-chevron {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 0.72rem;
   pointer-events: none;
   transition: transform var(--duration-base) ease;
@@ -430,18 +427,17 @@
   background: none;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-xs);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.01em;
   padding: 3px var(--space-2);
-  text-transform: uppercase;
   transition: background var(--duration-base), color var(--duration-base), border-color var(--duration-base);
 }
 
-.skills-agent-chip:hover:not(:disabled) { color: var(--ink-spectral); }
+.skills-agent-chip:hover:not(:disabled) { color: var(--text-secondary); }
 
 .skills-agent-chip.is-active {
   background: color-mix(in srgb, var(--brass) 15%, transparent);
@@ -459,7 +455,7 @@
 }
 
 .skills-permission-warning {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 0.6875rem;
   line-height: 1.45;
   margin: 0;
@@ -502,15 +498,15 @@
 }
 
 .skills-overlay-title {
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-body);
   font-size: 1rem;
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   white-space: nowrap;
 }
 
 .skills-overlay-meta {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 0.75rem;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -520,7 +516,7 @@
 .skills-overlay-close {
   background: none;
   border: none;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   cursor: pointer;
   font-size: 1rem;
   line-height: 1;
@@ -528,7 +524,7 @@
   padding: var(--space-1);
 }
 
-.skills-overlay-close:hover { color: var(--ink-spectral); }
+.skills-overlay-close:hover { color: var(--text-secondary); }
 
 .skills-overlay-body {
   flex: 1 1 0;
@@ -560,7 +556,7 @@
   bottom: var(--space-3);
   color: var(--aurora);
   font-size: 0.8125rem;
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   left: var(--space-3);
   padding: var(--space-2) var(--space-3);
   position: absolute;

--- a/runtime/fleet-plugins/terminal/client/agent/analysis.css
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis.css
@@ -2,8 +2,8 @@
 .session-analyst-handle { position: absolute; z-index: 2; right: 0; top: 50%; transform: translateY(-50%); display: inline-flex; width: 25px; box-sizing: border-box; flex-direction: column; align-items: center; gap: var(--space-2); border: 1px solid var(--hairline-strong); border-right: none; border-radius: 12px 0 0 12px; background: color-mix(in oklch, var(--ink-deep) 94%, black); color: var(--text-tertiary); font-family: var(--font-mono); padding: 11px 4px 12px 6px; cursor: pointer; box-shadow: inset 1px 0 0 color-mix(in oklch, var(--aurora) 10%, transparent); transition: transform var(--duration-base) var(--ease-glide), background var(--duration-base) var(--ease-glide), color var(--duration-base) var(--ease-glide), box-shadow var(--duration-base) var(--ease-glide); }
 .session-analyst-handle:hover { transform: translate(-2px, -50%); background: color-mix(in oklch, var(--ink-mid) 72%, var(--ink-deep)); color: var(--text-secondary); box-shadow: inset 2px 0 0 color-mix(in oklch, var(--aurora) 32%, transparent); }
 .session-analyst-handle__chev { font-size: 13px; line-height: 1; }
-.session-analyst-handle__label { writing-mode: vertical-rl; font-size: 8.5px; font-weight: 600; letter-spacing: .18em; }
-.session-analyst-handle__count { display: grid; place-items: center; min-width: 16px; min-height: 16px; border-radius: 999px; background: color-mix(in oklch, var(--aurora) 16%, transparent); color: var(--aurora); font: 700 9px/1 var(--font-mono); }
+.session-analyst-handle__label { writing-mode: vertical-rl; font-size: 8.5px; font-weight: var(--weight-medium); letter-spacing: .18em; }
+.session-analyst-handle__count { display: grid; place-items: center; min-width: 16px; min-height: 16px; border-radius: 999px; background: color-mix(in oklch, var(--aurora) 16%, transparent); color: var(--aurora); font-weight: var(--weight-bold); font-size: 10px; line-height: 1; font-family: var(--font-mono); }
 .session-analyst-handle__count.is-pulsing { animation: analyst-artifact-count-pulse var(--duration-slow) var(--ease-glide); }
 .session-analyst-handle.is-waiting { opacity: .45; border-color: var(--hairline); color: var(--text-tertiary); cursor: default; box-shadow: none; }
 .session-analyst-handle.is-waiting:hover { transform: translateY(-50%); background: var(--ink-deep); }
@@ -16,10 +16,10 @@
 .session-analyst__panel-mark { display: grid; place-items: center; width: 38px; height: 38px; flex: none; border: 1px solid color-mix(in oklch, var(--aurora) 45%, var(--hairline)); border-radius: 12px; color: var(--aurora); background: var(--aurora-glow); font-size: 16px; }
 .session-analyst__panel-copy { display: grid; min-width: 0; gap: 3px; }
 .session-analyst__panel-copy strong { color: var(--text-primary); font-size: 13px; line-height: 1.25; letter-spacing: -.01em; }
-.session-analyst__panel-copy small { overflow: hidden; color: var(--text-tertiary); font-size: 9.5px; line-height: 1.3; text-overflow: ellipsis; white-space: nowrap; }
-.session-analyst__panel-state { display: inline-flex; align-items: center; gap: 7px; color: var(--text-tertiary); font: 600 9px/1 var(--font-mono); letter-spacing: .08em; text-transform: uppercase; white-space: nowrap; }
+.session-analyst__panel-copy small { overflow: hidden; color: var(--text-tertiary); font-size: 10px; line-height: 1.3; text-overflow: ellipsis; white-space: nowrap; }
+.session-analyst__panel-state { display: inline-flex; align-items: center; gap: 7px; color: var(--text-tertiary); font-weight: var(--weight-medium); font-size: 10px; line-height: 1; font-family: var(--font-mono); letter-spacing: .08em; text-transform: uppercase; white-space: nowrap; }
 .session-analyst__panel-state i { width: 7px; height: 7px; border-radius: 50%; background: var(--text-tertiary); }
-.session-analyst__reset { margin-left: auto; border: 1px solid var(--hairline); border-radius: 999px; background: transparent; color: var(--text-tertiary); padding: 5px 10px; font: 9px/1 var(--font-mono); cursor: pointer; transition: border-color var(--duration-base) var(--ease-glide), background var(--duration-base) var(--ease-glide), color var(--duration-base) var(--ease-glide); }
+.session-analyst__reset { margin-left: auto; border: 1px solid var(--hairline); border-radius: var(--radius-sm); background: transparent; color: var(--text-tertiary); padding: 5px 10px; font-weight: var(--weight-regular); font-size: 10px; line-height: 1; font-family: var(--font-mono); cursor: pointer; transition: border-color var(--duration-base) var(--ease-glide), background var(--duration-base) var(--ease-glide), color var(--duration-base) var(--ease-glide); }
 .session-analyst__reset:hover:not(:disabled) { border-color: var(--hairline-strong); background: var(--ink-mid); color: var(--text-secondary); }
 .session-analyst__reset:disabled { opacity: .35; cursor: default; }
 .session-analyst__chat-pane[data-phase="starting"] .session-analyst__panel-state i,
@@ -37,10 +37,10 @@
 .session-analyst__chat-pane.is-initial .session-analyst__hero-wrap { margin: 0; }
 .session-analyst__hero { text-align: center; padding: 0 var(--space-2); }
 .session-analyst__sigil { display: block; color: var(--aurora); font-size: 26px; line-height: 1; opacity: .85; margin-bottom: var(--space-2); }
-.session-analyst__hero h2 { margin: 0 0 var(--space-1); font-family: var(--font-display); font-weight: 560; font-size: 17px; letter-spacing: .01em; }
+.session-analyst__hero h2 { margin: 0 0 var(--space-1); font-family: var(--font-display); font-weight: var(--weight-medium); font-size: 17px; letter-spacing: .01em; }
 .session-analyst__hero p { margin: 0 auto; color: var(--text-tertiary); font-size: 12px; line-height: 1.5; max-width: 34ch; }
 .session-analyst__suggestions { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-2); align-content: start; }
-.session-analyst__suggestions button { display: flex; flex-direction: column; align-items: flex-start; gap: var(--space-2); text-align: left; font: inherit; font-size: 12.5px; color: var(--text-secondary); background: var(--ink-deep); border: 1px solid var(--hairline); border-radius: var(--radius-md); padding: var(--space-3); cursor: pointer; transition: border-color var(--duration-base) var(--ease-glide), background var(--duration-base) var(--ease-glide), transform var(--duration-base) var(--ease-glide); }
+.session-analyst__suggestions button { display: flex; flex-direction: column; align-items: flex-start; gap: var(--space-2); text-align: left; font-style: inherit; font-variant: inherit; font-weight: var(--weight-regular); font-stretch: inherit; font-size: inherit; line-height: inherit; font-family: inherit; font-size: 12.5px; color: var(--text-secondary); background: var(--ink-deep); border: 1px solid var(--hairline); border-radius: var(--radius-md); padding: var(--space-3); cursor: pointer; transition: border-color var(--duration-base) var(--ease-glide), background var(--duration-base) var(--ease-glide), transform var(--duration-base) var(--ease-glide); }
 .session-analyst__suggestions button:hover { border-color: color-mix(in oklch, var(--aurora) 45%, var(--hairline)); background: var(--ink-mid); color: var(--text-primary); transform: translateY(-1px); }
 .session-analyst__suggestion-icon { font-size: 13px; line-height: 1; }
 .session-analyst__suggestion-icon[data-tone="aurora"] { color: var(--aurora); }
@@ -50,15 +50,15 @@
 
 .session-analyst__queue { display: grid; gap: 6px; padding: 0 14px var(--space-2); }
 .session-analyst__queue-item { display: flex; align-items: center; gap: var(--space-2); min-width: 0; border: 1px dashed color-mix(in oklch, var(--aurora) 40%, var(--hairline)); border-radius: var(--radius-md); background: color-mix(in oklch, var(--aurora) 5%, var(--ink-deep)); padding: 7px 10px; color: var(--text-secondary); font-size: 11.5px; animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
-.session-analyst__queue-tag { flex: none; border: 1px solid color-mix(in oklch, var(--aurora) 45%, transparent); border-radius: 999px; color: var(--aurora); padding: 3px 7px; font: 700 8.5px/1 var(--font-mono); letter-spacing: .12em; }
+.session-analyst__queue-tag { flex: none; border: 1px solid color-mix(in oklch, var(--aurora) 45%, transparent); border-radius: 999px; color: var(--aurora); padding: 3px 7px; font-weight: var(--weight-bold); font-size: 10px; line-height: 1; font-family: var(--font-mono); letter-spacing: .12em; }
 .session-analyst__queue-text { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .session-analyst__queue-item button { flex: none; border: 0; background: transparent; color: var(--text-tertiary); padding: 2px; font-size: 13px; line-height: 1; cursor: pointer; transition: color var(--duration-base) var(--ease-glide); }
 .session-analyst__queue-item button:hover { color: var(--coral); }
 
 .session-analyst__followups { display: grid; gap: var(--space-2); padding: 0 14px var(--space-2); animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
-.session-analyst__followups-label { color: var(--text-tertiary); font: 600 9px/1 var(--font-mono); letter-spacing: .14em; }
+.session-analyst__followups-label { color: var(--text-tertiary); font-weight: var(--weight-medium); font-size: 10px; line-height: 1; font-family: var(--font-mono); letter-spacing: .14em; }
 .session-analyst__followups-row { display: flex; flex-wrap: wrap; gap: var(--space-2); }
-.session-analyst__followups-row button { display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--hairline); border-radius: 999px; background: var(--ink-mid); color: var(--text-secondary); padding: 7px 12px; font: 550 11.5px/1.2 var(--font-body); cursor: pointer; transition: border-color var(--duration-base) var(--ease-glide), color var(--duration-base) var(--ease-glide), transform var(--duration-base) var(--ease-glide); }
+.session-analyst__followups-row button { display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--hairline); border-radius: var(--radius-sm); background: var(--ink-mid); color: var(--text-secondary); padding: 7px 12px; font-weight: var(--weight-medium); font-size: 11.5px; line-height: 1.2; font-family: var(--font-body); cursor: pointer; transition: border-color var(--duration-base) var(--ease-glide), color var(--duration-base) var(--ease-glide), transform var(--duration-base) var(--ease-glide); }
 .session-analyst__followups-row button:hover { border-color: color-mix(in oklch, var(--aurora) 45%, var(--hairline)); color: var(--text-primary); transform: translateY(-1px); }
 
 .session-analyst__chat > ol { display: grid; gap: 15px; align-content: start; padding: 0; margin: 0; list-style: none; user-select: text; cursor: text; }
@@ -109,13 +109,13 @@
 .session-analyst__author-head { display: flex; align-items: center; gap: var(--space-2); min-width: 0; }
 .session-analyst__author-sigil { flex: none; color: var(--aurora); font-size: 13px; line-height: 1; }
 .session-analyst__author-title { min-width: 0; flex: 1; overflow-wrap: anywhere; color: var(--text-primary); font-size: 12px; line-height: 1.35; }
-.session-analyst__author-time { flex: none; color: var(--aurora); font: 600 10px/1.3 var(--font-mono); }
+.session-analyst__author-time { flex: none; color: var(--aurora); font-weight: var(--weight-medium); font-size: 10px; line-height: 1.3; font-family: var(--font-mono); }
 .session-analyst__author-sub { margin: var(--space-2) 0 0 21px; color: var(--text-tertiary); font-size: 10px; line-height: 1.4; }
 .session-analyst__author-track { height: 3px; margin: var(--space-3) 0 0 21px; overflow: hidden; border-radius: 2px; background: color-mix(in oklch, var(--aurora) 14%, var(--ink-mid)); }
 .session-analyst__author-track span { display: block; width: 34%; height: 100%; border-radius: inherit; background: var(--aurora); animation: analyst-author-slide 1.5s var(--ease-glide) infinite; }
 .session-analyst__author-card.is-done { border-color: color-mix(in oklch, var(--positive) 45%, var(--hairline)); background: color-mix(in oklch, var(--positive) 7%, var(--ink-deep)); }
 .session-analyst__author-card.is-done :is(.session-analyst__author-sigil, .session-analyst__author-time, .session-analyst__author-open) { color: var(--positive); }
-.session-analyst__author-open { flex: none; border: 1px solid color-mix(in oklch, var(--positive) 45%, var(--hairline)); border-radius: 999px; background: color-mix(in oklch, var(--positive) 4%, var(--ink-deep)); padding: 5px 9px; font: 600 9px/1 var(--font-mono); white-space: nowrap; cursor: pointer; }
+.session-analyst__author-open { flex: none; border: 1px solid color-mix(in oklch, var(--positive) 45%, var(--hairline)); border-radius: var(--radius-sm); background: color-mix(in oklch, var(--positive) 4%, var(--ink-deep)); padding: 5px 9px; font-weight: var(--weight-medium); font-size: 10px; line-height: 1; font-family: var(--font-mono); white-space: nowrap; cursor: pointer; }
 .session-analyst__author-open:hover { background: color-mix(in oklch, var(--positive) 10%, transparent); }
 
 .session-analyst__pulse { position: relative; min-height: 92px; flex: none; margin-top: 15px; overflow: hidden; border: 1px solid color-mix(in oklch, var(--aurora) 35%, var(--hairline)); border-radius: var(--radius-md); background: color-mix(in oklch, var(--aurora) 6%, var(--ink-deep)); padding: var(--space-3); animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
@@ -128,13 +128,13 @@
 .session-analyst__pulse-copy { display: grid; gap: 2px; min-width: 0; }
 .session-analyst__pulse-copy strong { overflow-wrap: anywhere; color: var(--text-primary); font-size: 12px; line-height: 1.35; animation: analyst-stage-enter var(--duration-base) var(--ease-glide) both; }
 .session-analyst__pulse-copy small { color: var(--text-tertiary); font-size: 10px; line-height: 1.4; }
-.session-analyst__pulse time { color: var(--aurora); font: 600 10px/1.3 var(--font-mono); }
-.session-analyst__truth-mark { display: block; margin: var(--space-3) 0 0 30px; color: var(--text-tertiary); font-size: 9px; }
+.session-analyst__pulse time { color: var(--aurora); font-weight: var(--weight-medium); font-size: 10px; line-height: 1.3; font-family: var(--font-mono); }
+.session-analyst__truth-mark { display: block; margin: var(--space-3) 0 0 30px; color: var(--text-tertiary); font-size: 10px; }
 .session-analyst__pulse.is-error { border-color: color-mix(in oklch, var(--coral) 55%, var(--hairline)); background: var(--coral-glow); }
 .session-analyst__pulse.is-error .session-analyst__pulse-orbit::before { background: var(--coral); box-shadow: 0 0 12px var(--coral-glow); }
 .session-analyst__pulse.is-error .session-analyst__pulse-orbit::after { border-color: var(--coral); animation: none; }
 .session-analyst__pulse.is-error time { color: var(--coral); }
-.session-analyst__receipt { display: flex; align-items: center; gap: var(--space-2); min-height: 34px; flex: none; margin-top: 15px; border-left: 2px solid var(--text-tertiary); background: var(--surface-glass-strong); padding: 0 var(--space-3); color: var(--text-tertiary); font: 10px/1.3 var(--font-mono); animation: analyst-receipt-settle var(--duration-base) var(--ease-glide) both; }
+.session-analyst__receipt { display: flex; align-items: center; gap: var(--space-2); min-height: 34px; flex: none; margin-top: 15px; border-left: 2px solid var(--text-tertiary); background: var(--surface-glass-strong); padding: 0 var(--space-3); color: var(--text-tertiary); font-weight: var(--weight-regular); font-size: 10px; line-height: 1.3; font-family: var(--font-mono); animation: analyst-receipt-settle var(--duration-base) var(--ease-glide) both; }
 
 .session-analyst__composer { position: relative; min-width: 0; background: transparent; }
 .session-analyst__composer.is-initial { display: flex; align-items: center; gap: var(--space-2); flex: none; margin-top: 12px; padding: 0; }
@@ -142,21 +142,21 @@
 .session-analyst__composer.is-docking { animation: analyst-composer-dock var(--duration-slow) var(--ease-glide) both; }
 .session-analyst__composer-surface { position: relative; display: flex; align-items: flex-end; gap: 7px; min-width: 0; min-height: 48px; flex: 1; overflow: hidden; border: 1px solid var(--hairline-strong); border-radius: 24px; background: color-mix(in oklch, var(--ink-mid) 86%, var(--ink-deep)); padding: 5px 6px 5px 9px; box-shadow: inset 0 1px 0 color-mix(in oklch, white 4%, transparent); transition: border-color var(--duration-base) var(--ease-glide), background var(--duration-base) var(--ease-glide); }
 .session-analyst__composer-surface:focus-within { border-color: color-mix(in oklch, var(--aurora) 48%, var(--hairline-strong)); }
-.session-analyst__composer textarea { display: block; box-sizing: border-box; width: auto; min-width: 3rem; min-height: 36px; height: 36px; max-height: calc(1.5em * 6 + 16px); flex: 1 1 auto; resize: none; overflow-x: hidden; overflow-y: hidden; white-space: pre-wrap; border: 0; outline: 0; background: transparent; color: var(--text-primary); padding: 8px 6px; font: 12.5px/1.5 var(--font-body); transition: opacity var(--duration-base) var(--ease-glide); }
-.session-analyst__composer textarea::placeholder { color: color-mix(in oklch, var(--text-tertiary) 62%, transparent); }
+.session-analyst__composer textarea { display: block; box-sizing: border-box; width: auto; min-width: 3rem; min-height: 36px; height: 36px; max-height: calc(1.5em * 6 + 16px); flex: 1 1 auto; resize: none; overflow-x: hidden; overflow-y: hidden; white-space: pre-wrap; border: 0; outline: 0; background: transparent; color: var(--text-primary); padding: 8px 6px; font-weight: var(--weight-regular); font-size: 12.5px; line-height: 1.5; font-family: var(--font-body); transition: opacity var(--duration-base) var(--ease-glide); }
+.session-analyst__composer textarea::placeholder { color: var(--text-tertiary); }
 .session-analyst__slash { position: absolute; z-index: 5; right: 14px; bottom: calc(100% - 4px); left: 14px; overflow: hidden; border: 1px solid var(--hairline-strong); border-radius: var(--radius-md); background: var(--surface-pillar); box-shadow: var(--shadow-floating); animation: analyst-status-rise var(--duration-base) var(--ease-glide) both; }
-.session-analyst__slash-heading { display: block; border-bottom: 1px solid var(--hairline); padding: 8px 12px 6px; color: var(--text-tertiary); font: 600 9px/1 var(--font-mono); letter-spacing: .14em; text-transform: uppercase; }
-.session-analyst__slash button { display: flex; align-items: baseline; gap: var(--space-3); width: 100%; border: 0; background: transparent; color: var(--text-secondary); padding: 9px 12px; text-align: left; cursor: pointer; font: 500 12px/1.3 var(--font-body); }
-.session-analyst__slash button > span { min-width: 76px; color: var(--aurora); font: 700 11px/1 var(--font-mono); }
+.session-analyst__slash-heading { display: block; border-bottom: 1px solid var(--hairline); padding: 8px 12px 6px; color: var(--text-tertiary); font-weight: var(--weight-medium); font-size: 10px; line-height: 1; font-family: var(--font-mono); letter-spacing: .14em; text-transform: uppercase; }
+.session-analyst__slash button { display: flex; align-items: baseline; gap: var(--space-3); width: 100%; border: 0; background: transparent; color: var(--text-secondary); padding: 9px 12px; text-align: left; cursor: pointer; font-weight: var(--weight-medium); font-size: 12px; line-height: 1.3; font-family: var(--font-body); }
+.session-analyst__slash button > span { min-width: 76px; color: var(--aurora); font-weight: var(--weight-bold); font-size: 11px; line-height: 1; font-family: var(--font-mono); }
 .session-analyst__slash button small { color: var(--text-tertiary); font-size: 10.5px; }
 .session-analyst__slash button:is(.is-selected, :hover) { background: color-mix(in oklch, var(--aurora) 10%, transparent); color: var(--text-primary); }
-.session-analyst__composer-hint { padding: 6px 4px 0; color: var(--text-tertiary); font: 500 9.5px/1.4 var(--font-mono); }
-.session-analyst__selector-strip { display: flex; align-items: center; min-width: 0; flex: 0 1 auto; overflow: hidden; border: 1px solid var(--hairline); border-radius: 999px; background: color-mix(in oklch, var(--ink-veil) 45%, var(--ink-deep)); transition: opacity var(--duration-base) var(--ease-glide), border-color var(--duration-base) var(--ease-glide); }
+.session-analyst__composer-hint { padding: 6px 4px 0; color: var(--text-tertiary); font-weight: var(--weight-medium); font-size: 10px; line-height: 1.4; font-family: var(--font-mono); }
+.session-analyst__selector-strip { display: flex; align-items: center; min-width: 0; flex: 0 1 auto; overflow: hidden; border: 1px solid var(--hairline); border-radius: var(--radius-sm); background: color-mix(in oklch, var(--ink-veil) 45%, var(--ink-deep)); transition: opacity var(--duration-base) var(--ease-glide), border-color var(--duration-base) var(--ease-glide); }
 /* 스트립이 composer-surface 밖으로 나온 뒤에도 키보드 포커스 큐가 유지되도록 동일한 focus-within 병더 문법을 적용한다. */
 .session-analyst__selector-strip:focus-within { border-color: color-mix(in oklch, var(--aurora) 48%, var(--hairline-strong)); }
 .session-analyst__select { position: relative; display: inline-flex; min-width: 0; }
 .session-analyst__select + .session-analyst__select::before { content: ""; position: absolute; inset: 9px auto 9px 0; width: 1px; background: var(--hairline); }
-.session-analyst__send { display: grid; place-items: center; width: 38px; height: 38px; flex: none; margin-left: auto; border: 0; border-radius: 50%; background: color-mix(in oklch, var(--text-primary) 72%, var(--ink-mid)); color: var(--ink-abyss); cursor: pointer; }
+.session-analyst__send { display: grid; place-items: center; width: 32px; height: 32px; flex: none; margin-left: auto; border: 0; border-radius: 50%; background: color-mix(in oklch, var(--text-primary) 72%, var(--ink-mid)); color: var(--ink-abyss); cursor: pointer; }
 .session-analyst__send:hover:not(:disabled) { filter: brightness(1.08); }
 .session-analyst__send:disabled { opacity: .42; cursor: default; }
 .session-analyst__stop span { width: 8px; height: 8px; border-radius: 2px; background: currentColor; }
@@ -170,7 +170,7 @@
 .session-analyst__panel-head--artifacts { position: relative; z-index: 2; padding-right: 12px; }
 .session-analyst__panel-mark--artifact { border-color: color-mix(in oklch, var(--brass) 45%, var(--hairline)); background: var(--brass-glow); color: var(--brass-bright); }
 .session-analyst__artifact-list-shell { position: relative; margin-left: auto; }
-.session-analyst__artifact-count { display: inline-flex; align-items: baseline; gap: 4px; min-height: 32px; border: 1px solid transparent; border-radius: 999px; background: transparent; color: var(--text-secondary); padding: 5px 9px 5px 11px; font-family: var(--font-mono); white-space: nowrap; cursor: pointer; transition: border-color var(--duration-base) var(--ease-glide), background var(--duration-base) var(--ease-glide), color var(--duration-base) var(--ease-glide); }
+.session-analyst__artifact-count { display: inline-flex; align-items: baseline; gap: 4px; min-height: 32px; border: 1px solid transparent; border-radius: var(--radius-sm); background: transparent; color: var(--text-secondary); padding: 5px 9px 5px 11px; font-family: var(--font-mono); white-space: nowrap; cursor: pointer; transition: border-color var(--duration-base) var(--ease-glide), background var(--duration-base) var(--ease-glide), color var(--duration-base) var(--ease-glide); }
 .session-analyst__artifact-count strong { color: var(--text-primary); font-size: 14px; line-height: 1; }
 .session-analyst__artifact-count span { font-size: 10px; }
 .session-analyst__artifact-count i { width: 6px; height: 6px; margin: 0 2px 2px 4px; border-right: 1.5px solid currentColor; border-bottom: 1.5px solid currentColor; transform: rotate(45deg); transition: transform var(--duration-base) var(--ease-glide); }
@@ -178,7 +178,7 @@
 .session-analyst__artifact-count[aria-expanded="true"] i { transform: translateY(3px) rotate(-135deg); }
 .session-analyst__artifact-count:hover:not(:disabled) { border-color: var(--hairline); background: var(--surface-glass); color: var(--text-primary); }
 .session-analyst__artifact-count:disabled { opacity: .42; cursor: default; }
-.session-analyst__clear { border: 1px solid var(--hairline); border-radius: 999px; background: transparent; color: var(--text-secondary); padding: 4px 10px; cursor: pointer; font: 10px/1 var(--font-body); }
+.session-analyst__clear { border: 1px solid var(--hairline); border-radius: var(--radius-sm); background: transparent; color: var(--text-secondary); padding: 4px 10px; cursor: pointer; font-weight: var(--weight-regular); font-size: 10px; line-height: 1; font-family: var(--font-body); }
 .session-analyst__clear:hover:not(:disabled) { background: var(--ink-mid); }
 .session-analyst__clear:disabled { opacity: .4; cursor: default; }
 .session-analyst__artifacts-empty { display: grid; place-items: center; align-content: center; color: var(--text-tertiary); padding: var(--space-5); text-align: center; font-size: 11px; line-height: 1.55; }
@@ -190,10 +190,10 @@
 .session-analyst__artifact-menu button.is-active { border-color: color-mix(in oklch, var(--brass) 38%, var(--hairline)); background: color-mix(in oklch, var(--brass) 7%, var(--surface-glass-strong)); }
 .session-analyst__artifact-list-mark { display: grid; place-items: center; width: 28px; height: 28px; border-radius: 8px; background: var(--ink-veil); color: var(--brass-bright); font-size: 13px; }
 .session-analyst__artifact-menu button strong { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 10.5px; }
-.session-analyst__artifact-menu time, .session-analyst__artifacts article time { color: var(--text-tertiary); font: 8.5px/1.3 var(--font-mono); white-space: nowrap; }
+.session-analyst__artifact-menu time, .session-analyst__artifacts article time { color: var(--text-tertiary); font-weight: var(--weight-regular); font-size: 10px; line-height: 1.3; font-family: var(--font-mono); white-space: nowrap; }
 .session-analyst__artifacts article { min-height: 0; display: flex; flex-direction: column; overflow: hidden; border: 1px solid var(--hairline); border-radius: 13px; background: var(--ink-deep); }
 .session-analyst__artifacts article header { display: flex; align-items: center; gap: var(--space-2); min-height: 36px; border-bottom: 1px solid var(--hairline); padding: 0 11px; background: var(--canvas-sea-core); }
-.session-analyst__artifact-title { overflow: hidden; color: var(--text-secondary); font-size: 9.5px; text-overflow: ellipsis; white-space: nowrap; }
+.session-analyst__artifact-title { overflow: hidden; color: var(--text-secondary); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
 .session-analyst__artifacts article time { margin-left: auto; }
 .session-analyst__artifacts article p[role="alert"] { margin: 0; padding: var(--space-3); color: var(--coral); font-size: 12px; }
 .session-analyst__artifacts iframe { display: block; width: 100%; flex: 1; min-height: 0; border: 0; background: var(--ink-veil); }

--- a/runtime/fleet-plugins/terminal/client/carriers/styles.css
+++ b/runtime/fleet-plugins/terminal/client/carriers/styles.css
@@ -5,12 +5,11 @@
   padding: 6px var(--space-3);
   border: 1px solid transparent;
   border-radius: var(--radius-xs);
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.01em;
   white-space: nowrap;
   transition:
     color var(--duration-fast) var(--ease-spring),
@@ -19,7 +18,7 @@
 }
 
 .terminal-carriers-action-button:hover:not(:disabled) {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   background: color-mix(in oklch, var(--brass) 8%, transparent);
 }
 
@@ -29,7 +28,7 @@
 }
 
 .terminal-carriers-action-button:disabled {
-  color: var(--ink-rim);
+  color: var(--text-tertiary);
   cursor: not-allowed;
 }
 
@@ -57,12 +56,11 @@
   border: 1px solid transparent;
   border-radius: var(--radius-xs);
   background: transparent;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.01em;
   transition:
     color var(--duration-fast) var(--ease-spring),
     border-color var(--duration-fast) var(--ease-spring),
@@ -72,7 +70,7 @@
 }
 
 .terminal-carriers-chip:hover {
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   background: color-mix(in oklch, var(--ink-mid) 72%, transparent);
   transform: translateX(2px);
 }
@@ -149,10 +147,10 @@
   align-items: center;
   gap: 8px;
   margin-bottom: 8px;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.1em;
   text-transform: uppercase;
 }
@@ -167,10 +165,10 @@
 
 .terminal-carriers-captain-name {
   margin: 0 0 8px;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-size: 32px;
-  font-weight: 300;
+  font-weight: var(--weight-regular);
   letter-spacing: -0.03em;
   line-height: 1;
 }
@@ -186,10 +184,10 @@
 
 .terminal-carriers-captain-role {
   margin-bottom: 0;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-body);
   font-size: 16px;
-  font-weight: 500;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.02em;
 }
 
@@ -216,11 +214,11 @@
   border-left: 2px solid var(--cap-color);
   border-radius: 0 var(--radius-md) var(--radius-md) 0;
   background: color-mix(in oklch, var(--ink-deep) 70%, transparent);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-family: var(--font-body);
   font-style: italic;
   font-size: 18px;
-  font-weight: 300;
+  font-weight: var(--weight-regular);
   letter-spacing: -0.005em;
   line-height: 1.45;
 }
@@ -240,9 +238,9 @@
 
 .terminal-carriers-resp-title {
   margin: 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 11px;
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.18em;
   text-transform: uppercase;
 }
@@ -250,9 +248,9 @@
 .terminal-carriers-label {
   display: block;
   margin: 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
@@ -260,7 +258,7 @@
 .terminal-carriers-help,
 .terminal-carriers-empty {
   margin: 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-size: 11px;
   line-height: 1.55;
 }
@@ -314,18 +312,18 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--ink-mid) 48%, transparent);
-  color: var(--ink-pearl);
-  font: 600 13px/1.2 var(--font-body);
+  color: var(--text-primary);
+  font-weight: var(--weight-medium); font-size: 13px; line-height: 1.2; font-family: var(--font-body);
   box-shadow: inset 0 1px 0 color-mix(in oklch, var(--ink-pearl) 5%, transparent);
   padding: 0 13px;
 }
 
 .terminal-carriers-name-input {
   min-height: 54px;
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-body);
   font-size: 30px;
-  font-weight: 300;
+  font-weight: var(--weight-regular);
   letter-spacing: -0.03em;
 }
 
@@ -346,12 +344,11 @@
   border: 0;
   border-radius: var(--radius-xs);
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.01em;
   white-space: nowrap;
   transition:
     background var(--duration-fast) var(--ease-spring),
@@ -363,7 +360,7 @@
 .terminal-carriers-icon-button:hover:not(:disabled),
 .terminal-carriers-tf-toggle:hover:not(:disabled) {
   background: color-mix(in oklch, var(--brass) 8%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .terminal-carriers-tf-toggle[aria-expanded="true"] {
@@ -375,7 +372,7 @@
 .terminal-carriers-icon-button:active:not(:disabled),
 .terminal-carriers-tf-toggle:active:not(:disabled) {
   background: color-mix(in oklch, var(--brass) 16%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   transform: translateY(1px);
 }
 
@@ -388,9 +385,9 @@
 }
 
 .terminal-carriers-icon-button {
-  width: 34px;
-  min-width: 34px;
-  min-height: 34px;
+  width: 32px;
+  min-width: 32px;
+  min-height: 32px;
   padding: 0;
 }
 
@@ -454,7 +451,7 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--ink-mid) 42%, transparent);
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   transition:
     border-color var(--duration-fast) var(--ease-spring),
     color var(--duration-fast) var(--ease-spring),
@@ -463,7 +460,7 @@
 
 .terminal-carriers-tf-item:hover {
   border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   transform: translateX(3px);
 }
 
@@ -482,16 +479,16 @@
 
 .terminal-carriers-tf-title strong {
   overflow: hidden;
-  color: var(--ink-spectral);
+  color: var(--text-secondary);
   font-size: 14px;
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .terminal-carriers-tf-status {
   margin-left: auto;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
   white-space: nowrap;
@@ -525,14 +522,14 @@
 .terminal-carriers-tf-empty {
   margin: 0;
   padding: 10px 2px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
 }
 
 .terminal-carriers-save-status {
   min-width: 76px;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 11px;
   text-align: right;


### PR DESCRIPTION
## Summary

외부 UI 원칙 16개를 기준으로 fleet-console 전 시각 표면을 실측 감사하고, 위반이 모이는 세 뿌리를 제거했습니다.

- **판독 하한선** — 텍스트 색 약 590곳이 의미 토큰(`--text-*`)을 건너뛰고 원료 잉크 토큰을 직접 참조하고 있어, 대비 하한을 토큰 한 곳에서 통제할 수 없었습니다. 텍스트 역할을 의미 티어로 회수하고 Instrument의 `--text-tertiary`를 하한 위로 올렸습니다. 감쇠 표현도 알파 희석에서 티어 강등으로 바꿨습니다.
- **컨트롤 문법** — `font-weight` 25종 이상을 3티어 토큰으로, 아이콘 버튼 4규격을 24/32px 2티어로 수렴시키고, 컨트롤에 잘못 쓰인 pill 반경을 되돌렸으며 공용 `.fc-btn` 변형 체계를 신설했습니다. 대문자는 구조 축 라벨에만 남기고 컨트롤·CTA 라벨은 문장형으로 복원했습니다.
- **색 단독 지시자** — Operation 상태 비콘 4종이 색만으로 구분되던 것을 모양 채널로 이중 부호화했습니다.
- **미정의 토큰** — 참조되지만 어디에도 정의되지 않아 조용히 상속으로 흐르던 커스텀 프로퍼티 9종(`--font-ui`, `--ink-body`, `--surface-hover`, `--surface-active`, `--text-muted`, `--text`, `--font-size-body-sm`, `--font-size-label-sm`, 죽은 `--codex-side-width`)을 정리했습니다.
- **재발 방지** — 디자인 계약에 텍스트 티어 강제, weight 티어, 미정의 커스텀 프로퍼티 차단을 추가했습니다.

## Measurement

격리 인스턴스(`FLEET_CONSOLE_DIR`) + 헤드리스 크롬에서, 조상 배경을 전부 합성하고 누적 opacity를 반영해 WCAG 2.1 상대휘도로 계산한 실효 대비입니다. 비활성 컨트롤(SC 1.4.3 예외)은 제외했습니다.

| 표면 | 이전 (Instrument) | 이후 (3테마 전부) |
|---|---|---|
| Settings | 72건 / 16셀렉터 | 0건 |
| Repository 패널 | 29건 / 13셀렉터 | 0건 |
| What's new | 16건 / 13셀렉터 | 0건 |
| Plans · Files · Skills · Codex · Alerts | — | 0건 |

한 화면 동시 렌더 `font-weight`는 9종 → 3종, Settings 대문자 요소는 23 → 12, What's new 대문자 요소는 7 → 0입니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 잔여 실패 5건은 `canary`에서도 동일하게 실패하는 선존 실패(`operations-boot-minimization` 4건, `server.test.ts` 1건)로 대조 확인
- [x] `instrument-design-contract.test.ts` 24/24
- [x] 플러그인 4종 — file-explorer 60, repository 260, skills 87, terminal 375 전부 통과
- [x] `pnpm check:core-boundary`, `pnpm check:protocol-sync`
- [x] Instrument / Maritime / Carbon 3테마 실측 — 전 측정 표면 위반 0건
- [x] 헤드리스 스크린샷으로 레이아웃 회귀 없음 확인

## Changelog

- [x] `.changelog.d/pr-370.md` 추가 (grouped product/section 문법, 영문+`ko:` 이중 요약)
- [x] `node scripts/compile-changelog-fragments.mjs --check` 통과 (10 entries validated)
