### PR TITLE
feat(terminal): auto-dorm idle agent sessions with configurable threshold

### DIFF
--- a/.changelog.d/pr-397.md
+++ b/.changelog.d/pr-397.md
@@ -1,0 +1,6 @@
+### fleet-plugin
+#### Added
+- [fleet-console] Idle agent terminals now move to DORMANT automatically after a configurable idle period (default 1 hour), reclaiming CLI process resources while keeping the conversation one Resume click away; working sessions and sessions without a saved provider session are never transitioned.
+  ko: 유후 agent 터미널이 설정한 유후 시간(기본 1시간)을 넘기면 자동으로 DORMANT로 전이되어 CLI 프로세스 리소스를 회수하며, 대화는 Resume 한 번으로 복원됩니다. 작업 중이거나 저장된 provider 세션이 없는 세션은 전이되지 않습니다.
+- [fleet-console] Add an "Idle agent sessions" option to Settings > Terminal > General (Off / 30 minutes / 1 hour / 2 hours / 4 hours), persisted on the Console server.
+  ko: Settings > Terminal > General에 "Idle agent sessions" 옵션(Off / 30분 / 1시간 / 2시간 / 4시간)을 추가하고, 값은 Console 서버에 영속화됩니다.

--- a/packages/core-infra/src/data-dir/settings/store.ts
+++ b/packages/core-infra/src/data-dir/settings/store.ts
@@ -58,17 +58,26 @@ export function sanitizeGlobalOptionsData(value: unknown): GlobalOptionsValidati
   }
 
   const kimiModel = sanitizeKimiModel(value.kimiModel);
+  const agentIdleDormantMinutes = sanitizeAgentIdleDormantMinutes(value.agentIdleDormantMinutes);
   const data: GlobalOptionsData = {
     version: GLOBAL_OPTIONS_VERSION,
     ...(typeof value.enableMetaphor === "boolean" ? { enableMetaphor: value.enableMetaphor } : {}),
     ...(kimiModel ? { kimiModel } : {}),
+    ...(agentIdleDormantMinutes !== undefined ? { agentIdleDormantMinutes } : {}),
   };
-  const allowedKeys = new Set(["version", "enableMetaphor", "kimiModel"]);
+  const allowedKeys = new Set(["version", "enableMetaphor", "kimiModel", "agentIdleDormantMinutes"]);
   const changed = Object.keys(value).some((key) => !allowedKeys.has(key)) ||
     ("enableMetaphor" in value && typeof value.enableMetaphor !== "boolean") ||
-    ("kimiModel" in value && kimiModel === undefined);
+    ("kimiModel" in value && kimiModel === undefined) ||
+    ("agentIdleDormantMinutes" in value && agentIdleDormantMinutes === undefined);
 
   return { data, changed };
+}
+
+function sanitizeAgentIdleDormantMinutes(value: unknown): number | null | undefined {
+  if (value === null) return null;
+  if (typeof value === "number" && Number.isFinite(value) && Number.isInteger(value) && value > 0) return value;
+  return undefined;
 }
 
 function sanitizeKimiModel(

--- a/packages/core-infra/src/data-dir/settings/types.ts
+++ b/packages/core-infra/src/data-dir/settings/types.ts
@@ -2,6 +2,8 @@ export interface GlobalOptionsData {
   readonly version: 1;
   readonly enableMetaphor?: boolean;
   readonly kimiModel?: { readonly model: string; readonly effort?: string };
+  /** Idle agent auto-DORMANT threshold in minutes. `null` disables; key absent means server default. */
+  readonly agentIdleDormantMinutes?: number | null;
 }
 
 export interface GlobalOptionsValidationResult {

--- a/packages/core-infra/tests/data-dir-settings-store.test.ts
+++ b/packages/core-infra/tests/data-dir-settings-store.test.ts
@@ -134,6 +134,64 @@ describe("data-dir settings store", () => {
     });
   });
 
