### PR TITLE
feat(core-ai-gateway): bridge provider thinking streams

### DIFF
--- a/.changelog.d/pr-526.md
+++ b/.changelog.d/pr-526.md
@@ -1,0 +1,4 @@
+### fleet-core
+#### Added
+- [core-ai-gateway] Show OpenCode Chat Completions and Cursor reasoning as Claude Code thinking, with DeepSeek V4 reasoning history preserved across tool turns.
+  ko: OpenCode Chat Completions와 Cursor 추론을 Claude Code thinking으로 표시하고 DeepSeek V4 추론 기록을 도구 실행 턴 사이에도 보존합니다.

--- a/packages/core-ai-gateway/src/anthropic.ts
+++ b/packages/core-ai-gateway/src/anthropic.ts
@@ -350,8 +350,16 @@ function translateMessage(message: AnthropicMessage): CanonicalResponseRequest["
 
   const items: CanonicalResponseRequest["input"] = [];
   const parts: CanonicalInputContentPart[] = [];
+  let reasoningContent = "";
 
-  const flushParts = (): void => {
+  const takeReasoningContent = (): { reasoning_content?: string } => {
+    if (role !== "assistant" || reasoningContent.length === 0) return {};
+    const reasoning = reasoningContent;
+    reasoningContent = "";
+    return { reasoning_content: reasoning };
+  };
+
+  const flushParts = (includeReasoning = true): void => {
     if (parts.length === 0) {
       return;
     }
@@ -359,6 +367,7 @@ function translateMessage(message: AnthropicMessage): CanonicalResponseRequest["
       type: "message",
       role,
       content: normalizeCanonicalMessageContent(parts.splice(0, parts.length)),
+      ...(includeReasoning ? takeReasoningContent() : {}),
     });
   };
 
@@ -373,12 +382,13 @@ function translateMessage(message: AnthropicMessage): CanonicalResponseRequest["
         parts.push(translateImageBlock(block));
         break;
       case "tool_use":
-        flushParts();
+        flushParts(false);
         items.push({
           type: "function_call",
           call_id: block.id,
           name: block.name,
-          arguments: JSON.stringify(block.input)
+          arguments: JSON.stringify(block.input),
+          ...takeReasoningContent(),
         });
         break;
       case "tool_result": {
@@ -396,6 +406,10 @@ function translateMessage(message: AnthropicMessage): CanonicalResponseRequest["
         break;
       }
       case "thinking":
+        if (role === "assistant" && typeof block.thinking === "string") {
+          reasoningContent += block.thinking;
+        }
+        break;
       case "redacted_thinking":
         break;
       default:

--- a/packages/core-ai-gateway/src/canonical.ts
+++ b/packages/core-ai-gateway/src/canonical.ts
@@ -20,6 +20,8 @@ export interface CanonicalInputMessage {
   role: "user" | "assistant" | "developer";
   /** Plain text, or Responses-style multimodal parts when images are present. */
   content: string | CanonicalInputContentPart[];
+  /** Provider 추론 재생 메타데이터. 어댑터가 모델별로 선택하며 visible content로 노출하지 않는다. */
+  reasoning_content?: string;
 }
 
 /** Flatten message text for adapters that only accept a string prompt body. */
@@ -67,6 +69,8 @@ export interface CanonicalFunctionCall {
   call_id: string;
   name: string;
   arguments: string;
+  /** 이 assistant tool call 앞의 provider 추론. 요구하는 모델의 history에만 재생한다. */
+  reasoning_content?: string;
 }
 
 export interface CanonicalFunctionCallOutput {

--- a/packages/core-ai-gateway/src/cursor-adapter.ts
+++ b/packages/core-ai-gateway/src/cursor-adapter.ts
@@ -2437,6 +2437,12 @@ function createCursorLiveRun(options: CursorLiveRunOptions): CursorLiveRun {
     }
     if (isRecord(update.thinkingDelta) && typeof update.thinkingDelta.text === "string") {
       activeSegment.outputText += update.thinkingDelta.text;
+      emit({
+        type: "response.reasoning_summary_text.delta",
+        item_id: `${activeSegment.itemId}_reasoning`,
+        output_index: 0,
+        delta: update.thinkingDelta.text,
+      });
       return;
     }
     if (isRecord(update.tokenDelta)) {

--- a/packages/core-ai-gateway/src/openai-chat-adapter.ts
+++ b/packages/core-ai-gateway/src/openai-chat-adapter.ts
@@ -51,8 +51,9 @@ interface ChatWireToolCall {
 }
 
 type ChatWireMessage =
-  | { role: "system" | "assistant" | "user"; content: string | ChatWireContentPart[] }
-  | { role: "assistant"; content: string | null; tool_calls: ChatWireToolCall[] }
+  | { role: "system" | "user"; content: string | ChatWireContentPart[] }
+  | { role: "assistant"; content: string | ChatWireContentPart[]; reasoning_content?: string }
+  | { role: "assistant"; content: string | null; tool_calls: ChatWireToolCall[]; reasoning_content?: string }
   | { role: "tool"; tool_call_id: string; content: string };
 
 interface ChatWireRequest {
@@ -83,9 +84,9 @@ export interface OpenAIChatCompletionsAdapterOptions {
  * - No strict-mode schema rewrite. Chat Completions backends differ on strict
  *   support, so tools ship with their original schemas and the optional-argument
  *   pollution caveat documented for Cursor applies here too.
- * - `reasoning` never reaches the wire. Chat Completions has no portable
- *   reasoning parameter, and `reasoning_content` deltas some backends stream are
- *   hidden thinking — they are dropped, surfacing only in reported usage.
+ * - Chat Completions에는 이식 가능한 `reasoning` 요청 파라미터가 없어 설정은 wire에 싣지
+ *   않는다. Provider가 보낸 `reasoning_content`는 canonical reasoning으로 보존하고, 이전
+ *   assistant 추론은 wire 요구가 실측된 모델에만 재생한다.
  */
 export class OpenAIChatCompletionsAdapter implements AiGatewayAdapter {
   private readonly fetchImpl: FetchLike;
@@ -179,8 +180,10 @@ function forChatCompletionsBackend(request: CanonicalResponseRequest): ChatWireR
   //   assistant 메시지로 병합하고,
   // - 사이에 낀 user/developer 텍스트는 해당 호출의 결과 뒤로 미룬다(원문에서도 결과와
   //   함께 도착한 발화이므로 결과 직후가 의미상 제자리다).
+  const replayReasoning = request.model.startsWith("deepseek-v4-");
   let pendingToolCalls: ChatWireToolCall[] = [];
   let pendingAssistantText: string | undefined;
+  let pendingAssistantReasoning: string | undefined;
   let deferredMessages: ChatWireMessage[] = [];
   const flushToolCalls = (): void => {
     if (pendingToolCalls.length === 0) return;
@@ -188,9 +191,13 @@ function forChatCompletionsBackend(request: CanonicalResponseRequest): ChatWireR
       role: "assistant",
       content: pendingAssistantText ?? null,
       tool_calls: pendingToolCalls,
+      ...(replayReasoning && pendingAssistantReasoning
+        ? { reasoning_content: pendingAssistantReasoning }
+        : {}),
     });
     pendingToolCalls = [];
     pendingAssistantText = undefined;
+    pendingAssistantReasoning = undefined;
   };
   const flushDeferredMessages = (): void => {
     if (deferredMessages.length === 0) return;
@@ -206,6 +213,9 @@ function forChatCompletionsBackend(request: CanonicalResponseRequest): ChatWireR
         type: "function",
         function: { name: item.name, arguments: item.arguments },
       });
+      if (replayReasoning && item.reasoning_content) {
+        pendingAssistantReasoning ??= item.reasoning_content;
+      }
       continue;
     }
     if (item.type === "function_call_output") {
@@ -220,12 +230,12 @@ function forChatCompletionsBackend(request: CanonicalResponseRequest): ChatWireR
           pendingAssistantText = pendingAssistantText === undefined ? text : `${pendingAssistantText}\n\n${text}`;
         }
       } else {
-        deferredMessages.push(chatWireMessage(item));
+        deferredMessages.push(chatWireMessage(item, replayReasoning));
       }
       continue;
     }
     flushDeferredMessages();
-    messages.push(chatWireMessage(item));
+    messages.push(chatWireMessage(item, replayReasoning));
   }
   flushToolCalls();
   flushDeferredMessages();
@@ -264,15 +274,27 @@ function forChatCompletionsBackend(request: CanonicalResponseRequest): ChatWireR
   return payload;
 }
 
