### PR TITLE
feat(console): launch agent operations with an optional first prompt

### DIFF
--- a/.changelog.d/pr-372.md
+++ b/.changelog.d/pr-372.md
@@ -1,0 +1,9 @@
+### fleet-console
+#### Added
+- [fleet-console] Offer an optional first-prompt step when launching Claude, Kimi, or Codex operations from the Launch menu.
+  ko: Launch 메뉴에서 Claude, Kimi, Codex Operation을 기동할 때 선택적 첫 프롬프트 입력 단계를 제공합니다.
+
+### fleet-plugin
+#### Added
+- [fleet-console] Deliver the launch prompt as the session's first input once the agent CLI is ready, without exposing it to browser state.
+  ko: 에이전트 CLI가 준비되면 기동 프롬프트를 세션의 첫 입력으로 전달하며, 브라우저 상태에 노출하지 않습니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
 import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console/sdk/operations";
 
 interface CanvasContextMenuProps {
@@ -18,6 +18,7 @@ interface CanvasContextMenuProps {
 const MENU_WIDTH = 288;
 const MENU_MAX_HEIGHT = 520;
 const MENU_MARGIN = 12;
+const FOCUSABLE_SELECTOR = "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])";
 
 export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor", catalog, canLaunch, renderKindIcon, onLaunchKind, onClose }: CanvasContextMenuProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -75,7 +76,12 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
           </span>
         </div>
         {promptTarget ? (
-          <div className="canvas-context-menu-prompt-step">
+          <div
+            className="canvas-context-menu-prompt-step"
+            onKeyDown={(event) => {
+              if (event.key === "Tab") trapFocus(event, event.currentTarget);
+            }}
+          >
             <label className="canvas-context-menu-prompt-label" htmlFor="canvas-context-menu-initial-prompt">First prompt (optional)</label>
             <textarea
               id="canvas-context-menu-initial-prompt"
@@ -133,6 +139,21 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
       </div>
     </div>
   );
+}
+
+function trapFocus(event: ReactKeyboardEvent<HTMLElement>, container: HTMLElement | null): void {
+  if (!container) return;
+  const focusable = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (!first || !last) return;
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault();
+    first.focus();
+  }
 }
 
 // 좌하단 런처 FAB와 메뉴 헤더가 공유하는 '커맨드 레티클' 마크 — 외곽 스코프 링 + 사방 조준 틱 +

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console/sdk/operations";
 
 interface CanvasContextMenuProps {
@@ -11,7 +11,7 @@ interface CanvasContextMenuProps {
   readonly canLaunch: boolean;
   // 아이콘은 플러그인 소유다 — console-core는 어떤 플러그인인지 모른 채 렌더만 위임한다.
   readonly renderKindIcon: (pluginId: string, kind: OperationLaunchKind) => ReactNode;
-  readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind) => void;
+  readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind, initialPrompt?: string) => void;
   readonly onClose: () => void;
 }
 
@@ -22,13 +22,23 @@ const MENU_MARGIN = 12;
 export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor", catalog, canLaunch, renderKindIcon, onLaunchKind, onClose }: CanvasContextMenuProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [promptTarget, setPromptTarget] = useState<{ readonly pluginId: string; readonly kind: OperationLaunchKind } | null>(null);
+  const [initialPrompt, setInitialPrompt] = useState("");
 
   useEffect(() => {
     const handlePointer = (event: MouseEvent) => {
       if (!containerRef.current?.contains(event.target as Node)) onClose();
     };
     const handleKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
+      if (event.key !== "Escape") return;
+      if (promptTarget) {
+        event.preventDefault();
+        setPromptTarget(null);
+        setInitialPrompt("");
+        return;
+      }
+      onClose();
     };
     document.addEventListener("mousedown", handlePointer);
     document.addEventListener("keydown", handleKey);
@@ -36,12 +46,19 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
       document.removeEventListener("mousedown", handlePointer);
       document.removeEventListener("keydown", handleKey);
     };
-  }, [onClose]);
+  }, [onClose, promptTarget]);
 
   useEffect(() => {
     // 첫 항목을 강제 포커스하지 않고 컨테이너만 포커스해 '이미 선택된 듯한' UX를 피한다.
-    menuRef.current?.focus();
-  }, []);
+    if (promptTarget) textareaRef.current?.focus();
+    else menuRef.current?.focus();
+  }, [promptTarget]);
+
+  const launchPromptTarget = (launchEmpty: boolean) => {
+    if (!promptTarget) return;
+    const prompt = launchEmpty ? undefined : initialPrompt.trim() || undefined;
+    onLaunchKind(promptTarget.pluginId, promptTarget.kind, prompt);
+  };
 
   return (
     <div
@@ -57,6 +74,30 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
             <strong>Canvas controls</strong>
           </span>
         </div>
+        {promptTarget ? (
+          <div className="canvas-context-menu-prompt-step">
+            <label className="canvas-context-menu-prompt-label" htmlFor="canvas-context-menu-initial-prompt">First prompt (optional)</label>
+            <textarea
+              id="canvas-context-menu-initial-prompt"
+              ref={textareaRef}
+              className="canvas-context-menu-prompt-input"
+              placeholder="Type the first instruction for this session"
+              value={initialPrompt}
+              maxLength={4000}
+              onChange={(event) => setInitialPrompt(event.currentTarget.value)}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter" || event.shiftKey || event.nativeEvent.isComposing) return;
+                event.preventDefault();
+                launchPromptTarget(false);
+              }}
+            />
+            <p className="canvas-context-menu-prompt-hint">Enter to launch · Shift+Enter for a new line</p>
+            <div className="canvas-context-menu-prompt-actions">
+              <button type="button" className="canvas-context-menu-prompt-button is-primary" onClick={() => launchPromptTarget(false)}>Launch</button>
+              <button type="button" className="canvas-context-menu-prompt-button" onClick={() => launchPromptTarget(true)}>Launch empty</button>
+            </div>
+          </div>
+        ) : <>
         <p className="canvas-context-menu-section">Launch</p>
         {catalog.length > 0 ? catalog.map((plugin, index) => (
           <div key={plugin.id}>
@@ -72,7 +113,13 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                   className="theater-menu-item canvas-context-menu-item operation-launch-menu-item"
                   disabled={disabled}
                   title={kind.disabledReason}
-                  onClick={() => onLaunchKind(plugin.id, kind)}
+                  onClick={() => {
+                    if (kind.supportsInitialPrompt) {
+                      setPromptTarget({ pluginId: plugin.id, kind });
+                      return;
+                    }
+                    onLaunchKind(plugin.id, kind);
+                  }}
                 >
                   <span className="theater-menu-check" aria-hidden="true">{renderKindIcon(plugin.id, kind) ?? <FallbackGlyph />}</span>
                   <span className="theater-menu-label">{kind.title}</span>
@@ -82,6 +129,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
             })}
           </div>
         )) : <p className="theater-menu-empty">No operations available.</p>}
+        </>}
       </div>
     </div>
   );

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -27,7 +27,7 @@ interface OperationsCanvasProps {
   readonly catalog: readonly OperationCatalogPlugin[];
   readonly canLaunch: boolean;
   readonly renderKindIcon: (pluginId: string, kind: OperationLaunchKind) => ReactNode;
-  readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind, canvasPoint: CanvasPoint) => void;
+  readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind, canvasPoint: CanvasPoint, initialPrompt?: string) => void;
   readonly onLaunchAtGeometry: (pluginId: string, kind: OperationLaunchKind, geometry: OperationGeometry) => void;
   readonly onClose: (operationId: string) => void;
   readonly onFocus: (operationId: string) => void;
@@ -126,11 +126,11 @@ export function OperationsCanvas({
     onClick: clearTerminalFocus,
   });
 
-  const handleContextMenuLaunchKind = (pluginId: string, kind: OperationLaunchKind) => {
+  const handleContextMenuLaunchKind = (pluginId: string, kind: OperationLaunchKind, initialPrompt?: string) => {
     const point = contextMenu?.canvasPoint;
     setContextMenu(null);
     if (!point) return;
-    onLaunchKind(pluginId, kind, point);
+    onLaunchKind(pluginId, kind, point, initialPrompt);
   };
 
   const handleContextMenu = (event: ReactMouseEvent<HTMLElement>) => {

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -161,17 +161,17 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
     return plugin?.renderLaunchIcon?.(kind) ?? null;
   }, [registry.plugins]);
 
