### PR TITLE
fix(core-ai-gateway): drop a stale Cursor checkpoint after a compaction

### DIFF
--- a/packages/core-ai-gateway/src/cursor-adapter.ts
+++ b/packages/core-ai-gateway/src/cursor-adapter.ts
@@ -153,6 +153,11 @@ interface CursorContextCheckpoint {
 interface StoredCursorContextCheckpoint extends CursorContextCheckpoint {
   readonly wireModelId: string;
   readonly credentialFingerprint: string;
+  /**
+   * 이 체크포인트를 측정한 요청 자체의 입력 추정치. 대화가 그만큼 크다는 전제가
+   * 무너졌는지 판정하는 기준선이며, 체크포인트 값과는 다른 좌표다.
+   */
+  readonly requestInputTokens: number;
 }
 
 /** Last authoritative Cursor checkpoint for a credential-partitioned conversation and wire model. */
@@ -1385,6 +1390,7 @@ export class CursorAdapter implements AiGatewayAdapter {
       identity.conversationId,
       plan.wireModelId,
       descriptor.credentialFingerprint,
+      plan.estimatedInputTokens,
     );
     report("turn.start", {
       model,
@@ -1469,6 +1475,7 @@ export class CursorAdapter implements AiGatewayAdapter {
         identity.conversationId,
         plan.wireModelId,
         descriptor.credentialFingerprint,
+        plan.estimatedInputTokens,
         checkpoint,
       ),
       toolFinalizeGraceMs: this.toolFinalizeGraceMs,
@@ -1668,10 +1675,17 @@ function rememberCursorWireModel(
   return previous;
 }
 
+/**
+ * 보관된 체크포인트는 그것을 측정한 대화가 계속 자라는 동안에만 이 요청을 설명한다.
+ * Claude Code가 컴팩트하면 입력이 급감하는데, 낡은 값은 그 요청보다 큰 점유를 주장하고
+ * 소비 측이 그것을 바닥으로 쓰기 때문에 계기가 세션이 끝날 때까지 고정된다. 요청이
+ * 기준선보다 작아졌다면 대화가 줄어든 것이므로 체크포인트를 폐기한다.
+ */
 function recallCursorContextCheckpoint(
   conversationId: string,
   wireModelId: string,
   credentialFingerprint: string,
+  requestInputTokens: number,
 ): CursorContextCheckpoint | undefined {
   const key = cursorConversationStateKey(credentialFingerprint, conversationId);
   const checkpoint = CURSOR_CONTEXT_CHECKPOINT_BY_STATE.get(key);
@@ -1680,6 +1694,7 @@ function recallCursorContextCheckpoint(
   if (
     checkpoint.wireModelId !== wireModelId
     || checkpoint.credentialFingerprint !== credentialFingerprint
+    || requestInputTokens < checkpoint.requestInputTokens
   ) {
     return undefined;
   }
@@ -1691,6 +1706,7 @@ function rememberCursorContextCheckpoint(
   conversationId: string,
   wireModelId: string,
   credentialFingerprint: string,
+  requestInputTokens: number,
   checkpoint: CursorContextCheckpoint,
 ): void {
   const key = cursorConversationStateKey(credentialFingerprint, conversationId);
@@ -1705,6 +1721,7 @@ function rememberCursorContextCheckpoint(
   CURSOR_CONTEXT_CHECKPOINT_BY_STATE.set(key, {
     wireModelId,
     credentialFingerprint,
+    requestInputTokens,
     ...checkpoint,
   });
 }

--- a/packages/core-ai-gateway/tests/cursor-live-run.test.ts
+++ b/packages/core-ai-gateway/tests/cursor-live-run.test.ts
@@ -401,6 +401,42 @@ describe("Cursor live client-tool Run bridge", () => {
     }
   });
 
+  it("drops a carried checkpoint once the conversation shrinks below it", async () => {
+    // 소비 측은 보관 체크포인트를 입력 토큰의 바닥으로 쓴다. Claude Code가 컴팩트해
+    // 대화가 급감해도 바닥이 남아 있으면 계기가 세션이 끝날 때까지 그 값에 고정된다.
+    const largeStream = new BridgeCursorStream([
+      {
+        conversationCheckpointUpdate: {
+          tokenDetails: { usedTokens: 120_000, maxTokens: 256_000 },
+        },
+      },
+      ...cursorCompletionFrames("large turn complete"),
+    ]);
+    const compactedStream = new BridgeCursorStream(
+      cursorCompletionFrames("compacted turn complete"),
+    );
+    const harness = cursorHarness([largeStream, compactedStream]);
+    const base = cursorRequest("session-checkpoint-staleness", "kimi-k3-1m");
+    const large: CanonicalResponseRequest = {
+      ...base,
+      input: [{ type: "message", role: "user", content: "x".repeat(60_000) }],
+    };
+
+    try {
+      const largeUsage = cursorCompletedUsage(
+        await collectCursorResponse(harness.adapter, large),
+      );
+      expect(largeUsage?.input_tokens).toBeGreaterThan(100_000);
+
+      const compactedUsage = cursorCompletedUsage(
+        await collectCursorResponse(harness.adapter, base),
+      );
+      expect(compactedUsage?.input_tokens).toBeLessThan(10_000);
+    } finally {
+      harness.adapter.dispose();
+    }
+  });
+
   it.each(["partial", "extra", "duplicate", "stale"])(
     "rejects a %s result batch without injecting and falls back cold",
     async (kind) => {


### PR DESCRIPTION
## Summary

Cursor 어댑터는 보고 입력 토큰을 마지막 Cursor 컨텍스트 체크포인트로 **바닥 고정**합니다(`Math.max(estimatedInputTokens, contextCheckpointAtStart.contextTokens)`). 그래서 계기가 오르기만 하고 내려오지 못합니다.

Claude Code가 컴팩트하면 요청은 작아지지만 보관된 체크포인트는 컴팩션 이전 점유를 계속 주장하고, 체크포인트가 매 턴 recall→delete→remember로 왕복 저장되기 때문에 **그 값이 세션이 끝날 때까지 자기 자신을 재생산**합니다.

실측 사례(`cursor--grok-4.5-fast` 세션): `compactMetadata`가 `preTokens: 549,533 → postTokens: 13,968`을 기록했는데도 이후 25턴 90초 동안 보고 usage가 **정확히 549,418에서 단 1도 움직이지 않았습니다.** status line의 CW가 55%에 영구 고정됩니다.

체크포인트를 측정한 요청의 자체 입력 추정치를 함께 보관하고, 이후 요청이 그 기준선보다 작아지면 체크포인트를 폐기합니다. **바닥 자체는 유지합니다** — 대화가 자라는 동안에는 문자 기반 추정치가 실측값보다 낮게 잡히는 걸 막아주는 원래 목적이 유효합니다. 잘못된 것은 축소를 구분하지 못한 점입니다.

Codex 경로는 `store = false` 무상태라 이 결함이 없습니다. Cursor 전용입니다.

## Test Plan

- [x] 신규 회귀 테스트를 **수정 없이 먼저 실패시켜 재현** — `expected 120000 to be less than 10000` (트랜스크립트의 고정 현상과 동일)
- [x] `packages/core-ai-gateway` — `vitest run` 204 passed (5 files), `typecheck`, `build` 통과
- [x] `runtime/fleet-plugins/terminal` — `vitest run` 530 passed (52 files)
- [x] 루트 `check:core-boundary` 통과

## Changelog

`no-changelog`. AI Gateway는 아직 미릴리스입니다(`pr-455.md`가 `.changelog.d/`에 잔존). Release Baseline 규칙에 따라 사용자가 소비한 적 없는 동작의 교정은 독립 `Fixed` 항목을 만들지 않습니다.