### PR TITLE
feat(fleet-console): launch Fable with 1M context

### DIFF
--- a/.changelog.d/fable-default-1m.md
+++ b/.changelog.d/fable-default-1m.md
@@ -1,0 +1,8 @@
+---
+branch: fable-default-1m
+---
+
+### fleet-console
+#### Changed
+- Launch Fable with Claude Code's 1M context coordinate while keeping the existing Fable labels.
+  ko: 기존 Fable 표시 이름을 유지하면서 Claude Code의 1M 컨텍스트 좌표로 Fable을 실행합니다.

--- a/packages/core-agent/src/claude/sdk.ts
+++ b/packages/core-agent/src/claude/sdk.ts
@@ -28,7 +28,7 @@ import { runVendorQuery } from "./vendor-sdk.js";
  * 것을 실측했다.
  */
 /** 자식이 스스로 구체 id로 푸는 vendor 모델 별칭. */
-const NATIVE_MODEL_ALIASES = new Set(["sonnet", "opus", "haiku", "fable"]);
+const NATIVE_MODEL_ALIASES = new Set(["sonnet", "opus", "haiku", "fable", "fable[1m]"]);
 
 type AcceptedModel =
   | { readonly kind: "catalog"; readonly id: string; readonly model: GatewayModel }

--- a/packages/core-agent/tests/claude-sdk.test.ts
+++ b/packages/core-agent/tests/claude-sdk.test.ts
@@ -26,6 +26,7 @@ const { createClaudeGatewaySdk } = await import("../src/claude/sdk.js");
 const BASE_URL = "http://127.0.0.1:43210/plugins/terminal/ai-gateway";
 const LUNA = "claude-gateway--codex--gpt-5.6-luna-fast[1m]";
 const SOL = "claude-gateway--codex--gpt-5.6-sol-fast[1m]";
