### PR TITLE
feat(console): magnify triage deck cards into a readable quick-look

### DIFF
--- a/.changelog.d/pr-502.md
+++ b/.changelog.d/pr-502.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Added
+- [fleet-console] Triage Watch Deck cards now magnify into a readable quick-look after a 400ms hover dwell, scaling the live preview to legible text without resizing the underlying terminal; keyboard focus opens it instantly, edge cards expand inward, and clicking still stages the operation.
+  ko: 선별 처리 Watch Deck 카드가 hover 400ms 드웰 후 판독 가능한 quick-look으로 확대됩니다. 라이브 프리뷰가 터미널 리사이즈 없이 읽히는 크기로 커지고, 키보드 포커스는 즉시 열리며, 가장자리 카드는 안쪽으로 팽창하고, 클릭하면 기존처럼 무대로 올라갑니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -24,7 +24,7 @@ import { CanvasContextMenu } from "./canvas-context-menu.js";
 import { CanvasMinimap } from "./canvas-minimap.js";
 import { resolveAccentColor } from "./operation-accent.js";
 import { CanvasGrid, RubberBand, TriageClearPlate } from "./canvas-overlays.js";
-import { flashTriageDeckCard, getTriageDeckCardRect, resolveTriageDeckPromotion, TriageWatchDeck, type TriageDeckArrivalDwell } from "./triage-watch-deck.js";
+import { flashTriageDeckCard, getTriageDeckCardRect, resolveTriageDeckPromotion, takeTriageDeckDepartureRect, TriageWatchDeck, type TriageDeckArrivalDwell } from "./triage-watch-deck.js";
 import { resolveGlanceHudModel, type GlanceHudModel } from "./glance-hud.js";
 import { OperationFrame } from "./operation-frame.js";
 import { hasVisibleCanvasContent, OperationsCanvasEmptyState } from "./operations-canvas-empty-state.js";
