### PR TITLE
fix(console): procure Cursor gateway credentials on every platform

### DIFF
--- a/.changelog.d/pr-486.md
+++ b/.changelog.d/pr-486.md
@@ -1,0 +1,9 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] The AI Gateway now finds the Cursor subscription token on Linux and Windows, not only macOS. It reads the platform auth file (`%APPDATA%/Cursor/auth.json` on Windows, `$XDG_CONFIG_HOME` or `~/.config` under `cursor/auth.json` on Linux) when the macOS keychain is unavailable, so Cursor model calls no longer fail with a 401 that reported no subscription token.
+  ko: AI Gateway가 이제 macOS뿐 아니라 Linux와 Windows에서도 Cursor 구독 토큰을 찾습니다. macOS 키체인을 쓸 수 없을 때 플랫폼별 auth 파일(Windows는 `%APPDATA%/Cursor/auth.json`, Linux는 `$XDG_CONFIG_HOME` 또는 `~/.config` 아래 `cursor/auth.json`)을 읽으므로, 구독 토큰이 없다고 알리던 401로 Cursor 모델 호출이 실패하지 않습니다.
+
+### fleet-core
+#### Added
+- [core-ai-gateway] Add Cursor credential procurement as shared package API, so every caller resolves the subscription token through one platform-aware implementation instead of its own copy.
+  ko: Cursor 자격증명 조달을 공유 패키지 API로 추가했습니다. 모든 호출자가 각자의 복사본 대신 플랫폼을 인지하는 단일 구현으로 구독 토큰을 조달합니다.

