### PR TITLE
feat(console): let rail panels contribute results to the command palette

### DIFF
--- a/.changelog.d/pr-384.md
+++ b/.changelog.d/pr-384.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Added
+- [fleet-console] Search Repository commits, Files paths, Plans and Skills from the command palette, and open the owning panel at that result. The palette previously matched Operation titles only, and no panel could hand a commit or a path to another.
+  ko: 커맨드 팔레트에서 Repository 커밋·Files 경로·Plans·Skills를 검색하고, 결과를 고르면 해당 패널이 그 위치에서 열립니다. 이전에는 Operation 제목만 검색되었고 커밋이나 경로를 다른 패널로 넘길 방법이 없었습니다.

--- a/runtime/fleet-console/core/client/src/api.ts
+++ b/runtime/fleet-console/core/client/src/api.ts
@@ -56,6 +56,15 @@ export interface PlansListResult {
   readonly plans: readonly PlanListItem[];
 }
 
+export interface PlanSearchItem {
+  readonly name: string;
+  readonly title: string;
+}
+
+export interface PlansSearchResult {
+  readonly plans: readonly PlanSearchItem[];
+}
+
 export interface ReleaseNotesFetchOptions {
   readonly force?: boolean;
   readonly locale?: ReleaseNotesLocale;
@@ -200,6 +209,17 @@ export async function fetchPlanRead(theaterId: string, name: string, signal?: Ab
   });
   await assertOk(response);
   return await response.json() as PlanReadResult;
