### PR TITLE
refactor(console): consolidate Codex credential procurement

### DIFF
--- a/.changelog.d/pr-486.md
+++ b/.changelog.d/pr-486.md
@@ -5,5 +5,5 @@
 
 ### fleet-core
 #### Added
-- [core-ai-gateway] Add Cursor credential procurement as shared package API, so every caller resolves the subscription token through one platform-aware implementation instead of its own copy.
-  ko: Cursor 자격증명 조달을 공유 패키지 API로 추가했습니다. 모든 호출자가 각자의 복사본 대신 플랫폼을 인지하는 단일 구현으로 구독 토큰을 조달합니다.
+- [core-ai-gateway] Add Cursor and Codex credential procurement as shared package API, so every caller resolves a subscription token through one platform-aware implementation instead of its own copy.
+  ko: Cursor와 Codex 자격증명 조달을 공유 패키지 API로 추가했습니다. 모든 호출자가 각자의 복사본 대신 플랫폼을 인지하는 단일 구현으로 구독 토큰을 조달합니다.

--- a/.changelog.d/pr-487.md
+++ b/.changelog.d/pr-487.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] The AI Gateway now honors `CODEX_HOME` when it looks for the ChatGPT subscription token, so a relocated Codex home no longer makes Codex model calls fail with a 401 that reported no subscription token while the Usage limits panel found the same login.
+  ko: AI Gateway가 ChatGPT 구독 토큰을 찾을 때 `CODEX_HOME`을 존중합니다. Codex 홈을 옮겨 두어도 Usage limits 패널만 로그인을 찾고 Codex 모델 호출은 구독 토큰이 없다는 401로 실패하던 문제가 없어집니다.

--- a/packages/core-ai-gateway/src/index.ts
+++ b/packages/core-ai-gateway/src/index.ts
@@ -2,7 +2,7 @@ export * from "./anthropic.js";
 export * from "./canonical.js";
 export * from "./claude-context.js";
 export * from "./cursor-adapter.js";
-export * from "./cursor-credentials.js";
+export * from "./provider-credentials.js";
 // estimateTokens 는 어댑터 내부 헬퍼다 — 배럴로 올리면 패키지 공개 계약이 넓어진다.
 export { AnthropicMessagesGateway, ContextWindowExceededError } from "./gateway.js";
 export type { AnthropicGatewayCallOptions, AnthropicGatewayResponse } from "./gateway.js";

--- a/packages/core-ai-gateway/src/provider-credentials.ts
+++ b/packages/core-ai-gateway/src/provider-credentials.ts
@@ -1,10 +1,11 @@
 /**
- * Provider credential procurement for the Cursor subscription token.
+ * Provider credential procurement for the subscription tokens the gateway spends.
  *
- * Where Cursor leaves its login is provider knowledge, not Fleet knowledge, so
- * every consumer that needs the token — the Console AI gateway route and the
- * quota plugin — resolves it through this one module. Keeping a second copy is
- * what let the gateway stay macOS-only while quota already worked everywhere.
+ * Where a provider CLI leaves its login is provider knowledge, not Fleet
+ * knowledge, so every consumer that needs a token — the Console AI gateway route
+ * and the quota plugin — resolves it through this one module. Keeping a second
+ * copy is what let the gateway stay macOS-only for Cursor while quota already
+ * worked everywhere, and what left the gateway blind to `CODEX_HOME`.
  */
 
 import { execFile as nodeExecFile } from "node:child_process";
