### PR TITLE
refactor(fleet-console): carry the launch kind stage in the label

### DIFF
--- a/.changelog.d/pr-478.md
+++ b/.changelog.d/pr-478.md
@@ -1,7 +1,7 @@
 ### fleet-console
 #### Added
-- [fleet-console] Describe each Claude launch kind with a one-line summary in Canvas Controls and mark the newly added kinds with a NEW badge, so the difference stays readable every time you choose.
-  ko: 캔버스 제어의 Claude 실행 종류마다 한 줄 설명을 붙이고 새로 추가된 종류에 NEW 배지를 표시해, 고를 때마다 차이를 확인할 수 있습니다.
+- [fleet-console] Describe each Claude launch kind with a one-line summary in Canvas Controls, so the difference stays readable every time you choose.
+  ko: 캔버스 제어의 Claude 실행 종류마다 한 줄 설명을 붙여, 고를 때마다 차이를 확인할 수 있습니다.
 
 #### Changed
 - [fleet-console] Walk the three Claude launch kinds in menu order on the first Canvas Controls open, replacing the single Claude Gateway spotlight so Native and Classic are introduced alongside Gateway.
@@ -15,8 +15,3 @@
 #### Fixed
 - [fleet-console] Drop the (Classic) suffix from the Codex launch entry, which has no Native or Gateway variant to contrast with.
   ko: 대비할 Native·Gateway 변형이 없는 Codex 실행 항목에서 (Classic) 접미를 제거합니다.
-
-### fleet-core
-#### Changed
-- [fleet-admiral] Shorten the gateway Agent CLI label to `Claude (Gateway)` because the Console launch menu now marks the experimental stage with a badge.
-  ko: Console 실행 메뉴가 실험 단계를 배지로 표시하므로 게이트웨이 Agent CLI 라벨을 `Claude (Gateway)`로 줄입니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -80,7 +80,7 @@ Nimitz와 Vanguard는 여기에 더해 **Task Force**를 지원합니다. 둘 �
 | CLI | 제공자 | 프로토콜 | 대표 강점 |
 |---|---|---|---|
 | **Claude Code** | Anthropic | ACP | 심층 추론과 아키텍처 판단 |
-| **Claude (Gateway)** | OpenAI, Cursor, Moonshot AI | Claude Code gateway | 하나의 Claude Code 표면에서 최신 GPT·Cursor·Kimi K3 모델 사용 |
+| **Claude (Gateway • Experimental)** | OpenAI, Cursor, Moonshot AI | Claude Code gateway | 하나의 Claude Code 표면에서 최신 GPT·Cursor·Kimi K3 모델 사용 |
 | **Codex CLI** | OpenAI | Codex App Server | 빠른 구현과 반복 실행 |
 | **Cursor Agent** | Cursor | ACP | 다중 모델 라우팅 |
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Every supported CLI brings a model-native agent loop refined by its creator. Fle
 | CLI | Provider | Protocol | Typical strength |
 |---|---|---|---|
 | **Claude Code** | Anthropic | ACP | Deep reasoning and architecture judgment |
-| **Claude (Gateway)** | OpenAI, Cursor, Moonshot AI | Claude Code gateway | Latest GPT, Cursor, and Kimi K3 models in one Claude Code surface |
+| **Claude (Gateway • Experimental)** | OpenAI, Cursor, Moonshot AI | Claude Code gateway | Latest GPT, Cursor, and Kimi K3 models in one Claude Code surface |
 | **Codex CLI** | OpenAI | Codex App Server | Rapid implementation and iterative execution |
 | **Cursor Agent** | Cursor | ACP | Multi-model routing |
 

--- a/packages/fleet-admiral/src/agent-cli/claude/claude-gateway.ts
+++ b/packages/fleet-admiral/src/agent-cli/claude/claude-gateway.ts
@@ -2,9 +2,9 @@ import { createClaudeFamilyCliDefinition } from "./factory.js";
 
 // Experimental: 로컬 AI 게이트웨이로 향하는 Claude Code. 게이트웨이 URL과 세션 bearer는
 // Console 포트를 아는 host가 launch 시점에 주입하므로 여기서는 정적 env를 두지 않는다.
