### PR TITLE
feat(fleet-console): guide Claude Gateway launches

### DIFF
--- a/.changelog.d/pr-471.md
+++ b/.changelog.d/pr-471.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Added
+- [fleet-console] Guide the first Claude Gateway launch from Canvas Controls while keeping Triage guidance tied to entering Triage mode.
+  ko: 캔버스 제어에서 Claude Gateway 첫 실행을 안내하고 선별 처리 안내는 실제 모드 진입 시에만 표시합니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console/sdk/operations";
 
+import { FEATURE_TOUR_BOUNDARY_ATTRIBUTE, FEATURE_TOUR_LAYER_SELECTOR } from "../feature-tour-catalog.js";
 import { useT } from "../i18n/index.js";
 
 interface CanvasContextMenuProps {
@@ -49,7 +50,9 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
 
   useEffect(() => {
     const handlePointer = (event: MouseEvent) => {
-      if (!containerRef.current?.contains(event.target as Node)) onClose();
+      const target = event.target as Node;
+      if (containerRef.current?.contains(target) || document.querySelector(FEATURE_TOUR_LAYER_SELECTOR)?.contains(target)) return;
+      onClose();
     };
     const handleKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") onClose();
@@ -74,7 +77,14 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
       style={clampedAnchorStyle(anchor, viewportBounds, placement, menuSize)}
       data-canvas-blocker
     >
-      <div className="operation-launch-menu theater-menu canvas-context-menu" role="dialog" aria-label={t("canvas.menu.aria")} tabIndex={-1} ref={menuRef}>
+      <div
+        className="operation-launch-menu theater-menu canvas-context-menu"
+        role="dialog"
+        aria-label={t("canvas.menu.aria")}
+        tabIndex={-1}
+        ref={menuRef}
+        {...{ [FEATURE_TOUR_BOUNDARY_ATTRIBUTE]: "" }}
+      >
         <div className="canvas-context-menu-head">
           <span className="canvas-context-menu-reticle" aria-hidden="true"><CommandReticleIcon /></span>
           <span className="canvas-context-menu-head-text">
@@ -94,6 +104,9 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                   type="button"
                   role="menuitem"
                   className="theater-menu-item canvas-context-menu-item operation-launch-menu-item"
+                  // 실행 종류의 안정 식별자. 기능 투어처럼 특정 항목을 짚어야 하는 바깥 선택자가
+                  // 번역 가능한 title/label 문자열 대신 이 속성에 걸리도록 한다.
+                  data-operation-launch-kind={kind.id}
                   disabled={disabled}
                   title={kind.disabledReason}
                   onClick={() => onLaunchKind(plugin.id, kind)}

--- a/runtime/fleet-console/core/client/src/components/feature-tour.tsx
+++ b/runtime/fleet-console/core/client/src/components/feature-tour.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 
-import { FEATURE_TOURS, type FeatureTour, type FeatureTourStep } from "../feature-tour-catalog.js";
+import {
+  FEATURE_TOURS,
+  FEATURE_TOUR_BOUNDARY_SELECTOR,
+  FEATURE_TOUR_LAYER_ATTRIBUTE,
+  type FeatureTour,
+  type FeatureTourStep,
+} from "../feature-tour-catalog.js";
 import { setGlobalSettingsField, useGlobalSettingsStore } from "../global-settings-store.js";
 import { useT, type CoreMessageKey } from "../i18n/index.js";
 
@@ -82,21 +88,16 @@ export function FeatureTourOverlay() {
     }
     anchor.classList.add("is-feature-tour-anchor");
     const updatePosition = () => {
-      const rect = anchor.getBoundingClientRect();
+      const boundary = anchor.closest<HTMLElement>(FEATURE_TOUR_BOUNDARY_SELECTOR);
       const card = cardRef.current?.getBoundingClientRect();
-      const cardWidth = card?.width ?? 320;
-      const cardHeight = card?.height ?? 180;
-      const gap = 12;
-      const margin = 12;
-      const below = rect.bottom + gap;
-      const top = below + cardHeight <= window.innerHeight - margin
-        ? below
-        : Math.max(margin, rect.top - cardHeight - gap);
-      const left = Math.min(
-        window.innerWidth - cardWidth - margin,
-        Math.max(margin, rect.left + rect.width / 2 - cardWidth / 2),
-      );
-      setPosition({ left, top, centered: false });
+      setPosition(resolveFeatureTourCardPosition({
+        anchor: anchor.getBoundingClientRect(),
+        boundary: boundary?.getBoundingClientRect() ?? null,
+        cardWidth: card?.width ?? 320,
+        cardHeight: card?.height ?? 180,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+      }));
     };
     updatePosition();
     return () => anchor.classList.remove("is-feature-tour-anchor");
@@ -105,9 +106,7 @@ export function FeatureTourOverlay() {
   const finish = useCallback(async () => {
     if (!resolved) return;
     const key = featureTourSeenKey(resolved.tour.id, resolved.phase);
-    const completionBase = resolved.phase === "walkthrough"
-      ? appendSeenFeatureTour(seen, featureTourSeenKey(resolved.tour.id, "spotlight"))
-      : seen;
+    const completionBase = featureTourCompletionBase(seen, resolved.tour, resolved.phase);
     setLockedTour(null);
     setStepIndex(0);
     await persistFeatureTourSeen(completionBase, key, (next) => setGlobalSettingsField("seenFeatureTours", next));
@@ -122,6 +121,7 @@ export function FeatureTourOverlay() {
   return (
     <div
       className={`feature-tour-layer is-${resolved.phase} ${position.centered ? "is-centered" : ""}`}
+      {...{ [FEATURE_TOUR_LAYER_ATTRIBUTE]: "" }}
       data-feature-tour-id={resolved.tour.id}
       data-feature-tour-phase={resolved.phase}
     >
@@ -166,6 +166,54 @@ export function FeatureTourOverlay() {
       </section>
     </div>
   );
+}
+
+export function resolveFeatureTourCardPosition(options: {
+  readonly anchor: Pick<DOMRect, "left" | "right" | "top" | "bottom" | "width">;
+  readonly boundary: Pick<DOMRect, "left" | "right" | "top" | "bottom" | "width" | "height"> | null;
+  readonly cardWidth: number;
+  readonly cardHeight: number;
+  readonly viewportWidth: number;
+  readonly viewportHeight: number;
+}): CardPosition {
+  const { anchor, boundary, cardWidth, cardHeight, viewportWidth, viewportHeight } = options;
+  const gap = 12;
+  const margin = 12;
+  const clampLeft = (left: number) => Math.min(viewportWidth - cardWidth - margin, Math.max(margin, left));
+  const clampTop = (top: number) => Math.min(viewportHeight - cardHeight - margin, Math.max(margin, top));
+  if (boundary) {
+    const centeredTop = clampTop(boundary.top + boundary.height / 2 - cardHeight / 2);
+    if (boundary.right + gap + cardWidth <= viewportWidth - margin) {
+      return { left: boundary.right + gap, top: centeredTop, centered: false };
+    }
+    if (boundary.left - gap - cardWidth >= margin) {
+      return { left: boundary.left - gap - cardWidth, top: centeredTop, centered: false };
+    }
+    const centeredLeft = clampLeft(boundary.left + boundary.width / 2 - cardWidth / 2);
+    if (boundary.bottom + gap + cardHeight <= viewportHeight - margin) {
+      return { left: centeredLeft, top: boundary.bottom + gap, centered: false };
+    }
+    return { left: centeredLeft, top: Math.max(margin, boundary.top - cardHeight - gap), centered: false };
+  }
+  const below = anchor.bottom + gap;
+  const top = below + cardHeight <= viewportHeight - margin
+    ? below
+    : Math.max(margin, anchor.top - cardHeight - gap);
+  return {
+    left: clampLeft(anchor.left + anchor.width / 2 - cardWidth / 2),
+    top,
+    centered: false,
+  };
+}
+
+export function featureTourCompletionBase(
+  seen: readonly string[],
+  tour: FeatureTour,
+  phase: FeatureTourPhase,
+): readonly string[] {
+  return phase === "walkthrough" && tour.spotlight
+    ? appendSeenFeatureTour(seen, featureTourSeenKey(tour.id, "spotlight"))
+    : seen;
 }
 
 export function featureTourSeenKey(tourId: string, phase: FeatureTourPhase): string {

--- a/runtime/fleet-console/core/client/src/feature-tour-catalog.ts
+++ b/runtime/fleet-console/core/client/src/feature-tour-catalog.ts
@@ -1,3 +1,8 @@
+export const FEATURE_TOUR_LAYER_ATTRIBUTE = "data-feature-tour-layer";
+export const FEATURE_TOUR_LAYER_SELECTOR = `[${FEATURE_TOUR_LAYER_ATTRIBUTE}]`;
+export const FEATURE_TOUR_BOUNDARY_ATTRIBUTE = "data-feature-tour-boundary";
+export const FEATURE_TOUR_BOUNDARY_SELECTOR = `[${FEATURE_TOUR_BOUNDARY_ATTRIBUTE}]`;
+
 export interface FeatureTourStep {
   readonly anchor: string | null;
   readonly titleKey: string;
@@ -13,11 +18,8 @@ export interface FeatureTour {
 export const FEATURE_TOURS: readonly FeatureTour[] = [
   {
     id: "triage",
-    spotlight: {
-      anchor: ".command-band-triage-toggle",
-      titleKey: "featureTour.triage.spotlightTitle",
-      bodyKey: "featureTour.triage.spotlightBody",
-    },
+    // 버튼을 미리 소개하지 않고, 사용자가 선별 처리에 실제 진입했을 때만 안내한다.
+    spotlight: null,
     walkthrough: [
       {
         anchor: ".canvas-operation.is-triage-stage",
@@ -35,5 +37,16 @@ export const FEATURE_TOURS: readonly FeatureTour[] = [
         bodyKey: "featureTour.triage.step3Body",
       },
     ],
+  },
+  {
+    id: "claude-gateway",
+    // Canvas controls 메뉴의 Claude Gateway 실행 항목 하나만 가리킨다. 선택자는 의미 속성에 건다 —
+    // title/i18n 문자열에 걸면 라벨을 손보는 순간 앵커가 조용히 사라진다.
+    spotlight: {
+      anchor: '[data-operation-launch-kind="claude-gateway"]',
+      titleKey: "featureTour.claudeGateway.spotlightTitle",
+      bodyKey: "featureTour.claudeGateway.spotlightBody",
+    },
+    walkthrough: [],
   },
 ] as const;

--- a/runtime/fleet-console/core/client/src/i18n/messages/common.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/common.ts
@@ -28,14 +28,14 @@ export const commonEn = {
   "featureTour.skip": "Skip",
   "featureTour.gotIt": "Got it",
   "featureTour.progress": "{current} / {total}",
-  "featureTour.triage.spotlightTitle": "Triage mode is new",
-  "featureTour.triage.spotlightBody": "It stands up one waiting item at a time so you can clear them back to back. Click here, or press Alt+T.",
   "featureTour.triage.step1Title": "One at a time",
   "featureTour.triage.step1Body": "Only what is waiting stays. Answer it and the next item takes the same spot.",
   "featureTour.triage.step2Title": "You can jump the queue",
   "featureTour.triage.step2Body": "Click anything in the left list or the rail below to bring it up now. The rail also shows what is next.",
   "featureTour.triage.step3Title": "Turn it off and nothing is lost",
   "featureTour.triage.step3Body": "Press it again, or Alt+T, and every panel returns to its coordinates.",
+  "featureTour.claudeGateway.spotlightTitle": "Claude Gateway is available",
+  "featureTour.claudeGateway.spotlightBody": "Start Claude Code through AI Gateway to use the models enabled in Settings. It is well suited to large-scale workloads. You can switch models later with /model.",
 } as const;
 
 export const commonKo: Record<keyof typeof commonEn, string> = {
@@ -68,12 +68,12 @@ export const commonKo: Record<keyof typeof commonEn, string> = {
   "featureTour.skip": "건너뛰기",
   "featureTour.gotIt": "알겠습니다",
   "featureTour.progress": "{current} / {total}",
-  "featureTour.triage.spotlightTitle": "선별 처리 모드가 추가되었습니다",
-  "featureTour.triage.spotlightBody": "답을 기다리는 작업만 한 건씩 세워 연속으로 처리합니다. 눌러서 켜거나 Alt+T를 누르십시오.",
   "featureTour.triage.step1Title": "한 번에 하나만 세웁니다",
   "featureTour.triage.step1Body": "답을 기다리는 작업만 남습니다. 답을 보내면 다음 건이 같은 자리에 섭니다.",
   "featureTour.triage.step2Title": "순서는 가로챌 수 있습니다",
   "featureTour.triage.step2Body": "좌측 목록이나 아래 대기 레일에서 무엇이든 클릭하면 그 건이 바로 올라옵니다. 레일이 다음 순서도 함께 보여줍니다.",
   "featureTour.triage.step3Title": "끄면 원래 화면 그대로입니다",
   "featureTour.triage.step3Body": "다시 누르거나 Alt+T를 누르면 패널이 원래 자리로 돌아갑니다.",
+  "featureTour.claudeGateway.spotlightTitle": "Claude Gateway를 사용할 수 있습니다",
+  "featureTour.claudeGateway.spotlightBody": "Claude Code를 AI Gateway로 시작하면 설정에서 켠 모델을 사용할 수 있습니다. 대규모 워크로드에 적합합니다. 실행 후 /model로 모델을 바꿀 수도 있습니다.",
 };

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -3,12 +3,18 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OperationCatalogPlugin } from "@fleet-console/sdk/operations";
 
 import { CanvasContextMenu } from "../core/client/src/canvas/canvas-context-menu.js";
+import {
+  FEATURE_TOUR_BOUNDARY_ATTRIBUTE,
+  FEATURE_TOUR_LAYER_ATTRIBUTE,
+} from "../core/client/src/feature-tour-catalog.js";
 
 let container: HTMLDivElement;
 let root: Root;
 let originalGetBoundingClientRect: typeof Element.prototype.getBoundingClientRect;
+let tourLayer: HTMLDivElement | null;
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -23,10 +29,12 @@ beforeEach(() => {
   container = document.createElement("div");
   document.body.append(container);
   root = createRoot(container);
+  tourLayer = null;
 });
 
 afterEach(() => {
   act(() => root.unmount());
+  tourLayer?.remove();
   container.remove();
   Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
 });
@@ -62,19 +70,74 @@ describe("CanvasContextMenu anchor placement", () => {
   });
 });
 
+describe("CanvasContextMenu launch kind attribute", () => {
+  it("tags each launch item with its kind id so selectors do not depend on the title", () => {
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [
+      {
+        id: "terminal",
+        title: "Terminal",
+        kinds: [
+          { id: "claude", type: "agent", title: "Claude Code (Classic)" },
+          { id: "claude-gateway", type: "agent", title: "Claude (Gateway • Experimental)" },
+        ],
+      },
+    ]);
+
+    const gateway = document.querySelectorAll<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]');
+    expect(gateway).toHaveLength(1);
+    expect(gateway[0]?.textContent).toContain("Claude (Gateway • Experimental)");
+    expect(document.querySelector('[data-operation-launch-kind="claude"]')).not.toBeNull();
+  });
+
+  it("marks the rendered menu box as the tour placement boundary", () => {
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 });
+
+    const boundary = document.querySelector(`[${FEATURE_TOUR_BOUNDARY_ATTRIBUTE}]`);
+    expect(boundary).toBe(document.querySelector(".canvas-context-menu"));
+    expect(boundary).not.toBe(document.querySelector(".operation-launch-control"));
+  });
+
+  it("focuses the menu container and dismisses it with Escape", () => {
+    const onClose = vi.fn();
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [], onClose);
+
+    expect(document.activeElement).toBe(document.querySelector(".canvas-context-menu"));
+    act(() => document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not dismiss the menu before the feature tour card handles its click", () => {
+    const onClose = vi.fn();
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [], onClose);
+    tourLayer = document.createElement("div");
+    tourLayer.setAttribute(FEATURE_TOUR_LAYER_ATTRIBUTE, "");
+    const tourButton = document.createElement("button");
+    tourLayer.append(tourButton);
+    document.body.append(tourLayer);
+
+    act(() => tourButton.dispatchEvent(new MouseEvent("mousedown", { bubbles: true })));
+    expect(onClose).not.toHaveBeenCalled();
+
+    act(() => document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true })));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});
+
 function renderMenu(
   anchor: { readonly x: number; readonly y: number },
   viewportBounds: { readonly width: number; readonly height: number },
+  catalog: readonly OperationCatalogPlugin[] = [],
+  onClose = vi.fn(),
 ): void {
   act(() => root.render(
     <CanvasContextMenu
       anchor={anchor}
       viewportBounds={viewportBounds}
-      catalog={[]}
+      catalog={catalog}
       canLaunch
       renderKindIcon={() => null}
       onLaunchKind={vi.fn()}
-      onClose={vi.fn()}
+      onClose={onClose}
     />,
   ));
 }

--- a/runtime/fleet-console/tests/feature-tour.test.ts
+++ b/runtime/fleet-console/tests/feature-tour.test.ts
@@ -4,11 +4,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   availableFeatureTourSteps,
+  featureTourCompletionBase,
   persistFeatureTourSeen,
+  resolveFeatureTourCardPosition,
   resolveNextFeatureTour,
 } from "../core/client/src/components/feature-tour.js";
 import type { FeatureTour } from "../core/client/src/feature-tour-catalog.js";
 import { FEATURE_TOURS } from "../core/client/src/feature-tour-catalog.js";
+import { CORE_MESSAGES } from "../core/client/src/i18n/index.js";
 import { sanitizeSeenFeatureTours } from "../core/host/console-settings.js";
 
 const TOUR: FeatureTour = {
@@ -44,21 +47,114 @@ describe("feature tour", () => {
     expect(presentation?.steps).toEqual([TOUR.walkthrough[0]]);
   });
 
-  it("defines the Triage walkthrough as exactly three renumbered steps", () => {
-    const triage = FEATURE_TOURS.find((tour) => tour.id === "triage");
+  it("ships Triage as an entry-only walkthrough without a button spotlight", () => {
+    expect(FEATURE_TOURS.map((tour) => tour.id)).toEqual(["triage", "claude-gateway"]);
 
-    expect(triage?.walkthrough).toHaveLength(3);
+    const triage = FEATURE_TOURS.find((tour) => tour.id === "triage");
+    expect(triage?.spotlight).toBeNull();
     expect(triage?.walkthrough.map((step) => step.anchor)).toEqual([
       ".canvas-operation.is-triage-stage",
       ".canvas-triage-rail",
       ".command-band-triage-toggle",
     ]);
-    expect(triage?.walkthrough.map((step) => [step.titleKey, step.bodyKey])).toEqual([
-      ["featureTour.triage.step1Title", "featureTour.triage.step1Body"],
-      ["featureTour.triage.step2Title", "featureTour.triage.step2Body"],
-      ["featureTour.triage.step3Title", "featureTour.triage.step3Body"],
-    ]);
-    expect(triage?.walkthrough[1]?.anchor).toBe(".canvas-triage-rail");
+  });
+
+  it("ships the Claude Gateway tour as a spotlight with no walkthrough", () => {
+    const gateway = FEATURE_TOURS.find((tour) => tour.id === "claude-gateway");
+    expect(gateway?.walkthrough).toEqual([]);
+    expect(gateway?.spotlight).toEqual({
+      anchor: '[data-operation-launch-kind="claude-gateway"]',
+      titleKey: "featureTour.claudeGateway.spotlightTitle",
+      bodyKey: "featureTour.claudeGateway.spotlightBody",
+    });
+  });
+
+  it("does not show Triage onboarding for the button before mode entry", () => {
+    document.body.innerHTML = '<button class="command-band-triage-toggle"></button>';
+
+    expect(resolveNextFeatureTour(FEATURE_TOURS, [], document)).toBeNull();
+  });
+
+  it("resolves the Triage walkthrough on first mode entry", () => {
+    document.body.innerHTML = [
+      '<section class="canvas-operation is-triage-stage"></section>',
+      '<aside class="canvas-triage-rail"></aside>',
+      '<button class="command-band-triage-toggle"></button>',
+    ].join("");
+
+    const presentation = resolveNextFeatureTour(FEATURE_TOURS, [], document);
+    expect(presentation?.tour.id).toBe("triage");
+    expect(presentation?.phase).toBe("walkthrough");
+    expect(presentation?.steps).toEqual(
+      FEATURE_TOURS.find((tour) => tour.id === "triage")?.walkthrough,
+    );
+    expect(resolveNextFeatureTour(FEATURE_TOURS, ["triage.walkthrough"], document)).toBeNull();
+  });
+
+  it("resolves the shipped Claude Gateway catalog as a spotlight on its semantic launch attribute", () => {
+    const gateway = FEATURE_TOURS.find((tour) => tour.id === "claude-gateway");
+    const anchor = gateway?.spotlight?.anchor ?? "";
+    document.body.innerHTML = [
+      '<button data-operation-launch-kind="claude">Claude Code (Classic)</button>',
+      '<button data-operation-launch-kind="claude-gateway">Claude (Gateway • Experimental)</button>',
+      '<button data-operation-launch-kind="codex">Codex (Classic)</button>',
+    ].join("");
+
+    const presentation = resolveNextFeatureTour(FEATURE_TOURS, [], document);
+    expect(presentation?.tour.id).toBe("claude-gateway");
+    expect(presentation?.phase).toBe("spotlight");
+    expect(presentation?.steps).toEqual([gateway?.spotlight]);
+    const matches = document.querySelectorAll(anchor);
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.getAttribute("data-operation-launch-kind")).toBe("claude-gateway");
+    expect(anchor).not.toMatch(/Gateway •|Experimental/);
+  });
+
+  it("describes Claude Gateway as suitable for large-scale workloads in both locales", () => {
+    expect(CORE_MESSAGES.en["featureTour.claudeGateway.spotlightBody"])
+      .toContain("well suited to large-scale workloads");
+    expect(CORE_MESSAGES.ko["featureTour.claudeGateway.spotlightBody"])
+      .toContain("대규모 워크로드에 적합합니다");
+  });
+
+  it("keeps every shipped tour message key present in both locale catalogs", () => {
+    for (const tour of FEATURE_TOURS) {
+      const steps = [...(tour.spotlight ? [tour.spotlight] : []), ...tour.walkthrough];
+      for (const step of steps) {
+        expect(CORE_MESSAGES.en).toHaveProperty(step.titleKey);
+        expect(CORE_MESSAGES.ko).toHaveProperty(step.titleKey);
+        expect(CORE_MESSAGES.en).toHaveProperty(step.bodyKey);
+        expect(CORE_MESSAGES.ko).toHaveProperty(step.bodyKey);
+      }
+    }
+  });
+
+  it("positions a tour card outside its containing menu boundary", () => {
+    expect(resolveFeatureTourCardPosition({
+      anchor: { left: 640, right: 900, top: 360, bottom: 400, width: 260 },
+      boundary: { left: 620, right: 920, top: 120, bottom: 640, width: 300, height: 520 },
+      cardWidth: 340,
+      cardHeight: 180,
+      viewportWidth: 1440,
+      viewportHeight: 900,
+    })).toEqual({ left: 932, top: 290, centered: false });
+  });
+
+  it("falls back to the existing anchor placement without a boundary", () => {
+    expect(resolveFeatureTourCardPosition({
+      anchor: { left: 300, right: 420, top: 200, bottom: 240, width: 120 },
+      boundary: null,
+      cardWidth: 320,
+      cardHeight: 180,
+      viewportWidth: 1200,
+      viewportHeight: 800,
+    })).toEqual({ left: 200, top: 252, centered: false });
+  });
+
+  it("does not synthesize a spotlight seen key for a walkthrough-only tour", () => {
+    const triage = FEATURE_TOURS.find((tour) => tour.id === "triage");
+    expect(triage).toBeDefined();
+    expect(featureTourCompletionBase([], triage!, "walkthrough")).toEqual([]);
   });
 
   it("records the composite key when a phase completes", async () => {
@@ -71,10 +167,10 @@ describe("feature tour", () => {
 
   it("sanitizes malformed, oversized, and duplicate persisted keys", () => {
     const tooLong = "x".repeat(65);
-    const input = ["triage.spotlight", 4, "triage.spotlight", tooLong, "triage.walkthrough"];
+    const input = ["example.spotlight", 4, "example.spotlight", tooLong, "example.walkthrough"];
 
-    expect(sanitizeSeenFeatureTours(input)).toEqual(["triage.spotlight", "triage.walkthrough"]);
+    expect(sanitizeSeenFeatureTours(input)).toEqual(["example.spotlight", "example.walkthrough"]);
     expect(sanitizeSeenFeatureTours(Array.from({ length: 70 }, (_, index) => `tour-${index}`))).toHaveLength(64);
-    expect(sanitizeSeenFeatureTours("triage.spotlight")).toBeUndefined();
+    expect(sanitizeSeenFeatureTours("example.spotlight")).toBeUndefined();
   });
 });

--- a/runtime/fleet-console/tests/global-settings-api.test.ts
+++ b/runtime/fleet-console/tests/global-settings-api.test.ts
@@ -40,7 +40,7 @@ describe("global settings client transport", () => {
   });
 
   it("requires and sends the seen Feature Tour keys", async () => {
-    const seenFeatureTours = ["triage.spotlight"] as const;
+    const seenFeatureTours = ["example.spotlight"] as const;
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({ state: { ...SETTINGS, seenFeatureTours } })));
     globalThis.fetch = fetchMock as typeof fetch;
 

--- a/runtime/fleet-console/tests/global-settings-routes.test.ts
+++ b/runtime/fleet-console/tests/global-settings-routes.test.ts
@@ -221,14 +221,14 @@ describe("global settings routes", () => {
   it("PUT /global-settings stores seen Feature Tour keys through the global settings path", async () => {
     const harness = createRouterHarness({
       authorized: true,
-      body: { seenFeatureTours: ["triage.spotlight", "triage.walkthrough"] },
+      body: { seenFeatureTours: ["example.spotlight", "example.walkthrough"] },
       general: { language: "ko" },
     });
     await harness.router({ req: jsonReq("PUT"), res: res(), pathname: "/api/v1/settings/global" });
 
-    expect(harness.currentGeneral()?.seenFeatureTours).toEqual(["triage.spotlight", "triage.walkthrough"]);
+    expect(harness.currentGeneral()?.seenFeatureTours).toEqual(["example.spotlight", "example.walkthrough"]);
     expect(harness.writes[0]?.body).toMatchObject({
-      state: { seenFeatureTours: ["triage.spotlight", "triage.walkthrough"] },
+      state: { seenFeatureTours: ["example.spotlight", "example.walkthrough"] },
     });
   });
 


### PR DESCRIPTION
## Summary
- Add a one-time Claude Gateway spotlight when Canvas Controls exposes the launch option, including guidance for large-scale workloads.
- Remove the Triage button spotlight while preserving the existing first-entry walkthrough and its durable seen state.
- Keep the transient menu open while dismissing the guide and place the guide outside the menu on both launch paths.

## Type of Change
- [x] feat — new feature or carrier capability
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] chore — build, tooling, deps
- [ ] BREAKING CHANGE

## Scope
- [x] `runtime/fleet-console`

## Test Plan
- [x] `corepack pnpm --dir runtime/fleet-console exec vitest run tests/feature-tour.test.ts tests/canvas-context-menu-anchor.test.tsx tests/global-settings-api.test.ts tests/global-settings-routes.test.ts tests/i18n.test.ts tests/instrument-design-contract.test.ts` — 97 tests passed
- [x] `corepack pnpm --dir runtime/fleet-console typecheck`
- [x] `corepack pnpm --dir runtime/fleet-console build`
- [x] Browser E2E: Triage button does not auto-open a tour; Claude Gateway spotlight, copy, focus, dismissal, durable seen state, reload suppression, and zero card/menu overlap pass on FAB and canvas context-menu paths
- [x] `git diff --check`

## Changelog
- [x] Added `.changelog.d/pr-471.md`.
- [x] Fragment uses grouped `fleet-console` / `Added` syntax with adjacent English and Korean summaries.
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 39 entries validated.

## Notes for Reviewers
- The Triage walkthrough remains unchanged and still appears on first entry into Triage mode; only its pre-entry button spotlight is removed.