### PR TITLE
feat(gateway): back unmeasured OpenCode models with AA bench evidence

### DIFF
--- a/.changelog.d/feat-gateway-aa-bench.md
+++ b/.changelog.d/feat-gateway-aa-bench.md
@@ -1,0 +1,13 @@
+---
+branch: feat-gateway-aa-bench
+---
+
+### fleet-cli
+#### Changed
+- The AI Gateway roster now carries measured Terminal-Bench v2.1 evidence for Qwen3.8-Max, DeepSeek-V4-Flash, HY3, and MiMo-V2.5 instead of class-only priors.
+  ko: AI Gateway 로스터가 이제 Qwen3.8-Max, DeepSeek-V4-Flash, HY3, MiMo-V2.5에 대해 등급 기반 사전 추정 대신 측정된 Terminal-Bench v2.1 근거를 제공합니다.
+
+### fleet-console
+#### Changed
+- The AI Gateway roster now carries measured Terminal-Bench v2.1 evidence for Qwen3.8-Max, DeepSeek-V4-Flash, HY3, and MiMo-V2.5 instead of class-only priors.
+  ko: AI Gateway 로스터가 이제 Qwen3.8-Max, DeepSeek-V4-Flash, HY3, MiMo-V2.5에 대해 등급 기반 사전 추정 대신 측정된 Terminal-Bench v2.1 근거를 제공합니다.

--- a/packages/core-ai-gateway/benchmarks.json
+++ b/packages/core-ai-gateway/benchmarks.json
@@ -16,6 +16,14 @@
       "url": "https://swe-rebench.com/",
       "method": "Third-party continuously refreshed software-engineering benchmark: real GitHub issues mined into a decontaminated time window (2026-05-15 to 2026-07-01, 111 problems), every model run in the same harness with per-problem Docker images. Scores are resolved rates; token figures are per-problem and harness-relative. Score differences within the noise band are not significant, and scores never compare across sources.",
       "noiseBandPoints": 3
+    },
+    "aa-terminal-bench": {
+      "name": "AA Terminal-Bench",
+      "benchVersion": "v2.1",
+      "observedAt": "2026-08-08T00:00:00Z",
+      "url": "https://artificialanalysis.ai/evaluations/terminalbench-v2-1",
+      "method": "Third-party independent rerun of the public Terminal-Bench v2.1 agentic terminal-task suite: Artificial Analysis executes every model itself in one harness at the vendor-recommended reasoning setting. The task set is fixed and public, so vendor benchmark-targeting is possible and can affect entries unevenly. Scores are resolved rates; token figures are published for only a top slice of models, so entries below that cutoff carry scores alone and efficiency compares only between entries that both carry token figures. Score differences within the noise band are not significant, and scores never compare across sources.",
+      "noiseBandPoints": 3
     }
   },
   "models": {
@@ -110,6 +118,14 @@
       "source": "swe-rebench",
       "overall": { "score": 40.2, "tokensPerTask": 3955414 },
       "caveat": "Measured at the high reasoning setting; the gateway serves this model without effort control."
-    }
+    },
+    "qwen3.8-max": { "source": "aa-terminal-bench", "overall": { "score": 81.3, "tokensPerTask": 52428 } },
+    "deepseek-v4-flash": {
+      "source": "aa-terminal-bench",
+      "overall": { "score": 78.7 },
+      "caveat": "Measured on the 0731 re-post-trained build DeepSeek serves since 2026-07-31; the earlier build measures 61.8 on the same run, and which build a gateway provider serves is not observable from the catalog."
+    },
+    "hy3": { "source": "aa-terminal-bench", "overall": { "score": 64.4 } },
+    "mimo-v2.5": { "source": "aa-terminal-bench", "overall": { "score": 63.7 } }
   }
 }

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -351,7 +351,8 @@
           "modelId": "qwen3.8-max",
           "name": "Qwen3.8-Max",
           "capabilityClass": "flagship",
