### PR TITLE
fix(console): close the Analyst artifacts panel on EXIT

### DIFF
--- a/.changelog.d/pr-406.md
+++ b/.changelog.d/pr-406.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] EXIT on the Session Analyst handle now closes the artifacts panel together with the chat panel, instead of leaving the artifacts panel on screen with no control able to dismiss it.
+  ko: Session Analyst 핸들의 EXIT가 Chat 패널과 함께 아티팩트 패널도 닫습니다. 아티팩트 패널만 화면에 남아 닫을 수단이 사라지는 일이 없어집니다.

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-panel.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-panel.test.tsx
@@ -61,7 +61,7 @@ describe("Session Analyst contract", () => {
     expect(chat).toContain('export const ANALYST_ARTIFACTS_COMPANION_ID = "session-analyst-artifacts";');
     expect(source.match(/hideCaption: true/g)).toHaveLength(3);
     expect(source.match(/defaultHidden: true/g)).toHaveLength(3);
-    expect(source).toContain("toggleCompanionPanel(context, ANALYST_CHAT_COMPANION_ID)");
+    expect(source).toContain("toggleCompanionPanel(context, ANALYST_CHAT_COMPANION_ID, ANALYST_COMPANION_IDS)");
     expect(source).toContain("toggleCompanionPanel(context, CARRIER_STREAMS_COMPANION_ID)");
     expect(source).toContain("previousCompanionsOpenRef");
     // dispose 경합에서 orphan store를 만들지 않도록 re-arm은 조회 전용 API만 사용한다.

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -67,6 +67,7 @@ const FONT_META_KEYS = {
 const ANALYSIS_READY_POLL_MS = 5_000;
 export const CARRIER_STREAMS_COMPANION_ID = "carrier-streams";
 const ANALYST_CHAT_COMPANION_ID = "session-analyst-chat";
+const ANALYST_COMPANION_IDS = [ANALYST_CHAT_COMPANION_ID, ANALYST_ARTIFACTS_COMPANION_ID] as const;
 const AGENT_COMPANION_IDS = [CARRIER_STREAMS_COMPANION_ID, ANALYST_CHAT_COMPANION_ID, ANALYST_ARTIFACTS_COMPANION_ID] as const;
 type AnalysisReadiness = "unknown" | "ready" | "not-ready";
 
@@ -287,7 +288,11 @@ function isCompanionPanelVisible(context: OperationRenderContext, companionId: s
   return Boolean(context.companionsOpen) && !(context.hiddenCompanionPanelIds ?? []).includes(companionId);
 }
 
-function toggleCompanionPanel(context: OperationRenderContext, companionId: string): void {
+function toggleCompanionPanel(
+  context: OperationRenderContext,
+  companionId: string,
+  clusterIds: readonly string[] = [companionId],
+): void {
   if (!context.onSetCompanionPanelVisible) {
     context.onRequestCompanions?.(!context.companionsOpen);
     return;
@@ -299,9 +304,12 @@ function toggleCompanionPanel(context: OperationRenderContext, companionId: stri
     context.onSetCompanionPanelVisible(companionId, true);
     return;
   }
-  context.onSetCompanionPanelVisible(companionId, false);
-  const visibleCount = AGENT_COMPANION_IDS.filter((id) => isCompanionPanelVisible(context, id)).length;
-  if (visibleCount <= 1) context.onRequestCompanions?.(false);
+  // Artifacts는 Chat 안의 chip으로만 여닫히므로 Chat만 닫으면 닫을 수단이 사라진다.
+  for (const id of clusterIds) context.onSetCompanionPanelVisible(id, false);
+  const remainingVisibleCount = AGENT_COMPANION_IDS
+    .filter((id) => !clusterIds.includes(id) && isCompanionPanelVisible(context, id))
+    .length;
+  if (remainingVisibleCount === 0) context.onRequestCompanions?.(false);
 }
 
 function SessionAnalystHandle({
@@ -325,7 +333,7 @@ function SessionAnalystHandle({
       aria-disabled={!ready}
       disabled={!ready}
       title={ready ? undefined : t("terminal.analyst.sendMessageFirst")}
-      onClick={() => { if (ready) toggleCompanionPanel(context, ANALYST_CHAT_COMPANION_ID); }}
+      onClick={() => { if (ready) toggleCompanionPanel(context, ANALYST_CHAT_COMPANION_ID, ANALYST_COMPANION_IDS); }}
     >
       {working ? <span className="session-analyst-handle__live" aria-hidden="true" /> : null}
       <span className="session-analyst-handle__chev" aria-hidden="true">{open ? "«" : "»"}</span>

--- a/runtime/fleet-plugins/terminal/tests/carrier-streams-companion.test.tsx
+++ b/runtime/fleet-plugins/terminal/tests/carrier-streams-companion.test.tsx
@@ -406,6 +406,38 @@ describe("Carrier Streams companion", () => {
     expect(container?.querySelector('[aria-label="Exit Session Analyst"]')).not.toBeNull();
   });
 
+  it.each([
+    { streamsVisible: false, expectedCompanionsClosed: true },
+    { streamsVisible: true, expectedCompanionsClosed: false },
+  ])("closes the Analyst cluster on EXIT while preserving visible Carrier Streams ($streamsVisible)", async ({
+    streamsVisible,
+    expectedCompanionsClosed,
+  }) => {
+    installSession([]);
+    const onRequestCompanions = vi.fn();
+    const onSetCompanionPanelVisible = vi.fn();
+    await renderOperation(createContext({
+      api: createApi(true),
+      companionsOpen: true,
+      hiddenCompanionPanelIds: streamsVisible ? [] : ["carrier-streams"],
+      onRequestCompanions,
+      onSetCompanionPanelVisible,
+    }));
+    await vi.waitFor(() => {
+      expect(container?.querySelector<HTMLButtonElement>('[aria-label="Exit Session Analyst"]')?.disabled).toBe(false);
+    });
+
+    act(() => container?.querySelector<HTMLButtonElement>('[aria-label="Exit Session Analyst"]')?.click());
+
+    expect(onSetCompanionPanelVisible).toHaveBeenCalledWith("session-analyst-chat", false);
+    expect(onSetCompanionPanelVisible).toHaveBeenCalledWith("session-analyst-artifacts", false);
+    if (expectedCompanionsClosed) {
+      expect(onRequestCompanions).toHaveBeenCalledWith(false);
+    } else {
+      expect(onRequestCompanions).not.toHaveBeenCalled();
+    }
+  });
+
   it("localizes STREAMS handle and panel copy for Korean without changing English defaults", async () => {
     installSession([]);
     await renderOperation(createContext({


### PR DESCRIPTION
## Summary

- Session Analyst의 ANALYZE 핸들에서 EXIT를 누르면 Chat 패널만 닫히고 아티팩트 컴패니언이 화면에 남던 결함을 고칩니다. EXIT는 이제 Analyst 클러스터(Chat + Artifacts)를 한 단위로 닫습니다.
- 아티팩트 패널은 Chat 패널 내부의 칩으로만 여닫히고 호스트 `CompanionFrame`은 닫기 컨트롤을 렌더하지 않기 때문에, Chat이 먼저 닫히면 남은 아티팩트 패널을 닫을 수단이 사라졌습니다. 사용자는 아티팩트를 먼저 닫고 EXIT를 누르는 순서를 강제당했습니다.
- 컴패니언 레이아웃 종료 판정도 stale한 `visibleCount <= 1` 휴리스틱에서 "닫는 클러스터를 제외한 잔여 가시 패널 0" 판정으로 교체했습니다. 여는 경로와 Carrier Streams 핸들 동작은 무변경입니다.
- `analysisReadiness === "not-ready"` 경로가 이미 두 패널을 함께 숨기고 있었으므로, 이 변경은 기존 클러스터 독트린에 EXIT를 정렬시키는 작업입니다.

## Test Plan

- [x] `pnpm --filter @fleet-plugins/terminal test` — 44 files / 399 tests passed
- [x] `pnpm --filter @fleet-plugins/terminal build` (tsc) — passed
- [x] `pnpm --filter @dotobokuri/fleet-console build` — passed
- [x] 계약 테스트 갱신: `analysis-panel.test.tsx`의 `toggleCompanionPanel` 호출 형태 단언
- [x] 회귀 테스트 추가: EXIT가 chat/artifacts 양쪽을 숨기고, Carrier Streams 표시 여부에 따라 컴패니언 레이아웃 종료가 갈리는 2분기
- [x] 실브라우저 실측(격리 콘솔, 실제 Claude Operation + 실제 아티팩트 발행)
  - Chat+아티팩트 열린 상태 → EXIT → 두 패널 동시 폐쇄, 컴패니언 레이아웃 해제
  - EXIT 후 ANALYZE 재오픈 → Chat+아티팩트 함께 복원(종료/복귀 대칭)
  - Streams 포함 3패널 → EXIT → Analyst 클러스터만 폐쇄, Carrier Streams 생존
  - 페이지 오류 0건
- [x] Changelog: `.changelog.d/pr-406.md` 추가 — 그룹형 문법, 영문/한글 요약 인접, `node scripts/compile-changelog-fragments.mjs --check` 통과