### PR TITLE
fix(console): keep the feature tour card opaque in every theme

### DIFF
--- a/.changelog.d/feature-tour-card-opacity.md
+++ b/.changelog.d/feature-tour-card-opacity.md
@@ -1,0 +1,8 @@
+---
+branch: feature-tour-card-opacity
+---
+
+### fleet-console
+#### Fixed
+- Keep the guided feature tour card opaque in the Carbon, Maritime, and Whites themes, so the canvas and panels behind it no longer show through the guidance text.
+  ko: Carbon·Maritime·Whites 테마에서 화면 안내 카드를 불투명하게 유지해, 안내 문구 뒤로 캔버스와 패널이 비쳐 보이지 않습니다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -10877,13 +10877,18 @@ body[data-codex-reading="true"] .operations-side-bar {
   pointer-events: none;
 }
 
+/* 팝업 판독성 계약: glass 믹스 아래 불투명 --ink-deep 언더레이(whatsnew-card의 canonical 주석 참조).
+   안내 카드는 스크림 없이 캔버스·패널 바로 위에 떠서 가리키는 대상 옆에 서므로, 반투명 glass
+   토큰을 쓰는 테마에서는 카드 본문과 뒤 화면이 겹쳐 읽힌다. */
 .feature-tour-card {
   position: fixed;
   width: min(340px, calc(100vw - 24px));
   padding: var(--space-4);
   border: 1px solid color-mix(in oklch, var(--brass) 34%, var(--hairline));
   border-radius: var(--radius-md);
-  background: var(--surface-glass-strong);
+  background:
+    linear-gradient(var(--surface-glass-strong), var(--surface-glass-strong)),
+    var(--ink-deep);
   box-shadow: var(--shadow-floating);
   color: var(--text-primary);
   pointer-events: auto;

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -946,11 +946,12 @@ describe("Instrument core design contract", () => {
     const layout = source("styles/layout.css");
     const skillsCss = externalSource(SKILLS_CSS_PATH);
     const terminalAnalysisCss = externalSource(TERMINAL_ANALYSIS_CSS_PATH);
-    // Doctrine: scrim-backed popup cards and floating menus composite their glass layers
-    // over an opaque var(--ink-deep) final layer — maritime/carbon glass tokens carry
-    // 60~80% alpha, so without the underlay popups bleed the canvas through and legibility
-    // collapses (canonical doctrine comment: .whatsnew-card in components.css). Non-popup
-    // glass surfaces keep the themes' translucent glass identity untouched.
+    // Doctrine: scrim-backed popup cards, floating menus, and anchored guidance cards
+    // composite their glass layers over an opaque var(--ink-deep) final layer —
+    // maritime/carbon/whites glass tokens carry 60~82% alpha, so without the underlay they
+    // bleed the canvas through and legibility collapses (canonical doctrine comment:
+    // .whatsnew-card in components.css). Non-popup glass surfaces keep the themes'
+    // translucent glass identity untouched.
     const componentsPopupSelectors = [
       ".whatsnew-card",
       ".commissioning-card",
@@ -966,6 +967,7 @@ describe("Instrument core design contract", () => {
       ".theater-menu",
       ".operation-search-card",
       ".quick-launch-card",
+      ".feature-tour-card",
     ];
     // Quick Launch 오버레이도 fleet-pop을 타므로 억제 절을 함께 못 박는다 — 규칙 옆에 붙은
     // 자체 reduced-motion 블록은 .fc-select__* 선례와 같은 형태다.


### PR DESCRIPTION
## Summary
- 화면 안내(feature tour) 카드가 `--surface-glass-strong`을 단독 배경으로 써서, 해당 토큰이 반투명인 Carbon(80%)·Maritime(78%)·Whites(82%) 테마에서 카드 뒤 캔버스·패널이 그대로 비쳐 안내 문구와 겹쳐 읽혔습니다. Instrument는 이 토큰이 불투명 별칭(`--ink-mid`)이라 증상이 없었습니다.
- 이미 리포에 있는 팝업 판독성 계약(glass 믹스 아래 불투명 `--ink-deep` 언더레이)을 이 카드에도 동일하게 적용했습니다. 스크림 없이 대상 옆에 서는 안내 카드라 뒤 콘텐츠와 가장 직접적으로 겹치는 표면입니다.
- `tests/instrument-design-contract.test.ts`의 팝업 언더레이 계약 목록에 `.feature-tour-card`를 추가해 회귀를 잠갔습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test -- tests/instrument-design-contract.test.ts` (48 passed) — 새 계약 항목 포함
- [x] `pnpm --filter @dotobokuri/fleet-console test -- tests/instrument-design-contract.test.ts tests/feature-tour.test.ts tests/feature-tour-serialization.test.tsx` (73 passed)
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` (exit 0), `build` (exit 0)
- [x] 격리 Console + 실브라우저 실측: 카드 뒤에 순수 적색 프로브를 깔고 카드 영역 평균 RGB 측정 — Carbon `R=46.0/G=47.8/B=49.3`(수정 전 `R=90.5`), Maritime `R=38.5/G=55.1/B=69.5`(수정 전 `R=89.6`), Whites `R=232.4/G=231.1/B=226.1`(수정 전 `R=235.0/G=192.0/B=187.1`). 세 테마 모두 적색 누출이 사라졌고 페이지 에러·rejection 0건.
- [x] `.changelog.d/feature-tour-card-opacity.md` 추가, `node scripts/compile-changelog-fragments.mjs --check` 통과