### PR TITLE
fix(console): activate panels from portaled operation bodies

### DIFF
--- a/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/operation-frame.tsx
@@ -60,6 +60,7 @@ const CLOSE_ARM_DURATION_MS = 1500;
 export function OperationFrame({ operation, active, unseen, geometry, zoom, status, minimized = false, maximized = false, renderHidden = false, focusLayerTarget = false, topEdge = false, interactionDisabled = false, triageStage = false, triagePicked = false, formationSlotIndex, accentKey = null, children, onActivate, onClose, onMinimize, onMaximize, onRename, onSetAccent, onGeometryChange, onGeometryCommit, onRenderHiddenFocus }: OperationFrameProps) {
   const t = useT();
   const operationRef = useRef<HTMLElement | null>(null);
+  const terminalRef = useRef<HTMLDivElement | null>(null);
   const identityTriggerRef = useRef<HTMLButtonElement | null>(null);
   const dragRef = useRef<DragState | null>(null);
   const resizeRef = useRef<ResizeState | null>(null);
@@ -105,6 +106,21 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
     const frame = window.requestAnimationFrame(() => identityTriggerRef.current?.focus());
     return () => window.cancelAnimationFrame(frame);
   }, [rename.renaming]);
+
+  // Operation 본체는 body pool에서 createPortal로 렌더된 뒤 DOM만 이 슬롯으로 이식된다. React 합성
+  // 이벤트는 DOM 트리가 아니라 React 트리를 따라 전파하므로 아래 onPointerDown(stopOperationPointer)은
+  // 본체 클릭에서는 영원히 호출되지 않는다 — 본체가 화면 대부분인 Formation에서는 선택이 통째로 죽는다.
+  // 네이티브 리스너는 DOM 버블링을 타므로 이식된 본체 클릭까지 닿는다. 전파를 끊으면 React root의 위임
+  // 리스너까지 막히므로 여기서는 활성화만 하고, 직접 자식 경로를 소유한 React 핸들러는 그대로 둔다.
+  useEffect(() => {
+    const terminal = terminalRef.current;
+    if (!terminal) return;
+    const activate = () => {
+      onActivate();
+    };
+    terminal.addEventListener("pointerdown", activate);
+    return () => terminal.removeEventListener("pointerdown", activate);
+  }, [onActivate]);
 
   // focus layer가 현재 포커스를 담은 peer를 숨길 때는 body로 흘려보내지 않고 새 전면 frame(없으면 Canvas)으로 옮긴다.
   useLayoutEffect(() => {
@@ -417,7 +433,7 @@ export function OperationFrame({ operation, active, unseen, geometry, zoom, stat
         </div>
       </div>
       <div className="canvas-operation-glance-hud" aria-hidden="true">{displayTitle}</div>
-      <div className="canvas-operation-terminal" onPointerDown={stopOperationPointer} onWheel={stopOperationWheel} data-canvas-blocker>
+      <div ref={terminalRef} className="canvas-operation-terminal" onPointerDown={stopOperationPointer} onWheel={stopOperationWheel} data-canvas-blocker>
         {children}
       </div>
       {/* 최대화 상태에서는 리사이즈가 차단되므로 핸들 자체를 렌더하지 않는다 —

--- a/runtime/fleet-console/tests/operation-frame-body-activation.test.ts
+++ b/runtime/fleet-console/tests/operation-frame-body-activation.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { act, createElement, Fragment, useLayoutEffect, useMemo } from "react";
+import { createPortal } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OperationFrame } from "../core/client/src/canvas/operation-frame.js";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("OperationFrame body activation", () => {
+  it("activates from pointerdown in a portaled body moved into the terminal slot", () => {
+    const onActivate = vi.fn();
+
+    act(() => root!.render(createElement(Fragment, null,
+      createElement(OperationFrame, {
+        operation: {
+          id: "operation-body-activation",
+          theaterId: "theater-body-activation",
+          type: "shell",
+          pluginId: "terminal",
+          title: "Portaled Operation",
+          payload: {},
+          geometry: null,
+          ts: { createdAt: 1, updatedAt: 1 },
+        },
+        active: false,
+        unseen: false,
+        interactionDisabled: true,
+        geometry: { x: 0, y: 0, width: 320, height: 200, zIndex: 1 },
+        zoom: 1,
+        onActivate,
+        onClose: () => {},
+        onMinimize: () => {},
+        onRename: () => {},
+        onGeometryChange: () => {},
+        onGeometryCommit: () => {},
+        children: null,
+      }),
+      createElement(PortaledOperationBody),
+    )));
+
+    const body = document.querySelector<HTMLElement>("[data-test-operation-body]");
+    expect(body?.closest(".canvas-operation-terminal")).not.toBeNull();
+
+    act(() => body!.dispatchEvent(new Event("pointerdown", { bubbles: true, cancelable: true })));
+
+    expect(onActivate).toHaveBeenCalledTimes(1);
+  });
+});
+
+function PortaledOperationBody() {
+  const mountNode = useMemo(() => document.createElement("div"), []);
+
+  useLayoutEffect(() => {
+    const slot = document.querySelector(".canvas-operation-terminal");
+    if (!slot) throw new Error("Missing Operation terminal slot");
+    slot.appendChild(mountNode);
+    return () => mountNode.remove();
+  }, [mountNode]);
+
+  return createPortal(createElement("div", { "data-test-operation-body": true }), mountNode);
+}


### PR DESCRIPTION
## Summary

- 캔버스 패널의 **본문(터미널 영역)을 클릭해도 패널이 선택되지 않던 회귀**를 수정합니다. Operation 본체는 body pool에서 `createPortal`로 렌더된 뒤 DOM만 슬롯으로 이식되는데, React 합성 이벤트는 DOM 트리가 아니라 React 트리를 따르므로 `.canvas-operation-terminal`에 걸린 `onPointerDown`(→ `onActivate`)이 본문 클릭에서는 호출되지 않았습니다.
- 해당 슬롯에 네이티브 `pointerdown` 리스너를 추가해 활성화 경로를 복구했습니다. 전파는 끊지 않아 React root 위임 리스너와 기존 React 핸들러는 그대로 동작합니다.
- 회귀 유입은 #402(모바일 뷰 본체 풀 리프트)입니다. `operation-frame.tsx`의 핸들러 자체는 그대로였고, 발밑의 트리 구조가 바뀌며 죽었습니다. Formation View는 타일 대부분이 본문이라 선택이 전혀 되지 않는 것으로 체감됐습니다.

## Test Plan

- [x] 신규 회귀 테스트 `operation-frame-body-activation.test.ts` — 포털로 슬롯에 이식된 본체의 `pointerdown`이 `onActivate`를 호출하는 계약 고정. 수정을 되돌리면 실패함을 확인
- [x] canvas / triage / formation 관련 vitest 66건 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` 통과
- [x] 헤드리스 실측 전후 대조 — 맵 뷰 본문 클릭: 선택 변화 없음 → 정상 전환 / Formation 본문 클릭: 전환 실패 → 양방향 전환. 페이지 에러 0건
- [x] 수정 빌드를 격리 콘솔에 올려 수동 확인 완료
- [x] Changelog: `no-changelog`. 회귀를 유입시킨 #402가 아직 미릴리스(`.changelog.d/pr-402.md` 잔존, v1.34.0 이후 릴리스 커밋 없음)이므로 사용자에게 도달한 적 없는 결함입니다. 독립 Fixed 항목을 만들지 않습니다.