### PR TITLE
fix(fleet-console): retain and center Quick Launch choices

### DIFF
--- a/.changelog.d/quick-launch-composer.md
+++ b/.changelog.d/quick-launch-composer.md
@@ -10,8 +10,10 @@ branch: quick-launch-composer
   ko: 모델과 추론 강도를 컴포저 안에서 그대로 고릅니다. 모델은 팝오버에서, 강도는 모델 칩 옆 트랙에서 정합니다.
 - Aim a launch at any Theater, not only the one on screen, and read which Theater it will land in from the chip the composer opens with. Choosing another Theater switches to it and brings up the new Operation there.
   ko: 화면에 떠 있는 Theater뿐 아니라 어느 Theater로든 실행을 겨눕니다. 어디로 갈지는 컴포저가 열릴 때 띄우는 칩에서 바로 읽히고, 다른 Theater를 고르면 그쪽으로 전환하며 새 Operation을 그 자리에 띄웁니다.
-- Reuse the last Theater, model and reasoning effort you launched with, so a repeat launch is one shortcut and one sentence.
-  ko: 마지막으로 실행한 Theater·모델·추론 강도를 그대로 다시 씁니다. 반복 실행은 단축키 하나와 문장 하나로 끝납니다.
+- Reuse the last Theater, model and reasoning effort you selected, even after closing the composer without launching, so a repeat launch is one shortcut and one sentence.
+  ko: 실행하지 않고 컴포저를 닫아도 마지막으로 고른 Theater·모델·추론 강도를 그대로 다시 씁니다. 반복 실행은 단축키 하나와 문장 하나로 끝납니다.
+- Keep the composer centered horizontally and vertically in the Console viewport instead of anchoring it near the top edge.
+  ko: 컴포저를 화면 위쪽에 붙이지 않고 Console 화면의 가로·세로 정중앙에 표시합니다.
 - Open the composer while a terminal has focus; the shortcut is not swallowed by the Operation you are looking at.
   ko: 터미널에 포커스가 있는 상태에서도 컴포저가 열립니다. 보고 있던 Operation이 단축키를 삼키지 않습니다.
 - Keep the composer and its draft open when a prompt is too long, and refuse a prompt that a Windows command shim would rewrite before the agent reads it, instead of launching with corrupted text.

--- a/.changelog.d/quick-launch-composer.md
+++ b/.changelog.d/quick-launch-composer.md
@@ -10,8 +10,8 @@ branch: quick-launch-composer
   ko: 모델과 추론 강도를 컴포저 안에서 그대로 고릅니다. 모델은 팝오버에서, 강도는 모델 칩 옆 트랙에서 정합니다.
 - Aim a launch at any Theater, not only the one on screen, and read which Theater it will land in from the chip the composer opens with. Choosing another Theater switches to it and brings up the new Operation there.
   ko: 화면에 떠 있는 Theater뿐 아니라 어느 Theater로든 실행을 겨눕니다. 어디로 갈지는 컴포저가 열릴 때 띄우는 칩에서 바로 읽히고, 다른 Theater를 고르면 그쪽으로 전환하며 새 Operation을 그 자리에 띄웁니다.
