### PR TITLE
build(fleet-console): publish every external the console bundle needs

### DIFF
--- a/runtime/fleet-console/package.json
+++ b/runtime/fleet-console/package.json
@@ -38,7 +38,7 @@
     "node": ">=20.19.0"
   },
   "scripts": {
-    "build": "pnpm generate:admiral-assets && pnpm generate:shim-keys && tsup && node ../../scripts/check-dist-node-protocol.mjs && pnpm generate:desktop-protocol-declaration && pnpm verify:desktop-protocol && vite build --config core/client/vite.config.ts",
+    "build": "pnpm generate:admiral-assets && pnpm generate:shim-keys && tsup && node ../../scripts/check-dist-node-protocol.mjs && node ../../scripts/check-dist-published-externals.mjs && pnpm generate:desktop-protocol-declaration && pnpm verify:desktop-protocol && vite build --config core/client/vite.config.ts",
     "cli": "tsx core/host/cli.ts",
     "dev": "vite --config core/client/vite.config.ts",
     "generate:admiral-assets": "node ../../scripts/generate-fleet-admiral-assets.mjs",

--- a/runtime/fleet-console/tests/published-manifest.test.ts
+++ b/runtime/fleet-console/tests/published-manifest.test.ts
@@ -13,6 +13,7 @@ describe("published Console manifest", () => {
         "@anthropic-ai/claude-agent-sdk": "^0.3.212",
         ws: "^8.18.0",
         "font-list": "^2.1.0",
+        selfsigned: "^5.5.0",
         "@fleet-console/desktop-protocol": "workspace:*",
       },
       devDependencies: {
@@ -29,6 +30,6 @@ describe("published Console manifest", () => {
       expect(Object.values(entries).some((value) => typeof value === "string" && value.startsWith("workspace:"))).toBe(false);
     }
     expect(manifest.devDependencies).toEqual({ typescript: "^6.0.2" });
-    expect(manifest.dependencies).toEqual({ "node-pty": "^1.0.0", "@anthropic-ai/claude-agent-sdk": "^0.3.212", ws: "^8.18.0", "font-list": "^2.1.0" });
+    expect(manifest.dependencies).toEqual({ "node-pty": "^1.0.0", "@anthropic-ai/claude-agent-sdk": "^0.3.212", ws: "^8.18.0", "font-list": "^2.1.0", selfsigned: "^5.5.0" });
   });
 });

