### PR TITLE
fix(fleet-console): preserve codex panel state across rail switches

### DIFF
--- a/.changelog.d/pr-435.md
+++ b/.changelog.d/pr-435.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Preserve the codex panel search query, open document, and reading position when switching right-rail panels or reopening the rail, while still resetting them on a real Theater change.
+  ko: 우측 레일 패널을 전환하거나 레일을 다시 열 때 codex 패널의 검색어·열린 문서·읽기 위치를 유지하고, Theater가 실제로 바뀔 때만 초기화합니다.

--- a/runtime/fleet-console/core/client/src/codex-host.ts
+++ b/runtime/fleet-console/core/client/src/codex-host.ts
@@ -129,6 +129,7 @@ export function mountReaderInto(
   let animationFrameId: number | null = null;
   let quietTimerId: ReturnType<typeof setTimeout> | null = null;
   let failsafeTimerId: ReturnType<typeof setTimeout> | null = null;
+  let suspectTimerId: ReturnType<typeof setTimeout> | null = null;
   let observer: ResizeObserver | null = null;
   const userScrollEvents = ["wheel", "touchmove", "keydown"] as const;
 
@@ -139,16 +140,37 @@ export function mountReaderInto(
     if (animationFrameId !== null) cancelAnimationFrame(animationFrameId);
     if (quietTimerId !== null) clearTimeout(quietTimerId);
     if (failsafeTimerId !== null) clearTimeout(failsafeTimerId);
+    if (suspectTimerId !== null) clearTimeout(suspectTimerId);
     for (const eventName of userScrollEvents) {
       readSlot.removeEventListener(eventName, cleanup, { capture: true });
     }
+    readSlot.removeEventListener("scroll", handleScroll);
+    tNode.removeEventListener("click", cleanup, { capture: true });
     if (scrollRestoreCleanup === cleanup) scrollRestoreCleanup = null;
+  };
+
+  // scroll anchoring도 scroll 이벤트를 만들지만 콘텐츠 크기 변화를 동반하므로, 짧은 RO
+  // 상관 구간 안에 resize가 없을 때만 사용자의 스크롤바 이동으로 판정한다.
+  const handleScroll = () => {
+    if (!active) return;
+    if (Math.abs(readSlot.scrollTop - targetScrollTop) <= 2) return;
+    if (quietTimerId !== null) {
+      clearTimeout(quietTimerId);
+      quietTimerId = null;
+    }
+    if (suspectTimerId !== null) clearTimeout(suspectTimerId);
+    suspectTimerId = setTimeout(() => {
+      suspectTimerId = null;
+      cleanup();
+    }, 150);
   };
 
   scrollRestoreCleanup = cleanup;
   for (const eventName of userScrollEvents) {
     readSlot.addEventListener(eventName, cleanup, { passive: true, capture: true });
   }
+  readSlot.addEventListener("scroll", handleScroll, { passive: true });
+  tNode.addEventListener("click", cleanup, { capture: true });
 
   const restore = () => {
     if (!active) return;
@@ -173,6 +195,10 @@ export function mountReaderInto(
 
   observer = new ResizeObserver(() => {
     if (!active) return;
+    if (suspectTimerId !== null) {
+      clearTimeout(suspectTimerId);
+      suspectTimerId = null;
+    }
     if (Math.abs(readSlot.scrollTop - targetScrollTop) > 2) {
       restore();
     }

--- a/runtime/fleet-console/core/client/src/codex-host.ts
+++ b/runtime/fleet-console/core/client/src/codex-host.ts
@@ -16,6 +16,7 @@ export type ReaderSlotOptions = Omit<MountReadingOptions, "tocContainer">;
 let hostNode: HTMLDivElement | null = null;
 let navigatorController: NavigatorController | null = null;
 let onRequestOpenReaderHandler: ((r: NavigatorRequest) => void) | null = null;
+let activeNavigatorWorkspaceId: string | null = null;
 
 // Reader 싱글톤 — split·오버레이 사이를 같은 노드로 relocate하여 콘텐츠·스크롤 보존
 let readerHostNode: HTMLDivElement | null = null;
@@ -25,6 +26,7 @@ let activeReaderKind: "entry" | "drydock" | "conflicts" | "schema" | null = null
 let activeReaderEntryId: string | null = null;
 let activeReaderSubId: string | undefined = undefined;
 let lastReaderScrollTop = 0;
+let scrollRestoreCleanup: (() => void) | null = null;
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
@@ -52,6 +54,8 @@ export function mountNavigatorInto(
 }
 
 export function setNavigatorTheater(theaterId: string | null): void {
+  if (theaterId === activeNavigatorWorkspaceId) return;
+  activeNavigatorWorkspaceId = theaterId;
   navigatorController?.setTheater(theaterId);
 }
 
@@ -66,6 +70,7 @@ export function mountReaderInto(
   tocSlot: HTMLElement,
   opts: ReaderSlotOptions,
 ): void {
+  scrollRestoreCleanup?.();
   const rNode = ensureReaderHostNode();
   const tNode = ensureTocHostNode();
   // 같은 엔트리를 split↔오버레이로 relocate할 때 외부 스크롤 컨테이너(.codex-doc-scroll ↔
@@ -76,7 +81,9 @@ export function mountReaderInto(
     opts.kind === "entry" && activeReaderKind === "entry" && opts.initialEntryId === activeReaderEntryId;
   // 이전 컨테이너가 아직 살아 있으면(예: Expand 시 split doc-scroll) 그 scrollTop을 저장한다.
   // Esc 방향(overlay→split)은 overlay 언마운트 전 닫기 핸들러가 saveReaderScroll로 미리 저장.
-  if (prevReadSlot && prevReadSlot !== readSlot) lastReaderScrollTop = prevReadSlot.scrollTop;
+  if (prevReadSlot && prevReadSlot !== readSlot && prevReadSlot.isConnected) {
+    lastReaderScrollTop = prevReadSlot.scrollTop;
+  }
 
   // DOM의 appendChild는 기존 부모에서 자동 detach → split·오버레이 사이를 콘텐츠 보존으로 relocate
   if (rNode.parentElement !== readSlot) readSlot.appendChild(rNode);
@@ -107,14 +114,73 @@ export function mountReaderInto(
     theaterId: opts.theaterId,
   });
 
-  // 같은 엔트리를 split→오버레이(Expand)로 옮길 때는 읽기 위치를 보존한다. 반대 방향
-  // (오버레이→split, Esc)은 오버레이 언마운트로 reader가 먼저 detach되어 위치 복원이
-  // 불안정하므로 상단부터 시작한다(콤팩트 뷰 복귀라 허용). 새 엔트리/뷰도 상단부터.
-  // relocate 직후 reflow 전 set하면 clamp되므로 rAF로 미룬다.
   const targetScrollTop = sameEntry ? lastReaderScrollTop : 0;
-  requestAnimationFrame(() => {
+  if (targetScrollTop <= 0) {
+    requestAnimationFrame(() => {
+      readSlot.scrollTop = targetScrollTop;
+    });
+    return;
+  }
+
+  // 긴 문서는 마크다운 하이드레이션 뒤에도 높이가 바뀌므로 단발 rAF만으로는 읽기 위치가
+  // 밀린다. 다단계 reflow의 임시 geometry에서는 scrollTop 연속 일치도 안정의 증거가
+  // 아니므로 마지막 크기 변화 뒤 quiet window까지 보정하되 사용자 스크롤 시 즉시 포기한다.
+  let active = true;
+  let animationFrameId: number | null = null;
+  let quietTimerId: ReturnType<typeof setTimeout> | null = null;
+  let failsafeTimerId: ReturnType<typeof setTimeout> | null = null;
+  let observer: ResizeObserver | null = null;
+  const userScrollEvents = ["wheel", "touchmove", "keydown"] as const;
+
+  const cleanup = () => {
+    if (!active) return;
+    active = false;
+    observer?.disconnect();
+    if (animationFrameId !== null) cancelAnimationFrame(animationFrameId);
+    if (quietTimerId !== null) clearTimeout(quietTimerId);
+    if (failsafeTimerId !== null) clearTimeout(failsafeTimerId);
+    for (const eventName of userScrollEvents) {
+      readSlot.removeEventListener(eventName, cleanup, { capture: true });
+    }
+    if (scrollRestoreCleanup === cleanup) scrollRestoreCleanup = null;
+  };
+
+  scrollRestoreCleanup = cleanup;
+  for (const eventName of userScrollEvents) {
+    readSlot.addEventListener(eventName, cleanup, { passive: true, capture: true });
+  }
+
+  const restore = () => {
+    if (!active) return;
     readSlot.scrollTop = targetScrollTop;
+  };
+  const scheduleQuietCheck = () => {
+    if (quietTimerId !== null) clearTimeout(quietTimerId);
+    quietTimerId = setTimeout(() => {
+      quietTimerId = null;
+      if (!active) return;
+      if (Math.abs(readSlot.scrollTop - targetScrollTop) <= 2) {
+        cleanup();
+        return;
+      }
+      restore();
+      scheduleQuietCheck();
+    }, 400);
+  };
+
+  restore();
+  animationFrameId = requestAnimationFrame(restore);
+
+  observer = new ResizeObserver(() => {
+    if (!active) return;
+    if (Math.abs(readSlot.scrollTop - targetScrollTop) > 2) {
+      restore();
+    }
+    scheduleQuietCheck();
   });
+  observer.observe(rNode);
+  scheduleQuietCheck();
+  failsafeTimerId = setTimeout(cleanup, 5_000);
 }
 
 // 컨테이너 전환(특히 overlay→split) 직전, 아직 살아 있는 reader 컨테이너의 scrollTop을 저장한다.
@@ -125,6 +191,7 @@ export function saveReaderScroll(): void {
 }
 
 export function teardownReaderNodes(): void {
+  scrollRestoreCleanup?.();
   readerController?.destroy();
   readerController = null;
   activeReaderKind = null;
@@ -137,6 +204,7 @@ export function teardownCodex(): void {
   teardownReaderNodes();
   navigatorController?.destroy();
   navigatorController = null;
+  activeNavigatorWorkspaceId = null;
   if (hostNode?.parentElement) hostNode.parentElement.removeChild(hostNode);
 }
 

--- a/runtime/fleet-console/core/client/src/rail/codex-panel.tsx
+++ b/runtime/fleet-console/core/client/src/rail/codex-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import type { ConsoleLocale } from "@fleet-console/sdk/i18n";
 import type { RailPanelDescriptor } from "@fleet-console/sdk/rail";
@@ -9,6 +9,7 @@ import {
   mountNavigatorInto,
   mountReaderInto,
   refreshCodexLocale,
+  saveReaderScroll,
   setNavigatorTheater,
   setOnRequestOpenReader,
   teardownCodex,
@@ -24,6 +25,9 @@ interface CodexWorkspaceState {
   readonly hasWiki: boolean;
   readonly id: string | null;
 }
+
+let lastCodexContextKey: string | null = null;
+let lastResolvedWorkspace: CodexWorkspaceState | null = null;
 
 // ─── Rail panel descriptor ───────────────────────────────────────────────────
 
@@ -46,14 +50,18 @@ function CodexRailPanel({ theaterId }: { readonly theaterId: string | null }) {
   const tocRef = useRef<HTMLDivElement>(null);
   const latestContextKeyRef = useRef("");
   const localeRef = useRef(locale);
-  const [workspace, setWorkspace] = useState<CodexWorkspaceState | null>(null);
+  const contextKey = theaterId ?? "";
+  const [workspace, setWorkspace] = useState<CodexWorkspaceState | null>(
+    lastResolvedWorkspace && lastResolvedWorkspace.contextKey === contextKey
+      ? lastResolvedWorkspace
+      : null,
+  );
 
   const reader = state.codexReader;
   const hasReader = reader !== null;
   const expanded = state.codexReaderExpanded;
   const activeTheater = state.theaters.find((t) => t.id === state.activeTheaterId) ?? null;
   const hasTheaters = state.theaters.length > 0;
-  const contextKey = theaterId ?? "";
   const workspaceId = workspace?.contextKey === contextKey && workspace.hasWiki ? workspace.id : null;
   const shouldMountCodex = workspaceId !== null;
 
@@ -61,20 +69,29 @@ function CodexRailPanel({ theaterId }: { readonly theaterId: string | null }) {
     ? `${reader.kind}:${reader.kind === "entry" ? reader.entryId : reader.kind === "drydock" ? (reader.patchId ?? "") : reader.kind === "conflicts" ? (reader.id ?? "") : (reader.templateId ?? "")}`
     : null;
 
-  // Theater 변경 시 이전 reader가 새 workspace에서 잠시 보이지 않도록 먼저 닫는다.
+  // 실제 Theater가 바뀐 경우에만 이전 reader를 닫고, 같은 패널 재마운트 상태는 보존한다.
   useEffect(() => {
     latestContextKeyRef.current = contextKey;
-    closeCodexReader();
+    if (lastCodexContextKey !== null && lastCodexContextKey !== contextKey) {
+      closeCodexReader();
+    }
+    lastCodexContextKey = contextKey;
     if (!theaterId) {
-      setWorkspace({ contextKey, hasWiki: false, id: null });
+      const nextWorkspace = { contextKey, hasWiki: false, id: null };
+      lastResolvedWorkspace = nextWorkspace;
+      setWorkspace(nextWorkspace);
       return;
     }
     void resolveCodexWorkspace(theaterId).then((result) => {
       if (latestContextKeyRef.current !== contextKey) return;
-      setWorkspace({ contextKey, ...result });
+      const nextWorkspace = { contextKey, ...result };
+      lastResolvedWorkspace = nextWorkspace;
+      setWorkspace(nextWorkspace);
     }).catch(() => {
       if (latestContextKeyRef.current !== contextKey) return;
-      setWorkspace({ contextKey, hasWiki: false, id: null });
+      const nextWorkspace = { contextKey, hasWiki: false, id: null };
+      lastResolvedWorkspace = nextWorkspace;
+      setWorkspace(nextWorkspace);
     });
   }, [contextKey, theaterId]);
 
@@ -84,7 +101,8 @@ function CodexRailPanel({ theaterId }: { readonly theaterId: string | null }) {
     if (workspace?.contextKey === contextKey && !workspace.hasWiki) teardownCodex();
   }, [contextKey, workspace]);
 
-  useEffect(() => () => teardownCodex(), []);
+  // 패널 DOM이 detach되기 전에 현재 reader 위치를 싱글톤에 저장한다.
+  useLayoutEffect(() => () => saveReaderScroll(), []);
 
   // navigator 마운트 + onRequest 등록 — hasReader 전환 시 navRef 컨테이너가 바뀌므로 재배치
   // locale을 deps에 넣어 로케일 전환 시 effect를 다시 돌린다(싱글톤은 재배치만; 문구는 refreshCodexLocale).

--- a/runtime/fleet-console/tests/codex-host-state.test.ts
+++ b/runtime/fleet-console/tests/codex-host-state.test.ts
@@ -167,11 +167,49 @@ describe("Codex host in-memory state", () => {
 
     expect(nextReadSlot.scrollTop).toBe(730);
   });
+
+  it("stops restoring when an unmatched scroll has no resize within 150ms", () => {
+    const { nextReadSlot } = mountRelocatedReader(1_400);
+    vi.advanceTimersByTime(350);
+    nextReadSlot.scrollTop = 936;
+    nextReadSlot.dispatchEvent(new Event("scroll"));
+
+    vi.advanceTimersByTime(149);
+    expect(resizeObserverDisconnects.at(-1)).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(resizeObserverDisconnects.at(-1)).toHaveBeenCalledOnce();
+
+    nextReadSlot.scrollTop = 877;
+    triggerLatestResize();
+    expect(nextReadSlot.scrollTop).toBe(877);
+  });
+
+  it("keeps restoring when resize correlates with a scroll anchoring adjustment", () => {
+    const { nextReadSlot } = mountRelocatedReader(1_800);
+    nextReadSlot.scrollTop = 730;
+    nextReadSlot.dispatchEvent(new Event("scroll"));
+    triggerLatestResize();
+    vi.advanceTimersByTime(150);
+
+    expect(nextReadSlot.scrollTop).toBe(1_800);
+    expect(resizeObserverDisconnects.at(-1)).not.toHaveBeenCalled();
+  });
+
+  it("stops restoring immediately when the TOC is clicked", () => {
+    const { nextReadSlot, nextTocSlot } = mountRelocatedReader(1_400);
+    nextTocSlot.firstElementChild?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(resizeObserverDisconnects.at(-1)).toHaveBeenCalledOnce();
+
+    nextReadSlot.scrollTop = 936;
+    triggerLatestResize();
+    expect(nextReadSlot.scrollTop).toBe(936);
+  });
 });
 
 function mountRelocatedReader(scrollTop: number): {
   readonly firstReadSlot: HTMLDivElement;
   readonly nextReadSlot: HTMLDivElement;
+  readonly nextTocSlot: HTMLDivElement;
 } {
   const firstReadSlot = document.createElement("div");
   const firstTocSlot = document.createElement("div");
@@ -191,7 +229,7 @@ function mountRelocatedReader(scrollTop: number): {
   saveReaderScroll();
   firstReadSlot.remove();
   mountReaderInto(nextReadSlot, nextTocSlot, options);
-  return { firstReadSlot, nextReadSlot };
+  return { firstReadSlot, nextReadSlot, nextTocSlot };
 }
 
 function triggerLatestResize(): void {

--- a/runtime/fleet-console/tests/codex-host-state.test.ts
+++ b/runtime/fleet-console/tests/codex-host-state.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const codexMocks = vi.hoisted(() => ({
+  navigatorController: {
+    destroy: vi.fn(),
+    refreshLocale: vi.fn(),
+    setTheater: vi.fn(),
+  },
+  readerController: {
+    destroy: vi.fn(),
+    navigateSub: vi.fn(async () => undefined),
+    refreshCallbacks: vi.fn(),
+    refreshLocale: vi.fn(async () => undefined),
+    setEntry: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock("../core/client/src/codex/main.js", () => ({
+  mountNavigatorApp: vi.fn(() => codexMocks.navigatorController),
+}));
+
+vi.mock("../core/client/src/codex/reading-controller.js", () => ({
+  mountReadingInto: vi.fn(() => codexMocks.readerController),
+}));
+
+import {
+  mountNavigatorInto,
+  mountReaderInto,
+  saveReaderScroll,
+  setNavigatorTheater,
+  teardownCodex,
+} from "../core/client/src/codex-host.js";
+
+let requestAnimationFrameDescriptor: PropertyDescriptor | undefined;
+let resizeObserverCallbacks: ResizeObserverCallback[] = [];
+let resizeObserverDisconnects: ReturnType<typeof vi.fn>[] = [];
+
+beforeEach(() => {
+  requestAnimationFrameDescriptor = Object.getOwnPropertyDescriptor(globalThis, "requestAnimationFrame");
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  teardownCodex();
+  vi.clearAllMocks();
+  document.body.replaceChildren();
+  resizeObserverCallbacks = [];
+  resizeObserverDisconnects = [];
+  vi.stubGlobal("ResizeObserver", class {
+    readonly disconnect = vi.fn();
+
+    constructor(callback: ResizeObserverCallback) {
+      resizeObserverCallbacks.push(callback);
+      resizeObserverDisconnects.push(this.disconnect);
+    }
+
+    observe(): void {}
+    unobserve(): void {}
+  });
+  Object.defineProperty(globalThis, "requestAnimationFrame", {
+    configurable: true,
+    value: (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    },
+  });
+});
+
+afterEach(() => {
+  teardownCodex();
+  document.body.replaceChildren();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  if (requestAnimationFrameDescriptor) {
+    Object.defineProperty(globalThis, "requestAnimationFrame", requestAnimationFrameDescriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, "requestAnimationFrame");
+  }
+});
+
+describe("Codex host in-memory state", () => {
+  it("does not reset navigator state when the same workspace is assigned again", () => {
+    const firstSlot = document.createElement("div");
+    const secondSlot = document.createElement("div");
+    document.body.append(firstSlot, secondSlot);
+
+    mountNavigatorInto(firstSlot, "workspace-a");
+    setNavigatorTheater("workspace-a");
+    mountNavigatorInto(secondSlot, "workspace-a");
+    setNavigatorTheater("workspace-a");
+
+    expect(codexMocks.navigatorController.setTheater).toHaveBeenCalledTimes(1);
+    expect(codexMocks.navigatorController.setTheater).toHaveBeenLastCalledWith("workspace-a");
+
+    setNavigatorTheater("workspace-b");
+
+    expect(codexMocks.navigatorController.setTheater).toHaveBeenCalledTimes(2);
+    expect(codexMocks.navigatorController.setTheater).toHaveBeenLastCalledWith("workspace-b");
+  });
+
+  it("keeps the saved reader position when its previous slot was already detached", () => {
+    const firstReadSlot = document.createElement("div");
+    const firstTocSlot = document.createElement("div");
+    const nextReadSlot = document.createElement("div");
+    const nextTocSlot = document.createElement("div");
+    document.body.append(firstReadSlot, firstTocSlot, nextReadSlot, nextTocSlot);
+    const options = {
+      initialEntryId: "entry-a",
+      kind: "entry" as const,
+      theaterId: "workspace-a",
+      onRelatedClick: vi.fn(),
+      onClose: vi.fn(),
+    };
+
+    mountReaderInto(firstReadSlot, firstTocSlot, options);
+    firstReadSlot.scrollTop = 137;
+    saveReaderScroll();
+    firstReadSlot.remove();
+    firstReadSlot.scrollTop = 0;
+
+    mountReaderInto(nextReadSlot, nextTocSlot, options);
+
+    expect(nextReadSlot.scrollTop).toBe(137);
+  });
+
+  it("reapplies the saved reader position after asynchronous content resize", () => {
+    const { firstReadSlot, nextReadSlot } = mountRelocatedReader(1_400);
+    expect(nextReadSlot.scrollTop).toBe(1_400);
+
+    nextReadSlot.scrollTop = 996;
+    triggerLatestResize();
+
+    expect(nextReadSlot.scrollTop).toBe(1_400);
+    expect(firstReadSlot.isConnected).toBe(false);
+  });
+
+  it("keeps restoring when a later resize follows a temporarily matching scroll position", () => {
+    const { nextReadSlot } = mountRelocatedReader(1_400);
+    triggerLatestResize();
+    vi.advanceTimersByTime(200);
+    expect(resizeObserverDisconnects.at(-1)).not.toHaveBeenCalled();
+
+    nextReadSlot.scrollTop = 936;
+    triggerLatestResize();
+
+    expect(nextReadSlot.scrollTop).toBe(1_400);
+    expect(resizeObserverDisconnects.at(-1)).not.toHaveBeenCalled();
+  });
+
+  it("cleans up only after the 400ms quiet window elapses", () => {
+    mountRelocatedReader(1_800);
+    triggerLatestResize();
+
+    vi.advanceTimersByTime(399);
+    expect(resizeObserverDisconnects.at(-1)).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(resizeObserverDisconnects.at(-1)).toHaveBeenCalledOnce();
+  });
+
+  it("stops restoring as soon as the user scrolls", () => {
+    const { nextReadSlot } = mountRelocatedReader(1_800);
+    nextReadSlot.dispatchEvent(new WheelEvent("wheel", { bubbles: true }));
+    expect(resizeObserverDisconnects.at(-1)).toHaveBeenCalledOnce();
+
+    nextReadSlot.scrollTop = 730;
+    triggerLatestResize();
+
+    expect(nextReadSlot.scrollTop).toBe(730);
+  });
+});
+
+function mountRelocatedReader(scrollTop: number): {
+  readonly firstReadSlot: HTMLDivElement;
+  readonly nextReadSlot: HTMLDivElement;
+} {
+  const firstReadSlot = document.createElement("div");
+  const firstTocSlot = document.createElement("div");
+  const nextReadSlot = document.createElement("div");
+  const nextTocSlot = document.createElement("div");
+  document.body.append(firstReadSlot, firstTocSlot, nextReadSlot, nextTocSlot);
+  const options = {
+    initialEntryId: "entry-a",
+    kind: "entry" as const,
+    theaterId: "workspace-a",
+    onRelatedClick: vi.fn(),
+    onClose: vi.fn(),
+  };
+
+  mountReaderInto(firstReadSlot, firstTocSlot, options);
+  firstReadSlot.scrollTop = scrollTop;
+  saveReaderScroll();
+  firstReadSlot.remove();
+  mountReaderInto(nextReadSlot, nextTocSlot, options);
+  return { firstReadSlot, nextReadSlot };
+}
+
+function triggerLatestResize(): void {
+  const callback = resizeObserverCallbacks.at(-1);
+  if (!callback) throw new Error("ResizeObserver callback not registered");
+  callback([], {} as ResizeObserver);
+}

--- a/runtime/fleet-console/tests/codex-panel-state.test.tsx
+++ b/runtime/fleet-console/tests/codex-panel-state.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const panelMocks = vi.hoisted(() => ({
+  closeCodexReader: vi.fn(),
+  mountNavigatorInto: vi.fn(),
+  saveReaderScroll: vi.fn(),
+  setNavigatorTheater: vi.fn(),
+  teardownCodex: vi.fn(),
+}));
+
+vi.mock("../core/client/src/codex-host.js", () => ({
+  mountNavigatorInto: panelMocks.mountNavigatorInto,
+  mountReaderInto: vi.fn(),
+  refreshCodexLocale: vi.fn(),
+  saveReaderScroll: panelMocks.saveReaderScroll,
+  setNavigatorTheater: panelMocks.setNavigatorTheater,
+  setOnRequestOpenReader: vi.fn(),
+  teardownCodex: panelMocks.teardownCodex,
+  teardownReaderNodes: vi.fn(),
+}));
+
+vi.mock("../core/client/src/hooks/use-store.js", () => ({
+  useConsoleState: () => ({
+    activeTheaterId: "theater-a",
+    codexReader: null,
+    codexReaderExpanded: false,
+    theaters: [
+      { id: "theater-a", label: "Theater A" },
+      { id: "theater-b", label: "Theater B" },
+    ],
+  }),
+}));
+
+vi.mock("../core/client/src/i18n/index.js", () => ({
+  getT: () => (key: string) => key,
+  useConsoleLocale: () => "en",
+  useT: () => (key: string) => key,
+}));
+
+vi.mock("../core/client/src/store.js", () => ({
+  closeCodexReader: panelMocks.closeCodexReader,
+  expandCodexReader: vi.fn(),
+  openCodexReader: vi.fn(),
+}));
+
+vi.mock("../core/client/src/codex/state.js", () => ({
+  loadInitialData: vi.fn(),
+}));
+
+import { codexPanel } from "../core/client/src/rail/codex-panel.js";
+
+let container: HTMLDivElement;
+let root: Root;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+    const theaterId = String(input).includes("theater-b") ? "b" : "a";
+    return new Response(JSON.stringify({ hasWiki: true, id: `00000000000${theaterId}` }), {
+      headers: { "Content-Type": "application/json" },
+      status: 200,
+    });
+  }));
+  container = document.createElement("div");
+  document.body.replaceChildren(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  document.body.replaceChildren();
+  vi.unstubAllGlobals();
+});
+
+describe("Codex rail panel in-memory state", () => {
+  it("preserves same-Theater remount state and closes the reader only after a Theater change", async () => {
+    await renderPanel("theater-a");
+    expect(panelMocks.closeCodexReader).not.toHaveBeenCalled();
+    expect(container.querySelector(".codex-rail-host")).not.toBeNull();
+
+    act(() => root.unmount());
+    expect(panelMocks.saveReaderScroll).toHaveBeenCalledOnce();
+    expect(panelMocks.teardownCodex).not.toHaveBeenCalled();
+
+    root = createRoot(container);
+    act(() => {
+      root.render(codexPanel.render({ theaterId: "theater-a" } as never));
+    });
+
+    // 동일 Theater는 비동기 workspace 재해석 전에도 캐시된 navigator를 즉시 복원한다.
+    expect(container.querySelector(".codex-rail-host")).not.toBeNull();
+    await flushEffects();
+    expect(panelMocks.closeCodexReader).not.toHaveBeenCalled();
+
+    act(() => {
+      root.render(codexPanel.render({ theaterId: "theater-b" } as never));
+    });
+    await flushEffects();
+
+    expect(panelMocks.closeCodexReader).toHaveBeenCalledOnce();
+    expect(panelMocks.setNavigatorTheater).toHaveBeenLastCalledWith("00000000000b");
+  });
+});
+
+async function renderPanel(theaterId: string): Promise<void> {
+  await act(async () => {
+    root.render(codexPanel.render({ theaterId } as never));
+    await Promise.resolve();
+  });
+  await flushEffects();
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}


### PR DESCRIPTION
## Summary
- 우측 레일의 codex(wiki) 패널에서 다른 패널로 전환했다가 돌아오면 검색어·엔트리 목록·열린 문서·읽기 위치가 초기화되던 결함 수정 — navigator/reader 싱글톤을 언마운트 후에도 인메모리로 유지하고 재마운트 시 relocate
- Theater가 실제로 바뀔 때만 reader를 닫고 navigator 검색어를 초기화(패널이 닫혀 있는 동안의 전환 포함), 같은 Theater 재마운트는 `setNavigatorTheater` no-op으로 상태 보존
- 읽기 위치는 ResizeObserver quiet-window(400ms, failsafe 5000ms)로 복원해 다단계 마크다운 reflow에도 밀리지 않으며, 사용자가 스크롤하면 즉시 복원 포기

## Test Plan
- [x] `corepack pnpm vitest run tests/codex-host-state.test.ts tests/codex-panel-state.test.tsx` — 2 files, 7 tests
- [x] `corepack pnpm typecheck` / `corepack pnpm build`
- [x] Sentinel 실브라우저 E2E (격리 콘솔): 검색어·문서·스크롤(1400→1400, 1800→1800, 5회 왕복 1184 고정) 보존, Theater 전환 격리 회귀 없음, 오버레이 상호작용, 싱글톤·observer·타이머 누수 0, 콘솔 에러 0
- [x] changelog: `.changelog.d/pr-435.md` — fragment syntax·이중언어 요약·`compile-changelog-fragments --check` 검증 완료