-          "contextWindow": 1000000
+          "contextWindow": 1000000,
+          "benchmarkKey": "qwen3.8-max"
         },
         {
           "modelId": "gpt-5.6-luna",
@@ -392,7 +393,8 @@
           "name": "DeepSeek-V4-Flash",
           "capabilityClass": "light",
           "wire": "chat-completions",
-          "contextWindow": 1000000
+          "contextWindow": 1000000,
+          "benchmarkKey": "deepseek-v4-flash"
         },
         {
           "modelId": "deepseek-v4-pro",
@@ -431,14 +433,16 @@
           "name": "MiMo-V2.5",
           "capabilityClass": "standard",
           "wire": "chat-completions",
-          "contextWindow": 1000000
+          "contextWindow": 1000000,
+          "benchmarkKey": "mimo-v2.5"
         },
         {
           "modelId": "hy3",
           "name": "HY3",
           "capabilityClass": "flagship",
           "wire": "chat-completions",
-          "contextWindow": 256000
+          "contextWindow": 256000,
+          "benchmarkKey": "hy3"
         }
       ]
     }

--- a/packages/core-ai-gateway/src/models.ts
+++ b/packages/core-ai-gateway/src/models.ts
@@ -110,7 +110,7 @@ export type GatewayCapabilityClass = typeof GATEWAY_CAPABILITY_CLASSES[number];
 
 const GatewayBenchmarkFiguresSchema = z.object({
   score: z.number().positive().max(100),
-  tokensPerTask: z.number().int().positive(),
+  tokensPerTask: z.number().int().positive().optional(),
   stepsPerTask: z.number().int().positive().optional(),
 }).strict();
 
