### PR TITLE
fix(fleet-console): let Quick Launch file lookup reach the whole Theater

### DIFF
--- a/.changelog.d/quick-launch-search-proposal.md
+++ b/.changelog.d/quick-launch-search-proposal.md
@@ -4,5 +4,5 @@ branch: quick-launch-search-proposal
 
 ### fleet-console
 #### Added
-- Quick Launch can find Theater-relative files from a directly typed `@` query and insert a selected path without submitting the prompt.
-  ko: Quick Launch에서 직접 입력한 `@` 검색으로 Theater 상대 파일을 찾고, 프롬프트를 제출하지 않고 선택한 경로를 삽입할 수 있습니다.
+- Quick Launch can find Theater-relative files from a directly typed `@` query, skips paths the project already ignores such as dependency and version-control directories, lists recently modified files while the query is still empty, and inserts a selected path without submitting the prompt.
+  ko: Quick Launch에서 직접 입력한 `@` 검색으로 Theater 상대 파일을 찾고, 의존성·버전 관리 디렉터리처럼 프로젝트가 이미 무시하는 경로는 건너뛰며, 검색어가 비어 있는 동안에는 최근 수정한 파일을 보여 주고, 프롬프트를 제출하지 않고 선택한 경로를 삽입할 수 있습니다.

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -189,7 +189,8 @@ export function QuickLaunch() {
     fileSearchAbortRef.current?.abort();
     if (fileSearchTimerRef.current !== null) window.clearTimeout(fileSearchTimerRef.current);
     const generation = ++fileSearchGenerationRef.current;
-    if (token.query.length === 0) { setFileResults([]); return; }
+    // 쿼리가 비어도 검색한다 — `@`만 친 시점이 "무엇을 붙일지 아직 모른다"는 뜻이므로, 그때가
+    // 목록이 가장 필요한 순간이다(서버가 최근 만진 파일부터 돌려준다).
     fileSearchTimerRef.current = window.setTimeout(() => {
       const abort = new AbortController();
       fileSearchAbortRef.current = abort;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -11014,7 +11014,10 @@ body[data-codex-reading="true"] .operations-side-bar {
 .quick-launch-file-picker {
   display: grid;
   gap: 1px;
-  max-height: 256px;
+  /* 목록은 최대 8건이다(서버 limit). 8행이 스크롤 없이 들어가도록 한 행만큼 여유를 두고 상한을
+     잡는다 — 행 높이는 내용에 따라 1px씩 흔들려서, 8행에 딱 맞춘 상한은 마지막 행을 반쯤 걸친 채
+     멈추고 목록이 더 있는지 없는지를 못 읽게 만든다. 더 좁은 창은 overflow-y가 받는다. */
+  max-height: calc((9 * 32px) + (8 * 1px) + (2 * var(--space-1)));
   overflow-y: auto;
   padding: var(--space-1) var(--space-2);
   border-top: 1px solid var(--surface-rim);

--- a/runtime/fleet-plugins/file-explorer/server/tree-services.ts
+++ b/runtime/fleet-plugins/file-explorer/server/tree-services.ts
@@ -190,7 +190,7 @@ interface GitStatusDependencies {
   readonly environment?: NodeJS.ProcessEnv;
 }
 
-interface GitExecOptions {
+export interface GitExecOptions {
   readonly env: NodeJS.ProcessEnv;
   readonly killSignal: "SIGKILL";
   readonly maxBuffer: number;
@@ -363,13 +363,80 @@ function mapGitStatusFsError(error: unknown): GitStatusPathError {
 
 const SEARCH_DIRECTORY_CAP = 500;
 const SEARCH_ENTRY_CAP = 25_000;
+// 무시 규칙을 읽을 수 없는 Theater에서도 훑기가 의존성·VCS 디렉터리에 통째로 잡아먹히지 않게 막는
+// 최소 방어선이다. 규칙을 읽을 수 있으면 아래 git 경로가 이 목록보다 정확하다.
+const FALLBACK_IGNORED_DIRECTORY_NAMES = new Set([
+  ".git", ".hg", ".svn",
+  "node_modules", "vendor", "__pycache__", ".venv", "venv",
+  "dist", "build", "out", "target", "coverage",
+  ".next", ".nuxt", ".turbo", ".cache",
+]);
+// 최근순은 후보 전부의 mtime을 읽어야 한다. 그보다 큰 Theater는 경로 순으로 떨어뜨려, 목록 하나
+// 띄우자고 수만 번 stat을 돌지 않게 한다.
+const RECENT_STAT_CAP = 20_000;
 
-export async function searchTheaterFiles(theaterPath: string, query: string, limit: number): Promise<FileSearchItem[]> {
+export interface FileSearchDependencies {
+  readonly execGit?: (args: readonly string[], options: GitExecOptions) => Promise<string>;
+  readonly environment?: NodeJS.ProcessEnv;
+}
+
+export async function searchTheaterFiles(
+  theaterPath: string,
+  query: string,
+  limit: number,
+  deps: FileSearchDependencies = {},
+): Promise<FileSearchItem[]> {
   const realRoot = await fsp.realpath(theaterPath);
+  const candidates = await listTheaterFileCandidates(realRoot, deps);
   const tokens = query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+  // 쿼리가 비면 이름으로 고를 기준이 없다. 방금 만진 파일이 사용자가 가리키려는 파일이다.
+  if (tokens.length === 0) return await pickRecentlyModified(realRoot, candidates, limit);
+  const matches = candidates
+    .filter((relativePath) => {
+      const low = relativePath.toLocaleLowerCase();
+      return tokens.every((token) => low.includes(token));
+    })
+    .sort((left, right) => compareFileSearchItem({ relativePath: left }, { relativePath: right }, query));
+  return await takeExistingFiles(realRoot, matches, limit);
+}
+
+async function listTheaterFileCandidates(realRoot: string, deps: FileSearchDependencies): Promise<readonly string[]> {
+  // 무시 규칙의 판정자는 git이다 — 중첩 .gitignore, 부정 패턴, 사용자 전역 excludes까지 한 번에 맞는다.
+  // 결과가 비면 Theater 자체가 무시된 경로(예: 빌드 산출물 디렉터리)일 수 있으므로 훑기로 되돌린다.
+  const tracked = await listGitTheaterFiles(realRoot, deps);
+  return tracked && tracked.length > 0 ? tracked : await walkTheaterFiles(realRoot);
+}
+
+async function listGitTheaterFiles(realRoot: string, deps: FileSearchDependencies): Promise<readonly string[] | null> {
+  const execGit = deps.execGit ?? executeGit;
+  try {
+    const stdout = await execGit(
+      [
+        "-c", "core.fsmonitor=false",
+        "--no-optional-locks",
+        "-C", realRoot,
+        // --others + --exclude-standard: 아직 커밋하지 않은 새 파일도 후보에 남기되 무시 대상은 뺀다.
+        "ls-files", "--cached", "--others", "--exclude-standard", "-z", "--", ".",
+      ],
+      {
+        env: sanitizeGitEnvironment(deps.environment ?? process.env),
+        killSignal: "SIGKILL",
+        maxBuffer: GIT_MAX_BUFFER,
+        timeout: GIT_TIMEOUT_MS,
+      },
+    );
+    // -z 출력은 항목마다 NUL로 끝나므로 마지막 조각은 항상 빈 문자열이다.
+    return stdout.split("\0").filter((entry) => entry !== "");
+  } catch {
+    // git이 없거나 Theater가 저장소가 아니다 — 호출자가 훑기로 떨어진다.
+    return null;
+  }
+}
+
+async function walkTheaterFiles(realRoot: string): Promise<readonly string[]> {
   const pending: Array<{ readonly absolutePath: string; readonly relativePath: string }> = [{ absolutePath: realRoot, relativePath: "" }];
   const visited = new Set<string>();
-  const matches: FileSearchItem[] = [];
+  const files: string[] = [];
   let directoryCount = 0;
   let entryCount = 0;
 
@@ -405,18 +472,63 @@ export async function searchTheaterFiles(theaterPath: string, query: string, lim
         }
       }
       if (kind === "dir") {
+        if (FALLBACK_IGNORED_DIRECTORY_NAMES.has(entry.name)) continue;
         if (!visited.has(realPath)) pending.push({ absolutePath: realPath, relativePath });
         continue;
       }
       if (kind !== "file") continue;
-      const low = relativePath.toLocaleLowerCase();
-      if (tokens.every((token) => low.includes(token))) matches.push({ relativePath });
+      files.push(relativePath);
     }
   }
 
-  return matches
-    .sort((left, right) => compareFileSearchItem(left, right, query))
-    .slice(0, limit);
+  return files;
+}
+
+async function pickRecentlyModified(realRoot: string, candidates: readonly string[], limit: number): Promise<FileSearchItem[]> {
+  if (candidates.length > RECENT_STAT_CAP) {
+    const shallowFirst = [...candidates].sort(compareByDepthThenPath);
+    return await takeExistingFiles(realRoot, shallowFirst, limit);
+  }
+  const stamped = await Promise.all(candidates.map(async (relativePath) => {
+    const stat = await statContainedFile(realRoot, relativePath);
+    return stat === null ? null : { relativePath, mtimeMs: stat.mtimeMs };
+  }));
+  return stamped
+    .filter((entry): entry is { relativePath: string; mtimeMs: number } => entry !== null)
+    .sort((left, right) => right.mtimeMs - left.mtimeMs || left.relativePath.localeCompare(right.relativePath))
+    .slice(0, limit)
+    .map(({ relativePath }) => ({ relativePath }));
+}
+
+// git 인덱스는 지운 파일도 계속 들고 있다. 목록에 올릴 만큼만 존재를 확인해, 열 수 없는 경로를
+// 제시하지 않으면서도 후보 전체를 stat하지는 않는다.
+async function takeExistingFiles(realRoot: string, relativePaths: readonly string[], limit: number): Promise<FileSearchItem[]> {
+  const items: FileSearchItem[] = [];
+  for (const relativePath of relativePaths) {
+    if (items.length >= limit) break;
+    if (await statContainedFile(realRoot, relativePath) !== null) items.push({ relativePath });
+  }
+  return items;
+}
+
+// 후보가 어디서 왔든 Theater 밖을 가리키는 경로는 목록에 오르지 않는다 — 훑기가 심링크에 대해
+// 지키던 불변식을 git 목록도 똑같이 지켜야 한다. 어휘 검사 뒤 해석된 실경로로 포함을 확인한다.
+async function statContainedFile(realRoot: string, relativePath: string): Promise<{ readonly mtimeMs: number } | null> {
+  if (relativePath === "" || path.isAbsolute(relativePath) || relativePath.split("/").includes("..")) return null;
+  try {
+    const realPath = await fsp.realpath(path.join(realRoot, relativePath));
+    if (!isContained(realRoot, realPath)) return null;
+    const stat = await fsp.stat(realPath);
+    return stat.isFile() ? { mtimeMs: stat.mtimeMs } : null;
+  } catch {
+    return null;
+  }
+}
+
+function compareByDepthThenPath(left: string, right: string): number {
+  const leftDepth = left.split("/").length;
+  const rightDepth = right.split("/").length;
+  return leftDepth - rightDepth || left.localeCompare(right);
 }
 
 export async function handleFilesSearch(
@@ -435,7 +547,6 @@ export async function handleFilesSearch(
     !isPlainObject(body)
     || typeof body.theaterId !== "string"
     || typeof body.query !== "string"
-    || body.query.trim() === ""
     || !Number.isInteger(body.limit)
     || (body.limit as number) < 1
     || (body.limit as number) > 8

--- a/runtime/fleet-plugins/file-explorer/tests/search.test.ts
+++ b/runtime/fleet-plugins/file-explorer/tests/search.test.ts
@@ -16,12 +16,21 @@ beforeEach(async () => {
   theaterPath = path.join(temporaryDirectory, "theater");
   const outsidePath = path.join(temporaryDirectory, "outside");
   await fs.mkdir(path.join(theaterPath, "src", "nested"), { recursive: true });
+  await fs.mkdir(path.join(theaterPath, "node_modules", "dep"), { recursive: true });
   await fs.mkdir(outsidePath);
   await fs.writeFile(path.join(theaterPath, "src", "needle.ts"), "export {}");
   await fs.writeFile(path.join(theaterPath, "src", "nested", "needle.test.ts"), "test()");
+  await fs.writeFile(path.join(theaterPath, "node_modules", "dep", "needle-dep.ts"), "dep()");
   await fs.writeFile(path.join(outsidePath, "needle-secret.txt"), "secret");
   await fs.symlink(outsidePath, path.join(theaterPath, "escape"));
 });
+
+// git이 없거나 Theater가 저장소가 아닌 상태를 고정한다 — 호스트에 설치된 git 여부가 결과를 바꾸지 않는다.
+const NO_GIT = { execGit: () => Promise.reject(new Error("not a repository")) };
+
+function gitListing(...relativePaths: readonly string[]) {
+  return { execGit: () => Promise.resolve(relativePaths.map((entry) => `${entry}\0`).join("")) };
+}
 
 afterEach(async () => {
   await fs.rm(temporaryDirectory, { force: true, recursive: true });
@@ -29,7 +38,7 @@ afterEach(async () => {
 
 describe("Files palette search", () => {
   it("returns sorted Theater-relative file paths and excludes escaping symlinks", async () => {
-    const results = await searchTheaterFiles(theaterPath, "needle", 8);
+    const results = await searchTheaterFiles(theaterPath, "needle", 8, NO_GIT);
 
     expect(results).toEqual([
       { relativePath: "src/needle.ts" },
@@ -39,6 +48,64 @@ describe("Files palette search", () => {
     expect(serialized).not.toContain(temporaryDirectory);
     expect(serialized).not.toContain(await fs.realpath(theaterPath));
     expect(serialized).not.toContain("needle-secret");
+  });
+
+  it("lets git decide what is ignored instead of walking the Theater", async () => {
+    const results = await searchTheaterFiles(theaterPath, "needle", 8, gitListing("src/needle.ts"));
+
+    // 훑기였다면 node_modules 아래 파일도 후보였다. git 목록이 후보 집합 자체를 정한다.
+    expect(results).toEqual([{ relativePath: "src/needle.ts" }]);
+  });
+
+  it("skips dependency and VCS directories when no ignore rules can be read", async () => {
+    const results = await searchTheaterFiles(theaterPath, "needle", 8, NO_GIT);
+
+    expect(results.map((result) => result.relativePath)).not.toContain("node_modules/dep/needle-dep.ts");
+  });
+
+  it("drops a git-listed path that resolves outside the Theater", async () => {
+    // git이 추적하는 심링크라도 Theater 밖을 가리키면 목록에 오르지 않는다.
+    const results = await searchTheaterFiles(theaterPath, "needle", 8, gitListing("escape/needle-secret.txt", "src/needle.ts"));
+
+    expect(results).toEqual([{ relativePath: "src/needle.ts" }]);
+  });
+
+  it("drops index entries whose file no longer exists", async () => {
+    const results = await searchTheaterFiles(theaterPath, "needle", 8, gitListing("src/deleted-needle.ts", "src/needle.ts"));
+
+    expect(results).toEqual([{ relativePath: "src/needle.ts" }]);
+  });
+
+  it("answers an empty query with the most recently modified files", async () => {
+    const recent = new Date("2026-08-09T10:00:00.000Z");
+    const older = new Date("2020-01-01T00:00:00.000Z");
+    await fs.utimes(path.join(theaterPath, "src", "nested", "needle.test.ts"), recent, recent);
+    await fs.utimes(path.join(theaterPath, "src", "needle.ts"), older, older);
+
+    const results = await searchTheaterFiles(theaterPath, "", 8, gitListing("src/needle.ts", "src/nested/needle.test.ts"));
+
+    expect(results).toEqual([
+      { relativePath: "src/nested/needle.test.ts" },
+      { relativePath: "src/needle.ts" },
+    ]);
+  });
+
+  it("accepts an empty query over HTTP instead of rejecting it", async () => {
+    const writes: Array<{ readonly status: number; readonly body: unknown }> = [];
+    const ctx = {
+      host: {
+        http: {
+          readJsonBody: async () => ({ theaterId: "theater-a", query: "", limit: 8 }),
+          writeJson: (_res: http.ServerResponse, status: number, body: unknown) => writes.push({ status, body }),
+        },
+        security: { isTerminalAuthorized: () => true },
+        paths: { resolveTheaterPath: () => theaterPath },
+      },
+    } as unknown as FleetPluginServerContext;
+
+    await handleFilesSearch({ method: "POST" } as http.IncomingMessage, {} as http.ServerResponse, ctx);
+
+    expect(writes[0]?.status).toBe(200);
   });
 
   it("keeps the HTTP response free of absolute and real paths", async () => {


### PR DESCRIPTION
## Summary

- Quick Launch의 `@` 파일 조회가 Theater를 BFS로 훑으면서 무시 규칙 없이 디렉터리 500개에서 멈춰, `node_modules`(워크트리 462/500)와 `.git`(메인 체크아웃 428/500)이 예산을 다 먹고 소스 디렉터리에는 도달하지 못했습니다. 실제 파일을 검색해도 0건이 나오던 원인입니다. 후보 집합을 `git ls-files --cached --others --exclude-standard`가 정하도록 바꿔 중첩 `.gitignore`·부정 패턴·전역 excludes를 그대로 따르고, 저장소가 아닌 Theater는 의존성·VCS 건너뛰기 목록을 갖춘 훑기로 폴백합니다.
- 후보가 어디서 왔든 해석된 실경로로 포함(containment)을 확인해, 훑기 경로가 지키던 "Theater 밖을 가리키는 심링크는 목록에 올리지 않는다" 불변식을 git 목록에도 동일하게 적용합니다.
- 검색어가 비어 있는 동안에는 최근 수정한 파일을 돌려줍니다 — `@`만 누른 시점이 목록이 가장 필요한 순간인데 지금까지는 아무것도 뜨지 않았습니다.
- 결과 8건이 잘리지 않도록 피커 높이 상한을 행 높이에서 유도했습니다(기존 고정 256px은 8번째 행을 반쯤 걸친 채 멈췄습니다).

`Changelog-Amend: quick-launch-search-proposal.md`

`@` 조회 자체가 아직 릴리스되지 않은 기능(#595)이라, 별도 `Fixed` 대신 해당 미릴리스 프래그먼트를 개정했습니다.

## Test Plan

- [x] `pnpm --filter @fleet-plugins/file-explorer test` — 112 passed (신규 6건: git 무시 판정 / 폴백 건너뛰기 / Theater 밖 심링크 배제 / 인덱스 잔존 항목 배제 / 빈 쿼리 최근순 / 빈 쿼리 HTTP 200)
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 1809 passed, 24 skipped, 실패 0
- [x] `pnpm --filter @fleet-plugins/file-explorer typecheck` · `pnpm --filter @dotobokuri/fleet-console typecheck` — tsc 0 오류
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 123건 검증 OK
- [x] 격리 콘솔 실측(빌드 → `serve` → 실제 브라우저): `@rail` 0건 → 8건(`rail-panel.tsx` 포함), `@` 단독 → 최근 수정 8건, Enter 삽입 정상, 피커 `scrollHeight == clientHeight`(잘림 없음)