### PR TITLE
fix(console): close canvas control menu on map click; open it in triage mode

### DIFF
--- a/.changelog.d/pr-503.md
+++ b/.changelog.d/pr-503.md
@@ -1,0 +1,7 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Close the canvas control menu when left-clicking the map, regardless of whether it was opened from the map or the sidebar.
+  ko: 캔버스 제어 메뉴를 맵과 사이드바 어디에서 열었든 맵을 좌클릭하면 닫히도록 수정했습니다.
+#### Added
+- [fleet-console] Offer the canvas control menu on right-click in triage mode, placed at the cursor with launch actions disabled.
+  ko: 선별 처리 모드에서 우클릭하면 커서 위치에 캔버스 제어 메뉴가 열립니다(실행 항목은 비활성).

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -17,6 +17,9 @@ interface CanvasContextMenuProps {
   readonly renderKindIcon: (pluginId: string, kind: OperationLaunchKind) => ReactNode;
   readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind) => void;
   readonly onClose: () => void;
+  // true면 anchor를 뷰포트 기준 좌표로 보고 position: fixed로 띄운다 — 선별 처리처럼
+  // 월드/스테이지 프레임이 anchor 좌표계를 침범하는 모드에서 쓴다.
+  readonly fixed?: boolean;
 }
 
 const MENU_WIDTH = 340;
@@ -24,7 +27,7 @@ const MENU_MAX_HEIGHT = 520;
 const MENU_MIN_HEIGHT = 120;
 const MENU_MARGIN = 12;
 
-export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor", catalog, canLaunch, renderKindIcon, onLaunchKind, onClose }: CanvasContextMenuProps) {
+export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor", fixed = false, catalog, canLaunch, renderKindIcon, onLaunchKind, onClose }: CanvasContextMenuProps) {
   const t = useT();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
@@ -60,9 +63,13 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     };
     document.addEventListener("mousedown", handlePointer);
     document.addEventListener("keydown", handleKey);
+    // 호출 측에 닫기 신호 한 번 더 — pointerdown 단계에서 가로채는 레이어(캔버스는 pan을 위해
+    // preventDefault+포인터 캡처를 걸어 마우스 이벤트 합성이 끊긴다)가 mousedown을 삼켜도 닫히도록.
+    window.addEventListener("canvas-context-menu-close", onClose);
     return () => {
       document.removeEventListener("mousedown", handlePointer);
       document.removeEventListener("keydown", handleKey);
+      window.removeEventListener("canvas-context-menu-close", onClose);
     };
   }, [onClose]);
 
@@ -75,7 +82,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     <div
       className={`operation-launch-control operation-launch-control--canvas ${placement === "above" ? "operation-launch-control--up" : ""}`}
       ref={containerRef}
-      style={clampedAnchorStyle(anchor, viewportBounds, placement, menuSize)}
+      style={clampedAnchorStyle(anchor, viewportBounds, placement, menuSize, fixed)}
       data-canvas-blocker
     >
       <div
