### PR TITLE
fix(fleet-cli): register gateway identities as plugin agent files

### DIFF
--- a/.changelog.d/gateway-agents-as-plugin-files.md
+++ b/.changelog.d/gateway-agents-as-plugin-files.md
@@ -1,0 +1,21 @@
+---
+branch: gateway-agents-as-plugin-files
+---
+
+### fleet-cli
+#### Changed
+- Gateway model identities now carry the Fleet plugin scope. Select one as `fleet:<name>`, which is the spelling `gateway_models` reports, and the same rule the bundled Fleet skills already follow.
+  ko: 게이트웨이 모델 정체성이 이제 Fleet 플러그인 스코프를 답니다. `fleet:<name>` 철자로 고르며, 이는 `gateway_models`가 보고하는 철자이자 함께 실리는 Fleet 스킬이 이미 따르던 규칙입니다.
+
+#### Fixed
+- A large enabled model roster no longer breaks the launch on Windows. Identity definitions moved off the command line into plugin files, so the number of models you enable no longer competes with the Windows command-line limit.
+  ko: 활성 모델이 많아도 Windows에서 실행이 깨지지 않습니다. 정체성 정의가 명령줄에서 플러그인 파일로 옮겨져, 켜 둔 모델 수가 Windows 명령줄 한도와 더는 경합하지 않습니다.
+
+### fleet-console
+#### Changed
+- Gateway model identities now carry the Fleet plugin scope. An Agent Operation selects one as `fleet:<name>`, which is the spelling `gateway_models` reports.
+  ko: 게이트웨이 모델 정체성이 이제 Fleet 플러그인 스코프를 답니다. Agent Operation은 `fleet:<name>` 철자로 고르며, 이는 `gateway_models`가 보고하는 철자입니다.
+
+#### Fixed
+- A Claude (Gateway) Operation no longer fails to start on Windows when many gateway models are enabled. Identity definitions moved off the command line into plugin files, so the roster size no longer competes with the Windows command-line limit.
+  ko: 게이트웨이 모델을 많이 켜 두어도 Windows에서 Claude (Gateway) Operation이 시작에 실패하지 않습니다. 정체성 정의가 명령줄에서 플러그인 파일로 옮겨져, 로스터 크기가 Windows 명령줄 한도와 더는 경합하지 않습니다.

--- a/packages/fleet-admiral/src/agent-cli/builders/claude.ts
+++ b/packages/fleet-admiral/src/agent-cli/builders/claude.ts
@@ -9,7 +9,6 @@ export function buildClaudeNativeArgs(context: AgentCliInjectionContext): string
       pluginRoot,
     ]),
     ...(context.mcpServers.length > 0 ? ["--mcp-config", buildClaudeMcpConfig(context.mcpServers)] : []),
-    ...buildCustomAgentsArgs(context.customAgents),
     ...buildSettingsArgs(context.skillOverrides),
     "--dangerously-skip-permissions",
   ];
