### PR TITLE
feat(console): defer operation and theater deletion behind an undo window

### DIFF
--- a/.changelog.d/pr-378.md
+++ b/.changelog.d/pr-378.md
@@ -1,0 +1,7 @@
+### fleet-console
+#### Added
+- [fleet-console] Hold a closed Operation or a forgotten Theater for eight seconds before deleting it for good, with an undo toast and a Mod+Z shortcut to take the action back. Restored Operations come back dormant and start only when relaunched.
+  ko: 닫은 Operation과 잊은 Theater를 8초 동안 보관한 뒤 영구 삭제하고, 그동안 undo 토스트와 Mod+Z 단축키로 되돌릴 수 있게 합니다. 복원된 Operation은 dormant 상태로 돌아오며 다시 실행할 때만 기동합니다.
+#### Changed
+- [fleet-console] Answer a delete request for an Operation that no longer exists with a success response instead of a not-found error, so repeating a close is harmless.
+  ko: 이미 없는 Operation에 대한 삭제 요청에 not-found 오류 대신 성공 응답을 돌려주어, 닫기를 반복해도 문제가 없게 합니다.

--- a/runtime/fleet-console/core/client/src/api.ts
+++ b/runtime/fleet-console/core/client/src/api.ts
@@ -89,7 +89,25 @@ export interface OperationGroupPatchInput {
   readonly order?: number;
 }
 
