### PR TITLE
feat(fleet-admiral): budget staged workflow runs against silent stalls

### DIFF
--- a/.changelog.d/pr-523.md
+++ b/.changelog.d/pr-523.md
@@ -1,0 +1,5 @@
+### fleet-core
+
+#### Changed
+- [fleet-admiral] Staged workflow runs now declare a fifteen-minute stall budget instead of accepting the client default. The watchdog behind it measures the longest stretch with no progress rather than total runtime, and its three-minute default cut reasoning stages that were still working: a gateway identity at a high reasoning level was measured emitting nothing at all for two consecutive ten-second stretches. A trip restarts the stage from the beginning up to five times, so the doctrine now records that arithmetic alongside the value. Naming both an identity and a model id on one run is also called out as a silent misroute rather than an error.
+  ko: 스테이지 워크플로 실행이 클라이언트 기본값을 받아들이는 대신 15분 정체 예산을 명시합니다. 이 워치독이 재는 것은 총 실행 시간이 아니라 진행이 없는 가장 긴 구간이며, 기본값인 3분은 정상 동작 중인 추론 스테이지를 끊었습니다 — 높은 추론 수준의 게이트웨이 정체성이 10초짜리 무진행 구간을 두 번 연속 내는 것이 실측되었습니다. 한 번 걸리면 해당 스테이지를 최대 다섯 번까지 처음부터 다시 실행하므로, 그 산수도 값과 함께 지침에 등재했습니다. 하나의 실행에 정체성 이름과 모델 id를 함께 적는 것도 오류가 아니라 조용한 오라우팅으로 명시했습니다.

--- a/packages/fleet-admiral/assets/skills/gateway/workflow/SKILL.md
+++ b/packages/fleet-admiral/assets/skills/gateway/workflow/SKILL.md
@@ -27,9 +27,13 @@ Inspect the live tool surface before concluding anything about any of the three;
 
 **Call mechanics stay out of this skill on purpose.** Argument names, script syntax, return shapes, and which values a field accepts live in the live tool description. Read them there every time. Anything restated here would be a copy that goes stale silently.
 
+One narrow exception, and it exists because the rule above cannot reach: **an option the live description does not carry cannot be read there.** Where Fleet depends on such an option, this skill states it, says how it was verified and when, and warns that it can disappear without an error. `stallMs` is the only entry today. Nothing else earns the exception — if the live description carries a field, read it there.
+
 ## Gate 2 — Model Pin Gate
 
 Every run that leaves the host carries a pinned identity. An unpinned run is not the neutral choice: it inherits the session's own model and spends the session's own allowance, reached by omission rather than by selection. Closing that omission is this gate's whole job.
+
+Two fields can carry that pin, and **exactly one of them appears on any run.** A roster identity name already carries its model *and* its rung, so nothing goes beside it; a raw model id carries neither, so it needs the rung named separately. **Never both.** Passing an identity name and a model id together is not a syntax error and produces no warning — the explicit model overrides the identity's own, so the run reports one identity and bills another. That is this gate's own failure arriving through a field you filled in rather than one you left blank.
 
 **Call `gateway_models` first, every time.** Not once per session: allowances move while work is in flight, and a roster entry can be enabled or disabled between two runs. A gate cleared against a remembered roster is not cleared.
 
@@ -79,6 +83,18 @@ Fan-out helpers routinely turn a failed branch into an empty result rather than 
 - Have each stage **return its failure as a value** — a result that says it failed and why — instead of throwing into the helper.
 - Before synthesizing, check the branch count against what you started. A missing branch is a finding.
 - Never report coverage you did not verify. If the run capped, sampled, or dropped anything, say so in the report; silent truncation reads as completeness.
