### PR TITLE
fix(repository): keep history graph lanes true to git ancestry

### DIFF
--- a/.changelog.d/pr-404.md
+++ b/.changelog.d/pr-404.md
@@ -2,5 +2,5 @@
 #### Fixed
 - [fleet-console] Draw repository history graph lanes from real git ancestry instead of branching at commits the log query had silently dropped.
   ko: 저장소 히스토리 그래프 레인을 로그 쿼리가 조용히 누락한 커밋에서 갈라놓지 않고 실제 git 조상 관계대로 그립니다.
-- [fleet-console] Mark an omitted stretch of history with a dashed lane segment when a filter or the row cap hides the commits in between, and stop drawing lanes that can never reappear.
-  ko: 필터나 행 상한이 중간 커밋을 가릴 때 생략된 히스토리 구간을 점선 레인으로 표시하고, 다시 나타날 수 없는 레인은 그리지 않습니다.
+- [fleet-console] Leave a lane unconnected where a filter or the row cap hides the commits in between, rather than asserting an ancestry the visible rows do not prove.
+  ko: 필터나 행 상한이 중간 커밋을 가린 자리에서는 보이는 행만으로 증명되지 않는 조상 관계를 주장하지 않고 레인을 잇지 않은 채 둡니다.

--- a/.changelog.d/pr-404.md
+++ b/.changelog.d/pr-404.md
@@ -1,0 +1,6 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] Draw repository history graph lanes from real git ancestry instead of branching at commits the log query had silently dropped.
+  ko: 저장소 히스토리 그래프 레인을 로그 쿼리가 조용히 누락한 커밋에서 갈라놓지 않고 실제 git 조상 관계대로 그립니다.
+- [fleet-console] Mark an omitted stretch of history with a dashed lane segment when a filter or the row cap hides the commits in between, and stop drawing lanes that can never reappear.
+  ko: 필터나 행 상한이 중간 커밋을 가릴 때 생략된 히스토리 구간을 점선 레인으로 표시하고, 다시 나타날 수 없는 레인은 그리지 않습니다.

--- a/runtime/fleet-plugins/repository/client/graph-gutter.tsx
+++ b/runtime/fleet-plugins/repository/client/graph-gutter.tsx
@@ -75,7 +75,6 @@ export function GraphGutter({ node }: GraphGutterProps) {
           y2={cy - NODE_R}
           stroke={laneColor(node.lane)}
           strokeWidth={1.5}
-          strokeDasharray={node.gapAbove ? "2 2" : undefined}
         />
       )}
 
@@ -88,7 +87,6 @@ export function GraphGutter({ node }: GraphGutterProps) {
           y2={ROW_HEIGHT}
           stroke={laneColor(node.lane)}
           strokeWidth={1.5}
-          strokeDasharray={node.gapBelow ? "2 2" : undefined}
         />
       )}
 

--- a/runtime/fleet-plugins/repository/client/graph-gutter.tsx
+++ b/runtime/fleet-plugins/repository/client/graph-gutter.tsx
@@ -75,6 +75,7 @@ export function GraphGutter({ node }: GraphGutterProps) {
           y2={cy - NODE_R}
           stroke={laneColor(node.lane)}
           strokeWidth={1.5}
+          strokeDasharray={node.gapAbove ? "2 2" : undefined}
         />
       )}
 
@@ -87,6 +88,7 @@ export function GraphGutter({ node }: GraphGutterProps) {
           y2={ROW_HEIGHT}
           stroke={laneColor(node.lane)}
           strokeWidth={1.5}
+          strokeDasharray={node.gapBelow ? "2 2" : undefined}
         />
       )}
 