-const FORBIDDEN_BROWSER_PAYLOAD_KEYS = ["canonicalCwd", "cwd", "providerSession", "ticket", "token", "transcriptPath"] as const;
+export interface DeferredDeletionReceipt {
+  readonly deletionId: string;
+  readonly kind: "operation" | "theater";
+  readonly targetId: string;
+  readonly expiresAt: number;
+}
+
+export interface DeferredDeletionResponse {
+  readonly ok: true;
+  readonly deletion: DeferredDeletionReceipt | null;
+}
+
+export interface DeferredRestoreResponse {
+  readonly ok: true;
+  readonly kind: "operation" | "theater";
+  readonly targetId: string;
+}
+
+const FORBIDDEN_BROWSER_PAYLOAD_KEYS = ["canonicalCwd", "cwd", "providerSession", "realpath", "ticket", "token", "transcriptPath"] as const;
 
 export class ApiError extends Error {
   readonly status: number;
@@ -222,9 +240,26 @@ export async function fetchPlansSearch(theaterId: string, query: string, limit: 
   return await response.json() as PlansSearchResult;
 }
 
-export async function forgetTheater(theaterId: string, signal?: AbortSignal): Promise<void> {
+export async function forgetTheater(theaterId: string, signal?: AbortSignal): Promise<DeferredDeletionResponse> {
   const response = await fetch(`/api/v1/theaters/${encodeURIComponent(theaterId)}`, { method: "DELETE", signal });
   await assertOk(response);
+  return assertDeferredDeletionResponse(await response.json(), response.status);
+}
+
+export async function deleteOperation(operationId: string, signal?: AbortSignal): Promise<DeferredDeletionResponse> {
+  const response = await fetch(`/api/v1/operations/${encodeURIComponent(operationId)}`, { method: "DELETE", signal });
+  await assertOk(response);
+  return assertDeferredDeletionResponse(await response.json(), response.status);
+}
+
+export async function restoreDeletion(deletionId: string, signal?: AbortSignal): Promise<DeferredRestoreResponse> {
+  const response = await fetch(`/api/v1/deletions/${encodeURIComponent(deletionId)}/restore`, { method: "POST", signal });
+  await assertOk(response);
+  const payload = await response.json() as Partial<DeferredRestoreResponse>;
+  if (!payload || payload.ok !== true || (payload.kind !== "operation" && payload.kind !== "theater") || typeof payload.targetId !== "string" || hasForbiddenBrowserPayloadKey(payload)) {
+    throw new ApiError(response.status, "Invalid deletion restore response");
+  }
+  return { ok: true, kind: payload.kind, targetId: payload.targetId };
 }
 
 export async function fetchOperations(theaterId?: string | null, signal?: AbortSignal): Promise<readonly OperationNode[]> {
@@ -581,6 +616,33 @@ function hasForbiddenBrowserPayloadKey(value: unknown): boolean {
   if (!value || typeof value !== "object") return false;
   const payload = value as Record<string, unknown>;
   return FORBIDDEN_BROWSER_PAYLOAD_KEYS.some((key) => key in payload);
+}
+
+function assertDeferredDeletionResponse(value: unknown, status: number): DeferredDeletionResponse {
+  const payload = value as { readonly ok?: unknown; readonly deletion?: unknown };
+  if (!payload || payload.ok !== true || hasForbiddenBrowserPayloadKey(payload)) {
+    throw new ApiError(status, "Invalid deferred deletion response");
+  }
+  if (payload.deletion === null) return { ok: true, deletion: null };
+  const deletion = payload.deletion as Partial<DeferredDeletionReceipt>;
+  if (!deletion
+    || typeof deletion.deletionId !== "string"
+    || (deletion.kind !== "operation" && deletion.kind !== "theater")
+    || typeof deletion.targetId !== "string"
+    || typeof deletion.expiresAt !== "number"
+    || !Number.isFinite(deletion.expiresAt)
+    || hasForbiddenBrowserPayloadKey(deletion)) {
+    throw new ApiError(status, "Invalid deferred deletion receipt");
+  }
+  return {
+    ok: true,
+    deletion: {
+      deletionId: deletion.deletionId,
+      kind: deletion.kind,
+      targetId: deletion.targetId,
+      expiresAt: deletion.expiresAt,
+    },
+  };
 }
 
 async function assertOk(response: Response): Promise<void> {

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -214,7 +214,7 @@ export function App() {
           <Route path="*" element={<Navigate to="/operations" replace />} />
         </Routes>
       </main>
-      <OperationSearch state={state} railPanels={paletteRailPanels} plugins={registry.plugins} />
+      <OperationSearch state={state} railPanels={paletteRailPanels} plugins={registry.plugins} onDeferredDeletion={enqueueDeletion} />
       {state.keyboardShortcutsOpen ? <KeyboardShortcutsDialog onClose={closeKeyboardShortcuts} /> : null}
       <WhatsNewModal state={state} />
       <CommissioningOverlay state={state} />

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -1,13 +1,14 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 
-import { fetchGroups, fetchOperations, fetchTheaterBootstrap } from "./api.js";
+import { fetchGroups, fetchOperations, fetchTheaterBootstrap, fetchTheaters, restoreDeletion, type DeferredDeletionReceipt } from "./api.js";
 import { CommandBand } from "./components/command-band.js";
 import { CommissioningOverlay } from "./components/commissioning-overlay.js";
 import { KeyboardShortcutsDialog } from "./components/keyboard-shortcuts-dialog.js";
 import { takeKeyboardShortcutsReturnFocus } from "./keyboard-shortcuts-return-focus.js";
 import { OperationSearch } from "./components/operation-search.js";
 import { Toast } from "./components/toast.js";
+import { appendPendingDeletion, deletionCountdownSeconds, latestPendingDeletion } from "./deletion-undo.js";
 import { WhatsNewModal } from "./components/whatsnew-modal.js";
 import { useGlobalSettingsStore } from "./global-settings-store.js";
 import { installConsoleGlobalShortcuts } from "./global-shortcuts.js";
@@ -19,7 +20,7 @@ import { Operations } from "./pages/operations.js";
 import { BUILT_IN_RAIL_PANELS } from "./rail/built-in-panels.js";
 import { toggleRailChrome } from "./rail/rail-store.js";
 import { refreshObserverStatus } from "./operations-sse.js";
-import { closeKeyboardShortcuts, hydrateGroups, hydrateInitialOperations, hydrateOperations, hydrateTheaterBootstrap, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
+import { closeKeyboardShortcuts, hydrateGroups, hydrateInitialOperations, hydrateOperations, hydrateTheaterBootstrap, hydrateTheaters, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
 import { abortReleaseNotesFetch, requestReleaseNotes } from "./release-notes-fetch.js";
 import { getSideBarState, setSideBarCollapsed } from "./sidebar/operations-side-bar-store.js";
 import { resolveReleaseNotesLocale } from "./whatsnew-i18n.js";
@@ -27,6 +28,7 @@ import { resolveReleaseNotesLocale } from "./whatsnew-i18n.js";
 // 서버는 부팅 시 update 체크를 fire-and-forget으로 시작하므로, 첫 방문이 SSE 연결보다
 // 빠르면 GNB 배지가 누락될 수 있다. 짧은 지연 후 status를 1회만 재조회해 cold-start를 보정한다(폴링 아님).
 const UPDATE_STATUS_RECHECK_DELAY_MS = 6_000;
+const UNDO_WINDOW_MS = 8_000;
 
 export function App() {
   const state = useConsoleState();
@@ -35,6 +37,12 @@ export function App() {
   const location = useLocation();
   const registry = usePluginRegistry();
   const globalSettings = useGlobalSettingsStore();
+  const [pendingDeletions, setPendingDeletions] = useState<readonly DeferredDeletionReceipt[]>([]);
+  const [undoClock, setUndoClock] = useState(Date.now());
+  const pendingDeletionsRef = useRef(pendingDeletions);
+  const undoInFlightRef = useRef(false);
+  pendingDeletionsRef.current = pendingDeletions;
+  const activeDeletion = latestPendingDeletion(pendingDeletions, undoClock);
   const releaseNotesLocale = resolveReleaseNotesLocale(globalSettings.state?.language ?? "auto");
   const pathname = location.pathname;
   const operationsViewVisible = pathname.startsWith("/operations");
@@ -125,13 +133,74 @@ export function App() {
   }, [state.keyboardShortcutsOpen]);
 
   useEffect(() => {
+    if (pendingDeletions.length === 0) return;
+    const updateClock = () => {
+      const nextNow = Date.now();
+      setUndoClock(nextNow);
+      setPendingDeletions((current) => {
+        const next = current.filter((deletion) => deletion.expiresAt > nextNow);
+        pendingDeletionsRef.current = next;
+        return next;
+      });
+    };
+    updateClock();
+    const timer = window.setInterval(updateClock, 100);
+    return () => window.clearInterval(timer);
+  }, [pendingDeletions.length]);
+
+  const enqueueDeletion = useCallback((deletion: DeferredDeletionReceipt | null) => {
+    if (!deletion || deletion.expiresAt <= Date.now()) return;
+    setUndoClock(Date.now());
+    setPendingDeletions((current) => {
+      const next = appendPendingDeletion(current, deletion);
+      pendingDeletionsRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const undoLastClose = useCallback(() => {
+    if (undoInFlightRef.current) return;
+    const currentNow = Date.now();
+    const deletion = latestPendingDeletion(pendingDeletionsRef.current, currentNow);
+    if (!deletion) return;
+    undoInFlightRef.current = true;
+    void restoreDeletion(deletion.deletionId)
+      .then(() => {
+        setPendingDeletions((current) => {
+          const next = current.filter((item) => item.deletionId !== deletion.deletionId);
+          pendingDeletionsRef.current = next;
+          return next;
+        });
+        return Promise.allSettled([
+          fetchTheaters(null).then(hydrateTheaters),
+          fetchOperations(null).then(hydrateOperations),
+          fetchGroups(null).then(hydrateGroups),
+        ]);
+      })
+      .catch(() => {
+        if (deletion.expiresAt <= Date.now()) {
+          setPendingDeletions((current) => {
+            const next = current.filter((item) => item.deletionId !== deletion.deletionId);
+            pendingDeletionsRef.current = next;
+            return next;
+          });
+        }
+      })
+      .finally(() => {
+        undoInFlightRef.current = false;
+      });
+  }, []);
+
+  useEffect(() => {
     return installConsoleGlobalShortcuts({
       getSideBarCollapsed: () => getSideBarState().collapsed,
       setSideBarCollapsed,
       toggleOperationSearch,
       toggleRailChrome,
+      canUndoLastClose: () => pendingDeletionsRef.current.some((deletion) => deletion.expiresAt > Date.now()),
+      undoLastClose,
     });
-  }, []);
+  }, [undoLastClose]);
 
   return (
     <div className="console-shell">
@@ -139,7 +208,7 @@ export function App() {
       <main className="console-route-content">
         <Routes>
           <Route path="/" element={<Navigate to="/operations" replace />} />
-          <Route path="/operations" element={<Operations state={state} claimBootPanelMinimization={claimBootPanelMinimization} />} />
+          <Route path="/operations" element={<Operations state={state} claimBootPanelMinimization={claimBootPanelMinimization} onDeferredDeletion={enqueueDeletion} />} />
           <Route path="/carrier-settings" element={<Navigate to="/settings?section=terminal%3Acarriers" replace />} />
           <Route path="/settings" element={<GlobalSettings />} />
           <Route path="*" element={<Navigate to="/operations" replace />} />
@@ -154,6 +223,15 @@ export function App() {
         tone="error"
         title="Console link interrupted"
         message={state.connectionError ?? undefined}
+      />
+      <Toast
+        open={activeDeletion !== null}
+        tone="undo"
+        title={activeDeletion?.kind === "theater" ? "Theater forgotten" : "Operation closed"}
+        message={activeDeletion ? `${deletionCountdownSeconds(activeDeletion, undoClock)}s remaining` : undefined}
+        actionLabel="Undo"
+        onAction={undoLastClose}
+        progress={activeDeletion ? (activeDeletion.expiresAt - undoClock) / UNDO_WINDOW_MS : undefined}
       />
     </div>
   );

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -22,6 +22,7 @@ import {
 } from "../palette-commands.js";
 import { stashKeyboardShortcutsReturnFocus } from "../keyboard-shortcuts-return-focus.js";
 import { closeOperationCompletely } from "../operation-close.js";
+import type { DeferredDeletionReceipt } from "../api.js";
 import { getLoadedTheaterId, ensureDefaultGeometry, forceDropCompanionOperationId, getCompanionOperationId, loadForTheater, minimizeOperations, toggleFormationView } from "../canvas/canvas-store.js";
 import { openRailPanel, setRailChromeExpanded, toggleRailChrome } from "../rail/rail-store.js";
 import { getSideBarState, setSideBarCollapsed, toggleSideBarStatusAxis } from "../sidebar/operations-side-bar-store.js";
@@ -43,6 +44,8 @@ interface OperationSearchProps {
   readonly railPanels: readonly RailPanelDescriptor[];
   // virtual:fleet-plugins 의존을 테스트 경계 밖으로 밀기 위해 registry 직접 import 대신 prop으로 받는다.
   readonly plugins: readonly FleetClientPlugin[];
+  // 팔레트 close도 캔버스·사이드바와 같은 유예 큐에 receipt를 넣어야 Undo가 경로에 상관없이 동작한다.
+  readonly onDeferredDeletion?: (deletion: DeferredDeletionReceipt | null) => void;
 }
 
 const FOCUSABLE_SELECTOR = "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])";
@@ -50,7 +53,7 @@ const LISTBOX_ID = "operation-search-listbox";
 const UNASSIGNED_GROUP_KEY = "__unassigned__";
 const COMMAND_GROUP_HEADING_ID = "operation-search-heading-commands";
 
-export function OperationSearch({ state, railPanels, plugins }: OperationSearchProps) {
+export function OperationSearch({ state, railPanels, plugins, onDeferredDeletion }: OperationSearchProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const [query, setQuery] = useState("");
@@ -202,7 +205,7 @@ export function OperationSearch({ state, railPanels, plugins }: OperationSearchP
         if (getCompanionOperationId() === action.operationId) forceDropCompanionOperationId();
         const operation = state.operations.find((op) => op.id === action.operationId);
         const plugin = (operation ? plugins.find((candidate) => candidate.id === operation.pluginId) : null) ?? null;
-        void closeOperationCompletely(action.operationId, plugin);
+        void closeOperationCompletely(action.operationId, plugin).then((deletion) => onDeferredDeletion?.(deletion));
         break;
       }
       case "minimize-all-operations": {

--- a/runtime/fleet-console/core/client/src/components/toast.tsx
+++ b/runtime/fleet-console/core/client/src/components/toast.tsx
@@ -1,4 +1,4 @@
-export type ToastTone = "info" | "warn" | "error";
+export type ToastTone = "info" | "warn" | "error" | "undo";
 
 interface ToastProps {
   readonly open: boolean;
@@ -6,10 +6,13 @@ interface ToastProps {
   readonly message?: string;
   readonly tone?: ToastTone;
   readonly onDismiss?: () => void;
+  readonly actionLabel?: string;
+  readonly onAction?: () => void;
+  readonly progress?: number;
 }
 
 // 우하단 고정 토스트. 연결 이상 등 어떤 알림에도 재사용할 수 있도록 tone/title/message/onDismiss만 받는다.
-export function Toast({ open, title, message, tone = "info", onDismiss }: ToastProps) {
+export function Toast({ open, title, message, tone = "info", onDismiss, actionLabel, onAction, progress }: ToastProps) {
   if (!open) return null;
   return (
     <div className="app-toast-host">
@@ -18,7 +21,15 @@ export function Toast({ open, title, message, tone = "info", onDismiss }: ToastP
         <div className="app-toast-body">
           <p className="app-toast-title">{title}</p>
           {message ? <p className="app-toast-message">{message}</p> : null}
+          {typeof progress === "number" ? (
+            <span className="app-toast-progress" aria-hidden="true">
+              <span style={{ transform: `scaleX(${Math.max(0, Math.min(1, progress))})` }} />
+            </span>
+          ) : null}
         </div>
+        {actionLabel && onAction ? (
+          <button type="button" className="app-toast-action" onClick={onAction}>{actionLabel}</button>
+        ) : null}
         {onDismiss ? (
           <button type="button" className="app-toast-close" onClick={onDismiss} aria-label="Dismiss notification">
             ×

--- a/runtime/fleet-console/core/client/src/deletion-undo.ts
+++ b/runtime/fleet-console/core/client/src/deletion-undo.ts
@@ -1,0 +1,13 @@
+import type { DeferredDeletionReceipt } from "./api.js";
+
+export function appendPendingDeletion(current: readonly DeferredDeletionReceipt[], deletion: DeferredDeletionReceipt): readonly DeferredDeletionReceipt[] {
+  return [...current.filter((item) => item.deletionId !== deletion.deletionId), deletion];
+}
+
+export function latestPendingDeletion(current: readonly DeferredDeletionReceipt[], now: number): DeferredDeletionReceipt | null {
+  return [...current].reverse().find((deletion) => deletion.expiresAt > now) ?? null;
+}
+
+export function deletionCountdownSeconds(deletion: DeferredDeletionReceipt, now: number): number {
+  return Math.max(1, Math.ceil((deletion.expiresAt - now) / 1_000));
+}

--- a/runtime/fleet-console/core/client/src/global-shortcuts.ts
+++ b/runtime/fleet-console/core/client/src/global-shortcuts.ts
@@ -6,6 +6,8 @@ export interface ConsoleGlobalShortcutDependencies {
   readonly setSideBarCollapsed: (collapsed: boolean) => void;
   readonly toggleOperationSearch: () => void;
   readonly toggleRailChrome: () => void;
+  readonly canUndoLastClose?: () => boolean;
+  readonly undoLastClose?: () => void;
 }
 
 // This listener is intentionally installed on window: it owns Console-wide
@@ -13,6 +15,14 @@ export interface ConsoleGlobalShortcutDependencies {
 export function installConsoleGlobalShortcuts(dependencies: ConsoleGlobalShortcutDependencies, windowFor: Window = window): () => void {
   const handleKeyDown = (event: KeyboardEvent) => {
     if (isKeyboardShortcutsModalOpen() || isBlockingDialogOpen(windowFor.document)) return;
+    if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "z" && dependencies.canUndoLastClose?.()) {
+      const active = windowFor.document.activeElement;
+      if (active instanceof HTMLElement && (active.matches("input, textarea, [contenteditable='true']") || active.closest(".xterm"))) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      dependencies.undoLastClose?.();
+      return;
+    }
     if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
       event.preventDefault();
       event.stopImmediatePropagation();

--- a/runtime/fleet-console/core/client/src/operation-close.ts
+++ b/runtime/fleet-console/core/client/src/operation-close.ts
@@ -1,14 +1,22 @@
 import type { FleetClientPlugin } from "@fleet-console/sdk/plugin";
 
-import { fetchOperations } from "./api.js";
+import { deleteOperation, fetchOperations, type DeferredDeletionReceipt } from "./api.js";
 import { hydrateOperations } from "./store.js";
 
 // Operation 닫기의 단일 경로: plugin 정리 → host DELETE → 재수화.
 // operations 페이지(캔버스 프레임/사이드바 칩)와 팔레트 close 명령이 이 함수를 공유한다.
-export async function closeOperationCompletely(operationId: string, plugin: FleetClientPlugin | null): Promise<void> {
+// 호스트가 삭제를 유예하므로 receipt를 그대로 돌려주고, 호출자가 undo 토스트에 쓴다.
+export async function closeOperationCompletely(
+  operationId: string,
+  plugin: FleetClientPlugin | null,
+): Promise<DeferredDeletionReceipt | null> {
   try {
     if (plugin?.closeOperation) await plugin.closeOperation(operationId);
   } catch { /* 플러그인 close 오류는 무시 */ }
-  await fetch(`/api/v1/operations/${encodeURIComponent(operationId)}`, { method: "DELETE" }).catch(() => {});
+  let deletion: DeferredDeletionReceipt | null = null;
+  try {
+    deletion = (await deleteOperation(operationId)).deletion;
+  } catch { /* 삭제 요청 실패는 무시하고 재수화로 실제 상태를 따른다 */ }
   await fetchOperations(null).then(hydrateOperations).catch(() => {});
+  return deletion;
 }

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -6,6 +6,7 @@ import type { ClientApiCapability, FleetClientPlugin, OperationKindDescriptor } 
 
 import { addTheater, createGroup, deleteGroup, fetchGroups, fetchOperations, fetchTheaters, forgetTheater, issueTheaterFolderGrant, patchOperation, patchTheaterOrder, renameOperation, updateGroup, ApiError } from "../api.js";
 import { closeOperationCompletely } from "../operation-close.js";
+import type { DeferredDeletionReceipt } from "../api.js";
 import { claimTopZIndex, ensureDefaultGeometry, focusOperation as focusCanvasOperation, forceDropCompanionOperationId, getCompanionOperationId, getFocusLayerRevision, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useCompanionOperationId, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
 import { screenToCanvas, type CanvasPoint } from "../canvas/coordinates.js";
 import { playMinimizeFlight, playRestoreFlight } from "../canvas/panel-motion.js";

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -29,9 +29,10 @@ const closingOperationIds = new Set<string>();
 interface OperationsProps {
   readonly state: ConsoleState;
   readonly claimBootPanelMinimization: (theaterId: string) => readonly string[] | null;
+  readonly onDeferredDeletion: (deletion: DeferredDeletionReceipt | null) => void;
 }
 
-export function Operations({ state, claimBootPanelMinimization }: OperationsProps) {
+export function Operations({ state, claimBootPanelMinimization, onDeferredDeletion }: OperationsProps) {
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const maximizedOperationId = useMaximizedOperationId();
   const companionOperationId = useCompanionOperationId();
@@ -288,8 +289,10 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
     closingOperationIds.add(operationId);
     const pluginId = stateRef.current.operations.find((op) => op.id === operationId)?.pluginId;
     const plugin = (pluginId ? registry.plugins.find((p) => p.id === pluginId) : null) ?? null;
-    void closeOperationCompletely(operationId, plugin).finally(() => closingOperationIds.delete(operationId));
-  }, [registry.plugins]);
+    void closeOperationCompletely(operationId, plugin)
+      .then((deletion) => onDeferredDeletion(deletion))
+      .finally(() => closingOperationIds.delete(operationId));
+  }, [onDeferredDeletion, registry.plugins]);
 
   const handleAddTheater = useCallback(async (path: string) => {
     beginAddTheater();
@@ -314,18 +317,14 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
       fetchGroups(null).then(hydrateGroups),
     ]).then(() => {}).catch(() => {});
     try {
-      await forgetTheater(theaterId);
+      const response = await forgetTheater(theaterId);
       removeTheater(theaterId);
       await refreshCollections();
+      onDeferredDeletion(response.deletion);
     } catch (error) {
-      if (error instanceof ApiError && error.status === 404) {
-        removeTheater(theaterId);
-        await refreshCollections();
-        return;
-      }
       failAddTheater(error instanceof Error ? error.message : String(error));
     }
-  }, []);
+  }, [onDeferredDeletion]);
 
   return (
     <div className="console-body is-canvas">

--- a/runtime/fleet-console/core/client/src/shortcuts-catalog.ts
+++ b/runtime/fleet-console/core/client/src/shortcuts-catalog.ts
@@ -21,6 +21,7 @@ export const SHORTCUT_GROUPS: readonly ShortcutGroup[] = [
   {
     title: "Operations",
     entries: [
+      { combos: [["Mod", "Z"]], description: "Undo last close" },
       { combos: [["Esc"]], description: "Close the carrier job stream" },
       { combos: [["Shift", "Enter"]], description: "Insert a newline in the terminal instead of submitting" },
       { combos: [["Enter"], ["Esc"]], description: "Confirm or cancel a session rename" },

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -6264,6 +6264,10 @@
   border-color: var(--surface-rim-strong);
 }
 
+.app-toast--undo {
+  border-color: color-mix(in oklch, var(--brass) 42%, var(--surface-rim));
+}
+
 .app-toast-dot {
   margin-top: 5px;
   width: 8px;
@@ -6288,6 +6292,11 @@
   box-shadow: 0 0 10px var(--aurora-glow);
 }
 
+.app-toast--undo .app-toast-dot {
+  background: var(--brass);
+  box-shadow: 0 0 10px color-mix(in oklch, var(--brass) 36%, transparent);
+}
+
 .app-toast-body {
   display: flex;
   flex-direction: column;
@@ -6309,6 +6318,40 @@
   font-size: 11px;
   line-height: 1.5;
   word-break: break-word;
+}
+
+.app-toast-progress {
+  display: block;
+  width: 100%;
+  height: 2px;
+  margin-top: var(--space-2);
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--brass) 14%, transparent);
+}
+
+.app-toast-progress > span {
+  display: block;
+  width: 100%;
+  height: 100%;
+  transform-origin: left center;
+  background: var(--brass);
+  transition: transform 120ms linear;
+}
+
+.app-toast-action {
+  align-self: center;
+  flex: none;
+  padding: 5px 8px;
+  border: 1px solid color-mix(in oklch, var(--brass) 46%, var(--surface-rim));
+  border-radius: var(--radius-xs);
+  color: var(--text-primary);
+  font-size: 11px;
+  font-weight: var(--weight-medium);
+}
+
+.app-toast-action:hover {
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
 }
 
 .app-toast-close {

--- a/runtime/fleet-console/core/host/deferred-deletion.ts
+++ b/runtime/fleet-console/core/host/deferred-deletion.ts
@@ -1,0 +1,309 @@
+import crypto from "node:crypto";
+
+import type { DurableDeletionTombstone, DurableOperationGroup } from "./durable-state.js";
+import type { OperationNode, OperationStore } from "./operations/types.js";
+import { DELETION_GRACE_MS } from "./operations/types.js";
+import type { TheaterRegistration } from "./theaters.js";
+import type { TheaterRegistry } from "./theaters.js";
+
+export interface DeferredDeletionReceipt {
+  readonly deletionId: string;
+  readonly kind: "operation" | "theater";
+  readonly targetId: string;
+  readonly expiresAt: number;
+}
+
+export interface DeferredDeletionResponse {
+  readonly ok: true;
+  readonly deletion: DeferredDeletionReceipt | null;
+}
+
+export interface DeferredRestoreResponse {
+  readonly ok: true;
+  readonly kind: "operation" | "theater";
+  readonly targetId: string;
+}
+
+export class DeferredDeletionError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "DeferredDeletionError";
+    this.status = status;
+  }
+}
+
+export interface DeferredDeletionCoordinator {
+  readonly list: () => readonly DurableDeletionTombstone[];
+  readonly load: (tombstones: readonly DurableDeletionTombstone[]) => void;
+  readonly deleteOperation: (operationId: string) => DeferredDeletionReceipt | null;
+  readonly deleteTheater: (theaterId: string) => DeferredDeletionReceipt | null;
+  readonly restore: (deletionId: string) => Promise<DeferredRestoreResponse>;
+  readonly sweepExpired: () => void;
+  readonly hasPendingOperation: (operationId: string) => boolean;
+  readonly hasPendingTheater: (theaterId: string) => boolean;
+  readonly dispose: () => void;
+}
+
+interface DeferredDeletionCoordinatorDeps {
+  readonly operations: OperationStore;
+  readonly theaters: TheaterRegistry;
+  readonly save: (tombstones: readonly DurableDeletionTombstone[]) => void;
+  readonly publish: (channel: string, payload: unknown) => void;
+  readonly unregisterTheaterWorkspaces: (theaterId: string) => void;
+  readonly validateTheaterRestore: (theater: TheaterRegistration) => Promise<void>;
+  readonly registerTheaterWorkspace: (theater: TheaterRegistration) => Promise<void>;
+  readonly now?: () => number;
+  readonly randomId?: () => string;
+  readonly setTimer?: (callback: () => void, delay: number) => ReturnType<typeof setTimeout>;
+  readonly clearTimer?: (timer: ReturnType<typeof setTimeout>) => void;
+}
+
+const OPERATION_DELETED_EVENT_CHANNEL = "operation:deleted";
+const OPERATION_RESTORED_EVENT_CHANNEL = "operation:restored";
+const OPERATION_PURGED_EVENT_CHANNEL = "operation:purged";
+const PURGE_RETRY_MS = 1_000;
+
+export function createDeferredDeletionCoordinator(deps: DeferredDeletionCoordinatorDeps): DeferredDeletionCoordinator {
+  const now = deps.now ?? Date.now;
+  const randomId = deps.randomId ?? crypto.randomUUID;
+  const setTimer = deps.setTimer ?? setTimeout;
+  const clearTimer = deps.clearTimer ?? clearTimeout;
+  let tombstones: readonly DurableDeletionTombstone[] = [];
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  function list(): readonly DurableDeletionTombstone[] {
+    return tombstones;
+  }
+
+  function load(nextTombstones: readonly DurableDeletionTombstone[]): void {
+    tombstones = [...nextTombstones];
+    schedule();
+  }
+
+  function deleteOperation(operationId: string): DeferredDeletionReceipt | null {
+    sweepExpired();
+    const existing = tombstones.find((item) => item.kind === "operation" && item.targetId === operationId);
+    if (existing) return toReceipt(existing);
+    const operation = deps.operations.get(operationId);
+    if (!operation) return null;
+    const previousOperations = deps.operations.list();
+    const deletedAt = now();
+    const tombstone: DurableDeletionTombstone = {
+      deletionId: randomId(),
+      targetId: operation.id,
+      deletedAt,
+      expiresAt: deletedAt + DELETION_GRACE_MS,
+      kind: "operation",
+      operation,
+    };
+    const nextTombstones = [...tombstones, tombstone];
+    deps.operations.delete(operationId);
+    try {
+      deps.save(nextTombstones);
+    } catch (error) {
+      deps.operations.replace(previousOperations);
+      throw error;
+    }
+    tombstones = nextTombstones;
+    publishOperation(OPERATION_DELETED_EVENT_CHANNEL, operation);
+    schedule();
+    return toReceipt(tombstone);
+  }
+
+  function deleteTheater(theaterId: string): DeferredDeletionReceipt | null {
+    sweepExpired();
+    const existing = tombstones.find((item) => item.kind === "theater" && item.targetId === theaterId);
+    if (existing) return toReceipt(existing);
+    const theater = deps.theaters.get(theaterId);
+    if (!theater) return null;
+    const previousTheaters = deps.theaters.list();
+    const previousOperations = deps.operations.list();
+    const previousGroups = deps.operations.listAllGroups();
+    const deletedOperations = deps.operations.listByTheater(theaterId);
+    const deletedGroups = deps.operations.listGroups(theaterId);
+    const deletedAt = now();
+    const tombstone: DurableDeletionTombstone = {
+      deletionId: randomId(),
+      targetId: theater.id,
+      deletedAt,
+      expiresAt: deletedAt + DELETION_GRACE_MS,
+      kind: "theater",
+      theater,
+      operations: deletedOperations,
+      groups: deletedGroups,
+    };
+    const nextTombstones = [...tombstones, tombstone];
+    deps.theaters.remove(theaterId);
+    deps.operations.deleteByTheater(theaterId);
+    try {
+      deps.save(nextTombstones);
+    } catch (error) {
+      deps.theaters.restore(previousTheaters);
+      deps.operations.replace(previousOperations);
+      deps.operations.replaceGroups(previousGroups);
+      throw error;
+    }
+    tombstones = nextTombstones;
+    deps.unregisterTheaterWorkspaces(theaterId);
+    for (const operation of deletedOperations) publishOperation(OPERATION_DELETED_EVENT_CHANNEL, operation);
+    schedule();
+    return toReceipt(tombstone);
+  }
+
+  async function restore(deletionId: string): Promise<DeferredRestoreResponse> {
+    const restoredAt = now();
+    const tombstone = tombstones.find((item) => item.deletionId === deletionId);
+    if (!tombstone || tombstone.expiresAt <= restoredAt) {
+      if (tombstone) sweepExpired();
+      throw new DeferredDeletionError(404, "deletion_not_found");
+    }
+    if (tombstone.kind === "operation") {
+      if (deps.operations.get(tombstone.targetId) || !deps.theaters.get(tombstone.operation.theaterId)) {
+        throw new DeferredDeletionError(409, "restore_conflict");
+      }
+      const previousOperations = deps.operations.list();
+      const nextTombstones = tombstones.filter((item) => item.deletionId !== deletionId);
+      deps.operations.replace([...previousOperations, tombstone.operation]);
+      try {
+        deps.save(nextTombstones);
+      } catch (error) {
+        deps.operations.replace(previousOperations);
+        throw error;
+      }
+      tombstones = nextTombstones;
+      publishOperation(OPERATION_RESTORED_EVENT_CHANNEL, tombstone.operation);
+      schedule();
+      return { ok: true, kind: tombstone.kind, targetId: tombstone.targetId };
+    }
+
+    await deps.validateTheaterRestore(tombstone.theater);
+    if (deps.theaters.get(tombstone.targetId)
+      || tombstone.operations.some((operation) => deps.operations.get(operation.id))
+      || hasGroupConflict(tombstone.groups, deps.operations.listAllGroups())) {
+      throw new DeferredDeletionError(409, "restore_conflict");
+    }
+    const previousTheaters = deps.theaters.list();
+    const previousOperations = deps.operations.list();
+    const previousGroups = deps.operations.listAllGroups();
+    const nextTombstones = tombstones.filter((item) => item.deletionId !== deletionId);
+    deps.theaters.restore([...previousTheaters, tombstone.theater]);
+    deps.operations.replace([...previousOperations, ...tombstone.operations]);
+    deps.operations.replaceGroups([...previousGroups, ...tombstone.groups]);
+    try {
+      deps.save(nextTombstones);
+    } catch (error) {
+      deps.theaters.restore(previousTheaters);
+      deps.operations.replace(previousOperations);
+      deps.operations.replaceGroups(previousGroups);
+      throw error;
+    }
+    tombstones = nextTombstones;
+    await deps.registerTheaterWorkspace(tombstone.theater);
+    for (const operation of tombstone.operations) publishOperation(OPERATION_RESTORED_EVENT_CHANNEL, operation);
+    schedule();
+    return { ok: true, kind: tombstone.kind, targetId: tombstone.targetId };
+  }
+
+  function sweepExpired(): void {
+    const cutoff = now();
+    const expired = tombstones.filter((item) => item.expiresAt <= cutoff);
+    if (expired.length === 0) {
+      schedule();
+      return;
+    }
+    const expiredIds = new Set(expired.map((item) => item.deletionId));
+    const nextTombstones = tombstones.filter((item) => !expiredIds.has(item.deletionId));
+    try {
+      deps.save(nextTombstones);
+    } catch (error) {
+      schedule(PURGE_RETRY_MS);
+      throw error;
+    }
+    tombstones = nextTombstones;
+    for (const tombstone of expired) {
+      if (tombstone.kind === "operation") {
+        publishOperation(OPERATION_PURGED_EVENT_CHANNEL, tombstone.operation);
+      } else {
+        for (const operation of tombstone.operations) publishOperation(OPERATION_PURGED_EVENT_CHANNEL, operation);
+      }
+    }
+    schedule();
+  }
+
+  function hasPendingOperation(operationId: string): boolean {
+    sweepExpired();
+    return tombstones.some((item) => item.kind === "operation"
+      ? item.targetId === operationId
+      : item.operations.some((operation) => operation.id === operationId));
+  }
+
+  function hasPendingTheater(theaterId: string): boolean {
+    sweepExpired();
+    return tombstones.some((item) => item.kind === "theater" && item.targetId === theaterId);
+  }
+
+  function schedule(forcedDelay?: number): void {
+    if (timer) clearTimer(timer);
+    timer = null;
+    if (forcedDelay !== undefined) {
+      timer = setTimer(runScheduledSweep, forcedDelay);
+      timer.unref?.();
+      return;
+    }
+    const nearest = tombstones.reduce<number | null>((minimum, item) => minimum === null ? item.expiresAt : Math.min(minimum, item.expiresAt), null);
+    if (nearest === null) return;
+    timer = setTimer(runScheduledSweep, Math.max(0, nearest - now()));
+    timer.unref?.();
+  }
+
+  function runScheduledSweep(): void {
+    timer = null;
+    try {
+      sweepExpired();
+    } catch {
+      // 저장 실패는 다음 단일 재시도 타이머에서 다시 처리한다.
+    }
+  }
+
+  function dispose(): void {
+    if (timer) clearTimer(timer);
+    timer = null;
+  }
+
+  function publishOperation(channel: string, operation: OperationNode): void {
+    deps.publish(channel, {
+      operationId: operation.id,
+      pluginId: operation.pluginId,
+      type: operation.type,
+      ...(channel === OPERATION_RESTORED_EVENT_CHANNEL ? { operation } : {}),
+    });
+  }
+
+  return {
+    list,
+    load,
+    deleteOperation,
+    deleteTheater,
+    restore,
+    sweepExpired,
+    hasPendingOperation,
+    hasPendingTheater,
+    dispose,
+  };
+}
+
+function toReceipt(tombstone: DurableDeletionTombstone): DeferredDeletionReceipt {
+  return {
+    deletionId: tombstone.deletionId,
+    kind: tombstone.kind,
+    targetId: tombstone.targetId,
+    expiresAt: tombstone.expiresAt,
+  };
+}
+
+function hasGroupConflict(groups: readonly DurableOperationGroup[], existing: readonly DurableOperationGroup[]): boolean {
+  const existingIds = new Set(existing.map((group) => group.id));
+  return groups.some((group) => existingIds.has(group.id));
+}

--- a/runtime/fleet-console/core/host/durable-state.ts
+++ b/runtime/fleet-console/core/host/durable-state.ts
@@ -19,11 +19,28 @@ export interface DurableOperationGroup {
   readonly createdAt: number;
 }
 
+export interface DurableDeletionBase {
+  readonly deletionId: string;
+  readonly targetId: string;
+  readonly deletedAt: number;
+  readonly expiresAt: number;
+}
+
+export type DurableDeletionTombstone =
+  | (DurableDeletionBase & { readonly kind: "operation"; readonly operation: OperationNode })
+  | (DurableDeletionBase & {
+      readonly kind: "theater";
+      readonly theater: TheaterRegistration;
+      readonly operations: readonly OperationNode[];
+      readonly groups: readonly DurableOperationGroup[];
+    });
+
 export interface DurableConsoleState {
-  readonly version: 2;
+  readonly version: 3;
   readonly theaters: readonly TheaterRegistration[];
   readonly operations: readonly OperationNode[];
   readonly groups?: readonly DurableOperationGroup[];
+  readonly deletionTombstones?: readonly DurableDeletionTombstone[];
 }
 
 export interface CreateConsoleDurableStateStoreDeps {
@@ -32,7 +49,7 @@ export interface CreateConsoleDurableStateStoreDeps {
   readonly now?: () => number;
 }
 
-const STATE_VERSION = 2;
+export const STATE_VERSION = 3;
 const STATE_LOCK_DIR_NAME = "state.lock";
 const STATE_LOCK_OWNER_FILE_NAME = "owner.json";
 const STATE_TEMP_PREFIX = ".state.";
@@ -68,28 +85,41 @@ export function sanitizeDurableConsoleState(value: unknown): DurableConsoleState
     theaters: readTheaterRegistrations(upgraded.theaters),
     operations: readOperations(upgraded.operations),
     groups: readOperationGroups(upgraded.groups),
+    deletionTombstones: readDeletionTombstones(upgraded.deletionTombstones),
   };
 }
 
 export function emptyDurableConsoleState(): DurableConsoleState {
-  return { version: STATE_VERSION, theaters: [], operations: [], groups: [] };
+  return { version: STATE_VERSION, theaters: [], operations: [], groups: [], deletionTombstones: [] };
 }
 
 // 릴리스된 stable durable state(v1, flat 세션 레코드)을 현재 스키마(OperationNode)로 1회 변환한다.
 // 변환 결과는 readOperations의 sanitizeOperationNode가 다시 검증하므로 여기서는 모양만 맞춘다.
-// v1만 변환하고, 그 외 STATE_VERSION이 아닌 값은 상위 sanitize에서 empty 폴백된다.
+// 각 버전 단계를 순서대로 거쳐 단계별 기본값을 보존하고, 최종 sanitizer가 다시 검증한다.
 function migrateToCurrentVersion(value: Record<string, unknown>): Record<string, unknown> {
-  if (value.version === 1) return migrateV1ToV2(value);
-  return value;
+  let current = value;
+  if (current.version === 1) current = migrateV1ToV2(current);
+  if (current.version === 2) current = migrateV2ToV3(current);
+  return current;
 }
 
 function migrateV1ToV2(v1: Record<string, unknown>): Record<string, unknown> {
   const operations = Array.isArray(v1.operations) ? v1.operations.map(migrateV1Operation) : [];
   return {
-    version: STATE_VERSION,
+    version: 2,
     theaters: v1.theaters ?? [],
     operations,
     groups: [],
+  };
+}
+
+function migrateV2ToV3(v2: Record<string, unknown>): Record<string, unknown> {
+  return {
+    version: STATE_VERSION,
+    theaters: v2.theaters ?? [],
+    operations: v2.operations ?? [],
+    groups: v2.groups ?? [],
+    deletionTombstones: [],
   };
 }
 
@@ -274,4 +304,44 @@ function sanitizeOperationGroup(value: unknown): DurableOperationGroup | null {
   if (rawName.length > MAX_GROUP_NAME_LENGTH) return null;
   if (!VALID_GROUP_COLOR_KEYS.has(color)) return null;
   return { id, theaterId, name: rawName, color, order, createdAt };
+}
+
+function readDeletionTombstones(value: unknown): readonly DurableDeletionTombstone[] {
+  if (!Array.isArray(value)) return [];
+  const tombstones: DurableDeletionTombstone[] = [];
+  for (const item of value) {
+    const tombstone = sanitizeDeletionTombstone(item);
+    if (tombstone) tombstones.push(tombstone);
+  }
+  return tombstones;
+}
+
+function sanitizeDeletionTombstone(value: unknown): DurableDeletionTombstone | null {
+  if (!isRecord(value)) return null;
+  const deletionId = readNonEmptyString(value.deletionId);
+  const targetId = readNonEmptyString(value.targetId);
+  const deletedAt = readFiniteNumber(value.deletedAt);
+  const expiresAt = readFiniteNumber(value.expiresAt);
+  if (!deletionId || !targetId || deletedAt === null || expiresAt === null) return null;
+  if (value.kind === "operation") {
+    const operation = sanitizeOperationNode(value.operation);
+    if (!operation || operation.id !== targetId) return null;
+    return { deletionId, targetId, deletedAt, expiresAt, kind: "operation", operation };
+  }
+  if (value.kind === "theater") {
+    const theater = sanitizeTheaterRegistration(value.theater);
+    if (!theater || theater.id !== targetId || !Array.isArray(value.operations) || !Array.isArray(value.groups)) return null;
+    const operations = value.operations
+      .map(sanitizeOperationNode)
+      .filter((operation): operation is OperationNode => operation !== null);
+    const groups = value.groups
+      .map(sanitizeOperationGroup)
+      .filter((group): group is DurableOperationGroup => group !== null);
+    if (operations.length !== value.operations.length
+      || groups.length !== value.groups.length
+      || operations.some((operation) => operation.theaterId !== targetId)
+      || groups.some((group) => group.theaterId !== targetId)) return null;
+    return { deletionId, targetId, deletedAt, expiresAt, kind: "theater", theater, operations, groups };
+  }
+  return null;
 }

--- a/runtime/fleet-console/core/host/operations/routes.ts
+++ b/runtime/fleet-console/core/host/operations/routes.ts
@@ -1,5 +1,6 @@
 import type http from "node:http";
 
+import type { DeferredDeletionReceipt } from "../deferred-deletion.js";
 import type { OperationCatalogPlugin } from "../plugin-host/types.js";
 import type { OperationCreateInput, OperationGroup, OperationGroupCreateInput, OperationGroupPatchInput, OperationNode, OperationStore } from "./types.js";
 import { createSanitizedOpDto } from "./sanitize.js";
@@ -10,7 +11,8 @@ export interface OperationsRouterDeps {
   readonly readJsonBody: <T>(req: http.IncomingMessage) => Promise<T | null>;
   readonly writeJson: (res: http.ServerResponse, status: number, payload: unknown) => void;
   readonly persist: () => void;
-  readonly deleteOperation: (id: string) => boolean;
+  readonly deleteOperation: (id: string) => DeferredDeletionReceipt | null;
+  readonly isPendingDeletion?: (id: string) => boolean;
   readonly publishRenameEvent?: (event: OperationRenameEvent) => void;
   readonly broadcastOperationChanged?: (node: OperationNode) => void;
   readonly subscribeOperationSse?: (res: http.ServerResponse) => void;
@@ -103,6 +105,10 @@ async function handleCollection(req: http.IncomingMessage, res: http.ServerRespo
     deps.writeJson(res, 400, { error: "invalid_operation_accent" });
     return;
   }
+  if (typeof body.id === "string" && deps.isPendingDeletion?.(body.id)) {
+    deps.writeJson(res, 409, { error: "pending_deletion" });
+    return;
+  }
   try {
     const node = deps.store.create({
       id: typeof body.id === "string" ? body.id : undefined,
@@ -136,8 +142,8 @@ async function handleItem(req: http.IncomingMessage, res: http.ServerResponse, i
     return;
   }
   if (req.method === "DELETE") {
-    const deleted = deps.deleteOperation(id);
-    deps.writeJson(res, deleted ? 200 : 404, deleted ? { ok: true } : { error: "operation_not_found" });
+    const deletion = deps.deleteOperation(id);
+    deps.writeJson(res, 200, { ok: true, deletion });
     return;
   }
   const body = await deps.readJsonBody<PatchOperationBody>(req);

--- a/runtime/fleet-console/core/host/operations/types.ts
+++ b/runtime/fleet-console/core/host/operations/types.ts
@@ -65,3 +65,4 @@ export interface OperationStore {
 
 // 그룹 이름 최대 길이 — durable sanitize(영속 검증)와 store(생성/수정) 양쪽이 공유하는 단일 제한.
 export const MAX_GROUP_NAME_LENGTH = 64;
+export const DELETION_GRACE_MS = 8000;

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -15,7 +15,8 @@ import { DESKTOP_FULLSCREEN_EVENT, desktopFullscreenSnapshot } from "./desktop-f
 import { createDesktopFullscreenRouter } from "./desktop-fullscreen-routes.js";
 import { DESKTOP_THEME_EVENT, desktopThemeSnapshot } from "./desktop-theme.js";
 import { createDesktopThemeRouter } from "./desktop-theme-routes.js";
-import { createConsoleDurableStateStore, emptyDurableConsoleState, type DurableConsoleState } from "./durable-state.js";
+import { createDeferredDeletionCoordinator, DeferredDeletionError, type DeferredDeletionReceipt } from "./deferred-deletion.js";
+import { createConsoleDurableStateStore, emptyDurableConsoleState, STATE_VERSION, type DurableConsoleState } from "./durable-state.js";
 import { createGlobalSettingsRouter } from "./global-settings-routes.js";
 import { createPluginSettingsRouter } from "./plugin-settings-routes.js";
 import { createSystemFontsRouter } from "./system-fonts-routes.js";
@@ -110,7 +111,6 @@ const SERVER_TIMEOUT_MS = 30 * 60 * 1000;
 const MAX_BODY_BYTES = 1024 * 1024;
 const UPDATE_APPLY_FORBIDDEN_BODY_KEYS = new Set(["channel", "package", "packageName", "packageVersion", "packages", "targetVersion", "version"]);
 const OPERATION_RENAMED_EVENT_CHANNEL = "operation:renamed";
-const OPERATION_DELETED_EVENT_CHANNEL = "operation:deleted";
 export const PAIRING_IDENTITY_PATH = "/api/v1/pairing-identity";
 export const PAIRING_IDENTITY = { product: "fleet-console", schemaVersion: 1, pairingProtocolVersion: 1 } as const;
 export const SERVER_API_CATALOG: readonly ApiCatalogEntry[] = [
@@ -167,6 +167,13 @@ export const SERVER_API_CATALOG: readonly ApiCatalogEntry[] = [
     method: "DELETE",
     path: "/api/v1/theaters/:theaterId",
     summary: "Theater와 소속 Operation을 제거합니다.",
+    category: "Observer",
+    gate: "origin-write",
+  },
+  {
+    method: "POST",
+    path: "/api/v1/deletions/:deletionId/restore",
+    summary: "유예 중인 Operation 또는 Theater 삭제를 복구합니다.",
     category: "Observer",
     gate: "origin-write",
   },
@@ -315,17 +322,30 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   function publishPluginEvent(channel: string, payload: unknown): void {
     for (const listener of pluginEventListeners.get(channel) ?? []) listener(payload);
   }
-  // 모든 호스트 삭제 진입점은 삭제 성공 뒤 영속화와 단일 수명주기 발행을 이 경계에서 완료한다.
-  function deleteOperation(operationId: string): boolean {
-    const operation = operations.get(operationId);
-    if (!operation || !operations.delete(operationId)) return false;
-    persistDurableState();
-    publishPluginEvent(OPERATION_DELETED_EVENT_CHANNEL, {
-      operationId: operation.id,
-      pluginId: operation.pluginId,
-      type: operation.type,
-    });
-    return true;
+  const deletionCoordinator = createDeferredDeletionCoordinator({
+    operations,
+    theaters,
+    save: saveDurableState,
+    publish: publishPluginEvent,
+    unregisterTheaterWorkspaces: (theaterId) => codex.unregisterTheaterWorkspaces(theaterId),
+    validateTheaterRestore: async (theater) => {
+      try {
+        const restoredRealpath = await fs.promises.realpath(theater.path);
+        const stat = await fs.promises.stat(restoredRealpath);
+        if (!stat.isDirectory() || restoredRealpath !== theater.realpath || workspaceHash(restoredRealpath) !== theater.id) {
+          throw new Error("restore_conflict");
+        }
+      } catch {
+        throw new DeferredDeletionError(409, "restore_parent_missing");
+      }
+    },
+    registerTheaterWorkspace: async (theater) => {
+      await codex.registerWorkspace(theater.realpath, theater.lastOpenedAt, theater.id);
+    },
+  });
+  // 플러그인 capability는 기존 boolean 표면을 유지하되 실제 삭제는 receipt coordinator가 소유한다.
+  function deleteOperationForPlugin(operationId: string): boolean {
+    return deletionCoordinator.deleteOperation(operationId) !== null;
   }
   let desktopFullscreen = false;
   let unsubscribeUpdateCheckChanges = updateCheck.onChange?.(() => {
@@ -336,6 +356,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       list: () => operations.list(),
       get: (id) => operations.get(id),
       create: (input) => {
+        if (input.id && deletionCoordinator.hasPendingOperation(input.id)) throw new Error("pending_deletion");
         const operation = operations.create(input);
         persistDurableState();
         return operation;
@@ -351,7 +372,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
         }
         return operation;
       },
-      delete: deleteOperation,
+      delete: deleteOperationForPlugin,
       registerOperationType: (type) => {
         pluginOperationTypes.add(type);
         return () => {
@@ -572,7 +593,8 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     readJsonBody,
     writeJson,
     persist: persistDurableState,
-    deleteOperation,
+    deleteOperation: (operationId): DeferredDeletionReceipt | null => deletionCoordinator.deleteOperation(operationId),
+    isPendingDeletion: (operationId) => deletionCoordinator.hasPendingOperation(operationId),
     getPluginSensitiveFields: (pluginId) => [
       ...(pluginHost.sensitiveFieldsByPluginId.get(pluginId) ?? []),
       ...(pluginPayloadSanitizers.get(pluginId) ?? []),
@@ -671,6 +693,11 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     }
     if (pathname === "/api/v1/plans/list" || pathname === "/api/v1/plans/read" || pathname === "/api/v1/plans/events") {
       runAsyncBooleanHandler(plansRouter({ req, res, pathname }), res, () => false);
+      return;
+    }
+    const restoreMatch = pathname.match(/^\/api\/v1\/deletions\/([^/]+)\/restore$/);
+    if (restoreMatch) {
+      runAsyncHandler(handleDeferredDeletionRestore(req, res, decodeURIComponent(restoreMatch[1] ?? "")), res);
       return;
     }
     const theaterItemMatch = pathname.match(/^\/api\/v1\/theaters\/([^/]+)$/);
@@ -827,6 +854,11 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       writeJson(res, 400, { error: "invalid_folder_grant" });
       return;
     }
+    const canonicalCwd = canonicalizeTheaterPathSync(cwd);
+    if (deletionCoordinator.hasPendingTheater(workspaceHash(canonicalCwd))) {
+      writeJson(res, 409, { error: "pending_deletion" });
+      return;
+    }
     const theater = await theaters.register(cwd);
     await codex.registerWorkspace(theater.realpath, undefined, theater.id);
     persistDurableState();
@@ -857,16 +889,28 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       writeJson(res, 200, toTheaterInfo(theater, true));
       return;
     }
-    // DELETE는 idempotent해야 한다 — Theater가 레지스트리에 이미 없어도(유령 항목이나 중복 forget) 목표 상태(부재)는
-    // 이미 달성된 것이므로 404가 아닌 성공으로 처리하고, 남아 있을 수 있는 소속 Operation도 함께 정리한다.
-    theaters.remove(theaterId);
-    // Theater를 잊을 때 그 Theater가 소유한 root·nested Codex 워크스페이스를 모두 해제한다.
-    // 다른 Theater가 같은 workspace id를 소유하면 등록을 유지한다.
-    codex.unregisterTheaterWorkspaces(theaterId);
-    for (const operation of operations.listByTheater(theaterId)) deleteOperation(operation.id);
-    operations.deleteGroupsByTheater(theaterId);
-    persistDurableState();
-    writeJson(res, 200, { ok: true });
+    const deletion = deletionCoordinator.deleteTheater(theaterId);
+    writeJson(res, 200, { ok: true, deletion });
+  }
+
+  async function handleDeferredDeletionRestore(req: http.IncomingMessage, res: http.ServerResponse, deletionId: string): Promise<void> {
+    if (req.method !== "POST") {
+      writeJson(res, 405, { error: "Method not allowed" });
+      return;
+    }
+    if (!isTerminalAuthorized(req)) {
+      writeJson(res, 401, { error: "unauthorized" });
+      return;
+    }
+    try {
+      writeJson(res, 200, await deletionCoordinator.restore(deletionId));
+    } catch (error) {
+      if (error instanceof DeferredDeletionError) {
+        writeJson(res, error.status, { error: error.message });
+        return;
+      }
+      throw error;
+    }
   }
 
   function handleStatus(req: http.IncomingMessage, res: http.ServerResponse): void {
@@ -1103,6 +1147,12 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       operations.replace([]);
       operations.replaceGroups([]);
     }
+    deletionCoordinator.load(state.deletionTombstones ?? []);
+    try {
+      deletionCoordinator.sweepExpired();
+    } catch (error) {
+      console.warn(`[fleet-console] Expired deletion sweep deferred: ${error instanceof Error ? error.message : String(error)}`);
+    }
     // Codex WorkspaceRegistry는 인메모리이므로 durable Theater를 메타데이터만 복원한다.
     await restoreCodexWorkspaces();
   }
@@ -1157,15 +1207,20 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
 
   function persistDurableState(): void {
     try {
-      durableStateStore.save({
-        version: 2,
-        theaters: theaters.list(),
-        operations: operations.list(),
-        groups: operations.listAllGroups(),
-      });
+      saveDurableState(deletionCoordinator.list());
     } catch (error) {
       console.warn(`[fleet-console] Durable state save failed: ${error instanceof Error ? error.message : String(error)}`);
     }
+  }
+
+  function saveDurableState(deletionTombstones: ReturnType<typeof deletionCoordinator.list>): void {
+    durableStateStore.save({
+      version: STATE_VERSION,
+      theaters: theaters.list(),
+      operations: operations.list(),
+      groups: operations.listAllGroups(),
+      deletionTombstones,
+    });
   }
 
   async function stopServer(): Promise<void> {
@@ -1177,6 +1232,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     lockHandle = null;
     activeLockFile = null;
     activeEndpoint = null;
+    deletionCoordinator.dispose();
     try {
       await Promise.all([
         closeHttpServer(current),

--- a/runtime/fleet-console/tests/codex-wiki-storage-parity.test.ts
+++ b/runtime/fleet-console/tests/codex-wiki-storage-parity.test.ts
@@ -119,14 +119,16 @@ describe("Console and injected Wiki tools share Theater-root storage", () => {
 
     const forgotten = await fetch(`${fixture.endpoint}api/v1/theaters/${theaterB.id}`, { method: "DELETE" });
     expect(forgotten.status).toBe(200);
+    const forgottenBody = await forgotten.json() as { readonly deletion: { readonly deletionId: string } };
     const mruAfterForget = await fetch(`${fixture.endpoint}console/codex/api/entry/theater-a-entry`);
     expect(mruAfterForget.status).toBe(200);
     expect(await mruAfterForget.text()).toContain("A body");
 
     await rm(path.join(workspaceB.path, "knowledge"), { recursive: true, force: true });
     expect(await readFile(path.join(workspaceB.path, "knowledge.migrated.json"), "utf8")).toContain('"outcome":"copied"');
-    const reRegisteredB = await registerTheater(fixture.endpoint, fixture.theaterB);
-    const empty = await fetch(`${fixture.endpoint}api/v1/theaters/${reRegisteredB.id}/codex-workspace`, {
+    const restoredB = await fetch(`${fixture.endpoint}api/v1/deletions/${encodeURIComponent(forgottenBody.deletion.deletionId)}/restore`, { method: "POST" });
+    expect(restoredB.status).toBe(200);
+    const empty = await fetch(`${fixture.endpoint}api/v1/theaters/${theaterB.id}/codex-workspace`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: "{}",

--- a/runtime/fleet-console/tests/deferred-deletion.test.ts
+++ b/runtime/fleet-console/tests/deferred-deletion.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createDeferredDeletionCoordinator, DeferredDeletionError } from "../core/host/deferred-deletion.js";
+import type { DurableDeletionTombstone } from "../core/host/durable-state.js";
+import { createOperationStore } from "../core/host/operations/store.js";
+import { TheaterRegistry, type TheaterRegistration } from "../core/host/theaters.js";
+
+const THEATER: TheaterRegistration = {
+  id: "theater",
+  path: "/work/theater",
+  realpath: "/work/theater",
+  label: "theater",
+  registeredAt: "2026-01-01T00:00:00.000Z",
+  lastOpenedAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("deferred deletion coordinator", () => {
+  it("returns the same receipt for repeated deletion and blocks recreation during grace", () => {
+    const harness = createHarness();
+    harness.operations.create(makeOperation("op"));
+
+    const first = harness.coordinator.deleteOperation("op");
+    const repeated = harness.coordinator.deleteOperation("op");
+
+    expect(repeated).toEqual(first);
+    expect(harness.coordinator.hasPendingOperation("op")).toBe(true);
+    expect(harness.events.filter((event) => event.channel === "operation:deleted")).toHaveLength(1);
+  });
+
+  it("restores a Theater together with its Operations and groups", async () => {
+    const harness = createHarness();
+    harness.operations.create(makeOperation("op-a"));
+    harness.operations.create(makeOperation("op-b"));
+    harness.operations.createGroup({ id: "group-a", theaterId: THEATER.id, name: "Alpha", color: "blue" });
+    const deletion = harness.coordinator.deleteTheater(THEATER.id);
+    if (!deletion) throw new Error("expected deletion");
+
+    const restored = await harness.coordinator.restore(deletion.deletionId);
+
+    expect(restored).toEqual({ ok: true, kind: "theater", targetId: THEATER.id });
+    expect(harness.theaters.get(THEATER.id)).toEqual(THEATER);
+    expect(harness.operations.listByTheater(THEATER.id).map((operation) => operation.id)).toEqual(["op-a", "op-b"]);
+    expect(harness.operations.listGroups(THEATER.id).map((group) => group.id)).toEqual(["group-a"]);
+    expect(harness.events.filter((event) => event.channel === "operation:restored")).toHaveLength(2);
+  });
+
+  it("rolls memory back when the durable save fails", () => {
+    const harness = createHarness();
+    harness.operations.create(makeOperation("op"));
+    harness.failSave.value = true;
+
+    expect(() => harness.coordinator.deleteOperation("op")).toThrow("save_failed");
+    expect(harness.operations.get("op")).not.toBeNull();
+    expect(harness.coordinator.list()).toEqual([]);
+    expect(harness.events).toEqual([]);
+  });
+
+  it("rejects restore after expiry and purges on a startup sweep", async () => {
+    const harness = createHarness();
+    harness.operations.create(makeOperation("op"));
+    const deletion = harness.coordinator.deleteOperation("op");
+    if (!deletion) throw new Error("expected deletion");
+    harness.clock.value = deletion.expiresAt;
+
+    await expect(harness.coordinator.restore(deletion.deletionId)).rejects.toMatchObject({ status: 404 } satisfies Partial<DeferredDeletionError>);
+    expect(harness.coordinator.list()).toEqual([]);
+    expect(harness.events.some((event) => event.channel === "operation:purged")).toBe(true);
+
+    const startup = createHarness();
+    startup.clock.value = 10_000;
+    startup.coordinator.load([makeExpiredTombstone()]);
+    startup.coordinator.sweepExpired();
+    expect(startup.coordinator.list()).toEqual([]);
+    expect(startup.events).toEqual([expect.objectContaining({ channel: "operation:purged" })]);
+  });
+});
+
+function createHarness() {
+  const clock = { value: 1_000 };
+  const failSave = { value: false };
+  const operations = createOperationStore({ now: () => clock.value });
+  const theaters = new TheaterRegistry();
+  theaters.restore([THEATER]);
+  const events: Array<{ readonly channel: string; readonly payload: unknown }> = [];
+  const coordinator = createDeferredDeletionCoordinator({
+    operations,
+    theaters,
+    now: () => clock.value,
+    randomId: () => `deletion-${clock.value}`,
+    save: () => {
+      if (failSave.value) throw new Error("save_failed");
+    },
+    publish: (channel, payload) => events.push({ channel, payload }),
+    unregisterTheaterWorkspaces: vi.fn(),
+    validateTheaterRestore: async () => {},
+    registerTheaterWorkspace: async () => {},
+    setTimer: () => ({ unref: () => {} }) as unknown as ReturnType<typeof setTimeout>,
+    clearTimer: () => {},
+  });
+  return { clock, coordinator, events, failSave, operations, theaters };
+}
+
+function makeOperation(id: string) {
+  return {
+    id,
+    theaterId: THEATER.id,
+    type: "agent",
+    pluginId: "terminal",
+    title: id,
+    payload: { cwd: THEATER.path },
+    geometry: null,
+  };
+}
+
+function makeExpiredTombstone(): DurableDeletionTombstone {
+  return {
+    deletionId: "expired",
+    targetId: "expired-op",
+    deletedAt: 1,
+    expiresAt: 2,
+    kind: "operation",
+    operation: {
+      ...makeOperation("expired-op"),
+      ts: { createdAt: 1, updatedAt: 1 },
+    },
+  };
+}

--- a/runtime/fleet-console/tests/deletion-undo-client.test.tsx
+++ b/runtime/fleet-console/tests/deletion-undo-client.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DeferredDeletionReceipt } from "../core/client/src/api.js";
+import { Toast } from "../core/client/src/components/toast.js";
+import { appendPendingDeletion, deletionCountdownSeconds, latestPendingDeletion } from "../core/client/src/deletion-undo.js";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  document.body.replaceChildren();
+  root = null;
+  container = null;
+});
+
+describe("deletion Undo toast", () => {
+  it("renders status countdown and restores through Undo without moving focus automatically", () => {
+    const input = document.createElement("input");
+    document.body.prepend(input);
+    input.focus();
+    const onUndo = vi.fn();
+
+    act(() => {
+      root?.render(<Toast open tone="undo" title="Operation closed" message="8s remaining" actionLabel="Undo" onAction={onUndo} progress={1} />);
+    });
+
+    expect(container?.querySelector('[role="status"]')?.textContent).toContain("8s remaining");
+    expect(document.activeElement).toBe(input);
+    act(() => container?.querySelector<HTMLButtonElement>(".app-toast-action")?.click());
+    expect(onUndo).toHaveBeenCalledOnce();
+  });
+
+  it("counts down and chooses the most recent pending deletion first", () => {
+    const first = receipt("first", 9_000);
+    const second = receipt("second", 10_000);
+    const pending = appendPendingDeletion(appendPendingDeletion([], first), second);
+
+    expect(latestPendingDeletion(pending, 1_000)?.deletionId).toBe("second");
+    expect(deletionCountdownSeconds(second, 2_001)).toBe(8);
+    expect(latestPendingDeletion(pending, 9_500)?.deletionId).toBe("second");
+    expect(latestPendingDeletion(pending, 10_000)).toBeNull();
+  });
+});
+
+function receipt(deletionId: string, expiresAt: number): DeferredDeletionReceipt {
+  return { deletionId, kind: "operation", targetId: `${deletionId}-target`, expiresAt };
+}

--- a/runtime/fleet-console/tests/durable-state.test.ts
+++ b/runtime/fleet-console/tests/durable-state.test.ts
@@ -17,29 +17,29 @@ afterEach(() => {
 
 describe("durable console state", () => {
   it("falls back to an empty state for version mismatch or malformed data", () => {
-    expect(sanitizeDurableConsoleState({ version: 1, theaters: [], operations: [] })).toEqual({ version: 2, theaters: [], operations: [], groups: [] });
-    expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ id: "" }], operations: [{ id: "" }] })).toEqual({ version: 2, theaters: [], operations: [], groups: [] });
+    expect(sanitizeDurableConsoleState({ version: 1, theaters: [], operations: [] })).toEqual({ version: 3, theaters: [], operations: [], groups: [], deletionTombstones: [] });
+    expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ id: "" }], operations: [{ id: "" }] })).toEqual({ version: 3, theaters: [], operations: [], groups: [], deletionTombstones: [] });
   });
 
   it("drops legacy pathContext values without changing durable version", () => {
     const base = { id: "t", path: "/work/proj", realpath: "/work/proj", label: "proj", registeredAt: "1", lastOpenedAt: "2" };
-    expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, pathContext: "packages/core" }], operations: [] })).toMatchObject({ version: 2, theaters: [base] });
-    expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, pathContext: "../escape" }], operations: [] })).toMatchObject({ version: 2, theaters: [base] });
+    expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, pathContext: "packages/core" }], operations: [] })).toMatchObject({ version: 3, theaters: [base] });
+    expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, pathContext: "../escape" }], operations: [] })).toMatchObject({ version: 3, theaters: [base] });
   });
 
   it("round-trips optional Theater order without changing durable version", () => {
     const base = { id: "t", path: "/work/proj", realpath: "/work/proj", label: "proj", registeredAt: "1", lastOpenedAt: "2" };
 
     expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, order: 3 }], operations: [] })).toMatchObject({
-      version: 2,
+      version: 3,
       theaters: [{ ...base, order: 3 }],
     });
     expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, order: -1 }], operations: [] })).toMatchObject({
-      version: 2,
+      version: 3,
       theaters: [base],
     });
     expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, order: 1.5 }], operations: [] })).toMatchObject({
-      version: 2,
+      version: 3,
       theaters: [base],
     });
   });
