### PR TITLE
fix(fleet-plugin): make ledger rail panel scroll when operations overflow

### DIFF
--- a/.changelog.d/pr-431.md
+++ b/.changelog.d/pr-431.md
@@ -1,0 +1,6 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] Make the Ledger rail panel scroll when the operation list overflows, so the per-CLI device-wide section stays reachable.
+  ko: Operation 목록이 넘칠 때 Ledger rail 패널이 스크롤되어 CLI별 기기 전체 섹션에 항상 도달할 수 있습니다.
+- [fleet-console] Reset the Ledger panel scroll to the top when opening an operation detail and restore the list position on back.
+  ko: Operation 상세를 열 때 Ledger 패널 스크롤을 맨 위로 옮기고, 돌아올 때 목록 위치를 복원합니다.

--- a/runtime/fleet-plugins/ledger/client/ledger.css
+++ b/runtime/fleet-plugins/ledger/client/ledger.css
@@ -1,5 +1,8 @@
+/* rail 호스트는 고정 높이 + overflow: hidden만 제공하므로 스크롤은 패널이 자기 루트에서
+   소유한다 — 없으면 Operation이 많아질 때 아래 섹션(특히 clients)이 잘려 도달 불가. */
 .ledger-root {
-  min-height: 100%;
+  height: 100%;
+  overflow-y: auto;
   color: var(--text-primary);
   font-family: var(--font-body);
 }

--- a/runtime/fleet-plugins/ledger/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/ledger/client/rail-panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import type { Translate } from "@fleet-console/sdk/i18n";
 import type { RailPanelContext, RailPanelDescriptor } from "@fleet-console/sdk/rail";
@@ -148,6 +148,21 @@ function LedgerPanelBody({ ctx }: LedgerPanelProps) {
   const [refreshEpoch, setRefreshEpoch] = useState(0);
   const [forceRefresh, setForceRefresh] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const listScrollRef = useRef(0);
+
+  const openDetail = useCallback((operationId: string) => {
+    listScrollRef.current = rootRef.current?.scrollTop ?? 0;
+    setSelectedId(operationId);
+  }, []);
+
+  // 목록과 상세는 같은 .ledger-root DOM을 재사용하므로 scrollTop이 그대로 이어진다 —
+  // 상세 진입 시 맨 위로, 복귀 시 목록 위치 복원을 레이아웃 단계에서 처리해 깜빡임을 막는다.
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    root.scrollTop = selectedId ? 0 : listScrollRef.current;
+  }, [selectedId]);
 
   const refresh = useCallback(() => {
     setForceRefresh(true);
@@ -183,10 +198,10 @@ function LedgerPanelBody({ ctx }: LedgerPanelProps) {
   const expectedTheaterId = scope === "theater" ? ctx.theaterId : null;
   const visibleData = data?.scope.window === window && data.scope.theaterId === expectedTheaterId ? data : null;
   const selected = visibleData?.operations.find((operation) => operation.operationId === selectedId) ?? null;
-  if (selected) return <div className="ledger-root"><DetailView operation={selected} t={t} back={() => setSelectedId(null)} /></div>;
+  if (selected) return <div className="ledger-root" ref={rootRef}><DetailView operation={selected} t={t} back={() => setSelectedId(null)} /></div>;
 
   return (
-    <div className="ledger-root">
+    <div className="ledger-root" ref={rootRef}>
       <div className="ledger-controls">
         <div className="ledger-segment" role="group" aria-label={t("ledger.scope.aria")}>
           <button type="button" aria-pressed={scope === "theater"} disabled={!ctx.theaterId} onClick={() => setScope("theater")}>{t("ledger.scope.theater")}</button>
@@ -228,7 +243,7 @@ function LedgerPanelBody({ ctx }: LedgerPanelProps) {
               <div className="ledger-inline-empty"><strong>{t("ledger.empty.title")}</strong><p>{t("ledger.empty.body")}</p></div>
             ) : null}
             {visibleData.operations.map((operation) => (
-              <button type="button" className={`ledger-operation ledger-operation--${markKeyFromCliId(operation.cliId)}`} key={operation.operationId} onClick={() => setSelectedId(operation.operationId)}>
+              <button type="button" className={`ledger-operation ledger-operation--${markKeyFromCliId(operation.cliId)}`} key={operation.operationId} onClick={() => openDetail(operation.operationId)}>
                 <span className="ledger-operation-mark">{cliGlyph(markKeyFromCliId(operation.cliId))}</span>
                 <span className="ledger-operation-copy">
                   <strong>{operation.title}</strong>

--- a/runtime/fleet-plugins/ledger/tests/rail-panel.test.tsx
+++ b/runtime/fleet-plugins/ledger/tests/rail-panel.test.tsx
@@ -129,6 +129,24 @@ describe("Ledger rail status rendering", () => {
     expect(container.querySelector(".ledger-total-token")?.textContent).toContain("2k");
   });
 
+  it("resets scroll on detail entry and restores the list position on back", async () => {
+    await renderWith(dto("ok"));
+    const listRoot = container.querySelector<HTMLDivElement>(".ledger-root");
+    expect(listRoot).not.toBeNull();
+    listRoot!.scrollTop = 480;
+
+    const operation = container.querySelector<HTMLButtonElement>(".ledger-operation");
+    await act(async () => operation!.click());
+    expect(container.querySelector(".ledger-detail")).not.toBeNull();
+    expect(container.querySelector<HTMLDivElement>(".ledger-root")!.scrollTop).toBe(0);
+
+    const back = container.querySelector<HTMLButtonElement>(".ledger-back");
+    expect(back).not.toBeNull();
+    await act(async () => back!.click());
+    expect(container.querySelector(".ledger-operation")).not.toBeNull();
+    expect(container.querySelector<HTMLDivElement>(".ledger-root")!.scrollTop).toBe(480);
+  });
+
   it("hides the previous window data immediately while the next request is pending", async () => {
     let resolveToday!: (value: Response) => void;
     const fetch = vi.fn((_pluginId: string, path: string) => {


### PR DESCRIPTION
## Summary
- Ledger rail 패널은 rail 호스트가 `overflow: hidden` + 고정 높이만 제공하는데 자기 루트에 스크롤 규칙이 없어, Operation이 많아지면 하단 'CLI별 · 기기 전체' 섹션이 잘려 도달 불가였음 — `.ledger-root`가 높이를 채우고 `overflow-y: auto`로 스크롤을 소유하게 수정
- 목록↔상세가 같은 `.ledger-root` DOM을 재사용해 생기는 스크롤 상태 회귀(상세가 중간부터 열림, Back 시 목록 위치 증발)를 진입 시 top 리셋 + 복귀 시 저장 위치 복원으로 해소

## Test Plan
- [x] ledger 플러그인 vitest 69건 통과(신규 스크롤 회귀 테스트 포함)
- [x] ledger typecheck / build 통과
- [x] fleet-console instrument-design-contract 27건 통과
- [x] 격리 콘솔 실기 실측: 더미 Operation 20개 환경에서 스크롤 끝 도달 시 clients 섹션 완전 노출 + 수정 전 조건(규칙 묠리화)에서 스크롤 불가 대조 확인
- [x] Sentinel QA 2라운드 PASS(2차 리뷰 지적 0건)
- [x] changelog 프래그먼트: `.changelog.d/pr-431.md`(fleet-plugin / Fixed 2건, 이중언어, compile-changelog-fragments --check 통과)
