### PR TITLE
feat(console): launch from selected effort track rung

### DIFF
--- a/.changelog.d/effort-circle-reclick-launch.md
+++ b/.changelog.d/effort-circle-reclick-launch.md
@@ -1,0 +1,8 @@
+---
+branch: effort-circle-reclick-launch
+---
+
+### fleet-console
+#### Changed
+- After setting reasoning effort on a Canvas launch track (for example HIGH), clicking that same selected rung again, or pressing Enter on the track, launches with that model and effort. Moving the gauge still only changes the pending level; AUTO stays a set-only rung, and Quick Launch is unchanged.
+  ko: 캔버스 실행 메뉴에서 추론 강도 트랙을 HIGH처럼 한 단으로 맞춘 뒤, 그 선택된 단을 다시 누르거나 트랙에서 Enter를 누르면 해당 모델과 강도로 바로 실행합니다. 게이지를 옮기는 동작은 여전히 대기 중인 강도만 바꾸고, 자동 단은 값만 비우는 자리로 남으며 Quick Launch 동작은 그대로입니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -589,7 +589,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                 // 고른 강도도 종류·그룹까지 묶어야 같은 id를 쓰는 다른 행에 조용히 새지 않는다.
                 const rowKey = effortKey(openFlyout, group.id, row.id);
                 const effortOpen = hasEffort && openEffortRow === rowKey;
-                // 트랙은 값만 정한다 — 실행은 이 행이 일으키고, 고른 강도를 그대로 싣는다.
+                // 트랙으로 단을 고르고, 행을 누르거나 같은 단을 다시 확정하면 그 강도를 싣고 실행한다.
                 const chosenEffort = rowEfforts[rowKey] ?? null;
                 const chosenChip = chosenEffort === null
                   ? undefined
@@ -706,6 +706,14 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
             row={effortTarget}
             value={rowEfforts[openEffortRow] ?? null}
             onChange={(next) => setRowEfforts((previous) => ({ ...previous, [openEffortRow]: next }))}
+            onConfirmCurrent={() => {
+              // 자동을 다시 누르는 것은 값을 비운 채 머무는 일이다 — 모델만 싣는 실행은 행 본문이 맡는다.
+              const effort = rowEfforts[openEffortRow] ?? null;
+              if (effort === null) return;
+              const chip = effortTarget.chips?.find((entry) => entry.id === effort);
+              if (!chip) return;
+              onLaunchKind(flyoutTarget.pluginId, flyoutTarget.kind, chip.launch);
+            }}
             autoLabel={t("launchVariants.effort.auto")}
             ariaLabel={t("launchVariants.effort.track")}
             autoValueText={t("launchVariants.effort.autoValue")}

