### PR TITLE
docs(console-e2e): correct the gateway model-picker and wire-log claims

### DIFF
--- a/.agents/skills/console-e2e/references/live-agent-prompt-testing.md
+++ b/.agents/skills/console-e2e/references/live-agent-prompt-testing.md
@@ -52,8 +52,9 @@ env -u CLAUDE_CODE_CHILD_SESSION \
 - `FLEET_GATEWAY_WIRE_LOG` — the request body and the argument JSON a model actually
   produced. **It is a fallback, not an override.** The Settings wire-log toggle wins
   whenever the Console has a stored value: on writes to
-  `<plugin-data-dir>/ai-gateway/wire-log.jsonl` and ignores the variable, off writes
-  nothing at all, and only an *unset* toggle falls through to the path you named
+  `<plugin-data-dir>/ai-gateway/wire-log.jsonl` — the *plugin* data directory, a different
+  root from the settings file above — and ignores the variable, off writes nothing at all,
+  and only an *unset* toggle falls through to the path you named
   (`applyWireLog` in `runtime/fleet-plugins/terminal/routes.ts`). A fresh
   `FLEET_CONSOLE_DIR` has no stored value, which is why the variable works there — until
   someone touches the toggle. The file appears on the first gateway call, not at boot.
@@ -66,9 +67,12 @@ env -u CLAUDE_CODE_CHILD_SESSION \
 
 `/model` lists a gateway entry — labelled `From gateway` — only for models the Console was
 told to expose, and that list is **isolated per runtime directory**: it lives at
-`<plugin-data-dir>/ai-gateway.json`, not in `~/.fleet`. A fresh `FLEET_CONSOLE_DIR` starts
-with no such file, so the picker shows only the Claude entries and it reads as though
-gateway models were unsupported. They are not. Add one first:
+`<fleet-data-dir>/ai-gateway.json`, which under `FLEET_CONSOLE_DIR=<e2e-dir>` resolves to
+`<e2e-dir>/ai-gateway.json` — measured, not inferred. (The store also takes a `legacyDir`
+pointing at the plugin data directory, but that is a one-time migration source, never where
+current settings are written.) A fresh runtime directory has no such file, so the picker
+shows only the Claude entries and it reads as though gateway models were unsupported. They
+are not. Add one first:
 
 Settings → **AI Gateway** (Terminal) → the provider's row under *AI Gateway 모델* → choose
 the model in that row's combobox → **모델 추가**. Launch the Operation afterwards and the

--- a/.agents/skills/console-e2e/references/live-agent-prompt-testing.md
+++ b/.agents/skills/console-e2e/references/live-agent-prompt-testing.md
@@ -49,20 +49,43 @@ env -u CLAUDE_CODE_CHILD_SESSION \
 
 - `env -u CLAUDE_CODE_CHILD_SESSION` — without it the nested Claude Code inherits the
   parent session marker and misbehaves.
-- `FLEET_GATEWAY_WIRE_LOG` — the only way to see the request body and the argument JSON a
-  model actually produced. The file appears on the first gateway call, not at boot.
-- `FLEET_AI_GATEWAY_MODEL` — **the reliable way to pin a gateway model.** It overrides
-  `body.model` for every request (`packages/core-ai-gateway/src/gateway-router/router.ts`).
-  Use the roster id verbatim, quoted so the shell leaves `[1m]` alone.
+- `FLEET_GATEWAY_WIRE_LOG` — the request body and the argument JSON a model actually
+  produced. **It is a fallback, not an override.** The Settings wire-log toggle wins
+  whenever the Console has a stored value: on writes to
+  `<plugin-data-dir>/ai-gateway/wire-log.jsonl` and ignores the variable, off writes
+  nothing at all, and only an *unset* toggle falls through to the path you named
+  (`applyWireLog` in `runtime/fleet-plugins/terminal/routes.ts`). A fresh
+  `FLEET_CONSOLE_DIR` has no stored value, which is why the variable works there — until
+  someone touches the toggle. The file appears on the first gateway call, not at boot.
+- `FLEET_AI_GATEWAY_MODEL` — pins every request to one model whatever the client asked for
+  (`packages/core-ai-gateway/src/gateway-router/router.ts`). Use the roster id verbatim,
+  quoted so the shell leaves `[1m]` alone. Reach for it when you want one model forced for
+  the whole run — not as a substitute for the picker, which works once a model is exposed.
 
-**`/model` inside Claude Code does not list gateway models.** Measured 2026-08-07 on
-v2.1.224 with `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` set and the gateway attached:
-the picker showed only the five Claude entries. Do not burn turns hunting for a gateway
-entry in that list — pin the model at the server instead.
+## A fresh runtime directory exposes no gateway models
 
