### PR TITLE
feat(console): save and restore named workspace layouts per Theater

### DIFF
--- a/.changelog.d/pr-385.md
+++ b/.changelog.d/pr-385.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Added
+- [fleet-console] Save the current window arrangement, open rail panel and status axis as a named workspace layout on the Theater, and recall it later. Applying a layout skips Operations that no longer exist instead of failing, and undoing a forgotten Theater brings its layouts back.
+  ko: 현재 창 배치와 열린 레일 패널, 상태축을 Theater에 이름 붙인 작업 배치로 저장하고 나중에 다시 불러옵니다. 사라진 Operation은 건너뛰고 적용되며, 잊은 Theater를 되돌리면 저장한 배치도 함께 돌아옵니다.

--- a/runtime/fleet-console/core/client/src/api.ts
+++ b/runtime/fleet-console/core/client/src/api.ts
@@ -1,4 +1,4 @@
-import type { ConsoleEnvironmentDiagnostics, ConsoleUpdateApplyAcceptedResponse, OperationGroup, OperationNode, ObserverStatus, ReleaseNoteItem, ReleaseNoteProduct, ReleaseNoteSection, ReleaseNotes, ReleaseNotesLocale, ReleaseNotesResponse, TheaterBootstrap, TheaterInfo } from "./types.js";
+import type { ConsoleEnvironmentDiagnostics, ConsoleUpdateApplyAcceptedResponse, DurableWorkspacePreset, OperationGeometry, OperationGroup, OperationNode, ObserverStatus, ReleaseNoteItem, ReleaseNoteProduct, ReleaseNoteSection, ReleaseNotes, ReleaseNotesLocale, ReleaseNotesResponse, TheaterBootstrap, TheaterInfo, WorkspacePresetApplyResult, WorkspacePresetLayout } from "./types.js";
 
 export interface TheaterFolderListEntry {
   readonly name: string;
@@ -181,6 +181,85 @@ export async function patchTheaterOrder(theaterId: string, order: number, signal
   });
   await assertOk(response);
   return assertTheaterInfo(await response.json(), response.status);