-- Reuse the last Theater, model and reasoning effort you selected, even after closing the composer without launching, so a repeat launch is one shortcut and one sentence.
-  ko: 실행하지 않고 컴포저를 닫아도 마지막으로 고른 Theater·모델·추론 강도를 그대로 다시 씁니다. 반복 실행은 단축키 하나와 문장 하나로 끝납니다.
+- Reuse the last Theater you launched in and the last model and reasoning effort you selected, even after closing the composer without launching, so a repeat launch is one shortcut and one sentence.
+  ko: 마지막으로 실행한 Theater와 마지막으로 고른 모델·추론 강도를 다시 씁니다. 실행하지 않고 컴포저를 닫아도 모델·강도 선택은 유지되어, 반복 실행은 단축키 하나와 문장 하나로 끝납니다.
 - Keep the composer centered horizontally and vertically in the Console viewport instead of anchoring it near the top edge.
   ko: 컴포저를 화면 위쪽에 붙이지 않고 Console 화면의 가로·세로 정중앙에 표시합니다.
 - Open the composer while a terminal has focus; the shortcut is not swallowed by the Operation you are looking at.

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -256,7 +256,10 @@ export function QuickLaunch() {
             <EffortTrack
               row={selectedRow}
               value={effort}
-              onChange={setEffort}
+              onChange={(nextEffort) => {
+                setEffort(nextEffort);
+                writeQuickLaunchSelection({ theaterId, model, effort: nextEffort });
+              }}
               autoLabel={t("launchVariants.effort.auto")}
               ariaLabel={t("launchVariants.effort.track")}
               autoValueText={t("launchVariants.effort.autoValue")}
@@ -350,9 +353,11 @@ export function QuickLaunch() {
                       row={row}
                       selectedModel={model}
                       onPick={(nextModel) => {
-                        setModel(nextModel);
                         // 새 모델의 사다리에 없는 강도는 들고 갈 수 없다 — 비운 상태로 떨어진다.
-                        setEffort(resolveRowEffort(row, effort));
+                        const nextEffort = resolveRowEffort(row, effort);
+                        setModel(nextModel);
+                        setEffort(nextEffort);
+                        writeQuickLaunchSelection({ theaterId, model: nextModel, effort: nextEffort });
                         closePopover();
                         inputRef.current?.focus();
                       }}

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -7,7 +7,7 @@ import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 import { useConsoleState } from "../hooks/use-store.js";
 import { useT } from "../i18n/index.js";
 import { usePluginRegistry } from "../plugin-registry.js";
-import { readQuickLaunchSelection, writeQuickLaunchSelection } from "../quick-launch-preferences.js";
+import { readQuickLaunchSelection, writeQuickLaunchModelEffort, writeQuickLaunchSelection } from "../quick-launch-preferences.js";
 import { findVariantLaunchKind, QUICK_LAUNCH_DEFAULT_MODEL, QUICK_LAUNCH_PROMPT_MAX_CHARS, quickLaunchErrorMessageKey, resolveSelection } from "../quick-launch.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
 import { closeQuickLaunch, consumeQuickLaunchDraft, requestQuickLaunch, setActiveTheater } from "../store.js";
@@ -42,6 +42,8 @@ export function QuickLaunch() {
   const [effort, setEffort] = useState<string | null>(null);
   const [popover, setPopover] = useState<PopoverKind | null>(null);
   const [popoverLeft, setPopoverLeft] = useState<number | null>(null);
+  const [popoverMaxHeight, setPopoverMaxHeight] = useState<number | null>(null);
+  const [viewportEpoch, setViewportEpoch] = useState(0);
   const [submitting, setSubmitting] = useState(false);
 
   const open = state.quickLaunchOpen;
@@ -110,15 +112,32 @@ export function QuickLaunch() {
   useLayoutEffect(() => {
     if (!popover) {
       setPopoverLeft(null);
+      setPopoverMaxHeight(null);
       return;
     }
     const chip = (popover === "theater" ? theaterChipRef : modelChipRef).current;
     const bar = barRef.current;
-    if (!chip || !bar) return;
-    const width = bar.querySelector<HTMLElement>(".quick-launch-pop")?.getBoundingClientRect().width ?? 0;
+    const pop = bar?.querySelector<HTMLElement>(".quick-launch-pop");
+    if (!chip || !bar || !pop) return;
+    const width = pop.getBoundingClientRect().width;
     // 칩이 오른쪽으로 밀려 있어도 팝오버는 카드 안에 머문다.
     setPopoverLeft(Math.max(0, Math.min(chip.offsetLeft, bar.clientWidth - width - POPOVER_GAP)));
+    const top = pop.getBoundingClientRect().top;
+    const safePadding = parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--space-5")) || 0;
+    setPopoverMaxHeight(Math.max(0, window.innerHeight - top - safePadding));
+  }, [popover, prompt, groups.length, theaters.length, viewportEpoch]);
+
+  useEffect(() => {
+    if (!popover) return;
+    const handleResize = () => setViewportEpoch((epoch) => epoch + 1);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
   }, [popover]);
+
+  const updatePrompt = useCallback((nextPrompt: string, element: HTMLTextAreaElement) => {
+    setPrompt(nextPrompt);
+    autoGrow(element);
+  }, []);
 
   const closePopover = useCallback(() => setPopover(null), []);
 
@@ -202,10 +221,7 @@ export function QuickLaunch() {
             className="quick-launch-input"
             rows={1}
             value={prompt}
-            onChange={(event) => {
-              setPrompt(event.target.value);
-              autoGrow(event.target);
-            }}
+            onChange={(event) => updatePrompt(event.target.value, event.target)}
             onKeyDown={handleInputKeyDown}
             placeholder={t("chrome.quickLaunch.placeholder")}
             aria-label={t("chrome.quickLaunch.promptLabel")}
@@ -258,7 +274,7 @@ export function QuickLaunch() {
               value={effort}
               onChange={(nextEffort) => {
                 setEffort(nextEffort);
-                writeQuickLaunchSelection({ theaterId, model, effort: nextEffort });
+                writeQuickLaunchModelEffort(model, nextEffort);
               }}
               autoLabel={t("launchVariants.effort.auto")}
               ariaLabel={t("launchVariants.effort.track")}
@@ -302,7 +318,7 @@ export function QuickLaunch() {
               className="quick-launch-pop quick-launch-pop--theater theater-menu"
               role="menu"
               aria-label={t("chrome.quickLaunch.theaterMenu")}
-              style={popoverLeft === null ? undefined : { left: popoverLeft }}
+              style={{ ...(popoverLeft === null ? {} : { left: popoverLeft }), ...(popoverMaxHeight === null ? {} : { "--quick-launch-pop-max-height": `${popoverMaxHeight}px` }) }}
             >
               {theaters.map((theater) => (
                 <button
@@ -330,7 +346,7 @@ export function QuickLaunch() {
               className="quick-launch-pop quick-launch-pop--model theater-menu"
               role="menu"
               aria-label={t("chrome.quickLaunch.modelMenu")}
-              style={popoverLeft === null ? undefined : { left: popoverLeft }}
+              style={{ ...(popoverLeft === null ? {} : { left: popoverLeft }), ...(popoverMaxHeight === null ? {} : { "--quick-launch-pop-max-height": `${popoverMaxHeight}px` }) }}
             >
               {groups.map((group) => (
                 <div key={group.id} className="quick-launch-pop-group">
@@ -357,7 +373,7 @@ export function QuickLaunch() {
                         const nextEffort = resolveRowEffort(row, effort);
                         setModel(nextModel);
                         setEffort(nextEffort);
-                        writeQuickLaunchSelection({ theaterId, model: nextModel, effort: nextEffort });
+                        writeQuickLaunchModelEffort(nextModel, nextEffort);
                         closePopover();
                         inputRef.current?.focus();
                       }}

--- a/runtime/fleet-console/core/client/src/quick-launch-preferences.ts
+++ b/runtime/fleet-console/core/client/src/quick-launch-preferences.ts
@@ -55,6 +55,11 @@ export function writeQuickLaunchSelection(selection: QuickLaunchSelection): void
   }
 }
 
+export function writeQuickLaunchModelEffort(model: string | null, effort: string | null): void {
+  const remembered = readQuickLaunchSelection();
+  writeQuickLaunchSelection({ ...remembered, model, effort });
+}
+
 function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
 }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -11138,14 +11138,14 @@ body[data-codex-reading="true"] .operations-side-bar {
 }
 
 /* 팝오버는 .theater-menu의 팝업 스킨(테두리·언더레이·그림자)을 상속하고 위치·폭만 덮는다.
-   카드는 화면 위쪽(14vh)에 고정이라 팝오버는 항상 아래로 연다 — 위로 열면 뷰포트 밖으로 잘린다. */
+   카드는 뷰포트 중앙에 두고 팝오버는 아래로 열되, 카드 중심선부터 아래 여백을 계산해 화면 안에서 자른다. */
 .quick-launch-pop {
   top: calc(100% + var(--space-2));
   right: auto;
   bottom: auto;
   left: var(--space-4);
   z-index: 41;
-  max-height: 340px;
+  max-height: min(340px, calc(50vh - 64px - var(--space-2) - var(--space-5)));
   overflow-y: auto;
 }
 

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -11145,7 +11145,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   bottom: auto;
   left: var(--space-4);
   z-index: 41;
-  max-height: min(340px, calc(50vh - 64px - var(--space-2) - var(--space-5)));
+  max-height: min(340px, var(--quick-launch-pop-max-height, 340px));
   overflow-y: auto;
 }
 

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -10939,16 +10939,16 @@ body[data-codex-reading="true"] .operations-side-bar {
 }
 
 /* ── Quick Launch 컴포저 ──────────────────────────────────────────────
-   전역 단축키(Mod+J)로 열리는 프롬프트 컴포저. 오버레이 지오메트리와 스크림은
-   .operation-search-overlay의 계약을 그대로 승계한다 — 두 표면은 서로 배타적이며
-   (isBlockingDialogOpen이 aria-modal로 판정) 같은 z-index 층에 산다. */
+   전역 단축키(Mod+J)로 열리는 프롬프트 컴포저. 화면 중앙에 서되 스크림과 z-index는
+   .operation-search-overlay의 계약을 승계한다 — 두 표면은 서로 배타적이다
+   (isBlockingDialogOpen이 aria-modal로 판정). */
 .quick-launch-overlay {
   position: fixed;
   inset: 0;
   z-index: 90;
   display: grid;
-  place-items: start center;
-  padding: 14vh var(--space-5) var(--space-5);
+  place-items: center;
+  padding: var(--space-5);
   background: color-mix(in oklch, var(--ink-abyss) 66%, transparent);
   animation: fleet-pop 280ms var(--ease-spring) both;
 }

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -99,6 +99,8 @@ const RUNTIME_CUSTOM_PROPERTY_ALLOWLIST = new Set([
   "--ws-dock-files-width",
   // Canvas context menu TSX injects the viewport-derived height ceiling for its own box.
   "--canvas-menu-max-height",
+  // Quick Launch TSX injects the viewport-derived height ceiling for its open popover.
+  "--quick-launch-pop-max-height",
   // Triage Watch Deck TSX injects the grid-capped quick-look magnification at hover time.
   "--triage-quicklook-scale",
   // Watch Deck zoom tween injects card column/row sizing each frame.

--- a/runtime/fleet-console/tests/quick-launch-layout.test.tsx
+++ b/runtime/fleet-console/tests/quick-launch-layout.test.tsx
@@ -15,6 +15,12 @@ describe("Quick Launch composer layout", () => {
     expect(overlay).not.toMatch(/14vh/u);
   });
 
+  it("clamps the downward popover to the viewport while retaining its cap", () => {
+    const pop = ruleFor(".quick-launch-pop");
+    expect(pop).toMatch(/max-height:\s*min\(340px,\s*calc\(50vh\s*-\s*64px\s*-\s*var\(--space-2\)\s*-\s*var\(--space-5\)\)\);/u);
+    expect(pop).toMatch(/overflow-y:\s*auto;/u);
+  });
+
   it("keeps the model popover at its measured compact width", () => {
     expect(css).toMatch(/\.quick-launch-pop--model\s*\{[^}]*width:\s*216px;/u);
   });

--- a/runtime/fleet-console/tests/quick-launch-layout.test.tsx
+++ b/runtime/fleet-console/tests/quick-launch-layout.test.tsx
@@ -17,7 +17,10 @@ describe("Quick Launch composer layout", () => {
 
   it("clamps the downward popover to the viewport while retaining its cap", () => {
     const pop = ruleFor(".quick-launch-pop");
-    expect(pop).toMatch(/max-height:\s*min\(340px,\s*calc\(50vh\s*-\s*64px\s*-\s*var\(--space-2\)\s*-\s*var\(--space-5\)\)\);/u);
+    expect(pop).toMatch(/max-height:\s*min\(340px,\s*var\(--quick-launch-pop-max-height,\s*340px\)\);/u);
+    expect(quickLaunch).toMatch(/getBoundingClientRect\(\)\.top/iu);
+    expect(quickLaunch).toMatch(/window\.innerHeight\s*-\s*top\s*-\s*safePadding/u);
+    expect(quickLaunch).not.toMatch(/50vh|64px/u);
     expect(pop).toMatch(/overflow-y:\s*auto;/u);
   });
 
@@ -73,8 +76,8 @@ describe("Quick Launch effort surface", () => {
   });
 
   it("writes the normalized model and effort at selection time", () => {
-    expect(quickLaunch).toMatch(/const nextEffort = resolveRowEffort\(row, effort\);[\s\S]*setModel\(nextModel\);[\s\S]*setEffort\(nextEffort\);[\s\S]*writeQuickLaunchSelection\(\{ theaterId, model: nextModel, effort: nextEffort \}\);/u);
-    expect(quickLaunch).toMatch(/onChange=\{\(nextEffort\) => \{[\s\S]*setEffort\(nextEffort\);[\s\S]*writeQuickLaunchSelection\(\{ theaterId, model, effort: nextEffort \}\);/u);
+    expect(quickLaunch).toMatch(/const nextEffort = resolveRowEffort\(row, effort\);[\s\S]*setModel\(nextModel\);[\s\S]*setEffort\(nextEffort\);[\s\S]*writeQuickLaunchModelEffort\(nextModel, nextEffort\);/u);
+    expect(quickLaunch).toMatch(/onChange=\{\(nextEffort\) => \{[\s\S]*setEffort\(nextEffort\);[\s\S]*writeQuickLaunchModelEffort\(model, nextEffort\);/u);
   });
 
   it("waits for the seeded model to resolve against the catalog before submission", () => {

--- a/runtime/fleet-console/tests/quick-launch-layout.test.tsx
+++ b/runtime/fleet-console/tests/quick-launch-layout.test.tsx
@@ -8,6 +8,13 @@ const css = readFileSync(resolve(process.cwd(), "core/client/src/styles/componen
 const quickLaunch = readFileSync(resolve(process.cwd(), "core/client/src/components/quick-launch.tsx"), "utf8");
 
 describe("Quick Launch composer layout", () => {
+  it("centers the overlay with symmetric viewport padding", () => {
+    const overlay = ruleFor(".quick-launch-overlay");
+    expect(overlay).toMatch(/place-items:\s*center;/u);
+    expect(overlay).toMatch(/padding:\s*var\(--space-5\);/u);
+    expect(overlay).not.toMatch(/14vh/u);
+  });
+
   it("keeps the model popover at its measured compact width", () => {
     expect(css).toMatch(/\.quick-launch-pop--model\s*\{[^}]*width:\s*216px;/u);
   });
@@ -57,6 +64,11 @@ describe("Quick Launch effort surface", () => {
   it("folds the track away for a model with no ladder", () => {
     // 조작할 수 없는 컨트롤이 자리를 지키면 바가 고장 난 것처럼 읽힌다.
     expect(quickLaunch).toMatch(/selectedRow && \(selectedRow\.chips\?\.length \?\? 0\) > 0/u);
+  });
+
+  it("writes the normalized model and effort at selection time", () => {
+    expect(quickLaunch).toMatch(/const nextEffort = resolveRowEffort\(row, effort\);[\s\S]*setModel\(nextModel\);[\s\S]*setEffort\(nextEffort\);[\s\S]*writeQuickLaunchSelection\(\{ theaterId, model: nextModel, effort: nextEffort \}\);/u);
+    expect(quickLaunch).toMatch(/onChange=\{\(nextEffort\) => \{[\s\S]*setEffort\(nextEffort\);[\s\S]*writeQuickLaunchSelection\(\{ theaterId, model, effort: nextEffort \}\);/u);
   });
 
   it("waits for the seeded model to resolve against the catalog before submission", () => {

--- a/runtime/fleet-console/tests/quick-launch.test.ts
+++ b/runtime/fleet-console/tests/quick-launch.test.ts
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import type { OperationCatalogPlugin, OperationLaunchVariantGroup } from "@fleet-console/sdk/operations";
 
-import { readQuickLaunchSelection, writeQuickLaunchSelection } from "../core/client/src/quick-launch-preferences.js";
+import { readQuickLaunchSelection, writeQuickLaunchModelEffort, writeQuickLaunchSelection } from "../core/client/src/quick-launch-preferences.js";
 import { findVariantLaunchKind, QUICK_LAUNCH_DEFAULT_MODEL, QUICK_LAUNCH_PROMPT_MAX_CHARS, quickLaunchErrorMessageKey, resolveSelection } from "../core/client/src/quick-launch.js";
 import { getState, removeTheater, setState } from "../core/client/src/store.js";
 import type { TheaterInfo } from "../core/client/src/types.js";
@@ -152,6 +152,18 @@ describe("quick launch preferences", () => {
   it("round-trips the last selection", () => {
     writeQuickLaunchSelection({ theaterId: "t1", model: "opus[1m]", effort: "xhigh" });
     expect(readQuickLaunchSelection()).toEqual({ theaterId: "t1", model: "opus[1m]", effort: "xhigh" });
+  });
+
+  it("updates model and effort without replacing the last launched Theater", () => {
+    writeQuickLaunchSelection({ theaterId: "launched", model: "opus[1m]", effort: "high" });
+
+    writeQuickLaunchModelEffort("codex--gpt-5.6-luna-fast", "max");
+
+    expect(readQuickLaunchSelection()).toEqual({
+      theaterId: "launched",
+      model: "codex--gpt-5.6-luna-fast",
+      effort: "max",
+    });
   });
 
   it("rewrites a leftover bare opus selection when it is read", () => {


### PR DESCRIPTION
## Summary
- persist Quick Launch model and effort selections immediately so closing without launching does not reset them
- center the Quick Launch composer horizontally and vertically in the Console viewport
- amend the unreleased Quick Launch release note and add focused regression coverage

## Test Plan
- [x] `pnpm --dir runtime/fleet-console exec vitest run tests/quick-launch-layout.test.tsx tests/quick-launch.test.ts`
- [x] `pnpm --dir runtime/fleet-console typecheck`
- [x] `pnpm --dir runtime/fleet-console build`
- [x] independent review ran Quick Launch, Operation Search, focus, and design-contract tests
- [x] isolated browser E2E restored `GPT-5.6-Luna-Fast` / `MAX` after close and measured the card at 0px offset from both viewport center axes
- [x] `node scripts/compile-changelog-fragments.mjs --check`

Changelog-Amend: quick-launch-composer.md