@@ -133,13 +133,15 @@ const GatewayBenchmarkModelEntrySchema = z.object({
 });
 
 /**
- * benchmarks.json 저작 규칙 — 스키마가 강제하지 못하는 두 가지:
- * 모델 항목의 `source`는 그 모델의 도달 가능한 비교군을 더 많이 덮는 소스에 묶는다
- * (CursorBench 우선, CursorBench에 행이 없는 모델만 SWE-rebench). 소스의 수치를
- * 고치면 그 소스의 `observedAt`을 함께 올린다 — 로스터 revision이 이 스탬프를
- * 실어 나르므로, 올리지 않은 편집은 호스트에게 보이지 않는다. 조인의 나머지
- * 불변식(형제 키 공유·별칭 제외·고아 검출·내로잉 후 공백)은 validateRegistry와
- * validateBenchmarkCoverage가 강제한다.
+ * benchmarks.json 저작 규칙 — 스키마가 강제하지 못하는 세 가지:
+ * 모델 항목의 `source`는 그 모델의 도달 가능한 비교군을 더 많이 덮는 소스에 묶는다.
+ * CursorBench(에이전트형 다중 파일 코딩, 카탈로그 비교 모델이 가장 많음)를 우선하고,
+ * 행이 없으면 SWE-rebench, 둘 다 측정하지 않은 모델에만 AA Terminal-Bench v2.1을
+ * 쓴다. 소스가 그 모델의 토큰 수치를 공개하지 않으면 그 항목의 `tokensPerTask`는
+ * 비워 두고, 효율 타이브레이크는 토큰 수치를 둘 다 실은 항목 사이에서만 적용한다. 소스의 수치를 고치면 그 소스의 `observedAt`을
+ * 함께 올린다 — 로스터 revision이 이 스탬프를 실어 나르므로, 올리지 않은 편집은
+ * 호스트에게 보이지 않는다. 조인의 나머지 불변식(형제 키 공유·별칭 제외·고아 검출·
+ * 내로잉 후 공백)은 validateRegistry와 validateBenchmarkCoverage가 강제한다.
  */
 const GatewayBenchmarksRegistrySchema = z.object({
   version: z.number().int().positive(),
@@ -149,7 +151,7 @@ const GatewayBenchmarksRegistrySchema = z.object({
 
 export type GatewayBenchmarkFigures = {
   readonly score: number;
-  readonly tokensPerTask: number;
+  readonly tokensPerTask?: number;
   readonly stepsPerTask?: number;
 };
 

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -687,6 +687,30 @@ describe("model catalog", () => {
     }
   });
 
+  it("accepts benchmark scores without token figures", () => {
+    const parsed = parseGatewayBenchmarksRegistry({
+      version: 2,
+      sources: {
+        known: {
+          name: "Known",
+          benchVersion: "1",
+          observedAt: "2026-08-08T00:00:00Z",
+          url: "https://example.com",
+          method: "fixture",
+          noiseBandPoints: 1,
+        },
+      },
+      models: {
+        scoreOnly: {
+          source: "known",
+          overall: { score: 50 },
+        },
+      },
+    });
+
+    expect(parsed.models.scoreOnly?.overall).toEqual({ score: 50 });
+  });
+
   it("resolves benchmark evidence from benchmarks.json", () => {
     const base = findGatewayModel("codex--gpt-5.6-sol");
     const fast = findGatewayModel("codex--gpt-5.6-sol-fast");
@@ -709,6 +733,21 @@ describe("model catalog", () => {
     const deepseek = findGatewayModel("opencode--deepseek-v4-pro");
     expect(deepseek?.benchmark?.caveat).toContain("high reasoning setting");
 
+    const aaModels = [
+      ["qwen3.8-max", { score: 81.3, tokensPerTask: 52428 }],
+      ["deepseek-v4-flash", { score: 78.7 }],
+      ["hy3", { score: 64.4 }],
+      ["mimo-v2.5", { score: 63.7 }],
+    ] as const;
+    for (const [modelId, figures] of aaModels) {
+      const benchmark = findGatewayModel(`opencode--${modelId}`)?.benchmark;
+      expect(benchmark?.source, modelId).toBe("AA Terminal-Bench v2.1");
+      expect(benchmark?.overall, modelId).toEqual(figures);
+    }
+    expect(findGatewayModel("opencode--deepseek-v4-flash")?.benchmark?.caveat).toContain(
+      "0731 re-post-trained build",
+    );
+
     const glm = findGatewayModel("opencode--glm-5.2");
     expect(glm?.benchmark?.source).toBe("CursorBench 3.2");
     expect(glm?.benchmark?.rungs && Object.keys(glm.benchmark.rungs).sort()).toEqual(["high", "max"]);
@@ -716,6 +755,7 @@ describe("model catalog", () => {
 
     expect(GATEWAY_BENCHMARKS_STAMP).toContain("cursorbench:");
     expect(GATEWAY_BENCHMARKS_STAMP).toContain("swe-rebench:");
+    expect(GATEWAY_BENCHMARKS_STAMP).toContain("aa-terminal-bench:");
     expect(findGatewayModel("cursor--auto")?.benchmark).toBeUndefined();
     expect(findGatewayModel("cursor--grok-4.5-fast")?.benchmark).toBeUndefined();
 

--- a/packages/fleet-admiral/src/agent-cli/gateway-agents.ts
+++ b/packages/fleet-admiral/src/agent-cli/gateway-agents.ts
@@ -239,6 +239,10 @@ function formatTokenCount(n: number): string {
   return n >= 1000 ? `${Math.round(n / 1000)}k` : `${n}`;
 }
 
+function gatewayAgentTokenClause(tokensPerTask: number | undefined): string {
+  return tokensPerTask === undefined ? "" : `, ~${formatTokenCount(tokensPerTask)} tokens/task`;
+}
+
 function gatewayAgentBenchSentence(
   benchmark: GatewayModelBenchmark | undefined,
   effort: GatewayReasoningEffort | undefined,
@@ -250,13 +254,13 @@ function gatewayAgentBenchSentence(
   if (effort !== undefined) {
     const figures = benchmark?.rungs?.[effort];
     if (figures) {
-      return `Bench ${benchmark!.source}: ${figures.score}% at ${effort} effort, ~${formatTokenCount(figures.tokensPerTask)} tokens/task${caveatClause}.`;
+      return `Bench ${benchmark!.source}: ${figures.score}% at ${effort} effort${gatewayAgentTokenClause(figures.tokensPerTask)}${caveatClause}.`;
     }
     if (benchmark) {
       return `No bench figure at ${effort}; capability class is the prior at this rung.`;
     }
   } else if (benchmark?.overall) {
-    return `Bench ${benchmark.source}: ${benchmark.overall.score}% overall, ~${formatTokenCount(benchmark.overall.tokensPerTask)} tokens/task${caveatClause}.`;
+    return `Bench ${benchmark.source}: ${benchmark.overall.score}% overall${gatewayAgentTokenClause(benchmark.overall.tokensPerTask)}${caveatClause}.`;
   } else if (benchmark?.rungs) {
     const scores = Object.values(benchmark.rungs).map((rung) => rung.score);
     return `Bench ${benchmark.source}: ${Math.min(...scores)}%–${Math.max(...scores)}% across measured rungs, serving rung unknown${caveatClause}.`;

--- a/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
@@ -122,11 +122,26 @@ describe("claude-gateway custom agents", () => {
       expect(definition.description).toContain("score carries a caveat");
     }
 
-    const flash = Object.values(buildGatewayCustomAgents([requireGatewayModel("opencode--deepseek-v4-flash")]));
-    expect(flash.length).toBeGreaterThan(0);
-    for (const definition of flash) {
-      expect(definition.description).toContain("No bench evidence; capability class is the only prior.");
+    const aaBenchModels = [
+      ["qwen3.8-max", "81.3% overall, ~52k tokens/task.", true],
+      ["deepseek-v4-flash", "78.7% overall; score carries a caveat — read it via gateway_models before trusting it.", false],
+      ["hy3", "64.4% overall.", false],
+      ["mimo-v2.5", "63.7% overall.", false],
+    ] as const;
+    for (const [modelId, scoreClause, hasTokens] of aaBenchModels) {
+      const definitions = Object.values(buildGatewayCustomAgents([requireGatewayModel(`opencode--${modelId}`)]));
+      expect(definitions.length).toBeGreaterThan(0);
+      for (const definition of definitions) {
+        expect(definition.description).toContain(`Bench AA Terminal-Bench v2.1: ${scoreClause}`);
+        expect(definition.description).not.toContain("No bench evidence; capability class is the only prior.");
+        if (!hasTokens) {
+          expect(definition.description).not.toContain("tokens/task");
+        }
+      }
     }
+
+    const qwen = buildGatewayCustomAgents([requireGatewayModel("opencode--qwen3.8-max")])["opencode-qwen3-8-max-1m"];
+    expect(qwen?.description).toContain("Bench AA Terminal-Bench v2.1: 81.3% overall, ~52k tokens/task.");
   });
 
   it("registers gateway identities as plugin agent files, and never disables a built-in agent", async () => {


### PR DESCRIPTION
## Summary
- `benchmarks.json`에 제3의 측정 소스 `aa-terminal-bench`(Artificial Analysis가 자체 단일 하니스로 직접 실행하는 Terminal-Bench v2.1)를 추가하고, 지금까지 class 폴백만 있던 OpenCode 4종을 `benchmarkKey`로 조인: Qwen3.8-Max **81.3**(~52,428 tokens/task), DeepSeek-V4-Flash **78.7**(0731 재훈련 빌드 caveat — 구빌드는 동일 런에서 61.8), HY3 **64.4**, MiMo-V2.5 **63.7**. 수치는 AA 페이지 내장 데이터(187개 모델 전수)에서 추출·검산.
- 벤치 figures 스키마의 `tokensPerTask`를 optional로 완화: AA는 상위 일부 모델만 토큰을 공개하므로 미공개 항목은 점수만 저장하고, 효율 타이브레이크는 토큰이 둘 다 실린 항목 사이에서만 적용(소스 `method`·저작 주석에 명문화).
- Agent description의 토큰 절을 조건부 렌더링으로 전환 — score-only 항목은 `Bench AA Terminal-Bench v2.1: 64.4% overall.`처럼 끊기고, 토큰 보유 항목의 문장은 종전과 바이트 동일.
- 소스 선택 순서(CursorBench → SWE-rebench → AA Terminal-Bench v2.1)를 카탈로그 저작 주석에 확장.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 529/529 (score-only parse, 4종 실카탈로그 조인/점수, `GATEWAY_BENCHMARKS_STAMP`에 신규 소스 포함 검증 추가)
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck && build` — 클린
- [x] `pnpm --filter @dotobokuri/fleet-admiral test` — 155/155 (4종 description의 bench 문장·토큰 절 유무 고정)
- [x] `pnpm --filter @dotobokuri/fleet-admiral typecheck && build` — 클린
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK: 74 entries (프래그먼트 `feat-gateway-aa-bench.md` 포함)
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 1625 passed; 실패 2건은 base(`cc345d72`)에서도 동일 재현되는 canary 선존 결함(i18n locale parity·triage-store)으로 이 diff와 무관
- [x] 교차 계열 적대 검증(별도 런): 데이터 충실도(원본 분수→x100 반올림 검산)·조인 불변식·단일 소스 규칙·렌더링 클린; 유일 P2(method의 "토큰 미공개" 과잉 단정)는 문구 정정+qwen 토큰 수록으로 수리 완료