### PR TITLE
fix(terminal): fit carrier stream rows to the panel height

### DIFF
--- a/.changelog.d/pr-401.md
+++ b/.changelog.d/pr-401.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Changed
+- [fleet-console] Carrier stream rows now share the panel height instead of a fixed cap: a single stream fills what it needs without scrolling, and as more carriers stream the rows shrink evenly down to a readable floor while shorter rows hand their surplus height to longer ones.
+  ko: 캐리어 스트림 행이 고정 높이 대신 패널 높이를 나눠 갖습니다. 스트림이 하나면 스크롤 없이 필요한 만큼 채우고, 캐리어가 늘어날수록 판독 가능한 하한까지 행이 고르게 줄어들며, 짧은 행이 남긴 높이는 긴 행으로 넘어갑니다.

--- a/runtime/fleet-plugins/terminal/client/agent/analysis.css
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis.css
@@ -25,7 +25,9 @@
 .carrier-streams__state.is-live { color: var(--aurora); }
 .carrier-streams__state.is-live i { background: var(--aurora); box-shadow: 0 0 10px var(--aurora-glow); }
 .carrier-streams__board { display: flex; flex-direction: column; align-items: stretch; gap: 10px; min-width: 0; min-height: 0; overflow-x: hidden; overflow-y: auto; padding: 10px; scrollbar-width: thin; }
-.carrier-stream-column { position: relative; box-sizing: border-box; display: flex; flex: none; width: 100%; min-width: 0; min-height: 0; flex-direction: column; overflow: hidden; border: 1px solid var(--hairline); border-radius: 13px; background: var(--ink-deep); color: var(--text-primary); }
+/* 행은 보드 가용 높이를 나눠 갖는다 — flex-basis는 반드시 0이어야 한다. auto면 shrink 모드로 들어가
+   짧은 행이 하한까지 눌린다. max-content 상한이 짧은 행의 남는 몫을 긴 행으로 재분배한다. */
+.carrier-stream-column { position: relative; box-sizing: border-box; display: flex; flex: 1 1 0; width: 100%; min-width: 0; min-height: 240px; max-height: max-content; flex-direction: column; overflow: hidden; border: 1px solid var(--hairline); border-radius: 13px; background: var(--ink-deep); color: var(--text-primary); }
 .carrier-stream-column[data-tone="live"] { border-color: color-mix(in oklch, var(--aurora) 36%, var(--hairline)); }
 .carrier-stream-column[data-tone="done"] { border-color: color-mix(in oklch, var(--positive) 34%, var(--hairline)); }
 .carrier-stream-column[data-tone="error"] { border-color: color-mix(in oklch, var(--coral) 42%, var(--hairline)); }
@@ -42,7 +44,7 @@
 .carrier-stream-column__phase { color: var(--aurora); font-weight: var(--weight-bold); font-size: 9px; line-height: 1; font-family: var(--font-mono); letter-spacing: .08em; }
 .carrier-stream-column__phase[data-tone="done"] { color: var(--positive); }
 .carrier-stream-column__phase[data-tone="error"] { color: var(--coral); }
