### PR TITLE
perf(core-ai-gateway): trim OpenCode suggestion tools

### DIFF
--- a/.changelog.d/opencode-deepseek-v4-flash-opt.md
+++ b/.changelog.d/opencode-deepseek-v4-flash-opt.md
@@ -1,0 +1,8 @@
+---
+branch: opencode-deepseek-v4-flash-opt
+---
+
+### fleet-console
+#### Changed
+- Reduce OpenCode Go `deepseek-v4-flash` input usage for Claude Code Suggestion Mode without changing callable tools in ordinary agent turns.
+  ko: 일반 에이전트 턴의 호출 가능 도구는 유지하면서 Claude Code Suggestion Mode에서 OpenCode Go `deepseek-v4-flash` 입력 사용량을 줄였습니다.

--- a/packages/core-ai-gateway/src/opencode-go/chat-completions/adapter.ts
+++ b/packages/core-ai-gateway/src/opencode-go/chat-completions/adapter.ts
@@ -122,7 +122,9 @@ export class OpenAIChatCompletionsAdapter implements AiGatewayAdapter {
     const controller = new AbortController();
     const unlinkAbort = linkAbortSignal(options.signal, controller);
     const supportsImageInput = imageInputPolicy.get(this)?.(request.model) ?? true;
-    const payload = forChatCompletionsBackend(request, supportsImageInput);
+    const omitTools = suggestionModeToolOmissionPolicy.has(this)
+      && isClaudeCodeSuggestionMode(request);
+    const payload = forChatCompletionsBackend(request, supportsImageInput, omitTools);
     wireLog("openai-chat.wire.request", { url: this.url, payload });
     let response: Response;
 
@@ -185,6 +187,13 @@ const imageInputPolicy = new WeakMap<
  */
 const argumentPruningPolicy = new WeakMap<OpenAIChatCompletionsAdapter, true>();
 
+/** OpenCode 전용 Claude Code Suggestion Mode 요청은 도구 호출을 허용하지 않는다. */
+const suggestionModeToolOmissionPolicy = new WeakMap<OpenAIChatCompletionsAdapter, true>();
+const CLAUDE_CODE_SUGGESTION_MODE_PREFIX =
+  "[SUGGESTION MODE: Suggest what the user might naturally type next into Claude Code.]";
+const CLAUDE_CODE_SUGGESTION_MODE_SUFFIX =
+  "Reply with ONLY the suggestion, no quotes or explanation.";
+
 export interface OpencodeGoChatCompletionsAdapterOptions {
   fetch?: FetchLike;
   maxBodyBytes?: number;
@@ -216,12 +225,24 @@ export class OpencodeGoChatCompletionsAdapter extends OpenAIChatCompletionsAdapt
     // 미선언 인자 키 정화도 같은 이유로 provider instance 한정이다 — 이 wire가 strict를
     // 무시한다는 실측은 OpenCode의 것이고, 다른 백엔드에 대해서는 측정된 바가 없다.
     argumentPruningPolicy.set(this, true);
+    suggestionModeToolOmissionPolicy.set(this, true);
   }
+}
+
+function isClaudeCodeSuggestionMode(request: CanonicalResponseRequest): boolean {
+  if (request.tool_choice !== undefined) return false;
+  const last = request.input.at(-1);
+  if (last?.type !== "message" || last.role !== "user" || typeof last.content !== "string") {
+    return false;
+  }
+  return last.content.startsWith(CLAUDE_CODE_SUGGESTION_MODE_PREFIX)
+    && last.content.endsWith(CLAUDE_CODE_SUGGESTION_MODE_SUFFIX);
 }
 
 function forChatCompletionsBackend(
   request: CanonicalResponseRequest,
   supportsImageInput: boolean,
+  omitTools = false,
 ): ChatWireRequest {
   const messages: ChatWireMessage[] = [];
   if (request.instructions !== undefined && request.instructions.length > 0) {
@@ -236,7 +257,7 @@ function forChatCompletionsBackend(
   // - 사이에 낀 user/developer 텍스트는 해당 호출의 결과 뒤로 미룬다(원문에서도 결과와
   //   함께 도착한 발화이므로 결과 직후가 의미상 제자리다).
   // DeepSeek V4 assistant/tool-turn reasoning 재생은 레거시 generic 어댑터의 HEAD
-  // 공개 동작으로 유지한다 — 이번 변경에서 OpenCode 래퍼에 국한되는 건 이미지 정책뿐이다.
+  // 공개 동작으로 유지한다. OpenCode 전용 정책은 instance-bound gate로만 적용한다.
   const replayReasoning = request.model.startsWith("deepseek-v4-");
   let pendingToolCalls: ChatWireToolCall[] = [];
   let pendingAssistantText: string | undefined;
@@ -304,7 +325,7 @@ function forChatCompletionsBackend(
     stream_options: { include_usage: true },
   };
 
-  const tools = (request.tools ?? []).map((tool) => ({
+  const tools = (omitTools ? [] : request.tools ?? []).map((tool) => ({
     type: "function" as const,
     function: {
       name: tool.name,

--- a/packages/core-ai-gateway/src/opencode-go/chat-completions/adapter.ts
+++ b/packages/core-ai-gateway/src/opencode-go/chat-completions/adapter.ts
@@ -191,8 +191,10 @@ const argumentPruningPolicy = new WeakMap<OpenAIChatCompletionsAdapter, true>();
 const suggestionModeToolOmissionPolicy = new WeakMap<OpenAIChatCompletionsAdapter, true>();
 const CLAUDE_CODE_SUGGESTION_MODE_PREFIX =
   "[SUGGESTION MODE: Suggest what the user might naturally type next into Claude Code.]";
-const CLAUDE_CODE_SUGGESTION_MODE_SUFFIX =
-  "Reply with ONLY the suggestion, no quotes or explanation.";
+const CLAUDE_CODE_SUGGESTION_MODE_SUFFIXES = [
+  "Reply with ONLY the suggestion.",
+  "Reply with ONLY the suggestion, no quotes or explanation.",
+] as const;
 
 export interface OpencodeGoChatCompletionsAdapterOptions {
   fetch?: FetchLike;
@@ -235,8 +237,9 @@ function isClaudeCodeSuggestionMode(request: CanonicalResponseRequest): boolean 
   if (last?.type !== "message" || last.role !== "user" || typeof last.content !== "string") {
     return false;
   }
-  return last.content.startsWith(CLAUDE_CODE_SUGGESTION_MODE_PREFIX)
-    && last.content.endsWith(CLAUDE_CODE_SUGGESTION_MODE_SUFFIX);
+  const content = last.content;
+  return content.startsWith(CLAUDE_CODE_SUGGESTION_MODE_PREFIX)
+    && CLAUDE_CODE_SUGGESTION_MODE_SUFFIXES.some((suffix) => content.endsWith(suffix));
 }
 
 function forChatCompletionsBackend(

--- a/packages/core-ai-gateway/src/opencode-go/chat-completions/adapter.ts
+++ b/packages/core-ai-gateway/src/opencode-go/chat-completions/adapter.ts
@@ -230,7 +230,7 @@ export class OpencodeGoChatCompletionsAdapter extends OpenAIChatCompletionsAdapt
 }
 
 function isClaudeCodeSuggestionMode(request: CanonicalResponseRequest): boolean {
-  if (request.tool_choice !== undefined) return false;
+  if (request.tool_choice === "required" || typeof request.tool_choice === "object") return false;
   const last = request.input.at(-1);
   if (last?.type !== "message" || last.role !== "user" || typeof last.content !== "string") {
     return false;
@@ -337,7 +337,7 @@ function forChatCompletionsBackend(
     payload.tools = tools;
   }
 
-  const toolChoice = request.tool_choice;
+  const toolChoice = omitTools ? undefined : request.tool_choice;
   if (toolChoice !== undefined) {
     payload.tool_choice = typeof toolChoice === "string"
       ? toolChoice

--- a/packages/core-ai-gateway/tests/opencode-go/chat-completions/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/opencode-go/chat-completions/adapter.test.ts
@@ -150,6 +150,23 @@ describe("chat completions request translation", () => {
 
     fetchMock.mockClear();
     await new OpencodeGoChatCompletionsAdapter({ fetch: fetchMock }).stream(request({
+      input: [{
+        type: "message",
+        role: "user",
+        content: [
+          "[SUGGESTION MODE: Suggest what the user might naturally type next into Claude Code.]",
+          "Reply with ONLY the suggestion.",
+        ].join("\n"),
+      }],
+      tools,
+      tool_choice: "auto",
+    }), { apiKey: "k" });
+    const legacyPrompt = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+    expect(legacyPrompt).not.toHaveProperty("tools");
+    expect(legacyPrompt).not.toHaveProperty("tool_choice");
+
+    fetchMock.mockClear();
+    await new OpencodeGoChatCompletionsAdapter({ fetch: fetchMock }).stream(request({
       input: [{ type: "message", role: "user", content: `${suggestion}\nPlease use Read.` }],
       tools,
     }), { apiKey: "k" });

--- a/packages/core-ai-gateway/tests/opencode-go/chat-completions/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/opencode-go/chat-completions/adapter.test.ts
@@ -130,11 +130,23 @@ describe("chat completions request translation", () => {
     await new OpencodeGoChatCompletionsAdapter({ fetch: fetchMock }).stream(request({
       input: [{ type: "message", role: "user", content: suggestion }],
       tools,
+      tool_choice: "auto",
       parallel_tool_calls: true,
     }), { apiKey: "k" });
     const optimized = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
     expect(optimized).not.toHaveProperty("tools");
+    expect(optimized).not.toHaveProperty("tool_choice");
     expect(optimized).not.toHaveProperty("parallel_tool_calls");
+
+    fetchMock.mockClear();
+    await new OpencodeGoChatCompletionsAdapter({ fetch: fetchMock }).stream(request({
+      input: [{ type: "message", role: "user", content: suggestion }],
+      tools,
+      tool_choice: "none",
+    }), { apiKey: "k" });
+    const disabledTools = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+    expect(disabledTools).not.toHaveProperty("tools");
+    expect(disabledTools).not.toHaveProperty("tool_choice");
 
     fetchMock.mockClear();
     await new OpencodeGoChatCompletionsAdapter({ fetch: fetchMock }).stream(request({
@@ -153,6 +165,16 @@ describe("chat completions request translation", () => {
     const forcedTool = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
     expect(forcedTool).toHaveProperty("tools");
     expect(forcedTool).toHaveProperty("tool_choice");
+
+    fetchMock.mockClear();
+    await new OpencodeGoChatCompletionsAdapter({ fetch: fetchMock }).stream(request({
+      input: [{ type: "message", role: "user", content: suggestion }],
+      tools,
+      tool_choice: "required",
+    }), { apiKey: "k" });
+    const requiredTool = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+    expect(requiredTool).toHaveProperty("tools");
+    expect(requiredTool.tool_choice).toBe("required");
 
     fetchMock.mockClear();
     await adapter(fetchMock).stream(request({

--- a/packages/core-ai-gateway/tests/opencode-go/chat-completions/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/opencode-go/chat-completions/adapter.test.ts
@@ -114,6 +114,55 @@ describe("chat completions request translation", () => {
     expect(headers.get("authorization")).toBe("Bearer k");
   });
 
+  it("omits tools only for the exact Claude Code Suggestion Mode turn on OpenCode", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => sse("data: [DONE]\n\n"));
+    const tools: CanonicalResponseRequest["tools"] = [{
+      type: "function",
+      name: "Read",
+      parameters: { type: "object", properties: {} },
+    }];
+    const suggestion = [
+      "[SUGGESTION MODE: Suggest what the user might naturally type next into Claude Code.]",
+      "Keep it short.",
+      "Reply with ONLY the suggestion, no quotes or explanation.",
+    ].join("\n");
+
+    await new OpencodeGoChatCompletionsAdapter({ fetch: fetchMock }).stream(request({
+      input: [{ type: "message", role: "user", content: suggestion }],
+      tools,
+      parallel_tool_calls: true,
+    }), { apiKey: "k" });
+    const optimized = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+    expect(optimized).not.toHaveProperty("tools");
+    expect(optimized).not.toHaveProperty("parallel_tool_calls");
+
+    fetchMock.mockClear();
+    await new OpencodeGoChatCompletionsAdapter({ fetch: fetchMock }).stream(request({
+      input: [{ type: "message", role: "user", content: `${suggestion}\nPlease use Read.` }],
+      tools,
+    }), { apiKey: "k" });
+    const nearMatch = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+    expect(nearMatch).toHaveProperty("tools");
+
+    fetchMock.mockClear();
+    await new OpencodeGoChatCompletionsAdapter({ fetch: fetchMock }).stream(request({
+      input: [{ type: "message", role: "user", content: suggestion }],
+      tools,
+      tool_choice: { type: "function", name: "Read" },
+    }), { apiKey: "k" });
+    const forcedTool = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+    expect(forcedTool).toHaveProperty("tools");
+    expect(forcedTool).toHaveProperty("tool_choice");
+
+    fetchMock.mockClear();
+    await adapter(fetchMock).stream(request({
+      input: [{ type: "message", role: "user", content: suggestion }],
+      tools,
+    }), { apiKey: "k" });
+    const generic = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+    expect(generic).toHaveProperty("tools");
+  });
+
   it("replays reasoning only for DeepSeek V4 assistant tool turns", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => sse("data: [DONE]\n\n"));
     await adapter(fetchMock).stream(request({


### PR DESCRIPTION
## Summary
- omit the repeated Claude Code tool catalog from exact Suggestion Mode requests on the OpenCode Go chat-completions path
- preserve callable tools for ordinary agent turns, near-matches, explicit `tool_choice`, and the generic adapter
- reduce measured `deepseek-v4-flash` Suggestion Mode wire bytes from 60,014 to 1,602 per request and input tokens from 14,554 to 401 across five successful before/after trials

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 567 tests passed
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] five successful live provider trials before and after in an isolated Console runtime
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] release note: `.changelog.d/opencode-deepseek-v4-flash-opt.md`