### PR TITLE
feat(fleet-console): tell the owner when a remote device takes control

### DIFF
--- a/.changelog.d/remote-control-handover.md
+++ b/.changelog.d/remote-control-handover.md
@@ -1,0 +1,21 @@
+---
+branch: remote-control-handover
+---
+
+### fleet-console
+#### Added
+- When a device joins over an access link and takes control, the console now says so instead of changing silently. A full-screen notice names the device and offers to take control back; dismissing it leaves a bar that keeps the same control one click away.
+  ko: 액세스 링크로 접속한 기기가 제어를 가져가면, 조용히 바뀌는 대신 화면이 그 사실을 알립니다. 전체 화면 안내가 어느 기기인지 밝히고 제어권 회수를 제안하며, 안내를 닫으면 같은 회수 버튼을 한 번에 누를 수 있는 막대가 남습니다.
+- While another device is driving, the terminal keeps showing live output as read-only instead of going blank, so the owner can watch the work continue.
+  ko: 다른 기기가 모는 동안에도 터미널이 비워지지 않고 살아 있는 출력을 읽기 전용으로 계속 보여 주므로, 주인은 작업이 이어지는 것을 지켜볼 수 있습니다.
+- Only one device holds control at a time. A second full access link is refused while a device is connected, and the refused link stays usable for later.
+  ko: 제어를 쥐는 기기는 한 번에 하나입니다. 한 기기가 접속해 있는 동안 두 번째 full 액세스 링크는 거절되며, 거절된 링크는 나중에 그대로 다시 쓸 수 있습니다.
+
+#### Fixed
+- Opening the same terminal from a second window no longer strands the first one on a dead screen showing an internal code. It now keeps the live output read-only and offers to take the terminal back.
+  ko: 같은 터미널을 두 번째 창에서 열어도 먼저 있던 창이 내부 코드만 남은 죽은 화면에 갇히지 않습니다. 살아 있는 출력을 읽기 전용으로 계속 보여 주고 터미널을 되찾을 수 있게 합니다.
+
+### fleet-desktop
+#### Added
+- Opening a console that another device already controls now explains that, instead of suggesting the access link was bad.
+  ko: 다른 기기가 이미 제어 중인 Console을 열면, 액세스 링크가 잘못된 것처럼 안내하는 대신 그 사실을 그대로 설명합니다.

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -7,6 +7,9 @@ import { ActiveCompanionShortcutsProvider } from "./active-companion-shortcuts.j
 import { fetchGroups, fetchOperations, fetchTheaterBootstrap, fetchTheaters, restoreDeletion, type DeferredDeletionReceipt } from "./api.js";
 import { CommandBand } from "./components/command-band.js";
 import { CommissioningOverlay } from "./components/commissioning-overlay.js";
+import { ControlBar } from "./components/control-bar.js";
+import { ControlCurtain } from "./components/control-curtain.js";
+import { ControlReclaimedNotice } from "./components/control-reclaimed-notice.js";
 import { FeatureTourOverlay } from "./components/feature-tour.js";
 import { KeyboardShortcutsDialog } from "./components/keyboard-shortcuts-dialog.js";
 import { takeKeyboardShortcutsReturnFocus } from "./focus-guards.js";
@@ -318,6 +321,7 @@ export function App() {
             <ReconnectButton />
           </div>
         ) : null}
+        <ControlBar />
         <main className="console-route-content">
           <Routes>
             <Route path="/" element={<Navigate to="/operations" replace />} />
