### PR TITLE
feat(console): toggle Settings screen via the command-band Settings button

### DIFF
--- a/.changelog.d/pr-501.md
+++ b/.changelog.d/pr-501.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Changed
+- [fleet-console] Toggle the Settings screen with the command-band Settings button: pressing it again while on Settings returns to the previous page, or to Operations when Settings was opened directly.
+  ko: 커맨드 밴드의 설정 버튼으로 설정 화면을 토글합니다. 설정 화면에서 다시 누류이면 이전 페이지로 돌아가며, 설정에 직접 진입한 경우에는 Operations로 돌아갑니다.

--- a/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
@@ -43,7 +43,11 @@ export function recordSettingsEntryIndex() {
 }
 
 export function propagateSettingsEntryIndex(state: unknown): Record<string, unknown> {
-  return settingsEntryIndex === null ? {} : { ...(state as Record<string, unknown> | null), settingsEntry: settingsEntryIndex };
+  // 현재 항목이 이미 마커를 들고 있으면(Back으로 재방문한 과거 설정 항목 등)
+  // 그 항목의 마커가 진실이다 — 세션 스코프 값은 최근 진입의 것일 뿐이다.
+  const existing = (state as { settingsEntry?: unknown } | null)?.settingsEntry;
+  const entry = typeof existing === "number" ? existing : settingsEntryIndex;
+  return entry === null ? {} : { ...(state as Record<string, unknown> | null), settingsEntry: entry };
 }
 
 // 시스템 클러스터는 커맨드 밴드 우측에 상주한다 — 사이드바 접힘·라우트 전환과 무관하게

--- a/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
@@ -45,7 +45,9 @@ export function recordSettingsEntryIndex() {
 export function propagateSettingsEntryIndex(state: unknown): Record<string, unknown> {
   // 현재 항목이 이미 마커를 들고 있으면(Back으로 재방문한 과거 설정 항목 등)
   // 그 항목의 마커가 진실이다 — 세션 스코프 값은 최근 진입의 것일 뿐이다.
+  // 명시적 null은 "이 방문은 무표시"라는 기록이므로 세션 값을 빌려오지 않는다.
   const existing = (state as { settingsEntry?: unknown } | null)?.settingsEntry;
+  if (existing === null) return { ...(state as Record<string, unknown> | null), settingsEntry: null };
   const entry = typeof existing === "number" ? existing : settingsEntryIndex;
   return entry === null ? {} : { ...(state as Record<string, unknown> | null), settingsEntry: entry };
 }

--- a/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type Dispatch, type RefObject, type SetStateAction } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import type { Translate } from "@fleet-console/sdk/i18n";
 
