### PR TITLE
refactor(fleet-console): gather remote-access state under one directory

### DIFF
--- a/.agents/skills/console-e2e/references/remote-access-testing.md
+++ b/.agents/skills/console-e2e/references/remote-access-testing.md
@@ -105,7 +105,7 @@ The browser side is where the guest becomes visible. Settings -> Remote access -
 
 A connected device reads `Connected now` and carries **two** buttons — disconnect (reversible) and remove (permanent). After a disconnect the row stays, its time cell becomes relative, and only remove is left. A row that vanishes on disconnect is the old contract returning.
 
-Check `paired-devices.json` under the isolated `FLEET_CONSOLE_DIR` too: it must contain the device but never the cookie secret.
+Check `remote/paired-devices.json` under the isolated `FLEET_CONSOLE_DIR` too: it must contain the device but never the cookie secret.
 
 ## The curtain will block your clicks
 

--- a/runtime/fleet-console/core/host/paired-devices.ts
+++ b/runtime/fleet-console/core/host/paired-devices.ts
@@ -1,8 +1,8 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
-import path from "node:path";
 
 import type { AccessAudience, AccessClass } from "./auth.js";
+import { createRemoteStorage, type RemoteStorageDeps } from "./remote-storage.js";
 
 /**
  * 액세스 링크가 만든 페어링. 링크 자체는 여전히 1회용이지만, 그 교환으로 생긴 이 기록은
@@ -43,16 +43,14 @@ export interface PairedDeviceStore {
   revokeAll(audience: AccessAudience): readonly PairedDevice[];
 }
 
-export interface PairedDeviceStoreDeps {
-  readonly fileSystem?: Pick<typeof fs, "mkdirSync" | "readFileSync" | "renameSync" | "writeFileSync">;
+export interface PairedDeviceStoreDeps extends RemoteStorageDeps {
+  readonly readFile?: (file: string) => string;
   readonly now?: () => number;
   readonly randomId?: () => string;
   readonly randomSecret?: () => string;
 }
 
 const DEVICES_FILE = "paired-devices.json";
-const FILE_MODE = 0o600;
-const DIR_MODE = 0o700;
 const STORE_VERSION = 1;
 /** 한 콘솔이 기억하는 페어링 수. 상한에 닿으면 조용히 밀어내지 않고 거절한다. */
 export const PAIRED_DEVICE_LIMIT = 64;
