### PR TITLE
fix(fleet-console): restore side bar resize drag in War Room mode

### DIFF
--- a/.changelog.d/pr-528.md
+++ b/.changelog.d/pr-528.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Restore side bar resize in War Room mode. The War Room left column was the only mode without the edge handle, so its width could not be dragged and the handle double-click collapse was unreachable even though the column already shared the other modes' width and collapsed state; the handle is now the same shared control in every mode, and the width it sets carries across a mode switch.
+  ko: War Room 모드의 좌측 사이드바 폭 조절을 복구합니다. War Room 좌측 열만 가장자리 핸들이 없어 폭을 드래그로 바꿀 수 없고 핸들 더블클릭 접기도 닿지 않았습니다. 이미 다른 모드와 폭·접힘 상태를 공유하고 있었는데도 그랬습니다. 이제 모든 모드가 같은 핸들 하나를 쓰며, 여기서 정한 폭은 모드를 전환해도 그대로 이어집니다.

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -28,7 +28,6 @@ import { OperationsSideBarGroupHeader } from "./operations-side-bar-group-header
 import {
   consumeStatusLandings,
   setSideBarCollapsed,
-  setSideBarWidth,
   setTheaterCollapsed,
   getStatusTransitionTick,
   getSideBarStatusSectionCollapsed,
@@ -42,6 +41,7 @@ import {
   type SideBarStatus,
 } from "./operations-side-bar-store.js";
 import { resolveOperationLaunchKind } from "./interaction.js";
+import { SideBarResizeHandle, useSideBarResize } from "./side-bar-resize.js";
 
 interface OperationsSideBarProps {
   readonly theaters: readonly TheaterInfo[];
@@ -333,7 +333,7 @@ export function OperationsSideBar({
   const [activeContextMenu, setActiveContextMenu] = useState<ActiveContextMenu | null>(null);
   const [newMenu, setNewMenu] = useState<NewMenuState | null>(null);
   const [browserOpen, setBrowserOpen] = useState(false);
-  const [sideBarResizing, setSideBarResizing] = useState(false);
+  const { resizing, onPointerDown: onResizePointerDown, onDoubleClick: onResizeDoubleClick } = useSideBarResize();
   const collapsedGroups = useCollapsedGroups();
   const collapsedTheaters = useCollapsedTheaters();
   const {
@@ -707,33 +707,6 @@ export function OperationsSideBar({
     });
   };
 
-  const handleResizeDragStart = useCallback((e: React.PointerEvent) => {
-    e.preventDefault();
-    const startX = e.clientX;
-    const startWidth = sideBar.width;
-    setSideBarResizing(true);
-
-    const onMove = (ev: PointerEvent) => {
-      const dx = ev.clientX - startX;
-      setSideBarWidth(startWidth + dx);
-    };
-
-    const onEnd = () => {
-      setSideBarResizing(false);
-      document.removeEventListener("pointermove", onMove);
-      document.removeEventListener("pointerup", onEnd);
-      document.removeEventListener("pointercancel", onEnd);
-    };
-
-    document.addEventListener("pointermove", onMove);
-    document.addEventListener("pointerup", onEnd);
-    document.addEventListener("pointercancel", onEnd);
-  }, [sideBar.width]);
-
-  const handleResizeDoubleClick = () => {
-    setSideBarCollapsed(!collapsed);
-  };
-
   const openTheaterBrowser = () => {
     setNewMenu(null);
     setActiveContextMenu(null);
@@ -847,7 +820,7 @@ export function OperationsSideBar({
       className={`operations-side-bar ${collapsed ? "is-closed" : "is-expanded"}`}
       ref={rootRef}
       data-sidebar-state={collapsed ? "closed" : "expanded"}
-      data-resizing={sideBarResizing ? "true" : undefined}
+      data-resizing={resizing ? "true" : undefined}
       data-canvas-blocker
       style={{ "--side-bar-width": `${width}px` } as CSSProperties}
       inert={collapsed}
@@ -1106,12 +1079,7 @@ export function OperationsSideBar({
         </li>
       </ol>
 
-      <div
-        className="operations-side-bar-resize-handle"
-        onPointerDown={handleResizeDragStart}
-        onDoubleClick={handleResizeDoubleClick}
-        aria-hidden="true"
-      />
+      <SideBarResizeHandle onPointerDown={onResizePointerDown} onDoubleClick={onResizeDoubleClick} />
 
       {newMenu ? createPortal(
         <CanvasContextMenu

--- a/runtime/fleet-console/core/client/src/sidebar/side-bar-resize.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/side-bar-resize.tsx
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+
+import { setSideBarCollapsed, setSideBarWidth, useSideBarState } from "./operations-side-bar-store.js";
+
+// Map과 War Room 사이드바는 같은 좌측 열 상태를 공유한다 — 폭과 접힘을 바꾸는
+// 조작 표면도 한 구현을 써야 모드 전환 사이에서 같은 계약을 지킨다.
+export function useSideBarResize(): {
+  readonly resizing: boolean;
+  readonly onPointerDown: (event: ReactPointerEvent) => void;
+  readonly onDoubleClick: () => void;
+} {
+  const sideBar = useSideBarState();
+  const [resizing, setResizing] = useState(false);
+  const removeListenersRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => () => removeListenersRef.current?.(), []);
+
+  const onPointerDown = useCallback((event: ReactPointerEvent) => {
+    event.preventDefault();
+    const startX = event.clientX;
+    const startWidth = sideBar.width;
+    setResizing(true);
+
+    const onMove = (moveEvent: PointerEvent) => {
+      setSideBarWidth(startWidth + (moveEvent.clientX - startX));
+    };
+
+    const removeListeners = () => {
+      document.removeEventListener("pointermove", onMove);
+      document.removeEventListener("pointerup", onEnd);
+      document.removeEventListener("pointercancel", onEnd);
+      if (removeListenersRef.current === removeListeners) removeListenersRef.current = null;
+    };
+
+    const onEnd = () => {
+      setResizing(false);
+      removeListeners();
+    };
+
+    removeListenersRef.current?.();
+    removeListenersRef.current = removeListeners;
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", onEnd);
+    document.addEventListener("pointercancel", onEnd);
+  }, [sideBar.width]);
+
+  const onDoubleClick = useCallback(() => {
+    setSideBarCollapsed(!sideBar.collapsed);
+  }, [sideBar.collapsed]);
+
+  return { resizing, onPointerDown, onDoubleClick };
+}
+
+export function SideBarResizeHandle({
+  onPointerDown,
+  onDoubleClick,
+}: {
+  readonly onPointerDown: (event: ReactPointerEvent) => void;
+  readonly onDoubleClick: () => void;
+}) {
+  return (
+    <div
+      className="operations-side-bar-resize-handle"
+      onPointerDown={onPointerDown}
+      onDoubleClick={onDoubleClick}
+      aria-hidden="true"
+    />
+  );
+}

--- a/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
@@ -14,6 +14,7 @@ import { getTriagePick, getTriageSnapshot, resolveTriageQueue, subscribeTriage, 
 import { OperationsSideBarChip, type SideBarEntry } from "./operations-side-bar-chip.js";
 import { buildTheaterEntries, groupOperationsByStatus, StatusSectionSlot, type StatusSection } from "./operations-side-bar.js";
 import { useSideBarState } from "./operations-side-bar-store.js";
+import { SideBarResizeHandle, useSideBarResize } from "./side-bar-resize.js";
 
 // 선별 사이드바의 상태 섹션은 Map 사이드바 STATUS 축과 같은 collapse 저장소를 쓰되,
 // Theater 키가 아니라 전역 선별 고유 키 하나로 접힘을 기억한다.
@@ -74,6 +75,7 @@ export function TriageSideBar({
   // 접힘/폭은 Map 사이드바와 같은 좌측 열 상태를 공유한다 — 커맨드 밴드의 사이드바 토글이
   // 선별 중에도 계속 동작해야 하고, 모드 전환이 사용자의 접힘 선택을 잃지 않아야 한다.
   const sideBar = useSideBarState();
+  const { resizing, onPointerDown: onResizePointerDown, onDoubleClick: onResizeDoubleClick } = useSideBarResize();
   const [armedCloseId, setArmedCloseId] = useState<string | null>(null);
   const queue = resolveTriageQueue(operations, operationStatus);
   const stagedOperationId = getTriagePick() ?? queue[0]?.operation.id ?? null;
@@ -133,6 +135,7 @@ export function TriageSideBar({
       className={`operations-side-bar triage-side-bar ${sideBar.collapsed ? "is-closed" : "is-expanded"}`}
       data-canvas-blocker
       data-sidebar-state={sideBar.collapsed ? "closed" : "expanded"}
+      data-resizing={resizing ? "true" : undefined}
       style={{ "--side-bar-width": `${sideBar.width}px` } as CSSProperties}
       inert={sideBar.collapsed}
       aria-label={t("triageSidebar.aria")}
@@ -164,6 +167,7 @@ export function TriageSideBar({
           </ol>
         </footer>
       ) : null}
+      <SideBarResizeHandle onPointerDown={onResizePointerDown} onDoubleClick={onResizeDoubleClick} />
     </aside>
   );
 }

--- a/runtime/fleet-console/tests/side-bar-resize.test.tsx
+++ b/runtime/fleet-console/tests/side-bar-resize.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { loadForTheater } from "../core/client/src/canvas/canvas-store.js";
+import { OperationsSideBar } from "../core/client/src/sidebar/operations-side-bar.js";
+import {
+  getSideBarState,
+  MIN_EXPANDED_PX,
+  setSideBarCollapsed,
+  setSideBarWidth,
+} from "../core/client/src/sidebar/operations-side-bar-store.js";
+import { TriageSideBar } from "../core/client/src/sidebar/triage-side-bar.js";
+import type { TheaterInfo } from "../core/client/src/types.js";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  window.localStorage.clear();
+  setSideBarWidth(400);
+  setSideBarCollapsed(false);
+  loadForTheater(THEATER.id);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  loadForTheater(null);
+  setSideBarWidth(MIN_EXPANDED_PX);
+  setSideBarCollapsed(false);
+  window.localStorage.clear();
+});
+
+describe("shared side bar resize", () => {
+  it("renders the shared resize handle in both side bars", () => {
+    renderTriageSideBar();
+    expect(required(".operations-side-bar-resize-handle")).not.toBeNull();
+
+    act(() => root?.unmount());
+    container?.replaceChildren();
+    root = createRoot(container!);
+    act(() => root?.render(operationsSideBarElement()));
+
+    expect(required(".operations-side-bar-resize-handle")).not.toBeNull();
+  });
+
+  it("resizes the War Room side bar and marks only the active drag", () => {
+    renderTriageSideBar();
+    const handle = required<HTMLElement>(".operations-side-bar-resize-handle");
+    const aside = required<HTMLElement>(".triage-side-bar");
+
+    act(() => {
+      handle.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, clientX: 100 }));
+    });
+    expect(aside.getAttribute("data-resizing")).toBe("true");
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent("pointermove", { bubbles: true, clientX: 160 }));
+    });
+    expect(getSideBarState().width).toBe(460);
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent("pointerup", { bubbles: true }));
+    });
+    expect(aside.getAttribute("data-resizing")).toBeNull();
+  });
+
+  it("toggles the shared collapsed state from the War Room handle", () => {
+    renderTriageSideBar();
+    const handle = required<HTMLElement>(".operations-side-bar-resize-handle");
+
+    act(() => {
+      handle.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    });
+
+    expect(getSideBarState().collapsed).toBe(true);
+    expect(required<HTMLElement>(".triage-side-bar").classList.contains("is-closed")).toBe(true);
+  });
+});
+
+function renderTriageSideBar(): void {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  const onPick = vi.fn();
+  const onClose = vi.fn();
+  const onRename = vi.fn();
+  act(() => root?.render(createElement(TriageSideBar, {
+    theaters: [{ id: THEATER.id, label: THEATER.label }],
+    operations: [],
+    operationStatus: {},
+    operationNotifications: {},
+    catalog: [],
+    plugins: [],
+    renderKindIcon: () => null,
+    onPick,
+    onClose,
+    onRename,
+  })));
+}
+
+function operationsSideBarElement() {
+  return createElement(MemoryRouter, null, createElement(OperationsSideBar, {
+    theaters: [THEATER],
+    activeTheaterId: THEATER.id,
+    operations: [],
+    groups: [],
+    minimized: [],
+    activeOperationId: null,
+    operationNotifications: {},
+    catalog: [],
+    canLaunch: true,
+    addingTheater: false,
+    theaterError: null,
+    renderKindIcon: () => null,
+    onLaunchKind: () => {},
+    onClose: () => {},
+    onMinimize: () => {},
+    onFocus: () => {},
+    onSetAccent: () => {},
+    onRename: () => {},
+    onSetGroupId: () => {},
+    onCreateGroup: () => {},
+    onSetGroupColor: () => {},
+    onRenameGroup: () => {},
+    onReorderGroups: () => {},
+    onReorderTheaters: () => {},
+    onUngroupAll: () => {},
+    onSelectTheater: () => {},
+    onAddTheater: () => {},
+    onCancelAddTheater: () => {},
+    onForgetTheater: () => {},
+  }));
+}
+
+function required<T extends Element = Element>(selector: string): T {
+  const element = container?.querySelector<T>(selector);
+  if (!element) throw new Error(`Missing ${selector}`);
+  return element;
+}
+
+const THEATER: TheaterInfo = {
+  id: "theater-a",
+  label: "Alpha",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  lastOpenedAt: "2026-01-01T00:00:00.000Z",
+  hasWiki: false,
+  activeAdmiralCount: 0,
+};


### PR DESCRIPTION
## Summary

- War Room 모드의 좌측 열은 `TriageSideBar`가 렌더되는데, 이 컴포넌트가 `OperationsSideBar`만 갖고 있던 리사이즈 핸들을 렌더하지 않아 사이드바 폭 드래그와 핸들 더블클릭 접기가 아예 불가능했습니다. `TriageSideBar`는 이미 같은 좌측 열 상태(`useSideBarState`)를 구독하고 `--side-bar-width`를 주입하고 있었으므로, 빠져 있던 것은 조작 표면뿐이었습니다.
- 드래그 로직과 핸들 마크업을 `useSideBarResize` 훅 + `SideBarResizeHandle` 컴포넌트로 추출해 두 사이드바가 한 구현을 공유하도록 바꾸고, War Room 사이드바에도 핸들과 드래그 중 전환을 끄는 `data-resizing` 속성을 함께 연결했습니다. 공용 훅은 언마운트 시 document 포인터 리스너를 해제하므로, 드래그 도중 모드를 전환해도 리스너가 남지 않습니다.
- CSS는 수정하지 않았습니다. `.triage-side-bar`에는 베어 셀렉터 규칙이 없어 `.operations-side-bar`의 `position: relative` / `overflow: hidden` / `width: var(--side-bar-width)`를 그대로 상속하고, `.is-closed`의 `width: 0` + `visibility: hidden`이 접힘 상태에서 핸들을 자동으로 무력화합니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 두 TypeScript 프로젝트 0 오류
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과
- [x] `vitest run tests/side-bar-resize.test.tsx tests/triage-store.test.ts tests/operations-side-bar-status-axis.test.tsx tests/operations-side-bar-store.test.ts tests/instrument-design-contract.test.ts tests/feature-tour.test.ts` — 6 files / 157 tests 통과
- [x] 신규 회귀 테스트 `tests/side-bar-resize.test.tsx` — 두 사이드바의 핸들 렌더, War Room 드래그 폭 변경, `data-resizing` 수명주기, 더블클릭 접힘 토글
- [x] 격리 콘솔 브라우저 실측 — War Room에서 핸들 드래그로 340px → 420px 변경 확인, `elementFromPoint`가 핸들을 반환(덱에 가리지 않음), 상단 밴드 캡 `--command-band-left-width`와 중앙 무대가 동기 추종, 접힘 시 핸들 `visibility: hidden` + 히트테스트 비활성, Cruise ↔ War Room 왕복에서 폭 420px 보존, 페이지 오류 0건
- [x] Changelog: `.changelog.d/pr-528.md` 추가 — 그룹형 `### fleet-console` / `#### Fixed` 문법, 영문·한글 이중 요약 인접, `node scripts/compile-changelog-fragments.mjs --check` 통과