### PR TITLE
feat(console): surface console link loss across the chrome

### DIFF
--- a/.changelog.d/pr-416.md
+++ b/.changelog.d/pr-416.md
@@ -1,0 +1,6 @@
+### fleet-console
+#### Added
+- [fleet-console] The console now reports a lost server link on the command band, in a banner pinning the time values stopped updating, and over rail panels whose values are frozen, each offering to reconnect.
+  ko: 콘솔이 서버 연결이 끊긴 사실을 command band와, 값이 멈춘 시각을 고정한 배너와, 갱신이 멈춘 레일 패널 위에서 알리고 각각 다시 연결할 수 있게 합니다.
+- [fleet-console] While that overlay covers a rail panel, its contents stay out of the keyboard tab order and focus moves to the reconnect control, returning once the link is live.
+  ko: 그 덮개가 레일 패널을 가리는 동안에는 패널 내용이 키보드 탐색에서 빠지고 포커스가 다시 연결 컨트롤로 옮겨가며, 연결이 살아나면 원래 자리로 돌아옵니다.

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -20,7 +20,7 @@ import { GlobalSettings } from "./pages/global-settings.js";
 import { Operations } from "./pages/operations.js";
 import { BUILT_IN_RAIL_PANELS } from "./rail/built-in-panels.js";
 import { toggleRailChrome } from "./rail/rail-store.js";
