### PR TITLE
fix(console): keep operations SSE connections alive

### DIFF
--- a/.changelog.d/pr-425.md
+++ b/.changelog.d/pr-425.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Keep idle operations streams connected across loopback and WSL networking.
+  ko: loopback 및 WSL 네트워크에서 유휴 Operations 스트림 연결이 유지되도록 합니다.

--- a/.changelog.d/pr-425.md
+++ b/.changelog.d/pr-425.md
@@ -1,4 +1,4 @@
 ### fleet-console
 #### Fixed
-- [fleet-console] Keep idle operations streams connected across loopback and WSL networking.
-  ko: loopback 및 WSL 네트워크에서 유휴 Operations 스트림 연결이 유지되도록 합니다.
+- [fleet-console] Keep idle operations streams connected across local networking environments.
+  ko: 로컬 네트워크 환경에서 유휴 Operations 스트림 연결이 유지되도록 합니다.

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -39,7 +39,7 @@ import { ConsoleReleaseNotesUnavailableError, type ReleaseNotesLocale } from "./
 import { RouteRegistry } from "./route-registry/route-registry.js";
 import { UpgradeRegistry } from "./route-registry/upgrade-registry.js";
 import { withSecurityHeaders } from "./security-headers.js";
-import { encodeSseData } from "./sse.js";
+import { encodeSseData, startSseKeepaliveLifecycle } from "./sse.js";
 import { createStaticConsoleHandler } from "./static-console.js";
 import { listTheaterFolders, TheaterFolderListError } from "./theater-folder-browser.js";
 import { createFolderGrantStore } from "./theater-folder-grants.js";
@@ -599,7 +599,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       res.write(":connected\n\n");
       res.write(encodeSseData(DESKTOP_FULLSCREEN_EVENT, desktopFullscreenSnapshot(desktopFullscreen)));
       operationSseSubscribers.add(res);
-      res.on("close", () => {
+      startSseKeepaliveLifecycle(res, () => {
         operationSseSubscribers.delete(res);
       });
     },

--- a/runtime/fleet-console/core/host/sse.ts
+++ b/runtime/fleet-console/core/host/sse.ts
@@ -1,3 +1,30 @@
+import type http from "node:http";
+
+export const SSE_KEEPALIVE_INTERVAL_MS = 30_000;
+
 export function encodeSseData(event: string, data: unknown): string {
   return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+export function startSseKeepaliveLifecycle(
+  res: http.ServerResponse,
+  onCleanup: () => void,
+): () => void {
+  res.setTimeout(0);
+  const interval = setInterval(() => {
+    if (res.writableEnded || res.destroyed) return;
+    res.write(": keepalive\n\n");
+  }, SSE_KEEPALIVE_INTERVAL_MS);
+  interval.unref();
+
+  let cleanedUp = false;
+  const cleanup = () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    clearInterval(interval);
+    onCleanup();
+  };
+  res.on("close", cleanup);
+  res.on("error", cleanup);
+  return cleanup;
 }

--- a/runtime/fleet-console/tests/host-sse.test.ts
+++ b/runtime/fleet-console/tests/host-sse.test.ts
@@ -1,0 +1,62 @@
+import { EventEmitter } from "node:events";
+
+import type http from "node:http";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { SSE_KEEPALIVE_INTERVAL_MS, startSseKeepaliveLifecycle } from "../core/host/sse.js";
+
+class TestResponse extends EventEmitter {
+  destroyed = false;
+  writableEnded = false;
+  readonly setTimeout = vi.fn();
+  readonly write = vi.fn();
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("SSE keepalive lifecycle", () => {
+  it("disables inactivity timeout and writes the exact heartbeat after 30 seconds", () => {
+    vi.useFakeTimers();
+    const res = new TestResponse();
+
+    startSseKeepaliveLifecycle(res as unknown as http.ServerResponse, vi.fn());
+
+    expect(res.setTimeout).toHaveBeenCalledWith(0);
+    vi.advanceTimersByTime(SSE_KEEPALIVE_INTERVAL_MS - 1);
+    expect(res.write).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(res.write).toHaveBeenCalledOnce();
+    expect(res.write).toHaveBeenCalledWith(": keepalive\n\n");
+  });
+
+  it.each(["close", "error"] as const)("stops the timer and cleans up idempotently on %s", (event) => {
+    vi.useFakeTimers();
+    const res = new TestResponse();
+    const cleanup = vi.fn();
+    const stop = startSseKeepaliveLifecycle(res as unknown as http.ServerResponse, cleanup);
+
+    res.emit(event);
+    stop();
+    vi.advanceTimersByTime(SSE_KEEPALIVE_INTERVAL_MS * 2);
+
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(res.write).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["ended", { writableEnded: true, destroyed: false }],
+    ["destroyed", { writableEnded: false, destroyed: true }],
+  ] as const)("does not write to an %s response", (_state, responseState) => {
+    vi.useFakeTimers();
+    const res = new TestResponse();
+    Object.assign(res, responseState);
+
+    startSseKeepaliveLifecycle(res as unknown as http.ServerResponse, vi.fn());
+    vi.advanceTimersByTime(SSE_KEEPALIVE_INTERVAL_MS);
+
+    expect(res.write).not.toHaveBeenCalled();
+  });
+});

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -2620,7 +2620,7 @@ describe("console static and terminal ticket boundary", () => {
     let destroyed = 0;
     const handler = createPluginTerminalUpgradeHandler({
       tickets: { consume: () => null },
-      sessions: { canAttach: () => true, createSession: async () => undefined, attach: async () => undefined, getSessionMessagePolicy: () => undefined, getSessionRenameCommand: () => undefined, resolveSessionIdentity: async () => null, terminate: () => false, stop: async () => undefined, writeToSession: () => false },
+      sessions: { canAttach: () => true, createSession: async () => undefined, attach: async () => undefined, getSessionMessagePolicy: () => undefined, getSessionRenameCommand: () => undefined, getSessionLastActivityAt: () => null, resolveSessionIdentity: async () => null, terminate: () => false, stop: async () => undefined, writeToSession: () => false },
       isAuthorized: () => true,
     });
 
@@ -2654,6 +2654,7 @@ describe("console static and terminal ticket boundary", () => {
         attach: async () => undefined,
         getSessionMessagePolicy: () => undefined,
         getSessionRenameCommand: () => undefined,
+        getSessionLastActivityAt: () => null,
         resolveSessionIdentity: async () => null,
         terminate: () => false,
         stop: async () => undefined,


### PR DESCRIPTION
## Summary
- Keep the Console operations SSE connection active with a 30-second comment heartbeat and response-scoped inactivity timeout disablement.
- Clean up the keepalive timer and operation subscriber on both response close and error.
- Restore the current `TerminalSessionManager` contract in two Console server test doubles.
- Reproduction is confirmed on both WSL and Darwin, so the fix and release wording are platform-agnostic.

## Test Plan
- [x] `pnpm --dir runtime/fleet-console exec vitest run tests/host-sse.test.ts`
- [x] Targeted operations SSE integration test in `tests/server.test.ts`
- [x] Targeted terminal WebSocket tests covering the corrected mocks
- [x] `pnpm --dir runtime/fleet-console typecheck`
- [x] `pnpm --dir runtime/fleet-console build`
- [ ] Full Console suite: pre-existing `FloatingWidgetLayer` fixture failure reproduced identically on clean `canary`
- [x] Added `.changelog.d/pr-425.md` with validated bilingual fragment syntax
