### PR TITLE
fix(terminal): apply OSC 52 clipboard writes from full-screen CLIs

### DIFF
--- a/.changelog.d/terminal-drag-copy.md
+++ b/.changelog.d/terminal-drag-copy.md
@@ -1,0 +1,8 @@
+---
+branch: terminal-drag-copy
+---
+
+### fleet-console
+#### Fixed
+- Copying by dragging in a terminal panel now works while a full-screen agent CLI is running. A full-screen CLI takes the mouse over, draws its own selection, and reports the copy with `OSC 52`, which the terminal discarded, so a drag highlighted the text and pasting produced nothing. Clipboard writes the running program asks for are now applied; a clipboard read request is still refused, so a program cannot take what it did not put there.
+  ko: 전체 화면 agent CLI가 실행 중일 때도 터미널 패널에서 마우스 드래그로 복사됩니다. 전체 화면 CLI는 마우스를 가져가 자신의 선택을 직접 그리고 복사 결과를 `OSC 52`로 알리는데, 터미널이 이를 버려서 드래그로 글자가 반전돼도 붙여넣으면 아무것도 나오지 않았습니다. 이제 실행 중인 프로그램이 요청한 클립보드 쓰기를 반영하며, 클립보드 읽기 요청은 계속 거부하므로 프로그램이 자신이 넣지 않은 내용을 가져갈 수 없습니다.

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-connection.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-connection.ts
@@ -114,10 +114,13 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
         }
         if (!isReplayEndFrame(frame)) return;
         connectionOptions.terminal.drain(() => {
-          // 재생 바이트가 모두 파싱된 뒤다. 아래 입력 구독 가드보다 먼저 알려, 가드에 걸리는 경우에도
-          // 재생 구간이 열린 채로 남지 않게 한다.
+          // 이 소켓이 아직 활성일 때만 재생 구간을 닫는다. drain은 출력 파싱을 기다리므로 소켓이 먼저
+          // 닫히고 재접속이 새 재생을 시작한 뒤에 이 콜백이 도착할 수 있는데, 그때 창을 닫아버리면
+          // 새 연결의 재생분이 클립보드를 덮는다. 다른 소켓이 주인이면 그 소켓이 자기 창을 닫는다.
+          if (socket !== ws) return;
+          // 재생 바이트가 모두 파싱된 뒤다. 아래 입력 구독 조건과 무관하게 창은 닫는다.
           connectionOptions.onReplayStateChange?.(false);
-          if (socket !== ws || ws.readyState !== OPEN_READY_STATE || inputSubscription) return;
+          if (ws.readyState !== OPEN_READY_STATE || inputSubscription) return;
           disposeInput();
           inputSubscription = connectionOptions.terminal.onData((data) => {
             if (ws.readyState === OPEN_READY_STATE) ws.send(encoder.encode(data));

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-connection.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-connection.ts
@@ -12,6 +12,11 @@ export interface TerminalConnectionOptions {
   /** 콘솔 테마 극성 — ticket 요청에 실려 spawn env COLORFGBG 힌트가 된다(최초 spawn 시점 고정). */
   readonly colorScheme?: "light" | "dark";
   readonly onStatus?: (status: TerminalConnectionStatus, message?: string) => void;
+  /**
+   * 서버 보유 scrollback을 재생하는 구간의 시작(true)과 끝(false)을 알린다. 재생 청크는 과거에 이미
+   * 흘러간 바이트라, 그 안의 부수효과 시퀀스를 지금 다시 실행하면 안 되는 소비자를 위한 신호다.
+   */
+  readonly onReplayStateChange?: (replaying: boolean) => void;
   readonly onExit?: () => void;
   readonly location?: Pick<Location, "host" | "protocol">;
   readonly webSocketFactory?: (url: string) => WebSocketLike;
@@ -86,6 +91,8 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
   };
 
   const attachSocket = async (url: string, connectionOptions: TerminalConnectionOptions): Promise<void> => {
+    // 모든 (재)연결은 서버 attach에서 scrollback 재생으로 시작한다 — 재생 종료는 replay_end가 알린다.
+    connectionOptions.onReplayStateChange?.(true);
     await new Promise<void>((resolve, reject) => {
       const ws = (connectionOptions.webSocketFactory ?? defaultWebSocketFactory)(url);
       socket = ws;
@@ -107,6 +114,9 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
         }
         if (!isReplayEndFrame(frame)) return;
         connectionOptions.terminal.drain(() => {
+          // 재생 바이트가 모두 파싱된 뒤다. 아래 입력 구독 가드보다 먼저 알려, 가드에 걸리는 경우에도
+          // 재생 구간이 열린 채로 남지 않게 한다.
+          connectionOptions.onReplayStateChange?.(false);
           if (socket !== ws || ws.readyState !== OPEN_READY_STATE || inputSubscription) return;
           disposeInput();
           inputSubscription = connectionOptions.terminal.onData((data) => {

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-osc52-clipboard.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-osc52-clipboard.ts
@@ -13,6 +13,12 @@ interface ClipboardWriter {
 export interface TerminalOsc52ClipboardOptions {
   readonly parser: OscHandlerRegistrar;
   readonly clipboard?: ClipboardWriter;
+  /**
+   * True while the connection is replaying server-held scrollback. Replayed bytes are a transcript
+   * of copies the user already made, so re-applying them would overwrite the current clipboard with
+   * stale content just by reopening a panel or reconnecting.
+   */
+  readonly isReplayingScrollback?: () => boolean;
 }
 
 export interface TerminalOsc52ClipboardController {
@@ -34,12 +40,14 @@ export const OSC_CLIPBOARD_IDENT = 52;
 export function createTerminalOsc52Clipboard({
   parser,
   clipboard,
+  isReplayingScrollback,
 }: TerminalOsc52ClipboardOptions): TerminalOsc52ClipboardController {
   const subscription = parser.registerOscHandler(OSC_CLIPBOARD_IDENT, (data) => {
     const text = parseOsc52ClipboardWrite(data);
     // Returning true keeps the sequence consumed either way — an unhandled OSC 52 would otherwise
-    // be logged as unknown on every copy, and refusing a read query is still handling it.
-    if (text === null || !clipboard) return true;
+    // be logged as unknown on every copy, and refusing a read query or a replayed copy is still
+    // handling it.
+    if (text === null || !clipboard || isReplayingScrollback?.() === true) return true;
     try {
       void clipboard.writeText(text).catch(() => undefined);
     } catch {

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-osc52-clipboard.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-osc52-clipboard.ts
@@ -1,0 +1,84 @@
+interface Disposable {
+  readonly dispose: () => void;
+}
+
+interface OscHandlerRegistrar {
+  readonly registerOscHandler: (ident: number, callback: (data: string) => boolean) => Disposable;
+}
+
+interface ClipboardWriter {
+  readonly writeText: (text: string) => Promise<void>;
+}
+
+export interface TerminalOsc52ClipboardOptions {
+  readonly parser: OscHandlerRegistrar;
+  readonly clipboard?: ClipboardWriter;
+}
+
+export interface TerminalOsc52ClipboardController {
+  readonly dispose: () => void;
+}
+
+// OSC 52 is the only way a full-screen TUI can put text on the clipboard: once it enables mouse
+// tracking, xterm hands every drag to the application and disables its own selection, so the
+// application draws the selection itself and reports the copy over this sequence.
+export const OSC_CLIPBOARD_IDENT = 52;
+
+/**
+ * Applies OSC 52 clipboard writes emitted by the running terminal application.
+ *
+ * Writes only. A read query (`OSC 52 ; c ; ?`) asks the terminal to hand the user's clipboard
+ * back to the process on stdin; that answer is never sent, so a program running in a panel
+ * cannot exfiltrate clipboard contents it did not put there.
+ */
+export function createTerminalOsc52Clipboard({
+  parser,
+  clipboard,
+}: TerminalOsc52ClipboardOptions): TerminalOsc52ClipboardController {
+  const subscription = parser.registerOscHandler(OSC_CLIPBOARD_IDENT, (data) => {
+    const text = parseOsc52ClipboardWrite(data);
+    // Returning true keeps the sequence consumed either way — an unhandled OSC 52 would otherwise
+    // be logged as unknown on every copy, and refusing a read query is still handling it.
+    if (text === null || !clipboard) return true;
+    try {
+      void clipboard.writeText(text).catch(() => undefined);
+    } catch {
+      // Clipboard access is best-effort; a blocked write must not break terminal output parsing.
+    }
+    return true;
+  });
+
+  return { dispose: () => subscription.dispose() };
+}
+
+/**
+ * Returns the text an `OSC 52 ; Pc ; Pd` sequence asks to place on the clipboard, or null when the
+ * sequence is not a clipboard write this surface applies.
+ */
+export function parseOsc52ClipboardWrite(data: string): string | null {
+  const separator = data.indexOf(";");
+  if (separator === -1) return null;
+
+  // Pc selects the target buffers. Only `c` is the system clipboard; primary/secondary/select and
+  // the cut buffers are X11 concepts a browser has no counterpart for, so they are left alone.
+  if (!data.slice(0, separator).includes("c")) return null;
+
+  // Pd is `?` for a read query, base64 for a write. Whitespace is not part of the payload.
+  const payload = data.slice(separator + 1).replace(/\s+/g, "");
+  if (payload === "" || payload === "?") return null;
+
+  const text = decodeBase64Utf8(payload);
+  return text === null || text === "" ? null : text;
+}
+
+function decodeBase64Utf8(payload: string): string | null {
+  try {
+    const binary = atob(payload);
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    // atob yields one byte per code unit, so multi-byte text has to be decoded as UTF-8 —
+    // reading it as latin1 mangles every non-ASCII selection.
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return null;
+  }
+}

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -10,6 +10,7 @@ import { getT, useTerminalLocale } from "../i18n/index.js";
 import { createImeShiftEnterHandler } from "./ime-shift-enter.js";
 import { createTerminalConnection, type TerminalConnection } from "./terminal-connection.js";
 import { createTerminalCopyOnSelect } from "./terminal-copy-on-select.js";
+import { createTerminalOsc52Clipboard } from "./terminal-osc52-clipboard.js";
 import { TERMINAL_OPTIONS } from "./terminal-options.js";
 import { useTerminalPrefs } from "./terminal-preferences.js";
 import { createTerminalScrollFollow, type TerminalScrollFollowController } from "./terminal-scroll-follow.js";
@@ -245,6 +246,13 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
         windowTarget: window,
         clipboard: navigator.clipboard,
       });
+      // 전체 화면 TUI(agent CLI 등)가 마우스 트래킹을 켜면 xterm은 드래그를 애플리케이션에 넘기고 자체
+      // 선택을 끈다. 그때부터 선택 하이라이트도 복사도 애플리케이션이 수행하며, 복사 결과는 OSC 52로만
+      // 터미널에 전달된다 — copy-on-select가 읽는 xterm 선택은 그 상태에서 항상 비어 있다.
+      const osc52Clipboard = createTerminalOsc52Clipboard({
+        parser: terminal.parser,
+        clipboard: navigator.clipboard,
+      });
       terminal.loadAddon(new Unicode11Addon());
       terminal.unicode.activeVersion = "11";
 
@@ -352,6 +360,7 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
         imeHandler.dispose();
         connection.dispose();
         copyOnSelect.dispose();
+        osc52Clipboard.dispose();
         scrollGesture.dispose();
         outputScheduler.dispose();
         statusDetailReporter.dispose();

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -249,9 +249,14 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
       // 전체 화면 TUI(agent CLI 등)가 마우스 트래킹을 켜면 xterm은 드래그를 애플리케이션에 넘기고 자체
       // 선택을 끈다. 그때부터 선택 하이라이트도 복사도 애플리케이션이 수행하며, 복사 결과는 OSC 52로만
       // 터미널에 전달된다 — copy-on-select가 읽는 xterm 선택은 그 상태에서 항상 비어 있다.
+      // 단 scrollback 재생 구간은 제외한다: 재생 청크에는 과거 복사의 OSC 52가 그대로 들어 있어,
+      // 패널을 다시 열거나 재연결하는 것만으로 지금 클립보드가 낡은 내용으로 덮인다. connection이
+      // 재생 시작/종료를 알려줄 때까지는 억제해 둔다.
+      let replayingScrollback = true;
       const osc52Clipboard = createTerminalOsc52Clipboard({
         parser: terminal.parser,
         clipboard: navigator.clipboard,
+        isReplayingScrollback: () => replayingScrollback,
       });
       terminal.loadAddon(new Unicode11Addon());
       terminal.unicode.activeVersion = "11";
@@ -311,6 +316,9 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
             outputScheduler.write(data);
           },
           drain: outputScheduler.drain,
+        },
+        onReplayStateChange: (replaying) => {
+          replayingScrollback = replaying;
         },
         onExit: () => onExitRef.current?.(),
         onStatus: (nextStatus, message) => {

--- a/runtime/fleet-plugins/terminal/tests/terminal-connection-replay-gate.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-connection-replay-gate.test.ts
@@ -98,6 +98,53 @@ describe("terminal connection replay input gate", () => {
 
     connection.dispose();
   });
+
+  it("does not let a closed socket's late drain close the reconnected socket's replay window", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ ticket: "ticket-c", ttlMs: 10_000 }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })));
+    const terminal = new FakeTerminal();
+    const replayStates: boolean[] = [];
+    const sockets: FakeWebSocket[] = [];
+    const connection = createTerminalConnection({
+      operationId: "session-c",
+      terminal,
+      ticketPath: "/ticket",
+      wsPath: "/ws",
+      location: { host: "console.test", protocol: "http:" },
+      onReplayStateChange: (replaying) => replayStates.push(replaying),
+      webSocketFactory: () => {
+        const socket = new FakeWebSocket();
+        sockets.push(socket);
+        return socket;
+      },
+    });
+    connection.start();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    sockets[0]!.open();
+
+    // The first socket asks to close its window, but its drain has not run yet.
+    sockets[0]!.receive(JSON.stringify({ type: "replay_end" }));
+    expect(terminal.pendingDrains).toHaveLength(1);
+
+    // It dies first, and the reconnect opens a fresh replay window.
+    sockets[0]!.close();
+    await vi.waitFor(() => expect(sockets).toHaveLength(2), { timeout: 2_000 });
+    sockets[1]!.open();
+    expect(replayStates).toEqual([true, true]);
+
+    // The dead socket's callback finally lands. It must not close the live socket's window.
+    terminal.releaseDrain();
+    expect(replayStates).toEqual([true, true]);
+
+    // Only the live socket's own replay_end closes it.
+    sockets[1]!.receive(JSON.stringify({ type: "replay_end" }));
+    terminal.releaseDrain();
+    expect(replayStates).toEqual([true, true, false]);
+
+    connection.dispose();
+  });
 });
 
 class FakeTerminal {

--- a/runtime/fleet-plugins/terminal/tests/terminal-connection-replay-gate.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-connection-replay-gate.test.ts
@@ -52,6 +52,52 @@ describe("terminal connection replay input gate", () => {
 
     connection.dispose();
   });
+
+  it("reports the replay window on every attach so replayed side effects stay suppressed", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ ticket: "ticket-b", ttlMs: 10_000 }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })));
+    const terminal = new FakeTerminal();
+    const replayStates: boolean[] = [];
+    const sockets: FakeWebSocket[] = [];
+    const connection = createTerminalConnection({
+      operationId: "session-b",
+      terminal,
+      ticketPath: "/ticket",
+      wsPath: "/ws",
+      location: { host: "console.test", protocol: "http:" },
+      onReplayStateChange: (replaying) => replayStates.push(replaying),
+      webSocketFactory: () => {
+        const socket = new FakeWebSocket();
+        sockets.push(socket);
+        return socket;
+      },
+    });
+    connection.start();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    sockets[0]!.open();
+
+    // The window opens with the attach itself, before any replayed byte can reach the parser.
+    expect(replayStates).toEqual([true]);
+
+    sockets[0]!.receive(new TextEncoder().encode("replayed-output").buffer);
+    expect(replayStates).toEqual([true]);
+
+    sockets[0]!.receive(JSON.stringify({ type: "replay_end" }));
+    expect(replayStates).toEqual([true]);
+
+    // It closes only once the replayed bytes have actually been parsed.
+    terminal.releaseDrain();
+    expect(replayStates).toEqual([true, false]);
+
+    // A reconnect replays the same scrollback again, so the window must reopen.
+    sockets[0]!.close();
+    await vi.waitFor(() => expect(sockets).toHaveLength(2), { timeout: 2_000 });
+    expect(replayStates).toEqual([true, false, true]);
+
+    connection.dispose();
+  });
 });
 
 class FakeTerminal {

--- a/runtime/fleet-plugins/terminal/tests/terminal-osc52-clipboard.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-osc52-clipboard.test.ts
@@ -86,9 +86,35 @@ describe("createTerminalOsc52Clipboard", () => {
 
     expect(harness.disposeHandler).toHaveBeenCalledTimes(1);
   });
+
+  it("does not overwrite the clipboard with a copy replayed from scrollback", () => {
+    let replaying = true;
+    const harness = createHarness(() => Promise.resolve(), () => replaying);
+
+    // Reopening a panel replays every past chunk, including the OSC 52 of a copy made long ago.
+    expect(harness.emit(`c;${base64("copied an hour ago")}`)).toBe(true);
+    expect(harness.writeText).not.toHaveBeenCalled();
+
+    replaying = false;
+    harness.emit(`c;${base64("copied just now")}`);
+
+    expect(harness.writeText).toHaveBeenCalledTimes(1);
+    expect(harness.writeText).toHaveBeenCalledWith("copied just now");
+  });
+
+  it("applies writes when no replay state is supplied", () => {
+    const harness = createHarness();
+
+    harness.emit(`c;${base64("no replay signal")}`);
+
+    expect(harness.writeText).toHaveBeenCalledWith("no replay signal");
+  });
 });
 