--- a/runtime/fleet-console/core/client/src/components/effort-track.tsx
+++ b/runtime/fleet-console/core/client/src/components/effort-track.tsx
@@ -41,7 +41,8 @@ export function EffortTrack({ row, value, onChange, onConfirmCurrent, autoLabel,
   // 제스처 동안 React 커밋을 기다리지 않고 고른 단을 추적한다 — 같은 포인터 시퀀스에서
   // "다른 단으로 옮겼다"와 "처음부터 이 단을 다시 눌렀다"를 갈라야 한다.
   const liveIndexRef = useRef(0);
-  const gestureRef = useRef<{ readonly originIndex: number; dirty: boolean } | null>(null);
+  // pointerId까지 묶어 두면 터치에서 두 번째 손가락(button===0)이 제스처를 덮어 쓰지 못한다.
+  const gestureRef = useRef<{ readonly pointerId: number; readonly originIndex: number; dirty: boolean } | null>(null);
 
   const slots = useMemo<readonly EffortSlot[]>(() => {
     const byId = new Map<string, OperationLaunchVariantChip>((row.chips ?? []).map((chip) => [chip.id, chip]));
@@ -95,11 +96,13 @@ export function EffortTrack({ row, value, onChange, onConfirmCurrent, autoLabel,
 
   const endGesture = useCallback((event: PointerEvent<HTMLDivElement>, { confirm }: { readonly confirm: boolean }) => {
     const gesture = gestureRef.current;
-    gestureRef.current = null;
     if (event.currentTarget.hasPointerCapture(event.pointerId)) {
       event.currentTarget.releasePointerCapture(event.pointerId);
     }
-    if (!confirm || !gesture || gesture.dirty || !onConfirmCurrent) return;
+    // 시작한 포인터만 끝낸다 — 다른 접촉의 up이 활성 제스처를 지우면 안 된다.
+    if (!gesture || gesture.pointerId !== event.pointerId) return;
+    gestureRef.current = null;
+    if (!confirm || gesture.dirty || !onConfirmCurrent) return;
     // 주버튼으로 트랙 안에서 손을 뗄 때만 확정한다 — 우클릭·가운데 클릭이나
     // 세로로 트랙 밖까지 끌어 뺀 해제는 값을 고르는 실수가 되지 않게 막는다.
     if (event.button !== 0) return;
@@ -165,15 +168,19 @@ export function EffortTrack({ row, value, onChange, onConfirmCurrent, autoLabel,
         data-auto={isAuto ? true : undefined}
         onKeyDown={handleKeyDown}
         onPointerDown={(event) => {
+          // 주 접촉만 받는다. 터치 두 번째 손가락도 button===0이라 isPrimary·활성 제스처로 막는다.
+          if (!event.isPrimary || event.button !== 0 || gestureRef.current) return;
           event.preventDefault();
           event.currentTarget.setPointerCapture(event.pointerId);
           event.currentTarget.focus();
-          gestureRef.current = { originIndex: liveIndexRef.current, dirty: false };
+          gestureRef.current = { pointerId: event.pointerId, originIndex: liveIndexRef.current, dirty: false };
           fromPointer(event);
         }}
         onPointerMove={(event) => {
           const next = indexFromPointer(event.clientX);
           if (next !== null) setPreviewIndex(next);
+          const gesture = gestureRef.current;
+          if (!gesture || gesture.pointerId !== event.pointerId) return;
           if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
           fromPointer(event);
         }}

--- a/runtime/fleet-console/core/client/src/components/effort-track.tsx
+++ b/runtime/fleet-console/core/client/src/components/effort-track.tsx
@@ -17,6 +17,12 @@ export interface EffortTrackProps {
   /** 선택된 강도. `null`은 강도를 비운 상태(모델 기본값)다. */
   readonly value: string | null;
   readonly onChange: (effort: string | null) => void;
+  /**
+   * 이미 고른 단에 다시 눌렀을 때. 드래그로 다른 단을 거쳐 돌아온 경우는 호출하지 않는다 —
+   * 값을 고르는 제스처와 "이 값으로 확정" 제스처를 갈라야 한다. 생략하면 같은 단 재클릭은
+   * 아무 일도 없다(Quick Launch처럼 제출이 다른 자리인 표면).
+   */
+  readonly onConfirmCurrent?: () => void;
   /** 강도를 비운 상태를 트랙 맨 앞 자리로 노출한다. */
   readonly autoLabel: string;
   readonly ariaLabel: string;
@@ -29,9 +35,13 @@ export interface EffortTrackProps {
  * 모델이 내놓지 않은 단도 자리를 지킨다 — low/high/max만 있는 모델에서 셋을 균등히 벌리면
  * high가 한가운데 서서, 실제로는 3/5 지점인 단을 절반이라고 말하게 된다.
  */
-export function EffortTrack({ row, value, onChange, autoLabel, ariaLabel, autoValueText, className }: EffortTrackProps) {
+export function EffortTrack({ row, value, onChange, onConfirmCurrent, autoLabel, ariaLabel, autoValueText, className }: EffortTrackProps) {
   const trackRef = useRef<HTMLDivElement | null>(null);
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+  // 제스처 동안 React 커밋을 기다리지 않고 고른 단을 추적한다 — 같은 포인터 시퀀스에서
+  // "다른 단으로 옮겼다"와 "처음부터 이 단을 다시 눌렀다"를 갈라야 한다.
+  const liveIndexRef = useRef(0);
+  const gestureRef = useRef<{ readonly originIndex: number; dirty: boolean } | null>(null);
 
   const slots = useMemo<readonly EffortSlot[]>(() => {
     const byId = new Map<string, OperationLaunchVariantChip>((row.chips ?? []).map((chip) => [chip.id, chip]));
@@ -47,6 +57,7 @@ export function EffortTrack({ row, value, onChange, autoLabel, ariaLabel, autoVa
   const index = Math.max(0, slots.findIndex((slot) => slot.id === value));
   const current = slots[index]!;
   const isAuto = current.id === null;
+  liveIndexRef.current = index;
 
   const nearestSelectable = useCallback((target: number): number => {
     const bounded = Math.max(0, Math.min(target, last));
@@ -55,14 +66,16 @@ export function EffortTrack({ row, value, onChange, autoLabel, ariaLabel, autoVa
       if (slots[bounded - step]?.selectable) return bounded - step;
       if (slots[bounded + step]?.selectable) return bounded + step;
     }
-    return index;
-  }, [index, last, slots]);
+    return liveIndexRef.current;
+  }, [last, slots]);
 
   const commit = useCallback((next: number) => {
     const slot = slots[next];
-    if (!slot || slot.id === current.id) return;
+    if (!slot || slot.id === slots[liveIndexRef.current]?.id) return false;
+    liveIndexRef.current = next;
     onChange(slot.id);
-  }, [current.id, onChange, slots]);
+    return true;
+  }, [onChange, slots]);
 
   const indexFromPointer = useCallback((clientX: number): number | null => {
     const track = trackRef.current;
@@ -76,8 +89,21 @@ export function EffortTrack({ row, value, onChange, autoLabel, ariaLabel, autoVa
 
   const fromPointer = useCallback((event: PointerEvent<HTMLDivElement>) => {
     const next = indexFromPointer(event.clientX);
-    if (next !== null) commit(next);
+    if (next === null) return;
+    if (commit(next) && gestureRef.current) gestureRef.current.dirty = true;
   }, [commit, indexFromPointer]);
+
+  const endGesture = useCallback((event: PointerEvent<HTMLDivElement>, { confirm }: { readonly confirm: boolean }) => {
+    const gesture = gestureRef.current;
+    gestureRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    if (!confirm || !gesture || gesture.dirty || !onConfirmCurrent) return;
+    const next = indexFromPointer(event.clientX);
+    // 처음부터 고른 단을 다시 눌렀고, 그 사이 다른 단으로 옮기지 않았을 때만 확정한다.
+    if (next === gesture.originIndex) onConfirmCurrent();
+  }, [indexFromPointer, onConfirmCurrent]);
 
   const handleKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
     const direction = event.key === "ArrowLeft" || event.key === "ArrowDown"
@@ -92,12 +118,18 @@ export function EffortTrack({ row, value, onChange, autoLabel, ariaLabel, autoVa
     }
     if (event.key === "Home") next = 0;
     if (event.key === "End") next = nearestSelectable(last);
+    if (event.key === "Enter" && onConfirmCurrent) {
+      event.preventDefault();
+      event.stopPropagation();
+      onConfirmCurrent();
+      return;
+    }
     if (next === null) return;
     event.preventDefault();
     // 트랙은 메뉴 안에 산다. 방향키가 위로 새면 메뉴가 항목 이동으로 받아 함께 움직인다.
     event.stopPropagation();
     commit(next);
-  }, [commit, index, last, nearestSelectable, slots]);
+  }, [commit, index, last, nearestSelectable, onConfirmCurrent, slots]);
 
   const ratio = last === 0 ? 0 : index / last;
 
@@ -122,6 +154,7 @@ export function EffortTrack({ row, value, onChange, autoLabel, ariaLabel, autoVa
           event.preventDefault();
           event.currentTarget.setPointerCapture(event.pointerId);
           event.currentTarget.focus();
+          gestureRef.current = { originIndex: liveIndexRef.current, dirty: false };
           fromPointer(event);
         }}
         onPointerMove={(event) => {
@@ -130,8 +163,9 @@ export function EffortTrack({ row, value, onChange, autoLabel, ariaLabel, autoVa
           if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
           fromPointer(event);
         }}
+        onPointerUp={(event) => endGesture(event, { confirm: true })}
         onPointerLeave={() => setPreviewIndex(null)}
-        onPointerCancel={() => setPreviewIndex(null)}
+        onPointerCancel={(event) => endGesture(event, { confirm: false })}
       >
         {/* 자동은 폭 0이다. 손잡이 여백(EDGE)만큼이라도 남기면 트랙 왼쪽 끝에 brass 조각이 비쳐,
             비운 상태가 최소 강도를 고른 것처럼 보인다. */}

--- a/runtime/fleet-console/core/client/src/components/effort-track.tsx
+++ b/runtime/fleet-console/core/client/src/components/effort-track.tsx
@@ -100,6 +100,20 @@ export function EffortTrack({ row, value, onChange, onConfirmCurrent, autoLabel,
       event.currentTarget.releasePointerCapture(event.pointerId);
     }
     if (!confirm || !gesture || gesture.dirty || !onConfirmCurrent) return;
+    // 주버튼으로 트랙 안에서 손을 뗄 때만 확정한다 — 우클릭·가운데 클릭이나
+    // 세로로 트랙 밖까지 끌어 뺀 해제는 값을 고르는 실수가 되지 않게 막는다.
+    if (event.button !== 0) return;
+    const track = trackRef.current;
+    if (!track) return;
+    const rect = track.getBoundingClientRect();
+    if (
+      event.clientX < rect.left
+      || event.clientX > rect.right
+      || event.clientY < rect.top
+      || event.clientY > rect.bottom
+    ) {
+      return;
+    }
     const next = indexFromPointer(event.clientX);
     // 처음부터 고른 단을 다시 눌렀고, 그 사이 다른 단으로 옮기지 않았을 때만 확정한다.
     if (next === gesture.originIndex) onConfirmCurrent();

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -458,14 +458,19 @@ describe("CanvasContextMenu launch kind attribute", () => {
     act(() => row.dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
     expect(document.querySelector(".effort-track")).toBeNull();
 
-    // 트랙은 값만 정한다 — 실행은 여전히 모델 행이 일으킨다.
+    // End는 단만 고른다. 같은 단을 다시 확정(Enter)하면 그 강도로 출격한다.
     act(() => effortHandle("fable").dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
     const track = document.querySelector<HTMLElement>(".effort-track")!;
     expect(track).not.toBeNull();
+    act(() => track.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true })));
+    expect(onLaunchKind).toHaveBeenCalledTimes(1);
     act(() => track.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true })));
     expect(onLaunchKind).toHaveBeenCalledTimes(1);
+    act(() => track.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true })));
+    expect(onLaunchKind).toHaveBeenCalledTimes(2);
+    expect(onLaunchKind).toHaveBeenLastCalledWith("terminal", catalog[0]!.kinds[0], { model: "fable", effort: "max" });
 
-    // 고른 강도는 행에 되비치고, 그 행을 눌러야 실행된다.
+    // 고른 강도는 행에도 되비치고, 그 행을 눌러도 같은 페이로드로 실행된다.
     expect(effortHandle("fable").querySelector(".operation-launch-variant-effort")?.textContent).toBe("MAX");
     expect(effortHandle("fable").dataset.effortLevel).toBe("max");
     act(() => document.querySelector<HTMLButtonElement>('[data-launch-variant-row="fable"]')!.click());

--- a/runtime/fleet-console/tests/effort-track.test.tsx
+++ b/runtime/fleet-console/tests/effort-track.test.tsx
@@ -245,8 +245,8 @@ describe("EffortTrack", () => {
 
     // high(3) 자리: EDGE 13 + 0.6 × (126 − 26) = 73. 같은 단을 다시 누르면 값이 아니라 확정이다.
     act(() => {
-      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, button: 0, clientX: 73, clientY: 13 }));
-      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, clientX: 73, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 73, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 73, clientY: 13 }));
     });
     expect(onChange).not.toHaveBeenCalled();
     expect(onConfirmCurrent).toHaveBeenCalledTimes(1);
@@ -264,9 +264,9 @@ describe("EffortTrack", () => {
 
     // high → max로 옮긴 뒤 손을 떼면 값만 바뀌고 확정은 없다 — 그 제스처는 "고르기"다.
     act(() => {
-      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, button: 0, clientX: 73, clientY: 13 }));
-      element.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerId: 1, button: 0, clientX: 113, clientY: 13 }));
-      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, clientX: 113, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 73, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 113, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 113, clientY: 13 }));
     });
     expect(onChange).toHaveBeenCalledWith("max");
     expect(onConfirmCurrent).not.toHaveBeenCalled();
@@ -280,17 +280,39 @@ describe("EffortTrack", () => {
 
     // 우클릭은 X가 같은 단이어도 확정이 아니다.
     act(() => {
-      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 2, button: 2, clientX: 73, clientY: 13 }));
-      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 2, button: 2, clientX: 73, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 2, button: 2, isPrimary: true, clientX: 73, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 2, button: 2, isPrimary: true, clientX: 73, clientY: 13 }));
     });
     expect(onConfirmCurrent).not.toHaveBeenCalled();
 
     // 세로로 트랙 밖에서 손을 떼면 같은 X라도 확정하지 않는다.
     act(() => {
-      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 3, button: 0, clientX: 73, clientY: 13 }));
-      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 3, button: 0, clientX: 73, clientY: 40 }));
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 3, button: 0, isPrimary: true, clientX: 73, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 3, button: 0, isPrimary: true, clientX: 73, clientY: 40 }));
     });
     expect(onConfirmCurrent).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("ignores a second contact while the first gesture is active", () => {
+    const onChange = vi.fn();
+    const onConfirmCurrent = vi.fn();
+    render(row(), "high", onChange, onConfirmCurrent);
+    const element = stubTrackPointer();
+
+    // 첫 손가락은 잡고, 두 번째(비-primary)가 같은 단에서 떼어도 확정하지 않는다.
+    act(() => {
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 73, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 2, button: 0, isPrimary: false, clientX: 73, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 2, button: 0, isPrimary: false, clientX: 73, clientY: 13 }));
+    });
+    expect(onConfirmCurrent).not.toHaveBeenCalled();
+
+    // 시작한 포인터를 같은 단에서 떼면 그때 확정한다.
+    act(() => {
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 73, clientY: 13 }));
+    });
+    expect(onConfirmCurrent).toHaveBeenCalledTimes(1);
     expect(onChange).not.toHaveBeenCalled();
   });
 