@@ -77,17 +75,17 @@ export function hashPairingSecret(secret: string): string {
 }
 
 export function createPairedDeviceStore(consoleDir: string, deps: PairedDeviceStoreDeps = {}): PairedDeviceStore {
-  const fileSystem = deps.fileSystem ?? fs;
+  const storage = createRemoteStorage(consoleDir, deps);
+  const readFile = deps.readFile ?? ((file: string) => fs.readFileSync(file, "utf8"));
   const now = deps.now ?? Date.now;
   const randomId = deps.randomId ?? (() => crypto.randomBytes(8).toString("hex"));
   const randomSecret = deps.randomSecret ?? (() => crypto.randomBytes(32).toString("base64url"));
-  const file = path.join(consoleDir, DEVICES_FILE);
   let devices: StoredDevice[] = read();
   let flushedAt = now();
 
   function read(): StoredDevice[] {
     try {
-      const parsed = JSON.parse(fileSystem.readFileSync(file, "utf8")) as StoredFile;
+      const parsed = JSON.parse(readFile(storage.path(DEVICES_FILE))) as StoredFile;
       if (parsed?.version !== STORE_VERSION || !Array.isArray(parsed.devices)) return [];
       return parsed.devices.filter(isStoredDevice).slice(0, MAX_DEVICES);
     } catch {
@@ -97,10 +95,7 @@ export function createPairedDeviceStore(consoleDir: string, deps: PairedDeviceSt
 
   function write(): void {
     const body: StoredFile = { version: STORE_VERSION, devices };
-    const temporary = `${file}.tmp`;
-    fileSystem.mkdirSync(consoleDir, { recursive: true, mode: DIR_MODE });
-    fileSystem.writeFileSync(temporary, `${JSON.stringify(body, null, 2)}\n`, { encoding: "utf8", mode: FILE_MODE });
-    fileSystem.renameSync(temporary, file);
+    storage.write(DEVICES_FILE, `${JSON.stringify(body, null, 2)}\n`);
     flushedAt = now();
   }
 

--- a/runtime/fleet-console/core/host/remote-hosts.ts
+++ b/runtime/fleet-console/core/host/remote-hosts.ts
@@ -1,8 +1,8 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
-import path from "node:path";
 
 import { sanitizeAccessLabel, type ValidatedAccessLink } from "./access-link.js";
+import { createRemoteStorage, type RemoteStorageDeps } from "./remote-storage.js";
 
 /**
  * 이 콘솔에서 건너갈 수 있는 다른 콘솔들. 사용자가 액세스 링크를 붙여넣으면 여기에 남고,
@@ -42,15 +42,14 @@ export interface RemoteHostStore {
   takeHandoff(origin: string): RemoteHostHandoff | null;
 }
 
-export interface RemoteHostStoreDeps {
-  readonly fileSystem?: Pick<typeof fs, "mkdirSync" | "readFileSync" | "renameSync" | "writeFileSync">;
+export interface RemoteHostStoreDeps extends RemoteStorageDeps {
+  readonly readFile?: (file: string) => string;
   readonly now?: () => number;
   readonly randomId?: () => string;
 }
 
-const HOSTS_FILE = "remote-hosts.json";
-const FILE_MODE = 0o600;
-const DIR_MODE = 0o700;
+/** SSH의 known_hosts와 같은 뜻이다 — 이 콘솔이 아는 상대와, 그 상대에게 기대하는 신원. */
+const HOSTS_FILE = "known-hosts.json";
 const STORE_VERSION = 1;
 const MAX_HOSTS = 64;
 /** 붙여넣은 링크를 실제로 여는 데 걸리는 시간. 그 창을 넘기면 토큰은 버려진다. */
@@ -62,16 +61,16 @@ interface StoredFile {
 }
 
 export function createRemoteHostStore(consoleDir: string, deps: RemoteHostStoreDeps = {}): RemoteHostStore {
-  const fileSystem = deps.fileSystem ?? fs;
+  const storage = createRemoteStorage(consoleDir, deps);
+  const readFile = deps.readFile ?? ((file: string) => fs.readFileSync(file, "utf8"));
   const now = deps.now ?? Date.now;
   const randomId = deps.randomId ?? (() => crypto.randomUUID());
-  const file = path.join(consoleDir, HOSTS_FILE);
   const pending = new Map<string, { readonly token: string; readonly expiresAt: number }>();
   let hosts: RemoteHostRecord[] = read();
 
   function read(): RemoteHostRecord[] {
     try {
-      const parsed = JSON.parse(fileSystem.readFileSync(file, "utf8")) as StoredFile;
+      const parsed = JSON.parse(readFile(storage.path(HOSTS_FILE))) as StoredFile;
       if (parsed?.version !== STORE_VERSION || !Array.isArray(parsed.hosts)) return [];
       return parsed.hosts.filter(isRecord).slice(0, MAX_HOSTS);
     } catch {
@@ -81,10 +80,7 @@ export function createRemoteHostStore(consoleDir: string, deps: RemoteHostStoreD
 
   function write(): void {
     const body: StoredFile = { version: STORE_VERSION, hosts };
-    const temporary = `${file}.tmp`;
-    fileSystem.mkdirSync(consoleDir, { recursive: true, mode: DIR_MODE });
-    fileSystem.writeFileSync(temporary, `${JSON.stringify(body, null, 2)}\n`, { encoding: "utf8", mode: FILE_MODE });
-    fileSystem.renameSync(temporary, file);
+    storage.write(HOSTS_FILE, `${JSON.stringify(body, null, 2)}\n`);
   }
 
   return {

--- a/runtime/fleet-console/core/host/remote-identity.ts
+++ b/runtime/fleet-console/core/host/remote-identity.ts
@@ -1,10 +1,10 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
-import path from "node:path";
 
 import selfsigned from "selfsigned";
 
 import { normalizeFingerprint } from "./access-link.js";
+import { createRemoteStorage, type RemoteStorageDeps } from "./remote-storage.js";
 
 /**
  * 원격 리스너의 신원. 액세스 링크가 이 지문을 함께 실어 나르고, Desktop이 접속 직전
@@ -20,8 +20,8 @@ export interface RemoteIdentity {
   readonly expiresAt: number;
 }
 
-export interface RemoteIdentityStoreDeps {
-  readonly fileSystem?: Pick<typeof fs, "existsSync" | "mkdirSync" | "readFileSync" | "writeFileSync" | "renameSync" | "rmSync">;
+export interface RemoteIdentityStoreDeps extends RemoteStorageDeps {
+  readonly readFile?: (file: string) => string;
   readonly generate?: (host: string) => Promise<{ readonly certificatePem: string; readonly privateKeyPem: string }>;
   readonly now?: () => number;
 }
@@ -34,12 +34,9 @@ export interface RemoteIdentityStore {
   rotate(host: string): Promise<RemoteIdentity>;
 }
 
-const IDENTITY_DIR = "remote";
 const CERTIFICATE_FILE = "identity-cert.pem";
 const KEY_FILE = "identity-key.pem";
 const META_FILE = "identity.json";
-const FILE_MODE = 0o600;
-const DIR_MODE = 0o700;
 const VALIDITY_DAYS = 825;
 // 만료 직전에 새로 만들지 않으면 원격 접속이 어느 날 갑자기 끊긴다.
 const RENEW_BEFORE_MS = 30 * 24 * 60 * 60 * 1000;
@@ -51,16 +48,16 @@ interface StoredMeta {
 }
 
 export function createRemoteIdentityStore(consoleDir: string, deps: RemoteIdentityStoreDeps = {}): RemoteIdentityStore {
-  const fileSystem = deps.fileSystem ?? fs;
+  const storage = createRemoteStorage(consoleDir, deps);
+  const readFile = deps.readFile ?? ((file: string) => fs.readFileSync(file, "utf8"));
   const generate = deps.generate ?? generateSelfSignedCertificate;
   const now = deps.now ?? Date.now;
-  const directory = path.join(consoleDir, IDENTITY_DIR);
 
   function read(): RemoteIdentity | null {
     try {
-      const meta = JSON.parse(fileSystem.readFileSync(path.join(directory, META_FILE), "utf8")) as StoredMeta;
-      const certificatePem = fileSystem.readFileSync(path.join(directory, CERTIFICATE_FILE), "utf8");
-      const privateKeyPem = fileSystem.readFileSync(path.join(directory, KEY_FILE), "utf8");
+      const meta = JSON.parse(readFile(storage.path(META_FILE))) as StoredMeta;
+      const certificatePem = readFile(storage.path(CERTIFICATE_FILE));
+      const privateKeyPem = readFile(storage.path(KEY_FILE));
       if (typeof meta?.host !== "string" || typeof meta.expiresAt !== "number") return null;
       return { certificatePem, privateKeyPem, fingerprint: fingerprintOf(certificatePem), createdAt: meta.createdAt, expiresAt: meta.expiresAt };
     } catch {
@@ -80,25 +77,18 @@ export function createRemoteIdentityStore(consoleDir: string, deps: RemoteIdenti
     const createdAt = now();
     // 만료는 인증서 자신이 정한다. 별도로 계산해 두면 둘이 어긋나 어느 날 조용히 끊긴다.
     const expiresAt = Date.parse(new crypto.X509Certificate(certificatePem).validTo);
-    fileSystem.mkdirSync(directory, { recursive: true, mode: DIR_MODE });
-    writeSecret(path.join(directory, KEY_FILE), privateKeyPem);
-    writeSecret(path.join(directory, CERTIFICATE_FILE), certificatePem);
-    writeSecret(path.join(directory, META_FILE), `${JSON.stringify({ host, createdAt, expiresAt } satisfies StoredMeta)}\n`);
+    storage.write(KEY_FILE, privateKeyPem);
+    storage.write(CERTIFICATE_FILE, certificatePem);
+    storage.write(META_FILE, `${JSON.stringify({ host, createdAt, expiresAt } satisfies StoredMeta)}\n`);
     return { certificatePem, privateKeyPem, fingerprint: fingerprintOf(certificatePem), createdAt, expiresAt };
   }
 
   function readMeta(): StoredMeta | null {
     try {
-      return JSON.parse(fileSystem.readFileSync(path.join(directory, META_FILE), "utf8")) as StoredMeta;
+      return JSON.parse(readFile(storage.path(META_FILE))) as StoredMeta;
     } catch {
       return null;
     }
-  }
-
-  function writeSecret(file: string, content: string): void {
-    const temporary = `${file}.tmp`;
-    fileSystem.writeFileSync(temporary, content, { encoding: "utf8", mode: FILE_MODE });
-    fileSystem.renameSync(temporary, file);
   }
 
   return { ensure, read, rotate };

--- a/runtime/fleet-console/core/host/remote-storage.ts
+++ b/runtime/fleet-console/core/host/remote-storage.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { ensureSafeDirectory } from "@dotobokuri/core-infra";
+
+/**
+ * 원격 접속이 디스크에 남기는 것은 전부 이 디렉터리 하나에 모인다 — 이 콘솔의 신원,
+ * 그 신원을 보고 붙은 기기들, 그리고 이 콘솔이 건너갈 다른 콘솔들.
+ *
+ * 한자리에 두는 이유는 이들의 수명이 하나로 묶여 있기 때문이다. 신원을 갈아 끼우면 그
+ * 신원을 근거로 붙던 페어링이 함께 무효가 되고, 원격을 끄고 흔적을 지우는 일은 이
+ * 디렉터리 하나를 지우는 일이다. 콘솔 데이터 루트에 흩어 두면 무엇을 함께 거둬야 하는지가
+ * 코드를 따라 읽어야만 드러난다.
+ *
+ * 방향은 디렉터리가 아니라 이름이 가른다: `paired-devices`는 이리로 들어오는 기기,
+ * `known-hosts`는 이 콘솔이 건너가는 상대다.
+ */
+const REMOTE_DIR = "remote";
+const FILE_MODE = 0o600;
+
+export type RemoteStorageFs = Pick<typeof fs, "renameSync" | "writeFileSync">;
+
+export interface RemoteStorageDeps {
+  readonly fileSystem?: RemoteStorageFs;
+  /** 실제 디스크를 건드리지 않는 테스트가 갈아 끼우는 자리. */
+  readonly ensureDirectory?: (directory: string) => void;
+}
+
+export interface RemoteStorage {
+  path(file: string): string;
+  write(file: string, content: string): void;
+}
+
+export function createRemoteStorage(consoleDir: string, deps: RemoteStorageDeps = {}): RemoteStorage {
+  const fileSystem = deps.fileSystem ?? fs;
+  /**
+   * 매 쓰기마다 다시 확인한다. 만들 때 한 번만 0700을 주면 그 뒤에 느슨해진 권한을 되돌릴
+   * 길이 없는데, 이 디렉터리에는 리스너의 개인키가 있다. 콘솔 데이터 루트가 durable state
+   * 쓰기마다 같은 방식으로 굳는 것과 같은 계약이며, 심볼릭링크로 바꿔치기된 디렉터리는
+   * 여기서 걸린다.
+   */
+  const ensureDirectory = deps.ensureDirectory ?? ensureSafeDirectory;
+  const directory = path.join(consoleDir, REMOTE_DIR);
+
+  return {
+    path: (file) => path.join(directory, file),
+
+    /**
+     * temp+rename으로 갈아 끼운다. 쓰는 도중에 끊겨도 반쯤 쓰인 파일이 자리를 차지하지 않는다.
+     * 파일은 만들어질 때부터 0600이어야 한다 — 나중에 고치면 그사이에 열린 파일이 있다.
+     */
+    write(file, content) {
+      const target = path.join(directory, file);
+      const temporary = `${target}.tmp`;
+      ensureDirectory(directory);
+      fileSystem.writeFileSync(temporary, content, { encoding: "utf8", mode: FILE_MODE });
+      fileSystem.renameSync(temporary, target);
+    },
+  };
+}

--- a/runtime/fleet-console/tests/remote-access-listener.test.ts
+++ b/runtime/fleet-console/tests/remote-access-listener.test.ts
@@ -643,7 +643,7 @@ describe.skipIf(REMOTE_HOST === null)("remote access listener", () => {
     const secret = /fleet_console_pairing_\d+=([^;]+)/u.exec(cookies)?.[1];
     expect(secret).toBeTruthy();
 
-    const stored = fs.readFileSync(path.join(fixture.dir, "fleet-home", "console", "paired-devices.json"), "utf8");
+    const stored = fs.readFileSync(path.join(fixture.dir, "fleet-home", "console", "remote", "paired-devices.json"), "utf8");
 
     expect(stored).not.toContain(secret!);
     expect(JSON.parse(stored)).toMatchObject({ version: 1, devices: [{ device: "MacBook Pro", access: "full" }] });

--- a/runtime/fleet-console/tests/remote-hosts.test.ts
+++ b/runtime/fleet-console/tests/remote-hosts.test.ts
@@ -23,13 +23,13 @@ function createHarness(start = 10_000) {
   let current = start;
   let counter = 0;
   const deps: RemoteHostStoreDeps = {
+    ensureDirectory: () => undefined,
+    readFile: (file: string) => {
+      const found = files.get(file);
+      if (found === undefined) throw new Error("ENOENT");
+      return found;
+    },
     fileSystem: {
-      mkdirSync: () => undefined,
-      readFileSync: ((file: string) => {
-        const found = files.get(file);
-        if (found === undefined) throw new Error("ENOENT");
-        return found;
-      }) as never,
       writeFileSync: ((file: string, content: string) => { files.set(file, content); }) as never,
       renameSync: ((from: string, to: string) => {
         files.set(to, files.get(from) ?? "");
@@ -43,7 +43,7 @@ function createHarness(start = 10_000) {
     deps,
     files,
     advance: (ms: number) => { current += ms; },
-    stored: () => files.get("/console/remote-hosts.json") ?? "",
+    stored: () => files.get("/console/remote/known-hosts.json") ?? "",
     open: () => createRemoteHostStore("/console", deps),
   };
 }
@@ -139,14 +139,14 @@ describe("remote host store", () => {
 
   it("starts empty rather than throwing on a file it cannot read", () => {
     const harness = createHarness();
-    harness.files.set("/console/remote-hosts.json", "{ not json");
+    harness.files.set("/console/remote/known-hosts.json", "{ not json");
 
     expect(harness.open().list()).toEqual([]);
   });
 
   it("drops entries that lost their shape instead of trusting them", () => {
     const harness = createHarness();
-    harness.files.set("/console/remote-hosts.json", JSON.stringify({
+    harness.files.set("/console/remote/known-hosts.json", JSON.stringify({
       version: 1,
       hosts: [
         { id: "keep", label: "ok", origin: "https://a.test:4310", hostname: "a.test", port: 4310, fingerprint: FINGERPRINT_A, addedAt: 1, lastOpenedAt: null },

--- a/runtime/fleet-console/tests/remote-identity.test.ts
+++ b/runtime/fleet-console/tests/remote-identity.test.ts
@@ -6,6 +6,9 @@ import tls from "node:tls";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import { encodeAccessLink, parseAccessLink } from "../core/host/access-link.js";
+import { createPairedDeviceStore } from "../core/host/paired-devices.js";
+import { createRemoteHostStore } from "../core/host/remote-hosts.js";
 import { createRemoteIdentityStore, fingerprintOf, fingerprintsMatch, normalizeFingerprint } from "../core/host/remote-identity.js";
 
 const tempDirs: string[] = [];
@@ -73,6 +76,45 @@ describe("remote identity store", () => {
     const mode = fs.statSync(path.join(dir, "remote", "identity-key.pem")).mode & 0o777;
 
     expect(mode).toBe(0o600);
+  });
+
+  /**
+   * 만들 때 한 번 0700을 주는 것으로는 부족하다 — 그 뒤에 느슨해진 권한을 되돌릴 길이 없는데
+   * 이 디렉터리에는 리스너의 개인키가 있다. 콘솔 데이터 루트가 durable state를 쓸 때마다
+   * 같은 방식으로 굳는 것과 같은 계약이다.
+   */
+  it("hardens the remote directory again on every write, not only when it creates it", async () => {
+    const dir = createDir();
+    const store = createRemoteIdentityStore(dir);
+    await store.ensure("127.0.0.1");
+    const remoteDir = path.join(dir, "remote");
+    fs.chmodSync(remoteDir, 0o755);
+
+    await store.rotate("127.0.0.1");
+
+    expect(fs.statSync(remoteDir).mode & 0o777).toBe(0o700);
+  });
+
+  /** 신원과 페어링과 상대 목록은 함께 거둬지므로 한 디렉터리에 산다. */
+  it("keeps every remote-access file in one directory", async () => {
+    const dir = createDir();
+    await createRemoteIdentityStore(dir).ensure("127.0.0.1");
+    createPairedDeviceStore(dir).pair({ audience: "remote", access: "full", device: "MacBook Pro" });
+    createRemoteHostStore(dir).remember(parseAccessLink(encodeAccessLink({
+      endpoint: "https://100.84.12.7:6768",
+      token: "sEPaty9_Yzq-N46FjCUfme4_DrCZeYlTitGcbWd8kLA",
+      fingerprint: "8D3FBB2A855053305C32280A2ABB566FFF9C5B14C353AE0527092ED476CBB70F",
+      label: "devbox",
+    })));
+
+    expect(fs.readdirSync(dir)).toEqual(["remote"]);
+    expect(fs.readdirSync(path.join(dir, "remote")).sort()).toEqual([
+      "identity-cert.pem",
+      "identity-key.pem",
+      "identity.json",
+      "known-hosts.json",
+      "paired-devices.json",
+    ]);
   });
 
   it("rotates on request and leaves the previous fingerprint behind", async () => {


### PR DESCRIPTION
## Summary

- 원격 접속이 디스크에 남기는 것을 전부 `<consoleDir>/remote/` 한 디렉터리로 모았습니다. `remote/`는 원격 호스트 기능이 인증서와 개인키를 담으려고 만들었지만, 같은 시점의 `remote-hosts.json`과 이후 추가된 `paired-devices.json`은 콘솔 루트에 평평하게 놓여 있었습니다. 세 스토어가 각자 콘솔 루트를 받아 경로를 스스로 정하고 있어 `remote/`를 소유한 코드가 없었던 것이 원인입니다. 신원을 갱신하면 그 신원을 근거로 붙던 페어링이 함께 무효가 되므로(`revokeAll("remote")`), 함께 거둬지는 것은 한자리에 있어야 합니다.
- 레이아웃과 쓰기 규약을 소유하는 `remote-storage.ts`를 두고 세 스토어가 이를 경유하게 했습니다. `remote-hosts.json`은 `known-hosts.json`으로 개명했습니다 — `remote/` 안에서 `remote-` 접두사는 중복이고, 들어오는 기기(`paired-devices`)와 건너가는 상대(`known-hosts`)를 이름으로 가르는 편이 방향이 분명합니다. HTTP 경로 `/api/v1/remote-hosts`는 Desktop이 소비하는 표면이라 그대로 둡니다.
- 옮기면서 드러난 결함을 함께 고쳤습니다. 세 스토어의 `mkdirSync(dir, { mode: 0o700 })`는 한 번도 효과가 없었습니다 — POSIX에서 mode는 생성 시점에만 적용되는데 콘솔 루트는 durable state가 이미 만들어 둔 뒤였습니다. 콘솔 루트는 `ensureSafeDirectory`가 쓰기마다 0700으로 되돌려 주어 결과적으로 안전했지만 `remote/`는 그 보호를 받지 못합니다. 리스너의 개인키가 있는 디렉터리이므로 같은 헬퍼를 거치게 해 매 쓰기마다 0700으로 굳고 심볼릭 링크 바꿔치기도 걸리도록 했습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console test` — 1762 passed / 24 skipped
- [x] `pnpm -r --filter '!fleet-harness' typecheck` — 전체 통과
- [x] `pnpm -r --filter '!fleet-harness' test` — 워크스페이스 전체 통과
- [x] `pnpm check:core-boundary` — 통과
- [x] 권한 자가 복구 회귀 테스트가 실제로 결함을 잡는지 확인 — 옛 생성 시 1회 방식으로 되돌리면 0755로 남아 실패

Changelog-Impact: none
No-Changelog-Reason: internal-refactor

원격 접속 기능 자체가 아직 릴리스되지 않았고 이 변경은 그 미출시 기능의 내부 파일 배치와 디렉터리 권한 처리만 바꾸므로, 사용자가 인지할 수 있는 동작 변화가 없습니다.