### PR TITLE
feat(console): compact the canvas context menu

### DIFF
--- a/.changelog.d/canvas-menu-compact.md
+++ b/.changelog.d/canvas-menu-compact.md
@@ -1,0 +1,14 @@
+---
+branch: canvas-menu-compact
+---
+
+### fleet-console
+#### Changed
+- The canvas context menu is roughly half as tall. Its icon-and-title masthead collapses into one line that names what you are launching into and carries the `Launch` label, the plugin name joins that line when a single plugin supplies the kinds, and every row is a single line. With the four Terminal launch kinds the menu measures 288x168 instead of 340x307, and 115px of chrome ahead of the first action becomes 31px.
+  ko: 캔버스 컨텍스트 메뉴가 절반 가까이 낮아집니다. 아이콘과 제목이 차지하던 머리글이 한 줄로 접혀 무엇으로 실행하는지와 `Launch` 라벨을 함께 싣고, 플러그인 하나가 실행 종류를 모두 제공할 때는 플러그인 이름도 그 줄에 붙으며, 모든 항목이 한 줄이 됩니다. Terminal 실행 종류 네 개 기준으로 메뉴는 340x307에서 288x168이 되고, 첫 항목 앞을 막던 크롬 115px는 31px가 됩니다.
+- Each Claude launch kind now shows a short contrast beside its name, and its full one-line description opens next to the menu when you point at that row or move keyboard focus to it. The description no longer sits under every row at all times, and screen readers still read it on every row regardless of what is on screen.
+  ko: Claude 실행 종류마다 이름 옆에 짧은 대비 문구가 서고, 한 줄 설명 전문은 해당 항목을 가리키거나 키보드 포커스를 옮겼을 때 메뉴 옆에 펼쳐집니다. 설명이 모든 항목 아래에 상시로 깔리지 않으며, 화면 낭독기는 표시 여부와 무관하게 모든 항목에서 설명을 그대로 읽습니다.
+
+#### Fixed
+- Arrow keys move through the canvas context menu again: the first Down arrow enters the list without pre-selecting anything, Up and Down cycle past unavailable kinds, and Home and End jump to the ends. The menu also reports itself as a menu to screen readers, so its items are announced with their position in the list.
+  ko: 캔버스 컨텍스트 메뉴에서 방향키가 다시 동작합니다. 아래 방향키를 처음 누르면 아무것도 미리 고르지 않은 채 목록으로 들어가고, 위아래 방향키는 실행할 수 없는 종류를 건너뛰며 순환하고, Home과 End는 처음과 끝으로 이동합니다. 메뉴가 화면 낭독기에 자신을 메뉴로 알리므로 항목이 목록 안 위치와 함께 읽힙니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
 import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console/sdk/operations";
 
 import { FEATURE_TOUR_BOUNDARY_ATTRIBUTE, FEATURE_TOUR_LAYER_SELECTOR } from "../feature-tour-catalog.js";
@@ -24,16 +24,25 @@ interface CanvasContextMenuProps {
   readonly fixed?: boolean;
 }
 
-const MENU_WIDTH = 340;
+// 폭은 세 곳이 함께 알아야 한다 — 이 상수(측정 전 clamp 폴백), .canvas-context-menu의 width,
+// .operation-launch-control--canvas .operation-launch-menu의 min-width. 하나만 고치면 컴파일은
+// 되고 치수만 조용히 어긋난다.
+const MENU_WIDTH = 288;
 const MENU_MAX_HEIGHT = 520;
 const MENU_MIN_HEIGHT = 120;
 const MENU_MARGIN = 12;
+// 설명 어사이드는 메뉴 옆에 뜬다. 오른쪽에 자리가 없으면 왼쪽으로 뒤집는다.
+const ASIDE_WIDTH = 208;
+const ASIDE_GAP = 8;
 
 export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor", fixed = false, catalog, canLaunch, renderKindIcon, onLaunchKind, onClose, theaterLabel }: CanvasContextMenuProps) {
   const t = useT();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const [menuSize, setMenuSize] = useState<{ readonly width: number; readonly height: number } | null>(null);
+  // 설명을 펼칠 항목. 포인터 호버와 키보드 포커스가 같은 상태를 쓴다 — 둘이 갈라지면
+  // 키보드로 옮긴 자리와 옆에 뜬 설명이 서로 다른 항목을 가리킨다.
+  const [activeKindId, setActiveKindId] = useState<string | null>(null);
 
   // 배치 판정은 CSS의 max-height 상한이 아니라 실제 렌더 높이로 해야 한다 —
   // 상한(520px)으로 clamp하면 짧은 메뉴가 커서에서 수백 px 떨어진 곳에 열린다.
@@ -77,8 +86,65 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
 
   useEffect(() => {
     // 첫 항목을 강제 포커스하지 않고 컨테이너만 포커스해 '이미 선택된 듯한' UX를 피한다.
+    // 방향키를 처음 누른 순간에만 항목으로 들어간다.
     menuRef.current?.focus();
   }, []);
