### PR TITLE
fix(fleet-console): keep command band carets visible

### DIFF
--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -632,17 +632,10 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   place-items: center;
   flex: none;
   color: var(--text-tertiary);
-  opacity: 0;
-  transition: opacity var(--duration-fast) var(--ease-spring);
+  opacity: 0.75;
 }
 
 .command-band-trigger-caret svg { display: block; width: 10px; height: 10px; }
-
-.command-band-segment-trigger:hover .command-band-trigger-caret,
-.command-band-segment-trigger:focus-visible .command-band-trigger-caret,
-.command-band-segment-trigger.is-open .command-band-trigger-caret {
-  opacity: 0.75;
-}
 
 .command-band-operation-placeholder {
   color: var(--text-tertiary);

--- a/runtime/fleet-console/tests/command-band-v2-guards.test.ts
+++ b/runtime/fleet-console/tests/command-band-v2-guards.test.ts
@@ -65,6 +65,16 @@ describe("Command Band rename cancel follows the displayed Operation", () => {
   });
 });
 
+describe("Command Band switcher disclosure", () => {
+  it("keeps the Theater and Operation carets visible without hover", () => {
+    const styles = readFileSync(resolve(process.cwd(), "core/client/src/styles/layout.css"), "utf8");
+    const caretRule = styles.match(/\.command-band-trigger-caret \{(?<body>[^}]*)\}/)?.groups?.body ?? "";
+
+    expect(caretRule).toContain("opacity: 0.75");
+    expect(styles).not.toContain(".command-band-segment-trigger:hover .command-band-trigger-caret");
+  });
+});
+
 describe("Command Band switcher focusout close decision", () => {
   it("stays open while focus moves within the wrapper and closes when it leaves or vanishes", () => {
     const wrapper = document.createElement("div");


### PR DESCRIPTION
## Summary

- Keep the Theater and Operation switcher carets visible without requiring hover.
- Preserve the existing caret size, color, and active-state opacity while removing the hidden idle state.
- Add a regression guard for the persistent disclosure affordance.

## Test Plan

- [x] `pnpm --dir runtime/fleet-console exec vitest run tests/command-band-v2-guards.test.ts`
- [x] `pnpm --dir runtime/fleet-console typecheck`
- [x] `pnpm --dir runtime/fleet-console build`
- [x] Launch an isolated Console and confirm `/console/operations` returns HTTP 200.