### PR TITLE
feat(fleet-console): add Claude (Native) canvas launch

### DIFF
--- a/.changelog.d/pr-475.md
+++ b/.changelog.d/pr-475.md
@@ -1,0 +1,9 @@
+### fleet-plugin
+#### Added
+- [fleet-console] Add a Claude (Native) Canvas Controls launch that reuses Claude Code with wiki skills, Console hooks, and wiki MCP only.
+  ko: Claude Code를 재사용하되 wiki 스킬·Console 훅·wiki MCP만 싣는 Claude (Native) 캔버스 제어 런치를 추가합니다.
+
+### fleet-core
+#### Added
+- [fleet-admiral] Introduce a console-only `claude-native` Agent CLI with `native` doctrine that skips the Admiral system prompt and carrier/gateway tools.
+  ko: Admiral 시스템 프롬프트와 캐리어/게이트웨이 도구를 생략하는 `native` doctrine의 Console 전용 `claude-native` Agent CLI를 도입합니다.

--- a/packages/fleet-admiral/src/agent-cli/builders/claude.ts
+++ b/packages/fleet-admiral/src/agent-cli/builders/claude.ts
@@ -3,8 +3,7 @@ import type { AgentCliInjectionContext, AgentCliMcpServerArg } from "../types.js
 export function buildClaudeNativeArgs(context: AgentCliInjectionContext): string[] {
   return [
     ...buildResumeArgs(context.resumeSessionId),
-    "--append-system-prompt-file",
-    requireSystemPromptFile(context),
+    ...buildSystemPromptArgs(context),
     ...context.pluginRoots.flatMap((pluginRoot) => [
       "--plugin-dir",
       pluginRoot,
@@ -32,6 +31,12 @@ function buildResumeArgs(resumeSessionId: string | undefined): string[] {
   return resumeSessionId === undefined ? [] : ["--resume", resumeSessionId];
 }
 
+function buildSystemPromptArgs(context: AgentCliInjectionContext): string[] {
+  // native 세션은 Admiral 시스템 프롬프트를 붙이지 않는다.
+  if (context.systemPromptFile === undefined) return [];
+  return ["--append-system-prompt-file", context.systemPromptFile];
+}
+
 function buildClaudeMcpConfig(servers: readonly AgentCliMcpServerArg[]): string {
   return JSON.stringify({
     mcpServers: Object.fromEntries(
@@ -44,9 +49,4 @@ function buildClaudeMcpConfig(servers: readonly AgentCliMcpServerArg[]): string 
       }]),
     ),
   });
-}
-
-function requireSystemPromptFile(context: AgentCliInjectionContext): string {
-  if (context.systemPromptFile) return context.systemPromptFile;
-  throw new Error("Claude system prompt file is required for native injection");
 }

--- a/packages/fleet-admiral/src/agent-cli/capabilities.ts
+++ b/packages/fleet-admiral/src/agent-cli/capabilities.ts
@@ -5,6 +5,10 @@ const AGENT_CLI_INJECTION_CAPABILITIES: Record<AgentCliId, AgentCliInjectionCapa
     builderId: "claude-native",
     enabled: true,
   },
