### PR TITLE
fix(fleet-console): keep panel minimize state across console switches

### DIFF
--- a/.changelog.d/panel-state-across-consoles.md
+++ b/.changelog.d/panel-state-across-consoles.md
@@ -1,0 +1,8 @@
+---
+branch: panel-state-across-consoles
+---
+
+### fleet-console
+#### Changed
+- Fleet Console now counts "the first time each Theater opens in a session" against the browser tab session rather than the page load, so panels you expanded stay expanded when you move between the local console and a remote one, or reload the page. Opening a console for the first time in a tab still starts its existing panels minimized, and a freshly opened tab starts clean again.
+  ko: Fleet Console이 "세션 중 각 Theater를 처음 여는 시점"을 페이지 로드가 아니라 브라우저 탭 세션 기준으로 셉니다. 그래서 로컬 콘솔과 원격 콘솔을 오가거나 페이지를 새로고침해도 펼쳐 둔 패널이 접히지 않습니다. 한 탭에서 처음 여는 콘솔은 여전히 기존 패널을 최소화한 채 시작하고, 새로 연 탭은 다시 깨끗하게 시작합니다.

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -17,6 +17,7 @@ import { OperationSearch } from "./components/operation-search.js";
 import { QuickLaunch } from "./components/quick-launch.js";
 import { ReconnectButton } from "./components/reconnect-button.js";
 import { Toast, ToastHost } from "./components/toast.js";
+import { claimTheaterBootMinimization } from "./boot-minimization-session.js";
 import { appendPendingDeletion, deletionCountdownSeconds, latestPendingDeletion } from "./deletion-undo.js";
 import { WhatsNewModal } from "./components/whatsnew-modal.js";
 import { FloatingWidgetLayer } from "./floating-widget-layer.js";
@@ -47,7 +48,6 @@ const THEME_NOTICE_AUTO_DISMISS_MS = 8_000;
 
 export function App() {
   const state = useConsoleState();
-  const minimizedTheatersRef = useRef<Set<string>>(new Set());
   const bootOperationIdsRef = useRef<readonly string[] | null>(null);
   const location = useLocation();
   const registry = usePluginRegistry();
@@ -125,13 +125,14 @@ export function App() {
       : []) ?? [];
   }, [consoleLocale, registry.operationKinds, state.activeOperationId, state.operations]);
 
-  // 세션 중 각 Theater를 처음 여는 시점에 한 번, 그 Theater의 "부팅 시점에 이미 존재하던" 패널 집합을 최소화 대상으로 반환한다.
+  // 브라우저 세션 중 각 Theater를 처음 여는 시점에 한 번, 그 Theater의 "부팅 시점에 이미 존재하던" 패널 집합을 최소화 대상으로 반환한다.
   // App boot의 활성 Theater뿐 아니라 이후 선택·전환으로 처음 진입하는 Theater도 깨끗하게 열려, 선택한 패널만 하나씩 표면화된다.
+  // "처음"의 기준은 페이지 수명이 아니라 탭 세션이다 — 콘솔 전환·새로고침으로 같은 탭에 돌아왔을 때
+  // 사용자가 펼쳐둔 패널을 다시 접지 않기 위해서다.
   // 반환값은 전 Theater를 아우르는 초기 id 목록이고, 실제 최소화는 호출 측이 현재 Theater 패널로 좁힌다.
   const claimBootPanelMinimization = useCallback((theaterId: string): readonly string[] | null => {
     if (bootOperationIdsRef.current === null) return null;
-    if (minimizedTheatersRef.current.has(theaterId)) return null;
-    minimizedTheatersRef.current.add(theaterId);
+    if (!claimTheaterBootMinimization(theaterId)) return null;
     return bootOperationIdsRef.current;
   }, []);
 