+
+  // 플러그인이 하나뿐이면 그 이름은 헤더 줄에 붙는다 — 항목 네 개짜리 메뉴에서 이름만 있는
+  // 행 하나가 통째로 서는 것은 값을 못 한다. 둘 이상일 때만 그룹 라벨을 세운다.
+  const singlePlugin = catalog.length === 1 ? catalog[0]! : null;
+  const headTitle = theaterLabel ? t("canvas.menu.theaterTitle", { theater: theaterLabel }) : t("canvas.menu.title");
+
+  const moveFocus = useCallback((from: HTMLElement | null, delta: number, edge: "first" | "last" | null) => {
+    const menu = menuRef.current;
+    if (!menu) return;
+    const items = Array.from(menu.querySelectorAll<HTMLButtonElement>(".canvas-context-menu-item")).filter((item) => !item.disabled);
+    if (items.length === 0) return;
+    if (edge) {
+      items[edge === "first" ? 0 : items.length - 1]!.focus();
+      return;
+    }
+    const index = from ? items.indexOf(from as HTMLButtonElement) : -1;
+    const next = index < 0 ? (delta > 0 ? 0 : items.length - 1) : (index + delta + items.length) % items.length;
+    items[next]!.focus();
+  }, []);
+
+  const handleMenuKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    const target = event.target as HTMLElement;
+    const onItem = target.classList.contains("canvas-context-menu-item");
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        moveFocus(onItem ? target : null, 1, null);
+        return;
+      case "ArrowUp":
+        event.preventDefault();
+        moveFocus(onItem ? target : null, -1, null);
+        return;
+      case "Home":
+        event.preventDefault();
+        moveFocus(null, 0, "first");
+        return;
+      case "End":
+        event.preventDefault();
+        moveFocus(null, 0, "last");
+        return;
+      default:
+    }
+  };
+
+  const activeDescription = useMemo(() => {
+    if (!activeKindId) return null;
+    for (const plugin of catalog) {
+      for (const kind of plugin.kinds) {
+        if (kind.id !== activeKindId) continue;
+        if (kind.disabledReason) return null;
+        const annotation = resolveLaunchKindAnnotation(kind.id);
+        return annotation ? t(annotation.descriptionKey) : null;
+      }
+    }
+    return null;
+  }, [activeKindId, catalog, t]);
 
   return (
     <div
@@ -89,23 +155,25 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     >
       <div
         className="operation-launch-menu theater-menu canvas-context-menu"
-        role="dialog"
+        role="menu"
         aria-label={t("canvas.menu.aria")}
+        aria-orientation="vertical"
         tabIndex={-1}
         ref={menuRef}
+        onKeyDown={handleMenuKeyDown}
+        onMouseLeave={() => setActiveKindId(null)}
         {...{ [FEATURE_TOUR_BOUNDARY_ATTRIBUTE]: "" }}
       >
         <div className="canvas-context-menu-head">
-          <span className="canvas-context-menu-reticle" aria-hidden="true"><CommandReticleIcon /></span>
           <span className="canvas-context-menu-head-text">
-            <strong>{theaterLabel ? t("canvas.menu.theaterTitle", { theater: theaterLabel }) : t("canvas.menu.title")}</strong>
+            <strong>{singlePlugin ? `${headTitle} · ${singlePlugin.title}` : headTitle}</strong>
           </span>
+          <p className="canvas-context-menu-section">{t("canvas.menu.launch")}</p>
         </div>
-        <p className="canvas-context-menu-section">{t("canvas.menu.launch")}</p>
         {catalog.length > 0 ? catalog.map((plugin, index) => (
-          <div key={plugin.id}>
+          <div key={plugin.id} role="group" aria-label={plugin.title}>
             {index > 0 ? <div className="theater-menu-divider" role="separator" /> : null}
-            <p className="canvas-context-menu-plugin">{plugin.title}</p>
+            {singlePlugin ? null : <p className="canvas-context-menu-plugin">{plugin.title}</p>}
             {plugin.kinds.map((kind) => {
               const disabled = kind.disabled === true || !canLaunch;
               const annotation = resolveLaunchKindAnnotation(kind.id);
@@ -120,6 +188,9 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                   data-operation-launch-kind={kind.id}
                   disabled={disabled}
                   title={kind.disabledReason}
+                  tabIndex={-1}
+                  onMouseEnter={() => setActiveKindId(kind.id)}
+                  onFocus={() => setActiveKindId(kind.id)}
                   onClick={() => onLaunchKind(plugin.id, kind)}
                 >
                   <span className="theater-menu-check" aria-hidden="true">{renderKindIcon(plugin.id, kind) ?? <FallbackGlyph />}</span>
@@ -127,19 +198,40 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                   {/* 비활성 사유가 있으면 그것이 먼저다 — 지금 실행할 수 없다는 사실이 종류 설명보다 급하다. */}
                   {kind.disabledReason
                     ? <span className="operation-launch-menu-reason">{kind.disabledReason}</span>
-                    : annotation ? <span className="operation-launch-menu-description">{t(annotation.descriptionKey)}</span> : null}
+                    : annotation
+                      ? (
+                        <>
+                          <span className="operation-launch-menu-brief">{t(annotation.briefKey)}</span>
+                          {/* 설명 문장은 버튼 안에 남아 접근 이름에 실린다 — 시각적으로만 접고,
+                              같은 문자열을 옆 어사이드가 비춘다. 화면 낭독기는 어사이드 표시 여부와
+                              무관하게 늘 세 종류의 차이를 읽는다. */}
+                          <span className="operation-launch-menu-description operation-launch-menu-description--quiet">{t(annotation.descriptionKey)}</span>
+                        </>
+                      )
+                      : null}
                 </button>
               );
             })}
           </div>
         )) : <p className="theater-menu-empty">{t("canvas.menu.empty")}</p>}
       </div>
+      {activeDescription
+        ? (
+          <p
+            className={`canvas-context-menu-aside${asideFlips(anchor, viewportBounds, menuSize) ? " canvas-context-menu-aside--flip" : ""}`}
+            aria-hidden="true"
+          >
+            {activeDescription}
+          </p>
+        )
+        : null}
     </div>
   );
 }
 
