### PR TITLE
feat(fleet-console): tip first effort confirm gesture

### DIFF
--- a/.changelog.d/effort-confirm-tip.md
+++ b/.changelog.d/effort-confirm-tip.md
@@ -4,5 +4,5 @@ branch: effort-confirm-tip
 
 ### fleet-console
 #### Added
-- When you first pick a reasoning effort other than AUTO in the canvas launch cascade, a one-line tip under the track says to press the knob again to launch; Help > Show the screen guide restores it.
-  ko: 캔버스 실행 메뉴에서 AUTO가 아닌 추론 강도를 처음 고르면, 트랙 아래 한 줄 팁이 "노브를 다시 누르면 실행됩니다."라고 알려 주며, 도움말 > 화면 안내 다시 보기로 되돌릴 수 있습니다.
+- When you pick a reasoning effort other than AUTO in the canvas launch cascade, a tip under the track says to press the knob again to launch; it keeps appearing until that confirm gesture succeeds, and Help > Show the screen guide restores it.
+  ko: 캔버스 실행 메뉴에서 AUTO가 아닌 추론 강도를 고르면 트랙 아래 팁이 노브를 다시 누르면 실행된다고 알려 주며, 그 확정 제스처로 실행하기 전까지 다시 보이고, 도움말 > 화면 안내 다시 보기로 되돌릴 수 있습니다.

--- a/.changelog.d/effort-confirm-tip.md
+++ b/.changelog.d/effort-confirm-tip.md
@@ -4,5 +4,5 @@ branch: effort-confirm-tip
 
 ### fleet-console
 #### Added
-- When you first pick a reasoning effort other than AUTO in the canvas launch cascade, a one-line tip under the track explains that clicking the same rung again launches with that effort; Help → Show the screen guide restores it.
-  ko: 캔버스 실행 메뉴에서 AUTO가 아닌 추론 강도를 처음 고르면, 트랙 아래 한 줄 팁이 같은 단을 다시 누르면 그 강도로 실행된다고 알려 주며, 도움말 → 화면 안내 다시 보기로 되돌릴 수 있습니다.
+- When you first pick a reasoning effort other than AUTO in the canvas launch cascade, a one-line tip under the track explains that clicking the same rung again launches with that effort; Help > Show the screen guide restores it.
+  ko: 캔버스 실행 메뉴에서 AUTO가 아닌 추론 강도를 처음 고르면, 트랙 아래 한 줄 팁이 같은 단을 다시 누르면 그 강도로 실행된다고 알려 주며, 도움말 > 화면 안내 다시 보기로 되돌릴 수 있습니다.

--- a/.changelog.d/effort-confirm-tip.md
+++ b/.changelog.d/effort-confirm-tip.md
@@ -1,0 +1,8 @@
+---
+branch: effort-confirm-tip
+---
+
+### fleet-console
+#### Added
+- When you first pick a reasoning effort other than AUTO in the canvas launch cascade, a one-line tip under the track explains that clicking the same rung again launches with that effort; Help → Show the screen guide restores it.
+  ko: 캔버스 실행 메뉴에서 AUTO가 아닌 추론 강도를 처음 고르면, 트랙 아래 한 줄 팁이 같은 단을 다시 누르면 그 강도로 실행된다고 알려 주며, 도움말 → 화면 안내 다시 보기로 되돌릴 수 있습니다.

--- a/.changelog.d/effort-confirm-tip.md
+++ b/.changelog.d/effort-confirm-tip.md
@@ -4,5 +4,5 @@ branch: effort-confirm-tip
 
 ### fleet-console
 #### Added