--- a/runtime/fleet-console/core/client/src/boot-minimization-session.ts
+++ b/runtime/fleet-console/core/client/src/boot-minimization-session.ts
@@ -1,0 +1,70 @@
+/**
+ * "이 Theater는 이번 세션에 이미 깨끗하게 열었다"는 사실만 담는다. 부팅 최소화는 Theater마다 세션 중
+ * 한 번이어야 하는데, 그 "한 번"을 페이지 수명으로 세면 콘솔 전환이 새 부팅으로 잡힌다 — 로컬↔원격
+ * 이동은 origin을 건너뛰는 전체 페이지 이동이라 모듈 메모리가 통째로 사라지기 때문이다. 표식을
+ * sessionStorage에 적으면 같은 탭에 머무는 한 살아남아, 콘솔을 오가도 사용자가 펼쳐둔 패널이 다시
+ * 접히지 않는다.
+ *
+ * localStorage가 아닌 이유: 탭을 새로 열거나 콘솔을 다시 시작하면 다시 깨끗한 Map으로 시작해야 한다.
+ *
+ * 알려진 경계: 브라우저는 탭 복제나 opener가 있는 새 창에 sessionStorage를 복사해 준다. 그렇게 갈라져
+ * 나온 탭은 원본의 표식을 물려받아 부팅 최소화를 건너뛴다 — 복제한 탭이 원본과 같은 화면으로 열리는
+ * 것은 복제의 뜻에 맞으므로 그대로 둔다. 주소창에서 새로 연 탭은 복사본을 받지 않아 깨끗하게 열린다.
+ */
+
+/** 테스트가 탭 세션의 생존을 직접 다룰 수 있도록 열어 둔다 — 키 문자열을 양쪽에 베끼지 않기 위해서다. */
+export const BOOT_MINIMIZATION_STORAGE_KEY = "fleet.console.boot-minimized-theaters";
+
+// sessionStorage를 쓸 수 없는 브라우저에서도 한 페이지 안에서는 종전처럼 한 번만 접도록 남기는 대비책.
+const inMemory = new Set<string>();
+
+/**
+ * 이 Theater의 부팅 최소화 권리를 한 번만 내준다. 처음 여는 것이면 `true`를 돌려주며 표식을 남기고,
+ * 이번 세션에 이미 열었던 Theater면 `false`를 돌려준다.
+ */
+export function claimTheaterBootMinimization(theaterId: string): boolean {
+  const opened = readOpenedTheaters();
+  if (opened.has(theaterId)) return false;
+  opened.add(theaterId);
+  writeOpenedTheaters(opened);
+  return true;
+}
+
+/** 테스트가 세션을 다시 시작한 상태로 되돌린다. */
+export function resetBootMinimizationSession(): void {
+  inMemory.clear();
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(BOOT_MINIMIZATION_STORAGE_KEY);
+  } catch {
+    // 저장소 접근 실패는 메모리 집합만으로도 회복되므로 흐름을 막지 않는다.
+  }
+}
+
+function readOpenedTheaters(): Set<string> {
+  const opened = new Set(inMemory);
+  if (typeof window === "undefined") return opened;
+  try {
+    const stored = window.sessionStorage.getItem(BOOT_MINIMIZATION_STORAGE_KEY);
+    if (!stored) return opened;
+    const parsed: unknown = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return opened;
+    for (const entry of parsed) {
+      if (typeof entry === "string" && entry.length > 0) opened.add(entry);
+    }
+  } catch {
+    // 읽기 실패는 "아직 열지 않았다"로 수렴한다 — 최악이라도 종전의 깨끗한 열기로 돌아갈 뿐이다.
+  }
+  return opened;
+}
+
+function writeOpenedTheaters(opened: ReadonlySet<string>): void {
+  inMemory.clear();
+  for (const theaterId of opened) inMemory.add(theaterId);
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(BOOT_MINIMIZATION_STORAGE_KEY, JSON.stringify([...opened]));
+  } catch {
+    // 저장 실패는 콘솔 전환 시 패널이 다시 접히는 정도의 손실이라 런타임 흐름을 막지 않는다.
+  }
+}

