### PR TITLE
fix(fleet-plugin): sort AI Gateway /model picker by provider

### DIFF
--- a/.changelog.d/pr-455.md
+++ b/.changelog.d/pr-455.md
@@ -2,8 +2,8 @@
 #### Added
 - [fleet-console] Add a Claude (Gateway) launch that drives Claude Code through a local AI Gateway, routing each model call to the Codex (ChatGPT subscription), Cursor (subscription), or Kimi (API key) backend while native Claude models pass through untouched.
   ko: Claude Code를 로컬 AI Gateway로 구동하는 Claude (Gateway) 런치를 추가합니다 — 모델별 호출을 Codex(ChatGPT 구독)·Cursor(구독)·Kimi(API key) 백엔드로 중계하고, 네이티브 Claude 모델은 원문 그대로 통과합니다.
-- [fleet-console] Rework the Terminal settings Agent CLI section into AI Gateway with a per-provider model loadout: only enabled models reach the /model picker (opt-in), a starred model becomes the session default, and rows surface context window, effort ladder, Fast, and Max Mode chips. The selection persists in the console's terminal plugin state.
-  ko: Terminal 설정의 Agent CLI 섹션을 AI Gateway로 개편하고 프로바이더별 모델 로드아웃을 추가합니다 — 켠 모델만 /model 픽커에 노출(opt-in)되고, ★ 지정 모델이 세션 기본값이 되며, 행에 컨텍스트 윈도우·effort 사다리·Fast·Max Mode 칩이 표시됩니다. 선별 상태는 콘솔의 terminal 플러그인 상태에 저장됩니다.
+- [fleet-console] Rework the Terminal settings Agent CLI section into AI Gateway with a per-provider model loadout: only enabled models reach the /model picker (opt-in), sorted by provider (Codex, then Cursor, then Kimi) under Claude Code's built-ins; a starred model becomes the session default, and rows surface context window, effort ladder, Fast, and Max Mode chips. The selection persists in the console's terminal plugin state.
+  ko: Terminal 설정의 Agent CLI 섹션을 AI Gateway로 개편하고 프로바이더별 모델 로드아웃을 추가합니다 — 켠 모델만 /model 픽커에 노출(opt-in)되며 Claude 기본 모델 아래에서 Codex → Cursor → Kimi 순으로 정렬되고, ★ 지정 모델이 세션 기본값이 되며, 행에 컨텍스트 윈도우·effort 사다리·Fast·Max Mode 칩이 표시됩니다. 선별 상태는 콘솔의 terminal 플러그인 상태에 저장됩니다.
 #### Removed
 - [fleet-console] Remove the direct Kimi (Claude Code) launch and its default model and effort options; Kimi sessions now run through the AI Gateway, and reasoning effort is controlled inside Claude Code via /effort and the /model picker.
   ko: 직결 Kimi (Claude Code) 런치와 기본 모델·effort 옵션을 제거합니다. Kimi 세션은 이제 AI Gateway를 통해 실행되며, 추론 강도는 Claude Code의 /effort와 /model 픽커에서 제어합니다.

--- a/.changelog.d/pr-469.md
+++ b/.changelog.d/pr-469.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Changed
+- [fleet-console] Sort AI Gateway models in Claude Code's /model picker by provider (Codex, then Cursor, then Kimi), keeping Claude built-ins first.
+  ko: Claude Code /model 픽커의 AI Gateway 모델을 프로바이더(Codex → Cursor → Kimi) 순으로 정렬하고 Claude 기본 모델은 맨 위에 유지합니다.

--- a/.changelog.d/pr-469.md
+++ b/.changelog.d/pr-469.md
@@ -1,4 +1,0 @@
-### fleet-plugin
-#### Changed
-- [fleet-console] Sort AI Gateway models in Claude Code's /model picker by provider (Codex, then Cursor, then Kimi), keeping Claude built-ins first.
-  ko: Claude Code /model 픽커의 AI Gateway 모델을 프로바이더(Codex → Cursor → Kimi) 순으로 정렬하고 Claude 기본 모델은 맨 위에 유지합니다.

--- a/runtime/fleet-plugins/terminal/server/ai-gateway-settings.ts
+++ b/runtime/fleet-plugins/terminal/server/ai-gateway-settings.ts
@@ -120,9 +120,23 @@ export function resolveAiGatewaySelection(settings: AiGatewayStoredSettings | un
     if (!model || enabled.includes(model)) continue;
     enabled.push(model);
   }
+  // Claude Code's /model picker preserves discovery order under its built-ins.
+  // Settings UI is already grouped by GATEWAY_PROVIDERS; expose the same grammar
+  // on the wire regardless of Add-click membership order.
+  const models = sortGatewayModelsByProvider(enabled);
   const configuredDefault = settings?.defaultModel ? findGatewayModel(settings.defaultModel) : undefined;
-  const defaultModel = configuredDefault && enabled.includes(configuredDefault) ? configuredDefault : undefined;
-  return { models: enabled, defaultModel };
+  const defaultModel = configuredDefault && models.includes(configuredDefault) ? configuredDefault : undefined;
+  return { models, defaultModel };
+}
+
+/** Stable provider clusters (codex → cursor → kimi), then catalog order within each. */
+function sortGatewayModelsByProvider(models: readonly GatewayModel[]): GatewayModel[] {
+  return [...models].sort((left, right) => {
+    const providerDelta =
+      GATEWAY_PROVIDERS.indexOf(left.provider) - GATEWAY_PROVIDERS.indexOf(right.provider);
+    if (providerDelta !== 0) return providerDelta;
+    return GATEWAY_MODELS.indexOf(left) - GATEWAY_MODELS.indexOf(right);
+  });
 }
 
 /** 설정 PUT 본문의 aiGateway 값을 카탈로그에 대조 검증한다. `undefined` 값은 설정 해제를 뜻한다. */