-// 좌하단 런처 FAB와 메뉴 헤더가 공유하는 '커맨드 레티클' 마크 — 외곽 스코프 링 + 사방 조준 틱 +
-// 중앙의 '+'(생성 의미 보존). 단순 plus를 Canvas controls 진입점으로 제공한다.
+// 좌하단 런처 FAB와 메뉴 헤더가 공유하던 '커맨드 레티클' 마크 — 외곽 스코프 링 + 사방 조준 틱 +
+// 중앙의 '+'(생성 의미 보존). 메뉴 헤더가 한 줄로 내려앉으면서 메뉴에서는 쓰지 않지만,
+// Canvas controls 진입점의 마크로 계속 export한다.
 export function CommandReticleIcon() {
   return (
     <svg viewBox="0 0 24 24" aria-hidden="true">
@@ -148,6 +240,19 @@ export function CommandReticleIcon() {
       <path d="M12 9.2v5.6M9.2 12h5.6" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
     </svg>
   );
+}
+
+// 어사이드는 기본으로 메뉴 오른쪽에 선다. 오른쪽 끝에서 열려 자리가 없으면 왼쪽으로 뒤집는다 —
+// 뒤집지 않으면 밀도는 맞고 설명만 화면 밖으로 잘려 사실상 사라진다.
+function asideFlips(
+  anchor: { readonly x: number; readonly y: number },
+  bounds: { readonly width: number; readonly height: number } | undefined,
+  size: { readonly width: number; readonly height: number } | null,
+): boolean {
+  if (!bounds) return false;
+  const width = size?.width ?? MENU_WIDTH;
+  const left = Math.max(MENU_MARGIN, Math.min(anchor.x, bounds.width - width - MENU_MARGIN));
+  return left + width + ASIDE_GAP + ASIDE_WIDTH > bounds.width - MENU_MARGIN;
 }
 
 function clampedAnchorStyle(

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -40,11 +40,14 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   const containerRef = useRef<HTMLDivElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const [menuSize, setMenuSize] = useState<{ readonly width: number; readonly height: number } | null>(null);
-  // 설명을 펼칠 항목. 포인터 호버와 키보드 포커스가 같은 상태를 쓴다 — 둘이 갈라지면
-  // 키보드로 옮긴 자리와 옆에 뜬 설명이 서로 다른 항목을 가리킨다.
+  // 설명을 펼칠 항목. 포인터와 키보드는 각자 기억한다 — 하나로 합치면 포인터가 메뉴를 벗어날 때
+  // 포커스가 짚고 있던 항목의 설명까지 함께 지워져, 여전히 강조된 행에 설명만 사라진다.
+  // 가리키는 동안에는 포인터가 이기고, 포인터가 나가면 포커스가 다시 드러난다.
   // 키는 플러그인까지 포함해야 한다: 실행 종류 id는 플러그인 안에서만 고유하므로, 두 플러그인이
   // 같은 id를 쓰면 한쪽 항목에 다른 쪽 설명이 붙는다.
-  const [activeKey, setActiveKey] = useState<string | null>(null);
+  const [hoverKey, setHoverKey] = useState<string | null>(null);
+  const [focusKey, setFocusKey] = useState<string | null>(null);
+  const activeKey = hoverKey ?? focusKey;
 
   // 배치 판정은 CSS의 max-height 상한이 아니라 실제 렌더 높이로 해야 한다 —
   // 상한(520px)으로 clamp하면 짧은 메뉴가 커서에서 수백 px 떨어진 곳에 열린다.
@@ -170,14 +173,19 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
         tabIndex={-1}
         ref={menuRef}
         onKeyDown={handleMenuKeyDown}
-        onMouseLeave={() => setActiveKey(null)}
+        onMouseLeave={() => setHoverKey(null)}
         // 항목이 전부 tabIndex=-1이라 Tab은 메뉴를 건너뛴다. 그때 메뉴만 열린 채 남으면 사용자는
         // 다른 컨트롤에 포커스를 둔 채 떠 있는 실행 메뉴를 보게 된다 — 포커스가 떠나면 닫는다.
         onBlur={(event) => {
           const next = event.relatedTarget as Node | null;
           if (next && event.currentTarget.contains(next)) return;
           if (next === null) return; // 창 자체가 포커스를 잃은 경우는 닫지 않는다
-          setActiveKey(null);
+          // 기능 투어는 이 메뉴의 항목에 앵커를 걸고 여러 단계를 걷는다. 그 카드의 버튼으로
+          // 포커스가 가는 것은 메뉴를 떠나는 것이 아니다 — 여기서 닫으면 다음 단계가 짚을
+          // 항목이 사라져 설명하던 대상을 잃은 투어만 남는다(포인터 경로도 같은 이유로 면제한다).
+          if (document.querySelector(FEATURE_TOUR_LAYER_SELECTOR)?.contains(next)) return;
+          setHoverKey(null);
+          setFocusKey(null);
           onClose();
         }}
         {...{ [FEATURE_TOUR_BOUNDARY_ATTRIBUTE]: "" }}
@@ -207,8 +215,8 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                   disabled={disabled}
                   title={kind.disabledReason}
                   tabIndex={-1}
-                  onMouseEnter={() => setActiveKey(itemKey(plugin.id, kind.id))}
-                  onFocus={() => setActiveKey(itemKey(plugin.id, kind.id))}
+                  onMouseEnter={() => setHoverKey(itemKey(plugin.id, kind.id))}
+                  onFocus={() => setFocusKey(itemKey(plugin.id, kind.id))}
                   onClick={() => onLaunchKind(plugin.id, kind)}
                 >
                   <span className="theater-menu-check" aria-hidden="true">{renderKindIcon(plugin.id, kind) ?? <FallbackGlyph />}</span>

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -42,7 +42,9 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   const [menuSize, setMenuSize] = useState<{ readonly width: number; readonly height: number } | null>(null);
   // 설명을 펼칠 항목. 포인터 호버와 키보드 포커스가 같은 상태를 쓴다 — 둘이 갈라지면
   // 키보드로 옮긴 자리와 옆에 뜬 설명이 서로 다른 항목을 가리킨다.
-  const [activeKindId, setActiveKindId] = useState<string | null>(null);
+  // 키는 플러그인까지 포함해야 한다: 실행 종류 id는 플러그인 안에서만 고유하므로, 두 플러그인이
+  // 같은 id를 쓰면 한쪽 항목에 다른 쪽 설명이 붙는다.
+  const [activeKey, setActiveKey] = useState<string | null>(null);
 
   // 배치 판정은 CSS의 max-height 상한이 아니라 실제 렌더 높이로 해야 한다 —
   // 상한(520px)으로 clamp하면 짧은 메뉴가 커서에서 수백 px 떨어진 곳에 열린다.
@@ -94,6 +96,9 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   // 행 하나가 통째로 서는 것은 값을 못 한다. 둘 이상일 때만 그룹 라벨을 세운다.
   const singlePlugin = catalog.length === 1 ? catalog[0]! : null;
   const headTitle = theaterLabel ? t("canvas.menu.theaterTitle", { theater: theaterLabel }) : t("canvas.menu.title");
+  // 시각 머리글과 메뉴 이름이 같은 문자열이어야 한다 — 좁은 폭에서 머리글이 줄임표로 잘려도
+  // 어느 Theater로 실행되는지는 접근 이름에 온전히 남는다.
+  const headLabel = singlePlugin ? `${headTitle} · ${singlePlugin.title}` : headTitle;
 
   const moveFocus = useCallback((from: HTMLElement | null, delta: number, edge: "first" | "last" | null) => {
     const menu = menuRef.current;
@@ -134,17 +139,19 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   };
 
   const activeDescription = useMemo(() => {
-    if (!activeKindId) return null;
+    if (!activeKey) return null;
     for (const plugin of catalog) {
       for (const kind of plugin.kinds) {
-        if (kind.id !== activeKindId) continue;
+        if (itemKey(plugin.id, kind.id) !== activeKey) continue;
         if (kind.disabledReason) return null;
         const annotation = resolveLaunchKindAnnotation(kind.id);
         return annotation ? t(annotation.descriptionKey) : null;
       }
     }
     return null;
-  }, [activeKindId, catalog, t]);
+  }, [activeKey, catalog, t]);
+
+  const asideSide = activeDescription ? asidePlacement(anchor, viewportBounds, menuSize) : null;
 
   return (
     <div
@@ -156,17 +163,28 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
       <div
         className="operation-launch-menu theater-menu canvas-context-menu"
         role="menu"
-        aria-label={t("canvas.menu.aria")}
+        // 머리글은 시각 표면이고, 그 정보는 메뉴 이름이 대신 싣는다 — role="menu" 아래에 일반
+        // 콘텐츠를 두면 화면 낭독기의 메뉴 탐색이 첫 항목으로 곧장 들어가지 못한다.
+        aria-label={headLabel}
         aria-orientation="vertical"
         tabIndex={-1}
         ref={menuRef}
         onKeyDown={handleMenuKeyDown}
-        onMouseLeave={() => setActiveKindId(null)}
+        onMouseLeave={() => setActiveKey(null)}
+        // 항목이 전부 tabIndex=-1이라 Tab은 메뉴를 건너뛴다. 그때 메뉴만 열린 채 남으면 사용자는
+        // 다른 컨트롤에 포커스를 둔 채 떠 있는 실행 메뉴를 보게 된다 — 포커스가 떠나면 닫는다.
+        onBlur={(event) => {
+          const next = event.relatedTarget as Node | null;
+          if (next && event.currentTarget.contains(next)) return;
+          if (next === null) return; // 창 자체가 포커스를 잃은 경우는 닫지 않는다
+          setActiveKey(null);
+          onClose();
+        }}
         {...{ [FEATURE_TOUR_BOUNDARY_ATTRIBUTE]: "" }}
       >
-        <div className="canvas-context-menu-head">
+        <div className="canvas-context-menu-head" aria-hidden="true">
           <span className="canvas-context-menu-head-text">
-            <strong>{singlePlugin ? `${headTitle} · ${singlePlugin.title}` : headTitle}</strong>
+            <strong>{headLabel}</strong>
           </span>
           <p className="canvas-context-menu-section">{t("canvas.menu.launch")}</p>
         </div>
@@ -189,8 +207,8 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                   disabled={disabled}
                   title={kind.disabledReason}
                   tabIndex={-1}
-                  onMouseEnter={() => setActiveKindId(kind.id)}
-                  onFocus={() => setActiveKindId(kind.id)}
+                  onMouseEnter={() => setActiveKey(itemKey(plugin.id, kind.id))}
+                  onFocus={() => setActiveKey(itemKey(plugin.id, kind.id))}
                   onClick={() => onLaunchKind(plugin.id, kind)}
                 >
                   <span className="theater-menu-check" aria-hidden="true">{renderKindIcon(plugin.id, kind) ?? <FallbackGlyph />}</span>
@@ -215,10 +233,10 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
           </div>
         )) : <p className="theater-menu-empty">{t("canvas.menu.empty")}</p>}
       </div>
