### PR TITLE
feat(fleet-plugin): redraw the repository commit graph and ref badges

### DIFF
--- a/.changelog.d/fork-style-commit-graph.md
+++ b/.changelog.d/fork-style-commit-graph.md
@@ -1,0 +1,16 @@
+---
+branch: fork-style-commit-graph
+---
+
+### fleet-console
+#### Added
+- Choose whether Repository history lists commits in topological or date order, defaulting to topological so a branch and its commits stay contiguous.
+  ko: 저장소 기록이 커밋을 계보순으로 나열할지 시간순으로 나열할지 고를 수 있습니다. 기본값은 브랜치와 그 커밋이 끊기지 않고 이어지는 계보순입니다.
+- Show the author of each commit in Repository history, and mark the commits that carry a message body beyond their subject.
+  ko: 저장소 기록에서 각 커밋의 작성자를 보여 주고, 제목 밖에 메시지 본문이 있는 커밋을 표시합니다.
+
+#### Changed
+- Draw the Repository commit graph one row at a time, so a row spends width only on the lanes it actually draws and its commit text sits beside the graph rather than behind every lane the list ever opens. Branch and merge connectors follow right angles with rounded corners instead of diagonals.
+  ko: 저장소 커밋 그래프를 행 단위로 그립니다. 각 행은 실제로 그리는 레인만큼만 폭을 쓰고, 커밋 본문이 목록 전체가 여는 모든 레인 뒤가 아니라 그래프 바로 옆에 붙습니다. 분기와 병합 연결선은 대각선 대신 모서리가 둥근 직각을 따릅니다.
+- Restyle branch, tag, and remote badges as bold labels with their own icon segment, tinted by the graph lane of the commit they sit on while the current checkout stays on the location tone. Each commit subject now raises its Conventional Commit prefix above the rest of the line.
+  ko: 브랜치·태그·원격 뱃지를 아이콘 칸이 따로 있는 볼드 라벨로 다시 그립니다. 색조는 그 커밋이 놓인 그래프 레인을 따르고, 현재 체크아웃은 위치 색조를 유지합니다. 커밋 제목은 Conventional Commit 접두를 나머지 줄보다 강조합니다.

--- a/.changelog.d/fork-style-commit-graph.md
+++ b/.changelog.d/fork-style-commit-graph.md
@@ -14,3 +14,7 @@ branch: fork-style-commit-graph
   ko: 저장소 커밋 그래프를 행 단위로 그립니다. 각 행은 실제로 그리는 레인만큼만 폭을 쓰고, 커밋 본문이 목록 전체가 여는 모든 레인 뒤가 아니라 그래프 바로 옆에 붙습니다. 분기와 병합 연결선은 대각선 대신 모서리가 둥근 직각을 따릅니다.
 - Restyle branch, tag, and remote badges as bold labels with their own icon segment, tinted by the graph lane of the commit they sit on while the current checkout stays on the location tone. Each commit subject now raises its Conventional Commit prefix above the rest of the line.
   ko: 브랜치·태그·원격 뱃지를 아이콘 칸이 따로 있는 볼드 라벨로 다시 그립니다. 색조는 그 커밋이 놓인 그래프 레인을 따르고, 현재 체크아웃은 위치 색조를 유지합니다. 커밋 제목은 Conventional Commit 접두를 나머지 줄보다 강조합니다.
+
+#### Fixed
+- Reach the rest of Repository history in repositories whose commit messages are large enough to fill the log read buffer. Such a page previously reported that the first commit had been reached, and the commit the read stopped inside was listed with missing details and then skipped by the next page.
+  ko: 커밋 메시지가 커서 로그 읽기 버퍼를 채우는 저장소에서도 나머지 기록에 닿을 수 있습니다. 이전에는 그런 페이지가 첫 커밋에 도달했다고 알렸고, 읽기가 중간에서 멈춘 커밋은 세부 정보가 빠진 채 목록에 오른 뒤 다음 페이지에서 건너뛰어졌습니다.

--- a/runtime/fleet-plugins/repository/client/graph.tsx
+++ b/runtime/fleet-plugins/repository/client/graph.tsx
@@ -13,6 +13,12 @@ export interface GraphNode {
   readonly passThroughLanes: readonly number[];
   readonly mergeFromLanes: readonly number[];
   readonly branchToLanes: readonly number[];
+  /**
+   * 이 행에서 실제로 무언가가 그려지는 레인 수(최대 레인 인덱스 + 1).
+   * Fork 문법 — 거터 폭은 목록 전체 최대치가 아니라 행마다 이 값으로 정해지므로,
+   * 분기가 없는 대부분의 행에서 커밋 본문이 그래프 바로 옆에 붙는다.
+   */
+  readonly rowLaneCount: number;
 }
 
 export interface GraphLayout {
@@ -138,6 +144,7 @@ export function layoutGraph(commits: readonly LogCommitEntry[]): GraphLayout {
       passThroughLanes,
       mergeFromLanes,
       branchToLanes,
+      rowLaneCount: rowMaxLaneIndex + 1,
     });
   }
 
