### PR TITLE
fix(fleet-console): launch Canvas Opus as Claude Code opus[1m]

### DIFF
--- a/.changelog.d/canvas-opus-1m-alias.md
+++ b/.changelog.d/canvas-opus-1m-alias.md
@@ -4,5 +4,5 @@ branch: canvas-opus-1m-alias
 
 ### fleet-console
 #### Changed
-- Choosing Opus in Canvas controls now launches Claude Code's `opus[1m]` 1M-context alias. The dropdown still shows the plain `Opus` label, and a leftover bare `opus` selection, including one remembered by Quick Launch, is rewritten to `opus[1m]` before launch.
-  ko: 캔버스 제어에서 Opus를 고르면 Claude Code의 1M 컨텍스트 별칭인 `opus[1m]`으로 실행됩니다. 드롭다운 표시 이름은 그대로 `Opus`이며, Quick Launch에 남아 있던 기본 `opus` 선택을 포함해 남아 있던 `opus` 선택은 실행 전에 `opus[1m]`으로 바꿉니다.
+- Choosing Opus in Canvas controls now launches Claude Code's `opus[1m]` 1M-context alias. The dropdown still shows the plain `Opus` label, and a leftover bare `opus` selection - including one remembered by Quick Launch - is rewritten to `opus[1m]` when it is read and before launch.
+  ko: 캔버스 제어에서 Opus를 고르면 Claude Code의 1M 컨텍스트 별칭인 `opus[1m]`으로 실행됩니다. 드롭다운 표시 이름은 그대로 `Opus`이며, Quick Launch에 남아 있던 기본 `opus` 선택을 포함해 남아 있던 `opus` 선택은 읽을 때와 실행 전에 `opus[1m]`으로 바꿉니다.

--- a/.changelog.d/canvas-opus-1m-alias.md
+++ b/.changelog.d/canvas-opus-1m-alias.md
@@ -1,0 +1,8 @@
+---
+branch: canvas-opus-1m-alias
+---
+
+### fleet-console
+#### Changed
+- Choosing Opus in Canvas controls now launches Claude Code's `opus[1m]` 1M-context alias. The dropdown still shows the plain `Opus` label, and a leftover bare `opus` selection is rewritten to `opus[1m]` on launch.
+  ko: 캔버스 제어에서 Opus를 고르면 Claude Code의 1M 컨텍스트 별칭인 `opus[1m]`으로 실행됩니다. 드롭다운 표시 이름은 그대로 `Opus`이며, 남아 있던 기본 `opus` 선택도 실행 시 `opus[1m]`으로 바꿉니다.

--- a/.changelog.d/canvas-opus-1m-alias.md
+++ b/.changelog.d/canvas-opus-1m-alias.md
@@ -4,5 +4,5 @@ branch: canvas-opus-1m-alias
 
 ### fleet-console
 #### Changed
-- Choosing Opus in Canvas controls now launches Claude Code's `opus[1m]` 1M-context alias. The dropdown still shows the plain `Opus` label, and a leftover bare `opus` selection is rewritten to `opus[1m]` on launch.
-  ko: 캔버스 제어에서 Opus를 고르면 Claude Code의 1M 컨텍스트 별칭인 `opus[1m]`으로 실행됩니다. 드롭다운 표시 이름은 그대로 `Opus`이며, 남아 있던 기본 `opus` 선택도 실행 시 `opus[1m]`으로 바꿉니다.
+- Choosing Opus in Canvas controls now launches Claude Code's `opus[1m]` 1M-context alias. The dropdown still shows the plain `Opus` label, and a leftover bare `opus` selection, including one remembered by Quick Launch, is rewritten to `opus[1m]` before launch.
+  ko: 캔버스 제어에서 Opus를 고르면 Claude Code의 1M 컨텍스트 별칭인 `opus[1m]`으로 실행됩니다. 드롭다운 표시 이름은 그대로 `Opus`이며, Quick Launch에 남아 있던 기본 `opus` 선택을 포함해 남아 있던 `opus` 선택은 실행 전에 `opus[1m]`으로 바꿉니다.

