### PR TITLE
feat(console): open the launch menu directly on the model list

### DIFF
--- a/.changelog.d/canvas-menu-flatten.md
+++ b/.changelog.d/canvas-menu-flatten.md
@@ -4,5 +4,5 @@ branch: canvas-menu-flatten
 
 ### fleet-console
 #### Changed
-- Right-clicking the canvas or an empty sidebar row now opens the model list itself. The launch menu used to list launch kinds first and hide the models behind a side flyout, so picking a model took one hover more than it needed; now Shell sits on the first row and the provider bands follow it in the same menu, with reasoning effort still one step to the side.
-  ko: 캔버스나 사이드바 빈 자리를 우클릭하면 모델 목록이 곧바로 열립니다. 실행 메뉴가 실행 종류를 먼저 세우고 모델은 옆으로 펼쳐지는 상자에 숨겨 두어 모델 하나를 고르는 데 한 단계가 더 들었지만, 이제 Shell이 첫 행에 서고 그 아래로 공급자 밴드가 같은 메뉴에 이어지며 추론 강도만 옆으로 한 단 남습니다.
+- Right-clicking the canvas or an empty sidebar row now opens the model list itself. The launch menu used to list launch kinds first and hide the models behind a side flyout, so picking a model took one hover more than it needed; now Shell sits on the first row and the provider bands follow it in the same menu, with reasoning effort still one step to the side. The menu keeps one name wherever it opens, so its heading no longer changes with the surface it was opened from.
+  ko: 캔버스나 사이드바 빈 자리를 우클릭하면 모델 목록이 곧바로 열립니다. 실행 메뉴가 실행 종류를 먼저 세우고 모델은 옆으로 펼쳐지는 상자에 숨겨 두어 모델 하나를 고르는 데 한 단계가 더 들었지만, 이제 Shell이 첫 행에 서고 그 아래로 공급자 밴드가 같은 메뉴에 이어지며 추론 강도만 옆으로 한 단 남습니다. 상자 이름은 어디서 열든 하나라, 머리글이 여는 자리에 따라 달라지지 않습니다.

--- a/.changelog.d/canvas-menu-flatten.md
+++ b/.changelog.d/canvas-menu-flatten.md
@@ -1,0 +1,8 @@
+---
+branch: canvas-menu-flatten
+---
+
+### fleet-console
+#### Changed
+- Right-clicking the canvas or an empty sidebar row now opens the model list itself. The launch menu used to list launch kinds first and hide the models behind a side flyout, so picking a model took one hover more than it needed; now Shell sits on the first row and the provider bands follow it in the same menu, with reasoning effort still one step to the side.
+  ko: 캔버스나 사이드바 빈 자리를 우클릭하면 모델 목록이 곧바로 열립니다. 실행 메뉴가 실행 종류를 먼저 세우고 모델은 옆으로 펼쳐지는 상자에 숨겨 두어 모델 하나를 고르는 데 한 단계가 더 들었지만, 이제 Shell이 첫 행에 서고 그 아래로 공급자 밴드가 같은 메뉴에 이어지며 추론 강도만 옆으로 한 단 남습니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
-import type { OperationCatalogPlugin, OperationLaunchKind } from "@fleet-console/sdk/operations";
+import type { OperationCatalogPlugin, OperationLaunchKind, OperationLaunchVariantRow } from "@fleet-console/sdk/operations";
 
 import { FEATURE_TOUR_BOUNDARY_ATTRIBUTE, FEATURE_TOUR_LAYER_SELECTOR } from "../feature-tour-catalog.js";
 import { getGlobalSettingsStoreState, setGlobalSettingsField, useGlobalSettingsStore } from "../global-settings-store.js";
@@ -32,15 +32,10 @@ interface CanvasContextMenuProps {
 // .operation-launch-control--canvas .operation-launch-menu의 min-width. 하나만 고치면 컴파일은
 // 되고 치수만 조용히 어긋난다.
 const MENU_WIDTH = 288;
-// 변형 목록은 모델 이름만 담는다 — 실행 강도는 자기 서브메뉴로 빠졌다. 이름의 실측 최대 폭
-// (약 181px)에 여유만 얹는다: 더 넓히면 라벨 오른쪽이 통째로 빈 상자가 되고, 부모 메뉴(288px)보다
-// 넓어져 캐스케이드의 시각적 위계가 뒤집힌다.
-const FLYOUT_WIDTH = 216;
 const FLYOUT_GAP = 10;
 // 트랙과 그 값 라벨이 나란히 들어가는 폭이다.
 const EFFORT_SUBMENU_WIDTH = 216;
-// 두 폭은 components.css의 같은 선언과 짝이다. 계약 시험이 그 짝을 지킨다.
-export const OPERATION_LAUNCH_FLYOUT_WIDTH = FLYOUT_WIDTH;
+// components.css의 같은 선언과 짝이다. 계약 시험이 그 짝을 지킨다.
 export const OPERATION_LAUNCH_EFFORT_MENU_WIDTH = EFFORT_SUBMENU_WIDTH;
 const FLYOUT_CLOSE_GRACE_MS = 160;
 const MENU_MAX_HEIGHT = 520;
@@ -51,6 +46,8 @@ const EFFORT_POPUP_ID = "operation-launch-effort-track";
 // 설명 어사이드는 메뉴 옆에 뜬다. 오른쪽에 자리가 없으면 왼쪽으로 뒤집는다.
 const ASIDE_WIDTH = 208;
 const ASIDE_GAP = 8;
+// 방향키가 훑는 항목. 실행 종류 행과 모델 행은 이제 같은 목록의 형제라 한 집합으로 돈다.
+const MENU_ITEM_SELECTOR = ".canvas-context-menu-item, .operation-launch-variant-row";
 
 export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor", fixed = false, catalog, canLaunch, renderKindIcon, onLaunchKind, onClose, theaterLabel }: CanvasContextMenuProps) {
   const t = useT();
@@ -66,16 +63,6 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   const [hoverKey, setHoverKey] = useState<string | null>(null);
   const [focusKey, setFocusKey] = useState<string | null>(null);
   const activeKey = hoverKey ?? focusKey;
-  const [openFlyout, setOpenFlyout] = useState<string | null>(null);
-  const [flyoutPosition, setFlyoutPosition] = useState<{
-    readonly id: string;
-    readonly left: number;
-    readonly top: number;
-    readonly opensLeft: boolean;
-  } | null>(null);
-  const flyoutAnchorRefs = useRef(new Map<string, HTMLDivElement>());
-  const flyoutRef = useRef<HTMLDivElement | null>(null);
-  const flyoutCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [openEffortRow, setOpenEffortRow] = useState<string | null>(null);
   // 행마다 고른 강도. 트랙은 값만 정하고 실행은 모델 행이 일으키므로, 그 사이를 이 상태가 잇는다.
   const [rowEfforts, setRowEfforts] = useState<Readonly<Record<string, string | null>>>({});
@@ -97,11 +84,6 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     && openEffortValue !== null
     && !effortConfirmTipSeen;
 
-  const cancelFlyoutClose = () => {
-    if (flyoutCloseTimerRef.current === null) return;
-    clearTimeout(flyoutCloseTimerRef.current);
-    flyoutCloseTimerRef.current = null;
-  };
   const cancelEffortClose = () => {
     if (effortCloseTimerRef.current === null) return;
     clearTimeout(effortCloseTimerRef.current);
@@ -112,16 +94,9 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     setOpenEffortRow(null);
     setEffortPosition(null);
   };
-  const closeFlyout = () => {
-    cancelFlyoutClose();
-    closeEffortMenu();
-    setOpenFlyout(null);
-    setFlyoutPosition(null);
-  };
-  const openLaunchFlyout = (flyoutId: string) => {
-    cancelFlyoutClose();
-    closeEffortMenu();
-    const item = flyoutAnchorRefs.current.get(flyoutId);
+  const openEffortMenu = (rowId: string) => {
+    cancelEffortClose();
+    const item = effortAnchorRefs.current.get(rowId);
     const container = containerRef.current;
     if (!item || !container) return;
     const placement = placeCascade({
@@ -129,55 +104,23 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
       boxLeft: containerLeft(container),
       boxWidth: menuSize?.width ?? MENU_WIDTH,
       top: itemTop(item, container),
-      width: FLYOUT_WIDTH,
-      boundsWidth: viewportBounds?.width,
-      preferLeft: false,
-    });
-    setFlyoutPosition({ id: flyoutId, ...placement });
-    setOpenFlyout(flyoutId);
-  };
-  const openEffortMenu = (rowId: string) => {
-    cancelEffortClose();
-    cancelFlyoutClose();
-    const item = effortAnchorRefs.current.get(rowId);
-    const container = containerRef.current;
-    if (!item || !container) return;
-    const placement = placeCascade({
-      // flyout이 이미 확정한 좌표가 진실의 원천이다 — 그 상자는 그 자리에 fixed로 그려진다.
-      boxLeft: flyoutPosition?.left ?? containerLeft(container),
-      boxWidth: flyoutPosition ? FLYOUT_WIDTH : (menuSize?.width ?? MENU_WIDTH),
-      top: itemTop(item, container),
       width: EFFORT_SUBMENU_WIDTH,
       boundsWidth: viewportBounds?.width,
-      // Continue the parent flyout's direction so the cascade keeps reading one way.
-      preferLeft: flyoutPosition?.opensLeft === true,
+      preferLeft: false,
     });
     setEffortPosition({ id: rowId, ...placement });
     setOpenEffortRow(rowId);
   };
   const scheduleEffortClose = () => {
     cancelEffortClose();
+    // Cascade leave must wait for the grace window: closing the effort menu
+    // immediately would drop it before the pointer can reach the nested submenu.
     effortCloseTimerRef.current = setTimeout(() => {
       effortCloseTimerRef.current = null;
       setOpenEffortRow(null);
       setEffortPosition(null);
     }, FLYOUT_CLOSE_GRACE_MS);
   };
-  const scheduleFlyoutClose = () => {
-    cancelFlyoutClose();
-    // Cascade leave must wait for the grace window: closing the effort menu
-    // immediately would drop it before the pointer can reach the nested submenu.
-    flyoutCloseTimerRef.current = setTimeout(() => {
-      flyoutCloseTimerRef.current = null;
-      closeEffortMenu();
-      setOpenFlyout(null);
-      setFlyoutPosition(null);
-      setHoverKey(null);
-    }, FLYOUT_CLOSE_GRACE_MS);
-  };
-  const flyoutTarget = openFlyout === null
-    ? null
-    : findLaunchFlyout(catalog, openFlyout);
 
   // 배치 판정은 CSS의 max-height 상한이 아니라 실제 렌더 높이로 해야 한다 —
   // 상한(520px)으로 clamp하면 짧은 메뉴가 커서에서 수백 px 떨어진 곳에 열린다.
@@ -198,28 +141,8 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     return () => observer.disconnect();
   }, []);
 
