### PR TITLE
fix(console): align triage deck status vocabulary with sidebar

### DIFF
--- a/.changelog.d/pr-500.md
+++ b/.changelog.d/pr-500.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Triage Watch Deck cards now use the same status vocabulary and ordering as the sidebar STATUS axis, so an idle operation no longer reads as awaiting, and background operations sort consistently between the two surfaces.
+  ko: 선별 처리 Watch Deck 카드가 사이드바 STATUS 축과 동일한 상태 명칭과 정렬 순서를 사용해, 유휴 오퍼레이션이 대기로 잘못 읽히지 않고 백그라운드 오퍼레이션도 두 표면에서 일관되게 정렬됩니다.

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -36,12 +36,14 @@ interface TriageDeckPromotionDecision {
 }
 
 export const TRIAGE_DECK_ARRIVAL_DWELL_MS = 1_100;
-// 카드 정렬 등급 — 운영자 응답을 기다리는 것이 맨 앞, 그다음 실행 중, 유휴 순.
+// 카드 정렬 등급 — 사이드바 STATUS 축의 섹션 순서(대기→실행 중→백그라운드→유휴→휴면)를 그대로
+// 따른다. deck이 자체 순서를 정의하면 같은 상태가 두 표면에서 다른 위치로 읽힌다.
 const TRIAGE_DECK_ACTIVITY_RANK: Record<OperationActivity, number> = {
   awaiting: 0,
   running: 1,
-  idle: 2,
-  dormant: 3,
+  background: 2,
+  idle: 3,
+  dormant: 4,
 };
 const deckCardRects = new Map<string, DOMRect>();
 const CARD_FLASH_DURATION_MS = 900;

--- a/runtime/fleet-console/core/client/src/i18n/messages/pages.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/pages.ts
@@ -473,11 +473,13 @@ export const pagesKo: Record<keyof typeof pagesEn, string> = {
   "whatsnew.tab.fleetCore": "Fleet Core",
   "whatsnew.tab.preProductGrouping": "제품 분류 이전 업데이트",
 
+  // 상태별 명칭은 사이드바 STATUS 축(sidebar.status.*)과 동일해야 한다 — 유휴 카드가 "대기"로
+  // 보이면 사이드바의 대기(awaiting) 섹션과 상태가 충돌해 다른 상태로 읽힌다.
   "activity.running": "실행 중",
   "activity.background": "백그라운드",
-  "activity.awaiting": "입력 대기",
+  "activity.awaiting": "대기",
   "activity.dormant": "휴면",
-  "activity.idle": "대기",
+  "activity.idle": "유휴",
 
   "codex.cowork.requestFailed": "Cowork 요청에 실패했습니다.",
   "codex.cowork.draftChangesAria": "초안 변경",


### PR DESCRIPTION
## Summary
- 선별 처리(Watch Deck) 카드의 상태 표기가 좌측 사이드바 STATUS 축과 어긋나던 문제를 수정합니다. 카드가 자체 어휘(유휴 상태를 "대기", 입력 대기 상태를 "입력 대기")를 쓰는 바람에, 사이드바 "유휴" 섹션의 오퍼레이션이 카드에서는 "대기"로 보여 사이드바의 대기(awaiting) 섹션과 상태가 충돌해 읽혔습니다. 이제 카드/칩 상태 라벨(`activity.*` ko)이 사이드바 어휘(`sidebar.status.*`: 대기·실행 중·백그라운드·유휴·휴면)를 그대로 따릅니다.
- Watch Deck 카드 정렬 등급에 누락돼 있던 `background` 상태를 추가하고, 정렬 순서를 사이드바 섹션 순서(대기→실행 중→백그라운드→유휴→휴면)와 일치시킵니다. `background` 활동 상태가 Watch Deck 이후에 합류하면서 생긴 타입 오류(`Record<OperationActivity, number>` 키 누락)도 함께 해소됩니다.
- 휴면(dormant) 오퍼레이션을 카드로 노출하지 않는 기존 동작은 그대로 유지합니다.

## Test Plan
- [x] `pnpm typecheck` (runtime/fleet-console) — 0 오류 (선존하던 triage-watch-deck.tsx 타입 오류 해소 포함)
- [x] `pnpm vitest run tests/i18n.test.ts tests/triage-store.test.ts tests/triage-stage-companion.test.ts` — 58/58 통과
- [x] Changelog fragment — `.changelog.d/pr-500.md` 추가, 그룹형 문법·이중 언어 요약·`node scripts/compile-changelog-fragments.mjs --check` 검증 완료