@@ -27,6 +28,16 @@ export interface CredentialResolverDeps {
 export interface CursorCredentials {
   readonly accessToken: string;
   readonly method: CredentialMethod;
+}
+
+export interface CodexCredentials {
+  readonly accessToken: string;
+  /**
+   * Absent when the login left no account id. Callers that must send the
+   * `chatgpt-account-id` header treat that as no usable credential; the quota
+   * reader does not need it.
+   */
+  readonly accountId?: string;
 }
 
 const execFileAsync = promisify(nodeExecFile);
@@ -79,6 +90,10 @@ export function credentialRecord(value: unknown): Record<string, unknown> | null
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown>
     : null;
+}
+
+function optionalNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 export function optionalTrimmedString(value: unknown): string | undefined {
@@ -143,6 +158,31 @@ export async function resolveCursorCredentials(deps: CredentialResolverDeps): Pr
     return raw === null || raw.length > MAX_CREDENTIAL_BYTES
       ? null
       : parseCursorCredentialJson(raw, "file");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The auth file Codex CLI's ChatGPT login writes. `CODEX_HOME` relocates the
+ * whole Codex home, so ignoring it reads the wrong path for anyone who set it.
+ */
+export function codexAuthFilePath(deps: CredentialResolverDeps): string {
+  return path.join(deps.env.CODEX_HOME || path.join(deps.homedir(), ".codex"), "auth.json");
+}
+
+export async function resolveCodexCredentials(deps: CredentialResolverDeps): Promise<CodexCredentials | null> {
+  try {
+    const raw = await deps.readBounded(codexAuthFilePath(deps), MAX_CREDENTIAL_BYTES);
+    if (raw === null || raw.length > MAX_CREDENTIAL_BYTES) return null;
+    const parsed = credentialRecord(JSON.parse(raw));
+    const tokens = credentialRecord(parsed?.tokens);
+    // Both former copies stored the token verbatim; trimming here would silently
+    // change the credential the gateway sends upstream.
+    const accessToken = optionalNonEmptyString(tokens?.access_token);
+    if (!accessToken) return null;
+    const accountId = optionalNonEmptyString(tokens?.account_id);
+    return accountId === undefined ? { accessToken } : { accessToken, accountId };
   } catch {
     return null;
   }

--- a/packages/core-ai-gateway/tests/provider-credentials.test.ts
+++ b/packages/core-ai-gateway/tests/provider-credentials.test.ts
@@ -3,10 +3,12 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  codexAuthFilePath,
   cursorAuthFilePath,
+  resolveCodexCredentials,
   resolveCursorCredentials,
   type CredentialResolverDeps,
-} from "../src/cursor-credentials.js";
+} from "../src/provider-credentials.js";
 
 function deps(overrides: Partial<CredentialResolverDeps> = {}): CredentialResolverDeps {
   return {
@@ -128,5 +130,60 @@ describe("cursor credential procurement", () => {
       .toBe(path.join("/users/operator", ".cursor", "auth.json"));
     expect(cursorAuthFilePath(deps({ platform: "linux" })))
       .toBe(path.join("/users/operator", ".config", "cursor", "auth.json"));
+  });
+});
+
+describe("codex credential procurement", () => {
+  const codexAuth = (tokens: Record<string, unknown>): string => JSON.stringify({ tokens });
+
+  it("reads the default codex home and never shells out on any platform", async () => {
+    for (const platform of ["darwin", "linux", "win32"] as const) {
+      const execFile = vi.fn(async () => "");
+      const readBounded = vi.fn(async () => codexAuth({ access_token: "codex-token", account_id: "acct-1" }));
+      const result = await resolveCodexCredentials(deps({ platform, execFile, readBounded }));
+      expect(execFile).not.toHaveBeenCalled();
+      expect(readBounded).toHaveBeenCalledWith(path.join("/users/operator", ".codex", "auth.json"), 65_536);
+      expect(result).toEqual({ accessToken: "codex-token", accountId: "acct-1" });
+    }
+  });
+
+  // The gateway used to read ~/.codex/auth.json directly, so a relocated Codex
+  // home resolved no token there while the quota reader found it.
+  it("honors CODEX_HOME when the Codex home is relocated", async () => {
+    const readBounded = vi.fn(async () => codexAuth({ access_token: "codex-token", account_id: "acct-1" }));
+    await resolveCodexCredentials(deps({ env: { CODEX_HOME: "/custom/codex" }, readBounded }));
+    expect(readBounded).toHaveBeenCalledWith(path.join("/custom/codex", "auth.json"), 65_536);
+    expect(codexAuthFilePath(deps({ env: { CODEX_HOME: "/custom/codex" } })))
+      .toBe(path.join("/custom/codex", "auth.json"));
+  });
+
+  it("keeps the account id optional so a quota reader can use a token without one", async () => {
+    const result = await resolveCodexCredentials(deps({
+      readBounded: async () => codexAuth({ access_token: "codex-token" }),
+    }));
+    expect(result).toEqual({ accessToken: "codex-token" });
+  });
+
+  it("stores the token verbatim rather than trimming it", async () => {
+    const result = await resolveCodexCredentials(deps({
+      readBounded: async () => codexAuth({ access_token: " codex-token ", account_id: "acct-1" }),
+    }));
+    expect(result).toEqual({ accessToken: " codex-token ", accountId: "acct-1" });
+  });
+
+  it("returns null when the token is absent, empty, or the file is unreadable", async () => {
+    await expect(resolveCodexCredentials(deps({ readBounded: async () => codexAuth({ account_id: "acct-1" }) })))
+      .resolves.toBeNull();
+    await expect(resolveCodexCredentials(deps({ readBounded: async () => codexAuth({ access_token: "" }) })))
+      .resolves.toBeNull();
+    await expect(resolveCodexCredentials(deps({ readBounded: async () => "{" })))
+      .resolves.toBeNull();
+    await expect(resolveCodexCredentials(deps({ readBounded: async () => null })))
+      .resolves.toBeNull();
+    await expect(resolveCodexCredentials(deps({
+      readBounded: async () => {
+        throw new Error("EACCES");
+      },
+    }))).resolves.toBeNull();
   });
 });

