### PR TITLE
feat(core-ai-gateway): stream reasoning as thinking

### DIFF
--- a/.changelog.d/pr-525.md
+++ b/.changelog.d/pr-525.md
@@ -1,0 +1,4 @@
+### fleet-core
+#### Added
+- [core-ai-gateway] Stream OpenAI Responses reasoning as Anthropic thinking blocks for Claude Code.
+  ko: Claude Code에서 OpenAI Responses 추론을 Anthropic thinking 블록으로 스트리밍합니다.

--- a/packages/core-ai-gateway/src/anthropic.ts
+++ b/packages/core-ai-gateway/src/anthropic.ts
@@ -513,7 +513,7 @@ function stringMetadata(
 
 interface OpenBlock {
   index: number;
-  kind: "text" | "tool_use";
+  kind: "text" | "thinking" | "tool_use";
   accumulatedJson: string;
   closed: boolean;
 }
@@ -644,6 +644,7 @@ export async function collectAnthropicMessage(
   let id = "msg_gateway";
   let model = fallbackModel;
   let text = "";
+  const thinking = new Map<string, string>();
   let stopReason = "end_turn";
   let outputTokens = 0;
   let inputTokens = 0;
@@ -663,6 +664,9 @@ export async function collectAnthropicMessage(
         break;
       case "response.output_text.delta":
         text += event.delta;
+        break;
+      case "response.reasoning_summary_text.delta":
+        thinking.set(event.item_id, (thinking.get(event.item_id) ?? "") + event.delta);
         break;
       case "response.output_item.added":
         if (event.item.type === "function_call") {
@@ -722,6 +726,11 @@ export async function collectAnthropicMessage(
     if (block) block.input = safeJson(entry.text);
   }
   if (text.length > 0) content.unshift({ type: "text", text });
+  content.unshift(...[...thinking].map(([itemId, value]) => ({
+    type: "thinking",
+    thinking: value,
+    signature: `gateway_${reasoningBlockKey(itemId)}`,
+  })));
 
   return {
     id,
@@ -761,39 +770,57 @@ export async function* encodeAnthropicSse(
   let messageStarted = false;
   let messageStopped = false;
   let sawToolUse = false;
+  let activeContentKey: string | undefined;
 
   const encode = (event: string, data: unknown): Uint8Array =>
     encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
 
-  const startTextBlock = (key: string): Uint8Array | undefined => {
+  const startContentBlock = (key: string, kind: "text" | "thinking"): Uint8Array | undefined => {
     if (blocks.has(key)) {
       return undefined;
     }
     const block: OpenBlock = {
       index: nextBlockIndex++,
-      kind: "text",
+      kind,
       accumulatedJson: "",
       closed: false
     };
     blocks.set(key, block);
+    activeContentKey = key;
     return encode("content_block_start", {
       type: "content_block_start",
       index: block.index,
-      content_block: { type: "text", text: "" }
+      content_block: kind === "text"
+        ? { type: "text", text: "" }
+        : { type: "thinking", thinking: "", signature: "" }
     });
   };
 
-  const closeBlock = (key: string): Uint8Array | undefined => {
+  const closeBlock = (key: string): Uint8Array[] => {
     const block = blocks.get(key);
     if (block === undefined || block.closed) {
-      return undefined;
+      return [];
     }
     block.closed = true;
-    return encode("content_block_stop", {
-      type: "content_block_stop",
-      index: block.index
-    });
+    if (activeContentKey === key) activeContentKey = undefined;
+    return [
+      ...(block.kind === "thinking"
+        ? [encode("content_block_delta", {
+            type: "content_block_delta",
+            index: block.index,
+            delta: { type: "signature_delta", signature: `gateway_${key}` }
+          })]
+        : []),
+      encode("content_block_stop", {
+        type: "content_block_stop",
+        index: block.index
+      })
+    ];
   };
+
+  const closeActiveContent = (): Uint8Array[] => activeContentKey === undefined
+    ? []
+    : closeBlock(activeContentKey);
 
   for await (const event of events) {
     switch (event.type) {
@@ -819,17 +846,19 @@ export async function* encodeAnthropicSse(
         break;
       case "response.content_part.added": {
         const key = textBlockKey(event.item_id, event.content_index);
-        const start = startTextBlock(key);
-        if (start !== undefined) {
-          yield start;
+        if (!blocks.has(key)) {
+          yield* closeActiveContent();
+          const start = startContentBlock(key, "text");
+          if (start !== undefined) yield start;
         }
         break;
       }
       case "response.output_text.delta": {
         const key = textBlockKey(event.item_id, event.content_index);
-        const start = startTextBlock(key);
-        if (start !== undefined) {
-          yield start;
+        if (!blocks.has(key)) {
+          yield* closeActiveContent();
+          const start = startContentBlock(key, "text");
+          if (start !== undefined) yield start;
         }
         const block = blocks.get(key);
         if (block !== undefined) {
@@ -841,15 +870,29 @@ export async function* encodeAnthropicSse(
         }
         break;
       }
-      case "response.output_text.done": {
-        const stop = closeBlock(textBlockKey(event.item_id, event.content_index));
-        if (stop !== undefined) {
-          yield stop;
+      case "response.output_text.done":
+        yield* closeBlock(textBlockKey(event.item_id, event.content_index));
+        break;
+      case "response.reasoning_summary_text.delta": {
+        const key = reasoningBlockKey(event.item_id);
+        if (!blocks.has(key)) {
+          yield* closeActiveContent();
+          const start = startContentBlock(key, "thinking");
+          if (start !== undefined) yield start;
+        }
+        const block = blocks.get(key);
+        if (block !== undefined) {
+          yield encode("content_block_delta", {
+            type: "content_block_delta",
+            index: block.index,
+            delta: { type: "thinking_delta", thinking: event.delta }
+          });
         }
         break;
       }
       case "response.output_item.added":
         if (event.item.type === "function_call") {
+          yield* closeActiveContent();
           sawToolUse = true;
           const block: OpenBlock = {
             index: nextBlockIndex++,
@@ -891,16 +934,14 @@ export async function* encodeAnthropicSse(
             delta: { type: "input_json_delta", partial_json: remainder }
           });
         }
-        const stop = closeBlock(event.item_id);
-        if (stop !== undefined) {
-          yield stop;
-        }
+        yield* closeBlock(event.item_id);
         break;
       }
       case "response.output_item.done":
         if (event.item.type === "function_call") {
           let block = blocks.get(event.item.id);
           if (block === undefined) {
+            yield* closeActiveContent();
             const syntheticStart = functionCallStart(event.item, nextBlockIndex++);
             block = syntheticStart.block;
             blocks.set(event.item.id, block);
@@ -916,11 +957,9 @@ export async function* encodeAnthropicSse(
               delta: { type: "input_json_delta", partial_json: remainder }
             });
           }
-          const stop = closeBlock(event.item.id);
-          if (stop !== undefined) {
-            yield stop;
-          }
+          yield* closeBlock(event.item.id);
         } else if (event.item.type === "web_search_call") {
+          yield* closeActiveContent();
           // Provider-executed search arrives whole at `done` (never at `added`, which would
           // race a partial action). It never marks sawToolUse: server tools keep stop_reason
           // at end_turn, unlike a client tool_use round-trip.
@@ -958,10 +997,7 @@ export async function* encodeAnthropicSse(
         break;
       case "response.completed":
         for (const [key] of blocks) {
-          const stop = closeBlock(key);
-          if (stop !== undefined) {
-            yield stop;
-          }
+          yield* closeBlock(key);
         }
         yield encode("message_delta", {
           type: "message_delta",
@@ -978,10 +1014,12 @@ export async function* encodeAnthropicSse(
         messageStopped = true;
         break;
       case "response.failed":
+        yield* closeActiveContent();
         yield encode("error", { type: "error", error: event.response.error });
         messageStopped = true;
         break;
       case "error":
+        yield* closeActiveContent();
         yield encode("error", { type: "error", error: event.error });
         messageStopped = true;
         break;
@@ -995,6 +1033,10 @@ export async function* encodeAnthropicSse(
 
 function textBlockKey(itemId: string, contentIndex: number): string {
   return `${itemId}:${contentIndex}`;
+}
+
+function reasoningBlockKey(itemId: string): string {
+  return `reasoning:${itemId}`;
 }
 
 function requiredToolBlock(blocks: Map<string, OpenBlock>, itemId: string): OpenBlock {

--- a/packages/core-ai-gateway/src/canonical.ts
+++ b/packages/core-ai-gateway/src/canonical.ts
@@ -278,6 +278,12 @@ export type CanonicalResponseEvent =
       text: string;
     }
   | {
+      type: "response.reasoning_summary_text.delta";
+      item_id: string;
+      output_index: number;
+      delta: string;
+    }
+  | {
       type: "response.output_item.added";
       output_index: number;
       item: CanonicalOutputItem;

--- a/packages/core-ai-gateway/src/openai-responses-adapter.ts
+++ b/packages/core-ai-gateway/src/openai-responses-adapter.ts
@@ -397,6 +397,14 @@ function canonicalEvent(value: unknown): CanonicalResponseEvent | undefined {
         content_index: number(value.content_index, "content_index"),
         text: string(value.text, "text")
       };
+    case "response.reasoning_summary_text.delta":
+    case "response.reasoning_text.delta":
+      return {
+        type: "response.reasoning_summary_text.delta",
+        item_id: string(value.item_id, "item_id"),
+        output_index: number(value.output_index, "output_index"),
+        delta: string(value.delta, "delta")
+      };
     case "response.output_item.added":
     case "response.output_item.done": {
       const item = outputItem(value.item);

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -308,6 +308,24 @@ describe("Anthropic request translation", () => {
     })).not.toHaveProperty("reasoning");
   });
 
+  it("drops synthetic thinking blocks when replaying an assistant turn", () => {
+    const request: AnthropicMessagesRequest = {
+      ...baseRequest(),
+      messages: [{
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Inspecting.", signature: "gateway_reasoning:rs_1" },
+          { type: "redacted_thinking", data: "opaque" },
+          { type: "text", text: "Done" },
+        ],
+      }],
+    };
+
+    expect(translateAnthropicRequest(request).input).toEqual([
+      { type: "message", role: "assistant", content: "Done" },
+    ]);
+  });
+
   it("maps a second-turn tool_result back to the preserved function call id", () => {
     const request: AnthropicMessagesRequest = {
       model: "claude-sonnet-4-6",
@@ -2392,6 +2410,137 @@ describe("OpenAI Responses adapter", () => {
       },
     });
     expect(messageDelta?.data).toMatchObject({ delta: { stop_reason: "end_turn" } });
+  });
+
+  it("streams Responses reasoning summaries as Anthropic thinking before text", async () => {
+    const upstreamSse = [
+      frame("response.created", {
+        type: "response.created",
+        response: { id: "resp_reasoning", model: "gpt-5.6-sol", usage: null },
+      }),
+      frame("response.reasoning_summary_text.delta", {
+        type: "response.reasoning_summary_text.delta",
+        item_id: "rs_1",
+        output_index: 0,
+        delta: "Inspecting ",
+      }),
+      frame("response.reasoning_text.delta", {
+        type: "response.reasoning_text.delta",
+        item_id: "rs_1",
+        output_index: 0,
+        delta: "the repository.",
+      }),
+      frame("response.output_text.delta", {
+        type: "response.output_text.delta",
+        item_id: "msg_1",
+        output_index: 1,
+        content_index: 0,
+        delta: "Done",
+      }),
+      frame("response.output_text.done", {
+        type: "response.output_text.done",
+        item_id: "msg_1",
+        output_index: 1,
+        content_index: 0,
+        text: "Done",
+      }),
+      frame("response.completed", {
+        type: "response.completed",
+        response: { id: "resp_reasoning", model: "gpt-5.6-sol", usage: { input_tokens: 8, output_tokens: 5 } },
+      }),
+    ].join("");
+    const adapter = new OpenAIResponsesAdapter({ fetch: async () => sseResponse(upstreamSse) });
+    const result = await adapter.stream(
+      { model: "gpt-5.6-sol", input: [], stream: true },
+      { apiKey: "k" },
+    );
+    if (!result.ok) throw new Error("expected a successful stream");
+    const events: CanonicalResponseEvent[] = [];
+    for await (const event of result.events) events.push(event);
+
+    expect(events.filter((event) => event.type === "response.reasoning_summary_text.delta")).toEqual([
+      { type: "response.reasoning_summary_text.delta", item_id: "rs_1", output_index: 0, delta: "Inspecting " },
+      { type: "response.reasoning_summary_text.delta", item_id: "rs_1", output_index: 0, delta: "the repository." },
+    ]);
+
+    const frames = parseSse(await collectBody(encodeAnthropicSse(iterable(events))));
+    expect(frames.map((item) => item.event)).toEqual([
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_delta",
+      "content_block_delta",
+      "content_block_stop",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ]);
+    expect(frames[1]?.data).toMatchObject({
+      content_block: { type: "thinking", thinking: "", signature: "" },
+    });
+    expect(frames[2]?.data).toMatchObject({ delta: { type: "thinking_delta", thinking: "Inspecting " } });
+    expect(frames[3]?.data).toMatchObject({ delta: { type: "thinking_delta", thinking: "the repository." } });
+    expect(frames[4]?.data).toMatchObject({
+      delta: { type: "signature_delta", signature: "gateway_reasoning:rs_1" },
+    });
+    expect(frames[6]?.data).toMatchObject({ content_block: { type: "text", text: "" } });
+
+    const collected = await collectAnthropicMessage(iterable(events), "gpt-5.6-sol");
+    expect(collected.content).toEqual([
+      { type: "thinking", thinking: "Inspecting the repository.", signature: "gateway_reasoning:rs_1" },
+      { type: "text", text: "Done" },
+    ]);
+  });
+
+  it("closes thinking with a signature before starting a tool block", async () => {
+    const events = iterable<CanonicalResponseEvent>([
+      {
+        type: "response.created",
+        response: { id: "resp_reason_tool", model: "gpt-5.6-sol", usage: null },
+      },
+      {
+        type: "response.reasoning_summary_text.delta",
+        item_id: "rs_tool",
+        output_index: 0,
+        delta: "Need a file.",
+      },
+      {
+        type: "response.output_item.added",
+        output_index: 1,
+        item: {
+          type: "function_call",
+          id: "fc_tool",
+          call_id: "call_tool",
+          name: "read_file",
+          arguments: "",
+        },
+      },
+      {
+        type: "response.function_call_arguments.done",
+        item_id: "fc_tool",
+        output_index: 1,
+        arguments: '{"path":"README.md"}',
+      },
+      {
+        type: "response.completed",
+        response: { id: "resp_reason_tool", model: "gpt-5.6-sol", usage: { input_tokens: 5, output_tokens: 3 } },
+      },
+    ]);
+
+    const frames = parseSse(await collectBody(encodeAnthropicSse(events)));
+    expect(frames.slice(1, 7).map((item) => [item.event, (item.data.delta as { type?: string } | undefined)?.type])).toEqual([
+      ["content_block_start", undefined],
+      ["content_block_delta", "thinking_delta"],
+      ["content_block_delta", "signature_delta"],
+      ["content_block_stop", undefined],
+      ["content_block_start", undefined],
+      ["content_block_delta", "input_json_delta"],
+    ]);
+    expect(frames[5]?.data).toMatchObject({
+      content_block: { type: "tool_use", id: "call_tool", name: "read_file" },
+    });
   });
 
   it("streams function-call arguments into Anthropic tool_use deltas with the call id intact", async () => {


### PR DESCRIPTION
## Summary
- preserve OpenAI Responses reasoning summary and reasoning text deltas in the canonical response stream
- expose provider reasoning to Claude Code as Anthropic `thinking` blocks with deterministic synthetic signatures
- omit synthetic thinking and redacted-thinking blocks when replaying assistant turns upstream

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` (259 passed)
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `pnpm check:core-boundary`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] isolated Fleet Console returned HTTP 200 at `http://127.0.0.1:61552/console/`
- [x] added `.changelog.d/pr-525.md` with bilingual grouped syntax
- [x] `node scripts/compile-changelog-fragments.mjs --check`