--- a/packages/fleet-admiral/src/agent-cli/claude/definitions.ts
+++ b/packages/fleet-admiral/src/agent-cli/claude/definitions.ts
@@ -1,7 +1,24 @@
 import { createClaudeFamilyCliDefinition } from "./factory.js";
 
-export const NATIVE_CLAUDE_MODEL_ALIASES = ["fable", "opus", "sonnet"] as const;
+// Claude Code's bare `opus` alias is the default context window. Console's Opus
+// row launches the 1M coordinate (`opus[1m]`) while the menu label stays "Opus".
+export const NATIVE_CLAUDE_MODEL_ALIASES = ["fable", "opus[1m]", "sonnet"] as const;
 export const NATIVE_CLAUDE_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
+
+const NATIVE_CLAUDE_MODEL_ALIAS_REWRITES = {
+  opus: "opus[1m]",
+} as const satisfies Readonly<Record<string, (typeof NATIVE_CLAUDE_MODEL_ALIASES)[number]>>;
+
+/** Resolve a Console-native Claude Code model alias, rewriting legacy `opus` to `opus[1m]`. */
+export function resolveNativeClaudeModelAlias(
+  model: string,
+): (typeof NATIVE_CLAUDE_MODEL_ALIASES)[number] | undefined {
+  const rewritten =
+    NATIVE_CLAUDE_MODEL_ALIAS_REWRITES[model as keyof typeof NATIVE_CLAUDE_MODEL_ALIAS_REWRITES] ?? model;
+  return NATIVE_CLAUDE_MODEL_ALIASES.includes(rewritten as (typeof NATIVE_CLAUDE_MODEL_ALIASES)[number])
+    ? (rewritten as (typeof NATIVE_CLAUDE_MODEL_ALIASES)[number])
+    : undefined;
+}
 
 
 // Console Launch 전용: Admiral 시스템 프롬프트 없이 wiki 스킬·Console 훅·위키 MCP만 싣는 순정에 가까운 Claude Code.

--- a/packages/fleet-admiral/src/index.ts
+++ b/packages/fleet-admiral/src/index.ts
@@ -96,6 +96,7 @@ export {
 export {
   NATIVE_CLAUDE_EFFORTS,
   NATIVE_CLAUDE_MODEL_ALIASES,
+  resolveNativeClaudeModelAlias,
 } from "./agent-cli/claude/definitions.js";
 
 // Agent CLI 주입 능력 맵

--- a/packages/fleet-admiral/tests/native-claude-model-alias.test.ts
+++ b/packages/fleet-admiral/tests/native-claude-model-alias.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  NATIVE_CLAUDE_MODEL_ALIASES,
+  resolveNativeClaudeModelAlias,
+} from "../src/index.js";
+
+describe("resolveNativeClaudeModelAlias", () => {
+  it("keeps the Console-native Claude aliases as Claude Code launch ids", () => {
+    expect(NATIVE_CLAUDE_MODEL_ALIASES).toEqual(["fable", "opus[1m]", "sonnet"]);
+    expect(resolveNativeClaudeModelAlias("fable")).toBe("fable");
+    expect(resolveNativeClaudeModelAlias("opus[1m]")).toBe("opus[1m]");
+    expect(resolveNativeClaudeModelAlias("sonnet")).toBe("sonnet");
+  });
+
+  it("rewrites the bare opus menu alias onto Claude Code's 1M coordinate", () => {
+    expect(resolveNativeClaudeModelAlias("opus")).toBe("opus[1m]");
+  });
+
+  it("rejects unrecognized aliases", () => {
+    expect(resolveNativeClaudeModelAlias("haiku")).toBeUndefined();
+    expect(resolveNativeClaudeModelAlias("cursor--claude-opus-5")).toBeUndefined();
+  });
+});

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -85,13 +85,13 @@ export function QuickLaunch() {
   }, [open, state.activeTheaterId, theaters]);
 
   // 카탈로그가 도착하면 기억해 둔 조합을 실제 목록에 맞춘다.
