### PR TITLE
feat(analyst): exclusive listboxes, Escape ladder, themed artifact base sheet

### DIFF
--- a/.changelog.d/pr-451.md
+++ b/.changelog.d/pr-451.md
@@ -1,0 +1,9 @@
+### fleet-plugin
+#### Added
+- [fleet-console] Step the Session Analyst composer Escape key through three layers: dismiss the slash-command listbox, clear the draft, then close the Analyst companion cluster while leaving other companions untouched.
+  ko: Session Analyst 컴포저의 Escape 키가 세 단계로 동작합니다: slash 명령 리스트박스 닫기, 드래프트 지우기, Analyst 컴패니언 묶음 닫기(다른 컴패니언은 유지).
+- [fleet-console] Inject a theme-token base stylesheet into served Session Analyst artifacts, exposing --fleet-canvas/surface/ink/muted/hairline/accent so artifact content follows the active console theme.
+  ko: Session Analyst 아티팩트 제공 문서에 테마 토큰 기반 베이스 스타일시트를 주입해 --fleet-canvas/surface/ink/muted/hairline/accent 변수로 아티팩트가 활성 콘솔 테마를 따릅니다.
+#### Changed
+- [fleet-console] Dismiss the Session Analyst slash-command listbox when a catalog selector gains focus, so the two suggestion layers no longer stack.
+  ko: 카탈로그 선택기에 포커스가 이동하면 Session Analyst slash 명령 리스트박스를 닫아 두 추천 레이어가 겹치지 않습니다.

