### PR TITLE
feat(fleet-admiral): turn the claude-api skill off on gateway sessions

### DIFF
--- a/.changelog.d/pr-521.md
+++ b/.changelog.d/pr-521.md
@@ -1,0 +1,5 @@
+### fleet-core
+
+#### Changed
+- [fleet-admiral] A gateway session no longer carries the bundled Claude API reference skill. Its trigger fires on Claude model names and on LLM work in general, so it activated readily on the gateway path even though the models a gateway session drives are the third-party backends the gateway brokers, and its body is re-sent every turn once loaded. Fleet now launches the gateway path with that skill switched off, which removes it from the host session and from every subagent it spawns, including the injected gateway model identities. Ordinary Claude sessions keep the skill.
+  ko: 게이트웨이 세션은 이제 Claude API 레퍼런스 내장 스킬을 싣지 않습니다. 이 스킬의 트리거는 Claude 모델 이름과 LLM 작업 전반을 잡아 게이트웨이 경로에서도 쉽게 발동했지만 정작 이 세션이 부리는 모델은 게이트웨이가 중개하는 타사 백엔드였고, 한 번 실린 본문은 매 턴 다시 전송됩니다. 이제 Fleet은 게이트웨이 경로를 이 스킬이 꺼진 상태로 기동하며, 호스트 세션은 물론 주입된 게이트웨이 모델 정체성을 포함한 모든 서브에이전트에서도 함께 사라집니다. 일반 Claude 세션은 그대로 유지합니다.

--- a/packages/fleet-admiral/src/agent-cli/builders/claude.ts
+++ b/packages/fleet-admiral/src/agent-cli/builders/claude.ts
@@ -10,8 +10,20 @@ export function buildClaudeNativeArgs(context: AgentCliInjectionContext): string
     ]),
     ...(context.mcpServers.length > 0 ? ["--mcp-config", buildClaudeMcpConfig(context.mcpServers)] : []),
     ...buildCustomAgentsArgs(context.customAgents),
+    ...buildSettingsArgs(context.skillOverrides),
     "--dangerously-skip-permissions",
   ];
