### PR TITLE
feat(fleet-console): carry the supplier colour onto the Operation mark

### DIFF
--- a/.changelog.d/provider-glyph-tone.md
+++ b/.changelog.d/provider-glyph-tone.md
@@ -1,0 +1,8 @@
+---
+branch: provider-glyph-tone
+---
+
+### fleet-console
+#### Changed
+- Tint the Operation mark in the sidebar and the command band with the supplier colour the launch menu already uses, so an agent Operation reads as Claude at a glance while Shell stays neutral.
+  ko: 사이드바와 커맨드 밴드의 Operation 마크에 실행 메뉴가 쓰던 공급자 색을 입혀, 에이전트 Operation은 한눈에 Claude로 읽히고 셸은 중립으로 남습니다.

--- a/.changelog.d/provider-glyph-tone.md
+++ b/.changelog.d/provider-glyph-tone.md
@@ -6,5 +6,5 @@ branch: provider-glyph-tone
 #### Changed
 - Tint the Operation mark in the sidebar and the command band with the supplier colour the launch menu already uses, so an agent Operation reads as Claude at a glance while Shell stays neutral.
   ko: 사이드바와 커맨드 밴드의 Operation 마크에 실행 메뉴가 쓰던 공급자 색을 입혀, 에이전트 Operation은 한눈에 Claude로 읽히고 셸은 중립으로 남습니다.
-- Pair the launch menu's supplier band with the Claude Code mark it runs on, so a Cursor or Codex model reads as a model borrowed by the harness rather than that vendor's own CLI.
-  ko: 실행 메뉴의 공급자 밴드에 실제로 실행되는 Claude Code 마크를 나란히 붙여, Cursor나 Codex 모델이 그 회사 CLI가 아니라 하네스가 빌려 쓰는 모델로 읽히게 합니다.
+- Pair the launch menu's supplier band with the Claude Code mark it runs on — the harness box sits behind and the model box overlaps it in front, both leaning into each other — so a Cursor or Codex model reads as a model borrowed by the harness rather than that vendor's own CLI.
+  ko: 실행 메뉴의 공급자 밴드에 실제로 실행되는 Claude Code 마크를 겹쳐 붙입니다. 하네스 상자가 뒤, 모델 상자가 앞에서 서로 마주 기울어, Cursor나 Codex 모델이 그 회사 CLI가 아니라 하네스가 빌려 쓰는 모델로 읽히게 합니다.

--- a/.changelog.d/provider-glyph-tone.md
+++ b/.changelog.d/provider-glyph-tone.md
@@ -6,3 +6,5 @@ branch: provider-glyph-tone
 #### Changed
 - Tint the Operation mark in the sidebar and the command band with the supplier colour the launch menu already uses, so an agent Operation reads as Claude at a glance while Shell stays neutral.
   ko: 사이드바와 커맨드 밴드의 Operation 마크에 실행 메뉴가 쓰던 공급자 색을 입혀, 에이전트 Operation은 한눈에 Claude로 읽히고 셸은 중립으로 남습니다.
+- Pair the launch menu's supplier band with the Claude Code mark it runs on, so a Cursor or Codex model reads as a model borrowed by the harness rather than that vendor's own CLI.
+  ko: 실행 메뉴의 공급자 밴드에 실제로 실행되는 Claude Code 마크를 나란히 붙여, Cursor나 Codex 모델이 그 회사 CLI가 아니라 하네스가 빌려 쓰는 모델로 읽히게 합니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -7,7 +7,7 @@ import { useT } from "../i18n/index.js";
 import { resolveLaunchKindAnnotation } from "../launch-kind-annotations.js";
 import { EffortTrack, effortLadderPosition } from "../components/effort-track.js";
 import { appendSeenFeatureTour, EFFORT_CONFIRM_TIP_SEEN_KEY } from "../components/feature-tour.js";
-import { launchProviderFromGroupId, launchProviderGlyph } from "../components/launch-provider-glyphs.js";
+import { launchProviderFromGroupId, LaunchProviderMark } from "../components/launch-provider-glyphs.js";
 
 interface CanvasContextMenuProps {
   // 캔버스(<main>) 기준 화면 좌표. 메뉴를 이 지점에 띄운다.
@@ -430,11 +430,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                               : group.label;
                           return (
                             <p className={`operation-launch-variant-caption${provider ? ` is-${provider}` : ""}`}>
-                              {provider ? (
-                                <span className="operation-launch-provider-glyph" aria-hidden="true">
-                                  {launchProviderGlyph(provider)}
-                                </span>
-                              ) : null}
+                              {provider ? <LaunchProviderMark provider={provider} /> : null}
                               <span>{caption}</span>
                             </p>
                           );

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -10,6 +10,7 @@ import { cycleTriageDeckZoomPreset } from "../canvas/triage-watch-deck.js";
 import { COMMAND_BAND_RAIL_STRIP_PX, commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandMapControlsAnchor, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "./command-band-guards.js";
 import { CommandBandOperationMenu, CommandBandTheaterMenu, CommandBandTriggerCaret, type CommandBandSwitcherMenu } from "./command-band-switcher.js";
 import { CommandBandSystemCluster } from "./command-band-system-cluster.js";
+import { launchProviderFromKindId } from "./launch-provider-glyphs.js";
 import { useGlobalSettingsStore } from "../global-settings-store.js";
 import { useConsoleState } from "../hooks/use-store.js";
 import { setRailChromeExpanded, toggleRailChrome, useRailChromeExpanded } from "../rail/rail-store.js";
@@ -134,6 +135,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const language = resolveConsoleLanguage(globalSettings.state?.language ?? "auto");
   const activeKindTitle = activeKind ? resolveLocalizedText(activeKind.title, language) : null;
   const activeOperationIcon = activeOperation && activePlugin?.renderLaunchIcon ? activePlugin.renderLaunchIcon({ id: activeCliId ?? activeOperation.type, type: activeOperation.type, title: activeKindTitle ?? activeOperation.type }) : null;
+  const activeOperationProvider = launchProviderFromKindId(activeCliId ?? activeOperation?.type);
   const environmentTriggerRef = useRef<HTMLButtonElement>(null);
   const environmentPopoverRef = useRef<HTMLDivElement>(null);
   const commandBandRef = useRef<HTMLElement>(null);
@@ -611,7 +613,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
                 <span className="command-band-segment-label">{activeOperation.title}</span>
                 <CommandBandTriggerCaret />
               </button>}
-              {activeCliLabel ? <span className="command-band-operation-attribute" title={activeKindTitle ?? activeCliLabel}>{activeOperationIcon ? <span className="command-band-operation-kind" aria-hidden="true">{activeOperationIcon}</span> : null}{activeCliLabel}</span> : null}
+              {activeCliLabel ? <span className="command-band-operation-attribute" title={activeKindTitle ?? activeCliLabel}>{activeOperationIcon ? <span className={`command-band-operation-kind${activeOperationProvider ? ` is-${activeOperationProvider}` : ""}`} aria-hidden="true">{activeOperationIcon}</span> : null}{activeCliLabel}</span> : null}
             </> : <button
               ref={operationTriggerRef}
               type="button"

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -135,7 +135,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const language = resolveConsoleLanguage(globalSettings.state?.language ?? "auto");
   const activeKindTitle = activeKind ? resolveLocalizedText(activeKind.title, language) : null;
   const activeOperationIcon = activeOperation && activePlugin?.renderLaunchIcon ? activePlugin.renderLaunchIcon({ id: activeCliId ?? activeOperation.type, type: activeOperation.type, title: activeKindTitle ?? activeOperation.type }) : null;
-  const activeOperationProvider = launchProviderFromKindId(activeCliId ?? activeOperation?.type);
+  const activeOperationProvider = launchProviderFromKindId(activeCliId);
   const environmentTriggerRef = useRef<HTMLButtonElement>(null);
   const environmentPopoverRef = useRef<HTMLDivElement>(null);
   const commandBandRef = useRef<HTMLElement>(null);

--- a/runtime/fleet-console/core/client/src/components/launch-provider-glyphs.tsx
+++ b/runtime/fleet-console/core/client/src/components/launch-provider-glyphs.tsx
@@ -53,6 +53,33 @@ export function launchProviderGlyph(provider: LaunchProviderGlyphId): ReactNode 
   return <CodexGlyph />;
 }
 
