### PR TITLE
fix(terminal): track agent turn activity from terminal titles

### DIFF
--- a/.changelog.d/pr-389.md
+++ b/.changelog.d/pr-389.md
@@ -1,0 +1,9 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] An agent panel returns to the running state once the agent resumes work after an input prompt, and drops to idle when a turn is interrupted, resolved from the agent CLI terminal title signal instead of hook events alone.
+  ko: 입력 프롬프트 이후 에이전트가 작업을 재개하면 패널이 다시 실행 중 상태로 돌아오고, 턴이 중단되면 유휴로 내려갑니다. hook 이벤트만이 아니라 에이전트 CLI 터미널 제목 신호로 판정합니다.
+
+### fleet-core
+#### Added
+- [fleet-admiral] A Codex session reports input waiting to the Console through a PermissionRequest hook.
+  ko: Codex 세션이 PermissionRequest hook으로 입력 대기를 Console에 보고합니다.

--- a/packages/fleet-admiral/src/agent-cli/injection.ts
+++ b/packages/fleet-admiral/src/agent-cli/injection.ts
@@ -32,7 +32,7 @@ export interface InjectAgentCliProfileOptions {
   // 턴 시작(UserPromptSubmit)·턴 종료(Stop) 신호 hook. host가 빌드해 주입하며 claude/codex 양쪽에 와이어링된다.
   readonly turnStartHookExec?: FleetHookExec;
   readonly turnEndHookExec?: FleetHookExec;
-  // 입력 대기(AskUserQuestion PreToolUse · 입력 대기 Notification) 신호 hook. Claude 전용 와이어링.
+  // 입력 대기 신호 hook. Claude plugin과 Codex PermissionRequest에 와이어링된다.
   readonly inputWaitingHookExec?: FleetHookExec;
   // 작전명 자동 작명(UserPromptSubmit) hook. host가 빌드해 주입하며 Codex 고정 프로필에만 와이어링된다.
   readonly autoNameHookExec?: FleetHookExec;
@@ -57,6 +57,7 @@ interface CodexProfileHookExecs {
   readonly turnStartHookExec?: FleetHookExec;
   readonly turnEndHookExec?: FleetHookExec;
   readonly autoNameHookExec?: FleetHookExec;
+  readonly inputWaitingHookExec?: FleetHookExec;
 }
 
 interface DedicatedMcpSession {
@@ -125,6 +126,7 @@ export async function injectAgentCliProfile(
           turnStartHookExec: options.turnStartHookExec,
           turnEndHookExec: options.turnEndHookExec,
           autoNameHookExec: options.autoNameHookExec,
+          inputWaitingHookExec: options.inputWaitingHookExec,
         })
       : undefined;
     const launchWarnings: string[] = [];
@@ -260,18 +262,24 @@ function writeCodexFleetProfile(
 }
 
 function codexHooksConfig(hookExecs: CodexProfileHookExecs): string[] {
-  // UserPromptSubmit = 세션 캡처 + 턴 시작 + 자동 작명, Stop = 턴 종료. codex hook 이벤트 키는 PascalCase.
+  // UserPromptSubmit = 세션 캡처 + 턴 시작 + 자동 작명, Stop = 턴 종료,
+  // PermissionRequest = 입력 대기. codex hook 이벤트 키는 PascalCase.
   const userPromptSubmitExecs = [hookExecs.captureSessionHookExec, hookExecs.turnStartHookExec, hookExecs.autoNameHookExec]
     .filter((exec): exec is FleetHookExec => exec !== undefined);
   const stopExecs = [hookExecs.turnEndHookExec]
     .filter((exec): exec is FleetHookExec => exec !== undefined);
-  if (userPromptSubmitExecs.length === 0 && stopExecs.length === 0) return [];
+  const permissionRequestExecs = [hookExecs.inputWaitingHookExec]
+    .filter((exec): exec is FleetHookExec => exec !== undefined);
+  if (userPromptSubmitExecs.length === 0 && stopExecs.length === 0 && permissionRequestExecs.length === 0) return [];
   const lines = ["[hooks]"];
   if (userPromptSubmitExecs.length > 0) {
     lines.push(`UserPromptSubmit = ${codexHookHandlersInline(userPromptSubmitExecs)}`);
   }
   if (stopExecs.length > 0) {
     lines.push(`Stop = ${codexHookHandlersInline(stopExecs)}`);
+  }
+  if (permissionRequestExecs.length > 0) {
+    lines.push(`PermissionRequest = ${codexHookHandlersInline(permissionRequestExecs)}`);
   }
   lines.push("");
   return lines;

--- a/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
@@ -32,8 +32,8 @@ function claudeHooks(options: CreateAgentCliPluginOptions): unknown {
   // Stop: 턴 종료 신호.
   const stopExecs = [options.turnEndHookExec]
     .filter((exec): exec is FleetHookExec => exec !== undefined);
-  // 입력 대기 신호: AskUserQuestion은 tool call이라 PreToolUse(matcher=AskUserQuestion)로 확실히 잡고,
-  // 그 외 입력 대기는 Notification의 입력 대기 타입만 |-구분 정확 매처로 거른다
+  // 입력 대기 신호: AskUserQuestion은 PreToolUse(matcher=AskUserQuestion)와
+  // permission_prompt Notification을 모두 발화한다. 그 외 입력 대기도 Notification의 입력 대기 타입만 |-구분 정확 매처로 거른다
   // (idle_prompt(정상 유휴 대기, 차단 아님)·auth_success·elicitation_complete/response 등 비대기 타입 제외).
   // 한 번의 대기가 PreToolUse와 Notification 두 경로로 동시에 들어올 수 있어, 최종 중복 제거는 클라이언트(store)에서 세션별로 한다.
   const inputWaitingExec = options.inputWaitingHookExec;

--- a/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-session-resume.test.ts
@@ -254,7 +254,7 @@ describe("agent CLI session resume and capture hooks", () => {
     expect(pluginJson.version).toMatch(/^0\.0\.0\+[0-9a-f]{12}$/);
   });
 
-  it("keeps Codex capture, turn-start, auto-name, and turn-end hooks in order", async () => {
+  it("keeps existing Codex handlers in place and adds a synchronous PermissionRequest hook", async () => {
     const root = createTempRoot("fleet-admiral-codex-all-hooks-");
     const codexHome = path.join(root, "codex-home");
     const hookExecs = [
@@ -262,6 +262,7 @@ describe("agent CLI session resume and capture hooks", () => {
       hookExec("turn-start", []),
       hookExec("auto-name", []),
       hookExec("turn-end", []),
+      hookExec("attention", []),
     ];
     const profile = baseProfile("codex", {
       args: [],
@@ -274,11 +275,16 @@ describe("agent CLI session resume and capture hooks", () => {
       captureSessionHookExec: hookExecs[0],
       turnEndHookExec: hookExecs[3],
       turnStartHookExec: hookExecs[1],
+      inputWaitingHookExec: hookExecs[4],
     }));
 
     const toml = readFileSync(path.join(codexHome, "fleet.config.toml"), "utf8");
     expect(readTomlBasicStringValues(toml, "command")).toEqual(hookExecs.map((exec) =>
       buildHostShellCommand([exec.command, ...exec.args])));
+    expect(toml).toContain(`UserPromptSubmit = ${inlineCodexHooks(hookExecs.slice(0, 3))}`);
+    expect(toml).toContain(`Stop = ${inlineCodexHooks([hookExecs[3]!])}`);
+    expect(toml).toContain(`PermissionRequest = ${inlineCodexHooks([hookExecs[4]!])}`);
+    expect(toml).not.toContain("async =");
   });
 
   it.skipIf(process.platform !== "win32")("writes and executes a PowerShell-safe command_windows override for every Codex hook", async () => {
@@ -422,6 +428,7 @@ function baseInjectOptions(
     readonly captureSessionHookExec?: FleetHookExec;
     readonly dedicatedMcpSession?: TestDedicatedMcpSession;
     readonly enableMetaphor?: boolean;
+    readonly inputWaitingHookExec?: FleetHookExec;
     readonly resumeSessionId?: string;
     readonly serverBindings?: AgentServerBindings;
     readonly turnEndHookExec?: FleetHookExec;
@@ -436,6 +443,7 @@ function baseInjectOptions(
     ...(overrides.autoNameHookExec ? { autoNameHookExec: overrides.autoNameHookExec } : {}),
     ...(overrides.captureSessionHookExec ? { captureSessionHookExec: overrides.captureSessionHookExec } : {}),
     ...(overrides.enableMetaphor === undefined ? {} : { enableMetaphor: overrides.enableMetaphor }),
+    ...(overrides.inputWaitingHookExec ? { inputWaitingHookExec: overrides.inputWaitingHookExec } : {}),
     ...(overrides.resumeSessionId ? { resumeSessionId: overrides.resumeSessionId } : {}),
     ...(overrides.serverBindings ? { serverBindings: overrides.serverBindings } : {}),
     ...(overrides.turnEndHookExec ? { turnEndHookExec: overrides.turnEndHookExec } : {}),
@@ -479,6 +487,15 @@ function readTextFilesRecursively(directory: string): string[] {
 
 function hookExec(command: string, args: readonly string[]): FleetHookExec {
   return { args, command };
+}
+
+function inlineCodexHooks(execs: readonly FleetHookExec[]): string {
+  const handlers = execs.map((exec) => {
+    const command = escapeTomlBasicString(buildHostShellCommand([exec.command, ...exec.args]));
+    const commandWindows = escapeTomlBasicString(buildPowerShellCommand([exec.command, ...exec.args]));
+    return `{ type = "command", command = "${command}", command_windows = "${commandWindows}" }`;
+  }).join(", ");
+  return `[{ hooks = [${handlers}] }]`;
 }
 
 function indexOfSequence(values: readonly string[], sequence: readonly string[]): number {

--- a/runtime/fleet-plugins/terminal/client/agent/api.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/api.ts
@@ -115,6 +115,8 @@ export function assertSessionInfo(value: unknown, status: number): SessionInfo {
     cliLabel: typeof payload.cliLabel === "string" ? payload.cliLabel : undefined,
     status: payload.status,
     turnState: payload.turnState === "running" || payload.turnState === "ended" ? payload.turnState : "none",
+    modelActivity: payload.modelActivity === "working" || payload.modelActivity === "not-working" ? payload.modelActivity : undefined,
+    attentionPending: typeof payload.attentionPending === "boolean" ? payload.attentionPending : undefined,
     createdAt: payload.createdAt,
     theaterId: typeof payload.theaterId === "string" ? payload.theaterId : undefined,
     tenantId: typeof payload.tenantId === "string" ? payload.tenantId : undefined,

--- a/runtime/fleet-plugins/terminal/client/agent/connection.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/connection.ts
@@ -7,7 +7,7 @@ import { createSseFrameParser, interpretObserverFrame } from "./sse.js";
 import { applyJobsSnapshot, applyObservedEvent, applySessionUpdate, applyTenantSnapshot, applyTruncation, getAgentState, hydrateAgentClis, hydrateSessions, sessionJobs, setAgentState } from "./store.js";
 import type { SessionInfo } from "./types.js";
 
-interface AgentConnectionOptions {
+export interface AgentConnectionOptions {
   readonly operations: ClientOperationsCapability;
   readonly notifications: ClientNotificationsCapability;
   readonly status: ClientOperationStatusCapability;
@@ -85,8 +85,11 @@ async function consumeStream(reader: ReadableStreamDefaultReader<Uint8Array>, si
   }
 }
 
-function sessionActivity(session: SessionInfo): OperationActivity {
+export function sessionActivity(session: SessionInfo): OperationActivity {
   if (session.status === "dormant") return "dormant";
+  if (session.attentionPending === true) return "awaiting";
+  if (session.modelActivity === "working") return "running";
+  if (session.modelActivity === "not-working") return hasActiveCarrierStream(session) ? "running" : "idle";
   if (session.turnState === "running") return "running";
   // 턴이 종료(ended)됐어도 캐리어 스트리밍이 진행 중이면 running을 유지한다.
   if (session.turnState === "ended") return hasActiveCarrierStream(session) ? "running" : "idle";
@@ -101,7 +104,7 @@ function hasActiveCarrierStream(session: SessionInfo): boolean {
 // status를 반영하고, idle/awaiting로 전이될 때만 notification을 보낸다.
 // 같은 상태 반복은 알리지 않는다. idle 종료 알림은 실제 턴 완료(running/awaiting -> idle)에서만 보내며,
 // dormant -> idle(세션 재개)이나 초기 관측(undefined -> idle)은 턴 완료가 아니므로 제외한다.
-function applyActivity(options: AgentConnectionOptions, sessionId: string, activity: OperationActivity): void {
+export function applyActivity(options: AgentConnectionOptions, sessionId: string, activity: OperationActivity): void {
   const previous = lastActivity.get(sessionId);
   options.status.set(sessionId, activity);
   lastActivity.set(sessionId, activity);
@@ -115,7 +118,7 @@ function applyActivity(options: AgentConnectionOptions, sessionId: string, activ
 
 // 특정 테넌트의 캐리어 job 상태가 바뀌면, 그 테넌트에 연결된 세션의 activity를 다시 계산해 반영한다.
 // (예: 턴 종료 후 마지막 스트리밍 job이 끝나면 running -> idle로 전이)
-function reevaluateSessionsForTenant(options: AgentConnectionOptions, tenantId: string): void {
+export function reevaluateSessionsForTenant(options: AgentConnectionOptions, tenantId: string): void {
   const { sessions } = getAgentState();
   for (const session of Object.values(sessions)) {
     if (session.tenantId !== tenantId) continue;

--- a/runtime/fleet-plugins/terminal/client/agent/types.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/types.ts
@@ -1,6 +1,7 @@
 export type SessionStatus = "starting" | "live" | "registered" | "terminal-only" | "closed" | "error" | "dormant";
 
 export type TurnState = "none" | "running" | "ended";
+export type ModelActivity = "working" | "not-working";
 
 export type AttentionReason =
   | "idle_prompt"
@@ -37,6 +38,8 @@ export interface SessionInfo {
   readonly cliLabel?: string;
   readonly status: SessionStatus;
   readonly turnState: TurnState;
+  readonly modelActivity?: ModelActivity;
+  readonly attentionPending?: boolean;
   readonly createdAt: number;
   readonly theaterId?: string;
   readonly tenantId?: string;

--- a/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
@@ -318,9 +318,11 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
 
   function setTerminalSessionModelActivity(sessionId: string, modelActivity: AgentModelActivity): AgentTerminalSessionInfo | null {
     const session = terminalSessionsById.get(sessionId);
-    if (!session || session.modelActivity === modelActivity) return null;
+    if (!session) return null;
+    const clearsAttention = modelActivity === "working" && session.attentionPending === true;
+    if (session.modelActivity === modelActivity && !clearsAttention) return null;
     session.modelActivity = modelActivity;
-    if (modelActivity === "working") delete session.attentionPending;
+    if (clearsAttention) delete session.attentionPending;
     return toTerminalSessionInfo(session);
   }
 

--- a/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
@@ -6,6 +6,7 @@ import type {
   AgentAttentionReason,
   AgentDurableOperation,
   AgentLabelSource,
+  AgentModelActivity,
   AgentObservedEvent,
   AgentObservedJob,
   AgentObservedRequest,
@@ -63,6 +64,8 @@ interface PendingTerminalSessionState {
   readonly terminalSessionId: string;
   status: AgentSessionStatus;
   turnState?: AgentTurnState;
+  modelActivity?: AgentModelActivity;
+  attentionPending?: boolean;
   registrationId?: string;
   cliRunId?: string;
   providerSession?: AgentProviderSession;
@@ -298,6 +301,10 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
     const session = terminalSessionsById.get(sessionId);
     if (!session) return null;
     session.status = status;
+    if (status === "starting" || status === "dormant") {
+      delete session.modelActivity;
+      delete session.attentionPending;
+    }
     return toTerminalSessionInfo(session);
   }
 
@@ -305,6 +312,15 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
     const session = terminalSessionsById.get(sessionId);
     if (!session) return null;
     session.turnState = turnState;
+    delete session.attentionPending;
+    return toTerminalSessionInfo(session);
+  }
+
+  function setTerminalSessionModelActivity(sessionId: string, modelActivity: AgentModelActivity): AgentTerminalSessionInfo | null {
+    const session = terminalSessionsById.get(sessionId);
+    if (!session || session.modelActivity === modelActivity) return null;
+    session.modelActivity = modelActivity;
+    if (modelActivity === "working") delete session.attentionPending;
     return toTerminalSessionInfo(session);
   }
 
@@ -318,6 +334,8 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
     }
     session.status = "dormant";
     session.providerSession = providerSession;
+    delete session.modelActivity;
+    delete session.attentionPending;
     return toTerminalSessionInfo(session);
   }
 
@@ -393,8 +411,14 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
   }
 
   function notifySessionAttention(session: AgentTerminalSessionInfo, reason?: AgentAttentionReason): void {
-    const event: AgentSessionAttentionEvent = { type: "session:attention", session, reason };
-    // 입력 대기 알림은 1회성 신호다. session:updated와 같은 aggregate 경로로 흘리되 세션 메타는 갱신하지 않는다.
+    const state = terminalSessionsById.get(session.sessionId);
+    if (state && reason !== "idle_prompt") state.attentionPending = true;
+    const event: AgentSessionAttentionEvent = {
+      type: "session:attention",
+      session: state ? toTerminalSessionInfo(state) : session,
+      reason,
+    };
+    // 입력 대기 알림은 1회성 신호다. session:updated와 같은 aggregate 경로로 흘린다.
     for (const listener of allListeners) listener(event);
   }
 
@@ -445,6 +469,7 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
     clearTerminalSessionProviderSession,
     updateTerminalSessionStatus,
     setTerminalSessionTurnState,
+    setTerminalSessionModelActivity,
     transitionTerminalSessionToDormant,
     removeTerminalSession,
     registerTerminalRuntimeSession,
@@ -521,6 +546,8 @@ function toTerminalSessionInfo(state: PendingTerminalSessionState): AgentTermina
     cliLabel: state.cliLabel,
     status: state.status,
     turnState: state.turnState ?? "none",
+    ...(state.modelActivity ? { modelActivity: state.modelActivity } : {}),
+    ...(state.attentionPending === true ? { attentionPending: true } : {}),
     createdAt: state.createdAt,
     theaterId: state.theaterId,
     registrationId: state.registrationId,

--- a/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
@@ -312,6 +312,7 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
     const session = terminalSessionsById.get(sessionId);
     if (!session) return null;
     session.turnState = turnState;
+    delete session.modelActivity;
     delete session.attentionPending;
     return toTerminalSessionInfo(session);
   }

--- a/runtime/fleet-plugins/terminal/server/agent-api/osc-agent-activity.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/osc-agent-activity.ts
@@ -11,6 +11,7 @@ export interface OscAgentActivityTracker {
 
 interface OscAgentActivityTrackerOptions {
   readonly cliId: AgentCliId;
+  readonly cwdBasename: string;
   readonly onActivity: (activity: AgentModelActivity) => void;
 }
 
@@ -43,7 +44,9 @@ export function createOscAgentActivityTracker(options: OscAgentActivityTrackerOp
     const classification = classifyOscAgentActivity(options.cliId, title, codexWorkingBaseline);
     if (classification === "unknown") return;
     if (classification === "working") {
-      if (options.cliId === "codex") codexWorkingBaseline = readWorkingTitleBody(title);
+      if (options.cliId === "codex" && readWorkingTitleBody(title) === options.cwdBasename) {
+        codexWorkingBaseline = options.cwdBasename;
+      }
       cancelPendingNotWorking();
       committed = "working";
       options.onActivity("working");

--- a/runtime/fleet-plugins/terminal/server/agent-api/osc-agent-activity.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/osc-agent-activity.ts
@@ -1,0 +1,81 @@
+import type { AgentCliId } from "@dotobokuri/fleet-admiral";
+
+import type { AgentModelActivity } from "./types.js";
+
+export type OscAgentActivityClassification = AgentModelActivity | "unknown";
+
+export interface OscAgentActivityTracker {
+  observeTitle(title: string): void;
+  reset(): void;
+}
+
+interface OscAgentActivityTrackerOptions {
+  readonly cliId: AgentCliId;
+  readonly onActivity: (activity: AgentModelActivity) => void;
+}
+
+const NOT_WORKING_STABILITY_MS = 400;
+const BRAILLE_START = 0x2800;
+const BRAILLE_END = 0x28ff;
+const CLAUDE_NOT_WORKING = 0x2733;
+
+export function classifyOscAgentActivity(
+  cliId: AgentCliId,
+  title: string,
+  codexWorkingSeen = false,
+): OscAgentActivityClassification {
+  const first = title.codePointAt(0);
+  if (first === undefined) return "unknown";
+  if (first >= BRAILLE_START && first <= BRAILLE_END) return "working";
+  if (cliId === "claude" || cliId === "claude-kimi") {
+    return first === CLAUDE_NOT_WORKING ? "not-working" : "unknown";
+  }
+  if (!codexWorkingSeen) return "unknown";
+  return isOrdinaryTitlePrefix(first) ? "not-working" : "unknown";
+}
+
+export function createOscAgentActivityTracker(options: OscAgentActivityTrackerOptions): OscAgentActivityTracker {
+  let codexWorkingSeen = false;
+  let committed: AgentModelActivity | undefined;
+  let pendingNotWorking: ReturnType<typeof setTimeout> | undefined;
+
+  function observeTitle(title: string): void {
+    const classification = classifyOscAgentActivity(options.cliId, title, codexWorkingSeen);
+    if (classification === "unknown") return;
+    if (classification === "working") {
+      codexWorkingSeen = true;
+      cancelPendingNotWorking();
+      commit("working");
+      return;
+    }
+    if (committed === "not-working" || pendingNotWorking) return;
+    pendingNotWorking = setTimeout(() => {
+      pendingNotWorking = undefined;
+      commit("not-working");
+    }, NOT_WORKING_STABILITY_MS);
+  }
+
+  function commit(activity: AgentModelActivity): void {
+    if (committed === activity) return;
+    committed = activity;
+    options.onActivity(activity);
+  }
+
+  function cancelPendingNotWorking(): void {
+    if (!pendingNotWorking) return;
+    clearTimeout(pendingNotWorking);
+    pendingNotWorking = undefined;
+  }
+
+  function reset(): void {
+    cancelPendingNotWorking();
+    codexWorkingSeen = false;
+    committed = undefined;
+  }
+
+  return { observeTitle, reset };
+}
+
+function isOrdinaryTitlePrefix(codePoint: number): boolean {
+  return codePoint > 0x20 && !(codePoint >= 0x7f && codePoint <= 0x9f);
+}

--- a/runtime/fleet-plugins/terminal/server/agent-api/osc-agent-activity.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/osc-agent-activity.ts
@@ -22,7 +22,7 @@ const CLAUDE_NOT_WORKING = 0x2733;
 export function classifyOscAgentActivity(
   cliId: AgentCliId,
   title: string,
-  codexWorkingSeen = false,
+  codexWorkingBaseline?: string,
 ): OscAgentActivityClassification {
   const first = title.codePointAt(0);
   if (first === undefined) return "unknown";
@@ -30,22 +30,23 @@ export function classifyOscAgentActivity(
   if (cliId === "claude" || cliId === "claude-kimi") {
     return first === CLAUDE_NOT_WORKING ? "not-working" : "unknown";
   }
-  if (!codexWorkingSeen) return "unknown";
-  return isOrdinaryTitlePrefix(first) ? "not-working" : "unknown";
+  if (codexWorkingBaseline === undefined) return "unknown";
+  return title === codexWorkingBaseline ? "not-working" : "unknown";
 }
 
 export function createOscAgentActivityTracker(options: OscAgentActivityTrackerOptions): OscAgentActivityTracker {
-  let codexWorkingSeen = false;
+  let codexWorkingBaseline: string | undefined;
   let committed: AgentModelActivity | undefined;
   let pendingNotWorking: ReturnType<typeof setTimeout> | undefined;
 
   function observeTitle(title: string): void {
-    const classification = classifyOscAgentActivity(options.cliId, title, codexWorkingSeen);
+    const classification = classifyOscAgentActivity(options.cliId, title, codexWorkingBaseline);
     if (classification === "unknown") return;
     if (classification === "working") {
-      codexWorkingSeen = true;
+      if (options.cliId === "codex") codexWorkingBaseline = readWorkingTitleBody(title);
       cancelPendingNotWorking();
-      commit("working");
+      committed = "working";
+      options.onActivity("working");
       return;
     }
     if (committed === "not-working" || pendingNotWorking) return;
@@ -69,13 +70,15 @@ export function createOscAgentActivityTracker(options: OscAgentActivityTrackerOp
 
   function reset(): void {
     cancelPendingNotWorking();
-    codexWorkingSeen = false;
+    codexWorkingBaseline = undefined;
     committed = undefined;
   }
 
   return { observeTitle, reset };
 }
 
-function isOrdinaryTitlePrefix(codePoint: number): boolean {
-  return codePoint > 0x20 && !(codePoint >= 0x7f && codePoint <= 0x9f);
+function readWorkingTitleBody(title: string): string {
+  const first = title.codePointAt(0);
+  if (first === undefined) return "";
+  return title.slice(String.fromCodePoint(first).length).trimStart();
 }

--- a/runtime/fleet-plugins/terminal/server/agent-api/types.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/types.ts
@@ -2,6 +2,8 @@ export type AgentSessionStatus = "starting" | "terminal-only" | "registered" | "
 
 export type AgentTurnState = "none" | "running" | "ended";
 
+export type AgentModelActivity = "working" | "not-working";
+
 export type AgentAttentionReason =
   | "idle_prompt"
   | "permission_prompt"
@@ -49,6 +51,8 @@ export interface AgentTerminalSessionInfo {
   readonly cliLabel?: string;
   readonly status: AgentSessionStatus;
   readonly turnState: AgentTurnState;
+  readonly modelActivity?: AgentModelActivity;
+  readonly attentionPending?: boolean;
   readonly createdAt: number;
   readonly theaterId: string;
   readonly registrationId?: string;

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -129,10 +129,13 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     // spinner는 프레임마다 타이틀을 방출하므로 tracker가 이미 있으면 세션 조회(DTO 투영)를 건너뛴다.
     let tracker = oscActivityTrackers.get(sessionId);
     if (!tracker) {
-      const cliId = observability.getTerminalSessionInfo(sessionId)?.cliId;
+      const session = observability.getTerminalSessionInfo(sessionId);
+      if (!session) return;
+      const cliId = session.cliId;
       if (cliId !== "claude" && cliId !== "claude-kimi" && cliId !== "codex") return;
       tracker = createOscAgentActivityTracker({
         cliId,
+        cwdBasename: session.cwdLabel,
         onActivity: (modelActivity) => {
           const updated = observability.setTerminalSessionModelActivity(sessionId, modelActivity);
           if (updated) observability.notifySessionUpdated(updated);
@@ -454,6 +457,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       ctx.host.http.writeJson(res, 404, { error: "terminal_session_not_found" });
       return true;
     }
+    oscActivityTrackers.get(sessionId)?.reset();
     observability.notifySessionUpdated(updated);
     ctx.host.http.writeJson(res, 200, { ok: true });
     if (turnState === "ended") scheduleIdentityRefresh(sessionId);

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -21,6 +21,7 @@ import { normalizeAttentionReason } from "./agent-api/attention-hook.js";
 import { captureSession, readProviderSessionCapture, readProviderSessionCaptureRaw, unlinkProviderSessionCapture, writeProviderSessionCaptureRaw, type ProviderSession } from "./agent-api/session-capture.js";
 import { createAgentTerminalLaunchResolver, type ConsoleRuntimeSessionInfo } from "./agent-api/launch.js";
 import { createConsoleObservabilityStore } from "./agent-api/observability-store.js";
+import { createOscAgentActivityTracker, type OscAgentActivityTracker } from "./agent-api/osc-agent-activity.js";
 import { writeAggregateObserverEvents } from "./agent-api/observability-routes.js";
 import type { AgentProviderTitleMarker, AgentTerminalSessionInfo, AgentLabelSource } from "./agent-api/types.js";
 type SessionCreateBody = { readonly cliId?: unknown; readonly theaterId?: unknown };
@@ -102,6 +103,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
   const pendingRuntimeSessions = new Map<string, ConsoleRuntimeSessionInfo>();
   const identityRefreshes = new Map<string, { running: boolean; queued: boolean }>();
   const jobOriginById = new Map<string, string>();
+  const oscActivityTrackers = new Map<string, OscAgentActivityTracker>();
   const launchResolver = createAgentTerminalLaunchResolver({
     agentRuntime: runtime,
     dataDir: ctx.host.paths.fleetDataDir,
@@ -122,6 +124,23 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     const sessionId = resolveCarrierEventOrigin(event as { readonly jobId: string; readonly type: string; readonly originSessionId?: string }, jobOriginById);
     if (!sessionId) return;
     observability.appendTerminalRuntimeEvent(sessionId, withSignatureCli(event, runtime.carrierRuntime.registry));
+  });
+  const unsubscribeTitle = terminalRuntime.onTitle(AGENT_OPERATION_TYPE, (sessionId, title) => {
+    // spinner는 프레임마다 타이틀을 방출하므로 tracker가 이미 있으면 세션 조회(DTO 투영)를 건너뛴다.
+    let tracker = oscActivityTrackers.get(sessionId);
+    if (!tracker) {
+      const cliId = observability.getTerminalSessionInfo(sessionId)?.cliId;
+      if (cliId !== "claude" && cliId !== "claude-kimi" && cliId !== "codex") return;
+      tracker = createOscAgentActivityTracker({
+        cliId,
+        onActivity: (modelActivity) => {
+          const updated = observability.setTerminalSessionModelActivity(sessionId, modelActivity);
+          if (updated) observability.notifySessionUpdated(updated);
+        },
+      });
+      oscActivityTrackers.set(sessionId, tracker);
+    }
+    tracker.observeTitle(title);
   });
   // carrier 리마인더와 rename 주입이 세션 단위로 함께 직렬화되도록 공유 writer를 사용한다.
   const reminderWriter = createDelayedPtyWriter();
@@ -361,6 +380,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       ctx.host.http.writeJson(res, node ? 409 : 404, { error: node ? "resume_unavailable" : "session_not_found" });
       return true;
     }
+    resetOscActivity(sessionId);
     const starting = observability.updateTerminalSessionStatus(sessionId, "starting") ?? injectOperation(node);
     const staleCapture = fresh ? readProviderSessionCaptureRaw(sessionId, { capturesDir: ctx.host.paths.capturesDir }) : null;
     try {
@@ -402,6 +422,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       ctx.host.operations.patch(sessionId, { payload: toOperationPayload(currentPayload ?? node.payload, cwd, resumed, effectiveProviderSession, observability.getDurableOperation(sessionId)?.providerTitle) });
       ctx.host.http.writeJson(res, 200, resumed);
     } catch {
+      resetOscActivity(sessionId);
       if (fresh && providerSession) {
         // 실패 롤백: spawn 전에 떼어낸 capture 파일·payload providerSession·observability 세션을
         // 모두 복원한다 — payload만 복원하면 resume은 되지만 Analyst가 transcript를 잃는다(Codex P2).
@@ -529,6 +550,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
 
   async function handleExit(operationId: string): Promise<void> {
     reminderWriter.cancel(operationId);
+    resetOscActivity(operationId);
     pendingRuntimeSessions.delete(operationId);
     const providerSession = readProviderSessionCapture(operationId, { capturesDir: ctx.host.paths.capturesDir }) ?? readProviderSession(ctx.host.operations.get(operationId)?.payload);
     if (providerSession) {
@@ -547,6 +569,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
 
   function removeSession(sessionId: string): void {
     reminderWriter.cancel(sessionId);
+    resetOscActivity(sessionId);
     terminalRuntime.terminate(sessionId);
     pendingRuntimeSessions.delete(sessionId);
     observability.removeTerminalSession(sessionId);
@@ -562,7 +585,16 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
     unsubscribePurge();
     unsubscribeReminder();
     unsubscribeStream();
+    unsubscribeTitle();
+    for (const tracker of oscActivityTrackers.values()) tracker.reset();
+    oscActivityTrackers.clear();
     await runtime.cleanup();
+  }
+
+  function resetOscActivity(sessionId: string): void {
+    const tracker = oscActivityTrackers.get(sessionId);
+    tracker?.reset();
+    oscActivityTrackers.delete(sessionId);
   }
 
   function scheduleIdentityRefresh(sessionId: string): void {

--- a/runtime/fleet-plugins/terminal/server/shared/index.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/index.ts
@@ -8,6 +8,7 @@ export type {
   TerminalSocketData,
   TerminalTicket,
   TerminalTicketContext,
+  TerminalTitleListener,
 } from "./terminal-types.js";
 export { createPluginTerminalTicketRegistry } from "./tickets.js";
 export type { TerminalTicketRegistry, TerminalTicketRegistryDeps } from "./tickets.js";

--- a/runtime/fleet-plugins/terminal/server/shared/osc-title-parser.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/osc-title-parser.ts
@@ -1,0 +1,95 @@
+const ESC = 0x1b;
+const BEL = 0x07;
+const OSC = 0x5d;
+const STRING_TERMINATOR = 0x5c;
+const ASCII_ZERO = 0x30;
+const ASCII_TWO = 0x32;
+const SEMICOLON = 0x3b;
+const DEFAULT_OSC_TITLE_RESIDUAL_LIMIT = 8_192;
+const EMPTY_TITLES: readonly string[] = [];
+
+export interface OscTitleParser {
+  push(chunk: Buffer): readonly string[];
+  reset(): void;
+}
+
+export function createOscTitleParser(residualLimit = DEFAULT_OSC_TITLE_RESIDUAL_LIMIT): OscTitleParser {
+  let residual: Buffer | undefined;
+
+  function push(chunk: Buffer): readonly string[] {
+    if (chunk.length === 0) return EMPTY_TITLES;
+    if (!residual && chunk.indexOf(ESC) === -1) return EMPTY_TITLES;
+
+    const source = residual ? Buffer.concat([residual, chunk]) : chunk;
+    residual = undefined;
+    let titles: string[] | undefined;
+    let cursor = 0;
+
+    while (cursor < source.length) {
+      const start = source.indexOf(ESC, cursor);
+      if (start === -1) break;
+      const prefix = readOscTitlePrefix(source, start);
+      if (prefix === "partial") {
+        residual = retainResidual(source, start, residualLimit);
+        break;
+      }
+      if (prefix === "invalid") {
+        cursor = start + 1;
+        continue;
+      }
+
+      const titleStart = start + 4;
+      let index = titleStart;
+      let titleEnd = -1;
+      let sequenceEnd = -1;
+      while (index < source.length) {
+        const byte = source[index];
+        if (byte === BEL) {
+          titleEnd = index;
+          sequenceEnd = index + 1;
+          break;
+        }
+        if (byte === ESC) {
+          if (index + 1 >= source.length) break;
+          if (source[index + 1] === STRING_TERMINATOR) {
+            titleEnd = index;
+            sequenceEnd = index + 2;
+            break;
+          }
+        }
+        index += 1;
+      }
+
+      if (sequenceEnd === -1) {
+        residual = retainResidual(source, start, residualLimit);
+        break;
+      }
+      (titles ??= []).push(source.toString("utf8", titleStart, titleEnd));
+      cursor = sequenceEnd;
+    }
+
+    return titles ?? EMPTY_TITLES;
+  }
+
+  return {
+    push,
+    reset: () => {
+      residual = undefined;
+    },
+  };
+}
+
+function readOscTitlePrefix(source: Buffer, start: number): "valid" | "invalid" | "partial" {
+  if (start + 1 >= source.length) return "partial";
+  if (source[start + 1] !== OSC) return "invalid";
+  if (start + 2 >= source.length) return "partial";
+  if (source[start + 2] !== ASCII_ZERO && source[start + 2] !== ASCII_TWO) return "invalid";
+  if (start + 3 >= source.length) return "partial";
+  return source[start + 3] === SEMICOLON ? "valid" : "invalid";
+}
+
+function retainResidual(source: Buffer, start: number, limit: number): Buffer | undefined {
+  const length = source.length - start;
+  if (limit <= 0 || length > limit) return undefined;
+  return Buffer.from(source.subarray(start));
+}

--- a/runtime/fleet-plugins/terminal/server/shared/runtime.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/runtime.ts
@@ -5,7 +5,7 @@ import type { UpgradeHandler } from "@fleet-console/sdk/routing";
 import { createShellTerminalLaunchResolver, startTerminalShell, type TerminalLaunchResolver } from "./pty.js";
 import { createTerminalSessionManager } from "./session-manager.js";
 import { createPluginTerminalTicketRegistry } from "./tickets.js";
-import type { TerminalTicket, TerminalTicketContext, TerminalLaunchContext, TerminalLaunchSpec } from "./terminal-types.js";
+import type { TerminalTicket, TerminalTicketContext, TerminalLaunchContext, TerminalLaunchSpec, TerminalTitleListener } from "./terminal-types.js";
 import { createPluginTerminalUpgradeHandler } from "./ws.js";
 
 export interface TerminalRuntime {
@@ -19,6 +19,7 @@ export interface TerminalRuntime {
   getRenameCommand(operationId: string): string | undefined;
   resolveSessionIdentity(operationId: string, providerSessionId: string): Promise<string | null>;
   onExit(callback: (operationId: string) => void | Promise<void>): () => void;
+  onTitle(operationType: string, callback: TerminalTitleListener): () => void;
   registerLaunchResolver(operationType: string, resolver: TerminalLaunchResolver): () => void;
   stop(): Promise<void>;
 }
@@ -30,12 +31,20 @@ const SHELL_OPERATION_TYPE = "shell";
 export function createTerminalRuntime(ctx: FleetPluginServerContext): TerminalRuntime {
   const tickets = createPluginTerminalTicketRegistry();
   const terminalExitListeners = new Set<(operationId: string) => void | Promise<void>>();
+  const terminalTitleListeners = new Map<string, Set<TerminalTitleListener>>();
   const terminalLaunchResolvers = new Map<string, TerminalLaunchResolver>();
   const defaultTerminalLaunch = createShellTerminalLaunchResolver();
   terminalLaunchResolvers.set(SHELL_OPERATION_TYPE, (cwd, context) => defaultTerminalLaunch(cwd, { ...context, kind: "shell" }));
   const sessions = createTerminalSessionManager({
     launch: createRegistryAwareTerminalLaunchResolver(defaultTerminalLaunch, terminalLaunchResolvers),
     startShell: startTerminalShell,
+    resolveTitleListener: (context) => {
+      const operationType = context.operationType;
+      if (!operationType || !terminalTitleListeners.has(operationType)) return undefined;
+      return (sessionId, title) => {
+        for (const listener of terminalTitleListeners.get(operationType) ?? []) listener(sessionId, title);
+      };
+    },
     onSessionExit: async (sessionId) => {
       await Promise.all([...terminalExitListeners].map((listener) => listener(sessionId)));
     },
@@ -62,6 +71,15 @@ export function createTerminalRuntime(ctx: FleetPluginServerContext): TerminalRu
       terminalExitListeners.add(callback);
       return () => terminalExitListeners.delete(callback);
     },
+    onTitle: (operationType, callback) => {
+      const listeners = terminalTitleListeners.get(operationType) ?? new Set<TerminalTitleListener>();
+      listeners.add(callback);
+      terminalTitleListeners.set(operationType, listeners);
+      return () => {
+        listeners.delete(callback);
+        if (listeners.size === 0) terminalTitleListeners.delete(operationType);
+      };
+    },
     registerLaunchResolver: (operationType, resolver) => {
       terminalLaunchResolvers.set(operationType, resolver);
       return () => {
@@ -72,6 +90,7 @@ export function createTerminalRuntime(ctx: FleetPluginServerContext): TerminalRu
       upgrade.close();
       await sessions.stop();
       terminalExitListeners.clear();
+      terminalTitleListeners.clear();
       terminalLaunchResolvers.clear();
     },
   };

--- a/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
@@ -3,8 +3,9 @@ import { closeSync, fstatSync, readdirSync } from "node:fs";
 import type { CliMessagePolicy } from "@dotobokuri/fleet-admiral";
 import type { SessionIdentityResolver } from "@dotobokuri/core-unified-agent";
 
+import { createOscTitleParser, type OscTitleParser } from "./osc-title-parser.js";
 import { startTerminalShell, type TerminalLaunchResolver } from "./pty.js";
-import type { TerminalPtyHandle, TerminalSessionManager, TerminalSocket, TerminalSocketData, TerminalTicketContext } from "./terminal-types.js";
+import type { TerminalPtyHandle, TerminalSessionManager, TerminalSocket, TerminalSocketData, TerminalTicketContext, TerminalTitleListener } from "./terminal-types.js";
 
 export interface TerminalSessionManagerDeps {
   readonly launch: TerminalLaunchResolver;
@@ -12,6 +13,7 @@ export interface TerminalSessionManagerDeps {
   // DI 계약 유지용으로 받지만 더 이상 동시 세션 상한을 강제하지 않는다(상한 해제됨).
   readonly maxSessions?: number;
   readonly scrollbackLimit?: number;
+  readonly resolveTitleListener?: (context: TerminalTicketContext) => TerminalTitleListener | undefined;
   // PTY가 종료되거나 세션이 정리될 때(멱등) 정확히 한 번 호출 — 콘솔 세션 목록 정리에 쓰인다.
   readonly onSessionExit?: (sessionId: string) => unknown;
 }
@@ -26,6 +28,8 @@ interface TerminalSession {
   readonly messagePolicy?: CliMessagePolicy;
   readonly renameCommand?: string;
   readonly sessionIdentityResolver?: SessionIdentityResolver;
+  readonly titleListener?: TerminalTitleListener;
+  readonly titleParser?: OscTitleParser;
   activeSocket: TerminalSocket | null;
   cols: number;
   rows: number;
@@ -181,6 +185,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
       await runLaunchCleanup(launch.cleanup);
       throw error;
     }
+    const titleListener = deps.resolveTitleListener?.(context);
     const session: TerminalSession = {
       id: context.sessionId,
       pty,
@@ -191,6 +196,8 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
       messagePolicy: launch.messagePolicy,
       renameCommand: launch.renameCommand,
       sessionIdentityResolver: launch.sessionIdentityResolver,
+      titleListener,
+      ...(titleListener ? { titleParser: createOscTitleParser() } : {}),
       activeSocket: null,
       cols: DEFAULT_COLS,
       rows: DEFAULT_ROWS,
@@ -219,10 +226,26 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
   function handlePtyData(session: TerminalSession, data: string): void {
     const buffer = Buffer.from(data, "utf8");
     respondToTerminalQueries(session, buffer);
+    observeOscTitles(session, buffer);
     session.scrollback.push(buffer);
     while (session.scrollback.length > scrollbackLimit) session.scrollback.shift();
     if (session.activeSocket && session.activeSocket.readyState === WS_OPEN_STATE) {
       session.activeSocket.send(buffer, { binary: true });
+    }
+  }
+
+  function observeOscTitles(session: TerminalSession, buffer: Buffer): void {
+    if (!session.titleParser || !session.titleListener) return;
+    try {
+      for (const title of session.titleParser.push(buffer)) {
+        try {
+          session.titleListener(session.id, title);
+        } catch {
+          continue;
+        }
+      }
+    } catch {
+      session.titleParser.reset();
     }
   }
 

--- a/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
@@ -67,6 +67,8 @@ export interface TerminalSocket {
 
 export type TerminalSocketData = Buffer | ArrayBuffer | Buffer[];
 
+export type TerminalTitleListener = (sessionId: string, title: string) => unknown;
+
 export interface TerminalSessionManager {
   canAttach(sessionId: string): boolean;
   createSession(context: TerminalTicketContext): Promise<void>;

--- a/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
@@ -18,6 +18,7 @@ const cleanups: Array<() => void | Promise<void>> = [];
 const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
   for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
   for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
@@ -41,6 +42,54 @@ describe("agent provider capture grace", () => {
     harness.emitHostEvent("operation:purged", { operationId: sessionId, pluginId: "terminal", type: "agent" });
     expect(fs.existsSync(capturePath)).toBe(false);
   });
+
+  it("cancels pending OSC activity when a session is removed", async () => {
+    vi.useFakeTimers();
+    const harness = createHarness({ cliId: "codex" });
+    await harness.postSessions();
+    const sessionId = harness.operations[0]!.id;
+    harness.emitTitle(sessionId, "⠏ project");
+    harness.emitTitle(sessionId, "project");
+
+    await harness.deleteSession(sessionId);
+    vi.advanceTimersByTime(400);
+
+    expect(await harness.getSessions()).toEqual([]);
+  });
+
+  it("cancels pending OSC activity before a PTY exit makes the session dormant", async () => {
+    vi.useFakeTimers();
+    const harness = createHarness({ cliId: "codex" });
+    await harness.postSessions();
+    const sessionId = harness.operations[0]!.id;
+    harness.markProviderSession(sessionId);
+    harness.emitTitle(sessionId, "⠏ project");
+    harness.emitTitle(sessionId, "project");
+
+    await harness.emitExit(sessionId);
+    vi.advanceTimersByTime(400);
+
+    expect(await harness.getSessions()).toEqual([
+      expect.objectContaining({ sessionId, status: "dormant" }),
+    ]);
+    expect((await harness.getSessions())[0]).not.toHaveProperty("modelActivity");
+  });
+
+  it("cancels pending OSC activity before resume spawns a replacement PTY", async () => {
+    vi.useFakeTimers();
+    const harness = createHarness({ cliId: "codex" });
+    await harness.postSessions();
+    const sessionId = harness.operations[0]!.id;
+    harness.markProviderSession(sessionId);
+    harness.emitTitle(sessionId, "⠏ project");
+    harness.emitTitle(sessionId, "project");
+
+    await harness.resumeSession(sessionId);
+    vi.advanceTimersByTime(400);
+
+    expect((await harness.getSessions())[0]).toMatchObject({ sessionId, status: "terminal-only" });
+    expect((await harness.getSessions())[0]).not.toHaveProperty("modelActivity");
+  });
 });
 
 function createHarness(body: Record<string, unknown>) {
@@ -52,6 +101,7 @@ function createHarness(body: Record<string, unknown>) {
   let route: RouteHandler | undefined;
   let lifecycleCleanup: (() => void | Promise<void>) | undefined;
   let exitCallback: ((operationId: string) => void | Promise<void>) | undefined;
+  let titleCallback: ((operationId: string, title: string) => unknown) | undefined;
   const attach = vi.fn<TerminalRuntime["attach"]>(async () => {});
   const write = vi.fn<(sessionId: string, data: string) => boolean>(() => true);
   const terminate = vi.fn(() => true);
@@ -71,7 +121,12 @@ function createHarness(body: Record<string, unknown>) {
         if (exitCallback === callback) exitCallback = undefined;
       };
     },
-    onTitle: () => () => {},
+    onTitle: (_operationType, callback) => {
+      titleCallback = callback;
+      return () => {
+        if (titleCallback === callback) titleCallback = undefined;
+      };
+    },
     registerLaunchResolver: () => () => {},
     stop: async () => {},
   };
@@ -184,6 +239,10 @@ function createHarness(body: Record<string, unknown>) {
       for (const listener of eventListeners.get(channel) ?? []) listener(payload);
     },
     responses,
+    emitTitle: (sessionId: string, title: string) => {
+      if (!titleCallback) throw new Error("Terminal title callback was not registered");
+      titleCallback(sessionId, title);
+    },
     terminate,
     write,
     emitExit: async (sessionId: string) => {
@@ -206,6 +265,18 @@ function createHarness(body: Record<string, unknown>) {
         res: {} as http.ServerResponse,
         pathname: `/plugins/terminal/agent/sessions/${sessionId}`,
       });
+    },
+    getSessions: async (): Promise<readonly Record<string, unknown>[]> => {
+      if (!route) throw new Error("Agent route was not registered");
+      const responseCount = responses.length;
+      await route({
+        req: { method: "GET", url: "/plugins/terminal/agent/sessions" } as http.IncomingMessage,
+        res: {} as http.ServerResponse,
+        pathname: "/plugins/terminal/agent/sessions",
+      });
+      const response = responses[responseCount];
+      const body = response?.body as { readonly sessions?: readonly Record<string, unknown>[] } | undefined;
+      return body?.sessions ?? [];
     },
     postSessions: async () => {
       if (!route) throw new Error("Agent route was not registered");

--- a/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
@@ -71,6 +71,7 @@ function createHarness(body: Record<string, unknown>) {
         if (exitCallback === callback) exitCallback = undefined;
       };
     },
+    onTitle: () => () => {},
     registerLaunchResolver: () => () => {},
     stop: async () => {},
   };

--- a/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
@@ -48,8 +48,8 @@ describe("agent provider capture grace", () => {
     const harness = createHarness({ cliId: "codex" });
     await harness.postSessions();
     const sessionId = harness.operations[0]!.id;
-    harness.emitTitle(sessionId, "⠏ project");
-    harness.emitTitle(sessionId, "project");
+    harness.emitTitle(sessionId, "⠏ theater");
+    harness.emitTitle(sessionId, "theater");
 
     await harness.deleteSession(sessionId);
     vi.advanceTimersByTime(400);
@@ -63,8 +63,8 @@ describe("agent provider capture grace", () => {
     await harness.postSessions();
     const sessionId = harness.operations[0]!.id;
     harness.markProviderSession(sessionId);
-    harness.emitTitle(sessionId, "⠏ project");
-    harness.emitTitle(sessionId, "project");
+    harness.emitTitle(sessionId, "⠏ theater");
+    harness.emitTitle(sessionId, "theater");
 
     await harness.emitExit(sessionId);
     vi.advanceTimersByTime(400);
@@ -81,14 +81,38 @@ describe("agent provider capture grace", () => {
     await harness.postSessions();
     const sessionId = harness.operations[0]!.id;
     harness.markProviderSession(sessionId);
-    harness.emitTitle(sessionId, "⠏ project");
-    harness.emitTitle(sessionId, "project");
+    harness.emitTitle(sessionId, "⠏ theater");
+    harness.emitTitle(sessionId, "theater");
 
     await harness.resumeSession(sessionId);
     vi.advanceTimersByTime(400);
 
     expect((await harness.getSessions())[0]).toMatchObject({ sessionId, status: "terminal-only" });
     expect((await harness.getSessions())[0]).not.toHaveProperty("modelActivity");
+  });
+
+  it("resets tracker state on a turn transition before recommitting the same Codex bare title", async () => {
+    vi.useFakeTimers();
+    const harness = createHarness({ cliId: "codex", phase: "start" });
+    await harness.postSessions();
+    const sessionId = harness.operations[0]!.id;
+    harness.emitTitle(sessionId, "⠏ theater");
+    harness.emitTitle(sessionId, "theater");
+    vi.advanceTimersByTime(400);
+    expect((await harness.getSessions())[0]).toMatchObject({ modelActivity: "not-working" });
+
+    await harness.turnSession(sessionId);
+    expect((await harness.getSessions())[0]).toMatchObject({ turnState: "running" });
+    expect((await harness.getSessions())[0]).not.toHaveProperty("modelActivity");
+
+    harness.emitTitle(sessionId, "theater");
+    vi.advanceTimersByTime(400);
+    expect((await harness.getSessions())[0]).not.toHaveProperty("modelActivity");
+
+    harness.emitTitle(sessionId, "⠏ theater");
+    harness.emitTitle(sessionId, "theater");
+    vi.advanceTimersByTime(400);
+    expect((await harness.getSessions())[0]).toMatchObject({ modelActivity: "not-working" });
   });
 });
 
@@ -292,6 +316,14 @@ function createHarness(body: Record<string, unknown>) {
         req: { method: "POST", url: `/plugins/terminal/agent/sessions/${sessionId}/resume` } as http.IncomingMessage,
         res: {} as http.ServerResponse,
         pathname: `/plugins/terminal/agent/sessions/${sessionId}/resume`,
+      });
+    },
+    turnSession: async (sessionId: string) => {
+      if (!route) throw new Error("Agent route was not registered");
+      await route({
+        req: { method: "POST", url: `/plugins/terminal/agent/sessions/${sessionId}/turn` } as http.IncomingMessage,
+        res: {} as http.ServerResponse,
+        pathname: `/plugins/terminal/agent/sessions/${sessionId}/turn`,
       });
     },
   };

--- a/runtime/fleet-plugins/terminal/tests/agent-connection-activity.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-connection-activity.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { applyActivity, reevaluateSessionsForTenant, sessionActivity, type AgentConnectionOptions } from "../client/agent/connection.js";
+import { assertSessionInfo } from "../client/agent/api.js";
+import { applyJobsSnapshot, hydrateSessions } from "../client/agent/store.js";
+import type { SessionInfo } from "../client/agent/types.js";
+
+describe("Agent connection activity state machine", () => {
+  it("validates and maps additive activity facts from session DTOs", () => {
+    expect(assertSessionInfo({
+      sessionId: "dto-session",
+      cwdLabel: "project",
+      status: "registered",
+      createdAt: 1_000,
+      modelActivity: "working",
+      attentionPending: true,
+    }, 200)).toMatchObject({
+      modelActivity: "working",
+      attentionPending: true,
+    });
+    expect(assertSessionInfo({
+      sessionId: "legacy-session",
+      cwdLabel: "project",
+      status: "registered",
+      createdAt: 1_000,
+      modelActivity: "unexpected",
+      attentionPending: "yes",
+    }, 200)).toMatchObject({
+      modelActivity: undefined,
+      attentionPending: undefined,
+    });
+  });
+
+  it("composes attention, working, not-working, dormant, and legacy turn state in fixed priority order", () => {
+    expect(sessionActivity(makeSession({ status: "dormant", attentionPending: true, modelActivity: "working" }))).toBe("dormant");
+    expect(sessionActivity(makeSession({ attentionPending: true, modelActivity: "working" }))).toBe("awaiting");
+    expect(sessionActivity(makeSession({ modelActivity: "working", turnState: "ended" }))).toBe("running");
+    expect(sessionActivity(makeSession({ modelActivity: "not-working", turnState: "running" }))).toBe("idle");
+    expect(sessionActivity(makeSession({ turnState: "running" }))).toBe("running");
+    expect(sessionActivity(makeSession({ turnState: "ended" }))).toBe("idle");
+  });
+
+  it("keeps not-working sessions running while a Carrier stream is active", () => {
+    const session = makeSession({ sessionId: "carrier-active", tenantId: "tenant-carrier", modelActivity: "not-working" });
+    applyJobsSnapshot([{
+      tenantId: "tenant-carrier",
+      jobs: [{ jobId: "job-a", status: "active", updatedAt: 1_000, events: [] }],
+    }]);
+
+    expect(sessionActivity(session)).toBe("running");
+  });
+
+  it("moves awaiting to running on working and to idle on not-working without duplicate notifications", () => {
+    const { options, statusSet, notifications } = createOptions();
+    const sessionId = "activity-transitions";
+
+    applyActivity(options, sessionId, "awaiting");
+    applyActivity(options, sessionId, "awaiting");
+    applyActivity(options, sessionId, "running");
+    applyActivity(options, sessionId, "idle");
+    applyActivity(options, sessionId, "idle");
+
+    expect(statusSet.mock.calls.map((call) => call[1])).toEqual(["awaiting", "awaiting", "running", "idle", "idle"]);
+    expect(notifications.mock.calls.map((call) => call[0].kind)).toEqual(["agent.attention", "agent.ended"]);
+  });
+
+  it("does not let Carrier job reevaluation overwrite awaiting", () => {
+    const { options, statusSet } = createOptions();
+    const session = makeSession({ sessionId: "awaiting-carrier", tenantId: "tenant-awaiting", turnState: "running" });
+    hydrateSessions([session]);
+    applyJobsSnapshot([{
+      tenantId: "tenant-awaiting",
+      jobs: [{ jobId: "job-a", status: "active", updatedAt: 1_000, events: [] }],
+    }]);
+    applyActivity(options, session.sessionId, "awaiting");
+
+    reevaluateSessionsForTenant(options, "tenant-awaiting");
+
+    expect(statusSet).toHaveBeenCalledTimes(1);
+    expect(statusSet).toHaveBeenLastCalledWith(session.sessionId, "awaiting");
+  });
+});
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    sessionId: "session-a",
+    terminalSessionId: "session-a",
+    cwdLabel: "project",
+    status: "registered",
+    turnState: "none",
+    createdAt: 1_000,
+    resumeAvailable: false,
+    ...overrides,
+  };
+}
+
+function createOptions() {
+  const statusSet = vi.fn();
+  const notifications = vi.fn();
+  const options = {
+    status: { set: statusSet },
+    notifications: { emit: notifications },
+    operations: {},
+    refreshOperations: vi.fn(),
+  } as unknown as AgentConnectionOptions;
+  return { notifications, options, statusSet };
+}

--- a/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import { sessionActivity } from "../client/agent/connection.js";
 import { reduceSnapshotJob } from "../client/agent/reduce.js";
 import { createConsoleObservabilityStore } from "../server/agent-api/observability-store.js";
 
@@ -354,15 +355,22 @@ describe("agent activity observability state", () => {
     expect(JSON.stringify(store.listDurableOperations())).not.toContain("attentionPending");
   });
 
-  it("clears attention on either turn phase and clears both transient axes on dormant transition", () => {
+  it("clears both transient axes on either turn phase and falls back to the hook turn state", () => {
     const store = createStore();
     const initial = store.getTerminalSessionInfo("session-a")!;
     store.setTerminalSessionModelActivity("session-a", "not-working");
     store.notifySessionAttention(initial, "permission_prompt");
 
-    expect(store.setTerminalSessionTurnState("session-a", "running")).not.toHaveProperty("attentionPending");
+    const started = store.setTerminalSessionTurnState("session-a", "running")!;
+    expect(started).not.toHaveProperty("attentionPending");
+    expect(started).not.toHaveProperty("modelActivity");
+    expect(sessionActivity(started)).toBe("running");
+    store.setTerminalSessionModelActivity("session-a", "not-working");
     store.notifySessionAttention(store.getTerminalSessionInfo("session-a")!, "elicitation_dialog");
-    expect(store.setTerminalSessionTurnState("session-a", "ended")).not.toHaveProperty("attentionPending");
+    const ended = store.setTerminalSessionTurnState("session-a", "ended")!;
+    expect(ended).not.toHaveProperty("attentionPending");
+    expect(ended).not.toHaveProperty("modelActivity");
+    expect(sessionActivity(ended)).toBe("idle");
     store.notifySessionAttention(store.getTerminalSessionInfo("session-a")!, "idle_prompt");
     expect(store.getTerminalSessionInfo("session-a")).not.toHaveProperty("attentionPending");
 

--- a/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
@@ -376,6 +376,27 @@ describe("agent activity observability state", () => {
     expect(dormant).not.toHaveProperty("modelActivity");
     expect(dormant).not.toHaveProperty("attentionPending");
   });
+
+  it("emits exactly one update when repeated working clears late attention", () => {
+    const store = createStore();
+    const frames: unknown[] = [];
+    store.subscribeAll((event) => frames.push(event));
+    const firstWorking = store.setTerminalSessionModelActivity("session-a", "working")!;
+    store.notifySessionUpdated(firstWorking);
+    store.notifySessionAttention(firstWorking, "permission_prompt");
+
+    const cleared = store.setTerminalSessionModelActivity("session-a", "working");
+    expect(cleared).toMatchObject({ modelActivity: "working" });
+    expect(cleared).not.toHaveProperty("attentionPending");
+    if (cleared) store.notifySessionUpdated(cleared);
+    expect(store.setTerminalSessionModelActivity("session-a", "working")).toBeNull();
+
+    expect(frames.map((frame) => (frame as { readonly type: string }).type)).toEqual([
+      "session:updated",
+      "session:attention",
+      "session:updated",
+    ]);
+  });
 });
 
 describe("agent operation title precedence", () => {

--- a/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
@@ -314,6 +314,70 @@ describe("agent observability DTO boundary", () => {
   });
 });
 
+describe("agent activity observability state", () => {
+  function createStore() {
+    const store = createConsoleObservabilityStore({ workspaceHash: () => "theater-a" });
+    store.createPendingTerminalSession({ sessionId: "session-a", cwd: "/workspace/project", cliId: "claude", createdAt: 1_000 });
+    return store;
+  }
+
+  it("projects only classified activity and pending attention into browser DTOs", () => {
+    const store = createStore();
+    const frames: unknown[] = [];
+    store.subscribeAll((event) => frames.push(event));
+
+    const notWorking = store.setTerminalSessionModelActivity("session-a", "not-working");
+    expect(notWorking).toMatchObject({ modelActivity: "not-working" });
+    if (notWorking) store.notifySessionUpdated(notWorking);
+    expect(store.setTerminalSessionModelActivity("session-a", "not-working")).toBeNull();
+
+    store.notifySessionAttention(notWorking!, "permission_prompt");
+    expect(store.getTerminalSessionInfo("session-a")).toMatchObject({
+      modelActivity: "not-working",
+      attentionPending: true,
+    });
+
+    const working = store.setTerminalSessionModelActivity("session-a", "working");
+    expect(working).toMatchObject({ modelActivity: "working" });
+    expect(working).not.toHaveProperty("attentionPending");
+    if (working) store.notifySessionUpdated(working);
+    expect(store.setTerminalSessionModelActivity("session-a", "working")).toBeNull();
+
+    expect(frames.map((frame) => (frame as { readonly type: string }).type)).toEqual([
+      "session:updated",
+      "session:attention",
+      "session:updated",
+    ]);
+    const serialized = JSON.stringify({ durable: store.listDurableOperations(), frames });
+    expect(serialized).not.toContain("raw title");
+    expect(JSON.stringify(store.listDurableOperations())).not.toContain("modelActivity");
+    expect(JSON.stringify(store.listDurableOperations())).not.toContain("attentionPending");
+  });
+
+  it("clears attention on either turn phase and clears both transient axes on dormant transition", () => {
+    const store = createStore();
+    const initial = store.getTerminalSessionInfo("session-a")!;
+    store.setTerminalSessionModelActivity("session-a", "not-working");
+    store.notifySessionAttention(initial, "permission_prompt");
+
+    expect(store.setTerminalSessionTurnState("session-a", "running")).not.toHaveProperty("attentionPending");
+    store.notifySessionAttention(store.getTerminalSessionInfo("session-a")!, "elicitation_dialog");
+    expect(store.setTerminalSessionTurnState("session-a", "ended")).not.toHaveProperty("attentionPending");
+    store.notifySessionAttention(store.getTerminalSessionInfo("session-a")!, "idle_prompt");
+    expect(store.getTerminalSessionInfo("session-a")).not.toHaveProperty("attentionPending");
+
+    store.notifySessionAttention(store.getTerminalSessionInfo("session-a")!, "permission_prompt");
+    const dormant = store.transitionTerminalSessionToDormant("session-a", {
+      provider: "claude",
+      sessionId: "provider-session",
+      capturedAt: "2026-07-25T00:00:00.000Z",
+    });
+    expect(dormant).toMatchObject({ status: "dormant" });
+    expect(dormant).not.toHaveProperty("modelActivity");
+    expect(dormant).not.toHaveProperty("attentionPending");
+  });
+});
+
 describe("agent operation title precedence", () => {
   function createStore() {
     return createConsoleObservabilityStore({ workspaceHash: () => "theater-a" });

--- a/runtime/fleet-plugins/terminal/tests/osc-agent-activity.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/osc-agent-activity.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { classifyOscAgentActivity, createOscAgentActivityTracker } from "../server/agent-api/osc-agent-activity.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("OSC Agent activity classification", () => {
+  it("classifies Claude family spinner, not-working glyph, and unknown prefixes", () => {
+    expect(classifyOscAgentActivity("claude", "⠐ project")).toBe("working");
+    expect(classifyOscAgentActivity("claude-kimi", "✳ project")).toBe("not-working");
+    expect(classifyOscAgentActivity("claude", "project")).toBe("unknown");
+  });
+
+  it("gates bare Codex titles on a previously recognized spinner", () => {
+    expect(classifyOscAgentActivity("codex", "⠂ project", false)).toBe("working");
+    expect(classifyOscAgentActivity("codex", "project", false)).toBe("unknown");
+    expect(classifyOscAgentActivity("codex", "project", true)).toBe("not-working");
+    expect(classifyOscAgentActivity("codex", " project", true)).toBe("unknown");
+    expect(classifyOscAgentActivity("codex", "\x1bproject", true)).toBe("unknown");
+  });
+});
+
+describe("OSC Agent activity debounce", () => {
+  it("commits working immediately and not-working only after 400ms", () => {
+    vi.useFakeTimers();
+    const emitted: string[] = [];
+    const tracker = createOscAgentActivityTracker({ cliId: "claude", onActivity: (activity) => emitted.push(activity) });
+
+    tracker.observeTitle("⠐ project");
+    expect(emitted).toEqual(["working"]);
+    tracker.observeTitle("✳ project");
+    vi.advanceTimersByTime(399);
+    expect(emitted).toEqual(["working"]);
+    vi.advanceTimersByTime(1);
+    expect(emitted).toEqual(["working", "not-working"]);
+  });
+
+  it("cancels pending not-working when working returns and suppresses duplicate classifications", () => {
+    vi.useFakeTimers();
+    const emitted: string[] = [];
+    const tracker = createOscAgentActivityTracker({ cliId: "claude", onActivity: (activity) => emitted.push(activity) });
+
+    tracker.observeTitle("⠐ one");
+    tracker.observeTitle("⠂ two");
+    tracker.observeTitle("✳ project");
+    tracker.observeTitle("✳ project");
+    vi.advanceTimersByTime(200);
+    tracker.observeTitle("⠄ project");
+    vi.advanceTimersByTime(400);
+
+    expect(emitted).toEqual(["working"]);
+    tracker.observeTitle("✳ project");
+    vi.advanceTimersByTime(400);
+    tracker.observeTitle("✳ project");
+    vi.advanceTimersByTime(400);
+    expect(emitted).toEqual(["working", "not-working"]);
+  });
+
+  it("resets the Codex working-history gate and pending debounce", () => {
+    vi.useFakeTimers();
+    const emitted: string[] = [];
+    const tracker = createOscAgentActivityTracker({ cliId: "codex", onActivity: (activity) => emitted.push(activity) });
+
+    tracker.observeTitle("⠐ project");
+    tracker.observeTitle("project");
+    tracker.reset();
+    vi.advanceTimersByTime(400);
+    tracker.observeTitle("project");
+    vi.advanceTimersByTime(400);
+
+    expect(emitted).toEqual(["working"]);
+  });
+});

--- a/runtime/fleet-plugins/terminal/tests/osc-agent-activity.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/osc-agent-activity.test.ts
@@ -7,18 +7,27 @@ afterEach(() => {
 });
 
 describe("OSC Agent activity classification", () => {
-  it("classifies Claude family spinner, not-working glyph, and unknown prefixes", () => {
-    expect(classifyOscAgentActivity("claude", "⠐ project")).toBe("working");
-    expect(classifyOscAgentActivity("claude-kimi", "✳ project")).toBe("not-working");
+  it("keeps Claude not-working independent from the working title body", () => {
+    expect(classifyOscAgentActivity("claude", "⠐ Write sentences for numbers 1 to 120")).toBe("working");
+    expect(classifyOscAgentActivity("claude-kimi", "✳ Claude Code")).toBe("not-working");
+    expect(classifyOscAgentActivity("claude", "✳ 1부터 200까지 숫자별 문장 작성")).toBe("not-working");
     expect(classifyOscAgentActivity("claude", "project")).toBe("unknown");
   });
 
-  it("gates bare Codex titles on a previously recognized spinner", () => {
-    expect(classifyOscAgentActivity("codex", "⠂ project", false)).toBe("working");
-    expect(classifyOscAgentActivity("codex", "project", false)).toBe("unknown");
-    expect(classifyOscAgentActivity("codex", "project", true)).toBe("not-working");
-    expect(classifyOscAgentActivity("codex", " project", true)).toBe("unknown");
-    expect(classifyOscAgentActivity("codex", "\x1bproject", true)).toBe("unknown");
+  it("commits a bare Codex title only when it exactly matches the working body baseline", () => {
+    expect(classifyOscAgentActivity("codex", "⠏ codexlab")).toBe("working");
+    expect(classifyOscAgentActivity("codex", "codexlab")).toBe("unknown");
+    expect(classifyOscAgentActivity("codex", "codexlab", "codexlab")).toBe("not-working");
+    expect(classifyOscAgentActivity("codex", "child-title", "codexlab")).toBe("unknown");
+    expect(classifyOscAgentActivity("codex", " codexlab", "codexlab")).toBe("unknown");
+    expect(classifyOscAgentActivity("codex", "\x1bcodexlab", "codexlab")).toBe("unknown");
+  });
+
+  it("treats child braille as conservatively working and provider-specific star titles without cross-provider inference", () => {
+    expect(classifyOscAgentActivity("codex", "⠐ child-title", "codexlab")).toBe("working");
+    expect(classifyOscAgentActivity("codex", "✳ child-title", "codexlab")).toBe("unknown");
+    expect(classifyOscAgentActivity("claude", "⠐ child-title")).toBe("working");
+    expect(classifyOscAgentActivity("claude", "✳ child-title")).toBe("not-working");
   });
 });
 
@@ -37,7 +46,7 @@ describe("OSC Agent activity debounce", () => {
     expect(emitted).toEqual(["working", "not-working"]);
   });
 
-  it("cancels pending not-working when working returns and suppresses duplicate classifications", () => {
+  it("cancels pending not-working when working returns and preserves not-working duplicate suppression", () => {
     vi.useFakeTimers();
     const emitted: string[] = [];
     const tracker = createOscAgentActivityTracker({ cliId: "claude", onActivity: (activity) => emitted.push(activity) });
@@ -50,15 +59,30 @@ describe("OSC Agent activity debounce", () => {
     tracker.observeTitle("⠄ project");
     vi.advanceTimersByTime(400);
 
-    expect(emitted).toEqual(["working"]);
+    expect(emitted).toEqual(["working", "working", "working"]);
     tracker.observeTitle("✳ project");
     vi.advanceTimersByTime(400);
     tracker.observeTitle("✳ project");
+    vi.advanceTimersByTime(400);
+    expect(emitted).toEqual(["working", "working", "working", "not-working"]);
+  });
+
+  it("rejects a child OSC body while committing a matching Codex baseline after 400ms", () => {
+    vi.useFakeTimers();
+    const emitted: string[] = [];
+    const tracker = createOscAgentActivityTracker({ cliId: "codex", onActivity: (activity) => emitted.push(activity) });
+
+    tracker.observeTitle("⠏ codexlab");
+    tracker.observeTitle("child-title");
+    vi.advanceTimersByTime(450);
+    expect(emitted).toEqual(["working"]);
+
+    tracker.observeTitle("codexlab");
     vi.advanceTimersByTime(400);
     expect(emitted).toEqual(["working", "not-working"]);
   });
 
-  it("resets the Codex working-history gate and pending debounce", () => {
+  it.each(["tracker removal", "PTY exit", "resume"])("reset used by %s clears the Codex baseline and pending debounce", () => {
     vi.useFakeTimers();
     const emitted: string[] = [];
     const tracker = createOscAgentActivityTracker({ cliId: "codex", onActivity: (activity) => emitted.push(activity) });

--- a/runtime/fleet-plugins/terminal/tests/osc-agent-activity.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/osc-agent-activity.test.ts
@@ -35,7 +35,11 @@ describe("OSC Agent activity debounce", () => {
   it("commits working immediately and not-working only after 400ms", () => {
     vi.useFakeTimers();
     const emitted: string[] = [];
-    const tracker = createOscAgentActivityTracker({ cliId: "claude", onActivity: (activity) => emitted.push(activity) });
+    const tracker = createOscAgentActivityTracker({
+      cliId: "claude",
+      cwdBasename: "project",
+      onActivity: (activity) => emitted.push(activity),
+    });
 
     tracker.observeTitle("⠐ project");
     expect(emitted).toEqual(["working"]);
@@ -49,7 +53,11 @@ describe("OSC Agent activity debounce", () => {
   it("cancels pending not-working when working returns and preserves not-working duplicate suppression", () => {
     vi.useFakeTimers();
     const emitted: string[] = [];
-    const tracker = createOscAgentActivityTracker({ cliId: "claude", onActivity: (activity) => emitted.push(activity) });
+    const tracker = createOscAgentActivityTracker({
+      cliId: "claude",
+      cwdBasename: "project",
+      onActivity: (activity) => emitted.push(activity),
+    });
 
     tracker.observeTitle("⠐ one");
     tracker.observeTitle("⠂ two");
@@ -67,25 +75,51 @@ describe("OSC Agent activity debounce", () => {
     expect(emitted).toEqual(["working", "working", "working", "not-working"]);
   });
 
-  it("rejects a child OSC body while committing a matching Codex baseline after 400ms", () => {
+  it("does not let a braille-prefixed child title replace the Codex cwd baseline", () => {
     vi.useFakeTimers();
     const emitted: string[] = [];
-    const tracker = createOscAgentActivityTracker({ cliId: "codex", onActivity: (activity) => emitted.push(activity) });
+    const tracker = createOscAgentActivityTracker({
+      cliId: "codex",
+      cwdBasename: "codexlab",
+      onActivity: (activity) => emitted.push(activity),
+    });
 
     tracker.observeTitle("⠏ codexlab");
-    tracker.observeTitle("child-title");
-    vi.advanceTimersByTime(450);
-    expect(emitted).toEqual(["working"]);
+    tracker.observeTitle("⠋ child-work");
+    tracker.observeTitle("child-work");
+    vi.advanceTimersByTime(400);
+    expect(emitted).toEqual(["working", "working"]);
 
     tracker.observeTitle("codexlab");
     vi.advanceTimersByTime(400);
-    expect(emitted).toEqual(["working", "not-working"]);
+    expect(emitted).toEqual(["working", "working", "not-working"]);
+  });
+
+  it("keeps Codex not-working detection disabled when only non-cwd working titles were seen", () => {
+    vi.useFakeTimers();
+    const emitted: string[] = [];
+    const tracker = createOscAgentActivityTracker({
+      cliId: "codex",
+      cwdBasename: "codexlab",
+      onActivity: (activity) => emitted.push(activity),
+    });
+
+    tracker.observeTitle("⠋ child-work");
+    tracker.observeTitle("child-work");
+    tracker.observeTitle("codexlab");
+    vi.advanceTimersByTime(400);
+
+    expect(emitted).toEqual(["working"]);
   });
 
   it.each(["tracker removal", "PTY exit", "resume"])("reset used by %s clears the Codex baseline and pending debounce", () => {
     vi.useFakeTimers();
     const emitted: string[] = [];
-    const tracker = createOscAgentActivityTracker({ cliId: "codex", onActivity: (activity) => emitted.push(activity) });
+    const tracker = createOscAgentActivityTracker({
+      cliId: "codex",
+      cwdBasename: "project",
+      onActivity: (activity) => emitted.push(activity),
+    });
 
     tracker.observeTitle("⠐ project");
     tracker.observeTitle("project");

--- a/runtime/fleet-plugins/terminal/tests/osc-title-parser.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/osc-title-parser.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { createOscTitleParser } from "../server/shared/osc-title-parser.js";
+
+describe("OSC title parser", () => {
+  it("extracts OSC 0 and OSC 2 titles terminated by BEL or ST", () => {
+    const parser = createOscTitleParser();
+
+    expect(parser.push(Buffer.from("\x1b]0;⠐ project\x07plain\x1b]2;✳ project\x1b\\", "utf8"))).toEqual([
+      "⠐ project",
+      "✳ project",
+    ]);
+  });
+
+  it("retains incomplete prefixes, UTF-8 title bytes, and terminators across chunk boundaries", () => {
+    const parser = createOscTitleParser();
+    const sequence = Buffer.from("\x1b]0;⠂ long title\x1b\\", "utf8");
+    const titles: string[] = [];
+
+    for (const byte of sequence) {
+      titles.push(...parser.push(Buffer.from([byte])));
+    }
+
+    expect(titles).toEqual(["⠂ long title"]);
+  });
+
+  it("drops an over-cap residual without producing a title or poisoning the next sequence", () => {
+    const parser = createOscTitleParser(8);
+
+    expect(parser.push(Buffer.from("\x1b]0;12345", "utf8"))).toEqual([]);
+    expect(parser.push(Buffer.from("\x1b]0;ok\x07", "utf8"))).toEqual(["ok"]);
+  });
+
+  it("takes the no-OSC hot path without mutating the observed bytes", () => {
+    const parser = createOscTitleParser();
+    const chunk = Buffer.from("\x1b[31mordinary terminal output\x1b[0m", "utf8");
+    const before = Buffer.from(chunk);
+
+    expect(parser.push(chunk)).toEqual([]);
+    expect(chunk.equals(before)).toBe(true);
+  });
+
+  it("ignores malformed and unsupported OSC sequences without throwing", () => {
+    const parser = createOscTitleParser();
+
+    expect(() => parser.push(Buffer.from("\x1b]1;ignored\x07\x1b]0xbroken\x07\x1b]9;also ignored\x1b\\", "utf8"))).not.toThrow();
+    expect(parser.push(Buffer.from("\x1b]0;valid\x07", "utf8"))).toEqual(["valid"]);
+  });
+});

--- a/runtime/fleet-plugins/terminal/tests/osc-title-session-manager.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/osc-title-session-manager.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { createTerminalSessionManager } from "../server/shared/session-manager.js";
+import type { TerminalPtyHandle, TerminalSocket, TerminalSocketData } from "../server/shared/terminal-types.js";
+
+describe("OSC title session wiring", () => {
+  it("observes only opted-in sessions and preserves raw PTY output when a listener throws", async () => {
+    const ptys = new Map<string, MockPty>();
+    const titles: Array<{ readonly sessionId: string; readonly title: string }> = [];
+    const manager = createTerminalSessionManager({
+      launch: async (cwd, context) => ({ bin: "mock", args: [], cwd: cwd ?? "/", env: { SESSION_ID: context?.sessionId } }),
+      startShell: (launch) => {
+        const pty = createMockPty();
+        ptys.set(String(launch.env.SESSION_ID), pty);
+        return pty;
+      },
+      resolveTitleListener: (context) => context.operationType === "agent"
+        ? (sessionId, title) => {
+            titles.push({ sessionId, title });
+            throw new Error("observer failure");
+          }
+        : undefined,
+    });
+    const agentSocket = createMockSocket();
+    const shellSocket = createMockSocket();
+    await manager.attach(agentSocket, { sessionId: "agent-a", cwd: "/work", operationType: "agent" });
+    await manager.attach(shellSocket, { sessionId: "shell-a", cwd: "/work", operationType: "shell" });
+    const rawAgentOutput = Buffer.from("\x1b]0;⠐ project\x07visible", "utf8");
+
+    ptys.get("agent-a")?.emitData(rawAgentOutput.toString("utf8"));
+    ptys.get("agent-a")?.emitData("after-listener-error");
+    ptys.get("shell-a")?.emitData("\x1b]0;✳ shell\x07");
+
+    expect(titles).toEqual([{ sessionId: "agent-a", title: "⠐ project" }]);
+    expect(agentSocket.sent[0]?.equals(rawAgentOutput)).toBe(true);
+    expect(agentSocket.sent[1]?.toString("utf8")).toBe("after-listener-error");
+    expect(shellSocket.sent[0]?.toString("utf8")).toBe("\x1b]0;✳ shell\x07");
+    await manager.stop();
+  });
+});
+
+interface MockPty extends TerminalPtyHandle {
+  emitData(data: string): void;
+}
+
+function createMockPty(): MockPty {
+  const dataListeners: Array<(data: string) => void> = [];
+  const exitListeners: Array<() => void> = [];
+  return {
+    emitData(data) {
+      for (const listener of dataListeners) listener(data);
+    },
+    onData(callback) {
+      dataListeners.push(callback);
+      return { dispose: () => removeListener(dataListeners, callback) };
+    },
+    onExit(callback) {
+      exitListeners.push(callback);
+      return { dispose: () => removeListener(exitListeners, callback) };
+    },
+    write() {},
+    resize() {},
+    kill() {},
+  };
+}
+
+interface MockSocket extends TerminalSocket {
+  readonly sent: Buffer[];
+}
+
+function createMockSocket(): MockSocket {
+  return {
+    readyState: 1,
+    sent: [],
+    send(data) {
+      this.sent.push(Buffer.from(data));
+    },
+    close() {},
+    on(_event: "message", _listener: (data: TerminalSocketData, isBinary: boolean) => void) {},
+    once(_event: "close", _listener: () => void) {},
+  };
+}
+
+function removeListener<T>(listeners: T[], listener: T): void {
+  const index = listeners.indexOf(listener);
+  if (index >= 0) listeners.splice(index, 1);
+}

--- a/runtime/fleet-plugins/terminal/tests/osc-title-session-manager.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/osc-title-session-manager.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { createConsoleObservabilityStore } from "../server/agent-api/observability-store.js";
+import { createOscAgentActivityTracker } from "../server/agent-api/osc-agent-activity.js";
 import { createTerminalSessionManager } from "../server/shared/session-manager.js";
 import type { TerminalPtyHandle, TerminalSocket, TerminalSocketData } from "../server/shared/terminal-types.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("OSC title session wiring", () => {
   it("observes only opted-in sessions and preserves raw PTY output when a listener throws", async () => {
@@ -35,6 +41,64 @@ describe("OSC title session wiring", () => {
     expect(agentSocket.sent[0]?.equals(rawAgentOutput)).toBe(true);
     expect(agentSocket.sent[1]?.toString("utf8")).toBe("after-listener-error");
     expect(shellSocket.sent[0]?.toString("utf8")).toBe("\x1b]0;✳ shell\x07");
+    await manager.stop();
+  });
+
+  it("keeps raw titles private and emits once per semantic transition across repeated spinner frames", async () => {
+    const ptys = new Map<string, MockPty>();
+    const store = createConsoleObservabilityStore({ workspaceHash: () => "theater-a" });
+    store.createPendingTerminalSession({ sessionId: "agent-private", cwd: "/work", cliId: "codex", createdAt: 1_000 });
+    const frames: unknown[] = [];
+    const activityCalls: string[] = [];
+    store.subscribeAll((event) => frames.push(event));
+    const tracker = createOscAgentActivityTracker({
+      cliId: "codex",
+      onActivity: (activity) => {
+        activityCalls.push(activity);
+        const updated = store.setTerminalSessionModelActivity("agent-private", activity);
+        if (updated) store.notifySessionUpdated(updated);
+      },
+    });
+    const manager = createTerminalSessionManager({
+      launch: async (cwd, context) => ({ bin: "mock", args: [], cwd: cwd ?? "/", env: { SESSION_ID: context?.sessionId } }),
+      startShell: (launch) => {
+        const pty = createMockPty();
+        ptys.set(String(launch.env.SESSION_ID), pty);
+        return pty;
+      },
+      resolveTitleListener: () => (_sessionId, title) => tracker.observeTitle(title),
+    });
+    const socket = createMockSocket();
+    await manager.attach(socket, { sessionId: "agent-private", cwd: "/work", operationType: "agent" });
+    const privateBody = "private-conversation-codexlab";
+    const rawTitle = `⠏ ${privateBody}`;
+
+    for (let index = 0; index < 10; index += 1) {
+      ptys.get("agent-private")?.emitData(`\x1b]0;${rawTitle}\x07`);
+    }
+    expect(activityCalls).toHaveLength(10);
+    expect(frames.map((frame) => (frame as { readonly type: string }).type)).toEqual(["session:updated"]);
+
+    store.notifySessionAttention(store.getTerminalSessionInfo("agent-private")!, "permission_prompt");
+    for (let index = 0; index < 10; index += 1) {
+      ptys.get("agent-private")?.emitData(`\x1b]0;${rawTitle}\x07`);
+    }
+    expect(activityCalls).toHaveLength(20);
+    expect(frames.map((frame) => (frame as { readonly type: string }).type)).toEqual([
+      "session:updated",
+      "session:attention",
+      "session:updated",
+    ]);
+    expect(store.getTerminalSessionInfo("agent-private")).not.toHaveProperty("attentionPending");
+
+    const browserAndDurableState = JSON.stringify({
+      session: store.getTerminalSessionInfo("agent-private"),
+      frames,
+      durable: store.listDurableOperations(),
+    });
+    expect(browserAndDurableState).not.toContain(rawTitle);
+    expect(browserAndDurableState).not.toContain(privateBody);
+    expect(socket.sent[0]?.toString("utf8")).toContain(rawTitle);
     await manager.stop();
   });
 });

--- a/runtime/fleet-plugins/terminal/tests/osc-title-session-manager.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/osc-title-session-manager.test.ts
@@ -53,6 +53,7 @@ describe("OSC title session wiring", () => {
     store.subscribeAll((event) => frames.push(event));
     const tracker = createOscAgentActivityTracker({
       cliId: "codex",
+      cwdBasename: "work",
       onActivity: (activity) => {
         activityCalls.push(activity);
         const updated = store.setTerminalSessionModelActivity("agent-private", activity);


### PR DESCRIPTION
## Summary

- 입력 대기(AskUserQuestion·permission prompt) 응답 후 Operation이 RUNNING으로 복귀하지 않고 턴 종료까지 AWAITING에 고착되던 결함, 그리고 ESC로 턴을 인터럽트한 뒤에도 계속 RUNNING으로 표시되던 결함을 함께 해소합니다.
- 에이전트 CLI가 PTY로 방출하는 OSC 0 터미널 타이틀을 "모델 작업 여부"의 권위 신호로 수용하고, 기존 hook은 "입력 대기 진입"의 권위로 유지하는 차원 분리 구조입니다. 두 CLI 모두 인터럽트에 hook을 발화하지 않기 때문에 hook만으로는 닫히지 않는 전이입니다. Claude 쪽 신규 hook은 없습니다.
- Codex 프로필에 `PermissionRequest` hook을 배선해, 그동안 입력 대기 표시가 전혀 없던 Codex 세션도 AWAITING을 표시합니다.

### 신호 분류

| CLI | 작업 중 | 작업 중 아님 |
|---|---|---|
| Claude Code | 타이틀 접두사 U+2800–U+28FF (braille spinner) | 접두사 U+2733 |
| Codex | 타이틀 접두사 U+2800–U+28FF | working 본문과 정확히 일치하는 bare 타이틀 |

미인식 타이틀은 `unknown`(무의견)으로 처리해 상태를 바꾸지 않고 기존 hook 경로를 남깁니다. 드리프트·추출 실패는 모두 기존 동작으로 안전 퇴보하며 거짓 idle 경로를 만들지 않습니다. Codex의 bare 타이틀 판정에 본문 일치 게이트를 둔 이유는 자식 프로세스가 방출하는 임의 OSC 타이틀을 종료 신호로 오인하지 않기 위함입니다.

## Test Plan

- [x] `pnpm --filter @fleet-plugins/terminal test` — 41 files / 405 tests 통과
- [x] `pnpm --filter @fleet-plugins/terminal build` / `pnpm --filter @dotobokuri/fleet-admiral build` / `pnpm -C runtime/fleet-console build` 통과
- [x] 실물 node-pty(`TERM=xterm-256color`) 실측 — 작업 중 braille spinner 39회, 유휴 및 ESC 인터럽트 시 U+2733 전환 확인
- [x] QA 리뷰 지적(Codex 자식 타이틀 거짓 idle, working 중 늦은 attention 고착) 수정 및 회귀 테스트 추가
- [x] `.changelog.d/pr-389.md` — 제품/섹션 그룹 문법, 이중 언어 요약 인접 배치, `node scripts/compile-changelog-fragments.mjs --check` 통과(41 entries)

## Notes

- Codex 신규 hook은 Codex의 hook trust 정책상 기본 Untrusted이므로, 사용자가 Codex TUI startup review에서 1회 승인해야 발화합니다. 기존 `UserPromptSubmit`/`Stop` 신뢰는 새 이벤트 키를 추가하는 방식이라 깨지지 않습니다.
- Codex의 ESC 인터럽트 타이틀 전환은 실측하지 못했습니다. 본문 일치 게이트로 거짓 idle은 봉쇄했으나 Codex 인터럽트 강등은 실사용 확인이 필요합니다.