@@ -146,12 +153,14 @@ function clampedAnchorStyle(
   bounds: { readonly width: number; readonly height: number } | undefined,
   placement: "above" | "cursor",
   size: { readonly width: number; readonly height: number } | null,
+  fixed: boolean,
 ): CSSProperties {
   // 상한도 뷰포트에서 산출한다 — 520px보다 낮은 화면에서 메뉴가 잘려 나가지 않게.
   const maxHeight = bounds
     ? Math.max(MENU_MIN_HEIGHT, Math.min(MENU_MAX_HEIGHT, bounds.height - MENU_MARGIN * 2))
     : MENU_MAX_HEIGHT;
-  const base = { "--canvas-menu-max-height": `${maxHeight}px` };
+  const base = fixed ? { position: "fixed", "--canvas-menu-max-height": `${maxHeight}px` } as CSSProperties
+    : { "--canvas-menu-max-height": `${maxHeight}px` };
   const width = size?.width ?? MENU_WIDTH;
   // 측정 전 첫 렌더는 높이 0으로 두어 커서 좌표를 그대로 쓴다 —
   // useLayoutEffect 측정이 페인트 전에 반영되므로 위치가 튀지 않는다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -222,9 +222,15 @@ export function OperationsCanvas({
   const handleContextMenu = (event: ReactMouseEvent<HTMLElement>) => {
     if (event.target instanceof Element && event.target.closest("[data-canvas-blocker], [data-canvas-operation]")) return;
     event.preventDefault();
-    const rect = canvasRef.current?.getBoundingClientRect();
-    if (!rect) return;
-    const anchor: CanvasPoint = { x: event.clientX - rect.left, y: event.clientY - rect.top };
+    // 선별 처리/Formation은 map 좌표가 아닌 고정 배치라 메뉴 앵커를 커서 지점으로 둔다 —
+    // canvasPoint는 map 모드에서만 생성/실행 좌표로 쓰인다.
+    const anchor = triageActive
+      ? { x: event.clientX, y: event.clientY }
+      : (() => {
+          const rect = canvasRef.current?.getBoundingClientRect();
+          return rect ? { x: event.clientX - rect.left, y: event.clientY - rect.top } : null;
+        })();
+    if (!anchor) return;
     setContextMenu({ anchor, canvasPoint: screenToCanvas(anchor, canvas.viewport) });
   };
 
@@ -654,7 +660,13 @@ export function OperationsCanvas({
   return (
     <main
       className={`operations-canvas ${interaction.spaceActive ? "is-panning" : ""} ${interaction.shiftActive ? "is-creating" : ""} ${glanceVisible ? "is-glance" : ""} ${panelMaximized ? "is-panel-maximized" : ""} ${panelCompanion ? "is-companion-layout" : ""} ${formationView ? "is-formation-view" : ""} ${formationEntering ? "is-formation-entering" : ""} ${triageActive ? "is-triage" : ""} ${triageEntering ? "is-triage-entering" : ""}`}
-      onPointerDown={interaction.onPointerDown}
+      onPointerDown={(event) => {
+        // 캔버스 제어 메뉴가 어느 소유자(사이드바 포털/이 컴포넌트)로부터 열렸든 Map 클릭으로 닫는다 —
+        // pan의 preventDefault+포인터 캡처가 mousedown 합성을 끊어 포털의 외부-클릭 닫기가 못 잡는다.
+        // 메뉴 낶부 클릭은 data-canvas-blocker가 가로채 여기 도달하지 않는다.
+        window.dispatchEvent(new Event("canvas-context-menu-close"));
+        interaction.onPointerDown(event as Parameters<typeof interaction.onPointerDown>[0]);
+      }}
       onPointerMove={interaction.onPointerMove}
       onPointerUp={interaction.onPointerUp}
       onPointerCancel={interaction.onPointerCancel}
@@ -915,6 +927,7 @@ export function OperationsCanvas({
           renderKindIcon={renderKindIcon}
           onLaunchKind={handleContextMenuLaunchKind}
           onClose={() => setContextMenu(null)}
+          fixed={triageActive}
         />
       ) : null}
       <CanvasMinimap

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -661,10 +661,13 @@ export function OperationsCanvas({
     <main
       className={`operations-canvas ${interaction.spaceActive ? "is-panning" : ""} ${interaction.shiftActive ? "is-creating" : ""} ${glanceVisible ? "is-glance" : ""} ${panelMaximized ? "is-panel-maximized" : ""} ${panelCompanion ? "is-companion-layout" : ""} ${formationView ? "is-formation-view" : ""} ${formationEntering ? "is-formation-entering" : ""} ${triageActive ? "is-triage" : ""} ${triageEntering ? "is-triage-entering" : ""}`}
       onPointerDown={(event) => {
-        // 캔버스 제어 메뉴가 어느 소유자(사이드바 포털/이 컴포넌트)로부터 열렸든 Map 클릭으로 닫는다 —
-        // pan의 preventDefault+포인터 캡처가 mousedown 합성을 끊어 포털의 외부-클릭 닫기가 못 잡는다.
-        // 메뉴 낶부 클릭은 data-canvas-blocker가 가로채 여기 도달하지 않는다.
-        window.dispatchEvent(new Event("canvas-context-menu-close"));
+        // 메뉴 내부 클릭(캔버스 소유 메뉴는 <main> 자손이라 버블로 도달한다)은 실행 항목의
+        // click을 살리기 위해 닫기 신호를 본내지 않는다 — data-canvas-blocker는 전파를 멈추지 않는다.
+        if (!(event.target instanceof Element && event.target.closest("[data-canvas-blocker], [data-canvas-operation]"))) {
+          // 캔버스 제어 메뉴가 어느 소유자(사이드바 포털/이 컴포넌트)로부터 열었든 Map 클릭으로 닫는다 —
+          // pan의 preventDefault+포인터 캡처가 mousedown 합성을 끊어 포털의 외부-클릭 닫기가 못 잡는다.
+          window.dispatchEvent(new Event("canvas-context-menu-close"));
+        }
         interaction.onPointerDown(event as Parameters<typeof interaction.onPointerDown>[0]);
       }}
       onPointerMove={interaction.onPointerMove}

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -755,6 +755,9 @@ export function OperationsSideBar({
     if (event.defaultPrevented) return;
     event.preventDefault();
     setActiveContextMenu(null);
+    // 캔버스(Map) 쪽에 이미 열린 캔버스 제어 메뉴는 사이드바 <aside> 안에 있지 않아
+    // 포털의 mousedown 외부-클릭 닫기가 안 잡는다 — 포털이 구독하는 닫기 신호를 함께 본다.
+    window.dispatchEvent(new Event("canvas-context-menu-close"));
     setNewMenu({
       anchor: { x: event.clientX, y: event.clientY },
       viewportBounds: { width: window.innerWidth, height: window.innerHeight },

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -68,6 +68,15 @@ describe("CanvasContextMenu anchor placement", () => {
 
     expect(menuStyle().getPropertyValue("--canvas-menu-max-height")).toBe("376px");
   });
+
+  it("renders fixed at viewport coordinates when the fixed prop is set", () => {
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [], vi.fn(), true);
+
+    const style = menuStyle();
+    expect(style.position).toBe("fixed");
+    expect(style.left).toBe("520px");
+    expect(style.top).toBe("156px");
+  });
 });
 
 describe("CanvasContextMenu launch kind attribute", () => {
@@ -153,6 +162,14 @@ describe("CanvasContextMenu launch kind attribute", () => {
     expect(onClose).toHaveBeenCalledOnce();
   });
 
+  it("dismisses the menu on the shared close signal emitted by cross-surface interactions", () => {
+    const onClose = vi.fn();
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [], onClose);
+
+    act(() => window.dispatchEvent(new Event("canvas-context-menu-close")));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
   it("does not dismiss the menu before the feature tour card handles its click", () => {
     const onClose = vi.fn();
     renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [], onClose);
@@ -175,11 +192,13 @@ function renderMenu(
   viewportBounds: { readonly width: number; readonly height: number },
   catalog: readonly OperationCatalogPlugin[] = [],
   onClose = vi.fn(),
+  fixed = false,
 ): void {
   act(() => root.render(
     <CanvasContextMenu
       anchor={anchor}
       viewportBounds={viewportBounds}
+      fixed={fixed}
       catalog={catalog}
       canLaunch
       renderKindIcon={() => null}


### PR DESCRIPTION
## Summary
- 사이드바 우클릭으로 연 '캔버스 제어' 메뉴가 Map 좌클릭으로 닫히지 않던 문제 수정 — `<main>`의 pan `preventDefault`+포인터 캡처가 호환 `mousedown` 합성을 끊어 포털의 외부-클릭 닫기가 발동하지 않았고, 캔버스 consume 경로는 캔버스 자체 `contextMenu`만 추적해 사이드바 소유 메뉴(`newMenu`)를 닫지 못했다. `<main>` pointerdown과 사이드바 메뉴 오픈 시 공용 `canvas-context-menu-close` 신호를 본내고 포털이 구독하도록 해 소유자와 무관하게 닫히게 한다.
- 선별 처리 모드에서 우클릭 시 동일한 '캔버스 제어' 메뉴 제공 — 스테이지 프레임/Watch Deck가 캔버스 상대 좌표 공간을 덮으므로 `fixed` prop으로 뷰포트(커서) 좌표에 `position: fixed` 렌더. 실행 종류는 map 제스처 게이트와 마찬가지로 비활성 유지.

## Test Plan
- [x] `pnpm --filter fleet-console typecheck` — 0 errors
- [x] `vitest run tests/canvas-context-menu-anchor.test.tsx` — 12/12 (닫기 신호·fixed 배치 테스트 추가)
- [x] 인접 스위트(triage-store, triage-stage-companion, canvas-store, empty-state) 113/113
- [x] 격리 콘솔 + 실브라우저 e2e: 사이드바 우클릭→메뉴→Map 좌클릭 닫힘 ✅ / 선별 처리 우클릭→메뉴 표시(fixed)→좌클릭 닫힘·모드 유지 ✅ / 일반 Map 모드 회귀 ✅
- [x] `.changelog.d/pr-503.md` — fragment 문법·이중 언어 요약·컴파일러 검증 완료