### PR TITLE
feat(repository): zero-setup compare with default base and branch shortcuts

### DIFF
--- a/.changelog.d/pr-493.md
+++ b/.changelog.d/pr-493.md
@@ -1,0 +1,11 @@
+### fleet-plugin
+#### Added
+- [fleet-console] The Repository Compare view now prefills the base with the repository default branch (origin/HEAD, falling back to main/master) and the head with the current branch, then runs the comparison automatically on entry; a swap button exchanges base and head.
+  ko: Repository 비교 뷰가 base를 저장소 기본 브랜치(origin/HEAD, main/master 폴백)로, head를 현재 브랜치로 프리필하고 진입 시 비교를 자동 실행합니다. 교환 버튼으로 base와 head를 맞바꿀 수 있습니다.
+- [fleet-console] Branch rows in the Repository panel gain a hover compare action and a context menu (compare with current branch, compare with base) that open the Compare view prefilled and already run.
+  ko: Repository 패널의 브랜치 행에 hover 비교 액션과 컨텍스트 메뉴(현재 브랜치와 비교·베이스와 비교)가 추가되어, 비교 뷰가 프리필된 상태로 즉시 실행됩니다.
+#### Fixed
+- [fleet-console] The Compare run button no longer clips off-screen at the default rail width; controls wrap on narrow panes and long ref labels ellipsize.
+  ko: 기본 레일 폭에서 비교 실행 버튼이 화면 밖으로 잘리던 문제를 수리했습니다. 좁은 페인에서는 컨트롤이 줄바꿈되고 긴 ref 라벨은 말줄임됩니다.
+- [fleet-console] Repository hunk endpoints now pass --no-ext-diff and --no-textconv, so repository-local diff drivers and textconv commands can no longer execute from browser-triggered diffs.
+  ko: Repository hunk 엔드포인트가 --no-ext-diff와 --no-textconv를 사용해, 저장소-로컬 diff driver와 textconv 명령이 브라우저에서 유발된 diff로 실행될 수 없습니다.