-  useLayoutEffect(() => {
-    const element = flyoutRef.current;
-    const container = containerRef.current;
-    if (!element || !container || !viewportBounds || !openFlyout) return;
-    const measure = () => {
-      const height = element.getBoundingClientRect().height;
-      const maxTop = Math.max(MENU_MARGIN, viewportBounds.height - height - MENU_MARGIN);
-      setFlyoutPosition((previous) => {
-        if (!previous || previous.id !== openFlyout) return previous;
-        const nextTop = Math.max(MENU_MARGIN, Math.min(previous.top, maxTop));
-        return Math.abs(nextTop - previous.top) < 0.5 ? previous : { ...previous, top: nextTop };
-      });
-    };
-    measure();
-    if (typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(measure);
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, [openFlyout, viewportBounds]);
-
-  // Effort submenu uses the same measured-height clamp as the parent flyout —
-  // opening near the bottom would otherwise leave lower effort choices off-screen.
+  // Effort submenu uses a measured-height clamp — opening near the bottom would
+  // otherwise leave lower effort choices off-screen.
   useLayoutEffect(() => {
     const element = effortMenuRef.current;
     if (!element || !viewportBounds || !openEffortRow) return;
@@ -271,7 +194,6 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   }, []);
 
   useEffect(() => () => {
-    cancelFlyoutClose();
     cancelEffortClose();
   }, []);
 
@@ -279,19 +201,19 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   // 그 상자는 엉뚱한 행 옆에 붙어 그 행의 강도인 척한다 — 행을 눌러 실행하는 표면에서는
   // 그대로 오실행이 된다. 행이 아직 보이면 따라가고, 시야를 벗어나면 관계가 끊겼으니 닫는다.
   useEffect(() => {
-    const flyout = flyoutRef.current;
-    if (!flyout || openEffortRow === null) return;
+    const menu = menuRef.current;
+    if (!menu || openEffortRow === null) return;
     const follow = () => {
       const anchor = effortAnchorRefs.current.get(openEffortRow)?.getBoundingClientRect();
-      const bounds = flyout.getBoundingClientRect();
+      const bounds = menu.getBoundingClientRect();
       if (!anchor || anchor.bottom <= bounds.top || anchor.top >= bounds.bottom) {
         closeEffortMenu();
         return;
       }
       openEffortMenu(openEffortRow);
     };
-    flyout.addEventListener("scroll", follow, { passive: true });
-    return () => flyout.removeEventListener("scroll", follow);
+    menu.addEventListener("scroll", follow, { passive: true });
+    return () => menu.removeEventListener("scroll", follow);
     // 두 핸들러는 렌더마다 새로 만들어진다 — 여는 행이 바뀔 때만 다시 건다.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [openEffortRow]);
@@ -304,10 +226,30 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   // 어느 Theater로 실행되는지는 접근 이름에 온전히 남는다.
   const headLabel = singlePlugin ? `${headTitle} · ${singlePlugin.title}` : headTitle;
 
+  // 모델 행은 자기 행 키만 들고 다닌다(강도 상자·고른 단이 그 키에 매달린다). 실행은 여전히
+  // 실행 종류가 일으키므로, 키에서 그 종류로 되돌아오는 길을 카탈로그 한 번 훑어 만들어 둔다.
+  const variantRows = useMemo(() => {
+    const index = new Map<string, {
+      readonly pluginId: string;
+      readonly kind: OperationLaunchKind;
+      readonly row: OperationLaunchVariantRow;
+    }>();
+    for (const plugin of catalog) {
+      for (const kind of plugin.kinds.filter(expandsVariants)) {
+        for (const group of kind.variants ?? []) {
+          for (const row of group.rows) {
+            index.set(effortKey(itemKey(plugin.id, kind.id), group.id, row.id), { pluginId: plugin.id, kind, row });
+          }
+        }
+      }
+    }
+    return index;
+  }, [catalog]);
+
   const moveFocus = useCallback((from: HTMLElement | null, delta: number, edge: "first" | "last" | null) => {
     const menu = menuRef.current;
     if (!menu) return;
-    const items = Array.from(menu.querySelectorAll<HTMLButtonElement>(".canvas-context-menu-item")).filter((item) => !item.disabled);
+    const items = Array.from(menu.querySelectorAll<HTMLButtonElement>(MENU_ITEM_SELECTOR)).filter((item) => !item.disabled);
     if (items.length === 0) return;
     if (edge) {
       items[edge === "first" ? 0 : items.length - 1]!.focus();
@@ -320,7 +262,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
 
   const handleMenuKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
     const target = event.target as HTMLElement;
-    const onItem = target.classList.contains("canvas-context-menu-item");
+    const onItem = target.matches?.(MENU_ITEM_SELECTOR) === true;
     switch (event.key) {
       case "ArrowDown":
         event.preventDefault();
@@ -338,34 +280,26 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
         event.preventDefault();
         moveFocus(null, 0, "last");
         return;
+      case "ArrowRight": {
+        // 모델 행에서만 오른쪽이 열 것을 가진다 — 그 행의 강도 트랙이다.
+        const entry = target.closest<HTMLElement>(".operation-launch-variant-entry");
+        const rowKey = entry?.dataset.launchEffortKey;
+        if (!rowKey) return;
+        const row = variantRows.get(rowKey)?.row;
+        if (!row || (row.chips?.length ?? 0) === 0) return;
+        event.preventDefault();
+        openEffortMenu(rowKey);
+        requestAnimationFrame(() => {
+          effortMenuRef.current?.querySelector<HTMLElement>(".effort-track")?.focus();
+        });
+        return;
+      }
       default:
     }
   };
 
-  const moveMenuFocus = (
-    root: HTMLElement | null,
-    selector: string,
-    from: HTMLElement | null,
-    delta: number,
-    edge: "first" | "last" | null,
-  ) => {
-    if (!root) return;
-    const items = Array.from(root.querySelectorAll<HTMLButtonElement>(selector)).filter((item) => !item.disabled);
-    if (items.length === 0) return;
-    if (edge) {
-      items[edge === "first" ? 0 : items.length - 1]!.focus();
-      return;
-    }
-    const index = from ? items.indexOf(from as HTMLButtonElement) : -1;
-    const next = index < 0 ? (delta > 0 ? 0 : items.length - 1) : (index + delta + items.length) % items.length;
-    items[next]!.focus();
-  };
-  const moveFlyoutFocus = (from: HTMLElement | null, delta: number, edge: "first" | "last" | null) => {
-    moveMenuFocus(flyoutRef.current, ".operation-launch-variant-row", from, delta, edge);
-  };
-  const effortTarget = openEffortRow === null || flyoutTarget === null
-    ? null
-    : findEffortRow(flyoutTarget.kind, openFlyout, openEffortRow);
+  const effortTarget = openEffortRow === null ? null : variantRows.get(openEffortRow) ?? null;
+  const effortTargetRow = effortTarget && (effortTarget.row.chips?.length ?? 0) > 0 ? effortTarget.row : null;
 
   const activeDescription = useMemo(() => {
     if (!activeKey) return null;
@@ -380,9 +314,14 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     return null;
   }, [activeKey, catalog, t]);
 
-  const asideSide = activeDescription && flyoutTarget === null
-    ? asidePlacement(anchor, viewportBounds, menuSize)
-    : null;
+  const asideSide = activeDescription ? asidePlacement(anchor, viewportBounds, menuSize) : null;
+
+  // 실행 종류가 모델 밴드를 여럿 펼치면 어느 밴드가 어느 종류의 것인지 캡션만으로는 갈리지 않는다.
+  // 플러그인 라벨과 같은 규칙이다 — 하나뿐이면 세우지 않는다.
+  const variantKindCount = catalog.reduce(
+    (total, plugin) => total + plugin.kinds.filter(expandsVariants).length,
+    0,
+  );
 
   return (
     <div
@@ -424,84 +363,180 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
           </span>
           <p className="canvas-context-menu-section">{t("canvas.menu.launch")}</p>
         </div>
-        {catalog.length > 0 ? catalog.map((plugin, index) => (
-          <div key={plugin.id} role="group" aria-label={plugin.title}>
-            {index > 0 ? <div className="theater-menu-divider" role="separator" /> : null}
-            {singlePlugin ? null : <p className="canvas-context-menu-plugin">{plugin.title}</p>}
-            {plugin.kinds.map((kind) => {
-              const disabled = kind.disabled === true || !canLaunch;
-              const annotation = resolveLaunchKindAnnotation(kind.id);
-              const flyoutId = itemKey(plugin.id, kind.id);
-              const hasVariants = !disabled && (kind.variants?.length ?? 0) > 0;
-              const flyoutOpen = hasVariants && openFlyout === flyoutId;
-              const activateDescription = () => {
-                setHoverKey(flyoutId);
-                if (!hasVariants) closeFlyout();
-              };
-              const activateFocus = () => {
-                setFocusKey(flyoutId);
-                if (!hasVariants) closeFlyout();
-              };
-              return (
-                <div
-                  key={flyoutId}
-                  className="operation-launch-menu-item-wrap"
-                  ref={(element) => {
-                    if (element) flyoutAnchorRefs.current.set(flyoutId, element);
-                    else flyoutAnchorRefs.current.delete(flyoutId);
-                  }}
-                  onPointerEnter={() => { if (hasVariants) openLaunchFlyout(flyoutId); }}
-                  onPointerLeave={() => { if (hasVariants) scheduleFlyoutClose(); }}
-                  onFocus={() => { if (hasVariants) openLaunchFlyout(flyoutId); }}
-                  onBlur={(event) => {
-                    if (!event.currentTarget.contains(event.relatedTarget)) scheduleFlyoutClose();
-                  }}
-                >
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className={`theater-menu-item canvas-context-menu-item operation-launch-menu-item${annotation ? " operation-launch-menu-item--annotated" : ""}${hasVariants ? " operation-launch-menu-item--variants" : ""}`}
-                    // 실행 종류의 안정 식별자. 기능 투어처럼 특정 항목을 짚어야 하는 바깥 선택자가
-                    // 번역 가능한 title/label 문자열 대신 이 속성에 걸리도록 한다.
-                    data-operation-launch-kind={kind.id}
-                    disabled={disabled}
-                    title={kind.disabledReason}
-                    tabIndex={-1}
-                    {...(hasVariants ? { "aria-haspopup": "menu" as const, "aria-expanded": flyoutOpen } : {})}
-                    onMouseEnter={activateDescription}
-                    onFocus={activateFocus}
-                    onKeyDown={(event) => {
-                      if (event.key !== "ArrowRight" || !hasVariants) return;
-                      event.preventDefault();
-                      openLaunchFlyout(flyoutId);
-                      requestAnimationFrame(() => {
-                        containerRef.current?.querySelector<HTMLButtonElement>("[data-launch-variant-row]")?.focus();
-                      });
-                    }}
-                    onClick={() => onLaunchKind(plugin.id, kind)}
-                  >
-                    <span className="theater-menu-check" aria-hidden="true">{renderKindIcon(plugin.id, kind) ?? <FallbackGlyph />}</span>
-                    <span className="theater-menu-label">{kind.title}</span>
-                    {/* 비활성 사유가 있으면 그것이 먼저다 — 지금 실행할 수 없다는 사실이 종류 설명보다 급하다. */}
-                    {kind.disabledReason
-                      ? <span className="operation-launch-menu-reason">{kind.disabledReason}</span>
-                      : annotation
-                        ? (
-                          <>
-                            <span className="operation-launch-menu-brief">{t(annotation.briefKey)}</span>
-                            {/* 설명 문장은 버튼 안에 남아 접근 이름에 실린다 — 시각적으로만 접고,
-                                variant가 없는 행에서만 같은 문자열을 옆 어사이드가 비춘다. */}
-                            <span className="operation-launch-menu-description operation-launch-menu-description--quiet">{t(annotation.descriptionKey)}</span>
-                          </>
-                        )
-                        : null}
-                    {hasVariants ? <span className="operation-launch-menu-chevron" aria-hidden="true">›</span> : null}
-                  </button>
-                </div>
-              );
-            })}
-          </div>
-        )) : <p className="theater-menu-empty">{t("canvas.menu.empty")}</p>}
+        {catalog.length > 0 ? catalog.map((plugin, index) => {
+          // 모델 밴드를 펼치는 실행 종류와 바로 실행되는 종류를 갈라 세운다. 바로 실행되는 쪽이
+          // 위다 — 캡션 아래에 놓인 무캡션 행은 그 밴드의 일원으로 읽힌다.
+          const directKinds = plugin.kinds.filter((kind) => !expandsVariants(kind));
+          const variantKinds = plugin.kinds.filter(expandsVariants);
+          return (
+            <div key={plugin.id} role="group" aria-label={plugin.title}>
+              {index > 0 ? <div className="theater-menu-divider" role="separator" /> : null}
+              {singlePlugin ? null : <p className="canvas-context-menu-plugin">{plugin.title}</p>}
+              {directKinds.map((kind) => {
+                const disabled = kind.disabled === true || !canLaunch;
+                const annotation = resolveLaunchKindAnnotation(kind.id);
+                const rowKey = itemKey(plugin.id, kind.id);
+                return (
+                  <div key={rowKey} className="operation-launch-menu-item-wrap">
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className={`theater-menu-item canvas-context-menu-item operation-launch-menu-item${annotation ? " operation-launch-menu-item--annotated" : ""}`}
+                      // 실행 종류의 안정 식별자. 기능 투어처럼 특정 항목을 짚어야 하는 바깥 선택자가
+                      // 번역 가능한 title/label 문자열 대신 이 속성에 걸리도록 한다.
+                      data-operation-launch-kind={kind.id}
+                      disabled={disabled}
+                      title={kind.disabledReason}
+                      tabIndex={-1}
+                      onMouseEnter={() => setHoverKey(rowKey)}
+                      onFocus={() => setFocusKey(rowKey)}
+                      onClick={() => onLaunchKind(plugin.id, kind)}
+                    >
+                      <span className="theater-menu-check" aria-hidden="true">{renderKindIcon(plugin.id, kind) ?? <FallbackGlyph />}</span>
+                      <span className="theater-menu-label">{kind.title}</span>
+                      {/* 비활성 사유가 있으면 그것이 먼저다 — 지금 실행할 수 없다는 사실이 종류 설명보다 급하다. */}
+                      {kind.disabledReason
+                        ? <span className="operation-launch-menu-reason">{kind.disabledReason}</span>
+                        : annotation
+                          ? (
+                            <>
+                              <span className="operation-launch-menu-brief">{t(annotation.briefKey)}</span>
+                              {/* 설명 문장은 버튼 안에 남아 접근 이름에 실린다 — 시각적으로만 접고,
+                                  같은 문자열을 옆 어사이드가 비춘다. */}
+                              <span className="operation-launch-menu-description operation-launch-menu-description--quiet">{t(annotation.descriptionKey)}</span>
+                            </>
+                          )
+                          : null}
+                    </button>
+                  </div>
+                );
+              })}
+              {variantKinds.map((kind, kindIndex) => {
+                const kindKey = itemKey(plugin.id, kind.id);
+                return (
+                  <div key={kindKey} role="group" aria-label={kind.title}>
+                    {variantKindCount > 1 ? <p className="canvas-context-menu-plugin">{kind.title}</p> : null}
+                    {kind.variants!.map((group, groupIndex) => (
+                      <div key={group.id} className="operation-launch-variant-group">
+                        {directKinds.length > 0 || kindIndex > 0 || groupIndex > 0
+                          ? <div className="theater-menu-divider" role="separator" />
+                          : null}
+                        {(() => {
+                          const provider = launchProviderFromGroupId(group.id);
+                          const caption = group.id === "native"
+                            ? t("launchVariants.group.native")
+                            : group.id === "gateway"
+                              ? t("launchVariants.group.gateway")
+                              : group.label;
+                          return (
+                            <p className={`operation-launch-variant-caption${provider ? ` is-${provider}` : ""}`}>
+                              {provider ? (
+                                <span className="operation-launch-provider-glyph" aria-hidden="true">
+                                  {launchProviderGlyph(provider)}
+                                </span>
+                              ) : null}
+                              <span>{caption}</span>
+                            </p>
+                          );
+                        })()}
+                        {group.rows.map((row) => {
+                          const rowHasEffort = (row.chips?.length ?? 0) > 0;
+                          // 행 id는 그 그룹 안에서만 고유하다 — 실행 종류 설명을 itemKey로 잡는 것과 같은 이유로,
+                          // 고른 강도도 종류·그룹까지 묶어야 같은 id를 쓰는 다른 행에 조용히 새지 않는다.
+                          const rowKey = effortKey(kindKey, group.id, row.id);
+                          const effortOpen = rowHasEffort && openEffortRow === rowKey;
+                          // 트랙으로 단을 고르고, 행을 누르거나 같은 단을 다시 확정하면 그 강도를 싣고 실행한다.
+                          const chosenEffort = rowEfforts[rowKey] ?? null;
+                          const chosenChip = chosenEffort === null
+                            ? undefined
+                            : row.chips?.find((chip) => chip.id === chosenEffort);
+                          return (
+                            <div
+                              key={row.id}
+                              className="operation-launch-variant-entry"
+                              data-launch-effort-key={rowKey}
+                              ref={(element) => {
+                                if (element) effortAnchorRefs.current.set(rowKey, element);
+                                else effortAnchorRefs.current.delete(rowKey);
+                              }}
+                              // 행 본문은 강도를 열지 않는다 — 여는 것은 오른쪽 손잡이뿐이다. 다른 행으로
+                              // 넘어온 포인터는 유예를 두고 닫는다: 즉시 닫으면 손잡이에서 서브메뉴로
+                              // 비스듬히 가는 경로가 아래 행을 스칠 때 상자가 먼저 사라진다.
+                              onPointerEnter={scheduleEffortClose}
+                              onPointerLeave={() => {
+                                if (rowHasEffort) scheduleEffortClose();
+                              }}
+                              onFocus={() => {
+                                // 키보드로 다른 행에 닿으면 앞 행의 상자는 닫는다. 이 행의 상자를 여는 것은
+                                // ArrowRight이지 포커스가 아니다.
+                                if (openEffortRow !== null && openEffortRow !== rowKey) closeEffortMenu();
+                              }}
+                              onBlur={(event) => {
+                                if (!event.currentTarget.contains(event.relatedTarget as Node | null)
+                                  && !effortMenuRef.current?.contains(event.relatedTarget as Node | null)) {
+                                  scheduleEffortClose();
+                                }
+                              }}
+                            >
+                              <button
+                                type="button"
+                                role="menuitem"
+                                className={`operation-launch-variant-row${rowHasEffort ? " operation-launch-variant-row--effort" : ""}`}
+                                // 모델 행도 결국 이 실행 종류를 띄운다 — 종류를 짚는 바깥 선택자(기능 투어)가
+                                // 밴드로 펼쳐진 뒤에도 같은 속성으로 닿는다.
+                                data-operation-launch-kind={kind.id}
+                                data-launch-variant-row={row.id}
+                                disabled={!canLaunch}
+                                tabIndex={-1}
+                                // 펼쳐지는 것이 메뉴가 아니므로 haspopup=menu로 예고하지 않는다 — 무엇이
+                                // 열렸는지는 aria-controls가 가리킨다.
+                                aria-expanded={rowHasEffort ? effortOpen : undefined}
+                                aria-controls={effortOpen ? EFFORT_POPUP_ID : undefined}
+                                onClick={() => onLaunchKind(plugin.id, kind, chosenChip?.launch ?? row.launch)}
+                              >
+                                <span className="operation-launch-variant-row-label">{row.label}</span>
+                                {row.starred ? <span className="operation-launch-variant-star" aria-hidden="true">★</span> : null}
+                                {/* 강도 손잡이. 지금 실린 강도를 되비치는 표식이면서, 트랙을 여는 자리이기도 하다 —
+                                    트랙이 닫힌 뒤에도 이 행을 누르면 무엇으로 실행되는지 여기서 읽힌다.
+                                    버튼 안의 span이므로 초점 대상이 아니다: 키보드 경로는 지금처럼 행 버튼의
+                                    ArrowRight이고, 그 행이 aria-expanded·aria-controls로 상자를 예고한다. */}
+                                {rowHasEffort ? (
+                                  <span
+                                    className="operation-launch-variant-effort-handle"
+                                    data-launch-effort-handle={rowKey}
+                                    data-effort-level={chosenEffort ?? "auto"}
+                                    data-open={effortOpen ? "true" : undefined}
+                                    title={t("launchVariants.effort.track")}
+                                    onPointerEnter={() => openEffortMenu(rowKey)}
+                                    onPointerLeave={scheduleEffortClose}
+                                    onClick={(event) => {
+                                      // 손잡이는 실행이 아니라 강도를 연다. 행 버튼까지 함께 발화하면 강도를
+                                      // 고르려던 클릭이 그대로 출격이 된다.
+                                      event.preventDefault();
+                                      event.stopPropagation();
+                                      if (effortOpen) closeEffortMenu();
+                                      else openEffortMenu(rowKey);
+                                    }}
+                                  >
+                                    <EffortGaugeGlyph {...effortLadderPosition(row, chosenEffort)} />
+                                    <span className="operation-launch-variant-effort">
+                                      {chosenChip?.label ?? t("launchVariants.effort.auto")}
+                                    </span>
+                                    <span className="operation-launch-variant-chevron" aria-hidden="true">›</span>
+                                  </span>
+                                ) : null}
+                              </button>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    ))}
+                  </div>
+                );
+              })}
+            </div>
+          );
+        }) : <p className="theater-menu-empty">{t("canvas.menu.empty")}</p>}
       </div>
       {activeDescription && asideSide
         ? (
@@ -513,177 +548,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
           </p>
         )
         : null}
-      {flyoutTarget && flyoutPosition?.id === openFlyout ? (
-        <div
-          className={`operation-launch-flyout theater-menu${flyoutPosition.opensLeft ? " is-left" : ""}`}
-          role="menu"
-          ref={flyoutRef}
-          style={{ position: "fixed", left: flyoutPosition.left, right: "auto", top: flyoutPosition.top }}
-          onPointerEnter={cancelFlyoutClose}
-          onPointerLeave={scheduleFlyoutClose}
-          onFocus={cancelFlyoutClose}
-          onBlur={(event) => {
-            if (!containerRef.current?.contains(event.relatedTarget)) scheduleFlyoutClose();
-          }}
-          onKeyDown={(event) => {
-            const target = event.target as HTMLElement;
-            switch (event.key) {
-              case "ArrowDown":
-                event.preventDefault();
-                moveFlyoutFocus(target, 1, null);
-                return;
-              case "ArrowUp":
-                event.preventDefault();
-                moveFlyoutFocus(target, -1, null);
-                return;
-              case "Home":
-                event.preventDefault();
-                moveFlyoutFocus(null, 0, "first");
-                return;
-              case "End":
-                event.preventDefault();
-                moveFlyoutFocus(null, 0, "last");
-                return;
-              case "ArrowRight": {
-                const entry = target.closest<HTMLElement>(".operation-launch-variant-entry");
-                const rowKey = entry?.dataset.launchEffortKey;
-                if (!rowKey) return;
-                const row = findEffortRow(flyoutTarget.kind, openFlyout, rowKey);
-                if (!row || (row.chips?.length ?? 0) === 0) return;
-                event.preventDefault();
-                openEffortMenu(rowKey);
-                requestAnimationFrame(() => {
-                  effortMenuRef.current?.querySelector<HTMLElement>(".effort-track")?.focus();
-                });
-                return;
-              }
-              case "ArrowLeft":
-              case "Escape":
-                event.preventDefault();
-                event.stopPropagation();
-                if (openEffortRow !== null) {
-                  effortAnchorRefs.current.get(openEffortRow)?.querySelector<HTMLButtonElement>("[data-launch-variant-row]")?.focus();
-                  closeEffortMenu();
-                  return;
-                }
-                flyoutAnchorRefs.current.get(openFlyout!)?.querySelector<HTMLButtonElement>("[data-operation-launch-kind]")?.focus();
-                closeFlyout();
-                return;
-              default:
-            }
-          }}
-        >
-          {flyoutTarget.kind.variants!.map((group, groupIndex) => (
-            <div key={group.id} className="operation-launch-variant-group">
-              {groupIndex > 0 ? <div className="theater-menu-divider" role="separator" /> : null}
-              {(() => {
-                const provider = launchProviderFromGroupId(group.id);
-                const caption = group.id === "native"
-                  ? t("launchVariants.group.native")
-                  : group.id === "gateway"
-                    ? t("launchVariants.group.gateway")
-                    : group.label;
-                return (
-                  <p className={`operation-launch-variant-caption${provider ? ` is-${provider}` : ""}`}>
-                    {provider ? (
-                      <span className="operation-launch-provider-glyph" aria-hidden="true">
-                        {launchProviderGlyph(provider)}
-                      </span>
-                    ) : null}
-                    <span>{caption}</span>
-                  </p>
-                );
-              })()}
-              {group.rows.map((row) => {
-                const hasEffort = (row.chips?.length ?? 0) > 0;
-                // 행 id는 그 그룹 안에서만 고유하다 — 실행 종류 설명을 itemKey로 잡는 것과 같은 이유로,
-                // 고른 강도도 종류·그룹까지 묶어야 같은 id를 쓰는 다른 행에 조용히 새지 않는다.
-                const rowKey = effortKey(openFlyout, group.id, row.id);
-                const effortOpen = hasEffort && openEffortRow === rowKey;
-                // 트랙으로 단을 고르고, 행을 누르거나 같은 단을 다시 확정하면 그 강도를 싣고 실행한다.
-                const chosenEffort = rowEfforts[rowKey] ?? null;
-                const chosenChip = chosenEffort === null
-                  ? undefined
-                  : row.chips?.find((chip) => chip.id === chosenEffort);
-                return (
-                  <div
-                    key={row.id}
-                    className="operation-launch-variant-entry"
-                    data-launch-effort-key={rowKey}
-                    ref={(element) => {
-                      if (element) effortAnchorRefs.current.set(rowKey, element);
-                      else effortAnchorRefs.current.delete(rowKey);
-                    }}
-                    // 행 본문은 강도를 열지 않는다 — 여는 것은 오른쪽 손잡이뿐이다. 다른 행으로
-                    // 넘어온 포인터는 유예를 두고 닫는다: 즉시 닫으면 손잡이에서 서브메뉴로
-                    // 비스듬히 가는 경로가 아래 행을 스칠 때 상자가 먼저 사라진다.
-                    onPointerEnter={scheduleEffortClose}
-                    onPointerLeave={() => {
-                      if (hasEffort) scheduleEffortClose();
-                    }}
-                    onFocus={() => {
-                      // 키보드로 다른 행에 닿으면 앞 행의 상자는 닫는다. 이 행의 상자를 여는 것은
-                      // ArrowRight이지 포커스가 아니다.
-                      if (openEffortRow !== null && openEffortRow !== rowKey) closeEffortMenu();
-                    }}
-                    onBlur={(event) => {
-                      if (!event.currentTarget.contains(event.relatedTarget as Node | null)
-                        && !effortMenuRef.current?.contains(event.relatedTarget as Node | null)) {
-                        scheduleEffortClose();
-                      }
-                    }}
-                  >
-                    <button
-                      type="button"
-                      role="menuitem"
-                      className={`operation-launch-variant-row${hasEffort ? " operation-launch-variant-row--effort" : ""}`}
-                      data-launch-variant-row={row.id}
-                      // 펼쳐지는 것이 메뉴가 아니므로 haspopup=menu로 예고하지 않는다 — 무엇이
-                      // 열렸는지는 aria-controls가 가리킨다.
-                      aria-expanded={hasEffort ? effortOpen : undefined}
-                      aria-controls={effortOpen ? EFFORT_POPUP_ID : undefined}
-                      onClick={() => onLaunchKind(flyoutTarget.pluginId, flyoutTarget.kind, chosenChip?.launch ?? row.launch)}
-                    >
-                      <span className="operation-launch-variant-row-label">{row.label}</span>
-                      {row.starred ? <span className="operation-launch-variant-star" aria-hidden="true">★</span> : null}
-                      {/* 강도 손잡이. 지금 실린 강도를 되비치는 표식이면서, 트랙을 여는 자리이기도 하다 —
-                          트랙이 닫힌 뒤에도 이 행을 누르면 무엇으로 실행되는지 여기서 읽힌다.
-                          버튼 안의 span이므로 초점 대상이 아니다: 키보드 경로는 지금처럼 행 버튼의
-                          ArrowRight이고, 그 행이 aria-expanded·aria-controls로 상자를 예고한다. */}
-                      {hasEffort ? (
-                        <span
-                          className="operation-launch-variant-effort-handle"
-                          data-launch-effort-handle={rowKey}
-                          data-effort-level={chosenEffort ?? "auto"}
-                          data-open={effortOpen ? "true" : undefined}
-                          title={t("launchVariants.effort.track")}
-                          onPointerEnter={() => openEffortMenu(rowKey)}
-                          onPointerLeave={scheduleEffortClose}
-                          onClick={(event) => {
-                            // 손잡이는 실행이 아니라 강도를 연다. 행 버튼까지 함께 발화하면 강도를
-                            // 고르려던 클릭이 그대로 출격이 된다.
-                            event.preventDefault();
-                            event.stopPropagation();
-                            if (effortOpen) closeEffortMenu();
-                            else openEffortMenu(rowKey);
-                          }}
-                        >
-                          <EffortGaugeGlyph {...effortLadderPosition(row, chosenEffort)} />
-                          <span className="operation-launch-variant-effort">
-                            {chosenChip?.label ?? t("launchVariants.effort.auto")}
-                          </span>
-                          <span className="operation-launch-variant-chevron" aria-hidden="true">›</span>
-                        </span>
-                      ) : null}
-                    </button>
-                  </div>
-                );
-              })}
-            </div>
-          ))}
-        </div>
-      ) : null}
-      {flyoutTarget && effortTarget && effortPosition?.id === openEffortRow ? (
+      {effortTarget && effortTargetRow && effortPosition?.id === openEffortRow ? (
         <div
           className={`operation-launch-effort-menu theater-menu${effortPosition.opensLeft ? " is-left" : ""}`}
           // 이 상자가 담는 것은 메뉴 항목이 아니라 슬라이더 하나다. menu로 선언하면 보조기술이
@@ -693,15 +558,9 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
           aria-label={t("launchVariants.effort.track")}
           ref={effortMenuRef}
           style={{ position: "fixed", left: effortPosition.left, right: "auto", top: effortPosition.top }}
-          onPointerEnter={() => {
-            cancelEffortClose();
-            cancelFlyoutClose();
-          }}
+          onPointerEnter={cancelEffortClose}
           onPointerLeave={scheduleEffortClose}
-          onFocus={() => {
-            cancelEffortClose();
-            cancelFlyoutClose();
-          }}
+          onFocus={cancelEffortClose}
           onBlur={(event) => {
             if (!containerRef.current?.contains(event.relatedTarget as Node | null)) scheduleEffortClose();
           }}
@@ -715,19 +574,19 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
         >
           <div className="operation-launch-effort-menu-body">
             <EffortTrack
-              row={effortTarget}
-              value={rowEfforts[openEffortRow] ?? null}
-              onChange={(next) => setRowEfforts((previous) => ({ ...previous, [openEffortRow]: next }))}
+              row={effortTargetRow}
+              value={rowEfforts[openEffortRow!] ?? null}
+              onChange={(next) => setRowEfforts((previous) => ({ ...previous, [openEffortRow!]: next }))}
               onConfirmCurrent={() => {
                 // 자동을 다시 누르는 것은 값을 비운 채 머무는 일이다 — 모델만 싣는 실행은 행 본문이 맡는다.
-                const effort = rowEfforts[openEffortRow] ?? null;
+                const effort = rowEfforts[openEffortRow!] ?? null;
                 if (effort === null) return;
-                const chip = effortTarget.chips?.find((entry) => entry.id === effort);
+                const chip = effortTargetRow.chips?.find((entry) => entry.id === effort);
                 if (!chip) return;
                 // 같은 노브를 다시 눌러 실행한 순간에만 팁을 졸업시킨다. 선택·피처 투어 건너뛰기는
                 // 제스처를 익힌 증거가 아니다.
                 if (!effortConfirmTipSeen) void persistEffortConfirmTipSeen();
-                onLaunchKind(flyoutTarget.pluginId, flyoutTarget.kind, chip.launch);
+                onLaunchKind(effortTarget.pluginId, effortTarget.kind, chip.launch);
               }}
               autoLabel={t("launchVariants.effort.auto")}
               ariaLabel={t("launchVariants.effort.track")}
@@ -744,11 +603,6 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     </div>
   );
 }
-
-const GAUGE_BAR_WIDTH = 1.5;
-const GAUGE_BAR_PITCH = 2.5;
-const GAUGE_HEIGHT = 8;
-const GAUGE_MIN_BAR = 2;
 
 // 시청 기록 PUT은 전역 저장 슬롯 하나뿐이라, 피처 투어 완료 저장과 겹치면 뒤쪽 호출이 거절된다.
 // 잠깐 양보한 뒤 최신 seen 목록에 키를 합쳐 다시 쓴다. 실패해도 같은 마운트에서는 상한까지만
@@ -771,6 +625,11 @@ async function persistEffortConfirmTipSeen(): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 40));
   }
 }
+
+const GAUGE_BAR_WIDTH = 1.5;
+const GAUGE_BAR_PITCH = 2.5;
+const GAUGE_HEIGHT = 8;
+const GAUGE_MIN_BAR = 2;
 
 /**
  * 강도 사다리를 그대로 줄인 계기 표식. 꺾쇠만으로는 이 손잡이가 무엇을 여는지 말하지 못하므로,
@@ -806,6 +665,12 @@ function EffortGaugeGlyph({ rung, total }: { readonly rung: number; readonly tot
       })}
     </svg>
   );
+}
+
+// 모델 밴드로 펼쳐지는 실행 종류. 비활성 종류는 변형을 들고 있더라도 펼치지 않는다 —
+// 고를 수 없는 모델 목록을 여는 대신, 왜 못 쓰는지 밝히는 한 줄짜리 행으로 남는 편이 정직하다.
+function expandsVariants(kind: OperationLaunchKind): boolean {
+  return kind.disabled !== true && (kind.variants?.length ?? 0) > 0;
 }
 
 // 컨테이너는 자기 좌표를 인라인 스타일로 들고 있다. 캐스케이드의 모든 단이 이 좌표계 위에서
@@ -850,32 +715,11 @@ function placeCascade({ boxLeft, boxWidth, top, width, boundsWidth, preferLeft }
   };
 }
 
-function findLaunchFlyout(catalog: readonly OperationCatalogPlugin[], flyoutId: string): {
-  readonly pluginId: string;
-  readonly kind: OperationLaunchKind;
-} | null {
-  for (const plugin of catalog) {
-    const kind = plugin.kinds.find((candidate) => itemKey(plugin.id, candidate.id) === flyoutId);
-    if (kind?.variants && kind.variants.length > 0) return { pluginId: plugin.id, kind };
-  }
-  return null;
-}
-
 // 행 id는 그 그룹 안에서만 고유하다. 실행 종류 설명을 itemKey로 잡는 것과 같은 이유로, 열린
 // 트랙과 고른 강도도 종류·그룹까지 묶어 둔다. 구분자는 id에 나타나지 않는 제어문자를 쓴다 —
 // 실행 종류 키는 `terminal:claude-gateway`, 그룹 키는 `gateway:codex`라 콜론은 이미 모호하다.
-function effortKey(flyoutId: string | null, groupId: string, rowId: string): string {
-  return `${flyoutId ?? ""}\u001f${groupId}\u001f${rowId}`;
-}
-
-function findEffortRow(kind: OperationLaunchKind, flyoutId: string | null, key: string) {
-  for (const group of kind.variants ?? []) {
-    for (const row of group.rows) {
-      if (effortKey(flyoutId, group.id, row.id) !== key) continue;
-      return (row.chips?.length ?? 0) > 0 ? row : null;
-    }
-  }
-  return null;
+function effortKey(kindKey: string, groupId: string, rowId: string): string {
+  return `${kindKey}\u001f${groupId}\u001f${rowId}`;
 }
 
 // 좌하단 런처 FAB와 메뉴 헤더가 공유하던 '커맨드 레티클' 마크 — 외곽 스코프 링 + 사방 조준 틱 +

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -21,8 +21,6 @@ interface CanvasContextMenuProps {
   readonly renderKindIcon: (pluginId: string, kind: OperationLaunchKind) => ReactNode;
   readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind, variantLaunch?: Readonly<Record<string, string>>) => void;
   readonly onClose: () => void;
-  /** 특정 Theater 소유 영역에서 열렸을 때 메뉴 헤더에 그 소유자를 명시한다. */
-  readonly theaterLabel?: string;
   // true면 anchor를 뷰포트 기준 좌표로 보고 position: fixed로 띄운다 — 선별 처리처럼
   // 월드/스테이지 프레임이 anchor 좌표계를 침범하는 모드에서 쓴다.
   readonly fixed?: boolean;
@@ -49,7 +47,7 @@ const ASIDE_GAP = 8;
 // 방향키가 훑는 항목. 실행 종류 행과 모델 행은 이제 같은 목록의 형제라 한 집합으로 돈다.
 const MENU_ITEM_SELECTOR = ".canvas-context-menu-item, .operation-launch-variant-row";
 
-export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor", fixed = false, catalog, canLaunch, renderKindIcon, onLaunchKind, onClose, theaterLabel }: CanvasContextMenuProps) {
+export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor", fixed = false, catalog, canLaunch, renderKindIcon, onLaunchKind, onClose }: CanvasContextMenuProps) {
   const t = useT();
   const globalSettings = useGlobalSettingsStore();
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -221,9 +219,11 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   // 플러그인이 하나뿐이면 그 이름은 헤더 줄에 붙는다 — 항목 네 개짜리 메뉴에서 이름만 있는
   // 행 하나가 통째로 서는 것은 값을 못 한다. 둘 이상일 때만 그룹 라벨을 세운다.
   const singlePlugin = catalog.length === 1 ? catalog[0]! : null;
-  const headTitle = theaterLabel ? t("canvas.menu.theaterTitle", { theater: theaterLabel }) : t("canvas.menu.title");
+  // 머리글은 어디서 열었든 같은 이름을 쓴다 — 상자 이름에 여는 자리(캔버스)나 소유 Theater를 섞으면
+  // 같은 메뉴가 표면마다 다른 이름으로 불린다.
+  const headTitle = t("canvas.menu.title");
   // 시각 머리글과 메뉴 이름이 같은 문자열이어야 한다 — 좁은 폭에서 머리글이 줄임표로 잘려도
-  // 어느 Theater로 실행되는지는 접근 이름에 온전히 남는다.
+  // 접근 이름에는 온전히 남는다.
   const headLabel = singlePlugin ? `${headTitle} · ${singlePlugin.title}` : headTitle;
 
   // 모델 행은 자기 행 키만 들고 다닌다(강도 상자·고른 단이 그 키에 매달린다). 실행은 여전히
@@ -235,7 +235,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
       readonly row: OperationLaunchVariantRow;
     }>();
     for (const plugin of catalog) {
-      for (const kind of plugin.kinds.filter(expandsVariants)) {
+      for (const kind of plugin.kinds.filter((kind) => expandsVariants(kind, canLaunch))) {
         for (const group of kind.variants ?? []) {
           for (const row of group.rows) {
             index.set(effortKey(itemKey(plugin.id, kind.id), group.id, row.id), { pluginId: plugin.id, kind, row });
@@ -244,7 +244,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
       }
     }
     return index;
-  }, [catalog]);
+  }, [catalog, canLaunch]);
 
   const moveFocus = useCallback((from: HTMLElement | null, delta: number, edge: "first" | "last" | null) => {
     const menu = menuRef.current;
@@ -319,7 +319,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   // 실행 종류가 모델 밴드를 여럿 펼치면 어느 밴드가 어느 종류의 것인지 캡션만으로는 갈리지 않는다.
   // 플러그인 라벨과 같은 규칙이다 — 하나뿐이면 세우지 않는다.
   const variantKindCount = catalog.reduce(
-    (total, plugin) => total + plugin.kinds.filter(expandsVariants).length,
+    (total, plugin) => total + plugin.kinds.filter((kind) => expandsVariants(kind, canLaunch)).length,
     0,
   );
 
@@ -366,8 +366,8 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
         {catalog.length > 0 ? catalog.map((plugin, index) => {
           // 모델 밴드를 펼치는 실행 종류와 바로 실행되는 종류를 갈라 세운다. 바로 실행되는 쪽이
           // 위다 — 캡션 아래에 놓인 무캡션 행은 그 밴드의 일원으로 읽힌다.
-          const directKinds = plugin.kinds.filter((kind) => !expandsVariants(kind));
-          const variantKinds = plugin.kinds.filter(expandsVariants);
+          const directKinds = plugin.kinds.filter((kind) => !expandsVariants(kind, canLaunch));
+          const variantKinds = plugin.kinds.filter((kind) => expandsVariants(kind, canLaunch));
           return (
             <div key={plugin.id} role="group" aria-label={plugin.title}>
               {index > 0 ? <div className="theater-menu-divider" role="separator" /> : null}
@@ -462,11 +462,17 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                               // 행 본문은 강도를 열지 않는다 — 여는 것은 오른쪽 손잡이뿐이다. 다른 행으로
                               // 넘어온 포인터는 유예를 두고 닫는다: 즉시 닫으면 손잡이에서 서브메뉴로
                               // 비스듬히 가는 경로가 아래 행을 스칠 때 상자가 먼저 사라진다.
-                              onPointerEnter={scheduleEffortClose}
+                              onPointerEnter={() => {
+                                // 모델 행에는 설명이 없다 — 앞서 짚던 직접 행의 어사이드를 걷지 않으면
+                                // 짚지도 않은 행의 설명이 목록 옆에 떠 있는 채로 남는다.
+                                setHoverKey(null);
+                                scheduleEffortClose();
+                              }}
                               onPointerLeave={() => {
                                 if (rowHasEffort) scheduleEffortClose();
                               }}
                               onFocus={() => {
+                                setFocusKey(null);
                                 // 키보드로 다른 행에 닿으면 앞 행의 상자는 닫는다. 이 행의 상자를 여는 것은
                                 // ArrowRight이지 포커스가 아니다.
                                 if (openEffortRow !== null && openEffortRow !== rowKey) closeEffortMenu();
@@ -486,7 +492,6 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                                 // 밴드로 펼쳐진 뒤에도 같은 속성으로 닿는다.
                                 data-operation-launch-kind={kind.id}
                                 data-launch-variant-row={row.id}
-                                disabled={!canLaunch}
                                 tabIndex={-1}
                                 // 펼쳐지는 것이 메뉴가 아니므로 haspopup=menu로 예고하지 않는다 — 무엇이
                                 // 열렸는지는 aria-controls가 가리킨다.
@@ -667,10 +672,11 @@ function EffortGaugeGlyph({ rung, total }: { readonly rung: number; readonly tot
   );
 }
 
-// 모델 밴드로 펼쳐지는 실행 종류. 비활성 종류는 변형을 들고 있더라도 펼치지 않는다 —
-// 고를 수 없는 모델 목록을 여는 대신, 왜 못 쓰는지 밝히는 한 줄짜리 행으로 남는 편이 정직하다.
-function expandsVariants(kind: OperationLaunchKind): boolean {
-  return kind.disabled !== true && (kind.variants?.length ?? 0) > 0;
+// 모델 밴드로 펼쳐지는 실행 종류. 지금 실행할 수 없으면 — 그 종류가 비활성이든 Theater가 없어
+// 메뉴 전체가 잠겼든 — 펼치지 않는다. 고를 수 없는 모델 열두 줄을 세우는 대신, 왜 못 쓰는지
+// 밝히는 한 줄짜리 행으로 남는 편이 정직하다.
+function expandsVariants(kind: OperationLaunchKind, canLaunch: boolean): boolean {
+  return canLaunch && kind.disabled !== true && (kind.variants?.length ?? 0) > 0;
 }
 
 // 컨테이너는 자기 좌표를 인라인 스타일로 들고 있다. 캐스케이드의 모든 단이 이 좌표계 위에서

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -462,17 +462,20 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                               // 행 본문은 강도를 열지 않는다 — 여는 것은 오른쪽 손잡이뿐이다. 다른 행으로
                               // 넘어온 포인터는 유예를 두고 닫는다: 즉시 닫으면 손잡이에서 서브메뉴로
                               // 비스듬히 가는 경로가 아래 행을 스칠 때 상자가 먼저 사라진다.
+                              // 짚은 자리를 비우지 않고 이 행의 키로 덮는다. 비우면 두 채널을 합치는
+                              // `hoverKey ?? focusKey`가 앞서 포커스가 짚던 직접 행으로 되돌아가, 포인터가
+                              // 모델 행 위에 있는데 그 행과 무관한 설명이 옆에 남는다. 행 키는 어떤 실행
+                              // 종류 키와도 같아질 수 없으므로 "설명 없는 자리를 짚고 있다"가 된다 —
+                              // 평탄화 전 변형 부모 행을 짚었을 때와 같은 상태다.
                               onPointerEnter={() => {
-                                // 모델 행에는 설명이 없다 — 앞서 짚던 직접 행의 어사이드를 걷지 않으면
-                                // 짚지도 않은 행의 설명이 목록 옆에 떠 있는 채로 남는다.
-                                setHoverKey(null);
+                                setHoverKey(rowKey);
                                 scheduleEffortClose();
                               }}
                               onPointerLeave={() => {
                                 if (rowHasEffort) scheduleEffortClose();
                               }}
                               onFocus={() => {
-                                setFocusKey(null);
+                                setFocusKey(rowKey);
                                 // 키보드로 다른 행에 닿으면 앞 행의 상자는 닫는다. 이 행의 상자를 여는 것은
                                 // ArrowRight이지 포커스가 아니다.
                                 if (openEffortRow !== null && openEffortRow !== rowKey) closeEffortMenu();

--- a/runtime/fleet-console/core/client/src/canvas/canvas.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas.tsx
@@ -51,7 +51,6 @@ interface ContextMenuRequest {
   readonly anchor: CanvasPoint;
   readonly canvasPoint: CanvasPoint;
   readonly theaterId?: string;
-  readonly theaterLabel?: string;
 }
 
 interface PluginOperationRendererProps {
@@ -277,11 +276,7 @@ export function OperationsCanvas({
         setContextMenu(null);
         return;
       }
-      openTriageTheaterLaunchMenu(
-        activeTheaterId,
-        state.theaters.find((theater) => theater.id === activeTheaterId)?.label ?? activeTheaterId,
-        { x: event.clientX, y: event.clientY },
-      );
+      openTriageTheaterLaunchMenu(activeTheaterId, { x: event.clientX, y: event.clientY });
       return;
     }
     if (target?.closest("[data-canvas-blocker]")) return;
@@ -293,7 +288,7 @@ export function OperationsCanvas({
     onRefreshCatalog?.();
   };
 
-  const openTriageTheaterLaunchMenu = (theaterId: string, theaterLabel: string, cursor: CanvasPoint) => {
+  const openTriageTheaterLaunchMenu = (theaterId: string, cursor: CanvasPoint) => {
     const canvasRect = canvasRef.current?.getBoundingClientRect();
     if (!canvasRect) return;
     // 앵커와 클램프 경계는 같은 좌표계여야 한다 — 메뉴는 캔버스 크기로 클램프되므로 앵커도 캔버스-local이다.
@@ -309,7 +304,6 @@ export function OperationsCanvas({
       // 스냅샷의 뷰포트로 환산한다.
       canvasPoint: screenToCanvas(local, getTheaterCanvasSnapshot(theaterId).viewport),
       theaterId,
-      theaterLabel,
     });
     onRefreshCatalog?.();
   };
@@ -1130,7 +1124,6 @@ export function OperationsCanvas({
           renderKindIcon={renderKindIcon}
           onLaunchKind={handleContextMenuLaunchKind}
           onClose={() => setContextMenu(null)}
-          theaterLabel={contextMenu.theaterLabel}
           fixed={triageActive}
         />
       ) : null}

--- a/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/triage-watch-deck.tsx
@@ -77,7 +77,7 @@ interface TriageWatchDeckProps {
   readonly onMapMarkerMove?: (operationId: string, theaterId: string, geometry: OperationGeometry) => void;
   /** Operation 표면의 공용 메뉴와 Theater 소유 빈 영역의 launch 메뉴를 상위 canvas가 호스트한다. */
   readonly onOperationContextMenu?: (operationId: string, anchor: DOMRect, returnFocus?: HTMLElement | null) => void;
-  readonly onTheaterContextMenu?: (theaterId: string, theaterLabel: string, anchor: { readonly x: number; readonly y: number }) => void;
+  readonly onTheaterContextMenu?: (theaterId: string, anchor: { readonly x: number; readonly y: number }) => void;
   /** 카드의 창 컨트롤 — 최소화는 이 판(deck)에서 내리는 동작이고, 닫기는 두 번 눌러 확정한다.
       상태 변경은 canvas가 단일 소유하므로 deck는 의도만 올려보낸다. */
   readonly onMinimizeOperation?: (operationId: string) => void;
@@ -910,7 +910,7 @@ export function TriageWatchDeck({
     event.preventDefault();
     event.stopPropagation();
     dismissQuicklook();
-    onTheaterContextMenu?.(theater.id, theater.label, { x: event.clientX, y: event.clientY });
+    onTheaterContextMenu?.(theater.id, { x: event.clientX, y: event.clientY });
   };
   const openMapOperationMenu = (operationId: string, event: ReactMouseEvent<HTMLButtonElement>) => {
     const activeDrag = mapDragRef.current;

--- a/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
@@ -67,9 +67,8 @@ export const canvasEn = {
   "canvas.plugin.operationFailed": "Plugin operation failed to render.",
   "canvas.plugin.companionFailed": "Plugin companion failed to render.",
 
-  "canvas.menu.aria": "Canvas controls",
-  "canvas.menu.title": "Canvas controls",
-  "canvas.menu.theaterTitle": "{theater} controls",
+  "canvas.menu.aria": "Controls",
+  "canvas.menu.title": "Controls",
   "canvas.menu.launch": "Launch",
   "canvas.menu.empty": "No operations available.",
 
@@ -279,9 +278,8 @@ export const canvasKo: Record<keyof typeof canvasEn, string> = {
   "canvas.plugin.operationFailed": "Plugin Operation을 렌더하지 못했습니다.",
   "canvas.plugin.companionFailed": "Plugin Companion을 렌더하지 못했습니다.",
 
-  "canvas.menu.aria": "캔버스 제어",
-  "canvas.menu.title": "캔버스 제어",
-  "canvas.menu.theaterTitle": "{theater} 제어",
+  "canvas.menu.aria": "제어",
+  "canvas.menu.title": "제어",
   "canvas.menu.launch": "실행",
   "canvas.menu.empty": "사용 가능한 Operation이 없습니다.",
 

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -616,7 +616,6 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
           plugins={registry.plugins}
           renderKindIcon={renderKindIcon}
           canLaunch={canLaunch}
-          activeTheaterLabel={state.theaters.find((theater) => theater.id === state.activeTheaterId)?.label}
           onLaunchKind={handleSideBarLaunchKind}
           onPick={pickTriageOperation}
           onClose={handleClose}

--- a/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/triage-side-bar.tsx
@@ -53,7 +53,6 @@ interface TriageSideBarProps {
   readonly renderKindIcon: (pluginId: string, kind: OperationLaunchKind) => ReactNode;
   readonly canLaunch: boolean;
   /** 소유자 없는 자리의 실행 대상 — 사이드바 빈 영역은 활성 Theater로 실행한다. */
-  readonly activeTheaterLabel?: string;
   readonly onLaunchKind: (pluginId: string, kind: OperationLaunchKind, variantLaunch?: Readonly<Record<string, string>>) => void;
   readonly onPick: (operationId: string) => void;
   readonly onClose: (operationId: string) => void;
@@ -70,7 +69,6 @@ export function TriageSideBar({
   plugins,
   renderKindIcon,
   canLaunch,
-  activeTheaterLabel,
   onLaunchKind,
   onPick,
   onClose,
@@ -247,7 +245,6 @@ export function TriageSideBar({
           renderKindIcon={renderKindIcon}
           onLaunchKind={(pluginId, kind, variantLaunch) => { setLaunchMenu(null); onLaunchKind(pluginId, kind, variantLaunch); }}
           onClose={() => setLaunchMenu(null)}
-          theaterLabel={activeTheaterLabel}
         />,
         document.body,
       ) : null}

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7258,42 +7258,6 @@
   width: 100%;
 }
 
-.operation-launch-menu-chevron {
-  flex: none;
-  margin-left: auto;
-  color: var(--text-tertiary);
-  font-size: 16px;
-  line-height: 1;
-}
-
-.operation-launch-menu-item--annotated.operation-launch-menu-item--variants {
-  grid-template-columns: auto minmax(0, 1fr) auto auto;
-}
-
-.operation-launch-menu-item--annotated .operation-launch-menu-chevron {
-  grid-column: 4;
-  grid-row: 1;
-  margin-left: 0;
-}
-
-.operation-launch-flyout.theater-menu {
-  --flyout-enter-x: -4px;
-  top: -6px;
-  left: calc(100% + 10px);
-  right: auto;
-  z-index: 41;
-  /* 모델 이름만 담는 폭이다(실행 강도는 자기 서브메뉴로 빠졌다). canvas-context-menu.tsx의
-     FLYOUT_WIDTH와 같은 값이어야 한다 — 하나만 고치면 컴파일은 되고 배치만 조용히 어긋난다. */
-  width: 216px;
-  max-height: var(--canvas-menu-max-height, 520px);
-  overflow-y: auto;
-  animation: operation-launch-flyout-in var(--duration-fast) var(--ease-spring) both;
-}
-
-.operation-launch-flyout.theater-menu.is-left {
-  --flyout-enter-x: 4px;
-}
-
 .operation-launch-variant-caption {
   display: flex;
   align-items: center;
@@ -7377,6 +7341,15 @@
   background: color-mix(in oklch, var(--brass) 8%, transparent);
   color: var(--text-primary);
   outline: none;
+}
+
+/* 캔버스 메뉴는 실행 종류 행과 모델 밴드를 한 목록에 세운다. 그 목록의 왼쪽 홈통은 표식 자리다 —
+   종류 행의 아이콘과 밴드 캡션의 공급자 글리프가 같은 x에 서고, 글자는 그 오른쪽 한 열로 모인다.
+   모델 행에는 표식이 없으므로 그 홈통 폭만큼 들여쓰지 않으면 모델 이름만 왼쪽으로 튀어나와,
+   같은 메뉴 안에서 글자 열이 둘로 갈린다. 값은 .theater-menu-item의 라벨 자리를 그대로 옮긴 것
+   (항목 패딩 + .theater-menu-check 14px + 간격)에서 자기 조상 패딩(entry·row)만 되뺀다. */
+.canvas-context-menu .operation-launch-variant-row {
+  padding-left: calc(var(--space-2) + 14px + var(--space-2) - var(--space-1));
 }
 
 /* 라벨이 남는 폭을 전부 먹고 ★·꺾쇠는 그 뒤에 붙는다. 정렬을 표식 쪽 margin-left:auto로 만들면
@@ -10222,7 +10195,6 @@ body[data-codex-side="true"] .command-card {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .operation-launch-flyout,
   .operation-launch-effort-menu,
   .operation-launch-variant-row {
     animation: none;

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -418,7 +418,6 @@ describe("CanvasContextMenu launch kind attribute", () => {
         viewportBounds={{ width: 1116, height: 856 }}
         catalog={[{ id: "terminal", title: "Terminal", kinds: [{ id: "shell", type: "shell", title: "Shell" }] }]}
         canLaunch
-        theaterLabel="Alpha"
         renderKindIcon={() => null}
         onLaunchKind={vi.fn()}
         onClose={vi.fn()}
@@ -426,9 +425,9 @@ describe("CanvasContextMenu launch kind attribute", () => {
     ));
 
     const menu = document.querySelector(".canvas-context-menu")!;
-    expect(menu.getAttribute("aria-label")).toBe("Alpha controls · Terminal");
+    expect(menu.getAttribute("aria-label")).toBe("Controls · Terminal");
     // 같은 문자열이 눈에도 보이지만, 접근성 트리에는 메뉴 이름으로만 한 번 실린다.
-    expect(document.querySelector(".canvas-context-menu-head-text")?.textContent).toBe("Alpha controls · Terminal");
+    expect(document.querySelector(".canvas-context-menu-head-text")?.textContent).toBe("Controls · Terminal");
     expect(document.querySelector(".canvas-context-menu-head")?.getAttribute("aria-hidden")).toBe("true");
   });
 
@@ -511,6 +510,17 @@ describe("CanvasContextMenu launch kind attribute", () => {
         ?? "caption");
     // 카탈로그는 Shell을 마지막에 내놓지만(terminal/routes.ts), 목록에서는 첫 행이다.
     expect(order).toEqual(["shell", "caption", "fable"]);
+  });
+
+  it("keeps a locked menu on one direct row per kind instead of an unusable model band", () => {
+    // canLaunch=false는 Theater가 없거나 추가 중인 상태다. 밴드를 펴면 고를 수 없는 모델이
+    // 열두 줄 서고, 방향키 집합은 그 전부를 걸러 내 아무 항목도 남지 않는다.
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, gatewayVariantCatalog(), vi.fn(), false, vi.fn(), false);
+
+    expect(document.querySelector(".operation-launch-variant-caption")).toBeNull();
+    expect(document.querySelector("[data-launch-variant-row]")).toBeNull();
+    const locked = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!;
+    expect(locked.disabled).toBe(true);
   });
 
   it("expands a disabled variant kind as its own reason row instead of an unusable model band", () => {
@@ -833,6 +843,7 @@ function renderMenu(
   onClose = vi.fn(),
   fixed = false,
   onLaunchKind = vi.fn(),
+  canLaunch = true,
 ): void {
   act(() => root.render(
     <CanvasContextMenu
@@ -840,7 +851,7 @@ function renderMenu(
       viewportBounds={viewportBounds}
       fixed={fixed}
       catalog={catalog}
-      canLaunch
+      canLaunch={canLaunch}
       renderKindIcon={() => null}
       onLaunchKind={onLaunchKind}
       onClose={onClose}

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -10,7 +10,6 @@ import type { OperationCatalogPlugin } from "@fleet-console/sdk/operations";
 import {
   CanvasContextMenu,
   OPERATION_LAUNCH_EFFORT_MENU_WIDTH,
-  OPERATION_LAUNCH_FLYOUT_WIDTH,
 } from "../core/client/src/canvas/canvas-context-menu.js";
 import {
   FEATURE_TOUR_BOUNDARY_ATTRIBUTE,
@@ -43,9 +42,6 @@ beforeEach(() => {
   Element.prototype.getBoundingClientRect = function getBoundingClientRect(): DOMRect {
     if (this.classList.contains("canvas-context-menu")) {
       return { ...originalGetBoundingClientRect.call(this), width: 288, height: 133 } as DOMRect;
-    }
-    if (this.classList.contains("operation-launch-flyout")) {
-      return { ...originalGetBoundingClientRect.call(this), width: 216, height: 300 } as DOMRect;
     }
     return originalGetBoundingClientRect.call(this);
   };
@@ -452,25 +448,19 @@ describe("CanvasContextMenu launch kind attribute", () => {
     }
   });
 
-  it("opens launch variants on pointer, suppresses the description aside, and preserves every payload", () => {
+  it("lists the models directly in the menu, keeps direct-launch kinds above the bands, and preserves every payload", () => {
     const onLaunchKind = vi.fn();
     const catalog = gatewayVariantCatalog();
     renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, catalog, vi.fn(), false, onLaunchKind);
 
-    const parent = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!;
-    expect(parent.getAttribute("aria-haspopup")).toBe("menu");
-    expect(parent.getAttribute("aria-expanded")).toBe("false");
-    expect(parent.querySelector(".operation-launch-menu-chevron")?.textContent).toBe("›");
-
-    act(() => {
-      parent.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
-      parent.parentElement!.dispatchEvent(new MouseEvent("pointerover", { bubbles: true }));
-    });
-    expect(parent.getAttribute("aria-expanded")).toBe("true");
+    // 실행 종류를 짚어 여는 단이 사라졌다 — 모델 밴드가 메뉴의 첫 단이다.
+    expect(document.querySelector(".operation-launch-flyout")).toBeNull();
     expect(document.querySelector(".operation-launch-variant-caption")?.textContent).toBe("Claude built-in");
     expect(document.querySelector(".canvas-context-menu-aside")).toBeNull();
 
     const row = document.querySelector<HTMLButtonElement>('[data-launch-variant-row="fable"]')!;
+    // 모델 행도 결국 이 실행 종류를 띄운다 — 종류를 짚는 바깥 선택자가 밴드에서도 닿아야 한다.
+    expect(row.getAttribute("data-operation-launch-kind")).toBe("claude-gateway");
     // 펼쳐지는 것은 메뉴가 아니라 슬라이더 하나짜리 상자다 — haspopup=menu로 예고하면 보조기술이
     // 메뉴 탐색 모델을 씌워 트랙을 조작 대상으로 보지 않는다.
     expect(row.hasAttribute("aria-haspopup")).toBe(false);
@@ -503,16 +493,43 @@ describe("CanvasContextMenu launch kind attribute", () => {
     expect(effortHandle("fable").dataset.effortLevel).toBe("max");
     act(() => document.querySelector<HTMLButtonElement>('[data-launch-variant-row="fable"]')!.click());
     expect(onLaunchKind).toHaveBeenLastCalledWith("terminal", catalog[0]!.kinds[0], { model: "fable", effort: "max" });
+  });
 
-    act(() => parent.click());
-    expect(onLaunchKind).toHaveBeenLastCalledWith("terminal", catalog[0]!.kinds[0]);
+  it("keeps direct-launch kinds above the model bands", () => {
+    // 캡션 아래에 놓인 무캡션 행은 그 밴드의 일원으로 읽힌다 — 바로 실행되는 종류는 밴드보다 위다.
+    const [gateway] = gatewayVariantCatalog();
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [{
+      ...gateway!,
+      kinds: [...gateway!.kinds, { id: "shell", type: "shell", title: "Shell" }],
+    }]);
+
+    const order = Array.from(document
+      .querySelector(".canvas-context-menu")!
+      .querySelectorAll('[data-operation-launch-kind="shell"], .operation-launch-variant-caption, [data-launch-variant-row]'))
+      .map((element) => element.getAttribute("data-launch-variant-row")
+        ?? element.getAttribute("data-operation-launch-kind")
+        ?? "caption");
+    // 카탈로그는 Shell을 마지막에 내놓지만(terminal/routes.ts), 목록에서는 첫 행이다.
+    expect(order).toEqual(["shell", "caption", "fable"]);
+  });
+
+  it("expands a disabled variant kind as its own reason row instead of an unusable model band", () => {
+    const [gateway] = gatewayVariantCatalog();
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [{
+      ...gateway!,
+      kinds: [{ ...gateway!.kinds[0]!, disabled: true, disabledReason: "Not installed" }],
+    }]);
+
+    expect(document.querySelector(".operation-launch-variant-caption")).toBeNull();
+    expect(document.querySelector("[data-launch-variant-row]")).toBeNull();
+    const row = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!;
+    expect(row.disabled).toBe(true);
+    expect(row.querySelector(".operation-launch-menu-reason")?.textContent).toBe("Not installed");
   });
 
   it("says on the row what the effort handle opens, and opens it without launching", () => {
     const onLaunchKind = vi.fn();
     renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, gatewayVariantCatalog(), vi.fn(), false, onLaunchKind);
-    act(() => document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!
-      .parentElement!.dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
 
     const handle = effortHandle("fable");
     // 꺾쇠 하나로는 무엇이 열리는지 말하지 못한다 — 계기 표식과 지금 실린 단이 함께 선다.
@@ -539,78 +556,69 @@ describe("CanvasContextMenu launch kind attribute", () => {
     expect(effortHandle("fable").dataset.effortLevel).toBe("max");
   });
 
-  it("clamps the flyout inside narrow horizontal and vertical bounds", () => {
+  it("clamps the effort submenu inside narrow horizontal bounds", () => {
     const bounds = { width: 500, height: 360 };
     renderMenu({ x: 450, y: 320 }, bounds, gatewayVariantCatalog());
-    const parent = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!;
 
-    act(() => parent.parentElement!.dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
+    act(() => effortHandle("fable").dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
 
-    const flyout = document.querySelector<HTMLElement>(".operation-launch-flyout")!;
-    const left = Number.parseFloat(flyout.style.left);
-    const top = Number.parseFloat(flyout.style.top);
+    const effort = document.querySelector<HTMLElement>(".operation-launch-effort-menu")!;
+    const left = Number.parseFloat(effort.style.left);
     expect(left).toBeGreaterThanOrEqual(12);
-    expect(left).toBeLessThanOrEqual(bounds.width - 216 - 12);
-    expect(top).toBeGreaterThanOrEqual(12);
-    expect(top).toBeLessThanOrEqual(bounds.height - 300 - 12);
+    expect(left).toBeLessThanOrEqual(bounds.width - OPERATION_LAUNCH_EFFORT_MENU_WIDTH - 12);
+    expect(Number.parseFloat(effort.style.top)).toBeGreaterThanOrEqual(12);
   });
 
-  it("continues the cascade to the right instead of folding onto the parent when both sides fit", () => {
-    // 캔버스 왼쪽에서 연 메뉴는 flyout이 오른쪽으로 열린다. 그때 강도 서브메뉴가 "왼쪽 여유가
-    // 더 넓다"는 이유로 접히면 부모 메뉴 위에 겹쳐, 짚은 행과 무관한 자리에 뜬 상자가 된다.
+  it("opens the effort submenu to the right instead of folding onto the menu when both sides fit", () => {
+    // 캔버스 왼쪽에서 연 메뉴는 서브메뉴가 오른쪽으로 열린다. "왼쪽 여유가 더 넓다"는 이유로
+    // 접히면 메뉴 위에 겹쳐, 짚은 행과 무관한 자리에 뜬 상자가 된다.
     const bounds = { width: 1280, height: 800 };
     renderMenu({ x: 260, y: 100 }, bounds, gatewayVariantCatalog());
-    const parent = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!;
-    act(() => parent.parentElement!.dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
-
-    const flyout = document.querySelector<HTMLElement>(".operation-launch-flyout")!;
-    expect(flyout.classList.contains("is-left")).toBe(false);
 
     act(() => effortHandle("fable").dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
 
     const effort = document.querySelector<HTMLElement>(".operation-launch-effort-menu")!;
     expect(effort.classList.contains("is-left")).toBe(false);
-    // 서브메뉴는 flyout 상자의 오른쪽 바깥에 선다 — 부모 위로 되돌아오지 않는다.
-    expect(Number.parseFloat(effort.style.left))
-      .toBeGreaterThanOrEqual(Number.parseFloat(flyout.style.left) + 216);
+    // 서브메뉴는 메뉴 상자의 오른쪽 바깥에 선다 — 부모 위로 되돌아오지 않는다.
+    expect(Number.parseFloat(effort.style.left)).toBeGreaterThanOrEqual(260 + 288);
   });
 
   it("keeps the rendered widths in step with the placement constants", () => {
     const css = readFileSync(resolve(process.cwd(), "core/client/src/styles/components.css"), "utf8");
     const widthOf = (selector: string) =>
       Number(new RegExp(`${selector}\\.theater-menu\\s*\\{[^}]*?width:\\s*(\\d+)px;`, "u").exec(css)?.[1]);
-    expect(widthOf("\\.operation-launch-flyout")).toBe(OPERATION_LAUNCH_FLYOUT_WIDTH);
     expect(widthOf("\\.operation-launch-effort-menu")).toBe(OPERATION_LAUNCH_EFFORT_MENU_WIDTH);
+    // 모델 목록이 메뉴 자체가 되면서 옆으로 펼치던 상자는 남아 있으면 안 된다.
+    expect(css).not.toContain(".operation-launch-flyout");
   });
 
-  it("follows the model row while the flyout scrolls, and lets go once the row leaves it", () => {
+  it("follows the model row while the menu scrolls, and lets go once the row leaves it", () => {
     // 서브메뉴는 fixed라 목록이 굴러도 제자리에 남는다. 짚고 있던 행이 올라가 버리면 그 상자는
     // 엉뚱한 행 옆에서 그 행의 강도인 척하고, 행을 눌러 실행하는 표면에서는 그대로 오실행이 된다.
-    const flyoutRect = { top: 100, bottom: 400, left: 0, right: 216, width: 216, height: 300 };
+    // 목록이 메뉴 자체가 되었으므로 굴러가는 상자도 메뉴다.
+    const menuRect = { top: 100, bottom: 400, left: 0, right: 288, width: 288, height: 300 };
     let anchorRect = { top: 150, bottom: 178, left: 8, right: 208, width: 200, height: 28 };
     const previous = Element.prototype.getBoundingClientRect;
     Element.prototype.getBoundingClientRect = function getBoundingClientRect(): DOMRect {
-      if (this.classList.contains("operation-launch-flyout")) return { ...flyoutRect, x: 0, y: 100, toJSON: () => ({}) } as DOMRect;
+      if (this.classList.contains("canvas-context-menu")) return { ...menuRect, x: 0, y: 100, toJSON: () => ({}) } as DOMRect;
       if (this.classList.contains("operation-launch-variant-entry")) return { ...anchorRect, x: 8, y: anchorRect.top, toJSON: () => ({}) } as DOMRect;
       return previous.call(this);
     };
     try {
       renderMenu({ x: 200, y: 100 }, { width: 1280, height: 420 }, gatewayVariantCatalog());
-      const parent = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!;
-      act(() => parent.parentElement!.dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
       act(() => effortHandle("fable").dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
       const topAfterOpen = document.querySelector<HTMLElement>(".operation-launch-effort-menu")!.style.top;
 
-      // 행이 아직 flyout 안에 있으면 따라간다.
+      // 행이 아직 메뉴 안에 있으면 따라간다.
       anchorRect = { ...anchorRect, top: 120, bottom: 148 };
-      act(() => document.querySelector(".operation-launch-flyout")!.dispatchEvent(new Event("scroll")));
+      act(() => document.querySelector(".canvas-context-menu")!.dispatchEvent(new Event("scroll")));
       const menu = document.querySelector<HTMLElement>(".operation-launch-effort-menu");
       expect(menu).not.toBeNull();
       expect(menu!.style.top).not.toBe(topAfterOpen);
 
-      // 행이 flyout 위로 사라지면 "그 행의 강도"라는 관계가 끊긴다 — 따라가지 않고 닫는다.
+      // 행이 메뉴 위로 사라지면 "그 행의 강도"라는 관계가 끊긴다 — 따라가지 않고 닫는다.
       anchorRect = { ...anchorRect, top: 40, bottom: 68 };
-      act(() => document.querySelector(".operation-launch-flyout")!.dispatchEvent(new Event("scroll")));
+      act(() => document.querySelector(".canvas-context-menu")!.dispatchEvent(new Event("scroll")));
       expect(document.querySelector(".operation-launch-effort-menu")).toBeNull();
     } finally {
       Element.prototype.getBoundingClientRect = previous;
@@ -633,8 +641,6 @@ describe("CanvasContextMenu launch kind attribute", () => {
     };
     try {
       renderMenu({ x: 520, y: 120 }, bounds, gatewayVariantCatalog());
-      const parent = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!;
-      act(() => parent.parentElement!.dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
       act(() => effortHandle("fable").dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
 
       const effort = document.querySelector<HTMLElement>(".operation-launch-effort-menu")!;
@@ -645,32 +651,44 @@ describe("CanvasContextMenu launch kind attribute", () => {
     }
   });
 
-  it("opens the effort submenu from a model row, then restores focus with ArrowLeft", async () => {
+  it("walks direct-launch rows and model rows as one arrow-key set", () => {
+    const [gateway] = gatewayVariantCatalog();
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [{
+      ...gateway!,
+      kinds: [...gateway!.kinds, { id: "shell", type: "shell", title: "Shell" }],
+    }]);
+
+    const menu = document.querySelector<HTMLElement>(".canvas-context-menu")!;
+    const shell = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="shell"]')!;
+    const model = document.querySelector<HTMLButtonElement>('[data-launch-variant-row="fable"]')!;
+
+    // 두 종류의 행이 한 목록의 형제가 됐다 — 방향키는 그 사이를 건너다녀야 한다.
+    act(() => menu.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })));
+    expect(document.activeElement).toBe(shell);
+    pressFlyoutKey("ArrowDown");
+    expect(document.activeElement).toBe(model);
+    pressFlyoutKey("ArrowUp");
+    expect(document.activeElement).toBe(shell);
+  });
+
+  it("opens the effort submenu from a model row with ArrowRight, then restores focus with Escape", async () => {
     renderMenu({ x: 900, y: 156 }, { width: 1116, height: 856 }, gatewayVariantCatalog());
-    const parent = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!;
+    const row = document.querySelector<HTMLButtonElement>('[data-launch-variant-row="fable"]')!;
 
     act(() => {
-      parent.focus();
-      parent.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+      row.focus();
+      row.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
     });
     await act(async () => {
       await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
     });
 
-    const flyout = document.querySelector<HTMLElement>(".operation-launch-flyout")!;
-    const row = document.querySelector<HTMLButtonElement>('[data-launch-variant-row="fable"]')!;
-    expect(flyout.parentElement).toBe(document.querySelector(".operation-launch-control--canvas"));
-    expect(flyout.closest(".canvas-context-menu")).toBeNull();
-    expect(flyout.classList.contains("is-left")).toBe(true);
-    expect(document.activeElement).toBe(row);
-
-    pressFlyoutKey("ArrowRight");
-    await act(async () => {
-      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-    });
     const track = document.querySelector<HTMLElement>(".effort-track")!;
     const popup = document.querySelector<HTMLElement>(".operation-launch-effort-menu")!;
     expect(popup).not.toBeNull();
+    // 서브메뉴는 메뉴의 스크롤 상자 바깥 형제라 목록에 잘리지 않는다.
+    expect(popup.parentElement).toBe(document.querySelector(".operation-launch-control--canvas"));
+    expect(popup.closest(".canvas-context-menu")).toBeNull();
     // 상자는 그룹이고, 그것을 연 행이 aria-controls로 가리킨다.
     expect(popup.getAttribute("role")).toBe("group");
     expect(row.getAttribute("aria-controls")).toBe(popup.id);
@@ -684,24 +702,19 @@ describe("CanvasContextMenu launch kind attribute", () => {
     pressFlyoutKey("Escape");
     expect(document.querySelector(".operation-launch-effort-menu")).toBeNull();
     expect(document.activeElement).toBe(row);
-    expect(document.querySelector(".operation-launch-flyout")).not.toBeNull();
-
-    pressFlyoutKey("ArrowLeft");
-    expect(document.querySelector(".operation-launch-flyout")).toBeNull();
-    expect(document.activeElement).toBe(parent);
   });
 
-  it("closes only the flyout on Escape", () => {
+  it("closes only the effort submenu on Escape", () => {
     const onClose = vi.fn();
     renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, gatewayVariantCatalog(), onClose);
-    const parent = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!;
-    act(() => parent.parentElement!.dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
-    const flyout = document.querySelector<HTMLElement>(".operation-launch-flyout")!;
+    const row = document.querySelector<HTMLButtonElement>('[data-launch-variant-row="fable"]')!;
+    act(() => effortHandle("fable").dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
+    const popup = document.querySelector<HTMLElement>(".operation-launch-effort-menu")!;
 
-    act(() => flyout.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })));
+    act(() => popup.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })));
 
-    expect(document.querySelector(".operation-launch-flyout")).toBeNull();
-    expect(document.activeElement).toBe(parent);
+    expect(document.querySelector(".operation-launch-effort-menu")).toBeNull();
+    expect(document.activeElement).toBe(row);
     expect(onClose).not.toHaveBeenCalled();
   });
 

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -494,6 +494,28 @@ describe("CanvasContextMenu launch kind attribute", () => {
     expect(onLaunchKind).toHaveBeenLastCalledWith("terminal", catalog[0]!.kinds[0], { model: "fable", effort: "max" });
   });
 
+  it("drops the description aside when the pointer reaches a model row, even while focus sits on an annotated row", () => {
+    // 두 채널을 합치는 `hoverKey ?? focusKey`는 포인터 쪽을 비우면 포커스가 짚던 행으로 되돌아간다.
+    // 모델 행은 자기 키로 덮어야 "설명 없는 자리"가 되고, 포인터가 메뉴를 벗어나면 다시 포커스가 드러난다.
+    const [gateway] = gatewayVariantCatalog();
+    renderMenu({ x: 320, y: 156 }, { width: 1400, height: 856 }, [
+      { id: "terminal", title: "Terminal", kinds: [{ id: "claude-gateway", type: "agent", title: "Claude (Gateway)" }] },
+      { ...gateway!, id: "models", title: "Models" },
+    ]);
+
+    const annotated = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="claude-gateway"]')!;
+    act(() => annotated.focus());
+    expect(document.querySelector(".canvas-context-menu-aside")).not.toBeNull();
+
+    const entry = document.querySelector<HTMLElement>(".operation-launch-variant-entry")!;
+    act(() => entry.dispatchEvent(new PointerEvent("pointerover", { bubbles: true })));
+    expect(document.querySelector(".canvas-context-menu-aside")).toBeNull();
+
+    // 포인터가 메뉴를 떠나면 포커스가 짚던 설명이 다시 드러난다.
+    act(() => document.querySelector(".canvas-context-menu")!.dispatchEvent(new MouseEvent("mouseout", { bubbles: true })));
+    expect(document.querySelector(".canvas-context-menu-aside")).not.toBeNull();
+  });
+
   it("keeps direct-launch kinds above the model bands", () => {
     // 캡션 아래에 놓인 무캡션 행은 그 밴드의 일원으로 읽힌다 — 바로 실행되는 종류는 밴드보다 위다.
     const [gateway] = gatewayVariantCatalog();

--- a/runtime/fleet-console/tests/operations-side-bar-keyboard-context-menu.test.tsx
+++ b/runtime/fleet-console/tests/operations-side-bar-keyboard-context-menu.test.tsx
@@ -165,9 +165,10 @@ describe("sidebar context menu keyboard path", () => {
       clientX: 120,
       clientY: 80,
     })));
-    const parent = required<HTMLElement>('[data-operation-launch-kind="claude-gateway"]');
-    act(() => parent.parentElement!.dispatchEvent(new MouseEvent("pointerover", { bubbles: true })));
+    // 사이드바에서 연 메뉴도 모델 목록을 바로 편다 — 실행 종류를 짚어 여는 단은 없다.
+    expect(document.querySelector(".operation-launch-flyout")).toBeNull();
     const row = required<HTMLButtonElement>('[data-launch-variant-row="fable"]');
+    expect(row.getAttribute("data-operation-launch-kind")).toBe("claude-gateway");
     act(() => {
       row.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
       // 강도 상자는 행이 아니라 행 오른쪽 손잡이에서 열린다.

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -880,7 +880,7 @@ describe("triage store", () => {
     const fieldMenu = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 71, clientY: 82 });
     act(() => bandBody.dispatchEvent(fieldMenu));
     expect(fieldMenu.defaultPrevented).toBe(true);
-    expect(theaterMenu).toHaveBeenCalledWith("theater-a", "Alpha", { x: 71, y: 82 });
+    expect(theaterMenu).toHaveBeenCalledWith("theater-a", { x: 71, y: 82 });
 
     act(() => setTriageDeckMapModeLive(true));
     const dot = container.querySelector<HTMLButtonElement>('[data-triage-map-dot="picked"]')!;
@@ -1406,7 +1406,6 @@ describe("triage store", () => {
       plugins: [],
       renderKindIcon: () => null,
       canLaunch: true,
-      activeTheaterLabel: "Alpha",
       onLaunchKind,
       onPick: () => {},
       onClose: () => {},
@@ -1429,8 +1428,8 @@ describe("triage store", () => {
     expect(bareMenu.defaultPrevented).toBe(true);
     const launchMenu = document.querySelector(".canvas-context-menu");
     expect(launchMenu).not.toBeNull();
-    // 소유자가 없는 자리이므로 어느 Theater로 실행되는지는 헤더가 밝힌다.
-    expect(launchMenu?.querySelector(".canvas-context-menu-head-text")?.textContent).toContain("Alpha");
+    // 상자 이름은 어디서 열든 같다 — 실행이 어디로 가는지는 아래에서 실행 인자로 잰다.
+    expect(launchMenu?.querySelector(".canvas-context-menu-head-text")?.textContent).toBe("Controls · Terminal");
     const shellItem = launchMenu?.querySelector<HTMLButtonElement>('[data-operation-launch-kind="shell"]');
     expect(shellItem).not.toBeNull();
     expect(shellItem?.disabled).toBe(false);

--- a/runtime/fleet-console/tests/warroom-canvas-context-menu.test.tsx
+++ b/runtime/fleet-console/tests/warroom-canvas-context-menu.test.tsx
@@ -24,6 +24,8 @@ import { loadForTheater, setState as setCanvasState } from "../core/client/src/c
 import { isTriageDeckMapMode, resetTriageDeckZoomForTests, resetTriageTheater, setTriageActive, setTriageDeckZoom } from "../core/client/src/canvas/triage-store.js";
 import type { ConsoleState, OperationNode } from "../core/client/src/types.js";
 
+type OperationsCanvasLaunchKind = Parameters<typeof OperationsCanvas>[0]["onLaunchKind"];
+
 const THEATER_A = "theater-a";
 // War Room은 전 Theater를 한 판에 얹는다 — 밴드가 자기 Theater를 소유하는지는 활성 Theater가
 // 아닌 밴드에서만 드러난다. 두 밴드가 같은 이름이면 밴드 소유와 캔버스 폴백이 구별되지 않는다.
@@ -92,8 +94,8 @@ describe("War Room canvas controls reach", () => {
       expect(menu.defaultPrevented).toBe(true);
       const opened = container!.querySelector(".canvas-context-menu");
       expect(opened, `deck zoom ${zoom}`).not.toBeNull();
-      // 소유자가 없는 자리의 실행 대상은 활성 Theater이며, 헤더가 그것을 밝힌다.
-      expect(opened?.querySelector(".canvas-context-menu-head-text")?.textContent).toContain("Alpha");
+      // 상자 이름은 어디서 열든 같다 — 여는 자리나 소유 Theater를 이름에 섞지 않는다.
+      expect(opened?.querySelector(".canvas-context-menu-head-text")?.textContent).toBe("Controls · Test");
       expect(opened?.querySelector('[data-operation-launch-kind="shell"]')).not.toBeNull();
       act(() => { window.dispatchEvent(new Event("canvas-context-menu-close")); });
       expect(container!.querySelector(".canvas-context-menu")).toBeNull();
@@ -105,8 +107,9 @@ describe("War Room canvas controls reach", () => {
   // 덱을 세운 뒤 덱 자신의 빈 자리에서 우클릭해야 "밀도가 실행 진입점을 없애지 않는다"가 검증된다.
   it("reaches canvas controls from the deck's own empty space once the entry curtain lifts", () => {
     vi.useFakeTimers();
+    const onLaunchKind = vi.fn();
     try {
-      renderCanvas();
+      renderCanvas(onLaunchKind);
       // 진입 커튼이 걷혀야 덱이 선다(커튼 중에는 TriageWatchDeck이 null을 낸다).
       act(() => { vi.advanceTimersByTime(2_000); });
 
@@ -139,9 +142,11 @@ describe("War Room canvas controls reach", () => {
       const bandMenu = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 140, clientY: 260 });
       act(() => betaBand!.dispatchEvent(bandMenu));
       expect(bandMenu.defaultPrevented).toBe(true);
-      const bandHead = container!.querySelector(".canvas-context-menu-head-text")?.textContent;
-      expect(bandHead).toContain("Beta");
-      expect(bandHead).not.toContain("Alpha");
+      // 소유는 머리글 문구가 아니라 실행이 향하는 Theater로 재야 한다 — 상자 이름은 어디서 열든
+      // 같은 문자열이고, 그 이름을 재는 것은 소유가 아니라 라벨을 재는 것이다.
+      act(() => container!.querySelector<HTMLButtonElement>('[data-operation-launch-kind="shell"]')!.click());
+      expect(onLaunchKind).toHaveBeenCalledTimes(1);
+      expect(onLaunchKind.mock.calls[0]![3]).toBe(THEATER_B);
     } finally {
       act(() => { window.dispatchEvent(new Event("canvas-context-menu-close")); });
       vi.useRealTimers();
@@ -183,13 +188,13 @@ describe("War Room canvas controls reach", () => {
   });
 });
 
-function renderCanvas() {
+function renderCanvas(onLaunchKind: OperationsCanvasLaunchKind = () => {}) {
   act(() => root!.render(createElement(OperationsCanvas, {
     state: STATE,
     catalog: CATALOG,
     canLaunch: true,
     renderKindIcon: () => null,
-    onLaunchKind: () => {},
+    onLaunchKind,
     onLaunchAtGeometry: () => {},
     onClose: () => {},
     onFocus: () => {},


### PR DESCRIPTION
## Summary
- 캔버스·사이드바·War Room 사이드바가 공유하는 실행 메뉴에서 실행 종류를 세우던 부모 단을 없애고, 모델 목록을 루트 메뉴에 바로 편다. 옆으로 펼치던 `.operation-launch-flyout`은 제거되고 강도 트랙만 유일한 캐스케이드로 남아 상호작용 깊이가 3단 → 2단이 된다.
- 평탄화 규칙은 플러그인 무지 상태를 유지한다: variants가 없는 실행 종류(Shell·비활성 CLI·실행이 잠긴 상태)는 직접 실행 행으로 **밴드보다 위**에 서고, variants를 가진 종류는 그 그룹이 루트 메뉴의 밴드로 전개된다. 캡션 아래에 놓인 무캡션 행은 그 밴드의 일원으로 읽히므로 순서는 취향이 아니라 구조다.
- 메뉴 머리글 문구를 `캔버스 제어`/`{theater} 제어` → `제어`(en `Controls`)로 통일하고, 그 보간만 나르던 `theaterLabel` 배선을 함께 걷어냈다.
- SDK 계약(`plugin → kinds → variants → rows → chips`)은 **변경하지 않았다**. 실행은 여전히 `onLaunchKind(pluginId, kind, launch)`로 나가므로 카탈로그 producer·host sanitizer·Quick Launch·Operation 복원 경로가 모두 무변경이다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 163 files / 1827 passed, 24 skipped
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — tsc 0 오류 (`tsconfig.json` + `core/client/tsconfig.json`)
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 성공
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK
- [x] 격리 콘솔 헤드리스 실측(agent-browser): 실제 카탈로그(native 3 · codex 2 · cursor 5 · opencode 2 + Shell)로 우클릭 시 flyout 없이 목록이 열리고 Shell이 첫 행, 모든 라벨이 한 열(menu 기준 x=35)에 정렬, 강도 트랙이 메뉴 오른쪽 바깥에 배치, 메뉴 스크롤 시 트랙이 행을 따라감. 모델 행 클릭이 실선에 `{"cliId":"claude-gateway","model":"fable","effort":"max"}`를 실음. 페이지 에러/거부 0건.
- [x] 기능 투어 앵커 `[data-operation-launch-kind="claude-gateway"]`가 첫 모델 행으로 재해석되어 그대로 발화함을 헤디드 스크린샷으로 확인