### PR TITLE
fix(core-ai-gateway): stop models filling omitted tool arguments

### DIFF
--- a/.changelog.d/pr-481.md
+++ b/.changelog.d/pr-481.md
@@ -1,0 +1,8 @@
+### fleet-core
+#### Fixed
+- [core-ai-gateway] Gateway-backed models no longer fill in optional tool arguments they were never asked to send, so a subagent pinned to a gateway model is no longer rerouted to a Claude model behind your back, and a file read no longer fails on a fabricated argument.
+  ko: 게이트웨이 모델이 보내달라고 하지 않은 선택적 도구 인자를 임의로 채우지 않으므로, 게이트웨이 모델로 고정한 서브에이전트가 모르는 사이 Claude 모델로 바뀌어 실행되거나 파일 읽기가 없는 인자 때문에 실패하지 않습니다.
+
+#### Added
+- [core-ai-gateway] Add opt-in gateway wire logging behind `FLEET_GATEWAY_WIRE_LOG`, which records the inbound tool catalog, provider request bodies, and every response event to one file so provider behaviour differences can be diagnosed. It stays off unless the variable names a path.
+  ko: `FLEET_GATEWAY_WIRE_LOG`로 켜는 게이트웨이 통신 로깅을 추가합니다. 수신한 도구 목록, 프로바이더 요청 본문, 모든 응답 이벤트를 한 파일에 기록해 프로바이더별 동작 차이를 진단할 수 있으며, 변수에 경로를 지정하지 않으면 동작하지 않습니다.

--- a/packages/core-ai-gateway/AGENTS.md
+++ b/packages/core-ai-gateway/AGENTS.md
@@ -1,0 +1,22 @@
+# core-ai-gateway
+
+Translates Anthropic Messages traffic onto non-Anthropic provider backends.
+
+## Layer index
+
+| Layer | Responsibility |
+|---|---|
+| `src/anthropic.ts` | Client-facing Anthropic protocol seam, in both directions |
+| `src/canonical.ts` | Provider-neutral request/event vocabulary every adapter speaks |
+| `src/openai-responses-adapter.ts`, `src/cursor-adapter.ts` | Provider wire formats |
+| `src/models.ts`, `models.json` | Model catalog, context windows, effort ladders |
+
+## Constraints
+
+- Keep Fleet orchestration and persona semantics out of this package; it knows providers, not Carriers.
+- The OpenAI path rewrites every compatible tool schema into strict mode and strips the resulting nulls back out on the way in. **These two are one mechanism.** Change either alone and arguments silently gain or lose meaning: a surviving null reads as a real value to the client, and an un-rewritten schema loses the omission guarantee.
+- Strict compatibility is decided by an allowlist of JSON Schema keywords, never a denylist. The costs are asymmetric — judging a tool incompatible costs that one tool its guarantee, while wrongly admitting one returns a 400 that fails the entire request, every other tool included. Widen the allowlist only against an observed acceptance.
+- The OpenAI adapter drops `response.function_call_arguments.delta` deliberately. Nulls cannot be stripped from a partial JSON fragment, so forwarding fragments would let the client reassemble un-stripped arguments. Restoring argument streaming reintroduces the defect.
+- Strict mode makes omission expressible; it does not stop a model from filling an argument. Models still send the default quoted in a property's own description, and stating the omission rule in that description was measured to change nothing. Do not re-attempt schema-side persuasion — treat leftover default-valued arguments as accepted, since suppressing them cannot be distinguished from a caller who meant the default.
+- The Cursor path has no equivalent guarantee. Its optional-argument pollution is known and unaddressed; do not assume parity between adapters.
+- `FLEET_GATEWAY_WIRE_LOG` names a file to receive the inbound tool catalog, the canonical and provider wire bodies, and every response event as JSONL. It is inert when unset, and it is the only way to see the argument JSON a model actually produced — provider behaviour differences are not otherwise observable from either side of this package.

