### PR TITLE
feat(console): reach chip menus, operation actions and the file tree by keyboard

### DIFF
--- a/.changelog.d/pr-376.md
+++ b/.changelog.d/pr-376.md
@@ -1,0 +1,11 @@
+### fleet-console
+#### Added
+- [fleet-console] Open the Operation chip and Theater row context menus with Shift+F10 or the ContextMenu key, focusing the first item and returning focus to the row on Escape, so group and accent assignment no longer require a right click.
+  ko: Operation 칩과 Theater 행의 컨텍스트 메뉴를 Shift+F10 또는 ContextMenu 키로 엽니다. 첫 항목에 포커스가 가고 Escape로 닫으면 원래 행으로 돌아오므로, 그룹과 accent 지정에 더 이상 우클릭이 필요하지 않습니다.
+- [fleet-console] Add Close, Rename, Assign group, Set accent and Minimize commands for the active Operation to the command palette. Close arms the existing two-step confirmation on the sidebar chip instead of removing the session outright.
+  ko: 활성 Operation을 대상으로 하는 Close·Rename·Assign group·Set accent·Minimize 커맨드를 커맨드 팔레트에 추가합니다. Close는 세션을 바로 지우지 않고 사이드바 칩의 기존 2단 확인을 켭니다.
+
+### fleet-plugin
+#### Fixed
+- [fleet-console] Walk the Files tree with the Arrow, Home and End keys and keep a single tab stop for the whole tree, replacing a tab stop on every node.
+  ko: Files 트리를 화살표·Home·End 키로 이동할 수 있게 하고, 노드마다 멈추던 Tab을 트리 전체에서 한 번만 멈추도록 바꿉니다.

--- a/.changelog.d/pr-376.md
+++ b/.changelog.d/pr-376.md
@@ -2,8 +2,8 @@
 #### Added
 - [fleet-console] Open the Operation chip and Theater row context menus with Shift+F10 or the ContextMenu key, focusing the first item and returning focus to the row on Escape, so group and accent assignment no longer require a right click.
   ko: Operation 칩과 Theater 행의 컨텍스트 메뉴를 Shift+F10 또는 ContextMenu 키로 엽니다. 첫 항목에 포커스가 가고 Escape로 닫으면 원래 행으로 돌아오므로, 그룹과 accent 지정에 더 이상 우클릭이 필요하지 않습니다.
-- [fleet-console] Add Close, Rename, Assign group, Set accent and Minimize commands for the active Operation to the command palette. Close arms the existing two-step confirmation on the sidebar chip instead of removing the session outright.
-  ko: 활성 Operation을 대상으로 하는 Close·Rename·Assign group·Set accent·Minimize 커맨드를 커맨드 팔레트에 추가합니다. Close는 세션을 바로 지우지 않고 사이드바 칩의 기존 2단 확인을 켭니다.
+- [fleet-console] Add Rename, Assign group, Set accent and Minimize commands for the active Operation to the command palette, reaching chip menu actions that previously needed a right click.
+  ko: 활성 Operation을 대상으로 하는 Rename·Assign group·Set accent·Minimize 커맨드를 커맨드 팔레트에 추가해, 우클릭이 필요하던 칩 메뉴 동작에 닿을 수 있게 합니다.
 
 ### fleet-plugin
 #### Fixed

