### PR TITLE
fix(fleet-wiki): 한글 등 비라틴 문자 검색 토픽이 토큰화되지 않는 문제 수정

### DIFF
--- a/.changelog.d/pr-514.md
+++ b/.changelog.d/pr-514.md
@@ -1,0 +1,5 @@
+### fleet-core
+
+#### Fixed
+- [fleet-wiki] Wiki retrieval now tokenizes non-Latin topics, so a multi-word Korean query reaches per-token matching instead of returning nothing from `wiki_briefing`, `wiki_query`, and `wiki_resolve`.
+  ko: 위키 검색이 비라틴 문자 토픽을 토큰화하므로, 여러 단어로 된 한국어 질의가 `wiki_briefing`, `wiki_query`, `wiki_resolve`에서 빈 결과 대신 토큰 단위 매칭에 도달합니다.

--- a/packages/fleet-wiki/src/briefing.ts
+++ b/packages/fleet-wiki/src/briefing.ts
@@ -351,7 +351,10 @@ const MATCH_CONTEXT_AFTER = 80;
 export function tokenizeRetrievalTopic(topic: string): string[] {
   const tokens = topic
     .toLowerCase()
-    .split(/[^a-z0-9]+/i)
+    // Unicode letter/number classes so non-Latin scripts (Korean queries are
+    // the norm in this workspace) survive tokenization; [^a-z0-9] treated
+    // every Hangul character as a separator and produced zero tokens.
+    .split(/[^\p{L}\p{N}]+/u)
     .map((token) => token.trim())
     .filter((token) => token.length > 1 || /^[0-9]+$/.test(token));
   return dedupeStrings(tokens);

--- a/packages/fleet-wiki/tests/wiki-briefing.test.ts
+++ b/packages/fleet-wiki/tests/wiki-briefing.test.ts
@@ -304,6 +304,27 @@ describe("wiki briefing", () => {
     expect(hits[0]?.excerpt).toContain("<<<FLEET_WIKI_ENTRY_END>>>");
     expect(hits[0]?.matchedSnippets?.[0]?.snippet).toContain("<<<FLEET_WIKI_ENTRY_BEGIN");
   });
+
+  it("matches Korean multi-word topics through unicode tokenization", async () => {
+    const root = await makeTempRoot();
+    const paths = resolveMemoryPaths(root);
+
+    await writeWikiEntry({
+      id: "unit-renderer",
+      title: "유닛 렌더러 계약",
+      tags: ["rf2"],
+      created: "2026-04-26T00:00:00.000Z",
+      updated: "2026-04-26T00:00:00.000Z",
+      version: 1,
+      body: "렌더러 적용은 지연 실행이다. 머트리얼 예약과 파라미터 반영 경로를 다룬다.",
+    }, paths);
+
+    // No exact phrase match — recall must come from per-token matching, which
+    // previously produced zero tokens for Hangul-only topics.
+    const hits = await briefingQuery(paths, { topic: "머트리얼 렌더러 동작", limit: 5 });
+
+    expect(hits.map((hit) => hit.id)).toContain("unit-renderer");
+  });
 });
 
 async function makeTempRoot(): Promise<string> {


### PR DESCRIPTION
## 문제

`tokenizeRetrievalTopic`의 `split(/[^a-z0-9]+/i)`가 한글(비라틴 문자)을 전부 구분자로 처리해서, 한글 멀티 토큰 토픽(예: "스킬 시스템")이 토큰 0개가 됩니다. 이 경우 `topicTokens.length <= 1` 가드에 걸려 token-OR 매칭 경로에 진입하지 못하고 `wiki_briefing` / `wiki_query` / `wiki_resolve`가 0건을 반환합니다.

단일 한글 토큰(예: "스킬")은 exact-phrase 경로(`includes`)로 매칭되어 정상처럼 보이기 때문에 발견이 늦었습니다.

## 수정

- `[^a-z0-9]` → 유니코드 문자/숫자 클래스 `[^\p{L}\p{N}]` + `u` 플래그
- 한글 briefing 회귀 테스트 추가

## 검증

- `packages/fleet-wiki`에서 `vitest run tests/wiki-briefing.test.ts` **8/8 PASS** (v1.47.0 / `26de503f` 기준)
- 한국어 워크스페이스에서는 위키 검색 토픽이 대부분 한글이라 실사용에서 바로 드러나는 문제였습니다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)