### PR TITLE
fix(fleet-admiral): deny current built-in agent selectors

### DIFF
--- a/.changelog.d/pr-474.md
+++ b/.changelog.d/pr-474.md
@@ -1,0 +1,4 @@
+### fleet-core
+#### Fixed
+- [fleet-admiral] Deny built-in Claude Code agents with legacy and current selectors while simplifying gateway custom agent names.
+  ko: 기본 Claude Code 에이전트를 구형 및 현재 선택자로 차단하고 게이트웨이 커스텀 에이전트 이름을 간소화합니다.

--- a/packages/fleet-admiral/src/agent-cli/gateway-agents.ts
+++ b/packages/fleet-admiral/src/agent-cli/gateway-agents.ts
@@ -90,16 +90,19 @@ export function buildGatewayCustomAgents(
   return agents;
 }
 
-/** `--disallowedTools`에 넣을 `Task(name)` 목록. Claude Code는 Agent 비활성화를 이 문법으로 받는다. */
+/** `--disallowedTools`에 넣을 구·신 Agent 선택자 목록. */
 export function buildGatewayDisallowedAgentTools(
   agentTypes: readonly string[] = GATEWAY_DISABLED_BUILTIN_AGENTS,
 ): string[] {
-  return agentTypes.map((agentType) => `Task(${agentType})`);
+  return agentTypes.flatMap((agentType) => [
+    `Task(${agentType})`,
+    `Agent(${agentType})`,
+  ]);
 }
 
 /**
  * Claude Code Agent 타입 키로 쓸 안전한 이름.
- * `claude-gateway--cursor--claude-opus-5[1m]` + `high` → `gw-cursor-claude-opus-5-1m-high`
+ * `claude-gateway--cursor--claude-opus-5[1m]` + `high` → `cursor-claude-opus-5-1m-high`
  */
 export function toGatewayAgentName(modelId: string, effort?: GatewayReasoningEffort): string {
   const stripped = modelId.startsWith("claude-gateway--")
@@ -111,7 +114,7 @@ export function toGatewayAgentName(modelId: string, effort?: GatewayReasoningEff
     .replace(/^-+|-+$/g, "")
     .toLowerCase();
   const stem = base.length > 0 ? base : "model";
-  return effort === undefined ? `gw-${stem}` : `gw-${stem}-${effort}`;
+  return effort === undefined ? stem : `${stem}-${effort}`;
 }
 
 function gatewayAgentDescription(

--- a/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
@@ -50,12 +50,16 @@ describe("claude-gateway profile", () => {
 });
 
 describe("claude-gateway custom agents", () => {
-  it("builds Task(name) deny entries for the built-in agents", () => {
+  it("builds legacy and current deny entries for the built-in agents", () => {
     expect(buildGatewayDisallowedAgentTools()).toEqual([
       "Task(claude)",
+      "Agent(claude)",
       "Task(Explore)",
+      "Agent(Explore)",
       "Task(general-purpose)",
+      "Agent(general-purpose)",
       "Task(Plan)",
+      "Agent(Plan)",
     ]);
   });
 
@@ -66,7 +70,8 @@ describe("claude-gateway custom agents", () => {
     expect(names.length).toBeGreaterThan(0);
     for (const name of names) {
       const agent = agents[name]!;
-      expect(name.startsWith("gw-")).toBe(true);
+      expect(name.startsWith("gw-")).toBe(false);
+      expect(name.startsWith("cursor-")).toBe(true);
       expect(agent.model.startsWith("claude-gateway--")).toBe(true);
       expect(agent.prompt).toBe(GENERAL_PURPOSE_AGENT_PROMPT);
       expect(agent.description).toContain("gateway_models");
@@ -100,11 +105,15 @@ describe("claude-gateway custom agents", () => {
 
     const disallowedIndex = injectedGateway.args.indexOf("--disallowedTools");
     expect(disallowedIndex).toBeGreaterThanOrEqual(0);
-    expect(injectedGateway.args.slice(disallowedIndex + 1, disallowedIndex + 5)).toEqual([
+    expect(injectedGateway.args.slice(disallowedIndex + 1, disallowedIndex + 9)).toEqual([
       "Task(claude)",
+      "Agent(claude)",
       "Task(Explore)",
+      "Agent(Explore)",
       "Task(general-purpose)",
+      "Agent(general-purpose)",
       "Task(Plan)",
+      "Agent(Plan)",
     ]);
 
     const agentsIndex = injectedGateway.args.indexOf("--agents");


### PR DESCRIPTION
## Summary
- deny built-in Claude Code agents with both legacy `Task(name)` and current `Agent(name)` selectors
- retain gateway-provided custom agents while removing their redundant `gw-` name prefix
- update gateway launch contracts for both behaviors

## Test Plan
- [x] `pnpm --dir packages/fleet-admiral test`
- [x] `pnpm --dir packages/fleet-admiral typecheck`
- [x] `pnpm --dir packages/fleet-admiral build`
- [x] `git diff --check`
- [x] add `.changelog.d/pr-474.md` with bilingual summaries
- [x] `node scripts/compile-changelog-fragments.mjs --check`