### PR TITLE
fix(console): restore the Triage pick import in Operations

### DIFF
--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -11,7 +11,7 @@ import { claimTopZIndex, consumePendingFitAllOperations, ensureDefaultGeometry, 
 import { screenToCanvas, type CanvasPoint } from "../canvas/coordinates.js";
 import { playMinimizeFlight, playRestoreFlight } from "../canvas/panel-motion.js";
 import { OperationsCanvas } from "../canvas/canvas.js";
-import { deferTriageOperation, dismissTriageOperation, enterTriage, focusedTriageOperationId, forgetTriageOperation, isTriageActive, recordTriageActivity, resolveTriageQueue, setTriageActive } from "../canvas/triage-store.js";
+import { deferTriageOperation, dismissTriageOperation, enterTriage, focusedTriageOperationId, forgetTriageOperation, isTriageActive, pickTriageOperation, recordTriageActivity, resolveTriageQueue, setTriageActive } from "../canvas/triage-store.js";
 import { createHostCapabilities } from "../plugin-capabilities.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { RightRail } from "../rail/right-rail.js";


### PR DESCRIPTION
## Summary
- PR #418에서 `enterTriage`를 도입하며 `pages/operations.tsx`의 `pickTriageOperation` import가 함께 제거됐는데, 같은 파일 3곳(200·497·634행)이 여전히 그 함수를 호출합니다. 선별 처리 모드가 켜진 상태에서 패널을 고르거나 새 Operation을 만들면 `ReferenceError`가 납니다.
- import 한 줄을 복구합니다.

왜 게이트를 통과했는지: `pnpm build`는 vite/esbuild라 타입 검사를 하지 않아 미정의 식별자를 런타임까지 미룹니다. vitest도 이 경로를 덮지 않고, 헤디드 검증도 밟지 않는 경로였습니다. `tsc --noEmit`을 돌려야만 드러납니다.

## Test Plan
- [x] `pnpm --filter fleet-console exec tsc --noEmit` — 이 파일의 TS2304/TS2552 3건이 사라지고, canary 선존인 `tests/server.test.ts` 2건만 남음
- [x] `pnpm --filter fleet-console build` — 통과
- [x] Changelog: `.changelog.d/pr-418.md`가 아직 미릴리스라 이 회귀는 배포된 버전에 존재한 적이 없습니다. `.changelog.d/AGENTS.md`의 Release Baseline 규칙에 따라 standalone Fixed 항목을 만들지 않고 no-changelog로 처리합니다.