### PR TITLE
fix(fleet-console): tune light terminal tone and window frame tier

### DIFF
--- a/.changelog.d/pr-436.md
+++ b/.changelog.d/pr-436.md
@@ -11,5 +11,5 @@
 ### fleet-plugin
 
 #### Changed
-- [fleet-console] Light terminal backgrounds brighten to paper white with a softer blue cast, and bright-white ANSI blocks stay whiter than the page.
-  ko: 라이트 터미널 배경이 청색 기운을 낮춘 종이 흰색으로 밝아지고, bright-white ANSI 블록은 페이지보다 더 희게 유지됩니다.
+- [fleet-console] Light terminal backgrounds brighten into the brightest surface on screen while keeping each theme's tinted atmosphere, and bright-white ANSI blocks stay whiter than the page.
+  ko: 라이트 터미널 배경이 각 테마의 색조 대기를 유지한 채 화면에서 가장 밝은 표면이 되고, bright-white ANSI 블록은 페이지보다 더 희게 유지됩니다.

--- a/.changelog.d/pr-437.md
+++ b/.changelog.d/pr-437.md
@@ -1,0 +1,5 @@
+### fleet-console
+
+#### Changed
+- [fleet-console] Operation window frames and titlebars in light themes now share the command band's chrome tone instead of holding the darkest tone on screen. Dark themes are unchanged.
+  ko: 라이트 테마의 Operation 창 프레임과 타이틀바가 화면에서 가장 어두운 색 대신 커맨드 밴드와 같은 크롬 톤을 공유합니다. 다크 테마는 변화가 없습니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2357,7 +2357,8 @@
   overflow: visible;
   border: 1px solid var(--surface-rim);
   border-radius: var(--radius-lg);
-  background: var(--ink-mid);
+  /* 창 프레임은 --surface-frame — 라이트에서 최암면이 되지 않도록 밴드와 같은 크롬 패밀리를 탄다. */
+  background: var(--surface-frame);
   box-shadow: var(--shadow-soft);
   /* 공통 geometry 모션 레이어 — formation/최대화/companion/복원의 재배치가 같은 물리로 움직인다.
      visibility는 0s 즉시(복원·focus layer 즉시 표시), 최소화 시에만 is-minimized가 지연을 소유한다.
@@ -2649,7 +2650,7 @@
 }
 
 .canvas-operation[style*="--user-accent"] .canvas-operation-titlebar {
-  background: color-mix(in oklch, var(--user-accent) 10%, var(--ink-mid));
+  background: color-mix(in oklch, var(--user-accent) 10%, var(--surface-frame));
 }
 
 /* 진행 중 캐리어 스트림을 패널 바깥 아래에 floating으로 띄우는 dock. left/top/width는 패널 geometry를
@@ -3770,7 +3771,7 @@
   border: 1px solid var(--ink-rim);
   border-radius: var(--radius-sm);
   overflow: visible;
-  background: var(--ink-mid);
+  background: var(--surface-frame);
   box-shadow: var(--shadow-soft);
   cursor: grab;
   touch-action: none;
@@ -3785,7 +3786,7 @@
 
 .canvas-operation.is-active .canvas-operation-titlebar {
   border-color: color-mix(in oklch, var(--brass) 62%, var(--ink-rim));
-  background: color-mix(in oklch, var(--brass) 7%, var(--ink-mid));
+  background: color-mix(in oklch, var(--brass) 7%, var(--surface-frame));
 }
 
 .canvas-operation-identity-name,

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -107,6 +107,10 @@
      라이트 3종만 종이 표면(카드·터미널)보다 어두운 자체 리터럴로 분화한다(신호 ink 티어와 동형 구조).
      라이트에서 크롬이 종이보다 밝아지면 시선이 크롬으로 끌리는 극성 역전이 재발한다. */
   --surface-chrome: var(--surface-glass);
+  /* Operation 창 프레임(본체·타이틀바) 전용 티어 — 다크 3종은 ink-mid 별칭으로 기존 렌더를 유지하고,
+     라이트 3종은 ink-deep 별칭으로 GNB(밴드)와 같은 크롬 패밀리에 정렬한다. ink-mid 리터럴을 직접
+     밝히면 호버·칩 등 45개 소비처가 함께 움직여 어포던스가 희석되므로 프레임만 분리한다. */
+  --surface-frame: var(--ink-mid);
   --surface-glass-strong: var(--ink-mid);
   --surface-pillar: var(--ink-veil);
   --surface-rim: var(--hairline);
@@ -369,6 +373,7 @@
 
   --surface-glass: oklch(97% 0.008 245 / 72%);
   --surface-chrome: oklch(94.5% 0.009 245);
+  --surface-frame: var(--ink-deep);
   --surface-glass-strong: oklch(95.5% 0.01 245 / 82%);
   --surface-pillar: oklch(98% 0.006 245 / 90%);
   --surface-rim: oklch(40% 0.02 245 / 18%);
@@ -456,6 +461,7 @@
 
   --surface-glass: oklch(98% 0.004 250 / 70%);
   --surface-chrome: oklch(96% 0.004 250);