-Credentials are **not** isolated by `FLEET_CONSOLE_DIR`: the gateway reads the real
-`~/.fleet/auth.json` and `~/.fleet/ai-gateway.json`, so a live turn spends the user's
-actual provider quota. Keep prompts short and say so when reporting.
+`/model` lists a gateway entry — labelled `From gateway` — only for models the Console was
+told to expose, and that list is **isolated per runtime directory**: it lives at
+`<plugin-data-dir>/ai-gateway.json`, not in `~/.fleet`. A fresh `FLEET_CONSOLE_DIR` starts
+with no such file, so the picker shows only the Claude entries and it reads as though
+gateway models were unsupported. They are not. Add one first:
+
+Settings → **AI Gateway** (Terminal) → the provider's row under *AI Gateway 모델* → choose
+the model in that row's combobox → **모델 추가**. Launch the Operation afterwards and the
+entry appears, e.g. `OpenCode-DeepSeek-V4-Flash (1M Context) · From gateway`.
+
+That combobox resists automation in four separate ways, measured 2026-08-07:
+
+- `scrollintoview` first, or the click lands nowhere and `aria-expanded` stays `false`.
+- Its options never reach the accessibility tree — `snapshot` shows none even while open.
+  Select through `eval` against `[role="option"]` under the id in `aria-controls`.
+- A second click toggles it shut, so opening and choosing must happen in **one** tool call.
+- The button label still reads the old model if you check it in the same `eval` that
+  clicked. Re-read on a later call before concluding the selection failed.
+
+API keys are a separate store and are **not** isolated: the gateway reads the real
+`~/.fleet/auth.json`, so a live turn spends the user's actual provider quota. Keep prompts
+short and say so when reporting.
 
 ## Clear the dialogs before the first click
 
@@ -82,6 +105,11 @@ Theater registration is Console's own folder UI (`/n/folder-listings`), not a na
 dialog. Fill the **절대 경로로 이동 / absolute path** textbox, press 이동/Go, then
 Theater 추가. After that, `<theater>에서 새 Operation` opens a menu whose items are
 `Claude (Native)`, `Claude (Classic)`, `Claude (Gateway)`, `Shell`.
+
+Both entry points live in the sidebar, so a collapsed sidebar removes them from the
+accessibility tree and the snapshot simply has no `새 Theater` ref — which reads as a
+missing feature, not a hidden one. `Escape` can collapse it as a side effect of dismissing
+something else; re-expand with the `사이드바 펼치기 (⌘B)` button before hunting for the ref.
 
 Verify the launch actually attached to the gateway rather than trusting the banner — the
 header still reads the Claude model name even when every request is being rerouted:


### PR DESCRIPTION
## Summary

PR #545에서 제가 남긴 `console-e2e` reference에 **사실과 다른 서술 두 건**이 있었습니다. 실제 Console을 띄워 측정해 정정합니다.

- **`/model`은 gateway 모델을 표시합니다.** 이전 서술("picker에 안 뜬다, 서버에서 핀하라")은 틀렸습니다. 노출 목록이 `<plugin-data-dir>/ai-gateway.json`에 있어 **런타임 디렉터리별로 격리**되고, 새 `FLEET_CONSOLE_DIR`은 이 파일이 아예 없어 비어 있었을 뿐입니다. 설정 → AI Gateway에서 모델을 추가하면 `From gateway` 라벨로 나옵니다 (실측: `OpenCode-DeepSeek-V4-Flash (1M Context) · From gateway`).
- **`FLEET_GATEWAY_WIRE_LOG`는 override가 아니라 fallback입니다.** 설정의 wire-log 토글에 저장값이 있으면 그쪽이 이깁니다 — On이면 플러그인 데이터 디렉터리로 보내고 변수를 무시, Off면 변수가 있어도 아무것도 기록하지 않습니다. 토글이 미설정일 때만 변수가 삽니다(`applyWireLog`). 제 이전 측정이 통했던 건 새 런타임 디렉터리라 저장값이 없었기 때문입니다.
- 자격증명 주석에서 `~/.fleet/ai-gateway.json`을 공유 항목으로 잘못 적었습니다. **API key(`auth.json`)는 공유, 모델 노출 목록은 격리**입니다.
- 설정 combobox가 자동화를 막는 방식 4가지와, 접힌 사이드바가 Theater 진입점을 접근성 트리에서 지운다는 점을 추가했습니다.

## Test Plan

- [x] 격리 콘솔(새 `FLEET_CONSOLE_DIR`) 기동 후 `ai-gateway.json` 부재 확인 — 노출 모델 0개
- [x] 설정 → AI Gateway → opencode 행에서 DeepSeek-V4-Flash 선택 → 모델 추가 → 저장 파일에 `{"id":"opencode--deepseek-v4-flash"}` 기록 확인
- [x] Claude (Gateway) Operation 실행 후 `/model` — 6번 항목으로 `OpenCode-DeepSeek-V4-Flash (1M Contex… · From gateway)` 표시 확인 (스크린샷 실측)
- [x] wire-log 우선순위는 `applyWireLog`(`runtime/fleet-plugins/terminal/routes.ts`)와 `target()`(`packages/core-ai-gateway/src/transport/wire-log.ts`) 코드로 교차 확인 — 3상태(미설정→env, On→플러그인 경로, Off→차단)
- [x] 문서 전용 변경 — 소스/테스트 무변경

## Changelog

- [ ] `no-changelog` — `.agents/skills/` 아래 에이전트 지침 문서만 변경했고 제품 동작에 영향이 없습니다.