+
+## Stall Budget
+
+**Every `agent()` call in a staged run declares `stallMs: 900000`.** Fifteen minutes, the same on every stage. It is not tuned per stage, because what it bounds — how long an identity can go quiet — is a property of the identity and its rung, not of the work you handed it.
+
+What the option bounds is the **longest silent gap, never total runtime.** The watchdog re-arms on every progress signal and is cleared outright while a tool call is in flight, so a stage that streams for an hour never trips it and a stage that thinks in silence trips it on the default at three minutes. Reason about the silence, not the duration.
+
+That silence is real and it is not small. Measured 2026-08-05: a gateway reasoning identity at `high`, given a no-tool reasoning task, emitted **no progress signal at all for two consecutive ten-second stretches**. Nothing bounds that gap at the upper rungs, and the 180000 default cuts the run at three minutes of it.
+
+A trip is not one lost stage. The run is aborted and **respawned from the start, up to five times**, and only then does the call throw. An identity that goes quiet therefore spends the whole budget six times before the script sees an error — which is also the arithmetic against lowering the value: fifteen minutes against six attempts is up to ninety minutes before a genuinely hung run gives up. That is the deliberate trade. A late abort costs wall-clock on a run that was already lost; a premature one destroys a slow reasoning stage that was working, and the two are indistinguishable in the report.
+
+**`stallMs` is absent from the live tool description.** It is read — verified 2026-08-05 on `claude` 2.1.222, where `stallMs: 10000` cut two attempts at 10.017s and 10.027s and respawned between them — but an option no schema carries can be dropped by an upgrade with no error. The failure mode is silent reversion to 180000, never a rejection. Declare the value; never assume it took.
 
 ## Model and Effort Assignment
 
@@ -145,6 +161,14 @@ A stage running on another model has no feel for this repository's conventions, 
 - **Symptom:** The run took as long as doing it yourself, with the same total cost.
   **Action:** Count the barriers. Each one that no stage actually needed becomes wall-clock spent waiting for the slowest branch.
   **Why:** Staging buys overlap; a skeleton executed as a sequence of barriers pays the coordination cost and collects none of it back.
+
+- **Symptom:** A stage on a high reasoning rung restarted several times and then threw, or the same stage appears repeatedly in the progress tree with a `(retry N)` label.
+  **Action:** Read that stage's `stallMs`. A stage that restarts on a near-round interval was cut by the watchdog, not by the work; confirm the declared value and treat a missing one as the 180000 default.
+  **Why:** The watchdog measures silence, and a top-rung identity can think without emitting anything. Each trip respawns the stage from the start rather than resuming it, so one silent identity looks like five separate failures before the call finally throws.
+
+- **Symptom:** The progress tree named one identity, but the spend landed on another provider's allowance.
+  **Action:** Check whether that call carried both `agentType` and `model`. Remove the one you did not mean; the pin is exactly one field.
+  **Why:** The two are not validated against each other — the explicit `model` overrides the identity's own with no error and no warning, so the label keeps naming the identity you chose while the request goes elsewhere.
 
 - **Symptom:** A stage came back asking what to do, or made a choice the skeleton reserved for the host.
   **Action:** Move that decision to the preceding host-only barrier and run the stage again with the value spelled out.

--- a/packages/fleet-admiral/tests/gateway-workflow-skill.test.ts
+++ b/packages/fleet-admiral/tests/gateway-workflow-skill.test.ts
@@ -274,6 +274,50 @@ describe("gateway workflow skill asset", () => {
     expect(content).toContain("Reaching a newly enabled model requires a new session.");
   });
 