@@ -384,7 +384,9 @@ export function OperationsCanvas({
       const stage = canvasRef.current?.querySelector<HTMLElement>(`.canvas-operation[data-operation-id="${escapeSelectorValue(triageStageId)}"]`) ?? null;
       if (stage) triageStageRectRef.current.set(triageStageId, stage.getBoundingClientRect());
       if (previousStageId === null && !triageEntering) {
-        const from = getTriageDeckCardRect(triageStageId);
+        // 클릭 승격은 사용자가 보고 있던(Quick-Look이면 확대된) rect에서 출발한다 — 1회용 출발
+        // 채널이 비어 있으면(자동 승격 등) 비확대 캐시로 폴백한다.
+        const from = takeTriageDeckDepartureRect(triageStageId) ?? getTriageDeckCardRect(triageStageId);
         if (from) {
           window.requestAnimationFrame(() => {
             const target = canvasRef.current?.querySelector<HTMLElement>(`.canvas-operation[data-operation-id="${escapeSelectorValue(triageStageId)}"]`) ?? null;

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -172,9 +172,20 @@ export function TriageWatchDeck({
         const operationId = card.dataset.triageDeckCard;
         if (!operationId) continue;
         currentIds.add(operationId);
-        // Quick-Look 확대 중인 카드는 건너뛰어 마지막 비확대 rect를 유지한다 — 이 맵은 복귀
-        // flight의 목적지라 확대 rect가 실리면 고스트가 카드 두 배 크기 자리로 날아간다.
-        if (card.classList.contains("is-quicklook")) continue;
+        // Quick-Look 확대 중인 카드는 getBoundingClientRect가 확대 rect를 주므로 레이아웃
+        // 좌표(offset 기하는 transform 무영향)로 비확대 rect를 재구성한다 — 이 맵은 복귀
+        // flight의 목적지라 확대 rect가 실리면 고스트가 카드 두 배 크기 자리로 날아가고,
+        // 그렇다고 기록을 건너뛰면 확대 중 grid 스크롤이 일어났을 때 옛 위치가 남는다.
+        if (card.classList.contains("is-quicklook")) {
+          const gridRect = grid.getBoundingClientRect();
+          deckCardRects.set(operationId, new DOMRect(
+            gridRect.left + (card.offsetLeft - grid.offsetLeft) - grid.scrollLeft,
+            gridRect.top + (card.offsetTop - grid.offsetTop) - grid.scrollTop,
+            card.offsetWidth,
+            card.offsetHeight,
+          ));
+          continue;
+        }
         deckCardRects.set(operationId, card.getBoundingClientRect());
       }
       for (const operationId of deckCardRects.keys()) {

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -156,6 +156,12 @@ export function TriageWatchDeck({
   // 오갈 때 이전 카드의 드웰이 뒤늦게 발동해 두 카드가 동시에 확대되는 일을 막는다.
   const [quicklook, setQuicklook] = useState<{ operationId: string; origin: string; scale: number } | null>(null);
   const quicklookTimerRef = useRef<number | null>(null);
+  // rect 기록 effect는 quicklook을 deps로 갖지 않으므로(스크롤/리사이즈마다 재구독 방지),
+  // 스테일 클로저 없이 현재 값을 읽도록 ref 미러를 둔다.
+  const quicklookRef = useRef<typeof quicklook>(null);
+  useEffect(() => {
+    quicklookRef.current = quicklook;
+  }, [quicklook]);
   // 무대가 떠 있는 동안에도 deck는 mount를 유지하고 visibility로만 숨는다 — 비무대 body가
   // 카드(고정 크기)와 숨김 프레임(크롬 제외 크기) 사이를 오가며 전 세션에 PTY 리사이즈를
   // 뿌리는 churn을 없애기 위해서다. 리사이즈는 무대에 오른 Operation에만 남는다.
@@ -178,12 +184,24 @@ export function TriageWatchDeck({
         // 그렇다고 기록을 건너뛰면 확대 중 grid 스크롤이 일어났을 때 옛 위치가 남는다.
         if (card.classList.contains("is-quicklook")) {
           const gridRect = grid.getBoundingClientRect();
-          deckCardRects.set(operationId, new DOMRect(
+          const unscaledRect = new DOMRect(
             gridRect.left + (card.offsetLeft - grid.offsetLeft) - grid.scrollLeft,
             gridRect.top + (card.offsetTop - grid.offsetTop) - grid.scrollTop,
             card.offsetWidth,
             card.offsetHeight,
-          ));
+          );
+          deckCardRects.set(operationId, unscaledRect);
+          // 열린 quick-look의 scale/origin은 발동 시점 스냅샷이라, grid 스크롤이나 리사이즈
+          // (사이드바 토글 등)로 기하가 움직이면 새 경계에 맞게 재계산한다 — 스냅샷을 그대로
+          // 두면 좁아진 grid에서 1.95를 유지하거나 새로 인접해진 가장자리 밖으로 팽창한다.
+          const active = quicklookRef.current;
+          if (active?.operationId === operationId) {
+            const scale = resolveTriageQuicklookScale(unscaledRect, gridRect);
+            const origin = resolveTriageQuicklookOrigin(unscaledRect, gridRect, scale);
+            if (scale !== active.scale || origin !== active.origin) {
+              setQuicklook({ operationId, origin, scale });
+            }
+          }
           continue;
         }
         deckCardRects.set(operationId, card.getBoundingClientRect());

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState, type CSSProperties } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type PointerEvent } from "react";
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
 
 import { useT } from "../i18n/index.js";
@@ -36,6 +36,32 @@ interface TriageDeckPromotionDecision {
 }
 
 export const TRIAGE_DECK_ARRIVAL_DWELL_MS = 1_100;
+export const TRIAGE_DECK_QUICKLOOK_DWELL_MS = 400;
+export const TRIAGE_DECK_QUICKLOOK_SCALE = 1.95;
+
+// Quick-Look transform-origin 결정 — 확대 후 카드가 grid 경계를 넘는 방향으로 origin을
+// 클램프해 팽창이 경계 안쪽으로만 일어나게 한다. center origin 기준 카드는 절반 증가폭
+// (scale-1)/2 만큼 양쪽으로 팽창하므로, 그 폭이 카드와 grid 사이 여백보다 크면 해당 방향의
+// 경계를 넘는 것으로 본다.
+export function resolveTriageQuicklookOrigin(
+  cardRect: DOMRect,
+  gridRect: DOMRect,
+  scale = TRIAGE_DECK_QUICKLOOK_SCALE,
+): string {
+  const halfGrowX = ((scale - 1) / 2) * cardRect.width;
+  const halfGrowY = ((scale - 1) / 2) * cardRect.height;
+  const horizontal = cardRect.left - gridRect.left < halfGrowX
+    ? "left"
+    : gridRect.right - cardRect.right < halfGrowX
+      ? "right"
+      : "center";
+  const vertical = cardRect.top - gridRect.top < halfGrowY
+    ? "top"
+    : gridRect.bottom - cardRect.bottom < halfGrowY
+      ? "bottom"
+      : "center";
+  return `${horizontal} ${vertical}`;
+}
 // 카드 정렬 등급 — 사이드바 STATUS 축의 섹션 순서(대기→실행 중→백그라운드→유휴→휴면)를 그대로
 // 따른다. deck이 자체 순서를 정의하면 같은 상태가 두 표면에서 다른 위치로 읽힌다.
 const TRIAGE_DECK_ACTIVITY_RANK: Record<OperationActivity, number> = {
@@ -101,6 +127,10 @@ export function TriageWatchDeck({
   const gridRef = useRef<HTMLDivElement | null>(null);
   const poolAvailable = useOperationBodyPoolAvailable();
   useOperationStatusDetails();
+  // Quick-Look 상태 — 동시에 한 카드만 확대된다. 타이머도 1개만 유지해 카드 사이를 빠르게
+  // 오갈 때 이전 카드의 드웰이 뒤늦게 발동해 두 카드가 동시에 확대되는 일을 막는다.
+  const [quicklook, setQuicklook] = useState<{ operationId: string; origin: string } | null>(null);
+  const quicklookTimerRef = useRef<number | null>(null);
   // 무대가 떠 있는 동안에도 deck는 mount를 유지하고 visibility로만 숨는다 — 비무대 body가
   // 카드(고정 크기)와 숨김 프레임(크롬 제외 크기) 사이를 오가며 전 세션에 PTY 리사이즈를
   // 뿌리는 churn을 없애기 위해서다. 리사이즈는 무대에 오른 Operation에만 남는다.
@@ -144,6 +174,44 @@ export function TriageWatchDeck({
     };
   }, [operations, visible]);
 
+  const clearQuicklookTimer = () => {
+    if (quicklookTimerRef.current !== null) {
+      window.clearTimeout(quicklookTimerRef.current);
+      quicklookTimerRef.current = null;
+    }
+  };
+
+  const dismissQuicklook = () => {
+    clearQuicklookTimer();
+    setQuicklook(null);
+  };
+
+  const armQuicklook = (operationId: string, card: HTMLElement, dwell: boolean) => {
+    const fire = () => {
+      quicklookTimerRef.current = null;
+      const grid = gridRef.current;
+      if (!grid) return;
+      setQuicklook({
+        operationId,
+        origin: resolveTriageQuicklookOrigin(card.getBoundingClientRect(), grid.getBoundingClientRect()),
+      });
+    };
+    if (!dwell) {
+      // 키보드 사용자 동등성 — 드웰 없이 즉시 발동해 포인터와 같은 정보에 접근하게 한다.
+      fire();
+      return;
+    }
+    clearQuicklookTimer();
+    quicklookTimerRef.current = window.setTimeout(fire, TRIAGE_DECK_QUICKLOOK_DWELL_MS);
+  };
+
+  useEffect(() => {
+    if (!visible || stagedOperationId !== null) dismissQuicklook();
+  }, [visible, stagedOperationId]);
+
+  // unmount 시 드웰 타이머를 반납한다 — unmount 뒤 발동하면 떠난 카드에 setState를 던진다.
+  useEffect(() => () => clearQuicklookTimer(), []);
+
   if (!visible) return null;
 
   const activities = operations.map((operation) => resolveOperationActivity(operation, operationStatus));
@@ -171,14 +239,38 @@ export function TriageWatchDeck({
           const previewConfig = poolAvailable && previewConfigFor && operation.id !== stagedOperationId
             ? previewConfigFor(operation)
             : null;
+          const isQuicklook = quicklook?.operationId === operation.id;
           return (
             <button
-              className={`canvas-triage-deck-card is-${visual} ${previewConfig ? "has-preview" : ""} ${arrivingOperationId === operation.id ? "is-arriving" : ""}`}
+              className={`canvas-triage-deck-card is-${visual} ${previewConfig ? "has-preview" : ""} ${arrivingOperationId === operation.id ? "is-arriving" : ""} ${isQuicklook ? "is-quicklook" : ""}`}
               data-triage-deck-card={operation.id}
               key={operation.id}
               type="button"
+              style={isQuicklook ? { transformOrigin: quicklook.origin } : undefined}
               aria-label={t("canvas.triage.deckCardAria", { title: operation.title })}
-              onClick={() => pickTriageOperation(theaterId, operation.id)}
+              onPointerEnter={(event: PointerEvent<HTMLButtonElement>) => {
+                // 터치엔 hover 개념이 없다 — 손가락으로 카드를 누를 때마다 확대가 번쩍이지 않게 차단.
+                if (event.pointerType === "touch") return;
+                // 도착 맥동(1100ms)이 진행 중인 카드에 드웰 확대가 겹치면 두 신호가 충돌해
+                // 어떤 피드백인지 읽히지 않는다 — 맥동이 끝난 뒤에만 Quick-Look을 연다.
+                if (arrivingOperationId === operation.id) return;
+                armQuicklook(operation.id, event.currentTarget, true);
+              }}
+              onPointerLeave={dismissQuicklook}
+              onFocus={(event) => {
+                // 마우스 클릭 포커스는 onClick이 곧바로 승격시키므로 확대할 필요가 없고,
+                // :focus-visible(키보드 포커스)일 때만 드웰 없이 즉시 Quick-Look을 연다.
+                if (!event.currentTarget.matches(":focus-visible")) return;
+                armQuicklook(operation.id, event.currentTarget, false);
+              }}
+              onBlur={dismissQuicklook}
+              onClick={(event) => {
+                // 확대 상태에서의 클릭은 실제 rect를 재측정해 기록한다 — deckCardRects에 저장된
+                // rect는 Quick-Look 확대 전에 기록된 것이라 그대로 쓰면 승격 flight가 사용자가
+                // 보고 있는 확대된 위치가 아니라 원래 크기의 자리에서 출발해 위화감을 준다.
+                deckCardRects.set(operation.id, event.currentTarget.getBoundingClientRect());
+                pickTriageOperation(theaterId, operation.id);
+              }}
             >
               {accentColor ? <span className="canvas-triage-deck-card-spine" style={{ backgroundColor: accentColor } as CSSProperties} aria-hidden="true" /> : null}
               <span className="canvas-triage-deck-card-status">

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -39,6 +39,31 @@ export const TRIAGE_DECK_ARRIVAL_DWELL_MS = 1_100;
 export const TRIAGE_DECK_QUICKLOOK_DWELL_MS = 400;
 export const TRIAGE_DECK_QUICKLOOK_SCALE = 1.95;
 
+// Quick-Look 배율 상한 — 단일 컬럼처럼 카드가 grid 폭을 거의 채우면 1.95를 그대로 곱한 카드가
+// grid(overflow hidden)보다 커져 확대분이 잘려 나간다. origin 클램프는 컨테이너보다 큰 대상을
+// 구제하지 못하므로 배율 자체를 grid가 수용 가능한 값으로 깎는다. 1 미만으로는 내리지 않는다
+// (축소는 확대 보기가 아니다) — 좁은 창에서는 확대 없이 강조만 남는 정직한 열화를 택한다.
+export function resolveTriageQuicklookScale(
+  cardRect: DOMRect,
+  gridRect: DOMRect,
+  maxScale = TRIAGE_DECK_QUICKLOOK_SCALE,
+): number {
+  if (cardRect.width <= 0 || cardRect.height <= 0) return 1;
+  return Math.max(1, Math.min(maxScale, gridRect.width / cardRect.width, gridRect.height / cardRect.height));
+}
+
+// 승격 출발 rect 1회용 채널 — 클릭 순간의(Quick-Look이면 확대된) rect는 outbound flight의
+// 출발점으로만 쓰여야 한다. deckCardRects에 덮어쓰면 무대 복귀 flight의 목적지까지 확대
+// rect로 오염되므로, 소비 즉시 비워지는 별도 채널로 분리한다.
+let deckDepartureRect: { readonly operationId: string; readonly rect: DOMRect } | null = null;
+
+export function takeTriageDeckDepartureRect(operationId: string): DOMRect | null {
+  if (deckDepartureRect?.operationId !== operationId) return null;
+  const rect = deckDepartureRect.rect;
+  deckDepartureRect = null;
+  return rect;
+}
+
 // Quick-Look transform-origin 결정 — 확대 후 카드가 grid 경계를 넘는 방향으로 origin을
 // 클램프해 팽창이 경계 안쪽으로만 일어나게 한다. center origin 기준 카드는 절반 증가폭
 // (scale-1)/2 만큼 양쪽으로 팽창하므로, 그 폭이 카드와 grid 사이 여백보다 크면 해당 방향의
@@ -129,7 +154,7 @@ export function TriageWatchDeck({
   useOperationStatusDetails();
   // Quick-Look 상태 — 동시에 한 카드만 확대된다. 타이머도 1개만 유지해 카드 사이를 빠르게
   // 오갈 때 이전 카드의 드웰이 뒤늦게 발동해 두 카드가 동시에 확대되는 일을 막는다.
-  const [quicklook, setQuicklook] = useState<{ operationId: string; origin: string } | null>(null);
+  const [quicklook, setQuicklook] = useState<{ operationId: string; origin: string; scale: number } | null>(null);
   const quicklookTimerRef = useRef<number | null>(null);
   // 무대가 떠 있는 동안에도 deck는 mount를 유지하고 visibility로만 숨는다 — 비무대 body가
   // 카드(고정 크기)와 숨김 프레임(크롬 제외 크기) 사이를 오가며 전 세션에 PTY 리사이즈를
@@ -147,6 +172,9 @@ export function TriageWatchDeck({
         const operationId = card.dataset.triageDeckCard;
         if (!operationId) continue;
         currentIds.add(operationId);
+        // Quick-Look 확대 중인 카드는 건너뛰어 마지막 비확대 rect를 유지한다 — 이 맵은 복귀
+        // flight의 목적지라 확대 rect가 실리면 고스트가 카드 두 배 크기 자리로 날아간다.
+        if (card.classList.contains("is-quicklook")) continue;
         deckCardRects.set(operationId, card.getBoundingClientRect());
       }
       for (const operationId of deckCardRects.keys()) {
@@ -191,9 +219,13 @@ export function TriageWatchDeck({
       quicklookTimerRef.current = null;
       const grid = gridRef.current;
       if (!grid) return;
+      const cardRect = card.getBoundingClientRect();
+      const gridRect = grid.getBoundingClientRect();
+      const scale = resolveTriageQuicklookScale(cardRect, gridRect);
       setQuicklook({
         operationId,
-        origin: resolveTriageQuicklookOrigin(card.getBoundingClientRect(), grid.getBoundingClientRect()),
+        origin: resolveTriageQuicklookOrigin(cardRect, gridRect, scale),
+        scale,
       });
     };
     if (!dwell) {
@@ -246,7 +278,9 @@ export function TriageWatchDeck({
               data-triage-deck-card={operation.id}
               key={operation.id}
               type="button"
-              style={isQuicklook ? { transformOrigin: quicklook.origin } : undefined}
+              style={isQuicklook
+                ? { transformOrigin: quicklook.origin, "--triage-quicklook-scale": String(quicklook.scale) } as CSSProperties
+                : undefined}
               aria-label={t("canvas.triage.deckCardAria", { title: operation.title })}
               onPointerEnter={(event: PointerEvent<HTMLButtonElement>) => {
                 // 터치엔 hover 개념이 없다 — 손가락으로 카드를 누를 때마다 확대가 번쩍이지 않게 차단.
@@ -265,10 +299,10 @@ export function TriageWatchDeck({
               }}
               onBlur={dismissQuicklook}
               onClick={(event) => {
-                // 확대 상태에서의 클릭은 실제 rect를 재측정해 기록한다 — deckCardRects에 저장된
-                // rect는 Quick-Look 확대 전에 기록된 것이라 그대로 쓰면 승격 flight가 사용자가
-                // 보고 있는 확대된 위치가 아니라 원래 크기의 자리에서 출발해 위화감을 준다.
-                deckCardRects.set(operation.id, event.currentTarget.getBoundingClientRect());
+                // 클릭 순간의 rect(Quick-Look이면 확대된 모습 그대로)를 출발 전용 채널에 기록한다 —
+                // 승격 flight는 사용자가 보고 있는 위치에서 출발해야 하고, deckCardRects는 복귀
+                // flight 목적지용 비확대 rect로 남아야 하므로 두 용도를 분리한다.
+                deckDepartureRect = { operationId: operation.id, rect: event.currentTarget.getBoundingClientRect() };
                 pickTriageOperation(theaterId, operation.id);
               }}
             >

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2114,7 +2114,9 @@
   transition:
     border-color var(--duration-fast) var(--ease-glide),
     background var(--duration-fast) var(--ease-glide),
-    opacity var(--duration-fast) var(--ease-glide);
+    opacity var(--duration-fast) var(--ease-glide),
+    transform var(--duration-slow) var(--ease-glide),
+    box-shadow var(--duration-slow) var(--ease-glide);
 }
 
 .canvas-triage-deck-card:hover,
@@ -2122,6 +2124,22 @@
   border-color: color-mix(in oklch, var(--brass) 46%, var(--surface-rim));
   background: color-mix(in oklch, var(--brass) 7%, var(--surface-glass));
   outline: none;
+}
+
+/* Quick-Look — hover 드웰 후 카드를 transform으로만 확대해 프리뷰 유효 배율을 판독권(≈0.8)으로
+   올린다. 프리뷰 inner의 측정 크기는 불변이므로 PTY 리사이즈 계약과 pool 슬롯 유일성이 유지된다. */
+.canvas-triage-deck-card.is-quicklook {
+  transform: scale(1.95);
+  z-index: 9;
+  border-color: color-mix(in oklch, var(--brass) 60%, var(--surface-rim));
+  box-shadow: 0 18px 60px oklch(0% 0 0 / 55%), 0 0 0 1px var(--brass-glow);
+}
+
+/* 확대 시 카드 크롬(상태줄·제목)은 역보정해 프리뷰가 주인공으로 남게 한다. */
+.canvas-triage-deck-card.is-quicklook .canvas-triage-deck-card-status,
+.canvas-triage-deck-card.is-quicklook > strong {
+  transform: scale(0.72);
+  transform-origin: left top;
 }
 
 .canvas-triage-deck-card.is-idle,
@@ -2326,6 +2344,10 @@
   .canvas-formation-curtain {
     animation-timing-function: steps(1, start);
   }
+
+  /* Quick-Look 확대 자체는 유지하되 전이만 제거해 즉시 스냅되게 한다 — 확대 정보는
+     reduced-motion 사용자에게도 동일하게 필요하므로 상태가 아니라 동작만 끊는다. */
+  .canvas-triage-deck-card { transition-property: border-color, background, opacity; }
 }
 
 /* 순정 셸 패널 — Operation과 구별되도록 띠바에 아우로라(살아있는 것) 톤의 옅은 강조를 준다. */

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2137,10 +2137,12 @@
   box-shadow: 0 18px 60px oklch(0% 0 0 / 55%), 0 0 0 1px var(--brass-glow);
 }
 
-/* 확대 시 카드 크롬(상태줄·제목)은 역보정해 프리뷰가 주인공으로 남게 한다. */
+/* 확대 시 카드 크롬(상태줄·제목)은 역보정해 프리뷰가 주인공으로 남게 한다. 역보정은 해상
+   배율에 연동한다 — 1/scale 하한을 두어 캡이 배율을 1까지 깎은 좁은 창에서 크롬이 원본보다
+   작아지는 일이 없게 한다(0.72 고정이면 확대 없는 카드의 제목만 줄어든다). */
 .canvas-triage-deck-card.is-quicklook .canvas-triage-deck-card-status,
 .canvas-triage-deck-card.is-quicklook > strong {
-  transform: scale(0.72);
+  transform: scale(max(0.72, calc(1 / var(--triage-quicklook-scale, 1.95))));
   transform-origin: left top;
 }
 

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2129,7 +2129,9 @@
 /* Quick-Look — hover 드웰 후 카드를 transform으로만 확대해 프리뷰 유효 배율을 판독권(≈0.8)으로
    올린다. 프리뷰 inner의 측정 크기는 불변이므로 PTY 리사이즈 계약과 pool 슬롯 유일성이 유지된다. */
 .canvas-triage-deck-card.is-quicklook {
-  transform: scale(1.95);
+  /* 배율은 발동 시점에 JS가 grid 수용 한도로 깎아 주입한다(--triage-quicklook-scale) —
+     단일 컬럼처럼 카드가 grid를 채우는 창에서 고정 1.95는 overflow에 잘려 나가기 때문. */
+  transform: scale(var(--triage-quicklook-scale, 1.95));
   z-index: 9;
   border-color: color-mix(in oklch, var(--brass) 60%, var(--surface-rim));
   box-shadow: 0 18px 60px oklch(0% 0 0 / 55%), 0 0 0 1px var(--brass-glow);

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -95,6 +95,8 @@ const RUNTIME_CUSTOM_PROPERTY_ALLOWLIST = new Set([
   "--cap-color",
   // Canvas context menu TSX injects the viewport-derived height ceiling for its own box.
   "--canvas-menu-max-height",
+  // Triage Watch Deck TSX injects the grid-capped quick-look magnification at hover time.
+  "--triage-quicklook-scale",
 ]);
 
 function source(path: string): string {

--- a/runtime/fleet-console/tests/triage-deck-quicklook.test.ts
+++ b/runtime/fleet-console/tests/triage-deck-quicklook.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+
+import { resolveTriageQuicklookOrigin } from "../core/client/src/canvas/triage-watch-deck.js";
+
+function rect(left: number, top: number, width: number, height: number): DOMRect {
+  return {
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+// 1200×800 grid 안의 200×100 카드 — Quick-Look scale 1.95 기준 절반 증가폭은 가로 95, 세로 47.5.
+const GRID = rect(0, 0, 1200, 800);
+
+describe("resolveTriageQuicklookOrigin", () => {
+  it("returns 'center center' for a card with room on every side", () => {
+    expect(resolveTriageQuicklookOrigin(rect(500, 350, 200, 100), GRID)).toBe("center center");
+  });
+
+  it("clamps to 'left' when the card hugs the grid's left edge", () => {
+    expect(resolveTriageQuicklookOrigin(rect(10, 350, 200, 100), GRID)).toBe("left center");
+  });
+
+  it("clamps to 'right' when the card hugs the grid's right edge", () => {
+    expect(resolveTriageQuicklookOrigin(rect(990, 350, 200, 100), GRID)).toBe("right center");
+  });
+
+  it("clamps to 'top' when the card hugs the grid's top edge", () => {
+    expect(resolveTriageQuicklookOrigin(rect(500, 10, 200, 100), GRID)).toBe("center top");
+  });
+
+  it("clamps to 'bottom' when the card hugs the grid's bottom edge", () => {
+    expect(resolveTriageQuicklookOrigin(rect(500, 690, 200, 100), GRID)).toBe("center bottom");
+  });
+
+  it("clamps both axes for a corner card", () => {
+    expect(resolveTriageQuicklookOrigin(rect(0, 780, 200, 20), GRID)).toBe("left bottom");
+  });
+
+  it("keeps center when the remaining gap exactly fits the half-growth", () => {
+    // 좌측 여백이 정확히 95(scale 1.95 기준 절반 증가폭)이면 경계를 넘지 않으므로 center.
+    expect(resolveTriageQuicklookOrigin(rect(95, 47.5, 200, 100), GRID)).toBe("center center");
+  });
+});

--- a/runtime/fleet-console/tests/triage-deck-quicklook.test.ts
+++ b/runtime/fleet-console/tests/triage-deck-quicklook.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { resolveTriageQuicklookOrigin } from "../core/client/src/canvas/triage-watch-deck.js";
+import { resolveTriageQuicklookOrigin, resolveTriageQuicklookScale } from "../core/client/src/canvas/triage-watch-deck.js";
 
 function rect(left: number, top: number, width: number, height: number): DOMRect {
   return {
@@ -49,5 +49,35 @@ describe("resolveTriageQuicklookOrigin", () => {
   it("keeps center when the remaining gap exactly fits the half-growth", () => {
     // 좌측 여백이 정확히 95(scale 1.95 기준 절반 증가폭)이면 경계를 넘지 않으므로 center.
     expect(resolveTriageQuicklookOrigin(rect(95, 47.5, 200, 100), GRID)).toBe("center center");
+  });
+});
+
+describe("resolveTriageQuicklookScale", () => {
+  it("keeps the full 1.95 scale when the grid can absorb the growth", () => {
+    expect(resolveTriageQuicklookScale(rect(500, 350, 200, 100), GRID)).toBe(1.95);
+  });
+
+  it("caps to 1 when a single-column card already fills the grid width", () => {
+    // 단일 컬럼 deck — 카드 폭 == grid 폭이면 어떤 확대도 overflow에 잘리므로 확대하지 않는다.
+    expect(resolveTriageQuicklookScale(rect(0, 100, 1200, 210), GRID)).toBe(1);
+  });
+
+  it("caps to the width ratio when the card is wider than the height allows", () => {
+    // grid 800×800에 카드 500×100 — 폭 기준 1.6이 1.95보다 먼저 바닥난다.
+    expect(resolveTriageQuicklookScale(rect(0, 0, 500, 100), rect(0, 0, 800, 800))).toBe(1.6);
+  });
+
+  it("caps to the height ratio on short grids", () => {
+    // grid 높이 300에 카드 높이 210 — 300/210 ≈ 1.4286이 상한이 된다.
+    expect(resolveTriageQuicklookScale(rect(0, 0, 300, 210), rect(0, 0, 1200, 300)))
+      .toBeCloseTo(300 / 210, 5);
+  });
+
+  it("never scales below 1 even when the card overflows the grid", () => {
+    expect(resolveTriageQuicklookScale(rect(0, 0, 1400, 900), GRID)).toBe(1);
+  });
+
+  it("returns 1 for a degenerate zero-size card", () => {
+    expect(resolveTriageQuicklookScale(rect(0, 0, 0, 0), GRID)).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- 선별 처리 Watch Deck 카드에 hover 400ms 드웰 후 `transform: scale(1.95)`로 확대되는 Quick-Look을 추가합니다. 라이브 프리뷰 유효 텍스트가 실측 5.8px(판독 불가) → 11.3px(판독 가능)로 올라 무대 승격 없이 카드 내용을 읽을 수 있습니다.
- 확대는 transform 전용이라 프리뷰 inner의 측정 크기(PTY cols/rows)와 pool 슬롯 유일성 계약을 유지합니다. 가장자리 카드는 transform-origin이 grid 안쪽으로 클램프되고, `:focus-visible` 키보드 포커스는 드웰 없이 즉시 발동하며, 도착 맥동(1100ms) 중에는 발동하지 않습니다.
- Quick-Look 상태에서 클릭 시 확대된 rect를 재기록해 승격 flight가 사용자가 보고 있는 위치에서 출발합니다. `prefers-reduced-motion`에서는 전이 없이 스냅합니다.

## Test Plan
- [x] `tsc --noEmit` 0 오류 (fleet-console)
- [x] `tests/triage-deck-quicklook.test.ts` 8건 통과 (origin 클램프 pure 함수)
- [x] `tests/instrument-design-contract.test.ts` 27건 통과
- [x] 격리 콘솔 실브라우저 QA: 드웰 게이트, scale 1.95·유효 텍스트 11.26px, inner 640×400 불변(PTY 무접촉), pointer leave 해제, 클릭 무대 승격, 브라우저 에러 0

## Changelog
- [x] `.changelog.d/pr-502.md` — grouped fragment (fleet-console/Added), 영·한 요약 인접, `compile-changelog-fragments.mjs --check` 통과