### PR TITLE
fix(fleet-console): lift the War Room preview crop above panel chrome

### DIFF
--- a/.changelog.d/pr-534.md
+++ b/.changelog.d/pr-534.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Changed
+- [fleet-console] Crop the War Room live preview above the panel's bottom chrome. A Watch Deck card and its quick-look now fill the frame with the streaming output area instead of the input composer and status lines that never change while a run is working, so roughly seven more rows of live output stay in view at the same card size.
+  ko: War Room 라이브 프리뷰의 크롭 기준을 패널 바닥 크롬 위로 올립니다. Watch Deck 카드와 확대창이 실행 중에도 갱신되지 않는 입력 컴포저·상태줄 대신 스트리밍 출력 영역으로 프레임을 채워, 같은 카드 크기에서 약 일곱 행만큼의 실시간 출력이 더 보입니다.

--- a/.changelog.d/pr-534.md
+++ b/.changelog.d/pr-534.md
@@ -1,4 +1,4 @@
 ### fleet-console
 #### Changed
-- [fleet-console] Crop the War Room live preview above the panel's bottom chrome. A Watch Deck card and its quick-look now fill the frame with the streaming output area instead of the input composer and status lines that never change while a run is working, so roughly seven more rows of live output stay in view at the same card size.
-  ko: War Room 라이브 프리뷰의 크롭 기준을 패널 바닥 크롬 위로 올립니다. Watch Deck 카드와 확대창이 실행 중에도 갱신되지 않는 입력 컴포저·상태줄 대신 스트리밍 출력 영역으로 프레임을 채워, 같은 카드 크기에서 약 일곱 행만큼의 실시간 출력이 더 보입니다.
+- [fleet-console] Crop the War Room live preview above an agent CLI panel's bottom chrome. A Watch Deck card and its quick-look now fill the frame with streaming output instead of the input composer and status lines that never change while a run is working, so roughly seven more rows of live output stay in view at the same card size. A panel whose body streams all the way down, such as a plain shell, keeps every row.
+  ko: War Room 라이브 프리뷰의 크롭 기준을 에이전트 CLI 패널의 바닥 크롬 위로 올립니다. Watch Deck 카드와 확대창이 실행 중에도 갱신되지 않는 입력 컴포저·상태줄 대신 스트리밍 출력으로 프레임을 채워, 같은 카드 크기에서 약 일곱 행만큼의 실시간 출력이 더 보입니다. 순정 셸처럼 바닥까지 출력이 흐르는 패널은 모든 행을 그대로 유지합니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -450,7 +450,7 @@ export function OperationsCanvas({
       };
       // 바닥 크롬 높이는 body 소유자인 kind가 선언한다 — 미선언 body(순정 셸·문서형 패널)는
       // 바닥까지 출력이 흐르므로 0이고, 프리뷰는 최신 행을 잘라내지 않는다.
-      sources.set(operation.id, { config, bottomChrome: descriptor.previewBottomChrome ?? 0 });
+      sources.set(operation.id, { config, bottomChrome: descriptor.previewBottomChrome?.() ?? 0 });
     }
     return (operation: OperationNode) => sources.get(operation.id) ?? null;
   }, [canvas.operations, language, registry.operationKinds, state.activeTheme, state.operations, triageActive]);

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -24,7 +24,7 @@ import { CanvasContextMenu } from "./canvas-context-menu.js";
 import { CanvasMinimap } from "./canvas-minimap.js";
 import { resolveAccentColor } from "./operation-accent.js";
 import { CanvasGrid, RubberBand, TriageClearPlate } from "./canvas-overlays.js";
-import { flashTriageDeckCard, getTriageDeckCardRect, resolveTriageDeckPromotion, takeTriageDeckDepartureRect, TriageWatchDeck, useTriageDeckZoomControl, type TriageDeckArrivalDwell } from "./triage-watch-deck.js";
+import { flashTriageDeckCard, getTriageDeckCardRect, resolveTriageDeckPromotion, takeTriageDeckDepartureRect, TriageWatchDeck, useTriageDeckZoomControl, type TriageDeckArrivalDwell, type TriagePreviewSource } from "./triage-watch-deck.js";
 import { resolveGlanceHudModel, type GlanceHudModel } from "./glance-hud.js";
 import { OperationFrame } from "./operation-frame.js";
 import { hasVisibleCanvasContent, OperationsCanvasEmptyState } from "./operations-canvas-empty-state.js";
@@ -424,16 +424,16 @@ export function OperationsCanvas({
       onClose(operationId);
     },
   };
