### PR TITLE
fix(console): anchor Theater repository badges next to the Theater name

### DIFF
--- a/.changelog.d/pr-388.md
+++ b/.changelog.d/pr-388.md
@@ -1,0 +1,8 @@
+### fleet-console
+
+#### Fixed
+
+- [fleet-console] Place the Theater repository badges directly right of the Theater name instead of the far end of the row.
+  ko: Theater 저장소 배지를 행 끝이 아니라 Theater 이름 바로 오른쪽에 배치합니다.
+- [fleet-console] Stop the Theater name from starving the badge cluster, which hid the second badge entirely on a default-width sidebar.
+  ko: Theater 이름이 배지 영역을 잠식해 기본 폭 사이드바에서 두 번째 배지가 통째로 가려지던 문제를 고쳤습니다.

--- a/.changelog.d/pr-388.md
+++ b/.changelog.d/pr-388.md
@@ -1,8 +1,0 @@
-### fleet-console
-
-#### Fixed
-
-- [fleet-console] Place the Theater repository badges directly right of the Theater name instead of the far end of the row.
-  ko: Theater 저장소 배지를 행 끝이 아니라 Theater 이름 바로 오른쪽에 배치합니다.
-- [fleet-console] Stop the Theater name from starving the badge cluster, which hid the second badge entirely on a default-width sidebar.
-  ko: Theater 이름이 배지 영역을 잠식해 기본 폭 사이드바에서 두 번째 배지가 통째로 가려지던 문제를 고쳤습니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2453,9 +2453,11 @@
   opacity: 0.55;
 }
 
+/* 이름은 내용 폭만 차지한다. 예전처럼 남는 공간을 전부 흡수하면 배지가 행 끝으로 밀려
+   이름과 떨어지고, 좁은 행에서는 공간 다툼에 져 잘려 나간다. */
 .side-bar-theater-name {
-  flex: 1 1 100%;
-  min-width: 64px;
+  flex: 0 1 auto;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2501,8 +2503,11 @@
   color: var(--text-secondary);
 }
 
