### PR TITLE
feat(console): pick a gateway model and effort from the canvas launch menu

### DIFF
--- a/.changelog.d/gateway-launch-variants.md
+++ b/.changelog.d/gateway-launch-variants.md
@@ -1,0 +1,8 @@
+---
+branch: gateway-launch-variants
+---
+
+### fleet-console
+#### Added
+- The canvas launch menu can now start a Claude (Gateway) Operation on a specific Claude built-in alias or enabled Gateway model, with an optional reasoning effort selected before launch.
+  ko: 캔버스 실행 메뉴에서 이제 특정 Claude 내장 alias 또는 설정에서 활성화한 Gateway 모델로 Claude (Gateway) Operation을 시작하고, 실행 전에 reasoning effort를 선택할 수 있습니다.

--- a/packages/fleet-admiral/src/agent-cli/claude/definitions.ts
+++ b/packages/fleet-admiral/src/agent-cli/claude/definitions.ts
@@ -1,5 +1,9 @@
 import { createClaudeFamilyCliDefinition } from "./factory.js";
 
+export const NATIVE_CLAUDE_MODEL_ALIASES = ["fable", "opus", "sonnet"] as const;
+export const NATIVE_CLAUDE_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
+
+
 // Console Launch 전용: Admiral 시스템 프롬프트 없이 wiki 스킬·Console 훅·위키 MCP만 싣는 순정에 가까운 Claude Code.
 export const claudeNativeCli = createClaudeFamilyCliDefinition({
   id: "claude-native",

--- a/packages/fleet-admiral/src/agent-cli/claude/factory.ts
+++ b/packages/fleet-admiral/src/agent-cli/claude/factory.ts
@@ -23,7 +23,7 @@ export function createClaudeFamilyCliDefinition(
         delete childEnv.ANTHROPIC_AUTH_TOKEN;
       }
       return {
-        args: [...prefixArgs, ...buildModelArgs(profileOptions.model)],
+        args: [...prefixArgs, ...buildModelArgs(profileOptions.model), ...buildEffortArgs(profileOptions.effort)],
         bin,
         cwd: profileOptions.cwd,
         env: childEnv,
@@ -44,4 +44,8 @@ export function createClaudeFamilyCliDefinition(
 
 function buildModelArgs(model: string | undefined): string[] {
   return model === undefined ? [] : ["--model", model];
+}
+
+function buildEffortArgs(effort: string | undefined): string[] {
+  return effort === undefined ? [] : ["--effort", effort];
 }

--- a/packages/fleet-admiral/src/agent-cli/registry.ts
+++ b/packages/fleet-admiral/src/agent-cli/registry.ts
@@ -4,6 +4,7 @@ import type { AgentCliDefinition, AgentCliId, AgentCliProfile } from "./types.js
 export interface ResolveAgentCliProfileOptions {
   readonly cliId?: string;
   readonly model?: string;
+  readonly effort?: string;
   readonly resumeSessionId?: string;
 }
 
@@ -29,6 +30,7 @@ export async function resolveAgentCliProfile(
     cwd,
     env,
     model: options.model,
+    effort: options.effort,
     resumeSessionId: options.resumeSessionId,
   });
 }

--- a/packages/fleet-admiral/src/agent-cli/types.ts
+++ b/packages/fleet-admiral/src/agent-cli/types.ts
@@ -43,6 +43,7 @@ export interface AgentCliProfileOptions {
   readonly cwd: string;
   readonly env: NodeJS.ProcessEnv;
   readonly model?: string;
+  readonly effort?: string;
   readonly resumeSessionId?: string;
 }
 

--- a/packages/fleet-admiral/src/index.ts
+++ b/packages/fleet-admiral/src/index.ts
@@ -75,6 +75,10 @@ export {
   resolveAgentCliProfile,
   type ResolveAgentCliProfileOptions,
 } from "./agent-cli/registry.js";
+export {
+  NATIVE_CLAUDE_EFFORTS,
+  NATIVE_CLAUDE_MODEL_ALIASES,
+} from "./agent-cli/claude/definitions.js";
 
 // Agent CLI 주입 능력 맵
 export { getAgentCliInjectionCapability } from "./agent-cli/capabilities.js";

--- a/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
@@ -35,10 +35,11 @@ describe("claude-gateway profile", () => {
     }, "/tmp", {
       cliId: "claude-gateway",
       model: "claude-gateway--cursor-auto",
+      effort: "xhigh",
     });
 
     expect(profile).toMatchObject({
-      args: ["--model", "claude-gateway--cursor-auto"],
+      args: ["--model", "claude-gateway--cursor-auto", "--effort", "xhigh"],
       bin: process.execPath,
       id: "claude-gateway",
       label: "Claude (Gateway)",

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -15,7 +15,7 @@ interface CanvasContextMenuProps {
   readonly canLaunch: boolean;
   // 아이콘은 플러그인 소유다 — console-core는 어떤 플러그인인지 모른 채 렌더만 위임한다.
   readonly renderKindIcon: (pluginId: string, kind: OperationLaunchKind) => ReactNode;
-  readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind) => void;
+  readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind, variantLaunch?: Readonly<Record<string, string>>) => void;
   readonly onClose: () => void;
   /** 특정 Theater 소유 영역에서 열렸을 때 메뉴 헤더에 그 소유자를 명시한다. */
   readonly theaterLabel?: string;
@@ -28,6 +28,9 @@ interface CanvasContextMenuProps {
 // .operation-launch-control--canvas .operation-launch-menu의 min-width. 하나만 고치면 컴파일은
 // 되고 치수만 조용히 어긋난다.
 const MENU_WIDTH = 288;
+const FLYOUT_WIDTH = 324;
+const FLYOUT_GAP = 10;
+const FLYOUT_CLOSE_GRACE_MS = 160;
 const MENU_MAX_HEIGHT = 520;
 const MENU_MIN_HEIGHT = 120;
 const MENU_MARGIN = 12;
@@ -48,6 +51,79 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   const [hoverKey, setHoverKey] = useState<string | null>(null);
   const [focusKey, setFocusKey] = useState<string | null>(null);
   const activeKey = hoverKey ?? focusKey;
+  const [openFlyout, setOpenFlyout] = useState<string | null>(null);
+  const [flyoutPosition, setFlyoutPosition] = useState<{
+    readonly id: string;
+    readonly left: number;
+    readonly top: number;
+    readonly opensLeft: boolean;
+  } | null>(null);
+  const flyoutAnchorRefs = useRef(new Map<string, HTMLDivElement>());
+  const flyoutRef = useRef<HTMLDivElement | null>(null);
+  const flyoutCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelFlyoutClose = () => {
+    if (flyoutCloseTimerRef.current === null) return;
+    clearTimeout(flyoutCloseTimerRef.current);
+    flyoutCloseTimerRef.current = null;
+  };
+  const closeFlyout = () => {
+    cancelFlyoutClose();
+    setOpenFlyout(null);
+    setFlyoutPosition(null);
+  };
+  const openLaunchFlyout = (flyoutId: string) => {
+    cancelFlyoutClose();
+    const item = flyoutAnchorRefs.current.get(flyoutId);
+    const container = containerRef.current;
+    if (!item || !container) return;
+    const itemRect = item.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+    const styledLeft = Number.parseFloat(container.style.left);
+    const containerLeft = Number.isFinite(styledLeft) ? styledLeft : container.offsetLeft;
+    const itemLocalLeft = itemRect.left - containerRect.left;
+    const itemLocalRight = itemRect.right > itemRect.left
+      ? itemRect.right - containerRect.left
+      : itemLocalLeft + (menuSize?.width ?? MENU_WIDTH);
+    const itemLeft = containerLeft + itemLocalLeft;
+    const itemRight = containerLeft + itemLocalRight;
+    const rightCandidate = itemRight + FLYOUT_GAP;
+    const leftCandidate = itemLeft - FLYOUT_GAP - FLYOUT_WIDTH;
+    const boundsWidth = viewportBounds?.width;
+    const maxLeft = boundsWidth === undefined
+      ? Number.POSITIVE_INFINITY
+      : Math.max(MENU_MARGIN, boundsWidth - FLYOUT_WIDTH - MENU_MARGIN);
+    const rightFits = rightCandidate <= maxLeft;
+    const leftFits = leftCandidate >= MENU_MARGIN;
+    const rightRoom = boundsWidth === undefined ? Number.POSITIVE_INFINITY : boundsWidth - itemRight;
+    const leftRoom = itemLeft;
+    const opensLeft = leftFits
+      ? !rightFits || leftRoom > rightRoom
+      : !rightFits && leftRoom > rightRoom;
+    const absoluteLeft = Math.max(MENU_MARGIN, Math.min(opensLeft ? leftCandidate : rightCandidate, maxLeft));
+    const styledTop = Number.parseFloat(container.style.top);
+    const containerTop = Number.isFinite(styledTop) ? styledTop : container.offsetTop;
+    const absoluteTop = Math.max(MENU_MARGIN, containerTop + itemRect.top - containerRect.top - 6);
+    setFlyoutPosition({
+      id: flyoutId,
+      left: absoluteLeft,
+      top: absoluteTop,
+      opensLeft,
+    });
+    setOpenFlyout(flyoutId);
+  };
+  const scheduleFlyoutClose = () => {
+    cancelFlyoutClose();
+    flyoutCloseTimerRef.current = setTimeout(() => {
+      flyoutCloseTimerRef.current = null;
+      setOpenFlyout(null);
+      setFlyoutPosition(null);
+      setHoverKey(null);
+    }, FLYOUT_CLOSE_GRACE_MS);
+  };
+  const flyoutTarget = openFlyout === null
+    ? null
+    : findLaunchFlyout(catalog, openFlyout);
 
   // 배치 판정은 CSS의 max-height 상한이 아니라 실제 렌더 높이로 해야 한다 —
   // 상한(520px)으로 clamp하면 짧은 메뉴가 커서에서 수백 px 떨어진 곳에 열린다.
@@ -67,6 +143,26 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     observer.observe(element);
     return () => observer.disconnect();
   }, []);
+
+  useLayoutEffect(() => {
+    const element = flyoutRef.current;
+    const container = containerRef.current;
+    if (!element || !container || !viewportBounds || !openFlyout) return;
+    const measure = () => {
+      const height = element.getBoundingClientRect().height;
+      const maxTop = Math.max(MENU_MARGIN, viewportBounds.height - height - MENU_MARGIN);
+      setFlyoutPosition((previous) => {
+        if (!previous || previous.id !== openFlyout) return previous;
+        const nextTop = Math.max(MENU_MARGIN, Math.min(previous.top, maxTop));
+        return Math.abs(nextTop - previous.top) < 0.5 ? previous : { ...previous, top: nextTop };
+      });
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [openFlyout, viewportBounds]);
 
   useEffect(() => {
     const handlePointer = (event: MouseEvent) => {
@@ -94,6 +190,8 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     // 방향키를 처음 누른 순간에만 항목으로 들어간다.
     menuRef.current?.focus();
   }, []);
+
+  useEffect(() => () => cancelFlyoutClose(), []);
 
   // 플러그인이 하나뿐이면 그 이름은 헤더 줄에 붙는다 — 항목 네 개짜리 메뉴에서 이름만 있는
   // 행 하나가 통째로 서는 것은 값을 못 한다. 둘 이상일 때만 그룹 라벨을 세운다.
@@ -146,7 +244,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     for (const plugin of catalog) {
       for (const kind of plugin.kinds) {
         if (itemKey(plugin.id, kind.id) !== activeKey) continue;
-        if (kind.disabledReason) return null;
+        if (kind.disabledReason || (kind.variants?.length ?? 0) > 0) return null;
         const annotation = resolveLaunchKindAnnotation(kind.id);
         return annotation ? t(annotation.descriptionKey) : null;
       }
@@ -154,7 +252,9 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     return null;
   }, [activeKey, catalog, t]);
 
-  const asideSide = activeDescription ? asidePlacement(anchor, viewportBounds, menuSize) : null;
+  const asideSide = activeDescription && flyoutTarget === null
+    ? asidePlacement(anchor, viewportBounds, menuSize)
+    : null;
 
   return (
     <div
@@ -178,7 +278,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
         // 다른 컨트롤에 포커스를 둔 채 떠 있는 실행 메뉴를 보게 된다 — 포커스가 떠나면 닫는다.
         onBlur={(event) => {
           const next = event.relatedTarget as Node | null;
-          if (next && event.currentTarget.contains(next)) return;
+          if (next && containerRef.current?.contains(next)) return;
           if (next === null) return; // 창 자체가 포커스를 잃은 경우는 닫지 않는다
           // 기능 투어는 이 메뉴의 항목에 앵커를 걸고 여러 단계를 걷는다. 그 카드의 버튼으로
           // 포커스가 가는 것은 메뉴를 떠나는 것이 아니다 — 여기서 닫으면 다음 단계가 짚을
@@ -203,39 +303,73 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
             {plugin.kinds.map((kind) => {
               const disabled = kind.disabled === true || !canLaunch;
               const annotation = resolveLaunchKindAnnotation(kind.id);
+              const flyoutId = itemKey(plugin.id, kind.id);
+              const hasVariants = !disabled && (kind.variants?.length ?? 0) > 0;
+              const flyoutOpen = hasVariants && openFlyout === flyoutId;
+              const activateDescription = () => {
+                setHoverKey(flyoutId);
+                if (!hasVariants) closeFlyout();
+              };
+              const activateFocus = () => {
+                setFocusKey(flyoutId);
+                if (!hasVariants) closeFlyout();
+              };
               return (
-                <button
-                  key={`${plugin.id}:${kind.id}`}
-                  type="button"
-                  role="menuitem"
-                  className={`theater-menu-item canvas-context-menu-item operation-launch-menu-item${annotation ? " operation-launch-menu-item--annotated" : ""}`}
-                  // 실행 종류의 안정 식별자. 기능 투어처럼 특정 항목을 짚어야 하는 바깥 선택자가
-                  // 번역 가능한 title/label 문자열 대신 이 속성에 걸리도록 한다.
-                  data-operation-launch-kind={kind.id}
-                  disabled={disabled}
-                  title={kind.disabledReason}
-                  tabIndex={-1}
-                  onMouseEnter={() => setHoverKey(itemKey(plugin.id, kind.id))}
-                  onFocus={() => setFocusKey(itemKey(plugin.id, kind.id))}
-                  onClick={() => onLaunchKind(plugin.id, kind)}
+                <div
+                  key={flyoutId}
+                  className="operation-launch-menu-item-wrap"
+                  ref={(element) => {
+                    if (element) flyoutAnchorRefs.current.set(flyoutId, element);
+                    else flyoutAnchorRefs.current.delete(flyoutId);
+                  }}
+                  onPointerEnter={() => { if (hasVariants) openLaunchFlyout(flyoutId); }}
+                  onPointerLeave={() => { if (hasVariants) scheduleFlyoutClose(); }}
+                  onFocus={() => { if (hasVariants) openLaunchFlyout(flyoutId); }}
+                  onBlur={(event) => {
+                    if (!event.currentTarget.contains(event.relatedTarget)) scheduleFlyoutClose();
+                  }}
                 >
-                  <span className="theater-menu-check" aria-hidden="true">{renderKindIcon(plugin.id, kind) ?? <FallbackGlyph />}</span>
-                  <span className="theater-menu-label">{kind.title}</span>
-                  {/* 비활성 사유가 있으면 그것이 먼저다 — 지금 실행할 수 없다는 사실이 종류 설명보다 급하다. */}
-                  {kind.disabledReason
-                    ? <span className="operation-launch-menu-reason">{kind.disabledReason}</span>
-                    : annotation
-                      ? (
-                        <>
-                          <span className="operation-launch-menu-brief">{t(annotation.briefKey)}</span>
-                          {/* 설명 문장은 버튼 안에 남아 접근 이름에 실린다 — 시각적으로만 접고,
-                              같은 문자열을 옆 어사이드가 비춘다. 화면 낭독기는 어사이드 표시 여부와
-                              무관하게 늘 세 종류의 차이를 읽는다. */}
-                          <span className="operation-launch-menu-description operation-launch-menu-description--quiet">{t(annotation.descriptionKey)}</span>
-                        </>
-                      )
-                      : null}
-                </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={`theater-menu-item canvas-context-menu-item operation-launch-menu-item${annotation ? " operation-launch-menu-item--annotated" : ""}${hasVariants ? " operation-launch-menu-item--variants" : ""}`}
+                    // 실행 종류의 안정 식별자. 기능 투어처럼 특정 항목을 짚어야 하는 바깥 선택자가
+                    // 번역 가능한 title/label 문자열 대신 이 속성에 걸리도록 한다.
+                    data-operation-launch-kind={kind.id}
+                    disabled={disabled}
+                    title={kind.disabledReason}
+                    tabIndex={-1}
+                    {...(hasVariants ? { "aria-haspopup": "menu" as const, "aria-expanded": flyoutOpen } : {})}
+                    onMouseEnter={activateDescription}
+                    onFocus={activateFocus}
+                    onKeyDown={(event) => {
+                      if (event.key !== "ArrowRight" || !hasVariants) return;
+                      event.preventDefault();
+                      openLaunchFlyout(flyoutId);
+                      requestAnimationFrame(() => {
+                        containerRef.current?.querySelector<HTMLButtonElement>("[data-launch-variant-row]")?.focus();
+                      });
+                    }}
+                    onClick={() => onLaunchKind(plugin.id, kind)}
+                  >
+                    <span className="theater-menu-check" aria-hidden="true">{renderKindIcon(plugin.id, kind) ?? <FallbackGlyph />}</span>
+                    <span className="theater-menu-label">{kind.title}</span>
+                    {/* 비활성 사유가 있으면 그것이 먼저다 — 지금 실행할 수 없다는 사실이 종류 설명보다 급하다. */}
+                    {kind.disabledReason
+                      ? <span className="operation-launch-menu-reason">{kind.disabledReason}</span>
+                      : annotation
+                        ? (
+                          <>
+                            <span className="operation-launch-menu-brief">{t(annotation.briefKey)}</span>
+                            {/* 설명 문장은 버튼 안에 남아 접근 이름에 실린다 — 시각적으로만 접고,
+                                variant가 없는 행에서만 같은 문자열을 옆 어사이드가 비춘다. */}
+                            <span className="operation-launch-menu-description operation-launch-menu-description--quiet">{t(annotation.descriptionKey)}</span>
+                          </>
+                        )
+                        : null}
+                    {hasVariants ? <span className="operation-launch-menu-chevron" aria-hidden="true">›</span> : null}
+                  </button>
+                </div>
               );
             })}
           </div>
@@ -251,8 +385,82 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
           </p>
         )
         : null}
+      {flyoutTarget && flyoutPosition?.id === openFlyout ? (
+        <div
+          className={`operation-launch-flyout theater-menu${flyoutPosition.opensLeft ? " is-left" : ""}`}
+          role="menu"
+          ref={flyoutRef}
+          style={{ position: "fixed", left: flyoutPosition.left, right: "auto", top: flyoutPosition.top }}
+          onPointerEnter={cancelFlyoutClose}
+          onPointerLeave={scheduleFlyoutClose}
+          onFocus={cancelFlyoutClose}
+          onBlur={(event) => {
+            if (!containerRef.current?.contains(event.relatedTarget)) scheduleFlyoutClose();
+          }}
+          onKeyDown={(event) => {
+            if (event.key !== "ArrowLeft" && event.key !== "Escape") return;
+            event.preventDefault();
+            event.stopPropagation();
+            flyoutAnchorRefs.current.get(openFlyout!)?.querySelector<HTMLButtonElement>("[data-operation-launch-kind]")?.focus();
+            closeFlyout();
+          }}
+        >
+          {flyoutTarget.kind.variants!.map((group, groupIndex) => (
+            <div key={group.id} className="operation-launch-variant-group">
+              {groupIndex > 0 ? <div className="theater-menu-divider" role="separator" /> : null}
+              <p className="operation-launch-variant-caption">
+                {group.id === "native"
+                  ? t("launchVariants.group.native")
+                  : group.id === "gateway"
+                    ? t("launchVariants.group.gateway")
+                    : group.label}
+              </p>
+              {group.rows.map((row) => (
+                <div key={row.id} className="operation-launch-variant-entry">
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="operation-launch-variant-row"
+                    data-launch-variant-row={row.id}
+                    onClick={() => onLaunchKind(flyoutTarget.pluginId, flyoutTarget.kind, row.launch)}
+                  >
+                    <span>{row.label}</span>
+                    {row.starred ? <span className="operation-launch-variant-star" aria-hidden="true">★</span> : null}
+                  </button>
+                  {(row.chips?.length ?? 0) > 0 ? (
+                    <div className="operation-launch-variant-chips">
+                      {row.chips!.map((chip) => (
+                        <button
+                          key={chip.id}
+                          type="button"
+                          className="operation-launch-variant-chip"
+                          data-launch-variant-chip={`${row.id}:${chip.id}`}
+                          onClick={() => onLaunchKind(flyoutTarget.pluginId, flyoutTarget.kind, chip.launch)}
+                        >
+                          {chip.label}
+                        </button>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
+}
+
+function findLaunchFlyout(catalog: readonly OperationCatalogPlugin[], flyoutId: string): {
+  readonly pluginId: string;
+  readonly kind: OperationLaunchKind;
+} | null {
+  for (const plugin of catalog) {
+    const kind = plugin.kinds.find((candidate) => itemKey(plugin.id, candidate.id) === flyoutId);
+    if (kind?.variants && kind.variants.length > 0) return { pluginId: plugin.id, kind };
+  }
+  return null;
 }
 
 // 좌하단 런처 FAB와 메뉴 헤더가 공유하던 '커맨드 레티클' 마크 — 외곽 스코프 링 + 사방 조준 틱 +

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -239,6 +239,20 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     }
   };
 
+  const moveFlyoutFocus = (from: HTMLElement | null, delta: number, edge: "first" | "last" | null) => {
+    const flyout = flyoutRef.current;
+    if (!flyout) return;
+    const items = Array.from(flyout.querySelectorAll<HTMLButtonElement>(".operation-launch-variant-row, .operation-launch-variant-chip")).filter((item) => !item.disabled);
+    if (items.length === 0) return;
+    if (edge) {
+      items[edge === "first" ? 0 : items.length - 1]!.focus();
+      return;
+    }
+    const index = from ? items.indexOf(from as HTMLButtonElement) : -1;
+    const next = index < 0 ? (delta > 0 ? 0 : items.length - 1) : (index + delta + items.length) % items.length;
+    items[next]!.focus();
+  };
+
   const activeDescription = useMemo(() => {
     if (!activeKey) return null;
     for (const plugin of catalog) {
@@ -398,11 +412,33 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
             if (!containerRef.current?.contains(event.relatedTarget)) scheduleFlyoutClose();
           }}
           onKeyDown={(event) => {
-            if (event.key !== "ArrowLeft" && event.key !== "Escape") return;
-            event.preventDefault();
-            event.stopPropagation();
-            flyoutAnchorRefs.current.get(openFlyout!)?.querySelector<HTMLButtonElement>("[data-operation-launch-kind]")?.focus();
-            closeFlyout();
+            const target = event.target as HTMLElement;
+            switch (event.key) {
+              case "ArrowDown":
+                event.preventDefault();
+                moveFlyoutFocus(target, 1, null);
+                return;
+              case "ArrowUp":
+                event.preventDefault();
+                moveFlyoutFocus(target, -1, null);
+                return;
+              case "Home":
+                event.preventDefault();
+                moveFlyoutFocus(null, 0, "first");
+                return;
+              case "End":
+                event.preventDefault();
+                moveFlyoutFocus(null, 0, "last");
+                return;
+              case "ArrowLeft":
+              case "Escape":
+                event.preventDefault();
+                event.stopPropagation();
+                flyoutAnchorRefs.current.get(openFlyout!)?.querySelector<HTMLButtonElement>("[data-operation-launch-kind]")?.focus();
+                closeFlyout();
+                return;
+              default:
+            }
           }}
         >
           {flyoutTarget.kind.variants!.map((group, groupIndex) => (

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -37,8 +37,9 @@ interface OperationsCanvasProps {
   readonly catalog: readonly OperationCatalogPlugin[];
   readonly canLaunch: boolean;
   readonly renderKindIcon: (pluginId: string, kind: OperationLaunchKind) => ReactNode;
-  readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind, canvasPoint: CanvasPoint, theaterId?: string) => void;
+  readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind, canvasPoint: CanvasPoint, theaterId?: string, variant?: Readonly<Record<string, string>>) => void;
   readonly onLaunchAtGeometry: (pluginId: string, kind: OperationLaunchKind, geometry: OperationGeometry) => void;
+  readonly onRefreshCatalog?: () => void;
   readonly onClose: (operationId: string) => void;
   readonly onFocus: (operationId: string) => void;
   readonly onRename: (operationId: string, title: string) => void;
@@ -86,6 +87,7 @@ export function OperationsCanvas({
   renderKindIcon,
   onLaunchKind,
   onLaunchAtGeometry,
+  onRefreshCatalog,
   onClose,
   onFocus,
   onRename,
@@ -246,13 +248,17 @@ export function OperationsCanvas({
     onClick: clearTerminalFocus,
   });
 
-  const handleContextMenuLaunchKind = (pluginId: string, kind: OperationLaunchKind) => {
+  const handleContextMenuLaunchKind = (
+    pluginId: string,
+    kind: OperationLaunchKind,
+    variant?: Readonly<Record<string, string>>,
+  ) => {
     const request = contextMenu;
     setContextMenu(null);
     if (!request) return;
     // War Room의 소유 영역 launch도 페이지가 소유한 기존 plugin launch 경로를 그대로 탄다.
     // theaterId가 없으면 Cruise의 활성 Theater 경로이고, 있으면 소유 영역이 명시한 Theater다.
-    onLaunchKind(pluginId, kind, request.canvasPoint, request.theaterId);
+    onLaunchKind(pluginId, kind, request.canvasPoint, request.theaterId, variant);
   };
 
   const handleContextMenu = (event: ReactMouseEvent<HTMLElement>) => {
@@ -284,6 +290,7 @@ export function OperationsCanvas({
     const anchor = rect ? { x: event.clientX - rect.left, y: event.clientY - rect.top } : null;
     if (!anchor) return;
     setContextMenu({ anchor, canvasPoint: screenToCanvas(anchor, canvas.viewport) });
+    onRefreshCatalog?.();
   };
 
   const openTriageTheaterLaunchMenu = (theaterId: string, theaterLabel: string, cursor: CanvasPoint) => {
@@ -304,6 +311,7 @@ export function OperationsCanvas({
       theaterId,
       theaterLabel,
     });
+    onRefreshCatalog?.();
   };
 
   const minimizedSet = new Set(minimized);

--- a/runtime/fleet-console/core/client/src/i18n/messages/common.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/common.ts
@@ -61,6 +61,8 @@ export const commonEn = {
   "launchKind.claudeNative.brief": "No Admiral",
   "launchKind.claude.brief": "Admiral + Carriers",
   "launchKind.claudeGateway.brief": "Other models",
+  "launchVariants.group.native": "Claude built-in",
+  "launchVariants.group.gateway": "Gateway — models you enabled",
 } as const;
 
 export const commonKo: Record<keyof typeof commonEn, string> = {
@@ -124,4 +126,6 @@ export const commonKo: Record<keyof typeof commonEn, string> = {
   "launchKind.claudeNative.brief": "Admiral 없이",
   "launchKind.claude.brief": "Admiral + Carrier",
   "launchKind.claudeGateway.brief": "다른 모델",
+  "launchVariants.group.native": "Claude 내장",
+  "launchVariants.group.gateway": "Gateway — 설정에서 켠 모델",
 };

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -72,7 +72,17 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
   const stateRef = useRef(state);
   const triageMenuReturnFocusRef = useRef<HTMLElement | null>(null);
   const focusRequestEpochRef = useRef(0);
+  const catalogRequestEpochRef = useRef(0);
   stateRef.current = state;
+
+  const refreshCatalog = useCallback(() => {
+    const epoch = ++catalogRequestEpochRef.current;
+    void fetchOperationCatalog()
+      .then((nextCatalog) => {
+        if (catalogRequestEpochRef.current === epoch) setCatalog(nextCatalog);
+      })
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     loadForTheater(state.activeTheaterId);
@@ -87,9 +97,14 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
   }, [triageActive]);
 
   useEffect(() => {
-    if (!state.activeTheaterId) { setCatalog([]); return; }
-    void fetchOperationCatalog().then(setCatalog).catch(() => {});
-  }, [state.activeTheaterId]);
+    if (!state.activeTheaterId) {
+      catalogRequestEpochRef.current += 1;
+      setCatalog([]);
+      return;
+    }
+    refreshCatalog();
+    return () => { catalogRequestEpochRef.current += 1; };
+  }, [refreshCatalog, state.activeTheaterId]);
 
   // Alt+화살표는 캔버스 배치 순서와 패널 문법을 공유하고, Alt+F/Alt+S는 같은 capture/editable 가드 정책을 따른다.
   useEffect(() => {
@@ -308,20 +323,30 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
     return plugin?.renderLaunchIcon?.(kind) ?? null;
   }, [registry.plugins]);
 
-  const handleCanvasLaunchKind = useCallback((pluginId: string, kind: OperationLaunchKind, canvasPoint: CanvasPoint, theaterId?: string) => {
+  const handleCanvasLaunchKind = useCallback((
+    pluginId: string,
+    kind: OperationLaunchKind,
+    canvasPoint: CanvasPoint,
+    theaterId?: string,
+    variant?: Readonly<Record<string, string>>,
+  ) => {
     const launchTheaterId = theaterId ?? stateRef.current.activeTheaterId;
     if (!launchTheaterId) return;
     // Station Keeping이 켜진 Theater의 생성 좌표는 전부 정착을 거친다 — 어느 진입 경로든 같은 규율.
     const geometry = resolveLaunchGeometry(launchTheaterId, { ...canvasPointToGeometry(canvasPoint), zIndex: claimTopZIndex() });
-    void launchViaPlugin(pluginId, kind, geometry, launchTheaterId, registry.plugins);
+    void launchViaPlugin(pluginId, kind, geometry, launchTheaterId, registry.plugins, variant);
   }, [registry.plugins]);
 
-  const handleSideBarLaunchKind = useCallback((pluginId: string, kind: OperationLaunchKind) => {
+  const handleSideBarLaunchKind = useCallback((
+    pluginId: string,
+    kind: OperationLaunchKind,
+    variant?: Readonly<Record<string, string>>,
+  ) => {
     const launchTheaterId = stateRef.current.activeTheaterId;
     if (!launchTheaterId) return;
     const canvasPoint = canvasCenterPoint(bodyRef.current);
     const geometry = resolveLaunchGeometry(launchTheaterId, { ...canvasPointToGeometry(canvasPoint), zIndex: claimTopZIndex() });
-    void launchViaPlugin(pluginId, kind, geometry, launchTheaterId, registry.plugins);
+    void launchViaPlugin(pluginId, kind, geometry, launchTheaterId, registry.plugins, variant);
   }, [registry.plugins]);
 
   const handleLaunchAtGeometry = useCallback((pluginId: string, kind: OperationLaunchKind, geometry: OperationGeometry) => {
@@ -583,6 +608,7 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
           renderKindIcon={renderKindIcon}
           onLaunchKind={handleCanvasLaunchKind}
           onLaunchAtGeometry={handleLaunchAtGeometry}
+          onRefreshCatalog={refreshCatalog}
           onClose={handleClose}
           onFocus={handleFocus}
           onRename={handleRename}
@@ -735,13 +761,14 @@ async function launchViaPlugin(
   geometry: OperationGeometry,
   theaterId: string,
   plugins: readonly FleetClientPlugin[],
+  variant?: Readonly<Record<string, string>>,
 ): Promise<void> {
   const plugin = plugins.find((p) => p.id === pluginId);
   const resync = () => { void fetchOperations(null).then(hydrateOperations).catch(() => {}); };
   const capabilities = createHostCapabilities(resync);
   let newOperationId: string | null = null;
   if (plugin?.launch) {
-    const result = await plugin.launch({ theaterId, kind, geometry, operations: capabilities.operations });
+    const result = await plugin.launch({ theaterId, kind, geometry, operations: capabilities.operations, variant });
     newOperationId = result.id;
   } else {
     const operation = await capabilities.operations.create({

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -56,7 +56,7 @@ interface OperationsSideBarProps {
   readonly addingTheater: boolean;
   readonly theaterError: string | null;
   readonly renderKindIcon: (pluginId: string, kind: OperationLaunchKind) => ReactNode;
-  readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind) => void;
+  readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind, variantLaunch?: Readonly<Record<string, string>>) => void;
   readonly onClose: (operationId: string) => void;
   readonly onMinimize: (operationId: string) => void;
   readonly onFocus: (operationId: string) => void;
@@ -1090,7 +1090,7 @@ export function OperationsSideBar({
           catalog={catalog}
           canLaunch={canLaunch}
           renderKindIcon={renderKindIcon}
-          onLaunchKind={(pluginId, kind) => { setNewMenu(null); onLaunchKind(pluginId, kind); }}
+          onLaunchKind={(pluginId, kind, variantLaunch) => { setNewMenu(null); onLaunchKind(pluginId, kind, variantLaunch); }}
           onClose={() => setNewMenu(null)}
         />,
         document.body,

--- a/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
@@ -53,7 +53,7 @@ interface TriageSideBarProps {
   readonly canLaunch: boolean;
   /** 소유자 없는 자리의 실행 대상 — 사이드바 빈 영역은 활성 Theater로 실행한다. */
   readonly activeTheaterLabel?: string;
-  readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind) => void;
+  readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind, variantLaunch?: Readonly<Record<string, string>>) => void;
   readonly onPick: (operationId: string) => void;
   readonly onClose: (operationId: string) => void;
   readonly onRename: (operationId: string, title: string) => void;
@@ -211,7 +211,7 @@ export function TriageSideBar({
           catalog={catalog}
           canLaunch={canLaunch}
           renderKindIcon={renderKindIcon}
-          onLaunchKind={(pluginId, kind) => { setLaunchMenu(null); onLaunchKind(pluginId, kind); }}
+          onLaunchKind={(pluginId, kind, variantLaunch) => { setLaunchMenu(null); onLaunchKind(pluginId, kind, variantLaunch); }}
           onClose={() => setLaunchMenu(null)}
           theaterLabel={activeTheaterLabel}
         />,

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -6473,6 +6473,131 @@
   white-space: nowrap;
 }
 
+.operation-launch-menu-item-wrap {
+  position: relative;
+}
+
+.operation-launch-menu-item-wrap > .operation-launch-menu-item {
+  width: 100%;
+}
+
+.operation-launch-menu-chevron {
+  flex: none;
+  margin-left: auto;
+  color: var(--text-tertiary);
+  font-size: 16px;
+  line-height: 1;
+}
+
+.operation-launch-menu-item--annotated.operation-launch-menu-item--variants {
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+}
+
+.operation-launch-menu-item--annotated .operation-launch-menu-chevron {
+  grid-column: 4;
+  grid-row: 1;
+  margin-left: 0;
+}
+
+.operation-launch-flyout.theater-menu {
+  --flyout-enter-x: -4px;
+  top: -6px;
+  left: calc(100% + 10px);
+  right: auto;
+  z-index: 41;
+  width: 324px;
+  max-height: var(--canvas-menu-max-height, 520px);
+  overflow-y: auto;
+  animation: operation-launch-flyout-in var(--duration-fast) var(--ease-spring) both;
+}
+
+.operation-launch-flyout.theater-menu.is-left {
+  --flyout-enter-x: 4px;
+}
+
+.operation-launch-variant-caption {
+  margin: 0;
+  padding: var(--space-1) var(--space-2);
+  color: color-mix(in oklch, var(--brass) 72%, var(--text-tertiary));
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.operation-launch-variant-entry {
+  display: grid;
+  gap: 3px;
+  padding: 2px var(--space-1) 5px;
+}
+
+.operation-launch-variant-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: 4px var(--space-1);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-align: left;
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring);
+}
+
+.operation-launch-variant-row:hover,
+.operation-launch-variant-row:focus-visible {
+  background: color-mix(in oklch, var(--brass) 8%, transparent);
+  color: var(--text-primary);
+  outline: none;
+}
+
+.operation-launch-variant-star {
+  margin-left: auto;
+  color: var(--brass);
+  font-size: 9.5px;
+}
+
+.operation-launch-variant-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 0 var(--space-1);
+}
+
+.operation-launch-variant-chip {
+  padding: 3px 6px;
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition:
+    color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring);
+}
+
+.operation-launch-variant-chip:hover,
+.operation-launch-variant-chip:focus-visible {
+  border-color: color-mix(in oklch, var(--brass) 38%, var(--surface-rim));
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  color: var(--text-primary);
+  outline: none;
+}
+
+@keyframes operation-launch-flyout-in {
+  from { opacity: 0; transform: translateX(var(--flyout-enter-x)); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
 .theater-menu-error {
   margin: var(--space-1) 0 0;
   padding: var(--space-1) var(--space-2);
@@ -8929,6 +9054,13 @@ body[data-codex-side="true"] .command-card {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .operation-launch-flyout,
+  .operation-launch-variant-row,
+  .operation-launch-variant-chip {
+    animation: none;
+    transition: none;
+  }
+
   .codex-side-panel {
     animation: none;
   }

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import { createInfraServices, ensureWorkspaceDirectory, getFleetDataDir, withDirectoryLock } from "@dotobokuri/core-infra";
 import { createWikiWorkspaceResolver } from "@dotobokuri/fleet-wiki";
+import { readLaunchVariantGroups } from "@fleet-console/sdk/operations/launch-variants";
 
 import { buildApiCatalog, type ApiCatalogEntry } from "./api-catalog.js";
 import type { ConsoleEnvironmentDiagnostics, ConsoleHealth, ConsoleObserverStatus, ConsoleTheaterFolderListResponse, ConsoleTheaterInfo, ConsoleUpdateApplyAcceptedResponse, ConsoleUpdateApplyError } from "./console-contract-types.js";
@@ -1428,12 +1429,14 @@ function isValidConsoleStaticPort(value: unknown): value is number {
 
 function sanitizeLaunchKind(value: unknown): OperationLaunchKind | null {
   if (!isPlainObject(value) || typeof value.id !== "string" || typeof value.type !== "string" || typeof value.title !== "string") return null;
+  const variants = readLaunchVariantGroups(value.variants);
   return {
     id: value.id,
     type: value.type,
     title: value.title,
     ...(typeof value.disabled === "boolean" ? { disabled: value.disabled } : {}),
     ...(typeof value.disabledReason === "string" ? { disabledReason: value.disabledReason } : {}),
+    ...(variants.length > 0 ? { variants } : {}),
   };
 }
 

--- a/runtime/fleet-console/sdk/operations/browser.tsx
+++ b/runtime/fleet-console/sdk/operations/browser.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { readLaunchVariantGroups } from "./launch-variants.js";
 import type { OperationCatalogPlugin, OperationLaunchKind, OperationNode } from "./types.js";
 
 export interface OperationBodyProps {
@@ -65,12 +66,14 @@ function readCatalogPlugin(value: unknown): OperationCatalogPlugin | null {
 
 function readLaunchKind(value: unknown): OperationLaunchKind | null {
   if (!isRecord(value) || typeof value.id !== "string" || typeof value.type !== "string" || typeof value.title !== "string") return null;
+  const variants = readLaunchVariantGroups(value.variants);
   return {
     id: value.id,
     type: value.type,
     title: value.title,
     ...(typeof value.disabled === "boolean" ? { disabled: value.disabled } : {}),
     ...(typeof value.disabledReason === "string" ? { disabledReason: value.disabledReason } : {}),
+    ...(variants.length > 0 ? { variants } : {}),
   };
 }
 

--- a/runtime/fleet-console/sdk/operations/launch-variants.ts
+++ b/runtime/fleet-console/sdk/operations/launch-variants.ts
@@ -1,0 +1,56 @@
+import type {
+  OperationLaunchVariantChip,
+  OperationLaunchVariantGroup,
+  OperationLaunchVariantRow,
+} from "./types.js";
+
+export function readLaunchVariantGroups(value: unknown): readonly OperationLaunchVariantGroup[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map(readLaunchVariantGroup)
+    .filter((group): group is OperationLaunchVariantGroup => group !== null);
+}
+
+function readLaunchVariantGroup(value: unknown): OperationLaunchVariantGroup | null {
+  if (!isRecord(value) || typeof value.id !== "string" || typeof value.label !== "string" || !Array.isArray(value.rows)) return null;
+  const rows = value.rows.map(readLaunchVariantRow).filter((row): row is OperationLaunchVariantRow => row !== null);
+  return rows.length > 0 ? { id: value.id, label: value.label, rows } : null;
+}
+
+function readLaunchVariantRow(value: unknown): OperationLaunchVariantRow | null {
+  if (!isRecord(value) || typeof value.id !== "string" || typeof value.label !== "string") return null;
+  const launch = readLaunchPayload(value.launch);
+  if (!launch) return null;
+  const chips = Array.isArray(value.chips)
+    ? value.chips.map(readLaunchVariantChip).filter((chip): chip is OperationLaunchVariantChip => chip !== null)
+    : [];
+  return {
+    id: value.id,
+    label: value.label,
+    ...(typeof value.starred === "boolean" ? { starred: value.starred } : {}),
+    launch,
+    ...(chips.length > 0 ? { chips } : {}),
+  };
+}
+
+function readLaunchVariantChip(value: unknown): OperationLaunchVariantChip | null {
+  if (!isRecord(value) || typeof value.id !== "string" || typeof value.label !== "string") return null;
+  const launch = readLaunchPayload(value.launch);
+  return launch ? { id: value.id, label: value.label, launch } : null;
+}
+
+function readLaunchPayload(value: unknown): Readonly<Record<string, string>> | null {
+  if (!isPlainRecord(value)) return null;
+  const launch = Object.fromEntries(Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === "string"));
+  return Object.keys(launch).length > 0 ? launch : null;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/runtime/fleet-console/sdk/operations/types.ts
+++ b/runtime/fleet-console/sdk/operations/types.ts
@@ -40,12 +40,33 @@ export interface OperationPatchInput {
   readonly payload?: Record<string, unknown>;
 }
 
+export interface OperationLaunchVariantChip {
+  readonly id: string;
+  readonly label: string;
+  readonly launch: Readonly<Record<string, string>>;
+}
+
+export interface OperationLaunchVariantRow {
+  readonly id: string;
+  readonly label: string;
+  readonly starred?: boolean;
+  readonly launch: Readonly<Record<string, string>>;
+  readonly chips?: readonly OperationLaunchVariantChip[];
+}
+
+export interface OperationLaunchVariantGroup {
+  readonly id: string;
+  readonly label: string;
+  readonly rows: readonly OperationLaunchVariantRow[];
+}
+
 export interface OperationLaunchKind {
   readonly id: string;
   readonly type: string;
   readonly title: string;
   readonly disabled?: boolean;
   readonly disabledReason?: string;
+  readonly variants?: readonly OperationLaunchVariantGroup[];
 }
 
 export interface OperationCatalogPlugin {

--- a/runtime/fleet-console/sdk/package.json
+++ b/runtime/fleet-console/sdk/package.json
@@ -15,6 +15,11 @@
       "import": "./operations/browser.tsx",
       "default": "./operations/browser.tsx"
     },
+    "./operations/launch-variants": {
+      "types": "./operations/launch-variants.ts",
+      "import": "./operations/launch-variants.ts",
+      "default": "./operations/launch-variants.ts"
+    },
     "./version": {
       "types": "./version.ts",
       "import": "./version.ts",

--- a/runtime/fleet-console/sdk/plugin/types.ts
+++ b/runtime/fleet-console/sdk/plugin/types.ts
@@ -15,6 +15,7 @@ export interface LaunchContext {
   readonly kind: OperationLaunchKind;
   readonly geometry: OperationGeometry;
   readonly operations: ClientOperationsCapability;
+  readonly variant?: Readonly<Record<string, string>>;
 }
 
 export type ConsoleTheme = "instrument" | "maritime" | "carbon" | "whites";

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -451,7 +451,7 @@ describe("CanvasContextMenu launch kind attribute", () => {
     expect(top).toBeLessThanOrEqual(bounds.height - 300 - 12);
   });
 
-  it("opens and focuses the first variant with ArrowRight, then restores parent focus", async () => {
+  it("roves across flyout rows and chips, then restores parent focus with ArrowLeft", async () => {
     renderMenu({ x: 900, y: 156 }, { width: 1116, height: 856 }, gatewayVariantCatalog());
     const parent = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!;
 
@@ -464,12 +464,28 @@ describe("CanvasContextMenu launch kind attribute", () => {
     });
 
     const flyout = document.querySelector<HTMLElement>(".operation-launch-flyout")!;
+    const row = document.querySelector<HTMLButtonElement>('[data-launch-variant-row="fable"]')!;
+    const high = document.querySelector<HTMLButtonElement>('[data-launch-variant-chip="fable:high"]')!;
+    const max = document.querySelector<HTMLButtonElement>('[data-launch-variant-chip="fable:max"]')!;
     expect(flyout.parentElement).toBe(document.querySelector(".operation-launch-control--canvas"));
     expect(flyout.closest(".canvas-context-menu")).toBeNull();
     expect(flyout.classList.contains("is-left")).toBe(true);
-    expect(document.activeElement).toBe(document.querySelector('[data-launch-variant-row="fable"]'));
+    expect(document.activeElement).toBe(row);
 
-    act(() => flyout.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true })));
+    pressFlyoutKey("ArrowDown");
+    expect(document.activeElement).toBe(high);
+    pressFlyoutKey("ArrowDown");
+    expect(document.activeElement).toBe(max);
+    pressFlyoutKey("ArrowDown");
+    expect(document.activeElement).toBe(row);
+    pressFlyoutKey("ArrowUp");
+    expect(document.activeElement).toBe(max);
+    pressFlyoutKey("Home");
+    expect(document.activeElement).toBe(row);
+    pressFlyoutKey("End");
+    expect(document.activeElement).toBe(max);
+
+    pressFlyoutKey("ArrowLeft");
     expect(document.querySelector(".operation-launch-flyout")).toBeNull();
     expect(document.activeElement).toBe(parent);
   });
@@ -583,15 +599,26 @@ function gatewayVariantCatalog(): readonly OperationCatalogPlugin[] {
           id: "fable",
           label: "Fable",
           launch: { model: "fable" },
-          chips: [{
-            id: "max",
-            label: "MAX",
-            launch: { model: "fable", effort: "max" },
-          }],
+          chips: [
+            {
+              id: "high",
+              label: "HIGH",
+              launch: { model: "fable", effort: "high" },
+            },
+            {
+              id: "max",
+              label: "MAX",
+              launch: { model: "fable", effort: "max" },
+            },
+          ],
         }],
       }],
     }],
   }];
+}
+
+function pressFlyoutKey(key: string): void {
+  act(() => document.activeElement!.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true })));
 }
 
 function menuStyle(): CSSStyleDeclaration {

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -24,6 +24,9 @@ beforeEach(() => {
     if (this.classList.contains("canvas-context-menu")) {
       return { ...originalGetBoundingClientRect.call(this), width: 288, height: 133 } as DOMRect;
     }
+    if (this.classList.contains("operation-launch-flyout")) {
+      return { ...originalGetBoundingClientRect.call(this), width: 324, height: 300 } as DOMRect;
+    }
     return originalGetBoundingClientRect.call(this);
   };
   container = document.createElement("div");
@@ -404,6 +407,103 @@ describe("CanvasContextMenu launch kind attribute", () => {
     }
   });
 
+  it("opens launch variants on pointer, suppresses the description aside, and preserves every payload", () => {
+    const onLaunchKind = vi.fn();
+    const catalog = gatewayVariantCatalog();
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, catalog, vi.fn(), false, onLaunchKind);
+
+    const parent = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!;
+    expect(parent.getAttribute("aria-haspopup")).toBe("menu");
+    expect(parent.getAttribute("aria-expanded")).toBe("false");
+    expect(parent.querySelector(".operation-launch-menu-chevron")?.textContent).toBe("›");
+
+    act(() => {
+      parent.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      parent.parentElement!.dispatchEvent(new MouseEvent("pointerover", { bubbles: true }));
+    });
+    expect(parent.getAttribute("aria-expanded")).toBe("true");
+    expect(document.querySelector(".operation-launch-variant-caption")?.textContent).toBe("Claude built-in");
+    expect(document.querySelector(".canvas-context-menu-aside")).toBeNull();
+
+    const row = document.querySelector<HTMLButtonElement>('[data-launch-variant-row="fable"]')!;
+    const chip = document.querySelector<HTMLButtonElement>('[data-launch-variant-chip="fable:max"]')!;
+    act(() => row.click());
+    expect(onLaunchKind).toHaveBeenLastCalledWith("terminal", catalog[0]!.kinds[0], { model: "fable" });
+    act(() => chip.click());
+    expect(onLaunchKind).toHaveBeenLastCalledWith("terminal", catalog[0]!.kinds[0], { model: "fable", effort: "max" });
+    act(() => parent.click());
+    expect(onLaunchKind).toHaveBeenLastCalledWith("terminal", catalog[0]!.kinds[0]);
+  });
+
+  it("clamps the flyout inside narrow horizontal and vertical bounds", () => {
+    const bounds = { width: 500, height: 360 };
+    renderMenu({ x: 450, y: 320 }, bounds, gatewayVariantCatalog());
+    const parent = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!;
+
+    act(() => parent.parentElement!.dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
+
+    const flyout = document.querySelector<HTMLElement>(".operation-launch-flyout")!;
+    const left = Number.parseFloat(flyout.style.left);
+    const top = Number.parseFloat(flyout.style.top);
+    expect(left).toBeGreaterThanOrEqual(12);
+    expect(left).toBeLessThanOrEqual(bounds.width - 324 - 12);
+    expect(top).toBeGreaterThanOrEqual(12);
+    expect(top).toBeLessThanOrEqual(bounds.height - 300 - 12);
+  });
+
+  it("opens and focuses the first variant with ArrowRight, then restores parent focus", async () => {
+    renderMenu({ x: 900, y: 156 }, { width: 1116, height: 856 }, gatewayVariantCatalog());
+    const parent = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!;
+
+    act(() => {
+      parent.focus();
+      parent.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    });
+    await act(async () => {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
+
+    const flyout = document.querySelector<HTMLElement>(".operation-launch-flyout")!;
+    expect(flyout.parentElement).toBe(document.querySelector(".operation-launch-control--canvas"));
+    expect(flyout.closest(".canvas-context-menu")).toBeNull();
+    expect(flyout.classList.contains("is-left")).toBe(true);
+    expect(document.activeElement).toBe(document.querySelector('[data-launch-variant-row="fable"]'));
+
+    act(() => flyout.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true })));
+    expect(document.querySelector(".operation-launch-flyout")).toBeNull();
+    expect(document.activeElement).toBe(parent);
+  });
+
+  it("closes only the flyout on Escape", () => {
+    const onClose = vi.fn();
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, gatewayVariantCatalog(), onClose);
+    const parent = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!;
+    act(() => parent.parentElement!.dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
+    const flyout = document.querySelector<HTMLElement>(".operation-launch-flyout")!;
+
+    act(() => flyout.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })));
+
+    expect(document.querySelector(".operation-launch-flyout")).toBeNull();
+    expect(document.activeElement).toBe(parent);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("leaves kinds without variants on the existing direct-launch path", () => {
+    const onLaunchKind = vi.fn();
+    const catalog: readonly OperationCatalogPlugin[] = [{
+      id: "terminal",
+      title: "Terminal",
+      kinds: [{ id: "shell", type: "shell", title: "Shell" }],
+    }];
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, catalog, vi.fn(), false, onLaunchKind);
+
+    const shell = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="shell"]')!;
+    expect(shell.hasAttribute("aria-haspopup")).toBe(false);
+    expect(shell.querySelector(".operation-launch-menu-chevron")).toBeNull();
+    act(() => shell.click());
+    expect(onLaunchKind).toHaveBeenCalledWith("terminal", catalog[0]!.kinds[0]);
+  });
+
   it("marks the rendered menu box as the tour placement boundary", () => {
     renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 });
 
@@ -452,6 +552,7 @@ function renderMenu(
   catalog: readonly OperationCatalogPlugin[] = [],
   onClose = vi.fn(),
   fixed = false,
+  onLaunchKind = vi.fn(),
 ): void {
   act(() => root.render(
     <CanvasContextMenu
@@ -461,10 +562,36 @@ function renderMenu(
       catalog={catalog}
       canLaunch
       renderKindIcon={() => null}
-      onLaunchKind={vi.fn()}
+      onLaunchKind={onLaunchKind}
       onClose={onClose}
     />,
   ));
+}
+
+function gatewayVariantCatalog(): readonly OperationCatalogPlugin[] {
+  return [{
+    id: "terminal",
+    title: "Terminal",
+    kinds: [{
+      id: "claude-gateway",
+      type: "agent",
+      title: "Claude (Gateway)",
+      variants: [{
+        id: "native",
+        label: "Claude",
+        rows: [{
+          id: "fable",
+          label: "Fable",
+          launch: { model: "fable" },
+          chips: [{
+            id: "max",
+            label: "MAX",
+            launch: { model: "fable", effort: "max" },
+          }],
+        }],
+      }],
+    }],
+  }];
 }
 
 function menuStyle(): CSSStyleDeclaration {

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -94,7 +94,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
       messagePolicy: { bracketedPaste: true, multilineStrategy: "paste-mode" },
       terminalName: "xterm-256color",
     });
-    expect(resolveProfile).toHaveBeenCalledWith(expect.any(Object), "/work/project", expect.objectContaining({ cliId: undefined }));
+    expect(resolveProfile).toHaveBeenCalledWith(expect.any(Object), "/work/project", expect.objectContaining({ cliId: "claude" }));
     expect(injectProfile).toHaveBeenCalledTimes(1);
     expect(events).toEqual([]);
   });
@@ -178,6 +178,135 @@ describe("createDefaultTerminalLaunchResolver", () => {
     await resolve("/work", { sessionId: "session-standard-admiral", cliId: "claude" });
     expect(sharedResolveProfile).toHaveBeenCalledTimes(2);
     expect(sharedInjectProfile).toHaveBeenCalledTimes(2);
+  });
+
+  it("launches gateway variants with native aliases or converted scoped model ids", async () => {
+    const root = makeTempDir("fleet-gateway-launch-variant-");
+    const settings = {
+      version: 1 as const,
+      models: [{ id: "cursor--claude-opus-5" }],
+      defaultModel: "cursor--claude-opus-5",
+    };
+    const resolve = createDefaultTerminalLaunchResolver({
+      cwd: root,
+      dataDir: root,
+      env: {
+        CLAUDE_BIN: process.execPath,
+        CLAUDE_CONFIG_DIR: path.join(root, "claude-config"),
+        PATH: process.env.PATH,
+      },
+      agentRuntime: createFakeRuntime() as never,
+      aiGateway: {
+        routePath: "/plugins/terminal/ai-gateway",
+        origin: () => "http://127.0.0.1:43210",
+      },
+      infraServices: createFakeInfraServices() as never,
+      injectProfile: (async (profile: AgentCliProfile) => profile) as never,
+      createSessionIdentityResolver: (() => ({ resolve: async () => null })) as never,
+      readAiGatewaySettings: () => settings,
+    });
+
+    const native = await resolve(root, {
+      cliId: "claude-gateway",
+      model: "fable",
+      effort: "max",
+      sessionId: "gateway-native-variant",
+    });
+    const scoped = await resolve(root, {
+      cliId: "claude-gateway",
+      model: "cursor--claude-opus-5",
+      effort: "xhigh",
+      sessionId: "gateway-scoped-variant",
+    });
+    const rowOnly = await resolve(root, {
+      cliId: "claude-gateway",
+      model: "cursor--claude-opus-5",
+      sessionId: "gateway-scoped-row",
+    });
+
+    expect(native.args).toEqual(["--model", "fable", "--effort", "max"]);
+    expect(scoped.args).toEqual([
+      "--model",
+      "claude-gateway--cursor--claude-opus-5[1m]",
+      "--effort",
+      "xhigh",
+    ]);
+    expect(rowOnly.args).toEqual([
+      "--model",
+      "claude-gateway--cursor--claude-opus-5[1m]",
+    ]);
+    expect(rowOnly.args).not.toContain("--effort");
+    for (const spec of [native, scoped, rowOnly]) {
+      expect(spec.env.ANTHROPIC_MODEL).toBe("claude-gateway--cursor--claude-opus-5[1m]");
+      expect(spec.env.CLAUDE_CODE_EFFORT_LEVEL).toBeUndefined();
+      await spec.cleanup?.();
+    }
+  });
+
+  it("rejects a scoped gateway model that became stale before spawn", async () => {
+    const root = makeTempDir("fleet-gateway-stale-model-");
+    const resolve = createDefaultTerminalLaunchResolver({
+      cwd: root,
+      dataDir: root,
+      env: {
+        CLAUDE_BIN: process.execPath,
+        CLAUDE_CONFIG_DIR: path.join(root, "claude-config"),
+        PATH: process.env.PATH,
+      },
+      agentRuntime: createFakeRuntime() as never,
+      aiGateway: {
+        routePath: "/plugins/terminal/ai-gateway",
+        origin: () => "http://127.0.0.1:43210",
+      },
+      infraServices: createFakeInfraServices() as never,
+      injectProfile: (async (profile: AgentCliProfile) => profile) as never,
+      createSessionIdentityResolver: (() => ({ resolve: async () => null })) as never,
+      readAiGatewaySettings: () => ({ version: 1 }),
+    });
+
+    await expect(resolve(root, {
+      cliId: "claude-gateway",
+      model: "kimi--k3",
+      sessionId: "gateway-stale-model",
+    })).rejects.toMatchObject({
+      name: "GatewayLaunchOptionError",
+      code: "gateway_model_not_enabled",
+    });
+  });
+
+  it("rejects a scoped gateway effort that became stale before spawn", async () => {
+    const root = makeTempDir("fleet-gateway-stale-effort-");
+    const resolve = createDefaultTerminalLaunchResolver({
+      cwd: root,
+      dataDir: root,
+      env: {
+        CLAUDE_BIN: process.execPath,
+        CLAUDE_CONFIG_DIR: path.join(root, "claude-config"),
+        PATH: process.env.PATH,
+      },
+      agentRuntime: createFakeRuntime() as never,
+      aiGateway: {
+        routePath: "/plugins/terminal/ai-gateway",
+        origin: () => "http://127.0.0.1:43210",
+      },
+      infraServices: createFakeInfraServices() as never,
+      injectProfile: (async (profile: AgentCliProfile) => profile) as never,
+      createSessionIdentityResolver: (() => ({ resolve: async () => null })) as never,
+      readAiGatewaySettings: () => ({
+        version: 1,
+        models: [{ id: "kimi--k3", efforts: ["max"] }],
+      }),
+    });
+
+    await expect(resolve(root, {
+      cliId: "claude-gateway",
+      model: "kimi--k3",
+      effort: "high",
+      sessionId: "gateway-stale-effort",
+    })).rejects.toMatchObject({
+      name: "GatewayLaunchOptionError",
+      code: "invalid_effort",
+    });
   });
 
   it("launches claude-gateway through the real shared Admiral package", async () => {

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -3,6 +3,8 @@
 import { act, createElement, Fragment, useLayoutEffect, type ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import type { OperationCatalogPlugin } from "@fleet-console/sdk/operations";
+import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 import type { OperationKindDescriptor } from "@fleet-console/sdk/plugin";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -28,8 +30,10 @@ const sideBarMocks = vi.hoisted(() => ({
   onMinimize: null as null | ((operationId: string) => void),
 }));
 const canvasMocks = vi.hoisted(() => ({
+  catalog: [] as readonly OperationCatalogPlugin[],
   onMount: null as null | (() => void | (() => void)),
   onLaunchAtGeometry: null as null | ((pluginId: string, kind: { readonly type: string; readonly title: string }, geometry: { readonly x: number; readonly y: number; readonly width: number; readonly height: number; readonly zIndex: number }) => void),
+  onRefreshCatalog: null as null | (() => void),
 }));
 const registryMocks = vi.hoisted(() => ({
   plugins: [] as Array<Record<string, unknown>>,
@@ -59,8 +63,14 @@ vi.mock("../core/client/src/api.js", () => ({
 
 vi.mock("@fleet-console/sdk/operations/browser", () => ({ fetchOperationCatalog: vi.fn().mockResolvedValue([]) }));
 vi.mock("../core/client/src/canvas/canvas.js", () => ({
-  OperationsCanvas: ({ onLaunchAtGeometry }: { readonly onLaunchAtGeometry: NonNullable<typeof canvasMocks.onLaunchAtGeometry> }) => {
+  OperationsCanvas: ({ catalog, onLaunchAtGeometry, onRefreshCatalog }: {
+    readonly catalog: readonly OperationCatalogPlugin[];
+    readonly onLaunchAtGeometry: NonNullable<typeof canvasMocks.onLaunchAtGeometry>;
+    readonly onRefreshCatalog: () => void;
+  }) => {
+    canvasMocks.catalog = catalog;
     canvasMocks.onLaunchAtGeometry = onLaunchAtGeometry;
+    canvasMocks.onRefreshCatalog = onRefreshCatalog;
     useLayoutEffect(() => canvasMocks.onMount?.(), []);
     return null;
   },
@@ -142,8 +152,11 @@ beforeEach(() => {
   sideBarMocks.onFocus = null;
   sideBarMocks.onClose = null;
   sideBarMocks.onMinimize = null;
+  canvasMocks.catalog = [];
   canvasMocks.onMount = null;
   canvasMocks.onLaunchAtGeometry = null;
+  canvasMocks.onRefreshCatalog = null;
+  vi.mocked(fetchOperationCatalog).mockReset().mockResolvedValue([]);
   registryMocks.plugins = [];
   registryMocks.operationKinds = [];
   // 선별 처리는 Theater가 아니라 전역 축이라, Theater 단위 reset만으로는 꺼지지 않는다.
@@ -1063,6 +1076,29 @@ describe("Operations boot minimization", () => {
     expect(getState().activeTheaterId).toBe("theater-b");
     expect(getTheaterCompanionOperationId("theater-a")).toBe("first");
     expect(getCompanionOperationId()).toBeNull();
+  });
+
+  it("keeps a newer catalog refresh when an older request resolves last", async () => {
+    const stale = deferred<readonly OperationCatalogPlugin[]>();
+    const fresh = deferred<readonly OperationCatalogPlugin[]>();
+    vi.mocked(fetchOperationCatalog)
+      .mockReturnValueOnce(stale.promise)
+      .mockReturnValueOnce(fresh.promise);
+    await bootApp([]);
+    expect(canvasMocks.onRefreshCatalog).not.toBeNull();
+
+    act(() => canvasMocks.onRefreshCatalog?.());
+    await act(async () => {
+      fresh.resolve([{ id: "fresh", title: "Fresh", kinds: [{ id: "fresh", type: "shell", title: "Fresh" }] }]);
+      await Promise.resolve();
+    });
+    expect(canvasMocks.catalog[0]?.id).toBe("fresh");
+
+    await act(async () => {
+      stale.resolve([{ id: "stale", title: "Stale", kinds: [{ id: "stale", type: "shell", title: "Stale" }] }]);
+      await Promise.resolve();
+    });
+    expect(canvasMocks.catalog[0]?.id).toBe("fresh");
   });
 
   it("does not retarget Analyze when launch starts with it open", async () => {

--- a/runtime/fleet-console/tests/operations-side-bar-keyboard-context-menu.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-keyboard-context-menu.test.tsx
@@ -4,6 +4,7 @@ import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OperationCatalogPlugin } from "@fleet-console/sdk/operations";
 
 import { loadForTheater } from "../core/client/src/canvas/canvas-store.js";
 import { requestSideBarOperationAction } from "../core/client/src/sidebar/interaction.js";
@@ -152,6 +153,29 @@ describe("sidebar context menu keyboard path", () => {
     expect(document.activeElement).toBe(row);
   });
 
+  it("forwards a launch-variant chip payload through the sidebar menu", () => {
+    const onLaunchKind = vi.fn();
+    const catalog = gatewayVariantCatalog();
+    renderSideBar(catalog, onLaunchKind);
+    const sideBar = required<HTMLElement>(".operations-side-bar");
+
+    act(() => sideBar.dispatchEvent(new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 120,
+      clientY: 80,
+    })));
+    const parent = required<HTMLElement>('[data-operation-launch-kind="claude-gateway"]');
+    act(() => parent.parentElement!.dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
+    act(() => required<HTMLButtonElement>('[data-launch-variant-chip="fable:max"]').click());
+
+    expect(onLaunchKind).toHaveBeenCalledWith(
+      "terminal",
+      catalog[0]!.kinds[0],
+      { model: "fable", effort: "max" },
+    );
+  });
+
   it("executes the focused existing menu item with Enter", async () => {
     renderSideBar();
     const chip = required<HTMLElement>('[data-side-bar-chip-id="operation-a"]');
@@ -172,7 +196,10 @@ describe("sidebar context menu keyboard path", () => {
 
 });
 
-function renderSideBar(): void {
+function renderSideBar(
+  catalog: readonly OperationCatalogPlugin[] = [],
+  onLaunchKind = vi.fn(),
+): void {
   act(() => root?.render(createElement(MemoryRouter, null, createElement(OperationsSideBar, {
     theaters: [THEATER],
     activeTheaterId: THEATER.id,
@@ -181,12 +208,12 @@ function renderSideBar(): void {
     minimized: [],
     activeOperationId: OPERATION.id,
     operationNotifications: {},
-    catalog: [],
+    catalog,
     canLaunch: true,
     addingTheater: false,
     theaterError: null,
     renderKindIcon: () => null,
-    onLaunchKind: vi.fn(),
+    onLaunchKind,
     onClose: vi.fn(),
     onMinimize: vi.fn(),
     onFocus: vi.fn(),
@@ -204,6 +231,32 @@ function renderSideBar(): void {
     onCancelAddTheater: vi.fn(),
     onForgetTheater: vi.fn(),
   }))));
+}
+
+function gatewayVariantCatalog(): readonly OperationCatalogPlugin[] {
+  return [{
+    id: "terminal",
+    title: "Terminal",
+    kinds: [{
+      id: "claude-gateway",
+      type: "agent",
+      title: "Claude (Gateway)",
+      variants: [{
+        id: "native",
+        label: "Claude",
+        rows: [{
+          id: "fable",
+          label: "Fable",
+          launch: { model: "fable" },
+          chips: [{
+            id: "max",
+            label: "MAX",
+            launch: { model: "fable", effort: "max" },
+          }],
+        }],
+      }],
+    }],
+  }];
 }
 
 function dispatchKey(target: HTMLElement, key: string, options: KeyboardEventInit = {}): void {

--- a/runtime/fleet-console/tests/operations.test.ts
+++ b/runtime/fleet-console/tests/operations.test.ts
@@ -2,9 +2,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { assertOperationNode } from "@fleet-console/sdk/operations/browser";
+import type { OperationLaunchKind } from "@fleet-console/sdk/operations";
+import { assertOperationNode, fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
+import { readLaunchVariantGroups } from "@fleet-console/sdk/operations/launch-variants";
 import { createConsoleLock } from "../core/host/lock.js";
 import { createOperationsRouter } from "../core/host/operations/operations-domain.js";
 import { createSanitizedOpDto } from "../core/host/operations/operations-domain.js";
@@ -16,6 +18,7 @@ const tempDirs: string[] = [];
 const servers: ConsoleServer[] = [];
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await Promise.all(servers.splice(0).map((server) => server.stop()));
   for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
@@ -241,6 +244,102 @@ describe("operations platform", () => {
     expect(store.get("op")?.accent).toBeUndefined();
   });
 
+  it("omits all-malformed launch variants and non-boolean starred values", () => {
+    expect(readLaunchVariantGroups([
+      { id: 7, label: "Bad", rows: [] },
+      { id: "empty", label: "Empty", rows: [{ id: "bad", label: "Bad", launch: { model: false } }] },
+    ])).toEqual([]);
+
+    expect(readLaunchVariantGroups([{
+      id: "native",
+      label: "Claude",
+      rows: [{ id: "fable", label: "Fable", starred: "yes", launch: { model: "fable" } }],
+    }])).toEqual([{
+      id: "native",
+      label: "Claude",
+      rows: [{ id: "fable", label: "Fable", launch: { model: "fable" } }],
+    }]);
+  });
+
+  it("strictly reconstructs launch variants from the browser catalog response", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      plugins: [{
+        id: "terminal",
+        title: "Terminal",
+        kinds: [
+          {
+            id: "claude-gateway",
+            type: "agent",
+            title: "Claude (Gateway)",
+            variants: [
+              {
+                id: "native",
+                label: "Claude",
+                rows: [
+                  {
+                    id: "fable",
+                    label: "Fable",
+                    starred: true,
+                    ignored: "drop-me",
+                    launch: { model: "fable", effort: 5 },
+                    chips: [
+                      { id: "max", label: "MAX", launch: { model: "fable", effort: "max", extra: false } },
+                      { id: 7, label: "HIGH", launch: { model: "fable", effort: "high" } },
+                      { id: "empty", label: "EMPTY", launch: { effort: 5 } },
+                    ],
+                  },
+                  { id: "empty", label: "Empty", launch: { model: false } },
+                  { id: "missing-label", launch: { model: "opus" } },
+                ],
+              },
+              { id: 8, label: "Malformed", rows: [] },
+              { id: "empty", label: "Empty", rows: [{ id: "bad", label: "Bad", launch: [] }] },
+            ],
+          },
+          {
+            id: "malformed-variants",
+            type: "agent",
+            title: "Malformed variants",
+            variants: [{ id: "empty", label: "Empty", rows: [{ id: "bad", label: "Bad", launch: { model: false } }] }],
+          },
+          { id: "shell", type: "shell", title: "Shell" },
+        ],
+      }],
+    })));
+
+    const catalog = await fetchOperationCatalog();
+
+    expect(catalog).toEqual([{
+      id: "terminal",
+      title: "Terminal",
+      kinds: [
+        {
+          id: "claude-gateway",
+          type: "agent",
+          title: "Claude (Gateway)",
+          variants: [{
+            id: "native",
+            label: "Claude",
+            rows: [{
+              id: "fable",
+              label: "Fable",
+              starred: true,
+              launch: { model: "fable" },
+              chips: [{
+                id: "max",
+                label: "MAX",
+                launch: { model: "fable", effort: "max" },
+              }],
+            }],
+          }],
+        },
+        { id: "malformed-variants", type: "agent", title: "Malformed variants" },
+        { id: "shell", type: "shell", title: "Shell" },
+      ],
+    }]);
+    fetchMock.mockRestore();
+  });
+
   it("serves the operation launch catalog before item routes", async () => {
     const store = createOperationStore({ now: () => 10 });
     const router = createOperationsRouter({
@@ -292,9 +391,64 @@ describe("operations platform", () => {
       kinds: [
         { id: "shell", type: "shell", title: "Shell" },
         { id: "agent", type: "agent", title: "Agent CLI" },
+        {
+          id: "claude-gateway",
+          type: "agent",
+          title: "Claude (Gateway)",
+          variants: [{
+            id: "native",
+            label: "Claude",
+            rows: [{
+              id: "fable",
+              label: "Fable",
+              launch: { model: "fable" },
+              chips: [{
+                id: "max",
+                label: "MAX",
+                launch: { model: "fable", effort: "max" },
+              }],
+            }],
+          }],
+        },
       ],
     });
     expect(catalog.plugins.filter((plugin) => plugin.id === "terminal")).toHaveLength(1);
+  });
+
+  it("preserves launch variants through the host catalog HTTP sanitizer", async () => {
+    const fixture = await startCatalogFixture();
+
+    const response = await fetch(`${fixture.endpoint}api/v1/operations/catalog`);
+    const catalog = await response.json() as {
+      readonly plugins: ReadonlyArray<{
+        readonly id: string;
+        readonly kinds: readonly OperationLaunchKind[];
+      }>;
+    };
+    const gateway = catalog.plugins
+      .find((plugin) => plugin.id === "terminal")
+      ?.kinds.find((kind) => kind.id === "claude-gateway");
+
+    expect(response.status).toBe(200);
+    expect(gateway).toEqual({
+      id: "claude-gateway",
+      type: "agent",
+      title: "Claude (Gateway)",
+      variants: [{
+        id: "native",
+        label: "Claude",
+        rows: [{
+          id: "fable",
+          label: "Fable",
+          launch: { model: "fable" },
+          chips: [{
+            id: "max",
+            label: "MAX",
+            launch: { model: "fable", effort: "max" },
+          }],
+        }],
+      }],
+    });
   });
 
   it("deletes every OperationNode for a Theater", () => {
@@ -373,6 +527,15 @@ async function startCatalogFixture(): Promise<{ readonly endpoint: string }> {
     "  ctx.host.operations.registerLaunchCatalog(ctx.pluginId, () => [",
     "    { id: 'shell', type: 'ignored-duplicate', title: 'Ignored Duplicate' },",
     "    { id: 'agent', type: 'agent', title: 'Agent CLI' },",
+    "    {",
+    "      id: 'claude-gateway', type: 'agent', title: 'Claude (Gateway)', ignored: 'drop-me',",
+    "      variants: [{",
+    "        id: 'native', label: 'Claude', rows: [{",
+    "          id: 'fable', label: 'Fable', launch: { model: 'fable', invalid: false },",
+    "          chips: [{ id: 'max', label: 'MAX', launch: { model: 'fable', effort: 'max', invalid: 7 } }],",
+    "        }, { id: 'invalid', label: 'Invalid', launch: { model: false } }],",
+    "      }],",
+    "    },",
     "  ]);",
     "}",
   ].join("\n"));

--- a/runtime/fleet-plugins/terminal/client/agent/api.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/api.ts
@@ -70,11 +70,18 @@ export async function fetchOperationsSnapshot(signal?: AbortSignal): Promise<Ope
   return { operations: payload.operations.map((operation) => assertOperationNode(operation, response.status)) };
 }
 
-export async function createAgentSession(theaterId: string, cliId: string, signal?: AbortSignal): Promise<SessionInfo> {
+export async function createAgentSession(
+  theaterId: string,
+  cliId: string,
+  options?: { readonly model?: string; readonly effort?: string },
+  signal?: AbortSignal,
+): Promise<SessionInfo> {
+  const model = typeof options?.model === "string" && options.model.length > 0 ? options.model : undefined;
+  const effort = typeof options?.effort === "string" && options.effort.length > 0 ? options.effort : undefined;
   const response = await fetch("/plugins/terminal/agent/sessions", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ theaterId, cliId }),
+    body: JSON.stringify({ theaterId, cliId, ...(model ? { model } : {}), ...(effort ? { effort } : {}) }),
     signal,
   });
   await assertOk(response);

--- a/runtime/fleet-plugins/terminal/client/agent/index.tsx
+++ b/runtime/fleet-plugins/terminal/client/agent/index.tsx
@@ -161,8 +161,8 @@ export const agentPlugin = definePlugin({
       throw error;
     }
   },
-  launch: async ({ theaterId, kind }) => {
-    const session = await createAgentSession(theaterId, kind.id);
+  launch: async ({ theaterId, kind, variant }) => {
+    const session = await createAgentSession(theaterId, kind.id, { model: variant?.model, effort: variant?.effort });
     applySessionUpdate(session);
     selectSession(session.sessionId);
     return { id: session.sessionId };

--- a/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
@@ -1,10 +1,27 @@
-import type { OperationLaunchKind } from "@fleet-console/sdk/operations";
+import type { OperationLaunchKind, OperationLaunchVariantGroup } from "@fleet-console/sdk/operations";
+import { exposableEffortLadder, type AiGatewaySelection } from "@dotobokuri/core-ai-gateway";
+import { NATIVE_CLAUDE_EFFORTS, NATIVE_CLAUDE_MODEL_ALIASES } from "@dotobokuri/fleet-admiral";
 
 import type { AgentCliLaunchMetadata } from "./agent-cli-launch-metadata.js";
+
+const EFFORT_LABELS: Readonly<Record<string, string>> = {
+  low: "LOW",
+  medium: "MED",
+  high: "HIGH",
+  xhigh: "XHIGH",
+  max: "MAX",
+};
+
+const NATIVE_MODEL_LABELS: Readonly<Record<(typeof NATIVE_CLAUDE_MODEL_ALIASES)[number], string>> = {
+  fable: "Fable",
+  opus: "Opus",
+  sonnet: "Sonnet",
+};
 
 export function buildAgentCliLaunchKinds(
   metadata: readonly AgentCliLaunchMetadata[],
   operationType: string,
+  gatewaySelection?: AiGatewaySelection,
 ): OperationLaunchKind[] {
   return metadata
     .map((cli) => {
@@ -13,9 +30,53 @@ export function buildAgentCliLaunchKinds(
         id: cli.id,
         type: operationType,
         title: cli.label,
-        ...(disabledReason ? { disabled: true, disabledReason } : {}),
+        ...(disabledReason
+          ? { disabled: true, disabledReason }
+          : cli.id === "claude-gateway"
+            ? { variants: buildClaudeGatewayLaunchVariants(gatewaySelection) }
+            : {}),
       };
     });
+}
+
+export function buildClaudeGatewayLaunchVariants(selection?: AiGatewaySelection): readonly OperationLaunchVariantGroup[] {
+  const native: OperationLaunchVariantGroup = {
+    id: "native",
+    label: "Claude",
+    rows: NATIVE_CLAUDE_MODEL_ALIASES.map((model) => ({
+      id: model,
+      label: NATIVE_MODEL_LABELS[model],
+      launch: { model },
+      chips: NATIVE_CLAUDE_EFFORTS.map((effort) => ({
+        id: effort,
+        label: EFFORT_LABELS[effort]!,
+        launch: { model, effort },
+      })),
+    })),
+  };
+  if (!selection || selection.models.length === 0) return [native];
+  return [native, {
+    id: "gateway",
+    label: "Gateway",
+    rows: selection.models.map((model) => {
+      const efforts = (selection.effortExposure[model.id] ?? exposableEffortLadder(model))
+        .filter((effort): effort is (typeof NATIVE_CLAUDE_EFFORTS)[number] =>
+          NATIVE_CLAUDE_EFFORTS.includes(effort as (typeof NATIVE_CLAUDE_EFFORTS)[number]));
+      return {
+        id: model.id,
+        label: model.displayName,
+        ...(selection.defaultModel?.id === model.id ? { starred: true } : {}),
+        launch: { model: model.id },
+        ...(efforts.length > 0 ? {
+          chips: efforts.map((effort) => ({
+            id: effort,
+            label: EFFORT_LABELS[effort] ?? effort.toUpperCase(),
+            launch: { model: model.id, effort },
+          })),
+        } : {}),
+      };
+    }),
+  }];
 }
 
 function resolveDisabledReason(cli: AgentCliLaunchMetadata): string | undefined {

--- a/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
@@ -6,14 +6,17 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 import { resolvePathBinary } from "@dotobokuri/core-agent";
-import { resolveAiGatewaySelection } from "@dotobokuri/core-ai-gateway";
-import type { AiGatewayStoredSettings } from "@dotobokuri/core-ai-gateway";
+import { exposableEffortLadder, resolveAiGatewaySelection, toClaudeGatewayModelId } from "@dotobokuri/core-ai-gateway";
+import type { AiGatewaySelection, AiGatewayStoredSettings, GatewayModel, GatewayReasoningEffort } from "@dotobokuri/core-ai-gateway";
 import { createSessionIdentityResolver } from "@dotobokuri/core-unified-agent";
 import {
   createSessionCaptureHookExec,
   createSystemPromptBuilder,
   injectAgentCliProfile,
   prepareAiGatewayLaunchProfile,
+  NATIVE_CLAUDE_EFFORTS,
+  NATIVE_CLAUDE_MODEL_ALIASES,
+  resolveAgentCliId,
   resolveAgentCliProfile,
   type AgentCliId,
   type AgentCliProfile,
@@ -64,6 +67,28 @@ export interface ConsoleRuntimeSessionInfo {
   readonly label: string;
   readonly mcpToolCount: number;
   readonly sessionId: string;
+}
+
+export type GatewayLaunchOptionErrorCode = "gateway_model_not_enabled" | "invalid_effort";
+
+export class GatewayLaunchOptionError extends Error {
+  readonly code: GatewayLaunchOptionErrorCode;
+
+  constructor(code: GatewayLaunchOptionErrorCode, message: string) {
+    super(message);
+    this.name = "GatewayLaunchOptionError";
+    this.code = code;
+  }
+}
+
+export function isGatewayLaunchEffortAllowed(
+  selection: AiGatewaySelection,
+  model: GatewayModel,
+  effort: string,
+): boolean {
+  if (!NATIVE_CLAUDE_EFFORTS.includes(effort as (typeof NATIVE_CLAUDE_EFFORTS)[number])) return false;
+  const efforts = selection.effortExposure[model.id] ?? exposableEffortLadder(model);
+  return efforts.includes(effort as GatewayReasoningEffort);
 }
 
 export type TerminalLaunchResolver = (cwd?: string, context?: TerminalLaunchContext) => Promise<TerminalLaunchSpec>;
@@ -125,6 +150,8 @@ export function createAgentTerminalLaunchResolver(deps: TerminalLaunchResolverDe
       onRuntimeSessionStart: deps.onRuntimeSessionStart,
       resolveProfile,
       cliId: context?.cliId,
+      model: context?.model,
+      effort: context?.effort,
       createSessionIdentityResolver: resolveSessionIdentityResolver,
       resumeSessionId: context?.resumeSessionId,
       sessionId,
@@ -156,6 +183,8 @@ async function createAgentCliLaunchSpec(options: {
   readonly aiGateway?: AiGatewayLaunchBinding;
   readonly readAiGatewaySettings?: () => AiGatewayStoredSettings;
   readonly cliId?: string;
+  readonly model?: string;
+  readonly effort?: string;
   readonly createSessionCaptureHookExec: typeof createSessionCaptureHookExec;
   readonly createSessionIdentityResolver: typeof createSessionIdentityResolver;
   readonly createSystemPromptBuilder: typeof createSystemPromptBuilder;
@@ -176,15 +205,35 @@ async function createAgentCliLaunchSpec(options: {
     if (!agentRuntime) {
       throw new Error("Fleet Console agent runtime is unavailable.");
     }
-    const profile = await options.resolveProfile(options.env, options.cwd, {
-      cliId: options.cliId,
-      resumeSessionId: options.resumeSessionId,
-    });
+    const cliId = resolveAgentCliId(options.env, { cliId: options.cliId });
     // gateway Agent 주입과 ANTHROPIC_MODEL/cache는 같은 selection을 공유한다.
-    // inject보다 먼저 읽어 `--agents`에 노출 모델×effort를 스폰 인자로만 실는다.
-    const gatewaySelection = profile.id === "claude-gateway" && options.readAiGatewaySettings
+    // resolveProfile보다 먼저 읽어 명시 모델 검증·`--agents`·cache가 한 스냅샷을 공유한다.
+    const gatewaySelection = cliId === "claude-gateway" && options.readAiGatewaySettings
       ? resolveAiGatewaySelection(options.readAiGatewaySettings())
       : undefined;
+    let resolvedModel = options.model;
+    if (cliId === "claude-gateway" && resolvedModel && !NATIVE_CLAUDE_MODEL_ALIASES.includes(resolvedModel as (typeof NATIVE_CLAUDE_MODEL_ALIASES)[number])) {
+      const model = gatewaySelection?.models.find((candidate) => candidate.id === resolvedModel);
+      if (!model) {
+        throw new GatewayLaunchOptionError(
+          "gateway_model_not_enabled",
+          `Gateway model "${resolvedModel}" is not enabled.`,
+        );
+      }
+      if (options.effort !== undefined && (!gatewaySelection || !isGatewayLaunchEffortAllowed(gatewaySelection, model, options.effort))) {
+        throw new GatewayLaunchOptionError(
+          "invalid_effort",
+          `Gateway effort "${options.effort}" is not enabled for model "${resolvedModel}".`,
+        );
+      }
+      resolvedModel = toClaudeGatewayModelId(model);
+    }
+    const profile = await options.resolveProfile(options.env, options.cwd, {
+      cliId,
+      resumeSessionId: options.resumeSessionId,
+      model: resolvedModel,
+      effort: options.effort,
+    });
     const injectedProfile = await options.injectProfile(profile, {
       buildSystemPrompt: () => options.createSystemPromptBuilder().build(),
       dataDir: options.dataDir,

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import path from "node:path";
 import process from "node:process";
 
-import { buildGatewayModelsToolSpec, createDelayedPtyWriter, createFleetGatewayAgentRuntimeLifecycle, formatPtyMessage, getAgentCliIds, getAgentCliMetadata, parseAgentCliId, sanitizePtyMessageText, type AgentCliId } from "@dotobokuri/fleet-admiral";
+import { buildGatewayModelsToolSpec, createDelayedPtyWriter, createFleetGatewayAgentRuntimeLifecycle, formatPtyMessage, getAgentCliIds, getAgentCliMetadata, NATIVE_CLAUDE_EFFORTS, NATIVE_CLAUDE_MODEL_ALIASES, parseAgentCliId, sanitizePtyMessageText, type AgentCliId } from "@dotobokuri/fleet-admiral";
 import type { AgentToolSpec } from "@dotobokuri/core-agent";
 import { ensureWorkspaceDirectory, withDirectoryLock, type GlobalOptionsService } from "@dotobokuri/core-infra";
 import { createWikiWorkspaceResolver, getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
@@ -23,14 +23,14 @@ import type { AiGatewayLaunchBinding } from "./agent-api/launch.js";
 import { deriveOperationLabel } from "./agent-api/auto-name.js";
 import { normalizeAttentionReason } from "./agent-api/attention-hook.js";
 import { resolveBackgroundPendingFromHookInput } from "./agent-api/background-report.js";
-import { createAgentTerminalLaunchResolver, type ConsoleRuntimeSessionInfo } from "./agent-api/launch.js";
+import { createAgentTerminalLaunchResolver, GatewayLaunchOptionError, isGatewayLaunchEffortAllowed, type ConsoleRuntimeSessionInfo } from "./agent-api/launch.js";
 import { createConsoleObservabilityStore } from "./agent-api/observability-store.js";
 import { writeAgentSessionEvents } from "./agent-api/observability-routes.js";
 import { createOscAgentActivityTracker, type OscAgentActivityTracker } from "./agent-api/osc-agent-activity.js";
 import { readAnalysisProviderSession, readProviderSession, type AnalysisProviderSession } from "./agent-api/provider-session.js";
 import type { AgentProviderSession, AgentProviderTitleMarker, AgentTerminalSessionInfo, AgentLabelSource } from "./agent-api/types.js";
 import { startIdleAgentDormantSweeper } from "./agent-idle-dormant-sweeper.js";
-type SessionCreateBody = { readonly cliId?: unknown; readonly theaterId?: unknown };
+type SessionCreateBody = { readonly cliId?: unknown; readonly theaterId?: unknown; readonly model?: unknown; readonly effort?: unknown };
 type HookTurnBody = { readonly phase?: unknown; readonly input?: unknown };
 type HookBackgroundBody = { readonly input?: unknown };
 type HookAttentionBody = { readonly input?: unknown; readonly reason?: unknown };
@@ -303,13 +303,56 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
       ctx.host.http.writeJson(res, 400, { error: "theater_required" });
       return true;
     }
+    const launchOptions = readLaunchOptions(body, cliId, res);
+    if (launchOptions === false) return true;
     const cwd = ctx.host.paths.resolveTheaterPath(theaterId);
     if (!cwd) {
       ctx.host.http.writeJson(res, 404, { error: "theater_not_found" });
       return true;
     }
-    await createSession(cwd, theaterId, cliId, res);
+    await createSession(cwd, theaterId, cliId, res, launchOptions);
     return true;
+  }
+
+  function readLaunchOptions(
+    body: SessionCreateBody | null,
+    cliId: AgentCliId,
+    res: Parameters<typeof handle>[0]["res"],
+  ): { readonly model?: string; readonly effort?: string } | false {
+    if ((body?.model !== undefined && typeof body.model !== "string")
+      || (body?.effort !== undefined && typeof body.effort !== "string")) {
+      ctx.host.http.writeJson(res, 400, { error: "invalid_launch_option" });
+      return false;
+    }
+    const model = body?.model;
+    const effort = body?.effort;
+    if (model === undefined && effort === undefined) return {};
+    if (cliId !== "claude-gateway") {
+      ctx.host.http.writeJson(res, 400, { error: "launch_option_unsupported" });
+      return false;
+    }
+    if (model === undefined) {
+      ctx.host.http.writeJson(res, 400, { error: "invalid_launch_option" });
+      return false;
+    }
+    if (NATIVE_CLAUDE_MODEL_ALIASES.includes(model as (typeof NATIVE_CLAUDE_MODEL_ALIASES)[number])) {
+      if (effort !== undefined && !NATIVE_CLAUDE_EFFORTS.includes(effort as (typeof NATIVE_CLAUDE_EFFORTS)[number])) {
+        ctx.host.http.writeJson(res, 400, { error: "invalid_effort" });
+        return false;
+      }
+      return { model, ...(effort === undefined ? {} : { effort }) };
+    }
+    const selection = resolveAiGatewaySelection(deps.readAiGatewaySettings?.());
+    const gatewayModel = selection.models.find((candidate) => candidate.id === model);
+    if (!gatewayModel) {
+      ctx.host.http.writeJson(res, 409, { error: "gateway_model_not_enabled" });
+      return false;
+    }
+    if (effort !== undefined && !isGatewayLaunchEffortAllowed(selection, gatewayModel, effort)) {
+      ctx.host.http.writeJson(res, 400, { error: "invalid_effort" });
+      return false;
+    }
+    return { model, ...(effort === undefined ? {} : { effort }) };
   }
 
   async function handleSessionItem(req: Parameters<typeof handle>[0]["req"], res: Parameters<typeof handle>[0]["res"], sessionId: string, action: string): Promise<boolean> {
@@ -331,7 +374,13 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
     return methodNotAllowed(res);
   }
 
-  async function createSession(cwd: string, theaterId: string, cliId: AgentCliId, res: Parameters<typeof handle>[0]["res"]): Promise<void> {
+  async function createSession(
+    cwd: string,
+    theaterId: string,
+    cliId: AgentCliId,
+    res: Parameters<typeof handle>[0]["res"],
+    launchOptions: { readonly model?: string; readonly effort?: string } = {},
+  ): Promise<void> {
     const meta = (await buildAgentCliLaunchMetadata()).find((entry) => entry.id === cliId);
     if (!meta || !meta.available || !meta.signedIn) {
       ctx.host.http.writeJson(res, 409, { error: "agent_cli_unavailable" });
@@ -357,6 +406,8 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
         pluginId: ctx.pluginId,
         theaterId,
         cliId,
+        ...(launchOptions.model ? { model: launchOptions.model } : {}),
+        ...(launchOptions.effort ? { effort: launchOptions.effort } : {}),
       });
       const runtimeSession = pendingRuntimeSessions.get(sessionId);
       pendingRuntimeSessions.delete(sessionId);
@@ -366,9 +417,13 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
       observability.notifySessionUpdated(created);
       ctx.host.operations.patch(sessionId, { payload: toOperationPayload(ctx.host.operations.get(sessionId)?.payload, cwd, created, undefined, observability.getDurableOperation(sessionId)?.providerTitle) });
       ctx.host.http.writeJson(res, 200, created);
-    } catch {
+    } catch (error) {
       pendingRuntimeSessions.delete(sessionId);
       observability.updateTerminalSessionStatus(sessionId, "error");
+      if (error instanceof GatewayLaunchOptionError) {
+        ctx.host.http.writeJson(res, error.code === "gateway_model_not_enabled" ? 409 : 400, { error: error.code });
+        return;
+      }
       ctx.host.http.writeJson(res, 503, { error: "terminal_unavailable" });
     }
   }
@@ -572,10 +627,13 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
 
   async function buildLaunchKinds(): Promise<readonly OperationLaunchKind[]> {
     const metadata = await buildAgentCliLaunchMetadata();
-    return buildAgentCliLaunchKinds(metadata, AGENT_OPERATION_TYPE);
+    const selection = deps.readAiGatewaySettings
+      ? resolveAiGatewaySelection(deps.readAiGatewaySettings())
+      : undefined;
+    return buildAgentCliLaunchKinds(metadata, AGENT_OPERATION_TYPE, selection);
   }
 
-  function launch(cwd: string | undefined, context: { readonly operationId?: string } | undefined) {
+  function launch(cwd: string | undefined, context: { readonly operationId?: string; readonly model?: string; readonly effort?: string } | undefined) {
     const operationId = context?.operationId ?? "";
     const operation = ctx.host.operations.get(operationId);
     const cliId = typeof operation?.payload.cliId === "string" ? operation.payload.cliId : undefined;
@@ -587,6 +645,8 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
       pluginId: ctx.pluginId,
       ...(operation?.theaterId ? { theaterId: operation.theaterId } : {}),
       ...(cliId ? { cliId } : {}),
+      ...(context?.model ? { model: context.model } : {}),
+      ...(context?.effort ? { effort: context.effort } : {}),
       ...(providerSession ? { resumeSessionId: providerSession } : {}),
     });
   }

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -418,12 +418,13 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
       ctx.host.operations.patch(sessionId, { payload: toOperationPayload(ctx.host.operations.get(sessionId)?.payload, cwd, created, undefined, observability.getDurableOperation(sessionId)?.providerTitle) });
       ctx.host.http.writeJson(res, 200, created);
     } catch (error) {
-      pendingRuntimeSessions.delete(sessionId);
-      observability.updateTerminalSessionStatus(sessionId, "error");
       if (error instanceof GatewayLaunchOptionError) {
+        removeSession(sessionId);
         ctx.host.http.writeJson(res, error.code === "gateway_model_not_enabled" ? 409 : 400, { error: error.code });
         return;
       }
+      pendingRuntimeSessions.delete(sessionId);
+      observability.updateTerminalSessionStatus(sessionId, "error");
       ctx.host.http.writeJson(res, 503, { error: "terminal_unavailable" });
     }
   }

--- a/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
@@ -190,6 +190,8 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
       ...(context.theaterId ? { theaterId: context.theaterId } : {}),
       ...(context.kind ? { kind: context.kind } : {}),
       ...(context.cliId ? { cliId: context.cliId } : {}),
+      ...(context.model ? { model: context.model } : {}),
+      ...(context.effort ? { effort: context.effort } : {}),
       ...(context.resumeSessionId ? { resumeSessionId: context.resumeSessionId } : {}),
       ...(context.colorScheme ? { colorScheme: context.colorScheme } : {}),
     });

--- a/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
@@ -23,6 +23,8 @@ export interface TerminalLaunchContext {
   readonly theaterId?: string;
   readonly kind?: "fleet" | "shell";
   readonly cliId?: string;
+  readonly model?: string;
+  readonly effort?: string;
   readonly resumeSessionId?: string;
   /** 콘솔 테마 극성 힌트 — spawn env COLORFGBG로만 소비된다. PTY는 최초 spawn 시점 값에 고정된다. */
   readonly colorScheme?: "light" | "dark";
@@ -42,6 +44,8 @@ export interface TerminalTicketContext {
   readonly theaterId?: string;
   readonly kind?: "fleet" | "shell";
   readonly cliId?: string;
+  readonly model?: string;
+  readonly effort?: string;
   readonly resumeSessionId?: string;
   readonly colorScheme?: "light" | "dark";
 }

--- a/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
@@ -1,30 +1,98 @@
+import { resolveAiGatewaySelection } from "@dotobokuri/core-ai-gateway";
 import { describe, expect, it } from "vitest";
 
 import { buildAgentCliLaunchKinds } from "../server/agent-api/agent-cli-launch-kinds.js";
 
+const nativeVariants = {
+  id: "native",
+  label: "Claude",
+  rows: [
+    nativeRow("fable", "Fable"),
+    nativeRow("opus", "Opus"),
+    nativeRow("sonnet", "Sonnet"),
+  ],
+};
+
 describe("buildAgentCliLaunchKinds", () => {
-  it("지원되는 Claude CLI만 Operation Controls 목록에 포함한다", () => {
+  it("adds the complete native model and effort menu to the enabled gateway kind", () => {
     const result = buildAgentCliLaunchKinds(
       [
         { id: "claude-native", label: "Claude (Native)", available: true, signedIn: true },
         { id: "claude-gateway", label: "Claude (Gateway)", available: true, signedIn: true },
       ],
       "agent",
+      resolveAiGatewaySelection({ version: 1 }),
     );
 
     expect(result).toEqual([
       { id: "claude-native", type: "agent", title: "Claude (Native)" },
-      { id: "claude-gateway", type: "agent", title: "Claude (Gateway)" },
+      {
+        id: "claude-gateway",
+        type: "agent",
+        title: "Claude (Gateway)",
+        variants: [nativeVariants],
+      },
     ]);
   });
 
-  it("설치 미완료 및 로그인 미완료 CLI에 비활성화 사유를 표시한다", () => {
+  it("adds enabled gateway models in provider order with their exposed effort ladders", () => {
+    const selection = resolveAiGatewaySelection({
+      version: 1,
+      models: [
+        { id: "kimi--k3", efforts: ["max"] },
+        { id: "codex--gpt-5.6-sol-fast" },
+      ],
+      defaultModel: "kimi--k3",
+    });
+
+    const result = buildAgentCliLaunchKinds(
+      [{ id: "claude-gateway", label: "Claude (Gateway)", available: true, signedIn: true }],
+      "agent",
+      selection,
+    );
+
+    expect(result[0]?.variants).toEqual([
+      nativeVariants,
+      {
+        id: "gateway",
+        label: "Gateway",
+        rows: [
+          {
+            id: "codex--gpt-5.6-sol-fast",
+            label: selection.models[0]!.displayName,
+            launch: { model: "codex--gpt-5.6-sol-fast" },
+            chips: [
+              gatewayChip("codex--gpt-5.6-sol-fast", "low", "LOW"),
+              gatewayChip("codex--gpt-5.6-sol-fast", "medium", "MED"),
+              gatewayChip("codex--gpt-5.6-sol-fast", "high", "HIGH"),
+              gatewayChip("codex--gpt-5.6-sol-fast", "xhigh", "XHIGH"),
+              gatewayChip("codex--gpt-5.6-sol-fast", "max", "MAX"),
+            ],
+          },
+          {
+            id: "kimi--k3",
+            label: selection.models[1]!.displayName,
+            starred: true,
+            launch: { model: "kimi--k3" },
+            chips: [gatewayChip("kimi--k3", "max", "MAX")],
+          },
+        ],
+      },
+    ]);
+    expect(JSON.stringify(result)).not.toContain("ultra");
+  });
+
+  it("keeps disabled reasons and does not attach variants to a disabled gateway kind", () => {
     const result = buildAgentCliLaunchKinds(
       [
         { id: "claude-gateway", label: "Claude (Gateway)", available: false, signedIn: true },
         { id: "claude-native", label: "Claude (Native)", available: true, signedIn: false },
       ],
       "agent",
+      resolveAiGatewaySelection({
+        version: 1,
+        models: [{ id: "kimi--k3" }],
+      }),
     );
 
     expect(result).toEqual([
@@ -33,3 +101,26 @@ describe("buildAgentCliLaunchKinds", () => {
     ]);
   });
 });
+
+function nativeRow(model: string, label: string) {
+  return {
+    id: model,
+    label,
+    launch: { model },
+    chips: [
+      gatewayChip(model, "low", "LOW"),
+      gatewayChip(model, "medium", "MED"),
+      gatewayChip(model, "high", "HIGH"),
+      gatewayChip(model, "xhigh", "XHIGH"),
+      gatewayChip(model, "max", "MAX"),
+    ],
+  };
+}
+
+function gatewayChip(model: string, effort: string, label: string) {
+  return {
+    id: effort,
+    label,
+    launch: { model, effort },
+  };
+}

--- a/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
@@ -88,18 +88,40 @@ describe("agent launch variants", () => {
     }));
   });
 
-  it.each([
-    ["gateway_model_not_enabled", 409],
-    ["invalid_effort", 400],
-  ] as const)("maps spawn-time %s to its route response", async (code, status) => {
+  it("removes the pending operation when the gateway model becomes stale during spawn", async () => {
     const harness = await createHarness({
       body: { cliId: "claude-gateway", model: "fable", effort: "max" },
-      attachError: new GatewayLaunchOptionError(code, code),
+      attachError: new GatewayLaunchOptionError("gateway_model_not_enabled", "gateway_model_not_enabled"),
     });
 
     await harness.postSessions();
 
-    expect(harness.responses.at(-1)).toEqual({ status, body: { error: code } });
+    expect(harness.responses.at(-1)).toEqual({ status: 409, body: { error: "gateway_model_not_enabled" } });
+    expect(harness.operations).toEqual([]);
+  });
+
+  it("maps a spawn-time invalid effort and removes its pending operation", async () => {
+    const harness = await createHarness({
+      body: { cliId: "claude-gateway", model: "fable", effort: "max" },
+      attachError: new GatewayLaunchOptionError("invalid_effort", "invalid_effort"),
+    });
+
+    await harness.postSessions();
+
+    expect(harness.responses.at(-1)).toEqual({ status: 400, body: { error: "invalid_effort" } });
+    expect(harness.operations).toEqual([]);
+  });
+
+  it("retains the errored operation when terminal infrastructure fails", async () => {
+    const harness = await createHarness({
+      body: { cliId: "claude-gateway", model: "fable", effort: "max" },
+      attachError: new Error("pty unavailable"),
+    });
+
+    await harness.postSessions();
+
+    expect(harness.responses.at(-1)).toEqual({ status: 503, body: { error: "terminal_unavailable" } });
+    expect(harness.operations).toHaveLength(1);
   });
 
   it("threads a valid native alias and effort into the initial attach only", async () => {

--- a/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
@@ -3,11 +3,13 @@ import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import type { AiGatewayStoredSettings } from "@dotobokuri/core-ai-gateway";
 import type { OperationCreateInput, OperationNode, OperationPatchInput } from "@fleet-console/sdk/operations";
 import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 import type { RouteHandler } from "@fleet-console/sdk/routing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { GatewayLaunchOptionError } from "../server/agent-api/launch.js";
 import { registerAgentRoutes } from "../server/agent.js";
 import type { TerminalRuntime } from "../server/shared/index.js";
 import { createPluginTerminalTicketRegistry } from "../server/shared/tickets.js";
@@ -19,6 +21,114 @@ const temporaryDirectories: string[] = [];
 afterEach(async () => {
   for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
   for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("agent launch variants", () => {
+  it.each([
+    [{ cliId: "claude-gateway", model: 5 }, 400, "invalid_launch_option"],
+    [{ cliId: "claude-native", model: "fable" }, 400, "launch_option_unsupported"],
+    [{ cliId: "claude-gateway", model: "cursor--missing" }, 409, "gateway_model_not_enabled"],
+    [{ cliId: "claude-gateway", model: "fable", effort: "ultra" }, 400, "invalid_effort"],
+    [{ cliId: "claude-gateway", effort: "max" }, 400, "invalid_launch_option"],
+  ] as const)("rejects invalid launch body %#", async (body, status, error) => {
+    const harness = await createHarness({ body });
+
+    await harness.postSessions();
+
+    expect(harness.responses.at(-1)).toEqual({ status, body: { error } });
+    expect(harness.attach).not.toHaveBeenCalled();
+  });
+
+  it("rejects effort outside a model's exposed ladder", async () => {
+    const harness = await createHarness({
+      body: { cliId: "claude-gateway", model: "kimi--k3", effort: "high" },
+      aiGatewaySettings: {
+        version: 1,
+        models: [{ id: "kimi--k3", efforts: ["max"] }],
+      },
+    });
+
+    await harness.postSessions();
+
+    expect(harness.responses.at(-1)).toEqual({ status: 400, body: { error: "invalid_effort" } });
+    expect(harness.attach).not.toHaveBeenCalled();
+  });
+
+  it("rejects ultra even when the gateway model catalog includes it", async () => {
+    const harness = await createHarness({
+      body: { cliId: "claude-gateway", model: "codex--gpt-5.6-sol-fast", effort: "ultra" },
+      aiGatewaySettings: {
+        version: 1,
+        models: [{ id: "codex--gpt-5.6-sol-fast" }],
+      },
+    });
+
+    await harness.postSessions();
+
+    expect(harness.responses.at(-1)).toEqual({ status: 400, body: { error: "invalid_effort" } });
+    expect(harness.attach).not.toHaveBeenCalled();
+  });
+
+  it("threads a valid scoped gateway model and effort into attach", async () => {
+    const harness = await createHarness({
+      body: { cliId: "claude-gateway", model: "kimi--k3", effort: "max" },
+      aiGatewaySettings: {
+        version: 1,
+        models: [{ id: "kimi--k3", efforts: ["max"] }],
+      },
+    });
+
+    await harness.postSessions();
+
+    expect(harness.responses.at(-1)?.status).toBe(200);
+    expect(harness.attach).toHaveBeenCalledWith(expect.objectContaining({
+      cliId: "claude-gateway",
+      model: "kimi--k3",
+      effort: "max",
+    }));
+  });
+
+  it.each([
+    ["gateway_model_not_enabled", 409],
+    ["invalid_effort", 400],
+  ] as const)("maps spawn-time %s to its route response", async (code, status) => {
+    const harness = await createHarness({
+      body: { cliId: "claude-gateway", model: "fable", effort: "max" },
+      attachError: new GatewayLaunchOptionError(code, code),
+    });
+
+    await harness.postSessions();
+
+    expect(harness.responses.at(-1)).toEqual({ status, body: { error: code } });
+  });
+
+  it("threads a valid native alias and effort into the initial attach only", async () => {
+    const harness = await createHarness({
+      body: { cliId: "claude-gateway", model: "fable", effort: "max" },
+    });
+
+    await harness.postSessions();
+
+    expect(harness.responses.at(-1)?.status).toBe(200);
+    expect(harness.attach).toHaveBeenCalledWith(expect.objectContaining({
+      cliId: "claude-gateway",
+      model: "fable",
+      effort: "max",
+    }));
+
+    const sessionId = harness.operations[0]!.id;
+    harness.operations[0]!.payload.providerSession = {
+      provider: "claude",
+      sessionId: "provider-session-1",
+      capturedAt: "2026-08-07T00:00:00.000Z",
+    };
+    await harness.transitionToDormant(sessionId);
+    await harness.resumeSession(sessionId);
+
+    const resumeContext = harness.attach.mock.calls[1]?.[0];
+    expect(resumeContext).not.toHaveProperty("model");
+    expect(resumeContext).not.toHaveProperty("effort");
+  });
 });
 
 describe("agent dormant ticket guards", () => {
@@ -66,7 +176,11 @@ describe("agent dormant ticket guards", () => {
   });
 });
 
-async function createHarness() {
+async function createHarness(options: {
+  readonly body?: Readonly<Record<string, unknown>>;
+  readonly aiGatewaySettings?: AiGatewayStoredSettings;
+  readonly attachError?: Error;
+} = {}) {
   const fleetDataDir = mkdtempSync(path.join(os.tmpdir(), "fleet-terminal-dormant-ticket-"));
   temporaryDirectories.push(fleetDataDir);
   const operations: OperationNode[] = [];
@@ -83,7 +197,9 @@ async function createHarness() {
       return () => `ticket-${index++}`;
     })(),
   });
-  const attach = vi.fn<TerminalRuntime["attach"]>(async () => {});
+  const attach = vi.fn<TerminalRuntime["attach"]>(async () => {
+    if (options.attachError) throw options.attachError;
+  });
   const terminalRuntime: TerminalRuntime = {
     handleUpgrade: () => false,
     issueTicket: (context) => {
@@ -189,7 +305,7 @@ async function createHarness() {
           const url = req.url ?? "";
           if (url.includes("/ticket")) return { operationId: (req as http.IncomingMessage & { __body?: { operationId?: string } }).__body?.operationId } as T;
           if (url.includes("/resume")) return {} as T;
-          return { theaterId: "theater-1", cliId: "claude" } as T;
+          return { theaterId: "theater-1", cliId: "claude", ...options.body } as T;
         },
       },
       security: {
@@ -214,6 +330,9 @@ async function createHarness() {
       save: (data) => data,
       update: (mutate) => mutate({ version: 1 }),
     },
+    ...(options.aiGatewaySettings
+      ? { readAiGatewaySettings: () => options.aiGatewaySettings! }
+      : {}),
   });
   cleanups.push(async () => {
     if (previousTerminalCommand === undefined) delete process.env.FLEET_TERMINAL_CMD;
@@ -295,11 +414,20 @@ async function createHarness() {
 
   return {
     attach,
+    operations,
     tickets,
     responses,
     invalidateCalls,
     get ticketsIssued() { return ticketsIssued; },
     createLiveSession,
+    postSessions: async () => {
+      if (!route) throw new Error("Agent route was not registered");
+      await route({
+        req: { method: "POST", url: "/plugins/terminal/agent/sessions" } as http.IncomingMessage,
+        res: {} as http.ServerResponse,
+        pathname: "/plugins/terminal/agent/sessions",
+      });
+    },
     transitionToDormant,
     postTicket,
     getSessions,


### PR DESCRIPTION
## Summary

캔버스 실행 메뉴의 `Claude (Gateway)` 행에 hover/`→`로 열리는 variants 플라이아웃을 추가합니다. Claude 내장 별칭 밴드(Fable·Opus·Sonnet, LOW–MAX 5단)와 설정에서 켠 Gateway 모델 밴드(모델별 선별 사다리)를 한 표면에 올리고, 칩 클릭 한 번에 `{model, effort}`가 세션 생성 → 검증 → `--model`/`--effort` argv까지 관통합니다. 부모 행 클릭은 기존 ★ 기본 실행 그대로입니다.

- SDK `OperationLaunchKind.variants` 제네릭 계약 + 공유 순수 sanitizer(`sdk/operations/launch-variants.ts`, 브라우저·호스트 양측 소비)
- 라우트/스폰 2중 검증: 별칭 화이트리스트·`resolveAiGatewaySelection` 대조·강도 노출 사다리 검사, stale 조합은 typed `GatewayLaunchOptionError`→409/400
- 캔버스·사이드바·트리아지 3표면 모두 variant 전달, 카탈로그 재조회 epoch 가드
- #559 압축 메뉴와 통합: variants 보유 행은 설명 어사이드 대신 플라이아웃이 유일한 사이드 표면, 플라이아웃은 캔버스 경계 내 양축 클램프

## Type of Change

- [x] feat — new feature or carrier capability

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-admiral build` / `test` (148 tests)
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 0 errors
- [x] `pnpm --filter @fleet-plugins/terminal test` — 58 files, 542 tests
- [x] console targeted vitest 6 files 147 tests (design contract 포함)
- [x] 격리 콘솔 실측: 카탈로그 HTTP variants 보존, 플라이아웃 렌더·어사이드 억제, 칩 클릭 → `POST {"model":"fable","effort":"max"}` → 실프로세스 argv `--model fable --effort max` 확인 (sonnet·opus 조합 동일 검증)

## Changelog

- [x] `.changelog.d/gateway-launch-variants.md` (fleet-console · Added · en/ko)