@@ -339,6 +343,8 @@ export function App() {
         <WhatsNewModal state={state} />
         <CommissioningOverlay state={state} />
         <FeatureTourOverlay />
+        <ControlCurtain />
+        <ControlReclaimedNotice />
         <ToastHost>
           <Toast
             open={themeNotice !== null}

--- a/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
@@ -158,7 +158,11 @@ function HostSwitcher() {
    */
   const currentLabel = savedCurrent?.label || state.consoleName || location.host;
   // 이 컴퓨터의 콘솔에 서 있으면 어느 콘솔인지가 아니라 "여기"라는 사실만 말한다.
-  const chipLabel = nearbyCurrent ? t("chrome.hosts.local") : currentLabel;
+  const chipLabel = state.controlHolder !== null
+    ? t("chrome.control.shared")
+    : nearbyCurrent
+      ? t("chrome.hosts.local")
+      : currentLabel;
 
   if (nearby.length === 0 && hosts.length === 0) return null;
   const openSettings = () => {
@@ -175,14 +179,14 @@ function HostSwitcher() {
       <button
         ref={triggerRef}
         type="button"
-        className="host-switcher-chip"
+        className={`host-switcher-chip${state.controlHolder !== null ? " is-shared" : ""}`}
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={`${t("chrome.hosts.aria")}: ${chipLabel}`}
         title={chipLabel}
         onClick={() => setOpen((previous) => !previous)}
       >
-        <span className="host-switcher-dot is-live" aria-hidden="true" />
+        <span className={`host-switcher-dot ${state.controlHolder !== null ? "is-shared" : "is-live"}`} aria-hidden="true" />
         <span className="host-switcher-name">{chipLabel}</span>
         <ChevronGlyph />
       </button>

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -487,9 +487,9 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
       <div ref={bandLeftRef} className={`command-band-left${requestedOperationsViewVisible && sideBar.collapsed ? " is-collapsed" : ""}`}>
         <BrandHome />
         {state.channel === "local" ? <div className="command-band-environment">
-          <button ref={environmentTriggerRef} type="button" className="command-band-local-chip" aria-haspopup="dialog" aria-expanded={environmentOpen} onClick={() => { setSwitcherMenu(null); discardEnvironmentState(); setEnvironmentOpen((open) => !open); }}>
+          <button ref={environmentTriggerRef} type="button" className={`command-band-local-chip${state.controlHolder !== null ? " is-shared" : ""}`} aria-haspopup="dialog" aria-expanded={environmentOpen} onClick={() => { setSwitcherMenu(null); discardEnvironmentState(); setEnvironmentOpen((open) => !open); }}>
           <span className="command-band-local-dot" aria-hidden="true" />
-          <span className="command-band-local-chip-label">{desktopShell ? desktopChipLabel : t("chrome.commandBand.local")}</span>
+          <span className="command-band-local-chip-label">{state.controlHolder !== null ? t("chrome.control.shared") : desktopShell ? desktopChipLabel : t("chrome.commandBand.local")}</span>
           </button>
           {environmentOpen ? <div ref={environmentPopoverRef}><EnvironmentPopover environment={environment} error={environmentError} loading={environmentLoading} copiedValue={copiedValue} copyFailedValue={copyFailedValue} desktopShell={desktopShell} onCopy={copyEnvironmentValue} /></div> : null}
         </div> : null}

--- a/runtime/fleet-console/core/client/src/components/control-bar.tsx
+++ b/runtime/fleet-console/core/client/src/components/control-bar.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+
+import { revokeRemoteAccessSession } from "../global-settings-api.js";
+import { useConsoleState } from "../hooks/use-store.js";
+import { formatRelativeTime, useConsoleLocale, useT } from "../i18n/index.js";
+
+export function ControlBar() {
+  const state = useConsoleState();
+  const locale = useConsoleLocale();
+  const t = useT();
+  const [reclaiming, setReclaiming] = useState(false);
+  const [reclaimError, setReclaimError] = useState(false);
+  const holder = state.controlHolder;
+
+  if (holder === null || !state.controlCurtainDismissed) return null;
+  const device = holder.device ?? t("settings.remote.table.unnamedDevice");
+  const joined = formatRelativeTime(holder.openedAt, locale);
+  const takeBackControl = () => {
+    if (reclaiming) return;
+    setReclaiming(true);
+    setReclaimError(false);
+    void revokeRemoteAccessSession(holder.handle)
+      .catch(() => setReclaimError(true))
+      .finally(() => setReclaiming(false));
+  };
+
+  return (
+    <div className="control-bar" role="status" aria-live="polite">
+      <span className="control-bar-signal" aria-hidden="true" />
+      <span className="control-bar-copy">
+        <strong>{t("chrome.control.bar.title", { name: device })}</strong>
+        <span>{t("chrome.control.bar.joined", { time: joined })}</span>
+        {reclaimError ? <span className="control-bar-error" role="alert">{t("chrome.control.reclaimError")}</span> : null}
+      </span>
+      <button type="button" disabled={reclaiming} onClick={takeBackControl}>
+        {reclaiming ? t("chrome.control.reclaiming") : t("chrome.control.takeBack")}
+      </button>
+    </div>
+  );
+}

--- a/runtime/fleet-console/core/client/src/components/control-curtain.tsx
+++ b/runtime/fleet-console/core/client/src/components/control-curtain.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { revokeRemoteAccessSession } from "../global-settings-api.js";
+import { useConsoleState } from "../hooks/use-store.js";
+import { useT } from "../i18n/index.js";
+import { dismissControlCurtain } from "../store.js";
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+export function ControlCurtain() {
+  const state = useConsoleState();
+  const t = useT();
+  const [reclaiming, setReclaiming] = useState(false);
+  const [reclaimError, setReclaimError] = useState(false);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+  const primaryActionRef = useRef<HTMLButtonElement | null>(null);
+  const cardRef = useRef<HTMLElement | null>(null);
+  const holder = state.controlHolder;
+  const open = holder !== null && !state.controlCurtainDismissed;
+
+  useEffect(() => {
+    if (!open) return;
+    const shell = document.querySelector<HTMLElement>(".console-shell");
+    if (shell) shell.inert = true;
+    return () => {
+      if (shell) shell.inert = false;
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    returnFocusRef.current = document.activeElement as HTMLElement | null;
+    primaryActionRef.current?.focus();
+    return () => {
+      const target = returnFocusRef.current;
+      returnFocusRef.current = null;
+      target?.focus?.();
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        dismissControlCurtain();
+      } else if (event.key === "Tab") {
+        trapFocus(event, cardRef.current);
+      }
+      event.stopImmediatePropagation();
+    };
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [open]);
+
+  if (!open || holder === null) return null;
+  const device = holder.device ?? t("settings.remote.table.unnamedDevice");
+  const takeBackControl = () => {
+    if (reclaiming) return;
+    setReclaiming(true);
+    setReclaimError(false);
+    void revokeRemoteAccessSession(holder.handle)
+      .catch(() => setReclaimError(true))
+      .finally(() => setReclaiming(false));
+  };
+
+  return createPortal(
+    <div className="control-curtain" role="dialog" aria-modal="true" aria-labelledby="control-curtain-title">
+      <div className="control-curtain-scrim" aria-hidden="true" />
+      <section className="control-curtain-card" ref={cardRef}>
+        <span className="control-curtain-signal" aria-hidden="true" />
+        <div className="control-curtain-copy">
+          <span className="control-curtain-eyebrow">{t("chrome.control.curtain.eyebrow")}</span>
+          <h2 id="control-curtain-title">{t("chrome.control.curtain.title", { name: device })}</h2>
+          <p>{t("chrome.control.curtain.body")}</p>
+        </div>
+        {reclaimError ? <p className="control-curtain-error" role="alert">{t("chrome.control.reclaimError")}</p> : null}
+        <div className="control-curtain-actions">
+          <button
+            ref={primaryActionRef}
+            type="button"
+            className="control-curtain-primary"
+            disabled={reclaiming}
+            onClick={takeBackControl}
+          >
+            {reclaiming ? t("chrome.control.reclaiming") : t("chrome.control.takeBack")}
+          </button>
+          <button type="button" className="control-curtain-secondary" onClick={dismissControlCurtain}>
+            {t("chrome.control.keepWatching")}
+          </button>
+        </div>
+      </section>
+    </div>,
+    document.body,
+  );
+}
+
+function trapFocus(event: KeyboardEvent, container: HTMLElement | null): void {
+  if (!container) return;
+  const focusable = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (!first || !last) return;
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}

--- a/runtime/fleet-console/core/client/src/components/control-reclaimed-notice.tsx
+++ b/runtime/fleet-console/core/client/src/components/control-reclaimed-notice.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { useT } from "../i18n/index.js";
+
+const CONTROL_RECLAIMED_EVENT = "fleet-console:control-reclaimed";
+
+export function ControlReclaimedNotice() {
+  const t = useT();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const showNotice = () => setVisible(true);
+    window.addEventListener(CONTROL_RECLAIMED_EVENT, showNotice);
+    return () => window.removeEventListener(CONTROL_RECLAIMED_EVENT, showNotice);
+  }, []);
+
+  if (!visible) return null;
+  return createPortal(
+    <div className="control-reclaimed-notice" role="alert" aria-live="assertive">
+      <section className="control-reclaimed-card">
+        <span className="control-reclaimed-signal" aria-hidden="true" />
+        <span className="control-reclaimed-eyebrow">{t("chrome.control.reclaimed.eyebrow")}</span>
+        <h2>{t("chrome.control.reclaimed.title")}</h2>
+        <p>{t("chrome.control.reclaimed.body")}</p>
+      </section>
+    </div>,
+    document.body,
+  );
+}

--- a/runtime/fleet-console/core/client/src/components/whatsnew-modal.tsx
+++ b/runtime/fleet-console/core/client/src/components/whatsnew-modal.tsx
@@ -75,6 +75,7 @@ export function WhatsNewModal({ state }: WhatsNewModalProps) {
     !state.bootstrapped ||
     state.onboardingOpen ||
     state.operationSearchOpen ||
+    (state.controlHolder !== null && !state.controlCurtainDismissed) ||
     state.quickLaunchOpen ||
     state.keyboardShortcutsOpen;
   if (state.whatsNewOpen && !whatsNewSuppressed && returnFocusRef.current === null) {

--- a/runtime/fleet-console/core/client/src/i18n/messages/chrome.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/chrome.ts
@@ -62,6 +62,21 @@ export const chromeEn = {
   "chrome.link.staleHeadline": "Updates stopped here",
   "chrome.link.staleDetail": "Last updated {time}",
 
+  // remote control
+  "chrome.control.shared": "Shared",
+  "chrome.control.curtain.eyebrow": "REMOTE CONTROL · READ-ONLY VIEW",
+  "chrome.control.curtain.title": "{name} has control",
+  "chrome.control.curtain.body": "You can keep watching this Console, or take control back on this device.",
+  "chrome.control.takeBack": "Take back control",
+  "chrome.control.reclaiming": "Taking back…",
+  "chrome.control.keepWatching": "Keep watching",
+  "chrome.control.reclaimError": "Control could not be taken back. Try again.",
+  "chrome.control.bar.title": "{name} has control",
+  "chrome.control.bar.joined": "Joined {time}",
+  "chrome.control.reclaimed.eyebrow": "REMOTE CONTROL ENDED",
+  "chrome.control.reclaimed.title": "Control was taken back",
+  "chrome.control.reclaimed.body": "Returning you to your own console…",
+
   // operation-search
   "chrome.operationSearch.commandsDialog": "Console commands",
   "chrome.operationSearch.quickSearchDialog": "Operation quick search",
@@ -303,6 +318,21 @@ export const chromeKo: Record<keyof typeof chromeEn, string> = {
   "chrome.link.reconnect": "다시 연결",
   "chrome.link.staleHeadline": "이 값은 갱신이 멈췄습니다",
   "chrome.link.staleDetail": "마지막 갱신 {time}",
+
+  // 원격 제어
+  "chrome.control.shared": "공유 중",
+  "chrome.control.curtain.eyebrow": "원격 제어 · 읽기 전용 보기",
+  "chrome.control.curtain.title": "{name}에서 제어 중입니다",
+  "chrome.control.curtain.body": "이 Console을 계속 지켜보거나 이 기기로 제어권을 가져올 수 있습니다.",
+  "chrome.control.takeBack": "제어권 가져오기",
+  "chrome.control.reclaiming": "제어권 가져오는 중…",
+  "chrome.control.keepWatching": "계속 지켜보기",
+  "chrome.control.reclaimError": "제어권을 가져오지 못했습니다. 다시 시도하세요.",
+  "chrome.control.bar.title": "{name}에서 제어 중",
+  "chrome.control.bar.joined": "{time} 접속",
+  "chrome.control.reclaimed.eyebrow": "원격 제어 종료",
+  "chrome.control.reclaimed.title": "제어권이 회수되었습니다",
+  "chrome.control.reclaimed.body": "내 Console로 돌아가는 중…",
 
   "chrome.operationSearch.commandsDialog": "Console 명령",
   "chrome.operationSearch.quickSearchDialog": "Operation 빠른 검색",

--- a/runtime/fleet-console/core/client/src/operations-sse.ts
+++ b/runtime/fleet-console/core/client/src/operations-sse.ts
@@ -1,9 +1,11 @@
 import { fetchObserverStatus, fetchOperations } from "./api.js";
 import { applyDesktopFullscreenSnapshot, resetDesktopFullscreenSnapshot } from "./desktop-fullscreen.js";
-import { applyObserverStatus, applyOperationUpdate, getState, hydrateOperations, setConnectionState } from "./store.js";
-import type { OperationNode } from "./types.js";
+import { applyControlHolder, applyObserverStatus, applyOperationUpdate, getState, hydrateOperations, setConnectionState } from "./store.js";
+import type { ControlHolder, OperationNode } from "./types.js";
 
 const MAX_RECONNECT_DELAY_MS = 30_000;
+const CONTROL_RECLAIM_NAVIGATION_DELAY_MS = 2_500;
+const CONTROL_RECLAIMED_EVENT = "fleet-console:control-reclaimed";
 
 // 누락 스냅샷은 SSE가 열리기 전에만 hydrate해 이후 실시간 프레임을 덮어쓰지 않는다.
 let reconnectDelayMs = 1_000;
@@ -50,6 +52,30 @@ export function connectOperationsSse(): void {
     }
   });
 
+  source.addEventListener("control:changed", (e) => {
+    if (!isCurrentSource()) return;
+    const msg = e as MessageEvent<string>;
+    try {
+      const data = JSON.parse(msg.data) as { readonly holder?: unknown };
+      if (isControlHolderSnapshot(data)) applyControlHolder(data.holder);
+    } catch {
+      // ignore malformed SSE event
+    }
+  });
+
+  source.addEventListener("control:reclaimed", (e) => {
+    if (!isCurrentSource()) return;
+    const msg = e as MessageEvent<string>;
+    try {
+      const data = JSON.parse(msg.data) as { readonly reason?: unknown };
+      if (!isControlReclaimed(data)) return;
+      window.dispatchEvent(new Event(CONTROL_RECLAIMED_EVENT));
+      window.setTimeout(() => location.reload(), CONTROL_RECLAIM_NAVIGATION_DELAY_MS);
+    } catch {
+      // ignore malformed SSE event
+    }
+  });
+
   source.onopen = () => {
     if (!isCurrentSource()) return;
     reconnectDelayMs = 1_000;
@@ -63,6 +89,7 @@ export function connectOperationsSse(): void {
     activeSource = null;
     const retryGeneration = ++connectionGeneration;
     resetDesktopFullscreenSnapshot();
+    // SSE 단절은 원격 제어 세션이 끝났다는 증거가 아니므로 holder는 마지막 권위 스냅샷을 유지한다.
     setConnectionState("offline");
     reconnectHandle = setTimeout(() => {
       reconnectHandle = null;
@@ -124,4 +151,18 @@ export function refreshObserverStatus(): void {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isControlHolderSnapshot(value: unknown): value is { readonly holder: ControlHolder | null } {
+  if (!isRecord(value) || Object.keys(value).length !== 1 || !("holder" in value)) return false;
+  if (value.holder === null) return true;
+  if (!isRecord(value.holder) || Object.keys(value.holder).length !== 3) return false;
+  return typeof value.holder.handle === "string"
+    && (value.holder.device === null || typeof value.holder.device === "string")
+    && typeof value.holder.openedAt === "number"
+    && Number.isFinite(value.holder.openedAt);
+}
+
+function isControlReclaimed(value: unknown): value is { readonly reason: "reclaimed" } {
+  return isRecord(value) && Object.keys(value).length === 1 && value.reason === "reclaimed";
 }

--- a/runtime/fleet-console/core/client/src/store.ts
+++ b/runtime/fleet-console/core/client/src/store.ts
@@ -9,6 +9,7 @@ import type {
   CodexReaderRequest,
   ConnectionState,
   ConsoleState,
+  ControlHolder,
   NotificationKind,
   NotificationPreferences,
   OperationGroup,
@@ -50,6 +51,8 @@ let commissioningMigrationAttempted = false;
 let state: ConsoleState = {
   connection: "connecting",
   connectionLostAt: null,
+  controlHolder: null,
+  controlCurtainDismissed: false,
   consoleName: "",
   channel: "unknown",
   // The SDK ConsoleTheme union matches ThemeId; the selected theme passes
@@ -132,6 +135,18 @@ export function setConnectionState(next: ConnectionState): void {
     return;
   }
   setState({ connection: next });
+}
+
+export function applyControlHolder(holder: ControlHolder | null): void {
+  const handleChanged = state.controlHolder?.handle !== holder?.handle;
+  setState({
+    controlHolder: holder,
+    ...(handleChanged ? { controlCurtainDismissed: false } : {}),
+  });
+}
+
+export function dismissControlCurtain(): void {
+  setState({ controlCurtainDismissed: true });
 }
 
 export function setOperationsViewActive(active: boolean): void {

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -758,6 +758,8 @@
 }
 
 .host-switcher-dot.is-live { border-color: var(--aurora); background: var(--aurora); }
+.host-switcher-dot.is-shared { border-color: var(--warn); background: var(--warn); box-shadow: 0 0 10px var(--warn-glow); }
+.host-switcher-chip.is-shared { color: var(--warn-ink); }
 .host-switcher-name { color: var(--text-primary); }
 
 .host-switcher-panel {
@@ -7268,6 +7270,60 @@
   background: var(--warn);
 }
 
+/* 관전 배지는 상태 줄과 달리 화면을 대신하지 않는다 — 출력이 계속 흐르는 위에 얹혀
+   "보이지만 칠 수 없다"만 말한다. 상태 줄을 재사용하면 살아 있는 터미널이 오류처럼 읽힌다. */
+.terminal-viewer-badge {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-bottom: 1px solid color-mix(in oklch, var(--warn) 52%, var(--surface-rim));
+  background: var(--warn-glow);
+  font-size: 11.5px;
+}
+
+.terminal-viewer-badge-dot {
+  width: 8px;
+  height: 8px;
+  flex: none;
+  border-radius: 999px;
+  background: var(--warn);
+}
+
+.terminal-viewer-badge-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--warn-ink);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.terminal-viewer-badge-action {
+  flex: none;
+  min-height: 22px;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--surface-rim-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface-glass);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition: border-color var(--duration-fast) var(--ease-glide);
+}
+
+.terminal-viewer-badge-action:hover {
+  border-color: var(--brass);
+}
+
+.terminal-viewer-badge-action:focus-visible {
+  outline: 2px solid var(--brass);
+  outline-offset: 2px;
+}
+
 /* 줌 보정 레이어: position:relative 기준 박스를 제공해 .terminal-canvas의 역스케일(%-기반)이
    측정 없이 inner 크기에 정확히 맞도록 한다. flex:1로 상태바 아래 남는 공간을 채운다. */
 .terminal-viewport {
@@ -10745,6 +10801,262 @@ body[data-codex-reading="true"] .operations-side-bar {
 
   .quick-launch-chip,
   .quick-launch-variant-chip {
+    transition: none;
+  }
+}
+
+.command-band-local-chip.is-shared {
+  border-color: color-mix(in oklch, var(--warn) 50%, var(--surface-rim));
+  background: var(--warn-glow);
+  color: var(--warn-ink);
+}
+
+.command-band-local-chip.is-shared .command-band-local-dot {
+  background: var(--warn);
+  box-shadow: 0 0 10px var(--warn-glow);
+}
+
+/* 원격 제어 인계 — curtain은 로컬 입력을 멈추고, bar는 흐름 안에서 읽기 전용 상태를 계속 알린다. */
+.control-curtain,
+.control-reclaimed-notice {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: grid;
+  place-items: center;
+  padding: clamp(var(--space-4), 5vw, var(--space-8));
+}
+
+.control-curtain-scrim,
+.control-reclaimed-notice {
+  background:
+    radial-gradient(circle at 50% 18%, color-mix(in oklch, var(--warn) 13%, transparent), transparent 42%),
+    color-mix(in oklch, var(--ink-abyss) 76%, transparent);
+}
+
+.control-curtain-scrim {
+  position: absolute;
+  inset: 0;
+}
+
+.control-curtain-card,
+.control-reclaimed-card {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: min(620px, 100%);
+  overflow: hidden;
+  border: 1px solid color-mix(in oklch, var(--warn) 48%, var(--surface-rim));
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-floating), 0 0 44px -24px var(--warn-glow);
+  animation: fleet-pop var(--duration-slow) var(--ease-spring) both;
+}
+
+.control-curtain-card {
+  grid-template-columns: 4px minmax(0, 1fr);
+  /* 팝업 판독성 계약: warn wash와 glass 층 아래 불투명 --ink-deep 언더레이를 둔다. */
+  background:
+    radial-gradient(100% 90% at 0 0, color-mix(in oklch, var(--warn) 12%, transparent), transparent 62%),
+    linear-gradient(var(--surface-glass-strong), var(--surface-glass-strong)),
+    var(--ink-deep);
+  padding: clamp(var(--space-5), 5vw, var(--space-8));
+  column-gap: clamp(var(--space-4), 4vw, var(--space-6));
+}
+
+.control-curtain-signal,
+.control-reclaimed-signal {
+  display: block;
+  border-radius: 999px;
+  background: var(--warn);
+  box-shadow: 0 0 22px var(--warn-glow);
+}
+
+.control-curtain-signal {
+  grid-row: 1 / span 3;
+  width: 4px;
+  height: 100%;
+  min-height: 148px;
+}
+
+.control-curtain-copy {
+  display: grid;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.control-curtain-eyebrow,
+.control-reclaimed-eyebrow {
+  color: var(--warn-ink);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.control-curtain-copy h2,
+.control-reclaimed-card h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: clamp(30px, 6vw, 48px);
+  font-weight: var(--weight-bold);
+  line-height: 1.05;
+}
+
+.control-curtain-copy p,
+.control-reclaimed-card p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.control-curtain-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-top: var(--space-6);
+}
+
+.control-curtain-actions button,
+.control-bar button {
+  min-height: 38px;
+  padding: 0 var(--space-4);
+  border: 1px solid var(--surface-rim-strong);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: var(--weight-bold);
+  transition:
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring),
+    color var(--duration-fast) var(--ease-spring);
+}
+
+.control-curtain-primary,
+.control-bar button {
+  border-color: var(--brass);
+  background: var(--brass);
+  color: var(--text-on-brass);
+}
+
+.control-curtain-secondary {
+  background: var(--surface-glass);
+  color: var(--text-secondary);
+}
+
+.control-curtain-actions button:hover:not(:disabled),
+.control-curtain-actions button:focus-visible,
+.control-bar button:hover:not(:disabled),
+.control-bar button:focus-visible {
+  border-color: var(--brass-bright);
+  outline: 1px solid var(--brass);
+  outline-offset: 2px;
+}
+
+.control-curtain-actions button:disabled,
+.control-bar button:disabled {
+  color: var(--text-tertiary);
+  cursor: wait;
+}
+
+.control-curtain-error {
+  margin: var(--space-4) 0 0;
+  color: var(--warn-ink);
+  font-size: 12px;
+  font-weight: var(--weight-medium);
+}
+
+.control-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  flex: none;
+  min-height: 40px;
+  padding: var(--space-1) var(--space-4);
+  border-bottom: 1px solid color-mix(in oklch, var(--warn) 52%, var(--surface-rim));
+  background: var(--warn-glow);
+  color: var(--text-secondary);
+}
+
+.control-bar-signal {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--warn);
+  box-shadow: 0 0 12px var(--warn-glow);
+}
+
+.control-bar-copy {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2);
+  min-width: 0;
+  font-size: 12px;
+}
+
+.control-bar-copy strong {
+  color: var(--text-primary);
+  font-weight: var(--weight-bold);
+}
+
+.control-bar-error {
+  color: var(--warn-ink);
+  font-weight: var(--weight-medium);
+}
+
+.control-bar button {
+  min-height: 30px;
+  padding: 0 var(--space-3);
+}
+
+.control-reclaimed-card {
+  justify-items: center;
+  gap: var(--space-3);
+  padding: clamp(var(--space-6), 7vw, var(--space-8));
+  /* 팝업 판독성 계약: warn wash와 glass 층 아래 불투명 --ink-deep 언더레이를 둔다. */
+  background:
+    radial-gradient(100% 90% at 50% 0, color-mix(in oklch, var(--warn) 12%, transparent), transparent 62%),
+    linear-gradient(var(--surface-glass-strong), var(--surface-glass-strong)),
+    var(--ink-deep);
+  text-align: center;
+}
+
+.control-reclaimed-signal {
+  width: 34px;
+  height: 4px;
+  margin-bottom: var(--space-3);
+}
+
+.control-reclaimed-card p {
+  max-width: 420px;
+}
+
+@media (max-width: 640px) {
+  .control-bar {
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
+
+  .control-bar-copy {
+    flex: 1;
+    flex-direction: column;
+    gap: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .control-curtain-card,
+  .control-reclaimed-card {
+    animation: none;
+  }
+
+  .control-curtain-actions button,
+  .control-bar button {
     transition: none;
   }
 }

--- a/runtime/fleet-console/core/client/src/types.ts
+++ b/runtime/fleet-console/core/client/src/types.ts
@@ -213,6 +213,12 @@ export interface ApiCatalogEntry {
 
 export type ConnectionState = "connecting" | "live" | "offline";
 
+export interface ControlHolder {
+  readonly handle: string;
+  readonly device: string | null;
+  readonly openedAt: number;
+}
+
 export type NotificationKind = "ended" | "input-waiting";
 
 export interface OperationNotification {
@@ -241,6 +247,8 @@ export interface ConsoleState {
   readonly consoleName: string;
   readonly connection: ConnectionState;
   readonly connectionLostAt: number | null;
+  readonly controlHolder: ControlHolder | null;
+  readonly controlCurtainDismissed: boolean;
   readonly channel: ObserverStatus["channel"];
   readonly activeTheme: ConsoleTheme;
   readonly version: string;

--- a/runtime/fleet-console/core/host/access-control-contract.ts
+++ b/runtime/fleet-console/core/host/access-control-contract.ts
@@ -38,3 +38,9 @@ export interface ControlReclaimedSnapshot {
 }
 
 export const controlReclaimedSnapshot = (reason: ControlReclaimedReason): ControlReclaimedSnapshot => ({ reason });
+
+/**
+ * 플러그인에게 보유자 변화를 알리는 채널. 브라우저로 나가는 SSE 이벤트와 목적이 다르다 —
+ * 이쪽은 서버 안에서 이미 열려 있는 전송을 다시 협상시키기 위한 것이다.
+ */
+export const CONTROL_HOLDER_EVENT_CHANNEL = "control:holder";

--- a/runtime/fleet-console/core/host/access-control-contract.ts
+++ b/runtime/fleet-console/core/host/access-control-contract.ts
@@ -1,0 +1,40 @@
+/**
+ * 제어권 이양의 관측면. 원격 세션이 열리고 닫히는 사실은 설정 화면을 열어야만 보이던 정보였는데,
+ * 그 사이 원격은 이미 터미널을 몰 수 있다. 이 두 이벤트가 그 공백을 메운다.
+ *
+ * 두 이벤트의 수신자가 서로 다르다는 점이 이 계약의 핵심이다 — `control:changed`는 이 기계 앞에
+ * 앉은 사람의 것이고, `control:reclaimed`는 방금 끊긴 그 세션 하나의 것이다. 하나의 스트림으로
+ * 합치면 원격 세션이 다른 세션의 존재와 기기 이름을 읽게 된다.
+ */
+
+/** 루프백 구독자에게만. 지금 제어를 쥔 원격이 누구인지(없으면 null). */
+export const CONTROL_CHANGED_EVENT = "control:changed";
+
+/** 끊긴 그 원격 세션에게만. 자기 세션이 회수되었음을 알린다. */
+export const CONTROL_RECLAIMED_EVENT = "control:reclaimed";
+
+/**
+ * 제어를 쥔 원격 세션의 공개 표현. `handle`은 회수 호출의 대상이고 쿠키 비밀값과 다르다.
+ * 세션 요약에서 이 화면에 필요한 만큼만 옮겨 담는다 — 만료 시각은 커튼이 말할 것이 없다.
+ */
+export interface ControlHolderSnapshot {
+  readonly handle: string;
+  /** 조인할 때 기기가 스스로 밝힌 이름. null이면 화면이 대체 이름을 쓴다. */
+  readonly device: string | null;
+  readonly openedAt: number;
+}
+
+export interface ControlChangedSnapshot {
+  readonly holder: ControlHolderSnapshot | null;
+}
+
+export const controlChangedSnapshot = (holder: ControlHolderSnapshot | null): ControlChangedSnapshot => ({ holder });
+
+/** 회수 사유. 지금은 하나뿐이지만, 만료·리스너 종료와 구분할 자리를 남겨 둔다. */
+export type ControlReclaimedReason = "reclaimed";
+
+export interface ControlReclaimedSnapshot {
+  readonly reason: ControlReclaimedReason;
+}
+
+export const controlReclaimedSnapshot = (reason: ControlReclaimedReason): ControlReclaimedSnapshot => ({ reason });

--- a/runtime/fleet-console/core/host/auth.ts
+++ b/runtime/fleet-console/core/host/auth.ts
@@ -71,6 +71,13 @@ export interface AccessRegistryDeps {
   readonly randomToken?: () => string;
   /** 목록에 실리는 공개 이름. 토큰과 다른 생성기를 써서 둘을 섞을 여지를 없앤다. */
   readonly randomHandle?: () => string;
+  /**
+   * prune이 실제로 세션을 걷어냈을 때 알린다. 만료는 조용히 일어나므로 알리지 않으면 화면은
+   * 이미 없는 보유자를 계속 띄운 채 남는다 — 명시적 회수와 같은 신호가 나가야 한다.
+   *
+   * prune은 다른 레지스트리 호출 안에서 돌기도 하므로 콜백은 재진입을 견뎌야 한다.
+   */
+  readonly onSessionsPruned?: () => void;
 }
 
 export interface AccessRegistry {
@@ -240,9 +247,14 @@ export function createAccessRegistry(deps: AccessRegistryDeps = {}): AccessRegis
     for (const [token, grant] of grants) {
       if (grant.expiresAt <= current) grants.delete(token);
     }
+    let removed = false;
     for (const [id, stored] of sessions) {
-      if (stored.absoluteExpiresAt <= current || stored.idleExpiresAt <= current) sessions.delete(id);
+      if (stored.absoluteExpiresAt <= current || stored.idleExpiresAt <= current) {
+        sessions.delete(id);
+        removed = true;
+      }
     }
+    if (removed) deps.onSessionsPruned?.();
   }
 
   return { grantTtlMs, issueGrant, redeemGrant, peekGrant, resolveSession, listGrants, revokeGrant, revokeGrants, listSessions, hasSession, revokeSession, revokeSessionByHandle, revokeSessions, revokeAllSessions, prune };

--- a/runtime/fleet-console/core/host/auth.ts
+++ b/runtime/fleet-console/core/host/auth.ts
@@ -78,6 +78,12 @@ export interface AccessRegistry {
   issueGrant(audience: AccessAudience, access?: AccessClass): AccessGrant;
   /** 리스너의 audience와 일치하는 grant만 세션으로 교환된다. 교환된 grant는 소멸한다. */
   redeemGrant(token: string | null, audience: AccessAudience, device?: string | null): AccessSession | null;
+  /**
+   * 소모하지 않고 등급만 본다. 조인을 거절해야 하는 경우 자격을 태우기 전에 판정하기 위한 것이다 —
+   * redeemGrant는 거절할 때도 토큰을 지우므로, 그 뒤에서 막으면 1회용 링크만 소멸하고 아무도
+   * 붙지 못한 채 끝난다. 만료·audience 불일치는 여기서도 null이다.
+   */
+  peekGrant(token: string, audience: AccessAudience): AccessGrantSummary | null;
   resolveSession(id: string | null, audience: AccessAudience): AccessSession | null;
   listGrants(audience: AccessAudience): readonly AccessGrantSummary[];
   /** 아직 쓰이지 않은 링크를 하나만 무효화한다. */
@@ -85,6 +91,11 @@ export interface AccessRegistry {
   /** 이 audience의 미사용 링크를 전부 무효화한다. */
   revokeGrants(audience: AccessAudience): void;
   listSessions(audience: AccessAudience): readonly AccessSessionSummary[];
+  /**
+   * 이 audience에 해당 등급의 세션이 이미 열려 있는지. 제어를 쥔 원격은 한 번에 하나여야 하고,
+   * 그 판정을 조인 이전에 내려야 자격이 소모된 뒤 거절하는 일이 없다.
+   */
+  hasSession(audience: AccessAudience, access: AccessClass): boolean;
   revokeSession(id: string): boolean;
   /** 이미 열린 세션 하나를 공개 이름으로 끊는다. */
   revokeSessionByHandle(handle: string): boolean;
@@ -138,6 +149,13 @@ export function createAccessRegistry(deps: AccessRegistryDeps = {}): AccessRegis
     return openSession(audience, grant.access, device);
   }
 
+  function peekGrant(token: string, audience: AccessAudience): AccessGrantSummary | null {
+    prune();
+    const grant = grants.get(token);
+    if (!grant || grant.audience !== audience || grant.expiresAt <= now()) return null;
+    return { id: grant.id, access: grant.access, issuedAt: grant.issuedAt, expiresAt: grant.expiresAt };
+  }
+
   function openSession(audience: AccessAudience, access: AccessClass, device: string | null): AccessSession {
     const id = randomToken();
     const handle = randomHandle();
@@ -188,6 +206,14 @@ export function createAccessRegistry(deps: AccessRegistryDeps = {}): AccessRegis
       .sort((left, right) => right.openedAt - left.openedAt);
   }
 
+  function hasSession(audience: AccessAudience, access: AccessClass): boolean {
+    prune();
+    for (const stored of sessions.values()) {
+      if (stored.audience === audience && stored.access === access) return true;
+    }
+    return false;
+  }
+
   function revokeSessionByHandle(handle: string): boolean {
     for (const [id, stored] of sessions) {
       if (stored.handle === handle) return sessions.delete(id);
@@ -219,7 +245,7 @@ export function createAccessRegistry(deps: AccessRegistryDeps = {}): AccessRegis
     }
   }
 
-  return { grantTtlMs, issueGrant, redeemGrant, resolveSession, listGrants, revokeGrant, revokeGrants, listSessions, revokeSession, revokeSessionByHandle, revokeSessions, revokeAllSessions, prune };
+  return { grantTtlMs, issueGrant, redeemGrant, peekGrant, resolveSession, listGrants, revokeGrant, revokeGrants, listSessions, hasSession, revokeSession, revokeSessionByHandle, revokeSessions, revokeAllSessions, prune };
 }
 
 /**

--- a/runtime/fleet-console/core/host/operations/operations-domain.ts
+++ b/runtime/fleet-console/core/host/operations/operations-domain.ts
@@ -325,7 +325,8 @@ export interface OperationsRouterDeps {
   readonly isPendingDeletion?: (id: string) => boolean;
   readonly publishRenameEvent?: (event: OperationRenameEvent) => void;
   readonly broadcastOperationChanged?: (node: OperationNode) => void;
-  readonly subscribeOperationSse?: (res: http.ServerResponse) => void;
+  // 요청도 함께 넘긴다 — 구독자가 어느 리스너에서 왔는지에 따라 받을 이벤트가 갈린다.
+  readonly subscribeOperationSse?: (req: http.IncomingMessage, res: http.ServerResponse) => void;
   readonly getPluginSensitiveFields?: (pluginId: string) => readonly string[];
   readonly resolveLaunchCatalog?: () => Promise<{ readonly plugins: readonly OperationCatalogPlugin[] }>;
 }
@@ -370,7 +371,7 @@ export function createOperationsRouter(deps: OperationsRouterDeps): OperationsRo
         deps.writeJson(res, 405, { error: "Method not allowed" });
         return true;
       }
-      deps.subscribeOperationSse?.(res);
+      deps.subscribeOperationSse?.(req, res);
       return true;
     }
     if (pathname === "/api/v1/operations/groups") {

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -11,7 +11,8 @@ import { createWikiWorkspaceResolver } from "@dotobokuri/fleet-wiki";
 import { readLaunchVariantGroups } from "@fleet-console/sdk/operations/launch-variants";
 
 import { buildApiCatalog, type ApiCatalogEntry } from "./api-catalog.js";
-import { createAccessRegistry, createLoopbackListenerIdentity, formatSessionCookie, readSessionCookie, resolveListenerIdentity, type AccessClass, type ListenerIdentity } from "./auth.js";
+import { CONTROL_CHANGED_EVENT, CONTROL_RECLAIMED_EVENT, controlChangedSnapshot, controlReclaimedSnapshot, type ControlHolderSnapshot } from "./access-control-contract.js";
+import { createAccessRegistry, createLoopbackListenerIdentity, formatSessionCookie, readSessionCookie, resolveListenerIdentity, type AccessAudience, type AccessClass, type ListenerIdentity } from "./auth.js";
 import { listRemoteInterfaces } from "./remote-interfaces.js";
 import type { ConsoleEnvironmentDiagnostics, ConsoleHealth, ConsoleObserverStatus, ConsoleTheaterFolderListResponse, ConsoleTheaterInfo, ConsoleUpdateApplyAcceptedResponse, ConsoleUpdateApplyError } from "./console-contract-types.js";
 import { createCodexWorkspaceRouter } from "./codex/workspace-routes.js";
@@ -106,6 +107,18 @@ interface ConsolePortListenPlan {
   readonly requestedPort: number | null;
   readonly portMode: "dynamic" | "static";
   readonly allowFallback: boolean;
+}
+
+/**
+ * SSE 구독자는 이제 자기가 어느 리스너에서 왔는지를 들고 다닌다. 제어권 이벤트의 수신자가
+ * 구독자마다 다르기 때문이다 — 보유자 정보는 루프백만, 회수 통지는 끊긴 세션 하나만 받는다.
+ * 평면 Set으로 두면 원격 화면에 다른 기기의 이름이 실려 나간다.
+ */
+interface OperationSseSubscriber {
+  readonly res: http.ServerResponse;
+  readonly audience: AccessAudience;
+  /** 원격 구독자의 세션 공개 이름. 루프백 구독자는 null이다. */
+  readonly sessionHandle: string | null;
 }
 
 interface ConsolePortListenResult {
@@ -426,7 +439,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   const pluginLaunchCatalogProviders = new Map<string, OperationLaunchCatalogProvider[]>();
   const pluginCleanupCallbacks = new Set<() => void | Promise<void>>();
   const pluginEventListeners = new Map<string, Set<(payload: unknown) => void>>();
-  const operationSseSubscribers = new Set<http.ServerResponse>();
+  const operationSseSubscribers = new Set<OperationSseSubscriber>();
   const desktopThemeSseSubscribers = new Set<http.ServerResponse>();
   function publishPluginEvent(channel: string, payload: unknown): void {
     for (const listener of pluginEventListeners.get(channel) ?? []) listener(payload);
@@ -457,15 +470,18 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     return deletionCoordinator.deleteOperation(operationId) !== null;
   }
   let desktopFullscreen = false;
-  let desktopShell: DesktopShellSnapshot = emptyDesktopShell();
   /**
    * 셸의 집 주소를 되돌려 받을 자격은 그것을 게시한 창에만 있다.
    *
    * 이 값은 루프백 주소다. 다른 사람의 화면에 흘러가면 거기서는 그 사람의 기계를 가리키고,
    * 같은 포트를 쓰는 전혀 다른 콘솔로 데려간다. 그래서 게시한 세션(원격) 또는 루프백 요청
    * 자신(local)에게만 되돌려 준다.
+   *
+   * 소유자별로 나눠 담는다. 한 칸만 두면 마지막에 게시한 창이 앞의 것을 지우므로, 원격 Desktop이
+   * 붙는 순간 이 기계 앞 사람의 집 주소가 사라져 호스트 스위처에서 Home이 없어진다 — 두 창은
+   * 서로 다른 기계를 가리키고 있어 덮어쓸 관계가 아니다.
    */
-  let desktopShellOwner: string | "local" | null = null;
+  const desktopShellsByOwner = new Map<string | "local", DesktopShellSnapshot>();
   // 창을 들고 있는 Desktop이 게시하는 호스트 목록. 브라우저 단독이면 비어 있다.
   let unsubscribeUpdateCheckChanges = updateCheck.onChange?.(() => {
     broadcastUpdateAvailable();
@@ -648,12 +664,18 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     },
   });
   const desktopShellRouter = createDesktopShellRouter({
-    getShell: (req) => (shellOwnerOf(req) === desktopShellOwner ? desktopShell : emptyDesktopShell()),
+    getShell: (req) => {
+      const owner = shellOwnerOf(req);
+      return (owner === null ? undefined : desktopShellsByOwner.get(owner)) ?? emptyDesktopShell();
+    },
     isAuthorized: isExactConsoleOrigin,
     readJsonBody,
     setShell: (req, snapshot) => {
-      desktopShell = snapshot;
-      desktopShellOwner = snapshot.homeOrigin === null ? null : shellOwnerOf(req);
+      const owner = shellOwnerOf(req);
+      if (owner === null) return;
+      // homeOrigin이 비면 그 창은 더 이상 집을 주장하지 않는다 — 빈 스냅샷을 남기는 대신 지운다.
+      if (snapshot.homeOrigin === null) desktopShellsByOwner.delete(owner);
+      else desktopShellsByOwner.set(owner, snapshot);
     },
     writeJson,
     writeNoContent: (res) => { res.writeHead(204, withSecurityHeaders({})); res.end(); },
@@ -701,7 +723,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     resolveLaunchCatalog: resolveOperationCatalog,
     publishRenameEvent: (event) => pluginHostCapabilities.events.publish(OPERATION_RENAMED_EVENT_CHANNEL, event),
     broadcastOperationChanged,
-    subscribeOperationSse: (res) => {
+    subscribeOperationSse: (req, res) => {
       res.writeHead(200, withSecurityHeaders({
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
@@ -709,9 +731,20 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       }));
       res.write(":connected\n\n");
       res.write(encodeSseData(DESKTOP_FULLSCREEN_EVENT, desktopFullscreenSnapshot(desktopFullscreen)));
-      operationSseSubscribers.add(res);
+      const listener = listenerForRequest(req);
+      const audience: AccessAudience = listener?.audience ?? "local";
+      const sessionHandle = listener === null || listener.audience === "local"
+        ? null
+        : access.resolveSession(readSessionCookie(req.headers, listener.port), listener.audience)?.handle ?? null;
+      // 루프백은 붙는 순간 현재 보유자를 받는다 — 커튼은 세션이 열린 뒤에 새로고침한 화면에서도
+      // 떠 있어야 하고, 이벤트만으로는 그 사이에 놓친 사실을 되찾을 수 없다.
+      if (audience === "local") {
+        res.write(encodeSseData(CONTROL_CHANGED_EVENT, controlChangedSnapshot(currentControlHolder())));
+      }
+      const subscriber: OperationSseSubscriber = { res, audience, sessionHandle };
+      operationSseSubscribers.add(subscriber);
       startSseKeepaliveLifecycle(res, () => {
-        operationSseSubscribers.delete(res);
+        operationSseSubscribers.delete(subscriber);
       });
     },
   });
@@ -811,7 +844,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       return;
     }
     if (pathname === "/api/v1/access-links") {
-      if (req.method === "GET") handleRemoteAccessStatus(res);
+      if (req.method === "GET") handleRemoteAccessStatus(req, res);
       else handleAccessLinkIssue(req, res);
       return;
     }
@@ -980,7 +1013,18 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
    * 원격 리스너의 실제 상태. 설정값이 아니라 지금 열려 있는 리스너를 보고한다 — 켜 두었지만
    * 바인드에 실패한 경우를 설정 화면이 "켜짐"으로 오독하지 않게 한다.
    */
-  function handleRemoteAccessStatus(res: http.ServerResponse): void {
+  function handleRemoteAccessStatus(req: http.IncomingMessage, res: http.ServerResponse): void {
+    /**
+     * 읽기는 루프백이라는 사실만 요구한다 — 형제인 remote-hosts GET과 같은 선례다. Origin까지
+     * 요구하면 브라우저가 아닌 로컬 소비자(Desktop·진단 도구)가 함께 막힌다.
+     *
+     * 원격을 막는 것이 요점이다. 이 응답에는 인증서 지문, 열린 세션의 기기 이름, 미사용 링크,
+     * 그리고 이 기계가 가진 모든 주소가 실린다 — 초대받은 손님이 볼 목록이 아니다.
+     */
+    if (!isLoopbackListener(req)) {
+      writeJson(res, 401, { error: "unauthorized" });
+      return;
+    }
     const remote = listeners.find((entry) => entry.audience === "remote");
     writeJson(res, 200, {
       listening: remote !== undefined && remoteFingerprint !== null,
@@ -999,7 +1043,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       writeJson(res, 405, { error: "Method not allowed" });
       return;
     }
-    if (!isLockAuthorized(req) && !isExactConsoleOrigin(req)) {
+    if (!isAccessAdminAuthorized(req)) {
       writeJson(res, 401, { error: "unauthorized" });
       return;
     }
@@ -1016,14 +1060,21 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       writeJson(res, 405, { error: "Method not allowed" });
       return;
     }
-    if (!isLockAuthorized(req) && !isExactConsoleOrigin(req)) {
+    if (!isAccessAdminAuthorized(req)) {
       writeJson(res, 401, { error: "unauthorized" });
       return;
     }
-    if (!access.revokeSessionByHandle(decodeHandle(rawHandle))) {
+    const handle = decodeHandle(rawHandle);
+    if (!access.revokeSessionByHandle(handle)) {
       writeJson(res, 404, { error: "session_not_found" });
       return;
     }
+    // 세션이 사라지면 그 세션이 게시한 집 주소도 가리킬 주인이 없다. 남겨 두면 handle이
+    // 재사용되지 않는 이상 되살아나지는 않지만, 오래 뜬 서버에서 계속 쌓이기만 한다.
+    desktopShellsByOwner.delete(handle);
+    // 순서가 있다: 끊긴 쪽이 먼저 자기 안내를 받고, 그 다음 이 기계의 화면이 커튼을 걷는다.
+    notifyControlReclaimed(handle);
+    broadcastControlChanged();
     res.writeHead(204, withSecurityHeaders({}));
     res.end();
   }
@@ -1038,7 +1089,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       writeJson(res, 405, { error: "Method not allowed" });
       return true;
     }
-    if (!isLockAuthorized(req) && !isExactConsoleOrigin(req)) {
+    if (!isAccessAdminAuthorized(req)) {
       writeJson(res, 401, { error: "unauthorized" });
       return true;
     }
@@ -1087,7 +1138,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       writeJson(res, 405, { error: "Method not allowed" });
       return;
     }
-    if (!isLockAuthorized(req) && !isExactConsoleOrigin(req)) {
+    if (!isAccessAdminAuthorized(req)) {
       writeJson(res, 401, { error: "unauthorized" });
       return;
     }
@@ -1115,11 +1166,28 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     const body = await readJsonBody<{ readonly token?: unknown; readonly device?: unknown }>(req);
     const token = isPlainObject(body) && typeof body.token === "string" ? body.token : null;
     const device = isPlainObject(body) ? sanitizeDeviceName(body.device) : null;
+    /**
+     * 제어를 쥔 원격은 한 번에 하나다. 커튼은 "누가" 몰고 있는지를 하나로 말해야 하고 회수
+     * 버튼은 대상이 하나여야 하므로, 둘째 full 조인은 받지 않는다. 밀어내기로 하지 않는 이유는
+     * 유효한 링크를 쥔 사람이 현 보유자를 조용히 축출할 수 있게 되기 때문이다 — 자리를 비우는
+     * 판단은 콘솔 주인의 몫으로 남긴다.
+     *
+     * 자격을 소모하기 전에 판정한다. redeemGrant는 성공 여부와 무관하게 토큰을 지우므로,
+     * 뒤에서 거절하면 1회용 링크만 태우고 아무도 붙지 못한다.
+     */
+    if (listener?.audience === "remote" && access.hasSession("remote", "full")) {
+      const pending = token === null ? null : access.peekGrant(token, listener.audience);
+      if (pending?.access === "full") {
+        writeJson(res, 409, { error: "remote_control_held" });
+        return true;
+      }
+    }
     const session = listener ? access.redeemGrant(token, listener.audience, device) : null;
     if (!listener || !session) {
       writeJson(res, 401, { error: "unauthorized" });
       return true;
     }
+    if (listener.audience === "remote" && session.access === "full") broadcastControlChanged();
     // 평문 http 리스너에 Secure를 붙이면 브라우저가 쿠키를 버린다.
     res.writeHead(204, withSecurityHeaders({ "Set-Cookie": formatSessionCookie(session, { secure: listener.secure, port: listener.port }) }));
     res.end();
@@ -1143,6 +1211,18 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   }
 
   function isRemoteHostWriteAuthorized(req: http.IncomingMessage): boolean {
+    return isLoopbackListener(req) && (isLockAuthorized(req) || isExactConsoleOrigin(req));
+  }
+
+  /**
+   * 원격을 관리하는 자리는 이 기계 앞이다. 자격을 발급하고, 목록을 읽고, 남의 세션을 끊고,
+   * 신원을 갈아 끼우는 일은 초대받은 쪽이 할 일이 아니다.
+   *
+   * `isExactConsoleOrigin`만으로는 이 경계가 서지 않는다 — 그 함수는 요청이 도착한 리스너의
+   * origin과 대조하므로, 원격 브라우저가 원격 origin으로 보내면 그대로 통과한다. 루프백
+   * 판정을 함께 요구해야 카탈로그가 이미 선언해 둔 gate가 런타임에서도 참이 된다.
+   */
+  function isAccessAdminAuthorized(req: http.IncomingMessage): boolean {
     return isLoopbackListener(req) && (isLockAuthorized(req) || isExactConsoleOrigin(req));
   }
 
@@ -1730,23 +1810,61 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     ];
     const sanitized = createSanitizedOpDto(node, { sensitiveFields });
     const data = encodeSseData("operation:changed", { operation: sanitized });
-    for (const res of operationSseSubscribers) {
-      res.write(data);
+    for (const subscriber of operationSseSubscribers) {
+      subscriber.res.write(data);
     }
   }
 
   function broadcastUpdateAvailable(): void {
     if (operationSseSubscribers.size === 0) return;
     const data = encodeSseData("update:available", {});
-    for (const res of operationSseSubscribers) {
-      res.write(data);
+    for (const subscriber of operationSseSubscribers) {
+      subscriber.res.write(data);
     }
   }
 
   function broadcastDesktopFullscreenChanged(): void {
     if (operationSseSubscribers.size === 0) return;
     const data = encodeSseData(DESKTOP_FULLSCREEN_EVENT, desktopFullscreenSnapshot(desktopFullscreen));
-    for (const res of operationSseSubscribers) res.write(data);
+    for (const subscriber of operationSseSubscribers) subscriber.res.write(data);
+  }
+
+  /**
+   * 제어를 쥔 원격. full 등급 세션만 보유자가 된다 — monitoring은 명령을 실행하지 못하므로
+   * 그 접속으로 화면을 덮으면 아무것도 못 하는 관전자 때문에 콘솔이 잠긴다.
+   *
+   * 상한이 1이므로 목록에서 가장 먼저 나오는 하나가 곧 보유자다.
+   */
+  function currentControlHolder(): ControlHolderSnapshot | null {
+    for (const session of access.listSessions("remote")) {
+      if (session.access !== "full") continue;
+      return { handle: session.handle, device: session.device, openedAt: session.openedAt };
+    }
+    return null;
+  }
+
+  /** 보유자 변화는 이 기계 앞에 앉은 사람에게만 간다. 원격은 다른 세션의 존재를 알 이유가 없다. */
+  function broadcastControlChanged(): void {
+    if (operationSseSubscribers.size === 0) return;
+    const data = encodeSseData(CONTROL_CHANGED_EVENT, controlChangedSnapshot(currentControlHolder()));
+    for (const subscriber of operationSseSubscribers) {
+      if (subscriber.audience !== "local") continue;
+      subscriber.res.write(data);
+    }
+  }
+
+  /**
+   * 회수 통지는 끊긴 그 세션에게만. 쿠키는 이미 무효라 다음 요청이 401이 되는데, SPA가 떠 있는
+   * 동안에는 그 401을 아무도 마주치지 않는다 — 이 이벤트가 원격 화면에 안내를 띄우고 스스로
+   * 이동하게 만드는 유일한 신호다.
+   */
+  function notifyControlReclaimed(handle: string): void {
+    if (operationSseSubscribers.size === 0) return;
+    const data = encodeSseData(CONTROL_RECLAIMED_EVENT, controlReclaimedSnapshot("reclaimed"));
+    for (const subscriber of operationSseSubscribers) {
+      if (subscriber.sessionHandle !== handle) continue;
+      subscriber.res.write(data);
+    }
   }
 
   function broadcastDesktopThemeChanged(theme: ConsoleThemeId): void {
@@ -1946,6 +2064,12 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     // 옛 주소와 옛 지문을 실어 나르므로 함께 버린다.
     access.revokeSessions("remote");
     access.revokeGrants("remote");
+    for (const owner of desktopShellsByOwner.keys()) {
+      if (owner !== "local") desktopShellsByOwner.delete(owner);
+    }
+    // 원격을 끄면 보유자도 사라진다. 알리지 않으면 커튼이 아무도 없는 콘솔 위에 남는다 —
+    // 신원 갱신도 리스너를 다시 여는 경로라 이 자리를 지난다.
+    broadcastControlChanged();
     if (closing) await new Promise<void>((resolve) => closing.close(() => resolve()));
   }
 

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -431,7 +431,22 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   let remoteReconcile: Promise<void> = Promise.resolve();
   let remoteLastError: string | null = null;
   let boundPort: number | null = null;
-  const access = createAccessRegistry();
+  /**
+   * 만료도 회수와 같은 신호를 낸다. prune은 다른 레지스트리 호출 안에서 도는 일이 많아
+   * 브로드캐스트를 그 자리에서 부르면 listSessions -> prune으로 되돌아온다. 다음 틱으로
+   * 미뤄 재진입을 끊는다.
+   */
+  let controlPruneNotifyQueued = false;
+  const access = createAccessRegistry({
+    onSessionsPruned: () => {
+      if (controlPruneNotifyQueued) return;
+      controlPruneNotifyQueued = true;
+      queueMicrotask(() => {
+        controlPruneNotifyQueued = false;
+        broadcastControlChanged();
+      });
+    },
+  });
   const remoteIdentityStore = createRemoteIdentityStore(durablePaths.dir);
   const remoteHostStore = createRemoteHostStore(durablePaths.dir);
   const pluginOperationTypes = new Set<string>();
@@ -576,6 +591,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
       validateHost: isRequestHostAllowed,
       isTerminalAuthorized,
       isLockAuthorized,
+      resolveTerminalSocketRole,
     },
     lifecycle: {
       registerCleanup: (cleanup) => {
@@ -1066,6 +1082,9 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     }
     const handle = decodeHandle(rawHandle);
     if (!access.revokeSessionByHandle(handle)) {
+      // 이미 만료된 보유자를 향한 회수다. 404로만 끝내면 화면은 유령 보유자를 계속 띄운 채
+      // 남으므로, 사라졌다는 사실을 여기서 알려 스스로 정리되게 한다.
+      broadcastControlChanged();
       writeJson(res, 404, { error: "session_not_found" });
       return;
     }
@@ -1224,6 +1243,21 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
    */
   function isAccessAdminAuthorized(req: http.IncomingMessage): boolean {
     return isLoopbackListener(req) && (isLockAuthorized(req) || isExactConsoleOrigin(req));
+  }
+
+  /**
+   * 터미널 소켓의 등급. 제어를 쥔 원격이 있는 동안 이 기계 앞에서 열리는 터미널은 관전이다.
+   *
+   * 클라이언트가 스스로 정하게 두면 새로고침 한 번이 제어를 되가져간다 — 새 연결은 언제나
+   * control로 시작하고 attach는 앞의 소켓을 밀어내므로, 원격은 말없이 관전자로 내려가고
+   * 화면은 여전히 그 기기가 몰고 있다고 말한다. 판정을 서버에 두면 그 경합 자체가 없다.
+   *
+   * 원격 쪽 요청은 그대로 control이다. full 세션은 하나뿐이고 monitoring은 애초에 업그레이드에
+   * 닿지 못하므로, 원격에서 오는 티켓 요청의 주인은 지금 제어를 쥔 그 기기뿐이다.
+   */
+  function resolveTerminalSocketRole(req: http.IncomingMessage): "control" | "viewer" {
+    if (!isLoopbackListener(req)) return "control";
+    return access.hasSession("remote", "full") ? "viewer" : "control";
   }
 
   async function handleRemoteHosts(req: http.IncomingMessage, res: http.ServerResponse, pathname: string): Promise<boolean> {
@@ -2055,7 +2089,29 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     }
   }
 
+  /**
+   * 만료를 알아채는 시계. prune은 누가 레지스트리를 건드릴 때만 도는데, 유휴로 만료되는
+   * 세션은 정의상 아무도 건드리지 않는다 — 쓸어 주는 쪽이 없으면 커튼이 사라진 기기를
+   * 몇 시간이고 띄운 채 남는다. 원격 리스너가 열려 있는 동안에만 돈다.
+   */
+  const CONTROL_EXPIRY_SWEEP_MS = 60_000;
+  let controlExpirySweep: ReturnType<typeof setInterval> | null = null;
+
+  function startControlExpirySweep(): void {
+    if (controlExpirySweep !== null) return;
+    controlExpirySweep = setInterval(() => access.prune(), CONTROL_EXPIRY_SWEEP_MS);
+    // 이 타이머가 프로세스를 붙잡아 두지 않게 한다.
+    controlExpirySweep.unref();
+  }
+
+  function stopControlExpirySweep(): void {
+    if (controlExpirySweep === null) return;
+    clearInterval(controlExpirySweep);
+    controlExpirySweep = null;
+  }
+
   async function stopRemoteAccess(): Promise<void> {
+    stopControlExpirySweep();
     const closing = remoteServer;
     remoteServer = null;
     remoteFingerprint = null;
@@ -2108,6 +2164,7 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
     listeners = [...listeners, listener];
     remoteFingerprint = identity.fingerprint;
     remoteServer = started.server;
+    startControlExpirySweep();
   }
 
   function listenOnce(portToBind: number, statePatch: Omit<ConsolePortRuntimeState, "effectivePort">): Promise<ConsolePortListenResult> {

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -11,7 +11,7 @@ import { createWikiWorkspaceResolver } from "@dotobokuri/fleet-wiki";
 import { readLaunchVariantGroups } from "@fleet-console/sdk/operations/launch-variants";
 
 import { buildApiCatalog, type ApiCatalogEntry } from "./api-catalog.js";
-import { CONTROL_CHANGED_EVENT, CONTROL_RECLAIMED_EVENT, controlChangedSnapshot, controlReclaimedSnapshot, type ControlHolderSnapshot } from "./access-control-contract.js";
+import { CONTROL_CHANGED_EVENT, CONTROL_HOLDER_EVENT_CHANNEL, CONTROL_RECLAIMED_EVENT, controlChangedSnapshot, controlReclaimedSnapshot, type ControlHolderSnapshot } from "./access-control-contract.js";
 import { createAccessRegistry, createLoopbackListenerIdentity, formatSessionCookie, readSessionCookie, resolveListenerIdentity, type AccessAudience, type AccessClass, type ListenerIdentity } from "./auth.js";
 import { listRemoteInterfaces } from "./remote-interfaces.js";
 import type { ConsoleEnvironmentDiagnostics, ConsoleHealth, ConsoleObserverStatus, ConsoleTheaterFolderListResponse, ConsoleTheaterInfo, ConsoleUpdateApplyAcceptedResponse, ConsoleUpdateApplyError } from "./console-contract-types.js";
@@ -1879,6 +1879,13 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
 
   /** 보유자 변화는 이 기계 앞에 앉은 사람에게만 간다. 원격은 다른 세션의 존재를 알 이유가 없다. */
   function broadcastControlChanged(): void {
+    /**
+     * 플러그인 쪽이 먼저다. 이미 열려 있는 터미널 소켓은 티켓 발급 시점의 등급을 그대로
+     * 들고 있으므로, 화면이 새 사실을 그리기 전에 전송이 그 사실에 맞춰져야 한다.
+     *
+     * 구독자가 없어도 보낸다 — 이 신호의 수신자는 브라우저가 아니라 서버 안의 플러그인이다.
+     */
+    publishPluginEvent(CONTROL_HOLDER_EVENT_CHANNEL, { holder: currentControlHolder() });
     if (operationSseSubscribers.size === 0) return;
     const data = encodeSseData(CONTROL_CHANGED_EVENT, controlChangedSnapshot(currentControlHolder()));
     for (const subscriber of operationSseSubscribers) {

--- a/runtime/fleet-console/core/host/server.ts
+++ b/runtime/fleet-console/core/host/server.ts
@@ -437,6 +437,8 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
    * 미뤄 재진입을 끊는다.
    */
   let controlPruneNotifyQueued = false;
+  /** 마지막으로 알린 보유자의 공개 이름. 바뀌지 않은 사실을 신호로 내보내지 않기 위한 기준이다. */
+  let lastPublishedControlHolder: string | null = null;
   const access = createAccessRegistry({
     onSessionsPruned: () => {
       if (controlPruneNotifyQueued) return;
@@ -1880,14 +1882,24 @@ export function createConsoleServer(deps: ConsoleServerDeps = {}): ConsoleServer
   /** 보유자 변화는 이 기계 앞에 앉은 사람에게만 간다. 원격은 다른 세션의 존재를 알 이유가 없다. */
   function broadcastControlChanged(): void {
     /**
+     * 실제로 보유자가 바뀐 경우에만 알린다.
+     *
+     * 이 함수는 원격 세션이 사라지는 모든 자리에서 불리는데, 그중에는 제어를 쥔 적 없는
+     * monitoring 세션의 만료·회수도 있다. 그때까지 신호로 세면 터미널이 통째로 끊겼다
+     * 다시 붙으며 scrollback을 재생한다 — 아무것도 바뀌지 않았는데 화면이 깜빡인다.
+     */
+    const holder = currentControlHolder();
+    if (holder?.handle === lastPublishedControlHolder) return;
+    lastPublishedControlHolder = holder?.handle ?? null;
+    /**
      * 플러그인 쪽이 먼저다. 이미 열려 있는 터미널 소켓은 티켓 발급 시점의 등급을 그대로
      * 들고 있으므로, 화면이 새 사실을 그리기 전에 전송이 그 사실에 맞춰져야 한다.
      *
      * 구독자가 없어도 보낸다 — 이 신호의 수신자는 브라우저가 아니라 서버 안의 플러그인이다.
      */
-    publishPluginEvent(CONTROL_HOLDER_EVENT_CHANNEL, { holder: currentControlHolder() });
+    publishPluginEvent(CONTROL_HOLDER_EVENT_CHANNEL, { holder });
     if (operationSseSubscribers.size === 0) return;
-    const data = encodeSseData(CONTROL_CHANGED_EVENT, controlChangedSnapshot(currentControlHolder()));
+    const data = encodeSseData(CONTROL_CHANGED_EVENT, controlChangedSnapshot(holder));
     for (const subscriber of operationSseSubscribers) {
       if (subscriber.audience !== "local") continue;
       subscriber.res.write(data);

--- a/runtime/fleet-console/sdk/plugin/types.ts
+++ b/runtime/fleet-console/sdk/plugin/types.ts
@@ -294,6 +294,15 @@ export interface FleetPluginSecurityHost {
   validateHost(req: http.IncomingMessage): boolean;
   isTerminalAuthorized(req: http.IncomingMessage): boolean;
   isLockAuthorized(req: http.IncomingMessage): boolean;
+  /**
+   * 이 요청이 열 수 있는 소켓의 등급. 제어를 쥔 원격이 있는 동안 이 기계 앞의 새 터미널은
+   * 관전으로만 열린다 — 새로고침이나 패널 재마운트가 조용히 제어를 되가져가면 화면은
+   * 여전히 그 기기가 몰고 있다고 말하는데 실제 소유권은 넘어와 버린다.
+   *
+   * 플러그인이 스스로 판정할 수 없는 값이다. 어느 리스너로 들어왔는지도, 지금 제어를 쥔
+   * 세션이 있는지도 Console만 안다.
+   */
+  resolveTerminalSocketRole(req: http.IncomingMessage): "control" | "viewer";
 }
 
 export interface FleetPluginLifecycleHost {

--- a/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
+++ b/runtime/fleet-console/tests/canvas-minimap-formation.test.ts
@@ -534,6 +534,8 @@ const PEER_OPERATION: OperationNode = {
 const CANVAS_STATE: ConsoleState = {
   connection: "connecting",
   connectionLostAt: null,
+  controlHolder: null,
+  controlCurtainDismissed: false,
   consoleName: "",
   channel: "unknown",
   activeTheme: "maritime",

--- a/runtime/fleet-console/tests/control-handover-client.test.tsx
+++ b/runtime/fleet-console/tests/control-handover-client.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { act, createElement, Fragment } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ControlBar } from "../core/client/src/components/control-bar.js";
+import { ControlCurtain } from "../core/client/src/components/control-curtain.js";
+import { applyControlHolder, dismissControlCurtain, getState, setState } from "../core/client/src/store.js";
+import type { ControlHolder } from "../core/client/src/types.js";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+const holder: ControlHolder = { handle: "remote-a", device: "Kitchen iPad", openedAt: Date.now() - 60_000 };
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  setState({ controlHolder: null, controlCurtainDismissed: false });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  setState({ controlHolder: null, controlCurtainDismissed: false });
+});
+
+describe("remote control handover client", () => {
+  it("moves a dismissed holder from the curtain to the persistent bar", () => {
+    applyControlHolder(holder);
+    renderControlSurfaces();
+
+    expect(document.querySelector(".control-curtain-card")?.textContent).toContain("Kitchen iPad has control");
+    expect(document.querySelector(".control-bar")).toBeNull();
+
+    const keepWatching = Array.from(document.querySelectorAll<HTMLButtonElement>("button"))
+      .find((button) => button.textContent === "Keep watching");
+    act(() => keepWatching?.click());
+
+    expect(document.querySelector(".control-curtain")).toBeNull();
+    expect(document.querySelector(".control-bar")?.textContent).toContain("Kitchen iPad has control");
+  });
+
+  it("raises a fresh curtain only when the holder handle changes", () => {
+    applyControlHolder(holder);
+    dismissControlCurtain();
+
+    applyControlHolder({ ...holder, device: "Renamed iPad", openedAt: holder.openedAt + 1 });
+    expect(getState().controlCurtainDismissed).toBe(true);
+
+    applyControlHolder({ ...holder, handle: "remote-b" });
+    expect(getState().controlCurtainDismissed).toBe(false);
+
+    applyControlHolder(null);
+    expect(getState().controlHolder).toBeNull();
+    expect(getState().controlCurtainDismissed).toBe(false);
+  });
+
+  it("makes the console shell inert while the curtain is open and restores it on unmount", () => {
+    applyControlHolder(holder);
+    renderControlSurfaces();
+    const shell = document.querySelector<HTMLElement>(".console-shell")!;
+
+    expect(shell.inert).toBe(true);
+    act(() => dismissControlCurtain());
+    expect(shell.inert).toBe(false);
+  });
+});
+
+function renderControlSurfaces(): void {
+  act(() => root?.render(createElement(
+    "div",
+    { className: "console-shell" },
+    createElement(Fragment, null, createElement(ControlBar), createElement(ControlCurtain)),
+  )));
+}

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -887,6 +887,8 @@ describe("Instrument core design contract", () => {
     const componentsPopupSelectors = [
       ".whatsnew-card",
       ".commissioning-card",
+      ".control-curtain-card",
+      ".control-reclaimed-card",
       ".directory-browser-card",
       ".codex-reading-sheet",
       ".app-toast",

--- a/runtime/fleet-console/tests/notification-reduce.test.ts
+++ b/runtime/fleet-console/tests/notification-reduce.test.ts
@@ -76,6 +76,8 @@ function makeConsoleSnap(patch: Partial<ConsoleState> = {}): ConsoleState {
     operationNotifications: {},
     notificationPreferences: { globalMute: false, dnd: false, mutedTheaterIds: {} },
     ...patch,
+    controlHolder: patch.controlHolder ?? null,
+    controlCurtainDismissed: patch.controlCurtainDismissed ?? false,
     activeOperationAcknowledged: patch.activeOperationAcknowledged ?? true,
     codexReader: patch.codexReader ?? null,
     codexReaderExpanded: patch.codexReaderExpanded ?? false,

--- a/runtime/fleet-console/tests/operation-search.test.ts
+++ b/runtime/fleet-console/tests/operation-search.test.ts
@@ -30,6 +30,8 @@ function makeState(
   return {
     connection: "connecting",
     connectionLostAt: null,
+    controlHolder: null,
+    controlCurtainDismissed: false,
     consoleName: "",
     channel: "unknown",
     activeTheme: "maritime",

--- a/runtime/fleet-console/tests/operations-sse.test.ts
+++ b/runtime/fleet-console/tests/operations-sse.test.ts
@@ -17,13 +17,17 @@ vi.mock("../core/client/src/api.js", () => ({
   fetchOperations: mocks.fetchOperations,
 }));
 
-vi.mock("../core/client/src/store.js", () => ({
-  applyObserverStatus: mocks.applyObserverStatus,
-  applyOperationUpdate: mocks.applyOperationUpdate,
-  getState: mocks.getState,
-  hydrateOperations: mocks.hydrateOperations,
-  setConnectionState: mocks.setConnectionState,
-}));
+vi.mock("../core/client/src/store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../core/client/src/store.js")>();
+  return {
+    ...actual,
+    applyObserverStatus: mocks.applyObserverStatus,
+    applyOperationUpdate: mocks.applyOperationUpdate,
+    getState: mocks.getState,
+    hydrateOperations: mocks.hydrateOperations,
+    setConnectionState: mocks.setConnectionState,
+  };
+});
 
 vi.mock("../core/client/src/desktop-fullscreen.js", () => ({
   applyDesktopFullscreenSnapshot: mocks.applyDesktopFullscreenSnapshot,
@@ -169,6 +173,7 @@ describe("operations SSE update availability", () => {
     staleSource.emit("operation:changed", JSON.stringify({ operation: { id: "stale" } }));
     staleSource.emit("update:available");
     staleSource.emit("desktop:fullscreen", JSON.stringify({ fullscreen: true }));
+    staleSource.emit("control:changed", JSON.stringify({ holder: { handle: "stale", device: null, openedAt: 1 } }));
     staleSource.open();
     staleSource.onerror?.();
     await vi.advanceTimersByTimeAsync(30_000);
@@ -220,6 +225,31 @@ describe("operations SSE update availability", () => {
     TestEventSource.instances[0]?.onerror?.();
     expect(mocks.resetDesktopFullscreenSnapshot).toHaveBeenCalledTimes(2);
     expect(mocks.setConnectionState).toHaveBeenCalledWith("offline");
+  });
+
+  it("strictly replaces control holder snapshots and preserves them across SSE loss", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("EventSource", TestEventSource);
+    mocks.getState.mockReturnValue({ activeTheaterId: null });
+    const actualState = await vi.importActual<typeof import("../core/client/src/store.js")>("../core/client/src/store.js");
+    actualState.setState({ controlHolder: null, controlCurtainDismissed: false });
+
+    connectOperationsSse();
+    const holder = { handle: "remote-a", device: "Kitchen iPad", openedAt: 42 };
+    TestEventSource.instances[0]?.emit("control:changed", JSON.stringify({ holder }));
+    expect(actualState.getState().controlHolder).toEqual(holder);
+
+    TestEventSource.instances[0]?.emit("control:changed", JSON.stringify({ holder: { ...holder, extra: true } }));
+    TestEventSource.instances[0]?.emit("control:changed", "{not-json");
+    expect(actualState.getState().controlHolder).toEqual(holder);
+
+    TestEventSource.instances[0]?.emit("control:changed", JSON.stringify({ holder: null }));
+    expect(actualState.getState().controlHolder).toBeNull();
+    TestEventSource.instances[0]?.emit("control:changed", JSON.stringify({ holder }));
+
+    TestEventSource.instances[0]?.onerror?.();
+    expect(actualState.getState().controlHolder).toEqual(holder);
+    actualState.setState({ controlHolder: null, controlCurtainDismissed: false });
   });
 
   it("marks the retry attempt connecting while preserving the existing exponential retry path", async () => {

--- a/runtime/fleet-console/tests/palette-commands.test.ts
+++ b/runtime/fleet-console/tests/palette-commands.test.ts
@@ -87,6 +87,8 @@ function makeState(patch: Partial<ConsoleState> = {}): ConsoleState {
     codexReader: null,
     codexReaderExpanded: false,
     ...patch,
+    controlHolder: patch.controlHolder ?? null,
+    controlCurtainDismissed: patch.controlCurtainDismissed ?? false,
     activeOperationAcknowledged: patch.activeOperationAcknowledged ?? true,
   };
 }

--- a/runtime/fleet-console/tests/plugin-host.test.ts
+++ b/runtime/fleet-console/tests/plugin-host.test.ts
@@ -49,7 +49,7 @@ const noopHostCapabilities: FleetPluginHostCapabilities = {
   security: {
     validateHost: () => true,
     isTerminalAuthorized: () => true,
-    isLockAuthorized: () => true,
+    isLockAuthorized: () => true, resolveTerminalSocketRole: () => "control" as const,
   },
   lifecycle: {
     registerCleanup: () => () => {},

--- a/runtime/fleet-console/tests/remote-access-listener.test.ts
+++ b/runtime/fleet-console/tests/remote-access-listener.test.ts
@@ -443,6 +443,28 @@ describe.skipIf(REMOTE_HOST === null)("remote access listener", () => {
     remote.close();
   });
 
+  /**
+   * 만료는 조용하다. 알리지 않으면 화면은 이미 없는 보유자를 계속 띄우고, 그 보유자를 향한
+   * 회수는 404로 끝나 화면이 스스로 정리되지도 못한다.
+   */
+  it("clears a stale holder when the reclaim finds the session already gone", async () => {
+    const fixture = await startFixture({ remote: true });
+    const local = await openLoopbackEvents(fixture);
+    await joinAs(fixture, "full", "Ghost");
+    const held = await local.waitFor("control:changed", (data) => data.holder !== null);
+
+    await expect(revoke(fixture, `access-sessions/${held.holder.handle}`)).resolves.toBe(204);
+    await local.waitFor("control:changed", (data) => data.holder === null);
+
+    // 이미 사라진 세션을 다시 회수해도 화면이 정리되는 신호는 한 번 더 나간다.
+    const seenBefore = local.seen("control:changed");
+    await expect(revoke(fixture, `access-sessions/${held.holder.handle}`)).resolves.toBe(404);
+    await vi.waitFor(() => expect(local.seen("control:changed")).toBeGreaterThan(seenBefore));
+    expect(await local.waitFor("control:changed", (data) => data.holder === null)).toEqual({ holder: null });
+
+    local.close();
+  });
+
   /** monitoring은 제어를 쥐지 않으므로 상한과 무관하게 full 옆에 함께 붙는다. */
   it("lets a monitoring session join while a full session holds control", async () => {
     const fixture = await startFixture({ remote: true });

--- a/runtime/fleet-console/tests/remote-access-listener.test.ts
+++ b/runtime/fleet-console/tests/remote-access-listener.test.ts
@@ -369,6 +369,60 @@ describe.skipIf(REMOTE_HOST === null)("remote access listener", () => {
 
     await expect(fetch(`${fixture.loopbackEndpoint}api/v1/theaters`).then((r) => r.status)).resolves.toBe(200);
   });
+
+  /**
+   * 초대받은 손님은 초대장을 관리하지 못한다. 이 목록에는 인증서 지문, 다른 기기의 이름,
+   * 그리고 이 기계가 가진 모든 주소가 실려 있고, 이 쓰기들은 손님이 자기보다 오래 사는
+   * 초대장을 새로 찍거나 남의 자리를 끊거나 호스트 신원을 통째로 갈아 끼우게 한다.
+   */
+  it("keeps remote access administration on the loopback side", async () => {
+    const fixture = await startFixture({ remote: true });
+    const cookie = await joinAs(fixture, "full", "guest");
+    const remoteOrigin = `https://${BIND_HOST}:${fixture.remotePort}`;
+    const asRemote = { origin: remoteOrigin };
+
+    await expect(remoteRequest(fixture, "GET", "/api/v1/access-links", undefined, cookie, asRemote)).resolves.toMatchObject({ status: 401 });
+    await expect(remoteRequest(fixture, "POST", "/api/v1/access-links", undefined, cookie, asRemote)).resolves.toMatchObject({ status: 401 });
+    await expect(remoteRequest(fixture, "DELETE", "/api/v1/access-links/whatever", undefined, cookie, asRemote)).resolves.toMatchObject({ status: 401 });
+    await expect(remoteRequest(fixture, "POST", "/api/v1/remote-identity/rotations", undefined, cookie, asRemote)).resolves.toMatchObject({ status: 401 });
+
+    // 그 손님이 자기 handle을 알아도 끊는 일은 이 기계 앞에서만 일어난다.
+    const handle = (await readRemoteStatus(fixture)).sessions[0]!.handle;
+    await expect(remoteRequest(fixture, "DELETE", `/api/v1/access-sessions/${handle}`, undefined, cookie, asRemote)).resolves.toMatchObject({ status: 401 });
+    expect((await readRemoteStatus(fixture)).sessions).toHaveLength(1);
+  });
+
+  /**
+   * 제어를 쥔 원격은 하나다. 둘째를 받으면 커튼이 "누가" 몰고 있는지 하나로 말하지 못하고
+   * 회수 버튼의 대상도 갈라진다. 거절은 자격을 태우기 전에 일어나야 한다 — 뒤에서 막으면
+   * 1회용 링크만 소멸하고 아무도 붙지 못한다.
+   */
+  it("admits one full remote session and leaves the refused link usable", async () => {
+    const fixture = await startFixture({ remote: true });
+    await joinAs(fixture, "full", "first");
+    const secondLink = await createLink(fixture);
+
+    const refused = await remoteRequest(fixture, "POST", "/api/v1/join", JSON.stringify({ token: grantTokenOf(secondLink) }));
+    expect(refused.status).toBe(409);
+
+    const held = await readRemoteStatus(fixture);
+    expect(held.sessions).toHaveLength(1);
+    expect(held.links).toHaveLength(1);
+
+    // 보유자가 물러나면 같은 링크가 그대로 통한다 — 태워 버렸다면 여기서 401이 난다.
+    await expect(revoke(fixture, `access-sessions/${held.sessions[0]!.handle}`)).resolves.toBe(204);
+    await expect(remoteRequest(fixture, "POST", "/api/v1/join", JSON.stringify({ token: grantTokenOf(secondLink) }))).resolves.toMatchObject({ status: 204 });
+  });
+
+  /** monitoring은 제어를 쥐지 않으므로 상한과 무관하게 full 옆에 함께 붙는다. */
+  it("lets a monitoring session join while a full session holds control", async () => {
+    const fixture = await startFixture({ remote: true });
+    await joinAs(fixture, "full", "holder");
+    await joinAs(fixture, "monitoring", "watcher");
+
+    const status = await readRemoteStatus(fixture);
+    expect(status.sessions.map((entry) => entry.access).sort()).toEqual(["full", "monitoring"]);
+  });
 });
 
 interface RemoteAccessStatus {

--- a/runtime/fleet-console/tests/remote-access-listener.test.ts
+++ b/runtime/fleet-console/tests/remote-access-listener.test.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
+import http from "node:http";
 import https from "node:https";
 import os from "node:os";
 import path from "node:path";
@@ -414,6 +415,34 @@ describe.skipIf(REMOTE_HOST === null)("remote access listener", () => {
     await expect(remoteRequest(fixture, "POST", "/api/v1/join", JSON.stringify({ token: grantTokenOf(secondLink) }))).resolves.toMatchObject({ status: 204 });
   });
 
+  /**
+   * 커튼이 뜨고 걷히는 근거 전체. 보유자 정보는 이 기계 앞 화면에만 가고, 회수 통지는 끊긴
+   * 세션 하나에만 간다 — 두 수신자가 갈리지 않으면 원격 화면에 다른 기기의 이름이 실린다.
+   */
+  it("tells the local console who holds control, and tells only the evicted session it was reclaimed", async () => {
+    const fixture = await startFixture({ remote: true });
+    const local = await openLoopbackEvents(fixture);
+
+    const cookie = await joinAs(fixture, "full", "Kitchen iPad");
+    const remote = await openRemoteEvents(fixture, cookie);
+
+    const held = await local.waitFor("control:changed", (data) => data.holder !== null);
+    expect(held.holder).toMatchObject({ device: "Kitchen iPad" });
+    expect(typeof held.holder.handle).toBe("string");
+
+    await expect(revoke(fixture, `access-sessions/${held.holder.handle}`)).resolves.toBe(204);
+
+    // 끊긴 쪽은 자기 회수를 듣는다.
+    expect(await remote.waitFor("control:reclaimed", () => true)).toEqual({ reason: "reclaimed" });
+    // 이 기계 앞 화면은 보유자가 사라진 것을 듣는다.
+    expect(await local.waitFor("control:changed", (data) => data.holder === null)).toEqual({ holder: null });
+    // 원격은 보유자 정보를 한 번도 받지 않는다.
+    expect(remote.seen("control:changed")).toBe(0);
+
+    local.close();
+    remote.close();
+  });
+
   /** monitoring은 제어를 쥐지 않으므로 상한과 무관하게 full 옆에 함께 붙는다. */
   it("lets a monitoring session join while a full session holds control", async () => {
     const fixture = await startFixture({ remote: true });
@@ -443,6 +472,83 @@ async function joinAs(fixture: Fixture, access: string, device: string): Promise
   const token = grantTokenOf((await response.json() as { link: string }).link);
   const joined = await remoteRequest(fixture, "POST", "/api/v1/join", JSON.stringify({ token, device }));
   return (joined.headers["set-cookie"]?.[0] ?? "").split(";")[0]!;
+}
+
+/**
+ * SSE를 읽는 최소 클라이언트. EventSource가 없는 환경이라 프레임을 직접 가른다 — 스트림은
+ * 끝나지 않으므로 본문을 다 읽고 파싱하는 방식은 쓸 수 없다.
+ */
+interface EventProbe {
+  waitFor(event: string, predicate: (data: any) => boolean, timeoutMs?: number): Promise<any>;
+  seen(event: string): number;
+  close(): void;
+}
+
+function readEventStream(response: import("node:http").IncomingMessage): EventProbe {
+  const received: Array<{ readonly event: string; readonly data: unknown }> = [];
+  const waiters: Array<() => void> = [];
+  let buffer = "";
+  response.setEncoding("utf8");
+  response.on("data", (chunk: string) => {
+    buffer += chunk;
+    let split = buffer.indexOf("\n\n");
+    while (split !== -1) {
+      const frame = buffer.slice(0, split);
+      buffer = buffer.slice(split + 2);
+      const event = /^event: (.+)$/mu.exec(frame)?.[1];
+      const raw = /^data: (.*)$/mu.exec(frame)?.[1];
+      if (event && raw !== undefined) {
+        try {
+          received.push({ event, data: JSON.parse(raw) });
+        } catch {
+          // 프레임이 깨졌으면 그 프레임만 버린다.
+        }
+      }
+      while (waiters.length > 0) waiters.pop()!();
+      split = buffer.indexOf("\n\n");
+    }
+  });
+  return {
+    seen: (event) => received.filter((entry) => entry.event === event).length,
+    async waitFor(event, predicate, timeoutMs = 5_000) {
+      const deadline = Date.now() + timeoutMs;
+      for (;;) {
+        const hit = received.find((entry) => entry.event === event && predicate(entry.data));
+        if (hit) return hit.data;
+        if (Date.now() >= deadline) throw new Error(`timed out waiting for ${event}`);
+        await new Promise<void>((resolve) => {
+          waiters.push(resolve);
+          setTimeout(resolve, 50);
+        });
+      }
+    },
+    close: () => response.destroy(),
+  };
+}
+
+function openLoopbackEvents(fixture: Fixture): Promise<EventProbe> {
+  const url = new URL(`${fixture.loopbackEndpoint}api/v1/operations/events`);
+  return new Promise((resolve, reject) => {
+    const request = http.request({ host: url.hostname, port: Number(url.port), path: url.pathname, method: "GET" }, (response) => resolve(readEventStream(response)));
+    request.on("error", reject);
+    request.end();
+  });
+}
+
+function openRemoteEvents(fixture: Fixture, cookie: string): Promise<EventProbe> {
+  return new Promise((resolve, reject) => {
+    const request = https.request({
+      host: BIND_HOST,
+      port: fixture.remotePort,
+      path: "/api/v1/operations/events",
+      method: "GET",
+      rejectUnauthorized: false,
+      checkServerIdentity: () => undefined,
+      headers: { host: `${BIND_HOST}:${fixture.remotePort}`, cookie },
+    }, (response) => resolve(readEventStream(response)));
+    request.on("error", reject);
+    request.end();
+  });
 }
 
 async function revoke(fixture: Fixture, resource: string): Promise<number> {

--- a/runtime/fleet-console/tests/remote-access-listener.test.ts
+++ b/runtime/fleet-console/tests/remote-access-listener.test.ts
@@ -465,6 +465,33 @@ describe.skipIf(REMOTE_HOST === null)("remote access listener", () => {
     local.close();
   });
 
+  /**
+   * monitoring은 제어를 쥔 적이 없으므로 그 세션이 사라져도 보유자는 그대로다. 그때까지 신호로
+   * 세면 붙어 있던 터미널이 통째로 끊겼다 다시 붙으며 scrollback을 재생한다 — 아무것도 바뀌지
+   * 않았는데 화면이 깜빡인다.
+   */
+  it("stays quiet when a session that never held control goes away", async () => {
+    const fixture = await startFixture({ remote: true });
+    const local = await openLoopbackEvents(fixture);
+    await joinAs(fixture, "full", "holder");
+    const held = await local.waitFor("control:changed", (data) => data.holder !== null);
+    await joinAs(fixture, "monitoring", "watcher");
+
+    const watcher = (await readRemoteStatus(fixture)).sessions.find((entry) => entry.access === "monitoring");
+    const framesBefore = local.seen("control:changed");
+    await expect(revoke(fixture, `access-sessions/${watcher!.handle}`)).resolves.toBe(204);
+
+    // 보유자는 그대로다. 프레임이 늘지 않아야 한다.
+    await expect(readRemoteStatus(fixture).then((status) => status.sessions)).resolves.toHaveLength(1);
+    expect(local.seen("control:changed")).toBe(framesBefore);
+
+    // 진짜 보유자가 나가면 그때는 알린다 — 조용해진 것이지 멎은 것이 아니다.
+    await expect(revoke(fixture, `access-sessions/${held.holder.handle}`)).resolves.toBe(204);
+    expect(await local.waitFor("control:changed", (data) => data.holder === null)).toEqual({ holder: null });
+
+    local.close();
+  });
+
   /** monitoring은 제어를 쥐지 않으므로 상한과 무관하게 full 옆에 함께 붙는다. */
   it("lets a monitoring session join while a full session holds control", async () => {
     const fixture = await startFixture({ remote: true });

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -2393,7 +2393,7 @@ describe("console static and terminal ticket boundary", () => {
     let destroyed = 0;
     const handler = createPluginTerminalUpgradeHandler({
       tickets: { consume: () => null },
-      sessions: { canAttach: () => true, createSession: async () => undefined, attach: async () => undefined, attachViewer: () => false, getSessionMessagePolicy: () => undefined, getSessionRenameCommand: () => undefined, getSessionGoalCommand: () => undefined, getSessionLastActivityAt: () => null, resolveSessionIdentity: async () => null, terminate: () => false, stop: async () => undefined, writeToSession: () => false },
+      sessions: { canAttach: () => true, createSession: async () => undefined, attach: async () => undefined, attachViewer: () => false, renegotiateSockets: () => {}, getSessionMessagePolicy: () => undefined, getSessionRenameCommand: () => undefined, getSessionGoalCommand: () => undefined, getSessionLastActivityAt: () => null, resolveSessionIdentity: async () => null, terminate: () => false, stop: async () => undefined, writeToSession: () => false },
       isAuthorized: () => true,
     });
 
@@ -2424,7 +2424,7 @@ describe("console static and terminal ticket boundary", () => {
           return false;
         },
         createSession: async () => undefined,
-        attach: async () => undefined, attachViewer: () => false,
+        attach: async () => undefined, attachViewer: () => false, renegotiateSockets: () => {},
         getSessionMessagePolicy: () => undefined,
         getSessionGoalCommand: () => undefined,
         getSessionRenameCommand: () => undefined,

--- a/runtime/fleet-console/tests/server.test.ts
+++ b/runtime/fleet-console/tests/server.test.ts
@@ -2393,7 +2393,7 @@ describe("console static and terminal ticket boundary", () => {
     let destroyed = 0;
     const handler = createPluginTerminalUpgradeHandler({
       tickets: { consume: () => null },
-      sessions: { canAttach: () => true, createSession: async () => undefined, attach: async () => undefined, getSessionMessagePolicy: () => undefined, getSessionRenameCommand: () => undefined, getSessionGoalCommand: () => undefined, getSessionLastActivityAt: () => null, resolveSessionIdentity: async () => null, terminate: () => false, stop: async () => undefined, writeToSession: () => false },
+      sessions: { canAttach: () => true, createSession: async () => undefined, attach: async () => undefined, attachViewer: () => false, getSessionMessagePolicy: () => undefined, getSessionRenameCommand: () => undefined, getSessionGoalCommand: () => undefined, getSessionLastActivityAt: () => null, resolveSessionIdentity: async () => null, terminate: () => false, stop: async () => undefined, writeToSession: () => false },
       isAuthorized: () => true,
     });
 
@@ -2424,7 +2424,7 @@ describe("console static and terminal ticket boundary", () => {
           return false;
         },
         createSession: async () => undefined,
-        attach: async () => undefined,
+        attach: async () => undefined, attachViewer: () => false,
         getSessionMessagePolicy: () => undefined,
         getSessionGoalCommand: () => undefined,
         getSessionRenameCommand: () => undefined,

--- a/runtime/fleet-console/tests/session-manager.test.ts
+++ b/runtime/fleet-console/tests/session-manager.test.ts
@@ -289,6 +289,58 @@ describe("terminal session manager", () => {
     expect(viewer.sent).toHaveLength(afterClose);
   });
 
+  /**
+   * 보유자가 바뀌면 이미 붙어 있던 소켓도 등급을 다시 받아야 한다. 티켓 발급 시점의 판정만으로는
+   * 그때 열려 있던 터미널이 옛 등급 그대로 남아, 회수 뒤에도 읽기 전용에 갇힌다.
+   */
+  it("closes every attached socket so a holder change is renegotiated", async () => {
+    const manager = createTerminalSessionManager({
+      launch: async (cwd) => ({ bin: "mock", args: [], cwd: cwd ?? "/", env: {} }),
+      startShell: () => createMockPty(),
+    });
+    const controller = createMockSocket();
+    const viewer = createMockSocket();
+    await manager.attach(controller, { sessionId: "session-a", cwd: "/a" });
+    manager.attachViewer(viewer, "session-a");
+
+    manager.renegotiateSockets();
+
+    // 4000(밀려남)과 갈라야 한다 — 그 코드는 클라이언트를 관전자로 굳히지만, 이쪽은 다시 물어보게 한다.
+    expect(controller.closed).toEqual([{ code: 4002, reason: "terminal_control_changed" }]);
+    expect(viewer.closed).toEqual([{ code: 4002, reason: "terminal_control_changed" }]);
+  });
+
+  /**
+   * 관전자가 남아 있어 grace가 세션을 살려 둔 뒤, 그 마지막 관전자가 나가면 아무도 정리를 다시
+   * 걸어 주지 않는다 — theater-shell PTY가 패널이 모두 닫힌 뒤에도 영원히 남는다.
+   */
+  it("cleans up a theater shell once its last viewer leaves", async () => {
+    vi.useFakeTimers();
+    try {
+      const exits: string[] = [];
+      const manager = createTerminalSessionManager({
+        launch: async (cwd) => ({ bin: "mock", args: [], cwd: cwd ?? "/", env: {} }),
+        startShell: () => createMockPty(),
+        onSessionExit: (sessionId) => { exits.push(sessionId); },
+      });
+      const controller = createMockSocket();
+      const viewer = createMockSocket();
+      await manager.attach(controller, { sessionId: "shell:theater-1", cwd: "/a" });
+      manager.attachViewer(viewer, "shell:theater-1");
+
+      controller.emitClose();
+      await vi.advanceTimersByTimeAsync(5_000);
+      // 보는 사람이 남아 있으므로 아직 정리하지 않는다.
+      expect(exits).toEqual([]);
+
+      viewer.emitClose();
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(exits).toEqual(["shell:theater-1"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps scrollback isolated per session", async () => {
     const ptys = new Map<string, MockPty>();
     const manager = createTerminalSessionManager({

--- a/runtime/fleet-console/tests/session-manager.test.ts
+++ b/runtime/fleet-console/tests/session-manager.test.ts
@@ -228,6 +228,67 @@ describe("terminal session manager", () => {
     expect(secondA.closed).toEqual([]);
   });
 
+  /**
+   * 관전자는 출력만 받는다. 이 테스트가 지키는 것은 "본다"가 아니라 "몰지 않는다"이다 —
+   * 제어 소켓을 밀어내지 않고, PTY에 쓰지 않고, 크기를 바꾸지 않는다.
+   */
+  it("fans terminal output out to viewers without giving them the controls", async () => {
+    let pty: MockPty | null = null;
+    const manager = createTerminalSessionManager({
+      launch: async (cwd) => ({ bin: "mock", args: [], cwd: cwd ?? "/", env: {} }),
+      startShell: () => { pty = createMockPty(); return pty; },
+    });
+    const controller = createMockSocket();
+    const viewer = createMockSocket();
+
+    await manager.attach(controller, { sessionId: "session-a", cwd: "/a" });
+    expect(manager.attachViewer(viewer, "session-a")).toBe(true);
+    const beforeOutput = viewer.sent.length;
+
+    pty!.emitData("hello");
+
+    expect(controller.closed).toEqual([]);
+    expect(viewer.sent.slice(beforeOutput).map((chunk) => chunk.toString("utf8"))).toContain("hello");
+
+    // 관전자가 보낸 것은 어디에도 도달하지 않는다 — message 리스너 자체가 달려 있지 않다.
+    viewer.emitMessage(Buffer.from("rm -rf /", "utf8"), true);
+    viewer.emitMessage(Buffer.from(JSON.stringify({ type: "resize", cols: 1, rows: 1 }), "utf8"), false);
+    expect(pty!.writes).toEqual([]);
+    expect(pty!.resizes.some((size) => size.cols === 1 && size.rows === 1)).toBe(false);
+  });
+
+  /** 볼 대상이 없는 관전은 성립하지 않는다 — 여기서 PTY를 띄우면 관전이 실행이 된다. */
+  it("refuses to open a session for a viewer", () => {
+    const started: MockPty[] = [];
+    const manager = createTerminalSessionManager({
+      launch: async (cwd) => ({ bin: "mock", args: [], cwd: cwd ?? "/", env: {} }),
+      startShell: () => { const pty = createMockPty(); started.push(pty); return pty; },
+    });
+
+    expect(manager.attachViewer(createMockSocket(), "never-started")).toBe(false);
+    expect(started).toHaveLength(0);
+  });
+
+  /** 관전자는 자기가 붙기 전의 화면부터 본다 — 재생 없이는 빈 터미널을 보게 된다. */
+  it("replays scrollback to a viewer and stops sending once it closes", async () => {
+    let pty: MockPty | null = null;
+    const manager = createTerminalSessionManager({
+      launch: async (cwd) => ({ bin: "mock", args: [], cwd: cwd ?? "/", env: {} }),
+      startShell: () => { pty = createMockPty(); return pty; },
+    });
+    await manager.attach(createMockSocket(), { sessionId: "session-a", cwd: "/a" });
+    pty!.emitData("earlier");
+
+    const viewer = createMockSocket();
+    manager.attachViewer(viewer, "session-a");
+    expect(viewer.sent.map((chunk) => chunk.toString("utf8"))).toContain("earlier");
+
+    viewer.emitClose();
+    const afterClose = viewer.sent.length;
+    pty!.emitData("later");
+    expect(viewer.sent).toHaveLength(afterClose);
+  });
+
   it("keeps scrollback isolated per session", async () => {
     const ptys = new Map<string, MockPty>();
     const manager = createTerminalSessionManager({

--- a/runtime/fleet-console/tests/triage-stage-companion.test.ts
+++ b/runtime/fleet-console/tests/triage-stage-companion.test.ts
@@ -107,6 +107,8 @@ describe("Triage stage companion synchronization", () => {
 const STATE: ConsoleState = {
   connection: "connecting",
   connectionLostAt: null,
+  controlHolder: null,
+  controlCurtainDismissed: false,
   consoleName: "",
   channel: "unknown",
   activeTheme: "maritime",

--- a/runtime/fleet-desktop/src/remote-access.ts
+++ b/runtime/fleet-desktop/src/remote-access.ts
@@ -122,6 +122,9 @@ export async function joinRemoteConsole(sessionFetch: SessionFetch, joinUrl: str
     });
     if (response.status === 401) throw new Error("remote_link_rejected");
     if (response.status === 403) throw new Error("remote_link_host_mismatch");
+    // 409는 자격 문제가 아니다 — 그 콘솔의 제어를 이미 다른 기기가 쥐고 있다. 다른 4xx와
+    // 뭉개면 "링크를 새로 받아라"로 안내되고, 새 링크로도 같은 거절이 돌아온다.
+    if (response.status === 409) throw new Error("remote_link_control_held");
     if (!response.ok) throw new Error("remote_link_unverified");
   } catch (error) {
     if (error instanceof Error && error.message.startsWith("remote_link_")) throw error;

--- a/runtime/fleet-desktop/src/remote-bridge.ts
+++ b/runtime/fleet-desktop/src/remote-bridge.ts
@@ -249,6 +249,9 @@ function describe(code: string): string {
     case "remote_link_fingerprint_mismatch":
     case "remote_host_fingerprint_mismatch": return "That address answered with a different certificate. Ask for a fresh access link.";
     case "remote_link_rejected": return "That access link was already used, or it expired. Ask for a fresh one.";
+    // 자격이 나빠서가 아니라 자리가 차 있어서 거절된 경우다. "다시 받아라"로 안내하면 링크를
+    // 새로 받아도 같은 거절이 돌아온다 — 기다리거나 물러나 달라고 말해야 한다.
+    case "remote_link_control_held": return "Another device already has control of that console. Ask them to hand it back, then try again.";
     case "remote_host_session_expired": return "That console no longer recognises this device. Ask for a fresh access link.";
     case "remote_link_host_mismatch": return "That console refused the link as meant for a different address.";
     case "remote_host_is_self": return "That link points back at this console.";

--- a/runtime/fleet-plugins/terminal/client/i18n/index.ts
+++ b/runtime/fleet-plugins/terminal/client/i18n/index.ts
@@ -298,6 +298,7 @@ export const terminalEn = {
   "terminal.analysis.error.requestFailed": "Analysis request failed.",
   "terminal.viewer.readOnly": "Another device is using this terminal — read-only",
   "terminal.viewer.takeBack": "Take back control",
+  "terminal.viewer.remoteControlled": "A remote device has control — read-only",
 } as const;
 
 export const terminalKo: Record<keyof typeof terminalEn, string> = {
@@ -594,6 +595,7 @@ export const terminalKo: Record<keyof typeof terminalEn, string> = {
   "terminal.analysis.error.requestFailed": "분석 요청이 실패했습니다.",
   "terminal.viewer.readOnly": "다른 기기가 이 터미널을 쓰고 있습니다 — 읽기 전용",
   "terminal.viewer.takeBack": "제어권 가져오기",
+  "terminal.viewer.remoteControlled": "원격 기기가 제어 중입니다 — 읽기 전용",
 };
 
 export const TERMINAL_MESSAGES = { en: terminalEn, ko: terminalKo } as const;

--- a/runtime/fleet-plugins/terminal/client/i18n/index.ts
+++ b/runtime/fleet-plugins/terminal/client/i18n/index.ts
@@ -296,6 +296,8 @@ export const terminalEn = {
   "terminal.settings.missing": "Missing",
   "terminal.analysis.error.sessionNotFound": "Analysis session was not found.",
   "terminal.analysis.error.requestFailed": "Analysis request failed.",
+  "terminal.viewer.readOnly": "Another device is using this terminal — read-only",
+  "terminal.viewer.takeBack": "Take back control",
 } as const;
 
 export const terminalKo: Record<keyof typeof terminalEn, string> = {
@@ -590,6 +592,8 @@ export const terminalKo: Record<keyof typeof terminalEn, string> = {
   "terminal.settings.missing": "없음",
   "terminal.analysis.error.sessionNotFound": "분석 세션을 찾을 수 없습니다.",
   "terminal.analysis.error.requestFailed": "분석 요청이 실패했습니다.",
+  "terminal.viewer.readOnly": "다른 기기가 이 터미널을 쓰고 있습니다 — 읽기 전용",
+  "terminal.viewer.takeBack": "제어권 가져오기",
 };
 
 export const TERMINAL_MESSAGES = { en: terminalEn, ko: terminalKo } as const;

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-connection.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-connection.ts
@@ -20,6 +20,11 @@ export interface TerminalConnectionOptions {
   readonly colorScheme?: "light" | "dark";
   readonly onStatus?: (status: TerminalConnectionStatus, message?: string) => void;
   /**
+   * 제어를 되찾을 수 있는 상태인지 알린다. 원격이 제어를 쥐고 있어 서버가 관전으로 내려보낸
+   * 경우에는 되찾기가 성립하지 않는다 — 그 자리는 Console의 회수 버튼이 맡는다.
+   */
+  readonly onControlLockChange?: (lock: TerminalControlLock) => void;
+  /**
    * 서버 보유 scrollback을 재생하는 구간의 시작(true)과 끝(false)을 알린다. 재생 청크는 과거에 이미
    * 흘러간 바이트라, 그 안의 부수효과 시퀀스를 지금 다시 실행하면 안 되는 소비자를 위한 신호다.
    */
@@ -40,6 +45,9 @@ export interface TerminalConnection {
   readonly takeBackControl: () => void;
   readonly dispose: () => void;
 }
+
+/** 관전 중인 화면이 되찾기를 제안해도 되는지. 서버가 등급을 잠갔으면 제안할 수 없다. */
+export type TerminalControlLock = "open" | "locked";
 
 export interface WebSocketLike {
   binaryType: BinaryType;
@@ -96,8 +104,12 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
     while (!abort.signal.aborted) {
       options.onStatus?.("connecting");
       try {
-        const { ticket } = await requestTerminalTicket(options.ticketPath, options.operationId, abort.signal, options.colorScheme, role);
+        const requested = role;
+        const { ticket, role: granted } = await requestTerminalTicket(options.ticketPath, options.operationId, abort.signal, options.colorScheme, requested);
         if (abort.signal.aborted) return;
+        // 요청한 등급과 받은 등급이 갈리면 서버가 내려보낸 것이다 — 그 상태에서는 되찾기를 제안하지 않는다.
+        role = granted;
+        options.onControlLockChange?.(requested === "control" && granted === "viewer" ? "locked" : "open");
         await attachSocket(buildTerminalWsUrl(ticket, options.location, options.wsPath), options);
         reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
       } catch (err) {
@@ -208,7 +220,7 @@ export function buildTerminalWsUrl(ticket: string, targetLocation: Pick<Location
   return `${protocol}://${targetLocation.host}${pathname}?ticket=${encodeURIComponent(ticket)}`;
 }
 
-async function requestTerminalTicket(ticketPath: string, operationId: string, signal: AbortSignal, colorScheme?: "light" | "dark", role?: TerminalSocketRole): Promise<{ readonly ticket: string; readonly ttlMs: number }> {
+async function requestTerminalTicket(ticketPath: string, operationId: string, signal: AbortSignal, colorScheme?: "light" | "dark", role?: TerminalSocketRole): Promise<{ readonly ticket: string; readonly ttlMs: number; readonly role: TerminalSocketRole }> {
   const response = await fetch(ticketPath, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -217,11 +229,12 @@ async function requestTerminalTicket(ticketPath: string, operationId: string, si
     signal,
   });
   if (!response.ok) throw new Error(`Terminal ticket request failed: ${response.status}`);
-  const payload = await response.json() as { readonly ticket?: unknown; readonly ttlMs?: unknown };
+  const payload = await response.json() as { readonly ticket?: unknown; readonly ttlMs?: unknown; readonly role?: unknown };
   if (typeof payload.ticket !== "string" || typeof payload.ttlMs !== "number") {
     throw new Error("Invalid terminal ticket response");
   }
-  return { ticket: payload.ticket, ttlMs: payload.ttlMs };
+  // 옛 서버는 등급을 싣지 않는다. 그때는 요청한 대로 받은 것으로 본다.
+  return { ticket: payload.ticket, ttlMs: payload.ttlMs, role: payload.role === "viewer" ? "viewer" : (role ?? "control") };
 }
 
 function defaultWebSocketFactory(url: string): WebSocketLike {

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-connection.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-connection.ts
@@ -72,6 +72,8 @@ const OPEN_READY_STATE = 1;
 const TERMINAL_UNAVAILABLE_CLOSE_CODE = 1013;
 const TERMINAL_REPLACED_CLOSE_CODE = 4000;
 const TERMINAL_CLOSED_CLOSE_CODE = 4001;
+/** 제어 보유자가 바뀌어 서버가 재협상을 요구한 닫힘. 등급을 비우고 다시 물어본다. */
+const TERMINAL_CONTROL_CHANGED_CLOSE_CODE = 4002;
 
 export function createTerminalConnection(options: TerminalConnectionOptions): TerminalConnection {
   const abort = new AbortController();
@@ -178,6 +180,13 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
            * 역할만 내려놓고 루프는 계속 돈다 — 곧바로 관전자로 다시 붙어 같은 출력을 본다.
            */
           role = "viewer";
+          connectionOptions.onStatus?.("connecting");
+        } else if (code === TERMINAL_CONTROL_CHANGED_CLOSE_CODE) {
+          /**
+           * 보유자가 바뀌었다. 지금 들고 있던 등급은 옛 사실에 대한 답이므로 버리고 control로
+           * 되물어본다 — 승격이든 강등이든 판정은 서버가 하고, 이 자리에서 방향을 알 필요가 없다.
+           */
+          role = "control";
           connectionOptions.onStatus?.("connecting");
         } else if (code === TERMINAL_CLOSED_CLOSE_CODE) {
           abort.abort();

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-connection.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-connection.ts
@@ -1,3 +1,10 @@
+/**
+ * 소켓 역할. 서버의 같은 이름 타입과 값이 일치해야 하지만 타입을 건너 들여오지는 않는다 —
+ * 브라우저 코드가 서버 모듈을 참조하기 시작하면 그 경계는 조용히 사라진다. 서버는
+ * `readSocketRole`에서 "viewer" 외의 값을 전부 control로 떨어뜨리므로 오타는 여기서 끝난다.
+ */
+export type TerminalSocketRole = "control" | "viewer";
+
 export interface TerminalLike {
   readonly onData: (listener: (data: string) => void) => { readonly dispose: () => void };
   readonly write: (data: Uint8Array) => void;
@@ -29,6 +36,8 @@ export interface TerminalCloseInfo {
 export interface TerminalConnection {
   readonly start: () => void;
   readonly resize: (cols: number, rows: number) => void;
+  /** 관전 중인 소켓을 끊고 제어로 다시 붙는다. 지금 몰고 있는 소켓은 밀려난다. */
+  readonly takeBackControl: () => void;
   readonly dispose: () => void;
 }
 
@@ -43,7 +52,11 @@ export interface WebSocketLike {
   onerror: (() => void) | null;
 }
 
-export type TerminalConnectionStatus = "connecting" | "live" | "closed";
+/**
+ * `viewer`는 붙어 있고 출력도 흐르지만 입력이 가지 않는 상태다. `live`와 갈라 두는 이유는
+ * 화면이 그 차이를 말해야 하기 때문이다 — 반응 없는 키보드를 연결 문제로 읽게 두면 안 된다.
+ */
+export type TerminalConnectionStatus = "connecting" | "live" | "viewer" | "closed";
 
 const INITIAL_RECONNECT_DELAY_MS = 250;
 const MAX_RECONNECT_DELAY_MS = 5_000;
@@ -60,6 +73,11 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
   let inputSubscription: { readonly dispose: () => void } | null = null;
   let pendingSize: { readonly cols: number; readonly rows: number } | null = null;
   let started = false;
+  /**
+   * 이 연결이 지금 요구하는 역할. 밀려나면(4000) control에서 viewer로 내려가고, 사용자가
+   * 되찾겠다고 하면 control로 되돌린다 — 재접속 루프가 매 회 이 값으로 티켓을 받는다.
+   */
+  let role: TerminalSocketRole = "control";
 
   const disposeInput = () => {
     inputSubscription?.dispose();
@@ -68,6 +86,7 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
 
   const sendResize = (cols: number, rows: number) => {
     pendingSize = { cols, rows };
+    if (role === "viewer") return;
     if (socket?.readyState === OPEN_READY_STATE) {
       socket.send(JSON.stringify({ type: "resize", cols, rows }));
     }
@@ -77,7 +96,7 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
     while (!abort.signal.aborted) {
       options.onStatus?.("connecting");
       try {
-        const { ticket } = await requestTerminalTicket(options.ticketPath, options.operationId, abort.signal, options.colorScheme);
+        const { ticket } = await requestTerminalTicket(options.ticketPath, options.operationId, abort.signal, options.colorScheme, role);
         if (abort.signal.aborted) return;
         await attachSocket(buildTerminalWsUrl(ticket, options.location, options.wsPath), options);
         reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
@@ -98,8 +117,9 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
       socket = ws;
       ws.binaryType = "arraybuffer";
       ws.onopen = () => {
-        connectionOptions.onStatus?.("live");
-        if (pendingSize) sendResize(pendingSize.cols, pendingSize.rows);
+        connectionOptions.onStatus?.(role === "viewer" ? "viewer" : "live");
+        // 관전자는 PTY 크기를 협상하지 않는다 — 보는 사람의 창이 모는 사람의 터미널을 흔들면 안 된다.
+        if (role !== "viewer" && pendingSize) sendResize(pendingSize.cols, pendingSize.rows);
       };
       ws.onmessage = (event) => {
         if (event.data instanceof ArrayBuffer) {
@@ -120,6 +140,9 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
           if (socket !== ws) return;
           // 재생 바이트가 모두 파싱된 뒤다. 아래 입력 구독 조건과 무관하게 창은 닫는다.
           connectionOptions.onReplayStateChange?.(false);
+          // 입력 구독 자체를 만들지 않는 것이 관전의 실제 경계다. 서버도 viewer 소켓의 메시지를
+          // 듣지 않지만, 보내지 않는 편이 화면과 전송을 같은 이야기로 만든다.
+          if (role === "viewer") return;
           if (ws.readyState !== OPEN_READY_STATE || inputSubscription) return;
           disposeInput();
           inputSubscription = connectionOptions.terminal.onData((data) => {
@@ -135,8 +158,15 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
         if (socket === ws) socket = null;
         const code = event?.code;
         if (code === TERMINAL_REPLACED_CLOSE_CODE) {
-          abort.abort();
-          connectionOptions.onStatus?.("closed", "terminal_replaced");
+          /**
+           * 밀려났다고 해서 볼 자격까지 잃는 것은 아니다. 예전에는 여기서 재접속을 영구 포기해
+           * 화면에 `closed: terminal_replaced`만 남았는데, 그것은 터미널이 죽은 것인지 사람이
+           * 가져간 것인지 구분해 주지 않는 문자열이었다.
+           *
+           * 역할만 내려놓고 루프는 계속 돈다 — 곧바로 관전자로 다시 붙어 같은 출력을 본다.
+           */
+          role = "viewer";
+          connectionOptions.onStatus?.("connecting");
         } else if (code === TERMINAL_CLOSED_CLOSE_CODE) {
           abort.abort();
           connectionOptions.onStatus?.("closed", "terminal_closed");
@@ -157,6 +187,12 @@ export function createTerminalConnection(options: TerminalConnectionOptions): Te
       void connectLoop();
     },
     resize: sendResize,
+    takeBackControl: () => {
+      if (role === "control") return;
+      role = "control";
+      // 소켓을 닫으면 연결 루프가 다음 회차를 control 티켓으로 받는다.
+      socket?.close();
+    },
     dispose: () => {
       abort.abort();
       disposeInput();
@@ -172,11 +208,12 @@ export function buildTerminalWsUrl(ticket: string, targetLocation: Pick<Location
   return `${protocol}://${targetLocation.host}${pathname}?ticket=${encodeURIComponent(ticket)}`;
 }
 
-async function requestTerminalTicket(ticketPath: string, operationId: string, signal: AbortSignal, colorScheme?: "light" | "dark"): Promise<{ readonly ticket: string; readonly ttlMs: number }> {
+async function requestTerminalTicket(ticketPath: string, operationId: string, signal: AbortSignal, colorScheme?: "light" | "dark", role?: TerminalSocketRole): Promise<{ readonly ticket: string; readonly ttlMs: number }> {
   const response = await fetch(ticketPath, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ operationId, ...(colorScheme ? { colorScheme } : {}) }),
+    // control은 서버 기본값이라 싣지 않는다 — 옛 서버에 붙어도 같은 요청이 된다.
+    body: JSON.stringify({ operationId, ...(colorScheme ? { colorScheme } : {}), ...(role === "viewer" ? { role } : {}) }),
     signal,
   });
   if (!response.ok) throw new Error(`Terminal ticket request failed: ${response.status}`);

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -11,6 +11,9 @@ import { createTerminalConnection, type TerminalConnection } from "./terminal-co
 import { createTerminalCopyOnSelect } from "./terminal-copy-on-select.js";
 import { createTerminalOsc52Clipboard } from "./terminal-osc52-clipboard.js";
 import { TERMINAL_OPTIONS } from "./terminal-options.js";
+import type { ConsoleLocale } from "@fleet-console/sdk/i18n";
+
+import { getT } from "../i18n/index.js";
 import { useTerminalPrefs } from "./terminal-preferences.js";
 import { createTerminalScrollFollow, type TerminalScrollFollowController } from "./terminal-scroll-follow.js";
 import { createTerminalStatusDetailReporter, type TerminalStatusDetailReporter } from "./status-detail.js";
@@ -34,6 +37,8 @@ export interface TerminalSurfaceProps {
   // 터미널 마운트 단의 역스케일(scale(1/zoom)) + fontSize×zoom으로 net scale=1을 만들어 좌표를 정정한다.
   readonly zoom?: number;
   readonly onStatusDetail?: (detail: string) => void;
+  /** 관전 배지 문구용. 넘기지 않으면 영어로 떨어진다 — 배지 외의 동작에는 영향이 없다. */
+  readonly locale?: ConsoleLocale;
 }
 
 interface TerminalOutputScheduler {
@@ -168,9 +173,10 @@ function terminalPolarityFor(theme: TerminalThemeId): "light" | "dark" {
   return LIGHT_TERMINAL_THEMES.has(theme) ? "light" : "dark";
 }
 
-export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "instrument", onExit, active, keyboardFocusRequestId, zoom = 1, onStatusDetail }: TerminalSurfaceProps) {
+export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "instrument", onExit, active, keyboardFocusRequestId, zoom = 1, onStatusDetail, locale }: TerminalSurfaceProps) {
   const activeTheme = theme;
   const { renderer: terminalRenderer, font: terminalFontSettings } = useTerminalPrefs();
+  const t = getT(locale);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const terminalRef = useRef<XtermTerminal | null>(null);
   const connectionRef = useRef<TerminalConnection | null>(null);
@@ -528,9 +534,9 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
         {isViewing ? (
           <div className="terminal-viewer-badge" role="status">
             <span className="terminal-viewer-badge-dot" aria-hidden="true" />
-            <span className="terminal-viewer-badge-text">Another device is using this terminal — read-only</span>
+            <span className="terminal-viewer-badge-text">{t("terminal.viewer.readOnly")}</span>
             <button type="button" className="terminal-viewer-badge-action" onClick={() => connectionRef.current?.takeBackControl()}>
-              Take back control
+              {t("terminal.viewer.takeBack")}
             </button>
           </div>
         ) : null}

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -198,6 +198,8 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
   const activeRef = useRef(active);
   activeRef.current = active;
   const [status, setStatus] = useState("connecting");
+  // 서버가 등급을 잠갔으면 되찾기를 제안하지 않는다 — 눌러도 다시 관전으로 돌아오는 버튼은 거짓이다.
+  const [controlLocked, setControlLocked] = useState(false);
   // 마운트 effect는 심볼 폰트 선대기 등 await 뒤에 ticket 연결을 만들고 테마 변경에 재실행되지 않으므로,
   // 최신 극성은 ref로 읽는다(activeRef와 같은 이유) — 대기 중 테마가 바뀌어도 첫 ticket이 현재 극성을 싣는다.
   const colorSchemeRef = useRef(terminalPolarityFor(activeTheme));
@@ -317,6 +319,7 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
           replayingScrollback = replaying;
         },
         onExit: () => onExitRef.current?.(),
+        onControlLockChange: (lock) => { setControlLocked(lock === "locked"); },
         onStatus: (nextStatus, message) => {
           setStatus(message ? `${nextStatus}: ${message}` : nextStatus);
         },
@@ -534,10 +537,12 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
         {isViewing ? (
           <div className="terminal-viewer-badge" role="status">
             <span className="terminal-viewer-badge-dot" aria-hidden="true" />
-            <span className="terminal-viewer-badge-text">{t("terminal.viewer.readOnly")}</span>
-            <button type="button" className="terminal-viewer-badge-action" onClick={() => connectionRef.current?.takeBackControl()}>
-              {t("terminal.viewer.takeBack")}
-            </button>
+            <span className="terminal-viewer-badge-text">{t(controlLocked ? "terminal.viewer.remoteControlled" : "terminal.viewer.readOnly")}</span>
+            {controlLocked ? null : (
+              <button type="button" className="terminal-viewer-badge-action" onClick={() => connectionRef.current?.takeBackControl()}>
+                {t("terminal.viewer.takeBack")}
+              </button>
+            )}
           </div>
         ) : null}
         <div className="terminal-viewport">

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -499,6 +499,11 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
   // 연결이 'live'면 상태 바를 숨겨 터미널 canvas가 카드를 가득 채우게 하고,
   // connecting/error 등 문제 상황에서만 상태를 노출한다.
   const isLive = status.startsWith("live");
+  /**
+   * 관전 중에는 출력이 계속 흐르므로 화면을 가리지 않는다 — 상태 줄 대신 배지를 얹어
+   * "보이지만 칠 수 없다"만 말한다. 이 구분이 없으면 반응 없는 키보드가 연결 장애로 읽힌다.
+   */
+  const isViewing = status.startsWith("viewer");
   // 줌 보정: 마운트 단을 레이아웃상 zoom배로 키운 뒤 scale(1/zoom)으로 되돌려 부모 scale(zoom)과 net 1로 상쇄한다.
   // %는 position:relative인 .terminal-viewport 기준이라 별도 측정 없이 inner 크기에 정확히 맞춰진다. zoom=1이면
   // 기본 스타일(.terminal-canvas의 inset:0)을 그대로 써 캔버스 외 셸 패널 사용처에 영향이 없다.
@@ -514,10 +519,19 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
   return (
     <section className="terminal-stage" aria-label="Terminal">
       <div className="terminal-shell">
-        {!isLive ? (
+        {!isLive && !isViewing ? (
           <div className="terminal-status" aria-live="polite">
             <span className="terminal-status-dot" aria-hidden="true" />
             {status}
+          </div>
+        ) : null}
+        {isViewing ? (
+          <div className="terminal-viewer-badge" role="status">
+            <span className="terminal-viewer-badge-dot" aria-hidden="true" />
+            <span className="terminal-viewer-badge-text">Another device is using this terminal — read-only</span>
+            <button type="button" className="terminal-viewer-badge-action" onClick={() => connectionRef.current?.takeBackControl()}>
+              Take back control
+            </button>
           </div>
         ) : null}
         <div className="terminal-viewport">

--- a/runtime/fleet-plugins/terminal/routes.ts
+++ b/runtime/fleet-plugins/terminal/routes.ts
@@ -1,5 +1,8 @@
 import path from "node:path";
 
+/** Console이 제어 보유자 변화를 알리는 채널. 이름은 core/host/access-control-contract.ts와 한 벌이다. */
+const CONTROL_HOLDER_EVENT_CHANNEL = "control:holder";
+
 import type { OperationLaunchKind } from "@fleet-console/sdk/operations";
 import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 import { definePlugin, registerLaunchCatalog, registerWsHandler } from "@fleet-console/sdk/plugin/node";
@@ -84,6 +87,13 @@ export default definePlugin({
     const wireLog = createWireLogRuntime(ctx);
     applyStoredWireLog(ctx, aiGatewayStore.read);
     ctx.host.lifecycle.registerCleanup(() => setWireLogTarget(undefined));
+    /**
+     * 제어 보유자가 바뀌면 이미 붙어 있는 터미널 소켓도 등급을 다시 받아야 한다. 티켓 발급
+     * 시점의 판정만으로는 그때 이미 열려 있던 터미널이 옛 등급 그대로 남아, 회수한 뒤에도
+     * 읽기 전용에 갇히거나 넘긴 뒤에도 계속 입력이 간다.
+     */
+    const unsubscribeControl = ctx.host.events.subscribe(CONTROL_HOLDER_EVENT_CHANNEL, () => { runtime.renegotiateSockets(); });
+    ctx.host.lifecycle.registerCleanup(unsubscribeControl);
     registerShellRoutes(ctx, runtime);
     registerGlobalShellRoutes(ctx, runtime);
     registerTerminalSettingsRoutes(ctx, {

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -9,6 +9,7 @@ import { createWikiWorkspaceResolver, getWikiToolSpecs } from "@dotobokuri/fleet
 import type { OperationLaunchKind, OperationNode, OperationPatchInput } from "@fleet-console/sdk/operations";
 import { registerRouter } from "@fleet-console/sdk/plugin/node";
 import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
+import { readSocketRole } from "./shared/index.js";
 import type { TerminalRuntime } from "./shared/index.js";
 
 import { createDefaultAgentCliDetector, validateAgentCliPathForSave } from "./agent-api/agent-cli-detect.js";
@@ -268,7 +269,7 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
         ctx.host.http.writeJson(res, 401, { error: "Unauthorized" });
         return true;
       }
-      const body = await ctx.host.http.readJsonBody<{ readonly operationId?: unknown; readonly colorScheme?: unknown }>(req);
+      const body = await ctx.host.http.readJsonBody<{ readonly operationId?: unknown; readonly colorScheme?: unknown; readonly role?: unknown }>(req);
       if (typeof body?.operationId !== "string") {
         ctx.host.http.writeJson(res, 400, { error: "terminal_session_not_found" });
         return true;
@@ -290,6 +291,7 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
         return true;
       }
       const colorScheme = body?.colorScheme === "light" || body?.colorScheme === "dark" ? body.colorScheme : undefined;
+      const role = readSocketRole(body?.role);
       ctx.host.http.writeJson(res, 200, terminalRuntime.issueTicket({
         cwd,
         sessionId: operation.id,
@@ -299,6 +301,7 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
         theaterId: operation.theaterId,
         cliId: readPayloadString(operation.payload, "cliId") ?? undefined,
         ...(colorScheme ? { colorScheme } : {}),
+        ...(role ? { role } : {}),
       }));
       return true;
     }

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -291,7 +291,9 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
         return true;
       }
       const colorScheme = body?.colorScheme === "light" || body?.colorScheme === "dark" ? body.colorScheme : undefined;
-      const role = readSocketRole(body?.role);
+      // 등급은 Console이 정한다. 요청이 control을 원해도 제어를 쥔 원격이 있으면 관전으로 내려간다 —
+      // 새로고침 한 번이 조용히 제어를 되가져가는 경합을 클라이언트에 맡기지 않는다.
+      const role = ctx.host.security.resolveTerminalSocketRole(req) === "viewer" ? "viewer" : readSocketRole(body?.role);
       ctx.host.http.writeJson(res, 200, terminalRuntime.issueTicket({
         cwd,
         sessionId: operation.id,

--- a/runtime/fleet-plugins/terminal/server/global.ts
+++ b/runtime/fleet-plugins/terminal/server/global.ts
@@ -69,7 +69,9 @@ export function registerGlobalShellRoutes(ctx: FleetPluginServerContext, runtime
     // 재생성), ticket 발급 경로에서 별도의 stale 정리를 하지 않는다. 여기서 빈 write로 정리를 시도하면
     // 일시적 write 예외가 살아있는 세션을 오판 종료할 수 있어 오히려 위험하다.
     const colorScheme = body?.colorScheme === "light" || body?.colorScheme === "dark" ? body.colorScheme : undefined;
-    const role = readSocketRole(body?.role);
+    // 등급은 Console이 정한다. 요청이 control을 원해도 제어를 쥔 원격이 있으면 관전으로 내려간다 —
+    // 새로고침 한 번이 조용히 제어를 되가져가는 경합을 클라이언트에 맡기지 않는다.
+    const role = ctx.host.security.resolveTerminalSocketRole(req) === "viewer" ? "viewer" : readSocketRole(body?.role);
     ctx.host.http.writeJson(res, 200, runtime.issueTicket({
       cwd: theaterPath,
       sessionId: operationId,

--- a/runtime/fleet-plugins/terminal/server/global.ts
+++ b/runtime/fleet-plugins/terminal/server/global.ts
@@ -1,9 +1,10 @@
 import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 import { registerRouter } from "@fleet-console/sdk/plugin/node";
 
+import { readSocketRole } from "./shared/index.js";
 import type { TerminalRuntime } from "./shared/index.js";
 
-type TicketBody = { readonly operationId?: unknown; readonly sessionId?: unknown; readonly colorScheme?: unknown };
+type TicketBody = { readonly operationId?: unknown; readonly sessionId?: unknown; readonly colorScheme?: unknown; readonly role?: unknown };
 
 const GLOBAL_SHELL_OPERATION_PREFIX = "global-shell:theater:";
 const GLOBAL_SHELL_OPERATION_TYPE = "shell";
@@ -68,6 +69,7 @@ export function registerGlobalShellRoutes(ctx: FleetPluginServerContext, runtime
     // 재생성), ticket 발급 경로에서 별도의 stale 정리를 하지 않는다. 여기서 빈 write로 정리를 시도하면
     // 일시적 write 예외가 살아있는 세션을 오판 종료할 수 있어 오히려 위험하다.
     const colorScheme = body?.colorScheme === "light" || body?.colorScheme === "dark" ? body.colorScheme : undefined;
+    const role = readSocketRole(body?.role);
     ctx.host.http.writeJson(res, 200, runtime.issueTicket({
       cwd: theaterPath,
       sessionId: operationId,
@@ -77,6 +79,7 @@ export function registerGlobalShellRoutes(ctx: FleetPluginServerContext, runtime
       theaterId,
       kind: "shell",
       ...(colorScheme ? { colorScheme } : {}),
+      ...(role ? { role } : {}),
     }));
     return true;
   });

--- a/runtime/fleet-plugins/terminal/server/shared/index.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/index.ts
@@ -10,7 +10,7 @@ export type {
   TerminalTicketContext,
   TerminalTitleListener,
 } from "./terminal-types.js";
-export { createPluginTerminalTicketRegistry } from "./tickets.js";
+export { createPluginTerminalTicketRegistry, readSocketRole } from "./tickets.js";
 export type { TerminalTicketRegistry, TerminalTicketRegistryDeps } from "./tickets.js";
 export { createTerminalRuntime } from "./runtime.js";
 export type { TerminalRuntime, TerminalLaunchResolver } from "./runtime.js";

--- a/runtime/fleet-plugins/terminal/server/shared/runtime.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/runtime.ts
@@ -12,6 +12,8 @@ export interface TerminalRuntime {
   readonly handleUpgrade: UpgradeHandler;
   issueTicket(context: TerminalTicketContext): TerminalTicket;
   invalidateTicketsForSession(sessionId: string): void;
+  /** 제어 보유자가 바뀌었을 때 붙어 있는 소켓들이 등급을 다시 받게 한다. */
+  renegotiateSockets(): void;
   canAttach(operationId: string): boolean;
   attach(context: TerminalTicketContext): Promise<void>;
   write(operationId: string, data: string): boolean;
@@ -61,6 +63,7 @@ export function createTerminalRuntime(ctx: FleetPluginServerContext): TerminalRu
   return {
     handleUpgrade: upgrade.handleUpgrade,
     issueTicket: (context) => tickets.issue(context),
+    renegotiateSockets: () => sessions.renegotiateSockets(),
     invalidateTicketsForSession: (sessionId) => tickets.invalidateForSession(sessionId),
     canAttach: (operationId) => sessions.canAttach(operationId),
     attach: async (context) => {

--- a/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
@@ -34,6 +34,13 @@ interface TerminalSession {
   readonly titleListener?: TerminalTitleListener;
   readonly titleParser?: OscTitleParser;
   activeSocket: TerminalSocket | null;
+  /**
+   * 출력만 받는 소켓들. 제어를 원격에 넘긴 로컬 사용자가 여기 들어와 같은 화면을 계속 본다.
+   *
+   * activeSocket과 분리해 두는 것이 요점이다 — 한 칸짜리 소유권을 그대로 두어야 "입력은 한
+   * 곳에서만"이라는 성질이 유지되고, 관전자가 늘어도 누가 모는지는 여전히 하나로 답해진다.
+   */
+  readonly viewers: Set<TerminalSocket>;
   cols: number;
   rows: number;
   // theater-shell(캔버스 순정 셸) 전용: 소켓 단절 후 PTY 정리까지의 grace 타이머. 재연결 시 취소된다.
@@ -98,6 +105,26 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     }
     socket.on("message", (data, isBinary) => handleSocketMessage(session, data, isBinary));
     socket.once("close", () => detachSocket(session, socket));
+  }
+
+  /**
+   * 읽기 전용 부착. 제어 소켓을 건드리지 않는 것이 이 함수의 전부다 — 밀어내지 않고,
+   * activeSocket이 되지 않고, PTY를 리사이즈하지 않고, message 리스너를 달지 않는다.
+   * 마지막 항목이 입력 차단의 실제 수단이다: 핸들러가 없으면 보낸 바이트는 갈 곳이 없다.
+   *
+   * 세션을 만들지도 않는다. 볼 대상이 없는 관전은 성립하지 않고, 여기서 PTY를 띄우면
+   * 관전자가 프로세스를 시작시키는 셈이 된다.
+   */
+  function attachViewer(socket: TerminalSocket, sessionId: string): boolean {
+    const session = sessions.get(sessionId);
+    if (!session) return false;
+    session.viewers.add(socket);
+    replayScrollback(session, socket);
+    if (socket.readyState === WS_OPEN_STATE) {
+      socket.send(Buffer.from(JSON.stringify({ type: "replay_end" }), "utf8"), { binary: false });
+    }
+    socket.once("close", () => { session.viewers.delete(socket); });
+    return true;
   }
 
   async function createSession(context: TerminalTicketContext): Promise<void> {
@@ -226,6 +253,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
       titleListener,
       ...(titleListener ? { titleParser: createOscTitleParser() } : {}),
       activeSocket: null,
+      viewers: new Set<TerminalSocket>(),
       cols: DEFAULT_COLS,
       rows: DEFAULT_ROWS,
       graceTimer: null,
@@ -266,6 +294,12 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     session.scrollback.push(buffer);
     while (session.scrollback.length > scrollbackLimit) session.scrollback.shift();
     liveSocket?.send(buffer, { binary: true });
+    // 관전자는 같은 바이트를 받되 질의에는 답하지 않는다 — 응답 권한은 제어 소켓 하나에만
+    // 있고, 둘이 답하면 PTY가 두 벌의 응답을 읽는다.
+    for (const viewer of session.viewers) {
+      if (viewer.readyState !== WS_OPEN_STATE) continue;
+      viewer.send(buffer, { binary: true });
+    }
   }
 
   function observeOscTitles(session: TerminalSession, buffer: Buffer): void {
@@ -321,7 +355,9 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
       clearGraceTimer(session);
       session.graceTimer = setTimeout(() => {
         session.graceTimer = null;
-        if (session.activeSocket === null) removeSession(session);
+        // 보고 있는 사람이 남아 있으면 정리하지 않는다 — 제어가 원격으로 넘어가 이 소켓이
+        // 물러난 것뿐인데 PTY를 죽이면 관전자의 화면이 함께 사라진다.
+        if (session.activeSocket === null && session.viewers.size === 0) removeSession(session);
       }, THEATER_SHELL_DETACH_GRACE_MS);
     }
   }
@@ -350,6 +386,9 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     clearGraceTimer(session);
     session.activeSocket?.close(4001, "terminal_closed");
     session.activeSocket = null;
+    // 관전자도 같은 이유로 끝난다 — 남겨 두면 죽은 PTY를 보며 살아 있는 화면인 척한다.
+    for (const viewer of session.viewers) viewer.close(4001, "terminal_closed");
+    session.viewers.clear();
     for (const disposable of session.disposables) disposable.dispose();
     try {
       if (killPty) killPtyBestEffort(session.pty, session.ptyFds);
@@ -358,7 +397,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     }
   }
 
-  return { canAttach, createSession, attach, getSessionMessagePolicy, getSessionRenameCommand, getSessionGoalCommand, getSessionLastActivityAt, resolveSessionIdentity, terminate, stop, writeToSession };
+  return { canAttach, createSession, attach, attachViewer, getSessionMessagePolicy, getSessionRenameCommand, getSessionGoalCommand, getSessionLastActivityAt, resolveSessionIdentity, terminate, stop, writeToSession };
 }
 
 async function runLaunchCleanup(cleanup: (() => void | Promise<void>) | undefined): Promise<void> {

--- a/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/session-manager.ts
@@ -123,8 +123,26 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     if (socket.readyState === WS_OPEN_STATE) {
       socket.send(Buffer.from(JSON.stringify({ type: "replay_end" }), "utf8"), { binary: false });
     }
-    socket.once("close", () => { session.viewers.delete(socket); });
+    socket.once("close", () => {
+      session.viewers.delete(socket);
+      scheduleTheaterShellCleanup(session);
+    });
     return true;
+  }
+
+  /**
+   * 제어 보유자가 바뀌었으니 붙어 있는 소켓들을 다시 협상시킨다.
+   *
+   * 등급을 자리에서 올리고 내리는 대신 소켓을 닫는다. 클라이언트의 재연결 루프가 곧바로 새
+   * 티켓을 받고, 그 티켓의 등급은 이미 서버가 정한다 — 이미 옳게 도는 경로 하나만 쓰면
+   * 승격·강등 두 갈래를 따로 맞출 필요가 없다. 대가는 보유자가 바뀔 때의 scrollback 재생뿐이고,
+   * 그 일은 원격 세션 하나당 많아야 두 번 일어난다.
+   */
+  function renegotiateSockets(): void {
+    for (const session of sessions.values()) {
+      const sockets = [session.activeSocket, ...session.viewers].filter((socket): socket is TerminalSocket => socket !== null);
+      for (const socket of sockets) socket.close(4002, "terminal_control_changed");
+    }
   }
 
   async function createSession(context: TerminalTicketContext): Promise<void> {
@@ -343,6 +361,23 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     session.pty.resize(frame.cols, frame.rows);
   }
 
+  /**
+   * theater-shell은 "상태 미유지"라 아무도 보고 있지 않게 된 순간부터 짧은 유예 뒤 정리된다.
+   *
+   * 관전자도 보는 사람이므로 유예가 끝나도 남아 있으면 살려 둔다. 다만 그때 정리를 포기하면
+   * 마지막 관전자가 나간 뒤 아무도 다시 걸어 주지 않아 PTY가 영영 남는다 — 소켓이 하나라도
+   * 떨어질 때마다 다시 건다.
+   */
+  function scheduleTheaterShellCleanup(session: TerminalSession): void {
+    if (!isTheaterShell(session.id)) return;
+    if (session.activeSocket !== null || session.viewers.size > 0) return;
+    clearGraceTimer(session);
+    session.graceTimer = setTimeout(() => {
+      session.graceTimer = null;
+      if (session.activeSocket === null && session.viewers.size === 0) removeSession(session);
+    }, THEATER_SHELL_DETACH_GRACE_MS);
+  }
+
   function detachSocket(session: TerminalSession, socket: TerminalSocket): void {
     if (session.activeSocket !== socket) return;
     // 소켓이 끊겨도(콘솔 웹 종료·세션 전환 언마운트) PTY 세션은 유지한다. activeSocket만 비워
@@ -351,15 +386,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     session.activeSocket = null;
     // 예외: theater-shell(캔버스 순정 셸)은 "상태 미유지" 요구에 따라 소켓 단절 후 짧은 grace 뒤 PTY를 정리한다.
     // 패널 닫기·새로고침이 이 경로로 흘러 orphan PTY를 막는다. 재연결이 들어오면 attach가 타이머를 취소한다.
-    if (isTheaterShell(session.id)) {
-      clearGraceTimer(session);
-      session.graceTimer = setTimeout(() => {
-        session.graceTimer = null;
-        // 보고 있는 사람이 남아 있으면 정리하지 않는다 — 제어가 원격으로 넘어가 이 소켓이
-        // 물러난 것뿐인데 PTY를 죽이면 관전자의 화면이 함께 사라진다.
-        if (session.activeSocket === null && session.viewers.size === 0) removeSession(session);
-      }, THEATER_SHELL_DETACH_GRACE_MS);
-    }
+    scheduleTheaterShellCleanup(session);
   }
 
   function replayScrollback(session: TerminalSession, socket: TerminalSocket): void {
@@ -397,7 +424,7 @@ export function createTerminalSessionManager(deps: TerminalSessionManagerDeps): 
     }
   }
 
-  return { canAttach, createSession, attach, attachViewer, getSessionMessagePolicy, getSessionRenameCommand, getSessionGoalCommand, getSessionLastActivityAt, resolveSessionIdentity, terminate, stop, writeToSession };
+  return { canAttach, createSession, attach, attachViewer, renegotiateSockets, getSessionMessagePolicy, getSessionRenameCommand, getSessionGoalCommand, getSessionLastActivityAt, resolveSessionIdentity, terminate, stop, writeToSession };
 }
 
 async function runLaunchCleanup(cleanup: (() => void | Promise<void>) | undefined): Promise<void> {

--- a/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
@@ -54,7 +54,17 @@ export interface TerminalTicketContext {
   readonly prompt?: string;
   readonly resumeSessionId?: string;
   readonly colorScheme?: "light" | "dark";
+  /**
+   * 이 티켓이 여는 소켓의 역할. 생략하면 `control`이다 — 지금까지 발급된 모든 티켓이 그것이었고,
+   * 기본값을 바꾸면 옛 클라이언트가 조용히 읽기 전용이 된다.
+   *
+   * `viewer`는 출력만 받는다. 세션을 만들지도, 앞의 소켓을 밀어내지도, 입력이나 리사이즈를
+   * 보내지도 못한다.
+   */
+  readonly role?: TerminalSocketRole;
 }
+
+export type TerminalSocketRole = "control" | "viewer";
 
 export interface TerminalPtyDataDisposable {
   dispose(): void;
@@ -87,6 +97,11 @@ export interface TerminalSessionManager {
   canAttach(sessionId: string): boolean;
   createSession(context: TerminalTicketContext): Promise<void>;
   attach(socket: TerminalSocket, context: TerminalTicketContext): Promise<void>;
+  /**
+   * 읽기 전용으로 붙는다. 이미 살아 있는 세션에만 붙을 수 있다 — 볼 것이 없는데 PTY를 새로
+   * 띄우면 관전이 실행이 된다. 없는 세션이면 false를 돌려주고 호출자가 소켓을 닫는다.
+   */
+  attachViewer(socket: TerminalSocket, sessionId: string): boolean;
   getSessionMessagePolicy(sessionId: string): CliMessagePolicy | undefined;
   getSessionRenameCommand(sessionId: string): string | undefined;
   getSessionGoalCommand(sessionId: string): string | undefined;

--- a/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
@@ -37,6 +37,11 @@ export interface TerminalLaunchContext {
 export interface TerminalTicket {
   readonly ticket: string;
   readonly ttlMs: number;
+  /**
+   * 이 티켓이 실제로 여는 등급. 요청이 무엇을 원했든 결정은 Console이 한다 — 클라이언트는
+   * 자기가 무엇을 받았는지 알아야 입력 구독과 화면을 그 사실에 맞출 수 있다.
+   */
+  readonly role: TerminalSocketRole;
 }
 
 export interface TerminalTicketContext {

--- a/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/terminal-types.ts
@@ -107,6 +107,11 @@ export interface TerminalSessionManager {
    * 띄우면 관전이 실행이 된다. 없는 세션이면 false를 돌려주고 호출자가 소켓을 닫는다.
    */
   attachViewer(socket: TerminalSocket, sessionId: string): boolean;
+  /**
+   * 붙어 있는 모든 소켓을 닫아 등급을 다시 받게 한다. 제어 보유자가 바뀌었을 때 Console이 부른다 —
+   * 티켓 발급 시점의 판정만으로는 이미 열려 있던 터미널이 옛 등급 그대로 남는다.
+   */
+  renegotiateSockets(): void;
   getSessionMessagePolicy(sessionId: string): CliMessagePolicy | undefined;
   getSessionRenameCommand(sessionId: string): string | undefined;
   getSessionGoalCommand(sessionId: string): string | undefined;

--- a/runtime/fleet-plugins/terminal/server/shared/tickets.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/tickets.ts
@@ -42,7 +42,7 @@ export function createPluginTerminalTicketRegistry(deps: TerminalTicketRegistryD
     prune();
     const ticket = randomTicket();
     tickets.set(ticket, { context, expiresAt: now() + ttlMs });
-    return { ticket, ttlMs };
+    return { ticket, ttlMs, role: context.role ?? "control" };
   }
 
   function consume(ticket: string | null): TerminalTicketContext | null {

--- a/runtime/fleet-plugins/terminal/server/shared/tickets.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/tickets.ts
@@ -1,6 +1,14 @@
 import crypto from "node:crypto";
 
-import type { TerminalTicket, TerminalTicketContext } from "./terminal-types.js";
+import type { TerminalSocketRole, TerminalTicket, TerminalTicketContext } from "./terminal-types.js";
+
+/**
+ * 티켓 요청이 밝힌 역할. `viewer`만 알아듣고 나머지는 전부 undefined로 떨어뜨린다 — 모르는
+ * 값을 control로 승격시키면 오타 하나가 읽기 전용 의도를 조용히 뒤집는다.
+ */
+export function readSocketRole(value: unknown): TerminalSocketRole | undefined {
+  return value === "viewer" ? "viewer" : undefined;
+}
 
 export interface TerminalTicketRegistryDeps {
   readonly ttlMs?: number;

--- a/runtime/fleet-plugins/terminal/server/shared/ws.ts
+++ b/runtime/fleet-plugins/terminal/server/shared/ws.ts
@@ -40,6 +40,14 @@ export function createPluginTerminalUpgradeHandler(deps: TerminalUpgradeHandlerD
       return true;
     }
     const server = getWebSocketServer();
+    if (context.role === "viewer") {
+      // 관전은 살아 있는 세션에만 붙는다. 없으면 열자마자 닫아 클라이언트가 이유를 읽게 한다 —
+      // 소켓을 destroy하면 브라우저에는 원인 없는 연결 실패로만 보인다.
+      server.handleUpgrade(req, socket, head, (ws) => {
+        if (!deps.sessions.attachViewer(ws, context.sessionId)) ws.close(1013, "terminal_unavailable");
+      });
+      return true;
+    }
     server.handleUpgrade(req, socket, head, (ws) => {
       deps.sessions.attach(ws, context).catch((err: unknown) => {
         console.error("[terminal] attach failed", err);

--- a/runtime/fleet-plugins/terminal/server/shell.ts
+++ b/runtime/fleet-plugins/terminal/server/shell.ts
@@ -1,9 +1,10 @@
 import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 import { registerRouter } from "@fleet-console/sdk/plugin/node";
 
+import { readSocketRole } from "./shared/index.js";
 import type { TerminalRuntime } from "./shared/index.js";
 
-type TicketBody = { readonly operationId?: unknown; readonly sessionId?: unknown; readonly colorScheme?: unknown };
+type TicketBody = { readonly operationId?: unknown; readonly sessionId?: unknown; readonly colorScheme?: unknown; readonly role?: unknown };
 
 const OPERATION_RESTORED_EVENT_CHANNEL = "operation:restored";
 const RESTORED_DORMANT_PAYLOAD_KEY = "restoredDormant";
@@ -55,6 +56,7 @@ export function registerShellRoutes(ctx: FleetPluginServerContext, runtime: Term
         return true;
       }
       const colorScheme = body?.colorScheme === "light" || body?.colorScheme === "dark" ? body.colorScheme : undefined;
+      const role = readSocketRole(body?.role);
       ctx.host.http.writeJson(res, 200, runtime.issueTicket({
         cwd: theaterPath,
         sessionId: operationId,
@@ -64,6 +66,7 @@ export function registerShellRoutes(ctx: FleetPluginServerContext, runtime: Term
         theaterId: operation.theaterId,
         kind: "shell",
         ...(colorScheme ? { colorScheme } : {}),
+        ...(role ? { role } : {}),
       }));
       return true;
     });

--- a/runtime/fleet-plugins/terminal/server/shell.ts
+++ b/runtime/fleet-plugins/terminal/server/shell.ts
@@ -56,7 +56,9 @@ export function registerShellRoutes(ctx: FleetPluginServerContext, runtime: Term
         return true;
       }
       const colorScheme = body?.colorScheme === "light" || body?.colorScheme === "dark" ? body.colorScheme : undefined;
-      const role = readSocketRole(body?.role);
+      // 등급은 Console이 정한다. 요청이 control을 원해도 제어를 쥔 원격이 있으면 관전으로 내려간다 —
+      // 새로고침 한 번이 조용히 제어를 되가져가는 경합을 클라이언트에 맡기지 않는다.
+      const role = ctx.host.security.resolveTerminalSocketRole(req) === "viewer" ? "viewer" : readSocketRole(body?.role);
       ctx.host.http.writeJson(res, 200, runtime.issueTicket({
         cwd: theaterPath,
         sessionId: operationId,

--- a/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
@@ -258,7 +258,7 @@ async function createHarness(body: Record<string, unknown>) {
   const terminate = vi.fn(() => true);
   const terminalRuntime: TerminalRuntime = {
     handleUpgrade: () => false,
-    issueTicket: () => ({ ticket: "ticket", ttlMs: 1_000 }),
+    issueTicket: () => ({ ticket: "ticket", ttlMs: 1_000, role: "control" as const }),
     invalidateTicketsForSession: () => {},
     canAttach: () => true,
     attach,
@@ -362,7 +362,7 @@ async function createHarness(body: Record<string, unknown>) {
       security: {
         validateHost: () => true,
         isTerminalAuthorized: () => true,
-        isLockAuthorized: () => true,
+        isLockAuthorized: () => true, resolveTerminalSocketRole: () => "control" as const,
       },
       lifecycle: {
         registerCleanup: (cleanup: () => void | Promise<void>) => {

--- a/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-capture-grace.test.ts
@@ -259,6 +259,7 @@ async function createHarness(body: Record<string, unknown>) {
   const terminalRuntime: TerminalRuntime = {
     handleUpgrade: () => false,
     issueTicket: () => ({ ticket: "ticket", ttlMs: 1_000, role: "control" as const }),
+    renegotiateSockets: () => {},
     invalidateTicketsForSession: () => {},
     canAttach: () => true,
     attach,

--- a/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
@@ -385,7 +385,7 @@ async function createHarness(options: {
       security: {
         validateHost: () => true,
         isTerminalAuthorized: () => true,
-        isLockAuthorized: () => true,
+        isLockAuthorized: () => true, resolveTerminalSocketRole: () => "control" as const,
       },
       lifecycle: {
         registerCleanup: (cleanup: () => void | Promise<void>) => {

--- a/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
@@ -275,6 +275,7 @@ async function createHarness(options: {
   });
   const terminalRuntime: TerminalRuntime = {
     handleUpgrade: () => false,
+    renegotiateSockets: () => {},
     issueTicket: (context) => {
       ticketsIssued += 1;
       return tickets.issue(context);

--- a/runtime/fleet-plugins/terminal/tests/global-shell-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/global-shell-routes.test.ts
@@ -316,7 +316,7 @@ function createRouteHarness(options: HarnessOptions = {}) {
       security: {
         validateHost: () => true,
         isTerminalAuthorized: () => options.terminalAuthorized ?? true,
-        isLockAuthorized: () => true,
+        isLockAuthorized: () => true, resolveTerminalSocketRole: () => "control" as const,
       },
     },
   } as unknown as FleetPluginServerContext;

--- a/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
@@ -435,7 +435,7 @@ function createRouteHarness(options: HarnessOptions = {}) {
       security: {
         validateHost: () => true,
         isTerminalAuthorized: () => options.terminalAuthorized ?? true,
-        isLockAuthorized: () => true,
+        isLockAuthorized: () => true, resolveTerminalSocketRole: () => "control" as const,
       },
     },
   } as unknown as FleetPluginServerContext;

--- a/runtime/fleet-plugins/terminal/tests/shell-ticket-role.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/shell-ticket-role.test.ts
@@ -1,0 +1,126 @@
+import type http from "node:http";
+
+import { describe, expect, it } from "vitest";
+
+import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
+import type { RouteHandler } from "@fleet-console/sdk/routing";
+
+import { registerShellRoutes } from "../server/shell.js";
+import type { TerminalRuntime, TerminalTicketContext } from "../server/shared/index.js";
+
+/**
+ * 등급 판정은 Console의 것이다. 이 테스트가 지키는 것은 "플러그인이 그 판정을 덮어쓰지 않는다"이다 —
+ * 클라이언트가 control을 원해도, 새로고침이 control로 시작해도, Console이 viewer라고 하면 viewer다.
+ */
+describe("shell ticket role", () => {
+  it("issues a viewer ticket when the console says this request may only watch", async () => {
+    const issued: TerminalTicketContext[] = [];
+    const { call, responses } = await mount({ role: "viewer", issued });
+
+    await call({ operationId: "op-1", role: "control" });
+
+    expect(issued).toHaveLength(1);
+    expect(issued[0]!.role).toBe("viewer");
+    expect(responses.at(-1)).toMatchObject({ status: 200, body: { role: "viewer" } });
+  });
+
+  it("leaves the ticket at control when nothing holds the console", async () => {
+    const issued: TerminalTicketContext[] = [];
+    const { call, responses } = await mount({ role: "control", issued });
+
+    await call({ operationId: "op-1" });
+
+    expect(issued[0]!.role).toBeUndefined();
+    expect(responses.at(-1)).toMatchObject({ status: 200, body: { role: "control" } });
+  });
+
+  it("still honours an explicit viewer request while control is available", async () => {
+    const issued: TerminalTicketContext[] = [];
+    await mount({ role: "control", issued }).then(({ call }) => call({ operationId: "op-1", role: "viewer" }));
+
+    expect(issued[0]!.role).toBe("viewer");
+  });
+});
+
+interface MountOptions {
+  readonly role: "control" | "viewer";
+  readonly issued: TerminalTicketContext[];
+}
+
+async function mount(options: MountOptions): Promise<{
+  call(body: Record<string, unknown>): Promise<void>;
+  responses: Array<{ status: number; body: unknown }>;
+}> {
+  const responses: Array<{ status: number; body: unknown }> = [];
+  const routes = new Map<string, RouteHandler>();
+  let requestBody: Record<string, unknown> = {};
+
+  const terminalRuntime = {
+    handleUpgrade: () => false,
+    issueTicket: (context: TerminalTicketContext) => {
+      options.issued.push(context);
+      return { ticket: "ticket", ttlMs: 1_000, role: context.role ?? "control" };
+    },
+    invalidateTicketsForSession: () => {},
+    canAttach: () => true,
+    attach: async () => {},
+    attachViewer: () => true,
+    createSession: async () => {},
+    getSessionMessagePolicy: () => undefined,
+    getSessionRenameCommand: () => undefined,
+    getSessionGoalCommand: () => undefined,
+    getSessionLastActivityAt: () => null,
+    resolveSessionIdentity: async () => null,
+    terminate: () => true,
+    stop: async () => {},
+    writeToSession: () => false,
+  } as unknown as TerminalRuntime;
+
+  const ctx = {
+    pluginId: "terminal",
+    manifest: { id: "terminal" },
+    basePath: "/plugins/terminal",
+    wsBasePath: "/plugins/terminal/ws",
+    registerRouter: (routePath: string, handler: RouteHandler) => { routes.set(routePath, handler); },
+    registerWsHandler: () => {},
+    host: {
+      operations: {
+        get: () => ({ id: "op-1", type: "shell", pluginId: "terminal", theaterId: "theater-1", payload: {} }),
+        list: () => [],
+      },
+      paths: {
+        resolveTheaterPath: () => "/tmp/theater",
+        workspaceHash: () => "theater-1",
+      },
+      storage: { readJson: async () => null, writeJson: async () => {} },
+      events: { subscribe: () => () => {}, publish: () => {} },
+      http: {
+        writeJson: (_res: http.ServerResponse, status: number, body: unknown) => { responses.push({ status, body }); },
+        readJsonBody: async <T,>() => requestBody as T,
+      },
+      security: {
+        validateHost: () => true,
+        isTerminalAuthorized: () => true,
+        isLockAuthorized: () => true,
+        resolveTerminalSocketRole: () => options.role,
+      },
+      lifecycle: { registerCleanup: () => () => {} },
+    },
+  } as unknown as FleetPluginServerContext;
+
+  registerShellRoutes(ctx, terminalRuntime);
+  const handler = routes.get("shell/ticket");
+  if (!handler) throw new Error("shell/ticket route was not registered");
+
+  return {
+    responses,
+    async call(body) {
+      requestBody = body;
+      await handler({
+        req: { method: "POST", url: "/plugins/terminal/shell/ticket", headers: {} } as http.IncomingMessage,
+        res: {} as http.ServerResponse,
+        pathname: "/plugins/terminal/shell/ticket",
+      } as Parameters<RouteHandler>[0]);
+    },
+  };
+}

--- a/runtime/fleet-plugins/terminal/tests/shell-ticket-role.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/shell-ticket-role.test.ts
@@ -61,6 +61,7 @@ async function mount(options: MountOptions): Promise<{
       options.issued.push(context);
       return { ticket: "ticket", ttlMs: 1_000, role: context.role ?? "control" };
     },
+    renegotiateSockets: () => {},
     invalidateTicketsForSession: () => {},
     canAttach: () => true,
     attach: async () => {},


### PR DESCRIPTION
## Summary

- 원격 기기가 액세스 링크로 붙어 제어를 가져가면 콘솔이 그 사실을 알린다. 도착 순간 전체 화면 커튼이 어느 기기인지 말하고, 닫으면 회수 버튼을 한 번에 누를 수 있는 상시 바로 접힌다. 제어를 넘긴 동안에도 터미널은 살아 있는 출력을 **읽기 전용**으로 계속 보여 준다.
- 제어를 쥐는 원격은 한 번에 하나다. 커튼이 "누가" 몰고 있는지를 하나로 말해야 하고 회수 버튼의 대상도 하나여야 하므로, 둘째 `full` 조인은 `409 remote_control_held`로 거절한다. 판정은 1회용 자격을 **소모하기 전에** 내리므로 거절된 링크는 그대로 다시 쓸 수 있다.
- 회수하면 끊긴 세션만 자기 안내를 받고 자기 콘솔로 돌아간다. Desktop에 이미 있던 `recoverToHome` 경로를 재사용하되, SPA가 떠 있는 동안에는 발화하지 않던 공백을 SSE 통지로 메웠다.

### 함께 고친 것

- **선존 보안 결함.** `isExactConsoleOrigin`은 요청이 *도착한 리스너*의 origin과 대조하므로 원격 브라우저가 자기 origin으로 보내면 통과한다. Access 계열 엔드포인트에는 런타임 루프백 검사가 없어(형제인 `remote-hosts`에는 있다) `full` 원격 게스트가 인증서 지문·다른 기기 이름·미사용 링크·이 기계의 모든 LAN 주소를 읽고, 새 액세스 링크를 발급하고, 남의 세션을 끊고, 호스트 신원을 갈아 끼울 수 있었다. API 카탈로그는 이미 이 경로들을 `loopback`/`origin-write`로 선언하고 있었으나 런타임이 강제하지 않았다. `isAccessAdminAuthorized`로 좁혔다.
- `desktopShell`이 단일 슬롯이라 원격 Desktop이 자기 home을 게시하면 로컬 사용자의 `homeOrigin`이 지워져 호스트 스위처에서 Home이 사라졌다. 소유자별로 나눠 담는다.
- 터미널이 밀려난 클라이언트를 죽은 화면(`closed: terminal_replaced`)에 버려 두던 것을 고쳤다. 이건 원격과 무관하게 **로컬 창 두 개**에서도 나던 릴리스된 결함이다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — exit 0
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 2 failed / 1636 passed. 실패 2건은 **선존**(`tests/i18n.test.ts:201`, `tests/triage-store.test.ts:1441`)이며 브랜치 기준선과 동일하다. 테스트 파일 142→143, 테스트 1645→1656.
- [x] `pnpm --filter @fleet-plugins/terminal typecheck` / `test` — exit 0, 62 파일 516 테스트 전부 통과. (콘솔 typecheck가 놓친 `TicketBody` 3건을 플러그인 자체 typecheck가 잡았다.)
- [x] `pnpm --filter @dotobokuri/fleet-console build` — exit 0 (게시 external 게이트 포함)
- [x] `node scripts/check-core-boundary.mjs`, `node scripts/guard-fleet-agent-boundary.mjs` — exit 0
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK, 82 entries
- [x] **실 원격 세션 통합 테스트** — TLS 원격 리스너에 실제로 조인해 검증: 루프백은 기기명을 담은 `control:changed`를 받고, 회수 시 끊긴 세션만 `control:reclaimed`를 받으며, **원격은 보유자 프레임을 0회** 받는다. 거절된 링크가 보유자 퇴장 후 그대로 통하는 것도 확인.
- [x] **헤디드 실측** — 격리 콘솔에 실 원격 세션을 만들어 브라우저로 확인: 커튼 표시, `aria-modal=true`, `.console-shell` `inert=true`, z-index 100, 실 기기명 보간, 포커스가 주 액션에. *계속 지켜보기* → 커튼 제거·`inert=false`·바 표시. 회수 → 세션 종료·바 제거·칩 복귀. 모달이 없는 상태에서 바 버튼 히트테스트 통과.

## Changelog

- [x] `.changelog.d/remote-control-handover.md` — `fleet-console` Added ×3 / Fixed ×1, `fleet-desktop` Added ×1.
- 원격 접속 기능 자체가 아직 미릴리스이므로(`remote-access-auth-spine.md` 등이 `.changelog.d/`에 대기 중) 위 보안 게이트 수정은 사용자가 겪은 적 없는 동작이라 별도 `Fixed` 항목을 만들지 않았다. 터미널 항목만 릴리스된 결함이라 `Fixed`다.