### PR TITLE
fix(core-ai-gateway): signal context overflow to Claude Code

### DIFF
--- a/.changelog.d/pr-461.md
+++ b/.changelog.d/pr-461.md
@@ -1,0 +1,11 @@
+### fleet-plugin
+#### Added
+- [fleet-console] The AI Gateway answers a context-exhausted turn with the `Prompt is too long: N tokens > M maximum` signal Claude Code needs to compact and continue, and carries each model's real usable window independently of the `[1m]` accounting coordinate so a native Cursor model is guarded too.
+  ko: AI Gateway가 컨텍스트를 소진한 턴에 Claude Code가 컴팩트 후 이어가는 데 필요한 `Prompt is too long: N tokens > M maximum` 신호로 응답하고, 각 모델의 실제 사용 가능 창을 `[1m]` 회계 좌표와 무관하게 전달해 Cursor 네이티브 모델도 보호합니다.
+- [fleet-console] A gateway failure that happens after the response headers were sent now ends with a terminal SSE `error` frame carrying the reason, instead of silently truncating the stream.
+  ko: 응답 헤더 전송 후 발생한 게이트웨이 실패가 스트림을 무음으로 자르지 않고, 사유를 담은 종단 SSE `error` 프레임으로 종료됩니다.
+
+### fleet-core
+#### Added
+- [core-ai-gateway] The gateway refuses an over-window turn before calling upstream, and sizes only the tools an adapter actually serializes so a large declared tool catalog cannot lock a model out.
+  ko: 게이트웨이가 창을 넘는 턴을 상류 호출 전에 거절하며, 어댑터가 실제로 직렬화하는 툴만 계산해 선언된 툴 카탈로그가 크다는 이유로 모델이 잠기지 않습니다.

