### PR TITLE
feat(console): complete the command palette vocabulary

### DIFF
--- a/.changelog.d/pr-413.md
+++ b/.changelog.d/pr-413.md
@@ -1,0 +1,8 @@
+### fleet-console
+
+#### Added
+
+- [fleet-console] The command palette's command mode now covers session lifecycle verbs: Undo last close appears at the top while the eight-second undo window is live, Add Theater opens the existing folder picker, and each Theater gets a Forget command at the bottom of the list that routes through the same undo window as the sidebar.
+  ko: 커맨드 팔레트의 명령 모드가 세션 생명주기 동사를 포괄합니다. 8초 실행 취소 창이 살아 있는 동안 목록 맨 위에 "마지막 닫기 실행 취소"가 나타나고, "Theater 추가…"는 기존 폴더 선택기를 열며, Theater마다 목록 맨 끝의 "Theater 잊기" 명령이 사이드바와 같은 실행 취소 창을 거칩니다.
+- [fleet-console] Command mode now blends rail panel search results below the command list, so typing a query after the angle bracket reaches Files, Repository, and other panel providers without leaving command mode.
+  ko: 명령 모드가 명령 목록 아래에 rail 패널 검색 결과를 함께 표시합니다. 꺾쇠 뒤에 질의를 입력하면 명령 모드를 벗어나지 않고도 파일·저장소 등 패널 제공자에 닿습니다.

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -202,16 +202,21 @@ export function App() {
       });
   }, []);
 