-      {activeDescription
+      {activeDescription && asideSide
         ? (
           <p
-            className={`canvas-context-menu-aside${asideFlips(anchor, viewportBounds, menuSize) ? " canvas-context-menu-aside--flip" : ""}`}
+            className={`canvas-context-menu-aside${asideSide === "left" ? " canvas-context-menu-aside--flip" : ""}`}
             aria-hidden="true"
           >
             {activeDescription}
@@ -242,17 +260,21 @@ export function CommandReticleIcon() {
   );
 }
 
-// 어사이드는 기본으로 메뉴 오른쪽에 선다. 오른쪽 끝에서 열려 자리가 없으면 왼쪽으로 뒤집는다 —
-// 뒤집지 않으면 밀도는 맞고 설명만 화면 밖으로 잘려 사실상 사라진다.
-function asideFlips(
+// 어사이드는 기본으로 메뉴 오른쪽에 선다. 오른쪽에 자리가 없으면 왼쪽으로 뒤집고, 양쪽 모두
+// 좁으면(캔버스가 대략 516px 아래) 아예 펴지 않는다 — 뒤집기만 하고 왼쪽 여백을 안 보면 설명이
+// 화면 왼쪽으로 밀려 앞부분이 잘린 채 남는다. 펴지 못해도 한 단어 대비는 행에 그대로 있고
+// 설명 문장은 버튼의 접근 이름에 남으므로, 안 보이는 것보다 안 띄우는 쪽이 정직하다.
+function asidePlacement(
   anchor: { readonly x: number; readonly y: number },
   bounds: { readonly width: number; readonly height: number } | undefined,
   size: { readonly width: number; readonly height: number } | null,
-): boolean {
-  if (!bounds) return false;
+): "right" | "left" | null {
+  if (!bounds) return "right";
   const width = size?.width ?? MENU_WIDTH;
   const left = Math.max(MENU_MARGIN, Math.min(anchor.x, bounds.width - width - MENU_MARGIN));
-  return left + width + ASIDE_GAP + ASIDE_WIDTH > bounds.width - MENU_MARGIN;
+  if (left + width + ASIDE_GAP + ASIDE_WIDTH <= bounds.width - MENU_MARGIN) return "right";
+  if (left - ASIDE_GAP - ASIDE_WIDTH >= MENU_MARGIN) return "left";
+  return null;
 }
 
 function clampedAnchorStyle(
@@ -282,6 +304,12 @@ function clampedAnchorStyle(
   const preferred = anchor.y + height + MENU_MARGIN <= bounds.height ? anchor.y : anchor.y - height;
   const top = Math.max(MENU_MARGIN, Math.min(preferred, bounds.height - height - MENU_MARGIN));
   return { ...base, left, top } as CSSProperties;
+}
+
+// 실행 종류 id는 플러그인 안에서만 고유하다. 활성 항목을 이 키로 잡아야 두 플러그인이 같은
+// id를 가질 때 한쪽 항목에 다른 쪽 설명이 붙지 않는다.
+function itemKey(pluginId: string, kindId: string): string {
+  return `${pluginId}:${kindId}`;
 }
 
 // 플러그인이 아이콘을 등록하지 않았을 때의 일반 폴백 마크 — 특정 플러그인 지식이 아니다.

--- a/runtime/fleet-console/core/client/src/i18n/messages/common.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/common.ts
@@ -61,6 +61,11 @@ export const commonEn = {
   "launchKind.claudeNative.description": "Plain Claude Code, without the Admiral prompt",
   "launchKind.claude.description": "The one you know — Admiral standing orders and Carrier dispatch",
   "launchKind.claudeGateway.description": "Runs Claude Code on the models you enabled in Settings",
+  // 실행 종류 옆에 늘 보이는 한 단어짜리 대비. 설명 문장은 한 항목을 짚었을 때만 펼치므로,
+  // 짚지 않고 훑는 사람(그리고 호버가 없는 터치)도 세 Claude를 구별할 수 있어야 한다.
+  "launchKind.claudeNative.brief": "No Admiral",
+  "launchKind.claude.brief": "Admiral + Carriers",
+  "launchKind.claudeGateway.brief": "Other models",
 } as const;
 
 export const commonKo: Record<keyof typeof commonEn, string> = {
@@ -126,4 +131,7 @@ export const commonKo: Record<keyof typeof commonEn, string> = {
   "launchKind.claudeNative.description": "Admiral 프롬프트 없는 순정 Claude Code",
   "launchKind.claude.description": "Admiral 상비 명령과 Carrier 위임을 함께 싣는 기존 방식",
   "launchKind.claudeGateway.description": "설정에서 켠 다른 모델로 Claude Code를 실행",
+  "launchKind.claudeNative.brief": "Admiral 없이",
+  "launchKind.claude.brief": "Admiral + Carrier",
+  "launchKind.claudeGateway.brief": "다른 모델",
 };

--- a/runtime/fleet-console/core/client/src/launch-kind-annotations.ts
+++ b/runtime/fleet-console/core/client/src/launch-kind-annotations.ts
@@ -1,22 +1,30 @@
 import type { CoreMessageKey } from "./i18n/index.js";
 
-// 실행 메뉴 항목에 덧붙는 한 줄 설명. 플러그인이 주는 title은 로케일 없는 서버 문자열이라
+// 실행 메뉴 항목에 덧붙는 설명. 플러그인이 주는 title은 로케일 없는 서버 문자열이라
 // 번역할 수 없으므로, 번역이 필요한 문구는 여기(코어 i18n)에 두고 kind id로만 맞붙인다.
 // 코어가 특정 kind id를 아는 것은 feature-tour 카탈로그가 이미 쓰는 방식과 같다 — 두 곳 모두
 // 번역 가능한 라벨이 아니라 안정 식별자에 건다.
+//
+// 두 층으로 나뉜다: brief는 라벨 옆에 늘 서서 훑기만 해도 종류가 갈리게 하고,
+// description은 그 항목을 짚었을 때만 옆에 펼친다. 상시로 두 줄을 쓰면 메뉴가 실행 목록이
+// 아니라 설명서가 되고, 아예 없애면 이름만으로 세 Claude를 못 가른다.
 export interface LaunchKindAnnotation {
   readonly descriptionKey: CoreMessageKey;
+  readonly briefKey: CoreMessageKey;
 }
 
 export const LAUNCH_KIND_ANNOTATIONS: Readonly<Record<string, LaunchKindAnnotation>> = {
   "claude-native": {
     descriptionKey: "launchKind.claudeNative.description",
+    briefKey: "launchKind.claudeNative.brief",
   },
   claude: {
     descriptionKey: "launchKind.claude.description",
+    briefKey: "launchKind.claude.brief",
   },
   "claude-gateway": {
     descriptionKey: "launchKind.claudeGateway.description",
+    briefKey: "launchKind.claudeGateway.brief",
   },
 };
 

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2926,13 +2926,18 @@
   overflow: hidden;
 }
 
+/* 긴 Theater 이름은 줄임표로 끝난다 — 줄임표가 없으면 글자가 중간에서 그냥 끊겨 이름이
+   잘렸다는 사실 자체가 보이지 않는다. 온전한 이름은 메뉴의 접근 이름이 계속 들고 있다. */
 .canvas-context-menu-head-text strong {
+  display: block;
   font-family: var(--font-body);
   font-weight: var(--weight-medium);
   font-size: 11px;
   letter-spacing: -0.005em;
   color: var(--text-secondary);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* Launch 섹션 라벨 — 헤더 줄 오른쪽 끝에 선다. */

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -1620,6 +1620,11 @@
 .operation-launch-control--canvas {
   position: absolute;
   z-index: 30;
+  /* 캔버스 메뉴 폭의 단일 소유자. 메뉴 박스와 설명 어사이드의 기준점이 여기 하나로 모인다 —
+     컨테이너에 폭이 없으면 어사이드의 100%가 메뉴 오른쪽이 아니라 왼쪽 모서리를 가리켜
+     설명이 메뉴 위를 덮는다. 컴포넌트의 MENU_WIDTH(측정 전 clamp 폴백)만 이 값을 따로 안다. */
+  --canvas-menu-width: 288px;
+  width: var(--canvas-menu-width);
 }
 
 /* War Room의 메뉴는 이 모드의 층 위에 서야 한다 — 덱(80)과 레일(90)이 같은 스태킹 문맥에서 위에
@@ -1680,8 +1685,9 @@
 
 .operation-launch-control--canvas .operation-launch-menu {
   top: 0;
-  /* 'Canvas controls' 헤더가 한 줄에 들어가고, 실행 종류의 한 줄 설명이 두 줄 안에 끝나도록 넓힌다. */
-  min-width: 340px;
+  /* 설명 문장이 항목 안에서 접히면서 폭을 넓힐 이유가 사라졌다. 라벨과 한 단어짜리 대비만
+     한 줄에 들어가면 된다. */
+  min-width: var(--canvas-menu-width);
 }
 
 /* 런처로 연 경우 메뉴를 컨테이너 바닥에 정렬해 위로 펼친다(아래 FAB/Dock과 겹치지 않게). */
@@ -2903,50 +2909,37 @@
   background: color-mix(in oklch, var(--aurora) 9%, color-mix(in oklch, var(--ink-deep) 28%, transparent));
 }
 
-/* Canvas controls 헤더 — 마크 + 타이틀. */
+/* Canvas controls 헤더 — 실행 대상과 Launch 라벨이 한 줄을 나눠 쓴다. 이 메뉴는 설명서가 아니라
+   런처이므로 첫 액션 앞에 세울 수 있는 크롬은 이 한 줄이 전부다. 실행 대상 이름은 남는다 —
+   어느 Theater로 실행되는지 알려주는 표면이 여기 말고는 없다. */
 .canvas-context-menu-head {
   display: flex;
-  align-items: center;
+  align-items: baseline;
+  justify-content: space-between;
   gap: var(--space-3);
-  padding: var(--space-2) var(--space-2) var(--space-3);
-  margin-bottom: var(--space-1);
-  border-bottom: 1px solid var(--surface-rim);
-}
-
-.canvas-context-menu-reticle {
-  display: grid;
-  place-items: center;
-  flex: none;
-  width: 30px;
-  height: 30px;
-  color: var(--brass-ink);
-}
-
-.canvas-context-menu-reticle svg {
-  width: 30px;
-  height: 30px;
+  padding: var(--space-1) var(--space-2);
+  line-height: 16px;
 }
 
 .canvas-context-menu-head-text {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
   min-width: 0;
+  overflow: hidden;
 }
 
 .canvas-context-menu-head-text strong {
   font-family: var(--font-body);
   font-weight: var(--weight-medium);
-  font-size: 15px;
-  letter-spacing: -0.01em;
-  color: var(--text-primary);
+  font-size: 11px;
+  letter-spacing: -0.005em;
+  color: var(--text-secondary);
   white-space: nowrap;
 }
 
-/* Launch 섹션 라벨. */
+/* Launch 섹션 라벨 — 헤더 줄 오른쪽 끝에 선다. */
 .canvas-context-menu-section {
-  margin: var(--space-2) 0 0;
-  padding: var(--space-1) var(--space-2);
+  margin: 0;
+  padding: 0;
+  flex: none;
   font-family: var(--font-mono);
   font-size: 10px;
   font-weight: var(--weight-medium);
@@ -2956,12 +2949,60 @@
 }
 
 .canvas-context-menu {
-  width: 288px;
+  width: var(--canvas-menu-width);
   /* 상한은 뷰포트 높이에서 산출된 geometry 변수가 소유한다 — 짧은 화면에서도 메뉴가 잘리지 않는다. */
   max-height: var(--canvas-menu-max-height, 520px);
   overflow-y: auto;
 }
 
+/* 바깥 패딩은 캔버스 메뉴에서만 좁힌다 — 공유 .theater-menu를 고치면 사이드바 Theater 메뉴까지
+   함께 얇아진다. 두 클래스를 함께 짚어야 하는 이유: .theater-menu의 padding 선언이 이 파일
+   뒤쪽에 있어 한 클래스짜리 선택자로는 특이도가 같아 지고, 값은 조용히 8px로 남는다. */
+.operation-launch-menu.canvas-context-menu {
+  padding: var(--space-1);
+}
+
+/* 설명 어사이드 — 짚은 항목의 설명 문장을 메뉴 옆에 편다. 메뉴의 overflow 바깥 형제라
+   스크롤 박스에 잘리지 않는다. */
+.canvas-context-menu-aside {
+  position: absolute;
+  left: calc(100% + 8px);
+  top: 0;
+  width: 208px;
+  margin: 0;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  /* 팝업 판독성 계약: .theater-menu와 같은 불투명 --ink-deep 언더레이 위에 선다. */
+  background:
+    linear-gradient(
+      color-mix(in oklch, var(--ink-deep) 60%, var(--surface-pillar)),
+      color-mix(in oklch, var(--ink-deep) 60%, var(--surface-pillar))
+    ),
+    var(--ink-deep);
+  box-shadow: var(--shadow-floating);
+  font-family: var(--font-body);
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+  pointer-events: none;
+}
+
+/* 오른쪽 끝에서 열리면 왼쪽으로 뒤집는다 — 뒤집지 않으면 설명이 화면 밖으로 잘려 사라진다. */
+.canvas-context-menu-aside--flip {
+  left: auto;
+  right: calc(100% + 8px);
+}
+
+/* 항목은 tabIndex=-1이라 방향키로만 포커스가 옮겨온다. 프로그래매틱 포커스에서도 자리가
+   보이도록 :focus-visible뿐 아니라 :focus에도 같은 brass 강조를 준다. */
+.canvas-context-menu-item:focus {
+  outline: none;
+  color: var(--text-primary);
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
+}
+
+/* 플러그인이 둘 이상일 때만 서는 그룹 라벨. 하나뿐이면 헤더 줄에 병합돼 이 행 자체가 없다. */
 .canvas-context-menu-plugin {
   margin: var(--space-1) 0 0;
   padding: var(--space-1) var(--space-2) 0;
@@ -6345,11 +6386,12 @@
   text-transform: uppercase;
 }
 
-/* 한 줄 설명이 붙는 실행 종류 항목은 그리드로 둔다. 라벨이 첫 행을 온전히 쓰고, 설명과
-   비활성 사유는 그 아래 전체 폭에 선다. */
+/* 실행 종류 항목은 그리드로 둔다. 아이콘·라벨·한 단어 대비가 첫 행을 나눠 쓰고, 비활성 사유만
+   그 아래 전체 폭에 선다. 설명 문장은 첫 행에 접혀 있다가 항목을 짚었을 때 메뉴 옆에 펴진다 —
+   상시 두 줄로 두면 항목 하나가 50px를 먹어 메뉴가 실행 목록이 아니라 설명서가 된다. */
 .operation-launch-menu-item--annotated {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: start;
   column-gap: var(--space-2);
   row-gap: 2px;
@@ -6363,6 +6405,28 @@
 .operation-launch-menu-item--annotated .theater-menu-label {
   grid-column: 2;
   grid-row: 1;
+}
+
+/* 라벨 오른쪽에 늘 서는 한 단어짜리 대비. 배지가 아니라 무배경 텍스트다 — 캡슐을 두면
+   brass 채널을 빌려야 하고, 그 예외는 이미 폐기됐다. */
+.operation-launch-menu-brief {
+  grid-column: 3;
+  grid-row: 1;
+  justify-self: end;
+  min-width: 0;
+  max-width: 124px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-body);
+  font-size: 11px;
+  letter-spacing: 0;
+  color: color-mix(in oklch, var(--text-tertiary) 82%, transparent);
+}
+
+.operation-launch-menu-item:hover:not(:disabled) .operation-launch-menu-brief,
+.operation-launch-menu-item:focus-visible .operation-launch-menu-brief {
+  color: var(--text-tertiary);
 }
 
 /* 비활성 사유는 설명이 서던 아래 줄로 내린다 — 라벨과 같은 행에 두면 둘이 폭을 다투어
@@ -6388,6 +6452,20 @@
   letter-spacing: 0;
   line-height: 1.35;
   white-space: normal;
+}
+
+/* 캔버스 메뉴에서 설명 문장은 시각적으로만 접힌다. 지우지 않는 이유는 화면 낭독기 때문이다 —
+   버튼 안에 남아 접근 이름에 실리므로, 옆 어사이드가 떠 있든 아니든 세 Claude의 차이가
+   항상 낭독된다. absolute라 그리드 흐름에서 빠져 행 높이를 늘리지 않는다. */
+.operation-launch-menu-description--quiet {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
 }
 
 .theater-menu-error {

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -315,6 +315,61 @@ describe("CanvasContextMenu launch kind attribute", () => {
     outside.remove();
   });
 
+  it("stays open while the feature tour card takes focus from one of its anchored items", () => {
+    const onClose = vi.fn();
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [
+      {
+        id: "terminal",
+        title: "Terminal",
+        kinds: [{ id: "claude-native", type: "agent", title: "Claude (Native)" }],
+      },
+    ], onClose);
+    tourLayer = document.createElement("div");
+    tourLayer.setAttribute(FEATURE_TOUR_LAYER_ATTRIBUTE, "");
+    const tourNext = document.createElement("button");
+    tourLayer.append(tourNext);
+    document.body.append(tourLayer);
+
+    const menu = document.querySelector<HTMLElement>(".canvas-context-menu")!;
+    // 투어는 이 메뉴의 항목마다 앵커를 걸고 여러 단계를 걷는다 — 다음 단계 버튼을 눌렀다고
+    // 메뉴가 닫히면 남은 단계가 짚을 대상이 사라진다.
+    act(() => menu.dispatchEvent(new FocusEvent("focusout", { bubbles: true, relatedTarget: tourNext })));
+    expect(onClose).not.toHaveBeenCalled();
+
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    act(() => menu.dispatchEvent(new FocusEvent("focusout", { bubbles: true, relatedTarget: outside })));
+    expect(onClose).toHaveBeenCalledOnce();
+    outside.remove();
+  });
+
+  it("keeps the focused item's description when the pointer leaves the menu", () => {
+    renderMenu({ x: 100, y: 156 }, { width: 1116, height: 856 }, [
+      {
+        id: "terminal",
+        title: "Terminal",
+        kinds: [
+          { id: "claude-native", type: "agent", title: "Claude (Native)" },
+          { id: "claude-gateway", type: "agent", title: "Claude (Gateway)" },
+        ],
+      },
+    ]);
+
+    const menu = document.querySelector<HTMLElement>(".canvas-context-menu")!;
+    const rows = document.querySelectorAll<HTMLButtonElement>(".canvas-context-menu-item");
+    const asideText = () => document.querySelector(".canvas-context-menu-aside")?.textContent;
+
+    // 포인터로 열고 방향키로 옮기는 혼합 입력이 흔하다.
+    act(() => rows[0]!.dispatchEvent(new MouseEvent("mouseover", { bubbles: true })));
+    act(() => rows[1]!.focus());
+    // 가리키는 동안에는 포인터가 이긴다.
+    expect(asideText()).toBe("Plain Claude Code, without the Admiral prompt");
+
+    act(() => menu.dispatchEvent(new MouseEvent("mouseout", { bubbles: true, relatedTarget: document.body })));
+    // 포인터가 나가도 포커스가 짚고 있는 행의 설명은 남는다.
+    expect(asideText()).toBe("Runs Claude Code on the models you enabled in Settings");
+  });
+
   it("names the menu after its launch target and keeps the visual head out of the menu tree", () => {
     act(() => root.render(
       <CanvasContextMenu

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -145,6 +145,113 @@ describe("CanvasContextMenu launch kind attribute", () => {
     expect(item?.querySelector(".operation-launch-menu-description")).toBeNull();
   });
 
+  it("merges a lone plugin name into the head line and keeps group labels once a second plugin appears", () => {
+    const terminal: OperationCatalogPlugin = {
+      id: "terminal",
+      title: "Terminal",
+      kinds: [{ id: "shell", type: "shell", title: "Shell" }],
+    };
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [terminal]);
+
+    // 플러그인이 하나면 이름만 있는 행이 값을 못 한다 — 머리글 줄에 붙인다.
+    expect(document.querySelector(".canvas-context-menu-plugin")).toBeNull();
+    expect(document.querySelector(".canvas-context-menu-head-text")?.textContent).toContain("Terminal");
+
+    const notebooks: OperationCatalogPlugin = {
+      id: "notebooks",
+      title: "Notebooks",
+      kinds: [{ id: "notebook", type: "agent", title: "Notebook" }],
+    };
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [terminal, notebooks]);
+
+    // 둘 이상이면 어느 공급자가 어떤 종류를 갖는지 다시 밝혀야 한다.
+    const groupLabels = Array.from(document.querySelectorAll(".canvas-context-menu-plugin")).map((node) => node.textContent);
+    expect(groupLabels).toEqual(["Terminal", "Notebooks"]);
+    expect(document.querySelector(".canvas-context-menu-head-text")?.textContent).not.toContain("Terminal");
+    expect(document.querySelectorAll('[role="group"]')).toHaveLength(2);
+  });
+
+  it("keeps the kind contrast on the row and opens the full description only for the pointed kind", () => {
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [
+      {
+        id: "terminal",
+        title: "Terminal",
+        kinds: [
+          { id: "claude-native", type: "agent", title: "Claude (Native)" },
+          { id: "claude-gateway", type: "agent", title: "Claude (Gateway)" },
+        ],
+      },
+    ]);
+
+    // 짧은 대비는 늘 행 위에 있다 — 터치와 정적 스캔에서도 종류가 갈려야 한다.
+    const briefs = Array.from(document.querySelectorAll(".operation-launch-menu-brief")).map((node) => node.textContent);
+    expect(briefs).toEqual(["No Admiral", "Other models"]);
+
+    // 설명 문장은 짚기 전에는 옆에 펴지지 않지만, 버튼 안에는 남아 접근 이름에 실린다.
+    expect(document.querySelector(".canvas-context-menu-aside")).toBeNull();
+    const gateway = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!;
+    expect(gateway.textContent).toContain("Runs Claude Code on the models you enabled in Settings");
+
+    act(() => gateway.dispatchEvent(new MouseEvent("mouseover", { bubbles: true })));
+    expect(document.querySelector(".canvas-context-menu-aside")?.textContent)
+      .toBe("Runs Claude Code on the models you enabled in Settings");
+
+    // 어사이드는 메뉴 상자 바깥 형제다 — 안에 두면 메뉴의 overflow가 잘라낸다.
+    expect(document.querySelector(".canvas-context-menu")?.contains(document.querySelector(".canvas-context-menu-aside"))).toBe(false);
+  });
+
+  it("enters the list on the first arrow key and cycles past kinds that cannot launch", () => {
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [
+      {
+        id: "terminal",
+        title: "Terminal",
+        kinds: [
+          { id: "claude-native", type: "agent", title: "Claude (Native)" },
+          { id: "codex", type: "agent", title: "Codex", disabled: true, disabledReason: "Not installed" },
+          { id: "shell", type: "shell", title: "Shell" },
+        ],
+      },
+    ]);
+
+    const menu = document.querySelector<HTMLElement>(".canvas-context-menu")!;
+    const activeKind = () => (document.activeElement as HTMLElement | null)?.dataset.operationLaunchKind;
+
+    // 열자마자 아무것도 고르지 않는다 — 이미 선택된 듯 보이면 잘못 누르게 된다.
+    expect(document.activeElement).toBe(menu);
+
+    act(() => menu.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })));
+    expect(activeKind()).toBe("claude-native");
+
+    // 실행할 수 없는 종류는 건너뛴다.
+    act(() => document.activeElement!.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })));
+    expect(activeKind()).toBe("shell");
+
+    // 끝에서 다시 처음으로 돈다.
+    act(() => document.activeElement!.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })));
+    expect(activeKind()).toBe("claude-native");
+
+    act(() => document.activeElement!.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true })));
+    expect(activeKind()).toBe("shell");
+    act(() => document.activeElement!.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true })));
+    expect(activeKind()).toBe("claude-native");
+  });
+
+  it("gives the menu a valid ancestor for its menu items", () => {
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [
+      {
+        id: "terminal",
+        title: "Terminal",
+        kinds: [{ id: "shell", type: "shell", title: "Shell" }],
+      },
+    ]);
+
+    const menu = document.querySelector(".canvas-context-menu")!;
+    expect(menu.getAttribute("role")).toBe("menu");
+    for (const item of document.querySelectorAll('[role="menuitem"]')) {
+      expect(item.closest('[role="menu"]')).toBe(menu);
+    }
+  });
+
   it("marks the rendered menu box as the tour placement boundary", () => {
     renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 });
 

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -236,6 +236,106 @@ describe("CanvasContextMenu launch kind attribute", () => {
     expect(activeKind()).toBe("claude-native");
   });
 