--- a/packages/fleet-analyst/src/tools.ts
+++ b/packages/fleet-analyst/src/tools.ts
@@ -77,7 +77,7 @@ const TOOL_METADATA: Record<string, ToolMetadata> = {
   },
   [ANALYST_TOOL_IDS.publishArtifact]: {
     id: ANALYST_TOOL_IDS.publishArtifact,
-    description: "Publishes one newest-first, in-memory analysis artifact and emits it to the client event stream.",
+    description: "Publishes one newest-first, in-memory analysis artifact and emits it to the client event stream. The served document injects a base stylesheet exposing CSS variables --fleet-canvas, --fleet-surface, --fleet-ink, --fleet-muted, --fleet-hairline, --fleet-accent matching the user's console theme. Prefer these variables (with sensible fallbacks, e.g. var(--fleet-surface, #f5f5f5)) over hard-coded colors so the artifact reads correctly in both dark and light consoles.",
     promptSnippet: "Use publish_artifact with the exact title and html parameters for a self-contained structured explanation with evidence citations.",
     whenToUse: ["When a timeline, comparison, risk review, or visual brief is clearer than chat alone.", "After collecting cited evidence for the artifact."],
     whenNotToUse: ["Do not use it for raw transcript dumps, secrets, external resources, or oversized HTML."],

--- a/packages/fleet-analyst/tests/tools.test.ts
+++ b/packages/fleet-analyst/tests/tools.test.ts
@@ -22,6 +22,10 @@ describe("AnalystTools", () => {
       description: expect.stringContaining("Required before answering any question about current work"),
       whenNotToUse: expect.any(Array),
     });
+    expect(byId.get("publish_artifact")).toMatchObject({
+      description: expect.stringContaining("--fleet-canvas, --fleet-surface, --fleet-ink, --fleet-muted, --fleet-hairline, --fleet-accent"),
+    });
+    expect(byId.get("publish_artifact")?.description).toContain("var(--fleet-surface, #f5f5f5)");
     expect(await byId.get("session_read")!.execute({ ref: "e1", radius: 999 }, {} as never)).toMatchObject({ events: [{ ref: "e1" }] });
     expect(await byId.get("publish_artifact")!.execute({ title: "A", html: "<p>x</p>" }, {} as never)).toMatchObject({ artifact: { title: "A" } });
     await expect(byId.get("publish_artifact")!.execute({ title: "A", html: "x".repeat(50 * 1024 + 1) }, {} as never)).rejects.toThrow("50 KiB"); expect(events).toEqual(["artifact"]);

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-api.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-api.ts
@@ -24,8 +24,12 @@ let pendingRecreateTimer: ReturnType<typeof setTimeout> | null = null;
 let recreateDelayMs = RECREATE_BASE_DELAY_MS;
 const operations = new Map<string, OperationRecord>();
 
-export function analysisArtifactUrl(artifactId: string, theme: ConsoleTheme, canvas: string, foreground: string): string {
+export function analysisArtifactUrl(artifactId: string, theme: ConsoleTheme, canvas: string, foreground: string, surface?: string, hairline?: string, accent?: string, muted?: string): string {
   const query = new URLSearchParams({ theme, canvas, foreground });
+  if (surface) query.set("surface", surface);
+  if (hairline) query.set("hairline", hairline);
+  if (accent) query.set("accent", accent);
+  if (muted) query.set("muted", muted);
   return `/plugins/terminal/analysis/artifacts/${encodeURIComponent(artifactId)}?${query.toString()}`;
 }
 

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-artifacts-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-artifacts-panel.tsx
@@ -137,8 +137,11 @@ export function AnalystArtifactsPanel({ context }: { readonly context: Operation
   const openActiveInNewTab = () => {
     if (!active) return;
     closeExport(true);
-    const { canvas, foreground } = getArtifactColors();
-    window.open(analysisArtifactUrl(active.id, context.theme, canvas, foreground), "_blank", "noopener");
+    const { canvas, foreground, surface, hairline, accent, muted } = getArtifactColors();
+    const url = surface || hairline || accent || muted
+      ? analysisArtifactUrl(active.id, context.theme, canvas, foreground, surface, hairline, accent, muted)
+      : analysisArtifactUrl(active.id, context.theme, canvas, foreground);
+    window.open(url, "_blank", "noopener");
   };
   const handleExportMenuKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === "Escape") {
@@ -214,20 +217,29 @@ export function AnalystArtifactsPanel({ context }: { readonly context: Operation
 function ActiveArtifact({ artifact, theme, language }: { readonly artifact: AnalysisArtifact; readonly theme: ConsoleTheme; readonly language: ConsoleLocale }) {
   if (!artifact.id) return null;
   const t = getT(language);
-  const { canvas, foreground } = getArtifactColors();
+  const { canvas, foreground, surface, hairline, accent, muted } = getArtifactColors();
+  const frame = surface || hairline || accent || muted
+    ? <iframe title={artifact.title} src={analysisArtifactUrl(artifact.id, theme, canvas, foreground, surface, hairline, accent, muted)} sandbox="allow-scripts" />
+    : <iframe title={artifact.title} src={analysisArtifactUrl(artifact.id, theme, canvas, foreground)} sandbox="allow-scripts" />;
   return (
     <article aria-label={t("terminal.artifacts.selectedPreview")}>
       <header><span className="session-analyst__artifact-title">{artifact.title}</span><ArtifactTime createdAt={artifact.createdAt} language={language} /></header>
-      <iframe title={artifact.title} src={analysisArtifactUrl(artifact.id, theme, canvas, foreground)} sandbox="allow-scripts" />
+      {frame}
     </article>
   );
 }
 
-function getArtifactColors(): { readonly canvas: string; readonly foreground: string } {
+function getArtifactColors(): { readonly canvas: string; readonly foreground: string; readonly surface: string; readonly hairline: string; readonly accent: string; readonly muted: string } {
   const consoleStyle = getComputedStyle(document.documentElement);
+  const canvas = consoleStyle.getPropertyValue("--ink-veil").trim() || "Canvas";
+  const foreground = consoleStyle.getPropertyValue("--ink-pearl").trim() || "CanvasText";
   return {
-    canvas: consoleStyle.getPropertyValue("--ink-veil").trim() || "Canvas",
-    foreground: consoleStyle.getPropertyValue("--ink-pearl").trim() || "CanvasText",
+    canvas,
+    foreground,
+    surface: consoleStyle.getPropertyValue("--ink-deep").trim(),
+    hairline: consoleStyle.getPropertyValue("--hairline").trim(),
+    accent: consoleStyle.getPropertyValue("--aurora").trim(),
+    muted: consoleStyle.getPropertyValue("--ink-muted").trim(),
   };
 }
 

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.test.tsx
@@ -37,7 +37,12 @@ vi.mock("./analysis-store.js", () => ({
   useAnalysisStore: () => ({ state: storeState, dispatch, send, stop, reset }),
 }));
 
-import { ANALYST_ARTIFACTS_COMPANION_ID, AnalystChatPanel } from "./analysis-chat-panel.js";
+import { AnalystChatPanel } from "./analysis-chat-panel.js";
+import {
+  ANALYST_ARTIFACTS_COMPANION_ID,
+  ANALYST_CHAT_COMPANION_ID,
+  CARRIER_STREAMS_COMPANION_ID,
+} from "./analysis-visibility.js";
 
 const catalog = { clis: [{ cliId: "codex", label: "Codex", available: true, defaultModel: "gpt", models: [{ id: "gpt", label: "GPT", effortLevels: ["medium"], defaultEffort: "medium" }] }] };
 
@@ -480,6 +485,123 @@ describe("Session Analyst Evidence Pulse", () => {
     act(() => timeline.click());
     expect(storeState.draft).toBe("Walk me through how this session unfolded.");
     expect(send).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("dismisses the slash listbox when focus enters the initial selector strip", () => {
+    storeState = {
+      ...initialAnalysisState,
+      catalog,
+      cliId: "codex",
+      model: "gpt",
+      effort: "medium",
+      draft: "/",
+    };
+    const { container, root } = renderPanel();
+    const textarea = container.querySelector("textarea")!;
+    const trigger = container.querySelector<HTMLButtonElement>(".session-analyst__selector-strip .fc-select__trigger")!;
+
+    expect(container.querySelector('[role="listbox"]')).not.toBeNull();
+    act(() => trigger.focus());
+    expect(document.activeElement).toBe(trigger);
+    expect(container.querySelector('[role="listbox"]')).toBeNull();
+    expect(textarea.getAttribute("aria-expanded")).toBe("false");
+    expect(storeState.draft).toBe("/");
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("dismisses only the slash listbox on the first Escape", () => {
+    storeState = { ...initialAnalysisState, draft: "/" };
+    const { container, root } = renderPanel();
+    const textarea = container.querySelector("textarea")!;
+
+    expect(container.querySelector('[role="listbox"]')).not.toBeNull();
+    act(() => textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })));
+    expect(container.querySelector('[role="listbox"]')).toBeNull();
+    expect(storeState.draft).toBe("/");
+    expect(textarea.value).toBe("/");
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("clears a non-empty draft on Escape when the slash listbox is closed", () => {
+    const onRequestCompanions = vi.fn();
+    const onSetCompanionPanelVisible = vi.fn();
+    storeState = { ...initialAnalysisState, draft: "Keep this draft" };
+    const { container, root } = renderPanel({
+      operationId: "chat-test",
+      companionsOpen: true,
+      hiddenCompanionPanelIds: [CARRIER_STREAMS_COMPANION_ID, ANALYST_ARTIFACTS_COMPANION_ID],
+      onRequestCompanions,
+      onSetCompanionPanelVisible,
+    } as OperationRenderContext);
+    const textarea = container.querySelector("textarea")!;
+
+    act(() => textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })));
+    expect(storeState.draft).toBe("");
+    expect(textarea.value).toBe("");
+    expect(onSetCompanionPanelVisible).not.toHaveBeenCalled();
+    expect(onRequestCompanions).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("closes both Analyst companions and the empty companion layer on Escape", () => {
+    const onRequestCompanions = vi.fn();
+    const onSetCompanionPanelVisible = vi.fn();
+    storeState = {
+      ...initialAnalysisState,
+      artifacts: [{ id: "artifact", title: "Artifact", html: "<p>artifact</p>", createdAt: 1 }],
+    };
+    const { container, root } = renderPanel({
+      operationId: "chat-test",
+      companionsOpen: true,
+      hiddenCompanionPanelIds: [CARRIER_STREAMS_COMPANION_ID],
+      onRequestCompanions,
+      onSetCompanionPanelVisible,
+    } as OperationRenderContext);
+    const textarea = container.querySelector("textarea")!;
+
+    act(() => textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })));
+    expect(onSetCompanionPanelVisible.mock.calls).toEqual([
+      [ANALYST_CHAT_COMPANION_ID, false],
+      [ANALYST_ARTIFACTS_COMPANION_ID, false],
+    ]);
+    expect(onRequestCompanions).toHaveBeenCalledOnce();
+    expect(onRequestCompanions).toHaveBeenCalledWith(false);
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("keeps the companion layer open on Escape when Carrier Streams remains visible", () => {
+    const onRequestCompanions = vi.fn();
+    const onSetCompanionPanelVisible = vi.fn();
+    storeState = {
+      ...initialAnalysisState,
+      artifacts: [{ id: "artifact", title: "Artifact", html: "<p>artifact</p>", createdAt: 1 }],
+    };
+    const { container, root } = renderPanel({
+      operationId: "chat-test",
+      companionsOpen: true,
+      hiddenCompanionPanelIds: [],
+      onRequestCompanions,
+      onSetCompanionPanelVisible,
+    } as OperationRenderContext);
+    const textarea = container.querySelector("textarea")!;
+
+    act(() => textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })));
+    expect(onSetCompanionPanelVisible.mock.calls).toEqual([
+      [ANALYST_CHAT_COMPANION_ID, false],
+      [ANALYST_ARTIFACTS_COMPANION_ID, false],
+    ]);
+    expect(onRequestCompanions).not.toHaveBeenCalled();
 
     act(() => root.unmount());
     container.remove();

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-chat-panel.tsx
@@ -8,7 +8,10 @@ import type { AnalysisActivity, AnalysisState } from "./analysis-state.js";
 import type { ConsoleLocale } from "@fleet-console/sdk/i18n";
 import { diagramHydratorLabels, getT, translateServerMessage, type TerminalMessageKey } from "../i18n/index.js";
 import { useAnalysisStore } from "./analysis-store.js";
+import { ANALYST_ARTIFACTS_COMPANION_ID, closeAnalystCompanionPanels } from "./analysis-visibility.js";
 import { StreamedMarkdown } from "./streamed-markdown.js";
+
+export { ANALYST_ARTIFACTS_COMPANION_ID };
 
 const SUGGESTIONS = [
   { icon: "◈", tone: "aurora", textKey: "terminal.analyst.suggestion.walkthrough" },
@@ -42,7 +45,6 @@ const SLASH_COMMANDS = [
   readonly descriptionKey: TerminalMessageKey;
   readonly templateKey: TerminalMessageKey;
 }[];
-export const ANALYST_ARTIFACTS_COMPANION_ID = "session-analyst-artifacts";
 
 export function AnalystChatPanel({ context }: { readonly context: OperationRenderContext }) {
   const { state, dispatch, send, stop, reset } = useAnalysisStore(context);
@@ -257,7 +259,7 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
               ))}
             </div>
           ) : null}
-          {!hasInteracted ? <div className="session-analyst__selector-strip" aria-label={t("terminal.analyst.initialSettings")}>
+          {!hasInteracted ? <div className="session-analyst__selector-strip" aria-label={t("terminal.analyst.initialSettings")} onFocusCapture={() => setSlashDismissed(true)}>
             <span className="session-analyst__select">
               <Select
                 compact
@@ -319,6 +321,17 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
                 setSlashDismissed(false);
               }}
               onKeyDown={(event) => {
+                if (event.key === "Escape" && !event.nativeEvent.isComposing) {
+                  event.preventDefault();
+                  if (slashOpen) {
+                    setSlashDismissed(true);
+                  } else if (state.draft) {
+                    dispatch({ type: "set-draft", draft: "" });
+                  } else {
+                    closeAnalystCompanionPanels(context);
+                  }
+                  return;
+                }
                 if (slashOpen && !event.nativeEvent.isComposing) {
                   if (event.key === "ArrowDown") {
                     event.preventDefault();
@@ -333,11 +346,6 @@ export function AnalystChatPanel({ context }: { readonly context: OperationRende
                   if (event.key === "Enter") {
                     event.preventDefault();
                     selectSlashCommand(Math.min(slashSelection, slashMatches.length - 1));
-                    return;
-                  }
-                  if (event.key === "Escape") {
-                    event.preventDefault();
-                    setSlashDismissed(true);
                     return;
                   }
                 }

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-panel.test.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-panel.test.tsx
@@ -54,11 +54,11 @@ describe("Session Analyst contract", () => {
   });
   it("registers Carrier Streams first and keeps both Analyst panels hidden by default", () => {
     const source = readFileSync(new URL("./index.tsx", import.meta.url), "utf8");
-    const chat = readFileSync(new URL("./analysis-chat-panel.tsx", import.meta.url), "utf8");
+    const visibility = readFileSync(new URL("./analysis-visibility.ts", import.meta.url), "utf8");
     expect(source).toContain('id: CARRIER_STREAMS_COMPANION_ID, title: (locale) => getT(locale)("terminal.companion.carrierStreams"), hideCaption: true, defaultHidden: true');
     expect(source).toContain('id: ANALYST_CHAT_COMPANION_ID, title: (locale) => getT(locale)("terminal.companion.sessionAnalyst"), hideCaption: true, defaultHidden: true');
     expect(source).toContain('id: ANALYST_ARTIFACTS_COMPANION_ID, title: (locale) => getT(locale)("terminal.companion.artifacts"), hideCaption: true, defaultHidden: true');
-    expect(chat).toContain('export const ANALYST_ARTIFACTS_COMPANION_ID = "session-analyst-artifacts";');
+    expect(visibility).toContain('export const ANALYST_ARTIFACTS_COMPANION_ID = "session-analyst-artifacts";');
     expect(source.match(/hideCaption: true/g)).toHaveLength(3);
     expect(source.match(/defaultHidden: true/g)).toHaveLength(3);
     expect(source).toContain('shortcut: { code: "KeyC", label: "C" }');

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-visibility.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-visibility.ts
@@ -1,0 +1,31 @@
+import type { OperationRenderContext } from "@fleet-console/sdk/plugin";
+
+export const CARRIER_STREAMS_COMPANION_ID = "carrier-streams";
+export const ANALYST_CHAT_COMPANION_ID = "session-analyst-chat";
+export const ANALYST_ARTIFACTS_COMPANION_ID = "session-analyst-artifacts";
+export const ANALYST_COMPANION_IDS = [ANALYST_CHAT_COMPANION_ID, ANALYST_ARTIFACTS_COMPANION_ID] as const;
+
+const AGENT_COMPANION_IDS = [CARRIER_STREAMS_COMPANION_ID, ...ANALYST_COMPANION_IDS] as const;
+
+export function isCompanionPanelVisible(context: OperationRenderContext, companionId: string): boolean {
+  return Boolean(context.companionsOpen) && !(context.hiddenCompanionPanelIds ?? []).includes(companionId);
+}
+
+export function countRemainingVisibleCompanionPanels(
+  context: OperationRenderContext,
+  hiddenIds: readonly string[],
+): number {
+  return AGENT_COMPANION_IDS
+    .filter((id) => !hiddenIds.includes(id) && isCompanionPanelVisible(context, id))
+    .length;
+}
+
+export function closeAnalystCompanionPanels(context: OperationRenderContext): void {
+  if (!context.companionsOpen || !context.onSetCompanionPanelVisible) return;
+  for (const id of ANALYST_COMPANION_IDS) {
+    if (isCompanionPanelVisible(context, id)) context.onSetCompanionPanelVisible(id, false);
+  }
+  if (countRemainingVisibleCompanionPanels(context, ANALYST_COMPANION_IDS) === 0) {
+    context.onRequestCompanions?.(false);
+  }
+}

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -12,8 +12,17 @@ import { CURATED_TERMINAL_FONTS, DEFAULT_TERMINAL_FONT, TERMINAL_FONT_SIZE_RANGE
 import { useTerminalPrefs, setInstalledTerminalFont, setTerminalRenderer, setTerminalFont, setTerminalFontSize } from "../shared/terminal-prefs-store.js";
 import type { TerminalFontId, TerminalFontSettings, TerminalRenderer } from "../shared/types.js";
 import { AnalystArtifactsPanel } from "./analysis-artifacts-panel.js";
-import { ANALYST_ARTIFACTS_COMPANION_ID, AnalystChatPanel } from "./analysis-chat-panel.js";
+import { AnalystChatPanel } from "./analysis-chat-panel.js";
 import { fetchAnalysisReady } from "./analysis-api.js";
+import {
+  ANALYST_ARTIFACTS_COMPANION_ID,
+  ANALYST_CHAT_COMPANION_ID,
+  ANALYST_COMPANION_IDS,
+  CARRIER_STREAMS_COMPANION_ID,
+  closeAnalystCompanionPanels,
+  countRemainingVisibleCompanionPanels,
+  isCompanionPanelVisible,
+} from "./analysis-visibility.js";
 import type { ConsoleLocale } from "@fleet-console/sdk/i18n";
 import { currentTerminalLocale, getT, useTerminalLocale, type TerminalMessageKey } from "../i18n/index.js";
 import { disposeAnalysisStore, rearmAnalysisArtifacts, useAnalysisStore } from "./analysis-store.js";
@@ -32,6 +41,8 @@ import { isTerminalJobStatus } from "./reduce.js";
 import { StreamedMarkdown } from "./streamed-markdown.js";
 import { applySessionUpdate, hydrateAgentClis, removeSession, selectSession, sessionJobs, useAgentState } from "./store.js";
 import type { AgentCliDiagnosticsEntry, AgentCliStatus, JobView, SessionInfo, TrackView } from "./types.js";
+
+export { CARRIER_STREAMS_COMPANION_ID };
 
 interface SettingToggleRowProps {
   readonly title: string;
@@ -66,10 +77,6 @@ const FONT_META_KEYS = {
   "source-code-pro": "terminal.settings.fontMetaSourceCodePro",
 } as const satisfies Record<TerminalFontId, TerminalMessageKey>;
 const ANALYSIS_READY_POLL_MS = 5_000;
-export const CARRIER_STREAMS_COMPANION_ID = "carrier-streams";
-const ANALYST_CHAT_COMPANION_ID = "session-analyst-chat";
-const ANALYST_COMPANION_IDS = [ANALYST_CHAT_COMPANION_ID, ANALYST_ARTIFACTS_COMPANION_ID] as const;
-const AGENT_COMPANION_IDS = [CARRIER_STREAMS_COMPANION_ID, ANALYST_CHAT_COMPANION_ID, ANALYST_ARTIFACTS_COMPANION_ID] as const;
 type AnalysisReadiness = "unknown" | "ready" | "not-ready";
 
 const TRACK_PHASE_COPY_KEYS = {
@@ -292,19 +299,6 @@ function useAnalysisReady(context: OperationRenderContext): AnalysisReadiness {
   return readiness;
 }
 
-function isCompanionPanelVisible(context: OperationRenderContext, companionId: string): boolean {
-  return Boolean(context.companionsOpen) && !(context.hiddenCompanionPanelIds ?? []).includes(companionId);
-}
-
-function countRemainingVisibleCompanionPanels(
-  context: OperationRenderContext,
-  hiddenIds: readonly string[],
-): number {
-  return AGENT_COMPANION_IDS
-    .filter((id) => !hiddenIds.includes(id) && isCompanionPanelVisible(context, id))
-    .length;
-}
-
 // 리본은 상태 표면이지 토글이 아니다 — 접근성 이름이 "열기"인 컨트롤이 닫으면 안 된다.
 // 여닫는 것은 우측 STREAMS 핸들의 역할이고, 리본은 멱등하게 열기만 한다.
 function openCompanionPanel(context: OperationRenderContext, companionId: string): void {
@@ -454,12 +448,7 @@ function AgentOperationView({ context }: { readonly context: OperationRenderCont
   React.useEffect(() => {
     if (analysisReadiness !== "not-ready" || !context.companionsOpen || !context.onSetCompanionPanelVisible) return;
     // 단축키는 disabled 핸들 가드를 거치지 않으므로, 준비 전 진입이 빈 companion 배치를 남기지 않게 호스트 레이어까지 함께 정리한다.
-    for (const id of ANALYST_COMPANION_IDS) {
-      if (isCompanionPanelVisible(context, id)) context.onSetCompanionPanelVisible(id, false);
-    }
-    if (countRemainingVisibleCompanionPanels(context, ANALYST_COMPANION_IDS) === 0) {
-      context.onRequestCompanions?.(false);
-    }
+    closeAnalystCompanionPanels(context);
   }, [
     analysisReadiness,
     context.companionsOpen,

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.test.ts
@@ -8,11 +8,31 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@dotobokuri/fleet-analyst", () => ({ AnalystSession: class {} }));
 
+import { analysisArtifactUrl } from "../../client/agent/analysis-api.js";
 import { AnalysisRegistry, MAX_ANALYSIS_ARTIFACTS, MAX_STOPPED_ANALYSIS_ARTIFACTS } from "./analysis-registry.js";
 import { ANALYSIS_ARTIFACT_CSP, registerAnalysisRoutes } from "./analysis-routes.js";
 import { ANALYSIS_ERROR_CODES, buildAnalysisCatalog, isAnalysisSelection, isMessageBody, type AnalysisEvent, type AnalystCliId } from "./analysis-types.js";
 
+function artifactBaseCss(colors: { readonly canvas: string; readonly surface: string; readonly foreground: string; readonly muted: string; readonly hairline: string; readonly accent: string }): string {
+  return `:root{--fleet-canvas:${colors.canvas};--fleet-surface:${colors.surface};--fleet-ink:${colors.foreground};--fleet-muted:${colors.muted};--fleet-hairline:${colors.hairline};--fleet-accent:${colors.accent}}a{color:var(--fleet-accent)}code{background:var(--fleet-surface);border:1px solid var(--fleet-hairline);border-radius:4px;padding:0 .3em}pre{background:var(--fleet-surface);border:1px solid var(--fleet-hairline);border-radius:8px;padding:12px;overflow-x:auto}pre code{background:none;border:none;padding:0}blockquote{border-left:3px solid var(--fleet-hairline);color:var(--fleet-muted);margin-left:0;padding-left:1em}hr{border:none;border-top:1px solid var(--fleet-hairline)}th,td{border-color:var(--fleet-hairline)}::selection{background:var(--fleet-accent);color:var(--fleet-canvas)}`;
+}
+
 describe("Session Analyst server contract", () => {
+  it("serializes all Console theme colors into artifact URLs", () => {
+    const url = new URL(analysisArtifactUrl("artifact/id", "carbon", "#101820", "#f2f4f7", "#18212b", "#35404d", "#65d1ff", "#96a0ad"), "http://fleet.invalid");
+
+    expect(url.pathname).toBe("/plugins/terminal/analysis/artifacts/artifact%2Fid");
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      theme: "carbon",
+      canvas: "#101820",
+      foreground: "#f2f4f7",
+      surface: "#18212b",
+      hairline: "#35404d",
+      accent: "#65d1ff",
+      muted: "#96a0ad",
+    });
+  });
+
   it("maps detected binaries to a non-sensitive authoritative catalog and rejects stale selections", () => {
     const modelsFor = vi.fn((_cliId: AnalystCliId) => ({ defaultModel: "model-a", models: [{ modelId: "model-a", name: "Model A", effort: { supported: true, levels: ["low"], default: "low" } }] }));
     const catalog = buildAnalysisCatalog([
@@ -567,14 +587,24 @@ describe("Session Analyst server contract", () => {
     const html = "<main>Artifact<script>globalThis.__artifactRan = true</script></main>";
     emit?.({ type: "artifact", artifact: { id: "artifact/id", title: "Artifact", html, createdAt: new Date(0).toISOString() } });
 
-    const response = await router.call("GET", "/api/v1/plugins/terminal/analysis/artifacts/artifact%2Fid?theme=carbon&canvas=oklch%2833%25%200.006%20252%29&foreground=oklch%2895%25%200.003%20250%29");
+    const response = await router.call("GET", "/api/v1/plugins/terminal/analysis/artifacts/artifact%2Fid?theme=carbon&canvas=oklch%2833%25%200.006%20252%29&foreground=oklch%2895%25%200.003%20250%29&surface=%2318202b&hairline=%2335404d&accent=%2365d1ff&muted=%2396a0ad");
 
     expect(response).toMatchObject({ status: 200, ended: true });
     expect(response.body).toContain('<html data-theme="carbon" style="background-color:oklch(33% 0.006 252)!important;background-image:none!important;color:oklch(95% 0.003 250)!important;min-height:100%!important;color-scheme:dark!important;">');
     expect(response.body).toContain(`<body style="background-color:oklch(33% 0.006 252)!important;background-image:none!important;color:oklch(95% 0.003 250)!important;min-height:100%!important;color-scheme:dark!important;margin:0!important;">${html}</body>`);
     expect(response.body).toContain("<script>globalThis.__artifactRan = true</script>");
     const fragmentDocument = new DOMParser().parseFromString(response.body, "text/html");
+    const fragmentCss = artifactBaseCss({
+      canvas: "oklch(33% 0.006 252)",
+      surface: "#18202b",
+      foreground: "oklch(95% 0.003 250)",
+      muted: "#96a0ad",
+      hairline: "#35404d",
+      accent: "#65d1ff",
+    });
     expect(fragmentDocument.documentElement.getAttribute("data-theme")).toBe("carbon");
+    expect(response.body).toContain(`<head><style>${fragmentCss}</style></head><body`);
+    expect(fragmentDocument.head.querySelector("style")?.textContent).toBe(fragmentCss);
     expect(fragmentDocument.body.querySelector("main")?.textContent).toBe("ArtifactglobalThis.__artifactRan = true");
     expect(response.headers).toMatchObject({
       "Content-Type": "text/html; charset=utf-8",
@@ -589,11 +619,46 @@ describe("Session Analyst server contract", () => {
     expect(response.headers).not.toHaveProperty("Cross-Origin-Opener-Policy");
     expect(response.headers).not.toHaveProperty("Cross-Origin-Resource-Policy");
 
+    const legacyResponse = await router.call("GET", "/api/v1/plugins/terminal/analysis/artifacts/artifact%2Fid?canvas=%23101010&foreground=%23efefef");
+    const legacyDocument = new DOMParser().parseFromString(legacyResponse.body, "text/html");
+    expect(legacyDocument.head.querySelector("style")?.textContent).toBe(artifactBaseCss({
+      canvas: "#101010",
+      surface: "#101010",
+      foreground: "#efefef",
+      muted: "#efefef",
+      hairline: "#efefef",
+      accent: "#efefef",
+    }));
+
+    emit?.({ type: "artifact", artifact: { id: "headless", title: "Headless", html: "<!doctype html><html lang=\"en\"><body><main>Headless</main></body></html>", createdAt: new Date(0).toISOString() } });
+    const headlessResponse = await router.call("GET", "/api/v1/plugins/terminal/analysis/artifacts/headless?canvas=%23101010&foreground=%23efefef");
+    const htmlStart = headlessResponse.body.indexOf("<html");
+    const htmlStartEnd = headlessResponse.body.indexOf(">", htmlStart) + 1;
+    expect(headlessResponse.body.slice(htmlStartEnd)).toMatch(/^<style>:root\{/);
+
+    emit?.({ type: "artifact", artifact: { id: "decoy", title: "Decoy", html: "<!doctype html><html lang=\"en\"><template><head></head></template><body><main>Decoy</main></body></html>", createdAt: new Date(0).toISOString() } });
+    const decoyResponse = await router.call("GET", "/api/v1/plugins/terminal/analysis/artifacts/decoy?canvas=%23101010&foreground=%23efefef");
+    const decoyHtmlStart = decoyResponse.body.indexOf("<html");
+    const decoyHtmlStartEnd = decoyResponse.body.indexOf(">", decoyHtmlStart) + 1;
+    expect(decoyResponse.body.slice(decoyHtmlStartEnd)).toMatch(/^<style>:root\{/);
+    const decoyDocument = new DOMParser().parseFromString(decoyResponse.body, "text/html");
+    expect(decoyDocument.head.querySelector("style")?.textContent).toContain("--fleet-canvas:#101010");
+    expect(decoyDocument.querySelector("template")?.innerHTML).not.toContain("--fleet-canvas");
+
     await router.call("POST", "/api/v1/plugins/terminal/analysis/op/stop", {});
     const afterStop = await router.call("GET", "/api/v1/plugins/terminal/analysis/artifacts/artifact%2Fid");
     expect(afterStop).toMatchObject({ status: 200, ended: true });
     expect(afterStop.body).toContain(html);
     expect(afterStop.body).toContain('<html data-theme="instrument" style="background-color:Canvas!important;');
+    const defaultDocument = new DOMParser().parseFromString(afterStop.body, "text/html");
+    expect(defaultDocument.head.querySelector("style")?.textContent).toBe(artifactBaseCss({
+      canvas: "Canvas",
+      surface: "Canvas",
+      foreground: "CanvasText",
+      muted: "CanvasText",
+      hairline: "CanvasText",
+      accent: "CanvasText",
+    }));
     expect(dispose).toHaveBeenCalledOnce();
     dispose.mockClear();
 
@@ -632,11 +697,24 @@ describe("Session Analyst server contract", () => {
     emit?.({ type: "artifact", artifact: { id: "hostile", title: "Hostile", html: hostileHtml, createdAt: new Date(0).toISOString() } });
 
     for (const theme of ["instrument", "maritime", "carbon", "whites"] as const) {
-      const path = `/api/v1/plugins/terminal/analysis/artifacts/hostile?theme=${theme}&canvas=${encodeURIComponent("#123456")}&foreground=${encodeURIComponent("#f0f0f0")}`;
+      const path = `/api/v1/plugins/terminal/analysis/artifacts/hostile?theme=${theme}&canvas=${encodeURIComponent("#123456")}&foreground=${encodeURIComponent("#f0f0f0")}&surface=${encodeURIComponent("#18202b")}&hairline=${encodeURIComponent("#35404d")}&accent=${encodeURIComponent("#65d1ff")}&muted=${encodeURIComponent("#96a0ad")}`;
       const response = await router.call("GET", path);
       const expectedColorScheme = theme === "whites" ? "light" : "dark";
       expect(response.status).toBe(200);
       const document = new DOMParser().parseFromString(response.body, "text/html");
+      const headStyles = document.head.querySelectorAll("style");
+      expect(headStyles).toHaveLength(2);
+      expect(document.head.firstElementChild).toBe(headStyles[0]);
+      expect(headStyles[0]?.textContent).toBe(artifactBaseCss({
+        canvas: "#123456",
+        surface: "#18202b",
+        foreground: "#f0f0f0",
+        muted: "#96a0ad",
+        hairline: "#35404d",
+        accent: "#65d1ff",
+      }));
+      expect(headStyles[0]?.textContent).not.toContain("!important");
+      expect(headStyles[1]?.textContent).toContain("background:linear-gradient(white,white)!important");
       expect(document.documentElement.getAttribute("data-theme")).toBe(theme);
       expect(document.documentElement).toMatchObject({ lang: "en", className: "artifact-root" });
       expect(document.documentElement.getAttribute("data-note")).toBe("quoted > value");
@@ -684,7 +762,16 @@ describe("Session Analyst server contract", () => {
     await router.call("POST", "/api/v1/plugins/terminal/analysis/op/start", { cliId: "claude", model: "model-b" });
     emit?.({ type: "artifact", artifact: { id: "safe", title: "Safe", html: "<p>safe</p>", createdAt: new Date(0).toISOString() } });
     const hostile = 'red!important;"><script>globalThis.injected=true</script>';
-    const path = `/api/v1/plugins/terminal/analysis/artifacts/safe?theme=${encodeURIComponent('carbon" onload="alert(1)')}&canvas=${encodeURIComponent(hostile)}&foreground=${encodeURIComponent("x".repeat(101))}`;
+    const query = new URLSearchParams({
+      theme: 'carbon" onload="alert(1)',
+      canvas: hostile,
+      foreground: "x".repeat(101),
+      surface: '#fff";--injected-surface:red',
+      hairline: "rgb(1 2 3);color:red",
+      accent: "url(javascript:alert(1))",
+      muted: "oklch(50% 0 0);}</style><script>globalThis.mutedInjected=true</script>",
+    });
+    const path = `/api/v1/plugins/terminal/analysis/artifacts/safe?${query.toString()}`;
 
     const response = await router.call("GET", path);
 
@@ -693,7 +780,18 @@ describe("Session Analyst server contract", () => {
     expect(document.documentElement.getAttribute("data-theme")).toBe("instrument");
     expect(document.documentElement.style.getPropertyValue("background-color")).toBe("canvas");
     expect(document.documentElement.style.getPropertyValue("color")).toBe("canvastext");
+    expect(document.head.querySelector("style")?.textContent).toBe(artifactBaseCss({
+      canvas: "Canvas",
+      surface: "Canvas",
+      foreground: "CanvasText",
+      muted: "CanvasText",
+      hairline: "CanvasText",
+      accent: "CanvasText",
+    }));
     expect(response.body).not.toContain("globalThis.injected");
+    expect(response.body).not.toContain("mutedInjected");
+    expect(response.body).not.toContain("injected-surface");
+    expect(response.body).not.toContain("javascript:alert");
     expect(document.documentElement.hasAttribute("onload")).toBe(false);
   });
 

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-routes.ts
@@ -130,14 +130,21 @@ function artifactDocument(html: string, requestUrl: string | undefined): string 
   const theme = safeArtifactTheme(query.get("theme"));
   const canvas = safeArtifactColor(query.get("canvas"), "Canvas");
   const foreground = safeArtifactColor(query.get("foreground"), "CanvasText");
+  const surface = safeArtifactColor(query.get("surface"), canvas);
+  const hairline = safeArtifactColor(query.get("hairline"), foreground);
+  const accent = safeArtifactColor(query.get("accent"), foreground);
+  const muted = safeArtifactColor(query.get("muted"), foreground);
   const canvasStyle = `background-color:${canvas}!important;background-image:none!important;color:${foreground}!important;min-height:100%!important;color-scheme:${ANALYSIS_ARTIFACT_LIGHT_THEMES.has(theme) ? "light" : "dark"}!important;`;
+  const baseStylesheet = `<style>:root{--fleet-canvas:${canvas};--fleet-surface:${surface};--fleet-ink:${foreground};--fleet-muted:${muted};--fleet-hairline:${hairline};--fleet-accent:${accent}}a{color:var(--fleet-accent)}code{background:var(--fleet-surface);border:1px solid var(--fleet-hairline);border-radius:4px;padding:0 .3em}pre{background:var(--fleet-surface);border:1px solid var(--fleet-hairline);border-radius:8px;padding:12px;overflow-x:auto}pre code{background:none;border:none;padding:0}blockquote{border-left:3px solid var(--fleet-hairline);color:var(--fleet-muted);margin-left:0;padding-left:1em}hr{border:none;border-top:1px solid var(--fleet-hairline)}th,td{border-color:var(--fleet-hairline)}::selection{background:var(--fleet-accent);color:var(--fleet-canvas)}</style>`;
   const documentTags = findArtifactDocumentTags(html);
   if (documentTags) {
     const htmlTag = withArtifactAttribute(withArtifactAttribute(documentTags.htmlTag.source, "data-theme", theme), "style", canvasStyle, ARTIFACT_CANVAS_STYLE_PROPERTIES);
     const bodyTag = withArtifactAttribute(documentTags.bodyTag.source, "style", `${canvasStyle}margin:0!important;`, ARTIFACT_BODY_CANVAS_STYLE_PROPERTIES);
-    return `${html.slice(0, documentTags.htmlTag.start)}${htmlTag}${html.slice(documentTags.htmlTag.end, documentTags.bodyTag.start)}${bodyTag}${html.slice(documentTags.bodyTag.end)}`;
+    // 베이스 시트는 항상 재작성된 <html> 시작 태그 직후에 둔다 — 파서가 head로 hoist하므로
+    // <template> 안의 가짜 <head> 같은 decoy가 주입을 삼키는 경로가 성립하지 않는다.
+    return `${html.slice(0, documentTags.htmlTag.start)}${htmlTag}${baseStylesheet}${html.slice(documentTags.htmlTag.end, documentTags.bodyTag.start)}${bodyTag}${html.slice(documentTags.bodyTag.end)}`;
   }
-  return `<!doctype html><html data-theme="${theme}" style="${canvasStyle}"><head></head><body style="${canvasStyle}margin:0!important;">${html}</body></html>`;
+  return `<!doctype html><html data-theme="${theme}" style="${canvasStyle}"><head>${baseStylesheet}</head><body style="${canvasStyle}margin:0!important;">${html}</body></html>`;
 }
 
 type HtmlStartTag = { readonly start: number; readonly end: number; readonly source: string };
@@ -328,7 +335,7 @@ function safeArtifactTheme(value: string | null): string {
   return value !== null && ANALYSIS_ARTIFACT_THEMES.has(value) ? value : "instrument";
 }
 
-function safeArtifactColor(value: string | null, fallback: "Canvas" | "CanvasText"): string {
+function safeArtifactColor(value: string | null, fallback: string): string {
   return value !== null && value.length <= 100 && SAFE_ARTIFACT_COLOR.test(value) ? value : fallback;
 }
 


### PR DESCRIPTION
## Summary
- Session Analyst 컴포저의 slash 리스트박스와 카탈로그 Select가 동시에 열리던 중첩을 해소하고, 컴포저 Escape를 3단 사다리(리스트박스 닫기 → 드래프트 지우기 → Analyst 클러스터 닫기)로 정리했습니다.
- 아티팩트 serve 문서에 콘솔 테마 토큰 기반 베이스 스타일시트(`--fleet-canvas/surface/ink/muted/hairline/accent`)를 주입하고, `publish_artifact` 툴 설명에 변수 계약을 명기해 신규 아티팩트가 테마 변수를 우선 사용하도록 했습니다.
- 제품 배경: product-proposal 실측 기반 개선안 C(입력·키보드 문법) + E(아티팩트 테마 일치) — 실측 증거: 이중 listbox 스크린샷, 900px 3-pane 압착, 다크 콘솔 내 흰 아티팩트.

## Test Plan
- [x] terminal 플러그인 테스트 451/451, fleet-analyst 29/29
- [x] terminal typecheck, fleet-console production build
- [x] 격리 콘솔 실브라우저: Select 오픈 시 slash dismiss, Escape 1·2·3단 각각 검증, 다른 companion 가시 시 레이어 유지
- [x] 아티팩트 serve 응답에 `--fleet-*` 6변수 실토큰 값 주입 확인, 신규 아티팩트의 변수 사용 확인
- [x] `<template><head>` decoy 회귀 테스트 포함 (Sentinel LOW 반영)
- [x] fleet-console 테스트는 canary 기준선과 동일한 선존 실패 세트(api-catalog·carrier-settings·boot-minimization)만 재현
- [x] Changelog: `.changelog.d/pr-451.md` — fleet-plugin 그룹, Added 2·Changed 1, 이중언어, 컴파일러 검증 통과