### PR TITLE
fix(fleet-console): reach canvas controls from every War Room surface

### DIFF
--- a/.changelog.d/pr-529.md
+++ b/.changelog.d/pr-529.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Reach the canvas control menu from every War Room surface. Right-clicking bare space in the left sidebar, on the deck floor, between Theater bands, or on the queue rail background now opens the same launch menu the map zones already offered, and it names the Theater it will launch into, so the entry point no longer shrinks to a one-line band header at card density and vanish everywhere but the fleet map. Owned surfaces keep their menus, the dormant shelf still opens nothing, and collapsing the sidebar dismisses the menu it opened.
+  ko: War Room의 모든 표면에서 캔버스 제어 메뉴에 닿습니다. 좌측 사이드바 빈 영역, 덱 판 바닥, Theater 밴드 사이 여백, 큐 레일 배경을 우클릭하면 지도 구역이 이미 제공하던 실행 메뉴가 같은 방식으로 열리고 어느 Theater로 실행되는지 이름을 밝히므로, 카드 밀도에서 진입점이 밴드 헤더 한 줄로 줄었다가 작전 지도 말고는 어디서도 열리지 않던 문제가 사라집니다. 소유 표면의 메뉴는 그대로이고 휴면 선반은 여전히 아무것도 열지 않으며, 사이드바를 접으면 그 열이 연 메뉴도 함께 걷힙니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -250,10 +250,21 @@ export function OperationsCanvas({
     if (target?.closest("[data-canvas-operation]")) return;
     // War Room에서는 캔버스 전체가 이 모드의 것이다. 자기 메뉴를 가진 표면(카드·점·밴드·구역·레일 행)은
     // 이미 stopPropagation으로 여기 닿지 않으므로, 여기 오는 것은 전부 "주인 없는 자리"다.
-    // 밴드 사이 여백이나 구역 밖 판 바닥이 브라우저 메뉴를 여는 것은 아무것도 열지 않는다는 계약과 어긋난다.
+    // 그 자리도 캔버스 제어를 연다 — Theater를 소유한 표면(밴드 헤더·지도 구역)은 밀도 단계에 따라
+    // 얇은 띠로 줄거나 통째로 사라지므로, 소유 표면에만 메뉴를 두면 실행 진입점이 밀도에 따라 없어진다.
+    // 소유자가 없는 자리의 실행 대상은 활성 Theater이고, 어디로 실행되는지는 메뉴 헤더의 이름이 말한다.
     if (triageActive) {
       event.preventDefault();
-      setContextMenu(null);
+      const activeTheaterId = state.activeTheaterId;
+      if (!activeTheaterId) {
+        setContextMenu(null);
+        return;
+      }
+      openTriageTheaterLaunchMenu(
+        activeTheaterId,
+        state.theaters.find((theater) => theater.id === activeTheaterId)?.label ?? activeTheaterId,
+        { x: event.clientX, y: event.clientY },
+      );
       return;
     }
     if (target?.closest("[data-canvas-blocker]")) return;

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -530,6 +530,9 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
           catalog={catalog}
           plugins={registry.plugins}
           renderKindIcon={renderKindIcon}
+          canLaunch={canLaunch}
+          activeTheaterLabel={state.theaters.find((theater) => theater.id === state.activeTheaterId)?.label}
+          onLaunchKind={handleSideBarLaunchKind}
           onPick={pickTriageOperation}
           onClose={handleClose}
           onRename={handleRename}

--- a/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
@@ -1,9 +1,11 @@
-import { useState, useSyncExternalStore, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useState, useSyncExternalStore, type CSSProperties, type MouseEvent, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 
 import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console/sdk/operations";
 import type { FleetClientPlugin, OperationActivity } from "@fleet-console/sdk/plugin";
 
 import { useT } from "../i18n/index.js";
+import { CanvasContextMenu } from "../canvas/canvas-context-menu.js";
 import { resumeOperationInPlace } from "../operation-resume.js";
 import { getIdleArrivalIds, subscribeIdleArrival } from "../operation-idle-arrival.js";
 import type { OperationNode, OperationNotification } from "../types.js";
@@ -48,6 +50,10 @@ interface TriageSideBarProps {
   readonly catalog: readonly OperationCatalogPlugin[];
   readonly plugins: readonly FleetClientPlugin[];
   readonly renderKindIcon: (pluginId: string, kind: OperationLaunchKind) => ReactNode;
+  readonly canLaunch: boolean;
+  /** 소유자 없는 자리의 실행 대상 — 사이드바 빈 영역은 활성 Theater로 실행한다. */
+  readonly activeTheaterLabel?: string;
+  readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind) => void;
   readonly onPick: (operationId: string) => void;
   readonly onClose: (operationId: string) => void;
   readonly onRename: (operationId: string, title: string) => void;
@@ -62,6 +68,9 @@ export function TriageSideBar({
   catalog,
   plugins,
   renderKindIcon,
+  canLaunch,
+  activeTheaterLabel,
+  onLaunchKind,
   onPick,
   onClose,
   onRename,
@@ -77,6 +86,29 @@ export function TriageSideBar({
   const sideBar = useSideBarState();
   const { resizing, onPointerDown: onResizePointerDown, onDoubleClick: onResizeDoubleClick } = useSideBarResize();
   const [armedCloseId, setArmedCloseId] = useState<string | null>(null);
+  const [launchMenu, setLaunchMenu] = useState<{
+    readonly anchor: { readonly x: number; readonly y: number };
+    readonly viewportBounds: { readonly width: number; readonly height: number };
+  } | null>(null);
+  // 메뉴는 포털(document.body)이라 <aside>의 inert가 닿지 않는다 — 좌측 열을 접으면 그 열이 연
+  // 메뉴도 함께 걷어야 한다. 아니면 사라진 사이드바의 메뉴가 화면에 남아 실행까지 받는다.
+  useEffect(() => {
+    if (sideBar.collapsed) setLaunchMenu(null);
+  }, [sideBar.collapsed]);
+  // 사이드바 빈 영역 우클릭 = 캔버스의 주인 없는 자리와 같은 '캔버스 제어'를 커서 자리에 연다.
+  // 칩과 휴면 선반은 자기 우클릭에서 preventDefault()를 부르므로(버블로 도달 시 defaultPrevented=true)
+  // 그쪽 계약은 그대로 유지되고 여기서는 무시된다.
+  const openLaunchMenuAtCursor = (event: MouseEvent<HTMLElement>) => {
+    if (event.defaultPrevented) return;
+    event.preventDefault();
+    // 캔버스가 소유한 메뉴는 이 <aside> 안에 없어 포털의 mousedown 외부-클릭 닫기가 못 잡는다 —
+    // 포털이 구독하는 닫기 신호를 함께 보낸다.
+    window.dispatchEvent(new Event("canvas-context-menu-close"));
+    setLaunchMenu({
+      anchor: { x: event.clientX, y: event.clientY },
+      viewportBounds: { width: window.innerWidth, height: window.innerHeight },
+    });
+  };
   const queue = resolveTriageQueue(operations, operationStatus);
   const stagedOperationId = getTriagePick() ?? queue[0]?.operation.id ?? null;
   const theaterLabelById = new Map(theaters.map((theater) => [theater.id, theater.label]));
@@ -139,6 +171,7 @@ export function TriageSideBar({
       style={{ "--side-bar-width": `${sideBar.width}px` } as CSSProperties}
       inert={sideBar.collapsed}
       aria-label={t("triageSidebar.aria")}
+      onContextMenu={openLaunchMenuAtCursor}
     >
       {/* 상태 섹션은 비어 있어도 항상 선다 — 대기·실행 중·백그라운드·유휴는 War Room이 읽는
           축 자체라, 건수가 0이라고 축이 사라지면 좌측 열의 읽는 법이 상황에 따라 달라진다.
@@ -168,6 +201,22 @@ export function TriageSideBar({
         </footer>
       ) : null}
       <SideBarResizeHandle onPointerDown={onResizePointerDown} onDoubleClick={onResizeDoubleClick} />
+
+      {launchMenu ? createPortal(
+        <CanvasContextMenu
+          key={`${launchMenu.anchor.x}:${launchMenu.anchor.y}`}
+          anchor={launchMenu.anchor}
+          viewportBounds={launchMenu.viewportBounds}
+          placement="cursor"
+          catalog={catalog}
+          canLaunch={canLaunch}
+          renderKindIcon={renderKindIcon}
+          onLaunchKind={(pluginId, kind) => { setLaunchMenu(null); onLaunchKind(pluginId, kind); }}
+          onClose={() => setLaunchMenu(null)}
+          theaterLabel={activeTheaterLabel}
+        />,
+        document.body,
+      ) : null}
     </aside>
   );
 }

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -1302,6 +1302,8 @@ describe("triage store", () => {
         catalog: [],
         plugins: [],
         renderKindIcon: () => null,
+        canLaunch: true,
+        onLaunchKind: () => {},
         onPick: pickTriageOperation,
         onClose: () => {},
         onRename: () => {},
@@ -1355,6 +1357,8 @@ describe("triage store", () => {
       catalog: [],
       plugins: [{ id: "terminal", resumeOperation }],
       renderKindIcon: () => null,
+      canLaunch: true,
+      onLaunchKind: () => {},
       onPick,
       onClose: () => {},
       onRename: () => {},
@@ -1380,6 +1384,89 @@ describe("triage store", () => {
     expect(resumeOperation).toHaveBeenCalledWith("dormant");
     expect(onPick).not.toHaveBeenCalled();
     expect(isTriageActive()).toBe(true);
+  });
+
+  it("opens canvas controls from bare sidebar space while chips and the dormant shelf keep their own contract", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    triagePlateRoot = createRoot(container);
+    const operations = [operation("first", 1), operation("resting", 2)];
+    const status: Readonly<Record<string, OperationActivity>> = { first: "awaiting", resting: "dormant" };
+    const onOpenOperationMenu = vi.fn();
+    const onLaunchKind = vi.fn();
+    recordTriageActivity(operations, status, 1_000);
+    setTriageActive(true);
+
+    act(() => triagePlateRoot?.render(createElement(TriageSideBar, {
+      theaters: THEATERS,
+      operations,
+      operationStatus: status,
+      operationNotifications: {},
+      catalog: [{ id: "terminal", title: "Terminal", kinds: [{ id: "shell", type: "shell", title: "Shell" }] }],
+      plugins: [],
+      renderKindIcon: () => null,
+      canLaunch: true,
+      activeTheaterLabel: "Alpha",
+      onLaunchKind,
+      onPick: () => {},
+      onClose: () => {},
+      onRename: () => {},
+      onOpenOperationMenu,
+    })));
+
+    // 칩도 선반도 아닌 빈 자리는 캔버스의 주인 없는 자리와 같은 '캔버스 제어'를 연다 —
+    // War Room에서 좌측 열이 실행 진입점을 갖지 못하던 구멍을 메운다.
+    const aside = container.querySelector<HTMLElement>(".triage-side-bar")!;
+    // 이 표면은 열면서 공용 닫기 신호를 함께 보낸다 — 캔버스가 이미 연 메뉴는 이 <aside> 밖이라
+    // 포털의 외부-클릭 닫기가 잡지 못한다. 구독만 있고 발신이 없으면 두 메뉴가 동시에 뜬다.
+    const closeSignals: Event[] = [];
+    const recordClose = (event: Event) => closeSignals.push(event);
+    window.addEventListener("canvas-context-menu-close", recordClose);
+    const bareMenu = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 24, clientY: 48 });
+    act(() => aside.dispatchEvent(bareMenu));
+    window.removeEventListener("canvas-context-menu-close", recordClose);
+    expect(closeSignals).toHaveLength(1);
+    expect(bareMenu.defaultPrevented).toBe(true);
+    const launchMenu = document.querySelector(".canvas-context-menu");
+    expect(launchMenu).not.toBeNull();
+    // 소유자가 없는 자리이므로 어느 Theater로 실행되는지는 헤더가 밝힌다.
+    expect(launchMenu?.querySelector(".canvas-context-menu-head-text")?.textContent).toContain("Alpha");
+    const shellItem = launchMenu?.querySelector<HTMLButtonElement>('[data-operation-launch-kind="shell"]');
+    expect(shellItem).not.toBeNull();
+    expect(shellItem?.disabled).toBe(false);
+    expect(onOpenOperationMenu).not.toHaveBeenCalled();
+
+    // 항목은 실제로 실행을 배선한다 — 열리기만 하는 메뉴는 진입점이 아니다.
+    act(() => shellItem?.click());
+    expect(onLaunchKind).toHaveBeenCalledWith("terminal", expect.objectContaining({ id: "shell" }));
+    expect(document.querySelector(".canvas-context-menu")).toBeNull();
+
+    // 캔버스가 Map 클릭에서 보내는 같은 신호로도 닫힌다(pan이 mousedown 합성을 끊어 외부-클릭이 못 잡는다).
+    act(() => aside.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 24, clientY: 48 })));
+    expect(document.querySelector(".canvas-context-menu")).not.toBeNull();
+    act(() => { window.dispatchEvent(new Event("canvas-context-menu-close")); });
+    expect(document.querySelector(".canvas-context-menu")).toBeNull();
+
+    // 좌측 열을 접으면 그 열이 연 메뉴도 걷힌다 — 포털이라 <aside>의 inert가 닿지 않는다.
+    act(() => aside.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 24, clientY: 48 })));
+    expect(document.querySelector(".canvas-context-menu")).not.toBeNull();
+    act(() => setSideBarCollapsed(true));
+    expect(document.querySelector(".canvas-context-menu")).toBeNull();
+    act(() => setSideBarCollapsed(false));
+
+    // 칩 우클릭은 Operation 메뉴 계약 그대로다 — 빈 자리 핸들러가 가로채지 않는다.
+    const chip = container.querySelector<HTMLElement>(".triage-side-bar-sections .side-bar-chip")!;
+    const chipMenu = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 30, clientY: 60 });
+    act(() => chip.dispatchEvent(chipMenu));
+    expect(onOpenOperationMenu).toHaveBeenCalled();
+    expect(document.querySelector(".canvas-context-menu")).toBeNull();
+
+    // 휴면 선반은 아무것도 열지 않는 표면 계약을 유지한다.
+    const shelf = container.querySelector<HTMLElement>(".triage-side-bar-dormant-shelf")!;
+    const shelfMenu = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 30, clientY: 90 });
+    act(() => shelf.dispatchEvent(shelfMenu));
+    expect(shelfMenu.defaultPrevented).toBe(true);
+    expect(document.querySelector(".canvas-context-menu")).toBeNull();
   });
 
   it("renders live previews only for active-Theater cards and the detail fallback for foreign ones", () => {

--- a/runtime/fleet-console/tests/warroom-canvas-context-menu.test.tsx
+++ b/runtime/fleet-console/tests/warroom-canvas-context-menu.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../core/client/src/plugin-registry.js", () => ({
+  usePluginRegistry: () => ({
+    plugins: [],
+    operationKinds: [{
+      pluginId: "test-plugin",
+      type: "shell",
+      title: "Test",
+      render: () => null,
+    }],
+    settingsSections: [],
+    notificationKinds: [],
+    railPanels: [],
+  }),
+}));
+
+import { OperationsCanvas } from "../core/client/src/canvas/canvas.js";
+import { loadForTheater, setState as setCanvasState } from "../core/client/src/canvas/canvas-store.js";
+import { isTriageDeckMapMode, resetTriageDeckZoomForTests, resetTriageTheater, setTriageActive, setTriageDeckZoom } from "../core/client/src/canvas/triage-store.js";
+import type { ConsoleState, OperationNode } from "../core/client/src/types.js";
+
+const THEATER_A = "theater-a";
+const OPERATION: OperationNode = {
+  id: "operation-a",
+  theaterId: THEATER_A,
+  type: "shell",
+  pluginId: "test-plugin",
+  title: "Operation A",
+  payload: {},
+  geometry: { x: 0, y: 0, width: 320, height: 200, zIndex: 1 },
+  ts: { createdAt: 0, updatedAt: 0 },
+};
+const CATALOG = [{ id: "test-plugin", title: "Test", kinds: [{ id: "shell", type: "shell", title: "Shell" }] }];
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  loadForTheater(THEATER_A);
+  setCanvasState({
+    viewport: { x: 0, y: 0, zoom: 1 },
+    operations: { [OPERATION.id]: OPERATION.geometry! },
+  });
+  setTriageActive(true);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  resetTriageDeckZoomForTests();
+  setTriageActive(false);
+  resetTriageTheater(THEATER_A);
+  loadForTheater(null);
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("War Room canvas controls reach", () => {
+  it("opens canvas controls on unowned canvas space at every deck density", () => {
+    renderCanvas();
+    const canvas = container!.querySelector<HTMLElement>("main.operations-canvas")!;
+    // 밀도 칩이 순환시키는 실제 프리셋 전부. 0.4만 지도로 넘어가고 1.0/1.6은 카드다 —
+    // 카드 밀도에서 Theater를 소유한 표면은 밴드 헤더 한 줄뿐이라, 판 바닥이 아무것도 열지 않으면
+    // 실행 진입점이 밀도에 따라 사라진다.
+    expect([1.0, 1.6].map(isTriageDeckMapMode)).toEqual([false, false]);
+    expect(isTriageDeckMapMode(0.4)).toBe(true);
+
+    for (const zoom of [1.0, 1.6, 0.4]) {
+      act(() => setTriageDeckZoom(zoom));
+      const menu = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 120, clientY: 240 });
+      act(() => canvas.dispatchEvent(menu));
+      expect(menu.defaultPrevented).toBe(true);
+      const opened = container!.querySelector(".canvas-context-menu");
+      expect(opened, `deck zoom ${zoom}`).not.toBeNull();
+      // 소유자가 없는 자리의 실행 대상은 활성 Theater이며, 헤더가 그것을 밝힌다.
+      expect(opened?.querySelector(".canvas-context-menu-head-text")?.textContent).toContain("Alpha");
+      expect(opened?.querySelector('[data-operation-launch-kind="shell"]')).not.toBeNull();
+      act(() => { window.dispatchEvent(new Event("canvas-context-menu-close")); });
+      expect(container!.querySelector(".canvas-context-menu")).toBeNull();
+    }
+  });
+
+  it("opens nothing when no Theater owns the launch", () => {
+    // 실행 대상이 없으면 메뉴를 띄워도 아무것도 실행할 수 없다 — 브라우저 메뉴만 계속 막는다.
+    act(() => root!.render(createElement(OperationsCanvas, {
+      state: { ...STATE, theaters: [], operations: [], activeTheaterId: null, activeOperationId: null },
+      catalog: CATALOG,
+      canLaunch: false,
+      renderKindIcon: () => null,
+      onLaunchKind: () => {},
+      onLaunchAtGeometry: () => {},
+      onClose: () => {},
+      onFocus: () => {},
+      onRename: () => {},
+      onSetAccent: () => {},
+    })));
+
+    const canvas = container!.querySelector<HTMLElement>("main.operations-canvas")!;
+    const menu = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 120, clientY: 240 });
+    act(() => canvas.dispatchEvent(menu));
+    expect(menu.defaultPrevented).toBe(true);
+    expect(container!.querySelector(".canvas-context-menu")).toBeNull();
+  });
+
+  it("keeps the browser menu inside Operation panels", () => {
+    renderCanvas();
+
+    const panel = container!.querySelector<HTMLElement>("[data-canvas-operation]");
+    expect(panel).not.toBeNull();
+    const panelMenu = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 20, clientY: 20 });
+    act(() => panel!.dispatchEvent(panelMenu));
+    // 터미널 안은 복사·붙여넣기가 있는 자리다 — 우리 메뉴가 그것을 빼앗지 않는다.
+    expect(panelMenu.defaultPrevented).toBe(false);
+    expect(container!.querySelector(".canvas-context-menu")).toBeNull();
+  });
+});
+
+function renderCanvas() {
+  act(() => root!.render(createElement(OperationsCanvas, {
+    state: STATE,
+    catalog: CATALOG,
+    canLaunch: true,
+    renderKindIcon: () => null,
+    onLaunchKind: () => {},
+    onLaunchAtGeometry: () => {},
+    onClose: () => {},
+    onFocus: () => {},
+    onRename: () => {},
+    onSetAccent: () => {},
+  })));
+}
+
+const STATE: ConsoleState = {
+  connection: "connecting",
+  connectionLostAt: null,
+  channel: "unknown",
+  activeTheme: "maritime",
+  version: "test",
+  updateAvailable: false,
+  latestVersion: null,
+  portMode: "dynamic",
+  requestedPort: null,
+  effectivePort: 0,
+  portHonored: true,
+  theaters: [{ id: THEATER_A, label: "Alpha" }],
+  operations: [OPERATION],
+  operationsHydrated: true,
+  groups: [],
+  activeTheaterId: THEATER_A,
+  activeOperationId: OPERATION.id,
+  activeOperationAcknowledged: true,
+  operationStatus: { [OPERATION.id]: "awaiting" },
+  addingTheater: false,
+  theaterError: null,
+  operationsViewActive: true,
+  operationSearchOpen: false,
+  operationSearchSeed: null,
+  whatsNewOpen: false,
+  releaseNotes: [],
+  releaseNotesLoading: false,
+  releaseNotesError: null,
+  releaseNotesSourceRef: null,
+  releaseNotesFetchedAt: null,
+  releaseNotesStale: false,
+  automaticWhatsNewVersion: null,
+  selectedReleaseNoteKey: null,
+  onboardingOpen: false,
+  bootstrapped: true,
+  pendingOperationFocus: null,
+  keyboardFocusRequest: null,
+  pendingSideBarAddTheater: false,
+  pendingSideBarTheaterLaunch: null,
+  launchMenuRequest: null,
+  keyboardShortcutsOpen: false,
+  operationNotifications: {},
+  notificationPreferences: { globalMute: false, dnd: false, mutedTheaterIds: {} },
+  codexReader: null,
+  codexReaderExpanded: false,
+};


### PR DESCRIPTION
## Summary

- War Room에서 '캔버스 제어' 우클릭 메뉴가 사실상 최소 밀도(작전 지도, 줌 0.4)에서만 열렸습니다. 카드 밀도에서 Theater를 소유한 표면은 밴드 헤더 한 줄로 줄고, 좌측 사이드바·판 바닥·레일 배경은 우클릭을 먹고 아무것도 열지 않았습니다.
- 이제 주인 없는 캔버스 자리는 활성 Theater의 캔버스 제어를 열고, War Room 좌측 사이드바도 Cruise 사이드바가 이미 갖고 있던 빈 영역 메뉴를 갖습니다. 어느 Theater로 실행되는지는 메뉴 헤더가 밝힙니다.
- 소유 표면의 계약은 그대로입니다: 카드·지도 점은 Operation 메뉴, 밴드·구역은 그 Theater, 휴면 선반은 아무것도 열지 않음, Operation 패널 안은 브라우저 메뉴. 포털은 `<aside>` 밖이라 사이드바를 접으면 그 열이 연 메뉴도 함께 걷습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `vitest run` 전체 — 실패 39건은 선존(동일 조건 baseline과 파일별 분포까지 일치, 회귀 없음)
- [x] 신규/보강 계약 테스트: `tests/warroom-canvas-context-menu.test.tsx`, `tests/triage-store.test.ts` — 구현 롤백 시 실제로 실패함을 확인
- [x] 헤디드 실측(격리 콘솔, Theater 2 / Operation 9): 카드 밀도에서 사이드바 빈 영역·판 바닥·밴드 사이 여백·밴드 헤더·레일 배경 모두 개방, 지도 밀도에서 사이드바·판 바닥·구역 모두 개방
- [x] 회귀 실측: 덱 카드·지도 점·사이드바 칩은 Operation 메뉴만, Cruise 모드 우클릭 동작 불변, #528 드래그 리사이즈 정상(280→363px)

## Changelog

- [x] `.changelog.d/pr-529.md` 추가 — `### fleet-console` / `#### Fixed` 그룹, 영문/`ko:` 인접
- [x] `node scripts/compile-changelog-fragments.mjs --check` 통과 (3 entries validated)