### PR TITLE
fix(console): join the sidebar column across the command band seam

### DIFF
--- a/.changelog.d/pr-407.md
+++ b/.changelog.d/pr-407.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Join the expanded Theater sidebar to the command band block above it, so the shared column no longer stacks two hairlines at the seam and no longer breaks its right edge across a rounded corner.
+  ko: 펼친 Theater 사이드바를 바로 위 커맨드 밴드 블록과 이어 붙여, 같은 열 이음매에 가로선이 두 겹으로 깔리거나 우측 경계선이 둥근 모서리에서 끊기지 않게 합니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2287,6 +2287,15 @@
   transition: width 200ms ease, border-color 200ms ease, visibility 0s linear 0s;
 }
 
+/* 펼친 상태에서는 상단 크롬 좌측 블록(.command-band-left)이 같은 폭·표면·우측 경계선으로
+   이 열의 상단 캡이 된다 — 부유 카드의 상단 테두리와 안쪽 라운드를 거기서 다시 그리면
+   한 열 한가운데에 이중 hairline이 깔리고 우측 경계선이 코너만큼 끊긴다.
+   접으면 상단 캡이 밴드 표면으로 물러나므로(.command-band-left.is-collapsed) 카드 문법을 유지한다. */
+.operations-side-bar.is-expanded {
+  border-top: none;
+  border-top-right-radius: 0;
+}
+
 .operations-side-bar[data-resizing="true"] {
   transition: none;
 }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2290,8 +2290,10 @@
 /* 펼친 상태에서는 상단 크롬 좌측 블록(.command-band-left)이 같은 폭·표면·우측 경계선으로
    이 열의 상단 캡이 된다 — 부유 카드의 상단 테두리와 안쪽 라운드를 거기서 다시 그리면
    한 열 한가운데에 이중 hairline이 깔리고 우측 경계선이 코너만큼 끊긴다.
-   접으면 상단 캡이 밴드 표면으로 물러나므로(.command-band-left.is-collapsed) 카드 문법을 유지한다. */
-.operations-side-bar.is-expanded {
+   접으면 상단 캡이 밴드 표면으로 물러나므로(.command-band-left.is-collapsed) 카드 문법을 유지한다.
+   풀스크린은 밴드가 fixed로 흐름에서 빠져 자동 은닉되므로 캡이 아예 없다 — 그때는 사이드바가
+   뷰포트 최상단에 그대로 닿으니 카드 마감을 되살려야 한다. 그래서 캡이 실재하는 상태로 한정한다. */
+.console-shell:has(.command-band:not(.is-fullscreen)) .operations-side-bar.is-expanded {
   border-top: none;
   border-top-right-radius: 0;
 }

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -720,10 +720,15 @@ describe("Instrument core design contract", () => {
     const commandBandLeftBlock = layout.match(/\.command-band-left \{[^}]*\}/)?.[0] ?? "";
     expect(commandBandLeftBlock).toContain("border-right: 1px solid var(--surface-rim);");
     expect(commandBandLeftBlock).toContain("background: var(--surface-glass);");
-    const expandedSideBarBlock = components.match(/\.operations-side-bar\.is-expanded \{[^}]*\}/)?.[0] ?? "";
+    // 캡이 실재하는 상태로 한정한다 — 풀스크린은 밴드가 fixed로 흐름에서 빠져 자동 은닉되므로
+    // 캡이 없고, 사이드바가 뷰포트 최상단에 닿는다. 무조건 해제하면 그 화면에서 마감이 사라진다.
+    const expandedSideBarBlock =
+      components.match(/\.console-shell:has\(\.command-band:not\(\.is-fullscreen\)\) \.operations-side-bar\.is-expanded \{[^}]*\}/)?.[0] ?? "";
     expect(expandedSideBarBlock).toContain("border-top: none;");
     expect(expandedSideBarBlock).toContain("border-top-right-radius: 0;");
