### PR TITLE
fix(fleet-console): keep the canvas still when its context menu opens low

### DIFF
--- a/.changelog.d/canvas-context-menu-scroll-shift.md
+++ b/.changelog.d/canvas-context-menu-scroll-shift.md
@@ -1,0 +1,8 @@
+---
+branch: canvas-context-menu-scroll-shift
+---
+
+### fleet-console
+#### Fixed
+- Opening the canvas control menu near the bottom of the canvas no longer shoves the whole board upward. The board stayed shifted in Cruise, Tactical, and War Room alike until the page was reloaded; the canvas now keeps its position no matter where the menu opens.
+  ko: 캔버스 아래쪽에서 캔버스 제어 메뉴를 열어도 판 전체가 위로 밀리지 않습니다. 한 번 밀리면 Cruise·Tactical·War Room 어디로 옮겨도 밀린 채 남고 새로고침해야 돌아왔지만, 이제는 메뉴를 어디서 열든 캔버스가 제자리를 지킵니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -252,7 +252,11 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   useEffect(() => {
     // 첫 항목을 강제 포커스하지 않고 컨테이너만 포커스해 '이미 선택된 듯한' UX를 피한다.
     // 방향키를 처음 누른 순간에만 항목으로 들어간다.
-    menuRef.current?.focus();
+    // preventScroll: 이 메뉴는 커서 자리에 스스로 서므로 조상을 굴려 드러낼 것이 없다. 게다가 이
+    // 포커스는 높이 측정 전 좌표(커서를 그대로 쓴 첫 렌더)에서 발화한다 — 측정과 클램프는 layout
+    // effect가 페인트 전에 마치지만, passive effect인 이 focus는 그 재렌더보다 먼저 flush된다.
+    // 그 찰나의 위치로 스크롤을 허용하면 조상이 굴러간 채 남는다.
+    menuRef.current?.focus({ preventScroll: true });
   }, []);
 
   useEffect(() => () => {

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2292,7 +2292,13 @@
   height: 100%;
   min-width: 0;
   min-height: 0;
-  overflow: hidden;
+  /* clip이지 hidden이 아니다. hidden은 스크롤 포트를 만든다 — 스크롤바만 감출 뿐, 프로그램적
+     스크롤은 그대로 열려 있다. 캔버스 밖으로 나간 자손에 포커스가 닿는 순간(예: 커서 아래로
+     펼쳐진 캔버스 제어 메뉴) 브라우저가 그 자손을 드러내려고 이 컨테이너를 굴려, 판이 통째로
+     밀린 채 남는다. 이 캔버스의 이동은 world의 transform이 소유하고 스크롤 오프셋은 언제나 0이어야
+     한다 — 0이 아니면 clientX-rect.left로 뽑는 캔버스 좌표까지 함께 어긋난다. clip은 스크롤 포트
+     자체를 만들지 않아 그 경로를 원천에서 닫는다. */
+  overflow: clip;
   contain: paint;
   border: 1px solid var(--surface-rim);
   border-left-color: transparent;

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -78,6 +78,23 @@ describe("CanvasContextMenu anchor placement", () => {
     expect(menuStyle().getPropertyValue("--canvas-menu-max-height")).toBe("376px");
   });
 
+  // 이 포커스는 높이 측정 전 좌표에서 발화한다 — 커서를 그대로 쓴 첫 렌더라 하단에서 열면 메뉴가
+  // 캔버스 밖으로 넘친다. 그 찰나의 위치로 조상을 굴리게 두면 판이 밀린 채 남으므로, 여는 포커스는
+  // 스크롤을 요구하지 않아야 한다.
+  it("takes the opening focus without asking any ancestor to scroll", () => {
+    const focus = vi.spyOn(HTMLElement.prototype, "focus");
+    try {
+      renderMenu({ x: 520, y: 756 }, { width: 1116, height: 856 });
+
+      const menuFocus = focus.mock.calls.filter((_call, index) =>
+        (focus.mock.instances[index] as HTMLElement).classList.contains("canvas-context-menu"));
+      expect(menuFocus).toHaveLength(1);
+      expect(menuFocus[0]![0]).toEqual({ preventScroll: true });
+    } finally {
+      focus.mockRestore();
+    }
+  });
+
   it("renders fixed at viewport coordinates when the fixed prop is set", () => {
     renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [], vi.fn(), true);
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -369,6 +369,19 @@ describe("Instrument core design contract", () => {
     for (const path of OWNED_SOURCES) expect(source(path)).not.toMatch(FORBIDDEN_DECORATION);
   });
 
+  it("denies the canvas a scroll port so a focused overhanging descendant cannot shift the board", () => {
+    const components = source("styles/components.css");
+    const canvasBlock = components.match(/\n\.operations-canvas \{[\s\S]*?\n\}/)?.[0] ?? "";
+    const contextMenu = source("canvas/canvas-context-menu.tsx");
+
+    // hidden은 스크롤바만 감출 뿐 스크롤 포트를 남긴다 — 밖으로 나간 자손에 포커스가 닿으면
+    // 브라우저가 이 컨테이너를 굴려 판 전체가 밀린 채 남는다. clip은 그 포트를 만들지 않는다.
+    expect(canvasBlock).toContain("overflow: clip;");
+    expect(canvasBlock).not.toContain("overflow: hidden;");
+    // 메뉴는 커서 자리에 스스로 선다 — 조상을 굴려 드러낼 것이 없다.
+    expect(contextMenu).toContain("menuRef.current?.focus({ preventScroll: true });");
+  });
+
   it("keeps minimap navigation and collapse controls while hiding Map in Formation and maximize", () => {
     const minimap = source("canvas/canvas-minimap.tsx");
     const canvas = source("canvas/canvas.tsx");


### PR DESCRIPTION
## Summary
- 캔버스 아래쪽에서 우클릭으로 캔버스 제어 메뉴를 열면 판 전체가 위로 밀리고, Cruise·Tactical·War Room 어디로 옮겨도 밀린 채 남아 새로고침해야 복구되던 결함을 고칩니다.
- 원인은 두 겹입니다. (1) `.operations-canvas`가 `overflow: hidden`이라 스크롤바만 감춘 채 **스크롤 포트**를 그대로 갖고 있었고, (2) 메뉴를 여는 포커스가 **높이 측정 전 좌표**(커서를 그대로 쓴 첫 렌더)에서 발화해 캔버스 밖으로 넘친 위치를 드러내달라고 요구했습니다. 브라우저가 컨테이너를 굴렸고, 그 오프셋은 되돌아오지 않았습니다.
- `overflow: clip`으로 스크롤 포트 자체를 없애 이 계열 전체를 원천에서 닫고, 메뉴의 여는 포커스에는 `preventScroll`을 붙여 "이 메뉴는 조상을 굴려 드러낼 것이 없다"는 로컬 계약을 명시했습니다.

## 실측 근거 (격리 콘솔 + 헤드리스 브라우저)
- 재현: 캔버스 하단 우클릭 → `.operations-canvas.scrollTop 0 → 67`, 패널 top `112 → 45`. focus 시점 계측으로 메뉴가 미클램프 위치(`style.top: 516px`, rect bottom 695 > 캔버스 하단 577)에서 포커스를 받아 컨테이너를 118px 굴린 것을 확인했습니다.
- 수정 후: Cruise `scrollTop 0` 유지(패널 top 112 불변), War Room은 스크롤 여지가 530px 있음에도 `scrollTop 0` 유지, 메뉴는 커서 위로 정상 배치.
- 대조 실험: `hidden`으로 되돌린 상태에서 캔버스 밖 요소에 일반 `focus()` → `scrollTop 391`(패널 top 72.9 → -318.1). 같은 조작을 `clip`에서 반복 → `scrollTop 0`. `preventScroll`만으로는 다른 포커스 경로가 남는다는 근거이자 `clip`이 근본 방어인 근거입니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 161 files / 1780 tests passed
- [x] `pnpm test` (워크스페이스 전체) — 통과. 최초 실행의 core-infra·fleet-desktop 2건 실패는 세션에 남은 `FLEET_*_DATA_DIR` 환경변수 누출이 원인으로, 변수 제거 후 전부 통과함을 확인했습니다(본 변경과 무관).
- [x] `pnpm typecheck` (tsc --noEmit, 워크스페이스 전체) — 통과
- [x] `pnpm build` (워크스페이스 전체) — 통과
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK (118 entries)
- [x] 헤드리스 브라우저 실측(위 "실측 근거") — Cruise / War Room 재현 및 수정 확인
- [x] changelog fragment: `.changelog.d/canvas-context-menu-scroll-shift.md` (fleet-console / Fixed)