### PR TITLE
fix(console): decouple Alt+Arrow cycling from sidebar status sort

### DIFF
--- a/.changelog.d/pr-400.md
+++ b/.changelog.d/pr-400.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Alt+Arrow panel cycling keeps following the canvas layout order while the sidebar is sorted by status, instead of jumping through the status sections.
+  ko: 사이드바를 상태별로 정렬해도 Alt+방향키 패널 순환이 상태 구획을 건너뛰지 않고 캔버스 배치 순서를 그대로 따릅니다.

--- a/runtime/fleet-console/core/client/src/operation-activity.ts
+++ b/runtime/fleet-console/core/client/src/operation-activity.ts
@@ -10,7 +10,8 @@ export type OperationActivityVisual = "running" | "awaiting" | "dormant" | "idle
 // 활동 맵에 항목이 없는 Operation의 분류 폭백. 플러그인이 아직 status를 심지 않은 복원 Operation은
 // doctrine상 "dormant until explicitly relaunched"이다. providerSession 자체는 브라우저 DTO에서
 // 제거되므로, host가 DTO 시점에 심는 비민감 파생 마커 resumeAvailable로 dormant를 판별한다.
-// 사이드바 STATUS 축, Alt 순환, 팔레트 뱃지가 같은 분류를 공유하도록 이 함수가 단일 기준이다.
+// 사이드바 STATUS 축, Operation 검색, 팔레트 뱃지가 같은 분류를 공유하도록 이 함수가 단일 기준이다.
+// Alt+←/→ 순환은 상태를 해석하지 않으므로(캔버스 배치 순서 전용) 이 기준의 소비자가 아니다.
 export function resolveOperationActivity(
   operation: OperationNode,
   operationStatus: Readonly<Record<string, OperationActivity>>,

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -14,10 +14,10 @@ import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { RightRail } from "../rail/right-rail.js";
 import { OperationsSideBar } from "../sidebar/operations-side-bar.js";
-import { getSideBarStatusAxis, getSideBarStatusSectionCollapsed, getStatusTransitionTick, toggleSideBarStatusAxis } from "../sidebar/operations-side-bar-store.js";
+import { toggleSideBarStatusAxis } from "../sidebar/operations-side-bar-store.js";
 import { CodexReadingSheet } from "../components/codex-reading-sheet.js";
 import { shouldHandleOperationsKeyboardShortcut } from "../components/keyboard-shortcuts-dialog.js";
-import { beginAddTheater, cancelAddTheater, compareOperationCreatedAt, completeAddTheater, consumeOperationFocus, failAddTheater, focusCycleOperationIds, focusOperation, getState, hydrateGroups, hydrateOperations, hydrateTheaters, nextOperationId, removeTheater, requestOperationKeyboardFocus, setActiveOperation, setActiveTheater, sortOperationsByOrder, statusCycleOperationIds } from "../store.js";
+import { beginAddTheater, cancelAddTheater, compareOperationCreatedAt, completeAddTheater, consumeOperationFocus, failAddTheater, focusCycleOperationIds, focusOperation, getState, hydrateGroups, hydrateOperations, hydrateTheaters, nextOperationId, removeTheater, requestOperationKeyboardFocus, setActiveOperation, setActiveTheater, sortOperationsByOrder } from "../store.js";
 import type { ConsoleState, OperationNode } from "../types.js";
 
 const STABLE_RAIL_API: ClientApiCapability = createHostCapabilities().api;
@@ -59,7 +59,7 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
     void fetchOperationCatalog().then(setCatalog).catch(() => {});
   }, [state.activeTheaterId]);
 
-  // Alt+←/→는 SideBar 가시 순서로 포커스를 순환하고, Alt+F/Alt+S는 같은 capture/editable 가드 정책을 공유한다.
+  // Alt+←/→는 캔버스 배치 순서(그룹 order → 그룹 내 operationOrder → ungrouped)로 포커스를 순환하고, Alt+F/Alt+S는 같은 capture/editable 가드 정책을 공유한다.
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
       if (!shouldHandleOperationsKeyboardShortcut()) return;
@@ -84,24 +84,15 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
       const snapshot = stateRef.current;
       const canvas = getCanvasSnapshot();
       const theaterOperations = snapshot.operations.filter((operation) => operation.theaterId === snapshot.activeTheaterId);
