### PR TITLE
fix(fleet-plugin): restore the terminal plugin typecheck

### DIFF
--- a/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
@@ -123,6 +123,9 @@ function createHarness(body: Record<string, unknown>) {
         registerPayloadSanitizer: () => () => {},
         registerLaunchCatalog: () => () => {},
       },
+      theaters: {
+        registerRowBadgeProvider: () => () => {},
+      },
       events: {
         publish: () => {},
         subscribe: (channel: string, listener: (payload: unknown) => void) => {


### PR DESCRIPTION
## Summary

- `canary`가 red입니다. `runtime/fleet-plugins/terminal`의 `tsc -p tsconfig.json`이 실패하고, 이 스크립트는 워크스페이스 `postinstall`에도 걸려 있어 **새 워크트리의 `pnpm install --frozen-lockfile`부터 멎습니다.**
- 원인은 교차 머지입니다. #383이 `FleetPluginHostCapabilities`에 `theaters`를 **필수** 필드로 추가했고, 같은 시점에서 분기한 #378이 그 필드 없는 호스트 목을 담은 `tests/agent-capture-grace.test.ts`를 추가했습니다. 각자 base에서는 green이라 머지 시점에 아무도 막지 못했습니다.
- 목에 `theaters.registerRowBadgeProvider`를 채워 계약을 복구합니다. SDK 타입은 건드리지 않았습니다 — `theaters`는 호스트가 항상 제공하는 능력이므로 optional로 완화하면 실제 플러그인 코드의 계약이 약해집니다.

테스트 전용 변경이고 사용자 가시 동작이 없어 `no-changelog`입니다.

## Test Plan

- [x] `pnpm install --frozen-lockfile` (워크트리, postinstall 빌드 통과)
- [x] `pnpm -r build` 전체 green
- [x] `pnpm --filter "@fleet-plugins/*" test` — 801 passed (terminal 378 포함)
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 단독 실행 시 잔여 실패는 `server.test.ts`의 MCP 세션 1건(#353부터의 선존 실패)뿐

## 함께 보고하는 선존 상태 (이 PR 범위 아님)

- `tests/api-catalog.test.ts` / `tests/carrier-settings.test.ts`: 동시 실행 시에만 타임아웃, 파일 단독 실행 시 전건 통과 — 포트 경합
- `packages/core-unified-agent` E2E 2건: 실 CLI 호출. ① effort=max 응답 길이 단언이 비결정적 ② Codex 도구 식별자가 `mcp.test-math.add_numbers` → `test-math/add_numbers`로 상류 변경
- **이 저장소 CI에는 테스트·typecheck 게이트가 없습니다**(changelog-fragment / core-boundary / pr-target-guard / pr-title 4종뿐). 이번 건이 정확히 그 공백에서 나온 두 번째 사례입니다.