--- a/packages/core-ai-gateway/CLAUDE.md
+++ b/packages/core-ai-gateway/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/core-ai-gateway/src/cursor-adapter.ts
+++ b/packages/core-ai-gateway/src/cursor-adapter.ts
@@ -28,6 +28,7 @@ import {
   canonicalMessageText,
 } from "./canonical.js";
 import { cursorNativeExecPolicyReplies } from "./cursor-native-exec-policy.js";
+import { wireLog } from "./wire-log.js";
 import {
   cursorUnknownExecCaseName,
   cursorUnknownExecReply,
@@ -1237,6 +1238,9 @@ export class CursorAdapter implements AiGatewayAdapter {
       }
       throw error;
     }
+    // Cursor rewrites and caps the declared catalog before it reaches the wire; this is the
+    // post-rewrite tool set plus the resolved model coordinate.
+    wireLog("cursor.wire.plan", plan);
     const descriptor: CursorLiveRunDescriptor = {
       conversationId: identity.conversationId,
       sessionId: identity.sessionId,

--- a/packages/core-ai-gateway/src/gateway.ts
+++ b/packages/core-ai-gateway/src/gateway.ts
@@ -11,6 +11,7 @@ import type {
 } from "./canonical.js";
 import { OpenAIResponsesAdapter } from "./openai-responses-adapter.js";
 import { estimateTokens } from "./token-estimate.js";
+import { logCanonicalEvents, wireLog, wireLogEnabled } from "./wire-log.js";
 
 /** Claude Code recognizes this prefix and routes the failed turn through reactive compaction. */
 export class ContextWindowExceededError extends Error {
@@ -55,6 +56,16 @@ export class AnthropicMessagesGateway {
     request: AnthropicMessagesRequest,
     options: AnthropicGatewayCallOptions
   ): Promise<AnthropicGatewayResponse> {
+    // Inbound Anthropic tool catalog, verbatim. This is the only place the client's own
+    // `input_schema` (its `required` array and any `strict` flag) is visible before any
+    // translation touches it.
+    wireLog("anthropic.request", {
+      model: request.model,
+      resolvedModel: options.model,
+      stream: request.stream,
+      tool_choice: request.tool_choice,
+      tools: request.tools,
+    });
     const canonical = translateAnthropicRequest(request, {
       ...(options.model ? { model: options.model } : {}),
       ...(options.catalog ? { catalog: options.catalog } : {}),
@@ -63,6 +74,13 @@ export class AnthropicMessagesGateway {
       ...(this.adapter.capabilities?.nativeTools
         ? { nativeTools: this.adapter.capabilities.nativeTools }
         : {}),
+    });
+    wireLog("canonical.request", {
+      model: canonical.model,
+      tool_choice: canonical.tool_choice,
+      parallel_tool_calls: canonical.parallel_tool_calls,
+      reasoning: canonical.reasoning,
+      tools: canonical.tools,
     });
     guardModelContextWindow(canonical, options.modelContextWindow, this.adapter);
     const upstream = await this.adapter.stream(canonical, {
@@ -74,6 +92,10 @@ export class AnthropicMessagesGateway {
     });
 
     if (!upstream.ok) {
+      wireLog("upstream.error", {
+        status: upstream.status,
+        body: new TextDecoder().decode(upstream.body),
+      });
       const translated = translateUpstreamError(upstream.body);
       const headers = new Headers(upstream.headers);
       if (translated.changed) {
@@ -87,6 +109,12 @@ export class AnthropicMessagesGateway {
       };
     }
 
+    // One wrapper at the canonical boundary covers every adapter, and carries the argument
+    // JSON the model actually produced for each tool call.
+    const events = wireLogEnabled()
+      ? logCanonicalEvents(upstream.events, "canonical.event")
+      : upstream.events;
+
     if (request.stream === true) {
       return {
         status: upstream.status,
@@ -94,7 +122,7 @@ export class AnthropicMessagesGateway {
           "cache-control": "no-cache",
           "content-type": "text/event-stream; charset=utf-8"
         }),
-        body: encodeAnthropicSse(upstream.events, {
+        body: encodeAnthropicSse(events, {
           contextWindow: options.contextWindow,
           model: request.model,
         })
@@ -102,7 +130,7 @@ export class AnthropicMessagesGateway {
     }
 
     // Claude Code는 일부 요청을 비스트리밍으로 보낸다. 그때는 이벤트를 모아 단일 Messages 응답을 준다.
-    const message = await collectAnthropicMessage(upstream.events, request.model, {
+    const message = await collectAnthropicMessage(events, request.model, {
       contextWindow: options.contextWindow,
       model: request.model,
     });

--- a/packages/core-ai-gateway/src/openai-responses-adapter.ts
+++ b/packages/core-ai-gateway/src/openai-responses-adapter.ts
@@ -13,6 +13,7 @@ import type {
   CanonicalWebSearchCallOutputItem,
   CanonicalWebSearchSource
 } from "./canonical.js";
+import { wireLog } from "./wire-log.js";
 
 export const OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses";
 /** ChatGPT 구독으로 Codex가 호출하는 백엔드. Platform API와 다른 표면이다. */
@@ -144,6 +145,8 @@ export class OpenAIResponsesAdapter implements AiGatewayAdapter {
     const controller = new AbortController();
     const unlinkAbort = linkAbortSignal(options.signal, controller);
     const payload = forOpenAIResponsesBackend(request, this.dropSamplingParams);
+    // Exact JSON body sent upstream, including each tool's `parameters` and any `strict` flag.
+    wireLog("openai.wire.request", { url: this.url, payload });
     let response: Response;
 
     try {
@@ -224,7 +227,15 @@ function forOpenAIResponsesBackend(
 
   const wireTools: OpenAIResponsesWireTool[] = (canonicalTools ?? []).map((tool) => {
     const { defer_loading: _deferLoading, ...wireTool } = tool;
-    return wireTool;
+    // A schema outside strict mode's subset is rejected with a 400 that fails the whole
+    // request, not just that tool, so an incompatible tool keeps its original schema and
+    // forfeits the guarantee rather than taking every other tool down with it.
+    if (!strictCompatible(wireTool.parameters)) return wireTool;
+    return {
+      ...wireTool,
+      parameters: strictParameters(wireTool.parameters),
+      strict: true,
+    };
   });
 
   // native_tools is canonical-only: it must never reach the OpenAI wire body as-is.
@@ -515,19 +526,18 @@ function canonicalEvent(value: unknown): CanonicalResponseEvent | undefined {
         item
       };
     }
+    // Argument deltas are dropped: a partial JSON fragment cannot have its nulls stripped, and
+    // forwarding raw fragments would let the client reassemble the un-stripped text. The `.done`
+    // event below carries the whole argument object, which downstream treats as the remainder
+    // when nothing was streamed ahead of it.
     case "response.function_call_arguments.delta":
-      return {
-        type: value.type,
-        item_id: string(value.item_id, "item_id"),
-        output_index: number(value.output_index, "output_index"),
-        delta: string(value.delta, "delta")
-      };
+      return undefined;
     case "response.function_call_arguments.done":
       return {
         type: value.type,
         item_id: string(value.item_id, "item_id"),
         output_index: number(value.output_index, "output_index"),
-        arguments: string(value.arguments, "arguments")
+        arguments: stripNullArguments(string(value.arguments, "arguments"))
       };
     case "response.completed":
       return { type: value.type, response: responseSnapshot(value.response) };
@@ -598,6 +608,180 @@ function usage(value: unknown): CanonicalUsage {
   };
 }
 
+/**
+ * OpenAI strict mode admits no optional property: every key must appear in `required`, and
+ * "not provided" is expressed as an explicit null rather than omission.
+ *
+ * Without it the model fabricates values for omitted optional fields — empty strings for
+ * free-form strings, an arbitrary member for enums — and those reach the client as real
+ * arguments. A fabricated `Agent.model` silently overrides the subagent's pinned model, and a
+ * fabricated `Read.pages` fails the call outright.
+ *
+ * `stripNullArguments` is the inverse: the nulls this transform makes representable are
+ * removed again before the call reaches the client, restoring omission semantics.
+ */
+/**
+ * Keywords known to survive strict mode. An allowlist rather than a denylist: an unknown
+ * keyword is far more likely to be one strict rejects than one it accepts, and the cost is
+ * asymmetric — an over-strict verdict costs a single tool its guarantee, while a wrong
+ * permissive verdict costs the whole request a 400 that fails every tool with it.
+ */
+const STRICT_ALLOWED_KEYWORDS = new Set([
+  "type",
+  "properties",
+  "required",
+  "additionalProperties",
+  "items",
+  "enum",
+  "anyOf",
+  "$defs",
+  "$ref",
+  "description",
+  "title",
+  "format",
+  "pattern",
+  "minimum",
+  "maximum",
+  "exclusiveMinimum",
+  "exclusiveMaximum",
+  "multipleOf",
+  "minLength",
+  "maxLength",
+  "minItems",
+  "maxItems",
+  // Dropped by `strictSchema` before the schema reaches the wire.
+  "$schema",
+  "default",
+]);
+
+/** Whether every subschema stays inside the subset strict mode accepts. */
+function strictCompatible(schema: unknown): boolean {
+  if (!isRecord(schema)) return true;
+
+  for (const key of Object.keys(schema)) {
+    if (!STRICT_ALLOWED_KEYWORDS.has(key)) return false;
+  }
+  // Strict mode requires every subschema to declare what it accepts.
+  if (!("type" in schema) && !Array.isArray(schema.anyOf) && typeof schema.$ref !== "string") {
+    return false;
+  }
+  // A free-form object cannot satisfy strict mode, which requires every key to be declared
+  // with `additionalProperties: false`; an array must say what it holds.
+  if (schema.type === "object" && !isRecord(schema.properties)) return false;
+  if (schema.type === "array" && !isRecord(schema.items)) return false;
+
+  if (isRecord(schema.properties)) {
+    for (const value of Object.values(schema.properties)) {
+      if (!strictCompatible(value)) return false;
+    }
+  }
+  if (isRecord(schema.$defs)) {
+    for (const value of Object.values(schema.$defs)) {
+      if (!strictCompatible(value)) return false;
+    }
+  }
+  if (isRecord(schema.items) && !strictCompatible(schema.items)) return false;
+  if (Array.isArray(schema.anyOf)) {
+    for (const branch of schema.anyOf) {
+      if (!strictCompatible(branch)) return false;
+    }
+  }
+  return true;
+}
+
+function strictParameters(schema: Record<string, unknown>): Record<string, unknown> {
+  const converted = strictSchema(schema);
+  return isRecord(converted) ? converted : schema;
+}
+
+function strictSchema(schema: unknown): unknown {
+  if (!isRecord(schema)) return schema;
+  const next: Record<string, unknown> = { ...schema };
+
+  // Metadata strict mode has no use for: `$schema` is a dialect marker it does not accept, and
+  // `default` is meaningless once every property is required.
+  delete next.$schema;
+  delete next.default;
+
+  for (const key of ["anyOf", "oneOf", "allOf"] as const) {
+    const branches = next[key];
+    if (Array.isArray(branches)) next[key] = branches.map(strictSchema);
+  }
+  if (isRecord(next.items)) next.items = strictSchema(next.items);
+
+  const properties = next.properties;
+  if (isRecord(properties)) {
+    const required = new Set(
+      Array.isArray(next.required)
+        ? next.required.filter((name): name is string => typeof name === "string")
+        : [],
+    );
+    const rewritten: Record<string, unknown> = {};
+    for (const [name, value] of Object.entries(properties)) {
+      const child = strictSchema(value);
+      rewritten[name] = required.has(name) ? child : nullableSchema(child);
+    }
+    next.properties = rewritten;
+    next.required = Object.keys(rewritten);
+    next.additionalProperties = false;
+  }
+  return next;
+}
+
+/**
+ * Widens a schema so an explicit null is valid, which is how strict mode spells "absent".
+ *
+ * Naming that null in each property's description was measured and dropped: it changed
+ * nothing. Under strict mode a model still supplies the default quoted in the description
+ * rather than declining, and the instruction only grew the tool catalog. What strict does buy
+ * is that a value the model was told not to send is now omittable at all — which is what
+ * stopped `Agent.model` from overriding a pinned subagent model.
+ */
+function nullableSchema(schema: unknown): unknown {
+  if (!isRecord(schema)) return schema;
+  const next: Record<string, unknown> = { ...schema };
+
+  if (Array.isArray(next.enum) && !next.enum.includes(null)) {
+    next.enum = [...next.enum, null];
+  }
+  if (Array.isArray(next.anyOf)) {
+    next.anyOf = [...next.anyOf, { type: "null" }];
+    return next;
+  }
+  const type = next.type;
+  if (typeof type === "string") {
+    if (type !== "null") next.type = [type, "null"];
+  } else if (Array.isArray(type)) {
+    if (!type.includes("null")) next.type = [...type, "null"];
+  }
+  return next;
+}
+
+/**
+ * Removes the nulls strict mode requires, so the client sees an omitted argument rather than
+ * an explicit null. Anthropic tool schemas treat absence — not null — as "not provided".
+ */
+function stripNullArguments(raw: string): string {
+  if (raw.length === 0 || !raw.includes("null")) return raw;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+  if (!isRecord(parsed)) return raw;
+  return JSON.stringify(withoutNulls(parsed));
+}
+
+function withoutNulls(value: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry === null) continue;
+    out[key] = isRecord(entry) ? withoutNulls(entry) : entry;
+  }
+  return out;
+}
+
 function outputItem(value: unknown): CanonicalOutputItem | undefined {
   const item = record(value, "item");
   if (item.type === "message") {
@@ -614,7 +798,7 @@ function outputItem(value: unknown): CanonicalOutputItem | undefined {
       type: "function_call",
       call_id: typeof item.call_id === "string" ? item.call_id : id,
       name: string(item.name, "item.name"),
-      arguments: typeof item.arguments === "string" ? item.arguments : ""
+      arguments: typeof item.arguments === "string" ? stripNullArguments(item.arguments) : ""
     };
   }
   if (item.type === "web_search_call") {

--- a/packages/core-ai-gateway/src/wire-log.ts
+++ b/packages/core-ai-gateway/src/wire-log.ts
@@ -1,0 +1,63 @@
+/**
+ * Diagnostic wire logging.
+ *
+ * Entirely inert unless `FLEET_GATEWAY_WIRE_LOG` names a writable file path. It exists to
+ * answer one question the normal request path cannot: what tool schema actually reached the
+ * provider, and what argument JSON the model actually produced in reply.
+ *
+ * Every entry is one JSON line. Serialization never throws and never propagates: a
+ * diagnostics failure must not break a live request.
+ */
+import { appendFileSync } from "node:fs";
+
+function target(): string | undefined {
+  const value = process.env.FLEET_GATEWAY_WIRE_LOG;
+  return value !== undefined && value.length > 0 ? value : undefined;
+}
+
+export function wireLogEnabled(): boolean {
+  return target() !== undefined;
+}
+
+function safeJson(value: unknown): string {
+  const seen = new WeakSet<object>();
+  try {
+    return (
+      JSON.stringify(value, (_key, entry: unknown) => {
+        if (typeof entry === "bigint") return entry.toString();
+        if (typeof entry === "object" && entry !== null) {
+          if (seen.has(entry)) return "[circular]";
+          seen.add(entry);
+        }
+        return entry;
+      }) ?? "null"
+    );
+  } catch (error) {
+    return JSON.stringify({ serializationError: String(error) });
+  }
+}
+
+export function wireLog(event: string, payload: unknown): void {
+  const path = target();
+  if (path === undefined) return;
+  try {
+    appendFileSync(path, `{"ts":"${new Date().toISOString()}","event":"${event}","payload":${safeJson(payload)}}\n`);
+  } catch {
+    // Diagnostics must never break the request path.
+  }
+}
+
+/**
+ * Pass-through wrapper that records every canonical event as it streams. Placed at the
+ * canonical boundary so one wrapper covers every adapter, including the argument JSON the
+ * model emitted (`response.function_call_arguments.done`).
+ */
+export async function* logCanonicalEvents<T>(
+  events: AsyncIterable<T>,
+  event: string,
+): AsyncGenerator<T> {
+  for await (const item of events) {
+    wireLog(event, item);
+    yield item;
+  }
+}

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -1532,7 +1532,8 @@ describe("OpenAI Responses adapter", () => {
     expect(body.tools).toEqual([{
       type: "function",
       name: "mcp__fleet__carrier_dispatch",
-      parameters: { type: "object", properties: {} },
+      parameters: { type: "object", properties: {}, required: [], additionalProperties: false },
+      strict: true,
     }]);
   });
 
@@ -1725,7 +1726,13 @@ describe("OpenAI Responses adapter", () => {
       {
         type: "function",
         name: "read_file",
-        parameters: { type: "object", properties: { path: { type: "string" } } },
+        parameters: {
+          type: "object",
+          properties: { path: { type: ["string", "null"] } },
+          required: ["path"],
+          additionalProperties: false,
+        },
+        strict: true,
       },
       { type: "web_search" },
     ]);
@@ -1764,7 +1771,13 @@ describe("OpenAI Responses adapter", () => {
       {
         type: "function",
         name: "read_file",
-        parameters: { type: "object", properties: { path: { type: "string" } } },
+        parameters: {
+          type: "object",
+          properties: { path: { type: ["string", "null"] } },
+          required: ["path"],
+          additionalProperties: false,
+        },
+        strict: true,
       },
       { type: "web_search", filters: { allowed_domains: ["github.com"] } },
     ]);


### PR DESCRIPTION
## Summary

- OpenAI 경로에서 모델이 보내지도 않아야 할 optional 도구 인자를 임의로 채우던 문제를 수정합니다. 조작된 `Agent.model`이 프리셋에 고정된 서브에이전트 모델을 덮어써 게이트웨이 작업이 Claude 모델로 새어나갔고, 조작된 `Read.pages`는 호출 자체를 실패시켰습니다.
- strict 호환 도구 스키마를 strict 형태로 재작성하고 응답에서 그 null을 다시 제거해, "생략"의 의미가 왕복을 견디게 했습니다. 호환 판정은 키워드 allowlist로 하며, 비호환 도구는 원본 스키마를 유지합니다 — 잘못 허용하면 요청 전체가 400으로 실패하기 때문입니다.
- `FLEET_GATEWAY_WIRE_LOG`로 켜는 진단 로깅을 추가했습니다. 환경 변수가 없으면 완전히 비활성입니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` (204 passed)
- [x] `pnpm run build`
- [x] `pnpm run check:core-boundary`
- [x] 격리 콘솔에서 codex(gpt-5.6-sol) 세션 실측: `Agent`가 지시 없이도 `model`/`isolation`/`team_name` 없이 호출되고, `Read`에서 `pages`가 사라짐. upstream 400 없음
- [x] 팀메이트 왕복(`Agent` + `SendMessage`) 정상 동작 확인

## Notes

- Cursor 경로는 의도적으로 범위 밖입니다. 동일한 optional 인자 오염이 관측되었으나 strict에 해당하는 장치가 없어 별도 과제로 남깁니다.
- strict는 생략을 표현 가능하게 만들 뿐 모델이 값을 채우는 것 자체를 막지는 못합니다. 프로퍼티 description에 생략 규칙을 명시하는 방식은 실측 결과 효과가 없어 채택하지 않았습니다.

## Changelog

- [x] `.changelog.d/pr-481.md` 추가 (fleet-core / Fixed + Added, 영문·한글 요약 인접)
- [x] `node scripts/compile-changelog-fragments.mjs --check` 통과 (16 entries)