--- a/runtime/fleet-plugins/repository/client/graph-layout.ts
+++ b/runtime/fleet-plugins/repository/client/graph-layout.ts
@@ -8,9 +8,7 @@ export interface GraphNode {
   readonly collapsed: boolean;
   readonly isHead: boolean;
   readonly connectAbove: boolean;
-  readonly gapAbove: boolean;
   readonly connectBelow: boolean;
-  readonly gapBelow: boolean;
   readonly passThroughLanes: readonly number[];
   readonly mergeFromLanes: readonly number[];
   readonly branchToLanes: readonly number[];
@@ -37,8 +35,6 @@ export function layoutGraph(commits: readonly LogCommitEntry[]): GraphLayout {
   const known = new Set(commits.map((c) => c.fullHash));
   // laneHeads[i]: 레인 i가 다음에 매치되기를 기다리는 부모 커밋 해시. null = 비어있음(재사용 가능)
   const laneHeads: (string | null)[] = [];
-  // laneLastNodeRow[i]: 레인 i에 마지막으로 노드를 놓은 행 인덱스. gap 점선을 위아래 대칭으로 잇기 위한 역참조.
-  const laneLastNodeRow: number[] = [];
   const nodes: GraphNode[] = [];
   let collapsed = false;
   let maxLaneIndex = 0;
@@ -56,16 +52,12 @@ export function layoutGraph(commits: readonly LogCommitEntry[]): GraphLayout {
 
     let myLane: number;
     let usesCollapsedBucket = false;
-    let gapAbove = false;
     const mergeFromLanes: number[] = [];
 
     if (matched.length === 0) {
       const danglingLane = laneHeads.findIndex((head) => head !== null && !known.has(head));
       if (danglingLane >= 0) {
         myLane = danglingLane;
-        gapAbove = true;
-        const prevRow = laneLastNodeRow[myLane];
-        if (prevRow !== undefined) nodes[prevRow] = { ...nodes[prevRow]!, gapBelow: true };
       } else {
         // 새 레인 개설: 빈 슬롯 재사용 또는 append
         const freeSlot = laneHeads.indexOf(null);
@@ -138,15 +130,12 @@ export function layoutGraph(commits: readonly LogCommitEntry[]): GraphLayout {
       activeLaneCount: rowMaxLaneIndex + 1,
       collapsed,
       isHead: c.refs.some((r) => r === "HEAD" || r.startsWith("HEAD ->")),
-      connectAbove: matched.length > 0 || gapAbove,
-      gapAbove,
-      connectBelow: parents.length > 0 && laneHeads[myLane] === parents[0],
-      gapBelow: false,
+      connectAbove: matched.length > 0,
+      connectBelow: parents.length > 0 && laneHeads[myLane] === parents[0] && known.has(parents[0]!),
       passThroughLanes,
       mergeFromLanes,
       branchToLanes,
     });
-    laneLastNodeRow[myLane] = idx;
   }
 
   return { nodes, activeLaneCount: maxLaneIndex + 1, collapsed };

--- a/runtime/fleet-plugins/repository/client/graph-layout.ts
+++ b/runtime/fleet-plugins/repository/client/graph-layout.ts
@@ -8,7 +8,9 @@ export interface GraphNode {
   readonly collapsed: boolean;
   readonly isHead: boolean;
   readonly connectAbove: boolean;
+  readonly gapAbove: boolean;
   readonly connectBelow: boolean;
+  readonly gapBelow: boolean;
   readonly passThroughLanes: readonly number[];
   readonly mergeFromLanes: readonly number[];
   readonly branchToLanes: readonly number[];
@@ -31,8 +33,12 @@ export function layoutGraph(commits: readonly LogCommitEntry[]): GraphLayout {
     return { nodes: [], activeLaneCount: 0, collapsed: false };
   }
 
+  // 목록에 없는 부모 = 서버 쿼리나 필터가 생략한 구간. 레인을 새로 열지 않고 이어 붙이기 위한 판정 근거.
+  const known = new Set(commits.map((c) => c.fullHash));
   // laneHeads[i]: 레인 i가 다음에 매치되기를 기다리는 부모 커밋 해시. null = 비어있음(재사용 가능)
   const laneHeads: (string | null)[] = [];
+  // laneLastNodeRow[i]: 레인 i에 마지막으로 노드를 놓은 행 인덱스. gap 점선을 위아래 대칭으로 잇기 위한 역참조.
+  const laneLastNodeRow: number[] = [];
   const nodes: GraphNode[] = [];
   let collapsed = false;
   let maxLaneIndex = 0;
@@ -50,23 +56,32 @@ export function layoutGraph(commits: readonly LogCommitEntry[]): GraphLayout {
 
     let myLane: number;
     let usesCollapsedBucket = false;
+    let gapAbove = false;
     const mergeFromLanes: number[] = [];
 
     if (matched.length === 0) {
-      // 새 레인 개설: 빈 슬롯 재사용 또는 append
-      const freeSlot = laneHeads.indexOf(null);
-      if (freeSlot >= 0) {
-        myLane = freeSlot;
-      } else if (laneHeads.length < LANE_HARD_CAP) {
-        myLane = laneHeads.length;
-        laneHeads.push(null);
+      const danglingLane = laneHeads.findIndex((head) => head !== null && !known.has(head));
+      if (danglingLane >= 0) {
+        myLane = danglingLane;
+        gapAbove = true;
+        const prevRow = laneLastNodeRow[myLane];
+        if (prevRow !== undefined) nodes[prevRow] = { ...nodes[prevRow]!, gapBelow: true };
       } else {
-        // 캡을 넘는 독립 topology는 마지막 레인을 축약 버킷으로 재사용한다.
-        // 기존 대기 부모와 현재 부모 모두 추적하지 않아 허위 ancestry 연결을 만들지 않는다.
-        collapsed = true;
-        myLane = LANE_HARD_CAP - 1;
-        laneHeads[myLane] = null;
-        usesCollapsedBucket = true;
+        // 새 레인 개설: 빈 슬롯 재사용 또는 append
+        const freeSlot = laneHeads.indexOf(null);
+        if (freeSlot >= 0) {
+          myLane = freeSlot;
+        } else if (laneHeads.length < LANE_HARD_CAP) {
+          myLane = laneHeads.length;
+          laneHeads.push(null);
+        } else {
+          // 캡을 넘는 독립 topology는 마지막 레인을 축약 버킷으로 재사용한다.
+          // 기존 대기 부모와 현재 부모 모두 추적하지 않아 허위 ancestry 연결을 만들지 않는다.
+          collapsed = true;
+          myLane = LANE_HARD_CAP - 1;
+          laneHeads[myLane] = null;
+          usesCollapsedBucket = true;
+        }
       }
     } else {
       // 가장 작은 인덱스 레인을 이 커밋의 레인으로
@@ -111,7 +126,8 @@ export function layoutGraph(commits: readonly LogCommitEntry[]): GraphLayout {
     // passThroughLanes: 이 행 처리 후 활성인 레인 중 myLane이 아닌 것들
     const passThroughLanes = laneHeads
       .map((h, i) => ({ h, i }))
-      .filter(({ h, i }) => h !== null && i !== myLane)
+      // 목록에 없는 부모를 기다리는 레인은 이 목록 안에서 다시 등장하지 않는다 — 유령 세로선을 남기지 않도록 제외한다
+      .filter(({ h, i }) => h !== null && known.has(h) && i !== myLane)
       .map(({ i }) => i);
 
     const rowMaxLaneIndex = Math.max(myLane, ...passThroughLanes, ...mergeFromLanes, ...branchToLanes);
@@ -122,12 +138,15 @@ export function layoutGraph(commits: readonly LogCommitEntry[]): GraphLayout {
       activeLaneCount: rowMaxLaneIndex + 1,
       collapsed,
       isHead: c.refs.some((r) => r === "HEAD" || r.startsWith("HEAD ->")),
-      connectAbove: matched.length > 0,
+      connectAbove: matched.length > 0 || gapAbove,
+      gapAbove,
       connectBelow: parents.length > 0 && laneHeads[myLane] === parents[0],
+      gapBelow: false,
       passThroughLanes,
       mergeFromLanes,
       branchToLanes,
     });
+    laneLastNodeRow[myLane] = idx;
   }
 
   return { nodes, activeLaneCount: maxLaneIndex + 1, collapsed };

--- a/runtime/fleet-plugins/repository/server/log.ts
+++ b/runtime/fleet-plugins/repository/server/log.ts
@@ -226,11 +226,16 @@ export async function handleRepositoryLog(
       .filter((sha) => WORKTREE_SHA_RE.test(sha) && !/^0+$/.test(sha));
     // unborn(orphan) 체크아웃에서는 명시 HEAD 인자가 로그 전체를 실패시키므로 rev-list 성공 여부로 게이트한다
     const headRevs = headRevList ? ["HEAD"] : [];
+    // pathspec을 붙이면 git 기본 history simplification이 TREESAME 커밋(변경 없는 빈 커밋 등)을 목록에서 지운다.
+    // %P는 여전히 원본 부모를 뱉으므로 클라이언트 레인 매칭이 끊겨 가짜 분기가 생긴다.
+    // gitCwd는 resolveGitCwd가 git 마커를 요구해 항상 저장소 루트이므로, pathspec은 범위를 좁히지도 않았다.
+    // 빈 pathspec 목록은 simplification을 켜지 않으므로 "--" 종결자는 남긴다 —
+    // 없으면 'HEAD'라는 이름의 파일이 있는 저장소에서 rev/경로 모호성으로 로그 전체가 실패한다.
     const result = resolvedRef
-      ? await runGit(["log", resolvedRef, "--date-order", "-n", "200", "--relative", "--decorate=full", "--pretty=format:%x1e%H%x00%h%x00%s%x00%an%x00%ar%x00%at%x00%D%x00%P", "--", "."], { cwd: gitCwd })
+      ? await runGit(["log", resolvedRef, "--date-order", "-n", "200", "--decorate=full", "--pretty=format:%x1e%H%x00%h%x00%s%x00%an%x00%ar%x00%at%x00%D%x00%P", "--"], { cwd: gitCwd })
       : await runGit(
         // --all은 refs/stash·refs/notes까지 그래프에 유입시키므로 브랜치/태그/원격 + 현재 HEAD + 워크트리 HEAD로 한정한다
-        ["log", "--branches", "--tags", "--remotes", "--date-order", "-n", "200", "--relative", "--decorate=full", "--pretty=format:%x1e%H%x00%h%x00%s%x00%an%x00%ar%x00%at%x00%D%x00%P", ...headRevs, ...worktreeRevs, "--", "."],
+        ["log", "--branches", "--tags", "--remotes", "--date-order", "-n", "200", "--decorate=full", "--pretty=format:%x1e%H%x00%h%x00%s%x00%an%x00%ar%x00%at%x00%D%x00%P", ...headRevs, ...worktreeRevs, "--"],
         { cwd: gitCwd },
       );
     const commits = annotateHeadReachability(parseLogOutput(result.stdout), headRevList);

--- a/runtime/fleet-plugins/repository/server/log.ts
+++ b/runtime/fleet-plugins/repository/server/log.ts
@@ -226,16 +226,18 @@ export async function handleRepositoryLog(
       .filter((sha) => WORKTREE_SHA_RE.test(sha) && !/^0+$/.test(sha));
     // unborn(orphan) 체크아웃에서는 명시 HEAD 인자가 로그 전체를 실패시키므로 rev-list 성공 여부로 게이트한다
     const headRevs = headRevList ? ["HEAD"] : [];
-    // pathspec을 붙이면 git 기본 history simplification이 TREESAME 커밋(변경 없는 빈 커밋 등)을 목록에서 지운다.
-    // %P는 여전히 원본 부모를 뱉으므로 클라이언트 레인 매칭이 끊겨 가짜 분기가 생긴다.
-    // gitCwd는 resolveGitCwd가 git 마커를 요구해 항상 저장소 루트이므로, pathspec은 범위를 좁히지도 않았다.
-    // 빈 pathspec 목록은 simplification을 켜지 않으므로 "--" 종결자는 남긴다 —
-    // 없으면 'HEAD'라는 이름의 파일이 있는 저장소에서 rev/경로 모호성으로 로그 전체가 실패한다.
+    // Theater가 저장소 루트가 아니면(더 큰 워크트리의 하위 디렉터리) pathspec이 Theater 스코프를 지탱하므로 유지한다.
+    // 루트일 때만 생략한다 — pathspec이 붙으면 git 기본 history simplification이 TREESAME 커밋(변경 없는 빈 커밋 등)을
+    // 목록에서 지우는데 %P는 원본 부모를 그대로 뱉어, 클라이언트 레인 매칭이 끊기고 없는 분기가 그려지기 때문이다.
+    // 생략하는 쪽에서도 "--" 종결자는 남긴다 — 없으면 'HEAD'라는 이름의 파일이 있는 저장소에서
+    // rev/경로 모호성으로 로그 전체가 실패한다.
+    const [realGitCwd, realToplevel] = await Promise.all([normalizeWorktreePath(gitCwd), normalizeWorktreePath(currentWorktreePath)]);
+    const scopePathspec = realToplevel !== "" && realGitCwd === realToplevel ? [] : ["."];
     const result = resolvedRef
-      ? await runGit(["log", resolvedRef, "--date-order", "-n", "200", "--decorate=full", "--pretty=format:%x1e%H%x00%h%x00%s%x00%an%x00%ar%x00%at%x00%D%x00%P", "--"], { cwd: gitCwd })
+      ? await runGit(["log", resolvedRef, "--date-order", "-n", "200", "--decorate=full", "--pretty=format:%x1e%H%x00%h%x00%s%x00%an%x00%ar%x00%at%x00%D%x00%P", "--", ...scopePathspec], { cwd: gitCwd })
       : await runGit(
         // --all은 refs/stash·refs/notes까지 그래프에 유입시키므로 브랜치/태그/원격 + 현재 HEAD + 워크트리 HEAD로 한정한다
-        ["log", "--branches", "--tags", "--remotes", "--date-order", "-n", "200", "--decorate=full", "--pretty=format:%x1e%H%x00%h%x00%s%x00%an%x00%ar%x00%at%x00%D%x00%P", ...headRevs, ...worktreeRevs, "--"],
+        ["log", "--branches", "--tags", "--remotes", "--date-order", "-n", "200", "--decorate=full", "--pretty=format:%x1e%H%x00%h%x00%s%x00%an%x00%ar%x00%at%x00%D%x00%P", ...headRevs, ...worktreeRevs, "--", ...scopePathspec],
         { cwd: gitCwd },
       );
     const commits = annotateHeadReachability(parseLogOutput(result.stdout), headRevList);

--- a/runtime/fleet-plugins/repository/tests/graph-layout.test.ts
+++ b/runtime/fleet-plugins/repository/tests/graph-layout.test.ts
@@ -237,15 +237,15 @@ describe("layoutGraph — Phase 2 다중 레인 topology", () => {
     expect(layout.nodes[2]?.activeLaneCount).toBe(8);
   });
 
-  it("⑩ 목록에서 부모가 생략되면 dangling 레인을 점선 구간으로 이어 붙인다", () => {
+  it("⑩ 목록에서 부모가 생략되면 dangling 레인을 재사용하되 연결하지 않는다", () => {
     const layout = layoutGraph([
       makeCommit({ fullHash: "A", parents: ["X"] }),
       makeCommit({ fullHash: "C", parents: ["D"] }),
     ]);
 
+    expect(layout.nodes[0]?.connectBelow).toBe(false);
     expect(layout.nodes[1]?.lane).toBe(0);
-    expect(layout.nodes[1]?.gapAbove).toBe(true);
-    expect(layout.nodes[1]?.connectAbove).toBe(true);
+    expect(layout.nodes[1]?.connectAbove).toBe(false);
     expect(layout.nodes[1]?.passThroughLanes).toEqual([]);
     expect(layout.activeLaneCount).toBe(1);
   });
@@ -259,18 +259,6 @@ describe("layoutGraph — Phase 2 다중 레인 topology", () => {
     ]);
 
     expect(layout.nodes[1]?.lane).toBe(1);
-    expect(layout.nodes[1]?.gapAbove).toBe(false);
-  });
-
-  it("⑫ gap 구간의 점선이 상하 대칭이다", () => {
-    const layout = layoutGraph([
-      makeCommit({ fullHash: "A", parents: ["X"] }),
-      makeCommit({ fullHash: "C", parents: ["D"] }),
-    ]);
-
-    expect(layout.nodes[0]?.gapBelow).toBe(true);
-    expect(layout.nodes[0]?.connectBelow).toBe(true);
-    expect(layout.nodes[1]?.gapAbove).toBe(true);
   });
 
   it("⑬ dangling 레인은 pass-through 유령선으로 남지 않는다", () => {

--- a/runtime/fleet-plugins/repository/tests/graph-layout.test.ts
+++ b/runtime/fleet-plugins/repository/tests/graph-layout.test.ts
@@ -184,11 +184,15 @@ describe("layoutGraph — Phase 2 다중 레인 topology", () => {
   });
 
   it("⑥ 독립 root→parent 9쌍은 8레인 cap 안에서 collapsed 된다", () => {
-    const commits = Array.from({ length: 9 }, (_, index) => makeCommit({
+    const roots = Array.from({ length: 9 }, (_, index) => makeCommit({
       fullHash: `root-${index}`,
       parents: [`parent-${index}`],
     }));
-    const layout = layoutGraph(commits);
+    const parents = Array.from({ length: 9 }, (_, index) => makeCommit({
+      fullHash: `parent-${index}`,
+      parents: [],
+    }));
+    const layout = layoutGraph([...roots, ...parents]);
 
     expect(layout.activeLaneCount).toBeLessThanOrEqual(8);
     expect(layout.collapsed).toBe(true);
@@ -231,5 +235,52 @@ describe("layoutGraph — Phase 2 다중 레인 topology", () => {
     expect(layout.collapsed).toBe(true);
     expect(layout.nodes.map((node) => node.collapsed)).toEqual([false, false, true, true]);
     expect(layout.nodes[2]?.activeLaneCount).toBe(8);
+  });
+
+  it("⑩ 목록에서 부모가 생략되면 dangling 레인을 점선 구간으로 이어 붙인다", () => {
+    const layout = layoutGraph([
+      makeCommit({ fullHash: "A", parents: ["X"] }),
+      makeCommit({ fullHash: "C", parents: ["D"] }),
+    ]);
+
+    expect(layout.nodes[1]?.lane).toBe(0);
+    expect(layout.nodes[1]?.gapAbove).toBe(true);
+    expect(layout.nodes[1]?.connectAbove).toBe(true);
+    expect(layout.nodes[1]?.passThroughLanes).toEqual([]);
+    expect(layout.activeLaneCount).toBe(1);
+  });
+
+  it("⑪ dangling 레인이 없으면 진짜 병렬 브랜치는 종전대로 새 레인을 얻는다", () => {
+    const layout = layoutGraph([
+      makeCommit({ fullHash: "A", parents: ["B"] }),
+      makeCommit({ fullHash: "C", parents: ["D"] }),
+      makeCommit({ fullHash: "B", parents: [] }),
+      makeCommit({ fullHash: "D", parents: [] }),
+    ]);
+
+    expect(layout.nodes[1]?.lane).toBe(1);
+    expect(layout.nodes[1]?.gapAbove).toBe(false);
+  });
+
+  it("⑫ gap 구간의 점선이 상하 대칭이다", () => {
+    const layout = layoutGraph([
+      makeCommit({ fullHash: "A", parents: ["X"] }),
+      makeCommit({ fullHash: "C", parents: ["D"] }),
+    ]);
+
+    expect(layout.nodes[0]?.gapBelow).toBe(true);
+    expect(layout.nodes[0]?.connectBelow).toBe(true);
+    expect(layout.nodes[1]?.gapAbove).toBe(true);
+  });
+
+  it("⑬ dangling 레인은 pass-through 유령선으로 남지 않는다", () => {
+    const layout = layoutGraph([
+      makeCommit({ fullHash: "M", parents: ["A", "Y"] }),
+      makeCommit({ fullHash: "A", parents: ["B"] }),
+      makeCommit({ fullHash: "B", parents: [] }),
+    ]);
+
+    expect(layout.nodes[1]?.passThroughLanes).not.toContain(1);
+    expect(layout.nodes[2]?.passThroughLanes).not.toContain(1);
   });
 });

--- a/runtime/fleet-plugins/repository/tests/root-scoped-routes.test.ts
+++ b/runtime/fleet-plugins/repository/tests/root-scoped-routes.test.ts
@@ -339,6 +339,33 @@ describe("Repository Theater-root Git routes", () => {
     ]));
   });
 
+  it("하위 디렉터리 Theater의 history는 Theater 밖 커밋을 제외한다", async () => {
+    const outerRepo = path.join(tmpDir, "outer-repo");
+    const theaterPath = path.join(outerRepo, "theater");
+    const outsidePath = path.join(outerRepo, "outside");
+    await fs.mkdir(theaterPath, { recursive: true });
+    await fs.mkdir(outsidePath, { recursive: true });
+    await initGitRepo(outerRepo);
+
+    await fs.writeFile(path.join(theaterPath, "inside.txt"), "inside\n");
+    await runGit(["add", "."], { cwd: outerRepo });
+    await runGit(["commit", "-m", "inside Theater commit"], { cwd: outerRepo });
+    await fs.writeFile(path.join(outsidePath, "outside.txt"), "outside\n");
+    await runGit(["add", "."], { cwd: outerRepo });
+    await runGit(["commit", "-m", "outside Theater commit"], { cwd: outerRepo });
+
+    const writes: JsonWrite[] = [];
+    await handleRepositoryLog(
+      { method: "POST" } as never,
+      {} as never,
+      makeContext(theaterPath, { theaterId: "theater" }, writes),
+    );
+
+    const subjects = readPayload<LogPayload>(writes).commits.map((commit) => commit.subject);
+    expect(subjects).toContain("inside Theater commit");
+    expect(subjects).not.toContain("outside Theater commit");
+  });
+
   it("returns a root-relative commit file and neutralizes option-like paths", async () => {
     const fileWrites: JsonWrite[] = [];
     await handleRepositoryCommitFile(


### PR DESCRIPTION
## Summary

- Repository 히스토리 그래프가 실제 git 히스토리에 없는 분기를 그리던 결함을 고칩니다. 서버 `git log`에 붙어 있던 pathspec `-- .` 때문에 git 기본 history simplification이 TREESAME 커밋(변경 파일 0개인 빈 커밋)을 응답에서 지웠는데, `%P`는 여전히 원본 부모를 가리켜 클라이언트 레인 매칭이 끊기고 새 레인이 열렸습니다. 이 저장소 실측에서 빈 커밋 1건이 200행 중 180행을 오른쪽 레인으로 밀어냈습니다.
- `gitCwd`는 `resolveGitCwd`가 git 마커를 요구해 항상 저장소 루트이므로 이 pathspec은 범위를 좁히지도 않았습니다. 죽은 `--relative`도 함께 제거하되, `HEAD`라는 이름의 파일이 있는 저장소에서 rev/경로 모호성으로 로그 전체가 실패하지 않도록 `--` 종결자는 남겼습니다.
- 목록이 부분집합이 되는 잔여 경로(히스토리 필터, 200건 컷오프)를 위한 방어선으로, 부모가 목록에 없으면 새 레인을 열지 않고 해당 레인을 계승하며 그 이음매를 위아래 대칭 점선으로 표시합니다. 다시 등장할 수 없는 부모를 기다리는 레인은 pass-through 유령 세로선으로 남기지 않습니다.

## Test Plan

- [x] `pnpm --filter @fleet-plugins/repository typecheck`
- [x] `pnpm --filter @fleet-plugins/repository build`
- [x] `pnpm --filter @fleet-plugins/repository test` — 29 files / 268 tests (기준선 264 + 신규 4)
- [x] 실 저장소 200커밋을 `layoutGraph`에 투입한 재현 검증: 수정 전 `lane>0` 180/200 → 수정 후 2/200(실제 병렬 브랜치), 누락됐던 빈 커밋 복원 확인
- [x] 필터 경로 재현: 96건 부분집합에서 `lane>0` 0건, `activeLaneCount` 1, gap 41곳이 상하 대칭 점선
- [x] Changelog fragment `.changelog.d/pr-404.md` — 그룹 문법(`### fleet-plugin` / `#### Fixed`), 영문·한글 요약 인접, `node scripts/compile-changelog-fragments.mjs --check` 통과