+}
+
+export async function fetchPlansSearch(theaterId: string, query: string, limit: number, signal?: AbortSignal): Promise<PlansSearchResult> {
+  const response = await fetch("/api/v1/plans/search", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ theaterId, query, limit }),
+    signal,
+  });
+  await assertOk(response);
+  return await response.json() as PlansSearchResult;
 }
 
 export async function forgetTheater(theaterId: string, signal?: AbortSignal): Promise<void> {

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -38,10 +38,9 @@ export function App() {
   const releaseNotesLocale = resolveReleaseNotesLocale(globalSettings.state?.language ?? "auto");
   const pathname = location.pathname;
   const operationsViewVisible = pathname.startsWith("/operations");
-  // 팔레트 커맨드 모드의 "Open panel" 목록 — RightRail과 동일한 빌트인+플러그인 합성 순서를 미러한다.
+  // 팔레트의 "Open panel"과 패널 검색 목록 — RightRail과 동일한 빌트인+플러그인 합성 순서를 미러한다.
   const paletteRailPanels = useMemo(
-    () => [...BUILT_IN_RAIL_PANELS, ...registry.railPanels.filter((panel) => (panel.side ?? "right") === "right")]
-      .map((panel) => ({ id: panel.id, title: panel.title })),
+    () => [...BUILT_IN_RAIL_PANELS, ...registry.railPanels.filter((panel) => (panel.side ?? "right") === "right")],
     [registry.railPanels],
   );
 

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -2,16 +2,23 @@ import { useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboa
 import { useLocation, useNavigate } from "react-router-dom";
 
 import type { FleetClientPlugin } from "@fleet-console/sdk/plugin";
+import type { RailPanelDescriptor, RailSearchResult } from "@fleet-console/sdk/rail";
 
 import { setGlobalSettingsField } from "../global-settings-store.js";
-import { filterOperationSearchEntries, groupOperationSearchEntries, searchTokens } from "../operation-search.js";
+import {
+  filterOperationSearchEntries,
+  groupOperationSearchEntries,
+  RAIL_SEARCH_DEBOUNCE_MS,
+  searchRailPanels,
+  searchTokens,
+  type RailSearchGroup,
+} from "../operation-search.js";
 import {
   buildPaletteCommands,
   commandModeQuery,
   filterPaletteCommands,
   isCommandModeInput,
   type PaletteCommandEntry,
-  type PaletteRailPanelInfo,
 } from "../palette-commands.js";
 import { stashKeyboardShortcutsReturnFocus } from "../keyboard-shortcuts-return-focus.js";
 import { closeOperationCompletely } from "../operation-close.js";
@@ -33,7 +40,7 @@ import type { ConsoleState } from "../types.js";
 
 interface OperationSearchProps {
   readonly state: ConsoleState;
-  readonly railPanels: readonly PaletteRailPanelInfo[];
+  readonly railPanels: readonly RailPanelDescriptor[];
   // virtual:fleet-plugins 의존을 테스트 경계 밖으로 밀기 위해 registry 직접 import 대신 prop으로 받는다.
   readonly plugins: readonly FleetClientPlugin[];
 }
@@ -48,10 +55,12 @@ export function OperationSearch({ state, railPanels, plugins }: OperationSearchP
   const location = useLocation();
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [railSearchGroups, setRailSearchGroups] = useState<readonly RailSearchGroup[]>([]);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const cardRef = useRef<HTMLElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const resultRefs = useRef(new Map<string, HTMLButtonElement>());
+  const searchGenerationRef = useRef(0);
   const commandMode = isCommandModeInput(query);
   const entries = useMemo(() => operationSearchEntries(state), [state]);
   const filteredEntries = useMemo(() => filterOperationSearchEntries(entries, query), [entries, query]);
@@ -62,14 +71,45 @@ export function OperationSearch({ state, railPanels, plugins }: OperationSearchP
     [commandMode, commands, query],
   );
   const tokens = useMemo(() => searchTokens(commandMode ? commandModeQuery(query) : query), [commandMode, query]);
-  const resultCount = commandMode ? filteredCommands.length : filteredEntries.length;
+  const railSearchEntries = useMemo(
+    () => railSearchGroups.flatMap((group) => group.results.map((result) => ({ group, result }))),
+    [railSearchGroups],
+  );
+  const resultCount = commandMode ? filteredCommands.length : filteredEntries.length + railSearchEntries.length;
   const clampedSelectedIndex = clampIndex(selectedIndex, resultCount);
   const selectedResultKey = commandMode
-    ? filteredCommands[clampedSelectedIndex]?.commandId
-    : filteredEntries[clampedSelectedIndex]?.operationId;
+    ? filteredCommands[clampedSelectedIndex] ? commandResultKey(filteredCommands[clampedSelectedIndex]!.commandId) : undefined
+    : filteredEntries[clampedSelectedIndex]
+      ? operationResultKey(filteredEntries[clampedSelectedIndex]!.operationId)
+      : railSearchEntries[clampedSelectedIndex - filteredEntries.length]
+        ? railResultKey(
+          railSearchEntries[clampedSelectedIndex - filteredEntries.length]!.group.panelId,
+          railSearchEntries[clampedSelectedIndex - filteredEntries.length]!.result.id,
+        )
+        : undefined;
   const activeOptionId = selectedResultKey === undefined
     ? undefined
-    : commandMode ? commandOptionId(selectedResultKey) : operationOptionId(selectedResultKey);
+    : resultOptionId(selectedResultKey);
+
+  useEffect(() => {
+    const generation = ++searchGenerationRef.current;
+    setRailSearchGroups([]);
+    const theaterId = state.activeTheaterId;
+    if (!state.operationSearchOpen || commandMode || query.trim() === "" || !theaterId) return;
+
+    const abort = new AbortController();
+    const timer = window.setTimeout(() => {
+      void searchRailPanels(railPanels, query, theaterId, abort.signal).then((nextGroups) => {
+        // provider가 abort를 무시해도 이전 세대 결과는 현재 팔레트에 반영하지 않는다.
+        if (abort.signal.aborted || generation !== searchGenerationRef.current) return;
+        setRailSearchGroups(nextGroups);
+      });
+    }, RAIL_SEARCH_DEBOUNCE_MS);
+    return () => {
+      window.clearTimeout(timer);
+      abort.abort();
+    };
+  }, [commandMode, query, railPanels, state.activeTheaterId, state.operationSearchOpen]);
 
   useEffect(() => {
     if (!state.operationSearchOpen) return;
@@ -105,6 +145,20 @@ export function OperationSearch({ state, railPanels, plugins }: OperationSearchP
     // 최대화 해제는 이동 경로(operations.tsx의 pendingOperationFocus 소비)에 위임한다 — 최대화 중이면 유지·교체.
     focusOperation(operationId);
     navigate("/operations");
+    closeOperationSearch();
+  };
+
+  const selectRailResult = async (panelId: string, result: RailSearchResult) => {
+    // activate가 plugin-local 논리 타깃을 먼저 기록한 뒤에만 host route/rail을 연다.
+    previousFocusRef.current = null;
+    try {
+      await result.activate();
+    } catch {
+      return;
+    }
+    navigate("/operations");
+    openRailPanel(panelId);
+    setRailChromeExpanded(true);
     closeOperationSearch();
   };
 
@@ -256,9 +310,15 @@ export function OperationSearch({ state, railPanels, plugins }: OperationSearchP
         return;
       }
       const selected = filteredEntries[clampedSelectedIndex];
-      if (!selected) return;
+      if (selected) {
+        event.preventDefault();
+        selectEntry(selected.operationId);
+        return;
+      }
+      const panelEntry = railSearchEntries[clampedSelectedIndex - filteredEntries.length];
+      if (!panelEntry) return;
       event.preventDefault();
-      selectEntry(selected.operationId);
+      void selectRailResult(panelEntry.group.panelId, panelEntry.result);
       return;
     }
     if (event.key === "Tab") trapFocus(event, cardRef.current);
@@ -302,13 +362,14 @@ export function OperationSearch({ state, railPanels, plugins }: OperationSearchP
               <h2 id={COMMAND_GROUP_HEADING_ID} className="operation-search-section-heading">Commands</h2>
               {filteredCommands.map((command, index) => {
                 const active = index === clampedSelectedIndex;
+                const resultKey = commandResultKey(command.commandId);
                 return (
                   <button
                     id={commandOptionId(command.commandId)}
                     key={command.commandId}
                     ref={(node) => {
-                      if (node) resultRefs.current.set(command.commandId, node);
-                      else resultRefs.current.delete(command.commandId);
+                      if (node) resultRefs.current.set(resultKey, node);
+                      else resultRefs.current.delete(resultKey);
                     }}
                     type="button"
                     className={`operation-search-result ${active ? "is-active" : ""}`}
@@ -326,43 +387,83 @@ export function OperationSearch({ state, railPanels, plugins }: OperationSearchP
                 );
               })}
             </section>
-          ) : <p className="operation-search-empty">No matching commands.</p>) : groups.length > 0 ? groups.map((group) => {
-            const headingId = operationGroupHeadingId(group.theaterId);
-            return (
-            <section className="operation-search-section" key={group.theaterId ?? UNASSIGNED_GROUP_KEY} role="group" aria-labelledby={headingId}>
-              <h2 id={headingId} className="operation-search-section-heading">{highlightText(group.theaterLabel, tokens)}</h2>
-              {group.entries.map((entry) => {
-                const index = filteredEntries.indexOf(entry);
-                const active = index === clampedSelectedIndex;
+          ) : <p className="operation-search-empty">No matching commands.</p>) : (
+            groups.length > 0 || railSearchGroups.length > 0 ? <>
+              {groups.map((group) => {
+                const headingId = operationGroupHeadingId(group.theaterId);
                 return (
-                  <button
-                    id={operationOptionId(entry.operationId)}
-                    key={entry.operationId}
-                    ref={(node) => {
-                      if (node) resultRefs.current.set(entry.operationId, node);
-                      else resultRefs.current.delete(entry.operationId);
-                    }}
-                    type="button"
-                    className={`operation-search-result ${active ? "is-active" : ""}`}
-                    role="option"
-                    aria-selected={active}
-                    onMouseEnter={() => setSelectedIndex(index)}
-                    onClick={() => selectEntry(entry.operationId)}
-                  >
-                    <span className="operation-search-result-text">
-                      <strong>{highlightText(entry.operationName, tokens)}</strong>
-                      <small>{operationMeta(entry)}</small>
-                    </span>
-                    {entry.activity !== "idle" ? (
-                      <span className={`operation-search-status operation-search-status--${entry.activity}`}>{entry.activity}</span>
-                    ) : null}
-                    <span className="operation-search-theater">{highlightText(entry.theaterLabel, tokens)}</span>
-                  </button>
+                  <section className="operation-search-section" key={group.theaterId ?? UNASSIGNED_GROUP_KEY} role="group" aria-labelledby={headingId}>
+                    <h2 id={headingId} className="operation-search-section-heading">{highlightText(group.theaterLabel, tokens)}</h2>
+                    {group.entries.map((entry) => {
+                      const index = filteredEntries.indexOf(entry);
+                      const active = index === clampedSelectedIndex;
+                      const resultKey = operationResultKey(entry.operationId);
+                      return (
+                        <button
+                          id={resultOptionId(resultKey)}
+                          key={entry.operationId}
+                          ref={(node) => {
+                            if (node) resultRefs.current.set(resultKey, node);
+                            else resultRefs.current.delete(resultKey);
+                          }}
+                          type="button"
+                          className={`operation-search-result ${active ? "is-active" : ""}`}
+                          role="option"
+                          aria-selected={active}
+                          onMouseEnter={() => setSelectedIndex(index)}
+                          onClick={() => selectEntry(entry.operationId)}
+                        >
+                          <span className="operation-search-result-text">
+                            <strong>{highlightText(entry.operationName, tokens)}</strong>
+                            <small>{operationMeta(entry)}</small>
+                          </span>
+                          {entry.activity !== "idle" ? (
+                            <span className={`operation-search-status operation-search-status--${entry.activity}`}>{entry.activity}</span>
+                          ) : null}
+                          <span className="operation-search-theater">{highlightText(entry.theaterLabel, tokens)}</span>
+                        </button>
+                      );
+                    })}
+                  </section>
                 );
               })}
-            </section>
-            );
-          }) : <p className="operation-search-empty">No matching Operations.</p>}
+              {railSearchGroups.map((group) => {
+                const headingId = railGroupHeadingId(group.panelId);
+                return (
+                  <section className="operation-search-section operation-search-panel-section" key={group.panelId} role="group" aria-labelledby={headingId}>
+                    <h2 id={headingId} className="operation-search-section-heading">{group.panelTitle}</h2>
+                    {group.results.map((result) => {
+                      const index = filteredEntries.length + railSearchEntries.findIndex((entry) => entry.group.panelId === group.panelId && entry.result === result);
+                      const active = index === clampedSelectedIndex;
+                      const resultKey = railResultKey(group.panelId, result.id);
+                      return (
+                        <button
+                          id={resultOptionId(resultKey)}
+                          key={result.id}
+                          ref={(node) => {
+                            if (node) resultRefs.current.set(resultKey, node);
+                            else resultRefs.current.delete(resultKey);
+                          }}
+                          type="button"
+                          className={`operation-search-result operation-search-panel-result ${active ? "is-active" : ""}`}
+                          role="option"
+                          aria-selected={active}
+                          onMouseEnter={() => setSelectedIndex(index)}
+                          onClick={() => { void selectRailResult(group.panelId, result); }}
+                        >
+                          <span className="operation-search-result-text">
+                            <strong>{highlightText(result.title, tokens)}</strong>
+                            {result.subtitle ? <small>{highlightText(result.subtitle, tokens)}</small> : null}
+                          </span>
+                          <span className="operation-search-panel-open">open</span>
+                        </button>
+                      );
+                    })}
+                  </section>
+                );
+              })}
+            </> : <p className="operation-search-empty">No matching Operations or panel content.</p>
+          )}
         </div>
       </section>
     </div>
@@ -401,12 +502,28 @@ function operationGroupHeadingId(theaterId: string | null): string {
   return `operation-search-heading-${domIdPart(theaterId ?? UNASSIGNED_GROUP_KEY)}`;
 }
 
-function operationOptionId(operationId: string): string {
-  return `operation-search-option-${domIdPart(operationId)}`;
+function commandOptionId(commandId: string): string {
+  return resultOptionId(commandResultKey(commandId));
 }
 
-function commandOptionId(commandId: string): string {
-  return `operation-search-command-${domIdPart(commandId)}`;
+function resultOptionId(resultKey: string): string {
+  return `operation-search-option-${domIdPart(resultKey)}`;
+}
+
+function operationResultKey(operationId: string): string {
+  return `operation:${operationId}`;
+}
+
+function commandResultKey(commandId: string): string {
+  return `command:${commandId}`;
+}
+
+function railResultKey(panelId: string, resultId: string): string {
+  return `panel:${panelId}:${resultId}`;
+}
+
+function railGroupHeadingId(panelId: string): string {
+  return `operation-search-heading-panel-${domIdPart(panelId)}`;
 }
 
 function domIdPart(value: string): string {

--- a/runtime/fleet-console/core/client/src/operation-search.ts
+++ b/runtime/fleet-console/core/client/src/operation-search.ts
@@ -1,4 +1,5 @@
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
+import type { RailPanelDescriptor, RailSearchResult } from "@fleet-console/sdk/rail";
 
 import { resolveOperationActivity } from "./operation-activity.js";
 import type { ConsoleState, OperationNode, TheaterInfo } from "./types.js";
@@ -19,7 +20,70 @@ export interface OperationSearchGroup {
   readonly entries: readonly OperationSearchEntry[];
 }
 
+export interface RailSearchGroup {
+  readonly panelId: string;
+  readonly panelTitle: string;
+  readonly results: readonly RailSearchResult[];
+}
+
+export const RAIL_SEARCH_DEBOUNCE_MS = 150;
+export const RAIL_SEARCH_PROVIDER_TIMEOUT_MS = 500;
+export const RAIL_SEARCH_PROVIDER_LIMIT = 8;
+
 const UNASSIGNED_GROUP_KEY = "__unassigned__";
+
+export async function searchRailPanels(
+  panels: readonly RailPanelDescriptor[],
+  query: string,
+  theaterId: string,
+  signal: AbortSignal,
+): Promise<readonly RailSearchGroup[]> {
+  const groups = await Promise.all(panels.map(async (panel): Promise<RailSearchGroup | null> => {
+    if (!panel.search) return null;
+    const results = await searchRailPanel(panel, query, theaterId, signal);
+    if (!results || results.length === 0) return null;
+    return {
+      panelId: panel.id,
+      panelTitle: panel.title,
+      results: results.slice(0, RAIL_SEARCH_PROVIDER_LIMIT),
+    };
+  }));
+  return groups.filter((group): group is RailSearchGroup => group !== null);
+}
+
+async function searchRailPanel(
+  panel: RailPanelDescriptor,
+  query: string,
+  theaterId: string,
+  parentSignal: AbortSignal,
+): Promise<readonly RailSearchResult[] | null> {
+  if (!panel.search || parentSignal.aborted) return null;
+  const controller = new AbortController();
+  let stopSearch: (() => void) | null = null;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  try {
+    const stopped = new Promise<null>((resolve) => {
+      stopSearch = () => {
+        controller.abort();
+        resolve(null);
+      };
+      parentSignal.addEventListener("abort", stopSearch, { once: true });
+      timeoutId = setTimeout(stopSearch, RAIL_SEARCH_PROVIDER_TIMEOUT_MS);
+    });
+    const request = Promise.resolve()
+      .then(() => panel.search!({
+        query,
+        theaterId,
+        limit: RAIL_SEARCH_PROVIDER_LIMIT,
+        signal: controller.signal,
+      }))
+      .then((results) => results, () => null);
+    return await Promise.race([request, stopped]);
+  } finally {
+    if (timeoutId !== null) clearTimeout(timeoutId);
+    if (stopSearch) parentSignal.removeEventListener("abort", stopSearch);
+  }
+}
 
 export function buildOperationSearchEntries(current: ConsoleState): readonly OperationSearchEntry[] {
   const theaters = new Map(current.theaters.map((theater) => [theater.id, theater]));

--- a/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
@@ -5,12 +5,14 @@ import { installDiagramHydrator } from "@fleet-console/markdown/mermaid";
 import type { RailPanelContext, RailPanelDescriptor } from "@fleet-console/sdk/rail";
 
 import "@fleet-console/markdown/styles.css";
-import { fetchPlanRead, fetchPlansList, type PlanListItem, type PlanReadResult } from "../api.js";
+import { fetchPlanRead, fetchPlansList, fetchPlansSearch, type PlanListItem, type PlanReadResult } from "../api.js";
 import "./plans.css";
 import { filterPlans, formatRelativeTime, getLaneDispatchState, getProgressPercent, getWaveProgressState, normalizePlanHeading, planLaneHeadingMatches, planListSignature, type PlanStatusFilter } from "./plans-helpers.js";
 import { subscribeToPlanChanges } from "./plans-events.js";
+import { activatePlansSearchTarget, consumePlansSearchTarget, usePlansSearchTarget } from "./plans-search-navigation.js";
 
 interface PlansListProps {
+  readonly revealName: string | null;
   readonly selectedName: string | null;
   readonly state: PlansListState;
   readonly onRetry: () => void;
@@ -62,6 +64,15 @@ export const plansPanel: RailPanelDescriptor = {
   defaultWidth: 360,
   icon: PlansIcon,
   render: (ctx) => <PlansPanel {...ctx} />,
+  search: async ({ query, theaterId, limit, signal }) => {
+    const result = await fetchPlansSearch(theaterId, query, limit, signal);
+    return result.plans.map((plan) => ({
+      id: plan.name,
+      title: plan.title,
+      subtitle: plan.name,
+      activate: () => activatePlansSearchTarget(theaterId, plan.name),
+    }));
+  },
 };
 
 function PlansPanel(ctx: RailPanelContext) {
@@ -78,6 +89,8 @@ function PlansPanelBody(ctx: RailPanelContext) {
   const [listRetry, setListRetry] = useState(0);
   const [readerRetry, setReaderRetry] = useState(0);
   const [pulsedNames, setPulsedNames] = useState<ReadonlySet<string>>(() => new Set());
+  const [revealName, setRevealName] = useState<string | null>(null);
+  const searchTarget = usePlansSearchTarget();
   const listRequestRef = useRef(0);
   const readerRequestRef = useRef(0);
   const listSignaturesRef = useRef<Map<string, string> | null>(null);
@@ -94,6 +107,13 @@ function PlansPanelBody(ctx: RailPanelContext) {
   const selectedNameRef = useRef<string | null>(null);
   const pulseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectedName = selectedPlan?.theaterId === theaterId ? selectedPlan.name : null;
+
+  useEffect(() => {
+    if (!searchTarget || searchTarget.theaterId !== theaterId || !theaterId) return;
+    setSelectedPlan({ theaterId, name: searchTarget.name });
+    setRevealName(searchTarget.name);
+    consumePlansSearchTarget(searchTarget);
+  }, [searchTarget, theaterId]);
 
   useEffect(() => {
     selectedNameRef.current = selectedName;
@@ -224,6 +244,7 @@ function PlansPanelBody(ctx: RailPanelContext) {
         {selectedName && <PlanReader state={readerState} onClose={handleClose} onRetry={retryReader} />}
         {selectedName && <div className="plans-divider" aria-hidden="true" />}
         <PlansList
+          revealName={revealName}
           selectedName={selectedName}
           state={listState}
           onRetry={retryList}
@@ -235,11 +256,20 @@ function PlansPanelBody(ctx: RailPanelContext) {
   );
 }
 
-function PlansList({ selectedName, state, onRetry, onSelect, pulsedNames }: PlansListProps) {
+function PlansList({ revealName, selectedName, state, onRetry, onSelect, pulsedNames }: PlansListProps) {
   const [query, setQuery] = useState("");
   const [status, setStatus] = useState<PlanStatusFilter>("all");
   const [copiedName, setCopiedName] = useState<string | null>(null);
   const rowRefs = useRef(new Map<string, HTMLButtonElement>());
+  useEffect(() => {
+    if (!revealName) return;
+    setQuery("");
+    setStatus("all");
+  }, [revealName]);
+  useLayoutEffect(() => {
+    if (!revealName || state.kind !== "ready") return;
+    rowRefs.current.get(revealName)?.scrollIntoView({ block: "nearest" });
+  }, [revealName, state]);
   if (state.kind === "no-theater") {
     return <div className="plans-list-pane"><EmptyState>Select a Theater to browse plans.</EmptyState></div>;
   }

--- a/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/plans-panel.tsx
@@ -9,13 +9,14 @@ import { fetchPlanRead, fetchPlansList, fetchPlansSearch, type PlanListItem, typ
 import "./plans.css";
 import { filterPlans, formatRelativeTime, getLaneDispatchState, getProgressPercent, getWaveProgressState, normalizePlanHeading, planLaneHeadingMatches, planListSignature, type PlanStatusFilter } from "./plans-helpers.js";
 import { subscribeToPlanChanges } from "./plans-events.js";
-import { activatePlansSearchTarget, consumePlansSearchTarget, usePlansSearchTarget } from "./plans-search-navigation.js";
+import { activatePlansSearchTarget, consumePlansSearchTarget, type PlansSearchTarget, usePlansSearchTarget } from "./plans-search-navigation.js";
 
 interface PlansListProps {
-  readonly revealName: string | null;
+  readonly revealTarget: PlansSearchTarget | null;
   readonly selectedName: string | null;
   readonly state: PlansListState;
   readonly onRetry: () => void;
+  readonly onRevealHandled: (target: PlansSearchTarget) => void;
   readonly onSelect: (name: string) => void;
   readonly pulsedNames: ReadonlySet<string>;
 }
@@ -89,7 +90,7 @@ function PlansPanelBody(ctx: RailPanelContext) {
   const [listRetry, setListRetry] = useState(0);
   const [readerRetry, setReaderRetry] = useState(0);
   const [pulsedNames, setPulsedNames] = useState<ReadonlySet<string>>(() => new Set());
-  const [revealName, setRevealName] = useState<string | null>(null);
+  const [revealTarget, setRevealTarget] = useState<PlansSearchTarget | null>(null);
   const searchTarget = usePlansSearchTarget();
   const listRequestRef = useRef(0);
   const readerRequestRef = useRef(0);
@@ -111,8 +112,7 @@ function PlansPanelBody(ctx: RailPanelContext) {
   useEffect(() => {
     if (!searchTarget || searchTarget.theaterId !== theaterId || !theaterId) return;
     setSelectedPlan({ theaterId, name: searchTarget.name });
-    setRevealName(searchTarget.name);
-    consumePlansSearchTarget(searchTarget);
+    setRevealTarget(searchTarget);
   }, [searchTarget, theaterId]);
 
   useEffect(() => {
@@ -220,6 +220,10 @@ function PlansPanelBody(ctx: RailPanelContext) {
   const handleSelect = useCallback((name: string) => {
     if (theaterId) setSelectedPlan({ theaterId, name });
   }, [theaterId]);
+  const handleRevealHandled = useCallback((target: PlansSearchTarget) => {
+    consumePlansSearchTarget(target);
+    setRevealTarget((current) => current?.requestId === target.requestId ? null : current);
+  }, []);
   // 닫힌 리더는 유지할 내용이 없다 — ref/상태를 함께 리셋해 같은 플랜 재열람이 background로
   // 오분류되어 읽기 실패를 침묵시키는 일이 없게 한다(재열람은 항상 foreground).
   const handleClose = useCallback(() => {
@@ -244,10 +248,11 @@ function PlansPanelBody(ctx: RailPanelContext) {
         {selectedName && <PlanReader state={readerState} onClose={handleClose} onRetry={retryReader} />}
         {selectedName && <div className="plans-divider" aria-hidden="true" />}
         <PlansList
-          revealName={revealName}
+          revealTarget={revealTarget}
           selectedName={selectedName}
           state={listState}
           onRetry={retryList}
+          onRevealHandled={handleRevealHandled}
           onSelect={handleSelect}
           pulsedNames={pulsedNames}
         />
@@ -256,20 +261,25 @@ function PlansPanelBody(ctx: RailPanelContext) {
   );
 }
 
-function PlansList({ revealName, selectedName, state, onRetry, onSelect, pulsedNames }: PlansListProps) {
+function PlansList({ revealTarget, selectedName, state, onRetry, onRevealHandled, onSelect, pulsedNames }: PlansListProps) {
   const [query, setQuery] = useState("");
   const [status, setStatus] = useState<PlanStatusFilter>("all");
   const [copiedName, setCopiedName] = useState<string | null>(null);
   const rowRefs = useRef(new Map<string, HTMLButtonElement>());
-  useEffect(() => {
-    if (!revealName) return;
-    setQuery("");
-    setStatus("all");
-  }, [revealName]);
   useLayoutEffect(() => {
-    if (!revealName || state.kind !== "ready") return;
-    rowRefs.current.get(revealName)?.scrollIntoView({ block: "nearest" });
-  }, [revealName, state]);
+    if (!revealTarget || state.kind === "loading") return;
+    if (state.kind !== "ready") {
+      onRevealHandled(revealTarget);
+      return;
+    }
+    if (query !== "" || status !== "all") {
+      setQuery("");
+      setStatus("all");
+      return;
+    }
+    rowRefs.current.get(revealTarget.name)?.scrollIntoView({ block: "nearest" });
+    onRevealHandled(revealTarget);
+  }, [onRevealHandled, query, revealTarget, state, status]);
   if (state.kind === "no-theater") {
     return <div className="plans-list-pane"><EmptyState>Select a Theater to browse plans.</EmptyState></div>;
   }

--- a/runtime/fleet-console/core/client/src/rail/plans-search-navigation.ts
+++ b/runtime/fleet-console/core/client/src/rail/plans-search-navigation.ts
@@ -1,0 +1,41 @@
+import { useSyncExternalStore } from "react";
+
+export interface PlansSearchTarget {
+  readonly theaterId: string;
+  readonly name: string;
+  readonly requestId: number;
+}
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+let requestId = 0;
+let target: PlansSearchTarget | null = null;
+
+export function activatePlansSearchTarget(theaterId: string, name: string): void {
+  target = { theaterId, name, requestId: ++requestId };
+  emit();
+}
+
+export function consumePlansSearchTarget(expected: PlansSearchTarget): void {
+  if (target?.requestId !== expected.requestId) return;
+  target = null;
+  emit();
+}
+
+export function usePlansSearchTarget(): PlansSearchTarget | null {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+}
+
+function getSnapshot(): PlansSearchTarget | null {
+  return target;
+}
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}

--- a/runtime/fleet-console/core/client/src/rail/plans-search-navigation.ts
+++ b/runtime/fleet-console/core/client/src/rail/plans-search-navigation.ts
@@ -23,6 +23,10 @@ export function consumePlansSearchTarget(expected: PlansSearchTarget): void {
   emit();
 }
 
+export function getPlansSearchTargetForTest(): PlansSearchTarget | null {
+  return target;
+}
+
 export function usePlansSearchTarget(): PlansSearchTarget | null {
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -6422,6 +6422,10 @@
   gap: 2px;
 }
 
+.operation-search-panel-section {
+  border-top: 1px solid color-mix(in oklch, var(--surface-rim) 72%, transparent);
+}
+
 .operation-search-section-heading {
   display: flex;
   align-items: center;
@@ -6593,6 +6597,16 @@
 
 .operation-search-result.is-active .operation-search-command-glyph {
   color: var(--brass-bright);
+}
+
+.operation-search-panel-open {
+  flex: none;
+  color: var(--brass-bright);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
 }
 
 .operation-search-empty {

--- a/runtime/fleet-console/core/host/plans/routes.ts
+++ b/runtime/fleet-console/core/host/plans/routes.ts
@@ -27,6 +27,11 @@ interface PlansReadBody extends PlansListBody {
   readonly name?: unknown;
 }
 
+interface PlansSearchBody extends PlansListBody {
+  readonly query?: unknown;
+  readonly limit?: unknown;
+}
+
 export function createPlansRouter(deps: PlansRouteDeps): (context: PlansRouteContext) => Promise<boolean> {
   return async function handlePlansRoute(context: PlansRouteContext): Promise<boolean> {
     const { req, res, pathname } = context;
@@ -38,12 +43,60 @@ export function createPlansRouter(deps: PlansRouteDeps): (context: PlansRouteCon
       await handlePlansRead(req, res, deps);
       return true;
     }
+    if (pathname === "/api/v1/plans/search") {
+      await handlePlansSearch(req, res, deps);
+      return true;
+    }
     if (pathname === "/api/v1/plans/events") {
       await handlePlansEvents(req, res, deps);
       return true;
     }
     return false;
   };
+}
+
+async function handlePlansSearch(req: http.IncomingMessage, res: http.ServerResponse, deps: PlansRouteDeps): Promise<void> {
+  if (req.method !== "POST") {
+    deps.writeJson(res, 405, { error: "Method not allowed" });
+    return;
+  }
+  if (!deps.isAuthorized(req)) {
+    deps.writeJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  const body = await deps.readJsonBody<PlansSearchBody>(req);
+  if (
+    !isPlainObject(body)
+    || typeof body.theaterId !== "string"
+    || typeof body.query !== "string"
+    || body.query.trim() === ""
+    || !Number.isInteger(body.limit)
+    || (body.limit as number) < 1
+    || (body.limit as number) > 8
+    || "relPath" in body
+  ) {
+    deps.writeJson(res, 400, { error: "invalid_request" });
+    return;
+  }
+  const theaterPath = deps.resolveTheaterPath(body.theaterId);
+  if (!theaterPath) {
+    deps.writeJson(res, 404, { error: "theater_not_found" });
+    return;
+  }
+  try {
+    const context = await resolveTheaterRoot(theaterPath);
+    const tokens = body.query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+    const plans = (await listPlansForWorkspace(deps.dataDir, context.realRoot))
+      .filter((plan) => {
+        const text = `${plan.name}\n${plan.title}`.toLocaleLowerCase();
+        return tokens.every((token) => text.includes(token));
+      })
+      .slice(0, body.limit as number)
+      .map((plan) => ({ name: plan.name, title: plan.title }));
+    deps.writeJson(res, 200, { plans });
+  } catch (error) {
+    writePlanStoreError(res, deps, error);
+  }
 }
 
 async function handlePlansEvents(req: http.IncomingMessage, res: http.ServerResponse, deps: PlansRouteDeps): Promise<void> {

--- a/runtime/fleet-console/sdk/rail/types.ts
+++ b/runtime/fleet-console/sdk/rail/types.ts
@@ -19,11 +19,28 @@ export interface RailPanelContext {
   readonly requestExtraWidth?: (px: number | null) => void;
 }
 
+export interface RailSearchRequest {
+  readonly query: string;
+  readonly theaterId: string;
+  readonly limit: number;
+  readonly signal: AbortSignal;
+}
+
+export interface RailSearchResult {
+  readonly id: string;
+  readonly title: string;
+  readonly subtitle?: string;
+  readonly activate: () => void | Promise<void>;
+}
+
+export type RailSearchProvider = (request: RailSearchRequest) => Promise<readonly RailSearchResult[]>;
+
 export interface RailPanelDescriptor {
   readonly id: string;
   readonly title: string;
   readonly icon: ReactNode | (() => ReactNode);
   readonly render: (ctx: RailPanelContext) => ReactNode;
+  readonly search?: RailSearchProvider;
   readonly side?: "right";
   /** @deprecated Core ignores this field; every panel is Theater-root scoped. */
   readonly pathAware?: boolean;

--- a/runtime/fleet-console/tests/plans-panel.test.tsx
+++ b/runtime/fleet-console/tests/plans-panel.test.tsx
@@ -27,6 +27,11 @@ vi.mock("@fleet-console/markdown/mermaid", () => ({
 }));
 
 import { plansPanel } from "../core/client/src/rail/plans-panel.js";
+import {
+  activatePlansSearchTarget,
+  consumePlansSearchTarget,
+  getPlansSearchTargetForTest,
+} from "../core/client/src/rail/plans-search-navigation.js";
 
 let container: HTMLDivElement;
 let root: Root;
@@ -51,8 +56,11 @@ beforeEach(() => {
 
 afterEach(() => {
   act(() => root.unmount());
+  const target = getPlansSearchTargetForTest();
+  if (target) consumePlansSearchTarget(target);
   container.remove();
   vi.restoreAllMocks();
+  Reflect.deleteProperty(HTMLElement.prototype, "scrollIntoView");
 });
 
 describe("Plans panel reader revalidation", () => {
@@ -155,6 +163,51 @@ describe("Plans panel reader revalidation", () => {
   });
 });
 
+describe("Plans palette target reveal", () => {
+  it("clears active filters before selecting and scrolling the target, then consumes it", async () => {
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    mocks.fetchPlansList.mockResolvedValue({
+      plans: [
+        listPlan(),
+        listPlan({ name: "beta.md", title: "Beta", tasksDone: 1, tasksTotal: 1 }),
+      ],
+    });
+    mocks.fetchPlanRead.mockResolvedValue({
+      ...readPlan("Beta"),
+      name: "beta.md",
+    });
+
+    await renderPanel();
+    const search = container.querySelector<HTMLInputElement>(".plans-search");
+    const inProgress = [...container.querySelectorAll<HTMLButtonElement>(".plans-filter")]
+      .find((button) => button.textContent === "IN PROGRESS");
+    await act(async () => {
+      setInputValue(search, "alpha");
+      inProgress?.click();
+    });
+    expect(container.textContent).not.toContain("beta.md");
+
+    await act(async () => {
+      activatePlansSearchTarget("theater-1", "beta.md");
+    });
+    await flush();
+
+    expect(search?.value).toBe("");
+    expect(container.querySelector(".plans-filter.is-active")?.textContent).toBe("ALL");
+    expect(container.querySelector(".plans-row.is-selected .plans-row-name")?.textContent).toBe("beta.md");
+    expect(scrollIntoView).toHaveBeenCalledOnce();
+    expect(scrollIntoView.mock.instances[0]).toBe(
+      [...container.querySelectorAll<HTMLButtonElement>(".plans-row-select")]
+        .find((button) => button.textContent?.includes("beta.md")),
+    );
+    expect(getPlansSearchTargetForTest()).toBeNull();
+  });
+});
+
 async function renderPanel(): Promise<void> {
   await act(async () => {
     root.render(plansPanel.render({
@@ -225,4 +278,11 @@ function deferred<T>(): {
     reject = onReject;
   });
   return { promise, resolve, reject };
+}
+
+function setInputValue(input: HTMLInputElement | null, value: string): void {
+  if (!input) throw new Error("plans search input not found");
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
 }

--- a/runtime/fleet-console/tests/plans-security.test.ts
+++ b/runtime/fleet-console/tests/plans-security.test.ts
@@ -121,6 +121,21 @@ describe("Plans handlers — security", () => {
     expect(response.body).toMatchObject({ tasksDone: 2, tasksTotal: 3 });
   });
 
+  it("searches plan names without exposing workspace filesystem paths", async () => {
+    const plansPath = workspacePlansPath(theaterPath);
+    await fs.promises.writeFile(path.join(plansPath, "needle-plan.md"), "# Needle Plan");
+    const { ctx, responses } = createContext({ theaterId: "theater", query: "needle", limit: 8 }, () => theaterPath);
+
+    await handlePlansSearch({ method: "POST" } as http.IncomingMessage, {} as http.ServerResponse, ctx);
+
+    expect(responses).toEqual([{
+      status: 200,
+      body: { plans: [expect.objectContaining({ name: "needle-plan.md", title: "Needle Plan" })] },
+    }]);
+    expect(JSON.stringify(responses)).not.toContain(plansPath);
+    expect(JSON.stringify(responses)).not.toContain(await fs.promises.realpath(theaterPath));
+  });
+
   it("keeps Plans Theater-wide and excludes nested workspace Plans", async () => {
     const nestedPath = path.join(theaterPath, "worktrees", "feature");
     await fs.promises.mkdir(nestedPath, { recursive: true });
@@ -285,4 +300,8 @@ async function handlePlansList(req: http.IncomingMessage, res: http.ServerRespon
 
 async function handlePlansRead(req: http.IncomingMessage, res: http.ServerResponse, ctx: PlansTestContext): Promise<void> {
   await ctx.router({ req, res, pathname: "/api/v1/plans/read" });
+}
+
+async function handlePlansSearch(req: http.IncomingMessage, res: http.ServerResponse, ctx: PlansTestContext): Promise<void> {
+  await ctx.router({ req, res, pathname: "/api/v1/plans/search" });
 }

--- a/runtime/fleet-console/tests/rail-search.test.tsx
+++ b/runtime/fleet-console/tests/rail-search.test.tsx
@@ -1,0 +1,233 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RailPanelDescriptor, RailSearchProvider, RailSearchResult } from "@fleet-console/sdk/rail";
+
+import { OperationSearch } from "../core/client/src/components/operation-search.js";
+import { useConsoleState } from "../core/client/src/hooks/use-store.js";
+import {
+  RAIL_SEARCH_DEBOUNCE_MS,
+  RAIL_SEARCH_PROVIDER_LIMIT,
+  RAIL_SEARCH_PROVIDER_TIMEOUT_MS,
+  searchRailPanels,
+} from "../core/client/src/operation-search.js";
+import { closeRailPanel, getRailStoreSnapshot, setRailChromeExpanded } from "../core/client/src/rail/rail-store.js";
+import { getState, setState } from "../core/client/src/store.js";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+let panels: readonly RailPanelDescriptor[] = [];
+let pathname = "";
+let scrollIntoViewDescriptor: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  window.localStorage.clear();
+  document.body.replaceChildren();
+  scrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollIntoView");
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", { configurable: true, value: vi.fn() });
+  closeRailPanel();
+  setRailChromeExpanded(false);
+  setState({
+    ...getState(),
+    activeTheaterId: "theater-a",
+    theaters: [{
+      id: "theater-a",
+      label: "Theater A",
+      createdAt: "2026-07-25T00:00:00.000Z",
+      lastOpenedAt: "2026-07-25T00:00:00.000Z",
+      hasWiki: false,
+      activeAdmiralCount: 0,
+    }],
+    operations: [],
+    operationSearchOpen: true,
+  });
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  if (scrollIntoViewDescriptor) Object.defineProperty(HTMLElement.prototype, "scrollIntoView", scrollIntoViewDescriptor);
+  else Reflect.deleteProperty(HTMLElement.prototype, "scrollIntoView");
+  document.body.replaceChildren();
+  panels = [];
+  pathname = "";
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("rail search fan-out", () => {
+  it("enforces the provider timeout and per-provider result cap while isolating failures", async () => {
+    const slow = vi.fn<RailSearchProvider>(() => new Promise(() => undefined));
+    const failed = vi.fn<RailSearchProvider>(async () => { throw new Error("failed"); });
+    const fast = vi.fn<RailSearchProvider>(async ({ limit }) => {
+      expect(limit).toBe(RAIL_SEARCH_PROVIDER_LIMIT);
+      return Array.from({ length: 12 }, (_, index) => result(`fast-${index}`));
+    });
+    const abort = new AbortController();
+    const pending = searchRailPanels([
+      panel("slow", "Slow", slow),
+      panel("failed", "Failed", failed),
+      panel("fast", "Fast", fast),
+    ], "needle", "theater-a", abort.signal);
+
+    await vi.advanceTimersByTimeAsync(RAIL_SEARCH_PROVIDER_TIMEOUT_MS);
+    const groups = await pending;
+
+    expect(groups.map((group) => group.panelId)).toEqual(["fast"]);
+    expect(groups[0]?.results).toHaveLength(RAIL_SEARCH_PROVIDER_LIMIT);
+    expect(slow.mock.calls[0]?.[0].signal.aborted).toBe(true);
+  });
+
+  it("does not fan out for an empty query, missing Theater, or command mode", async () => {
+    const provider = vi.fn<RailSearchProvider>(async () => []);
+    panels = [panel("files", "Files", provider)];
+    renderPalette();
+
+    await advanceDebounce();
+    expect(provider).not.toHaveBeenCalled();
+
+    setInput(">open panel");
+    await advanceDebounce();
+    expect(provider).not.toHaveBeenCalled();
+
+    act(() => setState({ activeTheaterId: null }));
+    setInput("needle");
+    await advanceDebounce();
+    expect(provider).not.toHaveBeenCalled();
+  });
+
+  it("debounces providers and discards a response that arrives after abort via the generation fence", async () => {
+    const requests = new Map<string, { readonly signal: AbortSignal; readonly resolve: (results: readonly RailSearchResult[]) => void }>();
+    const provider = vi.fn<RailSearchProvider>(({ query, signal }) => new Promise((resolve) => {
+      requests.set(query, { signal, resolve });
+    }));
+    panels = [panel("repository", "Repository", provider)];
+    renderPalette();
+
+    setInput("old");
+    await act(async () => { await vi.advanceTimersByTimeAsync(RAIL_SEARCH_DEBOUNCE_MS - 1); });
+    expect(provider).not.toHaveBeenCalled();
+    await act(async () => { await vi.advanceTimersByTimeAsync(1); });
+    expect(provider).toHaveBeenCalledTimes(1);
+
+    setInput("new");
+    await advanceDebounce();
+    expect(requests.get("old")?.signal.aborted).toBe(true);
+    expect(provider).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      requests.get("new")?.resolve([result("new-result", "New result")]);
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("New result");
+
+    await act(async () => {
+      requests.get("old")?.resolve([result("old-result", "Old result")]);
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("New result");
+    expect(container.textContent).not.toContain("Old result");
+  });
+
+  it("runs activate before routing to Operations and opening the owning panel", async () => {
+    let finishActivation: (() => void) | undefined;
+    const activate = vi.fn(() => new Promise<void>((resolve) => { finishActivation = resolve; }));
+    panels = [panel("plans", "Plans", async () => [result("plan-a", "Plan A", activate)])];
+    renderPalette("/settings");
+
+    setInput("plan");
+    await advanceDebounce();
+    const option = container.querySelector<HTMLButtonElement>(".operation-search-panel-result");
+    expect(option?.textContent).toContain("Plan A");
+
+    act(() => option!.click());
+    expect(activate).toHaveBeenCalledOnce();
+    expect(pathname).toBe("/settings");
+    expect(getRailStoreSnapshot()).toMatchObject({ activeRailPanelId: null, railChromeExpanded: false });
+
+    await act(async () => {
+      finishActivation?.();
+      await Promise.resolve();
+    });
+    expect(pathname).toBe("/operations");
+    expect(getRailStoreSnapshot()).toMatchObject({ activeRailPanelId: "plans", railChromeExpanded: true });
+  });
+
+  it("keeps matching Operations above panel groups", async () => {
+    panels = [panel("files", "Files", async () => [result("file", "Needle file")])];
+    act(() => setState({
+      operations: [{
+        id: "operation-a",
+        theaterId: "theater-a",
+        type: "shell",
+        pluginId: "terminal",
+        title: "Needle Operation",
+        payload: {},
+        geometry: null,
+        ts: { createdAt: 1, updatedAt: 1 },
+      }],
+    }));
+    renderPalette();
+    setInput("needle");
+    await advanceDebounce();
+
+    const headings = [...container.querySelectorAll(".operation-search-section-heading")].map((node) => node.textContent);
+    expect(headings).toEqual(["Theater A", "Files"]);
+    expect(container.textContent).toContain("Needle Operation");
+    expect(container.textContent).toContain("Needle file");
+  });
+});
+
+function renderPalette(initialPath = "/operations"): void {
+  act(() => {
+    root.render(createElement(
+      MemoryRouter,
+      { initialEntries: [initialPath] },
+      createElement(PaletteHarness),
+      createElement(LocationProbe),
+    ));
+  });
+  act(() => { vi.advanceTimersByTime(0); });
+}
+
+function PaletteHarness() {
+  return createElement(OperationSearch, { state: useConsoleState(), railPanels: panels, plugins: [] });
+}
+
+function LocationProbe() {
+  pathname = useLocation().pathname;
+  return null;
+}
+
+function setInput(value: string): void {
+  const input = container.querySelector<HTMLInputElement>("#operation-search-input");
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+  act(() => {
+    setter?.call(input, value);
+    input?.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function advanceDebounce(): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(RAIL_SEARCH_DEBOUNCE_MS);
+    await Promise.resolve();
+  });
+}
+
+function panel(id: string, title: string, search: RailSearchProvider): RailPanelDescriptor {
+  return { id, title, icon: null, render: () => null, search };
+}
+
+function result(id: string, title = id, activate: RailSearchResult["activate"] = () => undefined): RailSearchResult {
+  return { id, title, activate };
+}

--- a/runtime/fleet-plugins/file-explorer/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/rail-panel.tsx
@@ -2,7 +2,7 @@ import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import type { RailPanelContext, RailPanelDescriptor } from "@fleet-console/sdk/rail";
 
-import type { FileReadResult, FolderEntry, FolderListResult } from "../server/types.js";
+import type { FileReadResult, FileSearchResult, FolderEntry, FolderListResult } from "../server/types.js";
 import "./explorer.css";
 import { FileTree, type PluginFilesClient } from "./tree.js";
 import { BinaryViewer } from "./viewer/binary.js";
@@ -16,6 +16,7 @@ import {
   resolveExtraWidth,
 } from "./layout.js";
 import { setSelectedPath, setTreePaneWidth, setViewState, useFileExplorerViewState } from "./view-store.js";
+import { activateFileSearchTarget, consumeFileSearchTarget, useFileSearchTarget, type FileSearchTarget } from "./search-navigation.js";
 
 const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".webp", ".gif"]);
 
@@ -25,6 +26,22 @@ export const fileExplorerPanel: RailPanelDescriptor = {
   defaultWidth: 360,
   icon: FileExplorerIcon,
   render: (ctx) => <FileExplorerPanel {...ctx} />,
+  search: async ({ query, theaterId, limit, signal }) => {
+    const response = await fetch("/plugins/file-explorer/files/palette-search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ theaterId, query, limit }),
+      signal,
+    });
+    if (!response.ok) throw new Error("file_search_failed");
+    const result = await response.json() as FileSearchResult;
+    return result.files.map((file) => ({
+      id: file.relativePath,
+      title: file.relativePath.split("/").at(-1) ?? file.relativePath,
+      subtitle: file.relativePath,
+      activate: () => activateFileSearchTarget(theaterId, file.relativePath),
+    }));
+  },
 };
 
 function makeFilesClient(theaterId: string | null): PluginFilesClient {
@@ -53,6 +70,8 @@ function FileExplorerPanel(ctx: RailPanelContext) {
   treePaneWidthRef.current = treePaneWidth;
   const rootRef = useRef<HTMLDivElement>(null);
   const [isDragging, setIsDragging] = useState(false);
+  const [revealTarget, setRevealTarget] = useState<FileSearchTarget | null>(null);
+  const searchTarget = useFileSearchTarget();
 
   // theaterId 변경마다 새 클라이언트 인스턴스를 생성한다(PluginFilesClient는 stateless).
   const files = useMemo(() => makeFilesClient(theaterId), [theaterId]);
@@ -101,6 +120,12 @@ function FileExplorerPanel(ctx: RailPanelContext) {
       }
     }
   }, [contextScope, theaterId]);
+  useLayoutEffect(() => {
+    if (!searchTarget || searchTarget.theaterId !== theaterId) return;
+    setRevealTarget(searchTarget);
+    void openFilePath(searchTarget.relativePath);
+    consumeFileSearchTarget(searchTarget);
+  }, [openFilePath, searchTarget, theaterId]);
   const handleSelect = useCallback(async (entry: FolderEntry) => {
     if (entry.kind !== "file") return;
     await openFilePath(entry.relativePath, entry.name);
@@ -202,6 +227,7 @@ function FileExplorerPanel(ctx: RailPanelContext) {
           theaterId={theaterId}
           contextKey={contextScope}
           selectedPath={selectedPath}
+          revealTarget={revealTarget}
           onSelect={handleSelect}
         />
       </div>

--- a/runtime/fleet-plugins/file-explorer/client/search-navigation.ts
+++ b/runtime/fleet-plugins/file-explorer/client/search-navigation.ts
@@ -1,0 +1,41 @@
+import { useSyncExternalStore } from "react";
+
+export interface FileSearchTarget {
+  readonly theaterId: string;
+  readonly relativePath: string;
+  readonly requestId: number;
+}
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+let requestId = 0;
+let target: FileSearchTarget | null = null;
+
+export function activateFileSearchTarget(theaterId: string, relativePath: string): void {
+  target = { theaterId, relativePath, requestId: ++requestId };
+  emit();
+}
+
+export function consumeFileSearchTarget(expected: FileSearchTarget): void {
+  if (target?.requestId !== expected.requestId) return;
+  target = null;
+  emit();
+}
+
+export function useFileSearchTarget(): FileSearchTarget | null {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+}
+
+function getSnapshot(): FileSearchTarget | null {
+  return target;
+}
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}

--- a/runtime/fleet-plugins/file-explorer/client/tree.tsx
+++ b/runtime/fleet-plugins/file-explorer/client/tree.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 
 import type { FolderEntry, FolderListResult } from "../server/types.js";
+import type { FileSearchTarget } from "./search-navigation.js";
 
 import { FileIcon, FolderIcon } from "./file-icon.js";
 export interface PluginFilesClient {
@@ -12,6 +13,7 @@ interface FileTreeProps {
   readonly files: PluginFilesClient;
   readonly theaterId: string | null;
   readonly selectedPath: string | null;
+  readonly revealTarget?: FileSearchTarget | null;
   readonly onSelect: (entry: FolderEntry) => void;
 }
 
@@ -171,7 +173,7 @@ export function resolveTreeNavigation(rows: readonly FlatRow[], index: number, k
   return { kind: "none" };
 }
 
-export function FileTree({ contextKey, files, theaterId, selectedPath, onSelect }: FileTreeProps) {
+export function FileTree({ contextKey, files, theaterId, selectedPath, revealTarget, onSelect }: FileTreeProps) {
   const [result, setResult] = useState<FolderListResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [currentPath, setCurrentPath] = useState<string>("");
@@ -187,6 +189,7 @@ export function FileTree({ contextKey, files, theaterId, selectedPath, onSelect 
   const treeRef = useRef<HTMLDivElement>(null);
   const rowRefs = useRef(new Map<string, HTMLButtonElement>());
   const pendingFocusPathRef = useRef<string | null>(null);
+  const revealedRequestRef = useRef(0);
 
   // SSE 핸들러가 최신 상태를 참조하도록 ref로 유지
   const expandedDirsRef = useRef<Set<string>>(expandedDirs);
@@ -227,6 +230,43 @@ export function FileTree({ contextKey, files, theaterId, selectedPath, onSelect 
       setError(e instanceof Error ? e.message : "Unable to load folder");
     });
   }, [contextKey, theaterId, currentPath, files]);
+
+  useEffect(() => {
+    if (!revealTarget || revealTarget.theaterId !== theaterId || revealTarget.requestId <= revealedRequestRef.current) return;
+    let active = true;
+    const requestContextKey = contextKey;
+    const loadRevealPath = async () => {
+      const rootResult = await files.listFolder();
+      const nextResults = new Map<string, FolderListResult>();
+      const nextExpanded = new Set<string>();
+      const parts = revealTarget.relativePath.split("/").filter(Boolean);
+      let parentPath = "";
+      for (const part of parts.slice(0, -1)) {
+        parentPath = parentPath ? `${parentPath}/${part}` : part;
+        const folderResult = await files.listFolder(parentPath);
+        nextResults.set(parentPath, folderResult);
+        nextExpanded.add(parentPath);
+      }
+      if (!active || !isCurrentContextRequest(requestContextKey, contextKeyRef.current)) return;
+      setFilterText("");
+      setFilterCollapsedDirs(new Set());
+      if (parts.some((part) => part.startsWith("."))) {
+        setShowHidden(true);
+        saveShowHidden(true);
+      }
+      setCurrentPath("");
+      setResult(rootResult);
+      setChildResults((current) => {
+        const next = new Map(current);
+        for (const [relativePath, folderResult] of nextResults) next.set(relativePath, folderResult);
+        return next;
+      });
+      setExpandedDirs((current) => new Set([...current, ...nextExpanded]));
+      setCursorPath(revealTarget.relativePath);
+    };
+    void loadRevealPath().catch(() => undefined);
+    return () => { active = false; };
+  }, [contextKey, files, revealTarget, theaterId]);
 
   useEffect(() => {
     const requestId = ++filterRequestRef.current;
@@ -422,6 +462,23 @@ export function FileTree({ contextKey, files, theaterId, selectedPath, onSelect 
     pendingFocusPathRef.current = null;
     rowRefs.current.get(path)?.focus();
   }, [renderedCursorPath, visibleRows]);
+
+  useLayoutEffect(() => {
+    if (!revealTarget || revealTarget.requestId <= revealedRequestRef.current) return;
+    const rowIndex = flatRows.findIndex((row) => row.entry.relativePath === revealTarget.relativePath);
+    if (rowIndex < 0) return;
+    setCursorPath(revealTarget.relativePath);
+    if (shouldVirtualize && (rowIndex < startIdx || rowIndex >= endIdx)) {
+      const nextScrollTop = Math.max(0, rowIndex * ROW_HEIGHT);
+      if (treeRef.current) treeRef.current.scrollTop = nextScrollTop;
+      setScrollTop(nextScrollTop);
+      return;
+    }
+    const row = rowRefs.current.get(revealTarget.relativePath);
+    if (!row) return;
+    row.scrollIntoView({ block: "nearest" });
+    revealedRequestRef.current = revealTarget.requestId;
+  }, [endIdx, flatRows, revealTarget, shouldVirtualize, startIdx, visibleRows]);
 
   const focusRow = (rowIndex: number) => {
     const row = flatRows[rowIndex];
@@ -699,5 +756,13 @@ function readShowHidden(): boolean {
     return localStorage.getItem(PREFS_SHOW_HIDDEN) === "1";
   } catch {
     return false;
+  }
+}
+
+function saveShowHidden(showHidden: boolean): void {
+  try {
+    localStorage.setItem(PREFS_SHOW_HIDDEN, showHidden ? "1" : "0");
+  } catch {
+    // localStorage 접근 실패 무시
   }
 }

--- a/runtime/fleet-plugins/file-explorer/routes.ts
+++ b/runtime/fleet-plugins/file-explorer/routes.ts
@@ -1,6 +1,7 @@
 import { definePlugin, registerRouter } from "@fleet-console/sdk/plugin/node";
 
 import { handleFilesImage, handleFilesList, handleFilesRead, handleFilesWatch } from "./server/handlers.js";
+import { handleFilesSearch } from "./server/search.js";
 
 export default definePlugin({
   id: "file-explorer",
@@ -19,6 +20,10 @@ export default definePlugin({
     });
     registerRouter(ctx, "files/watch", ({ req, res }) => {
       handleFilesWatch(req, res, ctx);
+      return true;
+    });
+    registerRouter(ctx, "files/palette-search", async ({ req, res }) => {
+      await handleFilesSearch(req, res, ctx);
       return true;
     });
   },

--- a/runtime/fleet-plugins/file-explorer/server/search.ts
+++ b/runtime/fleet-plugins/file-explorer/server/search.ts
@@ -1,0 +1,118 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type http from "node:http";
+
+import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
+
+import type { FileSearchItem } from "./types.js";
+
+const SEARCH_DIRECTORY_CAP = 500;
+const SEARCH_ENTRY_CAP = 25_000;
+
+export async function searchTheaterFiles(theaterPath: string, query: string, limit: number): Promise<FileSearchItem[]> {
+  const realRoot = await fs.realpath(theaterPath);
+  const tokens = query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+  const pending: Array<{ readonly absolutePath: string; readonly relativePath: string }> = [{ absolutePath: realRoot, relativePath: "" }];
+  const visited = new Set<string>();
+  const matches: FileSearchItem[] = [];
+  let directoryCount = 0;
+  let entryCount = 0;
+
+  while (pending.length > 0 && directoryCount < SEARCH_DIRECTORY_CAP && entryCount < SEARCH_ENTRY_CAP) {
+    const directory = pending.shift();
+    if (!directory || visited.has(directory.absolutePath)) continue;
+    visited.add(directory.absolutePath);
+    directoryCount += 1;
+
+    let entries;
+    try {
+      entries = await fs.readdir(directory.absolutePath, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+
+    for (const entry of entries) {
+      if (entryCount >= SEARCH_ENTRY_CAP) break;
+      entryCount += 1;
+      const relativePath = directory.relativePath ? `${directory.relativePath}/${entry.name}` : entry.name;
+      const absolutePath = path.join(directory.absolutePath, entry.name);
+      let kind: "dir" | "file" | null = entry.isDirectory() ? "dir" : entry.isFile() ? "file" : null;
+      let realPath = absolutePath;
+      if (entry.isSymbolicLink()) {
+        try {
+          realPath = await fs.realpath(absolutePath);
+          if (!isContained(realRoot, realPath)) continue;
+          const stat = await fs.stat(realPath);
+          kind = stat.isDirectory() ? "dir" : stat.isFile() ? "file" : null;
+        } catch {
+          continue;
+        }
+      }
+      if (kind === "dir") {
+        if (!visited.has(realPath)) pending.push({ absolutePath: realPath, relativePath });
+        continue;
+      }
+      if (kind !== "file") continue;
+      const low = relativePath.toLocaleLowerCase();
+      if (tokens.every((token) => low.includes(token))) matches.push({ relativePath });
+    }
+  }
+
+  return matches
+    .sort((left, right) => compareFileSearchItem(left, right, query))
+    .slice(0, limit);
+}
+
+export async function handleFilesSearch(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  ctx: FleetPluginServerContext,
+): Promise<void> {
+  if (req.method !== "POST") { ctx.host.http.writeJson(res, 405, { error: "Method not allowed" }); return; }
+  if (!ctx.host.security.isTerminalAuthorized(req)) { ctx.host.http.writeJson(res, 401, { error: "unauthorized" }); return; }
+  const body = await ctx.host.http.readJsonBody<{
+    readonly theaterId?: unknown;
+    readonly query?: unknown;
+    readonly limit?: unknown;
+  }>(req);
+  if (
+    !isPlainObject(body)
+    || typeof body.theaterId !== "string"
+    || typeof body.query !== "string"
+    || body.query.trim() === ""
+    || !Number.isInteger(body.limit)
+    || (body.limit as number) < 1
+    || (body.limit as number) > 8
+  ) {
+    ctx.host.http.writeJson(res, 400, { error: "invalid_request" });
+    return;
+  }
+  const theaterPath = ctx.host.paths.resolveTheaterPath(body.theaterId);
+  if (!theaterPath) { ctx.host.http.writeJson(res, 404, { error: "theater_not_found" }); return; }
+  try {
+    ctx.host.http.writeJson(res, 200, {
+      files: await searchTheaterFiles(theaterPath, body.query, body.limit as number),
+    });
+  } catch {
+    ctx.host.http.writeJson(res, 500, { error: "search_failed" });
+  }
+}
+
+function compareFileSearchItem(left: FileSearchItem, right: FileSearchItem, query: string): number {
+  const lowQuery = query.trim().toLocaleLowerCase();
+  const leftName = left.relativePath.split("/").at(-1)?.toLocaleLowerCase() ?? "";
+  const rightName = right.relativePath.split("/").at(-1)?.toLocaleLowerCase() ?? "";
+  const leftRank = leftName === lowQuery ? 0 : leftName.startsWith(lowQuery) ? 1 : 2;
+  const rightRank = rightName === lowQuery ? 0 : rightName.startsWith(lowQuery) ? 1 : 2;
+  return leftRank - rightRank || left.relativePath.localeCompare(right.relativePath);
+}
+
+function isContained(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/runtime/fleet-plugins/file-explorer/server/types.ts
+++ b/runtime/fleet-plugins/file-explorer/server/types.ts
@@ -18,3 +18,11 @@ export interface FileReadResult {
   readonly truncated?: boolean;
   readonly binary?: boolean;
 }
+
+export interface FileSearchItem {
+  readonly relativePath: string;
+}
+
+export interface FileSearchResult {
+  readonly files: readonly FileSearchItem[];
+}

--- a/runtime/fleet-plugins/file-explorer/tests/search.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/search.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type http from "node:http";
+
+import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { handleFilesSearch, searchTheaterFiles } from "../server/search.js";
+
+let temporaryDirectory: string;
+let theaterPath: string;
+
+beforeEach(async () => {
+  temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "file-search-"));
+  theaterPath = path.join(temporaryDirectory, "theater");
+  const outsidePath = path.join(temporaryDirectory, "outside");
+  await fs.mkdir(path.join(theaterPath, "src", "nested"), { recursive: true });
+  await fs.mkdir(outsidePath);
+  await fs.writeFile(path.join(theaterPath, "src", "needle.ts"), "export {}");
+  await fs.writeFile(path.join(theaterPath, "src", "nested", "needle.test.ts"), "test()");
+  await fs.writeFile(path.join(outsidePath, "needle-secret.txt"), "secret");
+  await fs.symlink(outsidePath, path.join(theaterPath, "escape"));
+});
+
+afterEach(async () => {
+  await fs.rm(temporaryDirectory, { force: true, recursive: true });
+});
+
+describe("Files palette search", () => {
+  it("returns sorted Theater-relative file paths and excludes escaping symlinks", async () => {
+    const results = await searchTheaterFiles(theaterPath, "needle", 8);
+
+    expect(results).toEqual([
+      { relativePath: "src/needle.ts" },
+      { relativePath: "src/nested/needle.test.ts" },
+    ]);
+    const serialized = JSON.stringify(results);
+    expect(serialized).not.toContain(temporaryDirectory);
+    expect(serialized).not.toContain(await fs.realpath(theaterPath));
+    expect(serialized).not.toContain("needle-secret");
+  });
+
+  it("keeps the HTTP response free of absolute and real paths", async () => {
+    const writes: Array<{ readonly status: number; readonly body: unknown }> = [];
+    const ctx = {
+      host: {
+        http: {
+          readJsonBody: async () => ({ theaterId: "theater-a", query: "needle", limit: 8 }),
+          writeJson: (_res: http.ServerResponse, status: number, body: unknown) => writes.push({ status, body }),
+        },
+        security: { isTerminalAuthorized: () => true },
+        paths: { resolveTheaterPath: () => theaterPath },
+      },
+    } as unknown as FleetPluginServerContext;
+
+    await handleFilesSearch({ method: "POST" } as http.IncomingMessage, {} as http.ServerResponse, ctx);
+
+    expect(writes[0]?.status).toBe(200);
+    expect(JSON.stringify(writes[0]?.body)).not.toContain(temporaryDirectory);
+    expect(JSON.stringify(writes[0]?.body)).not.toContain(await fs.realpath(theaterPath));
+  });
+});

--- a/runtime/fleet-plugins/repository/client/history-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/history-panel.tsx
@@ -11,6 +11,7 @@ import { HunkView } from "./hunk-view.js";
 import { formatCommitTime, refBadges } from "./log-parse.js";
 import { DIFF_DIVIDER_WIDTH, HISTORY_DETAIL_PANE_MIN_HEIGHT, HISTORY_LOG_PANE_MIN_HEIGHT, buildHistoryStackTemplate, buildInspectorChangesGridTemplate, buildInspectorDetailsGridTemplate, clampSplitPaneSize, installPointerDragLifecycle } from "./rail-layout.js";
 import { buildWorkspaceDockTemplate, clampWorkspaceDockHeight, normalizeWorkspaceDockHeight, readWorkspaceDockHeight, saveWorkspaceDockHeight } from "./workspace-layout.js";
+import { consumeRepositorySearchTarget, useRepositorySearchTarget } from "./search-navigation.js";
 
 type LoadState = { readonly kind: "loading" } | { readonly kind: "ok"; readonly commits: readonly LogCommitEntry[]; readonly checkouts: readonly WorktreeCheckout[]; readonly truncated: boolean } | { readonly kind: "error"; readonly message: string };
 type CommitTarget = { readonly fullHash: string; readonly entry?: LogCommitEntry };
@@ -37,10 +38,10 @@ export function shouldShowWip(wip: { readonly files: number }, filterText: strin
 
 function CheckoutIcon({ current }: { readonly current: boolean }) { return current ? <svg className="history-badge-icon" viewBox="0 0 12 12" fill="none"><path d="M2.5 6.2L5 8.7L9.5 3.5" stroke="currentColor" strokeWidth="1.5" /></svg> : <svg className="history-badge-icon" viewBox="0 0 12 12" fill="none"><path d="M1.5 3.4h3l1 1.1h5v5.1a.9.9 0 01-.9.9H2.4a.9.9 0 01-.9-.9V4.3a.9.9 0 01.9-.9z" stroke="currentColor" strokeWidth="1.2" /></svg>; }
 
-export function CommitRow({ entry, checkouts, selected, graphNode, onSelect }: { readonly entry: LogCommitEntry; readonly checkouts: readonly WorktreeCheckout[]; readonly selected: boolean; readonly graphNode: import("./graph-layout.js").GraphNode; readonly onSelect: (entry: LogCommitEntry) => void }) {
+export function CommitRow({ entry, checkouts, selected, graphNode, onSelect, rowRef }: { readonly entry: LogCommitEntry; readonly checkouts: readonly WorktreeCheckout[]; readonly selected: boolean; readonly graphNode: import("./graph-layout.js").GraphNode; readonly onSelect: (entry: LogCommitEntry) => void; readonly rowRef?: (node: HTMLButtonElement | null) => void }) {
   const badges = refBadges(entry); const detached = findDetachedCheckout(entry, checkouts);
   // Fork 문법: refs 뱃지는 제목 왼쪽(그래프 바로 뒤)에서 커밋의 정체를 먼저 알린다.
-  return <button type="button" className={`history-commit-row${selected ? " is-selected" : ""}${entry.onHead ? "" : " is-off-head"}`} onClick={() => onSelect(entry)}><span className="history-commit-badges">{badges.map((badge) => { const checkout = badge.kind === "branch" ? checkouts.find((item) => item.branch === badge.label) : null; return <span key={`${badge.kind}:${badge.label}`} className={`history-badge history-badge--${badge.kind}`}>{checkout && <CheckoutIcon current={checkout.isCurrent} />}{badge.label}</span>; })}{detached && <span className="history-badge history-badge--worktree"><CheckoutIcon current={detached.isCurrent} />detached</span>}</span><span className="history-commit-subject" title={entry.subject}>{entry.subject}</span><span className="history-commit-sha">{entry.shortHash}</span><span className="history-commit-time">{formatCommitTime(entry.authorAt)}</span><span className="history-graph-gutter" aria-hidden="true"><GraphGutter node={graphNode} /></span></button>;
+  return <button ref={rowRef} type="button" className={`history-commit-row${selected ? " is-selected" : ""}${entry.onHead ? "" : " is-off-head"}`} onClick={() => onSelect(entry)}><span className="history-commit-badges">{badges.map((badge) => { const checkout = badge.kind === "branch" ? checkouts.find((item) => item.branch === badge.label) : null; return <span key={`${badge.kind}:${badge.label}`} className={`history-badge history-badge--${badge.kind}`}>{checkout && <CheckoutIcon current={checkout.isCurrent} />}{badge.label}</span>; })}{detached && <span className="history-badge history-badge--worktree"><CheckoutIcon current={detached.isCurrent} />detached</span>}</span><span className="history-commit-subject" title={entry.subject}>{entry.subject}</span><span className="history-commit-sha">{entry.shortHash}</span><span className="history-commit-time">{formatCommitTime(entry.authorAt)}</span><span className="history-graph-gutter" aria-hidden="true"><GraphGutter node={graphNode} /></span></button>;
 }
 
 function CommitInspector({ ctx, repoRel, target, workspace, onSelectCommit, onClose }: { readonly ctx: RailPanelContext; readonly repoRel: string; readonly target: CommitTarget; readonly workspace: boolean; readonly onSelectCommit: (target: CommitTarget) => void; readonly onClose: () => void }) {
@@ -121,10 +122,29 @@ function HistoryPanelBody({ ctx, repoRel, active, refFilter, wipFiles, workspace
   const [dockHeight, setDockHeight] = useState(readWorkspaceDockHeight);
   const [isDragging, setIsDragging] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
+  const rowRefs = useRef(new Map<string, HTMLButtonElement>());
+  const searchTarget = useRepositorySearchTarget();
   const dragDisposeRef = useRef<(() => void) | null>(null);
   const logHeightRef = useRef(logHeight);
   const dockHeightRef = useRef(dockHeight);
   useEffect(() => { setTarget(null); }, [refFilter]);
+  useEffect(() => {
+    if (
+      !searchTarget
+      || searchTarget.theaterId !== ctx.theaterId
+      || searchTarget.repoRel !== repoRel
+      || state.kind !== "ok"
+    ) return;
+    const entry = state.commits.find((commit) => commit.fullHash === searchTarget.fullHash);
+    if (!entry) return;
+    setFilterText("");
+    setTarget({ fullHash: entry.fullHash, entry });
+    consumeRepositorySearchTarget(searchTarget);
+  }, [ctx.theaterId, repoRel, searchTarget, state]);
+  useLayoutEffect(() => {
+    if (!target) return;
+    rowRefs.current.get(target.fullHash)?.scrollIntoView({ block: "nearest" });
+  }, [target]);
   // 숨은 마운트는 상태 보존용일 뿐이므로, 첫 활성화 전에는 log 조회 비용을 지불하지 않는다
   const [everActive, setEverActive] = useState(active);
   useEffect(() => { if (active) setEverActive(true); }, [active]);
@@ -189,7 +209,7 @@ function HistoryPanelBody({ ctx, repoRel, active, refFilter, wipFiles, workspace
   return <div ref={rootRef} className={`history-root${workspace ? " repository-ws-history" : ""}${isDragging ? " is-dragging" : ""}`} style={stackTemplate ? { gridTemplateRows: stackTemplate } : undefined}>
     <div className="history-list-pane" hidden={workspace && workspaceMainVisible}>
       <div className="history-toolbar"><div className="history-filter"><input className="history-filter-input" placeholder="Filter…" value={filterText} onChange={(event) => setFilterText(event.target.value)} />{filterText && <button type="button" className="history-filter-clear" onClick={() => setFilterText("")}>✕</button>}</div>{refFilter && <button type="button" className="repository-ref-chip" onClick={onClearRef}>{refFilter} ✕</button>}{state.kind === "ok" && <span className="history-count">{filterText ? `${visible.length}/${state.commits.length}` : state.commits.length}</span>}</div>
-      <div className="history-list">{showWip && <button type="button" className="repository-wip-row" onClick={onWip}>Uncommitted changes <span>{wip.files} files · +{wip.additions} −{wip.deletions}</span></button>}{state.kind === "loading" && <div className="history-empty">Loading…</div>}{state.kind === "error" && <div className="history-error">{state.message}<button type="button" className="repository-refresh-btn" onClick={() => setRefreshToken((value) => value + 1)}>Retry</button></div>}{state.kind === "ok" && state.commits.length === 0 && <div className="history-empty">No history</div>}{state.kind === "ok" && state.commits.length > 0 && visible.length === 0 && <div className="history-empty">No matching items</div>}{state.kind === "ok" && layout && visible.map((entry, index) => <CommitRow key={entry.fullHash} entry={entry} checkouts={state.checkouts} selected={target?.fullHash === entry.fullHash} graphNode={layout.nodes[index]!} onSelect={(selected) => setTarget({ fullHash: selected.fullHash, entry: selected })} />)}{state.kind === "ok" && (state.truncated || state.commits.length >= 200) && <div className="history-truncated">History capped at 200 commits.</div>}</div>
+      <div className="history-list">{showWip && <button type="button" className="repository-wip-row" onClick={onWip}>Uncommitted changes <span>{wip.files} files · +{wip.additions} −{wip.deletions}</span></button>}{state.kind === "loading" && <div className="history-empty">Loading…</div>}{state.kind === "error" && <div className="history-error">{state.message}<button type="button" className="repository-refresh-btn" onClick={() => setRefreshToken((value) => value + 1)}>Retry</button></div>}{state.kind === "ok" && state.commits.length === 0 && <div className="history-empty">No history</div>}{state.kind === "ok" && state.commits.length > 0 && visible.length === 0 && <div className="history-empty">No matching items</div>}{state.kind === "ok" && layout && visible.map((entry, index) => <CommitRow key={entry.fullHash} rowRef={(node) => { if (node) rowRefs.current.set(entry.fullHash, node); else rowRefs.current.delete(entry.fullHash); }} entry={entry} checkouts={state.checkouts} selected={target?.fullHash === entry.fullHash} graphNode={layout.nodes[index]!} onSelect={(selected) => setTarget({ fullHash: selected.fullHash, entry: selected })} />)}{state.kind === "ok" && (state.truncated || state.commits.length >= 200) && <div className="history-truncated">History capped at 200 commits.</div>}</div>
     </div>
     {workspaceMain !== undefined && <div className="repository-ws-main" hidden={!workspaceMainVisible}>{workspaceMain}</div>}
     {target && <><div className="history-divider history-divider--horizontal" role="separator" aria-orientation="horizontal" aria-label={workspace ? "Resize commit detail dock" : "Resize commit log"} onPointerDown={handleDivider} /><div className="history-detail-pane"><CommitInspector ctx={ctx} repoRel={repoRel} target={target} workspace={workspace} onSelectCommit={setTarget} onClose={() => setTarget(null)} /></div></>}

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 
 import type { RailPanelContext, RailPanelDescriptor } from "@fleet-console/sdk/rail";
 
-import type { DiffFileEntry, DiffFileMode, DiffListResult, RepoCandidate, ReposResult, WorktreeCandidate, WorktreesResult } from "../server/types.js";
+import type { DiffFileEntry, DiffFileMode, DiffListResult, RepoCandidate, RepositorySearchResult, ReposResult, WorktreeCandidate, WorktreesResult } from "../server/types.js";
 import "./repository.css";
 import { ChangedFiles, type ChangedFilesState } from "./changed-files.js";
 import { CompareView } from "./compare-view.js";
@@ -13,6 +13,7 @@ import { HunkView } from "./hunk-view.js";
 import { HistoryPanel } from "./history-panel.js";
 import { DIFF_DIVIDER_WIDTH, HUNK_PANE_MIN_WIDTH, buildDiffGridTemplate, clampListPaneWidth } from "./rail-layout.js";
 import { buildWorkspaceTreeSections, clampWorkspaceTreeWidth, readWorkspaceTreeWidth, saveWorkspaceTreeWidth } from "./workspace-layout.js";
+import { activateRepositorySearchTarget, useRepositorySearchTarget } from "./search-navigation.js";
 
 type ViewMode = "list" | "tree";
 
@@ -166,6 +167,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   // 동일 컨텍스트 재착지는 repoRel key가 안 바뀌어 History 패널이 리마운트되지 않는다 —
   // epoch를 key에 섞어 전환 착지와 동일한 초기 상태(로컬 필터·선택·스크롤)로 재설정한다.
   const [historyLandingEpoch, setHistoryLandingEpoch] = useState(0);
+  const searchTarget = useRepositorySearchTarget();
   const selectedFile = useSelectedFile(ctx.theaterId ?? null, repoRel);
   const [listPaneWidth, setListPaneWidth] = useState(readListPaneWidth);
   const listPaneWidthRef = useRef(listPaneWidth);
@@ -211,6 +213,15 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
     setRepoRel(nextRepoRel);
     setSource(landing);
   }, [ctx.theaterId, setSource]);
+  useEffect(() => {
+    if (!searchTarget || searchTarget.theaterId !== ctx.theaterId) return;
+    setRefFilter(null);
+    if (repoRelRef.current !== searchTarget.repoRel) {
+      transitionRepository(searchTarget.repoRel, true, "history");
+      return;
+    }
+    setSource("history");
+  }, [ctx.theaterId, searchTarget, setSource, transitionRepository]);
   useEffect(() => {
     if (!ctx.theaterId) return;
     let cancelled = false;
@@ -522,4 +533,21 @@ export const repositoryPanel: RailPanelDescriptor = {
   defaultWidth: 420,
   icon: () => <RepositoryIcon />,
   render: (ctx: RailPanelContext) => <RepositoryPanel ctx={ctx} />,
+  search: async ({ query, theaterId, limit, signal }) => {
+    const repoRel = readStoredRepositoryRel(theaterId);
+    const response = await fetch("/plugins/repository/palette-search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ theaterId, repoRel, query, limit }),
+      signal,
+    });
+    if (!response.ok) throw new Error("repository_search_failed");
+    const result = await response.json() as RepositorySearchResult;
+    return result.commits.map((commit) => ({
+      id: `${result.repoRel}:${commit.fullHash}`,
+      title: commit.subject,
+      subtitle: commit.shortHash,
+      activate: () => activateRepositorySearchTarget(theaterId, result.repoRel, commit.fullHash),
+    }));
+  },
 };

--- a/runtime/fleet-plugins/repository/client/search-navigation.ts
+++ b/runtime/fleet-plugins/repository/client/search-navigation.ts
@@ -1,0 +1,42 @@
+import { useSyncExternalStore } from "react";
+
+export interface RepositorySearchTarget {
+  readonly theaterId: string;
+  readonly repoRel: string;
+  readonly fullHash: string;
+  readonly requestId: number;
+}
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+let requestId = 0;
+let target: RepositorySearchTarget | null = null;
+
+export function activateRepositorySearchTarget(theaterId: string, repoRel: string, fullHash: string): void {
+  target = { theaterId, repoRel, fullHash, requestId: ++requestId };
+  emit();
+}
+
+export function consumeRepositorySearchTarget(expected: RepositorySearchTarget): void {
+  if (target?.requestId !== expected.requestId) return;
+  target = null;
+  emit();
+}
+
+export function useRepositorySearchTarget(): RepositorySearchTarget | null {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+}
+
+function getSnapshot(): RepositorySearchTarget | null {
+  return target;
+}
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}

--- a/runtime/fleet-plugins/repository/routes.ts
+++ b/runtime/fleet-plugins/repository/routes.ts
@@ -9,6 +9,7 @@ import { handleRepositoryLog } from "./server/log.js";
 import { handleRepositoryRefs } from "./server/refs.js";
 import { handleRepositoryRepos } from "./server/repos.js";
 import { createRepositoryRowBadgeProvider } from "./server/row-badges.js";
+import { handleRepositorySearch } from "./server/search.js";
 import { handleRepositoryWorktrees } from "./server/worktrees.js";
 
 export default definePlugin({
@@ -37,6 +38,10 @@ export default definePlugin({
     });
     registerRouter(ctx, "log", async ({ req, res }) => {
       await handleRepositoryLog(req, res, ctx);
+      return true;
+    });
+    registerRouter(ctx, "palette-search", async ({ req, res }) => {
+      await handleRepositorySearch(req, res, ctx);
       return true;
     });
     registerRouter(ctx, "refs", async ({ req, res }) => { await handleRepositoryRefs(req, res, ctx); return true; });

--- a/runtime/fleet-plugins/repository/server/search.ts
+++ b/runtime/fleet-plugins/repository/server/search.ts
@@ -1,0 +1,108 @@
+import type http from "node:http";
+
+import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
+
+import { InvalidRepoError, resolveGitCwd } from "./diff.js";
+import { GitExecutorError, runGit } from "./git-executor.js";
+import type { RepositorySearchItem } from "./types.js";
+
+const SEARCH_COMMIT_CAP = 200;
+
+export function parseRepositorySearchOutput(stdout: string, query: string, limit: number): RepositorySearchItem[] {
+  const tokens = query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+  const results: RepositorySearchItem[] = [];
+  for (const line of stdout.split("\n")) {
+    const [fullHash = "", shortHash = "", ...subjectParts] = line.split("\0");
+    const subject = subjectParts.join("\0");
+    if (!/^[0-9a-f]{40}$/i.test(fullHash) || !/^[0-9a-f]{7,40}$/i.test(shortHash)) continue;
+    const text = `${subject}\n${shortHash}\n${fullHash}`.toLocaleLowerCase();
+    if (!tokens.every((token) => text.includes(token))) continue;
+    results.push({ fullHash, shortHash, subject });
+    if (results.length >= limit) break;
+  }
+  return results;
+}
+
+export async function handleRepositorySearch(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  ctx: FleetPluginServerContext,
+): Promise<void> {
+  if (req.method !== "POST") { ctx.host.http.writeJson(res, 405, { error: "Method not allowed" }); return; }
+  if (!ctx.host.security.isTerminalAuthorized(req)) { ctx.host.http.writeJson(res, 401, { error: "unauthorized" }); return; }
+
+  const body = await ctx.host.http.readJsonBody<{
+    readonly theaterId?: unknown;
+    readonly repoRel?: unknown;
+    readonly query?: unknown;
+    readonly limit?: unknown;
+  }>(req);
+  if (
+    !isPlainObject(body)
+    || typeof body.theaterId !== "string"
+    || typeof body.query !== "string"
+    || body.query.trim() === ""
+    || !Number.isInteger(body.limit)
+    || (body.limit as number) < 1
+    || (body.limit as number) > 8
+    || "subPath" in body
+    || "ref" in body
+  ) {
+    ctx.host.http.writeJson(res, 400, { error: "invalid_request" });
+    return;
+  }
+
+  const theaterPath = ctx.host.paths.resolveTheaterPath(body.theaterId);
+  if (!theaterPath) { ctx.host.http.writeJson(res, 404, { error: "theater_not_found" }); return; }
+
+  let gitCwd: string;
+  try {
+    gitCwd = (await resolveGitCwd(theaterPath, body.repoRel)).gitCwd;
+  } catch (error) {
+    if (error instanceof InvalidRepoError) {
+      ctx.host.http.writeJson(res, 400, { error: error.code });
+      return;
+    }
+    throw error;
+  }
+
+  try {
+    // 검색어는 Git 인자로 전달하지 않는다. revision 입력 표면을 만들지 않고 열거된 ref 로그만 필터한다.
+    const result = await runGit([
+      "log",
+      "--branches",
+      "--tags",
+      "--remotes",
+      "--date-order",
+      "-n",
+      String(SEARCH_COMMIT_CAP),
+      "--pretty=format:%H%x00%h%x00%s",
+    ], { cwd: gitCwd });
+    ctx.host.http.writeJson(res, 200, {
+      repoRel: typeof body.repoRel === "string" ? body.repoRel : "",
+      commits: parseRepositorySearchOutput(result.stdout, body.query, body.limit as number),
+    });
+  } catch (error) {
+    if (error instanceof GitExecutorError) {
+      if (error.code === "no_git_repo") {
+        ctx.host.http.writeJson(res, 200, { repoRel: typeof body.repoRel === "string" ? body.repoRel : "", commits: [] });
+        return;
+      }
+      if (error.code === "non_zero_exit" && error.stderr.includes("does not have any commits")) {
+        ctx.host.http.writeJson(res, 200, { repoRel: typeof body.repoRel === "string" ? body.repoRel : "", commits: [] });
+        return;
+      }
+      if (error.code === "git_unavailable") {
+        ctx.host.http.writeJson(res, 422, { error: error.code });
+        return;
+      }
+      ctx.host.http.writeJson(res, 500, { error: "git_failed" });
+      return;
+    }
+    throw error;
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/runtime/fleet-plugins/repository/server/types.ts
+++ b/runtime/fleet-plugins/repository/server/types.ts
@@ -67,6 +67,17 @@ export interface LogResult {
   readonly truncated?: boolean;
 }
 
+export interface RepositorySearchItem {
+  readonly fullHash: string;
+  readonly shortHash: string;
+  readonly subject: string;
+}
+
+export interface RepositorySearchResult {
+  readonly repoRel: string;
+  readonly commits: readonly RepositorySearchItem[];
+}
+
 export interface CommitParent {
   readonly full: string;
   readonly short: string;

--- a/runtime/fleet-plugins/repository/tests/search.test.ts
+++ b/runtime/fleet-plugins/repository/tests/search.test.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type http from "node:http";
+
+import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runGit } from "../server/git-executor.js";
+import { handleRepositorySearch, parseRepositorySearchOutput } from "../server/search.js";
+
+let temporaryDirectory: string;
+
+beforeEach(async () => {
+  temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "repository-search-"));
+  await runGit(["init"], { cwd: temporaryDirectory });
+  await runGit(["config", "user.email", "test@example.com"], { cwd: temporaryDirectory });
+  await runGit(["config", "user.name", "Test"], { cwd: temporaryDirectory });
+  await fs.writeFile(path.join(temporaryDirectory, "one.txt"), "one");
+  await runGit(["add", "."], { cwd: temporaryDirectory });
+  await runGit(["commit", "-m", "Needle commit"], { cwd: temporaryDirectory });
+});
+
+afterEach(async () => {
+  await fs.rm(temporaryDirectory, { force: true, recursive: true });
+});
+
+describe("Repository palette search", () => {
+  it("returns only logical repository ids and commit metadata", async () => {
+    const writes: Array<{ readonly status: number; readonly body: unknown }> = [];
+    const ctx = context({ theaterId: "theater-a", repoRel: "", query: "needle", limit: 8 }, writes);
+
+    await handleRepositorySearch({ method: "POST" } as http.IncomingMessage, {} as http.ServerResponse, ctx);
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]?.status).toBe(200);
+    expect(writes[0]?.body).toEqual({
+      repoRel: "",
+      commits: [expect.objectContaining({ subject: "Needle commit" })],
+    });
+    const serialized = JSON.stringify(writes[0]?.body);
+    expect(serialized).not.toContain(temporaryDirectory);
+    expect(serialized).not.toContain(await fs.realpath(temporaryDirectory));
+  });
+
+  it("rejects option-like revision input before Theater or Git resolution", async () => {
+    const resolveTheaterPath = vi.fn(() => temporaryDirectory);
+    const writes: Array<{ readonly status: number; readonly body: unknown }> = [];
+    const ctx = context({ theaterId: "theater-a", repoRel: "", query: "needle", limit: 8, ref: "--all" }, writes, resolveTheaterPath);
+
+    await handleRepositorySearch({ method: "POST" } as http.IncomingMessage, {} as http.ServerResponse, ctx);
+
+    expect(writes).toEqual([{ status: 400, body: { error: "invalid_request" } }]);
+    expect(resolveTheaterPath).not.toHaveBeenCalled();
+  });
+
+  it("matches subjects and SHA tokens while honoring the requested limit", () => {
+    const stdout = [
+      `${"a".repeat(40)}\0${"a".repeat(9)}\0Needle one`,
+      `${"b".repeat(40)}\0${"b".repeat(9)}\0Needle two`,
+    ].join("\n");
+    expect(parseRepositorySearchOutput(stdout, "needle", 1)).toEqual([{
+      fullHash: "a".repeat(40),
+      shortHash: "a".repeat(9),
+      subject: "Needle one",
+    }]);
+    expect(parseRepositorySearchOutput(stdout, "bbbb", 8)).toHaveLength(1);
+  });
+});
+
+function context(
+  body: Record<string, unknown>,
+  writes: Array<{ readonly status: number; readonly body: unknown }>,
+  resolveTheaterPath: (theaterId: string) => string | null = () => temporaryDirectory,
+): FleetPluginServerContext {
+  return {
+    host: {
+      http: {
+        readJsonBody: async () => body,
+        writeJson: (_res: http.ServerResponse, status: number, responseBody: unknown) => writes.push({ status, body: responseBody }),
+      },
+      security: { isTerminalAuthorized: () => true },
+      paths: { resolveTheaterPath },
+    },
+  } as unknown as FleetPluginServerContext;
+}

--- a/runtime/fleet-plugins/skills/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/skills/client/rail-panel.tsx
@@ -2,7 +2,7 @@ import { useCallback, useLayoutEffect, useState } from "react";
 
 import type { RailPanelContext, RailPanelDescriptor } from "@fleet-console/sdk/rail";
 
-import type { Scope, SkillListItem } from "../server/types.js";
+import type { InstalledSkillSearchResult, Scope, SkillListItem } from "../server/types.js";
 import { FindTab } from "./find-tab.js";
 import { InstalledTab } from "./installed-tab.js";
 import { ReadingOverlay } from "./reading-overlay.js";
@@ -11,10 +11,13 @@ import {
   hasInstalledStateForContext,
   resetProjectContextState,
   setActiveTab,
+  setFilterText,
   setInstallFormOpenId,
+  setScope,
   skillsContextKey,
   useSkillsStore,
 } from "./skills-store.js";
+import { activateSkillSearchTarget, consumeSkillSearchTarget, useSkillSearchTarget } from "./search-navigation.js";
 import { Toast } from "./toast.js";
 
 // ─── types ───────────────────────────────────────────────────────────────────
@@ -45,12 +48,33 @@ function SkillsPanelBody({ ctx }: SkillsPanelProps) {
   const [readMoreEntry, setReadMoreEntry] = useState<ReadMoreEntry | null>(null);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
   const [installedRefreshKey, setInstalledRefreshKey] = useState(0);
+  const searchTarget = useSkillSearchTarget();
 
   const installedCount = hasInstalledStateForContext(state, contextKey) ? state.installedList.length : 0;
 
   useLayoutEffect(() => {
     resetProjectContextState(contextKey);
   }, [contextKey]);
+
+  useLayoutEffect(() => {
+    if (!searchTarget || searchTarget.theaterId !== theaterId) return;
+    setActiveTab("installed");
+    setScope(searchTarget.scope);
+    setFilterText("");
+  }, [searchTarget, theaterId]);
+
+  useLayoutEffect(() => {
+    if (
+      !searchTarget
+      || searchTarget.theaterId !== theaterId
+      || !hasInstalledStateForContext(state, contextKey)
+      || state.installedLoading
+    ) return;
+    const skill = state.installedList.find((candidate) => candidate.name === searchTarget.name && candidate.scope === searchTarget.scope);
+    if (!skill) return;
+    setReadMoreEntry({ skill, isInstalled: true });
+    consumeSkillSearchTarget(searchTarget);
+  }, [contextKey, searchTarget, state, theaterId]);
 
   const handleReadMoreInstalled = useCallback((skill: SkillListItem) => {
     setReadMoreEntry({ skill, isInstalled: true });
@@ -147,4 +171,20 @@ export const skillsPanel: RailPanelDescriptor = {
   defaultWidth: 360,
   icon: SkillsIcon,
   render: (ctx: RailPanelContext) => <SkillsPanel ctx={ctx} />,
+  search: async ({ query, theaterId, limit, signal }) => {
+    const response = await fetch("/plugins/skills/palette-search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ theaterId, query, limit }),
+      signal,
+    });
+    if (!response.ok) throw new Error("skills_search_failed");
+    const result = await response.json() as InstalledSkillSearchResult;
+    return result.skills.map((skill) => ({
+      id: `${skill.scope}:${skill.name}`,
+      title: skill.name,
+      subtitle: skill.scope,
+      activate: () => activateSkillSearchTarget(theaterId, skill.name, skill.scope),
+    }));
+  },
 };

--- a/runtime/fleet-plugins/skills/client/search-navigation.ts
+++ b/runtime/fleet-plugins/skills/client/search-navigation.ts
@@ -1,0 +1,44 @@
+import { useSyncExternalStore } from "react";
+
+import type { Scope } from "../server/types.js";
+
+export interface SkillSearchTarget {
+  readonly theaterId: string;
+  readonly name: string;
+  readonly scope: Scope;
+  readonly requestId: number;
+}
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+let requestId = 0;
+let target: SkillSearchTarget | null = null;
+
+export function activateSkillSearchTarget(theaterId: string, name: string, scope: Scope): void {
+  target = { theaterId, name, scope, requestId: ++requestId };
+  emit();
+}
+
+export function consumeSkillSearchTarget(expected: SkillSearchTarget): void {
+  if (target?.requestId !== expected.requestId) return;
+  target = null;
+  emit();
+}
+
+export function useSkillSearchTarget(): SkillSearchTarget | null {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+}
+
+function getSnapshot(): SkillSearchTarget | null {
+  return target;
+}
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}

--- a/runtime/fleet-plugins/skills/routes.ts
+++ b/runtime/fleet-plugins/skills/routes.ts
@@ -8,6 +8,7 @@ import {
   handleInstalledFile,
   handleInstall,
   handleList,
+  handlePaletteSearch,
   handlePreview,
   handleRemove,
   handleSearch,
@@ -22,6 +23,10 @@ export default definePlugin({
 
     registerRouter(ctx, "list", async ({ req, res }) => {
       await handleList(req, res, ctx, executor);
+      return true;
+    });
+    registerRouter(ctx, "palette-search", async ({ req, res }) => {
+      await handlePaletteSearch(req, res, ctx, executor);
       return true;
     });
     registerRouter(ctx, "search", async ({ req, res }) => {

--- a/runtime/fleet-plugins/skills/server/handlers.ts
+++ b/runtime/fleet-plugins/skills/server/handlers.ts
@@ -9,7 +9,7 @@ import { type CliExecutor, defaultCwd, stripAnsi } from "./cli.js";
 import { appendChunk, createJob, finishJob, getJobResult } from "./jobs.js";
 import { ProjectPathError, resolveProjectCwd } from "./project-path.js";
 import { searchRegistry } from "./registry-search.js";
-import type { AgentId, Scope } from "./types.js";
+import type { AgentId, Scope, SkillListItem } from "./types.js";
 import { isPlainObject, validateAgent, validateScope, validateSkill, validateSource } from "./validation.js";
 
 // ─── types ───────────────────────────────────────────────────────────────────
@@ -164,6 +164,44 @@ function spawnJobAsync(
 
 // ─── handlers ────────────────────────────────────────────────────────────────
 
+async function listInstalledSkills(projectCwd: string | null, executor: CliExecutor): Promise<SkillListItem[]> {
+  if (projectCwd) {
+    const [projectRaw, globalRaw, projectSources, globalSources] = await Promise.all([
+      runListCommand(["list", "--json"], projectCwd, executor),
+      runListCommand(["list", "-g", "--json"], os.homedir(), executor),
+      readSkillSources(projectCwd),
+      readSkillSources(os.homedir()),
+    ]);
+    return [
+      ...projectRaw.map((entry) => ({
+        name: entry.name,
+        scope: "project" as Scope,
+        agents: entry.agents,
+        source: projectSources.get(entry.name),
+        displayPath: buildDisplayPath("project", entry.name),
+      })),
+      ...globalRaw.map((entry) => ({
+        name: entry.name,
+        scope: "global" as Scope,
+        agents: entry.agents,
+        source: globalSources.get(entry.name),
+        displayPath: buildDisplayPath("global", entry.name),
+      })),
+    ];
+  }
+  const [globalRaw, globalSources] = await Promise.all([
+    runListCommand(["list", "-g", "--json"], os.homedir(), executor),
+    readSkillSources(os.homedir()),
+  ]);
+  return globalRaw.map((entry) => ({
+    name: entry.name,
+    scope: "global" as Scope,
+    agents: entry.agents,
+    source: globalSources.get(entry.name),
+    displayPath: buildDisplayPath("global", entry.name),
+  }));
+}
+
 export async function handleList(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -192,47 +230,57 @@ export async function handleList(
   }
 
   try {
-    if (projectCwd) {
-      const [projectRaw, globalRaw, projectSources, globalSources] = await Promise.all([
-        runListCommand(["list", "--json"], projectCwd, executor),
-        runListCommand(["list", "-g", "--json"], os.homedir(), executor),
-        readSkillSources(projectCwd),
-        readSkillSources(os.homedir()),
-      ]);
+    ctx.host.http.writeJson(res, 200, { skills: await listInstalledSkills(projectCwd, executor) });
+  } catch {
+    ctx.host.http.writeJson(res, 200, { skills: [] });
+  }
+}
 
-      const projectSkills = projectRaw.map((entry) => ({
-        name: entry.name,
-        scope: "project" as Scope,
-        agents: entry.agents,
-        source: projectSources.get(entry.name),
-        displayPath: buildDisplayPath("project", entry.name),
-      }));
-
-      const globalSkills = globalRaw.map((entry) => ({
-        name: entry.name,
-        scope: "global" as Scope,
-        agents: entry.agents,
-        source: globalSources.get(entry.name),
-        displayPath: buildDisplayPath("global", entry.name),
-      }));
-
-      ctx.host.http.writeJson(res, 200, { skills: [...projectSkills, ...globalSkills] });
-    } else {
-      const [globalRaw, globalSources] = await Promise.all([
-        runListCommand(["list", "-g", "--json"], os.homedir(), executor),
-        readSkillSources(os.homedir()),
-      ]);
-
-      const skills = globalRaw.map((entry) => ({
-        name: entry.name,
-        scope: "global" as Scope,
-        agents: entry.agents,
-        source: globalSources.get(entry.name),
-        displayPath: buildDisplayPath("global", entry.name),
-      }));
-
-      ctx.host.http.writeJson(res, 200, { skills });
-    }
+export async function handlePaletteSearch(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  ctx: FleetPluginServerContext,
+  executor: CliExecutor,
+): Promise<void> {
+  if (req.method !== "POST") { ctx.host.http.writeJson(res, 405, { error: "Method not allowed" }); return; }
+  if (!ctx.host.security.isTerminalAuthorized(req)) { ctx.host.http.writeJson(res, 401, { error: "unauthorized" }); return; }
+  const body = await ctx.host.http.readJsonBody<{
+    readonly theaterId?: unknown;
+    readonly query?: unknown;
+    readonly limit?: unknown;
+  }>(req);
+  if (
+    !isPlainObject(body)
+    || typeof body.theaterId !== "string"
+    || typeof body.query !== "string"
+    || body.query.trim() === ""
+    || !Number.isInteger(body.limit)
+    || (body.limit as number) < 1
+    || (body.limit as number) > 8
+    || "relPath" in body
+  ) {
+    ctx.host.http.writeJson(res, 400, { error: "invalid_request" });
+    return;
+  }
+  let projectCwd: string | null;
+  try {
+    projectCwd = await resolveProjectScopeCwd(ctx, body.theaterId);
+  } catch (error) {
+    writeProjectPathError(res, ctx, error);
+    return;
+  }
+  if (!projectCwd) {
+    ctx.host.http.writeJson(res, 404, { error: "theater_not_found" });
+    return;
+  }
+  try {
+    const tokens = body.query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+    const skills = (await listInstalledSkills(projectCwd, executor))
+      .filter((skill) => tokens.every((token) => skill.name.toLocaleLowerCase().includes(token)))
+      .sort((left, right) => left.name.localeCompare(right.name) || left.scope.localeCompare(right.scope))
+      .slice(0, body.limit as number)
+      .map(({ name, scope }) => ({ name, scope }));
+    ctx.host.http.writeJson(res, 200, { skills });
   } catch {
     ctx.host.http.writeJson(res, 200, { skills: [] });
   }

--- a/runtime/fleet-plugins/skills/server/handlers.ts
+++ b/runtime/fleet-plugins/skills/server/handlers.ts
@@ -40,6 +40,7 @@ const PREVIEW_TIMEOUT_MS = 30_000;
 const CLI_TIMEOUT_MS = 120_000;
 const USERINFO_URL_RE = /\b[a-z][a-z0-9+.-]*:\/\/[^\s/@]+@[^\s]+/gi;
 const TOKEN_URL_PARAM_RE = /([?&](?:access_?token|token|api_?key|apikey|auth(?:orization)?|password|secret|credential)=)[^&#\s]*/gi;
+const installedSkillsByTheater = new Map<string, readonly SkillListItem[]>();
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
@@ -230,8 +231,11 @@ export async function handleList(
   }
 
   try {
-    ctx.host.http.writeJson(res, 200, { skills: await listInstalledSkills(projectCwd, executor) });
+    const skills = await listInstalledSkills(projectCwd, executor);
+    if (theaterId) installedSkillsByTheater.set(theaterId, skills);
+    ctx.host.http.writeJson(res, 200, { skills });
   } catch {
+    if (theaterId) installedSkillsByTheater.set(theaterId, []);
     ctx.host.http.writeJson(res, 200, { skills: [] });
   }
 }
@@ -273,17 +277,13 @@ export async function handlePaletteSearch(
     ctx.host.http.writeJson(res, 404, { error: "theater_not_found" });
     return;
   }
-  try {
-    const tokens = body.query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
-    const skills = (await listInstalledSkills(projectCwd, executor))
-      .filter((skill) => tokens.every((token) => skill.name.toLocaleLowerCase().includes(token)))
-      .sort((left, right) => left.name.localeCompare(right.name) || left.scope.localeCompare(right.scope))
-      .slice(0, body.limit as number)
-      .map(({ name, scope }) => ({ name, scope }));
-    ctx.host.http.writeJson(res, 200, { skills });
-  } catch {
-    ctx.host.http.writeJson(res, 200, { skills: [] });
-  }
+  const tokens = body.query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+  const skills = (installedSkillsByTheater.get(body.theaterId) ?? [])
+    .filter((skill) => tokens.every((token) => skill.name.toLocaleLowerCase().includes(token)))
+    .sort((left, right) => left.name.localeCompare(right.name) || left.scope.localeCompare(right.scope))
+    .slice(0, body.limit as number)
+    .map(({ name, scope }) => ({ name, scope }));
+  ctx.host.http.writeJson(res, 200, { skills });
 }
 
 export async function handleSearch(

--- a/runtime/fleet-plugins/skills/server/types.ts
+++ b/runtime/fleet-plugins/skills/server/types.ts
@@ -18,6 +18,15 @@ export interface SkillListResult {
   readonly skills: SkillListItem[];
 }
 
+export interface InstalledSkillSearchItem {
+  readonly name: string;
+  readonly scope: Scope;
+}
+
+export interface InstalledSkillSearchResult {
+  readonly skills: readonly InstalledSkillSearchItem[];
+}
+
 export interface SkillSearchItem {
   readonly id: string;
   readonly name: string;

--- a/runtime/fleet-plugins/skills/tests/routes.test.ts
+++ b/runtime/fleet-plugins/skills/tests/routes.test.ts
@@ -13,6 +13,7 @@ import {
   handleInstalledFile,
   handleInstall,
   handleList,
+  handlePaletteSearch,
   handlePreview,
   handleRemove,
   handleSearch,
@@ -173,6 +174,54 @@ describe("project scope cwd", () => {
 
       expect(res._status).toBe(200);
       expect(calls).toContain(await fs.realpath(theaterRoot));
+    } finally {
+      await fs.rm(temporaryDirectory, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("palette installed-skill search", () => {
+  it("returns only logical names and scopes without CLI filesystem paths", async () => {
+    const temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "fleet-skills-search-"));
+    const theaterRoot = path.join(temporaryDirectory, "theater");
+    await fs.mkdir(theaterRoot, { recursive: true });
+    try {
+      const ctx = {
+        host: {
+          security: { isTerminalAuthorized: () => true },
+          http: {
+            writeJson: (res: http.ServerResponse, status: number, body: unknown) => {
+              (res as unknown as { _status: number; _body: unknown })._status = status;
+              (res as unknown as { _status: number; _body: unknown })._body = body;
+            },
+            readJsonBody: async () => ({ theaterId: "theater-a", query: "needle", limit: 8 }),
+          },
+          paths: { resolveTheaterPath: () => theaterRoot },
+        },
+      } as unknown as FleetPluginServerContext;
+      const executor: CliExecutor = async (args, options) => ({
+        stdout: JSON.stringify([{
+          name: args.includes("-g") ? "needle-global" : "needle-project",
+          path: path.join(options.cwd, "absolute", "SKILL.md"),
+          scope: args.includes("-g") ? "global" : "project",
+          agents: ["codex"],
+        }]),
+        stderr: "",
+        exitCode: 0,
+      });
+      const res = makeRes();
+
+      await handlePaletteSearch(makeReq("POST", "/plugins/skills/palette-search"), res, ctx, executor);
+
+      expect(res._status).toBe(200);
+      expect(res._body).toEqual({
+        skills: [
+          { name: "needle-global", scope: "global" },
+          { name: "needle-project", scope: "project" },
+        ],
+      });
+      expect(JSON.stringify(res._body)).not.toContain(temporaryDirectory);
+      expect(JSON.stringify(res._body)).not.toContain(await fs.realpath(theaterRoot));
     } finally {
       await fs.rm(temporaryDirectory, { force: true, recursive: true });
     }

--- a/runtime/fleet-plugins/skills/tests/routes.test.ts
+++ b/runtime/fleet-plugins/skills/tests/routes.test.ts
@@ -181,7 +181,38 @@ describe("project scope cwd", () => {
 });
 
 describe("palette installed-skill search", () => {
-  it("returns only logical names and scopes without CLI filesystem paths", async () => {
+  it("returns an empty result without invoking the CLI when no list is cached", async () => {
+    const temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "fleet-skills-search-empty-"));
+    const theaterRoot = path.join(temporaryDirectory, "theater");
+    await fs.mkdir(theaterRoot, { recursive: true });
+    try {
+      const executor = vi.fn<CliExecutor>(async () => ({ stdout: "[]", stderr: "", exitCode: 0 }));
+      const ctx = {
+        host: {
+          security: { isTerminalAuthorized: () => true },
+          http: {
+            writeJson: (res: http.ServerResponse, status: number, body: unknown) => {
+              (res as unknown as { _status: number; _body: unknown })._status = status;
+              (res as unknown as { _status: number; _body: unknown })._body = body;
+            },
+            readJsonBody: async () => ({ theaterId: "uncached-theater", query: "needle", limit: 8 }),
+          },
+          paths: { resolveTheaterPath: () => theaterRoot },
+        },
+      } as unknown as FleetPluginServerContext;
+      const res = makeRes();
+
+      await handlePaletteSearch(makeReq("POST", "/plugins/skills/palette-search"), res, ctx, executor);
+
+      expect(res._status).toBe(200);
+      expect(res._body).toEqual({ skills: [] });
+      expect(executor).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(temporaryDirectory, { force: true, recursive: true });
+    }
+  });
+
+  it("returns only cached logical names and scopes without invoking the CLI", async () => {
     const temporaryDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "fleet-skills-search-"));
     const theaterRoot = path.join(temporaryDirectory, "theater");
     await fs.mkdir(theaterRoot, { recursive: true });
@@ -209,9 +240,14 @@ describe("palette installed-skill search", () => {
         stderr: "",
         exitCode: 0,
       });
-      const res = makeRes();
+      const executorSpy = vi.fn(executor);
+      const listRes = makeRes();
+      await handleList(makeReq("GET", "/plugins/skills/list?theaterId=theater-a"), listRes, ctx, executorSpy);
+      expect(listRes._status).toBe(200);
+      executorSpy.mockClear();
 
-      await handlePaletteSearch(makeReq("POST", "/plugins/skills/palette-search"), res, ctx, executor);
+      const res = makeRes();
+      await handlePaletteSearch(makeReq("POST", "/plugins/skills/palette-search"), res, ctx, executorSpy);
 
       expect(res._status).toBe(200);
       expect(res._body).toEqual({
@@ -220,6 +256,7 @@ describe("palette installed-skill search", () => {
           { name: "needle-project", scope: "project" },
         ],
       });
+      expect(executorSpy).not.toHaveBeenCalled();
       expect(JSON.stringify(res._body)).not.toContain(temporaryDirectory);
       expect(JSON.stringify(res._body)).not.toContain(await fs.realpath(theaterRoot));
     } finally {


### PR DESCRIPTION
## Summary

승인된 신규 기능 N3입니다.

- **실측된 결함.** ⌘K 검색 대상은 Operation 제목과 커맨드 목록뿐이었습니다. Repository 히스토리(로컬 브랜치 8·태그 122·전체 커밋), Files 트리, Plans, Skills의 **내용은 검색되지 않았습니다.** 게다가 플러그인 사이의 앱 내 이동 수단이 전 방향 0건이라(유일한 다리가 커밋 SHA 수동 클립보드 복사) 무엇을 찾든 사용자가 패널을 열고 직접 옮겨 다녀야 했습니다.
- **본질은 검색이 아니라 동선입니다.** 결과를 고르면 해당 패널이 그 위치에서 열리므로, 검색이 곧 패널 간 이동 경로가 됩니다.
- **계약.** 결과가 선언한 패널에 귀속되도록 기존 `RailPanelDescriptor`에 `search?` 한 필드만 얹었습니다. SDK 증분은 타입 3개 + 필드 1개이고 신규 서브패스나 별도 레지스트리는 만들지 않았습니다.
- **팬아웃.** 디바운스 150ms, provider별 타임아웃 500ms, provider별 상한 8. 낡은 응답은 `AbortSignal` **과 generation fence 둘 다**로 버립니다 — provider는 abort 이후에도 resolve할 수 있어서 신호만으로는 부족합니다.
- **동선.** `activate()`가 DOM 비의존 plugin-local store에 논리 타깃을 기록 → 호스트가 `/operations`로 이동하고 해당 패널을 열고 확장 → mount된 패널이 타깃을 소비해 해당 행·파일·커밋을 선택합니다. 라우팅 토큰이나 이벤트 채널을 새로 만들지 않았습니다.
- **v1 기여 패널** — repository(커밋) · file-explorer(경로) · plans · skills. 응답에는 Theater-relative 경로와 논리 ID만 담깁니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 0 errors
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `rail-search` · `operation-search` · `operation-search-focus` · `palette-commands` · `plans-security` · `api-catalog` — 40 passed
- [x] `pnpm --filter @fleet-plugins/{repository,file-explorer,skills} test` — 416 passed
- [ ] Changelog fragment — PR 번호 배정 후 추가 예정

### 선존 실패 (이 PR과 무관)

`tests/server.test.ts > … issues Theater-bound dedicated MCP sessions …` 1건. base에서 동일하게 재현됩니다.

실서버를 띄우는 테스트는 동시 vitest 실행과 겹치면 타임아웃으로 가짜 실패하므로, 위 결과는 모두 해당 파일 단독 실행 기준입니다.