--- a/runtime/fleet-plugins/quota/server/credentials.ts
+++ b/runtime/fleet-plugins/quota/server/credentials.ts
@@ -5,35 +5,33 @@ import {
   credentialRecord,
   defaultCredentialDeps,
   readBoundedFile,
+  resolveCodexCredentials,
   resolveCursorCredentials,
 } from "@dotobokuri/core-ai-gateway";
 import type {
+  CodexCredentials,
   CredentialResolverDeps,
   CursorCredentials,
 } from "@dotobokuri/core-ai-gateway";
 
 import type { CredentialMethod } from "./types.js";
 
-// Cursor 자격증명 조달은 core-ai-gateway가 단일 출처다. Console AI gateway 라우트도 같은
-// 구현을 쓰므로, 여기서 다시 구현하면 플랫폼 분기가 한쪽에만 반영되는 과거 불일치가 되살아난다.
+// Cursor/Codex 자격증명 조달은 core-ai-gateway가 단일 출처다. Console AI gateway 라우트도 같은
+// 구현을 쓰므로, 여기서 다시 구현하면 조달 규칙이 한쪽에만 반영되는 과거 불일치가 되살아난다.
 export {
   MAX_CREDENTIAL_BYTES,
   defaultCredentialDeps,
   readBoundedFile,
+  resolveCodexCredentials,
   resolveCursorCredentials,
 };
