### PR TITLE
feat(fleet-console): repolarize light-theme surfaces content-first

### DIFF
--- a/.changelog.d/pr-436.md
+++ b/.changelog.d/pr-436.md
@@ -1,0 +1,15 @@
+### fleet-console
+
+#### Changed
+- [fleet-console] Light themes now keep the terminal as the brightest surface: the sidebar and command-band cap sit on a new darker chrome tier, and the canvas and page backgrounds settle below the terminal paper so attention lands on the work area. Dark themes are unchanged.
+  ko: 라이트 테마에서 터미널이 화면에서 가장 밝은 표면이 되도록 사이드바·커맨드 밴드 캡을 더 어두운 크롬 계층으로 내리고 캔버스·페이지 배경을 터미널 종이 아래로 재정렬해, 시선이 작업 영역에 앉습니다. 다크 테마는 변화가 없습니다.
+
+#### Fixed
+- [fleet-console] Brass-filled primary buttons keep WCAG AA 4.5:1 text contrast in all three light themes.
+  ko: brass 채움 기본 버튼 텍스트가 라이트 3종 테마 모두에서 WCAG AA 4.5:1 대비를 유지합니다.
+
+### fleet-plugin
+
+#### Changed
+- [fleet-console] Light terminal backgrounds brighten to paper white with a softer blue cast, and bright-white ANSI blocks stay whiter than the page.
+  ko: 라이트 터미널 배경이 청색 기운을 낮춘 종이 흰색으로 밝아지고, bright-white ANSI 블록은 페이지보다 더 희게 유지됩니다.

--- a/runtime/fleet-console/core/client/src/codex/styles/components.css
+++ b/runtime/fleet-console/core/client/src/codex/styles/components.css
@@ -2345,7 +2345,7 @@ kbd {
 }
 .cowork-ghost { background: transparent; color: var(--text-tertiary); }
 .cowork-ghost:hover { background: color-mix(in oklch, var(--ink-pearl) 8%, transparent); color: var(--text-primary); }
-.cowork-solid { background: var(--brass); color: var(--ink-abyss); }
+.cowork-solid { background: var(--brass); color: var(--text-on-brass); }
 .cowork-solid:hover { background: var(--brass-bright); }
 .cowork-solid--danger { background: color-mix(in oklch, var(--coral) 80%, var(--ink-deep)); color: var(--text-primary); }
 .cowork-solid--danger:hover { background: var(--coral); }
@@ -2580,7 +2580,7 @@ kbd {
   border: 0;
   border-radius: var(--radius-sm);
   background: var(--brass);
-  color: var(--ink-abyss);
+  color: var(--text-on-brass);
   cursor: pointer;
   font-size: var(--font-size-sm);
   font-weight: var(--weight-bold);

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -84,7 +84,7 @@
 }
 .fc-btn--primary {
   background: var(--brass);
-  color: var(--ink-abyss);
+  color: var(--text-on-brass);
   font-weight: var(--weight-bold);
 }
 .fc-btn--secondary {
@@ -2681,7 +2681,8 @@
   min-width: 0;
   height: 100%;
   overflow: hidden;
-  background: var(--surface-glass);
+  /* 크롬 열은 --surface-chrome — 라이트에서 종이(카드·터미널)보다 어두워 시선을 작업면에 양보한다. */
+  background: var(--surface-chrome);
   border: 1px solid var(--surface-rim);
   /* 좌측 가장자리·하단 Global Navigation에 밀착 — 바깥(왼쪽)·하단 모서리는 각지게, 안쪽 상단만 둥글게. */
   border-left: none;

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -148,7 +148,8 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
   gap: var(--space-1);
   padding-inline: var(--space-2);
   border-right: 1px solid var(--surface-rim);
-  background: var(--surface-glass);
+  /* 사이드바 상단 캡 — 같은 크롬 표면(--surface-chrome)을 공유해야 한 열로 읽힌다. */
+  background: var(--surface-chrome);
   transition: background 200ms ease, border-color 200ms ease;
 }
 

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -10,6 +10,10 @@
   --text-primary: oklch(94% 0.008 90);
   --text-secondary: oklch(70% 0.012 245);
   --text-tertiary: oklch(64% 0.012 245);
