### PR TITLE
fix(fleet-console): keep canvas launch kinds enabled in Formation view

### DIFF
--- a/.changelog.d/canvas-menu-formation-launch.md
+++ b/.changelog.d/canvas-menu-formation-launch.md
@@ -1,0 +1,8 @@
+---
+branch: canvas-menu-formation-launch
+---
+
+### fleet-console
+#### Fixed
+- Right-clicking the canvas in Tactical view now offers every launch kind instead of showing them all greyed out with no reason. Launching from the canvas menu matches the sidebar and the launcher, which already launched in that mode, and Tactical keeps gating only canvas gestures such as panning, zooming, and drag-to-create.
+  ko: Tactical 뷰에서 캔버스를 우클릭하면 실행 종류가 사유 없이 모두 회색이던 문제를 고쳐, 이제 모든 실행 종류를 그대로 제공합니다. 캔버스 메뉴 실행이 이미 그 모드에서 실행되던 사이드바·런처와 같아지며, Tactical은 팬·줌·드래그 생성 같은 캔버스 제스처만 계속 막습니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -1064,7 +1064,10 @@ export function OperationsCanvas({
           viewportBounds={viewportBoundsFor(canvasRef.current)}
           placement="cursor"
           catalog={catalog}
-          canLaunch={canLaunch && !formationView}
+          // 실행 가부는 모드가 아니라 Theater가 정한다 — 사이드바와 좌하단 런처는 어느 모드에서도
+          // 같은 catalog를 그대로 실행하므로, 여기만 Formation을 이유로 막으면 같은 메뉴가
+          // 진입 경로에 따라 죽는다. Formation이 막는 것은 캔버스 제스처(팬·줌·드래그 생성)뿐이다.
+          canLaunch={canLaunch}
           renderKindIcon={renderKindIcon}
           onLaunchKind={handleContextMenuLaunchKind}
           onClose={() => setContextMenu(null)}

--- a/runtime/fleet-console/tests/canvas-context-menu-formation-launch.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-formation-launch.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../core/client/src/plugin-registry.js", () => ({
+  usePluginRegistry: () => ({
+    plugins: [],
+    operationKinds: [{
+      pluginId: "test-plugin",
+      type: "shell",
+      title: "Test",
+      render: () => null,
+    }],
+    settingsSections: [],
+    notificationKinds: [],
+    railPanels: [],
+  }),
+}));
+
+import { OperationsCanvas } from "../core/client/src/canvas/canvas.js";
+import { clearFormationView, loadForTheater, setState as setCanvasState, toggleFormationView } from "../core/client/src/canvas/canvas-store.js";
+import type { ConsoleState, OperationNode } from "../core/client/src/types.js";
+
+const THEATER = "theater-a";
+const OPERATION: OperationNode = {
+  id: "operation-a",
+  theaterId: THEATER,
+  type: "shell",
+  pluginId: "test-plugin",
+  title: "Operation A",
+  payload: {},
+  geometry: { x: 0, y: 0, width: 320, height: 200, zIndex: 1 },
+  ts: { createdAt: 0, updatedAt: 0 },
+};
+const CATALOG = [{ id: "test-plugin", title: "Test", kinds: [{ id: "shell", type: "shell", title: "Shell" }] }];
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  loadForTheater(THEATER);
+  setCanvasState({
+    viewport: { x: 0, y: 0, zoom: 1 },
+    operations: { [OPERATION.id]: OPERATION.geometry! },
+  });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  clearFormationView(THEATER);
+  loadForTheater(null);
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("canvas controls launch parity across canvas modes", () => {
+  // Formation은 캔버스 제스처(팬·줌·드래그 생성)를 막는 모드지 실행을 막는 모드가 아니다 —
+  // 같은 catalog가 사이드바와 좌하단 런처에서는 계속 실행되므로, 우클릭에서만 죽으면
+  // 사용자에게는 "메뉴는 열리는데 전부 회색"이라는 원인 없는 고장으로만 보인다.
+  it("keeps launch kinds enabled in Formation view", () => {
+    renderCanvas();
+    act(() => toggleFormationView());
+    expect(container!.querySelector("main.operations-canvas")?.className).toContain("is-formation-view");
+
+    const canvas = container!.querySelector<HTMLElement>("main.operations-canvas")!;
+    const menu = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 120, clientY: 240 });
+    act(() => canvas.dispatchEvent(menu));
+    expect(menu.defaultPrevented).toBe(true);
+
+    const item = container!.querySelector<HTMLButtonElement>('[data-operation-launch-kind="shell"]');
+    expect(item).not.toBeNull();
+    expect(item!.disabled).toBe(false);
+    act(() => { window.dispatchEvent(new Event("canvas-context-menu-close")); });
+  });
+
+  it("launches at the cursor from Formation view", () => {
+    const launches: string[] = [];
+    renderCanvas({ onLaunchKind: (pluginId, kind) => launches.push(`${pluginId}:${kind.id}`) });
+    act(() => toggleFormationView());
+
+    const canvas = container!.querySelector<HTMLElement>("main.operations-canvas")!;
+    act(() => canvas.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 120, clientY: 240 })));
+    act(() => container!.querySelector<HTMLButtonElement>('[data-operation-launch-kind="shell"]')!.click());
+
+    expect(launches).toEqual(["test-plugin:shell"]);
+  });
+
+  it("still disables launch kinds when no Theater owns the launch", () => {
+    // 모드가 아니라 Theater가 실행 가부를 정한다는 반대 방향 — 게이트 제거가 canLaunch까지
+    // 지워버리면 이 단언이 먼저 무너진다.
+    renderCanvas({ canLaunch: false });
+    act(() => toggleFormationView());
+
+    const canvas = container!.querySelector<HTMLElement>("main.operations-canvas")!;
+    act(() => canvas.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 120, clientY: 240 })));
+
+    const item = container!.querySelector<HTMLButtonElement>('[data-operation-launch-kind="shell"]');
+    expect(item).not.toBeNull();
+    expect(item!.disabled).toBe(true);
+    act(() => { window.dispatchEvent(new Event("canvas-context-menu-close")); });
+  });
+});
+
+function renderCanvas(overrides: Partial<Parameters<typeof OperationsCanvas>[0]> = {}) {
+  act(() => root!.render(createElement(OperationsCanvas, {
+    state: STATE,
+    catalog: CATALOG,
+    canLaunch: true,
+    renderKindIcon: () => null,
+    onLaunchKind: () => {},
+    onLaunchAtGeometry: () => {},
+    onClose: () => {},
+    onFocus: () => {},
+    onRename: () => {},
+    onSetAccent: () => {},
+    ...overrides,
+  })));
+}
+
+const STATE: ConsoleState = {
+  connection: "connecting",
+  connectionLostAt: null,
+  channel: "unknown",
+  activeTheme: "maritime",
+  version: "test",
+  updateAvailable: false,
+  latestVersion: null,
+  portMode: "dynamic",
+  requestedPort: null,
+  effectivePort: 0,
+  portHonored: true,
+  theaters: [{ id: THEATER, label: "Alpha" }],
+  operations: [OPERATION],
+  operationsHydrated: true,
+  groups: [],
+  activeTheaterId: THEATER,
+  activeOperationId: OPERATION.id,
+  activeOperationAcknowledged: true,
+  operationStatus: { [OPERATION.id]: "awaiting" },
+  addingTheater: false,
+  theaterError: null,
+  operationsViewActive: true,
+  operationSearchOpen: false,
+  operationSearchSeed: null,
+  whatsNewOpen: false,
+  releaseNotes: [],
+  releaseNotesLoading: false,
+  releaseNotesError: null,
+  releaseNotesSourceRef: null,
+  releaseNotesFetchedAt: null,
+  releaseNotesStale: false,
+  automaticWhatsNewVersion: null,
+  selectedReleaseNoteKey: null,
+  onboardingOpen: false,
+  bootstrapped: true,
+  pendingOperationFocus: null,
+  keyboardFocusRequest: null,
+  pendingSideBarAddTheater: false,
+  pendingSideBarTheaterLaunch: null,
+  launchMenuRequest: null,
+  keyboardShortcutsOpen: false,
+  operationNotifications: {},
+  notificationPreferences: { globalMute: false, dnd: false, mutedTheaterIds: {} },
+  codexReader: null,
+  codexReaderExpanded: false,
+};