--- a/packages/core-ai-gateway/src/canonical.ts
+++ b/packages/core-ai-gateway/src/canonical.ts
@@ -314,6 +314,13 @@ export interface AiGatewayAdapterCapabilities {
 
 export interface AiGatewayAdapter {
   readonly capabilities?: AiGatewayAdapterCapabilities;
+  /**
+   * The declared tools this adapter actually serializes upstream for the request.
+   * Adapters that drop or cap the declared catalog must implement it so pre-flight
+   * sizing measures the real upstream payload instead of the canonical declaration.
+   * Omitting it means every declared tool reaches the wire unchanged.
+   */
+  wireTools?(request: CanonicalResponseRequest): readonly CanonicalFunctionTool[];
   stream(
     request: CanonicalResponseRequest,
     options: AdapterCallOptions

--- a/packages/core-ai-gateway/src/cursor-adapter.ts
+++ b/packages/core-ai-gateway/src/cursor-adapter.ts
@@ -15,6 +15,7 @@ import type {
   AdapterCallOptions,
   AdapterResponse,
   AiGatewayAdapter,
+  CanonicalFunctionTool,
   CanonicalInputItem,
   CanonicalNativeTool,
   CanonicalResponseEvent,
@@ -1171,6 +1172,25 @@ export class CursorAdapter implements AiGatewayAdapter {
     this.diagnostics = options.diagnostics;
     this.conversationIdOverride = options.conversationId;
     this.sessionIdOverride = options.sessionId;
+  }
+
+  /**
+   * Cursor drops every `defer_loading` tool once the client advertises ToolSearch and
+   * then caps the survivors by count and bytes, so the declared catalog is far larger
+   * than the wire payload. Report only the survivors; charging a request for tools that
+   * never leave the gateway would refuse turns the provider would have accepted.
+   */
+  wireTools(request: CanonicalResponseRequest): readonly CanonicalFunctionTool[] {
+    const declared = request.tools ?? [];
+    if (declared.length === 0) return [];
+    let keptNames: ReadonlySet<string>;
+    try {
+      keptNames = new Set(applyCursorToolBudget(request).tools.map((tool) => tool.clientName));
+    } catch {
+      // A budget rejection belongs to `stream`, which raises it with the real diagnosis.
+      return [];
+    }
+    return declared.filter((tool) => keptNames.has(tool.name));
   }
 
   async stream(

--- a/packages/core-ai-gateway/src/gateway.ts
+++ b/packages/core-ai-gateway/src/gateway.ts
@@ -3,13 +3,40 @@ import type {
   AnthropicMessagesRequest,
   TranslateAnthropicRequestOptions
 } from "./anthropic.js";
-import type { AiGatewayAdapter } from "./canonical.js";
+import { canonicalMessageText } from "./canonical.js";
+import type {
+  AiGatewayAdapter,
+  CanonicalFunctionTool,
+  CanonicalResponseRequest,
+} from "./canonical.js";
 import { OpenAIResponsesAdapter } from "./openai-responses-adapter.js";
+import { estimateTokens } from "./token-estimate.js";
+
+/** Claude Code recognizes this prefix and routes the failed turn through reactive compaction. */
+export class ContextWindowExceededError extends Error {
+  constructor(
+    readonly requestTokens: number,
+    readonly contextWindow: number,
+  ) {
+    super(`Prompt is too long: ${requestTokens} tokens > ${contextWindow} maximum`);
+    this.name = "ContextWindowExceededError";
+  }
+}
 
 export interface AnthropicGatewayCallOptions extends TranslateAnthropicRequestOptions {
   apiKey: string;
-  /** Real provider window when the caller selected Claude Code's `[1m]` coordinate. */
+  /**
+   * Projection denominator for Claude Code's own context meter. Set ONLY when the
+   * caller selected Claude Code's `[1m]` coordinate; it rescales reported usage
+   * onto the 1M axis and is never a limit.
+   */
   contextWindow?: number;
+  /**
+   * The model's real usable context window. Always set by the caller, regardless of
+   * whether the `[1m]` coordinate applies, and used only by the pre-flight overflow
+   * guard — never as a projection denominator.
+   */
+  modelContextWindow?: number;
   /** 새로 여는 provider trace가 진단 이벤트를 낼지 결정한다. 생략하면 adapter 기본값을 유지한다. */
   diagnosticsEnabled?: boolean;
   signal?: AbortSignal;
@@ -37,6 +64,7 @@ export class AnthropicMessagesGateway {
         ? { nativeTools: this.adapter.capabilities.nativeTools }
         : {}),
     });
+    guardModelContextWindow(canonical, options.modelContextWindow, this.adapter);
     const upstream = await this.adapter.stream(canonical, {
       apiKey: options.apiKey,
       ...(options.diagnosticsEnabled === undefined
@@ -88,6 +116,68 @@ export class AnthropicMessagesGateway {
 
 async function* oneChunk(body: Uint8Array): AsyncGenerator<Uint8Array> {
   yield body;
+}
+
+/**
+ * Pre-flight overflow guard.
+ *
+ * Upstream providers report an overflow in provider-specific wire shapes we do not
+ * translate, so a turn that exceeds the model window can die without any text Claude
+ * Code can classify. Refusing the turn locally with the literal `Prompt is too long:`
+ * prefix keeps reactive compaction reachable.
+ *
+ * The estimate is a conservative character-based heuristic (see `estimateTokens`), not
+ * a tokenizer. It is a last-resort backstop behind correct window accounting, never the
+ * primary defence, so it only fires when the estimate is strictly over the window.
+ *
+ * Only the tools the adapter actually serializes upstream are counted. Cursor drops
+ * deferred tools and caps the rest, so counting the declared catalog would refuse turns
+ * whose real request is far under the window — and, because the catalog is re-declared
+ * every turn while reactive compaction only shrinks the conversation, a catalog large
+ * enough to overflow on its own would lock the model out permanently instead of
+ * degrading.
+ */
+function guardModelContextWindow(
+  canonical: CanonicalResponseRequest,
+  modelContextWindow: number | undefined,
+  adapter: AiGatewayAdapter,
+): void {
+  if (
+    typeof modelContextWindow !== "number"
+    || !Number.isFinite(modelContextWindow)
+    || modelContextWindow <= 0
+  ) {
+    return;
+  }
+  const wireTools = adapter.wireTools?.(canonical) ?? canonical.tools ?? [];
+  const requestTokens = estimateCanonicalRequestTokens(canonical, wireTools);
+  if (requestTokens > modelContextWindow) {
+    throw new ContextWindowExceededError(requestTokens, modelContextWindow);
+  }
+}
+
+/** Deterministic character-based input estimate over instructions, input items, and tools. */
+function estimateCanonicalRequestTokens(
+  canonical: CanonicalResponseRequest,
+  wireTools: readonly CanonicalFunctionTool[],
+): number {
+  const parts: string[] = [];
+  if (canonical.instructions !== undefined) parts.push(canonical.instructions);
+  for (const item of canonical.input) {
+    if (item.type === "message") {
+      parts.push(canonicalMessageText(item.content));
+    } else if (item.type === "function_call") {
+      parts.push(item.name, item.arguments);
+    } else {
+      parts.push(item.output);
+    }
+  }
+  for (const tool of wireTools) {
+    parts.push(tool.name);
+    if (tool.description !== undefined) parts.push(tool.description);
+    parts.push(JSON.stringify(tool.parameters));
+  }
+  return estimateTokens(parts.join("\n"), canonical.model);
 }
 
 function translateUpstreamError(body: Uint8Array): {

--- a/packages/core-ai-gateway/tests/cursor-adapter.test.ts
+++ b/packages/core-ai-gateway/tests/cursor-adapter.test.ts
@@ -228,6 +228,56 @@ describe("Cursor request budgets", () => {
     ]);
   });
 
+  it("reports only the tools Cursor actually puts on the wire", () => {
+    const canonical = request({
+      tools: [
+        tool("ToolSearch"),
+        tool("Read"),
+        { ...tool("mcp__fleet__carrier_dispatch"), defer_loading: true },
+        { ...tool("mcp__fleet__carrier_jobs"), defer_loading: true },
+      ],
+    });
+    const plan = buildCursorRunPlan(canonical, "conversation-wire-tools");
+
+    // The pre-flight sizing view must agree with the payload, not the declaration.
+    expect(new CursorAdapter().wireTools(canonical).map((entry) => entry.name)).toEqual([
+      "ToolSearch",
+      "Read",
+    ]);
+    expect(runRequest(plan).mcpTools?.mcpTools).toHaveLength(2);
+  });
+
+  it("reports the capped survivors when the declared catalog overruns the byte budget", () => {
+    const canonical = request({
+      tools: [
+        tool("ToolSearch"),
+        ...Array.from(
+          { length: 40 },
+          (_, index) => tool(`mcp__bulk__tool_${index}`, "d".repeat(8_000)),
+        ),
+      ],
+    });
+
+    const reported = new CursorAdapter().wireTools(canonical);
+    const wire = runRequest(buildCursorRunPlan(canonical, "conversation-wire-cap"))
+      .mcpTools?.mcpTools ?? [];
+
+    expect(reported.length).toBeLessThan(41);
+    expect(reported).toHaveLength(wire.length);
+  });
+
+  it("defers a tool-budget rejection to the streaming path instead of pre-flight sizing", () => {
+    const canonical = request({
+      // The selected tool alone overruns the byte budget, so no catalog can carry it.
+      tools: [tool("mcp__bulk__oversized", "d".repeat(CURSOR_TOOL_BYTES_LIMIT + 1))],
+      tool_choice: { type: "function", name: "mcp__bulk__oversized" },
+    });
+
+    expect(() => buildCursorRunPlan(canonical, "conversation-wire-throw"))
+      .toThrow(CursorRequestBudgetError);
+    expect(new CursorAdapter().wireTools(canonical)).toEqual([]);
+  });
+
   it("caps every tool catalog while retaining execution-critical tools", () => {
     const filler = Array.from({ length: CURSOR_TOOL_COUNT_LIMIT + 20 }, (_, index) => tool(`mcp__filler__tool_${index}`));
     const tools = [

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -17,6 +17,8 @@ import {
   toGatewayModelAlias,
   DEFAULT_CODEX_MODEL,
   CHATGPT_CODEX_RESPONSES_URL,
+  ContextWindowExceededError,
+  CursorAdapter,
   OPENAI_RESPONSES_URL,
   OpenAIResponsesAdapter,
   UpstreamBodyLimitError,
@@ -1460,6 +1462,212 @@ describe("upstream errors", () => {
 
     expect(response.status).toBe(529);
     expect(await collectBody(response.body)).toBe(raw);
+  });
+});
+
+describe("pre-flight context window guard", () => {
+  /** Claude Code 2.1.220's own extraction regex for reactive compaction. */
+  const CLAUDE_OVERFLOW_RE = /prompt is too long[^0-9]*(\d+)\s*tokens?\s*>\s*(\d+)/i;
+  /** 4 chars/token for a non-code model id, so this estimates 300_000 tokens. */
+  const OVERFLOW_CHARS = 1_200_000;
+
+  function guardedGateway(): {
+    gateway: AnthropicMessagesGateway;
+    calls: () => number;
+  } {
+    let calls = 0;
+    const adapter: AiGatewayAdapter = {
+      async stream() {
+        calls += 1;
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          events: iterable<CanonicalResponseEvent>([
+            { type: "response.created", response: { id: "resp_guard", model: "gpt-5.6-sol", usage: null } },
+            { type: "response.completed", response: { id: "resp_guard", model: "gpt-5.6-sol", usage: { input_tokens: 1, output_tokens: 1 } } },
+          ]),
+        };
+      },
+    };
+    return { gateway: new AnthropicMessagesGateway(adapter), calls: () => calls };
+  }
+
+  function requestOfChars(chars: number): AnthropicMessagesRequest {
+    return {
+      model: "claude-sonnet-4-6",
+      messages: [{ role: "user", content: "x".repeat(chars) }],
+      max_tokens: 128,
+      stream: true,
+    };
+  }
+
+  it("refuses a turn whose estimate exceeds the model's real window", async () => {
+    const { gateway, calls } = guardedGateway();
+
+    await expect(gateway.stream(requestOfChars(OVERFLOW_CHARS), {
+      apiKey: "k",
+      modelContextWindow: 272_000,
+    })).rejects.toBeInstanceOf(ContextWindowExceededError);
+    // Upstream must never see the overflowing turn.
+    expect(calls()).toBe(0);
+  });
+
+  it("emits the exact literal Claude Code classifies for reactive compaction", async () => {
+    const { gateway } = guardedGateway();
+
+    const error = await gateway.stream(requestOfChars(OVERFLOW_CHARS), {
+      apiKey: "k",
+      modelContextWindow: 272_000,
+    }).then(() => undefined, (thrown: unknown) => thrown);
+
+    expect(error).toBeInstanceOf(ContextWindowExceededError);
+    const overflow = error as ContextWindowExceededError;
+    expect(overflow.name).toBe("ContextWindowExceededError");
+    expect(overflow.message).toMatch(/^Prompt is too long: \d+ tokens > \d+ maximum$/);
+    // Claude Code's three classifiers: prefix, lowercased substring, numeric extraction.
+    expect(overflow.message.startsWith("Prompt is too long")).toBe(true);
+    expect(overflow.message.toLowerCase()).toContain("prompt is too long");
+    const match = CLAUDE_OVERFLOW_RE.exec(overflow.message);
+    expect(match).not.toBeNull();
+    expect(Number(match?.[1])).toBe(overflow.requestTokens);
+    expect(Number(match?.[2])).toBe(overflow.contextWindow);
+    expect(overflow.contextWindow).toBe(272_000);
+    expect(overflow.requestTokens).toBeGreaterThan(272_000);
+  });
+
+  it("passes a turn that fits inside the model's real window", async () => {
+    const { gateway, calls } = guardedGateway();
+
+    const response = await gateway.stream(requestOfChars(4_000), {
+      apiKey: "k",
+      modelContextWindow: 272_000,
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls()).toBe(1);
+  });
+
+  it("is skipped entirely when no model window is supplied", async () => {
+    const { gateway, calls } = guardedGateway();
+
+    const response = await gateway.stream(requestOfChars(OVERFLOW_CHARS), { apiKey: "k" });
+
+    expect(response.status).toBe(200);
+    expect(calls()).toBe(1);
+  });
+
+  it("is skipped for a non-positive model window", async () => {
+    const { gateway, calls } = guardedGateway();
+
+    await gateway.stream(requestOfChars(OVERFLOW_CHARS), { apiKey: "k", modelContextWindow: 0 });
+
+    expect(calls()).toBe(1);
+  });
+
+  it("counts system instructions and tool definitions, not only messages", async () => {
+    const { gateway, calls } = guardedGateway();
+    const request: AnthropicMessagesRequest = {
+      model: "claude-sonnet-4-6",
+      system: [{ type: "text", text: "s".repeat(80_000) }],
+      messages: [{ role: "user", content: "x".repeat(20_000) }],
+      tools: [{
+        name: "read_file",
+        description: "d".repeat(80_000),
+        input_schema: { type: "object", properties: {} },
+      }],
+      max_tokens: 128,
+      stream: true,
+    };
+
+    // Messages alone estimate ~5_000 tokens, well under the window.
+    await expect(gateway.stream(request, { apiKey: "k", modelContextWindow: 10_000 }))
+      .rejects.toBeInstanceOf(ContextWindowExceededError);
+    expect(calls()).toBe(0);
+
+    await expect(gateway.stream(requestOfChars(20_000), { apiKey: "k", modelContextWindow: 10_000 }))
+      .resolves.toMatchObject({ status: 200 });
+  });
+
+  it("charges only the tools the adapter reports as reaching the wire", async () => {
+    const seen: string[][] = [];
+    const narrowed: AiGatewayAdapter = {
+      wireTools(canonical) {
+        const tools = canonical.tools ?? [];
+        seen.push(tools.map((entry) => entry.name));
+        return tools.filter((entry) => entry.name === "kept");
+      },
+      async stream() {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          events: iterable<CanonicalResponseEvent>([
+            { type: "response.created", response: { id: "resp_wire", model: "m", usage: null } },
+          ]),
+        };
+      },
+    };
+    const request: AnthropicMessagesRequest = {
+      model: "claude-sonnet-4-6",
+      messages: [{ role: "user", content: "hi" }],
+      tools: [
+        { name: "kept", description: "d", input_schema: { type: "object", properties: {} } },
+        { name: "dropped", description: "d".repeat(200_000), input_schema: { type: "object", properties: {} } },
+      ],
+      max_tokens: 128,
+      stream: true,
+    };
+
+    // The dropped tool alone estimates ~50_000 tokens; charging it would refuse the turn.
+    await expect(new AnthropicMessagesGateway(narrowed).stream(request, {
+      apiKey: "k",
+      modelContextWindow: 10_000,
+    })).resolves.toMatchObject({ status: 200 });
+    expect(seen).toEqual([["kept", "dropped"]]);
+  });
+
+  it("does not lock a Cursor model out over a catalog Cursor never sends", async () => {
+    const cursor = new CursorAdapter();
+    let calls = 0;
+    const adapter: AiGatewayAdapter = {
+      capabilities: cursor.capabilities,
+      wireTools: (canonical) => cursor.wireTools(canonical),
+      async stream() {
+        calls += 1;
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          events: iterable<CanonicalResponseEvent>([
+            { type: "response.created", response: { id: "resp_cursor", model: "composer-2.5", usage: null } },
+          ]),
+        };
+      },
+    };
+    // ToolSearch plus a deferred catalog far larger than the window, and a two-character turn.
+    const request: AnthropicMessagesRequest = {
+      model: "claude-sonnet-4-6",
+      messages: [{ role: "user", content: "hi" }],
+      tools: [
+        { name: "ToolSearch", description: "search", input_schema: { type: "object", properties: {} } },
+        ...Array.from({ length: 200 }, (_, index) => ({
+          name: `mcp__deferred__tool_${index}`,
+          description: "d".repeat(7_700),
+          input_schema: { type: "object" as const, properties: {} },
+          defer_loading: true,
+        })),
+      ],
+      max_tokens: 128,
+      stream: true,
+    };
+
+    // Compaction shrinks the conversation, never the catalog, so charging it is unrecoverable.
+    await expect(new AnthropicMessagesGateway(adapter).stream(request, {
+      apiKey: "k",
+      modelContextWindow: 200_000,
+    })).resolves.toMatchObject({ status: 200 });
+    expect(calls).toBe(1);
   });
 });
 

--- a/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import {
   AnthropicMessagesGateway,
   CHATGPT_CODEX_RESPONSES_URL,
+  ContextWindowExceededError,
   CursorAdapter,
   CursorRequestBudgetError,
   CursorSessionIdentityError,
@@ -244,9 +245,17 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps = {}): AiGatewayR
       const diagnosticsEnabled = target.provider === "cursor"
         ? await cursorDiagnosticsEnabled()
         : undefined;
+      // The real usable window is independent of the `[1m]` accounting coordinate:
+      // a 200000-window Cursor model carries no marker but still needs the guard.
+      const modelContextWindow = typeof target.contextWindow === "number"
+        && Number.isFinite(target.contextWindow)
+        && target.contextWindow > 0
+        ? target.contextWindow
+        : undefined;
       const upstream = await gateway.stream(body, {
         apiKey: credential,
         ...(claudeContextWindow ? { contextWindow: claudeContextWindow } : {}),
+        ...(modelContextWindow === undefined ? {} : { modelContextWindow }),
         ...(diagnosticsEnabled === undefined ? {} : { diagnosticsEnabled }),
         signal: controller.signal,
         model: upstreamModelId(target),
@@ -264,19 +273,19 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps = {}): AiGatewayR
       }
       res.end();
     } catch (error) {
-      // 헤더를 이미 보낸 뒤의 실패는 스트림을 끊는 것 말고 알릴 방법이 없다.
+      const invalidRequest = error instanceof CursorRequestBudgetError
+        || error instanceof CursorSessionIdentityError
+        || error instanceof UnsupportedReasoningEffortError
+        || error instanceof ContextWindowExceededError;
+      const type = invalidRequest ? "invalid_request_error" : "api_error";
+      const message = errorMessage(error);
       if (res.headersSent) {
+        // 헤더를 보낸 뒤에는 상태 코드를 바꿀 수 없다. 그냥 끊으면 클라이언트는
+        // 오류 문구 없는 잘린 스트림만 보므로, 종단 SSE error 프레임으로 사유를 남긴다.
+        writeSseErrorFrame(res, type, message);
         res.end();
       } else {
-        const invalidRequest = error instanceof CursorRequestBudgetError
-          || error instanceof CursorSessionIdentityError
-          || error instanceof UnsupportedReasoningEffortError;
-        writeAnthropicError(
-          res,
-          invalidRequest ? 400 : 502,
-          invalidRequest ? "invalid_request_error" : "api_error",
-          errorMessage(error),
-        );
+        writeAnthropicError(res, invalidRequest ? 400 : 502, type, message);
       }
     } finally {
       req.off("close", abort);
@@ -556,6 +565,26 @@ function writeAnthropicError(
 ): void {
   res.writeHead(status, { "content-type": "application/json" });
   res.end(JSON.stringify({ type: "error", error: { type, message } }));
+}
+
+/**
+ * 헤더 전송 후의 유일한 통지 수단. 메시지에 따옴표/개행이 있어도 안전하도록 JSON.stringify로만 만든다.
+ *
+ * 선행 `\n\n`은 생략할 수 없다. passthrough 경로는 상류 네트워크 청크를 그대로 흘리므로
+ * 마지막 청크가 프레임 중간에서 끊길 수 있고, 그 뒤에 곧바로 이어 붙이면 잘린 data 줄에
+ * 융합되어 클라이언트 JSON 파싱이 깨진다. 이미 경계에 있을 때 덧붙는 빈 줄은 무해하다.
+ */
+function writeSseErrorFrame(
+  res: { write(chunk: string): boolean },
+  type: string,
+  message: string,
+): void {
+  try {
+    const data = JSON.stringify({ type: "error", error: { type, message } });
+    res.write(`\n\nevent: error\ndata: ${data}\n\n`);
+  } catch {
+    // 프레임 작성 자체가 실패해도 응답 종료는 막지 않는다.
+  }
 }
 
 function errorMessage(error: unknown): string {

--- a/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
@@ -1,6 +1,7 @@
 import {
   AnthropicMessagesGateway,
   CURSOR_EXTERNAL_ROOT_BYTE_LIMIT,
+  ContextWindowExceededError,
   CursorAdapter,
 } from "@dotobokuri/core-ai-gateway";
 import type {
@@ -377,6 +378,155 @@ describe("upstream credential", () => {
       error: {
         type: "invalid_request_error",
         message: expect.stringMatching(/^Prompt is too long:/),
+      },
+    });
+  });
+});
+
+describe("model context window", () => {
+  it.each([
+    // The real usable window travels for every translated model, marked or not.
+    ["claude-gateway--codex--gpt-5.6-sol", 372_000, 372_000],
+    ["claude-gateway--cursor--grok-4.5-fast", 256_000, 256_000],
+    // A 200000-window Cursor native model earns no `[1m]` marker, so it gets no
+    // projection denominator — but the guard still needs its real window.
+    ["claude-gateway--cursor--kimi-k3", 200_000, undefined],
+  ])("passes %s's real window as modelContextWindow", async (model, expected, projected) => {
+    const gateway = stubGateway();
+    const streamSpy = vi.spyOn(gateway, "stream");
+    const router = createAiGatewayRouter({
+      gateway,
+      readAuth,
+      readCursorToken: () => "cursor-subscription-token",
+    });
+
+    await router.handle(ctx({ res: response(), token: ANTHROPIC_CRED, model }));
+
+    expect(streamSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      modelContextWindow: expected,
+    }));
+    const options = streamSpy.mock.calls[0]?.[1];
+    if (projected === undefined) {
+      expect(options).not.toHaveProperty("contextWindow");
+    } else {
+      expect(options).toHaveProperty("contextWindow", projected);
+    }
+  });
+
+  it("answers a pre-flight overflow with Claude's prompt-too-long contract", async () => {
+    const gateway = stubGateway();
+    const streamSpy = vi.spyOn(gateway, "stream");
+    const router = createAiGatewayRouter({ gateway, readAuth });
+    const res = response();
+
+    await router.handle(ctx({
+      res,
+      token: ANTHROPIC_CRED,
+      model: "claude-gateway--codex--gpt-5.6-sol",
+      // 4 chars/token puts this at ~500_000 tokens against a 372_000 window.
+      messages: [{ role: "user", content: "x".repeat(2_000_000) }],
+    }));
+
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        message: expect.stringMatching(/^Prompt is too long: \d+ tokens > 372000 maximum$/),
+      },
+    });
+    // The guard runs inside the gateway, so upstream was still spared the turn.
+    expect(streamSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("mid-stream failure", () => {
+  function failingGateway(error: unknown): AnthropicMessagesGateway {
+    return {
+      async stream() {
+        return {
+          status: 200,
+          headers: new Headers({ "content-type": "text/event-stream" }),
+          body: (async function* () {
+            yield new TextEncoder().encode("event: message_start\ndata: {}\n\n");
+            throw error;
+          })(),
+        };
+      },
+    } as unknown as AnthropicMessagesGateway;
+  }
+
+  function errorFrame(body: string): unknown {
+    const data = body.split("event: error\ndata: ")[1]?.split("\n\n")[0];
+    return JSON.parse(data ?? "null");
+  }
+
+  it("emits a terminal SSE error frame instead of a bare end", async () => {
+    const router = createAiGatewayRouter({
+      gateway: failingGateway(new Error('upstream died: "quoted"\nsecond line')),
+      readAuth,
+    });
+    const res = response();
+
+    await router.handle(ctx({ res, token: ANTHROPIC_CRED }));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toContain("event: message_start");
+    expect(res.body).toContain("event: error\n");
+    // Hand-concatenation would break on the quote and the newline.
+    expect(errorFrame(res.body)).toEqual({
+      type: "error",
+      error: { type: "api_error", message: 'upstream died: "quoted"\nsecond line' },
+    });
+  });
+
+  it("keeps the error frame out of a truncated passthrough chunk", async () => {
+    // Passthrough forwards raw upstream chunks, so the last one can stop mid-frame.
+    const truncated = 'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,'
+      + '"delta":{"type":"text_delta","text":"Hel';
+    const router = createAiGatewayRouter({
+      gateway: {
+        async stream() {
+          return {
+            status: 200,
+            headers: new Headers({ "content-type": "text/event-stream" }),
+            body: (async function* () {
+              yield new TextEncoder().encode(truncated);
+              throw new Error("upstream socket reset");
+            })(),
+          };
+        },
+      } as unknown as AnthropicMessagesGateway,
+      readAuth,
+    });
+    const res = response();
+
+    await router.handle(ctx({ res, token: ANTHROPIC_CRED }));
+
+    const blocks = res.body.split("\n\n").filter((block) => block.length > 0);
+    // Without a leading separator the two would fuse into one unparseable frame.
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toBe(truncated);
+    expect(JSON.parse(blocks[1]?.split("data: ")[1] ?? "null")).toEqual({
+      type: "error",
+      error: { type: "api_error", message: "upstream socket reset" },
+    });
+  });
+
+  it("marks a mid-stream context overflow as an invalid request", async () => {
+    const router = createAiGatewayRouter({
+      gateway: failingGateway(new ContextWindowExceededError(300_000, 272_000)),
+      readAuth,
+    });
+    const res = response();
+
+    await router.handle(ctx({ res, token: ANTHROPIC_CRED }));
+
+    expect(errorFrame(res.body)).toEqual({
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        message: "Prompt is too long: 300000 tokens > 272000 maximum",
       },
     });
   });


### PR DESCRIPTION
## Summary

- Claude Code 2.1.220은 auto-compact 창이 `auto` 출처로 결정되면 **턴 이전 임계 기반 자동 컴팩트를 끄고** reactive compaction에 위임합니다. reactive compaction은 실패한 턴의 에러 문구가 `Prompt is too long`으로 시작하고 `N tokens > M` 쌍을 담고 있을 때만 발동합니다. Codex·Cursor 경로 모두 그런 신호를 만들지 않아, 컨텍스트가 소진된 세션은 분류 불가능한 상류 에러로 죽고 수동 `/compact`가 필요했습니다.
- Cursor 경로는 더 나쁩니다. 어댑터가 실패 응답(`ok:false`)을 한 번도 반환하지 않고 모든 실패를 throw하는데, 스트리밍 턴은 이미 헤더가 나간 뒤라 catch가 맨 `res.end()`로 끝냈습니다 — 클라이언트는 **에러 문구 없는 잘린 스트림**만 받았습니다. 게다가 Cursor의 유일한 기존 초과 신호는 외부 모델 전용이라 `default`/`auto`/`composer-*` 네이티브 모델은 무방비였습니다.
- provider 무관 사전 차단 가드를 추가해 창을 넘는 턴을 상류 호출 전에 `ContextWindowExceededError`로 거절하고, `[1m]` 투영 좌표와 분리된 모델 실제 창(`modelContextWindow`)을 게이트웨이까지 전달하며, 스트림 중 무음 절단을 종단 SSE `error` 프레임으로 대체합니다.
- 가드는 어댑터가 **실제로 전송하는** 툴만 과금합니다. Cursor는 `defer_loading` 툴을 전부 버리고 나머지를 개수/바이트로 캡하므로, 선언된 카탈로그를 세면 전송량이 창의 극히 일부인 턴을 거절하고 — 카탈로그는 매 턴 재선언되는데 컴팩트는 대화만 줄이므로 — 모델이 영구 잠금될 수 있었습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 162 passed (+11 신규)
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `pnpm --filter @fleet-plugins/terminal test` — 520 passed (+7 신규)
- [x] `pnpm --filter @fleet-plugins/terminal build`
- [x] `pnpm check:core-boundary`
- [x] 빌드된 `dist`에서 발생 메시지를 Claude Code의 판정기 3종에 직접 통과시켜 실증: `Prompt is too long: 265950 tokens > 272000 maximum` → prefix ✓ / substring ✓ / `N tokens > M` 추출 `{actual:265950, limit:272000}` ✓
- [x] Changelog fragment — `.changelog.d/pr-461.md` 추가, grouped product/section 문법과 이중언어 요약 준수, `node scripts/compile-changelog-fragments.mjs --check` 통과 (27 entries validated)
