### PR TITLE
feat(fleet-console): modernize rail float toggle and opacity slider

### DIFF
--- a/.changelog.d/pr-440.md
+++ b/.changelog.d/pr-440.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Changed
+- [fleet-console] Replace the rail panel header's "Float over Map" text toggle with a picture-in-picture icon button and swap the Solid/90/75/60 opacity presets for a continuous inline slider (40-100) with a live percentage readout; the header now stays on a single row even at the minimum panel width.
+  ko: rail 패널 헤더의 "Float over Map" 텍스트 토글을 picture-in-picture 아이콘 버튼으로 교체하고, Solid/90/75/60 불투명도 프리셋을 실시간 % 병기 연속 인라인 슬라이더(40-100)로 대체합니다. 헤더는 최소 패널 폭에서도 한 줄을 유지합니다.

--- a/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
@@ -160,7 +160,6 @@ export const canvasEn = {
   "rail.chrome.floatToggle": "Float panel over the Map",
   "rail.chrome.floatLabel": "Float over Map",
   "rail.chrome.opacityAria": "Panel opacity",
-  "rail.chrome.opacitySolid": "Solid",
   "rail.chrome.closePanel": "Close {title}",
   "rail.theater.fallback": "Theater",
 
@@ -386,7 +385,6 @@ export const canvasKo: Record<keyof typeof canvasEn, string> = {
   "rail.chrome.floatToggle": "패널을 Map 위에 띄우기",
   "rail.chrome.floatLabel": "Map 위에 띄우기",
   "rail.chrome.opacityAria": "패널 불투명도",
-  "rail.chrome.opacitySolid": "불투명",
   "rail.chrome.closePanel": "{title} 닫기",
   "rail.theater.fallback": "Theater",
 

--- a/runtime/fleet-console/core/client/src/rail/rail-store.ts
+++ b/runtime/fleet-console/core/client/src/rail/rail-store.ts
@@ -8,7 +8,11 @@ interface RailStore {
   readonly overlayAlpha: RailOverlayAlpha;
 }
 
-export type RailOverlayAlpha = 100 | 90 | 75 | 60;
+export type RailOverlayAlpha = number;
+
+export const RAIL_OVERLAY_ALPHA_MIN = 40;
+export const RAIL_OVERLAY_ALPHA_MAX = 100;
+export const RAIL_OVERLAY_ALPHA_DEFAULT = 100;
 
 type Listener = () => void;
 const PREFS_ACTIVE_PANEL = "fleet-console.rail.activePanelId";
@@ -77,10 +81,11 @@ export function toggleRailPanelBehavior(): void {
   setRailPanelBehavior(store.panelBehavior === "push" ? "overlay" : "push");
 }
 
-export function setRailOverlayAlpha(alpha: RailOverlayAlpha): void {
-  if (store.overlayAlpha === alpha) return;
-  setStore({ ...store, overlayAlpha: alpha });
-  saveStoredOverlayAlpha(alpha);
+export function setRailOverlayAlpha(alpha: number): void {
+  const clamped = clampRailOverlayAlpha(alpha);
+  if (store.overlayAlpha === clamped) return;
+  setStore({ ...store, overlayAlpha: clamped });
+  saveStoredOverlayAlpha(clamped);
 }
 
 export function requestRailPanelExtraWidth(panelId: string, px: number | null): void {
@@ -140,9 +145,13 @@ function readStoredPanelBehavior(): "push" | "overlay" {
 function readStoredOverlayAlpha(): RailOverlayAlpha {
   try {
     const stored = localStorage.getItem(PREFS_OVERLAY_ALPHA);
-    if (stored === "90" || stored === "75" || stored === "60") return Number(stored) as RailOverlayAlpha;
-    return 100;
-  } catch { return 100; }
+    const parsed = Number(stored);
+    return stored !== null && Number.isFinite(parsed) ? clampRailOverlayAlpha(parsed) : RAIL_OVERLAY_ALPHA_DEFAULT;
+  } catch { return RAIL_OVERLAY_ALPHA_DEFAULT; }
+}
+
+function clampRailOverlayAlpha(alpha: number): RailOverlayAlpha {
+  return Math.min(RAIL_OVERLAY_ALPHA_MAX, Math.max(RAIL_OVERLAY_ALPHA_MIN, Math.round(alpha)));
 }
 
 function saveStoredPanelId(id: string | null): void {

--- a/runtime/fleet-console/core/client/src/rail/rail-store.ts
+++ b/runtime/fleet-console/core/client/src/rail/rail-store.ts
@@ -145,8 +145,9 @@ function readStoredPanelBehavior(): "push" | "overlay" {
 function readStoredOverlayAlpha(): RailOverlayAlpha {
   try {
     const stored = localStorage.getItem(PREFS_OVERLAY_ALPHA);
+    if (stored === null || stored.trim() === "") return RAIL_OVERLAY_ALPHA_DEFAULT;
     const parsed = Number(stored);
-    return stored !== null && Number.isFinite(parsed) ? clampRailOverlayAlpha(parsed) : RAIL_OVERLAY_ALPHA_DEFAULT;
+    return Number.isFinite(parsed) ? clampRailOverlayAlpha(parsed) : RAIL_OVERLAY_ALPHA_DEFAULT;
   } catch { return RAIL_OVERLAY_ALPHA_DEFAULT; }
 }
 

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -9,14 +9,12 @@ import "../styles/rail.css";
 import { BUILT_IN_RAIL_PANELS } from "./built-in-panels.js";
 import { focusCommandBandToggleWhenPanelContainsActiveElement } from "../components/command-band-focus.js";
 import { useGlobalSettingsStore } from "../global-settings-store.js";
-import type { Translate } from "@fleet-console/sdk/i18n";
-
-import { useT, type CoreMessageKey } from "../i18n/index.js";
+import { useT } from "../i18n/index.js";
 import { ReconnectButton } from "../components/reconnect-button.js";
 import { getState, subscribe } from "../store.js";
 import type { ConnectionState } from "../types.js";
 import { resolveConsoleLanguage } from "../whatsnew-i18n.js";
-import { closeRailPanel, requestRailPanelExtraWidth, setRailOverlayAlpha, toggleRailPanel, toggleRailPanelBehavior, useActiveRailPanelId, useRailChromeExpanded, useRailOverlayAlpha, useRailPanelBehavior, useRailPanelExtraWidth, type RailOverlayAlpha } from "./rail-store.js";
+import { closeRailPanel, RAIL_OVERLAY_ALPHA_DEFAULT, RAIL_OVERLAY_ALPHA_MAX, RAIL_OVERLAY_ALPHA_MIN, requestRailPanelExtraWidth, setRailOverlayAlpha, toggleRailPanel, toggleRailPanelBehavior, useActiveRailPanelId, useRailChromeExpanded, useRailOverlayAlpha, useRailPanelBehavior, useRailPanelExtraWidth, type RailOverlayAlpha } from "./rail-store.js";
 import { useRailPanels } from "./rail-registry.js";
 import { useCodexSplitExtraWidth } from "./use-codex-split-extra-width.js";
 
@@ -29,15 +27,6 @@ const MIN_PANEL_WIDTH = 240;
 const DEFAULT_PANEL_WIDTH = 312;
 const PREFS_PANEL_WIDTHS = "fleet-console.rail.panelWidths";
 const LEGACY_PREFS_PANEL_WIDTH = "fleet-console.rail.panelWidth";
-
-function buildOverlayAlphaPresets(t: Translate<CoreMessageKey>): readonly { readonly label: string; readonly value: RailOverlayAlpha }[] {
-  return [
-    { label: t("rail.chrome.opacitySolid"), value: 100 },
-    { label: "90", value: 90 },
-    { label: "75", value: 75 },
-    { label: "60", value: 60 },
-  ];
-}
 
 function readStoredPanelWidths(): Record<string, number> {
   try {
@@ -339,7 +328,6 @@ interface RailPanelContentProps {
 // (activePanel·ctx·activeId·panelBehavior·overlayAlpha) props로 memo해 드래그 중 본문 재렌더를 건너뛴다(좌측 SideBar처럼 가벼운 부분만 재렌더).
 const RailPanelContent = memo(function RailPanelContent({ activePanel, activePanelTitle, activeId, ctx, panelBehavior, overlayAlpha, connection, connectionLostAt, language }: RailPanelContentProps) {
   const t = useT();
-  const overlayPresets = buildOverlayAlphaPresets(t);
   const connectionLostTime = connectionLostAt === null ? "" : new Date(connectionLostAt).toLocaleTimeString(language);
   const staleVisible = connection !== "live" && connectionLostAt !== null;
   const panelBodyRef = useRef<HTMLDivElement>(null);
@@ -387,26 +375,26 @@ const RailPanelContent = memo(function RailPanelContent({ activePanel, activePan
           type="button"
           aria-pressed={panelBehavior === "overlay"}
           aria-label={t("rail.chrome.floatToggle")}
+          title={t("rail.chrome.floatLabel")}
           onClick={toggleRailPanelBehavior}
         >
-          {t("rail.chrome.floatLabel")}
+          <svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="1.5" y="2.5" width="13" height="11" rx="1.5" stroke="currentColor" /><rect x="7.5" y="7.5" width="5" height="4" rx="1" fill="currentColor" /></svg>
         </button>
         {panelBehavior === "overlay" ? (
-          <div className="right-rail-opacity-segments" role="group" aria-label={t("rail.chrome.opacityAria")}>
-            {overlayPresets.map((preset) => {
-              const isActive = preset.value === overlayAlpha;
-              return (
-                <button
-                  key={preset.value}
-                  className={`right-rail-opacity-segment${isActive ? " is-active" : ""}`}
-                  type="button"
-                  aria-pressed={isActive}
-                  onClick={() => setRailOverlayAlpha(preset.value)}
-                >
-                  {preset.label}
-                </button>
-              );
-            })}
+          <div className="right-rail-alpha">
+            <input
+              className="right-rail-alpha-slider"
+              type="range"
+              min={RAIL_OVERLAY_ALPHA_MIN}
+              max={RAIL_OVERLAY_ALPHA_MAX}
+              step={1}
+              value={overlayAlpha}
+              aria-label={t("rail.chrome.opacityAria")}
+              onChange={(event) => setRailOverlayAlpha(Number(event.currentTarget.value))}
+              onDoubleClick={() => setRailOverlayAlpha(RAIL_OVERLAY_ALPHA_DEFAULT)}
+              style={{ "--alpha-fill": `${((overlayAlpha - RAIL_OVERLAY_ALPHA_MIN) / (RAIL_OVERLAY_ALPHA_MAX - RAIL_OVERLAY_ALPHA_MIN)) * 100}%` } as CSSProperties}
+            />
+            <span className="right-rail-alpha-value" aria-hidden="true">{overlayAlpha}%</span>
           </div>
         ) : null}
         <button

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -291,7 +291,10 @@ export function RightRail({ theaterId, api }: RightRailProps) {
           />
         )}
         {activePanel && (
-          <RailPanelContent activePanel={activePanel} activePanelTitle={activePanelTitle} activeId={activeId} ctx={ctx} panelBehavior={panelBehavior} overlayAlpha={overlayAlpha} connection={connection} connectionLostAt={connectionLostAt} language={language} />
+          <>
+            <RailPanelHead activePanelTitle={activePanelTitle} panelBehavior={panelBehavior} overlayAlpha={overlayAlpha} />
+            <RailPanelBody activePanel={activePanel} activeId={activeId} ctx={ctx} connection={connection} connectionLostAt={connectionLostAt} language={language} />
+          </>
         )}
       </div>
       <nav className="right-rail-icons" aria-label={t("rail.chrome.toolsAria")}>
@@ -311,22 +314,70 @@ export function RightRail({ theaterId, api }: RightRailProps) {
   );
 }
 
-interface RailPanelContentProps {
-  readonly activePanel: RailPanelDescriptor;
+interface RailPanelHeadProps {
   readonly activePanelTitle: string;
-  readonly activeId: string | null;
-  readonly ctx: RailPanelContext;
   readonly panelBehavior: "push" | "overlay";
   readonly overlayAlpha: RailOverlayAlpha;
+}
+
+function RailPanelHead({ activePanelTitle, panelBehavior, overlayAlpha }: RailPanelHeadProps) {
+  const t = useT();
+
+  return (
+    <div className="right-rail-panel-head">
+      <span className="right-rail-panel-title">{activePanelTitle}</span>
+      <button
+        className={`right-rail-float-toggle${panelBehavior === "overlay" ? " is-active" : ""}`}
+        type="button"
+        aria-pressed={panelBehavior === "overlay"}
+        aria-label={t("rail.chrome.floatToggle")}
+        title={t("rail.chrome.floatLabel")}
+        onClick={toggleRailPanelBehavior}
+      >
+        <svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="1.5" y="2.5" width="13" height="11" rx="1.5" stroke="currentColor" /><rect x="7.5" y="7.5" width="5" height="4" rx="1" fill="currentColor" /></svg>
+      </button>
+      {panelBehavior === "overlay" ? (
+        <div className="right-rail-alpha">
+          <input
+            className="right-rail-alpha-slider"
+            type="range"
+            min={RAIL_OVERLAY_ALPHA_MIN}
+            max={RAIL_OVERLAY_ALPHA_MAX}
+            step={1}
+            value={overlayAlpha}
+            aria-label={t("rail.chrome.opacityAria")}
+            onChange={(event) => setRailOverlayAlpha(Number(event.currentTarget.value))}
+            onDoubleClick={() => setRailOverlayAlpha(RAIL_OVERLAY_ALPHA_DEFAULT)}
+            style={{ "--alpha-fill": `${((overlayAlpha - RAIL_OVERLAY_ALPHA_MIN) / (RAIL_OVERLAY_ALPHA_MAX - RAIL_OVERLAY_ALPHA_MIN)) * 100}%` } as CSSProperties}
+          />
+          <span className="right-rail-alpha-value" aria-hidden="true">{overlayAlpha}%</span>
+        </div>
+      ) : null}
+      <button
+        className="right-rail-close-btn"
+        type="button"
+        aria-label={t("rail.chrome.closePanel", { title: activePanelTitle })}
+        onClick={closeRailPanel}
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
+
+interface RailPanelBodyProps {
+  readonly activePanel: RailPanelDescriptor;
+  readonly activeId: string | null;
+  readonly ctx: RailPanelContext;
   readonly connection: ConnectionState;
   readonly connectionLostAt: number | null;
   readonly language: ConsoleLocale;
 }
 
-// 패널 본문은 무거운 플러그인 콘텐츠(파일 트리·diff·Codex)를 렌더한다. 리사이즈 드래그가
-// 매 프레임 RightRail을 재렌더해도 이 본문이 함께 재렌더되면 끊김이 생기므로, 폭과 무관한
-// (activePanel·ctx·activeId·panelBehavior·overlayAlpha) props로 memo해 드래그 중 본문 재렌더를 건너뛴다(좌측 SideBar처럼 가벼운 부분만 재렌더).
-const RailPanelContent = memo(function RailPanelContent({ activePanel, activePanelTitle, activeId, ctx, panelBehavior, overlayAlpha, connection, connectionLostAt, language }: RailPanelContentProps) {
+// 패널 본문은 무거운 플러그인 콘텐츠(파일 트리·diff·Codex)를 렌더한다. 폭·알파와 무관한
+// props만 받는 memo 경계로 리사이즈/알파 드래그 중 본문 재렌더를 건너뛰고, 경량 헤더는
+// 경계 밖에서 자유롭게 재렌더한다(좌측 SideBar처럼 가벼운 부분만 재렌더).
+const RailPanelBody = memo(function RailPanelBody({ activePanel, activeId, ctx, connection, connectionLostAt, language }: RailPanelBodyProps) {
   const t = useT();
   const connectionLostTime = connectionLostAt === null ? "" : new Date(connectionLostAt).toLocaleTimeString(language);
   const staleVisible = connection !== "live" && connectionLostAt !== null;
@@ -367,59 +418,19 @@ const RailPanelContent = memo(function RailPanelContent({ activePanel, activePan
   }, [staleVisible]);
 
   return (
-    <>
-      <div className="right-rail-panel-head">
-        <span className="right-rail-panel-title">{activePanelTitle}</span>
-        <button
-          className={`right-rail-float-toggle${panelBehavior === "overlay" ? " is-active" : ""}`}
-          type="button"
-          aria-pressed={panelBehavior === "overlay"}
-          aria-label={t("rail.chrome.floatToggle")}
-          title={t("rail.chrome.floatLabel")}
-          onClick={toggleRailPanelBehavior}
-        >
-          <svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="1.5" y="2.5" width="13" height="11" rx="1.5" stroke="currentColor" /><rect x="7.5" y="7.5" width="5" height="4" rx="1" fill="currentColor" /></svg>
-        </button>
-        {panelBehavior === "overlay" ? (
-          <div className="right-rail-alpha">
-            <input
-              className="right-rail-alpha-slider"
-              type="range"
-              min={RAIL_OVERLAY_ALPHA_MIN}
-              max={RAIL_OVERLAY_ALPHA_MAX}
-              step={1}
-              value={overlayAlpha}
-              aria-label={t("rail.chrome.opacityAria")}
-              onChange={(event) => setRailOverlayAlpha(Number(event.currentTarget.value))}
-              onDoubleClick={() => setRailOverlayAlpha(RAIL_OVERLAY_ALPHA_DEFAULT)}
-              style={{ "--alpha-fill": `${((overlayAlpha - RAIL_OVERLAY_ALPHA_MIN) / (RAIL_OVERLAY_ALPHA_MAX - RAIL_OVERLAY_ALPHA_MIN)) * 100}%` } as CSSProperties}
-            />
-            <span className="right-rail-alpha-value" aria-hidden="true">{overlayAlpha}%</span>
-          </div>
-        ) : null}
-        <button
-          className="right-rail-close-btn"
-          type="button"
-          aria-label={t("rail.chrome.closePanel", { title: activePanelTitle })}
-          onClick={closeRailPanel}
-        >
-          ✕
-        </button>
+    <div ref={panelBodyRef} id={`rail-panel-${activePanel.id}`} className="right-rail-panel-body" role="tabpanel" aria-labelledby={`rail-tab-${activeId}`} tabIndex={-1}>
+      <div ref={panelContentRef} className="right-rail-panel-content" inert={staleVisible || undefined}>
+        {activePanel.render(ctx)}
       </div>
-      <div ref={panelBodyRef} id={`rail-panel-${activePanel.id}`} className="right-rail-panel-body" role="tabpanel" aria-labelledby={`rail-tab-${activeId}`} tabIndex={-1}>
-        <div ref={panelContentRef} className="right-rail-panel-content" inert={staleVisible || undefined}>
-          {activePanel.render(ctx)}
+      {/* 덮개도 배너와 같은 축으로 건다 — 재연결 시도 중에도 패널 값은 여전히 멈춰 있다. */}
+      {staleVisible ? (
+        <div ref={staleVeilRef} className="right-rail-stale-veil">
+          <strong>{t("chrome.link.staleHeadline")}</strong>
+          <span>{t("chrome.link.staleDetail", { time: connectionLostTime })}</span>
+          <ReconnectButton buttonRef={reconnectButtonRef} />
         </div>
-        {/* 덮개도 배너와 같은 축으로 건다 — 재연결 시도 중에도 패널 값은 여전히 멈춰 있다. */}
-        {staleVisible ? (
-          <div ref={staleVeilRef} className="right-rail-stale-veil">
-            <strong>{t("chrome.link.staleHeadline")}</strong>
-            <span>{t("chrome.link.staleDetail", { time: connectionLostTime })}</span>
-            <ReconnectButton buttonRef={reconnectButtonRef} />
-          </div>
-        ) : null}
-      </div>
-    </>
+      ) : null}
+    </div>
   );
 });
 

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -96,7 +96,7 @@
   position: relative;
   z-index: 1;
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: center;
   gap: 6px;
   padding: 9px 44px 9px 10px;
@@ -120,17 +120,23 @@
 
 .right-rail-float-toggle {
   flex: none;
-  padding: 4px 8px;
+  width: 24px;
+  height: 24px;
+  display: inline-grid;
+  place-items: center;
+  padding: 0;
   border-radius: var(--radius-sm);
   border: 1px solid var(--surface-rim-strong);
   background: transparent;
   color: var(--text-tertiary);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  line-height: 1;
-  white-space: nowrap;
   cursor: pointer;
   transition: color 140ms, background 140ms, border-color 140ms;
+}
+
+.right-rail-float-toggle svg {
+  width: 14px;
+  height: 14px;
+  display: block;
 }
 
 .right-rail-float-toggle:hover {
@@ -151,47 +157,86 @@
   border-color: color-mix(in oklch, var(--brass) 70%, transparent);
 }
 
-.right-rail-opacity-segments {
-  flex: none;
+.right-rail-alpha {
+  flex: 0 1 auto;
+  min-width: 0;
   display: inline-flex;
-  overflow: hidden;
+  align-items: center;
+  gap: 6px;
   border: 1px solid var(--surface-rim-strong);
   border-radius: var(--radius-sm);
+  padding: 0 7px;
+  height: 24px;
 }
 
-.right-rail-opacity-segment {
-  padding: 4px 8px;
-  border: none;
-  border-left: 1px solid var(--surface-rim-strong);
+.right-rail-alpha-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  flex: 1 1 44px;
+  width: 64px;
+  min-width: 44px;
+  height: 20px;
   background: transparent;
-  color: var(--text-tertiary);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  line-height: 1;
   cursor: pointer;
 }
 
-.right-rail-opacity-segment:first-child {
-  border-left: none;
+.right-rail-alpha-slider::-webkit-slider-runnable-track {
+  height: 3px;
+  border-radius: 2px;
+  background: linear-gradient(to right, var(--brass) 0%, var(--brass) var(--alpha-fill, 100%), var(--surface-rim-strong) var(--alpha-fill, 100%), var(--surface-rim-strong) 100%);
 }
 
-.right-rail-opacity-segment:hover,
-.right-rail-opacity-segment:focus-visible {
-  color: var(--text-primary);
-  background: var(--ink-veil);
+.right-rail-alpha-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  margin-top: -4.5px;
+  border-radius: 50%;
+  background: var(--text-primary);
+  border: 1px solid var(--surface-rim-strong);
+}
+
+/* Firefox는 runnable-track 채움 그라데이션을 지원하지 않으므로 progress 의사요소로 병기한다. */
+.right-rail-alpha-slider::-moz-range-track {
+  height: 3px;
+  border-radius: 2px;
+  background: var(--surface-rim-strong);
+}
+
+.right-rail-alpha-slider::-moz-range-progress {
+  height: 3px;
+  border-radius: 2px;
+  background: var(--brass);
+}
+
+.right-rail-alpha-slider::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--text-primary);
+  border: 1px solid var(--surface-rim-strong);
+}
+
+.right-rail-alpha-slider:focus-visible {
   outline: none;
 }
 
-.right-rail-opacity-segment.is-active,
-.right-rail-opacity-segment.is-active:hover {
-  color: var(--brass-ink);
-  background: var(--brass-glow);
+.right-rail-alpha-slider:focus-visible::-webkit-slider-thumb {
+  box-shadow: 0 0 0 2px var(--brass);
 }
 
-/* 활성 프리셋 위에서도 포커스가 구분되도록 inset 링을 쓴다 — 컨테이너의
-   overflow: hidden 바깥으로 나가지 않아 pill 클리핑과 충돌하지 않는다. */
-.right-rail-opacity-segment:focus-visible {
-  box-shadow: inset 0 0 0 1px var(--brass);
+.right-rail-alpha-slider:focus-visible::-moz-range-thumb {
+  box-shadow: 0 0 0 2px var(--brass);
+}
+
+.right-rail-alpha-value {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--brass-ink);
+  width: 30px;
+  text-align: right;
 }
 
 .right-rail-close-btn {

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -78,9 +78,9 @@
   z-index: 0;
   border-radius: inherit;
   /* maritime/carbon 테마의 --surface-glass-strong은 78~80% 알파의 반투명 토큰이라 glass 층만으로는
-     Solid(100) 프리셋에서도 Map이 비쳐 보인다. 최하단에 불투명 --ink-deep 언더레이를 깔아
-     프리셋 100=완전 불투명을 보장하고, glass 믹스의 제2 성분이 이미 --ink-deep이므로 색조는 유지된다.
-     감쇠는 ::before 전체 opacity로만 적용되어 프리셋 라벨(100/90/75/60)이 실제 불투명도와 일치한다. */
+     알파 100에서도 Map이 비쳐 보인다. 최하단에 불투명 --ink-deep 언더레이를 깔아 슬라이더
+     최대값 100=완전 불투명을 보장하고, glass 믹스의 제2 성분이 이미 --ink-deep이므로 색조는 유지된다.
+     감쇠는 ::before 전체 opacity로만 적용되어 슬라이더 수치(40–100%)가 실제 불투명도와 일치한다. */
   background:
     radial-gradient(130% 60% at 100% 0%, color-mix(in oklch, var(--brass) 7%, transparent), transparent 56%),
     linear-gradient(
@@ -228,6 +228,14 @@
 
 .right-rail-alpha-slider:focus-visible::-moz-range-thumb {
   box-shadow: 0 0 0 2px var(--brass);
+}
+
+/* forced-colors 모드는 box-shadow 포커스 링을 제거하므로 outline으로 병기한다. */
+@media (forced-colors: active) {
+  .right-rail-alpha-slider:focus-visible {
+    outline: 2px solid CanvasText;
+    outline-offset: 1px;
+  }
 }
 
 .right-rail-alpha-value {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -86,6 +86,8 @@ const RUNTIME_CUSTOM_PROPERTY_ALLOWLIST = new Set([
   "--right-rail-panel-width",
   // Right Rail TSX injects the user-selected overlay opacity.
   "--right-rail-overlay-alpha",
+  // Right Rail TSX injects the continuous opacity slider's filled-track percentage.
+  "--alpha-fill",
   // Repository Rail TSX injects the user-resized workspace tree width.
   "--ws-tree-width",
   // Terminal Carriers TSX injects the selected captain identity tone.
@@ -663,8 +665,12 @@ describe("Instrument core design contract", () => {
     // var(--ink-deep) final layer — maritime/carbon --surface-glass-strong is a 78~80%
     // alpha token, so without the underlay the Solid(100) preset can never be opaque.
     expect(rail).toMatch(/\.right-rail\.is-overlay \.right-rail-panel-slot::before \{[^}]*\)\s*,\s*var\(--ink-deep\);/);
+    // Doctrine: keep both WebKit and Firefox track styling so the continuous
+    // opacity control communicates its filled range in either engine.
+    expect(rail).toContain(".right-rail-alpha-slider::-moz-range-progress");
     expect(rightRail).toContain("useRailPanelBehavior");
     expect(rightRail).toContain("right-rail-float-toggle");
+    expect(rightRail).toContain("right-rail-alpha-slider");
     expect(rightRail).toContain("is-switching");
     expect(railStore).toContain("fleet-console.rail.panelBehavior");
   });

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -663,7 +663,7 @@ describe("Instrument core design contract", () => {
     expect(rail).toContain(".right-rail.is-switching");
     // Doctrine: the overlay slot ::before composites its glass layers over an opaque
     // var(--ink-deep) final layer — maritime/carbon --surface-glass-strong is a 78~80%
-    // alpha token, so without the underlay the Solid(100) preset can never be opaque.
+    // alpha token, so without the underlay the slider's 100% endpoint can never be opaque.
     expect(rail).toMatch(/\.right-rail\.is-overlay \.right-rail-panel-slot::before \{[^}]*\)\s*,\s*var\(--ink-deep\);/);
     // Doctrine: keep both WebKit and Firefox track styling so the continuous
     // opacity control communicates its filled range in either engine.

--- a/runtime/fleet-console/tests/rail-store.test.ts
+++ b/runtime/fleet-console/tests/rail-store.test.ts
@@ -226,7 +226,7 @@ describe("rail overlay alpha", () => {
     return { values, setItem };
   }
 
-  it("defaults to Solid (100) when no value is stored", async () => {
+  it("defaults to 100 when no value is stored", async () => {
     stubOverlayAlphaStorage();
     const { getRailStoreSnapshot } = await freshStore();
     expect(getRailStoreSnapshot().overlayAlpha).toBe(100);
@@ -237,26 +237,34 @@ describe("rail overlay alpha", () => {
     ["90", 90],
     ["75", 75],
     ["60", 60],
+    ["83", 83],
+    ["150", 100],
+    ["10", 40],
   ] as const)("restores stored alpha %s", async (stored, expected) => {
     stubOverlayAlphaStorage(stored);
     const { getRailStoreSnapshot } = await freshStore();
     expect(getRailStoreSnapshot().overlayAlpha).toBe(expected);
   });
 
-  it("persists the selected alpha as an exact string", async () => {
+  it("persists 65 as an exact string", async () => {
     const storage = stubOverlayAlphaStorage();
     const { setRailOverlayAlpha } = await freshStore();
-    setRailOverlayAlpha(75);
-    expect(storage.values.get("fleet-console.rail.overlayAlpha")).toBe("75");
-    expect(storage.setItem).toHaveBeenCalledWith("fleet-console.rail.overlayAlpha", "75");
-
-    setRailOverlayAlpha(100);
-    expect(storage.values.get("fleet-console.rail.overlayAlpha")).toBe("100");
-    expect(storage.setItem).toHaveBeenCalledWith("fleet-console.rail.overlayAlpha", "100");
+    setRailOverlayAlpha(65);
+    expect(storage.values.get("fleet-console.rail.overlayAlpha")).toBe("65");
+    expect(storage.setItem).toHaveBeenCalledWith("fleet-console.rail.overlayAlpha", "65");
   });
 
-  it.each(["0", "59", "74", "89", "101", "solid", "75.0"])("falls back to 100 for invalid stored value %s", async (stored) => {
-    stubOverlayAlphaStorage(stored);
+  it("clamps 37 to 40 before persisting", async () => {
+    const storage = stubOverlayAlphaStorage();
+    const { getRailStoreSnapshot, setRailOverlayAlpha } = await freshStore();
+    setRailOverlayAlpha(37);
+    expect(getRailStoreSnapshot().overlayAlpha).toBe(40);
+    expect(storage.values.get("fleet-console.rail.overlayAlpha")).toBe("40");
+    expect(storage.setItem).toHaveBeenCalledWith("fleet-console.rail.overlayAlpha", "40");
+  });
+
+  it("falls back to 100 for a non-numeric stored value", async () => {
+    stubOverlayAlphaStorage("abc");
     const { getRailStoreSnapshot } = await freshStore();
     expect(getRailStoreSnapshot().overlayAlpha).toBe(100);
   });

--- a/runtime/fleet-console/tests/rail-store.test.ts
+++ b/runtime/fleet-console/tests/rail-store.test.ts
@@ -240,6 +240,8 @@ describe("rail overlay alpha", () => {
     ["83", 83],
     ["150", 100],
     ["10", 40],
+    ["", 100],
+    ["  ", 100],
   ] as const)("restores stored alpha %s", async (stored, expected) => {
     stubOverlayAlphaStorage(stored);
     const { getRailStoreSnapshot } = await freshStore();

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -4,7 +4,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const railPanelContextMock = vi.hoisted(() => ({ themes: [] as unknown[] }));
+const railPanelContextMock = vi.hoisted(() => ({ themes: [] as unknown[], renderCount: 0 }));
 
 vi.mock("../core/client/src/rail/built-in-panels.js", () => ({
   BUILT_IN_RAIL_PANELS: [
@@ -14,6 +14,7 @@ vi.mock("../core/client/src/rail/built-in-panels.js", () => ({
       defaultWidth: 360,
       icon: "P",
       render: (ctx: { readonly theme?: unknown }) => {
+        railPanelContextMock.renderCount += 1;
         railPanelContextMock.themes.push(ctx.theme);
         return <button className="test-panel-action">Panel action</button>;
       },
@@ -71,6 +72,7 @@ beforeEach(() => {
   setRailPanelBehavior("push");
   setRailOverlayAlpha(100);
   railPanelContextMock.themes.length = 0;
+  railPanelContextMock.renderCount = 0;
   setState({ connection: "live", connectionLostAt: null, activeTheme: "instrument" });
   container = document.createElement("div");
   document.body.replaceChildren(container);
@@ -113,6 +115,22 @@ describe("Right Rail overlay opacity slider", () => {
 
     expect(getRailStoreSnapshot().overlayAlpha).toBe(100);
     expect(panelSlot().style.getPropertyValue("--right-rail-overlay-alpha")).toBe("1");
+  });
+
+  it("does not re-render the panel body while the opacity slider changes", () => {
+    setRailPanelBehavior("overlay");
+    renderRail();
+
+    const slider = container.querySelector<HTMLInputElement>('input[aria-label="Panel opacity"]')!;
+    const renderCountBeforeChange = railPanelContextMock.renderCount;
+    const setInputValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+    act(() => {
+      setInputValue.call(slider, "65");
+      slider.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    expect(getRailStoreSnapshot().overlayAlpha).toBe(65);
+    expect(railPanelContextMock.renderCount).toBe(renderCountBeforeChange);
   });
 });
 

--- a/runtime/fleet-console/tests/right-rail.test.tsx
+++ b/runtime/fleet-console/tests/right-rail.test.tsx
@@ -83,31 +83,36 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("Right Rail overlay opacity presets", () => {
-  it("renders no opacity group or alpha variable in push mode", () => {
+describe("Right Rail overlay opacity slider", () => {
+  it("renders no opacity slider or alpha variable in push mode", () => {
     renderRail();
 
-    expect(container.querySelector('[role="group"][aria-label="Panel opacity"]')).toBeNull();
+    expect(container.querySelector('input[aria-label="Panel opacity"]')).toBeNull();
     expect(panelSlot().style.getPropertyValue("--right-rail-overlay-alpha")).toBe("");
   });
 
-  it("renders the exact presets in overlay mode and applies selection to the slot background variable", () => {
+  it("renders the slider in overlay mode, applies changes, and resets on double-click", () => {
     setRailPanelBehavior("overlay");
     renderRail();
 
-    const group = container.querySelector<HTMLElement>('[role="group"][aria-label="Panel opacity"]');
-    expect(group).not.toBeNull();
-    const buttons = Array.from(group!.querySelectorAll("button"));
-    expect(buttons.map((button) => button.textContent)).toEqual(["Solid", "90", "75", "60"]);
-    expect(buttons.map((button) => button.getAttribute("aria-pressed"))).toEqual(["true", "false", "false", "false"]);
+    const slider = container.querySelector<HTMLInputElement>('input[aria-label="Panel opacity"]');
+    expect(slider).not.toBeNull();
     expect(panelSlot().style.getPropertyValue("--right-rail-overlay-alpha")).toBe("1");
 
-    act(() => buttons[2]?.click());
+    const setInputValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+    act(() => {
+      setInputValue.call(slider, "65");
+      slider!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
 
-    expect(getRailStoreSnapshot().overlayAlpha).toBe(75);
-    expect(window.localStorage.getItem("fleet-console.rail.overlayAlpha")).toBe("75");
-    expect(buttons.map((button) => button.getAttribute("aria-pressed"))).toEqual(["false", "false", "true", "false"]);
-    expect(panelSlot().style.getPropertyValue("--right-rail-overlay-alpha")).toBe("0.75");
+    expect(getRailStoreSnapshot().overlayAlpha).toBe(65);
+    expect(window.localStorage.getItem("fleet-console.rail.overlayAlpha")).toBe("65");
+    expect(panelSlot().style.getPropertyValue("--right-rail-overlay-alpha")).toBe("0.65");
+
+    act(() => slider!.dispatchEvent(new MouseEvent("dblclick", { bubbles: true })));
+
+    expect(getRailStoreSnapshot().overlayAlpha).toBe(100);
+    expect(panelSlot().style.getPropertyValue("--right-rail-overlay-alpha")).toBe("1");
   });
 });
 


### PR DESCRIPTION
## Summary
- 우측 rail 패널 헤더의 "Float over Map" 텍스트 토글을 24px PiP 아이콘 토글(라벨은 tooltip·aria-label로 보존)로 교체하고, Solid/90/75/60 불투명도 프리셋 세그먼트를 인라인 연속 슬라이더(40–100, % 병기, 더블클릭 100 리셋)로 대체합니다. 12개 모던 제품 조사에서 프리셋 세그먼트 채택은 0건, 연속 slider+수치 병행이 지배 관례(8/12)였습니다.
- `RailOverlayAlpha`를 리터럴 유니온에서 클램프된 number로 전환하고 기존 localStorage 저장값을 자연 흡수합니다(빈/비정상 문자열은 기본값 100 폴백). 배경-만-감쇠 `::before` 모델과 저장 키는 무변경입니다.
- 헤더를 경량 `RailPanelHead`와 memo된 `RailPanelBody`로 분리해 슬라이더 연속 드래그가 무거운 플러그인 본문을 재렌더하지 않도록 하고(회귀 테스트 포함), 헤더는 240px 최소폭에서도 1줄(46px)을 유지합니다(기존 2줄 65px 감김 해소).

## Test Plan
- [x] `corepack pnpm --filter @dotobokuri/fleet-console build`
- [x] `corepack pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit -p core/client`
- [x] 대상 vitest 3파일 87/87 통과 (rail-store · right-rail · instrument-design-contract)
- [x] console-e2e 헤디드 검증: instrument·daywatch 테마 × 392/240px — 슬라이더 실시간 반영·새로고침 복원·1줄 헤더·토큰 정합 확인
- [x] Changelog: `.changelog.d/pr-440.md` 추가, 그룹형 문법·EN/KO 병기, `node scripts/compile-changelog-fragments.mjs --check` 통과