### PR TITLE
feat(fleet-console): walk and describe the three Claude launch kinds

### DIFF
--- a/.changelog.d/pr-478.md
+++ b/.changelog.d/pr-478.md
@@ -1,0 +1,22 @@
+### fleet-console
+#### Added
+- [fleet-console] Describe each Claude launch kind with a one-line summary in Canvas Controls and mark the newly added kinds with a NEW badge, so the difference stays readable every time you choose.
+  ko: 캔버스 제어의 Claude 실행 종류마다 한 줄 설명을 붙이고 새로 추가된 종류에 NEW 배지를 표시해, 고를 때마다 차이를 확인할 수 있습니다.
+
+#### Changed
+- [fleet-console] Walk the three Claude launch kinds in menu order on the first Canvas Controls open, replacing the single Claude Gateway spotlight so Native and Classic are introduced alongside Gateway.
+  ko: 캔버스 제어를 처음 열면 Claude 세 종류를 메뉴 순서대로 안내합니다. 기존 Claude Gateway 단독 안내를 대체해 Native와 Classic도 Gateway와 함께 소개합니다.
+
+#### Fixed
+- [fleet-console] Keep the feature tour progress count within its total when the next button is pressed repeatedly before the card advances.
+  ko: 기능 안내에서 카드가 넘어가기 전에 다음 버튼을 연달아 눌러도 진행 표시가 전체 개수를 넘지 않습니다.
+
+### fleet-plugin
+#### Fixed
+- [fleet-console] Drop the (Classic) suffix from the Codex launch entry, which has no Native or Gateway variant to contrast with.
+  ko: 대비할 Native·Gateway 변형이 없는 Codex 실행 항목에서 (Classic) 접미를 제거합니다.
+
+### fleet-core
+#### Changed
+- [fleet-admiral] Shorten the gateway Agent CLI label to `Claude (Gateway)` because the Console launch menu now marks the experimental stage with a badge.
+  ko: Console 실행 메뉴가 실험 단계를 배지로 표시하므로 게이트웨이 Agent CLI 라벨을 `Claude (Gateway)`로 줄입니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -80,7 +80,7 @@ Nimitz와 Vanguard는 여기에 더해 **Task Force**를 지원합니다. 둘 �
 | CLI | 제공자 | 프로토콜 | 대표 강점 |
 |---|---|---|---|
 | **Claude Code** | Anthropic | ACP | 심층 추론과 아키텍처 판단 |
-| **Claude (Gateway • Experimental)** | OpenAI, Cursor, Moonshot AI | Claude Code gateway | 하나의 Claude Code 표면에서 최신 GPT·Cursor·Kimi K3 모델 사용 |
+| **Claude (Gateway)** | OpenAI, Cursor, Moonshot AI | Claude Code gateway | 하나의 Claude Code 표면에서 최신 GPT·Cursor·Kimi K3 모델 사용 |
 | **Codex CLI** | OpenAI | Codex App Server | 빠른 구현과 반복 실행 |
 | **Cursor Agent** | Cursor | ACP | 다중 모델 라우팅 |
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Every supported CLI brings a model-native agent loop refined by its creator. Fle
 | CLI | Provider | Protocol | Typical strength |
 |---|---|---|---|
 | **Claude Code** | Anthropic | ACP | Deep reasoning and architecture judgment |
-| **Claude (Gateway • Experimental)** | OpenAI, Cursor, Moonshot AI | Claude Code gateway | Latest GPT, Cursor, and Kimi K3 models in one Claude Code surface |
+| **Claude (Gateway)** | OpenAI, Cursor, Moonshot AI | Claude Code gateway | Latest GPT, Cursor, and Kimi K3 models in one Claude Code surface |
 | **Codex CLI** | OpenAI | Codex App Server | Rapid implementation and iterative execution |
 | **Cursor Agent** | Cursor | ACP | Multi-model routing |
 

--- a/packages/fleet-admiral/src/agent-cli/claude/claude-gateway.ts
+++ b/packages/fleet-admiral/src/agent-cli/claude/claude-gateway.ts
@@ -2,7 +2,9 @@ import { createClaudeFamilyCliDefinition } from "./factory.js";
 
 // Experimental: 로컬 AI 게이트웨이로 향하는 Claude Code. 게이트웨이 URL과 세션 bearer는
 // Console 포트를 아는 host가 launch 시점에 주입하므로 여기서는 정적 env를 두지 않는다.
+// 라벨은 종류만 말한다. 실험 단계라는 사실은 Console 실행 메뉴가 배지로 표시하므로,
+// 라벨에 겹쳐 적으면 배지와 함께 한 줄에 두 번 읽힌다.
 export const claudeGatewayCli = createClaudeFamilyCliDefinition({
   id: "claude-gateway",
-  label: "Claude (Gateway • Experimental)",
+  label: "Claude (Gateway)",
 });

--- a/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
@@ -40,7 +40,7 @@ describe("claude-gateway profile", () => {
       args: ["--model", "claude-gateway--cursor-auto"],
       bin: process.execPath,
       id: "claude-gateway",
-      label: "Claude (Gateway • Experimental)",
+      label: "Claude (Gateway)",
       renameCommand: "/rename",
     });
     expect(profile.env.KEEP_ME).toBe("yes");

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -19,7 +19,7 @@ interface CanvasContextMenuProps {
   readonly onClose: () => void;
 }
 
-const MENU_WIDTH = 296;
+const MENU_WIDTH = 340;
 const MENU_MAX_HEIGHT = 520;
 const MENU_MIN_HEIGHT = 120;
 const MENU_MARGIN = 12;

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -3,6 +3,7 @@ import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console
 
 import { FEATURE_TOUR_BOUNDARY_ATTRIBUTE, FEATURE_TOUR_LAYER_SELECTOR } from "../feature-tour-catalog.js";
 import { useT } from "../i18n/index.js";