+/**
+ * 실행 밴드가 다는 공급자 표식. Fleet은 공급자의 CLI를 띄우는 것이 아니라 Claude Code를 하네스로
+ * 두고 그 회사의 모델만 빌려 쓴다 — 공급자 마크가 홀로 서면 그 회사 CLI로 실행되는 것처럼 읽히므로,
+ * 하네스 상자와 공급자 상자를 이어 "Claude Code로, 이 모델을"이라고 말하게 한다.
+ * Claude 모델은 이을 상대가 없으니 상자 하나로 남는다.
+ */
+export function LaunchProviderMark({ provider }: { readonly provider: LaunchProviderGlyphId }): ReactNode {
+  if (provider === "claude") {
+    return (
+      <span className="operation-launch-provider-glyph" aria-hidden="true">
+        {launchProviderGlyph("claude")}
+      </span>
+    );
+  }
+  return (
+    <span className="operation-launch-provider-pair" aria-hidden="true">
+      <span className="operation-launch-provider-glyph is-harness">{launchProviderGlyph("claude")}</span>
+      <svg className="operation-launch-provider-link" viewBox="0 0 14 4" aria-hidden="true">
+        <circle cx="2" cy="2" r="1.1" fill="currentColor" />
+        <circle cx="7" cy="2" r="1.1" fill="currentColor" />
+        <circle cx="12" cy="2" r="1.1" fill="currentColor" />
+      </svg>
+      <span className="operation-launch-provider-glyph">{launchProviderGlyph(provider)}</span>
+    </span>
+  );
+}
+
 function asLaunchProvider(value: string | undefined): LaunchProviderGlyphId | null {
   if (
     value === "claude"
@@ -79,12 +106,20 @@ export function launchProviderFromModelId(modelId: string | null | undefined): L
   return asLaunchProvider(modelId.split("--", 1)[0]);
 }
 
+// 실행 종류 id는 플러그인이 자유롭게 짓는 문자열이라, 앞 토막을 공급자로 읽으면 `claude-report`
+// 같은 남의 어휘까지 신원을 주장한다. 아는 Agent CLI id만 적고 나머지는 중립으로 남긴다.
+const KIND_ID_PROVIDERS: Readonly<Record<string, LaunchProviderGlyphId>> = {
+  "claude-gateway": "claude",
+  // 퇴역 별칭 — 부팅 시 마이그레이션이 claude-gateway로 옮기지만, 그전까지도 Claude가 맞다.
+  claude: "claude",
+  "claude-native": "claude",
+};
+
 /**
- * Resolve the provider tone for a launch-kind id (`claude-gateway`). Agent CLI ids lead with the
- * supplier they speak to, so the leading segment is the same identity the launch menu bands carry.
- * Non-agent kinds such as `shell` have no supplier and stay untinted.
+ * Resolve the provider tone for an Agent CLI launch-kind id (`claude-gateway`). Any other kind —
+ * `shell`, a plugin's own vocabulary — has no supplier identity and stays untinted.
  */
 export function launchProviderFromKindId(kindId: string | null | undefined): LaunchProviderGlyphId | null {
   if (!kindId) return null;
-  return asLaunchProvider(kindId.split("-", 1)[0]);
+  return KIND_ID_PROVIDERS[kindId] ?? null;
 }

--- a/runtime/fleet-console/core/client/src/components/launch-provider-glyphs.tsx
+++ b/runtime/fleet-console/core/client/src/components/launch-provider-glyphs.tsx
@@ -56,8 +56,8 @@ export function launchProviderGlyph(provider: LaunchProviderGlyphId): ReactNode 
 /**
  * 실행 밴드가 다는 공급자 표식. Fleet은 공급자의 CLI를 띄우는 것이 아니라 Claude Code를 하네스로
  * 두고 그 회사의 모델만 빌려 쓴다 — 공급자 마크가 홀로 서면 그 회사 CLI로 실행되는 것처럼 읽히므로,
- * 하네스 상자와 공급자 상자를 이어 "Claude Code로, 이 모델을"이라고 말하게 한다.
- * Claude 모델은 이을 상대가 없으니 상자 하나로 남는다.
+ * 하네스 상자를 뒤에 깔고 공급자 상자를 그 위에 겹쳐 "Claude Code로, 이 모델을"이라고 말하게 한다.
+ * Claude 모델은 겹칠 상대가 없으니 상자 하나로 남는다.
  */
 export function LaunchProviderMark({ provider }: { readonly provider: LaunchProviderGlyphId }): ReactNode {
   if (provider === "claude") {
@@ -70,12 +70,7 @@ export function LaunchProviderMark({ provider }: { readonly provider: LaunchProv
   return (
     <span className="operation-launch-provider-pair" aria-hidden="true">
       <span className="operation-launch-provider-glyph is-harness">{launchProviderGlyph("claude")}</span>
-      <svg className="operation-launch-provider-link" viewBox="0 0 9 3" aria-hidden="true">
-        <circle cx="1.5" cy="1.5" r="0.95" fill="currentColor" />
-        <circle cx="4.5" cy="1.5" r="0.95" fill="currentColor" />
-        <circle cx="7.5" cy="1.5" r="0.95" fill="currentColor" />
-      </svg>
-      <span className="operation-launch-provider-glyph">{launchProviderGlyph(provider)}</span>
+      <span className="operation-launch-provider-glyph is-model">{launchProviderGlyph(provider)}</span>
     </span>
   );
 }

--- a/runtime/fleet-console/core/client/src/components/launch-provider-glyphs.tsx
+++ b/runtime/fleet-console/core/client/src/components/launch-provider-glyphs.tsx
@@ -70,10 +70,10 @@ export function LaunchProviderMark({ provider }: { readonly provider: LaunchProv
   return (
     <span className="operation-launch-provider-pair" aria-hidden="true">
       <span className="operation-launch-provider-glyph is-harness">{launchProviderGlyph("claude")}</span>
-      <svg className="operation-launch-provider-link" viewBox="0 0 14 4" aria-hidden="true">
-        <circle cx="2" cy="2" r="1.1" fill="currentColor" />
-        <circle cx="7" cy="2" r="1.1" fill="currentColor" />
-        <circle cx="12" cy="2" r="1.1" fill="currentColor" />
+      <svg className="operation-launch-provider-link" viewBox="0 0 9 3" aria-hidden="true">
+        <circle cx="1.5" cy="1.5" r="0.95" fill="currentColor" />
+        <circle cx="4.5" cy="1.5" r="0.95" fill="currentColor" />
+        <circle cx="7.5" cy="1.5" r="0.95" fill="currentColor" />
       </svg>
       <span className="operation-launch-provider-glyph">{launchProviderGlyph(provider)}</span>
     </span>

--- a/runtime/fleet-console/core/client/src/components/launch-provider-glyphs.tsx
+++ b/runtime/fleet-console/core/client/src/components/launch-provider-glyphs.tsx
@@ -53,35 +53,38 @@ export function launchProviderGlyph(provider: LaunchProviderGlyphId): ReactNode 
   return <CodexGlyph />;
 }
 
+function asLaunchProvider(value: string | undefined): LaunchProviderGlyphId | null {
+  if (
+    value === "claude"
+    || value === "codex"
+    || value === "cursor"
+    || value === "kimi"
+    || value === "opencode"
+  ) {
+    return value;
+  }
+  return null;
+}
+
 export function launchProviderFromGroupId(groupId: string): LaunchProviderGlyphId | null {
   if (groupId === "native") return "claude";
   if (!groupId.startsWith("gateway:")) return null;
-  const provider = groupId.slice("gateway:".length);
-  if (
-    provider === "claude"
-    || provider === "codex"
-    || provider === "cursor"
-    || provider === "kimi"
-    || provider === "opencode"
-  ) {
-    return provider;
-  }
-  return null;
+  return asLaunchProvider(groupId.slice("gateway:".length));
 }
 
 /** Resolve the provider glyph for a selected launch-model id (`fable` or `cursor--grok-4.5`). */
 export function launchProviderFromModelId(modelId: string | null | undefined): LaunchProviderGlyphId | null {
   if (!modelId) return null;
   if (!modelId.includes("--")) return "claude";
-  const provider = modelId.split("--", 1)[0];
-  if (
-    provider === "claude"
-    || provider === "codex"
-    || provider === "cursor"
-    || provider === "kimi"
-    || provider === "opencode"
-  ) {
-    return provider;
-  }
-  return null;
+  return asLaunchProvider(modelId.split("--", 1)[0]);
+}
+
+/**
+ * Resolve the provider tone for a launch-kind id (`claude-gateway`). Agent CLI ids lead with the
+ * supplier they speak to, so the leading segment is the same identity the launch menu bands carry.
+ * Non-agent kinds such as `shell` have no supplier and stay untinted.
+ */
+export function launchProviderFromKindId(kindId: string | null | undefined): LaunchProviderGlyphId | null {
+  if (!kindId) return null;
+  return asLaunchProvider(kindId.split("-", 1)[0]);
 }

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -11,7 +11,7 @@ import { readQuickLaunchSelection, writeQuickLaunchModelEffort, writeQuickLaunch
 import { findVariantLaunchKind, QUICK_LAUNCH_DEFAULT_MODEL, QUICK_LAUNCH_PROMPT_MAX_CHARS, quickLaunchErrorMessageKey, resolveSelection } from "../quick-launch.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
 import { closeQuickLaunch, consumeQuickLaunchDraft, requestQuickLaunch, setActiveTheater } from "../store.js";
-import { launchProviderFromGroupId, launchProviderFromModelId, launchProviderGlyph } from "./launch-provider-glyphs.js";
+import { launchProviderFromGroupId, launchProviderFromModelId, launchProviderGlyph, LaunchProviderMark } from "./launch-provider-glyphs.js";
 import { EffortTrack, resolveRowEffort } from "./effort-track.js";
 
 // 카드 폭은 팔레트(920px)보다 좁다 — 팔레트는 결과 목록을 담고, 여기는 한 문단을 담는다.
@@ -354,11 +354,7 @@ export function QuickLaunch() {
                     const provider = launchProviderFromGroupId(group.id);
                     return (
                       <p className={`quick-launch-pop-band${provider ? ` is-${provider}` : ""}`}>
-                        {provider ? (
-                          <span className="operation-launch-provider-glyph" aria-hidden="true">
-                            {launchProviderGlyph(provider)}
-                          </span>
-                        ) : null}
+                        {provider ? <LaunchProviderMark provider={provider} /> : null}
                         <span>{group.label}</span>
                       </p>
                     );

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, type CSSProperties, type PointerEvent as ReactPointe
 
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
 
+import type { LaunchProviderGlyphId } from "../components/launch-provider-glyphs.js";
 import { useT } from "../i18n/index.js";
 import { operationActivityLabel, operationActivityVisual } from "../operation-activity.js";
 import { useInlineRename } from "../use-inline-rename.js";
@@ -18,6 +19,8 @@ export interface SideBarEntry {
   readonly notificationCount: number;
   readonly status?: OperationActivity;
   readonly icon: ReactNode;
+  /** Supplier behind the icon, when the Operation has one — carries the launch menu's provider tone. */
+  readonly iconProvider?: LaunchProviderGlyphId | null;
 }
 
 interface SideBarChipProps {
@@ -221,7 +224,7 @@ export function OperationsSideBarChip({
       }}
     >
       <span className="side-bar-chip-beacon-button" aria-hidden="true">
-        <span className="side-bar-chip-op-icon">
+        <span className={`side-bar-chip-op-icon${entry.iconProvider ? ` is-${entry.iconProvider}` : ""}`}>
           {entry.icon ?? <DefaultOpIcon />}
         </span>
       </span>

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -11,6 +11,7 @@ import type { OperationGroup, OperationNode, OperationNotification, TheaterInfo 
 import { CanvasContextMenu } from "../canvas/canvas-context-menu.js";
 import { focusCommandBandToggleWhenPanelContainsActiveElement } from "../focus-guards.js";
 import { DirectoryBrowserModal } from "../components/directory-browser-modal.js";
+import { launchProviderFromKindId } from "../components/launch-provider-glyphs.js";
 import { useConsoleState } from "../hooks/use-store.js";
 import { GroupContextMenu } from "../canvas/group-context-menu.js";
 import { operationAccentFromNode, resolveAccentColor } from "../canvas/operation-accent.js";
@@ -403,6 +404,7 @@ export function OperationsSideBar({
       notificationCount: operationNotifications[operation.id] ? 1 : 0,
       status: resolveOperationActivity(operation, operationStatus),
       icon,
+      iconProvider: launchProviderFromKindId(kind?.id),
     };
   });
   const groupedSections = groupOperations(allEntries, activeGroups, canvas.operationOrder);
@@ -1358,6 +1360,7 @@ export function buildTheaterEntries({
       notificationCount: operationNotifications[operation.id] ? 1 : 0,
       status: resolveOperationActivity(operation, operationStatus),
       icon,
+      iconProvider: launchProviderFromKindId(kind?.id),
     };
   });
 }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7343,6 +7343,10 @@
   flex: none;
   /* 앞 상자의 z-index가 밴드 바깥 층과 겨루지 않도록 쌍 안에서만 쌓이게 가둔다. */
   isolation: isolate;
+  /* 앞 상자가 딛고 설 바닥. 이 표식이 놓이는 두 표면(캔버스 실행 메뉴·Quick Launch 모델 팝오버)이
+     모두 .theater-menu 바닥을 쓰므로 그 식을 그대로 딴다. 라이트에서 pillar가 알파를 가지므로 이
+     값 자체는 완전 불투명이 아니다 — 불투명이 필요한 자리에서는 섞지 말고 --ink-deep 위에 쌓는다. */
+  --launch-pair-floor: color-mix(in oklch, var(--ink-deep) 60%, var(--surface-pillar));
 }
 
 /* 두 상자는 같은 각을 반대로 기울여 꽃잎처럼 마주 선다 — 각이 어긋나면 한 쌍이 아니라 한쪽이
@@ -7358,9 +7362,21 @@
   /* 겹침 폭은 뒤 상자의 마크를 먹지 않는 선까지다 — 더 물리면 하네스가 잘린 조각으로 보인다. */
   margin-left: -5px;
   transform: rotate(15deg);
-  /* 앞 상자는 자기 실루엣을 메뉴 바닥색으로 한 번 끊는다. 끊지 않으면 반투명한 두 상자의 테두리가
-     겹친 자리에서 뭉쳐 앞뒤가 사라진다. 색은 .theater-menu 바닥과 같은 식이다. */
-  box-shadow: 0 0 0 1.5px color-mix(in oklch, var(--ink-deep) 60%, var(--surface-pillar));
+  /* 앞 상자는 불투명하게 선다. 투명 위에 얹으면 뒤 상자의 마크가 그대로 비쳐 앞 글리프가 반쯤
+     지워진 것처럼 읽힌다 — 겹침에서 앞뒤를 만드는 것은 z-index가 아니라 불투명함이다.
+     바닥을 섞지 않고 겹쳐 쌓는 이유는 두 가지다. 하나, 라이트의 pillar는 알파를 가져 섞은 값이
+     불투명해지지 않는다. 둘, 유채색 톤과 무채색 바닥을 oklch로 섞으면 색상환을 가로질러 라이트에서
+     테두리가 초록으로 돈다(실측 hue 255 → 149). 톤 워시는 투명 위에 두고 불투명은 아래 층이 진다.
+     마지막 --ink-deep 층은 팝업 언더레이 계약과 같은 형태다. */
+  background:
+    linear-gradient(
+      color-mix(in oklch, var(--launch-provider-tone) 12%, transparent),
+      color-mix(in oklch, var(--launch-provider-tone) 12%, transparent)
+    ),
+    linear-gradient(var(--launch-pair-floor), var(--launch-pair-floor)),
+    var(--ink-deep);
+  /* 실루엣을 바닥색으로 한 번 끊어 두 상자의 테두리가 겹친 자리에서 뭉치지 않게 한다. */
+  box-shadow: 0 0 0 1.5px var(--launch-pair-floor);
 }
 
 .quick-launch-kind-icon.is-claude,

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7334,6 +7334,27 @@
   height: 10px;
 }
 
+/* 공급자 한 쌍 — 하네스 상자(Claude Code)와 모델 공급자 상자를 잇는다. Fleet은 공급자의 CLI를
+   띄우지 않고 모델만 빌려 쓰므로, 공급자 마크가 홀로 서면 그 회사 CLI로 실행된다고 잘못 읽힌다. */
+.operation-launch-provider-pair {
+  display: inline-flex;
+  align-items: center;
+  flex: none;
+  gap: 3px;
+}
+
+.operation-launch-provider-glyph.is-harness {
+  --launch-provider-tone: var(--provider-claude);
+}
+
+/* 이음매는 신원이 아니라 두 상자의 관계다 — 어느 쪽 공급자 톤도 빌리지 않는다. */
+.operation-launch-provider-link {
+  flex: none;
+  width: 11px;
+  height: 4px;
+  color: var(--text-tertiary);
+}
+
 .quick-launch-kind-icon.is-claude,
 .quick-launch-kind-icon.is-codex,
 .quick-launch-kind-icon.is-cursor,

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -4893,6 +4893,15 @@
   flex: none;
 }
 
+/* 아이콘이 곧 공급자 신원이다 — 실행 메뉴 밴드가 쓰는 provider 톤을 그대로 빌려, 칩 목록에서도
+   같은 마크가 같은 색으로 읽히게 한다. 상자는 빌리지 않는다: 아이콘을 담은 beacon 버튼이 이미
+   hover에서 테두리를 켜므로 상자가 겹친다. Shell처럼 공급자가 없는 종류는 중립으로 남는다. */
+.side-bar-chip-op-icon.is-claude { color: var(--provider-claude); }
+.side-bar-chip-op-icon.is-codex { color: var(--provider-codex); }
+.side-bar-chip-op-icon.is-cursor { color: var(--provider-cursor); }
+.side-bar-chip-op-icon.is-kimi { color: var(--provider-kimi); }
+.side-bar-chip-op-icon.is-opencode { color: var(--provider-opencode); }
+
 
 .side-bar-chip-name {
   flex: 1;

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7334,34 +7334,33 @@
   height: 10px;
 }
 
-/* 공급자 한 쌍 — 하네스 상자(Claude Code)와 모델 공급자 상자를 잇는다. Fleet은 공급자의 CLI를
-   띄우지 않고 모델만 빌려 쓰므로, 공급자 마크가 홀로 서면 그 회사 CLI로 실행된다고 잘못 읽힌다. */
+/* 공급자 한 쌍 — 하네스 상자(Claude Code)가 뒤, 모델 공급자 상자가 앞이다. Fleet은 공급자의 CLI를
+   띄우지 않고 모델만 빌려 쓰므로, 공급자 마크가 홀로 서면 그 회사 CLI로 실행된다고 잘못 읽힌다.
+   겹침의 앞뒤가 곧 그 관계다 — 하네스를 딛고 이 모델이 선다. */
 .operation-launch-provider-pair {
   display: inline-flex;
   align-items: center;
   flex: none;
-  gap: 1px;
+  /* 앞 상자의 z-index가 밴드 바깥 층과 겨루지 않도록 쌍 안에서만 쌓이게 가둔다. */
+  isolation: isolate;
 }
 
-/* 두 상자는 서로 반대로 기울어 꽃잎처럼 마주 선다 — 기운 각이 같고 방향만 반대라야 한쪽이
-   비뚤어진 것이 아니라 한 쌍이라고 읽힌다. 회전은 레이아웃 상자를 넓히지 않으므로, 기운 모서리가
-   먹는 여백만큼 이음매 폭으로 갚는다. */
-.operation-launch-provider-pair .operation-launch-provider-glyph {
-  transform: rotate(15deg);
-}
-
+/* 두 상자는 같은 각을 반대로 기울여 꽃잎처럼 마주 선다 — 각이 어긋나면 한 쌍이 아니라 한쪽이
+   비뚤어진 것으로 읽힌다. */
 .operation-launch-provider-glyph.is-harness {
   --launch-provider-tone: var(--provider-claude);
   transform: rotate(-15deg);
 }
 
-/* 이음매는 신원이 아니라 두 상자의 관계다 — 어느 쪽 공급자 톤도 빌리지 않고, 기운 상자 사이에서
-   홀로 수평을 지켜 둘을 잇는 축이 된다. */
-.operation-launch-provider-link {
-  flex: none;
-  width: 9px;
-  height: 3px;
-  color: var(--text-tertiary);
+.operation-launch-provider-glyph.is-model {
+  position: relative;
+  z-index: 1;
+  /* 겹침 폭은 뒤 상자의 마크를 먹지 않는 선까지다 — 더 물리면 하네스가 잘린 조각으로 보인다. */
+  margin-left: -5px;
+  transform: rotate(15deg);
+  /* 앞 상자는 자기 실루엣을 메뉴 바닥색으로 한 번 끊는다. 끊지 않으면 반투명한 두 상자의 테두리가
+     겹친 자리에서 뭉쳐 앞뒤가 사라진다. 색은 .theater-menu 바닥과 같은 식이다. */
+  box-shadow: 0 0 0 1.5px color-mix(in oklch, var(--ink-deep) 60%, var(--surface-pillar));
 }
 
 .quick-launch-kind-icon.is-claude,

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7340,18 +7340,27 @@
   display: inline-flex;
   align-items: center;
   flex: none;
-  gap: 3px;
+  gap: 1px;
+}
+
+/* 두 상자는 서로 반대로 기울어 꽃잎처럼 마주 선다 — 기운 각이 같고 방향만 반대라야 한쪽이
+   비뚤어진 것이 아니라 한 쌍이라고 읽힌다. 회전은 레이아웃 상자를 넓히지 않으므로, 기운 모서리가
+   먹는 여백만큼 이음매 폭으로 갚는다. */
+.operation-launch-provider-pair .operation-launch-provider-glyph {
+  transform: rotate(15deg);
 }
 
 .operation-launch-provider-glyph.is-harness {
   --launch-provider-tone: var(--provider-claude);
+  transform: rotate(-15deg);
 }
 
-/* 이음매는 신원이 아니라 두 상자의 관계다 — 어느 쪽 공급자 톤도 빌리지 않는다. */
+/* 이음매는 신원이 아니라 두 상자의 관계다 — 어느 쪽 공급자 톤도 빌리지 않고, 기운 상자 사이에서
+   홀로 수평을 지켜 둘을 잇는 축이 된다. */
 .operation-launch-provider-link {
   flex: none;
-  width: 11px;
-  height: 4px;
+  width: 9px;
+  height: 3px;
   color: var(--text-tertiary);
 }
 

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -594,6 +594,13 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
 
 .command-band-operation-kind { display: flex; align-items: center; line-height: 0; }
 .command-band-operation-kind svg { display: block; width: 13px; height: 13px; }
+/* 사이드바 칩과 같은 판정이다 — 마크는 공급자 신원을 지니므로 실행 메뉴의 provider 톤을 쓰고,
+   그 옆의 CLI 라벨은 속성 칩의 중립 잉크로 남겨 색이 한 번만 말하게 한다. */
+.command-band-operation-kind.is-claude { color: var(--provider-claude); }
+.command-band-operation-kind.is-codex { color: var(--provider-codex); }
+.command-band-operation-kind.is-cursor { color: var(--provider-cursor); }
+.command-band-operation-kind.is-kimi { color: var(--provider-kimi); }
+.command-band-operation-kind.is-opencode { color: var(--provider-opencode); }
 
 /* ===== Command Band 세그먼트 드롭다운 전환기 — 메뉴 문법은 components.css .theater-menu 계열의 밴드 스코프 미러 ===== */
 .command-band-switcher {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1561,7 +1561,7 @@ describe("Instrument core design contract", () => {
     expect(source("components/command-band.tsx")).toContain("launchProviderFromKindId(activeCliId)");
   });
 
-  it("pins the launch-band supplier pair — harness box, neutral link, single box for Claude", () => {
+  it("pins the launch-band supplier pair — harness box behind, mirrored tilt, single box for Claude", () => {
     // Fleet은 공급자의 CLI를 띄우지 않고 모델만 빌려 쓴다. 공급자 마크가 홀로 서면 그 회사 CLI로
     // 실행된다고 읽히므로, 밴드는 하네스 상자와 공급자 상자를 이은 한 쌍으로 말해야 한다.
     const glyphs = source("components/launch-provider-glyphs.tsx");
@@ -1578,14 +1578,26 @@ describe("Instrument core design contract", () => {
     const harness = components.match(/\.operation-launch-provider-glyph\.is-harness \{[^}]*\}/)?.[0] ?? "";
     expect(harness).toContain("--launch-provider-tone: var(--provider-claude);");
     // 두 상자는 같은 각을 반대로 기울여야 한 쌍으로 읽힌다 — 각이 어긋나면 비뚤어진 상자 하나가 된다.
-    const pairTilt = components.match(/\.operation-launch-provider-pair \.operation-launch-provider-glyph \{[^}]*\}/)?.[0] ?? "";
+    const model = components.match(/\.operation-launch-provider-glyph\.is-model \{[^}]*\}/)?.[0] ?? "";
     const tiltAngle = (block: string): string => block.match(/transform: rotate\((-?[\d.]+)deg\);/)?.[1] ?? "";
-    expect(tiltAngle(pairTilt)).not.toBe("");
-    expect(tiltAngle(harness)).toBe(`-${tiltAngle(pairTilt)}`);
-    // 이음매는 관계이지 신원이 아니라, 공급자 톤도 신호색도 빌리지 않는다.
-    const link = components.match(/\.operation-launch-provider-link \{[^}]*\}/)?.[0] ?? "";
-    expect(link).toContain("color: var(--text-tertiary);");
-    expect(link).not.toMatch(/--launch-provider-tone|--aurora|--coral|--warn|--positive|--brass/);
+    expect(tiltAngle(model)).not.toBe("");
+    expect(tiltAngle(harness)).toBe(`-${tiltAngle(model)}`);
+
+    // 겹침의 앞뒤가 하네스와 모델의 관계를 말한다 — 공급자 상자가 앞이고, 물리는 폭이 0이면
+    // 두 상자는 그냥 나란히 선 도장 두 개가 된다.
+    const overlapPx = Number(model.match(/margin-left: -([\d.]+)px;/)?.[1] ?? 0);
+    expect(overlapPx).toBeGreaterThan(0);
+    // 뒤 상자의 마크(16px 상자 안 10px 글리프 = 양옆 3px 여백)를 먹기 시작하면 하네스가 잘려 보인다.
+    expect(overlapPx).toBeLessThanOrEqual(6);
+    expect(model).toContain("z-index: 1;");
+    expect(harness).not.toMatch(/z-index/);
+    // 쌓임을 쌍 안에 가두지 않으면 앞 상자가 밴드 바깥 층까지 뚫고 올라간다.
+    const pair = components.match(/\.operation-launch-provider-pair \{[^}]*\}/)?.[0] ?? "";
+    expect(pair).toContain("isolation: isolate;");
+    // 실루엣을 끊는 링은 메뉴 바닥이지 신원이 아니다 — 공급자 톤도 신호색도 빌리지 않는다.
+    const ring = model.match(/box-shadow: [^;]*;/)?.[0] ?? "";
+    expect(ring).toContain("color-mix(in oklch, var(--ink-deep) 60%, var(--surface-pillar))");
+    expect(ring).not.toMatch(/--launch-provider-tone|--aurora|--coral|--warn|--positive|--brass/);
   });
 
   it("forbids native product selects in Console core, SDK, and built-in plugins", () => {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1594,9 +1594,25 @@ describe("Instrument core design contract", () => {
     // 쌓임을 쌍 안에 가두지 않으면 앞 상자가 밴드 바깥 층까지 뚫고 올라간다.
     const pair = components.match(/\.operation-launch-provider-pair \{[^}]*\}/)?.[0] ?? "";
     expect(pair).toContain("isolation: isolate;");
-    // 실루엣을 끊는 링은 메뉴 바닥이지 신원이 아니다 — 공급자 톤도 신호색도 빌리지 않는다.
+    // 바닥은 이 표식이 놓이는 메뉴 표면이지 신원이 아니다 — 공급자 톤도 신호색도 빌리지 않는다.
+    expect(pair).toContain("--launch-pair-floor: color-mix(in oklch, var(--ink-deep) 60%, var(--surface-pillar));");
+    // 앞뒤를 만드는 것은 z-index가 아니라 불투명함이다 — 앞 상자가 비치면 뒤 상자의 마크가 그대로
+    // 올라와 앞 글리프가 반쯤 지워진 것으로 읽힌다. 그 불투명은 섞어서 얻지 않고 층으로 쌓는다:
+    // 라이트의 pillar는 알파를 가져 섞은 값이 불투명해지지 않고, 유채색 톤을 무채색 바닥과 oklch로
+    // 섞으면 색상환을 가로질러 라이트에서 테두리가 초록으로 돈다(실측 hue 255 → 149).
+    const background = model.match(/background:[^;]*;/)?.[0] ?? "";
+    expect(background).toContain("color-mix(in oklch, var(--launch-provider-tone) 12%, transparent)");
+    expect(background).toContain("var(--launch-pair-floor)");
+    // 마지막 층은 팝업 언더레이 계약과 같은 불투명 바닥이다.
+    expect(background).toMatch(/var\(--ink-deep\);$/);
+    // 톤과 바닥을 한 색으로 섞는 순간 위 두 함정이 함께 돌아온다.
+    expect(model).not.toMatch(/color-mix\([^)]*--launch-provider-tone[^)]*--launch-pair-floor/);
+    // 테두리는 기본 규칙의 톤 위임으로 남는다 — 앞 상자는 이미 제 불투명 바닥을 깔았으므로
+    // transparent와 섞인 테두리도 뒤 상자가 아니라 자기 채움 위에 얹힌다.
+    expect(model).not.toContain("border-color:");
+    // 실루엣을 끊는 링도 같은 바닥이다.
     const ring = model.match(/box-shadow: [^;]*;/)?.[0] ?? "";
-    expect(ring).toContain("color-mix(in oklch, var(--ink-deep) 60%, var(--surface-pillar))");
+    expect(ring).toContain("var(--launch-pair-floor)");
     expect(ring).not.toMatch(/--launch-provider-tone|--aurora|--coral|--warn|--positive|--brass/);
   });
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1575,7 +1575,13 @@ describe("Instrument core design contract", () => {
 
     const components = source("styles/components.css");
     // 하네스 상자는 어느 밴드에 있든 Claude 톤이다 — 캡션이 물려준 공급자 톤을 쓰면 두 상자가 같은 색이 된다.
-    expect(components).toContain(".operation-launch-provider-glyph.is-harness {\n  --launch-provider-tone: var(--provider-claude);\n}");
+    const harness = components.match(/\.operation-launch-provider-glyph\.is-harness \{[^}]*\}/)?.[0] ?? "";
+    expect(harness).toContain("--launch-provider-tone: var(--provider-claude);");
+    // 두 상자는 같은 각을 반대로 기울여야 한 쌍으로 읽힌다 — 각이 어긋나면 비뚤어진 상자 하나가 된다.
+    const pairTilt = components.match(/\.operation-launch-provider-pair \.operation-launch-provider-glyph \{[^}]*\}/)?.[0] ?? "";
+    const tiltAngle = (block: string): string => block.match(/transform: rotate\((-?[\d.]+)deg\);/)?.[1] ?? "";
+    expect(tiltAngle(pairTilt)).not.toBe("");
+    expect(tiltAngle(harness)).toBe(`-${tiltAngle(pairTilt)}`);
     // 이음매는 관계이지 신원이 아니라, 공급자 톤도 신호색도 빌리지 않는다.
     const link = components.match(/\.operation-launch-provider-link \{[^}]*\}/)?.[0] ?? "";
     expect(link).toContain("color: var(--text-tertiary);");

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1558,7 +1558,28 @@ describe("Instrument core design contract", () => {
     expect(source("components/launch-provider-glyphs.tsx")).toContain("export function launchProviderFromKindId");
     expect(source("sidebar/operations-side-bar.tsx").match(/iconProvider: launchProviderFromKindId\(kind\?\.id\)/g)).toHaveLength(2);
     expect(source("sidebar/operations-side-bar-chip.tsx")).toContain('entry.iconProvider ? ` is-${entry.iconProvider}` : ""');
-    expect(source("components/command-band.tsx")).toContain("launchProviderFromKindId(activeCliId ?? activeOperation?.type)");
+    expect(source("components/command-band.tsx")).toContain("launchProviderFromKindId(activeCliId)");
+  });
+
+  it("pins the launch-band supplier pair — harness box, neutral link, single box for Claude", () => {
+    // Fleet은 공급자의 CLI를 띄우지 않고 모델만 빌려 쓴다. 공급자 마크가 홀로 서면 그 회사 CLI로
+    // 실행된다고 읽히므로, 밴드는 하네스 상자와 공급자 상자를 이은 한 쌍으로 말해야 한다.
+    const glyphs = source("components/launch-provider-glyphs.tsx");
+    expect(glyphs).toContain("export function LaunchProviderMark");
+    expect(glyphs).toContain('<span className="operation-launch-provider-glyph is-harness">{launchProviderGlyph("claude")}</span>');
+    // 두 밴드 표면이 같은 표식을 쓰지 않으면 같은 실행 목록이 표면마다 다른 신원을 주장한다.
+    for (const path of ["canvas/canvas-context-menu.tsx", "components/quick-launch.tsx"] as const) {
+      expect(source(path)).toContain("<LaunchProviderMark provider={provider} />");
+      expect(source(path)).not.toContain('<span className="operation-launch-provider-glyph" aria-hidden="true">');
+    }
+
+    const components = source("styles/components.css");
+    // 하네스 상자는 어느 밴드에 있든 Claude 톤이다 — 캡션이 물려준 공급자 톤을 쓰면 두 상자가 같은 색이 된다.
+    expect(components).toContain(".operation-launch-provider-glyph.is-harness {\n  --launch-provider-tone: var(--provider-claude);\n}");
+    // 이음매는 관계이지 신원이 아니라, 공급자 톤도 신호색도 빌리지 않는다.
+    const link = components.match(/\.operation-launch-provider-link \{[^}]*\}/)?.[0] ?? "";
+    expect(link).toContain("color: var(--text-tertiary);");
+    expect(link).not.toMatch(/--launch-provider-tone|--aurora|--coral|--warn|--positive|--brass/);
   });
 
   it("forbids native product selects in Console core, SDK, and built-in plugins", () => {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1529,6 +1529,38 @@ describe("Instrument core design contract", () => {
     expect(rail).toContain("width: 44px");
   });
 
+  it("pins the Operation mark provider tone — launch-menu token, tone only, supplier-less kinds neutral", () => {
+    // 같은 마크가 표면마다 다른 색으로 읽히면 공급자 신원이 아니라 표면 장식이 된다. 사이드바 칩과
+    // 커맨드 밴드는 실행 메뉴 밴드가 쓰는 provider 토큰을 그대로 빌리되, 색만 빌린다.
+    const components = source("styles/components.css");
+    const layout = source("styles/layout.css");
+    const PROVIDERS = ["claude", "codex", "cursor", "kimi", "opencode"];
+
+    for (const [css, selector] of [[components, "\\.side-bar-chip-op-icon"], [layout, "\\.command-band-operation-kind"]] as const) {
+      const rules = [...css.matchAll(new RegExp(`${selector}\\.is-([a-z]+) \\{([^}]*)\\}`, "g"))];
+      expect(rules.map(([, provider]) => provider)).toEqual(PROVIDERS);
+      for (const [, provider, declarations] of rules) {
+        const body = declarations ?? "";
+        expect(body.trim()).toBe(`color: var(--provider-${provider});`);
+        // 상자까지 빌리면 실행 메뉴의 캡션 밴드 문법이 칩 안으로 새어, 아이콘을 감싼 beacon 버튼의
+        // hover 테두리와 두 겹으로 겹친다 — 톤만 옮기고 테두리·채움은 남겨 둔다.
+        expect(body).not.toMatch(/border|background/);
+      }
+    }
+
+    // 공급자가 없는 종류(Shell)는 중립 잉크로 남아야 색이 "공급자가 있다"만 말한다.
+    expect(components).toContain(".side-bar-chip-op-icon {\n  display: flex;");
+    expect(components).toMatch(/\.side-bar-chip-op-icon \{[^}]*color: var\(--text-secondary\);/);
+    // 밴드에서는 마크만 색을 말하고 그 옆 CLI 라벨은 속성 칩의 중립 잉크로 남는다.
+    expect(layout).toMatch(/\.command-band-operation-attribute \{[^}]*color: var\(--text-tertiary\);/);
+
+    // 톤의 출처는 실행 종류 id 하나다 — 표면마다 제 나름의 공급자 추론을 두면 서로 어긋난다.
+    expect(source("components/launch-provider-glyphs.tsx")).toContain("export function launchProviderFromKindId");
+    expect(source("sidebar/operations-side-bar.tsx").match(/iconProvider: launchProviderFromKindId\(kind\?\.id\)/g)).toHaveLength(2);
+    expect(source("sidebar/operations-side-bar-chip.tsx")).toContain('entry.iconProvider ? ` is-${entry.iconProvider}` : ""');
+    expect(source("components/command-band.tsx")).toContain("launchProviderFromKindId(activeCliId ?? activeOperation?.type)");
+  });
+
   it("forbids native product selects in Console core, SDK, and built-in plugins", () => {
     const hits = findRawProductSelects();
     expect(hits, hits.map((hit) => `${hit.file}:${hit.line} ${hit.snippet}`).join("\n")).toEqual([]);

--- a/runtime/fleet-console/tests/launch-provider-glyphs.test.ts
+++ b/runtime/fleet-console/tests/launch-provider-glyphs.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  launchProviderFromGroupId,
+  launchProviderFromKindId,
+  launchProviderFromModelId,
+} from "../core/client/src/components/launch-provider-glyphs.js";
+
+describe("launchProviderFromKindId", () => {
+  it("tints the Agent CLI kinds the Console ships", () => {
+    expect(launchProviderFromKindId("claude-gateway")).toBe("claude");
+  });
+
+  it("leaves every other launch kind neutral", () => {
+    // 실행 종류 id는 플러그인이 자유롭게 짓는 문자열이다. 앞 토막을 공급자로 읽으면
+    // 외부 플러그인의 claude-report·codex-review가 자기 것이 아닌 공급자 색을 얻는다 —
+    // 아는 Agent CLI id만 칠하고 모르는 어휘는 중립으로 남겨 잘못된 신원을 주장하지 않는다.
+    for (const kindId of ["claude-report", "codex-review", "cursor-board", "kimi-notes", "opencode-panel"]) {
+      expect(launchProviderFromKindId(kindId), kindId).toBeNull();
+    }
+    for (const kindId of ["shell", "notes", "agent", "", null, undefined]) {
+      expect(launchProviderFromKindId(kindId), String(kindId)).toBeNull();
+    }
+  });
+});
+
+describe("launch menu provider resolvers", () => {
+  it("keeps resolving the launch-menu band groups", () => {
+    expect(launchProviderFromGroupId("native")).toBe("claude");
+    expect(launchProviderFromGroupId("gateway:cursor")).toBe("cursor");
+    expect(launchProviderFromGroupId("gateway:nope")).toBeNull();
+    expect(launchProviderFromGroupId("cursor")).toBeNull();
+  });
+
+  it("keeps resolving selected model ids", () => {
+    expect(launchProviderFromModelId("fable")).toBe("claude");
+    expect(launchProviderFromModelId("cursor--grok-4.5")).toBe("cursor");
+    expect(launchProviderFromModelId("nope--x")).toBeNull();
+    expect(launchProviderFromModelId(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- 실행 메뉴의 밴드는 Claude 마크를 공급자 톤으로 칠하는데, Operation이 생기고 나면 그 신원이 사라졌습니다. 사이드바 칩과 커맨드 밴드가 같은 마크를 셸과 똑같은 중립 잉크로 그려서, Claude 실행과 Shell 실행이 회색 글리프 하나 차이였습니다.
- 실행 종류 id에서 공급자를 풀어 두 표면에 메뉴가 쓰던 `--provider-*` 토큰을 넘깁니다. 옮기는 것은 톤뿐입니다 — 메뉴의 테두리 칩까지 가져오면 칩 아이콘을 감싼 beacon 버튼의 hover 테두리와 두 겹이 되고, 밴드 마크 옆 CLI 라벨은 중립으로 남겨 색이 한 번만 말하게 했습니다.
- 공급자가 없는 실행 종류(Shell 포함)는 중립 잉크 그대로입니다. 세 곳에 흩어져 있던 공급자 판별을 `launch-provider-glyphs.tsx`의 가드 하나로 접었습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 0 errors
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 163 files / 1836 passed
- [x] `instrument-design-contract` 신규 핀 1건 추가(48 passed). 신호 토큰(`--aurora`)으로 치환해 실제로 실패하는지 역검증함
- [x] 격리 콘솔 실측: 사이드바 칩 `oklch(0.78 0.15 62)` = 컨텍스트 메뉴 글리프와 동일, Shell은 `oklch(0.7 0.012 245)` 유지
- [x] 커맨드 밴드 마크 `oklch(0.78 0.15 62)`, 옆 CLI 라벨은 `oklch(0.64 0.012 245)` 중립 유지
- [x] 라이트(whites) 테마 재조율 확인 `oklch(0.54 0.135 62)`, carbon 테마 및 최소화 칩(opacity 0.62) 확인