### PR TITLE
feat(console): scope Triage queue to unseen idle arrivals

### DIFF
--- a/.changelog.d/pr-403.md
+++ b/.changelog.d/pr-403.md
@@ -1,4 +1,4 @@
 ### fleet-console
 #### Changed
-- [fleet-console] An Operation that just went idle without being opened now signals it on every surface: the sidebar shows the unseen mark under any sort order, and a panel sitting on the Map takes a green rim with an outer glow. Focusing the Operation clears the signal everywhere at once, and the focus highlight always wins over it.
-  ko: 방금 유휴로 전이됐지만 아직 열지 않은 Operation을 모든 표면에서 알립니다. 사이드바는 정렬 방식과 무관하게 미확인 표시를 보여주고, Map에 떠 있는 패널은 초록 테두리와 외곽 글로우를 얻습니다. 해당 Operation에 포커스하면 모든 표면에서 한 번에 해제되며, 포커스 강조가 항상 우선합니다.
+- [fleet-console] An Operation that just went idle without being opened now signals it on every surface: the sidebar shows the unseen mark under any sort order and files it with the awaiting group when sorted by status, and a panel sitting on the Map takes a green rim with an outer glow. Focusing the Operation clears the signal everywhere at once, and the focus highlight always wins over it. While Triage mode is on the signal survives focus, so the panel you are working on cannot drop out of the queue.
+  ko: 방금 유휴로 전이됐지만 아직 열지 않은 Operation을 모든 표면에서 알립니다. 사이드바는 정렬 방식과 무관하게 미확인 표시를 보여주고 상태별 정렬에서는 대기 구획에 함께 묶으며, Map에 떠 있는 패널은 초록 테두리와 외곽 글로우를 얻습니다. 해당 Operation에 포커스하면 모든 표면에서 한 번에 해제되며, 포커스 강조가 항상 우선합니다. 선별 처리 모드가 켜져 있는 동안에는 포커스로 해제되지 않아 작업 중인 패널이 대기열에서 빠지지 않습니다.

--- a/.changelog.d/pr-409.md
+++ b/.changelog.d/pr-409.md
@@ -1,7 +1,7 @@
 ### fleet-console
 #### Added
-- [fleet-console] Add Triage mode, which stows every panel and brings up one waiting Operation at a time on a maximized stage with a queue rail, sidebar ordering, Alt+T toggle and Alt+Right defer.
-  ko: 모든 패널을 접고 답을 기다리는 Operation을 한 번에 하나씩 최대화해 세우는 선별 처리 모드를 추가합니다. 대기 레일과 사이드바 대기열 정렬, Alt+T 토글, Alt+Right 미루기를 제공합니다.
+- [fleet-console] Add Triage mode, which stows every panel and brings up one waiting Operation at a time on a maximized stage, with a queue rail, Alt+T toggle and Alt+Right defer. An Operation waits when it is awaiting input or has just returned to idle without being seen, and the sidebar shows that queue through its own status sort rather than a separate mode-only list.
+  ko: 모든 패널을 접고 답을 기다리는 Operation을 한 번에 하나씩 최대화해 세우는 선별 처리 모드를 추가합니다. 대기 레일과 Alt+T 토글, Alt+Right 미루기를 제공합니다. 여기서 대기란 입력을 기다리는 중이거나 방금 유휴로 돌아왔는데 아직 확인하지 않은 상태를 뜻하며, 사이드바는 모드 전용 목록 대신 기존 상태별 정렬로 그 대기열을 보여줍니다.
 - [fleet-console] Add guided feature tours that introduce a new capability at its entry point and walk through it once, remembering what has been seen.
   ko: 새 기능을 진입점에서 소개하고 사용법을 한 번 안내하는 기능 투어를 추가하며, 이미 본 안내는 다시 표시하지 않습니다.
 

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -12,7 +12,7 @@ import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { useGlobalSettingsStore } from "../global-settings-store.js";
 import { useT } from "../i18n/index.js";
-import { getIdleUnseenIds, subscribeIdleUnseen } from "../sidebar/operations-side-bar-store.js";
+import { getIdleArrivalIds, subscribeIdleArrival } from "../operation-idle-arrival.js";
 import { resolveOperationActivity } from "../operation-activity.js";
 import type { ConsoleState, OperationNode } from "../types.js";
 import { resolveConsoleLanguage } from "../whatsnew-i18n.js";