--- a/packages/core-ai-gateway/src/cursor-credentials.ts
+++ b/packages/core-ai-gateway/src/cursor-credentials.ts
@@ -1,0 +1,149 @@
+/**
+ * Provider credential procurement for the Cursor subscription token.
+ *
+ * Where Cursor leaves its login is provider knowledge, not Fleet knowledge, so
+ * every consumer that needs the token — the Console AI gateway route and the
+ * quota plugin — resolves it through this one module. Keeping a second copy is
+ * what let the gateway stay macOS-only while quota already worked everywhere.
+ */
+
+import { execFile as nodeExecFile } from "node:child_process";
+import { constants as fsConstants } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+export type CredentialMethod = "keychain" | "file";
+
+export interface CredentialResolverDeps {
+  readonly platform: NodeJS.Platform;
+  readonly homedir: () => string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly readBounded: (filePath: string, maxBytes: number) => Promise<string | null>;
+  readonly execFile: (file: string, args: readonly string[], options: { readonly timeout: number }) => Promise<string>;
+}
+
+export interface CursorCredentials {
+  readonly accessToken: string;
+  readonly method: CredentialMethod;
+}
+
+const execFileAsync = promisify(nodeExecFile);
+
+export const MAX_CREDENTIAL_BYTES = 65_536;
+
+// FIFO를 "r"로 열면 writer가 붙을 때까지 open 자체가 블록되어 뒤의 isFile 거부에 도달하지 못한다.
+// POSIX에서는 O_NONBLOCK으로 열어 즉시 디스크립터를 받은 뒤 거부한다. Windows에는 이 플래그도
+// 경로 네임스페이스상의 FIFO도 없으므로 기본 읽기 플래그를 그대로 쓴다.
+const CREDENTIAL_OPEN_FLAGS = process.platform === "win32"
+  ? fsConstants.O_RDONLY
+  : fsConstants.O_RDONLY | fsConstants.O_NONBLOCK;
+
+export async function readBoundedFile(filePath: string, maxBytes: number): Promise<string | null> {
+  const handle = await fs.open(filePath, CREDENTIAL_OPEN_FLAGS);
+  try {
+    const stat = await handle.stat();
+    // Bound during I/O: a stalled network mount or non-regular path (for example, FIFO) must not wedge single-flight.
+    if (!stat.isFile() || stat.size > maxBytes) return null;
+    const buffer = Buffer.allocUnsafe(maxBytes + 1);
+    let totalBytes = 0;
+    while (totalBytes < buffer.byteLength) {
+      const { bytesRead } = await handle.read(
+        buffer,
+        totalBytes,
+        buffer.byteLength - totalBytes,
+        totalBytes,
+      );
+      if (bytesRead === 0) break;
+      totalBytes += bytesRead;
+    }
+    return totalBytes > maxBytes ? null : buffer.subarray(0, totalBytes).toString("utf8");
+  } finally {
+    await handle.close();
+  }
+}
+
+export const defaultCredentialDeps: CredentialResolverDeps = {
+  platform: process.platform,
+  homedir: os.homedir,
+  env: process.env,
+  readBounded: readBoundedFile,
+  execFile: async (file, args, options) => {
+    const result = await execFileAsync(file, [...args], options);
+    return result.stdout;
+  },
+};
+
+export function credentialRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+export function optionalTrimmedString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseCursorCredentialJson(raw: string, method: CredentialMethod): CursorCredentials | null {
+  if (raw.length > MAX_CREDENTIAL_BYTES) return null;
+  try {
+    const parsed = credentialRecord(JSON.parse(raw));
+    if (!parsed) return null;
+    const tokens = credentialRecord(parsed.tokens);
+    const cursorAuth = credentialRecord(parsed.cursorAuth);
+    const accessToken = [
+      parsed.accessToken,
+      parsed.access_token,
+      tokens?.accessToken,
+      tokens?.access_token,
+      cursorAuth?.accessToken,
+      cursorAuth?.access_token,
+    ].map(optionalTrimmedString).find((value) => value !== undefined);
+    return accessToken ? { accessToken, method } : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The auth file Cursor's CLI/IDE login writes, per platform. macOS keeps the
+ * token in the keychain and uses this only as a fallback; on Linux and Windows
+ * it is the sole source, so skipping it is what produced a 401 there.
+ */
+export function cursorAuthFilePath(deps: CredentialResolverDeps): string {
+  const home = deps.homedir();
+  if (deps.platform === "win32") {
+    return path.join(deps.env.APPDATA || path.join(home, "AppData", "Roaming"), "Cursor", "auth.json");
+  }
+  if (deps.platform === "darwin") {
+    return path.join(home, ".cursor", "auth.json");
+  }
+  return path.join(deps.env.XDG_CONFIG_HOME || path.join(home, ".config"), "cursor", "auth.json");
+}
+
+export async function resolveCursorCredentials(deps: CredentialResolverDeps): Promise<CursorCredentials | null> {
+  if (deps.platform === "darwin") {
+    try {
+      const raw = await deps.execFile(
+        "security",
+        ["find-generic-password", "-s", "cursor-access-token", "-a", "cursor-user", "-w"],
+        { timeout: 5_000 },
+      );
+      const accessToken = raw.length <= MAX_CREDENTIAL_BYTES ? optionalTrimmedString(raw) : undefined;
+      if (accessToken) return { accessToken, method: "keychain" };
+    } catch {
+      // The auth file is the required macOS fallback.
+    }
+  }
+  try {
+    const raw = await deps.readBounded(cursorAuthFilePath(deps), MAX_CREDENTIAL_BYTES);
+    return raw === null || raw.length > MAX_CREDENTIAL_BYTES
+      ? null
+      : parseCursorCredentialJson(raw, "file");
+  } catch {
+    return null;
+  }
+}

--- a/packages/core-ai-gateway/src/index.ts
+++ b/packages/core-ai-gateway/src/index.ts
@@ -2,6 +2,7 @@ export * from "./anthropic.js";
 export * from "./canonical.js";
 export * from "./claude-context.js";
 export * from "./cursor-adapter.js";
+export * from "./cursor-credentials.js";
 // estimateTokens 는 어댑터 내부 헬퍼다 — 배럴로 올리면 패키지 공개 계약이 넓어진다.
 export { AnthropicMessagesGateway, ContextWindowExceededError } from "./gateway.js";
 export type { AnthropicGatewayCallOptions, AnthropicGatewayResponse } from "./gateway.js";

--- a/packages/core-ai-gateway/tests/cursor-credentials.test.ts
+++ b/packages/core-ai-gateway/tests/cursor-credentials.test.ts
@@ -1,0 +1,132 @@
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  cursorAuthFilePath,
+  resolveCursorCredentials,
+  type CredentialResolverDeps,
+} from "../src/cursor-credentials.js";
+
+function deps(overrides: Partial<CredentialResolverDeps> = {}): CredentialResolverDeps {
+  return {
+    platform: "linux",
+    homedir: () => "/users/operator",
+    env: {},
+    readBounded: vi.fn(async () => null),
+    execFile: vi.fn(async () => ""),
+    ...overrides,
+  };
+}
+
+describe("cursor credential procurement", () => {
+  it("reads the bare token from the macOS keychain before the auth file", async () => {
+    const execFile = vi.fn(async () => "cursor-token\n");
+    const readBounded = vi.fn(async () => null);
+    const result = await resolveCursorCredentials(deps({ platform: "darwin", execFile, readBounded }));
+    expect(execFile).toHaveBeenCalledWith(
+      "security",
+      ["find-generic-password", "-s", "cursor-access-token", "-a", "cursor-user", "-w"],
+      { timeout: 5_000 },
+    );
+    expect(readBounded).not.toHaveBeenCalled();
+    expect(result).toEqual({ accessToken: "cursor-token", method: "keychain" });
+  });
+
+  it("falls back to the macOS auth file when the keychain lookup fails", async () => {
+    const execFile = vi.fn(async () => {
+      throw new Error("no keychain entry");
+    });
+    const readBounded = vi.fn(async () => JSON.stringify({ accessToken: "file-token" }));
+    const result = await resolveCursorCredentials(deps({ platform: "darwin", execFile, readBounded }));
+    expect(readBounded).toHaveBeenCalledWith(
+      path.join("/users/operator", ".cursor", "auth.json"),
+      65_536,
+    );
+    expect(result).toEqual({ accessToken: "file-token", method: "file" });
+  });
+
+  // The WSL/Linux regression: `security` does not exist there, so a keychain-only
+  // procurement path resolved to no token and the gateway answered 401.
+  it("never shells out to the macOS keychain on Linux and reads the XDG auth file", async () => {
+    const execFile = vi.fn(async () => "");
+    const readBounded = vi.fn(async () => JSON.stringify({ accessToken: "linux-token" }));
+    const result = await resolveCursorCredentials(deps({
+      platform: "linux",
+      env: { XDG_CONFIG_HOME: "/users/operator/.xdg" },
+      execFile,
+      readBounded,
+    }));
+    expect(execFile).not.toHaveBeenCalled();
+    expect(readBounded).toHaveBeenCalledWith(
+      path.join("/users/operator/.xdg", "cursor", "auth.json"),
+      65_536,
+    );
+    expect(result).toEqual({ accessToken: "linux-token", method: "file" });
+  });
+
+  it("defaults to ~/.config on Linux when XDG_CONFIG_HOME is unset", async () => {
+    const readBounded = vi.fn(async () => JSON.stringify({ accessToken: "linux-token" }));
+    await resolveCursorCredentials(deps({ platform: "linux", readBounded }));
+    expect(readBounded).toHaveBeenCalledWith(
+      path.join("/users/operator", ".config", "cursor", "auth.json"),
+      65_536,
+    );
+  });
+
+  it("reads the roaming auth file on Windows without touching the keychain", async () => {
+    const execFile = vi.fn(async () => "");
+    const readBounded = vi.fn(async () => JSON.stringify({ accessToken: "win-token" }));
+    const result = await resolveCursorCredentials(deps({
+      platform: "win32",
+      homedir: () => "C:\\Users\\operator",
+      env: { APPDATA: "C:\\Users\\operator\\AppData\\Roaming" },
+      execFile,
+      readBounded,
+    }));
+    expect(execFile).not.toHaveBeenCalled();
+    expect(readBounded).toHaveBeenCalledWith(
+      path.join("C:\\Users\\operator\\AppData\\Roaming", "Cursor", "auth.json"),
+      65_536,
+    );
+    expect(result).toEqual({ accessToken: "win-token", method: "file" });
+  });
+
+  it("accepts every auth-file token shape Cursor has written", async () => {
+    const shapes = [
+      { accessToken: "a" },
+      { access_token: "a" },
+      { tokens: { accessToken: "a" } },
+      { tokens: { access_token: "a" } },
+      { cursorAuth: { accessToken: "a" } },
+      { cursorAuth: { access_token: "a" } },
+    ];
+    for (const shape of shapes) {
+      const result = await resolveCursorCredentials(deps({
+        readBounded: async () => JSON.stringify(shape),
+      }));
+      expect(result).toEqual({ accessToken: "a", method: "file" });
+    }
+  });
+
+  it("returns null instead of throwing when the auth file is absent or unreadable", async () => {
+    await expect(resolveCursorCredentials(deps({ readBounded: async () => null })))
+      .resolves.toBeNull();
+    await expect(resolveCursorCredentials(deps({
+      readBounded: async () => {
+        throw new Error("EACCES");
+      },
+    }))).resolves.toBeNull();
+    await expect(resolveCursorCredentials(deps({ readBounded: async () => "not json" })))
+      .resolves.toBeNull();
+    await expect(resolveCursorCredentials(deps({ readBounded: async () => JSON.stringify({ accessToken: "   " }) })))
+      .resolves.toBeNull();
+  });
+
+  it("resolves the same auth-file path the resolver reads", () => {
+    expect(cursorAuthFilePath(deps({ platform: "darwin" })))
+      .toBe(path.join("/users/operator", ".cursor", "auth.json"));
+    expect(cursorAuthFilePath(deps({ platform: "linux" })))
+      .toBe(path.join("/users/operator", ".config", "cursor", "auth.json"));
+  });
+});

--- a/runtime/fleet-plugins/quota/server/credentials.ts
+++ b/runtime/fleet-plugins/quota/server/credentials.ts
@@ -1,19 +1,28 @@
-import { execFile as nodeExecFile } from "node:child_process";
-import { constants as fsConstants } from "node:fs";
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { promisify } from "node:util";
+
+import {
+  MAX_CREDENTIAL_BYTES,
+  credentialRecord,
+  defaultCredentialDeps,
+  readBoundedFile,
+  resolveCursorCredentials,
+} from "@dotobokuri/core-ai-gateway";
+import type {
+  CredentialResolverDeps,
+  CursorCredentials,
+} from "@dotobokuri/core-ai-gateway";
 
 import type { CredentialMethod } from "./types.js";
 
-export interface CredentialResolverDeps {
-  readonly platform: NodeJS.Platform;
-  readonly homedir: () => string;
-  readonly env: NodeJS.ProcessEnv;
-  readonly readBounded: (filePath: string, maxBytes: number) => Promise<string | null>;
-  readonly execFile: (file: string, args: readonly string[], options: { readonly timeout: number }) => Promise<string>;
-}
+// Cursor 자격증명 조달은 core-ai-gateway가 단일 출처다. Console AI gateway 라우트도 같은
+// 구현을 쓰므로, 여기서 다시 구현하면 플랫폼 분기가 한쪽에만 반영되는 과거 불일치가 되살아난다.
+export {
+  MAX_CREDENTIAL_BYTES,
+  defaultCredentialDeps,
+  readBoundedFile,
+  resolveCursorCredentials,
+};
+export type { CredentialResolverDeps, CursorCredentials };
 
 export interface ClaudeCredentials {
   readonly accessToken: string;
@@ -27,70 +36,8 @@ export interface CodexCredentials {
   readonly accountId?: string;
 }
 
-export interface CursorCredentials {
-  readonly accessToken: string;
-  readonly method: CredentialMethod;
-}
-
-const execFileAsync = promisify(nodeExecFile);
-const MAX_CREDENTIAL_BYTES = 65_536;
-
-// FIFO를 "r"로 열면 writer가 붙을 때까지 open 자체가 블록되어 뒤의 isFile 거부에 도달하지 못한다.
-// POSIX에서는 O_NONBLOCK으로 열어 즉시 디스크립터를 받은 뒤 거부한다. Windows에는 이 플래그도
-// 경로 네임스페이스상의 FIFO도 없으므로 기본 읽기 플래그를 그대로 쓴다.
-const CREDENTIAL_OPEN_FLAGS = process.platform === "win32"
-  ? fsConstants.O_RDONLY
-  : fsConstants.O_RDONLY | fsConstants.O_NONBLOCK;
-
-export async function readBoundedFile(filePath: string, maxBytes: number): Promise<string | null> {
-  const handle = await fs.open(filePath, CREDENTIAL_OPEN_FLAGS);
-  try {
-    const stat = await handle.stat();
-    // Bound during I/O: a stalled network mount or non-regular path (for example, FIFO) must not wedge single-flight.
-    if (!stat.isFile() || stat.size > maxBytes) return null;
-    const buffer = Buffer.allocUnsafe(maxBytes + 1);
-    let totalBytes = 0;
-    while (totalBytes < buffer.byteLength) {
-      const { bytesRead } = await handle.read(
-        buffer,
-        totalBytes,
-        buffer.byteLength - totalBytes,
-        totalBytes,
-      );
-      if (bytesRead === 0) break;
-      totalBytes += bytesRead;
-    }
-    return totalBytes > maxBytes ? null : buffer.subarray(0, totalBytes).toString("utf8");
-  } finally {
-    await handle.close();
-  }
-}
-
-export const defaultCredentialDeps: CredentialResolverDeps = {
-  platform: process.platform,
-  homedir: os.homedir,
-  env: process.env,
-  readBounded: readBoundedFile,
-  execFile: async (file, args, options) => {
-    const result = await execFileAsync(file, [...args], options);
-    return result.stdout;
-  },
-};
-
-function record(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? value as Record<string, unknown>
-    : null;
-}
-
 function optionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-function optionalTrimmedString(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function optionalEpoch(value: unknown): number | undefined {
@@ -100,9 +47,9 @@ function optionalEpoch(value: unknown): number | undefined {
 function parseClaudeCredentialJson(raw: string, method: CredentialMethod): ClaudeCredentials | null {
   if (raw.length > MAX_CREDENTIAL_BYTES) return null;
   try {
-    const parsed = record(JSON.parse(raw));
+    const parsed = credentialRecord(JSON.parse(raw));
     if (!parsed) return null;
-    const oauth = record(parsed.claudeAiOauth);
+    const oauth = credentialRecord(parsed.claudeAiOauth);
     const accessToken = optionalString(oauth?.accessToken ?? parsed.accessToken);
     if (!accessToken) return null;
     return {
@@ -146,62 +93,11 @@ export async function resolveCodexCredentials(deps: CredentialResolverDeps): Pro
   try {
     const raw = await deps.readBounded(path.join(home, "auth.json"), MAX_CREDENTIAL_BYTES);
     if (raw === null || raw.length > MAX_CREDENTIAL_BYTES) return null;
-    const parsed = record(JSON.parse(raw));
-    const tokens = record(parsed?.tokens);
+    const parsed = credentialRecord(JSON.parse(raw));
+    const tokens = credentialRecord(parsed?.tokens);
     const accessToken = optionalString(tokens?.access_token);
     if (!accessToken) return null;
     return { accessToken, accountId: optionalString(tokens?.account_id) };
-  } catch {
-    return null;
-  }
-}
-
-function parseCursorCredentialJson(raw: string, method: CredentialMethod): CursorCredentials | null {
-  if (raw.length > MAX_CREDENTIAL_BYTES) return null;
-  try {
-    const parsed = record(JSON.parse(raw));
-    if (!parsed) return null;
-    const tokens = record(parsed.tokens);
-    const cursorAuth = record(parsed.cursorAuth);
-    const accessToken = [
-      parsed.accessToken,
-      parsed.access_token,
-      tokens?.accessToken,
-      tokens?.access_token,
-      cursorAuth?.accessToken,
-      cursorAuth?.access_token,
-    ].map(optionalTrimmedString).find((value) => value !== undefined);
-    return accessToken ? { accessToken, method } : null;
-  } catch {
-    return null;
-  }
-}
-
-export async function resolveCursorCredentials(deps: CredentialResolverDeps): Promise<CursorCredentials | null> {
-  if (deps.platform === "darwin") {
-    try {
-      const raw = await deps.execFile(
-        "security",
-        ["find-generic-password", "-s", "cursor-access-token", "-a", "cursor-user", "-w"],
-        { timeout: 5_000 },
-      );
-      const accessToken = raw.length <= MAX_CREDENTIAL_BYTES ? optionalTrimmedString(raw) : undefined;
-      if (accessToken) return { accessToken, method: "keychain" };
-    } catch {
-      // The auth file is the required macOS fallback.
-    }
-  }
-  const home = deps.homedir();
-  const authFile = deps.platform === "win32"
-    ? path.join(deps.env.APPDATA || path.join(home, "AppData", "Roaming"), "Cursor", "auth.json")
-    : deps.platform === "darwin"
-      ? path.join(home, ".cursor", "auth.json")
-      : path.join(deps.env.XDG_CONFIG_HOME || path.join(home, ".config"), "cursor", "auth.json");
-  try {
-    const raw = await deps.readBounded(authFile, MAX_CREDENTIAL_BYTES);
-    return raw === null || raw.length > MAX_CREDENTIAL_BYTES
-      ? null
-      : parseCursorCredentialJson(raw, "file");
   } catch {
     return null;
   }

--- a/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -16,10 +15,12 @@ import {
   UnsupportedReasoningEffortError,
   buildAnthropicModelList,
   clampReasoningEffort,
+  defaultCredentialDeps,
   findGatewayModel,
   hasClaudeOneMillionMarker,
   projectAnthropicResponseUsage,
   reasoningEffortFromOutputConfig,
+  resolveCursorCredentials,
   toClaudeGatewayModelId,
   upstreamModelId,
 } from "@dotobokuri/core-ai-gateway";
@@ -52,18 +53,16 @@ export const KIMI_MESSAGES_URL = "https://api.kimi.com/coding/v1/messages";
 /** Claude Code가 claude.ai 구독으로 붙일 때 보내는 자격증명 접두. OAuth 토큰도 이 접두를 쓴다. */
 const ANTHROPIC_CREDENTIAL_PREFIX = "sk-ant-";
 
-/** Cursor CLI/IDE 로그인이 keychain에 남긴 구독 토큰. */
-export function readCursorSubscriptionToken(): string | null {
-  try {
-    const token = execFileSync(
-      "security",
-      ["find-generic-password", "-s", "cursor-access-token", "-a", "cursor-user", "-w"],
-      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
-    ).trim();
-    return token.length > 0 ? token : null;
-  } catch {
-    return null;
-  }
+/**
+ * Cursor CLI/IDE 로그인이 남긴 구독 토큰.
+ *
+ * 조달 경로는 core-ai-gateway가 단일 출처다. macOS는 keychain을 먼저 보고, Linux/Windows는
+ * 각 플랫폼의 auth.json을 읽는다. 여기서 keychain만 보면 `security`가 없는 Linux/WSL에서
+ * 항상 토큰 없음으로 떨어져 Cursor 모델 호출이 401이 된다.
+ */
+export async function readCursorSubscriptionToken(): Promise<string | null> {
+  const credentials = await resolveCursorCredentials(defaultCredentialDeps);
+  return credentials?.accessToken ?? null;
 }
 
 export function readCodexSubscriptionAuth(
@@ -90,7 +89,7 @@ export interface AiGatewayRouteDeps {
   readonly gateway?: AnthropicMessagesGateway;
   /** 테스트가 구독 토큰 조회를 대체한다. */
   readonly readAuth?: () => CodexSubscriptionAuth | null;
-  readonly readCursorToken?: () => string | null;
+  readonly readCursorToken?: () => string | null | Promise<string | null>;
   readonly readKimiApiKey?: () => Promise<string | undefined>;
   readonly cursorDiagnostics?: CursorDiagnosticSink;
   readonly fetch?: typeof fetch;
@@ -184,7 +183,7 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps = {}): AiGatewayR
     let credential = "";
     let chatgptAccountId = "";
     if (target?.provider === "cursor") {
-      const cursorToken = (deps.readCursorToken ?? readCursorSubscriptionToken)();
+      const cursorToken = await (deps.readCursorToken ?? readCursorSubscriptionToken)();
       if (!cursorToken) {
         writeAnthropicError(res, 401, "authentication_error", "No Cursor subscription token was found. Sign in to Cursor first.");
         return true;


### PR DESCRIPTION
## Summary

- AI Gateway의 Cursor 구독 토큰 조달이 macOS `security` 키체인 전용이었습니다. Linux/Windows에서는 이 조회가 항상 실패해 토큰 없음으로 떨어지고, Cursor 모델 호출이 전부 401 `No Cursor subscription token was found`로 끝났습니다 (WSL 재현, macOS 정상).
- 같은 자격증명을 quota 플러그인은 이미 플랫폼별로 조달하고 있었습니다. 즉 조달 규칙이 리포에 두 벌 존재했고 한쪽만 Linux/Windows를 알고 있었습니다.
- Cursor 자격증명 조달을 `core-ai-gateway`로 옮겨 단일 출처로 만들고, AI Gateway 라우트와 quota 플러그인이 함께 그 구현을 쓰도록 했습니다. macOS는 키체인 우선, 실패 시 `~/.cursor/auth.json`; Windows는 `%APPDATA%/Cursor/auth.json`; Linux는 `$XDG_CONFIG_HOME`(없으면 `~/.config`)`/cursor/auth.json`.
- 부수 효과로 요청 경로에서 블로킹 `execFileSync`가 async 조달로 바뀌었습니다.

동작 규칙은 quota의 검증된 구현을 그대로 옮긴 것이며 새 경로를 창작하지 않았습니다.

## Type of Change

- [x] fix — bug fix

## Test Plan

- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck` / `build` / `test` — 212 passed (신규 8건 포함)
- [x] `pnpm --filter @fleet-plugins/quota typecheck` / `test` — 56 passed
- [x] `pnpm --filter @fleet-plugins/terminal typecheck` / `test` — 531 passed
- [x] `pnpm build` (전체 워크스페이스) 성공
- [x] `pnpm check:core-boundary`, `pnpm check:protocol-sync` 통과
- [x] 빌드 산출물 검증: `runtime/fleet-console/dist/fleet-plugins/terminal/routes.mjs`에 플랫폼 분기 경로가 포함됨
- [x] 런타임 검증: 빌드된 `core-ai-gateway`에 linux deps를 주입해 `~/.config/cursor/auth.json`에서 토큰 조달 성공, `security` 미호출 확인

신규 테스트는 플랫폼 매트릭스(darwin 키체인 우선/파일 폴백, linux에서 `security` 미호출 + XDG 경로, win32 APPDATA 경로, 토큰 JSON 형태 변형, 실패 시 null)를 고정합니다.

## Changelog

- [x] `.changelog.d/pr-486.md` 추가
- [x] 섹션은 `Fixed`(fleet-plugin)와 `Added`(fleet-core)
- [x] 영문/한글 요약 인접, 태그는 `[fleet-console]`, `[core-ai-gateway]`
- [x] `node scripts/compile-changelog-fragments.mjs --check` 통과 (10 entries validated)

## Notes for Reviewers

- `core-ai-gateway`는 이미 server-only이고 `node:` 빌트인을 사용하므로 자격증명 조달을 두기에 적합합니다. 브라우저 코드는 이 패키지를 import하지 않습니다.
- quota의 `CredentialMethod`는 브라우저에서 type-only로 참조되므로 로컬 정의를 유지했습니다.
- codex 토큰 조달도 terminal/quota에 중복되어 있으나 크로스플랫폼으로 동작 중이라 이번 범위에서 제외했습니다.