### PR TITLE
fix(core-ai-gateway): lift the unmeasured Cursor replay ceiling

### DIFF
--- a/.changelog.d/pr-519.md
+++ b/.changelog.d/pr-519.md
@@ -1,0 +1,9 @@
+### fleet-core
+
+#### Fixed
+- [core-ai-gateway] A Cursor conversation is no longer refused at roughly half of its model's context window. The replay carried a local 512 KiB size cap that no upstream limit backed, and its refusal was an HTTP 400 that Claude Code cannot start reactive compaction from, so a session ended with no compaction attempted; a measurement against Cursor accepted 857987 bytes across 117 replay roots without refusing, so the model's context window is now the only ceiling and it already answers with the 413 that does start compaction.
+  ko: Cursor 대화가 더 이상 모델 컨텍스트 창의 절반 근처에서 거절되지 않습니다. replay에 상류 근거가 없는 512 KiB 크기 상한이 걸려 있었고 그 거절이 Claude Code가 reactive compaction을 시작할 수 없는 HTTP 400이라 압축 시도 없이 세션이 끝났는데, Cursor 실측에서 117개 replay 루트에 걸친 857987 바이트가 거절 없이 수용되어 이제는 모델 컨텍스트 창만이 유일한 천장이며 그쪽은 이미 압축을 시작시키는 413으로 응답합니다.
+
+#### Added
+- [core-ai-gateway] `FLEET_GATEWAY_WIRE_LOG` now records what a Cursor turn actually puts on the wire: `cursor.wire.plan` carries the replay size and root count, and `cursor.wire.blobfetch`, `cursor.wire.blobsummary`, and `cursor.wire.checkpoint` report each blob the server pulls back, the per-run totals, and how far the gateway's own token estimate sits from the count Cursor reports. Cursor keeps no blob between turns, so a turn re-uploads its whole replay and this is the only way to see that cost.
+  ko: 이제 `FLEET_GATEWAY_WIRE_LOG`가 Cursor 턴이 실제로 와이어에 싣는 것을 기록합니다. `cursor.wire.plan`이 replay 크기와 루트 개수를 싣고, `cursor.wire.blobfetch`·`cursor.wire.blobsummary`·`cursor.wire.checkpoint`가 서버가 되가져가는 개별 blob과 런 단위 합계, 그리고 게이트웨이 자체 토큰 추정치가 Cursor 보고값과 얼마나 벌어지는지를 남깁니다. Cursor는 턴 사이에 blob을 보관하지 않아 매 턴이 replay 전체를 재업로드하며, 그 비용은 이 경로로만 보입니다.

--- a/packages/core-ai-gateway/src/cursor-adapter.ts
+++ b/packages/core-ai-gateway/src/cursor-adapter.ts
@@ -51,8 +51,6 @@ export const CURSOR_MODELS_PATH = "/agent.v1.AgentService/GetUsableModels";
 export const CURSOR_CLIENT_VERSION = "cli-2026.07.08-0c04a8a";
 export const CURSOR_TOOL_COUNT_LIMIT = 330;
 export const CURSOR_TOOL_BYTES_LIMIT = 120_000;
-export const CURSOR_EXTERNAL_ROOT_BLOB_LIMIT = 192;
-export const CURSOR_EXTERNAL_ROOT_BYTE_LIMIT = 512 * 1024;
 export const CURSOR_TOOL_PROVIDER_IDENTIFIER = "fleet-gateway";
 export const CURSOR_TOOL_FINALIZE_GRACE_MS = 50;
 export const CURSOR_CLIENT_HEARTBEAT_MS = 5_000;
@@ -69,14 +67,6 @@ export class CursorRequestBudgetError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "CursorRequestBudgetError";
-  }
-}
-
-/** Claude Code recognizes this prefix and routes the failed turn through reactive compaction. */
-export class CursorReplayBudgetError extends CursorRequestBudgetError {
-  constructor(message: string) {
-    super(`Prompt is too long: ${message}`);
-    this.name = "CursorReplayBudgetError";
   }
 }
 
