### PR TITLE
feat(fleet-console): animate effort track hover

### DIFF
--- a/.changelog.d/proposal-effort-bar-hover.md
+++ b/.changelog.d/proposal-effort-bar-hover.md
@@ -1,0 +1,8 @@
+---
+branch: proposal-effort-bar-hover
+---
+
+### fleet-console
+#### Changed
+- Preview the selectable reasoning-effort rung under the pointer, gently enlarge the track knob, and start a first-time Quick Launch on Opus.
+  ko: 포인터 아래 선택 가능한 추론 강도 단을 미리 표시하고 트랙 손잡이를 부드럽게 확대하며, Quick Launch의 최초 기본 모델을 Opus로 설정합니다.

--- a/runtime/fleet-console/core/client/src/components/effort-track.tsx
+++ b/runtime/fleet-console/core/client/src/components/effort-track.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, type KeyboardEvent, type PointerEvent } from "react";
+import { useCallback, useMemo, useRef, useState, type KeyboardEvent, type PointerEvent } from "react";
 
 import type { OperationLaunchVariantChip, OperationLaunchVariantRow } from "@fleet-console/sdk/operations";
 
@@ -31,6 +31,7 @@ export interface EffortTrackProps {
  */
 export function EffortTrack({ row, value, onChange, autoLabel, ariaLabel, autoValueText, className }: EffortTrackProps) {
   const trackRef = useRef<HTMLDivElement | null>(null);
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
 
   const slots = useMemo<readonly EffortSlot[]>(() => {
     const byId = new Map<string, OperationLaunchVariantChip>((row.chips ?? []).map((chip) => [chip.id, chip]));
@@ -63,15 +64,20 @@ export function EffortTrack({ row, value, onChange, autoLabel, ariaLabel, autoVa
     onChange(slot.id);
   }, [current.id, onChange, slots]);
 
-  const fromPointer = useCallback((event: PointerEvent<HTMLDivElement>) => {
+  const indexFromPointer = useCallback((clientX: number): number | null => {
     const track = trackRef.current;
-    if (!track || last === 0) return;
+    if (!track || last === 0) return null;
     const rect = track.getBoundingClientRect();
     const span = rect.width - EDGE * 2;
-    if (span <= 0) return;
-    const ratio = Math.max(0, Math.min((event.clientX - rect.left - EDGE) / span, 1));
-    commit(nearestSelectable(Math.round(ratio * last)));
-  }, [commit, last, nearestSelectable]);
+    if (span <= 0) return null;
+    const ratio = Math.max(0, Math.min((clientX - rect.left - EDGE) / span, 1));
+    return nearestSelectable(Math.round(ratio * last));
+  }, [last, nearestSelectable]);
+
+  const fromPointer = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    const next = indexFromPointer(event.clientX);
+    if (next !== null) commit(next);
+  }, [commit, indexFromPointer]);
 
   const handleKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
     const direction = event.key === "ArrowLeft" || event.key === "ArrowDown"
@@ -119,9 +125,13 @@ export function EffortTrack({ row, value, onChange, autoLabel, ariaLabel, autoVa
           fromPointer(event);
         }}
         onPointerMove={(event) => {
+          const next = indexFromPointer(event.clientX);
+          if (next !== null) setPreviewIndex(next);
           if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
           fromPointer(event);
         }}
+        onPointerLeave={() => setPreviewIndex(null)}
+        onPointerCancel={() => setPreviewIndex(null)}
       >
         {/* 자동은 폭 0이다. 손잡이 여백(EDGE)만큼이라도 남기면 트랙 왼쪽 끝에 brass 조각이 비쳐,
             비운 상태가 최소 강도를 고른 것처럼 보인다. */}
@@ -138,6 +148,7 @@ export function EffortTrack({ row, value, onChange, autoLabel, ariaLabel, autoVa
               style={{ left: last === 0 ? "50%" : `${(position / last) * 100}%` }}
               data-filled={position <= index && !isAuto ? true : undefined}
               data-gap={slot.selectable ? undefined : true}
+              data-previewed={position === previewIndex ? true : undefined}
             />
           ))}
         </span>

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -126,7 +126,7 @@ export function QuickLaunch() {
     const text = prompt.trim();
     // 상한을 넘긴 요청은 서버가 반드시 400으로 거절한다. 그대로 보내면 컴포저만 닫히고 초안이
     // 사라지므로, 확실히 실패할 요청으로는 넘기지 않는다.
-    if (text.length === 0 || text.length > QUICK_LAUNCH_PROMPT_MAX_CHARS || !theaterId || !target || submitting) return;
+    if (text.length === 0 || text.length > QUICK_LAUNCH_PROMPT_MAX_CHARS || !theaterId || !target || !selectedRow || submitting) return;
     setSubmitting(true);
     const variant: Record<string, string> = { prompt: text };
     if (model) variant.model = model;
@@ -138,7 +138,7 @@ export function QuickLaunch() {
     requestQuickLaunch({ theaterId, pluginId: target.pluginId, kind: target.kind, variant });
     navigate("/operations");
     closeQuickLaunch();
-  }, [effort, model, navigate, prompt, submitting, target, theaterId]);
+  }, [effort, model, navigate, prompt, selectedRow, submitting, target, theaterId]);
 
   const handleKeyDown = useCallback((event: ReactKeyboardEvent<HTMLElement>) => {
     if (event.key === "Escape") {
@@ -166,7 +166,7 @@ export function QuickLaunch() {
 
   const promptLength = prompt.trim().length;
   const overLimit = promptLength > QUICK_LAUNCH_PROMPT_MAX_CHARS;
-  const canSubmit = promptLength > 0 && !overLimit && !!theaterId && !!target && !submitting;
+  const canSubmit = promptLength > 0 && !overLimit && !!theaterId && !!target && !!selectedRow && !submitting;
   const modelLabel = selectedRow?.label ?? t("chrome.quickLaunch.modelUnset");
   const rejectionKey = quickLaunchErrorMessageKey(state.quickLaunchError, state.quickLaunchErrorShortenBy);
   // Prefer the selected model\'s provider mark. Falling back to the launch-kind

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -8,7 +8,7 @@ import { useConsoleState } from "../hooks/use-store.js";
 import { useT } from "../i18n/index.js";
 import { usePluginRegistry } from "../plugin-registry.js";
 import { readQuickLaunchSelection, writeQuickLaunchSelection } from "../quick-launch-preferences.js";
-import { findVariantLaunchKind, QUICK_LAUNCH_PROMPT_MAX_CHARS, quickLaunchErrorMessageKey, resolveSelection } from "../quick-launch.js";
+import { findVariantLaunchKind, QUICK_LAUNCH_DEFAULT_MODEL, QUICK_LAUNCH_PROMPT_MAX_CHARS, quickLaunchErrorMessageKey, resolveSelection } from "../quick-launch.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
 import { closeQuickLaunch, consumeQuickLaunchDraft, requestQuickLaunch, setActiveTheater } from "../store.js";
 import { launchProviderFromGroupId, launchProviderFromModelId, launchProviderGlyph } from "./launch-provider-glyphs.js";
@@ -38,7 +38,7 @@ export function QuickLaunch() {
   const [catalog, setCatalog] = useState<readonly OperationCatalogPlugin[]>([]);
   const [prompt, setPrompt] = useState("");
   const [theaterId, setTheaterId] = useState<string | null>(null);
-  const [model, setModel] = useState<string | null>(null);
+  const [model, setModel] = useState<string | null>(QUICK_LAUNCH_DEFAULT_MODEL);
   const [effort, setEffort] = useState<string | null>(null);
   const [popover, setPopover] = useState<PopoverKind | null>(null);
   const [popoverLeft, setPopoverLeft] = useState<number | null>(null);
@@ -79,7 +79,7 @@ export function QuickLaunch() {
     setPopover(null);
     setSubmitting(false);
     setTheaterId(rememberedTheater ?? state.activeTheaterId ?? theaters[0]?.id ?? null);
-    setModel(remembered.model);
+    setModel(remembered.model ?? QUICK_LAUNCH_DEFAULT_MODEL);
     setEffort(remembered.effort);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, state.activeTheaterId, theaters]);

--- a/runtime/fleet-console/core/client/src/quick-launch.ts
+++ b/runtime/fleet-console/core/client/src/quick-launch.ts
@@ -16,6 +16,7 @@ import type { OperationCatalogPlugin, OperationLaunchKind, OperationLaunchVarian
  * 실제 서버 상수와의 일치를 못 박는다.
  */
 export const QUICK_LAUNCH_PROMPT_MAX_CHARS = 16000;
+export const QUICK_LAUNCH_DEFAULT_MODEL = "opus[1m]";
 
 export interface VariantKindTarget {
   readonly pluginId: string;
@@ -58,9 +59,9 @@ function normalizeRememberedNativeModel(model: string): string {
 }
 
 /**
- * 기억해 둔 조합을 현재 카탈로그에 비추어 되살린다. 설정에서 모델을 끄거나 강도 사다리가 좁아지면
- * 기억은 낡은 값이 되므로, 여기서 걸러 ★기본 행으로 되돌린다 — 낡은 조합을 그대로 보내면 서버가
- * 409 gateway_model_not_enabled로 거절한다.
+ * 기억해 둔 조합을 현재 카탈로그에 비추어 되살린다. 처음 열었거나 기억이 낡았으면 native Opus를
+ * 기본으로 삼고, 그 행조차 없을 때만 ★행과 첫 행 순서로 물러난다 — 사용자가 Gateway 기본 모델을
+ * 바꿔도 Quick Launch의 첫 모델이 함께 흔들리지 않으며, 낡은 조합을 보내 생기는 409도 막는다.
  */
 export function resolveSelection(
   groups: readonly OperationLaunchVariantGroup[],
@@ -73,7 +74,10 @@ export function resolveSelection(
   const rememberedRow = rememberedModel === null
     ? undefined
     : rows.find((row) => row.launch.model === rememberedModel);
-  const row = rememberedRow ?? rows.find((candidate) => candidate.starred) ?? rows[0];
+  const row = rememberedRow
+    ?? rows.find((candidate) => candidate.launch.model === QUICK_LAUNCH_DEFAULT_MODEL)
+    ?? rows.find((candidate) => candidate.starred)
+    ?? rows[0];
   if (!row) return { model: null, effort: null, modelLabel: null, effortLabel: null };
   const chip = rememberedRow && remembered.effort !== null
     ? row.chips?.find((candidate) => candidate.launch.effort === remembered.effort)

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7513,7 +7513,10 @@
   margin: -1.5px 0 0 -1.5px;
   border-radius: 999px;
   background: var(--text-tertiary);
-  transition: background var(--duration-fast) var(--ease-spring);
+  transition:
+    transform var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring),
+    box-shadow var(--duration-fast) var(--ease-spring);
 }
 
 .effort-track-stop[data-filled="true"] {
@@ -7524,6 +7527,16 @@
 .effort-track-stop[data-gap="true"] {
   background: none;
   box-shadow: 0 0 0 1.5px color-mix(in oklch, var(--text-tertiary) 78%, transparent);
+}
+
+/* 포인터가 가리킨 자리 대신 실제로 선택될 가장 가까운 단을 미리 비춘다. 비어 있는 단은 이 상태를
+   받을 수 없어, preview와 click이 서로 다른 강도를 말하지 않는다. filled 상태 뒤에서 덮어야
+   현재 값의 왼쪽을 탐색할 때도 같은 brass preview가 보인다. */
+.effort-track-stop[data-previewed="true"] {
+  z-index: 1;
+  background: var(--brass);
+  box-shadow: 0 0 0 3px var(--brass-glow);
+  transform: scale(3);
 }
 
 .effort-track-knob {
@@ -7537,9 +7550,15 @@
   box-shadow: 0 1px 3px oklch(0% 0 0 / 55%);
   transition:
     left var(--duration-fast) var(--ease-spring),
+    transform var(--duration-fast) var(--ease-spring),
     background var(--duration-fast) var(--ease-spring),
     box-shadow var(--duration-fast) var(--ease-spring);
   pointer-events: none;
+}
+
+.effort-track:hover .effort-track-knob {
+  box-shadow: 0 2px 8px oklch(0% 0 0 / 62%);
+  transform: scale(1.1);
 }
 
 /* 값을 쥐지 않은 손잡이는 속이 비어 있다 — 꽉 찬 손잡이는 어느 자리에 있든 "이 단을 골랐다"로 읽힌다. */
@@ -11213,6 +11232,15 @@ body[data-codex-reading="true"] .operations-side-bar {
   .operation-launch-variant-effort-gauge rect {
     animation: none;
     transition: none;
+  }
+
+  .effort-track:hover .effort-track-knob,
+  .effort-track-stop[data-previewed="true"] {
+    transform: none;
+  }
+
+  .effort-track-stop[data-previewed="true"] {
+    box-shadow: 0 0 0 2px var(--brass);
   }
 }
 

--- a/runtime/fleet-console/tests/effort-track.test.tsx
+++ b/runtime/fleet-console/tests/effort-track.test.tsx
@@ -171,6 +171,30 @@ describe("EffortTrack", () => {
     document.body.removeEventListener("keydown", onMenuKey);
   });
 
+  it("previews the selectable rung that a pointer action would choose", () => {
+    const onChange = render(row(), "low");
+    Object.defineProperties(track(), {
+      getBoundingClientRect: {
+        configurable: true,
+        value: () => ({ left: 0, right: 126, top: 0, bottom: 26, width: 126, height: 26, x: 0, y: 0, toJSON: () => ({}) }),
+      },
+      hasPointerCapture: { configurable: true, value: () => false },
+    });
+
+    // medium(2) 자리를 가리켜도 이 모델이 실제로 고를 수 있는 가까운 low(1)를 비춘다.
+    act(() => track().dispatchEvent(new PointerEvent("pointermove", { bubbles: true, clientX: 53 })));
+    expect(stops().map((mark) => mark.dataset.previewed ?? null)).toEqual([null, "true", null, null, null, null]);
+    expect(onChange).not.toHaveBeenCalled();
+
+    // high(3)은 선택 가능하므로 그 자리 자체가 preview다.
+    act(() => track().dispatchEvent(new PointerEvent("pointermove", { bubbles: true, clientX: 73 })));
+    expect(stops().map((mark) => mark.dataset.previewed ?? null)).toEqual([null, null, null, "true", null, null]);
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => track().dispatchEvent(new PointerEvent("pointerout", { bubbles: true })));
+    expect(stops().every((mark) => mark.dataset.previewed === undefined)).toBe(true);
+  });
+
   it("marks only the top rung as the one at maximum", () => {
     render(row(), "max");
     expect(track().dataset.atMax).toBe("true");

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1635,6 +1635,26 @@ describe("Instrument core design contract", () => {
   });
 });
 
+describe("Effort track interaction grammar", () => {
+  it("pins the shared effort track's pointer preview motion", () => {
+    const components = source("styles/components.css");
+    const quickLaunch = source("components/quick-launch.tsx");
+    const canvasMenu = source("canvas/canvas-context-menu.tsx");
+    const preview = components.match(/\.effort-track-stop\[data-previewed="true"\] \{[^}]*\}/)?.[0] ?? "";
+    const knobHover = components.match(/\.effort-track:hover \.effort-track-knob \{[^}]*\}/)?.[0] ?? "";
+
+    // 한 공유 계기가 Quick Launch와 캔버스 실행 메뉴 양쪽의 hover 문법을 소유한다.
+    expect(quickLaunch).toContain("<EffortTrack");
+    expect(canvasMenu).toContain("<EffortTrack");
+    expect(preview).toContain("background: var(--brass)");
+    expect(preview).toContain("transform: scale(3)");
+    expect(knobHover).toContain("transform: scale(1.1)");
+    // 모션을 줄인 환경에서도 어떤 단을 가리키는지는 정적인 brass ring으로 남는다.
+    expect(components).toMatch(/@media \(prefers-reduced-motion: reduce\)[\s\S]*\.effort-track:hover \.effort-track-knob,[\s\S]*\.effort-track-stop\[data-previewed="true"\] \{\s*transform: none;/);
+    expect(components).toMatch(/@media \(prefers-reduced-motion: reduce\)[\s\S]*\.effort-track-stop\[data-previewed="true"\] \{\s*box-shadow: 0 0 0 2px var\(--brass\);/);
+  });
+});
+
 // War Room Quick-Look은 확대창 안의 프리뷰를 화면상 실물 크기(1:1)로 세운다. 배율 산술은
 // triage-deck-quicklook.test.ts가 고정하지만, 산술이 맞아도 배선이 끊기거나 전이 소유가 옮겨가면
 // 화면은 조용히 예전 동작 — 같은 축소판이 커지기만 하는 확대 — 으로 돌아간다.

--- a/runtime/fleet-console/tests/quick-launch-layout.test.tsx
+++ b/runtime/fleet-console/tests/quick-launch-layout.test.tsx
@@ -59,6 +59,13 @@ describe("Quick Launch effort surface", () => {
     expect(quickLaunch).toMatch(/selectedRow && \(selectedRow\.chips\?\.length \?\? 0\) > 0/u);
   });
 
+  it("waits for the seeded model to resolve against the catalog before submission", () => {
+    // 다른 plugin 카탈로그에 Opus가 없을 수 있다. passive 정규화 effect 전 한 프레임에서도 버튼과
+    // Enter 제출 모두 invalid opus[1m]을 보내면 안 되므로 같은 selectedRow gate를 공유한다.
+    expect(quickLaunch).toMatch(/\|\| !target \|\| !selectedRow \|\| submitting\) return;/u);
+    expect(quickLaunch).toMatch(/&& !!target && !!selectedRow && !submitting;/u);
+  });
+
   it("gives the track a fixed berth instead of letting it compete with the spacer", () => {
     // 남는 폭을 두고 겨루게 두면 트랙이 스톱 간격보다 좁아져 손잡이가 이웃 스톱을 덮는다.
     const rule = ruleFor(".quick-launch-effort-track");

--- a/runtime/fleet-console/tests/quick-launch.test.ts
+++ b/runtime/fleet-console/tests/quick-launch.test.ts
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import type { OperationCatalogPlugin, OperationLaunchVariantGroup } from "@fleet-console/sdk/operations";
 
 import { readQuickLaunchSelection, writeQuickLaunchSelection } from "../core/client/src/quick-launch-preferences.js";
-import { findVariantLaunchKind, QUICK_LAUNCH_PROMPT_MAX_CHARS, quickLaunchErrorMessageKey, resolveSelection } from "../core/client/src/quick-launch.js";
+import { findVariantLaunchKind, QUICK_LAUNCH_DEFAULT_MODEL, QUICK_LAUNCH_PROMPT_MAX_CHARS, quickLaunchErrorMessageKey, resolveSelection } from "../core/client/src/quick-launch.js";
 import { getState, removeTheater, setState } from "../core/client/src/store.js";
 import type { TheaterInfo } from "../core/client/src/types.js";
 
@@ -82,14 +82,34 @@ describe("resolveSelection", () => {
     });
   });
 
-  it("falls back to the starred row when the remembered model is no longer enabled", () => {
+  it("falls back to native Opus when the remembered model is no longer enabled", () => {
     // 설정에서 모델을 끄면 기억은 낡은 값이 된다 — 그대로 보내면 서버가 409 gateway_model_not_enabled로 거절한다.
     expect(resolveSelection(GROUPS, { model: "retired-model", effort: "high" })).toEqual({
-      model: "opus[1m]",
+      model: QUICK_LAUNCH_DEFAULT_MODEL,
       effort: null,
       modelLabel: "Opus",
       effortLabel: null,
     });
+  });
+
+  it("prefers native Opus over a starred Gateway default when nothing is remembered", () => {
+    const groups = [
+      {
+        id: "gateway",
+        label: "Gateway",
+        rows: [{ id: "kimi", label: "Kimi", starred: true, launch: { model: "kimi" } }],
+      },
+      ...GROUPS,
+    ];
+    expect(resolveSelection(groups, { model: null, effort: null })).toMatchObject({
+      model: QUICK_LAUNCH_DEFAULT_MODEL,
+      modelLabel: "Opus",
+    });
+  });
+
+  it("uses the starred row only when native Opus is absent", () => {
+    const groups = [{ id: "gateway", label: "Gateway", rows: [{ id: "kimi", label: "Kimi", starred: true, launch: { model: "kimi" } }] }];
+    expect(resolveSelection(groups, { model: null, effort: null })).toMatchObject({ model: "kimi", modelLabel: "Kimi" });
   });
 
   it("drops a remembered effort the model's ladder no longer exposes", () => {
@@ -110,8 +130,8 @@ describe("resolveSelection", () => {
     });
   });
 
-  it("uses the starred row when nothing is remembered", () => {
-    expect(resolveSelection(GROUPS, { model: null, effort: null })).toMatchObject({ model: "opus[1m]", effort: null });
+  it("uses native Opus when nothing is remembered", () => {
+    expect(resolveSelection(GROUPS, { model: null, effort: null })).toMatchObject({ model: QUICK_LAUNCH_DEFAULT_MODEL, effort: null });
   });
 
   it("returns an empty selection when the catalog has no rows", () => {


### PR DESCRIPTION
## Summary
- preview the selectable reasoning-effort rung under the pointer and gently enlarge the shared knob in Quick Launch and canvas launch controls
- preserve click/drag commit behavior and retain static brass feedback under reduced motion
- default a first-time or stale Quick Launch selection to native Opus while preserving valid remembered selections

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/quick-launch.test.ts tests/quick-launch-layout.test.tsx tests/effort-track.test.tsx tests/canvas-context-menu-anchor.test.tsx tests/instrument-design-contract.test.ts` (121 passed)
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] isolated production browser measurement and headed user verification
- [x] changelog fragment: `.changelog.d/proposal-effort-bar-hover.md`