### PR TITLE
feat(core-ai-gateway): guard gateway runs against oversized skills

### DIFF
--- a/.changelog.d/pr-518.md
+++ b/.changelog.d/pr-518.md
@@ -1,0 +1,9 @@
+### fleet-core
+
+#### Added
+- [core-ai-gateway] Withhold a skill body a gateway model's context window cannot afford, replace it with a stub naming its size, and drop that skill from the listing from then on so the model stops spending a turn loading what it will never receive. The rule measures size rather than names, because skills ship inside the client binary, change every release, and are not on disk until they load; a window of 1M or more keeps a payload it can afford while every smaller one refuses it.
+  ko: 게이트웨이 모델의 컨텍스트 창이 감당할 수 없는 스킬 본문을 보류하고 크기를 명시한 스텁으로 대체하며, 이후 그 스킬을 목록에서도 제거해 모델이 받지 못할 것을 적재하느라 턴을 쓰지 않게 합니다. 스킬은 클라이언트 바이너리 안에 있고 릴리스마다 바뀌며 적재 전에는 디스크에 없으므로 이름이 아니라 크기로 판정하며, 1M 이상 창은 감당 가능한 본문을 유지하고 그보다 작은 창은 모두 거부합니다.
+
+#### Fixed
+- [core-ai-gateway] A gateway turn that exceeds the model's real context window is now refused as HTTP 413 whose message names the context window, the only shape Claude Code arms reactive compaction from, so the run compacts and continues instead of ending with no compaction attempted.
+  ko: 모델의 실제 컨텍스트 창을 넘긴 게이트웨이 턴을 이제 컨텍스트 창을 명시한 HTTP 413으로 거절합니다. Claude Code가 reactive compaction을 무장하는 유일한 형태라, 압축 시도 없이 턴이 끝나는 대신 압축 후 계속됩니다.

--- a/packages/core-ai-gateway/src/claude-context.ts
+++ b/packages/core-ai-gateway/src/claude-context.ts
@@ -1,3 +1,5 @@
+import { estimateTokens } from "./token-estimate.js";
+
 export const CLAUDE_COMPAT_CONTEXT_WINDOW = 1_000_000;
 export const CLAUDE_DEFAULT_CONTEXT_WINDOW = 200_000;
 const DEFAULT_MAX_JSON_BYTES = 16 * 1024 * 1024;