+  it("preserves valid agentIdleDormantMinutes and drops invalid values", () => {
+    expect(sanitizeGlobalOptionsData({
+      version: 1,
+      agentIdleDormantMinutes: 60,
+    })).toEqual({
+      changed: false,
+      data: {
+        version: 1,
+        agentIdleDormantMinutes: 60,
+      },
+    });
+    expect(sanitizeGlobalOptionsData({
+      version: 1,
+      agentIdleDormantMinutes: null,
+    })).toEqual({
+      changed: false,
+      data: {
+        version: 1,
+        agentIdleDormantMinutes: null,
+      },
+    });
+    expect(sanitizeGlobalOptionsData({
+      version: 1,
+      agentIdleDormantMinutes: 0,
+    })).toEqual({
+      changed: true,
+      data: { version: 1 },
+    });
+    expect(sanitizeGlobalOptionsData({
+      version: 1,
+      agentIdleDormantMinutes: -5,
+    })).toEqual({
+      changed: true,
+      data: { version: 1 },
+    });
+    expect(sanitizeGlobalOptionsData({
+      version: 1,
+      agentIdleDormantMinutes: 1.5,
+    })).toEqual({
+      changed: true,
+      data: { version: 1 },
+    });
+    expect(sanitizeGlobalOptionsData({
+      version: 1,
+      agentIdleDormantMinutes: Number.POSITIVE_INFINITY,
+    })).toEqual({
+      changed: true,
+      data: { version: 1 },
+    });
+    expect(sanitizeGlobalOptionsData({
+      version: 1,
+      agentIdleDormantMinutes: "60",
+    })).toEqual({
+      changed: true,
+      data: { version: 1 },
+    });
+  });
+
   it("drops legacy codex launch modes", () => {
     expect(sanitizeGlobalOptionsData({
       version: 1,

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -597,9 +597,76 @@ function GeneralSection() {
   return (
     <>
       <SystemPromptSettingsBlock />
+      <IdleAgentSessionsSettingsBlock />
       <TerminalFontSettingsCard terminalFont={terminalFont} />
       <TerminalRendererCard terminalRenderer={terminalRenderer} />
     </>
+  );
+}
+
+const IDLE_AGENT_DORMANT_OPTIONS = [
+  { value: "off", label: "Off" },
+  { value: "30", label: "30 minutes" },
+  { value: "60", label: "1 hour" },
+  { value: "120", label: "2 hours" },
+  { value: "240", label: "4 hours" },
+] as const;
+
+function IdleAgentSessionsSettingsBlock() {
+  const settings = useSystemPromptSettingsStore();
+  const state = settings.state;
+  const saving = settings.savingField !== null;
+
+  React.useEffect(() => {
+    const controller = new AbortController();
+    void loadSystemPromptSettings(controller.signal);
+    return () => controller.abort();
+  }, []);
+
+  const selectValue = state?.agentIdleDormantMinutes === null
+    ? "off"
+    : state?.agentIdleDormantMinutes !== undefined
+      ? String(state.agentIdleDormantMinutes)
+      : "60";
+  const idleOptions = (() => {
+    const options: Array<{ value: string; label: string }> = IDLE_AGENT_DORMANT_OPTIONS.map((option) => ({
+      value: option.value,
+      label: option.label,
+    }));
+    const minutes = state?.agentIdleDormantMinutes;
+    if (minutes === null || minutes === undefined) return options;
+    const value = String(minutes);
+    if (options.some((option) => option.value === value)) return options;
+    options.push({ value, label: `${minutes} minutes` });
+    return options;
+  })();
+
+  return (
+    <section className="global-settings-card" aria-label="Idle agent sessions">
+      {settings.error ? <p className="global-settings-error" role="alert">{settings.error}</p> : null}
+      {state ? (
+        <div className="global-settings-row">
+          <div className="global-settings-row-text">
+            <p className="global-settings-resp-title" id="idle-agent-sessions-label">Idle agent sessions</p>
+            <p className="global-settings-help" id="idle-agent-sessions-help">
+              Automatically move idle agent terminals to Dormant after the selected period. Dormant sessions keep their conversation and resume with one click. Shell terminals are never affected. Persists on the Console server.
+            </p>
+          </div>
+          <Select
+            aria-labelledby="idle-agent-sessions-label"
+            value={selectValue}
+            disabled={saving}
+            options={idleOptions}
+            onChange={(raw) => {
+              const next = raw === "off" ? null : Number(raw);
+              void setSystemPromptSettingsField("agentIdleDormantMinutes", next);
+            }}
+          />
+        </div>
+      ) : (
+        <p className="global-settings-help">{settings.loading ? "Loading settings." : "Settings unavailable."}</p>
+      )}
+    </section>
   );
 }
 

--- a/runtime/fleet-plugins/terminal/client/agent/settings-api.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/settings-api.ts
@@ -6,11 +6,13 @@ export interface KimiModelSetting {
 export interface SystemPromptSettingsState {
   readonly enableMetaphor: boolean;
   readonly kimiModel: KimiModelSetting | null;
+  readonly agentIdleDormantMinutes: number | null;
 }
 
 export type SystemPromptSettingsUpdate =
   | { readonly enableMetaphor: boolean }
-  | { readonly kimiModel: KimiModelSetting };
+  | { readonly kimiModel: KimiModelSetting }
+  | { readonly agentIdleDormantMinutes: number | null };
 
 export class TerminalSettingsApiError extends Error {
   readonly status: number;
@@ -56,13 +58,20 @@ function assertSystemPromptSettingsState(value: unknown, status: number): System
   if (
     !payload
     || typeof payload.enableMetaphor !== "boolean"
+    || !isAgentIdleDormantMinutes(payload.agentIdleDormantMinutes)
   ) {
     throw new TerminalSettingsApiError(status, "Invalid Terminal settings response");
   }
   return {
     enableMetaphor: payload.enableMetaphor,
     kimiModel: assertKimiModelSetting(payload.kimiModel),
+    agentIdleDormantMinutes: payload.agentIdleDormantMinutes,
   };
+}
+
+function isAgentIdleDormantMinutes(value: unknown): value is number | null {
+  if (value === null) return true;
+  return typeof value === "number" && Number.isFinite(value) && Number.isInteger(value) && value > 0;
 }
 
 // kimiModel은 선택 필드다. null/부재는 null로, 형태가 깨진 값은 서버 계약 위반이지만

--- a/runtime/fleet-plugins/terminal/client/agent/settings-store.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/settings-store.ts
@@ -1,6 +1,6 @@
 import { React } from "@fleet-console/sdk/plugin/browser";
 
-import { fetchSystemPromptSettings, saveSystemPromptSettings, type SystemPromptSettingsState } from "./settings-api.js";
+import { fetchSystemPromptSettings, saveSystemPromptSettings, type SystemPromptSettingsState, type SystemPromptSettingsUpdate } from "./settings-api.js";
 
 export type SystemPromptSettingsField = keyof SystemPromptSettingsState;
 
@@ -63,9 +63,7 @@ export async function setSystemPromptSettingsField<Field extends SystemPromptSet
   // 진행 중인 로드 응답이 이 저장 결과를 덮지 않도록 세대값을 올린다.
   loadGeneration += 1;
   const optimistic = { ...current, [field]: value };
-  const update = field === "enableMetaphor"
-    ? { enableMetaphor: optimistic.enableMetaphor }
-    : { kimiModel: optimistic.kimiModel! };
+  const update = toSettingsUpdate(field, optimistic);
   setSnapshot({ state: optimistic, savingField: field, error: null });
   try {
     const state = await saveSystemPromptSettings(update);
@@ -75,6 +73,12 @@ export async function setSystemPromptSettingsField<Field extends SystemPromptSet
     setSnapshot({ state: current, savingField: null, error: toErrorMessage(error) });
     return false;
   }
+}
+
+function toSettingsUpdate(field: SystemPromptSettingsField, state: SystemPromptSettingsState): SystemPromptSettingsUpdate {
+  if (field === "enableMetaphor") return { enableMetaphor: state.enableMetaphor };
+  if (field === "agentIdleDormantMinutes") return { agentIdleDormantMinutes: state.agentIdleDormantMinutes };
+  return { kimiModel: state.kimiModel! };
 }
 
 function setSnapshot(patch: Partial<SystemPromptSettingsStoreState>): void {

--- a/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/observability-store.ts
@@ -338,7 +338,8 @@ export function createConsoleObservabilityStore(deps: ConsoleObservabilityStoreD
     session.status = "dormant";
     session.providerSession = providerSession;
     delete session.modelActivity;
-    delete session.attentionPending;
+    // attentionPending은 보존한다 — dormant 사이드바 "입력 대기" 배지가 Resume 전까지 유지되어야 한다.
+    // resume 실패 롤백용 updateTerminalSessionStatus("dormant") 분기는 기존처럼 attention을 지운다.
     return toTerminalSessionInfo(session);
   }
 

--- a/runtime/fleet-plugins/terminal/server/agent-idle-dormant-sweeper.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-idle-dormant-sweeper.ts
@@ -5,11 +5,16 @@ import { resolveAgentIdleDormantMinutes } from "./settings-routes.js";
 
 export const AGENT_IDLE_DORMANT_SWEEP_INTERVAL_MS = 60_000;
 
+/** 클라이언트 isTerminalJobStatus와 동일 어휘 — 이 집합 밖은 활성(non-terminal) job이다. */
+const TERMINAL_CARRIER_JOB_STATUSES = new Set(["done", "error", "aborted"]);
+
 export interface IdleAgentDormantSweepDeps {
   readonly loadGlobalOptions: () => GlobalOptionsData;
   readonly listTerminalSessions: () => readonly AgentTerminalSessionInfo[];
   readonly getSessionLastActivityAt: (sessionId: string) => number | null;
   readonly hasProviderSessionCapture: (sessionId: string) => boolean;
+  /** 세션에 종료되지 않은 carrier job이 있으면 true(주입). */
+  readonly hasActiveCarrierJob: (sessionId: string) => boolean;
   readonly terminate: (sessionId: string) => boolean;
   readonly now?: () => number;
 }
@@ -21,6 +26,10 @@ export interface IdleAgentDormantSweeperDeps extends IdleAgentDormantSweepDeps {
   readonly clearIntervalFn?: typeof clearInterval;
 }
 
+export function isTerminalCarrierJobStatus(status: string): boolean {
+  return TERMINAL_CARRIER_JOB_STATUSES.has(status);
+}
+
 export function sweepIdleAgentSessions(deps: IdleAgentDormantSweepDeps): void {
   const minutes = resolveAgentIdleDormantMinutes(deps.loadGlobalOptions());
   if (minutes === null) return;
@@ -28,8 +37,13 @@ export function sweepIdleAgentSessions(deps: IdleAgentDormantSweepDeps): void {
   const thresholdMs = minutes * 60_000;
   for (const session of deps.listTerminalSessions()) {
     if (session.status !== "registered" && session.status !== "terminal-only") continue;
+    // OSC working은 절대 건드리지 않는다.
     if (session.modelActivity === "working") continue;
-    if (session.turnState === "running") continue;
+    // turnState는 OSC가 의견 없을 때(modelActivity 부재)의 폴백만 쓴다.
+    // not-working이 확정되면 turn end hook 지연/유실과 무관하게 후속 가드로 진행한다.
+    if (session.modelActivity === undefined && session.turnState === "running") continue;
+    // detached carrier job이 돌면 reminder 주입용 live PTY를 유지해야 한다.
+    if (deps.hasActiveCarrierJob(session.sessionId)) continue;
     if (!deps.hasProviderSessionCapture(session.sessionId)) continue;
     const lastActivityAt = deps.getSessionLastActivityAt(session.sessionId);
     if (lastActivityAt === null || now - lastActivityAt < thresholdMs) continue;

--- a/runtime/fleet-plugins/terminal/server/agent-idle-dormant-sweeper.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-idle-dormant-sweeper.ts
@@ -1,0 +1,50 @@
+import type { GlobalOptionsData } from "@dotobokuri/core-infra";
+
+import type { AgentTerminalSessionInfo } from "./agent-api/types.js";
+import { resolveAgentIdleDormantMinutes } from "./settings-routes.js";
+
+export const AGENT_IDLE_DORMANT_SWEEP_INTERVAL_MS = 60_000;
+
+export interface IdleAgentDormantSweepDeps {
+  readonly loadGlobalOptions: () => GlobalOptionsData;
+  readonly listTerminalSessions: () => readonly AgentTerminalSessionInfo[];
+  readonly getSessionLastActivityAt: (sessionId: string) => number | null;
+  readonly hasProviderSessionCapture: (sessionId: string) => boolean;
+  readonly terminate: (sessionId: string) => boolean;
+  readonly now?: () => number;
+}
+
+export interface IdleAgentDormantSweeperDeps extends IdleAgentDormantSweepDeps {
+  readonly registerCleanup: (cleanup: () => void) => unknown;
+  readonly intervalMs?: number;
+  readonly setIntervalFn?: typeof setInterval;
+  readonly clearIntervalFn?: typeof clearInterval;
+}
+
+export function sweepIdleAgentSessions(deps: IdleAgentDormantSweepDeps): void {
+  const minutes = resolveAgentIdleDormantMinutes(deps.loadGlobalOptions());
+  if (minutes === null) return;
+  const now = (deps.now ?? (() => performance.now()))();
+  const thresholdMs = minutes * 60_000;
+  for (const session of deps.listTerminalSessions()) {
+    if (session.status !== "registered" && session.status !== "terminal-only") continue;
+    if (session.modelActivity === "working") continue;
+    if (session.turnState === "running") continue;
+    if (!deps.hasProviderSessionCapture(session.sessionId)) continue;
+    const lastActivityAt = deps.getSessionLastActivityAt(session.sessionId);
+    if (lastActivityAt === null || now - lastActivityAt < thresholdMs) continue;
+    deps.terminate(session.sessionId);
+  }
+}
+
+export function startIdleAgentDormantSweeper(deps: IdleAgentDormantSweeperDeps): void {
+  const intervalMs = deps.intervalMs ?? AGENT_IDLE_DORMANT_SWEEP_INTERVAL_MS;
+  const setIntervalFn = deps.setIntervalFn ?? setInterval;
+  const clearIntervalFn = deps.clearIntervalFn ?? clearInterval;
+  const timer = setIntervalFn(() => {
+    sweepIdleAgentSessions(deps);
+  }, intervalMs);
+  deps.registerCleanup(() => {
+    clearIntervalFn(timer);
+  });
+}

--- a/runtime/fleet-plugins/terminal/server/agent-idle-dormant-sweeper.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-idle-dormant-sweeper.ts
@@ -5,6 +5,13 @@ import { resolveAgentIdleDormantMinutes } from "./settings-routes.js";
 
 export const AGENT_IDLE_DORMANT_SWEEP_INTERVAL_MS = 60_000;
 
+/**
+ * carrier job finalize 직후 reminder Enter 제출(submitDelayMs=250)이 끝나기 전에
+ * sweep이 PTY를 죽이지 않도록 두는 유예. 250ms의 20배 마진이며, 유후 임계(분 단위)를
+ * 사실상 연장하지 않는다.
+ */
+export const CARRIER_JOB_FINALIZED_GRACE_MS = 5_000;
+
 /** 클라이언트 isTerminalJobStatus와 동일 어휘 — 이 집합 밖은 활성(non-terminal) job이다. */
 const TERMINAL_CARRIER_JOB_STATUSES = new Set(["done", "error", "aborted"]);
 
@@ -26,8 +33,23 @@ export interface IdleAgentDormantSweeperDeps extends IdleAgentDormantSweepDeps {
   readonly clearIntervalFn?: typeof clearInterval;
 }
 
+export interface CarrierJobIdleActivity {
+  readonly status: string;
+  readonly updatedAt: number;
+}
+
 export function isTerminalCarrierJobStatus(status: string): boolean {
   return TERMINAL_CARRIER_JOB_STATUSES.has(status);
+}
+
+/** non-terminal이거나, terminal이어도 finalize 직후 grace 안이면 idle dorm 관점에서 활성. */
+export function isCarrierJobActiveForIdle(
+  job: CarrierJobIdleActivity,
+  nowMs: number,
+  graceMs: number = CARRIER_JOB_FINALIZED_GRACE_MS,
+): boolean {
+  if (!isTerminalCarrierJobStatus(job.status)) return true;
+  return nowMs - job.updatedAt < graceMs;
 }
 
 export function sweepIdleAgentSessions(deps: IdleAgentDormantSweepDeps): void {

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -24,7 +24,7 @@ import { createConsoleObservabilityStore } from "./agent-api/observability-store
 import { createOscAgentActivityTracker, type OscAgentActivityTracker } from "./agent-api/osc-agent-activity.js";
 import { writeAggregateObserverEvents } from "./agent-api/observability-routes.js";
 import type { AgentProviderTitleMarker, AgentTerminalSessionInfo, AgentLabelSource } from "./agent-api/types.js";
-import { startIdleAgentDormantSweeper } from "./agent-idle-dormant-sweeper.js";
+import { isTerminalCarrierJobStatus, startIdleAgentDormantSweeper } from "./agent-idle-dormant-sweeper.js";
 type SessionCreateBody = { readonly cliId?: unknown; readonly theaterId?: unknown };
 type HookTurnBody = { readonly phase?: unknown };
 type HookAttentionBody = { readonly input?: unknown; readonly reason?: unknown };
@@ -202,6 +202,12 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       readProviderSessionCapture(sessionId, { capturesDir: ctx.host.paths.capturesDir }) !== null
       || readProviderSession(ctx.host.operations.get(sessionId)?.payload) !== undefined
     ),
+    // tenantId(=cliRunId)로 세션-job이 연결된다. 활성 carrier job이 있으면 reminder용 PTY를 지킨다.
+    hasActiveCarrierJob: (sessionId) => {
+      const tenantId = observability.getTerminalSessionInfo(sessionId)?.tenantId;
+      if (!tenantId) return false;
+      return observability.listJobs(tenantId).some((job) => !isTerminalCarrierJobStatus(job.status));
+    },
     terminate: (sessionId) => terminalRuntime.terminate(sessionId),
     registerCleanup: (cleanup) => ctx.host.lifecycle.registerCleanup(cleanup),
   });

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -24,6 +24,7 @@ import { createConsoleObservabilityStore } from "./agent-api/observability-store
 import { createOscAgentActivityTracker, type OscAgentActivityTracker } from "./agent-api/osc-agent-activity.js";
 import { writeAggregateObserverEvents } from "./agent-api/observability-routes.js";
 import type { AgentProviderTitleMarker, AgentTerminalSessionInfo, AgentLabelSource } from "./agent-api/types.js";
+import { startIdleAgentDormantSweeper } from "./agent-idle-dormant-sweeper.js";
 type SessionCreateBody = { readonly cliId?: unknown; readonly theaterId?: unknown };
 type HookTurnBody = { readonly phase?: unknown };
 type HookAttentionBody = { readonly input?: unknown; readonly reason?: unknown };
@@ -193,6 +194,17 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
   });
   backfillAgentOperationLaunchKinds();
   rehydrateDormantAgentOperations();
+  startIdleAgentDormantSweeper({
+    loadGlobalOptions: () => deps.globalOptionsService.load(),
+    listTerminalSessions: () => observability.listTerminalSessions(),
+    getSessionLastActivityAt: (sessionId) => terminalRuntime.getSessionLastActivityAt(sessionId),
+    hasProviderSessionCapture: (sessionId) => (
+      readProviderSessionCapture(sessionId, { capturesDir: ctx.host.paths.capturesDir }) !== null
+      || readProviderSession(ctx.host.operations.get(sessionId)?.payload) !== undefined
+    ),
+    terminate: (sessionId) => terminalRuntime.terminate(sessionId),
+    registerCleanup: (cleanup) => ctx.host.lifecycle.registerCleanup(cleanup),
+  });
 
   async function handle({ req, res, pathname }: Parameters<FleetPluginServerContext["registerRouter"]>[1] extends (arg: infer T) => unknown ? T : never): Promise<boolean> {
     const path = pathname.slice(`${ctx.basePath}/agent`.length) || "/";
@@ -251,6 +263,12 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       const operation = ctx.host.operations.get(body.operationId);
       if (!operation) {
         ctx.host.http.writeJson(res, 404, { error: "terminal_session_not_found" });
+        return true;
+      }
+      // dormant 세션은 ticket 발급을 거부한다 — stale 클라이언트가 PTY를 재생성하지 못하게 한다.
+      // resume은 /resume이 status를 dormant에서 뺀 뒤에야 TerminalSurface가 ticket을 요청한다.
+      if (observability.getTerminalSessionInfo(operation.id)?.status === "dormant") {
+        ctx.host.http.writeJson(res, 409, { error: "operation_dormant" });
         return true;
       }
       const cwd = readPayloadString(operation.payload, "cwd") ?? ctx.host.paths.resolveTheaterPath(operation.theaterId);
@@ -561,6 +579,8 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       observability.updateTerminalSessionProviderSession(operationId, providerSession);
       const dormant = observability.transitionTerminalSessionToDormant(operationId, providerSession);
       if (dormant) {
+        // 전이 전 발급된 미소비 ticket이 WS consume으로 PTY를 되살리지 못하도록 폐기한다.
+        terminalRuntime.invalidateTicketsForSession(operationId);
         observability.notifySessionUpdated(dormant);
         const exitCwd = readPayloadString(ctx.host.operations.get(operationId)?.payload ?? {}, "cwd") ?? "";
         ctx.host.operations.patch(operationId, { payload: toOperationPayload(ctx.host.operations.get(operationId)?.payload, exitCwd, dormant, providerSession, observability.getDurableOperation(operationId)?.providerTitle) });

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -24,7 +24,7 @@ import { createConsoleObservabilityStore } from "./agent-api/observability-store
 import { createOscAgentActivityTracker, type OscAgentActivityTracker } from "./agent-api/osc-agent-activity.js";
 import { writeAggregateObserverEvents } from "./agent-api/observability-routes.js";
 import type { AgentProviderTitleMarker, AgentTerminalSessionInfo, AgentLabelSource } from "./agent-api/types.js";
-import { isTerminalCarrierJobStatus, startIdleAgentDormantSweeper } from "./agent-idle-dormant-sweeper.js";
+import { CARRIER_JOB_FINALIZED_GRACE_MS, isCarrierJobActiveForIdle, startIdleAgentDormantSweeper } from "./agent-idle-dormant-sweeper.js";
 type SessionCreateBody = { readonly cliId?: unknown; readonly theaterId?: unknown };
 type HookTurnBody = { readonly phase?: unknown };
 type HookAttentionBody = { readonly input?: unknown; readonly reason?: unknown };
@@ -202,11 +202,13 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       readProviderSessionCapture(sessionId, { capturesDir: ctx.host.paths.capturesDir }) !== null
       || readProviderSession(ctx.host.operations.get(sessionId)?.payload) !== undefined
     ),
-    // tenantId(=cliRunId)로 세션-job이 연결된다. 활성 carrier job이 있으면 reminder용 PTY를 지킨다.
+    // tenantId(=cliRunId)로 세션-job이 연결된다. 활성·finalize grace 안 job이 있으면 reminder용 PTY를 지킨다.
+    // job.updatedAt은 wall-clock(Date.now) 기준이므로 grace 비교도 동일 시계를 쓴다.
     hasActiveCarrierJob: (sessionId) => {
       const tenantId = observability.getTerminalSessionInfo(sessionId)?.tenantId;
       if (!tenantId) return false;
-      return observability.listJobs(tenantId).some((job) => !isTerminalCarrierJobStatus(job.status));
+      const nowMs = Date.now();
+      return observability.listJobs(tenantId).some((job) => isCarrierJobActiveForIdle(job, nowMs, CARRIER_JOB_FINALIZED_GRACE_MS));
     },
     terminate: (sessionId) => terminalRuntime.terminate(sessionId),
     registerCleanup: (cleanup) => ctx.host.lifecycle.registerCleanup(cleanup),

--- a/runtime/fleet-plugins/terminal/server/settings-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/settings-routes.ts
@@ -12,15 +12,20 @@ interface TerminalSettingsRouteDeps {
 interface TerminalSettingsBody {
   readonly enableMetaphor?: unknown;
   readonly kimiModel?: unknown;
+  readonly agentIdleDormantMinutes?: unknown;
 }
 
 type TerminalSettingsUpdate =
   | { readonly enableMetaphor: boolean }
-  | { readonly kimiModel: { readonly model: string; readonly effort?: string } };
+  | { readonly kimiModel: { readonly model: string; readonly effort?: string } }
+  | { readonly agentIdleDormantMinutes: number | null };
+
+export const DEFAULT_AGENT_IDLE_DORMANT_MINUTES = 60;
 
 export interface TerminalSettingsState {
   readonly enableMetaphor: boolean;
   readonly kimiModel: { readonly model: string; readonly effort?: string } | null;
+  readonly agentIdleDormantMinutes: number | null;
 }
 
 export function registerTerminalSettingsRoutes(ctx: FleetPluginServerContext, deps: TerminalSettingsRouteDeps): void {
@@ -60,7 +65,16 @@ export function toTerminalSettingsState(data: GlobalOptionsData): TerminalSettin
   return {
     enableMetaphor: data.enableMetaphor ?? false,
     kimiModel: data.kimiModel ?? null,
+    agentIdleDormantMinutes: data.agentIdleDormantMinutes === undefined
+      ? DEFAULT_AGENT_IDLE_DORMANT_MINUTES
+      : data.agentIdleDormantMinutes,
   };
+}
+
+export function resolveAgentIdleDormantMinutes(data: GlobalOptionsData): number | null {
+  return data.agentIdleDormantMinutes === undefined
+    ? DEFAULT_AGENT_IDLE_DORMANT_MINUTES
+    : data.agentIdleDormantMinutes;
 }
 
 function isTerminalSettingsBody(value: unknown): value is TerminalSettingsUpdate {
@@ -70,7 +84,13 @@ function isTerminalSettingsBody(value: unknown): value is TerminalSettingsUpdate
   if (keys.length !== 1) return false;
   const body = value as TerminalSettingsBody;
   if (keys[0] === "enableMetaphor") return typeof body.enableMetaphor === "boolean";
+  if (keys[0] === "agentIdleDormantMinutes") return isAgentIdleDormantMinutes(body.agentIdleDormantMinutes);
   return keys[0] === "kimiModel" && isKimiModelSetting(body.kimiModel);
+}
+
+function isAgentIdleDormantMinutes(value: unknown): value is number | null {
+  if (value === null) return true;
+  return typeof value === "number" && Number.isFinite(value) && Number.isInteger(value) && value > 0;
 }
 
 // Kimi 프로바이더 기본 모델 설정 검증: 모델은 레지스트리 ID여야 하고,

--- a/runtime/fleet-plugins/terminal/server/shared/runtime.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/runtime.ts
@@ -11,12 +11,14 @@ import { createPluginTerminalUpgradeHandler } from "./ws.js";
 export interface TerminalRuntime {
   readonly handleUpgrade: UpgradeHandler;
   issueTicket(context: TerminalTicketContext): TerminalTicket;
+  invalidateTicketsForSession(sessionId: string): void;
   canAttach(operationId: string): boolean;
   attach(context: TerminalTicketContext): Promise<void>;
   write(operationId: string, data: string): boolean;
   terminate(operationId: string): boolean;
   getMessagePolicy(operationId: string): CliMessagePolicy | undefined;
   getRenameCommand(operationId: string): string | undefined;
+  getSessionLastActivityAt(operationId: string): number | null;
   resolveSessionIdentity(operationId: string, providerSessionId: string): Promise<string | null>;
   onExit(callback: (operationId: string) => void | Promise<void>): () => void;
   onTitle(operationType: string, callback: TerminalTitleListener): () => void;
@@ -58,6 +60,7 @@ export function createTerminalRuntime(ctx: FleetPluginServerContext): TerminalRu
   return {
     handleUpgrade: upgrade.handleUpgrade,
     issueTicket: (context) => tickets.issue(context),
+    invalidateTicketsForSession: (sessionId) => tickets.invalidateForSession(sessionId),
     canAttach: (operationId) => sessions.canAttach(operationId),
     attach: async (context) => {
       await sessions.createSession(context);
@@ -66,6 +69,7 @@ export function createTerminalRuntime(ctx: FleetPluginServerContext): TerminalRu
     terminate: (operationId) => sessions.terminate(operationId),
     getMessagePolicy: (operationId) => sessions.getSessionMessagePolicy(operationId),
     getRenameCommand: (operationId) => sessions.getSessionRenameCommand(operationId),
+    getSessionLastActivityAt: (operationId) => sessions.getSessionLastActivityAt(operationId),
     resolveSessionIdentity: (operationId, providerSessionId) => sessions.resolveSessionIdentity(operationId, providerSessionId),
     onExit: (callback) => {
       terminalExitListeners.add(callback);

--- a/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
@@ -16,6 +16,8 @@ export interface TerminalSessionManagerDeps {
   readonly resolveTitleListener?: (context: TerminalTicketContext) => TerminalTitleListener | undefined;
   // PTY가 종료되거나 세션이 정리될 때(멱등) 정확히 한 번 호출 — 콘솔 세션 목록 정리에 쓰인다.
   readonly onSessionExit?: (sessionId: string) => unknown;
+  /** Monotonic clock for idle tracking. Defaults to `performance.now`. */
+  readonly now?: () => number;
 }
 
 interface TerminalSession {
@@ -36,6 +38,8 @@ interface TerminalSession {
   // theater-shell(캔버스 순정 셸) 전용: 소켓 단절 후 PTY 정리까지의 grace 타이머. 재연결 시 취소된다.
   graceTimer: ReturnType<typeof setTimeout> | null;
   terminalQueryResidual: string;
+  // 인메모리 유후 추적(서버 monotonic). attach / PTY 출력 / binary 입력에서만 갱신.
+  lastActivityAt: number | undefined;
 }
 
 interface KillSessionOptions {
@@ -68,6 +72,7 @@ const SECONDARY_DEVICE_ATTRIBUTES_RESPONSE = `${ANSI_CSI_PREFIX}>0;0;0c`;
 export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): TerminalSessionManager {
   const startShell = deps.startShell ?? startTerminalShell;
   const scrollbackLimit = deps.scrollbackLimit ?? DEFAULT_SCROLLBACK_LIMIT;
+  const now = deps.now ?? (() => performance.now());
   const sessions = new Map<string, TerminalSession>();
   const pendingSessions = new Map<string, Promise<TerminalSession>>();
 
@@ -84,6 +89,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
       session.activeSocket.close(4000, "terminal_replaced");
     }
     session.activeSocket = socket;
+    touchActivity(session);
     session.pty.resize(session.cols, session.rows);
     replayScrollback(session, socket);
     socket.on("message", (data, isBinary) => handleSocketMessage(session, data, isBinary));
@@ -108,6 +114,11 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
 
   function getSessionRenameCommand(sessionId: string): string | undefined {
     return sessions.get(sessionId)?.renameCommand;
+  }
+
+  function getSessionLastActivityAt(sessionId: string): number | null {
+    const session = sessions.get(sessionId);
+    return session?.lastActivityAt === undefined ? null : session.lastActivityAt;
   }
 
   async function resolveSessionIdentity(sessionId: string, providerSessionId: string): Promise<string | null> {
@@ -203,6 +214,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
       rows: DEFAULT_ROWS,
       graceTimer: null,
       terminalQueryResidual: "",
+      lastActivityAt: undefined,
     };
     try {
       const dataDisposable = pty.onData((data) => handlePtyData(session, data));
@@ -224,6 +236,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
   }
 
   function handlePtyData(session: TerminalSession, data: string): void {
+    touchActivity(session);
     const buffer = Buffer.from(data, "utf8");
     respondToTerminalQueries(session, buffer);
     observeOscTitles(session, buffer);
@@ -251,10 +264,15 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
 
   function handleSocketMessage(session: TerminalSession, data: TerminalSocketData, isBinary: boolean): void {
     if (isBinary) {
+      touchActivity(session);
       session.pty.write(toBuffer(data).toString("utf8"));
       return;
     }
     handleControlFrame(session, toBuffer(data).toString("utf8"));
+  }
+
+  function touchActivity(session: TerminalSession): void {
+    session.lastActivityAt = now();
   }
 
   function handleControlFrame(session: TerminalSession, text: string): void {
@@ -319,7 +337,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     }
   }
 
-  return { canAttach, createSession, attach, getSessionMessagePolicy, getSessionRenameCommand, resolveSessionIdentity, terminate, stop, writeToSession };
+  return { canAttach, createSession, attach, getSessionMessagePolicy, getSessionRenameCommand, getSessionLastActivityAt, resolveSessionIdentity, terminate, stop, writeToSession };
 }
 
 async function runLaunchCleanup(cleanup: (() => void | Promise<void>) | undefined): Promise<void> {

--- a/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
@@ -139,6 +139,9 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     const session = sessions.get(sessionId);
     if (!session || typeof session.pty.write !== "function") return false;
     try {
+      // 서버 주입 입력(reminder·rename)도 활동이다 — 직렬화된 주입 큐가 길어져도
+      // 각 write가 다음 write(250ms)까지 유후 타이머를 밀어내 세션이 살아있는다.
+      touchActivity(session);
       session.pty.write(data);
       return true;
     } catch {

--- a/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
@@ -38,7 +38,7 @@ interface TerminalSession {
   // theater-shell(캔버스 순정 셸) 전용: 소켓 단절 후 PTY 정리까지의 grace 타이머. 재연결 시 취소된다.
   graceTimer: ReturnType<typeof setTimeout> | null;
   terminalQueryResidual: string;
-  // 인메모리 유후 추적(서버 monotonic). attach / PTY 출력 / binary 입력에서만 갱신.
+  // 인메모리 유후 추적(서버 monotonic). 생성 시 시드되고 attach / PTY 출력 / binary 입력 / 서버 주입 write에서 갱신.
   lastActivityAt: number | undefined;
 }
 
@@ -217,7 +217,8 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
       rows: DEFAULT_ROWS,
       graceTimer: null,
       terminalQueryResidual: "",
-      lastActivityAt: undefined,
+      // 생성 시각으로 시드한다 — 조용한 PTY가 attach 전에 고아가 되어도 sweeper가 유후 판정할 수 있게 한다.
+      lastActivityAt: now(),
     };
     try {
       const dataDisposable = pty.onData((data) => handlePtyData(session, data));

--- a/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
@@ -75,6 +75,7 @@ export interface TerminalSessionManager {
   attach(socket: TerminalSocket, context: TerminalTicketContext): Promise<void>;
   getSessionMessagePolicy(sessionId: string): CliMessagePolicy | undefined;
   getSessionRenameCommand(sessionId: string): string | undefined;
+  getSessionLastActivityAt(sessionId: string): number | null;
   resolveSessionIdentity(sessionId: string, providerSessionId: string): Promise<string | null>;
   terminate(sessionId: string): boolean;
   stop(): Promise<void>;

--- a/runtime/fleet-plugins/terminal/server/shared/tickets.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/tickets.ts
@@ -12,6 +12,8 @@ export interface TerminalTicketRegistry {
   readonly ttlMs: number;
   issue(context: TerminalTicketContext): TerminalTicket;
   consume(ticket: string | null): TerminalTicketContext | null;
+  /** Drop every outstanding (unconsumed) ticket for the given session identity. */
+  invalidateForSession(sessionId: string): void;
   prune(): void;
 }
 
@@ -47,6 +49,12 @@ export function createPluginTerminalTicketRegistry(deps: TerminalTicketRegistryD
     return stored.context;
   }
 
+  function invalidateForSession(sessionId: string): void {
+    for (const [ticket, stored] of tickets) {
+      if (stored.context.sessionId === sessionId) tickets.delete(ticket);
+    }
+  }
+
   function prune(): void {
     const current = now();
     for (const [ticket, stored] of tickets) {
@@ -54,5 +62,5 @@ export function createPluginTerminalTicketRegistry(deps: TerminalTicketRegistryD
     }
   }
 
-  return { ttlMs, issue, consume, prune };
+  return { ttlMs, issue, consume, invalidateForSession, prune };
 }

--- a/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
@@ -123,7 +123,7 @@ function createHarness(body: Record<string, unknown>) {
   const eventListeners = new Map<string, Array<(payload: unknown) => void>>();
   const responses: Array<{ readonly status: number; readonly body: unknown }> = [];
   let route: RouteHandler | undefined;
-  let lifecycleCleanup: (() => void | Promise<void>) | undefined;
+  const lifecycleCleanups: Array<() => void | Promise<void>> = [];
   let exitCallback: ((operationId: string) => void | Promise<void>) | undefined;
   let titleCallback: ((operationId: string, title: string) => unknown) | undefined;
   const attach = vi.fn<TerminalRuntime["attach"]>(async () => {});
@@ -132,12 +132,14 @@ function createHarness(body: Record<string, unknown>) {
   const terminalRuntime: TerminalRuntime = {
     handleUpgrade: () => false,
     issueTicket: () => ({ ticket: "ticket", ttlMs: 1_000 }),
+    invalidateTicketsForSession: () => {},
     canAttach: () => true,
     attach,
     write,
     terminate,
     getMessagePolicy: () => ({}),
     getRenameCommand: () => undefined,
+    getSessionLastActivityAt: () => null,
     resolveSessionIdentity: async () => null,
     onExit: (callback) => {
       exitCallback = callback;
@@ -236,7 +238,7 @@ function createHarness(body: Record<string, unknown>) {
       },
       lifecycle: {
         registerCleanup: (cleanup: () => void | Promise<void>) => {
-          lifecycleCleanup = cleanup;
+          lifecycleCleanups.push(cleanup);
           return () => {};
         },
       },
@@ -245,11 +247,18 @@ function createHarness(body: Record<string, unknown>) {
 
   const previousTerminalCommand = process.env.FLEET_TERMINAL_CMD;
   process.env.FLEET_TERMINAL_CMD = "test-terminal";
-  registerAgentRoutes(ctx, terminalRuntime, { authService: {} as never, globalOptionsService: {} as never });
+  registerAgentRoutes(ctx, terminalRuntime, {
+    authService: {} as never,
+    globalOptionsService: {
+      load: () => ({ version: 1, agentIdleDormantMinutes: null }),
+      save: (data) => data,
+      update: (mutate) => mutate({ version: 1 }),
+    },
+  });
   cleanups.push(async () => {
     if (previousTerminalCommand === undefined) delete process.env.FLEET_TERMINAL_CMD;
     else process.env.FLEET_TERMINAL_CMD = previousTerminalCommand;
-    await lifecycleCleanup?.();
+    for (const cleanup of [...lifecycleCleanups].reverse()) await cleanup();
   });
 
   return {

--- a/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
@@ -1,0 +1,320 @@
+import http from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { OperationCreateInput, OperationNode, OperationPatchInput } from "@fleet-console/sdk/operations";
+import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
+import type { RouteHandler } from "@fleet-console/sdk/routing";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { registerAgentRoutes } from "../server/agent.js";
+import { writeProviderSessionCaptureRaw } from "../server/agent-api/session-capture.js";
+import type { TerminalRuntime } from "../server/shared/index.js";
+import { createPluginTerminalTicketRegistry } from "../server/shared/tickets.js";
+import type { TerminalTicketContext } from "../server/shared/terminal-types.js";
+
+const cleanups: Array<() => void | Promise<void>> = [];
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("agent dormant ticket guards", () => {
+  it("rejects ticket issuance for a dormant session with operation_dormant", async () => {
+    const harness = createHarness();
+    const sessionId = await harness.createLiveSession();
+    await harness.transitionToDormant(sessionId);
+
+    await harness.postTicket(sessionId);
+    expect(harness.responses.at(-1)).toEqual({ status: 409, body: { error: "operation_dormant" } });
+    expect(harness.ticketsIssued).toBe(0);
+  });
+
+  it("invalidates outstanding tickets when a session transitions to dormant", async () => {
+    const harness = createHarness();
+    const sessionId = await harness.createLiveSession();
+    const issued = harness.issueDirectTicket(sessionId);
+    expect(harness.tickets.consume(issued.ticket)).toMatchObject({ sessionId });
+
+    const second = harness.issueDirectTicket(sessionId);
+    await harness.transitionToDormant(sessionId);
+
+    expect(harness.tickets.consume(second.ticket)).toBeNull();
+    expect(harness.invalidateCalls).toEqual([sessionId]);
+  });
+
+  it("allows ticket issuance after resume moves the session out of dormant", async () => {
+    const harness = createHarness();
+    const sessionId = await harness.createLiveSession();
+    await harness.transitionToDormant(sessionId);
+
+    await harness.postTicket(sessionId);
+    expect(harness.responses.at(-1)?.status).toBe(409);
+
+    await harness.resumeSession(sessionId);
+    expect(harness.attach).toHaveBeenCalledWith(expect.objectContaining({ sessionId }));
+    const sessions = await harness.getSessions();
+    expect(sessions[0]?.status).not.toBe("dormant");
+
+    await harness.postTicket(sessionId);
+    expect(harness.responses.at(-1)?.status).toBe(200);
+    const body = harness.responses.at(-1)?.body as { readonly ticket?: string };
+    expect(typeof body.ticket).toBe("string");
+    expect(harness.tickets.consume(body.ticket!)).toMatchObject({ sessionId });
+  });
+});
+
+function createHarness() {
+  const fleetDataDir = mkdtempSync(path.join(os.tmpdir(), "fleet-terminal-dormant-ticket-"));
+  temporaryDirectories.push(fleetDataDir);
+  const operations: OperationNode[] = [];
+  const eventListeners = new Map<string, Array<(payload: unknown) => void>>();
+  const responses: Array<{ readonly status: number; readonly body: unknown }> = [];
+  const lifecycleCleanups: Array<() => void | Promise<void>> = [];
+  const invalidateCalls: string[] = [];
+  let route: RouteHandler | undefined;
+  let exitCallback: ((operationId: string) => void | Promise<void>) | undefined;
+  let ticketsIssued = 0;
+  const tickets = createPluginTerminalTicketRegistry({
+    randomTicket: (() => {
+      let index = 0;
+      return () => `ticket-${index++}`;
+    })(),
+  });
+  const attach = vi.fn<TerminalRuntime["attach"]>(async () => {});
+  const terminalRuntime: TerminalRuntime = {
+    handleUpgrade: () => false,
+    issueTicket: (context) => {
+      ticketsIssued += 1;
+      return tickets.issue(context);
+    },
+    invalidateTicketsForSession: (sessionId) => {
+      invalidateCalls.push(sessionId);
+      tickets.invalidateForSession(sessionId);
+    },
+    canAttach: () => true,
+    attach,
+    write: () => true,
+    terminate: () => true,
+    getMessagePolicy: () => ({}),
+    getRenameCommand: () => undefined,
+    getSessionLastActivityAt: () => null,
+    resolveSessionIdentity: async () => null,
+    onExit: (callback) => {
+      exitCallback = callback;
+      return () => {
+        if (exitCallback === callback) exitCallback = undefined;
+      };
+    },
+    onTitle: () => () => {},
+    registerLaunchResolver: () => () => {},
+    stop: async () => {},
+  };
+  const ctx = {
+    pluginId: "terminal",
+    manifest: { id: "terminal" },
+    basePath: "/plugins/terminal",
+    wsBasePath: "/plugins/terminal/ws",
+    registerRouter: (_path: string, handler: RouteHandler) => { route = handler; },
+    registerWsHandler: () => {},
+    host: {
+      operations: {
+        list: () => operations,
+        get: (id: string) => operations.find((operation) => operation.id === id) ?? null,
+        create: (input: OperationCreateInput) => {
+          const createdAt = input.createdAt ?? Date.now();
+          const operation: OperationNode = {
+            id: input.id ?? cryptoRandomId(),
+            theaterId: input.theaterId,
+            type: input.type,
+            pluginId: input.pluginId,
+            title: input.title,
+            payload: { ...(input.payload ?? {}) },
+            geometry: input.geometry ?? null,
+            ts: { createdAt, updatedAt: createdAt },
+          };
+          operations.push(operation);
+          return operation;
+        },
+        patch: (id: string, input: OperationPatchInput) => {
+          const index = operations.findIndex((operation) => operation.id === id);
+          const current = operations[index];
+          if (!current) return null;
+          const patched = {
+            ...current,
+            ...(input.title === undefined ? {} : { title: input.title }),
+            ...(input.payload === undefined ? {} : { payload: { ...input.payload } }),
+            ts: { ...current.ts, updatedAt: Date.now() },
+          };
+          operations[index] = patched;
+          return patched;
+        },
+        delete: (id: string) => {
+          const index = operations.findIndex((candidate) => candidate.id === id);
+          if (index < 0) return false;
+          operations.splice(index, 1);
+          return true;
+        },
+        registerOperationType: () => () => {},
+        registerPayloadSanitizer: () => () => {},
+        registerLaunchCatalog: () => () => {},
+      },
+      events: {
+        publish: () => {},
+        subscribe: (channel: string, listener: (payload: unknown) => void) => {
+          const listeners = eventListeners.get(channel) ?? [];
+          listeners.push(listener);
+          eventListeners.set(channel, listeners);
+          return () => {};
+        },
+        registerSseChannel: () => () => {},
+      },
+      paths: {
+        fleetDataDir,
+        capturesDir: fleetDataDir,
+        pluginDataDir: () => fleetDataDir,
+        resolveTheaterPath: (theaterId: string) => theaterId === "theater-1" ? path.join(fleetDataDir, "theater") : null,
+        canonicalizeTheaterPath: (cwd: string) => cwd,
+        workspaceHash: () => "theater-1",
+      },
+      storage: {
+        readJson: async () => null,
+        writeJson: async () => {},
+      },
+      http: {
+        writeJson: (_res: http.ServerResponse, status: number, responseBody: unknown) => { responses.push({ status, body: responseBody }); },
+        readJsonBody: async <T,>(req: http.IncomingMessage) => {
+          const url = req.url ?? "";
+          if (url.includes("/ticket")) return { operationId: (req as http.IncomingMessage & { __body?: { operationId?: string } }).__body?.operationId } as T;
+          if (url.includes("/resume")) return {} as T;
+          return { theaterId: "theater-1", cliId: "claude" } as T;
+        },
+      },
+      security: {
+        validateHost: () => true,
+        isTerminalAuthorized: () => true,
+        isLockAuthorized: () => true,
+      },
+      lifecycle: {
+        registerCleanup: (cleanup: () => void | Promise<void>) => {
+          lifecycleCleanups.push(cleanup);
+          return () => {};
+        },
+      },
+    },
+  } satisfies FleetPluginServerContext;
+
+  const previousTerminalCommand = process.env.FLEET_TERMINAL_CMD;
+  process.env.FLEET_TERMINAL_CMD = "test-terminal";
+  registerAgentRoutes(ctx, terminalRuntime, {
+    authService: {} as never,
+    globalOptionsService: {
+      load: () => ({ version: 1, agentIdleDormantMinutes: null }),
+      save: (data) => data,
+      update: (mutate) => mutate({ version: 1 }),
+    },
+  });
+  cleanups.push(async () => {
+    if (previousTerminalCommand === undefined) delete process.env.FLEET_TERMINAL_CMD;
+    else process.env.FLEET_TERMINAL_CMD = previousTerminalCommand;
+    for (const cleanup of [...lifecycleCleanups].reverse()) await cleanup();
+  });
+
+  async function createLiveSession(): Promise<string> {
+    if (!route) throw new Error("Agent route was not registered");
+    await route({
+      req: { method: "POST", url: "/plugins/terminal/agent/sessions" } as http.IncomingMessage,
+      res: {} as http.ServerResponse,
+      pathname: "/plugins/terminal/agent/sessions",
+    });
+    const sessionId = operations[0]!.id;
+    const operation = operations[0]!;
+    operation.payload.providerSession = {
+      provider: "claude",
+      sessionId: "provider-session-1",
+      capturedAt: "2026-07-25T00:00:00.000Z",
+    };
+    writeProviderSessionCaptureRaw(sessionId, JSON.stringify({
+      provider: "claude",
+      sessionId: "provider-session-1",
+      capturedAt: "2026-07-25T00:00:00.000Z",
+    }), { capturesDir: fleetDataDir });
+    return sessionId;
+  }
+
+  async function transitionToDormant(sessionId: string): Promise<void> {
+    if (!exitCallback) throw new Error("Terminal exit callback was not registered");
+    await exitCallback(sessionId);
+    const sessions = await getSessions();
+    expect(sessions[0]).toMatchObject({ sessionId, status: "dormant" });
+  }
+
+  async function postTicket(operationId: string): Promise<void> {
+    if (!route) throw new Error("Agent route was not registered");
+    const req = {
+      method: "POST",
+      url: "/plugins/terminal/agent/ticket",
+      __body: { operationId },
+    } as http.IncomingMessage & { __body: { operationId: string } };
+    await route({
+      req,
+      res: {} as http.ServerResponse,
+      pathname: "/plugins/terminal/agent/ticket",
+    });
+  }
+
+  async function getSessions(): Promise<readonly Record<string, unknown>[]> {
+    if (!route) throw new Error("Agent route was not registered");
+    const responseCount = responses.length;
+    await route({
+      req: { method: "GET", url: "/plugins/terminal/agent/sessions" } as http.IncomingMessage,
+      res: {} as http.ServerResponse,
+      pathname: "/plugins/terminal/agent/sessions",
+    });
+    const body = responses[responseCount]?.body as { readonly sessions?: readonly Record<string, unknown>[] } | undefined;
+    return body?.sessions ?? [];
+  }
+
+  async function resumeSession(sessionId: string): Promise<void> {
+    if (!route) throw new Error("Agent route was not registered");
+    await route({
+      req: { method: "POST", url: `/plugins/terminal/agent/sessions/${sessionId}/resume` } as http.IncomingMessage,
+      res: {} as http.ServerResponse,
+      pathname: `/plugins/terminal/agent/sessions/${sessionId}/resume`,
+    });
+  }
+
+  function issueDirectTicket(sessionId: string) {
+    const context: TerminalTicketContext = {
+      cwd: path.join(fleetDataDir, "theater"),
+      sessionId,
+      operationId: sessionId,
+      operationType: "agent",
+      pluginId: "terminal",
+      theaterId: "theater-1",
+      cliId: "claude",
+    };
+    return tickets.issue(context);
+  }
+
+  return {
+    attach,
+    tickets,
+    responses,
+    invalidateCalls,
+    get ticketsIssued() { return ticketsIssued; },
+    createLiveSession,
+    transitionToDormant,
+    postTicket,
+    getSessions,
+    resumeSession,
+    issueDirectTicket,
+  };
+}
+
+function cryptoRandomId(): string {
+  return `session-${Math.random().toString(16).slice(2)}`;
+}

--- a/runtime/fleet-plugins/terminal/tests/agent-idle-dormant-sweeper.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-idle-dormant-sweeper.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { AgentTerminalSessionInfo } from "../server/agent-api/types.js";
-import { sweepIdleAgentSessions, startIdleAgentDormantSweeper } from "../server/agent-idle-dormant-sweeper.js";
+import {
+  CARRIER_JOB_FINALIZED_GRACE_MS,
+  isCarrierJobActiveForIdle,
+  sweepIdleAgentSessions,
+  startIdleAgentDormantSweeper,
+} from "../server/agent-idle-dormant-sweeper.js";
 
 describe("idle agent dormant sweeper", () => {
   it("returns immediately when auto-dormant is disabled (null)", () => {
@@ -89,6 +94,34 @@ describe("idle agent dormant sweeper", () => {
     expect(terminate).toHaveBeenCalledWith("no-osc-none");
   });
 
+  it("treats non-terminal carrier jobs as active regardless of grace", () => {
+    expect(isCarrierJobActiveForIdle({ status: "active", updatedAt: 0 }, 60_000)).toBe(true);
+  });
+
+  it("treats recently finalized carrier jobs as active within grace", () => {
+    const finalizedAt = 10_000;
+    expect(isCarrierJobActiveForIdle(
+      { status: "done", updatedAt: finalizedAt },
+      finalizedAt + CARRIER_JOB_FINALIZED_GRACE_MS - 1,
+    )).toBe(true);
+    expect(isCarrierJobActiveForIdle(
+      { status: "error", updatedAt: finalizedAt },
+      finalizedAt + CARRIER_JOB_FINALIZED_GRACE_MS - 1,
+    )).toBe(true);
+    expect(isCarrierJobActiveForIdle(
+      { status: "aborted", updatedAt: finalizedAt },
+      finalizedAt + CARRIER_JOB_FINALIZED_GRACE_MS - 1,
+    )).toBe(true);
+  });
+
+  it("treats finalized carrier jobs as inactive after grace elapses", () => {
+    const finalizedAt = 10_000;
+    expect(isCarrierJobActiveForIdle(
+      { status: "done", updatedAt: finalizedAt },
+      finalizedAt + CARRIER_JOB_FINALIZED_GRACE_MS,
+    )).toBe(false);
+  });
+
   it("skips sessions with an active carrier job", () => {
     const terminate = vi.fn();
     sweepIdleAgentSessions({
@@ -103,21 +136,53 @@ describe("idle agent dormant sweeper", () => {
     expect(terminate).not.toHaveBeenCalled();
   });
 
-  it("terminates idle sessions whose carrier jobs are all terminal", () => {
+  it("skips sessions whose carrier job finalized inside the grace window", () => {
+    const terminate = vi.fn();
+    const finalizedAt = 1_000;
+    const wallNow = finalizedAt + 250;
+    const jobs = [{ status: "done", updatedAt: finalizedAt }];
+    sweepIdleAgentSessions({
+      loadGlobalOptions: () => ({ version: 1, agentIdleDormantMinutes: 60 }),
+      listTerminalSessions: () => [liveSession({ sessionId: "just-finalized" })],
+      getSessionLastActivityAt: () => 0,
+      hasProviderSessionCapture: () => true,
+      hasActiveCarrierJob: () => jobs.some((job) => isCarrierJobActiveForIdle(job, wallNow)),
+      terminate,
+      now: () => 60 * 60_000,
+    });
+    expect(terminate).not.toHaveBeenCalled();
+  });
+
+  it("terminates idle sessions after finalize grace when jobs are terminal-only", () => {
     const terminate = vi.fn(() => true);
-    const activeBySession = new Map<string, boolean>([
-      ["carrier-done", false],
-    ]);
+    const finalizedAt = 1_000;
+    const wallNow = finalizedAt + CARRIER_JOB_FINALIZED_GRACE_MS;
+    const jobs = [{ status: "done", updatedAt: finalizedAt }];
     sweepIdleAgentSessions({
       loadGlobalOptions: () => ({ version: 1, agentIdleDormantMinutes: 60 }),
       listTerminalSessions: () => [liveSession({ sessionId: "carrier-done" })],
       getSessionLastActivityAt: () => 0,
       hasProviderSessionCapture: () => true,
-      hasActiveCarrierJob: (sessionId) => activeBySession.get(sessionId) === true,
+      hasActiveCarrierJob: () => jobs.some((job) => isCarrierJobActiveForIdle(job, wallNow)),
       terminate,
       now: () => 60 * 60_000,
     });
     expect(terminate).toHaveBeenCalledWith("carrier-done");
+  });
+
+  it("skips non-terminal carrier jobs even when updatedAt is old", () => {
+    const terminate = vi.fn();
+    const jobs = [{ status: "active", updatedAt: 0 }];
+    sweepIdleAgentSessions({
+      loadGlobalOptions: () => ({ version: 1, agentIdleDormantMinutes: 60 }),
+      listTerminalSessions: () => [liveSession({ sessionId: "carrier-active" })],
+      getSessionLastActivityAt: () => 0,
+      hasProviderSessionCapture: () => true,
+      hasActiveCarrierJob: () => jobs.some((job) => isCarrierJobActiveForIdle(job, 60 * 60_000)),
+      terminate,
+      now: () => 60 * 60_000,
+    });
+    expect(terminate).not.toHaveBeenCalled();
   });
 
   it("keeps terminating jobless idle sessions", () => {

--- a/runtime/fleet-plugins/terminal/tests/agent-idle-dormant-sweeper.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-idle-dormant-sweeper.test.ts
@@ -11,13 +11,14 @@ describe("idle agent dormant sweeper", () => {
       listTerminalSessions: () => [liveSession()],
       getSessionLastActivityAt: () => 0,
       hasProviderSessionCapture: () => true,
+      hasActiveCarrierJob: () => false,
       terminate,
       now: () => 60 * 60_000,
     });
     expect(terminate).not.toHaveBeenCalled();
   });
 
-  it("skips sessions that are working or turn-running", () => {
+  it("skips sessions that are working or turn-running without OSC opinion", () => {
     const terminate = vi.fn();
     sweepIdleAgentSessions({
       loadGlobalOptions: () => ({ version: 1, agentIdleDormantMinutes: 60 }),
@@ -27,10 +28,110 @@ describe("idle agent dormant sweeper", () => {
       ],
       getSessionLastActivityAt: () => 0,
       hasProviderSessionCapture: () => true,
+      hasActiveCarrierJob: () => false,
       terminate,
       now: () => 60 * 60_000,
     });
     expect(terminate).not.toHaveBeenCalled();
+  });
+
+  it("terminates not-working sessions even when turnState is still running", () => {
+    const terminate = vi.fn(() => true);
+    sweepIdleAgentSessions({
+      loadGlobalOptions: () => ({ version: 1, agentIdleDormantMinutes: 60 }),
+      listTerminalSessions: () => [
+        liveSession({
+          sessionId: "stale-turn",
+          modelActivity: "not-working",
+          turnState: "running",
+        }),
+      ],
+      getSessionLastActivityAt: () => 0,
+      hasProviderSessionCapture: () => true,
+      hasActiveCarrierJob: () => false,
+      terminate,
+      now: () => 60 * 60_000,
+    });
+    expect(terminate).toHaveBeenCalledWith("stale-turn");
+  });
+
+  it("skips when modelActivity is undefined and turnState is running", () => {
+    const terminate = vi.fn();
+    sweepIdleAgentSessions({
+      loadGlobalOptions: () => ({ version: 1, agentIdleDormantMinutes: 60 }),
+      listTerminalSessions: () => [
+        liveSession({ sessionId: "fallback-running", turnState: "running" }),
+      ],
+      getSessionLastActivityAt: () => 0,
+      hasProviderSessionCapture: () => true,
+      hasActiveCarrierJob: () => false,
+      terminate,
+      now: () => 60 * 60_000,
+    });
+    expect(terminate).not.toHaveBeenCalled();
+  });
+
+  it("terminates when modelActivity is undefined and turnState is not running", () => {
+    const terminate = vi.fn(() => true);
+    sweepIdleAgentSessions({
+      loadGlobalOptions: () => ({ version: 1, agentIdleDormantMinutes: 60 }),
+      listTerminalSessions: () => [
+        liveSession({ sessionId: "no-osc-ended", turnState: "ended" }),
+        liveSession({ sessionId: "no-osc-none", turnState: "none" }),
+      ],
+      getSessionLastActivityAt: () => 0,
+      hasProviderSessionCapture: () => true,
+      hasActiveCarrierJob: () => false,
+      terminate,
+      now: () => 60 * 60_000,
+    });
+    expect(terminate).toHaveBeenCalledWith("no-osc-ended");
+    expect(terminate).toHaveBeenCalledWith("no-osc-none");
+  });
+
+  it("skips sessions with an active carrier job", () => {
+    const terminate = vi.fn();
+    sweepIdleAgentSessions({
+      loadGlobalOptions: () => ({ version: 1, agentIdleDormantMinutes: 60 }),
+      listTerminalSessions: () => [liveSession({ sessionId: "carrier-live" })],
+      getSessionLastActivityAt: () => 0,
+      hasProviderSessionCapture: () => true,
+      hasActiveCarrierJob: (sessionId) => sessionId === "carrier-live",
+      terminate,
+      now: () => 60 * 60_000,
+    });
+    expect(terminate).not.toHaveBeenCalled();
+  });
+
+  it("terminates idle sessions whose carrier jobs are all terminal", () => {
+    const terminate = vi.fn(() => true);
+    const activeBySession = new Map<string, boolean>([
+      ["carrier-done", false],
+    ]);
+    sweepIdleAgentSessions({
+      loadGlobalOptions: () => ({ version: 1, agentIdleDormantMinutes: 60 }),
+      listTerminalSessions: () => [liveSession({ sessionId: "carrier-done" })],
+      getSessionLastActivityAt: () => 0,
+      hasProviderSessionCapture: () => true,
+      hasActiveCarrierJob: (sessionId) => activeBySession.get(sessionId) === true,
+      terminate,
+      now: () => 60 * 60_000,
+    });
+    expect(terminate).toHaveBeenCalledWith("carrier-done");
+  });
+
+  it("keeps terminating jobless idle sessions", () => {
+    const terminate = vi.fn(() => true);
+    sweepIdleAgentSessions({
+      loadGlobalOptions: () => ({ version: 1, agentIdleDormantMinutes: 60 }),
+      listTerminalSessions: () => [liveSession({ sessionId: "no-jobs" })],
+      getSessionLastActivityAt: () => 0,
+      hasProviderSessionCapture: () => true,
+      hasActiveCarrierJob: () => false,
+      terminate,
+      now: () => 60 * 60_000,
+    });
+    expect(terminate).toHaveBeenCalledWith("no-jobs");
   });
 
   it("skips sessions without a providerSession capture", () => {
@@ -40,6 +141,7 @@ describe("idle agent dormant sweeper", () => {
       listTerminalSessions: () => [liveSession()],
       getSessionLastActivityAt: () => 0,
       hasProviderSessionCapture: () => false,
+      hasActiveCarrierJob: () => false,
       terminate,
       now: () => 60 * 60_000,
     });
@@ -53,6 +155,7 @@ describe("idle agent dormant sweeper", () => {
       listTerminalSessions: () => [liveSession()],
       getSessionLastActivityAt: () => 30 * 60_000,
       hasProviderSessionCapture: () => true,
+      hasActiveCarrierJob: () => false,
       terminate,
       now: () => 60 * 60_000,
     });
@@ -71,6 +174,7 @@ describe("idle agent dormant sweeper", () => {
       ],
       getSessionLastActivityAt: () => 0,
       hasProviderSessionCapture: () => true,
+      hasActiveCarrierJob: () => false,
       terminate,
       now: () => 60 * 60_000,
     });
@@ -87,6 +191,7 @@ describe("idle agent dormant sweeper", () => {
       ],
       getSessionLastActivityAt: () => 0,
       hasProviderSessionCapture: () => true,
+      hasActiveCarrierJob: () => false,
       terminate,
       now: () => 30 * 60_000,
     });
@@ -102,6 +207,7 @@ describe("idle agent dormant sweeper", () => {
       listTerminalSessions: () => [liveSession({ sessionId: "default-idle" })],
       getSessionLastActivityAt: () => 0,
       hasProviderSessionCapture: () => true,
+      hasActiveCarrierJob: () => false,
       terminate,
       now: () => 59 * 60_000,
     });
@@ -111,6 +217,7 @@ describe("idle agent dormant sweeper", () => {
       listTerminalSessions: () => [liveSession({ sessionId: "default-idle" })],
       getSessionLastActivityAt: () => 0,
       hasProviderSessionCapture: () => true,
+      hasActiveCarrierJob: () => false,
       terminate,
       now: () => 60 * 60_000,
     });
@@ -131,6 +238,7 @@ describe("idle agent dormant sweeper", () => {
       listTerminalSessions: () => [liveSession({ sessionId: "tick" })],
       getSessionLastActivityAt: () => 0,
       hasProviderSessionCapture: () => true,
+      hasActiveCarrierJob: () => false,
       terminate,
       now: () => 60_000,
       intervalMs: 1_000,

--- a/runtime/fleet-plugins/terminal/tests/agent-idle-dormant-sweeper.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-idle-dormant-sweeper.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { AgentTerminalSessionInfo } from "../server/agent-api/types.js";
+import { sweepIdleAgentSessions, startIdleAgentDormantSweeper } from "../server/agent-idle-dormant-sweeper.js";
+
+describe("idle agent dormant sweeper", () => {
+  it("returns immediately when auto-dormant is disabled (null)", () => {
+    const terminate = vi.fn();
+    sweepIdleAgentSessions({
+      loadGlobalOptions: () => ({ version: 1, agentIdleDormantMinutes: null }),
+      listTerminalSessions: () => [liveSession()],
+      getSessionLastActivityAt: () => 0,
+      hasProviderSessionCapture: () => true,
+      terminate,
+      now: () => 60 * 60_000,
+    });
+    expect(terminate).not.toHaveBeenCalled();
+  });
+
+  it("skips sessions that are working or turn-running", () => {
+    const terminate = vi.fn();
+    sweepIdleAgentSessions({
+      loadGlobalOptions: () => ({ version: 1, agentIdleDormantMinutes: 60 }),
+      listTerminalSessions: () => [
+        liveSession({ sessionId: "working", modelActivity: "working" }),
+        liveSession({ sessionId: "running", turnState: "running" }),
+      ],
+      getSessionLastActivityAt: () => 0,
+      hasProviderSessionCapture: () => true,
+      terminate,
+      now: () => 60 * 60_000,
+    });
+    expect(terminate).not.toHaveBeenCalled();
+  });
+
+  it("skips sessions without a providerSession capture", () => {
+    const terminate = vi.fn();
+    sweepIdleAgentSessions({
+      loadGlobalOptions: () => ({ version: 1, agentIdleDormantMinutes: 60 }),
+      listTerminalSessions: () => [liveSession()],
+      getSessionLastActivityAt: () => 0,
+      hasProviderSessionCapture: () => false,
+      terminate,
+      now: () => 60 * 60_000,
+    });
+    expect(terminate).not.toHaveBeenCalled();
+  });
+
+  it("skips sessions that have not yet reached the idle threshold", () => {
+    const terminate = vi.fn();
+    sweepIdleAgentSessions({
+      loadGlobalOptions: () => ({ version: 1, agentIdleDormantMinutes: 60 }),
+      listTerminalSessions: () => [liveSession()],
+      getSessionLastActivityAt: () => 30 * 60_000,
+      hasProviderSessionCapture: () => true,
+      terminate,
+      now: () => 60 * 60_000,
+    });
+    expect(terminate).not.toHaveBeenCalled();
+  });
+
+  it("skips dormant/starting/closed/error sessions", () => {
+    const terminate = vi.fn();
+    sweepIdleAgentSessions({
+      loadGlobalOptions: () => ({ version: 1 }),
+      listTerminalSessions: () => [
+        liveSession({ sessionId: "dormant", status: "dormant" }),
+        liveSession({ sessionId: "starting", status: "starting" }),
+        liveSession({ sessionId: "closed", status: "closed" }),
+        liveSession({ sessionId: "error", status: "error" }),
+      ],
+      getSessionLastActivityAt: () => 0,
+      hasProviderSessionCapture: () => true,
+      terminate,
+      now: () => 60 * 60_000,
+    });
+    expect(terminate).not.toHaveBeenCalled();
+  });
+
+  it("terminates idle live sessions once the threshold elapses", () => {
+    const terminate = vi.fn(() => true);
+    sweepIdleAgentSessions({
+      loadGlobalOptions: () => ({ version: 1, agentIdleDormantMinutes: 30 }),
+      listTerminalSessions: () => [
+        liveSession({ sessionId: "idle-registered", status: "registered" }),
+        liveSession({ sessionId: "idle-terminal-only", status: "terminal-only" }),
+      ],
+      getSessionLastActivityAt: () => 0,
+      hasProviderSessionCapture: () => true,
+      terminate,
+      now: () => 30 * 60_000,
+    });
+    expect(terminate).toHaveBeenCalledTimes(2);
+    expect(terminate).toHaveBeenCalledWith("idle-registered");
+    expect(terminate).toHaveBeenCalledWith("idle-terminal-only");
+  });
+
+  it("uses the default 60-minute threshold when the setting key is absent", () => {
+    const terminate = vi.fn(() => true);
+    sweepIdleAgentSessions({
+      loadGlobalOptions: () => ({ version: 1 }),
+      listTerminalSessions: () => [liveSession({ sessionId: "default-idle" })],
+      getSessionLastActivityAt: () => 0,
+      hasProviderSessionCapture: () => true,
+      terminate,
+      now: () => 59 * 60_000,
+    });
+    expect(terminate).not.toHaveBeenCalled();
+    sweepIdleAgentSessions({
+      loadGlobalOptions: () => ({ version: 1 }),
+      listTerminalSessions: () => [liveSession({ sessionId: "default-idle" })],
+      getSessionLastActivityAt: () => 0,
+      hasProviderSessionCapture: () => true,
+      terminate,
+      now: () => 60 * 60_000,
+    });
+    expect(terminate).toHaveBeenCalledWith("default-idle");
+  });
+
+  it("registers an injectable interval and clears it on cleanup", () => {
+    const callbacks: Array<() => void> = [];
+    const clearIntervalFn = vi.fn();
+    const setIntervalFn = vi.fn((callback: () => void) => {
+      callbacks.push(callback);
+      return 42 as unknown as ReturnType<typeof setInterval>;
+    });
+    const terminate = vi.fn(() => true);
+    const cleanups: Array<() => void> = [];
+    startIdleAgentDormantSweeper({
+      loadGlobalOptions: () => ({ version: 1, agentIdleDormantMinutes: 1 }),
+      listTerminalSessions: () => [liveSession({ sessionId: "tick" })],
+      getSessionLastActivityAt: () => 0,
+      hasProviderSessionCapture: () => true,
+      terminate,
+      now: () => 60_000,
+      intervalMs: 1_000,
+      setIntervalFn: setIntervalFn as unknown as typeof setInterval,
+      clearIntervalFn: clearIntervalFn as unknown as typeof clearInterval,
+      registerCleanup: (cleanup) => { cleanups.push(cleanup); },
+    });
+    expect(setIntervalFn).toHaveBeenCalledWith(expect.any(Function), 1_000);
+    expect(cleanups).toHaveLength(1);
+    callbacks[0]?.();
+    expect(terminate).toHaveBeenCalledWith("tick");
+    cleanups[0]?.();
+    expect(clearIntervalFn).toHaveBeenCalledWith(42);
+  });
+});
+
+function liveSession(overrides: Partial<AgentTerminalSessionInfo> = {}): AgentTerminalSessionInfo {
+  return {
+    sessionId: "session-a",
+    terminalSessionId: "session-a",
+    cwdLabel: "work",
+    status: "registered",
+    turnState: "ended",
+    createdAt: 1,
+    theaterId: "theater-a",
+    resumeAvailable: true,
+    ...overrides,
+  };
+}

--- a/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/observability-store.test.ts
@@ -380,9 +380,32 @@ describe("agent activity observability state", () => {
       sessionId: "provider-session",
       capturedAt: "2026-07-25T00:00:00.000Z",
     });
-    expect(dormant).toMatchObject({ status: "dormant" });
+    expect(dormant).toMatchObject({ status: "dormant", attentionPending: true });
     expect(dormant).not.toHaveProperty("modelActivity");
-    expect(dormant).not.toHaveProperty("attentionPending");
+  });
+
+  it("preserves attentionPending across transitionTerminalSessionToDormant", () => {
+    const store = createStore();
+    store.setTerminalSessionModelActivity("session-a", "not-working");
+    store.notifySessionAttention(store.getTerminalSessionInfo("session-a")!, "permission_prompt");
+    expect(store.getTerminalSessionInfo("session-a")).toMatchObject({ attentionPending: true });
+
+    const dormant = store.transitionTerminalSessionToDormant("session-a", {
+      provider: "claude",
+      sessionId: "provider-session",
+      capturedAt: "2026-07-25T00:00:00.000Z",
+    });
+    expect(dormant).toMatchObject({ status: "dormant", attentionPending: true });
+    expect(store.getTerminalSessionInfo("session-a")).toMatchObject({ attentionPending: true });
+  });
+
+  it("still clears attentionPending when updateTerminalSessionStatus sets dormant", () => {
+    const store = createStore();
+    store.setTerminalSessionModelActivity("session-a", "not-working");
+    store.notifySessionAttention(store.getTerminalSessionInfo("session-a")!, "permission_prompt");
+    const rolledBack = store.updateTerminalSessionStatus("session-a", "dormant");
+    expect(rolledBack).toMatchObject({ status: "dormant" });
+    expect(rolledBack).not.toHaveProperty("attentionPending");
   });
 
   it("emits exactly one update when repeated working clears late attention", () => {

--- a/runtime/fleet-plugins/terminal/tests/session-manager-last-activity.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/session-manager-last-activity.test.ts
@@ -36,6 +36,11 @@ describe("session-manager lastActivityAt", () => {
     expect(manager.getSessionLastActivityAt("agent-a")).toBe(3_000);
     expect(ptys.get("agent-a")?.resized.at(-1)).toEqual({ cols: 120, rows: 40 });
 
+    // 서버 주입 입력(reminder·rename)도 활동으로 갱신한다.
+    clock = 5_000;
+    expect(manager.writeToSession("agent-a", "injected-reminder")).toBe(true);
+    expect(manager.getSessionLastActivityAt("agent-a")).toBe(5_000);
+
     await manager.stop();
   });
 

--- a/runtime/fleet-plugins/terminal/tests/session-manager-last-activity.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/session-manager-last-activity.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import { createTerminalSessionManager } from "../server/shared/session-manager.js";
+import type { TerminalPtyHandle, TerminalSocket, TerminalSocketData } from "../server/shared/terminal-types.js";
+
+describe("session-manager lastActivityAt", () => {
+  it("updates lastActivityAt on attach, PTY output, and binary input but not resize", async () => {
+    let clock = 1_000;
+    const ptys = new Map<string, MockPty>();
+    const manager = createTerminalSessionManager({
+      now: () => clock,
+      launch: async (cwd, context) => ({ bin: "mock", args: [], cwd: cwd ?? "/", env: { SESSION_ID: context?.sessionId } }),
+      startShell: (launch) => {
+        const pty = createMockPty();
+        ptys.set(String(launch.env.SESSION_ID), pty);
+        return pty;
+      },
+    });
+
+    expect(manager.getSessionLastActivityAt("agent-a")).toBeNull();
+
+    const socket = createMockSocket();
+    await manager.attach(socket, { sessionId: "agent-a", cwd: "/work", operationType: "agent" });
+    expect(manager.getSessionLastActivityAt("agent-a")).toBe(1_000);
+
+    clock = 2_000;
+    ptys.get("agent-a")?.emitData("pty-output");
+    expect(manager.getSessionLastActivityAt("agent-a")).toBe(2_000);
+
+    clock = 3_000;
+    socket.emitMessage(Buffer.from("user-input", "utf8"), true);
+    expect(manager.getSessionLastActivityAt("agent-a")).toBe(3_000);
+
+    clock = 4_000;
+    socket.emitMessage(Buffer.from(JSON.stringify({ type: "resize", cols: 120, rows: 40 }), "utf8"), false);
+    expect(manager.getSessionLastActivityAt("agent-a")).toBe(3_000);
+    expect(ptys.get("agent-a")?.resized.at(-1)).toEqual({ cols: 120, rows: 40 });
+
+    await manager.stop();
+  });
+
+  it("returns null for unknown sessions", () => {
+    const manager = createTerminalSessionManager({
+      launch: async () => ({ bin: "mock", args: [], cwd: "/", env: {} }),
+      startShell: () => createMockPty(),
+    });
+    expect(manager.getSessionLastActivityAt("missing")).toBeNull();
+  });
+});
+
+interface MockPty extends TerminalPtyHandle {
+  emitData(data: string): void;
+  readonly resized: Array<{ readonly cols: number; readonly rows: number }>;
+}
+
+function createMockPty(): MockPty {
+  const dataListeners: Array<(data: string) => void> = [];
+  const exitListeners: Array<() => void> = [];
+  const resized: Array<{ readonly cols: number; readonly rows: number }> = [];
+  return {
+    resized,
+    emitData(data) {
+      for (const listener of dataListeners) listener(data);
+    },
+    onData(callback) {
+      dataListeners.push(callback);
+      return { dispose: () => removeListener(dataListeners, callback) };
+    },
+    onExit(callback) {
+      exitListeners.push(callback);
+      return { dispose: () => removeListener(exitListeners, callback) };
+    },
+    write() {},
+    resize(cols, rows) {
+      resized.push({ cols, rows });
+    },
+    kill() {},
+  };
+}
+
+interface MockSocket extends TerminalSocket {
+  readonly sent: Buffer[];
+  emitMessage(data: TerminalSocketData, isBinary: boolean): void;
+}
+
+function createMockSocket(): MockSocket {
+  const messageListeners: Array<(data: TerminalSocketData, isBinary: boolean) => void> = [];
+  return {
+    readyState: 1,
+    sent: [],
+    send(data) {
+      this.sent.push(Buffer.from(data));
+    },
+    close() {},
+    on(event: "message", listener: (data: TerminalSocketData, isBinary: boolean) => void) {
+      if (event === "message") messageListeners.push(listener);
+    },
+    once(_event: "close", _listener: () => void) {},
+    emitMessage(data, isBinary) {
+      for (const listener of messageListeners) listener(data, isBinary);
+    },
+  };
+}
+
+function removeListener<T>(listeners: T[], listener: T): void {
+  const index = listeners.indexOf(listener);
+  if (index >= 0) listeners.splice(index, 1);
+}

--- a/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
@@ -24,7 +24,7 @@ describe("terminal settings routes", () => {
       data: { version: 1, enableMetaphor: false },
     });
     await harness.handle({ req: req("GET"), res: res(), pathname: "/plugins/terminal/settings" });
-    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, kimiModel: null } }]);
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, kimiModel: null, agentIdleDormantMinutes: 60 } }]);
     expect(harness.writes[0]?.body).not.toHaveProperty("consolePortMode");
   });
 
@@ -34,7 +34,7 @@ describe("terminal settings routes", () => {
       data: { version: 1, enableMetaphor: false },
     });
     await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
-    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: true, kimiModel: null } }]);
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: true, kimiModel: null, agentIdleDormantMinutes: 60 } }]);
     expect(harness.currentData()).toEqual({ version: 1, enableMetaphor: true });
   });
 
@@ -75,13 +75,54 @@ describe("terminal settings routes", () => {
     expect(harness.updateCalls).toBe(0);
   });
 
+  it("PUT /plugins/terminal/settings updates agentIdleDormantMinutes in global options", async () => {
+    const harness = createRouteHarness({
+      body: { agentIdleDormantMinutes: 120 },
+      data: { version: 1 },
+    });
+    await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, kimiModel: null, agentIdleDormantMinutes: 120 } }]);
+    expect(harness.currentData()).toEqual({ version: 1, agentIdleDormantMinutes: 120 });
+  });
+
+  it("PUT /plugins/terminal/settings accepts null agentIdleDormantMinutes to disable auto-dormant", async () => {
+    const harness = createRouteHarness({
+      body: { agentIdleDormantMinutes: null },
+      data: { version: 1, agentIdleDormantMinutes: 60 },
+    });
+    await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, kimiModel: null, agentIdleDormantMinutes: null } }]);
+    expect(harness.currentData()).toEqual({ version: 1, agentIdleDormantMinutes: null });
+  });
+
+  it("PUT /plugins/terminal/settings rejects invalid agentIdleDormantMinutes values", async () => {
+    for (const body of [
+      { agentIdleDormantMinutes: 0 },
+      { agentIdleDormantMinutes: -1 },
+      { agentIdleDormantMinutes: 1.5 },
+      { agentIdleDormantMinutes: "60" },
+      { agentIdleDormantMinutes: Number.POSITIVE_INFINITY },
+    ]) {
+      const harness = createRouteHarness({ body });
+      await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
+      expect(harness.writes.at(-1)?.status).toBe(400);
+      expect(harness.updateCalls).toBe(0);
+    }
+  });
+
+  it("GET /plugins/terminal/settings returns default agentIdleDormantMinutes when unset", async () => {
+    const harness = createRouteHarness({ data: { version: 1 } });
+    await harness.handle({ req: req("GET"), res: res(), pathname: "/plugins/terminal/settings" });
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, kimiModel: null, agentIdleDormantMinutes: 60 } }]);
+  });
+
   it("PUT /plugins/terminal/settings updates the Kimi default model in global options", async () => {
     const harness = createRouteHarness({
       body: { kimiModel: { model: "k3", effort: "max" } },
       data: { version: 1, enableMetaphor: false },
     });
     await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
-    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, kimiModel: { model: "k3", effort: "max" } } }]);
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, kimiModel: { model: "k3", effort: "max" }, agentIdleDormantMinutes: 60 } }]);
     expect(harness.currentData()).toEqual({ version: 1, enableMetaphor: false, kimiModel: { model: "k3", effort: "max" } });
   });
 