@@ -292,6 +282,7 @@ export function parseConnectEndStreamError(payload: Uint8Array): Error | null {
  */
 class BlobStore {
   private readonly values = new Map<string, string>();
+  private decodedBytes = 0;
 
   putSerialized(serialized: string): string {
     return this.putBytes(Buffer.from(serialized, "utf8"));
@@ -300,16 +291,33 @@ class BlobStore {
   putBytes(value: Uint8Array): string {
     const data = Buffer.from(value);
     const id = createHash("sha256").update(data).digest("base64");
-    this.values.set(id, data.toString("base64"));
+    this.store(id, data.toString("base64"), data.byteLength);
     return id;
   }
 
   set(id: string, base64Data: string): void {
-    this.values.set(id, base64Data);
+    this.store(id, base64Data, Buffer.byteLength(base64Data, "base64"));
   }
 
   get(id: string): string | undefined {
     return this.values.get(id);
+  }
+
+  /**
+   * Bodies this request could be asked for, against what a turn actually transmits.
+   * Cursor pulls blobs on demand, so the two would diverge if it ever cached one
+   * between turns; measured on 2026-08-05 it never did, and every root came back in
+   * full on each request.
+   */
+  inventory(): { readonly count: number; readonly bytes: number } {
+    return { count: this.values.size, bytes: this.decodedBytes };
+  }
+
+  private store(id: string, base64Data: string, byteLength: number): void {
+    // Ids are content hashes, so a repeat put is the same body; count it once but keep
+    // the write so `set` retains its overwrite semantics.
+    if (!this.values.has(id)) this.decodedBytes += byteLength;
+    this.values.set(id, base64Data);
   }
 }
 
@@ -320,6 +328,17 @@ export interface CursorRunPlan {
   readonly wireModelId: string;
   /** Request-local estimate from the exact root/action text sent to Cursor. */
   readonly estimatedInputTokens: number;
+  /**
+   * Size of the replay this turn re-uploads. Cursor caches nothing between turns —
+   * every root is pulled back in full on each request — so this grows with the whole
+   * conversation and is the transport's real cost. It is diagnostic only: a local cap
+   * on it once refused sessions at ~48% of the model's window, and a measurement
+   * against Cursor showed 858 KB / 117 roots accepted, so the token window is the only
+   * ceiling the gateway enforces. Do not restore a byte or root cap without an
+   * observed upstream refusal to size it from.
+   */
+  readonly replayRootCount: number;
+  readonly replayBytes: number;
 }
 
 interface CursorWireTool {
@@ -390,10 +409,7 @@ export function buildCursorRunPlan(
 
   const activeMessage = activeIndex >= 0 ? request.input[activeIndex] : undefined;
   const activeReplayRoot = activeMessage ? historyRoot(activeMessage, toolNames) : null;
-  assertCursorRootBudget(
-    activeReplayRoot ? [...roots, activeReplayRoot] : roots,
-    wireModelId,
-  );
+  const replayRoots = activeReplayRoot ? [...roots, activeReplayRoot] : roots;
   const rootIds = roots.map((entry) => blobs.putSerialized(entry.serialized));
   const turnIds = buildCursorConversationTurns(request, blobs, activeIndex, toolBudget.tools);
 
@@ -438,6 +454,8 @@ export function buildCursorRunPlan(
     tools: toolBudget.tools,
     wireModelId,
     estimatedInputTokens,
+    replayRootCount: replayRoots.length,
+    replayBytes: rootBytes(replayRoots),
   };
 }
 
@@ -986,32 +1004,6 @@ function findCursorToolName(
     if (match) return match.toolName;
   }
   return undefined;
-}
-
-function assertCursorRootBudget(
-  roots: readonly CursorRootEntry[],
-  modelId: string,
-): void {
-  if (isCursorNativeModel(modelId)) return;
-  const systemEntries = roots.filter((entry) => entry.role === "system");
-  const systemBytes = rootBytes(systemEntries);
-  if (
-    systemEntries.length > CURSOR_EXTERNAL_ROOT_BLOB_LIMIT
-    || systemBytes > CURSOR_EXTERNAL_ROOT_BYTE_LIMIT
-  ) {
-    throw new CursorRequestBudgetError(
-      `Cursor system prompt exceeds the external-model root budget (${systemBytes} bytes; limit ${CURSOR_EXTERNAL_ROOT_BYTE_LIMIT})`,
-    );
-  }
-  const totalBytes = rootBytes(roots);
-  if (
-    roots.length > CURSOR_EXTERNAL_ROOT_BLOB_LIMIT
-    || totalBytes > CURSOR_EXTERNAL_ROOT_BYTE_LIMIT
-  ) {
-    throw new CursorReplayBudgetError(
-      `Cursor external replay exceeds its transport budget (${roots.length} roots, ${totalBytes} bytes; limits ${CURSOR_EXTERNAL_ROOT_BLOB_LIMIT} roots and ${CURSOR_EXTERNAL_ROOT_BYTE_LIMIT} bytes)`,
-    );
-  }
 }
 
 function isCursorNativeModel(modelId: string): boolean {
@@ -1815,6 +1807,9 @@ function createCursorLiveRun(options: CursorLiveRunOptions): CursorLiveRun {
   let semanticStallTimer: ReturnType<typeof setTimeout> | undefined;
   let transportClosed = false;
   let terminalNotified = false;
+  let blobFetchCount = 0;
+  let blobFetchBytes = 0;
+  let blobFetchMisses = 0;
 
   const usage = (segment: CursorResponseSegment): CanonicalUsage => {
     const outputTokens = Math.max(
@@ -1893,6 +1888,18 @@ function createCursorLiveRun(options: CursorLiveRunOptions): CursorLiveRun {
   const notifyTerminal = (): void => {
     if (terminalNotified) return;
     terminalNotified = true;
+    // The root budget rejects on bodies this run *could* be asked for. Cursor pulls them
+    // on demand, so that ceiling only describes real traffic if the server re-pulls
+    // everything each turn. These two totals are what decides that.
+    const inventory = blobs.inventory();
+    wireLog("cursor.wire.blobsummary", {
+      model: diagnosticModel,
+      availableBlobs: inventory.count,
+      availableBytes: inventory.bytes,
+      fetchedBlobs: blobFetchCount,
+      fetchedBytes: blobFetchBytes,
+      misses: blobFetchMisses,
+    });
     options.onTerminal();
   };
 
@@ -2196,6 +2203,20 @@ function createCursorLiveRun(options: CursorLiveRunOptions): CursorLiveRun {
       ...(checkpointContextWindow === undefined ? {} : { contextWindow: checkpointContextWindow }),
     });
     if (isRecord(frame.conversationCheckpointUpdate)) {
+      if (checkpointContextTokens !== undefined) {
+        // Cursor reports a real token count only on some turns; every other turn
+        // reports our own character estimate back. When the two disagree, Claude
+        // Code's occupancy meter is wrong by that much — and it is the meter that
+        // decides whether a session auto-compacts before it reaches its window.
+        wireLog("cursor.wire.checkpoint", {
+          model: diagnosticModel,
+          estimatedInputTokens: activeSegment?.estimatedInputTokens ?? estimatedInputTokens,
+          checkpointContextTokens,
+          ...(checkpointContextWindow === undefined
+            ? {}
+            : { checkpointContextWindow }),
+        });
+      }
       if (checkpointContextWindow !== undefined) {
         contextWindow = checkpointContextWindow;
         contextWindowVersion += 1;
@@ -2211,7 +2232,22 @@ function createCursorLiveRun(options: CursorLiveRunOptions): CursorLiveRun {
       return;
     }
     if (isRecord(frame.kvServerMessage)) {
-      stream.write(encodeCursorClientMessage(kvReply(frame.kvServerMessage, blobs)));
+      const kv = kvReply(frame.kvServerMessage, blobs);
+      stream.write(encodeCursorClientMessage(kv.message));
+      if (kv.fetch) {
+        blobFetchCount += 1;
+        blobFetchBytes += kv.fetch.bytes;
+        if (!kv.fetch.hit) blobFetchMisses += 1;
+        // Per-fetch, not just per-run: a run can span several turns, and only the id
+        // sequence shows whether the server re-pulls a body it was already given.
+        wireLog("cursor.wire.blobfetch", {
+          model: diagnosticModel,
+          sequence: blobFetchCount,
+          blobId: kv.fetch.blobId,
+          bytes: kv.fetch.bytes,
+          hit: kv.fetch.hit,
+        });
+      }
       report("client.reply", {
         model: diagnosticModel,
         reply: `kv.${cursorNestedRecordCase(frame.kvServerMessage, CURSOR_KV_CASES)}`,
@@ -2670,20 +2706,37 @@ function cursorInteractionQueryReply(query: Record<string, unknown>): CursorInte
   return { message: response(), replyKind: "interaction.unsupported.failClosed" };
 }
 
-function kvReply(kv: Record<string, unknown>, blobs: BlobStore): unknown {
+interface CursorKvOutcome {
+  readonly message: unknown;
+  /** Present only for getBlob — the one frame that transmits a replay body. */
+  readonly fetch?: {
+    readonly blobId: string;
+    readonly bytes: number;
+    readonly hit: boolean;
+  };
+}
+
+function kvReply(kv: Record<string, unknown>, blobs: BlobStore): CursorKvOutcome {
   const id = kv.id ?? 0;
   if (isRecord(kv.getBlobArgs)) {
     const blobId = typeof kv.getBlobArgs.blobId === "string" ? kv.getBlobArgs.blobId : "";
     const blobData = blobs.get(blobId);
-    return { kvClientMessage: { id, getBlobResult: blobData ? { blobData } : {} } };
+    return {
+      message: { kvClientMessage: { id, getBlobResult: blobData ? { blobData } : {} } },
+      fetch: {
+        blobId,
+        bytes: blobData === undefined ? 0 : Buffer.byteLength(blobData, "base64"),
+        hit: blobData !== undefined,
+      },
+    };
   }
   if (isRecord(kv.setBlobArgs)) {
     const blobId = typeof kv.setBlobArgs.blobId === "string" ? kv.setBlobArgs.blobId : "";
     const blobData = typeof kv.setBlobArgs.blobData === "string" ? kv.setBlobArgs.blobData : "";
     if (blobId) blobs.set(blobId, blobData);
-    return { kvClientMessage: { id, setBlobResult: {} } };
+    return { message: { kvClientMessage: { id, setBlobResult: {} } } };
   }
-  return { kvClientMessage: { id } };
+  return { message: { kvClientMessage: { id } } };
 }
 
 function cursorRequestContextReply(

--- a/packages/core-ai-gateway/tests/cursor-adapter.test.ts
+++ b/packages/core-ai-gateway/tests/cursor-adapter.test.ts
@@ -4,12 +4,9 @@ import { ValueSchema } from "@bufbuild/protobuf/wkt";
 
 import {
   CURSOR_CLIENT_VERSION,
-  CURSOR_EXTERNAL_ROOT_BLOB_LIMIT,
-  CURSOR_EXTERNAL_ROOT_BYTE_LIMIT,
   CURSOR_TOOL_BYTES_LIMIT,
   CURSOR_TOOL_COUNT_LIMIT,
   CursorAdapter,
-  CursorReplayBudgetError,
   CursorRequestBudgetError,
   buildCursorRunPlan,
   translateAnthropicRequest,
@@ -328,53 +325,47 @@ describe("Cursor request budgets", () => {
     }), "conversation-selected-tool")).toThrow(CursorRequestBudgetError);
   });
 
-  it("rejects external replay over the root count ceiling instead of dropping history", () => {
+  // Replay size carries no gateway ceiling. A local 512 KiB / 192-root cap used to
+  // refuse these, which cut sessions off near 48% of the model's window; measuring
+  // against Cursor on 2026-08-05 saw 857,987 bytes across 117 roots accepted without
+  // a refusal, so the model's context window is the only limit left.
+  it("keeps every external replay root instead of capping the conversation", () => {
     const input: CanonicalResponseRequest["input"] = [];
     for (let index = 0; index < 220; index += 1) {
       input.push({ type: "message", role: "user", content: `user-${index}` });
       input.push({ type: "message", role: "assistant", content: `assistant-${index}` });
     }
     input.push({ type: "message", role: "user", content: "active-user" });
-    const build = () => buildCursorRunPlan(request({ input }), "conversation-roots");
+    const plan = buildCursorRunPlan(request({ input }), "conversation-roots");
 
-    expect(build).toThrow(CursorReplayBudgetError);
-    expect(build).toThrow(/^Prompt is too long:/);
+    // 440 history roots plus the system root; the active message replays next turn.
+    expect(rootValues(plan).length).toBe(441);
+    expect(plan.replayRootCount).toBe(442);
+    expect(plan.replayBytes).toBeGreaterThan(0);
   });
 
-  it("rejects an oversized trailing tool result instead of truncating it", () => {
-    const build = () => buildCursorRunPlan(request({
+  it("carries an oversized trailing tool result instead of truncating it", () => {
+    const output = "🧪".repeat(180_000);
+    const plan = buildCursorRunPlan(request({
       input: [
         { type: "message", role: "user", content: "run the tool" },
         { type: "function_call", call_id: "call-1", name: "exec_command", arguments: "{}" },
-        { type: "function_call_output", call_id: "call-1", output: "🧪".repeat(180_000) },
+        { type: "function_call_output", call_id: "call-1", output },
       ],
     }), "conversation-tool-result");
 
-    expect(build).toThrow(CursorReplayBudgetError);
-    expect(build).toThrow(/^Prompt is too long:/);
+    expect(plan.replayBytes).toBeGreaterThan(Buffer.byteLength(output, "utf8"));
   });
 
-  it("preflights an active user message against its next-turn replay budget", () => {
-    const build = () => buildCursorRunPlan(request({
-      input: [{
-        type: "message",
-        role: "user",
-        content: "x".repeat(CURSOR_EXTERNAL_ROOT_BYTE_LIMIT),
-      }],
-    }), "conversation-active-replay");
+  it("carries a system prompt of any size", () => {
+    const instructions = "p".repeat(600_000);
+    const plan = buildCursorRunPlan(request({ instructions }), "conversation-system-limit");
 
-    expect(build).toThrow(CursorReplayBudgetError);
-    expect(build).toThrow(/^Prompt is too long:/);
-  });
-
-  it("fails explicitly when the required system prompt alone exceeds the root budget", () => {
-    expect(() => buildCursorRunPlan(request({
-      instructions: "p".repeat(CURSOR_EXTERNAL_ROOT_BYTE_LIMIT),
-    }), "conversation-system-limit")).toThrow(CursorRequestBudgetError);
+    expect(systemText(plan)).toContain(instructions);
   });
 
   it("does not prune native Composer replay roots", () => {
-    const input = Array.from({ length: CURSOR_EXTERNAL_ROOT_BLOB_LIMIT + 10 }, (_, index) => ({
+    const input = Array.from({ length: 202 }, (_, index) => ({
       type: "message" as const,
       role: (index % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
       content: `message-${index}`,
@@ -382,7 +373,7 @@ describe("Cursor request budgets", () => {
     input.push({ type: "message", role: "user", content: "active" });
     const plan = buildCursorRunPlan(request({ model: "composer-2.5", input }), "conversation-native");
 
-    expect(rootValues(plan).length).toBe(CURSOR_EXTERNAL_ROOT_BLOB_LIMIT + 11);
+    expect(rootValues(plan).length).toBe(203);
   });
 
   it("forwards multimodal image parts on the active Cursor user message", () => {

--- a/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
@@ -1,6 +1,6 @@
 import {
   AnthropicMessagesGateway,
-  CURSOR_EXTERNAL_ROOT_BYTE_LIMIT,
+  CURSOR_TOOL_BYTES_LIMIT,
   ContextWindowExceededError,
   CursorAdapter,
 } from "@dotobokuri/core-ai-gateway";
@@ -357,7 +357,11 @@ describe("upstream credential", () => {
     expect(res.body).toContain("metadata.user_id");
   });
 
-  it("returns Claude's prompt-too-long contract for unreplayable Cursor input", async () => {
+  // A Cursor budget refusal is not a context overflow. It has to stay 400: 413 is the
+  // shape Claude Code arms reactive compaction from, and compacting cannot make an
+  // unfittable tool schema fit, so reporting one as the other sends the client
+  // shrinking the wrong thing.
+  it("keeps a Cursor transport-budget refusal at 400 rather than the 413 overflow shape", async () => {
     const router = createAiGatewayRouter({
       readAuth,
       readCursorToken: () => "cursor-subscription-token",
@@ -368,10 +372,12 @@ describe("upstream credential", () => {
       res,
       token: ANTHROPIC_CRED,
       model: "claude-gateway--cursor--grok-4.5-fast",
-      messages: [{
-        role: "user",
-        content: "x".repeat(CURSOR_EXTERNAL_ROOT_BYTE_LIMIT),
+      tools: [{
+        name: "selected",
+        description: "x".repeat(CURSOR_TOOL_BYTES_LIMIT),
+        input_schema: { type: "object", properties: {} },
       }],
+      toolChoice: { type: "tool", name: "selected" },
     }));
 
     expect(res.status).toBe(400);
@@ -379,7 +385,7 @@ describe("upstream credential", () => {
       type: "error",
       error: {
         type: "invalid_request_error",
-        message: expect.stringMatching(/^Prompt is too long:/),
+        message: expect.stringContaining("exceeds the transport budget"),
       },
     });
   });
@@ -1358,6 +1364,7 @@ function ctx(options: {
   readonly metadata?: Record<string, unknown> | null;
   readonly messages?: ReadonlyArray<Record<string, unknown>>;
   readonly tools?: ReadonlyArray<Record<string, unknown>>;
+  readonly toolChoice?: Record<string, unknown>;
 }): RouteHandlerContext {
   const payload = JSON.stringify({
     model: options.model ?? "claude-gateway--codex--gpt-5.6-sol",
@@ -1369,6 +1376,7 @@ function ctx(options: {
       ? {}
       : { metadata: options.metadata ?? { user_id: "claude-session-test" } }),
     ...(options.tools ? { tools: options.tools } : {}),
+    ...(options.toolChoice ? { tool_choice: options.toolChoice } : {}),
     stream: true,
   });
   const req = {


### PR DESCRIPTION
## Summary

- Cursor 경로의 replay에 걸려 있던 로컬 상한(512 KiB / 192 roots)을 제거합니다. 이 상한에는 상류 근거가 없었고, 실측 결과 256k 창 모델에서 약 124k 토큰(창의 ~48%)에서 대화를 거절하고 있었습니다. 게다가 그 거절은 HTTP 400이라 Claude Code가 reactive compaction을 무장하지 못해, 세션이 절반 용량에서 압축 없이 막다른 길로 끝났습니다.
- 제거 근거를 실측으로 확보했습니다. 상한을 올린 프로브로 같은 워크로드를 재현한 결과 Cursor는 **117 roots / 857,987 bytes**를 거절 없이 수용했습니다. 남는 유일한 천장은 모델의 컨텍스트 창이며, 그쪽은 이미 compaction을 무장시키는 413으로 처리됩니다.
- transport 비용을 관측 가능하게 만드는 계측을 함께 넣습니다. `cursor.wire.plan`에 `replayBytes`/`replayRootCount`가 실리고, `cursor.wire.blobfetch` / `blobsummary` / `checkpoint` wire-log 이벤트가 각 턴이 실제로 전송한 양과 Cursor가 되돌려 보고한 값을 남깁니다. 측정 결과 Cursor는 턴 간 blob을 캐시하지 않아 매 턴 전체 replay를 재업로드합니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck` — 0 errors
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 245 passed (8 files)
- [x] `pnpm --filter @fleet-plugins/terminal typecheck` — 0 errors
- [x] `pnpm --filter @fleet-plugins/terminal test` — 579 passed (56 files)
- [x] 실측: grok-4.5-fast 세션 42턴 전부 수용, 사전 거부 0건, blob miss 0건
- [x] 1M 경로 회귀 확인: `cursor--kimi-k3-1m`은 cw 1,048,576 / `[1m]` 마커 / maxMode 유지, `composer-2.5`(200k)는 마커 없음 유지
- [x] Changelog: `.changelog.d/pr-519.md` 추가 — grouped 문법·이중 언어 요약·`node scripts/compile-changelog-fragments.mjs --check` (OK: 18 entries) 통과

## Notes

- 이 PR은 auto-compact 자체를 고치지 않습니다. 같은 실측에서 Cursor는 42턴 중 3턴에서만 실제 토큰 수를 보고했고, 나머지 턴은 우리 문자 기반 추정치가 그대로 되돌아옵니다. 마지막 체크포인트가 262,338을 보고했을 때 우리 추정치는 210,670이었고, 그래서 Claude Code의 점유율 게이지가 82%에서 곧바로 100%로 건너뛰며 auto-compact 구간을 지나쳤습니다. 새로 추가한 `cursor.wire.checkpoint` 이벤트가 추정치와 Cursor 실측치를 나란히 남기므로, 다음 세션 한 번이면 그 편차를 정량화할 수 있습니다. 표본 3건(0.80x ~ 2.44x)으로 보정 상수를 넣는 것은 이 PR이 제거하는 바로 그 종류의 미실측 상수이므로 하지 않았습니다.