### PR TITLE
fix(console): center the command band breadcrumb on the panel area

### DIFF
--- a/.changelog.d/pr-422.md
+++ b/.changelog.d/pr-422.md
@@ -1,0 +1,8 @@
+### fleet-console
+#### Added
+- [fleet-console] The command band breadcrumb now folds away before it can reach the map controls when the window gets too narrow, and returns as soon as there is room again.
+  ko: 창이 너무 좁아지면 command band의 breadcrumb이 맵 컨트롤에 닿기 전에 접히고, 자리가 생기는 즉시 다시 나타납니다.
+
+#### Fixed
+- [fleet-console] The command band breadcrumb now centers on the panel area itself instead of the whole window, so the sidebar no longer pushes it off center and collapsing the sidebar keeps it centered.
+  ko: command band의 breadcrumb을 창 전체가 아니라 가운데 패널 영역 기준으로 정렬해, 사이드바 때문에 중심이 밀리지 않고 사이드바를 접어도 중앙을 유지합니다.

--- a/runtime/fleet-console/core/client/src/components/command-band-guards.ts
+++ b/runtime/fleet-console/core/client/src/components/command-band-guards.ts
@@ -55,16 +55,22 @@ export function commandBandMenuClampedLeft(
 // 맵 컨트롤 클러스터(.command-band-map-controls)는 절대 배치라 그리드가 그 폭을 모른다.
 // 매직 오프셋 상수는 버튼이 늘 때마다 겹침으로 깨졌으므로(구 116px 사고) 실측 폭에서 계산한다.
 // 좌우 여백 트랙은 반드시 같은 하한을 쓴다 — 값이 어긋나면 하한이 물리는 순간 중앙이 밀린다.
+// 사이드바를 접으면 밴드 좌측 캡은 자리를 지키지만 스테이지 좌단은 0으로 내려간다. 그 차이가
+// mapControlsLead — 하한은 스테이지 원점 기준으로 재야 접힌 상태에서도 겹치지 않는다.
 export const COMMAND_BAND_MAP_CONTROLS_INSET_PX = 8;
 export const COMMAND_BAND_CENTER_BREATHING_PX = 12;
 export const COMMAND_BAND_CENTER_GUTTER_FLOOR_PX = 44;
 export const COMMAND_BAND_CENTER_MIN_PX = 168;
 
-export function commandBandCenterGutter(mapControlsWidth: number): number {
+// Activity Rail의 고정 스트립 폭. 패널 폭은 포함하지 않는다 — PR #302가 밴드를 레일
+// 크기 조절에서 떼어냈고, 여기서 예약하는 것은 접히지 않은 레일이 늘 차지하는 스트립뿐이다.
+export const COMMAND_BAND_RAIL_STRIP_PX = 44;
+
+export function commandBandCenterGutter(mapControlsLead: number, mapControlsWidth: number): number {
   if (mapControlsWidth <= 0) return COMMAND_BAND_CENTER_GUTTER_FLOOR_PX;
   return Math.max(
     COMMAND_BAND_CENTER_GUTTER_FLOOR_PX,
-    COMMAND_BAND_MAP_CONTROLS_INSET_PX + mapControlsWidth + COMMAND_BAND_CENTER_BREATHING_PX,
+    mapControlsLead + COMMAND_BAND_MAP_CONTROLS_INSET_PX + mapControlsWidth + COMMAND_BAND_CENTER_BREATHING_PX,
   );
 }
 

--- a/runtime/fleet-console/core/client/src/components/command-band-guards.ts
+++ b/runtime/fleet-console/core/client/src/components/command-band-guards.ts
@@ -51,3 +51,26 @@ export function commandBandMenuClampedLeft(
   const minLeft = gutter - wrapperViewportLeft;
   return Math.max(minLeft, Math.min(desiredLeft, maxLeft));
 }
+
+// 맵 컨트롤 클러스터(.command-band-map-controls)는 절대 배치라 그리드가 그 폭을 모른다.
+// 매직 오프셋 상수는 버튼이 늘 때마다 겹침으로 깨졌으므로(구 116px 사고) 실측 폭에서 계산한다.
+// 좌우 여백 트랙은 반드시 같은 하한을 쓴다 — 값이 어긋나면 하한이 물리는 순간 중앙이 밀린다.
+export const COMMAND_BAND_MAP_CONTROLS_INSET_PX = 8;
+export const COMMAND_BAND_CENTER_BREATHING_PX = 12;
+export const COMMAND_BAND_CENTER_GUTTER_FLOOR_PX = 44;
+export const COMMAND_BAND_CENTER_MIN_PX = 168;
+
+export function commandBandCenterGutter(mapControlsWidth: number): number {
+  if (mapControlsWidth <= 0) return COMMAND_BAND_CENTER_GUTTER_FLOOR_PX;
+  return Math.max(
+    COMMAND_BAND_CENTER_GUTTER_FLOOR_PX,
+    COMMAND_BAND_MAP_CONTROLS_INSET_PX + mapControlsWidth + COMMAND_BAND_CENTER_BREATHING_PX,
+  );
+}
+
+// 좌우 여백 트랙을 뺀 나머지가 최소 판독 폭에 못 미치면 브레드크럼을 접는다.
+// 미측정(0 이하)은 보이는 쪽으로 판정한다 — 첫 페인트에서 깜빡이며 사라지지 않게 한다.
+export function commandBandCenterFits(centerTrackWidth: number, gutter: number): boolean {
+  if (centerTrackWidth <= 0) return true;
+  return centerTrackWidth - gutter * 2 >= COMMAND_BAND_CENTER_MIN_PX;
+}

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -206,9 +206,16 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   }, [state.activeTheaterId, state.activeOperationId]);
 
   // 접힌 브레드크럼은 트리거째 사라진다 — 열려 있던 메뉴가 고아로 남지 않게 같이 닫는다.