+}
+
+/**
+ * `--settings`는 인라인 JSON을 받아 flag 소스로 병합한다. 사용자·프로젝트 설정을
+ * 대체하지 않으므로 여기서는 Fleet이 강제하는 키만 싣는다.
+ */
+function buildSettingsArgs(
+  skillOverrides: AgentCliInjectionContext["skillOverrides"],
+): string[] {
+  if (skillOverrides === undefined || Object.keys(skillOverrides).length === 0) return [];
+  return ["--settings", JSON.stringify({ skillOverrides })];
 }
 
 function buildCustomAgentsArgs(

--- a/packages/fleet-admiral/src/agent-cli/gateway-skills.ts
+++ b/packages/fleet-admiral/src/agent-cli/gateway-skills.ts
@@ -1,0 +1,29 @@
+/**
+ * gateway-skills — claude-gateway 세션에서 끄고 들어가는 Claude Code 내장 스킬.
+ *
+ * `--settings`의 `skillOverrides`로만 전달하며 파일에 남기지 않는다. 이 override는
+ * 프로세스 단위 스킬 레지스트리 필터라, 메인 세션은 물론 같은 프로세스에서 도는
+ * 모든 서브에이전트(주입한 gateway 커스텀 Agent 포함)의 스킬 목록에서도 사라진다.
+ * Agent 정의쪽 `skills`는 메인 세션에만 걸리는 허용목록이라 이 용도로 쓸 수 없다.
+ */
+
+/** `skillOverrides`가 받는 값. `off`는 모델 목록과 사용자 슬래시 호출 양쪽에서 감춘다. */
+export type ClaudeSkillOverride = "on" | "name-only" | "user-invocable-only" | "off";
+
+/**
+ * gateway 세션이 싣지 않는 내장 스킬.
+ *
+ * `claude-api`는 Anthropic API 레퍼런스다. 트리거가 `claude-*` 모델 이름과 LLM
+ * 관련 작업 전반을 잡아 gateway 경로에서 쉽게 발동하는데, 정작 이 세션이 부리는
+ * 모델은 게이트웨이가 중개하는 타사 백엔드다. 본문은 매 턴 다시 실리는 사용자
+ * 텍스트 블록이라 발동 한 번이 세션 내내 창을 잡아먹는다.
+ */
+export const GATEWAY_DISABLED_CLAUDE_SKILLS: readonly string[] = ["claude-api"];
+
+/** 스킬 이름 목록 → `skillOverrides` 맵. 빈 목록이면 undefined(설정을 싣지 않음). */
+export function buildDisabledSkillOverrides(
+  skillNames: readonly string[],
+): Readonly<Record<string, ClaudeSkillOverride>> | undefined {
+  if (skillNames.length === 0) return undefined;
+  return Object.fromEntries(skillNames.map((name) => [name, "off" as const]));
+}

--- a/packages/fleet-admiral/src/agent-cli/injection.ts
+++ b/packages/fleet-admiral/src/agent-cli/injection.ts
@@ -11,6 +11,7 @@ import { isHostSessionToolAllowed } from "../tools.js";
 import type { SystemPromptBuildOptions } from "../prompts/index.js";
 import { getAgentCliInjectionCapability } from "./capabilities.js";
 import { buildGatewayCustomAgents, type GatewayEffortExposure } from "./gateway-agents.js";
+import { GATEWAY_DISABLED_CLAUDE_SKILLS, buildDisabledSkillOverrides } from "./gateway-skills.js";
 import { createAgentCliPlugin } from "./plugin/index.js";
 import type {
   AgentCliInjectionContext,
@@ -134,6 +135,7 @@ export async function injectAgentCliProfile(
           options.gatewayExposedModels ?? [],
           options.gatewayEffortExposure,
         ),
+        skillOverrides: buildDisabledSkillOverrides(GATEWAY_DISABLED_CLAUDE_SKILLS),
       }
       : {};
     const context: AgentCliInjectionContext = {

--- a/packages/fleet-admiral/src/agent-cli/types.ts
+++ b/packages/fleet-admiral/src/agent-cli/types.ts
@@ -1,4 +1,5 @@
 import type { AdmiralDoctrine } from "../protocols/doctrine.js";
+import type { ClaudeSkillOverride } from "./gateway-skills.js";
 
 export type AgentCliId = "claude" | "claude-native" | "claude-gateway";
 
@@ -63,6 +64,11 @@ export interface AgentCliInjectionContext {
     readonly model: string;
     readonly effort?: string;
   }>>;
+  /**
+   * Claude Code `--settings`의 `skillOverrides` 맵. 세션이 싣지 않을 내장 스킬을
+   * `off`로 넣는다. 프로세스 단위 필터라 서브에이전트 목록에도 함께 적용된다.
+   */
+  readonly skillOverrides?: Readonly<Record<string, ClaudeSkillOverride>>;
   readonly mcpServers: readonly AgentCliMcpServerArg[];
   readonly pluginRoot: string;
   readonly pluginRoots: readonly string[];

--- a/packages/fleet-admiral/src/index.ts
+++ b/packages/fleet-admiral/src/index.ts
@@ -109,6 +109,12 @@ export {
   type GatewayEffortExposure,
 } from "./agent-cli/gateway-agents.js";
 
+export {
+  GATEWAY_DISABLED_CLAUDE_SKILLS,
+  buildDisabledSkillOverrides,
+  type ClaudeSkillOverride,
+} from "./agent-cli/gateway-skills.js";
+
 // Fleet 에이전트 in-process MCP 런타임 라이프사이클
 export {
   createFleetAgentRuntimeLifecycle,

--- a/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
@@ -6,7 +6,9 @@ import { findGatewayModel } from "@dotobokuri/core-ai-gateway";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  GATEWAY_DISABLED_CLAUDE_SKILLS,
   GENERAL_PURPOSE_AGENT_PROMPT,
+  buildDisabledSkillOverrides,
   buildGatewayCustomAgents,
   injectAgentCliProfile,
   resolveAgentCliProfile,
@@ -147,6 +149,59 @@ describe("claude-gateway custom agents", () => {
     expect(injected.args).not.toContain("--agents");
     expect(injected.args).not.toContain("--disallowedTools");
     injected.cleanup?.();
+  });
+});
+
+describe("claude-gateway disabled skills", () => {
+  it("turns the built-in claude-api skill off through --settings", async () => {
+    const root = createTempRoot("fleet-admiral-gateway-skills-");
+    const profile = baseProfile("claude-gateway", {
+      args: [],
+      cwd: root,
+      env: { HOME: root },
+    });
+
+    const injected = await injectAgentCliProfile(profile, baseInjectOptions(root));
+
+    const settingsIndex = injected.args.indexOf("--settings");
+    expect(settingsIndex).toBeGreaterThanOrEqual(0);
+    const settingsJson = injected.args[settingsIndex + 1];
+    expect(typeof settingsJson).toBe("string");
+    const settings = JSON.parse(settingsJson as string) as {
+      skillOverrides?: Record<string, string>;
+    };
+    expect(settings.skillOverrides).toEqual({ "claude-api": "off" });
+    // `off`만 목록과 슬래시 호출 양쪽에서 감춘다. name-only/user-invocable-only는
+    // 서브에이전트에게 이름이 남거나 모델 목록에 그대로 실린다.
+    for (const override of Object.values(settings.skillOverrides ?? {})) {
+      expect(override).toBe("off");
+    }
+    // 이 설정은 Fleet이 강제하는 키만 실어야 한다. 사용자·프로젝트 설정을 이 자리에서
+    // 덮으면 flag 소스가 가장 세서 되돌릴 방법이 없다.
+    expect(Object.keys(settings)).toEqual(["skillOverrides"]);
+
+    injected.cleanup?.();
+  });
+
+  it("leaves classic and native Claude sessions untouched", async () => {
+    const root = createTempRoot("fleet-admiral-gateway-skills-other-");
+    const classic = baseProfile("claude", { args: [], cwd: root, env: { HOME: root } });
+    const native = baseProfile("claude-native", { args: [], cwd: root, env: { HOME: root } });
+
+    const injectedClassic = await injectAgentCliProfile(classic, baseInjectOptions(root));
+    const injectedNative = await injectAgentCliProfile(native, baseInjectOptions(root));
+
+    expect(injectedClassic.args).not.toContain("--settings");
+    expect(injectedNative.args).not.toContain("--settings");
+
+    injectedClassic.cleanup?.();
+    injectedNative.cleanup?.();
+  });
+
+  it("keeps the roster non-empty so the flag is never a no-op", () => {
+    expect(GATEWAY_DISABLED_CLAUDE_SKILLS).toContain("claude-api");
+    expect(buildDisabledSkillOverrides(GATEWAY_DISABLED_CLAUDE_SKILLS)).toBeDefined();
+    expect(buildDisabledSkillOverrides([])).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- `claude-gateway` 세션은 이제 `--settings '{"skillOverrides":{"claude-api":"off"}}'` 를 달고 기동한다. Anthropic API 레퍼런스 스킬은 트리거가 `claude-*` 모델 이름과 LLM 작업 전반을 잡아 gateway 경로에서 쉽게 발동하는데, 정작 이 세션이 부리는 모델은 게이트웨이가 중개하는 타사 백엔드다.
- `skillOverrides`는 프로세스 단위 스킬 레지스트리 필터라 호스트 세션 목록과 **모든 서브에이전트 목록**(주입한 gateway 커스텀 Agent 포함)에서 동시에 사라진다. Agent 정의쪽 `skills`는 메인 세션 전용 허용목록이라 이 용도로 쓸 수 없다.
- `--settings`에는 Fleet이 강제하는 키 하나만 싣는다. flag 소스가 사용자·프로젝트 설정보다 세서, 여기 적힌 것은 운영자가 되돌릴 방법이 없다.
- classic `claude` / `claude-native` 런치는 그대로 둔다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-admiral typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-admiral test` (13 files / 135 tests)
- [x] `pnpm --filter @dotobokuri/fleet-admiral build`
- [x] `pnpm check:core-boundary`, `pnpm check:protocol-sync`
- [x] 실 CLI 실측 (claude 2.1.222): 오버라이드 없이 실행하면 호스트 `MAIN=yes` / 서브에이전트 `SUB=yes`, `--settings '{"skillOverrides":{"claude-api":"off"}}'` 를 달면 둘 다 `no`. 슬래시 호출도 `Skill "claude-api" is disabled via skillOverrides.` 로 거부된다.
- [x] Changelog: `.changelog.d/pr-521.md` 추가 — 그룹형 syntax(`### fleet-core` / `#### Changed`), 영문·`ko:` 인접 요약, `node scripts/compile-changelog-fragments.mjs --check` 통과