### PR TITLE
feat(carriers): enable Task Force for Kirov

### DIFF
--- a/.changelog.d/pr-382.md
+++ b/.changelog.d/pr-382.md
@@ -1,0 +1,4 @@
+### fleet-core
+#### Added
+- [fleet-carriers] Enable Task Force backend configuration for Kirov so multiple models can independently cross-review a host-authored PlanRef without gaining Plan mutation authority.
+  ko: Kirov에 Task Force backend 구성을 제공해 여러 모델이 Plan 변경 권한 없이 호스트가 작성한 PlanRef를 독립적으로 교차 검토할 수 있습니다.

--- a/packages/fleet-carriers/src/personas/kirov.ts
+++ b/packages/fleet-carriers/src/personas/kirov.ts
@@ -13,6 +13,7 @@ export const KIROV_DEFAULTS: CarrierPersonaDefaults = {
   id: "kirov",
   displayName: "Kirov",
   slot: 2,
+  taskForceCapable: true,
   agent: {
     dispatch: {
       defaultCliType: "claude",

--- a/packages/fleet-carriers/tests/dispatch/taskforce-policy.test.ts
+++ b/packages/fleet-carriers/tests/dispatch/taskforce-policy.test.ts
@@ -34,15 +34,15 @@ afterEach(() => {
 });
 
 describe("Task Force capability policy", () => {
-  it("source-enables exactly the two capable default personas while custom carriers stay closed", () => {
+  it("source-enables exactly the three capable default personas while custom carriers stay closed", () => {
     const registry = createCarrierRegistry();
     registerDefaultCarriers(registry);
     registerCarrier(registry, config("custom", false));
 
-    const capable = ["nimitz", "vanguard", "kirov", "genesis", "ohio", "sentinel", "custom"]
+    const capable = ["nimitz", "kirov", "genesis", "ohio", "sentinel", "vanguard", "custom"]
       .filter((id) => isTaskForceCapable(registry, id));
 
-    expect(capable).toEqual(["nimitz", "vanguard"]);
+    expect(capable).toEqual(["nimitz", "kirov", "vanguard"]);
   });
 
   it("makes stale settings ineffective when capability is removed and reactivates them when it returns", () => {

--- a/packages/fleet-carriers/tests/personas.test.ts
+++ b/packages/fleet-carriers/tests/personas.test.ts
@@ -92,12 +92,12 @@ describe("allowedExecutorTools", () => {
 });
 
 describe("Task Force capability defaults", () => {
-  it("only nimitz and vanguard source-own the capability marker", () => {
+  it("only nimitz, kirov, and vanguard source-own the capability marker", () => {
     const capable = DEFAULT_PERSONAS
       .filter((persona) => persona.defaults.taskForceCapable === true)
       .map((persona) => persona.defaults.id);
 
-    expect(capable).toEqual(["nimitz", "vanguard"]);
+    expect(capable).toEqual(["nimitz", "kirov", "vanguard"]);
   });
 });
 

--- a/runtime/fleet-console/tests/carrier-settings.test.ts
+++ b/runtime/fleet-console/tests/carrier-settings.test.ts
@@ -182,6 +182,27 @@ describe("carrier settings routes", () => {
     expect(invalid.status).toBe(400);
   });
 
+  it("reports Kirov as Task Force capable and accepts backend PUT through the settings route", async () => {
+    const fixture = await startFixture();
+    const initial = await getJson<CarrierSettingsState>(`${fixture.endpoint}api/v1/plugins/terminal/carriers`);
+    const kirov = initial.carriers.find((carrier) => carrier.carrierId === "kirov");
+    if (!kirov) throw new Error("Kirov was not registered");
+    expect(kirov.taskForceCapable).toBe(true);
+
+    const model = getProviderModels("claude").defaultModel;
+    const effort = getEffort("claude", model);
+    const updated = await mutate<{ readonly state: CarrierSettingsState }>(
+      fixture,
+      "/api/v1/plugins/terminal/carriers/kirov/taskforce/claude",
+      "PUT",
+      { model, ...(effort.supported ? { effort: effort.default } : {}) },
+    );
+
+    expect(updated.state.carriers.find((carrier) => carrier.carrierId === "kirov")?.taskforce.backends).toEqual([
+      { cliType: "claude", model, ...(effort.supported ? { effort: effort.default } : {}) },
+    ]);
+  });
+
   it("keeps stale incapable Task Force settings ineffective, rejects PUT without a write, and permits cleanup", async () => {
     const model = getProviderModels("claude").defaultModel;
     const effort = getEffort("claude", model);
@@ -190,19 +211,19 @@ describe("carrier settings routes", () => {
         fs.mkdirSync(carrierStoreDir, { recursive: true });
         fs.writeFileSync(path.join(carrierStoreDir, "carriers.json"), JSON.stringify({
           _meta: { generation: 7 },
-          carriers: { kirov: { taskforce: { claude: { model } } } },
+          carriers: { genesis: { taskforce: { claude: { model } } } },
         }));
       },
     });
     const initial = await getJson<CarrierSettingsState>(`${fixture.endpoint}api/v1/plugins/terminal/carriers`);
-    const kirov = initial.carriers.find((carrier) => carrier.carrierId === "kirov");
-    if (!kirov) throw new Error("Kirov was not registered");
-    expect(kirov.taskForceCapable).toBe(false);
-    expect(kirov.taskforce.backends).toEqual([]);
+    const genesis = initial.carriers.find((carrier) => carrier.carrierId === "genesis");
+    if (!genesis) throw new Error("Genesis was not registered");
+    expect(genesis.taskForceCapable).toBe(false);
+    expect(genesis.taskforce.backends).toEqual([]);
 
     const rejected = await rawMutate(
       fixture,
-      "/api/v1/plugins/terminal/carriers/kirov/taskforce/claude",
+      "/api/v1/plugins/terminal/carriers/genesis/taskforce/claude",
       "PUT",
       { model, ...(effort.supported ? { effort: effort.default } : {}) },
     );
@@ -213,18 +234,18 @@ describe("carrier settings routes", () => {
 
     const cleaned = await mutate<{ readonly state: CarrierSettingsState }>(
       fixture,
-      "/api/v1/plugins/terminal/carriers/kirov/taskforce",
+      "/api/v1/plugins/terminal/carriers/genesis/taskforce",
       "DELETE",
       {},
     );
-    expect(cleaned.state.carriers.find((carrier) => carrier.carrierId === "kirov")?.taskforce.backends).toEqual([]);
+    expect(cleaned.state.carriers.find((carrier) => carrier.carrierId === "genesis")?.taskforce.backends).toEqual([]);
     expect(cleaned.state.generation).toBe(unchanged.generation + 1);
     const persisted = JSON.parse(fs.readFileSync(path.join(fixture.carrierStoreDir, "carriers.json"), "utf8")) as {
       readonly _meta?: { readonly generation?: number };
       readonly carriers?: Record<string, { readonly taskforce?: unknown }>;
     };
     expect(persisted._meta?.generation).toBe(cleaned.state.generation);
-    expect(persisted.carriers?.kirov?.taskforce).toBeUndefined();
+    expect(persisted.carriers?.genesis?.taskforce).toBeUndefined();
   });
 
   it("does not return 500 for malformed percent-encoded carrier ids", async () => {


### PR DESCRIPTION
## PR Title

feat(carriers): enable Task Force for Kirov

## Summary

Enables Kirov to use the existing Task Force backend configuration path for independent cross-review of host-authored Fleet Plans. Kirov remains a strictly read-only Plan assurance Carrier with no additional tools or mutation authority.

## Type of Change

- [x] feat — new feature or carrier capability
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope

- [ ] `extensions/core`
- [x] `extensions/fleet` (Admiral / Bridge / Carriers)
- [ ] `extensions/boot`
- [ ] `extensions/diagnostics`
- [ ] `extensions/metaphor`
- [ ] `packages/unified-agent`
- [ ] `bin/` or root tooling
- [ ] Documentation (README / SETUP / AGENTS.md)

## Test Plan

- [x] Fleet Carriers targeted capability tests — 29 passed
- [x] Console carrier settings route tests — 11 passed
- [x] Fleet Carriers typecheck and build
- [x] Fleet Console typecheck and build
- [x] `git diff --check`

The full Fleet Carriers suite has two known unrelated failures in `tests/dispatch/codex-acp-stderr.e2e.test.ts` (readiness expectation and timeout); 197 other tests pass, and that file is outside this diff.

## Changelog

- [x] Added `.changelog.d/pr-382.md`.
- [x] Fragment section is `Added`.
- [x] Fragment uses the allowed `[fleet-carriers]` tag with adjacent bilingual summaries.
- [x] `node scripts/compile-changelog-fragments.mjs --check` passed (28 entries).

## Related Issues / PRs

Follow-up to #374.

## Notes for Reviewers

- The production change is the source-owned `taskForceCapable: true` marker on `KIROV_DEFAULTS`; registration, settings routes, and UI already consume this generic capability.
- Kirov remains limited to `carrier_jobs` and `plan_read`; its request blocks, permissions, output format, and Plan mutation boundary are unchanged.
- Console integration coverage proves the Kirov Task Force backend PUT and preserves incapable-carrier rejection/cleanup coverage on Genesis.
