### PR TITLE
feat(fleet-console): open command palette directly with Mod+P

### DIFF
--- a/.changelog.d/pr-443.md
+++ b/.changelog.d/pr-443.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Added
+- [fleet-console] Open the command palette directly with Mod+P, pre-seeded with the command-mode prefix.
+  ko: Mod+P로 커맨드 모드 프리픽스가 입력된 커맨드 팔레트를 바로 엽니다.

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -26,7 +26,7 @@ import { Operations } from "./pages/operations.js";
 import { BUILT_IN_RAIL_PANELS } from "./rail/built-in-panels.js";
 import { toggleRailChrome } from "./rail/rail-store.js";
 import { refreshObserverStatus } from "./operations-sse.js";
-import { closeKeyboardShortcuts, hydrateGroups, hydrateInitialOperations, hydrateOperations, hydrateTheaterBootstrap, hydrateTheaters, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
+import { closeKeyboardShortcuts, hydrateGroups, hydrateInitialOperations, hydrateOperations, hydrateTheaterBootstrap, hydrateTheaters, openOperationSearch, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
 import { abortReleaseNotesFetch, requestReleaseNotes } from "./release-notes-fetch.js";
 import { getSideBarState, setSideBarCollapsed, subscribeOperationActivityTracking } from "./sidebar/operations-side-bar-store.js";
 import { useConsoleLocale, useT } from "./i18n/index.js";
@@ -233,6 +233,7 @@ export function App() {
     return installConsoleGlobalShortcuts({
       getSideBarCollapsed: () => getSideBarState().collapsed,
       setSideBarCollapsed,
+      openOperationSearch: () => openOperationSearch(">"),
       toggleOperationSearch,
       toggleRailChrome,
       canUndoLastClose,

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -77,6 +77,7 @@ export function OperationSearch({
   const inputRef = useRef<HTMLInputElement | null>(null);
   const cardRef = useRef<HTMLElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
+  const operationSearchWasOpenRef = useRef(false);
   const resultRefs = useRef(new Map<string, HTMLButtonElement>());
   const searchGenerationRef = useRef(0);
   const commandMode = isCommandModeInput(query);
@@ -154,6 +155,12 @@ export function OperationSearch({
       previousFocusRef.current?.focus();
     };
   }, [state.operationSearchOpen]);
+
+  useEffect(() => {
+    const opening = state.operationSearchOpen && !operationSearchWasOpenRef.current;
+    operationSearchWasOpenRef.current = state.operationSearchOpen;
+    if (opening) setQuery(state.operationSearchSeed ?? "");
+  }, [state.operationSearchOpen, state.operationSearchSeed]);
 
   useEffect(() => {
     if (!state.operationSearchOpen) {

--- a/runtime/fleet-console/core/client/src/global-shortcuts.ts
+++ b/runtime/fleet-console/core/client/src/global-shortcuts.ts
@@ -4,6 +4,7 @@ import { isKeyboardShortcutsModalOpen } from "./components/keyboard-shortcuts-di
 export interface ConsoleGlobalShortcutDependencies {
   readonly getSideBarCollapsed: () => boolean;
   readonly setSideBarCollapsed: (collapsed: boolean) => void;
+  readonly openOperationSearch: () => void;
   readonly toggleOperationSearch: () => void;
   readonly toggleRailChrome: () => void;
   readonly canUndoLastClose?: () => boolean;
@@ -27,6 +28,12 @@ export function installConsoleGlobalShortcuts(dependencies: ConsoleGlobalShortcu
       event.preventDefault();
       event.stopImmediatePropagation();
       dependencies.toggleOperationSearch();
+      return;
+    }
+    if ((event.metaKey || event.ctrlKey) && !event.altKey && event.key.toLowerCase() === "p") {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      dependencies.openOperationSearch();
       return;
     }
     // Mod+Alt+B(rail): macOS는 ⌘(+⌥)로 발화하며 ⌥B의 합성문자(∫)는 무시하고 code로 판정한다.

--- a/runtime/fleet-console/core/client/src/i18n/messages/pages.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/pages.ts
@@ -117,6 +117,7 @@ export const pagesEn = {
   // shortcuts
   "shortcuts.group.console": "Console",
   "shortcuts.console.searchOps": "Search Operations across Theaters",
+  "shortcuts.console.commandPalette": "Open Command Palette",
   "shortcuts.console.toggleSidebar": "Toggle the left sidebar",
   "shortcuts.console.toggleRail": "Toggle the right activity rail",
   "shortcuts.group.operations": "Operations",
@@ -405,6 +406,7 @@ export const pagesKo: Record<keyof typeof pagesEn, string> = {
 
   "shortcuts.group.console": "Console",
   "shortcuts.console.searchOps": "Theater 전체에서 Operation 검색",
+  "shortcuts.console.commandPalette": "커맨드 팔레트 열기",
   "shortcuts.console.toggleSidebar": "왼쪽 사이드바 전환",
   "shortcuts.console.toggleRail": "오른쪽 Activity Rail 전환",
   "shortcuts.group.operations": "Operations",

--- a/runtime/fleet-console/core/client/src/shortcuts-catalog.ts
+++ b/runtime/fleet-console/core/client/src/shortcuts-catalog.ts
@@ -28,6 +28,7 @@ export function buildShortcutGroups(
       title: t("shortcuts.group.console"),
       entries: [
         { combos: [["Mod", "K"]], description: t("shortcuts.console.searchOps") },
+        { combos: [["Mod", "P"]], description: t("shortcuts.console.commandPalette") },
         { combos: [["Mod", "B"]], description: t("shortcuts.console.toggleSidebar") },
         { combos: [["Mod", "Alt", "B"]], description: t("shortcuts.console.toggleRail") },
       ],

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -71,6 +71,7 @@ let state: ConsoleState = {
   theaterError: null,
   operationsViewActive: false,
   operationSearchOpen: false,
+  operationSearchSeed: null,
   whatsNewOpen: false,
   releaseNotes: [],
   releaseNotesLoading: false,
@@ -499,16 +500,20 @@ export function compareOperationCreatedAt(left: OperationNode, right: OperationN
   return left.ts.createdAt - right.ts.createdAt || left.id.localeCompare(right.id);
 }
 
-export function openOperationSearch(): void {
-  setState({ operationSearchOpen: true });
+export function openOperationSearch(seed?: string): void {
+  setState({ operationSearchOpen: true, operationSearchSeed: seed ?? null });
 }
 
 export function closeOperationSearch(): void {
-  setState({ operationSearchOpen: false });
+  setState({ operationSearchOpen: false, operationSearchSeed: null });
 }
 
 export function toggleOperationSearch(): void {
-  setState({ operationSearchOpen: !state.operationSearchOpen });
+  const operationSearchOpen = !state.operationSearchOpen;
+  setState({
+    operationSearchOpen,
+    ...(operationSearchOpen ? {} : { operationSearchSeed: null }),
+  });
 }
 
 export function openWhatsNew(): void {

--- a/runtime/fleet-console/core/client/src/types.ts
+++ b/runtime/fleet-console/core/client/src/types.ts
@@ -193,6 +193,7 @@ export interface ConsoleState {
   readonly theaterError: string | null;
   readonly operationsViewActive: boolean;
   readonly operationSearchOpen: boolean;
+  readonly operationSearchSeed: string | null;
   readonly whatsNewOpen: boolean;
   readonly releaseNotes: readonly ReleaseNotes[];
   readonly releaseNotesLoading: boolean;

--- a/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
+++ b/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
@@ -514,6 +514,7 @@ const CANVAS_STATE: ConsoleState = {
   theaterError: null,
   operationsViewActive: true,
   operationSearchOpen: false,
+  operationSearchSeed: null,
   whatsNewOpen: false,
   releaseNotes: [],
   releaseNotesLoading: false,

--- a/runtime/fleet-console/tests/global-shortcuts.test.ts
+++ b/runtime/fleet-console/tests/global-shortcuts.test.ts
@@ -15,6 +15,7 @@ describe("Console global shortcuts", () => {
     const cleanup = installConsoleGlobalShortcuts({
       getSideBarCollapsed: () => false,
       setSideBarCollapsed: vi.fn(),
+      openOperationSearch: vi.fn(),
       toggleOperationSearch,
       toggleRailChrome: vi.fn(),
     });
@@ -35,6 +36,7 @@ describe("Console global shortcuts", () => {
     const cleanup = installConsoleGlobalShortcuts({
       getSideBarCollapsed: () => false,
       setSideBarCollapsed: vi.fn(),
+      openOperationSearch: vi.fn(),
       toggleOperationSearch: vi.fn(),
       toggleRailChrome: vi.fn(),
       canUndoLastClose: () => active,
@@ -57,6 +59,42 @@ describe("Console global shortcuts", () => {
     dispatchUndo();
 
     expect(undoLastClose).toHaveBeenCalledOnce();
+    cleanup();
+  });
+
+  it("opens the command palette for Mod+P with optional Shift while rejecting Alt and modal-gated events", () => {
+    const openOperationSearch = vi.fn();
+    const cleanup = installConsoleGlobalShortcuts({
+      getSideBarCollapsed: () => false,
+      setSideBarCollapsed: vi.fn(),
+      openOperationSearch,
+      toggleOperationSearch: vi.fn(),
+      toggleRailChrome: vi.fn(),
+    });
+    const dispatch = (init: KeyboardEventInit) => {
+      const event = new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
+      const stopImmediatePropagation = vi.spyOn(event, "stopImmediatePropagation");
+      window.dispatchEvent(event);
+      return { event, stopImmediatePropagation };
+    };
+
+    const meta = dispatch({ key: "p", metaKey: true });
+    const ctrlShift = dispatch({ key: "P", ctrlKey: true, shiftKey: true });
+    const alt = dispatch({ key: "p", metaKey: true, altKey: true });
+    const dialog = document.createElement("div");
+    dialog.setAttribute("aria-modal", "true");
+    document.body.append(dialog);
+    const modalGated = dispatch({ key: "p", metaKey: true });
+
+    expect(openOperationSearch).toHaveBeenCalledTimes(2);
+    expect(meta.event.defaultPrevented).toBe(true);
+    expect(meta.stopImmediatePropagation).toHaveBeenCalledOnce();
+    expect(ctrlShift.event.defaultPrevented).toBe(true);
+    expect(ctrlShift.stopImmediatePropagation).toHaveBeenCalledOnce();
+    expect(alt.event.defaultPrevented).toBe(false);
+    expect(alt.stopImmediatePropagation).not.toHaveBeenCalled();
+    expect(modalGated.event.defaultPrevented).toBe(false);
+    expect(modalGated.stopImmediatePropagation).not.toHaveBeenCalled();
     cleanup();
   });
 });

--- a/runtime/fleet-console/tests/operation-search-focus.test.tsx
+++ b/runtime/fleet-console/tests/operation-search-focus.test.tsx
@@ -9,7 +9,7 @@ import { OperationSearch } from "../core/client/src/components/operation-search.
 import { takeKeyboardShortcutsReturnFocus } from "../core/client/src/keyboard-shortcuts-return-focus.js";
 import { useConsoleState } from "../core/client/src/hooks/use-store.js";
 import { getSideBarState, setSideBarCollapsed } from "../core/client/src/sidebar/operations-side-bar-store.js";
-import { getState, setState } from "../core/client/src/store.js";
+import { closeOperationSearch, getState, openOperationSearch, setState, toggleOperationSearch } from "../core/client/src/store.js";
 
 let container: HTMLDivElement | null = null;
 let previousFocus: HTMLButtonElement | null = null;
@@ -58,6 +58,7 @@ beforeEach(() => {
       ts: { createdAt: 1, updatedAt: 1 },
     }],
     operationSearchOpen: true,
+    operationSearchSeed: null,
     pendingOperationFocus: null,
     keyboardFocusRequest: null,
     pendingSideBarAddTheater: false,
@@ -83,6 +84,32 @@ afterEach(() => {
 });
 
 describe("Operation search focus handoff", () => {
+  it("consumes an opening seed once and lets Backspace return to operation search", () => {
+    act(() => setState({ operationSearchOpen: false }));
+    act(() => openOperationSearch(">"));
+
+    const input = document.querySelector<HTMLInputElement>("#operation-search-input");
+    expect(input?.value).toBe(">");
+    expect(input?.selectionStart).toBe(1);
+    expect(document.querySelector("#operation-search-heading-commands")?.textContent).toBe("Commands");
+
+    const setInputValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+    act(() => {
+      setInputValue.call(input, "");
+      input!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    act(() => setState({ operationSearchSeed: ">add theater" }));
+
+    expect(input?.value).toBe("");
+    expect(document.querySelector('[role="option"]')?.textContent).toContain("Operation A");
+
+    act(() => closeOperationSearch());
+    expect(getState()).toMatchObject({ operationSearchOpen: false, operationSearchSeed: null });
+    act(() => openOperationSearch(">"));
+    act(() => toggleOperationSearch());
+    expect(getState()).toMatchObject({ operationSearchOpen: false, operationSearchSeed: null });
+  });
+
   it("does not restore the previous focus after selecting an Operation", () => {
     const restoreFocus = vi.spyOn(previousFocus!, "focus");
     const result = document.querySelector<HTMLButtonElement>('[role="option"]');

--- a/runtime/fleet-console/tests/operation-search.test.ts
+++ b/runtime/fleet-console/tests/operation-search.test.ts
@@ -51,6 +51,7 @@ function makeState(
     theaterError: null,
     operationsViewActive: false,
     operationSearchOpen: false,
+    operationSearchSeed: null,
     whatsNewOpen: false,
     releaseNotes: [],
     releaseNotesLoading: false,

--- a/runtime/fleet-console/tests/palette-commands.test.ts
+++ b/runtime/fleet-console/tests/palette-commands.test.ts
@@ -56,6 +56,7 @@ function makeState(patch: Partial<ConsoleState> = {}): ConsoleState {
     theaterError: null,
     operationsViewActive: false,
     operationSearchOpen: false,
+    operationSearchSeed: null,
     whatsNewOpen: false,
     releaseNotes: [],
     releaseNotesLoading: false,

--- a/runtime/fleet-console/tests/reduce.test.ts
+++ b/runtime/fleet-console/tests/reduce.test.ts
@@ -58,6 +58,7 @@ function makeConsoleSnap(patch: Partial<ConsoleState> = {}): ConsoleState {
     theaterError: null,
     operationsViewActive: false,
     operationSearchOpen: false,
+    operationSearchSeed: null,
     whatsNewOpen: false,
     releaseNotes: [],
     releaseNotesLoading: false,

--- a/runtime/fleet-console/tests/shortcuts-catalog.test.ts
+++ b/runtime/fleet-console/tests/shortcuts-catalog.test.ts
@@ -4,6 +4,16 @@ import { getT } from "../core/client/src/i18n/index.js";
 import { buildShortcutGroups } from "../core/client/src/shortcuts-catalog.js";
 
 describe("shortcut catalog", () => {
+  it("lists the command palette immediately after operation search", () => {
+    const consoleGroup = buildShortcutGroups(getT("en"))
+      .find((group) => group.title === "Console")!;
+
+    expect(consoleGroup.entries.slice(0, 2)).toEqual([
+      { combos: [["Mod", "K"]], description: "Search Operations across Theaters" },
+      { combos: [["Mod", "P"]], description: "Open Command Palette" },
+    ]);
+  });
+
   it("appends active companion shortcuts to the end of Operations", () => {
     const operations = buildShortcutGroups(getT("en"), [
       { label: "C", title: "Carrier Streams" },

--- a/runtime/fleet-console/tests/triage-stage-companion.test.ts
+++ b/runtime/fleet-console/tests/triage-stage-companion.test.ts
@@ -128,6 +128,7 @@ const STATE: ConsoleState = {
   theaterError: null,
   operationsViewActive: true,
   operationSearchOpen: false,
+  operationSearchSeed: null,
   whatsNewOpen: false,
   releaseNotes: [],
   releaseNotesLoading: false,


### PR DESCRIPTION
## Summary
- Mod+K로 팔레트를 연 뒤 커맨드 모드까지 가려면 `>`를 한 번 더 입력해야 했던 마찰 제거 — Mod+P(Shift 허용, Alt 제외)로 `>`가 시드된 채 열어 커맨드 모드에 직행합니다 (VS Code cmd+shift+P 컨벤션).
- 시드는 새 `ConsoleState.operationSearchSeed` 필드를 통해 전달되며, 닫힘 전이에서만 소비(1회)되어 입력 중 덮어쓰기가 없습니다. Mod+K 동작은 변경 없습니다.
- 단축키 카탈로그와 EN/KO i18n(`shortcuts.console.commandPalette`)에도 반영했습니다.

## Test Plan
- [x] `vitest run tests/global-shortcuts.test.ts tests/shortcuts-catalog.test.ts tests/operation-search-focus.test.tsx tests/operation-search.test.ts` — 17/17 통과
- [x] `vitest run tests/palette-commands.test.ts tests/reduce.test.ts tests/canvas-minimap-formation.test.ts tests/triage-stage-companion.test.ts` — 64/64 통과
- [x] `pnpm -C runtime/fleet-console run build` 통과
- [x] Changelog: `.changelog.d/pr-443.md` — 그룹 문법·이중언어 요약·`compile-changelog-fragments --check` 검증 완료