### PR TITLE
feat(core-ai-gateway): meter Claude Code against a model's compaction budget

### DIFF
--- a/.changelog.d/pr-463.md
+++ b/.changelog.d/pr-463.md
@@ -1,0 +1,9 @@
+### fleet-plugin
+#### Added
+- [fleet-console] The AI Gateway meters a Codex session against the budget the Codex CLI itself compacts at, so a session compacts where a native Codex session would instead of running toward the larger window the backend still accepts.
+  ko: AI Gateway가 Codex 세션을 Codex CLI 자신이 컴팩트하는 예산 기준으로 계측해, 백엔드가 아직 수용하는 더 큰 창까지 달려가지 않고 네이티브 Codex 세션과 같은 지점에서 컴팩트합니다.
+
+### fleet-core
+#### Added
+- [core-ai-gateway] A model may declare `autoCompactThreshold`, the occupancy its provider's reference client compacts at, and the gateway projects Claude Code's context meter onto that budget while the pre-flight overflow guard keeps measuring against `contextWindow`. A model that declares no threshold keeps metering against its real window.
+  ko: 모델이 제공자 레퍼런스 클라이언트의 컴팩트 지점인 `autoCompactThreshold`를 선언할 수 있고, 게이트웨이는 Claude Code의 컨텍스트 계기를 그 예산에 투영하는 한편 사전 차단 가드는 계속 `contextWindow` 기준으로 측정합니다. 임계를 선언하지 않은 모델은 실제 창 기준 계측을 유지합니다.

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -5,12 +5,13 @@
     "codex": {
       "name": "Codex",
       "defaultModel": "gpt-5.6-sol",
-      "source": "codex app-server model/list (codex-cli 0.146.0, 2026-08-01)",
+      "source": "codex app-server model/list (codex-cli 0.146.0, 2026-08-01); autoCompactThreshold = context_window x effective_context_window_percent from codex debug models (codex-cli 0.146.0, 2026-08-02)",
       "models": [
         {
           "modelId": "gpt-5.6-sol",
           "name": "GPT-5.6-Sol",
           "contextWindow": 372000,
+          "autoCompactThreshold": 258400,
           "effort": {
             "supported": true,
             "levels": [
@@ -32,6 +33,7 @@
           "providerModelId": "gpt-5.6-sol",
           "serviceTier": "priority",
           "contextWindow": 372000,
+          "autoCompactThreshold": 258400,
           "effort": {
             "supported": true,
             "levels": [
@@ -51,6 +53,7 @@
           "modelId": "gpt-5.6-terra",
           "name": "GPT-5.6-Terra",
           "contextWindow": 372000,
+          "autoCompactThreshold": 258400,
           "effort": {
             "supported": true,
             "levels": [
@@ -72,6 +75,7 @@
           "providerModelId": "gpt-5.6-terra",
           "serviceTier": "priority",
           "contextWindow": 372000,
+          "autoCompactThreshold": 258400,
           "effort": {
             "supported": true,
             "levels": [
@@ -91,6 +95,7 @@
           "modelId": "gpt-5.6-luna",
           "name": "GPT-5.6-Luna",
           "contextWindow": 372000,
+          "autoCompactThreshold": 258400,
           "effort": {
             "supported": true,
             "levels": [
@@ -111,6 +116,7 @@
           "providerModelId": "gpt-5.6-luna",
           "serviceTier": "priority",
           "contextWindow": 372000,
+          "autoCompactThreshold": 258400,
           "effort": {
             "supported": true,
             "levels": [

--- a/packages/core-ai-gateway/src/models.ts
+++ b/packages/core-ai-gateway/src/models.ts
@@ -48,6 +48,7 @@ const GatewayModelEntrySchema = z.object({
   cursorMaxMode: z.literal(true).optional(),
   aliases: z.array(z.string().min(1)).optional(),
   contextWindow: z.number().int().positive().optional(),
+  autoCompactThreshold: z.number().int().positive().optional(),
   effort: GatewayModelEffortSchema.optional(),
 }).strict();
 
@@ -98,6 +99,12 @@ export interface GatewayModel {
   readonly description?: string;
   /** Authoritative input context window reported by the provider/reference catalog. */
   readonly contextWindow?: number;
+  /**
+   * Occupancy at which the provider's own reference client compacts, when it operates
+   * below the model's real window. It is the coordinate Claude Code is told to meter
+   * against — never the hard limit, which stays {@link contextWindow}.
+   */
+  readonly autoCompactThreshold?: number;
   /** Model-specific reasoning ladder. Missing registry metadata is treated as unsupported. */
   readonly effort: GatewayModelEffort;
   /** Accepted request ids that are intentionally omitted from discovery. */
@@ -145,16 +152,32 @@ export function toGatewayModelAlias(modelId: string): string {
 }
 
 /**
+ * The window Claude Code is told to meter its context against.
+ *
+ * A provider whose reference client compacts below the model's real window
+ * publishes that budget as `autoCompactThreshold`; metering against it makes a
+ * gateway session compact where a native session of that provider would, instead
+ * of running into the hard limit. Everything else keeps metering against the real
+ * window. This is an accounting coordinate, never a limit — the pre-flight
+ * overflow guard still measures against {@link GatewayModel.contextWindow}.
+ */
+export function claudeAccountingWindow(model: GatewayModel): number | undefined {
+  return model.autoCompactThreshold ?? model.contextWindow;
+}
+
+/**
  * Claude Code only understands its default 200k coordinate and a `[1m]`
- * coordinate. Translated models above 200k use the latter while the gateway
- * projects their response usage. Native Kimi passthrough only opts in when its
- * real window is at least 1M, so a synthetic long-context beta never reaches a
- * sub-1M Anthropic-compatible upstream.
+ * coordinate. Translated models whose accounting window is above 200k use the
+ * latter while the gateway projects their response usage onto it. The marker must
+ * follow the same quantity the projection divides by, or Claude Code would meter
+ * on the 1M axis while usage was scaled by a different window. Native Kimi
+ * passthrough additionally requires a real window of at least 1M, so a synthetic
+ * long-context beta never reaches a sub-1M Anthropic-compatible upstream.
  */
 export function toClaudeGatewayModelId(model: GatewayModel): string {
   const alias = toGatewayModelAlias(model.id);
   if (
-    canProjectClaudeContextWindow(model.contextWindow)
+    canProjectClaudeContextWindow(claudeAccountingWindow(model))
     && (model.provider !== "kimi" || isClaudeOneMillionContextWindow(model.contextWindow))
   ) {
     return `${alias}${CLAUDE_ONE_MILLION_MARKER}`;
@@ -359,6 +382,7 @@ function toGatewayModel(
     ...(entry.cursorMaxMode ? { cursorMaxMode: entry.cursorMaxMode } : {}),
     ...(entry.description ? { description: entry.description } : {}),
     ...(entry.contextWindow ? { contextWindow: entry.contextWindow } : {}),
+    ...(entry.autoCompactThreshold ? { autoCompactThreshold: entry.autoCompactThreshold } : {}),
     effort: freezeGatewayModelEffort(entry.effort),
     ...(entry.aliases ? { aliases: Object.freeze([...entry.aliases]) } : {}),
   };

--- a/packages/core-ai-gateway/src/models.ts
+++ b/packages/core-ai-gateway/src/models.ts
@@ -414,6 +414,17 @@ function validateRegistry(value: GatewayModelsRegistry): void {
       if (model.cursorMaxMode && provider !== "cursor") {
         throw new Error(`Gateway Cursor Max Mode is only supported by Cursor: ${provider}/${model.modelId}`);
       }
+      // 회계 창이 실제 창을 넘으면 Claude Code가 점유를 과소 보고해, 컴팩트 대신
+      // 사전 차단 가드에 부딪힌다. 임계는 창의 부분집합이어야만 의미가 있으므로
+      // 잘못된 레지스트리 편집을 조용히 통과시키지 않고 파싱 시점에 세운다.
+      if (model.autoCompactThreshold !== undefined) {
+        if (model.contextWindow === undefined) {
+          throw new Error(`Gateway auto-compact threshold requires contextWindow: ${provider}/${model.modelId}`);
+        }
+        if (model.autoCompactThreshold > model.contextWindow) {
+          throw new Error(`Gateway auto-compact threshold exceeds contextWindow: ${provider}/${model.modelId}`);
+        }
+      }
       if (model.effort?.supported) {
         if (new Set(model.effort.levels).size !== model.effort.levels.length) {
           throw new Error(`Gateway effort levels contain duplicates: ${provider}/${model.modelId}`);

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -7,6 +7,7 @@ import {
   KIMI_SUBSCRIPTION_MODELS,
   buildAnthropicModelList,
   clampReasoningEffort,
+  claudeAccountingWindow,
   findGatewayModel,
   parseGatewayModelsRegistry,
   projectAnthropicResponseUsage,
@@ -31,7 +32,8 @@ import type {
   AnthropicMessagesRequest,
   CanonicalResponseRequest,
   CanonicalResponseEvent,
-  FetchLike
+  FetchLike,
+  GatewayModel
 } from "../src/index.js";
 
 describe("Anthropic request translation", () => {
@@ -495,6 +497,8 @@ describe("model catalog", () => {
     expect(KIMI_SUBSCRIPTION_MODELS).toHaveLength(2);
     expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.upstreamId?.startsWith("gpt-5.6-"))).toBe(true);
     expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.contextWindow === 372_000)).toBe(true);
+    // Codex compacts well below the window its backend accepts, so the two differ.
+    expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.autoCompactThreshold === 258_400)).toBe(true);
     expect(CURSOR_SUBSCRIPTION_MODELS.map((model) => model.upstreamId)).toEqual([
       "default",
       "composer-2.5",
@@ -755,6 +759,49 @@ describe("model catalog", () => {
       id: "claude-gateway--kimi--k3-256k",
       max_input_tokens: 262_144,
     }));
+  });
+});
+
+describe("Claude accounting window", () => {
+  const model = (over: Partial<GatewayModel>): GatewayModel => ({
+    id: "codex--probe",
+    displayName: "Codex-Probe",
+    provider: "codex",
+    effort: { supported: false, levels: [] },
+    ...over,
+  } as GatewayModel);
+
+  it("meters against the declared compaction threshold, not the real window", () => {
+    expect(claudeAccountingWindow(model({ contextWindow: 372_000, autoCompactThreshold: 258_400 })))
+      .toBe(258_400);
+  });
+
+  it("falls back to the real window when no threshold is declared", () => {
+    expect(claudeAccountingWindow(model({ contextWindow: 256_000 }))).toBe(256_000);
+    expect(claudeAccountingWindow(model({}))).toBeUndefined();
+  });
+
+  it("keeps the 1M marker on a Codex model whose threshold still clears 200k", () => {
+    const codex = CODEX_SUBSCRIPTION_MODELS[0]!;
+    expect(codex.autoCompactThreshold).toBe(258_400);
+    expect(toClaudeGatewayModelId(codex).endsWith("[1m]")).toBe(true);
+  });
+
+  it("withholds the 1M marker when the threshold drops to Claude's default coordinate", () => {
+    // The marker must follow the projection denominator. A model whose real window
+    // clears 200k but whose accounting window does not would otherwise make Claude
+    // Code meter on the 1M axis while usage was scaled by a sub-200k window.
+    const throttled = model({ id: "codex--throttled", contextWindow: 372_000, autoCompactThreshold: 200_000 });
+    expect(claudeAccountingWindow(throttled)).toBe(200_000);
+    expect(toClaudeGatewayModelId(throttled).endsWith("[1m]")).toBe(false);
+  });
+
+  it("projects a full accounting window onto Claude Code's 1M coordinate", () => {
+    // Claude Code compacts at 967_000 of its 1M axis, which is 249_872 real tokens
+    // here — inside the 235k-247k band real Codex sessions were measured to occupy,
+    // and far below the 372_000 the backend would still accept.
+    expect(projectClaudeContextInputTokens(258_400, 258_400)).toBe(1_000_000);
+    expect(Math.floor(967_000 * 258_400 / 1_000_000)).toBe(249_872);
   });
 });
 

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -437,6 +437,36 @@ describe("model catalog", () => {
     };
     expect(() => parseGatewayModelsRegistry(invalidTier)).toThrow(/only supported by Codex/);
 
+    // 임계는 실제 창의 부분집합일 때만 의미가 있다. 창 없이 선언하거나 창을 넘기면
+    // Claude Code가 도달 불가능한 예산으로 계측하게 되므로 파싱에서 막는다.
+    const thresholdWithoutWindow = minimalRegistry();
+    thresholdWithoutWindow.providers.codex.models[0] = {
+      modelId: "codex-model",
+      name: "Model",
+      autoCompactThreshold: 258_400,
+    };
+    expect(() => parseGatewayModelsRegistry(thresholdWithoutWindow))
+      .toThrow(/auto-compact threshold requires contextWindow/);
+
+    const thresholdOverWindow = minimalRegistry();
+    thresholdOverWindow.providers.codex.models[0] = {
+      modelId: "codex-model",
+      name: "Model",
+      contextWindow: 200_000,
+      autoCompactThreshold: 258_400,
+    };
+    expect(() => parseGatewayModelsRegistry(thresholdOverWindow))
+      .toThrow(/auto-compact threshold exceeds contextWindow/);
+
+    const thresholdAtWindow = minimalRegistry();
+    thresholdAtWindow.providers.codex.models[0] = {
+      modelId: "codex-model",
+      name: "Model",
+      contextWindow: 258_400,
+      autoCompactThreshold: 258_400,
+    };
+    expect(() => parseGatewayModelsRegistry(thresholdAtWindow)).not.toThrow();
+
     const legacyEffortDefault = minimalRegistry();
     legacyEffortDefault.providers.codex.models[0] = {
       modelId: "codex-model",

--- a/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
@@ -16,6 +16,7 @@ import {
   UnsupportedReasoningEffortError,
   buildAnthropicModelList,
   clampReasoningEffort,
+  claudeAccountingWindow,
   findGatewayModel,
   hasClaudeOneMillionMarker,
   projectAnthropicResponseUsage,
@@ -221,9 +222,10 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps = {}): AiGatewayR
       // Claude Code may strip the discovery-only `[1m]` suffix before sending a
       // request. Derive its accounting coordinate from the resolved registry
       // model so every alias for the same Cursor/Codex model projects usage in
-      // the same way.
+      // the same way. The coordinate is the accounting window, not the real one:
+      // a provider that compacts below its hard limit meters against that budget.
       const claudeContextWindow = hasClaudeOneMillionMarker(toClaudeGatewayModelId(target))
-        ? target.contextWindow
+        ? claudeAccountingWindow(target)
         : undefined;
       if (target.provider === "kimi") {
         await proxyToKimi(
@@ -246,7 +248,8 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps = {}): AiGatewayR
         ? await cursorDiagnosticsEnabled()
         : undefined;
       // The real usable window is independent of the `[1m]` accounting coordinate:
-      // a 200000-window Cursor model carries no marker but still needs the guard.
+      // a 200000-window Cursor model carries no marker but still needs the guard,
+      // and a Codex model meters against a lower budget than it can actually hold.
       const modelContextWindow = typeof target.contextWindow === "number"
         && Number.isFinite(target.contextWindow)
         && target.contextWindow > 0

--- a/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
@@ -160,7 +160,7 @@ describe("upstream credential", () => {
 
     expect(streamSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
       apiKey: SUBSCRIPTION_TOKEN,
-      contextWindow: 372_000,
+      contextWindow: 258_400,
       model: "gpt-5.6-sol",
       serviceTier: "priority",
       reasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
@@ -182,7 +182,7 @@ describe("upstream credential", () => {
 
     expect(res.status).toBe(200);
     expect(streamSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
-      contextWindow: 372_000,
+      contextWindow: 258_400,
     }));
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -385,8 +385,10 @@ describe("upstream credential", () => {
 
 describe("model context window", () => {
   it.each([
-    // The real usable window travels for every translated model, marked or not.
-    ["claude-gateway--codex--gpt-5.6-sol", 372_000, 372_000],
+    // The guard always gets the real window; the projection gets the accounting
+    // window. Codex meters against its reference client's compaction budget, so the
+    // two differ; a model without a declared threshold keeps them equal.
+    ["claude-gateway--codex--gpt-5.6-sol", 372_000, 258_400],
     ["claude-gateway--cursor--grok-4.5-fast", 256_000, 256_000],
     // A 200000-window Cursor native model earns no `[1m]` marker, so it gets no
     // projection denominator — but the guard still needs its real window.


### PR DESCRIPTION
## Summary

- 레지스트리의 숫자 하나가 두 가지 일을 겸하고 있었습니다. `contextWindow`가 **모델이 담을 수 있는 양**과 **세션이 컴팩트해야 할 시점**을 동시에 뜻해서, 안전 여백이 저작된 결정이 아니라 1M 투영 산술의 부산물로 남았습니다. Claude Code의 예비값은 절대 상수(13k/20k/3k)라 투영 배율만큼 축소되고, 그 결과 Codex 세션은 compact 임계에서 실제 창까지 12,276 토큰밖에 남지 않았습니다.
- 둘을 분리합니다. `contextWindow`는 모델의 실제 창으로 남아 사전 차단 가드와 discovery를 계속 지지합니다. 신설한 선택 필드 `autoCompactThreshold`가 **제공자 자신의 레퍼런스 클라이언트가 컴팩트하는 예산**을 싣고, 게이트웨이는 이 값을 Claude Code의 1M 좌표에 투영합니다.
- Codex는 `258400`을 선언합니다 — 카탈로그 `context_window`(272000) × `effective_context_window_percent`(95). 최근 Codex CLI 세션 60개를 실측한 결과 턴별 점유 정점이 **246,674에서 천장이 끊기고** 그 위로 올라간 세션이 없습니다. 따라서 게이트웨이 세션은 이제 **~249,873 실토큰**에서 컴팩트합니다 — 네이티브 Codex 세션과 같은 지점이며, 백엔드가 아직 수용하는 372,000까지 달려가지 않습니다.
- 임계를 선언하지 않은 제공자는 실제 창으로 계속 계측하므로 **Cursor·Kimi 동작은 완전히 동일**합니다.
- `[1m]` 마커 판정을 실제 창이 아니라 회계 창 기준으로 옮겼습니다. 마커와 투영 분모는 같은 수치여야 합니다 — 실제 창은 200k를 넘는데 예산이 200k 이하인 모델이 생기면, Claude Code가 1M 축에서 재는데 usage는 sub-200k 창으로 스케일되어 좌표가 깨집니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 167 passed (+5 신규)
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `pnpm --filter @fleet-plugins/terminal test` — 520 passed
- [x] `pnpm --filter @fleet-plugins/terminal build`
- [x] `pnpm check:core-boundary`
- [x] 변경 유발 실패는 Codex 투영 분모 3건뿐이었고 전부 새 계약으로 갱신 — 약화·삭제된 단언 0건
- [x] 빌드된 `dist`로 실효 좌표 실증:

```
model id      : claude-gateway--codex--gpt-5.6-sol-fast[1m]
real window   : 372000  (pre-flight guard basis)
accounting win: 258400  (projection denominator)
  real 240000 -> projected  928793  ok
  real 249872 -> projected  966997  warn      <- compact 발동 직전
  real 258400 -> projected 1000000  blocked
```

- [x] Changelog fragment — `.changelog.d/pr-463.md` 추가, grouped product/section 문법과 이중언어 요약 준수, `node scripts/compile-changelog-fragments.mjs --check` 통과 (29 entries validated)

## Notes

`258400`은 `272000 x 95%`로 **파생한** 값입니다. Codex 바이너리는 네이티브라 계산식을 직접 읽어내지 못했고, 관측 천장 246,674가 방증합니다. 파생값이 틀리더라도 방향은 안전합니다 — 과소면 조금 일찍 컴팩트할 뿐이고, 하드 한도는 여전히 372000 기준 사전 차단 가드가 지킵니다.