-// 라벨은 종류만 말한다. 실험 단계라는 사실은 Console 실행 메뉴가 배지로 표시하므로,
-// 라벨에 겹쳐 적으면 배지와 함께 한 줄에 두 번 읽힌다.
+// 실험 단계라는 사실은 라벨 괄호 안이 들고 있다 — 별도 표식을 두지 않으므로 이름만 보고
+// 판단할 수 있어야 한다.
 export const claudeGatewayCli = createClaudeFamilyCliDefinition({
   id: "claude-gateway",
-  label: "Claude (Gateway)",
+  label: "Claude (Gateway • Experimental)",
 });

--- a/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
@@ -40,7 +40,7 @@ describe("claude-gateway profile", () => {
       args: ["--model", "claude-gateway--cursor-auto"],
       bin: process.execPath,
       id: "claude-gateway",
-      label: "Claude (Gateway)",
+      label: "Claude (Gateway • Experimental)",
       renameCommand: "/rename",
     });
     expect(profile.env.KEEP_ME).toBe("yes");

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -115,7 +115,6 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                 >
                   <span className="theater-menu-check" aria-hidden="true">{renderKindIcon(plugin.id, kind) ?? <FallbackGlyph />}</span>
                   <span className="theater-menu-label">{kind.title}</span>