--- a/runtime/fleet-console/core/client/src/canvas/accent-popover.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/accent-popover.tsx
@@ -34,6 +34,8 @@ export function AccentToneList({
           type="button"
           className="accent-tone-row accent-tone-row--clear"
           role="menuitem"
+          // 키보드 진입점이 accent 섹션을 찾는 근거 — 접근 이름 문구가 바뀌어도 깨지지 않아야 한다.
+          data-accent-option="none"
           aria-label="No accent"
           aria-pressed={activeKey === null}
           onClick={() => onSelect(null)}
@@ -48,6 +50,7 @@ export function AccentToneList({
           type="button"
           className="accent-tone-row"
           role="menuitem"
+          data-accent-option={accent.key}
           aria-label={accent.label}
           aria-pressed={activeKey === accent.key}
           onClick={() => onSelect(accent.key)}

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -18,6 +18,7 @@ import { closeOperationCompletely } from "../operation-close.js";
 import { getLoadedTheaterId, ensureDefaultGeometry, forceDropCompanionOperationId, getCompanionOperationId, loadForTheater, minimizeOperations, toggleFormationView } from "../canvas/canvas-store.js";
 import { openRailPanel, setRailChromeExpanded, toggleRailChrome } from "../rail/rail-store.js";
 import { getSideBarState, setSideBarCollapsed, toggleSideBarStatusAxis } from "../sidebar/operations-side-bar-store.js";
+import { requestSideBarOperationAction, type SideBarOperationAction } from "../sidebar/operation-action-request.js";
 import {
   closeOperationSearch,
   focusOperation,
@@ -217,6 +218,16 @@ export function OperationSearch({ state, railPanels, plugins }: OperationSearchP
         openKeyboardShortcuts();
         break;
       }
+      case "rename-operation":
+      case "assign-operation-group":
+      case "set-operation-accent":
+      case "minimize-operation": {
+        previousFocusRef.current = null;
+        if (!location.pathname.startsWith("/operations")) navigate("/operations");
+        if (getSideBarState().collapsed) setSideBarCollapsed(false);
+        requestSideBarOperationAction(action.operationId, paletteActionToSideBarAction(action.kind));
+        break;
+      }
       case "whats-new": {
         openWhatsNew();
         break;
@@ -356,6 +367,17 @@ export function OperationSearch({ state, railPanels, plugins }: OperationSearchP
       </section>
     </div>
   );
+}
+
+function paletteActionToSideBarAction(
+  kind: "rename-operation" | "assign-operation-group" | "set-operation-accent" | "minimize-operation",
+): SideBarOperationAction {
+  switch (kind) {
+    case "rename-operation": return "rename";
+    case "assign-operation-group": return "assign-group";
+    case "set-operation-accent": return "set-accent";
+    case "minimize-operation": return "minimize";
+  }
 }
 
 function clampIndex(index: number, length: number): number {

--- a/runtime/fleet-console/core/client/src/palette-commands.ts
+++ b/runtime/fleet-console/core/client/src/palette-commands.ts
@@ -21,6 +21,10 @@ export type PaletteCommandAction =
   | { readonly kind: "switch-theme"; readonly theme: ThemeId }
   | { readonly kind: "open-settings" }
   | { readonly kind: "open-keyboard-shortcuts" }
+  | { readonly kind: "rename-operation"; readonly operationId: string }
+  | { readonly kind: "assign-operation-group"; readonly operationId: string }
+  | { readonly kind: "set-operation-accent"; readonly operationId: string }
+  | { readonly kind: "minimize-operation"; readonly operationId: string }
   | { readonly kind: "whats-new" };
 
 export interface PaletteCommandEntry {
@@ -47,6 +51,9 @@ export function commandModeQuery(value: string): string {
 export function buildPaletteCommands(current: ConsoleState, railPanels: readonly PaletteRailPanelInfo[]): readonly PaletteCommandEntry[] {
   const commands: PaletteCommandEntry[] = [];
   const activeTheater = current.theaters.find((theater) => theater.id === current.activeTheaterId) ?? null;
+  const activeOperation = current.operations.find(
+    (operation) => operation.id === current.activeOperationId && operation.theaterId === current.activeTheaterId,
+  ) ?? null;
   for (const theater of current.theaters) {
     commands.push({
       commandId: `switch-theater:${theater.id}`,
@@ -101,6 +108,34 @@ export function buildPaletteCommands(current: ConsoleState, railPanels: readonly
       current: false,
       action: { kind: "toggle-status-axis" },
     });
+  }
+  if (activeOperation) {
+    commands.push(
+      {
+        commandId: "rename-operation",
+        label: "Rename operation…",
+        current: false,
+        action: { kind: "rename-operation", operationId: activeOperation.id },
+      },
+      {
+        commandId: "assign-operation-group",
+        label: "Assign group…",
+        current: false,
+        action: { kind: "assign-operation-group", operationId: activeOperation.id },
+      },
+      {
+        commandId: "set-operation-accent",
+        label: "Set accent…",
+        current: false,
+        action: { kind: "set-operation-accent", operationId: activeOperation.id },
+      },
+      {
+        commandId: "minimize-operation",
+        label: "Minimize operation",
+        current: false,
+        action: { kind: "minimize-operation", operationId: activeOperation.id },
+      },
+    );
   }
   for (const panel of railPanels) {
     commands.push({

--- a/runtime/fleet-console/core/client/src/sidebar/context-menu-keyboard.ts
+++ b/runtime/fleet-console/core/client/src/sidebar/context-menu-keyboard.ts
@@ -1,11 +1,16 @@
 import { useEffect, type RefObject } from "react";
 
+import type { SideBarOperationMenuAction } from "./operation-action-request.js";
+
 const MENU_ITEM_SELECTOR = 'button[role^="menuitem"]:not(:disabled)';
+// accent 섹션 판별은 data 마커로만 한다 — 접근 이름 문구는 다듬을 수 있는 표현이라 근거로 삼으면 조용히 깨진다.
+const ACCENT_OPTION_ATTRIBUTE = "data-accent-option";
 
 interface ContextMenuKeyboardOptions {
   readonly open: boolean;
   readonly menuSelector: string;
   readonly returnFocusRef: RefObject<HTMLElement | null>;
+  readonly requestedAction?: SideBarOperationMenuAction;
   readonly onEscape: () => void;
 }
 
@@ -13,6 +18,7 @@ export function useContextMenuKeyboard({
   open,
   menuSelector,
   returnFocusRef,
+  requestedAction,
   onEscape,
 }: ContextMenuKeyboardOptions): void {
   useEffect(() => {
@@ -31,10 +37,15 @@ export function useContextMenuKeyboard({
       };
       const initialItems = items();
       if (initialItems.length > 0) {
-        setCurrent(0, false);
+        const requestedIndex = requestedAction === "set-accent"
+          ? initialItems.findIndex((item) => item.hasAttribute(ACCENT_OPTION_ATTRIBUTE))
+          : 0;
+        // 마커를 못 찾으면 첫 항목으로 안전하게 떨어진다.
+        const initialIndex = Math.max(0, requestedIndex);
+        setCurrent(initialIndex, false);
         if (returnFocusRef.current !== null) {
           focusFrame = window.requestAnimationFrame(() => {
-            if (!cancelled && menu.isConnected) setCurrent(0, true);
+            if (!cancelled && menu.isConnected) setCurrent(initialIndex, true);
           });
         }
       }
@@ -103,5 +114,5 @@ export function useContextMenuKeyboard({
       observer?.disconnect();
       cleanupMenu?.();
     };
-  }, [menuSelector, onEscape, open, returnFocusRef]);
+  }, [menuSelector, onEscape, open, requestedAction, returnFocusRef]);
 }

--- a/runtime/fleet-console/core/client/src/sidebar/context-menu-keyboard.ts
+++ b/runtime/fleet-console/core/client/src/sidebar/context-menu-keyboard.ts
@@ -1,0 +1,107 @@
+import { useEffect, type RefObject } from "react";
+
+const MENU_ITEM_SELECTOR = 'button[role^="menuitem"]:not(:disabled)';
+
+interface ContextMenuKeyboardOptions {
+  readonly open: boolean;
+  readonly menuSelector: string;
+  readonly returnFocusRef: RefObject<HTMLElement | null>;
+  readonly onEscape: () => void;
+}
+
+export function useContextMenuKeyboard({
+  open,
+  menuSelector,
+  returnFocusRef,
+  onEscape,
+}: ContextMenuKeyboardOptions): void {
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    let focusFrame: number | null = null;
+    let cleanupMenu: (() => void) | null = null;
+    const attach = () => {
+      const menu = document.querySelector<HTMLElement>(menuSelector);
+      if (!menu) return false;
+      const items = () => Array.from(menu.querySelectorAll<HTMLButtonElement>(MENU_ITEM_SELECTOR));
+      const setCurrent = (nextIndex: number, focus: boolean) => {
+        const currentItems = items();
+        for (const [index, item] of currentItems.entries()) item.tabIndex = index === nextIndex ? 0 : -1;
+        if (focus) currentItems[nextIndex]?.focus();
+      };
+      const initialItems = items();
+      if (initialItems.length > 0) {
+        setCurrent(0, false);
+        if (returnFocusRef.current !== null) {
+          focusFrame = window.requestAnimationFrame(() => {
+            if (!cancelled && menu.isConnected) setCurrent(0, true);
+          });
+        }
+      }
+
+      const handleKeyDown = (event: KeyboardEvent) => {
+        const currentItems = items();
+        if (currentItems.length === 0) return;
+        if (event.key === "Escape") {
+          event.preventDefault();
+          event.stopPropagation();
+          const returnFocus = returnFocusRef.current;
+          onEscape();
+          returnFocus?.focus();
+          return;
+        }
+        if (event.key === "Enter" && document.activeElement instanceof HTMLButtonElement && menu.contains(document.activeElement)) {
+          event.preventDefault();
+          event.stopPropagation();
+          document.activeElement.click();
+          return;
+        }
+        if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+        event.preventDefault();
+        event.stopPropagation();
+        const currentIndex = currentItems.findIndex((item) => item === document.activeElement);
+        const nextIndex = event.key === "ArrowDown"
+          ? (currentIndex + 1) % currentItems.length
+          : currentIndex <= 0 ? currentItems.length - 1 : currentIndex - 1;
+        setCurrent(nextIndex, true);
+      };
+      const handleFocusIn = (event: FocusEvent) => {
+        if (!(event.target instanceof HTMLInputElement)) return;
+        for (const item of items()) item.tabIndex = -1;
+      };
+      const contentObserver = new MutationObserver(() => {
+        const currentItems = items();
+        if (document.activeElement instanceof HTMLInputElement && menu.contains(document.activeElement)) {
+          for (const item of currentItems) item.tabIndex = -1;
+          return;
+        }
+        const currentIndex = currentItems.findIndex((item) => item.tabIndex === 0);
+        if (currentItems.length > 0) setCurrent(Math.max(0, currentIndex), false);
+      });
+
+      menu.addEventListener("keydown", handleKeyDown);
+      menu.addEventListener("focusin", handleFocusIn);
+      contentObserver.observe(menu, { childList: true, subtree: true });
+      cleanupMenu = () => {
+        menu.removeEventListener("keydown", handleKeyDown);
+        menu.removeEventListener("focusin", handleFocusIn);
+        contentObserver.disconnect();
+      };
+      return true;
+    };
+    let observer: MutationObserver | null = null;
+    if (!attach()) {
+      observer = new MutationObserver(() => {
+        if (!attach()) return;
+        observer?.disconnect();
+      });
+    }
+    observer?.observe(document.body, { childList: true, subtree: true });
+    return () => {
+      cancelled = true;
+      if (focusFrame !== null) window.cancelAnimationFrame(focusFrame);
+      observer?.disconnect();
+      cleanupMenu?.();
+    };
+  }, [menuSelector, onEscape, open, returnFocusRef]);
+}

--- a/runtime/fleet-console/core/client/src/sidebar/operation-action-request.ts
+++ b/runtime/fleet-console/core/client/src/sidebar/operation-action-request.ts
@@ -4,6 +4,8 @@ export type SideBarOperationAction =
   | "set-accent"
   | "minimize";
 
+export type SideBarOperationMenuAction = Extract<SideBarOperationAction, "assign-group" | "set-accent">;
+
 interface PendingOperationAction {
   readonly operationId: string;
   readonly action: SideBarOperationAction;

--- a/runtime/fleet-console/core/client/src/sidebar/operation-action-request.ts
+++ b/runtime/fleet-console/core/client/src/sidebar/operation-action-request.ts
@@ -1,0 +1,38 @@
+export type SideBarOperationAction =
+  | "rename"
+  | "assign-group"
+  | "set-accent"
+  | "minimize";
+
+interface PendingOperationAction {
+  readonly operationId: string;
+  readonly action: SideBarOperationAction;
+}
+
+type OperationActionListener = (request: PendingOperationAction) => boolean;
+
+let pendingRequest: PendingOperationAction | null = null;
+const listeners = new Set<OperationActionListener>();
+
+export function requestSideBarOperationAction(operationId: string, action: SideBarOperationAction): void {
+  pendingRequest = { operationId, action };
+  notifyListeners();
+}
+
+export function subscribeSideBarOperationAction(listener: OperationActionListener): () => void {
+  listeners.add(listener);
+  notifyListener(listener);
+  return () => listeners.delete(listener);
+}
+
+function notifyListeners(): void {
+  for (const listener of listeners) {
+    if (notifyListener(listener)) return;
+  }
+}
+
+function notifyListener(listener: OperationActionListener): boolean {
+  if (pendingRequest === null || !listener(pendingRequest)) return false;
+  pendingRequest = null;
+  return true;
+}

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -135,6 +135,8 @@ export function OperationsSideBarChip({
     }
     if (request.action === "assign-group" || request.action === "set-accent") {
       onDisarmClose();
+      // 팔레트로 부른 칩은 사이드바 스크롤 밖일 수 있다. rect를 읽기 전에 끌어와야 메뉴가 화면 안에 앵커링된다.
+      chip.scrollIntoView({ block: "nearest" });
       onOpenAccent(operation.id, chip.getBoundingClientRect(), chip, request.action);
       return true;
     }

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -5,7 +5,10 @@ import type { OperationActivity } from "@fleet-console/sdk/plugin";
 import { operationActivityLabel, operationActivityVisual } from "../operation-activity.js";
 import { useInlineRename } from "../use-inline-rename.js";
 import type { OperationNode } from "../types.js";
-import { subscribeSideBarOperationAction } from "./operation-action-request.js";
+import {
+  subscribeSideBarOperationAction,
+  type SideBarOperationMenuAction,
+} from "./operation-action-request.js";
 
 export interface SideBarEntry {
   readonly operation: OperationNode;
@@ -37,7 +40,12 @@ interface SideBarChipProps {
   readonly onFocus: (operationId: string) => void;
   readonly onKeyboardMove: (operationId: string, direction: -1 | 1) => void;
   readonly onPointerDragStart: (event: ReactPointerEvent<HTMLLIElement>, operationId: string) => void;
-  readonly onOpenAccent: (operationId: string, anchor: DOMRect, returnFocus?: HTMLElement | null) => void;
+  readonly onOpenAccent: (
+    operationId: string,
+    anchor: DOMRect,
+    returnFocus?: HTMLElement | null,
+    requestedAction?: SideBarOperationMenuAction,
+  ) => void;
   readonly onRename: (operationId: string, title: string) => void;
 }
 
@@ -127,7 +135,7 @@ export function OperationsSideBarChip({
     }
     if (request.action === "assign-group" || request.action === "set-accent") {
       onDisarmClose();
-      onOpenAccent(operation.id, chip.getBoundingClientRect(), chip);
+      onOpenAccent(operation.id, chip.getBoundingClientRect(), chip, request.action);
       return true;
     }
     onDisarmClose();

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -1,10 +1,11 @@
-import { useRef, type CSSProperties, type PointerEvent as ReactPointerEvent, type ReactNode, type SyntheticEvent } from "react";
+import { useEffect, useRef, type CSSProperties, type PointerEvent as ReactPointerEvent, type ReactNode, type SyntheticEvent } from "react";
 
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
 
 import { operationActivityLabel, operationActivityVisual } from "../operation-activity.js";
 import { useInlineRename } from "../use-inline-rename.js";
 import type { OperationNode } from "../types.js";
+import { subscribeSideBarOperationAction } from "./operation-action-request.js";
 
 export interface SideBarEntry {
   readonly operation: OperationNode;
@@ -36,7 +37,7 @@ interface SideBarChipProps {
   readonly onFocus: (operationId: string) => void;
   readonly onKeyboardMove: (operationId: string, direction: -1 | 1) => void;
   readonly onPointerDragStart: (event: ReactPointerEvent<HTMLLIElement>, operationId: string) => void;
-  readonly onOpenAccent: (operationId: string, anchor: DOMRect) => void;
+  readonly onOpenAccent: (operationId: string, anchor: DOMRect, returnFocus?: HTMLElement | null) => void;
   readonly onRename: (operationId: string, title: string) => void;
 }
 
@@ -63,6 +64,7 @@ export function OperationsSideBarChip({
   onOpenAccent,
   onRename,
 }: SideBarChipProps) {
+  const chipRef = useRef<HTMLLIElement | null>(null);
   const suppressClickRef = useRef(false);
   const { operation, active, minimized, notificationCount, status } = entry;
   const title = displayTitle(operation);
@@ -114,13 +116,35 @@ export function OperationsSideBarChip({
     onOpenAccent(operation.id, event.currentTarget.getBoundingClientRect());
   };
 
+  useEffect(() => subscribeSideBarOperationAction((request) => {
+    if (request.operationId !== operation.id || preview) return false;
+    const chip = chipRef.current;
+    if (!chip) return false;
+    if (chip.closest("[inert]")) return false;
+    if (request.action === "rename") {
+      rename.begin();
+      return true;
+    }
+    if (request.action === "assign-group" || request.action === "set-accent") {
+      onDisarmClose();
+      onOpenAccent(operation.id, chip.getBoundingClientRect(), chip);
+      return true;
+    }
+    onDisarmClose();
+    onMinimize(operation.id);
+    chip.focus();
+    return true;
+  }), [onDisarmClose, onMinimize, onOpenAccent, operation.id, preview, rename]);
+
   return (
     <li
+      ref={chipRef}
       data-side-bar-chip-id={operation.id}
       data-reorder-enabled={reorderEnabled ? "true" : "false"}
       className={chipClassName}
       role="button"
       tabIndex={0}
+      aria-haspopup={preview ? undefined : "menu"}
       aria-label={chipAriaLabel}
       aria-current={active ? "true" : undefined}
       title={preview ? "Click to open in its Theater" : active ? "Focused · double-click to rename · right-click to set accent" : "Click to focus · double-click to rename · right-click to set accent"}
@@ -140,6 +164,12 @@ export function OperationsSideBarChip({
         if (!preview && reorderEnabled && event.altKey && event.shiftKey && (event.key === "ArrowUp" || event.key === "ArrowDown")) {
           event.preventDefault();
           onKeyboardMove(operation.id, event.key === "ArrowUp" ? -1 : 1);
+          return;
+        }
+        if (!preview && (event.key === "ContextMenu" || (event.shiftKey && event.key === "F10"))) {
+          event.preventDefault();
+          onDisarmClose();
+          onOpenAccent(operation.id, event.currentTarget.getBoundingClientRect(), event.currentTarget);
           return;
         }
         if (event.key === "Enter" || event.key === " ") {

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -16,12 +16,15 @@ import { consumeOperationLaunchMenu, consumeSideBarAddTheater, consumeSideBarThe
 import { resolveOperationActivity } from "../operation-activity.js";
 import { SideBarBrandFoot } from "../components/side-bar-brand-foot.js";
 import { applyVisibleReorder, groupDropIndexFromPoint, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderGroupIds, reorderTheaterIds, reorderWithinSegment, theaterDropIndexFromPoint, type DropSectionInfo } from "./operations-side-bar-hit-test.js";
+import { useContextMenuKeyboard } from "./context-menu-keyboard.js";
+import { subscribeSideBarOperationAction } from "./operation-action-request.js";
 import { OperationsSideBarChip, type SideBarEntry } from "./operations-side-bar-chip.js";
 import { OperationsSideBarGroupHeader } from "./operations-side-bar-group-header.js";
 import {
   setSideBarCollapsed,
   setSideBarWidth,
   setTheaterCollapsed,
+  getSideBarStatusSectionCollapsed,
   toggleSideBarStatusAxis,
   toggleSideBarStatusSectionCollapsed,
   useCollapsedTheaters,
@@ -65,9 +68,9 @@ interface OperationsSideBarProps {
 }
 
 type ActiveContextMenu =
-  | { readonly kind: "chip"; readonly operationId: string; readonly anchor: DOMRect }
-  | { readonly kind: "group"; readonly groupId: string; readonly anchor: DOMRect }
-  | { readonly kind: "theater"; readonly theaterId: string; readonly anchor: DOMRect; readonly returnFocus?: HTMLButtonElement | null };
+  | { readonly kind: "chip"; readonly operationId: string; readonly anchor: DOMRect; readonly returnFocus?: HTMLElement | null }
+  | { readonly kind: "group"; readonly groupId: string; readonly anchor: DOMRect; readonly returnFocus?: HTMLElement | null }
+  | { readonly kind: "theater"; readonly theaterId: string; readonly anchor: DOMRect; readonly returnFocus?: HTMLElement | null };
 
 interface NewMenuState {
   readonly anchor: { readonly x: number; readonly y: number };
@@ -138,7 +141,7 @@ interface TheaterSectionHeaderProps {
   readonly onToggleStatusAxis: () => void;
   readonly onOpenActions: (anchor: DOMRect, returnFocus?: HTMLButtonElement | null) => void;
   readonly onOpenLaunch: (event: MouseEvent<HTMLButtonElement>, theaterId: string) => void;
-  readonly onContextMenu: (anchor: DOMRect) => void;
+  readonly onContextMenu: (anchor: DOMRect, returnFocus?: HTMLElement | null) => void;
   readonly onPointerDragStart: (event: ReactPointerEvent<HTMLDivElement>, theaterId: string) => void;
 }
 
@@ -163,7 +166,7 @@ interface TheaterInactiveSectionProps {
   readonly onToggleStatusAxis: () => void;
   readonly onOpenActions: (anchor: DOMRect, returnFocus?: HTMLButtonElement | null) => void;
   readonly onOpenLaunch: (event: MouseEvent<HTMLButtonElement>, theaterId: string) => void;
-  readonly onContextMenu: (anchor: DOMRect) => void;
+  readonly onContextMenu: (anchor: DOMRect, returnFocus?: HTMLElement | null) => void;
   readonly onPointerDragStart: (event: ReactPointerEvent<HTMLDivElement>, theaterId: string) => void;
 }
 
@@ -302,6 +305,7 @@ export function OperationsSideBar({
   const onSetGroupIdRef = useRef(onSetGroupId);
   const onReorderGroupsRef = useRef(onReorderGroups);
   const onReorderTheatersRef = useRef(onReorderTheaters);
+  const contextMenuReturnFocusRef = useRef<HTMLElement | null>(null);
   const [activeContextMenu, setActiveContextMenu] = useState<ActiveContextMenu | null>(null);
   const [newMenu, setNewMenu] = useState<NewMenuState | null>(null);
   const [browserOpen, setBrowserOpen] = useState(false);
@@ -373,6 +377,30 @@ export function OperationsSideBar({
   );
 
   useEffect(() => clearCloseArmTimer, [clearCloseArmTimer]);
+
+  useEffect(() => subscribeSideBarOperationAction((request) => {
+    const operation = operations.find((candidate) => candidate.id === request.operationId);
+    if (!operation || operation.theaterId !== activeTheaterId) return false;
+    if (collapsed) {
+      setSideBarCollapsed(false);
+      return false;
+    }
+    if (collapsedTheaters.includes(operation.theaterId)) {
+      setTheaterCollapsed(operation.theaterId, false);
+      return false;
+    }
+    if (operation.groupId && collapsedGroupSet.has(operation.groupId)) {
+      toggleGroupCollapsed(operation.groupId);
+      return false;
+    }
+    if (statusAxis) {
+      const status = normalizeOperationStatus(operationStatus[operation.id]);
+      if (getSideBarStatusSectionCollapsed(operation.theaterId, status, false)) {
+        toggleSideBarStatusSectionCollapsed(operation.theaterId, status, false);
+      }
+    }
+    return false;
+  }), [activeTheaterId, collapsed, collapsedGroupSet, collapsedTheaters, operationStatus, operations, statusAxis]);
 
   useEffect(() => {
     if (armedCloseId === null) return;
@@ -693,10 +721,19 @@ export function OperationsSideBar({
   };
 
   const closeActiveContextMenu = useCallback(() => {
-    const returnFocus = activeContextMenu?.kind === "theater" ? activeContextMenu.returnFocus : null;
+    const returnFocus = activeContextMenu?.returnFocus ?? null;
     setActiveContextMenu(null);
     returnFocus?.focus();
   }, [activeContextMenu]);
+  contextMenuReturnFocusRef.current = activeContextMenu?.returnFocus ?? null;
+  useContextMenuKeyboard({
+    open: activeContextMenu !== null,
+    menuSelector: activeContextMenu?.kind === "theater"
+      ? '.side-bar-theater-menu[role="menu"]'
+      : '.group-context-menu-card[role="menu"]',
+    returnFocusRef: contextMenuReturnFocusRef,
+    onEscape: closeActiveContextMenu,
+  });
 
   const openTheaterLaunchMenuAt = (anchor: DOMRect, theaterId: string) => {
     if (theaterId !== activeTheaterId) onSelectTheater(theaterId);
@@ -829,9 +866,9 @@ export function OperationsSideBar({
                   setActiveContextMenu({ kind: "theater", theaterId: theater.id, anchor, returnFocus });
                 }}
                 onOpenLaunch={openTheaterLaunchMenu}
-                onContextMenu={(anchor) => {
+                onContextMenu={(anchor, returnFocus) => {
                   setNewMenu(null);
-                  setActiveContextMenu({ kind: "theater", theaterId: theater.id, anchor });
+                  setActiveContextMenu({ kind: "theater", theaterId: theater.id, anchor, returnFocus });
                 }}
                 onPointerDragStart={beginTheaterPointerDrag}
               />
@@ -865,9 +902,9 @@ export function OperationsSideBar({
                   setActiveContextMenu({ kind: "theater", theaterId: theater.id, anchor, returnFocus });
                 }}
                 onOpenLaunch={openTheaterLaunchMenu}
-                onContextMenu={(anchor) => {
+                onContextMenu={(anchor, returnFocus) => {
                   setNewMenu(null);
-                  setActiveContextMenu({ kind: "theater", theaterId: theater.id, anchor });
+                  setActiveContextMenu({ kind: "theater", theaterId: theater.id, anchor, returnFocus });
                 }}
                 onPointerDragStart={beginTheaterPointerDrag}
               />
@@ -905,7 +942,7 @@ export function OperationsSideBar({
                           onFocus={onFocus}
                           onKeyboardMove={keyboardMove}
                           onPointerDragStart={beginPointerDrag}
-                          onOpenAccent={(operationId, anchor) => setActiveContextMenu({ kind: "chip", operationId, anchor })}
+                          onOpenAccent={(operationId, anchor, returnFocus) => setActiveContextMenu({ kind: "chip", operationId, anchor, returnFocus })}
                           onRename={onRename}
                         />
                       );
@@ -992,7 +1029,7 @@ export function OperationsSideBar({
                         onFocus={onFocus}
                         onKeyboardMove={keyboardMove}
                         onPointerDragStart={beginPointerDrag}
-                        onOpenAccent={(operationId, anchor) => setActiveContextMenu({ kind: "chip", operationId, anchor })}
+                        onOpenAccent={(operationId, anchor, returnFocus) => setActiveContextMenu({ kind: "chip", operationId, anchor, returnFocus })}
                         onRename={onRename}
                       />
                     );
@@ -1211,6 +1248,11 @@ function TheaterSectionHeader({
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     // 중첩 행 컨트롤(status/+ /caret)에서 버블된 Enter/Space를 가로채면 버튼 키보드 활성화가 죽는다.
     if (event.target !== event.currentTarget) return;
+    if (event.key === "ContextMenu" || (event.shiftKey && event.key === "F10")) {
+      event.preventDefault();
+      onContextMenu(event.currentTarget.getBoundingClientRect(), event.currentTarget);
+      return;
+    }
     if (event.key !== "Enter" && event.key !== " ") return;
     event.preventDefault();
     activateOrToggle();
@@ -1248,6 +1290,7 @@ function TheaterSectionHeader({
     <div
       role="button"
       tabIndex={0}
+      aria-haspopup="menu"
       className={headerClassName}
       style={headerStyle}
       onClick={select}

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -17,7 +17,10 @@ import { resolveOperationActivity } from "../operation-activity.js";
 import { SideBarBrandFoot } from "../components/side-bar-brand-foot.js";
 import { applyVisibleReorder, groupDropIndexFromPoint, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderGroupIds, reorderTheaterIds, reorderWithinSegment, theaterDropIndexFromPoint, type DropSectionInfo } from "./operations-side-bar-hit-test.js";
 import { useContextMenuKeyboard } from "./context-menu-keyboard.js";
-import { subscribeSideBarOperationAction } from "./operation-action-request.js";
+import {
+  subscribeSideBarOperationAction,
+  type SideBarOperationMenuAction,
+} from "./operation-action-request.js";
 import { OperationsSideBarChip, type SideBarEntry } from "./operations-side-bar-chip.js";
 import { OperationsSideBarGroupHeader } from "./operations-side-bar-group-header.js";
 import {
@@ -68,7 +71,13 @@ interface OperationsSideBarProps {
 }
 
 type ActiveContextMenu =
-  | { readonly kind: "chip"; readonly operationId: string; readonly anchor: DOMRect; readonly returnFocus?: HTMLElement | null }
+  | {
+      readonly kind: "chip";
+      readonly operationId: string;
+      readonly anchor: DOMRect;
+      readonly returnFocus?: HTMLElement | null;
+      readonly requestedAction?: SideBarOperationMenuAction;
+    }
   | { readonly kind: "group"; readonly groupId: string; readonly anchor: DOMRect; readonly returnFocus?: HTMLElement | null }
   | { readonly kind: "theater"; readonly theaterId: string; readonly anchor: DOMRect; readonly returnFocus?: HTMLElement | null };
 
@@ -732,6 +741,7 @@ export function OperationsSideBar({
       ? '.side-bar-theater-menu[role="menu"]'
       : '.group-context-menu-card[role="menu"]',
     returnFocusRef: contextMenuReturnFocusRef,
+    requestedAction: activeContextMenu?.kind === "chip" ? activeContextMenu.requestedAction : undefined,
     onEscape: closeActiveContextMenu,
   });
 
@@ -942,7 +952,9 @@ export function OperationsSideBar({
                           onFocus={onFocus}
                           onKeyboardMove={keyboardMove}
                           onPointerDragStart={beginPointerDrag}
-                          onOpenAccent={(operationId, anchor, returnFocus) => setActiveContextMenu({ kind: "chip", operationId, anchor, returnFocus })}
+                          onOpenAccent={(operationId, anchor, returnFocus, requestedAction) => {
+                            setActiveContextMenu({ kind: "chip", operationId, anchor, returnFocus, requestedAction });
+                          }}
                           onRename={onRename}
                         />
                       );
@@ -1029,7 +1041,9 @@ export function OperationsSideBar({
                         onFocus={onFocus}
                         onKeyboardMove={keyboardMove}
                         onPointerDragStart={beginPointerDrag}
-                        onOpenAccent={(operationId, anchor, returnFocus) => setActiveContextMenu({ kind: "chip", operationId, anchor, returnFocus })}
+                        onOpenAccent={(operationId, anchor, returnFocus, requestedAction) => {
+                          setActiveContextMenu({ kind: "chip", operationId, anchor, returnFocus, requestedAction });
+                        }}
                         onRename={onRename}
                       />
                     );

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -400,7 +400,7 @@ export function OperationsSideBar({
     }
     // 상태축에서는 그룹 접힘이 배치에 영향을 주지 않는다 — 여기서 펼치면 사용자의 그룹축 설정만 조용히 바뀐다.
     if (statusAxis) {
-      const status = normalizeOperationStatus(operationStatus[operation.id]);
+      const status = resolveOperationActivity(operation, operationStatus);
       if (getSideBarStatusSectionCollapsed(operation.theaterId, status, false)) {
         toggleSideBarStatusSectionCollapsed(operation.theaterId, status, false);
       }

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -398,15 +398,17 @@ export function OperationsSideBar({
       setTheaterCollapsed(operation.theaterId, false);
       return false;
     }
-    if (operation.groupId && collapsedGroupSet.has(operation.groupId)) {
-      toggleGroupCollapsed(operation.groupId);
-      return false;
-    }
+    // 상태축에서는 그룹 접힘이 배치에 영향을 주지 않는다 — 여기서 펼치면 사용자의 그룹축 설정만 조용히 바뀐다.
     if (statusAxis) {
       const status = normalizeOperationStatus(operationStatus[operation.id]);
       if (getSideBarStatusSectionCollapsed(operation.theaterId, status, false)) {
         toggleSideBarStatusSectionCollapsed(operation.theaterId, status, false);
       }
+      return false;
+    }
+    if (operation.groupId && collapsedGroupSet.has(operation.groupId)) {
+      toggleGroupCollapsed(operation.groupId);
+      return false;
     }
     return false;
   }), [activeTheaterId, collapsed, collapsedGroupSet, collapsedTheaters, operationStatus, operations, statusAxis]);
@@ -1100,7 +1102,7 @@ export function OperationsSideBar({
             onSetGroupId: (groupId) => onSetGroupId(contextMenuOperation.id, groupId),
             onCreateGroup: (name) => onCreateGroup(contextMenuOperation.theaterId, name, contextMenuOperation.id),
           }}
-          onClose={() => setActiveContextMenu(null)}
+          onClose={closeActiveContextMenu}
         />
       ) : activeContextMenu?.kind === "group" && contextMenuGroup ? (
         <GroupContextMenu
@@ -1112,7 +1114,7 @@ export function OperationsSideBar({
             onRename: (name) => onRenameGroup(contextMenuGroup.id, name),
             onUngroupAll: () => onUngroupAll(contextMenuGroup.id),
           }}
-          onClose={() => setActiveContextMenu(null)}
+          onClose={closeActiveContextMenu}
         />
       ) : activeContextMenu?.kind === "theater" && contextMenuTheater ? (
         <TheaterActionsMenu

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2438,6 +2438,11 @@
   outline: none;
 }
 
+.side-bar-theater-header:focus-visible {
+  border-color: color-mix(in oklch, var(--brass) 55%, var(--surface-rim));
+  background: var(--brass-glow);
+}
+
 .side-bar-theater-header.is-active {
   color: var(--text-secondary);
   border-color: transparent;
@@ -2680,6 +2685,11 @@
 .side-bar-chip:focus-visible {
   background: color-mix(in oklch, var(--ink-spectral) 8%, transparent);
   outline: none;
+}
+
+.side-bar-chip:focus-visible {
+  border-color: color-mix(in oklch, var(--brass) 55%, var(--surface-rim));
+  background: var(--brass-glow);
 }
 
 /* active: brass highlight */
@@ -3539,6 +3549,11 @@
   outline: none;
 }
 
+.group-context-menu-item:focus-visible {
+  border-color: color-mix(in oklch, var(--brass) 55%, var(--surface-rim));
+  background: var(--brass-glow);
+}
+
 .group-context-menu-item.is-selected {
   background: color-mix(in oklch, var(--brass) 10%, transparent);
   color: color-mix(in oklch, var(--brass) 80%, var(--text-secondary));
@@ -3653,6 +3668,11 @@
   border-color: color-mix(in oklch, var(--ink-fog) 20%, transparent);
   background: color-mix(in oklch, var(--ink-spectral) 8%, transparent);
   outline: none;
+}
+
+.accent-tone-row:focus-visible {
+  border-color: color-mix(in oklch, var(--brass) 55%, var(--surface-rim));
+  background: var(--brass-glow);
 }
 
 .accent-tone-row[aria-pressed="true"] {

--- a/runtime/fleet-console/tests/operations-side-bar-keyboard-context-menu.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-keyboard-context-menu.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { loadForTheater } from "../core/client/src/canvas/canvas-store.js";
+import { OperationsSideBar } from "../core/client/src/sidebar/operations-side-bar.js";
+import { setSideBarCollapsed, setTheaterCollapsed } from "../core/client/src/sidebar/operations-side-bar-store.js";
+import type { OperationGroup, OperationNode, TheaterInfo } from "../core/client/src/types.js";
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  window.localStorage.clear();
+  setSideBarCollapsed(false);
+  setTheaterCollapsed("theater-a", false);
+  loadForTheater("theater-a");
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  document.body.replaceChildren();
+  root = null;
+  container = null;
+  loadForTheater(null);
+});
+
+describe("sidebar context menu keyboard path", () => {
+  it("opens the Operation menu with Shift+F10, roves cyclically, and restores focus on Escape", async () => {
+    renderSideBar();
+    const chip = required<HTMLElement>('[data-side-bar-chip-id="operation-a"]');
+    chip.focus();
+
+    dispatchKey(chip, "F10", { shiftKey: true });
+    await nextFrame();
+
+    const menu = required<HTMLElement>('.group-context-menu-card[role="menu"]');
+    const items = menuItems(menu);
+    expect(chip.getAttribute("aria-haspopup")).toBe("menu");
+    expect(items).toHaveLength(11);
+    expect(document.activeElement).toBe(items[0]);
+    expect(items.filter((item) => item.tabIndex === 0)).toEqual([items[0]]);
+
+    dispatchKey(items[0]!, "ArrowUp");
+    expect(document.activeElement?.textContent).toContain("Rose");
+    expect(menuItems(menu).filter((item) => item.tabIndex === 0)).toEqual([document.activeElement]);
+
+    dispatchKey(document.activeElement as HTMLElement, "ArrowDown");
+    expect(document.activeElement).toBe(items[0]);
+
+    dispatchKey(items[0]!, "Escape");
+    expect(document.querySelector('[role="menu"]')).toBeNull();
+    expect(document.activeElement).toBe(chip);
+  });
+
+  it("opens the Theater actions menu from the row with ContextMenu and applies the same focus loop", async () => {
+    renderSideBar();
+    const row = required<HTMLElement>(".side-bar-theater-header");
+    row.focus();
+
+    dispatchKey(row, "ContextMenu");
+    await nextFrame();
+
+    const menu = required<HTMLElement>('.side-bar-theater-menu[role="menu"]');
+    const items = menuItems(menu);
+    expect(row.getAttribute("aria-haspopup")).toBe("menu");
+    expect(document.activeElement).toBe(items[0]);
+    expect(items[0]?.textContent).toContain("New group…");
+
+    dispatchKey(items[0]!, "ArrowUp");
+    expect(document.activeElement?.textContent).toContain("Forget Theater");
+    dispatchKey(document.activeElement as HTMLElement, "ArrowDown");
+    expect(document.activeElement).toBe(items[0]);
+
+    dispatchKey(items[0]!, "Escape");
+    expect(document.querySelector('[role="menu"]')).toBeNull();
+    expect(document.activeElement).toBe(row);
+  });
+
+  it("executes the focused existing menu item with Enter", async () => {
+    renderSideBar();
+    const chip = required<HTMLElement>('[data-side-bar-chip-id="operation-a"]');
+    dispatchKey(chip, "F10", { shiftKey: true });
+    await nextFrame();
+    const firstItem = required<HTMLButtonElement>('.group-context-menu-card button[role="menuitemradio"]');
+    const click = vi.fn();
+    firstItem.addEventListener("click", click);
+
+    dispatchKey(firstItem, "Enter");
+
+    expect(click).toHaveBeenCalledOnce();
+    expect(document.querySelector('[role="menu"]')).toBeNull();
+  });
+});
+
+function renderSideBar(): void {
+  act(() => root?.render(createElement(MemoryRouter, null, createElement(OperationsSideBar, {
+    theaters: [THEATER],
+    activeTheaterId: THEATER.id,
+    operations: [OPERATION],
+    groups: [GROUP],
+    minimized: [],
+    activeOperationId: OPERATION.id,
+    operationNotifications: {},
+    catalog: [],
+    canLaunch: true,
+    addingTheater: false,
+    theaterError: null,
+    renderKindIcon: () => null,
+    onLaunchKind: vi.fn(),
+    onClose: vi.fn(),
+    onMinimize: vi.fn(),
+    onFocus: vi.fn(),
+    onSetAccent: vi.fn(),
+    onRename: vi.fn(),
+    onSetGroupId: vi.fn(),
+    onCreateGroup: vi.fn(),
+    onSetGroupColor: vi.fn(),
+    onRenameGroup: vi.fn(),
+    onReorderGroups: vi.fn(),
+    onReorderTheaters: vi.fn(),
+    onUngroupAll: vi.fn(),
+    onSelectTheater: vi.fn(),
+    onAddTheater: vi.fn(),
+    onCancelAddTheater: vi.fn(),
+    onForgetTheater: vi.fn(),
+  }))));
+}
+
+function dispatchKey(target: HTMLElement, key: string, options: KeyboardEventInit = {}): void {
+  act(() => target.dispatchEvent(new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...options,
+  })));
+}
+
+async function nextFrame(): Promise<void> {
+  await act(async () => new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve())));
+}
+
+function menuItems(menu: HTMLElement): HTMLButtonElement[] {
+  return Array.from(menu.querySelectorAll<HTMLButtonElement>('button[role^="menuitem"]'));
+}
+
+function required<T extends Element>(selector: string): T {
+  const element = document.querySelector<T>(selector);
+  if (!element) throw new Error(`Missing ${selector}`);
+  return element;
+}
+
+const THEATER: TheaterInfo = {
+  id: "theater-a",
+  label: "Alpha",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  lastOpenedAt: "2026-01-01T00:00:00.000Z",
+  hasWiki: false,
+  activeAdmiralCount: 0,
+};
+
+const OPERATION: OperationNode = {
+  id: "operation-a",
+  theaterId: THEATER.id,
+  type: "shell",
+  pluginId: "terminal",
+  title: "Bridge",
+  payload: {},
+  geometry: null,
+  groupId: "group-a",
+  ts: { createdAt: 1, updatedAt: 1 },
+};
+
+const GROUP: OperationGroup = {
+  id: "group-a",
+  theaterId: THEATER.id,
+  name: "Crew",
+  color: "cerulean",
+  order: 0,
+  createdAt: 1,
+};

--- a/runtime/fleet-console/tests/operations-side-bar-keyboard-context-menu.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-keyboard-context-menu.test.tsx
@@ -166,7 +166,10 @@ describe("sidebar context menu keyboard path", () => {
 
     expect(click).toHaveBeenCalledOnce();
     expect(document.querySelector('[role="menu"]')).toBeNull();
+    // Escape뿐 아니라 항목 실행으로 닫힐 때도 포커스가 칩으로 돌아와야 한다.
+    expect(document.activeElement).toBe(chip);
   });
+
 });
 
 function renderSideBar(): void {

--- a/runtime/fleet-console/tests/operations-side-bar-keyboard-context-menu.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-keyboard-context-menu.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { loadForTheater } from "../core/client/src/canvas/canvas-store.js";
+import { requestSideBarOperationAction } from "../core/client/src/sidebar/operation-action-request.js";
 import { OperationsSideBar } from "../core/client/src/sidebar/operations-side-bar.js";
 import { setSideBarCollapsed, setTheaterCollapsed } from "../core/client/src/sidebar/operations-side-bar-store.js";
 import type { OperationGroup, OperationNode, TheaterInfo } from "../core/client/src/types.js";
@@ -62,6 +63,46 @@ describe("sidebar context menu keyboard path", () => {
     expect(document.activeElement).toBe(chip);
   });
 
+  it("focuses the first accent for a palette set-accent request while preserving the full menu loop and Escape return", async () => {
+    renderSideBar();
+    const chip = required<HTMLElement>('[data-side-bar-chip-id="operation-a"]');
+
+    act(() => requestSideBarOperationAction(OPERATION.id, "set-accent"));
+    await nextFrame();
+
+    const menu = required<HTMLElement>('.group-context-menu-card[role="menu"]');
+    const items = menuItems(menu);
+    expect(document.activeElement?.getAttribute("data-accent-option")).toBe("none");
+    expect(document.activeElement?.textContent).toContain("None");
+    expect(items.filter((item) => item.tabIndex === 0)).toEqual([document.activeElement]);
+
+    const accentIndex = items.findIndex((item) => item.hasAttribute("data-accent-option"));
+    expect(accentIndex).toBeGreaterThan(0);
+    dispatchKey(document.activeElement as HTMLElement, "ArrowUp");
+    expect(document.activeElement).toBe(items[accentIndex - 1]);
+    expect(document.activeElement?.hasAttribute("data-accent-option")).toBe(false);
+
+    dispatchKey(document.activeElement as HTMLElement, "ArrowDown");
+    expect(document.activeElement?.getAttribute("data-accent-option")).toBe("none");
+
+    dispatchKey(document.activeElement as HTMLElement, "Escape");
+    expect(document.querySelector('[role="menu"]')).toBeNull();
+    expect(document.activeElement).toBe(chip);
+  });
+
+  it("keeps the first menu item focused for a palette assign-group request", async () => {
+    renderSideBar();
+
+    act(() => requestSideBarOperationAction(OPERATION.id, "assign-group"));
+    await nextFrame();
+
+    const menu = required<HTMLElement>('.group-context-menu-card[role="menu"]');
+    const items = menuItems(menu);
+    expect(document.activeElement).toBe(items[0]);
+    expect(document.activeElement?.hasAttribute("data-accent-option")).toBe(false);
+    expect(items.filter((item) => item.tabIndex === 0)).toEqual([items[0]]);
+  });
+
   it("opens the Theater actions menu from the row with ContextMenu and applies the same focus loop", async () => {
     renderSideBar();
     const row = required<HTMLElement>(".side-bar-theater-header");
@@ -91,9 +132,10 @@ describe("sidebar context menu keyboard path", () => {
     const chip = required<HTMLElement>('[data-side-bar-chip-id="operation-a"]');
     dispatchKey(chip, "F10", { shiftKey: true });
     await nextFrame();
-    const firstItem = required<HTMLButtonElement>('.group-context-menu-card button[role="menuitemradio"]');
+    const firstItem = required<HTMLButtonElement>('.group-context-menu-card button[data-accent-option="none"]');
     const click = vi.fn();
     firstItem.addEventListener("click", click);
+    firstItem.focus();
 
     dispatchKey(firstItem, "Enter");
 

--- a/runtime/fleet-console/tests/operations-side-bar-keyboard-context-menu.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-keyboard-context-menu.test.tsx
@@ -13,10 +13,15 @@ import type { OperationGroup, OperationNode, TheaterInfo } from "../core/client/
 
 let container: HTMLDivElement | null = null;
 let root: Root | null = null;
+let scrollIntoViewDescriptor: PropertyDescriptor | undefined;
+const scrollIntoView = vi.fn();
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 beforeEach(() => {
+  scrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollIntoView");
+  scrollIntoView.mockClear();
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", { configurable: true, value: scrollIntoView });
   document.body.replaceChildren();
   window.localStorage.clear();
   setSideBarCollapsed(false);
@@ -29,6 +34,8 @@ beforeEach(() => {
 
 afterEach(() => {
   act(() => root?.unmount());
+  if (scrollIntoViewDescriptor) Object.defineProperty(HTMLElement.prototype, "scrollIntoView", scrollIntoViewDescriptor);
+  else Reflect.deleteProperty(HTMLElement.prototype, "scrollIntoView");
   document.body.replaceChildren();
   root = null;
   container = null;
@@ -88,6 +95,24 @@ describe("sidebar context menu keyboard path", () => {
     dispatchKey(document.activeElement as HTMLElement, "Escape");
     expect(document.querySelector('[role="menu"]')).toBeNull();
     expect(document.activeElement).toBe(chip);
+  });
+
+  it("scrolls an offscreen chip into view before anchoring the palette menu", async () => {
+    renderSideBar();
+    const chip = required<HTMLElement>('[data-side-bar-chip-id="operation-a"]');
+    let rectReadBeforeScroll: number | null = null;
+    const originalRect = chip.getBoundingClientRect.bind(chip);
+    chip.getBoundingClientRect = () => {
+      rectReadBeforeScroll ??= scrollIntoView.mock.calls.length;
+      return originalRect();
+    };
+
+    act(() => requestSideBarOperationAction(OPERATION.id, "set-accent"));
+    await nextFrame();
+
+    // rect를 읽는 시점에 이미 스크롤이 끝나 있어야 메뉴가 화면 안에 앵커링된다.
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+    expect(rectReadBeforeScroll).toBeGreaterThan(0);
   });
 
   it("keeps the first menu item focused for a palette assign-group request", async () => {

--- a/runtime/fleet-console/tests/palette-commands.test.ts
+++ b/runtime/fleet-console/tests/palette-commands.test.ts
@@ -146,6 +146,7 @@ describe("buildPaletteCommands", () => {
   it("omits Minimize all when the active Theater has no operations", () => {
     const commands = buildPaletteCommands(makeState(), []);
     expect(commands.some((command) => command.commandId === "minimize-all-operations")).toBe(false);
+  });
 
   it("shows the four exact chip-menu Operation actions only for an active Operation in the active Theater", () => {
     const withoutActive = buildPaletteCommands(makeState(), []);

--- a/runtime/fleet-console/tests/palette-commands.test.ts
+++ b/runtime/fleet-console/tests/palette-commands.test.ts
@@ -146,6 +146,41 @@ describe("buildPaletteCommands", () => {
   it("omits Minimize all when the active Theater has no operations", () => {
     const commands = buildPaletteCommands(makeState(), []);
     expect(commands.some((command) => command.commandId === "minimize-all-operations")).toBe(false);
+
+  it("shows the four exact chip-menu Operation actions only for an active Operation in the active Theater", () => {
+    const withoutActive = buildPaletteCommands(makeState(), []);
+    const operationLabels = ["Rename operation…", "Assign group…", "Set accent…", "Minimize operation"];
+    expect(withoutActive.filter((command) => operationLabels.includes(command.label))).toEqual([]);
+
+    const withActive = buildPaletteCommands(makeState({
+      activeOperationId: "operation-a",
+      operations: [{
+        id: "operation-a",
+        theaterId: "theater-alpha",
+        type: "shell",
+        pluginId: "terminal",
+        title: "Operation A",
+        payload: {},
+        geometry: null,
+        ts: { createdAt: 1, updatedAt: 1 },
+      }],
+    }), []);
+    expect(withActive.filter((command) => operationLabels.includes(command.label)).map((command) => command.label)).toEqual(operationLabels);
+
+    const staleActive = buildPaletteCommands(makeState({
+      activeOperationId: "operation-b",
+      operations: [{
+        id: "operation-b",
+        theaterId: "theater-beta",
+        type: "shell",
+        pluginId: "terminal",
+        title: "Operation B",
+        payload: {},
+        geometry: null,
+        ts: { createdAt: 1, updatedAt: 1 },
+      }],
+    }), []);
+    expect(staleActive.filter((command) => operationLabels.includes(command.label))).toEqual([]);
   });
 });
 

--- a/runtime/fleet-plugins/file-explorer/client/explorer.css
+++ b/runtime/fleet-plugins/file-explorer/client/explorer.css
@@ -241,6 +241,11 @@
   background: var(--surface-glass);
 }
 
+.fexp-tree-row:focus-visible {
+  outline: 2px solid var(--brass);
+  outline-offset: -2px;
+}
+
 .fexp-tree-row.is-cur {
   color: var(--brass);
   background: var(--surface-glass-strong);

--- a/runtime/fleet-plugins/file-explorer/client/tree.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/tree.tsx
@@ -427,6 +427,13 @@ export function FileTree({ contextKey, files, theaterId, selectedPath, onSelect 
     const row = flatRows[rowIndex];
     if (!row) return;
     const path = row.entry.relativePath;
+    if (path === renderedCursorPath) {
+      // 경계(첫/마지막 행)에서는 커서가 그대로라 리렌더가 없다. 요청을 남겨두면 나중의 SSE 리렌더가
+      // 그걸 소비해 사용자가 떠난 뒤 포커스를 훔치므로, 여기서 바로 처리하고 큐를 비운다.
+      pendingFocusPathRef.current = null;
+      rowRefs.current.get(path)?.focus();
+      return;
+    }
     pendingFocusPathRef.current = path;
     setCursorPath(path);
     if (shouldVirtualize && (rowIndex < startIdx || rowIndex >= endIdx)) {

--- a/runtime/fleet-plugins/file-explorer/client/tree.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/tree.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 
 import type { FolderEntry, FolderListResult } from "../server/types.js";
 
@@ -15,13 +15,20 @@ interface FileTreeProps {
   readonly onSelect: (entry: FolderEntry) => void;
 }
 
-interface FlatRow {
+export interface FlatRow {
   readonly entry: FolderEntry;
   readonly depth: number;
   readonly isSelected: boolean;
   readonly isExpanded: boolean;
   readonly isLoading: boolean;
 }
+
+export type TreeNavigationAction =
+  | { readonly kind: "focus"; readonly index: number }
+  | { readonly kind: "expand" }
+  | { readonly kind: "collapse" }
+  | { readonly kind: "activate" }
+  | { readonly kind: "none" };
 
 interface FilterDescendantLoadOptions {
   readonly entries: readonly FolderEntry[];
@@ -94,6 +101,7 @@ export function buildFlatRows(
   low: string,
   showHidden: boolean,
   ancestorFolders: ReadonlySet<string> = new Set(),
+  filterCollapsedDirs: ReadonlySet<string> = new Set(),
 ): FlatRow[] {
   const rows: FlatRow[] = [];
   for (const entry of entries) {
@@ -107,7 +115,8 @@ export function buildFlatRows(
       const directMatch = entry.name.toLowerCase().includes(low);
       if (!directMatch && !childMatch) continue;
     }
-    const isExpanded = expandedDirs.has(entry.relativePath) || Boolean(low && childMatch);
+    const isExpanded = !filterCollapsedDirs.has(entry.relativePath)
+      && (expandedDirs.has(entry.relativePath) || Boolean(low && childMatch));
     rows.push({
       entry,
       depth,
@@ -119,11 +128,47 @@ export function buildFlatRows(
       if (children) {
         const nextAncestorFolders = new Set(ancestorFolders);
         nextAncestorFolders.add(folderIdentity);
-        rows.push(...buildFlatRows(children, depth + 1, selectedPath, expandedDirs, loadingDirs, childResults, low, showHidden, nextAncestorFolders));
+        rows.push(...buildFlatRows(
+          children,
+          depth + 1,
+          selectedPath,
+          expandedDirs,
+          loadingDirs,
+          childResults,
+          low,
+          showHidden,
+          nextAncestorFolders,
+          filterCollapsedDirs,
+        ));
       }
     }
   }
   return rows;
+}
+
+export function resolveTreeNavigation(rows: readonly FlatRow[], index: number, key: string): TreeNavigationAction {
+  const row = rows[index];
+  if (!row) return { kind: "none" };
+  if (key === "ArrowDown") return { kind: "focus", index: Math.min(rows.length - 1, index + 1) };
+  if (key === "ArrowUp") return { kind: "focus", index: Math.max(0, index - 1) };
+  if (key === "Home") return { kind: "focus", index: 0 };
+  if (key === "End") return { kind: "focus", index: rows.length - 1 };
+  if (key === "ArrowRight") {
+    if (row.entry.kind !== "dir") return { kind: "none" };
+    if (!row.isExpanded) return { kind: "expand" };
+    return rows[index + 1]?.depth === row.depth + 1
+      ? { kind: "focus", index: index + 1 }
+      : { kind: "none" };
+  }
+  if (key === "ArrowLeft") {
+    if (row.entry.kind === "dir" && row.isExpanded) return { kind: "collapse" };
+    for (let parentIndex = index - 1; parentIndex >= 0; parentIndex -= 1) {
+      if (rows[parentIndex]?.depth === row.depth - 1) return { kind: "focus", index: parentIndex };
+    }
+    return { kind: "none" };
+  }
+  if (key === "Enter" || key === " ") return { kind: "activate" };
+  return { kind: "none" };
 }
 
 export function FileTree({ contextKey, files, theaterId, selectedPath, onSelect }: FileTreeProps) {
@@ -134,10 +179,14 @@ export function FileTree({ contextKey, files, theaterId, selectedPath, onSelect 
   const [loadingDirs, setLoadingDirs] = useState<Set<string>>(new Set());
   const [childResults, setChildResults] = useState<Map<string, FolderListResult>>(new Map());
   const [filterText, setFilterText] = useState<string>("");
+  const [filterCollapsedDirs, setFilterCollapsedDirs] = useState<Set<string>>(new Set());
   const [scrollTop, setScrollTop] = useState(0);
   const [containerHeight, setContainerHeight] = useState(600);
   const [showHidden, setShowHidden] = useState<boolean>(() => readShowHidden());
+  const [cursorPath, setCursorPath] = useState<string | null>(null);
   const treeRef = useRef<HTMLDivElement>(null);
+  const rowRefs = useRef(new Map<string, HTMLButtonElement>());
+  const pendingFocusPathRef = useRef<string | null>(null);
 
   // SSE 핸들러가 최신 상태를 참조하도록 ref로 유지
   const expandedDirsRef = useRef<Set<string>>(expandedDirs);
@@ -161,7 +210,9 @@ export function FileTree({ contextKey, files, theaterId, selectedPath, onSelect 
     setExpandedDirs(new Set());
     setChildResults(new Map());
     setFilterText("");
+    setFilterCollapsedDirs(new Set());
     setScrollTop(0);
+    setCursorPath(null);
   }, [contextKey, theaterId]);
 
   useEffect(() => {
@@ -299,11 +350,6 @@ export function FileTree({ contextKey, files, theaterId, selectedPath, onSelect 
     }
   }, [contextKey, files, expandedDirs]);
 
-  const handleEntryClick = useCallback((entry: FolderEntry) => {
-    if (entry.kind === "dir") handleDirClick(entry);
-    else onSelect(entry);
-  }, [handleDirClick, onSelect]);
-
   const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
     setScrollTop((e.currentTarget as HTMLDivElement).scrollTop);
   }, []);
@@ -345,8 +391,8 @@ export function FileTree({ contextKey, files, theaterId, selectedPath, onSelect 
 
   const flatRows = useMemo(() => {
     if (!result) return [];
-    return buildFlatRows(result.entries, 0, selectedPath, expandedDirs, loadingDirs, childResults, low, showHidden);
-  }, [result, selectedPath, expandedDirs, loadingDirs, childResults, low, showHidden]);
+    return buildFlatRows(result.entries, 0, selectedPath, expandedDirs, loadingDirs, childResults, low, showHidden, new Set(), filterCollapsedDirs);
+  }, [result, selectedPath, expandedDirs, loadingDirs, childResults, low, showHidden, filterCollapsedDirs]);
 
   const hasOnlyHiddenEntries = !showHidden && result !== null && result.entries.length > 0 && flatRows.length === 0 && !filterText;
 
@@ -356,6 +402,103 @@ export function FileTree({ contextKey, files, theaterId, selectedPath, onSelect 
   const visibleRows = flatRows.slice(startIdx, endIdx);
   const totalHeight = flatRows.length * ROW_HEIGHT;
   const offsetY = startIdx * ROW_HEIGHT;
+  const selectedVisiblePath = selectedPath && flatRows.some((row) => row.entry.relativePath === selectedPath)
+    ? selectedPath
+    : null;
+  const resolvedCursorPath = cursorPath && flatRows.some((row) => row.entry.relativePath === cursorPath)
+    ? cursorPath
+    : selectedVisiblePath ?? flatRows[0]?.entry.relativePath ?? null;
+  const renderedCursorPath = visibleRows.some((row) => row.entry.relativePath === resolvedCursorPath)
+    ? resolvedCursorPath
+    : visibleRows[0]?.entry.relativePath ?? null;
+
+  useEffect(() => {
+    if (renderedCursorPath !== cursorPath) setCursorPath(renderedCursorPath);
+  }, [cursorPath, renderedCursorPath]);
+
+  useLayoutEffect(() => {
+    const path = pendingFocusPathRef.current;
+    if (path === null || path !== renderedCursorPath) return;
+    pendingFocusPathRef.current = null;
+    rowRefs.current.get(path)?.focus();
+  }, [renderedCursorPath, visibleRows]);
+
+  const focusRow = (rowIndex: number) => {
+    const row = flatRows[rowIndex];
+    if (!row) return;
+    const path = row.entry.relativePath;
+    pendingFocusPathRef.current = path;
+    setCursorPath(path);
+    if (shouldVirtualize && (rowIndex < startIdx || rowIndex >= endIdx)) {
+      const nextScrollTop = Math.max(0, rowIndex * ROW_HEIGHT);
+      if (treeRef.current) treeRef.current.scrollTop = nextScrollTop;
+      setScrollTop(nextScrollTop);
+    }
+  };
+
+  const handleTreeItemKeyDown = (row: FlatRow, event: ReactKeyboardEvent<HTMLButtonElement>) => {
+    const index = flatRows.findIndex((candidate) => candidate.entry.relativePath === row.entry.relativePath);
+    if (index < 0) return;
+    const action = resolveTreeNavigation(flatRows, index, event.key);
+    if (action.kind === "none") {
+      if (event.key === "ArrowRight" || event.key === "ArrowLeft") event.preventDefault();
+      return;
+    }
+    event.preventDefault();
+    if (action.kind === "focus") {
+      focusRow(action.index);
+      return;
+    }
+    if (action.kind === "expand") {
+      if (low) {
+        setFilterCollapsedDirs((current) => {
+          const next = new Set(current);
+          next.delete(row.entry.relativePath);
+          return next;
+        });
+      } else {
+        handleDirClick(row.entry);
+      }
+      return;
+    }
+    if (action.kind === "collapse") {
+      if (row.entry.kind === "dir") {
+        if (low) {
+          setFilterCollapsedDirs((current) => new Set(current).add(row.entry.relativePath));
+        } else {
+          setExpandedDirs((current) => {
+            const next = new Set(current);
+            next.delete(row.entry.relativePath);
+            return next;
+          });
+        }
+      }
+      return;
+    }
+    activateRow(row);
+  };
+
+  const activateRow = (row: FlatRow) => {
+    if (row.entry.kind !== "dir") {
+      onSelect(row.entry);
+      return;
+    }
+    if (!low) {
+      handleDirClick(row.entry);
+      return;
+    }
+    setFilterCollapsedDirs((current) => {
+      const next = new Set(current);
+      if (row.isExpanded) next.add(row.entry.relativePath);
+      else next.delete(row.entry.relativePath);
+      return next;
+    });
+  };
+
+  const handleRowClick = (row: FlatRow) => {
+    setCursorPath(row.entry.relativePath);
+    activateRow(row);
+  };
 
   if (!theaterId) return <div className="fexp-tree-empty">Select a Theater</div>;
   // 전체 에러 화면은 보여줄 트리가 아예 없을 때(초기 로드 실패)만 —
@@ -371,14 +514,20 @@ export function FileTree({ contextKey, files, theaterId, selectedPath, onSelect 
           className="fexp-filter-input"
           placeholder="Filter…"
           value={filterText}
-          onChange={(e) => setFilterText(e.target.value)}
+          onChange={(e) => {
+            setFilterText(e.target.value);
+            setFilterCollapsedDirs(new Set());
+          }}
           aria-label="Filter files"
         />
         {filterText && (
           <button
             type="button"
             className="fexp-filter-clear"
-            onClick={() => setFilterText("")}
+            onClick={() => {
+              setFilterText("");
+              setFilterCollapsedDirs(new Set());
+            }}
             aria-label="Clear filter"
           >
             ✕
@@ -436,13 +585,27 @@ export function FileTree({ contextKey, files, theaterId, selectedPath, onSelect 
           <div style={{ height: totalHeight, position: "relative" }}>
             <div style={{ transform: `translateY(${offsetY}px)` }}>
               {visibleRows.map((row) => (
-                <FlatTreeRow key={row.entry.relativePath} row={row} onEntryClick={handleEntryClick} />
+                <FlatTreeRow
+                  key={row.entry.relativePath}
+                  row={row}
+                  cursor={row.entry.relativePath === renderedCursorPath}
+                  rowRefs={rowRefs}
+                  onEntryClick={handleRowClick}
+                  onKeyDown={handleTreeItemKeyDown}
+                />
               ))}
             </div>
           </div>
         ) : (
           visibleRows.map((row) => (
-            <FlatTreeRow key={row.entry.relativePath} row={row} onEntryClick={handleEntryClick} />
+            <FlatTreeRow
+              key={row.entry.relativePath}
+              row={row}
+              cursor={row.entry.relativePath === renderedCursorPath}
+              rowRefs={rowRefs}
+              onEntryClick={handleRowClick}
+              onKeyDown={handleTreeItemKeyDown}
+            />
           ))
         )}
         {flatRows.length === 0 && filterText && (
@@ -487,24 +650,33 @@ function isVisibleDirectory(entry: FolderEntry, showHidden: boolean): boolean {
 
 interface FlatTreeRowProps {
   readonly row: FlatRow;
-  readonly onEntryClick: (entry: FolderEntry) => void;
+  readonly cursor: boolean;
+  readonly rowRefs: React.MutableRefObject<Map<string, HTMLButtonElement>>;
+  readonly onEntryClick: (row: FlatRow) => void;
+  readonly onKeyDown: (row: FlatRow, event: ReactKeyboardEvent<HTMLButtonElement>) => void;
 }
 
-function FlatTreeRow({ row, onEntryClick }: FlatTreeRowProps) {
+function FlatTreeRow({ row, cursor, rowRefs, onEntryClick, onKeyDown }: FlatTreeRowProps) {
   const { entry, depth, isSelected, isExpanded, isLoading } = row;
   const isDir = entry.kind === "dir";
   const indent = depth * 16;
-  const handleClick = useCallback(() => onEntryClick(entry), [entry, onEntryClick]);
+  const handleClick = useCallback(() => onEntryClick(row), [onEntryClick, row]);
 
   return (
     <button
+      ref={(node) => {
+        if (node) rowRefs.current.set(entry.relativePath, node);
+        else rowRefs.current.delete(entry.relativePath);
+      }}
       className={`fexp-tree-row${isSelected ? " is-cur" : ""}${isDir ? " is-dir" : " is-file"}`}
       style={{ paddingLeft: `${indent + 12}px` }}
       type="button"
       role="treeitem"
+      tabIndex={cursor ? 0 : -1}
       aria-selected={isSelected}
       aria-expanded={isDir ? isExpanded : undefined}
       onClick={handleClick}
+      onKeyDown={(event) => onKeyDown(row, event)}
     >
       <span className="fexp-tree-icon" aria-hidden="true">
         {isDir ? <FolderIcon name={entry.name} open={isExpanded} /> : <FileIcon name={entry.name} />}

--- a/runtime/fleet-plugins/file-explorer/tests/tree-keyboard.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/tree-keyboard.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+
+import { buildFlatRows, resolveTreeNavigation } from "../client/tree.js";
+import type { FolderEntry, FolderListResult } from "../server/types.js";
+
+describe("FileTree keyboard navigation", () => {
+  it("keeps one roving tab stop while actual KeyboardEvents drive four directions, Home, End, and activation", () => {
+    const expanded = new Set<string>();
+    const activated = vi.fn();
+    const harness = createHarness(() => rows(expanded, ""), expanded, activated);
+
+    expect(harness.tabStops()).toHaveLength(1);
+    expect(harness.focusedPath()).toBe("src");
+
+    expect(harness.key("ArrowRight").defaultPrevented).toBe(true);
+    expect(expanded.has("src")).toBe(true);
+    expect(harness.focusedPath()).toBe("src");
+
+    harness.key("ArrowRight");
+    expect(harness.focusedPath()).toBe("src/match.ts");
+    harness.key("ArrowDown");
+    expect(harness.focusedPath()).toBe("src/other.ts");
+    harness.key("ArrowUp");
+    expect(harness.focusedPath()).toBe("src/match.ts");
+    harness.key("ArrowLeft");
+    expect(harness.focusedPath()).toBe("src");
+    harness.key("ArrowLeft");
+    expect(expanded.has("src")).toBe(false);
+    expect(harness.tabStops()).toHaveLength(1);
+
+    harness.key("End");
+    expect(harness.focusedPath()).toBe("root.txt");
+    harness.key("Home");
+    expect(harness.focusedPath()).toBe("src");
+
+    harness.key("ArrowDown");
+    harness.key("Enter");
+    expect(activated).toHaveBeenCalledWith("docs");
+    expect(expanded.has("docs")).toBe(true);
+
+    harness.click("root.txt");
+    expect(harness.focusedPath()).toBe("root.txt");
+    expect(harness.tabStops()).toHaveLength(1);
+    expect(activated).toHaveBeenCalledWith("root.txt");
+  });
+
+  it("uses only filtered visible rows as the traversal order", () => {
+    const expanded = new Set<string>();
+    const harness = createHarness(() => rows(expanded, "match"), expanded, vi.fn());
+
+    expect(harness.paths()).toEqual(["src", "src/match.ts", "docs", "docs/match.md"]);
+    expect(harness.tabStops()).toHaveLength(1);
+    harness.key("End");
+    expect(harness.focusedPath()).toBe("docs/match.md");
+    harness.key("Home");
+    expect(harness.focusedPath()).toBe("src");
+    harness.key("ArrowDown");
+    expect(harness.focusedPath()).toBe("src/match.ts");
+    expect(harness.paths()).not.toContain("src/other.ts");
+    expect(harness.paths()).not.toContain("root.txt");
+    expect(harness.tabStops()).toHaveLength(1);
+  });
+});
+
+function createHarness(
+  getRows: () => ReturnType<typeof buildFlatRows>,
+  expanded: Set<string>,
+  activated: (path: string) => void,
+) {
+  const tree = document.createElement("div");
+  tree.setAttribute("role", "tree");
+  document.body.replaceChildren(tree);
+  let cursorPath = getRows()[0]?.entry.relativePath ?? null;
+
+  const render = () => {
+    const currentRows = getRows();
+    if (!currentRows.some((row) => row.entry.relativePath === cursorPath)) {
+      cursorPath = currentRows[0]?.entry.relativePath ?? null;
+    }
+    tree.replaceChildren(...currentRows.map((row, index) => {
+      const button = document.createElement("button");
+      button.dataset.path = row.entry.relativePath;
+      button.tabIndex = row.entry.relativePath === cursorPath ? 0 : -1;
+      button.addEventListener("click", () => {
+        cursorPath = row.entry.relativePath;
+        activate(row);
+      });
+      button.addEventListener("keydown", (event) => {
+        const action = resolveTreeNavigation(currentRows, index, event.key);
+        if (action.kind === "none") {
+          if (event.key === "ArrowRight" || event.key === "ArrowLeft") event.preventDefault();
+          return;
+        }
+        event.preventDefault();
+        if (action.kind === "focus") {
+          cursorPath = currentRows[action.index]?.entry.relativePath ?? cursorPath;
+          render();
+          focusCursor();
+          return;
+        }
+        if (action.kind === "expand") expanded.add(row.entry.relativePath);
+        if (action.kind === "collapse") expanded.delete(row.entry.relativePath);
+        if (action.kind === "activate") activate(row);
+        render();
+        focusCursor();
+      });
+      return button;
+    }));
+    focusCursor();
+  };
+
+  const activate = (row: ReturnType<typeof buildFlatRows>[number]) => {
+    activated(row.entry.relativePath);
+    if (row.entry.kind !== "dir") return;
+    if (expanded.has(row.entry.relativePath)) expanded.delete(row.entry.relativePath);
+    else expanded.add(row.entry.relativePath);
+  };
+  const focusCursor = () => tree.querySelector<HTMLElement>(`[data-path="${cursorPath}"]`)?.focus();
+  render();
+
+  return {
+    click(path: string) {
+      tree.querySelector<HTMLButtonElement>(`[data-path="${path}"]`)?.click();
+      render();
+    },
+    focusedPath: () => (document.activeElement as HTMLElement | null)?.dataset.path ?? null,
+    key(key: string) {
+      const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+      document.activeElement?.dispatchEvent(event);
+      return event;
+    },
+    paths: () => Array.from(tree.querySelectorAll<HTMLElement>("[data-path]")).map((node) => node.dataset.path ?? ""),
+    tabStops: () => Array.from(tree.querySelectorAll<HTMLButtonElement>("[data-path]")).filter((node) => node.tabIndex === 0),
+  };
+}
+
+function rows(expanded: Set<string>, filter: string) {
+  return buildFlatRows(ROOT_ENTRIES, 0, null, expanded, new Set(), CHILD_RESULTS, filter, true);
+}
+
+function entry(name: string, relativePath: string, kind: FolderEntry["kind"]): FolderEntry {
+  return { name, relativePath, kind };
+}
+
+const ROOT_ENTRIES = [
+  entry("src", "src", "dir"),
+  entry("docs", "docs", "dir"),
+  entry("root.txt", "root.txt", "file"),
+];
+
+const CHILD_RESULTS = new Map<string, FolderListResult>([
+  ["src", { relativePath: "src", parentRelativePath: null, entries: [
+    entry("match.ts", "src/match.ts", "file"),
+    entry("other.ts", "src/other.ts", "file"),
+  ] }],
+  ["docs", { relativePath: "docs", parentRelativePath: null, entries: [
+    entry("match.md", "docs/match.md", "file"),
+  ] }],
+]);


### PR DESCRIPTION
## Summary

승인된 개선안 R3입니다. 마우스로만 도달 가능하던 세 곳을 키보드로도 열어줍니다. 콘솔은 손이 키보드에 있는 도구인데, 아래 기능들은 매번 손을 떼게 만들었습니다.

- **Operation 칩과 Theater 행의 컨텍스트 메뉴에 키보드 경로.** 칩은 `tabIndex=0`으로 포커스는 됐지만 `Shift+F10`·`ContextMenu`에 아무 반응이 없었고 `aria-haspopup`도 없었습니다. Group 배정과 Accent 9색은 **우클릭 외에는 도달할 방법이 없었습니다.** 이제 두 키로 같은 메뉴가 열리고, 첫 항목에 포커스가 가며, `↑`/`↓`로 순환하고 `Esc`나 항목 실행으로 닫히면 원래 요소로 포커스가 돌아옵니다. macOS 키보드 다수에 `ContextMenu` 키가 없어 `Shift+F10`을 1차 경로로 두었습니다.
- **⌘K 커맨드 모드에 칩 메뉴 액션 4종.** `Rename operation…` / `Assign group…` / `Set accent…` / `Minimize operation`을 추가했고, 활성 Operation이 없으면 나타나지 않습니다. `Set accent…`는 accent 섹션에서 시작하도록 초기 포커스를 분기하고, 사이드바 밖으로 스크롤된 칩은 메뉴를 앵커링하기 전에 화면 안으로 끌어옵니다.
- **Files 트리에 roving tabindex와 화살표 탐색.** `role="tree"`/`role="treeitem"`을 선언하고도 키 핸들러가 없어, 노드 전부가 `tabIndex=0`이라 **Tab이 노드 수만큼 멈추고** 트리를 걸어다닐 수 없었습니다. 이제 포커스 가능한 노드는 항상 1개이고 `↑`/`↓` 이동, `→` 펼침(펼쳐져 있으면 첫 자식), `←` 접기(접혀 있으면 부모), `Home`/`End`, `Enter`/`Space` 활성화가 동작합니다. 필터가 강제로 펼친 폴더도 접을 수 있고, 가상 스크롤 구간에서는 대상 행을 스크롤로 끌어온 뒤 포커스합니다.

### #371과의 통합

이 브랜치를 리베이스하는 동안 #371이 팔레트에 **Operation별 `Close operation: <title>`** 을 추가했습니다. 여기서 준비했던 활성 Operation용 `Close operation`은 **철회**했습니다 — 두 개를 다 남기면 이름이 같고 동작이 다른 커맨드가 중복 노출되고, #371 쪽이 모든 Operation을 덮는 상위집합입니다. 그에 따라 칩 액션 핸들러의 close 분기도 도달 불가가 되어 함께 제거했습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 0 errors
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 1053 passed
- [x] `pnpm --filter @fleet-plugins/file-explorer test` — 62 passed
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 26 entries validated
- [x] 격리 콘솔 실브라우저 검증(실제 키 입력):
  - 칩 `Shift+F10` → 메뉴 첫 항목 포커스 · `↓↓↑` 순환 · 첫 항목에서 `↑` → 마지막으로 감김 · `Esc` → 칩으로 포커스 복귀
  - Theater 행 `Shift+F10` → `New group…` / `Forget Theater`, `Esc` 복귀
  - 팔레트: 활성 Operation 없을 때 커맨드 목록에 칩 액션 없음 → 있을 때 4종 노출
  - Files 트리: 노드 16개 중 `tabIndex=0`이 **항상 1개**, `↓↑` 이동, `→` 16→18 펼침, `←` 18→16 접기, `End`→마지막 `Home`→처음
- [x] Changelog fragment — `.changelog.d/pr-376.md`

### 선존 실패 (이 PR과 무관)

`tests/server.test.ts > … issues Theater-bound dedicated MCP sessions …` 1건. base에서 동일하게 재현되며, 이 어설션이 도입된 #353 시점에도 실패합니다.

전체 스위트에서 `api-catalog`·`carrier-settings`·`codex-security-routes`·`server.test.ts`의 다른 항목이 함께 실패로 보일 수 있으나, 실서버를 기동하는 테스트라 다른 콘솔이나 동시 vitest 실행과 겹치면 타임아웃하는 부하성 오탐입니다. 단독 재실행에서 각각 통과를 확인했습니다.

### 리뷰 반영 기록

3패스 동안 P2 6건을 모두 수용했습니다 — accent 라우팅, 화면 밖 칩 스크롤, 항목 실행 후 포커스 복귀, 상태축에서 그룹 설정 보존, 트리 stale 포커스 요청, 그리고 초기 라운드의 accent 섹션 분기. 상태축 수정만 회귀 테스트가 없으며(테스트 환경에서 해당 스토어 상태를 재현하지 못해 무효 테스트가 되어 제거함), 나머지는 실패-우선 검증을 마쳤습니다.