### PR TITLE
feat(console): show repository context on Theater rows

### DIFF
--- a/.changelog.d/pr-383.md
+++ b/.changelog.d/pr-383.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Added
+- [fleet-console] Show each Theater's branch, working tree state and unpushed or unpulled commit counts directly on its sidebar row, so reading repository context no longer means opening the Repository panel and switching Theaters one at a time.
+  ko: Theater마다 브랜치·작업 트리 상태·미푸시/미풀 커밋 수를 사이드바 행에 바로 표시합니다. 저장소 상태를 보려고 Repository 패널을 열고 Theater를 하나씩 바꿀 필요가 없습니다.

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProp
 import { createPortal } from "react-dom";
 
 import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console/sdk/operations";
-import type { OperationActivity } from "@fleet-console/sdk/plugin";
+import type { OperationActivity, TheaterRowBadge } from "@fleet-console/sdk/plugin";
 
 import type { OperationGroup, OperationNode, OperationNotification, TheaterInfo } from "../types.js";
 import { CanvasContextMenu } from "../canvas/canvas-context-menu.js";
@@ -37,6 +37,7 @@ import {
   type SideBarStatus,
 } from "./operations-side-bar-store.js";
 import { resolveOperationLaunchKind } from "./resolve-launch-kind.js";
