### PR TITLE
fix(core-ai-gateway): preserve Codex usage details

### DIFF
--- a/.changelog.d/pr-466.md
+++ b/.changelog.d/pr-466.md
@@ -1,0 +1,4 @@
+### fleet-core
+#### Added
+- [core-ai-gateway] Preserve Codex cache and reasoning usage details while keeping Anthropic token accounting consistent across streaming and non-streaming responses.
+  ko: 스트리밍 및 비스트리밍 응답에서 Anthropic 토큰 회계를 일관되게 유지하면서 Codex 캐시 및 추론 사용량 세부 정보를 보존합니다.

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -5,7 +5,7 @@
     "codex": {
       "name": "Codex",
       "defaultModel": "gpt-5.6-sol",
-      "source": "codex app-server model/list (codex-cli 0.146.0, 2026-08-01); autoCompactThreshold = context_window x effective_context_window_percent from codex debug models (codex-cli 0.146.0, 2026-08-02)",
+      "source": "codex app-server model/list (codex-cli 0.146.0, 2026-08-01) for model/effort/service-tier only; contextWindow=372000 is a retained operational value pending authenticated backend verification; autoCompactThreshold=258400 is a reproducible accounting threshold from codex debug models (codex-cli 0.146.0, 2026-08-02): 272000 x 95%",
       "models": [
         {
           "modelId": "gpt-5.6-sol",

--- a/packages/core-ai-gateway/src/anthropic.ts
+++ b/packages/core-ai-gateway/src/anthropic.ts
@@ -8,6 +8,7 @@ import type {
   CanonicalResponseEvent,
   CanonicalResponseRequest,
   CanonicalToolChoice,
+  CanonicalUsage,
   ReasoningEffort,
 } from "./canonical.js";
 import {
@@ -518,6 +519,114 @@ export interface ClaudeResponseCompatibilityOptions {
   readonly model?: string;
 }
 
+interface AnthropicCacheAwareUsage {
+  readonly input_tokens: number;
+  readonly cache_read_input_tokens: number;
+  readonly cache_creation_input_tokens: number;
+  readonly output_tokens: number;
+}
+
+/**
+ * Convert an upstream input/output/cache breakdown into the Anthropic Messages usage shape.
+ *
+ * OpenAI's `input_tokens` already counts cache hits and cache writes as a subset, but
+ * Anthropic expects those tokens removed from `input_tokens` and reported separately
+ * through `cache_read_input_tokens` / `cache_creation_input_tokens` — Claude Code sums all
+ * three, so leaving the subset inside `input_tokens` would double count it. Both streaming
+ * (message_start, message_delta) and non-streaming callers share this conversion so their
+ * usage shapes never drift apart.
+ *
+ * When the 1M compatibility projection is active, the three input coordinates are scaled
+ * together (by the same ratio used for the plain input-only path) so their sum still equals
+ * the projected total input exactly.
+ */
+function toAnthropicCacheAwareUsage(
+  rawInputTokens: number,
+  cachedInputTokens: number | undefined,
+  cacheWriteInputTokens: number | undefined,
+  outputTokens: number,
+  advertisedContextWindow: number | undefined,
+  upstreamContextWindow: number | undefined,
+): AnthropicCacheAwareUsage {
+  const safeInputTokens = Number.isFinite(rawInputTokens) && rawInputTokens > 0 ? rawInputTokens : 0;
+
+  const projectedTotal = projectClaudeContextInputTokens(
+    safeInputTokens,
+    advertisedContextWindow,
+    upstreamContextWindow,
+  );
+
+  if (safeInputTokens === 0) {
+    return {
+      input_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      output_tokens: outputTokens,
+    };
+  }
+
+  const safeCacheRead = nonNegativeCacheValue(cachedInputTokens);
+  const safeCacheCreation = nonNegativeCacheValue(cacheWriteInputTokens);
+
+  // The upstream envelope can be self-inconsistent (cached + cache-write exceeding the
+  // parent input total) while still being well-typed; the canonical layer preserves that
+  // as-is rather than rejecting it. There is no principled way to decide which of
+  // cached/cache-write "wins" a truncation here, so inventing a read-over-write priority
+  // would just fabricate a number. Fall back to the authoritative parent total (raw, or
+  // projected when the 1M coordinate is active) with no cache breakdown at all instead.
+  if (safeCacheRead + safeCacheCreation > safeInputTokens) {
+    return {
+      input_tokens: projectedTotal,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      output_tokens: outputTokens,
+    };
+  }
+
+  if (projectedTotal === safeInputTokens) {
+    return {
+      input_tokens: safeInputTokens - safeCacheRead - safeCacheCreation,
+      cache_read_input_tokens: safeCacheRead,
+      cache_creation_input_tokens: safeCacheCreation,
+      output_tokens: outputTokens,
+    };
+  }
+
+  // Scale each cache coordinate by the same ratio as the total, flooring so the three
+  // parts can never overshoot the projected total; the remainder lands on input_tokens.
+  const scaledCacheRead = Math.floor((safeCacheRead * projectedTotal) / safeInputTokens);
+  const scaledCacheCreation = Math.floor((safeCacheCreation * projectedTotal) / safeInputTokens);
+  return {
+    input_tokens: projectedTotal - scaledCacheRead - scaledCacheCreation,
+    cache_read_input_tokens: scaledCacheRead,
+    cache_creation_input_tokens: scaledCacheCreation,
+    output_tokens: outputTokens,
+  };
+}
+
+function nonNegativeCacheValue(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return value;
+}
+
+/** Build the shared usage shape directly from a canonical response snapshot's usage. */
+function anthropicUsageFromCanonical(
+  usage: CanonicalUsage | null | undefined,
+  advertisedContextWindow: number | undefined,
+  options: { forceOutputZero?: boolean } = {},
+): AnthropicCacheAwareUsage {
+  return toAnthropicCacheAwareUsage(
+    usage?.input_tokens ?? 0,
+    usage?.cached_input_tokens,
+    usage?.cache_write_input_tokens,
+    options.forceOutputZero ? 0 : usage?.output_tokens ?? 0,
+    advertisedContextWindow,
+    usage?.context_window,
+  );
+}
+
 /** 비스트리밍 요청에 돌려줄 Anthropic Messages 응답 본문을 이벤트에서 조립한다. */
 export async function collectAnthropicMessage(
   events: AsyncIterable<CanonicalResponseEvent>,
@@ -532,6 +641,8 @@ export async function collectAnthropicMessage(
   let stopReason = "end_turn";
   let outputTokens = 0;
   let inputTokens = 0;
+  let cachedInputTokens: number | undefined;
+  let cacheWriteInputTokens: number | undefined;
   let upstreamContextWindow: number | undefined;
 
   for await (const event of events) {
@@ -540,6 +651,8 @@ export async function collectAnthropicMessage(
         id = event.response.id;
         model = options.model ?? event.response.model;
         inputTokens = event.response.usage?.input_tokens ?? 0;
+        cachedInputTokens = event.response.usage?.cached_input_tokens;
+        cacheWriteInputTokens = event.response.usage?.cache_write_input_tokens;
         upstreamContextWindow = event.response.usage?.context_window;
         break;
       case "response.output_text.delta":
@@ -566,6 +679,8 @@ export async function collectAnthropicMessage(
       case "response.completed":
         inputTokens = event.response.usage?.input_tokens ?? inputTokens;
         outputTokens = event.response.usage?.output_tokens ?? 0;
+        cachedInputTokens = event.response.usage?.cached_input_tokens ?? cachedInputTokens;
+        cacheWriteInputTokens = event.response.usage?.cache_write_input_tokens ?? cacheWriteInputTokens;
         upstreamContextWindow = event.response.usage?.context_window ?? upstreamContextWindow;
         break;
       case "response.failed":
@@ -591,14 +706,14 @@ export async function collectAnthropicMessage(
     model,
     stop_reason: stopReason,
     stop_sequence: null,
-    usage: {
-      input_tokens: projectClaudeContextInputTokens(
-        inputTokens,
-        options.contextWindow,
-        upstreamContextWindow,
-      ),
-      output_tokens: outputTokens,
-    },
+    usage: toAnthropicCacheAwareUsage(
+      inputTokens,
+      cachedInputTokens,
+      cacheWriteInputTokens,
+      outputTokens,
+      options.contextWindow,
+      upstreamContextWindow,
+    ),
   };
 }
 
@@ -670,14 +785,9 @@ export async function* encodeAnthropicSse(
               model: options.model ?? event.response.model,
               stop_reason: null,
               stop_sequence: null,
-              usage: {
-                input_tokens: projectClaudeContextInputTokens(
-                  event.response.usage?.input_tokens ?? 0,
-                  options.contextWindow,
-                  event.response.usage?.context_window,
-                ),
-                output_tokens: 0
-              }
+              usage: anthropicUsageFromCanonical(event.response.usage, options.contextWindow, {
+                forceOutputZero: true,
+              })
             }
           });
         }
@@ -800,19 +910,10 @@ export async function* encodeAnthropicSse(
             stop_reason: sawToolUse ? "tool_use" : "end_turn",
             stop_sequence: null
           },
-          usage: {
-            // Claude Code updates context occupancy from the terminal cumulative
-            // usage frame. Sending output-only leaves Responses-backed models at
-            // zero input usage even though Kimi's native Anthropic stream works.
-            input_tokens: projectClaudeContextInputTokens(
-              event.response.usage?.input_tokens ?? 0,
-              options.contextWindow,
-              event.response.usage?.context_window,
-            ),
-            output_tokens: event.response.usage?.output_tokens ?? 0,
-            cache_read_input_tokens: 0,
-            cache_creation_input_tokens: 0
-          }
+          // Claude Code updates context occupancy from the terminal cumulative
+          // usage frame. Sending output-only leaves Responses-backed models at
+          // zero input usage even though Kimi's native Anthropic stream works.
+          usage: anthropicUsageFromCanonical(event.response.usage, options.contextWindow)
         });
         yield encode("message_stop", { type: "message_stop" });
         messageStopped = true;

--- a/packages/core-ai-gateway/src/canonical.ts
+++ b/packages/core-ai-gateway/src/canonical.ts
@@ -190,6 +190,14 @@ export interface CanonicalUsage {
   output_tokens: number;
   /** Provider-reported total context limit for this concrete model turn, when available. */
   context_window?: number;
+  /** Subset of input_tokens served from an upstream prompt-cache hit. */
+  cached_input_tokens?: number;
+  /** Subset of input_tokens spent writing a new upstream prompt-cache entry. */
+  cache_write_input_tokens?: number;
+  /** Subset of output_tokens spent on hidden reasoning traces. */
+  reasoning_output_tokens?: number;
+  /** Provider-reported input_tokens + output_tokens total, when available. */
+  total_tokens?: number;
 }
 
 export interface CanonicalResponseSnapshot {

--- a/packages/core-ai-gateway/src/openai-responses-adapter.ts
+++ b/packages/core-ai-gateway/src/openai-responses-adapter.ts
@@ -466,9 +466,42 @@ function responseSnapshot(value: unknown): CanonicalResponseSnapshot {
 
 function usage(value: unknown): CanonicalUsage {
   const parsed = record(value, "usage");
+  const inputTokens = number(parsed.input_tokens, "usage.input_tokens");
+  const outputTokens = number(parsed.output_tokens, "usage.output_tokens");
+
+  const inputDetails = optionalRecord(parsed.input_tokens_details, "usage.input_tokens_details");
+  const cachedInputTokens = inputDetails === undefined
+    ? undefined
+    : optionalNonNegativeNumber(inputDetails.cached_tokens, "usage.input_tokens_details.cached_tokens");
+  const cacheWriteInputTokens = inputDetails === undefined
+    ? undefined
+    : optionalNonNegativeNumber(inputDetails.cache_write_tokens, "usage.input_tokens_details.cache_write_tokens");
+
+  const outputDetails = optionalRecord(parsed.output_tokens_details, "usage.output_tokens_details");
+  const reasoningOutputTokens = outputDetails === undefined
+    ? undefined
+    : optionalNonNegativeNumber(outputDetails.reasoning_tokens, "usage.output_tokens_details.reasoning_tokens");
+
+  const totalTokens = optionalNonNegativeNumber(parsed.total_tokens, "usage.total_tokens");
+
+  // cached_tokens/cache_write_tokens/reasoning_tokens are documented as subsets of their
+  // parent totals and total_tokens as their sum, but the ChatGPT subscription backend's
+  // real envelopes have not been observed to guarantee that arithmetic. Reject only
+  // malformed shape (wrong type / negative / non-finite) here; a self-inconsistent but
+  // well-typed envelope is preserved as-is on the canonical event rather than failing the
+  // whole response. reasoning_tokens/total_tokens never reach the Anthropic wire at all.
+  // cached_tokens/cache_write_tokens do reach it when consistent with input_tokens, but the
+  // Anthropic conversion layer (see toAnthropicCacheAwareUsage in anthropic.ts) falls back
+  // to the authoritative parent input total with no cache breakdown when the two exceed it,
+  // rather than inventing a read-over-write truncation priority.
+
   return {
-    input_tokens: number(parsed.input_tokens, "usage.input_tokens"),
-    output_tokens: number(parsed.output_tokens, "usage.output_tokens")
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    ...(cachedInputTokens === undefined ? {} : { cached_input_tokens: cachedInputTokens }),
+    ...(cacheWriteInputTokens === undefined ? {} : { cache_write_input_tokens: cacheWriteInputTokens }),
+    ...(reasoningOutputTokens === undefined ? {} : { reasoning_output_tokens: reasoningOutputTokens }),
+    ...(totalTokens === undefined ? {} : { total_tokens: totalTokens })
   };
 }
 
@@ -540,6 +573,14 @@ function record(value: unknown, name: string): Record<string, unknown> {
   return value;
 }
 
+/** Optional nested detail object. Absent or null means the field was never reported. */
+function optionalRecord(value: unknown, name: string): Record<string, unknown> | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  return record(value, name);
+}
+
 function string(value: unknown, name: string): string {
   if (typeof value !== "string") {
     throw new UpstreamProtocolError(`${name} must be a string`);
@@ -550,6 +591,17 @@ function string(value: unknown, name: string): string {
 function number(value: unknown, name: string): number {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     throw new UpstreamProtocolError(`${name} must be a number`);
+  }
+  return value;
+}
+
+/** Optional finite nonnegative detail count. Absent or null means the field was never reported. */
+function optionalNonNegativeNumber(value: unknown, name: string): number | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new UpstreamProtocolError(`${name} must be a finite nonnegative number`);
   }
   return value;
 }

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -24,6 +24,8 @@ import {
   OpenAIResponsesAdapter,
   UpstreamBodyLimitError,
   UpstreamIdleTimeoutError,
+  UpstreamProtocolError,
+  collectAnthropicMessage,
   encodeAnthropicSse,
   translateAnthropicRequest
 } from "../src/index.js";
@@ -1119,6 +1121,56 @@ describe("Anthropic SSE encoding", () => {
       usage: { input_tokens: 250_000, output_tokens: 1 },
     });
   });
+
+  it("preserves the projected input total when a cache breakdown rides the 1M coordinate", async () => {
+    const events = iterable<CanonicalResponseEvent>([
+      {
+        type: "response.created",
+        response: {
+          id: "resp_proj_cache",
+          model: "gpt-5.6-sol",
+          usage: {
+            input_tokens: 302_572,
+            output_tokens: 0,
+            cached_input_tokens: 100_000,
+            cache_write_input_tokens: 50_000,
+          },
+        },
+      },
+      {
+        type: "response.completed",
+        response: {
+          id: "resp_proj_cache",
+          model: "gpt-5.6-sol",
+          usage: {
+            input_tokens: 302_572,
+            output_tokens: 6_277,
+            cached_input_tokens: 100_000,
+            cache_write_input_tokens: 50_000,
+          },
+        },
+      },
+    ]);
+
+    const frames = parseSse(await collectBody(encodeAnthropicSse(events, { contextWindow: 372_000 })));
+    const messageDelta = frames.find((item) => item.event === "message_delta");
+    const usage = messageDelta?.data.usage as {
+      input_tokens: number;
+      cache_read_input_tokens: number;
+      cache_creation_input_tokens: number;
+      output_tokens: number;
+    };
+
+    // Same total as the plain (non-cache-aware) 1M projection test above: the
+    // breakdown must land on the identical coordinate, never inflate or shrink it.
+    expect(usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens).toBe(813_366);
+    expect(usage).toEqual({
+      input_tokens: 410_141,
+      cache_read_input_tokens: 268_817,
+      cache_creation_input_tokens: 134_408,
+      output_tokens: 6_277,
+    });
+  });
 });
 
 describe("OpenAI Responses adapter", () => {
@@ -1314,6 +1366,244 @@ describe("OpenAI Responses adapter", () => {
     const [url, init] = fetchMock.mock.calls[0] ?? [];
     expect(url).toBe(OPENAI_RESPONSES_URL);
     expect(new Headers(init?.headers).get("authorization")).toBe("Bearer injected-key");
+  });
+
+  it("carries a real OpenAI usage envelope end-to-end into matching streaming and non-streaming Anthropic usage", async () => {
+    const upstreamSse = [
+      frame("response.created", {
+        type: "response.created",
+        response: {
+          id: "resp_usage",
+          model: "gpt-5.6-sol",
+          usage: {
+            input_tokens: 1_000,
+            output_tokens: 0,
+            input_tokens_details: { cached_tokens: 400, cache_write_tokens: 100 }
+          }
+        }
+      }),
+      frame("response.completed", {
+        type: "response.completed",
+        response: {
+          id: "resp_usage",
+          model: "gpt-5.6-sol",
+          usage: {
+            input_tokens: 1_000,
+            output_tokens: 200,
+            input_tokens_details: { cached_tokens: 400, cache_write_tokens: 100 },
+            output_tokens_details: { reasoning_tokens: 50 },
+            total_tokens: 1_200
+          }
+        }
+      })
+    ].join("");
+    const fetchMock = vi.fn<FetchLike>(async () => sseResponse(upstreamSse));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+    const result = await adapter.stream(
+      { model: "gpt-5.6-sol", input: [], stream: true },
+      { apiKey: "k" }
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected a successful stream");
+    }
+    const events: CanonicalResponseEvent[] = [];
+    for await (const event of result.events) events.push(event);
+    const completed = events.find((event) => event.type === "response.completed");
+
+    expect(completed?.type).toBe("response.completed");
+    if (completed?.type !== "response.completed") {
+      throw new Error("expected a response.completed event");
+    }
+    // Parser field mapping: OpenAI's input_tokens_details/output_tokens_details/total_tokens
+    // land on the canonical event exactly as documented on CanonicalUsage.
+    expect(completed.response.usage).toEqual({
+      input_tokens: 1_000,
+      output_tokens: 200,
+      cached_input_tokens: 400,
+      cache_write_input_tokens: 100,
+      reasoning_output_tokens: 50,
+      total_tokens: 1_200
+    });
+
+    // Encoder mapping: OpenAI's input_tokens counts cache tokens as a subset, so the
+    // Anthropic encoder must remove them from input_tokens and surface them as
+    // cache_read/cache_creation instead, so Claude Code's own summation does not double
+    // count. reasoning_tokens/total_tokens must never reappear on the Anthropic wire.
+    const expectedAnthropicUsage = {
+      input_tokens: 500,
+      cache_read_input_tokens: 400,
+      cache_creation_input_tokens: 100,
+      output_tokens: 200
+    };
+
+    const streamedFrames = parseSse(await collectBody(encodeAnthropicSse(iterable(events))));
+    const messageStart = streamedFrames.find((item) => item.event === "message_start");
+    const messageDelta = streamedFrames.find((item) => item.event === "message_delta");
+    const collected = await collectAnthropicMessage(iterable(events), "gpt-5.6-sol");
+
+    expect(messageStart?.data).toMatchObject({
+      message: {
+        usage: {
+          cache_read_input_tokens: 400,
+          cache_creation_input_tokens: 100,
+          output_tokens: 0
+        }
+      }
+    });
+    // Streaming/non-streaming shape parity: both consumers of the same canonical
+    // events must agree on the final cache-aware Anthropic usage shape.
+    expect(messageDelta?.data).toMatchObject({ usage: expectedAnthropicUsage });
+    expect(collected.usage).toEqual(expectedAnthropicUsage);
+    expect(messageStart?.data).not.toHaveProperty("message.usage.reasoning_tokens");
+    expect(messageDelta?.data).not.toHaveProperty("usage.reasoning_tokens");
+    expect(messageDelta?.data).not.toHaveProperty("usage.total_tokens");
+    expect(collected.usage).not.toHaveProperty("reasoning_tokens");
+    expect(collected.usage).not.toHaveProperty("total_tokens");
+  });
+
+  it("tolerates an OpenAI usage envelope that omits every optional detail field", async () => {
+    const upstreamSse = frame("response.completed", {
+      type: "response.completed",
+      response: {
+        id: "resp_minimal",
+        model: "gpt-5.5",
+        usage: { input_tokens: 10, output_tokens: 5 }
+      }
+    });
+    const fetchMock = vi.fn<FetchLike>(async () => sseResponse(upstreamSse));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+    const result = await adapter.stream(
+      { model: "gpt-5.5", input: [], stream: true },
+      { apiKey: "k" }
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected a successful stream");
+    }
+    const events: CanonicalResponseEvent[] = [];
+    for await (const event of result.events) events.push(event);
+    const completed = events.find((event) => event.type === "response.completed");
+
+    expect(completed?.type).toBe("response.completed");
+    if (completed?.type !== "response.completed") {
+      throw new Error("expected a response.completed event");
+    }
+    expect(completed.response.usage).toEqual({ input_tokens: 10, output_tokens: 5 });
+  });
+
+  it.each([
+    [
+      "input_tokens_details.cached_tokens has the wrong type",
+      { input_tokens: 100, output_tokens: 10, input_tokens_details: { cached_tokens: "90" } }
+    ],
+    [
+      "input_tokens_details.cache_write_tokens is negative",
+      { input_tokens: 100, output_tokens: 10, input_tokens_details: { cache_write_tokens: -20 } }
+    ],
+    [
+      "output_tokens_details.reasoning_tokens is negative",
+      { input_tokens: 100, output_tokens: 10, output_tokens_details: { reasoning_tokens: -1 } }
+    ],
+    [
+      "output_tokens_details is not an object",
+      { input_tokens: 100, output_tokens: 10, output_tokens_details: "none" }
+    ],
+    [
+      "total_tokens has the wrong type",
+      { input_tokens: 100, output_tokens: 10, total_tokens: "1200" }
+    ]
+  ])("rejects a malformed OpenAI usage envelope: %s", async (_label, usage) => {
+    const upstreamSse = frame("response.completed", {
+      type: "response.completed",
+      response: { id: "resp_bad", model: "gpt-5.5", usage }
+    });
+    const fetchMock = vi.fn<FetchLike>(async () => sseResponse(upstreamSse));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+    const result = await adapter.stream(
+      { model: "gpt-5.5", input: [], stream: true },
+      { apiKey: "k" }
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected a successful stream");
+    }
+    await expect(collectEvents(result.events)).rejects.toThrow(UpstreamProtocolError);
+  });
+
+  it("preserves a self-inconsistent but well-typed OpenAI usage envelope instead of failing the response", async () => {
+    // The real ChatGPT subscription backend has not been observed to guarantee that
+    // cached/cache_write are mutually exclusive subsets of input_tokens, that
+    // reasoning_tokens never exceeds output_tokens, or that total_tokens always equals
+    // input_tokens + output_tokens, so a well-typed but arithmetically inconsistent envelope
+    // must be parsed through unchanged rather than failing the whole response.
+    // reasoning_tokens/total_tokens never reach the Anthropic wire. cached_tokens/
+    // cache_write_tokens do reach it when consistent with input_tokens, but here
+    // cached (90) + cache_write (20) exceeds input_tokens (100), so the Anthropic
+    // conversion must not invent a read-over-write truncation priority: it falls back to
+    // the authoritative parent input total with no cache breakdown at all.
+    const upstreamSse = frame("response.completed", {
+      type: "response.completed",
+      response: {
+        id: "resp_inconsistent",
+        model: "gpt-5.5",
+        usage: {
+          input_tokens: 100,
+          output_tokens: 10,
+          input_tokens_details: { cached_tokens: 90, cache_write_tokens: 20 },
+          output_tokens_details: { reasoning_tokens: 11 },
+          total_tokens: 999
+        }
+      }
+    });
+    const fetchMock = vi.fn<FetchLike>(async () => sseResponse(upstreamSse));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+    const result = await adapter.stream(
+      { model: "gpt-5.5", input: [], stream: true },
+      { apiKey: "k" }
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected a successful stream");
+    }
+    const events: CanonicalResponseEvent[] = [];
+    for await (const event of result.events) events.push(event);
+    const completed = events.find((event) => event.type === "response.completed");
+
+    expect(completed?.type).toBe("response.completed");
+    if (completed?.type !== "response.completed") {
+      throw new Error("expected a response.completed event");
+    }
+    // The canonical layer preserves the self-inconsistent detail values as parsed.
+    expect(completed.response.usage).toEqual({
+      input_tokens: 100,
+      output_tokens: 10,
+      cached_input_tokens: 90,
+      cache_write_input_tokens: 20,
+      reasoning_output_tokens: 11,
+      total_tokens: 999
+    });
+
+    const expectedFallbackUsage = {
+      input_tokens: 100,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      output_tokens: 10
+    };
+
+    const streamedFrames = parseSse(await collectBody(encodeAnthropicSse(iterable(events))));
+    const messageDelta = streamedFrames.find((item) => item.event === "message_delta");
+    const collected = await collectAnthropicMessage(iterable(events), "gpt-5.5");
+
+    // The Anthropic wire falls back to the parent input total with a zeroed cache
+    // breakdown, in both the streaming and non-streaming paths, instead of silently
+    // truncating cached/cache_write into a fabricated read-over-write split.
+    expect(messageDelta?.data).toMatchObject({ usage: expectedFallbackUsage });
+    expect(collected.usage).toEqual(expectedFallbackUsage);
   });
 
   it("bounds the total upstream stream body size", async () => {


### PR DESCRIPTION
## Summary
- Preserve Codex/OpenAI cache, reasoning, and total token details in the canonical gateway usage model.
- Translate consistent cache breakdowns into Anthropic usage fields without double-counting input tokens, with safe parent-total fallback for inconsistent upstream details.
- Align streaming and non-streaming usage envelopes and clarify the provenance of Codex context accounting values.

## Type of Change
- [x] fix — bug fix

## Scope
- [x] `packages/core-ai-gateway`

## Test Plan
- [x] `corepack pnpm --filter @dotobokuri/core-ai-gateway test` — 176 tests passed
- [x] `corepack pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `corepack pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `corepack pnpm check:core-boundary`
- [x] `git diff --check`

## Changelog
- [x] Added `.changelog.d/pr-466.md`.
- [x] Fragment uses grouped `fleet-core / Added` syntax with bilingual summaries.
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 30 entries validated.

## Notes for Reviewers
- The user explicitly excluded the 1M output-token projection issue from this change.
- `contextWindow=372000` remains unchanged; only its source description was corrected.
- Codex automated review is explicitly bypassed by user instruction for immediate merge.