### PR TITLE
fix(console): restore the design contract and Alt navigation gates

### DIFF
--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -1760,7 +1760,7 @@
   color: var(--brass);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 600;
+  font-weight: var(--weight-medium);
   letter-spacing: 0.08em;
 }
 
@@ -1773,14 +1773,14 @@
   border-radius: var(--radius-sm);
   outline: none;
   background: var(--surface-glass);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.5;
 }
 
 .canvas-context-menu-prompt-input::placeholder {
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
 }
 
 .canvas-context-menu-prompt-input:focus-visible {
@@ -1790,7 +1790,7 @@
 
 .canvas-context-menu-prompt-hint {
   margin: 0;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 9px;
   line-height: 1.4;
@@ -1807,7 +1807,7 @@
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--ink-fog);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
 }
@@ -1817,7 +1817,7 @@
 .canvas-context-menu-prompt-button.is-primary {
   border-color: color-mix(in oklch, var(--brass) 48%, var(--surface-rim));
   background: color-mix(in oklch, var(--brass) 12%, transparent);
-  color: var(--ink-pearl);
+  color: var(--text-primary);
 }
 
 .canvas-context-menu-help {
@@ -4063,7 +4063,7 @@
   color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -4071,7 +4071,7 @@
 .operations-canvas-empty-headline {
   color: var(--text-primary);
   font-size: 15px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
 }
 
 .operations-canvas-empty-standby {
@@ -4112,7 +4112,7 @@
   color: var(--text-tertiary);
   font-family: var(--font-mono);
   font-size: 9px;
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   letter-spacing: 0.08em;
 }
 
@@ -4123,7 +4123,7 @@
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--brass) 10%, var(--surface-glass));
   color: var(--brass-bright);
-  font: 700 11px/1.2 var(--font-mono);
+  font: var(--weight-bold) 11px/1.2 var(--font-mono);
 }
 
 .operations-canvas-empty-standby-chip:hover,
@@ -4159,7 +4159,7 @@
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--ink-deep) 80%, transparent);
   color: var(--text-secondary);
