### PR TITLE
feat(console): give each rail panel its own width and keyboard resize

### DIFF
--- a/.changelog.d/pr-373.md
+++ b/.changelog.d/pr-373.md
@@ -5,5 +5,5 @@
 #### Changed
 - [fleet-console] Remember Activity Rail width per panel instead of sharing one width across every panel, so widening Repository no longer leaves Alerts occupying the same space and shrinking the map.
   ko: Activity Rail 폭을 모든 패널이 공유하지 않고 패널별로 기억합니다. Repository를 넓혀도 Alerts가 같은 폭을 차지해 맵을 좁히는 일이 없어집니다.
-- [fleet-console] Open each Activity Rail panel at its own default width, using Repository, Codex and Shell at 420px and Plans, Files and Skills at 360px.
-  ko: Activity Rail 패널을 각자의 기본 폭으로 엽니다. Repository·Codex·Shell은 420px, Plans·Files·Skills는 360px입니다.
+- [fleet-console] Open each Activity Rail panel at its own default width, using Repository and Codex at 420px and Plans, Files and Skills at 360px.
+  ko: Activity Rail 패널을 각자의 기본 폭으로 엽니다. Repository·Codex는 420px, Plans·Files·Skills는 360px입니다.

--- a/.changelog.d/pr-373.md
+++ b/.changelog.d/pr-373.md
@@ -1,0 +1,9 @@
+### fleet-console
+#### Added
+- [fleet-console] Make the Activity Rail resize handle keyboard operable as a focusable separator, with Arrow keys resizing by 16px, Shift+Arrow by 64px, and Home/End jumping to the minimum and maximum width.
+  ko: Activity Rail 리사이즈 핸들을 포커스 가능한 separator로 만들어 키보드로 조작할 수 있게 합니다. 화살표 키는 16px, Shift+화살표는 64px씩 조절하고 Home/End는 최소·최대 폭으로 이동합니다.
+#### Changed
+- [fleet-console] Remember Activity Rail width per panel instead of sharing one width across every panel, so widening Repository no longer leaves Alerts occupying the same space and shrinking the map.
+  ko: Activity Rail 폭을 모든 패널이 공유하지 않고 패널별로 기억합니다. Repository를 넓혀도 Alerts가 같은 폭을 차지해 맵을 좁히는 일이 없어집니다.
+- [fleet-console] Open each Activity Rail panel at its own default width, using Repository, Codex and Shell at 420px and Plans, Files and Skills at 360px.
+  ko: Activity Rail 패널을 각자의 기본 폭으로 엽니다. Repository·Codex·Shell은 420px, Plans·Files·Skills는 360px입니다.

--- a/runtime/fleet-console/core/client/src/rail/codex-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/codex-panel.tsx
@@ -27,6 +27,7 @@ interface CodexWorkspaceState {
 export const codexPanel: RailPanelDescriptor = {
   id: "codex",
   title: "Codex",
+  defaultWidth: 420,
   icon: () => <CodexIcon />,
   render: (ctx) => <CodexRailPanel theaterId={ctx.theaterId} />,
 };

--- a/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
@@ -59,6 +59,7 @@ const PLANS_EXTRA_WIDTH = 360;
 export const plansPanel: RailPanelDescriptor = {
   id: "plans",
   title: "Plans",
+  defaultWidth: 360,
   icon: PlansIcon,
   render: (ctx) => <PlansPanel {...ctx} />,
 };

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -116,6 +116,7 @@ export function RightRail({ theaterId, api }: RightRailProps) {
     const storedWidths = readStoredPanelWidthsWithLegacyMigration(activePanel?.id ?? null, maxPanelWidth);
     return resolvePanelWidth(activeId, activePanel?.defaultWidth, maxPanelWidth, storedWidths);
   });
+  const desiredWidthRef = useRef(panelWidth);
   const panelWidthRef = useRef(panelWidth);
   const [isDragging, setIsDragging] = useState(false);
   const [isSwitching, setIsSwitching] = useState(false);
