### PR TITLE
refactor(console): rename language setting to Display language

### DIFF
--- a/.changelog.d/pr-395.md
+++ b/.changelog.d/pr-395.md
@@ -1,0 +1,5 @@
+### fleet-console
+
+#### Changed
+- [fleet-console] Rename the Settings > General language card to "Display language" and describe it as the language used across Console surfaces, matching the setting that already drives What's New and plugin panel copy.
+  ko: Settings > General의 언어 카드를 "Display language"로 바꾸고 콘솔 전반의 표시 언어라는 설명으로 정리해, What's New와 플러그인 패널 문구를 이미 함께 지배하던 설정의 실제 범위와 일치시킵니다.

--- a/runtime/fleet-console/core/client/src/components/whatsnew-modal.tsx
+++ b/runtime/fleet-console/core/client/src/components/whatsnew-modal.tsx
@@ -172,7 +172,7 @@ export function WhatsNewModal({ state }: WhatsNewModalProps) {
                 </button>
               </div>
             ) : null}
-            <div className="whatsnew-language-picker" role="group" aria-label="Release notes language">
+            <div className="whatsnew-language-picker" role="group" aria-label="Display language">
               {(["en", "ko"] as const).map((nextLocale) => (
                 <button
                   key={nextLocale}

--- a/runtime/fleet-console/core/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/core/client/src/pages/global-settings.tsx
@@ -405,10 +405,10 @@ function LanguageSettings({ state, saving }: { readonly state: GlobalSettingsSta
   return (
     <div className="global-settings-row is-stack language-settings-row">
       <div className="global-settings-row-text">
-        <p className="global-settings-resp-title">Release notes language</p>
-        <p className="global-settings-help">Choose the language for What's New. Auto follows this browser's language.</p>
+        <p className="global-settings-resp-title">Display language</p>
+        <p className="global-settings-help">Choose the language used across Console surfaces. Auto follows this browser's language.</p>
       </div>
-      <div className="segmented language-picker" role="group" aria-label="Release notes language">
+      <div className="segmented language-picker" role="group" aria-label="Display language">
         {LANGUAGES.map((language) => {
           const isActive = state.language === language.id;
           return (


### PR DESCRIPTION
## Summary
- Settings > General의 언어 카드 정체성을 `Release notes language` → `Display language`로 변경했습니다. 이 설정은 이미 What's New 본문뿐 아니라 plugin operation context(`language`)를 통해 Session Analyst 등 플러그인 문구까지 지배하고 있어, 릴리스 노트에 묶인 기존 라벨이 실제 범위를 좁게 설명하고 있었습니다.
- 설명 문구를 "Choose the language used across Console surfaces."로 바꿔 콘솔 표시 언어라는 정체성을 명시했습니다.
- What's New 모달의 EN/한국어 토글 접근성 이름도 동일하게 `Display language`로 맞췄습니다. 같은 전역 설정을 쓰기 때문입니다.
- 동작 변경 없음: 저장 키(`language`), 값(`auto`/`en`/`ko`), 해석 규칙(`resolveConsoleLanguage`) 모두 그대로입니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] 헤디드 검증(agent-browser, 격리 콘솔): `/console/settings`에서 카드 제목 `DISPLAY LANGUAGE`, 설명/노트/세그먼트(Auto·English·한국어) 렌더 및 정렬 확인, 행 오버플로 없음, 페이지 에러 0건
- [x] `rg -i "release notes language"` 잔존 0건
- [x] Changelog: `.changelog.d/pr-395.md` 추가 (grouped 문법, 영문/`ko:` 인접, `node scripts/compile-changelog-fragments.mjs --check` 통과)