-  const handleCanvasLaunchKind = useCallback((pluginId: string, kind: OperationLaunchKind, canvasPoint: CanvasPoint) => {
+  const handleCanvasLaunchKind = useCallback((pluginId: string, kind: OperationLaunchKind, canvasPoint: CanvasPoint, initialPrompt?: string) => {
     if (!stateRef.current.activeTheaterId) return;
     const geometry = { ...canvasPointToGeometry(canvasPoint), zIndex: claimTopZIndex() };
-    void launchViaPlugin(pluginId, kind, geometry, stateRef.current.activeTheaterId, registry.plugins);
+    void launchViaPlugin(pluginId, kind, geometry, stateRef.current.activeTheaterId, registry.plugins, initialPrompt);
   }, [registry.plugins]);
 
-  const handleSideBarLaunchKind = useCallback((pluginId: string, kind: OperationLaunchKind) => {
+  const handleSideBarLaunchKind = useCallback((pluginId: string, kind: OperationLaunchKind, initialPrompt?: string) => {
     if (!stateRef.current.activeTheaterId) return;
     const canvasPoint = canvasCenterPoint(bodyRef.current);
     const geometry = { ...canvasPointToGeometry(canvasPoint), zIndex: claimTopZIndex() };
-    void launchViaPlugin(pluginId, kind, geometry, stateRef.current.activeTheaterId, registry.plugins);
+    void launchViaPlugin(pluginId, kind, geometry, stateRef.current.activeTheaterId, registry.plugins, initialPrompt);
   }, [registry.plugins]);
 
   const handleLaunchAtGeometry = useCallback((pluginId: string, kind: OperationLaunchKind, geometry: OperationGeometry) => {
@@ -479,13 +479,14 @@ async function launchViaPlugin(
   geometry: OperationGeometry,
   theaterId: string,
   plugins: readonly FleetClientPlugin[],
+  initialPrompt?: string,
 ): Promise<void> {
   const plugin = plugins.find((p) => p.id === pluginId);
   const resync = () => { void fetchOperations(null).then(hydrateOperations).catch(() => {}); };
   const capabilities = createHostCapabilities(resync);
   let newOperationId: string | null = null;
   if (plugin?.launch) {
-    const result = await plugin.launch({ theaterId, kind, geometry, operations: capabilities.operations });
+    const result = await plugin.launch({ theaterId, kind, geometry, ...(initialPrompt === undefined ? {} : { initialPrompt }), operations: capabilities.operations });
     newOperationId = result.id;
   } else {
     const operation = await capabilities.operations.create({

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -44,7 +44,7 @@ interface OperationsSideBarProps {
   readonly addingTheater: boolean;
   readonly theaterError: string | null;
   readonly renderKindIcon: (pluginId: string, kind: OperationLaunchKind) => ReactNode;
-  readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind) => void;
+  readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind, initialPrompt?: string) => void;
   readonly onClose: (operationId: string) => void;
   readonly onMinimize: (operationId: string) => void;
   readonly onFocus: (operationId: string) => void;
@@ -1030,7 +1030,7 @@ export function OperationsSideBar({
           catalog={catalog}
           canLaunch={canLaunch}
           renderKindIcon={renderKindIcon}
-          onLaunchKind={(pluginId, kind) => { setNewMenu(null); onLaunchKind(pluginId, kind); }}
+          onLaunchKind={(pluginId, kind, initialPrompt) => { setNewMenu(null); onLaunchKind(pluginId, kind, initialPrompt); }}
           onClose={() => setNewMenu(null)}
         />,
         document.body,

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -1704,6 +1704,76 @@
   text-transform: uppercase;
 }
 
+.canvas-context-menu-prompt-step {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-2);
+}
+
+.canvas-context-menu-prompt-label {
+  color: var(--brass);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.canvas-context-menu-prompt-input {
+  width: 100%;
+  min-height: 116px;
+  resize: vertical;
+  padding: var(--space-2);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  outline: none;
+  background: var(--surface-glass);
+  color: var(--ink-pearl);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.canvas-context-menu-prompt-input::placeholder {
+  color: var(--ink-fog);
+}
+
+.canvas-context-menu-prompt-input:focus-visible {
+  border-color: color-mix(in oklch, var(--brass) 58%, var(--surface-rim));
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--brass) 16%, transparent);
+}
+
+.canvas-context-menu-prompt-hint {
+  margin: 0;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  line-height: 1.4;
+}
+
+.canvas-context-menu-prompt-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+.canvas-context-menu-prompt-button {
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--ink-fog);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.canvas-context-menu-prompt-button:hover,
+.canvas-context-menu-prompt-button:focus-visible,
+.canvas-context-menu-prompt-button.is-primary {
+  border-color: color-mix(in oklch, var(--brass) 48%, var(--surface-rim));
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  color: var(--ink-pearl);
+}
+
 .canvas-context-menu-help {
   display: grid;
   gap: var(--space-2);

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -1387,6 +1387,7 @@ function sanitizeLaunchKind(value: unknown): OperationLaunchKind | null {
     id: value.id,
     type: value.type,
     title: value.title,
+    ...(typeof value.supportsInitialPrompt === "boolean" ? { supportsInitialPrompt: value.supportsInitialPrompt } : {}),
     ...(typeof value.disabled === "boolean" ? { disabled: value.disabled } : {}),
     ...(typeof value.disabledReason === "string" ? { disabledReason: value.disabledReason } : {}),
   };

--- a/runtime/fleet-console/sdk/launch/types.ts
+++ b/runtime/fleet-console/sdk/launch/types.ts
@@ -5,5 +5,6 @@ export interface LaunchContext {
   readonly theaterId: string;
   readonly kind: OperationLaunchKind;
   readonly geometry: OperationGeometry;
+  readonly initialPrompt?: string;
   readonly operations: ClientOperationsCapability;
 }

--- a/runtime/fleet-console/sdk/operations/browser.tsx
+++ b/runtime/fleet-console/sdk/operations/browser.tsx
@@ -49,7 +49,7 @@ export function assertOperationNode(value: unknown): OperationNode {
 }
 
 export function hasForbiddenBrowserPayloadKey(value: unknown): boolean {
-  return containsForbiddenKey(value, new Set(["canonicalCwd", "cwd", "persona", "prompt", "providerSession", "ticket", "token", "toolAllowlist", "tools", "transcriptPath"]));
+  return containsForbiddenKey(value, new Set(["canonicalCwd", "cwd", "initialPrompt", "persona", "prompt", "providerSession", "ticket", "token", "toolAllowlist", "tools", "transcriptPath"]));
 }
 
 export function OperationBody({ children, className }: OperationBodyProps): React.ReactElement {
@@ -69,6 +69,7 @@ function readLaunchKind(value: unknown): OperationLaunchKind | null {
     id: value.id,
     type: value.type,
     title: value.title,
+    ...(typeof value.supportsInitialPrompt === "boolean" ? { supportsInitialPrompt: value.supportsInitialPrompt } : {}),
     ...(typeof value.disabled === "boolean" ? { disabled: value.disabled } : {}),
     ...(typeof value.disabledReason === "string" ? { disabledReason: value.disabledReason } : {}),
   };

--- a/runtime/fleet-console/sdk/operations/types.ts
+++ b/runtime/fleet-console/sdk/operations/types.ts
@@ -44,6 +44,7 @@ export interface OperationLaunchKind {
   readonly id: string;
   readonly type: string;
   readonly title: string;
+  readonly supportsInitialPrompt?: boolean;
   readonly disabled?: boolean;
   readonly disabledReason?: string;
 }

--- a/runtime/fleet-console/tests/canvas-context-menu-initial-prompt.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-initial-prompt.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CanvasContextMenu } from "../core/client/src/canvas/canvas-context-menu.js";
+import type { OperationCatalogPlugin } from "../sdk/operations/index.js";
+
+let container: HTMLDivElement;
+let root: Root;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("CanvasContextMenu initial prompt launch", () => {
+  it("shows an inline first-prompt step for a supported launch kind", () => {
+    const onLaunchKind = vi.fn();
+    const onClose = vi.fn();
+    renderMenu(agentCatalog(), onLaunchKind, onClose);
+
+    act(() => buttonNamed("Claude").click());
+
+    expect(onLaunchKind).not.toHaveBeenCalled();
+    expect(document.querySelector("label")?.textContent).toBe("First prompt (optional)");
+    const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+    expect(textarea?.placeholder).toBe("Type the first instruction for this session");
+    expect(document.activeElement).toBe(textarea);
+    expect(buttonNamed("Launch")).toBeDefined();
+    expect(buttonNamed("Launch empty")).toBeDefined();
+    expect(container.textContent).toContain("Enter to launch · Shift+Enter for a new line");
+
+    act(() => document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })));
+    expect(document.querySelector("textarea")).toBeNull();
+    expect(buttonNamed("Claude")).toBeDefined();
+    expect(onClose).not.toHaveBeenCalled();
+
+    act(() => document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("launches an unsupported kind immediately without showing the prompt step", () => {
+    const onLaunchKind = vi.fn();
+    const shell = { id: "shell", type: "shell", title: "Shell" } as const;
+    renderMenu([{ id: "terminal", title: "Terminal", kinds: [shell] }], onLaunchKind);
+
+    act(() => buttonNamed("Shell").click());
+
+    expect(onLaunchKind).toHaveBeenCalledWith("terminal", shell);
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("trims and launches the prompt on Enter while preserving Shift+Enter for a new line", () => {
+    const onLaunchKind = vi.fn();
+    const catalog = agentCatalog();
+    const kind = catalog[0]!.kinds[0]!;
+    renderMenu(catalog, onLaunchKind);
+    act(() => buttonNamed("Claude").click());
+    const textarea = document.querySelector<HTMLTextAreaElement>("textarea")!;
+
+    act(() => {
+      setTextareaValue(textarea, "  Run the focused tests  ");
+      textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", shiftKey: true, bubbles: true, cancelable: true }));
+    });
+    expect(onLaunchKind).not.toHaveBeenCalled();
+
+    act(() => textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })));
+    expect(onLaunchKind).toHaveBeenCalledWith("terminal", kind, "Run the focused tests");
+  });
+});
+
+function renderMenu(catalog: readonly OperationCatalogPlugin[], onLaunchKind: ReturnType<typeof vi.fn>, onClose = vi.fn()): void {
+  act(() => root.render(
+    <CanvasContextMenu
+      anchor={{ x: 20, y: 20 }}
+      catalog={catalog}
+      canLaunch
+      renderKindIcon={() => null}
+      onLaunchKind={onLaunchKind}
+      onClose={onClose}
+    />,
+  ));
+}
+
+function setTextareaValue(textarea: HTMLTextAreaElement, value: string): void {
+  const valueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+  valueSetter?.call(textarea, value);
+  textarea.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function buttonNamed(name: string): HTMLButtonElement {
+  const button = [...document.querySelectorAll<HTMLButtonElement>("button")].find((candidate) => candidate.textContent === name);
+  if (!button) throw new Error(`Button not found: ${name}`);
+  return button;
+}
+
+function agentCatalog(): readonly OperationCatalogPlugin[] {
+  return [{
+    id: "terminal",
+    title: "Terminal",
+    kinds: [{ id: "claude", type: "agent", title: "Claude", supportsInitialPrompt: true }],
+  }];
+}

--- a/runtime/fleet-console/tests/canvas-context-menu-initial-prompt.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-initial-prompt.test.tsx
@@ -77,6 +77,26 @@ describe("CanvasContextMenu initial prompt launch", () => {
     act(() => textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })));
     expect(onLaunchKind).toHaveBeenCalledWith("terminal", kind, "Run the focused tests");
   });
+
+  it("traps Tab focus within the prompt textarea and launch actions", () => {
+    renderMenu(agentCatalog(), vi.fn());
+    act(() => buttonNamed("Claude").click());
+    const promptStep = document.querySelector<HTMLElement>(".canvas-context-menu-prompt-step")!;
+    const textarea = promptStep.querySelector<HTMLTextAreaElement>("textarea")!;
+    const launch = buttonNamed("Launch");
+    const launchEmpty = buttonNamed("Launch empty");
+
+    expect([...promptStep.querySelectorAll<HTMLElement>("textarea, button")]).toEqual([textarea, launch, launchEmpty]);
+
+    // jsdom은 기본 Tab 순차 이동을 수행하지 않으므로 양 끝의 trapFocus 경계 순환을 직접 단언한다.
+    act(() => launchEmpty.focus());
+    expect(dispatchTab(launchEmpty)).toBe(false);
+    expect(document.activeElement).toBe(textarea);
+
+    act(() => textarea.focus());
+    expect(dispatchTab(textarea, true)).toBe(false);
+    expect(document.activeElement).toBe(launchEmpty);
+  });
 });
 
 function renderMenu(catalog: readonly OperationCatalogPlugin[], onLaunchKind: ReturnType<typeof vi.fn>, onClose = vi.fn()): void {
@@ -96,6 +116,10 @@ function setTextareaValue(textarea: HTMLTextAreaElement, value: string): void {
   const valueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
   valueSetter?.call(textarea, value);
   textarea.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function dispatchTab(element: HTMLElement, shiftKey = false): boolean {
+  return element.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", shiftKey, bubbles: true, cancelable: true }));
 }
 
 function buttonNamed(name: string): HTMLButtonElement {

--- a/runtime/fleet-console/tests/operations.test.ts
+++ b/runtime/fleet-console/tests/operations.test.ts
@@ -202,7 +202,7 @@ describe("operations platform", () => {
     const fixture = await startCatalogFixture();
 
     const response = await fetch(`${fixture.endpoint}api/v1/operations/catalog`);
-    const catalog = await response.json() as { readonly plugins: ReadonlyArray<{ readonly id: string; readonly title: string; readonly kinds: ReadonlyArray<{ readonly id: string; readonly type: string; readonly title: string }> }> };
+    const catalog = await response.json() as { readonly plugins: ReadonlyArray<{ readonly id: string; readonly title: string; readonly kinds: ReadonlyArray<{ readonly id: string; readonly type: string; readonly title: string; readonly supportsInitialPrompt?: boolean }> }> };
     const terminal = catalog.plugins.find((plugin) => plugin.id === "terminal");
 
     expect(response.status).toBe(200);
@@ -211,7 +211,7 @@ describe("operations platform", () => {
       title: "Terminal",
       kinds: [
         { id: "shell", type: "shell", title: "Shell" },
-        { id: "agent", type: "agent", title: "Agent CLI" },
+        { id: "agent", type: "agent", title: "Agent CLI", supportsInitialPrompt: true },
       ],
     });
     expect(catalog.plugins.filter((plugin) => plugin.id === "terminal")).toHaveLength(1);
@@ -292,7 +292,7 @@ async function startCatalogFixture(): Promise<{ readonly endpoint: string }> {
     "  ]);",
     "  ctx.host.operations.registerLaunchCatalog(ctx.pluginId, () => [",
     "    { id: 'shell', type: 'ignored-duplicate', title: 'Ignored Duplicate' },",
-    "    { id: 'agent', type: 'agent', title: 'Agent CLI' },",
+    "    { id: 'agent', type: 'agent', title: 'Agent CLI', supportsInitialPrompt: true },",
     "  ]);",
     "}",
   ].join("\n"));

--- a/runtime/fleet-plugins/terminal/client/agent/api.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/api.ts
@@ -5,7 +5,7 @@ export interface OperationsSnapshot {
   readonly operations: readonly OperationNode[];
 }
 
-const FORBIDDEN_BROWSER_PAYLOAD_KEYS = ["canonicalCwd", "cwd", "providerSession", "ticket", "token", "transcriptPath", "prompt", "persona", "toolAllowlist"] as const;
+const FORBIDDEN_BROWSER_PAYLOAD_KEYS = ["canonicalCwd", "cwd", "initialPrompt", "providerSession", "ticket", "token", "transcriptPath", "prompt", "persona", "toolAllowlist"] as const;
 
 export class AgentApiError extends Error {
   readonly status: number;
@@ -65,11 +65,11 @@ export async function fetchOperationsSnapshot(signal?: AbortSignal): Promise<Ope
   return { operations: payload.operations.map((operation) => assertOperationNode(operation, response.status)) };
 }
 
-export async function createAgentSession(theaterId: string, cliId: string, signal?: AbortSignal): Promise<SessionInfo> {
+export async function createAgentSession(theaterId: string, cliId: string, initialPrompt?: string, signal?: AbortSignal): Promise<SessionInfo> {
   const response = await fetch("/plugins/terminal/agent/sessions", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ theaterId, cliId }),
+    body: JSON.stringify({ theaterId, cliId, ...(initialPrompt === undefined ? {} : { initialPrompt }) }),
     signal,
   });
   await assertOk(response);

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -132,8 +132,8 @@ export const agentPlugin = definePlugin({
       removeSession(operationId);
     }
   },
-  launch: async ({ theaterId, kind }) => {
-    const session = await createAgentSession(theaterId, kind.id);
+  launch: async ({ theaterId, kind, initialPrompt }) => {
+    const session = await createAgentSession(theaterId, kind.id, initialPrompt);
     applySessionUpdate(session);
     selectSession(session.sessionId);
     return { id: session.sessionId };

--- a/runtime/fleet-plugins/terminal/plugin.json
+++ b/runtime/fleet-plugins/terminal/plugin.json
@@ -12,6 +12,7 @@
     "token",
     "ticket",
     "prompt",
+    "initialPrompt",
     "persona",
     "toolAllowlist"
   ]

--- a/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
@@ -13,6 +13,7 @@ export function buildAgentCliLaunchKinds(
         id: cli.id,
         type: operationType,
         title: cli.label,
+        supportsInitialPrompt: true,
         ...(disabledReason ? { disabled: true, disabledReason } : {}),
       };
     });

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -96,6 +96,8 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
   const detector = createDefaultAgentCliDetector();
   const pendingRuntimeSessions = new Map<string, ConsoleRuntimeSessionInfo>();
   const initialPromptRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const initialPromptGenerations = new Map<string, number>();
+  let nextInitialPromptGeneration = 1;
   const identityRefreshes = new Map<string, { running: boolean; queued: boolean }>();
   const jobOriginById = new Map<string, string>();
   const launchResolver = createAgentTerminalLaunchResolver({
@@ -298,6 +300,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       return;
     }
     const sessionId = crypto.randomUUID();
+    const initialPromptGeneration = beginInitialPromptGeneration(sessionId);
     const session = observability.createPendingTerminalSession({ sessionId, cwd, cliId });
     ctx.host.operations.create({
       id: session.sessionId,
@@ -318,7 +321,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
         theaterId,
         cliId,
       });
-      if (initialPrompt) injectInitialPrompt(sessionId, initialPrompt);
+      if (initialPrompt) injectInitialPrompt(sessionId, initialPrompt, initialPromptGeneration);
       const runtimeSession = pendingRuntimeSessions.get(sessionId);
       pendingRuntimeSessions.delete(sessionId);
       const created = runtimeSession
@@ -328,6 +331,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       ctx.host.operations.patch(sessionId, { payload: toOperationPayload(ctx.host.operations.get(sessionId)?.payload, cwd, created, undefined, observability.getDurableOperation(sessionId)?.providerTitle) });
       ctx.host.http.writeJson(res, 200, created);
     } catch {
+      invalidateInitialPromptGeneration(sessionId);
       pendingRuntimeSessions.delete(sessionId);
       observability.updateTerminalSessionStatus(sessionId, "error");
       ctx.host.http.writeJson(res, 503, { error: "terminal_unavailable" });
@@ -355,6 +359,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
         ctx.host.http.writeJson(res, 404, { error: "theater_not_found" });
         return true;
       }
+      beginInitialPromptGeneration(sessionId);
       await terminalRuntime.attach({
         cwd,
         sessionId,
@@ -372,6 +377,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       ctx.host.operations.patch(sessionId, { payload: toOperationPayload(node.payload, cwd, resumed, providerSession, observability.getDurableOperation(sessionId)?.providerTitle) });
       ctx.host.http.writeJson(res, 200, resumed);
     } catch {
+      invalidateInitialPromptGeneration(sessionId);
       pendingRuntimeSessions.delete(sessionId);
       const reverted = observability.updateTerminalSessionStatus(sessionId, "dormant");
       if (reverted) observability.notifySessionUpdated(reverted);
@@ -490,7 +496,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
 
   async function handleExit(operationId: string): Promise<void> {
     reminderWriter.cancel(operationId);
-    clearInitialPromptRetry(operationId);
+    invalidateInitialPromptGeneration(operationId);
     pendingRuntimeSessions.delete(operationId);
     const providerSession = readProviderSessionCapture(operationId, { capturesDir: ctx.host.paths.capturesDir }) ?? readProviderSession(ctx.host.operations.get(operationId)?.payload);
     if (providerSession) {
@@ -509,7 +515,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
 
   function removeSession(sessionId: string): void {
     reminderWriter.cancel(sessionId);
-    clearInitialPromptRetry(sessionId);
+    invalidateInitialPromptGeneration(sessionId);
     terminalRuntime.terminate(sessionId);
     pendingRuntimeSessions.delete(sessionId);
     observability.removeTerminalSession(sessionId);
@@ -519,7 +525,9 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
 
   async function cleanup(): Promise<void> {
     reminderWriter.cancelAll();
-    for (const sessionId of [...initialPromptRetryTimers.keys()]) clearInitialPromptRetry(sessionId);
+    for (const sessionId of new Set([...initialPromptGenerations.keys(), ...initialPromptRetryTimers.keys()])) {
+      invalidateInitialPromptGeneration(sessionId);
+    }
     unsubscribeRename();
     unsubscribeReminder();
     unsubscribeStream();
@@ -584,7 +592,8 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     );
   }
 
-  function injectInitialPrompt(sessionId: string, prompt: string, isRetry = false): void {
+  function injectInitialPrompt(sessionId: string, prompt: string, generation: number, isRetry = false): void {
+    if (!isCurrentInitialPromptGeneration(sessionId, generation)) return;
     const safePrompt = sanitizeCarrierResultReminder(prompt).trim();
     if (safePrompt.length === 0) return;
     const policy = terminalRuntime.getMessagePolicy(sessionId) ?? {};
@@ -592,23 +601,46 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     reminderWriter.enqueue(
       sessionId,
       (data) => {
+        if (!isCurrentInitialPromptGeneration(sessionId, generation)) return false;
         const written = terminalRuntime.write(sessionId, data);
         if (written || handledWriteFailure) return written;
         handledWriteFailure = true;
+        if (!isCurrentInitialPromptGeneration(sessionId, generation)) return false;
         if (isRetry) {
           console.debug("[fleet-console] Initial prompt injection dropped because the PTY was unavailable", { sessionId });
           return false;
         }
         const timer = setTimeout(() => {
           if (initialPromptRetryTimers.get(sessionId) !== timer) return;
+          if (!isCurrentInitialPromptGeneration(sessionId, generation)) {
+            initialPromptRetryTimers.delete(sessionId);
+            return;
+          }
           initialPromptRetryTimers.delete(sessionId);
-          injectInitialPrompt(sessionId, safePrompt, true);
+          injectInitialPrompt(sessionId, safePrompt, generation, true);
         }, INITIAL_PROMPT_RETRY_DELAY_MS);
         initialPromptRetryTimers.set(sessionId, timer);
         return false;
       },
       formatCarrierResultReminderMessage(policy, safePrompt, process.platform, CONSOLE_PTY_MESSAGE_DELIVERY),
     );
+  }
+
+  function beginInitialPromptGeneration(sessionId: string): number {
+    clearInitialPromptRetry(sessionId);
+    const generation = nextInitialPromptGeneration;
+    nextInitialPromptGeneration += 1;
+    initialPromptGenerations.set(sessionId, generation);
+    return generation;
+  }
+
+  function invalidateInitialPromptGeneration(sessionId: string): void {
+    clearInitialPromptRetry(sessionId);
+    initialPromptGenerations.delete(sessionId);
+  }
+
+  function isCurrentInitialPromptGeneration(sessionId: string, generation: number): boolean {
+    return initialPromptGenerations.get(sessionId) === generation;
   }
 
   function clearInitialPromptRetry(sessionId: string): void {

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -23,7 +23,7 @@ import { createAgentTerminalLaunchResolver, type ConsoleRuntimeSessionInfo } fro
 import { createConsoleObservabilityStore } from "./agent-api/observability-store.js";
 import { writeAggregateObserverEvents } from "./agent-api/observability-routes.js";
 import type { AgentProviderTitleMarker, AgentTerminalSessionInfo, AgentLabelSource } from "./agent-api/types.js";
-type SessionCreateBody = { readonly cliId?: unknown; readonly theaterId?: unknown };
+type SessionCreateBody = { readonly cliId?: unknown; readonly theaterId?: unknown; readonly initialPrompt?: unknown };
 type HookTurnBody = { readonly phase?: unknown };
 type HookAttentionBody = { readonly input?: unknown; readonly reason?: unknown };
 type HookAutoNameBody = { readonly input?: unknown; readonly prompt?: unknown };
@@ -43,6 +43,8 @@ interface AgentRouteDeps {
 
 const AGENT_OPERATION_TYPE = "agent";
 const CONSOLE_PTY_MESSAGE_DELIVERY = { submitDelayMs: 250 } as const;
+const INITIAL_PROMPT_MAX_LENGTH = 4_000;
+const INITIAL_PROMPT_RETRY_DELAY_MS = 500;
 const OPERATION_RENAMED_EVENT_CHANNEL = "operation:renamed";
 const TERMINAL_PLUGIN_ID = "terminal";
 
@@ -93,6 +95,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
   });
   const detector = createDefaultAgentCliDetector();
   const pendingRuntimeSessions = new Map<string, ConsoleRuntimeSessionInfo>();
+  const initialPromptRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const identityRefreshes = new Map<string, { running: boolean; queued: boolean }>();
   const jobOriginById = new Map<string, string>();
   const launchResolver = createAgentTerminalLaunchResolver({
@@ -243,6 +246,11 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     }
     if (req.method !== "POST") return methodNotAllowed(res);
     const body = await ctx.host.http.readJsonBody<SessionCreateBody>(req);
+    const initialPrompt = readInitialPrompt(body?.initialPrompt);
+    if (initialPrompt === false) {
+      ctx.host.http.writeJson(res, 400, { error: "invalid_initial_prompt" });
+      return true;
+    }
     const cliId = readOptionalAgentCliId(body?.cliId, res);
     if (cliId === false) return true;
     if (!cliId) {
@@ -261,7 +269,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       ctx.host.http.writeJson(res, 404, { error: "theater_not_found" });
       return true;
     }
-    await createSession(cwd, theaterId, cliId, res);
+    await createSession(cwd, theaterId, cliId, initialPrompt, res);
     return true;
   }
 
@@ -283,7 +291,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     return methodNotAllowed(res);
   }
 
-  async function createSession(cwd: string, theaterId: string, cliId: AgentCliId, res: Parameters<typeof handle>[0]["res"]): Promise<void> {
+  async function createSession(cwd: string, theaterId: string, cliId: AgentCliId, initialPrompt: string | undefined, res: Parameters<typeof handle>[0]["res"]): Promise<void> {
     const meta = (await buildAgentCliLaunchMetadata()).find((entry) => entry.id === cliId);
     if (!meta || !meta.available || !meta.signedIn) {
       ctx.host.http.writeJson(res, 409, { error: "agent_cli_unavailable" });
@@ -310,6 +318,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
         theaterId,
         cliId,
       });
+      if (initialPrompt) injectInitialPrompt(sessionId, initialPrompt);
       const runtimeSession = pendingRuntimeSessions.get(sessionId);
       pendingRuntimeSessions.delete(sessionId);
       const created = runtimeSession
@@ -481,6 +490,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
 
   async function handleExit(operationId: string): Promise<void> {
     reminderWriter.cancel(operationId);
+    clearInitialPromptRetry(operationId);
     pendingRuntimeSessions.delete(operationId);
     const providerSession = readProviderSessionCapture(operationId, { capturesDir: ctx.host.paths.capturesDir }) ?? readProviderSession(ctx.host.operations.get(operationId)?.payload);
     if (providerSession) {
@@ -499,6 +509,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
 
   function removeSession(sessionId: string): void {
     reminderWriter.cancel(sessionId);
+    clearInitialPromptRetry(sessionId);
     terminalRuntime.terminate(sessionId);
     pendingRuntimeSessions.delete(sessionId);
     observability.removeTerminalSession(sessionId);
@@ -508,6 +519,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
 
   async function cleanup(): Promise<void> {
     reminderWriter.cancelAll();
+    for (const sessionId of [...initialPromptRetryTimers.keys()]) clearInitialPromptRetry(sessionId);
     unsubscribeRename();
     unsubscribeReminder();
     unsubscribeStream();
@@ -570,6 +582,39 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       (data) => terminalRuntime.write(sessionId, data),
       formatCarrierResultReminderMessage(policy, `${renameCommand} ${safeLabel}`, process.platform, CONSOLE_PTY_MESSAGE_DELIVERY),
     );
+  }
+
+  function injectInitialPrompt(sessionId: string, prompt: string, isRetry = false): void {
+    const safePrompt = sanitizeCarrierResultReminder(prompt).trim();
+    if (safePrompt.length === 0) return;
+    const policy = terminalRuntime.getMessagePolicy(sessionId) ?? {};
+    let handledWriteFailure = false;
+    reminderWriter.enqueue(
+      sessionId,
+      (data) => {
+        const written = terminalRuntime.write(sessionId, data);
+        if (written || handledWriteFailure) return written;
+        handledWriteFailure = true;
+        if (isRetry) {
+          console.debug("[fleet-console] Initial prompt injection dropped because the PTY was unavailable", { sessionId });
+          return false;
+        }
+        const timer = setTimeout(() => {
+          if (initialPromptRetryTimers.get(sessionId) !== timer) return;
+          initialPromptRetryTimers.delete(sessionId);
+          injectInitialPrompt(sessionId, safePrompt, true);
+        }, INITIAL_PROMPT_RETRY_DELAY_MS);
+        initialPromptRetryTimers.set(sessionId, timer);
+        return false;
+      },
+      formatCarrierResultReminderMessage(policy, safePrompt, process.platform, CONSOLE_PTY_MESSAGE_DELIVERY),
+    );
+  }
+
+  function clearInitialPromptRetry(sessionId: string): void {
+    const timer = initialPromptRetryTimers.get(sessionId);
+    if (timer) clearTimeout(timer);
+    initialPromptRetryTimers.delete(sessionId);
   }
 
   function injectOperation(operation: OperationNode): AgentTerminalSessionInfo {
@@ -675,6 +720,14 @@ function readOptionalAgentCliId(value: unknown, res: Parameters<FleetPluginServe
     res.end(JSON.stringify({ error: "invalid_agent_cli" }));
     return false;
   }
+}
+
+function readInitialPrompt(value: unknown): string | undefined | false {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") return false;
+  const prompt = value.trim();
+  if (prompt.length > INITIAL_PROMPT_MAX_LENGTH) return false;
+  return prompt.length > 0 ? prompt : undefined;
 }
 
 function readProviderSession(value: Record<string, unknown> | undefined): ProviderSession | undefined {

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -40,10 +40,18 @@ interface AgentRouteDeps {
   readonly authService: AuthService;
   readonly globalOptionsService: GlobalOptionsService;
 }
+interface InitialPromptReadyWatcher {
+  readonly generation: number;
+  readonly prompt: string;
+  quietTimer: ReturnType<typeof setTimeout> | undefined;
+  timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+}
 
 const AGENT_OPERATION_TYPE = "agent";
 const CONSOLE_PTY_MESSAGE_DELIVERY = { submitDelayMs: 250 } as const;
 const INITIAL_PROMPT_MAX_LENGTH = 4_000;
+const INITIAL_PROMPT_READY_QUIET_MS = 800;
+const INITIAL_PROMPT_READY_TIMEOUT_MS = 15_000;
 const INITIAL_PROMPT_RETRY_DELAY_MS = 500;
 const OPERATION_RENAMED_EVENT_CHANNEL = "operation:renamed";
 const TERMINAL_PLUGIN_ID = "terminal";
@@ -96,6 +104,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
   const detector = createDefaultAgentCliDetector();
   const pendingRuntimeSessions = new Map<string, ConsoleRuntimeSessionInfo>();
   const initialPromptRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const initialPromptReadyWatchers = new Map<string, InitialPromptReadyWatcher>();
   const initialPromptGenerations = new Map<string, number>();
   let nextInitialPromptGeneration = 1;
   const identityRefreshes = new Map<string, { running: boolean; queued: boolean }>();
@@ -121,6 +130,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     if (!sessionId) return;
     observability.appendTerminalRuntimeEvent(sessionId, withSignatureCli(event, runtime.carrierRuntime.registry));
   });
+  const unsubscribePtyOutput = terminalRuntime.onOutput(handleInitialPromptOutput);
   // carrier 리마인더와 rename 주입이 세션 단위로 함께 직렬화되도록 공유 writer를 사용한다.
   const reminderWriter = createDelayedPtyWriter();
   const unsubscribeReminder = createCarrierResultReminderRouter({
@@ -311,6 +321,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       payload: toOperationPayload(undefined, cwd, session),
       createdAt: session.createdAt,
     });
+    if (initialPrompt) watchInitialPromptReadiness(sessionId, initialPrompt, initialPromptGeneration);
     try {
       await terminalRuntime.attach({
         cwd,
@@ -321,7 +332,6 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
         theaterId,
         cliId,
       });
-      if (initialPrompt) injectInitialPrompt(sessionId, initialPrompt, initialPromptGeneration);
       const runtimeSession = pendingRuntimeSessions.get(sessionId);
       pendingRuntimeSessions.delete(sessionId);
       const created = runtimeSession
@@ -525,9 +535,10 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
 
   async function cleanup(): Promise<void> {
     reminderWriter.cancelAll();
-    for (const sessionId of new Set([...initialPromptGenerations.keys(), ...initialPromptRetryTimers.keys()])) {
+    for (const sessionId of new Set([...initialPromptGenerations.keys(), ...initialPromptReadyWatchers.keys(), ...initialPromptRetryTimers.keys()])) {
       invalidateInitialPromptGeneration(sessionId);
     }
+    unsubscribePtyOutput();
     unsubscribeRename();
     unsubscribeReminder();
     unsubscribeStream();
@@ -592,6 +603,49 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     );
   }
 
+  function watchInitialPromptReadiness(sessionId: string, prompt: string, generation: number): void {
+    clearInitialPromptReadyWatcher(sessionId);
+    if (!isCurrentInitialPromptGeneration(sessionId, generation)) return;
+    const watcher: InitialPromptReadyWatcher = {
+      generation,
+      prompt,
+      quietTimer: undefined,
+      timeoutTimer: undefined,
+    };
+    initialPromptReadyWatchers.set(sessionId, watcher);
+    watcher.timeoutTimer = setTimeout(() => {
+      completeInitialPromptReadiness(sessionId, watcher);
+    }, INITIAL_PROMPT_READY_TIMEOUT_MS);
+  }
+
+  function handleInitialPromptOutput(sessionId: string): void {
+    const watcher = initialPromptReadyWatchers.get(sessionId);
+    if (!watcher) return;
+    if (!isCurrentInitialPromptGeneration(sessionId, watcher.generation)) {
+      clearInitialPromptReadyWatcher(sessionId, watcher);
+      return;
+    }
+    if (watcher.quietTimer) clearTimeout(watcher.quietTimer);
+    watcher.quietTimer = setTimeout(() => {
+      completeInitialPromptReadiness(sessionId, watcher);
+    }, INITIAL_PROMPT_READY_QUIET_MS);
+  }
+
+  function completeInitialPromptReadiness(sessionId: string, watcher: InitialPromptReadyWatcher): void {
+    if (initialPromptReadyWatchers.get(sessionId) !== watcher) return;
+    clearInitialPromptReadyWatcher(sessionId, watcher);
+    if (!isCurrentInitialPromptGeneration(sessionId, watcher.generation)) return;
+    injectInitialPrompt(sessionId, watcher.prompt, watcher.generation);
+  }
+
+  function clearInitialPromptReadyWatcher(sessionId: string, expected?: InitialPromptReadyWatcher): void {
+    const watcher = initialPromptReadyWatchers.get(sessionId);
+    if (!watcher || (expected && watcher !== expected)) return;
+    if (watcher.quietTimer) clearTimeout(watcher.quietTimer);
+    if (watcher.timeoutTimer) clearTimeout(watcher.timeoutTimer);
+    initialPromptReadyWatchers.delete(sessionId);
+  }
+
   function injectInitialPrompt(sessionId: string, prompt: string, generation: number, isRetry = false): void {
     if (!isCurrentInitialPromptGeneration(sessionId, generation)) return;
     const safePrompt = sanitizeCarrierResultReminder(prompt).trim();
@@ -627,6 +681,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
   }
 
   function beginInitialPromptGeneration(sessionId: string): number {
+    clearInitialPromptReadyWatcher(sessionId);
     clearInitialPromptRetry(sessionId);
     const generation = nextInitialPromptGeneration;
     nextInitialPromptGeneration += 1;
@@ -635,6 +690,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
   }
 
   function invalidateInitialPromptGeneration(sessionId: string): void {
+    clearInitialPromptReadyWatcher(sessionId);
     clearInitialPromptRetry(sessionId);
     initialPromptGenerations.delete(sessionId);
   }

--- a/runtime/fleet-plugins/terminal/server/shared/runtime.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/runtime.ts
@@ -18,6 +18,7 @@ export interface TerminalRuntime {
   getMessagePolicy(operationId: string): CliMessagePolicy | undefined;
   getRenameCommand(operationId: string): string | undefined;
   resolveSessionIdentity(operationId: string, providerSessionId: string): Promise<string | null>;
+  onOutput(callback: (operationId: string) => void): () => void;
   onExit(callback: (operationId: string) => void | Promise<void>): () => void;
   registerLaunchResolver(operationType: string, resolver: TerminalLaunchResolver): () => void;
   stop(): Promise<void>;
@@ -29,6 +30,7 @@ const SHELL_OPERATION_TYPE = "shell";
 
 export function createTerminalRuntime(ctx: FleetPluginServerContext): TerminalRuntime {
   const tickets = createPluginTerminalTicketRegistry();
+  const terminalOutputListeners = new Set<(operationId: string) => void>();
   const terminalExitListeners = new Set<(operationId: string) => void | Promise<void>>();
   const terminalLaunchResolvers = new Map<string, TerminalLaunchResolver>();
   const defaultTerminalLaunch = createShellTerminalLaunchResolver();
@@ -36,6 +38,9 @@ export function createTerminalRuntime(ctx: FleetPluginServerContext): TerminalRu
   const sessions = createTerminalSessionManager({
     launch: createRegistryAwareTerminalLaunchResolver(defaultTerminalLaunch, terminalLaunchResolvers),
     startShell: startTerminalShell,
+    onSessionOutput: (sessionId) => {
+      for (const listener of terminalOutputListeners) listener(sessionId);
+    },
     onSessionExit: async (sessionId) => {
       await Promise.all([...terminalExitListeners].map((listener) => listener(sessionId)));
     },
@@ -58,6 +63,10 @@ export function createTerminalRuntime(ctx: FleetPluginServerContext): TerminalRu
     getMessagePolicy: (operationId) => sessions.getSessionMessagePolicy(operationId),
     getRenameCommand: (operationId) => sessions.getSessionRenameCommand(operationId),
     resolveSessionIdentity: (operationId, providerSessionId) => sessions.resolveSessionIdentity(operationId, providerSessionId),
+    onOutput: (callback) => {
+      terminalOutputListeners.add(callback);
+      return () => terminalOutputListeners.delete(callback);
+    },
     onExit: (callback) => {
       terminalExitListeners.add(callback);
       return () => terminalExitListeners.delete(callback);
@@ -71,6 +80,7 @@ export function createTerminalRuntime(ctx: FleetPluginServerContext): TerminalRu
     stop: async () => {
       upgrade.close();
       await sessions.stop();
+      terminalOutputListeners.clear();
       terminalExitListeners.clear();
       terminalLaunchResolvers.clear();
     },

--- a/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
@@ -12,6 +12,7 @@ export interface TerminalSessionManagerDeps {
   // DI 계약 유지용으로 받지만 더 이상 동시 세션 상한을 강제하지 않는다(상한 해제됨).
   readonly maxSessions?: number;
   readonly scrollbackLimit?: number;
+  readonly onSessionOutput?: (sessionId: string) => unknown;
   // PTY가 종료되거나 세션이 정리될 때(멱등) 정확히 한 번 호출 — 콘솔 세션 목록 정리에 쓰인다.
   readonly onSessionExit?: (sessionId: string) => unknown;
 }
@@ -217,6 +218,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
   }
 
   function handlePtyData(session: TerminalSession, data: string): void {
+    deps.onSessionOutput?.(session.id);
     const buffer = Buffer.from(data, "utf8");
     respondToTerminalQueries(session, buffer);
     session.scrollback.push(buffer);

--- a/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
@@ -14,9 +14,9 @@ describe("buildAgentCliLaunchKinds", () => {
     );
 
     expect(result).toEqual([
-      { id: "claude", type: "agent", title: "Claude" },
-      { id: "claude-kimi", type: "agent", title: "Kimi (Claude Code)" },
-      { id: "codex", type: "agent", title: "Codex" },
+      { id: "claude", type: "agent", title: "Claude", supportsInitialPrompt: true },
+      { id: "claude-kimi", type: "agent", title: "Kimi (Claude Code)", supportsInitialPrompt: true },
+      { id: "codex", type: "agent", title: "Codex", supportsInitialPrompt: true },
     ]);
   });
 
@@ -31,9 +31,9 @@ describe("buildAgentCliLaunchKinds", () => {
     );
 
     expect(result).toEqual([
-      { id: "claude", type: "agent", title: "Claude", disabled: true, disabledReason: "Not installed" },
-      { id: "claude-kimi", type: "agent", title: "Kimi (Claude Code)", disabled: true, disabledReason: "Sign in required" },
-      { id: "codex", type: "agent", title: "Codex", disabled: true, disabledReason: "Sign in required" },
+      { id: "claude", type: "agent", title: "Claude", supportsInitialPrompt: true, disabled: true, disabledReason: "Not installed" },
+      { id: "claude-kimi", type: "agent", title: "Kimi (Claude Code)", supportsInitialPrompt: true, disabled: true, disabledReason: "Sign in required" },
+      { id: "codex", type: "agent", title: "Codex", supportsInitialPrompt: true, disabled: true, disabledReason: "Sign in required" },
     ]);
   });
 });

--- a/runtime/fleet-plugins/terminal/tests/agent-initial-prompt.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-initial-prompt.test.ts
@@ -24,17 +24,24 @@ afterEach(async () => {
 describe("agent session initial prompt", () => {
   it("injects the trimmed prompt through the delayed PTY writer without echoing it in session or Operation DTOs", async () => {
     const harness = createHarness({ initialPrompt: "  Inspect the failing test  " });
+    vi.useFakeTimers();
+    try {
+      await harness.postSessions();
+      const sessionId = harness.attach.mock.calls[0]?.[0]?.sessionId;
+      expect(sessionId).toBeTypeOf("string");
+      harness.emitOutput(sessionId!);
+      await vi.advanceTimersByTimeAsync(1_051);
 
-    await harness.postSessions();
-    await vi.waitFor(() => expect(harness.write).toHaveBeenCalledTimes(2));
-
-    expect(harness.attach).toHaveBeenCalledOnce();
-    expect(harness.write.mock.calls.map(([_, data]) => data)).toEqual(["Inspect the failing test", "\r"]);
-    expect(harness.responses.at(-1)?.status).toBe(200);
-    expect(harness.responses.at(-1)?.body).not.toHaveProperty("initialPrompt");
-    expect(harness.operations[0]?.payload).not.toHaveProperty("initialPrompt");
-    expect(JSON.stringify(harness.responses)).not.toContain("Inspect the failing test");
-    expect(JSON.stringify(harness.operations)).not.toContain("Inspect the failing test");
+      expect(harness.attach).toHaveBeenCalledOnce();
+      expect(harness.write.mock.calls.map(([_, data]) => data)).toEqual(["Inspect the failing test", "\r"]);
+      expect(harness.responses.at(-1)?.status).toBe(200);
+      expect(harness.responses.at(-1)?.body).not.toHaveProperty("initialPrompt");
+      expect(harness.operations[0]?.payload).not.toHaveProperty("initialPrompt");
+      expect(JSON.stringify(harness.responses)).not.toContain("Inspect the failing test");
+      expect(JSON.stringify(harness.operations)).not.toContain("Inspect the failing test");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("rejects prompts longer than 4000 trimmed characters", async () => {
@@ -62,10 +69,72 @@ describe("agent session initial prompt", () => {
     vi.useFakeTimers();
     try {
       await harness.postSessions();
-      await vi.advanceTimersByTimeAsync(751);
+      const sessionId = harness.attach.mock.calls[0]?.[0]?.sessionId;
+      harness.emitOutput(sessionId!);
+      await vi.advanceTimersByTimeAsync(1_551);
 
       expect(harness.write.mock.calls.map(([_, data]) => data)).toEqual(["Retry me", "Retry me", "\r"]);
       expect(harness.terminate).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the prompt gated while PTY output continues before the 800ms quiet window", async () => {
+    const harness = createHarness({ initialPrompt: "Wait for quiet" });
+    vi.useFakeTimers();
+    try {
+      await harness.postSessions();
+      const sessionId = harness.attach.mock.calls[0]?.[0]?.sessionId;
+      harness.emitOutput(sessionId!);
+
+      await vi.advanceTimersByTimeAsync(799);
+      expect(harness.write).not.toHaveBeenCalled();
+      harness.emitOutput(sessionId!);
+
+      await vi.advanceTimersByTimeAsync(799);
+      expect(harness.write).not.toHaveBeenCalled();
+      harness.emitOutput(sessionId!);
+
+      await vi.advanceTimersByTimeAsync(799);
+      expect(harness.write).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(harness.write.mock.calls.map(([_, data]) => data)).toEqual(["Wait for quiet"]);
+      await vi.advanceTimersByTimeAsync(250);
+      expect(harness.write.mock.calls.map(([_, data]) => data)).toEqual(["Wait for quiet", "\r"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("falls back to prompt injection after the 15 second readiness timeout", async () => {
+    const harness = createHarness({ initialPrompt: "Timeout fallback" });
+    vi.useFakeTimers();
+    try {
+      await harness.postSessions();
+
+      await vi.advanceTimersByTimeAsync(14_999);
+      expect(harness.write).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(harness.write.mock.calls.map(([_, data]) => data)).toEqual(["Timeout fallback"]);
+      await vi.advanceTimersByTimeAsync(250);
+      expect(harness.write.mock.calls.map(([_, data]) => data)).toEqual(["Timeout fallback", "\r"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears the readiness watcher without injecting when the session exits before ready", async () => {
+    const harness = createHarness({ initialPrompt: "Do not inject" });
+    vi.useFakeTimers();
+    try {
+      await harness.postSessions();
+      const sessionId = harness.attach.mock.calls[0]?.[0]?.sessionId;
+      harness.emitOutput(sessionId!);
+      await harness.emitExit(sessionId!);
+
+      await vi.advanceTimersByTimeAsync(15_250);
+      expect(harness.write).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }
@@ -82,15 +151,16 @@ describe("agent session initial prompt", () => {
     vi.useFakeTimers();
     try {
       await harness.postSessions();
-      await Promise.resolve();
       const firstAttachContext = harness.attach.mock.calls[0]?.[0];
       expect(firstAttachContext).toBeDefined();
       const sessionId = firstAttachContext!.sessionId;
+      harness.emitOutput(sessionId);
+      await vi.advanceTimersByTimeAsync(800);
       expect(harness.write.mock.calls.map(([_, data]) => data)).toEqual(["Stale prompt"]);
       await exitPromise;
 
       await harness.resumeSession(sessionId!);
-      await vi.advanceTimersByTimeAsync(751);
+      await vi.advanceTimersByTimeAsync(15_250);
 
       expect(harness.attach).toHaveBeenCalledTimes(2);
       expect(harness.attach.mock.calls[1]?.[0]?.sessionId).toBe(sessionId);
@@ -128,6 +198,7 @@ function createHarness(body: Record<string, unknown>) {
   const responses: Array<{ readonly status: number; readonly body: unknown }> = [];
   let route: RouteHandler | undefined;
   let lifecycleCleanup: (() => void | Promise<void>) | undefined;
+  let outputCallback: ((operationId: string) => void) | undefined;
   let exitCallback: ((operationId: string) => void | Promise<void>) | undefined;
   const attach = vi.fn<TerminalRuntime["attach"]>(async () => {});
   const write = vi.fn<(sessionId: string, data: string) => boolean>(() => true);
@@ -142,6 +213,12 @@ function createHarness(body: Record<string, unknown>) {
     getMessagePolicy: () => ({}),
     getRenameCommand: () => undefined,
     resolveSessionIdentity: async () => null,
+    onOutput: (callback) => {
+      outputCallback = callback;
+      return () => {
+        if (outputCallback === callback) outputCallback = undefined;
+      };
+    },
     onExit: (callback) => {
       exitCallback = callback;
       return () => {
@@ -250,6 +327,10 @@ function createHarness(body: Record<string, unknown>) {
     responses,
     terminate,
     write,
+    emitOutput: (sessionId: string) => {
+      if (!outputCallback) throw new Error("Terminal output callback was not registered");
+      outputCallback(sessionId);
+    },
     emitExit: async (sessionId: string) => {
       if (!exitCallback) throw new Error("Terminal exit callback was not registered");
       await exitCallback(sessionId);

--- a/runtime/fleet-plugins/terminal/tests/agent-initial-prompt.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-initial-prompt.test.ts
@@ -1,0 +1,227 @@
+import http from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { OperationCreateInput, OperationNode, OperationPatchInput } from "@fleet-console/sdk/operations";
+import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
+import type { RouteHandler } from "@fleet-console/sdk/routing";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createAgentSession } from "../client/agent/api.js";
+import { registerAgentRoutes } from "../server/agent.js";
+import type { TerminalRuntime } from "../server/shared/index.js";
+
+const cleanups: Array<() => void | Promise<void>> = [];
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("agent session initial prompt", () => {
+  it("injects the trimmed prompt through the delayed PTY writer without echoing it in session or Operation DTOs", async () => {
+    const harness = createHarness({ initialPrompt: "  Inspect the failing test  " });
+
+    await harness.postSessions();
+    await vi.waitFor(() => expect(harness.write).toHaveBeenCalledTimes(2));
+
+    expect(harness.attach).toHaveBeenCalledOnce();
+    expect(harness.write.mock.calls.map(([_, data]) => data)).toEqual(["Inspect the failing test", "\r"]);
+    expect(harness.responses.at(-1)?.status).toBe(200);
+    expect(harness.responses.at(-1)?.body).not.toHaveProperty("initialPrompt");
+    expect(harness.operations[0]?.payload).not.toHaveProperty("initialPrompt");
+    expect(JSON.stringify(harness.responses)).not.toContain("Inspect the failing test");
+    expect(JSON.stringify(harness.operations)).not.toContain("Inspect the failing test");
+  });
+
+  it("rejects prompts longer than 4000 trimmed characters", async () => {
+    const harness = createHarness({ initialPrompt: "x".repeat(4_001) });
+
+    await harness.postSessions();
+
+    expect(harness.responses.at(-1)).toEqual({ status: 400, body: { error: "invalid_initial_prompt" } });
+    expect(harness.attach).not.toHaveBeenCalled();
+    expect(harness.operations).toHaveLength(0);
+  });
+
+  it("rejects non-string initial prompts", async () => {
+    const harness = createHarness({ initialPrompt: 42 });
+
+    await harness.postSessions();
+
+    expect(harness.responses.at(-1)).toEqual({ status: 400, body: { error: "invalid_initial_prompt" } });
+    expect(harness.attach).not.toHaveBeenCalled();
+  });
+
+  it("retries once after a missing PTY without terminating the session", async () => {
+    const harness = createHarness({ initialPrompt: "Retry me" });
+    harness.write.mockReturnValueOnce(false).mockReturnValue(true);
+    vi.useFakeTimers();
+    try {
+      await harness.postSessions();
+      await vi.advanceTimersByTimeAsync(751);
+
+      expect(harness.write.mock.calls.map(([_, data]) => data)).toEqual(["Retry me", "Retry me", "\r"]);
+      expect(harness.terminate).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("agent session client request", () => {
+  it("sends initialPrompt only in the session creation JSON body", async () => {
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(async () => new Response(JSON.stringify({
+      sessionId: "session-1",
+      cwdLabel: "theater",
+      status: "terminal-only",
+      createdAt: 1,
+    }), { status: 200, headers: { "content-type": "application/json" } }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await createAgentSession("theater-1", "claude", "Inspect the failure");
+
+    expect(fetchMock).toHaveBeenCalledWith("/plugins/terminal/agent/sessions", expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({ theaterId: "theater-1", cliId: "claude", initialPrompt: "Inspect the failure" }),
+    }));
+    expect(fetchMock.mock.calls[0]?.[0]).not.toContain("Inspect");
+  });
+});
+
+function createHarness(body: Record<string, unknown>) {
+  const fleetDataDir = mkdtempSync(path.join(os.tmpdir(), "fleet-terminal-initial-prompt-"));
+  temporaryDirectories.push(fleetDataDir);
+  const operations: OperationNode[] = [];
+  const responses: Array<{ readonly status: number; readonly body: unknown }> = [];
+  let route: RouteHandler | undefined;
+  let lifecycleCleanup: (() => void | Promise<void>) | undefined;
+  const attach = vi.fn(async () => {});
+  const write = vi.fn<(sessionId: string, data: string) => boolean>(() => true);
+  const terminate = vi.fn(() => true);
+  const terminalRuntime: TerminalRuntime = {
+    handleUpgrade: () => false,
+    issueTicket: () => ({ ticket: "ticket", ttlMs: 1_000 }),
+    canAttach: () => true,
+    attach,
+    write,
+    terminate,
+    getMessagePolicy: () => ({}),
+    getRenameCommand: () => undefined,
+    resolveSessionIdentity: async () => null,
+    onExit: () => () => {},
+    registerLaunchResolver: () => () => {},
+    stop: async () => {},
+  };
+  const ctx = {
+    pluginId: "terminal",
+    manifest: { id: "terminal" },
+    basePath: "/plugins/terminal",
+    wsBasePath: "/plugins/terminal/ws",
+    registerRouter: (_path: string, handler: RouteHandler) => { route = handler; },
+    registerWsHandler: () => {},
+    host: {
+      operations: {
+        list: () => operations,
+        get: (id: string) => operations.find((operation) => operation.id === id) ?? null,
+        create: (input: OperationCreateInput) => {
+          const createdAt = input.createdAt ?? Date.now();
+          const operation: OperationNode = {
+            id: input.id ?? `operation-${operations.length + 1}`,
+            theaterId: input.theaterId,
+            type: input.type,
+            pluginId: input.pluginId,
+            title: input.title,
+            payload: { ...(input.payload ?? {}) },
+            geometry: input.geometry ?? null,
+            ts: { createdAt, updatedAt: createdAt },
+          };
+          operations.push(operation);
+          return operation;
+        },
+        patch: (id: string, input: OperationPatchInput) => {
+          const index = operations.findIndex((operation) => operation.id === id);
+          const current = operations[index];
+          if (!current) return null;
+          const patched = {
+            ...current,
+            ...(input.title === undefined ? {} : { title: input.title }),
+            ...(input.payload === undefined ? {} : { payload: { ...input.payload } }),
+            ts: { ...current.ts, updatedAt: Date.now() },
+          };
+          operations[index] = patched;
+          return patched;
+        },
+        delete: (id: string) => {
+          const index = operations.findIndex((operation) => operation.id === id);
+          if (index < 0) return false;
+          operations.splice(index, 1);
+          return true;
+        },
+        registerOperationType: () => () => {},
+        registerPayloadSanitizer: () => () => {},
+        registerLaunchCatalog: () => () => {},
+      },
+      events: {
+        publish: () => {},
+        subscribe: () => () => {},
+        registerSseChannel: () => () => {},
+      },
+      paths: {
+        fleetDataDir,
+        capturesDir: fleetDataDir,
+        pluginDataDir: () => fleetDataDir,
+        resolveTheaterPath: (theaterId: string) => theaterId === "theater-1" ? path.join(fleetDataDir, "theater") : null,
+        canonicalizeTheaterPath: (cwd: string) => cwd,
+        workspaceHash: () => "theater-1",
+      },
+      storage: {
+        readJson: async () => null,
+        writeJson: async () => {},
+      },
+      http: {
+        writeJson: (_res: http.ServerResponse, status: number, responseBody: unknown) => { responses.push({ status, body: responseBody }); },
+        readJsonBody: async <T,>() => ({ theaterId: "theater-1", cliId: "claude", ...body }) as T,
+      },
+      security: {
+        validateHost: () => true,
+        isTerminalAuthorized: () => true,
+        isLockAuthorized: () => true,
+      },
+      lifecycle: {
+        registerCleanup: (cleanup: () => void | Promise<void>) => {
+          lifecycleCleanup = cleanup;
+          return () => {};
+        },
+      },
+    },
+  } satisfies FleetPluginServerContext;
+
+  const previousTerminalCommand = process.env.FLEET_TERMINAL_CMD;
+  process.env.FLEET_TERMINAL_CMD = "test-terminal";
+  registerAgentRoutes(ctx, terminalRuntime, { authService: {} as never, globalOptionsService: {} as never });
+  cleanups.push(async () => {
+    if (previousTerminalCommand === undefined) delete process.env.FLEET_TERMINAL_CMD;
+    else process.env.FLEET_TERMINAL_CMD = previousTerminalCommand;
+    await lifecycleCleanup?.();
+  });
+
+  return {
+    attach,
+    operations,
+    responses,
+    terminate,
+    write,
+    postSessions: async () => {
+      if (!route) throw new Error("Agent route was not registered");
+      await route({
+        req: { method: "POST", url: "/plugins/terminal/agent/sessions" } as http.IncomingMessage,
+        res: {} as http.ServerResponse,
+        pathname: "/plugins/terminal/agent/sessions",
+      });
+    },
+  };
+}

--- a/runtime/fleet-plugins/terminal/tests/agent-initial-prompt.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-initial-prompt.test.ts
@@ -70,6 +70,35 @@ describe("agent session initial prompt", () => {
       vi.useRealTimers();
     }
   });
+
+  it("does not inject a stale prompt after onExit and resume reuse the same session id", async () => {
+    const harness = createHarness({ initialPrompt: "Stale prompt" });
+    let exitPromise: Promise<void> | undefined;
+    harness.write.mockImplementationOnce((sessionId) => {
+      harness.markProviderSession(sessionId);
+      exitPromise = harness.emitExit(sessionId);
+      return false;
+    });
+    vi.useFakeTimers();
+    try {
+      await harness.postSessions();
+      await Promise.resolve();
+      const firstAttachContext = harness.attach.mock.calls[0]?.[0];
+      expect(firstAttachContext).toBeDefined();
+      const sessionId = firstAttachContext!.sessionId;
+      expect(harness.write.mock.calls.map(([_, data]) => data)).toEqual(["Stale prompt"]);
+      await exitPromise;
+
+      await harness.resumeSession(sessionId!);
+      await vi.advanceTimersByTimeAsync(751);
+
+      expect(harness.attach).toHaveBeenCalledTimes(2);
+      expect(harness.attach.mock.calls[1]?.[0]?.sessionId).toBe(sessionId);
+      expect(harness.write.mock.calls.map(([_, data]) => data)).toEqual(["Stale prompt"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("agent session client request", () => {
@@ -99,7 +128,8 @@ function createHarness(body: Record<string, unknown>) {
   const responses: Array<{ readonly status: number; readonly body: unknown }> = [];
   let route: RouteHandler | undefined;
   let lifecycleCleanup: (() => void | Promise<void>) | undefined;
-  const attach = vi.fn(async () => {});
+  let exitCallback: ((operationId: string) => void | Promise<void>) | undefined;
+  const attach = vi.fn<TerminalRuntime["attach"]>(async () => {});
   const write = vi.fn<(sessionId: string, data: string) => boolean>(() => true);
   const terminate = vi.fn(() => true);
   const terminalRuntime: TerminalRuntime = {
@@ -112,7 +142,12 @@ function createHarness(body: Record<string, unknown>) {
     getMessagePolicy: () => ({}),
     getRenameCommand: () => undefined,
     resolveSessionIdentity: async () => null,
-    onExit: () => () => {},
+    onExit: (callback) => {
+      exitCallback = callback;
+      return () => {
+        if (exitCallback === callback) exitCallback = undefined;
+      };
+    },
     registerLaunchResolver: () => () => {},
     stop: async () => {},
   };
@@ -215,12 +250,33 @@ function createHarness(body: Record<string, unknown>) {
     responses,
     terminate,
     write,
+    emitExit: async (sessionId: string) => {
+      if (!exitCallback) throw new Error("Terminal exit callback was not registered");
+      await exitCallback(sessionId);
+    },
+    markProviderSession: (sessionId: string) => {
+      const operation = operations.find((candidate) => candidate.id === sessionId);
+      if (!operation) throw new Error(`Operation not found: ${sessionId}`);
+      operation.payload.providerSession = {
+        provider: "claude",
+        sessionId: "provider-session-1",
+        capturedAt: "2026-07-25T00:00:00.000Z",
+      };
+    },
     postSessions: async () => {
       if (!route) throw new Error("Agent route was not registered");
       await route({
         req: { method: "POST", url: "/plugins/terminal/agent/sessions" } as http.IncomingMessage,
         res: {} as http.ServerResponse,
         pathname: "/plugins/terminal/agent/sessions",
+      });
+    },
+    resumeSession: async (sessionId: string) => {
+      if (!route) throw new Error("Agent route was not registered");
+      await route({
+        req: { method: "POST", url: `/plugins/terminal/agent/sessions/${sessionId}/resume` } as http.IncomingMessage,
+        res: {} as http.ServerResponse,
+        pathname: `/plugins/terminal/agent/sessions/${sessionId}/resume`,
       });
     },
   };


### PR DESCRIPTION
## Summary
- Launch 메뉴에서 에이전트 CLI(Claude/Kimi/Codex) 선택 시 인라인 프롬프트 스텝을 제공합니다: `First prompt (optional)` 입력 후 Launch(Enter) 또는 Launch empty — Shell은 기존 즉시 기동 유지. SDK 계약은 옵셔널 필드(`OperationLaunchKind.supportsInitialPrompt`, `LaunchContext.initialPrompt`)만 추가한 하위호환 확장입니다.
- 서버는 프롬프트를 in-memory로만 보관(4000자 캡, 400 `invalid_initial_prompt`)하고, PTY 출력 정지 기반 준비 감지(800ms quiet, 15초 fallback) 후 기존 rename 주입 경로(지연 writer·sanitizer·250ms submit)로 첫 입력을 주입합니다. 세션 generation 가드로 stale 재주입을 차단하며, DTO·로그·durable state 어디에도 프롬프트를 노출하지 않습니다(plugin sensitive field + 브라우저 payload 차단 이중 방어).
- 프롬프트 스텝은 자동 포커스·Tab 포커스 트랩·Esc 1회 리스트 복귀를 지원합니다.
- 실측 근거: 기존 Launch는 CLI 4종 플랫 리스트로 입력 경로 0 — 2026-07-25 product-proposal N-1 승인분.

## Test Plan
- [x] `@fleet-plugins/terminal` typecheck/build/test green (34 files, 384 tests — 주입·검증·비노출·재시도·generation·준비감지 회귀 포함)
- [x] `@dotobokuri/fleet-console` build green + 관련 vitest(프롬프트 스텝 게이팅·포커스 순환) green
- [x] sentinel 보안 리뷰: 결함 2건(stale 재시도 타이머·포커스 트랩) 수정 완료, DTO 비노출·sanitizer(ESC/C0/C1 제거)·캡 방어 확인
- [x] 실브라우저 종단 검증(실제 Claude Code 기동): 프롬프트 주입→제출→응답(SEAWORTHY)→auto-name까지 확인, 부팅 레이스로 인한 제출 유실은 준비 감지 게이팅으로 해소(스크린샷 증거)
- [x] Changelog: `.changelog.d/pr-372.md` 추가 완료 (fleet-console/fleet-plugin 양 그룹, EN/KO 병기, `--check` 검증 통과)