-.carrier-stream-column__body { max-height: 320px; min-height: 0; flex: 1; overflow-y: auto; outline: none; scrollbar-width: thin; }
+.carrier-stream-column__body { min-height: 0; flex: 1; overflow-y: auto; outline: none; scrollbar-width: thin; }
 .carrier-stream-column__body:focus-visible { box-shadow: inset 0 0 0 2px var(--brass-bright); }
 .carrier-stream-column__content { display: flex; min-height: 100%; flex-direction: column; gap: 12px; padding: 12px; }
 /* 출격 명령서 — 채팅 말풍선이 아니라 캐리어에게 발부된 명령 블록. 정체성은 spine+wash 문법

--- a/runtime/fleet-plugins/terminal/tests/carrier-streams-companion.test.tsx
+++ b/runtime/fleet-plugins/terminal/tests/carrier-streams-companion.test.tsx
@@ -111,7 +111,8 @@ describe("Carrier Streams companion", () => {
     expect(container?.textContent).not.toContain("another private thought");
     expect(container?.querySelector('[data-captain="genesis"]')).not.toBeNull();
     expect(ANALYSIS_CSS).toMatch(/\.carrier-streams__board \{[^}]*flex-direction: column;[^}]*gap: 10px;[^}]*overflow-x: hidden;[^}]*overflow-y: auto;/);
-    expect(ANALYSIS_CSS).toMatch(/\.carrier-stream-column \{[^}]*flex: none;[^}]*width: 100%;/);
+    expect(ANALYSIS_CSS).toMatch(/\.carrier-stream-column \{[^}]*flex: 1 1 0;[^}]*width: 100%;[^}]*min-height: 240px;[^}]*max-height: max-content;/);
+    expect(ANALYSIS_CSS).not.toMatch(/\.carrier-stream-column__body \{[^}]*max-height:/);
     expect(ANALYSIS_CSS).not.toContain("flex: 1 0 250px");
     expect(ANALYSIS_CSS).not.toContain("max-width: 420px");
     const firstColumn = columns?.[0];


### PR DESCRIPTION
## Summary
- Carrier Streams 행이 패널 높이를 인식하지 못하던 문제를 해결합니다. 기존 정책은 `헤더 46px + 본문 max-height 320px`로 행 높이가 고정되어, 트랙이 1개일 때 보드 930px 중 542px가 빈 채로 남는데도 행 안에서는 스크롤이 걸렸습니다.
- `.carrier-stream-column`을 `flex: 1 1 0; min-height: 240px; max-height: max-content`로 바꿔 행이 보드 가용 높이를 나눠 갖되, 짧은 행은 제 콘텐츠에서 멈추고 남는 몫이 긴 행으로 재분배되도록 했습니다. `flex-basis`는 반드시 `0`이어야 합니다 — `auto`면 shrink 모드로 들어가 짧은 행이 하한까지 눌리는 것을 실측으로 확인했습니다.
- `.carrier-stream-column__body`의 고정 `max-height: 320px`를 제거했습니다. 완료 트랙의 36px 스트립은 `flex: none`으로 높이 분배에서 계속 제외됩니다.

## Measured impact
격리 콘솔(1680x1050, 보드 930px)에 합성 캐리어 잡을 주입해 변경 전후를 측정했습니다.

| 트랙 | 변경 전 | 변경 후 |
|---|---|---|
| 1 | 행 368px, 숨은 콘텐츠 96px, 미사용 542px | 행 464px, **숨은 콘텐츠 0**, 미사용 446px |
| 2 | 미사용 164px | **미사용 0px** (보드를 정확히 채움) |
| 3 | 보드 스크롤 166px + **중첩 스크롤 발생** | **보드 스크롤 없음, 중첩 스크롤 없음** |
| 5 | 보드 스크롤 890px | 보드 스크롤 330px (63% 감소) |

총 스크롤 거리는 콘텐츠 총량이 정하므로 정책이 줄이지 못합니다. 이 변경이 바꾸는 것은 한 화면에서 동시에 감시할 수 있는 캐리어 수(2.4 -> 3.4)와 스크롤 위치의 예측 가능성입니다. 5 캐리어 이상에서 하한(240px)에 닿으면 보드 스크롤이 남는 것은 의도된 트레이드오프입니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal test` — 44 files / 397 tests pass
- [x] `pnpm --filter @fleet-plugins/terminal build` — exit 0
- [x] `pnpm --filter @fleet-plugins/terminal typecheck` — exit 0
- [x] `pnpm --filter @dotobokuri/fleet-console build` — exit 0
- [x] 격리 콘솔 실측 재현 (1/2/3/5 트랙), 페이지 에러 0 / rejection 0
- [x] Changelog: `.changelog.d/pr-401.md` (grouped `### fleet-plugin` / `#### Changed`, 영문+`ko:` 인접, `node scripts/compile-changelog-fragments.mjs --check` OK)