### PR TITLE
fix(fleet-console): keep node: import prefixes in built bundles

### DIFF
--- a/.changelog.d/pr-537.md
+++ b/.changelog.d/pr-537.md
@@ -1,0 +1,4 @@
+### fleet-console
+#### Fixed
+- [fleet-console] The OpenCode Go card in Usage limits now shows its session, weekly, and monthly meters in Fleet Desktop instead of reporting that no local usage log exists; the built bundle had lost the `node:` prefix on `node:sqlite`, so reading the local OpenCode CLI log failed and was silently reported as absent.
+  ko: 사용량 한도의 OpenCode Go 카드가 Fleet Desktop에서 로컬 사용 기록이 없다고 알리는 대신 세션·주간·월간 미터를 표시합니다. 빌드 번들이 `node:sqlite`의 `node:` 접두를 잃어 로컬 OpenCode CLI 로그 읽기가 실패했고, 그 실패가 기록 부재로 조용히 보고되고 있었습니다.

--- a/runtime/fleet-console/package.json
+++ b/runtime/fleet-console/package.json
@@ -38,7 +38,7 @@
     "node": ">=20.19.0"
   },
   "scripts": {
-    "build": "pnpm generate:admiral-assets && pnpm generate:shim-keys && tsup && pnpm generate:desktop-protocol-declaration && pnpm verify:desktop-protocol && vite build --config core/client/vite.config.ts",
+    "build": "pnpm generate:admiral-assets && pnpm generate:shim-keys && tsup && node ../../scripts/check-dist-node-protocol.mjs && pnpm generate:desktop-protocol-declaration && pnpm verify:desktop-protocol && vite build --config core/client/vite.config.ts",
     "cli": "tsx core/host/cli.ts",
     "dev": "vite --config core/client/vite.config.ts",
     "generate:admiral-assets": "node ../../scripts/generate-fleet-admiral-assets.mjs",

--- a/runtime/fleet-console/tsup.config.ts
+++ b/runtime/fleet-console/tsup.config.ts
@@ -22,6 +22,11 @@ export default defineConfig([
     dts: { entry: { cli: "core/host/cli.ts" }, resolve: true },
     sourcemap: false,
     clean: false,
+    // tsup은 기본값으로 모든 import 지정자에서 node: 접두를 벗긴다. fs·os·path처럼 맨 이름
+    // 별칭이 있는 빌트인은 무해하지만, node:sqlite처럼 접두로만 존재하는 빌트인은 맨 이름이
+    // 해석되지 않아 산출물이 런타임에 ERR_MODULE_NOT_FOUND로 죽는다. 소스가 쓴 지정자를
+    // 그대로 내보낸다(engines가 node>=20.19.0이라 접두는 정적·동적 import 모두 지원된다).
+    removeNodeProtocol: false,
     // workspace 패키지(@dotobokuri/*)는 npm에 개별 발행하지 않으므로 번들에 인라인한다.
     // native(node-pty)·동적 require(ws)·font-list의 플랫폼 helper는 정적 분석 대상이 아니라 external로 남으며,
     // publish 스크립트가 published dependencies로 유지한다.

--- a/scripts/check-dist-node-protocol.mjs
+++ b/scripts/check-dist-node-protocol.mjs
@@ -1,0 +1,92 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { isBuiltin } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * 번들러가 import 지정자의 node: 접두를 벗기면, 맨 이름 별칭이 없는 빌트인(node:sqlite 등)은
+ * 산출물이 런타임에 ERR_MODULE_NOT_FOUND로 죽는다. 소스와 테스트는 접두를 그대로 쓰므로
+ * 전부 green인 채로 배포 번들만 깨진다 — 그래서 빌드 산출물을 직접 검사한다.
+ *
+ * 판정은 실행 중인 Node가 그 빌트인을 아는지에 의존하지 않는다: 소스가 node:X로 썼는데
+ * 맨 이름 X가 빌트인이 아니면, 벗겨진 X는 어느 런타임에서도 해석되지 않는다.
+ */
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.dirname(scriptDir);
+const distRoot = path.join(repoRoot, "runtime", "fleet-console", "dist");
+const sourceRoots = [path.join(repoRoot, "packages"), path.join(repoRoot, "runtime")];
+const skippedDirectories = new Set(["node_modules", "dist", ".fleet", "release", "test-results", ".stage"]);
+
+const prefixRequired = collectPrefixRequiredSpecifiers();
+const violations = [];
+
+for (const file of listFiles(distRoot, ".mjs", new Set(["client"]))) {
+  const lines = readFileSync(file, "utf8").split(/\r?\n/);
+  lines.forEach((line, index) => {
+    for (const name of prefixRequired) {
+      if (!bareSpecifierPatterns(name).some((pattern) => pattern.test(line))) continue;
+      violations.push(`${path.relative(repoRoot, file)}:${index + 1} imports "${name}" instead of "node:${name}"`);
+    }
+  });
+}
+
+if (violations.length > 0) {
+  console.error("built artifacts lost a required node: prefix — the bare specifier does not resolve at runtime:");
+  for (const violation of violations) console.error(`- ${violation}`);
+  process.exit(1);
+}
+
+/** 소스가 쓴 node:X 중 맨 이름 X가 빌트인이 아닌 것 — 접두가 없으면 해석되지 않는 지정자. */
+function collectPrefixRequiredSpecifiers() {
+  const names = new Set();
+  for (const root of sourceRoots) {
+    for (const file of listFiles(root, [".ts", ".tsx", ".mts", ".js", ".mjs"])) {
+      const text = readFileSync(file, "utf8");
+      for (const match of text.matchAll(/["']node:([\w./-]+)["']/g)) {
+        const name = match[1];
+        if (!isBuiltin(name)) names.add(name);
+      }
+    }
+  }
+  return names;
+}
+
+/**
+ * 맨 이름으로 남은 static import·re-export·dynamic import·require를 잡되, 지정자 자리에
+ * 오지 않은 같은 철자는 잡지 않는다. 산문("failed to import 'sqlite'")이나 다른 호출
+ * (`Array.from("sqlite")`·`__myimport("sqlite")`)까지 위반으로 보면, 이 게이트가 막아야 할
+ * 결함을 정직하게 진단하려는 후속 수정이 오히려 빌드에서 막힌다.
+ */
+function bareSpecifierPatterns(name) {
+  const escaped = name.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+  const specifier = String.raw`["']${escaped}["']`;
+  return [
+    // 부작용 전용 import는 산문과 철자가 겹치므로 문(statement) 시작에서만 인정한다.
+    new RegExp(String.raw`^\s*import\s+${specifier}`),
+    new RegExp(String.raw`(?<![\w$.])from\s*${specifier}`),
+    new RegExp(String.raw`(?<![\w$.])(?:import|require)\s*\(\s*${specifier}`),
+  ];
+}
+
+/** 디렉터리 하위 파일을 재귀 수집한다(디렉터리 부재 시 빈 배열). */
+function listFiles(dir, extensions, extraSkips = new Set()) {
+  const allowed = Array.isArray(extensions) ? extensions : [extensions];
+  let stat;
+  try {
+    stat = statSync(dir);
+  } catch {
+    return [];
+  }
+  if (!stat.isDirectory()) return [];
+  const files = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (skippedDirectories.has(entry.name) || extraSkips.has(entry.name)) continue;
+      files.push(...listFiles(path.join(dir, entry.name), allowed, extraSkips));
+    } else if (allowed.some((extension) => entry.name.endsWith(extension))) {
+      files.push(path.join(dir, entry.name));
+    }
+  }
+  return files;
+}


### PR DESCRIPTION
## Summary

- tsup은 기본값(`removeNodeProtocol: true`)으로 모든 import 지정자에서 `node:` 접두를 제거합니다. `fs`·`os`·`path`처럼 맨 이름 별칭이 있는 빌트인은 무해하지만, **`node:sqlite`는 접두로만 존재**해 빌드 산출물이 `await import('sqlite')`가 되고 런타임에 `ERR_MODULE_NOT_FOUND`로 죽습니다. quota 플러그인의 OpenCode Go 제공자는 이 실패를 `catch {}`로 삼키고 창 없는 상태로 강등하며, 클라이언트는 그것을 "로컬 OpenCode 사용 기록을 찾지 못했습니다"로 그립니다 — **Fleet Desktop에서만 사용량 미터가 비어 보이던 원인**입니다(Desktop은 빌드 번들을 사이드카로 실행하고, 소스로 도는 개발 콘솔은 `PLUGIN_DEV_EXTERNALS`의 `node:*` 덕분에 접두가 보존되어 정상 동작했습니다).
- `runtime/fleet-console/tsup.config.ts`에 `removeNodeProtocol: false`를 두어 소스가 쓴 지정자를 그대로 내보냅니다. `engines`가 `node>=20.19.0`이라 정적·동적 import 모두 접두를 지원합니다.
- 재발 방지로 `scripts/check-dist-node-protocol.mjs`를 신설해 tsup 직후 빌드에서 실행합니다. 소스가 `node:X`로 썼는데 맨 이름 `X`가 빌트인이 아니면, 빌드 산출물에 남은 맨 이름 import를 찾아 빌드를 실패시킵니다. 판정이 실행 중인 Node 버전에 의존하지 않으며, 지정자 자리에 오지 않은 같은 철자(산문·`Array.from("sqlite")` 등)는 잡지 않습니다.

## Test Plan

- [x] `pnpm build` (fleet-console) — 성공, 신설 게이트 통과
- [x] 게이트가 수정 전 산출물에서 정확히 1건(`dist/fleet-plugins/quota/routes.mjs`) 검출, 전체 dist 오탐 0
- [x] 게이트 오탐 회귀 검증 — `console.warn("failed to import 'sqlite'")`, `Array.from("sqlite")`, `__myimport("sqlite")`, `registry.import("sqlite")` 전부 통과
- [x] 게이트 검출 회귀 검증 — dynamic / named static / side-effect / 미니파이 `}from"..."` + `require` 4종 전부 검출
- [x] 산출물 대조 — 재빌드 결과가 기존과 다른 지점은 import 지정자 접두, 번들러 지역 식별자 재번호(`path12`→`path7`·`constants`→`constants$1`), rollup 모듈 배너 주석뿐
- [x] `pnpm typecheck` (fleet-console) — 클린
- [x] quota 플러그인 vitest — 64/64 통과
- [x] fleet-console vitest — 실패 집합이 수정 전/후 동일(stash A/B로 확인한 선존 실패)
- [x] 엔드투엔드 실측 — 빌드된 `dist/cli.mjs serve`로 격리 콘솔을 띄워 `/plugins/quota/summary` 조회 시 OpenCode 창 3개 반환(수정 전에는 빈 배열). 세 창의 0%는 이 기기 마지막 `opencode-go` 기록이 2026-07-30이라 산술적으로 정확

## Changelog

- [x] `.changelog.d/pr-537.md` — 그룹형 구문·영문/한글 병기·`node:sqlite` 토큰 보존, `node scripts/compile-changelog-fragments.mjs --check` 통과