### PR TITLE
fix(console): open the canvas context menu at the cursor

### DIFF
--- a/.changelog.d/pr-377.md
+++ b/.changelog.d/pr-377.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Open the canvas and sidebar right-click menu at the cursor, flipping it above the pointer when there is no room below and sizing its height ceiling from the viewport.
+  ko: 캔버스와 사이드바 우클릭 메뉴를 커서 위치에 열고, 아래쪽 공간이 없으면 커서 위로 펼치며 높이 상한을 뷰포트에서 산출합니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
 import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console/sdk/operations";
 
 interface CanvasContextMenuProps {
@@ -17,6 +17,7 @@ interface CanvasContextMenuProps {
 
 const MENU_WIDTH = 288;
 const MENU_MAX_HEIGHT = 520;
+const MENU_MIN_HEIGHT = 120;
 const MENU_MARGIN = 12;
 const FOCUSABLE_SELECTOR = "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])";
 
@@ -26,6 +27,26 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const [promptTarget, setPromptTarget] = useState<{ readonly pluginId: string; readonly kind: OperationLaunchKind } | null>(null);
   const [initialPrompt, setInitialPrompt] = useState("");
+  const [menuSize, setMenuSize] = useState<{ readonly width: number; readonly height: number } | null>(null);
+
+  // 배치 판정은 CSS의 max-height 상한이 아니라 실제 렌더 높이로 해야 한다 —
+  // 상한(520px)으로 clamp하면 짧은 메뉴가 커서에서 수백 px 떨어진 곳에 열린다.
+  useLayoutEffect(() => {
+    const element = menuRef.current;
+    if (!element) return;
+    const measure = () => {
+      const rect = element.getBoundingClientRect();
+      setMenuSize((previous) =>
+        previous && Math.abs(previous.width - rect.width) < 0.5 && Math.abs(previous.height - rect.height) < 0.5
+          ? previous
+          : { width: rect.width, height: rect.height });
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
 
   useEffect(() => {
     const handlePointer = (event: MouseEvent) => {
@@ -65,7 +86,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     <div
       className={`operation-launch-control operation-launch-control--canvas ${placement === "above" ? "operation-launch-control--up" : ""}`}
       ref={containerRef}
-      style={clampedAnchorStyle(anchor, viewportBounds, placement)}
+      style={clampedAnchorStyle(anchor, viewportBounds, placement, menuSize)}
       data-canvas-blocker
     >
       <div className="operation-launch-menu theater-menu canvas-context-menu" role="dialog" aria-label="Canvas controls" tabIndex={-1} ref={menuRef}>
@@ -172,14 +193,27 @@ function clampedAnchorStyle(
   anchor: { readonly x: number; readonly y: number },
   bounds: { readonly width: number; readonly height: number } | undefined,
   placement: "above" | "cursor",
-): { readonly left: number; readonly top?: number; readonly bottom?: number } {
-  const left = bounds ? Math.max(MENU_MARGIN, Math.min(anchor.x, bounds.width - MENU_WIDTH - MENU_MARGIN)) : anchor.x;
+  size: { readonly width: number; readonly height: number } | null,
+): CSSProperties {
+  // 상한도 뷰포트에서 산출한다 — 520px보다 낮은 화면에서 메뉴가 잘려 나가지 않게.
+  const maxHeight = bounds
+    ? Math.max(MENU_MIN_HEIGHT, Math.min(MENU_MAX_HEIGHT, bounds.height - MENU_MARGIN * 2))
+    : MENU_MAX_HEIGHT;
+  const base = { "--canvas-menu-max-height": `${maxHeight}px` };
+  const width = size?.width ?? MENU_WIDTH;
+  // 측정 전 첫 렌더는 높이 0으로 두어 커서 좌표를 그대로 쓴다 —
+  // useLayoutEffect 측정이 페인트 전에 반영되므로 위치가 튀지 않는다.
+  const height = size?.height ?? 0;
+  const left = bounds ? Math.max(MENU_MARGIN, Math.min(anchor.x, bounds.width - width - MENU_MARGIN)) : anchor.x;
   if (placement === "above") {
-    // anchor.y = 캔버스 하단에서 메뉴 바닥까지의 거리. 메뉴는 위로 자라며 max-height로 화면 안에 가둔다.
-    return { left, bottom: Math.max(MENU_MARGIN, anchor.y) };
+    // anchor.y = 캔버스 하단에서 메뉴 바닥까지의 거리. 메뉴는 위로 자란다.
+    return { ...base, left, bottom: Math.max(MENU_MARGIN, anchor.y) } as CSSProperties;
   }
-  const top = bounds ? Math.max(MENU_MARGIN, Math.min(anchor.y, bounds.height - MENU_MAX_HEIGHT - MENU_MARGIN)) : anchor.y;
-  return { left, top };
+  if (!bounds) return { ...base, left, top: anchor.y } as CSSProperties;
+  // 커서 아래에 자리가 없으면 커서를 메뉴 바닥으로 삼아 위로 펼친다(네이티브 컨텍스트 메뉴 문법).
+  const preferred = anchor.y + height + MENU_MARGIN <= bounds.height ? anchor.y : anchor.y - height;
+  const top = Math.max(MENU_MARGIN, Math.min(preferred, bounds.height - height - MENU_MARGIN));
+  return { ...base, left, top } as CSSProperties;
 }
 
 // 플러그인이 아이콘을 등록하지 않았을 때의 일반 폴백 마크 — 특정 플러그인 지식이 아니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -1736,7 +1736,8 @@
 
 .canvas-context-menu {
   width: 288px;
-  max-height: 520px;
+  /* 상한은 뷰포트 높이에서 산출된 geometry 변수가 소유한다 — 짧은 화면에서도 메뉴가 잘리지 않는다. */
+  max-height: var(--canvas-menu-max-height, 520px);
   overflow-y: auto;
 }
 

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CanvasContextMenu } from "../core/client/src/canvas/canvas-context-menu.js";
+
+let container: HTMLDivElement;
+let root: Root;
+let originalGetBoundingClientRect: typeof Element.prototype.getBoundingClientRect;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = function getBoundingClientRect(): DOMRect {
+    if (this.classList.contains("canvas-context-menu")) {
+      return { ...originalGetBoundingClientRect.call(this), width: 288, height: 133 } as DOMRect;
+    }
+    return originalGetBoundingClientRect.call(this);
+  };
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+});
+
+describe("CanvasContextMenu anchor placement", () => {
+  it("keeps the menu at the cursor when there is enough room below", () => {
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 });
+
+    const style = menuStyle();
+    expect(style.left).toBe("520px");
+    expect(style.top).toBe("156px");
+    expect(style.getPropertyValue("--canvas-menu-max-height")).toBe("520px");
+  });
+
+  it("flips the menu above the cursor using its rendered height", () => {
+    renderMenu({ x: 520, y: 756 }, { width: 1116, height: 856 });
+
+    const style = menuStyle();
+    expect(style.top).toBe("623px");
+    expect(style.top).not.toBe("324px");
+  });
+
+  it("clamps the menu horizontally using its rendered width", () => {
+    renderMenu({ x: 1000, y: 156 }, { width: 1116, height: 856 });
+
+    expect(menuStyle().left).toBe("816px");
+  });
+
+  it("derives the menu max-height from a short viewport", () => {
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 400 });
+
+    expect(menuStyle().getPropertyValue("--canvas-menu-max-height")).toBe("376px");
+  });
+});
+
+function renderMenu(
+  anchor: { readonly x: number; readonly y: number },
+  viewportBounds: { readonly width: number; readonly height: number },
+): void {
+  act(() => root.render(
+    <CanvasContextMenu
+      anchor={anchor}
+      viewportBounds={viewportBounds}
+      catalog={[]}
+      canLaunch
+      renderKindIcon={() => null}
+      onLaunchKind={vi.fn()}
+      onClose={vi.fn()}
+    />,
+  ));
+}
+
+function menuStyle(): CSSStyleDeclaration {
+  return document.querySelector<HTMLElement>(".operation-launch-control--canvas")!.style;
+}

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -86,6 +86,8 @@ const RUNTIME_CUSTOM_PROPERTY_ALLOWLIST = new Set([
   "--ws-tree-width",
   // Terminal Carriers TSX injects the selected captain identity tone.
   "--cap-color",
+  // Canvas context menu TSX injects the viewport-derived height ceiling for its own box.
+  "--canvas-menu-max-height",
 ]);
 
 function source(path: string): string {


### PR DESCRIPTION
## Summary

- 캔버스/사이드바 우클릭으로 열리는 `Canvas controls` 메뉴가 커서에서 수백 px 떨어진 고정 지점에 열리던 결함을 고칩니다. 위치 계산이 CSS `max-height: 520px`라는 *상한*을 메뉴의 실제 높이로 간주해 `top`을 clamp했고, 그 결과 뷰포트 1440x900에서 `856 - 520 - 12 = 324`라는 한 지점에 top이 고정됐습니다(실제 메뉴 높이 133px).
- 마운트 시 `useLayoutEffect` + `ResizeObserver`로 메뉴의 실제 렌더 크기를 측정하고, 커서 아래에 자리가 없으면 커서를 바닥 삼아 위로 펼칩니다(네이티브 컨텍스트 메뉴 문법).
- 높이 상한을 `--canvas-menu-max-height` geometry 변수로 뷰포트에서 산출해 520px보다 낮은 화면에서도 메뉴가 잘리지 않게 합니다.

캔버스(`canvas/canvas.tsx`)와 사이드바(`sidebar/operations-side-bar.tsx`)가 같은 `CanvasContextMenu`를 쓰므로 두 표면이 한 번에 고쳐집니다. 호출부 시그니처는 그대로입니다.

## Test Plan

- [x] `npx vitest run tests/canvas-context-menu-anchor.test.tsx tests/canvas-context-menu-initial-prompt.test.tsx tests/instrument-design-contract.test.ts` — 3 files / 33 tests pass
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 1068 passed / 1 failed(`server.test.ts > issues Theater-bound dedicated MCP sessions ...` 는 canary 기준선에서도 동일하게 실패하는 선존 실패)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] headless 실측(1440x900): 캔버스 y=200/500/800, 사이드바 y=200/500/820 6지점 모두 커서에 일치. 하단 지점은 메뉴 bottom이 커서에 정렬(위로 펼침)
- [x] headless 실측: 우측 경계 가로 clamp 정상, 뷰포트 400px에서 상한 `332px` 산출, 열린 뒤 메뉴가 500px로 커져도 `top: 456px -> 12px` 재배치되어 화면 안 유지
- [x] Changelog: `.changelog.d/pr-377.md` 추가 — 그룹 문법(`### fleet-console` / `#### Fixed`), 영문+`ko:` 인접 요약, `node scripts/compile-changelog-fragments.mjs --check` 통과(24 entries validated)