### PR TITLE
feat(gateway): add Cursor Opus/Fable Max Mode 1M models

### DIFF
--- a/.changelog.d/worktree-cursor-opus-fable-max-1m.md
+++ b/.changelog.d/worktree-cursor-opus-fable-max-1m.md
@@ -1,0 +1,8 @@
+---
+branch: worktree-cursor-opus-fable-max-1m
+---
+
+### fleet-console
+#### Added
+- Offer Cursor Max Mode 1M variants of Opus 5 and Fable 5 beside the existing Kimi K3 1M catalog model.
+  ko: 기존 Kimi K3 1M 카탈로그 모델 옆에 Cursor Max Mode 1M 변형 Opus 5·Fable 5를 제공합니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -79,7 +79,7 @@ Fleet은 선언된 제품 표면에서 실제 CLI 바이너리를 실행하고 �
 | 프로바이더 | 게이트웨이로 닿는 모델 |
 |---|---|
 | **Codex** | GPT-5.6 Sol · Terra · Luna, 각각 Fast 변형 |
-| **Cursor** | Composer 2.5 · Composer 2.5 Fast · Grok 4.5 · Grok 4.5 Fast · GPT-5.6 Sol · Claude Opus 5 · Claude Fable 5 · Kimi K3 · Kimi K3 1M · Auto |
+| **Cursor** | Composer 2.5 · Composer 2.5 Fast · Grok 4.5 · Grok 4.5 Fast · GPT-5.6 Sol · Claude Opus 5 · Claude Opus 5 1M · Claude Fable 5 · Claude Fable 5 1M · Kimi K3 · Kimi K3 1M · Auto |
 | **Moonshot-Kimi** | Kimi K3 1M, K3 256K |
 | **OpenCode** | MiniMax M3 · Qwen3.8 Max · DeepSeek V4 Flash · DeepSeek V4 Pro · GLM-5.2 · Kimi K3 · MiMo V2.5 · MiMo V2.5 Pro · HY3 · Grok 4.5 · GPT-5.6 Luna |
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The gateway is a local Claude Code endpoint, not an API proxy. Built-in Claude m
 | Provider | Models reachable through the gateway |
 |---|---|
 | **Codex** | GPT-5.6 Sol · Terra · Luna, each with a Fast variant |
-| **Cursor** | Composer 2.5 · Composer 2.5 Fast · Grok 4.5 · Grok 4.5 Fast · GPT-5.6 Sol · Claude Opus 5 · Claude Fable 5 · Kimi K3 · Kimi K3 1M · Auto |
+| **Cursor** | Composer 2.5 · Composer 2.5 Fast · Grok 4.5 · Grok 4.5 Fast · GPT-5.6 Sol · Claude Opus 5 · Claude Opus 5 1M · Claude Fable 5 · Claude Fable 5 1M · Kimi K3 · Kimi K3 1M · Auto |
 | **Moonshot-Kimi** | Kimi K3 1M, K3 256K |
 | **OpenCode** | MiniMax M3 · Qwen3.8 Max · DeepSeek V4 Flash · DeepSeek V4 Pro · GLM-5.2 · Kimi K3 · MiMo V2.5 · MiMo V2.5 Pro · HY3 · Grok 4.5 · GPT-5.6 Luna |
 