-  font: 700 9px/1.2 var(--font-mono);
+  font: var(--weight-bold) 9px/1.2 var(--font-mono);
 }
 
 .operations-canvas-empty-guide {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -135,7 +135,7 @@ function listCssFiles(root: URL): string[] {
 function listProductCssFiles(): string[] {
   return [
     ...CSS_SOURCE_ROOTS.flatMap(listCssFiles),
-    ...STANDALONE_CSS_SOURCES.map(fileURLToPath),
+    ...STANDALONE_CSS_SOURCES.map((source) => fileURLToPath(source)),
   ].sort();
 }
 

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -78,7 +78,14 @@ vi.mock("../core/client/src/plugin-registry.js", () => ({ usePluginRegistry: () 
 vi.mock("../core/client/src/rail/rail-store.js", () => ({ toggleRailChrome: vi.fn() }));
 vi.mock("../core/client/src/rail/right-rail.js", () => ({ RightRail: () => null }));
 vi.mock("../core/client/src/release-notes-fetch.js", () => ({ abortReleaseNotesFetch: vi.fn(), requestReleaseNotes: vi.fn() }));
-vi.mock("../core/client/src/sidebar/operations-side-bar-store.js", () => ({ getSideBarState: () => ({ collapsed: false }), setSideBarCollapsed: vi.fn() }));
+// operations.tsx의 Alt 핸들러가 상태축 분기를 위해 이 모듈을 함께 읽으므로, 누락되면 preventDefault 이전에 던진다.
+vi.mock("../core/client/src/sidebar/operations-side-bar-store.js", () => ({
+  getSideBarState: () => ({ collapsed: false }),
+  setSideBarCollapsed: vi.fn(),
+  getSideBarStatusAxis: () => false,
+  getSideBarStatusSectionCollapsed: () => false,
+  toggleSideBarStatusAxis: vi.fn(),
+}));
 vi.mock("../core/client/src/sidebar/operations-side-bar.js", () => ({
   OperationsSideBar: ({ onClose, onFocus, onMinimize }: { readonly onClose: (operationId: string) => void; readonly onFocus: (operationId: string) => void; readonly onMinimize: (operationId: string) => void }) => {
     sideBarMocks.onFocus = onFocus;


### PR DESCRIPTION
## Summary

`canary`가 red 상태여서 후속 작업의 기준선이 무너져 있었습니다. 원인이 서로 다른 세 가지였고, 모두 사용자에게 보이는 동작 변화 없이 복구합니다.

- **디자인 계약 위반 (교차 충돌).** #370이 텍스트 색 3계층 토큰과 폰트 웨이트 토큰 계약을 조인 뒤, 그 이전에 분기한 #369·#372가 계약을 못 보고 머지되었습니다. #370이 세운 매핑 그대로 되돌립니다 — `--ink-pearl`→`--text-primary`, `--ink-fog`→`--text-tertiary`, `600`→`var(--weight-medium)`, `700`→`var(--weight-bold)`. **세 테마 모두에서 치환 전후 값이 동일**하므로 시각적 변화는 없습니다(Instrument에서는 같은 oklch 값, maritime·carbon에서는 `--text-*`가 `--ink-*`의 별칭).
- **계약 테스트 자체의 타입 오류.** `STANDALONE_CSS_SOURCES.map(fileURLToPath)`가 콜백 두 번째 인자로 배열 index를 넘겨 `fileURLToPath`의 options 자리에 들어갔습니다(TS2345). 단일 인자로 묶습니다.
- **Alt 내비게이션 테스트 4건의 모킹 누락.** #361이 Operations 페이지의 Alt 핸들러에 상태축 분기를 추가하면서 `getSideBarStatusAxis`·`getSideBarStatusSectionCollapsed`·`toggleSideBarStatusAxis`를 import했는데, 통합 테스트의 사이드바 스토어 모킹은 상태축 이전 두 export만 제공했습니다. 핸들러가 `preventDefault` 이전에 던져서 4건이 전부 "이벤트가 취소되지 않음"으로 실패했습니다. **제품 코드는 정상이며 모킹만 갱신**합니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 0 errors (이전 1 error)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 1023 passed (이전 1017), 안정 실패 7 → 1
- [x] `tests/instrument-design-contract.test.ts` 24/24, `tests/operations-boot-minimization.integration.test.ts` 27/27
- [x] 원인 커밋 이분 탐색 — Alt 내비게이션 4건은 `2a9861b2f`(#361)에서 시작(직전 `056e4295d`까지 27/27)

## 남은 실패 (이 PR 범위 밖)

- `tests/server.test.ts > … issues Theater-bound dedicated MCP sessions …` — 어설션이 도입된 `77a174516`(#353) 시점에도 이 머신에서 실패합니다. 최근 회귀가 아니며 MCP·carrier 런타임 배선 쪽 별도 조사가 필요합니다.
- `tests/api-catalog.test.ts`, `tests/carrier-settings.test.ts`, `tests/server.test.ts > … requires the exact Console Origin …` — 실서버를 띄우는 테스트로 병렬 부하에서만 간헐 실패하고 단독 실행에서는 통과합니다.

## 참고

이 저장소의 CI에는 **테스트·typecheck 게이트가 없습니다**(Changelog Fragment / Core Boundary / PR Target Guard / PR Title뿐). 위 교차 충돌이 머지될 수 있었던 구조적 이유이며, 게이트 추가 여부는 별도 판단이 필요합니다.

## Changelog

`no-changelog` — 테스트 수정과 시각 변화 없는 토큰 정합뿐입니다. 대상이 된 #369/#370/#372의 프래그먼트는 아직 `.changelog.d/`에 미릴리스 상태라, 사용자가 소비한 적 없는 동작에 대한 수정입니다.