### PR TITLE
fix(core-ai-gateway): echo client-requested model id in gateway responses

### DIFF
--- a/packages/core-ai-gateway/src/anthropic.ts
+++ b/packages/core-ai-gateway/src/anthropic.ts
@@ -514,6 +514,8 @@ interface OpenBlock {
 export interface ClaudeResponseCompatibilityOptions {
   /** Picker-advertised window that decides whether Claude uses its 1M compatibility path. */
   readonly contextWindow?: number;
+  /** Rewrites the echoed response model to the client-requested id. */
+  readonly model?: string;
 }
 
 /** 비스트리밍 요청에 돌려줄 Anthropic Messages 응답 본문을 이벤트에서 조립한다. */
@@ -536,7 +538,7 @@ export async function collectAnthropicMessage(
     switch (event.type) {
       case "response.created":
         id = event.response.id;
-        model = event.response.model;
+        model = options.model ?? event.response.model;
         inputTokens = event.response.usage?.input_tokens ?? 0;
         upstreamContextWindow = event.response.usage?.context_window;
         break;
@@ -665,7 +667,7 @@ export async function* encodeAnthropicSse(
               type: "message",
               role: "assistant",
               content: [],
-              model: event.response.model,
+              model: options.model ?? event.response.model,
               stop_reason: null,
               stop_sequence: null,
               usage: {

--- a/packages/core-ai-gateway/src/gateway.ts
+++ b/packages/core-ai-gateway/src/gateway.ts
@@ -61,13 +61,17 @@ export class AnthropicMessagesGateway {
           "cache-control": "no-cache",
           "content-type": "text/event-stream; charset=utf-8"
         }),
-        body: encodeAnthropicSse(upstream.events, { contextWindow: options.contextWindow })
+        body: encodeAnthropicSse(upstream.events, {
+          contextWindow: options.contextWindow,
+          model: request.model,
+        })
       };
     }
 
     // Claude Code는 일부 요청을 비스트리밍으로 보낸다. 그때는 이벤트를 모아 단일 Messages 응답을 준다.
-    const message = await collectAnthropicMessage(upstream.events, canonical.model, {
+    const message = await collectAnthropicMessage(upstream.events, request.model, {
       contextWindow: options.contextWindow,
+      model: request.model,
     });
     return {
       status: upstream.status,

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -1386,6 +1386,46 @@ describe("non-streaming requests", () => {
   });
 });
 
+describe("response model rewrite", () => {
+  const adapterEchoing = (): AiGatewayAdapter => ({
+    async stream() {
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        events: iterable<CanonicalResponseEvent>([
+          { type: "response.created", response: { id: "resp_model", model: "grok-4.5-fast", usage: null } },
+          { type: "response.output_text.delta", item_id: "m", output_index: 0, content_index: 0, delta: "hi" },
+          {
+            type: "response.completed",
+            response: { id: "resp_model", model: "grok-4.5-fast", usage: { input_tokens: 3, output_tokens: 4 } },
+          },
+        ]),
+      };
+    },
+  });
+
+  it("rewrites the streamed message_start model to the client-requested id", async () => {
+    const request = { ...baseRequest(), model: "claude-gateway--cursor--grok-4.5-fast[1m]" };
+    const response = await new AnthropicMessagesGateway(adapterEchoing()).stream(request, { apiKey: "k" });
+    const frames = parseSse(await collectBody(response.body));
+    const start = frames.find((item) => item.event === "message_start");
+
+    expect(start?.data).toMatchObject({
+      message: { model: "claude-gateway--cursor--grok-4.5-fast[1m]" },
+    });
+  });
+
+  it("rewrites the non-streaming response model to the client-requested id", async () => {
+    const request = { ...baseRequest(), model: "claude-gateway--cursor--grok-4.5-fast[1m]", stream: false };
+    const response = await new AnthropicMessagesGateway(adapterEchoing()).stream(request, { apiKey: "k" });
+
+    expect(JSON.parse(await collectBody(response.body))).toMatchObject({
+      model: "claude-gateway--cursor--grok-4.5-fast[1m]",
+    });
+  });
+});
+
 describe("upstream errors", () => {
   it("maps an OpenAI error to Anthropic shape while preserving its HTTP status", async () => {
     const adapter = new OpenAIResponsesAdapter({


### PR DESCRIPTION
## Summary
- Claude Gateway Operation 세션 재개 시 `Session model grok-4.5-fast could not be restored` 경고가 발생하던 원인을 수정합니다.
- 원인: 게이트웨이가 업스트림 어댑터의 응답 `model`을 원문 중계해, Cursor 경로에서 bare 업스트림 ID(`grok-4.5-fast`)가 Claude Code 세션 파일에 기록됐습니다. Claude Code는 `claude` 접두가 없는 ID를 인식하지 못해 resume 시 폴리백했습니다.
- 수정: 게이트웨이 공용 경계(`AnthropicMessagesGateway.stream`)에서 스트리밍(`message_start`)·비스트리밍 양쪽 응답의 `model`을 클라이언트가 요청한 원본 ID(`request.model`, 예: `claude-gateway--cursor--grok-4.5-fast[1m]`)로 재작성합니다. 요청 측 변환(업스트림 wire ID)은 변경하지 않습니다.

## Test Plan
- [x] `pnpm run typecheck` (core-ai-gateway) — pass
- [x] `pnpm run build` (core-ai-gateway) — pass
- [x] `pnpm run test` (core-ai-gateway) — 148/148 pass (회귀 테스트 2건 신설: 스트리밍/비스트리밍 응답 model 재작성)
- [x] terminal 플러그인 테스트 — 502/502 pass
- [x] 호스트 diff 정밀검수(Artifact Inspection Gate) — pass

## Changelog
- [x] `no-changelog` — unreleased #455(`Added` 단계)의 날부 교정으로, 사용자가 소비한 적 없는 동작의 수정이므로 별도 프래그먼트를 만들지 않습니다.