+const FABLE_1M = "fable[1m]";
 
 async function drain(run: AsyncIterable<unknown>): Promise<void> {
   for await (const _ of run) { /* 스트림을 끝까지 읽어 실행 슬롯을 돌려준다 */ }
@@ -56,6 +57,13 @@ describe("construction", () => {
     const aliased = await createClaudeGatewaySdk({ baseUrl: BASE_URL, models: ["sonnet"] });
     expect(aliased.models).toEqual(["sonnet"]);
     await aliased.dispose();
+
+    const fable = await createClaudeGatewaySdk({ baseUrl: BASE_URL, models: [FABLE_1M] });
+    expect(fable.models).toEqual([FABLE_1M]);
+    await drain(await fable.startTurn({ prompt: "hi", model: FABLE_1M }));
+    const options = runVendorQuery.mock.calls[0]?.[0].options as Record<string, unknown>;
+    expect(options.model).toBe(FABLE_1M);
+    await fable.dispose();
   });
 
   it("owns an isolated config directory", async () => {

--- a/packages/fleet-admiral/src/agent-cli/claude/definitions.ts
+++ b/packages/fleet-admiral/src/agent-cli/claude/definitions.ts
@@ -1,15 +1,16 @@
 import { createClaudeFamilyCliDefinition } from "./factory.js";
 
-// Claude Code's bare `opus` alias is the default context window. Console's Opus
-// row launches the 1M coordinate (`opus[1m]`) while the menu label stays "Opus".
-export const NATIVE_CLAUDE_MODEL_ALIASES = ["fable", "opus[1m]", "sonnet"] as const;
+// Claude Code's bare `fable` and `opus` aliases use their default context windows.
+// Console launches their 1M coordinates while keeping the plain menu labels.
+export const NATIVE_CLAUDE_MODEL_ALIASES = ["fable[1m]", "opus[1m]", "sonnet"] as const;
 export const NATIVE_CLAUDE_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
 
 const NATIVE_CLAUDE_MODEL_ALIAS_REWRITES = {
+  fable: "fable[1m]",
   opus: "opus[1m]",
 } as const satisfies Readonly<Record<string, (typeof NATIVE_CLAUDE_MODEL_ALIASES)[number]>>;
 
-/** Resolve a Console-native Claude Code model alias, rewriting legacy `opus` to `opus[1m]`. */
+/** Resolve a Console-native Claude Code model alias, rewriting legacy bare aliases to 1M coordinates. */
 export function resolveNativeClaudeModelAlias(
   model: string,
 ): (typeof NATIVE_CLAUDE_MODEL_ALIASES)[number] | undefined {

--- a/packages/fleet-admiral/tests/native-claude-model-alias.test.ts
+++ b/packages/fleet-admiral/tests/native-claude-model-alias.test.ts
@@ -7,13 +7,14 @@ import {
 
 describe("resolveNativeClaudeModelAlias", () => {
   it("keeps the Console-native Claude aliases as Claude Code launch ids", () => {
-    expect(NATIVE_CLAUDE_MODEL_ALIASES).toEqual(["fable", "opus[1m]", "sonnet"]);
-    expect(resolveNativeClaudeModelAlias("fable")).toBe("fable");
+    expect(NATIVE_CLAUDE_MODEL_ALIASES).toEqual(["fable[1m]", "opus[1m]", "sonnet"]);
+    expect(resolveNativeClaudeModelAlias("fable[1m]")).toBe("fable[1m]");
     expect(resolveNativeClaudeModelAlias("opus[1m]")).toBe("opus[1m]");
     expect(resolveNativeClaudeModelAlias("sonnet")).toBe("sonnet");
   });
 
-  it("rewrites the bare opus menu alias onto Claude Code's 1M coordinate", () => {
+  it("rewrites bare menu aliases onto Claude Code's 1M coordinates", () => {
+    expect(resolveNativeClaudeModelAlias("fable")).toBe("fable[1m]");
     expect(resolveNativeClaudeModelAlias("opus")).toBe("opus[1m]");
   });
 

--- a/runtime/fleet-console/core/client/src/codex/cowork-controller.ts
+++ b/runtime/fleet-console/core/client/src/codex/cowork-controller.ts
@@ -393,6 +393,7 @@ export function mountCoworkInline(options: MountCoworkInlineOptions): CoworkCont
   // ── 세션 수명주기 ───────────────────────────────────────────────────────────
 
   const updateOptions = async () => {
+    settings = { ...settings, model: normalizeRememberedModel(settings.model) };
     optionsDto = await fetchCoworkOptions(options.theaterId, settings.model || undefined);
     // 저장값이 무효하면 제품 기본값(sonnet/low)을 우선 채택한다.
     const fallbackModel = optionsDto.defaultModel && optionsDto.models.includes(optionsDto.defaultModel) ? optionsDto.defaultModel : optionsDto.models[0] ?? "";
@@ -811,5 +812,15 @@ function clip(value: string, max: number): string { return value.length > max ? 
 function annotationId(): string { return typeof crypto?.randomUUID === "function" ? crypto.randomUUID() : `annotation-${Date.now()}-${Math.random().toString(16).slice(2)}`; }
 // 저장돼 있던 `cli`는 읽지 않는다 — Cowork가 Agent CLI를 고르지 않게 되면서 의미가 사라졌다.
 // 옛 값이 남아 있어도 무시될 뿐이라 마이그레이션이 필요 없다.
-function readSettings(): Settings { try { const saved = JSON.parse(localStorage.getItem(SETTINGS_KEY) ?? "{}"); return { model: typeof saved.model === "string" ? saved.model : "", effort: typeof saved.effort === "string" ? saved.effort : "low" }; } catch { return { model: "", effort: "low" }; } }
+function normalizeRememberedModel(model: string): string {
+  return model === "fable" ? "fable[1m]" : model;
+}
+function readSettings(): Settings {
+  try {
+    const saved = JSON.parse(localStorage.getItem(SETTINGS_KEY) ?? "{}");
+    const settings = { model: typeof saved.model === "string" ? normalizeRememberedModel(saved.model) : "", effort: typeof saved.effort === "string" ? saved.effort : "low" };
+    if (settings.model !== saved.model) saveSettings(settings);
+    return settings;
+  } catch { return { model: "", effort: "low" }; }
+}
 function saveSettings(settings: Settings): void { try { localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings)); } catch { /* Storage is optional. */ } }

--- a/runtime/fleet-console/core/client/src/quick-launch-preferences.ts
+++ b/runtime/fleet-console/core/client/src/quick-launch-preferences.ts
@@ -30,8 +30,8 @@ export function readQuickLaunchSelection(): QuickLaunchSelection {
       model: migrateRememberedModel(readNonEmptyString(parsed.model)),
       effort: readNonEmptyString(parsed.effort),
     };
-    // Canvas/Quick Launch Opus now launches as `opus[1m]`. Rewrite a leftover bare
-    // `opus` once so a reopen does not restore a retired catalog id into React state.
+    // Canvas/Quick Launch native models now launch on their 1M coordinates. Rewrite a leftover bare
+    // selection once so a reopen does not restore a retired catalog id into React state.
     if (selection.model !== readNonEmptyString(parsed.model)) {
       writeQuickLaunchSelection(selection);
     }
@@ -42,9 +42,11 @@ export function readQuickLaunchSelection(): QuickLaunchSelection {
   }
 }
 
-/** Bare `opus` was the pre-1M menu id; keep the same Opus row under `opus[1m]`. */
+/** Bare native model ids were the pre-1M menu ids; keep their rows under the 1M coordinates. */
 function migrateRememberedModel(model: string | null): string | null {
-  return model === "opus" ? "opus[1m]" : model;
+  if (model === "opus") return "opus[1m]";
+  if (model === "fable") return "fable[1m]";
+  return model;
 }
 
 export function writeQuickLaunchSelection(selection: QuickLaunchSelection): void {

--- a/runtime/fleet-console/core/client/src/quick-launch.ts
+++ b/runtime/fleet-console/core/client/src/quick-launch.ts
@@ -49,13 +49,14 @@ export function findVariantLaunchKind(catalog: readonly OperationCatalogPlugin[]
 }
 
 /**
- * Canvas/Quick Launch 메뉴의 Opus 행은 Claude Code `opus[1m]`을 쓴다. 업그레이드 전
- * `fleet-console.quickLaunch.selection`에 남은 bare `opus`는 같은 행으로 이어 붙인다 —
- * 브라우저 코드는 fleet-admiral를 끌어올 수 없어 서버의 resolveNativeClaudeModelAlias와
- * 같은 한 줄만 복제한다.
+ * Canvas/Quick Launch 메뉴의 Opus/Fable 행은 Claude Code의 1M 좌표를 쓴다. 업그레이드 전
+ * 저장된 bare native selection은 같은 행으로 이어 붙인다 — 브라우저 코드는 fleet-admiral를 끌어올 수
+ * 없어 서버의 resolveNativeClaudeModelAlias와 같은 작은 정규화만 복제한다.
  */
 function normalizeRememberedNativeModel(model: string): string {
-  return model === "opus" ? "opus[1m]" : model;
+  if (model === "opus") return "opus[1m]";
+  if (model === "fable") return "fable[1m]";
+  return model;
 }
 
 /**

--- a/runtime/fleet-console/tests/codex-cowork-ui.test.ts
+++ b/runtime/fleet-console/tests/codex-cowork-ui.test.ts
@@ -106,6 +106,22 @@ describe("Cowork inline copilot", () => {
     article.remove();
   });
 
+  it("migrates a stored bare Fable setting before roster matching", async () => {
+    localStorage.setItem("fleet.codex.cowork.settings", JSON.stringify({ model: "fable", effort: "max" }));
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/options")) return new Response(JSON.stringify({ models: ["fable[1m]"], efforts: ["max"] }));
+      return new Response(JSON.stringify({ error: "cowork_session_not_found" }), { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { article, body } = host();
+    const controller = mountCoworkInline({ theaterId: "theater", entryId: "entry", title: "Entry", article, body, onApplied: vi.fn() });
+    await vi.waitFor(() => expect(fetchMock.mock.calls.some(([input]) => String(input).includes("model=fable%5B1m%5D"))).toBe(true));
+    expect(JSON.parse(localStorage.getItem("fleet.codex.cowork.settings")!)).toMatchObject({ model: "fable[1m]" });
+    controller.destroy();
+    article.remove();
+  });
+
   it("shows the dock immediately and defers session creation until the first send", async () => {
     const listeners = new Map<string, EventListener>();
     class FakeEventSource { addEventListener(type: string, listener: EventListener) { listeners.set(type, listener); } close() {} }

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -206,7 +206,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
       sessionId: "gateway-scoped-row",
     });
 
-    expect(native.args).toEqual(["--model", "fable", "--effort", "max"]);
+    expect(native.args).toEqual(["--model", "fable[1m]", "--effort", "max"]);
     expect(scoped.args).toEqual([
       "--model",
       "claude-gateway--cursor--claude-opus-5[1m]",

--- a/runtime/fleet-console/tests/quick-launch.test.ts
+++ b/runtime/fleet-console/tests/quick-launch.test.ts
@@ -24,10 +24,10 @@ const GROUPS: readonly OperationLaunchVariantGroup[] = [
       {
         id: "fable",
         label: "Fable",
-        launch: { model: "fable" },
+        launch: { model: "fable[1m]" },
         chips: [
-          { id: "fable-low", label: "LOW", launch: { model: "fable", effort: "low" } },
-          { id: "fable-max", label: "MAX", launch: { model: "fable", effort: "max" } },
+          { id: "fable-low", label: "LOW", launch: { model: "fable[1m]", effort: "low" } },
+          { id: "fable-max", label: "MAX", launch: { model: "fable[1m]", effort: "max" } },
         ],
       },
       {
@@ -74,7 +74,7 @@ describe("findVariantLaunchKind", () => {
 describe("resolveSelection", () => {
   it("restores a remembered model and effort", () => {
     expect(resolveSelection(GROUPS, { model: "fable", effort: "max" })).toEqual({
-      model: "fable",
+      model: "fable[1m]",
       effort: "max",
       modelLabel: "Fable",
       effortLabel: "MAX",
@@ -120,7 +120,13 @@ describe("resolveSelection", () => {
     });
   });
 
-  it("rewrites a saved bare opus selection onto the 1M coordinate", () => {
+  it("rewrites saved bare native selections onto 1M coordinates", () => {
+    expect(resolveSelection(GROUPS, { model: "fable", effort: "max" })).toEqual({
+      model: "fable[1m]",
+      effort: "max",
+      modelLabel: "Fable",
+      effortLabel: "MAX",
+    });
     expect(resolveSelection(GROUPS, { model: "opus", effort: "high" })).toEqual({
       model: "opus[1m]",
       effort: "high",

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-store.test.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-store.test.ts
@@ -151,6 +151,33 @@ describe("per-operation analysis store", () => {
     await vi.waitFor(() => expect(harness.fetch.mock.calls.some((call) => call[1] === "analysis/operation-store-share/stop")).toBe(true));
   });
 
+  it("migrates a persisted bare Fable selection before catalog hydration", async () => {
+    const catalogBody = JSON.stringify({ clis: [{ cliId: "claude-gateway", label: "AI Gateway", available: true, defaultModel: "sonnet", models: [
+      { id: "sonnet", label: "Claude Sonnet", effortLevels: ["low"], defaultEffort: "low" },
+      { id: "fable[1m]", label: "Claude Fable", effortLevels: ["max"] },
+    ] }] });
+    const harness = createHarness((path) => path === "analysis/catalog"
+      ? new Response(catalogBody, { status: 200, headers: { "Content-Type": "application/json" } })
+      : null);
+    let terminalRecord: Record<string, unknown> = {
+      font: { source: "curated", id: "jetbrains", customName: "", size: 16 },
+      analyst: { selection: { cliId: "claude-gateway", model: "fable", effort: "max" } },
+    };
+    const settings: ClientSettingsCapability = {
+      read: vi.fn(async () => terminalRecord),
+      write: vi.fn(async (_pluginId, value) => { terminalRecord = value; }),
+    };
+    const operationId = "operation-store-fable-selection-migration";
+    const store = getAnalysisStore(operationId, harness.api, settings);
+
+    await vi.waitFor(() => expect(store.getSnapshot()).toMatchObject({ cliId: "claude-gateway", model: "fable[1m]", effort: "max" }));
+    expect(settings.write).toHaveBeenCalledWith("terminal", {
+      font: { source: "curated", id: "jetbrains", customName: "", size: 16 },
+      analyst: { selection: { cliId: "claude-gateway", model: "fable[1m]", effort: "max" } },
+    });
+    disposeAnalysisStore(operationId);
+  });
+
   it("hydrates, auto-saves with terminal sibling preservation, confirms the save, and resets to persisted selection", async () => {
     const catalogBody = JSON.stringify({ clis: [{ cliId: "claude", label: "Claude", available: true, defaultModel: "sonnet", models: [
       { id: "sonnet", label: "Sonnet", effortLevels: ["medium"], defaultEffort: "medium" },

--- a/runtime/fleet-plugins/terminal/client/agent/analysis-store.ts
+++ b/runtime/fleet-plugins/terminal/client/agent/analysis-store.ts
@@ -322,11 +322,19 @@ async function readPersistedSelection(settings: ClientSettingsCapability | undef
     if (!current) return null;
     const analyst = record(current["analyst"]);
     const selection = record(analyst["selection"]);
-    return typeof selection["cliId"] === "string"
-      && typeof selection["model"] === "string"
-      && typeof selection["effort"] === "string"
-      ? { cliId: selection["cliId"], model: selection["model"], effort: selection["effort"] }
-      : null;
+    if (typeof selection["cliId"] !== "string"
+      || typeof selection["model"] !== "string"
+      || typeof selection["effort"] !== "string") return null;
+    const persisted = {
+      cliId: selection["cliId"],
+      model: selection["model"] === "fable" ? "fable[1m]" : selection["model"],
+      effort: selection["effort"],
+    };
+    // 이전 Fable id는 새 카탈로그와 맞춘 뒤 한 번 저장한다. 저장 실패가 현재 복원을 막지는 않는다.
+    if (persisted.model !== selection["model"]) {
+      await mergeTerminalSettingsRecord(settings, { analyst: { selection: persisted } }).catch(() => {});
+    }
+    return persisted;
   } catch {
     return null;
   }

--- a/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
@@ -21,8 +21,8 @@ const EFFORT_LABELS: Readonly<Record<string, string>> = {
 };
 
 const NATIVE_MODEL_LABELS: Readonly<Record<(typeof NATIVE_CLAUDE_MODEL_ALIASES)[number], string>> = {
-  fable: "Fable",
-  // Claude Code's 1M coordinate stays under the plain "Opus" menu label.
+  // Claude Code's 1M coordinates stay under their plain menu labels.
+  "fable[1m]": "Fable",
   "opus[1m]": "Opus",
   sonnet: "Sonnet",
 };

--- a/runtime/fleet-plugins/terminal/server/agent-api/analysis-types.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/analysis-types.ts
@@ -47,7 +47,7 @@ export const ANALYST_DEFAULT_EFFORT = "low";
  * 보여 주고 있었다.
  */
 const NATIVE_CLAUDE_LABELS: Readonly<Record<string, string>> = {
-  fable: "Claude Fable",
+  "fable[1m]": "Claude Fable",
   sonnet: "Claude Sonnet",
   "opus[1m]": "Claude Opus [1M]",
 };

--- a/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
@@ -11,8 +11,8 @@ const builtinVariants = {
   id: "native",
   label: "Claude",
   rows: [
-    builtinRow("fable", "Fable"),
-    // Claude Code's 1M coordinate launches under the plain "Opus" label.
+    // Claude Code's 1M coordinates launch under their plain labels.
+    builtinRow("fable[1m]", "Fable"),
     builtinRow("opus[1m]", "Opus"),
     builtinRow("sonnet", "Sonnet"),
   ],

--- a/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
@@ -126,7 +126,7 @@ describe("agent launch variants", () => {
 
   it("threads a valid built-in model alias and effort into the initial attach only", async () => {
     const harness = await createHarness({
-      body: { cliId: "claude-gateway", model: "fable", effort: "max" },
+      body: { cliId: "claude-gateway", model: "fable[1m]", effort: "max" },
     });
 
     await harness.postSessions();
@@ -134,7 +134,7 @@ describe("agent launch variants", () => {
     expect(harness.responses.at(-1)?.status).toBe(200);
     expect(harness.attach).toHaveBeenCalledWith(expect.objectContaining({
       cliId: "claude-gateway",
-      model: "fable",
+      model: "fable[1m]",
       effort: "max",
     }));
 
@@ -152,9 +152,12 @@ describe("agent launch variants", () => {
     expect(resumeContext).not.toHaveProperty("effort");
   });
 
-  it("rewrites bare opus onto Claude Code's 1M coordinate before attach", async () => {
+  it.each([
+    ["fable", "fable[1m]"],
+    ["opus", "opus[1m]"],
+  ])("rewrites bare %s onto Claude Code's 1M coordinate before attach", async (model, expected) => {
     const harness = await createHarness({
-      body: { cliId: "claude-gateway", model: "opus", effort: "high" },
+      body: { cliId: "claude-gateway", model, effort: "high" },
     });
 
     await harness.postSessions();
@@ -162,7 +165,7 @@ describe("agent launch variants", () => {
     expect(harness.responses.at(-1)?.status).toBe(200);
     expect(harness.attach).toHaveBeenCalledWith(expect.objectContaining({
       cliId: "claude-gateway",
-      model: "opus[1m]",
+      model: expected,
       effort: "high",
     }));
   });

--- a/runtime/fleet-plugins/terminal/tests/client-launch-prompt.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/client-launch-prompt.test.ts
@@ -39,12 +39,12 @@ describe("agent client launch prompt threading", () => {
     const launch = agentPlugin.launch;
     if (!launch) throw new Error("Agent plugin launch must exist.");
 
-    await launch(createLaunchContext({ model: "fable" }));
+    await launch(createLaunchContext({ model: "fable[1m]" }));
 
     expect(readCreateBody(fetch)).toEqual({
       theaterId: "theater-1",
       cliId: "claude-gateway",
-      model: "fable",
+      model: "fable[1m]",
     });
   });
 


### PR DESCRIPTION
## Summary
- launch the Console Fable row with Claude Code's `fable[1m]` coordinate
- keep the existing `Fable` and `Claude Fable` labels unchanged
- rewrite legacy bare `fable` selections to the 1M coordinate before launch

## Test Plan
- [x] `pnpm exec vitest run tests/native-claude-model-alias.test.ts`
- [x] `pnpm exec vitest run tests/agent-cli-launch-kinds.test.ts tests/agent-dormant-ticket.test.ts tests/client-launch-prompt.test.ts`
- [x] `pnpm --filter @dotobokuri/fleet-admiral typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-admiral build`
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `pnpm --filter @fleet-plugins/terminal build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`