+  /* brass 채움 위 텍스트 전용 티어 — 다크 3종은 abyss 별칭(밝은 brass 위 어두운 글자),
+     라이트 3종은 페이지 배경보다 밝은 자체 리터럴로 AA 4.5:1을 보장한다(abyss에 얹혀 타면
+     페이지 배경 조정이 버튼 대비를 함께 끌어내리는 결합이 재발한다). */
+  --text-on-brass: var(--ink-abyss);
 
   --ink-abyss: oklch(13% 0.014 245);
   --ink-deep: oklch(16.5% 0.016 245);
@@ -99,6 +103,10 @@
   --captain-vanguard: var(--id-moss);
 
   --surface-glass: var(--ink-deep);
+  /* 크롬 열(사이드바·밴드 좌측 캡) 전용 표면 티어 — 다크 3종은 glass 별칭을 var 간접으로 상속하고,
+     라이트 3종만 종이 표면(카드·터미널)보다 어두운 자체 리터럴로 분화한다(신호 ink 티어와 동형 구조).
+     라이트에서 크롬이 종이보다 밝아지면 시선이 크롬으로 끌리는 극성 역전이 재발한다. */
+  --surface-chrome: var(--surface-glass);
   --surface-glass-strong: var(--ink-mid);
   --surface-pillar: var(--ink-veil);
   --surface-rim: var(--hairline);