@@ -300,8 +322,8 @@ describe("EffortTrack", () => {
     const element = stubTrackPointer();
 
     act(() => {
-      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, button: 0, clientX: 73, clientY: 13 }));
-      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, clientX: 73, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 73, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 73, clientY: 13 }));
     });
     expect(onChange).not.toHaveBeenCalled();
   });

--- a/runtime/fleet-console/tests/effort-track.test.tsx
+++ b/runtime/fleet-console/tests/effort-track.test.tsx
@@ -40,18 +40,48 @@ function row(overrides: Partial<OperationLaunchVariantRow> = {}): OperationLaunc
   };
 }
 
-function render(node: OperationLaunchVariantRow, value: string | null, onChange = vi.fn()) {
+function render(
+  node: OperationLaunchVariantRow,
+  value: string | null,
+  onChange = vi.fn(),
+  onConfirmCurrent?: () => void,
+) {
   act(() => root.render(
     <EffortTrack
       row={node}
       value={value}
       onChange={onChange}
+      onConfirmCurrent={onConfirmCurrent}
       autoLabel="AUTO"
       ariaLabel="Reasoning effort"
       autoValueText="Automatic"
     />,
   ));
   return onChange;
+}
+
+function stubTrackPointer(width = 126) {
+  const element = track();
+  let captured: number | null = null;
+  Object.defineProperties(element, {
+    getBoundingClientRect: {
+      configurable: true,
+      value: () => ({ left: 0, right: width, top: 0, bottom: 26, width, height: 26, x: 0, y: 0, toJSON: () => ({}) }),
+    },
+    setPointerCapture: {
+      configurable: true,
+      value: (pointerId: number) => { captured = pointerId; },
+    },
+    releasePointerCapture: {
+      configurable: true,
+      value: () => { captured = null; },
+    },
+    hasPointerCapture: {
+      configurable: true,
+      value: (pointerId: number) => captured === pointerId,
+    },
+  });
+  return element;
 }
 
 function stops(): readonly HTMLElement[] {
@@ -205,6 +235,53 @@ describe("EffortTrack", () => {
     // 비운 상태는 축의 맨 앞이지 최대가 아니다.
     render(row({ chips: [] }), null);
     expect(track().dataset.atMax).toBeUndefined();
+  });
+
+  it("confirms the current rung on re-press when onConfirmCurrent is set", () => {
+    const onChange = vi.fn();
+    const onConfirmCurrent = vi.fn();
+    render(row(), "high", onChange, onConfirmCurrent);
+    const element = stubTrackPointer();
+
+    // high(3) 자리: EDGE 13 + 0.6 × (126 − 26) = 73. 같은 단을 다시 누르면 값이 아니라 확정이다.
+    act(() => {
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, clientX: 73 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, clientX: 73 }));
+    });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onConfirmCurrent).toHaveBeenCalledTimes(1);
+
+    onConfirmCurrent.mockClear();
+    act(() => element.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true })));
+    expect(onConfirmCurrent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not confirm when the pointer first moves to another rung", () => {
+    const onChange = vi.fn();
+    const onConfirmCurrent = vi.fn();
+    render(row(), "high", onChange, onConfirmCurrent);
+    const element = stubTrackPointer();
+
+    // high → max로 옮긴 뒤 손을 떼면 값만 바뀌고 확정은 없다 — 그 제스처는 "고르기"다.
+    act(() => {
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, clientX: 73 }));
+      element.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerId: 1, clientX: 113 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, clientX: 113 }));
+    });
+    expect(onChange).toHaveBeenCalledWith("max");
+    expect(onConfirmCurrent).not.toHaveBeenCalled();
+  });
+
+  it("leaves same-rung re-press quiet when onConfirmCurrent is omitted", () => {
+    const onChange = vi.fn();
+    render(row(), "high", onChange);
+    const element = stubTrackPointer();
+
+    act(() => {
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, clientX: 73 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, clientX: 73 }));
+    });
+    expect(onChange).not.toHaveBeenCalled();
   });
 });
 

