### PR TITLE
fix(fleet-desktop): restore Windows access-link copy

### DIFF
--- a/.changelog.d/fix-windows-remote-access-copy.md
+++ b/.changelog.d/fix-windows-remote-access-copy.md
@@ -1,0 +1,8 @@
+---
+branch: fix-windows-remote-access-copy
+---
+
+### fleet-desktop
+#### Fixed
+- Make access-link copy actions work in the Windows Desktop app while keeping clipboard permission limited to the active Console origin.
+  ko: Windows 데스크톱 앱에서 클립보드 권한을 활성 Console origin으로 제한하면서 액세스 링크 복사 동작이 작동하도록 수정했습니다.

--- a/packages/core-process/src/bin-resolver.ts
+++ b/packages/core-process/src/bin-resolver.ts
@@ -12,6 +12,7 @@ export interface ResolvedBinary {
 
 const DEFAULT_WINDOWS_PATHEXT = ".COM;.EXE;.BAT;.CMD";
 const WINDOWS_PATH_SEPARATOR = ";";
+const POSIX_PATH_SEPARATOR = ":";
 const WINDOWS_SHIM_EXTENSIONS = new Set([".cmd", ".bat"]);
 const CMD_EXPANSION_SENSITIVE_PATTERN = /[%^]/;
 
@@ -66,7 +67,7 @@ export function prependPathEntries(env: NodeJS.ProcessEnv, entries: readonly str
   const isWindows = platform === "win32";
   const pathKey = isWindows ? Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "Path" : "PATH";
   const existingPath = isWindows ? (env.Path ?? env.PATH) : env.PATH;
-  const separator = isWindows ? WINDOWS_PATH_SEPARATOR : path.delimiter;
+  const separator = isWindows ? WINDOWS_PATH_SEPARATOR : POSIX_PATH_SEPARATOR;
   const seen = new Set<string>();
   const pathEntries: string[] = [];
   for (const entry of [...entries, ...(existingPath?.split(separator) ?? [])]) {

--- a/runtime/fleet-desktop/src/environment.ts
+++ b/runtime/fleet-desktop/src/environment.ts
@@ -21,6 +21,7 @@ export interface LoginShellPathProbe {
 
 export interface HydratedDesktopEnvironmentOptions {
   readonly platform?: NodeJS.Platform;
+  readonly homeDirectory?: string;
   readonly loginShellPathProbe?: LoginShellPathProbe;
 }
 
@@ -76,7 +77,7 @@ export function createDesktopEnvironment(userDataDir: string, appVersion: string
   if (!fs.existsSync(ownerFile)) fs.writeFileSync(ownerFile, `${ownerId}\n`, { mode: 0o600 });
   const sanitized = sanitizeEnvironment(env);
   const serviceBase = isPackaged
-    ? createPackagedServiceEnvironment(sanitized, options.loginShellPath, options.platform ?? process.platform)
+    ? createPackagedServiceEnvironment(sanitized, options.loginShellPath, options.platform ?? process.platform, options.homeDirectory ?? os.homedir())
     : sanitized;
   // TLS 검사 프록시 환경 대응(issue #531): sidecar Node가 OS 신뢰 저장소를 기본 신뢰하도록 한다. opt-out은 FLEET_CONSOLE_NO_SYSTEM_CA=1.
   const serviceBaseWithCa = env.FLEET_CONSOLE_NO_SYSTEM_CA === "1" ? serviceBase : withNodeSystemCa(serviceBase);
@@ -106,7 +107,7 @@ export async function createHydratedDesktopEnvironment(userDataDir: string, appV
   resolveDesktopDataDirectoryOverride(env);
   resolveFleetDataDir(env);
   const loginShellPath = await readInteractiveLoginShellPath(isPackaged, env, options);
-  return createDesktopEnvironment(userDataDir, appVersion, resourceRoot, isPackaged, env, { platform, loginShellPath });
+  return createDesktopEnvironment(userDataDir, appVersion, resourceRoot, isPackaged, env, { platform, homeDirectory: options.homeDirectory, loginShellPath });
 }
 
 export async function readInteractiveLoginShellPath(isPackaged: boolean, env: NodeJS.ProcessEnv, options: HydratedDesktopEnvironmentOptions = {}): Promise<string | undefined> {
@@ -131,19 +132,20 @@ export async function readInteractiveLoginShellPath(isPackaged: boolean, env: No
 export function desktopExecutableSearchPaths(homeDirectory: string, env: NodeJS.ProcessEnv, platform: NodeJS.Platform): readonly string[] {
   const configuredPrefix = readEnvironmentValue(env, "npm_config_prefix");
   const pnpmHome = readEnvironmentValue(env, "PNPM_HOME");
+  const platformPath = platform === "win32" ? path.win32 : path.posix;
   if (platform === "win32") {
     const appData = readEnvironmentValue(env, "APPDATA");
     return compactPaths([
       configuredPrefix,
       pnpmHome,
-      appData ? path.win32.join(appData, "npm") : undefined,
+      appData ? platformPath.join(appData, "npm") : undefined,
     ]);
   }
   return compactPaths([
-    configuredPrefix ? path.join(configuredPrefix, "bin") : undefined,
+    configuredPrefix ? platformPath.join(configuredPrefix, "bin") : undefined,
     pnpmHome,
-    path.join(homeDirectory, ".local", "bin"),
-    ...(platform === "darwin" ? [path.join(homeDirectory, "Library", "pnpm"), "/opt/homebrew/bin"] : []),
+    platformPath.join(homeDirectory, ".local", "bin"),
+    ...(platform === "darwin" ? [platformPath.join(homeDirectory, "Library", "pnpm"), "/opt/homebrew/bin"] : []),
     "/usr/local/bin",
   ]);
 }
@@ -157,13 +159,14 @@ export function sanitizeEnvironment(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return next;
 }
 
-function createPackagedServiceEnvironment(sanitized: NodeJS.ProcessEnv, loginShellPath: string | undefined, platform: NodeJS.Platform): NodeJS.ProcessEnv {
-  const fallbackEnvironment = prependPathEntries(sanitized, desktopExecutableSearchPaths(os.homedir(), sanitized, platform), { platform });
+function createPackagedServiceEnvironment(sanitized: NodeJS.ProcessEnv, loginShellPath: string | undefined, platform: NodeJS.Platform, homeDirectory: string): NodeJS.ProcessEnv {
+  const fallbackEnvironment = prependPathEntries(sanitized, desktopExecutableSearchPaths(homeDirectory, sanitized, platform), { platform });
   if (platform !== "darwin" || loginShellPath === undefined) return fallbackEnvironment;
   // 로그인 셸, Finder가 물려준 PATH, 기존의 결정적 폴백 순서로 한 번만 정규화한다.
   // 셸에서 온 값은 오직 PATH 출력이며, 다른 셸 환경 변수는 sidecar로 전달하지 않는다.
-  const inheritedAndFallbackPath = [sanitized.PATH, ...desktopExecutableSearchPaths(os.homedir(), sanitized, platform)].filter((value): value is string => value !== undefined).join(path.delimiter);
-  return prependPathEntries({ ...sanitized, PATH: inheritedAndFallbackPath }, loginShellPath.split(path.delimiter), { platform });
+  const pathDelimiter = ":";
+  const inheritedAndFallbackPath = [sanitized.PATH, ...desktopExecutableSearchPaths(homeDirectory, sanitized, platform)].filter((value): value is string => value !== undefined).join(pathDelimiter);
+  return prependPathEntries({ ...sanitized, PATH: inheritedAndFallbackPath }, loginShellPath.split(pathDelimiter), { platform });
 }
 
 function isSafeLoginShellPath(value: string): boolean {

--- a/runtime/fleet-desktop/src/window-policy.ts
+++ b/runtime/fleet-desktop/src/window-policy.ts
@@ -57,7 +57,14 @@ export function applyWindowPolicy(contents: WebContents, originOrOpenExternal: s
     if (consoleOrigin && isHttpUrl(url)) void openExternal(url);
     return { action: "deny" };
   });
-  contents.session.setPermissionRequestHandler((_wc, permission, callback, details) => callback(Boolean(consoleOrigin) && permission === "clipboard-sanitized-write" && hasExactOrigin(details.requestingUrl, consoleOrigin ?? "")));
+  const permitsClipboardWrite = (permission: string, requestingUrl: string): boolean =>
+    Boolean(consoleOrigin) && permission === "clipboard-sanitized-write" && hasExactOrigin(requestingUrl, consoleOrigin ?? "");
+  // Chromium은 플랫폼별로 check에서 곧장 끝내기도, 거부된 check 뒤 request로 이어 가기도 한다.
+  // 둘을 같은 exact-origin 판정에 묶어 Windows에서도 쓰기를 허용하되 권한 범위는 넓히지 않는다.
+  contents.session.setPermissionCheckHandler((requestingContents, permission, requestingOrigin, details) =>
+    (requestingContents === null || requestingContents === contents)
+    && permitsClipboardWrite(permission, details.requestingUrl ?? requestingOrigin));
+  contents.session.setPermissionRequestHandler((_wc, permission, callback, details) => callback(permitsClipboardWrite(permission, details.requestingUrl)));
   const admittedRemoteOrigins = new Set<string>();
   const validateOrigin = (origin: string): void => {
     // 루프백은 언제나, 원격은 지문을 대조해 들인 뒤에만.
@@ -90,7 +97,7 @@ export function applyWindowPolicy(contents: WebContents, originOrOpenExternal: s
 /**
  * 집의 목록을 그리는 덮개 렌더러의 항해 울타리.
  *
- * `applyWindowPolicy`를 그대로 쓸 수는 없다. 그쪽은 세션 단위인 `setPermissionRequestHandler`를
+ * `applyWindowPolicy`를 그대로 쓸 수는 없다. 그쪽은 세션 단위인 permission check/request handler를
  * 갈아 끼우는데, 이 뷰는 메인 창과 같은 defaultSession에 산다 — 덮개를 한 번 얹는 것만으로
  * 메인 창(원격 origin)의 클립보드 권한 판정이 집 origin 기준으로 바뀌고, 덮개를 걷어도
  * 그대로 남는다. 그래서 여기서는 세션에 손대지 않고 이 contents의 항해만 가둔다.

--- a/runtime/fleet-desktop/tests/console-installer.test.ts
+++ b/runtime/fleet-desktop/tests/console-installer.test.ts
@@ -8,7 +8,7 @@ import { resolveRuntimePaths } from "../src/runtime/runtime-paths.js";
 function missing(): NodeJS.ErrnoException { const error = new Error("missing") as NodeJS.ErrnoException; error.code = "ENOENT"; return error; }
 
 function fileSystem(existing = new Set<string>()) {
-  const stat = vi.fn(async (target: string) => { if (!existing.has(target) && !target.includes(".staging-test/")) throw missing(); });
+  const stat = vi.fn(async (target: string) => { if (!existing.has(target) && !target.replaceAll("\\", "/").includes(".staging-test/")) throw missing(); });
   const rename = vi.fn(async (from: string, to: string) => { if (!existing.has(from) && !from.includes(".staging-test") && !from.endsWith(".package")) throw missing(); existing.delete(from); existing.add(to); });
   return {
     accessExecutable: vi.fn(async () => undefined),
@@ -28,9 +28,12 @@ describe("console installer", () => {
     const fs = fileSystem();
     const run = vi.fn<(command: string, arguments_: readonly string[], options: { readonly env: NodeJS.ProcessEnv }) => Promise<void>>(async () => undefined);
     const paths = resolveRuntimePaths("/Users/fleet");
-    await expect(installConsole({ paths, nodeRoot: "/runtime/node", packageName: "@dotobokuri/fleet-console", version: "1.2.3", nodeRuntimeVersion: "22.23.1", platform: "darwin", architecture: "arm64", dependencies: { environment: { NODE_OPTIONS: "--require attacker", npm_config_registry: "https://attacker.invalid", NPM_CONFIG_CACHE: "/attacker", PATH: "/safe/bin" }, fileSystem: fs, run, randomSuffix: () => "test" } })).resolves.toEqual({ root: paths.latest, version: "1.2.3" });
-    // 번들 node bin("/runtime/node/bin")이 PATH 앞에 붙어야 npm lifecycle 스크립트가 node를 찾는다.
-    expect(run).toHaveBeenCalledWith("/runtime/node/bin/node", ["/runtime/node/lib/node_modules/npm/bin/npm-cli.js", "install", "--prefix", "/Users/fleet/.fleet/desktop/runtime/console/.staging-test", "--global=false", "--force=false", "--package-lock=false", "--no-audit", "--no-fund", "@dotobokuri/fleet-console@1.2.3"], { env: expect.objectContaining({ PATH: "/runtime/node/bin:/safe/bin", npm_config_registry: "https://registry.npmjs.org/", npm_config_userconfig: "/Users/fleet/.fleet/desktop/runtime/console/.staging-test/.npmrc", npm_config_globalconfig: "/Users/fleet/.fleet/desktop/runtime/console/.staging-test/.npmrc-global" }) });
+    const nodeRoot = path.resolve("/runtime/node");
+    const staging = path.join(paths.console, ".staging-test");
+    await expect(installConsole({ paths, nodeRoot, packageName: "@dotobokuri/fleet-console", version: "1.2.3", nodeRuntimeVersion: "22.23.1", platform: "darwin", architecture: "arm64", dependencies: { environment: { NODE_OPTIONS: "--require attacker", npm_config_registry: "https://attacker.invalid", NPM_CONFIG_CACHE: "/attacker", PATH: "/safe/bin" }, fileSystem: fs, run, randomSuffix: () => "test" } })).resolves.toEqual({ root: paths.latest, version: "1.2.3" });
+    const nodeBin = path.join(nodeRoot, "bin");
+    // 번들 node bin이 PATH 앞에 붙어야 npm lifecycle 스크립트가 node를 찾는다.
+    expect(run).toHaveBeenCalledWith(path.join(nodeBin, "node"), [path.join(nodeRoot, "lib", "node_modules", "npm", "bin", "npm-cli.js"), "install", "--prefix", staging, "--global=false", "--force=false", "--package-lock=false", "--no-audit", "--no-fund", "@dotobokuri/fleet-console@1.2.3"], { env: expect.objectContaining({ PATH: `${nodeBin}:/safe/bin`, npm_config_registry: "https://registry.npmjs.org/", npm_config_userconfig: path.join(staging, ".npmrc"), npm_config_globalconfig: path.join(staging, ".npmrc-global") }) });
     const firstRun = run.mock.calls[0];
     if (!firstRun) throw new Error("npm invocation was not captured");
     const runEnvironment = firstRun[2].env;
@@ -38,16 +41,17 @@ describe("console installer", () => {
     expect(runEnvironment.npm_config_registry).toBe("https://registry.npmjs.org/");
     expect(runEnvironment.NPM_CONFIG_CACHE).toBeUndefined();
     expect(runEnvironment.npm_config_userconfig).not.toBe(runEnvironment.npm_config_globalconfig);
-    expect(fs.writeFile).toHaveBeenCalledWith("/Users/fleet/.fleet/desktop/runtime/console/.staging-test/.npmrc", "");
-    expect(fs.writeFile).toHaveBeenCalledWith("/Users/fleet/.fleet/desktop/runtime/console/.staging-test/.npmrc-global", "");
-    expect(fs.rm).toHaveBeenCalledWith("/Users/fleet/.fleet/desktop/runtime/console/.staging-test/.npmrc");
-    expect(fs.rm).toHaveBeenCalledWith("/Users/fleet/.fleet/desktop/runtime/console/.staging-test/.npmrc-global");
-    expect(fs.rename).toHaveBeenCalledWith("/Users/fleet/.fleet/desktop/runtime/console/.staging-test/node_modules/@dotobokuri/fleet-console", "/Users/fleet/.fleet/desktop/runtime/console/.staging-test.package");
-    expect(fs.stat).toHaveBeenCalledWith("/Users/fleet/.fleet/desktop/runtime/console/.staging-test/dist/cli.mjs");
-    expect(fs.stat).toHaveBeenCalledWith("/Users/fleet/.fleet/desktop/runtime/console/.staging-test/node_modules/node-pty");
-    expect(fs.writeFile).toHaveBeenCalledWith("/Users/fleet/.fleet/desktop/runtime/console/.staging-test/.fleet-console-resource-root", "1\n");
-    expect(fs.chmod).toHaveBeenCalledWith("/Users/fleet/.fleet/desktop/runtime/console/.staging-test/node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper", 0o755);
-    expect(fs.accessExecutable).toHaveBeenCalledWith("/Users/fleet/.fleet/desktop/runtime/console/.staging-test/node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper");
+    expect(fs.writeFile).toHaveBeenCalledWith(path.join(staging, ".npmrc"), "");
+    expect(fs.writeFile).toHaveBeenCalledWith(path.join(staging, ".npmrc-global"), "");
+    expect(fs.rm).toHaveBeenCalledWith(path.join(staging, ".npmrc"));
+    expect(fs.rm).toHaveBeenCalledWith(path.join(staging, ".npmrc-global"));
+    expect(fs.rename).toHaveBeenCalledWith(path.join(staging, "node_modules", "@dotobokuri", "fleet-console"), `${staging}.package`);
+    expect(fs.stat).toHaveBeenCalledWith(path.join(staging, "dist", "cli.mjs"));
+    expect(fs.stat).toHaveBeenCalledWith(path.join(staging, "node_modules", "node-pty"));
+    expect(fs.writeFile).toHaveBeenCalledWith(path.join(staging, ".fleet-console-resource-root"), "1\n");
+    const spawnHelper = path.join(staging, "node_modules", "node-pty", "prebuilds", "darwin-arm64", "spawn-helper");
+    expect(fs.chmod).toHaveBeenCalledWith(spawnHelper, 0o755);
+    expect(fs.accessExecutable).toHaveBeenCalledWith(spawnHelper);
   });
 
   it("rejects npm aliases, URLs, ranges, and prereleases before spawning npm", async () => {
@@ -73,8 +77,9 @@ describe("console installer", () => {
   it("repairs an existing packaged macOS Console before sidecar launch", async () => {
     const fs = fileSystem();
     await repairConsoleNativeExecutables("/console/latest", "darwin", "x64", fs);
-    expect(fs.chmod).toHaveBeenCalledWith("/console/latest/node_modules/node-pty/prebuilds/darwin-x64/spawn-helper", 0o755);
-    expect(fs.accessExecutable).toHaveBeenCalledWith("/console/latest/node_modules/node-pty/prebuilds/darwin-x64/spawn-helper");
+    const spawnHelper = path.join("/console/latest", "node_modules", "node-pty", "prebuilds", "darwin-x64", "spawn-helper");
+    expect(fs.chmod).toHaveBeenCalledWith(spawnHelper, 0o755);
+    expect(fs.accessExecutable).toHaveBeenCalledWith(spawnHelper);
   });
 
   it("fails closed when the repaired macOS spawn helper is still not executable", async () => {
@@ -101,7 +106,7 @@ describe("console installer", () => {
     fs.readdir.mockResolvedValueOnce(["latest.rollback", ".staging-crashed", "keep"]);
     await reconcileConsoleInstallations(paths, fs);
     expect(fs.rename).toHaveBeenCalledWith(`${paths.latest}.rollback`, paths.latest);
-    expect(fs.rm).toHaveBeenCalledWith(`${paths.console}/.staging-crashed`);
+    expect(fs.rm).toHaveBeenCalledWith(path.join(paths.console, ".staging-crashed"));
   });
 
   it("keeps promoted latest when rollback cleanup fails so the next start can reconcile it", async () => {

--- a/runtime/fleet-desktop/tests/environment.test.ts
+++ b/runtime/fleet-desktop/tests/environment.test.ts
@@ -188,10 +188,10 @@ describe("desktop environment", () => {
       const environment = await createHydratedDesktopEnvironment(userDataDir, "1.23.0", "/packaged/resources/fleet-console", true, {
         SHELL: "/bin/zsh",
         PATH: "/inherited/bin",
-      }, { platform: "darwin", loginShellPathProbe });
-      expect(environment.serviceEnv.PATH?.split(path.delimiter)).toEqual([
-        path.join(os.homedir(), ".local", "bin"),
-        path.join(os.homedir(), "Library", "pnpm"),
+      }, { platform: "darwin", homeDirectory: "/Users/alice", loginShellPathProbe });
+      expect(environment.serviceEnv.PATH?.split(":")).toEqual([
+        "/Users/alice/.local/bin",
+        "/Users/alice/Library/pnpm",
         "/opt/homebrew/bin",
         "/usr/local/bin",
         "/inherited/bin",
@@ -203,24 +203,24 @@ describe("desktop environment", () => {
   it("orders and deduplicates packaged macOS shell, inherited, and deterministic PATH entries", async () => {
     const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "fleet-desktop-shell-path-"));
     TEMP_DIRS.push(userDataDir);
-    const home = os.homedir();
+    const home = "/Users/alice";
     const environment = await createHydratedDesktopEnvironment(userDataDir, "1.23.0", "/packaged/resources/fleet-console", true, {
       SHELL: "/bin/zsh",
       PATH: "/inherited/bin:/shared/bin",
       npm_config_prefix: "/fallback-prefix",
       PNPM_HOME: "/shared/bin",
-    }, { platform: "darwin", loginShellPathProbe: { run: vi.fn(async () => ({ stdout: "/Users/alice/.opencode/bin:/shared/bin" })) } });
+    }, { platform: "darwin", homeDirectory: "/Users/alice", loginShellPathProbe: { run: vi.fn(async () => ({ stdout: "/Users/alice/.opencode/bin:/shared/bin" })) } });
 
     expect(environment.serviceEnv.PATH).toBe([
       "/Users/alice/.opencode/bin",
       "/shared/bin",
       "/inherited/bin",
       "/fallback-prefix/bin",
-      path.join(home, ".local", "bin"),
-      path.join(home, "Library", "pnpm"),
+      path.posix.join(home, ".local", "bin"),
+      path.posix.join(home, "Library", "pnpm"),
       "/opt/homebrew/bin",
       "/usr/local/bin",
-    ].join(path.delimiter));
+    ].join(":"));
   });
 
   it("adds macOS user and npm executable locations for a packaged GUI launch", () => {

--- a/runtime/fleet-desktop/tests/node-bootstrap.test.ts
+++ b/runtime/fleet-desktop/tests/node-bootstrap.test.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
 
 const execFileMock = vi.hoisted(() => vi.fn());
@@ -20,10 +22,13 @@ function dependencies() {
 describe("Node runtime bootstrap", () => {
   it("downloads, verifies, extracts, and promotes the pinned runtime", async () => {
     const injected = dependencies();
-    await expect(bootstrapNodeRuntime({ destination: "/runtime/node", manifest, platform: "darwin", architecture: "arm64", dependencies: injected })).resolves.toEqual({ nodePath: "/runtime/node/bin/node", version: "22.23.1" });
-    expect(injected.download).toHaveBeenCalledWith("https://node.invalid/node.tar.gz", "/runtime/node.staging/node.tar.gz");
-    expect(injected.extract).toHaveBeenCalledWith("/runtime/node.staging/node.tar.gz", "/runtime/node.staging", "darwin");
-    expect(injected.fileSystem.rename).toHaveBeenCalledWith("/runtime/node.staging", "/runtime/node");
+    const destination = path.resolve("/runtime/node");
+    const staging = `${destination}.staging`;
+    const archive = path.join(staging, "node.tar.gz");
+    await expect(bootstrapNodeRuntime({ destination, manifest, platform: "darwin", architecture: "arm64", dependencies: injected })).resolves.toEqual({ nodePath: path.join(destination, "bin", "node"), version: "22.23.1" });
+    expect(injected.download).toHaveBeenCalledWith("https://node.invalid/node.tar.gz", archive);
+    expect(injected.extract).toHaveBeenCalledWith(archive, staging, "darwin");
+    expect(injected.fileSystem.rename).toHaveBeenCalledWith(staging, destination);
   });
 
   it("cleans partial output when checksum verification fails", async () => {
@@ -35,14 +40,17 @@ describe("Node runtime bootstrap", () => {
 
   it("exposes a reusable verified archive seam before an archive can be consumed", async () => {
     const injected = dependencies();
-    const archive = await downloadVerifiedNodeArchive({ directory: "/temporary", manifest, target: manifest.targets["darwin-arm64"]!, dependencies: injected });
-    expect(archive).toEqual({ path: "/temporary/node.tar.gz", content: new Uint8Array([1]) });
-    expect(injected.download).toHaveBeenCalledWith("https://node.invalid/node.tar.gz", "/temporary/node.tar.gz");
+    const directory = path.resolve("/temporary");
+    const archivePath = path.join(directory, "node.tar.gz");
+    const archive = await downloadVerifiedNodeArchive({ directory, manifest, target: manifest.targets["darwin-arm64"]!, dependencies: injected });
+    expect(archive).toEqual({ path: archivePath, content: new Uint8Array([1]) });
+    expect(injected.download).toHaveBeenCalledWith("https://node.invalid/node.tar.gz", archivePath);
   });
 
   it("uses the Windows node executable without executing it", async () => {
     const injected = dependencies();
-    await expect(bootstrapNodeRuntime({ destination: "C:/runtime/node", manifest, platform: "win32", architecture: "x64", dependencies: injected })).resolves.toMatchObject({ nodePath: "C:/runtime/node/node.exe" });
+    const destination = path.resolve("C:/runtime/node");
+    await expect(bootstrapNodeRuntime({ destination, manifest, platform: "win32", architecture: "x64", dependencies: injected })).resolves.toMatchObject({ nodePath: path.join(destination, "node.exe") });
   });
 
   it("accepts the trusted manifest only when it satisfies the installed Console engine", () => {

--- a/runtime/fleet-desktop/tests/runtime-paths.test.ts
+++ b/runtime/fleet-desktop/tests/runtime-paths.test.ts
@@ -1,12 +1,17 @@
+import path from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { createStagingPath, readRuntimePresence, resolveRuntimePaths } from "../src/runtime/runtime-paths.js";
 
 describe("desktop runtime paths", () => {
   it("separates desktop runtime code from Console data", async () => {
-    const paths = resolveRuntimePaths("/Users/fleet");
-    expect(paths).toMatchObject({ root: "/Users/fleet/.fleet/desktop/runtime", node: "/Users/fleet/.fleet/desktop/runtime/node", latest: "/Users/fleet/.fleet/desktop/runtime/console/latest" });
-    expect(createStagingPath(paths, "random")).toBe("/Users/fleet/.fleet/desktop/runtime/console/.staging-random");
+    const home = path.resolve("/Users/fleet");
+    const root = path.join(home, ".fleet", "desktop", "runtime");
+    const console = path.join(root, "console");
+    const paths = resolveRuntimePaths(home);
+    expect(paths).toMatchObject({ root, node: path.join(root, "node"), latest: path.join(console, "latest") });
+    expect(createStagingPath(paths, "random")).toBe(path.join(console, ".staging-random"));
     await expect(readRuntimePresence(paths, { access: async (target) => { if (target !== paths.node) throw new Error("missing"); } })).resolves.toEqual({ node: true, latest: false });
   });
 

--- a/runtime/fleet-desktop/tests/window-policy.test.ts
+++ b/runtime/fleet-desktop/tests/window-policy.test.ts
@@ -6,7 +6,7 @@ const HOME = "http://127.0.0.1:4310";
 
 function createPickerContents() {
   const listeners = new Map<string, (...args: never[]) => unknown>();
-  const session = { setPermissionRequestHandler: vi.fn() };
+  const session = { setPermissionCheckHandler: vi.fn(), setPermissionRequestHandler: vi.fn() };
   const contents = {
     on: vi.fn((name: string, listener: (...args: never[]) => unknown) => listeners.set(name, listener)),
     setWindowOpenHandler: vi.fn(),
@@ -30,6 +30,7 @@ describe("host picker view confinement", () => {
 
     confinePickerNavigation(contents as never, HOME, () => false);
 
+    expect(session.setPermissionCheckHandler).not.toHaveBeenCalled();
     expect(session.setPermissionRequestHandler).not.toHaveBeenCalled();
   });
 
@@ -81,7 +82,7 @@ describe("secure window policy", () => {
 
   it("locks the entry renderer until the main process activates one exact Console origin", () => {
     const listeners = new Map<string, (...args: never[]) => unknown>();
-    const contents = { on: vi.fn((name: string, listener: (...args: never[]) => unknown) => listeners.set(name, listener)), setWindowOpenHandler: vi.fn(), session: { setPermissionRequestHandler: vi.fn() } };
+    const contents = { on: vi.fn((name: string, listener: (...args: never[]) => unknown) => listeners.set(name, listener)), setWindowOpenHandler: vi.fn(), session: { setPermissionCheckHandler: vi.fn(), setPermissionRequestHandler: vi.fn() } };
     const policy = applyWindowPolicy(contents as never, async () => undefined);
     const before = vi.fn();
     (listeners.get("will-navigate") as ((event: { preventDefault(): void }, url: string) => void))({ preventDefault: before }, "http://127.0.0.1:4310/console/");
@@ -97,9 +98,33 @@ describe("secure window policy", () => {
     expect(() => policy.activateConsoleOrigin("https://fleet.example")).toThrow("window_policy_console_origin_not_admitted");
   });
 
+  it("allows clipboard writes only after activating the exact Console origin", () => {
+    const listeners = new Map<string, (...args: never[]) => unknown>();
+    const session = { setPermissionCheckHandler: vi.fn(), setPermissionRequestHandler: vi.fn() };
+    const contents = { on: vi.fn((name: string, listener: (...args: never[]) => unknown) => listeners.set(name, listener)), setWindowOpenHandler: vi.fn(), session };
+    const policy = applyWindowPolicy(contents as never, async () => undefined);
+    const check = session.setPermissionCheckHandler.mock.calls[0]![0] as (requestingContents: unknown, permission: string, requestingOrigin: string, details: { requestingUrl?: string }) => boolean;
+    const request = session.setPermissionRequestHandler.mock.calls[0]![0] as (_contents: unknown, permission: string, callback: (allowed: boolean) => void, details: { requestingUrl: string }) => void;
+
+    expect(check(contents, "clipboard-sanitized-write", HOME, { requestingUrl: `${HOME}/console/settings` })).toBe(false);
+    policy.activateConsoleOrigin(HOME);
+    // Windows의 clipboard check는 origin 대신 빈 문자열을 넘길 수 있으므로 마지막 frame URL로 판정한다.
+    expect(check(contents, "clipboard-sanitized-write", "", { requestingUrl: `${HOME}/console/settings` })).toBe(true);
+    expect(check(null, "clipboard-sanitized-write", "", { requestingUrl: `${HOME}/console/settings` })).toBe(true);
+    expect(check(contents, "clipboard-read", HOME, { requestingUrl: `${HOME}/console/settings` })).toBe(false);
+    expect(check(contents, "clipboard-sanitized-write", "", { requestingUrl: "http://localhost:4310/console/settings" })).toBe(false);
+    expect(check({}, "clipboard-sanitized-write", HOME, { requestingUrl: `${HOME}/console/settings` })).toBe(false);
+
+    const callback = vi.fn();
+    request(null, "clipboard-sanitized-write", callback, { requestingUrl: `${HOME}/console/settings` });
+    expect(callback).toHaveBeenCalledWith(true);
+    request(null, "clipboard-sanitized-write", callback, { requestingUrl: "https://fleet.example/console/settings" });
+    expect(callback).toHaveBeenLastCalledWith(false);
+  });
+
   it("allows a pending target only until a transactional pairing commits it", () => {
     const listeners = new Map<string, (...args: never[]) => unknown>();
-    const contents = { on: vi.fn((name: string, listener: (...args: never[]) => unknown) => listeners.set(name, listener)), setWindowOpenHandler: vi.fn(), session: { setPermissionRequestHandler: vi.fn() } };
+    const contents = { on: vi.fn((name: string, listener: (...args: never[]) => unknown) => listeners.set(name, listener)), setWindowOpenHandler: vi.fn(), session: { setPermissionCheckHandler: vi.fn(), setPermissionRequestHandler: vi.fn() } };
     const policy = applyWindowPolicy(contents as never, "http://127.0.0.1:4000", async () => undefined);
     policy.stageConsoleOrigin("http://127.0.0.1:4310");
     const pendingAllowed = vi.fn();
@@ -119,7 +144,7 @@ describe("secure window policy", () => {
   it("blocks popups and navigation while brokering HTTP links only", async () => {
     const listeners = new Map<string, (...args: never[]) => unknown>();
     const openExternal = vi.fn(async () => undefined);
-    const contents = { on: vi.fn((name: string, listener: (...args: never[]) => unknown) => listeners.set(name, listener)), setWindowOpenHandler: vi.fn(), session: { setPermissionRequestHandler: vi.fn() } };
+    const contents = { on: vi.fn((name: string, listener: (...args: never[]) => unknown) => listeners.set(name, listener)), setWindowOpenHandler: vi.fn(), session: { setPermissionCheckHandler: vi.fn(), setPermissionRequestHandler: vi.fn() } };
     applyWindowPolicy(contents as never, "http://127.0.0.1:4310", openExternal);
     const handler = contents.setWindowOpenHandler.mock.calls[0]![0] as ({ url }: { url: string }) => { action: string };
     expect(handler({ url: "https://fleet.example/docs" })).toEqual({ action: "deny" });


### PR DESCRIPTION
## Summary
- Allow Windows Fleet Desktop access-link copy actions through both Electron clipboard permission gates while limiting writes to the active Console origin.
- Make target-platform PATH assembly independent of the host OS used to run cross-platform tests.
- Normalize Desktop runtime fixtures so the full Windows test suite validates native path separators.

## Test Plan
- [x] Verify Remote Access link creation and the Copy button against the Windows OS clipboard in the Desktop app.
- [x] Run `pnpm --dir runtime/fleet-desktop test` (268/268 passed).
- [x] Run Fleet Desktop typecheck and build.
- [x] Run `pnpm --dir packages/core-process test` (24 passed, 3 platform-conditional skipped).
- [x] Run core-process typecheck and build.
- [x] Run `node scripts/compile-changelog-fragments.mjs --check` and `git diff --check`.