-function chatWireMessage(item: CanonicalInputMessage): ChatWireMessage {
+function chatWireMessage(
+  item: CanonicalInputMessage,
+  replayReasoning: boolean,
+): ChatWireMessage {
   // canonical developer = system 성격 메시지 (Codex 백엔드 전용 표기). Chat 와이어의
   // 보편 표기는 system이다.
   const role = item.role === "developer" ? "system" : item.role;
+  if (role === "assistant") {
+    return {
+      role,
+      content: canonicalMessageText(item.content),
+      ...(replayReasoning && item.reasoning_content
+        ? { reasoning_content: item.reasoning_content }
+        : {}),
+    };
+  }
   if (typeof item.content === "string") {
     return { role, content: item.content };
   }
-  // 이미지 파트는 user 멀티모달 메시지에서만 의미가 있다. 그 밖의 role은 텍스트로 접는다.
-  if (role !== "user") {
+  // 이미지 파트는 user 멀티모달 메시지에서만 의미가 있다. system은 텍스트로 접는다.
+  if (role === "system") {
     return { role, content: canonicalMessageText(item.content) };
   }
   const parts: ChatWireContentPart[] = item.content.map((part) => {
@@ -364,6 +386,14 @@ async function* translateChatCompletionsStream(
     for (const choice of choices) {
       if (!isRecord(choice)) continue;
       const delta = isRecord(choice.delta) ? choice.delta : {};
+      if (typeof delta.reasoning_content === "string" && delta.reasoning_content.length > 0) {
+        yield {
+          type: "response.reasoning_summary_text.delta",
+          item_id: `${MESSAGE_ITEM_ID}_reasoning`,
+          output_index: 0,
+          delta: delta.reasoning_content,
+        };
+      }
       if (typeof delta.content === "string" && delta.content.length > 0) {
         textSeen = true;
         accumulatedText += delta.content;

--- a/packages/core-ai-gateway/tests/cursor-tool-stream.test.ts
+++ b/packages/core-ai-gateway/tests/cursor-tool-stream.test.ts
@@ -515,6 +515,25 @@ describe("Cursor client tool suspension", () => {
     expect(events.at(-1)?.type).toBe("response.completed");
   });
 
+  it("preserves Cursor thinking deltas as canonical reasoning events", async () => {
+    const { events } = await runSyntheticCursorTurn([
+      { interactionUpdate: { thinkingDelta: { text: "Inspecting the repository." } } },
+      { interactionUpdate: { textDelta: { text: "Done" } } },
+      { interactionUpdate: { turnEnded: {} } },
+    ], request("claude-session-thinking"));
+
+    expect(events).toContainEqual({
+      type: "response.reasoning_summary_text.delta",
+      item_id: expect.stringMatching(/_reasoning$/),
+      output_index: 0,
+      delta: "Inspecting the repository.",
+    });
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "response.output_text.delta",
+      delta: "Done",
+    }));
+  });
+
   it("acknowledges a Cursor planning query and lets the turn continue", async () => {
     const { events, stream } = await runSyntheticCursorTurn([
       {

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -308,7 +308,7 @@ describe("Anthropic request translation", () => {
     })).not.toHaveProperty("reasoning");
   });
 
-  it("drops synthetic thinking blocks when replaying an assistant turn", () => {
+  it("preserves assistant thinking as non-visible replay metadata", () => {
     const request: AnthropicMessagesRequest = {
       ...baseRequest(),
       messages: [{
@@ -322,7 +322,37 @@ describe("Anthropic request translation", () => {
     };
 
     expect(translateAnthropicRequest(request).input).toEqual([
-      { type: "message", role: "assistant", content: "Done" },
+      {
+        type: "message",
+        role: "assistant",
+        content: "Done",
+        reasoning_content: "Inspecting.",
+      },
+    ]);
+  });
+
+  it("attaches assistant thinking to the following tool call for replay", () => {
+    const request: AnthropicMessagesRequest = {
+      ...baseRequest(),
+      messages: [{
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Need the file.", signature: "gateway_reasoning:rs_tool" },
+          { type: "text", text: "I'll inspect it." },
+          { type: "tool_use", id: "call_reasoning", name: "read_file", input: { path: "README.md" } },
+        ],
+      }],
+    };
+
+    expect(translateAnthropicRequest(request).input).toEqual([
+      { type: "message", role: "assistant", content: "I'll inspect it." },
+      {
+        type: "function_call",
+        call_id: "call_reasoning",
+        name: "read_file",
+        arguments: '{"path":"README.md"}',
+        reasoning_content: "Need the file.",
+      },
     ]);
   });
 

--- a/packages/core-ai-gateway/tests/openai-chat-adapter.test.ts
+++ b/packages/core-ai-gateway/tests/openai-chat-adapter.test.ts
@@ -105,6 +105,59 @@ describe("chat completions request translation", () => {
     expect(headers.get("authorization")).toBe("Bearer k");
   });
 
+  it("replays reasoning only for DeepSeek V4 assistant tool turns", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => sse("data: [DONE]\n\n"));
+    await adapter(fetchMock).stream(request({
+      input: [
+        { type: "message", role: "user", content: "go" },
+        {
+          type: "function_call",
+          call_id: "call-a",
+          name: "ToolA",
+          arguments: "{}",
+          reasoning_content: "Need the tool.",
+        },
+        { type: "function_call_output", call_id: "call-a", output: "done" },
+        {
+          type: "message",
+          role: "assistant",
+          content: "finished",
+          reasoning_content: "Interpreting the result.",
+        },
+      ],
+    }), { apiKey: "k" });
+
+    const deepSeekBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as {
+      messages: Array<Record<string, unknown>>;
+    };
+    expect(deepSeekBody.messages).toEqual([
+      { role: "user", content: "go" },
+      {
+        role: "assistant",
+        content: null,
+        reasoning_content: "Need the tool.",
+        tool_calls: [{ id: "call-a", type: "function", function: { name: "ToolA", arguments: "{}" } }],
+      },
+      { role: "tool", tool_call_id: "call-a", content: "done" },
+      { role: "assistant", content: "finished", reasoning_content: "Interpreting the result." },
+    ]);
+
+    fetchMock.mockClear();
+    await adapter(fetchMock).stream(request({
+      model: "kimi-k3",
+      input: [{
+        type: "message",
+        role: "assistant",
+        content: "finished",
+        reasoning_content: "Do not replay globally.",
+      }],
+    }), { apiKey: "k" });
+    const kimiBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as {
+      messages: Array<Record<string, unknown>>;
+    };
+    expect(kimiBody.messages).toEqual([{ role: "assistant", content: "finished" }]);
+  });
+
   it("folds same-turn trailing assistant text into the tool_calls message itself", async () => {
     // Chat 와이어의 정식 표현: 한 assistant 메시지가 content와 tool_calls를 함께 싣는다.
     const fetchMock = vi.fn<typeof fetch>(async () => sse("data: [DONE]\n\n"));
@@ -192,6 +245,33 @@ describe("chat completions request translation", () => {
 });
 
 describe("chat completions stream translation", () => {
+  it("translates reasoning_content into canonical reasoning events", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => sse(
+      chunk({ id: "c-reason", model: "deepseek-v4-flash", choices: [{ index: 0, delta: { reasoning_content: "Inspecting " } }] }),
+      chunk({ id: "c-reason", model: "deepseek-v4-flash", choices: [{ index: 0, delta: { reasoning_content: "the repository." } }] }),
+      chunk({ id: "c-reason", model: "deepseek-v4-flash", choices: [{ index: 0, delta: { content: "Done" } }] }),
+      "data: [DONE]\n\n",
+    ));
+    const response = await adapter(fetchMock).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+    const events = await collect(response.events);
+
+    expect(events.filter((event) => event.type === "response.reasoning_summary_text.delta")).toEqual([
+      {
+        type: "response.reasoning_summary_text.delta",
+        item_id: "chat_message_0_reasoning",
+        output_index: 0,
+        delta: "Inspecting ",
+      },
+      {
+        type: "response.reasoning_summary_text.delta",
+        item_id: "chat_message_0_reasoning",
+        output_index: 0,
+        delta: "the repository.",
+      },
+    ]);
+  });
+
   it("translates text chunks into canonical text events with final usage", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => sse(
       ": keep-alive\n\n",


### PR DESCRIPTION
## Summary
- translate OpenCode Go Chat Completions `reasoning_content` and Cursor `thinkingDelta` into the canonical reasoning stream consumed as Anthropic thinking blocks
- preserve assistant reasoning as non-visible metadata and replay it only for DeepSeek V4 Chat Completions history, including tool-call turns
- leave Kimi and Anthropic-wire OpenCode unchanged because their native Anthropic passthrough already preserves thinking; Responses-wire OpenCode already uses the existing Responses bridge

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` (263 passed)
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `pnpm check:core-boundary`
- [x] added `.changelog.d/pr-526.md` with bilingual grouped syntax
- [x] `node scripts/compile-changelog-fragments.mjs --check`

## Review
- Codex review intentionally skipped per user direction; required repository checks and final context audit remain mandatory.