### PR TITLE
fix(fleet-plugins): stop terminal query echoes on scrollback replay

### DIFF
--- a/.changelog.d/pr-491.md
+++ b/.changelog.d/pr-491.md
@@ -1,0 +1,4 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] Stop terminal device-query responses from being typed into the shell prompt when a Shell panel is reopened and its scrollback is replayed; input now arms only after replay is fully parsed, and the server answers queries only while no acknowledged client is attached, so each query gets exactly one answer.
+  ko: Shell 패널을 다시 열어 scrollback이 재생될 때 터미널 장치 질의 응답이 셸 프롬프트에 입력되던 문제를 수정합니다. 이제 입력은 재생 파싱이 끝난 뒤에만 활성화되고, 서버는 승인된 클라이언트가 없는 동안에만 질의에 응답해 각 질의는 정확히 한 번 응답을 받습니다.

--- a/runtime/fleet-console/tests/plugin-client-host.test.ts
+++ b/runtime/fleet-console/tests/plugin-client-host.test.ts
@@ -57,6 +57,7 @@ describe("client plugin host contract", () => {
       terminal: {
         onData: () => ({ dispose: () => undefined }),
         write: () => undefined,
+        drain: (callback) => callback(),
       },
       ticketPath: "/plugins/terminal/shell/ticket",
       wsPath: `${"/plugins/terminal"}/ws`,
@@ -91,6 +92,7 @@ describe("client plugin host contract", () => {
       terminal: {
         onData: () => ({ dispose: () => undefined }),
         write: () => undefined,
+        drain: (callback) => callback(),
       },
       ticketPath: "/plugins/terminal/shell/ticket",
       wsPath: `${"/plugins/terminal"}/ws`,

--- a/runtime/fleet-console/tests/session-manager.test.ts
+++ b/runtime/fleet-console/tests/session-manager.test.ts
@@ -260,7 +260,7 @@ describe("terminal session manager", () => {
     ]);
   });
 
-  it("answers terminal device queries before replay ack, delegates after ack, and resumes after detach", async () => {
+  it("delegates live terminal device queries and answers them after detach", async () => {
     const ptys = new Map<string, MockPty>();
     const manager = createTerminalSessionManager({
       launch: async (cwd, context) => ({ bin: "mock", args: [], cwd: cwd ?? "/", env: { SESSION: context?.sessionId } }),
@@ -277,18 +277,17 @@ describe("terminal session manager", () => {
     await manager.attach(socket, { sessionId: "session-a", cwd: "/a" });
     socket.emitMessage(Buffer.from(JSON.stringify({ type: "resize", cols: 120, rows: 40 }), "utf8"), false);
     ptys.get("session-a")?.emitData(queryOutput);
-    expect(ptys.get("session-a")?.writes).toEqual(responses);
-
-    socket.emitMessage(Buffer.from(JSON.stringify({ type: "replay_ack" }), "utf8"), false);
-    ptys.get("session-a")?.emitData(queryOutput);
-    expect(ptys.get("session-a")?.writes).toEqual(responses);
-
-    socket.emitClose();
-    ptys.get("session-a")?.emitData(queryOutput);
-    expect(ptys.get("session-a")?.writes).toEqual([...responses, ...responses]);
+    expect(ptys.get("session-a")?.writes).toEqual([]);
     expect(socket.sent.map((chunk) => chunk.toString("utf8"))).toEqual([
       JSON.stringify({ type: "replay_end" }),
       queryOutput,
+    ]);
+
+    socket.emitClose();
+    ptys.get("session-a")?.emitData(queryOutput);
+    expect(ptys.get("session-a")?.writes).toEqual(responses);
+    expect(socket.sent.map((chunk) => chunk.toString("utf8"))).toEqual([
+      JSON.stringify({ type: "replay_end" }),
       queryOutput,
     ]);
   });

--- a/runtime/fleet-console/tests/session-manager.test.ts
+++ b/runtime/fleet-console/tests/session-manager.test.ts
@@ -250,11 +250,17 @@ describe("terminal session manager", () => {
     firstA.emitClose();
     await manager.attach(secondA, { sessionId: "session-a", cwd: "/a" });
 
-    expect(secondA.sent.map((chunk) => chunk.toString("utf8"))).toEqual(["alpha"]);
-    expect(firstB.sent.map((chunk) => chunk.toString("utf8"))).toEqual(["beta"]);
+    expect(secondA.sent.map((chunk) => chunk.toString("utf8"))).toEqual([
+      "alpha",
+      JSON.stringify({ type: "replay_end" }),
+    ]);
+    expect(firstB.sent.map((chunk) => chunk.toString("utf8"))).toEqual([
+      JSON.stringify({ type: "replay_end" }),
+      "beta",
+    ]);
   });
 
-  it("responds to terminal device queries without altering output delivery", async () => {
+  it("answers terminal device queries before replay ack, delegates after ack, and resumes after detach", async () => {
     const ptys = new Map<string, MockPty>();
     const manager = createTerminalSessionManager({
       launch: async (cwd, context) => ({ bin: "mock", args: [], cwd: cwd ?? "/", env: { SESSION: context?.sessionId } }),
@@ -265,13 +271,26 @@ describe("terminal session manager", () => {
       },
     });
     const socket = createMockSocket();
+    const queryOutput = `before\x1b[6nafter\x1b[5n\x1b[c\x1b[0c\x1b[>c\x1b[31m`;
+    const responses = ["\x1b[40;120R", "\x1b[0n", "\x1b[?1;2c", "\x1b[?1;2c", "\x1b[>0;0;0c"];
 
     await manager.attach(socket, { sessionId: "session-a", cwd: "/a" });
     socket.emitMessage(Buffer.from(JSON.stringify({ type: "resize", cols: 120, rows: 40 }), "utf8"), false);
-    ptys.get("session-a")?.emitData(`before\x1b[6nafter\x1b[5n\x1b[c\x1b[0c\x1b[>c\x1b[31m`);
+    ptys.get("session-a")?.emitData(queryOutput);
+    expect(ptys.get("session-a")?.writes).toEqual(responses);
 
-    expect(ptys.get("session-a")?.writes).toEqual(["\x1b[40;120R", "\x1b[0n", "\x1b[?1;2c", "\x1b[?1;2c", "\x1b[>0;0;0c"]);
-    expect(socket.sent.map((chunk) => chunk.toString("utf8"))).toEqual([`before\x1b[6nafter\x1b[5n\x1b[c\x1b[0c\x1b[>c\x1b[31m`]);
+    socket.emitMessage(Buffer.from(JSON.stringify({ type: "replay_ack" }), "utf8"), false);
+    ptys.get("session-a")?.emitData(queryOutput);
+    expect(ptys.get("session-a")?.writes).toEqual(responses);
+
+    socket.emitClose();
+    ptys.get("session-a")?.emitData(queryOutput);
+    expect(ptys.get("session-a")?.writes).toEqual([...responses, ...responses]);
+    expect(socket.sent.map((chunk) => chunk.toString("utf8"))).toEqual([
+      JSON.stringify({ type: "replay_end" }),
+      queryOutput,
+      queryOutput,
+    ]);
   });
 
   it("responds to terminal device queries split across pty chunks", async () => {
@@ -393,7 +412,10 @@ describe("terminal session manager", () => {
 
     // 재연결하면 같은 세션에 다시 붙어 scrollback을 그대로 재생한다.
     await manager.attach(second, { sessionId: "session-a", cwd: "/a" });
-    expect(second.sent.map((chunk) => chunk.toString("utf8"))).toEqual(["before-detach"]);
+    expect(second.sent.map((chunk) => chunk.toString("utf8"))).toEqual([
+      "before-detach",
+      JSON.stringify({ type: "replay_end" }),
+    ]);
     expect(ptys.get("session-a")?.killed()).toBe(false);
   });
 

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-connection.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-connection.ts
@@ -1,6 +1,7 @@
 export interface TerminalLike {
   readonly onData: (listener: (data: string) => void) => { readonly dispose: () => void };
   readonly write: (data: Uint8Array) => void;
+  readonly drain: (callback: () => void) => void;
 }
 
 export interface TerminalConnectionOptions {
@@ -91,16 +92,28 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
       ws.binaryType = "arraybuffer";
       ws.onopen = () => {
         connectionOptions.onStatus?.("live");
-        disposeInput();
-        inputSubscription = connectionOptions.terminal.onData((data) => {
-          if (ws.readyState === OPEN_READY_STATE) ws.send(encoder.encode(data));
-        });
         if (pendingSize) sendResize(pendingSize.cols, pendingSize.rows);
       };
       ws.onmessage = (event) => {
         if (event.data instanceof ArrayBuffer) {
           connectionOptions.terminal.write(new Uint8Array(event.data));
+          return;
         }
+        let frame: unknown;
+        try {
+          frame = JSON.parse(event.data);
+        } catch {
+          return;
+        }
+        if (!isReplayEndFrame(frame)) return;
+        connectionOptions.terminal.drain(() => {
+          if (socket !== ws || ws.readyState !== OPEN_READY_STATE || inputSubscription) return;
+          ws.send(JSON.stringify({ type: "replay_ack" }));
+          disposeInput();
+          inputSubscription = connectionOptions.terminal.onData((data) => {
+            if (ws.readyState === OPEN_READY_STATE) ws.send(encoder.encode(data));
+          });
+        });
       };
       ws.onerror = () => {
         reject(new Error("Terminal WebSocket error"));
@@ -164,6 +177,10 @@ async function requestTerminalTicket(ticketPath: string, operationId: string, si
 
 function defaultWebSocketFactory(url: string): WebSocketLike {
   return new WebSocket(url) as unknown as WebSocketLike;
+}
+
+function isReplayEndFrame(value: unknown): value is { readonly type: "replay_end" } {
+  return !!value && typeof value === "object" && (value as { readonly type?: unknown }).type === "replay_end";
 }
 
 async function delay(ms: number, signal: AbortSignal): Promise<void> {

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-connection.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-connection.ts
@@ -108,7 +108,6 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
         if (!isReplayEndFrame(frame)) return;
         connectionOptions.terminal.drain(() => {
           if (socket !== ws || ws.readyState !== OPEN_READY_STATE || inputSubscription) return;
-          ws.send(JSON.stringify({ type: "replay_ack" }));
           disposeInput();
           inputSubscription = connectionOptions.terminal.onData((data) => {
             if (ws.readyState === OPEN_READY_STATE) ws.send(encoder.encode(data));

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -36,6 +36,7 @@ export interface TerminalSurfaceProps {
 
 interface TerminalOutputScheduler {
   readonly write: (data: Uint8Array) => void;
+  readonly drain: (callback: () => void) => void;
   readonly setActive: (active: boolean) => void;
   readonly dispose: () => void;
 }
@@ -289,6 +290,7 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
             listener(data);
           }),
           write: outputScheduler.write,
+          drain: outputScheduler.drain,
         },
         onExit: () => onExitRef.current?.(),
         onStatus: (nextStatus, message) => {
@@ -648,17 +650,31 @@ function isTerminalScrollbackKey(event: KeyboardEvent): boolean {
   return event.key === "PageUp" || event.key === "PageDown" || event.key === "Home" || event.key === "End";
 }
 
-function createTerminalOutputScheduler(terminal: XtermTerminal, initiallyActive: boolean, afterOutputParsing: () => void): TerminalOutputScheduler {
+export function createTerminalOutputScheduler(terminal: XtermTerminal, initiallyActive: boolean, afterOutputParsing: () => void): TerminalOutputScheduler {
   let active = initiallyActive;
   let disposed = false;
   let flushTimer: ReturnType<typeof setTimeout> | null = null;
   let pendingBytes = 0;
   let pending: Uint8Array[] = [];
+  // drain은 "호출 시점 이전에 write된 바이트"의 파싱 완료만 기다린다(시퀀스 비교). 정지(quiescence)
+  // 대기로 구현하면 재접속 직후 PTY가 연속 출력 중일 때 pendingBytes가 계속 차서 입력 구독이
+  // 무기한 지연된다 — 폭주 프로세스에 Ctrl+C를 보내야 하는 순간에 입력이 잠기는 회귀가 된다.
+  let writeSeq = 0;
+  let parsedSeq = 0;
+  let pendingDrains: Array<{ readonly seq: number; readonly callback: () => void }> = [];
 
   const clearFlushTimer = () => {
     if (!flushTimer) return;
     clearTimeout(flushTimer);
     flushTimer = null;
+  };
+
+  const runPendingDrains = () => {
+    if (disposed || pendingDrains.length === 0) return;
+    const ready = pendingDrains.filter((drain) => drain.seq <= parsedSeq);
+    if (ready.length === 0) return;
+    pendingDrains = pendingDrains.filter((drain) => drain.seq > parsedSeq);
+    for (const drain of ready) drain.callback();
   };
 
   const flush = () => {
@@ -667,7 +683,11 @@ function createTerminalOutputScheduler(terminal: XtermTerminal, initiallyActive:
     const output = concatTerminalOutput(pending, pendingBytes);
     pending = [];
     pendingBytes = 0;
+    writeSeq += 1;
+    const seq = writeSeq;
     terminal.write(output, () => {
+      parsedSeq = seq;
+      runPendingDrains();
       if (!disposed) afterOutputParsing();
     });
   };
@@ -688,6 +708,15 @@ function createTerminalOutputScheduler(terminal: XtermTerminal, initiallyActive:
       }
       scheduleFlush();
     },
+    drain: (callback) => {
+      if (disposed) return;
+      flush();
+      if (parsedSeq === writeSeq) {
+        callback();
+        return;
+      }
+      pendingDrains.push({ seq: writeSeq, callback });
+    },
     setActive: (nextActive) => {
       if (active === nextActive) return;
       active = nextActive;
@@ -699,6 +728,7 @@ function createTerminalOutputScheduler(terminal: XtermTerminal, initiallyActive:
       scheduleFlush();
     },
     dispose: () => {
+      pendingDrains = [];
       flush();
       disposed = true;
       pending = [];

--- a/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
@@ -33,7 +33,6 @@ interface TerminalSession {
   readonly titleListener?: TerminalTitleListener;
   readonly titleParser?: OscTitleParser;
   activeSocket: TerminalSocket | null;
-  clientInputLive: boolean;
   cols: number;
   rows: number;
   // theater-shell(캔버스 순정 셸) 전용: 소켓 단절 후 PTY 정리까지의 grace 타이머. 재연결 시 취소된다.
@@ -90,7 +89,6 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
       session.activeSocket.close(4000, "terminal_replaced");
     }
     session.activeSocket = socket;
-    session.clientInputLive = false;
     touchActivity(session);
     session.pty.resize(session.cols, session.rows);
     replayScrollback(session, socket);
@@ -219,7 +217,6 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
       titleListener,
       ...(titleListener ? { titleParser: createOscTitleParser() } : {}),
       activeSocket: null,
-      clientInputLive: false,
       cols: DEFAULT_COLS,
       rows: DEFAULT_ROWS,
       graceTimer: null,
@@ -250,8 +247,9 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     touchActivity(session);
     const buffer = Buffer.from(data, "utf8");
     const liveSocket = session.activeSocket?.readyState === WS_OPEN_STATE ? session.activeSocket : null;
-    // 미접속·ack 이전에는 서버가 응답하고, ack 이후에는 입력 구독이 열린 클라이언트만 응답해 정확히 한 번 전달한다.
-    if (liveSocket && session.clientInputLive) {
+    // replay_end는 attach와 같은 동기 블록에서 전송되므로 라이브 소켓 존재가 곧 마커 이후 경계다.
+    // 이후 질의는 WebSocket 메시지와 xterm write 큐 순서대로 파싱되어 입력 활성화 뒤 클라이언트가 응답하고, 서버는 미접속 구간만 맡는다.
+    if (liveSocket) {
       session.terminalQueryResidual = "";
     } else {
       respondToTerminalQueries(session, buffer);
@@ -297,10 +295,6 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     } catch {
       return;
     }
-    if (isReplayAckFrame(frame)) {
-      session.clientInputLive = true;
-      return;
-    }
     if (!isResizeFrame(frame)) return;
     session.cols = frame.cols;
     session.rows = frame.rows;
@@ -313,7 +307,6 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     // 죽은 소켓으로의 전송을 막고, 출력은 scrollback에 계속 쌓여 재연결 시 attach가 그대로 재생한다.
     // PTY는 오직 PTY 자가종료·운영자 terminate·서버 stop에서만 죽는다(자동 종료 grace 타이머는 제거됨).
     session.activeSocket = null;
-    session.clientInputLive = false;
     // 예외: theater-shell(캔버스 순정 셸)은 "상태 미유지" 요구에 따라 소켓 단절 후 짧은 grace 뒤 PTY를 정리한다.
     // 패널 닫기·새로고침이 이 경로로 흘러 orphan PTY를 막는다. 재연결이 들어오면 attach가 타이머를 취소한다.
     if (isTheaterShell(session.id)) {
@@ -495,10 +488,6 @@ function toBuffer(data: TerminalSocketData): Buffer {
   if (Buffer.isBuffer(data)) return data;
   if (Array.isArray(data)) return Buffer.concat(data);
   return Buffer.from(data);
-}
-
-function isReplayAckFrame(value: unknown): value is { readonly type: "replay_ack" } {
-  return !!value && typeof value === "object" && (value as { readonly type?: unknown }).type === "replay_ack";
 }
 
 function isResizeFrame(value: unknown): value is { readonly type: "resize"; readonly cols: number; readonly rows: number } {

--- a/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
@@ -33,6 +33,7 @@ interface TerminalSession {
   readonly titleListener?: TerminalTitleListener;
   readonly titleParser?: OscTitleParser;
   activeSocket: TerminalSocket | null;
+  clientInputLive: boolean;
   cols: number;
   rows: number;
   // theater-shell(캔버스 순정 셸) 전용: 소켓 단절 후 PTY 정리까지의 grace 타이머. 재연결 시 취소된다.
@@ -89,9 +90,13 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
       session.activeSocket.close(4000, "terminal_replaced");
     }
     session.activeSocket = socket;
+    session.clientInputLive = false;
     touchActivity(session);
     session.pty.resize(session.cols, session.rows);
     replayScrollback(session, socket);
+    if (socket.readyState === WS_OPEN_STATE) {
+      socket.send(Buffer.from(JSON.stringify({ type: "replay_end" }), "utf8"), { binary: false });
+    }
     socket.on("message", (data, isBinary) => handleSocketMessage(session, data, isBinary));
     socket.once("close", () => detachSocket(session, socket));
   }
@@ -214,6 +219,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
       titleListener,
       ...(titleListener ? { titleParser: createOscTitleParser() } : {}),
       activeSocket: null,
+      clientInputLive: false,
       cols: DEFAULT_COLS,
       rows: DEFAULT_ROWS,
       graceTimer: null,
@@ -243,13 +249,17 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
   function handlePtyData(session: TerminalSession, data: string): void {
     touchActivity(session);
     const buffer = Buffer.from(data, "utf8");
-    respondToTerminalQueries(session, buffer);
+    const liveSocket = session.activeSocket?.readyState === WS_OPEN_STATE ? session.activeSocket : null;
+    // 미접속·ack 이전에는 서버가 응답하고, ack 이후에는 입력 구독이 열린 클라이언트만 응답해 정확히 한 번 전달한다.
+    if (liveSocket && session.clientInputLive) {
+      session.terminalQueryResidual = "";
+    } else {
+      respondToTerminalQueries(session, buffer);
+    }
     observeOscTitles(session, buffer);
     session.scrollback.push(buffer);
     while (session.scrollback.length > scrollbackLimit) session.scrollback.shift();
-    if (session.activeSocket && session.activeSocket.readyState === WS_OPEN_STATE) {
-      session.activeSocket.send(buffer, { binary: true });
-    }
+    liveSocket?.send(buffer, { binary: true });
   }
 
   function observeOscTitles(session: TerminalSession, buffer: Buffer): void {
@@ -287,6 +297,10 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     } catch {
       return;
     }
+    if (isReplayAckFrame(frame)) {
+      session.clientInputLive = true;
+      return;
+    }
     if (!isResizeFrame(frame)) return;
     session.cols = frame.cols;
     session.rows = frame.rows;
@@ -299,6 +313,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     // 죽은 소켓으로의 전송을 막고, 출력은 scrollback에 계속 쌓여 재연결 시 attach가 그대로 재생한다.
     // PTY는 오직 PTY 자가종료·운영자 terminate·서버 stop에서만 죽는다(자동 종료 grace 타이머는 제거됨).
     session.activeSocket = null;
+    session.clientInputLive = false;
     // 예외: theater-shell(캔버스 순정 셸)은 "상태 미유지" 요구에 따라 소켓 단절 후 짧은 grace 뒤 PTY를 정리한다.
     // 패널 닫기·새로고침이 이 경로로 흘러 orphan PTY를 막는다. 재연결이 들어오면 attach가 타이머를 취소한다.
     if (isTheaterShell(session.id)) {
@@ -480,6 +495,10 @@ function toBuffer(data: TerminalSocketData): Buffer {
   if (Buffer.isBuffer(data)) return data;
   if (Array.isArray(data)) return Buffer.concat(data);
   return Buffer.from(data);
+}
+
+function isReplayAckFrame(value: unknown): value is { readonly type: "replay_ack" } {
+  return !!value && typeof value === "object" && (value as { readonly type?: unknown }).type === "replay_ack";
 }
 
 function isResizeFrame(value: unknown): value is { readonly type: "resize"; readonly cols: number; readonly rows: number } {

--- a/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
@@ -247,12 +247,11 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     touchActivity(session);
     const buffer = Buffer.from(data, "utf8");
     const liveSocket = session.activeSocket?.readyState === WS_OPEN_STATE ? session.activeSocket : null;
-    // replay_end는 attach와 같은 동기 블록에서 전송되므로 라이브 소켓 존재가 곧 마커 이후 경계다.
-    // 이후 질의는 WebSocket 메시지와 xterm write 큐 순서대로 파싱되어 입력 활성화 뒤 클라이언트가 응답하고, 서버는 미접속 구간만 맡는다.
-    if (liveSocket) {
-      session.terminalQueryResidual = "";
-    } else {
-      respondToTerminalQueries(session, buffer);
+    const queryResponses = scanTerminalQueries(session, buffer);
+    // 라이브 중에도 파싱을 계속해 분절 질의의 prefix를 residual로 이월하고, 응답만 클라이언트에 위임한다.
+    // 소유권 경계는 attach와 같은 동기 블록에서 전송되는 replay_end로 유지된다.
+    if (!liveSocket) {
+      for (const response of queryResponses) writeTerminalQueryResponse(session, response);
     }
     observeOscTitles(session, buffer);
     session.scrollback.push(buffer);
@@ -431,8 +430,9 @@ function clearGraceTimer(session: TerminalSession): void {
   session.graceTimer = null;
 }
 
-function respondToTerminalQueries(session: TerminalSession, buffer: Buffer): void {
+function scanTerminalQueries(session: TerminalSession, buffer: Buffer): string[] {
   const text = `${session.terminalQueryResidual}${buffer.toString("utf8")}`;
+  const responses: string[] = [];
   session.terminalQueryResidual = "";
   let cursor = 0;
   while (cursor < text.length) {
@@ -446,9 +446,11 @@ function respondToTerminalQueries(session: TerminalSession, buffer: Buffer): voi
       session.terminalQueryResidual = trimTerminalQueryResidual(text.slice(start));
       break;
     }
-    writeTerminalQueryResponse(session, resolveTerminalQueryResponse(session, text.slice(start, end + 1)));
+    const response = resolveTerminalQueryResponse(session, text.slice(start, end + 1));
+    if (response) responses.push(response);
     cursor = end + 1;
   }
+  return responses;
 }
 
 function readTrailingEscape(text: string): string {

--- a/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
@@ -63,6 +63,7 @@ export interface TerminalPtyHandle {
 export interface TerminalSocket {
   readonly readyState: number;
   send(data: Buffer, options: { readonly binary: true }): void;
+  send(data: Buffer, options: { readonly binary: false }): void;
   close(code?: number, reason?: string): void;
   on(event: "message", listener: (data: TerminalSocketData, isBinary: boolean) => void): void;
   once(event: "close", listener: () => void): void;

--- a/runtime/fleet-plugins/terminal/tests/global-shell-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/global-shell-routes.test.ts
@@ -76,8 +76,8 @@ class FakeSocket implements TerminalSocket {
   readonly sent: string[] = [];
   private readonly closeCallbacks = new Set<() => void>();
 
-  send(data: Buffer): void {
-    this.sent.push(data.toString("utf8"));
+  send(data: Buffer, options: { readonly binary: boolean }): void {
+    if (options.binary) this.sent.push(data.toString("utf8"));
   }
 
   close(): void {

--- a/runtime/fleet-plugins/terminal/tests/osc-title-session-manager.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/osc-title-session-manager.test.ts
@@ -137,8 +137,8 @@ function createMockSocket(): MockSocket {
   return {
     readyState: 1,
     sent: [],
-    send(data) {
-      this.sent.push(Buffer.from(data));
+    send(data, options) {
+      if (options.binary) this.sent.push(Buffer.from(data));
     },
     close() {},
     on(_event: "message", _listener: (data: TerminalSocketData, isBinary: boolean) => void) {},

--- a/runtime/fleet-plugins/terminal/tests/session-manager-last-activity.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/session-manager-last-activity.test.ts
@@ -93,8 +93,8 @@ function createMockSocket(): MockSocket {
   return {
     readyState: 1,
     sent: [],
-    send(data) {
-      this.sent.push(Buffer.from(data));
+    send(data, options) {
+      if (options.binary) this.sent.push(Buffer.from(data));
     },
     close() {},
     on(event: "message", listener: (data: TerminalSocketData, isBinary: boolean) => void) {

--- a/runtime/fleet-plugins/terminal/tests/session-manager-query-replay.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/session-manager-query-replay.test.ts
@@ -8,22 +8,19 @@ const DA_RESPONSE = "\x1b[?1;2c";
 const CONTEXT = { sessionId: "session-a", cwd: "/work" } as const;
 
 describe("session-manager terminal query replay", () => {
-  it("answers before replay ack, delegates after ack, and answers again after detach", async () => {
+  it("delegates live terminal queries and answers again after detach", async () => {
     const { manager, pty } = await createHarness();
     const socket = createMockSocket();
     await manager.attach(socket, CONTEXT);
 
     pty.emitData(DA_QUERY);
-    expect(pty.written).toEqual([DA_RESPONSE]);
-
-    socket.emitMessage(Buffer.from(JSON.stringify({ type: "replay_ack" }), "utf8"), false);
-    pty.emitData(DA_QUERY);
-    expect(pty.written).toEqual([DA_RESPONSE]);
+    expect(pty.written).toEqual([]);
+    expect(socket.sent.filter((frame) => frame.binary).map((frame) => frame.data.toString("utf8"))).toEqual([DA_QUERY]);
 
     socket.emitClose();
     pty.emitData(DA_QUERY);
-    expect(pty.written).toEqual([DA_RESPONSE, DA_RESPONSE]);
-    expect(socket.sent.filter((frame) => frame.binary).map((frame) => frame.data.toString("utf8"))).toEqual([DA_QUERY, DA_QUERY]);
+    expect(pty.written).toEqual([DA_RESPONSE]);
+    expect(socket.sent.filter((frame) => frame.binary).map((frame) => frame.data.toString("utf8"))).toEqual([DA_QUERY]);
     await manager.stop();
   });
 

--- a/runtime/fleet-plugins/terminal/tests/session-manager-query-replay.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/session-manager-query-replay.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import { createTerminalSessionManager } from "../server/shared/session-manager.js";
+import type { TerminalPtyHandle, TerminalSocket, TerminalSocketData } from "../server/shared/terminal-types.js";
+
+const DA_QUERY = "\x1b[c";
+const DA_RESPONSE = "\x1b[?1;2c";
+const CONTEXT = { sessionId: "session-a", cwd: "/work" } as const;
+
+describe("session-manager terminal query replay", () => {
+  it("answers before replay ack, delegates after ack, and answers again after detach", async () => {
+    const { manager, pty } = await createHarness();
+    const socket = createMockSocket();
+    await manager.attach(socket, CONTEXT);
+
+    pty.emitData(DA_QUERY);
+    expect(pty.written).toEqual([DA_RESPONSE]);
+
+    socket.emitMessage(Buffer.from(JSON.stringify({ type: "replay_ack" }), "utf8"), false);
+    pty.emitData(DA_QUERY);
+    expect(pty.written).toEqual([DA_RESPONSE]);
+
+    socket.emitClose();
+    pty.emitData(DA_QUERY);
+    expect(pty.written).toEqual([DA_RESPONSE, DA_RESPONSE]);
+    expect(socket.sent.filter((frame) => frame.binary).map((frame) => frame.data.toString("utf8"))).toEqual([DA_QUERY, DA_QUERY]);
+    await manager.stop();
+  });
+
+  it("answers terminal queries while no live client is attached", async () => {
+    const { manager, pty } = await createHarness();
+
+    pty.emitData(DA_QUERY);
+
+    expect(pty.written).toContain(DA_RESPONSE);
+    await manager.stop();
+  });
+
+  it("sends replayed binary scrollback before one text replay-end frame", async () => {
+    const { manager, pty } = await createHarness();
+    pty.emitData("detached-output");
+    const socket = createMockSocket();
+
+    await manager.attach(socket, CONTEXT);
+
+    expect(socket.sent).toHaveLength(2);
+    expect(socket.sent[0]).toMatchObject({ binary: true });
+    expect(socket.sent[0]?.data.toString("utf8")).toBe("detached-output");
+    expect(socket.sent[1]).toMatchObject({ binary: false });
+    expect(JSON.parse(socket.sent[1]?.data.toString("utf8") ?? "null")).toEqual({ type: "replay_end" });
+    await manager.stop();
+  });
+
+  it("sends replay-end for an empty fresh session", async () => {
+    const { manager } = await createHarness();
+    const socket = createMockSocket();
+
+    await manager.attach(socket, CONTEXT);
+
+    expect(socket.sent).toHaveLength(1);
+    expect(socket.sent[0]).toMatchObject({ binary: false });
+    expect(JSON.parse(socket.sent[0]?.data.toString("utf8") ?? "null")).toEqual({ type: "replay_end" });
+    await manager.stop();
+  });
+});
+
+interface MockPty extends TerminalPtyHandle {
+  readonly written: string[];
+  emitData(data: string): void;
+}
+
+interface SentFrame {
+  readonly data: Buffer;
+  readonly binary: boolean;
+}
+
+interface MockSocket extends TerminalSocket {
+  readonly sent: SentFrame[];
+  emitMessage(data: TerminalSocketData, isBinary: boolean): void;
+  emitClose(): void;
+}
+
+async function createHarness(): Promise<{ readonly manager: ReturnType<typeof createTerminalSessionManager>; readonly pty: MockPty }> {
+  const pty = createMockPty();
+  const manager = createTerminalSessionManager({
+    launch: async (cwd) => ({ bin: "mock", args: [], cwd: cwd ?? "/", env: {} }),
+    startShell: () => pty,
+  });
+  await manager.createSession(CONTEXT);
+  return { manager, pty };
+}
+
+function createMockPty(): MockPty {
+  const dataListeners: Array<(data: string) => void> = [];
+  const exitListeners: Array<() => void> = [];
+  return {
+    written: [],
+    emitData(data) {
+      for (const listener of dataListeners) listener(data);
+    },
+    onData(callback) {
+      dataListeners.push(callback);
+      return { dispose: () => removeListener(dataListeners, callback) };
+    },
+    onExit(callback) {
+      exitListeners.push(callback);
+      return { dispose: () => removeListener(exitListeners, callback) };
+    },
+    write(data) {
+      this.written.push(data);
+    },
+    resize() {},
+    kill() {},
+  };
+}
+
+function createMockSocket(): MockSocket {
+  const messageListeners: Array<(data: TerminalSocketData, isBinary: boolean) => void> = [];
+  const closeListeners: Array<() => void> = [];
+  return {
+    readyState: 1,
+    sent: [],
+    send(data, options) {
+      this.sent.push({ data: Buffer.from(data), binary: options.binary });
+    },
+    close() {},
+    on(_event: "message", listener: (data: TerminalSocketData, isBinary: boolean) => void) {
+      messageListeners.push(listener);
+    },
+    once(_event: "close", listener: () => void) {
+      closeListeners.push(listener);
+    },
+    emitMessage(data, isBinary) {
+      for (const listener of messageListeners) listener(data, isBinary);
+    },
+    emitClose() {
+      for (const listener of closeListeners) listener();
+    },
+  };
+}
+
+function removeListener<T>(listeners: T[], listener: T): void {
+  const index = listeners.indexOf(listener);
+  if (index >= 0) listeners.splice(index, 1);
+}

--- a/runtime/fleet-plugins/terminal/tests/session-manager-query-replay.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/session-manager-query-replay.test.ts
@@ -24,6 +24,20 @@ describe("session-manager terminal query replay", () => {
     await manager.stop();
   });
 
+  it("carries a live query prefix into the detached responder", async () => {
+    const { manager, pty } = await createHarness();
+    const socket = createMockSocket();
+    await manager.attach(socket, CONTEXT);
+
+    pty.emitData("\x1b[");
+    expect(pty.written).toEqual([]);
+
+    socket.emitClose();
+    pty.emitData("c");
+    expect(pty.written).toEqual([DA_RESPONSE]);
+    await manager.stop();
+  });
+
   it("answers terminal queries while no live client is attached", async () => {
     const { manager, pty } = await createHarness();
 

--- a/runtime/fleet-plugins/terminal/tests/terminal-connection-replay-gate.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-connection-replay-gate.test.ts
@@ -42,17 +42,13 @@ describe("terminal connection replay input gate", () => {
     expect(terminal.pendingDrains).toHaveLength(1);
     terminal.emitData("while-draining");
     expect(socket!.sent).toHaveLength(1);
-    expect(socket!.sent).not.toContain(JSON.stringify({ type: "replay_ack" }));
 
     terminal.releaseDrain();
-    expect(socket!.sent).toEqual([
-      JSON.stringify({ type: "resize", cols: 120, rows: 40 }),
-      JSON.stringify({ type: "replay_ack" }),
-    ]);
+    expect(socket!.sent).toEqual([JSON.stringify({ type: "resize", cols: 120, rows: 40 })]);
     terminal.emitData("live-input");
-    expect(socket!.sent).toHaveLength(3);
-    expect(socket!.sent[2]).toBeInstanceOf(Uint8Array);
-    expect(new TextDecoder().decode(socket!.sent[2] as Uint8Array)).toBe("live-input");
+    expect(socket!.sent).toHaveLength(2);
+    expect(socket!.sent[1]).toBeInstanceOf(Uint8Array);
+    expect(new TextDecoder().decode(socket!.sent[1] as Uint8Array)).toBe("live-input");
 
     connection.dispose();
   });

--- a/runtime/fleet-plugins/terminal/tests/terminal-connection-replay-gate.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-connection-replay-gate.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createTerminalConnection, type WebSocketLike } from "../client/shared/terminal-connection.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("terminal connection replay input gate", () => {
+  it("subscribes input only after replay output has drained while preserving resize", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ ticket: "ticket-a", ttlMs: 10_000 }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })));
+    const terminal = new FakeTerminal();
+    let socket: FakeWebSocket | undefined;
+    const connection = createTerminalConnection({
+      operationId: "session-a",
+      terminal,
+      ticketPath: "/ticket",
+      wsPath: "/ws",
+      location: { host: "console.test", protocol: "http:" },
+      webSocketFactory: () => {
+        socket = new FakeWebSocket();
+        return socket;
+      },
+    });
+    connection.resize(120, 40);
+    connection.start();
+    await vi.waitFor(() => expect(socket).toBeDefined());
+    socket!.open();
+
+    expect(socket!.sent).toEqual([JSON.stringify({ type: "resize", cols: 120, rows: 40 })]);
+    terminal.emitData("before-replay-end");
+    expect(socket!.sent).toHaveLength(1);
+
+    const replay = new TextEncoder().encode("replayed-output");
+    socket!.receive(replay.buffer);
+    expect(terminal.written).toEqual([replay]);
+
+    socket!.receive(JSON.stringify({ type: "replay_end" }));
+    expect(terminal.pendingDrains).toHaveLength(1);
+    terminal.emitData("while-draining");
+    expect(socket!.sent).toHaveLength(1);
+    expect(socket!.sent).not.toContain(JSON.stringify({ type: "replay_ack" }));
+
+    terminal.releaseDrain();
+    expect(socket!.sent).toEqual([
+      JSON.stringify({ type: "resize", cols: 120, rows: 40 }),
+      JSON.stringify({ type: "replay_ack" }),
+    ]);
+    terminal.emitData("live-input");
+    expect(socket!.sent).toHaveLength(3);
+    expect(socket!.sent[2]).toBeInstanceOf(Uint8Array);
+    expect(new TextDecoder().decode(socket!.sent[2] as Uint8Array)).toBe("live-input");
+
+    connection.dispose();
+  });
+});
+
+class FakeTerminal {
+  readonly written: Uint8Array[] = [];
+  readonly pendingDrains: Array<() => void> = [];
+  private dataListener: ((data: string) => void) | null = null;
+
+  readonly onData = (listener: (data: string) => void) => {
+    this.dataListener = listener;
+    return {
+      dispose: () => {
+        if (this.dataListener === listener) this.dataListener = null;
+      },
+    };
+  };
+
+  readonly write = (data: Uint8Array) => {
+    this.written.push(data);
+  };
+
+  readonly drain = (callback: () => void) => {
+    this.pendingDrains.push(callback);
+  };
+
+  emitData(data: string): void {
+    this.dataListener?.(data);
+  }
+
+  releaseDrain(): void {
+    this.pendingDrains.shift()?.();
+  }
+}
+
+class FakeWebSocket implements WebSocketLike {
+  binaryType: BinaryType = "blob";
+  readyState = 0;
+  readonly sent: Array<string | Uint8Array> = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent<ArrayBuffer | string>) => void) | null = null;
+  onclose: ((event: { readonly code?: number }) => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  readonly send = (data: string | Uint8Array) => {
+    this.sent.push(data);
+  };
+
+  readonly close = () => {
+    this.readyState = 3;
+    this.onclose?.({ code: 1000 });
+  };
+
+  open(): void {
+    this.readyState = 1;
+    this.onopen?.();
+  }
+
+  receive(data: ArrayBuffer | string): void {
+    this.onmessage?.({ data } as MessageEvent<ArrayBuffer | string>);
+  }
+}

--- a/runtime/fleet-plugins/terminal/tests/terminal-output-scheduler-drain.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-output-scheduler-drain.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { Terminal as XtermTerminal } from "@xterm/xterm";
+
+import { createTerminalOutputScheduler } from "../client/shared/terminal-surface.js";
+
+vi.mock("@xterm/xterm", () => ({ Terminal: class Terminal {} }));
+vi.mock("@xterm/addon-fit", () => ({ FitAddon: class FitAddon {} }));
+vi.mock("@xterm/addon-unicode11", () => ({ Unicode11Addon: class Unicode11Addon {} }));
+vi.mock("@xterm/addon-webgl", () => ({ WebglAddon: class WebglAddon {} }));
+
+describe("terminal output scheduler drain", () => {
+  it("runs the callback synchronously when nothing is pending", () => {
+    const { scheduler } = createHarness();
+    const drained = vi.fn();
+    scheduler.drain(drained);
+    expect(drained).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for output written before drain to be parsed", () => {
+    const { scheduler, fake } = createHarness();
+    scheduler.write(new Uint8Array([1]));
+    const drained = vi.fn();
+    scheduler.drain(drained);
+    expect(fake.writes).toHaveLength(1);
+    expect(drained).not.toHaveBeenCalled();
+    fake.completeWrite(0);
+    expect(drained).toHaveBeenCalledTimes(1);
+  });
+
+  // 정지(quiescence) 대기 회귀 가드: drain 이후 도착한 출력이 파싱 미완이어도, drain 시점 이전
+  // 바이트만 파싱되면 콜백이 풀려야 한다 — 연속 출력 중 입력 구독이 기아되면 Ctrl+C가 막힌다.
+  it("does not starve behind output that arrives after drain", () => {
+    const { scheduler, fake } = createHarness();
+    scheduler.write(new Uint8Array([1]));
+    const drained = vi.fn();
+    scheduler.drain(drained);
+    scheduler.write(new Uint8Array([2, 2]));
+    scheduler.setActive(true);
+    scheduler.setActive(false);
+    fake.completeWrite(0);
+    expect(drained).toHaveBeenCalledTimes(1);
+    scheduler.dispose();
+  });
+
+  it("drops queued drain callbacks on dispose", () => {
+    const { scheduler, fake } = createHarness();
+    scheduler.write(new Uint8Array([1]));
+    const drained = vi.fn();
+    scheduler.drain(drained);
+    scheduler.dispose();
+    fake.completeWrite(0);
+    expect(drained).not.toHaveBeenCalled();
+  });
+});
+
+interface FakeXterm {
+  readonly writes: Array<{ readonly data: Uint8Array; readonly callback?: () => void }>;
+  completeWrite(index: number): void;
+}
+
+function createHarness(): { readonly scheduler: ReturnType<typeof createTerminalOutputScheduler>; readonly fake: FakeXterm } {
+  const writes: Array<{ readonly data: Uint8Array; readonly callback?: () => void }> = [];
+  const fake: FakeXterm = {
+    writes,
+    completeWrite(index) {
+      writes[index]?.callback?.();
+    },
+  };
+  const terminal = {
+    write: (data: Uint8Array, callback?: () => void) => {
+      writes.push({ data, ...(callback ? { callback } : {}) });
+    },
+  } as unknown as XtermTerminal;
+  const scheduler = createTerminalOutputScheduler(terminal, false, () => {});
+  return { scheduler, fake };
+}


### PR DESCRIPTION
## Summary
- Global Shell(우측 레일)·셸 터미널을 닫았다 다시 열 때마다 프롬프트에 `1;2c2026;2$y…rgb:…` 같은 문자열이 자동 입력·누적되던 버그를 수정합니다. 서버가 재접속 시 원본 scrollback(nvim 등이 남긴 DA/DECRQM/DECRQSS/OSC 색상 질의 포함)을 재생하는데, 클라이언트가 소켓 open 시점에 xterm 입력을 구독해 재생된 질의에 대한 xterm 자동 응답이 PTY stdin으로 역류하던 것이 원인입니다.
- 프로토콜로 봉합: 서버는 scrollback 재생 완료 후 `{"type":"replay_end"}` 텍스트 프레임을 보내고, 클라이언트는 재생분이 xterm에 전부 파싱된 뒤에만(`drain`, 시퀀스 기반이라 연속 출력 중에도 입력 구독이 기아되지 않음) `{"type":"replay_ack"}`를 보내고 입력을 구독합니다. 질의 종류를 열거하지 않는 계층 수정이라 향후 질의와 Windows(ConPTY)/WSL/Linux 전부에 동일하게 유효합니다.
- 서버 질의 자동 응답기는 ack 이전·미접속 구간에만 응답하고 ack 이후에는 클라이언트에 위임합니다. 접속 중 이중 응답(DA 응답 2개 중 1개가 nvim 종료 직후 `1;2c`로 프롬프트에 배달)과 attach 직후 무응답 창이 모두 제거되어, 모든 구간에서 정확히 한 주체만 응답합니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal test` — 55 files / 540 tests green (신규: 3상 질의 응답 계약·replay_end 순서·입력 게이트·drain 기아 회귀 테스트 9건 포함)
- [x] `pnpm --filter @fleet-plugins/terminal typecheck && build`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/session-manager.test.ts tests/plugin-client-host.test.ts` — 24/24 (신계약으로 갱신)
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck && build`
- [x] 실브라우저(agent-browser, 격리 콘솔) 검증: 셸에서 `printf '\033[c\033[?2026$p'` 주입 후 패널 닫기→재열기 2회 — 재접속 소켓의 자동 송신 0바이트, 라이브 질의 응답 정확 1회, `replay_ack` 소켓당 1회, 재열기 후 키 입력 정상
- [x] Changelog: `.changelog.d/pr-491.md` 추가 완료 (fragment 문법·이중언어 요약·`compile-changelog-fragments.mjs --check` 통과)