@@ -51,9 +51,18 @@ export function CommandBandSystemCluster() {
 function SettingsButton({ updateAvailable }: { readonly updateAvailable: boolean }) {
   const t = useT();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const goToSettings = () => {
-    navigate("/settings");
+    // 설정 화면에서 다시 누륄 때 토글로 닫는다 — 설정 내 섹션 이동은 search만 바꾸므로
+    // pathname 기준으로 판별해야 잘못 닫히지 않는다. 직행 진입이 아닌 경우(딥링크 등)는
+    // 기본 화면인 /operations로 복귀한다.
+    if (location.pathname === "/settings") {
+      const from = (location.state as { from?: string } | null)?.from;
+      navigate(from ?? "/operations");
+      return;
+    }
+    navigate("/settings", { state: { from: `${location.pathname}${location.search}` } });
     window.requestAnimationFrame(() => {
       const target = document.querySelector<HTMLElement>("main h2, h2");
       target?.focus?.();

--- a/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
@@ -59,13 +59,18 @@ function SettingsButton({ updateAvailable }: { readonly updateAvailable: boolean
     // 비교·기록 모두 정규화한다. 직행 진입(딥링크 등)은 기본 화면인 /operations로 복귀한다.
     const pathname = location.pathname.replace(/\/+$/, "") || "/";
     if (pathname === "/settings") {
-      const from = (location.state as { from?: string } | null)?.from;
-      // 닫기는 설정 항목을 소비하는 동작이므로 replace — push면 토글마다
-      // settings/이전 화면이 교대로 쌓여 Back이 설정을 다시 연다.
-      navigate(from ?? "/operations", { replace: true });
+      const state = location.state as { from?: string; depth?: number } | null;
+      // 닫기는 설정을 연 채 쌓인 항목을 모두 소비하는 동작이다 — 섹션 이동이 push하는
+      // 중간 /settings?... 항목까지 idx 차이만큼 되돌아가야 Back이 설정을 다시 열지 않는다.
+      // depth를 알 수 없는 진입(딥링크·리로드)은 replace로 이전 화면에 대체한다.
+      if (typeof state?.depth === "number" && window.history.state?.idx > 0) {
+        navigate(-Math.min(state.depth, window.history.state.idx));
+        return;
+      }
+      navigate(state?.from ?? "/operations", { replace: true });
       return;
     }
-    navigate("/settings", { state: { from: `${pathname}${location.search}` } });
+    navigate("/settings", { state: { from: `${pathname}${location.search}`, depth: window.history.state?.idx ?? null } });
     window.requestAnimationFrame(() => {
       const target = document.querySelector<HTMLElement>("main h2, h2");
       target?.focus?.();

--- a/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
@@ -55,14 +55,17 @@ function SettingsButton({ updateAvailable }: { readonly updateAvailable: boolean
 
   const goToSettings = () => {
     // 설정 화면에서 다시 누륄 때 토글로 닫는다 — 설정 내 섹션 이동은 search만 바꾸므로
-    // pathname 기준으로 판별해야 잘못 닫히지 않는다. 직행 진입이 아닌 경우(딥링크 등)는
-    // 기본 화면인 /operations로 복귀한다.
-    if (location.pathname === "/settings") {
+    // pathname 기준으로 판별해야 잘못 닫히지 않는다. React Router는 후행 슬래시를 허용하므로
+    // 비교·기록 모두 정규화한다. 직행 진입(딥링크 등)은 기본 화면인 /operations로 복귀한다.
+    const pathname = location.pathname.replace(/\/+$/, "") || "/";
+    if (pathname === "/settings") {
       const from = (location.state as { from?: string } | null)?.from;
-      navigate(from ?? "/operations");
+      // 닫기는 설정 항목을 소비하는 동작이므로 replace — push면 토글마다
+      // settings/이전 화면이 교대로 쌓여 Back이 설정을 다시 연다.
+      navigate(from ?? "/operations", { replace: true });
       return;
     }
-    navigate("/settings", { state: { from: `${location.pathname}${location.search}` } });
+    navigate("/settings", { state: { from: `${pathname}${location.search}` } });
     window.requestAnimationFrame(() => {
       const target = document.querySelector<HTMLElement>("main h2, h2");
       target?.focus?.();

--- a/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
@@ -31,6 +31,21 @@ const GITHUB_STARS_CACHE_KEY = "fleet-console.github-stars";
 const GITHUB_STARS_TTL_MS = 6 * 60 * 60 * 1000;
 const ENABLED_MENU_ITEM_SELECTOR = '[role="menuitem"]:not([disabled])';
 
+// 설정 진입 시점의 history index를 기록하는 세션 스코프 마커. GlobalSettings의 섹션
+// 이동은 state 없이 push하므로 location.state로는 이 마커가 전파되지 않는다 — 모듈
+// 스코프 변수로 들고 있다가 selectSection이 다음 항목으로 전파한다(아래 export 참조).
+// 설정에 머무는 동안에만 의미가 있고, 설정을 벗어나는 다른 경로 전환과 무관하게
+// 마지막 진입 값이 남는 것은 허용한다(판별은 pathname이 한다).
+let settingsEntryIndex: number | null = null;
+
+export function recordSettingsEntryIndex() {
+  settingsEntryIndex = window.history.state?.idx ?? null;
+}
+
+export function propagateSettingsEntryIndex(state: unknown): Record<string, unknown> {
+  return settingsEntryIndex === null ? {} : { ...(state as Record<string, unknown> | null), settingsEntry: settingsEntryIndex };
+}
+
 // 시스템 클러스터는 커맨드 밴드 우측에 상주한다 — 사이드바 접힘·라우트 전환과 무관하게
 // 설정(직행)·도움말(메뉴)이 항상 도달 가능해야 한다는 배치 계약의 소유자다.
 export function CommandBandSystemCluster() {
@@ -59,18 +74,21 @@ function SettingsButton({ updateAvailable }: { readonly updateAvailable: boolean
     // 비교·기록 모두 정규화한다. 직행 진입(딥링크 등)은 기본 화면인 /operations로 복귀한다.
     const pathname = location.pathname.replace(/\/+$/, "") || "/";
     if (pathname === "/settings") {
-      const state = location.state as { from?: string; depth?: number } | null;
-      // 닫기는 설정을 연 채 쌓인 항목을 모두 소비하는 동작이다 — 섹션 이동이 push하는
-      // 중간 /settings?... 항목까지 idx 차이만큼 되돌아가야 Back이 설정을 다시 열지 않는다.
-      // depth를 알 수 없는 진입(딥링크·리로드)은 replace로 이전 화면에 대체한다.
-      if (typeof state?.depth === "number" && window.history.state?.idx > 0) {
-        navigate(-Math.min(state.depth, window.history.state.idx));
+      const state = location.state as { settingsEntry?: unknown } | null;
+      const entry = typeof state?.settingsEntry === "number" ? state.settingsEntry : null;
+      const currentIndex = window.history.state?.idx;
+      // 닫기는 설정을 연 채 쌓인 항목을 모두 소비하는 동작이다 — 섹션 이동이 push한
+      // 중간 /settings?... 항목까지 진입 지점과의 idx 차이만큼 되돌아가야 Back이
+      // 설정을 다시 열지 않는다. 마커를 알 수 없는 진입(딥링크·리로드)은 replace 폐기.
+      if (entry !== null && typeof currentIndex === "number" && currentIndex > entry) {
+        navigate(entry - currentIndex);
         return;
       }
-      navigate(state?.from ?? "/operations", { replace: true });
+      navigate("/operations", { replace: true });
       return;
     }
-    navigate("/settings", { state: { from: `${pathname}${location.search}`, depth: window.history.state?.idx ?? null } });
+    recordSettingsEntryIndex();
+    navigate("/settings", { state: propagateSettingsEntryIndex(null) });
     window.requestAnimationFrame(() => {
       const target = document.querySelector<HTMLElement>("main h2, h2");
       target?.focus?.();

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -397,7 +397,7 @@ export function OperationSearch({
         // 기존 마커를 보존하고 현재 항목을 대체한다.
         const onSettings = location.pathname.replace(/\/+$/, "") === "/settings";
         if (!onSettings) recordSettingsEntryIndex();
-        navigate("/settings", { replace: onSettings, state: propagateSettingsEntryIndex(null) });
+        navigate("/settings", { replace: onSettings, state: propagateSettingsEntryIndex(onSettings ? location.state : null) });
         break;
       }
       case "open-keyboard-shortcuts": {

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -5,6 +5,7 @@ import type { FleetClientPlugin } from "@fleet-console/sdk/plugin";
 import type { RailPanelDescriptor, RailSearchResult } from "@fleet-console/sdk/rail";
 
 import { fetchSearch } from "../codex/api.js";
+import { propagateSettingsEntryIndex, recordSettingsEntryIndex } from "./command-band-system-cluster.js";
 import { setGlobalSettingsField } from "../global-settings-store.js";
 import {
   filterOperationSearchEntries,
@@ -391,7 +392,9 @@ export function OperationSearch({
       case "open-settings": {
         // 라우트 전환으로 이전 포커스 요소가 unmount되므로 복원을 억제한다(switch-theater와 동일).
         previousFocusRef.current = null;
-        navigate("/settings");
+        // 토글 닫기가 설정 구간을 소비하려면 진입 마커가 필요하다 — 버튼 경로와 동일하게 기록한다.
+        recordSettingsEntryIndex();
+        navigate("/settings", { state: propagateSettingsEntryIndex(null) });
         break;
       }
       case "open-keyboard-shortcuts": {

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -392,9 +392,12 @@ export function OperationSearch({
       case "open-settings": {
         // 라우트 전환으로 이전 포커스 요소가 unmount되므로 복원을 억제한다(switch-theater와 동일).
         previousFocusRef.current = null;
-        // 토글 닫기가 설정 구간을 소비하려면 진입 마커가 필요하다 — 버튼 경로와 동일하게 기록한다.
-        recordSettingsEntryIndex();
-        navigate("/settings", { state: propagateSettingsEntryIndex(null) });
+        // 토글 닫기가 설정 구간을 소비하려면 진입 마커가 필요하다. 이미 설정 위에서
+        // 열 때는 새로 기록하면 마커가 설정 안쪽을 가리켜 첫 설정 항목이 고아가 되므로
+        // 기존 마커를 보존하고 현재 항목을 대체한다.
+        const onSettings = location.pathname.replace(/\/+$/, "") === "/settings";
+        if (!onSettings) recordSettingsEntryIndex();
+        navigate("/settings", { replace: onSettings, state: propagateSettingsEntryIndex(null) });
         break;
       }
       case "open-keyboard-shortcuts": {

--- a/runtime/fleet-console/core/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/core/client/src/pages/global-settings.tsx
@@ -116,7 +116,8 @@ export function GlobalSettings() {
     // 마커 없는 방문(직접 로드·리로드)에서 push하면 원본 설정 항목이 고아가 되어
     // Back이 설정을 다시 열으므로, 마커가 없을 때는 섹션 이동을 replace로 처리한다.
     const nextState = propagateSettingsEntryIndex(location.state);
-    const marked = typeof (nextState as { settingsEntry?: unknown }).settingsEntry === "number";
+    if (!("settingsEntry" in nextState)) nextState.settingsEntry = null;
+    const marked = typeof nextState.settingsEntry === "number";
     navigate(
       { pathname: "/settings", search: sectionId === "general" ? "" : `?section=${encodeURIComponent(sectionId)}` },
       { replace: !marked, state: nextState },

--- a/runtime/fleet-console/core/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/core/client/src/pages/global-settings.tsx
@@ -113,9 +113,13 @@ export function GlobalSettings() {
     setActiveSectionId(sectionId);
     // 설정 토글 버튼이 닫힐 때 설정 구간 전체를 소비하려면 진입 마커가 필요하다 —
     // 이 push는 state 없이 새 항목을 만들므로 현재 항목의 마커를 명시적으로 전파한다.
+    // 마커 없는 방문(직접 로드·리로드)에서 push하면 원본 설정 항목이 고아가 되어
+    // Back이 설정을 다시 열으므로, 마커가 없을 때는 섹션 이동을 replace로 처리한다.
+    const nextState = propagateSettingsEntryIndex(location.state);
+    const marked = typeof (nextState as { settingsEntry?: unknown }).settingsEntry === "number";
     navigate(
       { pathname: "/settings", search: sectionId === "general" ? "" : `?section=${encodeURIComponent(sectionId)}` },
-      { state: propagateSettingsEntryIndex(location.state) },
+      { replace: !marked, state: nextState },
     );
   };
 

--- a/runtime/fleet-console/core/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/core/client/src/pages/global-settings.tsx
@@ -8,6 +8,7 @@ import "@fleet-console/font-picker/styles.css";
 import { fetchSystemFonts, SystemFontsFetchError } from "@fleet-console/font-picker/system-fonts";
 
 import { BackendApiSection } from "../components/backend-api-section.js";
+import { propagateSettingsEntryIndex } from "../components/command-band-system-cluster.js";
 import { getGlobalSettingsStoreState, loadGlobalSettings, setGlobalSettingsField, useGlobalSettingsStore } from "../global-settings-store.js";
 import { renderMessage, useConsoleLocale, useT, type CoreMessageKey } from "../i18n/index.js";
 import { useConsoleState } from "../hooks/use-store.js";
@@ -110,7 +111,12 @@ export function GlobalSettings() {
   const pluginGroups = groupPluginSettingsSections(pluginSections);
   const selectSection = (sectionId: SettingsSectionId) => {
     setActiveSectionId(sectionId);
-    navigate({ pathname: "/settings", search: sectionId === "general" ? "" : `?section=${encodeURIComponent(sectionId)}` });
+    // 설정 토글 버튼이 닫힐 때 설정 구간 전체를 소비하려면 진입 마커가 필요하다 —
+    // 이 push는 state 없이 새 항목을 만들므로 마커를 명시적으로 전파한다.
+    navigate(
+      { pathname: "/settings", search: sectionId === "general" ? "" : `?section=${encodeURIComponent(sectionId)}` },
+      { state: propagateSettingsEntryIndex(null) },
+    );
   };
 
   useEffect(() => {

--- a/runtime/fleet-console/core/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/core/client/src/pages/global-settings.tsx
@@ -112,10 +112,10 @@ export function GlobalSettings() {
   const selectSection = (sectionId: SettingsSectionId) => {
     setActiveSectionId(sectionId);
     // 설정 토글 버튼이 닫힐 때 설정 구간 전체를 소비하려면 진입 마커가 필요하다 —
-    // 이 push는 state 없이 새 항목을 만들므로 마커를 명시적으로 전파한다.
+    // 이 push는 state 없이 새 항목을 만들므로 현재 항목의 마커를 명시적으로 전파한다.
     navigate(
       { pathname: "/settings", search: sectionId === "general" ? "" : `?section=${encodeURIComponent(sectionId)}` },
-      { state: propagateSettingsEntryIndex(null) },
+      { state: propagateSettingsEntryIndex(location.state) },
     );
   };
 

--- a/runtime/fleet-console/core/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/core/client/src/pages/global-settings.tsx
@@ -115,8 +115,11 @@ export function GlobalSettings() {
     // 이 push는 state 없이 새 항목을 만들므로 현재 항목의 마커를 명시적으로 전파한다.
     // 마커 없는 방문(직접 로드·리로드)에서 push하면 원본 설정 항목이 고아가 되어
     // Back이 설정을 다시 열으므로, 마커가 없을 때는 섹션 이동을 replace로 처리한다.
-    const nextState = propagateSettingsEntryIndex(location.state);
-    if (!("settingsEntry" in nextState)) nextState.settingsEntry = null;
+    const nextState = propagateSettingsEntryIndex(
+      "settingsEntry" in ((location.state ?? {}) as Record<string, unknown>)
+        ? location.state
+        : { settingsEntry: null },
+    );
     const marked = typeof nextState.settingsEntry === "number";
     navigate(
       { pathname: "/settings", search: sectionId === "general" ? "" : `?section=${encodeURIComponent(sectionId)}` },
@@ -135,7 +138,7 @@ export function GlobalSettings() {
     const available = new Set<SettingsSectionId>([...coreSections.map((section) => section.id), ...pluginSections.map((section) => section.id)]);
     const next = requested && available.has(requested as SettingsSectionId) ? requested as SettingsSectionId : "general";
     setActiveSectionId(next);
-    if (requested && requested !== next) navigate({ pathname: "/settings", search: "" }, { replace: true, state: propagateSettingsEntryIndex(null) });
+    if (requested && requested !== next) navigate({ pathname: "/settings", search: "" }, { replace: true, state: propagateSettingsEntryIndex(location.state) });
   }, [location.search, navigate, coreSections, pluginSections]);
 
   return (

--- a/runtime/fleet-console/core/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/core/client/src/pages/global-settings.tsx
@@ -130,7 +130,7 @@ export function GlobalSettings() {
     const available = new Set<SettingsSectionId>([...coreSections.map((section) => section.id), ...pluginSections.map((section) => section.id)]);
     const next = requested && available.has(requested as SettingsSectionId) ? requested as SettingsSectionId : "general";
     setActiveSectionId(next);
-    if (requested && requested !== next) navigate({ pathname: "/settings", search: "" }, { replace: true });
+    if (requested && requested !== next) navigate({ pathname: "/settings", search: "" }, { replace: true, state: propagateSettingsEntryIndex(null) });
   }, [location.search, navigate, coreSections, pluginSections]);
 
   return (

--- a/runtime/fleet-console/tests/command-band-system-cluster.test.ts
+++ b/runtime/fleet-console/tests/command-band-system-cluster.test.ts
@@ -5,7 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter, useLocation, useNavigate } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { CommandBandSystemCluster, resolveUpdateApplyCopy } from "../core/client/src/components/command-band-system-cluster.js";
+import { CommandBandSystemCluster, propagateSettingsEntryIndex, resolveUpdateApplyCopy } from "../core/client/src/components/command-band-system-cluster.js";
 import { getT } from "../core/client/src/i18n/index.js";
 
 let root: Root | null = null;
@@ -52,8 +52,9 @@ function HistoryLengthProbe() {
 // GlobalSettings.selectSection과 같은 방식의 push 네비게이션을 재현하는 프로브.
 function SectionPushProbe() {
   const navigate = useNavigate();
+  const location = useLocation();
   (window as typeof window & { __pushSettingsSection?: () => void }).__pushSettingsSection = () => {
-    navigate({ pathname: "/settings", search: "?section=backend-api" });
+    navigate({ pathname: "/settings", search: "?section=backend-api" }, { state: propagateSettingsEntryIndex(location.state) });
   };
   return null;
 }

--- a/runtime/fleet-console/tests/command-band-system-cluster.test.ts
+++ b/runtime/fleet-console/tests/command-band-system-cluster.test.ts
@@ -45,6 +45,10 @@ function LocationProbe() {
   return createElement("output", { "data-testid": "location" }, `${location.pathname}${location.search}`);
 }
 
+function HistoryLengthProbe() {
+  return createElement("output", { "data-testid": "history-length" }, String(window.history.length));
+}
+
 function mountClusterAt(initialPath: string) {
   container = document.createElement("div");
   document.body.appendChild(container);
@@ -54,11 +58,16 @@ function mountClusterAt(initialPath: string) {
     { initialEntries: [initialPath] },
     createElement(CommandBandSystemCluster),
     createElement(LocationProbe),
+    createElement(HistoryLengthProbe),
   )));
 }
 
 function currentPath(): string {
   return document.querySelector<HTMLOutputElement>('[data-testid="location"]')!.value;
+}
+
+function currentHistoryLength(): number {
+  return Number(document.querySelector<HTMLOutputElement>('[data-testid="history-length"]')!.value);
 }
 
 function menuItems(): HTMLElement[] {
@@ -89,6 +98,17 @@ describe("CommandBandSystemCluster", () => {
 
     act(() => settings.click());
     expect(currentPath()).toBe("/settings");
+    const lengthAtSettings = currentHistoryLength();
+
+    act(() => settings.click());
+    expect(currentPath()).toBe("/operations");
+    // Closing consumes the Settings entry instead of pushing another one.
+    expect(currentHistoryLength()).toBe(lengthAtSettings);
+  });
+
+  it("treats a trailing-slash Settings pathname as the settings page and closes to /operations", () => {
+    mountClusterAt("/settings/");
+    const settings = document.querySelector<HTMLButtonElement>(".command-band-settings")!;
 
     act(() => settings.click());
     expect(currentPath()).toBe("/operations");

--- a/runtime/fleet-console/tests/command-band-system-cluster.test.ts
+++ b/runtime/fleet-console/tests/command-band-system-cluster.test.ts
@@ -2,7 +2,7 @@
 
 import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { MemoryRouter, useLocation } from "react-router-dom";
+import { MemoryRouter, useLocation, useNavigate } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { CommandBandSystemCluster, resolveUpdateApplyCopy } from "../core/client/src/components/command-band-system-cluster.js";
@@ -49,6 +49,15 @@ function HistoryLengthProbe() {
   return createElement("output", { "data-testid": "history-length" }, String(window.history.length));
 }
 
+// GlobalSettings.selectSection과 같은 방식의 push 네비게이션을 재현하는 프로브.
+function SectionPushProbe() {
+  const navigate = useNavigate();
+  (window as typeof window & { __pushSettingsSection?: () => void }).__pushSettingsSection = () => {
+    navigate({ pathname: "/settings", search: "?section=backend-api" });
+  };
+  return null;
+}
+
 function mountClusterAt(initialPath: string) {
   container = document.createElement("div");
   document.body.appendChild(container);
@@ -59,6 +68,7 @@ function mountClusterAt(initialPath: string) {
     createElement(CommandBandSystemCluster),
     createElement(LocationProbe),
     createElement(HistoryLengthProbe),
+    createElement(SectionPushProbe),
   )));
 }
 
@@ -109,6 +119,21 @@ describe("CommandBandSystemCluster", () => {
   it("treats a trailing-slash Settings pathname as the settings page and closes to /operations", () => {
     mountClusterAt("/settings/");
     const settings = document.querySelector<HTMLButtonElement>(".command-band-settings")!;
+
+    act(() => settings.click());
+    expect(currentPath()).toBe("/operations");
+  });
+
+  it("consumes section-navigation entries too when closing Settings", () => {
+    mountClusterAt("/operations");
+    const settings = document.querySelector<HTMLButtonElement>(".command-band-settings")!;
+
+    act(() => settings.click());
+    expect(currentPath()).toBe("/settings");
+
+    // Settings 내 섹션 이동은 /settings?... 항목을 push한다 (global-settings selectSection).
+    act(() => { (window as typeof window & { __pushSettingsSection: () => void }).__pushSettingsSection(); });
+    expect(currentPath()).toBe("/settings?section=backend-api");
 
     act(() => settings.click());
     expect(currentPath()).toBe("/operations");

--- a/runtime/fleet-console/tests/command-band-system-cluster.test.ts
+++ b/runtime/fleet-console/tests/command-band-system-cluster.test.ts
@@ -2,7 +2,7 @@
 
 import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { CommandBandSystemCluster, resolveUpdateApplyCopy } from "../core/client/src/components/command-band-system-cluster.js";
@@ -40,6 +40,27 @@ function mountCluster() {
   act(() => root!.render(createElement(MemoryRouter, null, createElement(CommandBandSystemCluster))));
 }
 
+function LocationProbe() {
+  const location = useLocation();
+  return createElement("output", { "data-testid": "location" }, `${location.pathname}${location.search}`);
+}
+
+function mountClusterAt(initialPath: string) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root!.render(createElement(
+    MemoryRouter,
+    { initialEntries: [initialPath] },
+    createElement(CommandBandSystemCluster),
+    createElement(LocationProbe),
+  )));
+}
+
+function currentPath(): string {
+  return document.querySelector<HTMLOutputElement>('[data-testid="location"]')!.value;
+}
+
 function menuItems(): HTMLElement[] {
   return [...document.querySelectorAll<HTMLElement>('[role="menuitem"]')];
 }
@@ -60,6 +81,25 @@ describe("CommandBandSystemCluster", () => {
     expect(settings.getAttribute("aria-label")).toBe("Settings");
     expect(settings.getAttribute("aria-haspopup")).toBeNull();
     expect(document.querySelector(".command-band-system-menu")).toBeNull();
+  });
+
+  it("returns to the previous route when Settings is pressed again from the settings page", () => {
+    mountClusterAt("/operations");
+    const settings = document.querySelector<HTMLButtonElement>(".command-band-settings")!;
+
+    act(() => settings.click());
+    expect(currentPath()).toBe("/settings");
+
+    act(() => settings.click());
+    expect(currentPath()).toBe("/operations");
+  });
+
+  it("falls back to /operations when Settings is pressed on a deep-linked settings page", () => {
+    mountClusterAt("/settings?section=terminal%3Acarriers");
+    const settings = document.querySelector<HTMLButtonElement>(".command-band-settings")!;
+
+    act(() => settings.click());
+    expect(currentPath()).toBe("/operations");
   });
 
   it("opens the Help menu with focus on the first enabled item and cycles with arrow keys", () => {


### PR DESCRIPTION
## Summary
- 설정 화면에서 커맨드 밴드의 Settings 버튼을 다시 누류이면 진입 전 경로로 복귀한다 (location state의 `from` 기준, 딥링크 등 직행 진입은 `/operations` 폐기)
- 설정 내 섹션 이동은 search만 바뀌므로 토글 판별은 pathname 기준으로 한다

## Test Plan
- [x] `vitest run tests/command-band-system-cluster.test.ts` — 6/6 통과 (토글 왕복 + 딥링크 폐기 케이스 추가)
- [x] `tsc --noEmit` — 0 오류
- [x] 격리 콘솔 실브라우저 검증: /operations → 설정 → /operations 복귀, 설정 내 섹션 이동 후 토글 시 /operations 복귀, 페이지 오류 0건
- [x] `.changelog.d/pr-501.md` — fragment 문법·이중언어 요약·컴파일러 검증 완료