### PR TITLE
fix(core-ai-gateway): retry safe Codex socket terminations

### DIFF
--- a/packages/core-ai-gateway/src/codex/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/codex/responses/adapter.ts
@@ -37,6 +37,7 @@ export const OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses";
 export const CHATGPT_CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
 export const DEFAULT_MAX_UPSTREAM_BODY_BYTES = 64 * 1024 * 1024;
 export const DEFAULT_UPSTREAM_IDLE_TIMEOUT_MS = 30_000;
+const CODEX_SOCKET_RETRY_DELAY_MS = 200;
 
 // ChatGPT 백엔드는 Platform API가 받는 샘플링 파라미터를 400으로 거절한다.
 // 실측으로 확정한 거부 목록. metadata는 "Unsupported parameter", 샘플링 필드는 400으로 돌아온다.
@@ -223,12 +224,124 @@ export class CodexResponsesAdapter extends OpenAIResponsesAdapter {
         ...(options.accountId ? { "chatgpt-account-id": options.accountId } : {}),
         ...options.headers,
       },
-      ...(options.fetch ? { fetch: options.fetch } : {}),
+      fetch: markCodexFetchFailures(options.fetch ?? globalThis.fetch.bind(globalThis)),
       // `!== undefined` 여야 명시적 0이 상속된 positiveInteger 검증을 통과한다.
       ...(options.maxBodyBytes !== undefined ? { maxBodyBytes: options.maxBodyBytes } : {}),
       ...(options.idleTimeoutMs !== undefined ? { idleTimeoutMs: options.idleTimeoutMs } : {}),
     });
   }