-- When you first pick a reasoning effort other than AUTO in the canvas launch cascade, a one-line tip under the track explains that clicking the same rung again launches with that effort; Help > Show the screen guide restores it.
-  ko: 캔버스 실행 메뉴에서 AUTO가 아닌 추론 강도를 처음 고르면, 트랙 아래 한 줄 팁이 같은 단을 다시 누르면 그 강도로 실행된다고 알려 주며, 도움말 > 화면 안내 다시 보기로 되돌릴 수 있습니다.
+- When you first pick a reasoning effort other than AUTO in the canvas launch cascade, a one-line tip under the track says to press the knob again to launch; Help > Show the screen guide restores it.
+  ko: 캔버스 실행 메뉴에서 AUTO가 아닌 추론 강도를 처음 고르면, 트랙 아래 한 줄 팁이 "노브를 다시 누르면 실행됩니다."라고 알려 주며, 도움말 > 화면 안내 다시 보기로 되돌릴 수 있습니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -79,9 +79,6 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   const [openEffortRow, setOpenEffortRow] = useState<string | null>(null);
   // 행마다 고른 강도. 트랙은 값만 정하고 실행은 모델 행이 일으키므로, 그 사이를 이 상태가 잇는다.
   const [rowEfforts, setRowEfforts] = useState<Readonly<Record<string, string | null>>>({});
-  // 시청 기록이 저장되는 순간 팁이 사라지면 방금 읽던 안내가 눈앞에서 접힌다. 이번 메뉴가
-  // 열려 있는 동안은 첫 노출을 붙잡아 두고, 메뉴가 닫히면(언마운트) 기록만 남긴다.
-  const [effortConfirmTipSticky, setEffortConfirmTipSticky] = useState(false);
   const [effortPosition, setEffortPosition] = useState<{
     readonly id: string;
     readonly left: number;
@@ -91,15 +88,14 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   const effortAnchorRefs = useRef(new Map<string, HTMLDivElement>());
   const effortMenuRef = useRef<HTMLDivElement | null>(null);
   const effortCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // PUT 실패·동시 저장 거부로 설정이 되돌아가도 effect가 같은 마운트에서 무한 재시도하지 않게 한다.
-  // 메뉴를 다시 열면(재마운트) 한 번 더 시도한다.
-  const effortConfirmTipPersistStartedRef = useRef(false);
   const seenFeatureTours = globalSettings.state?.seenFeatureTours ?? [];
   const effortConfirmTipSeen = seenFeatureTours.includes(EFFORT_CONFIRM_TIP_SEEN_KEY);
   const openEffortValue = openEffortRow === null ? null : (rowEfforts[openEffortRow] ?? null);
+  // 선택만으로는 졸업시키지 않는다 — 피처 투어를 건너뛰고 메뉴를 닫아도, 같은 노브 재클릭으로
+  // 실행하기 전까지는 비-AUTO를 고를 때마다 팁이 다시 선다.
   const showEffortConfirmTip = globalSettings.state !== null
     && openEffortValue !== null
-    && (!effortConfirmTipSeen || effortConfirmTipSticky);
+    && !effortConfirmTipSeen;
 
   const cancelFlyoutClose = () => {
     if (flyoutCloseTimerRef.current === null) return;
@@ -242,17 +238,6 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     observer.observe(element);
     return () => observer.disconnect();
   }, [openEffortRow, viewportBounds]);
