### PR TITLE
fix(gateway): strip format hints from OpenAI strict tool schemas

### DIFF
--- a/.changelog.d/pr-492.md
+++ b/.changelog.d/pr-492.md
@@ -1,0 +1,4 @@
+### fleet-core
+#### Fixed
+- [core-ai-gateway] Strip JSON Schema `format` hints (such as `format: "uri"` on WebFetch's `url`) from OpenAI strict tool schemas, and apply the same strict cleanup to `$defs` subschemas, so a format value outside OpenAI's accepted set no longer fails the whole request with a 400 schema error on the Codex path.
+  ko: OpenAI strict 도구 스키마에서 JSON Schema `format` 힌트(WebFetch `url`의 `format: "uri"` 등)를 제거하고 `$defs` 하위 스키마에도 동일한 strict 정화를 적용하여, OpenAI가 허용하지 않는 format 값이 Codex 경로에서 요청 전체를 400 스키마 오류로 실패시키지 않도록 수정했습니다.

--- a/packages/core-ai-gateway/src/openai-responses-adapter.ts
+++ b/packages/core-ai-gateway/src/openai-responses-adapter.ts
@@ -638,7 +638,6 @@ const STRICT_ALLOWED_KEYWORDS = new Set([
   "$ref",
   "description",
   "title",
-  "format",
   "pattern",
   "minimum",
   "maximum",
@@ -652,6 +651,7 @@ const STRICT_ALLOWED_KEYWORDS = new Set([
   // Dropped by `strictSchema` before the schema reaches the wire.
   "$schema",
   "default",
+  "format",
 ]);
 
 /** Whether every subschema stays inside the subset strict mode accepts. */
@@ -699,15 +699,25 @@ function strictSchema(schema: unknown): unknown {
   const next: Record<string, unknown> = { ...schema };
 
   // Metadata strict mode has no use for: `$schema` is a dialect marker it does not accept, and
-  // `default` is meaningless once every property is required.
+  // `default` is meaningless once every property is required. `format` is validated against a
+  // closed set of values strict mode enumerates — `uri` (WebFetch.url) is rejected with a
+  // request-wide 400 — so the advisory hint is stripped rather than gambling the request on it.
   delete next.$schema;
   delete next.default;
+  delete next.format;
 
   for (const key of ["anyOf", "oneOf", "allOf"] as const) {
     const branches = next[key];
     if (Array.isArray(branches)) next[key] = branches.map(strictSchema);
   }
   if (isRecord(next.items)) next.items = strictSchema(next.items);
+  if (isRecord(next.$defs)) {
+    const rewrittenDefs: Record<string, unknown> = {};
+    for (const [name, value] of Object.entries(next.$defs)) {
+      rewrittenDefs[name] = strictSchema(value);
+    }
+    next.$defs = rewrittenDefs;
+  }
 
   const properties = next.properties;
   if (isRecord(properties)) {

--- a/packages/core-ai-gateway/src/openai-responses-adapter.ts
+++ b/packages/core-ai-gateway/src/openai-responses-adapter.ts
@@ -787,9 +787,18 @@ function withoutNulls(value: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
     if (entry === null) continue;
-    out[key] = isRecord(entry) ? withoutNulls(entry) : entry;
+    out[key] = withoutNullMembers(entry);
   }
   return out;
+}
+
+// strict 재작성의 정확한 역변환: 재작성이 표현 가능하게 만든 것은 객체 프로퍼티 위치의
+// null뿐이므로 배열 속 객체까지 내려가 그 null만 제거하고, 배열 원소 자체의 null은
+// 재작성이 만든 값이 아니라 모델이 실제로 보낸 데이터이므로 보존한다.
+function withoutNullMembers(entry: unknown): unknown {
+  if (isRecord(entry)) return withoutNulls(entry);
+  if (Array.isArray(entry)) return entry.map(withoutNullMembers);
+  return entry;
 }
 
 function outputItem(value: unknown): CanonicalOutputItem | undefined {

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -2204,6 +2204,57 @@ describe("OpenAI Responses adapter", () => {
     expect(new Headers(init?.headers).get("authorization")).toBe("Bearer injected-key");
   });
 
+  it("strips synthetic nulls from objects inside array arguments while keeping null elements", async () => {
+    const upstreamSse = [
+      frame("response.created", {
+        type: "response.created",
+        response: { id: "resp_array_nulls", model: "gpt-5.5", usage: null }
+      }),
+      frame("response.output_item.added", {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: {
+          type: "function_call",
+          id: "fc_array",
+          call_id: "call_array",
+          name: "open_links",
+          arguments: ""
+        }
+      }),
+      frame("response.output_item.done", {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          type: "function_call",
+          id: "fc_array",
+          call_id: "call_array",
+          name: "open_links",
+          arguments: '{"links":[{"href":"https://a.example","label":null}],"tags":["a",null]}'
+        }
+      }),
+      frame("response.completed", {
+        type: "response.completed",
+        response: { id: "resp_array_nulls", model: "gpt-5.5", usage: { input_tokens: 5, output_tokens: 3 } }
+      })
+    ].join("");
+    const fetchMock = vi.fn<FetchLike>(async () => sseResponse(upstreamSse));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+    const result = await adapter.stream(
+      { model: "gpt-5.5", input: [], stream: true },
+      { apiKey: "injected-key" }
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected a successful stream");
+    }
+    const frames = parseSse(await collectBody(encodeAnthropicSse(result.events)));
+    const deltas = frames.filter((item) => item.event === "content_block_delta");
+    expect(
+      deltas.map((item) => (item.data.delta as { partial_json: string }).partial_json).join("")
+    ).toBe('{"links":[{"href":"https://a.example"}],"tags":["a",null]}');
+  });
+
   it("carries a real OpenAI usage envelope end-to-end into matching streaming and non-streaming Anthropic usage", async () => {
     const upstreamSse = [
       frame("response.created", {

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -1537,6 +1537,105 @@ describe("OpenAI Responses adapter", () => {
     }]);
   });
 
+  it("strips format hints during the strict rewrite instead of forfeiting it or the request", async () => {
+    // Observed rejection: 400 "Invalid schema for function 'WebFetch': In context=
+    // ('properties', 'url'), 'uri' is not a valid format." Strict mode validates `format`
+    // against a closed value set, so the hint must not reach the wire.
+    const fetchMock = vi.fn<FetchLike>(async () => new Response(
+      JSON.stringify({ error: { message: "stop after capture" } }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    ));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+
+    await adapter.stream({
+      model: "gpt-5.6-sol",
+      input: [],
+      tools: [{
+        type: "function",
+        name: "WebFetch",
+        parameters: {
+          type: "object",
+          properties: {
+            url: { type: "string", format: "uri" },
+            prompt: { type: "string" },
+          },
+          required: ["url", "prompt"],
+          additionalProperties: false,
+        },
+      }],
+      stream: true,
+    }, { apiKey: "platform-key" });
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.tools).toEqual([{
+      type: "function",
+      name: "WebFetch",
+      parameters: {
+        type: "object",
+        properties: {
+          url: { type: "string" },
+          prompt: { type: "string" },
+        },
+        required: ["url", "prompt"],
+        additionalProperties: false,
+      },
+      strict: true,
+    }]);
+  });
+
+  it("rewrites $defs subschemas with the same strict cleanup as inline subschemas", async () => {
+    const fetchMock = vi.fn<FetchLike>(async () => new Response(
+      JSON.stringify({ error: { message: "stop after capture" } }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    ));
+    const adapter = new OpenAIResponsesAdapter({ fetch: fetchMock });
+
+    await adapter.stream({
+      model: "gpt-5.6-sol",
+      input: [],
+      tools: [{
+        type: "function",
+        name: "open_link",
+        parameters: {
+          type: "object",
+          properties: { link: { $ref: "#/$defs/link" } },
+          required: ["link"],
+          $defs: {
+            link: {
+              type: "object",
+              properties: { href: { type: "string", format: "uri", default: "" } },
+              required: ["href"],
+            },
+          },
+        },
+      }],
+      stream: true,
+    }, { apiKey: "platform-key" });
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.tools).toEqual([{
+      type: "function",
+      name: "open_link",
+      parameters: {
+        type: "object",
+        properties: { link: { $ref: "#/$defs/link" } },
+        required: ["link"],
+        additionalProperties: false,
+        $defs: {
+          link: {
+            type: "object",
+            properties: { href: { type: "string" } },
+            required: ["href"],
+            additionalProperties: false,
+          },
+        },
+      },
+      strict: true,
+    }]);
+  });
+
   it("forwards a Codex Fast service tier to the ChatGPT Responses backend", async () => {
     const fetchMock = vi.fn<FetchLike>(async () => new Response(
       JSON.stringify({ error: { message: "stop after capture" } }),


### PR DESCRIPTION
## Summary
- codex 경로에서 Claude Code의 `WebFetch` 도구가 `url: { format: "uri" }`를 갖고 있어, strict 재작성 후 OpenAI가 요청 전체를 400(`'uri' is not a valid format`)으로 거부하는 결함을 수리합니다.
- OpenAI strict 모드는 `format` 키워드를 닫힌 값 집합에 대해 검증하므로, `format`을 `$schema`/`default`와 같은 "strictSchema가 와이어 도달 전 드롭하는 키워드" 그룹으로 이동했습니다. 자문적 힌트만 사라질 뿐 생략 보장(strict 재작성 ↔ null 스트립) 메커니즘은 불변입니다.
- 같은 메커니즘의 잔여 구멍인 `$defs` 미재귀를 봉합했습니다: `strictCompatible`은 `$defs` 하위 스키마를 허용 판정하면서 `strictSchema`는 정화하지 않아, `$defs` 안의 `format`/`default`/미재작성 객체가 동일 계열 400을 유발할 수 있었습니다.

## Test Plan
- [x] 관측된 WebFetch 거부를 재현하는 와이어 바디 회귀 테스트 추가 (`format: "uri"`가 strict 재작성 후 와이어에 남지 않음)
- [x] `$defs` 하위 스키마가 인라인 하위 스키마와 동일한 strict 정화를 받는지 회귀 테스트 추가
- [x] `packages/core-ai-gateway` vitest 219/219 통과
- [x] `tsc --noEmit` + `pnpm build` 통과

## Changelog
- [x] `.changelog.d/pr-492.md` — 문법·이중언어 요약·`compile-changelog-fragments.mjs --check` 검증 완료