+  --surface-frame: var(--ink-deep);
   --surface-glass-strong: oklch(96.5% 0.005 250 / 82%);
   --surface-pillar: oklch(98.5% 0.003 250 / 90%);
   --surface-rim: oklch(38% 0.03 256 / 18%);
@@ -542,6 +548,7 @@
 
   --surface-glass: oklch(96.5% 0.013 235 / 74%);
   --surface-chrome: oklch(93.5% 0.015 235);
+  --surface-frame: var(--ink-deep);
   --surface-glass-strong: oklch(95% 0.016 236 / 84%);
   --surface-pillar: oklch(97% 0.011 235 / 90%);
   --surface-rim: oklch(40% 0.04 245 / 18%);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -492,7 +492,7 @@ describe("Instrument core design contract", () => {
     expect(markBlock).toContain("width: 8px;");
     expect(markBlock).toContain("height: 14px;");
     expect(markBlock).toContain("background: var(--user-accent);");
-    expect(washBlock).toContain("color-mix(in oklch, var(--user-accent) 10%, var(--ink-mid))");
+    expect(washBlock).toContain("color-mix(in oklch, var(--user-accent) 10%, var(--surface-frame))");
     expect(chipAccentBlock).toContain("width: 3px;");
     expect(chipAccentBlock).toContain("top: 7px;");
     expect(chipAccentBlock).toContain("bottom: 7px;");
@@ -828,6 +828,11 @@ describe("Instrument core design contract", () => {
     // 사이드바도 같은 크롬 표면을 소비해야 캡과 한 열로 읽힌다 — glass 회귀를 여기서 잡는다.
     const sideBarBlock = components.match(/^\.operations-side-bar \{[^}]*\}/m)?.[0] ?? "";
     expect(sideBarBlock).toContain("background: var(--surface-chrome);");
+    // Operation 창 본체·타이틀바는 --surface-frame을 소비한다 — ink-mid 재결합은 라이트 최암면 회귀다.
+    const operationBlock = components.match(/^\.canvas-operation \{[^}]*\}/m)?.[0] ?? "";
+    expect(operationBlock).toContain("background: var(--surface-frame);");
+    const titlebarBlock = components.match(/^\.canvas-operation-titlebar \{[^}]*\}/m)?.[0] ?? "";
+    expect(titlebarBlock).toContain("background: var(--surface-frame);");
     // 캡이 실재하는 상태로 한정한다 — 풀스크린은 밴드가 fixed로 흐름에서 빠져 자동 은닉되므로
     // 캡이 없고, 사이드바가 뷰포트 최상단에 닿는다. 무조건 해제하면 그 화면에서 마감이 사라진다.
     const expandedSideBarBlock =
@@ -999,7 +1004,7 @@ describe("Instrument core design contract", () => {
     expect(theme).toContain("--surface-chrome: oklch(94.5% 0.009 245);");
     expect(theme).toContain("--surface-chrome: oklch(96% 0.004 250);");
     expect(theme).toContain("--surface-chrome: oklch(93.5% 0.015 235);");
-    // 라이트 캔버스는 종이(터미널 98.5/99.2/97.8%)보다 어둡고 크롬보다 밝은 중간층이다 —
+    // 라이트 캔버스는 종이(터미널 97.2/98.2/96.2%)보다 어둡고 크롬보다 밝은 중간층이다 —
     // 이 순서가 무너지면 작업면 최명면 극성이 다시 뒤집힌다.
     expect(theme).toContain("--canvas-abyss: oklch(96.8% 0.005 245);");
     expect(theme).toContain("--canvas-abyss: oklch(97.8% 0.003 250);");
@@ -1011,6 +1016,11 @@ describe("Instrument core design contract", () => {
     expect(theme).toContain("--text-on-brass: oklch(99% 0.003 245);");
     expect(theme).toContain("--text-on-brass: oklch(99.8% 0.001 250);");
     expect(theme).toContain("--text-on-brass: oklch(98.8% 0.005 235);");
+    // Operation 창 프레임 티어 — 다크는 ink-mid 별칭(기존 렌더 유지), 라이트는 ink-deep 별칭으로
+    // GNB(밴드)와 같은 크롬 패밀리에 정렬해 프레임이 라이트 최암면이 되는 것을 막는다.
+    expect(base).toContain("--surface-frame: var(--ink-mid);");
+    expect(theme.match(/--surface-frame:/g)).toHaveLength(4);
+    expect(theme.match(/--surface-frame: var\(--ink-deep\);/g)).toHaveLength(3);
     expect(theme).not.toMatch(/#fff(?:fff)?\b/i);
     expect(theme).not.toMatch(/body::(?:before|after)/);
   });
@@ -1141,7 +1151,8 @@ describe("Instrument core design contract", () => {
     expect(identityInputBlock).not.toContain("width: 0;");
     expect(components).toContain("top: calc(-1 * var(--space-3));");
     expect(components).toContain("border-radius: 999px;");
-    expect(components).toContain("background: var(--ink-mid);");
+    // 활성 타이틀바는 brass 7% 틴트를 frame 위에 얹는다 — ink-mid 재결합 회귀를 여기서 잡는다.
+    expect(components).toContain("color-mix(in oklch, var(--brass) 7%, var(--surface-frame))");
     expect(components).toContain("color: var(--text-secondary);");
     expect(components).toContain(".canvas-operation.is-active .canvas-operation-titlebar {");
     expect(components).toContain("color-mix(in oklch, var(--brass) 62%, var(--ink-rim))");

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -122,8 +122,10 @@ const CARBON_TERMINAL_THEME: ITheme = {
 // 단 brightWhite는 예외로 배경보다 밝게 유지한다(SGR 107 블록이 종이보다 희어야 극성이 산다).
 // 라이트 배경은 화면 최명면이어야 한다: 각 테마의 --canvas-abyss(L 96.8/97.8/95.8%)보다 밝게 고정 —
 // 작업면이 크롬보다 어두워지면 시선이 크롬으로 끌리는 극성 역전이 재발한다(다크는 반대 방향으로 동일 원칙).
+// 동시에 chroma는 테마 대기(캔버스~밴드 패밀리)를 따른다 — 최명면 + 최저채도가 겹치면
+// 터미널이 테마 밖 백지로 읽힌다(실사용 피드백으로 확인된 과중화 회귀).
 const DAYWATCH_TERMINAL_THEME: ITheme = {
-  background: "oklch(98.5% 0.004 245)",
+  background: "oklch(97.2% 0.009 245)",
   foreground: "oklch(25% 0.02 248)",
   cursor: "oklch(51% 0.09 205)",
   selectionBackground: "oklch(54% 0.11 72 / 22%)",
@@ -147,7 +149,7 @@ const DAYWATCH_TERMINAL_THEME: ITheme = {
 
 
 const WHITES_TERMINAL_THEME: ITheme = {
-  background: "oklch(99.2% 0.002 250)",
+  background: "oklch(98.2% 0.004 250)",
   foreground: "oklch(22% 0.045 260)",
   cursor: "oklch(50% 0.1 210)",
   selectionBackground: "oklch(56% 0.125 82 / 20%)",
@@ -192,7 +194,7 @@ function terminalPolarityFor(theme: TerminalThemeId): "light" | "dark" {
 const sessionPolarityBaseline = new Map<string, "light" | "dark">();
 
 const DRYDOCK_TERMINAL_THEME: ITheme = {
-  background: "oklch(97.8% 0.008 238)",
+  background: "oklch(96.2% 0.015 236)",
   foreground: "oklch(25% 0.045 250)",
   cursor: "oklch(50% 0.09 190)",
   selectionBackground: "oklch(54% 0.1 70 / 22%)",


### PR DESCRIPTION
## Summary
- PR#436 실사용 피드백("터미널이 너무 재극성 — 테마와 동떨어진 컬러감") 교정입니다. 라이트 3종 터미널 배경의 chroma를 캔버스~밴드 대기 패밀리로 복원하고 캔버스 대비 L 갭을 +0.4%p로 좁혀(daywatch 97.2% 0.009 245 / whites 98.2% 0.004 250 / drydock 96.2% 0.015 236), 극성(터미널=최명면)은 유지한 채 백지 인상을 제거합니다.
- Operation 창 본체·타이틀바 전용 `--surface-frame` 티어를 신설합니다(별칭 관례 4례째): 다크 3종=`var(--ink-mid)` 별칭으로 렌더 무변, 라이트 3종=`var(--ink-deep)` 별칭으로 프레임이 GNB와 같은 크롬 패밀리에 정렬되어 화면 최암면 지위를 반납합니다. active brass 7%·identity 10% 워시도 같은 티어를 탑니다. `--ink-mid` 리터럴 직접 상향은 소비처 45곳(호버 35곳) 파급으로 기각된 결정입니다.
- 디자인 계약 동반 갱신: frame 별칭 pin(base ink-mid + 라이트 ink-deep×3 + 개수 4)·소비처 assertion(창 본체·타이틀바)·active 틴트 pin·스테일 titlebar pin 교체.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console build` exit 0
- [x] `vitest run tests/instrument-design-contract.test.ts` 27/27
- [x] terminal 플러그인 자체 러너 447/447, 테마 인접 콘솔 테스트 98/98
- [x] 격리 콘솔 실측: 3테마 xterm 배경·`--surface-frame` 해석값 전수 일치, 터미널>캔버스 극성 +0.4%p 유지, instrument 다크 frame=ink-mid 20% 무변
- [x] Sentinel 리뷰 2회(PASS): 라이트 타이틀바 대비 6.78:1+(accent 워시 최저 포함), brightWhite>배경 +1.6~2.8%p, ink-mid 소비처 전수 재확인(누락/오전환 0)
- [x] Changelog: `.changelog.d/pr-437.md` 추가(프레임 변경) + 미릴리스 `.changelog.d/pr-436.md`에 터미널 톤 교정 접어 넣기(릴리스 기준선 독트린), `node scripts/compile-changelog-fragments.mjs --check` 통과(4 entries)