+  // 편집 중이던 rename도 여기서 취소한다: 포커스된 input이 언마운트돼도 blur가 발화하지 않아
+  // (실브라우저 실측) 다시 넓히면 스테일 draft가 포커스 없이 되살아나고, 그 상태에서는
+  // Escape·Enter가 닿지 않아 input을 다시 클릭하기 전까지 편집을 끝낼 수 없다.
   useEffect(() => {
-    if (!centerBreadcrumbVisible) setSwitcherMenu(null);
-  }, [centerBreadcrumbVisible]);
+    if (centerBreadcrumbVisible) return;
+    setSwitcherMenu(null);
+    if (!rename.renaming) return;
+    renameTargetOperationIdRef.current = null;
+    rename.cancel();
+  }, [centerBreadcrumbVisible, rename]);
 
   // Operation 메뉴는 자기 트리거 아래 정렬(래퍼 offsetLeft), Theater 메뉴는 좌단 기준 —
   // 어느 쪽이든 좁은 viewport에서 우측이 화면을 넘지 않도록 실측 clamp하고 resize 시 재측정한다.

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -5,7 +5,7 @@ import { resolveLocalizedText } from "@fleet-console/sdk/i18n/translate";
 import { fetchConsoleEnvironment, fetchOperations, renameOperation } from "../api.js";
 import { animateViewportTo, fitAllOperations, selectFormationLayout, useCanvasState, useFormationLayout, useFormationView } from "../canvas/canvas-store.js";
 import { enterTriage, focusedTriageOperationId, setTriageActive, useTriageActive } from "../canvas/triage-store.js";