-import { refreshObserverStatus } from "./operations-sse.js";
+import { reconnectOperationsSseNow, refreshObserverStatus } from "./operations-sse.js";
 import { closeKeyboardShortcuts, hydrateGroups, hydrateInitialOperations, hydrateOperations, hydrateTheaterBootstrap, hydrateTheaters, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
 import { abortReleaseNotesFetch, requestReleaseNotes } from "./release-notes-fetch.js";
 import { getSideBarState, setSideBarCollapsed, subscribeOperationActivityTracking } from "./sidebar/operations-side-bar-store.js";
@@ -48,6 +48,9 @@ export function App() {
   const t = useT();
   const consoleLocale = useConsoleLocale();
   const releaseNotesLocale = resolveReleaseNotesLocale(globalSettings.state?.language ?? "auto");
+  const connectionLostTime = state.connectionLostAt === null
+    ? ""
+    : new Date(state.connectionLostAt).toLocaleTimeString(consoleLocale);
 
   useEffect(() => {
     document.documentElement.lang = consoleLocale;
@@ -216,6 +219,12 @@ export function App() {
   return (
     <div className="console-shell">
       <CommandBand operationsViewVisible={operationsViewVisible} />
+      {state.connection === "offline" ? (
+        <div className="console-link-banner" role="status" aria-live="polite">
+          <span>{t("chrome.link.offline")}. {t("chrome.link.bannerDetail", { time: connectionLostTime })}</span>
+          <button type="button" onClick={reconnectOperationsSseNow}>{t("chrome.link.reconnect")}</button>
+        </div>
+      ) : null}
       <main className="console-route-content">
         <Routes>
           <Route path="/" element={<Navigate to="/operations" replace />} />
@@ -230,12 +239,6 @@ export function App() {
       <WhatsNewModal state={state} />
       <CommissioningOverlay state={state} />
       <FeatureTourOverlay />
-      <Toast
-        open={state.connectionError !== null}
-        tone="error"
-        title={t("chrome.toast.consoleLinkInterrupted")}
-        message={state.connectionError ?? undefined}
-      />
       <Toast
         open={activeDeletion !== null}
         tone="undo"

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -8,6 +8,7 @@ import { FeatureTourOverlay } from "./components/feature-tour.js";
 import { KeyboardShortcutsDialog } from "./components/keyboard-shortcuts-dialog.js";
 import { takeKeyboardShortcutsReturnFocus } from "./keyboard-shortcuts-return-focus.js";
 import { OperationSearch } from "./components/operation-search.js";
+import { ReconnectButton } from "./components/reconnect-button.js";
 import { Toast } from "./components/toast.js";
 import { appendPendingDeletion, deletionCountdownSeconds, latestPendingDeletion } from "./deletion-undo.js";
 import { WhatsNewModal } from "./components/whatsnew-modal.js";
@@ -20,7 +21,7 @@ import { GlobalSettings } from "./pages/global-settings.js";
 import { Operations } from "./pages/operations.js";
 import { BUILT_IN_RAIL_PANELS } from "./rail/built-in-panels.js";
 import { toggleRailChrome } from "./rail/rail-store.js";
-import { reconnectOperationsSseNow, refreshObserverStatus } from "./operations-sse.js";
+import { refreshObserverStatus } from "./operations-sse.js";
 import { closeKeyboardShortcuts, hydrateGroups, hydrateInitialOperations, hydrateOperations, hydrateTheaterBootstrap, hydrateTheaters, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
 import { abortReleaseNotesFetch, requestReleaseNotes } from "./release-notes-fetch.js";
 import { getSideBarState, setSideBarCollapsed, subscribeOperationActivityTracking } from "./sidebar/operations-side-bar-store.js";
@@ -219,10 +220,12 @@ export function App() {
   return (
     <div className="console-shell">
       <CommandBand operationsViewVisible={operationsViewVisible} />
-      {state.connection === "offline" ? (
+      {/* 배너는 링크가 live가 아닌 동안 유지한다 — offline에만 걸면 재연결 시도가 시작되는 순간
+          배너째 언마운트되어, 눌린 버튼의 피드백까지 함께 사라진다(실브라우저 재현). */}
+      {state.connection !== "live" && state.connectionLostAt !== null ? (
         <div className="console-link-banner" role="status" aria-live="polite">
-          <span>{t("chrome.link.offline")}. {t("chrome.link.bannerDetail", { time: connectionLostTime })}</span>
-          <button type="button" onClick={reconnectOperationsSseNow}>{t("chrome.link.reconnect")}</button>
+          <span>{t(state.connection === "offline" ? "chrome.link.offline" : "chrome.link.reconnecting")}. {t("chrome.link.bannerDetail", { time: connectionLostTime })}</span>
+          <ReconnectButton />
         </div>
       ) : null}
       <main className="console-route-content">

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -340,6 +340,11 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
           </button>
           {environmentOpen ? <div ref={environmentPopoverRef}><EnvironmentPopover environment={environment} error={environmentError} loading={environmentLoading} copiedValue={copiedValue} copyFailedValue={copyFailedValue} desktopShell={desktopShell} onCopy={copyEnvironmentValue} /></div> : null}
         </div> : null}
+        {state.connection !== "live" ? (
+          <span className="command-band-link-chip" data-link-state={state.connection}>
+            {t(state.connection === "offline" ? "chrome.link.offline" : "chrome.link.reconnecting")}
+          </span>
+        ) : null}
         {operationsViewVisible ? <button type="button" className="command-band-button command-band-sidebar-toggle" onClick={() => setSideBarCollapsed(!sideBar.collapsed)} aria-label={t(sideBar.collapsed ? "chrome.commandBand.expandSidebar" : "chrome.commandBand.collapseSidebar", { shortcut: sideBarShortcut })} title={t(sideBar.collapsed ? "chrome.commandBand.expandSidebar" : "chrome.commandBand.collapseSidebar", { shortcut: sideBarShortcut })}>
           <PanelToggleIcon side="left" />
         </button> : null}

--- a/runtime/fleet-console/core/client/src/components/reconnect-button.tsx
+++ b/runtime/fleet-console/core/client/src/components/reconnect-button.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+import { useT } from "../i18n/index.js";
+import { reconnectOperationsSseNow } from "../operations-sse.js";
+
+// 재연결이 실패하면 EventSource가 거의 즉시 error를 내므로 connection 상태만으로는
+// "다시 연결하는 중"이 사람 눈에 걸리지 않는다(실측: 클릭 250ms 뒤 이미 offline).
+// 버튼이 눌렸다는 사실은 상태 기계와 무관하게 이 로컬 pending이 보증한다.
+const RECONNECT_FEEDBACK_MS = 800;
+
+export function ReconnectButton() {
+  const t = useT();
+  const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    if (!pending) return;
+    const handle = setTimeout(() => setPending(false), RECONNECT_FEEDBACK_MS);
+    return () => clearTimeout(handle);
+  }, [pending]);
+
+  return (
+    <button
+      type="button"
+      disabled={pending}
+      onClick={() => {
+        setPending(true);
+        reconnectOperationsSseNow();
+      }}
+    >
+      {t(pending ? "chrome.link.reconnecting" : "chrome.link.reconnect")}
+    </button>
+  );
+}

--- a/runtime/fleet-console/core/client/src/components/reconnect-button.tsx
+++ b/runtime/fleet-console/core/client/src/components/reconnect-button.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type Ref } from "react";
 
 import { useT } from "../i18n/index.js";
 import { reconnectOperationsSseNow } from "../operations-sse.js";
@@ -8,7 +8,11 @@ import { reconnectOperationsSseNow } from "../operations-sse.js";
 // 버튼이 눌렸다는 사실은 상태 기계와 무관하게 이 로컬 pending이 보증한다.
 const RECONNECT_FEEDBACK_MS = 800;
 
-export function ReconnectButton() {
+interface ReconnectButtonProps {
+  readonly buttonRef?: Ref<HTMLButtonElement>;
+}
+
+export function ReconnectButton({ buttonRef }: ReconnectButtonProps = {}) {
   const t = useT();
   const [pending, setPending] = useState(false);
 
@@ -20,6 +24,7 @@ export function ReconnectButton() {
 
   return (
     <button
+      ref={buttonRef}
       type="button"
       disabled={pending}
       onClick={() => {

--- a/runtime/fleet-console/core/client/src/i18n/messages/chrome.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/chrome.ts
@@ -48,6 +48,14 @@ export const chromeEn = {
   "chrome.commandBand.newOperationIn": "New Operation in {theater}…",
   "chrome.commandBand.noOperationsInTheater": "No operations in this Theater",
 
+  // console link
+  "chrome.link.offline": "Connection lost",
+  "chrome.link.reconnecting": "Reconnecting…",
+  "chrome.link.bannerDetail": "Values on screen are from {time}.",
+  "chrome.link.reconnect": "Reconnect",
+  "chrome.link.staleHeadline": "Updates stopped here",
+  "chrome.link.staleDetail": "Last updated {time}",
+
   // operation-search
   "chrome.operationSearch.commandsDialog": "Console commands",
   "chrome.operationSearch.quickSearchDialog": "Operation quick search",
@@ -163,7 +171,6 @@ export const chromeEn = {
 
   // toast
   "chrome.toast.dismissNotification": "Dismiss notification",
-  "chrome.toast.consoleLinkInterrupted": "Console link interrupted",
   "chrome.toast.theaterForgotten": "Theater forgotten",
   "chrome.toast.operationClosed": "Operation closed",
   "chrome.toast.secondsRemaining": "{count}s remaining",
@@ -239,6 +246,13 @@ export const chromeKo: Record<keyof typeof chromeEn, string> = {
   "chrome.commandBand.renameCurrentOperation": "현재 Operation 이름 변경…",
   "chrome.commandBand.newOperationIn": "{theater}에서 새 Operation…",
   "chrome.commandBand.noOperationsInTheater": "이 Theater에 Operation이 없습니다",
+
+  "chrome.link.offline": "연결 끊김",
+  "chrome.link.reconnecting": "다시 연결하는 중…",
+  "chrome.link.bannerDetail": "화면의 값은 {time} 기준입니다.",
+  "chrome.link.reconnect": "다시 연결",
+  "chrome.link.staleHeadline": "이 값은 갱신이 멈췄습니다",
+  "chrome.link.staleDetail": "마지막 갱신 {time}",
 
   "chrome.operationSearch.commandsDialog": "Console 명령",
   "chrome.operationSearch.quickSearchDialog": "Operation 빠른 검색",
@@ -348,7 +362,6 @@ export const chromeKo: Record<keyof typeof chromeEn, string> = {
   "chrome.brandFoot.update.blockedTitle": "Console이 업데이트를 시작할 준비가 되지 않았습니다. 잠시 후 다시 시도하세요.",
 
   "chrome.toast.dismissNotification": "알림 닫기",
-  "chrome.toast.consoleLinkInterrupted": "Console 연결이 끊겼습니다",
   "chrome.toast.theaterForgotten": "Theater를 잊었습니다",
   "chrome.toast.operationClosed": "Operation이 닫혔습니다",
   "chrome.toast.secondsRemaining": "{count}초 남음",

--- a/runtime/fleet-console/core/client/src/operations-sse.ts
+++ b/runtime/fleet-console/core/client/src/operations-sse.ts
@@ -5,6 +5,7 @@ import type { OperationNode } from "./types.js";
 
 const MAX_RECONNECT_DELAY_MS = 30_000;
 
+// 누락 스냅샷은 SSE가 열리기 전에만 hydrate해 이후 실시간 프레임을 덮어쓰지 않는다.
 let reconnectDelayMs = 1_000;
 let reconnectHandle: ReturnType<typeof setTimeout> | null = null;
 let activeSource: EventSource | null = null;
@@ -54,11 +55,6 @@ export function connectOperationsSse(): void {
     reconnectDelayMs = 1_000;
     setConnectionState("live");
     refreshObserverStatus();
-    void fetchOperations()
-      .then((operations) => {
-        if (isCurrentSource()) hydrateOperations(operations);
-      })
-      .catch(() => undefined);
   };
 
   source.onerror = () => {
@@ -73,7 +69,14 @@ export function connectOperationsSse(): void {
       if (retryGeneration !== connectionGeneration) return;
       setConnectionState("connecting");
       reconnectDelayMs = Math.min(reconnectDelayMs * 2, MAX_RECONNECT_DELAY_MS);
-      connectOperationsSse();
+      void fetchOperations()
+        .then((operations) => {
+          if (retryGeneration === connectionGeneration) hydrateOperations(operations);
+        })
+        .catch(() => undefined)
+        .finally(() => {
+          if (retryGeneration === connectionGeneration) connectOperationsSse();
+        });
     }, reconnectDelayMs);
   };
 }
@@ -87,7 +90,17 @@ export function reconnectOperationsSseNow(): void {
   // 수동 재연결도 "다시 연결하는 중"으로 전이시킨다 — 상태를 offline에 둔 채 재접속하면
   // 서버가 여전히 죽어 있을 때 버튼을 눌러도 화면이 그대로여서 눌린 것인지 알 수 없다.
   setConnectionState("connecting");
-  connectOperationsSse();
+  activeSource?.close();
+  activeSource = null;
+  const reconnectGeneration = ++connectionGeneration;
+  void fetchOperations()
+    .then((operations) => {
+      if (reconnectGeneration === connectionGeneration) hydrateOperations(operations);
+    })
+    .catch(() => undefined)
+    .finally(() => {
+      if (reconnectGeneration === connectionGeneration) connectOperationsSse();
+    });
 }
 
 export function refreshObserverStatus(): void {

--- a/runtime/fleet-console/core/client/src/operations-sse.ts
+++ b/runtime/fleet-console/core/client/src/operations-sse.ts
@@ -1,6 +1,6 @@
 import { fetchObserverStatus, fetchOperations } from "./api.js";
 import { applyDesktopFullscreenSnapshot, resetDesktopFullscreenSnapshot } from "./desktop-fullscreen.js";
-import { applyObserverStatus, applyOperationUpdate, getState, hydrateOperations } from "./store.js";
+import { applyObserverStatus, applyOperationUpdate, getState, hydrateOperations, setConnectionState } from "./store.js";
 import type { OperationNode } from "./types.js";
 
 const MAX_RECONNECT_DELAY_MS = 30_000;
@@ -42,14 +42,17 @@ export function connectOperationsSse(): void {
 
   source.onopen = () => {
     reconnectDelayMs = 1_000;
+    setConnectionState("live");
     refreshObserverStatus();
   };
 
   source.onerror = () => {
     source.close();
     resetDesktopFullscreenSnapshot();
+    setConnectionState("offline");
     reconnectHandle = setTimeout(() => {
       reconnectHandle = null;
+      setConnectionState("connecting");
       reconnectDelayMs = Math.min(reconnectDelayMs * 2, MAX_RECONNECT_DELAY_MS);
       void fetchOperations()
         .then(hydrateOperations)
@@ -57,6 +60,18 @@ export function connectOperationsSse(): void {
         .finally(connectOperationsSse);
     }, reconnectDelayMs);
   };
+}
+
+export function reconnectOperationsSseNow(): void {
+  if (reconnectHandle !== null) {
+    clearTimeout(reconnectHandle);
+    reconnectHandle = null;
+  }
+  reconnectDelayMs = 1_000;
+  // 수동 재연결도 "다시 연결하는 중"으로 전이시킨다 — 상태를 offline에 둔 채 재접속하면
+  // 서버가 여전히 죽어 있을 때 버튼을 눌러도 화면이 그대로여서 눌린 것인지 알 수 없다.
+  setConnectionState("connecting");
+  connectOperationsSse();
 }
 
 export function refreshObserverStatus(): void {

--- a/runtime/fleet-console/core/client/src/operations-sse.ts
+++ b/runtime/fleet-console/core/client/src/operations-sse.ts
@@ -7,6 +7,8 @@ const MAX_RECONNECT_DELAY_MS = 30_000;
 
 let reconnectDelayMs = 1_000;
 let reconnectHandle: ReturnType<typeof setTimeout> | null = null;
+let activeSource: EventSource | null = null;
+let connectionGeneration = 0;
 let statusRefreshInFlight: Promise<void> | null = null;
 let statusRefreshPending = false;
 
@@ -15,9 +17,14 @@ export function connectOperationsSse(): void {
     clearTimeout(reconnectHandle);
     reconnectHandle = null;
   }
+  activeSource?.close();
+  const generation = ++connectionGeneration;
   const source = new EventSource("/api/v1/operations/events");
+  activeSource = source;
+  const isCurrentSource = () => generation === connectionGeneration && activeSource === source;
 
   source.addEventListener("operation:changed", (e) => {
+    if (!isCurrentSource()) return;
     const msg = e as MessageEvent<string>;
     try {
       const data = JSON.parse(msg.data) as { readonly operation?: unknown };
@@ -28,10 +35,12 @@ export function connectOperationsSse(): void {
   });
 
   source.addEventListener("update:available", () => {
+    if (!isCurrentSource()) return;
     refreshObserverStatus();
   });
 
   source.addEventListener("desktop:fullscreen", (e) => {
+    if (!isCurrentSource()) return;
     const msg = e as MessageEvent<string>;
     try {
       applyDesktopFullscreenSnapshot(JSON.parse(msg.data));
@@ -41,23 +50,32 @@ export function connectOperationsSse(): void {
   });
 
   source.onopen = () => {
+    if (!isCurrentSource()) return;
     reconnectDelayMs = 1_000;
     setConnectionState("live");
     refreshObserverStatus();
   };
 
   source.onerror = () => {
+    if (!isCurrentSource()) return;
     source.close();
+    activeSource = null;
+    const retryGeneration = ++connectionGeneration;
     resetDesktopFullscreenSnapshot();
     setConnectionState("offline");
     reconnectHandle = setTimeout(() => {
       reconnectHandle = null;
+      if (retryGeneration !== connectionGeneration) return;
       setConnectionState("connecting");
       reconnectDelayMs = Math.min(reconnectDelayMs * 2, MAX_RECONNECT_DELAY_MS);
       void fetchOperations()
-        .then(hydrateOperations)
+        .then((operations) => {
+          if (retryGeneration === connectionGeneration) hydrateOperations(operations);
+        })
         .catch(() => undefined)
-        .finally(connectOperationsSse);
+        .finally(() => {
+          if (retryGeneration === connectionGeneration) connectOperationsSse();
+        });
     }, reconnectDelayMs);
   };
 }
@@ -79,8 +97,11 @@ export function refreshObserverStatus(): void {
     statusRefreshPending = true;
     return;
   }
+  const generation = connectionGeneration;
   statusRefreshInFlight = fetchObserverStatus(getState().activeTheaterId)
-    .then(applyObserverStatus)
+    .then((status) => {
+      if (generation === connectionGeneration) applyObserverStatus(status);
+    })
     .catch(() => undefined)
     .finally(() => {
       statusRefreshInFlight = null;

--- a/runtime/fleet-console/core/client/src/operations-sse.ts
+++ b/runtime/fleet-console/core/client/src/operations-sse.ts
@@ -54,6 +54,11 @@ export function connectOperationsSse(): void {
     reconnectDelayMs = 1_000;
     setConnectionState("live");
     refreshObserverStatus();
+    void fetchOperations()
+      .then((operations) => {
+        if (isCurrentSource()) hydrateOperations(operations);
+      })
+      .catch(() => undefined);
   };
 
   source.onerror = () => {
@@ -68,14 +73,7 @@ export function connectOperationsSse(): void {
       if (retryGeneration !== connectionGeneration) return;
       setConnectionState("connecting");
       reconnectDelayMs = Math.min(reconnectDelayMs * 2, MAX_RECONNECT_DELAY_MS);
-      void fetchOperations()
-        .then((operations) => {
-          if (retryGeneration === connectionGeneration) hydrateOperations(operations);
-        })
-        .catch(() => undefined)
-        .finally(() => {
-          if (retryGeneration === connectionGeneration) connectOperationsSse();
-        });
+      connectOperationsSse();
     }, reconnectDelayMs);
   };
 }

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -12,7 +12,9 @@ import { useGlobalSettingsStore } from "../global-settings-store.js";
 import type { Translate } from "@fleet-console/sdk/i18n";
 
 import { useT, type CoreMessageKey } from "../i18n/index.js";
+import { reconnectOperationsSseNow } from "../operations-sse.js";
 import { getState, subscribe } from "../store.js";
+import type { ConnectionState } from "../types.js";
 import { resolveConsoleLanguage } from "../whatsnew-i18n.js";
 import { closeRailPanel, requestRailPanelExtraWidth, setRailOverlayAlpha, toggleRailPanel, toggleRailPanelBehavior, useActiveRailPanelId, useRailChromeExpanded, useRailOverlayAlpha, useRailPanelBehavior, useRailPanelExtraWidth, type RailOverlayAlpha } from "./rail-store.js";
 import { useRailPanels } from "./rail-registry.js";
@@ -103,6 +105,8 @@ export function RightRail({ theaterId, api }: RightRailProps) {
     () => getState().theaters.find((theater) => theater.id === theaterId)?.label ?? theaterFallback,
     () => theaterFallback,
   );
+  const connection = useSyncExternalStore(subscribe, () => getState().connection, () => "connecting" as const);
+  const connectionLostAt = useSyncExternalStore(subscribe, () => getState().connectionLostAt, () => null);
   const globalSettings = useGlobalSettingsStore();
   const language = resolveConsoleLanguage(globalSettings.state?.language ?? "auto");
   const rootRef = useRef<HTMLDivElement>(null);
@@ -296,7 +300,7 @@ export function RightRail({ theaterId, api }: RightRailProps) {
           />
         )}
         {activePanel && (
-          <RailPanelContent activePanel={activePanel} activePanelTitle={activePanelTitle} activeId={activeId} ctx={ctx} panelBehavior={panelBehavior} overlayAlpha={overlayAlpha} />
+          <RailPanelContent activePanel={activePanel} activePanelTitle={activePanelTitle} activeId={activeId} ctx={ctx} panelBehavior={panelBehavior} overlayAlpha={overlayAlpha} connection={connection} connectionLostAt={connectionLostAt} language={language} />
         )}
       </div>
       <nav className="right-rail-icons" aria-label={t("rail.chrome.toolsAria")}>
@@ -323,14 +327,18 @@ interface RailPanelContentProps {
   readonly ctx: RailPanelContext;
   readonly panelBehavior: "push" | "overlay";
   readonly overlayAlpha: RailOverlayAlpha;
+  readonly connection: ConnectionState;
+  readonly connectionLostAt: number | null;
+  readonly language: ConsoleLocale;
 }
 
 // 패널 본문은 무거운 플러그인 콘텐츠(파일 트리·diff·Codex)를 렌더한다. 리사이즈 드래그가
 // 매 프레임 RightRail을 재렌더해도 이 본문이 함께 재렌더되면 끊김이 생기므로, 폭과 무관한
 // (activePanel·ctx·activeId·panelBehavior·overlayAlpha) props로 memo해 드래그 중 본문 재렌더를 건너뛴다(좌측 SideBar처럼 가벼운 부분만 재렌더).
-const RailPanelContent = memo(function RailPanelContent({ activePanel, activePanelTitle, activeId, ctx, panelBehavior, overlayAlpha }: RailPanelContentProps) {
+const RailPanelContent = memo(function RailPanelContent({ activePanel, activePanelTitle, activeId, ctx, panelBehavior, overlayAlpha, connection, connectionLostAt, language }: RailPanelContentProps) {
   const t = useT();
   const overlayPresets = buildOverlayAlphaPresets(t);
+  const connectionLostTime = connectionLostAt === null ? "" : new Date(connectionLostAt).toLocaleTimeString(language);
   return (
     <>
       <div className="right-rail-panel-head">
@@ -373,6 +381,13 @@ const RailPanelContent = memo(function RailPanelContent({ activePanel, activePan
       </div>
       <div id={`rail-panel-${activePanel.id}`} className="right-rail-panel-body" role="tabpanel" aria-labelledby={`rail-tab-${activeId}`}>
         {activePanel.render(ctx)}
+        {connection === "offline" ? (
+          <div className="right-rail-stale-veil">
+            <strong>{t("chrome.link.staleHeadline")}</strong>
+            <span>{t("chrome.link.staleDetail", { time: connectionLostTime })}</span>
+            <button type="button" onClick={reconnectOperationsSseNow}>{t("chrome.link.reconnect")}</button>
+          </div>
+        ) : null}
       </div>
     </>
   );

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -342,6 +342,7 @@ const RailPanelContent = memo(function RailPanelContent({ activePanel, activePan
   const staleVisible = connection !== "live" && connectionLostAt !== null;
   const panelBodyRef = useRef<HTMLDivElement>(null);
   const panelContentRef = useRef<HTMLDivElement>(null);
+  const staleVeilRef = useRef<HTMLDivElement>(null);
   const reconnectButtonRef = useRef<HTMLButtonElement>(null);
   const returnFocusRef = useRef<HTMLElement | null>(null);
   const previousStaleVisibleRef = useRef(false);
@@ -364,6 +365,10 @@ const RailPanelContent = memo(function RailPanelContent({ activePanel, activePan
     const returnFocus = returnFocusRef.current;
     returnFocusRef.current = null;
     if (returnFocus === null) return;
+    const activeElement = document.activeElement;
+    const focusStillOwned = activeElement === document.body
+      || (activeElement instanceof HTMLElement && staleVeilRef.current?.contains(activeElement));
+    if (!focusStillOwned) return;
     if (returnFocus?.isConnected && panelContentRef.current?.contains(returnFocus)) {
       returnFocus.focus();
     } else {
@@ -417,7 +422,7 @@ const RailPanelContent = memo(function RailPanelContent({ activePanel, activePan
         </div>
         {/* 덮개도 배너와 같은 축으로 건다 — 재연결 시도 중에도 패널 값은 여전히 멈춰 있다. */}
         {staleVisible ? (
-          <div className="right-rail-stale-veil">
+          <div ref={staleVeilRef} className="right-rail-stale-veil">
             <strong>{t("chrome.link.staleHeadline")}</strong>
             <span>{t("chrome.link.staleDetail", { time: connectionLostTime })}</span>
             <ReconnectButton buttonRef={reconnectButtonRef} />

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -339,6 +339,37 @@ const RailPanelContent = memo(function RailPanelContent({ activePanel, activePan
   const t = useT();
   const overlayPresets = buildOverlayAlphaPresets(t);
   const connectionLostTime = connectionLostAt === null ? "" : new Date(connectionLostAt).toLocaleTimeString(language);
+  const staleVisible = connection !== "live" && connectionLostAt !== null;
+  const panelBodyRef = useRef<HTMLDivElement>(null);
+  const panelContentRef = useRef<HTMLDivElement>(null);
+  const reconnectButtonRef = useRef<HTMLButtonElement>(null);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+  const previousStaleVisibleRef = useRef(false);
+
+  useLayoutEffect(() => {
+    const wasVisible = previousStaleVisibleRef.current;
+    previousStaleVisibleRef.current = staleVisible;
+    if (!wasVisible && staleVisible) {
+      const activeElement = document.activeElement;
+      if (activeElement instanceof HTMLElement && panelContentRef.current?.contains(activeElement)) {
+        returnFocusRef.current = activeElement;
+        reconnectButtonRef.current?.focus();
+      }
+      return;
+    }
+    if (!wasVisible || staleVisible) return;
+
+    // 이 layout effect가 실행될 때는 React가 wrapper의 inert를 이미 해제했다. 그 전에는
+    // 실브라우저가 focus()를 조용히 무시하므로, 렌더 중 직접 복원하지 않는다.
+    const returnFocus = returnFocusRef.current;
+    returnFocusRef.current = null;
+    if (returnFocus?.isConnected && panelContentRef.current?.contains(returnFocus)) {
+      returnFocus.focus();
+    } else {
+      panelBodyRef.current?.focus();
+    }
+  }, [staleVisible]);
+
   return (
     <>
       <div className="right-rail-panel-head">
@@ -379,14 +410,16 @@ const RailPanelContent = memo(function RailPanelContent({ activePanel, activePan
           ✕
         </button>
       </div>
-      <div id={`rail-panel-${activePanel.id}`} className="right-rail-panel-body" role="tabpanel" aria-labelledby={`rail-tab-${activeId}`}>
-        {activePanel.render(ctx)}
+      <div ref={panelBodyRef} id={`rail-panel-${activePanel.id}`} className="right-rail-panel-body" role="tabpanel" aria-labelledby={`rail-tab-${activeId}`} tabIndex={-1}>
+        <div ref={panelContentRef} className="right-rail-panel-content" inert={staleVisible || undefined}>
+          {activePanel.render(ctx)}
+        </div>
         {/* 덮개도 배너와 같은 축으로 건다 — 재연결 시도 중에도 패널 값은 여전히 멈춰 있다. */}
-        {connection !== "live" && connectionLostAt !== null ? (
+        {staleVisible ? (
           <div className="right-rail-stale-veil">
             <strong>{t("chrome.link.staleHeadline")}</strong>
             <span>{t("chrome.link.staleDetail", { time: connectionLostTime })}</span>
-            <ReconnectButton />
+            <ReconnectButton buttonRef={reconnectButtonRef} />
           </div>
         ) : null}
       </div>

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -363,6 +363,7 @@ const RailPanelContent = memo(function RailPanelContent({ activePanel, activePan
     // 실브라우저가 focus()를 조용히 무시하므로, 렌더 중 직접 복원하지 않는다.
     const returnFocus = returnFocusRef.current;
     returnFocusRef.current = null;
+    if (returnFocus === null) return;
     if (returnFocus?.isConnected && panelContentRef.current?.contains(returnFocus)) {
       returnFocus.focus();
     } else {

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -12,7 +12,7 @@ import { useGlobalSettingsStore } from "../global-settings-store.js";
 import type { Translate } from "@fleet-console/sdk/i18n";
 
 import { useT, type CoreMessageKey } from "../i18n/index.js";
-import { reconnectOperationsSseNow } from "../operations-sse.js";
+import { ReconnectButton } from "../components/reconnect-button.js";
 import { getState, subscribe } from "../store.js";
 import type { ConnectionState } from "../types.js";
 import { resolveConsoleLanguage } from "../whatsnew-i18n.js";
@@ -381,11 +381,12 @@ const RailPanelContent = memo(function RailPanelContent({ activePanel, activePan
       </div>
       <div id={`rail-panel-${activePanel.id}`} className="right-rail-panel-body" role="tabpanel" aria-labelledby={`rail-tab-${activeId}`}>
         {activePanel.render(ctx)}
-        {connection === "offline" ? (
+        {/* 덮개도 배너와 같은 축으로 건다 — 재연결 시도 중에도 패널 값은 여전히 멈춰 있다. */}
+        {connection !== "live" && connectionLostAt !== null ? (
           <div className="right-rail-stale-veil">
             <strong>{t("chrome.link.staleHeadline")}</strong>
             <span>{t("chrome.link.staleDetail", { time: connectionLostTime })}</span>
-            <button type="button" onClick={reconnectOperationsSseNow}>{t("chrome.link.reconnect")}</button>
+            <ReconnectButton />
           </div>
         ) : null}
       </div>

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -7,6 +7,7 @@ import { acknowledgeIdleArrival } from "./operation-idle-arrival.js";
 import { uiFontFamily } from "./ui-font.js";
 import type {
   CodexReaderRequest,
+  ConnectionState,
   ConsoleState,
   NotificationKind,
   NotificationPreferences,
@@ -45,7 +46,7 @@ let commissioningMigrationAttempted = false;
 
 let state: ConsoleState = {
   connection: "connecting",
-  connectionError: null,
+  connectionLostAt: null,
   channel: "unknown",
   // The SDK ConsoleTheme union matches ThemeId; the selected theme passes
   // through to the plugin context unchanged.
@@ -106,6 +107,21 @@ export function subscribe(listener: Listener): () => void {
 export function setState(patch: Partial<ConsoleState>): void {
   state = { ...state, ...patch };
   emit();
+}
+
+export function setConnectionState(next: ConnectionState): void {
+  if (next === "offline") {
+    setState({
+      connection: next,
+      connectionLostAt: state.connectionLostAt ?? Date.now(),
+    });
+    return;
+  }
+  if (next === "live") {
+    setState({ connection: next, connectionLostAt: null });
+    return;
+  }
+  setState({ connection: next });
 }
 
 export function setOperationsViewActive(active: boolean): void {

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -13,6 +13,42 @@
   overflow: hidden;
 }
 
+.console-link-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  flex: none;
+  min-height: 34px;
+  padding: var(--space-1) var(--space-4);
+  border-bottom: 1px solid color-mix(in oklch, var(--coral) 55%, var(--surface-rim));
+  background: var(--coral-glow);
+  color: var(--coral);
+  font-size: 12px;
+  font-weight: var(--weight-medium);
+}
+
+.console-link-banner button,
+.right-rail-stale-veil button {
+  padding: 4px 8px;
+  border: 1px solid currentColor;
+  border-radius: var(--radius-xs);
+  background: var(--surface-glass);
+  color: inherit;
+  font: inherit;
+  font-weight: var(--weight-bold);
+  cursor: pointer;
+}
+
+.console-link-banner button:hover,
+.console-link-banner button:focus-visible,
+.right-rail-stale-veil button:hover,
+.right-rail-stale-veil button:focus-visible {
+  border-color: var(--brass);
+  outline: 1px solid var(--brass);
+  outline-offset: 1px;
+}
+
 .console-body,
 .console-body.is-canvas {
   height: 100%;
@@ -154,6 +190,30 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.command-band-link-chip {
+  display: inline-flex;
+  align-items: center;
+  flex: none;
+  padding: 4px 7px;
+  border: 1px solid currentColor;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: var(--weight-bold);
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.command-band-link-chip[data-link-state="offline"] {
+  background: var(--coral-glow);
+  color: var(--coral);
+}
+
+.command-band-link-chip[data-link-state="connecting"] {
+  background: var(--warn-glow);
+  color: var(--warn);
 }
 
 /* macOS Desktop은 traffic-light 인셋(좌측 88px)이 첫 트랙 폭을 잠식하므로
@@ -648,5 +708,6 @@ html[data-desktop-shell="true"][data-desktop-platform="darwin"] .command-band-le
     transition: none !important;
   }
 
+  .right-rail-stale-veil { animation: none !important; }
   .command-band.is-fullscreen { transition: none !important; }
 }

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -224,6 +224,11 @@
   min-width: 240px;
 }
 
+.right-rail-panel-content {
+  height: 100%;
+  min-height: 0;
+}
+
 .right-rail-stale-veil {
   position: absolute;
   z-index: 20;

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -224,6 +224,38 @@
   min-width: 240px;
 }
 
+.right-rail-stale-veil {
+  position: absolute;
+  z-index: 20;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  background: color-mix(in oklch, var(--ink-deep) 88%, transparent);
+  color: var(--coral);
+  text-align: center;
+  /* 덮개는 offline일 때만 마운트되므로 상태 전환이 없다 — transition은 발화하지 않고
+     진입 페이드는 animation이 진다. */
+  animation: right-rail-stale-veil-in var(--duration-base) var(--ease-glide);
+}
+
+@keyframes right-rail-stale-veil-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.right-rail-stale-veil strong {
+  font-size: 13px;
+}
+
+.right-rail-stale-veil span {
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
 /* ── 아이콘 레일 ────────────────────────────────────────────────── */
 .right-rail-icons {
   width: 44px;

--- a/runtime/fleet-console/core/client/src/types.ts
+++ b/runtime/fleet-console/core/client/src/types.ts
@@ -144,7 +144,7 @@ export interface ApiCatalogEntry {
   readonly gate: string;
 }
 
-export type ConnectionState = "connecting" | "live";
+export type ConnectionState = "connecting" | "live" | "offline";
 
 export type NotificationKind = "ended" | "input-waiting";
 
@@ -171,7 +171,7 @@ export type CodexReaderRequest =
 
 export interface ConsoleState {
   readonly connection: ConnectionState;
-  readonly connectionError: string | null;
+  readonly connectionLostAt: number | null;
   readonly channel: ObserverStatus["channel"];
   readonly activeTheme: ConsoleTheme;
   readonly version: string;

--- a/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
+++ b/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
@@ -476,7 +476,7 @@ const PEER_OPERATION: OperationNode = {
 
 const CANVAS_STATE: ConsoleState = {
   connection: "connecting",
-  connectionError: null,
+  connectionLostAt: null,
   channel: "unknown",
   activeTheme: "maritime",
   version: "test",

--- a/runtime/fleet-console/tests/connection-state.test.ts
+++ b/runtime/fleet-console/tests/connection-state.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getState, setConnectionState, setState } from "../core/client/src/store.js";
+
+describe("console connection state", () => {
+  beforeEach(() => {
+    setState({ connection: "connecting", connectionLostAt: null });
+    vi.restoreAllMocks();
+  });
+
+  it("records only the first offline timestamp until the connection is live again", () => {
+    vi.spyOn(Date, "now")
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(2_000);
+
+    setConnectionState("offline");
+    expect(getState()).toMatchObject({ connection: "offline", connectionLostAt: 1_000 });
+
+    setConnectionState("offline");
+    expect(getState()).toMatchObject({ connection: "offline", connectionLostAt: 1_000 });
+
+    setConnectionState("live");
+    expect(getState()).toMatchObject({ connection: "live", connectionLostAt: null });
+  });
+
+  it("keeps the lost timestamp while a reconnect attempt is connecting", () => {
+    setState({ connection: "offline", connectionLostAt: 3_000 });
+
+    setConnectionState("connecting");
+
+    expect(getState()).toMatchObject({ connection: "connecting", connectionLostAt: 3_000 });
+  });
+});

--- a/runtime/fleet-console/tests/connection-ui-contract.test.ts
+++ b/runtime/fleet-console/tests/connection-ui-contract.test.ts
@@ -36,11 +36,17 @@ describe("console connection-loss UI contract", () => {
     expect(commandBand).toContain('className="command-band-link-chip" data-link-state={state.connection}');
     expect(commandBand).toContain('state.connection !== "live"');
     expect(app).toContain('className="console-link-banner" role="status" aria-live="polite"');
-    expect(app).toContain('state.connection === "offline"');
-    expect(app).toContain("onClick={reconnectOperationsSseNow}");
+    expect(app).toContain('state.connection !== "live" && state.connectionLostAt !== null');
+    expect(app).toContain("<ReconnectButton />");
     expect(rail).toContain('className="right-rail-stale-veil"');
-    expect(rail).toContain('connection === "offline"');
-    expect(rail).toContain("onClick={reconnectOperationsSseNow}");
+    expect(rail).toContain('connection !== "live" && connectionLostAt !== null');
+    expect(rail).toContain("<ReconnectButton />");
+
+    // 재연결 버튼은 상태 기계와 별개로 눌렸다는 사실을 보증한다 — 서버가 죽어 있으면
+    // EventSource가 즉시 실패해 connecting이 250ms 안에 사라지기 때문이다(실측).
+    const button = source("components/reconnect-button.tsx");
+    expect(button).toContain("disabled={pending}");
+    expect(button).toContain('t(pending ? "chrome.link.reconnecting" : "chrome.link.reconnect")');
   });
 
   it("uses signal tokens and the required stale-veil motion grammar", () => {

--- a/runtime/fleet-console/tests/connection-ui-contract.test.ts
+++ b/runtime/fleet-console/tests/connection-ui-contract.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { getT } from "../core/client/src/i18n/index.js";
+
+const CLIENT_ROOT = resolve(import.meta.dirname, "../core/client/src");
+const source = (path: string) => readFileSync(resolve(CLIENT_ROOT, path), "utf8");
+
+describe("console connection-loss UI contract", () => {
+  it("keeps the approved English and Korean connection copy literal", () => {
+    const en = getT("en");
+    const ko = getT("ko");
+
+    expect(en("chrome.link.offline")).toBe("Connection lost");
+    expect(en("chrome.link.reconnecting")).toBe("Reconnecting…");
+    expect(en("chrome.link.bannerDetail", { time: "10:00" })).toBe("Values on screen are from 10:00.");
+    expect(en("chrome.link.reconnect")).toBe("Reconnect");
+    expect(en("chrome.link.staleHeadline")).toBe("Updates stopped here");
+    expect(en("chrome.link.staleDetail", { time: "10:00" })).toBe("Last updated 10:00");
+
+    expect(ko("chrome.link.offline")).toBe("연결 끊김");
+    expect(ko("chrome.link.reconnecting")).toBe("다시 연결하는 중…");
+    expect(ko("chrome.link.bannerDetail", { time: "10:00" })).toBe("화면의 값은 10:00 기준입니다.");
+    expect(ko("chrome.link.reconnect")).toBe("다시 연결");
+    expect(ko("chrome.link.staleHeadline")).toBe("이 값은 갱신이 멈췄습니다");
+    expect(ko("chrome.link.staleDetail", { time: "10:00" })).toBe("마지막 갱신 10:00");
+  });
+
+  it("renders distinct command-band, global banner, and rail stale surfaces", () => {
+    const commandBand = source("components/command-band.tsx");
+    const app = source("app.tsx");
+    const rail = source("rail/right-rail.tsx");
+
+    expect(commandBand).toContain('className="command-band-link-chip" data-link-state={state.connection}');
+    expect(commandBand).toContain('state.connection !== "live"');
+    expect(app).toContain('className="console-link-banner" role="status" aria-live="polite"');
+    expect(app).toContain('state.connection === "offline"');
+    expect(app).toContain("onClick={reconnectOperationsSseNow}");
+    expect(rail).toContain('className="right-rail-stale-veil"');
+    expect(rail).toContain('connection === "offline"');
+    expect(rail).toContain("onClick={reconnectOperationsSseNow}");
+  });
+
+  it("uses signal tokens and the required stale-veil motion grammar", () => {
+    const layout = source("styles/layout.css");
+    const rail = source("styles/rail.css");
+
+    expect(layout).toMatch(/\.command-band-link-chip\[data-link-state="offline"\][^{]*\{[^}]*var\(--coral-glow\)[^}]*var\(--coral\)/s);
+    expect(layout).toMatch(/\.command-band-link-chip\[data-link-state="connecting"\][^{]*\{[^}]*var\(--warn-glow\)[^}]*var\(--warn\)/s);
+    expect(layout).toMatch(/\.console-link-banner \{[^}]*var\(--coral\)[^}]*var\(--coral-glow\)/s);
+    // 덮개는 offline일 때만 마운트되므로 상태 전환이 없다 — 진입 페이드는 transition이 아니라
+    // animation이 져야 실제로 발화한다.
+    expect(rail).toMatch(/\.right-rail-stale-veil \{[^}]*animation: right-rail-stale-veil-in var\(--duration-base\) var\(--ease-glide\)/s);
+    expect(rail).toMatch(/@keyframes right-rail-stale-veil-in \{[\s\S]*opacity: 0[\s\S]*opacity: 1/);
+    expect(layout).toMatch(/@media \(prefers-reduced-motion: reduce\)[\s\S]*\.right-rail-stale-veil[\s\S]*animation: none !important/);
+  });
+});

--- a/runtime/fleet-console/tests/connection-ui-contract.test.ts
+++ b/runtime/fleet-console/tests/connection-ui-contract.test.ts
@@ -44,6 +44,7 @@ describe("console connection-loss UI contract", () => {
     expect(rail).toContain('className="right-rail-panel-content" inert={staleVisible || undefined}');
     expect(rail).toContain("reconnectButtonRef.current?.focus()");
     expect(rail).toContain("returnFocus?.isConnected");
+    expect(rail).toContain("if (returnFocus === null) return;");
     expect(rail).toContain("panelBodyRef.current?.focus()");
 
     // 재연결 버튼은 상태 기계와 별개로 눌렸다는 사실을 보증한다 — 서버가 죽어 있으면

--- a/runtime/fleet-console/tests/connection-ui-contract.test.ts
+++ b/runtime/fleet-console/tests/connection-ui-contract.test.ts
@@ -45,6 +45,7 @@ describe("console connection-loss UI contract", () => {
     expect(rail).toContain("reconnectButtonRef.current?.focus()");
     expect(rail).toContain("returnFocus?.isConnected");
     expect(rail).toContain("if (returnFocus === null) return;");
+    expect(rail).toContain("if (!focusStillOwned) return;");
     expect(rail).toContain("panelBodyRef.current?.focus()");
 
     // 재연결 버튼은 상태 기계와 별개로 눌렸다는 사실을 보증한다 — 서버가 죽어 있으면

--- a/runtime/fleet-console/tests/connection-ui-contract.test.ts
+++ b/runtime/fleet-console/tests/connection-ui-contract.test.ts
@@ -40,7 +40,11 @@ describe("console connection-loss UI contract", () => {
     expect(app).toContain("<ReconnectButton />");
     expect(rail).toContain('className="right-rail-stale-veil"');
     expect(rail).toContain('connection !== "live" && connectionLostAt !== null');
-    expect(rail).toContain("<ReconnectButton />");
+    expect(rail).toContain("<ReconnectButton buttonRef={reconnectButtonRef} />");
+    expect(rail).toContain('className="right-rail-panel-content" inert={staleVisible || undefined}');
+    expect(rail).toContain("reconnectButtonRef.current?.focus()");
+    expect(rail).toContain("returnFocus?.isConnected");
+    expect(rail).toContain("panelBodyRef.current?.focus()");
 
     // 재연결 버튼은 상태 기계와 별개로 눌렸다는 사실을 보증한다 — 서버가 죽어 있으면
     // EventSource가 즉시 실패해 connecting이 250ms 안에 사라지기 때문이다(실측).

--- a/runtime/fleet-console/tests/operation-search.test.ts
+++ b/runtime/fleet-console/tests/operation-search.test.ts
@@ -29,7 +29,7 @@ function makeState(
 ): ConsoleState {
   return {
     connection: "connecting",
-    connectionError: null,
+    connectionLostAt: null,
     channel: "unknown",
     activeTheme: "maritime",
     version: "1.8.0",

--- a/runtime/fleet-console/tests/operations-sse.test.ts
+++ b/runtime/fleet-console/tests/operations-sse.test.ts
@@ -98,13 +98,49 @@ describe("operations SSE update availability", () => {
     vi.stubGlobal("EventSource", TestEventSource);
     mocks.getState.mockReturnValue({ activeTheaterId: null });
     mocks.fetchObserverStatus.mockResolvedValue(status);
+    mocks.fetchOperations.mockResolvedValue([]);
 
     connectOperationsSse();
     TestEventSource.instances[0]?.open();
 
     await vi.waitFor(() => expect(mocks.applyObserverStatus).toHaveBeenCalledWith(status));
+    await vi.waitFor(() => expect(mocks.hydrateOperations).toHaveBeenCalledWith([]));
     expect(mocks.fetchObserverStatus).toHaveBeenCalledWith(null);
     expect(mocks.setConnectionState).toHaveBeenCalledWith("live");
+  });
+
+  it("hydrates missed operations when a manual reconnect opens", async () => {
+    const operations = [{ id: "created-while-offline" }];
+    vi.stubGlobal("EventSource", TestEventSource);
+    mocks.getState.mockReturnValue({ activeTheaterId: null });
+    mocks.fetchObserverStatus.mockResolvedValue({});
+    mocks.fetchOperations.mockResolvedValue(operations);
+
+    reconnectOperationsSseNow();
+    TestEventSource.instances[0]?.open();
+
+    await vi.waitFor(() => expect(mocks.hydrateOperations).toHaveBeenCalledWith(operations));
+  });
+
+  it("does not hydrate an onopen snapshot from a superseded source", async () => {
+    vi.stubGlobal("EventSource", TestEventSource);
+    mocks.getState.mockReturnValue({ activeTheaterId: null });
+    mocks.fetchObserverStatus.mockResolvedValue({});
+    let resolveOperations: (operations: readonly [{ readonly id: string }]) => void = () => {
+      throw new Error("operations fetch did not start");
+    };
+    mocks.fetchOperations.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveOperations = resolve;
+    }));
+
+    reconnectOperationsSseNow();
+    TestEventSource.instances[0]?.open();
+    reconnectOperationsSseNow();
+    resolveOperations([{ id: "stale" }]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.hydrateOperations).not.toHaveBeenCalled();
   });
 
   it("keeps one active source and ignores every callback from superseded generations", async () => {
@@ -186,7 +222,8 @@ describe("operations SSE update availability", () => {
 
     await vi.advanceTimersByTimeAsync(1_000);
     expect(mocks.setConnectionState).toHaveBeenLastCalledWith("connecting");
-    await vi.waitFor(() => expect(TestEventSource.instances).toHaveLength(2));
+    expect(TestEventSource.instances).toHaveLength(2);
+    expect(mocks.fetchOperations).not.toHaveBeenCalled();
   });
 
   it("cancels the pending backoff and reconnects immediately", async () => {
@@ -211,36 +248,10 @@ describe("operations SSE update availability", () => {
     await vi.waitFor(() => expect(TestEventSource.instances).toHaveLength(4));
   });
 
-  it("does not reconnect or hydrate from an automatic retry superseded by a manual reconnect", async () => {
-    vi.useFakeTimers();
-    vi.stubGlobal("EventSource", TestEventSource);
-    mocks.getState.mockReturnValue({ activeTheaterId: null });
-    let resolveOperations: (operations: readonly []) => void = () => {
-      throw new Error("operations fetch did not start");
-    };
-    mocks.fetchOperations.mockImplementation(() => new Promise((resolve) => {
-      resolveOperations = resolve;
-    }));
-
-    reconnectOperationsSseNow();
-    TestEventSource.instances[0]?.onerror?.();
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(mocks.fetchOperations).toHaveBeenCalledOnce();
-
-    reconnectOperationsSseNow();
-    expect(TestEventSource.instances).toHaveLength(2);
-    resolveOperations([]);
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(mocks.hydrateOperations).not.toHaveBeenCalled();
-    expect(TestEventSource.instances).toHaveLength(2);
-    expect(TestEventSource.instances.filter((source) => !source.closed)).toHaveLength(1);
-  });
-
   it("discards an observer status response from a superseded connection generation", async () => {
     vi.stubGlobal("EventSource", TestEventSource);
     mocks.getState.mockReturnValue({ activeTheaterId: null });
+    mocks.fetchOperations.mockResolvedValue([]);
     let resolveStaleStatus: (status: { version: string; updateAvailable: boolean }) => void = () => {
       throw new Error("status fetch did not start");
     };

--- a/runtime/fleet-console/tests/operations-sse.test.ts
+++ b/runtime/fleet-console/tests/operations-sse.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   getState: vi.fn(),
   hydrateOperations: vi.fn(),
   resetDesktopFullscreenSnapshot: vi.fn(),
+  setConnectionState: vi.fn(),
 }));
 
 vi.mock("../core/client/src/api.js", () => ({
@@ -21,6 +22,7 @@ vi.mock("../core/client/src/store.js", () => ({
   applyOperationUpdate: mocks.applyOperationUpdate,
   getState: mocks.getState,
   hydrateOperations: mocks.hydrateOperations,
+  setConnectionState: mocks.setConnectionState,
 }));
 
 vi.mock("../core/client/src/desktop-fullscreen.js", () => ({
@@ -28,13 +30,14 @@ vi.mock("../core/client/src/desktop-fullscreen.js", () => ({
   resetDesktopFullscreenSnapshot: mocks.resetDesktopFullscreenSnapshot,
 }));
 
-import { connectOperationsSse } from "../core/client/src/operations-sse.js";
+import { connectOperationsSse, reconnectOperationsSseNow } from "../core/client/src/operations-sse.js";
 
 class TestEventSource {
   static instances: TestEventSource[] = [];
 
   onerror: (() => void) | null = null;
   onopen: (() => void) | null = null;
+  closed = false;
   private readonly listeners = new Map<string, ((event: Event) => void)[]>();
 
   constructor(_url: string) {
@@ -47,7 +50,9 @@ class TestEventSource {
     this.listeners.set(type, registered);
   }
 
-  close(): void {}
+  close(): void {
+    this.closed = true;
+  }
 
   emit(type: string, data?: string): void {
     for (const listener of this.listeners.get(type) ?? []) listener({ data } as MessageEvent<string>);
@@ -69,6 +74,9 @@ describe("operations SSE update availability", () => {
     mocks.getState.mockReset();
     mocks.hydrateOperations.mockReset();
     mocks.resetDesktopFullscreenSnapshot.mockReset();
+    mocks.setConnectionState.mockReset();
+    vi.clearAllTimers();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -96,6 +104,7 @@ describe("operations SSE update availability", () => {
 
     await vi.waitFor(() => expect(mocks.applyObserverStatus).toHaveBeenCalledWith(status));
     expect(mocks.fetchObserverStatus).toHaveBeenCalledWith(null);
+    expect(mocks.setConnectionState).toHaveBeenCalledWith("live");
   });
 
   it("trails a status refresh when a later update frame arrives in flight", async () => {
@@ -135,6 +144,43 @@ describe("operations SSE update availability", () => {
     expect(mocks.resetDesktopFullscreenSnapshot).toHaveBeenCalledOnce();
     TestEventSource.instances[0]?.onerror?.();
     expect(mocks.resetDesktopFullscreenSnapshot).toHaveBeenCalledTimes(2);
-    vi.useRealTimers();
+    expect(mocks.setConnectionState).toHaveBeenCalledWith("offline");
+  });
+
+  it("marks the retry attempt connecting while preserving the existing exponential retry path", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("EventSource", TestEventSource);
+    mocks.getState.mockReturnValue({ activeTheaterId: null });
+    mocks.fetchOperations.mockResolvedValue([]);
+
+    connectOperationsSse();
+    TestEventSource.instances[0]?.onerror?.();
+    expect(mocks.setConnectionState).toHaveBeenLastCalledWith("offline");
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(mocks.setConnectionState).toHaveBeenLastCalledWith("connecting");
+    await vi.waitFor(() => expect(TestEventSource.instances).toHaveLength(2));
+  });
+
+  it("cancels the pending backoff and reconnects immediately", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("EventSource", TestEventSource);
+    mocks.getState.mockReturnValue({ activeTheaterId: null });
+    mocks.fetchOperations.mockResolvedValue([]);
+
+    reconnectOperationsSseNow();
+    TestEventSource.instances[0]?.onerror?.();
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.waitFor(() => expect(TestEventSource.instances).toHaveLength(2));
+    TestEventSource.instances[1]?.onerror?.();
+
+    reconnectOperationsSseNow();
+    expect(TestEventSource.instances).toHaveLength(3);
+    TestEventSource.instances[2]?.onerror?.();
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(TestEventSource.instances).toHaveLength(3);
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.waitFor(() => expect(TestEventSource.instances).toHaveLength(4));
   });
 });

--- a/runtime/fleet-console/tests/operations-sse.test.ts
+++ b/runtime/fleet-console/tests/operations-sse.test.ts
@@ -107,6 +107,33 @@ describe("operations SSE update availability", () => {
     expect(mocks.setConnectionState).toHaveBeenCalledWith("live");
   });
 
+  it("keeps one active source and ignores every callback from superseded generations", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("EventSource", TestEventSource);
+    mocks.getState.mockReturnValue({ activeTheaterId: null });
+
+    connectOperationsSse();
+    const staleSource = TestEventSource.instances[0]!;
+    connectOperationsSse();
+    const currentSource = TestEventSource.instances[1]!;
+
+    expect(staleSource.closed).toBe(true);
+    staleSource.emit("operation:changed", JSON.stringify({ operation: { id: "stale" } }));
+    staleSource.emit("update:available");
+    staleSource.emit("desktop:fullscreen", JSON.stringify({ fullscreen: true }));
+    staleSource.open();
+    staleSource.onerror?.();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(mocks.applyOperationUpdate).not.toHaveBeenCalled();
+    expect(mocks.fetchObserverStatus).not.toHaveBeenCalled();
+    expect(mocks.applyDesktopFullscreenSnapshot).not.toHaveBeenCalled();
+    expect(mocks.resetDesktopFullscreenSnapshot).not.toHaveBeenCalled();
+    expect(mocks.setConnectionState).not.toHaveBeenCalled();
+    expect(TestEventSource.instances).toHaveLength(2);
+    expect(currentSource.closed).toBe(false);
+  });
+
   it("trails a status refresh when a later update frame arrives in flight", async () => {
     let resolveFirstStatus: ((status: { version: string; updateAvailable: boolean }) => void) | null = null;
     const staleStatus = { version: "1.0.0", updateAvailable: false };
@@ -182,5 +209,56 @@ describe("operations SSE update availability", () => {
     expect(TestEventSource.instances).toHaveLength(3);
     await vi.advanceTimersByTimeAsync(1);
     await vi.waitFor(() => expect(TestEventSource.instances).toHaveLength(4));
+  });
+
+  it("does not reconnect or hydrate from an automatic retry superseded by a manual reconnect", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("EventSource", TestEventSource);
+    mocks.getState.mockReturnValue({ activeTheaterId: null });
+    let resolveOperations: (operations: readonly []) => void = () => {
+      throw new Error("operations fetch did not start");
+    };
+    mocks.fetchOperations.mockImplementation(() => new Promise((resolve) => {
+      resolveOperations = resolve;
+    }));
+
+    reconnectOperationsSseNow();
+    TestEventSource.instances[0]?.onerror?.();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(mocks.fetchOperations).toHaveBeenCalledOnce();
+
+    reconnectOperationsSseNow();
+    expect(TestEventSource.instances).toHaveLength(2);
+    resolveOperations([]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.hydrateOperations).not.toHaveBeenCalled();
+    expect(TestEventSource.instances).toHaveLength(2);
+    expect(TestEventSource.instances.filter((source) => !source.closed)).toHaveLength(1);
+  });
+
+  it("discards an observer status response from a superseded connection generation", async () => {
+    vi.stubGlobal("EventSource", TestEventSource);
+    mocks.getState.mockReturnValue({ activeTheaterId: null });
+    let resolveStaleStatus: (status: { version: string; updateAvailable: boolean }) => void = () => {
+      throw new Error("status fetch did not start");
+    };
+    const currentStatus = { version: "2.0.0", updateAvailable: true };
+    mocks.fetchObserverStatus
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveStaleStatus = resolve;
+      }))
+      .mockResolvedValueOnce(currentStatus);
+
+    reconnectOperationsSseNow();
+    TestEventSource.instances[0]?.open();
+    reconnectOperationsSseNow();
+    TestEventSource.instances[1]?.open();
+    resolveStaleStatus({ version: "1.0.0", updateAvailable: false });
+
+    await vi.waitFor(() => expect(mocks.fetchObserverStatus).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(mocks.applyObserverStatus).toHaveBeenCalledOnce());
+    expect(mocks.applyObserverStatus).toHaveBeenCalledWith(currentStatus);
   });
 });

--- a/runtime/fleet-console/tests/operations-sse.test.ts
+++ b/runtime/fleet-console/tests/operations-sse.test.ts
@@ -98,35 +98,21 @@ describe("operations SSE update availability", () => {
     vi.stubGlobal("EventSource", TestEventSource);
     mocks.getState.mockReturnValue({ activeTheaterId: null });
     mocks.fetchObserverStatus.mockResolvedValue(status);
-    mocks.fetchOperations.mockResolvedValue([]);
 
     connectOperationsSse();
     TestEventSource.instances[0]?.open();
 
     await vi.waitFor(() => expect(mocks.applyObserverStatus).toHaveBeenCalledWith(status));
-    await vi.waitFor(() => expect(mocks.hydrateOperations).toHaveBeenCalledWith([]));
     expect(mocks.fetchObserverStatus).toHaveBeenCalledWith(null);
+    expect(mocks.fetchOperations).not.toHaveBeenCalled();
     expect(mocks.setConnectionState).toHaveBeenCalledWith("live");
   });
 
-  it("hydrates missed operations when a manual reconnect opens", async () => {
+  it("hydrates missed operations before creating the manual reconnect source", async () => {
     const operations = [{ id: "created-while-offline" }];
     vi.stubGlobal("EventSource", TestEventSource);
     mocks.getState.mockReturnValue({ activeTheaterId: null });
-    mocks.fetchObserverStatus.mockResolvedValue({});
-    mocks.fetchOperations.mockResolvedValue(operations);
-
-    reconnectOperationsSseNow();
-    TestEventSource.instances[0]?.open();
-
-    await vi.waitFor(() => expect(mocks.hydrateOperations).toHaveBeenCalledWith(operations));
-  });
-
-  it("does not hydrate an onopen snapshot from a superseded source", async () => {
-    vi.stubGlobal("EventSource", TestEventSource);
-    mocks.getState.mockReturnValue({ activeTheaterId: null });
-    mocks.fetchObserverStatus.mockResolvedValue({});
-    let resolveOperations: (operations: readonly [{ readonly id: string }]) => void = () => {
+    let resolveOperations: (operations: readonly { readonly id: string }[]) => void = () => {
       throw new Error("operations fetch did not start");
     };
     mocks.fetchOperations.mockImplementationOnce(() => new Promise((resolve) => {
@@ -134,13 +120,39 @@ describe("operations SSE update availability", () => {
     }));
 
     reconnectOperationsSseNow();
-    TestEventSource.instances[0]?.open();
-    reconnectOperationsSseNow();
-    resolveOperations([{ id: "stale" }]);
-    await Promise.resolve();
-    await Promise.resolve();
+    expect(TestEventSource.instances).toHaveLength(0);
+    resolveOperations(operations);
 
-    expect(mocks.hydrateOperations).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(mocks.hydrateOperations).toHaveBeenCalledWith(operations));
+    expect(TestEventSource.instances).toHaveLength(1);
+  });
+
+  it("does not hydrate or connect a delayed manual snapshot from a superseded generation", async () => {
+    vi.stubGlobal("EventSource", TestEventSource);
+    mocks.getState.mockReturnValue({ activeTheaterId: null });
+    let resolveStaleOperations: (operations: readonly { readonly id: string }[]) => void = () => {
+      throw new Error("stale operations fetch did not start");
+    };
+    let resolveCurrentOperations: (operations: readonly { readonly id: string }[]) => void = () => {
+      throw new Error("current operations fetch did not start");
+    };
+    mocks.fetchOperations
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveStaleOperations = resolve;
+      }))
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveCurrentOperations = resolve;
+      }));
+
+    reconnectOperationsSseNow();
+    reconnectOperationsSseNow();
+    resolveCurrentOperations([{ id: "current" }]);
+    await vi.waitFor(() => expect(TestEventSource.instances).toHaveLength(1));
+    resolveStaleOperations([{ id: "stale" }]);
+    await vi.waitFor(() => expect(mocks.hydrateOperations).toHaveBeenCalledTimes(1));
+
+    expect(mocks.hydrateOperations).toHaveBeenCalledWith([{ id: "current" }]);
+    expect(TestEventSource.instances).toHaveLength(1);
   });
 
   it("keeps one active source and ignores every callback from superseded generations", async () => {
@@ -214,7 +226,12 @@ describe("operations SSE update availability", () => {
     vi.useFakeTimers();
     vi.stubGlobal("EventSource", TestEventSource);
     mocks.getState.mockReturnValue({ activeTheaterId: null });
-    mocks.fetchOperations.mockResolvedValue([]);
+    let resolveOperations: (operations: readonly []) => void = () => {
+      throw new Error("operations fetch did not start");
+    };
+    mocks.fetchOperations.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveOperations = resolve;
+    }));
 
     connectOperationsSse();
     TestEventSource.instances[0]?.onerror?.();
@@ -222,8 +239,11 @@ describe("operations SSE update availability", () => {
 
     await vi.advanceTimersByTimeAsync(1_000);
     expect(mocks.setConnectionState).toHaveBeenLastCalledWith("connecting");
+    expect(mocks.fetchOperations).toHaveBeenCalledOnce();
+    expect(TestEventSource.instances).toHaveLength(1);
+    resolveOperations([]);
+    await vi.waitFor(() => expect(mocks.hydrateOperations).toHaveBeenCalledWith([]));
     expect(TestEventSource.instances).toHaveLength(2);
-    expect(mocks.fetchOperations).not.toHaveBeenCalled();
   });
 
   it("cancels the pending backoff and reconnects immediately", async () => {
@@ -233,13 +253,14 @@ describe("operations SSE update availability", () => {
     mocks.fetchOperations.mockResolvedValue([]);
 
     reconnectOperationsSseNow();
+    await vi.waitFor(() => expect(TestEventSource.instances).toHaveLength(1));
     TestEventSource.instances[0]?.onerror?.();
     await vi.advanceTimersByTimeAsync(1_000);
     await vi.waitFor(() => expect(TestEventSource.instances).toHaveLength(2));
     TestEventSource.instances[1]?.onerror?.();
 
     reconnectOperationsSseNow();
-    expect(TestEventSource.instances).toHaveLength(3);
+    await vi.waitFor(() => expect(TestEventSource.instances).toHaveLength(3));
     TestEventSource.instances[2]?.onerror?.();
 
     await vi.advanceTimersByTimeAsync(999);
@@ -263,8 +284,10 @@ describe("operations SSE update availability", () => {
       .mockResolvedValueOnce(currentStatus);
 
     reconnectOperationsSseNow();
+    await vi.waitFor(() => expect(TestEventSource.instances).toHaveLength(1));
     TestEventSource.instances[0]?.open();
     reconnectOperationsSseNow();
+    await vi.waitFor(() => expect(TestEventSource.instances).toHaveLength(2));
     TestEventSource.instances[1]?.open();
     resolveStaleStatus({ version: "1.0.0", updateAvailable: false });
 

--- a/runtime/fleet-console/tests/palette-commands.test.ts
+++ b/runtime/fleet-console/tests/palette-commands.test.ts
@@ -32,7 +32,7 @@ const THEATER_BETA: TheaterInfo = { id: "theater-beta", label: "Beta Dock", crea
 function makeState(patch: Partial<ConsoleState> = {}): ConsoleState {
   return {
     connection: "connecting",
-    connectionError: null,
+    connectionLostAt: null,
     channel: "unknown",
     activeTheme: "instrument",
     version: "1.30.0",

--- a/runtime/fleet-console/tests/reduce.test.ts
+++ b/runtime/fleet-console/tests/reduce.test.ts
@@ -37,7 +37,7 @@ function makeNotification(
 function makeConsoleSnap(patch: Partial<ConsoleState> = {}): ConsoleState {
   return {
     connection: "live",
-    connectionError: null,
+    connectionLostAt: null,
     channel: "unknown",
     activeTheme: "maritime",
     version: "1.8.0",

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -139,6 +139,21 @@ describe("Right Rail stale veil focus boundary", () => {
     expect(document.activeElement).not.toBe(document.body);
   });
 
+  it("leaves focus where the user moved it after the stale veil took ownership", () => {
+    renderRail();
+    const action = container.querySelector<HTMLButtonElement>(".test-panel-action")!;
+    action.focus();
+    act(() => setState({ connection: "offline", connectionLostAt: 1_000 }));
+    const outside = document.createElement("button");
+    outside.textContent = "Outside rail";
+    document.body.appendChild(outside);
+    outside.focus();
+
+    act(() => setState({ connection: "live", connectionLostAt: null }));
+
+    expect(document.activeElement).toBe(outside);
+  });
+
   it("leaves focus unchanged when the stale veil never took ownership", () => {
     renderRail();
     const outside = document.createElement("button");

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -138,6 +138,22 @@ describe("Right Rail stale veil focus boundary", () => {
     expect(document.activeElement).toBe(panelBody());
     expect(document.activeElement).not.toBe(document.body);
   });
+
+  it("leaves focus unchanged when the stale veil never took ownership", () => {
+    renderRail();
+    const outside = document.createElement("button");
+    outside.textContent = "Outside rail";
+    document.body.appendChild(outside);
+    outside.focus();
+    expect(document.activeElement).toBe(outside);
+
+    act(() => setState({ connection: "offline", connectionLostAt: 1_000 }));
+    expect(document.activeElement).toBe(outside);
+
+    act(() => setState({ connection: "live", connectionLostAt: null }));
+
+    expect(document.activeElement).toBe(outside);
+  });
 });
 
 describe("Right Rail panel width", () => {

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -11,7 +11,7 @@ vi.mock("../core/client/src/rail/built-in-panels.js", () => ({
       title: "PLANS",
       defaultWidth: 360,
       icon: "P",
-      render: () => null,
+      render: () => <button className="test-panel-action">Panel action</button>,
     },
     {
       id: "codex",
@@ -51,6 +51,7 @@ import {
   setRailOverlayAlpha,
   setRailPanelBehavior,
 } from "../core/client/src/rail/rail-store.js";
+import { setState } from "../core/client/src/store.js";
 
 let container: HTMLDivElement;
 let root: Root;
@@ -64,6 +65,7 @@ beforeEach(() => {
   requestRailPanelExtraWidth("plans", null);
   setRailPanelBehavior("push");
   setRailOverlayAlpha(100);
+  setState({ connection: "live", connectionLostAt: null });
   container = document.createElement("div");
   document.body.replaceChildren(container);
   root = createRoot(container);
@@ -100,6 +102,41 @@ describe("Right Rail overlay opacity presets", () => {
     expect(window.localStorage.getItem("fleet-console.rail.overlayAlpha")).toBe("75");
     expect(buttons.map((button) => button.getAttribute("aria-pressed"))).toEqual(["false", "false", "true", "false"]);
     expect(panelSlot().style.getPropertyValue("--right-rail-overlay-alpha")).toBe("0.75");
+  });
+});
+
+describe("Right Rail stale veil focus boundary", () => {
+  it("inerts the covered content, moves focus to reconnect, and restores it after inert is removed", () => {
+    renderRail();
+    const action = container.querySelector<HTMLButtonElement>(".test-panel-action")!;
+    action.focus();
+    expect(document.activeElement).toBe(action);
+
+    act(() => setState({ connection: "offline", connectionLostAt: 1_000 }));
+
+    const content = container.querySelector<HTMLElement>(".right-rail-panel-content")!;
+    const reconnect = container.querySelector<HTMLButtonElement>(".right-rail-stale-veil button")!;
+    expect(content.hasAttribute("inert")).toBe(true);
+    expect(document.activeElement).toBe(reconnect);
+
+    act(() => setState({ connection: "live", connectionLostAt: null }));
+
+    expect(content.hasAttribute("inert")).toBe(false);
+    expect(document.activeElement).toBe(action);
+  });
+
+  it("falls back to the panel body when the original focus target disappeared", () => {
+    renderRail();
+    const action = container.querySelector<HTMLButtonElement>(".test-panel-action")!;
+    action.focus();
+    act(() => setState({ connection: "offline", connectionLostAt: 1_000 }));
+    act(() => setActiveRailPanel("codex"));
+    expect(action.isConnected).toBe(false);
+
+    act(() => setState({ connection: "live", connectionLostAt: null }));
+
+    expect(document.activeElement).toBe(panelBody());
+    expect(document.activeElement).not.toBe(document.body);
   });
 });
 


### PR DESCRIPTION
## Summary

- 콘솔 서버가 죽어도 전역 배너·토스트·모달이 하나도 뜨지 않았습니다. 실측하면 저장소 패널이 브랜치 8→0, 태그 124→0, 기록 200행→"기록 없음"으로 **오류 표시 없이 빈 값으로 리셋**되어, 빈 저장소와 죽은 서버가 화면에서 구별되지 않았습니다. `connectionError` 상태는 Toast 배선까지 있었지만 설정하는 호출부가 0건인 데드코드였습니다.
- 링크 상태를 세 층으로 알립니다: command band 상태 칩, 마지막 갱신 시각을 고정하는 배너, 값이 멈춘 레일 패널 위의 stale 덮개. 각 층에 재연결 컨트롤이 있습니다. **연결이 정상이면 셋 다 렌더되지 않아** 평상시 크롬은 그대로입니다.
- 활성 EventSource와 그 generation을 한 곳에서 소유합니다. 이전 연결을 닫지 않던 재연결 경로가 여러 살아있는 연결을 만들어 상태를 경합시키던 문제를 없앴습니다.
- 덮개가 떠 있는 동안 패널 콘텐츠를 `inert`로 만들고, 포커스를 재연결 컨트롤로 넘겼다가 링크가 살아나면 원래 요소로 되돌립니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과
- [x] 집중 테스트 5 files, 59 tests 통과 (`connection-state`, `connection-ui-contract`, `operations-sse`, `right-rail`, `instrument-design-contract`)
- [x] `pnpm typecheck` — `tests/server.test.ts:2623,2648` TS2741 2건만 남음(canary 선존, 이 변경과 무관)
- [x] 격리 실브라우저 — 연결 정상: 칩·배너·덮개 전부 미렌더
- [x] 격리 실브라우저 — 서버 SIGKILL: 3층 전부 표시, 배너 `role=status`/`aria-live=polite`, 최초 단절 시각이 재시도 중에도 유지
- [x] 격리 실브라우저 — 재연결 연타 4회: 열린 EventSource **항상 0개**(수정 전에는 `closed:false` 2개 잔존)
- [x] 격리 실브라우저 — 단절 시 패널 콘텐츠 `inert=true`, 포커스가 덮개 재연결 버튼으로 이동
- [ ] 링크 복구 시 포커스 복원 — 단위 테스트와 캐리어 실측은 통과했으나, 호스트가 독립 재현하지 못했습니다(격리 서버 재기동 시 포트가 바뀌어 같은 페이지로 복구를 유도할 수 없고, loopback SSE는 브라우저 오프라인 토글로 끊기지 않음)
- [x] Changelog fragment — `.changelog.d/pr-416.md` (grouped 문법, EN/KO 병기, `--check` 통과). 덮개 포커스 항목은 이 PR이 도입한 미출시 동작이라 Release Baseline 규칙에 따라 독립 Fixed가 아닌 Added로 접어 넣었습니다.