### PR TITLE
fix(console): make maritime/carbon surface tokens opaque

### DIFF
--- a/.changelog.d/pr-405.md
+++ b/.changelog.d/pr-405.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Make the maritime and carbon surface tokens opaque so the right-rail "float over Map" panel at the Solid preset and every scrim-backed modal, palette, toast, and floating menu no longer bleed the canvas through in those themes.
+  ko: maritime/carbon 테마의 surface 토큰을 불투명하게 만들어, 해당 테마에서 우측 레일 'Map 위에 띄우기'의 '불투명' 프리셋과 scrim 동반 모달·팔레트·토스트·플로팅 메뉴에 뒤 화면이 비치지 않게 합니다.

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -179,9 +179,12 @@
   --canvas-sea-mid: oklch(7% 0.015 246);
   --canvas-sea-far: oklch(6% 0.012 250);
 
-  --surface-glass: oklch(28% 0.04 248 / 60%);
-  --surface-glass-strong: oklch(32% 0.04 248 / 78%);
-  --surface-pillar: oklch(22% 0.05 248 / 86%);
+  /* surface 토큰은 불투명이 계약이다(instrument와 동일 규칙) — 반투명 glass 토큰은 scrim 동반
+     모달·팝업·플로팅 메뉴에서 뒤 콘텐츠를 비춰 판독성을 해치는 회귀의 뿌리였다.
+     반투명 효과는 호출부가 color-mix(..., transparent)로 명시적으로 소유한다. */
+  --surface-glass: oklch(28% 0.04 248);
+  --surface-glass-strong: oklch(32% 0.04 248);
+  --surface-pillar: oklch(22% 0.05 248);
   --surface-rim: oklch(64% 0.04 248 / 24%);
   --surface-rim-strong: oklch(72% 0.05 248 / 38%);
   --surface-band: var(--ink-deep);
@@ -232,9 +235,10 @@
   --canvas-sea-mid: oklch(8% 0.006 255);
   --canvas-sea-far: oklch(6% 0.005 258);
 
-  --surface-glass: oklch(25% 0.006 252 / 62%);
-  --surface-glass-strong: oklch(29% 0.007 252 / 80%);
-  --surface-pillar: oklch(20% 0.008 252 / 88%);
+  /* surface 불투명 계약 — 위 maritime 블록의 주석과 동일 규칙. */
+  --surface-glass: oklch(25% 0.006 252);
+  --surface-glass-strong: oklch(29% 0.007 252);
+  --surface-pillar: oklch(20% 0.008 252);
   --surface-rim: oklch(62% 0.006 252 / 22%);
   --surface-rim-strong: oklch(70% 0.007 252 / 36%);
   --surface-band: var(--ink-deep);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -844,6 +844,13 @@ describe("Instrument core design contract", () => {
       for (const declaration of declarations) {
         expect(declaration.trim()).toMatch(/^--(?:ink|brass|aurora|coral|warn|positive|canvas|surface|hairline|text|id)[a-z-]*:$/);
       }
+      // Surface 불투명 계약: maritime/carbon의 surface-glass/-strong/pillar는 알파를 갖지 않는다.
+      // 반투명 surface 토큰은 scrim 동반 모달·팝업의 비침 회귀 뿌리였고(instrument는 불투명 별칭),
+      // 반투명 효과는 호출부의 color-mix(..., transparent)만 명시적으로 소유한다.
+      const surfaceDeclarations = block.match(/^\s{2}--surface-(?:glass|glass-strong|pillar):[^;]+;/gm) ?? [];
+      for (const declaration of surfaceDeclarations) {
+        expect(declaration).not.toContain("/");
+      }
     }
     expect(theme).not.toMatch(/body::(?:before|after)/);
   });


### PR DESCRIPTION
## Summary
- maritime/carbon 테마의 `--surface-glass`/`--surface-glass-strong`/`--surface-pillar` 토큰에서 60~88% 알파를 제거해 Instrument와 동일한 "surface는 불투명" 계약으로 통일합니다.
- 우측 레일 'Map 위에 띄우기' + '불투명' 프리셋, What's New 모달, ⌘K 팔레트, 토스트, 드롭다운/컨텍스트 메뉴 등 glass 소비 표면 전체가 호출부 수정 없이 불투명화됩니다. 레일 90/75/60 프리셋 감쇠는 `::before` opacity 메커니즘 그대로 유지됩니다.
- design-contract 테스트에 maritime/carbon surface 선언의 알파 재도입을 막는 핀을 추가합니다.

## Test Plan
- [x] `tests/instrument-design-contract.test.ts` 25/25 green (신규 불투명 핀 포함)
- [x] console 전체 vitest — 실패 28건이 canary 선존 baseline(operations-boot-minimization 27 + server MCP 1)과 정확히 일치, 신규 실패 없음
- [x] `pnpm --filter @dotobokuri/fleet-console build` green
- [x] 헤디드 e2e(maritime): surface 토큰 computed 무알파, What's New 모달/레일 Solid 불투명 확인, 60 프리셋 opacity 0.6 정상
- [ ] `.changelog.d/pr-<번호>.md` — PR 번호 부여 후 추가 예정