+/* 이름+배지 묶음은 좌측에 붙고, 남는 공간은 전부 이 auto margin이 흡수해 ⌄와 행 컨트롤을
+   우측 끝에 고정한다. */
 .side-bar-theater-chevron {
   flex: none;
+  margin-left: auto;
   width: 12px;
   height: 12px;
   color: var(--text-tertiary);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -610,15 +610,21 @@ describe("Instrument core design contract", () => {
     expect(components).toContain(".side-bar-status-header--awaiting .side-bar-status-header__dot {");
   });
 
-  it("keeps Theater repository badges on signal tokens and preserves label priority", () => {
+  it("keeps Theater repository badges on signal tokens and anchored to the label", () => {
     const sidebar = source("sidebar/operations-side-bar.tsx");
     const components = source("styles/components.css");
     const badgeStart = components.indexOf(".side-bar-theater-badge {");
     const badgeEnd = components.indexOf(".side-bar-theater-chevron {", badgeStart);
     const badgeGrammar = components.slice(badgeStart, badgeEnd);
+    const chevronStart = components.indexOf(".side-bar-theater-chevron {");
+    const chevronGrammar = components.slice(chevronStart, components.indexOf("}", chevronStart));
 
     expect(sidebar).toContain('className={`side-bar-theater-badge side-bar-theater-badge--${badge.tone ?? "neutral"}`}');
-    expect(components).toContain(".side-bar-theater-name {\n  flex: 1 1 100%;\n  min-width: 64px;");
+    // 배지는 Theater 이름 바로 오른쪽에 붙는다. 이름이 남는 공간을 흡수하면 배지가 행 끝으로
+    // 밀려 이름과 분리되고, 좁은 행에서는 공간 다툼에 져 잘려 나간다.
+    expect(components).toContain(".side-bar-theater-name {\n  flex: 0 1 auto;\n  min-width: 0;");
+    // 남는 공간은 ⌄의 auto margin이 흡수해 ⌄와 행 컨트롤만 우측 끝에 고정된다.
+    expect(chevronGrammar).toContain("margin-left: auto;");
     expect(components).toContain("max-width: min(42%, 180px);");
     expect(badgeGrammar).toContain("var(--aurora)");
     expect(badgeGrammar).toContain("var(--warn)");


### PR DESCRIPTION
## Summary

Theater 행의 저장소 컨텍스트 배지(#383)를 **Theater 이름 바로 오른쪽**에 붙입니다.

마크업 순서는 원래부터 `이름 → 배지 → ⌄ → 컨트롤`이었고, 배지가 멀리 떨어져 보인 건 DOM이 아니라 flex 분배 탓이었습니다. `.side-bar-theater-name`의 `flex: 1 1 100%`가 남는 공간을 전부 흡수해 배지를 행 끝으로 밀어냈습니다.

- 이름을 `flex: 0 1 auto; min-width: 0`으로 바꿔 내용 폭만 차지하게 했습니다. `min-width: 64px`는 짧은 이름 옆에 빈 상자를 만들어 간극의 두 번째 원인이었습니다.
- 남는 공간은 `.side-bar-theater-chevron`의 `margin-left: auto`가 흡수해 ⌄와 행 컨트롤은 예전과 **동일한 좌표**(chev=171, ctrl=193 @280px)에 그대로 남습니다.

### 배치뿐 아니라 사라져 있던 배지가 복구됩니다

기본 폭 사이드바에서 이름이 공간 다툼을 이겨 배지 컨테이너를 굶기고 있었습니다. 실측(격리 콘솔, 280px):

| 행 | 변경 전 | 변경 후 |
|---|---|---|
| `alpha` (main / clean) | 배지 상자 `135..163`(28px) — `main` 잘림, **`clean` 완전히 안 보임** | `77..153`(76px) — **2/2 온전, 이름에 밀착** |
| `a-very-long-…` (feature/… / 5 changed) | `117..163`(46px) | `113..163`(50px) |
| 배지 없는 Theater | — | 렌더 동일(회귀 없음) |

## 알려진 잔여 사항 (이 PR로 해결되지 않음)

긴 Theater 이름 + 좁은 사이드바에서는 두 번째 배지가 여전히 잘립니다. **산술적 제약**입니다 — 280px 행에서 앵커·⌄·컨트롤·간격이 130px(51%)를 고정 점유해 이름+배지에 123px만 남는데, 배지만으로 106px을 요구합니다. 440px까지 넓혀도 이름이 162px을 선점해 `5 changed`가 잘립니다(측정치 첨부).

해소하려면 "폭 임계값 아래에서는 부차 배지를 떨어뜨린다" 같은 **동작 변경**이 필요하고, 어느 배지가 이기는지는 제품 판단이라 이번 배치 변경 범위 밖으로 두고 보고만 합니다. 변경 전보다 나빠지는 케이스는 측정 범위에서 없었습니다(46→50px).

## 디자인 계약

`instrument-design-contract.test.ts`가 `flex: 1 1 100%`를 "label priority"로 못 박고 있었습니다(제가 #383에서 넣은 단언). 이번 변경이 그 규칙을 뒤집으므로 계약도 함께 갱신했습니다 — 새 단언은 이름의 내용 폭 규칙과 ⌄의 `margin-left: auto`를 핀합니다.

**되돌림 검증 완료**: 두 CSS 규칙을 각각 원복하면 계약 테스트가 실제로 실패합니다(무효 테스트 아님).

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console build` green
- [x] 디자인 계약 + 사이드바 4파일 98 tests passed (#386 리베이스 후 재실행)
- [x] 격리 콘솔 실측: git 2곳 + 비-git 1곳 Theater 시드, 280/360/440px 폭별 기하 측정, 스크린샷 전/후 대조
- [x] 행 컨트롤 상호작용(상태축 토글 / Theater 액션 메뉴) 정상, 콘솔 오류 0
- [x] 전체 콘솔 스위트: 잔여 실패는 `server.test.ts` MCP 세션 1건(#353 선존) — 변경 전 기준선과 동일

## 별건 관찰 (수정하지 않음)

Theater 행의 접근 가능한 이름이 `"alpha alpha repository status alpha controls"`로 읽힙니다. `role="button"` 안의 배지 span과 컨트롤 group에 붙은 `aria-label`이 이름 계산에 합류하기 때문입니다. #383 이전에도 `"alpha alpha controls"`였던 선존 결함이고, 제대로 고치려면 행에 `aria-labelledby`를 도입해야 해서 배치 변경과 분리했습니다.

## Changelog

`.changelog.d/pr-<번호>.md`는 PR 번호 확정 후 별도 커밋으로 추가합니다.