### PR TITLE
fix(fleet-console): reach Codex from a remote session

### DIFF
--- a/runtime/fleet-console/core/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/core/client/src/pages/global-settings.tsx
@@ -567,7 +567,10 @@ function RemoteAccessSection({ state, saving }: { readonly state: GlobalSettings
     setLink(null);
     setActionError(null);
     setRotateArmed(false);
-    void setGlobalSettingsField("remoteAccess", next);
+    // 저장은 낙관적 상태를 먼저 쓴다. 그 값에 걸린 위 effect는 서버가 리스너를 다시 세우기 전에
+    // 상태를 읽고, 뒤이어 도착하는 응답은 값이 같아 effect를 다시 깨우지 않는다 — 저장이 끝난 뒤
+    // 한 번 더 읽지 않으면 신원과 링크는 새로 고침 전까지 예전 값에 머문다.
+    void setGlobalSettingsField("remoteAccess", next).finally(refresh);
   };
   const run = (kind: "create" | "rotate" | "revoke", action: () => Promise<unknown>) => {
     setBusy(kind);

--- a/runtime/fleet-console/core/host/codex/cowork/routes.ts
+++ b/runtime/fleet-console/core/host/codex/cowork/routes.ts
@@ -7,12 +7,12 @@ import { withSecurityHeaders } from "../contracts.js";
 
 const CONFLICT_ERRORS = new Set(["cowork_busy", "cowork_apply_stale", "cowork_apply_busy", "cowork_apply_stale_revision"]);
 
-export async function handleCoworkRequest(request: IncomingMessage, response: ServerResponse, context: { workspaceId: string; paths: MemoryPaths; coworkService: CoworkService; allowedOrigins: Set<string>; port: number }): Promise<boolean> {
+export async function handleCoworkRequest(request: IncomingMessage, response: ServerResponse, context: { workspaceId: string; paths: MemoryPaths; coworkService: CoworkService; allowedOrigins: Set<string>; port: number; admitted: boolean }): Promise<boolean> {
   const url = new URL(request.url ?? "/", "http://127.0.0.1");
   if (!url.pathname.startsWith("/api/cowork")) return false;
-  // Read gate: loopback always; when a browser supplies Origin it must be an allowed one.
+  // Read gate: an admitted listener always; when a browser supplies Origin it must be an allowed one.
   if (!readAllowed(request, context)) return json(response, 403, { error: "origin_mismatch" });
-  // Write gate: loopback plus a mandatory allowed Origin.
+  // Write gate: an admitted listener plus a mandatory allowed Origin.
   if (request.method !== "GET" && !writeAllowed(request, context)) return json(response, 403, { error: "origin_mismatch" });
   // 인메모리 store 특성상 요청별 서비스 생성은 세션 소실로 이어진다 — 게이트웨이 캐시가 유일한 소유자다.
   const service = context.coworkService;
@@ -61,9 +61,10 @@ export async function handleCoworkRequest(request: IncomingMessage, response: Se
     return json(response, 404, { error: "not_found" });
   } catch (error) { const message = error instanceof Error ? error.message : "internal_error"; return json(response, CONFLICT_ERRORS.has(message) ? 409 : message.includes("not_found") ? 404 : 400, { error: message }); }
 }
-function isLoopback(r: IncomingMessage) { const addr = r.socket.remoteAddress; return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1"; }
-function readAllowed(r: IncomingMessage, c: { allowedOrigins: Set<string> }) { if (!isLoopback(r)) return false; const origin = r.headers.origin; return typeof origin !== "string" || c.allowedOrigins.has(origin); }
-function writeAllowed(r: IncomingMessage, c: { allowedOrigins: Set<string> }) { return isLoopback(r) && typeof r.headers.origin === "string" && c.allowedOrigins.has(r.headers.origin); }
+// 자격은 피어 주소가 아니라 요청이 통과한 리스너가 정한다 — 원격 리스너 요청은 라우팅 이전에
+// 세션 게이트를 통과했고, 읽기 전용 자격도 거기서 이미 묶인다.
+function readAllowed(r: IncomingMessage, c: { allowedOrigins: Set<string>; admitted: boolean }) { if (!c.admitted) return false; const origin = r.headers.origin; return typeof origin !== "string" || c.allowedOrigins.has(origin); }
+function writeAllowed(r: IncomingMessage, c: { allowedOrigins: Set<string>; admitted: boolean }) { return c.admitted && typeof r.headers.origin === "string" && c.allowedOrigins.has(r.headers.origin); }
 async function body(r: IncomingMessage): Promise<Record<string, unknown>> { let raw = ""; for await (const c of r) { raw += String(c); if (raw.length > 1024 * 1024) throw new Error("body_too_large"); } try { const v: unknown = JSON.parse(raw || "{}"); return v && typeof v === "object" && !Array.isArray(v) ? v as Record<string, unknown> : {}; } catch { throw new Error("invalid_json"); } }
 function annotation(value: unknown): CoworkAnnotationDto | null {
   if (!value || typeof value !== "object") return null;

--- a/runtime/fleet-console/core/host/codex/gateway.ts
+++ b/runtime/fleet-console/core/host/codex/gateway.ts
@@ -5,11 +5,12 @@ import net from "node:net";
 
 import type { MemoryPaths, WikiWorkspaceResolver } from "@dotobokuri/fleet-wiki";
 
-import { handleApiRequest } from "./routes.js";
+import { handleApiRequest, isLoopbackRemoteAddress } from "./routes.js";
 import { CoworkService, CoworkStore } from "@dotobokuri/fleet-wiki/cowork";
 import type { CoworkConnector } from "@dotobokuri/fleet-wiki/cowork";
 import { UnifiedAgent } from "@dotobokuri/core-unified-agent";
 import type { UnifiedClientOptions } from "@dotobokuri/core-unified-agent";
+import type { ListenerIdentity } from "../auth.js";
 import type { AllowedAccessSets } from "./contracts.js";
 import { WorkspaceRegistry } from "./workspaces.js";
 import type { WorkspaceRegistration } from "./workspaces.js";
@@ -20,6 +21,12 @@ interface CodexGatewayDeps {
   readonly host: string;
   readonly version: string;
   readonly getPort: () => number;
+  /**
+   * 요청이 도착한 리스너. Codex는 코어 Host 게이트보다 앞에서 분기하므로 자기 게이트가 유일한
+   * 경계인데, 그 경계는 바인드 호스트가 아니라 리스너마다 다르다. 원격 리스너를 모르는 게이트는
+   * 원격에서 연 Wiki를 전부 host_mismatch로 되돌린다.
+   */
+  readonly resolveListener?: (request: IncomingMessage) => ListenerIdentity | null;
   readonly wikiWorkspaceResolver: WikiWorkspaceResolver;
   readonly dataDir?: string;
 }
@@ -61,7 +68,7 @@ const LOOPBACK_HOST = "127.0.0.1";
 export function createCodexGateway(deps: CodexGatewayDeps): CodexGateway {
   const workspaces = new WorkspaceRegistry();
   const workspaceOwners = new Map<string, Set<string>>();
-  let accessSets: AllowedAccessSets | null = null;
+  const accessSetsByGate = new Map<string, AllowedAccessSets>();
   let initialWorkspace: Promise<WorkspaceRegistration> | null = null;
   let initialWorkspaceId: string | null = null;
   const coworkServices = new Map<string, CoworkService>();
@@ -85,7 +92,8 @@ export function createCodexGateway(deps: CodexGatewayDeps): CodexGateway {
       return true;
     }
     const port = deps.getPort();
-    accessSets ??= buildAllowedAccessSets(deps.host, port);
+    const listener = deps.resolveListener?.(request) ?? null;
+    const accessSets = accessSetsFor(listener, port);
     if (!isHostAllowed(request.rawHeaders, request.url ?? "/", accessSets.allowedHosts, port)) {
       sendJson(response, 403, { error: "host_mismatch" });
       return true;
@@ -127,10 +135,31 @@ export function createCodexGateway(deps: CodexGatewayDeps): CodexGateway {
       workspaceId: workspace.id,
       allowedOrigins: accessSets.allowedOrigins,
       externalMode: accessSets.externalMode,
+      admitted: isRequestAdmitted(listener, request),
       coworkService,
     });
     request.url = originalUrl;
     return handled;
+  }
+
+  /**
+   * 루프백 리스너와 리스너를 찾지 못한 요청은 바인드 호스트에서 파생한 기존 집합을 그대로 쓴다 —
+   * wildcard 바인드가 열어 두던 LAN 주소 집합을 좁히지 않기 위해서다. 원격 리스너는 그와 달리
+   * 자기 주소 하나만 연다.
+   */
+  function accessSetsFor(listener: ListenerIdentity | null, port: number): AllowedAccessSets {
+    if (listener === null || listener.audience === "local") {
+      return cachedAccessSets(`bind|${deps.host}|${port}`, () => buildAllowedAccessSets(deps.host, port));
+    }
+    return cachedAccessSets(`listener|${listener.origin}`, () => buildListenerAccessSets(listener));
+  }
+
+  function cachedAccessSets(key: string, build: () => AllowedAccessSets): AllowedAccessSets {
+    const cached = accessSetsByGate.get(key);
+    if (cached) return cached;
+    const sets = build();
+    accessSetsByGate.set(key, sets);
+    return sets;
   }
 
   async function ensureInitialWorkspace(): Promise<WorkspaceRegistration> {
@@ -219,6 +248,31 @@ export function buildAllowedAccessSets(
     allowedOrigins.add(`http://${formatHostForUrl(canonical)}:${port}`);
   }
   return { allowedHosts, allowedOrigins, externalMode: !isLoopbackBindHost(host) };
+}
+
+/**
+ * 원격 리스너의 경계는 그 리스너 하나다. 바인드 호스트에서 파생한 집합은 루프백을 동반하고
+ * 스킴이 http로 고정돼 있어, TLS로 뜬 원격 리스너는 자기 주소도 자기 Origin도 통과시키지 못한다.
+ */
+export function buildListenerAccessSets(listener: ListenerIdentity): AllowedAccessSets {
+  const canonical = canonicalizeAllowedHost(listener.host);
+  const allowedHosts = new Set<string>();
+  const allowedOrigins = new Set<string>();
+  if (canonical) {
+    allowedHosts.add(canonical);
+    allowedOrigins.add(`${listener.secure ? "https" : "http"}://${formatHostForUrl(canonical)}:${listener.port}`);
+  }
+  return { allowedHosts, allowedOrigins, externalMode: true };
+}
+
+/**
+ * 쓰기 자격은 "이 기계에서 왔는가"가 아니라 "어느 리스너를 통과했는가"다. 원격 리스너 요청은
+ * 라우팅 이전에 세션 게이트를 통과했고, monitoring 자격은 거기서 이미 읽기로 묶인다 — 여기서
+ * 피어 주소를 다시 보면 원격은 세션이 있어도 영원히 읽기 전용이 된다.
+ */
+function isRequestAdmitted(listener: ListenerIdentity | null, request: IncomingMessage): boolean {
+  if (listener !== null && listener.audience !== "local") return true;
+  return isLoopbackRemoteAddress(request.socket.remoteAddress);
 }
 
 function selectWorkspace(requestUrl: string, workspaces: WorkspaceRegistry, cwd: string): WorkspaceSelection {

--- a/runtime/fleet-console/core/host/codex/routes.ts
+++ b/runtime/fleet-console/core/host/codex/routes.ts
@@ -55,6 +55,8 @@ interface RouteContext {
   workspaceId: string;
   allowedOrigins: Set<string>;
   externalMode: boolean;
+  /** 이 요청이 통과한 리스너가 쓰기를 허락하는가. 게이트웨이가 리스너로 판정해 넘긴다. */
+  admitted: boolean;
   coworkService?: CoworkService;
 }
 
@@ -227,7 +229,7 @@ async function routePost(url: URL, request: IncomingMessage, response: ServerRes
     return;
   }
 
-  if (!isLoopbackRemoteAddress(request.socket.remoteAddress)) {
+  if (!context.admitted) {
     sendJson(response, 403, { error: "write_loopback_only" });
     return;
   }
@@ -631,11 +633,13 @@ function isOriginAllowed(origin: string, allowedOrigins: Set<string>, serverPort
   } catch {
     return false;
   }
-  if (parsed.protocol !== "http:") return false;
+  // 원격 리스너는 TLS라 Origin이 https로 온다. 스킴을 http로 못 박으면 그 Origin은 어떤 집합과도
+  // 일치할 수 없다 — 허용 집합이 스킴까지 들고 있으므로 비교는 Origin의 스킴 그대로 한다.
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
   if (Number(parsed.port) !== serverPort) return false;
   const normalizedHost = normalizeOriginHostname(parsed.hostname);
   if (!normalizedHost) return false;
-  return allowedOrigins.has(`http://${net.isIP(normalizedHost) === 6 ? `[${normalizedHost}]` : normalizedHost}:${serverPort}`);
+  return allowedOrigins.has(`${parsed.protocol}//${net.isIP(normalizedHost) === 6 ? `[${normalizedHost}]` : normalizedHost}:${serverPort}`);
 }
 
 function sendJson(response: ServerResponse, statusCode: number, body: unknown): void {

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -404,6 +404,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     host,
     version,
     getPort: () => lockHandle?.payload.port ?? port,
+    resolveListener: (request) => listenerForRequest(request),
     wikiWorkspaceResolver,
     dataDir: durablePaths.dir,
   });
@@ -785,7 +786,9 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       runAsyncBooleanHandler(codex.handle(req, res), res, () => tryServeStaticConsole(req, res, pathname));
       return;
     }
-    // Host 게이트는 순서를 바꾸지 않는다 — Codex는 wildcard 바인드에서 더 넓은 host 집합을 쓴다.
+    // Host 게이트는 순서를 바꾸지 않는다 — Codex는 wildcard 바인드에서 더 넓은 host 집합을 쓰므로
+    // 자기 게이트를 그대로 유지한다. 대신 같은 리스너 판정을 주입받아, 원격 리스너의 Host·Origin도
+    // 그 게이트가 알고 있다.
     if (!isRequestHostAllowed(req)) {
       writeJson(res, 403, { error: "host_mismatch" });
       return;

--- a/runtime/fleet-console/tests/codex-cowork-routes.test.ts
+++ b/runtime/fleet-console/tests/codex-cowork-routes.test.ts
@@ -42,7 +42,7 @@ describe("Cowork DTO", () => {
     await writeWikiEntry(entry(), paths);
     const service = new CoworkService(new CoworkStore(), paths, root, new FakeConnector());
     const session = await service.create("workspace", "entry");
-    const server = createServer((request, response) => void handleCoworkRequest(request, response, { workspaceId: "workspace", paths, coworkService: service, allowedOrigins: new Set(["http://console.test"]), port: 0 }));
+    const server = createServer((request, response) => void handleCoworkRequest(request, response, { workspaceId: "workspace", paths, coworkService: service, allowedOrigins: new Set(["http://console.test"]), port: 0, admitted: true }));
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
     try {
@@ -69,7 +69,7 @@ describe("Cowork DTO", () => {
     const paths = createMemoryPaths(join(root, "knowledge"));
     await ensureMemoryRoot(paths);
     const service = new CoworkService(new CoworkStore(), paths, root, new FakeConnector());
-    const server = createServer((request, response) => void handleCoworkRequest(request, response, { workspaceId: "workspace", paths, coworkService: service, allowedOrigins: new Set(["http://console.test"]), port: 0 }));
+    const server = createServer((request, response) => void handleCoworkRequest(request, response, { workspaceId: "workspace", paths, coworkService: service, allowedOrigins: new Set(["http://console.test"]), port: 0, admitted: true }));
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
     try {
@@ -96,7 +96,7 @@ describe("Cowork DTO", () => {
     await writeWikiEntry(entry(), paths);
     const service = new CoworkService(new CoworkStore(), paths, root, new FakeConnector());
     const session = await service.create("workspace", "entry");
-    const server = createServer((request, response) => void handleCoworkRequest(request, response, { workspaceId: "workspace", paths, coworkService: service, allowedOrigins: new Set(["http://console.test"]), port: 0 }));
+    const server = createServer((request, response) => void handleCoworkRequest(request, response, { workspaceId: "workspace", paths, coworkService: service, allowedOrigins: new Set(["http://console.test"]), port: 0, admitted: true }));
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
     try {
@@ -132,7 +132,7 @@ describe("Cowork DTO", () => {
     const service = new CoworkService(new CoworkStore(), paths, root, connector);
     const session = await service.create("workspace", "entry");
     await service.prompt("workspace", session.id, "first");
-    const server = createServer((request, response) => void handleCoworkRequest(request, response, { workspaceId: "workspace", paths, coworkService: service, allowedOrigins: new Set(["http://console.test"]), port: 0 }));
+    const server = createServer((request, response) => void handleCoworkRequest(request, response, { workspaceId: "workspace", paths, coworkService: service, allowedOrigins: new Set(["http://console.test"]), port: 0, admitted: true }));
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
     try {

--- a/runtime/fleet-console/tests/codex-schema-api.test.ts
+++ b/runtime/fleet-console/tests/codex-schema-api.test.ts
@@ -122,6 +122,7 @@ describe("Codex schema API", () => {
       workspaceId: "test",
       allowedOrigins: new Set(),
       externalMode: false,
+      admitted: true,
     });
     return result;
   }

--- a/runtime/fleet-console/tests/codex-security-routes.test.ts
+++ b/runtime/fleet-console/tests/codex-security-routes.test.ts
@@ -7,7 +7,7 @@ import type { ServerResponse } from "node:http";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { buildAllowedAccessSets } from "../core/host/codex/gateway.js";
+import { buildAllowedAccessSets, buildListenerAccessSets } from "../core/host/codex/gateway.js";
 import { handleApiRequest, isLoopbackRemoteAddress } from "../core/host/codex/routes.js";
 import { startCodexTestServer } from "./codex-test-server.js";
 import type { CodexTestServer } from "./codex-test-server.js";
@@ -555,15 +555,54 @@ describe("loopback-only origin check", () => {
     expect(isLoopbackRemoteAddress("::ffff:192.168.1.10")).toBe(false);
   });
 
-  it("rejects non-loopback drydock writes before Origin validation", async () => {
+  it("rejects drydock writes the listener did not admit, before Origin validation", async () => {
     const response = createResponseRecorder();
     await handleApiRequest(
       createRouteRequest(`/api/drydock/${VALID_PATCH_ID}/decision`, "POST", "192.168.1.10"),
       response.response,
-      createMinimalRouteContext(),
+      createMinimalRouteContext({ admitted: false }),
     );
     expect(response.statusCode).toBe(403);
     expect(response.body).toContain("write_loopback_only");
+  });
+
+  // 원격 리스너를 통과한 요청은 피어 주소가 루프백이 아니어도 쓰기 자격을 갖는다 — 세션 게이트가
+  // 라우팅 이전에 이미 판정했고, 여기서 피어를 다시 보면 원격은 영원히 읽기 전용이 된다.
+  it("admits drydock writes from a remote listener with its own https Origin", async () => {
+    const request = createRouteRequest(`/api/drydock/${VALID_PATCH_ID}/decision`, "POST", "192.168.1.10");
+    request.headers.origin = "https://desk.local:3737";
+    const response = createResponseRecorder();
+    await handleApiRequest(request, response.response, createMinimalRouteContext({
+      allowedOrigins: new Set(["https://desk.local:3737"]),
+    }));
+    expect(response.statusCode).toBe(415);
+    expect(response.body).toContain("unsupported_media_type");
+  });
+
+  it("still rejects an Origin the listener does not allow", async () => {
+    const request = createRouteRequest(`/api/drydock/${VALID_PATCH_ID}/decision`, "POST", "192.168.1.10");
+    request.headers.origin = "https://evil.example:3737";
+    const response = createResponseRecorder();
+    await handleApiRequest(request, response.response, createMinimalRouteContext({
+      allowedOrigins: new Set(["https://desk.local:3737"]),
+    }));
+    expect(response.statusCode).toBe(403);
+    expect(response.body).toContain("origin_mismatch");
+  });
+
+  it("scopes a remote listener's access sets to that listener alone", () => {
+    const access = buildListenerAccessSets({
+      audience: "remote",
+      host: "desk.local",
+      port: 4242,
+      origin: "https://desk.local:4242",
+      secure: true,
+      bindAddress: "192.168.1.50",
+    });
+    expect(access.allowedHosts).toEqual(new Set(["desk.local"]));
+    expect(access.allowedOrigins).toEqual(new Set(["https://desk.local:4242"]));
+    expect(access.allowedHosts.has("127.0.0.1")).toBe(false);
+    expect(access.externalMode).toBe(true);
   });
 });
 
@@ -655,7 +694,9 @@ function findNonLoopbackIpv4(): string | null {
   return null;
 }
 
-function createMinimalRouteContext(): Parameters<typeof handleApiRequest>[2] {
+function createMinimalRouteContext(
+  overrides: { admitted?: boolean; allowedOrigins?: Set<string> } = {},
+): Parameters<typeof handleApiRequest>[2] {
   return {
     cwd: tempDir || "/tmp/fleet-console-codex-test",
     knowledgeRoot: path.join(tempDir || "/tmp/fleet-console-codex-test", ".fleet", "knowledge"),
@@ -672,8 +713,9 @@ function createMinimalRouteContext(): Parameters<typeof handleApiRequest>[2] {
     port: 3737,
     host: "127.0.0.1",
     workspaceId: "test-workspace",
-    allowedOrigins: new Set(["http://127.0.0.1:3737"]),
+    allowedOrigins: overrides.allowedOrigins ?? new Set(["http://127.0.0.1:3737"]),
     externalMode: false,
+    admitted: overrides.admitted ?? true,
   };
 }
 

--- a/runtime/fleet-console/tests/remote-access-listener.test.ts
+++ b/runtime/fleet-console/tests/remote-access-listener.test.ts
@@ -251,6 +251,25 @@ describe.skipIf(REMOTE_HOST === null)("remote access listener", () => {
   });
 
   /**
+   * 원격 리스너의 Host는 루프백 바인드 호스트가 아니다. Codex가 자기 게이트를 바인드 호스트에서만
+   * 세우면, 세션을 정상적으로 연 사용자도 Wiki를 열 때마다 host_mismatch를 돌려받는다.
+   */
+  it("lets an admitted session reach Codex through the remote listener's own host", async () => {
+    const fixture = await startFixture({ remote: true });
+    const operator = await joinAs(fixture, "full", "MacBook Pro");
+
+    // 등록되지 않은 workspace라 라우팅은 곧장 404로 끝난다 — 여기서 보는 것은 Host 게이트뿐이다.
+    const reached = await remoteRequestBody(fixture, "GET", "/console/codex/w/absent/api/search", undefined, operator);
+    // 자기 주소만 연다: 원격 리스너에 붙어 다른 호스트를 주장하는 요청은 그대로 막힌다.
+    const foreign = await remoteRequestBody(fixture, "GET", "/console/codex/w/absent/api/search", `203.0.113.10:${fixture.remotePort}`, operator);
+
+    expect(reached.status).toBe(404);
+    expect(reached.body).toContain("workspace_not_found");
+    expect(foreign.status).toBe(403);
+    expect(foreign.body).toContain("host_mismatch");
+  });
+
+  /**
    * 저장된 주소는 어제 붙어 있던 인터페이스의 것이다. 그 주소가 사라졌을 때 기동까지 함께
    * 무너지면, 사용자는 설정을 고칠 화면조차 열 수 없다.
    */
@@ -432,6 +451,7 @@ function remoteRequestBody(
   requestPath: string,
   /** Host를 위조한 요청을 보내기 위한 자리 — 게이트가 헤더를 믿지 않는지 확인한다. */
   hostHeader?: string,
+  cookie?: string,
 ): Promise<{ status: number; headers: import("node:http").IncomingHttpHeaders; body: string }> {
   return new Promise((resolve, reject) => {
     const request = https.request({
@@ -441,7 +461,10 @@ function remoteRequestBody(
       method,
       rejectUnauthorized: false,
       checkServerIdentity: () => undefined,
-      headers: { host: hostHeader ?? `${BIND_HOST}:${fixture.remotePort}` },
+      headers: {
+        host: hostHeader ?? `${BIND_HOST}:${fixture.remotePort}`,
+        ...(cookie ? { cookie } : {}),
+      },
     }, (response) => {
       const chunks: Buffer[] = [];
       response.on("data", (chunk: Buffer) => chunks.push(chunk));


### PR DESCRIPTION
## Summary

원격 리스너로 접속한 브라우저에서 Codex(Wiki)를 열면 `host_mismatch`가 돌아왔고, 설정의 "다른 기기의 접속 허용"을 켜도 신원·링크가 새로 고침 전까지 갱신되지 않았습니다.

- **Codex 게이트가 리스너를 모른다.** Codex는 코어 Host 게이트보다 앞에서 분기하므로 자기 게이트가 유일한 경계인데, 그 게이트는 루프백 바인드 호스트에서 파생한 집합 하나를 만들어 메모이즈했습니다. 이제 코어가 이미 계산해 두는 리스너 신원을 주입받아 게이트별로 집합을 나눠 캐시합니다 — 루프백과 리스너 미상 경로는 기존 바인드 호스트 집합 그대로(wildcard 바인드의 LAN 주소 열거 포함), 원격 리스너는 자기 주소 하나만.
- **Origin 비교가 `http:`로 못박혀** 있어 TLS 원격 리스너의 `https://` Origin은 어떤 집합과도 일치할 수 없었습니다. Origin 자신의 스킴으로 비교합니다.
- **쓰기 게이트가 피어 주소를 봤습니다.** Codex `routePost`와 cowork 읽기/쓰기 게이트가 "루프백에서 왔는가"를 물었는데, 원격 요청은 이를 영원히 만족할 수 없습니다. 원격 세션 게이트가 라우팅 이전에 이미 판정했고 monitoring 자격은 거기서 읽기로 묶이므로, 이제 그 판정(`admitted`)을 읽습니다.
- **설정 화면**은 저장이 resolve된 뒤 remote access를 한 번 더 읽습니다. 낙관적 상태에 걸린 effect가 서버의 리스너 재구성보다 먼저 돌고, 뒤이은 응답은 값이 같아 effect를 다시 깨우지 않던 경로였습니다.

## Test Plan

- [x] `pnpm --filter fleet-console typecheck` — 0 errors
- [x] `pnpm --filter fleet-console build`
- [x] 전체 vitest: 2 failed / 1622 passed / 18 skipped. 실패 2건(`tests/i18n.test.ts`, `tests/triage-store.test.ts`)은 `git stash` 후 동일 baseline에서 동일하게 재현되는 선존 실패
- [x] 신규 회귀 테스트: 원격 리스너 Host 게이트 e2e(`remote-access-listener.test.ts` — 사전 403 `host_mismatch` → 사후 404 `workspace_not_found`, 위조 Host는 여전히 403), 원격 리스너 https Origin 쓰기 허용/거부와 리스너별 집합 범위(`codex-security-routes.test.ts`)

## Changelog

두 결함 모두 아직 릴리스되지 않은 `.changelog.d/remote-access-auth-spine.md`(원격 접속 기능)가 도입한 동작의 정정입니다. `.changelog.d/AGENTS.md`의 Release Baseline은 이 경우 standalone `Fixed` 항목을 금지하고 해당 프래그먼트에 접어 넣거나 `no-changelog`로 분류하라고 요구하는데, CI base-fragment 가드가 base에 있는 프래그먼트의 어떤 수정도 차단하므로 PR 경로에서는 접어 넣을 수 없습니다. 따라서 `no-changelog`입니다 — 출시된 어떤 버전의 사용자도 이 동작에 닿을 수 없었습니다. 사유 코드 다섯 개 중 "미릴리스 동작 정정"에 정확히 대응하는 값은 없어, 실제 변경(리스너 경계 게이트)에 가장 가까운 `boundary-gate`를 씁니다.

Changelog-Impact: none
No-Changelog-Reason: boundary-gate