+  // model/effort도 의존성에 둔다 — 재오픈이 bare opus를 잠깐 복원해도 정규화된 값으로 다시 맞춘다.
   useEffect(() => {
     if (!open || groups.length === 0) return;
     const resolved = resolveSelection(groups, { model, effort });
     if (resolved.model !== model) setModel(resolved.model);
     if (resolved.effort !== effort) setEffort(resolved.effort);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, groups]);
+  }, [open, groups, model, effort]);
 
   useEffect(() => {
     if (!open) return;

--- a/runtime/fleet-console/core/client/src/quick-launch-preferences.ts
+++ b/runtime/fleet-console/core/client/src/quick-launch-preferences.ts
@@ -25,15 +25,26 @@ export function readQuickLaunchSelection(): QuickLaunchSelection {
     const raw = window.localStorage.getItem(STORAGE_KEY);
     if (!raw) return EMPTY_QUICK_LAUNCH_SELECTION;
     const parsed = JSON.parse(raw) as Partial<Record<keyof QuickLaunchSelection, unknown>>;
-    return {
+    const selection = {
       theaterId: readNonEmptyString(parsed.theaterId),
-      model: readNonEmptyString(parsed.model),
+      model: migrateRememberedModel(readNonEmptyString(parsed.model)),
       effort: readNonEmptyString(parsed.effort),
     };
+    // Canvas/Quick Launch Opus now launches as `opus[1m]`. Rewrite a leftover bare
+    // `opus` once so a reopen does not restore a retired catalog id into React state.
+    if (selection.model !== readNonEmptyString(parsed.model)) {
+      writeQuickLaunchSelection(selection);
+    }
+    return selection;
   } catch {
     // 파싱 불가·스토리지 차단(사생활 보호 모드)은 "기억 없음"과 같은 상태다.
     return EMPTY_QUICK_LAUNCH_SELECTION;
   }
+}
+
+/** Bare `opus` was the pre-1M menu id; keep the same Opus row under `opus[1m]`. */
+function migrateRememberedModel(model: string | null): string | null {
+  return model === "opus" ? "opus[1m]" : model;
 }
 
 export function writeQuickLaunchSelection(selection: QuickLaunchSelection): void {

--- a/runtime/fleet-console/core/client/src/quick-launch.ts
+++ b/runtime/fleet-console/core/client/src/quick-launch.ts
@@ -48,6 +48,16 @@ export function findVariantLaunchKind(catalog: readonly OperationCatalogPlugin[]
 }
 
 /**
+ * Canvas/Quick Launch 메뉴의 Opus 행은 Claude Code `opus[1m]`을 쓴다. 업그레이드 전
+ * `fleet-console.quickLaunch.selection`에 남은 bare `opus`는 같은 행으로 이어 붙인다 —
+ * 브라우저 코드는 fleet-admiral를 끌어올 수 없어 서버의 resolveNativeClaudeModelAlias와
+ * 같은 한 줄만 복제한다.
+ */
+function normalizeRememberedNativeModel(model: string): string {
+  return model === "opus" ? "opus[1m]" : model;
+}
+
+/**
  * 기억해 둔 조합을 현재 카탈로그에 비추어 되살린다. 설정에서 모델을 끄거나 강도 사다리가 좁아지면
  * 기억은 낡은 값이 되므로, 여기서 걸러 ★기본 행으로 되돌린다 — 낡은 조합을 그대로 보내면 서버가
  * 409 gateway_model_not_enabled로 거절한다.
@@ -57,9 +67,12 @@ export function resolveSelection(
   remembered: { readonly model: string | null; readonly effort: string | null },
 ): ResolvedSelection {
   const rows = groups.flatMap((group) => group.rows);
-  const rememberedRow = remembered.model === null
+  const rememberedModel = remembered.model === null
+    ? null
+    : normalizeRememberedNativeModel(remembered.model);
+  const rememberedRow = rememberedModel === null
     ? undefined
-    : rows.find((row) => row.launch.model === remembered.model);
+    : rows.find((row) => row.launch.model === rememberedModel);
   const row = rememberedRow ?? rows.find((candidate) => candidate.starred) ?? rows[0];
   if (!row) return { model: null, effort: null, modelLabel: null, effortLabel: null };
   const chip = rememberedRow && remembered.effort !== null

--- a/runtime/fleet-console/tests/quick-launch.test.ts
+++ b/runtime/fleet-console/tests/quick-launch.test.ts
@@ -31,13 +31,13 @@ const GROUPS: readonly OperationLaunchVariantGroup[] = [
         ],
       },
       {
-        id: "opus",
+        id: "opus[1m]",
         label: "Opus",
         starred: true,
-        launch: { model: "opus" },
+        launch: { model: "opus[1m]" },
         chips: [
-          { id: "opus-high", label: "HIGH", launch: { model: "opus", effort: "high" } },
-          { id: "opus-xhigh", label: "XHIGH", launch: { model: "opus", effort: "xhigh" } },
+          { id: "opus-high", label: "HIGH", launch: { model: "opus[1m]", effort: "high" } },
+          { id: "opus-xhigh", label: "XHIGH", launch: { model: "opus[1m]", effort: "xhigh" } },
         ],
       },
     ],
@@ -85,7 +85,7 @@ describe("resolveSelection", () => {
   it("falls back to the starred row when the remembered model is no longer enabled", () => {
     // 설정에서 모델을 끄면 기억은 낡은 값이 된다 — 그대로 보내면 서버가 409 gateway_model_not_enabled로 거절한다.
     expect(resolveSelection(GROUPS, { model: "retired-model", effort: "high" })).toEqual({
-      model: "opus",
+      model: "opus[1m]",
       effort: null,
       modelLabel: "Opus",
       effortLabel: null,
@@ -93,16 +93,25 @@ describe("resolveSelection", () => {
   });
 
   it("drops a remembered effort the model's ladder no longer exposes", () => {
-    expect(resolveSelection(GROUPS, { model: "opus", effort: "low" })).toEqual({
-      model: "opus",
+    expect(resolveSelection(GROUPS, { model: "opus[1m]", effort: "low" })).toEqual({
+      model: "opus[1m]",
       effort: null,
       modelLabel: "Opus",
       effortLabel: null,
     });
   });
 
+  it("rewrites a saved bare opus selection onto the 1M coordinate", () => {
+    expect(resolveSelection(GROUPS, { model: "opus", effort: "high" })).toEqual({
+      model: "opus[1m]",
+      effort: "high",
+      modelLabel: "Opus",
+      effortLabel: "HIGH",
+    });
+  });
+
   it("uses the starred row when nothing is remembered", () => {
-    expect(resolveSelection(GROUPS, { model: null, effort: null })).toMatchObject({ model: "opus", effort: null });
+    expect(resolveSelection(GROUPS, { model: null, effort: null })).toMatchObject({ model: "opus[1m]", effort: null });
   });
 
   it("returns an empty selection when the catalog has no rows", () => {

--- a/runtime/fleet-console/tests/quick-launch.test.ts
+++ b/runtime/fleet-console/tests/quick-launch.test.ts
@@ -130,8 +130,21 @@ describe("quick launch preferences", () => {
   });
 
   it("round-trips the last selection", () => {
-    writeQuickLaunchSelection({ theaterId: "t1", model: "opus", effort: "xhigh" });
-    expect(readQuickLaunchSelection()).toEqual({ theaterId: "t1", model: "opus", effort: "xhigh" });
+    writeQuickLaunchSelection({ theaterId: "t1", model: "opus[1m]", effort: "xhigh" });
+    expect(readQuickLaunchSelection()).toEqual({ theaterId: "t1", model: "opus[1m]", effort: "xhigh" });
+  });
+
+  it("rewrites a leftover bare opus selection when it is read", () => {
+    window.localStorage.setItem(
+      "fleet-console.quickLaunch.selection",
+      JSON.stringify({ theaterId: "t1", model: "opus", effort: "high" }),
+    );
+    expect(readQuickLaunchSelection()).toEqual({ theaterId: "t1", model: "opus[1m]", effort: "high" });
+    expect(JSON.parse(window.localStorage.getItem("fleet-console.quickLaunch.selection")!)).toEqual({
+      theaterId: "t1",
+      model: "opus[1m]",
+      effort: "high",
+    });
   });
 
   it("reads an empty selection when nothing was stored", () => {

--- a/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
@@ -22,7 +22,8 @@ const EFFORT_LABELS: Readonly<Record<string, string>> = {
 
 const NATIVE_MODEL_LABELS: Readonly<Record<(typeof NATIVE_CLAUDE_MODEL_ALIASES)[number], string>> = {
   fable: "Fable",
-  opus: "Opus",
+  // Claude Code's 1M coordinate stays under the plain "Opus" menu label.
+  "opus[1m]": "Opus",
   sonnet: "Sonnet",
 };
 

--- a/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
@@ -15,9 +15,9 @@ import {
   injectAgentCliProfile,
   prepareAiGatewayLaunchProfile,
   NATIVE_CLAUDE_EFFORTS,
-  NATIVE_CLAUDE_MODEL_ALIASES,
   resolveAgentCliId,
   resolveAgentCliProfile,
+  resolveNativeClaudeModelAlias,
   type AgentCliId,
   type AgentCliProfile,
   LaunchPromptError,
@@ -227,21 +227,26 @@ async function createAgentCliLaunchSpec(options: {
       ? resolveAiGatewaySelection(options.readAiGatewaySettings())
       : undefined;
     let resolvedModel = options.model;
-    if (cliId === "claude-gateway" && resolvedModel && !NATIVE_CLAUDE_MODEL_ALIASES.includes(resolvedModel as (typeof NATIVE_CLAUDE_MODEL_ALIASES)[number])) {
-      const model = gatewaySelection?.models.find((candidate) => candidate.id === resolvedModel);
-      if (!model) {
-        throw new GatewayLaunchOptionError(
-          "gateway_model_not_enabled",
-          `Gateway model "${resolvedModel}" is not enabled.`,
-        );
+    if (cliId === "claude-gateway" && resolvedModel) {
+      const nativeAlias = resolveNativeClaudeModelAlias(resolvedModel);
+      if (nativeAlias) {
+        resolvedModel = nativeAlias;
+      } else {
+        const model = gatewaySelection?.models.find((candidate) => candidate.id === resolvedModel);
+        if (!model) {
+          throw new GatewayLaunchOptionError(
+            "gateway_model_not_enabled",
+            `Gateway model "${resolvedModel}" is not enabled.`,
+          );
+        }
+        if (options.effort !== undefined && (!gatewaySelection || !isGatewayLaunchEffortAllowed(gatewaySelection, model, options.effort))) {
+          throw new GatewayLaunchOptionError(
+            "invalid_effort",
+            `Gateway effort "${options.effort}" is not enabled for model "${resolvedModel}".`,
+          );
+        }
+        resolvedModel = toClaudeGatewayModelId(model);
       }
-      if (options.effort !== undefined && (!gatewaySelection || !isGatewayLaunchEffortAllowed(gatewaySelection, model, options.effort))) {
-        throw new GatewayLaunchOptionError(
-          "invalid_effort",
-          `Gateway effort "${options.effort}" is not enabled for model "${resolvedModel}".`,
-        );
-      }
-      resolvedModel = toClaudeGatewayModelId(model);
     }
     const profile = await options.resolveProfile(options.env, options.cwd, {
       cliId,

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import path from "node:path";
 import process from "node:process";
 
-import { buildGatewayModelsToolSpec, clampGoalCheckLimit, createDelayedPtyWriter, createFleetGatewayAgentRuntimeLifecycle, formatPtyMessage, getAgentCliIds, getAgentCliMetadata, MAX_GOAL_CONDITION_CHARS, LaunchPromptError, MAX_LAUNCH_PROMPT_CHARS, NATIVE_CLAUDE_EFFORTS, NATIVE_CLAUDE_MODEL_ALIASES, parseAgentCliId, sanitizeLaunchPrompt, sanitizePtyMessageText, type AgentCliId } from "@dotobokuri/fleet-admiral";
+import { buildGatewayModelsToolSpec, clampGoalCheckLimit, createDelayedPtyWriter, createFleetGatewayAgentRuntimeLifecycle, formatPtyMessage, getAgentCliIds, getAgentCliMetadata, MAX_GOAL_CONDITION_CHARS, LaunchPromptError, MAX_LAUNCH_PROMPT_CHARS, NATIVE_CLAUDE_EFFORTS, parseAgentCliId, resolveNativeClaudeModelAlias, sanitizeLaunchPrompt, sanitizePtyMessageText, type AgentCliId } from "@dotobokuri/fleet-admiral";
 import type { AgentToolSpec } from "@dotobokuri/core-agent";
 import { ensureWorkspaceDirectory, withDirectoryLock, type GlobalOptionsService } from "@dotobokuri/core-infra";
 import { createWikiWorkspaceResolver, getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
@@ -382,12 +382,13 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
       ctx.host.http.writeJson(res, 400, { error: "invalid_launch_option" });
       return false;
     }
-    if (NATIVE_CLAUDE_MODEL_ALIASES.includes(model as (typeof NATIVE_CLAUDE_MODEL_ALIASES)[number])) {
+    const nativeAlias = resolveNativeClaudeModelAlias(model);
+    if (nativeAlias) {
       if (effort !== undefined && !NATIVE_CLAUDE_EFFORTS.includes(effort as (typeof NATIVE_CLAUDE_EFFORTS)[number])) {
         ctx.host.http.writeJson(res, 400, { error: "invalid_effort" });
         return false;
       }
-      return { model, ...(effort === undefined ? {} : { effort }) };
+      return { model: nativeAlias, ...(effort === undefined ? {} : { effort }) };
     }
     const selection = resolveAiGatewaySelection(deps.readAiGatewaySettings?.());
     const gatewayModel = selection.models.find((candidate) => candidate.id === model);

--- a/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
@@ -12,7 +12,8 @@ const nativeVariants = {
   label: "Claude",
   rows: [
     nativeRow("fable", "Fable"),
-    nativeRow("opus", "Opus"),
+    // Claude Code's 1M coordinate launches under the plain "Opus" label.
+    nativeRow("opus[1m]", "Opus"),
     nativeRow("sonnet", "Sonnet"),
   ],
 };

--- a/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
@@ -153,6 +153,21 @@ describe("agent launch variants", () => {
     expect(resumeContext).not.toHaveProperty("effort");
   });
 
+  it("rewrites bare opus onto Claude Code's 1M coordinate before attach", async () => {
+    const harness = await createHarness({
+      body: { cliId: "claude-gateway", model: "opus", effort: "high" },
+    });
+
+    await harness.postSessions();
+
+    expect(harness.responses.at(-1)?.status).toBe(200);
+    expect(harness.attach).toHaveBeenCalledWith(expect.objectContaining({
+      cliId: "claude-gateway",
+      model: "opus[1m]",
+      effort: "high",
+    }));
+  });
+
   it("rejects a non-string prompt", async () => {
     const harness = await createHarness({
       body: { cliId: "claude-native", prompt: 12 },


### PR DESCRIPTION
## Summary
- Canvas controls keep the plain `Opus` dropdown label, but Claude (Gateway) now launches Claude Code's `opus[1m]` 1M-context alias.
- A leftover bare `opus` selection is rewritten to `opus[1m]` during launch validation so the menu and attach path stay aligned.
- Unit and dormant-ticket coverage lock both the label/launch split and the legacy rewrite.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-admiral build`
- [x] `pnpm --filter @dotobokuri/fleet-admiral typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-admiral exec vitest run tests/native-claude-model-alias.test.ts`
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `pnpm --filter @fleet-plugins/terminal build`
- [x] `pnpm --filter @fleet-plugins/terminal test -- agent-cli-launch-kinds.test.ts agent-dormant-ticket.test.ts`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] Changelog fragment: `.changelog.d/canvas-opus-1m-alias.md`