### PR TITLE
fix(core-ai-gateway): keep translated streams alive

### DIFF
--- a/.changelog.d/pr-524.md
+++ b/.changelog.d/pr-524.md
@@ -5,5 +5,5 @@
 
 ### fleet-core
 #### Fixed
-- [core-ai-gateway] Emit Anthropic-compatible SSE keepalive comments for translated response streams.
-  ko: 변환된 응답 스트림에 Anthropic 호환 SSE keepalive comment를 전송합니다.
+- [core-ai-gateway] Emit Anthropic-compatible SSE keepalive comments for gateway-facing response streams.
+  ko: 게이트웨이가 제공하는 응답 스트림에 Anthropic 호환 SSE keepalive comment를 전송합니다.

--- a/.changelog.d/pr-524.md
+++ b/.changelog.d/pr-524.md
@@ -1,0 +1,9 @@
+### fleet-plugin
+#### Fixed
+- [fleet-console] Keep AI Gateway response streams active during silent provider reasoning intervals.
+  ko: 공급자 추론 중 응답이 조용한 구간에도 AI Gateway 응답 스트림의 연결을 유지합니다.
+
+### fleet-core
+#### Fixed
+- [core-ai-gateway] Emit Anthropic-compatible SSE keepalive comments for translated response streams.
+  ko: 변환된 응답 스트림에 Anthropic 호환 SSE keepalive comment를 전송합니다.

--- a/packages/core-ai-gateway/src/gateway.ts
+++ b/packages/core-ai-gateway/src/gateway.ts
@@ -10,6 +10,7 @@ import type {
   CanonicalResponseRequest,
 } from "./canonical.js";
 import { OpenAIResponsesAdapter } from "./openai-responses-adapter.js";
+import { withSseKeepAlive } from "./sse-keepalive.js";
 import { estimateTokens } from "./token-estimate.js";
 import { logCanonicalEvents, wireLog, wireLogEnabled } from "./wire-log.js";
 
@@ -116,10 +117,10 @@ export class AnthropicMessagesGateway {
           "cache-control": "no-cache",
           "content-type": "text/event-stream; charset=utf-8"
         }),
-        body: encodeAnthropicSse(events, {
+        body: withSseKeepAlive(encodeAnthropicSse(events, {
           contextWindow: options.contextWindow,
           model: request.model,
-        })
+        }))
       };
     }
 

--- a/packages/core-ai-gateway/src/index.ts
+++ b/packages/core-ai-gateway/src/index.ts
@@ -11,3 +11,4 @@ export * from "./models.js";
 export * from "./openai-chat-adapter.js";
 export * from "./openai-responses-adapter.js";
 export * from "./opencode-go.js";
+export * from "./sse-keepalive.js";

--- a/packages/core-ai-gateway/src/sse-keepalive.ts
+++ b/packages/core-ai-gateway/src/sse-keepalive.ts
@@ -1,0 +1,60 @@
+export const ANTHROPIC_SSE_KEEPALIVE_INTERVAL_MS = 10_000;
+
+const KEEPALIVE_FRAME = new TextEncoder().encode(": keep-alive\n\n");
+
+type NextResult<T> =
+  | { readonly kind: "chunk"; readonly result: IteratorResult<T> }
+  | { readonly kind: "keepalive" };
+
+/** SSE 본문이 조용한 동안 comment frame을 보내 downstream byte watchdog을 살려 둔다. */
+export async function* withSseKeepAlive(
+  chunks: AsyncIterable<Uint8Array>,
+  intervalMs = ANTHROPIC_SSE_KEEPALIVE_INTERVAL_MS,
+): AsyncGenerator<Uint8Array> {
+  const iterator = chunks[Symbol.asyncIterator]();
+  let next = iterator.next();
+
+  try {
+    for (;;) {
+      const result = await waitForChunk(next, intervalMs);
+      if (result.kind === "keepalive") {
+        yield KEEPALIVE_FRAME;
+        continue;
+      }
+      if (result.result.done) return;
+      yield result.result.value;
+      next = iterator.next();
+    }
+  } finally {
+    await iterator.return?.();
+  }
+}
+
+async function waitForChunk<T>(
+  next: Promise<IteratorResult<T>>,
+  intervalMs: number,
+): Promise<NextResult<T>> {
+  return await new Promise<NextResult<T>>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      settled = true;
+      resolve({ kind: "keepalive" });
+    }, intervalMs);
+    timer.unref?.();
+
+    next.then(
+      (result) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve({ kind: "chunk", result });
+      },
+      (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}