@@ -96,7 +96,7 @@ export function OperationsCanvas({
   const companionPanelVisibilityOverrides = useCompanionPanelVisibilityOverrides(companionOperationId);
   const lastValidCompanionRef = useRef<{ readonly operation: OperationNode; readonly descriptor: OperationKindDescriptor } | null>(null);
   const minimized = useMinimized();
-  const idleUnseenIds = useSyncExternalStore(subscribeIdleUnseen, getIdleUnseenIds, getIdleUnseenIds);
+  const idleArrivalIds = useSyncExternalStore(subscribeIdleArrival, getIdleArrivalIds, getIdleArrivalIds);
   const activePluginOperationId = state.activeOperationId;
   const [contextMenu, setContextMenu] = useState<ContextMenuRequest | null>(null);
   const registry = usePluginRegistry();
@@ -227,6 +227,10 @@ export function OperationsCanvas({
   const triageQueue = state.activeTheaterId
     ? resolveTriageQueue(state.activeTheaterId, theaterOperations, state.operationStatus)
     : [];
+  const triageQueueIdSet = new Set(triageQueue.map((entry) => entry.operation.id));
+  const triageIdleCount = theaterOperations.filter((operation) =>
+    resolveOperationActivity(operation, state.operationStatus) === "idle"
+    && !triageQueueIdSet.has(operation.id)).length;
   const automaticTriageStage = triageQueue[0] ?? null;
   const previousTriageStageId = previousTriageStageRef.current;
   const previousTriageStageOperation = previousTriageStageId
@@ -304,7 +308,7 @@ export function OperationsCanvas({
         && activeElement.closest(".canvas-operation")
         && activeElement.matches("input, textarea, [contenteditable='true']")
         && !activeElement.closest(".xterm")) return;
-      setActiveOperation(triageStageId);
+      setActiveOperation(triageStageId, { acknowledged: false });
       requestOperationKeyboardFocus(triageStageId);
     });
     return () => window.cancelAnimationFrame(frame);
@@ -564,7 +568,7 @@ export function OperationsCanvas({
             && canvas.viewport.y + frameGeometry.y * effectiveZoom < TITLEBAR_OUTSET_PX * effectiveZoom;
           return renderPluginOperation(operation, {
             active: activePluginOperationId === operation.id,
-            unseen: idleUnseenIds.has(operation.id),
+            unseen: idleArrivalIds.has(operation.id),
             keyboardFocusRequestId: state.keyboardFocusRequest?.operationId === operation.id
               ? state.keyboardFocusRequest.requestId
               : 0,
@@ -704,7 +708,7 @@ export function OperationsCanvas({
           ) : null}
         </>
       ) : null}
-      <TriageClearPlate active={triageActive} entering={triageEntering} hasContent={hasContent} />
+      <TriageClearPlate active={triageActive} entering={triageEntering} hasContent={hasContent} idleCount={triageIdleCount} />
       {!triageActive && !hasContent && !formationEntering ? (
         <OperationsCanvasEmptyState
           activeTheaterId={state.activeTheaterId}

--- a/runtime/fleet-console/core/client/src/canvas/triage-clear-plate.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-clear-plate.tsx
@@ -4,16 +4,19 @@ interface TriageClearPlateProps {
   readonly active: boolean;
   readonly entering: boolean;
   readonly hasContent: boolean;
+  readonly idleCount: number;
 }
 
-export function TriageClearPlate({ active, entering, hasContent }: TriageClearPlateProps) {
+export function TriageClearPlate({ active, entering, hasContent, idleCount }: TriageClearPlateProps) {
   const t = useT();
   if (!active || entering || hasContent) return null;
   return (
     <div className="canvas-triage-clear" data-canvas-blocker>
       <span>{t("canvas.triage.clearMark")}</span>
       <strong>{t("canvas.triage.clearTitle")}</strong>
-      <p>{t("canvas.triage.clearBody")}</p>
+      <p>{idleCount > 0
+        ? t("canvas.triage.clearBodyIdle", { count: idleCount })
+        : t("canvas.triage.clearBody")}</p>
     </div>
   );
 }

--- a/runtime/fleet-console/core/client/src/canvas/triage-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/triage-store.ts
@@ -99,9 +99,9 @@ export function setTriageActive(theaterId: string, active: boolean): void {
     if (activeOperationId !== null && !activeOperationAcknowledged) {
       setActiveOperation(activeOperationId);
     }
+    setSideBarStatusAxis(previousStatusAxis);
   }
   setTheaterFocusLayerSnapshot(theaterId, restoredFocusLayer);
-  setSideBarStatusAxis(previousStatusAxis);
   emitTriage();
 }
 

--- a/runtime/fleet-console/core/client/src/canvas/triage-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/triage-store.ts
@@ -2,8 +2,9 @@ import { useSyncExternalStore } from "react";
 
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
 
+import { clearIdleArrival, getIdleArrivalIds, setIdleArrivalAcknowledgementSuspended } from "../operation-idle-arrival.js";
 import { resolveOperationActivity } from "../operation-activity.js";
-import { registerSideBarStatusAxisActivationGuard, setSideBarStatusAxis } from "../sidebar/operations-side-bar-store.js";
+import { getSideBarStatusAxis, setSideBarStatusAxis } from "../sidebar/operations-side-bar-store.js";
 import type { OperationNode } from "../types.js";
 import {
   clearFormationView,
@@ -42,15 +43,13 @@ const dismissed = new Set<string>();
 const seenAt = new Map<string, number>();
 
 const activityByOperation = new Map<string, OperationActivity>();
-const liveActivityObserved = new Set<string>();
 const operationTheater = new Map<string, string>();
 const focusLayerBeforeTriage = new Map<string, FocusLayerState | null>();
+const statusAxisBeforeTriage = new Map<string, boolean>();
 const listeners = new Set<Listener>();
 let revision = 0;
 
 registerBeforeFormationViewActivation((theaterId) => setTriageActive(theaterId, false));
-registerSideBarStatusAxisActivationGuard(() => !isTriageActive(getLoadedTheaterId()));
-
 export function isTriageActive(theaterId: string | null): boolean {
   return theaterId !== null && triageByTheater.has(theaterId);
 }
@@ -58,19 +57,25 @@ export function isTriageActive(theaterId: string | null): boolean {
 export function setTriageActive(theaterId: string, active: boolean): void {
   if (active) {
     clearFormationView(theaterId);
-    setSideBarStatusAxis(false);
     if (!triageByTheater.has(theaterId)) {
       focusLayerBeforeTriage.set(theaterId, getTheaterFocusLayerSnapshot(theaterId));
+      statusAxisBeforeTriage.set(theaterId, getSideBarStatusAxis());
       triageByTheater.set(theaterId, true);
       clearedByTheater.set(theaterId, 0);
       enteredAtByTheater.set(theaterId, Date.now());
     }
+    setSideBarStatusAxis(true);
+    setIdleArrivalAcknowledgementSuspended(triageByTheater.size > 0);
     setTheaterFocusLayerSnapshot(theaterId, null);
     emitTriage();
     return;
   }
-  if (!triageByTheater.has(theaterId)) return;
+  if (!triageByTheater.has(theaterId)) {
+    setIdleArrivalAcknowledgementSuspended(triageByTheater.size > 0);
+    return;
+  }
   const previousFocusLayer = focusLayerBeforeTriage.get(theaterId) ?? null;
+  const previousStatusAxis = statusAxisBeforeTriage.get(theaterId) ?? false;
   const canvas = getTheaterCanvasSnapshot(theaterId);
   const restoredFocusLayer = previousFocusLayer
     && canvas.operations[previousFocusLayer.operationId]
@@ -85,8 +90,11 @@ export function setTriageActive(theaterId: string, active: boolean): void {
   clearedByTheater.delete(theaterId);
   enteredAtByTheater.delete(theaterId);
   focusLayerBeforeTriage.delete(theaterId);
+  statusAxisBeforeTriage.delete(theaterId);
   clearTheaterTransientOperations(theaterId);
+  setIdleArrivalAcknowledgementSuspended(triageByTheater.size > 0);
   setTheaterFocusLayerSnapshot(theaterId, restoredFocusLayer);
+  setSideBarStatusAxis(previousStatusAxis);
   emitTriage();
 }
 
@@ -131,6 +139,7 @@ export function dismissTriageOperation(theaterId: string, operationId: string): 
   operationTheater.set(operationId, theaterId);
   deferredAt.delete(operationId);
   dismissed.add(operationId);
+  clearIdleArrival(operationId);
   if (pickedByTheater.get(theaterId) === operationId) pickedByTheater.delete(theaterId);
   emitTriage();
 }
@@ -143,7 +152,9 @@ export function resetTriageTheater(theaterId: string): void {
     clearedByTheater.delete(theaterId);
     enteredAtByTheater.delete(theaterId);
     focusLayerBeforeTriage.delete(theaterId);
+    statusAxisBeforeTriage.delete(theaterId);
     clearTheaterTransientOperations(theaterId);
+    setIdleArrivalAcknowledgementSuspended(triageByTheater.size > 0);
     emitTriage();
   }
 }
@@ -155,7 +166,6 @@ export function forgetTriageOperation(operationId: string): void {
   deferredAt.delete(operationId);
   seenAt.delete(operationId);
   activityByOperation.delete(operationId);
-  liveActivityObserved.delete(operationId);
   operationTheater.delete(operationId);
   if (theaterId && pickedByTheater.get(theaterId) === operationId) {
     pickedByTheater.delete(theaterId);
@@ -219,11 +229,7 @@ export function recordTriageActivity(
     if ((activity === "running" || activity === "dormant") && deferredAt.delete(operation.id)) {
       changed = true;
     }
-    const liveActivity = Object.prototype.hasOwnProperty.call(operationStatus, operation.id);
-    const liveActivityChanged = liveActivityObserved.has(operation.id) !== liveActivity;
-    if (liveActivity) liveActivityObserved.add(operation.id);
-    else liveActivityObserved.delete(operation.id);
-    if (activityByOperation.get(operation.id) === activity && !liveActivityChanged) continue;
+    if (activityByOperation.get(operation.id) === activity) continue;
     activityByOperation.set(operation.id, activity);
     seenAt.set(operation.id, now);
     changed = true;
@@ -245,7 +251,7 @@ export function isTriageWaitingOperation(
 ): boolean {
   const activity = resolveOperationActivity(operation, operationStatus);
   return activity === "awaiting"
-    || (activity === "idle" && Object.prototype.hasOwnProperty.call(operationStatus, operation.id));
+    || (activity === "idle" && getIdleArrivalIds().has(operation.id));
 }
 
 export function scheduleTriageClear(
@@ -333,7 +339,6 @@ function clearTheaterTransientOperations(theaterId: string): void {
     deferredAt.delete(operationId);
     seenAt.delete(operationId);
     activityByOperation.delete(operationId);
-    liveActivityObserved.delete(operationId);
     operationTheater.delete(operationId);
   }
 }

--- a/runtime/fleet-console/core/client/src/canvas/triage-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/triage-store.ts
@@ -46,7 +46,7 @@ const seenAt = new Map<string, number>();
 const activityByOperation = new Map<string, OperationActivity>();
 const operationTheater = new Map<string, string>();
 const focusLayerBeforeTriage = new Map<string, FocusLayerState | null>();
-const statusAxisBeforeTriage = new Map<string, boolean>();
+let statusAxisBeforeTriage = false;
 const listeners = new Set<Listener>();
 let revision = 0;
 
@@ -59,8 +59,8 @@ export function setTriageActive(theaterId: string, active: boolean): void {
   if (active) {
     clearFormationView(theaterId);
     if (!triageByTheater.has(theaterId)) {
+      if (triageByTheater.size === 0) statusAxisBeforeTriage = getSideBarStatusAxis();
       focusLayerBeforeTriage.set(theaterId, getTheaterFocusLayerSnapshot(theaterId));
-      statusAxisBeforeTriage.set(theaterId, getSideBarStatusAxis());
       triageByTheater.set(theaterId, true);
       clearedByTheater.set(theaterId, 0);
       enteredAtByTheater.set(theaterId, Date.now());
@@ -76,7 +76,6 @@ export function setTriageActive(theaterId: string, active: boolean): void {
     return;
   }
   const previousFocusLayer = focusLayerBeforeTriage.get(theaterId) ?? null;
-  const previousStatusAxis = statusAxisBeforeTriage.get(theaterId) ?? false;
   const canvas = getTheaterCanvasSnapshot(theaterId);
   const restoredFocusLayer = previousFocusLayer
     && canvas.operations[previousFocusLayer.operationId]
@@ -91,7 +90,6 @@ export function setTriageActive(theaterId: string, active: boolean): void {
   clearedByTheater.delete(theaterId);
   enteredAtByTheater.delete(theaterId);
   focusLayerBeforeTriage.delete(theaterId);
-  statusAxisBeforeTriage.delete(theaterId);
   clearTheaterTransientOperations(theaterId);
   setIdleArrivalAcknowledgementSuspended(triageByTheater.size > 0);
   if (triageByTheater.size === 0) {
@@ -99,7 +97,7 @@ export function setTriageActive(theaterId: string, active: boolean): void {
     if (activeOperationId !== null && !activeOperationAcknowledged) {
       setActiveOperation(activeOperationId);
     }
-    setSideBarStatusAxis(previousStatusAxis);
+    setSideBarStatusAxis(statusAxisBeforeTriage);
   }
   setTheaterFocusLayerSnapshot(theaterId, restoredFocusLayer);
   emitTriage();
@@ -159,7 +157,6 @@ export function resetTriageTheater(theaterId: string): void {
     clearedByTheater.delete(theaterId);
     enteredAtByTheater.delete(theaterId);
     focusLayerBeforeTriage.delete(theaterId);
-    statusAxisBeforeTriage.delete(theaterId);
     clearTheaterTransientOperations(theaterId);
     setIdleArrivalAcknowledgementSuspended(triageByTheater.size > 0);
     emitTriage();

--- a/runtime/fleet-console/core/client/src/canvas/triage-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/triage-store.ts
@@ -5,6 +5,7 @@ import type { OperationActivity } from "@fleet-console/sdk/plugin";
 import { clearIdleArrival, getIdleArrivalIds, setIdleArrivalAcknowledgementSuspended } from "../operation-idle-arrival.js";
 import { resolveOperationActivity } from "../operation-activity.js";
 import { getSideBarStatusAxis, setSideBarStatusAxis } from "../sidebar/operations-side-bar-store.js";
+import { getState, setActiveOperation } from "../store.js";
 import type { OperationNode } from "../types.js";
 import {
   clearFormationView,
@@ -93,6 +94,12 @@ export function setTriageActive(theaterId: string, active: boolean): void {
   statusAxisBeforeTriage.delete(theaterId);
   clearTheaterTransientOperations(theaterId);
   setIdleArrivalAcknowledgementSuspended(triageByTheater.size > 0);
+  if (triageByTheater.size === 0) {
+    const { activeOperationId, activeOperationAcknowledged } = getState();
+    if (activeOperationId !== null && !activeOperationAcknowledged) {
+      setActiveOperation(activeOperationId);
+    }
+  }
   setTheaterFocusLayerSnapshot(theaterId, restoredFocusLayer);
   setSideBarStatusAxis(previousStatusAxis);
   emitTriage();

--- a/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
@@ -25,6 +25,7 @@ export const canvasEn = {
   "canvas.triage.clearMark": "All clear",
   "canvas.triage.clearTitle": "Nothing is waiting on you",
   "canvas.triage.clearBody": "Panels return here when an agent needs an answer. Stowed panels go back to their coordinates when you turn the mode off.",
+  "canvas.triage.clearBodyIdle": "Nothing is waiting on you. {count} idle panels sit in the left list. Click one to bring it up.",
   "canvas.formation.curtainKicker": "FORMATION VIEW",
   "canvas.formation.curtainTitle": "Full board",
   "canvas.formation.curtainBody": "Arranging {count} Operations on the grid.",
@@ -100,8 +101,6 @@ export const canvasEn = {
   "sidebar.status.collapse": "Collapse",
   "sidebar.status.sectionOperations": "{label} operations",
   "sidebar.status.noOperations": "No operations",
-  "sidebar.triage.queueSection": "Queue",
-  "sidebar.triage.restSection": "Not waiting",
 
   "sidebar.list.aria": "Theaters and operations",
   "sidebar.theater.operationsAria": "{theater} operations",
@@ -245,6 +244,7 @@ export const canvasKo: Record<keyof typeof canvasEn, string> = {
   "canvas.triage.clearMark": "모두 정리됨",
   "canvas.triage.clearTitle": "기다리는 작업이 없습니다",
   "canvas.triage.clearBody": "에이전트가 답을 요청하면 이 자리에 다시 올라옵니다. 접힌 패널은 모드를 끄면 원래 좌표로 돌아갑니다.",
+  "canvas.triage.clearBodyIdle": "기다리는 작업은 없습니다. 유휴 상태인 {count}개는 왼쪽 목록에 있습니다. 눌러서 올릴 수 있습니다.",
   "canvas.formation.curtainKicker": "FORMATION VIEW",
   "canvas.formation.curtainTitle": "전체 조망",
   "canvas.formation.curtainBody": "{count}개 Operation을 격자에 정렬합니다.",
@@ -319,8 +319,6 @@ export const canvasKo: Record<keyof typeof canvasEn, string> = {
   "sidebar.status.collapse": "접기",
   "sidebar.status.sectionOperations": "{label} Operation",
   "sidebar.status.noOperations": "Operation 없음",
-  "sidebar.triage.queueSection": "처리 대기",
-  "sidebar.triage.restSection": "대기 아님",
 
   "sidebar.list.aria": "Theater와 Operation",
   "sidebar.theater.operationsAria": "{theater} Operation",

--- a/runtime/fleet-console/core/client/src/operation-idle-arrival.ts
+++ b/runtime/fleet-console/core/client/src/operation-idle-arrival.ts
@@ -10,9 +10,10 @@ export function markIdleArrival(id: string): void {
   for (const listener of listeners) listener();
 }
 
-export function acknowledgeIdleArrival(id: string): void {
-  if (acknowledgementSuspended) return;
+export function acknowledgeIdleArrival(id: string): boolean {
+  if (acknowledgementSuspended) return false;
   clearIdleArrival(id);
+  return true;
 }
 
 export function setIdleArrivalAcknowledgementSuspended(suspended: boolean): void {

--- a/runtime/fleet-console/core/client/src/operation-idle-arrival.ts
+++ b/runtime/fleet-console/core/client/src/operation-idle-arrival.ts
@@ -1,0 +1,43 @@
+const listeners = new Set<() => void>();
+
+let idleArrivalIds = new Set<string>();
+let acknowledgementSuspended = false;
+
+export function markIdleArrival(id: string): void {
+  if (idleArrivalIds.has(id)) return;
+  idleArrivalIds = new Set(idleArrivalIds);
+  idleArrivalIds.add(id);
+  for (const listener of listeners) listener();
+}
+
+export function acknowledgeIdleArrival(id: string): void {
+  if (acknowledgementSuspended) return;
+  clearIdleArrival(id);
+}
+
+export function setIdleArrivalAcknowledgementSuspended(suspended: boolean): void {
+  acknowledgementSuspended = suspended;
+}
+
+export function clearIdleArrival(id: string): void {
+  if (!idleArrivalIds.has(id)) return;
+  idleArrivalIds = new Set(idleArrivalIds);
+  idleArrivalIds.delete(id);
+  for (const listener of listeners) listener();
+}
+
+export function getIdleArrivalIds(): ReadonlySet<string> {
+  return idleArrivalIds;
+}
+
+export function subscribeIdleArrival(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function resetIdleArrivalForTests(): void {
+  idleArrivalIds = new Set();
+  acknowledgementSuspended = false;
+}

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -29,9 +29,6 @@ interface SideBarChipProps {
   readonly statusAxis?: boolean;
   readonly idleUnseen?: boolean;
   readonly statusLanded?: boolean;
-  readonly triageOrder?: number;
-  readonly triageStage?: boolean;
-  readonly triageMode?: boolean;
   readonly reorderEnabled?: boolean;
   readonly dragging: boolean;
   readonly dragOffsetY: number;
@@ -63,9 +60,6 @@ export function OperationsSideBarChip({
   statusAxis = false,
   idleUnseen = false,
   statusLanded = false,
-  triageOrder,
-  triageStage = false,
-  triageMode = false,
   reorderEnabled = true,
   dragging,
   dragOffsetY,
@@ -100,7 +94,6 @@ export function OperationsSideBarChip({
     statusLanded ? "side-bar-chip--status-landed" : "",
     dragging ? "side-bar-chip--dragging" : "",
     dropTarget ? "side-bar-chip--drop-target" : "",
-    triageStage ? "is-triage-stage" : "",
   ].filter(Boolean).join(" ");
   const closeClassName = ["side-bar-chip-close", isCloseArmed ? "is-armed" : ""].filter(Boolean).join(" ");
   const chipStyle = {
@@ -153,12 +146,11 @@ export function OperationsSideBarChip({
       onOpenAccent(operation.id, chip.getBoundingClientRect(), chip, request.action);
       return true;
     }
-    if (triageMode) return false;
     onDisarmClose();
     onMinimize(operation.id);
     chip.focus();
     return true;
-  }), [onDisarmClose, onMinimize, onOpenAccent, operation.id, preview, rename, triageMode]);
+  }), [onDisarmClose, onMinimize, onOpenAccent, operation.id, preview, rename]);
 
   return (
     <li
@@ -225,7 +217,6 @@ export function OperationsSideBarChip({
       {notificationCount > 0 ? (
         <span className="side-bar-chip-count">{notificationCount}</span>
       ) : null}
-      {triageOrder !== undefined ? <span className="side-bar-chip-triage-order">{triageOrder}</span> : null}
       {groupMark && statusAxis && !preview ? (
         <span
           className="side-bar-chip-group-pill"
@@ -258,7 +249,7 @@ export function OperationsSideBarChip({
           title={chipStatusLabel(status)}
         />
       ) : null}
-      {!preview && !minimized && !triageMode ? (
+      {!preview && !minimized ? (
         <button
           type="button"
           className="side-bar-chip-minimize"

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-store.ts
@@ -2,6 +2,7 @@ import { useCallback, useSyncExternalStore } from "react";
 
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
 
+import { clearIdleArrival, markIdleArrival, resetIdleArrivalForTests } from "../operation-idle-arrival.js";
 import { resolveOperationActivity } from "../operation-activity.js";
 import { getState, subscribe } from "../store.js";
 import type { OperationNode } from "../types.js";
@@ -21,7 +22,6 @@ const sideBarListeners = new Set<() => void>();
 const collapsedTheaterListeners = new Set<() => void>();
 const statusAxisListeners = new Set<() => void>();
 const statusSectionCollapseListeners = new Set<() => void>();
-const idleUnseenListeners = new Set<() => void>();
 
 let sideBarState: SideBarState = {
   width: readInitialWidth(),
@@ -37,11 +37,9 @@ let userCollapsedStatusSections = new Set<string>();
 let userExpandedStatusSections = new Set<string>();
 let statusTransitionCounter = 0;
 let statusTransitionTicks = new Map<string, number>();
-let idleUnseenIds = new Set<string>();
 let previousActivityById = new Map<string, SideBarStatus>();
 let baselinedLiveActivityIds = new Set<string>();
 let pendingStatusLandingIds = new Set<string>();
-let canActivateStatusAxis: () => boolean = () => true;
 
 export type SideBarStatus = "awaiting" | "running" | "idle" | "dormant";
 
@@ -102,14 +100,9 @@ export function setTheaterCollapsed(theaterId: string, collapsed: boolean): void
 }
 
 export function setSideBarStatusAxis(active: boolean): void {
-  if (active && !canActivateStatusAxis()) return;
   if (statusAxis === active) return;
   statusAxis = active;
   for (const listener of statusAxisListeners) listener();
-}
-
-export function registerSideBarStatusAxisActivationGuard(guard: () => boolean): void {
-  canActivateStatusAxis = guard;
 }
 
 export function toggleSideBarStatusAxis(): void {
@@ -167,38 +160,12 @@ export function getStatusTransitionTick(id: string): number | undefined {
   return statusTransitionTicks.get(id);
 }
 
-export function markIdleUnseen(id: string): void {
-  if (idleUnseenIds.has(id)) return;
-  idleUnseenIds = new Set(idleUnseenIds);
-  idleUnseenIds.add(id);
-  for (const listener of idleUnseenListeners) listener();
-}
-
-export function clearIdleUnseen(id: string): void {
-  if (!idleUnseenIds.has(id)) return;
-  idleUnseenIds = new Set(idleUnseenIds);
-  idleUnseenIds.delete(id);
-  for (const listener of idleUnseenListeners) listener();
-}
-
-// Operation-scope 상태가 역사적 이유로 사이드바 스토어에 산다. 세 번째 비-사이드바
-// 소비자가 생기면 중립 activity 모듈로 승격하라.
-export function getIdleUnseenIds(): ReadonlySet<string> {
-  return idleUnseenIds;
-}
-
-export function subscribeIdleUnseen(listener: () => void): () => void {
-  idleUnseenListeners.add(listener);
-  return () => {
-    idleUnseenListeners.delete(listener);
-  };
-}
-
 export function trackOperationActivityTransitions(input: {
   readonly operations: readonly OperationNode[];
   readonly operationStatus: Readonly<Record<string, OperationActivity>>;
   readonly activeTheaterId: string | null;
   readonly activeOperationId: string | null;
+  readonly activeOperationAcknowledged: boolean;
 }): readonly string[] {
   const nextStatuses = new Map<string, SideBarStatus>(
     input.operations.map((operation) => [
@@ -229,17 +196,13 @@ export function trackOperationActivityTransitions(input: {
   for (const operation of input.operations) {
     if (!movedIds.includes(operation.id)) continue;
     if (nextStatuses.get(operation.id) === "idle") {
-      if (!(operation.id === input.activeOperationId && operation.theaterId === input.activeTheaterId)) {
-        markIdleUnseen(operation.id);
+      if (!(operation.id === input.activeOperationId
+        && operation.theaterId === input.activeTheaterId
+        && input.activeOperationAcknowledged === true)) {
+        markIdleArrival(operation.id);
       }
     } else {
-      clearIdleUnseen(operation.id);
-    }
-  }
-  if (input.activeOperationId !== null) {
-    const activeOp = input.operations.find((operation) => operation.id === input.activeOperationId);
-    if (activeOp !== undefined && activeOp.theaterId === input.activeTheaterId) {
-      clearIdleUnseen(input.activeOperationId);
+      clearIdleArrival(operation.id);
     }
   }
   previousActivityById = nextStatuses;
@@ -260,6 +223,7 @@ export function subscribeOperationActivityTracking(): () => void {
       operationStatus: state.operationStatus,
       activeTheaterId: state.activeTheaterId,
       activeOperationId: state.activeOperationId,
+      activeOperationAcknowledged: state.activeOperationAcknowledged,
     });
   });
 }
@@ -272,7 +236,7 @@ export function resetSideBarStatusSectionCollapseForTests(): void {
 export function resetSideBarStatusRecencyForTests(): void {
   statusTransitionCounter = 0;
   statusTransitionTicks = new Map();
-  idleUnseenIds = new Set();
+  resetIdleArrivalForTests();
   previousActivityById = new Map();
   baselinedLiveActivityIds = new Set();
   pendingStatusLandingIds = new Set();

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -6,6 +6,7 @@ import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
 
 import { getT, useT, type CoreMessageKey } from "../i18n/index.js";
+import { getIdleArrivalIds, subscribeIdleArrival } from "../operation-idle-arrival.js";
 import type { OperationGroup, OperationNode, OperationNotification, TheaterInfo } from "../types.js";
 import { CanvasContextMenu } from "../canvas/canvas-context-menu.js";
 import { focusCommandBandToggleWhenPanelContainsActiveElement } from "../components/command-band-focus.js";
@@ -14,7 +15,6 @@ import { useConsoleState } from "../hooks/use-store.js";
 import { GroupContextMenu } from "../canvas/group-context-menu.js";
 import { operationAccentFromNode, resolveAccentColor } from "../canvas/operation-accent.js";
 import { getTheaterCanvasSnapshot, setOperationOrder, toggleGroupCollapsed, toggleTheaterGroupCollapsed, useCanvasState, useCollapsedGroups } from "../canvas/canvas-store.js";
-import { getTriageSnapshot, isTriageActive, resolveTriageQueue, subscribeTriage } from "../canvas/triage-store.js";
 import { consumeOperationLaunchMenu, consumeSideBarAddTheater, consumeSideBarTheaterLaunch, sortOperationsByOrder } from "../store.js";
 import { resolveOperationActivity } from "../operation-activity.js";
 import { SideBarBrandFoot } from "../components/side-bar-brand-foot.js";
@@ -28,7 +28,6 @@ import { OperationsSideBarChip, type SideBarEntry } from "./operations-side-bar-
 import { OperationsSideBarGroupHeader } from "./operations-side-bar-group-header.js";
 import {
   consumeStatusLandings,
-  getIdleUnseenIds,
   setSideBarCollapsed,
   setSideBarWidth,
   setTheaterCollapsed,
@@ -172,10 +171,6 @@ interface TheaterInactiveSectionProps {
   readonly statusActionsOpen: boolean;
   readonly showStatusLiveTick: boolean;
   readonly statusLandingIds: ReadonlySet<string>;
-  readonly triageOrderByOperation: ReadonlyMap<string, number>;
-  readonly triageStageIds: ReadonlySet<string>;
-  readonly triageActive: boolean;
-  readonly triageQueueIds: readonly string[];
   readonly dragging: boolean;
   readonly dropBefore: boolean;
   readonly dropAfter: boolean;
@@ -207,12 +202,6 @@ const STATUS_LANDING_DURATION_MS = 500;
 
 interface StatusSection {
   readonly status: SideBarStatus;
-  readonly label: string;
-  readonly entries: readonly SideBarEntry[];
-}
-
-interface TriageSection {
-  readonly key: "queue" | "rest";
   readonly label: string;
   readonly entries: readonly SideBarEntry[];
 }
@@ -269,33 +258,6 @@ function StatusSectionSlot({
           {empty ? <li className="side-bar-status-empty-hint">{t("sidebar.status.noOperations")}</li> : children}
         </ol>
       ) : null}
-    </li>
-  );
-}
-
-function TriageSectionSlot({
-  section,
-  children,
-}: {
-  readonly section: TriageSection;
-  readonly children: ReactNode;
-}) {
-  const statusClass = section.key === "queue" ? "awaiting" : "dormant";
-  return (
-    <li className={[
-      "side-bar-status-section",
-      `side-bar-status-section--${statusClass}`,
-      `side-bar-status-section--triage-${section.key}`,
-      section.entries.length === 0 ? "side-bar-status-section--empty" : "",
-    ].filter(Boolean).join(" ")}>
-      <div className={`side-bar-status-header side-bar-status-header--${statusClass} side-bar-status-header--triage-${section.key}`}>
-        <span className="side-bar-status-header__dot" aria-hidden="true" />
-        <span className="side-bar-status-header__label">{section.label}</span>
-        <span className="side-bar-status-header__count">{section.entries.length}</span>
-      </div>
-      <ol className="side-bar-group-chips" aria-label={section.label}>
-        {children}
-      </ol>
     </li>
   );
 }
@@ -372,18 +334,14 @@ export function OperationsSideBar({
   const [sideBarResizing, setSideBarResizing] = useState(false);
   const collapsedGroups = useCollapsedGroups();
   const collapsedTheaters = useCollapsedTheaters();
-  const { operationStatus, pendingSideBarAddTheater, pendingSideBarTheaterLaunch, launchMenuRequest } = useConsoleState();
-  useSyncExternalStore(subscribeTriage, getTriageSnapshot, getTriageSnapshot);
-  const triageOrderByOperation = new Map<string, number>();
-  const triageStageIds = new Set<string>();
-  const triageQueueIdsByTheater = new Map<string, readonly string[]>();
-  for (const theater of theaters) {
-    if (!isTriageActive(theater.id)) continue;
-    const queue = resolveTriageQueue(theater.id, operations, operationStatus);
-    triageQueueIdsByTheater.set(theater.id, queue.map((entry) => entry.operation.id));
-    queue.forEach((entry, index) => triageOrderByOperation.set(entry.operation.id, index + 1));
-    if (queue[0]) triageStageIds.add(queue[0].operation.id);
-  }
+  const {
+    operationStatus,
+    activeOperationAcknowledged,
+    pendingSideBarAddTheater,
+    pendingSideBarTheaterLaunch,
+    launchMenuRequest,
+  } = useConsoleState();
+  useSyncExternalStore(subscribeIdleArrival, getIdleArrivalIds, getIdleArrivalIds);
 
   useLayoutEffect(() => {
     if (!previousCollapsedRef.current && collapsed) focusCommandBandToggleWhenPanelContainsActiveElement(rootRef.current, ".command-band-sidebar-toggle");
@@ -406,11 +364,9 @@ export function OperationsSideBar({
       icon,
     };
   });
-  const triageAxisActive = isTriageActive(activeTheaterId);
-  const triageSections = buildTriageSections(allEntries, triageQueueIdsByTheater.get(activeTheaterId ?? "") ?? [], t);
   const groupedSections = groupOperations(allEntries, activeGroups, canvas.operationOrder);
   const statusSections = groupOperationsByStatus(allEntries, getStatusTransitionTick, t);
-  const idleUnseenIds = getIdleUnseenIds();
+  const idleUnseenIds = getIdleArrivalIds();
   const isIdleUnseen = (id: string) => id !== activeOperationId && idleUnseenIds.has(id);
   // STATUS 축 렌더는 entry/그룹 조회가 칩마다 반복되므로 O(n²)를 피해 Map으로 한 번만 인덱싱한다.
   const entryIndexById = new Map(allEntries.map((entry, index) => [entry.operation.id, index] as const));
@@ -465,7 +421,6 @@ export function OperationsSideBar({
       return false;
     }
     // 상태축에서는 그룹 접힘이 배치에 영향을 주지 않는다 — 여기서 펼치면 사용자의 그룹축 설정만 조용히 바뀐다.
-    if (triageAxisActive) return false;
     if (statusAxis) {
       const status = resolveOperationActivity(operation, operationStatus);
       if (getSideBarStatusSectionCollapsed(operation.theaterId, status, false)) {
@@ -478,7 +433,7 @@ export function OperationsSideBar({
       return false;
     }
     return false;
-  }), [activeTheaterId, collapsed, collapsedGroupSet, collapsedTheaters, operationStatus, operations, statusAxis, triageAxisActive]);
+  }), [activeTheaterId, collapsed, collapsedGroupSet, collapsedTheaters, operationStatus, operations, statusAxis]);
 
   useEffect(() => {
     if (armedCloseId === null) return;
@@ -494,6 +449,7 @@ export function OperationsSideBar({
       operationStatus,
       activeTheaterId,
       activeOperationId,
+      activeOperationAcknowledged,
     });
     const landedIds = consumeStatusLandings();
     if (!didMountStatusLandingRef.current) {
@@ -524,7 +480,7 @@ export function OperationsSideBar({
     statusLandingTimeoutsRef.current.add(timeoutId);
   // statusSignature is the stable primitive dependency for the operation/status map assembled above.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [statusAxis, statusSignature, activeTheaterId, activeOperationId]);
+  }, [statusAxis, statusSignature, activeTheaterId, activeOperationId, activeOperationAcknowledged]);
 
   useEffect(() => () => {
     for (const timeoutId of statusLandingTimeoutsRef.current) window.clearTimeout(timeoutId);
@@ -559,7 +515,7 @@ export function OperationsSideBar({
     : null;
 
   const keyboardMove = (operationId: string, direction: -1 | 1) => {
-    if (statusAxis || triageAxisActive) return;
+    if (statusAxis) return;
     const index = visibleEntries.findIndex((e) => e.operation.id === operationId);
     if (index === -1) return;
     const targetIndex = Math.max(0, Math.min(visibleEntries.length - 1, index + direction));
@@ -596,8 +552,8 @@ export function OperationsSideBar({
   };
 
   useEffect(() => {
-    if ((statusAxis || triageAxisActive) && dragRef.current?.kind === "chip") updateDrag(null);
-  }, [statusAxis, triageAxisActive]);
+    if (statusAxis && dragRef.current?.kind === "chip") updateDrag(null);
+  }, [statusAxis]);
 
   // drag 시작(pointerId가 생김)에만 window 리스너 3개를 등록하고, drag 종료 시 정확히 3개 해제한다.
   const dragPointerId = drag?.pointerId ?? null;
@@ -687,7 +643,7 @@ export function OperationsSideBar({
   }, [dragPointerId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const beginPointerDrag = (event: ReactPointerEvent<HTMLLIElement>, operationId: string) => {
-    if (statusAxis || triageAxisActive) return;
+    if (statusAxis) return;
     if (event.button !== 0) return;
     if (event.target instanceof Element && event.target.closest("button")) return;
     setActiveContextMenu(null);
@@ -894,8 +850,7 @@ export function OperationsSideBar({
         {theaters.map((theater, theaterIndex) => {
           const isActiveTheater = theater.id === activeTheaterId;
           const theaterOperations = operations.filter((operation) => operation.theaterId === theater.id);
-          const theaterTriageActive = isTriageActive(theater.id);
-          const showStatusLiveTick = !statusAxis && !theaterTriageActive && hasAwaitingOperation(theaterOperations, operationStatus);
+          const showStatusLiveTick = !statusAxis && hasAwaitingOperation(theaterOperations, operationStatus);
           const statusActionsOpen = activeContextMenu?.kind === "theater" && activeContextMenu.theaterId === theater.id;
           const theaterCollapsed = collapsedTheaters.includes(theater.id);
           const isTheaterDragging = drag?.kind === "theater" && drag.sourceTheaterId === theater.id && drag.dragging;
@@ -936,10 +891,6 @@ export function OperationsSideBar({
                 statusActionsOpen={statusActionsOpen}
                 showStatusLiveTick={showStatusLiveTick}
                 statusLandingIds={statusLandingIds}
-                triageOrderByOperation={triageOrderByOperation}
-                triageStageIds={triageStageIds}
-                triageActive={theaterTriageActive}
-                triageQueueIds={triageQueueIdsByTheater.get(theater.id) ?? []}
                 dragging={isTheaterDragging}
                 dropBefore={theaterDropBefore}
                 dropAfter={theaterDropAfter}
@@ -997,50 +948,12 @@ export function OperationsSideBar({
               />
               {!theaterCollapsed ? (
               <ol className="side-bar-theater-groups" aria-label={t("sidebar.theater.operationsAria", { theater: theater.label })}>
-                {triageAxisActive ? triageSections.map((section) => (
-                  <TriageSectionSlot key={section.key} section={section}>
-                    {section.entries.map((entry) => {
-                      const globalIndex = entryIndexById.get(entry.operation.id) ?? 0;
-                      const accentKey = canvas.operationAccent[entry.operation.id] ?? operationAccentFromNode(entry.operation);
-                      const accentValue = accentKey ? resolveAccentColor(accentKey) : null;
-                      return (
-                        <OperationsSideBarChip
-                          key={entry.operation.id}
-                          entry={entry}
-                          index={globalIndex}
-                          isCloseArmed={armedCloseId === entry.operation.id}
-                          accentValue={accentValue}
-                          idleUnseen={isIdleUnseen(entry.operation.id)}
-                          triageOrder={triageOrderByOperation.get(entry.operation.id)}
-                          triageStage={triageStageIds.has(entry.operation.id)}
-                          triageMode
-                          reorderEnabled={false}
-                          dragging={false}
-                          dragOffsetY={0}
-                          dropTarget={false}
-                          onArmClose={armClose}
-                          onDisarmClose={disarmClose}
-                          onClose={onClose}
-                          onMinimize={onMinimize}
-                          onFocus={onFocus}
-                          onKeyboardMove={keyboardMove}
-                          onPointerDragStart={beginPointerDrag}
-                          onOpenAccent={(operationId, anchor, returnFocus, requestedAction) => {
-                            setActiveContextMenu({ kind: "chip", operationId, anchor, returnFocus, requestedAction });
-                          }}
-                          onRename={onRename}
-                        />
-                      );
-                    })}
-                  </TriageSectionSlot>
-                )) : statusAxis ? statusSections.map((section) => (
+                {statusAxis ? statusSections.map((section) => (
                   <StatusSectionSlot
                     key={section.status}
                     theaterId={theater.id}
                     section={section}
-                    unseenCount={section.status === "idle"
-                      ? section.entries.filter((entry) => isIdleUnseen(entry.operation.id)).length
-                      : undefined}
+                    unseenCount={section.entries.filter((entry) => isIdleUnseen(entry.operation.id)).length}
                   >
                     {section.entries.map((entry) => {
                       const globalIndex = entryIndexById.get(entry.operation.id) ?? 0;
@@ -1058,8 +971,6 @@ export function OperationsSideBar({
                           statusAxis
                           idleUnseen={isIdleUnseen(entry.operation.id)}
                           statusLanded={statusLandingIds.has(entry.operation.id)}
-                          triageOrder={triageOrderByOperation.get(entry.operation.id)}
-                          triageStage={triageStageIds.has(entry.operation.id)}
                           reorderEnabled={false}
                           dragging={false}
                           dragOffsetY={0}
@@ -1144,8 +1055,6 @@ export function OperationsSideBar({
                         isCloseArmed={armedCloseId === entry.operation.id}
                         accentValue={accentValue}
                         idleUnseen={isIdleUnseen(entry.operation.id)}
-                        triageOrder={triageOrderByOperation.get(entry.operation.id)}
-                        triageStage={triageStageIds.has(entry.operation.id)}
                         dragging={drag?.kind === "chip" && drag.sourceId === entry.operation.id && drag.dragging}
                         dragOffsetY={drag?.kind === "chip" && drag.sourceId === entry.operation.id && drag.dragging ? drag.currentY - drag.startY : 0}
                         dropTarget={
@@ -1297,13 +1206,20 @@ export function groupOperationsByStatus(
   getTick?: (id: string) => number | undefined,
   t: Translate<CoreMessageKey> = getT("en"),
 ): StatusSection[] {
+  const idleArrivalIds = getIdleArrivalIds();
   return buildStatusSectionOrder(t).map(({ status, label }) => ({
     status,
     label,
     // entry.status는 엔트리 생성 시점에 resolveOperationActivity로 이미 해소된다.
     // 미해소(undefined) 엔트리의 idle 폭백은 직접 구성된 입력에 대한 방어 계약이다.
     entries: entries
-      .filter((entry) => (entry.status ?? "idle") === status)
+      .filter((entry) => {
+        const entryStatus = entry.status ?? "idle";
+        const idleArrival = entryStatus === "idle" && idleArrivalIds.has(entry.operation.id);
+        if (status === "awaiting") return entryStatus === "awaiting" || idleArrival;
+        if (status === "idle") return entryStatus === "idle" && !idleArrival;
+        return entryStatus === status;
+      })
       .sort((left, right) => {
         const leftTick = getTick?.(left.operation.id);
         const rightTick = getTick?.(right.operation.id);
@@ -1315,35 +1231,14 @@ export function groupOperationsByStatus(
   }));
 }
 
-export function buildTriageSections(
-  entries: readonly SideBarEntry[],
-  queueIds: readonly string[],
-  t: Translate<CoreMessageKey> = getT("en"),
-): TriageSection[] {
-  const entryById = new Map(entries.map((entry) => [entry.operation.id, entry] as const));
-  const queueEntries = queueIds
-    .map((operationId) => entryById.get(operationId))
-    .filter((entry): entry is SideBarEntry => entry !== undefined);
-  const queueIdSet = new Set(queueIds);
-  return [
-    {
-      key: "queue",
-      label: t("sidebar.triage.queueSection"),
-      entries: queueEntries,
-    },
-    {
-      key: "rest",
-      label: t("sidebar.triage.restSection"),
-      entries: entries.filter((entry) => !queueIdSet.has(entry.operation.id)),
-    },
-  ];
-}
-
 export function hasAwaitingOperation(
   operations: readonly OperationNode[],
   operationStatus: Readonly<Record<string, OperationActivity>>,
 ): boolean {
-  return operations.some((operation) => operationStatus[operation.id] === "awaiting");
+  const idleArrivalIds = getIdleArrivalIds();
+  return operations.some((operation) =>
+    operationStatus[operation.id] === "awaiting"
+    || (resolveOperationActivity(operation, operationStatus) === "idle" && idleArrivalIds.has(operation.id)));
 }
 
 function resolveEntryGroupMark(
@@ -1535,10 +1430,6 @@ function TheaterInactiveSection({
   statusActionsOpen,
   showStatusLiveTick,
   statusLandingIds,
-  triageOrderByOperation,
-  triageStageIds,
-  triageActive,
-  triageQueueIds,
   dragging,
   dropBefore,
   dropAfter,
@@ -1555,8 +1446,7 @@ function TheaterInactiveSection({
   const t = useT();
   const sections = groupOperations(entries, groups, []);
   const statusSections = groupOperationsByStatus(entries, getStatusTransitionTick, t);
-  const triageSections = buildTriageSections(entries, triageQueueIds, t);
-  const idleUnseenIds = getIdleUnseenIds();
+  const idleUnseenIds = getIdleArrivalIds();
   const hasCustomGroups = sections.some((section) => section.group !== null);
   return (
     <li
@@ -1585,50 +1475,14 @@ function TheaterInactiveSection({
         onContextMenu={onContextMenu}
         onPointerDragStart={onPointerDragStart}
       />
-      {!collapsed && (triageActive ? triageSections.length : statusAxis ? statusSections.length : sections.length) > 0 ? (
+      {!collapsed && (statusAxis ? statusSections.length : sections.length) > 0 ? (
         <ol className="side-bar-theater-groups" aria-label={t("sidebar.theater.operationsAria", { theater: theater.label })}>
-          {triageActive ? triageSections.map((section) => (
-            <TriageSectionSlot key={section.key} section={section}>
-              {section.entries.map((entry, index) => {
-                const accentKey = operationAccent[entry.operation.id] ?? operationAccentFromNode(entry.operation);
-                const accentValue = accentKey ? resolveAccentColor(accentKey) : null;
-                return (
-                  <OperationsSideBarChip
-                    key={entry.operation.id}
-                    entry={entry}
-                    index={index}
-                    isCloseArmed={false}
-                    accentValue={accentValue}
-                    idleUnseen={idleUnseenIds.has(entry.operation.id)}
-                    triageOrder={triageOrderByOperation.get(entry.operation.id)}
-                    triageStage={triageStageIds.has(entry.operation.id)}
-                    triageMode
-                    reorderEnabled={false}
-                    dragging={false}
-                    dragOffsetY={0}
-                    dropTarget={false}
-                    preview
-                    onArmClose={() => {}}
-                    onDisarmClose={() => {}}
-                    onClose={() => {}}
-                    onMinimize={() => {}}
-                    onFocus={onFocus}
-                    onKeyboardMove={() => {}}
-                    onPointerDragStart={() => {}}
-                    onOpenAccent={() => {}}
-                    onRename={() => {}}
-                  />
-                );
-              })}
-            </TriageSectionSlot>
-          )) : statusAxis ? statusSections.map((section) => (
+          {statusAxis ? statusSections.map((section) => (
             <StatusSectionSlot
               key={section.status}
               theaterId={theater.id}
               section={section}
-              unseenCount={section.status === "idle"
-                ? section.entries.filter((entry) => idleUnseenIds.has(entry.operation.id)).length
-                : undefined}
+              unseenCount={section.entries.filter((entry) => idleUnseenIds.has(entry.operation.id)).length}
             >
               {section.entries.map((entry, index) => {
                 const accentKey = operationAccent[entry.operation.id] ?? operationAccentFromNode(entry.operation);
@@ -1644,8 +1498,6 @@ function TheaterInactiveSection({
                     statusAxis
                     idleUnseen={idleUnseenIds.has(entry.operation.id)}
                     statusLanded={statusLandingIds.has(entry.operation.id)}
-                    triageOrder={triageOrderByOperation.get(entry.operation.id)}
-                    triageStage={triageStageIds.has(entry.operation.id)}
                     reorderEnabled={false}
                     dragging={false}
                     dragOffsetY={0}
@@ -1703,8 +1555,6 @@ function TheaterInactiveSection({
                           isCloseArmed={false}
                           accentValue={accentValue}
                           idleUnseen={idleUnseenIds.has(entry.operation.id)}
-                          triageOrder={triageOrderByOperation.get(entry.operation.id)}
-                          triageStage={triageStageIds.has(entry.operation.id)}
                           dragging={false}
                           dragOffsetY={0}
                           dropTarget={false}

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -341,7 +341,7 @@ export function OperationsSideBar({
     pendingSideBarTheaterLaunch,
     launchMenuRequest,
   } = useConsoleState();
-  useSyncExternalStore(subscribeIdleArrival, getIdleArrivalIds, getIdleArrivalIds);
+  const idleArrivalIds = useSyncExternalStore(subscribeIdleArrival, getIdleArrivalIds, getIdleArrivalIds);
 
   useLayoutEffect(() => {
     if (!previousCollapsedRef.current && collapsed) focusCommandBandToggleWhenPanelContainsActiveElement(rootRef.current, ".command-band-sidebar-toggle");
@@ -366,7 +366,7 @@ export function OperationsSideBar({
   });
   const groupedSections = groupOperations(allEntries, activeGroups, canvas.operationOrder);
   const statusSections = groupOperationsByStatus(allEntries, getStatusTransitionTick, t);
-  const idleUnseenIds = getIdleArrivalIds();
+  const idleUnseenIds = idleArrivalIds;
   const isIdleUnseen = (id: string) => id !== activeOperationId && idleUnseenIds.has(id);
   // STATUS 축 렌더는 entry/그룹 조회가 칩마다 반복되므로 O(n²)를 피해 Map으로 한 번만 인덱싱한다.
   const entryIndexById = new Map(allEntries.map((entry, index) => [entry.operation.id, index] as const));
@@ -422,7 +422,11 @@ export function OperationsSideBar({
     }
     // 상태축에서는 그룹 접힘이 배치에 영향을 주지 않는다 — 여기서 펼치면 사용자의 그룹축 설정만 조용히 바뀐다.
     if (statusAxis) {
-      const status = resolveOperationActivity(operation, operationStatus);
+      const status = resolveSideBarStatusSection(
+        resolveOperationActivity(operation, operationStatus),
+        operation.id,
+        idleArrivalIds,
+      );
       if (getSideBarStatusSectionCollapsed(operation.theaterId, status, false)) {
         toggleSideBarStatusSectionCollapsed(operation.theaterId, status, false);
       }
@@ -433,7 +437,7 @@ export function OperationsSideBar({
       return false;
     }
     return false;
-  }), [activeTheaterId, collapsed, collapsedGroupSet, collapsedTheaters, operationStatus, operations, statusAxis]);
+  }), [activeTheaterId, collapsed, collapsedGroupSet, collapsedTheaters, idleArrivalIds, operationStatus, operations, statusAxis]);
 
   useEffect(() => {
     if (armedCloseId === null) return;
@@ -1213,13 +1217,8 @@ export function groupOperationsByStatus(
     // entry.status는 엔트리 생성 시점에 resolveOperationActivity로 이미 해소된다.
     // 미해소(undefined) 엔트리의 idle 폭백은 직접 구성된 입력에 대한 방어 계약이다.
     entries: entries
-      .filter((entry) => {
-        const entryStatus = entry.status ?? "idle";
-        const idleArrival = entryStatus === "idle" && idleArrivalIds.has(entry.operation.id);
-        if (status === "awaiting") return entryStatus === "awaiting" || idleArrival;
-        if (status === "idle") return entryStatus === "idle" && !idleArrival;
-        return entryStatus === status;
-      })
+      .filter((entry) =>
+        resolveSideBarStatusSection(entry.status ?? "idle", entry.operation.id, idleArrivalIds) === status)
       .sort((left, right) => {
         const leftTick = getTick?.(left.operation.id);
         const rightTick = getTick?.(right.operation.id);
@@ -1231,14 +1230,25 @@ export function groupOperationsByStatus(
   }));
 }
 
+export function resolveSideBarStatusSection(
+  entryStatus: SideBarStatus,
+  operationId: string,
+  idleArrivalIds: ReadonlySet<string>,
+): SideBarStatus {
+  return entryStatus === "idle" && idleArrivalIds.has(operationId) ? "awaiting" : entryStatus;
+}
+
 export function hasAwaitingOperation(
   operations: readonly OperationNode[],
   operationStatus: Readonly<Record<string, OperationActivity>>,
 ): boolean {
   const idleArrivalIds = getIdleArrivalIds();
   return operations.some((operation) =>
-    operationStatus[operation.id] === "awaiting"
-    || (resolveOperationActivity(operation, operationStatus) === "idle" && idleArrivalIds.has(operation.id)));
+    resolveSideBarStatusSection(
+      resolveOperationActivity(operation, operationStatus),
+      operation.id,
+      idleArrivalIds,
+    ) === "awaiting");
 }
 
 function resolveEntryGroupMark(

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -3,6 +3,7 @@ import type { OperationActivity } from "@fleet-console/sdk/plugin";
 
 import { buildOperationSearchEntries } from "./operation-search.js";
 import { getGlobalSettingsStoreState, setGlobalSettingsField } from "./global-settings-store.js";
+import { acknowledgeIdleArrival } from "./operation-idle-arrival.js";
 import { uiFontFamily } from "./ui-font.js";
 import type {
   CodexReaderRequest,
@@ -62,6 +63,7 @@ let state: ConsoleState = {
   groups: [],
   activeTheaterId: null,
   activeOperationId: null,
+  activeOperationAcknowledged: true,
   operationStatus: {},
   addingTheater: false,
   theaterError: null,
@@ -232,9 +234,14 @@ export function setActiveTheater(theaterId: string | null): void {
   setState({ activeTheaterId: theaterId });
 }
 
-export function setActiveOperation(operationId: string | null): void {
-  if (state.activeOperationId === operationId) return;
-  setState({ activeOperationId: operationId });
+export function setActiveOperation(
+  operationId: string | null,
+  options?: { readonly acknowledged?: boolean },
+): void {
+  const acknowledged = operationId === null ? true : options?.acknowledged ?? true;
+  if (acknowledged && operationId !== null) acknowledgeIdleArrival(operationId);
+  if (state.activeOperationId === operationId && state.activeOperationAcknowledged === acknowledged) return;
+  setState({ activeOperationId: operationId, activeOperationAcknowledged: acknowledged });
 }
 
 export function setOperationStatus(operationId: string, status: OperationActivity): void {
@@ -304,9 +311,11 @@ export function focusOperation(operationId: string): void {
   const operation = state.operations.find((item) => item.id === operationId);
   if (!operation) return;
   writeStoredActiveTheaterId(operation.theaterId);
+  acknowledgeIdleArrival(operationId);
   setState({
     activeTheaterId: operation.theaterId,
     activeOperationId: operationId,
+    activeOperationAcknowledged: true,
     pendingOperationFocus: operationId,
     operationNotifications: removeNotificationForOperation(state.operationNotifications, operationId),
   });
@@ -536,8 +545,9 @@ export function removeTheater(theaterId: string): void {
   const operationNotifications = pruneNotificationsForTheater(state.operationNotifications, theaterId);
   const removedOperationIds = new Set(state.operations.filter((operation) => operation.theaterId === theaterId).map((operation) => operation.id));
   const activeOperationId = state.activeOperationId && removedOperationIds.has(state.activeOperationId) ? null : state.activeOperationId;
+  const activeOperationAcknowledged = activeOperationId === null ? true : state.activeOperationAcknowledged;
   writeStoredActiveTheaterId(activeTheaterId);
-  setState({ theaters, activeTheaterId, activeOperationId, operationNotifications });
+  setState({ theaters, activeTheaterId, activeOperationId, activeOperationAcknowledged, operationNotifications });
 }
 
 export function dismissNotificationsForOperation(operationId: string): void {

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -238,8 +238,11 @@ export function setActiveOperation(
   operationId: string | null,
   options?: { readonly acknowledged?: boolean },
 ): void {
-  const acknowledged = operationId === null ? true : options?.acknowledged ?? true;
-  if (acknowledged && operationId !== null) acknowledgeIdleArrival(operationId);
+  const acknowledged = operationId === null
+    ? true
+    : options?.acknowledged === false
+      ? false
+      : acknowledgeIdleArrival(operationId);
   if (state.activeOperationId === operationId && state.activeOperationAcknowledged === acknowledged) return;
   setState({ activeOperationId: operationId, activeOperationAcknowledged: acknowledged });
 }
@@ -311,11 +314,11 @@ export function focusOperation(operationId: string): void {
   const operation = state.operations.find((item) => item.id === operationId);
   if (!operation) return;
   writeStoredActiveTheaterId(operation.theaterId);
-  acknowledgeIdleArrival(operationId);
+  const activeOperationAcknowledged = acknowledgeIdleArrival(operationId);
   setState({
     activeTheaterId: operation.theaterId,
     activeOperationId: operationId,
-    activeOperationAcknowledged: true,
+    activeOperationAcknowledged,
     pendingOperationFocus: operationId,
     operationNotifications: removeNotificationForOperation(state.operationNotifications, operationId),
   });

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3103,11 +3103,6 @@
   color: color-mix(in oklch, var(--brass) 88%, var(--text-secondary));
 }
 
-.side-bar-chip.is-triage-stage {
-  border-left: 2px solid var(--brass);
-  background: color-mix(in oklch, var(--brass) 11%, transparent);
-}
-
 /* minimized: 이름은 판독 가능한 --ink-muted 티어로 유지하고 "치워둠" 신호는 아이콘 감쇠로만
    전달한다. 예전의 칩 전체 opacity(색 × 투명도 이중 감쇠)는 이름 대비를 WCAG 하한 아래로
    무너뜨렸다(instrument 1.84:1). 위계: active brass › 기본 ink-spectral › 최소화 ink-muted. */
@@ -3239,20 +3234,6 @@
   text-align: right;
 }
 
-.side-bar-chip-triage-order {
-  display: grid;
-  place-items: center;
-  flex: none;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 4px;
-  border: 1px solid color-mix(in oklch, var(--brass) 28%, var(--hairline));
-  border-radius: var(--radius-pill);
-  color: var(--text-secondary);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: var(--weight-bold);
-}
 
 .side-bar-chip-status {
   flex: none;

--- a/runtime/fleet-console/core/client/src/types.ts
+++ b/runtime/fleet-console/core/client/src/types.ts
@@ -187,6 +187,7 @@ export interface ConsoleState {
   readonly groups: readonly OperationGroup[];
   readonly activeTheaterId: string | null;
   readonly activeOperationId: string | null;
+  readonly activeOperationAcknowledged: boolean;
   readonly operationStatus: Readonly<Record<string, OperationActivity>>;
   readonly addingTheater: boolean;
   readonly theaterError: string | null;

--- a/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
+++ b/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
@@ -492,6 +492,7 @@ const CANVAS_STATE: ConsoleState = {
   groups: [],
   activeTheaterId: "minimap-boundary",
   activeOperationId: null,
+  activeOperationAcknowledged: true,
   operationStatus: {},
   addingTheater: false,
   theaterError: null,

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -604,6 +604,7 @@ describe("Instrument core design contract", () => {
     const operations = source("pages/operations.tsx");
     const sidebar = source("sidebar/operations-side-bar.tsx");
     const sideBarStore = source("sidebar/operations-side-bar-store.ts");
+    const idleArrival = source("operation-idle-arrival.ts");
     const chip = source("sidebar/operations-side-bar-chip.tsx");
     const components = source("styles/components.css");
 
@@ -621,11 +622,12 @@ describe("Instrument core design contract", () => {
     expect(chip).not.toContain("statusAxis && idleUnseen");
     expect(sideBarStore).toContain("let statusAxis = false;");
     expect(sideBarStore).toContain("let statusTransitionTicks = new Map<string, number>();");
-    expect(sideBarStore).toContain("let idleUnseenIds = new Set<string>();");
+    expect(idleArrival).toContain("let idleArrivalIds = new Set<string>();");
     expect(sideBarStore).toContain("let previousActivityById = new Map<string, SideBarStatus>();");
     expect(sideBarStore).toContain("let baselinedLiveActivityIds = new Set<string>();");
     expect(sideBarStore).toContain("let pendingStatusLandingIds = new Set<string>();");
-    expect(sideBarStore).toContain("export function subscribeIdleUnseen(");
+    expect(idleArrival).toContain("export function subscribeIdleArrival(");
+    expect(sideBarStore).not.toContain("idleUnseenIds");
     expect(sideBarStore).not.toContain("STORAGE_KEY_STATUS");
     expect(sideBarStore).not.toContain("fleet-console.operations.status");
 

--- a/runtime/fleet-console/tests/operation-search.test.ts
+++ b/runtime/fleet-console/tests/operation-search.test.ts
@@ -45,6 +45,7 @@ function makeState(
     groups: [],
     activeTheaterId: "theater-alpha",
     activeOperationId: null,
+    activeOperationAcknowledged: true,
     operationStatus,
     addingTheater: false,
     theaterError: null,

--- a/runtime/fleet-console/tests/operations-side-bar-chip-status.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-chip-status.test.ts
@@ -31,15 +31,9 @@ describe("OperationsSideBarChip activity status", () => {
     expect(statusDot.getAttribute("aria-label")).toBe(expectedLabel);
   });
 
-  it("hides the minimize control in Triage mode while keeping the close control", () => {
-    renderChip("awaiting", true);
-
-    expect(container?.querySelector(".side-bar-chip-minimize")).toBeNull();
-    expect(container?.querySelector(".side-bar-chip-close")).not.toBeNull();
-  });
 });
 
-function renderChip(status: OperationActivity | undefined, triageMode = false): HTMLSpanElement {
+function renderChip(status: OperationActivity | undefined): HTMLSpanElement {
   container = document.createElement("div");
   document.body.append(container);
   root = createRoot(container);
@@ -64,7 +58,6 @@ function renderChip(status: OperationActivity | undefined, triageMode = false): 
     index: 0,
     isCloseArmed: false,
     accentValue: null,
-    triageMode,
     dragging: false,
     dragOffsetY: 0,
     dropTarget: false,

--- a/runtime/fleet-console/tests/operations-side-bar-group.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-group.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
 
 import { applyVisibleReorder, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderWithinSegment, type DropSectionInfo } from "../core/client/src/sidebar/operations-side-bar-hit-test.js";
-import { groupOperations, groupOperationsByStatus, hasAwaitingOperation, theaterInitials } from "../core/client/src/sidebar/operations-side-bar.js";
+import { groupOperations, groupOperationsByStatus, hasAwaitingOperation, resolveSideBarStatusSection, theaterInitials } from "../core/client/src/sidebar/operations-side-bar.js";
 import type { SideBarEntry } from "../core/client/src/sidebar/operations-side-bar-chip.js";
 import { resolveTriageQueue } from "../core/client/src/canvas/triage-store.js";
 import {
@@ -310,6 +310,16 @@ describe("groupOperations", () => {
 });
 
 describe("groupOperationsByStatus", () => {
+  it.each([
+    { status: "idle", operationId: "arrived", arrivals: new Set(["arrived"]), expected: "awaiting" },
+    { status: "idle", operationId: "ordinary", arrivals: new Set<string>(), expected: "idle" },
+    { status: "awaiting", operationId: "arrived", arrivals: new Set(["arrived"]), expected: "awaiting" },
+    { status: "running", operationId: "arrived", arrivals: new Set(["arrived"]), expected: "running" },
+    { status: "dormant", operationId: "arrived", arrivals: new Set(["arrived"]), expected: "dormant" },
+  ] as const)("resolves $status for $operationId into the shared $expected section", ({ status, operationId, arrivals, expected }) => {
+    expect(resolveSideBarStatusSection(status, operationId, arrivals)).toBe(expected);
+  });
+
   it("places idle arrivals with awaiting and keeps every entry in exactly one status section", () => {
     const entries = [
       makeEntry("awaiting", null, "awaiting"),

--- a/runtime/fleet-console/tests/operations-side-bar-group.test.ts
+++ b/runtime/fleet-console/tests/operations-side-bar-group.test.ts
@@ -4,20 +4,23 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
 
 import { applyVisibleReorder, dropTargetFromPoint, insertIntoSegment, moveByTargetIndex, reorderWithinSegment, type DropSectionInfo } from "../core/client/src/sidebar/operations-side-bar-hit-test.js";
-import { buildTriageSections, groupOperations, groupOperationsByStatus, hasAwaitingOperation, theaterInitials } from "../core/client/src/sidebar/operations-side-bar.js";
+import { groupOperations, groupOperationsByStatus, hasAwaitingOperation, theaterInitials } from "../core/client/src/sidebar/operations-side-bar.js";
 import type { SideBarEntry } from "../core/client/src/sidebar/operations-side-bar-chip.js";
+import { resolveTriageQueue } from "../core/client/src/canvas/triage-store.js";
 import {
-  clearIdleUnseen,
-  getIdleUnseenIds,
+  clearIdleArrival,
+  getIdleArrivalIds,
+  markIdleArrival,
+  subscribeIdleArrival,
+} from "../core/client/src/operation-idle-arrival.js";
+import {
   getStatusTransitionTick,
-  markIdleUnseen,
   recordStatusTransitions,
   resetSideBarStatusRecencyForTests,
-  subscribeIdleUnseen,
   subscribeOperationActivityTracking,
   trackOperationActivityTransitions,
 } from "../core/client/src/sidebar/operations-side-bar-store.js";
-import { setState as setConsoleState } from "../core/client/src/store.js";
+import { getState, setActiveOperation, setState as setConsoleState } from "../core/client/src/store.js";
 import type { OperationGroup, OperationNode } from "../core/client/src/types.js";
 
 function makeNode(id: string, groupId?: string | null): OperationNode {
@@ -307,6 +310,26 @@ describe("groupOperations", () => {
 });
 
 describe("groupOperationsByStatus", () => {
+  it("places idle arrivals with awaiting and keeps every entry in exactly one status section", () => {
+    const entries = [
+      makeEntry("awaiting", null, "awaiting"),
+      makeEntry("arrived", null, "idle"),
+      makeEntry("idle", null, "idle"),
+      makeEntry("running", null, "running"),
+    ];
+    markIdleArrival("arrived");
+
+    const sections = groupOperationsByStatus(entries);
+    expect(sections[0]?.entries.map((entry) => entry.operation.id)).toEqual(["awaiting", "arrived"]);
+    expect(sections[2]?.entries.map((entry) => entry.operation.id)).toEqual(["idle"]);
+    expect(sections.flatMap((section) => section.entries)).toHaveLength(entries.length);
+
+    const operations = entries.map((entry) => entry.operation);
+    const statuses = { awaiting: "awaiting", arrived: "idle", idle: "idle", running: "running" } as const;
+    expect(new Set(sections[0]?.entries.map((entry) => entry.operation.id)))
+      .toEqual(new Set(resolveTriageQueue("t1", operations, statuses).map((entry) => entry.operation.id)));
+  });
+
   it("renders only non-empty sections in the literal status order and treats a missing key as idle", () => {
     const entries = [
       makeEntry("idle-missing"),
@@ -354,45 +377,45 @@ describe("groupOperationsByStatus", () => {
 
   it("resets transition ticks and idle unseen state together", () => {
     recordStatusTransitions(["operation"]);
-    markIdleUnseen("operation");
+    markIdleArrival("operation");
     expect(getStatusTransitionTick("operation")).toBe(1);
-    expect(getIdleUnseenIds().has("operation")).toBe(true);
+    expect(getIdleArrivalIds().has("operation")).toBe(true);
 
     resetSideBarStatusRecencyForTests();
 
     expect(getStatusTransitionTick("operation")).toBeUndefined();
-    expect(getIdleUnseenIds().size).toBe(0);
+    expect(getIdleArrivalIds().size).toBe(0);
     recordStatusTransitions(["next-operation"]);
     expect(getStatusTransitionTick("next-operation")).toBe(1);
   });
 
-  it("publishes one immutable idle-unseen snapshot per membership change", () => {
+  it("publishes one immutable idle-arrival snapshot per membership change", () => {
     const id = "operation";
     const listener = vi.fn();
-    const initialSnapshot = getIdleUnseenIds();
-    const unsubscribe = subscribeIdleUnseen(listener);
+    const initialSnapshot = getIdleArrivalIds();
+    const unsubscribe = subscribeIdleArrival(listener);
 
     try {
-      markIdleUnseen(id);
-      const markedSnapshot = getIdleUnseenIds();
+      markIdleArrival(id);
+      const markedSnapshot = getIdleArrivalIds();
       expect(markedSnapshot).not.toBe(initialSnapshot);
       expect(listener).toHaveBeenCalledTimes(1);
 
-      markIdleUnseen(id);
-      expect(getIdleUnseenIds()).toBe(markedSnapshot);
+      markIdleArrival(id);
+      expect(getIdleArrivalIds()).toBe(markedSnapshot);
       expect(listener).toHaveBeenCalledTimes(1);
 
-      clearIdleUnseen("missing-operation");
-      expect(getIdleUnseenIds()).toBe(markedSnapshot);
+      clearIdleArrival("missing-operation");
+      expect(getIdleArrivalIds()).toBe(markedSnapshot);
       expect(listener).toHaveBeenCalledTimes(1);
 
-      clearIdleUnseen(id);
-      const clearedSnapshot = getIdleUnseenIds();
+      clearIdleArrival(id);
+      const clearedSnapshot = getIdleArrivalIds();
       expect(clearedSnapshot).not.toBe(markedSnapshot);
       expect(listener).toHaveBeenCalledTimes(2);
 
       unsubscribe();
-      markIdleUnseen(id);
+      markIdleArrival(id);
       expect(listener).toHaveBeenCalledTimes(2);
     } finally {
       unsubscribe();
@@ -406,6 +429,7 @@ describe("groupOperationsByStatus", () => {
       operationStatus: { operation: "running" },
       activeTheaterId: "theater-b",
       activeOperationId: operation.id,
+      activeOperationAcknowledged: true,
     });
 
     expect(trackOperationActivityTransitions({
@@ -413,8 +437,9 @@ describe("groupOperationsByStatus", () => {
       operationStatus: { operation: "idle" },
       activeTheaterId: "theater-b",
       activeOperationId: operation.id,
+      activeOperationAcknowledged: true,
     })).toEqual([operation.id]);
-    expect(getIdleUnseenIds().has(operation.id)).toBe(true);
+    expect(getIdleArrivalIds().has(operation.id)).toBe(true);
     const tick = getStatusTransitionTick(operation.id);
 
     expect(trackOperationActivityTransitions({
@@ -422,17 +447,19 @@ describe("groupOperationsByStatus", () => {
       operationStatus: { operation: "idle" },
       activeTheaterId: "theater-b",
       activeOperationId: operation.id,
+      activeOperationAcknowledged: true,
     })).toEqual([]);
     expect(getStatusTransitionTick(operation.id)).toBe(tick);
-    expect(getIdleUnseenIds().has(operation.id)).toBe(true);
+    expect(getIdleArrivalIds().has(operation.id)).toBe(true);
 
     expect(trackOperationActivityTransitions({
       operations: [operation],
       operationStatus: { operation: "idle" },
       activeTheaterId: operation.theaterId,
       activeOperationId: operation.id,
+      activeOperationAcknowledged: true,
     })).toEqual([]);
-    expect(getIdleUnseenIds().has(operation.id)).toBe(false);
+    expect(getIdleArrivalIds().has(operation.id)).toBe(true);
   });
 
   it("does not mark an idle transition for the focused Operation in the active Theater", () => {
@@ -442,6 +469,7 @@ describe("groupOperationsByStatus", () => {
       operationStatus: { focused: "running" },
       activeTheaterId: operation.theaterId,
       activeOperationId: operation.id,
+      activeOperationAcknowledged: true,
     });
 
     expect(trackOperationActivityTransitions({
@@ -449,21 +477,28 @@ describe("groupOperationsByStatus", () => {
       operationStatus: { focused: "idle" },
       activeTheaterId: operation.theaterId,
       activeOperationId: operation.id,
+      activeOperationAcknowledged: true,
     })).toEqual([operation.id]);
-    expect(getIdleUnseenIds().has(operation.id)).toBe(false);
+    expect(getIdleArrivalIds().has(operation.id)).toBe(false);
   });
 
-  it("clears unseen for the active Operation on every tracker call", () => {
+  it("keeps an arrival during system activation and acknowledges it on user activation", () => {
     const operation = makeNode("focused");
-    markIdleUnseen("focused");
-
-    expect(trackOperationActivityTransitions({
+    markIdleArrival("focused");
+    setConsoleState({
       operations: [operation],
-      operationStatus: {},
       activeTheaterId: operation.theaterId,
-      activeOperationId: "focused",
-    })).toEqual([]);
-    expect(getIdleUnseenIds().has("focused")).toBe(false);
+      activeOperationId: null,
+      activeOperationAcknowledged: true,
+    });
+
+    setActiveOperation("focused", { acknowledged: false });
+    expect(getIdleArrivalIds().has("focused")).toBe(true);
+    expect(getState().activeOperationAcknowledged).toBe(false);
+
+    setActiveOperation("focused");
+    expect(getIdleArrivalIds().has("focused")).toBe(false);
+    expect(getState().activeOperationAcknowledged).toBe(true);
   });
 
   it("tracks both synchronous store emissions instead of observing only the batched final snapshot", () => {
@@ -477,12 +512,13 @@ describe("groupOperationsByStatus", () => {
           operationStatus: { streamed: "running" },
           activeTheaterId: operation.theaterId,
           activeOperationId: null,
+          activeOperationAcknowledged: true,
         });
         setConsoleState({ operationStatus: { streamed: "idle" } });
       });
 
       expect(getStatusTransitionTick(operation.id)).toBeDefined();
-      expect(getIdleUnseenIds().has(operation.id)).toBe(true);
+      expect(getIdleArrivalIds().has(operation.id)).toBe(true);
     } finally {
       unsubscribe();
       setConsoleState({
@@ -490,6 +526,7 @@ describe("groupOperationsByStatus", () => {
         operationStatus: {},
         activeTheaterId: null,
         activeOperationId: null,
+        activeOperationAcknowledged: true,
       });
     }
   });
@@ -498,19 +535,6 @@ describe("groupOperationsByStatus", () => {
     const operations = [makeNode("a"), makeNode("b")];
     expect(hasAwaitingOperation(operations, { a: "running", b: "awaiting" })).toBe(true);
     expect(hasAwaitingOperation(operations, { a: "running" })).toBe(false);
-  });
-});
-
-describe("buildTriageSections", () => {
-  it("renders the queue in queue order and keeps every other Operation in the flat rest section", () => {
-    const sections = buildTriageSections(
-      [makeEntry("rest-first"), makeEntry("queue-second"), makeEntry("queue-first")],
-      ["queue-first", "queue-second"],
-    );
-
-    expect(sections.map((section) => section.label)).toEqual(["Queue", "Not waiting"]);
-    expect(sections[0]?.entries.map((entry) => entry.operation.id)).toEqual(["queue-first", "queue-second"]);
-    expect(sections[1]?.entries.map((entry) => entry.operation.id)).toEqual(["rest-first"]);
   });
 });
 

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -6,15 +6,18 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getSnapshot, loadForTheater, setOperationOrder } from "../core/client/src/canvas/canvas-store.js";
-import { getIdleArrivalIds } from "../core/client/src/operation-idle-arrival.js";
+import { getIdleArrivalIds, markIdleArrival } from "../core/client/src/operation-idle-arrival.js";
+import { requestSideBarOperationAction } from "../core/client/src/sidebar/operation-action-request.js";
 import { OperationsSideBar } from "../core/client/src/sidebar/operations-side-bar.js";
 import {
+  getSideBarStatusSectionCollapsed,
   getStatusTransitionTick,
   resetSideBarStatusRecencyForTests,
   resetSideBarStatusSectionCollapseForTests,
   setSideBarCollapsed,
   setSideBarStatusAxis,
   setTheaterCollapsed,
+  toggleSideBarStatusSectionCollapsed,
   trackOperationActivityTransitions,
 } from "../core/client/src/sidebar/operations-side-bar-store.js";
 import { setActiveOperation, setState as setConsoleState } from "../core/client/src/store.js";
@@ -127,6 +130,35 @@ describe("OperationsSideBar STATUS axis", () => {
     expect(container?.querySelector('[data-side-bar-chip-id="only"]')).toBeNull();
     act(() => required<HTMLButtonElement>('.side-bar-status-section--running [aria-label="Expand section RUNNING"]').click());
     expect(container?.querySelector('[data-side-bar-chip-id="only"]')).not.toBeNull();
+  });
+
+  it("reveals an idle arrival from the AWAITING section for a palette action", () => {
+    const operation = makeOperation("arrived", null);
+    setConsoleState({ operationStatus: { arrived: "idle" } });
+    markIdleArrival(operation.id);
+    setSideBarStatusAxis(true);
+    toggleSideBarStatusSectionCollapsed(THEATER.id, "awaiting", false);
+    renderSideBar([operation]);
+    expect(getSideBarStatusSectionCollapsed(THEATER.id, "awaiting", false)).toBe(true);
+
+    act(() => requestSideBarOperationAction(operation.id, "rename"));
+
+    expect(getSideBarStatusSectionCollapsed(THEATER.id, "awaiting", false)).toBe(false);
+    expect(getSideBarStatusSectionCollapsed(THEATER.id, "idle", true)).toBe(true);
+  });
+
+  it("continues to reveal an ordinary idle Operation from the IDLE section", () => {
+    const operation = makeOperation("idle", null);
+    setConsoleState({ operationStatus: { idle: "idle" } });
+    setSideBarStatusAxis(true);
+    toggleSideBarStatusSectionCollapsed(THEATER.id, "idle", false);
+    renderSideBar([operation]);
+    expect(getSideBarStatusSectionCollapsed(THEATER.id, "idle", false)).toBe(true);
+
+    act(() => requestSideBarOperationAction(operation.id, "rename"));
+
+    expect(getSideBarStatusSectionCollapsed(THEATER.id, "idle", false)).toBe(false);
+    expect(getSideBarStatusSectionCollapsed(THEATER.id, "awaiting", true)).toBe(true);
   });
 
   it("keeps an explicit empty-section expansion when an Operation enters and leaves again", () => {

--- a/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-status-axis.test.tsx
@@ -6,9 +6,9 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getSnapshot, loadForTheater, setOperationOrder } from "../core/client/src/canvas/canvas-store.js";
+import { getIdleArrivalIds } from "../core/client/src/operation-idle-arrival.js";
 import { OperationsSideBar } from "../core/client/src/sidebar/operations-side-bar.js";
 import {
-  getIdleUnseenIds,
   getStatusTransitionTick,
   resetSideBarStatusRecencyForTests,
   resetSideBarStatusSectionCollapseForTests,
@@ -17,7 +17,7 @@ import {
   setTheaterCollapsed,
   trackOperationActivityTransitions,
 } from "../core/client/src/sidebar/operations-side-bar-store.js";
-import { setState as setConsoleState } from "../core/client/src/store.js";
+import { setActiveOperation, setState as setConsoleState } from "../core/client/src/store.js";
 import type { OperationGroup, OperationNode, TheaterInfo } from "../core/client/src/types.js";
 
 let root: Root | null = null;
@@ -288,12 +288,14 @@ describe("OperationsSideBar STATUS axis", () => {
       operationStatus: { recorded: "running" },
       activeTheaterId: THEATER.id,
       activeOperationId: null,
+      activeOperationAcknowledged: true,
     });
     expect(trackOperationActivityTransitions({
       operations,
       operationStatus: { recorded: "idle" },
       activeTheaterId: THEATER.id,
       activeOperationId: null,
+      activeOperationAcknowledged: true,
     })).toEqual(["recorded"]);
 
     setConsoleState({ operationStatus: { recorded: "idle" } });
@@ -304,11 +306,15 @@ describe("OperationsSideBar STATUS axis", () => {
       required<HTMLElement>(".side-bar-status-section--idle").querySelectorAll<HTMLElement>("[data-side-bar-chip-id]"),
       (chip) => chip.dataset.sideBarChipId,
     );
-    expect(idleChips).toEqual(["recorded", "untouched"]);
+    expect(idleChips).toEqual(["untouched"]);
+    expect(Array.from(
+      required<HTMLElement>(".side-bar-status-section--awaiting").querySelectorAll<HTMLElement>("[data-side-bar-chip-id]"),
+      (chip) => chip.dataset.sideBarChipId,
+    )).toEqual(["recorded"]);
     const recordedChip = required<HTMLElement>('[data-side-bar-chip-id="recorded"]');
     expect(recordedChip.querySelector(".side-bar-chip-unseen")).not.toBeNull();
     expect(recordedChip.className).not.toContain("side-bar-chip--status-landed");
-    expect(required<HTMLElement>(".side-bar-status-section--idle .side-bar-status-header__unseen").textContent).toBe("1");
+    expect(required<HTMLElement>(".side-bar-status-section--awaiting .side-bar-status-header__unseen").textContent).toBe("1");
   });
 
   it("tracks idle unseen while STATUS is off, omits focused transitions, and clears on focus", () => {
@@ -317,21 +323,22 @@ describe("OperationsSideBar STATUS axis", () => {
     renderSideBar(operations, [], vi.fn(), THEATER.id, [THEATER], "focused");
 
     act(() => setConsoleState({ operationStatus: { unseen: "idle", focused: "idle" } }));
-    expect(container?.querySelector(".side-bar-chip-unseen")).toBeNull();
+    expect(container?.querySelector(".side-bar-chip-unseen")).not.toBeNull();
 
     act(() => setSideBarStatusAxis(true));
 
     const unseenChip = required<HTMLElement>('[data-side-bar-chip-id="unseen"]');
     expect(unseenChip.querySelector(".side-bar-chip-unseen")?.getAttribute("title")).toBe("Finished — not opened yet");
     expect(unseenChip.getAttribute("aria-label")).toContain(" (unseen since idle)");
-    expect(required<HTMLElement>(".side-bar-status-section--idle .side-bar-status-header__unseen").textContent).toBe("1");
+    expect(required<HTMLElement>(".side-bar-status-section--awaiting .side-bar-status-header__unseen").textContent).toBe("1");
     expect(required<HTMLElement>('[data-side-bar-chip-id="focused"]').querySelector(".side-bar-chip-unseen")).toBeNull();
 
+    act(() => setActiveOperation("unseen"));
     rerenderSideBar(operations, [], THEATER.id, [THEATER], "unseen");
 
     expect(required<HTMLElement>('[data-side-bar-chip-id="unseen"]').querySelector(".side-bar-chip-unseen")).toBeNull();
     expect(container?.querySelector(".side-bar-status-section--idle .side-bar-status-header__unseen")).toBeNull();
-    expect(getIdleUnseenIds().has("unseen")).toBe(false);
+    expect(getIdleArrivalIds().has("unseen")).toBe(false);
   });
 
   it("removes idle unseen on exit and grants it again on a later idle episode", () => {
@@ -387,7 +394,7 @@ describe("OperationsSideBar STATUS axis", () => {
     expect(getStatusTransitionTick("restored")).toBeGreaterThan(runningTick ?? 0);
     expect(transitionedChip.querySelector(".side-bar-chip-unseen")).not.toBeNull();
     expect(transitionedChip.className).toContain("side-bar-chip--status-landed");
-    expect(required<HTMLElement>(".side-bar-status-section--idle .side-bar-status-header__unseen").textContent).toBe("1");
+    expect(required<HTMLElement>(".side-bar-status-section--awaiting .side-bar-status-header__unseen").textContent).toBe("1");
   });
 
   it("uses the Theater name row for persisted collapse and exposes the split control accessibility contract", () => {

--- a/runtime/fleet-console/tests/palette-commands.test.ts
+++ b/runtime/fleet-console/tests/palette-commands.test.ts
@@ -75,6 +75,7 @@ function makeState(patch: Partial<ConsoleState> = {}): ConsoleState {
     codexReader: null,
     codexReaderExpanded: false,
     ...patch,
+    activeOperationAcknowledged: patch.activeOperationAcknowledged ?? true,
   };
 }
 

--- a/runtime/fleet-console/tests/reduce.test.ts
+++ b/runtime/fleet-console/tests/reduce.test.ts
@@ -78,6 +78,7 @@ function makeConsoleSnap(patch: Partial<ConsoleState> = {}): ConsoleState {
     operationNotifications: {},
     notificationPreferences: { globalMute: false, dnd: false, mutedTheaterIds: {} },
     ...patch,
+    activeOperationAcknowledged: patch.activeOperationAcknowledged ?? true,
     codexReader: patch.codexReader ?? null,
     codexReaderExpanded: patch.codexReaderExpanded ?? false,
   };

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -101,15 +101,17 @@ describe("triage store", () => {
   });
 
   it.each([
-    [THEATER_ID, "theater-b", true],
-    ["theater-b", THEATER_ID, false],
-  ] as const)("keeps the status axis enabled when %s exits and restores %s on the last exit", (
+    [false, THEATER_ID, "theater-b"],
+    [false, "theater-b", THEATER_ID],
+    [true, THEATER_ID, "theater-b"],
+    [true, "theater-b", THEATER_ID],
+  ] as const)("restores the initial %s status axis after %s then %s exit", (
+    initial,
     firstExit,
     lastExit,
-    expectedRestored,
   ) => {
     const otherTheaterId = "theater-b";
-    setSideBarStatusAxis(false);
+    setSideBarStatusAxis(initial);
     setTriageActive(THEATER_ID, true);
     setTriageActive(otherTheaterId, true);
 
@@ -117,7 +119,7 @@ describe("triage store", () => {
     expect(getSideBarStatusAxis()).toBe(true);
 
     resetTriageTheater(lastExit);
-    expect(getSideBarStatusAxis()).toBe(expectedRestored);
+    expect(getSideBarStatusAxis()).toBe(initial);
   });
 
   it("removes a picked stage after its waiting activity clears and advances the next item", () => {

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -7,6 +7,15 @@ import { createRoot, type Root } from "react-dom/client";
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
 
 import {
+  acknowledgeIdleArrival,
+  clearIdleArrival,
+  getIdleArrivalIds,
+  markIdleArrival,
+  resetIdleArrivalForTests,
+} from "../core/client/src/operation-idle-arrival.js";
+import { setActiveOperation, setState as setConsoleState } from "../core/client/src/store.js";
+import { getSideBarStatusAxis, setSideBarStatusAxis } from "../core/client/src/sidebar/operations-side-bar-store.js";
+import {
   clearFormationView,
   forceDropCompanionOperationId,
   getCompanionOperationId,
@@ -22,6 +31,7 @@ import {
 } from "../core/client/src/canvas/canvas-store.js";
 import {
   deferTriageOperation,
+  dismissTriageOperation,
   focusedTriageOperationId,
   forgetTriageOperation,
   getTriageCleared,
@@ -50,11 +60,20 @@ beforeEach(() => {
   vi.setSystemTime(1_000);
   window.localStorage.clear();
   loadForTheater(THEATER_ID);
+  resetIdleArrivalForTests();
+  setConsoleState({
+    operations: [],
+    activeTheaterId: null,
+    activeOperationId: null,
+    activeOperationAcknowledged: true,
+    operationStatus: {},
+  });
   resetTriageTheater(THEATER_ID);
+  resetIdleArrivalForTests();
   clearFormationView();
   clearMaximizedOperationId();
   forceDropCompanionOperationId();
-  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 });
 
 afterEach(() => {
@@ -68,16 +87,25 @@ afterEach(() => {
     triagePlateRoot = null;
   }
   document.body.replaceChildren();
-  delete globalThis.IS_REACT_ACT_ENVIRONMENT;
+  delete (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
   vi.useRealTimers();
 });
 
 describe("triage store", () => {
+  it.each([false, true])("enables the status axis during Triage and restores %s on exit", (initial) => {
+    setSideBarStatusAxis(initial);
+    setTriageActive(THEATER_ID, true);
+    expect(getSideBarStatusAxis()).toBe(true);
+    setTriageActive(THEATER_ID, false);
+    expect(getSideBarStatusAxis()).toBe(initial);
+  });
+
   it("removes a picked stage after its waiting activity clears and advances the next item", () => {
     const waiting: Readonly<Record<string, OperationActivity>> = {
       picked: "awaiting",
       next: "idle",
     };
+    markIdleArrival("next");
     recordTriageActivity(THEATER_ID, OPERATIONS, waiting, 1_000);
     pickTriageOperation(THEATER_ID, "picked");
 
@@ -181,6 +209,7 @@ describe("triage store", () => {
       picked: "awaiting",
       next: "idle",
     };
+    markIdleArrival("next");
     recordTriageActivity(THEATER_ID, OPERATIONS, waiting, 1_000);
     pickTriageOperation(THEATER_ID, "picked");
     const initialActivity = resolveTriageQueue(THEATER_ID, OPERATIONS, waiting, 1_000)[0]!.activity;
@@ -201,18 +230,92 @@ describe("triage store", () => {
     expect(resolveTriageQueue(THEATER_ID, OPERATIONS, running, 2_600)[0]?.operation.id).toBe("next");
   });
 
-  it("queues only reported idle Operations unless a fallback idle Operation is picked", () => {
+  it("queues only idle arrivals unless an ordinary idle Operation is picked", () => {
     const fallbackIdle = operation("fallback-idle", 1);
     const liveIdle = operation("live-idle", 2);
     const status: Readonly<Record<string, OperationActivity>> = { "live-idle": "idle" };
     recordTriageActivity(THEATER_ID, [fallbackIdle, liveIdle], status, 1_000);
 
     expect(resolveTriageQueue(THEATER_ID, [fallbackIdle, liveIdle], status, 1_000)
+      .map((entry) => entry.operation.id)).toEqual([]);
+
+    markIdleArrival("live-idle");
+    expect(resolveTriageQueue(THEATER_ID, [fallbackIdle, liveIdle], status, 1_000)
       .map((entry) => entry.operation.id)).toEqual(["live-idle"]);
 
     pickTriageOperation(THEATER_ID, "fallback-idle");
     expect(resolveTriageQueue(THEATER_ID, [fallbackIdle, liveIdle], status, 1_000)
       .map((entry) => entry.operation.id)).toEqual(["fallback-idle", "live-idle"]);
+  });
+
+  it("keeps an idle arrival as queue head when the user activates the stage during Triage", () => {
+    const arrived = operation("arrived", 1);
+    const status: Readonly<Record<string, OperationActivity>> = { arrived: "idle" };
+    markIdleArrival(arrived.id);
+    setConsoleState({
+      operations: [arrived],
+      activeTheaterId: THEATER_ID,
+      activeOperationId: null,
+      activeOperationAcknowledged: true,
+      operationStatus: status,
+    });
+
+    setTriageActive(THEATER_ID, true);
+    setActiveOperation(arrived.id, { acknowledged: false });
+    expect(resolveTriageQueue(THEATER_ID, [arrived], status)[0]?.operation.id).toBe(arrived.id);
+
+    setActiveOperation(arrived.id);
+    acknowledgeIdleArrival(arrived.id);
+    expect(getIdleArrivalIds().has(arrived.id)).toBe(true);
+    expect(resolveTriageQueue(THEATER_ID, [arrived], status)[0]?.operation.id).toBe(arrived.id);
+
+    setTriageActive(THEATER_ID, false);
+    setActiveOperation(arrived.id);
+    expect(resolveTriageQueue(THEATER_ID, [arrived], status)).toEqual([]);
+  });
+
+  it("keeps acknowledgement suspended while any Theater remains in Triage", () => {
+    const otherTheaterId = "theater-b";
+    const inactiveTheaterId = "theater-c";
+    markIdleArrival("arrived");
+    setTriageActive(THEATER_ID, true);
+
+    resetTriageTheater(inactiveTheaterId);
+    acknowledgeIdleArrival("arrived");
+    expect(getIdleArrivalIds().has("arrived")).toBe(true);
+
+    setTriageActive(otherTheaterId, true);
+    resetTriageTheater(THEATER_ID);
+    acknowledgeIdleArrival("arrived");
+    expect(getIdleArrivalIds().has("arrived")).toBe(true);
+
+    resetTriageTheater(otherTheaterId);
+    acknowledgeIdleArrival("arrived");
+    expect(getIdleArrivalIds().has("arrived")).toBe(false);
+  });
+
+  it("clears an idle arrival explicitly even while acknowledgement is suspended", () => {
+    markIdleArrival("arrived");
+    setTriageActive(THEATER_ID, true);
+
+    clearIdleArrival("arrived");
+
+    expect(getIdleArrivalIds().has("arrived")).toBe(false);
+  });
+
+  it("clears an idle arrival when its Triage item is dismissed", () => {
+    markIdleArrival("arrived");
+    setTriageActive(THEATER_ID, true);
+
+    dismissTriageOperation(THEATER_ID, "arrived");
+
+    expect(getIdleArrivalIds().has("arrived")).toBe(false);
+  });
+
+  it("always queues awaiting Operations without an idle arrival", () => {
+    const awaiting = operation("awaiting", 1);
+    expect(resolveTriageQueue(THEATER_ID, [awaiting], { awaiting: "awaiting" })
+      .map((entry) => entry.operation.id)).toEqual(["awaiting"]);
   });
 
   it("round-robins the queue through repeated deferrals without clearing or removing items", () => {
@@ -249,6 +352,8 @@ describe("triage store", () => {
       "idle-a": "idle",
       "idle-b": "idle",
     };
+    markIdleArrival("idle-a");
+    markIdleArrival("idle-b");
     recordTriageActivity(THEATER_ID, operations, mixed, 1_000);
 
     const visited: string[] = [];
@@ -328,6 +433,7 @@ describe("triage store", () => {
         active: true,
         entering: true,
         hasContent: false,
+        idleCount: 0,
       }));
     });
     expect(container.querySelector(".canvas-triage-clear")).toBeNull();
@@ -337,9 +443,28 @@ describe("triage store", () => {
         active: true,
         entering: false,
         hasContent: false,
+        idleCount: 0,
       }));
     });
     expect(container.querySelector(".canvas-triage-clear")).not.toBeNull();
+  });
+
+  it("guides an empty queue toward idle panels", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    triagePlateRoot = createRoot(container);
+
+    act(() => {
+      triagePlateRoot?.render(createElement(TriageClearPlate, {
+        active: true,
+        entering: false,
+        hasContent: false,
+        idleCount: 2,
+      }));
+    });
+
+    expect(container.querySelector(".canvas-triage-clear p")?.textContent)
+      .toBe("Nothing is waiting on you. 2 idle panels sit in the left list. Click one to bring it up.");
   });
 
   it("closes inherited companions on entry and stage changes but preserves an explicitly opened companion", () => {

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -13,7 +13,7 @@ import {
   markIdleArrival,
   resetIdleArrivalForTests,
 } from "../core/client/src/operation-idle-arrival.js";
-import { setActiveOperation, setState as setConsoleState } from "../core/client/src/store.js";
+import { getState, setActiveOperation, setState as setConsoleState } from "../core/client/src/store.js";
 import { getSideBarStatusAxis, setSideBarStatusAxis } from "../core/client/src/sidebar/operations-side-bar-store.js";
 import {
   clearFormationView,
@@ -274,24 +274,72 @@ describe("triage store", () => {
     expect(resolveTriageQueue(THEATER_ID, [arrived], status)).toEqual([]);
   });
 
+  it("acknowledges only the active Operation when the last Triage Theater exits", () => {
+    const active = operation("active", 1);
+    const waiting = operation("waiting", 2);
+    markIdleArrival(active.id);
+    markIdleArrival(waiting.id);
+    setConsoleState({
+      operations: [active, waiting],
+      activeTheaterId: THEATER_ID,
+      activeOperationId: active.id,
+      activeOperationAcknowledged: false,
+    });
+    setTriageActive(THEATER_ID, true);
+
+    setTriageActive(THEATER_ID, false);
+
+    expect(getIdleArrivalIds().has(active.id)).toBe(false);
+    expect(getIdleArrivalIds().has(waiting.id)).toBe(true);
+    expect(getState().activeOperationAcknowledged).toBe(true);
+  });
+
   it("keeps acknowledgement suspended while any Theater remains in Triage", () => {
     const otherTheaterId = "theater-b";
     const inactiveTheaterId = "theater-c";
     markIdleArrival("arrived");
+    setConsoleState({
+      activeOperationId: "arrived",
+      activeOperationAcknowledged: false,
+    });
     setTriageActive(THEATER_ID, true);
 
     resetTriageTheater(inactiveTheaterId);
-    acknowledgeIdleArrival("arrived");
     expect(getIdleArrivalIds().has("arrived")).toBe(true);
+    expect(getState().activeOperationAcknowledged).toBe(false);
 
     setTriageActive(otherTheaterId, true);
     resetTriageTheater(THEATER_ID);
-    acknowledgeIdleArrival("arrived");
     expect(getIdleArrivalIds().has("arrived")).toBe(true);
+    expect(getState().activeOperationAcknowledged).toBe(false);
 
     resetTriageTheater(otherTheaterId);
-    acknowledgeIdleArrival("arrived");
     expect(getIdleArrivalIds().has("arrived")).toBe(false);
+    expect(getState().activeOperationAcknowledged).toBe(true);
+  });
+
+  it("does nothing when the last Triage Theater exits without an active Operation", () => {
+    markIdleArrival("waiting");
+    setTriageActive(THEATER_ID, true);
+
+    setTriageActive(THEATER_ID, false);
+
+    expect(getIdleArrivalIds().has("waiting")).toBe(true);
+    expect(getState().activeOperationId).toBeNull();
+    expect(getState().activeOperationAcknowledged).toBe(true);
+  });
+
+  it("does not acknowledge an active Operation when resetting an inactive Theater", () => {
+    markIdleArrival("active");
+    setConsoleState({
+      activeOperationId: "active",
+      activeOperationAcknowledged: false,
+    });
+
+    resetTriageTheater("inactive-theater");
+
+    expect(getIdleArrivalIds().has("active")).toBe(true);
+    expect(getState().activeOperationAcknowledged).toBe(false);
   });
 
   it("clears an idle arrival explicitly even while acknowledgement is suspended", () => {

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -13,7 +13,7 @@ import {
   markIdleArrival,
   resetIdleArrivalForTests,
 } from "../core/client/src/operation-idle-arrival.js";
-import { getState, setActiveOperation, setState as setConsoleState } from "../core/client/src/store.js";
+import { focusOperation, getState, setActiveOperation, setState as setConsoleState } from "../core/client/src/store.js";
 import { getSideBarStatusAxis, setSideBarStatusAxis } from "../core/client/src/sidebar/operations-side-bar-store.js";
 import {
   clearFormationView,
@@ -98,6 +98,26 @@ describe("triage store", () => {
     expect(getSideBarStatusAxis()).toBe(true);
     setTriageActive(THEATER_ID, false);
     expect(getSideBarStatusAxis()).toBe(initial);
+  });
+
+  it.each([
+    [THEATER_ID, "theater-b", true],
+    ["theater-b", THEATER_ID, false],
+  ] as const)("keeps the status axis enabled when %s exits and restores %s on the last exit", (
+    firstExit,
+    lastExit,
+    expectedRestored,
+  ) => {
+    const otherTheaterId = "theater-b";
+    setSideBarStatusAxis(false);
+    setTriageActive(THEATER_ID, true);
+    setTriageActive(otherTheaterId, true);
+
+    setTriageActive(firstExit, false);
+    expect(getSideBarStatusAxis()).toBe(true);
+
+    resetTriageTheater(lastExit);
+    expect(getSideBarStatusAxis()).toBe(expectedRestored);
   });
 
   it("removes a picked stage after its waiting activity clears and advances the next item", () => {
@@ -265,13 +285,32 @@ describe("triage store", () => {
     expect(resolveTriageQueue(THEATER_ID, [arrived], status)[0]?.operation.id).toBe(arrived.id);
 
     setActiveOperation(arrived.id);
-    acknowledgeIdleArrival(arrived.id);
+    expect(acknowledgeIdleArrival(arrived.id)).toBe(false);
+    expect(getState().activeOperationAcknowledged).toBe(false);
     expect(getIdleArrivalIds().has(arrived.id)).toBe(true);
     expect(resolveTriageQueue(THEATER_ID, [arrived], status)[0]?.operation.id).toBe(arrived.id);
 
     setTriageActive(THEATER_ID, false);
-    setActiveOperation(arrived.id);
+    expect(getState().activeOperationAcknowledged).toBe(true);
+    expect(getIdleArrivalIds().has(arrived.id)).toBe(false);
     expect(resolveTriageQueue(THEATER_ID, [arrived], status)).toEqual([]);
+  });
+
+  it("keeps focusOperation unacknowledged while Triage suspends acknowledgement", () => {
+    const arrived = operation("arrived", 1);
+    markIdleArrival(arrived.id);
+    setConsoleState({
+      operations: [arrived],
+      activeTheaterId: THEATER_ID,
+      activeOperationId: null,
+      activeOperationAcknowledged: true,
+    });
+    setTriageActive(THEATER_ID, true);
+
+    focusOperation(arrived.id);
+
+    expect(getIdleArrivalIds().has(arrived.id)).toBe(true);
+    expect(getState().activeOperationAcknowledged).toBe(false);
   });
 
   it("acknowledges only the active Operation when the last Triage Theater exits", () => {


### PR DESCRIPTION
## Summary

- 선별 처리 큐에 자동으로 들어가는 대상을 `awaiting` 상태이거나 **방금 유휴로 전이되어 아직 확인되지 않은** Operation으로 한정합니다. 그냥 놓여 있던 유휴 패널은 더 이상 자동으로 올라오지 않고, 사용자가 직접 골라야 스테이지에 섭니다.
- 선별 처리 전용 사이드바 축을 폐기하고 기존 `Sort by status`에 통합했습니다. `AWAITING` 섹션이 미확인 유휴 전이까지 담게 되어 **큐와 그 섹션의 구성원이 정확히 일치**합니다. 사이드바는 이제 선별 처리라는 모드의 존재를 알지 못합니다. 큐 순번 칩과 스테이지 강조는 제거되고, 순서는 캔버스 하단 레일이 전담합니다.
- `idleUnseen` 상태를 사이드바 스토어에서 중립 모듈 `operation-idle-arrival.ts`로 승격했습니다. 기존 코드가 자기 주석으로 남겨 둔 지시("세 번째 비-사이드바 소비자가 생기면 중립 activity 모듈로 승격하라")를 이행한 것입니다.

## 근본 수정 — 확인 판정의 정밀화

큐 자격을 미확인 신호에 그대로 걸면 순환이 생깁니다. 선별 처리는 스테이지 패널을 `setActiveOperation`으로 활성화하는데, 기존 규칙은 활성 Operation의 미확인 표식을 즉시 해제했습니다. 그래서 스테이지에 올리는 순간 자격을 잃고 다음 항목으로 튕겨나갑니다.

호출부마다 예외를 뿌리는 대신 등식을 좁혔습니다.

> `사용자 주도 활성화 = 확인`. 선별 처리 모드 안에서는 시스템이 패널을 올려놓은 것이고, 사용자의 클릭은 "골랐다"가 아니라 "작업 중"이다.

- `setActiveOperation(id, { acknowledged })`로 호출자가 의도를 전달하고, 자동 스테이지 승격만 `acknowledged: false`를 씁니다.
- 중립 모듈이 억제 게이트를 소유하고 선별 처리 진입·이탈이 이를 켜고 끕니다. 모듈은 누가 왜 켜는지 모르며, 의존은 `triage-store → operation-idle-arrival` 단방향입니다.
- 모드 중 arrival이 사라지는 경로는 처리 완료(running/dormant 전이) · dismiss · 모드 종료 셋뿐입니다.

이 게이트가 전역이라, 이후 새로 추가되는 활성화 경로(예: #410의 portaled body 활성화)도 별도 조치 없이 커버됩니다.

## Changelog

`no-changelog` — 이 변경이 고치는 두 동작의 fragment가 **둘 다 아직 미릴리스**입니다.

- `.changelog.d/pr-409.md` (선별 처리 모드)
- `.changelog.d/pr-403.md` (미확인 유휴 신호)

`.changelog.d/AGENTS.md`의 release-baseline 규칙에 따라, 아직 사용자가 소비할 수 없는 동작의 정정은 standalone 항목을 내지 않고 해당 pending fragment에 접습니다. 두 fragment를 이번 PR에서 갱신했고, `pr-409`의 "sidebar ordering / 사이드바 대기열 정렬" 기술은 이번 변경으로 사실이 아니게 되어 함께 정정했습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console build` — green
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 31 failed / 1104 passed / 19 skipped. 실패 목록이 canary 기준선과 동일(`operations-boot-minimization` 27 + i18n 1 + palette 1 + empty-state 1 + server MCP 1), 신규 실패 0
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK, 15 entries
- [x] 전용 축 잔재 정확 매치 0건 (사이드바 · i18n · CSS)
- [x] 신규 계약 테스트: 큐와 `AWAITING` 섹션 구성원 일치 / 자동 승격이 arrival을 소멸시키지 않음(무한 회전 회귀 방지) / 억제 해제 후 사용자 활성화가 다시 소멸시킴 / 상태축 진입 활성화와 종료 복원
- [ ] 격리 콘솔 실측 — 대원수 확인 진행 중