--- a/runtime/fleet-console/tests/boot-minimization-session.test.ts
+++ b/runtime/fleet-console/tests/boot-minimization-session.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BOOT_MINIMIZATION_STORAGE_KEY, claimTheaterBootMinimization, resetBootMinimizationSession } from "../core/client/src/boot-minimization-session.js";
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+  resetBootMinimizationSession();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.sessionStorage.clear();
+  resetBootMinimizationSession();
+});
+
+describe("boot minimization session", () => {
+  it("hands the claim to the first open of a Theater and refuses the next one", () => {
+    expect(claimTheaterBootMinimization("theater-a")).toBe(true);
+    expect(claimTheaterBootMinimization("theater-a")).toBe(false);
+  });
+
+  it("tracks Theaters independently", () => {
+    expect(claimTheaterBootMinimization("theater-a")).toBe(true);
+    expect(claimTheaterBootMinimization("theater-b")).toBe(true);
+    expect(claimTheaterBootMinimization("theater-a")).toBe(false);
+  });
+
+  // 콘솔 전환은 origin을 건너뛰는 전체 페이지 이동이라 모듈 메모리가 사라진다. 같은 탭이라면
+  // sessionStorage에 남은 표식만으로 "이미 열었다"를 알아봐야 한다.
+  it("refuses the claim after a page load wipes module memory but the tab session survives", () => {
+    expect(claimTheaterBootMinimization("theater-a")).toBe(true);
+
+    // 새 페이지의 빈 모듈 메모리를 재현한다 — sessionStorage는 탭에 그대로 남아 있다.
+    const surviving = window.sessionStorage.getItem(BOOT_MINIMIZATION_STORAGE_KEY);
+    resetBootMinimizationSession();
+    window.sessionStorage.setItem(BOOT_MINIMIZATION_STORAGE_KEY, surviving!);
+
+    expect(claimTheaterBootMinimization("theater-a")).toBe(false);
+  });
+
+  it("falls back to page-lifetime memory when sessionStorage is unusable", () => {
+    vi.spyOn(window.sessionStorage, "getItem").mockImplementation(() => { throw new Error("denied"); });
+    vi.spyOn(window.sessionStorage, "setItem").mockImplementation(() => { throw new Error("denied"); });
+
+    expect(claimTheaterBootMinimization("theater-a")).toBe(true);
+    expect(claimTheaterBootMinimization("theater-a")).toBe(false);
+  });
+
+  it("ignores stored junk instead of refusing every claim", () => {
+    window.sessionStorage.setItem(BOOT_MINIMIZATION_STORAGE_KEY, "{not json");
+    expect(claimTheaterBootMinimization("theater-a")).toBe(true);
+
+    resetBootMinimizationSession();
+    window.sessionStorage.setItem(BOOT_MINIMIZATION_STORAGE_KEY, JSON.stringify({ "theater-a": true }));
+    expect(claimTheaterBootMinimization("theater-a")).toBe(true);
+  });
+});

--- a/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
+++ b/runtime/fleet-console/tests/operations-boot-minimization.integration.test.ts
@@ -9,6 +9,7 @@ import type { OperationKindDescriptor } from "@fleet-console/sdk/plugin";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { clearCompanionOperationId, clearFormationView, clearMaximizedOperationId, getCompanionOperationId, getFormationView, getMaximizedOperationId, getSnapshot, getTheaterCompanionOperationId, loadForTheater, minimizeOperation, requestFitAllOperations, resetCanvasViewportSize, restoreOperation, setCanvasViewportSize, setCompanionOperationId, setMaximizedOperationId, setOperationGeometry, setViewport, subscribe as subscribeCanvas, toggleFormationView } from "../core/client/src/canvas/canvas-store.js";
+import { BOOT_MINIMIZATION_STORAGE_KEY, resetBootMinimizationSession } from "../core/client/src/boot-minimization-session.js";
 import { armTriageSetAside, getTriageSetAsideArmedId, resetTriageTheater, setTriageActive } from "../core/client/src/canvas/triage-store.js";
 import { focusOperation, getState, hydrateOperations, setActiveOperation, setState } from "../core/client/src/store.js";
 import type { OperationNode, TheaterBootstrap } from "../core/client/src/types.js";
