### PR TITLE
feat(console): recency-ordered status sections with unseen idle marks

### DIFF
--- a/.changelog.d/pr-386.md
+++ b/.changelog.d/pr-386.md
@@ -1,0 +1,8 @@
+### fleet-console
+#### Changed
+- [fleet-console] Order each sidebar status section by the most recent transition, keeping untouched operations in their manual order.
+  ko: 사이드바 상태 섹션을 가장 최근 전이 순으로 정렬하고, 전이되지 않은 Operation은 기존 순서를 유지합니다.
+- [fleet-console] Mark operations that land in IDLE with a session-only unseen dot and section header count until you open them once.
+  ko: IDLE로 전이된 Operation에 세션 한정 미확인 점과 섹션 헤더 카운트를 표시하고, 한 번 열면 해제합니다.
+- [fleet-console] Shorten the first status section header from "AWAITING INPUT" to "AWAITING".
+  ko: 첫 상태 섹션 헤더를 "AWAITING INPUT"에서 "AWAITING"으로 줄였습니다.

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -21,7 +21,7 @@ import { toggleRailChrome } from "./rail/rail-store.js";
 import { refreshObserverStatus } from "./operations-sse.js";
 import { closeKeyboardShortcuts, hydrateGroups, hydrateInitialOperations, hydrateOperations, hydrateTheaterBootstrap, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
 import { abortReleaseNotesFetch, requestReleaseNotes } from "./release-notes-fetch.js";
-import { getSideBarState, setSideBarCollapsed } from "./sidebar/operations-side-bar-store.js";
+import { getSideBarState, setSideBarCollapsed, trackOperationActivityTransitions } from "./sidebar/operations-side-bar-store.js";
 import { resolveReleaseNotesLocale } from "./whatsnew-i18n.js";
 
 // 서버는 부팅 시 update 체크를 fire-and-forget으로 시작하므로, 첫 방문이 SSE 연결보다
@@ -68,6 +68,15 @@ export function App() {
   useEffect(() => {
     setOperationsViewActive(operationsViewVisible);
   }, [operationsViewVisible]);
+
+  useEffect(() => {
+    trackOperationActivityTransitions({
+      operations: state.operations,
+      operationStatus: state.operationStatus,
+      activeTheaterId: state.activeTheaterId,
+      activeOperationId: state.activeOperationId,
+    });
+  }, [state.operations, state.operationStatus, state.activeTheaterId, state.activeOperationId]);
 
   useEffect(() => {
     const abort = new AbortController();

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -21,7 +21,7 @@ import { toggleRailChrome } from "./rail/rail-store.js";
 import { refreshObserverStatus } from "./operations-sse.js";
 import { closeKeyboardShortcuts, hydrateGroups, hydrateInitialOperations, hydrateOperations, hydrateTheaterBootstrap, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
 import { abortReleaseNotesFetch, requestReleaseNotes } from "./release-notes-fetch.js";
-import { getSideBarState, setSideBarCollapsed, trackOperationActivityTransitions } from "./sidebar/operations-side-bar-store.js";
+import { getSideBarState, setSideBarCollapsed, subscribeOperationActivityTracking } from "./sidebar/operations-side-bar-store.js";
 import { resolveReleaseNotesLocale } from "./whatsnew-i18n.js";
 
 // 서버는 부팅 시 update 체크를 fire-and-forget으로 시작하므로, 첫 방문이 SSE 연결보다
@@ -69,14 +69,7 @@ export function App() {
     setOperationsViewActive(operationsViewVisible);
   }, [operationsViewVisible]);
 
-  useEffect(() => {
-    trackOperationActivityTransitions({
-      operations: state.operations,
-      operationStatus: state.operationStatus,
-      activeTheaterId: state.activeTheaterId,
-      activeOperationId: state.activeOperationId,
-    });
-  }, [state.operations, state.operationStatus, state.activeTheaterId, state.activeOperationId]);
+  useEffect(() => subscribeOperationActivityTracking(), []);
 
   useEffect(() => {
     const abort = new AbortController();

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -14,7 +14,7 @@ import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { RightRail } from "../rail/right-rail.js";
 import { OperationsSideBar } from "../sidebar/operations-side-bar.js";
-import { getSideBarStatusAxis, getSideBarStatusSectionCollapsed, toggleSideBarStatusAxis } from "../sidebar/operations-side-bar-store.js";
+import { getSideBarStatusAxis, getSideBarStatusSectionCollapsed, getStatusTransitionTick, toggleSideBarStatusAxis } from "../sidebar/operations-side-bar-store.js";
 import { CodexReadingSheet } from "../components/codex-reading-sheet.js";
 import { shouldHandleOperationsKeyboardShortcut } from "../components/keyboard-shortcuts-dialog.js";
 import { beginAddTheater, cancelAddTheater, compareOperationCreatedAt, completeAddTheater, consumeOperationFocus, failAddTheater, focusCycleOperationIds, focusOperation, getState, hydrateGroups, hydrateOperations, hydrateTheaters, nextOperationId, removeTheater, requestOperationKeyboardFocus, setActiveOperation, setActiveTheater, sortOperationsByOrder, statusCycleOperationIds } from "../store.js";
@@ -92,6 +92,7 @@ export function Operations({ state, claimBootPanelMinimization }: OperationsProp
             canvas.minimized,
             (status) => snapshot.activeTheaterId !== null
               && getSideBarStatusSectionCollapsed(snapshot.activeTheaterId, status, false),
+            getStatusTransitionTick,
           )
         : focusCycleOperationIds(
             theaterOperations,

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -26,6 +26,7 @@ interface SideBarChipProps {
   readonly accentValue: string | null;
   readonly groupMark?: { readonly name: string; readonly color: string } | null;
   readonly statusAxis?: boolean;
+  readonly idleUnseen?: boolean;
   readonly statusLanded?: boolean;
   readonly reorderEnabled?: boolean;
   readonly dragging: boolean;
@@ -56,6 +57,7 @@ export function OperationsSideBarChip({
   accentValue,
   groupMark = null,
   statusAxis = false,
+  idleUnseen = false,
   statusLanded = false,
   reorderEnabled = true,
   dragging,
@@ -77,9 +79,10 @@ export function OperationsSideBarChip({
   const { operation, active, minimized, notificationCount, status } = entry;
   const title = displayTitle(operation);
   const groupContext = statusAxis && groupMark ? ` in group ${groupMark.name}` : "";
+  const unseenContext = idleUnseen ? " (unseen since idle)" : "";
   const chipAriaLabel = active
-    ? `${title}${groupContext} (focused)`
-    : `Focus operation ${title}${groupContext}`;
+    ? `${title}${groupContext} (focused)${unseenContext}`
+    : `Focus operation ${title}${groupContext}${unseenContext}`;
   const rename = useInlineRename({ currentTitle: title, onCommit: (next) => onRename(operation.id, next), onBegin: onDisarmClose });
   const chipClassName = [
     "side-bar-chip",
@@ -226,6 +229,14 @@ export function OperationsSideBarChip({
           title={groupMark.name}
           aria-label={`Group ${groupMark.name}`}
           style={{ "--group-mark": groupMark.color } as CSSProperties}
+        />
+      ) : null}
+      {statusAxis && idleUnseen ? (
+        <span
+          className="side-bar-chip-unseen"
+          role="img"
+          aria-label="Unseen since idle"
+          title="Finished — not opened yet"
         />
       ) : null}
       {!statusAxis ? (

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
@@ -3,6 +3,7 @@ import { useCallback, useSyncExternalStore } from "react";
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
 
 import { resolveOperationActivity } from "../operation-activity.js";
+import { getState, subscribe } from "../store.js";
 import type { OperationNode } from "../types.js";
 
 interface SideBarState {
@@ -38,6 +39,7 @@ let statusTransitionTicks = new Map<string, number>();
 let idleUnseenIds = new Set<string>();
 let previousActivityById = new Map<string, SideBarStatus>();
 let baselinedLiveActivityIds = new Set<string>();
+let pendingStatusLandingIds = new Set<string>();
 
 export type SideBarStatus = "awaiting" | "running" | "idle" | "dormant";
 
@@ -201,6 +203,7 @@ export function trackOperationActivityTransitions(input: {
     .map((operation) => operation.id);
 
   recordStatusTransitions(movedIds);
+  movedIds.forEach((id) => pendingStatusLandingIds.add(id));
   for (const operation of input.operations) {
     if (!movedIds.includes(operation.id)) continue;
     if (nextStatuses.get(operation.id) === "idle") {
@@ -221,6 +224,24 @@ export function trackOperationActivityTransitions(input: {
   return movedIds;
 }
 
+export function consumeStatusLandings(): readonly string[] {
+  const landedIds = Array.from(pendingStatusLandingIds);
+  pendingStatusLandingIds = new Set();
+  return landedIds;
+}
+
+export function subscribeOperationActivityTracking(): () => void {
+  return subscribe(() => {
+    const state = getState();
+    trackOperationActivityTransitions({
+      operations: state.operations,
+      operationStatus: state.operationStatus,
+      activeTheaterId: state.activeTheaterId,
+      activeOperationId: state.activeOperationId,
+    });
+  });
+}
+
 export function resetSideBarStatusSectionCollapseForTests(): void {
   userCollapsedStatusSections = new Set();
   userExpandedStatusSections = new Set();
@@ -232,6 +253,7 @@ export function resetSideBarStatusRecencyForTests(): void {
   idleUnseenIds = new Set();
   previousActivityById = new Map();
   baselinedLiveActivityIds = new Set();
+  pendingStatusLandingIds = new Set();
 }
 
 function statusSectionKey(theaterId: string, status: SideBarStatus): string {

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
@@ -28,6 +28,9 @@ let statusAxis = false;
 // 접기/펼치기를 구분하려고 두 집합을 유지하며 localStorage에는 기록하지 않는다.
 let userCollapsedStatusSections = new Set<string>();
 let userExpandedStatusSections = new Set<string>();
+let statusTransitionCounter = 0;
+let statusTransitionTicks = new Map<string, number>();
+let idleUnseenIds = new Set<string>();
 
 export type SideBarStatus = "awaiting" | "running" | "idle" | "dormant";
 
@@ -140,9 +143,35 @@ export function subscribeStatusSectionCollapse(listener: () => void): () => void
   return () => statusSectionCollapseListeners.delete(listener);
 }
 
+export function recordStatusTransitions(ids: readonly string[]): void {
+  for (const id of ids) statusTransitionTicks.set(id, ++statusTransitionCounter);
+}
+
+export function getStatusTransitionTick(id: string): number | undefined {
+  return statusTransitionTicks.get(id);
+}
+
+export function markIdleUnseen(id: string): void {
+  idleUnseenIds.add(id);
+}
+
+export function clearIdleUnseen(id: string): void {
+  idleUnseenIds.delete(id);
+}
+
+export function getIdleUnseenIds(): ReadonlySet<string> {
+  return idleUnseenIds;
+}
+
 export function resetSideBarStatusSectionCollapseForTests(): void {
   userCollapsedStatusSections = new Set();
   userExpandedStatusSections = new Set();
+}
+
+export function resetSideBarStatusRecencyForTests(): void {
+  statusTransitionCounter = 0;
+  statusTransitionTicks = new Map();
+  idleUnseenIds = new Set();
 }
 
 function statusSectionKey(theaterId: string, status: SideBarStatus): string {

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
@@ -1,5 +1,10 @@
 import { useCallback, useSyncExternalStore } from "react";
 
+import type { OperationActivity } from "@fleet-console/sdk/plugin";
+
+import { resolveOperationActivity } from "../operation-activity.js";
+import type { OperationNode } from "../types.js";
+
 interface SideBarState {
   readonly width: number;
   readonly collapsed: boolean;
@@ -31,6 +36,8 @@ let userExpandedStatusSections = new Set<string>();
 let statusTransitionCounter = 0;
 let statusTransitionTicks = new Map<string, number>();
 let idleUnseenIds = new Set<string>();
+let previousActivityById = new Map<string, SideBarStatus>();
+let baselinedLiveActivityIds = new Set<string>();
 
 export type SideBarStatus = "awaiting" | "running" | "idle" | "dormant";
 
@@ -163,6 +170,57 @@ export function getIdleUnseenIds(): ReadonlySet<string> {
   return idleUnseenIds;
 }
 
+export function trackOperationActivityTransitions(input: {
+  readonly operations: readonly OperationNode[];
+  readonly operationStatus: Readonly<Record<string, OperationActivity>>;
+  readonly activeTheaterId: string | null;
+  readonly activeOperationId: string | null;
+}): readonly string[] {
+  const nextStatuses = new Map<string, SideBarStatus>(
+    input.operations.map((operation) => [
+      operation.id,
+      resolveOperationActivity(operation, input.operationStatus),
+    ]),
+  );
+  const firstLiveIds = input.operations
+    .filter((operation) => {
+      if (input.operationStatus[operation.id] === undefined || baselinedLiveActivityIds.has(operation.id)) {
+        return false;
+      }
+      baselinedLiveActivityIds.add(operation.id);
+      return true;
+    })
+    .map((operation) => operation.id);
+  const movedIds = input.operations
+    .filter((operation) => {
+      const previous = previousActivityById.get(operation.id);
+      return previous !== undefined
+        && previous !== nextStatuses.get(operation.id)
+        && !firstLiveIds.includes(operation.id);
+    })
+    .map((operation) => operation.id);
+
+  recordStatusTransitions(movedIds);
+  for (const operation of input.operations) {
+    if (!movedIds.includes(operation.id)) continue;
+    if (nextStatuses.get(operation.id) === "idle") {
+      if (!(operation.id === input.activeOperationId && operation.theaterId === input.activeTheaterId)) {
+        markIdleUnseen(operation.id);
+      }
+    } else {
+      clearIdleUnseen(operation.id);
+    }
+  }
+  if (input.activeOperationId !== null) {
+    const activeOp = input.operations.find((operation) => operation.id === input.activeOperationId);
+    if (activeOp !== undefined && activeOp.theaterId === input.activeTheaterId) {
+      clearIdleUnseen(input.activeOperationId);
+    }
+  }
+  previousActivityById = nextStatuses;
+  return movedIds;
+}
+
 export function resetSideBarStatusSectionCollapseForTests(): void {
   userCollapsedStatusSections = new Set();
   userExpandedStatusSections = new Set();
@@ -172,6 +230,8 @@ export function resetSideBarStatusRecencyForTests(): void {
   statusTransitionCounter = 0;
   statusTransitionTicks = new Map();
   idleUnseenIds = new Set();
+  previousActivityById = new Map();
+  baselinedLiveActivityIds = new Set();
 }
 
 function statusSectionKey(theaterId: string, status: SideBarStatus): string {

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -24,10 +24,15 @@ import {
 import { OperationsSideBarChip, type SideBarEntry } from "./operations-side-bar-chip.js";
 import { OperationsSideBarGroupHeader } from "./operations-side-bar-group-header.js";
 import {
+  clearIdleUnseen,
+  getIdleUnseenIds,
   setSideBarCollapsed,
   setSideBarWidth,
   setTheaterCollapsed,
+  getStatusTransitionTick,
   getSideBarStatusSectionCollapsed,
+  markIdleUnseen,
+  recordStatusTransitions,
   toggleSideBarStatusAxis,
   toggleSideBarStatusSectionCollapsed,
   useCollapsedTheaters,
@@ -196,12 +201,12 @@ const STATUS_LANDING_DURATION_MS = 500;
 
 interface StatusSection {
   readonly status: SideBarStatus;
-  readonly label: "AWAITING INPUT" | "RUNNING" | "IDLE" | "DORMANT";
+  readonly label: "AWAITING" | "RUNNING" | "IDLE" | "DORMANT";
   readonly entries: readonly SideBarEntry[];
 }
 
 const STATUS_SECTION_ORDER: readonly Omit<StatusSection, "entries">[] = [
-  { status: "awaiting", label: "AWAITING INPUT" },
+  { status: "awaiting", label: "AWAITING" },
   { status: "running", label: "RUNNING" },
   { status: "idle", label: "IDLE" },
   { status: "dormant", label: "DORMANT" },
@@ -210,10 +215,12 @@ const STATUS_SECTION_ORDER: readonly Omit<StatusSection, "entries">[] = [
 function StatusSectionSlot({
   theaterId,
   section,
+  unseenCount = 0,
   children,
 }: {
   readonly theaterId: string;
   readonly section: StatusSection;
+  readonly unseenCount?: number;
   readonly children: ReactNode;
 }) {
   const empty = section.entries.length === 0;
@@ -239,6 +246,7 @@ function StatusSectionSlot({
         </button>
         <span className="side-bar-status-header__dot" aria-hidden="true" />
         <span className="side-bar-status-header__label">{section.label}</span>
+        {unseenCount > 0 ? <span className="side-bar-status-header__unseen">{unseenCount}</span> : null}
         <span className="side-bar-status-header__count">{section.entries.length}</span>
       </div>
       {!collapsed ? (
@@ -345,7 +353,9 @@ export function OperationsSideBar({
     };
   });
   const groupedSections = groupOperations(allEntries, activeGroups, canvas.operationOrder);
-  const statusSections = groupOperationsByStatus(allEntries);
+  const statusSections = groupOperationsByStatus(allEntries, getStatusTransitionTick);
+  const idleUnseenIds = getIdleUnseenIds();
+  const isIdleUnseen = (id: string) => id !== activeOperationId && idleUnseenIds.has(id);
   // STATUS 축 렌더는 entry/그룹 조회가 칩마다 반복되므로 O(n²)를 피해 Map으로 한 번만 인덱싱한다.
   const entryIndexById = new Map(allEntries.map((entry, index) => [entry.operation.id, index] as const));
   const groupMarkByGroupId = new Map(activeGroups.map((group) => {
@@ -425,18 +435,26 @@ export function OperationsSideBar({
     );
     const previousStatuses = previousOperationStatusRef.current;
     previousOperationStatusRef.current = nextStatuses;
-    if (!statusAxis) {
-      for (const timeoutId of statusLandingTimeoutsRef.current) window.clearTimeout(timeoutId);
-      statusLandingTimeoutsRef.current.clear();
-      setStatusLandingIds((current) => current.size === 0 ? current : new Set());
-      return;
-    }
     const movedIds = operations
       .filter((operation) => {
         const previous = previousStatuses.get(operation.id);
         return previous !== undefined && previous !== nextStatuses.get(operation.id);
       })
       .map((operation) => operation.id);
+    recordStatusTransitions(movedIds);
+    for (const id of movedIds) {
+      if (nextStatuses.get(id) === "idle") {
+        if (id !== activeOperationId) markIdleUnseen(id);
+      } else {
+        clearIdleUnseen(id);
+      }
+    }
+    if (!statusAxis) {
+      for (const timeoutId of statusLandingTimeoutsRef.current) window.clearTimeout(timeoutId);
+      statusLandingTimeoutsRef.current.clear();
+      setStatusLandingIds((current) => current.size === 0 ? current : new Set());
+      return;
+    }
     if (movedIds.length === 0) return;
     // 이동 배치별 독립 타이머: 기존 flash를 취소하지 않고 병합했다가 이 배치의 ID만 만료시킨다.
     setStatusLandingIds((current) => {
@@ -456,6 +474,10 @@ export function OperationsSideBar({
   // statusSignature is the stable primitive dependency for the operation/status map assembled above.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [statusAxis, statusSignature]);
+
+  useEffect(() => {
+    if (activeOperationId !== null) clearIdleUnseen(activeOperationId);
+  }, [activeOperationId]);
 
   useEffect(() => () => {
     for (const timeoutId of statusLandingTimeoutsRef.current) window.clearTimeout(timeoutId);
@@ -927,6 +949,9 @@ export function OperationsSideBar({
                     key={section.status}
                     theaterId={theater.id}
                     section={section}
+                    unseenCount={section.status === "idle"
+                      ? section.entries.filter((entry) => isIdleUnseen(entry.operation.id)).length
+                      : undefined}
                   >
                     {section.entries.map((entry) => {
                       const globalIndex = entryIndexById.get(entry.operation.id) ?? 0;
@@ -942,6 +967,7 @@ export function OperationsSideBar({
                           accentValue={accentValue}
                           groupMark={groupMark}
                           statusAxis
+                          idleUnseen={isIdleUnseen(entry.operation.id)}
                           statusLanded={statusLandingIds.has(entry.operation.id)}
                           reorderEnabled={false}
                           dragging={false}
@@ -1172,13 +1198,25 @@ export function groupOperations(
   return [...sections, ungrouped];
 }
 
-export function groupOperationsByStatus(entries: readonly SideBarEntry[]): StatusSection[] {
+export function groupOperationsByStatus(
+  entries: readonly SideBarEntry[],
+  getTick?: (id: string) => number | undefined,
+): StatusSection[] {
   return STATUS_SECTION_ORDER.map(({ status, label }) => ({
     status,
     label,
     // entry.status는 엔트리 생성 시점에 resolveOperationActivity로 이미 해소된다.
     // 미해소(undefined) 엔트리의 idle 폭백은 직접 구성된 입력에 대한 방어 계약이다.
-    entries: entries.filter((entry) => (entry.status ?? "idle") === status),
+    entries: entries
+      .filter((entry) => (entry.status ?? "idle") === status)
+      .sort((left, right) => {
+        const leftTick = getTick?.(left.operation.id);
+        const rightTick = getTick?.(right.operation.id);
+        if (leftTick === undefined && rightTick === undefined) return 0;
+        if (leftTick === undefined) return 1;
+        if (rightTick === undefined) return -1;
+        return rightTick - leftTick;
+      }),
   }));
 }
 
@@ -1391,7 +1429,8 @@ function TheaterInactiveSection({
   onPointerDragStart,
 }: TheaterInactiveSectionProps) {
   const sections = groupOperations(entries, groups, []);
-  const statusSections = groupOperationsByStatus(entries);
+  const statusSections = groupOperationsByStatus(entries, getStatusTransitionTick);
+  const idleUnseenIds = getIdleUnseenIds();
   const hasCustomGroups = sections.some((section) => section.group !== null);
   return (
     <li
@@ -1427,6 +1466,9 @@ function TheaterInactiveSection({
               key={section.status}
               theaterId={theater.id}
               section={section}
+              unseenCount={section.status === "idle"
+                ? section.entries.filter((entry) => idleUnseenIds.has(entry.operation.id)).length
+                : undefined}
             >
               {section.entries.map((entry, index) => {
                 const accentKey = operationAccent[entry.operation.id] ?? operationAccentFromNode(entry.operation);
@@ -1440,6 +1482,7 @@ function TheaterInactiveSection({
                     accentValue={accentValue}
                     groupMark={resolveEntryGroupMark(entry, groups)}
                     statusAxis
+                    idleUnseen={idleUnseenIds.has(entry.operation.id)}
                     statusLanded={statusLandingIds.has(entry.operation.id)}
                     reorderEnabled={false}
                     dragging={false}

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -24,15 +24,13 @@ import {
 import { OperationsSideBarChip, type SideBarEntry } from "./operations-side-bar-chip.js";
 import { OperationsSideBarGroupHeader } from "./operations-side-bar-group-header.js";
 import {
-  clearIdleUnseen,
   getIdleUnseenIds,
   setSideBarCollapsed,
   setSideBarWidth,
   setTheaterCollapsed,
   getStatusTransitionTick,
   getSideBarStatusSectionCollapsed,
-  markIdleUnseen,
-  recordStatusTransitions,
+  trackOperationActivityTransitions,
   toggleSideBarStatusAxis,
   toggleSideBarStatusSectionCollapsed,
   useCollapsedTheaters,
@@ -309,8 +307,6 @@ export function OperationsSideBar({
   const canvas = useCanvasState();
   const closeArmTimeoutRef = useRef<number | null>(null);
   const statusLandingTimeoutsRef = useRef<Set<number>>(new Set());
-  const previousOperationStatusRef = useRef<ReadonlyMap<string, SideBarStatus>>(new Map());
-  const baselinedLiveStatusIdsRef = useRef<Set<string>>(new Set());
   const [armedCloseId, setArmedCloseId] = useState<string | null>(null);
   const [statusLandingIds, setStatusLandingIds] = useState<ReadonlySet<string>>(new Set());
   const [drag, setDrag] = useState<DragState | null>(null);
@@ -430,37 +426,15 @@ export function OperationsSideBar({
     disarmClose();
   }, [armedCloseId, allEntries, disarmClose]);
 
+  // React passive effect는 자식부터 실행된다. 사이드바가 마운트된 전이는 여기서 기록+flash하고
+  // 뒤이은 App effect는 멱등 no-op이 되며, 사이드바가 언마운트된 라우트에서는 App effect가 기록한다.
   useEffect(() => {
-    const nextStatuses = new Map(
-      operations.map((operation) => [operation.id, resolveOperationActivity(operation, operationStatus)] as const),
-    );
-    const previousStatuses = previousOperationStatusRef.current;
-    previousOperationStatusRef.current = nextStatuses;
-    const firstLiveIds = operations
-      .filter((operation) => {
-        if (operationStatus[operation.id] === undefined || baselinedLiveStatusIdsRef.current.has(operation.id)) {
-          return false;
-        }
-        baselinedLiveStatusIdsRef.current.add(operation.id);
-        return true;
-      })
-      .map((operation) => operation.id);
-    const movedIds = operations
-      .filter((operation) => {
-        const previous = previousStatuses.get(operation.id);
-        return previous !== undefined
-          && previous !== nextStatuses.get(operation.id)
-          && !firstLiveIds.includes(operation.id);
-      })
-      .map((operation) => operation.id);
-    recordStatusTransitions(movedIds);
-    for (const id of movedIds) {
-      if (nextStatuses.get(id) === "idle") {
-        if (id !== activeOperationId) markIdleUnseen(id);
-      } else {
-        clearIdleUnseen(id);
-      }
-    }
+    const movedIds = trackOperationActivityTransitions({
+      operations,
+      operationStatus,
+      activeTheaterId,
+      activeOperationId,
+    });
     if (!statusAxis) {
       for (const timeoutId of statusLandingTimeoutsRef.current) window.clearTimeout(timeoutId);
       statusLandingTimeoutsRef.current.clear();
@@ -485,11 +459,7 @@ export function OperationsSideBar({
     statusLandingTimeoutsRef.current.add(timeoutId);
   // statusSignature is the stable primitive dependency for the operation/status map assembled above.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [statusAxis, statusSignature]);
-
-  useEffect(() => {
-    if (activeOperationId !== null) clearIdleUnseen(activeOperationId);
-  }, [activeOperationId]);
+  }, [statusAxis, statusSignature, activeTheaterId, activeOperationId]);
 
   useEffect(() => () => {
     for (const timeoutId of statusLandingTimeoutsRef.current) window.clearTimeout(timeoutId);

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -24,6 +24,7 @@ import {
 import { OperationsSideBarChip, type SideBarEntry } from "./operations-side-bar-chip.js";
 import { OperationsSideBarGroupHeader } from "./operations-side-bar-group-header.js";
 import {
+  consumeStatusLandings,
   getIdleUnseenIds,
   setSideBarCollapsed,
   setSideBarWidth,
@@ -307,6 +308,7 @@ export function OperationsSideBar({
   const canvas = useCanvasState();
   const closeArmTimeoutRef = useRef<number | null>(null);
   const statusLandingTimeoutsRef = useRef<Set<number>>(new Set());
+  const didMountStatusLandingRef = useRef(false);
   const [armedCloseId, setArmedCloseId] = useState<string | null>(null);
   const [statusLandingIds, setStatusLandingIds] = useState<ReadonlySet<string>>(new Set());
   const [drag, setDrag] = useState<DragState | null>(null);
@@ -426,33 +428,38 @@ export function OperationsSideBar({
     disarmClose();
   }, [armedCloseId, allEntries, disarmClose]);
 
-  // React passive effect는 자식부터 실행된다. 사이드바가 마운트된 전이는 여기서 기록+flash하고
-  // 뒤이은 App effect는 멱등 no-op이 되며, 사이드바가 언마운트된 라우트에서는 App effect가 기록한다.
+  // App의 동기 store 구독이 렌더 배칭 전의 각 전이를 기록한다. 아래 백업 호출은 App 없는
+  // jsdom 경로를 자기완결적으로 유지하고, pending landing만 사이드바 표시 수명주기로 소비한다.
   useEffect(() => {
-    const movedIds = trackOperationActivityTransitions({
+    trackOperationActivityTransitions({
       operations,
       operationStatus,
       activeTheaterId,
       activeOperationId,
     });
+    const landedIds = consumeStatusLandings();
+    if (!didMountStatusLandingRef.current) {
+      didMountStatusLandingRef.current = true;
+      return;
+    }
     if (!statusAxis) {
       for (const timeoutId of statusLandingTimeoutsRef.current) window.clearTimeout(timeoutId);
       statusLandingTimeoutsRef.current.clear();
       setStatusLandingIds((current) => current.size === 0 ? current : new Set());
       return;
     }
-    if (movedIds.length === 0) return;
+    if (landedIds.length === 0) return;
     // 이동 배치별 독립 타이머: 기존 flash를 취소하지 않고 병합했다가 이 배치의 ID만 만료시킨다.
     setStatusLandingIds((current) => {
       const next = new Set(current);
-      for (const id of movedIds) next.add(id);
+      for (const id of landedIds) next.add(id);
       return next;
     });
     const timeoutId = window.setTimeout(() => {
       statusLandingTimeoutsRef.current.delete(timeoutId);
       setStatusLandingIds((current) => {
         const next = new Set(current);
-        for (const id of movedIds) next.delete(id);
+        for (const id of landedIds) next.delete(id);
         return next.size === current.size ? current : next;
       });
     }, STATUS_LANDING_DURATION_MS);

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -310,6 +310,7 @@ export function OperationsSideBar({
   const closeArmTimeoutRef = useRef<number | null>(null);
   const statusLandingTimeoutsRef = useRef<Set<number>>(new Set());
   const previousOperationStatusRef = useRef<ReadonlyMap<string, SideBarStatus>>(new Map());
+  const baselinedLiveStatusIdsRef = useRef<Set<string>>(new Set());
   const [armedCloseId, setArmedCloseId] = useState<string | null>(null);
   const [statusLandingIds, setStatusLandingIds] = useState<ReadonlySet<string>>(new Set());
   const [drag, setDrag] = useState<DragState | null>(null);
@@ -435,10 +436,21 @@ export function OperationsSideBar({
     );
     const previousStatuses = previousOperationStatusRef.current;
     previousOperationStatusRef.current = nextStatuses;
+    const firstLiveIds = operations
+      .filter((operation) => {
+        if (operationStatus[operation.id] === undefined || baselinedLiveStatusIdsRef.current.has(operation.id)) {
+          return false;
+        }
+        baselinedLiveStatusIdsRef.current.add(operation.id);
+        return true;
+      })
+      .map((operation) => operation.id);
     const movedIds = operations
       .filter((operation) => {
         const previous = previousStatuses.get(operation.id);
-        return previous !== undefined && previous !== nextStatuses.get(operation.id);
+        return previous !== undefined
+          && previous !== nextStatuses.get(operation.id)
+          && !firstLiveIds.includes(operation.id);
       })
       .map((operation) => operation.id);
     recordStatusTransitions(movedIds);

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -446,12 +446,22 @@ export function statusCycleOperationIds(
   operationStatus: Readonly<Record<string, OperationActivity>>,
   minimized: readonly string[],
   isStatusSectionCollapsed: (status: OperationActivity) => boolean,
+  getTick?: (id: string) => number | undefined,
 ): readonly string[] {
   const minimizedIds = new Set(minimized);
   const status = (operation: OperationNode): OperationActivity => resolveOperationActivity(operation, operationStatus);
   const rank = (operation: OperationNode): number => STATUS_CYCLE_RANK[status(operation)];
   return [...sortOperationsByOrder(operations, operationOrder)]
-    .sort((left, right) => rank(left) - rank(right))
+    .sort((left, right) => {
+      const rankDifference = rank(left) - rank(right);
+      if (rankDifference !== 0) return rankDifference;
+      const leftTick = getTick?.(left.id);
+      const rightTick = getTick?.(right.id);
+      if (leftTick === undefined && rightTick === undefined) return 0;
+      if (leftTick === undefined) return 1;
+      if (rightTick === undefined) return -1;
+      return rightTick - leftTick;
+    })
     .filter((operation) => !minimizedIds.has(operation.id) && !isStatusSectionCollapsed(status(operation)))
     .map((operation) => operation.id);
 }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2843,6 +2843,16 @@
   background: var(--ink-fog);
 }
 
+.side-bar-chip-unseen {
+  flex: none;
+  width: 7px;
+  height: 7px;
+  margin-left: auto;
+  border-radius: 999px;
+  background: var(--positive);
+  box-shadow: 0 0 7px var(--positive-glow);
+}
+
 /* 그룹 mark와 STATUS 축 pill은 identity 채널만 사용한다. 그룹의 resolveAccentColor(--id-*) 값은
    기존 operation spine과 독립된 mark/pill로만 표시하고 signal 색을 identity에 재사용하지 않는다. */
 .side-bar-chip-group-mark {
@@ -3121,6 +3131,29 @@
   color: color-mix(in oklch, var(--status-color) 65%, var(--text-primary));
   font-variant-numeric: tabular-nums;
   text-align: right;
+}
+
+.side-bar-status-header__unseen {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  /* 미확인 카운트는 전체 카운트와 함께 우측 끝에 묶는다 — 라벨 옆에 띄우면 두 숫자가 헤더 양端에 갈라진다. */
+  margin-left: auto;
+  color: var(--positive);
+  font-variant-numeric: tabular-nums;
+}
+
+.side-bar-status-header__unseen + .side-bar-status-header__count {
+  margin-left: 6px;
+}
+
+.side-bar-status-header__unseen::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--positive);
+  box-shadow: 0 0 6px var(--positive-glow);
 }
 
 .side-bar-status-empty-hint {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -570,6 +570,7 @@ describe("Instrument core design contract", () => {
   });
 
   it("pins the non-durable STATUS regroup signal and identity channel grammar", () => {
+    const app = source("app.tsx");
     const operations = source("pages/operations.tsx");
     const sidebar = source("sidebar/operations-side-bar.tsx");
     const sideBarStore = source("sidebar/operations-side-bar-store.ts");
@@ -580,13 +581,18 @@ describe("Instrument core design contract", () => {
     expect(operations).toContain("toggleSideBarStatusAxis();");
     expect(sidebar).toContain('title="Sort by status (Alt+S)"');
     expect(sidebar).toContain("groupOperationsByStatus(allEntries, getStatusTransitionTick)");
-    expect(sidebar).toContain("recordStatusTransitions(movedIds);");
+    expect(sidebar).toContain("const movedIds = trackOperationActivityTransitions({");
+    expect(sidebar).not.toContain("recordStatusTransitions(movedIds);");
+    expect(app).toContain("trackOperationActivityTransitions({");
+    expect(app).toContain("}, [state.operations, state.operationStatus, state.activeTheaterId, state.activeOperationId]);");
     expect(sidebar).toContain("if (!statusAxis) {");
     expect(chip).toContain("reorderEnabled && event.altKey && event.shiftKey");
     expect(chip).toContain('className="side-bar-chip-unseen"');
     expect(sideBarStore).toContain("let statusAxis = false;");
     expect(sideBarStore).toContain("let statusTransitionTicks = new Map<string, number>();");
     expect(sideBarStore).toContain("let idleUnseenIds = new Set<string>();");
+    expect(sideBarStore).toContain("let previousActivityById = new Map<string, SideBarStatus>();");
+    expect(sideBarStore).toContain("let baselinedLiveActivityIds = new Set<string>();");
     expect(sideBarStore).not.toContain("STORAGE_KEY_STATUS");
     expect(sideBarStore).not.toContain("fleet-console.operations.status");
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -581,10 +581,10 @@ describe("Instrument core design contract", () => {
     expect(operations).toContain("toggleSideBarStatusAxis();");
     expect(sidebar).toContain('title="Sort by status (Alt+S)"');
     expect(sidebar).toContain("groupOperationsByStatus(allEntries, getStatusTransitionTick)");
-    expect(sidebar).toContain("const movedIds = trackOperationActivityTransitions({");
+    expect(sidebar).toContain("trackOperationActivityTransitions({");
+    expect(sidebar).toContain("const landedIds = consumeStatusLandings();");
     expect(sidebar).not.toContain("recordStatusTransitions(movedIds);");
-    expect(app).toContain("trackOperationActivityTransitions({");
-    expect(app).toContain("}, [state.operations, state.operationStatus, state.activeTheaterId, state.activeOperationId]);");
+    expect(app).toContain("useEffect(() => subscribeOperationActivityTracking(), []);");
     expect(sidebar).toContain("if (!statusAxis) {");
     expect(chip).toContain("reorderEnabled && event.altKey && event.shiftKey");
     expect(chip).toContain('className="side-bar-chip-unseen"');
@@ -593,6 +593,7 @@ describe("Instrument core design contract", () => {
     expect(sideBarStore).toContain("let idleUnseenIds = new Set<string>();");
     expect(sideBarStore).toContain("let previousActivityById = new Map<string, SideBarStatus>();");
     expect(sideBarStore).toContain("let baselinedLiveActivityIds = new Set<string>();");
+    expect(sideBarStore).toContain("let pendingStatusLandingIds = new Set<string>();");
     expect(sideBarStore).not.toContain("STORAGE_KEY_STATUS");
     expect(sideBarStore).not.toContain("fleet-console.operations.status");
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -579,10 +579,14 @@ describe("Instrument core design contract", () => {
     expect(operations).toContain('event.code === "KeyS" && !event.shiftKey');
     expect(operations).toContain("toggleSideBarStatusAxis();");
     expect(sidebar).toContain('title="Sort by status (Alt+S)"');
-    expect(sidebar).toContain("groupOperationsByStatus(allEntries)");
-    expect(sidebar).toContain("if (statusAxis) return;");
+    expect(sidebar).toContain("groupOperationsByStatus(allEntries, getStatusTransitionTick)");
+    expect(sidebar).toContain("recordStatusTransitions(movedIds);");
+    expect(sidebar).toContain("if (!statusAxis) {");
     expect(chip).toContain("reorderEnabled && event.altKey && event.shiftKey");
+    expect(chip).toContain('className="side-bar-chip-unseen"');
     expect(sideBarStore).toContain("let statusAxis = false;");
+    expect(sideBarStore).toContain("let statusTransitionTicks = new Map<string, number>();");
+    expect(sideBarStore).toContain("let idleUnseenIds = new Set<string>();");
     expect(sideBarStore).not.toContain("STORAGE_KEY_STATUS");
     expect(sideBarStore).not.toContain("fleet-console.operations.status");
 
@@ -593,6 +597,8 @@ describe("Instrument core design contract", () => {
     expect(components).toContain("--status-color: color-mix(in oklch, var(--brass) 55%, var(--ink-rim));");
     expect(components).toContain("border-left: 3px solid var(--status-color);");
     expect(components).toContain("background: var(--group-mark);");
+    expect(components).toMatch(/\.side-bar-chip-unseen \{[^}]*background:\s*var\(--positive\)/);
+    expect(components).toMatch(/\.side-bar-status-header__unseen::before \{[^}]*background:\s*var\(--positive\)/);
     expect(components).toContain(".side-bar-status-axis-live-tick,");
     expect(components).toContain(".side-bar-status-header--awaiting .side-bar-status-header__dot {");
   });

--- a/runtime/fleet-console/tests/operation-focus.test.ts
+++ b/runtime/fleet-console/tests/operation-focus.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   getSideBarStatusSectionCollapsed,
+  getStatusTransitionTick,
+  recordStatusTransitions,
+  resetSideBarStatusRecencyForTests,
   resetSideBarStatusSectionCollapseForTests,
   toggleSideBarStatusSectionCollapsed,
 } from "../core/client/src/sidebar/operations-side-bar-store.js";
@@ -25,6 +28,9 @@ function makeOperation(id: string, groupId: string | null = null, createdAt = 1)
 function makeGroup(id: string, order: number): OperationGroup {
   return { id, name: id, color: "blue", order, theaterId: "theater", createdAt: order };
 }
+
+beforeEach(() => resetSideBarStatusRecencyForTests());
+afterEach(() => resetSideBarStatusRecencyForTests());
 
 describe("nextOperationId — Alt+←/→ focus cycle", () => {
   const order = ["a", "b", "c"];
@@ -142,6 +148,26 @@ describe("statusCycleOperationIds — STATUS 축 Alt+←/→ 순환", () => {
       () => false,
     );
     expect(order).toEqual(["plain"]);
+  });
+
+  it("uses descending transition ticks inside a status rank before untouched operationOrder entries", () => {
+    const operations = [
+      makeOperation("untouched-first"),
+      makeOperation("latest"),
+      makeOperation("earlier"),
+      makeOperation("untouched-second"),
+    ];
+    recordStatusTransitions(["earlier"]);
+    recordStatusTransitions(["latest"]);
+
+    expect(statusCycleOperationIds(
+      operations,
+      operations.map((operation) => operation.id),
+      Object.fromEntries(operations.map((operation) => [operation.id, "running"])),
+      [],
+      () => false,
+      getStatusTransitionTick,
+    )).toEqual(["latest", "earlier", "untouched-first", "untouched-second"]);
   });
 
   it("ranks a restored operation with resumeAvailable but no live status as dormant", () => {

--- a/runtime/fleet-console/tests/operations-side-bar-group.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-group.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
 
@@ -11,8 +12,10 @@ import {
   markIdleUnseen,
   recordStatusTransitions,
   resetSideBarStatusRecencyForTests,
+  subscribeOperationActivityTracking,
   trackOperationActivityTransitions,
 } from "../core/client/src/sidebar/operations-side-bar-store.js";
+import { setState as setConsoleState } from "../core/client/src/store.js";
 import type { OperationGroup, OperationNode } from "../core/client/src/types.js";
 
 function makeNode(id: string, groupId?: string | null): OperationNode {
@@ -426,6 +429,34 @@ describe("groupOperationsByStatus", () => {
       activeOperationId: "focused",
     })).toEqual([]);
     expect(getIdleUnseenIds().has("focused")).toBe(false);
+  });
+
+  it("tracks both synchronous store emissions instead of observing only the batched final snapshot", () => {
+    const operation = makeNode("streamed");
+    const unsubscribe = subscribeOperationActivityTracking();
+
+    try {
+      act(() => {
+        setConsoleState({
+          operations: [operation],
+          operationStatus: { streamed: "running" },
+          activeTheaterId: operation.theaterId,
+          activeOperationId: null,
+        });
+        setConsoleState({ operationStatus: { streamed: "idle" } });
+      });
+
+      expect(getStatusTransitionTick(operation.id)).toBeDefined();
+      expect(getIdleUnseenIds().has(operation.id)).toBe(true);
+    } finally {
+      unsubscribe();
+      setConsoleState({
+        operations: [],
+        operationStatus: {},
+        activeTheaterId: null,
+        activeOperationId: null,
+      });
+    }
   });
 
   it("detects the GROUP-axis live tick only for an explicit awaiting status", () => {

--- a/runtime/fleet-console/tests/operations-side-bar-group.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-group.test.ts
@@ -1,10 +1,17 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
 
 import { applyVisibleReorder, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderWithinSegment, type DropSectionInfo } from "../core/client/src/sidebar/operations-side-bar-hit-test.js";
 import { groupOperations, groupOperationsByStatus, hasAwaitingOperation, theaterInitials } from "../core/client/src/sidebar/operations-side-bar.js";
 import type { SideBarEntry } from "../core/client/src/sidebar/operations-side-bar-chip.js";
+import {
+  getIdleUnseenIds,
+  getStatusTransitionTick,
+  markIdleUnseen,
+  recordStatusTransitions,
+  resetSideBarStatusRecencyForTests,
+} from "../core/client/src/sidebar/operations-side-bar-store.js";
 import type { OperationGroup, OperationNode } from "../core/client/src/types.js";
 
 function makeNode(id: string, groupId?: string | null): OperationNode {
@@ -31,6 +38,9 @@ function makeEntry(id: string, groupId?: string | null, status?: OperationActivi
     icon: null,
   };
 }
+
+beforeEach(() => resetSideBarStatusRecencyForTests());
+afterEach(() => resetSideBarStatusRecencyForTests());
 
 function makeGroup(id: string, order: number): OperationGroup {
   return { id, name: id, color: "blue", order, theaterId: "t1", createdAt: order };
@@ -303,7 +313,7 @@ describe("groupOperationsByStatus", () => {
     const sections = groupOperationsByStatus(entries);
 
     expect(sections.map((section) => [section.status, section.label])).toEqual([
-      ["awaiting", "AWAITING INPUT"],
+      ["awaiting", "AWAITING"],
       ["running", "RUNNING"],
       ["idle", "IDLE"],
       ["dormant", "DORMANT"],
@@ -320,6 +330,34 @@ describe("groupOperationsByStatus", () => {
 
     expect(sections.find((section) => section.status === "running")?.entries.map((entry) => entry.operation.id))
       .toEqual(["running-second", "running-first"]);
+  });
+
+  it("orders transitioned entries by descending tick before untouched entries", () => {
+    recordStatusTransitions(["earlier"]);
+    recordStatusTransitions(["latest"]);
+    const sections = groupOperationsByStatus([
+      makeEntry("untouched-first", null, "running"),
+      makeEntry("latest", null, "running"),
+      makeEntry("earlier", null, "running"),
+      makeEntry("untouched-second", null, "running"),
+    ], getStatusTransitionTick);
+
+    expect(sections.find((section) => section.status === "running")?.entries.map((entry) => entry.operation.id))
+      .toEqual(["latest", "earlier", "untouched-first", "untouched-second"]);
+  });
+
+  it("resets transition ticks and idle unseen state together", () => {
+    recordStatusTransitions(["operation"]);
+    markIdleUnseen("operation");
+    expect(getStatusTransitionTick("operation")).toBe(1);
+    expect(getIdleUnseenIds().has("operation")).toBe(true);
+
+    resetSideBarStatusRecencyForTests();
+
+    expect(getStatusTransitionTick("operation")).toBeUndefined();
+    expect(getIdleUnseenIds().size).toBe(0);
+    recordStatusTransitions(["next-operation"]);
+    expect(getStatusTransitionTick("next-operation")).toBe(1);
   });
 
   it("detects the GROUP-axis live tick only for an explicit awaiting status", () => {

--- a/runtime/fleet-console/tests/operations-side-bar-group.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-group.test.ts
@@ -11,6 +11,7 @@ import {
   markIdleUnseen,
   recordStatusTransitions,
   resetSideBarStatusRecencyForTests,
+  trackOperationActivityTransitions,
 } from "../core/client/src/sidebar/operations-side-bar-store.js";
 import type { OperationGroup, OperationNode } from "../core/client/src/types.js";
 
@@ -358,6 +359,73 @@ describe("groupOperationsByStatus", () => {
     expect(getIdleUnseenIds().size).toBe(0);
     recordStatusTransitions(["next-operation"]);
     expect(getStatusTransitionTick("next-operation")).toBe(1);
+  });
+
+  it("marks an idle transition when the preserved active Operation belongs to another Theater", () => {
+    const operation = { ...makeNode("operation"), theaterId: "theater-a" };
+    trackOperationActivityTransitions({
+      operations: [operation],
+      operationStatus: { operation: "running" },
+      activeTheaterId: "theater-b",
+      activeOperationId: operation.id,
+    });
+
+    expect(trackOperationActivityTransitions({
+      operations: [operation],
+      operationStatus: { operation: "idle" },
+      activeTheaterId: "theater-b",
+      activeOperationId: operation.id,
+    })).toEqual([operation.id]);
+    expect(getIdleUnseenIds().has(operation.id)).toBe(true);
+    const tick = getStatusTransitionTick(operation.id);
+
+    expect(trackOperationActivityTransitions({
+      operations: [operation],
+      operationStatus: { operation: "idle" },
+      activeTheaterId: "theater-b",
+      activeOperationId: operation.id,
+    })).toEqual([]);
+    expect(getStatusTransitionTick(operation.id)).toBe(tick);
+    expect(getIdleUnseenIds().has(operation.id)).toBe(true);
+
+    expect(trackOperationActivityTransitions({
+      operations: [operation],
+      operationStatus: { operation: "idle" },
+      activeTheaterId: operation.theaterId,
+      activeOperationId: operation.id,
+    })).toEqual([]);
+    expect(getIdleUnseenIds().has(operation.id)).toBe(false);
+  });
+
+  it("does not mark an idle transition for the focused Operation in the active Theater", () => {
+    const operation = { ...makeNode("focused"), theaterId: "theater-a" };
+    trackOperationActivityTransitions({
+      operations: [operation],
+      operationStatus: { focused: "running" },
+      activeTheaterId: operation.theaterId,
+      activeOperationId: operation.id,
+    });
+
+    expect(trackOperationActivityTransitions({
+      operations: [operation],
+      operationStatus: { focused: "idle" },
+      activeTheaterId: operation.theaterId,
+      activeOperationId: operation.id,
+    })).toEqual([operation.id]);
+    expect(getIdleUnseenIds().has(operation.id)).toBe(false);
+  });
+
+  it("clears unseen for the active Operation on every tracker call", () => {
+    const operation = makeNode("focused");
+    markIdleUnseen("focused");
+
+    expect(trackOperationActivityTransitions({
+      operations: [operation],
+      operationStatus: {},
+      activeTheaterId: operation.theaterId,
+      activeOperationId: "focused",
+    })).toEqual([]);
+    expect(getIdleUnseenIds().has("focused")).toBe(false);
   });
 
   it("detects the GROUP-axis live tick only for an explicit awaiting status", () => {

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -277,7 +277,7 @@ describe("OperationsSideBar STATUS axis", () => {
     expect(runningIds).toEqual(["latest", "earlier", "untouched-first", "untouched-second"]);
   });
 
-  it("renders an idle transition recorded while the SideBar was unmounted", () => {
+  it("renders synchronous running to idle recorded while unmounted without retroactive landing flash", () => {
     const operations = [
       makeOperation("untouched", null),
       makeOperation("recorded", null),
@@ -305,7 +305,9 @@ describe("OperationsSideBar STATUS axis", () => {
       (chip) => chip.dataset.sideBarChipId,
     );
     expect(idleChips).toEqual(["recorded", "untouched"]);
-    expect(required<HTMLElement>('[data-side-bar-chip-id="recorded"] .side-bar-chip-unseen')).not.toBeNull();
+    const recordedChip = required<HTMLElement>('[data-side-bar-chip-id="recorded"]');
+    expect(recordedChip.querySelector(".side-bar-chip-unseen")).not.toBeNull();
+    expect(recordedChip.className).not.toContain("side-bar-chip--status-landed");
     expect(required<HTMLElement>(".side-bar-status-section--idle .side-bar-status-header__unseen").textContent).toBe("1");
   });
 

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -15,6 +15,7 @@ import {
   setSideBarCollapsed,
   setSideBarStatusAxis,
   setTheaterCollapsed,
+  trackOperationActivityTransitions,
 } from "../core/client/src/sidebar/operations-side-bar-store.js";
 import { setState as setConsoleState } from "../core/client/src/store.js";
 import type { OperationGroup, OperationNode, TheaterInfo } from "../core/client/src/types.js";
@@ -274,6 +275,38 @@ describe("OperationsSideBar STATUS axis", () => {
       (chip) => chip.dataset.sideBarChipId,
     );
     expect(runningIds).toEqual(["latest", "earlier", "untouched-first", "untouched-second"]);
+  });
+
+  it("renders an idle transition recorded while the SideBar was unmounted", () => {
+    const operations = [
+      makeOperation("untouched", null),
+      makeOperation("recorded", null),
+    ];
+    setOperationOrder(operations.map((operation) => operation.id));
+    trackOperationActivityTransitions({
+      operations,
+      operationStatus: { recorded: "running" },
+      activeTheaterId: THEATER.id,
+      activeOperationId: null,
+    });
+    expect(trackOperationActivityTransitions({
+      operations,
+      operationStatus: { recorded: "idle" },
+      activeTheaterId: THEATER.id,
+      activeOperationId: null,
+    })).toEqual(["recorded"]);
+
+    setConsoleState({ operationStatus: { recorded: "idle" } });
+    setSideBarStatusAxis(true);
+    renderSideBar(operations);
+
+    const idleChips = Array.from(
+      required<HTMLElement>(".side-bar-status-section--idle").querySelectorAll<HTMLElement>("[data-side-bar-chip-id]"),
+      (chip) => chip.dataset.sideBarChipId,
+    );
+    expect(idleChips).toEqual(["recorded", "untouched"]);
+    expect(required<HTMLElement>('[data-side-bar-chip-id="recorded"] .side-bar-chip-unseen')).not.toBeNull();
+    expect(required<HTMLElement>(".side-bar-status-section--idle .side-bar-status-header__unseen").textContent).toBe("1");
   });
 
   it("tracks idle unseen while STATUS is off, omits focused transitions, and clears on focus", () => {

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -8,6 +8,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getSnapshot, loadForTheater, setOperationOrder } from "../core/client/src/canvas/canvas-store.js";
 import { OperationsSideBar } from "../core/client/src/sidebar/operations-side-bar.js";
 import {
+  getIdleUnseenIds,
+  resetSideBarStatusRecencyForTests,
   resetSideBarStatusSectionCollapseForTests,
   setSideBarCollapsed,
   setSideBarStatusAxis,
@@ -26,6 +28,7 @@ beforeEach(() => {
   window.localStorage.clear();
   setSideBarCollapsed(false);
   setSideBarStatusAxis(false);
+  resetSideBarStatusRecencyForTests();
   resetSideBarStatusSectionCollapseForTests();
   setTheaterCollapsed("theater-a", false);
   setTheaterCollapsed("theater-b", false);
@@ -39,6 +42,7 @@ afterEach(() => {
   root = null;
   container = null;
   setSideBarStatusAxis(false);
+  resetSideBarStatusRecencyForTests();
   resetSideBarStatusSectionCollapseForTests();
   setConsoleState({ operationStatus: {} });
   loadForTheater(null);
@@ -73,7 +77,7 @@ describe("OperationsSideBar STATUS axis", () => {
     expect(toggle.getAttribute("aria-pressed")).toBe("true");
     expect(toggle.querySelector(".side-bar-status-axis-live-tick")).toBeNull();
     expect(Array.from(container?.querySelectorAll(".side-bar-status-header__label") ?? []).map((node) => node.textContent)).toEqual([
-      "AWAITING INPUT",
+      "AWAITING",
       "RUNNING",
       "IDLE",
       "DORMANT",
@@ -105,13 +109,13 @@ describe("OperationsSideBar STATUS axis", () => {
 
     const awaiting = required<HTMLElement>(".side-bar-status-section--awaiting");
     expect(awaiting.className).toContain("side-bar-status-section--empty");
-    const awaitingToggle = required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Expand section AWAITING INPUT"]');
+    const awaitingToggle = required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Expand section AWAITING"]');
     expect(awaitingToggle.getAttribute("aria-expanded")).toBe("false");
     expect(awaiting.querySelector(".side-bar-status-empty-hint")).toBeNull();
 
     act(() => awaitingToggle.click());
 
-    expect(required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Collapse section AWAITING INPUT"]').title).toBe("Collapse");
+    expect(required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Collapse section AWAITING"]').title).toBe("Collapse");
     expect(required<HTMLElement>(".side-bar-status-section--awaiting .side-bar-status-empty-hint").textContent).toBe("No operations");
 
     const runningToggle = required<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Collapse section RUNNING"]');
@@ -127,19 +131,19 @@ describe("OperationsSideBar STATUS axis", () => {
     setSideBarStatusAxis(true);
     renderSideBar([]);
 
-    act(() => required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Expand section AWAITING INPUT"]').click());
+    act(() => required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Expand section AWAITING"]').click());
     expect(required<HTMLElement>(".side-bar-status-section--awaiting .side-bar-status-empty-hint").textContent).toBe("No operations");
 
     act(() => setConsoleState({ operationStatus: { arriving: "awaiting" } }));
     rerenderSideBar([makeOperation("arriving", null)]);
 
-    expect(required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Collapse section AWAITING INPUT"]').getAttribute("aria-expanded")).toBe("true");
+    expect(required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Collapse section AWAITING"]').getAttribute("aria-expanded")).toBe("true");
     expect(container?.querySelector('[data-side-bar-chip-id="arriving"]')).not.toBeNull();
 
     act(() => setConsoleState({ operationStatus: {} }));
     rerenderSideBar([]);
 
-    expect(required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Collapse section AWAITING INPUT"]').getAttribute("aria-expanded")).toBe("true");
+    expect(required<HTMLButtonElement>('.side-bar-status-section--awaiting [aria-label="Collapse section AWAITING"]').getAttribute("aria-expanded")).toBe("true");
     expect(required<HTMLElement>(".side-bar-status-section--awaiting .side-bar-status-empty-hint").textContent).toBe("No operations");
   });
 
@@ -166,8 +170,8 @@ describe("OperationsSideBar STATUS axis", () => {
     expect(bravo.querySelector('.side-bar-status-section--running [aria-label="Expand section RUNNING"]')).not.toBeNull();
   });
 
-  it("suppresses both group pills and status beacons in inactive Theater preview chips", () => {
-    setConsoleState({ operationStatus: { preview: "awaiting" } });
+  it("suppresses group pills and status beacons but shows idle unseen in inactive Theater preview chips", () => {
+    setConsoleState({ operationStatus: { preview: "running" } });
     setSideBarStatusAxis(true);
     renderSideBar([makeOperation("preview", "group-a")], [GROUP_A], vi.fn(), "theater-other");
 
@@ -175,6 +179,10 @@ describe("OperationsSideBar STATUS axis", () => {
     expect(preview.querySelector(".side-bar-chip-group-pill")).toBeNull();
     expect(preview.querySelector(".side-bar-chip-group-mark")).toBeNull();
     expect(preview.querySelector(".side-bar-chip-status")).toBeNull();
+
+    act(() => setConsoleState({ operationStatus: { preview: "idle" } }));
+
+    expect(required<HTMLElement>('[data-side-bar-chip-id="preview"] .side-bar-chip-unseen')).not.toBeNull();
   });
 
   it("keeps keyboard reordering disabled in STATUS and unchanged in GROUP", () => {
@@ -220,7 +228,99 @@ describe("OperationsSideBar STATUS axis", () => {
     act(() => setConsoleState({ operationStatus: { moving: "awaiting" } }));
 
     expect(required<HTMLElement>('[data-side-bar-chip-id="moving"]').className).toContain("side-bar-chip--status-landed");
-    expect(required<HTMLElement>(".side-bar-status-header__label").textContent).toBe("AWAITING INPUT");
+    expect(required<HTMLElement>(".side-bar-status-header__label").textContent).toBe("AWAITING");
+  });
+
+  it("puts the most recently transitioned Operation first and keeps untouched Operations in operationOrder", () => {
+    const operations = [
+      makeOperation("untouched-first", null),
+      makeOperation("latest", null),
+      makeOperation("earlier", null),
+      makeOperation("untouched-second", null),
+    ];
+    setOperationOrder(operations.map((operation) => operation.id));
+    setConsoleState({ operationStatus: Object.fromEntries(operations.map((operation) => [operation.id, "running"])) });
+    setSideBarStatusAxis(true);
+    renderSideBar(operations);
+
+    act(() => setConsoleState({ operationStatus: {
+      "untouched-first": "running",
+      latest: "running",
+      earlier: "idle",
+      "untouched-second": "running",
+    } }));
+    act(() => setConsoleState({ operationStatus: {
+      "untouched-first": "running",
+      latest: "running",
+      earlier: "running",
+      "untouched-second": "running",
+    } }));
+    act(() => setConsoleState({ operationStatus: {
+      "untouched-first": "running",
+      latest: "idle",
+      earlier: "running",
+      "untouched-second": "running",
+    } }));
+    act(() => setConsoleState({ operationStatus: {
+      "untouched-first": "running",
+      latest: "running",
+      earlier: "running",
+      "untouched-second": "running",
+    } }));
+
+    const runningIds = Array.from(
+      required<HTMLElement>(".side-bar-status-section--running").querySelectorAll<HTMLElement>("[data-side-bar-chip-id]"),
+      (chip) => chip.dataset.sideBarChipId,
+    );
+    expect(runningIds).toEqual(["latest", "earlier", "untouched-first", "untouched-second"]);
+  });
+
+  it("tracks idle unseen while STATUS is off, omits focused transitions, and clears on focus", () => {
+    const operations = [makeOperation("unseen", null), makeOperation("focused", null)];
+    setConsoleState({ operationStatus: { unseen: "running", focused: "running" } });
+    renderSideBar(operations, [], vi.fn(), THEATER.id, [THEATER], "focused");
+
+    act(() => setConsoleState({ operationStatus: { unseen: "idle", focused: "idle" } }));
+    expect(container?.querySelector(".side-bar-chip-unseen")).toBeNull();
+
+    act(() => setSideBarStatusAxis(true));
+
+    const unseenChip = required<HTMLElement>('[data-side-bar-chip-id="unseen"]');
+    expect(unseenChip.querySelector(".side-bar-chip-unseen")?.getAttribute("title")).toBe("Finished — not opened yet");
+    expect(unseenChip.getAttribute("aria-label")).toContain(" (unseen since idle)");
+    expect(required<HTMLElement>(".side-bar-status-section--idle .side-bar-status-header__unseen").textContent).toBe("1");
+    expect(required<HTMLElement>('[data-side-bar-chip-id="focused"]').querySelector(".side-bar-chip-unseen")).toBeNull();
+
+    rerenderSideBar(operations, [], THEATER.id, [THEATER], "unseen");
+
+    expect(required<HTMLElement>('[data-side-bar-chip-id="unseen"]').querySelector(".side-bar-chip-unseen")).toBeNull();
+    expect(container?.querySelector(".side-bar-status-section--idle .side-bar-status-header__unseen")).toBeNull();
+    expect(getIdleUnseenIds().has("unseen")).toBe(false);
+  });
+
+  it("removes idle unseen on exit and grants it again on a later idle episode", () => {
+    const operations = [makeOperation("repeat", null)];
+    setConsoleState({ operationStatus: { repeat: "running" } });
+    setSideBarStatusAxis(true);
+    renderSideBar(operations);
+
+    act(() => setConsoleState({ operationStatus: { repeat: "idle" } }));
+    expect(required<HTMLElement>('[data-side-bar-chip-id="repeat"] .side-bar-chip-unseen')).not.toBeNull();
+
+    act(() => setConsoleState({ operationStatus: { repeat: "running" } }));
+    expect(required<HTMLElement>('[data-side-bar-chip-id="repeat"]').querySelector(".side-bar-chip-unseen")).toBeNull();
+
+    act(() => setConsoleState({ operationStatus: { repeat: "idle" } }));
+    expect(required<HTMLElement>('[data-side-bar-chip-id="repeat"] .side-bar-chip-unseen')).not.toBeNull();
+  });
+
+  it("does not mark an Operation that is already idle on page load", () => {
+    setConsoleState({ operationStatus: { initial: "idle" } });
+    setSideBarStatusAxis(true);
+    renderSideBar([makeOperation("initial", null)]);
+
+    expect(required<HTMLElement>('[data-side-bar-chip-id="initial"]').querySelector(".side-bar-chip-unseen")).toBeNull();
+    expect(container?.querySelector(".side-bar-status-header__unseen")).toBeNull();
   });
 
   it("uses the Theater name row for persisted collapse and exposes the split control accessibility contract", () => {
@@ -264,11 +364,12 @@ function renderSideBar(
   onSelectTheater = vi.fn(),
   activeTheaterId: string = THEATER.id,
   theaters: readonly TheaterInfo[] = [THEATER],
+  activeOperationId: string | null = null,
 ): void {
   container = document.createElement("div");
   document.body.append(container);
   root = createRoot(container);
-  act(() => root?.render(sideBarElement(operations, groups, onSelectTheater, activeTheaterId, theaters)));
+  act(() => root?.render(sideBarElement(operations, groups, onSelectTheater, activeTheaterId, theaters, activeOperationId)));
 }
 
 function rerenderSideBar(
@@ -276,8 +377,9 @@ function rerenderSideBar(
   groups: readonly OperationGroup[] = [],
   activeTheaterId: string = THEATER.id,
   theaters: readonly TheaterInfo[] = [THEATER],
+  activeOperationId: string | null = null,
 ): void {
-  act(() => root?.render(sideBarElement(operations, groups, vi.fn(), activeTheaterId, theaters)));
+  act(() => root?.render(sideBarElement(operations, groups, vi.fn(), activeTheaterId, theaters, activeOperationId)));
 }
 
 function sideBarElement(
@@ -286,6 +388,7 @@ function sideBarElement(
   onSelectTheater: (theaterId: string) => void,
   activeTheaterId: string,
   theaters: readonly TheaterInfo[],
+  activeOperationId: string | null,
 ) {
   return createElement(MemoryRouter, null, createElement(OperationsSideBar, {
     theaters,
@@ -293,7 +396,7 @@ function sideBarElement(
     operations,
     groups,
     minimized: [],
-    activeOperationId: null,
+    activeOperationId,
     operationNotifications: {},
     catalog: [],
     canLaunch: true,

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -9,6 +9,7 @@ import { getSnapshot, loadForTheater, setOperationOrder } from "../core/client/s
 import { OperationsSideBar } from "../core/client/src/sidebar/operations-side-bar.js";
 import {
   getIdleUnseenIds,
+  getStatusTransitionTick,
   resetSideBarStatusRecencyForTests,
   resetSideBarStatusSectionCollapseForTests,
   setSideBarCollapsed,
@@ -321,6 +322,37 @@ describe("OperationsSideBar STATUS axis", () => {
 
     expect(required<HTMLElement>('[data-side-bar-chip-id="initial"]').querySelector(".side-bar-chip-unseen")).toBeNull();
     expect(container?.querySelector(".side-bar-status-header__unseen")).toBeNull();
+  });
+
+  it("baselines the first live status of a restored Operation before tracking later transitions", () => {
+    const operation = {
+      ...makeOperation("restored", null),
+      payload: { resumeAvailable: true },
+    };
+    setSideBarStatusAxis(true);
+    renderSideBar([operation]);
+
+    expect(required<HTMLElement>('[data-side-bar-chip-id="restored"]').closest(".side-bar-status-section--dormant")).not.toBeNull();
+
+    act(() => setConsoleState({ operationStatus: { restored: "idle" } }));
+
+    const firstLiveChip = required<HTMLElement>('[data-side-bar-chip-id="restored"]');
+    expect(getStatusTransitionTick("restored")).toBeUndefined();
+    expect(firstLiveChip.querySelector(".side-bar-chip-unseen")).toBeNull();
+    expect(firstLiveChip.className).not.toContain("side-bar-chip--status-landed");
+    expect(container?.querySelector(".side-bar-status-section--idle .side-bar-status-header__unseen")).toBeNull();
+
+    act(() => setConsoleState({ operationStatus: { restored: "running" } }));
+    const runningTick = getStatusTransitionTick("restored");
+    expect(runningTick).toBeDefined();
+
+    act(() => setConsoleState({ operationStatus: { restored: "idle" } }));
+
+    const transitionedChip = required<HTMLElement>('[data-side-bar-chip-id="restored"]');
+    expect(getStatusTransitionTick("restored")).toBeGreaterThan(runningTick ?? 0);
+    expect(transitionedChip.querySelector(".side-bar-chip-unseen")).not.toBeNull();
+    expect(transitionedChip.className).toContain("side-bar-chip--status-landed");
+    expect(required<HTMLElement>(".side-bar-status-section--idle .side-bar-status-header__unseen").textContent).toBe("1");
   });
 
   it("uses the Theater name row for persisted collapse and exposes the split control accessibility contract", () => {


### PR DESCRIPTION
## Summary
- 사이드바 STATUS 축(Sort by status)의 각 섹션이 마지막 상태 전이 순으로 Operation을 정렬합니다. 전이된 적 없는 Operation은 기존 operationOrder를 유지하며 뒤에 위치하고, Alt+←/→ 순환도 같은 가시 순서를 따릅니다.
- idle로 전이된 Operation에 세션 한정 미확인 표시(칩 우측 positive dot + IDLE 헤더 미확인 카운트)를 부여합니다. 전이 시점에 이미 포커스된 Operation은 제외되며, 한 번 열면 해제되고 idle 재진입 시 재부여됩니다. 복원(dormant) Operation의 최초 live status는 discovery로 간주해 마커를 붙이지 않습니다.
- 첫 섹션 헤더를 AWAITING INPUT에서 AWAITING으로 줄였습니다(칩 beacon 툴팁 "Awaiting input"은 유지).

## Test Plan
- [x] `vitest run tests/operations-side-bar-status-axis.test.tsx tests/operations-side-bar-group.test.ts tests/operation-focus.test.ts tests/instrument-design-contract.test.ts` — 103/103 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 성공
- [x] Sentinel console-e2e (헤디드, 격리 인스턴스) — recency/미확인/해제/축 off→on/Alt 순환 시나리오 스크린샷 증거 6건, Medium 1건 수정(최초 live status baseline) 후 회귀 테스트 추가
- [x] `.changelog.d/pr-386.md` — 프래그먼트 문법·이중언어 요약·`compile-changelog-fragments.mjs --check` 검증 완료