-      // STATUS 축에서는 사이드바 가시 순서가 상태 섹션 순서이므로 순환도 같은 순서를 따른다.
-      const order = getSideBarStatusAxis()
-        ? statusCycleOperationIds(
-            theaterOperations,
-            canvas.operationOrder,
-            snapshot.operationStatus,
-            canvas.minimized,
-            (status) => snapshot.activeTheaterId !== null
-              && getSideBarStatusSectionCollapsed(snapshot.activeTheaterId, status, false),
-            getStatusTransitionTick,
-          )
-        : focusCycleOperationIds(
-            theaterOperations,
-            snapshot.groups.filter((g) => g.theaterId === snapshot.activeTheaterId),
-            canvas.operationOrder,
-            canvas.collapsedGroups,
-            canvas.minimized,
-          );
+      // 사이드바 'Sort by status'(statusAxis)는 순환 순서에 관여하지 않는다. 캔버스 패널 배치는 그룹/order
+      // 순서 그대로이므로 상태 랭크로 순환하면 포커스가 화면 배치와 어긋나 튄다(PR#361 계약 되돌림).
+      const order = focusCycleOperationIds(
+        theaterOperations,
+        snapshot.groups.filter((g) => g.theaterId === snapshot.activeTheaterId),
+        canvas.operationOrder,
+        canvas.collapsedGroups,
+        canvas.minimized,
+      );
       event.preventDefault();
       event.stopImmediatePropagation();
       if (order.length === 0) return;

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -2,7 +2,6 @@ import type { ClientNotification } from "@fleet-console/sdk/notifications";
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
 
 import { buildOperationSearchEntries } from "./operation-search.js";