@@ -70,7 +70,7 @@ describe("durable console state", () => {
       ],
     });
 
-    expect(migrated.version).toBe(2);
+    expect(migrated.version).toBe(3);
     expect(migrated.theaters).toHaveLength(1);
     expect(migrated.groups).toEqual([]);
     expect(migrated.operations).toEqual([
@@ -116,6 +116,34 @@ describe("durable console state", () => {
       { id: "agent-op", pluginId: "terminal", type: "agent" },
       { id: "shell-op", pluginId: "terminal", type: "shell" },
       { id: "demo-op", pluginId: "demo", type: "demo" },
+    ]);
+  });
+
+  it("migrates v2 to v3 and sanitizes tombstones item by item", () => {
+    const theater = { id: "t", path: "/work/proj", realpath: "/work/proj", label: "proj", registeredAt: "1", lastOpenedAt: "2" };
+    const operation = makeOperationNode({ id: "op", pluginId: "terminal", type: "agent" });
+    const theaterOperation = { ...operation, theaterId: theater.id };
+    const sanitized = sanitizeDurableConsoleState({
+      version: 3,
+      theaters: [],
+      operations: [],
+      groups: [],
+      deletionTombstones: [
+        { deletionId: "d-op", targetId: "op", deletedAt: 1, expiresAt: 2, kind: "operation", operation },
+        { deletionId: "d-theater", targetId: "t", deletedAt: 3, expiresAt: 4, kind: "theater", theater, operations: [theaterOperation], groups: [] },
+        { deletionId: "bad-theater", targetId: "t", deletedAt: 3, expiresAt: 4, kind: "theater", theater, operations: [theaterOperation, { id: "" }], groups: [] },
+        { deletionId: "", targetId: "bad", deletedAt: 1, expiresAt: 2, kind: "operation", operation },
+        { deletionId: "bad-number", targetId: "bad", deletedAt: Number.NaN, expiresAt: 2, kind: "operation", operation },
+      ],
+    });
+
+    expect(sanitizeDurableConsoleState({ version: 2, theaters: [theater], operations: [operation], groups: [] })).toMatchObject({
+      version: 3,
+      deletionTombstones: [],
+    });
+    expect(sanitized.deletionTombstones).toEqual([
+      expect.objectContaining({ deletionId: "d-op", kind: "operation", targetId: "op" }),
+      expect.objectContaining({ deletionId: "d-theater", kind: "theater", targetId: "t", operations: [expect.objectContaining({ id: "op" })] }),
     ]);
   });
 