+}
+
+export async function fetchWorkspacePresets(theaterId: string, signal?: AbortSignal): Promise<readonly DurableWorkspacePreset[]> {
+  const response = await fetch(`/api/v1/theaters/${encodeURIComponent(theaterId)}/workspace-presets`, { signal });
+  await assertOk(response);
+  const payload = await response.json() as { readonly workspacePresets?: unknown };
+  if (!Array.isArray(payload.workspacePresets) || hasForbiddenBrowserPayloadKeyDeep(payload)) {
+    throw new ApiError(response.status, "Invalid Workspace Preset response");
+  }
+  return payload.workspacePresets.map((preset) => assertWorkspacePreset(preset, response.status));
+}
+
+export async function createWorkspacePreset(
+  theaterId: string,
+  name: string,
+  layout: WorkspacePresetLayout,
+  signal?: AbortSignal,
+): Promise<DurableWorkspacePreset> {
+  const response = await fetch(`/api/v1/theaters/${encodeURIComponent(theaterId)}/workspace-presets`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, layout }),
+    signal,
+  });
+  await assertOk(response);
+  const payload = await response.json() as { readonly workspacePreset?: unknown };
+  if (hasForbiddenBrowserPayloadKeyDeep(payload)) throw new ApiError(response.status, "Invalid Workspace Preset response");
+  return assertWorkspacePreset(payload.workspacePreset, response.status);
+}
+
+export async function renameWorkspacePreset(
+  theaterId: string,
+  presetId: string,
+  name: string,
+  signal?: AbortSignal,
+): Promise<DurableWorkspacePreset> {
+  const response = await fetch(`/api/v1/theaters/${encodeURIComponent(theaterId)}/workspace-presets/${encodeURIComponent(presetId)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+    signal,
+  });
+  await assertOk(response);
+  const payload = await response.json() as { readonly workspacePreset?: unknown };
+  if (hasForbiddenBrowserPayloadKeyDeep(payload)) throw new ApiError(response.status, "Invalid Workspace Preset response");
+  return assertWorkspacePreset(payload.workspacePreset, response.status);
+}
+
+export async function deleteWorkspacePreset(theaterId: string, presetId: string, signal?: AbortSignal): Promise<void> {
+  const response = await fetch(`/api/v1/theaters/${encodeURIComponent(theaterId)}/workspace-presets/${encodeURIComponent(presetId)}`, {
+    method: "DELETE",
+    signal,
+  });
+  await assertOk(response);
+}
+
+export async function applyWorkspacePreset(
+  theaterId: string,
+  presetId: string,
+  signal?: AbortSignal,
+): Promise<WorkspacePresetApplyResult> {
+  const response = await fetch(`/api/v1/theaters/${encodeURIComponent(theaterId)}/workspace-presets/${encodeURIComponent(presetId)}/apply`, {
+    method: "POST",
+    signal,
+  });
+  await assertOk(response);
+  const payload = await response.json() as Partial<WorkspacePresetApplyResult>;
+  if (!Array.isArray(payload.appliedOperationIds)
+    || !payload.appliedOperationIds.every((id) => typeof id === "string")
+    || !Array.isArray(payload.missingOperationIds)
+    || !payload.missingOperationIds.every((id) => typeof id === "string")
+    || hasForbiddenBrowserPayloadKeyDeep(payload)) {
+    throw new ApiError(response.status, "Invalid Workspace Preset apply response");
+  }
+  return {
+    preset: assertWorkspacePreset(payload.preset, response.status),
+    appliedOperationIds: payload.appliedOperationIds,
+    missingOperationIds: payload.missingOperationIds,
+  };
 }
 
 export async function listTheaterFolders(path: string | null, signal?: AbortSignal): Promise<TheaterFolderListResponse> {
@@ -419,6 +498,86 @@ function assertOperationGroup(value: unknown, status: number): OperationGroup {
   };
 }
 
+function assertWorkspacePreset(value: unknown, status: number): DurableWorkspacePreset {
+  const payload = value as Partial<DurableWorkspacePreset>;
+  if (!payload
+    || typeof payload.id !== "string"
+    || typeof payload.theaterId !== "string"
+    || typeof payload.name !== "string"
+    || typeof payload.createdAt !== "number"
+    || !Number.isFinite(payload.createdAt)
+    || typeof payload.updatedAt !== "number"
+    || !Number.isFinite(payload.updatedAt)
+    || hasForbiddenBrowserPayloadKeyDeep(payload)) {
+    throw new ApiError(status, "Invalid Workspace Preset response");
+  }
+  return {
+    id: payload.id,
+    theaterId: payload.theaterId,
+    name: payload.name,
+    createdAt: payload.createdAt,
+    updatedAt: payload.updatedAt,
+    layout: assertWorkspacePresetLayout(payload.layout, status),
+  };
+}
+
+function assertWorkspacePresetLayout(value: unknown, status: number): WorkspacePresetLayout {
+  const payload = value as Partial<WorkspacePresetLayout>;
+  const viewport = payload?.viewport;
+  const rail = payload?.rail;
+  const sidebar = payload?.sidebar;
+  if (!payload
+    || !viewport
+    || !isFiniteNumber(viewport.x)
+    || !isFiniteNumber(viewport.y)
+    || !isFiniteNumber(viewport.zoom)
+    || !payload.operationGeometries
+    || typeof payload.operationGeometries !== "object"
+    || Array.isArray(payload.operationGeometries)
+    || !Array.isArray(payload.minimizedOperationIds)
+    || !payload.minimizedOperationIds.every((id) => typeof id === "string")
+    || !rail
+    || (rail.activePanelId !== null && typeof rail.activePanelId !== "string")
+    || typeof rail.chromeExpanded !== "boolean"
+    || (rail.panelWidth !== null && !isFiniteNumber(rail.panelWidth))
+    || !sidebar
+    || (sidebar.statusAxis !== "group" && sidebar.statusAxis !== "status")) {
+    throw new ApiError(status, "Invalid Workspace Preset response");
+  }
+  const operationGeometryEntries: Array<[string, OperationGeometry]> = [];
+  for (const [operationId, geometry] of Object.entries(payload.operationGeometries)) {
+    operationGeometryEntries.push([operationId, assertOperationGeometry(geometry, status)]);
+  }
+  return {
+    viewport: { x: viewport.x, y: viewport.y, zoom: viewport.zoom },
+    operationGeometries: Object.fromEntries(operationGeometryEntries),
+    minimizedOperationIds: payload.minimizedOperationIds,
+    rail: {
+      activePanelId: rail.activePanelId,
+      chromeExpanded: rail.chromeExpanded,
+      panelWidth: rail.panelWidth,
+    },
+    sidebar: { statusAxis: sidebar.statusAxis },
+  };
+}
+
+function assertOperationGeometry(value: unknown, status: number): OperationGeometry {
+  const geometry = value as Partial<OperationGeometry>;
+  if (!geometry
+    || !isFiniteNumber(geometry.x)
+    || !isFiniteNumber(geometry.y)
+    || !isFiniteNumber(geometry.width)
+    || !isFiniteNumber(geometry.height)
+    || !isFiniteNumber(geometry.zIndex)) {
+    throw new ApiError(status, "Invalid Workspace Preset geometry");
+  }
+  return { x: geometry.x, y: geometry.y, width: geometry.width, height: geometry.height, zIndex: geometry.zIndex };
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
 function assertTheaterInfo(value: unknown, status: number): TheaterInfo {
   const payload = value as Partial<TheaterInfo>;
   if (
@@ -616,6 +775,12 @@ function hasForbiddenBrowserPayloadKey(value: unknown): boolean {
   if (!value || typeof value !== "object") return false;
   const payload = value as Record<string, unknown>;
   return FORBIDDEN_BROWSER_PAYLOAD_KEYS.some((key) => key in payload);
+}
+
+function hasForbiddenBrowserPayloadKeyDeep(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  if (hasForbiddenBrowserPayloadKey(value)) return true;
+  return Object.values(value).some(hasForbiddenBrowserPayloadKeyDeep);
 }
 
 function assertDeferredDeletionResponse(value: unknown, status: number): DeferredDeletionResponse {

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -14,6 +14,7 @@ import { focusOperation, hydrateOperations, requestSideBarAddTheater, requestSid
 import type { ConsoleEnvironmentDiagnostics } from "../types.js";
 import { useInlineRename } from "../use-inline-rename.js";
 import { useFullscreenCommandBand } from "./use-fullscreen-command-band.js";
+import { WorkspacePresets } from "./workspace-presets.js";
 
 interface NavigatorWithUserAgentData extends Navigator {
   readonly userAgentData?: {
@@ -332,6 +333,8 @@ export function CommandBand({ operationsViewVisible }: CommandBandProps) {
         <button type="button" className="command-band-formation-toggle command-band-formation-seg" onClick={() => selectFormationLayout("grid")} disabled={state.activeTheaterId === null} aria-pressed={formationView && formationLayout === "grid"} aria-label="Formation view — Grid layout" title="Formation view — Grid layout"><FormationGridIcon /></button>
         <button type="button" className="command-band-formation-toggle command-band-formation-seg" onClick={() => selectFormationLayout("columns")} disabled={state.activeTheaterId === null} aria-pressed={formationView && formationLayout === "columns"} aria-label="Formation view — Columns layout" title="Formation view — Columns layout"><FormationColumnsIcon /></button>
         <button type="button" className="command-band-formation-toggle command-band-formation-seg" onClick={() => selectFormationLayout("rows")} disabled={state.activeTheaterId === null} aria-pressed={formationView && formationLayout === "rows"} aria-label="Formation view — Rows layout" title="Formation view — Rows layout"><FormationRowsIcon /></button>
+        <span className="command-band-formation-divider" aria-hidden="true" />
+        <WorkspacePresets theaterId={state.activeTheaterId} />
       </div> : null}
       <div className="command-band-center">
         {operationsViewVisible && activeTheater ? <div ref={switcherRef} className="command-band-switcher" onBlur={handleSwitcherFocusOut}>

--- a/runtime/fleet-console/core/client/src/components/workspace-presets.tsx
+++ b/runtime/fleet-console/core/client/src/components/workspace-presets.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useRef, useState, type FormEvent, type KeyboardEvent } from "react";
+
+import {
+  applyWorkspacePreset,
+  createWorkspacePreset,
+  deleteWorkspacePreset,
+  fetchOperations,
+  fetchWorkspacePresets,
+  renameWorkspacePreset,
+} from "../api.js";
+import { useCanvasState } from "../canvas/canvas-store.js";
+import { useConsoleState } from "../hooks/use-store.js";
+import { usePluginRegistry } from "../plugin-registry.js";
+import { BUILT_IN_RAIL_PANELS } from "../rail/built-in-panels.js";
+import { hydrateOperations } from "../store.js";
+import type { DurableWorkspacePreset } from "../types.js";
+import { applyWorkspacePresetClientLayout, captureWorkspacePresetLayout } from "../workspace-preset-layout.js";
+
+const MAX_PRESET_NAME_LENGTH = 64;
+
+interface WorkspacePresetsProps {
+  readonly theaterId: string | null;
+}
+
+type EditorState =
+  | { readonly kind: "create" }
+  | { readonly kind: "rename"; readonly presetId: string }
+  | null;
+
+export function WorkspacePresets({ theaterId }: WorkspacePresetsProps) {
+  const state = useConsoleState();
+  const canvas = useCanvasState();
+  const registry = usePluginRegistry();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const rowRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const [open, setOpen] = useState(false);
+  const [presets, setPresets] = useState<readonly DurableWorkspacePreset[]>([]);
+  const [editor, setEditor] = useState<EditorState>(null);
+  const [name, setName] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<{ readonly tone: "warning" | "error" | "success"; readonly text: string } | null>(null);
+  const installedPanelIds = new Set([
+    ...BUILT_IN_RAIL_PANELS.map((panel) => panel.id),
+    ...registry.railPanels.filter((panel) => (panel.side ?? "right") === "right").map((panel) => panel.id),
+  ]);
+
+  useEffect(() => {
+    setOpen(false);
+    setPresets([]);
+    setEditor(null);
+    setMessage(null);
+  }, [theaterId]);
+
+  useEffect(() => {
+    if (!open || !theaterId) return;
+    const controller = new AbortController();
+    setBusy(true);
+    fetchWorkspacePresets(theaterId, controller.signal)
+      .then(setPresets)
+      .catch((error: unknown) => {
+        if (!controller.signal.aborted) setMessage({ tone: "error", text: error instanceof Error ? error.message : "Unable to load presets." });
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setBusy(false);
+      });
+    return () => controller.abort();
+  }, [open, theaterId]);
+
+  useEffect(() => {
+    if (!open) return;
+    const closeOnPointer = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node) || triggerRef.current?.contains(target) || popoverRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const closeOnEscape = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setOpen(false);
+      triggerRef.current?.focus();
+    };
+    document.addEventListener("pointerdown", closeOnPointer);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closeOnPointer);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [open]);
+
+  const beginCreate = () => {
+    setEditor({ kind: "create" });
+    setName("");
+    setMessage(null);
+  };
+
+  const beginRename = (preset: DurableWorkspacePreset) => {
+    setEditor({ kind: "rename", presetId: preset.id });
+    setName(preset.name);
+    setMessage(null);
+  };
+
+  const submitEditor = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!theaterId || !editor || busy) return;
+    setBusy(true);
+    setMessage(null);
+    try {
+      if (editor.kind === "create") {
+        const preset = await createWorkspacePreset(theaterId, name, captureWorkspacePresetLayout(
+          canvas,
+          state.operations.filter((operation) => operation.theaterId === theaterId).map((operation) => operation.id),
+        ));
+        setPresets((current) => [...current, preset]);
+        setMessage({ tone: "success", text: `Saved “${preset.name}”.` });
+      } else {
+        const preset = await renameWorkspacePreset(theaterId, editor.presetId, name);
+        setPresets((current) => current.map((item) => item.id === preset.id ? preset : item));
+        setMessage({ tone: "success", text: `Renamed to “${preset.name}”.` });
+      }
+      setEditor(null);
+      setName("");
+    } catch (error) {
+      setMessage({ tone: "error", text: error instanceof Error ? error.message : "Workspace Preset update failed." });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const applyPreset = async (presetId: string) => {
+    if (!theaterId || busy) return;
+    setBusy(true);
+    setMessage(null);
+    try {
+      const result = await applyWorkspacePreset(theaterId, presetId);
+      const warning = applyWorkspacePresetClientLayout(
+        result,
+        state.operations.filter((operation) => operation.theaterId === theaterId).map((operation) => operation.id),
+        installedPanelIds,
+      );
+      void fetchOperations(null).then(hydrateOperations).catch(() => {});
+      setMessage(warning
+        ? { tone: "warning", text: warning }
+        : { tone: "success", text: `Applied “${result.preset.name}”.` });
+    } catch (error) {
+      setMessage({ tone: "error", text: error instanceof Error ? error.message : "Workspace Preset apply failed." });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const removePreset = async (preset: DurableWorkspacePreset) => {
+    if (!theaterId || busy) return;
+    setBusy(true);
+    setMessage(null);
+    try {
+      await deleteWorkspacePreset(theaterId, preset.id);
+      setPresets((current) => current.filter((item) => item.id !== preset.id));
+      if (editor?.kind === "rename" && editor.presetId === preset.id) setEditor(null);
+      setMessage({ tone: "success", text: `Deleted “${preset.name}”.` });
+    } catch (error) {
+      setMessage({ tone: "error", text: error instanceof Error ? error.message : "Workspace Preset delete failed." });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const moveListFocus = (event: KeyboardEvent, index: number) => {
+    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+    event.preventDefault();
+    const offset = event.key === "ArrowDown" ? 1 : -1;
+    const next = (index + offset + presets.length) % presets.length;
+    rowRefs.current[next]?.focus();
+  };
+
+  return (
+    <span className="workspace-presets-control">
+      <button
+        ref={triggerRef}
+        type="button"
+        className="command-band-formation-toggle command-band-formation-seg workspace-presets-trigger"
+        disabled={theaterId === null}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label="Workspace Presets"
+        title="Workspace Presets"
+        onClick={() => setOpen((current) => !current)}
+      >
+        <WorkspacePresetIcon />
+      </button>
+      {open ? (
+        <div ref={popoverRef} className="workspace-presets-popover" role="dialog" aria-label="Workspace Presets">
+          <div className="workspace-presets-head">
+            <span className="workspace-presets-eyebrow">Workspace Presets</span>
+            <button type="button" className="workspace-presets-save" onClick={beginCreate} disabled={busy}>Save current</button>
+          </div>
+          {editor ? (
+            <form className="workspace-presets-editor" onSubmit={(event) => void submitEditor(event)}>
+              <label htmlFor="workspace-preset-name">{editor.kind === "create" ? "Preset name" : "New name"}</label>
+              <div className="workspace-presets-editor-row">
+                <input
+                  id="workspace-preset-name"
+                  autoFocus
+                  value={name}
+                  maxLength={MAX_PRESET_NAME_LENGTH}
+                  onChange={(event) => setName(event.target.value)}
+                />
+                <button type="submit" disabled={busy || name.trim().length === 0}>{editor.kind === "create" ? "Save" : "Rename"}</button>
+                <button type="button" onClick={() => setEditor(null)}>Cancel</button>
+              </div>
+            </form>
+          ) : null}
+          <div className="workspace-presets-list" aria-label="Saved Workspace Presets">
+            {presets.map((preset, index) => (
+              <div className="workspace-presets-row" key={preset.id}>
+                <button
+                  ref={(node) => { rowRefs.current[index] = node; }}
+                  type="button"
+                  className="workspace-presets-apply"
+                  disabled={busy}
+                  onClick={() => void applyPreset(preset.id)}
+                  onKeyDown={(event) => moveListFocus(event, index)}
+                >
+                  <span className="workspace-presets-name">{preset.name}</span>
+                  <span className="workspace-presets-meta">{Object.keys(preset.layout.operationGeometries).length} operations</span>
+                </button>
+                <button type="button" className="workspace-presets-row-action" onClick={() => beginRename(preset)} disabled={busy} aria-label={`Rename ${preset.name}`}>Rename</button>
+                <button type="button" className="workspace-presets-row-action is-delete" onClick={() => void removePreset(preset)} disabled={busy} aria-label={`Delete ${preset.name}`}>Delete</button>
+              </div>
+            ))}
+            {!busy && presets.length === 0 ? <p className="workspace-presets-empty">No saved presets yet.</p> : null}
+            {busy && presets.length === 0 ? <p className="workspace-presets-empty">Loading…</p> : null}
+          </div>
+          {message ? <p className={`workspace-presets-message is-${message.tone}`} role={message.tone === "error" ? "alert" : "status"}>{message.text}</p> : null}
+        </div>
+      ) : null}
+    </span>
+  );
+}
+
+function WorkspacePresetIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M3 2.5h10v11l-5-3-5 3z" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -4,9 +4,8 @@ import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console
 import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 import type { ClientApiCapability, FleetClientPlugin, OperationKindDescriptor } from "@fleet-console/sdk/plugin";
 
-import { addTheater, createGroup, deleteGroup, fetchGroups, fetchOperations, fetchTheaters, forgetTheater, issueTheaterFolderGrant, patchOperation, patchTheaterOrder, renameOperation, updateGroup, ApiError } from "../api.js";
+import { addTheater, createGroup, deleteGroup, fetchGroups, fetchOperations, fetchTheaters, forgetTheater, issueTheaterFolderGrant, patchOperation, patchTheaterOrder, renameOperation, updateGroup, ApiError, type DeferredDeletionReceipt } from "../api.js";
 import { closeOperationCompletely } from "../operation-close.js";
-import type { DeferredDeletionReceipt } from "../api.js";
 import { claimTopZIndex, ensureDefaultGeometry, focusOperation as focusCanvasOperation, forceDropCompanionOperationId, getCompanionOperationId, getFocusLayerRevision, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useCompanionOperationId, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
 import { screenToCanvas, type CanvasPoint } from "../canvas/coordinates.js";
 import { playMinimizeFlight, playRestoreFlight } from "../canvas/panel-motion.js";

--- a/runtime/fleet-console/core/client/src/rail/rail-store.ts
+++ b/runtime/fleet-console/core/client/src/rail/rail-store.ts
@@ -4,11 +4,18 @@ interface RailStore {
   readonly activeRailPanelId: string | null;
   readonly railChromeExpanded: boolean;
   readonly panelExtraWidth: number;
+  readonly currentPanelWidth: number | null;
+  readonly presetPanelWidthRequest: RailPresetPanelWidthRequest | null;
   readonly panelBehavior: "push" | "overlay";
   readonly overlayAlpha: RailOverlayAlpha;
 }
 
 export type RailOverlayAlpha = 100 | 90 | 75 | 60;
+export interface RailPresetPanelWidthRequest {
+  readonly panelId: string;
+  readonly width: number;
+  readonly revision: number;
+}
 
 type Listener = () => void;
 const PREFS_ACTIVE_PANEL = "fleet-console.rail.activePanelId";
@@ -21,6 +28,8 @@ let store: RailStore = {
   activeRailPanelId: readStoredPanelId(),
   railChromeExpanded: readStoredChromeExpanded(),
   panelExtraWidth: 0,
+  currentPanelWidth: null,
+  presetPanelWidthRequest: null,
   panelBehavior: readStoredPanelBehavior(),
   overlayAlpha: readStoredOverlayAlpha(),
 };
@@ -63,6 +72,40 @@ export function setRailChromeExpanded(expanded: boolean): void {
   saveStoredChromeExpanded(expanded);
 }
 
+export function applyRailPreset(input: {
+  readonly activePanelId: string | null;
+  readonly chromeExpanded: boolean;
+  readonly panelWidth: number | null;
+}): void {
+  const request = input.activePanelId !== null && input.panelWidth !== null
+    ? {
+      panelId: input.activePanelId,
+      width: input.panelWidth,
+      revision: (store.presetPanelWidthRequest?.revision ?? 0) + 1,
+    }
+    : null;
+  setStore({
+    ...store,
+    activeRailPanelId: input.activePanelId,
+    railChromeExpanded: input.chromeExpanded,
+    panelExtraWidth: 0,
+    presetPanelWidthRequest: request,
+  });
+  saveStoredPanelId(input.activePanelId);
+  saveStoredChromeExpanded(input.chromeExpanded);
+}
+
+export function publishRailPanelWidth(panelId: string | null, width: number | null): void {
+  const nextWidth = panelId === store.activeRailPanelId ? width : null;
+  if (store.currentPanelWidth === nextWidth) return;
+  setStore({ ...store, currentPanelWidth: nextWidth });
+}
+
+export function consumeRailPresetPanelWidth(revision: number): void {
+  if (store.presetPanelWidthRequest?.revision !== revision) return;
+  setStore({ ...store, presetPanelWidthRequest: null });
+}
+
 export function toggleRailChrome(): void {
   setRailChromeExpanded(!store.railChromeExpanded);
 }
@@ -102,6 +145,10 @@ export function useRailChromeExpanded(): boolean {
 
 export function useRailPanelExtraWidth(): number {
   return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).panelExtraWidth;
+}
+
+export function useRailPresetPanelWidthRequest(): RailPresetPanelWidthRequest | null {
+  return useSyncExternalStore(subscribeRailStore, getRailStoreSnapshot).presetPanelWidthRequest;
 }
 
 export function useRailPanelBehavior(): "push" | "overlay" {

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -7,7 +7,7 @@ import "../styles/rail.css";
 import { BUILT_IN_RAIL_PANELS } from "./built-in-panels.js";
 import { focusCommandBandToggleWhenPanelContainsActiveElement } from "../components/command-band-focus.js";
 import { getState, subscribe } from "../store.js";
-import { closeRailPanel, requestRailPanelExtraWidth, setRailOverlayAlpha, toggleRailPanel, toggleRailPanelBehavior, useActiveRailPanelId, useRailChromeExpanded, useRailOverlayAlpha, useRailPanelBehavior, useRailPanelExtraWidth, type RailOverlayAlpha } from "./rail-store.js";
+import { closeRailPanel, consumeRailPresetPanelWidth, publishRailPanelWidth, requestRailPanelExtraWidth, setRailOverlayAlpha, toggleRailPanel, toggleRailPanelBehavior, useActiveRailPanelId, useRailChromeExpanded, useRailOverlayAlpha, useRailPanelBehavior, useRailPanelExtraWidth, useRailPresetPanelWidthRequest, type RailOverlayAlpha } from "./rail-store.js";
 import { useRailPanels } from "./rail-registry.js";
 import { useCodexSplitExtraWidth } from "./use-codex-split-extra-width.js";
 
@@ -97,6 +97,7 @@ export function RightRail({ theaterId, api }: RightRailProps) {
   const railChromeExpanded = useRailChromeExpanded();
   const panelBehavior = useRailPanelBehavior();
   const overlayAlpha = useRailOverlayAlpha();
+  const presetPanelWidthRequest = useRailPresetPanelWidthRequest();
   const previousRailChromeExpandedRef = useRef(railChromeExpanded);
   const previousPanelBehaviorRef = useRef(panelBehavior);
   const pluginPanels = useRailPanels();
@@ -156,12 +157,26 @@ export function RightRail({ theaterId, api }: RightRailProps) {
   }, [activeId, activePanel?.id, activePanel?.defaultWidth, isDragging, maxPanelWidth]);
 
   useLayoutEffect(() => {
+    if (!presetPanelWidthRequest || activePanel?.id !== presetPanelWidthRequest.panelId) return;
+    const next = Math.max(MIN_PANEL_WIDTH, Math.min(maxPanelWidth, Math.round(presetPanelWidthRequest.width)));
+    desiredWidthRef.current = next;
+    panelWidthRef.current = next;
+    setPanelWidthState(next);
+    saveStoredPanelWidth(activePanel.id, next);
+    consumeRailPresetPanelWidth(presetPanelWidthRequest.revision);
+  }, [activePanel?.id, maxPanelWidth, presetPanelWidthRequest]);
+
+  useLayoutEffect(() => {
     const desiredWidth = isDragging ? panelWidthRef.current : desiredWidthRef.current;
     const next = Math.max(MIN_PANEL_WIDTH, Math.min(maxPanelWidth, desiredWidth));
     if (next === panelWidthRef.current) return;
     panelWidthRef.current = next;
     setPanelWidthState(next);
   }, [isDragging, maxPanelWidth]);
+
+  useLayoutEffect(() => {
+    publishRailPanelWidth(activePanel?.id ?? null, activePanel ? panelWidth : null);
+  }, [activePanel, panelWidth]);
 
   useLayoutEffect(() => {
     if (previousRailChromeExpandedRef.current && !railChromeExpanded) focusCommandBandToggleWhenPanelContainsActiveElement(rootRef.current, ".command-band-rail-toggle");

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -271,6 +271,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 
 .command-band-formation-group {
   position: absolute;
+  z-index: 48;
   left: calc(var(--command-band-left-width, 280px) + var(--space-2));
   top: 50%;
   transform: translateY(-50%);
@@ -318,6 +319,182 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 }
 
 .command-band-formation-toggle:disabled { cursor: not-allowed; opacity: 0.55; }
+
+.workspace-presets-control {
+  position: relative;
+  display: inline-flex;
+}
+
+.workspace-presets-popover {
+  position: absolute;
+  z-index: 48;
+  top: calc(100% + var(--space-3));
+  left: 0;
+  width: min(420px, calc(100vw - 24px));
+  padding: var(--space-3);
+  border: 1px solid var(--surface-rim-strong);
+  border-radius: var(--radius-lg);
+  background: color-mix(in oklch, var(--ink-deep) 60%, var(--surface-pillar));
+  box-shadow: var(--shadow-floating);
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  transform: none;
+}
+
+.workspace-presets-head,
+.workspace-presets-editor-row,
+.workspace-presets-row {
+  display: flex;
+  align-items: center;
+}
+
+.workspace-presets-head {
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-2);
+}
+
+.workspace-presets-eyebrow {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.01em;
+}
+
+.workspace-presets-save,
+.workspace-presets-editor button,
+.workspace-presets-row-action {
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--surface-rim-strong);
+  border-radius: var(--radius-xs);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: var(--weight-medium);
+}
+
+.workspace-presets-save:hover:not(:disabled),
+.workspace-presets-save:focus-visible,
+.workspace-presets-editor button:hover:not(:disabled),
+.workspace-presets-editor button:focus-visible,
+.workspace-presets-row-action:hover:not(:disabled),
+.workspace-presets-row-action:focus-visible {
+  border-color: var(--brass);
+  color: var(--text-primary);
+  outline: none;
+}
+
+.workspace-presets-editor {
+  display: grid;
+  gap: var(--space-1);
+  margin-bottom: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--surface-glass-strong) 72%, transparent);
+}
+
+.workspace-presets-editor label {
+  color: var(--text-tertiary);
+  font-size: 10px;
+  font-weight: var(--weight-regular);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.workspace-presets-editor-row { gap: var(--space-1); }
+
+.workspace-presets-editor input {
+  min-width: 0;
+  flex: 1;
+  padding: 6px var(--space-2);
+  border: 1px solid var(--surface-rim-strong);
+  border-radius: var(--radius-xs);
+  background: var(--surface-glass);
+  color: var(--text-primary);
+  font: inherit;
+}
+
+.workspace-presets-editor input:focus {
+  border-color: var(--brass);
+  outline: none;
+}
+
+.workspace-presets-list {
+  display: grid;
+  gap: var(--space-1);
+  max-height: min(52vh, 360px);
+  overflow-y: auto;
+}
+
+.workspace-presets-row {
+  gap: var(--space-1);
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+}
+
+.workspace-presets-row:hover {
+  background: color-mix(in oklch, var(--brass) 8%, transparent);
+}
+
+.workspace-presets-apply {
+  display: grid;
+  min-width: 0;
+  flex: 1;
+  gap: 2px;
+  padding: var(--space-1);
+  border-radius: var(--radius-xs);
+  text-align: left;
+}
+
+.workspace-presets-apply:focus-visible {
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  outline: 1px solid var(--brass);
+}
+
+.workspace-presets-name {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: var(--weight-medium);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-presets-meta,
+.workspace-presets-empty,
+.workspace-presets-message {
+  color: var(--text-tertiary);
+  font-size: 10px;
+  font-weight: var(--weight-regular);
+}
+
+.workspace-presets-row-action.is-delete:hover:not(:disabled),
+.workspace-presets-row-action.is-delete:focus-visible {
+  border-color: var(--coral);
+  color: var(--coral);
+}
+
+.workspace-presets-empty {
+  margin: var(--space-3) 0;
+  text-align: center;
+}
+
+.workspace-presets-message {
+  margin: var(--space-2) 0 0;
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--surface-rim);
+}
+
+.workspace-presets-message.is-warning { color: var(--warn); }
+.workspace-presets-message.is-error { color: var(--coral); }
+.workspace-presets-message.is-success { color: var(--positive); }
+
+.workspace-presets-save:disabled,
+.workspace-presets-editor button:disabled,
+.workspace-presets-row button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
 
 .command-band-theater-cluster {
   display: flex;

--- a/runtime/fleet-console/core/client/src/types.ts
+++ b/runtime/fleet-console/core/client/src/types.ts
@@ -95,6 +95,41 @@ export interface OperationGeometry {
   readonly zIndex: number;
 }
 
+export interface WorkspacePresetViewport {
+  readonly x: number;
+  readonly y: number;
+  readonly zoom: number;
+}
+
+export interface WorkspacePresetLayout {
+  readonly viewport: WorkspacePresetViewport;
+  readonly operationGeometries: Readonly<Record<string, OperationGeometry>>;
+  readonly minimizedOperationIds: readonly string[];
+  readonly rail: {
+    readonly activePanelId: string | null;
+    readonly chromeExpanded: boolean;
+    readonly panelWidth: number | null;
+  };
+  readonly sidebar: {
+    readonly statusAxis: "group" | "status";
+  };
+}
+
+export interface DurableWorkspacePreset {
+  readonly id: string;
+  readonly theaterId: string;
+  readonly name: string;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly layout: WorkspacePresetLayout;
+}
+
+export interface WorkspacePresetApplyResult {
+  readonly preset: DurableWorkspacePreset;
+  readonly appliedOperationIds: readonly string[];
+  readonly missingOperationIds: readonly string[];
+}
+
 export interface OperationGroup {
   readonly id: string;
   readonly name: string;

--- a/runtime/fleet-console/core/client/src/workspace-preset-layout.ts
+++ b/runtime/fleet-console/core/client/src/workspace-preset-layout.ts
@@ -1,0 +1,57 @@
+import { getSnapshot as getCanvasSnapshot, setState as setCanvasState, setViewport } from "./canvas/canvas-store.js";
+import { applyRailPreset, getRailStoreSnapshot } from "./rail/rail-store.js";
+import { getSideBarStatusAxis, setSideBarStatusAxis } from "./sidebar/operations-side-bar-store.js";
+import type { WorkspacePresetApplyResult, WorkspacePresetLayout } from "./types.js";
+
+export function captureWorkspacePresetLayout(
+  canvas: ReturnType<typeof getCanvasSnapshot>,
+  operationIds: readonly string[],
+): WorkspacePresetLayout {
+  const validOperationIds = new Set(operationIds);
+  const operationGeometries = Object.fromEntries(
+    Object.entries(canvas.operations)
+      .filter(([operationId]) => validOperationIds.has(operationId))
+      .map(([operationId, geometry]) => [operationId, { ...geometry }]),
+  );
+  const rail = getRailStoreSnapshot();
+  return {
+    viewport: { ...canvas.viewport },
+    operationGeometries,
+    minimizedOperationIds: canvas.minimized.filter((operationId) => validOperationIds.has(operationId)),
+    rail: {
+      activePanelId: rail.activeRailPanelId,
+      chromeExpanded: rail.railChromeExpanded,
+      panelWidth: rail.activeRailPanelId === null ? null : rail.currentPanelWidth,
+    },
+    sidebar: { statusAxis: getSideBarStatusAxis() ? "status" : "group" },
+  };
+}
+
+export function applyWorkspacePresetClientLayout(
+  result: WorkspacePresetApplyResult,
+  currentOperationIds: readonly string[],
+  installedPanelIds: ReadonlySet<string>,
+): string | null {
+  const currentIdSet = new Set(currentOperationIds);
+  const canvas = getCanvasSnapshot();
+  const operations = { ...canvas.operations };
+  for (const operationId of result.appliedOperationIds) {
+    const geometry = result.preset.layout.operationGeometries[operationId];
+    if (geometry) operations[operationId] = { ...geometry };
+  }
+  setCanvasState({
+    operations,
+    minimized: result.preset.layout.minimizedOperationIds.filter((operationId) => currentIdSet.has(operationId)),
+  });
+  setViewport(result.preset.layout.viewport);
+  setSideBarStatusAxis(result.preset.layout.sidebar.statusAxis === "status");
+
+  const presetPanelId = result.preset.layout.rail.activePanelId;
+  const panelUnavailable = presetPanelId !== null && !installedPanelIds.has(presetPanelId);
+  if (!panelUnavailable) applyRailPreset(result.preset.layout.rail);
+
+  const warnings: string[] = [];
+  if (panelUnavailable) warnings.push(`Panel “${presetPanelId}” is not installed; the current rail was preserved.`);
+  if (result.missingOperationIds.length > 0) warnings.push(`${result.missingOperationIds.length} missing operation${result.missingOperationIds.length === 1 ? "" : "s"} skipped.`);
+  return warnings.length > 0 ? warnings.join(" ") : null;
+}

--- a/runtime/fleet-console/core/host/deferred-deletion.ts
+++ b/runtime/fleet-console/core/host/deferred-deletion.ts
@@ -1,10 +1,11 @@
 import crypto from "node:crypto";
 
-import type { DurableDeletionTombstone, DurableOperationGroup } from "./durable-state.js";
+import type { DurableDeletionTombstone, DurableOperationGroup, DurableWorkspacePreset } from "./durable-state.js";
 import type { OperationNode, OperationStore } from "./operations/types.js";
 import { DELETION_GRACE_MS } from "./operations/types.js";
 import type { TheaterRegistration } from "./theaters.js";
 import type { TheaterRegistry } from "./theaters.js";
+import type { WorkspacePresetStore } from "./workspace-presets/store.js";
 
 export interface DeferredDeletionReceipt {
   readonly deletionId: string;
@@ -49,6 +50,7 @@ export interface DeferredDeletionCoordinator {
 interface DeferredDeletionCoordinatorDeps {
   readonly operations: OperationStore;
   readonly theaters: TheaterRegistry;
+  readonly workspacePresets: WorkspacePresetStore;
   readonly save: (tombstones: readonly DurableDeletionTombstone[]) => void;
   readonly publish: (channel: string, payload: unknown) => void;
   readonly unregisterTheaterWorkspaces: (theaterId: string) => void;
@@ -121,8 +123,10 @@ export function createDeferredDeletionCoordinator(deps: DeferredDeletionCoordina
     const previousTheaters = deps.theaters.list();
     const previousOperations = deps.operations.list();
     const previousGroups = deps.operations.listAllGroups();
+    const previousWorkspacePresets = deps.workspacePresets.list();
     const deletedOperations = deps.operations.listByTheater(theaterId);
     const deletedGroups = deps.operations.listGroups(theaterId);
+    const deletedWorkspacePresets = deps.workspacePresets.list(theaterId);
     const deletedAt = now();
     const tombstone: DurableDeletionTombstone = {
       deletionId: randomId(),
@@ -133,16 +137,19 @@ export function createDeferredDeletionCoordinator(deps: DeferredDeletionCoordina
       theater,
       operations: deletedOperations,
       groups: deletedGroups,
+      workspacePresets: deletedWorkspacePresets,
     };
     const nextTombstones = [...tombstones, tombstone];
     deps.theaters.remove(theaterId);
     deps.operations.deleteByTheater(theaterId);
+    deps.workspacePresets.deleteByTheater(theaterId);
     try {
       deps.save(nextTombstones);
     } catch (error) {
       deps.theaters.restore(previousTheaters);
       deps.operations.replace(previousOperations);
       deps.operations.replaceGroups(previousGroups);
+      deps.workspacePresets.replace(previousWorkspacePresets);
       throw error;
     }
     tombstones = nextTombstones;
@@ -181,22 +188,26 @@ export function createDeferredDeletionCoordinator(deps: DeferredDeletionCoordina
     await deps.validateTheaterRestore(tombstone.theater);
     if (deps.theaters.get(tombstone.targetId)
       || tombstone.operations.some((operation) => deps.operations.get(operation.id))
-      || hasGroupConflict(tombstone.groups, deps.operations.listAllGroups())) {
+      || hasGroupConflict(tombstone.groups, deps.operations.listAllGroups())
+      || hasWorkspacePresetConflict(tombstone.workspacePresets, deps.workspacePresets.list())) {
       throw new DeferredDeletionError(409, "restore_conflict");
     }
     const previousTheaters = deps.theaters.list();
     const previousOperations = deps.operations.list();
     const previousGroups = deps.operations.listAllGroups();
+    const previousWorkspacePresets = deps.workspacePresets.list();
     const nextTombstones = tombstones.filter((item) => item.deletionId !== deletionId);
     deps.theaters.restore([...previousTheaters, tombstone.theater]);
     deps.operations.replace([...previousOperations, ...tombstone.operations]);
     deps.operations.replaceGroups([...previousGroups, ...tombstone.groups]);
+    deps.workspacePresets.replace([...previousWorkspacePresets, ...tombstone.workspacePresets]);
     try {
       deps.save(nextTombstones);
     } catch (error) {
       deps.theaters.restore(previousTheaters);
       deps.operations.replace(previousOperations);
       deps.operations.replaceGroups(previousGroups);
+      deps.workspacePresets.replace(previousWorkspacePresets);
       throw error;
     }
     tombstones = nextTombstones;
@@ -306,4 +317,9 @@ function toReceipt(tombstone: DurableDeletionTombstone): DeferredDeletionReceipt
 function hasGroupConflict(groups: readonly DurableOperationGroup[], existing: readonly DurableOperationGroup[]): boolean {
   const existingIds = new Set(existing.map((group) => group.id));
   return groups.some((group) => existingIds.has(group.id));
+}
+
+function hasWorkspacePresetConflict(presets: readonly DurableWorkspacePreset[], existing: readonly DurableWorkspacePreset[]): boolean {
+  const existingIds = new Set(existing.map((preset) => preset.id));
+  return presets.some((preset) => existingIds.has(preset.id));
 }

--- a/runtime/fleet-console/core/host/durable-state.ts
+++ b/runtime/fleet-console/core/host/durable-state.ts
@@ -7,7 +7,7 @@ import {
 } from "@dotobokuri/core-infra";
 
 import { createConsoleDataPaths, type ConsoleDataPaths } from "./paths.js";
-import { MAX_GROUP_NAME_LENGTH, type OperationNode } from "./operations/types.js";
+import { MAX_GROUP_NAME_LENGTH, type OperationGeometry, type OperationNode } from "./operations/types.js";
 import type { TheaterRegistration } from "./theaters.js";
 
 export interface DurableOperationGroup {
@@ -26,6 +26,41 @@ export interface DurableDeletionBase {
   readonly expiresAt: number;
 }
 
+export interface WorkspacePresetViewport {
+  readonly x: number;
+  readonly y: number;
+  readonly zoom: number;
+}
+
+export interface WorkspacePresetLayout {
+  readonly viewport: WorkspacePresetViewport;
+  readonly operationGeometries: Readonly<Record<string, OperationGeometry>>;
+  readonly minimizedOperationIds: readonly string[];
+  readonly rail: {
+    readonly activePanelId: string | null;
+    readonly chromeExpanded: boolean;
+    readonly panelWidth: number | null;
+  };
+  readonly sidebar: {
+    readonly statusAxis: "group" | "status";
+  };
+}
+
+export interface DurableWorkspacePreset {
+  readonly id: string;
+  readonly theaterId: string;
+  readonly name: string;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly layout: WorkspacePresetLayout;
+}
+
+export interface WorkspacePresetApplyResult {
+  readonly preset: DurableWorkspacePreset;
+  readonly appliedOperationIds: readonly string[];
+  readonly missingOperationIds: readonly string[];
+}
+
 export type DurableDeletionTombstone =
   | (DurableDeletionBase & { readonly kind: "operation"; readonly operation: OperationNode })
   | (DurableDeletionBase & {
@@ -33,14 +68,16 @@ export type DurableDeletionTombstone =
       readonly theater: TheaterRegistration;
       readonly operations: readonly OperationNode[];
       readonly groups: readonly DurableOperationGroup[];
+      readonly workspacePresets: readonly DurableWorkspacePreset[];
     });
 
 export interface DurableConsoleState {
-  readonly version: 3;
+  readonly version: 4;
   readonly theaters: readonly TheaterRegistration[];
   readonly operations: readonly OperationNode[];
   readonly groups?: readonly DurableOperationGroup[];
   readonly deletionTombstones?: readonly DurableDeletionTombstone[];
+  readonly workspacePresets?: readonly DurableWorkspacePreset[];
 }
 
 export interface CreateConsoleDurableStateStoreDeps {
@@ -49,7 +86,8 @@ export interface CreateConsoleDurableStateStoreDeps {
   readonly now?: () => number;
 }
 
-export const STATE_VERSION = 3;
+export const STATE_VERSION = 4;
+export const MAX_WORKSPACE_PRESET_NAME_LENGTH = 64;
 const STATE_LOCK_DIR_NAME = "state.lock";
 const STATE_LOCK_OWNER_FILE_NAME = "owner.json";
 const STATE_TEMP_PREFIX = ".state.";
@@ -86,11 +124,12 @@ export function sanitizeDurableConsoleState(value: unknown): DurableConsoleState
     operations: readOperations(upgraded.operations),
     groups: readOperationGroups(upgraded.groups),
     deletionTombstones: readDeletionTombstones(upgraded.deletionTombstones),
+    workspacePresets: readWorkspacePresets(upgraded.workspacePresets),
   };
 }
 
 export function emptyDurableConsoleState(): DurableConsoleState {
-  return { version: STATE_VERSION, theaters: [], operations: [], groups: [], deletionTombstones: [] };
+  return { version: STATE_VERSION, theaters: [], operations: [], groups: [], deletionTombstones: [], workspacePresets: [] };
 }
 
 // 릴리스된 stable durable state(v1, flat 세션 레코드)을 현재 스키마(OperationNode)로 1회 변환한다.
@@ -100,6 +139,7 @@ function migrateToCurrentVersion(value: Record<string, unknown>): Record<string,
   let current = value;
   if (current.version === 1) current = migrateV1ToV2(current);
   if (current.version === 2) current = migrateV2ToV3(current);
+  if (current.version === 3) current = migrateV3ToV4(current);
   return current;
 }
 
@@ -115,11 +155,27 @@ function migrateV1ToV2(v1: Record<string, unknown>): Record<string, unknown> {
 
 function migrateV2ToV3(v2: Record<string, unknown>): Record<string, unknown> {
   return {
-    version: STATE_VERSION,
+    version: 3,
     theaters: v2.theaters ?? [],
     operations: v2.operations ?? [],
     groups: v2.groups ?? [],
     deletionTombstones: [],
+  };
+}
+
+function migrateV3ToV4(v3: Record<string, unknown>): Record<string, unknown> {
+  const deletionTombstones = Array.isArray(v3.deletionTombstones)
+    ? v3.deletionTombstones.map((value) => isRecord(value) && value.kind === "theater"
+      ? { ...value, workspacePresets: [] }
+      : value)
+    : [];
+  return {
+    version: STATE_VERSION,
+    theaters: v3.theaters ?? [],
+    operations: v3.operations ?? [],
+    groups: v3.groups ?? [],
+    deletionTombstones,
+    workspacePresets: [],
   };
 }
 
@@ -330,18 +386,81 @@ function sanitizeDeletionTombstone(value: unknown): DurableDeletionTombstone | n
   }
   if (value.kind === "theater") {
     const theater = sanitizeTheaterRegistration(value.theater);
-    if (!theater || theater.id !== targetId || !Array.isArray(value.operations) || !Array.isArray(value.groups)) return null;
+    if (!theater || theater.id !== targetId || !Array.isArray(value.operations) || !Array.isArray(value.groups) || !Array.isArray(value.workspacePresets)) return null;
     const operations = value.operations
       .map(sanitizeOperationNode)
       .filter((operation): operation is OperationNode => operation !== null);
     const groups = value.groups
       .map(sanitizeOperationGroup)
       .filter((group): group is DurableOperationGroup => group !== null);
+    const workspacePresets = value.workspacePresets
+      .map(sanitizeWorkspacePreset)
+      .filter((preset): preset is DurableWorkspacePreset => preset !== null);
     if (operations.length !== value.operations.length
       || groups.length !== value.groups.length
+      || workspacePresets.length !== value.workspacePresets.length
       || operations.some((operation) => operation.theaterId !== targetId)
-      || groups.some((group) => group.theaterId !== targetId)) return null;
-    return { deletionId, targetId, deletedAt, expiresAt, kind: "theater", theater, operations, groups };
+      || groups.some((group) => group.theaterId !== targetId)
+      || workspacePresets.some((preset) => preset.theaterId !== targetId)) return null;
+    return { deletionId, targetId, deletedAt, expiresAt, kind: "theater", theater, operations, groups, workspacePresets };
   }
   return null;
+}
+
+function readWorkspacePresets(value: unknown): readonly DurableWorkspacePreset[] {
+  if (!Array.isArray(value)) return [];
+  const presets: DurableWorkspacePreset[] = [];
+  for (const item of value) {
+    const preset = sanitizeWorkspacePreset(item);
+    if (preset) presets.push(preset);
+  }
+  return presets;
+}
+
+function sanitizeWorkspacePreset(value: unknown): DurableWorkspacePreset | null {
+  if (!isRecord(value)) return null;
+  const id = readNonEmptyString(value.id);
+  const theaterId = readNonEmptyString(value.theaterId);
+  const name = readNonEmptyString(value.name);
+  const createdAt = readFiniteNumber(value.createdAt);
+  const updatedAt = readFiniteNumber(value.updatedAt);
+  const layout = sanitizeWorkspacePresetLayout(value.layout);
+  if (!id || !theaterId || !name || name.trim().length === 0 || name.length > MAX_WORKSPACE_PRESET_NAME_LENGTH || createdAt === null || updatedAt === null || !layout) return null;
+  return { id, theaterId, name, createdAt, updatedAt, layout };
+}
+
+export function sanitizeWorkspacePresetLayout(value: unknown): WorkspacePresetLayout | null {
+  if (!isRecord(value) || !isRecord(value.viewport) || !isRecord(value.operationGeometries)
+    || !Array.isArray(value.minimizedOperationIds) || !isRecord(value.rail) || !isRecord(value.sidebar)) return null;
+  const x = readFiniteNumber(value.viewport.x);
+  const y = readFiniteNumber(value.viewport.y);
+  const zoom = readFiniteNumber(value.viewport.zoom);
+  if (x === null || y === null || zoom === null) return null;
+
+  const operationGeometryEntries: Array<[string, OperationGeometry]> = [];
+  for (const [operationId, rawGeometry] of Object.entries(value.operationGeometries)) {
+    const geometry = sanitizeOperationGeometry(rawGeometry);
+    if (!operationId || !geometry) return null;
+    operationGeometryEntries.push([operationId, geometry]);
+  }
+  if (!value.minimizedOperationIds.every((operationId) => typeof operationId === "string" && operationId.length > 0)) return null;
+
+  const activePanelId = value.rail.activePanelId;
+  const panelWidth = value.rail.panelWidth;
+  if ((activePanelId !== null && (typeof activePanelId !== "string" || activePanelId.length === 0))
+    || typeof value.rail.chromeExpanded !== "boolean"
+    || (panelWidth !== null && (typeof panelWidth !== "number" || !Number.isFinite(panelWidth)))
+    || (value.sidebar.statusAxis !== "group" && value.sidebar.statusAxis !== "status")) return null;
+
+  return {
+    viewport: { x, y, zoom },
+    operationGeometries: Object.fromEntries(operationGeometryEntries),
+    minimizedOperationIds: [...value.minimizedOperationIds],
+    rail: {
+      activePanelId,
+      chromeExpanded: value.rail.chromeExpanded,
+      panelWidth,
+    },
+    sidebar: { statusAxis: value.sidebar.statusAxis },
+  };
 }

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -49,6 +49,8 @@ import { TheaterRegistry } from "./theaters.js";
 import { canonicalizeTheaterPathSync, workspaceHash } from "./theater.js";
 import { createConsoleUpdateApplyService, type ConsoleUpdateApplyService } from "./update-apply.js";
 import { createConsoleUpdateCheckService, type ConsoleUpdateCheckService } from "./update-check.js";
+import { createWorkspacePresetsRouter } from "./workspace-presets/routes.js";
+import { createWorkspacePresetStore } from "./workspace-presets/store.js";
 
 export interface ConsoleServerDeps {
   readonly host?: string;
@@ -167,6 +169,41 @@ export const SERVER_API_CATALOG: readonly ApiCatalogEntry[] = [
     method: "DELETE",
     path: "/api/v1/theaters/:theaterId",
     summary: "Theater와 소속 Operation을 제거합니다.",
+    category: "Observer",
+    gate: "origin-write",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/theaters/:theaterId/workspace-presets",
+    summary: "Theater의 Workspace Preset 목록을 조회합니다.",
+    category: "Observer",
+    gate: "loopback",
+  },
+  {
+    method: "POST",
+    path: "/api/v1/theaters/:theaterId/workspace-presets",
+    summary: "현재 배치를 Workspace Preset으로 저장합니다.",
+    category: "Observer",
+    gate: "origin-write",
+  },
+  {
+    method: "PATCH",
+    path: "/api/v1/theaters/:theaterId/workspace-presets/:presetId",
+    summary: "Workspace Preset 이름을 변경합니다.",
+    category: "Observer",
+    gate: "origin-write",
+  },
+  {
+    method: "DELETE",
+    path: "/api/v1/theaters/:theaterId/workspace-presets/:presetId",
+    summary: "Workspace Preset을 삭제합니다.",
+    category: "Observer",
+    gate: "origin-write",
+  },
+  {
+    method: "POST",
+    path: "/api/v1/theaters/:theaterId/workspace-presets/:presetId/apply",
+    summary: "Workspace Preset 배치를 적용합니다.",
     category: "Observer",
     gate: "origin-write",
   },
@@ -322,9 +359,11 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   function publishPluginEvent(channel: string, payload: unknown): void {
     for (const listener of pluginEventListeners.get(channel) ?? []) listener(payload);
   }
+  const workspacePresets = createWorkspacePresetStore();
   const deletionCoordinator = createDeferredDeletionCoordinator({
     operations,
     theaters,
+    workspacePresets,
     save: saveDurableState,
     publish: publishPluginEvent,
     unregisterTheaterWorkspaces: (theaterId) => codex.unregisterTheaterWorkspaces(theaterId),
@@ -616,8 +655,18 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       });
     },
   });
+  const workspacePresetsRouter = createWorkspacePresetsRouter({
+    store: workspacePresets,
+    operations,
+    theaters,
+    isAuthorized: isTerminalAuthorized,
+    readJsonBody,
+    writeJson,
+    persist: persistDurableState,
+  });
   routeRegistry.register("/api/v1/operations", operationsRouter);
   routeRegistry.register("/api/v1/theaters", async (context) => {
+    if (await workspacePresetsRouter(context)) return true;
     return codexWorkspaceRouter(context);
   });
   routeRegistry.register("/api/v1/settings", async (ctx) => {
@@ -1140,12 +1189,14 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       theaters.restore(state.theaters);
       operations.replace(state.operations);
       operations.replaceGroups(state.groups ?? []);
+      workspacePresets.replace(state.workspacePresets ?? []);
     } catch (error) {
       console.warn(`[fleet-console] Durable state restore skipped: ${error instanceof Error ? error.message : String(error)}`);
       state = emptyDurableConsoleState();
       theaters.restore([]);
       operations.replace([]);
       operations.replaceGroups([]);
+      workspacePresets.replace([]);
     }
     deletionCoordinator.load(state.deletionTombstones ?? []);
     try {
@@ -1220,6 +1271,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       operations: operations.list(),
       groups: operations.listAllGroups(),
       deletionTombstones,
+      workspacePresets: workspacePresets.list(),
     });
   }
 

--- a/runtime/fleet-console/core/host/workspace-presets/routes.ts
+++ b/runtime/fleet-console/core/host/workspace-presets/routes.ts
@@ -1,0 +1,183 @@
+import type http from "node:http";
+
+import {
+  sanitizeWorkspacePresetLayout,
+  type WorkspacePresetApplyResult,
+} from "../durable-state.js";
+import type { OperationStore } from "../operations/types.js";
+import type { TheaterRegistry } from "../theaters.js";
+import type { WorkspacePresetStore } from "./store.js";
+
+export interface WorkspacePresetsRouterDeps {
+  readonly store: WorkspacePresetStore;
+  readonly operations: OperationStore;
+  readonly theaters: TheaterRegistry;
+  readonly isAuthorized: (req: http.IncomingMessage) => boolean;
+  readonly readJsonBody: <T>(req: http.IncomingMessage) => Promise<T | null>;
+  readonly writeJson: (res: http.ServerResponse, status: number, payload: unknown) => void;
+  readonly persist: () => void;
+}
+
+type WorkspacePresetsRouter = (context: {
+  readonly req: http.IncomingMessage;
+  readonly res: http.ServerResponse;
+  readonly pathname: string;
+}) => Promise<boolean>;
+
+export function createWorkspacePresetsRouter(deps: WorkspacePresetsRouterDeps): WorkspacePresetsRouter {
+  return async ({ req, res, pathname }) => {
+    const collectionMatch = pathname.match(/^\/api\/v1\/theaters\/([^/]+)\/workspace-presets$/u);
+    if (collectionMatch) {
+      await handleCollection(req, res, decodeURIComponent(collectionMatch[1] ?? ""), deps);
+      return true;
+    }
+    const applyMatch = pathname.match(/^\/api\/v1\/theaters\/([^/]+)\/workspace-presets\/([^/]+)\/apply$/u);
+    if (applyMatch) {
+      await handleApply(
+        req,
+        res,
+        decodeURIComponent(applyMatch[1] ?? ""),
+        decodeURIComponent(applyMatch[2] ?? ""),
+        deps,
+      );
+      return true;
+    }
+    const itemMatch = pathname.match(/^\/api\/v1\/theaters\/([^/]+)\/workspace-presets\/([^/]+)$/u);
+    if (itemMatch) {
+      await handleItem(
+        req,
+        res,
+        decodeURIComponent(itemMatch[1] ?? ""),
+        decodeURIComponent(itemMatch[2] ?? ""),
+        deps,
+      );
+      return true;
+    }
+    return false;
+  };
+}
+
+async function handleCollection(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  theaterId: string,
+  deps: WorkspacePresetsRouterDeps,
+): Promise<void> {
+  if (req.method === "GET") {
+    deps.writeJson(res, 200, { workspacePresets: deps.store.list(theaterId) });
+    return;
+  }
+  if (req.method !== "POST") {
+    deps.writeJson(res, 405, { error: "Method not allowed" });
+    return;
+  }
+  if (!deps.isAuthorized(req)) {
+    deps.writeJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  if (!deps.theaters.get(theaterId)) {
+    deps.writeJson(res, 404, { error: "theater_not_found" });
+    return;
+  }
+  const body = await deps.readJsonBody<{ readonly name?: unknown; readonly layout?: unknown }>(req);
+  const layout = sanitizeWorkspacePresetLayout(body?.layout);
+  if (!body || typeof body.name !== "string" || !layout) {
+    deps.writeJson(res, 400, { error: "invalid_workspace_preset" });
+    return;
+  }
+  try {
+    const preset = deps.store.create(theaterId, body.name, layout);
+    deps.persist();
+    deps.writeJson(res, 201, { workspacePreset: preset });
+  } catch (error) {
+    deps.writeJson(res, 400, { error: error instanceof Error ? error.message : "invalid_workspace_preset" });
+  }
+}
+
+async function handleItem(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  theaterId: string,
+  presetId: string,
+  deps: WorkspacePresetsRouterDeps,
+): Promise<void> {
+  if (req.method !== "PATCH" && req.method !== "DELETE") {
+    deps.writeJson(res, 405, { error: "Method not allowed" });
+    return;
+  }
+  if (!deps.isAuthorized(req)) {
+    deps.writeJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  if (req.method === "DELETE") {
+    const deleted = deps.store.delete(theaterId, presetId);
+    if (deleted) deps.persist();
+    deps.writeJson(res, deleted ? 200 : 404, deleted ? { ok: true } : { error: "workspace_preset_not_found" });
+    return;
+  }
+  const body = await deps.readJsonBody<{ readonly name?: unknown }>(req);
+  if (!body || typeof body.name !== "string") {
+    deps.writeJson(res, 400, { error: "invalid_workspace_preset_patch" });
+    return;
+  }
+  try {
+    const preset = deps.store.rename(theaterId, presetId, body.name);
+    if (!preset) {
+      deps.writeJson(res, 404, { error: "workspace_preset_not_found" });
+      return;
+    }
+    deps.persist();
+    deps.writeJson(res, 200, { workspacePreset: preset });
+  } catch (error) {
+    deps.writeJson(res, 400, { error: error instanceof Error ? error.message : "invalid_workspace_preset_patch" });
+  }
+}
+
+async function handleApply(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  theaterId: string,
+  presetId: string,
+  deps: WorkspacePresetsRouterDeps,
+): Promise<void> {
+  if (req.method !== "POST") {
+    deps.writeJson(res, 405, { error: "Method not allowed" });
+    return;
+  }
+  if (!deps.isAuthorized(req)) {
+    deps.writeJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  const preset = deps.store.get(theaterId, presetId);
+  if (!preset) {
+    deps.writeJson(res, 404, { error: "workspace_preset_not_found" });
+    return;
+  }
+
+  const currentOperations = deps.operations.list();
+  const currentById = new Map(deps.operations.listByTheater(theaterId).map((operation) => [operation.id, operation]));
+  const appliedOperationIds: string[] = [];
+  const missingOperationIds: string[] = [];
+  const nextGeometryById = new Map<string, typeof currentOperations[number]["geometry"]>();
+  for (const [operationId, geometry] of Object.entries(preset.layout.operationGeometries)) {
+    if (currentById.has(operationId)) {
+      appliedOperationIds.push(operationId);
+      nextGeometryById.set(operationId, { ...geometry });
+    } else {
+      missingOperationIds.push(operationId);
+    }
+  }
+  if (appliedOperationIds.length > 0) {
+    deps.operations.replace(currentOperations.map((operation) => {
+      const geometry = nextGeometryById.get(operation.id);
+      return geometry ? { ...operation, geometry } : operation;
+    }));
+    deps.persist();
+  }
+  const result: WorkspacePresetApplyResult = {
+    preset,
+    appliedOperationIds,
+    missingOperationIds,
+  };
+  deps.writeJson(res, 200, result);
+}

--- a/runtime/fleet-console/core/host/workspace-presets/store.ts
+++ b/runtime/fleet-console/core/host/workspace-presets/store.ts
@@ -1,0 +1,104 @@
+import crypto from "node:crypto";
+
+import {
+  MAX_WORKSPACE_PRESET_NAME_LENGTH,
+  type DurableWorkspacePreset,
+  type WorkspacePresetLayout,
+} from "../durable-state.js";
+
+export interface WorkspacePresetStore {
+  readonly list: (theaterId?: string) => readonly DurableWorkspacePreset[];
+  readonly get: (theaterId: string, presetId: string) => DurableWorkspacePreset | null;
+  readonly create: (theaterId: string, name: string, layout: WorkspacePresetLayout) => DurableWorkspacePreset;
+  readonly rename: (theaterId: string, presetId: string, name: string) => DurableWorkspacePreset | null;
+  readonly delete: (theaterId: string, presetId: string) => boolean;
+  readonly deleteByTheater: (theaterId: string) => readonly DurableWorkspacePreset[];
+  readonly replace: (presets: readonly DurableWorkspacePreset[]) => void;
+}
+
+export function createWorkspacePresetStore(deps: {
+  readonly now?: () => number;
+  readonly randomId?: () => string;
+} = {}): WorkspacePresetStore {
+  const now = deps.now ?? Date.now;
+  const randomId = deps.randomId ?? crypto.randomUUID;
+  const presets = new Map<string, DurableWorkspacePreset>();
+
+  function list(theaterId?: string): readonly DurableWorkspacePreset[] {
+    return [...presets.values()]
+      .filter((preset) => theaterId === undefined || preset.theaterId === theaterId)
+      .sort((left, right) => left.createdAt - right.createdAt || left.id.localeCompare(right.id));
+  }
+
+  function get(theaterId: string, presetId: string): DurableWorkspacePreset | null {
+    const preset = presets.get(presetId);
+    return preset?.theaterId === theaterId ? preset : null;
+  }
+
+  function create(theaterId: string, rawName: string, layout: WorkspacePresetLayout): DurableWorkspacePreset {
+    const name = normalizeName(rawName);
+    if (!name) throw new Error("invalid_workspace_preset_name");
+    const timestamp = now();
+    const preset: DurableWorkspacePreset = {
+      id: randomId(),
+      theaterId,
+      name,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      layout: cloneLayout(layout),
+    };
+    presets.set(preset.id, preset);
+    return preset;
+  }
+
+  function rename(theaterId: string, presetId: string, rawName: string): DurableWorkspacePreset | null {
+    const existing = get(theaterId, presetId);
+    if (!existing) return null;
+    const name = normalizeName(rawName);
+    if (!name) throw new Error("invalid_workspace_preset_name");
+    const updated = { ...existing, name, updatedAt: now() };
+    presets.set(updated.id, updated);
+    return updated;
+  }
+
+  function deletePreset(theaterId: string, presetId: string): boolean {
+    const existing = get(theaterId, presetId);
+    return existing ? presets.delete(existing.id) : false;
+  }
+
+  function deleteByTheater(theaterId: string): readonly DurableWorkspacePreset[] {
+    const deleted = list(theaterId);
+    for (const preset of deleted) presets.delete(preset.id);
+    return deleted;
+  }
+
+  function replace(nextPresets: readonly DurableWorkspacePreset[]): void {
+    presets.clear();
+    for (const preset of nextPresets) {
+      if (!presets.has(preset.id)) presets.set(preset.id, clonePreset(preset));
+    }
+  }
+
+  return { list, get, create, rename, delete: deletePreset, deleteByTheater, replace };
+}
+
+function normalizeName(value: string): string | null {
+  const name = value.trim();
+  return name.length > 0 && name.length <= MAX_WORKSPACE_PRESET_NAME_LENGTH ? name : null;
+}
+
+function clonePreset(preset: DurableWorkspacePreset): DurableWorkspacePreset {
+  return { ...preset, layout: cloneLayout(preset.layout) };
+}
+
+function cloneLayout(layout: WorkspacePresetLayout): WorkspacePresetLayout {
+  return {
+    viewport: { ...layout.viewport },
+    operationGeometries: Object.fromEntries(
+      Object.entries(layout.operationGeometries).map(([operationId, geometry]) => [operationId, { ...geometry }]),
+    ),
+    minimizedOperationIds: [...layout.minimizedOperationIds],
+    rail: { ...layout.rail },
+    sidebar: { ...layout.sidebar },
+  };
+}

--- a/runtime/fleet-console/tests/api-catalog.test.ts
+++ b/runtime/fleet-console/tests/api-catalog.test.ts
@@ -106,6 +106,16 @@ describe("api catalog", () => {
     }
   });
 
+  it("registers the complete Workspace Preset route table", () => {
+    expect(buildApiCatalog()).toEqual(expect.arrayContaining([
+      expect.objectContaining({ method: "GET", path: "/api/v1/theaters/:theaterId/workspace-presets", gate: "loopback" }),
+      expect.objectContaining({ method: "POST", path: "/api/v1/theaters/:theaterId/workspace-presets", gate: "origin-write" }),
+      expect.objectContaining({ method: "PATCH", path: "/api/v1/theaters/:theaterId/workspace-presets/:presetId", gate: "origin-write" }),
+      expect.objectContaining({ method: "DELETE", path: "/api/v1/theaters/:theaterId/workspace-presets/:presetId", gate: "origin-write" }),
+      expect.objectContaining({ method: "POST", path: "/api/v1/theaters/:theaterId/workspace-presets/:presetId/apply", gate: "origin-write" }),
+    ]));
+  });
+
   it("lists the loopback system-font route without scanning the developer machine", async () => {
     const fixture = await startFixture();
     const response = await fetch(`${fixture.endpoint}api/v1/settings/fonts/system`);

--- a/runtime/fleet-console/tests/deferred-deletion.test.ts
+++ b/runtime/fleet-console/tests/deferred-deletion.test.ts
@@ -4,6 +4,7 @@ import { createDeferredDeletionCoordinator, DeferredDeletionError } from "../cor
 import type { DurableDeletionTombstone } from "../core/host/durable-state.js";
 import { createOperationStore } from "../core/host/operations/store.js";
 import { TheaterRegistry, type TheaterRegistration } from "../core/host/theaters.js";
+import { createWorkspacePresetStore } from "../core/host/workspace-presets/store.js";
 
 const THEATER: TheaterRegistration = {
   id: "theater",
@@ -32,8 +33,13 @@ describe("deferred deletion coordinator", () => {
     harness.operations.create(makeOperation("op-a"));
     harness.operations.create(makeOperation("op-b"));
     harness.operations.createGroup({ id: "group-a", theaterId: THEATER.id, name: "Alpha", color: "blue" });
+    const preset = harness.workspacePresets.create(THEATER.id, "Review", makeWorkspacePresetLayout());
     const deletion = harness.coordinator.deleteTheater(THEATER.id);
     if (!deletion) throw new Error("expected deletion");
+    expect(harness.workspacePresets.list(THEATER.id)).toEqual([]);
+    expect(harness.coordinator.list()).toEqual([
+      expect.objectContaining({ kind: "theater", workspacePresets: [preset] }),
+    ]);
 
     const restored = await harness.coordinator.restore(deletion.deletionId);
 
@@ -41,7 +47,21 @@ describe("deferred deletion coordinator", () => {
     expect(harness.theaters.get(THEATER.id)).toEqual(THEATER);
     expect(harness.operations.listByTheater(THEATER.id).map((operation) => operation.id)).toEqual(["op-a", "op-b"]);
     expect(harness.operations.listGroups(THEATER.id).map((group) => group.id)).toEqual(["group-a"]);
+    expect(harness.workspacePresets.list(THEATER.id)).toEqual([preset]);
     expect(harness.events.filter((event) => event.channel === "operation:restored")).toHaveLength(2);
+  });
+
+  it("purges Theater presets with the expired tombstone", () => {
+    const harness = createHarness();
+    harness.workspacePresets.create(THEATER.id, "Review", makeWorkspacePresetLayout());
+    const deletion = harness.coordinator.deleteTheater(THEATER.id);
+    if (!deletion) throw new Error("expected deletion");
+    harness.clock.value = deletion.expiresAt;
+
+    harness.coordinator.sweepExpired();
+
+    expect(harness.workspacePresets.list()).toEqual([]);
+    expect(harness.coordinator.list()).toEqual([]);
   });
 
   it("rolls memory back when the durable save fails", () => {
@@ -81,10 +101,12 @@ function createHarness() {
   const operations = createOperationStore({ now: () => clock.value });
   const theaters = new TheaterRegistry();
   theaters.restore([THEATER]);
+  const workspacePresets = createWorkspacePresetStore({ now: () => clock.value, randomId: () => `preset-${clock.value}` });
   const events: Array<{ readonly channel: string; readonly payload: unknown }> = [];
   const coordinator = createDeferredDeletionCoordinator({
     operations,
     theaters,
+    workspacePresets,
     now: () => clock.value,
     randomId: () => `deletion-${clock.value}`,
     save: () => {
@@ -97,7 +119,7 @@ function createHarness() {
     setTimer: () => ({ unref: () => {} }) as unknown as ReturnType<typeof setTimeout>,
     clearTimer: () => {},
   });
-  return { clock, coordinator, events, failSave, operations, theaters };
+  return { clock, coordinator, events, failSave, operations, theaters, workspacePresets };
 }
 
 function makeOperation(id: string) {
@@ -123,5 +145,15 @@ function makeExpiredTombstone(): DurableDeletionTombstone {
       ...makeOperation("expired-op"),
       ts: { createdAt: 1, updatedAt: 1 },
     },
+  };
+}
+
+function makeWorkspacePresetLayout() {
+  return {
+    viewport: { x: 0, y: 0, zoom: 1 },
+    operationGeometries: {},
+    minimizedOperationIds: [],
+    rail: { activePanelId: null, chromeExpanded: true, panelWidth: null },
+    sidebar: { statusAxis: "group" as const },
   };
 }

--- a/runtime/fleet-console/tests/durable-state.test.ts
+++ b/runtime/fleet-console/tests/durable-state.test.ts
@@ -17,29 +17,29 @@ afterEach(() => {
 
 describe("durable console state", () => {
   it("falls back to an empty state for version mismatch or malformed data", () => {
-    expect(sanitizeDurableConsoleState({ version: 1, theaters: [], operations: [] })).toEqual({ version: 3, theaters: [], operations: [], groups: [], deletionTombstones: [] });
-    expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ id: "" }], operations: [{ id: "" }] })).toEqual({ version: 3, theaters: [], operations: [], groups: [], deletionTombstones: [] });
+    expect(sanitizeDurableConsoleState({ version: 1, theaters: [], operations: [] })).toEqual({ version: 4, theaters: [], operations: [], groups: [], deletionTombstones: [], workspacePresets: [] });
+    expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ id: "" }], operations: [{ id: "" }] })).toEqual({ version: 4, theaters: [], operations: [], groups: [], deletionTombstones: [], workspacePresets: [] });
   });
 
   it("drops legacy pathContext values without changing durable version", () => {
     const base = { id: "t", path: "/work/proj", realpath: "/work/proj", label: "proj", registeredAt: "1", lastOpenedAt: "2" };
-    expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, pathContext: "packages/core" }], operations: [] })).toMatchObject({ version: 3, theaters: [base] });
-    expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, pathContext: "../escape" }], operations: [] })).toMatchObject({ version: 3, theaters: [base] });
+    expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, pathContext: "packages/core" }], operations: [] })).toMatchObject({ version: 4, theaters: [base] });
+    expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, pathContext: "../escape" }], operations: [] })).toMatchObject({ version: 4, theaters: [base] });
   });
 
   it("round-trips optional Theater order without changing durable version", () => {
     const base = { id: "t", path: "/work/proj", realpath: "/work/proj", label: "proj", registeredAt: "1", lastOpenedAt: "2" };
 
     expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, order: 3 }], operations: [] })).toMatchObject({
-      version: 3,
+      version: 4,
       theaters: [{ ...base, order: 3 }],
     });
     expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, order: -1 }], operations: [] })).toMatchObject({
-      version: 3,
+      version: 4,
       theaters: [base],
     });
     expect(sanitizeDurableConsoleState({ version: 2, theaters: [{ ...base, order: 1.5 }], operations: [] })).toMatchObject({
-      version: 3,
+      version: 4,
       theaters: [base],
     });
   });
@@ -70,7 +70,7 @@ describe("durable console state", () => {
       ],
     });
 
-    expect(migrated.version).toBe(3);
+    expect(migrated.version).toBe(4);
     expect(migrated.theaters).toHaveLength(1);
     expect(migrated.groups).toEqual([]);
     expect(migrated.operations).toEqual([
@@ -138,13 +138,51 @@ describe("durable console state", () => {
     });
 
     expect(sanitizeDurableConsoleState({ version: 2, theaters: [theater], operations: [operation], groups: [] })).toMatchObject({
-      version: 3,
+      version: 4,
       deletionTombstones: [],
+      workspacePresets: [],
     });
     expect(sanitized.deletionTombstones).toEqual([
       expect.objectContaining({ deletionId: "d-op", kind: "operation", targetId: "op" }),
-      expect.objectContaining({ deletionId: "d-theater", kind: "theater", targetId: "t", operations: [expect.objectContaining({ id: "op" })] }),
+      expect.objectContaining({ deletionId: "d-theater", kind: "theater", targetId: "t", operations: [expect.objectContaining({ id: "op" })], workspacePresets: [] }),
     ]);
+  });
+
+  it("migrates v3 to v4 through the sequential chain and sanitizes presets item by item", () => {
+    const layout = makeWorkspacePresetLayout();
+    const valid = {
+      id: "preset-a",
+      theaterId: "theater",
+      name: "Review",
+      createdAt: 1,
+      updatedAt: 2,
+      layout,
+    };
+
+    const migrated = sanitizeDurableConsoleState({
+      version: 3,
+      theaters: [],
+      operations: [],
+      groups: [],
+      deletionTombstones: [],
+    });
+    const sanitized = sanitizeDurableConsoleState({
+      version: 4,
+      theaters: [],
+      operations: [],
+      groups: [],
+      deletionTombstones: [],
+      workspacePresets: [
+        valid,
+        { ...valid, id: "bad-name", name: "x".repeat(65) },
+        { ...valid, id: "bad-viewport", layout: { ...layout, viewport: { ...layout.viewport, zoom: Number.NaN } } },
+        { ...valid, id: "bad-geometry", layout: { ...layout, operationGeometries: { op: { ...layout.operationGeometries.op, width: "wide" } } } },
+        { ...valid, id: "bad-panel", layout: { ...layout, rail: { ...layout.rail, panelWidth: Number.POSITIVE_INFINITY } } },
+      ],
+    });
+
+    expect(migrated).toMatchObject({ version: 4, workspacePresets: [] });
+    expect(sanitized.workspacePresets).toEqual([valid]);
   });
 
   it("creates the state store with sensitive durable JSON settings", () => {
@@ -191,5 +229,17 @@ function makeOperationNode(input: { readonly id: string; readonly pluginId: stri
     geometry: null,
     state: {},
     ts: { createdAt: 1, updatedAt: 1 },
+  };
+}
+
+function makeWorkspacePresetLayout() {
+  return {
+    viewport: { x: 12, y: -4, zoom: 0.8 },
+    operationGeometries: {
+      op: { x: 1, y: 2, width: 640, height: 400, zIndex: 3 },
+    },
+    minimizedOperationIds: ["op"],
+    rail: { activePanelId: "plans", chromeExpanded: true, panelWidth: 420 },
+    sidebar: { statusAxis: "status" as const },
   };
 }

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -674,6 +674,7 @@ describe("Instrument core design contract", () => {
     expect(components).not.toContain(".side-bar-formation-group {");
     expect(components).not.toContain(".side-bar-theater-add-btn {");
     expect(layout).toContain(".command-band-formation-group {");
+    expect(layout).toContain("z-index: 48;");
     expect(layout).toContain("left: calc(var(--command-band-left-width, 280px) + var(--space-2));");
     expect(layout).not.toContain(".command-band-formation-group .command-band-formation-seg + .command-band-formation-seg {");
     expect(commandBand).toContain('"--command-band-left-width": `${sideBar.width}px`');

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -45,11 +45,13 @@ vi.mock("../core/client/src/rail/use-codex-split-extra-width.js", () => ({
 
 import { RightRail } from "../core/client/src/rail/right-rail.js";
 import {
+  applyRailPreset,
   getRailStoreSnapshot,
   requestRailPanelExtraWidth,
   setActiveRailPanel,
   setRailOverlayAlpha,
   setRailPanelBehavior,
+  setRailChromeExpanded,
 } from "../core/client/src/rail/rail-store.js";
 
 let container: HTMLDivElement;
@@ -64,6 +66,7 @@ beforeEach(() => {
   requestRailPanelExtraWidth("plans", null);
   setRailPanelBehavior("push");
   setRailOverlayAlpha(100);
+  setRailChromeExpanded(true);
   container = document.createElement("div");
   document.body.replaceChildren(container);
   root = createRoot(container);
@@ -104,6 +107,22 @@ describe("Right Rail overlay opacity presets", () => {
 });
 
 describe("Right Rail panel width", () => {
+  it("applies preset width before remembered/default values, updates memory, and leaves the preset immutable after manual resize", () => {
+    window.localStorage.setItem("fleet-console.rail.panelWidths", JSON.stringify({ plans: 508 }));
+    renderRail();
+    const presetRail = { activePanelId: "plans", chromeExpanded: true, panelWidth: 620 } as const;
+
+    act(() => applyRailPreset(presetRail));
+
+    expect(renderedPanelWidth()).toBe(620);
+    expect(storedPanelWidths()).toEqual({ plans: 620 });
+
+    dispatchResizeKey(resizeHandle(), "ArrowLeft");
+    expect(renderedPanelWidth()).toBe(636);
+    expect(storedPanelWidths()).toEqual({ plans: 636 });
+    expect(presetRail.panelWidth).toBe(620);
+  });
+
   it("resolves remembered width before descriptor defaultWidth and the 312 fallback", () => {
     window.localStorage.setItem("fleet-console.rail.panelWidths", JSON.stringify({ plans: 508 }));
     renderRail();

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -1364,7 +1364,7 @@ describe("console static and terminal ticket boundary", () => {
     });
     const stateFile = path.join(fixture.carrierStoreDir, "console", "state.json");
     const state = JSON.parse(fs.readFileSync(stateFile, "utf8")) as { version: number; operations: Array<{ id?: string; pluginId?: string; type?: string; payload?: { providerSession?: unknown } }> };
-    expect(state.version).toBe(3);
+    expect(state.version).toBe(4);
     expect(state.operations).toHaveLength(1);
     expect(state.operations[0]).toMatchObject({ id: session.sessionId, pluginId: "terminal", type: "agent" });
     expect(state.operations[0]?.payload?.providerSession).toBeUndefined();
@@ -2779,7 +2779,7 @@ describe("observer theater order", () => {
     expect(patched.status).toBe(200);
     expect(patchedBody).toMatchObject({ id: theater.id, order: 3 });
     expect(listed.theaters.find((entry) => entry.id === theater.id)?.order).toBe(3);
-    expect(state.version).toBe(3);
+    expect(state.version).toBe(4);
     expect(state.theaters.find((entry) => entry.id === theater.id)?.order).toBe(3);
 
     await fixture.server.stop();

--- a/runtime/fleet-console/tests/workspace-preset-layout.test.ts
+++ b/runtime/fleet-console/tests/workspace-preset-layout.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getSnapshot as getCanvasSnapshot, loadForTheater, setState as setCanvasState } from "../core/client/src/canvas/canvas-store.js";
+import { getRailStoreSnapshot, setActiveRailPanel, setRailChromeExpanded } from "../core/client/src/rail/rail-store.js";
+import { getSideBarStatusAxis, setSideBarStatusAxis } from "../core/client/src/sidebar/operations-side-bar-store.js";
+import type { WorkspacePresetApplyResult } from "../core/client/src/types.js";
+import { applyWorkspacePresetClientLayout } from "../core/client/src/workspace-preset-layout.js";
+
+describe("Workspace Preset client layout", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    loadForTheater("theater");
+    setCanvasState({
+      viewport: { x: 0, y: 0, zoom: 1 },
+      operations: {
+        "op-a": { x: 0, y: 0, width: 400, height: 300, zIndex: 1 },
+        "op-new": { x: 30, y: 30, width: 500, height: 320, zIndex: 2 },
+      },
+      minimized: ["op-new"],
+    });
+    setActiveRailPanel("plans");
+    setRailChromeExpanded(false);
+    setSideBarStatusAxis(false);
+  });
+
+  it("partially applies core state, preserves the rail for an unavailable panel, and returns a warning", () => {
+    const previousRail = getRailStoreSnapshot();
+    const result = makeApplyResult("missing-plugin");
+
+    const warning = applyWorkspacePresetClientLayout(result, ["op-a", "op-new"], new Set(["plans"]));
+
+    expect(getCanvasSnapshot()).toMatchObject({
+      viewport: { x: 12, y: -8, zoom: 0.8 },
+      operations: {
+        "op-a": { x: 100, y: 120, width: 640, height: 400, zIndex: 8 },
+        "op-new": { x: 30, y: 30, width: 500, height: 320, zIndex: 2 },
+      },
+      minimized: ["op-a"],
+    });
+    expect(getSideBarStatusAxis()).toBe(true);
+    expect(getRailStoreSnapshot()).toMatchObject({
+      activeRailPanelId: previousRail.activeRailPanelId,
+      railChromeExpanded: previousRail.railChromeExpanded,
+      currentPanelWidth: previousRail.currentPanelWidth,
+    });
+    expect(warning).toBe("Panel “missing-plugin” is not installed; the current rail was preserved. 1 missing operation skipped.");
+  });
+
+  it("applies an installed panel and queues the preset width without mutating the preset", () => {
+    const result = makeApplyResult("plans");
+
+    const warning = applyWorkspacePresetClientLayout(result, ["op-a", "op-new"], new Set(["plans"]));
+
+    expect(warning).toBe("1 missing operation skipped.");
+    expect(getRailStoreSnapshot()).toMatchObject({
+      activeRailPanelId: "plans",
+      railChromeExpanded: true,
+      presetPanelWidthRequest: { panelId: "plans", width: 520 },
+    });
+    expect(result.preset.layout.rail.panelWidth).toBe(520);
+  });
+});
+
+function makeApplyResult(activePanelId: string): WorkspacePresetApplyResult {
+  return {
+    preset: {
+      id: "preset",
+      theaterId: "theater",
+      name: "Review",
+      createdAt: 1,
+      updatedAt: 1,
+      layout: {
+        viewport: { x: 12, y: -8, zoom: 0.8 },
+        operationGeometries: {
+          "op-a": { x: 100, y: 120, width: 640, height: 400, zIndex: 8 },
+          "op-missing": { x: 40, y: 40, width: 500, height: 320, zIndex: 3 },
+        },
+        minimizedOperationIds: ["op-a", "op-missing"],
+        rail: { activePanelId, chromeExpanded: true, panelWidth: 520 },
+        sidebar: { statusAxis: "status" },
+      },
+    },
+    appliedOperationIds: ["op-a"],
+    missingOperationIds: ["op-missing"],
+  };
+}

--- a/runtime/fleet-console/tests/workspace-presets-routes.test.ts
+++ b/runtime/fleet-console/tests/workspace-presets-routes.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createOperationStore } from "../core/host/operations/store.js";
+import { TheaterRegistry, type TheaterRegistration } from "../core/host/theaters.js";
+import { createWorkspacePresetsRouter } from "../core/host/workspace-presets/routes.js";
+import { createWorkspacePresetStore } from "../core/host/workspace-presets/store.js";
+
+const THEATER: TheaterRegistration = {
+  id: "theater",
+  path: "/work/theater",
+  realpath: "/work/theater",
+  label: "theater",
+  registeredAt: "2026-01-01T00:00:00.000Z",
+  lastOpenedAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("Workspace Preset routes", () => {
+  let body: unknown;
+  let authorized: boolean;
+  let harness: ReturnType<typeof createHarness>;
+
+  beforeEach(() => {
+    body = null;
+    authorized = true;
+    harness = createHarness(
+      () => body,
+      () => authorized,
+    );
+  });
+
+  it("supports Theater-scoped CRUD behind the existing write gate without path-bearing DTOs", async () => {
+    body = { name: "Review", layout: makeLayout() };
+    const created = await request("POST", "/api/v1/theaters/theater/workspace-presets");
+    expect(created.status).toBe(201);
+    const preset = (created.payload as { readonly workspacePreset: { readonly id: string } }).workspacePreset;
+    expect(harness.persist).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(created.payload)).not.toContain(THEATER.path);
+    expect(JSON.stringify(created.payload)).not.toMatch(/"(?:cwd|realpath|providerSession|transcriptPath)":/);
+
+    const listed = await request("GET", "/api/v1/theaters/theater/workspace-presets");
+    expect(listed).toMatchObject({ status: 200, payload: { workspacePresets: [{ id: preset.id, name: "Review" }] } });
+
+    body = { name: "Implementation" };
+    const renamed = await request("PATCH", `/api/v1/theaters/theater/workspace-presets/${preset.id}`);
+    expect(renamed).toMatchObject({ status: 200, payload: { workspacePreset: { id: preset.id, name: "Implementation" } } });
+
+    const deleted = await request("DELETE", `/api/v1/theaters/theater/workspace-presets/${preset.id}`);
+    expect(deleted).toEqual({ status: 200, payload: { ok: true } });
+    expect(harness.store.list(THEATER.id)).toEqual([]);
+
+    authorized = false;
+    body = { name: "Denied", layout: makeLayout() };
+    await expect(request("POST", "/api/v1/theaters/theater/workspace-presets")).resolves.toEqual({
+      status: 401,
+      payload: { error: "unauthorized" },
+    });
+  });
+
+  it("applies only the current Theater intersection with one persistence and reports missing ids", async () => {
+    const sourceLayout = makeLayout();
+    const preset = harness.store.create(THEATER.id, "Review", sourceLayout);
+    harness.operations.create(makeOperation("op-a"));
+    harness.operations.create(makeOperation("op-new"));
+    const originalPresetGeometry = preset.layout.operationGeometries["op-a"];
+
+    const response = await request("POST", `/api/v1/theaters/theater/workspace-presets/${preset.id}/apply`);
+
+    expect(response).toMatchObject({
+      status: 200,
+      payload: {
+        preset: { id: preset.id, name: "Review" },
+        appliedOperationIds: ["op-a"],
+        missingOperationIds: ["op-missing"],
+      },
+    });
+    expect(harness.operations.get("op-a")?.geometry).toEqual(sourceLayout.operationGeometries["op-a"]);
+    expect(harness.operations.get("op-a")?.geometry).not.toBe(originalPresetGeometry);
+    expect(harness.operations.get("op-new")?.geometry).toBeNull();
+    expect(harness.store.get(THEATER.id, preset.id)).toEqual(preset);
+    expect(harness.persist).toHaveBeenCalledTimes(1);
+  });
+
+  async function request(method: string, pathname: string): Promise<{ readonly status: number; readonly payload: unknown }> {
+    harness.writeJson.mockClear();
+    await harness.router({
+      req: { method } as never,
+      res: {} as never,
+      pathname,
+    });
+    const call = harness.writeJson.mock.calls.at(-1);
+    if (!call) throw new Error("expected JSON response");
+    return { status: call[1] as number, payload: call[2] };
+  }
+});
+
+function createHarness(readBody: () => unknown, isAuthorized: () => boolean) {
+  const clock = { value: 1_000 };
+  const theaters = new TheaterRegistry();
+  theaters.restore([THEATER]);
+  const operations = createOperationStore({ now: () => clock.value });
+  const store = createWorkspacePresetStore({
+    now: () => clock.value++,
+    randomId: () => `preset-${clock.value}`,
+  });
+  const persist = vi.fn();
+  const writeJson = vi.fn();
+  const router = createWorkspacePresetsRouter({
+    store,
+    operations,
+    theaters,
+    isAuthorized: () => isAuthorized(),
+    readJsonBody: async () => readBody() as never,
+    writeJson,
+    persist,
+  });
+  return { operations, persist, router, store, writeJson };
+}
+
+function makeLayout() {
+  return {
+    viewport: { x: 4, y: 8, zoom: 0.75 },
+    operationGeometries: {
+      "op-a": { x: 10, y: 20, width: 600, height: 360, zIndex: 4 },
+      "op-missing": { x: 30, y: 40, width: 500, height: 320, zIndex: 5 },
+    },
+    minimizedOperationIds: ["op-a"],
+    rail: { activePanelId: "plans", chromeExpanded: true, panelWidth: 440 },
+    sidebar: { statusAxis: "status" as const },
+  };
+}
+
+function makeOperation(id: string) {
+  return {
+    id,
+    theaterId: THEATER.id,
+    type: "agent",
+    pluginId: "terminal",
+    title: id,
+    payload: { cwd: THEATER.path },
+    geometry: null,
+  };
+}


### PR DESCRIPTION
## Summary

승인된 신규 기능 N2입니다.

- **실측된 결함.** 새 창은 `+40px`씩 계단식으로 겹쳐 떴고(7창 실측 x=192→419, 각 614×384라 마지막 창만 온전히 보임), Formation은 Grid/Columns/Rows 즉석 타일링 3종뿐이라 **이름으로 저장하거나 되돌릴 수 없었습니다.** 사용자는 하루에 몇 가지 모드로 일하는데(리뷰할 때·구현할 때·지켜볼 때) 매번 창을 다시 끌고 패널을 다시 열어야 했습니다.
- **저장 대상**은 창 geometry, 열린 레일 패널과 그 폭, 사이드바 상태축입니다. v1은 **코어 소유 상태로 한정**했습니다 — 플러그인 내부 선택·필터·스크롤을 넣으면 플러그인 serializer와 부분 복원 계약이 SDK 표면으로 올라옵니다.
- **geometry는 값 복사 스냅샷**입니다. 적용은 현재 Theater와 교집합인 Operation에만 하고 사라진 ID는 `missingOperationIds`로 돌려줍니다(전체 실패가 아니라 부분 적용). 설치되지 않은 panel ID도 현재 rail을 보존하고 경고만 냅니다.
- **레일 폭 계층**은 적용 중인 preset 폭 > 패널별 기억 폭 > descriptor `defaultWidth` > 312입니다. preset을 적용하면 기억 값도 함께 갱신되고, 이후 수동 resize는 기억 값만 바꾸며 preset 원본은 그대로입니다.
- **Theater tombstone에 preset을 함께 담아**, forget을 되돌리면 배치도 같이 돌아옵니다.
- durable state를 #378의 `version: 3` 위에 **`version: 4`로 순차 승격**합니다(v1→v2→v3→v4).

#378이 머지되어 이 브랜치는 canary로 리베이스했고, 이제 자기 커밋만 남습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 0 errors
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `workspace-presets-routes` · `workspace-preset-layout` · `durable-state` · `deferred-deletion` · `right-rail` · `api-catalog` — 41 passed
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 39 entries validated
- [x] Changelog fragment — `.changelog.d/pr-385.md`

### 선존 실패 (이 PR과 무관)

`tests/server.test.ts > … issues Theater-bound dedicated MCP sessions …` 1건. base에서 동일하게 재현되며 이 어설션이 도입된 #353 시점에도 실패합니다.

실서버를 띄우는 테스트는 동시 vitest 실행과 겹치면 타임아웃으로 가짜 실패하므로, 위 결과는 해당 파일 단독 실행 기준입니다.