+  // stallMs 는 라이브 도구 설명에 없는 옵션이라 "거기서 읽어라" 규칙이 닿지 않는다. 값과
+  // 근거가 문언에서 사라지면 호스트는 180초 기본값으로 조용히 되돌아가고, 상위 rung 의
+  // 침묵이 정상 실행을 끊는다.
+  it("mandates a 15-minute stall budget on every call, with its measured basis", () => {
+    const content = skillContent();
+
+    expect(content).toContain("## Stall Budget");
+    expect(content).toContain("**Every `agent()` call in a staged run declares `stallMs: 900000`.**");
+    // 이 옵션이 재는 것은 총 실행 시간이 아니라 최장 무진행 구간이다. 이 구분이 빠지면
+    // 값이 "오래 걸리는 작업" 기준으로 재조정되어 실제 위험과 어긋난다.
+    expect(content).toContain("longest silent gap, never total runtime");
+    // 트립은 재개가 아니라 처음부터 재출격이고 최대 5회다 — 값을 낮출 때의 산수 근거.
+    expect(content).toContain("respawned from the start, up to five times");
+    expect(content).toContain("up to ninety minutes before a genuinely hung run gives up");
+    // 미문서화 옵션임을 지운 채 값만 남기면, 상류가 필드를 버려도 아무도 알아채지 못한다.
+    expect(content).toContain("**`stallMs` is absent from the live tool description.**");
+    expect(content).toContain("silent reversion to 180000, never a rejection");
+    expect(content).toContain("10.017s and 10.027s");
+  });
+
+  // 라이브 설명이 싣지 않는 항목만 예외로 적는다. 이 울타리가 없으면 "call mechanics는
+  // 여기 두지 않는다"는 규칙과 충돌하는 복사본이 무제한으로 자란다.
+  it("fences the call-mechanics exception to options the live description cannot carry", () => {
+    const content = skillContent();
+
+    expect(content).toContain("**Call mechanics stay out of this skill on purpose.**");
+    expect(content).toContain("an option the live description does not carry cannot be read there");
+    expect(content).toContain("`stallMs` is the only entry today");
+  });
+
+  // 핀은 정확히 한 필드다. 병기는 에러가 아니라 조용한 덮어쓰기라서, 진행 트리가 부르는
+  // 정체성과 실제 청구 대상이 갈라진다 — Gate 2 가 막으려던 실패가 빈칸이 아니라
+  // 채워 넣은 칸으로 들어오는 경로다.
+  it("makes the pin exactly one field and names the silent-override failure", () => {
+    const content = skillContent();
+
+    expect(content).toContain("exactly one of them appears on any run");
+    expect(content).toContain("**Never both.**");
+    expect(content).toContain("the explicit model overrides the identity's own");
+    // 정체성 이름은 rung 을 이미 들고 있다. 옆에 덧대는 관행이 살아나면 사다리
+    // 재선택 절차가 두 곳에서 각각 돌아간다.
+    expect(content).toContain("already carries its model *and* its rung, so nothing goes beside it");
+  });
+
   it("keeps executor-persona vocabulary out of the gateway path", () => {
     const content = skillContent();
 


### PR DESCRIPTION
## Summary
- 스테이지 워크플로의 모든 실행 호출에 `stallMs: 900000`(15분)을 필수화한다. 이 워치독이 재는 것은 **총 실행 시간이 아니라 최장 무진행 구간**이며, 진행 신호마다 재무장되고 툴 호출 중에는 해제된다. 기본값 180000은 상위 rung에서 정상 동작 중인 추론 스테이지를 끊는다.
- 근거는 실측이다 (2026-08-05): 게이트웨이 추론 정체성 `high`가 툴 없는 추론 과제에서 **10초짜리 무진행 구간을 두 번 연속** 냈다. 상위 rung에서 이 침묵을 묶어 주는 것은 없다.
- 값을 낮출 때의 산수도 함께 등재했다. 트립은 재개가 아니라 **처음부터 재출격이고 최대 5회**라, 조용해진 정체성은 스크립트가 에러를 보기까지 예산을 여섯 번 쓴다 (15분 × 6 = 최장 90분).
- 이 스킬의 "call mechanics는 여기 두지 않는다" 규칙을 **라이브 도구 설명이 실을 수 없는 항목만**으로 좁혀 명문화했다. `stallMs`가 유일한 항목이고, 스키마에 없는 옵션이라 업그레이드가 조용히 버려도 에러가 아니라 180000으로의 무음 복귀로 나타난다는 경고를 붙였다.
- Gate 2에 **핀은 정확히 한 필드**라는 규칙을 추가했다. 정체성 이름과 모델 id를 병기하면 에러가 아니라 모델이 이겨서, 진행 트리가 부르는 정체성과 실제 청구 대상이 갈라진다 (`R.model = O.model ?? R.model`).

예시 스크립트는 검토 중 제외했다 — 필드 규칙은 산문으로 충분하고, 코드 블록은 이 스킬의 no-call-mechanics 원칙과 유지비 대비 이득이 맞지 않는다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-admiral test` (13 files / 138 tests, 신규 계약 3건)
- [x] `pnpm --filter @dotobokuri/fleet-admiral typecheck`, `build`
- [x] `pnpm check:core-boundary`, `pnpm check:protocol-sync`
- [x] 실 CLI 실측 (claude 2.1.222): `stallMs: 10000`으로 sol `high` 출격 시 10.017s / 10.027s에서 각각 잘리고 동일 key로 respawn — 180초 기본값으로는 불가능한 시간대이므로 옵션이 실제로 읽힌다는 확증
- [x] 스킬 토큰 크기 재측정: 6,758 → PR#518의 oversized-skill 천장(최소 카탈로그 창 기준 52,428) 대비 여유 유지, 최대 스킬은 여전히 `pr-workflow`(8,254)이므로 claude-context.ts 주석 갱신 불필요
- [x] Changelog: `.changelog.d/pr-523.md` 추가 — `### fleet-core` / `#### Changed` 그룹형, 영문·`ko:` 인접 요약, `node scripts/compile-changelog-fragments.mjs --check` 통과 (3 entries)