### PR TITLE
feat(core-unified-agent): archive codex sessions on disconnect

### DIFF
--- a/.changelog.d/pr-393.md
+++ b/.changelog.d/pr-393.md
@@ -1,0 +1,8 @@
+### fleet-core
+#### Changed
+- [core-unified-agent] Keep codex sessions out of the codex CLI resume picker by archiving each thread on disconnect and unarchiving it when the session resumes.
+  ko: codex 세션을 disconnect 시 아카이브하고 재개할 때 언아카이브해, codex CLI resume picker에 노출되지 않게 합니다.
+
+#### Fixed
+- [core-unified-agent] Stop codex session teardown from hanging when the app-server exits before answering the archive request.
+  ko: app-server가 아카이브 요청에 응답하기 전에 종료되어도 codex 세션 정리가 멈추지 않도록 고칩니다.

--- a/packages/core-agent/src/internal/executor-engine.ts
+++ b/packages/core-agent/src/internal/executor-engine.ts
@@ -347,7 +347,7 @@ async function setupExecutorMcp(
 }
 
 async function buildConnectOptions(cli: CliType, cwd: string, overrides: { model?: string; promptIdleTimeout?: number; effort?: string }, systemPrompt: string | null | undefined, authEnvResolver: AuthEnvResolver, mcpServers?: McpServerConfig[]): Promise<UnifiedClientOptions> {
-  const options: UnifiedClientOptions = { cwd, cli, autoApprove: true, clientInfo: CLIENT_INFO, timeout: 0, strictMcp: true };
+  const options: UnifiedClientOptions = { cwd, cli, autoApprove: true, clientInfo: CLIENT_INFO, timeout: 0, strictMcp: true, archiveSessionOnDisconnect: true };
   if (overrides.model) options.model = overrides.model;
   if (overrides.effort) options.effort = overrides.effort;
   if (overrides.promptIdleTimeout !== undefined) options.promptIdleTimeout = overrides.promptIdleTimeout;

--- a/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
+++ b/packages/core-unified-agent/src/client/UnifiedCodexAgentClient.ts
@@ -87,6 +87,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
   private firstPromptPending: string | null = null;
   private pendingOverrides: CodexPendingOverrides | null = null;
   private currentModelSelection: CodexModelSelection = {};
+  private archiveSessionOnDisconnect = false;
   private detector = new CliDetector();
 
   on<K extends keyof UnifiedClientEvents>(
@@ -190,6 +191,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     this.currentSystemPrompt = options.systemPrompt ?? null;
     this.firstPromptPending = options.sessionId ? null : this.currentSystemPrompt;
     this.currentModelSelection = modelSelection;
+    this.archiveSessionOnDisconnect = options.archiveSessionOnDisconnect === true;
     this.pendingOverrides = {
       turnConfig: options.effort ? { effort: options.effort } : {},
       threadConfig: {
@@ -209,6 +211,10 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     if (!this.connection) {
       this.clearSessionState();
       return;
+    }
+
+    if (this.archiveSessionOnDisconnect && this.sessionId) {
+      await this.connection.endSession().catch(() => {});
     }
 
     await this.connection.disconnect();
@@ -380,6 +386,7 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     this.firstPromptPending = null;
     this.pendingOverrides = null;
     this.currentModelSelection = {};
+    this.archiveSessionOnDisconnect = false;
   }
 
   private validateModelEffort(modelId: string | undefined, effort: string | undefined): void {
@@ -588,6 +595,9 @@ export class UnifiedCodexAgentClient extends EventEmitter implements IUnifiedAge
     }
 
     try {
+      if (this.archiveSessionOnDisconnect && this.sessionId) {
+        await this.connection.endSession().catch(() => {});
+      }
       await this.connection.disconnect();
     } catch {
     }

--- a/packages/core-unified-agent/src/connection/CodexAppServerConnection.ts
+++ b/packages/core-unified-agent/src/connection/CodexAppServerConnection.ts
@@ -36,6 +36,8 @@ import type {
   CodexThreadReadResponse,
   CodexThreadResumeResponse,
   CodexThreadStartResponse,
+  CodexThreadUnarchiveParams,
+  CodexThreadUnarchiveResponse,
   CodexTurnCompletedNotification,
   CodexTurnInterruptResponse,
   CodexTurnStartResponse,
@@ -172,6 +174,7 @@ const CODEX_MCP_READY_STATUS = 'ready';
 const CODEX_MCP_FAILED_STATUSES = new Set(['failed', 'error']);
 const DEFAULT_MCP_STARTUP_TIMEOUT = 60_000;
 const STDERR_TAIL_LIMIT = 20;
+const SESSION_TEARDOWN_TIMEOUT_MS = 5_000;
 
 /**
  * Codex app-server v2와 직접 JSON-RPC로 통신하는 연결 클래스입니다.
@@ -312,11 +315,29 @@ export class CodexAppServerConnection extends BaseConnection {
     try {
       response = await this.sendThreadResumeRequest(threadId, options);
     } catch (error) {
-      const rolloutPath = this.findRolloutPathForThreadId(threadId);
-      if (!rolloutPath || !isMissingRolloutError(error, threadId)) {
-        throw error;
+      if (isArchivedThreadError(error, threadId)) {
+        try {
+          await this.sendRequest<CodexThreadUnarchiveResponse>(
+            CODEX_METHODS.THREAD_UNARCHIVE,
+            { threadId } satisfies CodexThreadUnarchiveParams,
+          );
+        } catch (unarchiveError) {
+          const message = unarchiveError instanceof Error
+            ? unarchiveError.message
+            : String(unarchiveError);
+          throw new Error(
+            `thread/unarchive에 실패했습니다(원인: archived 상태로 resume 거부됨): ${message}`,
+            { cause: unarchiveError },
+          );
+        }
+        response = await this.sendThreadResumeRequest(threadId, options);
+      } else {
+        const rolloutPath = this.findRolloutPathForThreadId(threadId);
+        if (!rolloutPath || !isMissingRolloutError(error, threadId)) {
+          throw error;
+        }
+        response = await this.sendThreadResumeRequest(threadId, options, rolloutPath);
       }
-      response = await this.sendThreadResumeRequest(threadId, options, rolloutPath);
     }
     this.threadId = response.thread.id;
     this.turnId = null;
@@ -435,6 +456,7 @@ export class CodexAppServerConnection extends BaseConnection {
       await this.sendRequest<CodexTurnInterruptResponse>(
         CODEX_METHODS.TURN_INTERRUPT,
         { threadId, turnId: activeTurnId },
+        SESSION_TEARDOWN_TIMEOUT_MS,
       ).catch(() => {});
     }
 
@@ -442,6 +464,7 @@ export class CodexAppServerConnection extends BaseConnection {
       await this.sendRequest<CodexThreadArchiveResponse>(
         CODEX_METHODS.THREAD_ARCHIVE,
         { threadId },
+        SESSION_TEARDOWN_TIMEOUT_MS,
       ).catch(() => {});
     }
 
@@ -1159,6 +1182,10 @@ export class CodexAppServerConnection extends BaseConnection {
 
 function isMissingRolloutError(error: unknown, threadId: string): boolean {
   return error instanceof Error && error.message.includes(`no rollout found for thread id ${threadId}`);
+}
+
+function isArchivedThreadError(error: unknown, threadId: string): boolean {
+  return error instanceof Error && error.message.includes(`session ${threadId} is archived`);
 }
 
 function findRolloutPath(root: string, threadId: string): string | null {

--- a/packages/core-unified-agent/src/connection/CodexAppServerConnection.ts
+++ b/packages/core-unified-agent/src/connection/CodexAppServerConnection.ts
@@ -330,7 +330,16 @@ export class CodexAppServerConnection extends BaseConnection {
             { cause: unarchiveError },
           );
         }
-        response = await this.sendThreadResumeRequest(threadId, options);
+        try {
+          response = await this.sendThreadResumeRequest(threadId, options);
+        } catch (resumeError) {
+          await this.sendRequest<CodexThreadArchiveResponse>(
+            CODEX_METHODS.THREAD_ARCHIVE,
+            { threadId },
+            SESSION_TEARDOWN_TIMEOUT_MS,
+          ).catch(() => {});
+          throw resumeError;
+        }
       } else {
         const rolloutPath = this.findRolloutPathForThreadId(threadId);
         if (!rolloutPath || !isMissingRolloutError(error, threadId)) {

--- a/packages/core-unified-agent/src/types/codex-app-server.ts
+++ b/packages/core-unified-agent/src/types/codex-app-server.ts
@@ -82,6 +82,14 @@ export interface CodexThreadArchiveParams {
 
 export type CodexThreadArchiveResponse = Record<string, never>;
 
+export interface CodexThreadUnarchiveParams {
+  threadId: string;
+}
+
+export interface CodexThreadUnarchiveResponse {
+  thread: CodexThreadInfo;
+}
+
 export interface CodexTurnStartParams {
   threadId: string;
   input: CodexUserInput[];
@@ -353,6 +361,7 @@ export const CODEX_METHODS = {
   THREAD_RESUME: 'thread/resume',
   THREAD_READ: 'thread/read',
   THREAD_ARCHIVE: 'thread/archive',
+  THREAD_UNARCHIVE: 'thread/unarchive',
   TURN_START: 'turn/start',
   TURN_INTERRUPT: 'turn/interrupt',
   TURN_STEER: 'turn/steer',

--- a/packages/core-unified-agent/src/types/config.ts
+++ b/packages/core-unified-agent/src/types/config.ts
@@ -133,6 +133,10 @@ export interface UnifiedClientOptions extends ConnectionOptions {
    * 차단한다. ACP로 명시 등록한 MCP는 유지되며, OAuth 인증 경로에는 영향이 없다.
    * Claude 외 CLI(codex/opencode-go)는 본 옵션을 무시한다. 기본값 undefined. */
   strictMcp?: boolean;
+  /** Codex에서만 의미한다. true이면 disconnect 전에 thread/archive를 호출해
+   * 세션을 resume picker에서 숨긴다. 재개 시에는 thread/unarchive 후 resume한다.
+   * Codex 외 CLI는 본 옵션을 무시한다. 기본값 undefined. */
+  archiveSessionOnDisconnect?: boolean;
   /** 재개할 기존 세션 ID */
   sessionId?: string;
   /** 세션 초기 시스템 지침.

--- a/packages/core-unified-agent/tests/unit/CodexAppServerConnection.lifecycle.test.ts
+++ b/packages/core-unified-agent/tests/unit/CodexAppServerConnection.lifecycle.test.ts
@@ -640,6 +640,49 @@ describe('CodexAppServerConnection lifecycle', () => {
     expect(connection.sessionId).toBe(threadId);
   });
 
+  it('loadSession이 unarchive 후 resume 재시도 실패 시 thread/archive로 되돌린다', async () => {
+    const threadId = '019f9884-64b3-78f2-8b54-e9901b6ce4d2';
+    const resumeErrorMessage = 'Invalid request: unknown variant `not-a-sandbox`, expected one of `read-only`, `workspace-write`, `danger-full-access`';
+    const connectPromise = connection.connect({ skipThreadStart: true });
+    child.stdout.emit(
+      'data',
+      `${jsonRpcResult(1, {
+        userAgent: 'codex/test',
+        codexHome: '/tmp/codex',
+        platformFamily: 'unix',
+        platformOs: 'macos',
+      })}\n`,
+    );
+    await connectPromise;
+
+    const loadPromise = connection.loadSession(threadId);
+    await flushMicrotask();
+    child.stdout.emit(
+      'data',
+      `${jsonRpcError(2, `session ${threadId} is archived. Run \`codex unarchive ${threadId}\` to unarchive it first.`)}\n`,
+    );
+    await flushMicrotask();
+    child.stdout.emit('data', `${jsonRpcResult(3, { thread: { id: threadId } })}\n`);
+    await flushMicrotask();
+    child.stdout.emit('data', `${jsonRpcError(4, resumeErrorMessage)}\n`);
+    await flushMicrotask();
+    expect(lastOutgoingMessage(child)).toMatchObject({
+      method: 'thread/archive',
+      params: { threadId },
+    });
+    child.stdout.emit('data', `${jsonRpcResult(5, {})}\n`);
+
+    await expect(loadPromise).rejects.toThrow(resumeErrorMessage);
+
+    expect(readOutgoingMethods(child)).toEqual([
+      'initialize',
+      'thread/resume',
+      'thread/unarchive',
+      'thread/resume',
+      'thread/archive',
+    ]);
+  });
+
   it('stderr를 log/logEntry로 전달한다', async () => {
     const logs: string[] = [];
     const entries: string[] = [];

--- a/packages/core-unified-agent/tests/unit/CodexAppServerConnection.lifecycle.test.ts
+++ b/packages/core-unified-agent/tests/unit/CodexAppServerConnection.lifecycle.test.ts
@@ -31,7 +31,7 @@ class MockChildProcess extends EventEmitter {
 class TestCodexAppServerConnection extends CodexAppServerConnection {
   constructor(
     private readonly mockChild: MockChildProcess,
-    options?: { mcpServerNames?: string[]; mcpStartupTimeout?: number },
+    options?: { mcpServerNames?: string[]; mcpStartupTimeout?: number; requestTimeout?: number },
   ) {
     super({
       command: 'codex',
@@ -39,6 +39,7 @@ class TestCodexAppServerConnection extends CodexAppServerConnection {
       cwd: process.cwd(),
       mcpServerNames: options?.mcpServerNames,
       mcpStartupTimeout: options?.mcpStartupTimeout,
+      requestTimeout: options?.requestTimeout,
     });
   }
 
@@ -485,6 +486,26 @@ describe('CodexAppServerConnection lifecycle', () => {
     });
   });
 
+  it('requestTimeout: 0이어도 endSession teardown 요청은 시간 상한 후 resolve된다', async () => {
+    connection = new TestCodexAppServerConnection(child, { requestTimeout: 0 });
+    await establishSession(connection, child);
+
+    vi.useFakeTimers();
+    try {
+      const endPromise = connection.endSession();
+      expect(lastOutgoingMessage(child)).toMatchObject({
+        method: 'thread/archive',
+        params: { threadId: 'thread-1' },
+      });
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      await expect(endPromise).resolves.toBeUndefined();
+      expect(connection.sessionId).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('disconnect가 프로세스를 종료한다', async () => {
     await establishSession(connection, child);
 
@@ -573,6 +594,50 @@ describe('CodexAppServerConnection lifecycle', () => {
     } finally {
       fs.rmSync(codexHome, { recursive: true, force: true });
     }
+  });
+
+  it('loadSession이 archived 에러면 thread/unarchive 후 thread/resume을 재시도한다', async () => {
+    const threadId = '019f9884-64b3-78f2-8b54-e9901b6ce4d2';
+    const connectPromise = connection.connect({ skipThreadStart: true });
+    child.stdout.emit(
+      'data',
+      `${jsonRpcResult(1, {
+        userAgent: 'codex/test',
+        codexHome: '/tmp/codex',
+        platformFamily: 'unix',
+        platformOs: 'macos',
+      })}\n`,
+    );
+    await connectPromise;
+
+    const loadPromise = connection.loadSession(threadId);
+    await flushMicrotask();
+    child.stdout.emit(
+      'data',
+      `${jsonRpcError(2, `session ${threadId} is archived. Run \`codex unarchive ${threadId}\` to unarchive it first.`)}\n`,
+    );
+    await flushMicrotask();
+    expect(lastOutgoingMessage(child)).toMatchObject({
+      method: 'thread/unarchive',
+      params: { threadId },
+    });
+    child.stdout.emit('data', `${jsonRpcResult(3, { thread: { id: threadId } })}\n`);
+    await flushMicrotask();
+    expect(lastOutgoingMessage(child)).toMatchObject({
+      method: 'thread/resume',
+      params: { threadId },
+    });
+    child.stdout.emit('data', `${jsonRpcResult(4, { thread: { id: threadId } })}\n`);
+
+    await loadPromise;
+
+    expect(readOutgoingMethods(child)).toEqual([
+      'initialize',
+      'thread/resume',
+      'thread/unarchive',
+      'thread/resume',
+    ]);
+    expect(connection.sessionId).toBe(threadId);
   });
 
   it('stderr를 log/logEntry로 전달한다', async () => {

--- a/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
+++ b/packages/core-unified-agent/tests/unit/UnifiedAgentClient.codex-config.test.ts
@@ -312,4 +312,68 @@ describe('UnifiedCodexAgentClient App Server config staging', () => {
       config: { notify: 'false' },
     });
   });
+
+  it('archiveSessionOnDisconnect: true이면 disconnect 전에 endSession(thread/archive)을 호출한다', async () => {
+    const client = new UnifiedCodexAgentClient();
+    await client.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+      archiveSessionOnDisconnect: true,
+    });
+
+    const callOrder: string[] = [];
+    mockEndSession.mockImplementation(async () => {
+      callOrder.push('endSession');
+    });
+    mockDisconnect.mockImplementation(async () => {
+      callOrder.push('disconnect');
+    });
+
+    await client.disconnect();
+
+    expect(mockEndSession).toHaveBeenCalledTimes(1);
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(['endSession', 'disconnect']);
+  });
+
+  it('archiveSessionOnDisconnect 미지정 시 disconnect가 endSession을 호출하지 않는다', async () => {
+    const client = new UnifiedCodexAgentClient();
+    await client.connect({ cwd: '/workspace', cli: 'codex' });
+
+    await client.disconnect();
+
+    expect(mockEndSession).not.toHaveBeenCalled();
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('archiveSessionOnDisconnect: true여도 endSession 실패 시 disconnect는 계속 진행한다', async () => {
+    const client = new UnifiedCodexAgentClient();
+    await client.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+      archiveSessionOnDisconnect: true,
+    });
+    mockEndSession.mockRejectedValue(new Error('archive failed'));
+
+    await expect(client.disconnect()).resolves.toBeUndefined();
+    expect(mockEndSession).toHaveBeenCalledTimes(1);
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('archiveSessionOnDisconnect: true여도 sessionId가 없으면 endSession을 호출하지 않는다', async () => {
+    const client = new UnifiedCodexAgentClient();
+    await client.connect({
+      cwd: '/workspace',
+      cli: 'codex',
+      archiveSessionOnDisconnect: true,
+    });
+    await client.endSession();
+    mockEndSession.mockClear();
+    mockDisconnect.mockClear();
+
+    await client.disconnect();
+
+    expect(mockEndSession).not.toHaveBeenCalled();
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary

- codex 캐리어 세션이 사용자의 codex CLI `/resume` picker에 노출되던 문제를 해소합니다. `archiveSessionOnDisconnect` 옵션을 신설해, 켜져 있으면 disconnect 직전에 `thread/archive`를 호출합니다. rollout은 `~/.codex/archived_sessions/`로 이동해 파일은 보존되지만 picker에서는 사라집니다.
- 재개 가능성은 유지됩니다. codex는 archived thread의 `thread/resume`을 거부하므로(`session <id> is archived`), `loadSession()`이 이 에러를 감지하면 `thread/unarchive` 후 resume을 재시도합니다. 기존 missing-rollout path 폴백은 그대로 둔 채 archived 분기를 앞에 추가했습니다.
- 세션 teardown 요청에 5초 상한을 부여했습니다. `core-agent` executor가 `timeout: 0`을 넘기고 `BaseConnection`의 exit 핸들러가 pending request를 reject하지 않아, archive 요청 직후 app-server가 죽으면 `disconnect()`가 영구 hang할 수 있었습니다. 이 상한은 기존 `resetSession()` 경유의 동일 노출도 함께 덮습니다.
- `core-agent`의 `buildConnectOptions()`가 기존 `strictMcp: true`와 같은 방식으로 옵션을 배선합니다. 옵션 미지정 시 동작은 종전과 동일합니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/core-unified-agent lint` (tsc)
- [x] `pnpm --filter @dotobokuri/core-unified-agent build`
- [x] `pnpm --filter @dotobokuri/core-unified-agent exec vitest run tests/unit` — 144 passed (신규 6건 포함)
- [x] `pnpm --filter @dotobokuri/core-agent typecheck`
- [x] `pnpm --filter @dotobokuri/core-agent build`
- [x] 실제 codex 0.145.0 왕복 실측: connect+turn+disconnect → rollout이 `archived_sessions/`로 이동, 같은 sessionId 재연결 → unarchive 폴백 발동 후 resume 성공 + 이전 턴 이력 보존, 재disconnect → 다시 archive. 기본 `thread/list`(picker)에 미노출 확인
- [x] Changelog fragment: `.changelog.d/pr-393.md` (grouped 문법, 영문/한글 요약 인접, `node scripts/compile-changelog-fragments.mjs --check` 통과)

### 알려진 한계

unarchive~re-archive 사이 구간(캐리어가 세션을 재개해 작업 중인 동안)에는 picker에 다시 노출됩니다. 캐리어가 비정상 종료해 re-archive에 실패하면 노출 상태로 남습니다. 이는 의도된 트레이드오프로, 사용자가 인지한 상태에서 채택했습니다.

### 참고

- `packages/core-agent`의 `tests/global-package-updater.test.ts` 실패 1건은 `canary`에서도 동일하게 재현되는 선존 실패로, 이 변경과 무관합니다.