--- a/runtime/fleet-plugins/terminal/tests/ai-gateway-launch-env.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ai-gateway-launch-env.test.ts
@@ -82,6 +82,43 @@ describe("Claude gateway launch environment", () => {
     ]);
   });
 
+  it("writes the discovery cache in provider clusters even when membership was interleaved", () => {
+    const configDir = mkdtempSync(path.join(os.tmpdir(), "fleet-ai-gateway-claude-"));
+    temporaryDirectories.push(configDir);
+
+    const selection = resolveAiGatewaySelection({
+      version: 1,
+      models: [
+        { id: "cursor--grok-4.5-fast" },
+        { id: "codex--gpt-5.6-sol-fast" },
+        { id: "kimi--k3" },
+        { id: "codex--gpt-5.6-luna-fast" },
+      ],
+    });
+    applyAiGatewayEnv({
+      id: "claude-gateway",
+      label: "Claude Gateway",
+      bin: "claude",
+      args: [],
+      cwd: "/workspace",
+      env: { CLAUDE_CONFIG_DIR: configDir },
+      terminalName: "xterm-256color",
+    } as const, {
+      routePath: "/plugins/terminal/ai-gateway",
+      origin: () => "http://127.0.0.1:4310",
+    }, selection);
+
+    const cache = JSON.parse(readFileSync(path.join(configDir, "cache", "gateway-models.json"), "utf8")) as {
+      readonly models: readonly { readonly id: string }[];
+    };
+    expect(cache.models.map((model) => model.id)).toEqual([
+      "claude-gateway--codex--gpt-5.6-sol-fast[1m]",
+      "claude-gateway--codex--gpt-5.6-luna-fast[1m]",
+      "claude-gateway--cursor--grok-4.5-fast[1m]",
+      "claude-gateway--kimi--k3[1m]",
+    ]);
+  });
+
   it("writes an empty cache when the settings enable no models (opt-in)", () => {
     const configDir = mkdtempSync(path.join(os.tmpdir(), "fleet-ai-gateway-claude-"));
     temporaryDirectories.push(configDir);

--- a/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
@@ -864,6 +864,33 @@ describe("route surface", () => {
     ]);
   });
 
+  it("sorts an interleaved allowlist into provider clusters for /v1/models", async () => {
+    const router = createAiGatewayRouter({
+      gateway: stubGateway(),
+      readAuth,
+      readAiGatewaySettings: aiGatewaySettingsStub({
+        version: 1,
+        models: [
+          { id: "kimi--k3" },
+          { id: "codex--gpt-5.6-luna-fast" },
+          { id: "cursor--grok-4.5-fast" },
+          { id: "codex--gpt-5.6-sol-fast" },
+        ],
+      }),
+    });
+    const res = response();
+    await router.handle(ctx({ res, token: ANTHROPIC_CRED, pathname: `${BASE}/v1/models`, method: "GET" }));
+
+    expect(res.status).toBe(200);
+    const list = JSON.parse(res.body) as { data: Array<{ id: string }> };
+    expect(list.data.map((entry) => entry.id)).toEqual([
+      "claude-gateway--codex--gpt-5.6-sol-fast[1m]",
+      "claude-gateway--codex--gpt-5.6-luna-fast[1m]",
+      "claude-gateway--cursor--grok-4.5-fast[1m]",
+      "claude-gateway--kimi--k3[1m]",
+    ]);
+  });
+
   it("exposes no gateway models until the settings enable some (opt-in)", async () => {
     const router = createAiGatewayRouter({
       gateway: stubGateway(),

--- a/runtime/fleet-plugins/terminal/tests/ai-gateway-settings.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ai-gateway-settings.test.ts
@@ -73,4 +73,24 @@ describe("ai-gateway settings store", () => {
     expect(selection.models.map((model) => model.id)).toEqual(["cursor--claude-opus-5"]);
     expect(selection.defaultModel).toBeUndefined();
   });
+
+  it("exposes enabled models in GATEWAY_PROVIDERS order, not Add-click order", () => {
+    const selection = resolveAiGatewaySelection({
+      version: 1,
+      models: [
+        { id: "cursor--grok-4.5-fast" },
+        { id: "codex--gpt-5.6-sol-fast" },
+        { id: "kimi--k3" },
+        { id: "codex--gpt-5.6-luna-fast" },
+      ],
+      defaultModel: "cursor--grok-4.5-fast",
+    });
+    expect(selection.models.map((model) => model.id)).toEqual([
+      "codex--gpt-5.6-sol-fast",
+      "codex--gpt-5.6-luna-fast",
+      "cursor--grok-4.5-fast",
+      "kimi--k3",
+    ]);
+    expect(selection.defaultModel?.id).toBe("cursor--grok-4.5-fast");
+  });
 });


### PR DESCRIPTION
## Summary
- Sort AI Gateway-enabled models for Claude Code's `/model` picker by provider (`codex → cursor → kimi`) at `resolveAiGatewaySelection()`, so live `/v1/models` and the launch discovery cache share the same grammar as Settings.
- Claude Code built-ins stay first; stored Add-click membership order is no longer preserved on the wire.
- Changelog: folded into still-unreleased `.changelog.d/pr-455.md` and labeled `no-changelog` for this PR (public baseline not yet shipped).

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal test` — 530 passed
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] Contract coverage for interleaved stored selection → provider-sorted exposure on resolve, `/v1/models`, and launch cache
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] Classified `no-changelog`; ordering note folded into pending `.changelog.d/pr-455.md`