-                  {annotation?.badgeKey ? <span className="operation-launch-menu-badge">{t(annotation.badgeKey)}</span> : null}
                   {/* 비활성 사유가 있으면 그것이 먼저다 — 지금 실행할 수 없다는 사실이 종류 설명보다 급하다. */}
                   {kind.disabledReason
                     ? <span className="operation-launch-menu-reason">{kind.disabledReason}</span>

--- a/runtime/fleet-console/core/client/src/i18n/messages/common.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/common.ts
@@ -40,10 +40,6 @@ export const commonEn = {
   "featureTour.claudeOperations.step2Body": "This is the Operation you already run. Admiral standing orders and Carrier dispatch load with it. Nothing about it changed — only the name gained (Classic).",
   "featureTour.claudeOperations.step3Title": "Claude, on other models",
   "featureTour.claudeOperations.step3Body": "New and experimental. Runs Claude Code through the local AI Gateway so it can use the models you enabled in Settings. It suits large workloads, and you can switch models later with /model.",
-  // 배지는 대문자를 값에 담는다 — text-transform으로 올리면 한글 로케일에서 변환이 무효라
-  // 자간만 남아 자글자글해진다.
-  "launchKind.badge.new": "NEW",
-  "launchKind.badge.newExperimental": "NEW · EXPERIMENTAL",
   "launchKind.claudeNative.description": "Plain Claude Code, without the Admiral prompt",
   "launchKind.claude.description": "The one you know — Admiral standing orders and Carrier dispatch",
   "launchKind.claudeGateway.description": "Runs Claude Code on the models you enabled in Settings",
@@ -91,10 +87,6 @@ export const commonKo: Record<keyof typeof commonEn, string> = {
   "featureTour.claudeOperations.step2Body": "쓰시던 Operation 그대로입니다. Admiral 상비 명령과 Carrier 위임이 함께 실립니다. 달라진 것은 없고, 이름에 (Classic)만 붙었습니다.",
   "featureTour.claudeOperations.step3Title": "다른 모델로 도는 Claude입니다",
   "featureTour.claudeOperations.step3Body": "새로 추가된 실험 기능입니다. 로컬 AI Gateway를 거쳐 설정에서 켠 모델로 Claude Code를 실행합니다. 대규모 작업에 적합하고, 실행 후 /model로 모델을 바꿀 수 있습니다.",
-  // 배지는 두 로케일이 같은 라틴 대문자를 쓴다 — 표식은 읽는 문장이 아니라 눈에 걸리는 표시이고,
-  // 로케일마다 길이가 달라지면 같은 메뉴가 로케일에 따라 다른 폭으로 접힌다.
-  "launchKind.badge.new": "NEW",
-  "launchKind.badge.newExperimental": "NEW · EXPERIMENTAL",
   "launchKind.claudeNative.description": "Admiral 프롬프트 없는 순정 Claude Code",
   "launchKind.claude.description": "Admiral 상비 명령과 Carrier 위임을 함께 싣는 기존 방식",
   "launchKind.claudeGateway.description": "설정에서 켠 다른 모델로 Claude Code를 실행",

--- a/runtime/fleet-console/core/client/src/launch-kind-annotations.ts
+++ b/runtime/fleet-console/core/client/src/launch-kind-annotations.ts
@@ -1,26 +1,22 @@
 import type { CoreMessageKey } from "./i18n/index.js";
 
-// 실행 메뉴 항목에 덧붙는 한 줄 설명과 배지. 플러그인이 주는 title은 로케일 없는 서버 문자열이라
+// 실행 메뉴 항목에 덧붙는 한 줄 설명. 플러그인이 주는 title은 로케일 없는 서버 문자열이라
 // 번역할 수 없으므로, 번역이 필요한 문구는 여기(코어 i18n)에 두고 kind id로만 맞붙인다.
 // 코어가 특정 kind id를 아는 것은 feature-tour 카탈로그가 이미 쓰는 방식과 같다 — 두 곳 모두
 // 번역 가능한 라벨이 아니라 안정 식별자에 건다.
 export interface LaunchKindAnnotation {
   readonly descriptionKey: CoreMessageKey;
-  // 새로 생긴 실행 종류에만 붙는 한시적 표식. 종류가 익숙해지면 이 필드만 지우면 된다.
-  readonly badgeKey?: CoreMessageKey;
 }
 
 export const LAUNCH_KIND_ANNOTATIONS: Readonly<Record<string, LaunchKindAnnotation>> = {
   "claude-native": {
     descriptionKey: "launchKind.claudeNative.description",
-    badgeKey: "launchKind.badge.new",
   },
   claude: {
     descriptionKey: "launchKind.claude.description",
   },
   "claude-gateway": {
     descriptionKey: "launchKind.claudeGateway.description",
-    badgeKey: "launchKind.badge.newExperimental",
   },
 };
 

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -5518,11 +5518,11 @@
   text-transform: uppercase;
 }
 
-/* 설명·배지가 붙는 실행 종류 항목은 그리드로 둔다. 배지를 라벨과 같은 행에 흘려두면 설명이
-   배지 폭만큼 좁아져 세 줄로 접히므로, 라벨·배지는 한 행에 두고 설명은 그 아래 전체 폭을 쓴다. */
+/* 한 줄 설명이 붙는 실행 종류 항목은 그리드로 둔다. 라벨이 첫 행을 온전히 쓰고, 설명과
+   비활성 사유는 그 아래 전체 폭에 선다. */
 .operation-launch-menu-item--annotated {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr);
   align-items: start;
   column-gap: var(--space-2);
   row-gap: 2px;
@@ -5538,15 +5538,8 @@
   grid-row: 1;
 }
 
-.operation-launch-menu-item--annotated .operation-launch-menu-badge {
-  grid-column: 3;
-  grid-row: 1;
-  margin-left: 0;
-  padding-left: 0;
-}
-
-/* 비활성 사유는 배지와 같은 칸을 두고 다투지 않도록 설명이 서던 아래 줄로 내린다 —
-   같은 칸에 두면 사유가 배지에 완전히 가려, 미설치 사용자가 정작 필요한 이유를 읽지 못한다. */
+/* 비활성 사유는 설명이 서던 아래 줄로 내린다 — 라벨과 같은 행에 두면 둘이 폭을 다투어
+   `Claude (Gateway • Experimental)` 같은 긴 종류 이름이 잘린다. */
 .operation-launch-menu-item--annotated .operation-launch-menu-reason {
   grid-column: 2 / -1;
   grid-row: 2;
@@ -5568,23 +5561,6 @@
   letter-spacing: 0;
   line-height: 1.35;
   white-space: normal;
-}
-
-/* Doctrine 예외 — 신규 표식 배지는 brass 채널을 빌린다.
-   brass는 위치/포커스/hover 채널이고 signal 토큰(aurora/warn/coral/positive)은 상태 채널인데,
-   '최근에 추가된 종류'는 둘 중 어느 축도 아니다. 축 하나를 새로 만드는 대신 항목을 지목하는
-   성격이 가장 가까운 brass를 저채도로 빌린다. 종류가 익숙해지면 통째로 걷어내는 한시적 장치다. */
-.operation-launch-menu-badge {
-  flex: none;
-  padding: 0 6px;
-  border: 1px solid color-mix(in oklch, var(--brass) 48%, var(--hairline));
-  border-radius: var(--radius-sm);
-  background: color-mix(in oklch, var(--brass) 12%, transparent);
-  color: var(--brass-ink);
-  font-size: 9px;
-  letter-spacing: 0.1em;
-  line-height: 1.8;
-  white-space: nowrap;
 }
 
 .theater-menu-error {

--- a/runtime/fleet-console/tests/agent-cli-launch-metadata.test.ts
+++ b/runtime/fleet-console/tests/agent-cli-launch-metadata.test.ts
@@ -5,7 +5,7 @@ import { combineAgentCliLaunchMetadata } from "../../fleet-plugins/terminal/serv
 const METADATA = [
   { id: "claude", label: "Claude" },
   { id: "codex", label: "Codex" },
-  { id: "claude-gateway", label: "Claude (Gateway)" },
+  { id: "claude-gateway", label: "Claude (Gateway • Experimental)" },
 ] as const;
 
 describe("combineAgentCliLaunchMetadata", () => {
@@ -22,7 +22,7 @@ describe("combineAgentCliLaunchMetadata", () => {
     expect(result).toEqual([
       { id: "claude", label: "Claude", available: true, signedIn: true },
       { id: "codex", label: "Codex", available: true, signedIn: true },
-      { id: "claude-gateway", label: "Claude (Gateway)", available: true, signedIn: true },
+      { id: "claude-gateway", label: "Claude (Gateway • Experimental)", available: true, signedIn: true },
     ]);
   });
 

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -78,18 +78,18 @@ describe("CanvasContextMenu launch kind attribute", () => {
         title: "Terminal",
         kinds: [
           { id: "claude", type: "agent", title: "Claude Code (Classic)" },
-          { id: "claude-gateway", type: "agent", title: "Claude (Gateway)" },
+          { id: "claude-gateway", type: "agent", title: "Claude (Gateway • Experimental)" },
         ],
       },
     ]);
 
     const gateway = document.querySelectorAll<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]');
     expect(gateway).toHaveLength(1);
-    expect(gateway[0]?.textContent).toContain("Claude (Gateway)");
+    expect(gateway[0]?.textContent).toContain("Claude (Gateway • Experimental)");
     expect(document.querySelector('[data-operation-launch-kind="claude"]')).not.toBeNull();
   });
 
