### PR TITLE
feat(core-ai-gateway): add Cursor GPT-5.6 Sol to the model catalog

### DIFF
--- a/.changelog.d/pr-527.md
+++ b/.changelog.d/pr-527.md
@@ -1,0 +1,5 @@
+### fleet-core
+
+#### Added
+- [core-ai-gateway] Offer Cursor GPT-5.6 Sol through the AI Gateway, with the low through max reasoning ladder Cursor serves, a measured 272000-token context window, and billing against the Cursor API usage pool.
+  ko: AI Gateway에서 Cursor GPT-5.6 Sol을 제공합니다. Cursor가 실제로 서빙하는 low~max 추론 사다리, 실측한 272000 토큰 컨텍스트 윈도, Cursor API 사용량 풀 기준 청구를 함께 반영합니다.

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-08-06T00:00:00Z",
+  "updatedAt": "2026-08-05T00:00:00Z",
   "providers": {
     "codex": {
       "name": "Codex",
@@ -130,7 +130,7 @@
     "cursor": {
       "name": "Cursor",
       "defaultModel": "auto",
-      "source": "Cursor GetUsableModels + Run conversationCheckpointUpdate.token_details.max_tokens (cli-2026.07.08-0c04a8a; standard and Max Mode observed 2026-08-01, gpt-5.6-sol observed 2026-08-06 on cursor-agent 2026.07.23-e383d2b); quotaScope from DashboardService/GetCurrentPeriodUsage autoBucketModels (2026-08-06)",
+      "source": "Cursor GetUsableModels + Run conversationCheckpointUpdate.token_details.max_tokens (cli-2026.07.08-0c04a8a; standard and Max Mode observed 2026-08-01, gpt-5.6-sol observed 2026-08-05 on cursor-agent 2026.07.23-e383d2b); quotaScope from DashboardService/GetCurrentPeriodUsage autoBucketModels (2026-08-05)",
       "models": [
         {
           "modelId": "auto",

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-08-03T00:00:00Z",
+  "updatedAt": "2026-08-06T00:00:00Z",
   "providers": {
     "codex": {
       "name": "Codex",
@@ -130,7 +130,7 @@
     "cursor": {
       "name": "Cursor",
       "defaultModel": "auto",
-      "source": "Cursor GetUsableModels + Run conversationCheckpointUpdate.token_details.max_tokens (cli-2026.07.08-0c04a8a; standard and Max Mode observed 2026-08-01)",
+      "source": "Cursor GetUsableModels + Run conversationCheckpointUpdate.token_details.max_tokens (cli-2026.07.08-0c04a8a; standard and Max Mode observed 2026-08-01, gpt-5.6-sol observed 2026-08-06 on cursor-agent 2026.07.23-e383d2b); quotaScope from DashboardService/GetCurrentPeriodUsage autoBucketModels (2026-08-06)",
       "models": [
         {
           "modelId": "auto",
@@ -182,6 +182,23 @@
               "high"
             ],
             "upstreamModelIdTemplate": "cursor-grok-4.5-{effort}-fast"
+          }
+        },
+        {
+          "modelId": "gpt-5.6-sol",
+          "name": "GPT-5.6-Sol",
+          "quotaScope": "api",
+          "contextWindow": 272000,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "upstreamModelIdTemplate": "gpt-5.6-sol-{effort}"
           }
         },
         {

--- a/packages/core-ai-gateway/tests/cursor-adapter.test.ts
+++ b/packages/core-ai-gateway/tests/cursor-adapter.test.ts
@@ -35,6 +35,7 @@ describe("Cursor request budgets", () => {
     ["claude-opus-5", "xhigh", "claude-opus-5-thinking-xhigh"],
     ["claude-opus-5", "max", "claude-opus-5-thinking-max"],
     ["grok-4.5-fast", "low", "cursor-grok-4.5-low-fast"],
+    ["gpt-5.6-sol", "max", "gpt-5.6-sol-max"],
   ] as const)("writes Cursor model %s with effort %s as %s", (model, effort, expected) => {
     const plan = buildCursorRunPlan(request({
       model,

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -632,7 +632,7 @@ describe("model catalog", () => {
 
   it("contains only the approved latest provider families", () => {
     expect(CODEX_SUBSCRIPTION_MODELS).toHaveLength(6);
-    expect(CURSOR_SUBSCRIPTION_MODELS).toHaveLength(9);
+    expect(CURSOR_SUBSCRIPTION_MODELS).toHaveLength(10);
     expect(KIMI_SUBSCRIPTION_MODELS).toHaveLength(2);
     expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.upstreamId?.startsWith("gpt-5.6-"))).toBe(true);
     expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.contextWindow === 272_000)).toBe(true);
@@ -642,6 +642,7 @@ describe("model catalog", () => {
       "composer-2.5-fast",
       "grok-4.5",
       "grok-4.5-fast",
+      "gpt-5.6-sol",
       "claude-opus-5",
       "claude-fable-5",
       "kimi-k3-max",
@@ -653,6 +654,7 @@ describe("model catalog", () => {
     ]))).toEqual({
       "claude-opus-5": 300_000,
       "claude-fable-5": 300_000,
+      "gpt-5.6-sol": 272_000,
       "composer-2.5": 200_000,
       "composer-2.5-fast": 200_000,
       "grok-4.5": 256_000,

--- a/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
@@ -1201,9 +1201,10 @@ describe("route surface", () => {
     const ids = list.data.map((entry) => entry.id);
     // picker가 버리지 않도록 모든 항목이 claude- alias로 나가야 한다.
     expect(ids.every((id) => id.startsWith("claude"))).toBe(true);
-    expect(list.data).toHaveLength(39);
+    expect(list.data).toHaveLength(40);
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast[1m]");
     expect(ids).toContain("claude-gateway--cursor--auto[1m]");
+    expect(ids).toContain("claude-gateway--cursor--gpt-5.6-sol[1m]");
     expect(ids).toContain("claude-gateway--cursor--kimi-k3");
     expect(ids).toContain("claude-gateway--cursor--kimi-k3-1m[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3[1m]");


### PR DESCRIPTION
## Summary
- Cursor provider 카탈로그에 `gpt-5.6-sol`을 추가했습니다. wire id는 `gpt-5.6-sol-{effort}` 템플릿으로 해석되며, effort 사다리는 Cursor가 실제로 서빙하는 `low`/`medium`/`high`/`xhigh`/`max`입니다(`none`은 게이트웨이 어휘에 없어 제외).
- `contextWindow`는 라이브 Run 프로브로 측정한 standard 모드 값 272000입니다. 같은 프로브의 Max Mode 값 1000000은 별도 `cursorMaxMode` 엔트리를 요구하므로 이번 범위에서 제외했습니다.
- `quotaScope`는 `api`입니다. `DashboardService/GetCurrentPeriodUsage`의 `autoBucketModels`에 어떤 `gpt-5.6-sol` wire id도 없어 Auto 풀이 아님을 확인했습니다.

## 측정 근거 (모든 날짜 UTC)
- `cursor-agent --list-models` (2026.07.23-e383d2b, 2026-08-05): `gpt-5.6-sol-{none,low,medium,high,xhigh,max}` 및 각 `-fast` 변형 확인.
- `probe:cursor-context --model gpt-5.6-sol --mode both --effort high`: wireModel `gpt-5.6-sol-high`, standard `contextWindow=272000`, Max Mode `contextWindow=1000000`.
- 노출 id: `claude-gateway--cursor--gpt-5.6-sol[1m]`, 표시명 `Cursor-GPT-5.6-Sol`.

## 범위 밖(의도적 제외)
- `-fast`(priority) 변형: 기존 api 풀 모델(Opus-5, Fable-5, Kimi-K3)과 동일하게 미등재.
- Max Mode 1M 변형: 별도 청구 모드라 별도 결정이 필요합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` (264 passed) / `typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-admiral test` (137 passed) / `typecheck`
- [x] `pnpm --filter @fleet-plugins/terminal test` (581 passed) / `typecheck`
- [x] `pnpm run check:core-boundary`
- [x] Changelog fragment: `.changelog.d/pr-527.md` (문법/이중 언어/`--check` 검증 완료)