### PR TITLE
feat(fleet-console): streamline operation launch menu

### DIFF
--- a/.changelog.d/console-context-menu-etc.md
+++ b/.changelog.d/console-context-menu-etc.md
@@ -1,0 +1,8 @@
+---
+branch: console-context-menu-etc
+---
+
+### fleet-console
+#### Changed
+- Streamline the Operation launch menu with compact model rows and a final Etc group for Shell.
+  ko: Operation 실행 메뉴의 모델 행을 간결하게 정리하고 Shell을 마지막 Etc 그룹으로 묶습니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -7,7 +7,7 @@ import { useT } from "../i18n/index.js";
 import { resolveLaunchKindAnnotation } from "../launch-kind-annotations.js";
 import { EffortTrack, effortLadderPosition } from "../components/effort-track.js";
 import { appendSeenFeatureTour, EFFORT_CONFIRM_TIP_SEEN_KEY } from "../components/feature-tour.js";
-import { launchProviderFromGroupId, launchProviderGlyph } from "../components/launch-provider-glyphs.js";
+import { launchEtcGlyph, launchProviderFromGroupId, launchProviderGlyph } from "../components/launch-provider-glyphs.js";
 
 interface CanvasContextMenuProps {
   // 캔버스(<main>) 기준 화면 좌표. 메뉴를 이 지점에 띄운다.
@@ -29,7 +29,7 @@ interface CanvasContextMenuProps {
 // 폭은 세 곳이 함께 알아야 한다 — 이 상수(측정 전 clamp 폴백), .canvas-context-menu의 width,
 // .operation-launch-control--canvas .operation-launch-menu의 min-width. 하나만 고치면 컴파일은
 // 되고 치수만 조용히 어긋난다.
-const MENU_WIDTH = 288;
+const MENU_WIDTH = 264;
 const FLYOUT_GAP = 10;
 // 트랙과 그 값 라벨이 나란히 들어가는 폭이다.
 const EFFORT_SUBMENU_WIDTH = 216;
@@ -216,15 +216,19 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [openEffortRow]);
 
-  // 플러그인이 하나뿐이면 그 이름은 헤더 줄에 붙는다 — 항목 네 개짜리 메뉴에서 이름만 있는
-  // 행 하나가 통째로 서는 것은 값을 못 한다. 둘 이상일 때만 그룹 라벨을 세운다.
-  const singlePlugin = catalog.length === 1 ? catalog[0]! : null;
-  // 머리글은 어디서 열었든 같은 이름을 쓴다 — 상자 이름에 여는 자리(캔버스)나 소유 Theater를 섞으면
-  // 같은 메뉴가 표면마다 다른 이름으로 불린다.
-  const headTitle = t("canvas.menu.title");
-  // 시각 머리글과 메뉴 이름이 같은 문자열이어야 한다 — 좁은 폭에서 머리글이 줄임표로 잘려도
-  // 접근 이름에는 온전히 남는다.
-  const headLabel = singlePlugin ? `${headTitle} · ${singlePlugin.title}` : headTitle;
+  // 시각 헤더 없이도 보조기술에는 메뉴의 역할을 온전히 알린다. 플러그인 이름이나 동작 이름을
+  // 상자 위에 반복하지 않아 첫 번째 실제 선택지가 곧 메뉴의 시작점이 되게 한다.
+  const menuLabel = t("canvas.menu.aria");
+  // Terminal의 Shell은 에이전트/모델 실행과 성격이 다르다. 카탈로그 순서와 무관하게 마지막 Etc
+  // 섹션으로 보내되, 실제 실행 소유권과 아이콘 렌더링에는 원래 plugin id를 그대로 쓴다.
+  const terminalShellKinds = catalog
+    .find((plugin) => plugin.id === "terminal")
+    ?.kinds.filter((kind) => kind.type === "shell") ?? [];
+  const primaryCatalog = catalog
+    .map((plugin) => plugin.id === "terminal"
+      ? { ...plugin, kinds: plugin.kinds.filter((kind) => kind.type !== "shell") }
+      : plugin)
+    .filter((plugin) => plugin.kinds.length > 0);
 
   // 모델 행은 자기 행 키만 들고 다닌다(강도 상자·고른 단이 그 키에 매달린다). 실행은 여전히
   // 실행 종류가 일으키므로, 키에서 그 종류로 되돌아오는 길을 카탈로그 한 번 훑어 만들어 둔다.
@@ -333,9 +337,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
       <div
         className="operation-launch-menu theater-menu canvas-context-menu"
         role="menu"
-        // 머리글은 시각 표면이고, 그 정보는 메뉴 이름이 대신 싣는다 — role="menu" 아래에 일반
-        // 콘텐츠를 두면 화면 낭독기의 메뉴 탐색이 첫 항목으로 곧장 들어가지 못한다.
-        aria-label={headLabel}
+        aria-label={menuLabel}
         aria-orientation="vertical"
         tabIndex={-1}
         ref={menuRef}
@@ -357,21 +359,15 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
         }}
         {...{ [FEATURE_TOUR_BOUNDARY_ATTRIBUTE]: "" }}
       >
