### PR TITLE
fix(core-ai-gateway): refuse a Cursor turn at the measured window

### DIFF
--- a/.changelog.d/pr-520.md
+++ b/.changelog.d/pr-520.md
@@ -1,0 +1,5 @@
+### fleet-core
+
+#### Fixed
+- [core-ai-gateway] A Cursor conversation no longer keeps running blind once it fills the model's context window. Claude Code's occupancy meter reads a projection that saturates at that window, so past it every turn reported the same full number and the client could not see itself reaching its own compaction threshold; one measured session sent 31 consecutive requests at a saturated meter before compaction finally fired, minutes late. The gateway now refuses the next turn from the count Cursor itself reported, carrying the 413 that starts reactive compaction, and lets the compacted retry through.
+  ko: Cursor 대화가 모델 컨텍스트 창을 채운 뒤에도 눈먼 채 계속되지 않습니다. Claude Code의 점유 계기는 그 창에서 포화하는 투영값을 읽기 때문에, 포화 이후에는 매 턴 같은 값만 보고되어 클라이언트가 자기 압축 임계에 도달하는 것을 볼 수 없었고, 실측된 한 세션은 포화된 계기로 31회 연속 요청을 보낸 뒤에야 수 분 늦게 압축이 걸렸습니다. 이제 게이트웨이가 Cursor 자신이 보고한 값을 기준으로 다음 턴을 거절하며, reactive compaction을 시작시키는 413을 실어 보내고 압축된 재시도는 통과시킵니다.

--- a/packages/core-ai-gateway/src/canonical.ts
+++ b/packages/core-ai-gateway/src/canonical.ts
@@ -319,8 +319,39 @@ export interface CanonicalError {
   message: string;
 }
 