+  "claude-native": {
+    builderId: "claude-native",
+    enabled: true,
+  },
   "claude-gateway": {
     builderId: "claude-native",
     enabled: true,

--- a/packages/fleet-admiral/src/agent-cli/claude/claude-native.ts
+++ b/packages/fleet-admiral/src/agent-cli/claude/claude-native.ts
@@ -1,0 +1,7 @@
+import { createClaudeFamilyCliDefinition } from "./factory.js";
+
+// Console Launch 전용: Admiral 시스템 프롬프트 없이 wiki 스킬·Console 훅·위키 MCP만 싣는 순정에 가까운 Claude Code.
+export const claudeNativeCli = createClaudeFamilyCliDefinition({
+  id: "claude-native",
+  label: "Claude (Native)",
+});

--- a/packages/fleet-admiral/src/agent-cli/claude/factory.ts
+++ b/packages/fleet-admiral/src/agent-cli/claude/factory.ts
@@ -3,7 +3,7 @@ import { createChildEnv, resolveBinary } from "@dotobokuri/core-agent";
 import type { AgentCliDefinition, AgentCliId, AgentCliProfileOptions } from "../types.js";
 
 interface ClaudeFamilyCliFactoryOptions {
-  readonly id: Extract<AgentCliId, "claude" | "claude-gateway">;
+  readonly id: Extract<AgentCliId, "claude" | "claude-native" | "claude-gateway">;
   readonly label: string;
 }
 

--- a/packages/fleet-admiral/src/agent-cli/injection.ts
+++ b/packages/fleet-admiral/src/agent-cli/injection.ts
@@ -112,15 +112,19 @@ export async function injectAgentCliProfile(
   const tokenLabel = options.mcpSessionLabel ?? `agent:${profile.id}:${crypto.randomUUID()}`;
   const tokens = await options.dedicatedMcpSession.issueSessionToken({
     cwd: profile.cwd,
-    // gateway doctrine 세션에는 캐리어 운용 도구를 노출하지 않는다.
+    // gateway/native doctrine 세션에는 캐리어 운용 도구를 노출하지 않는다.
+    // native는 위키 MCP만 남긴다.
     includeTool: (toolId) => isHostSessionToolAllowed(toolId, doctrine),
     label: tokenLabel,
   });
   const mcpServers = buildAgentCliMcpServerConfigs(endpoint.servers, tokens);
-  const systemPrompt = options.buildSystemPrompt({ enableMetaphor, doctrine });
+  // native는 Admiral 시스템 프롬프트를 붙이지 않는다.
+  const systemPrompt = doctrine === "native"
+    ? undefined
+    : options.buildSystemPrompt({ enableMetaphor, doctrine });
   const tempCleanups: Array<() => void> = [];
   try {
-    const systemPromptFile = isClaudeFamilyProfile(profile)
+    const systemPromptFile = systemPrompt !== undefined && isClaudeFamilyProfile(profile)
       ? writeSystemPromptFile(profile.id, systemPrompt, (cleanup) => tempCleanups.push(cleanup))
       : undefined;
     const plugin = await createAgentCliPlugin({
@@ -138,7 +142,7 @@ export async function injectAgentCliProfile(
       withMarketplaceLock: options.withMarketplaceLock,
     });
     const codexPluginKeys = plugin.codexRegistrations.map((registration) => `${registration.pluginName}@${registration.marketplaceName}`);
-    const codexProfile = profile.id === "codex"
+    const codexProfile = profile.id === "codex" && systemPrompt !== undefined
       ? writeCodexFleetProfile(profile.env, systemPrompt, codexPluginKeys, {
           captureSessionHookExec: options.captureSessionHookExec,
           turnStartHookExec: options.turnStartHookExec,
@@ -218,7 +222,7 @@ export async function injectAgentCliProfile(
 }
 
 function isClaudeFamilyProfile(profile: AgentCliProfile): boolean {
-  return profile.id === "claude" || profile.id === "claude-gateway";
+  return profile.id === "claude" || profile.id === "claude-native" || profile.id === "claude-gateway";
 }
 
 function buildAgentCliMcpServerConfigs(

--- a/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
@@ -7,7 +7,7 @@ import type { FleetHookExec } from "../types.js";
 import type { AssetPluginBundle, CreateAgentCliPluginOptions } from "./types.js";
 
 /** Classic and gateway asset roots must coexist under the same marketplace. */
-export const ASSET_PLUGIN_DIRECTORY_NAMES = ["fleet", "fleet-gateway"] as const;
+export const ASSET_PLUGIN_DIRECTORY_NAMES = ["fleet", "fleet-gateway", "fleet-native"] as const;
 
 export const assetBundle: AssetPluginBundle = {
   description: "Fleet carrier delegation and wiki evidence plugin",
@@ -19,7 +19,9 @@ export const assetBundle: AssetPluginBundle = {
 };
 
 export function resolveAssetPluginDirectoryName(doctrine: AdmiralDoctrine): string {
-  return doctrine === "gateway" ? "fleet-gateway" : "fleet";
+  if (doctrine === "gateway") return "fleet-gateway";
+  if (doctrine === "native") return "fleet-native";
+  return "fleet";
 }
 
 export function renderAssetPluginRoot(
@@ -29,7 +31,7 @@ export function renderAssetPluginRoot(
 ): void {
   const doctrine = options.doctrine ?? resolveDoctrineFromCliId(options.cliId);
   renderEmbeddedSkillAssets(pluginRoot, doctrine);
-  if (options.cliId === "claude" || options.cliId === "claude-gateway") {
+  if (options.cliId === "claude" || options.cliId === "claude-native" || options.cliId === "claude-gateway") {
     writePrivateJson(path.join(pluginRoot, "hooks", "hooks.json"), claudeHooks(options), pluginRoot);
   }
 }
@@ -91,6 +93,13 @@ function renderEmbeddedSkillAssets(pluginRoot: string, doctrine: AdmiralDoctrine
 function selectSkillAssetsForDoctrine(
   doctrine: AdmiralDoctrine,
 ): ReadonlyArray<{ readonly relativePath: string; readonly content: string }> {
+  if (doctrine === "native") {
+    // native는 wiki-operations만 렌더한다. Console 훅은 별도로 유지된다.
+    return EMBEDDED_AGENT_CLI_SKILL_ASSETS.filter(
+      (asset) => asset.relativePath.startsWith("wiki-operations/"),
+    );
+  }
+
   if (doctrine === "gateway") {
     // gateway 경로는 protocol-* 스킬과 carrier-operations를 렌더하지 않는다.
     // gateway/<name>/SKILL.md는 접두를 벗겨 동일 이름의 base 자산을 대체한다.

--- a/packages/fleet-admiral/src/agent-cli/plugin/index.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/index.ts
@@ -153,7 +153,7 @@ function renderPluginRoot(
     writePrivateJson(path.join(stagedPluginRoot, ".claude-plugin", "plugin.json"), claudeManifest(bundle), stagedPluginRoot);
     switch (bundle.source) {
       case "asset":
-        if (options.cliId === "claude" || options.cliId === "claude-gateway") {
+        if (options.cliId === "claude" || options.cliId === "claude-native" || options.cliId === "claude-gateway") {
           ensurePrivateDir(path.join(stagedPluginRoot, "agents"), stagedPluginRoot);
         }
         ensurePrivateDir(path.join(stagedPluginRoot, "skills"), stagedPluginRoot);

--- a/packages/fleet-admiral/src/agent-cli/registry.ts
+++ b/packages/fleet-admiral/src/agent-cli/registry.ts
@@ -1,5 +1,6 @@
 import { claudeCli } from "./claude/claude.js";
 import { claudeGatewayCli } from "./claude/claude-gateway.js";
+import { claudeNativeCli } from "./claude/claude-native.js";
 import { codexCli } from "./codex/codex.js";
 import type { AgentCliDefinition, AgentCliId, AgentCliProfile } from "./types.js";
 
@@ -15,8 +16,9 @@ export interface AgentCliMetadata {
 }
 
 const DEFAULT_CLI_ID: AgentCliId = "claude";
-// Console 캔버스 제어 메뉴 순서를 고정한다: Claude → Codex → Claude (Gateway).
+// Console 캔버스 제어 메뉴 순서를 고정한다: Claude (Native) → Claude → Codex → Claude (Gateway).
 const DEFINITIONS: Record<AgentCliId, AgentCliDefinition> = {
+  "claude-native": claudeNativeCli,
   claude: claudeCli,
   codex: codexCli,
   "claude-gateway": claudeGatewayCli,
@@ -50,7 +52,7 @@ export function getDefaultAgentCliId(): AgentCliId {
 
 // Console 호스트에서만 성립하는 CLI. 게이트웨이 라우트가 Console에 마운트되어야 동작하므로
 // 기본 카탈로그(예: Fleet CLI의 Start CLI 목록)에서는 제외한다.
-const CONSOLE_ONLY_CLI_IDS: ReadonlySet<AgentCliId> = new Set<AgentCliId>(["claude-gateway"]);
+const CONSOLE_ONLY_CLI_IDS: ReadonlySet<AgentCliId> = new Set<AgentCliId>(["claude-native", "claude-gateway"]);
 
 export interface AgentCliIdListOptions {
   readonly includeConsoleOnly?: boolean;

--- a/packages/fleet-admiral/src/agent-cli/types.ts
+++ b/packages/fleet-admiral/src/agent-cli/types.ts
@@ -1,4 +1,4 @@
-export type AgentCliId = "claude" | "claude-gateway" | "codex";
+export type AgentCliId = "claude" | "claude-native" | "claude-gateway" | "codex";
 
 export interface AgentCliProfile {
   readonly id: AgentCliId;

--- a/packages/fleet-admiral/src/protocols/doctrine.ts
+++ b/packages/fleet-admiral/src/protocols/doctrine.ts
@@ -1,14 +1,18 @@
 /**
- * protocols/doctrine — Admiral prompt doctrine axis
+ * protocols/doctrine — Admiral prompt / plugin / MCP doctrine axis
  *
  * Orthogonal to metaphor: classic keeps carrier_dispatch-centric wording; gateway
  * names no executor at all and describes execution as workflow stages, leaving the
  * surface those stages run on to the `workflow` skill and the live tool metadata.
+ * native is console-launch only: no Admiral system prompt, wiki skills + console
+ * hooks only, and wiki MCP without carrier operation tools.
  */
 
-export type AdmiralDoctrine = "classic" | "gateway";
+export type AdmiralDoctrine = "classic" | "gateway" | "native";
 
 /** Resolve prompt doctrine from the active Agent CLI id. */
 export function resolveDoctrineFromCliId(cliId: string): AdmiralDoctrine {
-  return cliId === "claude-gateway" ? "gateway" : "classic";
+  if (cliId === "claude-gateway") return "gateway";
+  if (cliId === "claude-native") return "native";
+  return "classic";
 }

--- a/packages/fleet-admiral/src/tools.ts
+++ b/packages/fleet-admiral/src/tools.ts
@@ -24,6 +24,10 @@ export const GATEWAY_DOCTRINE_TOOL_IDS = new Set<string>([
 
 /** 해당 doctrine 호스트 세션이 이 도구를 받아야 하는지 판정한다. */
 export function isHostSessionToolAllowed(toolId: string, doctrine: AdmiralDoctrine): boolean {
+  if (doctrine === "native") {
+    // Native는 위키 MCP만 남긴다. 캐리어 운용과 게이트웨이 로스터는 제외한다.
+    return toolId.startsWith("wiki_") && !CARRIER_OPERATION_TOOL_IDS.has(toolId) && !GATEWAY_DOCTRINE_TOOL_IDS.has(toolId);
+  }
   return doctrine === "gateway"
     ? !CARRIER_OPERATION_TOOL_IDS.has(toolId)
     : !GATEWAY_DOCTRINE_TOOL_IDS.has(toolId);

--- a/packages/fleet-admiral/tests/agent-cli-native.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-native.test.ts
@@ -1,0 +1,156 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  getAgentCliIds,
+  getAgentCliMetadata,
+  injectAgentCliProfile,
+  resolveAgentCliProfile,
+  type AgentCliProfile,
+  type FleetHookExec,
+} from "../src/index.js";
+import { createAgentCliPlugin } from "../src/agent-cli/plugin/index.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("claude-native profile", () => {
+  it("resolves as Claude Code with the Native label", async () => {
+    const profile = await resolveAgentCliProfile({
+      CLAUDE_BIN: process.execPath,
+    }, "/tmp", {
+      cliId: "claude-native",
+    });
+
+    expect(profile).toMatchObject({
+      bin: process.execPath,
+      id: "claude-native",
+      label: "Claude (Native)",
+      renameCommand: "/rename",
+    });
+  });
+
+  it("lists Native ahead of Classic in the console-only catalog", () => {
+    const ids = getAgentCliIds({ includeConsoleOnly: true });
+    expect(ids.indexOf("claude-native")).toBeLessThan(ids.indexOf("claude"));
+    expect(ids).toContain("claude-gateway");
+    expect(getAgentCliIds()).not.toContain("claude-native");
+    expect(getAgentCliMetadata(ids).find((entry) => entry.id === "claude-native")?.label).toBe("Claude (Native)");
+  });
+});
+
+describe("claude-native injection", () => {
+  it("omits the Admiral system prompt and keeps plugin/MCP args", async () => {
+    const root = createTempRoot("fleet-admiral-native-inject-");
+    const profile = baseProfile("claude-native", {
+      args: [],
+      cwd: root,
+      env: { HOME: root },
+    });
+    let builtPrompt = false;
+    const injected = await injectAgentCliProfile(profile, {
+      buildSystemPrompt: () => {
+        builtPrompt = true;
+        return "Fleet doctrine";
+      },
+      codexCommandRunner: () => ({ status: 0, stderr: "", stdout: "" }),
+      dataDir: path.join(root, "data"),
+      dedicatedMcpSession: {
+        async getEndpoint() {
+          return { servers: [{ name: "fleet", url: "http://127.0.0.1:48123/mcp" }] };
+        },
+        issueSessionToken(request) {
+          expect(request.includeTool?.("carrier_dispatch")).toBe(false);
+          expect(request.includeTool?.("carrier_jobs")).toBe(false);
+          expect(request.includeTool?.("gateway_models")).toBe(false);
+          expect(request.includeTool?.("wiki_read")).toBe(true);
+          return [{ name: "fleet", token: "token-123" }];
+        },
+        releaseSessionToken() {},
+      },
+      withMarketplaceLock: async (_target, fn) => fn(),
+    });
+
+    expect(builtPrompt).toBe(false);
+    expect(injected.args).not.toContain("--append-system-prompt-file");
+    expect(injected.args).toContain("--plugin-dir");
+    expect(injected.args).toContain("--mcp-config");
+    expect(injected.args).toContain("--dangerously-skip-permissions");
+    expect(injected.args).not.toContain("--agents");
+    expect(injected.args).not.toContain("--disallowedTools");
+
+    const mcpIndex = injected.args.indexOf("--mcp-config");
+    const mcpJson = JSON.parse(injected.args[mcpIndex + 1] as string) as {
+      mcpServers: Record<string, { url: string }>;
+    };
+    expect(Object.keys(mcpJson.mcpServers)).toEqual(["fleet"]);
+    injected.cleanup?.();
+  });
+
+  it("renders wiki-operations and console hooks only under fleet-native", async () => {
+    const root = createTempRoot("fleet-admiral-native-plugin-");
+    const plugin = await createAgentCliPlugin({
+      cliId: "claude-native",
+      cwd: path.join(root, "project"),
+      dataDir: path.join(root, "data"),
+      captureSessionHookExec: hookExec("node", ["console.js", "hook", "capture-session", "claude"]),
+      turnStartHookExec: hookExec("node", ["console.js", "hook", "turn-start"]),
+      turnEndHookExec: hookExec("node", ["console.js", "hook", "turn-end"]),
+      inputWaitingHookExec: hookExec("node", ["console.js", "hook", "attention"]),
+      autoNameHookExec: hookExec("node", ["console.js", "hook", "auto-name"]),
+      withMarketplaceLock: async (_target, fn) => fn(),
+    });
+
+    expect(plugin.pluginRoot).toBe(path.join(root, "data", "marketplace", "plugins", "fleet-native"));
+    const skillsRoot = path.join(plugin.pluginRoot, "skills");
+    expect(existsSync(path.join(skillsRoot, "wiki-operations", "SKILL.md"))).toBe(true);
+    expect(existsSync(path.join(skillsRoot, "carrier-operations", "SKILL.md"))).toBe(false);
+    expect(existsSync(path.join(skillsRoot, "assumption-audit", "SKILL.md"))).toBe(false);
+    expect(existsSync(path.join(skillsRoot, "workflow", "SKILL.md"))).toBe(false);
+    for (const mode of ["protocol-baseline", "protocol-frontline", "protocol-midline", "protocol-redline"]) {
+      expect(existsSync(path.join(skillsRoot, mode, "SKILL.md"))).toBe(false);
+    }
+    const skillNames = readdirSync(skillsRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+    expect(skillNames).toEqual(["wiki-operations"]);
+    expect(existsSync(path.join(plugin.pluginRoot, "hooks", "hooks.json"))).toBe(true);
+  });
+});
+
+function createTempRoot(prefix: string): string {
+  const root = mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(root);
+  return root;
+}
+
+function baseProfile(
+  id: AgentCliProfile["id"],
+  options: {
+    readonly args: readonly string[];
+    readonly cwd: string;
+    readonly env: Readonly<Record<string, string>>;
+  },
+): AgentCliProfile {
+  return {
+    args: options.args,
+    bin: id,
+    cwd: options.cwd,
+    env: options.env,
+    id,
+    label: id,
+    terminalName: "xterm-256color",
+  };
+}
+
+function hookExec(command: string, args: readonly string[]): FleetHookExec {
+  return { command, args };
+}

--- a/packages/fleet-admiral/tests/agent-cli-plugin-marketplace.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-plugin-marketplace.test.ts
@@ -280,6 +280,27 @@ describe("agent CLI plugin marketplace rendering", () => {
     }
   });
 
+  it("renders wiki-operations only for native doctrine", async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "fleet-admiral-plugin-native-doctrine-"));
+    tempDirs.push(root);
+
+    const plugin = await createAgentCliPlugin({
+      cliId: "claude-native",
+      cwd: path.join(root, "project"),
+      dataDir: path.join(root, "data"),
+      captureSessionHookExec: { command: "node", args: ["cli.mjs", "hook", "capture-session", "claude"] },
+      withMarketplaceLock: async (_target, fn) => fn(),
+    });
+
+    expect(plugin.pluginRoot).toBe(path.join(root, "data", "marketplace", "plugins", "fleet-native"));
+    const skillsRoot = path.join(plugin.pluginRoot, "skills");
+    expect(existsSync(path.join(skillsRoot, "wiki-operations", "SKILL.md"))).toBe(true);
+    expect(existsSync(path.join(skillsRoot, "carrier-operations", "SKILL.md"))).toBe(false);
+    expect(existsSync(path.join(skillsRoot, "assumption-audit", "SKILL.md"))).toBe(false);
+    expect(existsSync(path.join(skillsRoot, "protocol-baseline", "SKILL.md"))).toBe(false);
+    expect(existsSync(path.join(plugin.pluginRoot, "hooks", "hooks.json"))).toBe(true);
+  });
+
   it("keeps classic and gateway asset roots isolated under the same dataDir", async () => {
     const root = mkdtempSync(path.join(os.tmpdir(), "fleet-admiral-plugin-doctrine-roots-"));
     tempDirs.push(root);
@@ -289,27 +310,35 @@ describe("agent CLI plugin marketplace rendering", () => {
     const withMarketplaceLock = async <T>(_target: string, fn: () => T | Promise<T>): Promise<T> => fn();
     const classicRoot = path.join(dataDir, "marketplace", "plugins", "fleet");
     const gatewayRoot = path.join(dataDir, "marketplace", "plugins", "fleet-gateway");
+    const nativeRoot = path.join(dataDir, "marketplace", "plugins", "fleet-native");
 
     for (const order of [
-      ["claude", "claude-gateway"],
-      ["claude-gateway", "claude"],
+      ["claude", "claude-gateway", "claude-native"],
+      ["claude-native", "claude-gateway", "claude"],
     ] as const) {
       let classicPluginRoot = "";
       let gatewayPluginRoot = "";
+      let nativePluginRoot = "";
       for (const cliId of order) {
         const plugin = await createAgentCliPlugin({ cliId, cwd, dataDir, withMarketplaceLock });
         if (cliId === "claude") classicPluginRoot = plugin.pluginRoot;
-        else gatewayPluginRoot = plugin.pluginRoot;
+        else if (cliId === "claude-gateway") gatewayPluginRoot = plugin.pluginRoot;
+        else nativePluginRoot = plugin.pluginRoot;
       }
 
       expect(classicPluginRoot).toBe(classicRoot);
       expect(gatewayPluginRoot).toBe(gatewayRoot);
+      expect(nativePluginRoot).toBe(nativeRoot);
       expect(existsSync(classicRoot)).toBe(true);
       expect(existsSync(gatewayRoot)).toBe(true);
+      expect(existsSync(nativeRoot)).toBe(true);
       expect(existsSync(path.join(classicRoot, "skills", "carrier-operations", "SKILL.md"))).toBe(true);
       expect(existsSync(path.join(gatewayRoot, "skills", "carrier-operations", "SKILL.md"))).toBe(false);
+      expect(existsSync(path.join(nativeRoot, "skills", "carrier-operations", "SKILL.md"))).toBe(false);
       expect(existsSync(path.join(classicRoot, "skills", "protocol-baseline", "SKILL.md"))).toBe(true);
       expect(existsSync(path.join(gatewayRoot, "skills", "protocol-baseline", "SKILL.md"))).toBe(false);
+      expect(existsSync(path.join(nativeRoot, "skills", "wiki-operations", "SKILL.md"))).toBe(true);
+      expect(existsSync(path.join(nativeRoot, "skills", "assumption-audit", "SKILL.md"))).toBe(false);
     }
   });
 });

--- a/packages/fleet-admiral/tests/ai-gateway-model-loadout.test.ts
+++ b/packages/fleet-admiral/tests/ai-gateway-model-loadout.test.ts
@@ -133,11 +133,13 @@ describe("gateway loadout", () => {
 });
 
 describe("gateway_models tool", () => {
-  it("is withheld from classic sessions that cannot route its ids", () => {
+  it("is withheld from classic and native sessions that cannot route its ids", () => {
     expect(isHostSessionToolAllowed(GATEWAY_MODELS_TOOL_ID, "gateway")).toBe(true);
     expect(isHostSessionToolAllowed(GATEWAY_MODELS_TOOL_ID, "classic")).toBe(false);
+    expect(isHostSessionToolAllowed(GATEWAY_MODELS_TOOL_ID, "native")).toBe(false);
     expect(isHostSessionToolAllowed("carrier_dispatch", "classic")).toBe(true);
     expect(isHostSessionToolAllowed("carrier_dispatch", "gateway")).toBe(false);
+    expect(isHostSessionToolAllowed("carrier_dispatch", "native")).toBe(false);
   });
 
   it("resolves the roster on every call rather than at registration", async () => {

--- a/packages/fleet-admiral/tests/prompts.test.ts
+++ b/packages/fleet-admiral/tests/prompts.test.ts
@@ -180,20 +180,24 @@ describe("Admiral prompts", () => {
     expect(prompt).not.toContain("# Fleet Action Protocol — Operational Doctrine");
   });
 
-  it("withholds carrier operation tools from gateway host sessions only", () => {
+  it("withholds carrier operation tools from gateway and native host sessions", () => {
     expect([...CARRIER_OPERATION_TOOL_IDS].sort()).toEqual(["carrier_dispatch", "carrier_jobs"]);
     for (const toolId of CARRIER_OPERATION_TOOL_IDS) {
       expect(isHostSessionToolAllowed(toolId, "classic")).toBe(true);
       expect(isHostSessionToolAllowed(toolId, "gateway")).toBe(false);
+      expect(isHostSessionToolAllowed(toolId, "native")).toBe(false);
     }
     for (const toolId of ["wiki_read", "wiki_briefing"]) {
       expect(isHostSessionToolAllowed(toolId, "classic")).toBe(true);
       expect(isHostSessionToolAllowed(toolId, "gateway")).toBe(true);
+      expect(isHostSessionToolAllowed(toolId, "native")).toBe(true);
     }
+    expect(isHostSessionToolAllowed("gateway_models", "native")).toBe(false);
   });
 
-  it("resolves claude-gateway to gateway doctrine and keeps other CLIs classic", () => {
+  it("resolves claude-native to native doctrine and keeps classic/gateway mappings", () => {
     expect(resolveDoctrineFromCliId("claude-gateway")).toBe("gateway");
+    expect(resolveDoctrineFromCliId("claude-native")).toBe("native");
     expect(resolveDoctrineFromCliId("claude")).toBe("classic");
     expect(resolveDoctrineFromCliId("codex")).toBe("classic");
   });

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -171,7 +171,7 @@ export const agentPlugin = definePlugin({
     return { id: session.sessionId };
   },
   renderLaunchIcon: (kind) => {
-    if (kind.id === "claude" || kind.id === "claude-gateway") return <ClaudeGlyph />;
+    if (kind.id === "claude" || kind.id === "claude-native" || kind.id === "claude-gateway") return <ClaudeGlyph />;
     if (kind.id === "codex") return <CodexGlyph />;
     return <AgentGlyph />;
   },

--- a/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-metadata.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-metadata.ts
@@ -33,8 +33,8 @@ export function combineAgentCliLaunchMetadata(
   }));
 }
 
-// claude-gateway는 Launch 전용이라 CLI_BACKENDS(Carrier/Analyst 전송 카탈로그)에 등재하지 않는다.
+// claude-native / claude-gateway는 Launch 전용이라 CLI_BACKENDS(Carrier/Analyst 전송 카탈로그)에 등재하지 않는다.
 // 실행 바이너리는 claude와 같으므로 설치 판정도 claude를 따른다.
 function resolveCliCommand(id: AgentCliId): string {
-  return id === "claude-gateway" ? "claude" : CLI_BACKENDS[id].cliCommand;
+  return id === "claude-gateway" || id === "claude-native" ? "claude" : CLI_BACKENDS[id].cliCommand;
 }

--- a/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-paths.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-paths.ts
@@ -126,7 +126,7 @@ export function validateUserAgentCliPath(
 }
 
 export function agentCliCommandForId(cliId: string | undefined): string | null {
-  if (cliId === "claude" || cliId === "claude-gateway") return "claude";
+  if (cliId === "claude" || cliId === "claude-native" || cliId === "claude-gateway") return "claude";
   if (cliId === "codex") return "codex";
   if (cliId === "cursor") return "cursor-agent";
   return null;

--- a/runtime/fleet-plugins/terminal/server/agent-api/osc-agent-activity.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/osc-agent-activity.ts
@@ -28,7 +28,7 @@ export function classifyOscAgentActivity(
   const first = title.codePointAt(0);
   if (first === undefined) return "unknown";
   if (first >= BRAILLE_START && first <= BRAILLE_END) return "working";
-  if (cliId === "claude" || cliId === "claude-gateway") {
+  if (cliId === "claude" || cliId === "claude-native" || cliId === "claude-gateway") {
     return first === CLAUDE_NOT_WORKING ? "not-working" : "unknown";
   }
   if (codexWorkingBaseline === undefined) return "unknown";

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -145,7 +145,7 @@ function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Terminal
       const session = observability.getTerminalSessionInfo(sessionId);
       if (!session) return;
       const cliId = session.cliId;
-      if (cliId !== "claude" && cliId !== "claude-gateway" && cliId !== "codex") return;
+      if (cliId !== "claude" && cliId !== "claude-native" && cliId !== "claude-gateway" && cliId !== "codex") return;
       tracker = createOscAgentActivityTracker({
         cliId,
         cwdBasename: session.cwdLabel,

--- a/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
@@ -6,6 +6,7 @@ describe("buildAgentCliLaunchKinds", () => {
   it("모든 CLI를 Operation Controls 목록에 포함한다", () => {
     const result = buildAgentCliLaunchKinds(
       [
+        { id: "claude-native", label: "Claude (Native)", available: true, signedIn: true },
         { id: "claude", label: "Claude", available: true, signedIn: true },
         { id: "codex", label: "Codex", available: true, signedIn: true },
         { id: "claude-gateway", label: "Claude (Gateway • Experimental)", available: true, signedIn: true },
@@ -14,6 +15,7 @@ describe("buildAgentCliLaunchKinds", () => {
     );
 
     expect(result).toEqual([
+      { id: "claude-native", type: "agent", title: "Claude (Native)" },
       { id: "claude", type: "agent", title: "Claude (Classic)" },
       { id: "codex", type: "agent", title: "Codex (Classic)" },
       { id: "claude-gateway", type: "agent", title: "Claude (Gateway • Experimental)" },

--- a/runtime/fleet-plugins/terminal/tests/agent-cli-paths.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-cli-paths.test.ts
@@ -176,6 +176,9 @@ describe("Agent CLI launch env overlay", () => {
     expect(applyAgentCliPathEnvOverlay({ PATH: "/usr/bin" }, "claude-gateway", { claude: "/custom/claude" })).toMatchObject({
       CLAUDE_BIN: "/custom/claude",
     });
+    expect(applyAgentCliPathEnvOverlay({ PATH: "/usr/bin" }, "claude-native", { claude: "/custom/claude" })).toMatchObject({
+      CLAUDE_BIN: "/custom/claude",
+    });
     expect(applyAgentCliPathEnvOverlay({ CLAUDE_BIN: "/managed/claude" }, "claude", { claude: "/custom/claude" })).toEqual({
       CLAUDE_BIN: "/managed/claude",
     });

--- a/runtime/fleet-plugins/terminal/tests/osc-agent-activity.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/osc-agent-activity.test.ts
@@ -10,6 +10,7 @@ describe("OSC Agent activity classification", () => {
   it("keeps Claude not-working independent from the working title body", () => {
     expect(classifyOscAgentActivity("claude", "⠐ Write sentences for numbers 1 to 120")).toBe("working");
     expect(classifyOscAgentActivity("claude-gateway", "✳ Claude Code")).toBe("not-working");
+    expect(classifyOscAgentActivity("claude-native", "✳ Claude Code")).toBe("not-working");
     expect(classifyOscAgentActivity("claude", "✳ 1부터 200까지 숫자별 문장 작성")).toBe("not-working");
     expect(classifyOscAgentActivity("claude", "project")).toBe("unknown");
   });


### PR DESCRIPTION
## Summary
- Canvas Controls에 Console 전용 **Claude (Native)** 런치를 Classic 위에 추가합니다.
- `claude-native`는 동일 Claude Code 바이너리를 쓰되 Admiral 시스템 프롬프트를 붙이지 않고, `wiki-operations` 스킬·Console 훅·wiki MCP만 주입합니다.
- `native` doctrine은 `carrier_dispatch` / `carrier_jobs` / `gateway_models`를 제외합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-admiral test -- tests/agent-cli-native.test.ts tests/prompts.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-admiral typecheck && pnpm --filter @dotobokuri/fleet-admiral build`
- [x] `pnpm --filter @dotobokuri/fleet-plugin-terminal test`
- [x] Changelog fragment `.changelog.d/pr-475.md` validated with `node scripts/compile-changelog-fragments.mjs --check`

## Changelog
- [x] `.changelog.d/pr-475.md` — bilingual `fleet-plugin`/`fleet-core` Added entries