-  it("annotates the Claude launch kinds with a description and marks the new ones", () => {
+  it("annotates the Claude launch kinds with a description and no extra decoration", () => {
     renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [
       {
         id: "terminal",
@@ -98,7 +98,7 @@ describe("CanvasContextMenu launch kind attribute", () => {
           { id: "claude-native", type: "agent", title: "Claude (Native)" },
           { id: "claude", type: "agent", title: "Claude (Classic)" },
           { id: "codex", type: "agent", title: "Codex" },
-          { id: "claude-gateway", type: "agent", title: "Claude (Gateway)" },
+          { id: "claude-gateway", type: "agent", title: "Claude (Gateway • Experimental)" },
           { id: "shell", type: "shell", title: "Shell" },
         ],
       },
@@ -106,8 +106,6 @@ describe("CanvasContextMenu launch kind attribute", () => {
 
     const descriptionOf = (kindId: string) =>
       document.querySelector(`[data-operation-launch-kind="${kindId}"] .operation-launch-menu-description`)?.textContent;
-    const badgeOf = (kindId: string) =>
-      document.querySelector(`[data-operation-launch-kind="${kindId}"] .operation-launch-menu-badge`)?.textContent;
 
     expect(descriptionOf("claude-native")).toBe("Plain Claude Code, without the Admiral prompt");
     expect(descriptionOf("claude")).toContain("Admiral standing orders");
@@ -116,9 +114,10 @@ describe("CanvasContextMenu launch kind attribute", () => {
     expect(descriptionOf("codex")).toBeUndefined();
     expect(descriptionOf("shell")).toBeUndefined();
 
-    expect(badgeOf("claude-native")).toBe("NEW");
-    expect(badgeOf("claude-gateway")).toBe("NEW · EXPERIMENTAL");
-    expect(badgeOf("claude")).toBeUndefined();
+    // 신규·실험 여부는 라벨 괄호 안이 들고 있다 — 항목에 별도 표식을 덧붙이지 않는다.
+    expect(document.querySelector(".operation-launch-menu-badge")).toBeNull();
+    expect(document.querySelector('[data-operation-launch-kind="claude-gateway"]')?.textContent)
+      .toContain("Claude (Gateway • Experimental)");
   });
 
   it("shows the disabled reason instead of the description when the CLI cannot launch", () => {
@@ -135,8 +134,6 @@ describe("CanvasContextMenu launch kind attribute", () => {
     const item = document.querySelector('[data-operation-launch-kind="claude-native"]');
     expect(item?.querySelector(".operation-launch-menu-reason")?.textContent).toBe("Not installed");
     expect(item?.querySelector(".operation-launch-menu-description")).toBeNull();
-    // 배지는 사유와 함께 남는다 — 아직 설치하지 않았어도 새 종류라는 사실은 그대로다.
-    expect(item?.querySelector(".operation-launch-menu-badge")?.textContent).toBe("NEW");
   });
 
   it("marks the rendered menu box as the tour placement boundary", () => {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1084,32 +1084,22 @@ describe("Instrument core design contract", () => {
     expect(terminalAnalysisCss).not.toContain("--captain-tempest");
   });
 
-  it("pins the launch-kind annotation grammar and its recorded brass exception", () => {
+  it("pins the launch-kind description grammar and keeps the menu free of decoration tokens", () => {
     const components = source("styles/components.css");
     // 줄머리 앵커가 필요하다 — 앵커 없이는 `--annotated` 하위 배치 규칙이 먼저 잡힌다.
-    const badgeBlock = components.match(/^\.operation-launch-menu-badge \{[^}]*\}/m)?.[0] ?? "";
     const descriptionBlock = components.match(/^\.operation-launch-menu-description \{[^}]*\}/m)?.[0] ?? "";
-
-    // 신규 표식은 brass를 빌리는 기록된 예외다 — 예외 사유는 CSS 규칙 옆 doctrine 주석이 소유한다.
-    expect(components).toContain("/* Doctrine 예외 — 신규 표식 배지는 brass 채널을 빌린다.");
-    expect(badgeBlock).toContain("border: 1px solid color-mix(in oklch, var(--brass) 48%, var(--hairline));");
-    expect(badgeBlock).toContain("background: color-mix(in oklch, var(--brass) 12%, transparent);");
-    expect(badgeBlock).toContain("color: var(--brass-ink);");
-    // 예외는 brass 한 채널까지다. 상태 채널을 함께 끌어 쓰면 배지가 상태로 오독된다.
-    expect(badgeBlock).not.toMatch(/--(?:aurora|warn|coral|positive)/);
-    // 대문자는 i18n 값이 들고 있다 — text-transform은 한글 로케일에서 무효라 자간만 남는다.
-    expect(badgeBlock).not.toContain("text-transform");
-
-    // 배지와 비활성 사유는 서로 다른 줄을 차지해야 한다 — 같은 칸에 두면 사유가 배지에 가려 읽히지 않는다.
-    const badgeCell = components.match(/\.operation-launch-menu-item--annotated \.operation-launch-menu-badge \{[^}]*\}/)?.[0] ?? "";
     const reasonCell = components.match(/\.operation-launch-menu-item--annotated \.operation-launch-menu-reason \{[^}]*\}/)?.[0] ?? "";
-    expect(badgeCell).toContain("grid-row: 1;");
+
+    // 설명과 비활성 사유는 라벨 아래 줄에 선다 — 같은 행에 두면 긴 종류 이름이 잘린다.
     expect(reasonCell).toContain("grid-row: 2;");
     expect(reasonCell).toContain("grid-column: 2 / -1;");
-
     expect(descriptionBlock).toContain("color: var(--text-tertiary);");
     expect(descriptionBlock).toContain("font-family: var(--font-body);");
     expect(descriptionBlock).not.toMatch(/font-weight:\s*\d/);
+
+    // 실행 메뉴에는 신규 표식 배지를 두지 않는다 — 실험/신규 여부는 라벨 괄호 안이 들고 있다.
+    // 배지가 돌아오면 brass 채널을 빌리는 doctrine 예외가 다시 필요해지므로 여기서 막는다.
+    expect(components).not.toContain("operation-launch-menu-badge");
   });
 
   it("keeps the v4 navigation, Theater, map, CLI, and rail visual producers", () => {

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -178,7 +178,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
     const sharedResolveProfile = vi.fn(async (env: NodeJS.ProcessEnv, cwd: string, options: { readonly cliId?: string }) => ({
       ...baseProfile,
       id: options.cliId === "claude-gateway" ? "claude-gateway" as const : "codex" as const,
-      label: options.cliId === "claude-gateway" ? "Claude (Gateway)" : "Codex",
+      label: options.cliId === "claude-gateway" ? "Claude (Gateway • Experimental)" : "Codex",
       cwd,
       env: { ...env },
     }));
@@ -426,7 +426,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
       },
       infraServices: createFakeInfraServices() as never,
       injectProfile: (async (profile: AgentCliProfile) => profile) as never,
-      resolveProfile: (async () => ({ ...baseProfile, id: "claude-gateway", label: "Claude (Gateway)" })) as never,
+      resolveProfile: (async () => ({ ...baseProfile, id: "claude-gateway", label: "Claude (Gateway • Experimental)" })) as never,
       createSessionIdentityResolver: createResolver as never,
     });
 
@@ -452,7 +452,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
       resolveProfile: (async (env: NodeJS.ProcessEnv, cwd: string) => ({
         ...baseProfile,
         id: "claude-gateway",
-        label: "Claude (Gateway)",
+        label: "Claude (Gateway • Experimental)",
         cwd,
         env: { ...env },
       })) as never,
@@ -510,7 +510,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
       resolveProfile: (async (env: NodeJS.ProcessEnv, cwd: string) => ({
         ...baseProfile,
         id: "claude-gateway",
-        label: "Claude (Gateway)",
+        label: "Claude (Gateway • Experimental)",
         cwd,
         env: { ...env },
       })) as never,

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -2292,7 +2292,7 @@ describe("console static and terminal ticket boundary", () => {
     expect((listed.agentClis ?? []).map((cli) => ({ id: cli.id, label: cli.label }))).toEqual([
       { id: "claude", label: "Claude" },
       { id: "codex", label: "Codex" },
-      { id: "claude-gateway", label: "Claude (Gateway)" },
+      { id: "claude-gateway", label: "Claude (Gateway • Experimental)" },
     ]);
     for (const cli of listed.agentClis ?? []) {
       expect(typeof cli.available).toBe("boolean");

--- a/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
@@ -9,7 +9,7 @@ describe("buildAgentCliLaunchKinds", () => {
         { id: "claude-native", label: "Claude (Native)", available: true, signedIn: true },
         { id: "claude", label: "Claude", available: true, signedIn: true },
         { id: "codex", label: "Codex", available: true, signedIn: true },
-        { id: "claude-gateway", label: "Claude (Gateway)", available: true, signedIn: true },
+        { id: "claude-gateway", label: "Claude (Gateway • Experimental)", available: true, signedIn: true },
       ],
       "agent",
     );
@@ -19,7 +19,7 @@ describe("buildAgentCliLaunchKinds", () => {
       { id: "claude-native", type: "agent", title: "Claude (Native)" },
       { id: "claude", type: "agent", title: "Claude (Classic)" },
       { id: "codex", type: "agent", title: "Codex" },
-      { id: "claude-gateway", type: "agent", title: "Claude (Gateway)" },
+      { id: "claude-gateway", type: "agent", title: "Claude (Gateway • Experimental)" },
     ]);
   });
 


### PR DESCRIPTION
## Summary

- 실행 메뉴의 `NEW` / `NEW · EXPERIMENTAL` 배지를 제거했습니다. 신규·실험 여부는 라벨 괄호 안이 들고 갑니다.
- 게이트웨이 Agent CLI 라벨을 `Claude (Gateway • Experimental)`로 되돌렸습니다.
- 비활성 사유를 라벨 아래 줄로 내렸습니다 — 같은 행에 두면 긴 종류 이름이 잘립니다(실측 확인).
- 한 줄 설명과 3스텝 워크스루는 그대로 유지됩니다.

배지는 #478에서 들어왔고 아직 릴리스되지 않았으므로(`.changelog.d/pr-478.md` 잔존), 별도 Removed 항목 대신 그 fragment의 문구에서 배지·라벨 언급을 걷어냈습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console build` / `@dotobokuri/fleet-admiral build` (tsc 게이트)
- [x] `vitest run tests/feature-tour.test.ts tests/canvas-context-menu-anchor.test.tsx tests/instrument-design-contract.test.ts tests/agent-cli-launch-metadata.test.ts` — 58 passed
- [x] `pnpm --filter "*terminal*" test` — 532 passed / `@dotobokuri/fleet-admiral test` — 124 passed
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 13 entries validated
- [x] 격리 콘솔 e2e: 배지 0건, 라벨 `Claude (Gateway • Experimental)` 잘림 없음(`truncatedLabels: []`), 설명 3건 유지, 투어 `1 / 3` 정상
- [x] 비활성 사유 실측: 라벨 아래 줄에 서고 종류 이름은 온전(`labelTruncated: false`)
- [x] Changelog: `.changelog.d/pr-478.md` 문구 정정 — 미릴리스 fragment에 접었으므로 새 fragment 없음

### 선존 실패 (이 PR과 무관)

- `operations-boot-minimization.integration` 36건, `whatsnew-tabs` 2건, `launch` 1건 — canary에서 동일 재현