### PR TITLE
refactor(fleet-core): own AI Gateway settings in core-ai-gateway

### DIFF
--- a/.changelog.d/pr-542.md
+++ b/.changelog.d/pr-542.md
@@ -1,0 +1,6 @@
+### fleet-plugin
+
+#### Changed
+
+- [fleet-console] Store the AI Gateway model selection as one Fleet-wide file at `~/.fleet/ai-gateway.json`, alongside the global settings file, instead of a per-Console-channel plugin slot. An existing selection is carried over on first use, so the models, per-model reasoning levels, Cursor diagnostics, and wire-log switches stay as they were. Development and published Consoles now share one AI Gateway selection; a Console started with an explicit data-root override keeps its own.
+  ko: AI Gateway 모델 선별을 Console 채널별 플러그인 슬롯이 아니라 전역 설정 파일 옆의 Fleet 단일 파일 `~/.fleet/ai-gateway.json`에 저장합니다. 기존 선별은 처음 사용할 때 그대로 승계되어 모델, 모델별 추론 강도, Cursor 진단, 와이어 로그 스위치가 유지됩니다. 이제 개발용과 게시본 Console이 하나의 AI Gateway 선별을 공유하며, 데이터 루트를 명시해 띄운 Console은 자기 것을 따로 갖습니다.

--- a/packages/core-ai-gateway/AGENTS.md
+++ b/packages/core-ai-gateway/AGENTS.md
@@ -11,6 +11,7 @@ Translates Anthropic Messages traffic onto non-Anthropic provider backends.
 | `src/transport/` | Provider-unaware transport mechanics: SSE framing, token estimate, wire log, keepalive, credential file I/O |
 | `src/<provider>/` | One folder per provider (`codex/`, `cursor/`, `kimi/`, `opencode-go/`). OpenCode behavior is additionally split by wire under `src/opencode-go/{anthropic,responses,chat-completions}/` |
 | `src/models.ts`, `models.json` | Model catalog, context windows, effort ladders |
+| `src/settings/` | Which catalog models a user exposed and where that choice is stored: stored shape, catalog-checked validation, selection resolution, and the `<dataDir>/ai-gateway.json` durable store |
 
 ## Routing doctrine
 
@@ -19,6 +20,7 @@ Translates Anthropic Messages traffic onto non-Anthropic provider backends.
 - Same wire protocol is not a reason to share provider request/response/tool/header/capability semantics — duplicate provider semantics deliberately.
 - Only canonical protocol vocabulary (`src/canonical/`), provider-unaware transport mechanics (`src/transport/`), and exactly two Anthropic normalization modules — `src/anthropic/protocol.ts` and `src/anthropic/passthrough.ts` — may be shared across providers. `src/transport/` must not import any provider folder, and `src/anthropic/native.ts` is Anthropic-owned provider semantics other providers must not import.
 - Provider request/response/tool/header/capability exceptions cannot live in `canonical/`, `transport/`, or the root facade.
+- `src/settings/` is a catalog reader, never a provider: it may consume `src/models.ts` and the Claude compatibility seam, but must not import a provider folder or carry provider request/response semantics. Hosts wire it with an explicit data root and an optional legacy directory; the package resolves no host path of its own.
 - `src/index.ts` is a compatibility facade only: it re-exports the public surface from the new locations and must not add provider branching or behavior.
 - The one sanctioned seam→provider coupling is `AnthropicMessagesGateway`'s backwards-compatible default constructor (`src/anthropic/gateway.ts` → `codex/responses/adapter.ts`, the legacy `OpenAIResponsesAdapter`). It is pinned by the provider-boundaries test; any other anthropic-seam import of a provider folder is a violation.
 

--- a/packages/core-ai-gateway/package.json
+++ b/packages/core-ai-gateway/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.12.0",
+    "@dotobokuri/core-infra": "workspace:*",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/core-ai-gateway/src/index.ts
+++ b/packages/core-ai-gateway/src/index.ts
@@ -12,6 +12,8 @@ export type { WireLogTarget } from "./transport/wire-log.js";
 export { AnthropicMessagesGateway, ContextWindowExceededError } from "./anthropic/gateway.js";
 export type { AnthropicGatewayCallOptions, AnthropicGatewayResponse } from "./anthropic/gateway.js";
 export * from "./models.js";
+export * from "./settings/index.js";
+export * from "./settings/store.js";
 export * from "./opencode-go/index.js";
 export * from "./codex/index.js";
 export * from "./kimi/index.js";

--- a/packages/core-ai-gateway/src/models.ts
+++ b/packages/core-ai-gateway/src/models.ts
@@ -62,6 +62,12 @@ export const GATEWAY_REASONING_EFFORTS = [
 ] as const;
 export type GatewayReasoningEffort = typeof GATEWAY_REASONING_EFFORTS[number];
 
+/**
+ * Scoped gateway model id → the reasoning rungs exposed as delegation identities.
+ * An absent entry means that model's whole ladder.
+ */
+export type GatewayEffortExposure = Readonly<Record<string, readonly GatewayReasoningEffort[]>>;
+
 const GatewayEffortUpstreamModelIdsSchema = z.partialRecord(
   z.enum(GATEWAY_REASONING_EFFORTS),
   z.string().min(1),

--- a/packages/core-ai-gateway/src/settings/index.ts
+++ b/packages/core-ai-gateway/src/settings/index.ts
@@ -1,26 +1,22 @@
+import { hasClaudeOneMillionMarker } from "../anthropic/claude-context.js";
 import {
   GATEWAY_MODELS,
   GATEWAY_PROVIDER_NAMES,
   GATEWAY_PROVIDERS,
   buildGatewayModelConstraints,
   findGatewayModel,
-  hasClaudeOneMillionMarker,
   toClaudeGatewayModelId,
-} from "@dotobokuri/core-ai-gateway";
+} from "../models.js";
 import type {
+  GatewayEffortExposure,
   GatewayModel,
   GatewayProvider,
   GatewayReasoningEffort,
-} from "@dotobokuri/core-ai-gateway";
-import type { GatewayEffortExposure } from "@dotobokuri/fleet-admiral";
-import type { FleetPluginStorageHost } from "@fleet-console/sdk/plugin";
+} from "../models.js";
 
