### PR TITLE
feat(console): show the War Room quick-look preview at actual size

### DIFF
--- a/.changelog.d/triage-quicklook-actual-size.md
+++ b/.changelog.d/triage-quicklook-actual-size.md
@@ -1,0 +1,8 @@
+---
+branch: triage-quicklook-actual-size
+---
+
+### fleet-console
+#### Changed
+- Show the War Room quick-look preview at actual size. Hovering a Watch Deck card used to magnify the card and the shrunken preview inside it together, so the same thumbnail simply got bigger and its terminal text stayed under reading size. The preview now cancels out the card's magnification and stands at 1:1, which puts the text at the size you read it at in the panel itself, and the frame shows as much of the latest output as it can hold. The fleet map's quick-look window reads at the same size.
+  ko: War Room 확대 미리보기를 실제 크기로 보여줍니다. 지금까지는 Watch Deck 카드에 마우스를 올리면 카드와 그 안의 축소된 미리보기가 함께 커져, 같은 축소판이 커지기만 할 뿐 터미널 글자는 판독 크기에 미치지 못했습니다. 이제 미리보기가 카드 확대 배율을 상쇄해 1:1로 서므로 글자가 패널에서 읽던 그 크기가 되고, 프레임에는 담을 수 있는 만큼의 최신 출력이 보입니다. 작전지도의 확대창도 같은 크기로 읽힙니다.

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -1069,6 +1069,10 @@ export function TriageWatchDeck({
                           detail={statusDetail.detail}
                           accentColor={accentColor}
                           preview={preview}
+                          // 확대된 카드만 자기 배율을 넘긴다 — 프리뷰는 그 배율을 상쇄해
+                          // 터미널을 화면상 실물 크기로 세운다. 배율이 grid 한도에 걸려 1까지
+                          // 깎인 좁은 창에서도 판독이라는 목적은 그대로 선다.
+                          surfaceScale={isQuicklook ? quicklook.scale : 0}
                         />
                       </button>
                     );
@@ -1144,6 +1148,9 @@ export function TriageWatchDeck({
               detail={mapQuicklookOperation.detail}
               accentColor={mapQuicklookOperation.accentColor}
               preview={mapQuicklookOperation.preview}
+              // 지도 확대창은 transform 없이 제 크기로 뜨므로 표면 배율이 곧 1이다 — 그래도
+              // 확대창이라는 사실은 같으므로 프리뷰는 카드 Quick-Look과 같은 실물 크기로 선다.
+              surfaceScale={1}
             />
           </div>
         ) : null}
@@ -1305,13 +1312,15 @@ function renderTriageMapDots(
 
 // 카드 얼굴 — 덱 카드와 지도 점의 확대창이 같은 조각(스파인·상태줄·제목·프리뷰/tail)을 공유한다.
 // 두 표면이 각자 얼굴을 조립하면 같은 Operation이 밀도에 따라 다르게 읽힌다.
-function TriageDeckCardFace({ operationId, title, label, detail, accentColor, preview }: {
+function TriageDeckCardFace({ operationId, title, label, detail, accentColor, preview, surfaceScale = 0 }: {
   readonly operationId: string;
   readonly title: string;
   readonly label: string;
   readonly detail: string | null | undefined;
   readonly accentColor: string | null;
   readonly preview: TriagePreviewSource | null;
+  /** 이 얼굴을 담은 표면의 화면상 확대 배율 — 확대창만 넘긴다(기본 0 = 확대창 아님). */
+  readonly surfaceScale?: number;
 }) {
   return (
     <>
@@ -1322,7 +1331,12 @@ function TriageDeckCardFace({ operationId, title, label, detail, accentColor, pr
       </span>
       <strong title={title}>{title}</strong>
       {preview ? (
-        <TriageDeckCardPreview config={preview.config} bottomChrome={preview.bottomChrome} operationId={operationId} />
+        <TriageDeckCardPreview
+          config={preview.config}
+          bottomChrome={preview.bottomChrome}
+          operationId={operationId}
+          surfaceScale={surfaceScale}
+        />
       ) : (
         <span className="canvas-triage-deck-card-detail" title={detail ?? label}>
           {detail ?? label}
@@ -1342,10 +1356,18 @@ const TRIAGE_PREVIEW_BOTTOM_CHROME_MAX_RATIO = 0.3;
 // 비어 보이는 것은 정직한 상태 표현이다). 밴드 높이는 body 소유자인 kind가 선언하며
 // (OperationKindDescriptor.previewBottomChrome), 선언이 없는 body는 바닥까지 출력이 흐른다는
 // 뜻이므로 0 — 순정 셸과 문서형 패널은 최신 행을 잃지 않는다.
+//
+// minScale은 확대창이 요구하는 배율 하한이다. 카드는 함대를 한눈에 담는 축소판이므로 cover-fit이
+// 정답이지만, Quick-Look은 "축소판을 크게 키운 그림"이 아니라 "실물을 들여다보는 창"이다. 표면이
+// 화면에서 S배로 확대돼 있을 때 1/S를 하한으로 받으면 두 배율이 상쇄되어 화면상 1:1이 서고, 글자는
+// 패널에서 읽던 크기 그대로가 된다. 대신 보이는 범위는 창이 담는 만큼으로 좁아진다(그것이 돋보기다).
+// cover-fit이 하한보다 크면 cover가 이긴다 — 레터박스를 만들면서까지 실물 크기를 고집하지 않고,
+// 이미 실물보다 크게 보이는 프리뷰를 굳이 줄이지도 않는다.
 export function resolveTriagePreviewFit(
   viewport: { readonly width: number; readonly height: number },
   inner: { readonly width: number; readonly height: number },
   bottomChrome = 0,
+  minScale = 0,
 ): { scale: number; left: number; top: number } | null {
   if (viewport.width <= 0 || viewport.height <= 0) return null;
   if (inner.width <= 0 || inner.height <= 0) return null;
@@ -1353,7 +1375,8 @@ export function resolveTriagePreviewFit(
   const declared = Number.isFinite(bottomChrome) ? Math.max(0, bottomChrome) : 0;
   const chrome = Math.min(declared, inner.height * TRIAGE_PREVIEW_BOTTOM_CHROME_MAX_RATIO);
   const contentHeight = inner.height - chrome;
-  const scale = Math.max(viewport.width / inner.width, viewport.height / contentHeight);
+  const floor = Number.isFinite(minScale) ? Math.max(0, minScale) : 0;
+  const scale = Math.max(floor, viewport.width / inner.width, viewport.height / contentHeight);
   return {
     scale,
     left: (viewport.width - inner.width * scale) / 2,
@@ -1361,13 +1384,22 @@ export function resolveTriagePreviewFit(
   };
 }
 
+// 표면 배율을 프리뷰가 되돌려야 할 하한으로 옮긴다 — 확대창이 아니면(0) 하한도 없다.
+export function resolveTriagePreviewMinScale(surfaceScale: number): number {
+  if (!Number.isFinite(surfaceScale) || surfaceScale <= 0) return 0;
+  return 1 / surfaceScale;
+}
+
 // 라이브 프리뷰 — pool 슬롯이 실제 패널 body를 카드 안으로 끌어온다. 내부 박스는 패널의 원래
 // 픽셀 크기를 고정 유지한 채 transform scale로만 축소한다: FitAddon이 카드 크기를 측정하면
 // PTY cols/rows가 타일 크기로 리사이즈되어 실세션 레이아웃이 깨지므로, 측정 크기 불변이 계약이다.
-function TriageDeckCardPreview({ operationId, config, bottomChrome }: {
+function TriageDeckCardPreview({ operationId, config, bottomChrome, surfaceScale }: {
   readonly operationId: string;
   readonly config: OperationBodyConfig;
   readonly bottomChrome: number;
+  /** 이 프리뷰를 담은 표면의 화면상 확대 배율 — Quick-Look으로 확대된 표면만 자기 배율을
+      넘긴다. 0은 확대창이 아니라는 뜻이고, 평상시 카드는 축소판(cover-fit)으로 남는다. */
+  readonly surfaceScale: number;
 }) {
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const [fit, setFit] = useState<{ scale: number; left: number; top: number } | null>(null);
@@ -1375,6 +1407,7 @@ function TriageDeckCardPreview({ operationId, config, bottomChrome }: {
   // 올려 잡으면 지원되는 작은 패널의 프리뷰 컨테이너가 실제 geometry보다 커져 refit을 유발한다.
   const innerWidth = Math.max(320, config.geometry.width);
   const innerHeight = Math.max(200, config.geometry.height);
+  const minScale = resolveTriagePreviewMinScale(surfaceScale);
   useLayoutEffect(() => {
     const viewport = viewportRef.current;
     if (!viewport) return;
@@ -1383,6 +1416,7 @@ function TriageDeckCardPreview({ operationId, config, bottomChrome }: {
         { width: viewport.clientWidth, height: viewport.clientHeight },
         { width: innerWidth, height: innerHeight },
         bottomChrome,
+        minScale,
       ));
     };
     measure();
@@ -1390,10 +1424,17 @@ function TriageDeckCardPreview({ operationId, config, bottomChrome }: {
     const observer = new ResizeObserver(measure);
     observer.observe(viewport);
     return () => observer.disconnect();
-  }, [bottomChrome, innerHeight, innerWidth]);
+    // Quick-Look 배율은 열려 있는 동안에도 grid 스크롤·리사이즈로 재계산되므로(recordRects),
+    // 하한이 바뀌면 fit도 다시 잡아야 한다. 뷰포트 크기는 그대로일 수 있어 ResizeObserver만으로는
+    // 이 변화를 잡지 못한다.
+  }, [bottomChrome, innerHeight, innerWidth, minScale]);
   return (
     <span className="canvas-triage-deck-card-preview" ref={viewportRef} aria-hidden="true" inert>
       {fit ? (
+        // 이 transform에는 전이를 붙이지 않는다. 전이는 카드 확대가 이미 소유하고 있고 프리뷰
+        // 배율은 거기에 올라탄다 — 프리뷰가 자기 전이를 따로 가지면 두 전이가 서로 다른 값을
+        // 쫓게 되고, 덱 줌 tween이나 창 리사이즈처럼 fit이 매 프레임 다시 잡히는 동안 프리뷰가
+        // 뒤처져 화면 배율이 1:1을 벗어나고 가장자리에 빈 띠가 뜬다.
         <span
           className="canvas-triage-deck-card-preview-inner"
           style={{

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2719,7 +2719,10 @@
 }
 
 /* 내부 박스는 패널의 원래 픽셀 크기를 유지한 채 transform으로만 축소된다(PTY 리사이즈 금지 계약).
-   translate+scale은 JS가 min 비율 fit으로 계산해 전체 패널을 중앙 배치한다. */
+   translate+scale은 JS가 min 비율 fit으로 계산해 전체 패널을 중앙 배치한다. Quick-Look이 열리면
+   같은 값에 실물 크기 하한(1/카드배율)이 들어와 화면상 1:1이 선다. 이 transform에는 전이를 두지
+   않는다 — 전이는 카드 확대가 소유하고, 여기에 따로 걸면 덱 줌 tween처럼 fit이 매 프레임 다시
+   잡히는 동안 프리뷰가 뒤처져 가장자리에 빈 띠가 뜬다. */
 .canvas-triage-deck-card-preview-inner {
   position: absolute;
   top: 0;

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1391,3 +1391,39 @@ describe("Instrument core design contract", () => {
     expect(40).toBeLessThan(60);
   });
 });
+
+// War Room Quick-Look은 확대창 안의 프리뷰를 화면상 실물 크기(1:1)로 세운다. 배율 산술은
+// triage-deck-quicklook.test.ts가 고정하지만, 산술이 맞아도 배선이 끊기거나 전이 소유가 옮겨가면
+// 화면은 조용히 예전 동작 — 같은 축소판이 커지기만 하는 확대 — 으로 돌아간다.
+describe("War Room Quick-Look actual-size grammar", () => {
+  const deck = source("canvas/triage-watch-deck.tsx");
+  const components = source("styles/components.css");
+
+  it("hands a card its own magnification only while its Quick-Look is open", () => {
+    expect(deck).toContain("surfaceScale={isQuicklook ? quicklook.scale : 0}");
+  });
+
+  it("treats the map Quick-Look window as a magnified surface standing at its own size", () => {
+    expect(deck).toContain("surfaceScale={1}");
+  });
+
+  it("feeds the floor into the fit and re-measures when the floor moves", () => {
+    expect(deck).toContain("resolveTriagePreviewMinScale(surfaceScale)");
+    // Quick-Look 배율은 열린 채로도 재계산된다(recordRects) — deps에서 빠지면 뷰포트가 그대로인
+    // 동안 fit이 낡은 하한에 머물러 확대창이 1:1을 잃는다.
+    expect(deck).toMatch(/\[bottomChrome, innerHeight, innerWidth, minScale\]/);
+  });
+
+  it("leaves the preview transform without a transition of its own", () => {
+    const inner = components.match(/\.canvas-triage-deck-card-preview-inner \{[^}]*\}/)?.[0] ?? "";
+    expect(inner).not.toBe("");
+    // fit은 덱 줌 tween과 창 리사이즈마다 매 프레임 다시 잡힌다 — 여기 전이를 걸면 프리뷰가
+    // 카드보다 뒤처져 화면 배율이 1:1을 벗어나고 가장자리에 빈 띠가 뜬다.
+    expect(inner).not.toContain("transition");
+  });
+
+  it("keeps the magnification transition on the card that owns it", () => {
+    const card = components.match(/\.canvas-triage-deck-card \{[^}]*\}/)?.[0] ?? "";
+    expect(card).toContain("transform var(--duration-slow)");
+  });
+});

--- a/runtime/fleet-console/tests/triage-deck-quicklook.test.ts
+++ b/runtime/fleet-console/tests/triage-deck-quicklook.test.ts
@@ -7,8 +7,10 @@ import {
   resolveTriageMapQuicklookPlacement,
   resolveTriageMorphFrame,
   resolveTriagePreviewFit,
+  resolveTriagePreviewMinScale,
   resolveTriageQuicklookOrigin,
   resolveTriageQuicklookScale,
+  TRIAGE_DECK_QUICKLOOK_SCALE,
   TRIAGE_MAP_QUICKLOOK_HEIGHT,
   TRIAGE_MAP_QUICKLOOK_WIDTH,
 } from "../core/client/src/canvas/triage-watch-deck.js";
@@ -230,3 +232,90 @@ describe("resolveTriagePreviewFit", () => {
     expect(resolveTriagePreviewFit({ width: 200, height: 0 }, { width: 800, height: 600 }, AGENT_CHROME)).toBeNull();
   });
 });
+
+describe("resolveTriagePreviewMinScale", () => {
+  it("asks for no floor outside a magnified window", () => {
+    // 평상시 카드는 함대를 한눈에 담는 축소판이다 — 확대창이 아니므로 하한도 없다.
+    expect(resolveTriagePreviewMinScale(0)).toBe(0);
+  });
+
+  it("turns a surface magnification into the floor that cancels it", () => {
+    expect(resolveTriagePreviewMinScale(TRIAGE_DECK_QUICKLOOK_SCALE)).toBeCloseTo(1 / 1.95, 10);
+    // 지도 확대창은 transform 없이 제 크기로 뜨므로 표면 배율이 1이고, 하한도 그대로 실물 크기다.
+    expect(resolveTriagePreviewMinScale(1)).toBe(1);
+  });
+
+  it("falls back to no floor for degenerate input", () => {
+    expect(resolveTriagePreviewMinScale(-1)).toBe(0);
+    expect(resolveTriagePreviewMinScale(Number.NaN)).toBe(0);
+    expect(resolveTriagePreviewMinScale(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe("resolveTriagePreviewFit — actual-size floor", () => {
+  // 실측 기하(1680×1050 창, 덱 줌 1.0): 카드 프리뷰 뷰포트 282×123, 지도 확대창 471×206,
+  // 프리뷰 소스 640×400.
+  const SOURCE = { width: 640, height: 400 };
+
+  it("lands the card Quick-Look on exactly 1:1 once the card magnification is applied", () => {
+    const surface = TRIAGE_DECK_QUICKLOOK_SCALE;
+    const fit = resolveTriagePreviewFit(
+      { width: 282, height: 123 },
+      SOURCE,
+      0,
+      resolveTriagePreviewMinScale(surface),
+    )!;
+    expect(surface * fit.scale).toBeCloseTo(1, 10);
+  });
+
+  it("lands the map Quick-Look on exactly 1:1", () => {
+    const fit = resolveTriagePreviewFit(
+      { width: 471, height: 206 },
+      SOURCE,
+      0,
+      resolveTriagePreviewMinScale(1),
+    )!;
+    expect(fit.scale).toBeCloseTo(1, 10);
+  });
+
+  it("still reaches actual size when the grid cap shaved the card scale down to 1", () => {
+    // 좁은 창에서 카드가 커지지 못해도 판독이라는 목적은 남는다.
+    const fit = resolveTriagePreviewFit({ width: 282, height: 123 }, SOURCE, 0, resolveTriagePreviewMinScale(1))!;
+    expect(fit.scale).toBeCloseTo(1, 10);
+  });
+
+  it("keeps the unmagnified card on cover-fit", () => {
+    const floored = resolveTriagePreviewFit({ width: 282, height: 123 }, SOURCE, 0, 0)!;
+    const plain = resolveTriagePreviewFit({ width: 282, height: 123 }, SOURCE, 0)!;
+    expect(floored).toEqual(plain);
+    expect(plain.scale).toBeCloseTo(282 / 640, 10);
+  });
+
+  it("lets cover-fit win over the floor rather than opening a letterbox", () => {
+    // 큰 카드·작은 패널에서는 cover-fit이 이미 실물을 넘는다 — 하한을 위해 줄이면 프레임에
+    // 빈 띠가 생기므로 cover가 이긴다.
+    const fit = resolveTriagePreviewFit(
+      { width: 486, height: 336 },
+      { width: 320, height: 200 },
+      0,
+      resolveTriagePreviewMinScale(TRIAGE_DECK_QUICKLOOK_SCALE),
+    )!;
+    expect(fit.scale).toBeCloseTo(Math.max(486 / 320, 336 / 200), 10);
+  });
+
+  it("keeps the crop anchors under the floor", () => {
+    // 이 케이스는 아래 배선 계약과 짝이다 — 산술만 맞고 배선이 끊기면 화면은 여전히 축소판이다.
+    const fit = resolveTriagePreviewFit(
+      { width: 282, height: 123 },
+      SOURCE,
+      104,
+      resolveTriagePreviewMinScale(TRIAGE_DECK_QUICKLOOK_SCALE),
+    )!;
+    // 상단에 빈 띠가 열리지 않고, 가로는 중앙에 남는다.
+    expect(fit.top).toBeLessThanOrEqual(0);
+    expect(fit.left).toBeCloseTo((282 - 640 * fit.scale) / 2, 10);
+    // 크롬을 뺀 출력 영역의 바닥은 여전히 프레임 바닥에 닿는다.
+    expect(fit.top + (400 - 104) * fit.scale).toBeCloseTo(123, 10);
+  });
+});
+


### PR DESCRIPTION
## Summary

War Room의 hover 확대(Quick-Look)가 카드와 그 안의 축소된 프리뷰를 함께 키우기만 해서, 확대해도 같은 축소판이 커질 뿐 터미널 글자가 판독 크기에 미치지 못했습니다. 프리뷰 cover-fit에 **실물 크기 하한(1/카드배율)** 을 넣어 두 배율이 상쇄되게 했고, 그 결과 확대창 안 터미널이 화면상 1:1로 섭니다. 작전지도의 확대창도 같은 크기로 읽힙니다.

- 평상시 카드는 그대로 축소판(cover-fit)입니다 — 확대창만 하한을 받습니다.
- cover-fit이 이미 하한을 넘는 구간(큰 줌·작은 패널)은 건드리지 않습니다. 하한을 위해 줄이면 프레임에 빈 띠가 생기기 때문입니다.
- 프리뷰 transform에는 전이를 두지 않습니다. 전이는 카드 확대가 소유하고, 여기에 따로 걸면 덱 줌 tween처럼 fit이 매 프레임 다시 잡히는 동안 프리뷰가 뒤처져 배율이 1:1을 벗어나고 가장자리에 빈 띠가 뜹니다.

## Type of Change

- [x] feat — new feature or carrier capability

## Test Plan

- [x] 격리 콘솔 헤드리스 실측(1680×1050, 덱 줌 1.0): 카드 Quick-Look 합성 배율 `1.95 × 0.512821 = 1.000001`, 화면상 글꼴 14px(패널 원본과 동일)
- [x] 같은 실측에서 평상시 카드는 `0.440625`(cover-fit) 유지 — 회귀 없음
- [x] 지도 Quick-Look 합성 배율 `1:1` 확인(직전 구조에서 `0.99999`, 최종 구조는 동일 산술)
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 130 files / 1438 passed, 0 failed
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 0 errors
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 성공
- [x] 계약 트립와이어 고의 위반 2종(프리뷰 transform에 전이 추가 / 카드 배율 배선 스왑)이 실제로 red를 내는지 확인

## Changelog

- [x] Added the branch-named fragment from `node scripts/compile-changelog-fragments.mjs --name-for-branch`, or declared it internal below.
- [x] Entries sit under the runtime the user notices them in — `### fleet-console`.
- [x] Section headings are `Added`, `Changed`, `Fixed`, `Removed`, or `Breaking Changes`; bullets are English ASCII with no package tag, each followed by its `  ko:` line.

## Notes for Reviewers

- 가시 범위는 의도적으로 좁아집니다(패널 좌표계 640×279 → 550×240px). 돋보기의 대가이며 요청된 1:1의 필연적 결과입니다.
- 별건으로, 카드 프리뷰 안에서 `.operation-body-mount`가 `display:block`인데 자식 `.terminal-stage`가 `flex:1 1 0%`라 셸 터미널이 1행으로 무너지는 기존 결함을 확인했습니다. 이 PR과 무관하며(레이어 구조를 무력화해도 재현) 여기서 다루지 않습니다.