+  const canUndoLastClose = useCallback(
+    () => pendingDeletionsRef.current.some((deletion) => deletion.expiresAt > Date.now()),
+    [],
+  );
+
   useEffect(() => {
     return installConsoleGlobalShortcuts({
       getSideBarCollapsed: () => getSideBarState().collapsed,
       setSideBarCollapsed,
       toggleOperationSearch,
       toggleRailChrome,
-      canUndoLastClose: () => pendingDeletionsRef.current.some((deletion) => deletion.expiresAt > Date.now()),
+      canUndoLastClose,
       undoLastClose,
     });
-  }, [undoLastClose]);
+  }, [canUndoLastClose, undoLastClose]);
 
   return (
     <div className="console-shell">
@@ -225,7 +230,14 @@ export function App() {
           <Route path="*" element={<Navigate to="/operations" replace />} />
         </Routes>
       </main>
-      <OperationSearch state={state} railPanels={paletteRailPanels} plugins={registry.plugins} onDeferredDeletion={enqueueDeletion} />
+      <OperationSearch
+        state={state}
+        railPanels={paletteRailPanels}
+        plugins={registry.plugins}
+        onDeferredDeletion={enqueueDeletion}
+        canUndoLastClose={canUndoLastClose}
+        onUndoLastClose={undoLastClose}
+      />
       {state.keyboardShortcutsOpen ? <KeyboardShortcutsDialog onClose={closeKeyboardShortcuts} /> : null}
       <WhatsNewModal state={state} />
       <CommissioningOverlay state={state} />

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -82,7 +82,7 @@ export function OperationSearch({
   const entries = useMemo(() => operationSearchEntries(state), [state]);
   const filteredEntries = useMemo(() => filterOperationSearchEntries(entries, query), [entries, query]);
   const groups = useMemo(() => groupOperationSearchEntries(filteredEntries), [filteredEntries]);
-  const undoAvailable = canUndoLastClose?.() === true;
+  const undoAvailable = useMemo(() => canUndoLastClose?.() === true, [state.operationSearchOpen, canUndoLastClose]);
   const commands = useMemo(
     () => buildPaletteCommands(state, railPanels, t, { canUndoLastClose: undoAvailable }),
     [state, railPanels, t, undoAvailable],

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -22,6 +22,7 @@ import {
 } from "../palette-commands.js";
 import { stashKeyboardShortcutsReturnFocus } from "../keyboard-shortcuts-return-focus.js";
 import { closeOperationCompletely } from "../operation-close.js";
+import { forgetTheaterCompletely } from "../theater-forget.js";
 import type { DeferredDeletionReceipt } from "../api.js";
 import { getLoadedTheaterId, ensureDefaultGeometry, forceDropCompanionOperationId, getCompanionOperationId, loadForTheater, minimizeOperations, toggleFormationView } from "../canvas/canvas-store.js";
 import { forgetTriageOperation, isTriageActive, setTriageActive } from "../canvas/triage-store.js";
@@ -35,6 +36,7 @@ import {
   openWhatsNew,
   operationSearchEntries,
   requestOperationLaunchMenu,
+  requestSideBarAddTheater,
   setActiveTheater,
   setActiveTheme,
 } from "../store.js";
@@ -48,6 +50,8 @@ interface OperationSearchProps {
   readonly plugins: readonly FleetClientPlugin[];
   // 팔레트 close도 캔버스·사이드바와 같은 유예 큐에 receipt를 넣어야 Undo가 경로에 상관없이 동작한다.
   readonly onDeferredDeletion?: (deletion: DeferredDeletionReceipt | null) => void;
+  readonly canUndoLastClose?: () => boolean;
+  readonly onUndoLastClose?: () => void;
 }
 
 const FOCUSABLE_SELECTOR = "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])";
@@ -55,7 +59,14 @@ const LISTBOX_ID = "operation-search-listbox";
 const UNASSIGNED_GROUP_KEY = "__unassigned__";
 const COMMAND_GROUP_HEADING_ID = "operation-search-heading-commands";
 
-export function OperationSearch({ state, railPanels, plugins, onDeferredDeletion }: OperationSearchProps) {
+export function OperationSearch({
+  state,
+  railPanels,
+  plugins,
+  onDeferredDeletion,
+  canUndoLastClose,
+  onUndoLastClose,
+}: OperationSearchProps) {
   const t = useT();
   const navigate = useNavigate();
   const location = useLocation();
@@ -71,7 +82,11 @@ export function OperationSearch({ state, railPanels, plugins, onDeferredDeletion
   const entries = useMemo(() => operationSearchEntries(state), [state]);
   const filteredEntries = useMemo(() => filterOperationSearchEntries(entries, query), [entries, query]);
   const groups = useMemo(() => groupOperationSearchEntries(filteredEntries), [filteredEntries]);
-  const commands = useMemo(() => buildPaletteCommands(state, railPanels, t), [state, railPanels, t]);
+  const undoAvailable = canUndoLastClose?.() === true;
+  const commands = useMemo(
+    () => buildPaletteCommands(state, railPanels, t, { canUndoLastClose: undoAvailable }),
+    [state, railPanels, t, undoAvailable],
+  );
   const filteredCommands = useMemo(
     () => (commandMode ? filterPaletteCommands(commands, commandModeQuery(query)) : commands),
     [commandMode, commands, query],
@@ -81,10 +96,19 @@ export function OperationSearch({ state, railPanels, plugins, onDeferredDeletion
     () => railSearchGroups.flatMap((group) => group.results.map((result) => ({ group, result }))),
     [railSearchGroups],
   );
-  const resultCount = commandMode ? filteredCommands.length : filteredEntries.length + railSearchEntries.length;
+  const resultCount = commandMode
+    ? filteredCommands.length + railSearchEntries.length
+    : filteredEntries.length + railSearchEntries.length;
   const clampedSelectedIndex = clampIndex(selectedIndex, resultCount);
   const selectedResultKey = commandMode
-    ? filteredCommands[clampedSelectedIndex] ? commandResultKey(filteredCommands[clampedSelectedIndex]!.commandId) : undefined
+    ? filteredCommands[clampedSelectedIndex]
+      ? commandResultKey(filteredCommands[clampedSelectedIndex]!.commandId)
+      : railSearchEntries[clampedSelectedIndex - filteredCommands.length]
+        ? railResultKey(
+          railSearchEntries[clampedSelectedIndex - filteredCommands.length]!.group.panelId,
+          railSearchEntries[clampedSelectedIndex - filteredCommands.length]!.result.id,
+        )
+        : undefined
     : filteredEntries[clampedSelectedIndex]
       ? operationResultKey(filteredEntries[clampedSelectedIndex]!.operationId)
       : railSearchEntries[clampedSelectedIndex - filteredEntries.length]
@@ -101,11 +125,12 @@ export function OperationSearch({ state, railPanels, plugins, onDeferredDeletion
     const generation = ++searchGenerationRef.current;
     setRailSearchGroups([]);
     const theaterId = state.activeTheaterId;
-    if (!state.operationSearchOpen || commandMode || query.trim() === "" || !theaterId) return;
+    const effectiveQuery = commandMode ? commandModeQuery(query) : query;
+    if (!state.operationSearchOpen || effectiveQuery.trim() === "" || !theaterId) return;
 
     const abort = new AbortController();
     const timer = window.setTimeout(() => {
-      void searchRailPanels(railPanels, query, theaterId, abort.signal).then((nextGroups) => {
+      void searchRailPanels(railPanels, effectiveQuery, theaterId, abort.signal).then((nextGroups) => {
         // provider가 abort를 무시해도 이전 세대 결과는 현재 팔레트에 반영하지 않는다.
         if (abort.signal.aborted || generation !== searchGenerationRef.current) return;
         setRailSearchGroups(nextGroups);
@@ -171,12 +196,24 @@ export function OperationSearch({ state, railPanels, plugins, onDeferredDeletion
   const runCommand = (command: PaletteCommandEntry) => {
     const action = command.action;
     switch (action.kind) {
+      case "undo-close": {
+        previousFocusRef.current = null;
+        if (canUndoLastClose?.()) onUndoLastClose?.();
+        break;
+      }
       case "switch-theater": {
         if (command.current) break;
         // Theater 전환은 캔버스로 포커스 문맥을 넘기므로 selectEntry처럼 이전 포커스 복원을 억제한다.
         previousFocusRef.current = null;
         setActiveTheater(action.theaterId);
         navigate("/operations");
+        break;
+      }
+      case "new-theater": {
+        previousFocusRef.current = null;
+        if (!location.pathname.startsWith("/operations")) navigate("/operations");
+        if (getSideBarState().collapsed) setSideBarCollapsed(false);
+        requestSideBarAddTheater();
         break;
       }
       case "new-operation": {
@@ -303,6 +340,10 @@ export function OperationSearch({ state, railPanels, plugins, onDeferredDeletion
         openWhatsNew();
         break;
       }
+      case "forget-theater": {
+        void forgetTheaterCompletely(action.theaterId).then(onDeferredDeletion);
+        break;
+      }
     }
     closeOperationSearch();
   };
@@ -321,9 +362,15 @@ export function OperationSearch({ state, railPanels, plugins, onDeferredDeletion
     if (event.key === "Enter") {
       if (commandMode) {
         const selected = filteredCommands[clampedSelectedIndex];
-        if (!selected) return;
+        if (selected) {
+          event.preventDefault();
+          runCommand(selected);
+          return;
+        }
+        const panelEntry = railSearchEntries[clampedSelectedIndex - filteredCommands.length];
+        if (!panelEntry) return;
         event.preventDefault();
-        runCommand(selected);
+        void selectRailResult(panelEntry.group.panelId, panelEntry.result);
         return;
       }
       const selected = filteredEntries[clampedSelectedIndex];
@@ -374,37 +421,76 @@ export function OperationSearch({ state, railPanels, plugins, onDeferredDeletion
           <kbd>esc</kbd>
         </div>
         <div id={LISTBOX_ID} className="operation-search-results" role="listbox" aria-label={commandMode ? t("chrome.operationSearch.commandResults") : t("chrome.operationSearch.operationResults")}>
-          {commandMode ? (filteredCommands.length > 0 ? (
-            <section className="operation-search-section" role="group" aria-labelledby={COMMAND_GROUP_HEADING_ID}>
-              <h2 id={COMMAND_GROUP_HEADING_ID} className="operation-search-section-heading">{t("chrome.operationSearch.commands")}</h2>
-              {filteredCommands.map((command, index) => {
-                const active = index === clampedSelectedIndex;
-                const resultKey = commandResultKey(command.commandId);
+          {commandMode ? (
+            filteredCommands.length > 0 || railSearchGroups.length > 0 ? <>
+              {filteredCommands.length > 0 ? (
+                <section className="operation-search-section" role="group" aria-labelledby={COMMAND_GROUP_HEADING_ID}>
+                  <h2 id={COMMAND_GROUP_HEADING_ID} className="operation-search-section-heading">{t("chrome.operationSearch.commands")}</h2>
+                  {filteredCommands.map((command, index) => {
+                    const active = index === clampedSelectedIndex;
+                    const resultKey = commandResultKey(command.commandId);
+                    return (
+                      <button
+                        id={commandOptionId(command.commandId)}
+                        key={command.commandId}
+                        ref={(node) => {
+                          if (node) resultRefs.current.set(resultKey, node);
+                          else resultRefs.current.delete(resultKey);
+                        }}
+                        type="button"
+                        className={`operation-search-result ${active ? "is-active" : ""}`}
+                        role="option"
+                        aria-selected={active}
+                        onMouseEnter={() => setSelectedIndex(index)}
+                        onClick={() => runCommand(command)}
+                      >
+                        <span className="operation-search-command-glyph" aria-hidden="true">›</span>
+                        <span className="operation-search-result-text">
+                          <strong>{highlightText(command.label, tokens)}</strong>
+                        </span>
+                        {command.current ? <span className="operation-search-theater">{t("chrome.operationSearch.current")}</span> : null}
+                      </button>
+                    );
+                  })}
+                </section>
+              ) : null}
+              {railSearchGroups.map((group) => {
+                const headingId = railGroupHeadingId(group.panelId);
                 return (
-                  <button
-                    id={commandOptionId(command.commandId)}
-                    key={command.commandId}
-                    ref={(node) => {
-                      if (node) resultRefs.current.set(resultKey, node);
-                      else resultRefs.current.delete(resultKey);
-                    }}
-                    type="button"
-                    className={`operation-search-result ${active ? "is-active" : ""}`}
-                    role="option"
-                    aria-selected={active}
-                    onMouseEnter={() => setSelectedIndex(index)}
-                    onClick={() => runCommand(command)}
-                  >
-                    <span className="operation-search-command-glyph" aria-hidden="true">›</span>
-                    <span className="operation-search-result-text">
-                      <strong>{highlightText(command.label, tokens)}</strong>
-                    </span>
-                    {command.current ? <span className="operation-search-theater">{t("chrome.operationSearch.current")}</span> : null}
-                  </button>
+                  <section className="operation-search-section operation-search-panel-section" key={group.panelId} role="group" aria-labelledby={headingId}>
+                    <h2 id={headingId} className="operation-search-section-heading">{group.panelTitle}</h2>
+                    {group.results.map((result) => {
+                      const index = filteredCommands.length + railSearchEntries.findIndex((entry) => entry.group.panelId === group.panelId && entry.result === result);
+                      const active = index === clampedSelectedIndex;
+                      const resultKey = railResultKey(group.panelId, result.id);
+                      return (
+                        <button
+                          id={resultOptionId(resultKey)}
+                          key={result.id}
+                          ref={(node) => {
+                            if (node) resultRefs.current.set(resultKey, node);
+                            else resultRefs.current.delete(resultKey);
+                          }}
+                          type="button"
+                          className={`operation-search-result operation-search-panel-result ${active ? "is-active" : ""}`}
+                          role="option"
+                          aria-selected={active}
+                          onMouseEnter={() => setSelectedIndex(index)}
+                          onClick={() => { void selectRailResult(group.panelId, result); }}
+                        >
+                          <span className="operation-search-result-text">
+                            <strong>{highlightText(result.title, tokens)}</strong>
+                            {result.subtitle ? <small>{highlightText(result.subtitle, tokens)}</small> : null}
+                          </span>
+                          <span className="operation-search-panel-open">{t("chrome.operationSearch.open")}</span>
+                        </button>
+                      );
+                    })}
+                  </section>
                 );
               })}
-            </section>
-          ) : <p className="operation-search-empty">{t("chrome.operationSearch.noMatchingCommands")}</p>) : (
+            </> : <p className="operation-search-empty">{t("chrome.operationSearch.noMatchingCommands")}</p>
+          ) : (
             groups.length > 0 || railSearchGroups.length > 0 ? <>
               {groups.map((group) => {
                 const headingId = operationGroupHeadingId(group.theaterId);

--- a/runtime/fleet-console/core/client/src/i18n/messages/pages.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/pages.ts
@@ -81,7 +81,9 @@ export const pagesEn = {
   "palette.theme.instrument": "Instrument",
   "palette.theme.maritime": "Maritime",
   "palette.theme.carbon": "Carbon",
+  "palette.undoClose": "Undo last close",
   "palette.switchTheater": "Switch theater: {label}",
+  "palette.newTheater": "Add Theater…",
   "palette.newOperation": "New Operation in {label}",
   "palette.resumeOperation": "Resume operation: {title}",
   "palette.closeOperation": "Close operation: {title}",
@@ -100,6 +102,7 @@ export const pagesEn = {
   "palette.openSettings": "Open Settings",
   "palette.openKeyboardShortcuts": "Open keyboard shortcuts",
   "palette.whatsNew": "What's new",
+  "palette.forgetTheater": "Forget Theater: {label}",
 
   // shortcuts
   "shortcuts.group.console": "Console",
@@ -354,7 +357,9 @@ export const pagesKo: Record<keyof typeof pagesEn, string> = {
   "palette.theme.instrument": "Instrument",
   "palette.theme.maritime": "Maritime",
   "palette.theme.carbon": "Carbon",
+  "palette.undoClose": "마지막 닫기 실행 취소",
   "palette.switchTheater": "Theater 전환: {label}",
+  "palette.newTheater": "Theater 추가…",
   "palette.newOperation": "{label}에서 새 Operation",
   "palette.resumeOperation": "Operation 재개: {title}",
   "palette.closeOperation": "Operation 닫기: {title}",
@@ -373,6 +378,7 @@ export const pagesKo: Record<keyof typeof pagesEn, string> = {
   "palette.openSettings": "설정 열기",
   "palette.openKeyboardShortcuts": "키보드 단축키 열기",
   "palette.whatsNew": "새로운 기능",
+  "palette.forgetTheater": "Theater 잊기: {label}",
 
   "shortcuts.group.console": "Console",
   "shortcuts.console.searchOps": "Theater 전체에서 Operation 검색",

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -4,13 +4,14 @@ import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console
 import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 import type { ClientApiCapability, FleetClientPlugin, OperationKindDescriptor } from "@fleet-console/sdk/plugin";
 
-import { addTheater, createGroup, deleteGroup, fetchGroups, fetchOperations, fetchTheaters, forgetTheater, issueTheaterFolderGrant, patchOperation, patchTheaterOrder, renameOperation, updateGroup, ApiError, type DeferredDeletionReceipt } from "../api.js";
+import { addTheater, createGroup, deleteGroup, fetchGroups, fetchOperations, fetchTheaters, issueTheaterFolderGrant, patchOperation, patchTheaterOrder, renameOperation, updateGroup, ApiError, type DeferredDeletionReceipt } from "../api.js";
 import { closeOperationCompletely } from "../operation-close.js";
+import { forgetTheaterCompletely } from "../theater-forget.js";
 import { claimTopZIndex, ensureDefaultGeometry, focusOperation as focusCanvasOperation, forceDropCompanionOperationId, getCompanionOperationId, getFocusLayerRevision, getFormationView, getLoadedTheaterId, getMaximizedOperationId, getSnapshot as getCanvasSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, minimizeOperations, pruneOperations, restoreOperation, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, toggleFormationView, useCompanionOperationId, useFormationView, useMaximizedOperationId, useMinimized, type OperationGeometry } from "../canvas/canvas-store.js";
 import { screenToCanvas, type CanvasPoint } from "../canvas/coordinates.js";
 import { playMinimizeFlight, playRestoreFlight } from "../canvas/panel-motion.js";
 import { OperationsCanvas } from "../canvas/canvas.js";
-import { deferTriageOperation, dismissTriageOperation, focusedTriageOperationId, forgetTriageOperation, isTriageActive, pickTriageOperation, recordTriageActivity, resetTriageTheater, resolveTriageQueue, setTriageActive } from "../canvas/triage-store.js";
+import { deferTriageOperation, dismissTriageOperation, focusedTriageOperationId, forgetTriageOperation, isTriageActive, pickTriageOperation, recordTriageActivity, resolveTriageQueue, setTriageActive } from "../canvas/triage-store.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { RightRail } from "../rail/right-rail.js";
@@ -20,7 +21,7 @@ import { CodexReadingSheet } from "../components/codex-reading-sheet.js";
 import { useGlobalSettingsStore } from "../global-settings-store.js";
 import { shouldHandleOperationsKeyboardShortcut } from "../components/keyboard-shortcuts-dialog.js";
 import { resolveOperationsArrowShortcutAction } from "../operations-arrow-shortcut.js";
-import { beginAddTheater, cancelAddTheater, compareOperationCreatedAt, completeAddTheater, consumeOperationFocus, failAddTheater, focusCycleOperationIds, focusOperation, getState, hydrateGroups, hydrateOperations, hydrateTheaters, nextOperationId, removeTheater, requestOperationKeyboardFocus, setActiveOperation, setActiveTheater, sortOperationsByOrder } from "../store.js";
+import { beginAddTheater, cancelAddTheater, compareOperationCreatedAt, completeAddTheater, consumeOperationFocus, failAddTheater, focusCycleOperationIds, focusOperation, getState, hydrateGroups, hydrateOperations, hydrateTheaters, nextOperationId, requestOperationKeyboardFocus, setActiveOperation, setActiveTheater, sortOperationsByOrder } from "../store.js";
 import type { ConsoleState, OperationNode } from "../types.js";
 import { MobileShell } from "../mobile/mobile-shell.js";
 import { OperationBodyPool, type OperationBodyConfig } from "../mobile/operation-body-pool.js";
@@ -396,21 +397,7 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
   }, []);
 
   const handleForgetTheater = useCallback(async (theaterId: string) => {
-    // 서버는 Theater 삭제 시 소속 Operation/Group 레코드도 정리한다 — 로컬 목록만 지우면
-    // stale 패널이 퀵서치 등에 남으므로(Codex P2) 두 컬렉션을 재수화한다.
-    const refreshCollections = () => Promise.all([
-      fetchOperations(null).then(hydrateOperations),
-      fetchGroups(null).then(hydrateGroups),
-    ]).then(() => {}).catch(() => {});
-    try {
-      const response = await forgetTheater(theaterId);
-      resetTriageTheater(theaterId);
-      removeTheater(theaterId);
-      await refreshCollections();
-      onDeferredDeletion(response.deletion);
-    } catch (error) {
-      failAddTheater(error instanceof Error ? error.message : String(error));
-    }
+    onDeferredDeletion(await forgetTheaterCompletely(theaterId));
   }, [onDeferredDeletion]);
 
   const shell = viewMode.effective === "mobile" ? (

--- a/runtime/fleet-console/core/client/src/palette-commands.ts
+++ b/runtime/fleet-console/core/client/src/palette-commands.ts
@@ -14,7 +14,9 @@ export interface PaletteRailPanelInfo {
 }
 
 export type PaletteCommandAction =
+  | { readonly kind: "undo-close" }
   | { readonly kind: "switch-theater"; readonly theaterId: string }
+  | { readonly kind: "new-theater" }
   | { readonly kind: "new-operation" }
   | { readonly kind: "resume-operation"; readonly operationId: string }
   | { readonly kind: "close-operation"; readonly operationId: string }
@@ -32,7 +34,8 @@ export type PaletteCommandAction =
   | { readonly kind: "assign-operation-group"; readonly operationId: string }
   | { readonly kind: "set-operation-accent"; readonly operationId: string }
   | { readonly kind: "minimize-operation"; readonly operationId: string }
-  | { readonly kind: "whats-new" };
+  | { readonly kind: "whats-new" }
+  | { readonly kind: "forget-theater"; readonly theaterId: string };
 
 export interface PaletteCommandEntry {
   readonly commandId: string;
@@ -63,6 +66,7 @@ export function buildPaletteCommands(
   current: ConsoleState,
   railPanels: readonly PaletteRailPanelInfo[],
   t: T,
+  options?: { readonly canUndoLastClose?: boolean },
 ): readonly PaletteCommandEntry[] {
   const commands: PaletteCommandEntry[] = [];
   const language = resolveActiveLocale();
@@ -70,6 +74,14 @@ export function buildPaletteCommands(
   const activeOperation = current.operations.find(
     (operation) => operation.id === current.activeOperationId && operation.theaterId === current.activeTheaterId,
   ) ?? null;
+  if (options?.canUndoLastClose === true) {
+    commands.push({
+      commandId: "undo-close",
+      label: t("palette.undoClose"),
+      current: false,
+      action: { kind: "undo-close" },
+    });
+  }
   for (const theater of current.theaters) {
     commands.push({
       commandId: `switch-theater:${theater.id}`,
@@ -78,6 +90,12 @@ export function buildPaletteCommands(
       action: { kind: "switch-theater", theaterId: theater.id },
     });
   }
+  commands.push({
+    commandId: "new-theater",
+    label: t("palette.newTheater"),
+    current: false,
+    action: { kind: "new-theater" },
+  });
   if (activeTheater) {
     commands.push({
       commandId: "new-operation",
@@ -205,6 +223,14 @@ export function buildPaletteCommands(
       label: t("palette.whatsNew"),
       current: false,
       action: { kind: "whats-new" },
+    });
+  }
+  for (const theater of current.theaters) {
+    commands.push({
+      commandId: `forget-theater:${theater.id}`,
+      label: t("palette.forgetTheater", { label: theater.label }),
+      current: false,
+      action: { kind: "forget-theater", theaterId: theater.id },
     });
   }
   return commands;

--- a/runtime/fleet-console/core/client/src/theater-forget.ts
+++ b/runtime/fleet-console/core/client/src/theater-forget.ts
@@ -1,0 +1,34 @@
+import {
+  fetchGroups,
+  fetchOperations,
+  forgetTheater,
+  type DeferredDeletionReceipt,
+} from "./api.js";
+import { resetTriageTheater } from "./canvas/triage-store.js";
+import {
+  failAddTheater,
+  hydrateGroups,
+  hydrateOperations,
+  removeTheater,
+} from "./store.js";
+
+// Theater 잊기의 단일 경로: host DELETE → 로컬 Theater/triage 정리 → 소속 컬렉션 재수화.
+// Operations 사이드바와 팔레트 명령이 공유하며, receipt는 App의 8초 undo 큐로 전달한다.
+export async function forgetTheaterCompletely(
+  theaterId: string,
+): Promise<DeferredDeletionReceipt | null> {
+  try {
+    const response = await forgetTheater(theaterId);
+    resetTriageTheater(theaterId);
+    removeTheater(theaterId);
+    // 재수화 실패는 삼킨다 — 서버 forget이 이미 성공했으므로 receipt(undo 경로)는 보존해야 한다.
+    await Promise.all([
+      fetchOperations(null).then(hydrateOperations),
+      fetchGroups(null).then(hydrateGroups),
+    ]).catch(() => {});
+    return response.deletion;
+  } catch (error) {
+    failAddTheater(error instanceof Error ? error.message : String(error));
+    return null;
+  }
+}

--- a/runtime/fleet-console/tests/operation-search-focus.test.tsx
+++ b/runtime/fleet-console/tests/operation-search-focus.test.tsx
@@ -8,12 +8,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { OperationSearch } from "../core/client/src/components/operation-search.js";
 import { takeKeyboardShortcutsReturnFocus } from "../core/client/src/keyboard-shortcuts-return-focus.js";
 import { useConsoleState } from "../core/client/src/hooks/use-store.js";
-import { setState } from "../core/client/src/store.js";
+import { getSideBarState, setSideBarCollapsed } from "../core/client/src/sidebar/operations-side-bar-store.js";
+import { getState, setState } from "../core/client/src/store.js";
 
 let container: HTMLDivElement | null = null;
 let previousFocus: HTMLButtonElement | null = null;
 let root: Root | null = null;
 let scrollIntoViewDescriptor: PropertyDescriptor | undefined;
+let canUndoLastClose = false;
+let onUndoLastClose = vi.fn();
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -22,6 +25,9 @@ beforeEach(() => {
   window.localStorage.clear();
   scrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollIntoView");
   Object.defineProperty(HTMLElement.prototype, "scrollIntoView", { configurable: true, value: vi.fn() });
+  canUndoLastClose = false;
+  onUndoLastClose = vi.fn();
+  setSideBarCollapsed(false);
 
   previousFocus = document.createElement("button");
   previousFocus.textContent = "Previous control";
@@ -133,6 +139,49 @@ describe("Operation search focus handoff", () => {
     expect(document.querySelector('[role="dialog"]')).toBeNull();
   });
 
+  it("rechecks Undo availability at execution time before invoking the callback", () => {
+    canUndoLastClose = true;
+    act(() => root!.render(createElement(MemoryRouter, null, createElement(SearchHarness))));
+    const input = document.querySelector<HTMLInputElement>("#operation-search-input");
+    const setInputValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+    act(() => {
+      setInputValue.call(input, ">undo");
+      input!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    const commandOption = document.querySelector<HTMLButtonElement>('[role="option"]');
+    expect(commandOption?.textContent).toContain("Undo last close");
+
+    canUndoLastClose = false;
+    act(() => commandOption!.click());
+
+    expect(onUndoLastClose).not.toHaveBeenCalled();
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it("routes to Operations, expands the sidebar, and requests the Add Theater flow", () => {
+    setSideBarCollapsed(true);
+    act(() => root!.render(createElement(
+      MemoryRouter,
+      { key: "add-theater-route", initialEntries: ["/settings"] },
+      createElement(SearchHarness),
+      createElement(LocationProbe),
+    )));
+    const input = document.querySelector<HTMLInputElement>("#operation-search-input");
+    const setInputValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+    act(() => {
+      setInputValue.call(input, ">add theater");
+      input!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const commandOption = document.querySelector<HTMLButtonElement>('[role="option"]');
+    expect(commandOption?.textContent).toContain("Add Theater…");
+    act(() => commandOption!.click());
+
+    expect(observedPathname).toBe("/operations");
+    expect(getSideBarState().collapsed).toBe(false);
+    expect(getState().pendingSideBarAddTheater).toBe(true);
+  });
+
   it("restores the previous focus after Escape cancellation", () => {
     const restoreFocus = vi.spyOn(previousFocus!, "focus");
     const input = document.querySelector<HTMLInputElement>("#operation-search-input");
@@ -147,7 +196,13 @@ describe("Operation search focus handoff", () => {
 });
 
 function SearchHarness() {
-  return createElement(OperationSearch, { state: useConsoleState(), railPanels: [{ id: "alerts", title: "Alerts" }], plugins: [] });
+  return createElement(OperationSearch, {
+    state: useConsoleState(),
+    railPanels: [{ id: "alerts", title: "Alerts" }],
+    plugins: [],
+    canUndoLastClose: () => canUndoLastClose,
+    onUndoLastClose,
+  });
 }
 
 let observedPathname = "";

--- a/runtime/fleet-console/tests/operation-search-focus.test.tsx
+++ b/runtime/fleet-console/tests/operation-search-focus.test.tsx
@@ -17,6 +17,7 @@ let root: Root | null = null;
 let scrollIntoViewDescriptor: PropertyDescriptor | undefined;
 let canUndoLastClose = false;
 let onUndoLastClose = vi.fn();
+const readCanUndoLastClose = () => canUndoLastClose;
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -139,9 +140,10 @@ describe("Operation search focus handoff", () => {
     expect(document.querySelector('[role="dialog"]')).toBeNull();
   });
 
-  it("rechecks Undo availability at execution time before invoking the callback", () => {
+  it("keeps the opening-time Undo row snapshot while rechecking availability at execution time", () => {
+    act(() => setState({ operationSearchOpen: false }));
     canUndoLastClose = true;
-    act(() => root!.render(createElement(MemoryRouter, null, createElement(SearchHarness))));
+    act(() => setState({ operationSearchOpen: true }));
     const input = document.querySelector<HTMLInputElement>("#operation-search-input");
     const setInputValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
     act(() => {
@@ -152,7 +154,10 @@ describe("Operation search focus handoff", () => {
     expect(commandOption?.textContent).toContain("Undo last close");
 
     canUndoLastClose = false;
-    act(() => commandOption!.click());
+    act(() => root!.render(createElement(MemoryRouter, null, createElement(SearchHarness))));
+    const retainedCommandOption = document.querySelector<HTMLButtonElement>('[role="option"]');
+    expect(retainedCommandOption?.textContent).toContain("Undo last close");
+    act(() => input!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })));
 
     expect(onUndoLastClose).not.toHaveBeenCalled();
     expect(document.querySelector('[role="dialog"]')).toBeNull();
@@ -200,7 +205,7 @@ function SearchHarness() {
     state: useConsoleState(),
     railPanels: [{ id: "alerts", title: "Alerts" }],
     plugins: [],
-    canUndoLastClose: () => canUndoLastClose,
+    canUndoLastClose: readCanUndoLastClose,
     onUndoLastClose,
   });
 }

--- a/runtime/fleet-console/tests/palette-commands.test.ts
+++ b/runtime/fleet-console/tests/palette-commands.test.ts
@@ -105,7 +105,9 @@ describe("buildPaletteCommands", () => {
     expect(commands.map((command) => command.commandId)).toEqual([
       "switch-theater:theater-alpha",
       "switch-theater:theater-beta",
+      "new-theater",
       "new-operation",
+      "toggle-triage-mode",
       "toggle-formation",
       "toggle-status-axis",
       "open-rail-panel:alerts",
@@ -117,9 +119,32 @@ describe("buildPaletteCommands", () => {
       "switch-theme:carbon",
       "open-settings",
       "open-keyboard-shortcuts",
+      "forget-theater:theater-alpha",
+      "forget-theater:theater-beta",
     ]);
+    expect(commands.find((command) => command.commandId === "new-theater")?.label).toBe("Add Theater…");
     expect(commands.find((command) => command.commandId === "new-operation")?.label).toBe("New Operation in Alpha Harbor");
     expect(commands.find((command) => command.commandId === "open-rail-panel:repository")?.label).toBe("Open panel: Repository");
+    expect(commands.find((command) => command.commandId === "forget-theater:theater-alpha")?.label)
+      .toBe("Forget Theater: Alpha Harbor");
+  });
+
+  it("gates Undo last close and preserves the approved safe-to-destructive ordering", () => {
+    const unavailable = buildPaletteCommands(makeState(), [], tEn);
+    expect(unavailable.some((command) => command.commandId === "undo-close")).toBe(false);
+
+    const commands = buildPaletteCommands(makeState({
+      releaseNotes: [{ version: "1.30.0", date: "2026-07-20", sections: [], localizationFallback: false }],
+    }), [], tEn, { canUndoLastClose: true });
+    const ids = commands.map((command) => command.commandId);
+    expect(ids[0]).toBe("undo-close");
+    expect(commands[0]?.label).toBe("Undo last close");
+    expect(ids.indexOf("new-theater")).toBe(ids.indexOf("switch-theater:theater-beta") + 1);
+    expect(ids.slice(-3)).toEqual([
+      "whats-new",
+      "forget-theater:theater-alpha",
+      "forget-theater:theater-beta",
+    ]);
   });
 
   it("marks the active Theater and active theme as current", () => {

--- a/runtime/fleet-console/tests/rail-search.test.tsx
+++ b/runtime/fleet-console/tests/rail-search.test.tsx
@@ -87,7 +87,7 @@ describe("rail search fan-out", () => {
     expect(slow.mock.calls[0]?.[0].signal.aborted).toBe(true);
   });
 
-  it("does not fan out for an empty query, missing Theater, or command mode", async () => {
+  it("does not fan out for an empty query, bare command mode, or a missing Theater", async () => {
     const provider = vi.fn<RailSearchProvider>(async () => []);
     panels = [panel("files", "Files", provider)];
     renderPalette();
@@ -95,7 +95,7 @@ describe("rail search fan-out", () => {
     await advanceDebounce();
     expect(provider).not.toHaveBeenCalled();
 
-    setInput(">open panel");
+    setInput(">");
     await advanceDebounce();
     expect(provider).not.toHaveBeenCalled();
 
@@ -103,6 +103,36 @@ describe("rail search fan-out", () => {
     setInput("needle");
     await advanceDebounce();
     expect(provider).not.toHaveBeenCalled();
+  });
+
+  it("mixes rail matches after commands in command mode and selects them with the shared index", async () => {
+    const activate = vi.fn();
+    const provider = vi.fn<RailSearchProvider>(async ({ query }) => {
+      expect(query).toBe("plan");
+      return [result("plan-a", "Plan A", activate)];
+    });
+    panels = [panel("plans", "Plans", provider)];
+    renderPalette();
+
+    setInput(">plan");
+    await advanceDebounce();
+
+    const headings = [...container.querySelectorAll(".operation-search-section-heading")].map((node) => node.textContent);
+    expect(headings).toEqual(["Commands", "Plans"]);
+    const options = [...container.querySelectorAll<HTMLButtonElement>('[role="option"]')];
+    expect(options.map((option) => option.textContent)).toEqual([
+      expect.stringContaining("Open panel: Plans"),
+      expect.stringContaining("Plan A"),
+    ]);
+
+    const input = container.querySelector<HTMLInputElement>("#operation-search-input");
+    act(() => input!.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true })));
+    expect(options[1]?.getAttribute("aria-selected")).toBe("true");
+    await act(async () => {
+      input!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+    expect(activate).toHaveBeenCalledOnce();
   });
 
   it("debounces providers and discards a response that arrives after abort via the generation fence", async () => {

--- a/runtime/fleet-console/tests/rail-search.test.tsx
+++ b/runtime/fleet-console/tests/rail-search.test.tsx
@@ -128,6 +128,8 @@ describe("rail search fan-out", () => {
     const input = container.querySelector<HTMLInputElement>("#operation-search-input");
     act(() => input!.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true })));
     expect(options[1]?.getAttribute("aria-selected")).toBe("true");
+    expect(input?.getAttribute("aria-activedescendant")).toBe("operation-search-option-panel-plans-plan-a");
+    expect(input?.getAttribute("aria-activedescendant")).toBe(options[1]?.id);
     await act(async () => {
       input!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
       await Promise.resolve();

--- a/runtime/fleet-console/tests/theater-forget.test.ts
+++ b/runtime/fleet-console/tests/theater-forget.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  failAddTheater: vi.fn(),
+  fetchGroups: vi.fn(),
+  fetchOperations: vi.fn(),
+  forgetTheater: vi.fn(),
+  hydrateGroups: vi.fn(),
+  hydrateOperations: vi.fn(),
+  removeTheater: vi.fn(),
+  resetTriageTheater: vi.fn(),
+}));
+
+vi.mock("../core/client/src/api.js", () => ({
+  fetchGroups: mocks.fetchGroups,
+  fetchOperations: mocks.fetchOperations,
+  forgetTheater: mocks.forgetTheater,
+}));
+
+vi.mock("../core/client/src/canvas/triage-store.js", () => ({
+  resetTriageTheater: mocks.resetTriageTheater,
+}));
+
+vi.mock("../core/client/src/store.js", () => ({
+  failAddTheater: mocks.failAddTheater,
+  hydrateGroups: mocks.hydrateGroups,
+  hydrateOperations: mocks.hydrateOperations,
+  removeTheater: mocks.removeTheater,
+}));
+
+import { forgetTheaterCompletely } from "../core/client/src/theater-forget.js";
+
+const RECEIPT = {
+  deletionId: "deletion-theater-a",
+  kind: "theater",
+  targetId: "theater-a",
+  expiresAt: 12_345,
+} as const;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.fetchOperations.mockResolvedValue([]);
+  mocks.fetchGroups.mockResolvedValue([]);
+  mocks.forgetTheater.mockResolvedValue({ ok: true, deletion: RECEIPT });
+});
+
+describe("forgetTheaterCompletely", () => {
+  it("returns the receipt and clears triage and local Theater state after a successful forget", async () => {
+    await expect(forgetTheaterCompletely("theater-a")).resolves.toEqual(RECEIPT);
+
+    expect(mocks.forgetTheater).toHaveBeenCalledWith("theater-a");
+    expect(mocks.resetTriageTheater).toHaveBeenCalledWith("theater-a");
+    expect(mocks.removeTheater).toHaveBeenCalledWith("theater-a");
+    expect(mocks.fetchOperations).toHaveBeenCalledWith(null);
+    expect(mocks.fetchGroups).toHaveBeenCalledWith(null);
+    expect(mocks.hydrateOperations).toHaveBeenCalledWith([]);
+    expect(mocks.hydrateGroups).toHaveBeenCalledWith([]);
+  });
+
+  it("reports an API failure and returns null", async () => {
+    mocks.forgetTheater.mockRejectedValue(new Error("forget failed"));
+
+    await expect(forgetTheaterCompletely("theater-a")).resolves.toBeNull();
+
+    expect(mocks.failAddTheater).toHaveBeenCalledWith("forget failed");
+    expect(mocks.resetTriageTheater).not.toHaveBeenCalled();
+    expect(mocks.removeTheater).not.toHaveBeenCalled();
+  });
+
+  it("preserves the receipt when collection rehydration fails", async () => {
+    mocks.fetchOperations.mockRejectedValue(new Error("refresh failed"));
+
+    await expect(forgetTheaterCompletely("theater-a")).resolves.toEqual(RECEIPT);
+
+    expect(mocks.resetTriageTheater).toHaveBeenCalledWith("theater-a");
+    expect(mocks.removeTheater).toHaveBeenCalledWith("theater-a");
+    expect(mocks.failAddTheater).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- 커맨드 팔레트(`>`)에 생명주기 명령 3종을 추가합니다: **Undo last close**(8초 유예 창이 살아 있을 때만, 목록 맨 앞), **Add Theater…**(사이드바 Add Theater 플로 재사용), **Forget Theater: {label}**(Theater별, 목록 맨 끝, 8초 undo 유예 경유).
- 커맨드 모드에서도 rail 패널 검색 결과를 명령 섹션 뒤에 혼합 표시합니다(`> readme` → 파일/저장소 결과). bare `>`에서는 rail 잡음을 내지 않습니다.
- Forget 로직을 `theater-forget.ts` 단일 헬퍼로 추출해 사이드바와 팔레트가 공유합니다(receipt는 재수화 완료 후 전달 — 기존 순서 보존).
- Undo 가용성은 팔레트 열림 시점에 고정해 8초 만료가 열림 중 선택 인덱스를 밀지 않게 하고, 실행 시 재확인 가드로 만료 레이스를 막습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` green (typecheck의 tests/server.test.ts TS2741은 순정 canary 선존 실패)
- [x] 집중 스위트 5개(palette-commands·operation-search-focus·rail-search·theater-forget·instrument-design-contract) 52 tests green
- [x] 격리 콘솔 헤디드 검증: 신규 행 순서 / 닫기→undo 명령 복원 / `> readme` rail 혼합 / Add Theater→directory-browser / Forget→토스트→undo 완전 복원
- [x] Changelog: `.changelog.d/pr-413.md` 추가 — 그룹형 문법·영/한 요약 인접·`compile-changelog-fragments.mjs --check` 통과