### PR TITLE
fix(fleet-console): keep the panel toggles on every command band route

### DIFF
--- a/.changelog.d/pr-532.md
+++ b/.changelog.d/pr-532.md
@@ -1,0 +1,6 @@
+### fleet-console
+#### Fixed
+- [fleet-console] Keep the sidebar and Activity Rail toggles in the command band outside the Operations screen, where pressing one returns to Operations and opens that panel.
+  ko: Operations 화면 밖에서도 커맨드 밴드에 사이드바와 Activity Rail 토글을 유지하고, 누르면 Operations로 돌아가 해당 패널을 엽니다.
+- [fleet-console] Stop the sidebar and Activity Rail keyboard shortcuts from changing the stored panel state on screens that show neither panel.
+  ko: 두 패널이 모두 보이지 않는 화면에서는 사이드바와 Activity Rail 단축키가 저장된 패널 상태를 바꾸지 않습니다.

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Navigate, Route, Routes, useLocation } from "react-router-dom";
+import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 
 import { resolveLocalizedText } from "@fleet-console/sdk/i18n/translate";
 
@@ -17,18 +17,19 @@ import { appendPendingDeletion, deletionCountdownSeconds, latestPendingDeletion 
 import { WhatsNewModal } from "./components/whatsnew-modal.js";
 import { FloatingWidgetLayer } from "./floating-widget-layer.js";
 import { useGlobalSettingsStore } from "./global-settings-store.js";
-import { installConsoleGlobalShortcuts } from "./global-shortcuts.js";
+import { installConsoleGlobalShortcuts, resolvePanelShortcutOutcome } from "./global-shortcuts.js";
 import { useConsoleState } from "./hooks/use-store.js";
 import { createHostCapabilities } from "./plugin-capabilities.js";
 import { usePluginRegistry } from "./plugin-registry.js";
 import { GlobalSettings } from "./pages/global-settings.js";
 import { Operations } from "./pages/operations.js";
 import { BUILT_IN_RAIL_PANELS } from "./rail/built-in-panels.js";
-import { toggleRailChrome } from "./rail/rail-store.js";
+import { setRailChromeExpanded, toggleRailChrome } from "./rail/rail-store.js";
 import { refreshObserverStatus } from "./operations-sse.js";
 import { closeKeyboardShortcuts, hydrateGroups, hydrateInitialOperations, hydrateOperations, hydrateTheaterBootstrap, hydrateTheaters, openOperationSearch, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
 import { abortReleaseNotesFetch, requestReleaseNotes } from "./release-notes-fetch.js";
 import { getSideBarState, setSideBarCollapsed, subscribeOperationActivityTracking } from "./sidebar/operations-side-bar-store.js";
+import { getViewModeSnapshot } from "./view-mode-store.js";
 import { useConsoleLocale, useT } from "./i18n/index.js";
 import type { CompanionShortcutEntry } from "./shortcuts-catalog.js";
 import { availableCompanionPanels, usableCompanionShortcuts } from "./companion-shortcut.js";
@@ -65,6 +66,11 @@ export function App() {
 
   const pathname = location.pathname;
   const operationsViewVisible = pathname.startsWith("/operations");
+  const navigate = useNavigate();
+  // 전역 단축키는 밴드의 패널 토글과 같은 계약을 따른다 — 사이드바·rail은 /operations에만 마운트되므로
+  // 다른 경로에서 누르면 조작할 표면이 없다. ref로 읽어 리스너 재설치 없이 최신 경로를 본다.
+  const operationsViewVisibleRef = useRef(operationsViewVisible);
+  operationsViewVisibleRef.current = operationsViewVisible;
   // 팔레트의 "Open panel"과 패널 검색 목록 — RightRail과 동일한 빌트인+플러그인 합성 순서를 미러한다.
   const paletteRailPanels = useMemo(
     () => [...BUILT_IN_RAIL_PANELS, ...registry.railPanels.filter((panel) => (panel.side ?? "right") === "right")],
@@ -232,17 +238,41 @@ export function App() {
     [],
   );
 
+  // 뷰 모드는 구독하지 않고 발화 시점에 읽는다 — 뷰포트가 바뀔 때마다 리스너를 재설치할 이유가 없다.
+  const resolvePanelShortcut = useCallback(() => resolvePanelShortcutOutcome({
+    panelSurfacesReachable: getViewModeSnapshot().effective !== "mobile",
+    operationsViewVisible: operationsViewVisibleRef.current,
+  }), []);
+
   useEffect(() => {
     return installConsoleGlobalShortcuts({
       getSideBarCollapsed: () => getSideBarState().collapsed,
-      setSideBarCollapsed,
+      setSideBarCollapsed: (collapsed) => {
+        const outcome = resolvePanelShortcut();
+        if (outcome === "suppress") return;
+        if (outcome === "reveal") {
+          navigate("/operations");
+          setSideBarCollapsed(false);
+          return;
+        }
+        setSideBarCollapsed(collapsed);
+      },
       openOperationSearch: () => openOperationSearch(">"),
       toggleOperationSearch,
-      toggleRailChrome,
+      toggleRailChrome: () => {
+        const outcome = resolvePanelShortcut();
+        if (outcome === "suppress") return;
+        if (outcome === "reveal") {
+          navigate("/operations");
+          setRailChromeExpanded(true);
+          return;
+        }
+        toggleRailChrome();
+      },
       canUndoLastClose,
       undoLastClose,
     });
-  }, [canUndoLastClose, undoLastClose]);
+  }, [canUndoLastClose, navigate, resolvePanelShortcut, undoLastClose]);
 
   return (
     <ActiveCompanionShortcutsProvider value={companionShortcuts}>

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type FocusEvent, type ReactElement } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 import { resolveLocalizedText } from "@fleet-console/sdk/i18n/translate";
 
@@ -12,7 +12,7 @@ import { CommandBandOperationMenu, CommandBandTheaterMenu, CommandBandTriggerCar
 import { CommandBandSystemCluster } from "./command-band-system-cluster.js";
 import { useGlobalSettingsStore } from "../global-settings-store.js";
 import { useConsoleState } from "../hooks/use-store.js";
-import { toggleRailChrome, useRailChromeExpanded } from "../rail/rail-store.js";
+import { setRailChromeExpanded, toggleRailChrome, useRailChromeExpanded } from "../rail/rail-store.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
 import { setSideBarCollapsed, useSideBarState } from "../sidebar/operations-side-bar-store.js";
@@ -78,6 +78,31 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const modLabel = resolveModLabel();
   const sideBarShortcut = `${modLabel}${modLabel === "⌘" ? "" : "+"}B`;
   const railShortcut = `${modLabel}${modLabel === "⌘" ? "⌥" : "+Alt+"}B`;
+  const navigate = useNavigate();
+  // 두 패널 토글은 데스크톱 밴드에 상주한다 — 사라졌다 나타나는 조작 표면은 밴드를 불안정하게 읽히게 하고,
+  // 버튼이 없는 동안에도 ⌘B·⌘⌥B는 계속 발화해 보이지 않는 영속 상태만 바꿨다(2026-08 실측).
+  // /operations 밖에서는 접을 표면 자체가 없으므로 팔레트 toggle-rail과 같은 경로로 Operations로 돌아가 펼친다.
+  const panelTogglesVisible = viewMode.effective !== "mobile";
+  const sideBarToggleExpands = !operationsViewVisible || sideBar.collapsed;
+  const sideBarToggleLabel = t(sideBarToggleExpands ? "chrome.commandBand.expandSidebar" : "chrome.commandBand.collapseSidebar", { shortcut: sideBarShortcut });
+  const railToggleExpands = !operationsViewVisible || !railChromeExpanded;
+  const railToggleLabel = t(railToggleExpands ? "chrome.commandBand.expandActivityRail" : "chrome.commandBand.collapseActivityRail", { shortcut: railShortcut });
+  const handleSideBarToggle = useCallback(() => {
+    if (operationsViewVisible) {
+      setSideBarCollapsed(!sideBar.collapsed);
+      return;
+    }
+    navigate("/operations");
+    setSideBarCollapsed(false);
+  }, [navigate, operationsViewVisible, sideBar.collapsed]);
+  const handleRailToggle = useCallback(() => {
+    if (operationsViewVisible) {
+      toggleRailChrome();
+      return;
+    }
+    navigate("/operations");
+    setRailChromeExpanded(true);
+  }, [navigate, operationsViewVisible]);
   const canvas = useCanvasState();
   const formationLayout = useFormationLayout();
   const formationView = useFormationView();
@@ -460,7 +485,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
             {t(state.connection === "offline" ? "chrome.link.offline" : "chrome.link.reconnecting")}
           </span>
         ) : null}
-        {operationsViewVisible ? <button type="button" className="command-band-button command-band-sidebar-toggle" onClick={() => setSideBarCollapsed(!sideBar.collapsed)} aria-label={t(sideBar.collapsed ? "chrome.commandBand.expandSidebar" : "chrome.commandBand.collapseSidebar", { shortcut: sideBarShortcut })} title={t(sideBar.collapsed ? "chrome.commandBand.expandSidebar" : "chrome.commandBand.collapseSidebar", { shortcut: sideBarShortcut })}>
+        {panelTogglesVisible ? <button type="button" className="command-band-button command-band-sidebar-toggle" onClick={handleSideBarToggle} aria-label={sideBarToggleLabel} title={sideBarToggleLabel}>
           <PanelToggleIcon side="left" />
         </button> : null}
         <button type="button" className="command-band-button command-band-search" onClick={toggleOperationSearch} aria-label={t("chrome.commandBand.searchSessions")} title={t("chrome.commandBand.searchSessionsTitle")}>
@@ -607,7 +632,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
           {viewMode.preference === "auto" ? <ViewModeAutoIcon /> : viewMode.preference === "mobile" ? <ViewModeMobileIcon /> : <ViewModeDesktopIcon />}
         </button>
         <CommandBandSystemCluster />
-        {operationsViewVisible ? <button type="button" className="command-band-button command-band-rail-toggle" onClick={toggleRailChrome} aria-label={t(railChromeExpanded ? "chrome.commandBand.collapseActivityRail" : "chrome.commandBand.expandActivityRail", { shortcut: railShortcut })} title={t(railChromeExpanded ? "chrome.commandBand.collapseActivityRail" : "chrome.commandBand.expandActivityRail", { shortcut: railShortcut })}>
+        {panelTogglesVisible ? <button type="button" className="command-band-button command-band-rail-toggle" onClick={handleRailToggle} aria-label={railToggleLabel} title={railToggleLabel}>
           <PanelToggleIcon side="right" />
         </button> : null}
       </div>

--- a/runtime/fleet-console/core/client/src/global-shortcuts.ts
+++ b/runtime/fleet-console/core/client/src/global-shortcuts.ts
@@ -1,6 +1,20 @@
 import { isBlockingDialogOpen } from "./focus-guards.js";
 import { isKeyboardShortcutsModalOpen } from "./components/keyboard-shortcuts-dialog.js";
 
+export type PanelShortcutOutcome = "suppress" | "reveal" | "apply";
+
+// 사이드바와 Activity Rail은 데스크톱 /operations에만 마운트된다. 표면이 없는 곳에서 토글을 그대로
+// 적용하면 아무 변화 없이 영속 상태만 바뀌고, 나중에 그 표면으로 돌아갔을 때 누른 적 없는 접힘이
+// 나타난다(2026-08 실측). 모바일 셸에는 두 표면이 아예 없으므로 발화를 막고(suppress),
+// 라우트만 다르면 그 표면으로 돌아가 펼친다(reveal).
+export function resolvePanelShortcutOutcome(surfaces: {
+  readonly panelSurfacesReachable: boolean;
+  readonly operationsViewVisible: boolean;
+}): PanelShortcutOutcome {
+  if (!surfaces.panelSurfacesReachable) return "suppress";
+  return surfaces.operationsViewVisible ? "apply" : "reveal";
+}
+
 export interface ConsoleGlobalShortcutDependencies {
   readonly getSideBarCollapsed: () => boolean;
   readonly setSideBarCollapsed: (collapsed: boolean) => void;

--- a/runtime/fleet-console/tests/global-shortcuts.test.ts
+++ b/runtime/fleet-console/tests/global-shortcuts.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { installConsoleGlobalShortcuts } from "../core/client/src/global-shortcuts.js";
+import { installConsoleGlobalShortcuts, resolvePanelShortcutOutcome } from "../core/client/src/global-shortcuts.js";
 
 afterEach(() => {
   document.body.replaceChildren();
@@ -96,5 +96,15 @@ describe("Console global shortcuts", () => {
     expect(modalGated.event.defaultPrevented).toBe(false);
     expect(modalGated.stopImmediatePropagation).not.toHaveBeenCalled();
     cleanup();
+  });
+
+  // 사이드바·Activity Rail 단축키가 조작할 표면이 없는 곳에서도 발화하면, 아무 변화 없이 영속 상태만
+  // 바뀌어 나중에 누른 적 없는 접힘으로 나타난다. 표면 가용성이 결과를 결정한다.
+  it("resolves the panel shortcut outcome from surface availability, not from the key alone", () => {
+    expect(resolvePanelShortcutOutcome({ panelSurfacesReachable: true, operationsViewVisible: true })).toBe("apply");
+    expect(resolvePanelShortcutOutcome({ panelSurfacesReachable: true, operationsViewVisible: false })).toBe("reveal");
+    // 모바일 셸에는 두 표면이 아예 없다 — 경로가 /operations여도 발화하지 않는다.
+    expect(resolvePanelShortcutOutcome({ panelSurfacesReachable: false, operationsViewVisible: true })).toBe("suppress");
+    expect(resolvePanelShortcutOutcome({ panelSurfacesReachable: false, operationsViewVisible: false })).toBe("suppress");
   });
 });

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -810,12 +810,17 @@ describe("Instrument core design contract", () => {
     expect(commandBand).toContain('className="command-band-button command-band-sidebar-toggle"');
     expect(commandBand).toContain("<BrandHome />");
     expect(commandBand).toContain("<CommandBandSystemCluster />");
-    expect(commandBand).toContain("onClick={() => setSideBarCollapsed(!sideBar.collapsed)}");
+    expect(commandBand).toContain("onClick={handleSideBarToggle}");
     expect(commandBand).toContain('className="command-band-button command-band-search"');
     expect(commandBand).toContain("onClick={toggleOperationSearch}");
     expect(commandBand).toContain('className="command-band-button command-band-viewmode"');
     expect(commandBand).toContain('className="command-band-button command-band-rail-toggle"');
-    expect(commandBand).toContain("onClick={toggleRailChrome}");
+    expect(commandBand).toContain("onClick={handleRailToggle}");
+    // 두 패널 토글은 라우트가 아니라 뷰 모드로만 걸린다 — /operations 밖에서도 밴드에 상주하고,
+    // 눌리면 Operations로 돌아가 그 표면을 펼친다(사라지는 조작 표면 + 무음 단축키 금지).
+    expect(commandBand).toContain("const panelTogglesVisible = viewMode.effective !== \"mobile\";");
+    expect(commandBand).toContain("{panelTogglesVisible ? <button type=\"button\" className=\"command-band-button command-band-sidebar-toggle\"");
+    expect(commandBand).toContain("{panelTogglesVisible ? <button type=\"button\" className=\"command-band-button command-band-rail-toggle\"");
     expect(commandBand).toContain(`      </div>
       {operationsViewVisible ? <div ref={mapControlsRef} className={\`command-band-map-controls\${sideBar.collapsed ? " is-docked" : ""}\`}>`);
     // 접힘 도킹 구분선은 맵 컨트롤의 첫 플로우 자식이다 — 도킹 상태에서만 display로 나타나


### PR DESCRIPTION
## Summary

- Settings 화면에 들어가면 커맨드 밴드에서 좌측 사이드바 토글과 우측 Activity Rail 토글이 함께 사라졌습니다. 두 버튼은 이제 라우트가 아니라 유효 뷰 모드로만 걸리며, 비-Operations 경로에서도 밴드에 상주하고 "펼치기" 라벨을 답니다.
- `/operations` 밖에서 누르면 Operations로 돌아가 그 표면을 펼칩니다 — 팔레트의 기존 `toggle-rail` 디스패치와 같은 경로입니다.
- 버튼이 없던 동안에도 `⌘B`·`⌘⌥B`는 계속 발화해 표면 없이 영속 상태만 바꿨습니다(실측: `/settings`에서 `⌘⌥B` → `fleet-console.rail.chromeExpanded="0"` 기록 → Operations 복귀 시 누른 적 없는 접힘). 단축키도 같은 계약을 따르고, 두 표면을 아예 렌더하지 않는 모바일 셸에서는 `resolvePanelShortcutOutcome` 정책으로 발화를 막습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit` — 0 errors
- [x] `vitest run` (global-shortcuts, instrument-design-contract, command-band-focus, rail-store, rail-search, palette-commands, operations-side-bar-store) — 112 passed
- [x] 전체 `vitest run` — 실패 파일이 무수정 `origin/canary` 실패 집합의 부분집합(7 < 9 파일, 63 < 80 테스트), 전부 서버·통합 계열 선존 실패
- [x] 격리 콘솔 헤디드 실측: `/settings`에 두 토글 상주 + 클릭 시 Operations 복귀·펼침, `⌘B`/`⌘⌥B` 동일 동작, 모바일 모드에서 두 단축키 억제(localStorage 무변경), `/operations` 접기·펼치기 양방향 정상, 페이지 오류 0건
- [x] Changelog: `.changelog.d/pr-532.md` 추가 — 그룹형 syntax, 영문/`ko:` 인접 쌍, `node scripts/compile-changelog-fragments.mjs --check` 통과(7 entries validated)