--- a/scripts/check-dist-published-externals.mjs
+++ b/scripts/check-dist-published-externals.mjs
@@ -1,0 +1,144 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { isBuiltin } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createPublishedFleetConsoleManifest } from "./pack-fleet-console-manifest.mjs";
+
+/**
+ * 번들에 인라인되지 않은 의존성은 게시 매니페스트가 들고 있어야 설치처에서 해석된다.
+ * tsup은 `dependencies`를 전부 external로 남기지만 게시 매니페스트는 allowlist라
+ * `pkg.dependencies`를 통째로 교체한다 — 그래서 콘솔에 런타임 의존성을 한 줄 추가하고
+ * allowlist를 잊으면, 워크스페이스는 전부 green인 채로 게시본만 부팅 즉시
+ * ERR_MODULE_NOT_FOUND로 죽는다.
+ *
+ * 판정은 산출물이 실제로 무엇을 해석하려 드는지에서 나온다. 소스의 import 문이 아니라
+ * 게시되는 dist를 읽는 이유이고, 소스만 보면 번들 인라인된 것과 external로 남은 것을
+ * 구분할 수 없기 때문이다.
+ */
+
+/**
+ * 번들에 남아 있으나 게시 dependencies에 없어도 되는 지정자.
+ *
+ * esbuild는 plugin-host가 dev 환경의 .ts 로더에서만 동적 import하는 devDependency다.
+ * 게시본에서 그 경로에 도달하지 않으므로 설치처에 없어도 되고, 번들에 인라인하면
+ * 내부 CJS의 require("fs")가 ESM 출력에서 boot 시 throw한다(tsup.config.ts 참조).
+ */
+const ALLOWED_OMISSIONS = new Map([
+  ["esbuild", "dev 전용 .ts 로더에서만 동적 import되는 devDependency"],
+]);
+
+/** npm 패키지 이름의 첫 세그먼트 모양. 산문이 지정자 자리처럼 보이는 경우를 걸러낸다. */
+const PACKAGE_NAME = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
+/**
+ * 런타임이 해석해야 하는 자리에 놓인 지정자만 뽑는다.
+ *
+ * tsup이 require 심을 `require4`·`nodePtyRequire`처럼 이름을 바꿔 내보내므로 그 형태도
+ * 함께 본다. 지정자 자리에 오지 않은 같은 철자(산문·다른 호출)는 뽑지 않는다 —
+ * 게이트가 잡아야 할 결함이 아닌 것으로 빌드를 막으면 진단이 오히려 어려워진다.
+ */
+// 인용부호 앞의 `(?<!\\)`는 산문 안의 이스케이프된 인용부호(`... from \"x\"`)를 지정자로 읽지
+// 않게 한다. 남는 오탐 위험보다 누락이 더 나쁘므로 패턴 자체는 넓게 두고, 아래 패키지 이름
+// 모양 검사와 ALLOWED_OMISSIONS가 마지막 여과를 맡는다.
+const SPECIFIER_PATTERNS = [
+  // 부작용 전용 import는 산문과 철자가 겹치므로 문(statement) 시작에서만 인정한다.
+  /^[ \t]*import\s*(?<!\\)(['"])([^'"]+)\1/gm,
+  /(?<![\w$.])from\s*(?<!\\)(['"])([^'"]+)\1/g,
+  /(?<![\w$.])import\s*\(\s*(?<!\\)(['"])([^'"]+)\1\s*\)/g,
+  /(?<![\w$.])[\w$]*[Rr]equire\d*\s*\(\s*(?<!\\)(['"])([^'"]+)\1\s*\)/g,
+];
+
+const skippedDirectories = new Set(["node_modules", "client"]);
+
+if (process.argv[1] !== undefined && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}
+
+function main() {
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = path.dirname(scriptDir);
+  const consoleRoot = path.join(repoRoot, "runtime", "fleet-console");
+  const distRoot = path.join(consoleRoot, "dist");
+
+  const manifest = createPublishedFleetConsoleManifest(JSON.parse(readFileSync(path.join(consoleRoot, "package.json"), "utf8")));
+  const published = new Set(Object.keys(manifest.dependencies ?? {}));
+
+  const files = listFiles(distRoot, ".mjs");
+  // 검사할 번들이 없으면 통과가 아니라 실패다 — 빈 검사는 "전부 통과"와 구분되지 않는다.
+  if (files.length === 0) {
+    console.error(`no built console bundles under ${path.relative(repoRoot, distRoot)} — build before running this gate`);
+    process.exit(1);
+  }
+
+  const violations = [];
+  for (const file of files) {
+    for (const { name, line } of collectExternalPackages(readFileSync(file, "utf8"))) {
+      if (published.has(name) || ALLOWED_OMISSIONS.has(name)) continue;
+      violations.push(`${path.relative(repoRoot, file)}:${line} needs "${name}", which the published manifest does not depend on`);
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error("built artifacts reference packages the published manifest omits — a clean install cannot resolve them:");
+    for (const violation of violations) console.error(`- ${violation}`);
+    console.error(`Add the package to EXTERNAL_DEP_NAMES in ${path.relative(repoRoot, path.join(scriptDir, "pack-fleet-console-manifest.mjs"))}, bundle it via tsup noExternal, or record why the published install never reaches it.`);
+    process.exit(1);
+  }
+
+  console.log(`published externals verified across ${files.length} console bundle(s).`);
+}
+
+/**
+ * 번들 텍스트에서 해석 대상 패키지 이름과 그 줄 번호를 뽑는다. 상대 경로·빌트인·
+ * 패키지 이름 모양이 아닌 것은 제외하고, 서브패스는 패키지 이름으로 접는다.
+ */
+export function collectExternalPackages(text) {
+  const found = new Map();
+  for (const pattern of SPECIFIER_PATTERNS) {
+    for (const match of text.matchAll(pattern)) {
+      const specifier = match[2];
+      if (specifier.startsWith(".") || specifier.startsWith("/") || specifier.startsWith("node:")) continue;
+      const name = packageNameOf(specifier);
+      if (name === null || isBuiltin(name)) continue;
+      if (!found.has(name)) found.set(name, lineOf(text, match.index));
+    }
+  }
+  return [...found].map(([name, line]) => ({ name, line })).sort((left, right) => left.line - right.line);
+}
+
+/** `@scope/name/sub` → `@scope/name`, `name/sub` → `name`. 이름 모양이 아니면 null. */
+function packageNameOf(specifier) {
+  const segments = specifier.split("/");
+  const name = specifier.startsWith("@") ? segments.slice(0, 2).join("/") : segments[0];
+  return PACKAGE_NAME.test(name) ? name : null;
+}
+
+function lineOf(text, index) {
+  let line = 1;
+  for (let cursor = 0; cursor < index; cursor += 1) {
+    if (text[cursor] === "\n") line += 1;
+  }
+  return line;
+}
+
+/** 디렉터리 하위 파일을 재귀 수집한다(디렉터리 부재 시 빈 배열). */
+function listFiles(dir, extension) {
+  let stat;
+  try {
+    stat = statSync(dir);
+  } catch {
+    return [];
+  }
+  if (!stat.isDirectory()) return [];
+  const files = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (skippedDirectories.has(entry.name)) continue;
+      files.push(...listFiles(path.join(dir, entry.name), extension));
+    } else if (entry.name.endsWith(extension)) {
+      files.push(path.join(dir, entry.name));
+    }
+  }
+  return files;
+}

--- a/scripts/check-dist-published-externals.mjs
+++ b/scripts/check-dist-published-externals.mjs
@@ -18,14 +18,22 @@ import { createPublishedFleetConsoleManifest } from "./pack-fleet-console-manife
  */
 
 /**
- * 번들에 남아 있으나 게시 dependencies에 없어도 되는 지정자.
+ * 번들에 남아 있으나 게시 dependencies에 없는 지정자. 통과시키되, 통과의 근거는 "게시본이
+ * 그 경로에 도달하지 않는다"가 아니라 "무엇을 잃는지 알고 있다"여야 한다 — 도달 불가를
+ * 근거로 적으면 그 주장이 틀렸을 때 게이트가 결함을 승인한 기록으로 남는다.
  *
- * esbuild는 plugin-host가 dev 환경의 .ts 로더에서만 동적 import하는 devDependency다.
- * 게시본에서 그 경로에 도달하지 않으므로 설치처에 없어도 되고, 번들에 인라인하면
- * 내부 CJS의 require("fs")가 ESM 출력에서 boot 시 throw한다(tsup.config.ts 참조).
+ * esbuild는 devDependency이고 플랫폼 바이너리가 설치본마다 10MB 규모라 게시되지 않는다.
+ * 그 대가는 실재한다: plugin-host는 `~/.fleet/plugins`를 언제나 스캔하고 `.ts`/`.tsx`
+ * 엔트리를 확장자만으로 수락하므로(plugin-host.ts:54·273·467), TypeScript 엔트리를 쓰는
+ * 외부 플러그인은 게시 설치본에서 해석에 실패해 그 플러그인만 건너뛰어진다. 게시할지
+ * TypeScript 엔트리 수락을 접을지는 배포 무게와 저작 편의를 맞바꾸는 제품 결정이라
+ * 이 게이트가 정하지 않는다 — 게이트는 현재 상태를 사실대로 기록할 뿐이다.
+ *
+ * 번들 인라인은 대안이 아니다. 내부 CJS의 require("fs")가 ESM 출력에서 boot 시 throw한다
+ * (tsup.config.ts 참조).
  */
 const ALLOWED_OMISSIONS = new Map([
-  ["esbuild", "dev 전용 .ts 로더에서만 동적 import되는 devDependency"],
+  ["esbuild", "게시되지 않는 devDependency — 게시본은 TypeScript 플러그인 엔트리를 번들하지 못한다"],
 ]);
 
 /** npm 패키지 이름의 첫 세그먼트 모양. 산문이 지정자 자리처럼 보이는 경우를 걸러낸다. */
@@ -72,9 +80,12 @@ function main() {
   }
 
   const violations = [];
+  // 행사된 예외는 통과 로그에 드러낸다 — 조용히 넘긴 예외는 "전부 게시됨"과 구분되지 않는다.
+  const exercisedOmissions = new Set();
   for (const file of files) {
     for (const { name, line } of collectExternalPackages(readFileSync(file, "utf8"))) {
-      if (published.has(name) || ALLOWED_OMISSIONS.has(name)) continue;
+      if (published.has(name)) continue;
+      if (ALLOWED_OMISSIONS.has(name)) { exercisedOmissions.add(name); continue; }
       violations.push(`${path.relative(repoRoot, file)}:${line} needs "${name}", which the published manifest does not depend on`);
     }
   }
@@ -87,6 +98,9 @@ function main() {
   }
 
   console.log(`published externals verified across ${files.length} console bundle(s).`);
+  for (const name of exercisedOmissions) {
+    console.log(`- omitted on record: ${name} — ${ALLOWED_OMISSIONS.get(name)}`);
+  }
 }
 
 /**

--- a/scripts/check-dist-published-externals.test.mjs
+++ b/scripts/check-dist-published-externals.test.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { collectExternalPackages } from './check-dist-published-externals.mjs';
+import { createPublishedFleetConsoleManifest } from './pack-fleet-console-manifest.mjs';
+
+const names = (text) => collectExternalPackages(text).map((entry) => entry.name);
+
+test('collects every specifier form a bundle can ask the runtime to resolve', () => {
+  const bundle = [
+    `import selfsigned from 'selfsigned';`,
+    `import fontList from "font-list";`,
+    `import 'side-effect-only';`,
+    `export { thing } from 'reexported-pkg';`,
+    `const mod = await import('esbuild');`,
+    `const pty = nodePtyRequire("node-pty");`,
+    `const server = require4("ws");`,
+  ].join('\n');
+
+  assert.deepEqual(names(bundle).sort(), [
+    'esbuild',
+    'font-list',
+    'node-pty',
+    'reexported-pkg',
+    'selfsigned',
+    'side-effect-only',
+    'ws',
+  ]);
+});
+
+test('reports the first line each package appears on', () => {
+  const bundle = `import a from 'node:fs';\nimport b from 'alpha';\nimport c from 'beta';\nimport d from 'alpha/sub';`;
+
+  assert.deepEqual(collectExternalPackages(bundle), [
+    { name: 'alpha', line: 2 },
+    { name: 'beta', line: 3 },
+  ]);
+});
+
+test('ignores builtins whether or not they carry the node: prefix', () => {
+  // 번들러가 접두를 벗긴 맨 이름 빌트인도 설치 대상이 아니다 — 그 결함은 다른 게이트가 본다.
+  const bundle = `import http from 'node:http';\nimport { EventEmitter } from 'events';\nimport { execFile } from 'child_process';\nconst db = await import('node:sqlite');`;
+
+  assert.deepEqual(names(bundle), []);
+});
+
+test('ignores relative and absolute paths', () => {
+  const bundle = `import a from './local.mjs';\nimport b from '../sibling/mod.mjs';\nimport c from '/abs/path.mjs';`;
+
+  assert.deepEqual(names(bundle), []);
+});
+
+test('folds a subpath import onto its package name', () => {
+  const bundle = `import x from '@scope/pkg/deep/entry.js';\nimport y from 'plain-pkg/sub';`;
+
+  assert.deepEqual(names(bundle).sort(), ['@scope/pkg', 'plain-pkg']);
+});
+
+test('does not read prose or unrelated calls as specifiers', () => {
+  // 지정자 자리에 오지 않은 같은 철자로 빌드를 막으면, 이 게이트가 잡아야 할 결함을
+  // 정직하게 진단하려는 후속 수정이 오히려 막힌다.
+  const bundle = [
+    `throw new Error("failed to load from \\"totally-not-a-package\\"");`,
+    `const label = t("chrome.hosts.local");`,
+    `const parts = Array.from("abc");`,
+    `const note = "imported from a remote host";`,
+  ].join('\n');
+
+  assert.deepEqual(names(bundle), []);
+});
+
+test('keeps every external the published console install must resolve', () => {
+  // 게시 매니페스트는 allowlist라 `pkg.dependencies`를 통째로 교체한다. 여기서 하나가 빠지면
+  // 워크스페이스는 green인 채로 게시본만 ERR_MODULE_NOT_FOUND로 죽는다.
+  const manifest = createPublishedFleetConsoleManifest({
+    name: '@dotobokuri/fleet-console',
+    private: true,
+    dependencies: {
+      'node-pty': '^1.0.0',
+      ws: '^8.18.0',
+      'font-list': '^2.1.0',
+      '@anthropic-ai/claude-agent-sdk': '^0.3.212',
+      selfsigned: '^5.5.0',
+      react: '^19.0.0',
+    },
+  });
+
+  assert.deepEqual(manifest.dependencies, {
+    'node-pty': '^1.0.0',
+    ws: '^8.18.0',
+    'font-list': '^2.1.0',
+    '@anthropic-ai/claude-agent-sdk': '^0.3.212',
+    selfsigned: '^5.5.0',
+  });
+});

--- a/scripts/pack-fleet-console-manifest.mjs
+++ b/scripts/pack-fleet-console-manifest.mjs
@@ -6,7 +6,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PKG_PATH = path.resolve(__dirname, "../runtime/fleet-console/package.json");
 const BACKUP_PATH = path.resolve(__dirname, "../runtime/fleet-console/.package.json.prepack-backup");
 const TEMP_PATH = path.resolve(__dirname, "../runtime/fleet-console/.package.json.prepack-tmp");
-const EXTERNAL_DEP_NAMES = ["node-pty", "ws", "font-list", "@anthropic-ai/claude-agent-sdk"];
+// 번들에 인라인되지 않고 산출물이 그대로 해석하려 드는 의존성. 빠뜨리면 게시본이 설치처에서
+// ERR_MODULE_NOT_FOUND로 죽으므로, check-dist-published-externals.mjs가 빌드마다 dist와 대조한다.
+const EXTERNAL_DEP_NAMES = ["node-pty", "ws", "font-list", "@anthropic-ai/claude-agent-sdk", "selfsigned"];
 
 if (process.argv[1] !== undefined && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   const action = process.argv[2];


### PR DESCRIPTION
## Summary

- 게시 매니페스트는 `pkg.dependencies`를 allowlist로 **통째 교체**하는데, #566이 원격 리스너용으로 추가한 `selfsigned`가 그 목록에 없었습니다. 번들은 `dist/cli.mjs:21`에서 최상단 정적 import로 그것을 그대로 참조하므로, 게시본을 깨끗이 설치하면 **어떤 명령에 도달하기도 전에** `ERR_MODULE_NOT_FOUND`로 죽습니다 — npx·현행 Desktop·최신 Console을 조달하는 0.4.1 셸 전부입니다.
- allowlist에 `selfsigned`를 추가하고, 같은 결함이 다시 생기지 않도록 `check-dist-published-externals.mjs`를 콘솔 빌드(node: 접두 게이트 직후)에 붙였습니다. 빌드 산출물이 해석하려는 패키지 중 게시 매니페스트에 없는 것이 있으면 빌드가 실패합니다.
- `esbuild`는 의도적 예외로 기록했습니다 — plugin host가 dev `.ts` 로더에서만 동적 import하고, 게시 설치본은 그 경로에 도달하지 않습니다.

## Test Plan

- [x] **게이트가 실제 결함에 발화**(수정 전): `node scripts/check-dist-published-externals.mjs` → `dist/cli.mjs:21 needs "selfsigned"` 1건, 번들 9개 전수에서 오탐 0
- [x] 수정 후 게이트·빌드 통과: `published externals verified across 9 console bundle(s).`
- [x] **게시 tarball 실측**: `npm pack` → 매니페스트 dependencies 5종에 `selfsigned` 포함, tarball 내 `dist/cli.mjs:21`에 해당 import 존재, postpack이 워크스페이스 매니페스트 복원
- [x] **깨끗한 설치 부팅 실측**(격리 `FLEET_CONSOLE_DIR`): 5종 전부 해석되고 `node dist/cli.mjs hook turn-start` exit 0
- [x] **대조군**: 같은 설치본에서 `selfsigned`만 제거 → `ERR_MODULE_NOT_FOUND: Cannot find package 'selfsigned' imported from .../dist/cli.mjs`, exit 1 → 복구 후 exit 0
- [x] `node --test scripts/*.test.mjs` → 30 pass (신규 7 포함)
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` → exit 0
- [x] `vitest run tests/published-manifest.test.ts` → 1 pass

## Coverage limit

PR CI는 콘솔을 빌드하지 않으므로 이 게이트는 CI가 아니라 **빌드·릴리스 시점**에 발화합니다(`pnpm install` postinstall, `pnpm console`, release build). CI가 고정하는 것은 신규 `scripts/*.test.mjs`가 검사하는 검출기 동작과 allowlist 계약입니다.

## Changelog

결함을 들여온 #566의 프래그먼트(`.changelog.d/remote-access-auth-spine.md`)가 아직 base에 미릴리스로 남아 있어, 사용자가 소비할 수 있었던 동작이 아닙니다. Release Baseline상 standalone `Fixed`가 금지되고 base 프래그먼트는 이 PR이 건드릴 수 없습니다. 변경 자체도 게시 매니페스트와 빌드 게이트라 사용자가 인지하는 런타임 동작 변화가 없습니다.

Changelog-Impact: none
No-Changelog-Reason: release-tooling