+import { useTheaterRowBadges } from "./theater-row-badges.js";
 
 interface OperationsSideBarProps {
   readonly theaters: readonly TheaterInfo[];
@@ -137,6 +138,7 @@ interface TheaterEntryBuildInput {
 
 interface TheaterSectionHeaderProps {
   readonly theater: TheaterInfo;
+  readonly badges: readonly TheaterRowBadge[];
   readonly active: boolean;
   readonly collapsed: boolean;
   readonly statusAxis: boolean;
@@ -156,6 +158,7 @@ interface TheaterSectionHeaderProps {
 
 interface TheaterInactiveSectionProps {
   readonly theater: TheaterInfo;
+  readonly badges: readonly TheaterRowBadge[];
   readonly entries: readonly SideBarEntry[];
   readonly groups: readonly OperationGroup[];
   readonly collapsedGroups: ReadonlySet<string>;
@@ -296,6 +299,7 @@ export function OperationsSideBar({
   const chipsRef = useRef<HTMLOListElement | null>(null);
   const sideBar = useSideBarState();
   const { width, collapsed } = sideBar;
+  const badgesByTheater = useTheaterRowBadges(theaters.map((theater) => theater.id), collapsed);
   const statusAxis = useSideBarStatusAxis();
   const previousCollapsedRef = useRef(collapsed);
   const canvas = useCanvasState();
@@ -856,6 +860,7 @@ export function OperationsSideBar({
               <TheaterInactiveSection
                 key={theater.id}
                 theater={theater}
+                badges={badgesByTheater[theater.id] ?? []}
                 entries={theaterCollapsed ? [] : inactiveEntries}
                 groups={groups.filter((group) => group.theaterId === theater.id)}
                 collapsedGroups={new Set(theaterCanvas.collapsedGroups)}
@@ -898,6 +903,7 @@ export function OperationsSideBar({
             >
               <TheaterSectionHeader
                 theater={theater}
+                badges={badgesByTheater[theater.id] ?? []}
                 active
                 collapsed={theaterCollapsed}
                 statusAxis={statusAxis}
@@ -1231,6 +1237,7 @@ function buildTheaterEntries({
 
 function TheaterSectionHeader({
   theater,
+  badges,
   active,
   collapsed,
   statusAxis,
@@ -1320,6 +1327,20 @@ function TheaterSectionHeader({
     >
       <span className="side-bar-theater-anchor" aria-hidden="true">{theaterInitials(theater.label)}</span>
       <span className="side-bar-theater-name">{theater.label}</span>
+      {badges.length > 0 ? (
+        <span className="side-bar-theater-badges" aria-label={`${theater.label} repository status`}>
+          {badges.map((badge) => (
+            <span
+              key={badge.id}
+              className={`side-bar-theater-badge side-bar-theater-badge--${badge.tone ?? "neutral"}`}
+              aria-label={badge.ariaLabel}
+              title={badge.ariaLabel ?? badge.text}
+            >
+              {badge.text}
+            </span>
+          ))}
+        </span>
+      ) : null}
       <ChevronIcon collapsed={collapsed} />
       <span className="side-bar-theater-row-controls" role="group" aria-label={`${theater.label} controls`}>
         <button
@@ -1368,6 +1389,7 @@ function TheaterSectionHeader({
 
 function TheaterInactiveSection({
   theater,
+  badges,
   entries,
   groups,
   collapsedGroups,
@@ -1404,6 +1426,7 @@ function TheaterInactiveSection({
     >
       <TheaterSectionHeader
         theater={theater}
+        badges={badges}
         active={false}
         collapsed={collapsed}
         statusAxis={statusAxis}

--- a/runtime/fleet-console/core/client/src/sidebar/theater-row-badges.ts
+++ b/runtime/fleet-console/core/client/src/sidebar/theater-row-badges.ts
@@ -1,0 +1,126 @@
+import { useEffect, useState } from "react";
+
+import type {
+  TheaterRowBadge,
+  TheaterRowBadgeContribution,
+  TheaterRowBadgeTone,
+} from "@fleet-console/sdk/plugin";
+
+export const THEATER_ROW_BADGE_REFRESH_MS = 30_000;
+
+const BADGE_TONES = new Set<TheaterRowBadgeTone>(["neutral", "info", "warn", "positive"]);
+
+export function useTheaterRowBadges(
+  theaterIds: readonly string[],
+  sideBarCollapsed: boolean,
+): Readonly<Record<string, readonly TheaterRowBadge[]>> {
+  const theaterIdsKey = JSON.stringify(theaterIds);
+  const [byTheater, setByTheater] = useState<Readonly<Record<string, readonly TheaterRowBadge[]>>>({});
+
+  useEffect(() => {
+    const requestedTheaterIds = parseTheaterIdsKey(theaterIdsKey);
+    if (requestedTheaterIds.length === 0) {
+      setByTheater({});
+      return;
+    }
+    let active = true;
+    let requestController: AbortController | null = null;
+    let interval: number | null = null;
+
+    const refresh = async () => {
+      if (sideBarCollapsed || document.visibilityState === "hidden") return;
+      requestController?.abort();
+      const controller = new AbortController();
+      requestController = controller;
+      try {
+        const response = await fetch("/api/v1/theaters/row-badges", { signal: controller.signal });
+        if (!response.ok) return;
+        const payload = await response.json() as unknown;
+        if (!active || controller.signal.aborted) return;
+        setByTheater(normalizeBadgeResponse(payload, requestedTheaterIds));
+      } catch {
+        // 재검증 실패 시 직전의 안전한 스냅샷을 유지한다.
+      }
+    };
+    const stopPolling = () => {
+      if (interval === null) return;
+      window.clearInterval(interval);
+      interval = null;
+    };
+    const startPolling = () => {
+      if (sideBarCollapsed || document.visibilityState === "hidden" || interval !== null) return;
+      void refresh();
+      interval = window.setInterval(() => void refresh(), THEATER_ROW_BADGE_REFRESH_MS);
+    };
+    const handleFocus = () => {
+      void refresh();
+    };
+    const handleVisibilityChange = () => {
+      stopPolling();
+      if (document.visibilityState !== "hidden") startPolling();
+    };
+
+    window.addEventListener("focus", handleFocus);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    startPolling();
+    return () => {
+      active = false;
+      requestController?.abort();
+      stopPolling();
+      window.removeEventListener("focus", handleFocus);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [sideBarCollapsed, theaterIdsKey]);
+
+  return byTheater;
+}
+
+export function normalizeBadgeResponse(
+  value: unknown,
+  theaterIds: readonly string[],
+): Readonly<Record<string, readonly TheaterRowBadge[]>> {
+  if (!isObject(value) || !Array.isArray(value.theaters)) return {};
+  const known = new Set(theaterIds);
+  const result: Record<string, TheaterRowBadge[]> = {};
+  for (const contribution of value.theaters) {
+    const normalized = normalizeContribution(contribution, known);
+    if (!normalized) continue;
+    result[normalized.theaterId] = [
+      ...(result[normalized.theaterId] ?? []),
+      ...normalized.badges,
+    ];
+  }
+  return result;
+}
+
+function normalizeContribution(
+  value: unknown,
+  knownTheaterIds: ReadonlySet<string>,
+): TheaterRowBadgeContribution | null {
+  if (!isObject(value) || typeof value.theaterId !== "string" || !knownTheaterIds.has(value.theaterId) || !Array.isArray(value.badges)) return null;
+  const badges = value.badges.flatMap((candidate): TheaterRowBadge[] => {
+    if (!isObject(candidate) || typeof candidate.id !== "string" || typeof candidate.text !== "string") return [];
+    if (candidate.ariaLabel !== undefined && typeof candidate.ariaLabel !== "string") return [];
+    if (candidate.tone !== undefined && (typeof candidate.tone !== "string" || !BADGE_TONES.has(candidate.tone as TheaterRowBadgeTone))) return [];
+    return [{
+      id: candidate.id,
+      text: candidate.text,
+      ...(typeof candidate.ariaLabel === "string" ? { ariaLabel: candidate.ariaLabel } : {}),
+      ...(typeof candidate.tone === "string" ? { tone: candidate.tone as TheaterRowBadgeTone } : {}),
+    }];
+  });
+  return { theaterId: value.theaterId, badges };
+}
+
+function parseTheaterIdsKey(value: string): readonly string[] {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((entry): entry is string => typeof entry === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2523,11 +2523,51 @@
 }
 
 .side-bar-theater-name {
-  flex: 1;
-  min-width: 0;
+  flex: 1 1 100%;
+  min-width: 64px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.side-bar-theater-badges {
+  display: flex;
+  flex: 0 1 auto;
+  gap: 3px;
+  min-width: 0;
+  max-width: min(42%, 180px);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.side-bar-theater-badge {
+  flex: none;
+  max-width: 96px;
+  overflow: hidden;
+  padding: 2px 5px;
+  border: 1px solid var(--surface-rim);
+  border-radius: 999px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: var(--weight-medium);
+  line-height: 1;
+  text-overflow: ellipsis;
+}
+
+.side-bar-theater-badge--info {
+  border-color: color-mix(in oklch, var(--aurora) 42%, var(--surface-rim));
+  color: var(--text-secondary);
+}
+
+.side-bar-theater-badge--warn {
+  border-color: color-mix(in oklch, var(--warn) 48%, var(--surface-rim));
+  color: var(--text-primary);
+}
+
+.side-bar-theater-badge--positive {
+  border-color: color-mix(in oklch, var(--positive) 44%, var(--surface-rim));
+  color: var(--text-secondary);
 }
 
 .side-bar-theater-chevron {

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -42,6 +42,7 @@ import { encodeSseData } from "./sse.js";
 import { createStaticConsoleHandler } from "./static-console.js";
 import { listTheaterFolders, TheaterFolderListError } from "./theater-folder-browser.js";
 import { createFolderGrantStore } from "./theater-folder-grants.js";
+import { createTheaterRowBadgeRegistry, handleTheaterRowBadges } from "./theater-row-badges.js";
 import type { TheaterRegistration } from "./theaters.js";
 import { TheaterRegistry } from "./theaters.js";
 import { canonicalizeTheaterPathSync, workspaceHash } from "./theater.js";
@@ -212,6 +213,13 @@ export const SERVER_API_CATALOG: readonly ApiCatalogEntry[] = [
     gate: "origin-write",
   },
   {
+    method: "GET",
+    path: "/api/v1/theaters/row-badges",
+    summary: "Theater 행의 플러그인 컨텍스트 배지를 조회합니다.",
+    category: "Observer",
+    gate: "origin-write",
+  },
+  {
     method: "POST",
     path: "/api/v1/plans/list",
     summary: "Theater의 실행 계획 목록을 조회합니다.",
@@ -299,6 +307,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   const pluginOperationTypes = new Set<string>();
   const pluginPayloadSanitizers = new Map<string, readonly string[]>();
   const pluginLaunchCatalogProviders = new Map<string, OperationLaunchCatalogProvider[]>();
+  const theaterRowBadges = createTheaterRowBadgeRegistry();
   const pluginCleanupCallbacks = new Set<() => void | Promise<void>>();
   const pluginEventListeners = new Map<string, Set<(payload: unknown) => void>>();
   const operationSseSubscribers = new Set<http.ServerResponse>();
@@ -372,6 +381,9 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
           if (current.length === 0) pluginLaunchCatalogProviders.delete(pluginId);
         };
       },
+    },
+    theaters: {
+      registerRowBadgeProvider: (pluginId, provider) => theaterRowBadges.register(pluginId, provider),
     },
     events: {
       publish: publishPluginEvent,
@@ -638,6 +650,15 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     }
     if (pathname === "/api/v1/theaters") {
       runAsyncHandler(handleObserverTheaters(req, res), res);
+      return;
+    }
+    if (pathname === "/api/v1/theaters/row-badges") {
+      runAsyncHandler(handleTheaterRowBadges(req, res, {
+        isAuthorized: isTerminalAuthorized,
+        listTheaterIds: () => theaters.list().map((theater) => theater.id),
+        resolve: (theaterIds) => theaterRowBadges.resolve(theaterIds),
+        writeJson,
+      }), res);
       return;
     }
     if (pathname === "/api/v1/theaters/folder-listings") {

--- a/runtime/fleet-console/core/host/theater-row-badges.ts
+++ b/runtime/fleet-console/core/host/theater-row-badges.ts
@@ -1,0 +1,215 @@
+import type http from "node:http";
+
+import type {
+  TheaterRowBadge,
+  TheaterRowBadgeContribution,
+  TheaterRowBadgeProvider,
+  TheaterRowBadgeTone,
+} from "@fleet-console/sdk/plugin";
+
+export const THEATER_ROW_BADGE_PROVIDER_TIMEOUT_MS = 800;
+export const THEATER_ROW_BADGE_DEADLINE_MS = 3_000;
+export const THEATER_ROW_BADGE_MAX_CONCURRENCY = 4;
+export const MAX_THEATER_ROW_BADGES = 8;
+export const MAX_THEATER_ROW_BADGE_ID_LENGTH = 64;
+export const MAX_THEATER_ROW_BADGE_TEXT_LENGTH = 80;
+export const MAX_THEATER_ROW_BADGE_ARIA_LABEL_LENGTH = 160;
+
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/u;
+const ABSOLUTE_PATH_PATTERN = /^(?:\/|\\\\|[a-zA-Z]:[\\/]|file:\/\/)/u;
+const BADGE_TONES = new Set<TheaterRowBadgeTone>(["neutral", "info", "warn", "positive"]);
+
+export interface TheaterRowBadgeRegistry {
+  register(pluginId: string, provider: TheaterRowBadgeProvider): () => void;
+  resolve(theaterIds: readonly string[]): Promise<readonly TheaterRowBadgeContribution[]>;
+}
+
+interface ResolveOptions {
+  readonly maxConcurrency?: number;
+  readonly providerTimeoutMs?: number;
+  readonly deadlineMs?: number;
+}
+
+interface TheaterRowBadgeRouteDeps {
+  readonly isAuthorized: (req: http.IncomingMessage) => boolean;
+  readonly listTheaterIds: () => readonly string[];
+  readonly resolve: (theaterIds: readonly string[]) => Promise<readonly TheaterRowBadgeContribution[]>;
+  readonly writeJson: (res: http.ServerResponse, status: number, payload: unknown) => void;
+}
+
+export function createTheaterRowBadgeRegistry(): TheaterRowBadgeRegistry {
+  const providers = new Map<string, TheaterRowBadgeProvider[]>();
+
+  return {
+    register(pluginId, provider) {
+      const registered = providers.get(pluginId) ?? [];
+      registered.push(provider);
+      providers.set(pluginId, registered);
+      let disposed = false;
+      return () => {
+        if (disposed) return;
+        disposed = true;
+        const current = providers.get(pluginId);
+        if (!current) return;
+        const index = current.indexOf(provider);
+        if (index >= 0) current.splice(index, 1);
+        if (current.length === 0) providers.delete(pluginId);
+      };
+    },
+    resolve(theaterIds) {
+      return resolveTheaterRowBadges(
+        [...providers.values()].flat(),
+        theaterIds,
+      );
+    },
+  };
+}
+
+export async function handleTheaterRowBadges(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  deps: TheaterRowBadgeRouteDeps,
+): Promise<void> {
+  if (req.method !== "GET") {
+    deps.writeJson(res, 405, { error: "Method not allowed" });
+    return;
+  }
+  if (!deps.isAuthorized(req)) {
+    deps.writeJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  const theaterIds = deps.listTheaterIds();
+  deps.writeJson(res, 200, { theaters: await deps.resolve(theaterIds) });
+}
+
+export async function resolveTheaterRowBadges(
+  providers: readonly TheaterRowBadgeProvider[],
+  theaterIds: readonly string[],
+  options: ResolveOptions = {},
+): Promise<readonly TheaterRowBadgeContribution[]> {
+  if (providers.length === 0 || theaterIds.length === 0) return [];
+  const maxConcurrency = options.maxConcurrency ?? THEATER_ROW_BADGE_MAX_CONCURRENCY;
+  const providerTimeoutMs = options.providerTimeoutMs ?? THEATER_ROW_BADGE_PROVIDER_TIMEOUT_MS;
+  const deadlineMs = options.deadlineMs ?? THEATER_ROW_BADGE_DEADLINE_MS;
+  const deadlineAt = Date.now() + deadlineMs;
+  const results: unknown[] = [];
+  const activeControllers = new Set<AbortController>();
+  let nextIndex = 0;
+
+  const deadlineTimer = setTimeout(() => {
+    for (const controller of activeControllers) controller.abort();
+  }, deadlineMs);
+  const worker = async () => {
+    while (nextIndex < providers.length) {
+      if (Date.now() >= deadlineAt) return;
+      const index = nextIndex;
+      nextIndex += 1;
+      const provider = providers[index];
+      if (!provider) continue;
+      const remainingMs = deadlineAt - Date.now();
+      if (remainingMs <= 0) return;
+      const controller = new AbortController();
+      activeControllers.add(controller);
+      const timeoutMs = Math.min(providerTimeoutMs, remainingMs);
+      const timeout = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const value = await Promise.race([
+          Promise.resolve().then(() => provider({ theaterIds, signal: controller.signal })),
+          waitForAbort(controller.signal),
+        ]);
+        if (!controller.signal.aborted) results.push(value);
+      } catch {
+        // 한 provider의 실패는 다른 provider의 결과를 막지 않는다.
+      } finally {
+        clearTimeout(timeout);
+        activeControllers.delete(controller);
+      }
+    }
+  };
+
+  try {
+    await Promise.all(
+      Array.from(
+        { length: Math.min(maxConcurrency, providers.length) },
+        () => worker(),
+      ),
+    );
+  } finally {
+    clearTimeout(deadlineTimer);
+    for (const controller of activeControllers) controller.abort();
+  }
+  return sanitizeTheaterRowBadgeContributions(results, theaterIds);
+}
+
+export function sanitizeTheaterRowBadgeContributions(
+  values: readonly unknown[],
+  knownTheaterIds: readonly string[],
+): readonly TheaterRowBadgeContribution[] {
+  const known = new Set(knownTheaterIds);
+  const byTheater = new Map<string, TheaterRowBadge[]>();
+
+  for (const value of values) {
+    if (!Array.isArray(value)) continue;
+    for (const contribution of value) {
+      if (!isObject(contribution) || typeof contribution.theaterId !== "string" || !known.has(contribution.theaterId) || !Array.isArray(contribution.badges)) continue;
+      const badges = byTheater.get(contribution.theaterId) ?? [];
+      const seenIds = new Set(badges.map((badge) => badge.id));
+      for (const candidate of contribution.badges) {
+        if (badges.length >= MAX_THEATER_ROW_BADGES) break;
+        const badge = sanitizeBadge(candidate);
+        if (!badge || seenIds.has(badge.id)) continue;
+        badges.push(badge);
+        seenIds.add(badge.id);
+      }
+      if (badges.length > 0) byTheater.set(contribution.theaterId, badges);
+    }
+  }
+
+  return knownTheaterIds.flatMap((theaterId) => {
+    const badges = byTheater.get(theaterId);
+    return badges ? [{ theaterId, badges }] : [];
+  });
+}
+
+function sanitizeBadge(value: unknown): TheaterRowBadge | null {
+  if (!isObject(value)) return null;
+  const id = sanitizeString(value.id, MAX_THEATER_ROW_BADGE_ID_LENGTH);
+  const text = sanitizeString(value.text, MAX_THEATER_ROW_BADGE_TEXT_LENGTH);
+  if (!id || !text) return null;
+  const ariaLabel = value.ariaLabel === undefined
+    ? undefined
+    : sanitizeString(value.ariaLabel, MAX_THEATER_ROW_BADGE_ARIA_LABEL_LENGTH);
+  if (value.ariaLabel !== undefined && !ariaLabel) return null;
+  const tone = value.tone === undefined
+    ? undefined
+    : typeof value.tone === "string" && BADGE_TONES.has(value.tone as TheaterRowBadgeTone)
+      ? value.tone as TheaterRowBadgeTone
+      : null;
+  if (tone === null) return null;
+  return {
+    id,
+    text,
+    ...(ariaLabel ? { ariaLabel } : {}),
+    ...(tone ? { tone } : {}),
+  };
+}
+
+function sanitizeString(value: unknown, maxLength: number): string | null {
+  if (typeof value !== "string" || value.length === 0 || value.length > maxLength) return null;
+  if (CONTROL_CHARACTER_PATTERN.test(value) || ABSOLUTE_PATH_PATTERN.test(value.trim())) return null;
+  return value;
+}
+
+function waitForAbort(signal: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    if (signal.aborted) {
+      reject(new Error("aborted"));
+      return;
+    }
+    signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+  });
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/runtime/fleet-console/core/host/theater-row-badges.ts
+++ b/runtime/fleet-console/core/host/theater-row-badges.ts
@@ -16,7 +16,7 @@ export const MAX_THEATER_ROW_BADGE_TEXT_LENGTH = 80;
 export const MAX_THEATER_ROW_BADGE_ARIA_LABEL_LENGTH = 160;
 
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/u;
-const ABSOLUTE_PATH_PATTERN = /^(?:\/|\\\\|[a-zA-Z]:[\\/]|file:\/\/)/u;
+const ABSOLUTE_PATH_PATTERN = /(?:^|\s)(?:\/|\\\\|[a-zA-Z]:[\\/]|file:\/\/)/u;
 const BADGE_TONES = new Set<TheaterRowBadgeTone>(["neutral", "info", "warn", "positive"]);
 
 export interface TheaterRowBadgeRegistry {
@@ -113,11 +113,12 @@ export async function resolveTheaterRowBadges(
       const timeoutMs = Math.min(providerTimeoutMs, remainingMs);
       const timeout = setTimeout(() => controller.abort(), timeoutMs);
       try {
+        const providerResult = provider({ theaterIds, signal: controller.signal });
         const value = await Promise.race([
-          Promise.resolve().then(() => provider({ theaterIds, signal: controller.signal })),
+          providerResult,
           waitForAbort(controller.signal),
         ]);
-        if (!controller.signal.aborted) results.push(value);
+        results.push(value);
       } catch {
         // 한 provider의 실패는 다른 provider의 결과를 막지 않는다.
       } finally {

--- a/runtime/fleet-console/sdk/plugin/types.ts
+++ b/runtime/fleet-console/sdk/plugin/types.ts
@@ -189,8 +189,32 @@ export interface FleetPluginServerContext {
   registerWsHandler(path: string, handler: UpgradeHandler): void;
 }
 
+export type TheaterRowBadgeTone = "neutral" | "info" | "warn" | "positive";
+
+export interface TheaterRowBadge {
+  readonly id: string;
+  readonly text: string;
+  readonly ariaLabel?: string;
+  readonly tone?: TheaterRowBadgeTone;
+}
+
+export interface TheaterRowBadgeContribution {
+  readonly theaterId: string;
+  readonly badges: readonly TheaterRowBadge[];
+}
+
+export interface TheaterRowBadgeRequest {
+  readonly theaterIds: readonly string[];
+  readonly signal: AbortSignal;
+}
+
+export type TheaterRowBadgeProvider = (request: TheaterRowBadgeRequest) => Promise<readonly TheaterRowBadgeContribution[]>;
+
 export interface FleetPluginHostCapabilities {
   readonly operations: FleetPluginOperationsHost;
+  readonly theaters: {
+    registerRowBadgeProvider(pluginId: string, provider: TheaterRowBadgeProvider): () => void;
+  };
   readonly events: FleetPluginEventsHost;
   readonly paths: FleetPluginPathsHost;
   readonly storage: FleetPluginStorageHost;

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -595,6 +595,22 @@ describe("Instrument core design contract", () => {
     expect(components).toContain(".side-bar-status-header--awaiting .side-bar-status-header__dot {");
   });
 
+  it("keeps Theater repository badges on signal tokens and preserves label priority", () => {
+    const sidebar = source("sidebar/operations-side-bar.tsx");
+    const components = source("styles/components.css");
+    const badgeStart = components.indexOf(".side-bar-theater-badge {");
+    const badgeEnd = components.indexOf(".side-bar-theater-chevron {", badgeStart);
+    const badgeGrammar = components.slice(badgeStart, badgeEnd);
+
+    expect(sidebar).toContain('className={`side-bar-theater-badge side-bar-theater-badge--${badge.tone ?? "neutral"}`}');
+    expect(components).toContain(".side-bar-theater-name {\n  flex: 1 1 100%;\n  min-width: 64px;");
+    expect(components).toContain("max-width: min(42%, 180px);");
+    expect(badgeGrammar).toContain("var(--aurora)");
+    expect(badgeGrammar).toContain("var(--warn)");
+    expect(badgeGrammar).toContain("var(--positive)");
+    expect(badgeGrammar).not.toContain("var(--id-");
+  });
+
   it("pins the selectable Right Rail panel behavior contract", () => {
     const rail = source("styles/rail.css");
     const rightRail = source("rail/right-rail.tsx");

--- a/runtime/fleet-console/tests/plugin-host.test.ts
+++ b/runtime/fleet-console/tests/plugin-host.test.ts
@@ -25,6 +25,9 @@ const noopHostCapabilities: FleetPluginHostCapabilities = {
     registerPayloadSanitizer: () => () => {},
     registerLaunchCatalog: () => () => {},
   },
+  theaters: {
+    registerRowBadgeProvider: () => () => {},
+  },
   events: {
     publish: () => {},
     subscribe: () => () => {},

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -3,6 +3,7 @@ import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -1007,6 +1008,40 @@ describe("console static and terminal ticket boundary", () => {
     });
 
     expect(response.status).toBe(401);
+  });
+
+  it("serves repository row badges through the core batch route with Theater security gates", async () => {
+    const fixture = await startFixture({
+      release: { channel: "local", version: "test", packageRoot: CONSOLE_PACKAGE_ROOT },
+    });
+    const repo = path.join(fixture.dir, "row-badge-repo");
+    fs.mkdirSync(repo);
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    fs.writeFileSync(path.join(repo, "changed.txt"), "changed\n");
+    const theater = await createTheater(fixture, repo);
+
+    const response = await fetch(`${fixture.endpoint}api/v1/theaters/row-badges`);
+    const payload = await response.json() as {
+      readonly theaters?: readonly { readonly theaterId?: string; readonly badges?: readonly { readonly text?: string; readonly tone?: string }[] }[];
+    };
+    const serialized = JSON.stringify(payload);
+    const denied = await fetch(`${fixture.endpoint}api/v1/theaters/row-badges`, {
+      headers: { Origin: "http://evil.example" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(payload.theaters).toEqual([{
+      theaterId: theater.id,
+      badges: [
+        { id: "branch", text: "main", tone: "neutral" },
+        { id: "changed", text: "1 changed", tone: "warn" },
+      ],
+    }]);
+    expect(denied.status).toBe(401);
+    expect(serialized).not.toContain(repo);
+    expect(serialized).not.toContain("realpath");
+    expect(serialized).not.toContain("\"path\"");
+    expect(serialized).not.toMatch(/(?:^|")\/(?:Users|private|tmp)\//u);
   });
 
   it("rejects update apply without an exact console Origin", async () => {

--- a/runtime/fleet-console/tests/theater-row-badges-client.test.tsx
+++ b/runtime/fleet-console/tests/theater-row-badges-client.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  normalizeBadgeResponse,
+  THEATER_ROW_BADGE_REFRESH_MS,
+  useTheaterRowBadges,
+} from "../core/client/src/sidebar/theater-row-badges.js";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  document.body.replaceChildren();
+  Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  document.body.replaceChildren();
+  root = null;
+  container = null;
+});
+
+describe("Theater row badge client", () => {
+  it("refreshes immediately, every 30 seconds, on focus, and when Theater registration changes", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ theaters: [{ theaterId: "one", badges: [{ id: "branch", text: "main", tone: "neutral" }] }] }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await renderHarness(["one"], false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(container?.textContent).toContain("main");
+
+    await act(async () => {
+      vi.advanceTimersByTime(THEATER_ROW_BADGE_REFRESH_MS);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    await renderHarness(["one", "two"], false);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not poll while the sidebar is collapsed or the document is hidden", async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ theaters: [] }) }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await renderHarness(["one"], true);
+    await act(async () => {
+      vi.advanceTimersByTime(THEATER_ROW_BADGE_REFRESH_MS * 2);
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+    await renderHarness(["one"], false);
+    await act(async () => {
+      vi.advanceTimersByTime(THEATER_ROW_BADGE_REFRESH_MS * 2);
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts only known Theater contributions and supported tones", () => {
+    expect(normalizeBadgeResponse({
+      theaters: [
+        { theaterId: "unknown", badges: [{ id: "branch", text: "secret" }] },
+        { theaterId: "known", badges: [
+          { id: "branch", text: "main", tone: "neutral" },
+          { id: "bad", text: "bad", tone: "identity" },
+        ] },
+      ],
+    }, ["known"])).toEqual({
+      known: [{ id: "branch", text: "main", tone: "neutral" }],
+    });
+  });
+});
+
+function BadgeHarness({ theaterIds, collapsed }: { readonly theaterIds: readonly string[]; readonly collapsed: boolean }) {
+  return createElement("pre", null, JSON.stringify(useTheaterRowBadges(theaterIds, collapsed)));
+}
+
+async function renderHarness(theaterIds: readonly string[], collapsed: boolean): Promise<void> {
+  await act(async () => {
+    root?.render(createElement(BadgeHarness, { theaterIds, collapsed }));
+  });
+}

--- a/runtime/fleet-console/tests/theater-row-badges.test.ts
+++ b/runtime/fleet-console/tests/theater-row-badges.test.ts
@@ -28,6 +28,12 @@ describe("Theater row badge host", () => {
           { id: "C:\\secret\\repo", text: "windows" },
           { id: "control", text: "main\u0000secret" },
           { id: "absolute-aria", text: "main", ariaLabel: "\\\\server\\share" },
+          { id: "embedded-posix", text: "Repository: /home/alice/project" },
+          { id: "embedded-drive", text: "Repository: C:\\work\\project" },
+          { id: "embedded-unc", text: "Repository: \\\\server\\share" },
+          { id: "embedded-file-url", text: "Repository: file:///home/alice/project" },
+          { id: "remote-branch", text: "origin/canary", tone: "neutral" },
+          { id: "feature-branch", text: "feat/foo", tone: "neutral" },
           { id: "safe", text: "clean", tone: "positive", cwd: "/private/repo" },
         ] },
       ],
@@ -36,7 +42,11 @@ describe("Theater row badge host", () => {
     expect(result[0]?.badges).toHaveLength(MAX_THEATER_ROW_BADGES);
     expect(result[1]).toEqual({
       theaterId: "known-path",
-      badges: [{ id: "safe", text: "clean", tone: "positive" }],
+      badges: [
+        { id: "remote-branch", text: "origin/canary", tone: "neutral" },
+        { id: "feature-branch", text: "feat/foo", tone: "neutral" },
+        { id: "safe", text: "clean", tone: "positive" },
+      ],
     });
     const serialized = JSON.stringify(result);
     expect(serialized).not.toContain("unknown");
@@ -59,6 +69,22 @@ describe("Theater row badge host", () => {
 
     await expect(resolveTheaterRowBadges(
       [timeout, failure, success],
+      ["known"],
+      { providerTimeoutMs: 20, deadlineMs: 100 },
+    )).resolves.toEqual([
+      { theaterId: "known", badges: [{ id: "branch", text: "main" }] },
+    ]);
+  });
+
+  it("accepts contributions finalized before a provider abort", async () => {
+    const partial: TheaterRowBadgeProvider = ({ signal }) => new Promise((resolve) => {
+      signal.addEventListener("abort", () => resolve([
+        { theaterId: "known", badges: [{ id: "branch", text: "main" }] },
+      ]), { once: true });
+    });
+
+    await expect(resolveTheaterRowBadges(
+      [partial],
       ["known"],
       { providerTimeoutMs: 20, deadlineMs: 100 },
     )).resolves.toEqual([

--- a/runtime/fleet-console/tests/theater-row-badges.test.ts
+++ b/runtime/fleet-console/tests/theater-row-badges.test.ts
@@ -1,0 +1,128 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  handleTheaterRowBadges,
+  MAX_THEATER_ROW_BADGES,
+  resolveTheaterRowBadges,
+  sanitizeTheaterRowBadgeContributions,
+} from "../core/host/theater-row-badges.js";
+import type { TheaterRowBadgeProvider } from "../sdk/plugin/types.js";
+
+describe("Theater row badge host", () => {
+  it("sanitizes unknown Theaters, excessive badges, control characters, absolute paths, and undeclared fields", () => {
+    const excessive = Array.from({ length: MAX_THEATER_ROW_BADGES + 3 }, (_, index) => ({
+      id: `badge-${index}`,
+      text: `value-${index}`,
+      tone: "neutral",
+    }));
+    const result = sanitizeTheaterRowBadgeContributions([
+      [
+        { theaterId: "unknown", badges: [{ id: "branch", text: "main" }] },
+        { theaterId: "known", badges: excessive, path: "/Users/secret/repo", realpath: "/private/repo" },
+        { theaterId: "known-path", badges: [
+          { id: "absolute-text", text: "/Users/secret/repo" },
+          { id: "C:\\secret\\repo", text: "windows" },
+          { id: "control", text: "main\u0000secret" },
+          { id: "absolute-aria", text: "main", ariaLabel: "\\\\server\\share" },
+          { id: "safe", text: "clean", tone: "positive", cwd: "/private/repo" },
+        ] },
+      ],
+    ], ["known", "known-path"]);
+
+    expect(result[0]?.badges).toHaveLength(MAX_THEATER_ROW_BADGES);
+    expect(result[1]).toEqual({
+      theaterId: "known-path",
+      badges: [{ id: "safe", text: "clean", tone: "positive" }],
+    });
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("unknown");
+    expect(serialized).not.toContain("/Users/");
+    expect(serialized).not.toContain("/private/");
+    expect(serialized).not.toContain("realpath");
+    expect(serialized).not.toContain("cwd");
+  });
+
+  it("isolates provider timeouts and failures while preserving successful results", async () => {
+    const success: TheaterRowBadgeProvider = async () => [
+      { theaterId: "known", badges: [{ id: "branch", text: "main" }] },
+    ];
+    const failure: TheaterRowBadgeProvider = async () => {
+      throw new Error("provider failed");
+    };
+    const timeout: TheaterRowBadgeProvider = ({ signal }) => new Promise((_, reject) => {
+      signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+    });
+
+    await expect(resolveTheaterRowBadges(
+      [timeout, failure, success],
+      ["known"],
+      { providerTimeoutMs: 20, deadlineMs: 100 },
+    )).resolves.toEqual([
+      { theaterId: "known", badges: [{ id: "branch", text: "main" }] },
+    ]);
+  });
+
+  it("runs no more than four providers concurrently", async () => {
+    let active = 0;
+    let peak = 0;
+    const providers = Array.from({ length: 12 }, (_, index): TheaterRowBadgeProvider => async () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      active -= 1;
+      return [{ theaterId: "known", badges: [{ id: `badge-${index}`, text: String(index) }] }];
+    });
+
+    const result = await resolveTheaterRowBadges(providers, ["known"]);
+
+    expect(peak).toBe(4);
+    expect(result[0]?.badges).toHaveLength(MAX_THEATER_ROW_BADGES);
+  });
+
+  it("requires GET and the Theater Origin authorization gate", async () => {
+    const responses: { status: number; payload: unknown }[] = [];
+    let resolved = false;
+    const deps = {
+      isAuthorized: (req: { readonly headers: { readonly origin?: string } }) => req.headers.origin === "http://127.0.0.1:4312",
+      listTheaterIds: () => ["known"],
+      resolve: async () => {
+        resolved = true;
+        return [];
+      },
+      writeJson: (_res: unknown, status: number, payload: unknown) => responses.push({ status, payload }),
+    };
+
+    await handleTheaterRowBadges(
+      { method: "GET", headers: { origin: "http://evil.example" } } as never,
+      {} as never,
+      deps as never,
+    );
+    await handleTheaterRowBadges(
+      { method: "POST", headers: { origin: "http://127.0.0.1:4312" } } as never,
+      {} as never,
+      deps as never,
+    );
+
+    expect(responses).toEqual([
+      { status: 401, payload: { error: "unauthorized" } },
+      { status: 405, payload: { error: "Method not allowed" } },
+    ]);
+    expect(resolved).toBe(false);
+  });
+
+  it("matches the row-badges route before the Theater item regular expression", () => {
+    const serverSource = fs.readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), "../core/host/server.ts"),
+      "utf8",
+    );
+    const routeIndex = serverSource.indexOf('pathname === "/api/v1/theaters/row-badges"');
+    const itemIndex = serverSource.indexOf("const theaterItemMatch = pathname.match");
+
+    expect(routeIndex).toBeGreaterThan(-1);
+    expect(itemIndex).toBeGreaterThan(routeIndex);
+  });
+});

--- a/runtime/fleet-plugins/repository/routes.ts
+++ b/runtime/fleet-plugins/repository/routes.ts
@@ -8,11 +8,17 @@ import { handleRepositoryChanged, handleRepositoryFile } from "./server/diff.js"
 import { handleRepositoryLog } from "./server/log.js";
 import { handleRepositoryRefs } from "./server/refs.js";
 import { handleRepositoryRepos } from "./server/repos.js";
+import { createRepositoryRowBadgeProvider } from "./server/row-badges.js";
 import { handleRepositoryWorktrees } from "./server/worktrees.js";
 
 export default definePlugin({
   id: "repository",
   register(ctx) {
+    const unregisterRowBadges = ctx.host.theaters.registerRowBadgeProvider(
+      ctx.pluginId,
+      createRepositoryRowBadgeProvider(ctx.host.paths.resolveTheaterPath),
+    );
+    ctx.host.lifecycle.registerCleanup(unregisterRowBadges);
     registerRouter(ctx, "repos", async ({ req, res }) => {
       await handleRepositoryRepos(req, res, ctx);
       return true;

--- a/runtime/fleet-plugins/repository/server/git-executor.ts
+++ b/runtime/fleet-plugins/repository/server/git-executor.ts
@@ -27,12 +27,16 @@ const DEFAULT_MAX_BUFFER = 8 * 1024 * 1024;
 
 export function runGit(
   args: readonly string[],
-  opts: { readonly cwd: string; readonly timeoutMs?: number; readonly maxBuffer?: number; readonly allowExitCodes?: readonly number[] },
+  opts: { readonly cwd: string; readonly timeoutMs?: number; readonly maxBuffer?: number; readonly allowExitCodes?: readonly number[]; readonly signal?: AbortSignal },
 ): Promise<GitRunResult> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxBuffer = opts.maxBuffer ?? DEFAULT_MAX_BUFFER;
 
   return new Promise((resolve, reject) => {
+    if (opts.signal?.aborted) {
+      reject(new GitExecutorError("timeout"));
+      return;
+    }
     let child;
     try {
       // Windows에서 자식 프로세스 콘솔 창이 깜빡이며 떴다 사라지는 현상 방지
@@ -50,11 +54,20 @@ export function runGit(
     let truncated = false;
     let timedOut = false;
 
-    const timer = setTimeout(() => {
+    const abort = () => {
       timedOut = true;
       child.kill("SIGTERM");
       reject(new GitExecutorError("timeout"));
+    };
+    opts.signal?.addEventListener("abort", abort, { once: true });
+    const timer = setTimeout(() => {
+      abort();
     }, timeoutMs);
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      opts.signal?.removeEventListener("abort", abort);
+    };
 
     child.stdout.on("data", (chunk: Buffer) => {
       if (truncated) return;
@@ -74,14 +87,14 @@ export function runGit(
     });
 
     child.on("error", (error) => {
-      clearTimeout(timer);
+      cleanup();
       // ENOENT = git 바이너리가 PATH에 없음; 나머지는 일반 spawn 실패
       const code = (error as NodeJS.ErrnoException).code === "ENOENT" ? "git_unavailable" : "spawn_failed";
       reject(new GitExecutorError(code, error.message));
     });
 
     child.on("close", (code) => {
-      clearTimeout(timer);
+      cleanup();
       if (timedOut) return;
       const stderr = Buffer.concat(stderrChunks).toString("utf8");
       if (code !== 0) {

--- a/runtime/fleet-plugins/repository/server/row-badges.ts
+++ b/runtime/fleet-plugins/repository/server/row-badges.ts
@@ -20,29 +20,54 @@ interface RepositoryStatus {
   readonly ahead: number;
   readonly behind: number;
   readonly changed: number;
+  readonly truncated: boolean;
 }
 
 export function createRepositoryRowBadgeProvider(
   resolveTheaterPath: (theaterId: string) => string | null,
   executeGit: GitRunner = runGit,
 ): TheaterRowBadgeProvider {
-  return async ({ theaterIds, signal }) => {
-    const contributions = await Promise.all(theaterIds.map(async (theaterId): Promise<TheaterRowBadgeContribution | null> => {
+  return ({ theaterIds, signal }) => new Promise((resolve) => {
+    const contributions = new Map<string, TheaterRowBadgeContribution>();
+    let pending = 0;
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", finish);
+      resolve(theaterIds.flatMap((theaterId) => {
+        const contribution = contributions.get(theaterId);
+        return contribution ? [contribution] : [];
+      }));
+    };
+    signal.addEventListener("abort", finish, { once: true });
+    if (signal.aborted) {
+      finish();
+      return;
+    }
+    for (const theaterId of theaterIds) {
       const cwd = resolveTheaterPath(theaterId);
-      if (!cwd || signal.aborted) return null;
-      try {
-        const result = await executeGit(STATUS_ARGS, { cwd, signal });
-        if (signal.aborted) return null;
-        return { theaterId, badges: statusBadges(parsePorcelainV2Status(result.stdout)) };
-      } catch {
-        return null;
-      }
-    }));
-    return contributions.filter((contribution): contribution is TheaterRowBadgeContribution => contribution !== null);
-  };
+      if (!cwd) continue;
+      pending += 1;
+      void executeGit(STATUS_ARGS, { cwd, signal })
+        .then((result) => {
+          if (settled) return;
+          contributions.set(theaterId, {
+            theaterId,
+            badges: statusBadges(parsePorcelainV2Status(result.stdout, result.truncated)),
+          });
+        })
+        .catch(() => undefined)
+        .finally(() => {
+          pending -= 1;
+          if (pending === 0) finish();
+        });
+    }
+    if (pending === 0) finish();
+  });
 }
 
-export function parsePorcelainV2Status(stdout: string): RepositoryStatus {
+export function parsePorcelainV2Status(stdout: string, truncated = false): RepositoryStatus {
   let oid: string | null = null;
   let head: string | null = null;
   let upstream: string | null = null;
@@ -84,7 +109,7 @@ export function parsePorcelainV2Status(stdout: string): RepositoryStatus {
     }
   }
 
-  return { oid, head, upstream, ahead, behind, changed };
+  return { oid, head, upstream, ahead, behind, changed, truncated };
 }
 
 export function statusBadges(status: RepositoryStatus): readonly TheaterRowBadge[] {
@@ -93,7 +118,9 @@ export function statusBadges(status: RepositoryStatus): readonly TheaterRowBadge
     : status.head ?? status.oid?.slice(0, 7) ?? "unknown";
   const badges: TheaterRowBadge[] = [
     { id: "branch", text: branch, tone: "neutral" },
-    status.changed > 0
+    status.truncated
+      ? { id: "changed", text: `${status.changed}+ changed`, tone: "warn" }
+      : status.changed > 0
       ? { id: "changed", text: `${status.changed} changed`, tone: "warn" }
       : { id: "changed", text: "clean", tone: "positive" },
   ];

--- a/runtime/fleet-plugins/repository/server/row-badges.ts
+++ b/runtime/fleet-plugins/repository/server/row-badges.ts
@@ -1,0 +1,103 @@
+import type {
+  TheaterRowBadge,
+  TheaterRowBadgeContribution,
+  TheaterRowBadgeProvider,
+} from "@fleet-console/sdk/plugin";
+
+import { runGit, type GitRunResult } from "./git-executor.js";
+
+const STATUS_ARGS = ["status", "--porcelain=v2", "--branch", "-z", "--untracked-files=all"] as const;
+
+type GitRunner = (
+  args: readonly string[],
+  opts: { readonly cwd: string; readonly signal?: AbortSignal },
+) => Promise<GitRunResult>;
+
+interface RepositoryStatus {
+  readonly oid: string | null;
+  readonly head: string | null;
+  readonly upstream: string | null;
+  readonly ahead: number;
+  readonly behind: number;
+  readonly changed: number;
+}
+
+export function createRepositoryRowBadgeProvider(
+  resolveTheaterPath: (theaterId: string) => string | null,
+  executeGit: GitRunner = runGit,
+): TheaterRowBadgeProvider {
+  return async ({ theaterIds, signal }) => {
+    const contributions = await Promise.all(theaterIds.map(async (theaterId): Promise<TheaterRowBadgeContribution | null> => {
+      const cwd = resolveTheaterPath(theaterId);
+      if (!cwd || signal.aborted) return null;
+      try {
+        const result = await executeGit(STATUS_ARGS, { cwd, signal });
+        if (signal.aborted) return null;
+        return { theaterId, badges: statusBadges(parsePorcelainV2Status(result.stdout)) };
+      } catch {
+        return null;
+      }
+    }));
+    return contributions.filter((contribution): contribution is TheaterRowBadgeContribution => contribution !== null);
+  };
+}
+
+export function parsePorcelainV2Status(stdout: string): RepositoryStatus {
+  let oid: string | null = null;
+  let head: string | null = null;
+  let upstream: string | null = null;
+  let ahead = 0;
+  let behind = 0;
+  let changed = 0;
+  const records = stdout.split("\0");
+
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    if (!record) continue;
+    if (record.startsWith("# branch.oid ")) {
+      oid = record.slice("# branch.oid ".length);
+      continue;
+    }
+    if (record.startsWith("# branch.head ")) {
+      head = record.slice("# branch.head ".length);
+      continue;
+    }
+    if (record.startsWith("# branch.upstream ")) {
+      upstream = record.slice("# branch.upstream ".length);
+      continue;
+    }
+    if (record.startsWith("# branch.ab ")) {
+      const match = /^# branch\.ab \+(\d+) -(\d+)$/u.exec(record);
+      if (match) {
+        ahead = Number(match[1]);
+        behind = Number(match[2]);
+      }
+      continue;
+    }
+    if (record.startsWith("2 ")) {
+      changed += 1;
+      index += 1;
+      continue;
+    }
+    if (record.startsWith("1 ") || record.startsWith("u ") || record.startsWith("? ")) {
+      changed += 1;
+    }
+  }
+
+  return { oid, head, upstream, ahead, behind, changed };
+}
+
+export function statusBadges(status: RepositoryStatus): readonly TheaterRowBadge[] {
+  const branch = status.head === "(detached)"
+    ? status.oid?.slice(0, 7) ?? "detached"
+    : status.head ?? status.oid?.slice(0, 7) ?? "unknown";
+  const badges: TheaterRowBadge[] = [
+    { id: "branch", text: branch, tone: "neutral" },
+    status.changed > 0
+      ? { id: "changed", text: `${status.changed} changed`, tone: "warn" }
+      : { id: "changed", text: "clean", tone: "positive" },
+  ];
+  if (status.upstream && status.ahead > 0) badges.push({ id: "ahead", text: `↑${status.ahead}`, tone: "info" });
+  if (status.upstream && status.behind > 0) badges.push({ id: "behind", text: `↓${status.behind}`, tone: "info" });
+  return badges;
+}

--- a/runtime/fleet-plugins/repository/tests/row-badges.test.ts
+++ b/runtime/fleet-plugins/repository/tests/row-badges.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createRepositoryRowBadgeProvider,
+  parsePorcelainV2Status,
+  statusBadges,
+} from "../server/row-badges.js";
+
+describe("repository Theater row badges", () => {
+  it("shows a seven-character OID for detached HEAD", () => {
+    const status = parsePorcelainV2Status([
+      "# branch.oid 1234567890abcdef",
+      "# branch.head (detached)",
+      "",
+    ].join("\0"));
+
+    expect(statusBadges(status)).toEqual([
+      { id: "branch", text: "1234567", tone: "neutral" },
+      { id: "changed", text: "clean", tone: "positive" },
+    ]);
+  });
+
+  it("omits ahead and behind without an upstream and emits them when upstream exists", () => {
+    const withoutUpstream = parsePorcelainV2Status([
+      "# branch.oid 1234567890abcdef",
+      "# branch.head main",
+      "# branch.ab +3 -2",
+      "",
+    ].join("\0"));
+    const withUpstream = parsePorcelainV2Status([
+      "# branch.oid 1234567890abcdef",
+      "# branch.head main",
+      "# branch.upstream origin/main",
+      "# branch.ab +3 -2",
+      "",
+    ].join("\0"));
+
+    expect(statusBadges(withoutUpstream).map((badge) => badge.text)).toEqual(["main", "clean"]);
+    expect(statusBadges(withUpstream)).toEqual([
+      { id: "branch", text: "main", tone: "neutral" },
+      { id: "changed", text: "clean", tone: "positive" },
+      { id: "ahead", text: "↑3", tone: "info" },
+      { id: "behind", text: "↓2", tone: "info" },
+    ]);
+  });
+
+  it("counts tracked, unmerged, renamed, and untracked files once", () => {
+    const status = parsePorcelainV2Status([
+      "# branch.oid 1234567890abcdef",
+      "# branch.head main",
+      "1 .M N... 100644 100644 100644 a b file-one",
+      "u UU N... 100644 100644 100644 100644 a b c conflict",
+      "2 R. N... 100644 100644 100644 a b R100 renamed",
+      "? old-name-that-looks-like-a-record",
+      "? untracked",
+      "",
+    ].join("\0"));
+
+    expect(status.changed).toBe(4);
+    expect(statusBadges(status)[1]).toEqual({ id: "changed", text: "4 changed", tone: "warn" });
+  });
+
+  it("runs one fixed-argument git process for each known Theater root", async () => {
+    const executeGit = vi.fn(async (
+      _args: readonly string[],
+      _options: { readonly cwd: string; readonly signal?: AbortSignal },
+    ) => ({
+      stdout: "# branch.oid 1234567890abcdef\0# branch.head main\0",
+      truncated: false,
+    }));
+    const provider = createRepositoryRowBadgeProvider(
+      (theaterId) => theaterId === "missing" ? null : `/repo/${theaterId}`,
+      executeGit,
+    );
+    const result = await provider({
+      theaterIds: ["one", "two", "missing"],
+      signal: new AbortController().signal,
+    });
+
+    expect(executeGit).toHaveBeenCalledTimes(2);
+    expect(executeGit.mock.calls.map(([args, options]) => ({ args, cwd: options.cwd }))).toEqual([
+      {
+        args: ["status", "--porcelain=v2", "--branch", "-z", "--untracked-files=all"],
+        cwd: "/repo/one",
+      },
+      {
+        args: ["status", "--porcelain=v2", "--branch", "-z", "--untracked-files=all"],
+        cwd: "/repo/two",
+      },
+    ]);
+    expect(result.map((contribution) => contribution.theaterId)).toEqual(["one", "two"]);
+  });
+});

--- a/runtime/fleet-plugins/repository/tests/row-badges.test.ts
+++ b/runtime/fleet-plugins/repository/tests/row-badges.test.ts
@@ -60,6 +60,61 @@ describe("repository Theater row badges", () => {
     expect(statusBadges(status)[1]).toEqual({ id: "changed", text: "4 changed", tone: "warn" });
   });
 
+  it("reports truncated changed counts as a lower bound and never clean", () => {
+    const changed = parsePorcelainV2Status([
+      "# branch.oid 1234567890abcdef",
+      "# branch.head main",
+      "? first",
+      "? second",
+      "",
+    ].join("\0"), true);
+    const noVisibleChanges = parsePorcelainV2Status([
+      "# branch.oid 1234567890abcdef",
+      "# branch.head main",
+      "",
+    ].join("\0"), true);
+
+    expect(statusBadges(changed)[1]).toEqual({ id: "changed", text: "2+ changed", tone: "warn" });
+    expect(statusBadges(noVisibleChanges)[1]).toEqual({ id: "changed", text: "0+ changed", tone: "warn" });
+  });
+
+  it("preserves completed Theater badges when another Theater fails or is aborted", async () => {
+    const controller = new AbortController();
+    const executeGit = vi.fn((
+      _args: readonly string[],
+      options: { readonly cwd: string; readonly signal?: AbortSignal },
+    ) => {
+      if (options.cwd === "/repo/fast") {
+        return Promise.resolve({
+          stdout: "# branch.oid 1234567890abcdef\0# branch.head main\0",
+          truncated: false,
+        });
+      }
+      if (options.cwd === "/repo/failed") return Promise.reject(new Error("git failed"));
+      return new Promise<never>((_, reject) => {
+        options.signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+      });
+    });
+    const provider = createRepositoryRowBadgeProvider(
+      (theaterId) => `/repo/${theaterId}`,
+      executeGit,
+    );
+    const resultPromise = provider({
+      theaterIds: ["fast", "slow", "failed"],
+      signal: controller.signal,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    controller.abort();
+
+    await expect(resultPromise).resolves.toEqual([{
+      theaterId: "fast",
+      badges: [
+        { id: "branch", text: "main", tone: "neutral" },
+        { id: "changed", text: "clean", tone: "positive" },
+      ],
+    }]);
+  });
+
   it("runs one fixed-argument git process for each known Theater root", async () => {
     const executeGit = vi.fn(async (
       _args: readonly string[],


### PR DESCRIPTION
## Summary

승인된 신규 기능 N1입니다.

- **실측된 결함.** Theater 2개를 등록한 사이드바 전체 텍스트가 이니셜 배지와 라벨뿐이었습니다. 브랜치도, 변경 파일 수도, ahead/behind도 없어서 브랜치 하나 확인하려면 Repository 레일 패널을 **열고** Theater를 **하나씩 바꿔가며** 봐야 했습니다(패널은 활성 Theater 하나만 보여줍니다). 여러 저장소를 띄워두고 일하는 조종석인데, 에이전트에게 일을 시키기 전 알아야 할 첫 사실이 가려져 있었습니다.
- **경계.** 코어 사이드바가 플러그인 라우트를 직접 호출하지 않도록, 호스트에 provider 레지스트리와 **배치 라우트** `GET /api/v1/theaters/row-badges`를 두고 repository 플러그인이 서버에서 provider를 등록합니다. `ConsoleTheaterInfo`는 건드리지 않았습니다 — 거기에 넣으면 `/api/v1/theaters`가 git 호출에 블로킹되어 사이드바 첫 렌더가 늦어집니다.
- **수집.** Theater 루트당 단일 git 프로세스(`git status --porcelain=v2 --branch -z --untracked-files=all`). detached HEAD는 7자리 OID, upstream이 없으면 ahead/behind는 생략합니다.
- **격리.** 동시 실행 4, provider별 800ms, 전체 3000ms. 느리거나 실패한 provider는 결과에서 빠지고 나머지는 그대로 응답합니다.
- **보안.** 호스트 sanitizer가 알려진 Theater ID만 통과시키고 배지 개수·문자열 길이를 제한하며 제어문자와 절대경로 형태를 거부합니다. provider가 경로를 흘려도 브라우저 DTO에 도달하지 못합니다.
- **디자인.** 신호색(`aurora`/`warn`/`positive`)은 **테두리에만** 쓰고 텍스트는 3계층 토큰으로 둡니다. 정체성 톤 `--id-*`는 기존 Theater spine에 그대로 남깁니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 0 errors
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @fleet-plugins/repository typecheck` · `test` — 265 passed
- [x] `theater-row-badges` · `theater-row-badges-client` · `plugin-host` · `instrument-design-contract` · `api-catalog` — 57 passed
- [ ] Changelog fragment — PR 번호 배정 후 추가 예정

### 알려진 한계

절대경로 차단은 **문자열 접두** 기준입니다(`/`, UNC, 드라이브 문자, `file://`). 브랜치명이 `origin/canary`처럼 슬래시를 정상적으로 포함하므로 contains 검사는 오탐이 되어 채택하지 않았습니다.

### 선존 실패 (이 PR과 무관)

`tests/server.test.ts > … issues Theater-bound dedicated MCP sessions …` 1건. base에서 동일하게 재현됩니다.

실서버를 띄우는 테스트(`api-catalog`·`carrier-settings`·`codex-security-routes`·`server.test.ts`의 Origin/diagnostics)는 동시 vitest 실행과 겹치면 타임아웃으로 가짜 실패합니다. 위 결과는 모두 해당 파일 단독 실행 기준입니다.