@@ -127,16 +128,18 @@ export function RightRail({ theaterId, api }: RightRailProps) {
       : readStoredPanelWidths();
     if (canMigrate) migrationPendingRef.current = false;
     const next = resolvePanelWidth(activeId, activePanel?.defaultWidth, maxPanelWidth, storedWidths);
+    desiredWidthRef.current = next;
     panelWidthRef.current = next;
     setPanelWidthState(next);
   }, [activeId, activePanel?.id, activePanel?.defaultWidth]);
 
   useLayoutEffect(() => {
-    const next = Math.max(MIN_PANEL_WIDTH, Math.min(maxPanelWidth, panelWidthRef.current));
+    const desiredWidth = isDragging ? panelWidthRef.current : desiredWidthRef.current;
+    const next = Math.max(MIN_PANEL_WIDTH, Math.min(maxPanelWidth, desiredWidth));
     if (next === panelWidthRef.current) return;
     panelWidthRef.current = next;
     setPanelWidthState(next);
-  }, [maxPanelWidth]);
+  }, [isDragging, maxPanelWidth]);
 
   useLayoutEffect(() => {
     if (previousRailChromeExpandedRef.current && !railChromeExpanded) focusCommandBandToggleWhenPanelContainsActiveElement(rootRef.current, ".command-band-rail-toggle");
@@ -176,8 +179,9 @@ export function RightRail({ theaterId, api }: RightRailProps) {
     const onUp = () => {
       document.removeEventListener("pointermove", onMove);
       document.removeEventListener("pointerup", onUp);
+      desiredWidthRef.current = panelWidthRef.current;
       setIsDragging(false);
-      saveStoredPanelWidth(activeIdRef.current, panelWidthRef.current);
+      saveStoredPanelWidth(activeIdRef.current, desiredWidthRef.current);
     };
 
     document.addEventListener("pointermove", onMove);
@@ -208,9 +212,10 @@ export function RightRail({ theaterId, api }: RightRailProps) {
 
     event.preventDefault();
     next = Math.max(MIN_PANEL_WIDTH, Math.min(currentMaxWidth, Math.round(next)));
+    desiredWidthRef.current = next;
     panelWidthRef.current = next;
     setPanelWidthState(next);
-    saveStoredPanelWidth(activeIdRef.current, next);
+    saveStoredPanelWidth(activeIdRef.current, desiredWidthRef.current);
   }, []);
 
   const ctx: RailPanelContext = useMemo(() => ({

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -46,7 +46,7 @@ function readStoredPanelWidths(): Record<string, number> {
   return Object.create(null) as Record<string, number>;
 }
 
-function readStoredPanelWidthsWithLegacyMigration(activePanelId: string | null, maxWidth: number): Record<string, number> {
+function readStoredPanelWidthsWithLegacyMigration(activePanelId: string | null): Record<string, number> {
   const widths = readStoredPanelWidths();
   if (activePanelId === null) return widths;
 
@@ -55,7 +55,7 @@ function readStoredPanelWidthsWithLegacyMigration(activePanelId: string | null, 
     if (legacyRaw === null) return widths;
 
     const legacyWidth = Number(legacyRaw);
-    if (Number.isFinite(legacyWidth) && legacyWidth >= MIN_PANEL_WIDTH && legacyWidth <= maxWidth) {
+    if (Number.isFinite(legacyWidth) && legacyWidth >= MIN_PANEL_WIDTH) {
       widths[activePanelId] = Math.round(legacyWidth);
       localStorage.setItem(PREFS_PANEL_WIDTHS, JSON.stringify(widths));
     }
@@ -105,15 +105,17 @@ export function RightRail({ theaterId, api }: RightRailProps) {
   const activePanel = allPanels.find((p) => p.id === activeId) ?? null;
   const hasPanel = activePanel !== null;
   const extraWidth = useCodexSplitExtraWidth(activeId) + (activePanel?.preferredExtraWidth ?? 0) + useRailPanelExtraWidth();
-  const maxPanelWidth = Math.max(MIN_PANEL_WIDTH, Math.floor(window.innerWidth - 148 - extraWidth));
+  const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth);
+  const maxPanelWidth = Math.max(MIN_PANEL_WIDTH, Math.floor(viewportWidth - 148 - extraWidth));
   const extraWidthRef = useRef(extraWidth);
   extraWidthRef.current = extraWidth;
   const activeIdRef = useRef(activeId);
   activeIdRef.current = activeId;
 
   const migrationPendingRef = useRef(activePanel === null);
+  const interpretedPanelIdRef = useRef(activePanel?.id ?? null);
   const [panelWidth, setPanelWidthState] = useState(() => {
-    const storedWidths = readStoredPanelWidthsWithLegacyMigration(activePanel?.id ?? null, maxPanelWidth);
+    const storedWidths = readStoredPanelWidthsWithLegacyMigration(activePanel?.id ?? null);
     return resolvePanelWidth(activeId, activePanel?.defaultWidth, maxPanelWidth, storedWidths);
   });
   const desiredWidthRef = useRef(panelWidth);
@@ -122,16 +124,36 @@ export function RightRail({ theaterId, api }: RightRailProps) {
   const [isSwitching, setIsSwitching] = useState(false);
 
   useLayoutEffect(() => {
+    const onResize = () => {
+      const next = window.innerWidth;
+      setViewportWidth((current) => current === next ? current : next);
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  useLayoutEffect(() => {
+    const nextPanelId = activePanel?.id ?? null;
+    if (interpretedPanelIdRef.current === nextPanelId) {
+      if (isDragging || activePanel === null || activeId === null) return;
+      const rememberedWidth = readStoredPanelWidths()[activeId];
+      if (rememberedWidth === undefined || rememberedWidth > maxPanelWidth || rememberedWidth === desiredWidthRef.current) return;
+      desiredWidthRef.current = rememberedWidth;
+      panelWidthRef.current = rememberedWidth;
+      setPanelWidthState(rememberedWidth);
+      return;
+    }
+    interpretedPanelIdRef.current = nextPanelId;
     const canMigrate = activePanel !== null;
     const storedWidths = migrationPendingRef.current && canMigrate
-      ? readStoredPanelWidthsWithLegacyMigration(activeId, maxPanelWidth)
+      ? readStoredPanelWidthsWithLegacyMigration(activeId)
       : readStoredPanelWidths();
     if (canMigrate) migrationPendingRef.current = false;
     const next = resolvePanelWidth(activeId, activePanel?.defaultWidth, maxPanelWidth, storedWidths);
     desiredWidthRef.current = next;
     panelWidthRef.current = next;
     setPanelWidthState(next);
-  }, [activeId, activePanel?.id, activePanel?.defaultWidth]);
+  }, [activeId, activePanel?.id, activePanel?.defaultWidth, isDragging, maxPanelWidth]);
 
   useLayoutEffect(() => {
     const desiredWidth = isDragging ? panelWidthRef.current : desiredWidthRef.current;

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -18,7 +18,8 @@ interface RightRailProps {
 
 const MIN_PANEL_WIDTH = 240;
 const DEFAULT_PANEL_WIDTH = 312;
-const PREFS_PANEL_WIDTH = "fleet-console.rail.panelWidth";
+const PREFS_PANEL_WIDTHS = "fleet-console.rail.panelWidths";
+const LEGACY_PREFS_PANEL_WIDTH = "fleet-console.rail.panelWidth";
 const FALLBACK_THEATER_LABEL = "Theater";
 const OVERLAY_ALPHA_PRESETS: readonly { readonly label: string; readonly value: RailOverlayAlpha }[] = [
   { label: "Solid", value: 100 },
@@ -27,15 +28,62 @@ const OVERLAY_ALPHA_PRESETS: readonly { readonly label: string; readonly value: 
   { label: "60", value: 60 },
 ];
 
-function readStoredPanelWidth(): number {
+function readStoredPanelWidths(): Record<string, number> {
   try {
-    const v = localStorage.getItem(PREFS_PANEL_WIDTH);
-    if (v !== null) {
-      const n = parseInt(v, 10);
-      if (!isNaN(n) && n >= MIN_PANEL_WIDTH) return n;
+    const raw = localStorage.getItem(PREFS_PANEL_WIDTHS);
+    if (raw === null) return Object.create(null) as Record<string, number>;
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return Object.create(null) as Record<string, number>;
+
+    const widths: Record<string, number> = Object.create(null);
+    for (const [panelId, width] of Object.entries(parsed)) {
+      if (typeof width === "number" && Number.isFinite(width) && width >= MIN_PANEL_WIDTH) {
+        widths[panelId] = Math.round(width);
+      }
     }
+    return widths;
   } catch { /* ignore */ }
-  return DEFAULT_PANEL_WIDTH;
+  return Object.create(null) as Record<string, number>;
+}
+
+function readStoredPanelWidthsWithLegacyMigration(activePanelId: string | null, maxWidth: number): Record<string, number> {
+  const widths = readStoredPanelWidths();
+  if (activePanelId === null) return widths;
+
+  try {
+    const legacyRaw = localStorage.getItem(LEGACY_PREFS_PANEL_WIDTH);
+    if (legacyRaw === null) return widths;
+
+    const legacyWidth = Number(legacyRaw);
+    if (Number.isFinite(legacyWidth) && legacyWidth >= MIN_PANEL_WIDTH && legacyWidth <= maxWidth) {
+      widths[activePanelId] = Math.round(legacyWidth);
+      localStorage.setItem(PREFS_PANEL_WIDTHS, JSON.stringify(widths));
+    }
+    localStorage.removeItem(LEGACY_PREFS_PANEL_WIDTH);
+  } catch { /* ignore */ }
+  return widths;
+}
+
+function resolvePanelWidth(
+  activePanelId: string | null,
+  defaultWidth: number | undefined,
+  maxWidth: number,
+  storedWidths: Record<string, number>,
+): number {
+  const rememberedWidth = activePanelId === null ? undefined : storedWidths[activePanelId];
+  if (rememberedWidth !== undefined && rememberedWidth >= MIN_PANEL_WIDTH && rememberedWidth <= maxWidth) {
+    return rememberedWidth;
+  }
+  return Math.max(MIN_PANEL_WIDTH, Math.min(maxWidth, Math.round(defaultWidth ?? DEFAULT_PANEL_WIDTH)));
+}
+
+function saveStoredPanelWidth(activePanelId: string | null, width: number): void {
+  if (activePanelId === null) return;
+  try {
+    const widths = readStoredPanelWidths();
+    widths[activePanelId] = Math.round(width);
+    localStorage.setItem(PREFS_PANEL_WIDTHS, JSON.stringify(widths));
+  } catch { /* ignore */ }
 }
 
 export function RightRail({ theaterId, api }: RightRailProps) {
@@ -57,13 +105,38 @@ export function RightRail({ theaterId, api }: RightRailProps) {
   const activePanel = allPanels.find((p) => p.id === activeId) ?? null;
   const hasPanel = activePanel !== null;
   const extraWidth = useCodexSplitExtraWidth(activeId) + (activePanel?.preferredExtraWidth ?? 0) + useRailPanelExtraWidth();
+  const maxPanelWidth = Math.max(MIN_PANEL_WIDTH, Math.floor(window.innerWidth - 148 - extraWidth));
   const extraWidthRef = useRef(extraWidth);
   extraWidthRef.current = extraWidth;
+  const activeIdRef = useRef(activeId);
+  activeIdRef.current = activeId;
 
-  const [panelWidth, setPanelWidthState] = useState(readStoredPanelWidth);
+  const migrationPendingRef = useRef(activePanel === null);
+  const [panelWidth, setPanelWidthState] = useState(() => {
+    const storedWidths = readStoredPanelWidthsWithLegacyMigration(activePanel?.id ?? null, maxPanelWidth);
+    return resolvePanelWidth(activeId, activePanel?.defaultWidth, maxPanelWidth, storedWidths);
+  });
   const panelWidthRef = useRef(panelWidth);
   const [isDragging, setIsDragging] = useState(false);
   const [isSwitching, setIsSwitching] = useState(false);
+
+  useLayoutEffect(() => {
+    const canMigrate = activePanel !== null;
+    const storedWidths = migrationPendingRef.current && canMigrate
+      ? readStoredPanelWidthsWithLegacyMigration(activeId, maxPanelWidth)
+      : readStoredPanelWidths();
+    if (canMigrate) migrationPendingRef.current = false;
+    const next = resolvePanelWidth(activeId, activePanel?.defaultWidth, maxPanelWidth, storedWidths);
+    panelWidthRef.current = next;
+    setPanelWidthState(next);
+  }, [activeId, activePanel?.id, activePanel?.defaultWidth]);
+
+  useLayoutEffect(() => {
+    const next = Math.max(MIN_PANEL_WIDTH, Math.min(maxPanelWidth, panelWidthRef.current));
+    if (next === panelWidthRef.current) return;
+    panelWidthRef.current = next;
+    setPanelWidthState(next);
+  }, [maxPanelWidth]);
 
   useLayoutEffect(() => {
     if (previousRailChromeExpandedRef.current && !railChromeExpanded) focusCommandBandToggleWhenPanelContainsActiveElement(rootRef.current, ".command-band-rail-toggle");
@@ -94,8 +167,8 @@ export function RightRail({ theaterId, api }: RightRailProps) {
 
     const onMove = (ev: PointerEvent) => {
       const dx = startX - ev.clientX;
-      const maxWidth = window.innerWidth - 148 - extraWidthRef.current;
-      const next = Math.max(MIN_PANEL_WIDTH, Math.min(maxWidth, startWidth + dx));
+      const maxWidth = Math.max(MIN_PANEL_WIDTH, Math.floor(window.innerWidth - 148 - extraWidthRef.current));
+      const next = Math.max(MIN_PANEL_WIDTH, Math.min(maxWidth, Math.round(startWidth + dx)));
       panelWidthRef.current = next;
       setPanelWidthState(next);
     };
@@ -104,11 +177,40 @@ export function RightRail({ theaterId, api }: RightRailProps) {
       document.removeEventListener("pointermove", onMove);
       document.removeEventListener("pointerup", onUp);
       setIsDragging(false);
-      try { localStorage.setItem(PREFS_PANEL_WIDTH, String(panelWidthRef.current)); } catch { /* ignore */ }
+      saveStoredPanelWidth(activeIdRef.current, panelWidthRef.current);
     };
 
     document.addEventListener("pointermove", onMove);
     document.addEventListener("pointerup", onUp);
+  }, []);
+
+  const handleResizeKeyDown = useCallback((event: React.KeyboardEvent) => {
+    let next: number;
+    const step = event.shiftKey ? 64 : 16;
+    const currentMaxWidth = Math.max(MIN_PANEL_WIDTH, Math.floor(window.innerWidth - 148 - extraWidthRef.current));
+
+    switch (event.key) {
+      case "ArrowLeft":
+        next = panelWidthRef.current + step;
+        break;
+      case "ArrowRight":
+        next = panelWidthRef.current - step;
+        break;
+      case "Home":
+        next = MIN_PANEL_WIDTH;
+        break;
+      case "End":
+        next = currentMaxWidth;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    next = Math.max(MIN_PANEL_WIDTH, Math.min(currentMaxWidth, Math.round(next)));
+    panelWidthRef.current = next;
+    setPanelWidthState(next);
+    saveStoredPanelWidth(activeIdRef.current, next);
   }, []);
 
   const ctx: RailPanelContext = useMemo(() => ({
@@ -136,11 +238,19 @@ export function RightRail({ theaterId, api }: RightRailProps) {
           ? { "--right-rail-overlay-alpha": overlayAlpha / 100 } as CSSProperties
           : undefined}
       >
-        {hasPanel && (
+        {activePanel && (
           <div
             className="right-rail-resize-handle"
             onPointerDown={handleResizeDragStart}
-            aria-hidden="true"
+            onKeyDown={handleResizeKeyDown}
+            role="separator"
+            aria-orientation="vertical"
+            tabIndex={0}
+            aria-label={`Resize ${activePanel.title} panel`}
+            aria-controls={`rail-panel-${activePanel.id}`}
+            aria-valuenow={Math.round(panelWidth)}
+            aria-valuemin={MIN_PANEL_WIDTH}
+            aria-valuemax={maxPanelWidth}
           />
         )}
         {activePanel && (
@@ -216,7 +326,7 @@ const RailPanelContent = memo(function RailPanelContent({ activePanel, activeId,
           ✕
         </button>
       </div>
-      <div className="right-rail-panel-body" role="tabpanel" aria-labelledby={`rail-tab-${activeId}`}>
+      <div id={`rail-panel-${activePanel.id}`} className="right-rail-panel-body" role="tabpanel" aria-labelledby={`rail-tab-${activeId}`}>
         {activePanel.render(ctx)}
       </div>
     </>

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -296,6 +296,12 @@
   background: color-mix(in oklch, var(--brass) 50%, transparent);
 }
 
+.right-rail-resize-handle:focus-visible {
+  outline: 2px solid var(--brass);
+  outline-offset: -2px;
+  background: color-mix(in oklch, var(--brass) 50%, transparent);
+}
+
 .right-rail.is-dragging .right-rail-resize-handle {
   background: color-mix(in oklch, var(--brass) 70%, transparent);
 }
@@ -349,7 +355,8 @@
   }
 
   .right-rail-ico,
-  .right-rail-float-toggle {
+  .right-rail-float-toggle,
+  .right-rail-resize-handle {
     transition-duration: 0.01ms !important;
   }
 }

--- a/runtime/fleet-console/sdk/rail/types.ts
+++ b/runtime/fleet-console/sdk/rail/types.ts
@@ -27,5 +27,6 @@ export interface RailPanelDescriptor {
   readonly side?: "right";
   /** @deprecated Core ignores this field; every panel is Theater-root scoped. */
   readonly pathAware?: boolean;
+  readonly defaultWidth?: number;
   readonly preferredExtraWidth?: number;
 }

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -162,6 +162,20 @@ describe("Right Rail panel width", () => {
     expect(storedPanelWidths()).toEqual({ plans: 402 });
   });
 
+  it("restores the desired width when capacity returns without persisting the temporary clamp", () => {
+    window.localStorage.setItem("fleet-console.rail.panelWidths", JSON.stringify({ plans: 900 }));
+    renderRail();
+    expect(reportedPanelWidth()).toBe(900);
+
+    act(() => requestRailPanelExtraWidth("plans", 360));
+    expect(reportedPanelWidth()).toBe(692);
+    expect(storedPanelWidths()).toEqual({ plans: 900 });
+
+    act(() => requestRailPanelExtraWidth("plans", null));
+    expect(reportedPanelWidth()).toBe(900);
+    expect(storedPanelWidths()).toEqual({ plans: 900 });
+  });
+
   it("exposes separator values and persists keyboard resizing with the right-rail direction", () => {
     renderRail();
     const handle = resizeHandle();

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -5,12 +5,34 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../core/client/src/rail/built-in-panels.js", () => ({
-  BUILT_IN_RAIL_PANELS: [{
-    id: "plans",
-    title: "PLANS",
-    icon: "P",
-    render: () => null,
-  }],
+  BUILT_IN_RAIL_PANELS: [
+    {
+      id: "plans",
+      title: "PLANS",
+      defaultWidth: 360,
+      icon: "P",
+      render: () => null,
+    },
+    {
+      id: "codex",
+      title: "CODEX",
+      defaultWidth: 420,
+      icon: "C",
+      render: () => null,
+    },
+    {
+      id: "alerts",
+      title: "ALERTS",
+      icon: "A",
+      render: () => null,
+    },
+    {
+      id: "__proto__",
+      title: "SPECIAL",
+      icon: "S",
+      render: () => null,
+    },
+  ],
 }));
 
 vi.mock("../core/client/src/rail/rail-registry.js", () => ({
@@ -24,6 +46,7 @@ vi.mock("../core/client/src/rail/use-codex-split-extra-width.js", () => ({
 import { RightRail } from "../core/client/src/rail/right-rail.js";
 import {
   getRailStoreSnapshot,
+  requestRailPanelExtraWidth,
   setActiveRailPanel,
   setRailOverlayAlpha,
   setRailPanelBehavior,
@@ -35,8 +58,10 @@ let root: Root;
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 beforeEach(() => {
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: 1200 });
   window.localStorage.clear();
   setActiveRailPanel("plans");
+  requestRailPanelExtraWidth("plans", null);
   setRailPanelBehavior("push");
   setRailOverlayAlpha(100);
   container = document.createElement("div");
@@ -78,6 +103,145 @@ describe("Right Rail overlay opacity presets", () => {
   });
 });
 
+describe("Right Rail panel width", () => {
+  it("resolves remembered width before descriptor defaultWidth and the 312 fallback", () => {
+    window.localStorage.setItem("fleet-console.rail.panelWidths", JSON.stringify({ plans: 508 }));
+    renderRail();
+    expect(renderedPanelWidth()).toBe(508);
+
+    act(() => setActiveRailPanel("codex"));
+    expect(renderedPanelWidth()).toBe(420);
+
+    act(() => setActiveRailPanel("alerts"));
+    expect(renderedPanelWidth()).toBe(312);
+  });
+
+  it("switches immediately between each panel's remembered or default width", () => {
+    window.localStorage.setItem("fleet-console.rail.panelWidths", JSON.stringify({ plans: 480, alerts: 288 }));
+    renderRail();
+    expect(renderedPanelWidth()).toBe(480);
+
+    act(() => setActiveRailPanel("alerts"));
+    expect(renderedPanelWidth()).toBe(288);
+
+    act(() => setActiveRailPanel("plans"));
+    expect(renderedPanelWidth()).toBe(480);
+  });
+
+  it("persists the active panel width at drag end", () => {
+    renderRail();
+    const handle = resizeHandle();
+
+    act(() => {
+      handle.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, clientX: 600 }));
+      document.dispatchEvent(new MouseEvent("pointermove", { bubbles: true, clientX: 500 }));
+      document.dispatchEvent(new MouseEvent("pointerup", { bubbles: true }));
+    });
+
+    expect(renderedPanelWidth()).toBe(460);
+    expect(storedPanelWidths()).toEqual({ plans: 460 });
+  });
+
+  it("keeps the in-progress drag width when extra width changes and clamps only to reduced capacity", () => {
+    renderRail();
+    const handle = resizeHandle();
+
+    act(() => {
+      handle.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, clientX: 600 }));
+      document.dispatchEvent(new MouseEvent("pointermove", { bubbles: true, clientX: 400 }));
+    });
+    expect(reportedPanelWidth()).toBe(560);
+
+    act(() => requestRailPanelExtraWidth("plans", 300));
+    expect(reportedPanelWidth()).toBe(560);
+
+    act(() => requestRailPanelExtraWidth("plans", 650));
+    expect(reportedPanelWidth()).toBe(402);
+
+    act(() => document.dispatchEvent(new MouseEvent("pointerup", { bubbles: true })));
+    expect(storedPanelWidths()).toEqual({ plans: 402 });
+  });
+
+  it("exposes separator values and persists keyboard resizing with the right-rail direction", () => {
+    renderRail();
+    const handle = resizeHandle();
+    expect(handle).toMatchObject({
+      tabIndex: 0,
+    });
+    expect(handle.getAttribute("role")).toBe("separator");
+    expect(handle.getAttribute("aria-orientation")).toBe("vertical");
+    expect(handle.getAttribute("aria-label")).toBe("Resize PLANS panel");
+    expect(handle.getAttribute("aria-controls")).toBe("rail-panel-plans");
+    expect(document.getElementById(handle.getAttribute("aria-controls")!)).toBe(panelBody());
+    expect(handle.getAttribute("aria-valuemin")).toBe("240");
+    expect(handle.getAttribute("aria-valuemax")).toBe("1052");
+    expect(handle.getAttribute("aria-valuenow")).toBe("360");
+
+    expect(dispatchResizeKey(handle, "ArrowLeft")).toBe(false);
+    expect(renderedPanelWidth()).toBe(376);
+    expect(storedPanelWidths()).toEqual({ plans: 376 });
+
+    expect(dispatchResizeKey(handle, "ArrowRight", true)).toBe(false);
+    expect(renderedPanelWidth()).toBe(312);
+
+    dispatchResizeKey(handle, "Home");
+    expect(renderedPanelWidth()).toBe(240);
+
+    dispatchResizeKey(handle, "End");
+    expect(renderedPanelWidth()).toBe(1052);
+    expect(handle.getAttribute("aria-valuenow")).toBe("1052");
+    expect(storedPanelWidths()).toEqual({ plans: 1052 });
+  });
+
+  it("migrates the legacy width once to the active panel and removes the legacy key", () => {
+    window.localStorage.setItem("fleet-console.rail.panelWidth", "500");
+    const removeItem = vi.spyOn(Storage.prototype, "removeItem");
+    renderRail();
+
+    expect(renderedPanelWidth()).toBe(500);
+    expect(storedPanelWidths()).toEqual({ plans: 500 });
+    expect(window.localStorage.getItem("fleet-console.rail.panelWidth")).toBeNull();
+
+    act(() => setActiveRailPanel("alerts"));
+    expect(removeItem.mock.calls.filter(([key]) => key === "fleet-console.rail.panelWidth")).toHaveLength(1);
+  });
+
+  it("preserves legacy width for a missing descriptor and migrates after a valid panel becomes active", () => {
+    setActiveRailPanel("missing-plugin");
+    window.localStorage.setItem("fleet-console.rail.panelWidth", "640");
+    renderRail();
+
+    expect(window.localStorage.getItem("fleet-console.rail.panelWidth")).toBe("640");
+    expect(window.localStorage.getItem("fleet-console.rail.panelWidths")).toBeNull();
+
+    act(() => setActiveRailPanel("plans"));
+    expect(renderedPanelWidth()).toBe(640);
+    expect(storedPanelWidths()).toEqual({ plans: 640 });
+    expect(window.localStorage.getItem("fleet-console.rail.panelWidth")).toBeNull();
+  });
+
+  it("stores a special panel id from an empty width record", () => {
+    setActiveRailPanel("__proto__");
+    renderRail();
+
+    dispatchResizeKey(resizeHandle(), "ArrowLeft");
+    const stored = storedPanelWidths();
+    expect(Object.prototype.hasOwnProperty.call(stored, "__proto__")).toBe(true);
+    expect(stored["__proto__"]).toBe(328);
+  });
+
+  it.each([
+    ["non-JSON record", "not-json"],
+    ["non-number width", JSON.stringify({ plans: "wide" })],
+    ["below-minimum width", JSON.stringify({ plans: 200 })],
+    ["above-maximum width", JSON.stringify({ plans: 1100 })],
+  ])("falls back without crashing for a corrupted %s", (_label, stored) => {
+    window.localStorage.setItem("fleet-console.rail.panelWidths", stored);
+    expect(() => renderRail()).not.toThrow();
+    expect(renderedPanelWidth()).toBe(360);
+  });
+});
+
 function renderRail(): void {
   act(() => {
     root.render(<RightRail theaterId={null} api={{} as never} />);
@@ -88,4 +252,43 @@ function panelSlot(): HTMLDivElement {
   const slot = container.querySelector<HTMLDivElement>(".right-rail-panel-slot");
   expect(slot).not.toBeNull();
   return slot!;
+}
+
+function panelBody(): HTMLDivElement {
+  const body = container.querySelector<HTMLDivElement>(".right-rail-panel-body");
+  expect(body).not.toBeNull();
+  return body!;
+}
+
+function renderedPanelWidth(): number {
+  const rail = container.querySelector<HTMLElement>(".right-rail");
+  expect(rail).not.toBeNull();
+  return Number.parseInt(rail!.style.getPropertyValue("--right-rail-panel-width"), 10);
+}
+
+function resizeHandle(): HTMLDivElement {
+  const handle = container.querySelector<HTMLDivElement>(".right-rail-resize-handle");
+  expect(handle).not.toBeNull();
+  return handle!;
+}
+
+function reportedPanelWidth(): number {
+  return Number(resizeHandle().getAttribute("aria-valuenow"));
+}
+
+function dispatchResizeKey(handle: HTMLElement, key: string, shiftKey = false): boolean {
+  let result = true;
+  act(() => {
+    result = handle.dispatchEvent(new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key,
+      shiftKey,
+    }));
+  });
+  return result;
+}
+
+function storedPanelWidths(): Record<string, number> {
+  return JSON.parse(window.localStorage.getItem("fleet-console.rail.panelWidths") ?? "{}") as Record<string, number>;
 }

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -176,6 +176,22 @@ describe("Right Rail panel width", () => {
     expect(storedPanelWidths()).toEqual({ plans: 900 });
   });
 
+  it("updates ARIA capacity on viewport resize and restores the desired width without persisting the clamp", () => {
+    window.localStorage.setItem("fleet-console.rail.panelWidths", JSON.stringify({ plans: 900 }));
+    renderRail();
+    expect(reportedPanelWidth()).toBe(900);
+
+    resizeViewport(1000);
+    expect(resizeHandle().getAttribute("aria-valuemax")).toBe("852");
+    expect(reportedPanelWidth()).toBe(852);
+    expect(storedPanelWidths()).toEqual({ plans: 900 });
+
+    resizeViewport(1200);
+    expect(resizeHandle().getAttribute("aria-valuemax")).toBe("1052");
+    expect(reportedPanelWidth()).toBe(900);
+    expect(storedPanelWidths()).toEqual({ plans: 900 });
+  });
+
   it("exposes separator values and persists keyboard resizing with the right-rail direction", () => {
     renderRail();
     const handle = resizeHandle();
@@ -218,6 +234,20 @@ describe("Right Rail panel width", () => {
 
     act(() => setActiveRailPanel("alerts"));
     expect(removeItem.mock.calls.filter(([key]) => key === "fleet-console.rail.panelWidth")).toHaveLength(1);
+  });
+
+  it("preserves an oversized legacy width in the panel map and restores it when the viewport can fit it", () => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 800 });
+    window.localStorage.setItem("fleet-console.rail.panelWidth", "900");
+    renderRail();
+
+    expect(storedPanelWidths()).toEqual({ plans: 900 });
+    expect(window.localStorage.getItem("fleet-console.rail.panelWidth")).toBeNull();
+    expect(reportedPanelWidth()).toBe(360);
+
+    resizeViewport(1200);
+    expect(reportedPanelWidth()).toBe(900);
+    expect(storedPanelWidths()).toEqual({ plans: 900 });
   });
 
   it("preserves legacy width for a missing descriptor and migrates after a valid panel becomes active", () => {
@@ -288,6 +318,13 @@ function resizeHandle(): HTMLDivElement {
 
 function reportedPanelWidth(): number {
   return Number(resizeHandle().getAttribute("aria-valuenow"));
+}
+
+function resizeViewport(width: number): void {
+  act(() => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: width });
+    window.dispatchEvent(new Event("resize"));
+  });
 }
 
 function dispatchResizeKey(handle: HTMLElement, key: string, shiftKey = false): boolean {

--- a/runtime/fleet-plugins/file-explorer/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/rail-panel.tsx
@@ -22,6 +22,7 @@ const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".webp", ".gif"]);
 export const fileExplorerPanel: RailPanelDescriptor = {
   id: "file-explorer",
   title: "Files",
+  defaultWidth: 360,
   icon: FileExplorerIcon,
   render: (ctx) => <FileExplorerPanel {...ctx} />,
 };

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -519,6 +519,7 @@ function RepositoryIcon() {
 export const repositoryPanel: RailPanelDescriptor = {
   id: "repository",
   title: "Repository",
+  defaultWidth: 420,
   icon: () => <RepositoryIcon />,
   render: (ctx: RailPanelContext) => <RepositoryPanel ctx={ctx} />,
 };

--- a/runtime/fleet-plugins/skills/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/skills/client/rail-panel.tsx
@@ -144,6 +144,7 @@ function SkillsIcon() {
 export const skillsPanel: RailPanelDescriptor = {
   id: "skills",
   title: "Skills",
+  defaultWidth: 360,
   icon: SkillsIcon,
   render: (ctx: RailPanelContext) => <SkillsPanel ctx={ctx} />,
 };

--- a/runtime/fleet-plugins/terminal/client/global-shell/rail-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/global-shell/rail-panel.tsx
@@ -22,6 +22,7 @@ const PANEL_ROOT_STYLE: CSSProperties = {
 export const globalShellPanel: RailPanelDescriptor = {
   id: "global-shell",
   title: "Shell",
+  defaultWidth: 420,
   icon: TerminalGlyphIcon,
   preferredExtraWidth: GLOBAL_SHELL_EXTRA_WIDTH,
   render: (ctx: RailPanelContext) => (

--- a/runtime/fleet-plugins/terminal/client/global-shell/rail-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/global-shell/rail-panel.tsx
@@ -22,7 +22,6 @@ const PANEL_ROOT_STYLE: CSSProperties = {
 export const globalShellPanel: RailPanelDescriptor = {
   id: "global-shell",
   title: "Shell",
-  defaultWidth: 420,
   icon: TerminalGlyphIcon,
   preferredExtraWidth: GLOBAL_SHELL_EXTRA_WIDTH,
   render: (ctx: RailPanelContext) => (


### PR DESCRIPTION
## Summary

- 레일 패널 폭을 `fleet-console.rail.panelWidths`에 **패널별로** 기억합니다. 기존에는 `fleet-console.rail.panelWidth` 단일 키를 모든 패널이 공유해서, Repository를 읽으려 레일을 넓히면 Alerts 같은 한 줄짜리 패널도 같은 폭을 차지하고 맵이 눌렸습니다. 실측에서 Repository용 1083px가 Alerts로 그대로 옮겨가며 맵이 237px까지 줄었고, 이 변경 후 같은 조작에서 맵이 964px로 회복됩니다.
- 폭 결정 순서는 **기억된 폭 > descriptor의 `defaultWidth` > 312 fallback** 입니다. 기존 단일 키는 최초 로드 시 활성 패널 항목으로 1회 이관한 뒤 제거합니다. 뷰포트에 맞지 않는 기억 폭은 클램프하지 않고 `defaultWidth`로 강등되는데, 넓은 모니터에서 저장한 값이 좁은 창에서 맵을 잠식하지 않게 하려는 의도입니다.
- 패널별 기본 폭을 선언합니다 — Repository/Codex/Shell `420`, Plans/Files/Skills `360`. Alerts는 선언하지 않고 312 fallback을 씁니다.
- 리사이즈 핸들을 포커스 가능한 `role="separator"`로 승격했습니다. 기존에는 `tabIndex=-1`에 role도 접근 이름도 없어 **키보드로 도달할 수 없었습니다**. 이제 `aria-controls`로 패널 본문을 가리키고, 접근 이름이 패널 제목을 포함하며(`Resize Repository panel`), `←`/`→`로 16px, `Shift` 동반 시 64px, `Home`/`End`로 최소·최대 폭까지 조절됩니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 1030 passed (canary 기준선 1018 + 신규 12)
- [x] `pnpm --filter @fleet-plugins/{repository,file-explorer,skills,terminal} test` — 783 passed
- [x] 격리 콘솔 실브라우저 검증 — 패널별 기본 폭 6종, Repository 699px 드래그 후 Alerts 전환(맵 964px 회복) 및 복귀, 키보드 16/64/Home/End 영속, 포커스 링 `--brass`, 레거시 키 640 이관 후 제거
- [x] Changelog fragment — `.changelog.d/pr-373.md` 추가, 제품/섹션 그룹 문법과 영·한 요약 쌍 준수, `node scripts/compile-changelog-fragments.mjs --check` 통과 (17 entries validated)

### 선존 실패 (이 PR과 무관)

`origin/canary` @ 1e5fd004b 순정 상태에서 동일하게 재현되며, 이 브랜치의 실패 목록과 **테스트 이름까지 일치**합니다 (canary 7 failed / 1018 passed → 이 브랜치 7 failed / 1030 passed).

- `tests/instrument-design-contract.test.ts` 2건 (텍스트 색 3계층 토큰 문법 / 폰트 웨이트 토큰 계층)
- `tests/operations-boot-minimization.integration.test.ts` 4건 (Alt+Arrow 최소화 처리)
- `tests/server.test.ts` 1건 (Theater-bound dedicated MCP sessions)
- `typecheck` 1건 — `tests/instrument-design-contract.test.ts:138` TS2345 (`fileURLToPath`를 `map` 콜백에 직접 전달). canary에서 동일 재현