@@ -145,6 +146,8 @@ let container: HTMLDivElement | null = null;
 beforeEach(() => {
   document.body.replaceChildren();
   window.localStorage.clear();
+  // 부팅 최소화의 "한 번"은 이제 탭 세션 단위라, 케이스마다 새 탭에서 시작한 것으로 되돌린다.
+  resetBootMinimizationSession();
   window.history.replaceState({}, "", "/operations");
   loadForTheater("theater-a");
   clearMaximizedOperationId();
@@ -1291,7 +1294,58 @@ describe("Operations boot minimization", () => {
     expect(getSnapshot().operations).toHaveProperty("b1");
     expect(getSnapshot().operations).toHaveProperty("b2");
   });
+
+  // 콘솔 전환(로컬↔원격)은 origin을 건너뛰는 전체 페이지 이동이라 App이 통째로 다시 뜬다. 그때마다
+  // 부팅 최소화가 다시 걸리면 사용자가 펼쳐둔 패널이 매번 접혀, 오갈 때마다 하나하나 다시 열어야 했다.
+  it("keeps a restored panel open when the console reloads inside the same tab session", async () => {
+    await bootApp([operation("first"), operation("second")]);
+    expect(getSnapshot().minimized).toEqual(["first", "second"]);
+
+    restoreOperation("first");
+    expect(getSnapshot().minimized).toEqual(["second"]);
+
+    await reloadTab();
+    await bootApp([operation("first"), operation("second")]);
+
+    expect(getSnapshot().minimized).toEqual(["second"]);
+  });
+
+  // 세션 단위로 좁힌 것이지 기능을 끈 것이 아니다 — 새 탭은 여전히 깨끗한 Map으로 시작한다.
+  it("minimizes boot panels again in a new tab session", async () => {
+    await bootApp([operation("first"), operation("second")]);
+    restoreOperation("first");
+    expect(getSnapshot().minimized).toEqual(["second"]);
+
+    await reloadTab();
+    resetBootMinimizationSession();
+    await bootApp([operation("first"), operation("second")]);
+
+    // 이미 접혀 있던 패널이 목록 앞자리를 지키므로 순서가 아니라 집합으로 본다.
+    expect([...getSnapshot().minimized].sort()).toEqual(["first", "second"]);
+  });
 });
+
+/**
+ * 같은 탭에서 페이지가 다시 뜬 상황을 만든다. localStorage와 sessionStorage는 그대로 두고 React 트리와
+ * 캔버스 로드 상태만 부팅 직전으로 되돌린다 — 콘솔 전환이 브라우저에서 일으키는 것과 같은 초기화다.
+ *
+ * 모듈 메모리도 반드시 함께 비운다. 실제 페이지 로드는 번들을 다시 평가해 모듈 수준 상태를 통째로
+ * 날리므로, 그것을 남겨두면 부팅 최소화 표식이 sessionStorage가 아니라 메모리로 살아남아 — 영속화를
+ * 지워도 통과하는 — 가짜 초록이 된다.
+ */
+async function reloadTab(): Promise<void> {
+  await act(async () => root?.unmount());
+  // 이탈 시점의 캔버스 상태를 localStorage로 흘려보낸 뒤 로드를 비운다.
+  loadForTheater(null);
+  const survivingSession = window.sessionStorage.getItem(BOOT_MINIMIZATION_STORAGE_KEY);
+  resetBootMinimizationSession();
+  if (survivingSession !== null) window.sessionStorage.setItem(BOOT_MINIMIZATION_STORAGE_KEY, survivingSession);
+  container?.remove();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  setState({ activeOperationId: null, activeTheaterId: null, groups: [], keyboardFocusRequest: null, operations: [], operationsHydrated: false, theaters: [] });
+}
 
 async function navigateTo(pathname: string): Promise<void> {
   await act(async () => {


### PR DESCRIPTION
## Summary
- 로컬 콘솔 ↔ 원격 콘솔 전환은 `location.assign()`으로 다른 origin에 가는 전체 페이지 이동이라, 매 전환마다 부팅 최소화(#246)가 다시 걸려 사용자가 펼쳐 둔 패널이 전부 접혔습니다. 최소화 여부 자체는 이미 `canvas-store`가 Theater별 localStorage에 저장하고 있었고, 부팅 최소화가 그 위를 덮어쓰는 것이 원인이었습니다.
- 부팅 최소화의 "세션 중 한 번" 판정을 React `useRef`(페이지 수명)에서 `sessionStorage`(탭 세션)로 옮겼습니다. 같은 탭에 머무는 한 표식이 살아남아 콘솔을 오가도 패널 상태가 유지되고, 새로 연 탭은 종전대로 깨끗하게 시작합니다.
- 승인된 부수 변경: 같은 탭에서의 새로고침(F5)도 이제 최소화 상태를 유지합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 1778 passed / 24 skipped
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과
- [x] `pnpm --filter @dotobokuri/fleet-console boundary:guard` — 통과
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 117 fragment 검증 통과 (`.changelog.d/panel-state-across-consoles.md`)
- [x] 변이 테스트: `writeOpenedTheaters`의 `sessionStorage.setItem`을 제거하면 신규 통합 테스트가 실패함을 확인 (영속화 경로를 실제로 검증함)
- [x] 브라우저 실측(headless Chrome, CDP): 같은 탭에서 origin A → B → A 왕복 후 A의 `sessionStorage`가 생존하고 B에서는 격리됨을 확인