--- a/runtime/fleet-console/tests/effort-track.test.tsx
+++ b/runtime/fleet-console/tests/effort-track.test.tsx
@@ -245,8 +245,8 @@ describe("EffortTrack", () => {
 
     // high(3) 자리: EDGE 13 + 0.6 × (126 − 26) = 73. 같은 단을 다시 누르면 값이 아니라 확정이다.
     act(() => {
-      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, clientX: 73 }));
-      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, clientX: 73 }));
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, button: 0, clientX: 73, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, clientX: 73, clientY: 13 }));
     });
     expect(onChange).not.toHaveBeenCalled();
     expect(onConfirmCurrent).toHaveBeenCalledTimes(1);
@@ -264,12 +264,34 @@ describe("EffortTrack", () => {
 
     // high → max로 옮긴 뒤 손을 떼면 값만 바뀌고 확정은 없다 — 그 제스처는 "고르기"다.
     act(() => {
-      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, clientX: 73 }));
-      element.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerId: 1, clientX: 113 }));
-      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, clientX: 113 }));
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, button: 0, clientX: 73, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerId: 1, button: 0, clientX: 113, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, clientX: 113, clientY: 13 }));
     });
     expect(onChange).toHaveBeenCalledWith("max");
     expect(onConfirmCurrent).not.toHaveBeenCalled();