--- a/packages/core-ai-gateway/src/sse-keepalive.ts
+++ b/packages/core-ai-gateway/src/sse-keepalive.ts
@@ -13,21 +13,37 @@ export async function* withSseKeepAlive(
 ): AsyncGenerator<Uint8Array> {
   const iterator = chunks[Symbol.asyncIterator]();
   let next = iterator.next();
+  let boundaryTail = "";
+  let atFrameBoundary = true;
 
   try {
     for (;;) {
-      const result = await waitForChunk(next, intervalMs);
+      const result = atFrameBoundary
+        ? await waitForChunk(next, intervalMs)
+        : { kind: "chunk" as const, result: await next };
       if (result.kind === "keepalive") {
         yield KEEPALIVE_FRAME;
         continue;
       }
       if (result.result.done) return;
+      if (result.result.value.byteLength > 0) {
+        boundaryTail = appendBoundaryTail(boundaryTail, result.result.value);
+        atFrameBoundary = endsAtSseFrameBoundary(boundaryTail);
+      }
       yield result.result.value;
       next = iterator.next();
     }
   } finally {
     await iterator.return?.();
   }
+}
+
+function appendBoundaryTail(tail: string, chunk: Uint8Array): string {
+  return (tail + new TextDecoder().decode(chunk)).slice(-4);
+}
+
+function endsAtSseFrameBoundary(tail: string): boolean {
+  return tail.endsWith("\n\n") || tail.endsWith("\r\r") || tail.endsWith("\r\n\r\n");
 }
 
 async function waitForChunk<T>(

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -1249,6 +1249,44 @@ describe("Anthropic SSE keepalive", () => {
     }
   });
 