+import { resolveLaunchKindAnnotation } from "../launch-kind-annotations.js";
 
 interface CanvasContextMenuProps {
   // 캔버스(<main>) 기준 화면 좌표. 메뉴를 이 지점에 띄운다.
@@ -18,7 +19,7 @@ interface CanvasContextMenuProps {
   readonly onClose: () => void;
 }
 
-const MENU_WIDTH = 288;
+const MENU_WIDTH = 296;
 const MENU_MAX_HEIGHT = 520;
 const MENU_MIN_HEIGHT = 120;
 const MENU_MARGIN = 12;
@@ -98,12 +99,13 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
             <p className="canvas-context-menu-plugin">{plugin.title}</p>
             {plugin.kinds.map((kind) => {
               const disabled = kind.disabled === true || !canLaunch;
+              const annotation = resolveLaunchKindAnnotation(kind.id);
               return (
                 <button
                   key={`${plugin.id}:${kind.id}`}
                   type="button"
                   role="menuitem"
-                  className="theater-menu-item canvas-context-menu-item operation-launch-menu-item"
+                  className={`theater-menu-item canvas-context-menu-item operation-launch-menu-item${annotation ? " operation-launch-menu-item--annotated" : ""}`}
                   // 실행 종류의 안정 식별자. 기능 투어처럼 특정 항목을 짚어야 하는 바깥 선택자가
                   // 번역 가능한 title/label 문자열 대신 이 속성에 걸리도록 한다.
                   data-operation-launch-kind={kind.id}
@@ -113,7 +115,11 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                 >
                   <span className="theater-menu-check" aria-hidden="true">{renderKindIcon(plugin.id, kind) ?? <FallbackGlyph />}</span>
                   <span className="theater-menu-label">{kind.title}</span>
-                  {kind.disabledReason ? <span className="operation-launch-menu-reason">{kind.disabledReason}</span> : null}
+                  {annotation?.badgeKey ? <span className="operation-launch-menu-badge">{t(annotation.badgeKey)}</span> : null}
+                  {/* 비활성 사유가 있으면 그것이 먼저다 — 지금 실행할 수 없다는 사실이 종류 설명보다 급하다. */}
+                  {kind.disabledReason
+                    ? <span className="operation-launch-menu-reason">{kind.disabledReason}</span>
+                    : annotation ? <span className="operation-launch-menu-description">{t(annotation.descriptionKey)}</span> : null}
                 </button>
               );
             })}

--- a/runtime/fleet-console/core/client/src/components/feature-tour.tsx
+++ b/runtime/fleet-console/core/client/src/components/feature-tour.tsx
@@ -87,6 +87,10 @@ export function FeatureTourOverlay() {
       return;
     }
     anchor.classList.add("is-feature-tour-anchor");
+    // 스크롤되는 메뉴 안에서는 앵커가 보이는 영역 밖에 있을 수 있다. 가리키는 대상이 보이지 않으면
+    // 안내가 성립하지 않으므로, 카드 자리를 잡기 전에 가장 가까운 보이는 위치로 끌어온다.
+    // nearest는 이미 보이는 앵커에는 아무 일도 하지 않아 평소 배치를 흔들지 않는다.
+    anchor.scrollIntoView?.({ block: "nearest", inline: "nearest" });
     const updatePosition = () => {
       const boundary = anchor.closest<HTMLElement>(FEATURE_TOUR_BOUNDARY_SELECTOR);
       const card = cardRef.current?.getBoundingClientRect();

--- a/runtime/fleet-console/core/client/src/components/feature-tour.tsx
+++ b/runtime/fleet-console/core/client/src/components/feature-tour.tsx
@@ -154,7 +154,7 @@ export function FeatureTourOverlay() {
                     if (lastStep) {
                       void finish();
                     } else {
-                      setStepIndex((index) => index + 1);
+                      setStepIndex((index) => advanceFeatureTourStep(index, resolved.steps.length));
                     }
                   }}
                   type="button"
@@ -214,6 +214,13 @@ export function featureTourCompletionBase(
   return phase === "walkthrough" && tour.spotlight
     ? appendSeenFeatureTour(seen, featureTourSeenKey(tour.id, "spotlight"))
     : seen;
+}
+
+// 다음 스텝은 마지막 스텝을 넘지 않는다 — 진행 버튼의 '마지막인가' 판정은 렌더 시점 값이라,
+// 리렌더 전에 두 번 눌리면 두 번 다 '마지막이 아니다'로 읽혀 인덱스가 총수를 넘어간다.
+// 본문은 어차피 clamp되지만 진행 표시는 그대로 새어 나가 "4 / 3"이 된다.
+export function advanceFeatureTourStep(index: number, total: number): number {
+  return Math.min(index + 1, Math.max(0, total - 1));
 }
 
 export function featureTourSeenKey(tourId: string, phase: FeatureTourPhase): string {

--- a/runtime/fleet-console/core/client/src/feature-tour-catalog.ts
+++ b/runtime/fleet-console/core/client/src/feature-tour-catalog.ts
@@ -39,14 +39,28 @@ export const FEATURE_TOURS: readonly FeatureTour[] = [
     ],
   },
   {
-    id: "claude-gateway",
-    // Canvas controls 메뉴의 Claude Gateway 실행 항목 하나만 가리킨다. 선택자는 의미 속성에 건다 —
-    // title/i18n 문자열에 걸면 라벨을 손보는 순간 앵커가 조용히 사라진다.
-    spotlight: {
-      anchor: '[data-operation-launch-kind="claude-gateway"]',
-      titleKey: "featureTour.claudeGateway.spotlightTitle",
-      bodyKey: "featureTour.claudeGateway.spotlightBody",
-    },
-    walkthrough: [],
+    id: "claude-operations",
+    // Claude가 세 갈래로 나뉜 사실은 셋을 차례로 짚어야 전해진다 — 하나만 비추면 나머지 둘과
+    // 무엇이 다른지가 빠진다. 순서는 메뉴에 놓인 순서(Native → Classic → Gateway)를 따른다.
+    // 이 투어는 주의를 한 번 환기할 뿐이고, 되짚어 볼 설명은 메뉴 항목에 상시 남는다.
+    spotlight: null,
+    walkthrough: [
+      // 선택자는 의미 속성에 건다 — title/i18n 문자열에 걸면 라벨을 손보는 순간 앵커가 조용히 사라진다.
+      {
+        anchor: '[data-operation-launch-kind="claude-native"]',
+        titleKey: "featureTour.claudeOperations.step1Title",
+        bodyKey: "featureTour.claudeOperations.step1Body",
+      },
+      {
+        anchor: '[data-operation-launch-kind="claude"]',
+        titleKey: "featureTour.claudeOperations.step2Title",
+        bodyKey: "featureTour.claudeOperations.step2Body",
+      },
+      {
+        anchor: '[data-operation-launch-kind="claude-gateway"]',
+        titleKey: "featureTour.claudeOperations.step3Title",
+        bodyKey: "featureTour.claudeOperations.step3Body",
+      },
+    ],
   },
 ] as const;

