### PR TITLE
fix(core-infra): raise AI Gateway key validation timeout

### DIFF
--- a/.changelog.d/fix-opencode-go-api-key-save.md
+++ b/.changelog.d/fix-opencode-go-api-key-save.md
@@ -1,0 +1,13 @@
+---
+branch: fix-opencode-go-api-key-save
+---
+
+### fleet-console
+#### Fixed
+- Give AI Gateway API key sign-in enough time for the live validation probe to return, so a slow OpenCode Go response no longer fails as a timeout before the key is stored.
+  ko: AI Gateway API 키 로그인 검증 프로브가 돌아올 시간을 늘려, OpenCode Go 응답이 느려도 타임아웃으로 키가 저장되지 않던 문제를 고칩니다.
+
+### fleet-cli
+#### Fixed
+- Give AI Gateway API key login enough time for the live validation probe to return, so a slow OpenCode Go response no longer fails as a timeout before the key is stored.
+  ko: AI Gateway API 키 로그인 검증 프로브가 돌아올 시간을 늘려, OpenCode Go 응답이 느려도 타임아웃으로 키가 저장되지 않던 문제를 고칩니다.

--- a/packages/core-infra/src/auth/index.ts
+++ b/packages/core-infra/src/auth/index.ts
@@ -2,6 +2,7 @@
 
 export { createAuthService, DEFAULT_AUTH_PATH } from "./auth-storage.js";
 export {
+  DEFAULT_AUTH_VALIDATION_TIMEOUT_MS,
   createAuthValidationError,
   isAuthValidationSuccess,
   validateAnthropicCompatibleApiKey,

--- a/packages/core-infra/src/auth/validation.ts
+++ b/packages/core-infra/src/auth/validation.ts
@@ -6,7 +6,10 @@ import type {
 
 import { formatAuthValidationFailureMessage } from "./auth-storage.js";
 
-const DEFAULT_AUTH_VALIDATION_TIMEOUT_MS = 5_000;
+// Auth validation issues a real 1-token generation probe. Upstream TTFB for a
+// live model often exceeds a few seconds, so a short budget falsely times out
+// valid keys (observed on OpenCode Go / minimax-m3) before they can be stored.
+export const DEFAULT_AUTH_VALIDATION_TIMEOUT_MS = 20_000;
 
 export async function validateAnthropicCompatibleApiKey(
   request: AuthValidationRequest,
@@ -36,6 +39,9 @@ export async function validateAnthropicCompatibleApiKey(
       }),
       signal: controller.signal,
     });
+    // Status alone decides validity; drop the body so a slow token stream cannot
+    // keep the socket (or the provider generation) alive after we already know.
+    if (response.body) void response.body.cancel();
 
     if (response.ok) {
       return { providerId: request.providerId, status: "success" };
@@ -87,5 +93,8 @@ function buildMessagesUrl(baseUrl: string): string {
 }
 
 function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError";
+  if (typeof DOMException !== "undefined" && error instanceof DOMException && error.name === "AbortError") {
+    return true;
+  }
+  return error instanceof Error && error.name === "AbortError";
 }

--- a/packages/core-infra/src/auth/validation.ts
+++ b/packages/core-infra/src/auth/validation.ts
@@ -41,7 +41,9 @@ export async function validateAnthropicCompatibleApiKey(
     });
     // Status alone decides validity; drop the body so a slow token stream cannot
     // keep the socket (or the provider generation) alive after we already know.
-    if (response.body) void response.body.cancel();
+    // cancel() can reject after a dropped connection — absorb so cleanup never
+    // overrides the status we already have or becomes an unhandled rejection.
+    if (response.body) void response.body.cancel().catch(() => undefined);
 
     if (response.ok) {
       return { providerId: request.providerId, status: "success" };

--- a/packages/core-infra/tests/auth/validation.test.ts
+++ b/packages/core-infra/tests/auth/validation.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  DEFAULT_AUTH_VALIDATION_TIMEOUT_MS,
   createAuthValidationError,
   isAuthValidationSuccess,
   validateAnthropicCompatibleApiKey,
@@ -62,6 +63,10 @@ describe("auth validation", () => {
     });
   });
 
