### PR TITLE
fix(core-ai-gateway): support Codex web search

### DIFF
--- a/.changelog.d/pr-467.md
+++ b/.changelog.d/pr-467.md
@@ -1,0 +1,4 @@
+### fleet-core
+#### Added
+- [core-ai-gateway] Support Claude Code `Web Search` through Codex Responses with domain filters, source results, and explicit provider search errors.
+  ko: Codex Responses를 통해 Claude Code `Web Search`를 지원하며 도메인 필터, 출처 결과, 명시적인 제공자 검색 오류를 전달합니다.

--- a/packages/core-ai-gateway/src/anthropic.ts
+++ b/packages/core-ai-gateway/src/anthropic.ts
@@ -9,6 +9,7 @@ import type {
   CanonicalResponseRequest,
   CanonicalToolChoice,
   CanonicalUsage,
+  CanonicalWebSearchAction,
   ReasoningEffort,
 } from "./canonical.js";
 import {
@@ -240,6 +241,11 @@ function translateAnthropicTools(
     if (tool.type === "web_search_20250305" && tool.name === "web_search") {
       if (!supported.has("web_search")) {
         throw new TypeError("Selected adapter does not support Anthropic server tool web_search_20250305");
+      }
+      // Anthropic's own contract treats allowed_domains and blocked_domains as mutually
+      // exclusive; the OpenAI wire filter mirrors that (one filter, allow XOR block).
+      if (tool.allowed_domains !== undefined && tool.blocked_domains !== undefined) {
+        throw new TypeError("web_search allowed_domains and blocked_domains are mutually exclusive");
       }
       native.push({
         type: "web_search",
@@ -676,6 +682,25 @@ export async function collectAnthropicMessage(
         if (entry) entry.text = event.arguments;
         break;
       }
+      case "response.output_item.done":
+        // Provider-executed web search arrives whole at `done` — there is no argument-delta
+        // stream to accumulate the way client function calls have. It does not set tool_use
+        // as the stop reason: this is a server-side tool, not a client round-trip.
+        if (event.item.type === "web_search_call") {
+          const query = derivedWebSearchQuery(event.item.action);
+          content.push({
+            type: "server_tool_use",
+            id: event.item.id,
+            name: "web_search",
+            input: { query }
+          });
+          content.push({
+            type: "web_search_tool_result",
+            tool_use_id: event.item.id,
+            content: webSearchResultContent(event.item.status, event.item.action?.sources)
+          });
+        }
+        break;
       case "response.completed":
         inputTokens = event.response.usage?.input_tokens ?? inputTokens;
         outputTokens = event.response.usage?.output_tokens ?? 0;
@@ -895,6 +920,40 @@ export async function* encodeAnthropicSse(
           if (stop !== undefined) {
             yield stop;
           }
+        } else if (event.item.type === "web_search_call") {
+          // Provider-executed search arrives whole at `done` (never at `added`, which would
+          // race a partial action). It never marks sawToolUse: server tools keep stop_reason
+          // at end_turn, unlike a client tool_use round-trip.
+          const query = derivedWebSearchQuery(event.item.action);
+          const searchIndex = nextBlockIndex++;
+          yield encode("content_block_start", {
+            type: "content_block_start",
+            index: searchIndex,
+            content_block: {
+              type: "server_tool_use",
+              id: event.item.id,
+              name: "web_search",
+              input: {}
+            }
+          });
+          yield encode("content_block_delta", {
+            type: "content_block_delta",
+            index: searchIndex,
+            delta: { type: "input_json_delta", partial_json: JSON.stringify({ query }) }
+          });
+          yield encode("content_block_stop", { type: "content_block_stop", index: searchIndex });
+
+          const resultIndex = nextBlockIndex++;
+          yield encode("content_block_start", {
+            type: "content_block_start",
+            index: resultIndex,
+            content_block: {
+              type: "web_search_tool_result",
+              tool_use_id: event.item.id,
+              content: webSearchResultContent(event.item.status, event.item.action?.sources)
+            }
+          });
+          yield encode("content_block_stop", { type: "content_block_stop", index: resultIndex });
         }
         break;
       case "response.completed":
@@ -948,6 +1007,68 @@ function requiredToolBlock(blocks: Map<string, OpenBlock>, itemId: string): Open
 
 function remainingArguments(accumulated: string, complete: string): string {
   return complete.startsWith(accumulated) ? complete.slice(accumulated.length) : "";
+}
+
+/**
+ * Prefers the action's own query; falls back through the OpenAI live shape's other
+ * action variants without ever inventing a value. Information-lossless and stable
+ * so the same action always derives the same query.
+ */
+function derivedWebSearchQuery(action: CanonicalWebSearchAction | undefined): string {
+  if (action === undefined) {
+    return "";
+  }
+  if (typeof action.query === "string" && action.query.length > 0) {
+    return action.query;
+  }
+  if (Array.isArray(action.queries) && typeof action.queries[0] === "string" && action.queries[0].length > 0) {
+    return action.queries[0];
+  }
+  if (action.type === "open_page" && typeof action.url === "string") {
+    return action.url;
+  }
+  if (action.type === "find_in_page") {
+    if (typeof action.pattern === "string" && typeof action.url === "string") {
+      return `${action.pattern} ${action.url}`;
+    }
+    if (typeof action.pattern === "string") {
+      return action.pattern;
+    }
+  }
+  if (typeof action.url === "string") {
+    return action.url;
+  }
+  if (typeof action.pattern === "string") {
+    return action.pattern;
+  }
+  return "";
+}
+
+type WebSearchResultBlockContent =
+  | Array<{ type: "web_search_result"; url: string; title: string }>
+  | { type: "web_search_tool_result_error"; error_code: "unavailable" };
+
+/**
+ * OpenAI's confirmed schema allows `web_search_call.status` to land as anything but
+ * `completed` (`in_progress`/`searching`/`failed`) on `response.output_item.done`, and there
+ * is no item-level error code to translate. An explicit non-completed status is reported as
+ * Anthropic's `web_search_tool_result_error` (`unavailable`) rather than disguised as a
+ * successful empty result. `status === undefined` keeps the pre-existing success path for
+ * backward compatibility; `completed` with no sources is a genuine empty success result.
+ * `title` is the source's real reported title; a missing title falls back to the URL, never a fabricated string.
+ */
+function webSearchResultContent(
+  status: string | undefined,
+  sources: CanonicalWebSearchAction["sources"],
+): WebSearchResultBlockContent {
+  if (status !== undefined && status !== "completed") {
+    return { type: "web_search_tool_result_error", error_code: "unavailable" };
+  }
+  return (sources ?? []).map((source) => ({
+    type: "web_search_result" as const,
+    url: source.url,
+    title: source.title !== undefined && source.title.length > 0 ? source.title : source.url,
+  }));
 }
 
 function functionCallStart(item: CanonicalFunctionCallOutputItem, index: number): {

--- a/packages/core-ai-gateway/src/canonical.ts
+++ b/packages/core-ai-gateway/src/canonical.ts
@@ -220,9 +220,36 @@ export interface CanonicalFunctionCallOutputItem {
   arguments: string;
 }
 
+/** A source cited by a completed provider web search. Never fabricated: only what the provider reported. */
+export interface CanonicalWebSearchSource {
+  type: string;
+  url: string;
+  /** The provider's real page title, when it reported one. */
+  title?: string;
+}
+
+/** Provider-owned web search action. Shape varies by action type (search/open_page/find_in_page/...). */
+export interface CanonicalWebSearchAction {
+  type: string;
+  query?: string;
+  queries?: string[];
+  url?: string;
+  pattern?: string;
+  sources?: CanonicalWebSearchSource[];
+}
+
+/** A completed provider-executed web search, translated from the wire's `web_search_call` output item. */
+export interface CanonicalWebSearchCallOutputItem {
+  id: string;
+  type: "web_search_call";
+  status?: string;
+  action?: CanonicalWebSearchAction;
+}
+
 export type CanonicalOutputItem =
   | CanonicalMessageOutputItem
-  | CanonicalFunctionCallOutputItem;
+  | CanonicalFunctionCallOutputItem
+  | CanonicalWebSearchCallOutputItem;
 
 export type CanonicalResponseEvent =
   | {

--- a/packages/core-ai-gateway/src/openai-responses-adapter.ts
+++ b/packages/core-ai-gateway/src/openai-responses-adapter.ts
@@ -7,7 +7,11 @@ import type {
   CanonicalResponseEvent,
   CanonicalResponseRequest,
   CanonicalResponseSnapshot,
-  CanonicalUsage
+  CanonicalToolChoice,
+  CanonicalUsage,
+  CanonicalWebSearchAction,
+  CanonicalWebSearchCallOutputItem,
+  CanonicalWebSearchSource
 } from "./canonical.js";
 
 export const OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses";
@@ -32,6 +36,45 @@ export type FetchLike = (
   input: string | URL | Request,
   init?: RequestInit
 ) => Promise<Response>;
+
+/**
+ * OpenAI Responses wire shapes. The canonical model keeps `native_tools` as a
+ * provider-neutral list and `tool_choice` as a small closed union that has no member
+ * for a hosted tool selector, so this adapter's outbound payload is its own honest
+ * type rather than a reuse of `CanonicalResponseRequest`. `native_tools` never reaches
+ * the wire: it is merged into `tools`/`tool_choice` below and dropped.
+ */
+interface OpenAIResponsesWireFunctionTool {
+  type: "function";
+  name: string;
+  description?: string;
+  parameters: Record<string, unknown>;
+  strict?: boolean;
+}
+
+/**
+ * Live-probe confirmed (HTTP 200, one `web_search_call` with 17 sources): the OpenAI Responses
+ * hosted web search filter accepts either `allowed_domains` or `blocked_domains`, mirroring
+ * Anthropic's own mutually-exclusive pair. `max_uses` still has no confirmed wire field and is dropped.
+ */
+interface OpenAIResponsesWireWebSearchTool {
+  type: "web_search";
+  filters?: { allowed_domains: string[] } | { blocked_domains: string[] };
+}
+
+type OpenAIResponsesWireTool = OpenAIResponsesWireFunctionTool | OpenAIResponsesWireWebSearchTool;
+
+type OpenAIResponsesWireToolChoice = CanonicalToolChoice | { type: "web_search" };
+
+type OpenAIResponsesWireRequest = Omit<
+  CanonicalResponseRequest,
+  "tools" | "tool_choice" | "native_tools"
+> & {
+  tools?: OpenAIResponsesWireTool[];
+  tool_choice?: OpenAIResponsesWireToolChoice;
+  /** Requests extra output fields, e.g. `web_search_call.action.sources` for hosted web search results. */
+  include?: string[];
+};
 
 export interface OpenAIResponsesAdapterOptions {
   fetch?: FetchLike;
@@ -67,6 +110,7 @@ export class UpstreamProtocolError extends Error {
 }
 
 export class OpenAIResponsesAdapter implements AiGatewayAdapter {
+  readonly capabilities = { nativeTools: ["web_search"] } as const;
   private readonly fetchImpl: FetchLike;
   private readonly maxBodyBytes: number;
   private readonly idleTimeoutMs: number;
@@ -158,8 +202,16 @@ export class OpenAIResponsesAdapter implements AiGatewayAdapter {
 function forOpenAIResponsesBackend(
   request: CanonicalResponseRequest,
   dropSamplingParams: boolean,
-): CanonicalResponseRequest {
-  const payload = dropSamplingParams ? forChatGptBackend(request) : { ...request };
+): OpenAIResponsesWireRequest {
+  const source = dropSamplingParams ? forChatGptBackend(request) : { ...request };
+  const {
+    tools: canonicalTools,
+    tool_choice: canonicalToolChoice,
+    native_tools: nativeTools,
+    ...rest
+  } = source;
+  const payload: OpenAIResponsesWireRequest = { ...rest };
+
   payload.input = request.input.map((item) => {
     if (item.type !== "function_call_output") return item;
     const {
@@ -169,12 +221,53 @@ function forOpenAIResponsesBackend(
     } = item;
     return wireItem;
   });
-  if (request.tools !== undefined) {
-    payload.tools = request.tools.map((tool) => {
-      const { defer_loading: _deferLoading, ...wireTool } = tool;
-      return wireTool;
-    });
+
+  const wireTools: OpenAIResponsesWireTool[] = (canonicalTools ?? []).map((tool) => {
+    const { defer_loading: _deferLoading, ...wireTool } = tool;
+    return wireTool;
+  });
+
+  // native_tools is canonical-only: it must never reach the OpenAI wire body as-is.
+  // Provider-owned web search is merged into `tools` as a hosted tool selector instead.
+  let requiresHostedWebSearch = false;
+  let hasHostedWebSearch = false;
+  for (const nativeTool of nativeTools ?? []) {
+    const webSearchTool: OpenAIResponsesWireWebSearchTool = { type: "web_search" };
+    if (nativeTool.allowed_domains !== undefined && nativeTool.allowed_domains.length > 0) {
+      webSearchTool.filters = { allowed_domains: [...nativeTool.allowed_domains] };
+    } else if (nativeTool.blocked_domains !== undefined && nativeTool.blocked_domains.length > 0) {
+      webSearchTool.filters = { blocked_domains: [...nativeTool.blocked_domains] };
+    }
+    // max_uses has no confirmed OpenAI Responses wire field. Dropping it here
+    // (rather than inventing a shape) is deliberate; allowed/blocked_domains are anthropic's
+    // own mutually-exclusive pair, so translateAnthropicTools rejects requests that set both.
+    wireTools.push(webSearchTool);
+    hasHostedWebSearch = true;
+    if (nativeTool.required === true) {
+      requiresHostedWebSearch = true;
+    }
   }
+
+  if (wireTools.length > 0) {
+    payload.tools = wireTools;
+  }
+
+  if (requiresHostedWebSearch) {
+    payload.tool_choice = { type: "web_search" };
+  } else if (canonicalToolChoice !== undefined) {
+    payload.tool_choice = canonicalToolChoice;
+  }
+
+  // Hosted web search only reports its sources when explicitly requested via `include`.
+  // Without this, `response.output_item.done` for `web_search_call` arrives with no `action.sources`.
+  if (hasHostedWebSearch) {
+    const rawInclude = (source as { include?: unknown }).include;
+    const existingInclude = Array.isArray(rawInclude)
+      ? rawInclude.filter((entry): entry is string => typeof entry === "string")
+      : [];
+    payload.include = Array.from(new Set([...existingInclude, "web_search_call.action.sources"]));
+  }
+
   return payload;
 }
 
@@ -524,7 +617,71 @@ function outputItem(value: unknown): CanonicalOutputItem | undefined {
       arguments: typeof item.arguments === "string" ? item.arguments : ""
     };
   }
+  if (item.type === "web_search_call") {
+    const result: CanonicalWebSearchCallOutputItem = {
+      id: string(item.id, "item.id"),
+      type: "web_search_call"
+    };
+    if (typeof item.status === "string") {
+      result.status = item.status;
+    }
+    const action = webSearchAction(item.action);
+    if (action !== undefined) {
+      result.action = action;
+    }
+    return result;
+  }
   return undefined;
+}
+
+/** Parses the OpenAI live `web_search_call.action` shape leniently: unknown/missing fields are just omitted. */
+function webSearchAction(value: unknown): CanonicalWebSearchAction | undefined {
+  if (!isRecord(value) || typeof value.type !== "string") {
+    return undefined;
+  }
+  const action: CanonicalWebSearchAction = { type: value.type };
+  if (typeof value.query === "string") {
+    action.query = value.query;
+  }
+  if (Array.isArray(value.queries)) {
+    const queries = value.queries.filter((entry): entry is string => typeof entry === "string");
+    if (queries.length > 0) {
+      action.queries = queries;
+    }
+  }
+  if (typeof value.url === "string") {
+    action.url = value.url;
+  }
+  if (typeof value.pattern === "string") {
+    action.pattern = value.pattern;
+  }
+  const sources = webSearchSources(value.sources);
+  if (sources !== undefined) {
+    action.sources = sources;
+  }
+  return action;
+}
+
+/** Invalid or incomplete source entries are dropped, never fabricated with placeholder values. */
+function webSearchSources(value: unknown): CanonicalWebSearchSource[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const sources: CanonicalWebSearchSource[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry) || typeof entry.url !== "string" || entry.url.length === 0) {
+      continue;
+    }
+    const source: CanonicalWebSearchSource = {
+      type: typeof entry.type === "string" ? entry.type : "url",
+      url: entry.url
+    };
+    if (typeof entry.title === "string" && entry.title.length > 0) {
+      source.title = entry.title;
+    }
+    sources.push(source);
+  }
+  return sources.length > 0 ? sources : undefined;
 }
 
 function canonicalError(value: unknown): CanonicalError {

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -230,6 +230,22 @@ describe("Anthropic request translation", () => {
     );
   });
 
+  it("rejects web search requests that set both allowed_domains and blocked_domains", () => {
+    const request: AnthropicMessagesRequest = {
+      ...baseRequest(),
+      tools: [{
+        type: "web_search_20250305",
+        name: "web_search",
+        allowed_domains: ["github.com"],
+        blocked_domains: ["spam.example"],
+      }],
+    };
+
+    expect(() => translateAnthropicRequest(request, { nativeTools: ["web_search"] })).toThrow(
+      "web_search allowed_domains and blocked_domains are mutually exclusive",
+    );
+  });
+
   it.each(["minimal", "low", "medium", "high", "xhigh", "max", "ultra"])(
     "maps Claude Code adaptive /effort %s to Responses reasoning",
     (effort) => {
@@ -1230,9 +1246,256 @@ describe("Anthropic SSE encoding", () => {
       output_tokens: 6_277,
     });
   });
+
+  it("emits server_tool_use then web_search_tool_result for a completed web search, keeping stop_reason at end_turn", async () => {
+    const events = iterable<CanonicalResponseEvent>([
+      {
+        type: "response.created",
+        response: { id: "resp_search", model: "gpt-5.5", usage: { input_tokens: 5, output_tokens: 0 } }
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          id: "ws_1",
+          type: "web_search_call",
+          status: "completed",
+          action: {
+            type: "search",
+            query: "fleet harness",
+            sources: [
+              { type: "url", url: "https://example.com/a", title: "Example A" },
+              { type: "url", url: "https://example.com/b" },
+            ],
+          },
+        },
+      },
+      {
+        type: "response.completed",
+        response: { id: "resp_search", model: "gpt-5.5", usage: { input_tokens: 5, output_tokens: 3 } }
+      },
+    ]);
+
+    const frames = parseSse(await collectBody(encodeAnthropicSse(events)));
+
+    expect(frames.map((frame) => frame.event)).toEqual([
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "content_block_start",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ]);
+    expect(frames[1]?.data).toMatchObject({
+      content_block: { type: "server_tool_use", id: "ws_1", name: "web_search", input: {} },
+    });
+    expect(frames[2]?.data).toMatchObject({
+      delta: { type: "input_json_delta", partial_json: JSON.stringify({ query: "fleet harness" }) },
+    });
+    expect(frames[4]?.data).toMatchObject({
+      content_block: {
+        type: "web_search_tool_result",
+        tool_use_id: "ws_1",
+        content: [
+          { type: "web_search_result", url: "https://example.com/a", title: "Example A" },
+          { type: "web_search_result", url: "https://example.com/b", title: "https://example.com/b" },
+        ],
+      },
+    });
+    expect(frames[6]?.data).toMatchObject({ delta: { stop_reason: "end_turn" } });
+  });
+
+  it("emits a web_search_tool_result_error instead of a disguised empty success when status is failed", async () => {
+    const events = iterable<CanonicalResponseEvent>([
+      {
+        type: "response.created",
+        response: { id: "resp_search_failed", model: "gpt-5.5", usage: { input_tokens: 5, output_tokens: 0 } }
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          id: "ws_failed",
+          type: "web_search_call",
+          status: "failed",
+          action: { type: "search", query: "fleet harness" },
+        },
+      },
+      {
+        type: "response.completed",
+        response: { id: "resp_search_failed", model: "gpt-5.5", usage: { input_tokens: 5, output_tokens: 1 } }
+      },
+    ]);
+
+    const frames = parseSse(await collectBody(encodeAnthropicSse(events)));
+
+    // server_tool_use/query block is preserved even on failure to keep the tool_use_id linkage intact.
+    expect(frames[1]?.data).toMatchObject({
+      content_block: { type: "server_tool_use", id: "ws_failed", name: "web_search", input: {} },
+    });
+    expect(frames[2]?.data).toMatchObject({
+      delta: { type: "input_json_delta", partial_json: JSON.stringify({ query: "fleet harness" }) },
+    });
+    expect(frames[4]?.data).toMatchObject({
+      content_block: {
+        type: "web_search_tool_result",
+        tool_use_id: "ws_failed",
+        content: { type: "web_search_tool_result_error", error_code: "unavailable" },
+      },
+    });
+    // A server-side search failure is not a client tool_use round-trip: stop_reason stays end_turn.
+    expect(frames[6]?.data).toMatchObject({ delta: { stop_reason: "end_turn" } });
+  });
+
+  it("keeps a completed web search with no sources as a genuine empty success result, not an error", async () => {
+    const events = iterable<CanonicalResponseEvent>([
+      {
+        type: "response.created",
+        response: { id: "resp_search_empty", model: "gpt-5.5", usage: { input_tokens: 5, output_tokens: 0 } }
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          id: "ws_empty",
+          type: "web_search_call",
+          status: "completed",
+          action: { type: "search", query: "no results here" },
+        },
+      },
+      {
+        type: "response.completed",
+        response: { id: "resp_search_empty", model: "gpt-5.5", usage: { input_tokens: 5, output_tokens: 1 } }
+      },
+    ]);
+
+    const frames = parseSse(await collectBody(encodeAnthropicSse(events)));
+
+    expect(frames[4]?.data).toMatchObject({
+      content_block: {
+        type: "web_search_tool_result",
+        tool_use_id: "ws_empty",
+        content: [],
+      },
+    });
+  });
+
+  it("does not open a block on response.output_item.added for a web search item, only on done", async () => {
+    const events = iterable<CanonicalResponseEvent>([
+      { type: "response.created", response: { id: "resp_added", model: "gpt-5.5", usage: null } },
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { id: "ws_partial", type: "web_search_call", status: "in_progress" },
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          id: "ws_partial",
+          type: "web_search_call",
+          status: "completed",
+          action: { type: "search", query: "done now" },
+        },
+      },
+      {
+        type: "response.completed",
+        response: { id: "resp_added", model: "gpt-5.5", usage: { input_tokens: 1, output_tokens: 1 } }
+      },
+    ]);
+
+    const frames = parseSse(await collectBody(encodeAnthropicSse(events)));
+
+    expect(frames.map((frame) => frame.event)).toEqual([
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "content_block_start",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ]);
+  });
+
+  it("handles two separate web search calls independently with distinct block indices", async () => {
+    const events = iterable<CanonicalResponseEvent>([
+      { type: "response.created", response: { id: "resp_multi", model: "gpt-5.5", usage: null } },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: { id: "ws_a", type: "web_search_call", action: { type: "search", query: "first" } },
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 1,
+        item: { id: "ws_b", type: "web_search_call", action: { type: "search", query: "second" } },
+      },
+      {
+        type: "response.completed",
+        response: { id: "resp_multi", model: "gpt-5.5", usage: { input_tokens: 1, output_tokens: 1 } }
+      },
+    ]);
+
+    const frames = parseSse(await collectBody(encodeAnthropicSse(events)));
+    const starts = frames.filter((frame) => frame.event === "content_block_start");
+    expect(starts).toHaveLength(4);
+    expect(starts.map((frame) => (frame.data.content_block as Record<string, unknown>).type)).toEqual([
+      "server_tool_use",
+      "web_search_tool_result",
+      "server_tool_use",
+      "web_search_tool_result",
+    ]);
+    expect(starts.map((frame) => frame.data.index)).toEqual([0, 1, 2, 3]);
+    const deltas = frames.filter((frame) => frame.event === "content_block_delta");
+    expect(deltas.map((frame) => (frame.data.delta as { partial_json: string }).partial_json)).toEqual([
+      JSON.stringify({ query: "first" }),
+      JSON.stringify({ query: "second" }),
+    ]);
+  });
+
+  it("derives a stable fallback query for open_page and find_in_page actions without fabricating data", async () => {
+    const events = iterable<CanonicalResponseEvent>([
+      { type: "response.created", response: { id: "resp_fallback", model: "gpt-5.5", usage: null } },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: { id: "ws_open", type: "web_search_call", action: { type: "open_page", url: "https://example.com/doc" } },
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 1,
+        item: {
+          id: "ws_find",
+          type: "web_search_call",
+          action: { type: "find_in_page", pattern: "release notes", url: "https://example.com/doc" },
+        },
+      },
+      {
+        type: "response.completed",
+        response: { id: "resp_fallback", model: "gpt-5.5", usage: { input_tokens: 1, output_tokens: 1 } }
+      },
+    ]);
+
+    const frames = parseSse(await collectBody(encodeAnthropicSse(events)));
+    const deltas = frames.filter((frame) => frame.event === "content_block_delta");
+    expect(JSON.parse((deltas[0]?.data.delta as { partial_json: string }).partial_json)).toEqual({
+      query: "https://example.com/doc",
+    });
+    expect(JSON.parse((deltas[1]?.data.delta as { partial_json: string }).partial_json)).toEqual({
+      query: "release notes https://example.com/doc",
+    });
+  });
 });
 
 describe("OpenAI Responses adapter", () => {
+  it("advertises native web search support", () => {
+    const adapter = new OpenAIResponsesAdapter();
+    expect(adapter.capabilities).toEqual({ nativeTools: ["web_search"] });
+  });
+
   it("keeps canonical tool failure metadata provider-private", async () => {
     const fetchMock = vi.fn<FetchLike>(async () => new Response(
       JSON.stringify({ error: { message: "stop after capture" } }),
@@ -1327,6 +1590,433 @@ describe("OpenAI Responses adapter", () => {
       store: false,
     });
     expect(body).not.toHaveProperty("max_output_tokens");
+  });
+
+  it("merges a canonical web_search native tool into the outbound tools array and drops native_tools", async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => new Response(
+      JSON.stringify({ error: { message: "stop after capture" } }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    ));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+
+    await adapter.stream({
+      model: "gpt-5.5",
+      input: [{ type: "message", role: "user", content: "What's new today?" }],
+      native_tools: [{ type: "web_search" }],
+      stream: true,
+    }, { apiKey: "platform-key" });
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.tools).toEqual([{ type: "web_search" }]);
+    expect(body).not.toHaveProperty("native_tools");
+  });
+
+  it("merges native web_search into the outbound tools array on the ChatGPT subscription backend too", async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => new Response(
+      JSON.stringify({ error: { message: "stop after capture" } }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    ));
+    const adapter = new OpenAIResponsesAdapter({
+      fetch: fetchMock,
+      url: CHATGPT_CODEX_RESPONSES_URL,
+      dropSamplingParams: true,
+    });
+
+    await adapter.stream({
+      model: "gpt-5.6-sol",
+      input: [],
+      native_tools: [{ type: "web_search" }],
+      stream: true,
+    }, { apiKey: "subscription-token" });
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.tools).toEqual([{ type: "web_search" }]);
+    expect(body).not.toHaveProperty("native_tools");
+    expect(body).toMatchObject({ store: false });
+  });
+
+  it("forwards allowed_domains as an OpenAI web search filter", async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => new Response(
+      JSON.stringify({ error: { message: "stop after capture" } }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    ));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+
+    await adapter.stream({
+      model: "gpt-5.5",
+      input: [],
+      native_tools: [{ type: "web_search", allowed_domains: ["github.com", "arxiv.org"] }],
+      stream: true,
+    }, { apiKey: "platform-key" });
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.tools).toEqual([{
+      type: "web_search",
+      filters: { allowed_domains: ["github.com", "arxiv.org"] },
+    }]);
+  });
+
+  it("forwards blocked_domains as an OpenAI web search filter (live-probe confirmed: HTTP 200, 17 sources)", async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => new Response(
+      JSON.stringify({ error: { message: "stop after capture" } }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    ));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+
+    await adapter.stream({
+      model: "gpt-5.5",
+      input: [],
+      native_tools: [{ type: "web_search", blocked_domains: ["spam.example"] }],
+      stream: true,
+    }, { apiKey: "platform-key" });
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.tools).toEqual([{
+      type: "web_search",
+      filters: { blocked_domains: ["spam.example"] },
+    }]);
+  });
+
+  it("drops max_uses rather than inventing an OpenAI wire field for it", async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => new Response(
+      JSON.stringify({ error: { message: "stop after capture" } }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    ));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+
+    await adapter.stream({
+      model: "gpt-5.5",
+      input: [],
+      native_tools: [{
+        type: "web_search",
+        max_uses: 8,
+        allowed_domains: ["github.com"],
+      }],
+      stream: true,
+    }, { apiKey: "platform-key" });
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    const wireTools = body.tools as Array<Record<string, unknown>>;
+    expect(wireTools).toEqual([{ type: "web_search", filters: { allowed_domains: ["github.com"] } }]);
+    expect(wireTools[0]).not.toHaveProperty("max_uses");
+  });
+
+  it("maps a required native web search into the OpenAI hosted tool_choice selector", async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => new Response(
+      JSON.stringify({ error: { message: "stop after capture" } }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    ));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+
+    await adapter.stream({
+      model: "gpt-5.5",
+      input: [],
+      native_tools: [{ type: "web_search", required: true }],
+      stream: true,
+    }, { apiKey: "platform-key" });
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.tool_choice).toEqual({ type: "web_search" });
+  });
+
+  it("keeps client function tools alongside the merged native web search tool", async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => new Response(
+      JSON.stringify({ error: { message: "stop after capture" } }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    ));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+
+    await adapter.stream({
+      model: "gpt-5.5",
+      input: [],
+      tools: [{
+        type: "function",
+        name: "read_file",
+        parameters: { type: "object", properties: { path: { type: "string" } } },
+      }],
+      native_tools: [{ type: "web_search" }],
+      stream: true,
+    }, { apiKey: "platform-key" });
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.tools).toEqual([
+      {
+        type: "function",
+        name: "read_file",
+        parameters: { type: "object", properties: { path: { type: "string" } } },
+      },
+      { type: "web_search" },
+    ]);
+  });
+
+  it("carries Claude Code's web_search_20250305 tool through the gateway to the OpenAI wire body", async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => new Response(
+      JSON.stringify({ error: { message: "stop after capture" } }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    ));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+    const gateway = new AnthropicMessagesGateway(adapter);
+    const request = {
+      ...baseRequest(),
+      tools: [
+        {
+          type: "web_search_20250305",
+          name: "web_search",
+          allowed_domains: ["github.com"],
+          max_uses: 5,
+        },
+        {
+          name: "read_file",
+          input_schema: { type: "object", properties: { path: { type: "string" } } },
+        },
+      ],
+      tool_choice: { type: "tool", name: "web_search" },
+    } as unknown as AnthropicMessagesRequest;
+
+    await gateway.stream(request, { apiKey: "platform-key" });
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body).not.toHaveProperty("native_tools");
+    expect(body.tools).toEqual([
+      {
+        type: "function",
+        name: "read_file",
+        parameters: { type: "object", properties: { path: { type: "string" } } },
+      },
+      { type: "web_search", filters: { allowed_domains: ["github.com"] } },
+    ]);
+    expect(body.tool_choice).toEqual({ type: "web_search" });
+    const webSearchWireTool = (body.tools as Array<Record<string, unknown>>)[1];
+    expect(webSearchWireTool).not.toHaveProperty("max_uses");
+  });
+
+  it("requests web_search_call.action.sources via include when native web_search is present", async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => new Response(
+      JSON.stringify({ error: { message: "stop after capture" } }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    ));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+
+    await adapter.stream({
+      model: "gpt-5.5",
+      input: [],
+      native_tools: [{ type: "web_search" }],
+      stream: true,
+    }, { apiKey: "platform-key" });
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.include).toEqual(["web_search_call.action.sources"]);
+  });
+
+  it("does not add include when there is no native web_search tool", async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => new Response(
+      JSON.stringify({ error: { message: "stop after capture" } }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    ));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+
+    await adapter.stream({
+      model: "gpt-5.5",
+      input: [],
+      stream: true,
+    }, { apiKey: "platform-key" });
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body).not.toHaveProperty("include");
+  });
+
+  it("preserves and dedupes a pre-existing include list when merging web_search_call.action.sources", async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => new Response(
+      JSON.stringify({ error: { message: "stop after capture" } }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    ));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+
+    await adapter.stream({
+      model: "gpt-5.5",
+      input: [],
+      native_tools: [{ type: "web_search" }],
+      stream: true,
+      include: ["file_search_call.results", "web_search_call.action.sources"],
+    } as unknown as CanonicalResponseRequest, { apiKey: "platform-key" });
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.include).toEqual(["file_search_call.results", "web_search_call.action.sources"]);
+  });
+
+  it("parses a completed web_search_call output item with sources into canonical form", async () => {
+    const upstreamSse = [
+      frame("response.created", {
+        type: "response.created",
+        response: { id: "resp_search", model: "gpt-5.5", usage: null }
+      }),
+      frame("response.output_item.done", {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          type: "web_search_call",
+          id: "ws_1",
+          status: "completed",
+          action: {
+            type: "search",
+            query: "fleet harness release notes",
+            sources: [
+              { type: "url", url: "https://example.com/a", title: "Example A" },
+              { type: "url", url: "https://example.com/b" },
+              { not_a_url: true }
+            ]
+          }
+        }
+      }),
+      frame("response.completed", {
+        type: "response.completed",
+        response: { id: "resp_search", model: "gpt-5.5", usage: { input_tokens: 10, output_tokens: 2 } }
+      })
+    ].join("");
+    const fetchMock = vi.fn<FetchLike>(async () => sseResponse(upstreamSse));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+    const result = await adapter.stream(
+      { model: "gpt-5.5", input: [], stream: true },
+      { apiKey: "key" }
+    );
+    if (!result.ok) {
+      throw new Error("expected a successful stream");
+    }
+    const events: CanonicalResponseEvent[] = [];
+    for await (const event of result.events) events.push(event);
+    const done = events.find((event) => event.type === "response.output_item.done");
+
+    expect(done).toMatchObject({
+      item: {
+        id: "ws_1",
+        type: "web_search_call",
+        status: "completed",
+        action: {
+          type: "search",
+          query: "fleet harness release notes",
+          sources: [
+            { type: "url", url: "https://example.com/a", title: "Example A" },
+            { type: "url", url: "https://example.com/b" }
+          ]
+        }
+      }
+    });
+  });
+
+  it("drops invalid source entries instead of fabricating them", async () => {
+    const upstreamSse = [
+      frame("response.created", {
+        type: "response.created",
+        response: { id: "resp_search_invalid", model: "gpt-5.5", usage: null }
+      }),
+      frame("response.output_item.done", {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          type: "web_search_call",
+          id: "ws_2",
+          action: {
+            type: "search",
+            query: "q",
+            sources: [{ type: "url" }, { url: 123 }, "not-an-object"]
+          }
+        }
+      }),
+      frame("response.completed", {
+        type: "response.completed",
+        response: { id: "resp_search_invalid", model: "gpt-5.5", usage: { input_tokens: 1, output_tokens: 1 } }
+      })
+    ].join("");
+    const fetchMock = vi.fn<FetchLike>(async () => sseResponse(upstreamSse));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+    const result = await adapter.stream(
+      { model: "gpt-5.5", input: [], stream: true },
+      { apiKey: "key" }
+    );
+    if (!result.ok) {
+      throw new Error("expected a successful stream");
+    }
+    const events: CanonicalResponseEvent[] = [];
+    for await (const event of result.events) events.push(event);
+    const done = events.find((event) => event.type === "response.output_item.done");
+
+    expect(done).toMatchObject({ item: { id: "ws_2", action: { type: "search", query: "q" } } });
+    if (done?.type === "response.output_item.done" && done.item.type === "web_search_call") {
+      expect(done.item.action?.sources).toBeUndefined();
+    } else {
+      throw new Error("expected a web_search_call output item");
+    }
+  });
+
+  it("delivers a complete web search result to Claude Code end-to-end through the gateway", async () => {
+    const upstreamSse = [
+      frame("response.created", {
+        type: "response.created",
+        response: { id: "resp_e2e_search", model: "gpt-5.5", usage: { input_tokens: 20, output_tokens: 0 } }
+      }),
+      frame("response.output_item.done", {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          type: "web_search_call",
+          id: "ws_e2e",
+          status: "completed",
+          action: {
+            type: "search",
+            query: "latest fleet-harness release",
+            sources: [{ type: "url", url: "https://example.com/release", title: "Release notes" }]
+          }
+        }
+      }),
+      frame("response.completed", {
+        type: "response.completed",
+        response: { id: "resp_e2e_search", model: "gpt-5.5", usage: { input_tokens: 20, output_tokens: 6 } }
+      })
+    ].join("");
+    const fetchMock = vi.fn<FetchLike>(async () => sseResponse(upstreamSse));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+    const gateway = new AnthropicMessagesGateway(adapter);
+    const request = {
+      ...baseRequest(),
+      tools: [{ type: "web_search_20250305", name: "web_search" }],
+    } as unknown as AnthropicMessagesRequest;
+
+    const response = await gateway.stream(request, { apiKey: "platform-key" });
+    const frames = parseSse(await collectBody(response.body));
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const outboundBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(outboundBody.tools).toEqual([{ type: "web_search" }]);
+    expect(outboundBody.include).toEqual(["web_search_call.action.sources"]);
+
+    const searchStart = frames.find((item) => item.event === "content_block_start"
+      && (item.data.content_block as Record<string, unknown>).type === "server_tool_use");
+    const resultStart = frames.find((item) => item.event === "content_block_start"
+      && (item.data.content_block as Record<string, unknown>).type === "web_search_tool_result");
+    const messageDelta = frames.find((item) => item.event === "message_delta");
+
+    expect(searchStart?.data).toMatchObject({
+      content_block: { type: "server_tool_use", id: "ws_e2e", name: "web_search", input: {} },
+    });
+    expect(resultStart?.data).toMatchObject({
+      content_block: {
+        type: "web_search_tool_result",
+        tool_use_id: "ws_e2e",
+        content: [{ type: "web_search_result", url: "https://example.com/release", title: "Release notes" }],
+      },
+    });
+    expect(messageDelta?.data).toMatchObject({ delta: { stop_reason: "end_turn" } });
   });
 
   it("streams function-call arguments into Anthropic tool_use deltas with the call id intact", async () => {
@@ -1810,6 +2500,90 @@ describe("non-streaming requests", () => {
 
     expect(JSON.parse(await collectBody(response.body))).toMatchObject({
       usage: { input_tokens: 250_000, output_tokens: 1 },
+    });
+  });
+
+  it("includes a completed web search's blocks in the non-streaming response, without setting stop_reason to tool_use", async () => {
+    const adapter: AiGatewayAdapter = {
+      async stream() {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          events: iterable<CanonicalResponseEvent>([
+            { type: "response.created", response: { id: "resp_json_search", model: "gpt-5.5", usage: { input_tokens: 9, output_tokens: 0 } } },
+            {
+              type: "response.output_item.done",
+              output_index: 0,
+              item: {
+                id: "ws_json",
+                type: "web_search_call",
+                status: "completed",
+                action: {
+                  type: "search",
+                  query: "fleet harness changelog",
+                  sources: [{ type: "url", url: "https://example.com/changelog" }],
+                },
+              },
+            },
+            { type: "response.completed", response: { id: "resp_json_search", model: "gpt-5.5", usage: { input_tokens: 9, output_tokens: 5 } } },
+          ]),
+        };
+      },
+    };
+    const { stream: _drop, ...rest } = baseRequest();
+    const response = await new AnthropicMessagesGateway(adapter).stream(rest as AnthropicMessagesRequest, { apiKey: "k" });
+
+    expect(JSON.parse(await collectBody(response.body))).toMatchObject({
+      stop_reason: "end_turn",
+      content: [
+        { type: "server_tool_use", id: "ws_json", name: "web_search", input: { query: "fleet harness changelog" } },
+        {
+          type: "web_search_tool_result",
+          tool_use_id: "ws_json",
+          content: [{ type: "web_search_result", url: "https://example.com/changelog", title: "https://example.com/changelog" }],
+        },
+      ],
+    });
+  });
+
+  it("reports a failed web search as web_search_tool_result_error in the non-streaming response, without setting stop_reason to tool_use", async () => {
+    const adapter: AiGatewayAdapter = {
+      async stream() {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          events: iterable<CanonicalResponseEvent>([
+            { type: "response.created", response: { id: "resp_json_search_failed", model: "gpt-5.5", usage: { input_tokens: 9, output_tokens: 0 } } },
+            {
+              type: "response.output_item.done",
+              output_index: 0,
+              item: {
+                id: "ws_json_failed",
+                type: "web_search_call",
+                status: "failed",
+                action: { type: "search", query: "fleet harness changelog" },
+              },
+            },
+            { type: "response.completed", response: { id: "resp_json_search_failed", model: "gpt-5.5", usage: { input_tokens: 9, output_tokens: 5 } } },
+          ]),
+        };
+      },
+    };
+    const { stream: _drop, ...rest } = baseRequest();
+    const response = await new AnthropicMessagesGateway(adapter).stream(rest as AnthropicMessagesRequest, { apiKey: "k" });
+
+    expect(JSON.parse(await collectBody(response.body))).toMatchObject({
+      stop_reason: "end_turn",
+      content: [
+        { type: "server_tool_use", id: "ws_json_failed", name: "web_search", input: { query: "fleet harness changelog" } },
+        {
+          type: "web_search_tool_result",
+          tool_use_id: "ws_json_failed",
+          content: { type: "web_search_tool_result_error", error_code: "unavailable" },
+        },
+      ],
     });
   });
 });


### PR DESCRIPTION
## Summary
- Translate Claude Code's `web_search_20250305` server tool to Codex/OpenAI Responses hosted web search.
- Reconstruct provider search calls, sources, and failures as Anthropic-compatible content blocks.
- Preserve allowed/blocked domain filters and request complete source metadata.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` (191/191)
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `pnpm check:core-boundary`
- [x] Live ChatGPT Codex backend validation for forced and thinking-disabled web search
- [x] Added `.changelog.d/pr-467.md` with bilingual summaries
- [x] `node scripts/compile-changelog-fragments.mjs --check`

## Review
- Codex automated review is intentionally skipped per the author's explicit instruction.