### PR TITLE
fix(repository): make retained list scroll actually restore

### DIFF
--- a/.changelog.d/pr-432.md
+++ b/.changelog.d/pr-432.md
@@ -1,0 +1,6 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] Repository changes and compare lists now actually restore their retained scroll position when you return to the panel; the position was previously tracked on a non-scrolling container and always reset to the top.
+  ko: 저장소 변경 파일·비교 목록이 패널 복귀 시 보존한 스크롤 위치를 실제로 복원합니다. 이전에는 스크롤되지 않는 컨테이너를 추적해 항상 맨 위로 되돌아갔습니다.
+- [fleet-console] The workspace source tree no longer loses its pending scroll restore when branches, worktrees, or change counts finish loading after the panel appears.
+  ko: 워크스페이스 소스 트리가 패널 표시 후 브랜치·워크트리·변경 개수 로딩이 끝나도 대기 중이던 스크롤 복원을 잃지 않습니다.

--- a/runtime/fleet-plugins/repository/client/changed-files.tsx
+++ b/runtime/fleet-plugins/repository/client/changed-files.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type RefObject } from "react";
 
 import type { Translate } from "@fleet-console/sdk/i18n";
 
@@ -24,6 +24,8 @@ interface ChangedFilesProps {
   readonly t: Translate<RepositoryMessageKey>;
   readonly collapsedFolders?: ReadonlySet<string>;
   readonly onToggleFolder?: (path: string) => void;
+  readonly scrollContainerRef?: RefObject<HTMLDivElement | null>;
+  readonly onScroll?: () => void;
 }
 
 interface ListFileRowProps {
@@ -62,7 +64,7 @@ function readCollapsed(key: string): boolean {
   try { return localStorage.getItem(key) === "1"; } catch { return false; }
 }
 
-export function ChangedFiles({ state, onRetry, viewMode, selectedPath, onSelect, filterText, t, collapsedFolders, onToggleFolder }: ChangedFilesProps) {
+export function ChangedFiles({ state, onRetry, viewMode, selectedPath, onSelect, filterText, t, collapsedFolders, onToggleFolder, scrollContainerRef, onScroll }: ChangedFilesProps) {
   const [changesCollapsed, setChangesCollapsed] = useState(() => readCollapsed(PREFS_CHANGES_COLLAPSED));
 
   const handleToggleChanges = useCallback(() => {
@@ -109,7 +111,7 @@ export function ChangedFiles({ state, onRetry, viewMode, selectedPath, onSelect,
   const countLabel = filterText ? `${visibleFiles.length}/${state.files.length}` : String(state.files.length);
 
   return (
-    <div className="repository-sections">
+    <div ref={scrollContainerRef} className="repository-sections" onScroll={onScroll}>
       <div className={`repository-section${changesCollapsed ? " is-collapsed" : ""}`}>
         <button type="button" className="repository-section-head" onClick={handleToggleChanges}>
           <svg className="repository-section-chevron" viewBox="0 0 12 12" fill="none" aria-hidden="true">

--- a/runtime/fleet-plugins/repository/client/compare-view.tsx
+++ b/runtime/fleet-plugins/repository/client/compare-view.tsx
@@ -75,7 +75,6 @@ export function CompareView({ ctx, repoRel, refs, refsError = false, onRetryRefs
     return initialResult.files.find((entry) => entry.path === initialCache.selectedPath) ?? null;
   });
   const [listPaneWidth, setListPaneWidth] = useState(initialCache?.listPaneWidth ?? LIST_PANE_DEFAULT_WIDTH);
-  const [scrollTop, setScrollTop] = useState(initialCache?.scrollTop ?? 0);
   const [isDragging, setIsDragging] = useState(false);
   const listPaneWidthRef = useRef(listPaneWidth);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -83,6 +82,7 @@ export function CompareView({ ctx, repoRel, refs, refsError = false, onRetryRefs
   const scrollTopRef = useRef(initialCache?.scrollTop ?? 0);
   const restoredScrollTopRef = useRef<number | null>(initialCache?.scrollTop ?? null);
   const stateCacheKeyRef = useRef(`${ctx.theaterId ?? ""}\x00${repoRel}`);
+  const cacheFrameRef = useRef<number | null>(null);
   const dragDisposeRef = useRef<(() => void) | null>(null);
   const hydratedRef = useRef(false);
   const requestSeqRef = useRef(0);
@@ -114,6 +114,25 @@ export function CompareView({ ctx, repoRel, refs, refsError = false, onRetryRefs
 
   useEffect(() => { onFileOpenChange?.(selected !== null); }, [onFileOpenChange, selected]);
   useEffect(() => () => dragDisposeRef.current?.(), []);
+  const cacheSnapshotRef = useRef({ theaterId: ctx.theaterId, repoRel, result, selected, listPaneWidth });
+  cacheSnapshotRef.current = { theaterId: ctx.theaterId, repoRel, result, selected, listPaneWidth };
+  const flushCompareCache = useCallback(() => {
+    const snapshot = cacheSnapshotRef.current;
+    if (!snapshot.theaterId || stateCacheKeyRef.current !== `${snapshot.theaterId}\x00${snapshot.repoRel}` || snapshot.result.kind === "loading") return;
+    writeCompareViewState(snapshot.theaterId, snapshot.repoRel, {
+      result: snapshot.result.kind === "idle" ? null : snapshot.result,
+      selectedPath: snapshot.result.kind === "ok" && snapshot.selected && snapshot.result.files.some((entry) => entry.path === snapshot.selected?.path) ? snapshot.selected.path : null,
+      listPaneWidth: snapshot.listPaneWidth,
+      scrollTop: scrollTopRef.current,
+    });
+  }, []);
+  const scheduleCompareCacheWrite = useCallback(() => {
+    if (cacheFrameRef.current !== null) return;
+    cacheFrameRef.current = requestAnimationFrame(() => {
+      cacheFrameRef.current = null;
+      flushCompareCache();
+    });
+  }, [flushCompareCache]);
   const updateResultsScroll = useCallback(() => {
     const list = resultsRef.current;
     if (!list || list.clientHeight <= 0 || list.scrollHeight <= 0) return;
@@ -124,17 +143,18 @@ export function CompareView({ ctx, repoRel, refs, refsError = false, onRetryRefs
       restoredScrollTopRef.current = null;
     }
     scrollTopRef.current = list.scrollTop;
-    setScrollTop(list.scrollTop);
-  }, []);
+    scheduleCompareCacheWrite();
+  }, [scheduleCompareCacheWrite]);
   useEffect(() => {
-    if (!ctx.theaterId || stateCacheKeyRef.current !== `${ctx.theaterId}\x00${repoRel}` || result.kind === "loading") return;
-    writeCompareViewState(ctx.theaterId, repoRel, {
-      result: result.kind === "idle" ? null : result,
-      selectedPath: result.kind === "ok" && selected && result.files.some((entry) => entry.path === selected.path) ? selected.path : null,
-      listPaneWidth,
-      scrollTop: scrollTopRef.current,
-    });
-  }, [ctx.theaterId, listPaneWidth, repoRel, result, scrollTop, selected]);
+    scheduleCompareCacheWrite();
+  }, [listPaneWidth, result, scheduleCompareCacheWrite, selected]);
+  useEffect(() => () => {
+    if (cacheFrameRef.current !== null) {
+      cancelAnimationFrame(cacheFrameRef.current);
+      cacheFrameRef.current = null;
+    }
+    flushCompareCache();
+  }, [flushCompareCache]);
   useLayoutEffect(() => {
     updateResultsScroll();
     const list = resultsRef.current;
@@ -240,7 +260,7 @@ export function CompareView({ ctx, repoRel, refs, refsError = false, onRetryRefs
       <div ref={rootRef} className={`repository-root${selected ? " has-hunk" : ""}${isDragging ? " is-dragging" : ""}`} style={selected ? { gridTemplateColumns: buildDiffGridTemplate(listPaneWidth) } : undefined}>
         {selected && compareSelection ? <div className="repository-hunk-pane"><div className="repository-hunk-head"><span>{selected.path}</span><button type="button" onClick={() => setSelected(null)}>✕</button></div><HunkView ctx={ctx} repoRel={repoRel} file={selected} mode="unified" compare={compareSelection} /></div> : null}
         {selected ? <div className="repository-divider" onPointerDown={handleDividerDown} aria-hidden="true" /> : null}
-        <div ref={resultsRef} className="repository-list-pane repository-compare-results" onScroll={updateResultsScroll}>
+        <div className="repository-list-pane repository-compare-results">
           {result.kind === "idle" && <div className="history-empty">{t("repository.compare.idle")}</div>}
           {result.kind === "loading" && <div className="history-empty">{t("repository.compare.comparing")}</div>}
           {result.kind === "ok" && result.files.length === 0 && <div className="history-empty">{t("repository.compare.noDifferences")}</div>}
@@ -257,6 +277,8 @@ export function CompareView({ ctx, repoRel, refs, refsError = false, onRetryRefs
                 onSelect={setSelected}
                 filterText=""
                 t={t}
+                scrollContainerRef={resultsRef}
+                onScroll={updateResultsScroll}
               />
               {result.kind === "ok" && result.truncated && <div className="history-truncated">{t("repository.compare.capped")}</div>}
             </>

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -217,8 +217,34 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
     document.addEventListener("pointermove", onMove);
     document.addEventListener("pointerup", onUp);
   }, []);
+  const repoViewSnapshotRef = useRef({ theaterId: ctx.theaterId, repoRel, repoViewCacheKey, hydratedRepoViewCacheKey, filterText, refFilter, collapsedChangeFolders });
+  repoViewSnapshotRef.current = { theaterId: ctx.theaterId, repoRel, repoViewCacheKey, hydratedRepoViewCacheKey, filterText, refFilter, collapsedChangeFolders };
+  const flushChangesCache = useCallback(() => {
+    const snapshot = repoViewSnapshotRef.current;
+    if (!snapshot.theaterId || snapshot.hydratedRepoViewCacheKey !== snapshot.repoViewCacheKey) return;
+    writeRepoViewState(snapshot.theaterId, snapshot.repoRel, {
+      filterText: snapshot.filterText,
+      refFilter: snapshot.refFilter,
+      scrollTop: changesScrollTopRef.current,
+      collapsedFolders: [...snapshot.collapsedChangeFolders],
+    });
+  }, []);
+  const scheduleChangesCacheWrite = useCallback(() => {
+    if (changesCacheFrameRef.current !== null) return;
+    changesCacheFrameRef.current = requestAnimationFrame(() => {
+      changesCacheFrameRef.current = null;
+      flushChangesCache();
+    });
+  }, [flushChangesCache]);
   const transitionRepository = useCallback((nextRepoRel: string, persist: boolean, landing: Source = "changes") => {
     if (!ctx.theaterId) return;
+    // rAF로 미뤄둔 이전 스코프의 캐시 write가 있다면 스코프가 바뀌기 전에 동기로 flush한다 —
+    // 전환 후 발화하면 snapshot이 새 스코프로 바뀌어 이전 스코프의 마지막 스크롤/필터가 소실된다.
+    if (changesCacheFrameRef.current !== null) {
+      cancelAnimationFrame(changesCacheFrameRef.current);
+      changesCacheFrameRef.current = null;
+    }
+    flushChangesCache();
     if (persist) saveRepositoryRel(ctx.theaterId, nextRepoRel);
     clearSelectedFile();
     setChangedFiles({ kind: "loading" });
@@ -226,7 +252,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
     repoRelRef.current = nextRepoRel;
     setRepoRel(nextRepoRel);
     setSource(landing);
-  }, [ctx.theaterId, setSource]);
+  }, [ctx.theaterId, flushChangesCache, setSource]);
   useEffect(() => {
     if (!searchTarget || searchTarget.theaterId !== ctx.theaterId) return;
     setRefFilter(null);
@@ -320,25 +346,6 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
 
   useLayoutEffect(() => () => clearSelectedFile(), []);
 
-  const repoViewSnapshotRef = useRef({ theaterId: ctx.theaterId, repoRel, repoViewCacheKey, hydratedRepoViewCacheKey, filterText, refFilter, collapsedChangeFolders });
-  repoViewSnapshotRef.current = { theaterId: ctx.theaterId, repoRel, repoViewCacheKey, hydratedRepoViewCacheKey, filterText, refFilter, collapsedChangeFolders };
-  const flushChangesCache = useCallback(() => {
-    const snapshot = repoViewSnapshotRef.current;
-    if (!snapshot.theaterId || snapshot.hydratedRepoViewCacheKey !== snapshot.repoViewCacheKey) return;
-    writeRepoViewState(snapshot.theaterId, snapshot.repoRel, {
-      filterText: snapshot.filterText,
-      refFilter: snapshot.refFilter,
-      scrollTop: changesScrollTopRef.current,
-      collapsedFolders: [...snapshot.collapsedChangeFolders],
-    });
-  }, []);
-  const scheduleChangesCacheWrite = useCallback(() => {
-    if (changesCacheFrameRef.current !== null) return;
-    changesCacheFrameRef.current = requestAnimationFrame(() => {
-      changesCacheFrameRef.current = null;
-      flushChangesCache();
-    });
-  }, [flushChangesCache]);
   const updateChangesScroll = useCallback(() => {
     const list = changesListRef.current;
     if (!list || list.clientHeight <= 0 || list.scrollHeight <= 0) return;

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -173,13 +173,13 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   const [viewMode, setViewMode] = useState<ViewMode>(readViewMode);
   const [filterText, setFilterText] = useState(initialRepoViewState?.filterText ?? "");
   const [collapsedChangeFolders, setCollapsedChangeFolders] = useState(() => new Set(initialRepoViewState?.collapsedFolders ?? []));
-  const [changesScrollTop, setChangesScrollTop] = useState(initialRepoViewState?.scrollTop ?? 0);
   const repoViewCacheKey = `${ctx.theaterId ?? ""}\x00${repoRel}`;
   const [hydratedRepoViewCacheKey, setHydratedRepoViewCacheKey] = useState(repoViewCacheKey);
   const freshRefFilterCacheKeyRef = useRef<string | null>(null);
   const changesListRef = useRef<HTMLDivElement>(null);
   const restoredChangesScrollTopRef = useRef<number | null>(initialRepoViewState?.scrollTop ?? null);
   const changesScrollTopRef = useRef(initialRepoViewState?.scrollTop ?? 0);
+  const changesCacheFrameRef = useRef<number | null>(null);
   // 동일 컨텍스트 재착지는 repoRel key가 안 바뀌어 History 패널이 리마운트되지 않는다 —
   // epoch를 key에 섞어 전환 착지와 동일한 초기 상태(로컬 필터·선택·스크롤)로 재설정한다.
   const [historyLandingEpoch, setHistoryLandingEpoch] = useState(0);
@@ -247,7 +247,6 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
     const restoredScrollTop = cached?.scrollTop ?? 0;
     restoredChangesScrollTopRef.current = restoredScrollTop;
     changesScrollTopRef.current = restoredScrollTop;
-    setChangesScrollTop(restoredScrollTop);
     setHydratedRepoViewCacheKey(repoViewCacheKey);
     if (freshRefLanding) freshRefFilterCacheKeyRef.current = null;
   }, [ctx.theaterId, hydratedRepoViewCacheKey, repoRel, repoViewCacheKey]);
@@ -321,6 +320,25 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
 
   useLayoutEffect(() => () => clearSelectedFile(), []);
 
+  const repoViewSnapshotRef = useRef({ theaterId: ctx.theaterId, repoRel, repoViewCacheKey, hydratedRepoViewCacheKey, filterText, refFilter, collapsedChangeFolders });
+  repoViewSnapshotRef.current = { theaterId: ctx.theaterId, repoRel, repoViewCacheKey, hydratedRepoViewCacheKey, filterText, refFilter, collapsedChangeFolders };
+  const flushChangesCache = useCallback(() => {
+    const snapshot = repoViewSnapshotRef.current;
+    if (!snapshot.theaterId || snapshot.hydratedRepoViewCacheKey !== snapshot.repoViewCacheKey) return;
+    writeRepoViewState(snapshot.theaterId, snapshot.repoRel, {
+      filterText: snapshot.filterText,
+      refFilter: snapshot.refFilter,
+      scrollTop: changesScrollTopRef.current,
+      collapsedFolders: [...snapshot.collapsedChangeFolders],
+    });
+  }, []);
+  const scheduleChangesCacheWrite = useCallback(() => {
+    if (changesCacheFrameRef.current !== null) return;
+    changesCacheFrameRef.current = requestAnimationFrame(() => {
+      changesCacheFrameRef.current = null;
+      flushChangesCache();
+    });
+  }, [flushChangesCache]);
   const updateChangesScroll = useCallback(() => {
     const list = changesListRef.current;
     if (!list || list.clientHeight <= 0 || list.scrollHeight <= 0) return;
@@ -331,8 +349,8 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
       restoredChangesScrollTopRef.current = null;
     }
     changesScrollTopRef.current = list.scrollTop;
-    setChangesScrollTop(list.scrollTop);
-  }, []);
+    scheduleChangesCacheWrite();
+  }, [scheduleChangesCacheWrite]);
   useLayoutEffect(() => {
     updateChangesScroll();
     const list = changesListRef.current;
@@ -342,14 +360,15 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
     return () => observer.disconnect();
   }, [changedFiles, filterText, hydratedRepoViewCacheKey, updateChangesScroll, viewMode]);
   useEffect(() => {
-    if (!ctx.theaterId || hydratedRepoViewCacheKey !== repoViewCacheKey) return;
-    writeRepoViewState(ctx.theaterId, repoRel, {
-      filterText,
-      refFilter,
-      scrollTop: changesScrollTopRef.current,
-      collapsedFolders: [...collapsedChangeFolders],
-    });
-  }, [changesScrollTop, collapsedChangeFolders, ctx.theaterId, filterText, hydratedRepoViewCacheKey, refFilter, repoRel, repoViewCacheKey]);
+    scheduleChangesCacheWrite();
+  }, [collapsedChangeFolders, filterText, hydratedRepoViewCacheKey, refFilter, repoRel, scheduleChangesCacheWrite]);
+  useEffect(() => () => {
+    if (changesCacheFrameRef.current !== null) {
+      cancelAnimationFrame(changesCacheFrameRef.current);
+      changesCacheFrameRef.current = null;
+    }
+    flushChangesCache();
+  }, [flushChangesCache]);
 
   const handleSelectFile = useCallback((entry: DiffFileEntry) => {
     if (ctx.theaterId) setSelectedFile(entry, ctx.theaterId, repoRel);
@@ -416,9 +435,9 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   const changesView = <div ref={rootRef} className={`repository-root${selectedFile ? " has-hunk" : ""}${isDragging ? " is-dragging" : ""}`} style={selectedFile ? { gridTemplateColumns: buildDiffGridTemplate(listPaneWidth) } : undefined}>
     {selectedFile && hunkMode ? <div className="repository-hunk-pane"><div className="repository-hunk-head"><span>{selectedFile.entry.path}</span><button type="button" onClick={handleCloseHunk}>✕</button></div><HunkView ctx={ctx} repoRel={repoRel} file={selectedFile.entry} mode={hunkMode} /></div> : null}
     {selectedFile ? <div className="repository-divider" onPointerDown={handleDividerDown} aria-hidden="true" /> : null}
-    <div ref={changesListRef} className="repository-list-pane" onScroll={updateChangesScroll}>
+    <div className="repository-list-pane">
       <div className="repository-toolbar"><div className="repository-filter"><input type="text" className="repository-filter-input" placeholder={t("repository.common.filterPlaceholder")} aria-label={t("repository.common.filterChangedFiles")} value={filterText} onChange={(event) => setFilterText(event.target.value)} />{filterText ? <button type="button" className="repository-filter-clear" aria-label={t("repository.common.clearFilter")} onClick={() => setFilterText("")}>✕</button> : null}</div><div className="repository-view-toggle"><button type="button" className={`repository-toggle-btn${viewMode === "list" ? " is-active" : ""}`} title={t("repository.common.listView")} aria-pressed={viewMode === "list"} onClick={() => handleViewMode("list")}><svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><line x1="2" y1="3.5" x2="12" y2="3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" /><line x1="2" y1="7" x2="12" y2="7" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" /><line x1="2" y1="10.5" x2="12" y2="10.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" /></svg></button><button type="button" className={`repository-toggle-btn${viewMode === "tree" ? " is-active" : ""}`} title={t("repository.common.treeView")} aria-pressed={viewMode === "tree"} onClick={() => handleViewMode("tree")}><svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><rect x="1" y="1" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /><rect x="9" y="1" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /><rect x="1" y="9" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /><rect x="9" y="9" width="4" height="4" rx="1" stroke="currentColor" strokeWidth="1.3" /></svg></button></div></div>
-      <ChangedFiles state={changedFiles} onRetry={retryChangedFiles} viewMode={viewMode} selectedPath={selectedFile?.entry.path ?? null} onSelect={handleSelectFile} filterText={filterText} t={t} collapsedFolders={collapsedChangeFolders} onToggleFolder={handleToggleChangeFolder} />
+      <ChangedFiles state={changedFiles} onRetry={retryChangedFiles} viewMode={viewMode} selectedPath={selectedFile?.entry.path ?? null} onSelect={handleSelectFile} filterText={filterText} t={t} collapsedFolders={collapsedChangeFolders} onToggleFolder={handleToggleChangeFolder} scrollContainerRef={changesListRef} onScroll={updateChangesScroll} />
     </div>
   </div>;
   const compareView = <CompareView key={`${ctx.theaterId ?? ""}:${repoRel}`} ctx={ctx} repoRel={repoRel} refs={refs} refsError={refsError} onRetryRefs={() => setRefsRetry((value) => value + 1)} />;
@@ -469,7 +488,6 @@ export function WorkspaceTree({ theaterId = "", t, repos, reposError, reposTrunc
   const [query, setQuery] = useState(initialTreeState?.query ?? "");
   const [collapsedSections, setCollapsedSections] = useState(() => new Set(initialTreeState?.collapsedSections ?? ["tags", "stashes"]));
   const [collapsedFolders, setCollapsedFolders] = useState(() => new Set(initialTreeState?.collapsedFolders ?? []));
-  const [scrollTop, setScrollTop] = useState(initialTreeState?.scrollTop ?? 0);
   const handleToggleRepoFolder = (path: string) => {
     setCollapsedFolders((current) => {
       const next = new Set(current);
@@ -486,6 +504,7 @@ export function WorkspaceTree({ theaterId = "", t, repos, reposError, reposTrunc
   const nestedMatches = query ? nestedRepos.filter((repo) => matchRepository(repo) !== null) : nestedRepos;
   const matchedCount = rootMatches.length + nestedMatches.length;
   const branchCount = refs.branches.length + refs.remotes.filter((item) => !isRemoteHeadRef(item.ref)).length;
+  const refRowCount = refs.branches.length + refs.remotes.length + refs.tags.length + refs.stashes.length;
   const changesCount = changedFiles.kind === "ok" ? changedFiles.files.length : 0;
   const sections = buildWorkspaceTreeSections({
     context: repos.length,
@@ -523,7 +542,7 @@ export function WorkspaceTree({ theaterId = "", t, repos, reposError, reposTrunc
       const first = rootMatches[0] ?? nestedMatches[0];
       if (first) onRepository(first);
     }} />
-    <WorkspaceTreeScroll theaterId={theaterId} query={query} collapsedSections={collapsedSections} collapsedFolders={collapsedFolders} scrollTop={scrollTop} onScrollTop={setScrollTop} contentVersion={`${repos.length}:${collapsedSections.size}:${collapsedFolders.size}`}>
+    <WorkspaceTreeScroll theaterId={theaterId} query={query} collapsedSections={collapsedSections} collapsedFolders={collapsedFolders} initialScrollTop={initialTreeState?.scrollTop ?? 0} contentVersion={`${repos.length}:${worktrees.length}:${refRowCount}:${changesCount}:${collapsedSections.size}:${collapsedFolders.size}`}>
       <section className={`repository-ws-section${collapsedSections.has("context") ? " is-collapsed" : ""}`}>{sectionHeader("context")}
         {!collapsedSections.has("context") && (reposError ? <WorkspaceTreeError t={t} label={t("repository.discovery.loadReposFailed")} onRetry={onRetryRepos} /> : <>
           {rootMatches.map((repo) => <RepoLeafRow key={repo.relPath} repo={repo} depth={0} selectedRel={selectedRel} onRepository={onRepository} />)}
@@ -550,19 +569,37 @@ export function WorkspaceTree({ theaterId = "", t, repos, reposError, reposTrunc
   </aside>;
 }
 
-function WorkspaceTreeScroll({ theaterId, query, collapsedSections, collapsedFolders, scrollTop, onScrollTop, contentVersion, children }: {
+function WorkspaceTreeScroll({ theaterId, query, collapsedSections, collapsedFolders, initialScrollTop, contentVersion, children }: {
   readonly theaterId: string;
   readonly query: string;
   readonly collapsedSections: ReadonlySet<string>;
   readonly collapsedFolders: ReadonlySet<string>;
-  readonly scrollTop: number;
-  readonly onScrollTop: (scrollTop: number) => void;
+  readonly initialScrollTop: number;
   readonly contentVersion: string;
   readonly children: React.ReactNode;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const scrollTopRef = useRef(scrollTop);
-  const restoredScrollTopRef = useRef<number | null>(scrollTop);
+  const scrollTopRef = useRef(initialScrollTop);
+  const restoredScrollTopRef = useRef<number | null>(initialScrollTop);
+  const cacheFrameRef = useRef<number | null>(null);
+  const snapshotRef = useRef({ theaterId, query, collapsedSections, collapsedFolders });
+  snapshotRef.current = { theaterId, query, collapsedSections, collapsedFolders };
+  const flushCache = useCallback(() => {
+    const snapshot = snapshotRef.current;
+    writeWorkspaceTreeState(snapshot.theaterId, {
+      query: snapshot.query,
+      collapsedSections: [...snapshot.collapsedSections],
+      collapsedFolders: [...snapshot.collapsedFolders],
+      scrollTop: scrollTopRef.current,
+    });
+  }, []);
+  const scheduleCacheWrite = useCallback(() => {
+    if (cacheFrameRef.current !== null) return;
+    cacheFrameRef.current = requestAnimationFrame(() => {
+      cacheFrameRef.current = null;
+      flushCache();
+    });
+  }, [flushCache]);
   const updateTreeScroll = useCallback(() => {
     const tree = scrollRef.current;
     if (!tree || tree.clientHeight <= 0 || tree.scrollHeight <= 0) return;
@@ -573,8 +610,8 @@ function WorkspaceTreeScroll({ theaterId, query, collapsedSections, collapsedFol
       restoredScrollTopRef.current = null;
     }
     scrollTopRef.current = tree.scrollTop;
-    onScrollTop(tree.scrollTop);
-  }, [onScrollTop]);
+    scheduleCacheWrite();
+  }, [scheduleCacheWrite]);
   useLayoutEffect(() => {
     updateTreeScroll();
     const tree = scrollRef.current;
@@ -584,13 +621,15 @@ function WorkspaceTreeScroll({ theaterId, query, collapsedSections, collapsedFol
     return () => observer.disconnect();
   }, [contentVersion, updateTreeScroll]);
   useEffect(() => {
-    writeWorkspaceTreeState(theaterId, {
-      query,
-      collapsedSections: [...collapsedSections],
-      collapsedFolders: [...collapsedFolders],
-      scrollTop: scrollTopRef.current,
-    });
-  }, [collapsedFolders, collapsedSections, query, scrollTop, theaterId]);
+    scheduleCacheWrite();
+  }, [collapsedFolders, collapsedSections, query, scheduleCacheWrite, theaterId]);
+  useEffect(() => () => {
+    if (cacheFrameRef.current !== null) {
+      cancelAnimationFrame(cacheFrameRef.current);
+      cacheFrameRef.current = null;
+    }
+    flushCache();
+  }, [flushCache]);
   return <div ref={scrollRef} className="repository-ws-tree-scroll" onScroll={updateTreeScroll}>{children}</div>;
 }
 


### PR DESCRIPTION
## Summary
- #428(스쿼시 머지)에 포함된 패널 상태 캐시의 QA 후속 수정 — Changes/Compare의 스크롤 추적이 `overflow: hidden`인 바깥 pane에 붙어 저장값이 항상 0이던 결함을 실제 스크롤러(`.repository-sections`)로 이전
- refs/worktrees 비동기 도착 시 워크스페이스 트리 스크롤 복원이 재시도되지 않던 경로를 contentVersion에 데이터 도착 반영으로 해소
- 스크롤 프레임마다 패널 전체 리렌더+캐시 write 하던 경로를 ref-only + requestAnimationFrame 스로틀 + 언마운트 flush로 완화

## Test Plan
- [x] `corepack pnpm --filter @fleet-plugins/repository typecheck` 통과
- [x] `corepack pnpm --filter @fleet-plugins/repository test` — 31 files / 302 tests 통과
- [x] `corepack pnpm --filter @fleet-plugins/repository build` 통과
- [x] `.changelog.d/pr-432.md` — 프래그먼트 문법·이중언어 요약·`compile-changelog-fragments.mjs --check` 검증 완료