### PR TITLE
feat(fleet-console): unfold the home host list on a remote console

### DIFF
--- a/.changelog.d/remote-host-box-unified.md
+++ b/.changelog.d/remote-host-box-unified.md
@@ -1,0 +1,10 @@
+---
+branch: remote-host-box-unified
+---
+
+### fleet-console
+
+#### Changed
+
+- Opening the host box on a remote console now unfolds your own computer's list of machines, so you can go straight from one remote console to another instead of returning home first. Your console draws that list itself, and the remote console you are viewing never receives the addresses of your other machines.
+  ko: 원격 콘솔에서 호스트 박스를 열면 이제 내 컴퓨터의 기계 목록이 그대로 펼쳐집니다. 집으로 돌아왔다 다시 나갈 필요 없이 원격 콘솔에서 다른 원격 콘솔로 바로 건너갑니다. 목록은 내 콘솔이 직접 그리며, 지금 보고 있는 원격 콘솔은 내 다른 기계의 주소를 받지 않습니다.

--- a/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
@@ -37,6 +37,51 @@ const GITHUB_STARS_CACHE_KEY = "fleet-console.github-stars";
 const GITHUB_STARS_TTL_MS = 6 * 60 * 60 * 1000;
 const ENABLED_MENU_ITEM_SELECTOR = '[role="menuitem"]:not([disabled])';
 
+/**
+ * Desktop 셸과의 계약 리터럴 — 셸이 이 항해를 가로채므로 요청은 기계를 떠나지 않는다.
+ * 같은 값이 fleet-desktop/src/remote-bridge.ts에도 선언되어 있다(Console 내부를 import하지
+ * 않는다는 규칙 때문이며, DESKTOP_SHELL_PATH와 같은 방식이다). 한쪽만 고치면 목록이 열리지
+ * 않고 창이 집으로 돌아가 버리므로, 양쪽을 함께 고친다.
+ */
+const PICKER_SURFACE_PARAM = "desktop-surface";
+const PICKER_SURFACE_OPEN = "host-picker";
+const PICKER_SURFACE_DISMISS = "host-picker-dismiss";
+/** 목록을 펼칠 때 실려 가는 유일한 값: 지금 사용자가 서 있는 콘솔. 남의 기계는 실리지 않는다. */
+const PICKER_AT_PARAM = "at";
+
+export interface HostPickerContext {
+  /** 이 목록을 부른 콘솔. 현재 줄을 표시하는 데만 쓴다. */
+  readonly at: string | null;
+}
+
+/**
+ * 이 화면이 "집의 목록만 펼치는 표면"으로 서빙됐는가.
+ *
+ * 부른 쪽이 실어 보낸 origin은 그대로 믿지 않는다 — 화면에 그릴 값이므로 모양을 먼저 본다.
+ */
+export function readHostPickerSurface(search: string): HostPickerContext | null {
+  const params = new URLSearchParams(search);
+  if (params.get(PICKER_SURFACE_PARAM) !== PICKER_SURFACE_OPEN) return null;
+  const at = params.get(PICKER_AT_PARAM);
+  return { at: at !== null && isConsoleOriginShape(at) ? at : null };
+}
+
+function isConsoleOriginShape(origin: string): boolean {
+  try {
+    const parsed = new URL(origin);
+    return parsed.origin === origin && (parsed.protocol === "http:" || parsed.protocol === "https:");
+  } catch {
+    return false;
+  }
+}
+
+function pickerUrl(homeOrigin: string, surface: string, at?: string): string {
+  const url = new URL("/console/", `${homeOrigin}/`);
+  url.searchParams.set(PICKER_SURFACE_PARAM, surface);
+  if (at !== undefined) url.searchParams.set(PICKER_AT_PARAM, at);
+  return url.toString();
+}
+
 // 설정 진입 시점의 history index를 기록하는 세션 스코프 마커. GlobalSettings의 섹션
 // 이동은 state 없이 push하므로 location.state로는 이 마커가 전파되지 않는다 — 모듈
 // 스코프 변수로 들고 있다가 selectSection이 다음 항목으로 전파한다(아래 export 참조).
@@ -86,7 +131,7 @@ export function CommandBandSystemCluster() {
  * 닿는지 여부는 열어 볼 때 확인한다. 목록에 든 것만으로 매번 남의 기계를 두드리면, 보지도
  * 않는 화면 때문에 조용한 네트워크 소음이 계속 흐른다.
  */
-function HostSwitcher() {
+export function HostSwitcher({ picker }: { readonly picker?: HostPickerContext } = {}) {
   const t = useT();
   const state = useConsoleState();
   const hosts = useRemoteHosts();
@@ -94,22 +139,42 @@ function HostSwitcher() {
   // 원격으로 건너가는 일은 셸의 인증서 배관을 거쳐야 한다. 브라우저 단독에서는 내주지 않는다.
   const canOpenRemote = isDesktopShell();
   const navigate = useNavigate();
-  const [open, setOpen] = useState(false);
+  /** 집이 펼친 목록으로 서빙된 화면. 칩은 없고, 판은 처음부터 열려 있다. */
+  const inPicker = picker !== undefined;
+  const [open, setOpen] = useState(inPicker);
   const [addOpen, setAddOpen] = useState(false);
   const [local, setLocal] = useState<readonly LocalConsole[]>([]);
   const [reach, setReach] = useState<Readonly<Record<string, RemoteHostReach>>>({});
   const triggerRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  /**
+   * 목록을 접는 일. 집이 펼친 판은 이 화면의 상태가 아니라 셸이 얹은 덮개라, 접겠다는 말도
+   * 셸에게 가야 한다 — 여기서 state만 내리면 빈 덮개가 콘솔을 가린 채 남는다.
+   */
+  const dismiss = () => {
+    if (inPicker) location.assign(pickerUrl(location.origin, PICKER_SURFACE_DISMISS));
+    else setOpen(false);
+  };
+
+  /**
+   * 이 화면을 내주는 콘솔에게 목록을 물어도 되는가.
+   *
+   * 원격 콘솔에게는 묻지 않는다. 그 두 경로는 루프백 전용이라 어차피 401이지만, 답이 없다는
+   * 것과 묻지 않는다는 것은 다르다 — 남의 기계에 내 목록을 묻는 요청 자체가 남지 않아야 한다.
+   * 집이 펼친 목록(피커)은 집이 서빙하므로 이 판정이 참이고, 평소대로 묻는다.
+   */
+  const servedFromLoopback = isLoopbackOrigin(location.origin);
 
   useEffect(() => {
+    if (!servedFromLoopback) return;
     const controller = new AbortController();
     void refreshRemoteHosts(controller.signal).catch(() => undefined);
     void fetchLocalConsoles(controller.signal).then(setLocal).catch(() => undefined);
     return () => controller.abort();
-  }, []);
+  }, [servedFromLoopback]);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || !servedFromLoopback) return;
     const controller = new AbortController();
     // 열 때마다 다시 본다 — 이 기계의 콘솔은 조용히 뜨고 진다.
     void fetchLocalConsoles(controller.signal).then(setLocal).catch(() => undefined);
@@ -118,21 +183,30 @@ function HostSwitcher() {
         .then((result) => setReach((previous) => ({ ...previous, [host.id]: result })))
         .catch(() => undefined);
     }
+    return () => controller.abort();
+  }, [open, hosts, servedFromLoopback]);
+
+  // 판을 닫는 길은 목록을 어디서 읽어 왔는지와 무관하다 — 묻지 않는 콘솔에서도 판은 닫혀야 한다.
+  useEffect(() => {
+    if (!open) return;
     const onPointer = (event: PointerEvent) => {
       const target = event.target as Node;
-      if (!panelRef.current?.contains(target) && !triggerRef.current?.contains(target)) setOpen(false);
+      if (!panelRef.current?.contains(target) && !triggerRef.current?.contains(target)) dismiss();
     };
-    const onKey = (event: KeyboardEvent) => { if (event.key === "Escape") { setOpen(false); triggerRef.current?.focus(); } };
+    const onKey = (event: KeyboardEvent) => { if (event.key === "Escape") { dismiss(); triggerRef.current?.focus(); } };
     document.addEventListener("pointerdown", onPointer, true);
     document.addEventListener("keydown", onKey);
     return () => {
-      controller.abort();
       document.removeEventListener("pointerdown", onPointer, true);
       document.removeEventListener("keydown", onKey);
     };
-  }, [open, hosts]);
+  }, [open]);
 