-    // 접으면 상단 캡이 밴드 표면으로 물러나므로 부유 카드 문법이 그대로 남는다.
+    expect(components).not.toMatch(/^\.operations-side-bar\.is-expanded \{/m);
+    expect(layout).toContain(".command-band.is-fullscreen {");
+    // 접거나 풀스크린이면 상단 캡이 없으므로 부유 카드 문법이 그대로 남는다.
     expect(components).toContain("border-radius: 0 var(--radius-xl) 0 0;");
     expect(layout).toContain(".command-band-left.is-collapsed {");
     expect(components).not.toContain(".float-handle");

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -714,6 +714,18 @@ describe("Instrument core design contract", () => {
     expect(layout).toContain("@media (prefers-reduced-motion: reduce)");
     expect(layout).toContain(".command-band-left {");
     expect(components).toContain(".operations-side-bar.is-closed");
+    // 상단 크롬 좌측 블록은 사이드바와 같은 폭·표면·우측 경계선으로 그 열의 상단 캡이 된다.
+    // 그래서 펼침 상태에서만 카드의 상단 테두리·안쪽 라운드를 해제한다 — 세 규칙이 함께 살아
+    // 있어야 한 열 한가운데의 이중 hairline과 우측 경계선 단절이 재발하지 않는다.
+    const commandBandLeftBlock = layout.match(/\.command-band-left \{[^}]*\}/)?.[0] ?? "";
+    expect(commandBandLeftBlock).toContain("border-right: 1px solid var(--surface-rim);");
+    expect(commandBandLeftBlock).toContain("background: var(--surface-glass);");
+    const expandedSideBarBlock = components.match(/\.operations-side-bar\.is-expanded \{[^}]*\}/)?.[0] ?? "";
+    expect(expandedSideBarBlock).toContain("border-top: none;");
+    expect(expandedSideBarBlock).toContain("border-top-right-radius: 0;");
+    // 접으면 상단 캡이 밴드 표면으로 물러나므로 부유 카드 문법이 그대로 남는다.
+    expect(components).toContain("border-radius: 0 var(--radius-xl) 0 0;");
+    expect(layout).toContain(".command-band-left.is-collapsed {");
     expect(components).not.toContain(".float-handle");
     expect(components).not.toContain("focus-mode-reveal");
     expect(rail).toContain(".right-rail.is-closed");


### PR DESCRIPTION
## Summary

- 상단 크롬 좌측 블록 `.command-band-left`는 Theater 사이드바와 같은 폭·표면 토큰(`--surface-glass`)·우측 1px 경계선을 공유해 그 열의 상단 캡으로 읽히도록 설계돼 있는데, 바로 아래 `.operations-side-bar`가 부유 카드 문법(상단 1px 테두리 + 우상단 10px 라운드)을 다시 적용해 두 문법이 한 열에서 충돌했습니다.
- 그 결과 이음매에서 같은 색 가로선이 2px 이중으로 깔리고(y=43 밴드 하단선 + y=44 사이드바 상단선), 우측 세로 경계선이 코너 아크만큼(y=44~49) 끊겨 두 판이 어긋나 포개진 것처럼 보였습니다.
- 펼침 상태(`.operations-side-bar.is-expanded`)에서만 카드의 상단 테두리와 안쪽 라운드를 해제해 열을 잇습니다. 접으면 상단 캡이 밴드 표면으로 물러나므로(`.command-band-left.is-collapsed`) 부유 카드 문법은 그대로 유지됩니다.
- 서로 맞물린 세 규칙이 따로 표류하지 않도록 `instrument-design-contract`에 이음매 계약을 고정했습니다.

## 실측 (헤디드, macOS 데스크톱 셸 속성 재현)

| 측정 | 수정 전 | 수정 후 |
|---|---|---|
| 가로 hairline (x=100) | y=43·44 2px 실선 | y=43 1px |
| 세로 경계선 (x=279) | y=44~49 단절 후 곡선 복귀 | y=38~51 연속 |
| 접힘 상태 | — | `border-top: 1px`, `border-radius: 0 10px 0 0` 유지 |

우측 레일은 상단에 대응하는 세로 경계선이 없어(`.command-band-right` 배경 투명·무테두리) 같은 결함이 없습니다. 변경은 좌측 열에 한정됩니다.

결함을 만든 `9c2f92952`(#391)는 v1.34.0에 포함되어 이미 릴리스된 동작이므로 `Fixed` 항목으로 기록합니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/instrument-design-contract.test.ts` — 25/25 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 성공
- [x] 격리 콘솔 헤디드 실측: 펼침/접힘 양방향 픽셀 프로파일 대조
- [x] Changelog: `.changelog.d/pr-407.md` 추가 — 제품/섹션 그룹 문법, 영문/한글 요약 인접, `node scripts/compile-changelog-fragments.mjs --check` 통과(10건 검증)