### PR TITLE
fix(console): enter Triage with nothing focused when nothing is waiting

### DIFF
--- a/.changelog.d/pr-418.md
+++ b/.changelog.d/pr-418.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Triage mode opens with nothing on stage and nothing focused when no Operation is waiting, instead of surfacing whichever panel was focused before.
+  ko: 대기 중인 Operation이 없으면 선별 처리 모드가 직전에 포커스돼 있던 패널을 세우지 않고, 아무것도 올리지 않은 채 포커스도 해제한 상태로 열립니다.

--- a/runtime/fleet-console/core/client/src/canvas/triage-store.ts
+++ b/runtime/fleet-console/core/client/src/canvas/triage-store.ts
@@ -103,6 +103,30 @@ export function setTriageActive(theaterId: string, active: boolean): void {
   emitTriage();
 }
 
+export function enterTriage(theaterId: string, focusedOperationId: string | null): void {
+  const { operations, operationStatus } = getState();
+  const theaterOperations = operations.filter((operation) => operation.theaterId === theaterId);
+  const focusedOperation = focusedOperationId === null
+    ? null
+    : theaterOperations.find((operation) => operation.id === focusedOperationId) ?? null;
+  if (focusedOperation && isTriageWaitingOperation(focusedOperation, operationStatus)) {
+    pickTriageOperation(theaterId, focusedOperation.id);
+  }
+  setTriageActive(theaterId, true);
+  if (resolveTriageQueue(theaterId, theaterOperations, operationStatus).length > 0) return;
+  setActiveOperation(null);
+  const document = globalThis.document;
+  const HTMLElementConstructor = document?.defaultView?.HTMLElement;
+  const activeElement = document?.activeElement;
+  if (
+    HTMLElementConstructor
+    && activeElement instanceof HTMLElementConstructor
+    && activeElement.closest(".canvas-operation")
+  ) {
+    activeElement.blur();
+  }
+}
+
 export function useTriageActive(theaterId: string | null): boolean {
   return useSyncExternalStore(
     subscribeTriage,

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -4,7 +4,7 @@ import { resolveLocalizedText } from "@fleet-console/sdk/i18n/translate";
 
 import { fetchConsoleEnvironment, fetchOperations, renameOperation } from "../api.js";
 import { animateViewportTo, selectFormationLayout, useCanvasState, useFormationLayout, useFormationView } from "../canvas/canvas-store.js";
-import { focusedTriageOperationId, pickTriageOperation, setTriageActive, useTriageActive } from "../canvas/triage-store.js";
+import { enterTriage, focusedTriageOperationId, setTriageActive, useTriageActive } from "../canvas/triage-store.js";
 import { commandBandActiveOperation, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "./command-band-guards.js";
 import { CommandBandOperationMenu, CommandBandTheaterMenu, CommandBandTriggerCaret, type CommandBandSwitcherMenu } from "./command-band-switcher.js";
 import { FleetBrandHome } from "./side-bar-brand-foot.js";
@@ -366,10 +366,10 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
           if (state.activeTheaterId) {
             const activating = !triageActive;
             if (activating) {
-              const operationId = focusedTriageOperationId(document.activeElement);
-              if (operationId) pickTriageOperation(state.activeTheaterId, operationId);
+              enterTriage(state.activeTheaterId, focusedTriageOperationId(document.activeElement));
+            } else {
+              setTriageActive(state.activeTheaterId, false);
             }
-            setTriageActive(state.activeTheaterId, activating);
           }
         }}
       >

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -25,7 +25,7 @@ import { closeOperationCompletely } from "../operation-close.js";
 import { forgetTheaterCompletely } from "../theater-forget.js";
 import type { DeferredDeletionReceipt } from "../api.js";
 import { getLoadedTheaterId, ensureDefaultGeometry, forceDropCompanionOperationId, getCompanionOperationId, loadForTheater, minimizeOperations, toggleFormationView } from "../canvas/canvas-store.js";
-import { forgetTriageOperation, isTriageActive, setTriageActive } from "../canvas/triage-store.js";
+import { enterTriage, focusedTriageOperationId, forgetTriageOperation, isTriageActive, setTriageActive } from "../canvas/triage-store.js";
 import { openRailPanel, setRailChromeExpanded, toggleRailChrome } from "../rail/rail-store.js";
 import { getSideBarState, setSideBarCollapsed, toggleSideBarStatusAxis } from "../sidebar/operations-side-bar-store.js";
 import { requestSideBarOperationAction, type SideBarOperationAction } from "../sidebar/operation-action-request.js";
@@ -268,7 +268,15 @@ export function OperationSearch({
         if (!location.pathname.startsWith("/operations")) navigate("/operations");
         ensurePaletteCanvasTheater(state);
         if (state.activeTheaterId) {
-          setTriageActive(state.activeTheaterId, !isTriageActive(state.activeTheaterId));
+          if (isTriageActive(state.activeTheaterId)) {
+            setTriageActive(state.activeTheaterId, false);
+          } else {
+            // 팔레트 진입 시점의 activeElement는 입력창이므로 캔버스 포커스는 previousFocusRef에서 읽는다.
+            // 그 뒤 복원을 끊지 않으면 팔레트가 닫히며 이전 패널을 다시 포커스해 빈 대기열 진입의 해제가 무효화된다.
+            const focusedOperationId = focusedTriageOperationId(previousFocusRef.current);
+            previousFocusRef.current = null;
+            enterTriage(state.activeTheaterId, focusedOperationId);
+          }
         }
         break;
       }

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -11,7 +11,7 @@ import { claimTopZIndex, ensureDefaultGeometry, focusOperation as focusCanvasOpe
 import { screenToCanvas, type CanvasPoint } from "../canvas/coordinates.js";
 import { playMinimizeFlight, playRestoreFlight } from "../canvas/panel-motion.js";
 import { OperationsCanvas } from "../canvas/canvas.js";
-import { deferTriageOperation, dismissTriageOperation, focusedTriageOperationId, forgetTriageOperation, isTriageActive, pickTriageOperation, recordTriageActivity, resolveTriageQueue, setTriageActive } from "../canvas/triage-store.js";
+import { deferTriageOperation, dismissTriageOperation, enterTriage, focusedTriageOperationId, forgetTriageOperation, isTriageActive, recordTriageActivity, resolveTriageQueue, setTriageActive } from "../canvas/triage-store.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { RightRail } from "../rail/right-rail.js";
@@ -107,10 +107,10 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
         if (theaterId) {
           const activating = !isTriageActive(theaterId);
           if (activating) {
-            const operationId = focusedTriageOperationId(document.activeElement);
-            if (operationId) pickTriageOperation(theaterId, operationId);
+            enterTriage(theaterId, focusedTriageOperationId(document.activeElement));
+          } else {
+            setTriageActive(theaterId, false);
           }
-          setTriageActive(theaterId, activating);
         }
         return;
       }

--- a/runtime/fleet-console/tests/i18n.test.ts
+++ b/runtime/fleet-console/tests/i18n.test.ts
@@ -59,6 +59,10 @@ const IDENTICAL_LOCALE_VALUE_ALLOWLIST = new Set([
   // Plans/뱃지 프로토콜·상태 토큰
   "PARALLEL",
   "READY",
+  // 모드 커튼 키커(고정 대문자 각인)·투어 진행 표기(숫자 포맷)
+  "TRIAGE MODE",
+  "FORMATION VIEW",
+  "{current} / {total}",
   // 제품 탭·Cowork 설정 토큰
   "Fleet CLI",
   "Fleet Console",

--- a/runtime/fleet-console/tests/operations-canvas-empty-state.test.tsx
+++ b/runtime/fleet-console/tests/operations-canvas-empty-state.test.tsx
@@ -47,7 +47,7 @@ describe("Operations Canvas empty state", () => {
 
     expect(container?.querySelector(".operations-canvas-empty-headline")?.textContent).toBe("Launch your first operation");
     expect(container?.querySelector(".operations-canvas-empty-ghost")).toBeNull();
-    expect(container?.querySelector(".operations-canvas-empty-hints")?.textContent).toBe("⌘K Search · Alt+F Formation · Alt+S Status board");
+    expect(container?.querySelector(".operations-canvas-empty-hints")?.textContent).toBe("⌘K Search · Alt+F Formation · Alt+S Status board · Alt+T Triage");
     expect(container?.querySelector(".operations-canvas-empty-guide")?.textContent).toBe("Shift-drag to create a Shell. Right-click for actions. Drag to pan; scroll to zoom.");
 
     const launch = container?.querySelector<HTMLButtonElement>('[aria-label="New Operation in Alpha"]');

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -32,6 +32,7 @@ import {
 import {
   deferTriageOperation,
   dismissTriageOperation,
+  enterTriage,
   focusedTriageOperationId,
   forgetTriageOperation,
   getTriageCleared,
@@ -166,20 +167,82 @@ describe("triage store", () => {
     expect(getMaximizedOperationId()).toBeNull();
   });
 
-  it("resolves the focused canvas Operation for activation-time picking", () => {
+  it("enters with no pick, active Operation, or canvas focus when the focused Operation is running", () => {
+    const running = operation("running", 1);
     const frame = document.createElement("article");
     frame.className = "canvas-operation";
-    frame.dataset.operationId = "focused-op";
+    frame.dataset.operationId = running.id;
     const input = document.createElement("input");
     frame.append(input);
     document.body.append(frame);
     input.focus();
+    setConsoleState({
+      operations: [running],
+      activeTheaterId: THEATER_ID,
+      activeOperationId: running.id,
+      activeOperationAcknowledged: true,
+      operationStatus: { [running.id]: "running" },
+    });
 
     const focusedOperationId = focusedTriageOperationId(document.activeElement);
-    expect(focusedOperationId).toBe("focused-op");
-    if (focusedOperationId) pickTriageOperation(THEATER_ID, focusedOperationId);
-    setTriageActive(THEATER_ID, true);
-    expect(getTriagePick(THEATER_ID)).toBe("focused-op");
+    expect(focusedOperationId).toBe(running.id);
+    enterTriage(THEATER_ID, focusedOperationId);
+
+    const state = getState();
+    expect(resolveTriageQueue(THEATER_ID, [running], state.operationStatus)).toHaveLength(0);
+    expect(getTriagePick(THEATER_ID)).toBeNull();
+    expect(state.activeOperationId).toBeNull();
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  it("picks a focused awaiting Operation as the queue head on entry", () => {
+    const awaiting = operation("awaiting", 1);
+    const later = operation("later", 2);
+    const operationStatus: Readonly<Record<string, OperationActivity>> = {
+      awaiting: "awaiting",
+      later: "awaiting",
+    };
+    setConsoleState({ operations: [later, awaiting], operationStatus });
+
+    enterTriage(THEATER_ID, awaiting.id);
+
+    expect(getTriagePick(THEATER_ID)).toBe(awaiting.id);
+    expect(resolveTriageQueue(THEATER_ID, [later, awaiting], operationStatus)[0]?.operation.id)
+      .toBe(awaiting.id);
+  });
+
+  it("picks a focused idle arrival on entry", () => {
+    const arrived = operation("arrived", 1);
+    const operationStatus: Readonly<Record<string, OperationActivity>> = { arrived: "idle" };
+    markIdleArrival(arrived.id);
+    setConsoleState({ operations: [arrived], operationStatus });
+
+    enterTriage(THEATER_ID, arrived.id);
+
+    expect(getTriagePick(THEATER_ID)).toBe(arrived.id);
+    expect(resolveTriageQueue(THEATER_ID, [arrived], operationStatus)[0]?.operation.id)
+      .toBe(arrived.id);
+  });
+
+  it("does not let a focused non-waiting Operation displace another waiting Operation on entry", () => {
+    const running = operation("running", 1);
+    const waiting = operation("waiting", 2);
+    const operationStatus: Readonly<Record<string, OperationActivity>> = {
+      running: "running",
+      waiting: "awaiting",
+    };
+    setConsoleState({
+      operations: [running, waiting],
+      activeOperationId: running.id,
+      operationStatus,
+    });
+
+    enterTriage(THEATER_ID, running.id);
+
+    expect(getTriagePick(THEATER_ID)).toBeNull();
+    expect(resolveTriageQueue(THEATER_ID, [running, waiting], operationStatus)
+      .map((entry) => entry.operation.id)).toEqual([waiting.id]);
+    expect(getState().activeOperationId).toBe(running.id);
   });
 
   it("drops an invalid saved focus layer instead of restoring a minimized target", () => {


### PR DESCRIPTION
## Summary
- 선별 처리 모드 진입 시 직전에 포커스돼 있던 패널을 대기 여부와 무관하게 `pickTriageOperation`으로 지정하던 경로를 고쳤습니다. `resolveTriageQueue`가 `picked` 항목을 대기 판정에서 면제하기 때문에, 대기 중인 작업이 하나도 없어도 그 비-대기 패널이 스테이지에 올라왔습니다.
- 이제 포커스돼 있던 패널이 `awaiting`이거나 미확인 유휴 도착일 때만 pick하고, 진입 직후 큐가 비어 있으면 활성 Operation과 캔버스 DOM 포커스를 모두 해제합니다. 처리할 항목이 없으면 사용자가 좌측 사이드바에서 직접 고르는 흐름으로 돌아갑니다.
- Alt+T 단축키와 커맨드 밴드 토글이 각자 들고 있던 3단 진입 로직을 `enterTriage` 하나로 통합했습니다.
- 함께: 선별 처리 모드 도입 때 갱신되지 않은 로케일 allowlist와 빈 캔버스 힌트 기대값을 실제 문자열에 맞췄습니다.

## Test Plan
- [x] `pnpm --filter fleet-console exec vitest run tests/triage-store.test.ts` — 34/34 통과 (진입 계약 4건 신규)
- [x] `pnpm --filter fleet-console exec vitest run tests/i18n.test.ts tests/operations-canvas-empty-state.test.tsx` — 통과 (기존 실패 해소)
- [x] `pnpm --filter fleet-console build` — 통과
- [x] 헤디드 실측(격리 콘솔): dormant 패널을 활성·포커스 상태로 둔 뒤 Alt+T → 보이는 패널 0개, 활성 패널 0개, `document.activeElement`가 `BODY`, 레일 "없음", 페이지 에러 0건
- [x] Changelog: `.changelog.d/pr-418.md` 추가, 제품/섹션 그룹 문법·영한 병기 준수, `node scripts/compile-changelog-fragments.mjs --check` 통과