-  const currentOrigin = location.origin;
+  /**
+   * 어느 콘솔에 서 있는가. 집이 펼친 목록에서는 이 화면(집)이 아니라 목록을 부른 콘솔이
+   * 그 답이다 — 아니면 사용자가 지금 보고 있는 콘솔에 현재 표시가 서지 않는다.
+   */
+  const currentOrigin = (inPicker ? picker.at : null) ?? location.origin;
   const currentIsLoopback = isLoopbackOrigin(currentOrigin);
   /**
    * "이 컴퓨터"에 실릴 수 있는 것은 이 창이 실제로 닿을 수 있는 콘솔뿐이다.
@@ -166,13 +240,25 @@ function HostSwitcher() {
       ? t("chrome.hosts.local")
       : currentLabel;
 
-  if (nearby.length === 0 && hosts.length === 0) return null;
+  /**
+   * 원격 콘솔에서 칩을 누르면 이 콘솔의 목록을 펴는 대신 집에게 목록을 펴 달라고 한다.
+   * 셸이 그 항해를 가로채 집의 화면을 이 위에 얹으므로, 이 콘솔은 남의 기계 주소를 받지 않는다.
+   */
+  const pickerHome = !inPicker && canOpenRemote && !currentIsLoopback && home !== null ? home : null;
+
+  if (!inPicker && nearby.length === 0 && hosts.length === 0) return null;
   const openSettings = () => {
+    // 관리는 집의 설정 화면에서 한다. 덮개는 목록만 들고 있으므로 창째로 집에 보낸다.
+    if (inPicker) {
+      location.assign(new URL("/console/settings?section=remote-access", `${location.origin}/`).toString());
+      return;
+    }
     setOpen(false);
     navigate({ pathname: "/settings", search: "?section=remote-access" });
   };
   const openAdd = () => {
-    setOpen(false);
+    // 덮개에서는 판을 접지 않는다 — 접으면 팝업이 닫힌 뒤 빈 덮개만 남는다.
+    if (!inPicker) setOpen(false);
     setAddOpen(true);
   };
   const go = (origin: string) => {
@@ -181,21 +267,26 @@ function HostSwitcher() {
   };
 
   return (
-    <div className="host-switcher">
-      <button
-        ref={triggerRef}
-        type="button"
-        className={`host-switcher-chip${state.controlHolder !== null ? " is-shared" : ""}`}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        aria-label={`${t("chrome.hosts.aria")}: ${chipLabel}`}
-        title={chipLabel}
-        onClick={() => setOpen((previous) => !previous)}
-      >
-        <span className={`host-switcher-dot ${state.controlHolder !== null ? "is-shared" : "is-live"}`} aria-hidden="true" />
-        <span className="host-switcher-name">{chipLabel}</span>
-        <ChevronGlyph />
-      </button>
+    <div className={`host-switcher${inPicker ? " is-picker-surface" : ""}`}>
+      {inPicker ? null : (
+        <button
+          ref={triggerRef}
+          type="button"
+          className={`host-switcher-chip${state.controlHolder !== null ? " is-shared" : ""}`}
+          aria-haspopup="menu"
+          aria-expanded={pickerHome === null && open}
+          aria-label={`${t("chrome.hosts.aria")}: ${chipLabel}`}
+          title={chipLabel}
+          onClick={() => {
+            if (pickerHome !== null) { location.assign(pickerUrl(pickerHome, PICKER_SURFACE_OPEN, currentOrigin)); return; }
+            setOpen((previous) => !previous);
+          }}
+        >
+          <span className={`host-switcher-dot ${state.controlHolder !== null ? "is-shared" : "is-live"}`} aria-hidden="true" />
+          <span className="host-switcher-name">{chipLabel}</span>
+          <ChevronGlyph />
+        </button>
+      )}
       {open ? (
         <div ref={panelRef} className="host-switcher-panel" role="menu" aria-label={t("chrome.hosts.aria")}>
           {nearby.length > 0 ? (

--- a/runtime/fleet-console/core/client/src/components/host-picker-surface.tsx
+++ b/runtime/fleet-console/core/client/src/components/host-picker-surface.tsx
@@ -1,0 +1,19 @@
+import { HostSwitcher, type HostPickerContext } from "./command-band-system-cluster.js";
+
+/**
+ * 집이 자기 목록만 펼쳐 내주는 화면.
+ *
+ * 원격 콘솔을 보고 있는 동안에도 사용자가 고르는 목록은 언제나 자기 기계의 것이어야 하는데,
+ * 그 목록은 집의 루프백에서만 읽을 수 있다. 그래서 이 화면은 집이 서빙하고, 셸이 보고 있던
+ * 콘솔 위에 얹는다 — 목록이 원격 콘솔을 지나가지 않는 유일한 방법이다.
+ *
+ * 콘솔 한 벌을 통째로 띄우지 않는다. 여기 필요한 것은 호스트 박스 하나뿐이고, 그 뒤에 두 번째
+ * 콘솔이 통째로 떠오르면 사용자는 자기가 어디에 서 있는지를 잃는다.
+ */
+export function HostPickerScreen({ surface }: { readonly surface: HostPickerContext }) {
+  return (
+    <div className="host-picker-surface">
+      <HostSwitcher picker={surface} />
+    </div>
+  );
+}

--- a/runtime/fleet-console/core/client/src/main.tsx
+++ b/runtime/fleet-console/core/client/src/main.tsx
@@ -22,6 +22,8 @@ import "./styles/theme.css";
 import "./styles/layout.css";
 import "./styles/components.css";
 import { App } from "./app.js";
+import { readHostPickerSurface } from "./components/command-band-system-cluster.js";
+import { HostPickerScreen } from "./components/host-picker-surface.js";
 import { fetchGlobalSettingsState } from "./global-settings-api.js";
 import { failGlobalSettingsLoad, hydrateGlobalSettings } from "./global-settings-store.js";
 import { connectOperationsSse } from "./operations-sse.js";
@@ -67,10 +69,24 @@ try {
   // 서버 미응답 시 기본 Theme 및 Manrope UI font를 유지한다.
 }
 
-const registry = await loadPluginRegistry();
-connectOperationsSse();
 const app = document.querySelector("#app");
-if (app) {
+/**
+ * 집이 목록만 펼쳐 내주는 표면으로 서빙됐다면 콘솔을 세우지 않는다 — 플러그인도 SSE도
+ * 이 화면과 무관하고, 그 둘을 켜는 순간 덮개 한 장이 콘솔 한 벌만큼 무거워진다.
+ */
+const hostPicker = app ? readHostPickerSurface(location.search) : null;
+if (app && hostPicker) {
+  document.documentElement.dataset.hostPicker = "true";
+  createRoot(app).render(
+    <StrictMode>
+      <BrowserRouter basename="/console">
+        <HostPickerScreen surface={hostPicker} />
+      </BrowserRouter>
+    </StrictMode>,
+  );
+} else if (app) {
+  const registry = await loadPluginRegistry();
+  connectOperationsSse();
   createRoot(app).render(
     <StrictMode>
       <BrowserRouter basename="/console">

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -834,6 +834,33 @@
 .host-switcher-divider { height: 1px; margin: var(--space-2) var(--space-3); background: var(--surface-rim); }
 .host-switcher-link { color: var(--aurora-ink); font-size: 13px; }
 
+/* ── 집이 펼친 호스트 목록 표면 ────────────────────────────────────────
+   원격 콘솔을 보고 있을 때 목록은 집이 그려 이 위에 얹힌다. 판 자체는 위와 같은 문법을 쓰고,
+   여기서 바꾸는 것은 "무엇 위에 서 있는가"뿐이다 — 아래에 깔린 콘솔이 비쳐야 사용자가 자기가
+   어디에 서 있었는지를 잃지 않는다. 그래서 이 화면에서만 문서 바탕을 비운다. */
+:root[data-host-picker="true"],
+:root[data-host-picker="true"] body {
+  background: transparent;
+}
+
+.host-picker-surface {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  padding: calc(var(--chrome-band-height) + var(--space-2)) var(--space-3) var(--space-3);
+  background: color-mix(in oklch, var(--ink-abyss) 62%, transparent);
+}
+
+/* 칩이 없는 표면이라 판을 매달 기준점도 없다 — 흐름에 그대로 세운다. */
+.host-picker-surface .host-switcher.is-picker-surface { position: static; display: contents; }
+.host-picker-surface .host-switcher-panel {
+  position: static;
+  max-height: 100%;
+  overflow-y: auto;
+}
+
 /* ── 콘솔 추가 팝업 ───────────────────────────────────────────────────
    스위처의 "호스트 추가"와 설정의 추가 버튼이 함께 여는 한 장. 오버레이 지오메트리는
    .directory-browser-*의 계약을 승계한다 — 둘 다 배타적인 모달이라 같은 층에 산다. */

--- a/runtime/fleet-console/tests/host-picker-surface.test.tsx
+++ b/runtime/fleet-console/tests/host-picker-surface.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+// @vitest-environment-options { "url": "https://192.168.0.62:63371/console/" }
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HostSwitcher, readHostPickerSurface } from "../core/client/src/components/command-band-system-cluster.js";
+import { HostPickerScreen } from "../core/client/src/components/host-picker-surface.js";
+
+const HOME = "http://127.0.0.1:59229";
+const HERE = "https://192.168.0.62:63371";
+const THERE = "https://10.211.55.3:6186";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+let assign: ReturnType<typeof vi.fn>;
+let requested: string[];
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * 원격 콘솔이 서빙한 화면. 목록 두 경로는 여기서 401이지만, 이 테스트가 지키는 것은 그 답이
+ * 아니라 "요청이 아예 남지 않는다"는 쪽이다.
+ */
+function stubRemoteConsole(): void {
+  requested = [];
+  vi.stubGlobal("fetch", vi.fn(async (input: string) => {
+    const path = new URL(input, HERE).pathname;
+    requested.push(path);
+    if (path === "/api/v1/desktop/shell") return Response.json({ homeOrigin: HOME });
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }));
+}
+
+/** 집이 자기 루프백에서 목록을 내주는 화면. */
+function stubHomeConsole(): void {
+  standOn(HOME);
+  requested = [];
+  vi.stubGlobal("fetch", vi.fn(async (input: string) => {
+    const path = new URL(input, HOME).pathname;
+    requested.push(path);
+    if (path === "/api/v1/desktop/shell") return Response.json({ homeOrigin: HOME });
+    if (path === "/api/v1/local-consoles") {
+      return Response.json({ consoles: [{ origin: HOME, version: "1.51.0", owner: "desktop", distro: null }] });
+    }
+    if (path === "/api/v1/remote-hosts") {
+      return Response.json({
+        hosts: [
+          { id: "there", label: "SBLUEMIN2C23", origin: THERE, hostname: "10.211.55.3", port: 6186, fingerprint: "A".repeat(64), addedAt: 1, lastOpenedAt: null },
+          { id: "here", label: "dotobokuliui-Macmini", origin: HERE, hostname: "192.168.0.62", port: 63371, fingerprint: "B".repeat(64), addedAt: 2, lastOpenedAt: null },
+        ],
+      });
+    }
+    return Response.json({ reachable: true, trusted: true });
+  }));
+}
+
+/** jsdom의 location은 재정의를 거부하므로 전역을 통째로 세워 둔다. */
+function standOn(origin: string): void {
+  assign = vi.fn();
+  vi.stubGlobal("location", { origin, host: new URL(origin).host, search: "", href: `${origin}/console/`, assign });
+}
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  document.documentElement.dataset.desktopShell = "true";
+  standOn(HERE);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  delete document.documentElement.dataset.desktopShell;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+async function mount(element: ReturnType<typeof createElement>): Promise<void> {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => { root!.render(createElement(MemoryRouter, null, element)); });
+  // 셸 origin·목록 응답이 상태에 반영될 때까지 한 턴 더 돌린다.
+  await act(async () => { await Promise.resolve(); });
+}
+
+function rows(): HTMLElement[] {
+  return [...document.querySelectorAll<HTMLElement>('[role="menuitemradio"]')];
+}
+
+function rowText(): string[] {
+  return rows().map((row) => row.textContent ?? "");
+}
+
+describe("host picker surface query", () => {
+  it.each([
+    ["?desktop-surface=host-picker", null],
+    [`?desktop-surface=host-picker&at=${encodeURIComponent(HERE)}`, HERE],
+    // 부른 쪽이 실어 보낸 값이라 모양을 먼저 본다 — 화면에 그릴 값이기 때문이다.
+    ["?desktop-surface=host-picker&at=not-an-origin", null],
+    [`?desktop-surface=host-picker&at=${encodeURIComponent(`${HERE}/console/`)}`, null],
+  ])("reads %s", (search, at) => {
+    expect(readHostPickerSurface(search)).toEqual({ at });
+  });
+
+  it.each([
+    ["a plain console url", ""],
+    ["the dismissal signal", "?desktop-surface=host-picker-dismiss"],
+    ["an unknown surface", "?desktop-surface=whatever"],
+  ])("refuses %s", (_label, search) => {
+    expect(readHostPickerSurface(search)).toBeNull();
+  });
+});
+
+describe("host box on a remote console", () => {
+  /**
+   * 이 제안의 결정 축. 목록이 B를 지나가지 않는다는 것은 B가 401을 돌려준다는 뜻이 아니라,
+   * B에게 물은 적이 없다는 뜻이다.
+   */
+  it("never asks the console it is standing on for a roster", async () => {
+    stubRemoteConsole();
+
+    await mount(createElement(HostSwitcher));
+
+    expect(requested).not.toContain("/api/v1/remote-hosts");
+    expect(requested).not.toContain("/api/v1/local-consoles");
+    expect(requested).toContain("/api/v1/desktop/shell");
+  });
+
+  it("asks home to unfold its own list instead of opening this console's", async () => {
+    stubRemoteConsole();
+    await mount(createElement(HostSwitcher));
+
+    const chip = document.querySelector<HTMLButtonElement>(".host-switcher-chip")!;
+    await act(async () => { chip.click(); });
+
+    // 실려 가는 값은 지금 서 있는 콘솔 하나뿐이다 — 남의 기계는 이 URL에 없다.
+    expect(assign).toHaveBeenCalledOnce();
+    const url = new URL(assign.mock.calls[0]![0] as string);
+    expect(url.origin).toBe(HOME);
+    expect(url.pathname).toBe("/console/");
+    expect(url.searchParams.get("desktop-surface")).toBe("host-picker");
+    expect(url.searchParams.get("at")).toBe(HERE);
+    // 이 콘솔의 판은 열리지 않는다.
+    expect(rows()).toHaveLength(0);
+  });
+});
+
+describe("the list home unfolds", () => {
+  it("shows home's own hosts and marks the console the user is standing on", async () => {
+    stubHomeConsole();
+
+    await mount(createElement(HostPickerScreen, { surface: { at: HERE } }));
+
+    expect(rowText().join("\n")).toContain("SBLUEMIN2C23");
+    const current = rows().find((row) => row.getAttribute("aria-checked") === "true");
+    expect(current?.textContent).toContain("dotobokuliui-Macmini");
+    expect((current as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("opens with the list already unfolded and no chip of its own", async () => {
+    stubHomeConsole();
+
+    await mount(createElement(HostPickerScreen, { surface: { at: HERE } }));
+
+    expect(rows().length).toBeGreaterThan(0);
+    expect(document.querySelector(".host-switcher-chip")).toBeNull();
+  });
+
+  /** 판은 이 화면의 상태가 아니라 셸이 얹은 덮개라, 접겠다는 말도 셸에게 가야 한다. */
+  it("tells the shell to take the cover down instead of just hiding the list", async () => {
+    stubHomeConsole();
+    await mount(createElement(HostPickerScreen, { surface: { at: HERE } }));
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+
+    expect(assign).toHaveBeenCalledOnce();
+    const url = new URL(assign.mock.calls[0]![0] as string);
+    expect(url.origin).toBe(HOME);
+    expect(url.searchParams.get("desktop-surface")).toBe("host-picker-dismiss");
+  });
+
+  it("sends the window to the chosen console", async () => {
+    stubHomeConsole();
+    await mount(createElement(HostPickerScreen, { surface: { at: HERE } }));
+
+    const target = rows().find((row) => row.textContent?.includes("SBLUEMIN2C23"))!;
+    await act(async () => { target.click(); });
+
+    expect(assign).toHaveBeenCalledWith(`${THERE}/console/`);
+  });
+});

--- a/runtime/fleet-desktop/src/host-picker-view.ts
+++ b/runtime/fleet-desktop/src/host-picker-view.ts
@@ -1,0 +1,121 @@
+import type { BrowserWindow, WebContents, WebContentsView } from "electron";
+
+/**
+ * 집의 호스트 목록을 지금 보고 있는 콘솔 위에 그대로 펼치는 덮개.
+ *
+ * 목록은 이 셸이 띄운 콘솔(집)이 자기 루프백에서 직접 그린다. 원격 콘솔이 서빙한 화면은
+ * 이 렌더러를 참조할 수도, 그 응답을 읽을 수도 없으므로 남의 기계 주소는 그 화면을 지나가지
+ * 않는다 — 화면 아래에 깔린 콘솔은 픽셀로만 남는다.
+ *
+ * 덮개는 하나뿐이고, 걷는 일은 여러 경로에서 불린다: 고르고 났을 때, Esc, 렌더러 사망,
+ * 적재 실패, 메인 창의 항해, 창 종료. 전부 같은 함수로 모여 몇 번을 불려도 같은 결과가 된다.
+ */
+export interface HostPickerViewDeps {
+  readonly createView: () => WebContentsView;
+  readonly window: () => BrowserWindow | null;
+  /** 이 contents의 항해 울타리. 세션에는 손대지 않는다(window-policy 참조). */
+  readonly confine: (contents: WebContents) => void;
+  /** 여기서 고른 콘솔을 메인 창으로 보내는 다리. */
+  readonly attachBridge: (contents: WebContents) => void;
+  readonly log?: (message: string) => void;
+  readonly now?: () => number;
+}
+
+export interface HostPickerView {
+  open(url: string): Promise<void>;
+  close(): void;
+  isOpen(): boolean;
+}
+
+/**
+ * 덮개를 걷자마자 다시 소환하는 것은 사람의 손이 아니다. 아래에 깔린 화면은 남의 콘솔이므로,
+ * 그 화면의 스크립트가 신뢰 UI를 반복해서 띄우는 길을 좁혀 둔다.
+ */
+const REOPEN_COOLDOWN_MS = 400;
+
+interface OpenPicker {
+  readonly view: WebContentsView;
+  readonly onResize: () => void;
+}
+
+export function createHostPickerView(deps: HostPickerViewDeps): HostPickerView {
+  const now = deps.now ?? Date.now;
+  let current: OpenPicker | null = null;
+  let closedAt = 0;
+
+  function close(): void {
+    const open = current;
+    if (!open) return;
+    // 먼저 비운다 — 아래 정리 중에 다시 불려도 두 번 걷지 않는다.
+    current = null;
+    closedAt = now();
+    const window = deps.window();
+    try { window?.off("resize", open.onResize); } catch { /* 이미 사라진 창은 뗄 리스너도 없다. */ }
+    try { window?.contentView.removeChildView(open.view); } catch { /* 창이 먼저 닫힌 경우. */ }
+    try { open.view.webContents.close(); } catch { /* 이미 죽은 렌더러. */ }
+    // 덮개가 걷히면 손은 원래 보던 콘솔로 돌아가야 한다.
+    try { if (window && !window.isDestroyed()) window.webContents.focus(); } catch { /* 창이 없으면 돌려줄 포커스도 없다. */ }
+  }
+
+  return {
+    isOpen: () => current !== null,
+
+    close,
+
+    async open(url: string): Promise<void> {
+      const window = deps.window();
+      if (!window || window.isDestroyed()) throw new Error("remote_bridge_no_picker");
+      if (current) {
+        // 이미 떠 있으면 하나 더 만들지 않는다.
+        try { current.view.webContents.focus(); } catch { /* 포커스는 부가 동작이다. */ }
+        return;
+      }
+      if (now() - closedAt < REOPEN_COOLDOWN_MS) {
+        deps.log?.("host picker reopen ignored: too soon after the last dismissal");
+        return;
+      }
+
+      const view = deps.createView();
+      const contents = view.webContents;
+      const applyBounds = (): void => {
+        const target = deps.window();
+        if (!target || target.isDestroyed()) return;
+        const { width, height } = target.getContentBounds();
+        view.setBounds({ x: 0, y: 0, width, height });
+      };
+      const onResize = (): void => applyBounds();
+      const open: OpenPicker = { view, onResize };
+      current = open;
+
+      window.contentView.addChildView(view);
+      // 목록이 그려지기 전에는 보이지 않는다 — 빈 판을 먼저 보여 주면 목록이 사라진 것처럼 읽힌다.
+      view.setVisible(false);
+      applyBounds();
+      window.on("resize", onResize);
+
+      deps.confine(contents);
+      deps.attachBridge(contents);
+      contents.on("before-input-event", (_event, input) => {
+        if (input.type === "keyDown" && input.key === "Escape") close();
+      });
+      // 덮개만 살아남는 상태를 만들지 않는다.
+      contents.on("render-process-gone", () => close());
+      contents.once("did-fail-load", (_event, _code, description) => {
+        deps.log?.(`host picker load failed: ${description}`);
+        close();
+      });
+      contents.once("did-finish-load", () => {
+        if (current !== open) return;
+        view.setVisible(true);
+        try { contents.focus(); } catch { /* 포커스는 부가 동작이다. */ }
+      });
+
+      try {
+        await contents.loadURL(url);
+      } catch (error) {
+        close();
+        throw error;
+      }
+    },
+  };
+}

--- a/runtime/fleet-desktop/src/main.ts
+++ b/runtime/fleet-desktop/src/main.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { app, BrowserWindow, dialog, Menu, Notification, session, shell, Tray } from "electron";
+import { app, BrowserWindow, dialog, Menu, Notification, session, shell, Tray, WebContentsView } from "electron";
 
 import { createDesktopLifecycle } from "./app-lifecycle.js";
 import { isConsoleConflict, showConsoleConflictAndQuit } from "./console-conflict.js";
@@ -13,9 +13,10 @@ import { pushEntrySnapshot } from "./entry-page.js";
 import { applyDesktopDockIcon, applyDesktopIdentity } from "./identity.js";
 import { createLaunchController, type RuntimeEntryState } from "./launch-controller.js";
 import { createDesktopNotifier } from "./desktop-notices.js";
+import { createHostPickerView } from "./host-picker-view.js";
 import { isRemoteConsoleOrigin } from "./console-origin.js";
 import { installRemoteCertificatePins } from "./remote-access.js";
-import { createRemoteBridge, type RemoteBridge } from "./remote-bridge.js";
+import { consoleTarget, createRemoteBridge, type RemoteBridge } from "./remote-bridge.js";
 import { findAccessLinkArgument, FLEET_PROTOCOL, isFleetProtocolLink } from "./fleet-protocol.js";
 import { createDesktopLogger, describeError, type DesktopLogger } from "./logging.js";
 import { createDesktopThemeSynchronizer } from "./desktop-theme-sync.js";
@@ -29,7 +30,7 @@ import { resolveRuntimePaths } from "./runtime/runtime-paths.js";
 import { SidecarSupervisor, type SidecarRuntime } from "./sidecar-supervisor.js";
 import { configureTray, createDesktopTray, shouldConfigureTray } from "./tray.js";
 import { createNoopUpdateController, createUpdateController, resolveActiveWindow, showWindowsHiddenUpdateDialog } from "./update-controller.js";
-import { applyWindowPolicy, createSecureWindow } from "./window-policy.js";
+import { applyWindowPolicy, confinePickerNavigation, createSecureWindow } from "./window-policy.js";
 import { createZoomState } from "./zoom-state.js";
 
 type RuntimeProgress = (state: RuntimeEntryState, detail?: string, progress?: number) => Promise<void>;
@@ -161,7 +162,27 @@ async function boot(): Promise<void> {
       fullscreenSynchronizer?.activate(origin);
       await publishShellHome(origin);
     },
+    openPicker: (url) => picker.open(url),
+    closePicker: () => picker.close(),
     notify: (notice) => notifier.show(notice),
+    log: (message) => logger.error(message),
+  });
+  /**
+   * 집의 목록을 지금 보고 있는 콘솔 위에 펼치는 덮개. 화면은 집이 그리고, Desktop은 그 렌더러를
+   * 얹었다 걷는 일만 한다 — 어느 콘솔을 고를지도, 그 이름도 여기서 정하지 않는다.
+   */
+  const picker = createHostPickerView({
+    createView: () => {
+      const view = new WebContentsView({
+        webPreferences: { nodeIntegration: false, contextIsolation: true, sandbox: true, webSecurity: true },
+      });
+      // 덮개는 아래 콘솔 위에 합성된다 — 목록을 보는 동안에도 어느 콘솔에 서 있었는지가 남아야 한다.
+      view.setBackgroundColor("#00000000");
+      return view;
+    },
+    window: () => window,
+    confine: (contents) => confinePickerNavigation(contents, localConsoleOrigin ?? "", (url) => consoleTarget(url, localConsoleOrigin) !== null),
+    attachBridge: (contents) => bridge.attachPicker(contents),
     log: (message) => logger.error(message),
   });
   const lifecycle = createDesktopLifecycle(app, async () => {
@@ -174,11 +195,14 @@ async function boot(): Promise<void> {
           themeSynchronizer?.stop();
           fullscreenSynchronizer?.stop();
           fullscreenSynchronizer = null;
+          picker.close();
         });
         controls.attachWindow(createdWindow);
         lifecycle.attachWindow(createdWindow);
         policy = applyWindowPolicy(createdWindow.webContents, async (external) => shell.openExternal(external));
         bridge.attach(createdWindow.webContents);
+        // 창이 어디로 옮겨 가든 덮개는 따라가지 않는다 — 새 콘솔 위에 남은 옛 목록은 거짓말이다.
+        createdWindow.webContents.on("did-navigate", () => picker.close());
         createdWindow.webContents.on("zoom-changed", (_event, zoomDirection) => controls.zoomChanged(createdWindow.webContents, zoomDirection));
         refreshNativeUpdateActions?.();
         await createdWindow.loadFile(desktopResources.entryPagePath);

--- a/runtime/fleet-desktop/src/remote-bridge.ts
+++ b/runtime/fleet-desktop/src/remote-bridge.ts
@@ -42,8 +42,8 @@ export interface RemoteBridge {
    * 성공이든 실패든 닫는다. 실패한 채 덮개만 남으면 사용자는 돌아갈 화면을 잃는다.
    */
   attachPicker(contents: Pick<WebContents, "on" | "removeListener">): void;
-  /** 목록에 이미 있는 호스트를 연다. */
-  open(origin: string): Promise<void>;
+  /** 목록에 이미 있는 호스트를 연다. `url`은 루프백 대상의 특정 화면까지 정해져 온 경우에만 쓰인다. */
+  open(origin: string, url?: string): Promise<void>;
   /** `fleet://join?code=…`를 로컬 Console에 넘기고, 받아들여지면 그 호스트를 연다. */
   receiveLink(link: string): Promise<void>;
   /** 실패를 사람이 읽을 수 있는 한 줄로 바꿔 알린다. 화면이 없는 배관의 유일한 발화 지점이다. */
@@ -90,9 +90,13 @@ export function createRemoteBridge(deps: RemoteBridgeDeps): RemoteBridge {
     });
   }
 
-  async function open(origin: string): Promise<void> {
+  /**
+   * `url`은 루프백 콘솔로 갈 때만 쓰인다 — 그 콘솔 안의 어느 화면을 열지까지 정해져 온 경우다
+   * (덮개의 "호스트 관리"가 그렇다). 원격은 핸드오프가 돌려준 origin의 `/console/`로만 간다.
+   */
+  async function open(origin: string, url?: string): Promise<void> {
     // 집으로 돌아가는 길에는 핀도 자격도 필요 없다 — 루프백은 언제나 허용된 origin이다.
-    if (origin === deps.localOrigin()) return openLocal(origin);
+    if (origin === deps.localOrigin()) return openLocal(origin, url);
     /**
      * 이 기계의 다른 콘솔도 핀과 자격 없이 열 수 있다. 다만 창을 아무 로컬 포트로나 보낼 수는
      * 없다 — 원격 콘솔이 서빙한 페이지가 `http://127.0.0.1:<임의>`로 항해를 걸면 그 주소는
@@ -100,7 +104,7 @@ export function createRemoteBridge(deps: RemoteBridgeDeps): RemoteBridge {
      */
     if (isLoopbackConsoleOrigin(origin)) {
       if (!(await isDiscoveredLocally(origin))) throw new Error("remote_host_unknown");
-      return openLocal(origin);
+      return openLocal(origin, url);
     }
     const response = await askLocalConsole(HANDOFF_PATH, { origin });
     if (response.status === 404) throw new Error("remote_host_unknown");
@@ -173,11 +177,12 @@ export function createRemoteBridge(deps: RemoteBridgeDeps): RemoteBridge {
     deps.closePicker?.();
   }
 
-  async function openLocal(origin: string): Promise<void> {
+  async function openLocal(origin: string, url?: string): Promise<void> {
     const policy = deps.policy();
     if (!policy) throw new Error("remote_bridge_no_window");
     policy.activateConsoleOrigin(origin);
-    await deps.loadConsole(`${origin}${CONSOLE_PATH}`);
+    // 정해져 온 화면이 있어도 그 콘솔의 `/console/` 안이어야 한다 — 아니면 기본 화면으로 연다.
+    await deps.loadConsole(url !== undefined && consoleTarget(url, origin) === origin ? url : `${origin}${CONSOLE_PATH}`);
   }
 
   async function receiveLink(link: string): Promise<void> {
@@ -260,7 +265,7 @@ export function createRemoteBridge(deps: RemoteBridgeDeps): RemoteBridge {
          * 고르고 난 뒤에는 성공이든 실패든 덮개를 걷는다. 실패한 채로 남기면 사용자는
          * 아무 일도 일어나지 않은 목록을 마주하고, 그 아래 멀쩡한 콘솔에는 손이 닿지 않는다.
          */
-        void open(target).then(closePicker, (error: unknown) => { closePicker(); report(error); });
+        void open(target, url).then(closePicker, (error: unknown) => { closePicker(); report(error); });
       };
       contents.on("will-navigate", listener as never);
       attached.push({ contents, listener: listener as never });

--- a/runtime/fleet-desktop/src/remote-bridge.ts
+++ b/runtime/fleet-desktop/src/remote-bridge.ts
@@ -24,6 +24,12 @@ export interface RemoteBridgeDeps {
   /** 원격 콘솔의 세션 목록에 남을 이 기기의 이름. */
   readonly deviceName?: string;
   readonly loadConsole: (url: string) => Promise<void>;
+  /**
+   * 집의 목록을 그 자리에서 펼친다. 원격 콘솔이 서빙한 화면은 남의 기계 주소를 알 수 없고
+   * 알아서도 안 되므로, 목록은 이 URL을 적재하는 홈 origin의 렌더러가 직접 그린다.
+   */
+  readonly openPicker?: (url: string) => Promise<void>;
+  readonly closePicker?: () => void;
   readonly notify: (notice: DesktopNotice) => void;
   readonly log?: (message: string) => void;
   readonly confirmIdentity?: (hostname: string, port: number, fingerprint: string) => Promise<void>;
@@ -31,6 +37,11 @@ export interface RemoteBridgeDeps {
 
 export interface RemoteBridge {
   attach(contents: Pick<WebContents, "on" | "removeListener">): void;
+  /**
+   * 집의 목록을 그리는 렌더러. 여기서 고른 콘솔은 메인 창이 받아 열고, 피커는 닫힌다 —
+   * 성공이든 실패든 닫는다. 실패한 채 덮개만 남으면 사용자는 돌아갈 화면을 잃는다.
+   */
+  attachPicker(contents: Pick<WebContents, "on" | "removeListener">): void;
   /** 목록에 이미 있는 호스트를 연다. */
   open(origin: string): Promise<void>;
   /** `fleet://join?code=…`를 로컬 Console에 넘기고, 받아들여지면 그 호스트를 연다. */
@@ -53,6 +64,15 @@ const LOCAL_CONSOLES_PATH = "/api/v1/local-consoles";
 const REMOTE_HOSTS_PATH = "/api/v1/remote-hosts";
 const CONSOLE_PATH = "/console/";
 const JOIN_PATH = "/api/v1/join";
+
+/**
+ * Console 계약의 쿼리 리터럴 — DESKTOP_SHELL_PATH와 같은 방식으로 여기서 선언한다
+ * (Console 내부를 import하지 않는다). 이 항해는 절대 기계를 떠나지 않는다: 아래 리스너가
+ * 요청이 나가기 전에 가로채고, 값을 실어 나르는 것도 아니라 어느 표면을 뜻하는지만 말한다.
+ */
+const PICKER_SURFACE_PARAM = "desktop-surface";
+const PICKER_SURFACE_OPEN = "host-picker";
+const PICKER_SURFACE_DISMISS = "host-picker-dismiss";
 
 export function createRemoteBridge(deps: RemoteBridgeDeps): RemoteBridge {
   const localFetch = deps.localFetch ?? globalThis.fetch;
@@ -143,6 +163,16 @@ export function createRemoteBridge(deps: RemoteBridgeDeps): RemoteBridge {
     }
   }
 
+  async function openPicker(url: string): Promise<void> {
+    if (!deps.openPicker) throw new Error("remote_bridge_no_picker");
+    await deps.openPicker(url);
+  }
+
+  /** 덮개를 걷는 일은 여러 경로에서 불린다 — 없어도, 이미 걷혔어도 실패가 아니다. */
+  function closePicker(): void {
+    deps.closePicker?.();
+  }
+
   async function openLocal(origin: string): Promise<void> {
     const policy = deps.policy();
     if (!policy) throw new Error("remote_bridge_no_window");
@@ -181,6 +211,17 @@ export function createRemoteBridge(deps: RemoteBridgeDeps): RemoteBridge {
     attach(contents) {
       const listener = (event: { preventDefault: () => void }, url: string, _redirect?: unknown, isMainFrame?: boolean): void => {
         if (isMainFrame === false) return;
+        /**
+         * 피커 판정이 consoleTarget보다 먼저다. 센티넬도 홈의 `/console/`이라 아래 판정에
+         * 걸리는데, 그러면 목록을 펼치는 대신 창째로 집에 돌아가 버린다 — 지금의 2단 동선 그대로다.
+         */
+        const surface = pickerSurfaceOf(url, deps.localOrigin());
+        if (surface !== null) {
+          event.preventDefault();
+          if (surface === "open") void openPicker(url).catch(report);
+          else closePicker();
+          return;
+        }
         const target = consoleTarget(url, deps.localOrigin());
         // 이미 활성인 콘솔 안에서의 이동은 window policy의 몫이다.
         if (target === null || target === deps.policy()?.currentConsoleOrigin()) return;
@@ -200,6 +241,29 @@ export function createRemoteBridge(deps: RemoteBridgeDeps): RemoteBridge {
       };
       contents.on("did-navigate", landed as never);
       attached.push({ contents, listener: landed as never, event: "did-navigate" });
+    },
+
+    attachPicker(contents) {
+      const listener = (event: { preventDefault: () => void }, url: string, _redirect?: unknown, isMainFrame?: boolean): void => {
+        if (isMainFrame === false) return;
+        // 피커 안에서 다시 피커를 부르는 일은 없다. 스스로를 다시 여는 대신 조용히 닫는다.
+        const surface = pickerSurfaceOf(url, deps.localOrigin());
+        if (surface !== null) {
+          event.preventDefault();
+          closePicker();
+          return;
+        }
+        const target = consoleTarget(url, deps.localOrigin());
+        if (target === null) return;
+        event.preventDefault();
+        /**
+         * 고르고 난 뒤에는 성공이든 실패든 덮개를 걷는다. 실패한 채로 남기면 사용자는
+         * 아무 일도 일어나지 않은 목록을 마주하고, 그 아래 멀쩡한 콘솔에는 손이 닿지 않는다.
+         */
+        void open(target).then(closePicker, (error: unknown) => { closePicker(); report(error); });
+      };
+      contents.on("will-navigate", listener as never);
+      attached.push({ contents, listener: listener as never });
     },
     open,
     receiveLink,
@@ -221,6 +285,26 @@ export function createRemoteBridge(deps: RemoteBridgeDeps): RemoteBridge {
  * 돌아오는 길. 돌아오는 길도 여기를 거쳐야 하는 이유는 window policy가 활성 origin 밖으로의
  * 항해를 막기 때문이다.
  */
+/**
+ * 집의 목록을 펼치라는(또는 걷으라는) 신호인가.
+ *
+ * 신호는 홈 origin의 `/console/`로만 온다 — 원격 콘솔이 서빙한 화면이 남의 주소로 이 신호를
+ * 흉내 내도 여기서 걸린다. 실을 수 있는 것은 어느 표면이냐는 사실 하나뿐이고, 그래서 이 URL이
+ * 새어도 알려지는 것이 없다.
+ */
+export function pickerSurfaceOf(url: string, localOrigin: string | null): "open" | "dismiss" | null {
+  if (localOrigin === null) return null;
+  try {
+    const parsed = new URL(url);
+    if (parsed.origin !== localOrigin || !parsed.pathname.startsWith(CONSOLE_PATH)) return null;
+    const surface = parsed.searchParams.get(PICKER_SURFACE_PARAM);
+    if (surface === PICKER_SURFACE_OPEN) return "open";
+    return surface === PICKER_SURFACE_DISMISS ? "dismiss" : null;
+  } catch {
+    return null;
+  }
+}
+
 export function consoleTarget(url: string, localOrigin: string | null): string | null {
   try {
     const parsed = new URL(url);
@@ -269,6 +353,8 @@ function describe(code: string): string {
     case "remote_link_host_mismatch": return "That console refused the link as meant for a different address.";
     case "remote_host_is_self": return "That link points back at this console.";
     case "pairing_target_invalid": return "That is not a Fleet Console access link.";
+    // 덮개를 얹을 창이 없다. 목록은 이 셸이 띄운 콘솔에 그대로 있으므로 그리로 안내한다.
+    case "remote_bridge_no_picker": return "The host list could not open here. Go back to this computer's console to switch machines.";
     default: return "The connection failed. This console remains available.";
   }
 }

--- a/runtime/fleet-desktop/src/window-policy.ts
+++ b/runtime/fleet-desktop/src/window-policy.ts
@@ -87,6 +87,30 @@ export function applyWindowPolicy(contents: WebContents, originOrOpenExternal: s
   };
 }
 
+/**
+ * 집의 목록을 그리는 덮개 렌더러의 항해 울타리.
+ *
+ * `applyWindowPolicy`를 그대로 쓸 수는 없다. 그쪽은 세션 단위인 `setPermissionRequestHandler`를
+ * 갈아 끼우는데, 이 뷰는 메인 창과 같은 defaultSession에 산다 — 덮개를 한 번 얹는 것만으로
+ * 메인 창(원격 origin)의 클립보드 권한 판정이 집 origin 기준으로 바뀌고, 덮개를 걷어도
+ * 그대로 남는다. 그래서 여기서는 세션에 손대지 않고 이 contents의 항해만 가둔다.
+ *
+ * 콘솔을 갈아타는 항해는 여기서 막지 않는다 — remote bridge가 같은 이벤트에서 가로채
+ * 메인 창으로 보내는 것이 그 동선의 전부이기 때문이다.
+ */
+export function confinePickerNavigation(
+  contents: Pick<WebContents, "on" | "setWindowOpenHandler">,
+  origin: string,
+  isConsoleSwitch: (url: string) => boolean,
+): void {
+  contents.on("will-navigate", (event, url) => {
+    if (isAllowedConsoleUrl(url, origin) || isConsoleSwitch(url)) return;
+    event.preventDefault();
+  });
+  // 덮개에서 새 창은 열리지 않는다. 바깥으로 나가는 링크는 메인 창의 몫이다.
+  contents.setWindowOpenHandler(() => ({ action: "deny" }));
+}
+
 export function isAllowedConsoleUrl(url: string, origin: string): boolean { try { const parsed = new URL(url); return parsed.origin === origin && parsed.pathname.startsWith("/console/"); } catch { return false; } }
 function isHttpUrl(url: string): boolean { try { return ["http:", "https:"].includes(new URL(url).protocol); } catch { return false; } }
 function hasExactOrigin(url: string, origin: string): boolean { try { return new URL(url).origin === origin; } catch { return false; } }

--- a/runtime/fleet-desktop/tests/host-picker-view.test.ts
+++ b/runtime/fleet-desktop/tests/host-picker-view.test.ts
@@ -1,0 +1,182 @@
+import { EventEmitter } from "node:events";
+
+import { describe, expect, it } from "vitest";
+
+import { createHostPickerView } from "../src/host-picker-view.js";
+
+const PICKER_URL = "http://127.0.0.1:4310/console/?desktop-surface=host-picker";
+
+class FakeContents extends EventEmitter {
+  closed = false;
+  focused = 0;
+  loaded: string | null = null;
+  failLoad = false;
+
+  async loadURL(url: string): Promise<void> {
+    this.loaded = url;
+    if (this.failLoad) throw new Error("ERR_CONNECTION_REFUSED");
+    this.emit("did-finish-load");
+  }
+
+  close(): void { this.closed = true; }
+  focus(): void { this.focused += 1; }
+}
+
+/** 덮개가 실제로 화면을 가리는지·걷혔는지는 이 두 값이 전부다. */
+function createHarness(options: { readonly failLoad?: boolean } = {}) {
+  const trace: string[] = [];
+  const contents = new FakeContents();
+  contents.failLoad = options.failLoad === true;
+  let visible: boolean | null = null;
+  let bounds: { width: number; height: number } | null = null;
+  const view = {
+    webContents: contents,
+    setVisible: (next: boolean) => { visible = next; trace.push(`visible:${next}`); },
+    setBounds: (next: { width: number; height: number }) => { bounds = { width: next.width, height: next.height }; },
+  };
+  const children: unknown[] = [];
+  const windowEvents = new EventEmitter();
+  const mainContents = { focus: () => trace.push("main:focus") };
+  const window = {
+    isDestroyed: () => false,
+    getContentBounds: () => ({ x: 0, y: 0, width: 1200, height: 800 }),
+    contentView: {
+      addChildView: (child: unknown) => { children.push(child); trace.push("addChild"); },
+      removeChildView: (child: unknown) => { children.splice(children.indexOf(child), 1); trace.push("removeChild"); },
+    },
+    on: (event: string, listener: () => void) => windowEvents.on(event, listener),
+    off: (event: string, listener: () => void) => windowEvents.off(event, listener),
+    webContents: mainContents,
+  };
+
+  let clock = 10_000;
+  const picker = createHostPickerView({
+    createView: () => { trace.push("createView"); return view as never; },
+    window: () => window as never,
+    confine: () => trace.push("confine"),
+    attachBridge: () => trace.push("attachBridge"),
+    log: (message) => trace.push(`log:${message}`),
+    now: () => clock,
+  });
+
+  return {
+    picker,
+    trace,
+    contents,
+    children,
+    windowEvents,
+    isVisible: () => visible,
+    getBounds: () => bounds,
+    advance: (ms: number) => { clock += ms; },
+  };
+}
+
+describe("host picker view", () => {
+  it("keeps the cover invisible until the list has actually drawn", async () => {
+    const harness = createHarness();
+
+    await harness.picker.open(PICKER_URL);
+
+    // 먼저 숨기고, 그린 뒤에 드러낸다 — 순서가 뒤집히면 빈 판이 한 프레임 보인다.
+    expect(harness.trace.filter((entry) => entry.startsWith("visible:"))).toEqual(["visible:false", "visible:true"]);
+    expect(harness.isVisible()).toBe(true);
+    expect(harness.contents.loaded).toBe(PICKER_URL);
+  });
+
+  it("covers the whole window and follows it as it resizes", async () => {
+    const harness = createHarness();
+
+    await harness.picker.open(PICKER_URL);
+    harness.windowEvents.emit("resize");
+
+    expect(harness.getBounds()).toEqual({ width: 1200, height: 800 });
+  });
+
+  it("fences the list off before it is pointed anywhere", async () => {
+    const harness = createHarness();
+
+    await harness.picker.open(PICKER_URL);
+
+    // 울타리와 다리가 적재보다 먼저다.
+    expect(harness.trace.indexOf("confine")).toBeLessThan(harness.trace.indexOf("visible:true"));
+    expect(harness.trace).toContain("attachBridge");
+  });
+
+  it("holds exactly one cover however many times it is asked", async () => {
+    const harness = createHarness();
+
+    await harness.picker.open(PICKER_URL);
+    await harness.picker.open(PICKER_URL);
+
+    expect(harness.trace.filter((entry) => entry === "createView")).toHaveLength(1);
+    expect(harness.children).toHaveLength(1);
+  });
+
+  it("takes the cover down once, whatever path asks", async () => {
+    const harness = createHarness();
+    await harness.picker.open(PICKER_URL);
+
+    harness.picker.close();
+    harness.picker.close();
+
+    expect(harness.trace.filter((entry) => entry === "removeChild")).toHaveLength(1);
+    expect(harness.contents.closed).toBe(true);
+    expect(harness.picker.isOpen()).toBe(false);
+    // 손은 원래 보던 콘솔로 돌아간다.
+    expect(harness.trace).toContain("main:focus");
+    expect(harness.windowEvents.listenerCount("resize")).toBe(0);
+  });
+
+  it("does not leave a cover behind when its renderer dies", async () => {
+    const harness = createHarness();
+    await harness.picker.open(PICKER_URL);
+
+    harness.contents.emit("render-process-gone");
+
+    expect(harness.picker.isOpen()).toBe(false);
+  });
+
+  it("does not leave a cover behind when the list cannot be loaded", async () => {
+    const harness = createHarness({ failLoad: true });
+
+    await expect(harness.picker.open(PICKER_URL)).rejects.toThrow("ERR_CONNECTION_REFUSED");
+
+    expect(harness.picker.isOpen()).toBe(false);
+    expect(harness.contents.closed).toBe(true);
+  });
+
+  it("closes on Escape", async () => {
+    const harness = createHarness();
+    await harness.picker.open(PICKER_URL);
+
+    harness.contents.emit("before-input-event", {}, { type: "keyDown", key: "Escape" });
+
+    expect(harness.picker.isOpen()).toBe(false);
+  });
+
+  /**
+   * 덮개 아래에 깔린 것은 남의 콘솔이다. 걷자마자 다시 소환되는 것은 사람의 손이 아니므로,
+   * 그 화면의 스크립트가 신뢰 UI를 반복해 띄우는 길을 좁혀 둔다.
+   */
+  it("refuses to be summoned again the instant it was dismissed", async () => {
+    const harness = createHarness();
+    await harness.picker.open(PICKER_URL);
+    harness.picker.close();
+
+    await harness.picker.open(PICKER_URL);
+
+    expect(harness.picker.isOpen()).toBe(false);
+    expect(harness.trace.some((entry) => entry.startsWith("log:host picker reopen ignored"))).toBe(true);
+  });
+
+  it("opens again once the user has had a moment", async () => {
+    const harness = createHarness();
+    await harness.picker.open(PICKER_URL);
+    harness.picker.close();
+    harness.advance(1_000);
+
+    await harness.picker.open(PICKER_URL);
+
+    expect(harness.picker.isOpen()).toBe(true);
+  });
+});

--- a/runtime/fleet-desktop/tests/remote-bridge.test.ts
+++ b/runtime/fleet-desktop/tests/remote-bridge.test.ts
@@ -387,6 +387,29 @@ describe("host picker surface", () => {
     expect(harness.notices[0]?.body).toContain("no longer in this list");
   });
 
+  /** "호스트 관리"는 이름대로 관리 화면을 열어야 한다 — 집의 기본 화면에 내려놓으면 거짓말이다. */
+  it("keeps the screen the list asked for when it sends the window home", async () => {
+    const picker = new EventEmitter();
+    const harness = createHarness();
+    harness.bridge.attachPicker(picker as never);
+    harness.setCurrent(REMOTE);
+
+    picker.emit("will-navigate", { preventDefault: () => undefined }, `${LOCAL}/console/settings?section=remote-access`, undefined, true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(harness.trace).toContain(`load:${LOCAL}/console/settings?section=remote-access`);
+  });
+
+  it("falls back to the default screen when the asked-for screen is not that console's", async () => {
+    const picker = new EventEmitter();
+    const harness = createHarness();
+    harness.bridge.attachPicker(picker as never);
+
+    await harness.bridge.open(LOCAL, `${REMOTE}/console/settings`);
+
+    expect(harness.trace).toContain(`load:${LOCAL}/console/`);
+  });
+
   it("does not summon a second list from inside the list", async () => {
     const picker = new EventEmitter();
     const harness = createHarness();

--- a/runtime/fleet-desktop/tests/remote-bridge.test.ts
+++ b/runtime/fleet-desktop/tests/remote-bridge.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "node:events";
 
 import { describe, expect, it, vi } from "vitest";
 
-import { consoleTarget, createRemoteBridge } from "../src/remote-bridge.js";
+import { consoleTarget, createRemoteBridge, pickerSurfaceOf } from "../src/remote-bridge.js";
 
 const LOCAL = "http://127.0.0.1:4310";
 const REMOTE = "https://100.84.12.7:6768";
@@ -13,7 +13,7 @@ function handoff(overrides: Record<string, unknown> = {}): Response {
 }
 
 /** 무엇이 어떤 차례로 일어났는지가 이 다리의 계약이라, 호출을 한 줄로 기록해 둔다. */
-function createHarness(options: { readonly responses?: (path: string) => Response; readonly confirm?: () => Promise<void>; readonly load?: () => Promise<void>; readonly verify?: () => Response } = {}) {
+function createHarness(options: { readonly responses?: (path: string) => Response; readonly confirm?: () => Promise<void>; readonly load?: () => Promise<void>; readonly verify?: () => Response; readonly picker?: () => Promise<void> } = {}) {
   const trace: string[] = [];
   const requests: Array<{ url: string; init: RequestInit }> = [];
   const notices: Array<{ title: string; body: string }> = [];
@@ -57,6 +57,11 @@ function createHarness(options: { readonly responses?: (path: string) => Respons
       trace.push(`load:${url}`);
       if (options.load) await options.load();
     },
+    openPicker: async (url: string) => {
+      trace.push(`picker:open:${url}`);
+      if (options.picker) await options.picker();
+    },
+    closePicker: () => trace.push("picker:close"),
     notify: (notice) => notices.push({ title: notice.title, body: notice.body }),
     confirmIdentity: options.confirm ?? (async () => { trace.push("confirm"); }),
   });
@@ -295,5 +300,109 @@ describe("remote bridge", () => {
     harness.bridge.dispose();
 
     expect(contents.listenerCount("will-navigate")).toBe(0);
+  });
+});
+
+const PICKER_OPEN_URL = `${LOCAL}/console/?desktop-surface=host-picker&at=${encodeURIComponent(REMOTE)}`;
+const PICKER_DISMISS_URL = `${LOCAL}/console/?desktop-surface=host-picker-dismiss`;
+
+/** 항해 하나가 두 뜻으로 읽히면 안 된다 — 목록을 펴는 신호와, 창째로 집에 가는 길. */
+describe("host picker surface", () => {
+  it.each([
+    [PICKER_OPEN_URL, "open"],
+    [PICKER_DISMISS_URL, "dismiss"],
+  ])("reads %s as %s", (url, surface) => {
+    expect(pickerSurfaceOf(url, LOCAL)).toBe(surface);
+  });
+
+  it.each([
+    ["a plain console url", `${LOCAL}/console/`],
+    ["an unknown surface", `${LOCAL}/console/?desktop-surface=whatever`],
+    // 원격 콘솔이 자기 주소로 신호를 흉내 내도 집의 목록은 열리지 않는다.
+    ["the same query on another origin", `${REMOTE}/console/?desktop-surface=host-picker`],
+    ["a path outside the console", `${LOCAL}/join?desktop-surface=host-picker`],
+    ["a non-url", "not a url"],
+  ])("refuses %s", (_label, url) => {
+    expect(pickerSurfaceOf(url, LOCAL)).toBeNull();
+  });
+
+  it("claims no surface when the shell has no console of its own", () => {
+    expect(pickerSurfaceOf(PICKER_OPEN_URL, null)).toBeNull();
+  });
+
+  /**
+   * 이 판정이 consoleTarget보다 늦으면 목록이 열리는 대신 창이 집으로 넘어간다 — 고치려던
+   * 2단 동선 그대로다. 리스너 등록 순서가 아니라 이 다리 안의 순서가 그것을 정한다.
+   */
+  it("opens the home list instead of sending the window home", async () => {
+    const contents = new EventEmitter();
+    const harness = createHarness();
+    harness.bridge.attach(contents as never);
+    harness.setCurrent(REMOTE);
+    let prevented = false;
+
+    contents.emit("will-navigate", { preventDefault: () => { prevented = true; } }, PICKER_OPEN_URL, undefined, true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(prevented).toBe(true);
+    expect(harness.trace).toEqual([`picker:open:${PICKER_OPEN_URL}`]);
+    expect(harness.trace).not.toContain(`load:${LOCAL}/console/`);
+  });
+
+  it("takes the cover back down when the list asks to be dismissed", async () => {
+    const contents = new EventEmitter();
+    const harness = createHarness();
+    harness.bridge.attach(contents as never);
+    harness.setCurrent(REMOTE);
+
+    contents.emit("will-navigate", { preventDefault: () => undefined }, PICKER_DISMISS_URL, undefined, true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(harness.trace).toEqual(["picker:close"]);
+  });
+
+  it("sends the chosen console to the main window and takes the cover down", async () => {
+    const picker = new EventEmitter();
+    const harness = createHarness();
+    harness.bridge.attachPicker(picker as never);
+    harness.setCurrent(REMOTE);
+
+    picker.emit("will-navigate", { preventDefault: () => undefined }, `${REMOTE}/console/`, undefined, true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(harness.trace).toContain(`load:${REMOTE}/console/`);
+    expect(harness.trace.at(-1)).toBe("picker:close");
+  });
+
+  /** 실패한 채 덮개만 남으면 사용자는 멀쩡한 콘솔에 손이 닿지 않는다. */
+  it("takes the cover down even when the chosen console refuses", async () => {
+    const picker = new EventEmitter();
+    const harness = createHarness({ responses: () => Response.json({ error: "remote_host_unknown" }, { status: 404 }) });
+    harness.bridge.attachPicker(picker as never);
+
+    picker.emit("will-navigate", { preventDefault: () => undefined }, `${REMOTE}/console/`, undefined, true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(harness.trace).toContain("picker:close");
+    expect(harness.notices[0]?.body).toContain("no longer in this list");
+  });
+
+  it("does not summon a second list from inside the list", async () => {
+    const picker = new EventEmitter();
+    const harness = createHarness();
+    harness.bridge.attachPicker(picker as never);
+
+    picker.emit("will-navigate", { preventDefault: () => undefined }, PICKER_OPEN_URL, undefined, true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(harness.trace).toEqual(["picker:close"]);
+  });
+
+  /**
+   * 이 신호를 모르는 옛 셸에게 이 URL은 그냥 집의 콘솔이다 — 목록 대신 집에 착지하는,
+   * 오늘과 똑같은 동선으로 강등된다. 그 판정이 유지되는지 여기서 못박는다.
+   */
+  it("still reads as the home console for a shell that never heard of the surface", () => {
+    expect(consoleTarget(PICKER_OPEN_URL, LOCAL)).toBe(LOCAL);
   });
 });

--- a/runtime/fleet-desktop/tests/window-policy.test.ts
+++ b/runtime/fleet-desktop/tests/window-policy.test.ts
@@ -1,6 +1,56 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { applyWindowPolicy, createSecureWindow, isAllowedConsoleUrl } from "../src/window-policy.js";
+import { applyWindowPolicy, confinePickerNavigation, createSecureWindow, isAllowedConsoleUrl } from "../src/window-policy.js";
+
+const HOME = "http://127.0.0.1:4310";
+
+function createPickerContents() {
+  const listeners = new Map<string, (...args: never[]) => unknown>();
+  const session = { setPermissionRequestHandler: vi.fn() };
+  const contents = {
+    on: vi.fn((name: string, listener: (...args: never[]) => unknown) => listeners.set(name, listener)),
+    setWindowOpenHandler: vi.fn(),
+    session,
+  };
+  return { contents, session, navigate: (url: string) => {
+    const preventDefault = vi.fn();
+    (listeners.get("will-navigate") as ((event: { preventDefault(): void }, url: string) => void))({ preventDefault }, url);
+    return preventDefault;
+  } };
+}
+
+describe("host picker view confinement", () => {
+  /**
+   * 이 뷰는 메인 창과 같은 defaultSession에 산다. applyWindowPolicy를 그대로 쓰면 세션 단위인
+   * 권한 핸들러를 집 origin 기준으로 갈아 끼우고, 덮개를 걷어도 그대로 남아 원격 콘솔의
+   * 클립보드 판정이 조용히 뒤집힌다. 그래서 세션에는 손대지 않는다.
+   */
+  it("never touches the session it shares with the main window", () => {
+    const { contents, session } = createPickerContents();
+
+    confinePickerNavigation(contents as never, HOME, () => false);
+
+    expect(session.setPermissionRequestHandler).not.toHaveBeenCalled();
+  });
+
+  it("keeps the list on its own console and denies popups", () => {
+    const { contents, navigate } = createPickerContents();
+    confinePickerNavigation(contents as never, HOME, () => false);
+
+    expect(navigate(`${HOME}/console/settings`)).not.toHaveBeenCalled();
+    expect(navigate(`${HOME}/api/v1/remote-hosts`)).toHaveBeenCalledOnce();
+    expect(navigate("https://100.84.12.7:6768/console/")).toHaveBeenCalledOnce();
+    expect(contents.setWindowOpenHandler.mock.calls[0]?.[0]?.({ url: "https://example.com" })).toEqual({ action: "deny" });
+  });
+
+  /** 콘솔을 갈아타는 항해는 remote bridge가 같은 이벤트에서 가져간다 — 여기서 막을 일이 아니다. */
+  it("leaves a console switch to the bridge", () => {
+    const { contents, navigate } = createPickerContents();
+    confinePickerNavigation(contents as never, HOME, (url) => url.startsWith("https://100.84.12.7:6768/console/"));
+
+    expect(navigate("https://100.84.12.7:6768/console/")).not.toHaveBeenCalled();
+  });
+});
 
 describe("secure window policy", () => {
   it("creates a renderer without Node or preload privilege", () => {


### PR DESCRIPTION
## Summary

- 원격 콘솔 B에서 호스트 박스를 열면, B의 데이터 대신 **집(A)이 자기 루프백에서 직접 그린 목록**이 B 위에 얹힙니다. 집으로 돌아왔다 다시 나가는 2-depth 없이 B → C로 바로 건너갑니다.
- Desktop이 센티넬 항해(`/console/?desktop-surface=host-picker`)를 가로채 A origin의 `WebContentsView`를 창 위에 올립니다. **B의 서버도 렌더러도 제3 기계의 주소·이름·지문을 받지 않습니다** — `runtime/fleet-console/AGENTS.md`의 "a remote session must not enumerate ... the addresses and certificate pins of third machines"를 문자 그대로 지킵니다.
- 원격 콘솔에서는 그 콘솔에 로스터를 **묻지도 않습니다**. 두 목록 경로는 어차피 루프백 전용 401이지만, 답이 없는 것과 묻지 않는 것은 다릅니다.
- 센티넬 판정은 `remote-bridge`의 기존 `will-navigate` 처리기 안에서 `consoleTarget`보다 먼저 이뤄집니다. `main.ts`에 별도 리스너를 달면 `window-policy`와의 등록 순서에 따라 조용히 오늘 동선(창째로 집 이동)으로 되돌아갑니다.
- 구형 Desktop 셸은 센티넬을 모르므로 그 URL을 집의 콘솔로 읽어 A에 착지합니다 — 오늘 동선으로 안전하게 강등됩니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` / `build` — 0 오류
- [x] `pnpm --filter @dotobokuri/fleet-desktop typecheck` / `build` — 0 오류
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 1797 passed / 24 skipped, 실패 0 (`instrument-design-contract` 포함: Add가 Manage 위 유지)
- [x] `pnpm --filter @dotobokuri/fleet-desktop test` — 265 passed / 2 failed. 실패 2건은 `tests/environment.test.ts`로, base 커밋에서도 동일하게 실패하는 선존 결함 (detached 체크아웃으로 대조 확인)
- [x] `pnpm check:core-boundary` — 통과
- [x] 신규 테스트: `remote-bridge.test.ts` 13건(센티넬 판정·양방향 가로채기·실패 시 덮개 걷힘·구형 셸 강등), `host-picker-view.test.ts` 10건(준비 전 숨김·멱등 파기·Esc·크래시·재소환 차단), `window-policy.test.ts` 3건(세션 미접촉), `host-picker-surface.test.tsx` 13건(B에 로스터 미요청·센티넬 발신·현재 행 표시)
- [x] 헤디드 실측: 격리 콘솔 + `known-hosts.json` 시드로 피커 표면 렌더 확인 — `at` origin이 현재 행(`aria-checked=true`, disabled), 칩 없음, `body` 배경 투명, JS 에러 0
- [ ] **미검증**: 실제 Desktop 오버레이 동작(기계 2대 + Desktop 앱 필요). `WebContentsView` 합성·Esc·핸드오프 후 파기는 단위 테스트로만 확인됨

## Changelog

- `.changelog.d/remote-host-box-unified.md` (fleet-console / Changed)