@@ -405,4 +407,187 @@ function positiveContextWindow(value: number | undefined): number | undefined {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Claude Code's own preamble on a skill body it has loaded into the conversation. */
+const CLAUDE_SKILL_BODY_PREFIX = "Base directory for this skill:";
+/** Claude Code's own preamble on the skill listing it attaches to a conversation. */
+const CLAUDE_SKILL_LISTING_PREFIX = "The following skills are available for use with the Skill tool:";
+/** Entry line in that listing: `- <name>: <description>`, continued by unprefixed lines. */
+const CLAUDE_SKILL_LISTING_ENTRY = /^- ([A-Za-z0-9_.:-]+): /;
+/** Share of a model's real window one skill body may occupy before it is withheld. */
+export const CLAUDE_SKILL_BODY_BUDGET_FRACTION = 0.1;
+
+interface ClaudeTextBlockLike {
+  readonly type?: unknown;
+  readonly text?: unknown;
+}
+
+/** Structural shape of an Anthropic message, kept local so this module stays a leaf. */
+interface ClaudeMessageLike {
+  readonly content: unknown;
+}
+
+export interface ClaudeSkillPruneOptions {
+  /** The model's real context window. Omit to leave skill bodies untouched. */
+  readonly contextWindow?: number;
+  /** Upstream wire model id, for the estimator's characters-per-token ratio. */
+  readonly model?: string;
+  /** Skills already withheld on this connection. Their listing entries go before turn one. */
+  readonly withheld?: ReadonlySet<string>;
+  /** Share of the window one skill body may occupy. Defaults to the exported fraction. */
+  readonly budgetFraction?: number;
+}
+
+export interface ClaudeWithheldSkill {
+  readonly name: string;
+  readonly tokens: number;
+}
+
+export interface ClaudeSkillPruneResult<M> {
+  readonly messages: readonly M[];
+  readonly changed: boolean;
+  /** Skill bodies replaced by a stub in this request. */
+  readonly withheld: readonly ClaudeWithheldSkill[];
+  /** Listing entries removed in this request. */
+  readonly delisted: readonly string[];
+}
+
+/**
+ * Withhold skill payloads a model's window cannot afford, and hide the skills they
+ * came from.
+ *
+ * A Claude Code skill body arrives as one user text block and is re-sent every turn,
+ * so an oversized one is a fixed tax the client's own compaction can never reclaim —
+ * it only ever shrinks the conversation around it. One measured skill body occupied
+ * 162,681 estimated tokens, 60% of a 272,000-token window, before the agent had read
+ * a single file.
+ *
+ * Size is the test, never a name: skills ship inside the client binary, change with
+ * every release, and are not on disk until the moment they are loaded, so a list of
+ * bad names cannot be written in advance or kept correct. The only layer that can see
+ * how large one actually is, is the one the bytes pass through.
+ *
+ * Withholding a body also teaches the caller that skill's name, which removes its
+ * listing entry from then on so the model stops spending a turn loading something it
+ * will never receive. The caller owns that set, and its lifetime is the caller's:
+ * hold it for the process and the cost is one stubbed turn, ever.
+ */
+export function pruneClaudeSkillPayloads<M extends ClaudeMessageLike>(
+  messages: readonly M[],
+  options: ClaudeSkillPruneOptions = {},
+): ClaudeSkillPruneResult<M> {
+  const budget = skillBodyBudget(options);
+  const known = new Set(options.withheld ?? []);
+  const withheld: ClaudeWithheldSkill[] = [];
+  const delisted: string[] = [];
+  let changed = false;
+
+  // Bodies first: one withheld here must also leave the listing in this same request.
+  const bodies = messages.map((message) => mapClaudeMessageText(message, (text) => {
+    if (budget === undefined || !text.startsWith(CLAUDE_SKILL_BODY_PREFIX)) return text;
+    const tokens = estimateTokens(text, options.model);
+    if (tokens <= budget) return text;
+    const name = claudeSkillNameFromBody(text);
+    withheld.push({ name, tokens });
+    known.add(name);
+    changed = true;
+    return withheldClaudeSkillStub(name, tokens, budget);
+  }));
+
+  if (known.size === 0) return { messages: bodies, changed, withheld, delisted };
+
+  const listings = bodies.map((message) => mapClaudeMessageText(message, (text) => {
+    if (!text.startsWith(CLAUDE_SKILL_LISTING_PREFIX)) return text;
+    const next = removeClaudeSkillListingEntries(text, known, delisted);
+    if (next !== text) changed = true;
+    return next;
+  }));
+
+  return { messages: listings, changed, withheld, delisted };
+}
+
+function skillBodyBudget(options: ClaudeSkillPruneOptions): number | undefined {
+  const window = options.contextWindow;
+  if (typeof window !== "number" || !Number.isFinite(window) || window <= 0) return undefined;
+  const fraction = options.budgetFraction ?? CLAUDE_SKILL_BODY_BUDGET_FRACTION;
+  if (!Number.isFinite(fraction) || fraction <= 0 || fraction >= 1) return undefined;
+  return Math.floor(window * fraction);
+}
+
+function mapClaudeMessageText<M extends ClaudeMessageLike>(
+  message: M,
+  map: (text: string) => string,
+): M {
+  const content = message.content;
+  if (typeof content === "string") {
+    const next = map(content);
+    return next === content ? message : { ...message, content: next } as M;
+  }
+  if (!Array.isArray(content)) return message;
+  let changed = false;
+  const blocks = content.map((block: unknown) => {
+    if (!isClaudeTextBlock(block)) return block;
+    const next = map(block.text);
+    if (next === block.text) return block;
+    changed = true;
+    return { ...block, text: next };
+  });
+  return changed ? { ...message, content: blocks } as M : message;
+}
+
+function isClaudeTextBlock(block: unknown): block is { readonly text: string } {
+  if (typeof block !== "object" || block === null) return false;
+  const candidate = block as ClaudeTextBlockLike;
+  return candidate.type === "text" && typeof candidate.text === "string";
+}
+
+/** The skill directory's last segment. `.../skills/workflow` is the skill `workflow`. */
+function claudeSkillNameFromBody(text: string): string {
+  const breakAt = text.indexOf("\n");
+  const firstLine = breakAt === -1 ? text : text.slice(0, breakAt);
+  const directory = firstLine.slice(CLAUDE_SKILL_BODY_PREFIX.length).trim();
+  const segments = directory.split("/").filter((segment) => segment.length > 0);
+  return segments[segments.length - 1] ?? "";
+}
+
+/**
+ * A plugin skill is listed under a namespaced name (`fleet:workflow`) but loaded from a
+ * directory named for its last segment, so the listing name matches on that tail too.
+ */
+function claudeSkillListingMatches(entryName: string, withheldName: string): boolean {
+  if (withheldName.length === 0) return false;
+  if (entryName === withheldName) return true;
+  return entryName.slice(entryName.lastIndexOf(":") + 1) === withheldName;
+}
+
+function removeClaudeSkillListingEntries(
+  text: string,
+  withheld: ReadonlySet<string>,
+  delisted: string[],
+): string {
+  const kept: string[] = [];
+  let dropping = false;
+  for (const line of text.split("\n")) {
+    const entry = CLAUDE_SKILL_LISTING_ENTRY.exec(line);
+    if (entry) {
+      const name = entry[1] ?? "";
+      dropping = false;
+      for (const candidate of withheld) {
+        if (claudeSkillListingMatches(name, candidate)) {
+          dropping = true;
+          delisted.push(name);
+          break;
+        }
+      }
+    }
+    if (!dropping) kept.push(line);
+  }
+  return kept.join("\n");
+}
+
+function withheldClaudeSkillStub(name: string, tokens: number, budget: number): string {
+  return `[Fleet AI gateway withheld the "${name}" skill: its body is about ${tokens} tokens, `
+    + `over the ${budget}-token ceiling one skill may take from this model's context window. `
+    + `Read the skill's own files if you need it, or run this work on a model with a larger window.]`;
 }

--- a/packages/core-ai-gateway/src/claude-context.ts
+++ b/packages/core-ai-gateway/src/claude-context.ts
@@ -415,8 +415,20 @@ const CLAUDE_SKILL_BODY_PREFIX = "Base directory for this skill:";
 const CLAUDE_SKILL_LISTING_PREFIX = "The following skills are available for use with the Skill tool:";
 /** Entry line in that listing: `- <name>: <description>`, continued by unprefixed lines. */
 const CLAUDE_SKILL_LISTING_ENTRY = /^- ([A-Za-z0-9_.:-]+): /;
-/** Share of a model's real window one skill body may occupy before it is withheld. */
-export const CLAUDE_SKILL_BODY_BUDGET_FRACTION = 0.1;
+/**
+ * Share of a model's real window one skill body may occupy before it is withheld.
+ *
+ * Calibrated against the catalog so a model that can afford a payload keeps it. At this
+ * share the measured 162,681-token skill passes on every window of 1M or more — 16% of
+ * one, leaving 824k to work in — and is refused on every window below that, including
+ * the 272,000-token model it overran. No branch on the window is needed: the fraction
+ * lands the split exactly where affordability does.
+ *
+ * The largest skill this repository ships estimates at 8,303 tokens, more than 4x under
+ * the ceiling this produces for even the smallest catalog window, so an ordinary skill
+ * never reaches the rule.
+ */
+export const CLAUDE_SKILL_BODY_BUDGET_FRACTION = 0.2;
 
 interface ClaudeTextBlockLike {
   readonly type?: unknown;

--- a/packages/core-ai-gateway/src/cursor-adapter.ts
+++ b/packages/core-ai-gateway/src/cursor-adapter.ts
@@ -40,8 +40,8 @@ import {
   ConversationTurnStructureSchema,
   UserMessageSchema,
 } from "./generated/cursor-agent-protobuf.js";
-import { estimateTokens } from "./gateway.js";
 import { resolveCursorModelSelection } from "./models.js";
+import { estimateTokens } from "./token-estimate.js";
 
 export const CURSOR_API_ORIGIN = "https://api2.cursor.sh";
 export const CURSOR_RUN_PATH = "/agent.v1.AgentService/Run";

--- a/packages/core-ai-gateway/src/gateway.ts
+++ b/packages/core-ai-gateway/src/gateway.ts
@@ -10,49 +10,26 @@ import type {
   CanonicalResponseRequest,
 } from "./canonical.js";
 import { OpenAIResponsesAdapter } from "./openai-responses-adapter.js";
+import { estimateTokens } from "./token-estimate.js";
 import { logCanonicalEvents, wireLog, wireLogEnabled } from "./wire-log.js";
 
-const DEFAULT_CHARS_PER_TOKEN = 4;
-const CODE_MODEL_CHARS_PER_TOKEN = 3.5;
-const CJK_CHARS_PER_TOKEN = 2.5;
-const CJK_RATIO_THRESHOLD = 0.3;
-const CODE_MODEL_PREFIXES = ["kiro", "claude", "deepseek", "minimax", "glm", "qwen"];
-const CJK_RE = /[\uAC00-\uD7A3\u1100-\u11FF\u3130-\u318F\u4E00-\u9FFF\u3400-\u4DBF\u3040-\u30FF]/;
-
-export function estimateTokens(text: string, modelId?: string): number {
-  if (text.length === 0) return 0;
-  let charsPerToken = modelCharsPerToken(modelId);
-  if (cjkRatio(text) > CJK_RATIO_THRESHOLD) {
-    charsPerToken = Math.min(charsPerToken, CJK_CHARS_PER_TOKEN);
-  }
-  return Math.max(1, Math.ceil(text.length / charsPerToken));
-}
-
-function modelCharsPerToken(modelId: string | undefined): number {
-  const normalized = modelId?.toLowerCase();
-  return normalized && CODE_MODEL_PREFIXES.some((prefix) => normalized.startsWith(prefix))
-    ? CODE_MODEL_CHARS_PER_TOKEN
-    : DEFAULT_CHARS_PER_TOKEN;
-}
-
-function cjkRatio(text: string): number {
-  const stride = text.length > 2_048 ? Math.ceil(text.length / 2_048) : 1;
-  let cjk = 0;
-  let sampled = 0;
-  for (let index = 0; index < text.length; index += stride) {
-    sampled += 1;
-    if (CJK_RE.test(text[index] ?? "")) cjk += 1;
-  }
-  return sampled === 0 ? 0 : cjk / sampled;
-}
-
-/** Claude Code recognizes this prefix and routes the failed turn through reactive compaction. */
+/**
+ * Refusal Claude Code can recover from, rather than one that ends the turn.
+ *
+ * Claude Code classifies an overflow only from an HTTP **413** whose message contains
+ * `context window`; that classification is what arms its reactive compaction. The
+ * `Prompt is too long` prefix is a second, separate contract — the compaction routine
+ * matches it to decide that its own summarization request overflowed and to retry with
+ * older messages dropped. Both are required, so the message carries the prefix and the
+ * phrase, and `writeAnthropicError` must send this as 413. Any other status is surfaced
+ * as a plain failure and the turn dies with no compaction attempted.
+ */
 export class ContextWindowExceededError extends Error {
   constructor(
     readonly requestTokens: number,
     readonly contextWindow: number,
   ) {
-    super(`Prompt is too long: ${requestTokens} tokens > ${contextWindow} maximum`);
+    super(`Prompt is too long: ${requestTokens} tokens > ${contextWindow} maximum context window`);
     this.name = "ContextWindowExceededError";
   }
 }

--- a/packages/core-ai-gateway/src/index.ts
+++ b/packages/core-ai-gateway/src/index.ts
@@ -3,7 +3,8 @@ export * from "./canonical.js";
 export * from "./claude-context.js";
 export * from "./cursor-adapter.js";
 export * from "./provider-credentials.js";
-// estimateTokens 는 어댑터 내부 헬퍼다 — 배럴로 올리면 패키지 공개 계약이 넓어진다.
+// token-estimate.js 는 의도적으로 배럴 밖이다 — estimateTokens 는 이 패키지가 요청을
+// 내보내기 전에 쓰는 내부 휴리스틱이고, 올리면 공개 계약이 넓어진다.
 export { AnthropicMessagesGateway, ContextWindowExceededError } from "./gateway.js";
 export type { AnthropicGatewayCallOptions, AnthropicGatewayResponse } from "./gateway.js";
 export * from "./models.js";

--- a/packages/core-ai-gateway/src/token-estimate.ts
+++ b/packages/core-ai-gateway/src/token-estimate.ts
@@ -1,0 +1,41 @@
+/**
+ * Deterministic character-based token estimate.
+ *
+ * Not a tokenizer. It backs decisions that must be made before a request leaves this
+ * package — the pre-flight overflow guard and the oversized-payload guard — where an
+ * exact count is unavailable and a conservative one is the safe direction.
+ */
+
+const DEFAULT_CHARS_PER_TOKEN = 4;
+const CODE_MODEL_CHARS_PER_TOKEN = 3.5;
+const CJK_CHARS_PER_TOKEN = 2.5;
+const CJK_RATIO_THRESHOLD = 0.3;
+const CODE_MODEL_PREFIXES = ["kiro", "claude", "deepseek", "minimax", "glm", "qwen"];
+const CJK_RE = /[\uAC00-\uD7A3\u1100-\u11FF\u3130-\u318F\u4E00-\u9FFF\u3400-\u4DBF\u3040-\u30FF]/;
+
+export function estimateTokens(text: string, modelId?: string): number {
+  if (text.length === 0) return 0;
+  let charsPerToken = modelCharsPerToken(modelId);
+  if (cjkRatio(text) > CJK_RATIO_THRESHOLD) {
+    charsPerToken = Math.min(charsPerToken, CJK_CHARS_PER_TOKEN);
+  }
+  return Math.max(1, Math.ceil(text.length / charsPerToken));
+}
+
+function modelCharsPerToken(modelId: string | undefined): number {
+  const normalized = modelId?.toLowerCase();
+  return normalized && CODE_MODEL_PREFIXES.some((prefix) => normalized.startsWith(prefix))
+    ? CODE_MODEL_CHARS_PER_TOKEN
+    : DEFAULT_CHARS_PER_TOKEN;
+}
+
+function cjkRatio(text: string): number {
+  const stride = text.length > 2_048 ? Math.ceil(text.length / 2_048) : 1;
+  let cjk = 0;
+  let sampled = 0;
+  for (let index = 0; index < text.length; index += stride) {
+    sampled += 1;
+    if (CJK_RE.test(text[index] ?? "")) cjk += 1;
+  }
+  return sampled === 0 ? 0 : cjk / sampled;
+}

--- a/packages/core-ai-gateway/tests/claude-skill-prune.test.ts
+++ b/packages/core-ai-gateway/tests/claude-skill-prune.test.ts
@@ -135,4 +135,20 @@ describe("pruneClaudeSkillPayloads", () => {
 
     expect(second.messages[0]!.content[0]!.text).toBe(first.messages[0]!.content[0]!.text);
   });
+
+  it("keeps a payload a 1M model can afford, and refuses it on every smaller window", () => {
+    // The skill body measured in the incident: 650,724 characters, 162,681 tokens.
+    const body = skillBody("claude-api", 650_724);
+
+    const onOneMillion = pruneClaudeSkillPayloads([userText(body)], { contextWindow: 1_000_000 });
+    const onTwoSeventyTwo = pruneClaudeSkillPayloads([userText(body)], { contextWindow: CONTEXT_WINDOW });
+    const onFiveHundred = pruneClaudeSkillPayloads([userText(body)], { contextWindow: 500_000 });
+
+    expect(onOneMillion.withheld).toEqual([]);
+    expect(onOneMillion.messages[0]!.content[0]!.text).toBe(body);
+    expect(onTwoSeventyTwo.withheld).toEqual([{ name: "claude-api", tokens: 162_681 }]);
+    // 500_000 is the largest window that still cannot afford it, so the split is not
+    // "carries the [1m] marker" — it is the window the payload actually fits inside.
+    expect(onFiveHundred.withheld).toEqual([{ name: "claude-api", tokens: 162_681 }]);
+  });
 });