+/**
+ * Refusal Claude Code can recover from, rather than one that ends the turn.
+ *
+ * Claude Code classifies an overflow only from an HTTP **413** whose message contains
+ * `context window`; that classification is what arms its reactive compaction. The
+ * `Prompt is too long` prefix is a second, separate contract — the compaction routine
+ * matches it to decide that its own summarization request overflowed and to retry with
+ * older messages dropped. Both are required, so the message carries the prefix and the
+ * phrase, and `writeAnthropicError` must send this as 413. Any other status is surfaced
+ * as a plain failure and the turn dies with no compaction attempted.
+ *
+ * It lives in the canonical vocabulary rather than the gateway because an adapter that
+ * holds a provider-measured occupancy has to raise the same refusal, and an adapter
+ * importing the gateway would invert the layer.
+ */
+export class ContextWindowExceededError extends Error {
+  constructor(
+    readonly requestTokens: number,
+    readonly contextWindow: number,
+  ) {
+    super(`Prompt is too long: ${requestTokens} tokens > ${contextWindow} maximum context window`);
+    this.name = "ContextWindowExceededError";
+  }
+}
+
 export interface AdapterCallOptions {
   apiKey: string;
+  /**
+   * The model's real usable context window. Adapters that hold a provider-measured
+   * occupancy for the conversation use it to refuse a turn the estimate cannot see;
+   * it is never a projection denominator and never a transport budget.
+   */
+  modelContextWindow?: number;
   /** 새로 여는 provider trace가 진단 이벤트를 낼지 결정한다. 생략하면 adapter 기본값을 유지한다. */
   diagnosticsEnabled?: boolean;
   signal?: AbortSignal;

--- a/packages/core-ai-gateway/src/cursor-adapter.ts
+++ b/packages/core-ai-gateway/src/cursor-adapter.ts
@@ -24,6 +24,7 @@ import type {
   ReasoningEffort,
 } from "./canonical.js";
 import {
+  ContextWindowExceededError,
   canonicalMessageImages,
   canonicalMessageText,
 } from "./canonical.js";
@@ -1388,6 +1389,7 @@ export class CursorAdapter implements AiGatewayAdapter {
       descriptor.credentialFingerprint,
       plan.estimatedInputTokens,
     );
+    assertCursorContextWindow(previousContextCheckpoint, options.modelContextWindow);
     report("turn.start", {
       model,
       wireModel,
@@ -1696,6 +1698,44 @@ function recallCursorContextCheckpoint(
   }
   CURSOR_CONTEXT_CHECKPOINT_BY_STATE.set(key, checkpoint);
   return checkpoint;
+}
+
+/**
+ * Refuse a new turn once Cursor's own measurement says the conversation already fills
+ * the model's window.
+ *
+ * This is not a transport budget — it is what keeps Claude Code's occupancy meter
+ * informative. That meter reads a projection onto Claude Code's 1M coordinate, and the
+ * projection saturates at exactly this point: past it every turn reports 1,000,000 no
+ * matter how much further the conversation grew, so the client can no longer see itself
+ * approaching its own compaction threshold. Measured on 2026-08-05, a `grok-4.5-fast`
+ * session sat at a saturated 1,000,000 across 31 consecutive requests before compaction
+ * finally fired from the client's own local accounting, several minutes late.
+ *
+ * The refusal restores that signal: it carries the 413 Claude Code arms reactive
+ * compaction from, so the turn compacts instead of continuing blind. The count is
+ * Cursor's, never our character estimate — on that same session the estimate read
+ * 210,670 against a measured 262,338, which is why the gateway's own pre-flight guard
+ * never fired.
+ *
+ * A compacted retry sends a smaller request, and `recallCursorContextCheckpoint` drops
+ * the stale checkpoint on exactly that shrink, so this cannot fire twice against a
+ * conversation that already compacted.
+ */
+function assertCursorContextWindow(
+  checkpoint: CursorContextCheckpoint | undefined,
+  modelContextWindow: number | undefined,
+): void {
+  if (
+    checkpoint === undefined
+    || typeof modelContextWindow !== "number"
+    || !Number.isFinite(modelContextWindow)
+    || modelContextWindow <= 0
+    || checkpoint.contextTokens < modelContextWindow
+  ) {
+    return;
+  }
+  throw new ContextWindowExceededError(checkpoint.contextTokens, modelContextWindow);
 }
 
 function rememberCursorContextCheckpoint(

--- a/packages/core-ai-gateway/src/cursor-adapter.ts
+++ b/packages/core-ai-gateway/src/cursor-adapter.ts
@@ -1234,6 +1234,16 @@ export class CursorAdapter implements AiGatewayAdapter {
     // Cursor rewrites and caps the declared catalog before it reaches the wire; this is the
     // post-rewrite tool set plus the resolved model coordinate.
     wireLog("cursor.wire.plan", plan);
+    // 모든 진입 경로가 이 판정을 지나야 한다. bridge를 지원하는 모델은 tool 결과가
+    // parked Run에 붙어 cold Run 경로를 건너뛰므로, 판정을 그 뒤에 두면 tool을 쓰는
+    // 세션만 포화된 계기로 계속 달리게 된다.
+    const contextCheckpoint = recallCursorContextCheckpoint(
+      identity.conversationId,
+      plan.wireModelId,
+      credentialFingerprint,
+      plan.estimatedInputTokens,
+    );
+    assertCursorContextWindow(contextCheckpoint, options.modelContextWindow);
     const descriptor: CursorLiveRunDescriptor = {
       conversationId: identity.conversationId,
       sessionId: identity.sessionId,
@@ -1280,7 +1290,7 @@ export class CursorAdapter implements AiGatewayAdapter {
       }
     }
 
-    return this.openRun(request, options, identity, plan, descriptor);
+    return this.openRun(request, options, identity, plan, descriptor, contextCheckpoint);
   }
 
   /** Close every adapter-owned parked Run. Safe to call more than once. */
@@ -1369,6 +1379,7 @@ export class CursorAdapter implements AiGatewayAdapter {
     identity: CursorSessionIdentity,
     plan: CursorRunPlan,
     descriptor: CursorLiveRunDescriptor,
+    previousContextCheckpoint: CursorContextCheckpoint | undefined,
   ): Promise<AdapterResponse> {
     if (options.signal?.aborted) throw new Error("cancelled by caller");
     // Cursor Run을 열 때 기록 정책을 고정한다. tool continuation은 이 Run에 붙어 reporter를
@@ -1383,13 +1394,6 @@ export class CursorAdapter implements AiGatewayAdapter {
       descriptor.credentialFingerprint,
       plan.wireModelId,
     );
-    const previousContextCheckpoint = recallCursorContextCheckpoint(
-      identity.conversationId,
-      plan.wireModelId,
-      descriptor.credentialFingerprint,
-      plan.estimatedInputTokens,
-    );
-    assertCursorContextWindow(previousContextCheckpoint, options.modelContextWindow);
     report("turn.start", {
       model,
       wireModel,

--- a/packages/core-ai-gateway/src/cursor-adapter.ts
+++ b/packages/core-ai-gateway/src/cursor-adapter.ts
@@ -1243,7 +1243,25 @@ export class CursorAdapter implements AiGatewayAdapter {
       credentialFingerprint,
       plan.estimatedInputTokens,
     );
-    assertCursorContextWindow(contextCheckpoint, options.modelContextWindow);
+    const contextRefusal = cursorContextWindowRefusal(
+      contextCheckpoint,
+      options.modelContextWindow,
+    );
+    if (contextRefusal) {
+      // 거절만으로는 부족하다. mismatch 판정은 대화 내용을 보지 않으므로, 압축된
+      // 재시도가 같은 call id를 보존하면 이미 포화된 Run에 그대로 다시 붙는다. 압축이
+      // 클라이언트에만 반영되고 업스트림 세션은 가득 찬 채 이어지므로, 그 Run을 여기서
+      // 버려 재시도가 차갑게 열리도록 강제한다.
+      const saturated = this.pendingLiveRuns.get(conversationStateKey);
+      if (saturated && this.claimPendingLiveRun(saturated)) {
+        saturated.run.report("bridge.mismatch", {
+          model: cursorDiagnosticLabel(request.model),
+          outcome: "context_window_exceeded",
+        });
+        saturated.run.dispose("bridge_mismatch_context_window_exceeded");
+      }
+      throw contextRefusal;
+    }
     const descriptor: CursorLiveRunDescriptor = {
       conversationId: identity.conversationId,
       sessionId: identity.sessionId,
@@ -1726,10 +1744,10 @@ function recallCursorContextCheckpoint(
  * the stale checkpoint on exactly that shrink, so this cannot fire twice against a
  * conversation that already compacted.
  */
-function assertCursorContextWindow(
+function cursorContextWindowRefusal(
   checkpoint: CursorContextCheckpoint | undefined,
   modelContextWindow: number | undefined,
-): void {
+): ContextWindowExceededError | undefined {
   if (
     checkpoint === undefined
     || typeof modelContextWindow !== "number"
@@ -1737,9 +1755,9 @@ function assertCursorContextWindow(
     || modelContextWindow <= 0
     || checkpoint.contextTokens < modelContextWindow
   ) {
-    return;
+    return undefined;
   }
-  throw new ContextWindowExceededError(checkpoint.contextTokens, modelContextWindow);
+  return new ContextWindowExceededError(checkpoint.contextTokens, modelContextWindow);
 }
 
 function rememberCursorContextCheckpoint(

--- a/packages/core-ai-gateway/src/cursor-adapter.ts
+++ b/packages/core-ai-gateway/src/cursor-adapter.ts
@@ -1237,30 +1237,32 @@ export class CursorAdapter implements AiGatewayAdapter {
     // 모든 진입 경로가 이 판정을 지나야 한다. bridge를 지원하는 모델은 tool 결과가
     // parked Run에 붙어 cold Run 경로를 건너뛰므로, 판정을 그 뒤에 두면 tool을 쓰는
     // 세션만 포화된 계기로 계속 달리게 된다.
-    const contextCheckpoint = recallCursorContextCheckpoint(
+    const contextRecall = recallCursorContextCheckpoint(
       identity.conversationId,
       plan.wireModelId,
       credentialFingerprint,
       plan.estimatedInputTokens,
     );
     const contextRefusal = cursorContextWindowRefusal(
-      contextCheckpoint,
+      contextRecall.checkpoint,
       options.modelContextWindow,
     );
-    if (contextRefusal) {
-      // 거절만으로는 부족하다. mismatch 판정은 대화 내용을 보지 않으므로, 압축된
-      // 재시도가 같은 call id를 보존하면 이미 포화된 Run에 그대로 다시 붙는다. 압축이
-      // 클라이언트에만 반영되고 업스트림 세션은 가득 찬 채 이어지므로, 그 Run을 여기서
-      // 버려 재시도가 차갑게 열리도록 강제한다.
-      const saturated = this.pendingLiveRuns.get(conversationStateKey);
-      if (saturated && this.claimPendingLiveRun(saturated)) {
-        saturated.run.report("bridge.mismatch", {
+    if (contextRefusal || contextRecall.compacted) {
+      // parked Run은 park될 당시의 대화를 전제로 업스트림에 이어져 있다. 창이 찼다면
+      // 압축이 곧 오고, 이미 축소됐다면 압축이 지나간 것이라 어느 쪽이든 그 전제가
+      // 깨졌다. 그런데 mismatch 판정은 대화 내용을 보지 않아 call id만 같으면 그대로
+      // 다시 붙고, 그러면 압축이 클라이언트에만 반영된 채 업스트림 세션은 가득 찬
+      // 상태로 이어진다. 여기서 버려야 다음 요청이 차갑게 열린다.
+      const stale = this.pendingLiveRuns.get(conversationStateKey);
+      if (stale && this.claimPendingLiveRun(stale)) {
+        const outcome = contextRefusal ? "context_window_exceeded" : "conversation_compacted";
+        stale.run.report("bridge.mismatch", {
           model: cursorDiagnosticLabel(request.model),
-          outcome: "context_window_exceeded",
+          outcome,
         });
-        saturated.run.dispose("bridge_mismatch_context_window_exceeded");
+        stale.run.dispose(`bridge_mismatch_${outcome}`);
       }
-      throw contextRefusal;
+      if (contextRefusal) throw contextRefusal;
     }
     const descriptor: CursorLiveRunDescriptor = {
       conversationId: identity.conversationId,
@@ -1308,7 +1310,7 @@ export class CursorAdapter implements AiGatewayAdapter {
       }
     }
 
-    return this.openRun(request, options, identity, plan, descriptor, contextCheckpoint);
+    return this.openRun(request, options, identity, plan, descriptor, contextRecall.checkpoint);
   }
 
   /** Close every adapter-owned parked Run. Safe to call more than once. */
@@ -1695,6 +1697,15 @@ function rememberCursorWireModel(
   return previous;
 }
 
+interface CursorCheckpointRecall {
+  readonly checkpoint: CursorContextCheckpoint | undefined;
+  /**
+   * 요청이 기준선보다 작아져 체크포인트를 폐기한 경우. 대화가 재구성됐다는 신호이며,
+   * 그 대화를 전제로 열려 있는 parked Run도 함께 무효가 된다.
+   */
+  readonly compacted: boolean;
+}
+
 /**
  * 보관된 체크포인트는 그것을 측정한 대화가 계속 자라는 동안에만 이 요청을 설명한다.
  * Claude Code가 컴팩트하면 입력이 급감하는데, 낡은 값은 그 요청보다 큰 점유를 주장하고
@@ -1706,20 +1717,22 @@ function recallCursorContextCheckpoint(
   wireModelId: string,
   credentialFingerprint: string,
   requestInputTokens: number,
-): CursorContextCheckpoint | undefined {
+): CursorCheckpointRecall {
   const key = cursorConversationStateKey(credentialFingerprint, conversationId);
   const checkpoint = CURSOR_CONTEXT_CHECKPOINT_BY_STATE.get(key);
-  if (!checkpoint) return undefined;
+  if (!checkpoint) return { checkpoint: undefined, compacted: false };
   CURSOR_CONTEXT_CHECKPOINT_BY_STATE.delete(key);
   if (
     checkpoint.wireModelId !== wireModelId
     || checkpoint.credentialFingerprint !== credentialFingerprint
-    || requestInputTokens < checkpoint.requestInputTokens
   ) {
-    return undefined;
+    return { checkpoint: undefined, compacted: false };
+  }
+  if (requestInputTokens < checkpoint.requestInputTokens) {
+    return { checkpoint: undefined, compacted: true };
   }
   CURSOR_CONTEXT_CHECKPOINT_BY_STATE.set(key, checkpoint);
-  return checkpoint;
+  return { checkpoint, compacted: false };
 }
 
 /**

--- a/packages/core-ai-gateway/src/gateway.ts
+++ b/packages/core-ai-gateway/src/gateway.ts
@@ -3,7 +3,7 @@ import type {
   AnthropicMessagesRequest,
   TranslateAnthropicRequestOptions
 } from "./anthropic.js";
-import { canonicalMessageText } from "./canonical.js";
+import { ContextWindowExceededError, canonicalMessageText } from "./canonical.js";
 import type {
   AiGatewayAdapter,
   CanonicalFunctionTool,
@@ -13,26 +13,7 @@ import { OpenAIResponsesAdapter } from "./openai-responses-adapter.js";
 import { estimateTokens } from "./token-estimate.js";
 import { logCanonicalEvents, wireLog, wireLogEnabled } from "./wire-log.js";
 
-/**
- * Refusal Claude Code can recover from, rather than one that ends the turn.
- *
- * Claude Code classifies an overflow only from an HTTP **413** whose message contains
- * `context window`; that classification is what arms its reactive compaction. The
- * `Prompt is too long` prefix is a second, separate contract — the compaction routine
- * matches it to decide that its own summarization request overflowed and to retry with
- * older messages dropped. Both are required, so the message carries the prefix and the
- * phrase, and `writeAnthropicError` must send this as 413. Any other status is surfaced
- * as a plain failure and the turn dies with no compaction attempted.
- */
-export class ContextWindowExceededError extends Error {
-  constructor(
-    readonly requestTokens: number,
-    readonly contextWindow: number,
-  ) {
-    super(`Prompt is too long: ${requestTokens} tokens > ${contextWindow} maximum context window`);
-    this.name = "ContextWindowExceededError";
-  }
-}
+export { ContextWindowExceededError } from "./canonical.js";
 
 export interface AnthropicGatewayCallOptions extends TranslateAnthropicRequestOptions {
   apiKey: string;
@@ -95,6 +76,9 @@ export class AnthropicMessagesGateway {
     guardModelContextWindow(canonical, options.modelContextWindow, this.adapter);
     const upstream = await this.adapter.stream(canonical, {
       apiKey: options.apiKey,
+      ...(options.modelContextWindow === undefined
+        ? {}
+        : { modelContextWindow: options.modelContextWindow }),
       ...(options.diagnosticsEnabled === undefined
         ? {}
         : { diagnosticsEnabled: options.diagnosticsEnabled }),

--- a/packages/core-ai-gateway/tests/cursor-live-run.test.ts
+++ b/packages/core-ai-gateway/tests/cursor-live-run.test.ts
@@ -543,6 +543,46 @@ describe("Cursor live client-tool Run bridge", () => {
     }
   });
 
+  it("opens cold when the first request after a saturated call is already compacted", async () => {
+    // Claude Code가 413을 받기 전에 스스로 압축하면 거절 경로가 아예 실행되지 않는다.
+    // 그때도 parked Run이 전제한 대화는 사라졌으므로 붙여서는 안 된다.
+    const call = cursorCall("call-window-selfcompact", 63);
+    const parked = new BridgeCursorStream(
+      [
+        {
+          conversationCheckpointUpdate: {
+            tokenDetails: { usedTokens: 256_000, maxTokens: 256_000 },
+          },
+        },
+        ...cursorToolFrames([call]),
+      ],
+      cursorCompletionFrames("saturated run continued"),
+      1,
+    );
+    const cold = new BridgeCursorStream(cursorCompletionFrames("cold run opened"));
+    const harness = cursorHarness([parked, cold]);
+    const base = cursorRequest("session-window-selfcompact", "kimi-k3-1m");
+    const large: CanonicalResponseRequest = {
+      ...base,
+      input: [{ type: "message", role: "user", content: "x".repeat(60_000) }],
+    };
+
+    try {
+      await collectCursorResponse(harness.adapter, large);
+
+      // 413 없이 곧바로 압축된 continuation이 도착한다.
+      const events = await collectAdapterEvents(await harness.adapter.stream(
+        cursorContinuation(base, [call], [cursorResult(call, "tool result")]),
+        { apiKey: "cursor-test-token", modelContextWindow: 256_000 },
+      ));
+
+      expect(canonicalText(events)).toBe("cold run opened");
+      expect(harness.openedStreams).toBe(2);
+    } finally {
+      harness.adapter.dispose();
+    }
+  });
+
   it("stays out of the way while Cursor's count is under the window", async () => {
     const belowWindow = new BridgeCursorStream([
       {

--- a/packages/core-ai-gateway/tests/cursor-live-run.test.ts
+++ b/packages/core-ai-gateway/tests/cursor-live-run.test.ts
@@ -466,6 +466,38 @@ describe("Cursor live client-tool Run bridge", () => {
     }
   });
 
+  it("refuses a tool continuation at the window instead of reattaching blind", async () => {
+    // bridge를 지원하는 모델은 tool 결과가 parked Run에 붙으므로 cold Run 경로를
+    // 타지 않는다. 그 경로에만 검사를 두면 tool을 쓰는 세션 전체가 포화된 계기로
+    // 계속 달린다 — 정확히 이 수정이 없애려는 상태다.
+    const call = cursorCall("call-window-full", 61);
+    const stream = new BridgeCursorStream([
+      {
+        conversationCheckpointUpdate: {
+          tokenDetails: { usedTokens: 256_000, maxTokens: 256_000 },
+        },
+      },
+      ...cursorToolFrames([call]),
+    ]);
+    const harness = cursorHarness([stream]);
+    const initial = cursorRequest("session-window-continuation", "kimi-k3-1m");
+
+    try {
+      await collectCursorResponse(harness.adapter, initial);
+      const continuation = cursorContinuation(initial, [call], [
+        cursorResult(call, "tool result"),
+      ]);
+
+      await expect(harness.adapter.stream(continuation, {
+        apiKey: "cursor-test-token",
+        modelContextWindow: 256_000,
+      })).rejects.toBeInstanceOf(ContextWindowExceededError);
+      expect(harness.openedStreams).toBe(1);
+    } finally {
+      harness.adapter.dispose();
+    }
+  });
+
   it("stays out of the way while Cursor's count is under the window", async () => {
     const belowWindow = new BridgeCursorStream([
       {

--- a/packages/core-ai-gateway/tests/cursor-live-run.test.ts
+++ b/packages/core-ai-gateway/tests/cursor-live-run.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   CURSOR_TOOL_PROVIDER_IDENTIFIER,
+  ContextWindowExceededError,
   CursorAdapter,
   buildCursorRunPlan,
   decodeConnectFrames,
@@ -432,6 +433,94 @@ describe("Cursor live client-tool Run bridge", () => {
         await collectCursorResponse(harness.adapter, base),
       );
       expect(compactedUsage?.input_tokens).toBeLessThan(10_000);
+    } finally {
+      harness.adapter.dispose();
+    }
+  });
+
+  it("refuses the next turn once Cursor's own count fills the model window", async () => {
+    // 이 지점이 곧 Claude Code의 점유 계기가 1M 좌표에서 포화하는 지점이다. 넘어가면
+    // 대화가 더 커져도 계기가 움직이지 않아 클라이언트가 자기 압축 임계를 볼 수 없다.
+    const saturating = new BridgeCursorStream([
+      {
+        conversationCheckpointUpdate: {
+          tokenDetails: { usedTokens: 256_000, maxTokens: 256_000 },
+        },
+      },
+      ...cursorCompletionFrames("window is full"),
+    ]);
+    const harness = cursorHarness([saturating]);
+    const request = cursorRequest("session-window-saturated", "kimi-k3-1m");
+
+    try {
+      await collectCursorResponse(harness.adapter, request);
+
+      await expect(harness.adapter.stream(request, {
+        apiKey: "cursor-test-token",
+        modelContextWindow: 256_000,
+      })).rejects.toBeInstanceOf(ContextWindowExceededError);
+      // 거절된 턴은 업스트림에 닿지 않는다.
+      expect(harness.openedStreams).toBe(1);
+    } finally {
+      harness.adapter.dispose();
+    }
+  });
+
+  it("stays out of the way while Cursor's count is under the window", async () => {
+    const belowWindow = new BridgeCursorStream([
+      {
+        conversationCheckpointUpdate: {
+          tokenDetails: { usedTokens: 255_999, maxTokens: 256_000 },
+        },
+      },
+      ...cursorCompletionFrames("first turn complete"),
+    ]);
+    const next = new BridgeCursorStream(cursorCompletionFrames("second turn complete"));
+    const harness = cursorHarness([belowWindow, next]);
+    const request = cursorRequest("session-window-under", "kimi-k3-1m");
+
+    try {
+      await collectCursorResponse(harness.adapter, request);
+      const events = await collectAdapterEvents(await harness.adapter.stream(request, {
+        apiKey: "cursor-test-token",
+        modelContextWindow: 256_000,
+      }));
+
+      expect(canonicalText(events)).toBe("second turn complete");
+      expect(harness.openedStreams).toBe(2);
+    } finally {
+      harness.adapter.dispose();
+    }
+  });
+
+  it("lets a compacted retry through instead of refusing it again", async () => {
+    // 413을 받은 Claude Code는 압축 후 훨씬 작은 요청을 다시 보낸다. 그 축소가
+    // 체크포인트를 폐기시키므로 같은 거절이 반복되지 않는다.
+    const saturating = new BridgeCursorStream([
+      {
+        conversationCheckpointUpdate: {
+          tokenDetails: { usedTokens: 256_000, maxTokens: 256_000 },
+        },
+      },
+      ...cursorCompletionFrames("window is full"),
+    ]);
+    const compacted = new BridgeCursorStream(cursorCompletionFrames("compacted turn complete"));
+    const harness = cursorHarness([saturating, compacted]);
+    const base = cursorRequest("session-window-compacted", "kimi-k3-1m");
+    const large: CanonicalResponseRequest = {
+      ...base,
+      input: [{ type: "message", role: "user", content: "x".repeat(60_000) }],
+    };
+
+    try {
+      await collectCursorResponse(harness.adapter, large);
+      const events = await collectAdapterEvents(await harness.adapter.stream(base, {
+        apiKey: "cursor-test-token",
+        modelContextWindow: 256_000,
+      }));
+
+      expect(canonicalText(events)).toBe("compacted turn complete");
+      expect(harness.openedStreams).toBe(2);
     } finally {
       harness.adapter.dispose();
     }

--- a/packages/core-ai-gateway/tests/cursor-live-run.test.ts
+++ b/packages/core-ai-gateway/tests/cursor-live-run.test.ts
@@ -498,6 +498,51 @@ describe("Cursor live client-tool Run bridge", () => {
     }
   });
 
+  it("forces a compacted retry to open a cold Run instead of the saturated one", async () => {
+    // mismatch 판정은 대화 내용을 보지 않는다. 압축된 재시도가 같은 call id를 보존하면
+    // 그대로 통과해 이미 포화된 Run에 다시 붙고, 압축은 클라이언트에만 반영된 채
+    // 업스트림 세션은 가득 찬 상태로 이어진다.
+    const call = cursorCall("call-window-retry", 62);
+    const parked = new BridgeCursorStream(
+      [
+        {
+          conversationCheckpointUpdate: {
+            tokenDetails: { usedTokens: 256_000, maxTokens: 256_000 },
+          },
+        },
+        ...cursorToolFrames([call]),
+      ],
+      cursorCompletionFrames("saturated run continued"),
+      1,
+    );
+    const cold = new BridgeCursorStream(cursorCompletionFrames("cold run opened"));
+    const harness = cursorHarness([parked, cold]);
+    const base = cursorRequest("session-window-retry", "kimi-k3-1m");
+    const large: CanonicalResponseRequest = {
+      ...base,
+      input: [{ type: "message", role: "user", content: "x".repeat(60_000) }],
+    };
+
+    try {
+      await collectCursorResponse(harness.adapter, large);
+      await expect(harness.adapter.stream(
+        cursorContinuation(large, [call], [cursorResult(call, "tool result")]),
+        { apiKey: "cursor-test-token", modelContextWindow: 256_000 },
+      )).rejects.toBeInstanceOf(ContextWindowExceededError);
+
+      // 압축된 재시도 — 히스토리는 줄었지만 진행 중이던 call/result는 보존된다.
+      const events = await collectAdapterEvents(await harness.adapter.stream(
+        cursorContinuation(base, [call], [cursorResult(call, "tool result")]),
+        { apiKey: "cursor-test-token", modelContextWindow: 256_000 },
+      ));
+
+      expect(canonicalText(events)).toBe("cold run opened");
+      expect(harness.openedStreams).toBe(2);
+    } finally {
+      harness.adapter.dispose();
+    }
+  });
+
   it("stays out of the way while Cursor's count is under the window", async () => {
     const belowWindow = new BridgeCursorStream([
       {

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -3067,6 +3067,36 @@ describe("pre-flight context window guard", () => {
       .resolves.toMatchObject({ status: 200 });
   });
 
+  it("hands the window to the adapter so a provider measurement can refuse the turn", async () => {
+    // 문자 추정은 provider가 실제로 센 점유를 볼 수 없다. 그 측정값을 쥔 adapter에게
+    // 창을 넘기지 않으면 어떤 adapter도 그 거절을 낼 수 없다.
+    let seenWindow: number | undefined;
+    const measuring: AiGatewayAdapter = {
+      async stream(_request, options) {
+        seenWindow = options.modelContextWindow;
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          events: iterable<CanonicalResponseEvent>([
+            { type: "response.created", response: { id: "resp_window", model: "gpt-5.6-sol", usage: null } },
+            {
+              type: "response.completed",
+              response: { id: "resp_window", model: "gpt-5.6-sol", usage: { input_tokens: 1, output_tokens: 1 } },
+            },
+          ]),
+        };
+      },
+    };
+
+    await new AnthropicMessagesGateway(measuring).stream(requestOfChars(100), {
+      apiKey: "k",
+      modelContextWindow: 272_000,
+    });
+
+    expect(seenWindow).toBe(272_000);
+  });
+
   it("charges only the tools the adapter reports as reaching the wire", async () => {
     const seen: string[][] = [];
     const narrowed: AiGatewayAdapter = {


### PR DESCRIPTION
## Summary

- Claude Code의 점유 계기는 1M 좌표로 투영된 값을 읽고, 그 투영은 모델의 실제 창에서 포화한다. 포화 이후에는 대화가 아무리 커져도 매 턴 `1,000,000`이 보고되어 클라이언트가 자기 압축 임계에 다가가는 것을 볼 수 없다. 2026-08-05 실측에서 `grok-4.5-fast` 세션이 포화된 `1,000,000`으로 **31회 연속 요청**을 보낸 뒤에야, 그것도 클라이언트 자체 로컬 집계로 뒤늦게 압축이 걸렸다(`preTokens 1,008,422`, 포화 후 5분 35초).
- Cursor가 스스로 보고한 checkpoint가 모델 창에 닿으면 다음 턴을 거절한다. 거절은 Claude Code가 reactive compaction을 무장시키는 **413**을 싣는다. 기준은 Cursor의 측정값이며 우리 문자 추정치가 아니다 — 같은 세션에서 추정은 `210,670`, Cursor 측정은 `262,338`이었고, 이것이 게이트웨이 자체 pre-flight guard가 끝내 발동하지 않은 이유다.
- `ContextWindowExceededError`를 canonical 어휘로 옮겨, provider 측정값을 쥔 adapter가 게이트웨이를 import해 계층을 뒤집지 않고도 같은 거절을 낼 수 있게 했다. 모델의 실제 창은 `AdapterCallOptions`로 adapter에 전달된다.

압축된 재시도는 훨씬 작은 요청을 보내고, 그 축소가 낡은 checkpoint를 폐기시키므로 같은 거절이 반복되지 않는다. 진행 중인 tool-continuation은 거절 대상이 아니다.

이 PR은 게이지 정확도(Cursor가 42턴 중 3턴만 실제 토큰을 보고하는 문제)는 다루지 않는다. 그 보정은 편차 곡선을 뽑을 추가 계측이 선행되어야 하며, 지금 계수를 넣으면 #519에서 제거한 것과 같은 종류의 미실측 상수가 된다.

## Test Plan

- [x] `packages/core-ai-gateway` — `pnpm typecheck` 0 오류 / `pnpm test` 249 통과 (신규 4건 포함)
- [x] `runtime/fleet-plugins/terminal` — `pnpm typecheck` 0 오류 / `pnpm test` 579 통과
- [x] `pnpm check:core-boundary` 통과
- [x] 신규 테스트: 창 포화 시 거절 · 창 미만 시 무간섭(255,999) · 압축된 재시도 통과 · gateway→adapter 창 전달
- [x] Changelog: `.changelog.d/pr-520.md` — 그룹 문법 · 이중언어 요약 · `node scripts/compile-changelog-fragments.mjs --check` 검증 완료