@@ -121,7 +162,7 @@ describe("terminal settings routes", () => {
       data: { version: 1, kimiModel: { model: "k3[1m]", effort: "high" } },
     });
     await harness.handle({ req: req("GET"), res: res(), pathname: "/plugins/terminal/settings" });
-    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, kimiModel: { model: "k3[1m]", effort: "high" } } }]);
+    expect(harness.writes).toEqual([{ status: 200, body: { enableMetaphor: false, kimiModel: { model: "k3[1m]", effort: "high" }, agentIdleDormantMinutes: 60 } }]);
   });
 
   it("PUT /plugins/terminal/settings enforces terminal-origin authorization", async () => {

--- a/runtime/fleet-plugins/terminal/tests/system-prompt-settings-api.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/system-prompt-settings-api.test.ts
@@ -8,16 +8,24 @@ describe("system prompt settings api", () => {
   });
 
   it("loads Terminal prompt settings from the plugin route", async () => {
-    const fetchMock = vi.fn(async () => jsonResponse({ enableMetaphor: false }));
+    const fetchMock = vi.fn(async () => jsonResponse({ enableMetaphor: false, agentIdleDormantMinutes: 60 }));
     vi.stubGlobal("fetch", fetchMock);
-    await expect(fetchSystemPromptSettings()).resolves.toEqual({ enableMetaphor: false, kimiModel: null });
+    await expect(fetchSystemPromptSettings()).resolves.toEqual({
+      enableMetaphor: false,
+      kimiModel: null,
+      agentIdleDormantMinutes: 60,
+    });
     expect(fetchMock).toHaveBeenCalledWith("/plugins/terminal/settings", { signal: undefined });
   });
 
   it("saves the prompt boolean to the plugin route", async () => {
-    const fetchMock = vi.fn(async () => jsonResponse({ enableMetaphor: true }));
+    const fetchMock = vi.fn(async () => jsonResponse({ enableMetaphor: true, agentIdleDormantMinutes: 60 }));
     vi.stubGlobal("fetch", fetchMock);
-    await expect(saveSystemPromptSettings({ enableMetaphor: true })).resolves.toEqual({ enableMetaphor: true, kimiModel: null });
+    await expect(saveSystemPromptSettings({ enableMetaphor: true })).resolves.toEqual({
+      enableMetaphor: true,
+      kimiModel: null,
+      agentIdleDormantMinutes: 60,
+    });
     expect(fetchMock).toHaveBeenCalledWith("/plugins/terminal/settings", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -31,15 +39,22 @@ describe("system prompt settings api", () => {
     await expect(fetchSystemPromptSettings()).rejects.toThrow("Invalid Terminal settings response");
   });
 
+  it("rejects responses missing agentIdleDormantMinutes", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({ enableMetaphor: false, kimiModel: null })));
+    await expect(fetchSystemPromptSettings()).rejects.toThrow("Invalid Terminal settings response");
+  });
+
   it("loads the stored Kimi default model from the plugin route", async () => {
     const fetchMock = vi.fn(async () => jsonResponse({
       enableMetaphor: false,
       kimiModel: { model: "k3", effort: "low" },
+      agentIdleDormantMinutes: 60,
     }));
     vi.stubGlobal("fetch", fetchMock);
     await expect(fetchSystemPromptSettings()).resolves.toEqual({
       enableMetaphor: false,
       kimiModel: { model: "k3", effort: "low" },
+      agentIdleDormantMinutes: 60,
     });
   });
 
@@ -47,16 +62,38 @@ describe("system prompt settings api", () => {
     const fetchMock = vi.fn(async () => jsonResponse({
       enableMetaphor: false,
       kimiModel: { model: "k3[1m]", effort: "high" },
+      agentIdleDormantMinutes: 60,
     }));
     vi.stubGlobal("fetch", fetchMock);
     await expect(saveSystemPromptSettings({ kimiModel: { model: "k3[1m]", effort: "high" } })).resolves.toEqual({
       enableMetaphor: false,
       kimiModel: { model: "k3[1m]", effort: "high" },
+      agentIdleDormantMinutes: 60,
     });
     expect(fetchMock).toHaveBeenCalledWith("/plugins/terminal/settings", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ kimiModel: { model: "k3[1m]", effort: "high" } }),
+      signal: undefined,
+    });
+  });
+
+  it("saves agentIdleDormantMinutes including null Off", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({
+      enableMetaphor: false,
+      kimiModel: null,
+      agentIdleDormantMinutes: null,
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(saveSystemPromptSettings({ agentIdleDormantMinutes: null })).resolves.toEqual({
+      enableMetaphor: false,
+      kimiModel: null,
+      agentIdleDormantMinutes: null,
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/plugins/terminal/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agentIdleDormantMinutes: null }),
       signal: undefined,
     });
   });