@@ -296,7 +304,7 @@
 :root[data-theme="daywatch"] {
   color-scheme: light;
 
-  --ink-abyss: oklch(96% 0.008 245);
+  --ink-abyss: oklch(95.5% 0.007 245);
   --ink-deep: oklch(94% 0.01 245);
   --ink-mid: oklch(91.5% 0.012 245);
   --ink-veil: oklch(89% 0.014 245);
@@ -311,6 +319,7 @@
   --text-primary: var(--ink-pearl);
   --text-secondary: var(--ink-spectral);
   --text-tertiary: var(--ink-fog);
+  --text-on-brass: oklch(99% 0.003 245);
 
   --brass: oklch(54% 0.11 72);
   --brass-bright: oklch(47% 0.125 74);
@@ -336,7 +345,7 @@
   --brass-halo: none;
   --positive-halo: none;
 
-  --canvas-abyss: oklch(97.5% 0.006 245);
+  --canvas-abyss: oklch(96.8% 0.005 245);
   --canvas-sea-core: oklch(93% 0.012 240);
   --canvas-sea-near: oklch(94.5% 0.01 242);
   --canvas-sea-mid: oklch(96% 0.008 245);
@@ -359,6 +368,7 @@
   --id-rose: oklch(55% 0.08 350);
 
   --surface-glass: oklch(97% 0.008 245 / 72%);
+  --surface-chrome: oklch(94.5% 0.009 245);
   --surface-glass-strong: oklch(95.5% 0.01 245 / 82%);
   --surface-pillar: oklch(98% 0.006 245 / 90%);
   --surface-rim: oklch(40% 0.02 245 / 18%);
@@ -381,7 +391,7 @@
 :root[data-theme="whites"] {
   color-scheme: light;
 
-  --ink-abyss: oklch(97.3% 0.004 250);
+  --ink-abyss: oklch(97% 0.003 250);
   --ink-deep: oklch(95.5% 0.005 250);
   --ink-mid: oklch(93% 0.007 252);
   --ink-veil: oklch(90.5% 0.009 252);
@@ -396,6 +406,7 @@
   --text-primary: var(--ink-pearl);
   --text-secondary: var(--ink-spectral);
   --text-tertiary: var(--ink-fog);
+  --text-on-brass: oklch(99.8% 0.001 250);
 
   --brass: oklch(56% 0.125 82);
   --brass-bright: oklch(49% 0.14 80);
@@ -421,7 +432,7 @@
   --brass-halo: none;
   --positive-halo: none;
 
-  --canvas-abyss: oklch(98% 0.003 250);
+  --canvas-abyss: oklch(97.8% 0.003 250);
   --canvas-sea-core: oklch(94% 0.006 250);
   --canvas-sea-near: oklch(95.3% 0.005 250);
   --canvas-sea-mid: oklch(96.5% 0.004 250);
@@ -444,6 +455,7 @@
   --id-rose: oklch(53% 0.09 350);
 
   --surface-glass: oklch(98% 0.004 250 / 70%);
+  --surface-chrome: oklch(96% 0.004 250);
   --surface-glass-strong: oklch(96.5% 0.005 250 / 82%);
   --surface-pillar: oklch(98.5% 0.003 250 / 90%);
   --surface-rim: oklch(38% 0.03 256 / 18%);
@@ -465,7 +477,7 @@
 :root[data-theme="drydock"] {
   color-scheme: light;
 
-  --ink-abyss: oklch(95% 0.015 235);
+  --ink-abyss: oklch(94.5% 0.013 235);
   --ink-deep: oklch(93% 0.018 236);
   --ink-mid: oklch(90.5% 0.019 236);
   --ink-veil: oklch(88% 0.022 238);
@@ -480,6 +492,7 @@
   --text-primary: var(--ink-pearl);
   --text-secondary: var(--ink-spectral);
   --text-tertiary: var(--ink-fog);
+  --text-on-brass: oklch(98.8% 0.005 235);
 
   --brass: oklch(54% 0.1 70);
   --brass-bright: oklch(47% 0.115 68);
@@ -505,7 +518,7 @@
   --brass-halo: none;
   --positive-halo: none;
 
-  --canvas-abyss: oklch(96.3% 0.012 235);
+  --canvas-abyss: oklch(95.8% 0.011 235);
   --canvas-sea-core: oklch(92.5% 0.02 238);
   --canvas-sea-near: oklch(93.8% 0.018 237);
   --canvas-sea-mid: oklch(95% 0.015 236);
@@ -528,6 +541,7 @@
   --id-rose: oklch(54% 0.08 350);
 
   --surface-glass: oklch(96.5% 0.013 235 / 74%);
+  --surface-chrome: oklch(93.5% 0.015 235);
   --surface-glass-strong: oklch(95% 0.016 236 / 84%);
   --surface-pillar: oklch(97% 0.011 235 / 90%);
   --surface-rim: oklch(40% 0.04 245 / 18%);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -399,6 +399,8 @@ describe("Instrument core design contract", () => {
     expect(css).not.toMatch(/backdrop-filter|--op-accent|--chip-accent/);
     expect(css).toContain("background: var(--surface-glass)");
     expect(css).toContain(":focus-visible");
+    // brass 채움 버튼은 전용 on-brass 텍스트 티어를 소비한다 — abyss 재결합은 라이트 AA 회귀다.
+    expect(css).toMatch(/\.fc-btn--primary \{[^}]*color: var\(--text-on-brass\);/);
   });
 
   // 텍스트 3티어만 대비를 통제하므로 원료 잉크를 color에 직접 쓰면 판독 하한을 한곳에서 보장할 수 없다.
@@ -822,7 +824,10 @@ describe("Instrument core design contract", () => {
     // 있어야 한 열 한가운데의 이중 hairline과 우측 경계선 단절이 재발하지 않는다.
     const commandBandLeftBlock = layout.match(/\.command-band-left \{[^}]*\}/)?.[0] ?? "";
     expect(commandBandLeftBlock).toContain("border-right: 1px solid var(--surface-rim);");
-    expect(commandBandLeftBlock).toContain("background: var(--surface-glass);");
+    expect(commandBandLeftBlock).toContain("background: var(--surface-chrome);");
+    // 사이드바도 같은 크롬 표면을 소비해야 캡과 한 열로 읽힌다 — glass 회귀를 여기서 잡는다.
+    const sideBarBlock = components.match(/^\.operations-side-bar \{[^}]*\}/m)?.[0] ?? "";
+    expect(sideBarBlock).toContain("background: var(--surface-chrome);");
     // 캡이 실재하는 상태로 한정한다 — 풀스크린은 밴드가 fixed로 흐름에서 빠져 자동 은닉되므로
     // 캡이 없고, 사이드바가 뷰포트 최상단에 닿는다. 무조건 해제하면 그 화면에서 마감이 사라진다.
     const expandedSideBarBlock =
@@ -956,9 +961,9 @@ describe("Instrument core design contract", () => {
     expect(theme).toContain("--brass: oklch(78% 0.13 75);");
     expect(theme).toContain("--ink-muted: oklch(75% 0.02 248);");
     expect(theme).toContain("--ink-muted: oklch(72% 0.005 250);");
-    expect(theme).toContain("--ink-abyss: oklch(96% 0.008 245);");
-    expect(theme).toContain("--ink-abyss: oklch(97.3% 0.004 250);");
-    expect(theme).toContain("--ink-abyss: oklch(95% 0.015 235);");
+    expect(theme).toContain("--ink-abyss: oklch(95.5% 0.007 245);");
+    expect(theme).toContain("--ink-abyss: oklch(97% 0.003 250);");
+    expect(theme).toContain("--ink-abyss: oklch(94.5% 0.013 235);");
     expect(theme.match(/^:root \{/gm)).toHaveLength(1);
     // Legacy dark 테마는 팔레트 토큰만 — 광학·color-scheme과 형상·타이포 오버라이드는 진입 불가.
     const darkVariantBlocks = theme.match(/^:root\[data-theme="(?:maritime|carbon)"\][^{]*\{[^}]*\}/gm) ?? [];
@@ -987,6 +992,25 @@ describe("Instrument core design contract", () => {
       expect(base).toContain(`${ink}: var(`);
       expect(theme.match(new RegExp(`${ink}:`, "g"))).toHaveLength(4);
     }
+    // 크롬 표면 티어도 같은 별칭 구조다 — base가 glass 별칭을 제공해 다크 3종이 var 간접으로 상속하고,
+    // 라이트 3종만 종이 표면보다 어두운 자체 리터럴로 분화한다(작업면 최명면 극성).
+    expect(base).toContain("--surface-chrome: var(--surface-glass);");
+    expect(theme.match(/--surface-chrome:/g)).toHaveLength(4);
+    expect(theme).toContain("--surface-chrome: oklch(94.5% 0.009 245);");
+    expect(theme).toContain("--surface-chrome: oklch(96% 0.004 250);");
+    expect(theme).toContain("--surface-chrome: oklch(93.5% 0.015 235);");
+    // 라이트 캔버스는 종이(터미널 98.5/99.2/97.8%)보다 어둡고 크롬보다 밝은 중간층이다 —
+    // 이 순서가 무너지면 작업면 최명면 극성이 다시 뒤집힌다.
+    expect(theme).toContain("--canvas-abyss: oklch(96.8% 0.005 245);");
+    expect(theme).toContain("--canvas-abyss: oklch(97.8% 0.003 250);");
+    expect(theme).toContain("--canvas-abyss: oklch(95.8% 0.011 235);");
+    // brass 채움 위 텍스트 티어 — 다크는 abyss 별칭, 라이트는 페이지 배경과 독립된 자체 리터럴로
+    // AA 4.5:1을 보장한다(abyss 결합 시 페이지 배경 조정이 버튼 대비를 함께 끌어내린다).
+    expect(base).toContain("--text-on-brass: var(--ink-abyss);");
+    expect(theme.match(/--text-on-brass:/g)).toHaveLength(4);
+    expect(theme).toContain("--text-on-brass: oklch(99% 0.003 245);");
+    expect(theme).toContain("--text-on-brass: oklch(99.8% 0.001 250);");
+    expect(theme).toContain("--text-on-brass: oklch(98.8% 0.005 235);");
     expect(theme).not.toMatch(/#fff(?:fff)?\b/i);
     expect(theme).not.toMatch(/body::(?:before|after)/);
   });

--- a/runtime/fleet-plugins/scuttlebutt/client/styles.css
+++ b/runtime/fleet-plugins/scuttlebutt/client/styles.css
@@ -688,7 +688,7 @@
   border: 0;
   border-radius: var(--radius-sm);
   background: var(--brass);
-  color: var(--ink-abyss);
+  color: var(--text-on-brass);
   cursor: pointer;
   font: inherit;
   font-size: 12.5px;

--- a/runtime/fleet-plugins/scuttlebutt/tests/client-design-tokens.test.ts
+++ b/runtime/fleet-plugins/scuttlebutt/tests/client-design-tokens.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const styles = readFileSync(new URL("../client/styles.css", import.meta.url), "utf8");
+
+describe("Scuttlebutt design tokens", () => {
+  // brass 채움 버튼은 전용 on-brass 텍스트 티어를 소비한다 — abyss 재결합은 라이트 테마에서
+  // 페이지 배경 조정이 버튼 대비를 함께 끌어내리는 AA 회귀다(instrument-design-contract 동형 계약).
+  it("keeps the send button text on the on-brass tier", () => {
+    const block = styles.match(/\.scuttlebutt-send \{[^}]*\}/)?.[0] ?? "";
+    expect(block).toContain("background: var(--brass);");
+    expect(block).toContain("color: var(--text-on-brass);");
+  });
+});

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -119,8 +119,11 @@ const CARBON_TERMINAL_THEME: ITheme = {
 };
 
 // 라이트 터미널의 bright 계열은 밝히지 않고 더 진하게(L −5%p, C +0.02) 간다 — 밝은 배경에서 '밝은' ANSI는 판독 불능이기 때문.
+// 단 brightWhite는 예외로 배경보다 밝게 유지한다(SGR 107 블록이 종이보다 희어야 극성이 산다).
+// 라이트 배경은 화면 최명면이어야 한다: 각 테마의 --canvas-abyss(L 96.8/97.8/95.8%)보다 밝게 고정 —
+// 작업면이 크롬보다 어두워지면 시선이 크롬으로 끌리는 극성 역전이 재발한다(다크는 반대 방향으로 동일 원칙).
 const DAYWATCH_TERMINAL_THEME: ITheme = {
-  background: "oklch(93% 0.01 245)",
+  background: "oklch(98.5% 0.004 245)",
   foreground: "oklch(25% 0.02 248)",
   cursor: "oklch(51% 0.09 205)",
   selectionBackground: "oklch(54% 0.11 72 / 22%)",
@@ -139,12 +142,12 @@ const DAYWATCH_TERMINAL_THEME: ITheme = {
   brightBlue: "oklch(45% 0.1 245)",
   brightMagenta: "oklch(47% 0.12 318)",
   brightCyan: "oklch(46% 0.1 205)",
-  brightWhite: "oklch(96% 0.008 245)",
+  brightWhite: "oklch(99.5% 0.002 245)",
 };
 
 
 const WHITES_TERMINAL_THEME: ITheme = {
-  background: "oklch(95.5% 0.004 250)",
+  background: "oklch(99.2% 0.002 250)",
   foreground: "oklch(22% 0.045 260)",
   cursor: "oklch(50% 0.1 210)",
   selectionBackground: "oklch(56% 0.125 82 / 20%)",
@@ -163,7 +166,7 @@ const WHITES_TERMINAL_THEME: ITheme = {
   brightBlue: "oklch(45% 0.11 250)",
   brightMagenta: "oklch(46% 0.12 318)",
   brightCyan: "oklch(45% 0.11 210)",
-  brightWhite: "oklch(97% 0.003 250)",
+  brightWhite: "oklch(99.8% 0.001 250)",
 };
 
 /* 라이트 터미널은 agent CLI가 직접 찍는 다크용 truecolor(회색 #999/#ccc, 연한 액센트)가 팔레트
@@ -189,7 +192,7 @@ function terminalPolarityFor(theme: TerminalThemeId): "light" | "dark" {
 const sessionPolarityBaseline = new Map<string, "light" | "dark">();
 
 const DRYDOCK_TERMINAL_THEME: ITheme = {
-  background: "oklch(92.5% 0.02 238)",
+  background: "oklch(97.8% 0.008 238)",
   foreground: "oklch(25% 0.045 250)",
   cursor: "oklch(50% 0.09 190)",
   selectionBackground: "oklch(54% 0.1 70 / 22%)",
@@ -208,7 +211,7 @@ const DRYDOCK_TERMINAL_THEME: ITheme = {
   brightBlue: "oklch(46% 0.1 250)",
   brightMagenta: "oklch(47% 0.11 318)",
   brightCyan: "oklch(45% 0.1 190)",
-  brightWhite: "oklch(95% 0.012 236)",
+  brightWhite: "oklch(99% 0.004 236)",
 };
 
 export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "instrument", onExit, active, keyboardFocusRequestId, zoom = 1 }: TerminalSurfaceProps) {


### PR DESCRIPTION
## Summary
- 라이트 3종(Daywatch·Whites·Drydock)에서 터미널이 화면 최암면이던 주의 극성 역전을 해소합니다: 터미널 xterm 배경을 화면 최명면(98.5/99.2/97.8%)으로 올리고, 신규 `--surface-chrome` 티어(다크 3종=`--surface-glass` 별칭, 라이트 3종만 자체 리터럴)로 사이드바·커맨드 밴드 좌측 캡을 캔버스보다 어둡게 침하시켜 시선이 작업면에 앉게 합니다. 라이트 `--canvas-abyss`/`--ink-abyss`도 종이 아래로 재정렬하고 대면적 chroma를 낮춰 청색 틴트를 완화합니다.
- brass 채움 버튼 텍스트가 `--ink-abyss`에 결합되어 있던 선존 AA 미달을 신규 `--text-on-brass` 티어로 해소합니다(라이트 3종 실산출 5.030/4.682/4.998:1, 소비처 `fc-btn--primary`·`scuttlebutt-send`). 다크 3종은 전 티어가 별칭 상속이라 렌더 무변입니다.
- instrument 디자인 계약에 신설 문법(pin 리터럴·별칭 구조·소비처 assertion)을 동반 갱신하고 scuttlebutt design-token 테스트를 추가했습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` exit 0
- [x] `vitest run tests/instrument-design-contract.test.ts` 27/27
- [x] terminal 플러그인 자체 러너 447/447, scuttlebutt 95/95(신규 테스트 포함)
- [x] 테마 인접 콘솔 테스트 6파일 98/98
- [x] 격리 콘솔 실브라우저 실측: 4테마 `--surface-chrome`/`--text-on-brass` 해석값 전수 일치, 라이트 3종 xterm 뷰포트 배경 의도 리터럴 일치, instrument 다크 무변(16.5%/13%)
- [x] Sentinel 리뷰 2회(PASS): AA 실산출 4.5:1 이상 확인, 계약 pin 회귀 시나리오 포착 확인
- [x] Changelog: `.changelog.d/pr-436.md` 추가, 이중언어 요약·그룹형 문법, `node scripts/compile-changelog-fragments.mjs --check` 통과(3 entries)

repository 플러그인 design-grammar 테스트 2건 실패는 canary 선존 실패로 본 PR과 무관합니다(clean canary에서 동일 재현).