### PR TITLE
fix(core-ai-gateway): meter Codex against its real context window

### DIFF
--- a/.changelog.d/pr-463.md
+++ b/.changelog.d/pr-463.md
@@ -1,9 +1,0 @@
-### fleet-plugin
-#### Added
-- [fleet-console] The AI Gateway meters a Codex session against the budget the Codex CLI itself compacts at, so a session compacts where a native Codex session would instead of running toward the larger window the backend still accepts.
-  ko: AI Gateway가 Codex 세션을 Codex CLI 자신이 컴팩트하는 예산 기준으로 계측해, 백엔드가 아직 수용하는 더 큰 창까지 달려가지 않고 네이티브 Codex 세션과 같은 지점에서 컴팩트합니다.
-
-### fleet-core
-#### Added
-- [core-ai-gateway] A model may declare `autoCompactThreshold`, the occupancy its provider's reference client compacts at, and the gateway projects Claude Code's context meter onto that budget while the pre-flight overflow guard keeps measuring against `contextWindow`. A model that declares no threshold keeps metering against its real window.
-  ko: 모델이 제공자 레퍼런스 클라이언트의 컴팩트 지점인 `autoCompactThreshold`를 선언할 수 있고, 게이트웨이는 Claude Code의 컨텍스트 계기를 그 예산에 투영하는 한편 사전 차단 가드는 계속 `contextWindow` 기준으로 측정합니다. 임계를 선언하지 않은 모델은 실제 창 기준 계측을 유지합니다.

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -5,13 +5,12 @@
     "codex": {
       "name": "Codex",
       "defaultModel": "gpt-5.6-sol",
-      "source": "codex app-server model/list (codex-cli 0.146.0, 2026-08-01) for model/effort/service-tier only; contextWindow=372000 is a retained operational value pending authenticated backend verification; autoCompactThreshold=258400 is a reproducible accounting threshold from codex debug models (codex-cli 0.146.0, 2026-08-02): 272000 x 95%",
+      "source": "codex app-server model/list (codex-cli 0.146.0, 2026-08-01) for model/effort/service-tier; contextWindow=272000 is codex debug models context_window/max_context_window (codex-cli 0.146.0, 2026-08-02)",
       "models": [
         {
           "modelId": "gpt-5.6-sol",
           "name": "GPT-5.6-Sol",
-          "contextWindow": 372000,
-          "autoCompactThreshold": 258400,
+          "contextWindow": 272000,
           "effort": {
             "supported": true,
             "levels": [
@@ -32,8 +31,7 @@
           "name": "GPT-5.6-Sol-Fast",
           "providerModelId": "gpt-5.6-sol",
           "serviceTier": "priority",
-          "contextWindow": 372000,
-          "autoCompactThreshold": 258400,
+          "contextWindow": 272000,
           "effort": {
             "supported": true,
             "levels": [
@@ -52,8 +50,7 @@
         {
           "modelId": "gpt-5.6-terra",
           "name": "GPT-5.6-Terra",
-          "contextWindow": 372000,
-          "autoCompactThreshold": 258400,
+          "contextWindow": 272000,
           "effort": {
             "supported": true,
             "levels": [
@@ -74,8 +71,7 @@
           "name": "GPT-5.6-Terra-Fast",
           "providerModelId": "gpt-5.6-terra",
           "serviceTier": "priority",
-          "contextWindow": 372000,
-          "autoCompactThreshold": 258400,
+          "contextWindow": 272000,
           "effort": {
             "supported": true,
             "levels": [
@@ -94,8 +90,7 @@
         {
           "modelId": "gpt-5.6-luna",
           "name": "GPT-5.6-Luna",
-          "contextWindow": 372000,
-          "autoCompactThreshold": 258400,
+          "contextWindow": 272000,
           "effort": {
             "supported": true,
             "levels": [
@@ -115,8 +110,7 @@
           "name": "GPT-5.6-Luna-Fast",
           "providerModelId": "gpt-5.6-luna",
           "serviceTier": "priority",
-          "contextWindow": 372000,
-          "autoCompactThreshold": 258400,
+          "contextWindow": 272000,
           "effort": {
             "supported": true,
             "levels": [

--- a/packages/core-ai-gateway/src/claude-context.ts
+++ b/packages/core-ai-gateway/src/claude-context.ts
@@ -54,6 +54,14 @@ export function stripClaudeOneMillionMarker(modelId: string): string {
 /**
  * Project a marked provider model's input usage onto Claude Code's 1M coordinate.
  * The projection preserves the provider model's occupied-context ratio.
+ *
+ * The result is capped at the coordinate itself. Claude Code has no representation
+ * for an occupancy above the window it was told the model has: past that point it
+ * reports `Context exceeds the 1m-token limit` and stops auto-compacting, leaving
+ * the session recoverable only by a manual `/compact`. A denominator that
+ * understates the real window — or an upstream that reports more input than the
+ * catalog claims the model holds — would otherwise push the session into that
+ * state, so the cap is a floor under the whole projection, not a rounding detail.
  */
 export function projectClaudeContextInputTokens(
   inputTokens: number,
@@ -70,7 +78,10 @@ export function projectClaudeContextInputTokens(
   const projectionWindow = positiveContextWindow(upstreamContextWindow)
     ?? positiveContextWindow(advertisedContextWindow);
   if (projectionWindow === undefined) return inputTokens;
-  return Math.ceil(inputTokens * CLAUDE_COMPAT_CONTEXT_WINDOW / projectionWindow);
+  return Math.min(
+    CLAUDE_COMPAT_CONTEXT_WINDOW,
+    Math.ceil(inputTokens * CLAUDE_COMPAT_CONTEXT_WINDOW / projectionWindow),
+  );
 }
 
 /**

--- a/packages/core-ai-gateway/src/models.ts
+++ b/packages/core-ai-gateway/src/models.ts
@@ -52,7 +52,6 @@ const GatewayModelEntrySchema = z.object({
   quotaScope: z.enum(GATEWAY_QUOTA_SCOPES).optional(),
   aliases: z.array(z.string().min(1)).optional(),
   contextWindow: z.number().int().positive().optional(),
-  autoCompactThreshold: z.number().int().positive().optional(),
   effort: GatewayModelEffortSchema.optional(),
 }).strict();
 
@@ -110,12 +109,6 @@ export interface GatewayModel {
   readonly description?: string;
   /** Authoritative input context window reported by the provider/reference catalog. */
   readonly contextWindow?: number;
-  /**
-   * Occupancy at which the provider's own reference client compacts, when it operates
-   * below the model's real window. It is the coordinate Claude Code is told to meter
-   * against — never the hard limit, which stays {@link contextWindow}.
-   */
-  readonly autoCompactThreshold?: number;
   /** Model-specific reasoning ladder. Missing registry metadata is treated as unsupported. */
   readonly effort: GatewayModelEffort;
   /** Accepted request ids that are intentionally omitted from discovery. */
@@ -163,32 +156,24 @@ export function toGatewayModelAlias(modelId: string): string {
 }
 
 /**
- * The window Claude Code is told to meter its context against.
- *
- * A provider whose reference client compacts below the model's real window
- * publishes that budget as `autoCompactThreshold`; metering against it makes a
- * gateway session compact where a native session of that provider would, instead
- * of running into the hard limit. Everything else keeps metering against the real
- * window. This is an accounting coordinate, never a limit — the pre-flight
- * overflow guard still measures against {@link GatewayModel.contextWindow}.
- */
-export function claudeAccountingWindow(model: GatewayModel): number | undefined {
-  return model.autoCompactThreshold ?? model.contextWindow;
-}
-
-/**
  * Claude Code only understands its default 200k coordinate and a `[1m]`
- * coordinate. Translated models whose accounting window is above 200k use the
- * latter while the gateway projects their response usage onto it. The marker must
- * follow the same quantity the projection divides by, or Claude Code would meter
- * on the 1M axis while usage was scaled by a different window. Native Kimi
- * passthrough additionally requires a real window of at least 1M, so a synthetic
- * long-context beta never reaches a sub-1M Anthropic-compatible upstream.
+ * coordinate. Translated models whose real window is above 200k use the latter
+ * while the gateway projects their response usage onto it.
+ *
+ * The projection divides by the model's real window and nothing else. Dividing by
+ * a smaller budget — a provider's own compaction threshold, say — would map the
+ * band between that budget and the real window onto 100%+ of the 1M coordinate, a
+ * region Claude Code treats as "context exceeds the limit" and refuses to
+ * auto-compact out of. Metering against the real window instead lets Claude Code's
+ * own reserve compact the session while capacity remains.
+ *
+ * Native Kimi passthrough additionally requires a real window of at least 1M, so a
+ * synthetic long-context beta never reaches a sub-1M Anthropic-compatible upstream.
  */
 export function toClaudeGatewayModelId(model: GatewayModel): string {
   const alias = toGatewayModelAlias(model.id);
   if (
-    canProjectClaudeContextWindow(claudeAccountingWindow(model))
+    canProjectClaudeContextWindow(model.contextWindow)
     && (model.provider !== "kimi" || isClaudeOneMillionContextWindow(model.contextWindow))
   ) {
     return `${alias}${CLAUDE_ONE_MILLION_MARKER}`;
@@ -449,7 +434,6 @@ function toGatewayModel(
     ...(entry.quotaScope ? { quotaScope: entry.quotaScope } : {}),
     ...(entry.description ? { description: entry.description } : {}),
     ...(entry.contextWindow ? { contextWindow: entry.contextWindow } : {}),
-    ...(entry.autoCompactThreshold ? { autoCompactThreshold: entry.autoCompactThreshold } : {}),
     effort: freezeGatewayModelEffort(entry.effort),
     ...(entry.aliases ? { aliases: Object.freeze([...entry.aliases]) } : {}),
   };
@@ -486,17 +470,6 @@ function validateRegistry(value: GatewayModelsRegistry): void {
       // per-pool window that provider's usage response never reports.
       if (model.quotaScope && provider !== "cursor") {
         throw new Error(`Gateway quota scope is only supported by Cursor: ${provider}/${model.modelId}`);
-      }
-      // 회계 창이 실제 창을 넘으면 Claude Code가 점유를 과소 보고해, 컴팩트 대신
-      // 사전 차단 가드에 부딪힌다. 임계는 창의 부분집합이어야만 의미가 있으므로
-      // 잘못된 레지스트리 편집을 조용히 통과시키지 않고 파싱 시점에 세운다.
-      if (model.autoCompactThreshold !== undefined) {
-        if (model.contextWindow === undefined) {
-          throw new Error(`Gateway auto-compact threshold requires contextWindow: ${provider}/${model.modelId}`);
-        }
-        if (model.autoCompactThreshold > model.contextWindow) {
-          throw new Error(`Gateway auto-compact threshold exceeds contextWindow: ${provider}/${model.modelId}`);
-        }
       }
       if (model.effort?.supported) {
         if (new Set(model.effort.levels).size !== model.effort.levels.length) {

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -8,7 +8,6 @@ import {
   buildAnthropicModelList,
   buildGatewayModelConstraints,
   clampReasoningEffort,
-  claudeAccountingWindow,
   findGatewayModel,
   gatewayModelIdentity,
   parseGatewayModelsRegistry,
@@ -457,35 +456,16 @@ describe("model catalog", () => {
     };
     expect(() => parseGatewayModelsRegistry(invalidTier)).toThrow(/only supported by Codex/);
 
-    // 임계는 실제 창의 부분집합일 때만 의미가 있다. 창 없이 선언하거나 창을 넘기면
-    // Claude Code가 도달 불가능한 예산으로 계측하게 되므로 파싱에서 막는다.
-    const thresholdWithoutWindow = minimalRegistry();
-    thresholdWithoutWindow.providers.codex.models[0] = {
+    const legacyAutoCompactThreshold = minimalRegistry();
+    legacyAutoCompactThreshold.providers.codex.models[0] = {
       modelId: "codex-model",
       name: "Model",
+      contextWindow: 272_000,
+      // 컴팩션 예산 분모는 폐기된 개념이다. 실제 창보다 작은 분모는 남은 용량을
+      // 1M 좌표의 100% 위로 밀어내 Claude Code가 컴팩트할 수 없는 상태를 만든다.
       autoCompactThreshold: 258_400,
     };
-    expect(() => parseGatewayModelsRegistry(thresholdWithoutWindow))
-      .toThrow(/auto-compact threshold requires contextWindow/);
-
-    const thresholdOverWindow = minimalRegistry();
-    thresholdOverWindow.providers.codex.models[0] = {
-      modelId: "codex-model",
-      name: "Model",
-      contextWindow: 200_000,
-      autoCompactThreshold: 258_400,
-    };
-    expect(() => parseGatewayModelsRegistry(thresholdOverWindow))
-      .toThrow(/auto-compact threshold exceeds contextWindow/);
-
-    const thresholdAtWindow = minimalRegistry();
-    thresholdAtWindow.providers.codex.models[0] = {
-      modelId: "codex-model",
-      name: "Model",
-      contextWindow: 258_400,
-      autoCompactThreshold: 258_400,
-    };
-    expect(() => parseGatewayModelsRegistry(thresholdAtWindow)).not.toThrow();
+    expect(() => parseGatewayModelsRegistry(legacyAutoCompactThreshold)).toThrow();
 
     const legacyEffortDefault = minimalRegistry();
     legacyEffortDefault.providers.codex.models[0] = {
@@ -603,9 +583,7 @@ describe("model catalog", () => {
     expect(CURSOR_SUBSCRIPTION_MODELS).toHaveLength(9);
     expect(KIMI_SUBSCRIPTION_MODELS).toHaveLength(2);
     expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.upstreamId?.startsWith("gpt-5.6-"))).toBe(true);
-    expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.contextWindow === 372_000)).toBe(true);
-    // Codex compacts well below the window its backend accepts, so the two differ.
-    expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.autoCompactThreshold === 258_400)).toBe(true);
+    expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.contextWindow === 272_000)).toBe(true);
     expect(CURSOR_SUBSCRIPTION_MODELS.map((model) => model.upstreamId)).toEqual([
       "default",
       "composer-2.5",
@@ -729,7 +707,7 @@ describe("model catalog", () => {
     expect(list.data.every((entry) => entry.id.startsWith("claude"))).toBe(true);
     expect(list.data.find((entry) => entry.id === "claude-gateway--codex--gpt-5.6-sol[1m]")).toMatchObject({
       display_name: "Codex-GPT-5.6-Sol",
-      max_input_tokens: 372_000,
+      max_input_tokens: 272_000,
     });
     expect(list.data.some((entry) => entry.id.includes("--codex--") && entry.id.endsWith("[1m]")))
       .toBe(true);
@@ -760,11 +738,20 @@ describe("model catalog", () => {
   it("projects every marked provider window onto Claude Code's 1M coordinate", () => {
     expect(projectClaudeContextInputTokens(65_536, 1_048_576)).toBe(62_500);
     expect(projectClaudeContextInputTokens(50_000, 1_000_000, 800_000)).toBe(62_500);
-    expect(projectClaudeContextInputTokens(302_572, 372_000)).toBe(813_366);
+    expect(projectClaudeContextInputTokens(221_000, 272_000)).toBe(812_500);
     expect(projectClaudeContextInputTokens(250_000, 500_000)).toBe(500_000);
     expect(projectClaudeContextInputTokens(50_000, 256_000, 200_000)).toBe(250_000);
     expect(projectClaudeContextInputTokens(50_000, 200_000)).toBe(50_000);
     expect(projectClaudeContextInputTokens(50_000, undefined)).toBe(50_000);
+  });
+
+  it("never projects past the 1M coordinate Claude Code was told to meter against", () => {
+    // Claude Code reads any occupancy above the advertised window as
+    // "Context exceeds the 1m-token limit" and stops auto-compacting, so an
+    // upstream reporting more input than the catalog window must still land at 100%.
+    expect(projectClaudeContextInputTokens(272_000, 272_000)).toBe(1_000_000);
+    expect(projectClaudeContextInputTokens(300_000, 272_000)).toBe(1_000_000);
+    expect(projectClaudeContextInputTokens(2_000_000, 1_048_576)).toBe(1_000_000);
   });
 
   it("advertises the official Anthropic effort capability per gateway model", () => {
@@ -869,7 +856,7 @@ describe("model catalog", () => {
   });
 });
 
-describe("Claude accounting window", () => {
+describe("Claude context coordinate", () => {
   const model = (over: Partial<GatewayModel>): GatewayModel => ({
     id: "codex--probe",
     displayName: "Codex-Probe",
@@ -878,37 +865,25 @@ describe("Claude accounting window", () => {
     ...over,
   } as GatewayModel);
 
-  it("meters against the declared compaction threshold, not the real window", () => {
-    expect(claudeAccountingWindow(model({ contextWindow: 372_000, autoCompactThreshold: 258_400 })))
-      .toBe(258_400);
-  });
-
-  it("falls back to the real window when no threshold is declared", () => {
-    expect(claudeAccountingWindow(model({ contextWindow: 256_000 }))).toBe(256_000);
-    expect(claudeAccountingWindow(model({}))).toBeUndefined();
-  });
-
-  it("keeps the 1M marker on a Codex model whose threshold still clears 200k", () => {
+  it("marks a model whose real window clears Claude's default coordinate", () => {
     const codex = CODEX_SUBSCRIPTION_MODELS[0]!;
-    expect(codex.autoCompactThreshold).toBe(258_400);
+    expect(codex.contextWindow).toBe(272_000);
     expect(toClaudeGatewayModelId(codex).endsWith("[1m]")).toBe(true);
   });
 
-  it("withholds the 1M marker when the threshold drops to Claude's default coordinate", () => {
-    // The marker must follow the projection denominator. A model whose real window
-    // clears 200k but whose accounting window does not would otherwise make Claude
-    // Code meter on the 1M axis while usage was scaled by a sub-200k window.
-    const throttled = model({ id: "codex--throttled", contextWindow: 372_000, autoCompactThreshold: 200_000 });
-    expect(claudeAccountingWindow(throttled)).toBe(200_000);
-    expect(toClaudeGatewayModelId(throttled).endsWith("[1m]")).toBe(false);
+  it("withholds the marker when there is no window above Claude's default coordinate", () => {
+    expect(toClaudeGatewayModelId(model({ contextWindow: 200_000 })).endsWith("[1m]")).toBe(false);
+    expect(toClaudeGatewayModelId(model({})).endsWith("[1m]")).toBe(false);
   });
 
-  it("projects a full accounting window onto Claude Code's 1M coordinate", () => {
-    // Claude Code compacts at 967_000 of its 1M axis, which is 249_872 real tokens
-    // here — inside the 235k-247k band real Codex sessions were measured to occupy,
-    // and far below the 372_000 the backend would still accept.
-    expect(projectClaudeContextInputTokens(258_400, 258_400)).toBe(1_000_000);
-    expect(Math.floor(967_000 * 258_400 / 1_000_000)).toBe(249_872);
+  it("keeps auto-compact reachable inside the real window", () => {
+    // Claude Code compacts at 967_000 of its 1M axis. Dividing by the real window
+    // puts that at 263_024 real tokens — under the 272_000 the backend accepts, so
+    // the session compacts instead of pinning at an exceeded context. A smaller
+    // denominator (Codex's own 258_400 compaction budget) would instead map the
+    // remaining capacity above 100%, where Claude Code refuses to auto-compact.
+    expect(projectClaudeContextInputTokens(272_000, 272_000)).toBe(1_000_000);
+    expect(Math.floor(967_000 * 272_000 / 1_000_000)).toBe(263_024);
   });
 });
 
@@ -1140,7 +1115,7 @@ describe("Anthropic SSE encoding", () => {
         response: {
           id: "resp_projected",
           model: "gpt-5.6-sol",
-          usage: { input_tokens: 302_572, output_tokens: 0 },
+          usage: { input_tokens: 221_000, output_tokens: 0 },
         },
       },
       {
@@ -1148,20 +1123,20 @@ describe("Anthropic SSE encoding", () => {
         response: {
           id: "resp_projected",
           model: "gpt-5.6-sol",
-          usage: { input_tokens: 302_572, output_tokens: 6_277 },
+          usage: { input_tokens: 221_000, output_tokens: 6_277 },
         },
       },
     ]);
 
     const frames = parseSse(await collectBody(encodeAnthropicSse(events, {
-      contextWindow: 372_000,
+      contextWindow: 272_000,
     })));
 
     expect(frames[0]?.data).toMatchObject({
-      message: { usage: { input_tokens: 813_366, output_tokens: 0 } },
+      message: { usage: { input_tokens: 812_500, output_tokens: 0 } },
     });
     expect(frames[1]?.data).toMatchObject({
-      usage: { input_tokens: 813_366, output_tokens: 6_277 },
+      usage: { input_tokens: 812_500, output_tokens: 6_277 },
     });
   });
 
@@ -1205,7 +1180,7 @@ describe("Anthropic SSE encoding", () => {
           id: "resp_proj_cache",
           model: "gpt-5.6-sol",
           usage: {
-            input_tokens: 302_572,
+            input_tokens: 221_000,
             output_tokens: 0,
             cached_input_tokens: 100_000,
             cache_write_input_tokens: 50_000,
@@ -1218,7 +1193,7 @@ describe("Anthropic SSE encoding", () => {
           id: "resp_proj_cache",
           model: "gpt-5.6-sol",
           usage: {
-            input_tokens: 302_572,
+            input_tokens: 221_000,
             output_tokens: 6_277,
             cached_input_tokens: 100_000,
             cache_write_input_tokens: 50_000,
@@ -1227,7 +1202,7 @@ describe("Anthropic SSE encoding", () => {
       },
     ]);
 
-    const frames = parseSse(await collectBody(encodeAnthropicSse(events, { contextWindow: 372_000 })));
+    const frames = parseSse(await collectBody(encodeAnthropicSse(events, { contextWindow: 272_000 })));
     const messageDelta = frames.find((item) => item.event === "message_delta");
     const usage = messageDelta?.data.usage as {
       input_tokens: number;
@@ -1238,11 +1213,11 @@ describe("Anthropic SSE encoding", () => {
 
     // Same total as the plain (non-cache-aware) 1M projection test above: the
     // breakdown must land on the identical coordinate, never inflate or shrink it.
-    expect(usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens).toBe(813_366);
+    expect(usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens).toBe(812_500);
     expect(usage).toEqual({
-      input_tokens: 410_141,
-      cache_read_input_tokens: 268_817,
-      cache_creation_input_tokens: 134_408,
+      input_tokens: 261_030,
+      cache_read_input_tokens: 367_647,
+      cache_creation_input_tokens: 183_823,
       output_tokens: 6_277,
     });
   });
@@ -2455,7 +2430,7 @@ describe("non-streaming requests", () => {
           headers: new Headers(),
           events: iterable<CanonicalResponseEvent>([
             { type: "response.created", response: { id: "resp_virtual", model: "gpt-5.6-sol", usage: null } },
-            { type: "response.completed", response: { id: "resp_virtual", model: "gpt-5.6-sol", usage: { input_tokens: 302_572, output_tokens: 6_277 } } },
+            { type: "response.completed", response: { id: "resp_virtual", model: "gpt-5.6-sol", usage: { input_tokens: 221_000, output_tokens: 6_277 } } },
           ]),
         };
       },
@@ -2463,11 +2438,11 @@ describe("non-streaming requests", () => {
     const { stream: _drop, ...rest } = baseRequest();
     const response = await new AnthropicMessagesGateway(adapter).stream(
       rest as AnthropicMessagesRequest,
-      { apiKey: "k", contextWindow: 372_000 },
+      { apiKey: "k", contextWindow: 272_000 },
     );
 
     expect(JSON.parse(await collectBody(response.body))).toMatchObject({
-      usage: { input_tokens: 813_366, output_tokens: 6_277 },
+      usage: { input_tokens: 812_500, output_tokens: 6_277 },
     });
   });
 

--- a/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
@@ -16,7 +16,6 @@ import {
   UnsupportedReasoningEffortError,
   buildAnthropicModelList,
   clampReasoningEffort,
-  claudeAccountingWindow,
   findGatewayModel,
   hasClaudeOneMillionMarker,
   projectAnthropicResponseUsage,
@@ -220,12 +219,13 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps = {}): AiGatewayR
         return true;
       }
       // Claude Code may strip the discovery-only `[1m]` suffix before sending a
-      // request. Derive its accounting coordinate from the resolved registry
+      // request. Derive the projection denominator from the resolved registry
       // model so every alias for the same Cursor/Codex model projects usage in
-      // the same way. The coordinate is the accounting window, not the real one:
-      // a provider that compacts below its hard limit meters against that budget.
+      // the same way. It is the model's real window: projecting against anything
+      // smaller maps the remaining capacity above 100% of the 1M coordinate,
+      // which Claude Code reads as an exceeded context and will not compact.
       const claudeContextWindow = hasClaudeOneMillionMarker(toClaudeGatewayModelId(target))
-        ? claudeAccountingWindow(target)
+        ? target.contextWindow
         : undefined;
       if (target.provider === "kimi") {
         await proxyToKimi(
@@ -247,9 +247,8 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps = {}): AiGatewayR
       const diagnosticsEnabled = target.provider === "cursor"
         ? await cursorDiagnosticsEnabled()
         : undefined;
-      // The real usable window is independent of the `[1m]` accounting coordinate:
-      // a 200000-window Cursor model carries no marker but still needs the guard,
-      // and a Codex model meters against a lower budget than it can actually hold.
+      // The guard runs regardless of the `[1m]` coordinate: a 200000-window Cursor
+      // model carries no marker but still needs to be refused before it overflows.
       const modelContextWindow = typeof target.contextWindow === "number"
         && Number.isFinite(target.contextWindow)
         && target.contextWindow > 0

--- a/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
@@ -160,7 +160,7 @@ describe("upstream credential", () => {
 
     expect(streamSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
       apiKey: SUBSCRIPTION_TOKEN,
-      contextWindow: 258_400,
+      contextWindow: 272_000,
       model: "gpt-5.6-sol",
       serviceTier: "priority",
       reasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
@@ -182,7 +182,7 @@ describe("upstream credential", () => {
 
     expect(res.status).toBe(200);
     expect(streamSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
-      contextWindow: 258_400,
+      contextWindow: 272_000,
     }));
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -385,10 +385,9 @@ describe("upstream credential", () => {
 
 describe("model context window", () => {
   it.each([
-    // The guard always gets the real window; the projection gets the accounting
-    // window. Codex meters against its reference client's compaction budget, so the
-    // two differ; a model without a declared threshold keeps them equal.
-    ["claude-gateway--codex--gpt-5.6-sol", 372_000, 258_400],
+    // The guard and the projection both take the model's real window, so a marked
+    // model's occupancy can never be reported above the 1M coordinate.
+    ["claude-gateway--codex--gpt-5.6-sol", 272_000, 272_000],
     ["claude-gateway--cursor--grok-4.5-fast", 256_000, 256_000],
     // A 200000-window Cursor native model earns no `[1m]` marker, so it gets no
     // projection denominator — but the guard still needs its real window.
@@ -425,7 +424,7 @@ describe("model context window", () => {
       res,
       token: ANTHROPIC_CRED,
       model: "claude-gateway--codex--gpt-5.6-sol",
-      // 4 chars/token puts this at ~500_000 tokens against a 372_000 window.
+      // 4 chars/token puts this at ~500_000 tokens against a 272_000 window.
       messages: [{ role: "user", content: "x".repeat(2_000_000) }],
     }));
 
@@ -434,7 +433,7 @@ describe("model context window", () => {
       type: "error",
       error: {
         type: "invalid_request_error",
-        message: expect.stringMatching(/^Prompt is too long: \d+ tokens > 372000 maximum$/),
+        message: expect.stringMatching(/^Prompt is too long: \d+ tokens > 272000 maximum$/),
       },
     });
     // The guard runs inside the gateway, so upstream was still spared the turn.


### PR DESCRIPTION
## Summary

- Codex 카탈로그의 `contextWindow`를 372000에서 실측값 **272000**으로 정정합니다. `codex debug models`(codex-cli 0.146.0)가 `context_window`/`max_context_window` 모두 272000으로 보고합니다. 기존 값은 사전 오버플로 가드를 100k 늦게 발동시켜 사실상 무력화하고 있었습니다.
- `autoCompactThreshold`를 폐기하고 usage 투영 분모를 모델의 **실제 창**으로 일원화합니다. 실제 창보다 작은 예산(258400)으로 나누면 남은 용량 구간이 Claude Code 1M 좌표의 100% 위로 매핑되는데, 그 영역에서 Claude Code는 `Context exceeds the 1m-token limit`을 띄우고 auto-compact을 중단해 수동 `/compact` 없이는 회복이 안 됩니다.
- 투영 결과를 1M 좌표 자체로 **상한 클램프**합니다. 상류가 카탈로그 창보다 큰 입력을 보고해도 세션이 초과 상태로 넘어가지 않습니다. Codex 외 프로바이더에도 동일하게 적용됩니다.

실측 잠김 사례: 실제 264,843 토큰(272000 창의 97%)이 258400 분모를 거쳐 1,024,923으로 보고되었고, Claude Code는 `1.1m/1m (112%)`로 표시한 채 auto-compact을 멈췄습니다. 정정 후에는 Claude Code 자체 예비분이 263,024 토큰(벽까지 8,976 여유)에서 압축을 발동시키고, 그마저 넘기면 사전 가드가 `Prompt is too long:`으로 거부해 reactive compaction으로 넘깁니다.

Cursor·Kimi는 동일 결함이 없습니다. Cursor 모델은 `autoCompactThreshold`를 선언한 적이 없어 분모가 이미 실제 창이고, 어댑터가 `usage.context_window`로 상류 실측 창을 함께 실어 보냅니다.

## Test Plan

- [x] `packages/core-ai-gateway` — `vitest run` 203 passed (5 files)
- [x] `packages/core-ai-gateway` — `typecheck` (tsc --noEmit), `build` (tsup) 통과
- [x] `runtime/fleet-plugins/terminal` — `vitest run` 530 passed (52 files), `typecheck` 통과
- [x] 루트 `check:core-boundary` 통과
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 36 entries validated
- [x] 폐기 필드 재유입 차단 및 1M 클램프 계약 테스트 신설

## Changelog

`no-changelog`. AI Gateway는 아직 미릴리스입니다(`pr-455.md`, `pr-463.md`가 `.changelog.d/`에 잔존). Release Baseline 규칙에 따라 사용자가 소비한 적 없는 동작의 교정은 독립 `Fixed` 항목을 만들지 않습니다. 대신 폐기된 기능을 광고하던 `pr-463.md`를 제거해 잘못된 릴리스 노트가 나가지 않도록 했습니다.