### PR DESCRIPTION
## Summary

Tactical(Formation) 뷰에서 캔버스를 우클릭하면 실행 종류가 **전부 비활성**으로 뜨고, 비활성 사유조차 표시되지 않았습니다. 원인은 `canvas.tsx`의 우클릭 메뉴에만 걸려 있던 `canLaunch && !formationView` 게이트입니다. 같은 `CanvasContextMenu`를 쓰는 사이드바·War Room 사이드바·빈 상태 런처는 `canLaunch`를 그대로 넘기므로, **같은 메뉴가 여는 방법에 따라 죽거나 살았습니다.**

Formation 플래그는 Theater별로 남아 그 Theater로 돌아오면 되살아나고, `disabledReason`은 플러그인이 Agent CLI를 못 찾았을 때만 붙습니다. 그래서 사용자에게는 원인 없는 간헐적 고장으로 보였습니다.

게이트는 Formation 도입 커밋 `f4eeb5bc`(#202)의 잔재입니다. 당시 메뉴는 Formation 토글을 품은 종합 메뉴였지만 지금은 실행 전용이라, Formation에서는 아무것도 못 하는 죽은 메뉴가 됐습니다. Formation이 실제로 막는 것은 `useCanvasInteraction`의 캔버스 제스처(팬·줌·드래그 생성)뿐이고 실행을 막은 적은 없습니다.

## Type of Change

- [x] fix — bug fix

## Test Plan

격리 콘솔(전용 `FLEET_CONSOLE_DIR`, Theater 2개 시드)에서 CDP `Input.dispatchMouseEvent`로 실제 우클릭을 보내 측정했습니다.

| 상태 | 메뉴 | 활성/전체 |
|---|---|---|
| Cruise 우클릭 | 열림 | 4/4 |
| Tactical 우클릭 (수정 전) | 열림 | **0/4** (사유 `null`) |
| Tactical 사이드바 실행 | 열림 | 4/4 |
| War Room 우클릭 | 열림 | 4/4 |
| Tactical 우클릭 (수정 후) | 열림 | 4/4 |

- [x] 재현 — Tactical에서 4개 실행 종류 전부 `disabled: true`, `disabledReason` 없음
- [x] Theater별 Formation 부활 확인 — A에서 Tactical → B 전환 → A 복귀 시 `is-formation-view` 재적용
- [x] 수정 후 세 모드(Cruise/Tactical/War Room) 모두 4/4 활성, 페이지 에러·rejection 0건
- [x] Tactical에서 Shell을 실제로 실행해 Operation 생성까지 확인
- [x] 회귀 테스트 3건 추가 — 게이트를 임시 복원하면 2건이 red가 되는 트립와이어임을 확인
- [x] `pnpm --filter @dotobokuri/fleet-console exec tsc --noEmit` — 0 오류
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run` — 131 파일 1427건 통과

## Changelog

- [x] 브랜치명 프래그먼트 `.changelog.d/canvas-menu-formation-launch.md` 동봉
- [x] 항목은 사용자가 체감하는 런타임(`### fleet-console`) 아래에 배치
- [x] `node scripts/compile-changelog-fragments.mjs --check` 통과