-import { resolveOperationActivity } from "./operation-activity.js";
 import { uiFontFamily } from "./ui-font.js";
 import type {
   CodexReaderRequest,
@@ -372,7 +371,7 @@ export function nextOperationId(order: readonly string[], currentId: string | nu
   return order[nextIndex] ?? null;
 }
 
-// SideBar 표시 순서와 Alt+←/→ 순환 순서가 갈라지지 않도록 Operation 정렬을 이 한 함수로 단일화한다.
+// GROUP 축 SideBar 표시 순서와 Alt+←/→ 순환 순서가 갈라지지 않도록 Operation 정렬을 이 한 함수로 단일화한다.
 // operationOrder(드래그 재정렬 SSoT)에 있는 항목은 그 순서를 따르고, 없는 항목은 createdAt 순으로 뒤에 붙인다.
 export function sortOperationsByOrder(
   operations: readonly OperationNode[],
@@ -391,7 +390,7 @@ export function sortOperationsByOrder(
 }
 
 // 그룹 적용 visible 순서(비-collapsed 그룹 order → 그룹 내 operationOrder → ungrouped)로 flatten한 배열을 반환.
-// SideBar visible 순서와 Alt+←/→ cycling 순서의 공유 SSoT.
+// GROUP 축 SideBar visible 순서와 Alt+←/→ cycling 순서의 공유 SSoT.
 // collapsedGroups: 접힌 그룹 id 목록 — 해당 그룹의 멤버는 결과에서 제외한다.
 export function flattenGroupedOrder(
   operations: readonly OperationNode[],
@@ -421,7 +420,7 @@ export function flattenGroupedOrder(
   ];
 }
 
-// Alt+←/→는 SideBar 가시 순서를 따르되, 캔버스에서 최소화된 Operation은 순환 대상에서 제외한다.
+// Alt+←/→는 캔버스 배치 순서를 따르되, 캔버스에서 최소화된 Operation은 순환 대상에서 제외한다. 사이드바의 'Sort by status' 축은 이 순서에 관여하지 않는다.
 export function focusCycleOperationIds(
   operations: readonly OperationNode[],
   groups: readonly OperationGroup[],
@@ -432,37 +431,6 @@ export function focusCycleOperationIds(
   const minimizedIds = new Set(minimized);
   return flattenGroupedOrder(operations, groups, operationOrder, collapsedGroups)
     .filter((operation) => !minimizedIds.has(operation.id))
-    .map((operation) => operation.id);
-}
-
-// STATUS 축의 Alt+←/→ 순환 순서: 사이드바 STATUS 섹션의 가시 순서와 동일하게
-// awaiting → running → idle → dormant 랭크로 안정 정렬한다(랭크 내부는 operationOrder 순서 유지).
-// 그룹 접힘은 적용하지 않되, 상태 섹션 접힘 predicate로 사이드바에서 숨은 Operation을 제외한다.
-const STATUS_CYCLE_RANK: Readonly<Record<OperationActivity, number>> = { awaiting: 0, running: 1, idle: 2, dormant: 3 };
-
-export function statusCycleOperationIds(
-  operations: readonly OperationNode[],
-  operationOrder: readonly string[],
-  operationStatus: Readonly<Record<string, OperationActivity>>,
-  minimized: readonly string[],
-  isStatusSectionCollapsed: (status: OperationActivity) => boolean,
-  getTick?: (id: string) => number | undefined,
-): readonly string[] {
-  const minimizedIds = new Set(minimized);
-  const status = (operation: OperationNode): OperationActivity => resolveOperationActivity(operation, operationStatus);
-  const rank = (operation: OperationNode): number => STATUS_CYCLE_RANK[status(operation)];
-  return [...sortOperationsByOrder(operations, operationOrder)]
-    .sort((left, right) => {
-      const rankDifference = rank(left) - rank(right);
-      if (rankDifference !== 0) return rankDifference;
-      const leftTick = getTick?.(left.id);
-      const rightTick = getTick?.(right.id);
-      if (leftTick === undefined && rightTick === undefined) return 0;
-      if (leftTick === undefined) return 1;
-      if (rightTick === undefined) return -1;
-      return rightTick - leftTick;
-    })
-    .filter((operation) => !minimizedIds.has(operation.id) && !isStatusSectionCollapsed(status(operation)))
     .map((operation) => operation.id);
 }
 

--- a/runtime/fleet-console/tests/operation-focus.test.ts
+++ b/runtime/fleet-console/tests/operation-focus.test.ts
@@ -1,14 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
 
-import {
-  getSideBarStatusSectionCollapsed,
-  getStatusTransitionTick,
-  recordStatusTransitions,
-  resetSideBarStatusRecencyForTests,
-  resetSideBarStatusSectionCollapseForTests,
-  toggleSideBarStatusSectionCollapsed,
-} from "../core/client/src/sidebar/operations-side-bar-store.js";
-import { focusCycleOperationIds, getState, nextOperationId, requestOperationKeyboardFocus, setState, statusCycleOperationIds } from "../core/client/src/store.js";
+import { describe, expect, it } from "vitest";
+
+import { focusCycleOperationIds, getState, nextOperationId, requestOperationKeyboardFocus, setState } from "../core/client/src/store.js";
 import type { OperationGroup, OperationNode } from "../core/client/src/types.js";
 
 function makeOperation(id: string, groupId: string | null = null, createdAt = 1): OperationNode {
@@ -28,9 +22,6 @@ function makeOperation(id: string, groupId: string | null = null, createdAt = 1)
 function makeGroup(id: string, order: number): OperationGroup {
   return { id, name: id, color: "blue", order, theaterId: "theater", createdAt: order };
 }
-
-beforeEach(() => resetSideBarStatusRecencyForTests());
-afterEach(() => resetSideBarStatusRecencyForTests());
 
 describe("nextOperationId — Alt+←/→ focus cycle", () => {
   const order = ["a", "b", "c"];
@@ -98,6 +89,16 @@ describe("nextOperationId — Alt+←/→ focus cycle", () => {
     expect(nextOperationId(order, null, -1)).toBeNull();
   });
 
+  // statusAxis 상태는 operations-side-bar-store 모듈에만 존재하므로, Operations 페이지가 그 모듈에서
+  // 무엇을 가져오는지가 "순환 순서는 상태 정렬 축과 무관하다"는 계약의 렉시컬 방어선이다.
+  // (행동 자체는 focusCycleOperationIds가 statusAxis를 인자로도 받지 않는다는 시그니처가 보장한다.)
+  it("Alt+←/→ 순환은 사이드바 'Sort by status' 축에 분기하지 않는다", () => {
+    const source = fs.readFileSync(new URL("../core/client/src/pages/operations.tsx", import.meta.url), "utf8");
+    expect(source).not.toContain("statusCycleOperationIds");
+    const sideBarStoreImport = /import \{([^}]*)\} from "\.\.\/sidebar\/operations-side-bar-store\.js";/.exec(source);
+    expect(sideBarStoreImport?.[1]?.split(",").map((symbol) => symbol.trim())).toEqual(["toggleSideBarStatusAxis"]);
+  });
+
 });
 
 describe("Operation keyboard focus requests", () => {
@@ -112,136 +113,5 @@ describe("Operation keyboard focus requests", () => {
 
     requestOperationKeyboardFocus("other-operation");
     expect(getState().keyboardFocusRequest).toEqual({ operationId: "other-operation", requestId: 3 });
-  });
-});
-
-describe("statusCycleOperationIds — STATUS 축 Alt+←/→ 순환", () => {
-  it("orders by awaiting → running → idle → dormant, keeping operationOrder inside each rank and ignoring group collapse", () => {
-    const operations = [
-      makeOperation("idle-late", null, 1),
-      makeOperation("running-1", "collapsed-group", 2),
-      makeOperation("awaiting-1", "collapsed-group", 3),
-      makeOperation("idle-early", null, 4),
-      makeOperation("dormant-1", null, 5),
-    ];
-    const order = statusCycleOperationIds(
-      operations,
-      ["idle-early", "idle-late", "running-1", "awaiting-1", "dormant-1"],
-      { "running-1": "running", "awaiting-1": "awaiting", "dormant-1": "dormant" },
-      [],
-      () => false,
-    );
-    // 사이드바 STATUS 섹션과 동일한 가시 순서: 접힌 그룹 소속이어도 제외되지 않는다.
-    expect(order).toEqual(["awaiting-1", "running-1", "idle-early", "idle-late", "dormant-1"]);
-  });
-
-  it("drops minimized operations and treats missing status as idle", () => {
-    const operations = [
-      makeOperation("plain", null, 1),
-      makeOperation("minimized-awaiting", null, 2),
-    ];
-    const order = statusCycleOperationIds(
-      operations,
-      ["plain", "minimized-awaiting"],
-      { "minimized-awaiting": "awaiting" },
-      ["minimized-awaiting"],
-      () => false,
-    );
-    expect(order).toEqual(["plain"]);
-  });
-
-  it("uses descending transition ticks inside a status rank before untouched operationOrder entries", () => {
-    const operations = [
-      makeOperation("untouched-first"),
-      makeOperation("latest"),
-      makeOperation("earlier"),
-      makeOperation("untouched-second"),
-    ];
-    recordStatusTransitions(["earlier"]);
-    recordStatusTransitions(["latest"]);
-
-    expect(statusCycleOperationIds(
-      operations,
-      operations.map((operation) => operation.id),
-      Object.fromEntries(operations.map((operation) => [operation.id, "running"])),
-      [],
-      () => false,
-      getStatusTransitionTick,
-    )).toEqual(["latest", "earlier", "untouched-first", "untouched-second"]);
-  });
-
-  it("ranks a restored operation with resumeAvailable but no live status as dormant", () => {
-    const restored = { ...makeOperation("restored", null, 1), payload: { resumeAvailable: true } };
-    const operations = [makeOperation("plain", null, 2), restored];
-    const order = statusCycleOperationIds(
-      operations,
-      ["restored", "plain"],
-      {},
-      [],
-      () => false,
-    );
-    // idle(plain) → dormant(restored) 랭크 순서여야 사이드바 STATUS 섹션과 일치한다.
-    expect(order).toEqual(["plain", "restored"]);
-  });
-
-  it("lets a live status entry win over the resumeAvailable dormant fallback", () => {
-    const restored = { ...makeOperation("restored", null, 1), payload: { resumeAvailable: true } };
-    const order = statusCycleOperationIds(
-      [restored, makeOperation("plain", null, 2)],
-      ["restored", "plain"],
-      { restored: "running" },
-      [],
-      () => false,
-    );
-    expect(order).toEqual(["restored", "plain"]);
-  });
-
-  it("keeps a resumed live-idle operation idle — an explicit idle entry beats the dormant fallback", () => {
-    // resume 성공 직후 plugin은 idle을 보고한다. idle이 항목 삭제로 표현되면 resumeAvailable
-    // 마커와 함께 dormant로 재분류된다(Codex P1) — 명시 idle 항목이 이를 막는다.
-    const restored = { ...makeOperation("restored", null, 1), payload: { resumeAvailable: true } };
-    const order = statusCycleOperationIds(
-      [restored, makeOperation("plain", null, 2)],
-      ["restored", "plain"],
-      { restored: "idle" },
-      [],
-      () => false,
-    );
-    // 둘 다 idle 랭크여야 operationOrder가 유지된다(dormant로 밀리면 plain이 앞선다).
-    expect(order).toEqual(["restored", "plain"]);
-  });
-
-  it("excludes explicitly collapsed status sections, restores them when expanded, and leaves GROUP cycling unchanged", () => {
-    resetSideBarStatusSectionCollapseForTests();
-    const operations = [
-      makeOperation("awaiting"),
-      makeOperation("running"),
-      makeOperation("idle"),
-    ];
-    const operationOrder = operations.map((operation) => operation.id);
-    const operationStatus = { awaiting: "awaiting", running: "running" } as const;
-    const statusOrder = () => statusCycleOperationIds(
-      operations,
-      operationOrder,
-      operationStatus,
-      [],
-      (status) => getSideBarStatusSectionCollapsed("theater", status, false),
-    );
-
-    try {
-      expect(statusOrder()).toEqual(["awaiting", "running", "idle"]);
-
-      toggleSideBarStatusSectionCollapsed("theater", "running", false);
-
-      expect(statusOrder()).toEqual(["awaiting", "idle"]);
-      expect(focusCycleOperationIds(operations, [], operationOrder, [], []))
-        .toEqual(["awaiting", "running", "idle"]);
-
-      toggleSideBarStatusSectionCollapsed("theater", "running", false);
-
-      expect(statusOrder()).toEqual(["awaiting", "running", "idle"]);
-    } finally {
-      resetSideBarStatusSectionCollapseForTests();
-    }
   });
 });


### PR DESCRIPTION
## Summary
- Alt+←/→ 패널 포커스 순환이 좌측 사이드바의 `Sort by status`(statusAxis) 토글에 분기하지 않고, 축의 on/off와 무관하게 항상 캔버스 배치 순서(그룹 order → 그룹 내 operationOrder → ungrouped, 접힌 그룹·최소화 패널 제외)를 따르도록 되돌립니다. 캔버스 패널 배치는 상태와 무관하게 유지되는데 순환만 상태 랭크를 따라 포커스가 화면 배치와 어긋나 튀던 문제를 해소합니다.
- 죽은 코드가 된 `statusCycleOperationIds`·`STATUS_CYCLE_RANK`와 `store.ts`의 미사용 `resolveOperationActivity` import를 제거하고, 순서 계약 주석을 GROUP 축 기준으로 정정했습니다. 사이드바의 상태 정렬·섹션 접기·recency 동작은 그대로입니다.
- 삭제된 STATUS 축 순환 유닛 테스트를 대신해, Operations 페이지가 사이드바 스토어에서 `toggleSideBarStatusAxis`만 가져온다는 계약 테스트를 추가해 상태축 분기 재도입을 차단합니다.

## Design note (의도된 트레이드오프)
PR#361에서 도입된 "Alt 순환 순서 = 사이드바 STATUS 가시 순서" 계약은 사용자 결정으로 되돌립니다. 캔버스 패널 배치가 상태 정렬을 따르지 않는 이상, 순환만 상태 랭크를 따르면 포커스가 화면과 어긋납니다. 따라서 STATUS 축에서 사이드바 표시 순서와 순환 순서가 일치하지 않는 것은 결함이 아니라 의도된 동작이며, 상태 섹션을 접어도 해당 패널이 순환에서 제외되지 않습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/operation-focus.test.ts tests/operations-side-bar-status-axis.test.tsx tests/operations-side-bar-group.test.ts tests/operation-search.test.ts tests/instrument-design-contract.test.ts` — 5 files / 106 tests 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과
- [x] Sentinel QA — Critical/High/Medium 0, Low 2건 반영 완료
- [x] Changelog: `.changelog.d/pr-400.md` 추가, 제품/섹션 그룹 문법·영문/한글 요약 쌍 준수, `node scripts/compile-changelog-fragments.mjs --check` 통과