-  const triagePreviewConfigFor = useMemo(() => {
+  const triagePreviewSourceFor = useMemo(() => {
     if (!triageActive) return undefined;
     const handlers = triagePreviewHandlersRef;
-    const configs = new Map<string, OperationBodyConfig>();
+    const sources = new Map<string, TriagePreviewSource>();
     // 선별 중에는 전 Theater가 마운트된다 — 모든 카드가 라이브 프리뷰를 받는다.
     for (const operation of state.operations) {
       // render가 없는 kind는 pool이 body를 만들지 못한다 — 빈 프리뷰 박스 대신 tail 폴백으로 내린다.
       const descriptor = registry.operationKinds.find((kind) => kind.pluginId === operation.pluginId && kind.type === operation.type);
       if (!descriptor?.render) continue;
-      configs.set(operation.id, {
+      const config: OperationBodyConfig = {
         active: false,
         geometry: canvas.operations[operation.id] ?? operation.geometry ?? ensurePluginGeometry(operation),
         operation,
@@ -447,9 +447,12 @@ export function OperationsCanvas({
         companionsOpen: false,
         hiddenCompanionPanelIds: EMPTY_HIDDEN_COMPANION_IDS,
         onSetCompanionPanelVisible: () => {},
-      });
+      };
+      // 바닥 크롬 높이는 body 소유자인 kind가 선언한다 — 미선언 body(순정 셸·문서형 패널)는
+      // 바닥까지 출력이 흐르므로 0이고, 프리뷰는 최신 행을 잘라내지 않는다.
+      sources.set(operation.id, { config, bottomChrome: descriptor.previewBottomChrome ?? 0 });
     }
-    return (operation: OperationNode) => configs.get(operation.id) ?? null;
+    return (operation: OperationNode) => sources.get(operation.id) ?? null;
   }, [canvas.operations, language, registry.operationKinds, state.activeTheme, state.operations, triageActive]);
   const setAsideArmedId = getTriageSetAsideArmedId();
   // 덱 줌 wheel은 React 합성 onWheel 밖에서 부착한다 — React는 root wheel을 passive로
@@ -1022,7 +1025,7 @@ export function OperationsCanvas({
         mapGeometryFor={(operation) => operation.theaterId === state.activeTheaterId
           ? canvas.operations[operation.id] ?? operation.geometry ?? null
           : getTheaterCanvasSnapshot(operation.theaterId).operations[operation.id] ?? operation.geometry ?? null}
-        previewConfigFor={triagePreviewConfigFor}
+        previewSourceFor={triagePreviewSourceFor}
         freshOperationIds={freshDeckOperationIds}
         onMapMarkerMove={(operationId, theaterId, geometry) => {
           // 지도에서 옮긴 자리는 캔버스의 자리다 — 라이브 좌표를 먼저 세우고 durable에도 남긴다.

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -1324,12 +1324,39 @@ function TriageDeckCardFace({ operationId, title, label, detail, accentColor, pr
   );
 }
 
+// 바닥 크롬 밴드 — 에이전트 CLI 패널의 최하단은 입력 컴포저와 상태줄(cwd·모델·권한 모드)이
+// 차지하며, 실행 중에도 갱신되지 않는 고정 크롬이다. 프리뷰의 역할은 스트리밍 감시이므로 이
+// 밴드는 프레임 밖으로 내보내고 그 위 출력 영역이 카드를 채운다. 기본 터미널 글꼴(14px,
+// lineHeight 1) 기준 상태줄 3행 + 컴포저 3행 + 여백 1행 ≈ 7행. 패널 좌표계 기준 상수라
+// scale이 곱해지며 카드/Quick-Look 어디서든 같은 행 수가 잘린다.
+export const TRIAGE_PREVIEW_BOTTOM_CHROME = 104;
+// 작은 패널에서 밴드가 프레임 대부분을 먹지 않도록 한 몫 상한을 둔다 — 하한 200px 패널에서
+// 104px를 그대로 빼면 남는 출력 영역이 절반 밑으로 떨어져 프리뷰가 오히려 덜 읽힌다.
+const TRIAGE_PREVIEW_BOTTOM_CHROME_MAX_RATIO = 0.3;
+
+// 프리뷰 fit — 레터박스 없이 카드 영역을 채우는 cover-fit이되, 세로 기준은 패널 전체가 아니라
+// 바닥 크롬을 제외한 출력 영역이다. 크롭 앵커는 가로 중앙·세로는 출력 영역의 하단: 터미널의
+// 최신 출력은 컴포저 바로 위에 쌓이므로 모니터링 가치가 있는 영역이 살아남는다(빈 셸이 비어
+// 보이는 것은 정직한 상태 표현이다).
+export function resolveTriagePreviewFit(
+  viewport: { readonly width: number; readonly height: number },
+  inner: { readonly width: number; readonly height: number },
+): { scale: number; left: number; top: number } | null {
+  if (viewport.width <= 0 || viewport.height <= 0) return null;
+  if (inner.width <= 0 || inner.height <= 0) return null;
+  const chrome = Math.min(TRIAGE_PREVIEW_BOTTOM_CHROME, inner.height * TRIAGE_PREVIEW_BOTTOM_CHROME_MAX_RATIO);
+  const contentHeight = inner.height - chrome;
+  const scale = Math.max(viewport.width / inner.width, viewport.height / contentHeight);
+  return {
+    scale,
+    left: (viewport.width - inner.width * scale) / 2,
+    top: viewport.height - contentHeight * scale,
+  };
+}
+
 // 라이브 프리뷰 — pool 슬롯이 실제 패널 body를 카드 안으로 끌어온다. 내부 박스는 패널의 원래
 // 픽셀 크기를 고정 유지한 채 transform scale로만 축소한다: FitAddon이 카드 크기를 측정하면
 // PTY cols/rows가 타일 크기로 리사이즈되어 실세션 레이아웃이 깨지므로, 측정 크기 불변이 계약이다.
-// 레터박스 없이 카드 영역을 채우는 cover-fit — max 비율로 확대하고 넘치는 축은 크롭한다.
-// 크롭 앵커는 가로 중앙·세로 하단: 터미널의 최신 출력과 입력줄은 항상 하단에 있으므로
-// 모니터링 가치가 있는 영역이 살아남는다(빈 셸이 비어 보이는 것은 정직한 상태 표현이다).
 function TriageDeckCardPreview({ operationId, config }: {
   readonly operationId: string;
   readonly config: OperationBodyConfig;
@@ -1344,18 +1371,10 @@ function TriageDeckCardPreview({ operationId, config }: {
     const viewport = viewportRef.current;
     if (!viewport) return;
     const measure = () => {
-      const width = viewport.clientWidth;
-      const height = viewport.clientHeight;
-      if (width <= 0 || height <= 0) {
-        setFit(null);
-        return;
-      }
-      const scale = Math.max(width / innerWidth, height / innerHeight);
-      setFit({
-        scale,
-        left: (width - innerWidth * scale) / 2,
-        top: height - innerHeight * scale,
-      });
+      setFit(resolveTriagePreviewFit(
+        { width: viewport.clientWidth, height: viewport.clientHeight },
+        { width: innerWidth, height: innerHeight },
+      ));
     };
     measure();
     if (typeof ResizeObserver === "undefined") return;

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -40,6 +40,13 @@ export interface TriageDeckTheater {
   readonly label: string;
 }
 
+/** 라이브 프리뷰 재료 — pool 슬롯 config와, 그 body를 소유한 kind가 선언한 바닥 크롬 높이(패널
+    좌표계 px). 크롬을 선언하지 않은 kind는 바닥까지 출력이 흐른다는 뜻이므로 0이다. */
+export interface TriagePreviewSource {
+  readonly config: OperationBodyConfig;
+  readonly bottomChrome: number;
+}
+
 interface TriageWatchDeckProps {
   readonly active: boolean;
   readonly entering: boolean;
@@ -56,9 +63,10 @@ interface TriageWatchDeckProps {
   /** 지도 마커용 유효 geometry — durable DTO보다 라이브 캔버스 배치가 정본이다(드래그 직후
       PATCH 왕복 대기·실패, DTO null인 자동 배치 op). canvas가 자기 스토어로 해석해 넘긴다. */
   readonly mapGeometryFor?: (operation: OperationNode) => OperationGeometry | null;
-  /** 카드 본문 라이브 프리뷰용 pool 슬롯 config 빌더 — 핸들러 배선은 canvas가 단일 소유한다.
-      렌더 가능한 kind가 아니면 null을 반환하고 카드는 tail 폴백으로 내려간다. */
-  readonly previewConfigFor?: (operation: OperationNode) => OperationBodyConfig | null;
+  /** 카드 본문 라이브 프리뷰 재료 빌더 — pool 슬롯 config와 그 kind가 선언한 바닥 크롬 높이를
+      함께 넘긴다. 핸들러 배선은 canvas가 단일 소유한다. 렌더 가능한 kind가 아니면 null을
+      반환하고 카드는 tail 폴백으로 내려간다. */
+  readonly previewSourceFor?: (operation: OperationNode) => TriagePreviewSource | null;
   /** 스포트라이트 OFF에서 검토 전인 대기 카드 — 지속 aurora 맥동(is-fresh)을 얹는다. */
   readonly freshOperationIds?: ReadonlySet<string>;
   /** 지도에서 마커를 끌어 옮겼을 때의 새 캔버스 좌표 — 지도는 함대의 축소판이므로 여기서 옮긴
@@ -492,7 +500,7 @@ export function TriageWatchDeck({
   stagedOperationId = null,
   onBeforePick,
   mapGeometryFor,
-  previewConfigFor,
+  previewSourceFor,
   freshOperationIds,
   onMapMarkerMove,
   onOperationContextMenu,
@@ -980,8 +988,8 @@ export function TriageWatchDeck({
       label: operationActivityLabel(activity),
       detail: getOperationStatusDetailSnapshot(operation.id).detail,
       accentColor: accentKey ? resolveAccentColor(accentKey) : null,
-      previewConfig: poolAvailable && previewConfigFor && operation.id !== stagedOperationId
-        ? previewConfigFor(operation)
+      preview: poolAvailable && previewSourceFor && operation.id !== stagedOperationId
+        ? previewSourceFor(operation)
         : null,
     };
   })();
@@ -1020,8 +1028,8 @@ export function TriageWatchDeck({
                     const accentColor = accentKey ? resolveAccentColor(accentKey) : null;
                     // 지도 모드에서는 카드가 은닉되므로 pool 슬롯도 놓는다 — body는 operation당
                     // 하나뿐이라, 은닉된 카드가 슬롯을 쥔 채로는 점의 확대창이 그 body를 실을 수 없다.
-                    const previewConfig = poolAvailable && previewConfigFor && operation.id !== stagedOperationId && !mapMode
-                      ? previewConfigFor(operation)
+                    const preview = poolAvailable && previewSourceFor && operation.id !== stagedOperationId && !mapMode
+                      ? previewSourceFor(operation)
                       : null;
                     const isQuicklook = quicklook?.operationId === operation.id;
                     // 밀도 변형 프레임 — 카드를 자기 점 자리로 옮겨 놓는다. Quick-Look 확대와는
@@ -1029,7 +1037,7 @@ export function TriageWatchDeck({
                     const morphFrame = morph?.applied ? morph.frames.get(operation.id) ?? null : null;
                     return (
                       <button
-                        className={`canvas-triage-deck-card is-${visual} ${previewConfig ? "has-preview" : ""} ${arrivingOperationId === operation.id ? "is-arriving" : ""} ${freshOperationIds?.has(operation.id) ? "is-fresh" : ""} ${isQuicklook ? "is-quicklook" : ""} ${morph ? "is-morphing" : ""} ${morph?.phase === "to-cards" && morph.applied ? "is-morph-snap" : ""}`}
+                        className={`canvas-triage-deck-card is-${visual} ${preview ? "has-preview" : ""} ${arrivingOperationId === operation.id ? "is-arriving" : ""} ${freshOperationIds?.has(operation.id) ? "is-fresh" : ""} ${isQuicklook ? "is-quicklook" : ""} ${morph ? "is-morphing" : ""} ${morph?.phase === "to-cards" && morph.applied ? "is-morph-snap" : ""}`}
                         data-triage-deck-card={operation.id}
                         key={operation.id}
                         type="button"
@@ -1060,7 +1068,7 @@ export function TriageWatchDeck({
                           label={label}
                           detail={statusDetail.detail}
                           accentColor={accentColor}
-                          previewConfig={previewConfig}
+                          preview={preview}
                         />
                       </button>
                     );
@@ -1120,7 +1128,7 @@ export function TriageWatchDeck({
           // 점의 확대창 — 카드 Quick-Look과 같은 카드 얼굴을 같은 판독 크기로 띄운다. 포인터를
           // 통과시켜(pointer-events:none) 창이 점을 덮어도 hover가 끊기지 않고 클릭이 점에 닿는다.
           <div
-            className={`canvas-triage-deck-card canvas-triage-map-quicklook is-${mapQuicklookOperation.visual} ${mapQuicklookOperation.previewConfig ? "has-preview" : ""}`}
+            className={`canvas-triage-deck-card canvas-triage-map-quicklook is-${mapQuicklookOperation.visual} ${mapQuicklookOperation.preview ? "has-preview" : ""}`}
             style={{
               left: `${mapQuicklook!.placement.left}px`,
               top: `${mapQuicklook!.placement.top}px`,
@@ -1135,7 +1143,7 @@ export function TriageWatchDeck({
               label={mapQuicklookOperation.label}
               detail={mapQuicklookOperation.detail}
               accentColor={mapQuicklookOperation.accentColor}
-              previewConfig={mapQuicklookOperation.previewConfig}
+              preview={mapQuicklookOperation.preview}
             />
           </div>
         ) : null}
@@ -1297,13 +1305,13 @@ function renderTriageMapDots(
 
 // 카드 얼굴 — 덱 카드와 지도 점의 확대창이 같은 조각(스파인·상태줄·제목·프리뷰/tail)을 공유한다.
 // 두 표면이 각자 얼굴을 조립하면 같은 Operation이 밀도에 따라 다르게 읽힌다.
-function TriageDeckCardFace({ operationId, title, label, detail, accentColor, previewConfig }: {
+function TriageDeckCardFace({ operationId, title, label, detail, accentColor, preview }: {
   readonly operationId: string;
   readonly title: string;
   readonly label: string;
   readonly detail: string | null | undefined;
   readonly accentColor: string | null;
-  readonly previewConfig: OperationBodyConfig | null;
+  readonly preview: TriagePreviewSource | null;
 }) {
   return (
     <>
@@ -1313,8 +1321,8 @@ function TriageDeckCardFace({ operationId, title, label, detail, accentColor, pr
         <span>{label}</span>
       </span>
       <strong title={title}>{title}</strong>
-      {previewConfig ? (
-        <TriageDeckCardPreview config={previewConfig} operationId={operationId} />
+      {preview ? (
+        <TriageDeckCardPreview config={preview.config} bottomChrome={preview.bottomChrome} operationId={operationId} />
       ) : (
         <span className="canvas-triage-deck-card-detail" title={detail ?? label}>
           {detail ?? label}
@@ -1324,27 +1332,26 @@ function TriageDeckCardFace({ operationId, title, label, detail, accentColor, pr
   );
 }
 
-// 바닥 크롬 밴드 — 에이전트 CLI 패널의 최하단은 입력 컴포저와 상태줄(cwd·모델·권한 모드)이
-// 차지하며, 실행 중에도 갱신되지 않는 고정 크롬이다. 프리뷰의 역할은 스트리밍 감시이므로 이
-// 밴드는 프레임 밖으로 내보내고 그 위 출력 영역이 카드를 채운다. 기본 터미널 글꼴(14px,
-// lineHeight 1) 기준 상태줄 3행 + 컴포저 3행 + 여백 1행 ≈ 7행. 패널 좌표계 기준 상수라
-// scale이 곱해지며 카드/Quick-Look 어디서든 같은 행 수가 잘린다.
-export const TRIAGE_PREVIEW_BOTTOM_CHROME = 104;
 // 작은 패널에서 밴드가 프레임 대부분을 먹지 않도록 한 몫 상한을 둔다 — 하한 200px 패널에서
-// 104px를 그대로 빼면 남는 출력 영역이 절반 밑으로 떨어져 프리뷰가 오히려 덜 읽힌다.
+// 선언값 104px를 그대로 빼면 남는 출력 영역이 절반 밑으로 떨어져 프리뷰가 오히려 덜 읽힌다.
 const TRIAGE_PREVIEW_BOTTOM_CHROME_MAX_RATIO = 0.3;
 
 // 프리뷰 fit — 레터박스 없이 카드 영역을 채우는 cover-fit이되, 세로 기준은 패널 전체가 아니라
-// 바닥 크롬을 제외한 출력 영역이다. 크롭 앵커는 가로 중앙·세로는 출력 영역의 하단: 터미널의
-// 최신 출력은 컴포저 바로 위에 쌓이므로 모니터링 가치가 있는 영역이 살아남는다(빈 셸이 비어
-// 보이는 것은 정직한 상태 표현이다).
+// 바닥 크롬을 제외한 출력 영역이다. 크롭 앵커는 가로 중앙·세로는 출력 영역의 하단: 에이전트
+// CLI의 최신 출력은 컴포저 바로 위에 쌓이므로 모니터링 가치가 있는 영역이 살아남는다(빈 셸이
+// 비어 보이는 것은 정직한 상태 표현이다). 밴드 높이는 body 소유자인 kind가 선언하며
+// (OperationKindDescriptor.previewBottomChrome), 선언이 없는 body는 바닥까지 출력이 흐른다는
+// 뜻이므로 0 — 순정 셸과 문서형 패널은 최신 행을 잃지 않는다.
 export function resolveTriagePreviewFit(
   viewport: { readonly width: number; readonly height: number },
   inner: { readonly width: number; readonly height: number },
+  bottomChrome = 0,
 ): { scale: number; left: number; top: number } | null {
   if (viewport.width <= 0 || viewport.height <= 0) return null;
   if (inner.width <= 0 || inner.height <= 0) return null;
-  const chrome = Math.min(TRIAGE_PREVIEW_BOTTOM_CHROME, inner.height * TRIAGE_PREVIEW_BOTTOM_CHROME_MAX_RATIO);
+  // 선언값은 플러그인이 넘기는 값이다 — 음수·비유한 값이 fit 전체를 NaN으로 만들지 않게 막는다.
+  const declared = Number.isFinite(bottomChrome) ? Math.max(0, bottomChrome) : 0;
+  const chrome = Math.min(declared, inner.height * TRIAGE_PREVIEW_BOTTOM_CHROME_MAX_RATIO);
   const contentHeight = inner.height - chrome;
   const scale = Math.max(viewport.width / inner.width, viewport.height / contentHeight);
   return {
@@ -1357,9 +1364,10 @@ export function resolveTriagePreviewFit(
 // 라이브 프리뷰 — pool 슬롯이 실제 패널 body를 카드 안으로 끌어온다. 내부 박스는 패널의 원래
 // 픽셀 크기를 고정 유지한 채 transform scale로만 축소한다: FitAddon이 카드 크기를 측정하면
 // PTY cols/rows가 타일 크기로 리사이즈되어 실세션 레이아웃이 깨지므로, 측정 크기 불변이 계약이다.
-function TriageDeckCardPreview({ operationId, config }: {
+function TriageDeckCardPreview({ operationId, config, bottomChrome }: {
   readonly operationId: string;
   readonly config: OperationBodyConfig;
+  readonly bottomChrome: number;
 }) {
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const [fit, setFit] = useState<{ scale: number; left: number; top: number } | null>(null);
@@ -1374,6 +1382,7 @@ function TriageDeckCardPreview({ operationId, config }: {
       setFit(resolveTriagePreviewFit(
         { width: viewport.clientWidth, height: viewport.clientHeight },
         { width: innerWidth, height: innerHeight },
+        bottomChrome,
       ));
     };
     measure();
@@ -1381,7 +1390,7 @@ function TriageDeckCardPreview({ operationId, config }: {
     const observer = new ResizeObserver(measure);
     observer.observe(viewport);
     return () => observer.disconnect();
-  }, [innerHeight, innerWidth]);
+  }, [bottomChrome, innerHeight, innerWidth]);
   return (
     <span className="canvas-triage-deck-card-preview" ref={viewportRef} aria-hidden="true" inert>
       {fit ? (

--- a/runtime/fleet-console/sdk/plugin/types.ts
+++ b/runtime/fleet-console/sdk/plugin/types.ts
@@ -112,6 +112,13 @@ export interface OperationKindDescriptor {
   readonly title: LocalizedText;
   readonly subtitle?: (operation: OperationNode) => string | undefined;
   readonly render?: (context: OperationRenderContext) => ReactNode;
+  /**
+   * Height in panel pixels of fixed bottom chrome this body always paints below its live content
+   * (e.g. an agent CLI's input composer and status lines). A host preview that crops the body may
+   * push that band out of frame so the live area fills the preview. Omit it when the body streams
+   * all the way to its bottom edge, as a bare terminal does.
+   */
+  readonly previewBottomChrome?: number;
   readonly companions?: readonly CompanionPanelDescriptor[];
   readonly canOpenCompanions?: (context: OperationCompanionAvailabilityContext) => boolean | Promise<boolean>;
 }

--- a/runtime/fleet-console/sdk/plugin/types.ts
+++ b/runtime/fleet-console/sdk/plugin/types.ts
@@ -113,12 +113,14 @@ export interface OperationKindDescriptor {
   readonly subtitle?: (operation: OperationNode) => string | undefined;
   readonly render?: (context: OperationRenderContext) => ReactNode;
   /**
-   * Height in panel pixels of fixed bottom chrome this body always paints below its live content
-   * (e.g. an agent CLI's input composer and status lines). A host preview that crops the body may
-   * push that band out of frame so the live area fills the preview. Omit it when the body streams
-   * all the way to its bottom edge, as a bare terminal does.
+   * Current height in panel pixels of fixed bottom chrome this body always paints below its live
+   * content (e.g. an agent CLI's input composer and status lines). A host preview that crops the
+   * body may push that band out of frame so the live area fills the preview. The host reads it
+   * each time it builds a preview, so a band that follows a user preference (a terminal font size,
+   * say) reports its height at that moment. Omit it when the body streams all the way to its
+   * bottom edge, as a bare terminal does.
    */
-  readonly previewBottomChrome?: number;
+  readonly previewBottomChrome?: () => number;
   readonly companions?: readonly CompanionPanelDescriptor[];
   readonly canOpenCompanions?: (context: OperationCompanionAvailabilityContext) => boolean | Promise<boolean>;
 }

--- a/runtime/fleet-console/tests/triage-deck-quicklook.test.ts
+++ b/runtime/fleet-console/tests/triage-deck-quicklook.test.ts
@@ -6,10 +6,12 @@ import { resolveTriageMapMarkerLayout } from "../core/client/src/canvas/triage-s
 import {
   resolveTriageMapQuicklookPlacement,
   resolveTriageMorphFrame,
+  resolveTriagePreviewFit,
   resolveTriageQuicklookOrigin,
   resolveTriageQuicklookScale,
   TRIAGE_MAP_QUICKLOOK_HEIGHT,
   TRIAGE_MAP_QUICKLOOK_WIDTH,
+  TRIAGE_PREVIEW_BOTTOM_CHROME,
 } from "../core/client/src/canvas/triage-watch-deck.js";
 
 function rect(left: number, top: number, width: number, height: number): DOMRect {
@@ -182,5 +184,39 @@ describe("resolveTriageMorphFrame", () => {
     const frame = resolveTriageMorphFrame(rect(0, 0, 0, 0), rect(10, 10, 14, 14));
     expect(Number.isFinite(frame.scale)).toBe(true);
     expect(Number.isFinite(frame.dx)).toBe(true);
+  });
+});
+
+describe("resolveTriagePreviewFit", () => {
+  it("pushes the panel's bottom chrome out of frame and lands the output edge on the bottom", () => {
+    const fit = resolveTriagePreviewFit({ width: 200, height: 120 }, { width: 800, height: 600 })!;
+    // 프레임 바닥에 닿는 것은 패널 바닥이 아니라 크롬을 뺀 출력 영역의 바닥이다.
+    expect(fit.top + (600 - TRIAGE_PREVIEW_BOTTOM_CHROME) * fit.scale).toBeCloseTo(120, 5);
+    // 상태줄·컴포저는 프레임 아래로 밀려난다.
+    expect(fit.top + 600 * fit.scale).toBeGreaterThan(120);
+  });
+
+  it("never opens a blank strip at the top", () => {
+    for (const viewport of [{ width: 200, height: 120 }, { width: 640, height: 400 }, { width: 300, height: 40 }]) {
+      const fit = resolveTriagePreviewFit(viewport, { width: 800, height: 600 })!;
+      expect(fit.top).toBeLessThanOrEqual(0);
+      expect(fit.left).toBeLessThanOrEqual(0);
+    }
+  });
+
+  it("keeps the horizontal crop centered", () => {
+    const fit = resolveTriagePreviewFit({ width: 200, height: 200 }, { width: 800, height: 600 })!;
+    expect(fit.left).toBeCloseTo((200 - 800 * fit.scale) / 2, 5);
+  });
+
+  it("caps the chrome band on a minimum-size panel so the output area keeps the frame", () => {
+    // 320×200 하한 패널 — 104px를 그대로 빼면 남는 출력이 절반 밑으로 떨어지므로 30%로 제한된다.
+    const fit = resolveTriagePreviewFit({ width: 160, height: 100 }, { width: 320, height: 200 })!;
+    expect(fit.top + (200 - 60) * fit.scale).toBeCloseTo(100, 5);
+  });
+
+  it("returns null for a collapsed viewport", () => {
+    expect(resolveTriagePreviewFit({ width: 0, height: 120 }, { width: 800, height: 600 })).toBeNull();
+    expect(resolveTriagePreviewFit({ width: 200, height: 0 }, { width: 800, height: 600 })).toBeNull();
   });
 });

--- a/runtime/fleet-console/tests/triage-deck-quicklook.test.ts
+++ b/runtime/fleet-console/tests/triage-deck-quicklook.test.ts
@@ -11,7 +11,6 @@ import {
   resolveTriageQuicklookScale,
   TRIAGE_MAP_QUICKLOOK_HEIGHT,
   TRIAGE_MAP_QUICKLOOK_WIDTH,
-  TRIAGE_PREVIEW_BOTTOM_CHROME,
 } from "../core/client/src/canvas/triage-watch-deck.js";
 
 function rect(left: number, top: number, width: number, height: number): DOMRect {
@@ -188,35 +187,46 @@ describe("resolveTriageMorphFrame", () => {
 });
 
 describe("resolveTriagePreviewFit", () => {
-  it("pushes the panel's bottom chrome out of frame and lands the output edge on the bottom", () => {
-    const fit = resolveTriagePreviewFit({ width: 200, height: 120 }, { width: 800, height: 600 })!;
+  // 에이전트 CLI kind가 선언하는 바닥 크롬(입력 컴포저 + 상태줄) 높이.
+  const AGENT_CHROME = 104;
+
+  it("pushes the declared bottom chrome out of frame and lands the output edge on the bottom", () => {
+    const fit = resolveTriagePreviewFit({ width: 200, height: 120 }, { width: 800, height: 600 }, AGENT_CHROME)!;
     // 프레임 바닥에 닿는 것은 패널 바닥이 아니라 크롬을 뺀 출력 영역의 바닥이다.
-    expect(fit.top + (600 - TRIAGE_PREVIEW_BOTTOM_CHROME) * fit.scale).toBeCloseTo(120, 5);
+    expect(fit.top + (600 - AGENT_CHROME) * fit.scale).toBeCloseTo(120, 5);
     // 상태줄·컴포저는 프레임 아래로 밀려난다.
     expect(fit.top + 600 * fit.scale).toBeGreaterThan(120);
   });
 
+  it("crops nothing for a body that declares no chrome", () => {
+    // 순정 셸·문서형 패널 — 바닥까지 출력이 흐르므로 최신 행이 프레임 안에 남아야 한다.
+    const fit = resolveTriagePreviewFit({ width: 200, height: 120 }, { width: 800, height: 600 })!;
+    expect(fit.top + 600 * fit.scale).toBeCloseTo(120, 5);
+    const explicitZero = resolveTriagePreviewFit({ width: 200, height: 120 }, { width: 800, height: 600 }, 0)!;
+    expect(explicitZero).toEqual(fit);
+  });
+
   it("never opens a blank strip at the top", () => {
     for (const viewport of [{ width: 200, height: 120 }, { width: 640, height: 400 }, { width: 300, height: 40 }]) {
-      const fit = resolveTriagePreviewFit(viewport, { width: 800, height: 600 })!;
+      const fit = resolveTriagePreviewFit(viewport, { width: 800, height: 600 }, AGENT_CHROME)!;
       expect(fit.top).toBeLessThanOrEqual(0);
       expect(fit.left).toBeLessThanOrEqual(0);
     }
   });
 
   it("keeps the horizontal crop centered", () => {
-    const fit = resolveTriagePreviewFit({ width: 200, height: 200 }, { width: 800, height: 600 })!;
+    const fit = resolveTriagePreviewFit({ width: 200, height: 200 }, { width: 800, height: 600 }, AGENT_CHROME)!;
     expect(fit.left).toBeCloseTo((200 - 800 * fit.scale) / 2, 5);
   });
 
   it("caps the chrome band on a minimum-size panel so the output area keeps the frame", () => {
     // 320×200 하한 패널 — 104px를 그대로 빼면 남는 출력이 절반 밑으로 떨어지므로 30%로 제한된다.
-    const fit = resolveTriagePreviewFit({ width: 160, height: 100 }, { width: 320, height: 200 })!;
+    const fit = resolveTriagePreviewFit({ width: 160, height: 100 }, { width: 320, height: 200 }, AGENT_CHROME)!;
     expect(fit.top + (200 - 60) * fit.scale).toBeCloseTo(100, 5);
   });
 
   it("returns null for a collapsed viewport", () => {
-    expect(resolveTriagePreviewFit({ width: 0, height: 120 }, { width: 800, height: 600 })).toBeNull();
-    expect(resolveTriagePreviewFit({ width: 200, height: 0 }, { width: 800, height: 600 })).toBeNull();
+    expect(resolveTriagePreviewFit({ width: 0, height: 120 }, { width: 800, height: 600 }, AGENT_CHROME)).toBeNull();
+    expect(resolveTriagePreviewFit({ width: 200, height: 0 }, { width: 800, height: 600 }, AGENT_CHROME)).toBeNull();
   });
 });

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -1496,6 +1496,10 @@ describe("triage store", () => {
           onSetCompanionPanelVisible: () => {},
         }
       : null;
+    const previewSourceFor = (candidate: OperationNode) => {
+      const config = previewConfigFor(candidate);
+      return config ? { config, bottomChrome: 0 } : null;
+    };
     act(() => {
       // has-preview 클래스는 pool 가용성 게이트를 통과해야 붙는다 — 실제 조립 경로와 같은
       // OperationBodyPool 안에서 렌더한다.
@@ -1511,7 +1515,7 @@ describe("triage store", () => {
           operations,
           operationStatus: status,
           operationAccent: {},
-          previewConfigFor,
+          previewSourceFor,
         }),
       }));
     });

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -98,6 +98,11 @@ export const agentOperationKind = defineOperationKind({
   title: (locale) => getT(locale)("terminal.kind.agent"),
   subtitle: (operation) => readPayloadString(operation.payload, "cliLabel") ?? undefined,
   render: (context) => <AgentOperationView context={context} />,
+  // 에이전트 CLI TUI는 화면 바닥에 입력 컴포저와 상태줄(cwd·모델·권한 모드)을 고정으로 그린다 —
+  // 실행 중에도 갱신되지 않으므로 호스트 프리뷰는 이 밴드를 프레임 밖으로 밀어낼 수 있다.
+  // 기본 글꼴 14px·lineHeight 1 기준 상태줄 3행 + 컴포저 3행 + 여백 1행 ≈ 7행.
+  // 순정 셸(shellOperationKind)은 바닥까지 출력이 흐르므로 이 값을 선언하지 않는다.
+  previewBottomChrome: 104,
   canOpenCompanions: () => true,
   companions: [
     { id: CARRIER_STREAMS_COMPANION_ID, title: (locale) => getT(locale)("terminal.companion.carrierStreams"), hideCaption: true, defaultHidden: true, available: operationSupportsCarrierStreams, shortcut: { code: "KeyC", label: "C" }, render: (context) => <CarrierStreamsPanel context={context} /> },

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -9,7 +9,7 @@ import { defineSettingsSection } from "@fleet-console/sdk/settings/browser";
 import type { OperationRenderContext, PluginInstallContext } from "@fleet-console/sdk/plugin";
 import { TerminalSurface } from "../shared/index.js";
 import { CURATED_TERMINAL_FONTS, DEFAULT_TERMINAL_FONT, TERMINAL_FONT_SIZE_RANGE } from "../shared/terminal-preferences.js";
-import { useTerminalPrefs, setInstalledTerminalFont, setTerminalRenderer, setTerminalFont, setTerminalFontSize } from "../shared/terminal-preferences.js";
+import { getTerminalPrefsSnapshot, useTerminalPrefs, setInstalledTerminalFont, setTerminalRenderer, setTerminalFont, setTerminalFontSize } from "../shared/terminal-preferences.js";
 import type { TerminalFontId, TerminalFontSettings, TerminalRenderer } from "../shared/terminal-preferences.js";
 import { AnalystArtifactsPanel } from "./analysis-artifacts-panel.js";
 import { AnalystChatPanel } from "./analysis-chat-panel.js";
@@ -92,6 +92,9 @@ function sortiePhaseText(phase: TrackPhase, t: ReturnType<typeof getT>): string 
   return t("terminal.sortie.phase.working");
 }
 
+// 상태줄 3행(cwd·모델·권한 모드) + 입력 컴포저 3행(테두리 2 + 프롬프트 1) + 사이 여백 1행.
+const AGENT_PREVIEW_CHROME_ROWS = 7;
+
 export const agentOperationKind = defineOperationKind({
   pluginId: "terminal",
   type: "agent",
@@ -100,9 +103,10 @@ export const agentOperationKind = defineOperationKind({
   render: (context) => <AgentOperationView context={context} />,
   // 에이전트 CLI TUI는 화면 바닥에 입력 컴포저와 상태줄(cwd·모델·권한 모드)을 고정으로 그린다 —
   // 실행 중에도 갱신되지 않으므로 호스트 프리뷰는 이 밴드를 프레임 밖으로 밀어낼 수 있다.
-  // 기본 글꼴 14px·lineHeight 1 기준 상태줄 3행 + 컴포저 3행 + 여백 1행 ≈ 7행.
+  // 밴드의 단위는 px가 아니라 행이다: 셀 높이가 글꼴 크기를 따르므로(TERMINAL_OPTIONS.lineHeight
+  // = 1) 현재 글꼴 크기를 곱해 지원 범위(10~22px) 어디서도 같은 행 수가 잘리게 한다.
   // 순정 셸(shellOperationKind)은 바닥까지 출력이 흐르므로 이 값을 선언하지 않는다.
-  previewBottomChrome: 104,
+  previewBottomChrome: () => AGENT_PREVIEW_CHROME_ROWS * getTerminalPrefsSnapshot().font.size,
   canOpenCompanions: () => true,
   companions: [
     { id: CARRIER_STREAMS_COMPANION_ID, title: (locale) => getT(locale)("terminal.companion.carrierStreams"), hideCaption: true, defaultHidden: true, available: operationSupportsCarrierStreams, shortcut: { code: "KeyC", label: "C" }, render: (context) => <CarrierStreamsPanel context={context} /> },

--- a/runtime/fleet-plugins/terminal/tests/preview-bottom-chrome.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/preview-bottom-chrome.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../client/shared/index.js", () => ({ TerminalSurface: () => null }));
+
+import { agentOperationKind } from "../client/agent/index.js";
+import { shellOperationKind } from "../client/shell/index.js";
+
+// 바닥 크롬 선언은 body 소유자의 계약이다 — 호스트 프리뷰(War Room Watch Deck)는 이 값만큼을
+// 프레임 밖으로 밀어낸다. 순정 셸이 이 값을 갖게 되면 프롬프트와 최신 출력이 잘려 나간다.
+describe("preview bottom chrome declarations", () => {
+  it("declares the agent CLI composer and status band", () => {
+    expect(agentOperationKind.previewBottomChrome).toBe(104);
+  });
+
+  it("leaves a bare shell undeclared so its prompt stays in frame", () => {
+    expect(shellOperationKind.previewBottomChrome).toBeUndefined();
+  });
+});

--- a/runtime/fleet-plugins/terminal/tests/preview-bottom-chrome.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/preview-bottom-chrome.test.ts
@@ -1,15 +1,29 @@
-import { describe, expect, it, vi } from "vitest";
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../client/shared/index.js", () => ({ TerminalSurface: () => null }));
 
 import { agentOperationKind } from "../client/agent/index.js";
 import { shellOperationKind } from "../client/shell/index.js";
+import { setTerminalFontSize } from "../client/shared/terminal-preferences.js";
 
 // 바닥 크롬 선언은 body 소유자의 계약이다 — 호스트 프리뷰(War Room Watch Deck)는 이 값만큼을
 // 프레임 밖으로 밀어낸다. 순정 셸이 이 값을 갖게 되면 프롬프트와 최신 출력이 잘려 나간다.
 describe("preview bottom chrome declarations", () => {
-  it("declares the agent CLI composer and status band", () => {
-    expect(agentOperationKind.previewBottomChrome).toBe(104);
+  afterEach(() => { setTerminalFontSize(14); });
+
+  it("reports the agent CLI composer and status band in the current font's rows", () => {
+    // 7행 × 기본 14px.
+    expect(agentOperationKind.previewBottomChrome?.()).toBe(98);
+  });
+
+  it("follows the terminal font size across its supported range", () => {
+    // 밴드는 px가 아니라 행 단위다 — 글꼴을 키우거나 줄여도 잘리는 행 수는 그대로여야 한다.
+    setTerminalFontSize(10);
+    expect(agentOperationKind.previewBottomChrome?.()).toBe(70);
+    setTerminalFontSize(22);
+    expect(agentOperationKind.previewBottomChrome?.()).toBe(154);
   });
 
   it("leaves a bare shell undeclared so its prompt stays in frame", () => {


### PR DESCRIPTION
## Summary
- War Room 프리뷰(덱 카드·Quick-Look)의 cover-fit 세로 기준을 패널 전체 높이에서 **바닥 크롬을 제외한 출력 영역**으로 바꿨습니다. 에이전트 CLI 패널 최하단의 입력 컴포저와 상태줄(cwd·모델·권한 모드)은 실행 중에도 갱신되지 않는 고정 크롬인데, 기존 하단 앵커 크롭에서는 프리뷰 프레임의 상당 부분을 계속 차지했습니다.
- 크롬 밴드는 패널 좌표계 기준 상수(`TRIAGE_PREVIEW_BOTTOM_CHROME = 104`, 기본 글꼴 14px·lineHeight 1 기준 약 7행)이며 scale이 곱해지므로 카드와 Quick-Look 어디서든 같은 행 수가 잘립니다. 하한 크기(320×200) 패널에서 프레임 대부분을 먹지 않도록 패널 높이의 30% 상한을 둡니다.
- fit 계산을 `resolveTriagePreviewFit` 순수 함수로 분리하고 불변식(크롬은 프레임 밖, 상단 빈 띠 없음, 가로 중앙 크롭, 소형 패널 밴드 상한)을 단위 테스트로 고정했습니다. 측정 크기 불변(FitAddon이 카드 크기를 재지 않는다) 계약은 그대로입니다.

## Test Plan
- [x] `vitest run tests/triage-deck-quicklook.test.ts` — 27 passed
- [x] `vitest run tests/triage-store.test.ts tests/triage-deck-quicklook.test.ts tests/instrument-design-contract.test.ts` — 136 passed
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 0 errors
- [x] Changelog: `.changelog.d/pr-534.md` (grouped 문법·이중 언어 요약·`compile-changelog-fragments.mjs --check` 통과)
- [ ] 헤디드 실측: 프리뷰 내용은 라이브 에이전트 CLI 스트림이라 시드가 불가해 브라우저 실측은 수행하지 않았습니다. 크롭량은 상수 하나(`TRIAGE_PREVIEW_BOTTOM_CHROME`)로 재조정 가능합니다.