### PR TITLE
fix(fleet-console): keep the way home from a console that is not home

### DIFF
--- a/.changelog.d/wsl-console-home-context.md
+++ b/.changelog.d/wsl-console-home-context.md
@@ -1,0 +1,10 @@
+---
+branch: wsl-console-home-context
+---
+
+### fleet-console
+
+#### Fixed
+
+- Moving to a console that runs somewhere else on this computer, such as one inside a WSL distribution or a second console you started yourself, no longer strips the way back. The host box now works out where you are standing from the console the app launched rather than from the shape of the address, so any console that is not that one unfolds your own computer's list exactly as a remote console does. The chip names the console you are standing on instead of calling it local, that console's row in the list carries its own name rather than borrowing the name of the console drawing the list, and the app tells a console where home is before the window arrives, so the way back no longer depends on which of the two gets there first.
+  ko: 이 컴퓨터의 다른 곳에서 도는 콘솔 — WSL 배포판 안의 콘솔이나 직접 띄운 두 번째 콘솔 — 로 건너가도 돌아갈 길이 사라지지 않습니다. 호스트 박스는 이제 주소 모양이 아니라 앱이 띄운 콘솔을 기준으로 지금 어디에 서 있는지를 가리므로, 그 콘솔이 아닌 곳에서는 원격 콘솔에서와 똑같이 내 컴퓨터의 목록이 그대로 펼쳐집니다. 칩은 "여기"라고 말하는 대신 지금 서 있는 콘솔의 이름을 말하고, 목록 속 그 줄도 목록을 그리는 콘솔의 이름을 빌리지 않고 자기 이름을 달며, 집 주소는 창보다 먼저 그 콘솔에 도착하므로 돌아갈 길이 둘 중 무엇이 먼저 닿느냐에 좌우되지 않습니다.