--- a/packages/core-ai-gateway/tests/claude-skill-prune.test.ts
+++ b/packages/core-ai-gateway/tests/claude-skill-prune.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CLAUDE_SKILL_BODY_BUDGET_FRACTION,
+  pruneClaudeSkillPayloads,
+} from "../src/claude-context.js";
+
+const CONTEXT_WINDOW = 272_000;
+const BUDGET_TOKENS = CONTEXT_WINDOW * CLAUDE_SKILL_BODY_BUDGET_FRACTION;
+
+/** Claude Code's own skill-body preamble, followed by enough text to blow the budget. */
+function skillBody(name: string, chars: number): string {
+  const head = `Base directory for this skill: /tmp/bundled-skills/2.1.222/abc123/${name}\n\n`;
+  return head + "x".repeat(Math.max(0, chars - head.length));
+}
+
+const LISTING = [
+  "The following skills are available for use with the Skill tool:",
+  "",
+  "- agent-browser: Browser automation CLI for AI agents.",
+  "- claude-api: Reference for the Claude API / Anthropic SDK.",
+  "TRIGGER — read BEFORE opening the target file; don't skip because it looks like a one-liner.",
+  "SKIP only when another provider is being worked on.",
+  "- fleet:workflow: Run a staged multi-agent operation.",
+  "- dataviz: Use this skill whenever you are about to create ANY chart.",
+].join("\n");
+
+function userText(text: string): { role: "user"; content: { type: "text"; text: string }[] } {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+describe("pruneClaudeSkillPayloads", () => {
+  it("withholds a skill body over the model's per-skill budget", () => {
+    // 4 chars/token against a 272_000 window puts this well past the 27_200 ceiling.
+    const messages = [userText(skillBody("claude-api", 400_000))];
+
+    const result = pruneClaudeSkillPayloads(messages, { contextWindow: CONTEXT_WINDOW });
+
+    expect(result.changed).toBe(true);
+    expect(result.withheld).toEqual([{ name: "claude-api", tokens: 100_000 }]);
+    const [block] = result.messages[0]!.content;
+    expect(block!.text).toMatch(/^\[Fleet AI gateway withheld the "claude-api" skill/);
+    expect(block!.text).toContain(`${BUDGET_TOKENS}-token ceiling`);
+    expect(block!.text).not.toContain("xxxx");
+  });
+
+  it("leaves a skill body inside the budget byte-for-byte intact", () => {
+    const body = skillBody("git-worktree", 20_000);
+    const messages = [userText(body)];
+
+    const result = pruneClaudeSkillPayloads(messages, { contextWindow: CONTEXT_WINDOW });
+
+    expect(result.changed).toBe(false);
+    expect(result.withheld).toEqual([]);
+    expect(result.messages[0]!.content[0]!.text).toBe(body);
+  });
+
+  it("leaves every body alone when the model declares no window", () => {
+    const body = skillBody("claude-api", 400_000);
+
+    const result = pruneClaudeSkillPayloads([userText(body)], {});
+
+    expect(result.changed).toBe(false);
+    expect(result.messages[0]!.content[0]!.text).toBe(body);
+  });
+
+  it("drops the withheld skill's listing entry and its continuation lines", () => {
+    const messages = [
+      userText(LISTING),
+      userText(skillBody("claude-api", 400_000)),
+    ];
+
+    const result = pruneClaudeSkillPayloads(messages, { contextWindow: CONTEXT_WINDOW });
+
+    expect(result.delisted).toEqual(["claude-api"]);
+    const listing = result.messages[0]!.content[0]!.text;
+    expect(listing).not.toContain("claude-api");
+    expect(listing).not.toContain("TRIGGER —");
+    expect(listing).not.toContain("SKIP only when");
+    // Neighbouring entries survive, including the one directly after the dropped block.
+    expect(listing).toContain("- agent-browser: Browser automation CLI for AI agents.");
+    expect(listing).toContain("- fleet:workflow: Run a staged multi-agent operation.");
+    expect(listing).toContain("- dataviz: Use this skill whenever");
+  });
+
+  it("delists from the first request when the caller already learned the skill", () => {
+    const result = pruneClaudeSkillPayloads([userText(LISTING)], {
+      contextWindow: CONTEXT_WINDOW,
+      withheld: new Set(["claude-api"]),
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.withheld).toEqual([]);
+    expect(result.messages[0]!.content[0]!.text).not.toContain("claude-api");
+  });
+
+  it("matches a namespaced listing name against the skill's directory name", () => {
+    const result = pruneClaudeSkillPayloads([userText(LISTING)], {
+      contextWindow: CONTEXT_WINDOW,
+      withheld: new Set(["workflow"]),
+    });
+
+    expect(result.delisted).toEqual(["fleet:workflow"]);
+    expect(result.messages[0]!.content[0]!.text).not.toContain("fleet:workflow");
+    expect(result.messages[0]!.content[0]!.text).toContain("- claude-api:");
+  });
+
+  it("reads and rewrites plain string content as well as block arrays", () => {
+    const messages = [{ role: "user" as const, content: skillBody("claude-api", 400_000) }];
+
+    const result = pruneClaudeSkillPayloads(messages, { contextWindow: CONTEXT_WINDOW });
+
+    expect(result.withheld).toEqual([{ name: "claude-api", tokens: 100_000 }]);
+    expect(result.messages[0]!.content).toMatch(/^\[Fleet AI gateway withheld/);
+  });
+
+  it("returns the original messages untouched when nothing crosses the budget", () => {
+    const messages = [userText("just a normal turn"), userText(LISTING)];
+
+    const result = pruneClaudeSkillPayloads(messages, { contextWindow: CONTEXT_WINDOW });
+
+    expect(result.changed).toBe(false);
+    expect(result.messages[0]).toBe(messages[0]);
+    expect(result.messages[1]).toBe(messages[1]);
+  });
+
+  it("keeps the stub stable across turns so the cached prefix survives", () => {
+    const body = skillBody("claude-api", 400_000);
+
+    const first = pruneClaudeSkillPayloads([userText(body)], { contextWindow: CONTEXT_WINDOW });
+    const second = pruneClaudeSkillPayloads([userText(body)], {
+      contextWindow: CONTEXT_WINDOW,
+      withheld: new Set(["claude-api"]),
+    });
+
+    expect(second.messages[0]!.content[0]!.text).toBe(first.messages[0]!.content[0]!.text);
+  });
+});

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -3002,7 +3002,7 @@ describe("pre-flight context window guard", () => {
     expect(error).toBeInstanceOf(ContextWindowExceededError);
     const overflow = error as ContextWindowExceededError;
     expect(overflow.name).toBe("ContextWindowExceededError");
-    expect(overflow.message).toMatch(/^Prompt is too long: \d+ tokens > \d+ maximum$/);
+    expect(overflow.message).toMatch(/^Prompt is too long: \d+ tokens > \d+ maximum context window$/);
     // Claude Code's three classifiers: prefix, lowercased substring, numeric extraction.
     expect(overflow.message.startsWith("Prompt is too long")).toBe(true);
     expect(overflow.message.toLowerCase()).toContain("prompt is too long");

--- a/packages/core-ai-gateway/tests/token-estimate.test.ts
+++ b/packages/core-ai-gateway/tests/token-estimate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { estimateTokens } from "../src/gateway.js";
+import { estimateTokens } from "../src/token-estimate.js";
 
 describe("token estimate", () => {
   it("uses the conservative model ratio for code-oriented model families", () => {

--- a/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
@@ -15,6 +15,7 @@ import {
   findGatewayModel,
   hasClaudeOneMillionMarker,
   projectAnthropicResponseUsage,
+  pruneClaudeSkillPayloads,
   reasoningEffortFromOutputConfig,
   resolveCodexCredentials,
   resolveCursorCredentials,
@@ -122,6 +123,9 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps = {}): AiGatewayR
   const ownedCursorGateway = ownedCursorAdapter
     ? new AnthropicMessagesGateway(ownedCursorAdapter)
     : undefined;
+  // 창을 감당 못 해 본문이 한 번 보류된 스킬들. 이 라우터가 사는 동안 유지해야
+  // 다음 세션의 첫 요청부터 목록에서 빠진다 — 프로세스당 한 번만 낭비되는 턴이 된다.
+  const withheldSkills = new Set<string>();
   // 설정 리더가 있으면 노출은 opt-in(켠 모델만)이다. 미주입(테스트 하네스 등)일 때만
   // 전체 카탈로그로 동작한다 — Console 배선(routes.ts)은 항상 리더를 주입한다.
   const gatewaySettings = async (): Promise<AiGatewayStoredSettings | undefined> => (
@@ -190,6 +194,18 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps = {}): AiGatewayR
     if (!target && requested.startsWith(GATEWAY_MODEL_ALIAS_PREFIX)) {
       writeAnthropicError(res, 400, "invalid_request_error", `Unknown AI gateway model: ${requested}`);
       return true;
+    }
+
+    // 스킬 본문은 매 턴 재전송되는 고정 비용이라 클라이언트 압축이 걷어낼 수 없다.
+    // 프로바이더 분기보다 앞이어야 canonical을 거치지 않는 passthrough까지 함께 덮는다.
+    if (target) {
+      const pruned = pruneClaudeSkillPayloads(body.messages, {
+        ...(typeof target.contextWindow === "number" ? { contextWindow: target.contextWindow } : {}),
+        model: upstreamModelId(target),
+        withheld: withheldSkills,
+      });
+      for (const skill of pruned.withheld) withheldSkills.add(skill.name);
+      if (pruned.changed) body = { ...body, messages: [...pruned.messages] };
     }
 
     let credential = "";
@@ -313,6 +329,11 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps = {}): AiGatewayR
         || error instanceof UnsupportedReasoningEffortError
         || error instanceof ContextWindowExceededError;
       const type = invalidRequest ? "invalid_request_error" : "api_error";
+      // Claude Code arms reactive compaction only from a 413 whose message names the
+      // context window; a 400 carrying the same text ends the turn instead. Everything
+      // else keeps 400 — a Cursor transport-budget refusal is not an overflow, and
+      // reporting it as one would send the client compacting after the wrong thing.
+      const status = error instanceof ContextWindowExceededError ? 413 : invalidRequest ? 400 : 502;
       const message = errorMessage(error);
       if (res.headersSent) {
         // 헤더를 보낸 뒤에는 상태 코드를 바꿀 수 없다. 그냥 끊으면 클라이언트는
@@ -320,7 +341,7 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps = {}): AiGatewayR
         writeSseErrorFrame(res, type, message);
         res.end();
       } else {
-        writeAnthropicError(res, invalidRequest ? 400 : 502, type, message);
+        writeAnthropicError(res, status, type, message);
       }
     } finally {
       req.off("close", abort);

--- a/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
@@ -429,12 +429,12 @@ describe("model context window", () => {
       messages: [{ role: "user", content: "x".repeat(2_000_000) }],
     }));
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(413);
     expect(JSON.parse(res.body)).toEqual({
       type: "error",
       error: {
         type: "invalid_request_error",
-        message: expect.stringMatching(/^Prompt is too long: \d+ tokens > 272000 maximum$/),
+        message: expect.stringMatching(/^Prompt is too long: \d+ tokens > 272000 maximum context window$/),
       },
     });
     // The guard runs inside the gateway, so upstream was still spared the turn.
@@ -528,7 +528,7 @@ describe("mid-stream failure", () => {
       type: "error",
       error: {
         type: "invalid_request_error",
-        message: "Prompt is too long: 300000 tokens > 272000 maximum",
+        message: "Prompt is too long: 300000 tokens > 272000 maximum context window",
       },
     });
   });

--- a/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
@@ -7,6 +7,7 @@ import {
 import type {
   AdapterResponse,
   AiGatewayAdapter,
+  AnthropicMessagesRequest,
   CanonicalResponseRequest,
 } from "@dotobokuri/core-ai-gateway";
 import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
@@ -439,6 +440,74 @@ describe("model context window", () => {
     });
     // The guard runs inside the gateway, so upstream was still spared the turn.
     expect(streamSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("oversized skill payloads", () => {
+  const LISTING = [
+    "The following skills are available for use with the Skill tool:",
+    "",
+    "- agent-browser: Browser automation CLI for AI agents.",
+    "- claude-api: Reference for the Claude API / Anthropic SDK.",
+    "TRIGGER — read BEFORE opening the target file.",
+  ].join("\n");
+  // 4 chars/token puts this at 100_000 tokens, past the 27_200 one skill may take
+  // from a 272_000-token window.
+  const BODY = "Base directory for this skill: /tmp/bundled-skills/2.1.222/abc/claude-api\n\n"
+    + "x".repeat(400_000);
+
+  function sentText(request: AnthropicMessagesRequest | undefined, index: number): string {
+    const content = request?.messages[index]?.content;
+    if (typeof content === "string") return content;
+    const block = content?.[0];
+    return block && "text" in block && typeof block.text === "string" ? block.text : "";
+  }
+
+  it("withholds the body before the provider sees it, and delists the skill from then on", async () => {
+    const gateway = stubGateway();
+    const streamSpy = vi.spyOn(gateway, "stream");
+    const router = createAiGatewayRouter({ gateway, readAuth });
+    const listingTurn = { role: "user", content: [{ type: "text", text: LISTING }] };
+
+    await router.handle(ctx({
+      res: response(),
+      token: ANTHROPIC_CRED,
+      model: "claude-gateway--codex--gpt-5.6-sol",
+      messages: [listingTurn, { role: "user", content: [{ type: "text", text: BODY }] }],
+    }));
+
+    const first = streamSpy.mock.calls[0]?.[0];
+    expect(sentText(first, 1)).toMatch(/^\[Fleet AI gateway withheld the "claude-api" skill/);
+    expect(sentText(first, 1)).not.toContain("xxxx");
+    // The listing loses the entry in the same request that withheld its body.
+    expect(sentText(first, 0)).not.toContain("claude-api");
+    expect(sentText(first, 0)).toContain("- agent-browser:");
+
+    // A later turn on the same router never carries the entry at all.
+    await router.handle(ctx({
+      res: response(),
+      token: ANTHROPIC_CRED,
+      model: "claude-gateway--codex--gpt-5.6-sol",
+      messages: [listingTurn],
+    }));
+
+    expect(sentText(streamSpy.mock.calls[1]?.[0], 0)).not.toContain("claude-api");
+    expect(sentText(streamSpy.mock.calls[1]?.[0], 0)).toContain("- agent-browser:");
+  });
+
+  it("passes an ordinary turn through untouched", async () => {
+    const gateway = stubGateway();
+    const streamSpy = vi.spyOn(gateway, "stream");
+    const router = createAiGatewayRouter({ gateway, readAuth });
+
+    await router.handle(ctx({
+      res: response(),
+      token: ANTHROPIC_CRED,
+      model: "claude-gateway--codex--gpt-5.6-sol",
+      messages: [{ role: "user", content: [{ type: "text", text: LISTING }] }],
+    }));
+
+    expect(sentText(streamSpy.mock.calls[0]?.[0], 0)).toBe(LISTING);
   });
 });
 


### PR DESCRIPTION
## Summary

- 게이트웨이로 가는 요청에서 **모델이 감당 못 하는 스킬 본문을 보류**하고 스텁으로 대체합니다. 실측된 `claude-api` 스킬 본문은 162,681 추정 토큰으로, 272,000 창의 60%를 에이전트가 파일 하나 읽기 전에 선점했습니다. 스킬 본문은 매 턴 재전송되므로 클라이언트 압축이 걷어낼 수 없는 고정 비용입니다.
- 판정은 **이름이 아니라 크기**입니다. 스킬은 클라이언트 바이너리 안에 있고 릴리스마다 바뀌며 적재 순간까지 디스크에 없어서, 나쁜 이름 목록은 미리 쓸 수도 최신으로 유지할 수도 없습니다. 실창의 20%를 한계로 두면 1M 이상 모델 14종은 통과하고, 사고를 낸 272,000 모델을 포함한 그 아래는 전부 거부됩니다.
- 본문을 한 번 보류하면 그 스킬을 **목록에서도 제거**해, 모델이 받지 못할 것을 적재하느라 턴을 쓰지 않게 합니다.
- 컨텍스트 초과를 **HTTP 413 + `context window`** 문구로 거절합니다. Claude Code는 그 형태에서만 reactive compaction을 무장하므로, 같은 문구를 실은 기존 400은 압축 시도 없이 턴을 끝내고 있었습니다.
- 프루닝은 프로바이더 분기보다 앞에 있어 canonical을 거치지 않는 kimi/opencode passthrough까지 덮습니다. 게이트웨이 모델이 아닌 네이티브 Anthropic 요청은 원문 그대로 통과합니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 246 passed
- [x] `pnpm --filter @fleet-plugins/terminal test` — 579 passed
- [x] `pnpm --filter @dotobokuri/core-ai-gateway exec tsc --noEmit` — 0 errors
- [x] `pnpm --filter @fleet-plugins/terminal exec tsc --noEmit` — 0 errors
- [x] `pnpm run check:core-boundary`
- [x] 카탈로그 40종 전수 대조: 1M 이상 14종 통과 / 나머지 26종 차단
- [x] Changelog: `.changelog.d/pr-518.md` — 문법·이중언어 요약·`node scripts/compile-changelog-fragments.mjs --check` 통과 (16 entries validated)

## Notes

사용자 지시로 Codex 자동 리뷰를 생략하고 머지합니다.