@@ -150,16 +157,19 @@ export function layoutGraph(commits: readonly LogCommitEntry[]): GraphLayout {
 
 interface GraphGutterProps {
   readonly node: GraphNode;
-  readonly laneCount: number;
 }
 
 // ─── constants ───────────────────────────────────────────────────────────────
 
-const LANE_WIDTH = 12;
+const LANE_WIDTH = 14;
 // .history-commit-row의 고정 높이(diff.css)와 반드시 일치해야 행 간 레인 선이 이음새 없이 연결된다
 export const ROW_HEIGHT = 28;
-const NODE_R = 3;
-const HEAD_RING_R = 5;
+const NODE_R = 3.5;
+const HEAD_RING_R = 5.5;
+const STROKE_WIDTH = 2;
+// 대각선 대신 직각 + 라운드 코너로 잇는 Fork 문법의 코너 반지름.
+// 레인 간격(14px)의 절반보다 작아야 이웃 레인의 코너와 겹치지 않는다.
+const ELBOW_R = 5;
 // 장식적 구분 채도는 --id-* 정체성 봉투에서만 가져온다 — 테마별 재조율·상태 신호와
 // 혼동할 수 없어야 한다. 신호 토큰(warn/positive/aurora) 순환은 상태 채널을 침범하므로 폐기.
 const LANE_COLORS = [
@@ -176,17 +186,35 @@ const LANE_COLORS = [
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
 function laneCx(lane: number): number {
-  return lane * LANE_WIDTH + 6;
+  return lane * LANE_WIDTH + LANE_WIDTH / 2;
 }
 
-function laneColor(lane: number): string {
+export function laneColor(lane: number): string {
   return LANE_COLORS[lane % LANE_COLORS.length] ?? "var(--ink-fog)";
+}
+
+/** 행 위쪽 `fromLane`에서 내려와 `toX`의 노드로 합류하는 경로 — 수직 → 라운드 코너 → 수평. */
+function mergePath(fromLane: number, toX: number, cy: number): string {
+  const fromX = laneCx(fromLane);
+  const dir = Math.sign(toX - fromX);
+  if (dir === 0) return `M ${fromX} 0 V ${cy}`;
+  return `M ${fromX} 0 V ${cy - ELBOW_R} Q ${fromX} ${cy} ${fromX + dir * ELBOW_R} ${cy} H ${toX}`;
+}
+
+/** 노드에서 갈라져 나와 행 아래쪽 `toLane`으로 내려가는 경로 — 수평 → 라운드 코너 → 수직. */
+function branchPath(fromX: number, toLane: number, cy: number): string {
+  const toX = laneCx(toLane);
+  const dir = Math.sign(toX - fromX);
+  if (dir === 0) return `M ${fromX} ${cy} V ${ROW_HEIGHT}`;
+  return `M ${fromX} ${cy} H ${toX - dir * ELBOW_R} Q ${toX} ${cy} ${toX} ${cy + ELBOW_R} V ${ROW_HEIGHT}`;
 }
 
 // ─── GraphGutter ─────────────────────────────────────────────────────────────
 
-export function GraphGutter({ node, laneCount }: GraphGutterProps) {
-  const lanes = Math.max(laneCount, 1);
+export function GraphGutter({ node }: GraphGutterProps) {
+  // Fork 문법 — 거터 폭은 이 행이 실제로 쓰는 레인만큼이다. 목록 전체 최대 레인 수로 고정하면
+  // 분기가 하나도 없는 행까지 빈 레인만큼 본문이 밀려 좁은 rail에서 제목 폭을 상시 잠식한다.
+  const lanes = Math.max(node.rowLaneCount, 1);
   const collapseIndicatorWidth = node.collapsed ? 10 : 0;
   const width = lanes * LANE_WIDTH + collapseIndicatorWidth;
   const cx = laneCx(node.lane);
@@ -209,7 +237,7 @@ export function GraphGutter({ node, laneCount }: GraphGutterProps) {
           x2={laneCx(lane)}
           y2={ROW_HEIGHT}
           stroke={laneColor(lane)}
-          strokeWidth={1.5}
+          strokeWidth={STROKE_WIDTH}
         />
       ))}
 
@@ -221,7 +249,7 @@ export function GraphGutter({ node, laneCount }: GraphGutterProps) {
           x2={cx}
           y2={cy - NODE_R}
           stroke={laneColor(node.lane)}
-          strokeWidth={1.5}
+          strokeWidth={STROKE_WIDTH}
         />
       )}
 
@@ -233,34 +261,30 @@ export function GraphGutter({ node, laneCount }: GraphGutterProps) {
           x2={cx}
           y2={ROW_HEIGHT}
           stroke={laneColor(node.lane)}
-          strokeWidth={1.5}
+          strokeWidth={STROKE_WIDTH}
         />
       )}
 
-      {/* mergeFromLanes: 병합으로 닫히는 레인 — 위쪽에서 노드로 대각선 */}
+      {/* mergeFromLanes: 병합으로 닫히는 레인 — 위쪽에서 내려와 직각 라운드 코너로 노드에 합류 */}
       {node.mergeFromLanes.map((lane) => (
-        <line
+        <path
           key={`mf-${lane}`}
-          x1={laneCx(lane)}
-          y1={0}
-          x2={cx}
-          y2={cy}
+          d={mergePath(lane, cx, cy)}
+          fill="none"
           stroke={laneColor(lane)}
-          strokeWidth={1.5}
+          strokeWidth={STROKE_WIDTH}
           strokeLinecap="round"
         />
       ))}
 
-      {/* branchToLanes: 노드에서 새로 분기되는 레인 — 아래로 대각선 */}
+      {/* branchToLanes: 노드에서 갈라져 직각 라운드 코너로 아래 레인에 내려앉는다 */}
       {node.branchToLanes.map((lane) => (
-        <line
+        <path
           key={`bt-${lane}`}
-          x1={cx}
-          y1={cy}
-          x2={laneCx(lane)}
-          y2={ROW_HEIGHT}
+          d={branchPath(cx, lane, cy)}
+          fill="none"
           stroke={laneColor(lane)}
-          strokeWidth={1.5}
+          strokeWidth={STROKE_WIDTH}
           strokeLinecap="round"
         />
       ))}
@@ -273,7 +297,7 @@ export function GraphGutter({ node, laneCount }: GraphGutterProps) {
           r={HEAD_RING_R}
           fill="none"
           stroke={laneColor(node.lane)}
-          strokeWidth={1.5}
+          strokeWidth={STROKE_WIDTH}
         />
       )}
 

--- a/runtime/fleet-plugins/repository/client/history-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/history-panel.tsx
@@ -24,7 +24,23 @@ export type HistoryOkState = { readonly kind: "ok"; readonly commits: readonly L
 type LoadState = { readonly kind: "loading" } | HistoryOkState | { readonly kind: "error"; readonly message: string };
 type CommitTarget = { readonly fullHash: string; readonly entry?: LogCommitEntry };
 type CompareAnchor = { readonly fullHash: string; readonly shortHash: string };
-type ComparePair = { readonly base: string; readonly head: string; readonly baseLabel: string; readonly headLabel: string };
+export type ComparePair = { readonly base: string; readonly head: string; readonly baseLabel: string; readonly headLabel: string };
+
+/**
+ * 비교의 base/head 방향을 정한다. 목록 위치로 정해서는 안 된다 — topo 정렬에서는 브랜치 체인이 통째로 먼저
+ * 나오므로 위쪽 행이 아래쪽 행보다 오래된 커밋일 수 있고, 그때 base와 head가 뒤바뀌어 추가가 삭제로 보인다.
+ * 방향은 목록이 실제로 보여 주는 커밋 시각으로 정하고, 앵커의 시각을 알 수 없을 때만
+ * 사용자가 고른 순서(먼저 고른 쪽이 base)를 그대로 지킨다.
+ */
+export function chooseComparePair(
+  anchor: { readonly fullHash: string; readonly shortHash: string; readonly authorAt: number | null },
+  target: { readonly fullHash: string; readonly shortHash: string; readonly authorAt: number },
+): ComparePair {
+  const anchorIsOlder = anchor.authorAt === null || anchor.authorAt <= target.authorAt;
+  const older = anchorIsOlder ? anchor : target;
+  const newer = anchorIsOlder ? target : anchor;
+  return { base: older.fullHash, head: newer.fullHash, baseLabel: older.shortHash, headLabel: newer.shortHash };
+}
 type InspectorState = { readonly kind: "loading" } | { readonly kind: "ok"; readonly result: CommitResult } | { readonly kind: "error"; readonly message: string };
 type HistoryCacheRestore = { readonly state: HistoryOkState; readonly target: CommitTarget | null; readonly filterText: string; readonly scrollTop: number };
 
@@ -347,16 +363,16 @@ function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, acti
     setAnnounce(t("repository.compare.announceUnpinned"));
   }, [t]);
   const runPair = useCallback((a: CompareAnchor, b: LogCommitEntry) => {
-    const aIndex = commitIndexes.get(a.fullHash);
-    const bIndex = commitIndexes.get(b.fullHash);
-    const aIsOlder = aIndex !== undefined && bIndex !== undefined ? aIndex > bIndex : true;
-    const older = aIsOlder ? a : { fullHash: b.fullHash, shortHash: b.shortHash };
-    const newer = aIsOlder ? { fullHash: b.fullHash, shortHash: b.shortHash } : a;
-    setComparePair({ base: older.fullHash, head: newer.fullHash, baseLabel: older.shortHash, headLabel: newer.shortHash });
+    // 앵커는 shortHash만 들고 다니므로 시각은 적재된 목록에서 되찾는다 — 검사기에서 핀한 경우처럼
+    // 호출부가 항목을 쥐고 있지 않은 경로까지 한자리에서 덮는다.
+    const anchorIndex = commitIndexes.get(a.fullHash);
+    const anchorEntry = state.kind === "ok" && anchorIndex !== undefined ? state.commits[anchorIndex] : undefined;
+    const pair = chooseComparePair({ ...a, authorAt: anchorEntry?.authorAt ?? null }, b);
+    setComparePair(pair);
     setPin(null);
     setTarget(null);
-    setAnnounce(t("repository.compare.announceResult", { base: older.shortHash, head: newer.shortHash }));
-  }, [commitIndexes, t]);
+    setAnnounce(t("repository.compare.announceResult", { base: pair.baseLabel, head: pair.headLabel }));
+  }, [commitIndexes, state, t]);
   const onRowActivate = useCallback((entry: LogCommitEntry, shiftKey: boolean) => {
     if (!shiftKey) {
       setTarget({ fullHash: entry.fullHash, entry });

--- a/runtime/fleet-plugins/repository/client/history-panel.tsx
+++ b/runtime/fleet-plugins/repository/client/history-panel.tsx
@@ -1,18 +1,18 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 
 import type { ConsoleLocale, Translate } from "@fleet-console/sdk/i18n";
 import type { RailPanelContext } from "@fleet-console/sdk/rail";
 
-import type { CommitResult, DiffFileEntry, LogCommitEntry, LogResult, WorktreeCheckout } from "../server/types.js";
+import type { CommitResult, DiffFileEntry, LogCommitEntry, LogOrder, LogResult, WorktreeCheckout } from "../server/types.js";
 import { FileRow, FilesViewToggle, readFilesViewMode, saveFilesViewMode, type FilesViewMode } from "./changed-files.js";
 import { CompareInspector } from "./compare-inspector.js";
 import { DiffTreeView } from "./repository-tree.js";
-import { GraphGutter, ROW_HEIGHT } from "./graph.js";
+import { GraphGutter, ROW_HEIGHT, laneColor } from "./graph.js";
 import { layoutGraph, type GraphLayout, type GraphNode } from "./graph.js";
-import { dropHistoryCache, readHistoryCache, writeHistoryCache, type HistoryCacheEntry } from "./repository-state.js";
+import { dropHistoryCache, readHistoryCache, readHistoryOrder, saveHistoryOrder, writeHistoryCache, type HistoryCacheEntry } from "./repository-state.js";
 import { HunkView } from "./hunk-view.js";
 import { getT, localeTag, type RepositoryMessageKey } from "./i18n/index.js";
-import { formatCommitTime, refBadges, shortRefName } from "./repository-parsers.js";
+import { formatCommitTime, refBadges, shortRefName, splitCommitSubject, type RefBadge, type RefBadgeKind } from "./repository-parsers.js";
 import { DIFF_DIVIDER_WIDTH, HISTORY_DETAIL_PANE_MIN_HEIGHT, HISTORY_LOG_PANE_MIN_HEIGHT, buildHistoryStackTemplate, buildInspectorChangesGridTemplate, buildInspectorDetailsGridTemplate, clampSplitPaneSize, installPointerDragLifecycle } from "./rail-layout.js";
 import { WorkspaceDock } from "./workspace-dock.js";
 import { buildWorkspaceDockTemplate, clampWorkspaceDockHeight, normalizeWorkspaceDockHeight, readWorkspaceDockHeight, saveWorkspaceDockHeight } from "./workspace-layout.js";
@@ -48,6 +48,7 @@ export interface HistoryLoadGeneration {
   readonly theaterId: string | null | undefined;
   readonly repoRel: string;
   readonly refFilter: string | null;
+  readonly order: LogOrder;
   readonly refreshToken: number;
 }
 
@@ -93,6 +94,7 @@ export function isHistoryGenerationCurrent(request: HistoryLoadGeneration, curre
   return request.theaterId === current.theaterId
     && request.repoRel === current.repoRel
     && request.refFilter === current.refFilter
+    && request.order === current.order
     && request.refreshToken === current.refreshToken;
 }
 
@@ -145,14 +147,70 @@ export function aggregateWip(files: readonly DiffFileEntry[]): { files: number; 
 export function shouldShowWip(wip: { readonly files: number }, filterText: string, refFilter: string | null): boolean { return wip.files > 0 && !filterText && !refFilter; }
 
 function CheckoutIcon({ current }: { readonly current: boolean }) { return current ? <svg className="history-badge-icon" viewBox="0 0 12 12" fill="none"><path d="M2.5 6.2L5 8.7L9.5 3.5" stroke="currentColor" strokeWidth="1.5" /></svg> : <svg className="history-badge-icon" viewBox="0 0 12 12" fill="none"><path d="M1.5 3.4h3l1 1.1h5v5.1a.9.9 0 01-.9.9H2.4a.9.9 0 01-.9-.9V4.3a.9.9 0 01.9-.9z" stroke="currentColor" strokeWidth="1.2" /></svg>; }
+function BranchIcon() { return <svg className="history-badge-icon" viewBox="0 0 12 12" fill="none"><path d="M3.6 3.9v4.2M3.6 8.1h3.1a1.7 1.7 0 001.7-1.7V4.6" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" /><circle cx="3.6" cy="2.6" r="1.3" stroke="currentColor" strokeWidth="1.2" /><circle cx="8.4" cy="3.3" r="1.3" stroke="currentColor" strokeWidth="1.2" /></svg>; }
+function TagIcon() { return <svg className="history-badge-icon" viewBox="0 0 12 12" fill="none"><path d="M1.9 5.6V2.4a.6.6 0 01.6-.6h3.2L10.4 6a.8.8 0 010 1.1L7.1 10.4a.8.8 0 01-1.1 0z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" /><circle cx="4.1" cy="4.1" r=".85" fill="currentColor" /></svg>; }
+function RemoteIcon() { return <svg className="history-badge-icon" viewBox="0 0 12 12" fill="none"><circle cx="6" cy="6" r="4.3" stroke="currentColor" strokeWidth="1.2" /><path d="M1.7 6h8.6M6 1.7c1.1 1.2 1.7 2.7 1.7 4.3S7.1 9.1 6 10.3C4.9 9.1 4.3 7.6 4.3 6S4.9 2.9 6 1.7z" stroke="currentColor" strokeWidth="1.1" /></svg>; }
 
-export function CommitRow({ entry, checkouts, selected, picked = false, pin = null, graphNode, laneCount, onRowActivate, onCompareAction, onSelect, rowRef, locale }: { readonly entry: LogCommitEntry; readonly checkouts: readonly WorktreeCheckout[]; readonly selected: boolean; readonly picked?: boolean; readonly pin?: CompareAnchor | null; readonly graphNode: import("./graph.js").GraphNode; readonly laneCount: number; readonly onRowActivate?: (entry: LogCommitEntry, shiftKey: boolean) => void; readonly onCompareAction?: (entry: LogCommitEntry) => void; readonly onSelect?: (entry: LogCommitEntry) => void; readonly rowRef?: (node: HTMLButtonElement | null) => void; readonly locale?: ConsoleLocale }) {
+/**
+ * 뱃지 색조 — Fork처럼 ref 뱃지를 그래프와 같은 색 체계로 묶는다.
+ * 체크아웃 위치(brass)와 태그(plum)는 어느 레인에 있든 같아야 하므로 CSS가 소유하고,
+ * 나머지 브랜치·원격·워크트리만 자기 커밋의 레인 색을 물려받아 인라인으로 주입된다.
+ */
+function laneBadgeTone(kind: RefBadgeKind, checkout: WorktreeCheckout | null | undefined, lane: number | undefined): string | undefined {
+  if (lane === undefined || checkout?.isCurrent || kind === "head" || kind === "tag") return undefined;
+  return laneColor(lane);
+}
+
+function BadgeMark({ kind, checkout }: { readonly kind: RefBadgeKind; readonly checkout: WorktreeCheckout | null | undefined }) {
+  if (kind === "tag") return <TagIcon />;
+  if (kind === "remote") return <RemoteIcon />;
+  if (checkout) return <CheckoutIcon current={checkout.isCurrent} />;
+  if (kind === "head" || kind === "worktree") return <CheckoutIcon current={kind === "head"} />;
+  return <BranchIcon />;
+}
+
+/** `lane`을 넘기지 않으면 색조를 CSS 기본값에 맡긴다 — 그래프가 없는 검사기 칩이 그 경로를 쓴다. */
+function RefBadgeChip({ badge, checkout, lane }: { readonly badge: RefBadge; readonly checkout?: WorktreeCheckout | null; readonly lane?: number }) {
+  const tone = laneBadgeTone(badge.kind, checkout, lane);
+  return <span
+    className={`history-badge history-badge--${badge.kind}${checkout?.isCurrent ? " is-current" : ""}`}
+    style={tone ? ({ "--badge-tone": tone } as CSSProperties) : undefined}
+  >
+    <span className="history-badge-mark"><BadgeMark kind={badge.kind} checkout={checkout} /></span>
+    <span className="history-badge-label">{badge.label}</span>
+  </span>;
+}
+
+
+export function CommitRow({ entry, checkouts, selected, picked = false, pin = null, graphNode, onRowActivate, onCompareAction, onSelect, rowRef, locale }: { readonly entry: LogCommitEntry; readonly checkouts: readonly WorktreeCheckout[]; readonly selected: boolean; readonly picked?: boolean; readonly pin?: CompareAnchor | null; readonly graphNode: import("./graph.js").GraphNode; readonly onRowActivate?: (entry: LogCommitEntry, shiftKey: boolean) => void; readonly onCompareAction?: (entry: LogCommitEntry) => void; readonly onSelect?: (entry: LogCommitEntry) => void; readonly rowRef?: (node: HTMLButtonElement | null) => void; readonly locale?: ConsoleLocale }) {
   const t = getT(locale);
   const badges = refBadges(entry); const detached = findDetachedCheckout(entry, checkouts);
   const activateRow = onRowActivate ?? ((selectedEntry: LogCommitEntry) => onSelect?.(selectedEntry));
   const compareLabel = !pin ? t("repository.compare.pinRow", { short: entry.shortHash }) : pin.fullHash === entry.fullHash ? t("repository.compare.unpinRow", { short: entry.shortHash }) : t("repository.compare.completeRow", { short: entry.shortHash, base: pin.shortHash });
+  // Fork 문법 — Conventional Commit 접두만 볼드로 올려 커밋 종류를 훑어 읽게 한다. 규약 밖 제목은 통째로 한 티어에 둔다.
+  const subject = splitCommitSubject(entry.subject);
   // Fork 문법: refs 뱃지는 제목 왼쪽(그래프 바로 뒤)에서 커밋의 정체를 먼저 알린다.
-  return <div className={`history-commit-row${selected ? " is-selected" : ""}${entry.onHead ? "" : " is-off-head"}${picked ? " is-picked" : ""}`} title={entry.onHead ? undefined : t("repository.history.offHead")}><button ref={rowRef} type="button" className="history-commit-row-main" onClick={(event) => activateRow(entry, event.shiftKey)}><span className="history-commit-badges">{badges.map((badge) => { const checkout = badge.kind === "branch" ? checkouts.find((item) => item.branch === badge.label) : null; return <span key={`${badge.kind}:${badge.label}`} className={`history-badge history-badge--${badge.kind}`}>{checkout && <CheckoutIcon current={checkout.isCurrent} />}{badge.label}</span>; })}{detached && <span className="history-badge history-badge--worktree"><CheckoutIcon current={detached.isCurrent} />{t("repository.history.detached")}</span>}</span><span className="history-commit-subject" title={entry.subject}>{entry.subject}</span><span className="history-commit-sha">{entry.shortHash}</span><span className="history-commit-time">{formatCommitTime(entry.authorAt, new Date(), locale)}</span><span className="history-graph-gutter" aria-hidden="true"><GraphGutter node={graphNode} laneCount={laneCount} /></span></button>{onCompareAction && <button type="button" className="history-row-compare" aria-label={compareLabel} onClick={() => onCompareAction(entry)}>⇆</button>}</div>;
+  return <div className={`history-commit-row${selected ? " is-selected" : ""}${entry.onHead ? "" : " is-off-head"}${picked ? " is-picked" : ""}`} title={entry.onHead ? undefined : t("repository.history.offHead")}>
+    <button ref={rowRef} type="button" className="history-commit-row-main" onClick={(event) => activateRow(entry, event.shiftKey)}>
+      <span className="history-commit-badges">
+        {badges.map((badge) => <RefBadgeChip
+          key={`${badge.kind}:${badge.label}`}
+          badge={badge}
+          checkout={badge.kind === "branch" ? checkouts.find((item) => item.branch === badge.label) : null}
+          lane={graphNode.lane}
+        />)}
+        {detached && <RefBadgeChip badge={{ kind: "worktree", label: t("repository.history.detached") }} checkout={detached} lane={graphNode.lane} />}
+      </span>
+      <span className="history-commit-subject" title={entry.subject}>{subject.prefix ? <><b className="history-commit-kind">{subject.prefix}</b> {subject.rest}</> : entry.subject}</span>
+      {/* 본문이 더 있는 커밋만 표시한다 — 목록에서 "열어 볼 값이 있는 커밋"을 가려내는 Fork의 ↵ 마커. */}
+      {entry.hasBody && <span className="history-commit-body-mark" aria-label={t("repository.history.hasBody")} title={t("repository.history.hasBody")}>↵</span>}
+      <span className="history-commit-author"><span className="history-commit-avatar" aria-hidden="true">{initials(entry.authorName)}</span><span className="history-commit-author-name">{entry.authorName}</span></span>
+      <span className="history-commit-sha">{entry.shortHash}</span>
+      <span className="history-commit-time">{formatCommitTime(entry.authorAt, new Date(), locale)}</span>
+      <span className="history-graph-gutter" aria-hidden="true"><GraphGutter node={graphNode} /></span>
+    </button>
+    {onCompareAction && <button type="button" className="history-row-compare" aria-label={compareLabel} onClick={() => onCompareAction(entry)}>⇆</button>}
+  </div>;
 }
 
 function CommitInspector({ ctx, repoRel, target, workspace, onSelectCommit, onPinCompare, onClose }: { readonly ctx: RailPanelContext; readonly repoRel: string; readonly target: CommitTarget; readonly workspace: boolean; readonly onSelectCommit: (target: CommitTarget) => void; readonly onPinCompare?: () => void; readonly onClose: () => void }) {
@@ -206,7 +264,7 @@ function CommitInspector({ ctx, repoRel, target, workspace, onSelectCommit, onPi
   return <div className={`history-inspector${workspace ? " repository-ws-inspector" : ""}`} onKeyDown={(event) => { if (isInspectorDismissKey(event.key)) { event.preventDefault(); onClose(); } }}>{workspace ? content : <><div className="history-segmented"><button type="button" aria-pressed={tab === "details"} onClick={() => setTab("details")}>{t("repository.history.details")}</button><button type="button" aria-pressed={tab === "changes"} onClick={() => setTab("changes")}>{t("repository.source.changes")} {state.kind === "ok" && <span>{state.result.files.length}</span>}</button><button type="button" className="history-detail-close history-inspector-close" aria-label={t("repository.history.closeInspector")} title={t("repository.history.closeInspector")} onClick={onClose}>✕</button></div>{content}</>}</div>;
 }
 
-function CommitHeader({ meta, entry, fullHash, copied, onCopy, onParent, locale, t }: { readonly meta: CommitResult["meta"]; readonly entry?: LogCommitEntry; readonly fullHash: string; readonly copied: boolean; readonly onCopy: () => void; readonly onParent: (full: string) => void; readonly locale: ConsoleLocale | undefined; readonly t: T }) { return <div className="history-inspector-head"><div className="history-inspector-subject" title={meta.subject}>{meta.subject}</div>{meta.body && <pre className="history-inspector-message">{meta.body}</pre>}<div className="history-author"><span className="history-avatar">{initials(meta.authorName)}</span><span><b>{meta.authorName}</b><small>{meta.authorEmail}</small></span><time title={new Date(meta.authorAt * 1000).toLocaleString(localeTag(locale))}>{formatCommitTime(meta.authorAt, new Date(), locale)}</time></div><div className="history-inspector-ids"><button type="button" className={`history-sha-copy${copied ? " is-copied" : ""}`} onClick={onCopy}>{fullHash}<span>{copied ? t("repository.history.copied") : t("repository.history.copy")}</span></button>{meta.parents.map((parent) => <button type="button" className="history-parent" key={parent.full} onClick={() => onParent(parent.full)}>{t("repository.history.parent", { short: parent.short })}</button>)}</div>{entry && <div className="history-ref-chips">{refBadges(entry).map((badge) => <span key={`${badge.kind}:${badge.label}`} className={`history-badge history-badge--${badge.kind}`}>{badge.label}</span>)}</div>}</div>; }
+function CommitHeader({ meta, entry, fullHash, copied, onCopy, onParent, locale, t }: { readonly meta: CommitResult["meta"]; readonly entry?: LogCommitEntry; readonly fullHash: string; readonly copied: boolean; readonly onCopy: () => void; readonly onParent: (full: string) => void; readonly locale: ConsoleLocale | undefined; readonly t: T }) { return <div className="history-inspector-head"><div className="history-inspector-subject" title={meta.subject}>{meta.subject}</div>{meta.body && <pre className="history-inspector-message">{meta.body}</pre>}<div className="history-author"><span className="history-avatar">{initials(meta.authorName)}</span><span><b>{meta.authorName}</b><small>{meta.authorEmail}</small></span><time title={new Date(meta.authorAt * 1000).toLocaleString(localeTag(locale))}>{formatCommitTime(meta.authorAt, new Date(), locale)}</time></div><div className="history-inspector-ids"><button type="button" className={`history-sha-copy${copied ? " is-copied" : ""}`} onClick={onCopy}>{fullHash}<span>{copied ? t("repository.history.copied") : t("repository.history.copy")}</span></button>{meta.parents.map((parent) => <button type="button" className="history-parent" key={parent.full} onClick={() => onParent(parent.full)}>{t("repository.history.parent", { short: parent.short })}</button>)}</div>{entry && <div className="history-ref-chips">{refBadges(entry).map((badge) => <RefBadgeChip key={`${badge.kind}:${badge.label}`} badge={badge} />)}</div>}</div>; }
 function CommitFiles({ files, selectedPath, additions, deletions, viewMode, onViewMode, onSelect, t }: { readonly files: readonly DiffFileEntry[]; readonly selectedPath: string | null; readonly additions: number; readonly deletions: number; readonly viewMode: FilesViewMode; readonly onViewMode: (mode: FilesViewMode) => void; readonly onSelect: (file: DiffFileEntry) => void; readonly t: T }) { return <section className="history-commit-files"><div className="history-files-title"><span className="history-files-label">{t("repository.history.changedFiles")}</span><span className="history-files-stats">{files.length} <i>+{additions}</i> <em>−{deletions}</em></span><FilesViewToggle mode={viewMode} onMode={onViewMode} t={t} /></div><div className="history-files-scroll">{viewMode === "tree" ? <DiffTreeView files={files} selectedPath={selectedPath} onSelect={onSelect} /> : files.map((file) => <FileRow key={file.path} entry={file} isSelected={file.path === selectedPath} onSelect={onSelect} t={t} />)}</div></section>; }
 
 interface HistoryPanelProps {
@@ -233,7 +291,9 @@ export function HistoryPanel({ ctx, repoRel, cacheScope = `${ctx.theaterId ?? ""
 
 function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, active, refFilter, wipFiles, workspace, workspaceMain, workspaceMainVisible, compareRequest, inspectRequest, onInspectorOpenChange, onClearRef, onWip }: Required<Pick<HistoryPanelProps, "active" | "cacheScope" | "ctx" | "externalRefreshToken" | "refFilter" | "repoRel" | "wipFiles" | "workspace" | "workspaceMainVisible">> & Pick<HistoryPanelProps, "workspaceMain" | "compareRequest" | "inspectRequest" | "onInspectorOpenChange" | "onClearRef" | "onWip">) {
   const t = getT(ctx.language);
-  const historyCacheKey = `${cacheScope}::${refFilter ?? ""}`;
+  const [order, setOrder] = useState<LogOrder>(readHistoryOrder);
+  // 정렬 축이 바뀌면 커밋 순서와 그래프 레이아웃이 통째로 달라지므로 캐시 슬롯도 분리한다.
+  const historyCacheKey = `${cacheScope}::${refFilter ?? ""}::${order}`;
   const searchTarget = useRepositorySearchTarget();
   const pendingSearchTargetHash = searchTarget?.theaterId === ctx.theaterId && searchTarget.repoRel === repoRel ? searchTarget.fullHash : null;
   const [initialRestore] = useState(() => readHistoryCacheRestore(historyCacheKey, pendingSearchTargetHash));
@@ -270,7 +330,7 @@ function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, acti
   const dockHeightRef = useRef(dockHeight);
   const handledCompareRequestSeqRef = useRef(0);
   const handledInspectRequestSeqRef = useRef(0);
-  const generation = useMemo<HistoryLoadGeneration>(() => ({ theaterId: ctx.theaterId, repoRel, refFilter, refreshToken: refreshToken + externalRefreshToken }), [ctx.theaterId, externalRefreshToken, refFilter, refreshToken, repoRel]);
+  const generation = useMemo<HistoryLoadGeneration>(() => ({ theaterId: ctx.theaterId, repoRel, refFilter, order, refreshToken: refreshToken + externalRefreshToken }), [ctx.theaterId, externalRefreshToken, order, refFilter, refreshToken, repoRel]);
   const generationRef = useRef(generation);
   generationRef.current = generation;
   const visible = useMemo(() => state.kind === "ok" ? filterHistoryCommits(state.commits, filterText) : [], [filterText, state]);
@@ -463,7 +523,7 @@ function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, acti
     loadingMoreRef.current = false;
     setLoadingMore(false);
     setLoadMoreError(null);
-    ctx.api.fetch("repository", "log", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ theaterId: ctx.theaterId, repoRel, limit: HISTORY_PAGE_SIZE, skip: 0, ...(refFilter ? { ref: refFilter } : {}) }) }).then(async (response) => {
+    ctx.api.fetch("repository", "log", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ theaterId: ctx.theaterId, repoRel, limit: HISTORY_PAGE_SIZE, skip: 0, order, ...(refFilter ? { ref: refFilter } : {}) }) }).then(async (response) => {
       if (!response.ok) throw new Error((await response.json() as { readonly error?: string }).error ?? "git_failed");
       return response.json() as Promise<LogResult>;
     }).then((data) => {
@@ -481,7 +541,7 @@ function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, acti
       if (!cancelled) setState({ kind: "error", message: error instanceof Error ? error.message : "unknown" });
     });
     return () => { cancelled = true; };
-  }, [ctx.api, ctx.theaterId, everActive, externalRefreshToken, historyCacheKey, pendingSearchTargetHash, refreshToken, refFilter, repoRel]);
+  }, [ctx.api, ctx.theaterId, everActive, externalRefreshToken, historyCacheKey, order, pendingSearchTargetHash, refreshToken, refFilter, repoRel]);
   useEffect(() => {
     if (state.kind !== "ok" || stateCacheKeyRef.current !== historyCacheKey) return;
     const list = listRef.current;
@@ -564,7 +624,7 @@ function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, acti
     ctx.api.fetch("repository", "log", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ theaterId: ctx.theaterId, repoRel, limit: HISTORY_PAGE_SIZE, skip: state.commits.length, ...(refFilter ? { ref: refFilter } : {}) }),
+      body: JSON.stringify({ theaterId: ctx.theaterId, repoRel, limit: HISTORY_PAGE_SIZE, skip: state.commits.length, order, ...(refFilter ? { ref: refFilter } : {}) }),
     }).then(async (response) => {
       if (!response.ok) throw new Error((await response.json() as { readonly error?: string }).error ?? "git_failed");
       return response.json() as Promise<LogResult>;
@@ -587,7 +647,14 @@ function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, acti
       loadingMoreRef.current = false;
       setLoadingMore(false);
     });
-  }, [ctx.api, ctx.theaterId, generation, historyCacheKey, refFilter, repoRel, state]);
+  }, [ctx.api, ctx.theaterId, generation, historyCacheKey, order, refFilter, repoRel, state]);
+  const toggleOrder = useCallback(() => {
+    setOrder((current) => {
+      const next: LogOrder = current === "topo" ? "date" : "topo";
+      saveHistoryOrder(next);
+      return next;
+    });
+  }, []);
   const refreshHistory = useCallback(() => {
     dropHistoryCache(historyCacheKey);
     loadedCacheKeyRef.current = null;
@@ -601,8 +668,8 @@ function HistoryPanelBody({ ctx, repoRel, cacheScope, externalRefreshToken, acti
     : undefined;
   return <div ref={rootRef} className={`history-root${workspace ? " repository-ws-history" : ""}${isDragging ? " is-dragging" : ""}`} style={stackTemplate ? { gridTemplateRows: stackTemplate } : undefined} onKeyDown={(event) => { if (event.key !== "Escape" || target) return; /* 검사기가 열려 있으면 Esc는 검사기 닫기 한 겹만 벗긴다 — 같은 키로 핀까지 잃지 않게 */ if (pin) { unpin(); event.stopPropagation(); event.preventDefault(); } else if (comparePair) { setComparePair(null); event.stopPropagation(); event.preventDefault(); } }}>
     <div className="history-list-pane" hidden={workspace && workspaceMainVisible}>
-      <div className="history-toolbar"><div className="history-filter"><input className="history-filter-input" placeholder={t("repository.common.filterPlaceholder")} value={filterText} onChange={(event) => setFilterText(event.target.value)} />{filterText && <button type="button" className="history-filter-clear" onClick={() => setFilterText("")}>✕</button>}</div>{pin && <button type="button" className="repository-ref-chip repository-pin-chip" title={t("repository.compare.pinnedHint")} onClick={unpin}>⇆ {t("repository.compare.pinnedChip", { short: pin.shortHash })} ✕</button>}{refFilter && <button type="button" className="repository-ref-chip" title={refFilter} onClick={onClearRef}>⎇ {shortRefName(refFilter)} ✕</button>}{state.kind === "ok" && <><span className="history-count" title={t("repository.history.countLegend")}>{filterText ? `${visible.length}/${state.commits.length}` : state.commits.length}</span><button type="button" className="repository-refresh-btn" onClick={refreshHistory}>{t("repository.history.refresh")}</button></>}<span className="repository-sr-only" role="status">{announce}</span></div>
-      <div ref={listRef} className="history-list" onScroll={updateCommitViewport}>{showWip && <button type="button" className="repository-wip-row" onClick={onWip}>{t("repository.history.uncommitted")} <span>{t(wip.files === 1 ? "repository.history.wipStats_one" : "repository.history.wipStats_other", { count: wip.files, additions: wip.additions, deletions: wip.deletions })}</span></button>}{state.kind === "loading" && <div className="history-empty">{t("repository.common.loading")}</div>}{state.kind === "error" && <div className="history-error">{state.message}<button type="button" className="repository-refresh-btn" onClick={refreshHistory}>{t("repository.common.retry")}</button></div>}{state.kind === "ok" && state.commits.length === 0 && <div className="history-empty">{t("repository.history.empty")}</div>}{state.kind === "ok" && state.commits.length > 0 && visible.length === 0 && <div className="history-empty">{t("repository.common.noMatchingItems")}</div>}{state.kind === "ok" && layout && visible.length > 0 && <div ref={commitWindowRef} className="history-commit-window"><div className="history-window-spacer" aria-hidden="true" style={{ height: virtualWindow.topSpacerHeight }} />{windowRows.map(({ entry, graphNode }) => <CommitRow key={entry.fullHash} rowRef={(node) => { if (node) rowRefs.current.set(entry.fullHash, node); else rowRefs.current.delete(entry.fullHash); }} entry={entry} checkouts={state.checkouts} selected={target?.fullHash === entry.fullHash} picked={pin?.fullHash === entry.fullHash || comparePair?.base === entry.fullHash || comparePair?.head === entry.fullHash} pin={pin} graphNode={graphNode} laneCount={layout.activeLaneCount} onRowActivate={onRowActivate} onCompareAction={onCompareAction} locale={ctx.language} />)}<div className="history-window-spacer" aria-hidden="true" style={{ height: virtualWindow.bottomSpacerHeight }} /></div>}{state.kind === "ok" && state.commits.length > 0 && <div className="history-pagination">{state.hasMore ? loadingMore ? <span>{t("repository.history.loadingMore")}</span> : <button type="button" className="repository-refresh-btn" onClick={loadMore}>{t("repository.history.loadMore")}</button> : <><span>{t("repository.history.end")}</span>{state.truncated && <span>{t("repository.history.capped")}</span>}</>}{loadMoreError && <span className="history-pagination-error">{loadMoreError}</span>}</div>}</div>
+      <div className="history-toolbar"><div className="history-filter"><input className="history-filter-input" placeholder={t("repository.common.filterPlaceholder")} value={filterText} onChange={(event) => setFilterText(event.target.value)} />{filterText && <button type="button" className="history-filter-clear" onClick={() => setFilterText("")}>✕</button>}</div>{pin && <button type="button" className="repository-ref-chip repository-pin-chip" title={t("repository.compare.pinnedHint")} onClick={unpin}>⇆ {t("repository.compare.pinnedChip", { short: pin.shortHash })} ✕</button>}{refFilter && <button type="button" className="repository-ref-chip" title={refFilter} onClick={onClearRef}>⎇ {shortRefName(refFilter)} ✕</button>}{state.kind === "ok" && <><span className="history-count" title={t("repository.history.countLegend")}>{filterText ? `${visible.length}/${state.commits.length}` : state.commits.length}</span><button type="button" className="history-order-toggle" aria-label={t("repository.history.orderToggle")} title={t(order === "topo" ? "repository.history.orderTopoHint" : "repository.history.orderDateHint")} onClick={toggleOrder}><OrderIcon order={order} />{t(order === "topo" ? "repository.history.orderTopo" : "repository.history.orderDate")}</button><button type="button" className="repository-refresh-btn" onClick={refreshHistory}>{t("repository.history.refresh")}</button></>}<span className="repository-sr-only" role="status">{announce}</span></div>
+      <div ref={listRef} className="history-list" onScroll={updateCommitViewport}>{showWip && <button type="button" className="repository-wip-row" onClick={onWip}>{t("repository.history.uncommitted")} <span>{t(wip.files === 1 ? "repository.history.wipStats_one" : "repository.history.wipStats_other", { count: wip.files, additions: wip.additions, deletions: wip.deletions })}</span></button>}{state.kind === "loading" && <div className="history-empty">{t("repository.common.loading")}</div>}{state.kind === "error" && <div className="history-error">{state.message}<button type="button" className="repository-refresh-btn" onClick={refreshHistory}>{t("repository.common.retry")}</button></div>}{state.kind === "ok" && state.commits.length === 0 && <div className="history-empty">{t("repository.history.empty")}</div>}{state.kind === "ok" && state.commits.length > 0 && visible.length === 0 && <div className="history-empty">{t("repository.common.noMatchingItems")}</div>}{state.kind === "ok" && layout && visible.length > 0 && <div ref={commitWindowRef} className="history-commit-window"><div className="history-window-spacer" aria-hidden="true" style={{ height: virtualWindow.topSpacerHeight }} />{windowRows.map(({ entry, graphNode }) => <CommitRow key={entry.fullHash} rowRef={(node) => { if (node) rowRefs.current.set(entry.fullHash, node); else rowRefs.current.delete(entry.fullHash); }} entry={entry} checkouts={state.checkouts} selected={target?.fullHash === entry.fullHash} picked={pin?.fullHash === entry.fullHash || comparePair?.base === entry.fullHash || comparePair?.head === entry.fullHash} pin={pin} graphNode={graphNode} onRowActivate={onRowActivate} onCompareAction={onCompareAction} locale={ctx.language} />)}<div className="history-window-spacer" aria-hidden="true" style={{ height: virtualWindow.bottomSpacerHeight }} /></div>}{state.kind === "ok" && state.commits.length > 0 && <div className="history-pagination">{state.hasMore ? loadingMore ? <span>{t("repository.history.loadingMore")}</span> : <button type="button" className="repository-refresh-btn" onClick={loadMore}>{t("repository.history.loadMore")}</button> : <><span>{t("repository.history.end")}</span>{state.truncated && <span>{t("repository.history.capped")}</span>}</>}{loadMoreError && <span className="history-pagination-error">{loadMoreError}</span>}</div>}</div>
     </div>
     {workspaceMain !== undefined && <div className="repository-ws-main" hidden={!workspaceMainVisible}>{workspaceMain}</div>}
     {detailOpen && <><div className="history-divider history-divider--horizontal" role="separator" aria-orientation="horizontal" aria-label={workspace ? t("repository.history.resizeDock") : t("repository.history.resizeLog")} onPointerDown={handleDivider} /><div className="history-detail-pane">{comparePair ? <CompareInspector ctx={ctx} repoRel={repoRel} pair={comparePair} onSwap={() => setComparePair({ base: comparePair.head, head: comparePair.base, baseLabel: comparePair.headLabel, headLabel: comparePair.baseLabel })} onClose={() => setComparePair(null)} /> : target ? <CommitInspector ctx={ctx} repoRel={repoRel} target={target} workspace={workspace} onSelectCommit={(next) => { setComparePair(null); setTarget(next); }} onPinCompare={() => setPinFrom({ fullHash: target.fullHash, shortHash: target.entry?.shortHash ?? target.fullHash.slice(0, 9) })} onClose={() => setTarget(null)} /> : null}</div></>}
@@ -612,3 +679,9 @@ function readLogPaneHeight(): number { return readSize(PREFS_LOG_PANE_HEIGHT, LO
 function readSize(key: string, fallback: number, minimum = 0): number { try { const value = Number.parseFloat(localStorage.getItem(key) ?? ""); if (Number.isFinite(value) && value >= minimum) return value; } catch { /* ignore */ } return fallback; }
 function initials(name: string): string { return name.split(/[\s@._-]+/).filter(Boolean).slice(0, 2).map((part) => part[0]!.toUpperCase()).join("") || "?"; }
 function HistoryIcon() { return <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><path d="M5 3v12M10 7v8M14 11v4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" /><path d="M5 7c1.8 0 2.4 0 5 0M10 11c1.4 0 2.2 0 4 0" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" /></svg>; }
+/** topo는 갈라졌다 합류하는 갈래를, date는 시계를 그린다 — 라벨과 같은 축을 도형으로 한 번 더 말한다. */
+function OrderIcon({ order }: { readonly order: LogOrder }) {
+  return order === "topo"
+    ? <svg className="history-order-icon" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M3.4 1.6v8.8M3.4 4.2h3.4a1.8 1.8 0 011.8 1.8v4.4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" /></svg>
+    : <svg className="history-order-icon" viewBox="0 0 12 12" fill="none" aria-hidden="true"><circle cx="6" cy="6" r="4.4" stroke="currentColor" strokeWidth="1.2" /><path d="M6 3.4V6l1.9 1.3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" /></svg>;
+}

--- a/runtime/fleet-plugins/repository/client/i18n/index.ts
+++ b/runtime/fleet-plugins/repository/client/i18n/index.ts
@@ -92,6 +92,12 @@ export const repositoryEn = {
   "repository.history.resizeDock": "Resize commit detail dock",
   "repository.history.resizeFileList": "Resize file list",
   "repository.history.resizeLog": "Resize commit log",
+  "repository.history.hasBody": "Has a commit message body",
+  "repository.history.orderToggle": "Switch commit order",
+  "repository.history.orderTopo": "topo",
+  "repository.history.orderDate": "date",
+  "repository.history.orderTopoHint": "Topological order — branch chains stay contiguous. Click for date order.",
+  "repository.history.orderDateHint": "Date order — every ref interleaved newest first. Click for topological order.",
 
   // time
   "repository.time.today": "Today {time}",
@@ -220,6 +226,12 @@ export const repositoryKo: Record<keyof typeof repositoryEn, string> = {
   "repository.history.resizeDock": "커밋 상세 독 크기 조절",
   "repository.history.resizeFileList": "파일 목록 크기 조절",
   "repository.history.resizeLog": "커밋 로그 크기 조절",
+  "repository.history.hasBody": "커밋 메시지 본문이 있음",
+  "repository.history.orderToggle": "커밋 정렬 전환",
+  "repository.history.orderTopo": "계보순",
+  "repository.history.orderDate": "시간순",
+  "repository.history.orderTopoHint": "계보순 — 브랜치 체인이 끊기지 않고 이어집니다. 누르면 시간순으로 전환합니다.",
+  "repository.history.orderDateHint": "시간순 — 모든 ref를 최신 커밋부터 뒤섞어 나열합니다. 누르면 계보순으로 전환합니다.",
 
   "repository.time.today": "오늘 {time}",
   "repository.time.yesterday": "어제 {time}",

--- a/runtime/fleet-plugins/repository/client/repository-parsers.ts
+++ b/runtime/fleet-plugins/repository/client/repository-parsers.ts
@@ -52,6 +52,19 @@ export function formatCommitTime(authorAt: number, now = new Date(), locale: Con
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
 }
 
+/**
+ * Conventional Commit 접두(`type(scope)!:`)를 제목 본문에서 분리한다 — Fork처럼 접두만 강조하기 위해서다.
+ * 콜론 뒤 공백을 요구하므로 `https://…` 같은 스킴은 접두로 오인되지 않는다. 규약을 따르지 않는 제목은
+ * 접두 없이 그대로 돌려주므로 호출부가 한 가지 경로만 렌더하면 된다.
+ */
+const CONVENTIONAL_SUBJECT_RE = /^([A-Za-z][\w-]*(?:\([^()]*\))?!?:)\s+(.+)$/;
+
+export function splitCommitSubject(subject: string): { readonly prefix: string | null; readonly rest: string } {
+  const match = CONVENTIONAL_SUBJECT_RE.exec(subject);
+  if (!match) return { prefix: null, rest: subject };
+  return { prefix: match[1]!, rest: match[2]! };
+}
+
 export function refBadges(entry: LogCommitEntry): RefBadge[] {
   const badges: RefBadge[] = [];
   for (const ref of entry.refs) {

--- a/runtime/fleet-plugins/repository/client/repository-state.ts
+++ b/runtime/fleet-plugins/repository/client/repository-state.ts
@@ -1,6 +1,25 @@
 import { useSyncExternalStore } from "react";
 
-import type { DiffFileEntry, LogCommitEntry, WorktreeCheckout } from "../server/types.js";
+import type { DiffFileEntry, LogCommitEntry, LogOrder, WorktreeCheckout } from "../server/types.js";
+
+// ═══ history-order-preference ════════════════════════════════════════════════
+
+const HISTORY_ORDER_KEY = "fleet-console.history.order";
+
+/** 저장된 값이 없거나 알아볼 수 없으면 topo — 브랜치 체인이 끊기지 않는 쪽이 기본이다. */
+export function readHistoryOrder(): LogOrder {
+  try {
+    return localStorage.getItem(HISTORY_ORDER_KEY) === "date" ? "date" : "topo";
+  } catch {
+    return "topo";
+  }
+}
+
+export function saveHistoryOrder(order: LogOrder): void {
+  try {
+    localStorage.setItem(HISTORY_ORDER_KEY, order);
+  } catch { /* ignore */ }
+}
 
 // ═══ history-cache ═══════════════════════════════════════════════════════════
 

--- a/runtime/fleet-plugins/repository/client/repository.css
+++ b/runtime/fleet-plugins/repository/client/repository.css
@@ -736,6 +736,39 @@
   text-align: center;
 }
 
+/* 정렬 축 토글 — 현재 축을 라벨로 드러내고 누르면 반대 축으로 넘어간다.
+   두 상태가 대등해 어느 쪽도 "켜짐"이 아니므로 pressed 문법 대신 현재 값을 그대로 보여 준다. */
+.history-order-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: none;
+  padding: 3px 8px;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  background: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.history-order-toggle:hover {
+  border-color: color-mix(in oklch, var(--brass) 40%, var(--surface-rim));
+  color: var(--text-secondary);
+}
+
+.history-order-toggle:focus-visible {
+  outline: 1px solid var(--brass);
+  outline-offset: -1px;
+}
+
+.history-order-icon {
+  width: 11px;
+  height: 11px;
+  flex: none;
+}
+
 .history-list {
   min-height: 0;
   overflow: auto;
@@ -758,7 +791,7 @@
 
 .history-commit-row-main {
   display: grid;
-  grid-template-columns: auto auto minmax(120px, 1fr) minmax(78px, auto) 7ch 10ch;
+  grid-template-columns: auto auto minmax(120px, 1fr) auto minmax(0, auto) 7ch 10ch;
   align-items: center;
   gap: 0 8px;
   width: 100%;
@@ -786,7 +819,8 @@
    강등은 opacity가 아니라 텍스트 티어로 표현한다: 색 × 투명도 이중 감쇠는 판독 하한을 지키는
    토큰을 무력화한다(off-head 제목 실측 2.36:1). 티어 강등이면 하한이 그대로 보장된다. */
 .history-commit-row.is-off-head .history-commit-subject,
-.history-commit-row.is-off-head .history-commit-author,
+.history-commit-row.is-off-head .history-commit-kind,
+.history-commit-row.is-off-head .history-commit-author-name,
 .history-commit-row.is-off-head .history-commit-sha,
 .history-commit-row.is-off-head .history-commit-time {
   color: var(--text-tertiary);
@@ -806,17 +840,38 @@
   white-space: nowrap;
 }
 
+/* Fork 문법의 ref 뱃지 — 알약이 아니라 아이콘 칸과 라벨 칸이 구분선으로 나뉜 라운드 사각이고,
+   라벨은 볼드 sans로 훑어 읽힌다. 색조는 --badge-tone 하나로만 흐르며 테두리·아이콘·바탕이 그 톤을 공유한다.
+   기본 톤은 중성이고, 종류가 고정된 축(체크아웃 위치=brass, 태그=plum)만 아래 규칙이 덮어쓴다.
+   나머지 브랜치·원격·워크트리는 커밋 행이 자기 레인 색을 인라인으로 주입한다 —
+   장식적 구분 채도는 그래프 레인과 같은 --id-* 정체성 봉투에서만 오고, 상태 신호 채널을 침범하지 않는다. */
 .history-badge {
+  --badge-tone: var(--ink-fog);
+  display: inline-flex;
+  align-items: stretch;
+  flex: none;
+  overflow: hidden;
+  border: 1px solid color-mix(in oklch, var(--badge-tone) 62%, transparent);
+  border-radius: var(--radius-xs);
+  background: color-mix(in oklch, var(--badge-tone) 15%, transparent);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 10.5px;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.01em;
+  line-height: 1.5;
+}
+
+.history-badge-mark {
   display: inline-flex;
   align-items: center;
-  gap: 3px;
-  flex: none;
+  padding: 0 3px;
+  border-right: 1px solid color-mix(in oklch, var(--badge-tone) 45%, transparent);
+  color: color-mix(in oklch, var(--badge-tone) 85%, var(--text-primary));
+}
+
+.history-badge-label {
   padding: 0 5px;
-  border-radius: 999px;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.04em;
-  line-height: 1.55;
 }
 
 .history-badge-icon {
@@ -824,30 +879,18 @@
   height: 11px;
 }
 
-.history-badge--head {
-  color: var(--brass-ink);
-  border: 1px solid color-mix(in oklch, var(--brass) 48%, transparent);
+.history-badge--head,
+.history-badge.is-current {
+  --badge-tone: var(--brass);
 }
 
 .history-badge--tag {
-  color: var(--text-secondary);
-  border: 1px solid color-mix(in oklch, var(--ink-fog) 45%, transparent);
+  --badge-tone: var(--id-plum);
 }
 
-.history-badge--branch {
-  color: var(--text-secondary);
-  border: 1px solid color-mix(in oklch, var(--ink-fog) 45%, transparent);
-  background: color-mix(in oklch, var(--ink-fog) 10%, transparent);
-}
-
+/* 원격 추적 ref는 이 워크트리에 없는 사본이므로 테두리를 파선으로 낮춘다 — 톤은 그대로 공유한다. */
 .history-badge--remote {
-  color: var(--text-secondary);
-  border: 1px dashed color-mix(in oklch, var(--ink-fog) 60%, transparent);
-}
-
-.history-badge--worktree {
-  color: var(--text-secondary);
-  border: 1px dashed color-mix(in oklch, var(--ink-fog) 60%, transparent);
+  border-style: dashed;
 }
 
 .history-commit-subject,
@@ -861,7 +904,41 @@
   font-size: 12.5px;
 }
 
-.history-commit-author,
+/* Fork 문법 — Conventional Commit 접두만 한 티어 올려, 스캔할 때 커밋 종류가 먼저 읽힌다. */
+.history-commit-kind {
+  color: var(--text-primary);
+  font-weight: var(--weight-bold);
+}
+
+.history-commit-body-mark {
+  color: var(--text-tertiary);
+  font-size: 11px;
+  line-height: 1;
+}
+
+.history-commit-author {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+}
+
+.history-commit-avatar {
+  display: grid;
+  width: 16px;
+  height: 16px;
+  flex: none;
+  place-items: center;
+  border-radius: 50%;
+  background: color-mix(in oklch, var(--ink-fog) 24%, var(--ink-veil));
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 8px;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0;
+}
+
+.history-commit-author-name,
 .history-commit-sha,
 .history-commit-time,
 .history-detail-sha {
@@ -958,28 +1035,25 @@
   overflow: hidden;
 }
 
-@container (max-width: 500px) {
-  .history-commit-author {
-    display: none;
-  }
-}
-
 /* Segmented Commit Inspector — master graph/list remains above the detail. */
 .history-root { grid-template-rows: minmax(0, 1fr); }
 .history-list-pane { grid-row: 1; grid-column: 1; border-bottom: 1px solid var(--surface-rim); }
 .history-detail-pane { grid-row: 3; grid-column: 1; border-right: 0; border-left: 0; background: color-mix(in oklch, var(--surface-glass) 70%, transparent); }
 .history-root > .history-divider { grid-row: 2; grid-column: 1; touch-action: none; }
 .history-divider { touch-action: none; }
-.history-commit-row-main { grid-template-columns: auto auto minmax(96px, 1fr) 7ch auto; gap: 0 7px; }
+.history-commit-row-main { grid-template-columns: auto auto minmax(96px, 1fr) auto minmax(0, auto) 7ch auto; gap: 0 7px; }
 /* gutter는 DOM 최후미이나 col 1에 놓이므로 grid-row를 고정하지 않으면 auto-placement가 커서를 되돌리지 못해
    유령 2행 트랙(0px 28px)을 만든다 → 텍스트는 0px 트랙 상단, 노드는 28px 트랙 중앙으로 반 행 어긋난다.
-   grid-row: 1로 전 셀을 단일 28px 트랙에 묶어 노드와 커밋 텍스트를 정렬한다. */
+   grid-row: 1로 전 셀을 단일 28px 트랙에 묶어 노드와 커밋 텍스트를 정렬한다. 본문 마커는 조건부 셀이라
+   나머지 셀도 열을 명시해야 마커가 없는 행에서 뒤 셀들이 한 칸씩 당겨지지 않는다. */
 .history-graph-gutter { grid-column: 1; grid-row: 1; }
 /* Fork 문법 — refs 뱃지가 제목 앞(그래프 뒤)에서 커밋의 정체를 먼저 알린다. */
-.history-commit-badges { grid-column: 2; max-width: 40cqw; }
-.history-commit-subject { grid-column: 3; min-width: 96px; }
-.history-commit-sha { grid-column: 4; }
-.history-commit-time { grid-column: 5; }
+.history-commit-badges { grid-column: 2; grid-row: 1; max-width: 40cqw; }
+.history-commit-subject { grid-column: 3; grid-row: 1; min-width: 96px; }
+.history-commit-body-mark { grid-column: 4; grid-row: 1; }
+.history-commit-author { grid-column: 5; grid-row: 1; }
+.history-commit-sha { grid-column: 6; grid-row: 1; }
+.history-commit-time { grid-column: 7; grid-row: 1; }
 .history-inspector { display: grid; grid-template-rows: auto minmax(0, 1fr); height: 100%; min-height: 0; }
 .history-segmented { display: flex; gap: 4px; padding: 8px 12px; border-bottom: 1px solid var(--surface-rim); }
 .history-segmented button { flex: 1; border: 1px solid transparent; border-radius: var(--radius-sm); background: none; color: var(--text-tertiary); cursor: pointer; font-family: var(--font-mono); font-size: 11px; letter-spacing: .01em; padding: 6px; transition: color var(--duration-fast) var(--ease-glide), background var(--duration-fast) var(--ease-glide); }
@@ -1008,17 +1082,24 @@
 .history-changes-tab { min-height: 0; overflow: hidden; }.history-changes-columns { display: grid; min-height: 0; height: 100%; }.history-changes-columns > .history-commit-files { border-right: 1px solid var(--surface-rim); }
 .history-file-diff { display: grid; grid-template-rows: auto minmax(0, 1fr); min-width: 0; overflow: hidden; }.history-file-repository-head { display: flex; align-items: center; gap: 8px; min-width: 0; padding: 7px 12px; border-bottom: 1px solid var(--surface-rim); color: var(--text-tertiary); font-family: var(--font-mono); font-size: 11px; }.history-file-repository-head > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }.history-file-repository-head > div { display: flex; gap: 2px; margin-left: auto; }.history-file-repository-head button { width: 24px; height: 24px; border: 1px solid var(--surface-rim); border-radius: var(--radius-sm); background: none; color: var(--text-tertiary); cursor: pointer; }.history-file-repository-head button:disabled { cursor: default; opacity: .4; }
 .history-inspector-empty { padding: 16px; color: var(--text-tertiary); font-family: var(--font-mono); font-size: 12px; }.history-inspector-error { color: var(--coral-ink); }
-/* 진행형 축소 — 컨테이너(패널·트리 리사이즈)가 좁아질수록 시간 → sha → 뱃지 순으로 양보한다.
+/* 진행형 축소 — 컨테이너(패널·트리 리사이즈)가 좁아질수록 작성자 → 시간 → sha → 뱃지 순으로 양보한다.
+   숨긴 셀은 grid item에서 빠지므로 그 자리의 트랙까지 함께 걷어내야 한다(7ch 같은 고정 트랙은 비어도 폭을 잡는다).
    제목은 어느 폭에서도 한 줄을 유지한다(기본 규칙의 nowrap+ellipsis): 행 높이는 그래프 gutter의
    ROW_HEIGHT(28px)와 가상 스크롤 기하에 묶여 있어 줄바꿈이 레인 선과 스크롤 위치를 함께 깨뜨린다. */
+@container (max-width: 760px) {
+  .history-commit-author { display: none; }
+  .history-commit-row-main { grid-template-columns: auto auto minmax(96px, 1fr) auto 7ch auto; }
+  .history-commit-sha { grid-column: 5; }
+  .history-commit-time { grid-column: 6; }
+}
 @container (max-width: 640px) {
   .history-commit-time { display: none; }
   .history-commit-row-main {
-    grid-template-columns: auto auto minmax(96px, 1fr) 7ch;
+    grid-template-columns: auto auto minmax(96px, 1fr) auto 7ch;
   }
 }
-@container (max-width: 520px) { .history-commit-sha { display: none; } .history-commit-row-main { grid-template-columns: auto auto minmax(96px, 1fr); } }
-@container (max-width: 420px) { .history-commit-badges { display: none; } .history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr); } .history-commit-subject { grid-column: 2; } }
+@container (max-width: 520px) { .history-commit-sha { display: none; } .history-commit-row-main { grid-template-columns: auto auto minmax(96px, 1fr) auto; } }
+@container (max-width: 420px) { .history-commit-badges { display: none; } .history-commit-row-main { grid-template-columns: auto minmax(96px, 1fr) auto; } .history-commit-subject { grid-column: 2; } .history-commit-body-mark { grid-column: 3; } }
 @media (prefers-reduced-motion: reduce) { .history-segmented button { transition-duration: .01ms; } }
 /* Repository sources mirror the approved unified explorer. */
 .repository-unified { display: flex; flex-direction: column; min-width: 0; min-height: 0; height: 100%; container-type: inline-size; }

--- a/runtime/fleet-plugins/repository/server/log.ts
+++ b/runtime/fleet-plugins/repository/server/log.ts
@@ -24,8 +24,12 @@ const CANONICAL_REF_RE = /^refs\/(?:heads|remotes|tags)\//;
 // rev-parse가 reflog/조상 표현식을 해석해 /refs 열거 밖 커밋으로 필터되는 것을 막는다
 const REF_METACHAR_RE = /[~^:?*\[\\\s\x00-\x1f\x7f]/;
 
-// %b(본문)는 개행을 담을 수 있으므로 반드시 마지막 필드여야 한다 — 앞에 두면 뒤 필드가 다음 줄로 밀려 파싱이 깨진다.
-const LOG_PRETTY_FORMAT = "--pretty=format:%x1e%H%x00%h%x00%s%x00%an%x00%ar%x00%at%x00%D%x00%P%x00%b";
+// 본문은 존재 여부만 필요하므로 %b를 8칸으로 절단해 싣는다. 절단하지 않으면 커밋 하나의 본문 길이에
+// 상한이 없어, 목록 한 페이지가 runGit의 stdout 버퍼(8 MiB)를 먼저 소진할 수 있다. 그때 파싱되는 레코드 수가
+// limit 아래로 떨어지면 hasMore가 false로 접혀 그보다 오래된 이력이 페이지네이션에서 통째로 사라진다.
+// 절단본은 한 줄로 눌리므로 뒤 필드를 다음 줄로 밀지도 않는다. 여전히 마지막 필드 자리를 지킨다.
+// 알려진 한계: 본문이 공백 8칸으로 시작하면 존재 여부가 false로 읽힌다 — 마커 한 개가 빠질 뿐이다.
+const LOG_PRETTY_FORMAT = "--pretty=format:%x1e%H%x00%h%x00%s%x00%an%x00%ar%x00%at%x00%D%x00%P%x00%<(8,trunc)%b";
 
 // 정렬 축은 화이트리스트 상수로만 git 인자가 된다 — 요청 문자열이 인자 위치에 직접 닿지 않게 한다.
 const LOG_ORDER_ARGS: Readonly<Record<LogOrder, string>> = { topo: "--topo-order", date: "--date-order" };
@@ -78,9 +82,9 @@ export function parseLogOutput(stdout: string): LogCommitEntry[] {
 
     const refs = refsRaw.split(",").map((r) => r.trim()).filter(Boolean);
     const parents = parentsRaw.split(" ").map((p) => p.trim()).filter(Boolean);
-    // 본문은 마지막 필드이므로 첫 줄의 9번째 조각과 그 뒤의 모든 줄에 걸쳐 있다.
-    // 존재 여부만 남기고 내용은 버린다 — 목록 페이로드에 본문 전체를 싣지 않기 위해서다.
-    const hasBody = (fields[8] ?? "").trim() !== "" || lines.slice(1).some((line) => line.trim() !== "");
+    // 본문 필드는 8칸으로 절단되어 한 줄에 들어오므로 첫 줄의 9번째 조각만 보면 된다.
+    // 빈 본문은 공백으로 채워져 오고, 내용이 있으면 잘린 앞부분이 온다 — 존재 여부만 남기고 내용은 버린다.
+    const hasBody = (fields[8] ?? "").trim() !== "";
 
     commits.push({
       shortHash,

--- a/runtime/fleet-plugins/repository/server/log.ts
+++ b/runtime/fleet-plugins/repository/server/log.ts
@@ -4,7 +4,7 @@ import type http from "node:http";
 import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 
 import { GitExecutorError, runGit } from "./git-executor.js";
-import type { LogCommitEntry, WorktreeCheckout } from "./types.js";
+import type { LogCommitEntry, LogOrder, WorktreeCheckout } from "./types.js";
 import { InvalidRepoError, resolveGitCwd } from "./diff.js";
 
 // ─── types ───────────────────────────────────────────────────────────────────
@@ -23,6 +23,17 @@ const CANONICAL_REF_RE = /^refs\/(?:heads|remotes|tags)\//;
 // gitrevisions 선택자(@{n}·^·~ 등)와 check-ref-format 금지 문자를 이름 수준에서 거부한다 —
 // rev-parse가 reflog/조상 표현식을 해석해 /refs 열거 밖 커밋으로 필터되는 것을 막는다
 const REF_METACHAR_RE = /[~^:?*\[\\\s\x00-\x1f\x7f]/;
+
+// %b(본문)는 개행을 담을 수 있으므로 반드시 마지막 필드여야 한다 — 앞에 두면 뒤 필드가 다음 줄로 밀려 파싱이 깨진다.
+const LOG_PRETTY_FORMAT = "--pretty=format:%x1e%H%x00%h%x00%s%x00%an%x00%ar%x00%at%x00%D%x00%P%x00%b";
+
+// 정렬 축은 화이트리스트 상수로만 git 인자가 된다 — 요청 문자열이 인자 위치에 직접 닿지 않게 한다.
+const LOG_ORDER_ARGS: Readonly<Record<LogOrder, string>> = { topo: "--topo-order", date: "--date-order" };
+
+export function resolveLogOrder(requested: unknown): LogOrder | null {
+  if (requested === undefined) return "topo";
+  return requested === "topo" || requested === "date" ? requested : null;
+}
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
@@ -67,6 +78,9 @@ export function parseLogOutput(stdout: string): LogCommitEntry[] {
 
     const refs = refsRaw.split(",").map((r) => r.trim()).filter(Boolean);
     const parents = parentsRaw.split(" ").map((p) => p.trim()).filter(Boolean);
+    // 본문은 마지막 필드이므로 첫 줄의 9번째 조각과 그 뒤의 모든 줄에 걸쳐 있다.
+    // 존재 여부만 남기고 내용은 버린다 — 목록 페이로드에 본문 전체를 싣지 않기 위해서다.
+    const hasBody = (fields[8] ?? "").trim() !== "" || lines.slice(1).some((line) => line.trim() !== "");
 
     commits.push({
       shortHash,
@@ -78,6 +92,7 @@ export function parseLogOutput(stdout: string): LogCommitEntry[] {
       refs,
       parents,
       onHead: true,
+      hasBody,
     });
   }
 
@@ -189,11 +204,13 @@ export async function handleRepositoryLog(
   if (req.method !== "POST") { ctx.host.http.writeJson(res, 405, { error: "Method not allowed" }); return; }
   if (!ctx.host.security.isTerminalAuthorized(req)) { ctx.host.http.writeJson(res, 401, { error: "unauthorized" }); return; }
 
-  const body = await ctx.host.http.readJsonBody<{ readonly theaterId?: unknown; readonly repoRel?: unknown; readonly subPath?: unknown; readonly ref?: unknown; readonly limit?: unknown; readonly skip?: unknown }>(req);
+  const body = await ctx.host.http.readJsonBody<{ readonly theaterId?: unknown; readonly repoRel?: unknown; readonly subPath?: unknown; readonly ref?: unknown; readonly limit?: unknown; readonly skip?: unknown; readonly order?: unknown }>(req);
   if (!isPlainObject(body) || "subPath" in body) { ctx.host.http.writeJson(res, 400, { error: "invalid_request" }); return; }
 
   const theaterId = body.theaterId;
   if (typeof theaterId !== "string") { ctx.host.http.writeJson(res, 400, { error: "invalid_request" }); return; }
+  const order = resolveLogOrder(body.order);
+  if (order === null) { ctx.host.http.writeJson(res, 400, { error: "invalid_request" }); return; }
   const limit = body.limit === undefined ? 200 : body.limit;
   const skip = body.skip === undefined ? 0 : body.skip;
   if (!Number.isInteger(limit) || typeof limit !== "number" || limit < 1 || limit > 500
@@ -241,11 +258,12 @@ export async function handleRepositoryLog(
     const [realGitCwd, realToplevel] = await Promise.all([normalizeWorktreePath(gitCwd), normalizeWorktreePath(currentWorktreePath)]);
     const scopePathspec = realToplevel !== "" && realGitCwd === realToplevel ? [] : ["."];
     const skipArg = skip > 0 ? [`--skip=${skip}`] : [];
+    const orderArg = LOG_ORDER_ARGS[order];
     const result = resolvedRef
-      ? await runGit(["log", resolvedRef, "--date-order", "-n", String(limit + 1), ...skipArg, "--decorate=full", "--pretty=format:%x1e%H%x00%h%x00%s%x00%an%x00%ar%x00%at%x00%D%x00%P", "--", ...scopePathspec], { cwd: gitCwd })
+      ? await runGit(["log", resolvedRef, orderArg, "-n", String(limit + 1), ...skipArg, "--decorate=full", LOG_PRETTY_FORMAT, "--", ...scopePathspec], { cwd: gitCwd })
       : await runGit(
         // --all은 refs/stash·refs/notes까지 그래프에 유입시키므로 브랜치/태그/원격 + 현재 HEAD + 워크트리 HEAD로 한정한다
-        ["log", "--branches", "--tags", "--remotes", "--date-order", "-n", String(limit + 1), ...skipArg, "--decorate=full", "--pretty=format:%x1e%H%x00%h%x00%s%x00%an%x00%ar%x00%at%x00%D%x00%P", ...headRevs, ...worktreeRevs, "--", ...scopePathspec],
+        ["log", "--branches", "--tags", "--remotes", orderArg, "-n", String(limit + 1), ...skipArg, "--decorate=full", LOG_PRETTY_FORMAT, ...headRevs, ...worktreeRevs, "--", ...scopePathspec],
         { cwd: gitCwd },
       );
     const parsedCommits = parseLogOutput(result.stdout);

--- a/runtime/fleet-plugins/repository/server/log.ts
+++ b/runtime/fleet-plugins/repository/server/log.ts
@@ -24,10 +24,10 @@ const CANONICAL_REF_RE = /^refs\/(?:heads|remotes|tags)\//;
 // rev-parse가 reflog/조상 표현식을 해석해 /refs 열거 밖 커밋으로 필터되는 것을 막는다
 const REF_METACHAR_RE = /[~^:?*\[\\\s\x00-\x1f\x7f]/;
 
-// 본문은 존재 여부만 필요하므로 %b를 8칸으로 절단해 싣는다. 절단하지 않으면 커밋 하나의 본문 길이에
-// 상한이 없어, 목록 한 페이지가 runGit의 stdout 버퍼(8 MiB)를 먼저 소진할 수 있다. 그때 파싱되는 레코드 수가
-// limit 아래로 떨어지면 hasMore가 false로 접혀 그보다 오래된 이력이 페이지네이션에서 통째로 사라진다.
-// 절단본은 한 줄로 눌리므로 뒤 필드를 다음 줄로 밀지도 않는다. 여전히 마지막 필드 자리를 지킨다.
+// 본문은 존재 여부만 필요하므로 %b를 8칸으로 절단해 싣는다. 평범한 저장소에서 페이지 페이로드를 크게 줄이고
+// (실측: 400KB 본문 6커밋이 2.4MB → 1KB), 절단본은 한 줄로 눌려 뒤 필드를 다음 줄로 밀지도 않는다.
+// 다만 이 절단은 페이지 크기의 안전장치가 아니다 — 폭은 바이트가 아니라 표시 칸이라 폭 0인 문자에는 걸리지 않고,
+// %s·%D도 똑같이 바이트 상한이 없다. 버퍼가 잘렸을 때의 안전은 hasMore 판정이 진다(핸들러 참조).
 // 알려진 한계: 본문이 공백 8칸으로 시작하면 존재 여부가 false로 읽힌다 — 마커 한 개가 빠질 뿐이다.
 const LOG_PRETTY_FORMAT = "--pretty=format:%x1e%H%x00%h%x00%s%x00%an%x00%ar%x00%at%x00%D%x00%P%x00%<(8,trunc)%b";
 
@@ -271,7 +271,12 @@ export async function handleRepositoryLog(
         { cwd: gitCwd },
       );
     const parsedCommits = parseLogOutput(result.stdout);
-    const hasMore = parsedCommits.length > limit;
+    // stdout이 잘렸다면 레코드 수는 "더 없음"의 근거가 되지 못한다 — 잘린 지점 이후를 못 읽었을 뿐이다.
+    // 이때도 개수로 판정하면 hasMore가 false로 접혀 남은 이력이 페이지네이션에서 통째로 사라진다.
+    // 페이지 크기를 포맷으로 묶어 막을 수는 없다: %s·%D·%b는 모두 사용자 작성 텍스트라 바이트 상한이 없고,
+    // pretty-format의 절단 폭은 바이트가 아니라 표시 칸이라 폭 0인 문자에는 걸리지 않는다.
+    // 레코드를 하나도 못 읽었을 때는 열어 두지 않는다 — skip이 전진하지 못해 더 보기가 헛도는 쪽이 더 나쁘다.
+    const hasMore = parsedCommits.length > limit || (result.truncated && parsedCommits.length > 0);
     const commits = annotateHeadReachability(parsedCommits.slice(0, limit), headRevList);
     ctx.host.http.writeJson(res, 200, { commits, checkouts, hasMore, ...(result.truncated ? { truncated: true } : {}) });
   } catch (error) {

--- a/runtime/fleet-plugins/repository/server/log.ts
+++ b/runtime/fleet-plugins/repository/server/log.ts
@@ -30,6 +30,10 @@ const REF_METACHAR_RE = /[~^:?*\[\\\s\x00-\x1f\x7f]/;
 // %s·%D도 똑같이 바이트 상한이 없다. 버퍼가 잘렸을 때의 안전은 hasMore 판정이 진다(핸들러 참조).
 // 알려진 한계: 본문이 공백 8칸으로 시작하면 존재 여부가 false로 읽힌다 — 마커 한 개가 빠질 뿐이다.
 const LOG_PRETTY_FORMAT = "--pretty=format:%x1e%H%x00%h%x00%s%x00%an%x00%ar%x00%at%x00%D%x00%P%x00%<(8,trunc)%b";
+// 위 포맷이 레코드마다 내보내는 필드 수 — 파서가 잘린 꼬리 레코드를 가려내는 근거다. 포맷과 함께 갱신할 것.
+const LOG_FIELD_COUNT = 9;
+// %H는 저장소 해시 알고리즘에 따라 SHA-1 40자 또는 SHA-256 64자다. 그 사이 길이는 잘린 해시를 뜻한다.
+const FULL_HASH_RE = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
 
 // 정렬 축은 화이트리스트 상수로만 git 인자가 된다 — 요청 문자열이 인자 위치에 직접 닿지 않게 한다.
 const LOG_ORDER_ARGS: Readonly<Record<LogOrder, string>> = { topo: "--topo-order", date: "--date-order" };
@@ -78,7 +82,11 @@ export function parseLogOutput(stdout: string): LogCommitEntry[] {
     const refsRaw = fields[6] ?? "";
     const parentsRaw = fields[7] ?? "";
 
-    if (!fullHash) continue;
+    // 잘린 꼬리 레코드는 버린다. stdout 버퍼가 레코드 중간에서 끊기면 필드가 덜 온 조각이 남는데,
+    // 해시만 비어있지 않다고 받아들이면 제목·작성자가 빈 행이 목록에 서고 — 해시 자체가 잘렸을 수도 있다 —
+    // 그 조각이 반환 개수에 포함돼 클라이언트의 다음 skip이 그 커밋을 건너뛴다. 영영 다시 읽지 못한다.
+    // 완결 신호는 필드 수다: 본문은 절단되어 언제나 마지막 한 칸을 채우므로 온전한 레코드는 항상 LOG_FIELD_COUNT개다.
+    if (fields.length < LOG_FIELD_COUNT || !FULL_HASH_RE.test(fullHash)) continue;
 
     const refs = refsRaw.split(",").map((r) => r.trim()).filter(Boolean);
     const parents = parentsRaw.split(" ").map((p) => p.trim()).filter(Boolean);

--- a/runtime/fleet-plugins/repository/server/types.ts
+++ b/runtime/fleet-plugins/repository/server/types.ts
@@ -42,6 +42,13 @@ export interface WorktreesResult {
   readonly worktrees: readonly WorktreeCandidate[];
 }
 
+/**
+ * 커밋 목록의 정렬 축.
+ * - `topo`: 브랜치 체인을 끊지 않고 연속 배치한다(`git log --topo-order`). 그래프 레인이 짧게 유지된다.
+ * - `date`: 저장소 전체를 커밋 시각 역순으로 인터리브한다(`git log --date-order`).
+ */
+export type LogOrder = "topo" | "date";
+
 export interface LogCommitEntry {
   readonly shortHash: string;
   readonly fullHash: string;
@@ -53,6 +60,8 @@ export interface LogCommitEntry {
   readonly parents: readonly string[];
   /** 현재 체크아웃 HEAD에서 도달 가능한 커밋인지 — false면 UI가 dim 처리한다 */
   readonly onHead: boolean;
+  /** 제목 뒤에 본문이 더 있는지 — 목록이 "열어 볼 값이 있는 커밋"을 표시하는 데만 쓴다(본문 자체는 싣지 않는다) */
+  readonly hasBody: boolean;
 }
 
 export interface WorktreeCheckout {

--- a/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
+++ b/runtime/fleet-plugins/repository/tests/design-grammar.test.ts
@@ -161,6 +161,35 @@ describe("Repository design grammar", () => {
     expect(css).not.toMatch(/\.repository-scan-depth\b/);
   });
 
+  // 2026-08-07 재가 — Fork 문법의 ref 뱃지. 색조는 --badge-tone 한 채널로만 흐르고, 종류가 고정된 축만
+  // CSS가 소유한다(체크아웃 위치=brass, 태그=plum). 나머지는 커밋 행이 자기 레인 색을 주입한다.
+  it("routes every ref badge color through one tone channel, with location on brass", () => {
+    const badge = blockOf(".history-badge");
+    expect(badge).toContain("--badge-tone:");
+    for (const property of ["border", "background", "border-right"]) {
+      expect(blocksOf(".history-badge").concat(blocksOf(".history-badge-mark")).some((body) => body.includes(`${property}:`) && body.includes("var(--badge-tone)")), property).toBe(true);
+    }
+    // 알약이 아니라 라운드 사각 + 볼드 sans — Fork가 뱃지를 라벨이 아닌 표식으로 읽히게 하는 축.
+    expect(badge).not.toContain("border-radius: 999px");
+    expect(badge).toContain("border-radius: var(--radius-xs)");
+    expect(badge).toContain("font-family: var(--font-body)");
+    expect(badge).toContain("font-weight: var(--weight-bold)");
+
+    for (const selector of [".history-badge--head", ".history-badge.is-current"]) {
+      expect(blockOf(selector), selector).toContain("var(--brass)");
+    }
+    expect(blockOf(".history-badge--tag")).toContain("var(--id-plum)");
+    expect(blockOf(".history-badge--tag")).not.toContain("var(--brass)");
+    // 인라인으로 주입되는 레인 색이 --badge-tone을 덮어쓰므로, 정의되지 않은 var 참조가 되지 않도록 기본값이 있어야 한다.
+    expect(badge).toMatch(/--badge-tone:\s*var\(--ink-fog\)/);
+  });
+
+  it("raises only the Conventional Commit prefix, and demotes it with the rest off HEAD", () => {
+    expect(blockOf(".history-commit-kind")).toContain("font-weight: var(--weight-bold)");
+    expect(blockOf(".history-commit-kind")).toContain("color: var(--text-primary)");
+    expect(css).toContain(".history-commit-row.is-off-head .history-commit-kind");
+  });
+
   it("keeps commit subjects on one row at every container width", () => {
     const subjects = blocksOf(".history-commit-subject");
     // 행 높이는 그래프 gutter의 ROW_HEIGHT와 가상 스크롤 기하에 묶여 있다 — 줄바꿈은 둘 다 깨뜨린다.

--- a/runtime/fleet-plugins/repository/tests/filtering.test.ts
+++ b/runtime/fleet-plugins/repository/tests/filtering.test.ts
@@ -22,6 +22,7 @@ const COMMITS: readonly LogCommitEntry[] = [
     refs: ["HEAD -> refs/heads/main", "tag: v1.2.3"],
     parents: [],
     onHead: true,
+    hasBody: false,
   },
   {
     shortHash: "def5678",
@@ -33,6 +34,7 @@ const COMMITS: readonly LogCommitEntry[] = [
     refs: ["refs/remotes/origin/topic"],
     parents: [],
     onHead: true,
+    hasBody: false,
   },
 ];
 

--- a/runtime/fleet-plugins/repository/tests/graph-layout.test.ts
+++ b/runtime/fleet-plugins/repository/tests/graph-layout.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { layoutGraph } from "../client/graph.js";
+import { GraphGutter, layoutGraph } from "../client/graph.js";
 import type { LogCommitEntry } from "../server/types.js";
 
 function makeCommit(overrides: Partial<LogCommitEntry> = {}): LogCommitEntry {
@@ -14,6 +14,7 @@ function makeCommit(overrides: Partial<LogCommitEntry> = {}): LogCommitEntry {
     refs: [],
     parents: [],
     onHead: true,
+    hasBody: false,
     ...overrides,
   };
 }
@@ -302,5 +303,45 @@ describe("layoutGraph — Phase 2 다중 레인 topology", () => {
     expect(layout.nodes[0]?.branchToLanes).toEqual([]);
     expect(layout.activeLaneCount).toBe(1);
     expect(layout.collapsed).toBe(false);
+  });
+});
+
+// 2026-08-07 재가 — Fork 문법의 거터 폭. 목록 전체 최대 레인 수가 아니라 행마다 실제로 그려진 레인만
+// 폭을 차지하므로, 분기가 없는 구간에서 커밋 본문이 그래프 바로 옆에 붙는다.
+describe("layoutGraph — 행별 거터 폭(rowLaneCount)", () => {
+  const branchedHistory = [
+    makeCommit({ fullHash: "HEAD", parents: ["head-1"], refs: ["HEAD -> refs/heads/main"] }),
+    makeCommit({ fullHash: "head-1", parents: ["common"] }),
+    makeCommit({ fullHash: "topic", parents: ["common"], refs: ["refs/remotes/origin/topic"] }),
+    makeCommit({ fullHash: "common", parents: ["base"] }),
+    makeCommit({ fullHash: "base", parents: [] }),
+  ];
+
+  it("두 레인이 함께 살아 있는 구간만 2를 세고, 전역 activeLaneCount와 분리된다", () => {
+    const layout = layoutGraph(branchedHistory);
+
+    expect(layout.nodes.map((node) => node.rowLaneCount)).toEqual([1, 1, 2, 2, 1]);
+    expect(layout.activeLaneCount).toBe(2);
+  });
+
+  it("병합으로 닫히는 레인과 새로 갈라지는 레인도 그 행의 폭에 포함된다", () => {
+    const layout = layoutGraph([
+      makeCommit({ fullHash: "M", parents: ["A", "B"] }),
+      makeCommit({ fullHash: "A", parents: [] }),
+      makeCommit({ fullHash: "B", parents: [] }),
+    ]);
+
+    // M 행은 자기 레인 + 갈라져 나가는 레인을 함께 그린다.
+    expect(layout.nodes[0]?.branchToLanes).not.toEqual([]);
+    expect(layout.nodes[0]?.rowLaneCount).toBe(2);
+    expect(layout.nodes[2]?.rowLaneCount).toBe(2);
+  });
+
+  it("거터 SVG 폭은 그 행의 레인 수에 정비례한다", () => {
+    const nodes = layoutGraph(branchedHistory).nodes;
+    const single = Number(GraphGutter({ node: nodes[0]! }).props.width);
+    const double = Number(GraphGutter({ node: nodes[2]! }).props.width);
+
+    expect(double).toBe(single * 2);
   });
 });

--- a/runtime/fleet-plugins/repository/tests/history-cache.test.ts
+++ b/runtime/fleet-plugins/repository/tests/history-cache.test.ts
@@ -105,6 +105,7 @@ describe("history cache", () => {
       refs: ["HEAD -> canary"],
       parents: ["parent"],
       onHead: true,
+      hasBody: false,
     };
     const key = scope("commit-round-trip");
     const value: HistoryCacheEntry = {

--- a/runtime/fleet-plugins/repository/tests/history-invariance.test.ts
+++ b/runtime/fleet-plugins/repository/tests/history-invariance.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 
 import { shouldShowWip } from "../client/history-panel.js";
+import { resolveLogOrder } from "../server/log.js";
 
 // 2026-08-05 재가 계약 — History는 체크아웃과 무관한 "저장소의 객관적 기록"이다.
 // 체크아웃을 따라 움직여도 되는 표면은 정확히 두 개: is-off-head 텍스트 티어 강등과 WIP 행.
@@ -12,8 +13,19 @@ const cssSource = await fs.readFile(new URL("../client/repository.css", import.m
 const historyPanelSource = await fs.readFile(new URL("../client/history-panel.tsx", import.meta.url), "utf8");
 
 describe("History checkout-invariance contracts", () => {
-  it("keeps the default log an all-refs date-ordered query, never scoped to the active branch", () => {
-    expect(logSource).toContain('"log", "--branches", "--tags", "--remotes", "--date-order"');
+  // 2026-08-07 계약 개정 — 정렬 축은 사용자가 고르는 표시 선호가 되었다(기본 topo). 불변식은 "축이 하나로 고정된다"가
+  // 아니라 "어느 축을 골라도 질의 범위는 전체 ref이고, 축은 화이트리스트 상수로만 git 인자가 된다"로 옮겼다.
+  it("keeps the default log an all-refs query, never scoped to the active branch", () => {
+    expect(logSource).toContain('"log", "--branches", "--tags", "--remotes", orderArg');
+  });
+
+  it("resolves the order axis through a closed whitelist that defaults to topological", () => {
+    expect(resolveLogOrder(undefined)).toBe("topo");
+    expect(resolveLogOrder("topo")).toBe("topo");
+    expect(resolveLogOrder("date")).toBe("date");
+    // 요청 문자열이 git 인자 위치에 직접 닿으면 안 된다 — 알아볼 수 없는 값은 인자가 아니라 거절이다.
+    for (const rejected of ["--all", "reverse", "", 1, null, {}]) expect(resolveLogOrder(rejected)).toBeNull();
+    expect(logSource).toContain('const LOG_ORDER_ARGS: Readonly<Record<LogOrder, string>> = { topo: "--topo-order", date: "--date-order" }');
   });
 
   it("keeps off-head dimming a text-tier demotion, not opacity", () => {

--- a/runtime/fleet-plugins/repository/tests/history-panel-state.test.ts
+++ b/runtime/fleet-plugins/repository/tests/history-panel-state.test.ts
@@ -1,7 +1,7 @@
 import type { ReactElement, ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
-import { appendHistoryPage, calculateHistoryWindow, CommitRow, findDetachedCheckout, getHistoryWindowRows, type HistoryLoadGeneration, type HistoryOkState } from "../client/history-panel.js";
+import { appendHistoryPage, calculateHistoryWindow, chooseComparePair, CommitRow, findDetachedCheckout, getHistoryWindowRows, type HistoryLoadGeneration, type HistoryOkState } from "../client/history-panel.js";
 import { ROW_HEIGHT } from "../client/graph.js";
 import { layoutGraph } from "../client/graph.js";
 import type { LogCommitEntry, WorktreeCheckout } from "../server/types.js";
@@ -152,5 +152,39 @@ describe("History page accumulation", () => {
 
     expect(result?.commits).toEqual([COMMIT, nextCommit]);
     expect(result?.hasMore).toBe(false);
+  });
+});
+
+// 2026-08-07 회귀 — 기본 정렬이 topo가 되면서 목록 위치가 시간 순서를 뜻하지 않게 되었다.
+// 이 저장소 실측: topo 목록에서 ecf03342(20:23)가 35ee071f(20:43)보다 위에 선다.
+// 위치로 방향을 정하던 옛 로직은 그 둘을 비교할 때 base/head를 뒤집어 추가를 삭제로 보여 준다.
+describe("chooseComparePair", () => {
+  const ANCHOR = { fullHash: "ecf03342b4b50239", shortHash: "ecf03342", authorAt: 1_786_101_795 };
+  const TARGET: LogCommitEntry = { ...COMMIT, fullHash: "35ee071f0a1b2c3d", shortHash: "35ee071f", authorAt: 1_786_103_009 };
+
+  it("목록에서 앵커가 위에 있어도 더 오래된 쪽을 base로 삼는다", () => {
+    expect(chooseComparePair(ANCHOR, TARGET)).toEqual({
+      base: ANCHOR.fullHash, head: TARGET.fullHash, baseLabel: ANCHOR.shortHash, headLabel: TARGET.shortHash,
+    });
+  });
+
+  it("반대로 고른 순서에서도 같은 방향을 낸다 — 방향은 표시 순서가 아니라 커밋 시각이 정한다", () => {
+    const reversed = chooseComparePair(
+      { fullHash: TARGET.fullHash, shortHash: TARGET.shortHash, authorAt: TARGET.authorAt },
+      { ...COMMIT, fullHash: ANCHOR.fullHash, shortHash: ANCHOR.shortHash, authorAt: ANCHOR.authorAt },
+    );
+    expect(reversed.base).toBe(ANCHOR.fullHash);
+    expect(reversed.head).toBe(TARGET.fullHash);
+  });
+
+  it("앵커의 시각을 알 수 없으면 사용자가 고른 순서를 지킨다", () => {
+    const pair = chooseComparePair({ fullHash: "unknown", shortHash: "unknown", authorAt: null }, TARGET);
+    expect(pair.base).toBe("unknown");
+    expect(pair.head).toBe(TARGET.fullHash);
+  });
+
+  it("시각이 같으면 먼저 고른 쪽을 base로 둔다", () => {
+    const pair = chooseComparePair({ fullHash: "a", shortHash: "a", authorAt: TARGET.authorAt }, TARGET);
+    expect(pair.base).toBe("a");
   });
 });

--- a/runtime/fleet-plugins/repository/tests/history-panel-state.test.ts
+++ b/runtime/fleet-plugins/repository/tests/history-panel-state.test.ts
@@ -18,6 +18,7 @@ const COMMIT: LogCommitEntry = {
   refs: [],
   parents: [],
   onHead: true,
+  hasBody: false,
 };
 
 type ElementProps = Record<string, unknown> & {
@@ -50,7 +51,6 @@ describe("CommitRow", () => {
       checkouts: [],
       selected: false,
       graphNode: layoutGraph([COMMIT]).nodes[0]!,
-      laneCount: 1,
       onSelect: vi.fn(),
     });
     // 행은 비중첩 버튼 계약(래퍼 div + 본체 버튼 + ⇆ 액션)이라 subject는 본체 버튼 안에 있다.
@@ -125,7 +125,7 @@ describe("History window rendering", () => {
 });
 
 describe("History page accumulation", () => {
-  const generationA: HistoryLoadGeneration = { theaterId: "theater", repoRel: "", refFilter: "refs/heads/a", refreshToken: 0 };
+  const generationA: HistoryLoadGeneration = { theaterId: "theater", repoRel: "", refFilter: "refs/heads/a", order: "topo", refreshToken: 0 };
   const state: HistoryOkState = { kind: "ok", commits: [COMMIT], checkouts: [], hasMore: true, truncated: false };
   const nextCommit: LogCommitEntry = { ...COMMIT, shortHash: "def5678", fullHash: "def5678fedcba9876543210fedcba9876543210f", subject: "older commit" };
 

--- a/runtime/fleet-plugins/repository/tests/log-parse.test.ts
+++ b/runtime/fleet-plugins/repository/tests/log-parse.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { formatCommitTime, refBadges } from "../client/repository-parsers.js";
+import { formatCommitTime, refBadges, splitCommitSubject } from "../client/repository-parsers.js";
 import type { LogCommitEntry } from "../server/types.js";
 
 function makeEntry(overrides: Partial<LogCommitEntry> = {}): LogCommitEntry {
@@ -14,6 +14,7 @@ function makeEntry(overrides: Partial<LogCommitEntry> = {}): LogCommitEntry {
     refs: [],
     parents: ["parent1234"],
     onHead: true,
+    hasBody: false,
     ...overrides,
   };
 }
@@ -94,5 +95,29 @@ describe("refBadges", () => {
     expect(badges[0]?.kind).toBe("head");
     expect(badges[1]?.kind).toBe("branch");
     expect(badges[2]?.kind).toBe("tag");
+  });
+});
+
+describe("splitCommitSubject", () => {
+  it("Conventional Commit 접두를 본문에서 떼어낸다", () => {
+    expect(splitCommitSubject("feat(fleet-console): open console sessions"))
+      .toEqual({ prefix: "feat(fleet-console):", rest: "open console sessions" });
+    expect(splitCommitSubject("fix: gate WebSocket upgrades")).toEqual({ prefix: "fix:", rest: "gate WebSocket upgrades" });
+  });
+
+  it("breaking change 표식(!)을 접두에 포함한다", () => {
+    expect(splitCommitSubject("feat!: retire the Classic launch kind")).toEqual({ prefix: "feat!:", rest: "retire the Classic launch kind" });
+    expect(splitCommitSubject("feat(fleet-cli)!: rebuild fleet")).toEqual({ prefix: "feat(fleet-cli)!:", rest: "rebuild fleet" });
+  });
+
+  it("규약을 따르지 않는 제목은 접두 없이 그대로 돌려준다", () => {
+    for (const subject of ["Merge branch 'canary'", "", "wip"]) {
+      expect(splitCommitSubject(subject)).toEqual({ prefix: null, rest: subject });
+    }
+  });
+
+  it("콜론 뒤 공백을 요구해 URL 스킴을 접두로 오인하지 않는다", () => {
+    expect(splitCommitSubject("https://example.com/x is broken"))
+      .toEqual({ prefix: null, rest: "https://example.com/x is broken" });
   });
 });

--- a/runtime/fleet-plugins/repository/tests/log-server-parse.test.ts
+++ b/runtime/fleet-plugins/repository/tests/log-server-parse.test.ts
@@ -8,6 +8,8 @@ import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 import { runGit } from "../server/git-executor.js";
 import { annotateHeadReachability, handleRepositoryLog, isCanonicalRepositoryRef, parseLogOutput, parseWorktreePorcelain } from "../server/log.js";
 
+const logSource = await fs.readFile(new URL("../server/log.ts", import.meta.url), "utf8");
+
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
 async function initGitRepo(dir: string): Promise<void> {
@@ -46,16 +48,24 @@ describe("parseLogOutput", () => {
     }]);
   });
 
-  // %b는 개행을 담을 수 있어 반드시 마지막 필드다 — 본문은 첫 줄의 9번째 조각과 그 뒤 줄들에 걸쳐 있고,
+  // 본문은 8칸으로 절단되어 마지막 필드에 한 줄로 온다. 빈 본문은 공백 패딩, 내용이 있으면 잘린 앞부분.
   // 목록 페이로드에는 존재 여부만 남는다.
-  it("여러 줄 본문을 hasBody로만 요약하고 본문 자체는 싣지 않는다", () => {
+  it("절단된 본문 필드를 hasBody로만 요약하고 본문 자체는 싣지 않는다", () => {
     const head = "\x1eabc\x00abc\x00subject\x00Author\x002 hours ago\x001720000000\x00\x00parent-a\x00";
-    expect(parseLogOutput(`${head}first body line\nsecond body line\n`)).toEqual([{
+    expect(parseLogOutput(`${head}first b..\n`)).toEqual([{
       fullHash: "abc", shortHash: "abc", subject: "subject", authorName: "Author",
       relTime: "2 hours ago", authorAt: 1_720_000_000, refs: [], parents: ["parent-a"],
       onHead: true, hasBody: true,
     }]);
-    expect(parseLogOutput(`${head}\n`)[0]?.hasBody).toBe(false);
+    // 본문 없는 커밋은 공백 패딩만 온다 — 공백을 내용으로 오인하면 모든 행에 마커가 붙는다.
+    expect(parseLogOutput(`${head}        \n`)[0]?.hasBody).toBe(false);
+  });
+
+  // 절단을 잃으면 커밋 하나가 페이지 전체의 stdout 버퍼를 소진해 hasMore가 false로 접히고,
+  // 그보다 오래된 이력이 페이지네이션에서 사라진다. 포맷 문자열이 그 상한을 지고 있다.
+  it("본문 자리표시자를 절단해 페이지 한 건의 크기 상한을 유지한다", () => {
+    expect(logSource).toContain("%x00%<(8,trunc)%b");
+    expect(logSource).not.toMatch(/%x00%b(?!\w)/);
   });
 });
 

--- a/runtime/fleet-plugins/repository/tests/log-server-parse.test.ts
+++ b/runtime/fleet-plugins/repository/tests/log-server-parse.test.ts
@@ -61,9 +61,10 @@ describe("parseLogOutput", () => {
     expect(parseLogOutput(`${head}        \n`)[0]?.hasBody).toBe(false);
   });
 
-  // 절단을 잃으면 커밋 하나가 페이지 전체의 stdout 버퍼를 소진해 hasMore가 false로 접히고,
-  // 그보다 오래된 이력이 페이지네이션에서 사라진다. 포맷 문자열이 그 상한을 지고 있다.
-  it("본문 자리표시자를 절단해 페이지 한 건의 크기 상한을 유지한다", () => {
+  // 절단은 안전장치가 아니라 페이로드 절감이다 — 폭 단위가 표시 칸이라 폭 0인 문자에는 걸리지 않는다.
+  // 그래도 평범한 저장소에서 페이지가 본문 길이에 비례해 부푸는 것을 막으므로 포맷에 남긴다.
+  // 잘렸을 때의 안전은 위의 hasMore 계약이 진다.
+  it("목록 포맷이 본문을 절단해 실어 페이지 페이로드가 본문 길이에 비례하지 않게 한다", () => {
     expect(logSource).toContain("%x00%<(8,trunc)%b");
     expect(logSource).not.toMatch(/%x00%b(?!\w)/);
   });
@@ -165,6 +166,36 @@ describe("handleRepositoryLog", () => {
 
   afterEach(async () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // 페이지 크기는 포맷으로 묶을 수 없다 — %s·%D·%b는 사용자가 쓰는 텍스트라 바이트 상한이 없다.
+  // 그래서 stdout이 잘렸을 때 레코드 수로 "더 없음"을 판정하면 남은 이력이 조용히 사라진다.
+  // 아래는 제목 하나만으로 버퍼를 넘겨 그 경로를 재현한다(본문 없이도 도달한다는 뜻이기도 하다).
+  it("keeps pagination open when the log buffer truncates mid-page", async () => {
+    const repoDir = path.join(tmpDir, "repo");
+    await fs.mkdir(repoDir);
+    await initGitRepo(repoDir);
+    // 메시지는 파일로 넘긴다 — 이 크기를 인자로 주면 git 실행 전에 OS의 argv 상한에서 먼저 죽는다.
+    const messagePath = path.join(tmpDir, "message.txt");
+    for (let index = 0; index < 3; index += 1) {
+      await fs.writeFile(messagePath, `${"S".repeat(3 * 1024 * 1024)} ${index}\n`);
+      await fs.writeFile(path.join(repoDir, "entry.txt"), `history ${index}`);
+      await runGit(["add", "entry.txt"], { cwd: repoDir });
+      await runGit(["commit", "-F", messagePath], { cwd: repoDir });
+    }
+
+    const writes: { status: number; payload: unknown }[] = [];
+    await handleRepositoryLog({ method: "POST" } as never, {} as never, makeLogContext(repoDir, writes, { theaterId: "theater", limit: 200 }));
+
+    const payload = writes[0]?.payload as { readonly commits: readonly unknown[]; readonly hasMore: boolean; readonly truncated?: boolean };
+    expect(writes[0]?.status).toBe(200);
+    // 버퍼가 실제로 잘렸고, 요청한 200개보다 적게 파싱됐다.
+    expect(payload.truncated).toBe(true);
+    expect(payload.commits.length).toBeLessThan(200);
+    // 그럼에도 남은 이력에 도달할 길이 열려 있어야 한다.
+    expect(payload.hasMore).toBe(true);
+    // 다음 페이지의 skip이 전진할 수 있도록 최소 한 건은 돌려준다.
+    expect(payload.commits.length).toBeGreaterThan(0);
   });
 
   it("accepts canonical local refs with underscore and non-ASCII names", async () => {

--- a/runtime/fleet-plugins/repository/tests/log-server-parse.test.ts
+++ b/runtime/fleet-plugins/repository/tests/log-server-parse.test.ts
@@ -42,14 +42,27 @@ describe("parseLogOutput", () => {
       refs: ["HEAD -> refs/heads/main", "refs/remotes/origin/main", "tag: v1.2.3"],
       parents: ["parent-a", "parent-b"],
       onHead: true,
+      hasBody: false,
     }]);
+  });
+
+  // %b는 개행을 담을 수 있어 반드시 마지막 필드다 — 본문은 첫 줄의 9번째 조각과 그 뒤 줄들에 걸쳐 있고,
+  // 목록 페이로드에는 존재 여부만 남는다.
+  it("여러 줄 본문을 hasBody로만 요약하고 본문 자체는 싣지 않는다", () => {
+    const head = "\x1eabc\x00abc\x00subject\x00Author\x002 hours ago\x001720000000\x00\x00parent-a\x00";
+    expect(parseLogOutput(`${head}first body line\nsecond body line\n`)).toEqual([{
+      fullHash: "abc", shortHash: "abc", subject: "subject", authorName: "Author",
+      relTime: "2 hours ago", authorAt: 1_720_000_000, refs: [], parents: ["parent-a"],
+      onHead: true, hasBody: true,
+    }]);
+    expect(parseLogOutput(`${head}\n`)[0]?.hasBody).toBe(false);
   });
 });
 
 describe("annotateHeadReachability", () => {
   const base = {
     shortHash: "aaa", subject: "s", authorName: "a", relTime: "now", authorAt: 0,
-    refs: [], parents: [], onHead: true,
+    refs: [], parents: [], onHead: true, hasBody: false,
   };
 
   it("rev-list에 없는 커밋만 onHead=false로 표시한다", () => {

--- a/runtime/fleet-plugins/repository/tests/log-server-parse.test.ts
+++ b/runtime/fleet-plugins/repository/tests/log-server-parse.test.ts
@@ -31,11 +31,14 @@ function makeLogContext(theaterPath: string, writes: { status: number; payload: 
   } as unknown as FleetPluginServerContext;
 }
 
+const HASH_A = "0123456789abcdef0123456789abcdef01234567";
+const HASH_B = "89abcdef0123456789abcdef0123456789abcdef";
+
 describe("parseLogOutput", () => {
   it("%at author time을 정수로 파싱하고 full decorations를 보존한다", () => {
-    const output = "\x1e0123456789abcdef\x000123456\x00subject\x00Author\x002 hours ago\x001720000000\x00HEAD -> refs/heads/main, refs/remotes/origin/main, tag: v1.2.3\x00parent-a parent-b";
+    const output = `\x1e${HASH_A}\x000123456\x00subject\x00Author\x002 hours ago\x001720000000\x00HEAD -> refs/heads/main, refs/remotes/origin/main, tag: v1.2.3\x00parent-a parent-b\x00        `;
     expect(parseLogOutput(output)).toEqual([{
-      fullHash: "0123456789abcdef",
+      fullHash: HASH_A,
       shortHash: "0123456",
       subject: "subject",
       authorName: "Author",
@@ -51,14 +54,28 @@ describe("parseLogOutput", () => {
   // 본문은 8칸으로 절단되어 마지막 필드에 한 줄로 온다. 빈 본문은 공백 패딩, 내용이 있으면 잘린 앞부분.
   // 목록 페이로드에는 존재 여부만 남는다.
   it("절단된 본문 필드를 hasBody로만 요약하고 본문 자체는 싣지 않는다", () => {
-    const head = "\x1eabc\x00abc\x00subject\x00Author\x002 hours ago\x001720000000\x00\x00parent-a\x00";
+    const head = `\x1e${HASH_A}\x00abc\x00subject\x00Author\x002 hours ago\x001720000000\x00\x00parent-a\x00`;
     expect(parseLogOutput(`${head}first b..\n`)).toEqual([{
-      fullHash: "abc", shortHash: "abc", subject: "subject", authorName: "Author",
+      fullHash: HASH_A, shortHash: "abc", subject: "subject", authorName: "Author",
       relTime: "2 hours ago", authorAt: 1_720_000_000, refs: [], parents: ["parent-a"],
       onHead: true, hasBody: true,
     }]);
     // 본문 없는 커밋은 공백 패딩만 온다 — 공백을 내용으로 오인하면 모든 행에 마커가 붙는다.
     expect(parseLogOutput(`${head}        \n`)[0]?.hasBody).toBe(false);
+  });
+
+  // stdout 버퍼가 레코드 중간에서 끊기면 필드가 덜 온 조각이 남는다. 그 조각을 커밋으로 세면
+  // 클라이언트의 다음 skip이 그만큼 전진해 해당 커밋을 영영 건너뛴다 — 다음 페이지가 거기서 이어져야 한다.
+  it("필드가 덜 온 꼬리 레코드를 버려 다음 페이지가 그 커밋에서 이어지게 한다", () => {
+    const complete = `\x1e${HASH_A}\x00abc\x00subject\x00Author\x002 hours ago\x001720000000\x00\x00\x00        `;
+    for (const tail of [
+      `\x1e${HASH_B}\x00def\x00cut here`,          // 필드 중간에서 끊김
+      `\x1e${HASH_B.slice(0, 17)}`,                 // 해시 자체가 잘림
+      `\x1e${HASH_B}`,                              // 해시만 오고 나머지 필드 없음
+    ]) {
+      const parsed = parseLogOutput(`${complete}${tail}`);
+      expect(parsed.map((commit) => commit.fullHash)).toEqual([HASH_A]);
+    }
   });
 
   // 절단은 안전장치가 아니라 페이로드 절감이다 — 폭 단위가 표시 칸이라 폭 0인 문자에는 걸리지 않는다.


### PR DESCRIPTION
## Summary

- 커밋 그래프 거터 폭을 목록 전체 최대 레인 수 고정에서 **행별 실제 레인 수**로 바꿨습니다. 분기가 없는 대부분의 행에서 커밋 본문이 그래프 바로 옆에 붙습니다. 분기·병합 연결선은 대각선 대신 모서리가 둥근 직각을 따르고, 레인 간격을 12px → 14px로 넓혔습니다.
- History 목록의 정렬 축을 **계보순(`--topo-order`, 기본) / 시간순(`--date-order`)** 중에서 고를 수 있게 했습니다. 선호는 브라우저에 영속되고, 서버는 닫힌 화이트리스트로 해석하므로 요청 문자열이 git 인자 위치에 직접 닿지 않습니다.
- ref 뱃지를 알약에서 **아이콘 칸이 분리된 라운드 사각 + 볼드 sans 라벨**로 다시 그렸습니다. 색은 `--badge-tone` 단일 채널로만 흐릅니다 — 브랜치·원격·워크트리는 그 커밋의 그래프 레인 색, 현재 체크아웃은 brass(위치 채널), 태그는 plum 고정.
- 커밋 제목의 Conventional Commit 접두를 한 티어 올리고, 작성자 열과 본문 보유 커밋 마커(`↵`)를 추가했습니다. `hasBody`는 존재 여부 불리언만 싣고 본문은 페이로드에 넣지 않습니다.

정렬이 표현 차이의 근본 원인이라는 점은 실측으로 확정했습니다 — 이 저장소에서 `git log --topo-order` 출력이 참조 클라이언트의 커밋 순서와 12개 전부 일치하고, 기존 `--date-order`가 현행 Console 순서와 일치했습니다.

## Test Plan

- [x] `pnpm exec vitest run` (repository 플러그인) — 38파일 369테스트 통과
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과
- [x] `pnpm exec vitest run tests/instrument-design-contract.test.ts` (fleet-console) — 29/29 통과
- [x] `node --test scripts/*.test.mjs` — 23/23 통과
- [x] `node scripts/compile-changelog-fragments.mjs --check --allow-empty` — 통과. 브랜치명 프래그먼트 `.changelog.d/fork-style-commit-graph.md`를 변경과 같은 커밋에 동봉
- [x] 격리 Console(`FLEET_CONSOLE_DIR`) 브라우저 실측: 거터 SVG 폭이 행마다 28px/42px로 갈리는 것 확인(이전 코드는 전 행 동일), 뱃지 실측 `border-radius: 6px` · `font-weight: 700` · 테두리 `oklch(0.73 0.062 235 / .62)`(레인 0 색 주입), 정렬 토글 양방향 전환과 리로드 후 영속, 페이지 에러 0 / rejection 0, whites·carbon 테마에서 토큰 재조율 확인

## Notes

선택 행은 현행 중성 표기(ink wash + brass 스파인)를 유지했습니다. 참조 클라이언트의 솔리드 accent 채움은 "선택은 중성 ink, brass는 위치/포커스 전용" 독트린 및 `design-grammar` 계약과 충돌하므로 이식 대상에서 제외했습니다.