--- a/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
@@ -134,7 +134,8 @@ export function HostSwitcher({ picker }: { readonly picker?: HostPickerContext }
   const t = useT();
   const state = useConsoleState();
   const hosts = useRemoteHosts();
-  const homeOrigin = useDesktopHomeOrigin();
+  const shellHome = useDesktopHomeOrigin();
+  const homeOrigin = shellHome.origin;
   // 원격으로 건너가는 일은 셸의 인증서 배관을 거쳐야 한다. 브라우저 단독에서는 내주지 않는다.
   const canOpenRemote = isDesktopShell();
   const navigate = useNavigate();
@@ -257,9 +258,14 @@ export function HostSwitcher({ picker }: { readonly picker?: HostPickerContext }
   /**
    * 집에 서 있을 때만 "여기"라고 말한다. 집을 떠나 있으면 어느 콘솔인지가 답이다 — 칩을
    * 누르면 집의 목록이 펼쳐지므로, 칩까지 "여기"라고 하면 어디에 서 있었는지가 사라진다.
-   * 셸이 없어 집을 모를 때만 스캔에 든 사실로 대신한다.
+   *
+   * 셸이 창을 들고 있는데 아직 집 주소를 못 받았다면 아무 말도 하지 않는다. 그 순간 "여기"라고
+   * 하면 손님 콘솔이 집 행세를 하게 되고, 사용자는 그 말을 믿고 누른다. 셸이 아예 없을 때만
+   * 스캔에 든 사실로 대신한다 — 그때는 답이 늦는 것이 아니라 답할 셸이 없는 것이다.
    */
-  const standingAtHome = homeOrigin === null ? nearbyCurrent : currentOrigin === homeOrigin;
+  const standingAtHome = canOpenRemote && shellHome.pending
+    ? false
+    : homeOrigin === null ? nearbyCurrent : currentOrigin === homeOrigin;
   const chipLabel = state.controlHolder !== null
     ? t("chrome.control.shared")
     : standingAtHome
@@ -274,6 +280,14 @@ export function HostSwitcher({ picker }: { readonly picker?: HostPickerContext }
    * WSL처럼 스캔이 닿지 못하는 곳에서는 비어 있다 — 그 침묵이 돌아가는 길까지 지워서는 안 된다.
    */
   const pickerHome = !inPicker && canOpenRemote && awayFromHome ? homeOrigin : null;
+
+  /**
+   * 집 주소는 늦게 도착할 수 있고, 그 전에 누른 칩은 이 콘솔의 판을 편다. 주소가 도착해 이
+   * 콘솔이 목록의 주인이 아니게 되면 그 판은 남의 목록이므로 걷는다 — 다시 누르면 집의 것이 온다.
+   */
+  useEffect(() => {
+    if (pickerHome !== null) setOpen(false);
+  }, [pickerHome]);
 
   // 집을 떠나 있으면 목록이 비어 보여도 칩은 남는다 — 그 칩이 돌아가는 유일한 문이다.
   if (!inPicker && pickerHome === null && nearby.length === 0 && hosts.length === 0) return null;

--- a/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
@@ -283,11 +283,17 @@ export function HostSwitcher({ picker }: { readonly picker?: HostPickerContext }
 
   /**
    * 집 주소는 늦게 도착할 수 있고, 그 전에 누른 칩은 이 콘솔의 판을 편다. 주소가 도착해 이
-   * 콘솔이 목록의 주인이 아니게 되면 그 판은 남의 목록이므로 걷는다 — 다시 누르면 집의 것이 온다.
+   * 콘솔이 목록의 주인이 아니게 되면 그 판은 남의 목록이다 — 걷고, 사용자가 누른 뜻대로 집에게
+   * 목록을 청한다. 걷기만 하면 그 누름은 아무 일도 일어나지 않은 채 사라진다.
+   *
+   * 이 자리에 닿는 길은 그 어긋남 하나뿐이다. 주소를 알고 있었다면 칩이 처음부터 여기로 보냈고,
+   * 집이 펼친 목록에서는 `pickerHome`이 서지 않는다.
    */
   useEffect(() => {
-    if (pickerHome !== null) setOpen(false);
-  }, [pickerHome]);
+    if (pickerHome === null || !open) return;
+    setOpen(false);
+    location.assign(pickerUrl(pickerHome, PICKER_SURFACE_OPEN, currentOrigin));
+  }, [pickerHome, open, currentOrigin]);
 
   // 집을 떠나 있으면 목록이 비어 보여도 칩은 남는다 — 그 칩이 돌아가는 유일한 문이다.
   if (!inPicker && pickerHome === null && nearby.length === 0 && hosts.length === 0) return null;

--- a/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band-system-cluster.tsx
@@ -208,6 +208,15 @@ export function HostSwitcher({ picker }: { readonly picker?: HostPickerContext }
   const currentOrigin = (inPicker ? picker.at : null) ?? location.origin;
   const currentIsLoopback = isLoopbackOrigin(currentOrigin);
   /**
+   * 집을 떠나 있는가. 셸이 말한 집과 지금 서 있는 콘솔이 다르면 그렇다.
+   *
+   * 주소 모양은 이 질문에 답하지 못한다. WSL 안의 콘솔은 `127.0.0.1`로 열리지만 그 콘솔이
+   * 도는 곳은 이 기계의 콘솔을 원리적으로 찾지 못하는 다른 기계다 — 루프백이라는 사실은
+   * 같은 기계라는 뜻이 아니다. 셸은 창을 옮길 때마다 집 주소를 게시하므로, 그 값과의 비교
+   * 하나가 원격·WSL·이웃 콘솔을 한 규칙으로 가른다.
+   */
+  const awayFromHome = homeOrigin !== null && currentOrigin !== homeOrigin;
+  /**
    * "이 컴퓨터"에 실릴 수 있는 것은 이 창이 실제로 닿을 수 있는 콘솔뿐이다.
    *
    * 스캔은 루프백 리스너에서만 답하므로, 원격 콘솔을 보고 있으면 비어 있다. 그때 돌아갈 곳을
@@ -218,6 +227,9 @@ export function HostSwitcher({ picker }: { readonly picker?: HostPickerContext }
    * 때문이다. 스캔은 정규 슬롯 두 곳만 보므로 데이터 루트를 재지정한 콘솔(격리 실행 등)은
    * 설계상 자기 목록에도 잡히지 않는다. 그 추정을 그대로 두면 집이 살아 있는데도 집 줄이
    * 사라지고, 원격에서 펼친 목록에는 돌아갈 길이 아예 남지 않는다.
+   *
+   * 이 추정이 서는 곳은 이 콘솔이 직접 그리는 판뿐이다. 셸이 창을 들고 있으면 목록은 집이
+   * 그리므로(아래 `pickerHome`), 이 스캔이 무엇을 못 봤는지는 그 동선을 가로막지 못한다.
    */
   const homeIsLive = homeOrigin !== null
     && (homeOrigin === location.origin || local.length === 0 || local.some((entry) => entry.origin === homeOrigin));
@@ -236,22 +248,35 @@ export function HostSwitcher({ picker }: { readonly picker?: HostPickerContext }
   /**
    * 지금 서 있는 콘솔의 이름은 한 번만 정한다 — 칩과 목록이 서로 다른 규칙으로 지으면
    * 같은 콘솔이 두 이름으로 보인다. 사용자가 고쳐 부른 이름이 있으면 그것이 우선이다.
+   *
+   * 집이 펼친 목록에서는 이 화면의 이름도 주소도 빌려 오지 않는다. 거기서 도는 콘솔은 집이라,
+   * 그 이름을 손님 줄에 붙이면 집과 손님이 같은 이름으로 읽힌다. 사용자가 지어 준 이름이 없으면
+   * 비워 두고 각 줄이 자기 폴백을 쓰게 한다 — 주소는 이미 그 줄의 상세가 말한다.
    */
-  const currentLabel = savedCurrent?.label || state.consoleName || location.host;
-  // 이 컴퓨터의 콘솔에 서 있으면 어느 콘솔인지가 아니라 "여기"라는 사실만 말한다.
+  const currentLabel = savedCurrent?.label || (inPicker ? "" : state.consoleName || currentHost(currentOrigin));
+  /**
+   * 집에 서 있을 때만 "여기"라고 말한다. 집을 떠나 있으면 어느 콘솔인지가 답이다 — 칩을
+   * 누르면 집의 목록이 펼쳐지므로, 칩까지 "여기"라고 하면 어디에 서 있었는지가 사라진다.
+   * 셸이 없어 집을 모를 때만 스캔에 든 사실로 대신한다.
+   */
+  const standingAtHome = homeOrigin === null ? nearbyCurrent : currentOrigin === homeOrigin;
   const chipLabel = state.controlHolder !== null
     ? t("chrome.control.shared")
-    : nearbyCurrent
+    : standingAtHome
       ? t("chrome.hosts.local")
       : currentLabel;
 
   /**
-   * 원격 콘솔에서 칩을 누르면 이 콘솔의 목록을 펴는 대신 집에게 목록을 펴 달라고 한다.
+   * 집을 떠나 있을 때 칩을 누르면 이 콘솔의 목록을 펴는 대신 집에게 목록을 펴 달라고 한다.
    * 셸이 그 항해를 가로채 집의 화면을 이 위에 얹으므로, 이 콘솔은 남의 기계 주소를 받지 않는다.
+   *
+   * 목적지는 `home`이 아니라 셸이 말한 값 그대로다. `home`은 이 콘솔의 스캔이 확인해 준 집이고,
+   * WSL처럼 스캔이 닿지 못하는 곳에서는 비어 있다 — 그 침묵이 돌아가는 길까지 지워서는 안 된다.
    */
-  const pickerHome = !inPicker && canOpenRemote && !currentIsLoopback && home !== null ? home : null;
+  const pickerHome = !inPicker && canOpenRemote && awayFromHome ? homeOrigin : null;
 
-  if (!inPicker && nearby.length === 0 && hosts.length === 0) return null;
+  // 집을 떠나 있으면 목록이 비어 보여도 칩은 남는다 — 그 칩이 돌아가는 유일한 문이다.
+  if (!inPicker && pickerHome === null && nearby.length === 0 && hosts.length === 0) return null;
   const openSettings = () => {
     // 관리는 집의 설정 화면에서 한다. 덮개는 목록만 들고 있으므로 창째로 집에 보낸다.
     if (inPicker) {
@@ -337,7 +362,7 @@ export function HostSwitcher({ picker }: { readonly picker?: HostPickerContext }
           {!nearbyCurrent && savedCurrent === null ? (
             <>
               <div className="host-switcher-divider" role="separator" />
-              <HostRow live name={currentLabel} detail={`${location.host} · ${t("chrome.hosts.notSaved")}`} current />
+              <HostRow live name={currentLabel || t("chrome.hosts.console")} detail={`${currentHost(currentOrigin)} · ${t("chrome.hosts.notSaved")}`} current />
             </>
           ) : null}
           <div className="host-switcher-divider" role="separator" />
@@ -408,6 +433,18 @@ function isLoopbackOrigin(origin: string): boolean {
     return protocol === "http:" && (hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]");
   } catch {
     return false;
+  }
+}
+
+/**
+ * 지금 서 있는 콘솔의 주소. 집이 펼친 목록에서는 이 화면을 서빙한 곳(집)이 아니라 목록을
+ * 부른 콘솔이 그 답이므로, `location.host`를 그대로 쓰면 손님 줄에 집 주소가 선다.
+ */
+function currentHost(origin: string): string {
+  try {
+    return new URL(origin).host;
+  } catch {
+    return origin;
   }
 }
 

--- a/runtime/fleet-console/core/client/src/desktop-shell.ts
+++ b/runtime/fleet-console/core/client/src/desktop-shell.ts
@@ -7,16 +7,30 @@ import { useEffect, useState } from "react";
  * 이 값은 게시한 창에만 되돌아온다. 다른 사람의 화면에 흘러가면 거기서는 그 사람의 기계를
  * 가리키기 때문이다 — 서버가 요청자를 보고 가리므로, 여기서는 한 번 읽어 오기만 한다.
  */
-export function useDesktopHomeOrigin(): string | null {
-  const [homeOrigin, setHomeOrigin] = useState<string | null>(null);
+export interface DesktopShellHome {
+  /** 셸이 게시한 집. 셸이 없거나 아직 게시하지 않았으면 null. */
+  readonly origin: string | null;
+  /** 아직 답을 받지 못했는가. */
+  readonly pending: boolean;
+}
+
+/**
+ * "아직 모른다"와 "집이 없다"는 다르다. 둘을 하나의 null로 합치면, 답이 오기 전 잠깐 동안
+ * 손님 콘솔이 자기가 집인 것처럼 보인다 — 그 사이 사용자가 칩을 누르면 남의 목록이 펼쳐진다.
+ */
+export function useDesktopHomeOrigin(): DesktopShellHome {
+  const [home, setHome] = useState<DesktopShellHome>({ origin: null, pending: true });
 
   useEffect(() => {
     const controller = new AbortController();
-    void fetchDesktopHomeOrigin(controller.signal).then(setHomeOrigin).catch(() => undefined);
+    void fetchDesktopHomeOrigin(controller.signal)
+      .then((origin) => setHome({ origin, pending: false }))
+      // 끊긴 요청은 답이 아니다 — 이 화면은 이미 사라졌거나 곧 다시 묻는다.
+      .catch(() => { if (!controller.signal.aborted) setHome({ origin: null, pending: false }); });
     return () => controller.abort();
   }, []);
 
-  return homeOrigin;
+  return home;
 }
 
 export async function fetchDesktopHomeOrigin(signal?: AbortSignal): Promise<string | null> {

--- a/runtime/fleet-console/tests/host-picker-surface.test.tsx
+++ b/runtime/fleet-console/tests/host-picker-surface.test.tsx
@@ -254,6 +254,34 @@ describe("host box on a loopback console that is not home", () => {
     expect(document.querySelector(".host-switcher-chip")!.textContent).toContain("127.0.0.1:2253");
   });
 
+  /**
+   * 집 주소는 창보다 늦게 도착할 수 있다. 그 사이 "여기"라고 말하면 손님 콘솔이 집 행세를
+   * 하고, 사용자는 그 말을 믿고 눌러 남의 목록을 편다. 모를 때는 아무 말도 하지 않는다.
+   */
+  it("does not call itself local while it has not been told where home is", async () => {
+    standOn(GUEST);
+    let tellHome = (_: Response) => {};
+    vi.stubGlobal("fetch", vi.fn(async (input: string) => {
+      const path = new URL(input, GUEST).pathname;
+      if (path === "/api/v1/desktop/shell") return new Promise<Response>((resolve) => { tellHome = resolve; });
+      if (path === "/api/v1/local-consoles") return Response.json({ consoles: [scanned(GUEST)] });
+      if (path === "/api/v1/remote-hosts") return Response.json({ hosts: [] });
+      return Response.json({ reachable: true, trusted: true });
+    }));
+
+    await mount(createElement(HostSwitcher));
+
+    // 아직 답이 오지 않았다 — 이 콘솔은 자기가 집이라고 주장하지 않는다.
+    expect(document.querySelector(".host-switcher-chip")!.textContent).not.toContain("Local");
+
+    // 그새 눌러 이 콘솔의 판이 열렸더라도, 집 주소가 도착하면 그 판은 남의 목록이므로 걷힌다.
+    await act(async () => { document.querySelector<HTMLButtonElement>(".host-switcher-chip")!.click(); });
+    await act(async () => { tellHome(Response.json({ homeOrigin: HOME })); await Promise.resolve(); });
+    await act(async () => { await Promise.resolve(); });
+
+    expect(rows()).toHaveLength(0);
+  });
+
   /** 집이 그린 판에서도 손님 줄은 손님의 이름을 달아야 한다. */
   it("does not lend the serving console's own name to the guest row", async () => {
     stubHomeConsole([scanned(HOME), { origin: GUEST, version: "1.52.0", owner: "cli", distro: "Ubuntu-26.04" }]);

--- a/runtime/fleet-console/tests/host-picker-surface.test.tsx
+++ b/runtime/fleet-console/tests/host-picker-surface.test.tsx
@@ -276,10 +276,18 @@ describe("host box on a loopback console that is not home", () => {
 
     // 그새 눌러 이 콘솔의 판이 열렸더라도, 집 주소가 도착하면 그 판은 남의 목록이므로 걷힌다.
     await act(async () => { document.querySelector<HTMLButtonElement>(".host-switcher-chip")!.click(); });
+    expect(assign).not.toHaveBeenCalled();
+
     await act(async () => { tellHome(Response.json({ homeOrigin: HOME })); await Promise.resolve(); });
     await act(async () => { await Promise.resolve(); });
 
     expect(rows()).toHaveLength(0);
+    // 누름은 사라지지 않는다 — 뜻대로 집의 목록을 청한다.
+    expect(assign).toHaveBeenCalledOnce();
+    const url = new URL(assign.mock.calls[0]![0] as string);
+    expect(url.origin).toBe(HOME);
+    expect(url.searchParams.get("desktop-surface")).toBe("host-picker");
+    expect(url.searchParams.get("at")).toBe(GUEST);
   });
 
   /** 집이 그린 판에서도 손님 줄은 손님의 이름을 달아야 한다. */

--- a/runtime/fleet-console/tests/host-picker-surface.test.tsx
+++ b/runtime/fleet-console/tests/host-picker-surface.test.tsx
@@ -222,11 +222,60 @@ describe("the list home unfolds", () => {
 });
 
 /**
- * 스캔이 답했는데 그 안에 집이 없다는 사실은, 이 화면을 집이 아닌 콘솔이 서빙했을 때에만
- * 사망의 증거가 된다 — 그 판정은 위 완화 뒤에도 그대로 남아야 한다.
+ * WSL 안의 콘솔은 `127.0.0.1`로 열리지만 그 콘솔이 도는 곳은 Windows 쪽을 볼 수 없는 다른
+ * 기계다 — 그쪽 스캔은 이 기계의 콘솔을 원리적으로 찾지 못한다. 주소 모양에는 그 경계가
+ * 드러나지 않으므로, 집인지 아닌지는 셸이 말한 집 주소와의 비교만이 답한다.
+ */
+describe("host box on a loopback console that is not home", () => {
+  const GUEST = "http://127.0.0.1:2253";
+
+  it("asks home to unfold its list instead of opening this console's", async () => {
+    stubLoopbackConsole(GUEST, [scanned(GUEST)]);
+
+    await mount(createElement(HostSwitcher));
+    await act(async () => { document.querySelector<HTMLButtonElement>(".host-switcher-chip")!.click(); });
+
+    expect(assign).toHaveBeenCalledOnce();
+    const url = new URL(assign.mock.calls[0]![0] as string);
+    expect(url.origin).toBe(HOME);
+    expect(url.pathname).toBe("/console/");
+    expect(url.searchParams.get("desktop-surface")).toBe("host-picker");
+    expect(url.searchParams.get("at")).toBe(GUEST);
+    // 이 콘솔의 판은 열리지 않는다 — 목록은 집의 것이다.
+    expect(rows()).toHaveLength(0);
+  });
+
+  /** 칩이 "여기"라고 말하면 집을 떠나 있다는 사실이 사라진다. */
+  it("names the console it is standing on instead of calling it local", async () => {
+    stubLoopbackConsole(GUEST, [scanned(GUEST)]);
+
+    await mount(createElement(HostSwitcher));
+
+    expect(document.querySelector(".host-switcher-chip")!.textContent).toContain("127.0.0.1:2253");
+  });
+
+  /** 집이 그린 판에서도 손님 줄은 손님의 이름을 달아야 한다. */
+  it("does not lend the serving console's own name to the guest row", async () => {
+    stubHomeConsole([scanned(HOME), { origin: GUEST, version: "1.52.0", owner: "cli", distro: "Ubuntu-26.04" }]);
+
+    await mount(createElement(HostPickerScreen, { surface: { at: GUEST } }));
+
+    const current = rows().find((row) => row.getAttribute("aria-checked") === "true");
+    expect(current?.textContent).toContain("Ubuntu-26.04");
+    expect(current?.textContent).not.toContain(new URL(HOME).host);
+    // 이름을 지어 준 적이 없으면 그 줄은 자기 폴백을 쓴다 — 주소는 상세가 이미 말한다.
+    expect(current?.textContent).toContain("Fleet Console");
+  });
+});
+
+/**
+ * 스캔이 답했는데 그 안에 집이 없다는 사실은, 셸이 끼어들지 않은 화면에서만 사망의 증거가
+ * 된다 — 그 판정은 위 완화 뒤에도 그대로 남아야 한다. 셸이 창을 들고 있으면 목록을 그리는
+ * 쪽이 집이므로, 이 콘솔의 스캔이 무엇을 못 봤는지는 그 동선을 가로막지 못한다.
  */
 describe("a home the scan disproves", () => {
   it("does not stand a row on a console that is not home", async () => {
+    delete document.documentElement.dataset.desktopShell;
     stubLoopbackConsole(NEIGHBOUR, [scanned(NEIGHBOUR)]);
 
     await mount(createElement(HostSwitcher));

--- a/runtime/fleet-desktop/src/console-handoff.ts
+++ b/runtime/fleet-desktop/src/console-handoff.ts
@@ -6,8 +6,10 @@
  * 그 물음은 빈손으로 끝나고 그 콘솔에는 돌아가는 줄이 서지 않는다. 적재가 끝난 뒤에 게시하면
  * 둘 중 무엇이 먼저인지는 그때그때 달라진다 — 돌아갈 길이 붙었다 떨어졌다 하는 이유가 그것이다.
  *
- * 게시가 실패해도 항해는 막지 않는다. 이 라우트를 모르는 옛 콘솔도 열려야 하고, 돌아갈 길
- * 하나를 지키려다 가는 길까지 막으면 사용자가 잃는 쪽이 더 크다. 실패는 로그로만 남는다.
+ * 게시가 실패해도, 그리고 끝내 답하지 않아도 항해는 막지 않는다. 이 라우트를 모르는 옛 콘솔도
+ * 열려야 하고, 돌아갈 길 하나를 지키려다 가는 길까지 막으면 사용자가 잃는 쪽이 더 크다.
+ * 거절은 catch가 받지만 **침묵은 catch가 받지 못하므로**, 기다림에는 끝이 있어야 한다 —
+ * 없으면 응답하지 않는 콘솔 하나가 창을 영영 옛 화면에 붙들어 둔다.
  */
 export interface ConsoleHandoffDeps {
   /** 이 콘솔에 "이 셸이 띄운 콘솔은 어디인가"를 알린다. 실패는 삼키고 로그로 남긴다. */
@@ -15,14 +17,31 @@ export interface ConsoleHandoffDeps {
   readonly loadUrl: (url: string) => Promise<void>;
   readonly synchronizeTheme: (origin: string) => Promise<void>;
   readonly synchronizeFullscreen: (origin: string) => void;
+  /** 게시를 기다려 주는 시간. 테스트가 실제 시계를 기다리지 않도록 갈아 끼울 수 있게 둔다. */
+  readonly waitForPublishDeadline?: (ms: number) => Promise<void>;
 }
+
+/** 루프백 한 번 왕복에 넉넉하고, 사용자가 창이 멈췄다고 느끼기에는 짧은 값. */
+const PUBLISH_DEADLINE_MS = 2_000;
 
 export async function handOffWindowToConsole(deps: ConsoleHandoffDeps, url: string): Promise<void> {
   const origin = new URL(url).origin;
-  // 게시가 실패해도 항해는 계속된다. 그 판단이 한 곳에서만 참이 되도록 여기서 막는다.
-  await deps.publishShellHome(origin).catch(() => undefined);
+  const deadline = deps.waitForPublishDeadline ?? sleep;
+  // 게시가 실패해도, 답하지 않아도 항해는 계속된다. 그 판단이 한 곳에서만 참이 되도록 여기서 막는다.
+  await Promise.race([
+    deps.publishShellHome(origin).catch(() => undefined),
+    deadline(PUBLISH_DEADLINE_MS),
+  ]);
   await deps.loadUrl(url);
   // 창이 옮겨 갔으면 타이틀바·전체화면 동기화도 그 콘솔을 따라가야 한다.
   await deps.synchronizeTheme(origin);
   deps.synchronizeFullscreen(origin);
+}
+
+/** 이 타이머 하나 때문에 앱이 종료를 미루지는 않는다. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+  });
 }

--- a/runtime/fleet-desktop/src/console-handoff.ts
+++ b/runtime/fleet-desktop/src/console-handoff.ts
@@ -1,0 +1,28 @@
+/**
+ * 창을 다른 콘솔로 넘길 때의 순서.
+ *
+ * 네 가지 일이 일어나는데 그중 하나만 순서가 계약이다: **집 주소는 창보다 먼저 가야 한다.**
+ * 도착한 화면은 뜨자마자 "돌아갈 곳"을 한 번 묻고 다시 묻지 않으므로, 창이 먼저 도착하면
+ * 그 물음은 빈손으로 끝나고 그 콘솔에는 돌아가는 줄이 서지 않는다. 적재가 끝난 뒤에 게시하면
+ * 둘 중 무엇이 먼저인지는 그때그때 달라진다 — 돌아갈 길이 붙었다 떨어졌다 하는 이유가 그것이다.
+ *
+ * 게시가 실패해도 항해는 막지 않는다. 이 라우트를 모르는 옛 콘솔도 열려야 하고, 돌아갈 길
+ * 하나를 지키려다 가는 길까지 막으면 사용자가 잃는 쪽이 더 크다. 실패는 로그로만 남는다.
+ */
+export interface ConsoleHandoffDeps {
+  /** 이 콘솔에 "이 셸이 띄운 콘솔은 어디인가"를 알린다. 실패는 삼키고 로그로 남긴다. */
+  readonly publishShellHome: (origin: string) => Promise<void>;
+  readonly loadUrl: (url: string) => Promise<void>;
+  readonly synchronizeTheme: (origin: string) => Promise<void>;
+  readonly synchronizeFullscreen: (origin: string) => void;
+}
+
+export async function handOffWindowToConsole(deps: ConsoleHandoffDeps, url: string): Promise<void> {
+  const origin = new URL(url).origin;
+  // 게시가 실패해도 항해는 계속된다. 그 판단이 한 곳에서만 참이 되도록 여기서 막는다.
+  await deps.publishShellHome(origin).catch(() => undefined);
+  await deps.loadUrl(url);
+  // 창이 옮겨 갔으면 타이틀바·전체화면 동기화도 그 콘솔을 따라가야 한다.
+  await deps.synchronizeTheme(origin);
+  deps.synchronizeFullscreen(origin);
+}

--- a/runtime/fleet-desktop/src/main.ts
+++ b/runtime/fleet-desktop/src/main.ts
@@ -8,6 +8,7 @@ import { app, BrowserWindow, dialog, Menu, Notification, session, shell, Tray, W
 import { createDesktopLifecycle } from "./app-lifecycle.js";
 import { isConsoleConflict, showConsoleConflictAndQuit } from "./console-conflict.js";
 import { createConsoleControls } from "./console-controls.js";
+import { handOffWindowToConsole } from "./console-handoff.js";
 import { createHydratedDesktopEnvironment, resolveDesktopUserDataDirectory } from "./environment.js";
 import { pushEntrySnapshot } from "./entry-page.js";
 import { applyDesktopDockIcon, applyDesktopIdentity } from "./identity.js";
@@ -130,8 +131,9 @@ async function boot(): Promise<void> {
    */
   const notifier = createDesktopNotifier(Notification, { showMessageBox: (options) => dialog.showMessageBox(options) });
   /**
-   * 창이 어느 콘솔에 있든 "이 셸이 띄운 콘솔이 어디인가"는 알려 준다. 원격 콘솔이 서빙한
-   * 화면은 자기가 떠나온 곳을 알 수 없으므로, 이것이 없으면 돌아갈 길이 사라진다.
+   * 창이 어느 콘솔에 있든 "이 셸이 띄운 콘솔이 어디인가"는 알려 준다. 집이 아닌 콘솔이 서빙한
+   * 화면은 자기가 떠나온 곳을 알 수 없으므로 — 원격이든 이 기계의 다른 콘솔이든 — 이것이 없으면
+   * 돌아갈 길이 사라진다. 이 값이 창보다 먼저 도착해야 하는 이유는 console-handoff.ts에 있다.
    */
   const publishShellHome = async (origin: string): Promise<void> => {
     const home = localConsoleOrigin;
@@ -154,14 +156,12 @@ async function boot(): Promise<void> {
     sessionFetch: (input, init) => consoleSession.fetch(input, init),
     localOrigin: () => localConsoleOrigin,
     deviceName: os.hostname().replace(/\.local$/iu, ""),
-    loadConsole: async (url) => {
-      await window?.loadURL(url);
-      // 창이 옮겨 갔으면 타이틀바·전체화면 동기화와 "돌아갈 곳"도 그 콘솔을 따라가야 한다.
-      const origin = new URL(url).origin;
-      await themeSynchronizer?.start(origin);
-      fullscreenSynchronizer?.activate(origin);
-      await publishShellHome(origin);
-    },
+    loadConsole: (url) => handOffWindowToConsole({
+      publishShellHome,
+      loadUrl: async (target) => { await window?.loadURL(target); },
+      synchronizeTheme: async (origin) => { await themeSynchronizer?.start(origin); },
+      synchronizeFullscreen: (origin) => fullscreenSynchronizer?.activate(origin),
+    }, url),
     openPicker: (url) => picker.open(url),
     closePicker: () => picker.close(),
     notify: (notice) => notifier.show(notice),

--- a/runtime/fleet-desktop/src/remote-bridge.ts
+++ b/runtime/fleet-desktop/src/remote-bridge.ts
@@ -180,9 +180,21 @@ export function createRemoteBridge(deps: RemoteBridgeDeps): RemoteBridge {
   async function openLocal(origin: string, url?: string): Promise<void> {
     const policy = deps.policy();
     if (!policy) throw new Error("remote_bridge_no_window");
-    policy.activateConsoleOrigin(origin);
     // 정해져 온 화면이 있어도 그 콘솔의 `/console/` 안이어야 한다 — 아니면 기본 화면으로 연다.
-    await deps.loadConsole(url !== undefined && consoleTarget(url, origin) === origin ? url : `${origin}${CONSOLE_PATH}`);
+    const target = url !== undefined && consoleTarget(url, origin) === origin ? url : `${origin}${CONSOLE_PATH}`;
+    /**
+     * 창이 실제로 도착한 뒤에 활성 origin을 옮긴다. 먼저 옮겨 두면 적재가 실패했을 때 정책은
+     * 새 콘솔을, 창은 옛 콘솔을 가리킨 채 갈라지고, 그 창은 자기가 보고 있는 화면 안에서조차
+     * 움직이지 못한다. 원격 경로가 이미 쓰는 예약·확정 문법을 여기서도 쓴다.
+     */
+    policy.stageConsoleOrigin(origin);
+    try {
+      await deps.loadConsole(target);
+    } catch (error) {
+      policy.cancelPendingConsoleOrigin();
+      throw error;
+    }
+    policy.commitConsoleOrigin();
   }
 
   async function receiveLink(link: string): Promise<void> {

--- a/runtime/fleet-desktop/src/remote-bridge.ts
+++ b/runtime/fleet-desktop/src/remote-bridge.ts
@@ -77,6 +77,12 @@ const PICKER_SURFACE_DISMISS = "host-picker-dismiss";
 export function createRemoteBridge(deps: RemoteBridgeDeps): RemoteBridge {
   const localFetch = deps.localFetch ?? globalThis.fetch;
   const confirmIdentity = deps.confirmIdentity ?? confirmRemoteIdentity;
+  /**
+   * 몇 번째 여는 시도인가. 예약한 origin은 정책에 한 자리뿐이라, 앞선 시도가 늦게 끝나면서
+   * 뒤에 온 시도의 예약을 확정하거나 지워 버릴 수 있다 — 그러면 정책은 창이 있지도 않은
+   * 콘솔을 가리킨다. 자기가 아직 최신인 시도만 그 자리에 손을 댄다.
+   */
+  let opening = 0;
   const attached: Array<{ readonly contents: Pick<WebContents, "on" | "removeListener">; readonly listener: (...args: never[]) => void; readonly event?: "did-navigate" }> = [];
 
   async function askLocalConsole(path: string, body: unknown): Promise<Response> {
@@ -118,6 +124,7 @@ export function createRemoteBridge(deps: RemoteBridgeDeps): RemoteBridge {
     if (!policy) throw new Error("remote_bridge_no_window");
     deps.pins.pin(handoff.hostname, handoff.fingerprint);
     policy.admitRemoteConsoleOrigin(handoff.origin);
+    const attempt = ++opening;
     policy.stageConsoleOrigin(handoff.origin);
     try {
       /**
@@ -128,9 +135,10 @@ export function createRemoteBridge(deps: RemoteBridgeDeps): RemoteBridge {
       await joinRemoteConsole(deps.sessionFetch, `${handoff.origin}${JOIN_PATH}`, handoff.token, deps.deviceName ?? null);
       await verifyConsoleReachable(handoff.origin);
       await deps.loadConsole(`${handoff.origin}${CONSOLE_PATH}`);
-      policy.commitConsoleOrigin();
+      if (attempt === opening) policy.commitConsoleOrigin();
     } catch (error) {
-      policy.cancelPendingConsoleOrigin();
+      if (attempt === opening) policy.cancelPendingConsoleOrigin();
+      // 열지 못한 원격은 최신 시도가 아니어도 허용 목록에서 빼야 한다 — 지문 대조를 통과한 적이 없다.
       policy.withdrawRemoteConsoleOrigin(handoff.origin);
       deps.pins.unpin(handoff.hostname);
       throw error;
@@ -187,14 +195,15 @@ export function createRemoteBridge(deps: RemoteBridgeDeps): RemoteBridge {
      * 새 콘솔을, 창은 옛 콘솔을 가리킨 채 갈라지고, 그 창은 자기가 보고 있는 화면 안에서조차
      * 움직이지 못한다. 원격 경로가 이미 쓰는 예약·확정 문법을 여기서도 쓴다.
      */
+    const attempt = ++opening;
     policy.stageConsoleOrigin(origin);
     try {
       await deps.loadConsole(target);
     } catch (error) {
-      policy.cancelPendingConsoleOrigin();
+      if (attempt === opening) policy.cancelPendingConsoleOrigin();
       throw error;
     }
-    policy.commitConsoleOrigin();
+    if (attempt === opening) policy.commitConsoleOrigin();
   }
 
   async function receiveLink(link: string): Promise<void> {

--- a/runtime/fleet-desktop/tests/console-handoff.test.ts
+++ b/runtime/fleet-desktop/tests/console-handoff.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { handOffWindowToConsole, type ConsoleHandoffDeps } from "../src/console-handoff.js";
+
+const TARGET = "http://127.0.0.1:2253";
+
+function createHarness(overrides: Partial<ConsoleHandoffDeps> = {}) {
+  const trace: string[] = [];
+  const deps: ConsoleHandoffDeps = {
+    publishShellHome: async (origin) => { trace.push(`publish:${origin}`); },
+    loadUrl: async (url) => { trace.push(`load:${url}`); },
+    synchronizeTheme: async (origin) => { trace.push(`theme:${origin}`); },
+    synchronizeFullscreen: (origin) => { trace.push(`fullscreen:${origin}`); },
+    ...overrides,
+  };
+  return { trace, deps };
+}
+
+describe("console handoff", () => {
+  /**
+   * 이 순서가 이 파일의 전부다. 도착한 화면은 뜨자마자 "돌아갈 곳"을 한 번 묻고 다시 묻지
+   * 않으므로, 창이 먼저 도착하면 그 콘솔에는 돌아가는 줄이 서지 않는다.
+   */
+  it("tells the console where home is before the window arrives", async () => {
+    const harness = createHarness();
+
+    await handOffWindowToConsole(harness.deps, `${TARGET}/console/`);
+
+    expect(harness.trace).toEqual([
+      `publish:${TARGET}`,
+      `load:${TARGET}/console/`,
+      `theme:${TARGET}`,
+      `fullscreen:${TARGET}`,
+    ]);
+  });
+
+  /** 이 라우트를 모르는 옛 콘솔도 열려야 한다 — 돌아갈 길 하나 때문에 가는 길을 막지 않는다. */
+  it("still opens a console that refuses the shell-home publication", async () => {
+    const harness = createHarness({
+      publishShellHome: async () => { throw new Error("HTTP 404"); },
+    });
+
+    await handOffWindowToConsole(harness.deps, `${TARGET}/console/`);
+
+    expect(harness.trace).toEqual([`load:${TARGET}/console/`, `theme:${TARGET}`, `fullscreen:${TARGET}`]);
+  });
+});

--- a/runtime/fleet-desktop/tests/console-handoff.test.ts
+++ b/runtime/fleet-desktop/tests/console-handoff.test.ts
@@ -34,6 +34,34 @@ describe("console handoff", () => {
     ]);
   });
 
+  /** 순서가 계약이라면 게시가 *끝나기* 전에 창이 떠나서는 안 된다 — 호출 순서만으로는 부족하다. */
+  it("waits for the publication to finish, not merely to start", async () => {
+    let releasePublication = () => {};
+    const harness = createHarness({
+      publishShellHome: async (origin) => {
+        harness.trace.push(`publish:start:${origin}`);
+        await new Promise<void>((resolve) => { releasePublication = resolve; });
+        harness.trace.push(`publish:done:${origin}`);
+      },
+    });
+
+    const handoff = handOffWindowToConsole(harness.deps, `${TARGET}/console/`);
+    await Promise.resolve();
+    // 게시가 매달려 있는 동안 창은 아직 떠나지 않았다.
+    expect(harness.trace).toEqual([`publish:start:${TARGET}`]);
+
+    releasePublication();
+    await handoff;
+
+    expect(harness.trace).toEqual([
+      `publish:start:${TARGET}`,
+      `publish:done:${TARGET}`,
+      `load:${TARGET}/console/`,
+      `theme:${TARGET}`,
+      `fullscreen:${TARGET}`,
+    ]);
+  });
+
   /** 이 라우트를 모르는 옛 콘솔도 열려야 한다 — 돌아갈 길 하나 때문에 가는 길을 막지 않는다. */
   it("still opens a console that refuses the shell-home publication", async () => {
     const harness = createHarness({
@@ -43,5 +71,25 @@ describe("console handoff", () => {
     await handOffWindowToConsole(harness.deps, `${TARGET}/console/`);
 
     expect(harness.trace).toEqual([`load:${TARGET}/console/`, `theme:${TARGET}`, `fullscreen:${TARGET}`]);
+  });
+
+  /**
+   * 거절은 catch가 받지만 침묵은 받지 못한다. 답하지 않는 콘솔 하나가 창을 옛 화면에 영영
+   * 붙들어 두면, 게시가 항해를 막지 않는다는 계약은 그 콘솔에서만 거짓이 된다.
+   */
+  it("stops waiting for a publication that never answers and opens anyway", async () => {
+    const harness = createHarness({
+      publishShellHome: () => new Promise<void>(() => {}),
+      waitForPublishDeadline: async (ms) => { harness.trace.push(`deadline:${ms}`); },
+    });
+
+    await handOffWindowToConsole(harness.deps, `${TARGET}/console/`);
+
+    expect(harness.trace).toEqual([
+      "deadline:2000",
+      `load:${TARGET}/console/`,
+      `theme:${TARGET}`,
+      `fullscreen:${TARGET}`,
+    ]);
   });
 });

--- a/runtime/fleet-desktop/tests/remote-bridge.test.ts
+++ b/runtime/fleet-desktop/tests/remote-bridge.test.ts
@@ -13,7 +13,7 @@ function handoff(overrides: Record<string, unknown> = {}): Response {
 }
 
 /** 무엇이 어떤 차례로 일어났는지가 이 다리의 계약이라, 호출을 한 줄로 기록해 둔다. */
-function createHarness(options: { readonly responses?: (path: string) => Response; readonly confirm?: () => Promise<void>; readonly load?: () => Promise<void>; readonly verify?: () => Response; readonly picker?: () => Promise<void> } = {}) {
+function createHarness(options: { readonly responses?: (path: string) => Response; readonly confirm?: () => Promise<void>; readonly load?: (url: string) => Promise<void>; readonly verify?: () => Response; readonly picker?: () => Promise<void> } = {}) {
   const trace: string[] = [];
   const requests: Array<{ url: string; init: RequestInit }> = [];
   const notices: Array<{ title: string; body: string }> = [];
@@ -57,7 +57,7 @@ function createHarness(options: { readonly responses?: (path: string) => Respons
     localOrigin: () => LOCAL,
     loadConsole: async (url) => {
       trace.push(`load:${url}`);
-      if (options.load) await options.load();
+      if (options.load) await options.load(url);
     },
     openPicker: async (url: string) => {
       trace.push(`picker:open:${url}`);
@@ -300,6 +300,41 @@ describe("remote bridge", () => {
 
     // 핀도 자격도 거치지 않는다 — 같은 기계이므로 확인만으로 충분하다.
     expect(harness.trace).toEqual(["ask:/api/v1/local-consoles", `stage:${DISCOVERED}`, `load:${DISCOVERED}/console/`, "commit"]);
+  });
+
+  /**
+   * 예약 자리는 정책에 하나뿐이다. 앞선 시도가 늦게 끝나면서 뒤에 온 시도의 예약을 확정하면,
+   * 정책은 창이 가 있지도 않은 콘솔을 가리킨 채 남는다 — 그 창은 눈앞의 화면에서 움직이지 못한다.
+   */
+  it("does not let a slower open commit the origin a newer one staged", async () => {
+    const FIRST = "http://127.0.0.1:50001";
+    const SECOND = "http://127.0.0.1:50002";
+    const gates = new Map<string, () => void>();
+    const harness = createHarness({
+      responses: (path) => (path === "/api/v1/local-consoles"
+        ? Response.json({
+          consoles: [
+            { origin: FIRST, version: "1.52.0", owner: "cli", distro: null },
+            { origin: SECOND, version: "1.52.0", owner: "cli", distro: null },
+          ],
+        })
+        : handoff()),
+      load: (url) => new Promise<void>((resolve) => { gates.set(url, resolve); }),
+    });
+
+    const first = harness.bridge.open(FIRST);
+    await vi.waitFor(() => expect(gates.has(`${FIRST}/console/`)).toBe(true));
+    const second = harness.bridge.open(SECOND);
+    await vi.waitFor(() => expect(gates.has(`${SECOND}/console/`)).toBe(true));
+
+    // 먼저 시작한 쪽이 늦게 끝난다.
+    gates.get(`${FIRST}/console/`)!();
+    await first;
+    gates.get(`${SECOND}/console/`)!();
+    await second;
+
+    expect(harness.trace.filter((entry) => entry === "commit")).toHaveLength(1);
+    expect(harness.currentOrigin()).toBe(SECOND);
   });
 
   /**

--- a/runtime/fleet-desktop/tests/remote-bridge.test.ts
+++ b/runtime/fleet-desktop/tests/remote-bridge.test.ts
@@ -19,12 +19,14 @@ function createHarness(options: { readonly responses?: (path: string) => Respons
   const notices: Array<{ title: string; body: string }> = [];
   let current: string | null = LOCAL;
 
+  let pending: string | null = null;
   const policy = {
-    activateConsoleOrigin: (origin: string) => { trace.push(`activate:${origin}`); current = origin; },
+    activateConsoleOrigin: (origin: string) => { trace.push(`activate:${origin}`); current = origin; pending = null; },
     currentConsoleOrigin: () => current,
-    stageConsoleOrigin: (origin: string) => trace.push(`stage:${origin}`),
-    commitConsoleOrigin: () => { trace.push("commit"); },
-    cancelPendingConsoleOrigin: () => trace.push("cancel"),
+    // 실제 정책과 같은 의미론으로 둔다 — 확정 전까지 활성 origin은 옛 콘솔 그대로다.
+    stageConsoleOrigin: (origin: string) => { trace.push(`stage:${origin}`); pending = origin; },
+    commitConsoleOrigin: () => { trace.push("commit"); if (pending !== null) current = pending; pending = null; },
+    cancelPendingConsoleOrigin: () => { trace.push("cancel"); pending = null; },
     admitRemoteConsoleOrigin: (origin: string) => trace.push(`admit:${origin}`),
     withdrawRemoteConsoleOrigin: (origin: string) => trace.push(`withdraw:${origin}`),
   };
@@ -66,7 +68,15 @@ function createHarness(options: { readonly responses?: (path: string) => Respons
     confirmIdentity: options.confirm ?? (async () => { trace.push("confirm"); }),
   });
 
-  return { bridge, trace, requests, notices, sessionFetch, setCurrent: (origin: string | null) => { current = origin; } };
+  return {
+    bridge,
+    trace,
+    requests,
+    notices,
+    sessionFetch,
+    currentOrigin: () => current,
+    setCurrent: (origin: string | null) => { current = origin; },
+  };
 }
 
 describe("console target", () => {
@@ -247,9 +257,23 @@ describe("remote bridge", () => {
 
     await harness.bridge.open(LOCAL);
 
-    expect(harness.trace).toEqual([`activate:${LOCAL}`, `load:${LOCAL}/console/`]);
+    expect(harness.trace).toEqual([`stage:${LOCAL}`, `load:${LOCAL}/console/`, "commit"]);
     expect(harness.requests).toEqual([]);
     expect(harness.sessionFetch).not.toHaveBeenCalled();
+  });
+
+  /**
+   * 적재가 실패했는데 활성 origin만 옮겨 두면, 정책은 새 콘솔을 창은 옛 콘솔을 가리킨 채
+   * 갈라진다 — 그 창은 눈앞의 화면 안에서조차 항해하지 못한다.
+   */
+  it("leaves the window on the console it can still see when the load fails", async () => {
+    const harness = createHarness({ load: async () => { throw new Error("ERR_CONNECTION_REFUSED"); } });
+    harness.setCurrent(REMOTE);
+
+    await expect(harness.bridge.open(LOCAL)).rejects.toThrow("ERR_CONNECTION_REFUSED");
+
+    expect(harness.trace).toEqual([`stage:${LOCAL}`, `load:${LOCAL}/console/`, "cancel"]);
+    expect(harness.currentOrigin()).toBe(REMOTE);
   });
 
   it("intercepts the way home, which the window policy would otherwise block", () => {
@@ -275,7 +299,25 @@ describe("remote bridge", () => {
     await harness.bridge.open(DISCOVERED);
 
     // 핀도 자격도 거치지 않는다 — 같은 기계이므로 확인만으로 충분하다.
-    expect(harness.trace).toEqual(["ask:/api/v1/local-consoles", `activate:${DISCOVERED}`, `load:${DISCOVERED}/console/`]);
+    expect(harness.trace).toEqual(["ask:/api/v1/local-consoles", `stage:${DISCOVERED}`, `load:${DISCOVERED}/console/`, "commit"]);
+  });
+
+  /**
+   * WSL 안의 콘솔은 루프백 주소로 열리지만 집이 아니다. 그 화면에서 목록을 펴 달라는 신호는
+   * 원격에서 온 것과 똑같이 가로채여 덮개로 가야 한다 — 창째로 집에 돌아가 버리면 사용자는
+   * 보고 있던 콘솔을 잃는다.
+   */
+  it("overlays home's list when the signal comes from a loopback console that is not home", () => {
+    const contents = new EventEmitter();
+    const harness = createHarness();
+    harness.bridge.attach(contents as never);
+    harness.setCurrent("http://127.0.0.1:2253");
+
+    const event = { preventDefault: vi.fn() };
+    contents.emit("will-navigate", event, `${LOCAL}/console/?desktop-surface=host-picker&at=${encodeURIComponent("http://127.0.0.1:2253")}`, false, true);
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(harness.trace).toEqual([`picker:open:${LOCAL}/console/?desktop-surface=host-picker&at=${encodeURIComponent("http://127.0.0.1:2253")}`]);
   });
 
   /**


### PR DESCRIPTION
## Summary

- 호스트 박스가 **주소 모양**으로 "여기가 내 기계인가"를 판정하고 있었습니다. WSL 배포판 안의 콘솔은 `127.0.0.1`로 열리지만 그 콘솔의 스캔은 Windows 쪽을 원리적으로 볼 수 없는 다른 기계라, ① 그 콘솔의 스캔에 집이 없다는 사실이 "집이 죽었다"로 읽혀 집 줄이 사라지고 ② 루프백이라는 이유로 원격에서 이미 동작하던 "집이 목록을 펼친다"(#600) 동선이 아예 발동하지 않았습니다. 둘이 겹쳐 창에 돌아갈 길이 남지 않았습니다.
- 이제 **셸이 게시한 집 주소와의 비교** 하나가 원격·WSL·이웃 콘솔을 한 규칙으로 가릅니다. 집이 아니면 목록은 집이 그립니다. 피커의 목적지는 스캔이 확인해 준 값이 아니라 셸이 말한 값이라, 스캔의 침묵이 돌아갈 길을 지우지 못합니다. 칩도 집에 서 있을 때만 "Local"이라고 말합니다.
- Desktop은 집 주소를 창보다 **먼저** 게시합니다. 도착한 화면은 한 번 묻고 다시 묻지 않으므로, 뒤에 게시하면 돌아갈 길이 경합 결과에 따라 붙었다 떨어졌다 했습니다. 게시 실패는 여전히 항해를 막지 않습니다(그 라우트를 모르는 옛 콘솔도 열려야 합니다).
- 서버 DTO·라우트·WSL 프로세스 검출은 **의도적으로 추가하지 않았습니다**. 그 대안은 영구 버전-스큐 매트릭스와 "구 Console + 신 Desktop = WSL 진입 거부"라는 새 차단을 대가로 요구했습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console test` — 1827 passed (기준선 1823 + 신규 4)
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` / `build` — clean
- [x] `pnpm --filter @dotobokuri/fleet-desktop test` — 274 passed (기준선 267 + 신규 7)
- [x] `pnpm --filter @dotobokuri/fleet-desktop typecheck` / `build` — clean
- [x] 신규 회귀 테스트 3건은 각 수정을 되돌리면 실제로 실패함을 확인(vacuous 아님)
- [x] 격리 콘솔 2대로 실측: 손님 콘솔 칩이 콘솔 이름 → 클릭 시 `<home>/console/?desktop-surface=host-picker&at=<guest>` 도달 → 집이 그린 목록에 관리형 콘솔·현재 손님·발견된 콘솔 3행 → 집 행 클릭 시 복귀하며 칩이 `Local`로
- [x] 서버 계약 실측: Origin 없는 PUT `401`, 콘솔 자기 Origin PUT `204`, GET이 게시값 반환
- [ ] 실제 Windows + WSL2 + 패키징된 Desktop, 그리고 Electron `WebContentsView` 덮개 합성 — macOS에서는 확인 불가