+
+  override async stream(
+    request: CanonicalResponseRequest,
+    options: AdapterCallOptions,
+  ): Promise<AdapterResponse> {
+    let response: AdapterResponse;
+    try {
+      response = await super.stream(request, options);
+    } catch (error) {
+      if (!isRetryableCodexFetchSocketTermination(error, options.signal)) {
+        throw error;
+      }
+      await abortableDelay(CODEX_SOCKET_RETRY_DELAY_MS, options.signal);
+      return await super.stream(request, options);
+    }
+    if (!response.ok) {
+      return response;
+    }
+    return {
+      ...response,
+      events: retryCodexStreamBeforeFirstEvent(response.events, async () => {
+        await abortableDelay(CODEX_SOCKET_RETRY_DELAY_MS, options.signal);
+        const retried = await super.stream(request, options);
+        if (!retried.ok) {
+          throw new UpstreamProtocolError(`Codex retry failed with status ${retried.status}`);
+        }
+        return retried.events;
+      }, options.signal),
+    };
+  }
+}
+
+async function* retryCodexStreamBeforeFirstEvent(
+  events: AsyncIterable<CanonicalResponseEvent>,
+  retry: () => Promise<AsyncIterable<CanonicalResponseEvent>>,
+  signal?: AbortSignal,
+): AsyncGenerator<CanonicalResponseEvent> {
+  let yielded = false;
+  try {
+    for await (const event of events) {
+      yielded = true;
+      yield event;
+    }
+  } catch (error) {
+    if (yielded || signal?.aborted === true || !isUndiciSocketTermination(error)) {
+      throw error;
+    }
+    yield* await retry();
+  }
+}
+
+const codexFetchFailures = new WeakSet<object>();
+
+function markCodexFetchFailures(fetchImpl: FetchLike): FetchLike {
+  return async (input, init) => {
+    try {
+      return await fetchImpl(input, init);
+    } catch (error) {
+      if (error !== null && typeof error === "object") {
+        codexFetchFailures.add(error);
+      }
+      throw error;
+    }
+  };
+}
+
+function isRetryableCodexFetchSocketTermination(error: unknown, signal?: AbortSignal): boolean {
+  return signal?.aborted !== true
+    && isMarkedCodexFetchFailure(error)
+    && isUndiciSocketTermination(error);
+}
+
+function isMarkedCodexFetchFailure(error: unknown): boolean {
+  return error !== null && typeof error === "object" && codexFetchFailures.has(error);
+}
+
+function isUndiciSocketTermination(error: unknown): boolean {
+  const seen = new Set<object>();
+  let current: unknown = error;
+  for (let depth = 0; depth <= 4; depth += 1) {
+    if (current === null || typeof current !== "object" || seen.has(current)) {
+      return false;
+    }
+    seen.add(current);
+    if ((current as { code?: unknown }).code === "UND_ERR_SOCKET") {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+async function abortableDelay(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted === true) {
+    throw signal.reason;
+  }
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(finishResolve, delayMs);
+    function cleanup(): void {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", finishReject);
+    }
+    function finishResolve(): void {
+      cleanup();
+      resolve();
+    }
+    function finishReject(): void {
+      cleanup();
+      reject(signal?.reason);
+    }
+    signal?.addEventListener("abort", finishReject, { once: true });
+  });
 }
 
 function forOpenAIResponsesBackend(

--- a/packages/core-ai-gateway/tests/codex/responses/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/codex/responses/adapter.test.ts
@@ -102,6 +102,91 @@ describe("codex responses adapter", () => {
     expect(body.tools).toHaveLength(1);
   });
 
+  it("retries one UND_ERR_SOCKET before the response starts", async () => {
+    const socketError = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" });
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockRejectedValueOnce(new TypeError("terminated", { cause: socketError }))
+      .mockResolvedValueOnce(sse("data: [DONE]\n\n"));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    expect(response.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries one UND_ERR_SOCKET before the first canonical event", async () => {
+    const socketError = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" });
+    const terminated = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new TypeError("terminated", { cause: socketError }));
+      },
+    });
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(terminated, { status: 200 }))
+      .mockResolvedValueOnce(sse("data: [DONE]\n\n"));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const events = [];
+    for await (const event of response.events) events.push(event);
+    expect(events).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry UND_ERR_SOCKET after a canonical event was yielded", async () => {
+    const encoder = new TextEncoder();
+    const socketError = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" });
+    let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const terminated = new ReadableStream<Uint8Array>({
+      start(controller) {
+        streamController = controller;
+        controller.enqueue(encoder.encode('data: {"type":"response.created","response":{"id":"r","model":"gpt-5.6-luna"}}\n\n'));
+      },
+    });
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(terminated, { status: 200 }));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const iterator = response.events[Symbol.asyncIterator]();
+    await expect(iterator.next()).resolves.toMatchObject({ value: { type: "response.created" } });
+    streamController?.error(new TypeError("terminated", { cause: socketError }));
+    await expect(iterator.next()).rejects.toMatchObject({ message: "terminated" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a known HTTP status when its error body socket terminates", async () => {
+    const socketError = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" });
+    const terminated = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new TypeError("terminated", { cause: socketError }));
+      },
+    });
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(terminated, { status: 429 }));
+
+    await expect(new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" }))
+      .rejects.toMatchObject({ message: "terminated" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry caller aborts or unrelated transport failures", async () => {
+    const caller = new AbortController();
+    caller.abort(new Error("caller stopped"));
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      throw Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" });
+    });
+    await expect(new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), {
+      apiKey: "k",
+      signal: caller.signal,
+    })).rejects.toThrow("other side closed");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const unrelated = vi.fn<typeof fetch>(async () => {
+      throw Object.assign(new Error("connect reset"), { code: "ECONNRESET" });
+    });
+    await expect(new CodexResponsesAdapter({ fetch: unrelated }).stream(request(), { apiKey: "k" }))
+      .rejects.toThrow("connect reset");
+    expect(unrelated).toHaveBeenCalledTimes(1);
+  });
+
   it("validates explicit zero limits instead of silently accepting them", () => {
     expect(() => new CodexResponsesAdapter({ maxBodyBytes: 0 })).toThrow(TypeError);
     expect(() => new CodexResponsesAdapter({ idleTimeoutMs: 0 })).toThrow(TypeError);


### PR DESCRIPTION
## Summary
- Retry `UND_ERR_SOCKET` once when Codex fails before any caller-visible canonical event.
- Preserve caller aborts, known HTTP status failures, unrelated transport errors, and post-event stream failures without retry.
- Add deterministic coverage for fetch-level, pre-event stream, post-event stream, and HTTP error-body boundaries.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` — 583 tests passed
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] Real Undici socket fault injection for pre-event recovery and post-event no-retry
- [x] `node scripts/compile-changelog-fragments.mjs --check --allow-empty`
- [x] `git diff --check`