### PR TITLE
feat(fleet-console): fuzzy-match palette command queries

### DIFF
--- a/.changelog.d/pr-427.md
+++ b/.changelog.d/pr-427.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Changed
+- [fleet-console] Fuzzy-match command palette queries so typos and abbreviations find commands, ranking exact matches first and highlighting matched glyphs.
+  ko: 커맨드 팔레트 검색을 fuzzy 매칭으로 개선해 오타나 약어로도 명령을 찾을 수 있으며, 정확히 일치하는 결과를 먼저 보여주고 일치 글자를 강조합니다.

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -16,8 +16,8 @@ import {
 import {
   buildPaletteCommands,
   commandModeQuery,
-  filterPaletteCommands,
   isCommandModeInput,
+  matchPaletteCommands,
   type PaletteCommandEntry,
 } from "../palette-commands.js";
 import { stashKeyboardShortcutsReturnFocus } from "../keyboard-shortcuts-return-focus.js";
@@ -88,8 +88,8 @@ export function OperationSearch({
     () => buildPaletteCommands(state, railPanels, t, { canUndoLastClose: undoAvailable }),
     [state, railPanels, t, undoAvailable],
   );
-  const filteredCommands = useMemo(
-    () => (commandMode ? filterPaletteCommands(commands, commandModeQuery(query)) : commands),
+  const matchedCommands = useMemo(
+    () => (commandMode ? matchPaletteCommands(commands, commandModeQuery(query)) : []),
     [commandMode, commands, query],
   );
   const tokens = useMemo(() => searchTokens(commandMode ? commandModeQuery(query) : query), [commandMode, query]);
@@ -98,16 +98,16 @@ export function OperationSearch({
     [railSearchGroups],
   );
   const resultCount = commandMode
-    ? filteredCommands.length + railSearchEntries.length
+    ? matchedCommands.length + railSearchEntries.length
     : filteredEntries.length + railSearchEntries.length;
   const clampedSelectedIndex = clampIndex(selectedIndex, resultCount);
   const selectedResultKey = commandMode
-    ? filteredCommands[clampedSelectedIndex]
-      ? commandResultKey(filteredCommands[clampedSelectedIndex]!.commandId)
-      : railSearchEntries[clampedSelectedIndex - filteredCommands.length]
+    ? matchedCommands[clampedSelectedIndex]
+      ? commandResultKey(matchedCommands[clampedSelectedIndex]!.command.commandId)
+      : railSearchEntries[clampedSelectedIndex - matchedCommands.length]
         ? railResultKey(
-          railSearchEntries[clampedSelectedIndex - filteredCommands.length]!.group.panelId,
-          railSearchEntries[clampedSelectedIndex - filteredCommands.length]!.result.id,
+          railSearchEntries[clampedSelectedIndex - matchedCommands.length]!.group.panelId,
+          railSearchEntries[clampedSelectedIndex - matchedCommands.length]!.result.id,
         )
         : undefined
     : filteredEntries[clampedSelectedIndex]
@@ -379,13 +379,13 @@ export function OperationSearch({
     }
     if (event.key === "Enter") {
       if (commandMode) {
-        const selected = filteredCommands[clampedSelectedIndex];
+        const selected = matchedCommands[clampedSelectedIndex];
         if (selected) {
           event.preventDefault();
-          runCommand(selected);
+          runCommand(selected.command);
           return;
         }
-        const panelEntry = railSearchEntries[clampedSelectedIndex - filteredCommands.length];
+        const panelEntry = railSearchEntries[clampedSelectedIndex - matchedCommands.length];
         if (!panelEntry) return;
         event.preventDefault();
         void selectRailResult(panelEntry.group.panelId, panelEntry.result);
@@ -440,11 +440,12 @@ export function OperationSearch({
         </div>
         <div id={LISTBOX_ID} className="operation-search-results" role="listbox" aria-label={commandMode ? t("chrome.operationSearch.commandResults") : t("chrome.operationSearch.operationResults")}>
           {commandMode ? (
-            filteredCommands.length > 0 || railSearchGroups.length > 0 ? <>
-              {filteredCommands.length > 0 ? (
+            matchedCommands.length > 0 || railSearchGroups.length > 0 ? <>
+              {matchedCommands.length > 0 ? (
                 <section className="operation-search-section" role="group" aria-labelledby={COMMAND_GROUP_HEADING_ID}>
                   <h2 id={COMMAND_GROUP_HEADING_ID} className="operation-search-section-heading">{t("chrome.operationSearch.commands")}</h2>
-                  {filteredCommands.map((command, index) => {
+                  {matchedCommands.map((scored, index) => {
+                    const { command } = scored;
                     const active = index === clampedSelectedIndex;
                     const resultKey = commandResultKey(command.commandId);
                     return (
@@ -464,7 +465,7 @@ export function OperationSearch({
                       >
                         <span className="operation-search-command-glyph" aria-hidden="true">›</span>
                         <span className="operation-search-result-text">
-                          <strong>{highlightText(command.label, tokens)}</strong>
+                          <strong>{highlightIndices(command.label, scored.matchedIndices)}</strong>
                         </span>
                         {command.current ? <span className="operation-search-theater">{t("chrome.operationSearch.current")}</span> : null}
                       </button>
@@ -478,7 +479,7 @@ export function OperationSearch({
                   <section className="operation-search-section operation-search-panel-section" key={group.panelId} role="group" aria-labelledby={headingId}>
                     <h2 id={headingId} className="operation-search-section-heading">{group.panelTitle}</h2>
                     {group.results.map((result) => {
-                      const index = filteredCommands.length + railSearchEntries.findIndex((entry) => entry.group.panelId === group.panelId && entry.result === result);
+                      const index = matchedCommands.length + railSearchEntries.findIndex((entry) => entry.group.panelId === group.panelId && entry.result === result);
                       const active = index === clampedSelectedIndex;
                       const resultKey = railResultKey(group.panelId, result.id);
                       return (
@@ -665,6 +666,31 @@ function highlightText(text: string, tokens: readonly string[]): ReactNode {
     segments.push(<mark key={`${match.start}-${match.end}`}>{text.slice(match.start, match.end)}</mark>);
     cursor = match.end;
   }
+  return segments;
+}
+
+function highlightIndices(text: string, indices: readonly number[]): ReactNode {
+  if (indices.length === 0) return text;
+  const segments: ReactNode[] = [];
+  let cursor = 0;
+  let runStart = indices[0]!;
+  let runEnd = runStart + 1;
+
+  for (let index = 1; index <= indices.length; index += 1) {
+    const matchedIndex = indices[index];
+    if (matchedIndex === runEnd) {
+      runEnd += 1;
+      continue;
+    }
+    if (runStart > cursor) segments.push(text.slice(cursor, runStart));
+    segments.push(<mark key={`${runStart}-${runEnd}`}>{text.slice(runStart, runEnd)}</mark>);
+    cursor = runEnd;
+    if (matchedIndex !== undefined) {
+      runStart = matchedIndex;
+      runEnd = matchedIndex + 1;
+    }
+  }
+  if (cursor < text.length) segments.push(text.slice(cursor));
   return segments;
 }
 

--- a/runtime/fleet-console/core/client/src/palette-commands.ts
+++ b/runtime/fleet-console/core/client/src/palette-commands.ts
@@ -278,12 +278,13 @@ export function fuzzyMatchPaletteLabel(label: string, query: string): PaletteCom
       exactTokens += 1;
     } else {
       let searchFrom = 0;
-      for (let tokenIndex = 0; tokenIndex < token.length; tokenIndex += 1) {
-        const character = token[tokenIndex]!;
+      for (const character of token) {
         const matchedIndex = foldedLabel.indexOf(character, searchFrom);
         if (matchedIndex === -1) return null;
-        foldedTokenIndices.push(matchedIndex);
-        searchFrom = matchedIndex + 1;
+        for (let characterOffset = 0; characterOffset < character.length; characterOffset += 1) {
+          foldedTokenIndices.push(matchedIndex + characterOffset);
+        }
+        searchFrom = matchedIndex + character.length;
       }
     }
 

--- a/runtime/fleet-console/core/client/src/palette-commands.ts
+++ b/runtime/fleet-console/core/client/src/palette-commands.ts
@@ -287,15 +287,18 @@ export function fuzzyMatchPaletteLabel(label: string, query: string): PaletteCom
       }
     }
 
-    const tokenIndices = foldedTokenIndices
-      .map((foldedIndex) => foldMap[foldedIndex]!)
-      .filter((originalIndex, index, indices) => index === 0 || originalIndex !== indices[index - 1]);
+    const tokenIndices = foldMap === null
+      ? foldedTokenIndices
+      : foldedTokenIndices
+        .map((foldedIndex) => foldMap[foldedIndex]!)
+        .filter((originalIndex, index, indices) => index === 0 || originalIndex !== indices[index - 1]);
+    const scoreText = foldMap === null ? foldedLabel : label;
     for (let index = 0; index < tokenIndices.length; index += 1) {
       const matchedIndex = tokenIndices[index]!;
       const previousMatchedIndex = tokenIndices[index - 1];
       score += previousMatchedIndex !== undefined && matchedIndex === previousMatchedIndex + 1 ? 3 : 1;
-      if (matchedIndex === 0 || label[matchedIndex - 1] === " ") score += 2;
-      matchedIndices.add(matchedIndex);
+      if (matchedIndex === 0 || scoreText[matchedIndex - 1] === " ") score += 2;
+      if (foldMap !== null) matchedIndices.add(matchedIndex);
     }
   }
 
@@ -330,11 +333,11 @@ export function filterPaletteCommands(commands: readonly PaletteCommandEntry[], 
 
 function foldPaletteLabel(label: string): {
   readonly foldedLabel: string;
-  readonly foldMap: readonly number[];
+  readonly foldMap: readonly number[] | null;
 } {
   const foldedLabel = label.toLocaleLowerCase();
   if (label.length > 2_000) {
-    return { foldedLabel, foldMap: buildPerCharacterFoldMap(label) };
+    return { foldedLabel, foldMap: null };
   }
 
   const foldMap: number[] = [];
@@ -348,25 +351,14 @@ function foldPaletteLabel(label: string): {
   }
   return foldMap.length === foldedLabel.length
     ? { foldedLabel, foldMap }
-    : { foldedLabel, foldMap: buildPerCharacterFoldMap(label) };
-}
-
-function buildPerCharacterFoldMap(label: string): readonly number[] {
-  const foldMap: number[] = [];
-  for (let originalIndex = 0; originalIndex < label.length; originalIndex += 1) {
-    const foldedLength = label[originalIndex]!.toLocaleLowerCase().length;
-    for (let foldedOffset = 0; foldedOffset < foldedLength; foldedOffset += 1) {
-      foldMap.push(originalIndex);
-    }
-  }
-  return foldMap;
+    : { foldedLabel, foldMap: null };
 }
 
 function findBestExactStart(
   foldedLabel: string,
   token: string,
   label: string,
-  foldMap: readonly number[],
+  foldMap: readonly number[] | null,
 ): number {
   let firstStart = -1;
   let searchFrom = 0;
@@ -374,8 +366,9 @@ function findBestExactStart(
     const start = foldedLabel.indexOf(token, searchFrom);
     if (start === -1) break;
     if (firstStart === -1) firstStart = start;
-    const originalStart = foldMap[start];
-    if (originalStart !== undefined && (originalStart === 0 || label[originalStart - 1] === " ")) return start;
+    const boundaryIndex = foldMap?.[start] ?? start;
+    const boundaryText = foldMap === null ? foldedLabel : label;
+    if (boundaryIndex === 0 || boundaryText[boundaryIndex - 1] === " ") return start;
     searchFrom = start + 1;
   }
   return firstStart;

--- a/runtime/fleet-console/core/client/src/palette-commands.ts
+++ b/runtime/fleet-console/core/client/src/palette-commands.ts
@@ -333,17 +333,30 @@ function foldPaletteLabel(label: string): {
   readonly foldMap: readonly number[];
 } {
   const foldedLabel = label.toLocaleLowerCase();
-  let perCharacterFoldedLabel = "";
   const foldMap: number[] = [];
-  for (let originalIndex = 0; originalIndex < label.length; originalIndex += 1) {
+  let cursor = 0;
+  for (
+    let originalIndex = 0;
+    originalIndex < label.length && cursor < foldedLabel.length;
+    originalIndex += 1
+  ) {
     const foldedCharacter = label[originalIndex]!.toLocaleLowerCase();
-    perCharacterFoldedLabel += foldedCharacter;
-    for (let foldedOffset = 0; foldedOffset < foldedCharacter.length; foldedOffset += 1) {
-      foldMap.push(originalIndex);
+    if (foldedLabel.startsWith(foldedCharacter, cursor)) {
+      for (let foldedOffset = 0; foldedOffset < foldedCharacter.length; foldedOffset += 1) {
+        foldMap.push(originalIndex);
+      }
+      cursor += foldedCharacter.length;
+      continue;
     }
+    foldMap.push(originalIndex);
+    cursor += 1;
   }
-  if (foldMap.length !== foldedLabel.length) {
-    return { foldedLabel: perCharacterFoldedLabel, foldMap };
+  if (label.length > 0) {
+    const lastOriginalIndex = label.length - 1;
+    while (cursor < foldedLabel.length) {
+      foldMap.push(lastOriginalIndex);
+      cursor += 1;
+    }
   }
   return { foldedLabel, foldMap };
 }

--- a/runtime/fleet-console/core/client/src/palette-commands.ts
+++ b/runtime/fleet-console/core/client/src/palette-commands.ts
@@ -45,6 +45,17 @@ export interface PaletteCommandEntry {
   readonly action: PaletteCommandAction;
 }
 
+export interface PaletteCommandMatch {
+  readonly score: number;
+  readonly matchedIndices: readonly number[];
+}
+
+export interface ScoredPaletteCommand {
+  readonly command: PaletteCommandEntry;
+  readonly score: number;
+  readonly matchedIndices: readonly number[];
+}
+
 type T = Translate<CoreMessageKey>;
 
 export function buildPaletteThemes(t: T): readonly { readonly id: ThemeId; readonly label: string }[] {
@@ -246,13 +257,64 @@ export function buildPaletteCommands(
   return commands;
 }
 
-export function filterPaletteCommands(commands: readonly PaletteCommandEntry[], query: string): readonly PaletteCommandEntry[] {
+export function fuzzyMatchPaletteLabel(label: string, query: string): PaletteCommandMatch | null {
   const tokens = searchTokens(query);
-  if (tokens.length === 0) return commands;
-  return commands.filter((command) => {
-    const haystack = command.label.toLocaleLowerCase();
-    return tokens.every((token) => haystack.includes(token));
-  });
+  if (tokens.length === 0) return null;
+  const lowerLabel = label.toLocaleLowerCase();
+  const matchedIndices = new Set<number>();
+  let score = 0;
+
+  for (const token of tokens) {
+    const exactStart = lowerLabel.indexOf(token);
+    const tokenIndices: number[] = [];
+    if (exactStart !== -1) {
+      for (let offset = 0; offset < token.length; offset += 1) {
+        tokenIndices.push(exactStart + offset);
+      }
+      score += 100;
+    } else {
+      let searchFrom = 0;
+      for (let tokenIndex = 0; tokenIndex < token.length; tokenIndex += 1) {
+        const character = token[tokenIndex]!;
+        const matchedIndex = lowerLabel.indexOf(character, searchFrom);
+        if (matchedIndex === -1) return null;
+        tokenIndices.push(matchedIndex);
+        searchFrom = matchedIndex + 1;
+      }
+    }
+
+    for (let index = 0; index < tokenIndices.length; index += 1) {
+      const matchedIndex = tokenIndices[index]!;
+      const previousMatchedIndex = tokenIndices[index - 1];
+      score += previousMatchedIndex !== undefined && matchedIndex === previousMatchedIndex + 1 ? 3 : 1;
+      if (matchedIndex === 0 || lowerLabel[matchedIndex - 1] === " ") score += 2;
+      matchedIndices.add(matchedIndex);
+    }
+  }
+
+  return {
+    score: score - label.length * 0.01,
+    matchedIndices: [...matchedIndices].sort((left, right) => left - right),
+  };
+}
+
+export function matchPaletteCommands(
+  commands: readonly PaletteCommandEntry[],
+  query: string,
+): readonly ScoredPaletteCommand[] {
+  if (searchTokens(query).length === 0) {
+    return commands.map((command) => ({ command, score: 0, matchedIndices: [] }));
+  }
+  return commands.flatMap((command, originalIndex) => {
+    const match = fuzzyMatchPaletteLabel(command.label, query);
+    return match ? [{ command, ...match, originalIndex }] : [];
+  }).sort((left, right) => right.score - left.score || left.originalIndex - right.originalIndex)
+    .map(({ command, score, matchedIndices }) => ({ command, score, matchedIndices }));
+}
+
+export function filterPaletteCommands(commands: readonly PaletteCommandEntry[], query: string): readonly PaletteCommandEntry[] {
+  if (searchTokens(query).length === 0) return commands;
+  return matchPaletteCommands(commands, query).map(({ command }) => command);
 }
 
 function resolveActiveLocale() {

--- a/runtime/fleet-console/core/client/src/palette-commands.ts
+++ b/runtime/fleet-console/core/client/src/palette-commands.ts
@@ -333,66 +333,33 @@ function foldPaletteLabel(label: string): {
   readonly foldMap: readonly number[];
 } {
   const foldedLabel = label.toLocaleLowerCase();
+  if (label.length > 2_000) {
+    return { foldedLabel, foldMap: buildPerCharacterFoldMap(label) };
+  }
+
   const foldMap: number[] = [];
-  let cursor = 0;
-  for (
-    let originalIndex = 0;
-    originalIndex < label.length && cursor < foldedLabel.length;
-    originalIndex += 1
-  ) {
-    const foldedCharacter = label[originalIndex]!.toLocaleLowerCase();
-    if (foldedLabel.startsWith(foldedCharacter, cursor)) {
-      for (let foldedOffset = 0; foldedOffset < foldedCharacter.length; foldedOffset += 1) {
-        foldMap.push(originalIndex);
-      }
-      cursor += foldedCharacter.length;
-      continue;
+  let previousPrefixLength = 0;
+  for (let originalIndex = 0; originalIndex < label.length; originalIndex += 1) {
+    const nextPrefixLength = label.slice(0, originalIndex + 1).toLocaleLowerCase().length;
+    for (let foldedIndex = previousPrefixLength; foldedIndex < nextPrefixLength; foldedIndex += 1) {
+      foldMap.push(originalIndex);
     }
-    if (
-      originalIndex > 0
-      && cursor + 1 < foldedLabel.length
-      && foldedLabel.startsWith(foldedCharacter, cursor + 1)
-    ) {
-      foldMap.push(originalIndex - 1);
-      cursor += 1;
-      if (foldedLabel.startsWith(foldedCharacter, cursor)) {
-        for (let foldedOffset = 0; foldedOffset < foldedCharacter.length; foldedOffset += 1) {
-          foldMap.push(originalIndex);
-        }
-        cursor += foldedCharacter.length;
-        continue;
-      }
-    }
-    let resynchronized = false;
-    for (
-      let additionalCharacters = 1;
-      additionalCharacters <= 4 && originalIndex + 1 + additionalCharacters <= label.length;
-      additionalCharacters += 1
-    ) {
-      const foldedSpan = label
-        .slice(originalIndex, originalIndex + 1 + additionalCharacters)
-        .toLocaleLowerCase();
-      if (!foldedLabel.startsWith(foldedSpan, cursor)) continue;
-      for (let foldedOffset = 0; foldedOffset < foldedSpan.length; foldedOffset += 1) {
-        foldMap.push(originalIndex + foldedOffset);
-      }
-      cursor += foldedSpan.length;
-      originalIndex += additionalCharacters;
-      resynchronized = true;
-      break;
-    }
-    if (resynchronized) continue;
-    foldMap.push(originalIndex);
-    cursor += 1;
+    previousPrefixLength = nextPrefixLength;
   }
-  if (label.length > 0) {
-    const lastOriginalIndex = label.length - 1;
-    while (cursor < foldedLabel.length) {
-      foldMap.push(lastOriginalIndex);
-      cursor += 1;
+  return foldMap.length === foldedLabel.length
+    ? { foldedLabel, foldMap }
+    : { foldedLabel, foldMap: buildPerCharacterFoldMap(label) };
+}
+
+function buildPerCharacterFoldMap(label: string): readonly number[] {
+  const foldMap: number[] = [];
+  for (let originalIndex = 0; originalIndex < label.length; originalIndex += 1) {
+    const foldedLength = label[originalIndex]!.toLocaleLowerCase().length;
+    for (let foldedOffset = 0; foldedOffset < foldedLength; foldedOffset += 1) {
+      foldMap.push(originalIndex);
     }
   }
-  return { foldedLabel, foldMap };
+  return foldMap;
 }
 
 function findBestExactStart(

--- a/runtime/fleet-console/core/client/src/palette-commands.ts
+++ b/runtime/fleet-console/core/client/src/palette-commands.ts
@@ -332,14 +332,18 @@ function foldPaletteLabel(label: string): {
   readonly foldedLabel: string;
   readonly foldMap: readonly number[];
 } {
-  let foldedLabel = "";
+  const foldedLabel = label.toLocaleLowerCase();
+  let perCharacterFoldedLabel = "";
   const foldMap: number[] = [];
   for (let originalIndex = 0; originalIndex < label.length; originalIndex += 1) {
     const foldedCharacter = label[originalIndex]!.toLocaleLowerCase();
-    foldedLabel += foldedCharacter;
+    perCharacterFoldedLabel += foldedCharacter;
     for (let foldedOffset = 0; foldedOffset < foldedCharacter.length; foldedOffset += 1) {
       foldMap.push(originalIndex);
     }
+  }
+  if (foldMap.length !== foldedLabel.length) {
+    return { foldedLabel: perCharacterFoldedLabel, foldMap };
   }
   return { foldedLabel, foldMap };
 }

--- a/runtime/fleet-console/core/client/src/palette-commands.ts
+++ b/runtime/fleet-console/core/client/src/palette-commands.ts
@@ -348,6 +348,21 @@ function foldPaletteLabel(label: string): {
       cursor += foldedCharacter.length;
       continue;
     }
+    if (
+      originalIndex > 0
+      && cursor + 1 < foldedLabel.length
+      && foldedLabel.startsWith(foldedCharacter, cursor + 1)
+    ) {
+      foldMap.push(originalIndex - 1);
+      cursor += 1;
+      if (foldedLabel.startsWith(foldedCharacter, cursor)) {
+        for (let foldedOffset = 0; foldedOffset < foldedCharacter.length; foldedOffset += 1) {
+          foldMap.push(originalIndex);
+        }
+        cursor += foldedCharacter.length;
+        continue;
+      }
+    }
     let resynchronized = false;
     for (
       let additionalCharacters = 1;

--- a/runtime/fleet-console/core/client/src/palette-commands.ts
+++ b/runtime/fleet-console/core/client/src/palette-commands.ts
@@ -348,6 +348,25 @@ function foldPaletteLabel(label: string): {
       cursor += foldedCharacter.length;
       continue;
     }
+    let resynchronized = false;
+    for (
+      let additionalCharacters = 1;
+      additionalCharacters <= 4 && originalIndex + 1 + additionalCharacters <= label.length;
+      additionalCharacters += 1
+    ) {
+      const foldedSpan = label
+        .slice(originalIndex, originalIndex + 1 + additionalCharacters)
+        .toLocaleLowerCase();
+      if (!foldedLabel.startsWith(foldedSpan, cursor)) continue;
+      for (let foldedOffset = 0; foldedOffset < foldedSpan.length; foldedOffset += 1) {
+        foldMap.push(originalIndex + foldedOffset);
+      }
+      cursor += foldedSpan.length;
+      originalIndex += additionalCharacters;
+      resynchronized = true;
+      break;
+    }
+    if (resynchronized) continue;
     foldMap.push(originalIndex);
     cursor += 1;
   }

--- a/runtime/fleet-console/core/client/src/palette-commands.ts
+++ b/runtime/fleet-console/core/client/src/palette-commands.ts
@@ -47,12 +47,14 @@ export interface PaletteCommandEntry {
 
 export interface PaletteCommandMatch {
   readonly score: number;
+  readonly exactTokens: number;
   readonly matchedIndices: readonly number[];
 }
 
 export interface ScoredPaletteCommand {
   readonly command: PaletteCommandEntry;
   readonly score: number;
+  readonly exactTokens: number;
   readonly matchedIndices: readonly number[];
 }
 
@@ -260,40 +262,46 @@ export function buildPaletteCommands(
 export function fuzzyMatchPaletteLabel(label: string, query: string): PaletteCommandMatch | null {
   const tokens = searchTokens(query);
   if (tokens.length === 0) return null;
-  const lowerLabel = label.toLocaleLowerCase();
+  const { foldedLabel, foldMap } = foldPaletteLabel(label);
   const matchedIndices = new Set<number>();
   let score = 0;
+  let exactTokens = 0;
 
   for (const token of tokens) {
-    const exactStart = lowerLabel.indexOf(token);
-    const tokenIndices: number[] = [];
+    const exactStart = findBestExactStart(foldedLabel, token, label, foldMap);
+    const foldedTokenIndices: number[] = [];
     if (exactStart !== -1) {
       for (let offset = 0; offset < token.length; offset += 1) {
-        tokenIndices.push(exactStart + offset);
+        foldedTokenIndices.push(exactStart + offset);
       }
       score += 100;
+      exactTokens += 1;
     } else {
       let searchFrom = 0;
       for (let tokenIndex = 0; tokenIndex < token.length; tokenIndex += 1) {
         const character = token[tokenIndex]!;
-        const matchedIndex = lowerLabel.indexOf(character, searchFrom);
+        const matchedIndex = foldedLabel.indexOf(character, searchFrom);
         if (matchedIndex === -1) return null;
-        tokenIndices.push(matchedIndex);
+        foldedTokenIndices.push(matchedIndex);
         searchFrom = matchedIndex + 1;
       }
     }
 
+    const tokenIndices = foldedTokenIndices
+      .map((foldedIndex) => foldMap[foldedIndex]!)
+      .filter((originalIndex, index, indices) => index === 0 || originalIndex !== indices[index - 1]);
     for (let index = 0; index < tokenIndices.length; index += 1) {
       const matchedIndex = tokenIndices[index]!;
       const previousMatchedIndex = tokenIndices[index - 1];
       score += previousMatchedIndex !== undefined && matchedIndex === previousMatchedIndex + 1 ? 3 : 1;
-      if (matchedIndex === 0 || lowerLabel[matchedIndex - 1] === " ") score += 2;
+      if (matchedIndex === 0 || label[matchedIndex - 1] === " ") score += 2;
       matchedIndices.add(matchedIndex);
     }
   }
 
   return {
     score: score - label.length * 0.01,
+    exactTokens,
     matchedIndices: [...matchedIndices].sort((left, right) => left - right),
   };
 }
@@ -303,18 +311,56 @@ export function matchPaletteCommands(
   query: string,
 ): readonly ScoredPaletteCommand[] {
   if (searchTokens(query).length === 0) {
-    return commands.map((command) => ({ command, score: 0, matchedIndices: [] }));
+    return commands.map((command) => ({ command, score: 0, exactTokens: 0, matchedIndices: [] }));
   }
   return commands.flatMap((command, originalIndex) => {
     const match = fuzzyMatchPaletteLabel(command.label, query);
     return match ? [{ command, ...match, originalIndex }] : [];
-  }).sort((left, right) => right.score - left.score || left.originalIndex - right.originalIndex)
-    .map(({ command, score, matchedIndices }) => ({ command, score, matchedIndices }));
+  }).sort((left, right) =>
+    right.exactTokens - left.exactTokens
+    || right.score - left.score
+    || left.originalIndex - right.originalIndex)
+    .map(({ command, score, exactTokens, matchedIndices }) => ({ command, score, exactTokens, matchedIndices }));
 }
 
 export function filterPaletteCommands(commands: readonly PaletteCommandEntry[], query: string): readonly PaletteCommandEntry[] {
   if (searchTokens(query).length === 0) return commands;
   return matchPaletteCommands(commands, query).map(({ command }) => command);
+}
+
+function foldPaletteLabel(label: string): {
+  readonly foldedLabel: string;
+  readonly foldMap: readonly number[];
+} {
+  let foldedLabel = "";
+  const foldMap: number[] = [];
+  for (let originalIndex = 0; originalIndex < label.length; originalIndex += 1) {
+    const foldedCharacter = label[originalIndex]!.toLocaleLowerCase();
+    foldedLabel += foldedCharacter;
+    for (let foldedOffset = 0; foldedOffset < foldedCharacter.length; foldedOffset += 1) {
+      foldMap.push(originalIndex);
+    }
+  }
+  return { foldedLabel, foldMap };
+}
+
+function findBestExactStart(
+  foldedLabel: string,
+  token: string,
+  label: string,
+  foldMap: readonly number[],
+): number {
+  let firstStart = -1;
+  let searchFrom = 0;
+  while (searchFrom <= foldedLabel.length - token.length) {
+    const start = foldedLabel.indexOf(token, searchFrom);
+    if (start === -1) break;
+    if (firstStart === -1) firstStart = start;
+    const originalStart = foldMap[start];
+    if (originalStart !== undefined && (originalStart === 0 || label[originalStart - 1] === " ")) return start;
+    searchFrom = start + 1;
+  }
+  return firstStart;
 }
 
 function resolveActiveLocale() {

--- a/runtime/fleet-console/tests/palette-commands.test.ts
+++ b/runtime/fleet-console/tests/palette-commands.test.ts
@@ -449,6 +449,15 @@ describe("filterPaletteCommands", () => {
     }
   });
 
+  it("keeps supplementary-plane matches on complete surrogate-pair boundaries", () => {
+    expect(fuzzyMatchPaletteLabel("😁😃", "😃")?.matchedIndices).toEqual([2, 3]);
+    expect(fuzzyMatchPaletteLabel("😁😃-x", "😃x")?.matchedIndices).toEqual([2, 3, 5]);
+  });
+
+  it("continues matching BMP command text after a supplementary-plane prefix", () => {
+    expect(fuzzyMatchPaletteLabel("😀 deploy", "deploy")).not.toBeNull();
+  });
+
   it("ranks consecutive fuzzy glyphs above scattered glyphs", () => {
     const consecutive = fuzzyMatchPaletteLabel("ab-d-e-", "abde");
     const scattered = fuzzyMatchPaletteLabel("a-b-d-e", "abde");

--- a/runtime/fleet-console/tests/palette-commands.test.ts
+++ b/runtime/fleet-console/tests/palette-commands.test.ts
@@ -352,6 +352,40 @@ describe("filterPaletteCommands", () => {
     }
   });
 
+  it("maps context-inserted folded characters without shifting following original indices", () => {
+    const originalToLocaleLowerCase = String.prototype.toLocaleLowerCase;
+    const lowerCaseSpy = vi.spyOn(String.prototype, "toLocaleLowerCase").mockImplementation(function (
+      this: string,
+      locales?: string | string[],
+    ): string {
+      const value = String(this);
+      if (locales === undefined) {
+        if (value === "ÍXY") return "i̇́xy";
+        if (value === "I") return "i";
+        if (value === "́") return "́";
+        if (value === "X") return "x";
+        if (value === "Y") return "y";
+      }
+      return locales === undefined
+        ? originalToLocaleLowerCase.call(value)
+        : originalToLocaleLowerCase.call(value, locales);
+    });
+    try {
+      const label = "ÍXY";
+      const xMatch = fuzzyMatchPaletteLabel(label, "x");
+      const yMatch = fuzzyMatchPaletteLabel(label, "y");
+      expect(xMatch?.matchedIndices).toEqual([2]);
+      expect(yMatch?.matchedIndices).toEqual([3]);
+      const matchedIndices = [
+        ...(xMatch?.matchedIndices ?? []),
+        ...(yMatch?.matchedIndices ?? []),
+      ];
+      expect(matchedIndices.filter((index) => index < 0 || index >= label.length)).toEqual([]);
+    } finally {
+      lowerCaseSpy.mockRestore();
+    }
+  });
+
   it("ranks consecutive fuzzy glyphs above scattered glyphs", () => {
     const consecutive = fuzzyMatchPaletteLabel("ab-d-e-", "abde");
     const scattered = fuzzyMatchPaletteLabel("a-b-d-e", "abde");

--- a/runtime/fleet-console/tests/palette-commands.test.ts
+++ b/runtime/fleet-console/tests/palette-commands.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { hydrateGlobalSettings } from "../core/client/src/global-settings-store.js";
 import {
@@ -314,6 +314,36 @@ describe("filterPaletteCommands", () => {
     expect(match?.matchedIndices.filter((index) => index < 0 || index >= label.length)).toEqual([]);
     expect(match?.matchedIndices).toEqual([9, 10]);
     expect(match?.matchedIndices.map((index) => label.slice(index, index + 1)).join("")).toBe("ΟΣ");
+  });
+
+  it("keeps whole-string folding searchable when contextual casing changes the folded length", () => {
+    const originalToLocaleLowerCase = String.prototype.toLocaleLowerCase;
+    const lowerCaseSpy = vi.spyOn(String.prototype, "toLocaleLowerCase").mockImplementation(function (
+      this: string,
+      locales?: string | string[],
+    ): string {
+      const value = String(this);
+      if (locales === undefined) {
+        if (value === "İX") return "ix";
+        if (value === "İ") return "i";
+        if (value === "I") return "ı";
+        if (value === "̇") return "̇";
+      }
+      return locales === undefined
+        ? originalToLocaleLowerCase.call(value)
+        : originalToLocaleLowerCase.call(value, locales);
+    });
+    try {
+      const label = "İX";
+      const match = fuzzyMatchPaletteLabel(label, "i");
+      expect(match).not.toBeNull();
+      const matchedIndices = match?.matchedIndices ?? [];
+      expect(matchedIndices).not.toHaveLength(0);
+      expect(matchedIndices.filter((index) => index < 0 || index >= label.length)).toEqual([]);
+      expect(["I", "̇"]).toContain(label.slice(matchedIndices[0]!, matchedIndices[0]! + 1));
+    } finally {
+      lowerCaseSpy.mockRestore();
+    }
   });
 
   it("ranks consecutive fuzzy glyphs above scattered glyphs", () => {

--- a/runtime/fleet-console/tests/palette-commands.test.ts
+++ b/runtime/fleet-console/tests/palette-commands.test.ts
@@ -307,6 +307,15 @@ describe("filterPaletteCommands", () => {
     expect(match?.matchedIndices.map((index) => label.slice(index, index + 1)).join("").toLocaleLowerCase()).toBe("x");
   });
 
+  it("matches context-sensitive whole-string case folds and maps them to the original label", () => {
+    const label = "Theater: ΟΣ";
+    const match = fuzzyMatchPaletteLabel(label, "ος");
+    expect(match).not.toBeNull();
+    expect(match?.matchedIndices.filter((index) => index < 0 || index >= label.length)).toEqual([]);
+    expect(match?.matchedIndices).toEqual([9, 10]);
+    expect(match?.matchedIndices.map((index) => label.slice(index, index + 1)).join("")).toBe("ΟΣ");
+  });
+
   it("ranks consecutive fuzzy glyphs above scattered glyphs", () => {
     const consecutive = fuzzyMatchPaletteLabel("ab-d-e-", "abde");
     const scattered = fuzzyMatchPaletteLabel("a-b-d-e", "abde");

--- a/runtime/fleet-console/tests/palette-commands.test.ts
+++ b/runtime/fleet-console/tests/palette-commands.test.ts
@@ -5,7 +5,10 @@ import {
   buildPaletteCommands,
   commandModeQuery,
   filterPaletteCommands,
+  fuzzyMatchPaletteLabel,
   isCommandModeInput,
+  matchPaletteCommands,
+  type PaletteCommandEntry,
 } from "../core/client/src/palette-commands.js";
 import { getT } from "../core/client/src/i18n/index.js";
 import { DEFAULT_UI_FONT } from "../core/client/src/ui-font.js";
@@ -251,15 +254,69 @@ describe("filterPaletteCommands", () => {
     const commands = buildPaletteCommands(makeState(), RAIL_PANELS, tEn);
     expect(filterPaletteCommands(commands, "switch beta").map((command) => command.commandId)).toEqual(["switch-theater:theater-beta"]);
     expect(filterPaletteCommands(commands, "THEME").map((command) => command.commandId)).toEqual([
-      "switch-theme:instrument",
-      "switch-theme:maritime",
       "switch-theme:carbon",
-      "switch-theme:daywatch",
       "switch-theme:whites",
       "switch-theme:drydock",
+      "switch-theme:maritime",
+      "switch-theme:daywatch",
+      "switch-theme:instrument",
     ]);
     expect(filterPaletteCommands(commands, "theme beta")).toEqual([]);
     expect(filterPaletteCommands(commands, "")).toEqual(commands);
     expect(filterPaletteCommands(commands, "   ")).toEqual(commands);
   });
+
+  it("matches command abbreviations as greedy subsequences", () => {
+    const commands = commandEntries("Rename operation…", "Close operation", "New theater…");
+    expect(filterPaletteCommands(commands, "rnme").map((command) => command.label)).toEqual(["Rename operation…"]);
+    expect(filterPaletteCommands(commands, "clop").map((command) => command.label)).toEqual(["Close operation"]);
+    expect(filterPaletteCommands(commands, "newth").map((command) => command.label)).toEqual(["New theater…"]);
+  });
+
+  it("ranks exact substring matches above fuzzy-only matches", () => {
+    const commands = commandEntries("r-n-m-e", "Rename operation…", "rnme tools");
+    expect(filterPaletteCommands(commands, "rnme").map((command) => command.label)).toEqual([
+      "rnme tools",
+      "Rename operation…",
+      "r-n-m-e",
+    ]);
+  });
+
+  it("ranks consecutive fuzzy glyphs above scattered glyphs", () => {
+    const consecutive = fuzzyMatchPaletteLabel("ab-d-e-", "abde");
+    const scattered = fuzzyMatchPaletteLabel("a-b-d-e", "abde");
+    expect(consecutive?.score).toBeGreaterThan(scattered?.score ?? Number.NEGATIVE_INFINITY);
+  });
+
+  it("adds a bonus when a fuzzy glyph lands on a word boundary", () => {
+    const boundary = fuzzyMatchPaletteLabel("x a-b", "ab");
+    const nonBoundary = fuzzyMatchPaletteLabel("x-a-b", "ab");
+    expect(boundary?.score).toBeGreaterThan(nonBoundary?.score ?? Number.NEGATIVE_INFINITY);
+  });
+
+  it("requires every query token and excludes any token mismatch", () => {
+    const commands = commandEntries("Rename active operation", "Rename theater", "Close active operation");
+    expect(filterPaletteCommands(commands, "rnme act").map((command) => command.label)).toEqual([
+      "Rename active operation",
+    ]);
+    expect(filterPaletteCommands(commands, "rename missing")).toEqual([]);
+  });
+
+  it("preserves original order for empty queries and stable score ties", () => {
+    const commands = commandEntries("Same label", "Same label", "Different");
+    expect(filterPaletteCommands(commands, "   ")).toBe(commands);
+    expect(matchPaletteCommands(commands, "same").map(({ command }) => command.commandId)).toEqual([
+      "command-0",
+      "command-1",
+    ]);
+  });
 });
+
+function commandEntries(...labels: readonly string[]): readonly PaletteCommandEntry[] {
+  return labels.map((label, index) => ({
+    commandId: `command-${index}`,
+    label,
+    current: false,
+    action: { kind: "open-settings" },
+  }));
+}

--- a/runtime/fleet-console/tests/palette-commands.test.ts
+++ b/runtime/fleet-console/tests/palette-commands.test.ts
@@ -335,12 +335,18 @@ describe("filterPaletteCommands", () => {
     });
     try {
       const label = "İX";
-      const match = fuzzyMatchPaletteLabel(label, "i");
-      expect(match).not.toBeNull();
-      const matchedIndices = match?.matchedIndices ?? [];
-      expect(matchedIndices).not.toHaveLength(0);
+      const contractedMatch = fuzzyMatchPaletteLabel(label, "i");
+      const followingMatch = fuzzyMatchPaletteLabel(label, "x");
+      expect(contractedMatch).not.toBeNull();
+      expect(followingMatch).not.toBeNull();
+      expect(contractedMatch?.matchedIndices).toContain(0);
+      expect(contractedMatch?.matchedIndices).not.toContain(1);
+      expect(followingMatch?.matchedIndices).toEqual([2]);
+      const matchedIndices = [
+        ...(contractedMatch?.matchedIndices ?? []),
+        ...(followingMatch?.matchedIndices ?? []),
+      ];
       expect(matchedIndices.filter((index) => index < 0 || index >= label.length)).toEqual([]);
-      expect(["I", "̇"]).toContain(label.slice(matchedIndices[0]!, matchedIndices[0]! + 1));
     } finally {
       lowerCaseSpy.mockRestore();
     }

--- a/runtime/fleet-console/tests/palette-commands.test.ts
+++ b/runtime/fleet-console/tests/palette-commands.test.ts
@@ -282,6 +282,31 @@ describe("filterPaletteCommands", () => {
     ]);
   });
 
+  it("ranks exact matches above fuzzy-only matches regardless of the label length penalty", () => {
+    const longExactLabel = `Close operation: rnme${"x".repeat(11_000)}`;
+    const commands = commandEntries("Rename operation…", longExactLabel);
+    const matches = matchPaletteCommands(commands, "rnme");
+    expect(matches.map(({ command }) => command.label)).toEqual([longExactLabel, "Rename operation…"]);
+    expect(matches.map(({ exactTokens }) => exactTokens)).toEqual([1, 0]);
+  });
+
+  it("selects the earliest word-boundary exact occurrence", () => {
+    const boundary = fuzzyMatchPaletteLabel("xfoo foo", "foo");
+    const nonBoundary = fuzzyMatchPaletteLabel("xfoo-xxx", "foo");
+    const sameLengthNonBoundary = fuzzyMatchPaletteLabel("xfoo-foo", "foo");
+    expect(boundary?.matchedIndices).toEqual([5, 6, 7]);
+    expect(boundary?.score).toBeGreaterThan(nonBoundary?.score ?? Number.NEGATIVE_INFINITY);
+    expect(boundary?.score).toBeGreaterThan(sameLengthNonBoundary?.score ?? Number.NEGATIVE_INFINITY);
+  });
+
+  it("maps case-folded match indices back into the original label", () => {
+    const label = "Close operation: İX";
+    const match = fuzzyMatchPaletteLabel(label, "x");
+    expect(match).not.toBeNull();
+    expect(match?.matchedIndices.filter((index) => index < 0 || index >= label.length)).toEqual([]);
+    expect(match?.matchedIndices.map((index) => label.slice(index, index + 1)).join("").toLocaleLowerCase()).toBe("x");
+  });
+
   it("ranks consecutive fuzzy glyphs above scattered glyphs", () => {
     const consecutive = fuzzyMatchPaletteLabel("ab-d-e-", "abde");
     const scattered = fuzzyMatchPaletteLabel("a-b-d-e", "abde");

--- a/runtime/fleet-console/tests/palette-commands.test.ts
+++ b/runtime/fleet-console/tests/palette-commands.test.ts
@@ -425,6 +425,30 @@ describe("filterPaletteCommands", () => {
     }
   });
 
+  it("omits highlight indices when a long contextual fold cannot provide an aligned map", () => {
+    const label = `${"a".repeat(2_001)}Íxy`;
+    const foldedLabel = `${"a".repeat(2_001)}i̇́xy`;
+    const originalToLocaleLowerCase = String.prototype.toLocaleLowerCase;
+    const lowerCaseSpy = vi.spyOn(String.prototype, "toLocaleLowerCase").mockImplementation(function (
+      this: string,
+      locales?: string | string[],
+    ): string {
+      const value = String(this);
+      if (locales === undefined && value === label) return foldedLabel;
+      return locales === undefined
+        ? originalToLocaleLowerCase.call(value)
+        : originalToLocaleLowerCase.call(value, locales);
+    });
+    try {
+      const match = fuzzyMatchPaletteLabel(label, "xy");
+      expect(match).not.toBeNull();
+      expect(match?.matchedIndices).toEqual([]);
+      expect(typeof match?.score).toBe("number");
+    } finally {
+      lowerCaseSpy.mockRestore();
+    }
+  });
+
   it("ranks consecutive fuzzy glyphs above scattered glyphs", () => {
     const consecutive = fuzzyMatchPaletteLabel("ab-d-e-", "abde");
     const scattered = fuzzyMatchPaletteLabel("a-b-d-e", "abde");

--- a/runtime/fleet-console/tests/palette-commands.test.ts
+++ b/runtime/fleet-console/tests/palette-commands.test.ts
@@ -361,6 +361,8 @@ describe("filterPaletteCommands", () => {
       const value = String(this);
       if (locales === undefined) {
         if (value === "ÍXY") return "i̇́xy";
+        if (value === "ÍX") return "i̇́x";
+        if (value === "Í") return "i̇́";
         if (value === "I") return "i";
         if (value === "́") return "́";
         if (value === "X") return "x";
@@ -376,6 +378,43 @@ describe("filterPaletteCommands", () => {
       const yMatch = fuzzyMatchPaletteLabel(label, "y");
       expect(xMatch?.matchedIndices).toEqual([2]);
       expect(yMatch?.matchedIndices).toEqual([3]);
+      const matchedIndices = [
+        ...(xMatch?.matchedIndices ?? []),
+        ...(yMatch?.matchedIndices ?? []),
+      ];
+      expect(matchedIndices.filter((index) => index < 0 || index >= label.length)).toEqual([]);
+    } finally {
+      lowerCaseSpy.mockRestore();
+    }
+  });
+
+  it("maps contraction spans beyond a fixed lookahead without shifting following original indices", () => {
+    const originalToLocaleLowerCase = String.prototype.toLocaleLowerCase;
+    const lowerCaseSpy = vi.spyOn(String.prototype, "toLocaleLowerCase").mockImplementation(function (
+      this: string,
+      locales?: string | string[],
+    ): string {
+      const value = String(this);
+      if (locales === undefined) {
+        if (value === "Ị̣̣̣̇XY") return "ị̣̣̣xy";
+        if (value === "Ị̣̣̣̇X") return "ị̣̣̣x";
+        if (value === "Ị̣̣̣̇") return "ị̣̣̣";
+        if (value === "I") return "ı";
+        if (value === "̣") return "̣";
+        if (value === "̇") return "̇";
+        if (value === "X") return "x";
+        if (value === "Y") return "y";
+      }
+      return locales === undefined
+        ? originalToLocaleLowerCase.call(value)
+        : originalToLocaleLowerCase.call(value, locales);
+    });
+    try {
+      const label = "Ị̣̣̣̇XY";
+      const xMatch = fuzzyMatchPaletteLabel(label, "x");
+      const yMatch = fuzzyMatchPaletteLabel(label, "y");
+      expect(xMatch?.matchedIndices).toEqual([6]);
+      expect(yMatch?.matchedIndices).toEqual([7]);
       const matchedIndices = [
         ...(xMatch?.matchedIndices ?? []),
         ...(yMatch?.matchedIndices ?? []),


### PR DESCRIPTION
## Summary
- 커맨드 팔레트(`>` 커맨드 모드)에 subsequence fuzzy 매칭 도입 — 오타·약어(`rnme`, `테전`)로도 명령 검색 가능
- 스코어 정렬: exact substring 토큰 수 > 점수(연속 +3·단어경계 +2·길이 페널티) > 원본 순서. exact 매칭은 항상 fuzzy-only보다 상위
- 매칭 glyph는 기존 `<mark>` 스타일(brass location 채널)로 하이라이트 — 신규 CSS/토큰 없음
- Operation 검색(비커맨드 모드)은 변경 없음

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/palette-commands.test.ts` — 20/20 (fuzzy 오타·exact>fuzzy 장문 보장·경계 occurrence·case-fold 인덱스 역변환 등 9건 신규)
- [x] `pnpm --filter @dotobokuri/fleet-console build` — green
- [x] 격리 콘솔 실측(v1.37.1 베이스): `>테전` fuzzy 6행+glyph 하이라이트, `>테마` exact 동일 매칭, 첫 행 실행(테마 전환) 정상, 비커맨드 모드 무영향 확인
- [x] Sentinel QA PASS (Critical/High 0; Medium 1·Low 2 전건 수정 반영)
- [x] changelog 프래그먼트 `.changelog.d/pr-427.md` — 그룹 문법·이중 언어·`compile-changelog-fragments.mjs --check` 통과