--- a/runtime/fleet-plugins/terminal/tests/tickets-invalidate-session.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/tickets-invalidate-session.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { createPluginTerminalTicketRegistry } from "../server/shared/tickets.js";
+
+describe("terminal ticket invalidateForSession", () => {
+  it("drops outstanding tickets for the target session only", () => {
+    const tickets = createPluginTerminalTicketRegistry({
+      now: () => 1_000,
+      randomTicket: (() => {
+        let index = 0;
+        return () => `ticket-${index++}`;
+      })(),
+    });
+    const keep = tickets.issue({ cwd: "/a", sessionId: "keep" });
+    const dropA = tickets.issue({ cwd: "/b", sessionId: "drop" });
+    const dropB = tickets.issue({ cwd: "/b", sessionId: "drop" });
+
+    tickets.invalidateForSession("drop");
+
+    expect(tickets.consume(dropA.ticket)).toBeNull();
+    expect(tickets.consume(dropB.ticket)).toBeNull();
+    expect(tickets.consume(keep.ticket)).toMatchObject({ sessionId: "keep" });
+  });
+});


### PR DESCRIPTION
## Summary
- 콘솔이 열린 상태에서 유후 agent 터미널이 설정 시간(기본 60분)을 넘기면 자동으로 DORMANT 전이해 CLI 프로세스 리소스를 회수한다. 전이는 기존 exit 경로를 재사용하고 Resume으로 원클릭 복귀한다.
- Settings → Terminal → General에 "Idle agent sessions" 선택 옵션(Off/30분/1시간/2시간/4시간)을 추가하고, 값은 global options를 통해 서버에 영속화된다.
- 가드: working/running 세션·providerSession capture 부재 세션은 전이하지 않으며, dormant 전이 시 미소비 ticket을 폐기하고 dormant 세션의 ticket 발급을 409로 거부해 stale 클라이언트의 PTY 부활을 막는다. Shell·Global Shell은 영향 없음.

## Test Plan
- [x] core-infra: typecheck + build + test (68) green
- [x] fleet-plugins/terminal: typecheck + build + test (385) green — sweeper 가드/전이, dormant ticket 409·폐기, lastActivityAt 갱신, attentionPending 보존, 설정 계약
- [x] `check:core-boundary` green
- [x] 디자인 계약 테스트 (instrument-design-contract, 25) green — 네이티브 `<select>` 대신 공용 Select 사용
- [ ] 라이브 브라우저에서 General 셀렉트 조작 및 실제 유후→DORMANT→Resume 경로 확인

## Changelog
- [x] `.changelog.d/pr-397.md` — fleet-plugin/Added 2건, 이중언어 요약, `compile-changelog-fragments --check` 통과