--- a/runtime/fleet-console/core/client/src/i18n/messages/common.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/common.ts
@@ -91,8 +91,10 @@ export const commonKo: Record<keyof typeof commonEn, string> = {
   "featureTour.claudeOperations.step2Body": "쓰시던 Operation 그대로입니다. Admiral 상비 명령과 Carrier 위임이 함께 실립니다. 달라진 것은 없고, 이름에 (Classic)만 붙었습니다.",
   "featureTour.claudeOperations.step3Title": "다른 모델로 도는 Claude입니다",
   "featureTour.claudeOperations.step3Body": "새로 추가된 실험 기능입니다. 로컬 AI Gateway를 거쳐 설정에서 켠 모델로 Claude Code를 실행합니다. 대규모 작업에 적합하고, 실행 후 /model로 모델을 바꿀 수 있습니다.",
-  "launchKind.badge.new": "신규",
-  "launchKind.badge.newExperimental": "신규 · 실험",
+  // 배지는 두 로케일이 같은 라틴 대문자를 쓴다 — 표식은 읽는 문장이 아니라 눈에 걸리는 표시이고,
+  // 로케일마다 길이가 달라지면 같은 메뉴가 로케일에 따라 다른 폭으로 접힌다.
+  "launchKind.badge.new": "NEW",
+  "launchKind.badge.newExperimental": "NEW · EXPERIMENTAL",
   "launchKind.claudeNative.description": "Admiral 프롬프트 없는 순정 Claude Code",
   "launchKind.claude.description": "Admiral 상비 명령과 Carrier 위임을 함께 싣는 기존 방식",
   "launchKind.claudeGateway.description": "설정에서 켠 다른 모델로 Claude Code를 실행",

--- a/runtime/fleet-console/core/client/src/i18n/messages/common.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/common.ts
@@ -34,8 +34,19 @@ export const commonEn = {
   "featureTour.triage.step2Body": "Click anything in the left list or the rail below to bring it up now. The rail also shows what is next.",
   "featureTour.triage.step3Title": "Turn it off and nothing is lost",
   "featureTour.triage.step3Body": "Press it again, or Alt+T, and every panel returns to its coordinates.",
-  "featureTour.claudeGateway.spotlightTitle": "Claude Gateway is available",
-  "featureTour.claudeGateway.spotlightBody": "Start Claude Code through AI Gateway to use the models enabled in Settings. It is well suited to large-scale workloads. You can switch models later with /model.",
+  "featureTour.claudeOperations.step1Title": "Claude, plain",
+  "featureTour.claudeOperations.step1Body": "New here. Claude Code as it ships — no Admiral prompt, no Carriers. Console hooks and Wiki skills are all that get added. Pick it when you want the CLI you already know.",
+  "featureTour.claudeOperations.step2Title": "Claude, with the fleet",
+  "featureTour.claudeOperations.step2Body": "This is the Operation you already run. Admiral standing orders and Carrier dispatch load with it. Nothing about it changed — only the name gained (Classic).",
+  "featureTour.claudeOperations.step3Title": "Claude, on other models",
+  "featureTour.claudeOperations.step3Body": "New and experimental. Runs Claude Code through the local AI Gateway so it can use the models you enabled in Settings. It suits large workloads, and you can switch models later with /model.",
+  // 배지는 대문자를 값에 담는다 — text-transform으로 올리면 한글 로케일에서 변환이 무효라
+  // 자간만 남아 자글자글해진다.
+  "launchKind.badge.new": "NEW",
+  "launchKind.badge.newExperimental": "NEW · EXPERIMENTAL",
+  "launchKind.claudeNative.description": "Plain Claude Code, without the Admiral prompt",
+  "launchKind.claude.description": "The one you know — Admiral standing orders and Carrier dispatch",
+  "launchKind.claudeGateway.description": "Runs Claude Code on the models you enabled in Settings",
 } as const;
 
 export const commonKo: Record<keyof typeof commonEn, string> = {
@@ -74,6 +85,15 @@ export const commonKo: Record<keyof typeof commonEn, string> = {
   "featureTour.triage.step2Body": "좌측 목록이나 아래 대기 레일에서 무엇이든 클릭하면 그 건이 바로 올라옵니다. 레일이 다음 순서도 함께 보여줍니다.",
   "featureTour.triage.step3Title": "끄면 원래 화면 그대로입니다",
   "featureTour.triage.step3Body": "다시 누르거나 Alt+T를 누르면 패널이 원래 자리로 돌아갑니다.",
-  "featureTour.claudeGateway.spotlightTitle": "Claude Gateway를 사용할 수 있습니다",
-  "featureTour.claudeGateway.spotlightBody": "Claude Code를 AI Gateway로 시작하면 설정에서 켠 모델을 사용할 수 있습니다. 대규모 워크로드에 적합합니다. 실행 후 /model로 모델을 바꿀 수도 있습니다.",
+  "featureTour.claudeOperations.step1Title": "순정 Claude입니다",
+  "featureTour.claudeOperations.step1Body": "새로 추가됐습니다. Admiral 프롬프트도 Carrier도 싣지 않은 Claude Code 그대로입니다. Console 훅과 Wiki 스킬만 붙습니다. CLI를 쓰던 대로 쓰고 싶을 때 고르세요.",
+  "featureTour.claudeOperations.step2Title": "함대를 실은 Claude입니다",
+  "featureTour.claudeOperations.step2Body": "쓰시던 Operation 그대로입니다. Admiral 상비 명령과 Carrier 위임이 함께 실립니다. 달라진 것은 없고, 이름에 (Classic)만 붙었습니다.",
+  "featureTour.claudeOperations.step3Title": "다른 모델로 도는 Claude입니다",
+  "featureTour.claudeOperations.step3Body": "새로 추가된 실험 기능입니다. 로컬 AI Gateway를 거쳐 설정에서 켠 모델로 Claude Code를 실행합니다. 대규모 작업에 적합하고, 실행 후 /model로 모델을 바꿀 수 있습니다.",
+  "launchKind.badge.new": "신규",
+  "launchKind.badge.newExperimental": "신규 · 실험",
+  "launchKind.claudeNative.description": "Admiral 프롬프트 없는 순정 Claude Code",
+  "launchKind.claude.description": "Admiral 상비 명령과 Carrier 위임을 함께 싣는 기존 방식",
+  "launchKind.claudeGateway.description": "설정에서 켠 다른 모델로 Claude Code를 실행",
 };

--- a/runtime/fleet-console/core/client/src/launch-kind-annotations.ts
+++ b/runtime/fleet-console/core/client/src/launch-kind-annotations.ts
@@ -1,0 +1,29 @@
+import type { CoreMessageKey } from "./i18n/index.js";
+
+// 실행 메뉴 항목에 덧붙는 한 줄 설명과 배지. 플러그인이 주는 title은 로케일 없는 서버 문자열이라
+// 번역할 수 없으므로, 번역이 필요한 문구는 여기(코어 i18n)에 두고 kind id로만 맞붙인다.
+// 코어가 특정 kind id를 아는 것은 feature-tour 카탈로그가 이미 쓰는 방식과 같다 — 두 곳 모두
+// 번역 가능한 라벨이 아니라 안정 식별자에 건다.
+export interface LaunchKindAnnotation {
+  readonly descriptionKey: CoreMessageKey;
+  // 새로 생긴 실행 종류에만 붙는 한시적 표식. 종류가 익숙해지면 이 필드만 지우면 된다.
+  readonly badgeKey?: CoreMessageKey;
+}
+
+export const LAUNCH_KIND_ANNOTATIONS: Readonly<Record<string, LaunchKindAnnotation>> = {
+  "claude-native": {
+    descriptionKey: "launchKind.claudeNative.description",
+    badgeKey: "launchKind.badge.new",
+  },
+  claude: {
+    descriptionKey: "launchKind.claude.description",
+  },
+  "claude-gateway": {
+    descriptionKey: "launchKind.claudeGateway.description",
+    badgeKey: "launchKind.badge.newExperimental",
+  },
+};
+
+export function resolveLaunchKindAnnotation(kindId: string): LaunchKindAnnotation | null {
+  return LAUNCH_KIND_ANNOTATIONS[kindId] ?? null;
+}

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -1628,8 +1628,8 @@
 
 .operation-launch-control--canvas .operation-launch-menu {
   top: 0;
-  /* 'Canvas controls' 헤더가 한 줄에 들어가도록 폭을 넓힌다. */
-  min-width: 256px;
+  /* 'Canvas controls' 헤더가 한 줄에 들어가고, 실행 종류의 한 줄 설명이 두 줄 안에 끝나도록 넓힌다. */
+  min-width: 296px;
 }
 
 /* 런처로 연 경우 메뉴를 컨테이너 바닥에 정렬해 위로 펼친다(아래 FAB/Dock과 겹치지 않게). */
@@ -5516,6 +5516,74 @@
   font-size: 10px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+/* 설명·배지가 붙는 실행 종류 항목은 그리드로 둔다. 배지를 라벨과 같은 행에 흘려두면 설명이
+   배지 폭만큼 좁아져 세 줄로 접히므로, 라벨·배지는 한 행에 두고 설명은 그 아래 전체 폭을 쓴다. */
+.operation-launch-menu-item--annotated {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: start;
+  column-gap: var(--space-2);
+  row-gap: 2px;
+}
+
+.operation-launch-menu-item--annotated .theater-menu-check {
+  grid-row: 1;
+  margin-top: 1px;
+}
+
+.operation-launch-menu-item--annotated .theater-menu-label {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.operation-launch-menu-item--annotated .operation-launch-menu-badge,
+.operation-launch-menu-item--annotated .operation-launch-menu-reason {
+  grid-column: 3;
+  grid-row: 1;
+  margin-left: 0;
+  padding-left: 0;
+}
+
+.operation-launch-menu-item--annotated .operation-launch-menu-description {
+  grid-column: 2 / -1;
+  grid-row: 2;
+}
+
+/* 한 줄 설명은 본문 서체로 한 티어 낮은 잉크에 둔다 — mono 라벨과 같은 서체로 두면 이름과
+   설명이 한 덩어리로 뭉쳐 어디까지가 종류 이름인지 읽히지 않는다. */
+.operation-launch-menu-description {
+  color: var(--text-tertiary);
+  font-family: var(--font-body);
+  font-size: 11px;
+  letter-spacing: 0;
+  line-height: 1.35;
+  white-space: normal;
+}
+
+/* Doctrine 예외 — 신규 표식 배지는 brass 채널을 빌린다.
+   brass는 위치/포커스/hover 채널이고 signal 토큰(aurora/warn/coral/positive)은 상태 채널인데,
+   '최근에 추가된 종류'는 둘 중 어느 축도 아니다. 축 하나를 새로 만드는 대신 항목을 지목하는
+   성격이 가장 가까운 brass를 저채도로 빌린다. 종류가 익숙해지면 통째로 걷어내는 한시적 장치다. */
+.operation-launch-menu-badge {
+  flex: none;
+  padding: 0 6px;
+  border: 1px solid color-mix(in oklch, var(--brass) 48%, var(--hairline));
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  color: var(--brass-ink);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  line-height: 1.8;
+  white-space: nowrap;
+}
+
+/* 한글 배지는 라틴 전제 자간을 그대로 쓰면 글자가 흩어져 읽힌다. */
+.operation-launch-menu-badge:lang(ko) {
+  font-family: var(--font-body);
+  font-size: 10px;
+  letter-spacing: 0.02em;
 }
 
 .theater-menu-error {

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5538,10 +5538,18 @@
   grid-row: 1;
 }
 
-.operation-launch-menu-item--annotated .operation-launch-menu-badge,
-.operation-launch-menu-item--annotated .operation-launch-menu-reason {
+.operation-launch-menu-item--annotated .operation-launch-menu-badge {
   grid-column: 3;
   grid-row: 1;
+  margin-left: 0;
+  padding-left: 0;
+}
+
+/* 비활성 사유는 배지와 같은 칸을 두고 다투지 않도록 설명이 서던 아래 줄로 내린다 —
+   같은 칸에 두면 사유가 배지에 완전히 가려, 미설치 사용자가 정작 필요한 이유를 읽지 못한다. */
+.operation-launch-menu-item--annotated .operation-launch-menu-reason {
+  grid-column: 2 / -1;
+  grid-row: 2;
   margin-left: 0;
   padding-left: 0;
 }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -1629,7 +1629,7 @@
 .operation-launch-control--canvas .operation-launch-menu {
   top: 0;
   /* 'Canvas controls' 헤더가 한 줄에 들어가고, 실행 종류의 한 줄 설명이 두 줄 안에 끝나도록 넓힌다. */
-  min-width: 296px;
+  min-width: 340px;
 }
 
 /* 런처로 연 경우 메뉴를 컨테이너 바닥에 정렬해 위로 펼친다(아래 FAB/Dock과 겹치지 않게). */
@@ -5577,13 +5577,6 @@
   letter-spacing: 0.1em;
   line-height: 1.8;
   white-space: nowrap;
-}
-
-/* 한글 배지는 라틴 전제 자간을 그대로 쓰면 글자가 흩어져 읽힌다. */
-.operation-launch-menu-badge:lang(ko) {
-  font-family: var(--font-body);
-  font-size: 10px;
-  letter-spacing: 0.02em;
 }
 
 .theater-menu-error {

--- a/runtime/fleet-console/tests/agent-cli-launch-metadata.test.ts
+++ b/runtime/fleet-console/tests/agent-cli-launch-metadata.test.ts
@@ -5,7 +5,7 @@ import { combineAgentCliLaunchMetadata } from "../../fleet-plugins/terminal/serv
 const METADATA = [
   { id: "claude", label: "Claude" },
   { id: "codex", label: "Codex" },
-  { id: "claude-gateway", label: "Claude (Gateway • Experimental)" },
+  { id: "claude-gateway", label: "Claude (Gateway)" },
 ] as const;
 
 describe("combineAgentCliLaunchMetadata", () => {
@@ -22,7 +22,7 @@ describe("combineAgentCliLaunchMetadata", () => {
     expect(result).toEqual([
       { id: "claude", label: "Claude", available: true, signedIn: true },
       { id: "codex", label: "Codex", available: true, signedIn: true },
-      { id: "claude-gateway", label: "Claude (Gateway • Experimental)", available: true, signedIn: true },
+      { id: "claude-gateway", label: "Claude (Gateway)", available: true, signedIn: true },
     ]);
   });
 

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -78,15 +78,65 @@ describe("CanvasContextMenu launch kind attribute", () => {
         title: "Terminal",
         kinds: [
           { id: "claude", type: "agent", title: "Claude Code (Classic)" },
-          { id: "claude-gateway", type: "agent", title: "Claude (Gateway • Experimental)" },
+          { id: "claude-gateway", type: "agent", title: "Claude (Gateway)" },
         ],
       },
     ]);
 
     const gateway = document.querySelectorAll<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]');
     expect(gateway).toHaveLength(1);
-    expect(gateway[0]?.textContent).toContain("Claude (Gateway • Experimental)");
+    expect(gateway[0]?.textContent).toContain("Claude (Gateway)");
     expect(document.querySelector('[data-operation-launch-kind="claude"]')).not.toBeNull();
+  });
+
+  it("annotates the Claude launch kinds with a description and marks the new ones", () => {
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [
+      {
+        id: "terminal",
+        title: "Terminal",
+        kinds: [
+          { id: "claude-native", type: "agent", title: "Claude (Native)" },
+          { id: "claude", type: "agent", title: "Claude (Classic)" },
+          { id: "codex", type: "agent", title: "Codex" },
+          { id: "claude-gateway", type: "agent", title: "Claude (Gateway)" },
+          { id: "shell", type: "shell", title: "Shell" },
+        ],
+      },
+    ]);
+
+    const descriptionOf = (kindId: string) =>
+      document.querySelector(`[data-operation-launch-kind="${kindId}"] .operation-launch-menu-description`)?.textContent;
+    const badgeOf = (kindId: string) =>
+      document.querySelector(`[data-operation-launch-kind="${kindId}"] .operation-launch-menu-badge`)?.textContent;
+
+    expect(descriptionOf("claude-native")).toBe("Plain Claude Code, without the Admiral prompt");
+    expect(descriptionOf("claude")).toContain("Admiral standing orders");
+    expect(descriptionOf("claude-gateway")).toContain("models you enabled in Settings");
+    // 설명은 Claude 세 갈래에만 붙는다 — 대비가 필요 없는 종류까지 늘리면 메뉴만 길어진다.
+    expect(descriptionOf("codex")).toBeUndefined();
+    expect(descriptionOf("shell")).toBeUndefined();
+
+    expect(badgeOf("claude-native")).toBe("NEW");
+    expect(badgeOf("claude-gateway")).toBe("NEW · EXPERIMENTAL");
+    expect(badgeOf("claude")).toBeUndefined();
+  });
+
+  it("shows the disabled reason instead of the description when the CLI cannot launch", () => {
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [
+      {
+        id: "terminal",
+        title: "Terminal",
+        kinds: [
+          { id: "claude-native", type: "agent", title: "Claude (Native)", disabled: true, disabledReason: "Not installed" },
+        ],
+      },
+    ]);
+
+    const item = document.querySelector('[data-operation-launch-kind="claude-native"]');
+    expect(item?.querySelector(".operation-launch-menu-reason")?.textContent).toBe("Not installed");
+    expect(item?.querySelector(".operation-launch-menu-description")).toBeNull();
+    // 배지는 사유와 함께 남는다 — 아직 설치하지 않았어도 새 종류라는 사실은 그대로다.
+    expect(item?.querySelector(".operation-launch-menu-badge")?.textContent).toBe("NEW");
   });
 
   it("marks the rendered menu box as the tour placement boundary", () => {

--- a/runtime/fleet-console/tests/feature-tour.test.ts
+++ b/runtime/fleet-console/tests/feature-tour.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  advanceFeatureTourStep,
   availableFeatureTourSteps,
   featureTourCompletionBase,
   persistFeatureTourSeen,
@@ -118,6 +119,16 @@ describe("feature tour", () => {
       .toBe("Claude (Classic)");
 
     expect(resolveNextFeatureTour(FEATURE_TOURS, ["claude-operations.walkthrough"], document)).toBeNull();
+  });
+
+  it("never advances past the last step, so the progress count cannot exceed the total", () => {
+    expect(advanceFeatureTourStep(0, 3)).toBe(1);
+    expect(advanceFeatureTourStep(1, 3)).toBe(2);
+    // 리렌더 전 연타: 마지막 스텝에서 더 눌러도 인덱스는 그 자리에 머문다 — 넘어가면 "4 / 3"이 뜬다.
+    expect(advanceFeatureTourStep(2, 3)).toBe(2);
+    expect(advanceFeatureTourStep(9, 3)).toBe(2);
+    expect(advanceFeatureTourStep(0, 1)).toBe(0);
+    expect(advanceFeatureTourStep(0, 0)).toBe(0);
   });
 
   it("does not open the Claude walkthrough before the launch menu exists", () => {

--- a/runtime/fleet-console/tests/feature-tour.test.ts
+++ b/runtime/fleet-console/tests/feature-tour.test.ts
@@ -48,7 +48,7 @@ describe("feature tour", () => {
   });
 
   it("ships Triage as an entry-only walkthrough without a button spotlight", () => {
-    expect(FEATURE_TOURS.map((tour) => tour.id)).toEqual(["triage", "claude-gateway"]);
+    expect(FEATURE_TOURS.map((tour) => tour.id)).toEqual(["triage", "claude-operations"]);
 
     const triage = FEATURE_TOURS.find((tour) => tour.id === "triage");
     expect(triage?.spotlight).toBeNull();
@@ -59,14 +59,18 @@ describe("feature tour", () => {
     ]);
   });
 
-  it("ships the Claude Gateway tour as a spotlight with no walkthrough", () => {
-    const gateway = FEATURE_TOURS.find((tour) => tour.id === "claude-gateway");
-    expect(gateway?.walkthrough).toEqual([]);
-    expect(gateway?.spotlight).toEqual({
-      anchor: '[data-operation-launch-kind="claude-gateway"]',
-      titleKey: "featureTour.claudeGateway.spotlightTitle",
-      bodyKey: "featureTour.claudeGateway.spotlightBody",
-    });
+  it("walks the three Claude launch kinds in menu order without a spotlight", () => {
+    const claude = FEATURE_TOURS.find((tour) => tour.id === "claude-operations");
+    expect(claude?.spotlight).toBeNull();
+    expect(claude?.walkthrough.map((step) => step.anchor)).toEqual([
+      '[data-operation-launch-kind="claude-native"]',
+      '[data-operation-launch-kind="claude"]',
+      '[data-operation-launch-kind="claude-gateway"]',
+    ]);
+    // 앵커는 번역되는 라벨이 아니라 안정 식별자에 걸려야 한다.
+    for (const step of claude?.walkthrough ?? []) {
+      expect(step.anchor).not.toMatch(/Classic|Native|Gateway •|Experimental/);
+    }
   });
 
   it("does not show Triage onboarding for the button before mode entry", () => {
@@ -91,30 +95,44 @@ describe("feature tour", () => {
     expect(resolveNextFeatureTour(FEATURE_TOURS, ["triage.walkthrough"], document)).toBeNull();
   });
 
-  it("resolves the shipped Claude Gateway catalog as a spotlight on its semantic launch attribute", () => {
-    const gateway = FEATURE_TOURS.find((tour) => tour.id === "claude-gateway");
-    const anchor = gateway?.spotlight?.anchor ?? "";
+  it("resolves the shipped Claude walkthrough on the open launch menu, step by step", () => {
+    const claude = FEATURE_TOURS.find((tour) => tour.id === "claude-operations");
     document.body.innerHTML = [
-      '<button data-operation-launch-kind="claude">Claude Code (Classic)</button>',
-      '<button data-operation-launch-kind="claude-gateway">Claude (Gateway • Experimental)</button>',
-      '<button data-operation-launch-kind="codex">Codex (Classic)</button>',
+      '<button data-operation-launch-kind="claude-native">Claude (Native)</button>',
+      '<button data-operation-launch-kind="claude">Claude (Classic)</button>',
+      '<button data-operation-launch-kind="codex">Codex</button>',
+      '<button data-operation-launch-kind="claude-gateway">Claude (Gateway)</button>',
     ].join("");
 
     const presentation = resolveNextFeatureTour(FEATURE_TOURS, [], document);
-    expect(presentation?.tour.id).toBe("claude-gateway");
-    expect(presentation?.phase).toBe("spotlight");
-    expect(presentation?.steps).toEqual([gateway?.spotlight]);
-    const matches = document.querySelectorAll(anchor);
-    expect(matches).toHaveLength(1);
-    expect(matches[0]?.getAttribute("data-operation-launch-kind")).toBe("claude-gateway");
-    expect(anchor).not.toMatch(/Gateway •|Experimental/);
+    expect(presentation?.tour.id).toBe("claude-operations");
+    expect(presentation?.phase).toBe("walkthrough");
+    expect(presentation?.steps).toEqual(claude?.walkthrough);
+
+    // "claude" 앵커는 정확 일치라 claude-native·claude-gateway를 함께 집지 않는다.
+    for (const step of claude?.walkthrough ?? []) {
+      const matches = document.querySelectorAll(step.anchor ?? "");
+      expect(matches).toHaveLength(1);
+    }
+    expect(document.querySelector('[data-operation-launch-kind="claude"]')?.textContent)
+      .toBe("Claude (Classic)");
+
+    expect(resolveNextFeatureTour(FEATURE_TOURS, ["claude-operations.walkthrough"], document)).toBeNull();
   });
 
-  it("describes Claude Gateway as suitable for large-scale workloads in both locales", () => {
-    expect(CORE_MESSAGES.en["featureTour.claudeGateway.spotlightBody"])
-      .toContain("well suited to large-scale workloads");
-    expect(CORE_MESSAGES.ko["featureTour.claudeGateway.spotlightBody"])
-      .toContain("대규모 워크로드에 적합합니다");
+  it("does not open the Claude walkthrough before the launch menu exists", () => {
+    document.body.innerHTML = "";
+
+    expect(resolveNextFeatureTour(FEATURE_TOURS, [], document)).toBeNull();
+  });
+
+  it("names each Claude launch kind by what it loads, in both locales", () => {
+    expect(CORE_MESSAGES.en["featureTour.claudeOperations.step1Body"]).toContain("no Admiral prompt");
+    expect(CORE_MESSAGES.ko["featureTour.claudeOperations.step1Body"]).toContain("Admiral 프롬프트도 Carrier도");
+    expect(CORE_MESSAGES.en["featureTour.claudeOperations.step2Body"]).toContain("Carrier dispatch");
+    expect(CORE_MESSAGES.ko["featureTour.claudeOperations.step2Body"]).toContain("Carrier 위임");
+    expect(CORE_MESSAGES.en["featureTour.claudeOperations.step3Body"]).toContain("/model");
+    expect(CORE_MESSAGES.ko["featureTour.claudeOperations.step3Body"]).toContain("/model");
   });
 
   it("keeps every shipped tour message key present in both locale catalogs", () => {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1100,6 +1100,13 @@ describe("Instrument core design contract", () => {
     // 대문자는 i18n 값이 들고 있다 — text-transform은 한글 로케일에서 무효라 자간만 남는다.
     expect(badgeBlock).not.toContain("text-transform");
 
+    // 배지와 비활성 사유는 서로 다른 줄을 차지해야 한다 — 같은 칸에 두면 사유가 배지에 가려 읽히지 않는다.
+    const badgeCell = components.match(/\.operation-launch-menu-item--annotated \.operation-launch-menu-badge \{[^}]*\}/)?.[0] ?? "";
+    const reasonCell = components.match(/\.operation-launch-menu-item--annotated \.operation-launch-menu-reason \{[^}]*\}/)?.[0] ?? "";
+    expect(badgeCell).toContain("grid-row: 1;");
+    expect(reasonCell).toContain("grid-row: 2;");
+    expect(reasonCell).toContain("grid-column: 2 / -1;");
+
     expect(descriptionBlock).toContain("color: var(--text-tertiary);");
     expect(descriptionBlock).toContain("font-family: var(--font-body);");
     expect(descriptionBlock).not.toMatch(/font-weight:\s*\d/);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1097,9 +1097,8 @@ describe("Instrument core design contract", () => {
     expect(badgeBlock).toContain("color: var(--brass-ink);");
     // 예외는 brass 한 채널까지다. 상태 채널을 함께 끌어 쓰면 배지가 상태로 오독된다.
     expect(badgeBlock).not.toMatch(/--(?:aurora|warn|coral|positive)/);
-    // 대문자는 값이 들고 있다 — text-transform은 한글 로케일에서 무효라 자간만 남는다.
+    // 대문자는 i18n 값이 들고 있다 — text-transform은 한글 로케일에서 무효라 자간만 남는다.
     expect(badgeBlock).not.toContain("text-transform");
-    expect(components).toContain(".operation-launch-menu-badge:lang(ko) {");
 
     expect(descriptionBlock).toContain("color: var(--text-tertiary);");
     expect(descriptionBlock).toContain("font-family: var(--font-body);");

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1084,6 +1084,28 @@ describe("Instrument core design contract", () => {
     expect(terminalAnalysisCss).not.toContain("--captain-tempest");
   });
 
+  it("pins the launch-kind annotation grammar and its recorded brass exception", () => {
+    const components = source("styles/components.css");
+    // 줄머리 앵커가 필요하다 — 앵커 없이는 `--annotated` 하위 배치 규칙이 먼저 잡힌다.
+    const badgeBlock = components.match(/^\.operation-launch-menu-badge \{[^}]*\}/m)?.[0] ?? "";
+    const descriptionBlock = components.match(/^\.operation-launch-menu-description \{[^}]*\}/m)?.[0] ?? "";
+
+    // 신규 표식은 brass를 빌리는 기록된 예외다 — 예외 사유는 CSS 규칙 옆 doctrine 주석이 소유한다.
+    expect(components).toContain("/* Doctrine 예외 — 신규 표식 배지는 brass 채널을 빌린다.");
+    expect(badgeBlock).toContain("border: 1px solid color-mix(in oklch, var(--brass) 48%, var(--hairline));");
+    expect(badgeBlock).toContain("background: color-mix(in oklch, var(--brass) 12%, transparent);");
+    expect(badgeBlock).toContain("color: var(--brass-ink);");
+    // 예외는 brass 한 채널까지다. 상태 채널을 함께 끌어 쓰면 배지가 상태로 오독된다.
+    expect(badgeBlock).not.toMatch(/--(?:aurora|warn|coral|positive)/);
+    // 대문자는 값이 들고 있다 — text-transform은 한글 로케일에서 무효라 자간만 남는다.
+    expect(badgeBlock).not.toContain("text-transform");
+    expect(components).toContain(".operation-launch-menu-badge:lang(ko) {");
+
+    expect(descriptionBlock).toContain("color: var(--text-tertiary);");
+    expect(descriptionBlock).toContain("font-family: var(--font-body);");
+    expect(descriptionBlock).not.toMatch(/font-weight:\s*\d/);
+  });
+
   it("keeps the v4 navigation, Theater, map, CLI, and rail visual producers", () => {
     const brandFoot = source("components/side-bar-brand-foot.tsx");
     const sidebar = source("sidebar/operations-side-bar.tsx");

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -178,7 +178,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
     const sharedResolveProfile = vi.fn(async (env: NodeJS.ProcessEnv, cwd: string, options: { readonly cliId?: string }) => ({
       ...baseProfile,
       id: options.cliId === "claude-gateway" ? "claude-gateway" as const : "codex" as const,
-      label: options.cliId === "claude-gateway" ? "Claude (Gateway • Experimental)" : "Codex",
+      label: options.cliId === "claude-gateway" ? "Claude (Gateway)" : "Codex",
       cwd,
       env: { ...env },
     }));
@@ -426,7 +426,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
       },
       infraServices: createFakeInfraServices() as never,
       injectProfile: (async (profile: AgentCliProfile) => profile) as never,
-      resolveProfile: (async () => ({ ...baseProfile, id: "claude-gateway", label: "Claude (Gateway • Experimental)" })) as never,
+      resolveProfile: (async () => ({ ...baseProfile, id: "claude-gateway", label: "Claude (Gateway)" })) as never,
       createSessionIdentityResolver: createResolver as never,
     });
 
@@ -452,7 +452,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
       resolveProfile: (async (env: NodeJS.ProcessEnv, cwd: string) => ({
         ...baseProfile,
         id: "claude-gateway",
-        label: "Claude (Gateway • Experimental)",
+        label: "Claude (Gateway)",
         cwd,
         env: { ...env },
       })) as never,
@@ -510,7 +510,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
       resolveProfile: (async (env: NodeJS.ProcessEnv, cwd: string) => ({
         ...baseProfile,
         id: "claude-gateway",
-        label: "Claude (Gateway • Experimental)",
+        label: "Claude (Gateway)",
         cwd,
         env: { ...env },
       })) as never,

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -2292,7 +2292,7 @@ describe("console static and terminal ticket boundary", () => {
     expect((listed.agentClis ?? []).map((cli) => ({ id: cli.id, label: cli.label }))).toEqual([
       { id: "claude", label: "Claude" },
       { id: "codex", label: "Codex" },
-      { id: "claude-gateway", label: "Claude (Gateway • Experimental)" },
+      { id: "claude-gateway", label: "Claude (Gateway)" },
     ]);
     for (const cli of listed.agentClis ?? []) {
       expect(typeof cli.available).toBe("boolean");

--- a/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
@@ -18,8 +18,10 @@ export function buildAgentCliLaunchKinds(
     });
 }
 
+// (Classic)은 같은 CLI에 다른 변형이 함께 있을 때만 뜻이 있다. Claude는 Native·Gateway와 나란히
+// 서므로 구분이 필요하지만, Codex에는 대비할 변형이 없어 접미가 있지도 않은 선택지를 암시한다.
 function resolveOperationTitle(cli: AgentCliLaunchMetadata): string {
-  return cli.id === "claude" || cli.id === "codex" ? `${cli.label} (Classic)` : cli.label;
+  return cli.id === "claude" ? `${cli.label} (Classic)` : cli.label;
 }
 
 function resolveDisabledReason(cli: AgentCliLaunchMetadata): string | undefined {

--- a/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
@@ -9,16 +9,17 @@ describe("buildAgentCliLaunchKinds", () => {
         { id: "claude-native", label: "Claude (Native)", available: true, signedIn: true },
         { id: "claude", label: "Claude", available: true, signedIn: true },
         { id: "codex", label: "Codex", available: true, signedIn: true },
-        { id: "claude-gateway", label: "Claude (Gateway • Experimental)", available: true, signedIn: true },
+        { id: "claude-gateway", label: "Claude (Gateway)", available: true, signedIn: true },
       ],
       "agent",
     );
 
+    // (Classic)은 같은 CLI에 다른 변형이 있는 Claude에만 붙는다 — Codex는 대비할 변형이 없다.
     expect(result).toEqual([
       { id: "claude-native", type: "agent", title: "Claude (Native)" },
       { id: "claude", type: "agent", title: "Claude (Classic)" },
-      { id: "codex", type: "agent", title: "Codex (Classic)" },
-      { id: "claude-gateway", type: "agent", title: "Claude (Gateway • Experimental)" },
+      { id: "codex", type: "agent", title: "Codex" },
+      { id: "claude-gateway", type: "agent", title: "Claude (Gateway)" },
     ]);
   });
 
@@ -33,7 +34,7 @@ describe("buildAgentCliLaunchKinds", () => {
 
     expect(result).toEqual([
       { id: "claude", type: "agent", title: "Claude (Classic)", disabled: true, disabledReason: "Not installed" },
-      { id: "codex", type: "agent", title: "Codex (Classic)", disabled: true, disabledReason: "Sign in required" },
+      { id: "codex", type: "agent", title: "Codex", disabled: true, disabledReason: "Sign in required" },
     ]);
   });
 });


### PR DESCRIPTION
## Summary

- 캔버스 제어 메뉴를 처음 열면 Claude 세 갈래를 메뉴 순서대로 짚는 3스텝 워크스루가 뜹니다 — `claude-native` → `claude` → `claude-gateway`. 기존 Claude Gateway 단일 spotlight를 대체합니다.
- 세 항목에 한 줄 설명이 상시 남고, 새로 생긴 두 종류(`Claude (Native)` / `Claude (Gateway)`)에 `NEW` 배지가 붙습니다. 투어를 건너뛰거나 잊어도 고를 때마다 근거가 남습니다.
- 라벨을 정리했습니다: `Claude (Gateway • Experimental)` → `Claude (Gateway)`(실험 단계는 배지가 표시), `Codex (Classic)` → `Codex`(Codex에는 대비할 변형이 없어 없는 선택지를 암시했습니다).
- 기능 투어의 진행 표시가 총수를 넘던 문제를 함께 막았습니다(리렌더 전 연타 시 `4 / 3`).

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console build` (tsc 게이트)
- [x] `pnpm --filter @dotobokuri/fleet-admiral build` / `test` — 124 passed
- [x] `vitest run tests/feature-tour.test.ts tests/canvas-context-menu-anchor.test.tsx tests/instrument-design-contract.test.ts tests/agent-cli-launch-metadata.test.ts` — 58 passed
- [x] `pnpm --filter "*terminal*" test` — 530 passed
- [x] 격리 콘솔 e2e 실측: 투어 `1/3 → 2/3 → 3/3`, 앵커가 native → claude → gateway 순으로 이동, 종료 시 `seenFeatureTours: ["claude-operations.walkthrough"]` 저장, 메뉴 설명 3건·배지 2건 유지, 라벨 잘림 없음(`scrollWidth <= clientWidth`)
- [x] 대비 측정: 배지 다크 8.35 / 라이트(whites) 5.68, 설명 5.73 (기준 4.5)
- [x] Changelog: `.changelog.d/pr-478.md` 추가 — 제품·섹션 그룹 문법, 영문·한글 병기, `node scripts/compile-changelog-fragments.mjs --check` 통과(10건)

### 선존 실패 (이 PR과 무관, canary에서 동일 재현)

- `tests/operations-boot-minimization.integration.test.ts` 36건, `tests/whatsnew-tabs.test.ts` 2건, `tests/launch.test.ts` 1건 — canary(`a9492eed2`) 체크아웃에서 동일하게 실패
- `tests/api-catalog.test.ts` / `tests/carrier-settings.test.ts` — 단독 실행 시 17건 전부 통과(전체 실행 시 포트 경합에 의한 가짜 실패)