-
-  // 비-AUTO를 처음 고른 순간에 확인 팁을 붙이고 시청 기록을 남긴다. AUTO는 같은 단 재클릭이
-  // 실행이 아니므로 팁을 달지 않는다. 설정이 아직 안 실렸으면 거짓으로 보여 두고, 기록이
-  // 도착한 뒤에야 "처음"을 판정한다.
-  useEffect(() => {
-    if (!globalSettings.state || openEffortValue === null || effortConfirmTipSeen) return;
-    setEffortConfirmTipSticky(true);
-    if (effortConfirmTipPersistStartedRef.current) return;
-    effortConfirmTipPersistStartedRef.current = true;
-    void persistEffortConfirmTipSeen();
-  }, [effortConfirmTipSeen, globalSettings.state, openEffortValue]);
 
   useEffect(() => {
     const handlePointer = (event: MouseEvent) => {
@@ -739,6 +724,9 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                 if (effort === null) return;
                 const chip = effortTarget.chips?.find((entry) => entry.id === effort);
                 if (!chip) return;
+                // 같은 노브를 다시 눌러 실행한 순간에만 팁을 졸업시킨다. 선택·피처 투어 건너뛰기는
+                // 제스처를 익힌 증거가 아니다.
+                if (!effortConfirmTipSeen) void persistEffortConfirmTipSeen();
                 onLaunchKind(flyoutTarget.pluginId, flyoutTarget.kind, chip.launch);
               }}
               autoLabel={t("launchVariants.effort.auto")}

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, typ
 import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console/sdk/operations";
 
 import { FEATURE_TOUR_BOUNDARY_ATTRIBUTE, FEATURE_TOUR_LAYER_SELECTOR } from "../feature-tour-catalog.js";
-import { setGlobalSettingsField, useGlobalSettingsStore } from "../global-settings-store.js";
+import { getGlobalSettingsStoreState, setGlobalSettingsField, useGlobalSettingsStore } from "../global-settings-store.js";
 import { useT } from "../i18n/index.js";
 import { resolveLaunchKindAnnotation } from "../launch-kind-annotations.js";
 import { EffortTrack, effortLadderPosition } from "../components/effort-track.js";
@@ -91,6 +91,9 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   const effortAnchorRefs = useRef(new Map<string, HTMLDivElement>());
   const effortMenuRef = useRef<HTMLDivElement | null>(null);
   const effortCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // PUT 실패·동시 저장 거부로 설정이 되돌아가도 effect가 같은 마운트에서 무한 재시도하지 않게 한다.
+  // 메뉴를 다시 열면(재마운트) 한 번 더 시도한다.
+  const effortConfirmTipPersistStartedRef = useRef(false);
   const seenFeatureTours = globalSettings.state?.seenFeatureTours ?? [];
   const effortConfirmTipSeen = seenFeatureTours.includes(EFFORT_CONFIRM_TIP_SEEN_KEY);
   const openEffortValue = openEffortRow === null ? null : (rowEfforts[openEffortRow] ?? null);
@@ -246,10 +249,9 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   useEffect(() => {
     if (!globalSettings.state || openEffortValue === null || effortConfirmTipSeen) return;
     setEffortConfirmTipSticky(true);
-    void setGlobalSettingsField(
-      "seenFeatureTours",
-      appendSeenFeatureTour(globalSettings.state.seenFeatureTours, EFFORT_CONFIRM_TIP_SEEN_KEY),
-    );
+    if (effortConfirmTipPersistStartedRef.current) return;
+    effortConfirmTipPersistStartedRef.current = true;
+    void persistEffortConfirmTipSeen();
   }, [effortConfirmTipSeen, globalSettings.state, openEffortValue]);
 
   useEffect(() => {
@@ -759,6 +761,28 @@ const GAUGE_BAR_WIDTH = 1.5;
 const GAUGE_BAR_PITCH = 2.5;
 const GAUGE_HEIGHT = 8;
 const GAUGE_MIN_BAR = 2;
+
+// 시청 기록 PUT은 전역 저장 슬롯 하나뿐이라, 피처 투어 완료 저장과 겹치면 뒤쪽 호출이 거절된다.
+// 잠깐 양보한 뒤 최신 seen 목록에 키를 합쳐 다시 쓴다. 실패해도 같은 마운트에서는 상한까지만
+// 재시도해, 오프라인처럼 계속 실패하는 경우에도 요청이 무한히 돌지 않는다.
+async function persistEffortConfirmTipSeen(): Promise<void> {
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const store = getGlobalSettingsStoreState();
+    if (store.savingField !== null) {
+      await new Promise((resolve) => setTimeout(resolve, 40));
+      continue;
+    }
+    const seen = store.state?.seenFeatureTours;
+    if (!seen) return;
+    if (seen.includes(EFFORT_CONFIRM_TIP_SEEN_KEY)) return;
+    const saved = await setGlobalSettingsField(
+      "seenFeatureTours",
+      appendSeenFeatureTour(seen, EFFORT_CONFIRM_TIP_SEEN_KEY),
+    );
+    if (saved) return;
+    await new Promise((resolve) => setTimeout(resolve, 40));
+  }
+}
 
 /**
  * 강도 사다리를 그대로 줄인 계기 표식. 꺾쇠만으로는 이 손잡이가 무엇을 여는지 말하지 못하므로,

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -2,9 +2,11 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, typ
 import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console/sdk/operations";
 
 import { FEATURE_TOUR_BOUNDARY_ATTRIBUTE, FEATURE_TOUR_LAYER_SELECTOR } from "../feature-tour-catalog.js";
+import { setGlobalSettingsField, useGlobalSettingsStore } from "../global-settings-store.js";
 import { useT } from "../i18n/index.js";
 import { resolveLaunchKindAnnotation } from "../launch-kind-annotations.js";
 import { EffortTrack, effortLadderPosition } from "../components/effort-track.js";
+import { appendSeenFeatureTour, EFFORT_CONFIRM_TIP_SEEN_KEY } from "../components/feature-tour.js";
 import { launchProviderFromGroupId, launchProviderGlyph } from "../components/launch-provider-glyphs.js";
 
 interface CanvasContextMenuProps {
@@ -52,6 +54,7 @@ const ASIDE_GAP = 8;
 
 export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor", fixed = false, catalog, canLaunch, renderKindIcon, onLaunchKind, onClose, theaterLabel }: CanvasContextMenuProps) {
   const t = useT();
+  const globalSettings = useGlobalSettingsStore();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const [menuSize, setMenuSize] = useState<{ readonly width: number; readonly height: number } | null>(null);
@@ -76,6 +79,9 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   const [openEffortRow, setOpenEffortRow] = useState<string | null>(null);
   // 행마다 고른 강도. 트랙은 값만 정하고 실행은 모델 행이 일으키므로, 그 사이를 이 상태가 잇는다.
   const [rowEfforts, setRowEfforts] = useState<Readonly<Record<string, string | null>>>({});
+  // 시청 기록이 저장되는 순간 팁이 사라지면 방금 읽던 안내가 눈앞에서 접힌다. 이번 메뉴가
+  // 열려 있는 동안은 첫 노출을 붙잡아 두고, 메뉴가 닫히면(언마운트) 기록만 남긴다.
+  const [effortConfirmTipSticky, setEffortConfirmTipSticky] = useState(false);
   const [effortPosition, setEffortPosition] = useState<{
     readonly id: string;
     readonly left: number;
@@ -85,6 +91,12 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   const effortAnchorRefs = useRef(new Map<string, HTMLDivElement>());
   const effortMenuRef = useRef<HTMLDivElement | null>(null);
   const effortCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const seenFeatureTours = globalSettings.state?.seenFeatureTours ?? [];
+  const effortConfirmTipSeen = seenFeatureTours.includes(EFFORT_CONFIRM_TIP_SEEN_KEY);
+  const openEffortValue = openEffortRow === null ? null : (rowEfforts[openEffortRow] ?? null);
+  const showEffortConfirmTip = globalSettings.state !== null
+    && openEffortValue !== null
+    && (!effortConfirmTipSeen || effortConfirmTipSticky);
 
   const cancelFlyoutClose = () => {
     if (flyoutCloseTimerRef.current === null) return;
@@ -227,6 +239,18 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     observer.observe(element);
     return () => observer.disconnect();
   }, [openEffortRow, viewportBounds]);
+
+  // 비-AUTO를 처음 고른 순간에 확인 팁을 붙이고 시청 기록을 남긴다. AUTO는 같은 단 재클릭이
+  // 실행이 아니므로 팁을 달지 않는다. 설정이 아직 안 실렸으면 거짓으로 보여 두고, 기록이
+  // 도착한 뒤에야 "처음"을 판정한다.
+  useEffect(() => {
+    if (!globalSettings.state || openEffortValue === null || effortConfirmTipSeen) return;
+    setEffortConfirmTipSticky(true);
+    void setGlobalSettingsField(
+      "seenFeatureTours",
+      appendSeenFeatureTour(globalSettings.state.seenFeatureTours, EFFORT_CONFIRM_TIP_SEEN_KEY),
+    );
+  }, [effortConfirmTipSeen, globalSettings.state, openEffortValue]);
 
   useEffect(() => {
     const handlePointer = (event: MouseEvent) => {
@@ -702,22 +726,29 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
             closeEffortMenu();
           }}
         >
-          <EffortTrack
-            row={effortTarget}
-            value={rowEfforts[openEffortRow] ?? null}
-            onChange={(next) => setRowEfforts((previous) => ({ ...previous, [openEffortRow]: next }))}
-            onConfirmCurrent={() => {
-              // 자동을 다시 누르는 것은 값을 비운 채 머무는 일이다 — 모델만 싣는 실행은 행 본문이 맡는다.
-              const effort = rowEfforts[openEffortRow] ?? null;
-              if (effort === null) return;
-              const chip = effortTarget.chips?.find((entry) => entry.id === effort);
-              if (!chip) return;
-              onLaunchKind(flyoutTarget.pluginId, flyoutTarget.kind, chip.launch);
-            }}
-            autoLabel={t("launchVariants.effort.auto")}
-            ariaLabel={t("launchVariants.effort.track")}
-            autoValueText={t("launchVariants.effort.autoValue")}
-          />
+          <div className="operation-launch-effort-menu-body">
+            <EffortTrack
+              row={effortTarget}
+              value={rowEfforts[openEffortRow] ?? null}
+              onChange={(next) => setRowEfforts((previous) => ({ ...previous, [openEffortRow]: next }))}
+              onConfirmCurrent={() => {
+                // 자동을 다시 누르는 것은 값을 비운 채 머무는 일이다 — 모델만 싣는 실행은 행 본문이 맡는다.
+                const effort = rowEfforts[openEffortRow] ?? null;
+                if (effort === null) return;
+                const chip = effortTarget.chips?.find((entry) => entry.id === effort);
+                if (!chip) return;
+                onLaunchKind(flyoutTarget.pluginId, flyoutTarget.kind, chip.launch);
+              }}
+              autoLabel={t("launchVariants.effort.auto")}
+              ariaLabel={t("launchVariants.effort.track")}
+              autoValueText={t("launchVariants.effort.autoValue")}
+            />
+            {showEffortConfirmTip ? (
+              <p className="operation-launch-effort-confirm-tip" role="status">
+                {t("launchVariants.effort.confirmTip")}
+              </p>
+            ) : null}
+          </div>
         </div>
       ) : null}
     </div>

--- a/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
@@ -11,7 +11,7 @@ import { useConsoleState } from "../hooks/use-store.js";
 import { useT, type CoreMessageKey } from "../i18n/index.js";
 import { COMMISSIONING_SEEN_KEY, openWhatsNew } from "../store.js";
 import { AddHostDialog } from "./add-host-dialog.js";
-import { forgetAllFeatureTours } from "./feature-tour.js";
+import { EFFORT_CONFIRM_TIP_SEEN_KEY, forgetAllFeatureTours } from "./feature-tour.js";
 import { KeyboardShortcutsDialog } from "./keyboard-shortcuts-dialog.js";
 
 type UpdateApplyState = "idle" | "applying" | "accepted" | "completed" | "blocked" | "error";
@@ -504,13 +504,13 @@ function SettingsButton({ updateAvailable }: { readonly updateAvailable: boolean
 }
 
 // "화면 안내 다시 보기" — 화면에 닻을 건 투어 하나가 아니라 온보딩 전체를 초기화한다.
-// 카탈로그의 모든 피처 투어 시청 기록(walkthrough·spotlight)과 최초 설정 가이드 기록을
-// 함께 지워, 어느 화면에 있든 온보딩을 처음부터 다시 보게 한다.
+// 카탈로그의 모든 피처 투어 시청 기록(walkthrough·spotlight)·최초 설정 가이드·강도 확인 팁
+// 기록을 함께 지워, 어느 화면에 있든 온보딩을 처음부터 다시 보게 한다.
 function forgetAllOnboarding(seen: readonly string[]): readonly string[] {
+  const drop = new Set([COMMISSIONING_SEEN_KEY, EFFORT_CONFIRM_TIP_SEEN_KEY]);
   const afterTours = forgetAllFeatureTours(seen);
-  return afterTours.includes(COMMISSIONING_SEEN_KEY)
-    ? afterTours.filter((key) => key !== COMMISSIONING_SEEN_KEY)
-    : afterTours;
+  const next = afterTours.filter((key) => !drop.has(key));
+  return next.length === afterTours.length ? afterTours : next;
 }
 
 function HelpMenu({ releaseDisabled, updateAvailable, latestVersion, version }: {

--- a/runtime/fleet-console/core/client/src/components/feature-tour.tsx
+++ b/runtime/fleet-console/core/client/src/components/feature-tour.tsx
@@ -12,6 +12,10 @@ import { useT, type CoreMessageKey } from "../i18n/index.js";
 
 export type FeatureTourPhase = "spotlight" | "walkthrough";
 
+// 캔버스 실행 캐스케이드의 강도 확인 팁. Feature Tour 카탈로그 항목은 아니지만 같은
+// seenFeatureTours 필드에 실어, "화면 안내 다시 보기"가 투어·커미셔닝과 함께 되돌린다.
+export const EFFORT_CONFIRM_TIP_SEEN_KEY = "effort-confirm-tip";
+
 export interface FeatureTourPresentation {
   readonly tour: FeatureTour;
   readonly phase: FeatureTourPhase;

--- a/runtime/fleet-console/core/client/src/i18n/messages/common.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/common.ts
@@ -73,7 +73,7 @@ export const commonEn = {
   "launchVariants.effort.track": "Reasoning effort",
   "launchVariants.effort.auto": "AUTO",
   "launchVariants.effort.autoValue": "Automatic — the model's own default",
-  "launchVariants.effort.confirmTip": "Click the same rung again to launch with this effort.",
+  "launchVariants.effort.confirmTip": "Press the knob again to launch.",
 } as const;
 
 export const commonKo: Record<keyof typeof commonEn, string> = {
@@ -150,5 +150,5 @@ export const commonKo: Record<keyof typeof commonEn, string> = {
   "launchVariants.effort.track": "추론 강도",
   "launchVariants.effort.auto": "자동",
   "launchVariants.effort.autoValue": "자동 — 모델 자체 기본값",
-  "launchVariants.effort.confirmTip": "같은 단을 다시 누르면 이 강도로 실행합니다.",
+  "launchVariants.effort.confirmTip": "노브를 다시 누르면 실행됩니다.",
 };

--- a/runtime/fleet-console/core/client/src/i18n/messages/common.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/common.ts
@@ -73,6 +73,7 @@ export const commonEn = {
   "launchVariants.effort.track": "Reasoning effort",
   "launchVariants.effort.auto": "AUTO",
   "launchVariants.effort.autoValue": "Automatic — the model's own default",
+  "launchVariants.effort.confirmTip": "Click the same rung again to launch with this effort.",
 } as const;
 
 export const commonKo: Record<keyof typeof commonEn, string> = {
@@ -149,4 +150,5 @@ export const commonKo: Record<keyof typeof commonEn, string> = {
   "launchVariants.effort.track": "추론 강도",
   "launchVariants.effort.auto": "자동",
   "launchVariants.effort.autoValue": "자동 — 모델 자체 기본값",
+  "launchVariants.effort.confirmTip": "같은 단을 다시 누르면 이 강도로 실행합니다.",
 };

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7467,6 +7467,29 @@
   --flyout-enter-x: 4px;
 }
 
+.operation-launch-effort-menu-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+/* 같은 단을 다시 눌러 실행한다는 숨은 확정 제스처를 처음 비-AUTO를 고른 순간에만 알려 준다.
+   파선 테두리는 이 앱에서 "아직 확정되지 않은 자리"의 어휘이고, brass 워시로 위치·초점 채널에
+   묶는다 — 신호색을 쓰면 "무슨 일이 일어났다"로 읽힌다. */
+.operation-launch-effort-confirm-tip {
+  margin: 0;
+  padding: 7px 9px;
+  border: 1px dashed color-mix(in oklch, var(--brass) 42%, var(--surface-rim));
+  border-radius: var(--radius-xs);
+  background: color-mix(in oklch, var(--brass) 8%, transparent);
+  color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: 11px;
+  line-height: 1.35;
+  text-wrap: pretty;
+}
+
 /* ── 추론 강도 트랙 ─────────────────────────────────────────────────────────
    강도는 상태가 아니라 사용자가 고른 값이라, 채움은 위치·초점 채널인 brass를 쓴다. 신호색
    (aurora/warn/coral/positive)으로 칠하면 그 순간 "무슨 일이 일어났다"로 읽힌다. */

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -778,7 +778,7 @@ describe("CanvasContextMenu effort confirm tip", () => {
     });
 
     const tip = document.querySelector<HTMLElement>(".operation-launch-effort-confirm-tip");
-    expect(tip?.textContent).toBe("Click the same rung again to launch with this effort.");
+    expect(tip?.textContent).toBe("Press the knob again to launch.");
     expect(tip?.getAttribute("role")).toBe("status");
     expect(fetch).toHaveBeenCalledWith("/api/v1/settings/global", expect.objectContaining({
       method: "PUT",

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -16,11 +16,25 @@ import {
   FEATURE_TOUR_BOUNDARY_ATTRIBUTE,
   FEATURE_TOUR_LAYER_ATTRIBUTE,
 } from "../core/client/src/feature-tour-catalog.js";
+import { EFFORT_CONFIRM_TIP_SEEN_KEY } from "../core/client/src/components/feature-tour.js";
+import { getGlobalSettingsStoreState, hydrateGlobalSettings } from "../core/client/src/global-settings-store.js";
+import type { GlobalSettingsState } from "../core/client/src/types.js";
+
+const SETTINGS: GlobalSettingsState = {
+  consolePortMode: "dynamic",
+  consoleStaticPort: null,
+  remoteAccess: { enabled: false, bindHost: null },
+  language: "auto",
+  seenFeatureTours: [],
+  theme: "instrument",
+  uiFont: { source: "builtin", id: "manrope", size: 14 },
+};
 
 let container: HTMLDivElement;
 let root: Root;
 let originalGetBoundingClientRect: typeof Element.prototype.getBoundingClientRect;
 let tourLayer: HTMLDivElement | null;
+const originalFetch = globalThis.fetch;
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -39,6 +53,18 @@ beforeEach(() => {
   document.body.append(container);
   root = createRoot(container);
   tourLayer = null;
+  hydrateGlobalSettings(SETTINGS);
+  globalThis.fetch = vi.fn(async (_input, init) => {
+    const body = typeof init?.body === "string" ? JSON.parse(init.body) as Partial<GlobalSettingsState> : {};
+    const previous = getGlobalSettingsStoreState().state ?? SETTINGS;
+    return new Response(JSON.stringify({
+      state: {
+        ...previous,
+        ...body,
+        seenFeatureTours: body.seenFeatureTours ?? previous.seenFeatureTours,
+      },
+    }), { status: 200, headers: { "Content-Type": "application/json" } });
+  }) as typeof fetch;
 });
 
 afterEach(() => {
@@ -46,6 +72,8 @@ afterEach(() => {
   tourLayer?.remove();
   container.remove();
   Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  globalThis.fetch = originalFetch;
+  hydrateGlobalSettings(SETTINGS);
 });
 
 describe("CanvasContextMenu anchor placement", () => {
@@ -732,6 +760,47 @@ describe("CanvasContextMenu launch kind attribute", () => {
 
     act(() => document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true })));
     expect(onClose).toHaveBeenCalledOnce();
+  });
+});
+
+describe("CanvasContextMenu effort confirm tip", () => {
+  it("shows a one-shot tip on the first non-AUTO selection and records it as seen", async () => {
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, gatewayVariantCatalog());
+    act(() => document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!
+      .parentElement!.dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
+    act(() => effortHandle("fable").dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
+
+    const track = document.querySelector<HTMLElement>(".effort-track")!;
+    expect(document.querySelector(".operation-launch-effort-confirm-tip")).toBeNull();
+
+    await act(async () => {
+      track.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+    });
+
+    const tip = document.querySelector<HTMLElement>(".operation-launch-effort-confirm-tip");
+    expect(tip?.textContent).toBe("Click the same rung again to launch with this effort.");
+    expect(tip?.getAttribute("role")).toBe("status");
+    expect(fetch).toHaveBeenCalledWith("/api/v1/settings/global", expect.objectContaining({
+      method: "PUT",
+      body: JSON.stringify({ seenFeatureTours: [EFFORT_CONFIRM_TIP_SEEN_KEY] }),
+    }));
+    expect(getGlobalSettingsStoreState().state?.seenFeatureTours).toContain(EFFORT_CONFIRM_TIP_SEEN_KEY);
+  });
+
+  it("keeps AUTO quiet and skips the tip when the confirm gesture was already seen", () => {
+    hydrateGlobalSettings({ ...SETTINGS, seenFeatureTours: [EFFORT_CONFIRM_TIP_SEEN_KEY] });
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, gatewayVariantCatalog());
+    act(() => document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!
+      .parentElement!.dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
+    act(() => effortHandle("fable").dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
+
+    const track = document.querySelector<HTMLElement>(".effort-track")!;
+    act(() => track.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true })));
+    expect(document.querySelector(".operation-launch-effort-confirm-tip")).toBeNull();
+
+    act(() => track.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true })));
+    expect(document.querySelector(".operation-launch-effort-confirm-tip")).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
   });
 });
 

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -764,8 +764,9 @@ describe("CanvasContextMenu launch kind attribute", () => {
 });
 
 describe("CanvasContextMenu effort confirm tip", () => {
-  it("shows a one-shot tip on the first non-AUTO selection and records it as seen", async () => {
-    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, gatewayVariantCatalog());
+  it("keeps showing the tip on non-AUTO selection until the confirm gesture graduates it", async () => {
+    const onLaunchKind = vi.fn();
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, gatewayVariantCatalog(), vi.fn(), false, onLaunchKind);
     act(() => document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!
       .parentElement!.dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
     act(() => effortHandle("fable").dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
@@ -773,13 +774,21 @@ describe("CanvasContextMenu effort confirm tip", () => {
     const track = document.querySelector<HTMLElement>(".effort-track")!;
     expect(document.querySelector(".operation-launch-effort-confirm-tip")).toBeNull();
 
-    await act(async () => {
-      track.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
-    });
-
+    act(() => track.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true })));
     const tip = document.querySelector<HTMLElement>(".operation-launch-effort-confirm-tip");
     expect(tip?.textContent).toBe("Press the knob again to launch.");
     expect(tip?.getAttribute("role")).toBe("status");
+    // 선택만으로는 졸업하지 않는다 — 피처 투어를 건너뛰고 메뉴를 닫아도 다음에 다시 보인다.
+    expect(fetch).not.toHaveBeenCalled();
+    expect(getGlobalSettingsStoreState().state?.seenFeatureTours ?? []).not.toContain(EFFORT_CONFIRM_TIP_SEEN_KEY);
+
+    await act(async () => {
+      track.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+    expect(onLaunchKind).toHaveBeenCalledWith("terminal", gatewayVariantCatalog()[0]!.kinds[0], {
+      model: "fable",
+      effort: "max",
+    });
     expect(fetch).toHaveBeenCalledWith("/api/v1/settings/global", expect.objectContaining({
       method: "PUT",
       body: JSON.stringify({ seenFeatureTours: [EFFORT_CONFIRM_TIP_SEEN_KEY] }),

--- a/runtime/fleet-console/tests/command-band-system-cluster.test.ts
+++ b/runtime/fleet-console/tests/command-band-system-cluster.test.ts
@@ -207,6 +207,7 @@ describe("CommandBandSystemCluster", () => {
         "claude-operations.walkthrough",
         "remote-access.spotlight",
         "commissioning",
+        "effort-confirm-tip",
       ],
     });
     globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({
@@ -223,7 +224,7 @@ describe("CommandBandSystemCluster", () => {
     expect(entry.disabled).toBe(false);
     act(() => entry.click());
 
-    // 온보딩 전체(피처 투어 + 최초 설정 가이드)가 초기화되어 서버에 저장된다.
+    // 온보딩 전체(피처 투어 + 최초 설정 가이드 + 강도 확인 팁)가 초기화되어 서버에 저장된다.
     expect(fetch).toHaveBeenCalledWith("/api/v1/settings/global", expect.objectContaining({
       method: "PUT",
       body: JSON.stringify({ seenFeatureTours: [] }),


### PR DESCRIPTION
## Summary
- 캔버스 실행 캐스케이드에서 AUTO가 아닌 추론 강도를 처음 고르면, 트랙 아래 한 줄 팁이 같은 단을 다시 눌러 실행하는 숨은 제스처를 알려 줍니다.
- 시청 키 `effort-confirm.tip`는 프로필당 한 번만 보이며, 도움말 → 화면 안내 다시 보기로 초기화됩니다.
- Quick Launch와 AUTO 확정 실행 주장은 범위 밖입니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/canvas-context-menu-anchor.test.tsx tests/command-band-system-cluster.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [ ] 수동: 캔버스 메뉴 → Claude → 모델 → 강도 트랙에서 비-AUTO 선택 시 팁 표시 → 같은 단 재클릭으로 실행 → 팁 재등장 없음 → 화면 안내 다시 보기 후 복귀