--- a/docs/app.jsx
+++ b/docs/app.jsx
@@ -135,7 +135,7 @@ const PROVIDERS = [
       { ko: "Composer 2.5", en: "Composer 2.5" },
       { ko: "Grok 4.5", en: "Grok 4.5" },
       { ko: "GPT-5.6 Sol", en: "GPT-5.6 Sol" },
-      { ko: "Claude Opus 5 · Claude Fable 5", en: "Claude Opus 5 and Claude Fable 5" },
+      { ko: "Claude Opus 5 · Claude Fable 5 — 각각 Max Mode 1M 변형 포함", en: "Claude Opus 5 and Claude Fable 5 — each with a Max Mode 1M variant" },
       { ko: "Kimi K3 · Auto", en: "Kimi K3 and Auto" },
     ],
   },

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-08-08T00:00:00Z",
+  "updatedAt": "2026-08-10T00:00:00Z",
   "providers": {
     "codex": {
       "name": "Codex",
@@ -142,7 +142,7 @@
     "cursor": {
       "name": "Cursor",
       "defaultModel": "auto",
-      "source": "Cursor GetUsableModels + Run conversationCheckpointUpdate.token_details.max_tokens (cli-2026.07.08-0c04a8a; standard and Max Mode observed 2026-08-01, gpt-5.6-sol observed 2026-08-05 on cursor-agent 2026.07.23-e383d2b); quotaScope from DashboardService/GetCurrentPeriodUsage autoBucketModels (2026-08-05)",
+      "source": "Cursor GetUsableModels + Run conversationCheckpointUpdate.token_details.max_tokens (cli-2026.07.08-0c04a8a; standard and Max Mode observed 2026-08-01, gpt-5.6-sol observed 2026-08-05 on cursor-agent 2026.07.23-e383d2b, claude-opus-5 and claude-fable-5 standard/Max Mode windows observed 2026-08-10); quotaScope from DashboardService/GetCurrentPeriodUsage autoBucketModels (2026-08-05)",
       "models": [
         {
           "modelId": "auto",
@@ -245,12 +245,57 @@
           "benchmarkKey": "claude-opus-5"
         },
         {
+          "modelId": "claude-opus-5-1m",
+          "name": "Opus-5-1M",
+          "capabilityClass": "flagship",
+          "quotaScope": "api",
+          "contextWindow": 1000000,
+          "cursorMaxMode": true,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "upstreamModelIdTemplate": "claude-opus-5-{effort}",
+            "upstreamModelIds": {
+              "xhigh": "claude-opus-5-thinking-xhigh",
+              "max": "claude-opus-5-thinking-max"
+            }
+          },
+          "benchmarkKey": "claude-opus-5"
+        },
+        {
           "modelId": "claude-fable-5",
           "name": "Fable-5",
           "capabilityClass": "flagship",
           "quotaScope": "api",
           "description": "NO ZDR",
           "contextWindow": 300000,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "upstreamModelIdTemplate": "claude-fable-5-{effort}"
+          },
+          "benchmarkKey": "claude-fable-5"
+        },
+        {
+          "modelId": "claude-fable-5-1m",
+          "name": "Fable-5-1M",
+          "capabilityClass": "flagship",
+          "quotaScope": "api",
+          "description": "NO ZDR",
+          "contextWindow": 1000000,
+          "cursorMaxMode": true,
           "effort": {
             "supported": true,
             "levels": [

--- a/packages/core-ai-gateway/tests/cursor/native/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/cursor/native/adapter.test.ts
@@ -35,6 +35,8 @@ describe("Cursor request budgets", () => {
     ["kimi-k3-1m", "low", "kimi-k3-max"],
     ["claude-opus-5", "xhigh", "claude-opus-5-thinking-xhigh"],
     ["claude-opus-5", "max", "claude-opus-5-thinking-max"],
+    ["claude-opus-5-1m", "xhigh", "claude-opus-5-thinking-xhigh"],
+    ["claude-fable-5-1m", "high", "claude-fable-5-high"],
     ["grok-4.5-fast", "low", "cursor-grok-4.5-low-fast"],
     ["gpt-5.6-sol", "max", "gpt-5.6-sol-max"],
   ] as const)("writes Cursor model %s with effort %s as %s", (model, effort, expected) => {
@@ -52,11 +54,18 @@ describe("Cursor request budgets", () => {
     expect(runRequest(plan).modelDetails.modelId).toBe("kimi-k3-high");
   });
 
-  it("encodes Cursor Max Mode for the fixed Kimi K3 1M catalog model", () => {
-    const plan = buildCursorRunPlan(request({ model: "kimi-k3-1m" }), "conversation-kimi-1m");
+  it.each([
+    ["kimi-k3-1m", undefined, "kimi-k3-max"],
+    ["claude-opus-5-1m", "high", "claude-opus-5-high"],
+    ["claude-fable-5-1m", "high", "claude-fable-5-high"],
+  ] as const)("encodes Cursor Max Mode for catalog model %s", (model, effort, wireModel) => {
+    const plan = buildCursorRunPlan(request({
+      model,
+      ...(effort ? { reasoning: { summary: "auto" as const, effort } } : {}),
+    }), `conversation-${model}`);
 
     expect(encodedRunRequest(plan).modelDetails).toMatchObject({
-      modelId: "kimi-k3-max",
+      modelId: wireModel,
       maxMode: true,
     });
   });

--- a/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
@@ -1470,10 +1470,12 @@ describe("route surface", () => {
     const ids = list.data.map((entry) => entry.id);
     // picker가 버리지 않도록 모든 항목이 claude- alias로 나가야 한다.
     expect(ids.every((id) => id.startsWith("claude"))).toBe(true);
-    expect(list.data).toHaveLength(29);
+    expect(list.data).toHaveLength(31);
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast[1m]");
     expect(ids).toContain("claude-gateway--cursor--auto[1m]");
     expect(ids).toContain("claude-gateway--cursor--gpt-5.6-sol[1m]");
+    expect(ids).toContain("claude-gateway--cursor--claude-opus-5-1m[1m]");
+    expect(ids).toContain("claude-gateway--cursor--claude-fable-5-1m[1m]");
     expect(ids).toContain("claude-gateway--cursor--kimi-k3");
     expect(ids).toContain("claude-gateway--cursor--kimi-k3-1m[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3[1m]");

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -795,7 +795,7 @@ describe("model catalog", () => {
 
   it("contains only the approved latest provider families", () => {
     expect(CODEX_SUBSCRIPTION_MODELS).toHaveLength(6);
-    expect(CURSOR_SUBSCRIPTION_MODELS).toHaveLength(10);
+    expect(CURSOR_SUBSCRIPTION_MODELS).toHaveLength(12);
     expect(KIMI_SUBSCRIPTION_MODELS).toHaveLength(2);
     expect(OPENCODE_SUBSCRIPTION_MODELS).toHaveLength(11);
     expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.upstreamId?.startsWith("gpt-5.6-"))).toBe(true);
@@ -808,7 +808,9 @@ describe("model catalog", () => {
       "grok-4.5-fast",
       "gpt-5.6-sol",
       "claude-opus-5",
+      "claude-opus-5-1m",
       "claude-fable-5",
+      "claude-fable-5-1m",
       "kimi-k3-max",
       "kimi-k3",
     ]);
@@ -817,7 +819,9 @@ describe("model catalog", () => {
       model.contextWindow,
     ]))).toEqual({
       "claude-opus-5": 300_000,
+      "claude-opus-5-1m": 1_000_000,
       "claude-fable-5": 300_000,
+      "claude-fable-5-1m": 1_000_000,
       "gpt-5.6-sol": 272_000,
       "composer-2.5": 200_000,
       "composer-2.5-fast": 200_000,
@@ -827,8 +831,14 @@ describe("model catalog", () => {
       "kimi-k3": 200_000,
       default: 256_000,
     });
-    expect(CURSOR_SUBSCRIPTION_MODELS.find((model) => model.id === "cursor--kimi-k3-1m"))
-      .toMatchObject({ cursorMaxMode: true });
+    for (const id of [
+      "cursor--claude-opus-5-1m",
+      "cursor--claude-fable-5-1m",
+      "cursor--kimi-k3-1m",
+    ]) {
+      expect(CURSOR_SUBSCRIPTION_MODELS.find((model) => model.id === id))
+        .toMatchObject({ cursorMaxMode: true });
+    }
     expect(KIMI_SUBSCRIPTION_MODELS.map((model) => model.upstreamId)).toEqual(["k3", "k3-256k"]);
     // OpenCode Go의 서비스 가능 전 모델(2026-08-03 라이브 프로브). wire 미선언 =
     // Anthropic passthrough, 그 외에는 선언된 네이티브 wire의 번역 경로를 탄다.
@@ -888,6 +898,13 @@ describe("model catalog", () => {
         max: "claude-opus-5-thinking-max",
       },
     });
+    expect(efforts["cursor--claude-opus-5-1m"]).toEqual(efforts["cursor--claude-opus-5"]);
+    expect(efforts["cursor--claude-fable-5"]).toEqual({
+      supported: true,
+      levels: ["low", "medium", "high", "xhigh", "max"],
+      upstreamModelIdTemplate: "claude-fable-5-{effort}",
+    });
+    expect(efforts["cursor--claude-fable-5-1m"]).toEqual(efforts["cursor--claude-fable-5"]);
     expect(efforts["cursor--auto"]).toEqual({ supported: false });
   });
 
@@ -899,6 +916,10 @@ describe("model catalog", () => {
     ["claude-opus-5", "high", "claude-opus-5-high"],
     ["claude-opus-5", "xhigh", "claude-opus-5-thinking-xhigh"],
     ["claude-opus-5", "max", "claude-opus-5-thinking-max"],
+    ["claude-opus-5-1m", "high", "claude-opus-5-high"],
+    ["claude-opus-5-1m", "xhigh", "claude-opus-5-thinking-xhigh"],
+    ["claude-opus-5-1m", "max", "claude-opus-5-thinking-max"],
+    ["claude-fable-5-1m", "high", "claude-fable-5-high"],
     ["grok-4.5-fast", "low", "cursor-grok-4.5-low-fast"],
     ["composer-2.5", "high", "composer-2.5"],
     ["unknown-model", "high", "unknown-model"],
@@ -954,6 +975,14 @@ describe("model catalog", () => {
     });
     expect(list.data.some((entry) => entry.id.includes("--codex--") && entry.id.endsWith("[1m]")))
       .toBe(true);
+    expect(list.data.find((entry) => entry.id.endsWith("cursor--claude-opus-5-1m[1m]"))).toMatchObject({
+      display_name: "Cursor-Opus-5-1M (1M Context)",
+      max_input_tokens: 1_000_000,
+    });
+    expect(list.data.find((entry) => entry.id.endsWith("cursor--claude-fable-5-1m[1m]"))).toMatchObject({
+      display_name: "Cursor-Fable-5-1M (1M Context)",
+      max_input_tokens: 1_000_000,
+    });
     expect(list.data.find((entry) => entry.id.endsWith("cursor--kimi-k3-1m[1m]"))).toMatchObject({
       display_name: "Cursor-Kimi-K3-1M (1M Context)",
       max_input_tokens: 1_048_576,
@@ -1078,6 +1107,18 @@ describe("model catalog", () => {
       id: "codex--gpt-5.6-luna",
     });
     expect(findGatewayModel("claude-gateway--kimi--k3")).toMatchObject({ id: "kimi--k3" });
+    expect(findGatewayModel("claude-gateway--cursor--claude-opus-5-1m[1m]")).toMatchObject({
+      id: "cursor--claude-opus-5-1m",
+      upstreamId: "claude-opus-5-1m",
+      contextWindow: 1_000_000,
+      cursorMaxMode: true,
+    });
+    expect(findGatewayModel("claude-gateway--cursor--claude-fable-5-1m[1m]")).toMatchObject({
+      id: "cursor--claude-fable-5-1m",
+      upstreamId: "claude-fable-5-1m",
+      contextWindow: 1_000_000,
+      cursorMaxMode: true,
+    });
     expect(findGatewayModel("claude-gateway--cursor--kimi-k3-1m[1m]")).toMatchObject({
       id: "cursor--kimi-k3-1m",
       upstreamId: "kimi-k3-max",

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -640,9 +640,11 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(cache.baseUrl).toBe(spec.env.ANTHROPIC_BASE_URL);
     expect(cache.fetchedAt).toEqual(expect.any(Number));
     // core-ai-gateway의 GATEWAY_MODELS 전량이 prewrite되어야 한다 — 카탈로그가 바뀌면 이 수도 함께 맞춘다.
-    expect(cache.models).toHaveLength(29);
+    expect(cache.models).toHaveLength(31);
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast[1m]");
     expect(ids).toContain("claude-gateway--cursor--auto[1m]");
+    expect(ids).toContain("claude-gateway--cursor--claude-opus-5-1m[1m]");
+    expect(ids).toContain("claude-gateway--cursor--claude-fable-5-1m[1m]");
     expect(ids).toContain("claude-gateway--cursor--kimi-k3");
     expect(ids).toContain("claude-gateway--cursor--kimi-k3-1m[1m]");
     expect(ids).not.toContain("claude-gateway--cursor--gpt-5.6-luna[1m]");

--- a/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
@@ -39,7 +39,7 @@ describe("terminal settings routes", () => {
     expect(harness.writes[0]?.body).not.toHaveProperty("consolePortMode");
   });
 
-  it("GET /plugins/terminal/settings ships the gateway catalog with both Kimi routes", async () => {
+  it("GET /plugins/terminal/settings ships the gateway catalog with Cursor Max Mode routes", async () => {
     const harness = createRouteHarness({ data: { version: 1 } });
     await harness.handle({ req: req("GET"), res: res(), pathname: "/plugins/terminal/settings" });
     const body = harness.writes[0]?.body as {
@@ -49,10 +49,15 @@ describe("terminal settings routes", () => {
     expect(providers.map((provider) => provider.id)).toEqual(["codex", "cursor", "kimi", "opencode"]);
     const allIds = providers.flatMap((provider) => provider.models.map((model) => model.id));
     // Cursor 경유 Kimi와 Kimi 프로바이더는 다른 경로다 — 둘 다 노출한다.
-    expect(allIds).toContain("cursor--kimi-k3-1m");
     expect(allIds).toContain("kimi--k3");
-    const cursorKimi = providers[1]?.models.find((model) => model.id === "cursor--kimi-k3-1m");
-    expect(cursorKimi?.maxMode).toBe(true);
+    for (const id of [
+      "cursor--claude-opus-5-1m",
+      "cursor--claude-fable-5-1m",
+      "cursor--kimi-k3-1m",
+    ]) {
+      expect(allIds).toContain(id);
+      expect(providers[1]?.models.find((model) => model.id === id)?.maxMode).toBe(true);
+    }
     const fastIds = allIds.filter((id) => id.endsWith("-fast"));
     expect(fastIds.length).toBeGreaterThan(0);
     // 등급은 이 응답으로만 브라우저에 닿는다 — 투영에서 잘리면 로스터 배지가 사라진다.


### PR DESCRIPTION
## Summary
- Add separate Cursor Max Mode catalog siblings for Opus 5 and Fable 5 (`claude-opus-5-1m`, `claude-fable-5-1m`) with `contextWindow: 1000000` and `cursorMaxMode: true`, following the existing Kimi K3 1M pattern.
- Keep the standard 300K Opus/Fable entries unchanged and preserve their effort ladders/wire IDs on the 1M siblings.
- Update catalog/adapter/router/settings/launch assertions plus README, docs, and changelog.

## Test Plan
- [x] Cursor context probe (`--mode both`) confirmed Opus/Fable standard=300k, Max Mode=1M
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` (578)
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck` / `build`
- [x] focused Terminal `settings-routes` (39) and Console `launch` (26)
- [x] `node scripts/compile-changelog-fragments.mjs --check`