--- a/runtime/fleet-console/tests/global-shortcuts.test.ts
+++ b/runtime/fleet-console/tests/global-shortcuts.test.ts
@@ -28,4 +28,35 @@ describe("Console global shortcuts", () => {
     expect(toggleOperationSearch).toHaveBeenCalledOnce();
     cleanup();
   });
+
+  it("runs Undo only while a grace window exists and ignores editable or xterm focus", () => {
+    const undoLastClose = vi.fn();
+    let active = false;
+    const cleanup = installConsoleGlobalShortcuts({
+      getSideBarCollapsed: () => false,
+      setSideBarCollapsed: vi.fn(),
+      toggleOperationSearch: vi.fn(),
+      toggleRailChrome: vi.fn(),
+      canUndoLastClose: () => active,
+      undoLastClose,
+    });
+    const dispatchUndo = () => window.dispatchEvent(new KeyboardEvent("keydown", { key: "z", metaKey: true, bubbles: true, cancelable: true }));
+
+    dispatchUndo();
+    active = true;
+    dispatchUndo();
+    const input = document.createElement("input");
+    document.body.append(input);
+    input.focus();
+    dispatchUndo();
+    const xterm = document.createElement("div");
+    xterm.className = "xterm";
+    xterm.tabIndex = 0;
+    document.body.append(xterm);
+    xterm.focus();
+    dispatchUndo();
+
+    expect(undoLastClose).toHaveBeenCalledOnce();
+    cleanup();
+  });
 });

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -15,6 +15,8 @@ const apiMocks = vi.hoisted(() => ({
   fetchTheaters: vi.fn(),
   fetchOperations: vi.fn(),
   fetchGroups: vi.fn(),
+  deleteOperation: vi.fn(),
+  restoreDeletion: vi.fn(),
 }));
 const keyboardShortcutMocks = vi.hoisted(() => ({
   shouldHandleOperationsKeyboardShortcut: vi.fn(),
@@ -115,6 +117,11 @@ beforeEach(() => {
   document.body.appendChild(container);
   root = createRoot(container);
   apiMocks.fetchGroups.mockResolvedValue([]);
+  apiMocks.deleteOperation.mockImplementation(async (operationId: string) => ({
+    ok: true,
+    deletion: { deletionId: `delete-${operationId}`, kind: "operation", targetId: operationId, expiresAt: Date.now() + 8_000 },
+  }));
+  apiMocks.restoreDeletion.mockResolvedValue({ ok: true, kind: "operation", targetId: "restored" });
   keyboardShortcutMocks.shouldHandleOperationsKeyboardShortcut.mockReturnValue(false);
   sideBarMocks.onFocus = null;
   sideBarMocks.onClose = null;

--- a/runtime/fleet-console/tests/operations.test.ts
+++ b/runtime/fleet-console/tests/operations.test.ts
@@ -156,7 +156,7 @@ describe("operations platform", () => {
         Object.assign(res, { status, payload });
       },
       persist: () => {},
-      deleteOperation: (id) => store.delete(id),
+      deleteOperation: (id) => store.delete(id) ? ({ deletionId: `delete-${id}`, kind: "operation", targetId: id, expiresAt: 8_000 }) : null,
       getPluginSensitiveFields: (pluginId) => (pluginId === "terminal" ? ["pluginSecret", "providerTitle"] : []),
     });
 
@@ -201,7 +201,7 @@ describe("operations platform", () => {
         Object.assign(res, { status, payload });
       },
       persist: () => {},
-      deleteOperation: (id) => store.delete(id),
+      deleteOperation: (id) => store.delete(id) ? ({ deletionId: `delete-${id}`, kind: "operation", targetId: id, expiresAt: 8_000 }) : null,
     });
 
     requestBody = { accent: "blue" };
@@ -235,7 +235,7 @@ describe("operations platform", () => {
         Object.assign(res, { status, payload });
       },
       persist: () => {},
-      deleteOperation: (id) => store.delete(id),
+      deleteOperation: (id) => store.delete(id) ? ({ deletionId: `delete-${id}`, kind: "operation", targetId: id, expiresAt: 8_000 }) : null,
       resolveLaunchCatalog: async () => ({
         plugins: [
           {

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -660,7 +660,7 @@ describe("console static and terminal ticket boundary", () => {
       body: JSON.stringify({ operationId: "missing-operation" }),
     });
     expect(await pluginDelete.json()).toEqual({ deleted: true });
-    expect(await pluginRepeat.json()).toEqual({ deleted: false });
+    expect(await pluginRepeat.json()).toEqual({ deleted: true });
     expect(await pluginMissing.json()).toEqual({ deleted: false });
 
     const coreDeleted = await createOperation(fixture, theater.id, { type: "agent", pluginId: "terminal" });
@@ -668,8 +668,12 @@ describe("console static and terminal ticket boundary", () => {
     const coreRepeat = await fetch(`${fixture.endpoint}api/v1/operations/${encodeURIComponent(coreDeleted.id)}`, { method: "DELETE" });
     const coreMissing = await fetch(`${fixture.endpoint}api/v1/operations/missing-operation`, { method: "DELETE" });
     expect(coreDelete.status).toBe(200);
-    expect(coreRepeat.status).toBe(404);
-    expect(coreMissing.status).toBe(404);
+    expect(coreRepeat.status).toBe(200);
+    expect(coreMissing.status).toBe(200);
+    const coreDeleteBody = await coreDelete.json() as { readonly deletion: unknown };
+    expect(await coreRepeat.json()).toEqual(coreDeleteBody);
+    expect(await coreMissing.json()).toEqual({ ok: true, deletion: null });
+    expect(JSON.stringify(coreDeleteBody)).not.toMatch(/cwd|realpath|providerSession|transcriptPath/u);
 
     const theaterDeletedA = await createOperation(fixture, theater.id, { type: "demo-a", pluginId: "demo" });
     const theaterDeletedB = await createOperation(fixture, theater.id, { type: "demo-b", pluginId: "demo" });
@@ -677,6 +681,9 @@ describe("console static and terminal ticket boundary", () => {
     const theaterRepeat = await fetch(`${fixture.endpoint}api/v1/theaters/${encodeURIComponent(theater.id)}`, { method: "DELETE" });
     expect(theaterDelete.status).toBe(200);
     expect(theaterRepeat.status).toBe(200);
+    const theaterDeleteBody = await theaterDelete.json() as { readonly deletion: unknown };
+    expect(await theaterRepeat.json()).toEqual(theaterDeleteBody);
+    expect(JSON.stringify(theaterDeleteBody)).not.toMatch(/cwd|realpath|providerSession|transcriptPath/u);
 
     const response = await fetch(`${fixture.endpoint}plugins/demo/deletion-events`);
     const body = await response.json() as { readonly events: ReadonlyArray<{ readonly payload: { readonly operationId: string; readonly pluginId: string; readonly type: string }; readonly operationPresent: boolean }> };
@@ -690,6 +697,106 @@ describe("console static and terminal ticket boundary", () => {
     for (const operationId of [pluginDeleted.id, coreDeleted.id, theaterDeletedA.id, theaterDeletedB.id]) {
       expect(body.events.filter((event) => event.payload.operationId === operationId)).toHaveLength(1);
     }
+  });
+
+  it("restores deferred Operation and Theater metadata without leaking sensitive server state", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-console-deletion-restore-"));
+    tempDirs.push(dir);
+    const fixture = await startFixture();
+    const theater = await createTheater(fixture, dir);
+    const operationId = "recoverable-operation";
+    const created = await fetch(`${fixture.endpoint}api/v1/operations`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: operationId,
+        theaterId: theater.id,
+        type: "agent",
+        pluginId: "terminal",
+        title: "Recoverable",
+        payload: {
+          cwd: dir,
+          providerSession: { provider: "codex", sessionId: "provider-secret", transcriptPath: "/secret/transcript.jsonl", capturedAt: "2026-07-25T00:00:00.000Z" },
+        },
+      }),
+    });
+    expect(created.status).toBe(201);
+
+    const deleted = await fetch(`${fixture.endpoint}api/v1/operations/${operationId}`, { method: "DELETE" });
+    const deletedBody = await deleted.json() as { readonly deletion: { readonly deletionId: string } };
+    const serializedReceipt = JSON.stringify(deletedBody);
+    expect(deleted.status).toBe(200);
+    expect(serializedReceipt).not.toMatch(/cwd|realpath|providerSession|provider-secret|transcriptPath|transcript\.jsonl/u);
+
+    const recreate = await fetch(`${fixture.endpoint}api/v1/operations`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: operationId, theaterId: theater.id, type: "agent", pluginId: "terminal", title: "Conflict" }),
+    });
+    expect(recreate.status).toBe(409);
+    await expect(recreate.json()).resolves.toEqual({ error: "pending_deletion" });
+
+    const restoreUrl = `${fixture.endpoint}api/v1/deletions/${encodeURIComponent(deletedBody.deletion.deletionId)}/restore`;
+    const unauthorized = await fetch(restoreUrl, { method: "POST", headers: { Origin: "http://127.0.0.1:9" } });
+    expect(unauthorized.status).toBe(401);
+    const restored = await fetch(restoreUrl, { method: "POST" });
+    const restoredBody = await restored.json();
+    expect(restored.status).toBe(200);
+    expect(restoredBody).toEqual({ ok: true, kind: "operation", targetId: operationId });
+    expect(JSON.stringify(restoredBody)).not.toMatch(/cwd|realpath|providerSession|provider-secret|transcriptPath|transcript\.jsonl/u);
+    const restoredTerminalSessions = await getJson<{ readonly sessions: ReadonlyArray<{ readonly sessionId: string; readonly status: string }> }>(`${fixture.endpoint}plugins/terminal/agent/sessions`);
+    expect(restoredTerminalSessions.sessions).toContainEqual(expect.objectContaining({ sessionId: operationId, status: "dormant" }));
+
+    const group = await fetch(`${fixture.endpoint}api/v1/operations/groups`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ theaterId: theater.id, name: "Restorable", color: "blue" }),
+    });
+    expect(group.status).toBe(201);
+    const groupBody = await group.json() as { readonly group: { readonly id: string } };
+    const grouped = await fetch(`${fixture.endpoint}api/v1/operations/${operationId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ groupId: groupBody.group.id }),
+    });
+    expect(grouped.status).toBe(200);
+    const restoredShell = await createShellOperation(fixture, theater.id);
+
+    const theaterDeleted = await fetch(`${fixture.endpoint}api/v1/theaters/${theater.id}`, { method: "DELETE" });
+    const theaterDeletedBody = await theaterDeleted.json() as { readonly deletion: { readonly deletionId: string } };
+    expect(JSON.stringify(theaterDeletedBody)).not.toMatch(/cwd|realpath|providerSession|provider-secret|transcriptPath|transcript\.jsonl/u);
+    const pendingGrant = await issueTheaterFolderGrant(fixture, dir);
+    const pendingTheaterRecreate = await fetch(`${fixture.endpoint}api/v1/theaters`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ folderGrantId: pendingGrant.folderGrantId }),
+    });
+    expect(pendingTheaterRecreate.status).toBe(409);
+    await expect(pendingTheaterRecreate.json()).resolves.toEqual({ error: "pending_deletion" });
+    const theaterRestored = await fetch(`${fixture.endpoint}api/v1/deletions/${encodeURIComponent(theaterDeletedBody.deletion.deletionId)}/restore`, { method: "POST" });
+    const theaterRestoredBody = await theaterRestored.json();
+    expect(theaterRestored.status).toBe(200);
+    expect(theaterRestoredBody).toEqual({ ok: true, kind: "theater", targetId: theater.id });
+    expect(JSON.stringify(theaterRestoredBody)).not.toMatch(/cwd|realpath|providerSession|provider-secret|transcriptPath|transcript\.jsonl/u);
+    const operationsAfterRestore = await getJson<{ readonly operations: ReadonlyArray<{ readonly id: string; readonly groupId?: string }> }>(`${fixture.endpoint}api/v1/operations`);
+    const groupsAfterRestore = await getJson<{ readonly groups: ReadonlyArray<{ readonly id: string }> }>(`${fixture.endpoint}api/v1/operations/groups`);
+    expect(operationsAfterRestore.operations).toContainEqual(expect.objectContaining({ id: operationId, groupId: groupBody.group.id }));
+    expect(groupsAfterRestore.groups).toContainEqual(expect.objectContaining({ id: groupBody.group.id }));
+    const dormantShellTicket = await fetch(`${fixture.endpoint}plugins/terminal/shell/ticket`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ operationId: restoredShell.id }),
+    });
+    expect(dormantShellTicket.status).toBe(409);
+    await expect(dormantShellTicket.json()).resolves.toEqual({ error: "operation_dormant" });
+    const relaunchedShell = await fetch(`${fixture.endpoint}plugins/terminal/shell/sessions/${encodeURIComponent(restoredShell.id)}/relaunch`, { method: "POST" });
+    expect(relaunchedShell.status).toBe(200);
+    const relaunchedShellTicket = await fetch(`${fixture.endpoint}plugins/terminal/shell/ticket`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ operationId: restoredShell.id }),
+    });
+    expect(relaunchedShellTicket.status).toBe(200);
   });
 
   it("serves plugin runtime manifest and shims through core routes", async () => {
@@ -1257,7 +1364,7 @@ describe("console static and terminal ticket boundary", () => {
     });
     const stateFile = path.join(fixture.carrierStoreDir, "console", "state.json");
     const state = JSON.parse(fs.readFileSync(stateFile, "utf8")) as { version: number; operations: Array<{ id?: string; pluginId?: string; type?: string; payload?: { providerSession?: unknown } }> };
-    expect(state.version).toBe(2);
+    expect(state.version).toBe(3);
     expect(state.operations).toHaveLength(1);
     expect(state.operations[0]).toMatchObject({ id: session.sessionId, pluginId: "terminal", type: "agent" });
     expect(state.operations[0]?.payload?.providerSession).toBeUndefined();
@@ -2628,7 +2735,7 @@ describe("observer theater forget", () => {
 
     const forget = await fetch(`${fixture.endpoint}api/v1/theaters/deadbeefdead`, { method: "DELETE" });
     expect(forget.status).toBe(200);
-    expect(await forget.json()).toEqual({ ok: true });
+    expect(await forget.json()).toEqual({ ok: true, deletion: null });
   });
 });
 
@@ -2672,7 +2779,7 @@ describe("observer theater order", () => {
     expect(patched.status).toBe(200);
     expect(patchedBody).toMatchObject({ id: theater.id, order: 3 });
     expect(listed.theaters.find((entry) => entry.id === theater.id)?.order).toBe(3);
-    expect(state.version).toBe(2);
+    expect(state.version).toBe(3);
     expect(state.theaters.find((entry) => entry.id === theater.id)?.order).toBe(3);
 
     await fixture.server.stop();

--- a/runtime/fleet-plugins/terminal/client/shell/dormant.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/shell/dormant.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const terminalSurface = vi.hoisted(() => vi.fn(() => <div data-terminal-surface />));
+
+vi.mock("../shared/index.js", () => ({ TerminalSurface: terminalSurface }));
+
+import { shellOperationKind } from "./index.js";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  terminalSurface.mockClear();
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  document.body.replaceChildren();
+  root = null;
+  container = null;
+});
+
+describe("restored Shell dormancy", () => {
+  it("does not mount a terminal until Relaunch succeeds", async () => {
+    const api = {
+      fetch: vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 })),
+      resync: vi.fn(),
+    };
+    const context = {
+      operationId: "shell-restored",
+      operation: {
+        id: "shell-restored",
+        theaterId: "theater",
+        type: "shell",
+        pluginId: "terminal",
+        title: "Shell",
+        payload: { restoredDormant: true },
+        geometry: null,
+        ts: { createdAt: 1, updatedAt: 1 },
+      },
+      api,
+    };
+
+    act(() => root?.render(shellOperationKind.render?.(context as never)));
+    expect(container?.textContent).toContain("Dormant");
+    expect(container?.textContent).toContain("Relaunch");
+    expect(terminalSurface).not.toHaveBeenCalled();
+
+    await act(async () => {
+      container?.querySelector<HTMLButtonElement>(".canvas-operation-dormant")?.click();
+      await vi.waitFor(() => expect(api.resync).toHaveBeenCalledOnce());
+    });
+
+    expect(api.fetch).toHaveBeenCalledWith("terminal", "shell/sessions/shell-restored/relaunch", { method: "POST" });
+    expect(terminalSurface).toHaveBeenCalledOnce();
+  });
+});

--- a/runtime/fleet-plugins/terminal/client/shell/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/shell/index.tsx
@@ -38,6 +38,24 @@ export const operationKinds = [shellOperationKind] as const;
 export const plugins = [shellPlugin] as const;
 
 function ShellOperationView({ context }: { readonly context: OperationRenderContext }) {
+  const [relaunched, setRelaunched] = React.useState(false);
+  const restoredDormant = context.operation.payload.restoredDormant === true && !relaunched;
+  if (restoredDormant) {
+    return (
+      <button type="button" className="canvas-operation-dormant" onClick={() => {
+        void context.api.fetch("terminal", `shell/sessions/${encodeURIComponent(context.operationId)}/relaunch`, { method: "POST" })
+          .then((response) => {
+            if (!response.ok) throw new Error("shell_relaunch_failed");
+            setRelaunched(true);
+            context.api.resync();
+          })
+          .catch(() => {});
+      }}>
+        <span className="canvas-operation-dormant-status">Dormant</span>
+        <span className="canvas-operation-dormant-action">Relaunch</span>
+      </button>
+    );
+  }
   return (
     <TerminalSurface
       operationId={context.operationId}

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
@@ -524,6 +524,9 @@ describe("Session Analyst server contract", () => {
     router.emitOperationDeleted({ operationId: "op", pluginId: "terminal" });
     await vi.waitFor(() => expect(dispose).toHaveBeenCalledOnce());
     await router.call("GET", "/api/v1/plugins/terminal/analysis/artifacts/deleted-artifact");
+    expect(router.responses.at(-1)).toMatchObject({ status: 200 });
+    router.emitOperationPurged({ operationId: "op", pluginId: "terminal" });
+    await router.call("GET", "/api/v1/plugins/terminal/analysis/artifacts/deleted-artifact");
     expect(router.responses.at(-1)).toMatchObject({ status: 404, body: { error: { message: "Analysis artifact was not found." } } });
   });
 
@@ -832,7 +835,7 @@ describe("Session Analyst server contract", () => {
 
 function createRouterHarness(initialHostAllowance: boolean) {
   let handler: ((context: { req: EventEmitter & { method: string; headers: Record<string, string>; socket: { localPort: number } }; res: EventEmitter; pathname: string }) => Promise<boolean>) | undefined;
-  let operationDeletedHandler: ((payload: unknown) => void) | undefined;
+  const operationLifecycleHandlers = new Map<string, (payload: unknown) => void>();
   const responses: Array<{ status: number; body: unknown }> = [];
   const operation = { id: "op", pluginId: "terminal", type: "agent", theaterId: "theater", payload: {}, ts: { createdAt: 0, updatedAt: 0 } };
   const state = { allowHost: initialHostAllowance, operationPresent: true, operation };
@@ -847,7 +850,13 @@ function createRouterHarness(initialHostAllowance: boolean) {
       http: { writeJson: (_res: EventEmitter, status: number, body: unknown) => responses.push({ status, body }), readJsonBody: async (req: EventEmitter & { body?: unknown }) => req.body ?? null },
       operations: { get: (id: string) => state.operationPresent && id === "op" ? state.operation : null },
       paths: { capturesDir: "/capture", resolveTheaterPath: () => "/theater" },
-      events: { subscribe: (_channel: string, subscriber: (payload: unknown) => void) => { operationDeletedHandler = subscriber; return () => { operationDeletedHandler = undefined; }; } }, lifecycle: { registerCleanup: () => () => undefined },
+      events: {
+        subscribe: (channel: string, subscriber: (payload: unknown) => void) => {
+          operationLifecycleHandlers.set(channel, subscriber);
+          return () => { operationLifecycleHandlers.delete(channel); };
+        },
+      },
+      lifecycle: { registerCleanup: () => () => undefined },
     },
   };
   return {
@@ -858,7 +867,8 @@ function createRouterHarness(initialHostAllowance: boolean) {
       state.operation = { ...operation, theaterId: "replacement-theater", ts: { createdAt: 1, updatedAt: 1 } };
       state.operationPresent = true;
     },
-    emitOperationDeleted(payload: unknown) { operationDeletedHandler?.(payload); },
+    emitOperationDeleted(payload: unknown) { operationLifecycleHandlers.get("operation:deleted")?.(payload); },
+    emitOperationPurged(payload: unknown) { operationLifecycleHandlers.get("operation:purged")?.(payload); },
     async call(method: string, pathname: string, body?: unknown, headers: Record<string, string> = {}) {
       const writes: string[] = [];
       let ended = false;

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
@@ -14,6 +14,7 @@ import { readProviderSessionCapture } from "./session-capture.js";
 
 const AGENT_OPERATION_TYPE = "agent";
 const OPERATION_DELETED_EVENT_CHANNEL = "operation:deleted";
+const OPERATION_PURGED_EVENT_CHANNEL = "operation:purged";
 export const ANALYSIS_ARTIFACT_CSP = "sandbox allow-scripts; default-src 'self' data: blob: https: http:; script-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: https: http:; style-src 'self' 'unsafe-inline' data: blob: https: http:; img-src 'self' data: blob: https: http:; font-src 'self' data: blob: https: http:; connect-src *; frame-src 'self' data: blob: https: http:; media-src 'self' data: blob: https: http:; worker-src 'self' data: blob:; frame-ancestors 'self'";
 const ANALYSIS_ARTIFACT_THEMES = new Set(["instrument", "maritime", "carbon"]);
 const SAFE_ARTIFACT_COLOR = /^(?:#[\da-f]{3,8}|(?:rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch)\([\d.e%+\-/, ]{1,96}\)|Canvas|CanvasText)$/i;
@@ -84,11 +85,15 @@ export function registerAnalysisRoutes(ctx: FleetPluginServerContext, deps: Anal
       for (const marker of inFlightStartDeletionMarkers) {
         if (marker.operationId === payload.operationId) marker.deleted = true;
       }
-      registry.clearArtifacts(payload.operationId);
       void registry.stop(payload.operationId);
     }
   });
-  ctx.host.lifecycle.registerCleanup(async () => { unsubscribeDelete(); await registry.dispose(); });
+  const unsubscribePurge = ctx.host.events.subscribe(OPERATION_PURGED_EVENT_CHANNEL, (payload) => {
+    if (isOperationDeletedEvent(payload) && payload.pluginId === ctx.pluginId) {
+      registry.clearArtifacts(payload.operationId);
+    }
+  });
+  ctx.host.lifecycle.registerCleanup(async () => { unsubscribeDelete(); unsubscribePurge(); await registry.dispose(); });
 }
 
 async function handleCatalog(ctx: FleetPluginServerContext, req: http.IncomingMessage, res: http.ServerResponse, catalog: () => Promise<AnalysisCatalog>): Promise<boolean> {

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -44,6 +44,7 @@ interface AgentRouteDeps {
 const AGENT_OPERATION_TYPE = "agent";
 const CONSOLE_PTY_MESSAGE_DELIVERY = { submitDelayMs: 250 } as const;
 const OPERATION_RENAMED_EVENT_CHANNEL = "operation:renamed";
+const OPERATION_RESTORED_EVENT_CHANNEL = "operation:restored";
 const TERMINAL_PLUGIN_ID = "terminal";
 
 export function registerAgentRoutes(
@@ -155,6 +156,13 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       }
     }
     injectRenameCommand(payload.operationId, payload.title);
+  });
+  const unsubscribeRestore = ctx.host.events.subscribe(OPERATION_RESTORED_EVENT_CHANNEL, (payload) => {
+    if (!isOperationRestoredEvent(payload) || payload.pluginId !== ctx.pluginId || payload.type !== AGENT_OPERATION_TYPE) return;
+    const operation = ctx.host.operations.get(payload.operationId);
+    if (!operation || observability.getTerminalSessionInfo(operation.id)) return;
+    const dormant = injectOperation(operation);
+    observability.notifySessionUpdated(dormant);
   });
   backfillAgentOperationLaunchKinds();
   rehydrateDormantAgentOperations();
@@ -544,6 +552,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
   async function cleanup(): Promise<void> {
     reminderWriter.cancelAll();
     unsubscribeRename();
+    unsubscribeRestore();
     unsubscribeReminder();
     unsubscribeStream();
     await runtime.cleanup();
@@ -656,6 +665,12 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     ctx.host.http.writeJson(res, 401, { error: "Unauthorized" });
     return true;
   }
+}
+
+function isOperationRestoredEvent(value: unknown): value is { readonly operationId: string; readonly pluginId: string; readonly type: string } {
+  if (!value || typeof value !== "object") return false;
+  const event = value as { readonly operationId?: unknown; readonly pluginId?: unknown; readonly type?: unknown };
+  return typeof event.operationId === "string" && typeof event.pluginId === "string" && typeof event.type === "string";
 }
 
 export function createTerminalWikiToolSpecs(fleetDataDir: string) {

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -44,6 +44,7 @@ interface AgentRouteDeps {
 const AGENT_OPERATION_TYPE = "agent";
 const CONSOLE_PTY_MESSAGE_DELIVERY = { submitDelayMs: 250 } as const;
 const OPERATION_RENAMED_EVENT_CHANNEL = "operation:renamed";
+const OPERATION_PURGED_EVENT_CHANNEL = "operation:purged";
 const OPERATION_RESTORED_EVENT_CHANNEL = "operation:restored";
 const TERMINAL_PLUGIN_ID = "terminal";
 
@@ -156,6 +157,10 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       }
     }
     injectRenameCommand(payload.operationId, payload.title);
+  });
+  const unsubscribePurge = ctx.host.events.subscribe(OPERATION_PURGED_EVENT_CHANNEL, (payload) => {
+    if (!isOperationRestoredEvent(payload) || payload.pluginId !== ctx.pluginId || payload.type !== AGENT_OPERATION_TYPE) return;
+    unlinkProviderSessionCapture(payload.operationId, { capturesDir: ctx.host.paths.capturesDir });
   });
   const unsubscribeRestore = ctx.host.events.subscribe(OPERATION_RESTORED_EVENT_CHANNEL, (payload) => {
     if (!isOperationRestoredEvent(payload) || payload.pluginId !== ctx.pluginId || payload.type !== AGENT_OPERATION_TYPE) return;
@@ -546,13 +551,15 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     pendingRuntimeSessions.delete(sessionId);
     observability.removeTerminalSession(sessionId);
     ctx.host.operations.delete(sessionId);
-    unlinkProviderSessionCapture(sessionId, { capturesDir: ctx.host.paths.capturesDir });
+    // capture는 여기서 지우지 않는다 — 삭제가 유예되는 동안 undo가 복원해도 transcript가 없는
+    // 껍데기가 되기 때문이다. 실제 정리는 유예가 만료되는 operation:purged에서 한다.
   }
 
   async function cleanup(): Promise<void> {
     reminderWriter.cancelAll();
     unsubscribeRename();
     unsubscribeRestore();
+    unsubscribePurge();
     unsubscribeReminder();
     unsubscribeStream();
     await runtime.cleanup();

--- a/runtime/fleet-plugins/terminal/server/shell.ts
+++ b/runtime/fleet-plugins/terminal/server/shell.ts
@@ -5,7 +5,18 @@ import type { TerminalRuntime } from "./shared/index.js";
 
 type TicketBody = { readonly operationId?: unknown; readonly sessionId?: unknown };
 
+const OPERATION_RESTORED_EVENT_CHANNEL = "operation:restored";
+const RESTORED_DORMANT_PAYLOAD_KEY = "restoredDormant";
+
 export function registerShellRoutes(ctx: FleetPluginServerContext, runtime: TerminalRuntime): void {
+    const unsubscribeRestore = ctx.host.events.subscribe(OPERATION_RESTORED_EVENT_CHANNEL, (payload) => {
+      if (!isRestoredShellEvent(payload, ctx.pluginId)) return;
+      const operation = ctx.host.operations.get(payload.operationId);
+      if (!operation) return;
+      // 복구된 Shell은 durable 메타데이터만 되살리고, Relaunch 전에는 ticket/PTY 경로를 열지 않는다.
+      ctx.host.operations.patch(operation.id, { payload: { ...operation.payload, [RESTORED_DORMANT_PAYLOAD_KEY]: true } });
+    });
+    ctx.host.lifecycle.registerCleanup(unsubscribeRestore);
     registerRouter(ctx, "shell/ticket", async ({ req, res }) => {
       if (req.method !== "POST") {
         ctx.host.http.writeJson(res, 405, { error: "Method not allowed" });
@@ -30,6 +41,10 @@ export function registerShellRoutes(ctx: FleetPluginServerContext, runtime: Term
         ctx.host.http.writeJson(res, 409, { error: "invalid_shell_operation" });
         return true;
       }
+      if (operation.payload[RESTORED_DORMANT_PAYLOAD_KEY] === true) {
+        ctx.host.http.writeJson(res, 409, { error: "operation_dormant" });
+        return true;
+      }
       const theaterPath = ctx.host.paths.resolveTheaterPath(operation.theaterId);
       if (!theaterPath) {
         ctx.host.http.writeJson(res, 404, { error: "theater_not_found" });
@@ -51,7 +66,29 @@ export function registerShellRoutes(ctx: FleetPluginServerContext, runtime: Term
       return true;
     });
     registerRouter(ctx, "shell/sessions", ({ req, res, pathname }) => {
-      const operationId = decodeURIComponent(pathname.slice(`${ctx.basePath}/shell/sessions/`.length));
+      const suffix = pathname.slice(`${ctx.basePath}/shell/sessions/`.length);
+      const match = suffix.match(/^([^/]+)(?:\/(relaunch))?$/);
+      if (!match) return false;
+      const operationId = decodeURIComponent(match[1] ?? "");
+      if (match[2] === "relaunch") {
+        if (req.method !== "POST") {
+          ctx.host.http.writeJson(res, 405, { error: "Method not allowed" });
+          return true;
+        }
+        if (!ctx.host.security.isTerminalAuthorized(req)) {
+          ctx.host.http.writeJson(res, 401, { error: "unauthorized" });
+          return true;
+        }
+        const operation = ctx.host.operations.get(operationId);
+        if (!operation || operation.type !== "shell" || operation.pluginId !== ctx.pluginId) {
+          ctx.host.http.writeJson(res, 404, { error: "operation_not_found" });
+          return true;
+        }
+        const { [RESTORED_DORMANT_PAYLOAD_KEY]: _dormant, ...payload } = operation.payload;
+        ctx.host.operations.patch(operationId, { payload });
+        ctx.host.http.writeJson(res, 200, { ok: true });
+        return true;
+      }
       if (req.method !== "DELETE") {
         ctx.host.http.writeJson(res, 405, { error: "Method not allowed" });
         return true;
@@ -65,4 +102,10 @@ export function registerShellRoutes(ctx: FleetPluginServerContext, runtime: Term
       ctx.host.http.writeJson(res, 200, { ok: true });
       return true;
     });
+}
+
+function isRestoredShellEvent(value: unknown, pluginId: string): value is { readonly operationId: string } {
+  if (!value || typeof value !== "object") return false;
+  const event = value as { readonly operationId?: unknown; readonly pluginId?: unknown; readonly type?: unknown };
+  return typeof event.operationId === "string" && event.pluginId === pluginId && event.type === "shell";
 }

--- a/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
@@ -1,0 +1,223 @@
+import http from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import fs from "node:fs";
+import path from "node:path";
+
+import type { OperationCreateInput, OperationNode, OperationPatchInput } from "@fleet-console/sdk/operations";
+import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
+import type { RouteHandler } from "@fleet-console/sdk/routing";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createAgentSession } from "../client/agent/api.js";
+import { registerAgentRoutes } from "../server/agent.js";
+import { writeProviderSessionCaptureRaw } from "../server/agent-api/session-capture.js";
+import type { TerminalRuntime } from "../server/shared/index.js";
+
+const cleanups: Array<() => void | Promise<void>> = [];
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("agent provider capture grace", () => {
+  it("keeps the provider capture until the deferred deletion is purged", async () => {
+    const harness = createHarness({ initialPrompt: "hello" });
+    await harness.postSessions();
+    const sessionId = harness.operations[0]!.id;
+    harness.markProviderSession(sessionId);
+    const capturePath = path.join(harness.fleetDataDir, `${sessionId}.json`);
+    writeProviderSessionCaptureRaw(sessionId, JSON.stringify({ provider: "claude" }), { capturesDir: harness.fleetDataDir });
+    expect(fs.existsSync(capturePath)).toBe(true);
+
+    await harness.deleteSession(sessionId);
+
+    // 삭제는 유예되므로 undo가 복원할 transcript가 남아 있어야 한다.
+    expect(fs.existsSync(capturePath)).toBe(true);
+
+    harness.emitHostEvent("operation:purged", { operationId: sessionId, pluginId: "terminal", type: "agent" });
+    expect(fs.existsSync(capturePath)).toBe(false);
+  });
+});
+
+function createHarness(body: Record<string, unknown>) {
+  const fleetDataDir = mkdtempSync(path.join(os.tmpdir(), "fleet-terminal-initial-prompt-"));
+  temporaryDirectories.push(fleetDataDir);
+  const operations: OperationNode[] = [];
+  const eventListeners = new Map<string, Array<(payload: unknown) => void>>();
+  const responses: Array<{ readonly status: number; readonly body: unknown }> = [];
+  let route: RouteHandler | undefined;
+  let lifecycleCleanup: (() => void | Promise<void>) | undefined;
+  let exitCallback: ((operationId: string) => void | Promise<void>) | undefined;
+  const attach = vi.fn<TerminalRuntime["attach"]>(async () => {});
+  const write = vi.fn<(sessionId: string, data: string) => boolean>(() => true);
+  const terminate = vi.fn(() => true);
+  const terminalRuntime: TerminalRuntime = {
+    handleUpgrade: () => false,
+    issueTicket: () => ({ ticket: "ticket", ttlMs: 1_000 }),
+    canAttach: () => true,
+    attach,
+    write,
+    terminate,
+    getMessagePolicy: () => ({}),
+    getRenameCommand: () => undefined,
+    resolveSessionIdentity: async () => null,
+    onExit: (callback) => {
+      exitCallback = callback;
+      return () => {
+        if (exitCallback === callback) exitCallback = undefined;
+      };
+    },
+    registerLaunchResolver: () => () => {},
+    stop: async () => {},
+  };
+  const ctx = {
+    pluginId: "terminal",
+    manifest: { id: "terminal" },
+    basePath: "/plugins/terminal",
+    wsBasePath: "/plugins/terminal/ws",
+    registerRouter: (_path: string, handler: RouteHandler) => { route = handler; },
+    registerWsHandler: () => {},
+    host: {
+      operations: {
+        list: () => operations,
+        get: (id: string) => operations.find((operation) => operation.id === id) ?? null,
+        create: (input: OperationCreateInput) => {
+          const createdAt = input.createdAt ?? Date.now();
+          const operation: OperationNode = {
+            id: input.id ?? `operation-${operations.length + 1}`,
+            theaterId: input.theaterId,
+            type: input.type,
+            pluginId: input.pluginId,
+            title: input.title,
+            payload: { ...(input.payload ?? {}) },
+            geometry: input.geometry ?? null,
+            ts: { createdAt, updatedAt: createdAt },
+          };
+          operations.push(operation);
+          return operation;
+        },
+        patch: (id: string, input: OperationPatchInput) => {
+          const index = operations.findIndex((operation) => operation.id === id);
+          const current = operations[index];
+          if (!current) return null;
+          const patched = {
+            ...current,
+            ...(input.title === undefined ? {} : { title: input.title }),
+            ...(input.payload === undefined ? {} : { payload: { ...input.payload } }),
+            ts: { ...current.ts, updatedAt: Date.now() },
+          };
+          operations[index] = patched;
+          return patched;
+        },
+        delete: (id: string) => {
+          const index = operations.findIndex((operation) => operation.id === id);
+          if (index < 0) return false;
+          operations.splice(index, 1);
+          return true;
+        },
+        registerOperationType: () => () => {},
+        registerPayloadSanitizer: () => () => {},
+        registerLaunchCatalog: () => () => {},
+      },
+      events: {
+        publish: () => {},
+        subscribe: (channel: string, listener: (payload: unknown) => void) => {
+          const listeners = eventListeners.get(channel) ?? [];
+          listeners.push(listener);
+          eventListeners.set(channel, listeners);
+          return () => {};
+        },
+        registerSseChannel: () => () => {},
+      },
+      paths: {
+        fleetDataDir,
+        capturesDir: fleetDataDir,
+        pluginDataDir: () => fleetDataDir,
+        resolveTheaterPath: (theaterId: string) => theaterId === "theater-1" ? path.join(fleetDataDir, "theater") : null,
+        canonicalizeTheaterPath: (cwd: string) => cwd,
+        workspaceHash: () => "theater-1",
+      },
+      storage: {
+        readJson: async () => null,
+        writeJson: async () => {},
+      },
+      http: {
+        writeJson: (_res: http.ServerResponse, status: number, responseBody: unknown) => { responses.push({ status, body: responseBody }); },
+        readJsonBody: async <T,>() => ({ theaterId: "theater-1", cliId: "claude", ...body }) as T,
+      },
+      security: {
+        validateHost: () => true,
+        isTerminalAuthorized: () => true,
+        isLockAuthorized: () => true,
+      },
+      lifecycle: {
+        registerCleanup: (cleanup: () => void | Promise<void>) => {
+          lifecycleCleanup = cleanup;
+          return () => {};
+        },
+      },
+    },
+  } satisfies FleetPluginServerContext;
+
+  const previousTerminalCommand = process.env.FLEET_TERMINAL_CMD;
+  process.env.FLEET_TERMINAL_CMD = "test-terminal";
+  registerAgentRoutes(ctx, terminalRuntime, { authService: {} as never, globalOptionsService: {} as never });
+  cleanups.push(async () => {
+    if (previousTerminalCommand === undefined) delete process.env.FLEET_TERMINAL_CMD;
+    else process.env.FLEET_TERMINAL_CMD = previousTerminalCommand;
+    await lifecycleCleanup?.();
+  });
+
+  return {
+    attach,
+    fleetDataDir,
+    operations,
+    emitHostEvent: (channel: string, payload: unknown) => {
+      for (const listener of eventListeners.get(channel) ?? []) listener(payload);
+    },
+    responses,
+    terminate,
+    write,
+    emitExit: async (sessionId: string) => {
+      if (!exitCallback) throw new Error("Terminal exit callback was not registered");
+      await exitCallback(sessionId);
+    },
+    markProviderSession: (sessionId: string) => {
+      const operation = operations.find((candidate) => candidate.id === sessionId);
+      if (!operation) throw new Error(`Operation not found: ${sessionId}`);
+      operation.payload.providerSession = {
+        provider: "claude",
+        sessionId: "provider-session-1",
+        capturedAt: "2026-07-25T00:00:00.000Z",
+      };
+    },
+    deleteSession: async (sessionId: string) => {
+      if (!route) throw new Error("Agent route was not registered");
+      await route({
+        req: { method: "DELETE", url: `/plugins/terminal/agent/sessions/${sessionId}` } as http.IncomingMessage,
+        res: {} as http.ServerResponse,
+        pathname: `/plugins/terminal/agent/sessions/${sessionId}`,
+      });
+    },
+    postSessions: async () => {
+      if (!route) throw new Error("Agent route was not registered");
+      await route({
+        req: { method: "POST", url: "/plugins/terminal/agent/sessions" } as http.IncomingMessage,
+        res: {} as http.ServerResponse,
+        pathname: "/plugins/terminal/agent/sessions",
+      });
+    },
+    resumeSession: async (sessionId: string) => {
+      if (!route) throw new Error("Agent route was not registered");
+      await route({
+        req: { method: "POST", url: `/plugins/terminal/agent/sessions/${sessionId}/resume` } as http.IncomingMessage,
+        res: {} as http.ServerResponse,
+        pathname: `/plugins/terminal/agent/sessions/${sessionId}/resume`,
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary

승인된 개선안 R2입니다. 파괴적 액션의 보호 등급이 뒤집혀 있던 것을 복구 보장으로 바로잡습니다.

- **실측된 결함.** Operation 닫기는 2단 ARM(`Close operation X` → `Confirm close operation X`) 후 **하드 삭제**되고 토스트도 최근 닫음 목록도 되돌리기도 없었습니다. Theater `Forget Theater`는 메뉴에서 **1클릭에 즉시 실행**되며 확인조차 없이 소속 Operation 전부가 서버에서 함께 사라졌습니다. 즉 1개를 지울 땐 두 번 묻고, N개를 지울 땐 묻지 않았습니다.
- **본질은 클릭 수가 아니라 되돌릴 수 없다는 것**이라 판단해, 가드를 늘리는 대신 복구를 보장합니다. Operation 닫기의 2단 ARM은 그대로 두고, Theater forget에도 확인 단계를 추가하지 않습니다. 대신 두 액션 모두 **8초 유예** 뒤에 영구 삭제됩니다.
- **서버.** durable state를 `version: 3`으로 올리고 `deletionTombstones`를 추가했습니다(v1→v2→v3 순차 마이그레이션 유지). 삭제는 active 컬렉션 제거와 tombstone 추가를 **한 번의 durable 저장으로** 끝내고, 저장이 실패하면 메모리 변경을 되돌립니다. 만료 정리는 가장 가까운 만료 시각을 겨냥한 **단일 `unref()` 타이머** 하나가 맡고, 서버 시작 직후 sweep하며, restore도 현재 시각을 재검증해 재시작이나 지연 타이머로 유예가 늘어나지 않습니다.
- **세션은 삭제 즉시 종료**하고 undo는 metadata만 되살립니다. 복원된 Operation은 dormant이며 명시적 Resume 전에는 프로세스를 만들지 않습니다(restored-operations 독트린).
- **클라이언트.** 카운트다운이 있는 undo 토스트(`role="status"`)와 `Mod+Z` 단축키를 추가했습니다. **토스트는 포커스를 훔치지 않습니다** — 8초 뒤 사라지는 요소로 포커스를 옮기면 사용자가 있던 자리를 잃기 때문입니다. 승인 시안에는 포커스 이동이 있었으나 이 이유로 채택하지 않고, 대신 단축키로 키보드 복구를 보장했습니다.

### 기존 계약 변경 한 가지

`DELETE /api/v1/operations/:id`가 대상이 없을 때 `404`가 아니라 `200 { ok: true, deletion: null }`을 돌려줍니다. 삭제를 멱등적으로 만들기 위한 것이며, 저장소 내 호출자는 모두 상태 코드를 무시하고 있습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 0 errors
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 1059 passed
- [x] `pnpm --filter @fleet-plugins/terminal typecheck` · `test` — 386 passed
- [x] 격리 콘솔 실브라우저 검증
  - Operation 닫기 → `role="status"`/`aria-live="polite"` 토스트 "Operation closed · 8s remaining · Undo", 칩 제거, **포커스 이동 없음**
  - `Mod+Z` → Operation이 사이드바와 서버 양쪽에 복원, 토스트 닫힘
  - 유예 만료 → 영구 삭제 확인
  - `DELETE` 응답과 restore 응답에 절대경로·`realpath`·`providerSession` 없음(정규식 검사 `false`)
- [ ] Changelog fragment — PR 번호 배정 후 추가 예정

### 검증 한계 (그대로 밝힙니다)

`Mod+Z`는 페이지에 **합성 `KeyboardEvent`를 디스패치해** 검증했습니다. 이 세션의 브라우저 하네스가 실제 키 입력을 `key: "Unidentified"`·수식자 없음으로 전달해서, 통제 실험으로 **기존에 잘 동작하던 `⌘K`도 같은 방식으로 발동하지 않음**을 확인했습니다. 즉 하네스 한계이지 이 변경의 결함이 아니지만, 실제 키 입력 경로는 이 세션에서 직접 확인하지 못했습니다.

### 선존 실패 (이 PR과 무관)

`tests/server.test.ts > … issues Theater-bound dedicated MCP sessions …` 1건. base에서 동일하게 재현되며 이 어설션이 도입된 #353 시점에도 실패합니다.

전체 스위트에서 `api-catalog`·`carrier-settings`·`server.test.ts`의 다른 항목이 함께 실패로 보일 수 있으나, 실서버를 기동하는 테스트라 동시 vitest 실행과 겹치면 타임아웃하는 부하성 오탐입니다. 단독 재실행에서 통과를 확인했습니다.