@@ -24,13 +23,6 @@ function buildSettingsArgs(
 ): string[] {
   if (skillOverrides === undefined || Object.keys(skillOverrides).length === 0) return [];
   return ["--settings", JSON.stringify({ skillOverrides })];
-}
-
-function buildCustomAgentsArgs(
-  agents: AgentCliInjectionContext["customAgents"],
-): string[] {
-  if (agents === undefined || Object.keys(agents).length === 0) return [];
-  return ["--agents", JSON.stringify(agents)];
 }
 
 function buildResumeArgs(resumeSessionId: string | undefined): string[] {

--- a/packages/fleet-admiral/src/agent-cli/gateway-agents.ts
+++ b/packages/fleet-admiral/src/agent-cli/gateway-agents.ts
@@ -1,9 +1,16 @@
 /**
- * gateway-agents — claude-gateway 스폰 시 주입하는 커스텀 Agent 정의.
+ * gateway-agents — claude-gateway 세션이 등록하는 Agent 정의.
  *
- * 파일 영속화 없이 `--agents`로만 전달한다. 모델 id는 반드시
- * `claude-gateway--*` 형태(toClaudeGatewayModelId)다. effort를 지원하는 모델은
- * ladder의 각 강도마다 Agent를 하나씩 만든다.
+ * 정의는 Fleet 플러그인의 `agents/` 디렉터리에 파일로 놓인다. 한때는 `--agents`
+ * JSON으로 argv에 실어 보냈는데, 정의 하나가 1.9KB쯤이고 모델×강도마다 하나씩
+ * 생기므로 로스터가 스무 개만 돼도 페이로드가 40KB에 이른다. Windows는 명령줄
+ * 전체가 CreateProcess에서 32,767자, npm `.cmd` shim처럼 cmd.exe를 경유하는
+ * 경로에서는 8,191자에서 잘리므로, 프롬프트를 한 글자도 싣기 전에 실행 자체가
+ * 불가능해진다. 파일로 옮기면 argv에는 이미 있던 `--plugin-dir` 경로만 남는다.
+ *
+ * 대가는 이름이다. 플러그인이 실은 Agent는 `<plugin>:<name>`으로 등록되므로
+ * 호스트가 고르는 철자가 `fleet:`을 얻는다 — 같은 플러그인이 싣는 스킬이 이미
+ * `fleet:workflow`로 불리는 것과 같은 규칙이다.
  *
  * 게이트웨이 정의는 Claude Code 내장 Agent를 대체하지 않고 그 옆에 놓인다.
  * 내장 Agent를 끄면 상속(unpinned) 위임 자체가 막혀, 게이트웨이 세션에서
@@ -40,6 +47,14 @@ export const GENERAL_PURPOSE_AGENT_PROMPT = [
   "Final reply: concise essentials only — mode, what changed or found, key evidence (path:line when relevant), and blockers/deviations.",
 ].join("\n");
 
+/**
+ * Fleet 플러그인이 선언하는 이름. Claude Code는 플러그인이 실은 Agent를
+ * `<plugin>:<name>`으로 등록하므로, 이 값이 곧 정체성 철자의 앞부분이다.
+ * 플러그인 매니페스트는 이 상수를 그대로 쓴다 — 둘이 갈라지면 호스트가 부르는
+ * 이름과 Claude Code가 등록한 이름이 조용히 어긋난다.
+ */
+export const FLEET_PLUGIN_NAME = "fleet";
+
 export interface ClaudeCustomAgentDefinition {
   readonly description: string;
   readonly prompt: string;
@@ -49,8 +64,14 @@ export interface ClaudeCustomAgentDefinition {
   readonly effort?: GatewayReasoningEffort;
 }
 
-/** Agent 이름 → 정의. `--agents` JSON 객체와 동일 형태. */
+/** Agent 이름(스코프 없는 파일 stem) → 정의. */
 export type ClaudeCustomAgents = Readonly<Record<string, ClaudeCustomAgentDefinition>>;
+
+/** 플러그인 `agents/` 아래에 놓일 파일 하나. */
+export interface GatewayAgentFile {
+  readonly fileName: string;
+  readonly content: string;
+}
 
 /**
  * Scoped gateway 모델 id(`kimi--k3-256k`) → 사용자가 정체성으로 내보낸 강도들.
@@ -95,7 +116,7 @@ export function buildGatewayCustomAgents(
       for (const effort of exposedEffortLadder(model.id, constraints.effortLadder, exposure)) {
         const name = toGatewayAgentName(modelId, effort);
         agents[name] = {
-          description: gatewayAgentDescription(modelId, name, constraints.capabilityClass, effort),
+          description: gatewayAgentDescription(modelId, toGatewayAgentSelector(modelId, effort), constraints.capabilityClass, effort),
           prompt: GENERAL_PURPOSE_AGENT_PROMPT,
           model: modelId,
           effort,
@@ -105,7 +126,7 @@ export function buildGatewayCustomAgents(
     }
     const name = toGatewayAgentName(modelId);
     agents[name] = {
-      description: gatewayAgentDescription(modelId, name, constraints.capabilityClass),
+      description: gatewayAgentDescription(modelId, toGatewayAgentSelector(modelId), constraints.capabilityClass),
       prompt: GENERAL_PURPOSE_AGENT_PROMPT,
       model: modelId,
     };
@@ -114,7 +135,42 @@ export function buildGatewayCustomAgents(
 }
 
 /**
- * Claude Code Agent 타입 키로 쓸 안전한 이름.
+ * 플러그인 `agents/`에 그대로 쓸 파일들. frontmatter의 `name`은 스코프 없는 stem이다 —
+ * Claude Code는 `:`를 스코프 구분자로 예약해 두어, 이름에 넣으면 그 파일을 아예 읽지 않는다.
+ *
+ * 값은 전부 JSON 문자열로 적는다. JSON은 YAML 1.2의 부분집합이라 따옴표·백슬래시·개행이
+ * 그대로 살고, `[1m]`처럼 흐름 시퀀스로 읽힐 수 있는 모델 id도 스칼라로 고정된다.
+ */
+export function buildGatewayAgentFiles(
+  exposed: readonly GatewayModel[],
+  exposure?: GatewayEffortExposure,
+): readonly GatewayAgentFile[] {
+  return Object.entries(buildGatewayCustomAgents(exposed, exposure)).map(([name, definition]) => ({
+    fileName: `${name}.md`,
+    content: [
+      "---",
+      `name: ${JSON.stringify(name)}`,
+      `description: ${JSON.stringify(definition.description)}`,
+      `model: ${JSON.stringify(definition.model)}`,
+      ...(definition.effort === undefined ? [] : [`effort: ${JSON.stringify(definition.effort)}`]),
+      "---",
+      "",
+      definition.prompt,
+      "",
+    ].join("\n"),
+  }));
+}
+
+/**
+ * 호스트가 정체성을 고를 때 쓰는 철자. 플러그인 스코프가 붙은 이 이름만 Agent 자리에
+ * 넣을 수 있고, 스코프 없는 stem은 파일 이름일 뿐이다.
+ */
+export function toGatewayAgentSelector(modelId: string, effort?: GatewayReasoningEffort): string {
+  return `${FLEET_PLUGIN_NAME}:${toGatewayAgentName(modelId, effort)}`;
+}
+
+/**
+ * Agent 파일 이름과 frontmatter `name`에 쓰는 stem.
  * `claude-gateway--cursor--claude-opus-5[1m]` + `high` → `cursor-claude-opus-5-1m-high`
  */
 export function toGatewayAgentName(modelId: string, effort?: GatewayReasoningEffort): string {
@@ -136,7 +192,7 @@ export function toGatewayAgentName(modelId: string, effort?: GatewayReasoningEff
  */
 function gatewayAgentDescription(
   modelId: string,
-  name: string,
+  selector: string,
   capabilityClass?: GatewayCapabilityClass,
   effort?: GatewayReasoningEffort,
 ): string {
@@ -148,7 +204,7 @@ function gatewayAgentDescription(
     `Gateway model ${modelId}, ${classPart}, ${effortPart}.`,
     "Fleet execution agent that runs one mode — recon, decide, implement, or verify. Name the mode in the task.",
     "Use after calling gateway_models when this roster entry fits the stage.",
-    `Select this identity by the agent type name ${name}. The model id above is a value for a model field and is rejected wherever a name is expected.`,
+    `Select this identity by the agent type name ${selector}, colon included. The model id above is a value for a model field and is rejected wherever a name is expected.`,
     ...(effort === undefined
       ? []
       : [`That name already carries ${effort}, so pinning a reasoning effort alongside it is redundant.`]),

--- a/packages/fleet-admiral/src/agent-cli/injection.ts
+++ b/packages/fleet-admiral/src/agent-cli/injection.ts
@@ -113,6 +113,9 @@ export async function injectAgentCliProfile(
       inputWaitingHookExec: options.inputWaitingHookExec,
       backgroundReportHookExec: options.backgroundReportHookExec,
       autoNameHookExec: options.autoNameHookExec,
+      // 게이트웨이 정체성은 플러그인이 파일로 싣는다 — argv에는 이미 있던 플러그인 경로만 남는다.
+      gatewayExposedModels: options.gatewayExposedModels,
+      gatewayEffortExposure: options.gatewayEffortExposure,
       withMarketplaceLock: options.withMarketplaceLock,
     });
     const cleanup = createOnceCleanup(() => {
@@ -124,13 +127,7 @@ export async function injectAgentCliProfile(
     });
     options.onCleanup?.(cleanup);
     const gatewayAgents = profile.id === "claude-gateway"
-      ? {
-        customAgents: buildGatewayCustomAgents(
-          options.gatewayExposedModels ?? [],
-          options.gatewayEffortExposure,
-        ),
-        skillOverrides: buildDisabledSkillOverrides(GATEWAY_DISABLED_CLAUDE_SKILLS),
-      }
+      ? { skillOverrides: buildDisabledSkillOverrides(GATEWAY_DISABLED_CLAUDE_SKILLS) }
       : {};
     const context: AgentCliInjectionContext = {
       cliId: profile.id,

--- a/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
+++ b/packages/fleet-admiral/src/agent-cli/plugin/fleet.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 
 import { resolveDoctrineFromCliId, type AdmiralDoctrine } from "../../protocols/doctrine.js";
 import { EMBEDDED_AGENT_CLI_SKILL_ASSETS } from "../assets.generated.js";
+import { buildGatewayAgentFiles, FLEET_PLUGIN_NAME } from "../gateway-agents.js";
 import { writePrivateFile, writePrivateJson } from "./fs.js";
 import type { FleetHookExec } from "../types.js";
 import type { AssetPluginBundle, CreateAgentCliPluginOptions } from "../types.js";
@@ -13,7 +14,7 @@ export const assetBundle: AssetPluginBundle = {
   description: "Fleet workflow orchestration and wiki evidence plugin",
   directoryName: "fleet-gateway",
   displayName: "Fleet",
-  name: "fleet",
+  name: FLEET_PLUGIN_NAME,
   source: "asset",
 };
 
@@ -30,6 +31,17 @@ export function renderAssetPluginRoot(
   renderEmbeddedSkillAssets(pluginRoot, doctrine);
   if (options.cliId === "claude-native" || options.cliId === "claude-gateway") {
     writePrivateJson(path.join(pluginRoot, "hooks", "hooks.json"), claudeHooks(options), pluginRoot);
+  }
+  // 게이트웨이 정체성은 이 플러그인이 싣는다. 렌더는 스테이징 디렉터리에 전부 쓰고
+  // 한 번에 rename하므로, 노출 목록이 줄어든 세션에서 옛 정의가 남아 있을 수 없다.
+  if (options.cliId === "claude-gateway") {
+    renderGatewayAgentAssets(pluginRoot, options);
+  }
+}
+
+function renderGatewayAgentAssets(pluginRoot: string, options: CreateAgentCliPluginOptions): void {
+  for (const file of buildGatewayAgentFiles(options.gatewayExposedModels ?? [], options.gatewayEffortExposure)) {
+    writePrivateFile(path.join(pluginRoot, "agents", file.fileName), file.content, pluginRoot);
   }
 }
 

--- a/packages/fleet-admiral/src/agent-cli/types.ts
+++ b/packages/fleet-admiral/src/agent-cli/types.ts
@@ -1,3 +1,5 @@
+import type { GatewayEffortExposure, GatewayModel } from "@dotobokuri/core-ai-gateway";
+
 import type { AdmiralDoctrine } from "../protocols/doctrine.js";
 import type { ClaudeSkillOverride } from "./gateway-skills.js";
 
@@ -71,16 +73,6 @@ export interface AgentCliMcpServerArg {
 export interface AgentCliInjectionContext {
   readonly cliId: AgentCliId;
   /**
-   * Claude Code `--agents` JSON object. Gateway sessions inject AI Gateway
-   * model/effort agents here without writing agent files.
-   */
-  readonly customAgents?: Readonly<Record<string, {
-    readonly description: string;
-    readonly prompt: string;
-    readonly model: string;
-    readonly effort?: string;
-  }>>;
-  /**
    * Claude Code `--settings`의 `skillOverrides` 맵. 세션이 싣지 않을 내장 스킬을
    * `off`로 넣는다. 프로세스 단위 필터라 서브에이전트 목록에도 함께 적용된다.
    */
@@ -132,6 +124,10 @@ export interface CreateAgentCliPluginOptions {
   readonly inputWaitingHookExec?: FleetHookExec;
   // 작전명 자동 작명(UserPromptSubmit)을 위해 prompt를 호스트로 전달하는 hook.
   readonly autoNameHookExec?: FleetHookExec;
+  // 사용자가 노출한 gateway 모델과 강도. claude-gateway 렌더만 읽어 `agents/` 정의를 만든다.
+  // 정의가 argv가 아니라 이 플러그인에 실리므로, 노출 목록은 스폰 인자가 아니라 렌더 입력이다.
+  readonly gatewayExposedModels?: readonly GatewayModel[];
+  readonly gatewayEffortExposure?: GatewayEffortExposure;
   readonly onCleanup?: (cleanup: () => void) => void;
   readonly rootDir?: string;
   readonly withMarketplaceLock: AgentCliPluginMarketplaceLock;

--- a/packages/fleet-admiral/src/ai-gateway/model-loadout.ts
+++ b/packages/fleet-admiral/src/ai-gateway/model-loadout.ts
@@ -20,7 +20,7 @@ import { createHash } from "node:crypto";
 
 import {
   exposedEffortLadder,
-  toGatewayAgentName,
+  toGatewayAgentSelector,
   type GatewayEffortExposure,
 } from "../agent-cli/gateway-agents.js";
 
@@ -230,10 +230,10 @@ function toAgentTypeSelectors(
   constraints: GatewayLoadoutConstraints,
 ): GatewayAgentTypeSelectors {
   if (!constraints.effortSupported) {
-    return Object.freeze({ none: toGatewayAgentName(id) });
+    return Object.freeze({ none: toGatewayAgentSelector(id) });
   }
   return Object.freeze(Object.fromEntries(
-    constraints.effortLadder.map((effort) => [effort, toGatewayAgentName(id, effort)]),
+    constraints.effortLadder.map((effort) => [effort, toGatewayAgentSelector(id, effort)]),
   ));
 }
 

--- a/packages/fleet-admiral/src/index.ts
+++ b/packages/fleet-admiral/src/index.ts
@@ -101,11 +101,15 @@ export {
 } from "./agent-cli/injection.js";
 
 export {
+  FLEET_PLUGIN_NAME,
   GENERAL_PURPOSE_AGENT_PROMPT,
+  buildGatewayAgentFiles,
   buildGatewayCustomAgents,
   toGatewayAgentName,
+  toGatewayAgentSelector,
   type ClaudeCustomAgentDefinition,
   type ClaudeCustomAgents,
+  type GatewayAgentFile,
   type GatewayEffortExposure,
 } from "./agent-cli/gateway-agents.js";
 

--- a/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -6,6 +6,7 @@ import { findGatewayModel } from "@dotobokuri/core-ai-gateway";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  FLEET_PLUGIN_NAME,
   GATEWAY_DISABLED_CLAUDE_SKILLS,
   GENERAL_PURPOSE_AGENT_PROMPT,
   buildDisabledSkillOverrides,
@@ -86,7 +87,7 @@ describe("claude-gateway custom agents", () => {
       expect(agent.description).not.toMatch(/researching complex questions/i);
       // 이름과 모델 id는 철자가 다르고 서로 대체되지 않는다. 이 문장이 사라지면 둘을 잇는
       // 자리가 없어지고, 이름을 요구하는 자리에 모델 id를 넣는 실패로 되돌아간다.
-      expect(agent.description).toContain(`agent type name ${name}`);
+      expect(agent.description).toContain(`agent type name ${FLEET_PLUGIN_NAME}:${name}`);
     }
     const withEffort = names.find((name) => name.endsWith("-high"));
     expect(withEffort).toBeDefined();
@@ -106,7 +107,7 @@ describe("claude-gateway custom agents", () => {
     }
   });
 
-  it("injects --agents only for claude-gateway, and never disables a built-in agent", async () => {
+  it("registers gateway identities as plugin agent files, and never disables a built-in agent", async () => {
     const root = createTempRoot("fleet-admiral-gateway-agents-");
     const model = requireGatewayModel("cursor--claude-opus-5");
     const gateway = baseProfile("claude-gateway", {
@@ -131,29 +132,31 @@ describe("claude-gateway custom agents", () => {
     // 상속(unpinned) 위임이 막혀 세션 자신의 모델로 도는 작업을 만들 수 없다.
     expect(injectedGateway.args).not.toContain("--disallowedTools");
 
-    const agentsIndex = injectedGateway.args.indexOf("--agents");
-    expect(agentsIndex).toBeGreaterThanOrEqual(0);
-    const agentsJson = injectedGateway.args[agentsIndex + 1];
-    expect(typeof agentsJson).toBe("string");
-    const agents = JSON.parse(agentsJson as string) as Record<string, {
-      model: string;
-      prompt: string;
-      effort?: string;
-    }>;
-    expect(Object.keys(agents).length).toBeGreaterThan(0);
-    for (const agent of Object.values(agents)) {
-      expect(agent.model.startsWith("claude-gateway--")).toBe(true);
-      expect(agent.prompt).toBe(GENERAL_PURPOSE_AGENT_PROMPT);
-    }
-
-    expect(injectedNative.args).not.toContain("--disallowedTools");
+    // 정의가 argv에 실리면 Windows 명령줄 한도가 로스터 크기를 대신 정한다 — 정의 하나가
+    // 1.9KB쯤이라 스무 개만 노출해도 프롬프트를 싣기 전에 실행이 불가능해진다.
+    expect(injectedGateway.args).not.toContain("--agents");
     expect(injectedNative.args).not.toContain("--agents");
+    expect(injectedNative.args).not.toContain("--disallowedTools");
+
+    const files = readdirSync(agentsDirOf(injectedGateway));
+    expect(files.length).toBeGreaterThan(0);
+    for (const file of files) {
+      // `:`는 플러그인 스코프 구분자로 예약돼 있어, 이름에 들어간 파일은 아예 적재되지 않는다.
+      expect(file).not.toContain(":");
+      const content = readFileSync(path.join(agentsDirOf(injectedGateway), file), "utf8");
+      expect(content.startsWith("---\n")).toBe(true);
+      expect(content).toContain(`name: ${JSON.stringify(file.replace(/\.md$/u, ""))}`);
+      expect(content).toContain('model: "claude-gateway--');
+      expect(content).toContain(GENERAL_PURPOSE_AGENT_PROMPT);
+    }
+    // native 세션은 게이트웨이 정체성을 하나도 얻지 않는다.
+    expect(readdirSync(agentsDirOf(injectedNative))).toEqual([]);
 
     injectedGateway.cleanup?.();
     injectedNative.cleanup?.();
   });
 
-  it("injects neither flag when no gateway models are exposed", async () => {
+  it("registers no identity when no gateway models are exposed", async () => {
     const root = createTempRoot("fleet-admiral-gateway-agents-empty-");
     const profile = baseProfile("claude-gateway", {
       args: [],
@@ -164,6 +167,7 @@ describe("claude-gateway custom agents", () => {
     // 노출 모델이 없으면 게이트웨이 세션은 내장 Agent만 가진 평범한 세션이다.
     expect(injected.args).not.toContain("--agents");
     expect(injected.args).not.toContain("--disallowedTools");
+    expect(readdirSync(agentsDirOf(injected))).toEqual([]);
     injected.cleanup?.();
   });
 });
@@ -221,6 +225,16 @@ function requireGatewayModel(id: string) {
   const model = findGatewayModel(id);
   if (!model) throw new Error(`missing gateway model fixture: ${id}`);
   return model;
+}
+
+/**
+ * 세션이 실제로 적재하는 정의가 놓인 자리. argv의 `--plugin-dir`를 따라가야 렌더가 실제
+ * 스폰이 가리키는 곳에 떨어졌는지까지 확인된다 — 경로를 따로 계산하면 그 연결이 빠진다.
+ */
+function agentsDirOf(profile: AgentCliProfile): string {
+  const index = profile.args.indexOf("--plugin-dir");
+  expect(index).toBeGreaterThanOrEqual(0);
+  return path.join(profile.args[index + 1]!, "agents");
 }
 
 function createTempRoot(prefix: string): string {

--- a/packages/fleet-admiral/tests/ai-gateway-model-loadout.test.ts
+++ b/packages/fleet-admiral/tests/ai-gateway-model-loadout.test.ts
@@ -6,13 +6,26 @@ import {
 } from "@dotobokuri/core-ai-gateway";
 import { describe, expect, it } from "vitest";
 
-import { buildGatewayCustomAgents } from "../src/agent-cli/gateway-agents.js";
+import { buildGatewayAgentFiles, FLEET_PLUGIN_NAME } from "../src/agent-cli/gateway-agents.js";
 import { buildGatewayModelsToolSpec, GATEWAY_MODELS_TOOL_ID } from "../src/ai-gateway/gateway-models-tool.js";
 import { buildGatewayLoadout, type GatewayLoadout } from "../src/ai-gateway/model-loadout.js";
 import { isHostSessionToolAllowed } from "../src/tools.js";
 
 function allModels(loadout: ReturnType<typeof buildGatewayLoadout>) {
   return Object.values(loadout.providers).flatMap((provider) => provider.models);
+}
+
+/**
+ * 세션이 실제로 등록하는 철자. 정의는 플러그인 `agents/`에 파일로 놓이고 Claude Code가
+ * `<plugin>:<파일 stem>`으로 등록하므로, 로스터가 보고하는 이름은 그 파일 집합에서 나와야
+ * 한다 — 다른 곳에서 다시 만들면 둘이 갈라져도 이 테스트가 알아채지 못한다.
+ */
+function registeredSelectors(
+  exposed: readonly GatewayModel[],
+  exposure?: Parameters<typeof buildGatewayAgentFiles>[1],
+): Set<string> {
+  return new Set(buildGatewayAgentFiles(exposed, exposure)
+    .map((file) => `${FLEET_PLUGIN_NAME}:${file.fileName.replace(/\.md$/u, "")}`));
 }
 
 function model(id: string): GatewayModel {
@@ -26,7 +39,7 @@ describe("gateway loadout agent type selectors", () => {
   // 이름을 요구하는 자리에 넣을 값을 회수할 방법이 없어 모델 id를 넣고 실패한다.
   it("keys selectors by the model's own ladder and matches the registered agents", () => {
     const exposed = [model("cursor--claude-opus-5"), model("opencode--deepseek-v4-pro")];
-    const registered = new Set(Object.keys(buildGatewayCustomAgents(exposed)));
+    const registered = registeredSelectors(exposed);
     const loadout = buildGatewayLoadout({ exposed });
 
     expect(allModels(loadout).length).toBe(exposed.length);
@@ -48,7 +61,7 @@ describe("gateway loadout agent type selectors", () => {
   it("reports only the exposed rungs and keeps them matched to the registered agents", () => {
     const kimi = model("kimi--k3");
     const effortExposure = { [kimi.id]: ["max"] as const };
-    const registered = new Set(Object.keys(buildGatewayCustomAgents([kimi], effortExposure)));
+    const registered = registeredSelectors([kimi], effortExposure);
     const loadout = buildGatewayLoadout({ exposed: [kimi], effortExposure });
     const entry = allModels(loadout)[0];
 

--- a/runtime/fleet-cli/README.md
+++ b/runtime/fleet-cli/README.md
@@ -6,7 +6,7 @@ On startup it:
 
 - binds one in-process Fleet MCP server named `fleet` with Fleet Wiki tools and `gateway_models`;
 - injects that MCP endpoint into Claude Code through `--mcp-config`;
-- exposes configured gateway model × effort identities through Claude Code `--agents`;
+- registers configured gateway model × effort identities as agent files in the Fleet plugin, reachable as `fleet:<name>`;
 - serves the AI gateway on an ephemeral `127.0.0.1` port under `/ai-gateway`;
 - spawns Claude Code with inherited standard input, output, and error streams.
 

--- a/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
@@ -222,7 +222,7 @@ async function createAgentCliLaunchSpec(options: {
     }
     const cliId = resolveAgentCliId(options.env, { cliId: options.cliId });
     // gateway Agent 주입과 ANTHROPIC_MODEL/cache는 같은 selection을 공유한다.
-    // resolveProfile보다 먼저 읽어 명시 모델 검증·`--agents`·cache가 한 스냅샷을 공유한다.
+    // resolveProfile보다 먼저 읽어 명시 모델 검증·Agent 정의 렌더·cache가 한 스냅샷을 공유한다.
     const gatewaySelection = cliId === "claude-gateway" && options.readAiGatewaySettings
       ? resolveAiGatewaySelection(options.readAiGatewaySettings())
       : undefined;


### PR DESCRIPTION
## Summary

노출된 게이트웨이 모델 × 추론 강도마다 하나씩 만들어지던 Agent 정의가 `--agents` JSON으로 **명령줄에** 실려 있었습니다. 정의 하나가 약 1,929바이트인데(각 정의가 같은 실행 프롬프트를 통째로 반복합니다), 이 세션의 로스터 21개면 40,138자, 전체 카탈로그 40모델이면 **91개 정의 174,188바이트**입니다.

Windows는 `CreateProcess` 명령줄 전체를 32,767자로 자르고, npm이 설치하는 `claude.cmd` 같은 shim은 `core-process`의 `wrapWindowsShim`이 `cmd.exe /d /s /c call`로 감싸므로 **실질 상한이 8,191자**입니다. 즉 프롬프트를 한 글자도 싣기 전에, 강도 5단 모델 하나만 켜도(정의 5개 ≈ 9.6KB) 실행 자체가 불가능합니다.

- 정의를 Fleet 플러그인의 `agents/` 디렉터리에 파일로 렌더합니다. **그 디렉터리는 플러그인 렌더러가 이미 만들어 두고 비워 두던 자리**입니다. 실행은 원래부터 들고 있던 `--plugin-dir` 인자를 그대로 쓰고, 페이로드는 명령줄에서 통째로 사라집니다.
- 노출 목록은 세션별이 아니라 전역 설정이라 모든 게이트웨이 세션이 같은 집합을 렌더하고, 스킬과 훅을 이미 교체하던 그 staging→rename 스왑이 이 파일들도 함께 교체하므로 더 넓었던 로스터의 정의가 남지 않습니다.
- 플러그인은 자기가 싣는 것을 자기 이름 아래 등록하므로 **정체성 철자가 `fleet:<name>`이 됩니다.** 같은 플러그인이 싣는 Fleet 스킬이 이미 `fleet:workflow`로 불리던 것과 같은 규칙입니다. `gateway_models`의 `agentTypes`가 그 철자를 보고하고 각 정의도 자기 철자를 말하므로, 두 쪽이 어긋나면 loadout 테스트가 잡습니다 — 그 테스트는 이제 **실제로 쓰이는 파일 집합에서** 등록 이름을 유도합니다.

`--agents`가 실어 나르던 필드는 `description`·`prompt`·`model`·`effort` 넷뿐이었고 넷 모두 frontmatter로 옮겨졌습니다. MCP·훅·권한·`skillOverrides`는 애초에 세션 단위라 그대로 명령줄에 남습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-admiral typecheck` — 0 errors
- [x] `pnpm --filter @dotobokuri/fleet-admiral test` — 150 passed
- [x] `pnpm --filter @dotobokuri/fleet-cli typecheck` / `test` — 0 errors / 38 passed
- [x] `pnpm --filter @fleet-plugins/terminal test` — 507 passed
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` / `test` — 0 errors / 1622 passed, 2 failed
- [x] 위 실패 2건(`tests/i18n.test.ts` 로케일 파리티, `tests/triage-store.test.ts`)은 **detached `origin/canary` 워크트리에서 동일하게 재현**되는 선존 실패입니다.
- [x] `pnpm check:core-boundary` — 통과
- [x] 렌더 산출물 실측: 전체 카탈로그 40모델 → **91개 파일, 91개 고유 stem, 안전하지 않은 이름 0**. 91개 frontmatter를 실제 YAML 파서(`yaml@2.8.3`)로 전수 파싱 — 실패 0, 이름에 콜론 0, 파일명 불일치 0.
- [x] 테스트가 `--plugin-dir` 인자를 따라가 그 경로의 `agents/`를 읽습니다. 렌더가 실제 스폰이 가리키는 곳에 떨어졌는지까지 확인됩니다.
- [x] changelog fragment: `.changelog.d/gateway-agents-as-plugin-files.md` (fleet-cli · fleet-console / Changed · Fixed)