-// AI Gateway 모델 선별은 콘솔 durable state의 terminal 플러그인 네임스페이스에 저장된다
-// (console settings.json → plugins.terminal["ai-gateway"]). 저장 형태는 이 모듈이 보증하고,
-// 카탈로그 대조(모델 존재, 기본 모델 소속)도 카탈로그를 아는 이 계층이 소유한다.
-// 구 카탈로그가 남긴 stale id는 소비 시점에 걸러낸다.
-
-export const AI_GATEWAY_SETTINGS_STORAGE_KEY = "ai-gateway";
+// AI Gateway 모델 선별의 저장 형태·카탈로그 대조·검증은 이 패키지가 소유한다. 카탈로그를 아는
+// 계층만이 "지금 고를 수 있는 모델·강도"를 판정할 수 있기 때문이다. 호스트는 저장 위치와 HTTP
+// 표면만 배선하고, 구 카탈로그가 남긴 stale id는 소비 시점에 여기서 걸러낸다.
 
 /** 저장되는 모델 항목. `efforts` 부재 = 그 모델의 사다리 전체를 정체성으로 내보낸다. */
 export interface AiGatewayStoredModel {
@@ -28,7 +24,7 @@ export interface AiGatewayStoredModel {
   readonly efforts?: readonly string[];
 }
 
-/** `plugins.terminal["ai-gateway"]`에 저장되는 형태. models 부재/공백 = 미구성(노출 없음). */
+/** AI Gateway 설정 파일에 저장되는 형태. models 부재/공백 = 미구성(노출 없음). */
 export interface AiGatewayStoredSettings {
   readonly version: 1;
   readonly models?: readonly AiGatewayStoredModel[];
@@ -36,12 +32,17 @@ export interface AiGatewayStoredSettings {
   /** 부재/false는 기본 Off. 저장 정규형은 opt-in인 true만 보존한다. */
   readonly cursorDiagnosticsEnabled?: boolean;
   /**
-   * 부재는 env(`FLEET_GATEWAY_WIRE_LOG`) 폴백, true/false는 Console이 강제하는 On/Off다.
+   * 부재는 env(`FLEET_GATEWAY_WIRE_LOG`) 폴백, true/false는 호스트가 강제하는 On/Off다.
    * 위 `cursorDiagnosticsEnabled`와 달리 **false를 정규형에서 지우면 안 된다** — env를 켜 둔 설치에서
    * 사용자가 UI로 Off한 뒤 재시작하면 부재가 다시 env 상속으로 읽혀 로깅이 되살아나고,
    * 토글이 꺼지지 않는 결함이 된다.
    */
   readonly wireLogEnabled?: boolean;
+}
+
+export interface AiGatewayUpdateValue {
+  readonly models?: readonly AiGatewayStoredModel[];
+  readonly defaultModel?: string;
 }
 
 export function normalizeAiGatewaySettings(value: unknown): AiGatewayStoredSettings {
@@ -75,77 +76,6 @@ export function normalizeAiGatewaySettings(value: unknown): AiGatewayStoredSetti
     ...(value.cursorDiagnosticsEnabled === true ? { cursorDiagnosticsEnabled: true } : {}),
     ...(typeof value.wireLogEnabled === "boolean" ? { wireLogEnabled: value.wireLogEnabled } : {}),
   };
-}
-
-// 같은 서버 프로세스의 이 모듈 인스턴스에서 read+write만 직렬화한다(agent-cli-paths와 동일 관례).
-let aiGatewaySettingsWriteTail: Promise<void> = Promise.resolve();
-
-export interface AiGatewaySettingsStore {
-  readonly read: () => Promise<AiGatewayStoredSettings>;
-  /** 진단 opt-in은 보존하고 모델 선별만 교체한다. */
-  readonly write: (value: AiGatewayUpdateValue | undefined) => Promise<AiGatewayStoredSettings>;
-  /** 모델 선별은 보존하고 진단 opt-in만 갱신한다. */
-  readonly writeCursorDiagnosticsEnabled: (enabled: boolean) => Promise<AiGatewayStoredSettings>;
-  /** `undefined`는 wireLogEnabled 키를 제거해 env 폴백으로 돌아간다. */
-  readonly writeWireLogEnabled: (enabled: boolean | undefined) => Promise<AiGatewayStoredSettings>;
-}
-
-export interface AiGatewayUpdateValue {
-  readonly models?: readonly AiGatewayStoredModel[];
-  readonly defaultModel?: string;
-}
-
-export function createAiGatewaySettingsStore(storage: FleetPluginStorageHost, pluginId: string): AiGatewaySettingsStore {
-  const read = async (): Promise<AiGatewayStoredSettings> => normalizeAiGatewaySettings(
-    await storage.readJson(pluginId, AI_GATEWAY_SETTINGS_STORAGE_KEY),
-  );
-  return {
-    read,
-    write: (value) => serializeAiGatewaySettingsWrite(async () => {
-      const current = await read();
-      const next = normalizeAiGatewaySettings({
-        version: 1,
-        ...(current.cursorDiagnosticsEnabled === true ? { cursorDiagnosticsEnabled: true } : {}),
-        ...(typeof current.wireLogEnabled === "boolean" ? { wireLogEnabled: current.wireLogEnabled } : {}),
-        ...(value ?? {}),
-      });
-      await storage.writeJson(pluginId, AI_GATEWAY_SETTINGS_STORAGE_KEY, next);
-      return next;
-    }),
-    writeCursorDiagnosticsEnabled: (enabled) => serializeAiGatewaySettingsWrite(async () => {
-      const current = await read();
-      const next = normalizeAiGatewaySettings({
-        ...current,
-        cursorDiagnosticsEnabled: enabled,
-      });
-      await storage.writeJson(pluginId, AI_GATEWAY_SETTINGS_STORAGE_KEY, next);
-      return next;
-    }),
-    writeWireLogEnabled: (enabled) => serializeAiGatewaySettingsWrite(async () => {
-      const current = await read();
-      const next = normalizeAiGatewaySettings({
-        ...current,
-        ...(enabled === undefined ? {} : { wireLogEnabled: enabled }),
-      });
-      if (enabled === undefined) {
-        const withoutWireLog = { ...next } as { wireLogEnabled?: boolean };
-        delete withoutWireLog.wireLogEnabled;
-        await storage.writeJson(pluginId, AI_GATEWAY_SETTINGS_STORAGE_KEY, withoutWireLog);
-        return withoutWireLog as AiGatewayStoredSettings;
-      }
-      await storage.writeJson(pluginId, AI_GATEWAY_SETTINGS_STORAGE_KEY, next);
-      return next;
-    }),
-  };
-}
-
-function serializeAiGatewaySettingsWrite<T>(write: () => Promise<T>): Promise<T> {
-  const result = aiGatewaySettingsWriteTail.then(write);
-  aiGatewaySettingsWriteTail = result.then(
-    () => undefined,
-    () => undefined,
-  );
-  return result;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/core-ai-gateway/src/settings/store.ts
+++ b/packages/core-ai-gateway/src/settings/store.ts
@@ -1,0 +1,180 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { createDurableJsonStore, getFleetDataDir } from "@dotobokuri/core-infra";
+
+import {
+  normalizeAiGatewaySettings,
+  type AiGatewayStoredSettings,
+  type AiGatewayUpdateValue,
+} from "./index.js";
+
+// AI Gateway 설정은 Fleet 데이터 루트의 단일 파일(`<dataDir>/ai-gateway.json`)이 소유한다.
+// 전역 옵션(`settings.json`)과 같은 축이라 호스트·채널이 달라도 한 벌만 존재한다.
+
+const AI_GATEWAY_SETTINGS_FILE_NAME = "ai-gateway.json";
+const LOCK_DIR_NAME = `${AI_GATEWAY_SETTINGS_FILE_NAME}.lock`;
+const LOCK_OWNER_FILE_NAME = "owner";
+// 고아 temp 파일 정리 prefix. writeAtomicSync은 `<파일명>.<pid>.<ts>.<rand>.<host>.tmp`로 쓰므로
+// 접두는 파일명 뒤에 점을 붙인 형태여야 한다. 같은 접두의 락 디렉터리(`ai-gateway.json.lock`)도
+// 걸리지만 cleanupTempFiles는 일반 파일만 지우므로 디렉터리인 락은 건드리지 않는다.
+const TEMP_FILE_PREFIX = `${AI_GATEWAY_SETTINGS_FILE_NAME}.`;
+
+export interface AiGatewaySettingsStore {
+  readonly path: string;
+  readonly read: () => AiGatewayStoredSettings;
+  /** 진단 opt-in은 보존하고 모델 선별만 교체한다. */
+  readonly write: (value: AiGatewayUpdateValue | undefined) => AiGatewayStoredSettings;
+  /** 모델 선별은 보존하고 진단 opt-in만 갱신한다. */
+  readonly writeCursorDiagnosticsEnabled: (enabled: boolean) => AiGatewayStoredSettings;
+  /** `undefined`는 wireLogEnabled 키를 제거해 env 폴백으로 돌아간다. */
+  readonly writeWireLogEnabled: (enabled: boolean | undefined) => AiGatewayStoredSettings;
+}
+
+export interface CreateAiGatewaySettingsStoreDeps {
+  /** Fleet 데이터 루트. 호스트가 자기 유효 루트를 넘긴다. 기본값은 `~/.fleet`. */
+  readonly dataDir?: string;
+  /**
+   * 이 설정이 예전에 살던 호스트 소유 디렉터리. 그 안의 `ai-gateway.json`을 한 번만
+   * 승계한다. 부재는 "승계할 과거가 없다"는 뜻이고, 승계 자체가 일어나지 않는다.
+   * 호스트가 자기 환경(published / local 등)에 맞는 경로를 넘기므로 이 패키지는
+   * 어떤 호스트 경로도 알지 못한다.
+   */
+  readonly legacyDir?: string;
+  readonly now?: () => number;
+  readonly staleLockMs?: number;
+  readonly timeoutMs?: number;
+}
+
+export function createAiGatewaySettingsStore(
+  deps: CreateAiGatewaySettingsStoreDeps = {},
+): AiGatewaySettingsStore {
+  const dataDir = deps.dataDir ?? getFleetDataDir();
+  const settingsPath = path.join(dataDir, AI_GATEWAY_SETTINGS_FILE_NAME);
+  const legacyPath = deps.legacyDir === undefined
+    ? undefined
+    : path.join(deps.legacyDir, AI_GATEWAY_SETTINGS_FILE_NAME);
+
+  const store = createDurableJsonStore<AiGatewayStoredSettings>({
+    filePath: settingsPath,
+    lockDir: path.join(dataDir, LOCK_DIR_NAME),
+    lockOwnerFileName: LOCK_OWNER_FILE_NAME,
+    sanitize: (value) => normalizeAiGatewaySettings(value),
+    sensitivity: "sensitive",
+    timeoutMs: deps.timeoutMs,
+    staleLockMs: deps.staleLockMs,
+    tempCleanupPrefix: TEMP_FILE_PREFIX,
+    now: deps.now,
+  });
+
+  // 과거 파일 조사는 프로세스당 한 번이면 충분하지만, **결론이 났을 때만** 한 번으로 끝난다.
+  // 일시적 I/O 실패를 "승계할 것 없음"으로 굳히면 그 뒤의 어떤 쓰기든 목적지 파일을 만들어
+  // 승계를 영구히 막아버린다 — 사용자 선별이 조용히 사라지는 경로다.
+  let carriedOver: AiGatewayStoredSettings | undefined;
+  let probeSettled = legacyPath === undefined;
+
+  const probeLegacySettings = (): void => {
+    if (probeSettled) return;
+    const probe = readLegacySettings(legacyPath!);
+    // 결론 보류 — 다음 접근이 다시 조사한다.
+    if (probe.kind === "unavailable") return;
+    carriedOver = probe.kind === "adopt" ? probe.settings : undefined;
+    probeSettled = true;
+  };
+
+  /**
+   * 잠금 안에서 이번 갱신의 시작점을 정한다. 목적지에 파일이 이미 있으면 그쪽이 사실이다 —
+   * 사용자가 선별을 비운 상태와 "아직 승계 전"을 구분할 수 있는 건 파일 존재 여부뿐이라,
+   * 정규형이 비었는지로 판정하면 의도적으로 비운 선택을 과거 값으로 되살리게 된다.
+   */
+  const adoptedBase = (current: AiGatewayStoredSettings): AiGatewayStoredSettings => (
+    carriedOver && !fileExists(settingsPath) ? carriedOver : current
+  );
+
+  // 승계와 요청된 갱신을 같은 잠금 안에서 끝낸다. 둘을 나누면 승계가 실패한 직후의 부분 갱신이
+  // 목적지 파일을 먼저 만들어, 아직 옮기지 못한 선별을 영영 고아로 만든다.
+  const update = (
+    mutate: (current: AiGatewayStoredSettings) => AiGatewayStoredSettings,
+  ): AiGatewayStoredSettings => {
+    probeLegacySettings();
+    return store.update((current) => mutate(adoptedBase(current)));
+  };
+
+  return {
+    path: settingsPath,
+    read: () => {
+      probeLegacySettings();
+      if (carriedOver && !fileExists(settingsPath)) {
+        try {
+          store.update(adoptedBase);
+        } catch {
+          // 락 경합·쓰기 실패는 결론이 아니다. 이번 읽기는 미구성으로 답하고 다음 접근이 다시 시도한다.
+        }
+      }
+      return store.load();
+    },
+    write: (value) => update((current) => normalizeAiGatewaySettings({
+      version: 1,
+      ...(current.cursorDiagnosticsEnabled === true ? { cursorDiagnosticsEnabled: true } : {}),
+      ...(typeof current.wireLogEnabled === "boolean" ? { wireLogEnabled: current.wireLogEnabled } : {}),
+      ...(value ?? {}),
+    })),
+    writeCursorDiagnosticsEnabled: (enabled) => update((current) => normalizeAiGatewaySettings({
+      ...current,
+      cursorDiagnosticsEnabled: enabled,
+    })),
+    writeWireLogEnabled: (enabled) => update((current) => {
+      const next = normalizeAiGatewaySettings({
+        ...current,
+        ...(enabled === undefined ? {} : { wireLogEnabled: enabled }),
+      });
+      if (enabled !== undefined) return next;
+      const withoutWireLog = { ...next } as { wireLogEnabled?: boolean };
+      delete withoutWireLog.wireLogEnabled;
+      return withoutWireLog as AiGatewayStoredSettings;
+    }),
+  };
+}
+
+function fileExists(filePath: string): boolean {
+  try {
+    return fs.lstatSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+type LegacyProbe =
+  /** 옮길 값이 있다. */
+  | { readonly kind: "adopt"; readonly settings: AiGatewayStoredSettings }
+  /** 부재하거나 손상됐거나 비어 있다 — 옮길 것이 없다는 결론. */
+  | { readonly kind: "nothing" }
+  /** 읽지 못했다. 결론이 아니므로 다음 접근이 다시 조사해야 한다. */
+  | { readonly kind: "unavailable" };
+
+function readLegacySettings(legacyPath: string): LegacyProbe {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(legacyPath, "utf-8");
+  } catch (error) {
+    // 없는 파일은 결론이지만, 권한·I/O 실패는 결론이 아니다.
+    return (error as NodeJS.ErrnoException).code === "ENOENT"
+      ? { kind: "nothing" }
+      : { kind: "unavailable" };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    return { kind: "nothing" };
+  }
+  const settings = normalizeAiGatewaySettings(parsed);
+  return hasStoredValue(settings) ? { kind: "adopt", settings } : { kind: "nothing" };
+}
+
+function hasStoredValue(settings: AiGatewayStoredSettings): boolean {
+  return (settings.models?.length ?? 0) > 0
+    || settings.defaultModel !== undefined
+    || settings.cursorDiagnosticsEnabled !== undefined
+    || settings.wireLogEnabled !== undefined;
+}

--- a/packages/core-ai-gateway/src/settings/store.ts
+++ b/packages/core-ai-gateway/src/settings/store.ts
@@ -93,10 +93,22 @@ export function createAiGatewaySettingsStore(
 
   // 승계와 요청된 갱신을 같은 잠금 안에서 끝낸다. 둘을 나누면 승계가 실패한 직후의 부분 갱신이
   // 목적지 파일을 먼저 만들어, 아직 옮기지 못한 선별을 영영 고아로 만든다.
+  //
+  // 과거 파일을 아직 **읽지 못한** 상태에서도 같은 일이 벌어진다. 목적지 파일이 생기는 순간
+  // 그것이 "승계 끝"의 유일한 표식이 되므로, 조사에 결론이 나기 전에는 쓰지 않고 거절한다.
+  // 조용히 잃는 것보다 실패를 보이는 편이 낫다 — 저장은 다시 시도할 수 있지만 사라진 선별은
+  // 되돌릴 수 없다. 되돌아오지 못할 상태(디렉터리·심링크 루프 등)는 애초에 `nothing`으로
+  // 결론지으므로, 이 거절이 영구히 설정 저장을 막는 상태로 굳지 않는다.
   const update = (
     mutate: (current: AiGatewayStoredSettings) => AiGatewayStoredSettings,
   ): AiGatewayStoredSettings => {
     probeLegacySettings();
+    if (!probeSettled) {
+      throw new Error(
+        `AI Gateway settings were not written: the previous settings file at ${legacyPath!} could not be read, `
+        + "and writing now would strand it. Make that file readable or remove it, then retry.",
+      );
+    }
     return store.update((current) => mutate(adoptedBase(current)));
   };
 
@@ -152,13 +164,20 @@ type LegacyProbe =
   /** 읽지 못했다. 결론이 아니므로 다음 접근이 다시 조사해야 한다. */
   | { readonly kind: "unavailable" };
 
+/**
+ * 다시 읽어도 결과가 달라지지 않는 실패들. 그 자리에 읽을 수 있는 과거 파일이 **없다**는
+ * 결론이므로 재시도 대상이 아니다. 이걸 `unavailable`로 두면 승계를 기다리느라 설정 저장이
+ * 영구히 막히는데, 그건 원래 막으려던 손실보다 나쁘다.
+ */
+const CONCLUSIVE_LEGACY_READ_ERRORS = new Set(["ENOENT", "EISDIR", "ENOTDIR", "ELOOP", "ENAMETOOLONG"]);
+
 function readLegacySettings(legacyPath: string): LegacyProbe {
   let raw: string;
   try {
     raw = fs.readFileSync(legacyPath, "utf-8");
   } catch (error) {
-    // 없는 파일은 결론이지만, 권한·I/O 실패는 결론이 아니다.
-    return (error as NodeJS.ErrnoException).code === "ENOENT"
+    // 권한·I/O 실패는 결론이 아니다 — 지금 못 읽었을 뿐 값은 그대로 있을 수 있다.
+    return CONCLUSIVE_LEGACY_READ_ERRORS.has((error as NodeJS.ErrnoException).code ?? "")
       ? { kind: "nothing" }
       : { kind: "unavailable" };
   }

--- a/packages/core-ai-gateway/tests/settings/index.test.ts
+++ b/packages/core-ai-gateway/tests/settings/index.test.ts
@@ -1,14 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  AI_GATEWAY_SETTINGS_STORAGE_KEY,
-  createAiGatewaySettingsStore,
   normalizeAiGatewaySettings,
   parseAiGatewayUpdate,
   resolveAiGatewaySelection,
-} from "../server/ai-gateway-settings.js";
+} from "../../src/settings/index.js";
 
-describe("ai-gateway settings store", () => {
+describe("ai-gateway settings", () => {
   it("normalizes malformed stored payloads to an unconfigured slot", () => {
     expect(normalizeAiGatewaySettings(undefined)).toEqual({ version: 1 });
     expect(normalizeAiGatewaySettings("everything")).toEqual({ version: 1 });
@@ -39,60 +37,6 @@ describe("ai-gateway settings store", () => {
       version: 1,
       cursorDiagnosticsEnabled: false,
     })).toEqual({ version: 1 });
-  });
-
-  it("persists under the terminal plugin storage slot", async () => {
-    const written: Record<string, unknown> = {};
-    const store = createAiGatewaySettingsStore({
-      readJson: async (_pluginId: string, key: string) => written[key],
-      writeJson: async (_pluginId: string, key: string, value: unknown) => { written[key] = value; },
-    } as never, "terminal");
-
-    expect(await store.read()).toEqual({ version: 1 });
-    await store.write({ models: [{ id: "cursor--claude-opus-5" }], defaultModel: "cursor--claude-opus-5" });
-    expect(written[AI_GATEWAY_SETTINGS_STORAGE_KEY]).toEqual({
-      version: 1,
-      models: [{ id: "cursor--claude-opus-5" }],
-      defaultModel: "cursor--claude-opus-5",
-    });
-    await store.writeCursorDiagnosticsEnabled(true);
-    expect(await store.read()).toEqual({
-      version: 1,
-      models: [{ id: "cursor--claude-opus-5" }],
-      defaultModel: "cursor--claude-opus-5",
-      cursorDiagnosticsEnabled: true,
-    });
-    await store.write({ models: [{ id: "cursor--auto" }] });
-    expect(await store.read()).toEqual({
-      version: 1,
-      models: [{ id: "cursor--auto" }],
-      cursorDiagnosticsEnabled: true,
-    });
-    await store.write(undefined);
-    expect(await store.read()).toEqual({
-      version: 1,
-      cursorDiagnosticsEnabled: true,
-    });
-    await store.writeCursorDiagnosticsEnabled(false);
-    expect(await store.read()).toEqual({ version: 1 });
-
-    await store.writeWireLogEnabled(false);
-    expect(await store.read()).toEqual({ version: 1, wireLogEnabled: false });
-    await store.write({ models: [{ id: "cursor--auto" }] });
-    expect(await store.read()).toEqual({ version: 1, models: [{ id: "cursor--auto" }], wireLogEnabled: false });
-    await store.writeCursorDiagnosticsEnabled(true);
-    expect(await store.read()).toEqual({
-      version: 1,
-      models: [{ id: "cursor--auto" }],
-      cursorDiagnosticsEnabled: true,
-      wireLogEnabled: false,
-    });
-    await store.writeWireLogEnabled(undefined);
-    expect(await store.read()).toEqual({
-      version: 1,
-      models: [{ id: "cursor--auto" }],
-      cursorDiagnosticsEnabled: true,
-    });
   });
 
   it("drops a stored effort the catalog no longer offers instead of echoing it back", () => {

--- a/packages/core-ai-gateway/tests/settings/store.test.ts
+++ b/packages/core-ai-gateway/tests/settings/store.test.ts
@@ -1,4 +1,13 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -221,6 +230,49 @@ describe("ai-gateway settings store", () => {
       models: [{ id: "cursor--auto" }],
       cursorDiagnosticsEnabled: true,
     });
+  });
+
+  it("refuses to write while the previous file exists but cannot be read yet", () => {
+    const dataDir = createDataDir();
+    const legacyDir = seedLegacySettings(dataDir, { version: 1, models: [{ id: "cursor--auto" }] });
+    const legacyFile = path.join(legacyDir, "ai-gateway.json");
+    chmodSync(legacyFile, 0o000);
+    // root는 권한 검사를 우회해 EACCES가 나지 않는다. 그 환경에서는 이 경로를 재현할 수 없다.
+    let readable = true;
+    try {
+      readFileSync(legacyFile, "utf-8");
+    } catch {
+      readable = false;
+    }
+    if (readable) return;
+
+    const store = createAiGatewaySettingsStore({ dataDir, legacyDir });
+    // 읽기는 관대하다 — 미구성으로 답하되 목적지 파일을 만들어 결론을 굳히지 않는다.
+    expect(store.read()).toEqual({ version: 1 });
+    expect(existsSync(store.path)).toBe(false);
+    // 쓰기는 거절한다. 여기서 파일이 생기면 그 순간 과거 선별이 영영 고아가 된다.
+    expect(() => store.writeCursorDiagnosticsEnabled(true)).toThrow(/could not be read/);
+    expect(existsSync(store.path)).toBe(false);
+
+    chmodSync(legacyFile, 0o644);
+    store.writeCursorDiagnosticsEnabled(true);
+    expect(store.read()).toEqual({
+      version: 1,
+      models: [{ id: "cursor--auto" }],
+      cursorDiagnosticsEnabled: true,
+    });
+  });
+
+  it("does not wedge writes when the previous path can never yield a file", () => {
+    const dataDir = createDataDir();
+    // 그 자리에 디렉터리가 있으면 다시 읽어도 결과가 같다. 승계를 기다리며 저장을 영구히
+    // 막는 것은 원래 막으려던 손실보다 나쁘므로, 결론(`nothing`)으로 접고 진행해야 한다.
+    const legacyDir = path.join(dataDir, "console", "plugins", "terminal");
+    mkdirSync(path.join(legacyDir, "ai-gateway.json"), { recursive: true });
+    const store = createAiGatewaySettingsStore({ dataDir, legacyDir });
+
+    store.writeCursorDiagnosticsEnabled(true);
+    expect(store.read()).toEqual({ version: 1, cursorDiagnosticsEnabled: true });
   });
 
   it("cleans up its own orphaned temp files", () => {

--- a/packages/core-ai-gateway/tests/settings/store.test.ts
+++ b/packages/core-ai-gateway/tests/settings/store.test.ts
@@ -1,0 +1,242 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createAiGatewaySettingsStore } from "../../src/settings/store.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  while (temporaryDirectories.length > 0) {
+    rmSync(temporaryDirectories.pop()!, { recursive: true, force: true });
+  }
+});
+
+/** 격리된 Fleet 데이터 루트. 실 사용자 홈(`~/.fleet`)을 절대 건드리지 않게 항상 주입한다. */
+function createDataDir(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "fleet-ai-gateway-"));
+  temporaryDirectories.push(dir);
+  return dir;
+}
+
+/** 이 설정이 예전에 살던 호스트 디렉터리를 흉내낸다. 그 시절 파일은 compact JSON이었다. */
+function seedLegacySettings(root: string, value: unknown): string {
+  const legacyDir = path.join(root, "console", "plugins", "terminal");
+  mkdirSync(legacyDir, { recursive: true });
+  writeFileSync(path.join(legacyDir, "ai-gateway.json"), JSON.stringify(value), "utf-8");
+  return legacyDir;
+}
+
+describe("ai-gateway settings store", () => {
+  it("persists as a single file in the Fleet data root", () => {
+    const dataDir = createDataDir();
+    const store = createAiGatewaySettingsStore({ dataDir });
+
+    expect(store.path).toBe(path.join(dataDir, "ai-gateway.json"));
+    expect(store.read()).toEqual({ version: 1 });
+    // 읽기만으로는 파일이 생기지 않는다 — 미구성과 "빈 설정을 저장함"은 다른 상태다.
+    expect(existsSync(store.path)).toBe(false);
+
+    store.write({ models: [{ id: "cursor--claude-opus-5" }], defaultModel: "cursor--claude-opus-5" });
+    expect(JSON.parse(readFileSync(store.path, "utf-8"))).toEqual({
+      version: 1,
+      models: [{ id: "cursor--claude-opus-5" }],
+      defaultModel: "cursor--claude-opus-5",
+    });
+  });
+
+  it("keeps each setting axis independent across writes", () => {
+    const store = createAiGatewaySettingsStore({ dataDir: createDataDir() });
+
+    store.write({ models: [{ id: "cursor--claude-opus-5" }], defaultModel: "cursor--claude-opus-5" });
+    store.writeCursorDiagnosticsEnabled(true);
+    expect(store.read()).toEqual({
+      version: 1,
+      models: [{ id: "cursor--claude-opus-5" }],
+      defaultModel: "cursor--claude-opus-5",
+      cursorDiagnosticsEnabled: true,
+    });
+    store.write({ models: [{ id: "cursor--auto" }] });
+    expect(store.read()).toEqual({
+      version: 1,
+      models: [{ id: "cursor--auto" }],
+      cursorDiagnosticsEnabled: true,
+    });
+    store.write(undefined);
+    expect(store.read()).toEqual({ version: 1, cursorDiagnosticsEnabled: true });
+    store.writeCursorDiagnosticsEnabled(false);
+    expect(store.read()).toEqual({ version: 1 });
+
+    store.writeWireLogEnabled(false);
+    expect(store.read()).toEqual({ version: 1, wireLogEnabled: false });
+    store.write({ models: [{ id: "cursor--auto" }] });
+    expect(store.read()).toEqual({ version: 1, models: [{ id: "cursor--auto" }], wireLogEnabled: false });
+    store.writeCursorDiagnosticsEnabled(true);
+    expect(store.read()).toEqual({
+      version: 1,
+      models: [{ id: "cursor--auto" }],
+      cursorDiagnosticsEnabled: true,
+      wireLogEnabled: false,
+    });
+    store.writeWireLogEnabled(undefined);
+    expect(store.read()).toEqual({
+      version: 1,
+      models: [{ id: "cursor--auto" }],
+      cursorDiagnosticsEnabled: true,
+    });
+  });
+
+  it("adopts the settings from the host directory it is given, without announcing it", () => {
+    const dataDir = createDataDir();
+    const legacyDir = seedLegacySettings(dataDir, {
+      version: 1,
+      models: [{ id: "kimi--k3", efforts: ["max"] }, { id: "cursor--auto" }],
+      defaultModel: "cursor--auto",
+      wireLogEnabled: false,
+    });
+    const store = createAiGatewaySettingsStore({ dataDir, legacyDir });
+
+    expect(store.read()).toEqual({
+      version: 1,
+      models: [{ id: "kimi--k3", efforts: ["max"] }, { id: "cursor--auto" }],
+      defaultModel: "cursor--auto",
+      wireLogEnabled: false,
+    });
+    // 승계는 새 축에 실제로 안착해야 한다 — 매 부팅 과거 파일을 다시 읽는 상태로 남으면 안 된다.
+    expect(existsSync(store.path)).toBe(true);
+    // 과거 파일은 지우지 않는다. 예전 호스트로 되돌아가는 경로를 파괴하지 않기 위해서다.
+    expect(existsSync(path.join(legacyDir, "ai-gateway.json"))).toBe(true);
+  });
+
+  it("performs no adoption when no host directory is given", () => {
+    const dataDir = createDataDir();
+    seedLegacySettings(dataDir, { version: 1, models: [{ id: "cursor--auto" }] });
+    const store = createAiGatewaySettingsStore({ dataDir });
+
+    expect(store.read()).toEqual({ version: 1 });
+    expect(existsSync(store.path)).toBe(false);
+  });
+
+  it("never overwrites settings that already exist on the new axis", () => {
+    const dataDir = createDataDir();
+    const legacyDir = seedLegacySettings(dataDir, { version: 1, models: [{ id: "cursor--auto" }] });
+    createAiGatewaySettingsStore({ dataDir }).write({ models: [{ id: "kimi--k3" }] });
+
+    const store = createAiGatewaySettingsStore({ dataDir, legacyDir });
+    expect(store.read()).toEqual({ version: 1, models: [{ id: "kimi--k3" }] });
+  });
+
+  it("treats an emptied selection as a real state rather than something to re-adopt", () => {
+    const dataDir = createDataDir();
+    const legacyDir = seedLegacySettings(dataDir, { version: 1, models: [{ id: "cursor--auto" }] });
+    // 사용자가 전부 지운 상태. 정규형은 승계 전과 구분되지 않으므로 파일 존재로만 판정해야 한다.
+    createAiGatewaySettingsStore({ dataDir }).write(undefined);
+
+    const store = createAiGatewaySettingsStore({ dataDir, legacyDir });
+    expect(store.read()).toEqual({ version: 1 });
+  });
+
+  it("stays unconfigured when the host directory holds nothing usable", () => {
+    for (const seeded of [undefined, "{ not json", { version: 1 }, { version: 9, models: [{ id: "cursor--auto" }] }]) {
+      const dataDir = createDataDir();
+      const legacyDir = path.join(dataDir, "console", "plugins", "terminal");
+      if (seeded !== undefined) {
+        mkdirSync(legacyDir, { recursive: true });
+        writeFileSync(
+          path.join(legacyDir, "ai-gateway.json"),
+          typeof seeded === "string" ? seeded : JSON.stringify(seeded),
+          "utf-8",
+        );
+      }
+      const store = createAiGatewaySettingsStore({ dataDir, legacyDir });
+      expect(store.read()).toEqual({ version: 1 });
+      expect(existsSync(store.path)).toBe(false);
+    }
+  });
+
+  // 승계는 모든 첫 쓰기 경로보다 앞서야 한다. 한 축만 갱신하는 PUT이 먼저 목적지 파일을
+  // 만들어 버리면, 아직 옮기지 못한 나머지 축이 영영 고아가 된다.
+  // `write`는 선별 자체를 교체하는 연산이므로 모델이 바뀌는 게 정상이다. 각 경로가 건드리지
+  // **않는** 축이 승계된 값 그대로인지가 판정 기준이다.
+  it.each([
+    [
+      "write",
+      (store: ReturnType<typeof createAiGatewaySettingsStore>) => store.write({ models: [{ id: "kimi--k3" }] }),
+      { version: 1, models: [{ id: "kimi--k3" }], cursorDiagnosticsEnabled: true },
+    ],
+    [
+      "writeCursorDiagnosticsEnabled",
+      (store: ReturnType<typeof createAiGatewaySettingsStore>) => store.writeCursorDiagnosticsEnabled(false),
+      { version: 1, models: [{ id: "cursor--auto" }], defaultModel: "cursor--auto" },
+    ],
+    [
+      "writeWireLogEnabled",
+      (store: ReturnType<typeof createAiGatewaySettingsStore>) => store.writeWireLogEnabled(true),
+      {
+        version: 1,
+        models: [{ id: "cursor--auto" }],
+        defaultModel: "cursor--auto",
+        cursorDiagnosticsEnabled: true,
+        wireLogEnabled: true,
+      },
+    ],
+  ])("adopts before the first %s so a partial update cannot erase the adopted state", (_name, mutate, expected) => {
+    const dataDir = createDataDir();
+    const legacyDir = seedLegacySettings(dataDir, {
+      version: 1,
+      models: [{ id: "cursor--auto" }],
+      defaultModel: "cursor--auto",
+      cursorDiagnosticsEnabled: true,
+    });
+    const store = createAiGatewaySettingsStore({ dataDir, legacyDir });
+
+    mutate(store);
+    expect(store.read()).toEqual(expected);
+  });
+
+  it("retries adoption after a write it could not complete, instead of settling on the loss", () => {
+    const dataDir = createDataDir();
+    const legacyDir = seedLegacySettings(dataDir, { version: 1, models: [{ id: "cursor--auto" }] });
+    // 다른 프로세스가 락을 쥐고 있는 상태. staleLockMs를 크게 잡아 stale 회수 경로를 배제한다.
+    const lockDir = path.join(dataDir, "ai-gateway.json.lock");
+    mkdirSync(lockDir, { recursive: true });
+    const store = createAiGatewaySettingsStore({
+      dataDir,
+      legacyDir,
+      timeoutMs: 50,
+      staleLockMs: 10 * 60 * 1000,
+    });
+
+    // 승계가 실패한다. 조용히 미구성으로 답하되, 목적지 파일을 만들어 결론을 굳혀선 안 된다.
+    expect(store.read()).toEqual({ version: 1 });
+    expect(existsSync(store.path)).toBe(false);
+
+    rmSync(lockDir, { recursive: true, force: true });
+    // 락이 풀린 뒤 한 축만 갱신해도 승계가 먼저 일어나야 한다.
+    store.writeCursorDiagnosticsEnabled(true);
+    expect(store.read()).toEqual({
+      version: 1,
+      models: [{ id: "cursor--auto" }],
+      cursorDiagnosticsEnabled: true,
+    });
+  });
+
+  it("cleans up its own orphaned temp files", () => {
+    const dataDir = createDataDir();
+    const store = createAiGatewaySettingsStore({ dataDir });
+    store.write({ models: [{ id: "cursor--auto" }] });
+    // writeAtomicSync이 실제로 만드는 이름은 `<파일명>.<pid>.<ts>.<rand>.<host>.tmp`다.
+    // 정리 접두가 그 규약과 어긋나면 고아 temp가 영원히 쌓인다.
+    const orphan = `${store.path}.999.1.abc.host.tmp`;
+    writeFileSync(orphan, "{}", "utf-8");
+    utimesSync(orphan, new Date(0), new Date(0));
+
+    store.writeCursorDiagnosticsEnabled(true);
+
+    expect(existsSync(orphan)).toBe(false);
+    // 같은 접두를 가진 락 디렉터리는 파일이 아니므로 정리 대상이 아니다.
+    expect(store.read().cursorDiagnosticsEnabled).toBe(true);
+  });
+});

--- a/packages/core-infra/tests/data-dir-settings-store.test.ts
+++ b/packages/core-infra/tests/data-dir-settings-store.test.ts
@@ -133,7 +133,7 @@ describe("data-dir settings store", () => {
   });
 
   it("drops the relocated aiGateway key from global options", () => {
-    // AI Gateway 선별은 콘솔 durable state(plugins.terminal["ai-gateway"])로 이전됐다.
+    // AI Gateway 선별은 core-ai-gateway가 소유하는 별도 파일(`<dataDir>/ai-gateway.json`)로 이전됐다.
     expect(sanitizeGlobalOptionsData({
       version: 1,
       aiGateway: { models: [{ id: "cursor--claude-opus-5" }] },

--- a/packages/fleet-admiral/src/agent-cli/gateway-agents.ts
+++ b/packages/fleet-admiral/src/agent-cli/gateway-agents.ts
@@ -13,6 +13,7 @@
 import {
   buildGatewayModelConstraints,
   toClaudeGatewayModelId,
+  type GatewayEffortExposure,
   type GatewayModel,
   type GatewayReasoningEffort,
 } from "@dotobokuri/core-ai-gateway";
@@ -53,13 +54,14 @@ export type ClaudeCustomAgents = Readonly<Record<string, ClaudeCustomAgentDefini
 
 /**
  * Scoped gateway 모델 id(`kimi--k3-256k`) → 사용자가 정체성으로 내보낸 강도들.
- * 항목이 없으면 그 모델의 사다리 전체를 뜻한다.
+ * 항목이 없으면 그 모델의 사다리 전체를 뜻한다. 정의는 선별을 소유하는
+ * core-ai-gateway가 갖고, 여기서는 Agent 조립 어휘로 다시 내보내기만 한다.
  *
  * 이 좁히기는 **정체성 등록에만** 적용된다. 디스커버리(`/v1/models`)가 광고하는
  * 사다리는 그대로 두는데, 요청 강도를 카탈로그보다 좁게 강제하면 클램프가 요청
  * 이하로만 내려가는 성질 때문에 최상단만 남긴 모델이 일반 세션을 400으로 막는다.
  */
-export type GatewayEffortExposure = Readonly<Record<string, readonly GatewayReasoningEffort[]>>;
+export type { GatewayEffortExposure } from "@dotobokuri/core-ai-gateway";
 
 /**
  * 사용자가 고른 강도만 남긴 사다리. 순서는 카탈로그 사다리를 따른다.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@bufbuild/protobuf':
         specifier: ^2.12.0
         version: 2.13.0
+      '@dotobokuri/core-infra':
+        specifier: workspace:*
+        version: link:../core-infra
       zod:
         specifier: ^4.3.6
         version: 4.4.1

--- a/runtime/fleet-plugins/terminal/routes.ts
+++ b/runtime/fleet-plugins/terminal/routes.ts
@@ -8,15 +8,15 @@ import { createCarrierRegistry, initStore, registerDefaultCarriers } from "@doto
 import { KIMI_AUTH_PROVIDER_ID, OPENCODE_AUTH_PROVIDER_ID } from "@dotobokuri/fleet-admiral";
 import {
   DEFAULT_WIRE_LOG_MAX_BYTES,
+  createAiGatewaySettingsStore,
   setWireLogTarget,
   wireLogEnabled,
 } from "@dotobokuri/core-ai-gateway";
+import type { AiGatewayStoredSettings } from "@dotobokuri/core-ai-gateway";
 
 import { registerAgentRoutes } from "./server/agent.js";
 import { registerAnalysisRoutes } from "./server/agent-api/analysis-routes.js";
 import { AI_GATEWAY_ROUTE_SEGMENT, registerAiGatewayRoutes } from "./server/ai-gateway-routes.js";
-import { createAiGatewaySettingsStore } from "./server/ai-gateway-settings.js";
-import type { AiGatewayStoredSettings } from "./server/ai-gateway-settings.js";
 import { createAgentCliPathStore } from "./server/agent-api/agent-cli-paths.js";
 import { registerCarrierSettingsRoutes } from "./server/carrier-settings-routes.js";
 import { registerGlobalShellRoutes } from "./server/global.js";
@@ -43,11 +43,11 @@ function createWireLogRuntime(ctx: FleetPluginServerContext) {
   };
 }
 
-async function applyStoredWireLog(ctx: FleetPluginServerContext, read: () => Promise<AiGatewayStoredSettings>): Promise<void> {
+function applyStoredWireLog(ctx: FleetPluginServerContext, read: () => AiGatewayStoredSettings): void {
   try {
-    applyWireLog(ctx, (await read()).wireLogEnabled);
+    applyWireLog(ctx, read().wireLogEnabled);
   } catch {
-    // Malformed plugin storage must not prevent the built-in plugin from starting;
+    // Malformed durable settings must not prevent the built-in plugin from starting;
     // fail closed by overriding any env target until a valid setting is available.
     applyWireLog(ctx, false);
   }
@@ -77,11 +77,17 @@ export default definePlugin({
       runtime.terminate(payload.operationId);
     });
     ctx.host.lifecycle.registerCleanup(unsubscribeDelete);
-    // AI Gateway 선별은 콘솔 durable state(plugins.terminal["ai-gateway"]) 소유 — Fleet 전역 옵션이 아니다.
+    // AI Gateway 선별의 저장 형태·검증·승계는 core-ai-gateway가 소유한다. 호스트는 이 설정이
+    // 예전에 살던 자기 소유 디렉터리만 알려 주고(플러그인 데이터 슬롯), 그 승계 판단은 하지 않는다.
     // Apply the stored target before registering routes so no request can observe an uninitialized mode.
-    const aiGatewayStore = createAiGatewaySettingsStore(ctx.host.storage, ctx.pluginId);
+    // dataDir는 호스트의 **유효** Fleet 루트다. 생략하면 core가 실제 홈(`~/.fleet`)으로 떨어져,
+    // 격리 루트로 띄운 Console이 사용자의 진짜 설정을 읽고 덮어쓴다.
+    const aiGatewayStore = createAiGatewaySettingsStore({
+      dataDir: ctx.host.paths.fleetDataDir,
+      legacyDir: ctx.host.paths.pluginDataDir(ctx.pluginId),
+    });
     const wireLog = createWireLogRuntime(ctx);
-    await applyStoredWireLog(ctx, aiGatewayStore.read);
+    applyStoredWireLog(ctx, aiGatewayStore.read);
     ctx.host.lifecycle.registerCleanup(() => setWireLogTarget(undefined));
     registerShellRoutes(ctx, runtime);
     registerGlobalShellRoutes(ctx, runtime);

--- a/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
@@ -6,8 +6,13 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 import { resolvePathBinary } from "@dotobokuri/core-agent";
-import { GATEWAY_MODELS, buildAnthropicModelList, toClaudeGatewayModelId } from "@dotobokuri/core-ai-gateway";
-import type { GatewayModel } from "@dotobokuri/core-ai-gateway";
+import {
+  GATEWAY_MODELS,
+  buildAnthropicModelList,
+  resolveAiGatewaySelection,
+  toClaudeGatewayModelId,
+} from "@dotobokuri/core-ai-gateway";
+import type { AiGatewaySelection, AiGatewayStoredSettings, GatewayModel } from "@dotobokuri/core-ai-gateway";
 import { createSessionIdentityResolver } from "@dotobokuri/core-unified-agent";
 import {
   createSessionCaptureHookExec,
@@ -26,7 +31,6 @@ import {
 } from "@dotobokuri/core-infra";
 
 import { buildConsoleAttentionHookCommand, buildConsoleAutoNameHookCommand, buildConsoleBackgroundHookCommand, buildConsoleCaptureHookCommand, buildConsoleTurnHookCommand, toCaptureProvider, withConsoleMarketplaceLock, type ConsoleHookCommandEntry } from "./host-hooks.js";
-import { resolveAiGatewaySelection, type AiGatewaySelection, type AiGatewayStoredSettings } from "../ai-gateway-settings.js";
 import type { TerminalLaunchContext, TerminalLaunchSpec } from "../shared/terminal-types.js";
 import { stripConsoleInternalEnv } from "../shared/launch-env.js";
 import { applyAgentCliPathEnvOverlay } from "./agent-cli-paths.js";
@@ -56,7 +60,7 @@ export interface TerminalLaunchResolverDeps {
   readonly resolveProfile?: typeof resolveAgentCliProfile;
   readonly createSessionIdentityResolver?: typeof createSessionIdentityResolver;
   readonly readAgentCliPaths?: () => Promise<Readonly<Record<string, string>>>;
-  readonly readAiGatewaySettings?: () => Promise<AiGatewayStoredSettings>;
+  readonly readAiGatewaySettings?: () => AiGatewayStoredSettings;
 }
 
 export interface ConsoleRuntimeSessionInfo {
@@ -155,7 +159,7 @@ function hasHookEntryExtension(entryPath: string): boolean {
 async function createAgentCliLaunchSpec(options: {
   readonly agentRuntime?: FleetAgentRuntimeLifecycle;
   readonly aiGateway?: AiGatewayLaunchBinding;
-  readonly readAiGatewaySettings?: () => Promise<AiGatewayStoredSettings>;
+  readonly readAiGatewaySettings?: () => AiGatewayStoredSettings;
   readonly cliId?: string;
   readonly createSessionCaptureHookExec: typeof createSessionCaptureHookExec;
   readonly createSessionIdentityResolver: typeof createSessionIdentityResolver;
@@ -185,7 +189,7 @@ async function createAgentCliLaunchSpec(options: {
     // gateway Agent 주입과 ANTHROPIC_MODEL/cache는 같은 selection을 공유한다.
     // inject보다 먼저 읽어 `--agents`에 노출 모델×effort를 스폰 인자로만 실는다.
     const gatewaySelection = profile.id === "claude-gateway" && options.readAiGatewaySettings
-      ? resolveAiGatewaySelection(await options.readAiGatewaySettings())
+      ? resolveAiGatewaySelection(options.readAiGatewaySettings())
       : undefined;
     const injectedProfile = await options.injectProfile(profile, {
       buildSystemPrompt: (injectTone) => options.createSystemPromptBuilder({ carrierRuntime: agentRuntime.carrierRuntime }).build(injectTone),

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -19,9 +19,9 @@ import { combineAgentCliLaunchMetadata, type AgentCliLaunchMetadata } from "./ag
 import { AGENT_CLI_COMMANDS, createAgentCliPathStore, createCarrierAgentCliLaunchResolver, resolveAgentCliBinary } from "./agent-api/agent-cli-paths.js";
 import type { AgentCliDiagnostics } from "./agent-api/agent-cli-types.js";
 import { readConsoleQuotaSnapshot } from "./agent-api/gateway-loadout.js";
-import { resolveAiGatewaySelection } from "./ai-gateway-settings.js";
+import { resolveAiGatewaySelection } from "@dotobokuri/core-ai-gateway";
+import type { AiGatewayStoredSettings } from "@dotobokuri/core-ai-gateway";
 import type { AiGatewayLaunchBinding } from "./agent-api/launch.js";
-import type { AiGatewayStoredSettings } from "./ai-gateway-settings.js";
 import { deriveOperationLabel } from "./agent-api/auto-name.js";
 import { normalizeAttentionReason } from "./agent-api/attention-hook.js";
 import { createAgentTerminalLaunchResolver, type ConsoleRuntimeSessionInfo } from "./agent-api/launch.js";
@@ -48,7 +48,7 @@ type OperationRenamedEvent = {
 interface AgentRouteDeps {
   readonly globalOptionsService: GlobalOptionsService;
   readonly aiGateway?: AiGatewayLaunchBinding;
-  readonly readAiGatewaySettings?: () => Promise<AiGatewayStoredSettings>;
+  readonly readAiGatewaySettings?: () => AiGatewayStoredSettings;
 }
 
 const AGENT_OPERATION_TYPE = "agent";
@@ -87,8 +87,8 @@ function buildGatewayLoadoutTools(deps: AgentRouteDeps): readonly AgentToolSpec[
   if (!readAiGatewaySettings) return [];
   const aiGateway = deps.aiGateway;
   return [buildGatewayModelsToolSpec({
-    readSelection: async () => {
-      const selection = resolveAiGatewaySelection(await readAiGatewaySettings());
+    readSelection: () => {
+      const selection = resolveAiGatewaySelection(readAiGatewaySettings());
       return {
         models: selection.models,
         effortExposure: selection.effortExposure,

--- a/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/ai-gateway-routes.ts
@@ -18,12 +18,14 @@ import {
   kimiAnthropicHeaders,
   kimiRequestBody,
   pruneClaudeSkillPayloads,
+  resolveAiGatewaySelection,
   resolveCodexCredentials,
   resolveCursorCredentials,
   toClaudeGatewayModelId,
   upstreamModelId,
 } from "@dotobokuri/core-ai-gateway";
 import type {
+  AiGatewayStoredSettings,
   AnthropicMessagesRequest,
   CursorDiagnosticSink,
   GatewayModel,
@@ -47,7 +49,6 @@ import {
   writeSseErrorFrame,
   type GatewayProxyResponse,
 } from "./ai-gateway-proxy.js";
-import { resolveAiGatewaySelection, type AiGatewayStoredSettings } from "./ai-gateway-settings.js";
 
 export { OPENCODE_GO_MESSAGES_URL as OPENCODE_MESSAGES_URL } from "@dotobokuri/core-ai-gateway";
 export { KIMI_MESSAGES_URL } from "@dotobokuri/core-ai-gateway";
@@ -92,8 +93,8 @@ export async function readCodexSubscriptionAuth(): Promise<CodexSubscriptionAuth
 }
 
 export interface AiGatewayRouteDeps {
-  /** 콘솔 durable state의 노출 모델 선별을 읽는다. 미주입(테스트 하네스)이면 전체 카탈로그를 노출한다. */
-  readonly readAiGatewaySettings?: () => Promise<AiGatewayStoredSettings>;
+  /** core-ai-gateway 설정의 노출 모델 선별을 읽는다. 미주입(테스트 하네스)이면 전체 카탈로그를 노출한다. */
+  readonly readAiGatewaySettings?: () => AiGatewayStoredSettings;
   /** 테스트가 upstream을 대체할 수 있도록 주입 가능하게 둔다. */
   readonly gateway?: AnthropicMessagesGateway;
   /** 테스트가 구독 토큰 조회를 대체한다. */
@@ -125,13 +126,13 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps = {}): AiGatewayR
   const withheldSkills = new Set<string>();
   // 설정 리더가 있으면 노출은 opt-in(켠 모델만)이다. 미주입(테스트 하네스 등)일 때만
   // 전체 카탈로그로 동작한다 — Console 배선(routes.ts)은 항상 리더를 주입한다.
-  const gatewaySettings = async (): Promise<AiGatewayStoredSettings | undefined> => (
+  const gatewaySettings = (): AiGatewayStoredSettings | undefined => (
     deps.readAiGatewaySettings ? deps.readAiGatewaySettings() : undefined
   );
-  const cursorDiagnosticsEnabled = async (): Promise<boolean | undefined> => {
+  const cursorDiagnosticsEnabled = (): boolean | undefined => {
     if (!deps.readAiGatewaySettings) return undefined;
     try {
-      return (await deps.readAiGatewaySettings()).cursorDiagnosticsEnabled === true;
+      return deps.readAiGatewaySettings().cursorDiagnosticsEnabled === true;
     } catch {
       // 진단 설정 판독 실패는 모델 요청을 막지 않고 안전한 기본값 Off로 단락한다.
       return false;
@@ -152,7 +153,7 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps = {}): AiGatewayR
         return true;
       }
       res.writeHead(200, { "content-type": "application/json" });
-      const settings = await gatewaySettings();
+      const settings = gatewaySettings();
       res.end(JSON.stringify(buildAnthropicModelList(
         settings ? resolveAiGatewaySelection(settings).models : GATEWAY_MODELS,
       )));
@@ -291,7 +292,7 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps = {}): AiGatewayR
             ? createOpencodeGateway(opencodeGoWire(target) as "responses" | "chat-completions")
             : createGatewayFor(target, chatgptAccountId));
       const diagnosticsEnabled = target.provider === "cursor"
-        ? await cursorDiagnosticsEnabled()
+        ? cursorDiagnosticsEnabled()
         : undefined;
       // The guard runs regardless of the `[1m]` coordinate: a 200000-window Cursor
       // model carries no marker but still needs to be refused before it overflows.

--- a/runtime/fleet-plugins/terminal/server/settings-routes.ts
+++ b/runtime/fleet-plugins/terminal/server/settings-routes.ts
@@ -11,7 +11,7 @@ import {
   type AiGatewaySettingsStore,
   type AiGatewayStoredSettings,
   type AiGatewayUpdateValue,
-} from "./ai-gateway-settings.js";
+} from "@dotobokuri/core-ai-gateway";
 
 interface TerminalSettingsRouteDeps {
   readonly globalOptionsService: GlobalOptionsService;
@@ -54,7 +54,7 @@ export function registerTerminalSettingsRoutes(ctx: FleetPluginServerContext, de
       // 상류 host 게이트(server.ts:423)로 loopback이 보장된다. 플러그인 컨텍스트에는 콘솔 포트가 없다.
       ctx.host.http.writeJson(res, 200, toTerminalSettingsState(
         deps.globalOptionsService.load(),
-        await deps.aiGatewayStore.read(),
+        deps.aiGatewayStore.read(),
         deps.wireLogRuntime.enabled(),
       ));
       return true;
@@ -75,15 +75,15 @@ export function registerTerminalSettingsRoutes(ctx: FleetPluginServerContext, de
         return true;
       }
       if ("aiGateway" in update) {
-        // AI Gateway 선별은 Fleet 전역 옵션이 아니라 콘솔 durable state의 플러그인 슬롯 소유다.
-        const stored = await deps.aiGatewayStore.write(update.aiGateway);
+        // AI Gateway 선별은 Fleet 전역 옵션이 아니라 core-ai-gateway가 소유하는 자기 축이다.
+        const stored = deps.aiGatewayStore.write(update.aiGateway);
         ctx.host.http.writeJson(res, 200, toTerminalSettingsState(
           deps.globalOptionsService.load(), stored, deps.wireLogRuntime.enabled(),
         ));
         return true;
       }
       if ("cursorDiagnosticsEnabled" in update) {
-        const stored = await deps.aiGatewayStore.writeCursorDiagnosticsEnabled(
+        const stored = deps.aiGatewayStore.writeCursorDiagnosticsEnabled(
           update.cursorDiagnosticsEnabled,
         );
         ctx.host.http.writeJson(res, 200, toTerminalSettingsState(
@@ -92,16 +92,16 @@ export function registerTerminalSettingsRoutes(ctx: FleetPluginServerContext, de
         return true;
       }
       if ("wireLogEnabled" in update) {
-        const previous = await deps.aiGatewayStore.read();
+        const previous = deps.aiGatewayStore.read();
         let stored: AiGatewayStoredSettings;
         try {
-          stored = await deps.aiGatewayStore.writeWireLogEnabled(update.wireLogEnabled);
+          stored = deps.aiGatewayStore.writeWireLogEnabled(update.wireLogEnabled);
           deps.wireLogRuntime.apply(stored.wireLogEnabled);
         } catch {
           // Durable state and the live target must move together. Restore the prior raw value
           // when applying the new target fails, including absence for env fallback.
           try {
-            await deps.aiGatewayStore.writeWireLogEnabled(previous.wireLogEnabled);
+            deps.aiGatewayStore.writeWireLogEnabled(previous.wireLogEnabled);
           } catch {
             // Preserve the original 500; the store's writer has already reported the failure.
           }
@@ -115,7 +115,7 @@ export function registerTerminalSettingsRoutes(ctx: FleetPluginServerContext, de
       }
       const updated = deps.globalOptionsService.update((current) => ({ ...current, ...update }));
       ctx.host.http.writeJson(res, 200, toTerminalSettingsState(
-        updated, await deps.aiGatewayStore.read(), deps.wireLogRuntime.enabled(),
+        updated, deps.aiGatewayStore.read(), deps.wireLogRuntime.enabled(),
       ));
       return true;
     }

--- a/runtime/fleet-plugins/terminal/tests/ai-gateway-launch-env.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ai-gateway-launch-env.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { applyAiGatewayEnv } from "../server/agent-api/launch.js";
-import { resolveAiGatewaySelection } from "../server/ai-gateway-settings.js";
+import { resolveAiGatewaySelection } from "@dotobokuri/core-ai-gateway";
 
 const temporaryDirectories: string[] = [];
 

--- a/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ai-gateway-routes.test.ts
@@ -7,6 +7,7 @@ import {
 import type {
   AdapterResponse,
   AiGatewayAdapter,
+  AiGatewayStoredSettings,
   AnthropicMessagesRequest,
   CanonicalResponseRequest,
 } from "@dotobokuri/core-ai-gateway";
@@ -21,10 +22,9 @@ import {
   createAiGatewayRouter,
   registerAiGatewayRoutes,
 } from "../server/ai-gateway-routes.js";
-import type { AiGatewayStoredSettings } from "../server/ai-gateway-settings.js";
 
-function aiGatewaySettingsStub(settings: AiGatewayStoredSettings): () => Promise<AiGatewayStoredSettings> {
-  return () => Promise.resolve(settings);
+function aiGatewaySettingsStub(settings: AiGatewayStoredSettings): () => AiGatewayStoredSettings {
+  return () => settings;
 }
 
 const BASE = "/plugins/terminal/ai-gateway";
@@ -301,7 +301,7 @@ describe("upstream credential", () => {
     const streamSpy = vi.spyOn(gateway, "stream");
     const router = createAiGatewayRouter({
       gateway,
-      readAiGatewaySettings: async () => { throw new Error("settings unavailable"); },
+      readAiGatewaySettings: () => { throw new Error("settings unavailable"); },
       readAuth,
       readCursorToken: () => "cursor-subscription-token",
     });

--- a/runtime/fleet-plugins/terminal/tests/ai-gateway-store-wiring.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ai-gateway-store-wiring.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+// AI Gateway 설정의 저장 축은 core-ai-gateway가 소유하고, 이 플러그인은 **경로만** 넘긴다.
+// 그 주입이 빠져도 코드는 컴파일되고 테스트도 전부 통과한다 — core가 실제 홈(`~/.fleet`)으로
+// 조용히 폴백하기 때문이다. 그러면 격리 루트로 띄운 Console이 사용자의 진짜 설정을 읽고
+// 덮어쓰는데, 관측 가능한 실패가 하나도 없다. 그래서 배선 자체를 소스 계약으로 고정한다.
+const ROUTES_SOURCE = readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "routes.ts"),
+  "utf-8",
+);
+
+describe("ai gateway settings store wiring", () => {
+  it("injects the host's effective Fleet data root instead of letting core fall back to the real home", () => {
+    const construction = ROUTES_SOURCE.match(/createAiGatewaySettingsStore\(\{[^}]*\}\)/s);
+    expect(construction).not.toBeNull();
+    expect(construction![0]).toContain("dataDir: ctx.host.paths.fleetDataDir");
+  });
+
+  it("hands core the plugin data directory as the only adoption source", () => {
+    const construction = ROUTES_SOURCE.match(/createAiGatewaySettingsStore\(\{[^}]*\}\)/s);
+    // 승계 여부는 이 인자의 유무가 결정한다. 호스트가 경로 판단을 하지 않는다는 계약이기도 하다.
+    expect(construction![0]).toContain("legacyDir: ctx.host.paths.pluginDataDir(ctx.pluginId)");
+  });
+
+  it("keeps every AI Gateway settings decision out of this plugin", () => {
+    // 정규화·검증·카탈로그 투영·선별 해석은 core-ai-gateway 소유다. 플러그인이 자기 사본을
+    // 다시 들면 두 벌이 갈라진다.
+    expect(ROUTES_SOURCE).not.toContain("./server/ai-gateway-settings.js");
+    expect(ROUTES_SOURCE).toContain("createAiGatewaySettingsStore");
+    expect(ROUTES_SOURCE).toContain("@dotobokuri/core-ai-gateway");
+  });
+});

--- a/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
@@ -4,7 +4,7 @@ import type { GlobalOptionsData } from "@dotobokuri/core-infra";
 import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 import { describe, expect, it } from "vitest";
 
-import { normalizeAiGatewaySettings, type AiGatewayStoredSettings } from "../server/ai-gateway-settings.js";
+import { normalizeAiGatewaySettings, type AiGatewayStoredSettings } from "@dotobokuri/core-ai-gateway";
 import { registerTerminalSettingsRoutes } from "../server/settings-routes.js";
 
 interface WriteJsonCall {
@@ -360,19 +360,26 @@ function createRouteHarness(options: HarnessOptions = {}) {
       update: (mutate) => { updateCalls += 1; data = mutate(data); return data; },
     },
     aiGatewayStore: {
-      read: async () => aiGateway,
-      write: async (value) => {
+      path: "/test/ai-gateway.json",
+      read: () => aiGateway,
+      // 실 store(core-ai-gateway settings-store)의 write와 같은 보존 규칙을 지킨다.
+      // 여기서 wireLogEnabled를 빠뜨리면 모델만 바꾼 PUT이 로깅을 끈 것처럼 보이고,
+      // 하네스는 프로덕션에 없는 동작을 상대로 green이 된다.
+      write: (value) => {
         updateCalls += 1;
         aiGateway = normalizeAiGatewaySettings({
           version: 1,
           ...(aiGateway.cursorDiagnosticsEnabled === true
             ? { cursorDiagnosticsEnabled: true }
             : {}),
+          ...(typeof aiGateway.wireLogEnabled === "boolean"
+            ? { wireLogEnabled: aiGateway.wireLogEnabled }
+            : {}),
           ...(value ?? {}),
         });
         return aiGateway;
       },
-      writeCursorDiagnosticsEnabled: async (enabled) => {
+      writeCursorDiagnosticsEnabled: (enabled) => {
         updateCalls += 1;
         aiGateway = normalizeAiGatewaySettings({
           ...aiGateway,
@@ -380,7 +387,7 @@ function createRouteHarness(options: HarnessOptions = {}) {
         });
         return aiGateway;
       },
-      writeWireLogEnabled: async (enabled) => {
+      writeWireLogEnabled: (enabled) => {
         updateCalls += 1;
         aiGateway = normalizeAiGatewaySettings({
           ...aiGateway,


### PR DESCRIPTION
## Summary

- AI Gateway 모델 설정의 비즈니스 로직 소유권을 Terminal 플러그인에서 `core-ai-gateway`로 옮깁니다. 저장 형태, 정규화, 카탈로그 투영, PUT 검증, 선별 해석이 모두 core 소유가 되고, `GatewayEffortExposure` 타입도 `GatewayReasoningEffort` 옆으로 이동했습니다(`fleet-admiral`이 그대로 재노출하므로 공개 표면은 불변).
- 저장 위치를 Console 플러그인 저장 슬롯(`<consoleDataDir>/plugins/terminal/ai-gateway.json`)에서 Fleet 데이터 루트의 단일 파일 `<dataDir>/ai-gateway.json`으로 옮깁니다. 전역 옵션 `settings.json`과 같은 잠금·원자쓰기 스토어를 쓰며, 모듈 수준 쓰기 큐는 제거했습니다.
- 기존 설정 승계는 호출자가 지정한 디렉터리(`legacyDir`)에서만 일어납니다. 패키지는 어떤 호스트 경로도 하드코딩하지 않고, 인자가 없으면 승계 자체를 하지 않습니다. 승계는 결론이 났을 때만 종료 처리되고 요청된 갱신과 같은 잠금 안에서 끝나므로, 경합으로 실패한 쓰기가 이전 선별을 고아로 만들 수 없습니다.
- Terminal 플러그인에는 HTTP 배선과 경로 주입만 남습니다. 모든 리더가 동기 시그니처로 바뀌어 전역 옵션 스토어와 일치합니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 10 files / 294 tests pass
- [x] `pnpm --filter @dotobokuri/core-infra test` — 9 files / 68 tests pass
- [x] `pnpm --filter @fleet-plugins/terminal test` — 57 files / 588 tests pass
- [x] `pnpm --filter @dotobokuri/fleet-admiral test` — 13 files / 137 tests pass
- [x] `tsc --noEmit` clean: core-ai-gateway, core-infra, fleet-admiral, terminal, fleet-console
- [x] `node scripts/check-core-boundary.mjs` pass
- [x] `pnpm -r build` clean; 번들에 워크스페이스 bare import 잔존 없음
- [x] fleet-console suite: 무수정 canary 워크트리와 쌍대 대조 — 차집합이 실행마다 양방향으로 바뀌고 해당 파일은 단독 실행 시 전부 통과(환경 경합). 유일한 결정적 실패 `prewrites the complete Claude Code gateway model cache before launch`는 canary에서 동일 메시지로 재현되는 선존 실패
- [x] `.changelog.d/pr-542.md` 추가 — grouped product/section 문법, 영문+`ko:` 인접 쌍, `node scripts/compile-changelog-fragments.mjs --check` 통과

## Notes

- 승계 대상 경로는 호스트가 자기 환경에 맞게 넘기므로 published(`~/.fleet/console/plugins/terminal`)와 local(`<repo>/.fleet/console/plugins/terminal`)이 각자 자기 설정을 승계합니다. 목적지는 채널 구분이 없는 단일 파일이라 먼저 뜬 쪽이 승계합니다.
- 과거 파일은 삭제하지 않습니다.