--- a/runtime/fleet-plugins/repository/client/compare-view.tsx
+++ b/runtime/fleet-plugins/repository/client/compare-view.tsx
@@ -17,6 +17,7 @@ interface CompareViewProps {
   readonly ctx: RailPanelContext;
   readonly repoRel: string;
   readonly refs: RepositoryRefs;
+  readonly request?: { base: string; head: string; seq: number } | null;
   readonly refsError?: boolean;
   readonly onRetryRefs?: () => void;
   readonly onFileOpenChange?: (open: boolean) => void;
@@ -63,7 +64,7 @@ function saveCompareSelection(theaterId: string, repoRel: string, base: string, 
 
 // ─── CompareView ─────────────────────────────────────────────────────────────
 
-export function CompareView({ ctx, repoRel, refs, refsError = false, onRetryRefs, onFileOpenChange }: CompareViewProps) {
+export function CompareView({ ctx, repoRel, refs, request, refsError = false, onRetryRefs, onFileOpenChange }: CompareViewProps) {
   const t = getT(ctx.language);
   const [initialCache] = useState(() => ctx.theaterId ? readCompareViewState(ctx.theaterId, repoRel) : null);
   const initialResult: CompareState = initialCache?.result ?? { kind: "idle" };
@@ -85,7 +86,9 @@ export function CompareView({ ctx, repoRel, refs, refsError = false, onRetryRefs
   const cacheFrameRef = useRef<number | null>(null);
   const dragDisposeRef = useRef<(() => void) | null>(null);
   const hydratedRef = useRef(false);
+  const autoRanRef = useRef(false);
   const requestSeqRef = useRef(0);
+  const handledRequestSeqRef = useRef(0);
 
   const remoteRefs = useMemo(() => refs.remotes.filter((item) => !isRemoteHeadRef(item.ref)), [refs.remotes]);
   const currentBranch = refs.branches.find((item) => item.current) ?? null;
@@ -98,19 +101,23 @@ export function CompareView({ ctx, repoRel, refs, refsError = false, onRetryRefs
   // refs 도착 후 1회 hydrate — 저장된 선택은 현재 refs 목록 대조로 read-time 검증한다
   useEffect(() => {
     const refsLoaded = refs.branches.length > 0 || remoteRefs.length > 0 || refs.tags.length > 0;
+    // refs 재조회 중 빈 배열 과도 상태에서는 모든 ref가 invalid로 보이므로,
+    // 로드 전에는 hydrate도 유효성 폴백도 수행하지 않는다(선택 소실 방지).
+    if (!refsLoaded) return;
     const defaultHead = currentBranch?.ref ?? "HEAD";
+    const fallbackBase = refs.defaultBase && isValidSelection(refs.defaultBase) && refs.defaultBase !== defaultHead ? refs.defaultBase : "";
     if (!hydratedRef.current) {
-      if (!refsLoaded || !ctx.theaterId) return;
+      if (!ctx.theaterId) return;
       hydratedRef.current = true;
       const stored = readCompareSelection(ctx.theaterId, repoRel);
-      setBase(stored && isValidSelection(stored.base) ? stored.base : "");
+      setBase(stored && isValidSelection(stored.base) ? stored.base : fallbackBase);
       setHead(stored && isValidSelection(stored.head) ? stored.head : defaultHead);
       return;
     }
     // refs 갱신으로 사라진 ref는 기본값으로 폴백한다
-    setBase((value) => value && !isValidSelection(value) ? "" : value);
+    setBase((value) => value && !isValidSelection(value) ? fallbackBase : value);
     setHead((value) => value && !isValidSelection(value) ? defaultHead : value);
-  }, [ctx.theaterId, currentBranch, isValidSelection, refs.branches.length, refs.tags.length, remoteRefs.length, repoRel]);
+  }, [ctx.theaterId, currentBranch, isValidSelection, refs.branches.length, refs.defaultBase, refs.tags.length, remoteRefs.length, repoRel]);
 
   useEffect(() => { onFileOpenChange?.(selected !== null); }, [onFileOpenChange, selected]);
   useEffect(() => () => dragDisposeRef.current?.(), []);
@@ -171,13 +178,19 @@ export function CompareView({ ctx, repoRel, refs, refsError = false, onRetryRefs
     if (ctx.theaterId) saveCompareSelection(ctx.theaterId, repoRel, nextBase, nextHead);
   }, [base, ctx.theaterId, head, repoRel]);
 
-  const runCompare = useCallback(() => {
-    if (!ctx.theaterId || !base || !head || base === head) return;
+  const swapRefs = useCallback(() => {
+    setBase(head);
+    setHead(base);
+    if (ctx.theaterId) saveCompareSelection(ctx.theaterId, repoRel, head, base);
+  }, [base, head, ctx.theaterId, repoRel]);
+
+  const runCompare = useCallback((baseRef: string = base, headRef: string = head) => {
+    if (!ctx.theaterId || !baseRef || !headRef || baseRef === headRef) return;
     const seq = ++requestSeqRef.current;
     setSelected(null);
     setResult({ kind: "loading" });
     // api.fetch는 non-2xx에서 payload를 버리고 throw하므로 오류 코드 매핑을 위해 raw fetch를 유지한다
-    fetch("/plugins/repository/compare", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ theaterId: ctx.theaterId, repoRel, base, head }) }).then(async (response) => {
+    fetch("/plugins/repository/compare", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ theaterId: ctx.theaterId, repoRel, base: baseRef, head: headRef }) }).then(async (response) => {
       if (seq !== requestSeqRef.current) return;
       if (!response.ok) {
         const payload = await response.json() as { readonly error?: string };
@@ -189,11 +202,31 @@ export function CompareView({ ctx, repoRel, refs, refsError = false, onRetryRefs
       }
       const data = await response.json() as CompareResult;
       if (seq !== requestSeqRef.current) return;
-      setResult({ kind: "ok", base, head, files: data.files, ...(data.mergeBase ? { mergeBase: data.mergeBase } : {}), ...(data.truncated ? { truncated: true } : {}) });
+      setResult({ kind: "ok", base: baseRef, head: headRef, files: data.files, ...(data.mergeBase ? { mergeBase: data.mergeBase } : {}), ...(data.truncated ? { truncated: true } : {}) });
     }).catch((error: unknown) => {
       if (seq === requestSeqRef.current) setResult({ kind: "error", message: error instanceof Error ? error.message : "unknown" });
     });
   }, [base, ctx.theaterId, head, repoRel]);
+
+  useEffect(() => {
+    if (!request || request.seq === handledRequestSeqRef.current) return;
+    handledRequestSeqRef.current = request.seq;
+    if (!isValidSelection(request.base) || !isValidSelection(request.head)) return;
+    setBase(request.base);
+    setHead(request.head);
+    if (ctx.theaterId) saveCompareSelection(ctx.theaterId, repoRel, request.base, request.head);
+    runCompare(request.base, request.head);
+  }, [ctx.theaterId, isValidSelection, repoRel, request, runCompare]);
+
+  useEffect(() => {
+    if (autoRanRef.current || !hydratedRef.current || !base || !head || base === head) return;
+    // 캐시 복원 결과가 현재 선택과 일치하면 재실행하지 않는다.
+    // 불일치(예: 체크아웃 변경 후 재진입으로 head 기본값이 이동)면 1회 갱신해 셀렉터-결과 정합을 지킨다.
+    const staleOk = result.kind === "ok" && (result.base !== base || result.head !== head);
+    if (result.kind !== "idle" && !staleOk) return;
+    autoRanRef.current = true;
+    runCompare();
+  }, [base, head, result, runCompare]);
 
   const handleDividerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -228,8 +261,8 @@ export function CompareView({ ctx, repoRel, refs, refsError = false, onRetryRefs
     return options;
   }, [refs.branches, refs.tags, remoteRefs, showHeadOption, t]);
   const baseRefOptions = useMemo(
-    (): readonly SelectOption[] => [{ value: "", label: t("repository.compare.selectBase"), disabled: true }, ...headRefOptions],
-    [headRefOptions, t],
+    (): readonly SelectOption[] => [{ value: "", label: t("repository.compare.selectBase"), disabled: true }, ...headRefOptions.map((option) => option.value === refs.defaultBase ? { ...option, label: `${option.label} · ${t("repository.compare.baseBadge")}` } : option)],
+    [headRefOptions, refs.defaultBase, t],
   );
   const refSelect = (side: "base" | "head", value: string) => (
     <Select
@@ -253,14 +286,15 @@ export function CompareView({ ctx, repoRel, refs, refsError = false, onRetryRefs
     <div className="repository-compare">
       {refsError ? <div className="history-error">{t("repository.discovery.loadRefsFailed")}<button type="button" className="repository-refresh-btn" onClick={onRetryRefs}>{t("repository.common.retry")}</button></div> : <div className="repository-compare-controls">
         {refSelect("base", base)}
-        <span className="repository-compare-arrow" aria-hidden="true">…</span>
+        <button type="button" className="repository-compare-swap" disabled={!base || !head} onClick={swapRefs} title={t("repository.compare.swap")} aria-label={t("repository.compare.swap")}>⇄</button>
         {refSelect("head", head)}
-        <button type="button" className="repository-refresh-btn repository-compare-run" disabled={!canCompare} onClick={runCompare}>{t("repository.compare.run")}</button>
+        <button type="button" className="repository-refresh-btn repository-compare-run" disabled={!canCompare} onClick={() => runCompare()}>{t("repository.compare.run")}</button>
       </div>}
       <div ref={rootRef} className={`repository-root${selected ? " has-hunk" : ""}${isDragging ? " is-dragging" : ""}`} style={selected ? { gridTemplateColumns: buildDiffGridTemplate(listPaneWidth) } : undefined}>
         {selected && compareSelection ? <div className="repository-hunk-pane"><div className="repository-hunk-head"><span>{selected.path}</span><button type="button" onClick={() => setSelected(null)}>✕</button></div><HunkView ctx={ctx} repoRel={repoRel} file={selected} mode="unified" compare={compareSelection} /></div> : null}
         {selected ? <div className="repository-divider" onPointerDown={handleDividerDown} aria-hidden="true" /> : null}
         <div className="repository-list-pane repository-compare-results">
+          <span className="repository-sr-only" role="status">{result.kind === "ok" ? t("repository.compare.resultsAnnounce", { count: String(result.files.length) }) : ""}</span>
           {result.kind === "idle" && <div className="history-empty">{t("repository.compare.idle")}</div>}
           {result.kind === "loading" && <div className="history-empty">{t("repository.compare.comparing")}</div>}
           {result.kind === "ok" && result.files.length === 0 && <div className="history-empty">{t("repository.compare.noDifferences")}</div>}

--- a/runtime/fleet-plugins/repository/client/i18n/index.ts
+++ b/runtime/fleet-plugins/repository/client/i18n/index.ts
@@ -99,6 +99,9 @@ export const repositoryEn = {
 
   // compare
   "repository.compare.run": "Compare",
+  "repository.compare.swap": "Swap base and head",
+  "repository.compare.baseBadge": "base",
+  "repository.compare.resultsAnnounce": "Comparison finished — {count} files",
   "repository.compare.baseRef": "Base ref",
   "repository.compare.headRef": "Head ref",
   "repository.compare.selectBase": "Select base…",
@@ -111,6 +114,8 @@ export const repositoryEn = {
   "repository.compare.noMergeBase": "The selected refs share no common history.",
   "repository.compare.mergeBase": "merge-base",
   "repository.compare.capped": "Comparison capped — file list truncated.",
+  "repository.compare.withBase": "Compare with base",
+  "repository.compare.withCurrent": "Compare with current branch",
 
   // hunk
   "repository.hunk.diffTruncated": "Diff truncated",
@@ -201,6 +206,9 @@ export const repositoryKo: Record<keyof typeof repositoryEn, string> = {
   "repository.time.yesterday": "어제 {time}",
 
   "repository.compare.run": "비교",
+  "repository.compare.swap": "base와 head 교환",
+  "repository.compare.baseBadge": "베이스",
+  "repository.compare.resultsAnnounce": "비교 완료 — 파일 {count}개",
   "repository.compare.baseRef": "Base ref",
   "repository.compare.headRef": "Head ref",
   "repository.compare.selectBase": "base 선택…",
@@ -213,6 +221,8 @@ export const repositoryKo: Record<keyof typeof repositoryEn, string> = {
   "repository.compare.noMergeBase": "선택한 refs에 공통 이력이 없습니다.",
   "repository.compare.mergeBase": "merge-base",
   "repository.compare.capped": "비교 한도 — 파일 목록이 잘렸습니다.",
+  "repository.compare.withBase": "베이스와 비교",
+  "repository.compare.withCurrent": "현재 브랜치와 비교",
 
   "repository.hunk.diffTruncated": "Diff가 잘림",
 };

--- a/runtime/fleet-plugins/repository/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/rail-panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type RefObject } from "react";
 
 import type { Translate } from "@fleet-console/sdk/i18n";
 import type { RailPanelContext, RailPanelDescriptor } from "@fleet-console/sdk/rail";
@@ -121,10 +121,11 @@ type RefSource = "branches" | "tags" | "stashes";
 type SourceIconKind = Source | RefSource | "repositories" | "worktrees";
 export type RepositoryRefItem = { label: string; ref: string; current: boolean };
 export type RepositoryStash = { name: string; subject: string };
-export type RepositoryRefs = { branches: RepositoryRefItem[]; remotes: RepositoryRefItem[]; tags: RepositoryRefItem[]; stashes: RepositoryStash[] };
+export type RepositoryRefs = { branches: RepositoryRefItem[]; remotes: RepositoryRefItem[]; tags: RepositoryRefItem[]; stashes: RepositoryStash[]; readonly defaultBase?: string };
 export type RepositoryRefRow = { key: string; source: RefSource; primary: string; sub?: string; ref: string | null; current: boolean };
 export type RepositoryRefGroup = { label?: "LOCAL" | "REMOTES"; rows: RepositoryRefRow[] };
 type Refs = RepositoryRefs;
+type RefContextMenuState = { readonly row: RepositoryRefRow; readonly anchor: { readonly x: number; readonly y: number } };
 
 // 사용자 제스처 선택의 착지 결정 — 컨텍스트 전환 여부와 무관하게 History로 착지한다(refs 선택과 동일 문법).
 export function resolveRepositorySelection(theaterId: string | null, currentRel: string, nextRel: string): { readonly transition: boolean; readonly landing: Source } {
@@ -175,6 +176,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
   const [changedFiles, setChangedFiles] = useState<ChangedFilesState>({ kind: "loading" });
   const [changedFilesRetry, setChangedFilesRetry] = useState(0);
   const [historyExternalRefreshToken, setHistoryExternalRefreshToken] = useState(0);
+  const [compareRequest, setCompareRequest] = useState<{ base: string; head: string; seq: number } | null>(null);
   const [syncing, setSyncing] = useState(false);
   const syncRequestIdRef = useRef(0);
   const autoSyncTheaterRef = useRef<string | null>(null);
@@ -258,6 +260,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
     syncRequestIdRef.current += 1;
     setSyncing(false);
     setChangedFiles({ kind: "loading" });
+    setCompareRequest(null);
     setRefs({ branches: [], remotes: [], tags: [], stashes: [] });
     repoRelRef.current = nextRepoRel;
     setRepoRel(nextRepoRel);
@@ -475,6 +478,11 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
     document.addEventListener("pointerup", onUp);
   }, []);
 
+  const openCompare = useCallback((base: string, head: string) => {
+    setSource("compare");
+    setCompareRequest((prev) => ({ base, head, seq: (prev?.seq ?? 0) + 1 }));
+  }, [setSource]);
+
   const hunkMode = selectedFile ? getHunkMode(selectedFile) : null;
   const retryChangedFiles = useCallback(() => setChangedFilesRetry((value) => value + 1), []);
   const handleToggleChangeFolder = useCallback((path: string) => {
@@ -495,7 +503,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
       <ChangedFiles state={changedFiles} onRetry={retryChangedFiles} viewMode={viewMode} selectedPath={selectedFile?.entry.path ?? null} onSelect={handleSelectFile} filterText={filterText} t={t} collapsedFolders={collapsedChangeFolders} onToggleFolder={handleToggleChangeFolder} scrollContainerRef={changesListRef} onScroll={updateChangesScroll} />
     </div>
   </div>;
-  const compareView = <CompareView key={`${ctx.theaterId ?? ""}:${repoRel}`} ctx={ctx} repoRel={repoRel} refs={refs} refsError={refsError} onRetryRefs={() => setRefsRetry((value) => value + 1)} />;
+  const compareView = <CompareView key={`${ctx.theaterId ?? ""}:${repoRel}`} ctx={ctx} repoRel={repoRel} refs={refs} request={compareRequest} refsError={refsError} onRetryRefs={() => setRefsRetry((value) => value + 1)} />;
   // 컴팩트 레이아웃과 동일하게 Changes/Compare를 hidden으로 상시 마운트해 섹션 전환에도 내부 상태를 보존한다.
   const workspaceMainVisible = source === "changes" || source === "compare";
   const workspaceMain = <>
@@ -506,7 +514,7 @@ function RepositoryPanelBody({ ctx }: RepositoryPanelProps) {
     <div className="repository-unified is-workspace">
       <div className={`repository-identity${repoRel ? " is-subcontext" : ""}`}><RepositoryIcon /><strong>{selectedRepo?.name ?? t("repository.panel.title")}</strong>{selectedRepo?.branch && <span>{selectedRepo.branch}</span>}<button type="button" className={`repository-sync-button${syncing ? " is-syncing" : ""}`} title={t("repository.sync.title")} aria-label={t("repository.sync.title")} disabled={syncing} onClick={() => { void syncRepository(); }}><span className="repository-sync-icon" aria-hidden="true">↻</span>{t("repository.sync.button")}</button></div>
       <div ref={layoutRef} className={`repository-ws-layout${isTreeDragging ? " is-dragging" : ""}`} style={{ "--ws-tree-width": `${treeWidth}px` } as React.CSSProperties}>
-        <WorkspaceTree theaterId={ctx.theaterId ?? ""} t={t} repos={repos} reposError={reposError} reposTruncated={reposTruncated} scanDepth={scanDepth} worktrees={worktrees} worktreesError={worktreesError} refs={refs} refsError={refsError} changedFiles={changedFiles} selectedRel={repoRel} source={source} refFilter={refFilter} onRepository={handleSelectRepository} onScanDepth={setScanDepth} onRetryRepos={() => setReposRetry((value) => value + 1)} onRetryWorktrees={() => setWorktreesRetry((value) => value + 1)} onRetryRefs={() => setRefsRetry((value) => value + 1)} onSource={setSource} onRef={(ref) => { setRefFilter(ref); setSource("history"); }} />
+        <WorkspaceTree theaterId={ctx.theaterId ?? ""} t={t} repos={repos} reposError={reposError} reposTruncated={reposTruncated} scanDepth={scanDepth} worktrees={worktrees} worktreesError={worktreesError} refs={refs} refsError={refsError} changedFiles={changedFiles} selectedRel={repoRel} source={source} refFilter={refFilter} onRepository={handleSelectRepository} onScanDepth={setScanDepth} onRetryRepos={() => setReposRetry((value) => value + 1)} onRetryWorktrees={() => setWorktreesRetry((value) => value + 1)} onRetryRefs={() => setRefsRetry((value) => value + 1)} onSource={setSource} onRef={(ref) => { setRefFilter(ref); setSource("history"); }} onCompare={openCompare} />
         <div className="repository-divider repository-ws-tree-divider" onPointerDown={handleTreeDividerDown} role="separator" aria-orientation="vertical" aria-label={t("repository.common.resizeSourceTree")} />
         <HistoryPanel key={`${ctx.theaterId ?? ""}:${repoRel}:${historyLandingEpoch}`} cacheScope={`${ctx.theaterId ?? ""}:${repoRel}`} ctx={ctx} repoRel={repoRel} externalRefreshToken={historyExternalRefreshToken} active refFilter={refFilter} wipFiles={wipFiles} workspace workspaceMain={workspaceMain} workspaceMainVisible={workspaceMainVisible} onClearRef={() => setRefFilter(null)} onWip={() => setSource("changes")} />
       </div>
@@ -536,13 +544,16 @@ interface WorkspaceTreeProps {
   readonly onRetryRefs: () => void;
   readonly onSource: (source: Source) => void;
   readonly onRef: (ref: string) => void;
+  readonly onCompare: (base: string, head: string) => void;
 }
 
-export function WorkspaceTree({ theaterId = "", t, repos, reposError, reposTruncated, scanDepth, worktrees, worktreesError, refs, refsError, changedFiles, selectedRel, source, refFilter, onRepository, onScanDepth, onRetryRepos, onRetryWorktrees, onRetryRefs, onSource, onRef }: WorkspaceTreeProps) {
+export function WorkspaceTree({ theaterId = "", t, repos, reposError, reposTruncated, scanDepth, worktrees, worktreesError, refs, refsError, changedFiles, selectedRel, source, refFilter, onRepository, onScanDepth, onRetryRepos, onRetryWorktrees, onRetryRefs, onSource, onRef, onCompare }: WorkspaceTreeProps) {
   const [initialTreeState] = useState(() => readWorkspaceTreeState(theaterId));
   const [query, setQuery] = useState(initialTreeState?.query ?? "");
   const [collapsedSections, setCollapsedSections] = useState(() => new Set(initialTreeState?.collapsedSections ?? ["tags", "stashes"]));
   const [collapsedFolders, setCollapsedFolders] = useState(() => new Set(initialTreeState?.collapsedFolders ?? []));
+  const [refContextMenu, setRefContextMenu] = useState<RefContextMenuState | null>(null);
+  const [treeRef] = useState<RefObject<HTMLElement | null>>(() => ({ current: null }));
   const handleToggleRepoFolder = (path: string) => {
     setCollapsedFolders((current) => {
       const next = new Set(current);
@@ -586,13 +597,28 @@ export function WorkspaceTree({ theaterId = "", t, repos, reposError, reposTrunc
       <span>{section.label}</span><i>{section.count}</i>
     </button>;
   };
+  const currentBranchRef = refs.branches.find((item) => item.current)?.ref ?? null;
   const refRows = (refSource: RefSource) => buildRefListGroups(refSource, refs).map((group) => <div key={group.label ?? refSource} className="repository-ws-ref-group">
     {group.label && <span className="repository-ws-ref-subhead">{t(group.label === "LOCAL" ? "repository.refs.local" : "repository.refs.remotes")}</span>}
-    {group.rows.map((row) => <button type="button" key={row.key} className={`repository-ws-tree-row${row.current ? " is-current" : ""}${source === "history" && row.ref === refFilter ? " is-active" : ""}`} disabled={row.ref === null} onClick={() => row.ref && onRef(row.ref)}>
+    {/* 브랜치 행은 role=button 자손에 interactive content가 금지되므로(ARIA-in-HTML)
+        래퍼 div + 형제 네이티브 버튼 2개(행 본체·비교 액션)로 구성한다 */}
+    {group.rows.map((row) => row.source === "branches" && row.ref ? <div
+      key={row.key}
+      className={`repository-ws-tree-row is-branch${row.current ? " is-current" : ""}${source === "history" && row.ref === refFilter ? " is-active" : ""}`}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        setRefContextMenu({ row, anchor: { x: event.clientX, y: event.clientY } });
+      }}
+    >
+      <button type="button" className="repository-ws-tree-row-main" onClick={() => onRef(row.ref!)}>
+        <SourceIcon source={row.source} /><span>{row.primary}</span>{row.current && <i>HEAD</i>}
+      </button>
+      {refs.defaultBase && row.ref !== refs.defaultBase ? <button type="button" className="repository-tree-action" title={t("repository.compare.withBase")} aria-label={t("repository.compare.withBase")} onClick={() => onCompare(refs.defaultBase!, row.ref!)}>⇆</button> : null}
+    </div> : <button type="button" key={row.key} className={`repository-ws-tree-row${row.current ? " is-current" : ""}${source === "history" && row.ref === refFilter ? " is-active" : ""}`} disabled={row.ref === null} onClick={() => row.ref && onRef(row.ref)}>
       <SourceIcon source={row.source} /><span>{row.primary}</span>{row.current && <i>HEAD</i>}{row.sub && <i>{row.sub}</i>}
     </button>)}
   </div>);
-  return <aside className="repository-ws-tree">
+  return <aside ref={treeRef} className="repository-ws-tree">
     <RepositoryDiscovery t={t} query={query} onQuery={setQuery} totalCount={repos.length} matchedCount={matchedCount} scanDepth={scanDepth} onScanDepth={onScanDepth} truncated={reposTruncated} onEnter={() => {
       const first = rootMatches[0] ?? nestedMatches[0];
       if (first) onRepository(first);
@@ -621,7 +647,87 @@ export function WorkspaceTree({ theaterId = "", t, repos, reposError, reposTrunc
       <section className={`repository-ws-section${collapsedSections.has("tags") ? " is-collapsed" : ""}`}>{sectionHeader("tags")}{!collapsedSections.has("tags") && !refsError && refRows("tags")}</section>
       <section className={`repository-ws-section${collapsedSections.has("stashes") ? " is-collapsed" : ""}`}>{sectionHeader("stashes")}{!collapsedSections.has("stashes") && !refsError && refRows("stashes")}</section>
     </WorkspaceTreeScroll>
+    {refContextMenu ? <RepositoryRefContextMenu
+      key={`${refContextMenu.row.key}:${refContextMenu.anchor.x}:${refContextMenu.anchor.y}`}
+      anchor={refContextMenu.anchor}
+      boundaryRef={treeRef}
+      rowRef={refContextMenu.row.ref!}
+      currentRef={currentBranchRef}
+      defaultBase={refs.defaultBase}
+      t={t}
+      onCompare={onCompare}
+      onClose={() => setRefContextMenu(null)}
+    /> : null}
   </aside>;
+}
+
+function clampRepositoryContextMenuPosition(anchor: { readonly x: number; readonly y: number }, bounds: DOMRect, menuSize: DOMRect, margin = 4) {
+  const requestedLeft = anchor.x - bounds.left;
+  const requestedTop = anchor.y - bounds.top;
+  return {
+    x: Math.max(margin, Math.min(requestedLeft, Math.max(margin, bounds.width - menuSize.width - margin))),
+    y: Math.max(margin, Math.min(requestedTop, Math.max(margin, bounds.height - menuSize.height - margin))),
+  };
+}
+
+function RepositoryRefContextMenu({ anchor, boundaryRef, rowRef, currentRef, defaultBase, t, onCompare, onClose }: {
+  readonly anchor: { readonly x: number; readonly y: number };
+  readonly boundaryRef: RefObject<HTMLElement | null>;
+  readonly rowRef: string;
+  readonly currentRef: string | null;
+  readonly defaultBase?: string;
+  readonly t: T;
+  readonly onCompare: (base: string, head: string) => void;
+  readonly onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState<{ readonly x: number; readonly y: number } | null>(null);
+  useLayoutEffect(() => {
+    const menu = menuRef.current;
+    const boundary = boundaryRef.current;
+    if (!menu || !boundary) return;
+    const updatePosition = () => setPosition(clampRepositoryContextMenuPosition(anchor, boundary.getBoundingClientRect(), menu.getBoundingClientRect()));
+    updatePosition();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(updatePosition);
+    observer.observe(menu);
+    observer.observe(boundary);
+    return () => observer.disconnect();
+  }, [anchor, boundaryRef]);
+  useEffect(() => {
+    const focusFrame = window.requestAnimationFrame(() => menuRef.current?.querySelector<HTMLButtonElement>("button:not(:disabled)")?.focus());
+    return () => window.cancelAnimationFrame(focusFrame);
+  }, []);
+  useEffect(() => {
+    const handleOutsidePointer = (event: PointerEvent) => {
+      if (event.target instanceof Node && !menuRef.current?.contains(event.target)) onClose();
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      onClose();
+    };
+    const handleScroll = () => onClose();
+    document.addEventListener("pointerdown", handleOutsidePointer, true);
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("scroll", handleScroll, true);
+    return () => {
+      document.removeEventListener("pointerdown", handleOutsidePointer, true);
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("scroll", handleScroll, true);
+    };
+  }, [onClose]);
+  const style: CSSProperties = position ? { left: position.x, top: position.y } : { left: 0, top: 0, visibility: "hidden" };
+  const activate = (base: string | null | undefined) => {
+    if (!base || base === rowRef) return;
+    onClose();
+    onCompare(base, rowRef);
+  };
+  return <div ref={menuRef} className="repository-context-menu" role="menu" style={style}>
+    <button type="button" className="repository-context-menu-item" role="menuitem" disabled={!currentRef || currentRef === rowRef} onClick={() => activate(currentRef)}>{t("repository.compare.withCurrent")}</button>
+    <button type="button" className="repository-context-menu-item" role="menuitem" disabled={!defaultBase || defaultBase === rowRef} onClick={() => activate(defaultBase)}>{t("repository.compare.withBase")}</button>
+  </div>;
 }
 
 function WorkspaceTreeScroll({ theaterId, query, collapsedSections, collapsedFolders, initialScrollTop, contentVersion, children }: {

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -1,5 +1,14 @@
 /* Diff rail panel styles */
 
+.repository-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 /* ── 루트 레이아웃 ── */
 .repository-root {
   display: grid;
@@ -1023,7 +1032,7 @@
 @keyframes repository-sync-spin { to { transform: rotate(360deg); } }
 @media (prefers-reduced-motion: reduce) { .repository-sync-button.is-syncing .repository-sync-icon { animation: none; } }
 /* 숨김-마운트 래퍼가 높이 문맥을 끊으면 history-root의 height:100%가 내용 높이로 풀려 내부 스크롤이 죽는다 */
-.repository-source-fill { height: 100%; min-height: 0; }
+.repository-source-fill { height: 100%; min-width: 0; min-height: 0; }
 .repository-discovery { display: flex; align-items: center; gap: 8px; flex: none; padding: 6px 10px; border-bottom: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--surface-band) 55%, transparent); }
 .repository-discovery-depth { display: inline-flex; align-items: center; gap: 3px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 10px; letter-spacing: .1em; text-transform: uppercase; }
 .repository-depth-step { border: 0; background: none; color: var(--text-tertiary); cursor: pointer; font-family: var(--font-mono); font-size: 12px; padding: 0 3px; }
@@ -1071,6 +1080,8 @@
 }
 
 .repository-ws-tree {
+  /* 컨텍스트 메뉴(absolute)의 containing block — 없으면 상위 positioned 조상 기준으로 오배치된다 */
+  position: relative;
   display: flex;
   min-width: 0;
   min-height: 0;
@@ -1157,9 +1168,26 @@
   transition: color var(--duration-base) var(--ease-spring), background var(--duration-base) var(--ease-spring);
 }
 
-.repository-ws-tree-row:hover:not(:disabled) {
+.repository-ws-tree-row:hover:not(:disabled),
+.repository-ws-tree-row.is-branch:focus-within {
   background: color-mix(in oklch, var(--ink-fog) 9%, transparent);
   color: var(--text-primary);
+}
+
+/* 브랜치 행 본체 버튼 — 래퍼의 레이아웃/색을 그대로 잇는 투명 필 버튼 */
+.repository-ws-tree-row-main {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
 }
 
 .repository-ws-tree-row.is-active {
@@ -1177,21 +1205,24 @@
   color: var(--text-tertiary);
 }
 
-.repository-ws-tree-row > svg {
+.repository-ws-tree-row > svg,
+.repository-ws-tree-row-main > svg {
   width: 13px;
   height: 13px;
   flex: none;
   opacity: .85;
 }
 
-.repository-ws-tree-row > span {
+.repository-ws-tree-row > span,
+.repository-ws-tree-row-main > span {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.repository-ws-tree-row > i {
+.repository-ws-tree-row > i,
+.repository-ws-tree-row-main > i {
   margin-left: auto;
   overflow: hidden;
   color: var(--text-tertiary);
@@ -1205,6 +1236,101 @@
 
 .repository-ws-tree-row.is-current > i {
   color: var(--brass-ink);
+}
+
+.repository-tree-action {
+  display: none;
+  width: 22px;
+  height: 22px;
+  margin-left: auto;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.repository-tree-action:hover,
+.repository-tree-action:focus-visible {
+  border-color: var(--surface-rim);
+  background: color-mix(in oklch, var(--ink-fog) 9%, transparent);
+  color: var(--text-primary);
+  outline: none;
+}
+
+@media (hover: hover) {
+  .repository-ws-tree-row:hover > .repository-tree-action,
+  .repository-ws-tree-row:focus-within > .repository-tree-action {
+    display: inline-grid;
+    place-items: center;
+  }
+}
+
+@media (hover: none) {
+  .repository-tree-action {
+    display: inline-grid;
+    place-items: center;
+  }
+}
+
+.repository-context-menu {
+  position: absolute;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: max-content;
+  min-width: 196px;
+  max-width: calc(100% - 8px);
+  max-height: calc(100% - 8px);
+  overflow-y: auto;
+  padding: 6px;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-md);
+  background:
+    linear-gradient(
+      color-mix(in oklch, var(--surface-glass-strong) 88%, var(--ink-deep)),
+      color-mix(in oklch, var(--surface-glass-strong) 88%, var(--ink-deep))
+    ),
+    var(--ink-deep);
+  box-shadow: var(--shadow-anchor);
+}
+
+.repository-context-menu-item {
+  display: block;
+  width: 100%;
+  padding: 6px 9px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: var(--font-body);
+  font-size: 12px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.repository-context-menu-item:hover:not(:disabled) {
+  border-color: color-mix(in oklch, var(--ink-fog) 20%, transparent);
+  background: color-mix(in oklch, var(--ink-spectral) 8%, transparent);
+}
+
+.repository-context-menu-item:focus-visible {
+  outline: none;
+  border-color: color-mix(in oklch, var(--brass) 55%, var(--surface-rim));
+  background: var(--brass-glow);
+}
+
+.repository-context-menu-item:disabled {
+  color: var(--text-tertiary);
+  cursor: default;
+  opacity: .5;
 }
 
 .repository-ws-ref-group {
@@ -1344,11 +1470,15 @@
 }
 
 /* ── Compare 뷰 ── */
-.repository-compare { display: grid; grid-template-rows: auto minmax(0, 1fr); height: 100%; min-height: 0; }
-.repository-compare-controls { display: flex; align-items: center; gap: 6px; padding: 7px 10px; border-bottom: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--surface-band) 55%, transparent); }
+.repository-compare { display: grid; grid-template-rows: auto minmax(0, 1fr); height: 100%; min-width: 0; min-height: 0; container-type: inline-size; }
+.repository-compare-controls { display: flex; align-items: center; flex-wrap: wrap; min-width: 0; gap: 6px; padding: 7px 10px; border-bottom: 1px solid var(--surface-rim); background: color-mix(in oklch, var(--surface-band) 55%, transparent); }
 .repository-compare-controls .fc-select { flex: 1; min-width: 0; }
-.repository-compare-arrow { flex: none; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 12px; }
+.repository-compare-controls .fc-select__value { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.repository-compare-swap { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; padding: 0; border: 1px solid var(--surface-rim); border-radius: var(--radius-sm); background: none; color: var(--text-tertiary); cursor: pointer; flex: none; font-size: 12px; }
+.repository-compare-swap:hover:not(:disabled) { color: var(--text-secondary); }
+.repository-compare-swap:disabled,
 .repository-compare-run:disabled { opacity: .5; cursor: default; }
+@container (max-width: 359px) { .repository-compare-controls .repository-compare-run { flex: 1 0 100%; } }
 .repository-compare-results { display: flex; flex-direction: column; }
 .repository-compare-results .repository-sections { flex: 1; min-height: 0; }
 .repository-compare-results .history-truncated { flex: none; }

--- a/runtime/fleet-plugins/repository/server/commit-file.ts
+++ b/runtime/fleet-plugins/repository/server/commit-file.ts
@@ -45,8 +45,8 @@ export async function handleRepositoryCommitFile(req: http.IncomingMessage, res:
   if (!relativePath || (body.oldPath !== undefined && !oldPath)) { ctx.host.http.writeJson(res, 403, { error: "path_outside_theater" }); return; }
   try {
     const result = await runGit(oldPath
-      ? ["show", "--first-parent", body.ref, "-M", "--format=", "--unified=3", "--", literalPathspec(oldPath), literalPathspec(relativePath)]
-      : ["show", "--first-parent", body.ref, "--format=", "--unified=3", "--", literalPathspec(relativePath)], { cwd: cwdResult.gitCwd });
+      ? ["show", "--no-ext-diff", "--no-textconv", "--first-parent", body.ref, "-M", "--format=", "--unified=3", "--", literalPathspec(oldPath), literalPathspec(relativePath)]
+      : ["show", "--no-ext-diff", "--no-textconv", "--first-parent", body.ref, "--format=", "--unified=3", "--", literalPathspec(relativePath)], { cwd: cwdResult.gitCwd });
     ctx.host.http.writeJson(res, 200, { content: result.stdout, ...(result.truncated ? { truncated: true } : {}) });
   } catch (error) {
     if (error instanceof GitExecutorError) {

--- a/runtime/fleet-plugins/repository/server/compare-file.ts
+++ b/runtime/fleet-plugins/repository/server/compare-file.ts
@@ -45,9 +45,11 @@ export async function handleRepositoryCompareFile(req: http.IncomingMessage, res
   if (!relativePath || (body.oldPath !== undefined && !oldPath)) { ctx.host.http.writeJson(res, 403, { error: "path_outside_theater" }); return; }
   const range = `${body.base}...${body.head}`;
   try {
+    // repo-local diff driver/textconv(.gitattributes + .git/config)가 브라우저 클릭으로 실행되는
+    // 것을 차단한다 — hunk는 항상 git 내장 diff로 생성한다.
     const result = await runGit(oldPath
-      ? ["diff", "--unified=3", "-M", "--end-of-options", range, "--", literalPathspec(oldPath), literalPathspec(relativePath)]
-      : ["diff", "--unified=3", "-M", "--end-of-options", range, "--", literalPathspec(relativePath)], { cwd: cwdResult.gitCwd });
+      ? ["diff", "--no-ext-diff", "--no-textconv", "--unified=3", "-M", "--end-of-options", range, "--", literalPathspec(oldPath), literalPathspec(relativePath)]
+      : ["diff", "--no-ext-diff", "--no-textconv", "--unified=3", "-M", "--end-of-options", range, "--", literalPathspec(relativePath)], { cwd: cwdResult.gitCwd });
     ctx.host.http.writeJson(res, 200, { content: result.stdout, ...(result.truncated ? { truncated: true } : {}) });
   } catch (error) {
     if (error instanceof GitExecutorError) {

--- a/runtime/fleet-plugins/repository/server/diff.ts
+++ b/runtime/fleet-plugins/repository/server/diff.ts
@@ -257,7 +257,7 @@ export async function handleRepositoryFile(
       // (위의 lexical + realpath containment로 이미 방어). 여기에 :(literal)을 붙이면
       // git이 ":(literal)<path>"라는 없는 파일을 찾아 실패하므로 원본 경로를 그대로 전달한다.
       const result = await runGit(
-        ["diff", "--no-index", "--relative", "--unified=3", "--", "/dev/null", relativePath],
+        ["diff", "--no-ext-diff", "--no-textconv", "--no-index", "--relative", "--unified=3", "--", "/dev/null", relativePath],
         { cwd: gitCwd, allowExitCodes: [1] },
       );
       ctx.host.http.writeJson(res, 200, { content: result.stdout, truncated: result.truncated });
@@ -280,11 +280,11 @@ export async function handleRepositoryFile(
     }
     let result;
     try {
-      result = await runGit(["diff", "HEAD", "--relative", "--unified=3", "--", literalPathspec(relativePath)], { cwd: gitCwd });
+      result = await runGit(["diff", "--no-ext-diff", "--no-textconv", "HEAD", "--relative", "--unified=3", "--", literalPathspec(relativePath)], { cwd: gitCwd });
     } catch (err) {
       if (!isNoHeadError(err)) throw err;
       // no-HEAD 신규 저장소: staged hunk를 --cached로 조회 (changed 목록의 fallback과 동일)
-      result = await runGit(["diff", "--cached", "--relative", "--unified=3", "--", literalPathspec(relativePath)], { cwd: gitCwd });
+      result = await runGit(["diff", "--no-ext-diff", "--no-textconv", "--cached", "--relative", "--unified=3", "--", literalPathspec(relativePath)], { cwd: gitCwd });
     }
     ctx.host.http.writeJson(res, 200, { content: result.stdout, truncated: result.truncated });
   } catch (error) {

--- a/runtime/fleet-plugins/repository/server/refs.ts
+++ b/runtime/fleet-plugins/repository/server/refs.ts
@@ -6,6 +6,18 @@ import { InvalidRepoError, resolveGitCwd } from "./diff.js";
 function isObject(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null && !Array.isArray(value); }
 function lines(stdout: string): string[] { return stdout.split("\n").map((line) => line.trim()).filter(Boolean); }
 export function parseRefItems(stdout: string, current: string): { label: string; ref: string; current: boolean }[] { return lines(stdout).flatMap((line) => { const [ref, label] = line.split("\0"); return ref && label ? [{ ref, label, current: ref === current }] : []; }); }
+export function resolveDefaultBase(input: { originHead: string; branches: readonly { ref: string }[]; remotes: readonly { ref: string }[] }): string | null {
+  const originHead = input.originHead.trim();
+  const match = /^refs\/remotes\/origin\/(.+)$/.exec(originHead);
+  if (match) {
+    const localRef = `refs/heads/${match[1]}`;
+    if (input.branches.some((item) => item.ref === localRef)) return localRef;
+    if (input.remotes.some((item) => item.ref === originHead)) return originHead;
+  }
+  if (input.branches.some((item) => item.ref === "refs/heads/main")) return "refs/heads/main";
+  if (input.branches.some((item) => item.ref === "refs/heads/master")) return "refs/heads/master";
+  return null;
+}
 async function readStashes(gitCwd: string): Promise<string> {
   try {
     return (await runGit(["stash", "list", "--format=%gd%x00%s"], { cwd: gitCwd })).stdout;
@@ -29,17 +41,22 @@ export async function handleRepositoryRefs(req: http.IncomingMessage, res: http.
     throw error;
   }
   try {
-    const [head, local, remote, tags, stashes] = await Promise.all([
+    const [head, originHead, local, remote, tags, stashes] = await Promise.all([
       runGit(["symbolic-ref", "--quiet", "HEAD"], { cwd: resolved.gitCwd, allowExitCodes: [1] }),
+      runGit(["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"], { cwd: resolved.gitCwd, allowExitCodes: [1] }),
       runGit(["for-each-ref", "--format=%(refname)%00%(refname:short)", "refs/heads"], { cwd: resolved.gitCwd }),
       runGit(["for-each-ref", "--format=%(refname)%00%(refname:short)", "refs/remotes"], { cwd: resolved.gitCwd }),
       runGit(["for-each-ref", "--format=%(refname)%00%(refname:short)", "refs/tags"], { cwd: resolved.gitCwd }),
       readStashes(resolved.gitCwd),
     ]);
     const current = head.stdout.trim();
+    const branches = parseRefItems(local.stdout, current);
+    const remotes = parseRefItems(remote.stdout, current);
+    const defaultBase = resolveDefaultBase({ originHead: originHead.stdout, branches, remotes });
     ctx.host.http.writeJson(res, 200, {
-      branches: parseRefItems(local.stdout, current), remotes: parseRefItems(remote.stdout, current), tags: parseRefItems(tags.stdout, current),
+      branches, remotes, tags: parseRefItems(tags.stdout, current),
       stashes: lines(stashes).map((line) => { const [name, subject = ""] = line.split("\0"); return { name, subject }; }),
+      ...(defaultBase ? { defaultBase } : {}),
     });
   } catch (error) {
     if (error instanceof GitExecutorError && error.code === "no_git_repo") { ctx.host.http.writeJson(res, 200, { branches: [], remotes: [], tags: [], stashes: [] }); return; }

--- a/runtime/fleet-plugins/repository/tests/diff-driver-hardening.test.ts
+++ b/runtime/fleet-plugins/repository/tests/diff-driver-hardening.test.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
+
+import { handleRepositoryCompareFile } from "../server/compare-file.js";
+import { handleRepositoryCommitFile } from "../server/commit-file.js";
+import { handleRepositoryFile } from "../server/diff.js";
+import { runGit } from "../server/git-executor.js";
+
+interface JsonWrite {
+  readonly status: number;
+  readonly payload: unknown;
+}
+
+interface ContentPayload {
+  readonly content: string;
+}
+
+async function initGitRepo(dir: string): Promise<void> {
+  await runGit(["init"], { cwd: dir });
+  await runGit(["config", "user.email", "test@test.com"], { cwd: dir });
+  await runGit(["config", "user.name", "Test"], { cwd: dir });
+}
+
+function makeContext(theaterPath: string, body: Record<string, unknown>, writes: JsonWrite[]): FleetPluginServerContext {
+  return {
+    host: {
+      http: {
+        readJsonBody: async () => body,
+        writeJson: (_res: unknown, status: number, payload: unknown) => { writes.push({ status, payload }); },
+      },
+      security: { isTerminalAuthorized: () => true },
+      paths: { resolveTheaterPath: () => theaterPath },
+    },
+  } as unknown as FleetPluginServerContext;
+}
+
+// repo-local .gitattributes + .git/config의 custom diff driver/textconv가
+// hunk 조회(브라우저 클릭)로 실행되지 않아야 한다 — --no-ext-diff/--no-textconv 회귀 가드.
+describe("diff driver hardening", () => {
+  let tmpDir: string;
+  let theaterPath: string;
+  let driverMarker: string;
+  let textconvMarker: string;
+  let headRef: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "repo-diff-driver-"));
+    theaterPath = path.join(tmpDir, "repo");
+    driverMarker = path.join(tmpDir, "DRIVER_RAN");
+    textconvMarker = path.join(tmpDir, "TEXTCONV_RAN");
+    await fs.mkdir(theaterPath, { recursive: true });
+    await initGitRepo(theaterPath);
+
+    await fs.writeFile(path.join(theaterPath, "a.txt"), "one\n");
+    await fs.writeFile(path.join(theaterPath, ".gitattributes"), "*.txt diff=owned\n");
+    await runGit(["add", "."], { cwd: theaterPath });
+    await runGit(["commit", "-m", "base"], { cwd: theaterPath });
+    headRef = `refs/heads/${(await runGit(["rev-parse", "--abbrev-ref", "HEAD"], { cwd: theaterPath })).stdout.trim()}`;
+
+    await runGit(["checkout", "-b", "feature"], { cwd: theaterPath });
+    await fs.writeFile(path.join(theaterPath, "a.txt"), "two\n");
+    await runGit(["commit", "-am", "change"], { cwd: theaterPath });
+
+    const driverScript = path.join(tmpDir, "hook.sh");
+    const textconvScript = path.join(tmpDir, "tc.sh");
+    await fs.writeFile(driverScript, `#!/bin/sh\ntouch "${driverMarker}"\nexit 0\n`, { mode: 0o755 });
+    await fs.writeFile(textconvScript, `#!/bin/sh\ntouch "${textconvMarker}"\ncat "$1"\n`, { mode: 0o755 });
+    await runGit(["config", "diff.owned.command", driverScript], { cwd: theaterPath });
+    await runGit(["config", "diff.owned.textconv", textconvScript], { cwd: theaterPath });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function expectNoMarkers(): Promise<void> {
+    await expect(fs.access(driverMarker)).rejects.toThrow();
+    await expect(fs.access(textconvMarker)).rejects.toThrow();
+  }
+
+  it("compare-file hunks never invoke the repo-local driver or textconv", async () => {
+    const writes: JsonWrite[] = [];
+    const ctx = makeContext(theaterPath, { theaterId: "t1", base: headRef, head: "refs/heads/feature", filePath: "a.txt" }, writes);
+    await handleRepositoryCompareFile({ method: "POST" } as never, {} as never, ctx);
+    expect(writes[0]?.status).toBe(200);
+    expect((writes[0]?.payload as ContentPayload).content).toContain("+two");
+    await expectNoMarkers();
+  });
+
+  it("commit-file hunks never invoke the repo-local driver or textconv", async () => {
+    const writes: JsonWrite[] = [];
+    const featureSha = (await runGit(["rev-parse", "refs/heads/feature"], { cwd: theaterPath })).stdout.trim();
+    const ctx = makeContext(theaterPath, { theaterId: "t1", ref: featureSha, filePath: "a.txt" }, writes);
+    await handleRepositoryCommitFile({ method: "POST" } as never, {} as never, ctx);
+    expect(writes[0]?.status).toBe(200);
+    expect((writes[0]?.payload as ContentPayload).content).toContain("+two");
+    await expectNoMarkers();
+  });
+
+  it("working-changes hunks never invoke the repo-local driver or textconv", async () => {
+    await fs.writeFile(path.join(theaterPath, "a.txt"), "three\n");
+    const writes: JsonWrite[] = [];
+    const ctx = makeContext(theaterPath, { theaterId: "t1", filePath: "a.txt", mode: "unified" }, writes);
+    await handleRepositoryFile({ method: "POST" } as never, {} as never, ctx);
+    expect(writes[0]?.status).toBe(200);
+    expect((writes[0]?.payload as ContentPayload).content).toContain("+three");
+    await expectNoMarkers();
+  });
+});

--- a/runtime/fleet-plugins/repository/tests/refs-server.test.ts
+++ b/runtime/fleet-plugins/repository/tests/refs-server.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 
 import { runGit } from "../server/git-executor.js";
-import { handleRepositoryRefs } from "../server/refs.js";
+import { handleRepositoryRefs, resolveDefaultBase } from "../server/refs.js";
 
 async function initGitRepo(dir: string): Promise<void> {
   await runGit(["init"], { cwd: dir });
@@ -26,6 +26,30 @@ function makeRefsContext(theaterPath: string, writes: { status: number; payload:
     },
   } as unknown as FleetPluginServerContext;
 }
+
+describe("resolveDefaultBase", () => {
+  const branch = (ref: string) => ({ ref });
+
+  it("prefers the local branch targeted by origin/HEAD", () => {
+    expect(resolveDefaultBase({ originHead: "refs/remotes/origin/main\n", branches: [branch("refs/heads/main")], remotes: [branch("refs/remotes/origin/main")] })).toBe("refs/heads/main");
+  });
+
+  it("uses the remote target when origin/HEAD has no local branch", () => {
+    expect(resolveDefaultBase({ originHead: "refs/remotes/origin/main", branches: [], remotes: [branch("refs/remotes/origin/main")] })).toBe("refs/remotes/origin/main");
+  });
+
+  it("falls back to main when origin/HEAD is unavailable", () => {
+    expect(resolveDefaultBase({ originHead: "", branches: [branch("refs/heads/main")], remotes: [] })).toBe("refs/heads/main");
+  });
+
+  it("falls back to master after main", () => {
+    expect(resolveDefaultBase({ originHead: "", branches: [branch("refs/heads/master")], remotes: [] })).toBe("refs/heads/master");
+  });
+
+  it("returns null when no default branch exists", () => {
+    expect(resolveDefaultBase({ originHead: "", branches: [branch("refs/heads/topic")], remotes: [] })).toBeNull();
+  });
+});
 
 describe("handleRepositoryRefs", () => {
   let tmpDir: string;

--- a/runtime/fleet-plugins/repository/tests/workspace-tree-sections.test.ts
+++ b/runtime/fleet-plugins/repository/tests/workspace-tree-sections.test.ts
@@ -93,6 +93,7 @@ function renderWorkspaceTree(): ReactElement<ElementProps> {
     onRetryRefs: vi.fn(),
     onSource: vi.fn(),
     onRef: vi.fn(),
+    onCompare: vi.fn(),
   });
 }
 


### PR DESCRIPTION
## Summary
- 비교 뷰 제로-셋업: refs 응답에 `defaultBase`(origin/HEAD → 로컬 main/master 폴백)를 추가하고, 저장된 선택이 없으면 base=베이스 브랜치·head=현재 브랜치로 프리필 후 1회 자동 실행합니다(캐시 결과가 현재 선택과 불일치하면 1회 갱신). base 옵션에는 `· 베이스` 배지가 붙고, 결과 도착은 `role=status`로 고지됩니다.
- 컨트롤 행 도달성 수리: 기본 레일 폭(420px)에서 실행 버튼이 화면 밖으로 클리핑되던 결함을 수리했습니다(`min-width:0` 보강 + 컨테이너 쿼리로 좁은 폭에서 실행 버튼 전폭 줄내림 + 셀렉트 라벨 말줄임). base/head 교환(⇄) 버튼을 추가했습니다.
- 브랜치 행 직행: 로컬·원격 브랜치 행에 hover ⇆ 액션과 우클릭 컨텍스트 메뉴(현재 브랜치와 비교/베이스와 비교)를 추가해 비교 뷰를 프리필+실행합니다. 중첩 버튼 ARIA 위반을 피하도록 브랜치 행을 래퍼+형제 버튼 구조로 재편했습니다.
- 보안 하드닝: hunk 엔드포인트(compare-file·commit-file·작업 변경)에 `--no-ext-diff --no-textconv`를 부여해 repo-local diff driver/textconv 명령이 브라우저 클릭으로 실행되는 경로를 차단했습니다(재현 후 수리, 회귀 테스트 동반).

## Test Plan
- [x] `pnpm --filter @fleet-plugins/repository typecheck`
- [x] `pnpm --filter @fleet-plugins/repository test` (36 files / 334 tests, 신규: resolveDefaultBase 5건 + diff driver 하드닝 3건)
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] 격리 콘솔 console-e2e 실측: 진입 0클릭 자동 비교(base 배지 포함), 기본 폭에서 실행 버튼 가시, swap 동작·저장, hover ⇆ 직행, 컨텍스트 메뉴 위치·비활성 로직·Escape 닫힘, 페이지 에러 0
- [x] Changelog: `.changelog.d/pr-493.md` (grouped 문법, EN/ko 병기, `compile-changelog-fragments.mjs --check` 통과)