-import { commandBandActiveOperation, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "./command-band-guards.js";
+import { commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "./command-band-guards.js";
 import { CommandBandOperationMenu, CommandBandTheaterMenu, CommandBandTriggerCaret, type CommandBandSwitcherMenu } from "./command-band-switcher.js";
 import { FleetBrandHome } from "./side-bar-brand-foot.js";
 import { useGlobalSettingsStore } from "../global-settings-store.js";
@@ -65,6 +65,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const environmentTriggerRef = useRef<HTMLButtonElement>(null);
   const environmentPopoverRef = useRef<HTMLDivElement>(null);
   const commandBandRef = useRef<HTMLElement>(null);
+  const mapControlsRef = useRef<HTMLDivElement>(null);
   const edgeRevealRef = useRef<HTMLButtonElement>(null);
   const pointerWithinRef = useRef({ edge: false, band: false });
   const renameTargetOperationIdRef = useRef<string | null>(null);
@@ -74,12 +75,16 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const switcherMenuRef = useRef<HTMLDivElement>(null);
   const [switcherMenu, setSwitcherMenu] = useState<CommandBandSwitcherMenu | null>(null);
   const [switcherMenuLeft, setSwitcherMenuLeft] = useState(0);
+  const [bandWidth, setBandWidth] = useState(0);
+  const [mapControlsWidth, setMapControlsWidth] = useState(0);
   const [environmentOpen, setEnvironmentOpen] = useState(false);
   const [environment, setEnvironment] = useState<ConsoleEnvironmentDiagnostics | null>(null);
   const [environmentError, setEnvironmentError] = useState<string | null>(null);
   const [environmentLoading, setEnvironmentLoading] = useState(false);
   const [copiedValue, setCopiedValue] = useState<string | null>(null);
   const [copyFailedValue, setCopyFailedValue] = useState<string | null>(null);
+  const centerGutter = commandBandCenterGutter(mapControlsWidth);
+  const centerBreadcrumbVisible = viewMode.effective !== "mobile" && commandBandCenterFits(bandWidth - sideBar.width, centerGutter);
   // 열림/닫힘 전환 시 이벤트 핸들러에서 동기 호출한다 — open effect(폐기 후 fetch)는 paint 뒤에 돌므로
   // 여기서 지우지 않으면 재오픈 첫 프레임에 이전 절대경로가 그대로 렌더된다.
   const discardEnvironmentState = () => {
@@ -193,6 +198,11 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
     setSwitcherMenu(null);
   }, [state.activeTheaterId, state.activeOperationId]);
 
+  // 접힌 브레드크럼은 트리거째 사라진다 — 열려 있던 메뉴가 고아로 남지 않게 같이 닫는다.
+  useEffect(() => {
+    if (!centerBreadcrumbVisible) setSwitcherMenu(null);
+  }, [centerBreadcrumbVisible]);
+
   // Operation 메뉴는 자기 트리거 아래 정렬(래퍼 offsetLeft), Theater 메뉴는 좌단 기준 —
   // 어느 쪽이든 좁은 viewport에서 우측이 화면을 넘지 않도록 실측 clamp하고 resize 시 재측정한다.
   useLayoutEffect(() => {
@@ -208,6 +218,24 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
     window.addEventListener("resize", measure);
     return () => window.removeEventListener("resize", measure);
   }, [switcherMenu]);
+
+  // 맵 컨트롤은 절대 배치라 그리드 트랙에 잡히지 않는다 — 밴드 폭과 클러스터 폭을 실측해
+  // 여백 하한과 브레드크럼 접힘을 판정한다. 사이드바 폭이 드래그로 변하므로 viewport
+  // 미디어쿼리로는 판정할 수 없다.
+  useLayoutEffect(() => {
+    const band = commandBandRef.current;
+    if (!band || typeof ResizeObserver === "undefined") return;
+    const measure = () => {
+      setBandWidth(band.clientWidth);
+      setMapControlsWidth(mapControlsRef.current?.offsetWidth ?? 0);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(band);
+    const mapControls = mapControlsRef.current;
+    if (mapControls) observer.observe(mapControls);
+    return () => observer.disconnect();
+  }, [operationsViewVisible]);
 
   useEffect(() => {
     if (state.channel === "local") return;
@@ -323,7 +351,10 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
       <header
         ref={commandBandRef}
         className={`command-band${requestedOperationsViewVisible ? " is-operations" : " is-utility"}${fullscreen.isFullscreen ? " is-fullscreen" : ""}${fullscreen.isVisible ? " is-revealed" : ""}`}
-        style={{ "--command-band-left-width": viewMode.effective === "mobile" ? "min-content" : `${sideBar.width}px` } as CSSProperties}
+        style={{
+          "--command-band-left-width": viewMode.effective === "mobile" ? "min-content" : `${sideBar.width}px`,
+          "--command-band-center-gutter": `${centerGutter}px`,
+        } as CSSProperties}
         aria-hidden={commandBandHidden || undefined}
         inert={commandBandHidden || undefined}
         onPointerEnter={handleBandPointerEnter}
@@ -352,7 +383,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
           <SearchIcon />
         </button>
       </div>
-      {operationsViewVisible ? <div className="command-band-map-controls">
+      {operationsViewVisible ? <div ref={mapControlsRef} className="command-band-map-controls">
         <div className="command-band-formation-group" role="group" aria-label={t("chrome.commandBand.formationView")}>
         <button type="button" className="command-band-formation-toggle command-band-formation-seg" onClick={() => animateViewportTo({ x: 0, y: 0, zoom: 1 })} disabled={state.activeTheaterId === null} aria-label={t("chrome.commandBand.resetCanvasView")} title={t("chrome.commandBand.resetCanvasView")}><ResetViewIcon /></button>
         <button type="button" className="command-band-formation-toggle command-band-formation-seg" onClick={fitAllOperations} disabled={state.activeTheaterId === null || triageActive || !state.operationsHydrated} aria-label={t("chrome.commandBand.fitAllPanels")} title={t("chrome.commandBand.fitAllPanels")}><FitAllIcon /></button>
@@ -384,7 +415,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
         {triageActive ? <span>{t("chrome.commandBand.triage")}</span> : null}
         </button>
       </div> : null}
-      {viewMode.effective !== "mobile" ? <div className="command-band-center">
+      {centerBreadcrumbVisible ? <div className="command-band-center">
         {operationsViewVisible && activeTheater ? <div ref={switcherRef} className="command-band-switcher" onBlur={handleSwitcherFocusOut}>
           <div className="command-band-theater-cluster" aria-label={t("chrome.commandBand.activeTheater", { label: activeTheater.label })}>
             <button

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -88,6 +88,10 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const stageRightWidth = railChromeExpanded ? COMMAND_BAND_RAIL_STRIP_PX : 0;
   const centerGutter = commandBandCenterGutter(sideBar.width - stageLeftWidth, mapControlsWidth);
   const centerBreadcrumbVisible = viewMode.effective !== "mobile" && commandBandCenterFits(bandWidth - stageLeftWidth - stageRightWidth, centerGutter);
+  // 접힌 뒤에는 여백 트랙이 지킬 대상이 없다. 하한을 그대로 두면 고정 트랙 합이 밴드 폭을 넘어
+  // 우측 컨트롤이 화면 밖으로 밀린다 — 사이드바를 넓게 늘린 뒤 접으면 하한이 캡 폭만큼 커져
+  // 1280px 창에서도 터진다. 판정용 centerGutter는 그대로 두어 되돌아오는 폭이 흔들리지 않게 한다.
+  const injectedCenterGutter = centerBreadcrumbVisible ? centerGutter : 0;
   // 열림/닫힘 전환 시 이벤트 핸들러에서 동기 호출한다 — open effect(폐기 후 fetch)는 paint 뒤에 돌므로
   // 여기서 지우지 않으면 재오픈 첫 프레임에 이전 절대경로가 그대로 렌더된다.
   const discardEnvironmentState = () => {
@@ -358,7 +362,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
           "--command-band-left-width": viewMode.effective === "mobile" ? "min-content" : `${sideBar.width}px`,
           "--command-band-stage-left": viewMode.effective === "mobile" ? "min-content" : `${stageLeftWidth}px`,
           "--command-band-stage-right": `${stageRightWidth}px`,
-          "--command-band-center-gutter": `${centerGutter}px`,
+          "--command-band-center-gutter": `${injectedCenterGutter}px`,
         } as CSSProperties}
         aria-hidden={commandBandHidden || undefined}
         inert={commandBandHidden || undefined}

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -5,7 +5,7 @@ import { resolveLocalizedText } from "@fleet-console/sdk/i18n/translate";
 import { fetchConsoleEnvironment, fetchOperations, renameOperation } from "../api.js";
 import { animateViewportTo, fitAllOperations, selectFormationLayout, useCanvasState, useFormationLayout, useFormationView } from "../canvas/canvas-store.js";
 import { enterTriage, focusedTriageOperationId, setTriageActive, useTriageActive } from "../canvas/triage-store.js";
-import { commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "./command-band-guards.js";
+import { COMMAND_BAND_RAIL_STRIP_PX, commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "./command-band-guards.js";
 import { CommandBandOperationMenu, CommandBandTheaterMenu, CommandBandTriggerCaret, type CommandBandSwitcherMenu } from "./command-band-switcher.js";
 import { FleetBrandHome } from "./side-bar-brand-foot.js";
 import { useGlobalSettingsStore } from "../global-settings-store.js";
@@ -83,8 +83,11 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const [environmentLoading, setEnvironmentLoading] = useState(false);
   const [copiedValue, setCopiedValue] = useState<string | null>(null);
   const [copyFailedValue, setCopyFailedValue] = useState<string | null>(null);
-  const centerGutter = commandBandCenterGutter(mapControlsWidth);
-  const centerBreadcrumbVisible = viewMode.effective !== "mobile" && commandBandCenterFits(bandWidth - sideBar.width, centerGutter);
+  // 정렬 앵커는 실제 스테이지 경계다 — 접힌 사이드바는 폭 0, 접힌 레일 크롬은 스트립 0.
+  const stageLeftWidth = sideBar.collapsed ? 0 : sideBar.width;
+  const stageRightWidth = railChromeExpanded ? COMMAND_BAND_RAIL_STRIP_PX : 0;
+  const centerGutter = commandBandCenterGutter(sideBar.width - stageLeftWidth, mapControlsWidth);
+  const centerBreadcrumbVisible = viewMode.effective !== "mobile" && commandBandCenterFits(bandWidth - stageLeftWidth - stageRightWidth, centerGutter);
   // 열림/닫힘 전환 시 이벤트 핸들러에서 동기 호출한다 — open effect(폐기 후 fetch)는 paint 뒤에 돌므로
   // 여기서 지우지 않으면 재오픈 첫 프레임에 이전 절대경로가 그대로 렌더된다.
   const discardEnvironmentState = () => {
@@ -353,6 +356,8 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
         className={`command-band${requestedOperationsViewVisible ? " is-operations" : " is-utility"}${fullscreen.isFullscreen ? " is-fullscreen" : ""}${fullscreen.isVisible ? " is-revealed" : ""}`}
         style={{
           "--command-band-left-width": viewMode.effective === "mobile" ? "min-content" : `${sideBar.width}px`,
+          "--command-band-stage-left": viewMode.effective === "mobile" ? "min-content" : `${stageLeftWidth}px`,
+          "--command-band-stage-right": `${stageRightWidth}px`,
           "--command-band-center-gutter": `${centerGutter}px`,
         } as CSSProperties}
         aria-hidden={commandBandHidden || undefined}

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -55,15 +55,18 @@
   min-height: 0;
 }
 
-/* 중앙 브레드크럼은 사이드바 트랙을 제외한 나머지 폭(중앙 스테이지)의 정중앙에 놓는다 —
-   좌측 트랙을 1fr로 두면 여백이 밴드 전체폭 기준으로 나뉘어 사이드바까지 포함해 정렬된다.
-   좌우 여백 트랙은 동일 하한 + 동일 1fr이라 하한이 물려도 중심이 유지된다. 하한은
+/* 중앙 브레드크럼은 실제 중앙 스테이지(.operations-center-stage)의 정중앙에 놓는다 —
+   좌측 앵커는 실제 사이드바 폭(접히면 0), 우측 앵커는 Activity Rail의 고정 스트립 폭이다.
+   레일 "패널" 폭은 예약하지 않는다: PR #302가 밴드를 레일 크기 조절에서 떼어냈고, 그 결정은 유효하다.
+   좌우 여백 트랙은 동일 하한 + 동일 1fr이라 하한이 물려도 중심이 유지된다. 하한은 좌측 캡과
    맵 컨트롤 실측 폭에서 계산해 밴드에 주입한다(--command-band-center-gutter). */
 .command-band {
   --command-band-center-gutter: 44px;
+  --command-band-stage-left: var(--command-band-left-width, 280px);
+  --command-band-stage-right: 0px;
   position: relative;
   display: grid;
-  grid-template-columns: var(--command-band-left-width, 280px) minmax(var(--command-band-center-gutter), 1fr) minmax(0, max-content) minmax(var(--command-band-center-gutter), 1fr);
+  grid-template-columns: var(--command-band-stage-left) minmax(var(--command-band-center-gutter), 1fr) minmax(0, max-content) minmax(var(--command-band-center-gutter), 1fr) var(--command-band-stage-right);
   flex: none;
   height: var(--chrome-band-height);
   min-height: var(--chrome-band-height);
@@ -108,7 +111,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 }
 
 .command-band.is-utility {
-  grid-template-columns: auto minmax(0, 1fr) minmax(0, max-content) auto;
+  grid-template-columns: auto minmax(0, 1fr) minmax(0, max-content) auto 0px;
 }
 
 .command-band-left,
@@ -120,7 +123,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 }
 
 .command-band-left {
-  grid-column: 1;
+  grid-column: 1 / 3;
   width: var(--command-band-left-width, 280px);
   gap: var(--space-1);
   padding-inline: var(--space-2);
@@ -301,7 +304,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 }
 
 .command-band-right {
-  grid-column: 4;
+  grid-column: 4 / 6;
   justify-content: flex-end;
   gap: var(--space-1);
   padding-inline: var(--space-2);

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -55,10 +55,15 @@
   min-height: 0;
 }
 
+/* 중앙 브레드크럼은 사이드바 트랙을 제외한 나머지 폭(중앙 스테이지)의 정중앙에 놓는다 —
+   좌측 트랙을 1fr로 두면 여백이 밴드 전체폭 기준으로 나뉘어 사이드바까지 포함해 정렬된다.
+   좌우 여백 트랙은 동일 하한 + 동일 1fr이라 하한이 물려도 중심이 유지된다. 하한은
+   맵 컨트롤 실측 폭에서 계산해 밴드에 주입한다(--command-band-center-gutter). */
 .command-band {
+  --command-band-center-gutter: 44px;
   position: relative;
   display: grid;
-  grid-template-columns: minmax(var(--command-band-left-width, 280px), 1fr) minmax(0, max-content) minmax(44px, 1fr);
+  grid-template-columns: var(--command-band-left-width, 280px) minmax(var(--command-band-center-gutter), 1fr) minmax(0, max-content) minmax(var(--command-band-center-gutter), 1fr);
   flex: none;
   height: var(--chrome-band-height);
   min-height: var(--chrome-band-height);
@@ -103,7 +108,7 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 }
 
 .command-band.is-utility {
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) minmax(0, max-content) auto;
 }
 
 .command-band-left,
@@ -289,14 +294,14 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 }
 
 .command-band-center {
-  grid-column: 2;
+  grid-column: 3;
   justify-content: center;
   gap: var(--space-3);
   padding-inline: var(--space-3);
 }
 
 .command-band-right {
-  grid-column: 3;
+  grid-column: 4;
   justify-content: flex-end;
   gap: var(--space-1);
   padding-inline: var(--space-2);

--- a/runtime/fleet-console/tests/command-band-v2-guards.test.ts
+++ b/runtime/fleet-console/tests/command-band-v2-guards.test.ts
@@ -5,7 +5,7 @@ import { resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { commandBandActiveOperation, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "../core/client/src/components/command-band-guards.js";
+import { commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "../core/client/src/components/command-band-guards.js";
 import type { OperationGroup, OperationNode } from "../core/client/src/types.js";
 
 describe("Command Band v2 guards", () => {
@@ -96,6 +96,28 @@ describe("Command Band menu viewport clamp", () => {
 
   it("prioritizes the left gutter when the menu is wider than the viewport", () => {
     expect(commandBandMenuClampedLeft(0, 20, 500, 480)).toBe(12 - 20);
+  });
+});
+
+describe("Command Band center visibility measurements", () => {
+  it("uses the floor gutter while map controls are unmeasured or narrower than the floor", () => {
+    expect(commandBandCenterGutter(0)).toBe(44);
+    expect(commandBandCenterGutter(1)).toBe(44);
+  });
+
+  it("derives the gutter from the measured map control width", () => {
+    expect(commandBandCenterGutter(163)).toBe(8 + 163 + 12);
+  });
+
+  it("keeps the center visible while the track is unmeasured", () => {
+    expect(commandBandCenterFits(0, 183)).toBe(true);
+    expect(commandBandCenterFits(-1, 183)).toBe(true);
+  });
+
+  it("requires the two gutters plus the minimum readable center width", () => {
+    const gutter = 183;
+    expect(commandBandCenterFits(gutter * 2 + 168, gutter)).toBe(true);
+    expect(commandBandCenterFits(gutter * 2 + 168 - 1, gutter)).toBe(false);
   });
 });
 

--- a/runtime/fleet-console/tests/command-band-v2-guards.test.ts
+++ b/runtime/fleet-console/tests/command-band-v2-guards.test.ts
@@ -101,12 +101,14 @@ describe("Command Band menu viewport clamp", () => {
 
 describe("Command Band center visibility measurements", () => {
   it("uses the floor gutter while map controls are unmeasured or narrower than the floor", () => {
-    expect(commandBandCenterGutter(0)).toBe(44);
-    expect(commandBandCenterGutter(1)).toBe(44);
+    expect(commandBandCenterGutter(0, 0)).toBe(44);
+    expect(commandBandCenterGutter(0, 1)).toBe(44);
   });
 
   it("derives the gutter from the measured map control width", () => {
-    expect(commandBandCenterGutter(163)).toBe(8 + 163 + 12);
+    expect(commandBandCenterGutter(0, 163)).toBe(8 + 163 + 12);
+    // 사이드바를 접으면 좌측 캡(280px)이 스테이지 원점보다 앞서므로 그만큼 하한이 커진다.
+    expect(commandBandCenterGutter(280, 163)).toBe(280 + 8 + 163 + 12);
   });
 
   it("keeps the center visible while the track is unmeasured", () => {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -722,7 +722,7 @@ describe("Instrument core design contract", () => {
     expect(commandBand).toContain('className="command-band-button command-band-rail-toggle"');
     expect(commandBand).toContain("onClick={toggleRailChrome}");
     expect(commandBand).toContain(`      </div>
-      {operationsViewVisible ? <div className="command-band-map-controls">`);
+      {operationsViewVisible ? <div ref={mapControlsRef} className="command-band-map-controls">`);
     expect(commandBand).toContain('aria-label={t("chrome.commandBand.resetCanvasView")}');
     expect(commandBand).toContain("<ResetViewIcon />");
     expect(commandBand).toContain("onClick={() => animateViewportTo({ x: 0, y: 0, zoom: 1 })}");
@@ -760,10 +760,21 @@ describe("Instrument core design contract", () => {
     // 데스크톱은 사이드바 폭을 그대로 미러하고, 모바일 셸에는 미러할 사이드바가 없으므로
     // 좌측 트랙이 내용 크기로 접힌다. 두 갈래를 한 줄로 고정해 한쪽만 바뀌는 표류를 막는다.
     expect(commandBand).toContain('"--command-band-left-width": viewMode.effective === "mobile" ? "min-content" : `${sideBar.width}px`');
-    expect(layout).toContain("grid-template-columns: minmax(var(--command-band-left-width, 280px), 1fr) minmax(0, max-content) minmax(44px, 1fr);");
-    expect(layout).toContain("width: var(--command-band-left-width, 280px);");
+    expect(layout).toContain("grid-template-columns: var(--command-band-left-width, 280px) minmax(var(--command-band-center-gutter), 1fr) minmax(0, max-content) minmax(var(--command-band-center-gutter), 1fr);");
     const commandBandCenterBlock = layout.match(/\.command-band-center \{[^}]*\}/)?.[0] ?? "";
     const commandBandRightBlocks = [...layout.matchAll(/\.command-band-right \{[^}]*\}/g)].map((match) => match[0]);
+    // 좌측 트랙은 사이드바 폭으로 고정하고 좌우 여백 트랙은 동일 하한을 공유한다 —
+    // 어느 한쪽이라도 어긋나면 브레드크럼이 사이드바를 포함한 전체폭 기준으로 다시 밀린다.
+    expect(layout).toContain(".command-band.is-utility {\n  grid-template-columns: auto minmax(0, 1fr) minmax(0, max-content) auto;\n}");
+    expect(layout).toContain("  --command-band-center-gutter: 44px;");
+    expect(commandBandCenterBlock).toContain("grid-column: 3;");
+    expect(commandBandRightBlocks.some((block) => block.includes("grid-column: 4;"))).toBe(true);
+    expect(commandBand).toContain('"--command-band-center-gutter": `${centerGutter}px`,');
+    expect(commandBand).toContain("{centerBreadcrumbVisible ? <div className=\"command-band-center\">");
+    // 밴드 조상에 container-type을 걸면 contain:layout이 stacking context를 만들어
+    // .command-band-menu(z-index:45)가 우현 레일 아래로 깔린다 — 판정은 JS 실측 전용.
+    expect(layout).not.toContain("container-type");
+    expect(layout).toContain("width: var(--command-band-left-width, 280px);");
     expect(commandBandCenterBlock).toContain("justify-content: center;");
     expect(commandBandCenterBlock).not.toContain("overflow:");
     expect(commandBandRightBlocks.some((block) => block.includes("justify-content: flex-end;"))).toBe(true);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -781,6 +781,9 @@ describe("Instrument core design contract", () => {
     expect(commandBand).toContain("const injectedCenterGutter = centerBreadcrumbVisible ? centerGutter : 0;");
     expect(commandBand).toContain('"--command-band-center-gutter": `${injectedCenterGutter}px`,');
     expect(commandBand).toContain("{centerBreadcrumbVisible ? <div className=\"command-band-center\">");
+    // 접힘은 편집 중이던 input을 언마운트하는데 blur가 발화하지 않는다 — 취소를 빼면 다시 넓혔을 때
+    // 포커스 없는 스테일 draft로 되살아나 키보드로 빠져나올 수 없다.
+    expect(commandBand).toContain("    if (!rename.renaming) return;\n    renameTargetOperationIdRef.current = null;\n    rename.cancel();");
     // 밴드 조상에 container-type을 걸면 contain:layout이 stacking context를 만들어
     // .command-band-menu(z-index:45)가 우현 레일 아래로 깔린다 — 판정은 JS 실측 전용.
     expect(layout).not.toContain("container-type");

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -760,15 +760,22 @@ describe("Instrument core design contract", () => {
     // 데스크톱은 사이드바 폭을 그대로 미러하고, 모바일 셸에는 미러할 사이드바가 없으므로
     // 좌측 트랙이 내용 크기로 접힌다. 두 갈래를 한 줄로 고정해 한쪽만 바뀌는 표류를 막는다.
     expect(commandBand).toContain('"--command-band-left-width": viewMode.effective === "mobile" ? "min-content" : `${sideBar.width}px`');
-    expect(layout).toContain("grid-template-columns: var(--command-band-left-width, 280px) minmax(var(--command-band-center-gutter), 1fr) minmax(0, max-content) minmax(var(--command-band-center-gutter), 1fr);");
+    expect(layout).toContain("grid-template-columns: var(--command-band-stage-left) minmax(var(--command-band-center-gutter), 1fr) minmax(0, max-content) minmax(var(--command-band-center-gutter), 1fr) var(--command-band-stage-right);");
     const commandBandCenterBlock = layout.match(/\.command-band-center \{[^}]*\}/)?.[0] ?? "";
+    const commandBandLeftBlocks = [...layout.matchAll(/\.command-band-left \{[^}]*\}/g)].map((match) => match[0]);
     const commandBandRightBlocks = [...layout.matchAll(/\.command-band-right \{[^}]*\}/g)].map((match) => match[0]);
-    // 좌측 트랙은 사이드바 폭으로 고정하고 좌우 여백 트랙은 동일 하한을 공유한다 —
-    // 어느 한쪽이라도 어긋나면 브레드크럼이 사이드바를 포함한 전체폭 기준으로 다시 밀린다.
-    expect(layout).toContain(".command-band.is-utility {\n  grid-template-columns: auto minmax(0, 1fr) minmax(0, max-content) auto;\n}");
+    // 바깥 트랙은 실제 스테이지 경계(접힌 사이드바 0, 접힌 레일 스트립 0)를 담고, 좌측 캡과 우측
+    // 클러스터는 여백 트랙까지 걸쳐 밴드 양끝에 붙는다. 좌우 여백 트랙은 동일 하한을 공유한다 —
+    // 어느 한쪽이라도 어긋나면 브레드크럼이 스테이지 중심에서 밀린다.
+    expect(layout).toContain(".command-band.is-utility {\n  grid-template-columns: auto minmax(0, 1fr) minmax(0, max-content) auto 0px;\n}");
     expect(layout).toContain("  --command-band-center-gutter: 44px;");
+    expect(layout).toContain("  --command-band-stage-left: var(--command-band-left-width, 280px);");
+    expect(layout).toContain("  --command-band-stage-right: 0px;");
+    expect(commandBandLeftBlocks.some((block) => block.includes("grid-column: 1 / 3;"))).toBe(true);
     expect(commandBandCenterBlock).toContain("grid-column: 3;");
-    expect(commandBandRightBlocks.some((block) => block.includes("grid-column: 4;"))).toBe(true);
+    expect(commandBandRightBlocks.some((block) => block.includes("grid-column: 4 / 6;"))).toBe(true);
+    expect(commandBand).toContain('"--command-band-stage-left": viewMode.effective === "mobile" ? "min-content" : `${stageLeftWidth}px`,');
+    expect(commandBand).toContain('"--command-band-stage-right": `${stageRightWidth}px`,');
     expect(commandBand).toContain('"--command-band-center-gutter": `${centerGutter}px`,');
     expect(commandBand).toContain("{centerBreadcrumbVisible ? <div className=\"command-band-center\">");
     // 밴드 조상에 container-type을 걸면 contain:layout이 stacking context를 만들어

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -776,7 +776,10 @@ describe("Instrument core design contract", () => {
     expect(commandBandRightBlocks.some((block) => block.includes("grid-column: 4 / 6;"))).toBe(true);
     expect(commandBand).toContain('"--command-band-stage-left": viewMode.effective === "mobile" ? "min-content" : `${stageLeftWidth}px`,');
     expect(commandBand).toContain('"--command-band-stage-right": `${stageRightWidth}px`,');
-    expect(commandBand).toContain('"--command-band-center-gutter": `${centerGutter}px`,');
+    // 접힌 뒤에도 여백 하한을 주입하면 고정 트랙 합이 밴드 폭을 넘어 우측 컨트롤이 화면 밖으로
+    // 밀린다(넓힌 사이드바를 접었을 때 특히). 주입값과 판정값을 분리해 고정한다.
+    expect(commandBand).toContain("const injectedCenterGutter = centerBreadcrumbVisible ? centerGutter : 0;");
+    expect(commandBand).toContain('"--command-band-center-gutter": `${injectedCenterGutter}px`,');
     expect(commandBand).toContain("{centerBreadcrumbVisible ? <div className=\"command-band-center\">");
     // 밴드 조상에 container-type을 걸면 contain:layout이 stacking context를 만들어
     // .command-band-menu(z-index:45)가 우현 레일 아래로 깔린다 — 판정은 JS 실측 전용.


### PR DESCRIPTION
## Summary

- Command band 가운데의 Theater · Operation · CLI 경로 표시(breadcrumb)가 창 전체 폭 기준으로 정렬되어 왼쪽 사이드바까지 포함한 중앙에 놓이던 문제를 고칩니다. 이제 실제 가운데 패널 영역(`.operations-center-stage`)의 정중앙에 놓입니다.
- 창이 좁아져 breadcrumb이 왼쪽 맵 컨트롤(보기 초기화 · 전체 맞춤 · Formation · 선별 처리)에 닿기 직전이 되면 breadcrumb을 접고, 자리가 생기면 즉시 되돌립니다.

## Type of Change

- [x] fix — bug fix

## Scope

- [x] `runtime/fleet-console` (core/client chrome)

## 구현 노트

- `.command-band` 그리드를 5열(`stage-left | 여백 | breadcrumb | 여백 | stage-right`)로 바꾸고, 좌우 여백 트랙이 같은 하한과 같은 `1fr`을 공유하게 해 하한이 물려도 중심이 유지되게 했습니다.
- 정렬 앵커는 실제 렌더 경계입니다. 좌측은 사이드바 실폭(접히면 0), 우측은 Activity Rail의 고정 스트립(크롬 접히면 0)입니다.
- 레일 **패널** 폭은 추종하지 않습니다. PR #302가 command band를 레일 크기 조절에서 의도적으로 떼어냈고 그 결정을 유지합니다. 예약 대상은 접히지 않은 레일이 늘 차지하는 44px 스트립뿐입니다.
- 맵 컨트롤은 절대 배치라 그리드가 폭을 모릅니다. 하드코딩 오프셋은 과거 버튼 추가 때마다 겹침으로 깨졌으므로 `ResizeObserver` 실측 폭에서 여백 하한을 계산합니다.
- 접힘 판정은 CSS container query가 아니라 JS 실측입니다. 밴드 조상에 `container-type`을 걸면 `contain: layout`이 새 stacking context를 만들어 경로 전환 드롭다운(`z-index: 45`)이 우현 레일 아래로 깔립니다.

## Trade-offs

- 우현 레일 패널을 열면 가운데 패널이 좁아지지만 breadcrumb은 따라 움직이지 않습니다(위 PR #302 결정).
- 사이드바를 접으면 밴드 좌측 블록은 자리를 지키는데 패널 영역의 왼쪽 끝은 0으로 내려가므로, 중앙 정렬을 유지하려면 접힘 임계치가 그만큼(280px) 앞당겨집니다. 겹침은 발생하지 않습니다.

## Test Plan

- [x] `pnpm --filter fleet-console build`
- [x] `pnpm --filter fleet-console test` — 1222 passed / 19 skipped. `tests/server.test.ts`와 `tests/codex-security-routes.test.ts`는 canary에서도 동일하게 unhandled error 2건을 내는 선존 결함으로, 기준선 대조로 확인했습니다.
- [x] 헤디드 실측 — breadcrumb 중심과 가운데 패널 중심의 delta: 1440/1280/1024 × 사이드바 280px/503px/접힘 모두 0px(접힘만 반올림 -0.5px), 레일 크롬 접힘 +0.5px
- [x] 헤디드 실측 — 접힘 임계치와 직전 프레임 좌측 gap: 사이드바 펼침 842px/24px, 펼침+선별 처리 944px/24.3px, 접힘 1122px/24px, 접힘+선별 처리 1224px/24.3px. 네 조합 모두 재확대 시 복귀하며 히스테리시스 없음
- [x] 회귀 — 드롭다운 `z-index: 45` 유지 및 hit-test 최상단, 접힘 시 열린 메뉴 동반 종료, 인라인 rename, 긴 이름 말줄임 + 문서 가로 overflow 0, 접힘 상태 좌측 블록 컨트롤 겹침 0, 우측 클러스터 밴드 우단 정렬, 모바일 700/500/360px 및 utility 화면 overflow 0, 브라우저 오류 0건
- [x] 디자인 — Instrument · Maritime · Carbon 세 테마 대조, 첫 페인트 플리커 없음

## Changelog

- [x] `.changelog.d/pr-422.md` 한 개를 추가했습니다.
- [x] 섹션은 `Added`와 `Fixed`만 사용합니다.
- [x] 영문 bullet은 ASCII, 한글 `ko:` 줄이 각 bullet 바로 아래 붙어 있으며 태그는 `[fleet-console]`입니다.
- [x] `node scripts/compile-changelog-fragments.mjs --check` 통과 (20 entries validated).