+  it("keeps the default probe budget long enough for live model TTFB", () => {
+    expect(DEFAULT_AUTH_VALIDATION_TIMEOUT_MS).toBe(20_000);
+  });
+
   it("distinguishes timeout failures", async () => {
     const timeoutError = new DOMException("The operation was aborted.", "AbortError");
     vi.spyOn(globalThis, "fetch").mockRejectedValue(timeoutError);
@@ -69,6 +74,28 @@ describe("auth validation", () => {
     await expect(validateAnthropicCompatibleApiKey(baseRequest())).resolves.toMatchObject({
       status: "timeout",
     });
+  });
+
+  it("treats AbortError-named Errors as timeouts", async () => {
+    const timeoutError = new Error("This operation was aborted");
+    timeoutError.name = "AbortError";
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(timeoutError);
+
+    await expect(validateAnthropicCompatibleApiKey(baseRequest())).resolves.toMatchObject({
+      status: "timeout",
+    });
+  });
+
+  it("cancels the response body after reading the auth status", async () => {
+    const response = new Response("{}", { status: 200 });
+    if (!response.body) throw new Error("Expected a Response body for cancel coverage.");
+    const cancel = vi.spyOn(response.body, "cancel").mockResolvedValue(undefined);
+    mockFetch(response);
+
+    await expect(validateAnthropicCompatibleApiKey(baseRequest())).resolves.toMatchObject({
+      status: "success",
+    });
+    expect(cancel).toHaveBeenCalledOnce();
   });
 
   it("distinguishes network failures", async () => {

--- a/packages/core-infra/tests/auth/validation.test.ts
+++ b/packages/core-infra/tests/auth/validation.test.ts
@@ -98,6 +98,18 @@ describe("auth validation", () => {
     expect(cancel).toHaveBeenCalledOnce();
   });
 
+  it("keeps the auth status when body cancellation fails", async () => {
+    const response = new Response("{}", { status: 200 });
+    if (!response.body) throw new Error("Expected a Response body for cancel coverage.");
+    const cancel = vi.spyOn(response.body, "cancel").mockRejectedValue(new TypeError("body already closed"));
+    mockFetch(response);
+
+    await expect(validateAnthropicCompatibleApiKey(baseRequest())).resolves.toMatchObject({
+      status: "success",
+    });
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
   it("distinguishes network failures", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("network failed"));
 

--- a/packages/fleet-admiral/tests/ai-gateway-auth.test.ts
+++ b/packages/fleet-admiral/tests/ai-gateway-auth.test.ts
@@ -4,7 +4,11 @@ import {
   KIMI_AUTH_PROVIDER_ID,
   KIMI_CODE_API_BASE_URL,
   KIMI_CODE_MODEL,
+  OPENCODE_AUTH_PROVIDER_ID,
+  OPENCODE_GO_API_BASE_URL,
+  OPENCODE_GO_MODEL,
   validateKimiAuthKey,
+  validateOpencodeGoAuthKey,
 } from "../src/index.js";
 
 afterEach(() => {
@@ -35,5 +39,32 @@ describe("Kimi AI Gateway authentication", () => {
     const request = fetchMock.mock.calls[0]?.[1];
     if (!request) throw new Error("Expected Kimi validation request options.");
     expect(JSON.parse(String(request.body))).toMatchObject({ model: "k3" });
+  });
+});
+
+describe("OpenCode Go AI Gateway authentication", () => {
+  it("keeps the persisted provider id stable", () => {
+    expect(OPENCODE_AUTH_PROVIDER_ID).toBe("Claude Code with OpenCode Go");
+    expect(OPENCODE_GO_API_BASE_URL).toBe("https://opencode.ai/zen/go");
+    expect(OPENCODE_GO_MODEL).toBe("minimax-m3");
+  });
+
+  it("validates the key against the OpenCode Go messages endpoint", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(validateOpencodeGoAuthKey("opencode-secret")).resolves.toEqual({
+      providerId: OPENCODE_AUTH_PROVIDER_ID,
+      status: "success",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://opencode.ai/zen/go/v1/messages",
+      expect.objectContaining({
+        headers: expect.objectContaining({ "x-api-key": "opencode-secret" }),
+      }),
+    );
+    const request = fetchMock.mock.calls[0]?.[1];
+    if (!request) throw new Error("Expected OpenCode Go validation request options.");
+    expect(JSON.parse(String(request.body))).toMatchObject({ model: "minimax-m3", max_tokens: 1 });
   });
 });


### PR DESCRIPTION
## Summary
- OpenCode Go / AI Gateway 키 로그인 검증이 5초 예산에 걸려 느린 라이브 프로브가 타임아웃으로 떨어져 키가 저장되지 않던 문제를 고칩니다.
- Anthropic-compatible 검증 기본 타임아웃을 20초로 올리고, 상태만 확인한 뒤 응답 body를 즉시 cancel 하며 AbortError 판별을 보강합니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-infra test`
- [x] `pnpm --filter @dotobokuri/fleet-admiral test -- tests/ai-gateway-auth.test.ts`
- [x] `pnpm --filter @dotobokuri/core-infra typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-admiral typecheck`
- [x] `pnpm --filter @dotobokuri/core-infra build`
- [x] 격리 Console PUT 잘못된 키 → 400 unauthorized
- [x] 제공된 유효 OpenCode Go 키로 직접 probe / validate / 격리 Console PUT → 200 signedIn
- [x] `node scripts/compile-changelog-fragments.mjs --check`