### PR TITLE
fix(console): dock map controls to the left cluster when sidebar collapses

### DIFF
--- a/.changelog.d/pr-490.md
+++ b/.changelog.d/pr-490.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Dock the command band map controls (Formation view, Triage) to the left control cluster with a hairline divider when the sidebar is collapsed, instead of leaving them floating at the stale sidebar width; the anchor swap glides over 200ms and honors reduced motion.
+  ko: 사이드바를 접으면 커맨드 밴드의 맵 컨트롤(Formation view, Triage)이 이전 사이드바 폭 위치에 떠 있지 않고 hairline 구분선과 함께 좌측 컨트롤군에 도킹됩니다. 앵커 전환은 200ms 글라이드로 이동하며 reduced motion 설정을 존중합니다.

--- a/runtime/fleet-console/core/client/src/components/command-band-guards.ts
+++ b/runtime/fleet-console/core/client/src/components/command-band-guards.ts
@@ -55,12 +55,29 @@ export function commandBandMenuClampedLeft(
 // 맵 컨트롤 클러스터(.command-band-map-controls)는 절대 배치라 그리드가 그 폭을 모른다.
 // 매직 오프셋 상수는 버튼이 늘 때마다 겹침으로 깨졌으므로(구 116px 사고) 실측 폭에서 계산한다.
 // 좌우 여백 트랙은 반드시 같은 하한을 쓴다 — 값이 어긋나면 하한이 물리는 순간 중앙이 밀린다.
-// 사이드바를 접으면 밴드 좌측 캡은 자리를 지키지만 스테이지 좌단은 0으로 내려간다. 그 차이가
-// mapControlsLead — 하한은 스테이지 원점 기준으로 재야 접힌 상태에서도 겹치지 않는다.
+// mapControlsLead는 스테이지 원점에서 앵커까지의 거리다 — 펼침이면 앵커=사이드바 폭=스테이지
+// 원점이라 0, 접힘이면 스테이지 원점이 0이라 도킹 앵커 그대로다. 하한은 스테이지 원점 기준으로
+// 재야 접힌 상태에서도 겹치지 않는다.
 export const COMMAND_BAND_MAP_CONTROLS_INSET_PX = 8;
 export const COMMAND_BAND_CENTER_BREATHING_PX = 12;
 export const COMMAND_BAND_CENTER_GUTTER_FLOOR_PX = 44;
 export const COMMAND_BAND_CENTER_MIN_PX = 168;
+
+// 접힘 도킹 앵커 — 사이드바가 접히면 맵 컨트롤의 정박 경계(사이드바 우측 경계선)가 사라지므로,
+// 좌측 컨트롤군의 실측 콘텐츠 끝을 새 앵커로 쓴다(브레드크럼이 이미 쓰는 "정렬 앵커는 실제
+// 스테이지 경계" 원칙의 클러스터 판). CSS가 앵커에 INSET(--space-2)을 다시 더해 도킹 구분선이
+// 정확히 콘텐츠 끝 + DOCK_DIVIDER_LEAD에 놓인다. 미측정(0 이하)이면 사이드바 폭 앵커로
+// 폴백해 첫 페인트가 기존 문법과 동일하게 남는다.
+export const COMMAND_BAND_DOCK_DIVIDER_LEAD_PX = 10;
+
+export function commandBandMapControlsAnchor(
+  collapsed: boolean,
+  sideBarWidth: number,
+  leftContentEnd: number,
+): number {
+  if (!collapsed || leftContentEnd <= 0) return sideBarWidth;
+  return leftContentEnd + COMMAND_BAND_DOCK_DIVIDER_LEAD_PX - COMMAND_BAND_MAP_CONTROLS_INSET_PX;
+}
 
 // Activity Rail의 고정 스트립 폭. 패널 폭은 포함하지 않는다 — PR #302가 밴드를 레일
 // 크기 조절에서 떼어냈고, 여기서 예약하는 것은 접히지 않은 레일이 늘 차지하는 스트립뿐이다.

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -5,7 +5,7 @@ import { resolveLocalizedText } from "@fleet-console/sdk/i18n/translate";
 import { fetchConsoleEnvironment, fetchOperations, renameOperation } from "../api.js";
 import { animateViewportTo, fitAllOperations, selectFormationLayout, useCanvasState, useFormationLayout, useFormationView } from "../canvas/canvas-store.js";
 import { enterTriage, focusedTriageOperationId, setTriageActive, useTriageActive } from "../canvas/triage-store.js";
-import { COMMAND_BAND_RAIL_STRIP_PX, commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "./command-band-guards.js";
+import { COMMAND_BAND_RAIL_STRIP_PX, commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandMapControlsAnchor, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "./command-band-guards.js";
 import { CommandBandOperationMenu, CommandBandTheaterMenu, CommandBandTriggerCaret, type CommandBandSwitcherMenu } from "./command-band-switcher.js";
 import { FleetBrandHome } from "./side-bar-brand-foot.js";
 import { useGlobalSettingsStore } from "../global-settings-store.js";
@@ -66,6 +66,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const environmentPopoverRef = useRef<HTMLDivElement>(null);
   const commandBandRef = useRef<HTMLElement>(null);
   const mapControlsRef = useRef<HTMLDivElement>(null);
+  const bandLeftRef = useRef<HTMLDivElement>(null);
   const edgeRevealRef = useRef<HTMLButtonElement>(null);
   const pointerWithinRef = useRef({ edge: false, band: false });
   const renameTargetOperationIdRef = useRef<string | null>(null);
@@ -77,6 +78,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const [switcherMenuLeft, setSwitcherMenuLeft] = useState(0);
   const [bandWidth, setBandWidth] = useState(0);
   const [mapControlsWidth, setMapControlsWidth] = useState(0);
+  const [leftContentEnd, setLeftContentEnd] = useState(0);
   const [environmentOpen, setEnvironmentOpen] = useState(false);
   const [environment, setEnvironment] = useState<ConsoleEnvironmentDiagnostics | null>(null);
   const [environmentError, setEnvironmentError] = useState<string | null>(null);
@@ -86,7 +88,10 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   // 정렬 앵커는 실제 스테이지 경계다 — 접힌 사이드바는 폭 0, 접힌 레일 크롬은 스트립 0.
   const stageLeftWidth = sideBar.collapsed ? 0 : sideBar.width;
   const stageRightWidth = railChromeExpanded ? COMMAND_BAND_RAIL_STRIP_PX : 0;
-  const centerGutter = commandBandCenterGutter(sideBar.width - stageLeftWidth, mapControlsWidth);
+  // 맵 컨트롤 앵커도 같은 원칙을 따른다: 펼침 = 사이드바 경계선, 접힘 = 좌측 컨트롤군 끝(도킹).
+  // 옛 사이드바 폭에 남겨두면 경계 없는 밴드 한가운데에 떠 보이고, 넓힌 뒤 접으면 그만큼 더 밀린다.
+  const mapControlsAnchor = commandBandMapControlsAnchor(sideBar.collapsed, sideBar.width, leftContentEnd);
+  const centerGutter = commandBandCenterGutter(mapControlsAnchor - stageLeftWidth, mapControlsWidth);
   const centerBreadcrumbVisible = viewMode.effective !== "mobile" && commandBandCenterFits(bandWidth - stageLeftWidth - stageRightWidth, centerGutter);
   // 접힌 뒤에는 여백 트랙이 지킬 대상이 없다. 하한을 그대로 두면 고정 트랙 합이 밴드 폭을 넘어
   // 우측 컨트롤이 화면 밖으로 밀린다 — 사이드바를 넓게 늘린 뒤 접으면 하한이 캡 폭만큼 커져
@@ -235,21 +240,29 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
 
   // 맵 컨트롤은 절대 배치라 그리드 트랙에 잡히지 않는다 — 밴드 폭과 클러스터 폭을 실측해
   // 여백 하한과 브레드크럼 접힘을 판정한다. 사이드바 폭이 드래그로 변하므로 viewport
-  // 미디어쿼리로는 판정할 수 없다.
+  // 미디어쿼리로는 판정할 수 없다. 좌측 컨트롤군 콘텐츠 끝(자식 우단 최대값)은 접힘 도킹
+  // 앵커다 — 캡 폭은 좌표 불변 계약으로 사이드바 폭에 고정돼 있어 캡 자체로는 잴 수 없다.
+  // 자식들은 offsetParent가 밴드(.command-band, relative)라 앵커와 같은 좌표계다.
   useLayoutEffect(() => {
     const band = commandBandRef.current;
     if (!band || typeof ResizeObserver === "undefined") return;
     const measure = () => {
       setBandWidth(band.clientWidth);
       setMapControlsWidth(mapControlsRef.current?.offsetWidth ?? 0);
+      const bandLeft = bandLeftRef.current;
+      setLeftContentEnd(bandLeft === null ? 0 : Math.max(0, ...Array.from(bandLeft.children, (child) => (child instanceof HTMLElement ? child.offsetLeft + child.offsetWidth : 0))));
     };
     measure();
     const observer = new ResizeObserver(measure);
     observer.observe(band);
     const mapControls = mapControlsRef.current;
     if (mapControls) observer.observe(mapControls);
+    // 칩 폭 변화(연결 상태 라벨·폰트 로드)도 앵커를 움직인다 — 자식을 직접 관찰하고,
+    // 칩의 등장/퇴장은 아래 deps가 effect를 다시 돌려 관찰 대상을 갱신한다.
+    const bandLeft = bandLeftRef.current;
+    if (bandLeft) for (const child of bandLeft.children) observer.observe(child);
     return () => observer.disconnect();
-  }, [operationsViewVisible]);
+  }, [operationsViewVisible, state.channel, state.connection]);
 
   useEffect(() => {
     if (state.channel === "local") return;
@@ -367,6 +380,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
         className={`command-band${requestedOperationsViewVisible ? " is-operations" : " is-utility"}${fullscreen.isFullscreen ? " is-fullscreen" : ""}${fullscreen.isVisible ? " is-revealed" : ""}`}
         style={{
           "--command-band-left-width": viewMode.effective === "mobile" ? "min-content" : `${sideBar.width}px`,
+          "--command-band-map-anchor": `${mapControlsAnchor}px`,
           "--command-band-stage-left": viewMode.effective === "mobile" ? "min-content" : `${stageLeftWidth}px`,
           "--command-band-stage-right": `${stageRightWidth}px`,
           "--command-band-center-gutter": `${injectedCenterGutter}px`,
@@ -378,7 +392,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
         onFocus={fullscreen.reveal}
         onBlur={handleInteractionBlur}
       >
-      <div className={`command-band-left${requestedOperationsViewVisible && sideBar.collapsed ? " is-collapsed" : ""}`}>
+      <div ref={bandLeftRef} className={`command-band-left${requestedOperationsViewVisible && sideBar.collapsed ? " is-collapsed" : ""}`}>
         <FleetBrandHome className="command-band-brand" />
         {state.channel === "local" ? <div className="command-band-environment">
           <button ref={environmentTriggerRef} type="button" className="command-band-local-chip" aria-haspopup="dialog" aria-expanded={environmentOpen} onClick={() => { setSwitcherMenu(null); discardEnvironmentState(); setEnvironmentOpen((open) => !open); }}>
@@ -399,7 +413,8 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
           <SearchIcon />
         </button>
       </div>
-      {operationsViewVisible ? <div ref={mapControlsRef} className="command-band-map-controls">
+      {operationsViewVisible ? <div ref={mapControlsRef} className={`command-band-map-controls${sideBar.collapsed ? " is-docked" : ""}`}>
+        <span className="command-band-dock-divider" aria-hidden="true" />
         <div className="command-band-formation-group" role="group" aria-label={t("chrome.commandBand.formationView")}>
         <button type="button" className="command-band-formation-toggle command-band-formation-seg" onClick={() => animateViewportTo({ x: 0, y: 0, zoom: 1 })} disabled={state.activeTheaterId === null} aria-label={t("chrome.commandBand.resetCanvasView")} title={t("chrome.commandBand.resetCanvasView")}><ResetViewIcon /></button>
         <button type="button" className="command-band-formation-toggle command-band-formation-seg" onClick={fitAllOperations} disabled={state.activeTheaterId === null || triageActive || !state.operationsHydrated} aria-label={t("chrome.commandBand.fitAllPanels")} title={t("chrome.commandBand.fitAllPanels")}><FitAllIcon /></button>

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -362,15 +362,40 @@ body:has([aria-modal="true"]:not([hidden])) .command-band-edge-reveal.is-fullscr
 }
 
 /* 맵 컨트롤 클러스터(보기 초기화·전체 맞춤·Formation·선별 처리)는 한 컨테이너의 플로우 형제다 —
-   개별 절대 위치 + 매직 오프셋(116px)은 버튼 추가 시 겹침으로 깨졌다(fit-all 도입 당시 선별 처리 아이콘 덮임). */
+   개별 절대 위치 + 매직 오프셋(116px)은 버튼 추가 시 겹침으로 깨졌다(fit-all 도입 당시 선별 처리 아이콘 덮임).
+   앵커는 접힘 여부에 따라 갈린다: 펼침 = 사이드바 경계선 옆, 접힘 = 좌측 컨트롤군 끝(도킹) —
+   접힌 사이드바의 옛 폭에 남겨두면 아무 경계도 없는 밴드 한가운데에 떠 보인다. */
 .command-band-map-controls {
   position: absolute;
-  left: calc(var(--command-band-left-width, 280px) + var(--space-2));
+  left: calc(var(--command-band-map-anchor, var(--command-band-left-width, 280px)) + var(--space-2));
   top: 50%;
   transform: translateY(-50%);
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  /* 글라이드는 접힘/펼침 앵커 전환 전용 — 드래그 리사이즈는 아래 :has 게이트가 즉시 추종으로 끊는다. */
+  transition: left 200ms ease;
+}
+
+body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls { transition: none; }
+
+/* 접힘 도킹 구분선 — 클러스터가 좌측 컨트롤군에 붙을 때만 나타나는 hairline(formation-divider 문법).
+   플로우 형제라 도킹 해제 시 display로 제거해야 gap이 유령 폭을 남기지 않는다. */
+.command-band-dock-divider {
+  display: none;
+  align-self: stretch;
+  flex: none;
+  width: 1px;
+  background: var(--surface-rim);
+}
+
+.command-band-map-controls.is-docked .command-band-dock-divider {
+  display: block;
+  animation: command-band-dock-divider-in 200ms ease;
+}
+
+@keyframes command-band-dock-divider-in {
+  from { opacity: 0; }
 }
 
 .command-band-formation-group {
@@ -738,10 +763,12 @@ html[data-desktop-shell="true"][data-desktop-platform="darwin"] .command-band-le
   .console-shell,
   .operations-side-bar,
   .right-rail,
+  .command-band-map-controls,
   .command-band-left {
     transition: none !important;
   }
 
   .right-rail-stale-veil { animation: none !important; }
+  .command-band-dock-divider { animation: none !important; }
   .command-band.is-fullscreen { transition: none !important; }
 }

--- a/runtime/fleet-console/tests/command-band-v2-guards.test.ts
+++ b/runtime/fleet-console/tests/command-band-v2-guards.test.ts
@@ -5,7 +5,7 @@ import { resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "../core/client/src/components/command-band-guards.js";
+import { commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandMapControlsAnchor, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "../core/client/src/components/command-band-guards.js";
 import type { OperationGroup, OperationNode } from "../core/client/src/types.js";
 
 describe("Command Band v2 guards", () => {
@@ -107,8 +107,19 @@ describe("Command Band center visibility measurements", () => {
 
   it("derives the gutter from the measured map control width", () => {
     expect(commandBandCenterGutter(0, 163)).toBe(8 + 163 + 12);
-    // 사이드바를 접으면 좌측 캡(280px)이 스테이지 원점보다 앞서므로 그만큼 하한이 커진다.
-    expect(commandBandCenterGutter(280, 163)).toBe(280 + 8 + 163 + 12);
+    // 접힘 시 lead는 도킹 앵커(좌측 컨트롤군 끝 기준) 그대로다 — 스테이지 원점이 0이므로.
+    expect(commandBandCenterGutter(185, 163)).toBe(185 + 8 + 163 + 12);
+  });
+
+  it("docks the map controls to the measured left-cluster end only while collapsed", () => {
+    // 펼침: 앵커 = 사이드바 폭(경계선 옆) — 기존 문법 그대로.
+    expect(commandBandMapControlsAnchor(false, 280, 183)).toBe(280);
+    // 접힘: 앵커 = 콘텐츠 끝 + 구분선 리드(10) - CSS 인셋(8) → 구분선이 정확히 콘텐츠 끝 + 10에 놓인다.
+    expect(commandBandMapControlsAnchor(true, 280, 183)).toBe(183 + 10 - 8);
+    // 사이드바를 넓혀도 접힘 앵커는 사이드바 폭과 무관하다 — 넓힌-뒤-접기 부유가 소멸한다.
+    expect(commandBandMapControlsAnchor(true, 460, 183)).toBe(183 + 10 - 8);
+    // 미측정(0 이하) 폴백: 기존 사이드바 폭 앵커를 유지해 첫 페인트가 흔들리지 않는다.
+    expect(commandBandMapControlsAnchor(true, 280, 0)).toBe(280);
   });
 
   it("keeps the center visible while the track is unmeasured", () => {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -81,6 +81,8 @@ const RUNTIME_CUSTOM_PROPERTY_ALLOWLIST = new Set([
   "--whatsnew-delay",
   // Command Band TSX injects the measured left sidebar width.
   "--command-band-left-width",
+  // Command Band TSX injects the state-dependent map-controls anchor (sidebar seam ↔ docked left cluster).
+  "--command-band-map-anchor",
   // Right Rail TSX injects the current panel width.
   "--right-rail-panel-width",
   // Right Rail TSX injects the user-selected overlay opacity.
@@ -731,7 +733,10 @@ describe("Instrument core design contract", () => {
     expect(commandBand).toContain('className="command-band-button command-band-rail-toggle"');
     expect(commandBand).toContain("onClick={toggleRailChrome}");
     expect(commandBand).toContain(`      </div>
-      {operationsViewVisible ? <div ref={mapControlsRef} className="command-band-map-controls">`);
+      {operationsViewVisible ? <div ref={mapControlsRef} className={\`command-band-map-controls\${sideBar.collapsed ? " is-docked" : ""}\`}>`);
+    // 접힘 도킹 구분선은 맵 컨트롤의 첫 플로우 자식이다 — 도킹 상태에서만 display로 나타나
+    // 좌측 컨트롤군과 클러스터를 formation-divider 문법의 hairline으로 잇는다.
+    expect(commandBand).toContain('<span className="command-band-dock-divider" aria-hidden="true" />');
     expect(commandBand).toContain('aria-label={t("chrome.commandBand.resetCanvasView")}');
     expect(commandBand).toContain("<ResetViewIcon />");
     expect(commandBand).toContain("onClick={() => animateViewportTo({ x: 0, y: 0, zoom: 1 })}");
@@ -763,7 +768,17 @@ describe("Instrument core design contract", () => {
     // 맵 컨트롤 클러스터는 컨테이너 플로우 배치다 — 개별 절대 위치 + 매직 오프셋(구 116px)은
     // 버튼 추가 시 겹침으로 깨지므로(선별 처리 아이콘 덮임 사고) 다시 도입하지 않는다.
     expect(layout).toContain(".command-band-map-controls {");
-    expect(layout).toContain("left: calc(var(--command-band-left-width, 280px) + var(--space-2));");
+    // 앵커는 상태 이원제다: 펼침 = 사이드바 경계선(폭 미러), 접힘 = 좌측 컨트롤군 끝(도킹 앵커).
+    // 옛 사이드바 폭에 고정하면 접힘 시 경계 없는 밴드 한가운데에 떠 보인다(2026-08 부유 사고).
+    expect(layout).toContain("left: calc(var(--command-band-map-anchor, var(--command-band-left-width, 280px)) + var(--space-2));");
+    expect(commandBand).toContain('"--command-band-map-anchor": `${mapControlsAnchor}px`,');
+    expect(commandBand).toContain("const mapControlsAnchor = commandBandMapControlsAnchor(sideBar.collapsed, sideBar.width, leftContentEnd);");
+    expect(commandBand).toContain("const centerGutter = commandBandCenterGutter(mapControlsAnchor - stageLeftWidth, mapControlsWidth);");
+    // 글라이드는 접힘/펼침 앵커 전환 전용 — 드래그 리사이즈는 :has 게이트로 즉시 추종을 유지한다.
+    expect(layout).toContain("transition: left 200ms ease;");
+    expect(layout).toContain('body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls { transition: none; }');
+    expect(layout).toContain(".command-band-dock-divider {");
+    expect(layout).toContain(".command-band-map-controls.is-docked .command-band-dock-divider {");
     expect(layout).not.toContain(".command-band-triage-toggle {\n  position: absolute;");
     expect(layout).not.toContain(".command-band-formation-group .command-band-formation-seg + .command-band-formation-seg {");
     // 데스크톱은 사이드바 폭을 그대로 미러하고, 모바일 셸에는 미러할 사이드바가 없으므로
@@ -945,8 +960,10 @@ describe("Instrument core design contract", () => {
     const reducedMotionBlock = layout.slice(layout.indexOf("@media (prefers-reduced-motion: reduce)"));
     expect(reducedMotionBlock).toContain(".operations-side-bar,");
     expect(reducedMotionBlock).toContain(".right-rail,");
+    expect(reducedMotionBlock).toContain(".command-band-map-controls,");
     expect(reducedMotionBlock).toContain(".command-band-left {");
     expect(reducedMotionBlock).toContain("transition: none !important;");
+    expect(reducedMotionBlock).toContain(".command-band-dock-divider { animation: none !important; }");
   });
 
   it("keeps the Instrument base tokens and selector while blocking legacy palette escapes", () => {


### PR DESCRIPTION
## Summary
- 사이드바를 접으면 커맨드 밴드의 맵 컨트롤 클러스터(Reset view · Fit all · Formation grid/columns/rows · Triage)가 옛 사이드바 폭 좌표에 남아, 아무 경계도 없는 밴드 한가운데에 떠 보이던 문제를 수정합니다. 사이드바를 넓힌 뒤 접으면 부유 거리가 그만큼 더 커지는 악화 케이스도 함께 소멸합니다.
- 앵커를 상태 이원제로 전환: 펼침 = 사이드바 경계선 옆(기존 문법 그대로), 접힘 = 좌측 컨트롤군 실측 콘텐츠 끝에 도킹. 브레드크럼이 이미 쓰는 "정렬 앵커는 실제 스테이지 경계" 원칙을 클러스터에도 적용한 것입니다. 도킹 시 formation-divider 문법의 hairline 구분선이 좌측 컨트롤군과 클러스터를 잇습니다.
- 전환은 200ms ease 글라이드(`prefers-reduced-motion` 단락, 드래그 리사이즈는 `:has` 게이트로 즉시 추종 유지). 중앙 브레드크럼 여백 가드(`commandBandCenterGutter`)는 같은 앵커를 소비해 하한이 어긋나지 않습니다. 좌측 캡의 좌표 불변 계약(tint-only)은 건드리지 않았습니다.

## Test Plan
- [x] `vitest run tests/instrument-design-contract.test.ts tests/command-band-v2-guards.test.ts tests/command-band-switcher.test.tsx tests/command-band-focus.test.ts tests/fullscreen-command-band.test.ts` — 64/64 통과 (계약 핀은 새 앵커 문법으로 갱신)
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — exit 0, TS 에러 0
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 성공
- [x] 실브라우저 검증(격리 콘솔): 펼침 무회귀(x=288 동일·seam 유지), 접힘 도킹(구분선 lead 10px), 글라이드 288→193px ~200ms ease 양방향 rAF 실측, 460px 넓힌-뒤-접기에서도 동일 도킹(193px), whites 라이트 테마 토큰 리튠, 빌드 CSS의 reduced-motion 블록 포함 확인
- [x] Changelog: `.changelog.d/pr-490.md` — 그룹형 문법·영/한 병기 작성, `compile-changelog-fragments.mjs --check` 통과