+  it("places the description aside on the side that has room and withholds it when neither does", () => {
+    const catalog: readonly OperationCatalogPlugin[] = [
+      {
+        id: "terminal",
+        title: "Terminal",
+        kinds: [{ id: "claude-gateway", type: "agent", title: "Claude (Gateway)" }],
+      },
+    ];
+    const point = () => act(() =>
+      document.querySelector('[data-operation-launch-kind="claude-gateway"]')!
+        .dispatchEvent(new MouseEvent("mouseover", { bubbles: true })));
+
+    // 오른쪽에 자리가 있으면 오른쪽.
+    renderMenu({ x: 100, y: 156 }, { width: 1116, height: 856 }, catalog);
+    point();
+    expect(document.querySelector(".canvas-context-menu-aside")?.className).not.toContain("--flip");
+
+    // 오른쪽이 막히고 왼쪽이 열려 있으면 뒤집는다.
+    renderMenu({ x: 1000, y: 156 }, { width: 1116, height: 856 }, catalog);
+    point();
+    expect(document.querySelector(".canvas-context-menu-aside")?.className).toContain("--flip");
+
+    // 양쪽 모두 좁으면 아예 펴지 않는다 — 뒤집기만 하면 설명이 화면 왼쪽으로 밀려 잘린다.
+    renderMenu({ x: 200, y: 156 }, { width: 400, height: 800 }, catalog);
+    point();
+    expect(document.querySelector(".canvas-context-menu-aside")).toBeNull();
+    // 펴지 못해도 대비와 설명 문장 자체는 행에 남는다.
+    const row = document.querySelector('[data-operation-launch-kind="claude-gateway"]')!;
+    expect(row.querySelector(".operation-launch-menu-brief")?.textContent).toBe("Other models");
+    expect(row.textContent).toContain("models you enabled in Settings");
+  });
+
+  it("keys the open description by plugin so two plugins may share a kind id", () => {
+    renderMenu({ x: 100, y: 156 }, { width: 1116, height: 856 }, [
+      {
+        id: "terminal",
+        title: "Terminal",
+        kinds: [{ id: "claude", type: "agent", title: "Claude Local" }],
+      },
+      {
+        id: "remote",
+        title: "Remote",
+        kinds: [{ id: "claude-gateway", type: "agent", title: "Claude Remote" }],
+      },
+    ]);
+
+    const rows = document.querySelectorAll<HTMLButtonElement>(".canvas-context-menu-item");
+    expect(rows).toHaveLength(2);
+    act(() => rows[1]!.dispatchEvent(new MouseEvent("mouseover", { bubbles: true })));
+    expect(document.querySelector(".canvas-context-menu-aside")?.textContent)
+      .toBe("Runs Claude Code on the models you enabled in Settings");
+    act(() => rows[0]!.dispatchEvent(new MouseEvent("mouseover", { bubbles: true })));
+    expect(document.querySelector(".canvas-context-menu-aside")?.textContent)
+      .toContain("Admiral standing orders");
+  });
+
+  it("closes when focus leaves the menu, since its items sit outside the tab order", () => {
+    const onClose = vi.fn();
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [
+      {
+        id: "terminal",
+        title: "Terminal",
+        kinds: [{ id: "shell", type: "shell", title: "Shell" }],
+      },
+    ], onClose);
+
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const menu = document.querySelector<HTMLElement>(".canvas-context-menu")!;
+
+    // 메뉴 안에서 옮겨 다니는 동안에는 닫지 않는다.
+    act(() => menu.dispatchEvent(new FocusEvent("focusout", { bubbles: true, relatedTarget: menu.querySelector(".canvas-context-menu-item") })));
+    expect(onClose).not.toHaveBeenCalled();
+
+    act(() => menu.dispatchEvent(new FocusEvent("focusout", { bubbles: true, relatedTarget: outside })));
+    expect(onClose).toHaveBeenCalledOnce();
+    outside.remove();
+  });
+
+  it("names the menu after its launch target and keeps the visual head out of the menu tree", () => {
+    act(() => root.render(
+      <CanvasContextMenu
+        anchor={{ x: 520, y: 156 }}
+        viewportBounds={{ width: 1116, height: 856 }}
+        catalog={[{ id: "terminal", title: "Terminal", kinds: [{ id: "shell", type: "shell", title: "Shell" }] }]}
+        canLaunch
+        theaterLabel="Alpha"
+        renderKindIcon={() => null}
+        onLaunchKind={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    ));
+
+    const menu = document.querySelector(".canvas-context-menu")!;
+    expect(menu.getAttribute("aria-label")).toBe("Alpha controls · Terminal");
+    // 같은 문자열이 눈에도 보이지만, 접근성 트리에는 메뉴 이름으로만 한 번 실린다.
+    expect(document.querySelector(".canvas-context-menu-head-text")?.textContent).toBe("Alpha controls · Terminal");
+    expect(document.querySelector(".canvas-context-menu-head")?.getAttribute("aria-hidden")).toBe("true");
+  });
+
   it("gives the menu a valid ancestor for its menu items", () => {
     renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [
       {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1231,6 +1231,7 @@ describe("Instrument core design contract", () => {
 
   it("pins the launch-kind description grammar and keeps the menu free of decoration tokens", () => {
     const components = source("styles/components.css");
+    const contextMenu = source("canvas/canvas-context-menu.tsx");
     // 줄머리 앵커가 필요하다 — 앵커 없이는 `--annotated` 하위 배치 규칙이 먼저 잡힌다.
     const descriptionBlock = components.match(/^\.operation-launch-menu-description \{[^}]*\}/m)?.[0] ?? "";
     const reasonCell = components.match(/\.operation-launch-menu-item--annotated \.operation-launch-menu-reason \{[^}]*\}/)?.[0] ?? "";
@@ -1242,9 +1243,45 @@ describe("Instrument core design contract", () => {
     expect(descriptionBlock).toContain("font-family: var(--font-body);");
     expect(descriptionBlock).not.toMatch(/font-weight:\s*\d/);
 
-    // 실행 메뉴에는 별도 표식 배지를 두지 않는다 — 종류 구분은 라벨 괄호 안이 들고 있다.
-    // 배지가 돌아오면 brass 채널을 빌리는 doctrine 예외가 다시 필요해지므로 여기서 막는다.
+    // 실행 메뉴에는 별도 표식 배지를 두지 않는다 — 종류 구분은 라벨 괄호 안과 무배경 한 단어
+    // 대비가 들고 있다. 배지가 돌아오면 brass 채널을 빌리는 doctrine 예외가 다시 필요해지므로
+    // 여기서 막는다.
     expect(components).not.toContain("operation-launch-menu-badge");
+
+    // 캔버스 메뉴는 실행 목록이지 설명서가 아니다. 설명 문장은 항목 안에 남아 접근 이름에는
+    // 실리되 시각적으로는 접히고(--quiet), 짚은 항목의 것만 메뉴 옆 어사이드에 펴진다.
+    // 상시 두 줄로 되돌아오면 항목 하나가 33px에서 50px로 불어나므로 트립와이어를 건다.
+    const quietBlock = components.match(/^\.operation-launch-menu-description--quiet \{[^}]*\}/m)?.[0] ?? "";
+    expect(quietBlock).toContain("position: absolute;");
+    expect(quietBlock).toContain("clip-path: inset(50%);");
+    const briefBlock = components.match(/^\.operation-launch-menu-brief \{[^}]*\}/m)?.[0] ?? "";
+    expect(briefBlock).toContain("grid-row: 1;");
+    expect(briefBlock).toContain("font-family: var(--font-body);");
+    expect(briefBlock).not.toMatch(/background|border-radius/);
+    expect(contextMenu).toContain('className="operation-launch-menu-brief"');
+    expect(contextMenu).toContain("operation-launch-menu-description operation-launch-menu-description--quiet");
+
+    // 헤더는 한 줄이다 — 레티클 마크와 그 30px 블록은 메뉴에서 물러났다. 실행 대상 이름은
+    // 남는다: 어느 Theater로 실행되는지 알려주는 표면이 여기 말고는 없다.
+    expect(components).not.toContain(".canvas-context-menu-reticle");
+    expect(contextMenu).not.toContain('className="canvas-context-menu-reticle"');
+    expect(contextMenu).toContain('className="canvas-context-menu-head-text"');
+    expect(components).toContain(".canvas-context-menu-head {\n  display: flex;\n  align-items: baseline;");
+
+    // 폭은 세 곳이 함께 알아야 한다. 하나만 고치면 컴파일은 되고 치수만 조용히 어긋난다.
+    // 폭은 컨테이너가 단일 소유자다. 컨테이너에 폭이 없으면 설명 어사이드의 100%가 메뉴
+    // 오른쪽이 아니라 왼쪽 모서리를 가리켜 설명이 메뉴 위를 덮는다(실측으로 확인).
+    expect(contextMenu).toContain("const MENU_WIDTH = 288;");
+    expect(components).toMatch(/\.operation-launch-control--canvas \{[^}]*--canvas-menu-width: 288px;[^}]*width: var\(--canvas-menu-width\);/);
+    expect(components).toContain(".canvas-context-menu {\n  width: var(--canvas-menu-width);");
+    expect(components).toMatch(/\.operation-launch-control--canvas \.operation-launch-menu \{[^}]*min-width: var\(--canvas-menu-width\);/);
+    // 캔버스 전용 패딩은 두 클래스를 함께 짚어야 한다 — 한 클래스면 뒤쪽의 .theater-menu와
+    // 특이도가 같아 조용히 지고 8px로 남는다(실측으로 확인한 함정).
+    expect(components).toContain(".operation-launch-menu.canvas-context-menu {\n  padding: var(--space-1);");
+
+    // 메뉴 조상 관계가 올바라야 menuitem이 유효하다. dialog로 되돌아가면 ARIA가 깨진다.
+    expect(contextMenu).toContain('role="menu"');
+    expect(contextMenu).not.toContain('role="dialog"');
   });
 
   it("keeps the v4 navigation, Theater, map, CLI, and rail visual producers", () => {


### PR DESCRIPTION
## Summary

- 캔버스 컨텍스트 메뉴가 액션 네 개 기준 **340x307 → 288x167**로 낮아집니다. 아이콘+제목 매스트헤드(55px)가 실행 대상과 `Launch` 라벨을 함께 싣는 한 줄로 접히고, 플러그인 하나가 모든 실행 종류를 제공할 때는 플러그인 이름도 그 줄에 병합됩니다. 첫 액션 앞을 막던 크롬은 **115px → 30px**입니다.
- 항목마다 상시로 깔리던 설명 2행을 걷어냈습니다. 대신 실행 종류 옆에 한 단어짜리 대비가 늘 서고, 원문 한 줄 설명은 그 항목을 가리키거나 키보드 포커스를 옮겼을 때 메뉴 옆에 펼쳐집니다. 설명 문자열은 버튼 안에 그대로 남아 화면 낭독기에는 항상 실립니다.
- 방향키 내비게이션이 동작하고(첫 아래 방향키로 진입, 실행 불가 종류 건너뛰기, Home/End), 컨테이너가 `role="menu"`로 바뀌어 `role="menuitem"` 자식들이 유효한 조상을 갖습니다.

배경: 격리 콘솔 실측으로 현재 메뉴의 세로 예산을 분해했고(매스트헤드 55 + 섹션 31.5 + 플러그인 23.5 + 항목 182.7), 오픈소스 20개 제품의 컨텍스트 메뉴 항목 높이 중앙값이 32px이며 **아이콘+제품명 머리글을 두는 곳이 0곳, 실행형 메뉴에서 항목마다 설명을 상시 표시하는 곳도 0곳**임을 소스에서 직접 확인했습니다. 제품 내부의 다른 컨텍스트 메뉴(file-explorer 30.6 / repository 30.6 / group 32.15)도 같은 대역입니다.

의도한 트레이드오프:
- 세 Claude 설명을 한 화면에서 나란히 비교하는 능력은 포기합니다. 대신 한 단어 대비가 상시 남아 터치·정적 스캔에서도 종류가 갈립니다.
- 행 패딩은 `--space-2`(8px)를 유지해 31px 대신 33px입니다. 7px은 간격 토큰이 아닙니다.
- 어사이드는 양쪽 모두 자리가 없으면(캔버스 약 516px 미만) 아예 띄우지 않습니다. 대비어와 접근 이름이 남으므로 조용히 잘리는 것보다 낫습니다.

리뷰 이력: 적대적 리뷰 6개 차원에서 후보 10건 중 8건이 검증을 통과했고, 그중 5건을 세 번째 커밋에서 수정했습니다. 2건은 반증되어 기각(`placement="above"` 어사이드 앵커링 — 호출자 0; 좁은 캔버스 클립 — 배치 수정에 흡수), 1건은 유예(Escape가 호출 컨트롤로 포커스를 복원하지 않음 — 이 변경 이전부터의 동작이고, 올바른 수정은 닫기와 실행을 구분해야 해서 실행 흐름 쪽 작업입니다).

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 0 오류
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 131 파일 1481 통과 / 19 skipped
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 성공
- [x] `pnpm check:core-boundary` — 통과
- [x] `node --test scripts/*.test.mjs` — 23 통과
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 25 항목 검증
- [x] 격리 콘솔(`FLEET_CONSOLE_DIR`) 헤디드 실측: 288x167.2 / 크롬 30px / 행 33px / 페이지 오류 0
- [x] 실측 확인: 호버·포커스 시 어사이드 표시(메뉴 높이 불변), 오른쪽 가장자리에서 좌측 뒤집기, 캔버스 536px에서 어사이드 억제 + 대비어·접근 이름 유지, Tab으로 포커스 이탈 시 메뉴 자동 닫힘, ArrowDown 진입·순환, Escape 닫힘
- [x] changelog fragment `.changelog.d/canvas-menu-compact.md` 동봉 (fleet-console / Changed + Fixed)