+  it("does not insert a comment into an incomplete SSE frame", async () => {
+    vi.useFakeTimers();
+    try {
+      const pending: Array<(value: IteratorResult<Uint8Array>) => void> = [];
+      const chunks: AsyncIterable<Uint8Array> = {
+        [Symbol.asyncIterator]() {
+          return {
+            next: () => new Promise<IteratorResult<Uint8Array>>((resolve) => pending.push(resolve)),
+            return: async () => ({ done: true, value: undefined }),
+          };
+        },
+      };
+      const iterator = withSseKeepAlive(chunks)[Symbol.asyncIterator]();
+      const partial = iterator.next();
+      pending.shift()?.({ done: false, value: new TextEncoder().encode("event: message_start\ndata: {") });
+      await expect(partial).resolves.toMatchObject({ done: false });
+
+      const blocked = iterator.next();
+      await vi.advanceTimersByTimeAsync(ANTHROPIC_SSE_KEEPALIVE_INTERVAL_MS * 2);
+      let settled = false;
+      void blocked.then(() => { settled = true; });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      pending.shift()?.({ done: false, value: new TextEncoder().encode("}\n\n") });
+      await expect(blocked).resolves.toMatchObject({ done: false });
+      const keepalive = iterator.next();
+      await vi.advanceTimersByTimeAsync(ANTHROPIC_SSE_KEEPALIVE_INTERVAL_MS);
+      await expect(keepalive).resolves.toMatchObject({
+        done: false,
+        value: new TextEncoder().encode(": keep-alive\n\n"),
+      });
+      await iterator.return?.(undefined);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("passes through a real chunk and restarts the idle interval", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  ANTHROPIC_SSE_KEEPALIVE_INTERVAL_MS,
   AnthropicMessagesGateway,
   GATEWAY_MODELS,
   CODEX_SUBSCRIPTION_MODELS,
@@ -30,7 +31,8 @@ import {
   UpstreamProtocolError,
   collectAnthropicMessage,
   encodeAnthropicSse,
-  translateAnthropicRequest
+  translateAnthropicRequest,
+  withSseKeepAlive
 } from "../src/index.js";
 import type {
   AiGatewayAdapter,
@@ -1169,6 +1171,114 @@ describe("Anthropic response model rewrite", () => {
     ));
 
     expect(output).toBe(raw);
+  });
+});
+
+describe("Anthropic SSE keepalive", () => {
+  it("emits a comment before Claude Code's downstream stall threshold", async () => {
+    vi.useFakeTimers();
+    try {
+      let release!: (value: IteratorResult<Uint8Array>) => void;
+      const chunks: AsyncIterable<Uint8Array> = {
+        [Symbol.asyncIterator]() {
+          return {
+            next: () => new Promise<IteratorResult<Uint8Array>>((resolve) => { release = resolve; }),
+            return: async () => ({ done: true, value: undefined }),
+          };
+        },
+      };
+      const iterator = withSseKeepAlive(chunks)[Symbol.asyncIterator]();
+      const first = iterator.next();
+
+      await vi.advanceTimersByTimeAsync(ANTHROPIC_SSE_KEEPALIVE_INTERVAL_MS - 1);
+      let settled = false;
+      void first.then(() => { settled = true; });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(first).resolves.toMatchObject({
+        done: false,
+        value: new TextEncoder().encode(": keep-alive\n\n"),
+      });
+
+      release({ done: true, value: undefined });
+      await iterator.return?.(undefined);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a translated gateway response alive before the first canonical event", async () => {
+    vi.useFakeTimers();
+    try {
+      let finish!: () => void;
+      const adapter: AiGatewayAdapter = {
+        async stream() {
+          return {
+            ok: true as const,
+            status: 200,
+            headers: new Headers(),
+            events: {
+              [Symbol.asyncIterator]() {
+                return {
+                  next: () => new Promise<IteratorResult<CanonicalResponseEvent>>((resolve) => {
+                    finish = () => resolve({ done: true, value: undefined });
+                  }),
+                  return: async () => ({ done: true, value: undefined }),
+                };
+              },
+            },
+          };
+        },
+      };
+      const response = await new AnthropicMessagesGateway(adapter).stream(baseRequest(), { apiKey: "k" });
+      const iterator = response.body[Symbol.asyncIterator]();
+      const first = iterator.next();
+
+      await vi.advanceTimersByTimeAsync(ANTHROPIC_SSE_KEEPALIVE_INTERVAL_MS);
+      await expect(first).resolves.toMatchObject({
+        done: false,
+        value: new TextEncoder().encode(": keep-alive\n\n"),
+      });
+
+      finish();
+      await iterator.return?.(undefined);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("passes through a real chunk and restarts the idle interval", async () => {
+    vi.useFakeTimers();
+    try {
+      const pending: Array<(value: IteratorResult<Uint8Array>) => void> = [];
+      const chunks: AsyncIterable<Uint8Array> = {
+        [Symbol.asyncIterator]() {
+          return {
+            next: () => new Promise<IteratorResult<Uint8Array>>((resolve) => pending.push(resolve)),
+            return: async () => ({ done: true, value: undefined }),
+          };
+        },
+      };
+      const iterator = withSseKeepAlive(chunks)[Symbol.asyncIterator]();
+      const real = iterator.next();
+      await vi.advanceTimersByTimeAsync(6_000);
+      pending.shift()?.({ done: false, value: new TextEncoder().encode("event: message_start\n\n") });
+      await expect(real).resolves.toMatchObject({ done: false });
+
+      const keepalive = iterator.next();
+      await vi.advanceTimersByTimeAsync(9_999);
+      let settled = false;
+      void keepalive.then(() => { settled = true; });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(keepalive).resolves.toMatchObject({ done: false });
+      await iterator.return?.(undefined);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/runtime/fleet-plugins/terminal/server/ai-gateway-opencode.ts
+++ b/runtime/fleet-plugins/terminal/server/ai-gateway-opencode.ts
@@ -66,6 +66,7 @@ export async function proxyToOpencode(
   await proxyAnthropicMessages(res, opencodeRequestBody(body, model), {
     contextWindow,
     responseModel,
+    keepAlive: true,
     fetchImpl,
     headers,
     signal,

--- a/runtime/fleet-plugins/terminal/server/ai-gateway-proxy.ts
+++ b/runtime/fleet-plugins/terminal/server/ai-gateway-proxy.ts
@@ -1,4 +1,4 @@
-import { projectAnthropicResponseUsage } from "@dotobokuri/core-ai-gateway";
+import { projectAnthropicResponseUsage, withSseKeepAlive } from "@dotobokuri/core-ai-gateway";
 import type {
   AnthropicMessage,
   AnthropicMessagesRequest,
@@ -28,6 +28,8 @@ export interface AnthropicProxyOptions {
    * 되돌려 본다 — Claude Code가 자기 요청 모델과 응답 모델을 대조할 수 있게 한다.
    */
   readonly responseModel?: string;
+  /** Provider가 Anthropic 이벤트를 내지 않는 동안에도 gateway alias의 downstream 생존성을 유지한다. */
+  readonly keepAlive?: boolean;
   readonly fetchImpl: typeof fetch;
   readonly headers: Readonly<Record<string, string>>;
   readonly signal: AbortSignal;
@@ -69,13 +71,17 @@ export async function proxyAnthropicMessages(
   }
   const rawBody = readResponseBody(upstream.body);
   // contextWindow이 없어도 responseModel이 있으면 재작성이 필요하므로 변환기를 탄다.
-  const responseBody = options.contextWindow === undefined && options.responseModel === undefined
+  const contentType = upstream.headers.get("content-type");
+  const projectedBody = options.contextWindow === undefined && options.responseModel === undefined
     ? rawBody
     : projectAnthropicResponseUsage(rawBody, {
-        contentType: upstream.headers.get("content-type"),
+        contentType,
         contextWindow: options.contextWindow,
         responseModel: options.responseModel,
       });
+  const responseBody = options.keepAlive === true && contentType?.split(";", 1)[0]?.trim().toLowerCase() === "text/event-stream"
+    ? withSseKeepAlive(projectedBody)
+    : projectedBody;
   for await (const chunk of responseBody) {
     if (!res.write(chunk)) await drain(res);
   }

--- a/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
@@ -426,6 +426,7 @@ async function proxyToKimi(
   await proxyAnthropicMessages(res, kimiRequestBody(body, model), {
     contextWindow,
     responseModel,
+    keepAlive: true,
     fetchImpl,
     headers,
     signal,

--- a/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
@@ -393,6 +393,7 @@ async function proxyToAnthropic(
     if (typeof value === "string") headers[name] = value;
   }
   await proxyAnthropicMessages(res, body, {
+    keepAlive: true,
     fetchImpl,
     headers,
     signal,

--- a/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
@@ -721,6 +721,39 @@ describe("OpenCode Go passthrough", () => {
 });
 
 describe("Kimi passthrough", () => {
+  it("keeps Claude Code's downstream stream alive while the provider is silent", async () => {
+    vi.useFakeTimers();
+    try {
+      let close!: () => void;
+      const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            close = () => controller.close();
+          },
+        }),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      ));
+      const router = createAiGatewayRouter({
+        fetch: fetchMock,
+        readAuth,
+        readKimiApiKey: async () => "kimi-secret",
+      });
+      const res = response();
+      const handled = router.handle(ctx({
+        res,
+        token: ANTHROPIC_CRED,
+        model: "claude-gateway--kimi--k3-256k",
+      }));
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(res.body).toBe(": keep-alive\n\n");
+      close();
+      await handled;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("rewrites the model and replaces caller authentication with the stored Kimi key", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => new Response(
       "event: message_stop\n\n",

--- a/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
@@ -1077,6 +1077,35 @@ describe("Kimi passthrough", () => {
 });
 
 describe("anthropic passthrough", () => {
+  it("keeps Claude Code's downstream stream alive while Anthropic is silent", async () => {
+    vi.useFakeTimers();
+    try {
+      let close!: () => void;
+      const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            close = () => controller.close();
+          },
+        }),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      ));
+      const router = createAiGatewayRouter({ fetch: fetchMock, readAuth });
+      const res = response();
+      const handled = router.handle(ctx({
+        res,
+        token: ANTHROPIC_CRED,
+        model: "claude-opus-4-6",
+      }));
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(res.body).toBe(": keep-alive\n\n");
+      close();
+      await handled;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("relays a claude model to the Anthropic subscription without translating", async () => {
     const gateway = stubGateway();
     const streamSpy = vi.spyOn(gateway, "stream");


### PR DESCRIPTION
## Summary
- emit a 10-second SSE comment keepalive while gateway-facing response streams are silent
- apply the liveness bridge to translated, Kimi, Anthropic-wire OpenCode, and native Anthropic paths
- insert comments only at complete SSE frame boundaries so partial provider events remain intact

## Test Plan
- [x] `corepack pnpm --filter @dotobokuri/core-ai-gateway test`
- [x] `corepack pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `corepack pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `corepack pnpm --filter @fleet-plugins/terminal test`
- [x] `corepack pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `corepack pnpm --filter @fleet-plugins/terminal build`
- [x] `corepack pnpm check:core-boundary`
- [x] isolated Console remains available for manual testing (`HTTP 200`)
- [x] `.changelog.d/pr-524.md` has bilingual grouped entries and passes the fragment compiler