+  });
+
+  it("does not confirm a secondary-button release or a release outside the track", () => {
+    const onChange = vi.fn();
+    const onConfirmCurrent = vi.fn();
+    render(row(), "high", onChange, onConfirmCurrent);
+    const element = stubTrackPointer();
+
+    // 우클릭은 X가 같은 단이어도 확정이 아니다.
+    act(() => {
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 2, button: 2, clientX: 73, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 2, button: 2, clientX: 73, clientY: 13 }));
+    });
+    expect(onConfirmCurrent).not.toHaveBeenCalled();
+
+    // 세로로 트랙 밖에서 손을 떼면 같은 X라도 확정하지 않는다.
+    act(() => {
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 3, button: 0, clientX: 73, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 3, button: 0, clientX: 73, clientY: 40 }));
+    });
+    expect(onConfirmCurrent).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it("leaves same-rung re-press quiet when onConfirmCurrent is omitted", () => {
@@ -278,8 +300,8 @@ describe("EffortTrack", () => {
     const element = stubTrackPointer();
 
     act(() => {
-      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, clientX: 73 }));
-      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, clientX: 73 }));
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, button: 0, clientX: 73, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, clientX: 73, clientY: 13 }));
     });
     expect(onChange).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- 캔버스 제어 컨텍스트 메뉴에서 추론 강도 트랙을 HIGH처럼 한 단으로 맞춘 뒤, 그 선택된 단을 다시 누르거나 Enter로 확정하면 해당 모델·강도로 바로 출격합니다.
- 게이지를 다른 단으로 옮기는 동작은 여전히 대기 중인 강도만 바꾸고, AUTO 재클릭은 값만 비운 채 머무르며 Quick Launch는 `onConfirmCurrent`를 쓰지 않아 기존 제출 흐름을 유지합니다.
- 릴리스 노트: `.changelog.d/effort-circle-reclick-launch.md`

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/effort-track.test.tsx tests/canvas-context-menu-anchor.test.tsx`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [ ] 헤디드/격리 Console에서 강도 단 설정 → 같은 단 재클릭으로 패널 출격 확인