-        <div className="canvas-context-menu-head" aria-hidden="true">
-          <span className="canvas-context-menu-head-text">
-            <strong>{headLabel}</strong>
-          </span>
-          <p className="canvas-context-menu-section">{t("canvas.menu.launch")}</p>
-        </div>
-        {catalog.length > 0 ? catalog.map((plugin, index) => {
-          // 모델 밴드를 펼치는 실행 종류와 바로 실행되는 종류를 갈라 세운다. 바로 실행되는 쪽이
-          // 위다 — 캡션 아래에 놓인 무캡션 행은 그 밴드의 일원으로 읽힌다.
-          const directKinds = plugin.kinds.filter((kind) => !expandsVariants(kind, canLaunch));
-          const variantKinds = plugin.kinds.filter((kind) => expandsVariants(kind, canLaunch));
-          return (
-            <div key={plugin.id} role="group" aria-label={plugin.title}>
-              {index > 0 ? <div className="theater-menu-divider" role="separator" /> : null}
-              {singlePlugin ? null : <p className="canvas-context-menu-plugin">{plugin.title}</p>}
+        {catalog.length > 0 ? <>
+          {primaryCatalog.map((plugin, index) => {
+            // 모델 밴드를 펼치는 실행 종류와 바로 실행되는 종류를 갈라 세운다. Terminal Shell은
+            // 성격이 다른 최하단 Etc 섹션이 소유하므로 primaryCatalog에서 이미 제외됐다.
+            const directKinds = plugin.kinds.filter((kind) => !expandsVariants(kind, canLaunch));
+            const variantKinds = plugin.kinds.filter((kind) => expandsVariants(kind, canLaunch));
+            return (
+              <div key={plugin.id} role="group" aria-label={plugin.title}>
+                {index > 0 ? <div className="theater-menu-divider" role="separator" /> : null}
               {directKinds.map((kind) => {
                 const disabled = kind.disabled === true || !canLaunch;
                 const annotation = resolveLaunchKindAnnotation(kind.id);
@@ -543,8 +539,43 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                 );
               })}
             </div>
-          );
-        }) : <p className="theater-menu-empty">{t("canvas.menu.empty")}</p>}
+            );
+          })}
+          {terminalShellKinds.length > 0 ? (
+            <div role="group" aria-label={t("canvas.menu.etc")}>
+              {primaryCatalog.length > 0 ? <div className="theater-menu-divider" role="separator" /> : null}
+              <p className="canvas-context-menu-plugin canvas-context-menu-plugin--etc">
+                <span className="operation-launch-provider-glyph operation-launch-provider-glyph--etc" aria-hidden="true">
+                  {launchEtcGlyph()}
+                </span>
+                <span>{t("canvas.menu.etc")}</span>
+              </p>
+              {terminalShellKinds.map((kind) => {
+                const disabled = kind.disabled === true || !canLaunch;
+                return (
+                  <div key={itemKey("terminal", kind.id)} className="operation-launch-menu-item-wrap">
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className="theater-menu-item canvas-context-menu-item operation-launch-menu-item"
+                      data-operation-launch-kind={kind.id}
+                      disabled={disabled}
+                      title={kind.disabledReason}
+                      tabIndex={-1}
+                      onMouseEnter={() => setHoverKey(itemKey("terminal", kind.id))}
+                      onFocus={() => setFocusKey(itemKey("terminal", kind.id))}
+                      onClick={() => onLaunchKind("terminal", kind)}
+                    >
+                      <span className="theater-menu-check" aria-hidden="true">{renderKindIcon("terminal", kind) ?? <FallbackGlyph />}</span>
+                      <span className="theater-menu-label">{kind.title}</span>
+                      {kind.disabledReason ? <span className="operation-launch-menu-reason">{kind.disabledReason}</span> : null}
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
+        </> : <p className="theater-menu-empty">{t("canvas.menu.empty")}</p>}
       </div>
       {activeDescription && asideSide
         ? (

--- a/runtime/fleet-console/core/client/src/components/launch-provider-glyphs.tsx
+++ b/runtime/fleet-console/core/client/src/components/launch-provider-glyphs.tsx
@@ -53,6 +53,16 @@ export function launchProviderGlyph(provider: LaunchProviderGlyphId): ReactNode 
   return <CodexGlyph />;
 }
 
+export function launchEtcGlyph(): ReactNode {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <circle cx="5" cy="12" r="2" fill="currentColor" />
+      <circle cx="12" cy="12" r="2" fill="currentColor" />
+      <circle cx="19" cy="12" r="2" fill="currentColor" />
+    </svg>
+  );
+}
+
 export function launchProviderFromGroupId(groupId: string): LaunchProviderGlyphId | null {
   if (groupId === "native") return "claude";
   if (!groupId.startsWith("gateway:")) return null;

--- a/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
@@ -67,9 +67,8 @@ export const canvasEn = {
   "canvas.plugin.operationFailed": "Plugin operation failed to render.",
   "canvas.plugin.companionFailed": "Plugin companion failed to render.",
 
-  "canvas.menu.aria": "Controls",
-  "canvas.menu.title": "Controls",
-  "canvas.menu.launch": "Launch",
+  "canvas.menu.aria": "Operation launcher",
+  "canvas.menu.etc": "Etc",
   "canvas.menu.empty": "No operations available.",
 
   "canvas.minimap.open": "Open Map",
@@ -278,9 +277,8 @@ export const canvasKo: Record<keyof typeof canvasEn, string> = {
   "canvas.plugin.operationFailed": "Plugin Operation을 렌더하지 못했습니다.",
   "canvas.plugin.companionFailed": "Plugin Companion을 렌더하지 못했습니다.",
 
-  "canvas.menu.aria": "제어",
-  "canvas.menu.title": "제어",
-  "canvas.menu.launch": "실행",
+  "canvas.menu.aria": "Operation 실행 메뉴",
+  "canvas.menu.etc": "Etc",
   "canvas.menu.empty": "사용 가능한 Operation이 없습니다.",
 
   "canvas.minimap.open": "Map 열기",

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -2275,7 +2275,7 @@
   /* 캔버스 메뉴 폭의 단일 소유자. 메뉴 박스와 설명 어사이드의 기준점이 여기 하나로 모인다 —
      컨테이너에 폭이 없으면 어사이드의 100%가 메뉴 오른쪽이 아니라 왼쪽 모서리를 가리켜
      설명이 메뉴 위를 덮는다. 컴포넌트의 MENU_WIDTH(측정 전 clamp 폴백)만 이 값을 따로 안다. */
-  --canvas-menu-width: 288px;
+  --canvas-menu-width: 264px;
   width: var(--canvas-menu-width);
 }
 
@@ -3683,50 +3683,6 @@
   background: color-mix(in oklch, var(--aurora) 9%, color-mix(in oklch, var(--ink-deep) 28%, transparent));
 }
 
-/* Canvas controls 헤더 — 실행 대상과 Launch 라벨이 한 줄을 나눠 쓴다. 이 메뉴는 설명서가 아니라
-   런처이므로 첫 액션 앞에 세울 수 있는 크롬은 이 한 줄이 전부다. 실행 대상 이름은 남는다 —
-   어느 Theater로 실행되는지 알려주는 표면이 여기 말고는 없다. */
-.canvas-context-menu-head {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: var(--space-3);
-  padding: var(--space-1) var(--space-2);
-  line-height: 16px;
-}
-
-.canvas-context-menu-head-text {
-  min-width: 0;
-  overflow: hidden;
-}
-
-/* 긴 Theater 이름은 줄임표로 끝난다 — 줄임표가 없으면 글자가 중간에서 그냥 끊겨 이름이
-   잘렸다는 사실 자체가 보이지 않는다. 온전한 이름은 메뉴의 접근 이름이 계속 들고 있다. */
-.canvas-context-menu-head-text strong {
-  display: block;
-  font-family: var(--font-body);
-  font-weight: var(--weight-medium);
-  font-size: 11px;
-  letter-spacing: -0.005em;
-  color: var(--text-secondary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-/* Launch 섹션 라벨 — 헤더 줄 오른쪽 끝에 선다. */
-.canvas-context-menu-section {
-  margin: 0;
-  padding: 0;
-  flex: none;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: var(--weight-medium);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--brass-ink);
-}
-
 .canvas-context-menu {
   width: var(--canvas-menu-width);
   /* 상한은 뷰포트 높이에서 산출된 geometry 변수가 소유한다 — 짧은 화면에서도 메뉴가 잘리지 않는다. */
@@ -3790,6 +3746,16 @@
   font-size: 10px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+.canvas-context-menu-plugin--etc {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.operation-launch-provider-glyph--etc {
+  --launch-provider-tone: color-mix(in oklch, var(--brass) 72%, var(--text-tertiary));
 }
 
 .canvas-context-menu-help {

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -41,7 +41,7 @@ beforeEach(() => {
   originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
   Element.prototype.getBoundingClientRect = function getBoundingClientRect(): DOMRect {
     if (this.classList.contains("canvas-context-menu")) {
-      return { ...originalGetBoundingClientRect.call(this), width: 288, height: 133 } as DOMRect;
+      return { ...originalGetBoundingClientRect.call(this), width: 264, height: 133 } as DOMRect;
     }
     return originalGetBoundingClientRect.call(this);
   };
@@ -93,7 +93,7 @@ describe("CanvasContextMenu anchor placement", () => {
   it("clamps the menu horizontally using its rendered width", () => {
     renderMenu({ x: 1000, y: 156 }, { width: 1116, height: 856 });
 
-    expect(menuStyle().left).toBe("816px");
+    expect(menuStyle().left).toBe("840px");
   });
 
   it("derives the menu max-height from a short viewport", () => {
@@ -189,30 +189,37 @@ describe("CanvasContextMenu launch kind attribute", () => {
     expect(item?.querySelector(".operation-launch-menu-description")).toBeNull();
   });
 
-  it("merges a lone plugin name into the head line and keeps group labels once a second plugin appears", () => {
+  it("omits role and plugin chrome while keeping Terminal Shell in a final Etc group", () => {
     const terminal: OperationCatalogPlugin = {
       id: "terminal",
       title: "Terminal",
-      kinds: [{ id: "shell", type: "shell", title: "Shell" }],
+      kinds: [
+        { id: "codex", type: "agent", title: "Codex" },
+        { id: "shell", type: "shell", title: "Shell" },
+      ],
     };
     renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [terminal]);
 
-    // 플러그인이 하나면 이름만 있는 행이 값을 못 한다 — 머리글 줄에 붙인다.
-    expect(document.querySelector(".canvas-context-menu-plugin")).toBeNull();
-    expect(document.querySelector(".canvas-context-menu-head-text")?.textContent).toContain("Terminal");
+    expect(document.querySelector(".canvas-context-menu-head")).toBeNull();
+    expect(document.querySelector(".canvas-context-menu")?.textContent).not.toContain("Controls");
+    expect(document.querySelector(".canvas-context-menu")?.textContent).not.toContain("Terminal");
+    const groupLabels = Array.from(document.querySelectorAll(".canvas-context-menu-plugin")).map((node) => node.textContent?.trim());
+    expect(groupLabels).toEqual(["Etc"]);
+    const etcGlyph = document.querySelector(".operation-launch-provider-glyph--etc");
+    expect(etcGlyph?.querySelectorAll("circle")).toHaveLength(3);
+    expect(etcGlyph?.getAttribute("aria-hidden")).toBe("true");
 
-    const notebooks: OperationCatalogPlugin = {
-      id: "notebooks",
-      title: "Notebooks",
-      kinds: [{ id: "notebook", type: "agent", title: "Notebook" }],
-    };
-    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [terminal, notebooks]);
+    const order = Array.from(document.querySelectorAll("[data-operation-launch-kind]"))
+      .map((node) => node.getAttribute("data-operation-launch-kind"));
+    expect(order).toEqual(["codex", "shell"]);
+    expect(document.querySelector('[aria-label="Etc"] [data-operation-launch-kind="shell"]')).not.toBeNull();
+    expect(document.querySelectorAll(".theater-menu-divider")).toHaveLength(1);
 
-    // 둘 이상이면 어느 공급자가 어떤 종류를 갖는지 다시 밝혀야 한다.
-    const groupLabels = Array.from(document.querySelectorAll(".canvas-context-menu-plugin")).map((node) => node.textContent);
-    expect(groupLabels).toEqual(["Terminal", "Notebooks"]);
-    expect(document.querySelector(".canvas-context-menu-head-text")?.textContent).not.toContain("Terminal");
-    expect(document.querySelectorAll('[role="group"]')).toHaveLength(2);
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [{
+      ...terminal,
+      kinds: [{ id: "shell", type: "shell", title: "Shell" }],
+    }]);
+    expect(document.querySelectorAll(".theater-menu-divider")).toHaveLength(0);
   });
 
   it("keeps the kind contrast on the row and opens the full description only for the pointed kind", () => {
@@ -400,18 +407,18 @@ describe("CanvasContextMenu launch kind attribute", () => {
     const rows = document.querySelectorAll<HTMLButtonElement>(".canvas-context-menu-item");
     const asideText = () => document.querySelector(".canvas-context-menu-aside")?.textContent;
 
-    // 포인터로 열고 방향키로 옮기는 혼합 입력이 흔하다.
-    act(() => rows[0]!.dispatchEvent(new MouseEvent("mouseover", { bubbles: true })));
-    act(() => rows[1]!.focus());
-    // 가리키는 동안에는 포인터가 이긴다.
+    // 포인터로 열고 방향키로 옮기는 혼합 입력이 흔하다. Claude가 먼저, Shell은 Etc의 마지막 행이다.
+    act(() => rows[1]!.dispatchEvent(new MouseEvent("mouseover", { bubbles: true })));
+    act(() => rows[0]!.focus());
+    // 가리키는 동안에는 포인터가 이겨 설명 없는 Shell 상태를 유지한다.
     expect(asideText()).toBeUndefined();
 
     act(() => menu.dispatchEvent(new MouseEvent("mouseout", { bubbles: true, relatedTarget: document.body })));
-    // 포인터가 나가도 포커스가 짚고 있는 행의 설명은 남는다.
+    // 포인터가 나가면 포커스가 짚고 있는 Claude 행의 설명이 다시 드러난다.
     expect(asideText()).toBe("Runs Claude Code with built-in Claude and enabled Gateway models");
   });
 
-  it("names the menu after its launch target and keeps the visual head out of the menu tree", () => {
+  it("keeps a concise accessible name without rendering a visual header", () => {
     act(() => root.render(
       <CanvasContextMenu
         anchor={{ x: 520, y: 156 }}
@@ -425,10 +432,8 @@ describe("CanvasContextMenu launch kind attribute", () => {
     ));
 
     const menu = document.querySelector(".canvas-context-menu")!;
-    expect(menu.getAttribute("aria-label")).toBe("Controls · Terminal");
-    // 같은 문자열이 눈에도 보이지만, 접근성 트리에는 메뉴 이름으로만 한 번 실린다.
-    expect(document.querySelector(".canvas-context-menu-head-text")?.textContent).toBe("Controls · Terminal");
-    expect(document.querySelector(".canvas-context-menu-head")?.getAttribute("aria-hidden")).toBe("true");
+    expect(menu.getAttribute("aria-label")).toBe("Operation launcher");
+    expect(document.querySelector(".canvas-context-menu-head")).toBeNull();
   });
 
   it("gives the menu a valid ancestor for its menu items", () => {
@@ -516,8 +521,8 @@ describe("CanvasContextMenu launch kind attribute", () => {
     expect(document.querySelector(".canvas-context-menu-aside")).not.toBeNull();
   });
 
-  it("keeps direct-launch kinds above the model bands", () => {
-    // 캡션 아래에 놓인 무캡션 행은 그 밴드의 일원으로 읽힌다 — 바로 실행되는 종류는 밴드보다 위다.
+  it("keeps Terminal Shell below the model bands in the Etc group", () => {
+    // Terminal Shell은 모델 실행과 성격이 달라, 카탈로그 순서와 무관하게 마지막 Etc 그룹으로 간다.
     const [gateway] = gatewayVariantCatalog();
     renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, [{
       ...gateway!,
@@ -530,8 +535,8 @@ describe("CanvasContextMenu launch kind attribute", () => {
       .map((element) => element.getAttribute("data-launch-variant-row")
         ?? element.getAttribute("data-operation-launch-kind")
         ?? "caption");
-    // 카탈로그는 Shell을 마지막에 내놓지만(terminal/routes.ts), 목록에서는 첫 행이다.
-    expect(order).toEqual(["shell", "caption", "fable"]);
+    expect(order).toEqual(["caption", "fable", "shell"]);
+    expect(document.querySelector('[aria-label="Etc"] [data-operation-launch-kind="shell"]')).not.toBeNull();
   });
 
   it("keeps a locked menu on one direct row per kind instead of an unusable model band", () => {
@@ -612,7 +617,7 @@ describe("CanvasContextMenu launch kind attribute", () => {
     const effort = document.querySelector<HTMLElement>(".operation-launch-effort-menu")!;
     expect(effort.classList.contains("is-left")).toBe(false);
     // 서브메뉴는 메뉴 상자의 오른쪽 바깥에 선다 — 부모 위로 되돌아오지 않는다.
-    expect(Number.parseFloat(effort.style.left)).toBeGreaterThanOrEqual(260 + 288);
+    expect(Number.parseFloat(effort.style.left)).toBeGreaterThanOrEqual(260 + 264);
   });
 
   it("keeps the rendered widths in step with the placement constants", () => {
@@ -628,7 +633,7 @@ describe("CanvasContextMenu launch kind attribute", () => {
     // 서브메뉴는 fixed라 목록이 굴러도 제자리에 남는다. 짚고 있던 행이 올라가 버리면 그 상자는
     // 엉뚱한 행 옆에서 그 행의 강도인 척하고, 행을 눌러 실행하는 표면에서는 그대로 오실행이 된다.
     // 목록이 메뉴 자체가 되었으므로 굴러가는 상자도 메뉴다.
-    const menuRect = { top: 100, bottom: 400, left: 0, right: 288, width: 288, height: 300 };
+    const menuRect = { top: 100, bottom: 400, left: 0, right: 264, width: 264, height: 300 };
     let anchorRect = { top: 150, bottom: 178, left: 8, right: 208, width: 200, height: 28 };
     const previous = Element.prototype.getBoundingClientRect;
     Element.prototype.getBoundingClientRect = function getBoundingClientRect(): DOMRect {
@@ -694,13 +699,13 @@ describe("CanvasContextMenu launch kind attribute", () => {
     const shell = document.querySelector<HTMLButtonElement>('[data-operation-launch-kind="shell"]')!;
     const model = document.querySelector<HTMLButtonElement>('[data-launch-variant-row="fable"]')!;
 
-    // 두 종류의 행이 한 목록의 형제가 됐다 — 방향키는 그 사이를 건너다녀야 한다.
+    // 두 종류의 행이 한 목록의 형제다. 모델이 먼저이고 Etc의 Shell이 마지막이어도 순환한다.
     act(() => menu.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })));
-    expect(document.activeElement).toBe(shell);
-    pressFlyoutKey("ArrowDown");
     expect(document.activeElement).toBe(model);
-    pressFlyoutKey("ArrowUp");
+    pressFlyoutKey("ArrowDown");
     expect(document.activeElement).toBe(shell);
+    pressFlyoutKey("ArrowUp");
+    expect(document.activeElement).toBe(model);
   });
 
   it("opens the effort submenu from a model row with ArrowRight, then restores focus with Escape", async () => {

--- a/runtime/fleet-console/tests/command-band-switcher.test.tsx
+++ b/runtime/fleet-console/tests/command-band-switcher.test.tsx
@@ -186,14 +186,14 @@ describe("side bar signal consumption", () => {
   it("consumes the Theater launch request by opening the launch menu at the Theater's New Operation button", async () => {
     const onSelectTheater = vi.fn();
     renderSideBar(onSelectTheater);
-    expect(document.querySelector(".canvas-context-menu-head")).toBeNull();
+    expect(document.querySelector(".canvas-context-menu")).toBeNull();
 
     act(() => requestSideBarTheaterLaunch("theater-b"));
 
     // jsdom 기하는 항상 0이라 width 전환 미정착 경로(220ms 지연 실측)를 탄다. consume도 실측 시점에 일어난다.
     await act(() => new Promise((resolve) => setTimeout(resolve, 240)));
     expect(getState().pendingSideBarTheaterLaunch).toBeNull();
-    expect(document.querySelector(".canvas-context-menu-head")).not.toBeNull();
+    expect(document.querySelector(".canvas-context-menu")).not.toBeNull();
     expect(onSelectTheater).toHaveBeenCalledWith("theater-b");
   });
 });

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -431,7 +431,9 @@ describe("Instrument core design contract", () => {
     expect(components).toContain("background-size: 48px 48px !important;");
     expect(components).toContain(".canvas-formation-guide {");
     expect(components).toContain(".canvas-operation-formation-slot {");
-    expect(contextMenu).toContain('<p className="canvas-context-menu-section">{t("canvas.menu.launch")}</p>');
+    expect(contextMenu).not.toContain("canvas-context-menu-head");
+    expect(contextMenu).toContain('aria-label={t("canvas.menu.etc")}');
+    expect(contextMenu).toContain("operation-launch-provider-glyph--etc");
     expect(contextMenu).not.toContain("CanvasContextMenuMode");
     expect(contextMenu).not.toContain("canvas-context-menu-tabs");
     expect(contextMenu).not.toContain("Formation view");
@@ -1372,18 +1374,21 @@ describe("Instrument core design contract", () => {
     expect(contextMenu).toContain('className="operation-launch-menu-brief"');
     expect(contextMenu).toContain("operation-launch-menu-description operation-launch-menu-description--quiet");
 
-    // 헤더는 한 줄이다 — 레티클 마크와 그 30px 블록은 메뉴에서 물러났다. 실행 대상 이름은
-    // 남는다: 어느 Theater로 실행되는지 알려주는 표면이 여기 말고는 없다.
+    // 역할·플러그인·동작 이름을 반복하던 시각 헤더는 제거한다. 메뉴 역할은 aria-label이,
+    // Terminal Shell의 별도 성격은 최하단 Etc 그룹이 맡는다.
     expect(components).not.toContain(".canvas-context-menu-reticle");
     expect(contextMenu).not.toContain('className="canvas-context-menu-reticle"');
-    expect(contextMenu).toContain('className="canvas-context-menu-head-text"');
-    expect(components).toContain(".canvas-context-menu-head {\n  display: flex;\n  align-items: baseline;");
+    expect(contextMenu).not.toContain("canvas-context-menu-head");
+    expect(components).not.toContain(".canvas-context-menu-head {");
+    expect(contextMenu).toContain('aria-label={menuLabel}');
+    expect(contextMenu).toContain('aria-label={t("canvas.menu.etc")}');
+    expect(contextMenu).toContain("operation-launch-provider-glyph--etc");
 
     // 폭은 세 곳이 함께 알아야 한다. 하나만 고치면 컴파일은 되고 치수만 조용히 어긋난다.
     // 폭은 컨테이너가 단일 소유자다. 컨테이너에 폭이 없으면 설명 어사이드의 100%가 메뉴
     // 오른쪽이 아니라 왼쪽 모서리를 가리켜 설명이 메뉴 위를 덮는다(실측으로 확인).
-    expect(contextMenu).toContain("const MENU_WIDTH = 288;");
-    expect(components).toMatch(/\.operation-launch-control--canvas \{[^}]*--canvas-menu-width: 288px;[^}]*width: var\(--canvas-menu-width\);/);
+    expect(contextMenu).toContain("const MENU_WIDTH = 264;");
+    expect(components).toMatch(/\.operation-launch-control--canvas \{[^}]*--canvas-menu-width: 264px;[^}]*width: var\(--canvas-menu-width\);/);
     expect(components).toContain(".canvas-context-menu {\n  width: var(--canvas-menu-width);");
     expect(components).toMatch(/\.operation-launch-control--canvas \.operation-launch-menu \{[^}]*min-width: var\(--canvas-menu-width\);/);
     // 캔버스 전용 패딩은 두 클래스를 함께 짚어야 한다 — 한 클래스면 뒤쪽의 .theater-menu와

--- a/runtime/fleet-console/tests/triage-store.test.ts
+++ b/runtime/fleet-console/tests/triage-store.test.ts
@@ -1428,8 +1428,9 @@ describe("triage store", () => {
     expect(bareMenu.defaultPrevented).toBe(true);
     const launchMenu = document.querySelector(".canvas-context-menu");
     expect(launchMenu).not.toBeNull();
-    // 상자 이름은 어디서 열든 같다 — 실행이 어디로 가는지는 아래에서 실행 인자로 잰다.
-    expect(launchMenu?.querySelector(".canvas-context-menu-head-text")?.textContent).toBe("Controls · Terminal");
+    // 시각 헤더는 반복하지 않고, 메뉴 역할은 접근 이름으로만 유지한다.
+    expect(launchMenu?.getAttribute("aria-label")).toBe("Operation launcher");
+    expect(launchMenu?.querySelector(".canvas-context-menu-head")).toBeNull();
     const shellItem = launchMenu?.querySelector<HTMLButtonElement>('[data-operation-launch-kind="shell"]');
     expect(shellItem).not.toBeNull();
     expect(shellItem?.disabled).toBe(false);

--- a/runtime/fleet-console/tests/warroom-canvas-context-menu.test.tsx
+++ b/runtime/fleet-console/tests/warroom-canvas-context-menu.test.tsx
@@ -94,8 +94,9 @@ describe("War Room canvas controls reach", () => {
       expect(menu.defaultPrevented).toBe(true);
       const opened = container!.querySelector(".canvas-context-menu");
       expect(opened, `deck zoom ${zoom}`).not.toBeNull();
-      // 상자 이름은 어디서 열든 같다 — 여는 자리나 소유 Theater를 이름에 섞지 않는다.
-      expect(opened?.querySelector(".canvas-context-menu-head-text")?.textContent).toBe("Controls · Test");
+      // 시각 헤더 없이도 메뉴 역할은 접근 이름으로 유지한다.
+      expect(opened?.getAttribute("aria-label")).toBe("Operation launcher");
+      expect(opened?.querySelector(".canvas-context-menu-head")).toBeNull();
       expect(opened?.querySelector('[data-operation-launch-kind="shell"]')).not.toBeNull();
       act(() => { window.dispatchEvent(new Event("canvas-context-menu-close")); });
       expect(container!.querySelector(".canvas-context-menu")).toBeNull();


### PR DESCRIPTION
## Summary
- remove the redundant Controls, plugin, and Launch header chrome from the Operation launch menu while preserving an accessible menu name
- move Terminal Shell into a final divided Etc group and add a provider-style neutral ellipsis glyph
- reduce the menu width from 288px to 264px while preserving an 8px gap for the longest model and effort control

## Test Plan
- [x] `pnpm -C runtime/fleet-console exec vitest run tests/canvas-context-menu-anchor.test.tsx tests/command-band-switcher.test.tsx tests/triage-store.test.ts tests/warroom-canvas-context-menu.test.tsx tests/instrument-design-contract.test.ts tests/quick-launch-layout.test.tsx`
- [x] `pnpm -C runtime/fleet-console typecheck`
- [x] `pnpm -C runtime/fleet-console build`
- [x] verify the isolated Console in a real browser: 264px menu width, 8px model-to-effort gap, no wrapping or horizontal overflow