-export type { CredentialResolverDeps, CursorCredentials };
+export type { CodexCredentials, CredentialResolverDeps, CursorCredentials };
 
 export interface ClaudeCredentials {
   readonly accessToken: string;
   readonly expiresAt?: number;
   readonly subscriptionType?: string;
   readonly method: CredentialMethod;
-}
-
-export interface CodexCredentials {
-  readonly accessToken: string;
-  readonly accountId?: string;
 }
 
 function optionalString(value: unknown): string | undefined {
@@ -83,21 +81,6 @@ export async function resolveClaudeCredentials(deps: CredentialResolverDeps): Pr
   try {
     const raw = await deps.readBounded(path.join(configDir, ".credentials.json"), MAX_CREDENTIAL_BYTES);
     return raw === null || raw.length > MAX_CREDENTIAL_BYTES ? null : parseClaudeCredentialJson(raw, "file");
-  } catch {
-    return null;
-  }
-}
-
-export async function resolveCodexCredentials(deps: CredentialResolverDeps): Promise<CodexCredentials | null> {
-  const home = deps.env.CODEX_HOME || path.join(deps.homedir(), ".codex");
-  try {
-    const raw = await deps.readBounded(path.join(home, "auth.json"), MAX_CREDENTIAL_BYTES);
-    if (raw === null || raw.length > MAX_CREDENTIAL_BYTES) return null;
-    const parsed = credentialRecord(JSON.parse(raw));
-    const tokens = credentialRecord(parsed?.tokens);
-    const accessToken = optionalString(tokens?.access_token);
-    if (!accessToken) return null;
-    return { accessToken, accountId: optionalString(tokens?.account_id) };
   } catch {
     return null;
   }

--- a/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
@@ -1,7 +1,3 @@
-import { readFileSync } from "node:fs";
-import os from "node:os";
-import path from "node:path";
-
 import {
   AnthropicMessagesGateway,
   CHATGPT_CODEX_RESPONSES_URL,
@@ -20,6 +16,7 @@ import {
   hasClaudeOneMillionMarker,
   projectAnthropicResponseUsage,
   reasoningEffortFromOutputConfig,
+  resolveCodexCredentials,
   resolveCursorCredentials,
   toClaudeGatewayModelId,
   upstreamModelId,
@@ -65,21 +62,18 @@ export async function readCursorSubscriptionToken(): Promise<string | null> {
   return credentials?.accessToken ?? null;
 }
 
-export function readCodexSubscriptionAuth(
-  authPath: string = path.join(os.homedir(), ".codex", "auth.json"),
-): CodexSubscriptionAuth | null {
-  try {
-    const parsed = JSON.parse(readFileSync(authPath, "utf8")) as {
-      readonly tokens?: { readonly access_token?: unknown; readonly account_id?: unknown };
-    };
-    const accessToken = parsed.tokens?.access_token;
-    const accountId = parsed.tokens?.account_id;
-    if (typeof accessToken !== "string" || accessToken.length === 0) return null;
-    if (typeof accountId !== "string" || accountId.length === 0) return null;
-    return { accessToken, accountId };
-  } catch {
-    return null;
-  }
+/**
+ * Codex CLI 로그인이 남긴 ChatGPT 구독 토큰.
+ *
+ * 조달 경로는 core-ai-gateway가 단일 출처다. 여기서 직접 `~/.codex/auth.json`을 읽으면
+ * `CODEX_HOME`으로 Codex 홈을 옮긴 사용자의 파일을 놓친다 — quota 플러그인은 이미 그 변수를
+ * 존중하고 있었다. 게이트웨이는 `chatgpt-account-id` 헤더가 필요하므로 account id가 없는
+ * 자격증명은 여기서 사용 불가로 판정한다.
+ */
+export async function readCodexSubscriptionAuth(): Promise<CodexSubscriptionAuth | null> {
+  const credentials = await resolveCodexCredentials(defaultCredentialDeps);
+  if (!credentials?.accountId) return null;
+  return { accessToken: credentials.accessToken, accountId: credentials.accountId };
 }
 
 export interface AiGatewayRouteDeps {
@@ -88,7 +82,7 @@ export interface AiGatewayRouteDeps {
   /** 테스트가 upstream을 대체할 수 있도록 주입 가능하게 둔다. */
   readonly gateway?: AnthropicMessagesGateway;
   /** 테스트가 구독 토큰 조회를 대체한다. */
-  readonly readAuth?: () => CodexSubscriptionAuth | null;
+  readonly readAuth?: () => CodexSubscriptionAuth | null | Promise<CodexSubscriptionAuth | null>;
   readonly readCursorToken?: () => string | null | Promise<string | null>;
   readonly readKimiApiKey?: () => Promise<string | undefined>;
   readonly cursorDiagnostics?: CursorDiagnosticSink;
@@ -191,7 +185,7 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps = {}): AiGatewayR
       credential = cursorToken;
     } else if (target?.provider === "codex") {
       // ChatGPT 구독 토큰은 Codex CLI가 저장해 둔 것을 읽는다. 자식에게는 넘기지 않는다.
-      const auth = readAuth();
+      const auth = await readAuth();
       if (!auth) {
         writeAnthropicError(res, 401, "authentication_error", "No ChatGPT subscription token was found. Run `codex login` first.");
         return true;


### PR DESCRIPTION
## Summary

- Codex 구독 토큰 조달이 두 벌이었습니다. Terminal 플러그인의 AI Gateway 라우트는 `~/.codex/auth.json`을 직접 읽었고, quota 플러그인은 자체 리더로 같은 자격증명을 조달했습니다.
- 그중 **`CODEX_HOME`을 존중하는 쪽은 quota뿐**이었습니다. Codex 홈을 옮긴 사용자는 quota는 토큰을 찾는데 게이트웨이는 "No ChatGPT subscription token was found"로 401을 반환합니다. #486에서 고친 Cursor 건과 동일한 분기 누락입니다.
- Codex 조달을 Cursor 리졸버 옆(`core-ai-gateway`)으로 옮기고, 두 provider를 함께 담게 되었으므로 모듈명을 `provider-credentials`로 변경했습니다.
- 게이트웨이와 quota가 같은 리졸버를 쓰되, 게이트웨이는 `chatgpt-account-id` 헤더가 필요하므로 account id를 계속 필수로 요구하고 quota는 optional로 둡니다.
- 부수적으로 게이트웨이의 블로킹 `readFileSync`가 Cursor에서 이미 쓰던 bounded/FIFO-safe 읽기로 바뀝니다.

**동작 보존**: 토큰 값은 이전 두 구현과 동일하게 trim하지 않고 그대로 보관합니다(테스트로 고정). `CODEX_HOME` 인지 외에 의도한 동작 변경은 없습니다.

## Type of Change

- [x] refactor — no behavior change (게이트웨이의 `CODEX_HOME` 인지는 예외이며, 아래에 근거를 남깁니다)

## Test Plan

- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck` / `build` / `test` — 217 passed (Codex 신규 5건 포함)
- [x] `pnpm --filter @fleet-plugins/quota typecheck` / `test` — 56 passed
- [x] `pnpm --filter @fleet-plugins/terminal typecheck` / `test` — 531 passed
- [x] `pnpm build` (전체 워크스페이스) 성공
- [x] `pnpm check:core-boundary`, `pnpm check:protocol-sync` 통과
- [x] 빌드 산출물 검증: `dist/fleet-plugins/terminal/routes.mjs`에 `CODEX_HOME` 경로가 포함됨
- [x] 런타임 검증: 빌드된 패키지에 `CODEX_HOME`을 지정/미지정으로 주입해 각각 relocated 파일과 기본 홈에서 토큰 조달 확인

신규 테스트는 기본 홈 조달(3개 플랫폼 모두 셸 미호출), `CODEX_HOME` 존중, account id optional, 토큰 verbatim 보관, 토큰 부재·빈 문자열·파싱 실패·읽기 실패 시 null을 고정합니다.

## Changelog

- [x] `.changelog.d/pr-487.md` 추가 (fleet-plugin / `Fixed`)
- [x] core API 항목은 아직 미출시인 `.changelog.d/pr-486.md`의 `Added`에 병합 (release baseline 규칙)
- [x] `node scripts/compile-changelog-fragments.mjs --check` 통과 (11 entries validated)

## Notes for Reviewers

- 파일명 변경(`cursor-credentials` → `provider-credentials`)은 모듈이 이제 Cursor와 Codex를 모두 담기 때문입니다. `git mv`로 이력을 보존했습니다.
- `readCodexSubscriptionAuth`의 미사용 `authPath` 인자를 제거했습니다. 호출자가 없고(테스트는 `readAuth` 주입 사용) 플러그인 public export도 아닙니다.
- claude 자격증명은 게이트웨이가 읽지 않아(호출자 자격증명을 통과시킴) 중복이 아니므로 quota에 그대로 두었습니다.