-function createHarness(writeImplementation: (text: string) => Promise<void> = () => Promise.resolve()) {
+function createHarness(
+  writeImplementation: (text: string) => Promise<void> = () => Promise.resolve(),
+  isReplayingScrollback?: () => boolean,
+) {
   const writeText = vi.fn(writeImplementation);
   const disposeHandler = vi.fn();
   let registeredIdent: number | null = null;
@@ -103,6 +129,7 @@ function createHarness(writeImplementation: (text: string) => Promise<void> = ()
       },
     },
     clipboard: { writeText },
+    ...(isReplayingScrollback ? { isReplayingScrollback } : {}),
   });
 
   return {

--- a/runtime/fleet-plugins/terminal/tests/terminal-osc52-clipboard.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-osc52-clipboard.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { OSC_CLIPBOARD_IDENT, createTerminalOsc52Clipboard, parseOsc52ClipboardWrite } from "../client/shared/terminal-osc52-clipboard.js";
+
+const base64 = (text: string) => Buffer.from(text, "utf8").toString("base64");
+
+describe("parseOsc52ClipboardWrite", () => {
+  it("decodes a clipboard write targeted at the system clipboard", () => {
+    expect(parseOsc52ClipboardWrite(`c;${base64("copied from the TUI")}`)).toBe("copied from the TUI");
+  });
+
+  it("decodes multi-byte text as UTF-8", () => {
+    expect(parseOsc52ClipboardWrite(`c;${base64("복사된 텍스트 · ✳")}`)).toBe("복사된 텍스트 · ✳");
+  });
+
+  it("accepts a clipboard target listed alongside other buffers", () => {
+    expect(parseOsc52ClipboardWrite(`pc;${base64("both")}`)).toBe("both");
+  });
+
+  it("refuses a read query so the clipboard is never handed back to the process", () => {
+    expect(parseOsc52ClipboardWrite("c;?")).toBeNull();
+  });
+
+  it("ignores targets that have no browser counterpart", () => {
+    expect(parseOsc52ClipboardWrite(`p;${base64("primary selection")}`)).toBeNull();
+    expect(parseOsc52ClipboardWrite(`s0;${base64("cut buffer")}`)).toBeNull();
+  });
+
+  it("ignores an empty payload rather than clearing the clipboard", () => {
+    expect(parseOsc52ClipboardWrite("c;")).toBeNull();
+  });
+
+  it("ignores a malformed sequence", () => {
+    expect(parseOsc52ClipboardWrite("c")).toBeNull();
+    expect(parseOsc52ClipboardWrite("c;not base64!!")).toBeNull();
+  });
+
+  it("tolerates whitespace inside the payload", () => {
+    const padded = `${base64("wrapped payload").slice(0, 4)} ${base64("wrapped payload").slice(4)}`;
+    expect(parseOsc52ClipboardWrite(`c;${padded}`)).toBe("wrapped payload");
+  });
+});
+
+describe("createTerminalOsc52Clipboard", () => {
+  it("registers on the OSC 52 identifier and writes decoded text to the clipboard", () => {
+    const harness = createHarness();
+
+    expect(harness.registeredIdent).toBe(OSC_CLIPBOARD_IDENT);
+    expect(harness.emit(`c;${base64("selection from the app")}`)).toBe(true);
+    expect(harness.writeText).toHaveBeenCalledTimes(1);
+    expect(harness.writeText).toHaveBeenCalledWith("selection from the app");
+  });
+
+  it("consumes a read query without writing or answering it", () => {
+    const harness = createHarness();
+
+    expect(harness.emit("c;?")).toBe(true);
+    expect(harness.writeText).not.toHaveBeenCalled();
+  });
+
+  it("survives a rejected clipboard write", () => {
+    const harness = createHarness(() => Promise.reject(new Error("clipboard blocked")));
+
+    expect(() => harness.emit(`c;${base64("blocked")}`)).not.toThrow();
+  });
+
+  it("stays inert without a clipboard", () => {
+    const registeredHandlers: Array<(data: string) => boolean> = [];
+    const controller = createTerminalOsc52Clipboard({
+      parser: {
+        registerOscHandler: (_ident, callback) => {
+          registeredHandlers.push(callback);
+          return { dispose: () => undefined };
+        },
+      },
+    });
+
+    expect(registeredHandlers[0]?.(`c;${base64("no clipboard")}`)).toBe(true);
+    controller.dispose();
+  });
+
+  it("releases its handler on dispose", () => {
+    const harness = createHarness();
+
+    harness.controller.dispose();
+
+    expect(harness.disposeHandler).toHaveBeenCalledTimes(1);
+  });
+});
+
+function createHarness(writeImplementation: (text: string) => Promise<void> = () => Promise.resolve()) {
+  const writeText = vi.fn(writeImplementation);
+  const disposeHandler = vi.fn();
+  let registeredIdent: number | null = null;
+  let handler: ((data: string) => boolean) | null = null;
+
+  const controller = createTerminalOsc52Clipboard({
+    parser: {
+      registerOscHandler: (ident, callback) => {
+        registeredIdent = ident;
+        handler = callback;
+        return { dispose: disposeHandler };
+      },
+    },
+    clipboard: { writeText },
+  });
+
+  return {
+    controller,
+    disposeHandler,
+    writeText,
+    get registeredIdent() {
+      return registeredIdent;
+    },
+    emit: (data: string) => handler!(data),
+  };
+}

--- a/runtime/fleet-plugins/terminal/tests/terminal-surface-focus.test.tsx
+++ b/runtime/fleet-plugins/terminal/tests/terminal-surface-focus.test.tsx
@@ -18,6 +18,7 @@ vi.mock("@xterm/xterm", () => ({
     readonly cols = 80;
     readonly rows = 24;
     readonly unicode = { activeVersion: "" };
+    readonly parser = { registerOscHandler: () => ({ dispose() {} }) };
     readonly options: Record<string, unknown> = {};
     readonly focus = terminalMocks.focus;
     attachCustomKeyEventHandler() {}


### PR DESCRIPTION
## Summary

전체 화면 agent CLI가 실행 중이면 터미널 패널에서 마우스 드래그 복사가 되지 않았습니다. CLI가 마우스 트래킹을 켜면 xterm은 드래그를 애플리케이션에 넘기고 자체 선택을 끄므로(`SelectionService.disable()`), 그때부터 선택과 복사는 앱이 직접 수행하고 결과를 `OSC 52`로 터미널에 통보합니다. xterm 6.0.0에는 `OSC 52` 핸들러가 없어 그 시퀀스가 파서에서 버려졌고, 한편 기존 copy-on-select는 그 상태에서 항상 비어 있는 xterm 선택을 읽고 있었습니다. 결과적으로 앱은 화면에 `copied N chars to clipboard`까지 띄우는데 붙여넣으면 아무것도 나오지 않았습니다.

터미널 표면에 `OSC 52` 핸들러를 등록해 실행 중인 프로그램이 요청한 클립보드 **쓰기**를 반영합니다. 클립보드 **읽기 질의(`OSC 52 ; c ; ?`)는 거부**하므로 패널에서 도는 프로그램이 자신이 넣지 않은 내용을 가져갈 수 없습니다 — 공식 `@xterm/addon-clipboard`(읽기 포함) 대신 자체 구현한 주된 이유입니다.

터미널 클라이언트 공용 표면이라 Agent Operation, Shell Operation, Global Shell 세 마운트에 함께 적용됩니다.

## Type of Change

- [x] fix — bug fix

## Scope

- `runtime/fleet-plugins/terminal/client/shared/` — 터미널 공용 클라이언트 런타임

## Test Plan

- [x] 신규 유닛 13건 (`terminal-osc52-clipboard.test.ts`): `c` 타깃 디코딩, UTF-8 다바이트 복원, 읽기 질의 거부, primary/cut-buffer 타깃 무시, 빈 페이로드 무시, 잘못된 base64 무시, dispose 해제
- [x] 터미널 플러그인 전체 `vitest run` — 57 files / 521 tests 통과
- [x] `typecheck` (터미널 플러그인, fleet-console) 및 fleet-console `build`
- [x] `node scripts/compile-changelog-fragments.mjs --check` 통과
- [x] 격리 콘솔(`FLEET_CONSOLE_DIR`) 실측 — 캔버스 위 `Claude (Gateway)` Operation에서 실제 마우스 드래그:
  - 수정 전 번들: 앱은 선택 하이라이트를 그렸으나 클립보드 쓰기 `[]`
  - 수정 후 번들: 동일 드래그로 `~/workspace/fleet-harness/.fleet/worktrees/terminal-drag-copy` 도달, `pbpaste`로 시스템 클립보드 확인
- [x] PTY 실측으로 원인 확정: Claude Code 2.1.224가 부팅 시 `?1049h ?1000h ?1002h ?1003h ?1006h`를 켜고, 드래그 릴리스 시 `ESC ] 52 ; c ; <base64>` 전송

## Changelog

- [x] Added the branch-named fragment from `node scripts/compile-changelog-fragments.mjs --name-for-branch` (`.changelog.d/terminal-drag-copy.md`)
- [x] Entries sit under the runtime the user notices them in — `### fleet-console`
- [x] Section heading is `Fixed`; bullet is English ASCII with no package tag, followed by its `  ko:` line

## Notes for Reviewers

- 마우스 트래킹은 `/tui fullscreen` 전용이 아닙니다. Claude Code의 마우스 모드 기본값은 `full`(DECSET 1000/1002/1003/1006)이며 `CLAUDE_CODE_DISABLE_MOUSE` / `CLAUDE_CODE_DISABLE_MOUSE_CLICKS`로만 낮아집니다.
- 의도적으로 범위 밖에 둔 항목: `macOptionClickForcesSelection`. 이 옵션의 기본값이 `false`라 macOS에서는 자체 선택 UI가 없는 TUI(vim, htop 등)의 텍스트를 여전히 선택할 수 없지만, 켜면 xterm의 Option+드래그 열 선택을 잃습니다. 별도 판단 사항입니다.
- `fleet-cli`는 커밋 `37660d83`에서 같은 뿌리의 마우스 포워딩 절반을 이미 해결했습니다. CLI는 실제 터미널 에뮬레이터 안에서 돌아 `OSC 52`를 상위 터미널이 처리하므로 클립보드 갭은 Console에만 남아 있었습니다.