### PR TITLE
feat(fleet-console): one global toast on theme polarity switch

### DIFF
--- a/.changelog.d/theme-switch-global-toast.md
+++ b/.changelog.d/theme-switch-global-toast.md
@@ -1,0 +1,8 @@
+---
+branch: theme-switch-global-toast
+---
+
+### fleet-console
+#### Changed
+- Switching between light and dark console themes now raises a single dismissible notice instead of one hint per terminal panel. The notice appears once at the bottom-right, dismisses itself after a few seconds, and still suggests relaunching running CLIs or running `/theme` to match.
+  ko: 라이트·다크 콘솔 테마를 전환하면 이제 터미널 패널마다 힌트가 뜨는 대신 닫을 수 있는 안내가 하나만 표시됩니다. 안내는 오른쪽 아래에 한 번 뜨고 몇 초 뒤 스스로 사라지며, 실행 중인 CLI를 다시 시작하거나 `/theme`으로 테마를 맞추라는 제안은 그대로 담습니다.

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -12,7 +12,7 @@ import { KeyboardShortcutsDialog } from "./components/keyboard-shortcuts-dialog.
 import { takeKeyboardShortcutsReturnFocus } from "./focus-guards.js";
 import { OperationSearch } from "./components/operation-search.js";
 import { ReconnectButton } from "./components/reconnect-button.js";
-import { Toast } from "./components/toast.js";
+import { Toast, ToastHost } from "./components/toast.js";
 import { appendPendingDeletion, deletionCountdownSeconds, latestPendingDeletion } from "./deletion-undo.js";
 import { WhatsNewModal } from "./components/whatsnew-modal.js";
 import { FloatingWidgetLayer } from "./floating-widget-layer.js";
@@ -26,7 +26,7 @@ import { Operations } from "./pages/operations.js";
 import { BUILT_IN_RAIL_PANELS } from "./rail/built-in-panels.js";
 import { setRailChromeExpanded, toggleRailChrome } from "./rail/rail-store.js";
 import { refreshObserverStatus } from "./operations-sse.js";
-import { closeKeyboardShortcuts, hydrateGroups, hydrateInitialOperations, hydrateOperations, hydrateTheaterBootstrap, hydrateTheaters, openOperationSearch, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, toggleOperationSearch } from "./store.js";
+import { closeKeyboardShortcuts, hydrateGroups, hydrateInitialOperations, hydrateOperations, hydrateTheaterBootstrap, hydrateTheaters, openOperationSearch, resolveOnboardingOnBootstrap, setOperationsViewActive, setState, themePolarity, toggleOperationSearch } from "./store.js";
 import { abortReleaseNotesFetch, requestReleaseNotes } from "./release-notes-fetch.js";
 import { getSideBarState, setSideBarCollapsed, subscribeOperationActivityTracking } from "./sidebar/operations-side-bar-store.js";
 import { getViewModeSnapshot } from "./view-mode-store.js";
@@ -39,6 +39,7 @@ import { resolveReleaseNotesLocale } from "./whatsnew-i18n.js";
 // 빠르면 GNB 배지가 누락될 수 있다. 짧은 지연 후 status를 1회만 재조회해 cold-start를 보정한다(폴링 아님).
 const UPDATE_STATUS_RECHECK_DELAY_MS = 6_000;
 const UNDO_WINDOW_MS = 8_000;
