### PR TITLE
fix(fleet-console): distinguish classic agent operations

### DIFF
--- a/.changelog.d/pr-462.md
+++ b/.changelog.d/pr-462.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Changed
+- [fleet-console] Distinguish classic Claude and Codex canvas Operations from AI Gateway Operations.
+  ko: 기존 Claude와 Codex 캔버스 Operation을 AI Gateway Operation과 구분해 표시합니다.

--- a/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
@@ -12,10 +12,14 @@ export function buildAgentCliLaunchKinds(
       return {
         id: cli.id,
         type: operationType,
-        title: cli.label,
+        title: resolveOperationTitle(cli),
         ...(disabledReason ? { disabled: true, disabledReason } : {}),
       };
     });
+}
+
+function resolveOperationTitle(cli: AgentCliLaunchMetadata): string {
+  return cli.id === "claude" || cli.id === "codex" ? `${cli.label} (Classic)` : cli.label;
 }
 
 function resolveDisabledReason(cli: AgentCliLaunchMetadata): string | undefined {

--- a/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
@@ -14,8 +14,8 @@ describe("buildAgentCliLaunchKinds", () => {
     );
 
     expect(result).toEqual([
-      { id: "claude", type: "agent", title: "Claude" },
-      { id: "codex", type: "agent", title: "Codex" },
+      { id: "claude", type: "agent", title: "Claude (Classic)" },
+      { id: "codex", type: "agent", title: "Codex (Classic)" },
       { id: "claude-gateway", type: "agent", title: "Claude (Gateway • Experimental)" },
     ]);
   });
@@ -30,8 +30,8 @@ describe("buildAgentCliLaunchKinds", () => {
     );
 
     expect(result).toEqual([
-      { id: "claude", type: "agent", title: "Claude", disabled: true, disabledReason: "Not installed" },
-      { id: "codex", type: "agent", title: "Codex", disabled: true, disabledReason: "Sign in required" },
+      { id: "claude", type: "agent", title: "Claude (Classic)", disabled: true, disabledReason: "Not installed" },
+      { id: "codex", type: "agent", title: "Codex (Classic)", disabled: true, disabledReason: "Sign in required" },
     ]);
   });
 });


### PR DESCRIPTION
## Summary

- Label the existing Claude and Codex canvas launch entries as `Claude (Classic)` and `Codex (Classic)` to distinguish them from AI Gateway Operations.
- Preserve the durable IDs (`claude`, `codex`), launch routing, shared CLI metadata, and the existing AI Gateway label.

## Type of Change

- [x] fix — bug fix

## Scope

- [x] `runtime/fleet-plugins/terminal`

## Test Plan

- [x] `pnpm --filter @fleet-plugins/terminal test -- agent-cli-launch-kinds.test.ts`
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `pnpm --filter @fleet-plugins/terminal build`

## Changelog

- [x] Added `.changelog.d/pr-462.md`.
- [x] Fragment uses grouped `fleet-plugin` / `Changed` syntax with bilingual summaries.
- [x] `node scripts/compile-changelog-fragments.mjs --check` passes.