+const THEME_NOTICE_AUTO_DISMISS_MS = 8_000;
 
 export function App() {
   const state = useConsoleState();
@@ -63,6 +64,33 @@ export function App() {
   useEffect(() => {
     document.documentElement.lang = consoleLocale;
   }, [consoleLocale]);
+
+  // 테마 극성(다크↔라이트) 전환 1회성 전역 안내 — 이전에는 터미널 패널마다 힌트가 떠서 전환 한 번에
+  // 패널 수만큼 닫아야 했다. 실행 중 CLI의 내부 테마는 콘솔이 강제할 수 없으므로 안내는 유지하되,
+  // 콘솔 chrome이 단 하나의 토스트로 발화한다. 기준선은 bootstrap 완료 시점에 심는다 — 부팅 중
+  // localStorage→서버 settings 2회 적용(main.tsx)으로 극성이 정착 전에 흔들려도 오발화하지 않게.
+  const [themeNotice, setThemeNotice] = useState<"light" | "dark" | null>(null);
+  const themePolarityBaselineRef = useRef<"light" | "dark" | null>(null);
+  const activeThemePolarity = themePolarity(state.activeTheme);
+  useEffect(() => {
+    if (!state.bootstrapped) return;
+    if (themePolarityBaselineRef.current === null) {
+      themePolarityBaselineRef.current = activeThemePolarity;
+      return;
+    }
+    if (themePolarityBaselineRef.current !== activeThemePolarity) {
+      themePolarityBaselineRef.current = activeThemePolarity;
+      setThemeNotice(activeThemePolarity);
+    }
+  }, [state.bootstrapped, activeThemePolarity]);
+
+  // 안내는 잠시 띄우고 자동으로 거둔다 — 수동 닫기만 두면 "패널마다 닫기"가 "토스트 닫기 1회"로
+  // 바뀌는 데 그치므로, 읽을 시간 뒤에는 스스로 사라진다. 재전환 시 새 극성으로 타이머가 리셋된다.
+  useEffect(() => {
+    if (themeNotice === null) return;
+    const timer = setTimeout(() => setThemeNotice(null), THEME_NOTICE_AUTO_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [themeNotice]);
 
   const pathname = location.pathname;
   const operationsViewVisible = pathname.startsWith("/operations");
@@ -308,15 +336,23 @@ export function App() {
         <WhatsNewModal state={state} />
         <CommissioningOverlay state={state} />
         <FeatureTourOverlay />
-        <Toast
-          open={activeDeletion !== null}
-          tone="undo"
-          title={activeDeletion?.kind === "theater" ? t("chrome.toast.theaterForgotten") : t("chrome.toast.operationClosed")}
-          message={activeDeletion ? t("chrome.toast.secondsRemaining", { count: deletionCountdownSeconds(activeDeletion, undoClock) }) : undefined}
-          actionLabel={t("chrome.toast.undo")}
-          onAction={undoLastClose}
-          progress={activeDeletion ? (activeDeletion.expiresAt - undoClock) / UNDO_WINDOW_MS : undefined}
-        />
+        <ToastHost>
+          <Toast
+            open={themeNotice !== null}
+            tone="info"
+            title={themeNotice === "light" ? t("chrome.toast.themeLight") : t("chrome.toast.themeDark")}
+            onDismiss={() => setThemeNotice(null)}
+          />
+          <Toast
+            open={activeDeletion !== null}
+            tone="undo"
+            title={activeDeletion?.kind === "theater" ? t("chrome.toast.theaterForgotten") : t("chrome.toast.operationClosed")}
+            message={activeDeletion ? t("chrome.toast.secondsRemaining", { count: deletionCountdownSeconds(activeDeletion, undoClock) }) : undefined}
+            actionLabel={t("chrome.toast.undo")}
+            onAction={undoLastClose}
+            progress={activeDeletion ? (activeDeletion.expiresAt - undoClock) / UNDO_WINDOW_MS : undefined}
+          />
+        </ToastHost>
       </div>
     </ActiveCompanionShortcutsProvider>
   );

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -67,13 +67,14 @@ export function App() {
 
   // 테마 극성(다크↔라이트) 전환 1회성 전역 안내 — 이전에는 터미널 패널마다 힌트가 떠서 전환 한 번에
   // 패널 수만큼 닫아야 했다. 실행 중 CLI의 내부 테마는 콘솔이 강제할 수 없으므로 안내는 유지하되,
-  // 콘솔 chrome이 단 하나의 토스트로 발화한다. 기준선은 bootstrap 완료 시점에 심는다 — 부팅 중
-  // localStorage→서버 settings 2회 적용(main.tsx)으로 극성이 정착 전에 흔들려도 오발화하지 않게.
+  // 콘솔 chrome이 단 하나의 토스트로 발화한다. 기준선은 마운트 첫 실행에 심는다 — main.tsx가 주입/저장
+  // 테마와 서버 settings 적용을 모두 render 전 top-level await로 끝내므로, 마운트 이후의 테마 변경은
+  // 사용자 동작뿐이다. theaters bootstrap 같은 무관한 축에 게이트하면 그 응답이 늦거나 실패하는 동안의
+  // 전환이 통째로 소실된다(Settings는 그 전에도 조작 가능하다).
   const [themeNotice, setThemeNotice] = useState<"light" | "dark" | null>(null);
   const themePolarityBaselineRef = useRef<"light" | "dark" | null>(null);
   const activeThemePolarity = themePolarity(state.activeTheme);
   useEffect(() => {
-    if (!state.bootstrapped) return;
     if (themePolarityBaselineRef.current === null) {
       themePolarityBaselineRef.current = activeThemePolarity;
       return;
@@ -82,7 +83,7 @@ export function App() {
       themePolarityBaselineRef.current = activeThemePolarity;
       setThemeNotice(activeThemePolarity);
     }
-  }, [state.bootstrapped, activeThemePolarity]);
+  }, [activeThemePolarity]);
 
   // 안내는 잠시 띄우고 자동으로 거둔다 — 수동 닫기만 두면 "패널마다 닫기"가 "토스트 닫기 1회"로
   // 바뀌는 데 그치므로, 읽을 시간 뒤에는 스스로 사라진다. 재전환 시 새 극성으로 타이머가 리셋된다.

--- a/runtime/fleet-console/core/client/src/components/toast.tsx
+++ b/runtime/fleet-console/core/client/src/components/toast.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import { useT } from "../i18n/index.js";
 
 export type ToastTone = "info" | "warn" | "error" | "undo";
@@ -13,32 +15,36 @@ interface ToastProps {
   readonly progress?: number;
 }
 
-// 우하단 고정 토스트. 연결 이상 등 어떤 알림에도 재사용할 수 있도록 tone/title/message/onDismiss만 받는다.
+// 우하단 고정 토스트의 스택 컨테이너. 토스트가 여러 개 동시에 열릴 수 있으므로(undo + 테마 안내 등)
+// fixed 호스트는 하나만 두고 아이템이 세로로 쌓이게 한다 — 호스트를 토스트마다 두면 같은 위치에 겹친다.
+export function ToastHost({ children }: { readonly children: ReactNode }) {
+  return <div className="app-toast-host">{children}</div>;
+}
+
+// 우하단 고정 토스트 아이템. 연결 이상 등 어떤 알림에도 재사용할 수 있도록 tone/title/message/onDismiss만 받는다.
 export function Toast({ open, title, message, tone = "info", onDismiss, actionLabel, onAction, progress }: ToastProps) {
   const t = useT();
   if (!open) return null;
   return (
-    <div className="app-toast-host">
-      <div className={`app-toast app-toast--${tone}`} role="status" aria-live="polite">
-        <span className="app-toast-dot" aria-hidden="true" />
-        <div className="app-toast-body">
-          <p className="app-toast-title">{title}</p>
-          {message ? <p className="app-toast-message">{message}</p> : null}
-          {typeof progress === "number" ? (
-            <span className="app-toast-progress" aria-hidden="true">
-              <span style={{ transform: `scaleX(${Math.max(0, Math.min(1, progress))})` }} />
-            </span>
-          ) : null}
-        </div>
-        {actionLabel && onAction ? (
-          <button type="button" className="app-toast-action" onClick={onAction}>{actionLabel}</button>
-        ) : null}
-        {onDismiss ? (
-          <button type="button" className="app-toast-close" onClick={onDismiss} aria-label={t("chrome.toast.dismissNotification")}>
-            ×
-          </button>
+    <div className={`app-toast app-toast--${tone}`} role="status" aria-live="polite">
+      <span className="app-toast-dot" aria-hidden="true" />
+      <div className="app-toast-body">
+        <p className="app-toast-title">{title}</p>
+        {message ? <p className="app-toast-message">{message}</p> : null}
+        {typeof progress === "number" ? (
+          <span className="app-toast-progress" aria-hidden="true">
+            <span style={{ transform: `scaleX(${Math.max(0, Math.min(1, progress))})` }} />
+          </span>
         ) : null}
       </div>
+      {actionLabel && onAction ? (
+        <button type="button" className="app-toast-action" onClick={onAction}>{actionLabel}</button>
+      ) : null}
+      {onDismiss ? (
+        <button type="button" className="app-toast-close" onClick={onDismiss} aria-label={t("chrome.toast.dismissNotification")}>
+          ×
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/runtime/fleet-console/core/client/src/i18n/messages/chrome.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/chrome.ts
@@ -182,6 +182,8 @@ export const chromeEn = {
   "chrome.toast.operationClosed": "Operation closed",
   "chrome.toast.secondsRemaining": "{count}s remaining",
   "chrome.toast.undo": "Undo",
+  "chrome.toast.themeLight": "Console switched to a light theme — relaunch running CLIs or run /theme to match",
+  "chrome.toast.themeDark": "Console switched to a dark theme — relaunch running CLIs or run /theme to match",
 
   // backend-api
   "chrome.backendApi.sectionAria": "Backend API catalog",
@@ -380,6 +382,8 @@ export const chromeKo: Record<keyof typeof chromeEn, string> = {
   "chrome.toast.operationClosed": "Operation이 닫혔습니다",
   "chrome.toast.secondsRemaining": "{count}초 남음",
   "chrome.toast.undo": "실행 취소",
+  "chrome.toast.themeLight": "콘솔이 라이트 테마로 전환되었습니다 — 실행 중인 CLI는 다시 시작하거나 /theme으로 테마를 맞춰 주세요",
+  "chrome.toast.themeDark": "콘솔이 다크 테마로 전환되었습니다 — 실행 중인 CLI는 다시 시작하거나 /theme으로 테마를 맞춰 주세요",
 
   "chrome.backendApi.sectionAria": "Backend API 카탈로그",
   "chrome.backendApi.title": "Backend API",

--- a/runtime/fleet-console/core/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/core/client/src/pages/global-settings.tsx
@@ -13,7 +13,7 @@ import { getGlobalSettingsStoreState, loadGlobalSettings, setGlobalSettingsField
 import { renderMessage, useConsoleLocale, useT, type CoreMessageKey } from "../i18n/index.js";
 import { useConsoleState } from "../hooks/use-store.js";
 import { usePluginRegistry } from "../plugin-registry.js";
-import { readLastDarkTheme, setActiveTheme, setActiveUiFont } from "../store.js";
+import { readLastDarkTheme, setActiveTheme, setActiveUiFont, themePolarity } from "../store.js";
 import { DEFAULT_UI_FONT, UI_FONT_BUILT_INS, UI_FONT_DESCRIPTION_KEYS, UI_FONT_SIZE_RANGE, uiFontFamily } from "../ui-font.js";
 import type { GlobalSettingsState, ThemeId, UiFontId, UiFontSettings } from "../types.js";
 
@@ -274,7 +274,7 @@ function ThemeCard({
   const t = useT();
   const darkThemes = buildDarkThemeOptions(t);
   const activeTheme = state?.theme ?? "instrument";
-  const isLight = activeTheme === LIGHT_THEME_ID;
+  const isLight = themePolarity(activeTheme) === "light";
   const selectTheme = (theme: ThemeId) => {
     if (getGlobalSettingsStoreState().savingField !== null) return;
     const previousTheme = activeTheme;

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -228,6 +228,12 @@ export function readStoredThemeHint(): ThemeId | null {
   }
 }
 
+// 테마 극성(라이트/다크) 판별은 이 한 곳이 소유한다 — Settings의 모드 스위치와 App의 극성 전환
+// 안내 토스트가 같은 규칙을 봐야 한쪽만 다른 판정을 내리는 일이 없다.
+export function themePolarity(theme: ThemeId): "light" | "dark" {
+  return theme === "whites" ? "light" : "dark";
+}
+
 export function readServerInjectedTheme(): ThemeId | null {
   if (typeof document === "undefined") return null;
   if (document.documentElement.getAttribute("data-theme-source") !== "server") return null;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -6481,41 +6481,6 @@
   background: var(--warn);
 }
 
-/* 테마 극성 전환(다크↔라이트) 1회성 힌트 — 실행 중 CLI의 내부 테마는 콘솔이 강제할 수 없으므로
-   안내만 한다. 정보 칩이라 신호색이 아닌 중립 표면+텍스트 티어 문법을 쓴다. */
-.terminal-theme-hint {
-  position: absolute;
-  top: var(--space-2);
-  right: var(--space-2);
-  z-index: 3;
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  max-width: min(92%, 420px);
-  padding: var(--space-1) var(--space-2);
-  font-size: 12px;
-  color: var(--text-secondary);
-  background: var(--surface-glass-strong);
-  border: 1px solid var(--surface-rim-strong);
-  border-radius: var(--radius-sm);
-  box-shadow: var(--shadow-soft);
-}
-
-.terminal-theme-hint-dismiss {
-  flex: 0 0 auto;
-  display: grid;
-  place-items: center;
-  width: 18px;
-  height: 18px;
-  border-radius: var(--radius-xs);
-  color: var(--text-tertiary);
-}
-
-.terminal-theme-hint-dismiss:hover {
-  color: var(--text-primary);
-  background: color-mix(in oklch, var(--ink-mid) 72%, transparent);
-}
-
 /* 줌 보정 레이어: position:relative 기준 박스를 제공해 .terminal-canvas의 역스케일(%-기반)이
    측정 없이 inner 크기에 정확히 맞도록 한다. flex:1로 상태바 아래 남는 공간을 채운다. */
 .terminal-viewport {

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, createElement, useLayoutEffect } from "react";
+import { act, createElement, Fragment, useLayoutEffect, type ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import type { OperationKindDescriptor } from "@fleet-console/sdk/plugin";
@@ -70,7 +70,11 @@ vi.mock("../core/client/src/components/command-band.js", () => ({ CommandBand: (
 vi.mock("../core/client/src/components/commissioning-overlay.js", () => ({ CommissioningOverlay: () => null }));
 vi.mock("../core/client/src/components/keyboard-shortcuts-dialog.js", () => ({ isKeyboardShortcutsModalOpen: () => false, shouldHandleOperationsKeyboardShortcut: keyboardShortcutMocks.shouldHandleOperationsKeyboardShortcut }));
 vi.mock("../core/client/src/components/operation-search.js", () => ({ OperationSearch: () => null }));
-vi.mock("../core/client/src/components/toast.js", () => ({ Toast: () => null }));
+vi.mock("../core/client/src/components/toast.js", () => ({
+  Toast: () => null,
+  // App은 토스트를 ToastHost 스택으로 감싼다 — mock도 같은 쌍을 제공해야 App 렌더가 산다.
+  ToastHost: ({ children }: { readonly children?: ReactNode }) => createElement(Fragment, null, children),
+}));
 vi.mock("../core/client/src/components/whatsnew-modal.js", () => ({ WhatsNewModal: () => null }));
 vi.mock("../core/client/src/global-settings-store.js", () => ({
   getGlobalSettingsStoreState: () => ({ state: null }),

--- a/runtime/fleet-console/tests/theme-notice.test.ts
+++ b/runtime/fleet-console/tests/theme-notice.test.ts
@@ -1,0 +1,237 @@
+// @vitest-environment jsdom
+
+import { act, createElement, useLayoutEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import type { OperationKindDescriptor } from "@fleet-console/sdk/plugin";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getState, setActiveTheme, setState } from "../core/client/src/store.js";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchTheaterBootstrap: vi.fn(),
+  fetchTheaters: vi.fn(),
+  fetchOperations: vi.fn(),
+  fetchGroups: vi.fn(),
+  deleteOperation: vi.fn(),
+  restoreDeletion: vi.fn(),
+}));
+const keyboardShortcutMocks = vi.hoisted(() => ({
+  shouldHandleOperationsKeyboardShortcut: vi.fn(),
+}));
+const registryMocks = vi.hoisted(() => ({
+  plugins: [] as Array<Record<string, unknown>>,
+  operationKinds: [] as OperationKindDescriptor[],
+}));
+
+vi.mock("../core/client/src/api.js", () => ({
+  ...apiMocks,
+  ApiError: class ApiError extends Error {
+    readonly status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+  addTheater: vi.fn(),
+  createGroup: vi.fn(),
+  deleteGroup: vi.fn(),
+  forgetTheater: vi.fn(),
+  issueTheaterFolderGrant: vi.fn(),
+  patchOperation: vi.fn(),
+  patchTheaterOrder: vi.fn(),
+  renameOperation: vi.fn(),
+  updateGroup: vi.fn(),
+}));
+
+vi.mock("@fleet-console/sdk/operations/browser", () => ({ fetchOperationCatalog: vi.fn().mockResolvedValue([]) }));
+vi.mock("../core/client/src/canvas/canvas.js", () => ({ OperationsCanvas: () => null }));
+vi.mock("../core/client/src/components/codex-reading-sheet.js", () => ({ CodexReadingSheet: () => null }));
+vi.mock("../core/client/src/components/command-band.js", () => ({ CommandBand: () => null }));
+vi.mock("../core/client/src/components/commissioning-overlay.js", () => ({ CommissioningOverlay: () => null }));
+vi.mock("../core/client/src/components/keyboard-shortcuts-dialog.js", () => ({ isKeyboardShortcutsModalOpen: () => false, shouldHandleOperationsKeyboardShortcut: keyboardShortcutMocks.shouldHandleOperationsKeyboardShortcut }));
+vi.mock("../core/client/src/components/operation-search.js", () => ({ OperationSearch: () => null }));
+vi.mock("../core/client/src/components/whatsnew-modal.js", () => ({ WhatsNewModal: () => null }));
+vi.mock("../core/client/src/global-settings-store.js", () => ({
+  getGlobalSettingsStoreState: () => ({ state: null }),
+  useGlobalSettingsStore: () => ({ state: null }),
+}));
+vi.mock("../core/client/src/operations-sse.js", () => ({ refreshObserverStatus: vi.fn() }));
+vi.mock("../core/client/src/pages/global-settings.js", () => ({ GlobalSettings: () => createElement("div", { "data-route": "settings" }) }));
+vi.mock("../core/client/src/plugin-capabilities.js", () => ({ createHostCapabilities: () => ({ api: {} }) }));
+vi.mock("../core/client/src/plugin-registry.js", () => ({ usePluginRegistry: () => ({ plugins: registryMocks.plugins, operationKinds: registryMocks.operationKinds, settingsSections: [], notificationKinds: [], railPanels: [], floatingWidgets: [] }) }));
+vi.mock("../core/client/src/rail/rail-store.js", () => ({ toggleRailChrome: vi.fn() }));
+vi.mock("../core/client/src/rail/right-rail.js", () => ({ RightRail: () => null }));
+vi.mock("../core/client/src/release-notes-fetch.js", () => ({ abortReleaseNotesFetch: vi.fn(), requestReleaseNotes: vi.fn() }));
+vi.mock("../core/client/src/sidebar/operations-side-bar-store.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../core/client/src/sidebar/operations-side-bar-store.js")>()),
+  getSideBarState: () => ({ collapsed: false }),
+  setSideBarCollapsed: vi.fn(),
+  getSideBarStatusAxis: () => false,
+  getSideBarStatusSectionCollapsed: () => false,
+  setSideBarStatusAxis: vi.fn(),
+  subscribeOperationActivityTracking: () => () => {},
+  toggleSideBarStatusAxis: vi.fn(),
+}));
+vi.mock("../core/client/src/sidebar/operations-side-bar.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../core/client/src/sidebar/operations-side-bar.js")>()),
+  OperationsSideBar: () => null,
+}));
+vi.mock("../core/client/src/whatsnew-i18n.js", () => ({
+  resolveConsoleLanguage: () => "en",
+  resolveReleaseNotesLocale: () => "en",
+}));
+
+const THEME_DARK_TITLE = "Console switched to a dark theme — relaunch running CLIs or run /theme to match";
+const THEME_LIGHT_TITLE = "Console switched to a light theme — relaunch running CLIs or run /theme to match";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function themeToasts(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>(".app-toast--info"));
+}
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  window.localStorage.clear();
+  window.history.replaceState({}, "", "/operations");
+  setState({
+    activeOperationId: null,
+    activeTheaterId: null,
+    activeTheme: "instrument",
+    bootstrapped: false,
+    groups: [],
+    keyboardFocusRequest: null,
+    operations: [],
+    operationsHydrated: false,
+    theaters: [],
+  });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  apiMocks.fetchTheaters.mockResolvedValue([]);
+  apiMocks.fetchOperations.mockResolvedValue([]);
+  apiMocks.fetchGroups.mockResolvedValue([]);
+  apiMocks.fetchTheaterBootstrap.mockResolvedValue({ theaters: [] });
+  keyboardShortcutMocks.shouldHandleOperationsKeyboardShortcut.mockReturnValue(false);
+  registryMocks.plugins = [];
+  registryMocks.operationKinds = [];
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+async function renderApp(): Promise<void> {
+  const { App } = await import("../core/client/src/app.js");
+  await act(async () => {
+    root!.render(createElement(BrowserRouter, null, createElement(App)));
+    await Promise.resolve();
+  });
+}
+
+describe("Theme polarity notice", () => {
+  it("fires no toast while boot settles, even when the stored theme flips polarity before bootstrap", async () => {
+    // 부팅 중 localStorage→서버 settings 2회 적용으로 극성이 흔들려도 안내가 뜨면 안 된다.
+    setState({ activeTheme: "whites", bootstrapped: false });
+    await renderApp();
+    expect(themeToasts()).toHaveLength(0);
+
+    await act(async () => {
+      setState({ bootstrapped: true });
+    });
+    expect(themeToasts()).toHaveLength(0);
+  });
+
+  it("fires exactly one console-level toast on a polarity flip after bootstrap", async () => {
+    await renderApp();
+    await act(async () => {
+      setState({ bootstrapped: true });
+    });
+    expect(themeToasts()).toHaveLength(0);
+
+    await act(async () => {
+      setActiveTheme("whites");
+    });
+    const toasts = themeToasts();
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0]?.querySelector(".app-toast-title")?.textContent).toBe(THEME_LIGHT_TITLE);
+    expect(getState().activeTheme).toBe("whites");
+  });
+
+  it("stays silent for same-polarity theme changes", async () => {
+    await renderApp();
+    await act(async () => {
+      setState({ bootstrapped: true });
+    });
+
+    await act(async () => {
+      setActiveTheme("maritime");
+    });
+    expect(themeToasts()).toHaveLength(0);
+
+    await act(async () => {
+      setActiveTheme("carbon");
+    });
+    expect(themeToasts()).toHaveLength(0);
+  });
+
+  it("dismisses manually via the close button and refires on the next flip", async () => {
+    await renderApp();
+    await act(async () => {
+      setState({ bootstrapped: true });
+    });
+    await act(async () => {
+      setActiveTheme("whites");
+    });
+    expect(themeToasts()).toHaveLength(1);
+
+    const close = document.querySelector<HTMLButtonElement>(".app-toast--info .app-toast-close");
+    expect(close).not.toBeNull();
+    await act(async () => {
+      close!.click();
+    });
+    expect(themeToasts()).toHaveLength(0);
+
+    await act(async () => {
+      setActiveTheme("carbon");
+    });
+    const toasts = themeToasts();
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0]?.querySelector(".app-toast-title")?.textContent).toBe(THEME_DARK_TITLE);
+  });
+
+  it("auto-dismisses after the notice window", async () => {
+    await renderApp();
+    await act(async () => {
+      setState({ bootstrapped: true });
+    });
+
+    // fake timer는 flip으로 해제 타이머가 예약되기 "전"에 켜야 한다 — real timer로 예약된
+    // 타이머는 advanceTimersByTime이 밀어주지 않는다.
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        setActiveTheme("whites");
+      });
+      expect(themeToasts()).toHaveLength(1);
+
+      await act(async () => {
+        vi.advanceTimersByTime(8_100);
+      });
+      expect(themeToasts()).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/runtime/fleet-console/tests/theme-notice.test.ts
+++ b/runtime/fleet-console/tests/theme-notice.test.ts
@@ -141,8 +141,9 @@ async function renderApp(): Promise<void> {
 }
 
 describe("Theme polarity notice", () => {
-  it("fires no toast while boot settles, even when the stored theme flips polarity before bootstrap", async () => {
-    // 부팅 중 localStorage→서버 settings 2회 적용으로 극성이 흔들려도 안내가 뜨면 안 된다.
+  it("seeds its baseline on mount, so the already-applied boot theme raises nothing", async () => {
+    // main.tsx는 주입/저장 테마와 서버 settings를 render 전에 모두 적용하므로, 마운트 시점의
+    // 극성은 이미 정착값이다 — 그 값이 무엇이든 안내가 떠서는 안 된다.
     setState({ activeTheme: "whites", bootstrapped: false });
     await renderApp();
     expect(themeToasts()).toHaveLength(0);
@@ -151,6 +152,22 @@ describe("Theme polarity notice", () => {
       setState({ bootstrapped: true });
     });
     expect(themeToasts()).toHaveLength(0);
+  });
+
+  it("still fires while theater bootstrap is pending — the notice must not ride an unrelated axis", async () => {
+    // theaters bootstrap이 느리거나 실패해도 Settings는 조작 가능하다. 그 사이의 전환을 삼키면
+    // 사용자는 안내를 영영 받지 못한다. bootstrap 응답을 영구 보류시켜 그 구간을 재현한다.
+    apiMocks.fetchTheaterBootstrap.mockReturnValue(new Promise(() => {}));
+    setState({ bootstrapped: false });
+    await renderApp();
+
+    await act(async () => {
+      setActiveTheme("whites");
+    });
+    expect(getState().bootstrapped).toBe(false);
+    const pending = themeToasts();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.querySelector(".app-toast-title")?.textContent).toBe(THEME_LIGHT_TITLE);
   });
 
   it("fires exactly one console-level toast on a polarity flip after bootstrap", async () => {

--- a/runtime/fleet-plugins/terminal/client/i18n/index.ts
+++ b/runtime/fleet-plugins/terminal/client/i18n/index.ts
@@ -306,9 +306,6 @@ export const terminalEn = {
   "terminal.settings.missing": "Missing",
   "terminal.analysis.error.sessionNotFound": "Analysis session was not found.",
   "terminal.analysis.error.requestFailed": "Analysis request failed.",
-  "terminal.themeHint.light": "Console switched to a light theme — relaunch or run /theme in the CLI to match",
-  "terminal.themeHint.dark": "Console switched to a dark theme — relaunch or run /theme in the CLI to match",
-  "terminal.themeHint.dismiss": "Dismiss theme hint",
 } as const;
 
 export const terminalKo: Record<keyof typeof terminalEn, string> = {
@@ -613,9 +610,6 @@ export const terminalKo: Record<keyof typeof terminalEn, string> = {
   "terminal.settings.missing": "없음",
   "terminal.analysis.error.sessionNotFound": "분석 세션을 찾을 수 없습니다.",
   "terminal.analysis.error.requestFailed": "분석 요청이 실패했습니다.",
-  "terminal.themeHint.light": "콘솔이 라이트 테마로 전환되었습니다 — CLI를 다시 시작하거나 /theme으로 테마를 맞춰 주세요",
-  "terminal.themeHint.dark": "콘솔이 다크 테마로 전환되었습니다 — CLI를 다시 시작하거나 /theme으로 테마를 맞춰 주세요",
-  "terminal.themeHint.dismiss": "테마 안내 닫기",
 };
 
 export const TERMINAL_MESSAGES = { en: terminalEn, ko: terminalKo } as const;

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -6,7 +6,6 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal as XtermTerminal, type ITheme } from "@xterm/xterm";
 import { useEffect, useRef, useState, type CSSProperties } from "react";
 
-import { getT, useTerminalLocale } from "../i18n/index.js";
 import { createImeShiftEnterHandler } from "./ime-shift-enter.js";
 import { createTerminalConnection, type TerminalConnection } from "./terminal-connection.js";
 import { createTerminalCopyOnSelect } from "./terminal-copy-on-select.js";
@@ -168,12 +167,6 @@ function terminalPolarityFor(theme: TerminalThemeId): "light" | "dark" {
   return LIGHT_TERMINAL_THEMES.has(theme) ? "light" : "dark";
 }
 
-/* 세션 PTY는 패널 언마운트(Global Shell 닫기·Theater 전환)를 넘어 생존하므로, 극성 힌트의 기준선도
-   surface 수명 밖에 보관해야 닫힌 사이 전환된 테마가 재오픈 시 힌트를 발화한다. 같은 플러그인 번들
-   내부의 모듈 상태다 — 번들 경계를 넘는 공유가 아니다. PTY 종료 후 재spawn된 세션은 현재 극성 env를
-   받으므로, 닫힌 동안의 전환 + 재spawn이 겹치는 극단 경로에서만 힌트가 한 번 과발화할 수 있다(무해·해제 가능). */
-const sessionPolarityBaseline = new Map<string, "light" | "dark">();
-
 export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "instrument", onExit, active, keyboardFocusRequestId, zoom = 1, onStatusDetail }: TerminalSurfaceProps) {
   const activeTheme = theme;
   const { renderer: terminalRenderer, font: terminalFontSettings } = useTerminalPrefs();
@@ -198,9 +191,6 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
   const activeRef = useRef(active);
   activeRef.current = active;
   const [status, setStatus] = useState("connecting");
-  // 테마 극성(다크↔라이트) 전환 1회성 안내 — 실행 중 CLI 내부 테마는 강제할 수 없으므로 힌트만 띄운다.
-  const [themeHint, setThemeHint] = useState<"light" | "dark" | null>(null);
-  const t = getT(useTerminalLocale());
   // 마운트 effect는 심볼 폰트 선대기 등 await 뒤에 ticket 연결을 만들고 테마 변경에 재실행되지 않으므로,
   // 최신 극성은 ref로 읽는다(activeRef와 같은 이유) — 대기 중 테마가 바뀌어도 첫 ticket이 현재 극성을 싣는다.
   const colorSchemeRef = useRef(terminalPolarityFor(activeTheme));
@@ -455,27 +445,6 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
     syncTerminalViewportBackground(container, terminalTheme);
   }, [activeTheme, mountedTerminalEpoch]);
 
-  // 세션 전환(Global Shell theater 전환 등)은 같은 surface 인스턴스의 operationId만 바꾸므로,
-  // 이전 세션의 힌트가 새 세션 위에 남지 않게 먼저 지운다.
-  useEffect(() => {
-    setThemeHint(null);
-  }, [operationId]);
-
-  // 극성 전환 감지: 기준선은 세션(operationId) 단위 모듈 맵에 보관한다 — 패널이 닫혔다 열려도
-  // 생존한 PTY의 기준선이 유지되어, 닫힌 사이 일어난 다크↔라이트 전환도 재오픈 시 힌트를 발화한다.
-  useEffect(() => {
-    const polarity = terminalPolarityFor(activeTheme);
-    const baseline = sessionPolarityBaseline.get(operationId);
-    if (baseline === undefined) {
-      sessionPolarityBaseline.set(operationId, polarity);
-      return;
-    }
-    if (baseline !== polarity) {
-      sessionPolarityBaseline.set(operationId, polarity);
-      setThemeHint(polarity);
-    }
-  }, [activeTheme, operationId]);
-
   useEffect(() => {
     const terminal = terminalRef.current;
     if (!terminal) return;
@@ -535,12 +504,6 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
           </div>
         ) : null}
         <div className="terminal-viewport">
-          {themeHint ? (
-            <div className="terminal-theme-hint" role="status">
-              <span>{t(themeHint === "light" ? "terminal.themeHint.light" : "terminal.themeHint.dark")}</span>
-              <button type="button" className="terminal-theme-hint-dismiss" aria-label={t("terminal.themeHint.dismiss")} onClick={() => setThemeHint(null)}>✕</button>
-            </div>
-          ) : null}
           <div className="terminal-canvas" ref={containerRef} style={zoomStyle} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- 라이트↔다크 테마 극성 전환 시 터미널 패널마다 뜨던 "콘솔이 ○○ 테마로 전환되었습니다" 힌트를 제거하고, 콘솔 chrome이 우하단 전역 토스트를 정확히 1회 띄우도록 변경했습니다. 토스트는 8초 뒤 자동으로 사라지고 수동 닫기도 가능합니다.
- `Toast`를 `ToastHost`(단일 고정 스택)+`Toast`(아이템)로 분리해 기존 undo 토스트와 겹침 없이 공존합니다. 극성 규칙은 `store.ts`의 `themePolarity()` 한 곳이 소유하고 Settings가 소비합니다.
- 터미널 플러그인의 패널별 힌트(state·세션 극성 baseline 맵·effect·JSX·i18n 3키×2로케일·코어 CSS)를 전량 제거했습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` / `--filter @fleet-plugins/terminal typecheck` — 클린
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 1429 passed (신규 `theme-notice.test.ts` 5건: 부팅 무음·단일 발화·동극성 무음·수동 닫기·자동 해제)
- [x] `pnpm --filter @fleet-plugins/terminal test` — 508 passed
- [x] 두 패키지 `build` 통과
- [x] 격리 콘솔 헤드리스 실측: 라이트/다크 양방향 flip 각각 전역 토스트 1개·`.terminal-theme-hint` 0개(터미널 3개 마운트 상태)·8초 자동 해제·reload 후 오발화 없음
- [x] changelog fragment: `.changelog.d/theme-switch-global-toast.md` (`compile-changelog-fragments.mjs --check` OK)