### PR TITLE
feat(fleet-console): add ULTRACODE effort behind a gauge chamber

### DIFF
--- a/.changelog.d/ultracode-effort.md
+++ b/.changelog.d/ultracode-effort.md
@@ -10,3 +10,5 @@ branch: ultracode-effort
 #### Changed
 - Stop the ordinary effort rail at XHIGH and keep MAX and ULTRACODE behind a gate on the gauge, so the costly rungs take a deliberate press instead of a stray drag. Opening the gate states the cost and keeps it on screen, picking one of these rungs arms it without launching, and neither rung is carried over from disk or from the model you switched away from.
   ko: 평범한 강도 레일을 XHIGH에서 끊고 MAX와 ULTRACODE를 게이지의 게이트 뒤에 두었습니다. 비용이 큰 단은 스쳐 지나간 드래그가 아니라 분명한 조작으로만 닿습니다. 게이트를 열면 비용을 밝혀 화면에 남기고, 이 단을 고르는 것은 실행이 아니라 장전까지이며, 디스크나 직전 모델에서 물려받지도 않습니다.
+- Run a drifting spectrum across the gauge while MAX or ULTRACODE is loaded, so a session-only expensive mode keeps announcing itself instead of resting on one more notch of the ordinary ramp. Reduced-motion settings keep the spectrum and drop the drift.
+  ko: MAX나 ULTRACODE가 실린 동안에는 게이지에 스펙트럼이 흐릅니다. 세션 한정 고비용 모드가 평범한 램프의 한 칸 더로 보이지 않고 계속 자기를 알립니다. 모션을 줄인 환경에서는 색은 남기고 흐름만 걷어 냅니다.

--- a/.changelog.d/ultracode-effort.md
+++ b/.changelog.d/ultracode-effort.md
@@ -1,0 +1,12 @@
+---
+branch: ultracode-effort
+---
+
+### fleet-console
+#### Added
+- Offer ULTRACODE on the launch effort gauge, which runs Claude Code at XHIGH reasoning with dynamic workflow orchestration turned on for that session. Gateway models offer it only when the model can honour XHIGH, so the rung you pick is never quietly reduced upstream.
+  ko: 실행 강도 게이지에 ULTRACODE를 추가했습니다. Claude Code를 XHIGH 추론으로 실행하면서 그 세션에 한해 dynamic workflow 오케스트레이션을 켭니다. XHIGH를 소화할 수 있는 게이트웨이 모델에만 내주므로, 고른 단이 상류에서 조용히 깎이지 않습니다.
+
+#### Changed
+- Stop the ordinary effort rail at XHIGH and keep MAX and ULTRACODE behind a gate on the gauge, so the costly rungs take a deliberate press instead of a stray drag. Opening the gate states the cost and keeps it on screen, picking one of these rungs arms it without launching, and neither rung is carried over from disk or from the model you switched away from.
+  ko: 평범한 강도 레일을 XHIGH에서 끊고 MAX와 ULTRACODE를 게이지의 게이트 뒤에 두었습니다. 비용이 큰 단은 스쳐 지나간 드래그가 아니라 분명한 조작으로만 닿습니다. 게이트를 열면 비용을 밝혀 화면에 남기고, 이 단을 고르는 것은 실행이 아니라 장전까지이며, 디스크나 직전 모델에서 물려받지도 않습니다.

--- a/packages/fleet-admiral/assets/hooks/workflow-guard.mjs
+++ b/packages/fleet-admiral/assets/hooks/workflow-guard.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 // Fleet workflow model guard — Admiral 정책 게이트 (PreToolUse, matcher: Workflow).
 //
-// dynamic workflow 스크립트를 디스패치하기 전에 검증해 두 가지 사고를 차단한다:
+// dynamic workflow 스크립트를 디스패치하기 전에 검증해 세 가지 사고를 차단한다:
 //   1. opts.agentType 사용 (금지 — agentType은 팀메이트/서브에이전트 표면 전용)
 //   2. opts.model 값이 lineage alias도, claude-gateway-- 접두 modelId도 아닌 경우
 //      (gateway_models의 modelId에서 claude-gateway-- prefix를 누락한 사고)
+//   3. agent() 호출에 리터럴 opts.model pin이 없어 세션 모델을 상속하는 경우
 //
 // stdin으로 PreToolUse 훅 입력 JSON({ tool_name, tool_input, ... })을 받고,
 // 위반 시 stderr에 사유를 쓰고 exit 2로 호출을 차단한다. 통과 시 exit 0.
@@ -15,11 +16,354 @@ const MODEL_ALIASES = /^(fable|opus|sonnet|haiku)$/;
 const PREFIXED_ALIAS_RE = /^claude-gateway--(fable|opus|sonnet|haiku)$/;
 const GATEWAY_MODEL_PREFIX = "claude-gateway--";
 const AGENT_TYPE_RE = /agentType\s*:/;
-const MODEL_RE = /model:\s*['"]([^'"]+)['"]/g;
+const IDENTIFIER_CHAR_RE = /[A-Za-z0-9_$]/;
+const OPEN_TO_CLOSE = { "(": ")", "[": "]", "{": "}" };
+const CLOSING_DELIMITERS = new Set(Object.values(OPEN_TO_CLOSE));
 
 function block(message) {
   process.stderr.write(`[workflow-guard] ${message}\n`);
   process.exit(2);
+}
+
+function skipQuotedString(source, start) {
+  const quote = source[start];
+  let index = start + 1;
+  while (index < source.length) {
+    if (source[index] === "\\") {
+      index += 2;
+      continue;
+    }
+    if (source[index] === quote) return index + 1;
+    index += 1;
+  }
+  return source.length;
+}
+
+function skipLineComment(source, start) {
+  const newline = source.indexOf("\n", start + 2);
+  return newline === -1 ? source.length : newline + 1;
+}
+
+function skipBlockComment(source, start) {
+  const close = source.indexOf("*/", start + 2);
+  return close === -1 ? source.length : close + 2;
+}
+
+function skipComment(source, start) {
+  if (source[start] !== "/") return start;
+  if (source[start + 1] === "/") return skipLineComment(source, start);
+  if (source[start + 1] === "*") return skipBlockComment(source, start);
+  return start;
+}
+
+function findMatchingDelimiter(source, openIndex) {
+  const first = source[openIndex];
+  if (!OPEN_TO_CLOSE[first]) return -1;
+
+  const stack = [first];
+  let index = openIndex + 1;
+  while (index < source.length) {
+    const character = source[index];
+    if (character === "'" || character === '"') {
+      index = skipQuotedString(source, index);
+      continue;
+    }
+    if (character === "`") {
+      index = skipTemplateLiteral(source, index);
+      continue;
+    }
+    const afterComment = skipComment(source, index);
+    if (afterComment !== index) {
+      index = afterComment;
+      continue;
+    }
+    if (OPEN_TO_CLOSE[character]) {
+      stack.push(character);
+      index += 1;
+      continue;
+    }
+    if (CLOSING_DELIMITERS.has(character)) {
+      const open = stack.pop();
+      if (OPEN_TO_CLOSE[open] !== character) return -1;
+      if (stack.length === 0) return index;
+    }
+    index += 1;
+  }
+  return -1;
+}
+
+function skipTemplateLiteral(source, start, interpolationRanges) {
+  let index = start + 1;
+  while (index < source.length) {
+    if (source[index] === "\\") {
+      index += 2;
+      continue;
+    }
+    if (source[index] === "`") return index + 1;
+    if (source[index] === "$" && source[index + 1] === "{") {
+      const close = findMatchingDelimiter(source, index + 1);
+      if (close === -1) return source.length;
+      interpolationRanges?.push([index + 2, close]);
+      index = close + 1;
+      continue;
+    }
+    index += 1;
+  }
+  return source.length;
+}
+
+function skipTrivia(source, start, end = source.length) {
+  let index = start;
+  while (index < end) {
+    if (/\s/.test(source[index])) {
+      index += 1;
+      continue;
+    }
+    const afterComment = skipComment(source, index);
+    if (afterComment !== index) {
+      index = Math.min(afterComment, end);
+      continue;
+    }
+    break;
+  }
+  return index;
+}
+
+function findAgentCallsInRange(source, start, end, calls) {
+  let index = start;
+  let previousSignificant = "";
+  while (index < end) {
+    const character = source[index];
+    if (/\s/.test(character)) {
+      index += 1;
+      continue;
+    }
+    const afterComment = skipComment(source, index);
+    if (afterComment !== index) {
+      index = Math.min(afterComment, end);
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      index = Math.min(skipQuotedString(source, index), end);
+      previousSignificant = character;
+      continue;
+    }
+    if (character === "`") {
+      const interpolationRanges = [];
+      const afterTemplate = skipTemplateLiteral(source, index, interpolationRanges);
+      for (const [interpolationStart, interpolationEnd] of interpolationRanges) {
+        findAgentCallsInRange(source, interpolationStart, interpolationEnd, calls);
+      }
+      index = Math.min(afterTemplate, end);
+      previousSignificant = "`";
+      continue;
+    }
+    if (IDENTIFIER_CHAR_RE.test(character)) {
+      let identifierEnd = index + 1;
+      while (identifierEnd < end && IDENTIFIER_CHAR_RE.test(source[identifierEnd])) identifierEnd += 1;
+      const identifier = source.slice(index, identifierEnd);
+      if (identifier === "agent" && previousSignificant !== "." && previousSignificant !== "#") {
+        const openIndex = skipTrivia(source, identifierEnd, end);
+        if (source[openIndex] === "(") {
+          const closeIndex = findMatchingDelimiter(source, openIndex);
+          const afterCall = closeIndex === -1 ? -1 : skipTrivia(source, closeIndex + 1, end);
+          if (afterCall === -1 || source[afterCall] !== "{") {
+            calls.push({ start: index, open: openIndex, close: closeIndex });
+          }
+        }
+      }
+      previousSignificant = source[identifierEnd - 1];
+      index = identifierEnd;
+      continue;
+    }
+    previousSignificant = character;
+    index += 1;
+  }
+}
+
+function findAgentCalls(source) {
+  const calls = [];
+  findAgentCallsInRange(source, 0, source.length, calls);
+  return calls.sort((left, right) => left.start - right.start);
+}
+
+function splitTopLevelRanges(source, start, end) {
+  if (start === end) return [];
+
+  const ranges = [];
+  const stack = [];
+  let rangeStart = start;
+  let index = start;
+  while (index < end) {
+    const character = source[index];
+    if (character === "'" || character === '"') {
+      index = skipQuotedString(source, index);
+      continue;
+    }
+    if (character === "`") {
+      index = skipTemplateLiteral(source, index);
+      continue;
+    }
+    const afterComment = skipComment(source, index);
+    if (afterComment !== index) {
+      index = afterComment;
+      continue;
+    }
+    if (OPEN_TO_CLOSE[character]) {
+      stack.push(character);
+      index += 1;
+      continue;
+    }
+    if (CLOSING_DELIMITERS.has(character)) {
+      const open = stack.pop();
+      if (OPEN_TO_CLOSE[open] !== character) return [];
+      index += 1;
+      continue;
+    }
+    if (character === "," && stack.length === 0) {
+      ranges.push([rangeStart, index]);
+      rangeStart = index + 1;
+    }
+    index += 1;
+  }
+  if (stack.length > 0) return [];
+  ranges.push([rangeStart, end]);
+  return ranges;
+}
+
+function readQuotedLiteral(source, start, end) {
+  const after = skipQuotedString(source, start);
+  if (after > end || source[after - 1] !== source[start]) return undefined;
+  return { after, value: source.slice(start + 1, after - 1) };
+}
+
+function readModelProperty(source, start, end) {
+  let index = skipTrivia(source, start, end);
+  let key;
+  if (source[index] === "'" || source[index] === '"') {
+    const literal = readQuotedLiteral(source, index, end);
+    if (!literal) return undefined;
+    key = literal.value;
+    index = literal.after;
+  } else if (source.startsWith("model", index) && !IDENTIFIER_CHAR_RE.test(source[index + 5] ?? "")) {
+    key = "model";
+    index += 5;
+  } else {
+    return undefined;
+  }
+  if (key !== "model") return undefined;
+
+  index = skipTrivia(source, index, end);
+  if (source[index] !== ":") return { literal: false };
+  index = skipTrivia(source, index + 1, end);
+  if (source[index] !== "'" && source[index] !== '"') return { literal: false };
+
+  const literal = readQuotedLiteral(source, index, end);
+  if (!literal || skipTrivia(source, literal.after, end) !== end) return { literal: false };
+  return { literal: true, value: literal.value };
+}
+
+function findLiteralModelPin(source, call) {
+  if (call.close === -1) return undefined;
+  const argumentRanges = splitTopLevelRanges(source, call.open + 1, call.close);
+  if (argumentRanges.length < 2) return undefined;
+
+  const [optionsStart, optionsEnd] = argumentRanges[1];
+  const objectStart = skipTrivia(source, optionsStart, optionsEnd);
+  if (source[objectStart] !== "{") return undefined;
+  const objectClose = findMatchingDelimiter(source, objectStart);
+  if (objectClose === -1 || skipTrivia(source, objectClose + 1, optionsEnd) !== optionsEnd) return undefined;
+
+  let pin;
+  for (const [propertyStart, propertyEnd] of splitTopLevelRanges(source, objectStart + 1, objectClose)) {
+    const property = readModelProperty(source, propertyStart, propertyEnd);
+    if (property) pin = property;
+  }
+  return pin?.literal ? pin.value : undefined;
+}
+
+/**
+ * 코드 위치의 `model:` 리터럴만 모은다. 스크립트 전체를 정규식으로 훑으면 프롬프트 문장이나
+ * 주석에 적힌 `model: "gpt-4"` 같은 산문까지 값으로 읽혀, 아무 잘못 없는 워크플로우가 차단된다.
+ * 키로 쓰인 "model"과 그저 그렇게 시작하는 문자열을 가르려면 따옴표 안을 끝까지 읽어야 한다.
+ */
+function findModelPinValues(source, start, end, values) {
+  let index = start;
+  while (index < end) {
+    const character = source[index];
+    if (/\s/.test(character)) {
+      index += 1;
+      continue;
+    }
+    const afterComment = skipComment(source, index);
+    if (afterComment !== index) {
+      index = Math.min(afterComment, end);
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      const literal = readQuotedLiteral(source, index, end);
+      if (literal && literal.value === "model" && source[skipTrivia(source, literal.after, end)] === ":") {
+        index = readModelPinValue(source, skipTrivia(source, literal.after, end) + 1, end, values);
+        continue;
+      }
+      index = Math.min(skipQuotedString(source, index), end);
+      continue;
+    }
+    if (character === "`") {
+      const interpolationRanges = [];
+      const afterTemplate = skipTemplateLiteral(source, index, interpolationRanges);
+      for (const [interpolationStart, interpolationEnd] of interpolationRanges) {
+        findModelPinValues(source, interpolationStart, interpolationEnd, values);
+      }
+      index = Math.min(afterTemplate, end);
+      continue;
+    }
+    if (IDENTIFIER_CHAR_RE.test(character)) {
+      let identifierEnd = index + 1;
+      while (identifierEnd < end && IDENTIFIER_CHAR_RE.test(source[identifierEnd])) identifierEnd += 1;
+      const afterKey = skipTrivia(source, identifierEnd, end);
+      if (source.slice(index, identifierEnd) === "model" && source[afterKey] === ":") {
+        index = readModelPinValue(source, afterKey + 1, end, values);
+        continue;
+      }
+      index = identifierEnd;
+      continue;
+    }
+    index += 1;
+  }
+}
+
+function readModelPinValue(source, start, end, values) {
+  const valueStart = skipTrivia(source, start, end);
+  if (source[valueStart] === "'" || source[valueStart] === '"') {
+    const literal = readQuotedLiteral(source, valueStart, end);
+    if (literal) {
+      values.push(literal.value);
+      return literal.after;
+    }
+  }
+  return Math.max(valueStart, start + 1);
+}
+
+function validateModel(value) {
+  if (MODEL_ALIASES.test(value)) return;
+  if (PREFIXED_ALIAS_RE.test(value)) {
+    block(
+      `lineage alias에는 claude-gateway-- prefix를 붙이면 안 됩니다: "${value}". ` +
+        "alias는 그대로(fable|opus|sonnet|haiku) 사용하세요."
+    );
+  }
+  if (value.startsWith(GATEWAY_MODEL_PREFIX)) return;
+  block(
+    `opts.model 값이 올바르지 않습니다: "${value}". gateway_models의 modelId(claude-gateway-- prefix 포함)를 ` +
+      "그대로 복사하거나 lineage alias(fable|opus|sonnet|haiku)를 사용하세요."
+  );
+}
+
+function callSnippet(source, call) {
+  const end = call.close === -1 ? Math.min(source.length, call.start + 120) : call.close + 1;
+  const snippet = source.slice(call.start, end).replace(/\s+/g, " ").trim();
+  return snippet.length <= 120 ? snippet : `${snippet.slice(0, 117)}...`;
 }
 
 let input;
@@ -55,19 +399,24 @@ if (AGENT_TYPE_RE.test(script)) {
   );
 }
 
-for (const match of script.matchAll(MODEL_RE)) {
-  const value = match[1];
-  if (MODEL_ALIASES.test(value)) continue;
-  if (PREFIXED_ALIAS_RE.test(value)) {
-    block(
-      `lineage alias에는 claude-gateway-- prefix를 붙이면 안 됩니다: "${value}". ` +
-        "alias는 그대로(fable|opus|sonnet|haiku) 사용하세요."
-    );
+const modelPinValues = [];
+findModelPinValues(script, 0, script.length, modelPinValues);
+for (const value of modelPinValues) {
+  validateModel(value);
+}
+
+const calls = findAgentCalls(script);
+for (const [index, call] of calls.entries()) {
+  const model = findLiteralModelPin(script, call);
+  if (model !== undefined) {
+    validateModel(model);
+    continue;
   }
-  if (value.startsWith(GATEWAY_MODEL_PREFIX)) continue;
   block(
-    `opts.model 값이 올바르지 않습니다: "${value}". gateway_models의 modelId(claude-gateway-- prefix 포함)를 ` +
-      "그대로 복사하거나 lineage alias(fable|opus|sonnet|haiku)를 사용하세요."
+    `${index + 1}번째 agent() 호출에 리터럴 opts.model pin이 없습니다: ${callSnippet(script, call)}. ` +
+      "model을 지정하지 않은 agent() 호출은 세션 모델을 상속해 세션 자체 allowance를 소비하며, " +
+      "이는 선택이 아니라 누락으로 도달합니다. opts.model에 lineage alias(fable|opus|sonnet|haiku) 또는 " +
+      "gateway_models에서 claude-gateway-- prefix를 포함해 그대로 복사한 전체 modelId를 추가하세요."
   );
 }
 

--- a/packages/fleet-admiral/assets/hooks/workflow-guard.mjs
+++ b/packages/fleet-admiral/assets/hooks/workflow-guard.mjs
@@ -56,6 +56,55 @@ function skipComment(source, start) {
   return start;
 }
 
+/**
+ * `/`가 나눗셈이 아니라 정규식의 시작인지. 직전 유효 문자가 값을 끝내는 자리(식별자·숫자·닫는
+ * 괄호)면 나눗셈이고, 그렇지 않으면 정규식이다. 판정이 서지 않으면 나눗셈으로 본다 — 정규식으로
+ * 오인해 뒤를 통째로 삼키는 쪽이 훨씬 나쁘다.
+ */
+function isRegexPosition(source, start) {
+  let index = start - 1;
+  while (index >= 0 && /\s/.test(source[index])) index -= 1;
+  if (index < 0) return true;
+  const previous = source[index];
+  if (/[)\]}]/.test(previous)) return false;
+  if (/[A-Za-z0-9_$]/.test(previous)) {
+    let wordEnd = index + 1;
+    let wordStart = index;
+    while (wordStart >= 0 && /[A-Za-z0-9_$]/.test(source[wordStart])) wordStart -= 1;
+    const word = source.slice(wordStart + 1, wordEnd);
+    return ["return", "typeof", "instanceof", "in", "of", "new", "delete", "void", "case", "do", "else", "yield", "await"].includes(word);
+  }
+  return true;
+}
+
+/**
+ * 정규식 리터럴을 건너뛴다. 문자 클래스(`[...]`) 안의 `/`는 종결자가 아니므로 클래스 안팎을
+ * 따로 센다 — 이 구분이 없으면 `/[)]/g` 같은 리터럴의 `)`가 실제 닫는 괄호로 읽혀,
+ * 정상 스크립트의 `agent()` 인수 경계를 찾지 못하고 pin이 없다고 오판한다.
+ */
+function skipRegexLiteral(source, start) {
+  if (source[start] !== "/" || !isRegexPosition(source, start)) return start;
+  let index = start + 1;
+  let inClass = false;
+  while (index < source.length) {
+    const character = source[index];
+    if (character === "\\") {
+      index += 2;
+      continue;
+    }
+    if (character === "\n") return start;
+    if (character === "[") inClass = true;
+    else if (character === "]") inClass = false;
+    else if (character === "/" && !inClass) {
+      index += 1;
+      while (index < source.length && /[a-z]/.test(source[index])) index += 1;
+      return index;
+    }
+    index += 1;
+  }
+  return start;
+}
+
 function findMatchingDelimiter(source, openIndex) {
   const first = source[openIndex];
   if (!OPEN_TO_CLOSE[first]) return -1;
@@ -75,6 +124,11 @@ function findMatchingDelimiter(source, openIndex) {
     const afterComment = skipComment(source, index);
     if (afterComment !== index) {
       index = afterComment;
+      continue;
+    }
+    const afterRegex = skipRegexLiteral(source, index);
+    if (afterRegex !== index) {
+      index = afterRegex;
       continue;
     }
     if (OPEN_TO_CLOSE[character]) {
@@ -124,6 +178,11 @@ function skipTrivia(source, start, end = source.length) {
       index = Math.min(afterComment, end);
       continue;
     }
+    const afterRegex = skipRegexLiteral(source, index);
+    if (afterRegex !== index) {
+      index = Math.min(afterRegex, end);
+      continue;
+    }
     break;
   }
   return index;
@@ -141,6 +200,11 @@ function findAgentCallsInRange(source, start, end, calls) {
     const afterComment = skipComment(source, index);
     if (afterComment !== index) {
       index = Math.min(afterComment, end);
+      continue;
+    }
+    const afterRegex = skipRegexLiteral(source, index);
+    if (afterRegex !== index) {
+      index = Math.min(afterRegex, end);
       continue;
     }
     if (character === "'" || character === '"') {
@@ -207,6 +271,11 @@ function splitTopLevelRanges(source, start, end) {
     const afterComment = skipComment(source, index);
     if (afterComment !== index) {
       index = afterComment;
+      continue;
+    }
+    const afterRegex = skipRegexLiteral(source, index);
+    if (afterRegex !== index) {
+      index = afterRegex;
       continue;
     }
     if (OPEN_TO_CLOSE[character]) {
@@ -298,6 +367,11 @@ function findModelPinValues(source, start, end, values) {
     const afterComment = skipComment(source, index);
     if (afterComment !== index) {
       index = Math.min(afterComment, end);
+      continue;
+    }
+    const afterRegex = skipRegexLiteral(source, index);
+    if (afterRegex !== index) {
+      index = Math.min(afterRegex, end);
       continue;
     }
     if (character === "'" || character === '"') {

--- a/packages/fleet-admiral/src/agent-cli/claude/definitions.ts
+++ b/packages/fleet-admiral/src/agent-cli/claude/definitions.ts
@@ -5,6 +5,21 @@ import { createClaudeFamilyCliDefinition } from "./factory.js";
 export const NATIVE_CLAUDE_MODEL_ALIASES = ["fable[1m]", "opus[1m]", "sonnet"] as const;
 export const NATIVE_CLAUDE_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
 
+/**
+ * 사다리 위의 단이 아니라 Claude Code 세션 모드다. `ultracode`는 xhigh 추론에 상시
+ * dynamic workflow 오케스트레이션을 얹으므로 max보다 깊이 생각하는 단이 아니고, 세션 하나에만
+ * 걸린다. 강도를 깊이로 읽는 표면(Analyst·Cowork)이 사다리를 늘렸다고 조용히 물려받지 않도록
+ * 추론 사다리와 갈라 둔다. 게이트웨이 사다리의 `ultra`와는 다른 값이다 — Claude Code CLI는
+ * `ultracode`를 받고 `ultra`를 거부한다.
+ */
+export const NATIVE_CLAUDE_SPECIAL_EFFORTS = ["ultracode"] as const;
+
+/** 실행 인자로 받을 수 있는 native Claude Code 강도 전체. 추론 사다리 + 세션 모드. */
+export const NATIVE_CLAUDE_LAUNCH_EFFORTS = [
+  ...NATIVE_CLAUDE_EFFORTS,
+  ...NATIVE_CLAUDE_SPECIAL_EFFORTS,
+] as const;
+
 const NATIVE_CLAUDE_MODEL_ALIAS_REWRITES = {
   fable: "fable[1m]",
   opus: "opus[1m]",

--- a/packages/fleet-admiral/src/index.ts
+++ b/packages/fleet-admiral/src/index.ts
@@ -90,7 +90,9 @@ export {
 } from "./agent-cli/registry.js";
 export {
   NATIVE_CLAUDE_EFFORTS,
+  NATIVE_CLAUDE_LAUNCH_EFFORTS,
   NATIVE_CLAUDE_MODEL_ALIASES,
+  NATIVE_CLAUDE_SPECIAL_EFFORTS,
   resolveNativeClaudeModelAlias,
 } from "./agent-cli/claude/definitions.js";
 

--- a/packages/fleet-admiral/tests/native-claude-effort-ladder.test.ts
+++ b/packages/fleet-admiral/tests/native-claude-effort-ladder.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  NATIVE_CLAUDE_EFFORTS,
+  NATIVE_CLAUDE_LAUNCH_EFFORTS,
+  NATIVE_CLAUDE_SPECIAL_EFFORTS,
+} from "../src/index.js";
+
+describe("native Claude effort ladder", () => {
+  it("keeps the reasoning ladder as depth alone", () => {
+    expect(NATIVE_CLAUDE_EFFORTS).toEqual(["low", "medium", "high", "xhigh", "max"]);
+  });
+
+  // ultracode는 max보다 깊이 생각하는 단이 아니다 — xhigh 추론에 dynamic workflow 오케스트레이션을
+  // 얹은 세션 모드다. 깊이 사다리에 섞으면 램프의 한 칸 더로 읽힌다.
+  it("carries ultracode as a session mode, after the deepest rung", () => {
+    expect(NATIVE_CLAUDE_SPECIAL_EFFORTS).toEqual(["ultracode"]);
+    expect(NATIVE_CLAUDE_LAUNCH_EFFORTS).toEqual(["low", "medium", "high", "xhigh", "max", "ultracode"]);
+    expect(NATIVE_CLAUDE_LAUNCH_EFFORTS.indexOf("ultracode")).toBeGreaterThan(
+      NATIVE_CLAUDE_LAUNCH_EFFORTS.indexOf("max"),
+    );
+  });
+
+  /**
+   * 강도를 깊이로 읽는 표면(Analyst·Cowork)은 `NATIVE_CLAUDE_EFFORTS`를 그대로 펼쳐 쓴다. 두
+   * 상수를 다시 하나로 합치면 그 표면들이 아무 변경 없이 ultracode를 물려받아, 워크플로우
+   * 오케스트레이션을 켤 수 없는 자리에 그 단을 내놓는다.
+   */
+  it("never lets the depth ladder inherit the session mode", () => {
+    expect(NATIVE_CLAUDE_EFFORTS).not.toContain("ultracode");
+    for (const special of NATIVE_CLAUDE_SPECIAL_EFFORTS) {
+      expect(NATIVE_CLAUDE_EFFORTS as readonly string[]).not.toContain(special);
+    }
+  });
+
+  // 게이트웨이 사다리의 `ultra`와는 다른 값이다. Claude Code CLI는 `ultracode`를 받고 `ultra`를 거부한다.
+  it("does not confuse the session mode with the gateway's own ultra rung", () => {
+    expect(NATIVE_CLAUDE_LAUNCH_EFFORTS as readonly string[]).not.toContain("ultra");
+  });
+});

--- a/packages/fleet-admiral/tests/workflow-guard-hook.test.ts
+++ b/packages/fleet-admiral/tests/workflow-guard-hook.test.ts
@@ -18,12 +18,15 @@ afterEach(() => {
   }
 });
 
-function runGuard(toolInput: unknown): { readonly status: number; readonly stderr: string } {
+function runGuard(
+  toolInput: unknown,
+  toolName = "Workflow",
+): { readonly status: number; readonly stderr: string; readonly stdout: string } {
   const result = spawnSync(process.execPath, [GUARD_SCRIPT], {
-    input: JSON.stringify({ tool_name: "Workflow", tool_input: toolInput }),
+    input: JSON.stringify({ tool_name: toolName, tool_input: toolInput }),
     encoding: "utf8",
   });
-  return { status: result.status ?? -1, stderr: result.stderr };
+  return { status: result.status ?? -1, stderr: result.stderr, stdout: result.stdout };
 }
 
 describe("workflow-guard hook", () => {
@@ -76,11 +79,169 @@ describe("workflow-guard hook", () => {
     expect(status).toBe(0);
   });
 
-  it("ignores non-Workflow tools", () => {
-    const result = spawnSync(process.execPath, [GUARD_SCRIPT], {
-      input: JSON.stringify({ tool_name: "Bash", tool_input: { command: "ls" } }),
-      encoding: "utf8",
+  it("blocks an agent call with an empty options object and identifies it", () => {
+    const { status, stderr, stdout } = runGuard({ script: `agent("x", {})` });
+    expect(status).toBe(2);
+    expect(stderr).toContain("1번째 agent() 호출");
+    expect(stderr).toContain(`agent("x", {})`);
+    expect(stdout).toBe("");
+  });
+
+  it("blocks an agent call without an options argument", () => {
+    const { status, stderr } = runGuard({ script: `agent("x")` });
+    expect(status).toBe(2);
+    expect(stderr).toContain("리터럴 opts.model pin");
+  });
+
+  it("identifies the unpinned call in a mixed script", () => {
+    const { status, stderr } = runGuard({
+      script: `
+        const pinned = agent("pinned", { model: "sonnet" });
+        const unpinned = agent("unpinned", { effort: "low" });
+      `,
     });
-    expect(result.status).toBe(0);
+    expect(status).toBe(2);
+    expect(stderr).toContain("2번째 agent() 호출");
+    expect(stderr).toContain(`agent("unpinned", { effort: "low" })`);
+    expect(stderr).not.toContain(`agent("pinned", { model: "sonnet" })`);
+  });
+
+  it("passes when every call pins a lineage alias", () => {
+    const { status, stdout } = runGuard({
+      script: `
+        agent("a", { model: "fable" });
+        agent("b", { 'model': "opus" });
+        agent("c", { "model": "sonnet" });
+        agent("d", { model: "haiku" });
+      `,
+    });
+    expect(status).toBe(0);
+    expect(stdout).toBe("");
+  });
+
+  it("passes when every call pins a full gateway modelId", () => {
+    const { status } = runGuard({
+      script: `
+        agent("a", { model: "claude-gateway--codex--gpt-5.6-sol-fast[1m]" });
+        agent("b", { model: "claude-gateway--cursor--grok-4.5[1m]" });
+      `,
+    });
+    expect(status).toBe(0);
+  });
+
+  it("handles templates, nested delimiters, and nested schema objects", () => {
+    const { status } = runGuard({
+      script: `
+        agent("x", {
+          model: "sonnet",
+          prompt: \`inspect \${run({ value: "nested ) quote", list: [1, (2 + 3)] })}\`,
+          schema: { output: { nested: true } },
+        });
+      `,
+    });
+    expect(status).toBe(0);
+  });
+
+  it("does not count a model key nested under schema as a pin", () => {
+    const { status, stderr } = runGuard({
+      script: `agent("x", { schema: { model: "sonnet" } })`,
+    });
+    expect(status).toBe(2);
+    expect(stderr).toContain("1번째 agent() 호출");
+  });
+
+  it("ignores lookalike callees", () => {
+    const { status } = runGuard({
+      script: `
+        subagent("x", {});
+        spawnAgent("x", {});
+        obj.agent("x", {});
+        function agent(x) {}
+        agent("real", { model: "sonnet" });
+      `,
+    });
+    expect(status).toBe(0);
+  });
+
+  it("ignores agent call text in comments and string literals", () => {
+    const { status } = runGuard({
+      script: String.raw`
+        // agent("comment", {})
+        /* agent("block", {}) */
+        const single = 'agent("single", {})';
+        const double = "agent('double', {})";
+        const template = \`agent("template", {})\`;
+        agent("real", { model: "sonnet" });
+      `,
+    });
+    expect(status).toBe(0);
+  });
+
+  it("keeps agentType precedence over the unpinned check", () => {
+    const { status, stderr } = runGuard({
+      script: `agent("x", { agentType: "fleet:example" })`,
+    });
+    expect(status).toBe(2);
+    expect(stderr).toContain("agentType");
+    expect(stderr).not.toContain("리터럴 opts.model pin");
+  });
+
+  it("ignores an unpinned script for non-Workflow tools", () => {
+    const { status } = runGuard({ script: `agent("x", {})` }, "Bash");
+    expect(status).toBe(0);
+  });
+
+  it("passes an unreadable scriptPath without inspection", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "workflow-guard-"));
+    tempDirs.push(dir);
+    const { status } = runGuard({ scriptPath: path.join(dir, "missing.js") });
+    expect(status).toBe(0);
+  });
+
+  /**
+   * 값 검사는 코드 위치의 `model:`만 본다. 스크립트 전체를 정규식으로 훑으면 프롬프트 문장이나
+   * 주석에 적힌 산문이 값으로 읽혀, 제대로 핀을 박은 워크플로우가 차단된다 — 하드 차단에서
+   * 이 오탐은 곧 "정상 스크립트를 못 돌린다"가 된다.
+   */
+  it("reads model pins as code, not as prose inside prompts and comments", () => {
+    expect(runGuard({
+      script: 'await agent(`Report which model: "gpt-4" was used.`, { model: "opus" })',
+    }).status).toBe(0);
+
+    expect(runGuard({
+      script: '// always pin a model: "sonnet-x" style id\nawait agent("x", { model: "opus" })',
+    }).status).toBe(0);
+
+    expect(runGuard({
+      script: 'const hint = "model: \\"x\\""; await agent("x", { model: "opus" })',
+    }).status).toBe(0);
+
+    // 스키마가 우연히 model이라는 속성을 담아도 그것은 이 워크플로우의 핀이 아니다.
+    expect(runGuard({
+      script: 'await agent("x", { model: "opus", schema: { properties: { model: { type: "string" } } } })',
+    }).status).toBe(0);
+  });
+
+  // 산문을 걸러 내면서도 검사의 사정거리는 좁히지 않는다 — 헬퍼 객체에 잘못 박힌 값도 그대로 잡는다.
+  it("still rejects a bad value wherever the code puts it", () => {
+    const helper = runGuard({
+      script: 'const OPTS = { model: "nope" };\nawait agent("x", { model: "opus" })',
+    });
+    expect(helper.status).toBe(2);
+    expect(helper.stderr).toContain("nope");
+
+    const quoted = runGuard({ script: 'await agent("x", { "model": "sol-fast" })' });
+    expect(quoted.status).toBe(2);
+    expect(quoted.stderr).toContain("sol-fast");
+  });
+
+  it("blocks an unpinned script loaded from scriptPath", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "workflow-guard-"));
+    tempDirs.push(dir);
+    const scriptPath = path.join(dir, "unpinned.js");
+    writeFileSync(scriptPath, `agent("from-file", { schema: S })`);
+    const { status, stderr } = runGuard({ scriptPath });
+    expect(status).toBe(2);
+    expect(stderr).toContain(`agent("from-file", { schema: S })`);
   });
 });

--- a/packages/fleet-admiral/tests/workflow-guard-hook.test.ts
+++ b/packages/fleet-admiral/tests/workflow-guard-hook.test.ts
@@ -235,6 +235,32 @@ describe("workflow-guard hook", () => {
     expect(quoted.stderr).toContain("sol-fast");
   });
 
+  /**
+   * 정규식 리터럴 안의 괄호는 코드의 괄호가 아니다. 이것을 세면 `agent(` 의 인수 경계를 못 찾아,
+   * 제대로 핀을 박은 워크플로우가 "핀이 없다"며 하드 차단된다 — 가드가 막아야 할 것을 막는 대신
+   * 정상 실행을 막는 쪽이 훨씬 나쁘다.
+   */
+  it("reads regex literals as literals, not as stray delimiters", () => {
+    expect(runGuard({
+      script: 'const clean = (s) => s.replace(/[)}]/g, "");\nawait agent("x", { model: "opus" })',
+    }).status).toBe(0);
+
+    // 문자 클래스 안의 닫는 괄호가 실제 경계로 읽히면, 이 호출의 인수 범위 자체를 잃는다.
+    expect(runGuard({
+      script: 'await agent("x", { model: "opus", label: name.replace(/[)\\]]/g, "") })',
+    }).status).toBe(0);
+
+    // 정규식 안의 따옴표도 문자열을 열지 않는다.
+    expect(runGuard({
+      script: 'const q = /["\'`]/g;\nawait agent("x", { model: "opus" })',
+    }).status).toBe(0);
+
+    // 나눗셈은 나눗셈으로 남아야 한다 — 정규식으로 오인하면 뒤의 코드를 통째로 삼킨다.
+    expect(runGuard({
+      script: 'const half = total / 2;\nawait agent("x", { schema: S })',
+    }).status).toBe(2);
+  });
+
   it("blocks an unpinned script loaded from scriptPath", () => {
     const dir = mkdtempSync(path.join(os.tmpdir(), "workflow-guard-"));
     tempDirs.push(dir);

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -630,6 +630,13 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
               autoLabel={t("launchVariants.effort.auto")}
               ariaLabel={t("launchVariants.effort.track")}
               autoValueText={t("launchVariants.effort.autoValue")}
+              revealLabel={t("launchVariants.effort.reveal")}
+              collapseLabel={t("launchVariants.effort.collapse")}
+              specialWarning={t("launchVariants.effort.specialWarning")}
+              specialDescriptions={{
+                max: t("launchVariants.effort.maxValue"),
+                ultracode: t("launchVariants.effort.ultracodeValue"),
+              }}
             />
             {showEffortConfirmTip ? (
               <p className="operation-launch-effort-confirm-tip" role="status">
@@ -675,15 +682,23 @@ const GAUGE_MIN_BAR = 2;
  * 오르는 막대로 "단계를 고르는 자리"임을 아이콘 하나로 알린다. 자동은 한 칸도 켜지지 않는다 —
  * 최소 단을 고른 것과 갈려야 한다.
  */
-function EffortGaugeGlyph({ rung, total }: { readonly rung: number; readonly total: number }) {
+function EffortGaugeGlyph({ rung, total, special }: {
+  readonly rung: number;
+  readonly total: number;
+  readonly special: string | null;
+}) {
   if (total <= 0) return null;
-  const width = total * GAUGE_BAR_PITCH - (GAUGE_BAR_PITCH - GAUGE_BAR_WIDTH);
+  const bars = total * GAUGE_BAR_PITCH - (GAUGE_BAR_PITCH - GAUGE_BAR_WIDTH);
+  // 특수 모드 표식은 눈금 밖에 붙는다 — 막대를 하나 더 얹으면 "칸이 더 많으니 더 깊다"가 되는데,
+  // ultracode는 xhigh 깊이에 오케스트레이션을 얹은 모드다.
+  const width = special === null ? bars : bars + GAUGE_BAR_PITCH + GAUGE_BAR_WIDTH;
   return (
     <svg
       className="operation-launch-variant-effort-gauge"
       viewBox={`0 0 ${width} ${GAUGE_HEIGHT}`}
       width={width}
       height={GAUGE_HEIGHT}
+      data-special={special ?? undefined}
       aria-hidden="true"
     >
       {Array.from({ length: total }, (_unused, index) => {
@@ -702,6 +717,26 @@ function EffortGaugeGlyph({ rung, total }: { readonly rung: number; readonly tot
           />
         );
       })}
+      {special === "max" ? (
+        // 떨어져 선 마루 — 눈금 위의 한 칸이 아니라 눈금이 끝난 뒤의 천장이다.
+        <rect
+          x={bars + GAUGE_BAR_PITCH}
+          y={0}
+          width={GAUGE_BAR_WIDTH}
+          height={GAUGE_HEIGHT}
+          rx={0.5}
+          data-lit="true"
+          data-cap="true"
+        />
+      ) : null}
+      {special === "ultracode" ? (
+        // 깊이가 아니라 갈라지는 일감을 말한다 — 한 줄기에서 갈린 세 점.
+        <g data-orchestration="true">
+          {[0, GAUGE_HEIGHT / 2, GAUGE_HEIGHT].map((y, index) => (
+            <circle key={index} cx={bars + GAUGE_BAR_PITCH + GAUGE_BAR_WIDTH / 2} cy={Math.max(0.75, Math.min(y, GAUGE_HEIGHT - 0.75))} r={0.75} data-lit="true" />
+          ))}
+        </g>
+      ) : null}
     </svg>
   );
 }

--- a/runtime/fleet-console/core/client/src/components/effort-track.tsx
+++ b/runtime/fleet-console/core/client/src/components/effort-track.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState, type KeyboardEvent, type PointerEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent, type PointerEvent } from "react";
 
 import type { OperationLaunchVariantChip, OperationLaunchVariantRow } from "@fleet-console/sdk/operations";
 
@@ -10,6 +10,8 @@ interface EffortSlot {
   readonly label: string;
   /** 이 자리를 고를 수 있는가. 모델이 내놓지 않은 단은 자리만 지키고 비어 있다. */
   readonly selectable: boolean;
+  /** 평범한 레일 뒤 챔버에 사는 단인가. 스쳐 지나간 제스처가 닿아서는 안 되는 자리다. */
+  readonly special: boolean;
 }
 
 export interface EffortTrackProps {
@@ -21,12 +23,23 @@ export interface EffortTrackProps {
    * 이미 고른 단에 다시 눌렀을 때. 드래그로 다른 단을 거쳐 돌아온 경우는 호출하지 않는다 —
    * 값을 고르는 제스처와 "이 값으로 확정" 제스처를 갈라야 한다. 생략하면 같은 단 재클릭은
    * 아무 일도 없다(Quick Launch처럼 제출이 다른 자리인 표면).
+   *
+   * 챔버 안의 특수 강도는 이 경로를 절대 타지 않는다 — 비싼 모드는 고르는 것과 내보내는 것이
+   * 갈려야 하고, 실행은 호스트가 이름을 밝힌 별도 행위로 맡는다.
    */
   readonly onConfirmCurrent?: () => void;
   /** 강도를 비운 상태를 트랙 맨 앞 자리로 노출한다. */
   readonly autoLabel: string;
   readonly ariaLabel: string;
   readonly autoValueText: string;
+  /** 챔버를 여는 게이트에 붙는 이름. 무엇이 그 뒤에 있는지 이름이 다 말해야 한다. */
+  readonly revealLabel?: string;
+  /** 챔버가 열린 뒤 닫는 컨트롤의 이름. */
+  readonly collapseLabel?: string;
+  /** 챔버 안의 단이 왜 비싼지 한 줄로 밝히는 경고. 열렸을 때만 보인다. */
+  readonly specialWarning?: string;
+  /** 특수 강도 id → 이 모드가 무엇인지 밝히는 한 줄. 보조기술의 aria-valuetext에도 실린다. */
+  readonly specialDescriptions?: Readonly<Record<string, string>>;
   readonly className?: string;
 }
 
@@ -34,41 +47,87 @@ export interface EffortTrackProps {
  * 강도 사다리를 하나의 축으로 세운 트랙. 목록과 달리 축은 단들 사이의 거리까지 말하므로,
  * 모델이 내놓지 않은 단도 자리를 지킨다 — low/high/max만 있는 모델에서 셋을 균등히 벌리면
  * high가 한가운데 서서, 실제로는 3/5 지점인 단을 절반이라고 말하게 된다.
+ *
+ * 축의 꼬리(`effortExpansion`)는 레일 밖 챔버에 산다. 챔버 자리는 접혀 있을 때도 비워 두므로
+ * 펼쳐도 평범한 단들의 좌표가 움직이지 않는다 — 축 전체가 다시 눈금을 그리면 방금 고른 값이
+ * 옮겨 간 것처럼 읽힌다.
  */
-export function EffortTrack({ row, value, onChange, onConfirmCurrent, autoLabel, ariaLabel, autoValueText, className }: EffortTrackProps) {
+export function EffortTrack({
+  row,
+  value,
+  onChange,
+  onConfirmCurrent,
+  autoLabel,
+  ariaLabel,
+  autoValueText,
+  revealLabel,
+  collapseLabel,
+  specialWarning,
+  specialDescriptions,
+  className,
+}: EffortTrackProps) {
   const trackRef = useRef<HTMLDivElement | null>(null);
+  // 좌표는 레일이 아니라 프레임에서 읽는다. 접힌 레일은 축의 일부만 덮으므로 그 폭으로 나누면
+  // 같은 자리가 다른 단을 가리켜, 펼치는 순간 평범한 단들이 제자리에서 옮겨 간 것처럼 읽힌다.
+  const frameRef = useRef<HTMLDivElement | null>(null);
+  const gateRef = useRef<HTMLButtonElement | null>(null);
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+  const [expanded, setExpanded] = useState(false);
   // 제스처 동안 React 커밋을 기다리지 않고 고른 단을 추적한다 — 같은 포인터 시퀀스에서
   // "다른 단으로 옮겼다"와 "처음부터 이 단을 다시 눌렀다"를 갈라야 한다.
   const liveIndexRef = useRef(0);
   // pointerId까지 묶어 두면 터치에서 두 번째 손가락(button===0)이 제스처를 덮어 쓰지 못한다.
-  const gestureRef = useRef<{ readonly pointerId: number; readonly originIndex: number; dirty: boolean } | null>(null);
+  const gestureRef = useRef<{ readonly pointerId: number; readonly originIndex: number; readonly epoch: number; dirty: boolean } | null>(null);
+  // 펼침은 고를 수 있는 범위를 바꾼다. 그 경계를 넘어 살아남은 제스처는 방금 생긴 특수 단에
+  // 손을 얹은 채 놓게 되므로, epoch을 올려 이전 제스처의 이동·해제를 모두 버린다.
+  const epochRef = useRef(0);
 
   const slots = useMemo<readonly EffortSlot[]>(() => {
     const byId = new Map<string, OperationLaunchVariantChip>((row.chips ?? []).map((chip) => [chip.id, chip]));
+    const specials = new Set(row.effortExpansion?.rungs ?? []);
     const rungs = ladderRungs(row).map((id) => ({
       id,
       label: byId.get(id)?.label ?? id.toUpperCase(),
       selectable: byId.has(id),
+      special: specials.has(id),
     }));
-    return [{ id: null, label: autoLabel, selectable: true }, ...rungs];
+    return [{ id: null, label: autoLabel, selectable: true, special: false }, ...rungs];
   }, [autoLabel, row]);
 
   const last = slots.length - 1;
+  // 평범한 레일의 끝. 챔버가 없는 행에서는 축의 끝과 같다.
+  const ordinaryLast = useMemo(() => {
+    const firstSpecial = slots.findIndex((slot) => slot.special);
+    return firstSpecial < 0 ? last : firstSpecial - 1;
+  }, [last, slots]);
+  const hasChamber = ordinaryLast < last;
+
   const index = Math.max(0, slots.findIndex((slot) => slot.id === value));
   const current = slots[index]!;
   const isAuto = current.id === null;
+  const atSpecial = current.special;
   liveIndexRef.current = index;
 
+  // 특수 단이 실려 있으면 챔버는 열린 채로 둔다. 접힌 레일이 비싼 모드를 숨기고 있으면 아무도
+  // 고르지 않은 값으로 다음 실행이 나간다.
+  const open = expanded || atSpecial;
+  const activeLast = open ? last : ordinaryLast;
+
+  // 접힌 동안 남겨 두는 평범한 폴백. 챔버를 닫을 때 특수 단을 이 값으로 되돌린다.
+  const ordinaryFallbackRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!atSpecial) ordinaryFallbackRef.current = value;
+  }, [atSpecial, value]);
+
   const nearestSelectable = useCallback((target: number): number => {
-    const bounded = Math.max(0, Math.min(target, last));
+    const bounded = Math.max(0, Math.min(target, activeLast));
     if (slots[bounded]?.selectable) return bounded;
     for (let step = 1; step <= slots.length; step += 1) {
-      if (slots[bounded - step]?.selectable) return bounded - step;
-      if (slots[bounded + step]?.selectable) return bounded + step;
+      if (bounded - step >= 0 && slots[bounded - step]?.selectable) return bounded - step;
+      if (bounded + step <= activeLast && slots[bounded + step]?.selectable) return bounded + step;
     }
     return liveIndexRef.current;
-  }, [last, slots]);
+  }, [activeLast, slots]);
 
   const commit = useCallback((next: number) => {
     const slot = slots[next];
@@ -79,9 +138,9 @@ export function EffortTrack({ row, value, onChange, onConfirmCurrent, autoLabel,
   }, [onChange, slots]);
 
   const indexFromPointer = useCallback((clientX: number): number | null => {
-    const track = trackRef.current;
-    if (!track || last === 0) return null;
-    const rect = track.getBoundingClientRect();
+    const frame = frameRef.current;
+    if (!frame || last === 0) return null;
+    const rect = frame.getBoundingClientRect();
     const span = rect.width - EDGE * 2;
     if (span <= 0) return null;
     const ratio = Math.max(0, Math.min((clientX - rect.left - EDGE) / span, 1));
@@ -102,6 +161,8 @@ export function EffortTrack({ row, value, onChange, onConfirmCurrent, autoLabel,
     // 시작한 포인터만 끝낸다 — 다른 접촉의 up이 활성 제스처를 지우면 안 된다.
     if (!gesture || gesture.pointerId !== event.pointerId) return;
     gestureRef.current = null;
+    // 펼침 경계를 넘어온 제스처는 값을 고르는 의사로 읽지 않는다.
+    if (gesture.epoch !== epochRef.current) return;
     if (!confirm || gesture.dirty || !onConfirmCurrent) return;
     // 주버튼으로 트랙 안에서 손을 뗄 때만 확정한다 — 우클릭·가운데 클릭이나
     // 세로로 트랙 밖까지 끌어 뺀 해제는 값을 고르는 실수가 되지 않게 막는다.
@@ -118,9 +179,44 @@ export function EffortTrack({ row, value, onChange, onConfirmCurrent, autoLabel,
       return;
     }
     const next = indexFromPointer(event.clientX);
+    // 챔버 안의 단은 다시 눌러도 실행되지 않는다.
+    if (next !== null && slots[next]?.special) return;
     // 처음부터 고른 단을 다시 눌렀고, 그 사이 다른 단으로 옮기지 않았을 때만 확정한다.
     if (next === gesture.originIndex) onConfirmCurrent();
-  }, [indexFromPointer, onConfirmCurrent]);
+  }, [indexFromPointer, onConfirmCurrent, slots]);
+
+  /** 펼침·접힘은 제스처 경계다. 붙잡고 있던 포인터를 여기서 끊어야 방금 생긴 단에 착지하지 않는다. */
+  const breakGesture = useCallback(() => {
+    epochRef.current += 1;
+    gestureRef.current = null;
+    setPreviewIndex(null);
+  }, []);
+
+  // 게이트를 누르면 그 게이트가 사라진다. 초점을 옮겨 두지 않으면 body로 떨어져, 키보드로 온
+  // 사람이 방금 연 챔버 앞에서 조작할 대상을 잃는다. 버튼이 실제로 붙은 뒤에 옮겨야 하므로
+  // 의사만 남기고 커밋 이후에 처리한다.
+  const focusIntentRef = useRef<"rail" | "gate" | null>(null);
+  useEffect(() => {
+    const intent = focusIntentRef.current;
+    if (intent === null) return;
+    focusIntentRef.current = null;
+    if (intent === "rail") trackRef.current?.focus();
+    else gateRef.current?.focus();
+  }, [open]);
+
+  const openChamber = useCallback(() => {
+    breakGesture();
+    focusIntentRef.current = "rail";
+    setExpanded(true);
+  }, [breakGesture]);
+
+  const closeChamber = useCallback(() => {
+    breakGesture();
+    focusIntentRef.current = "gate";
+    setExpanded(false);
+    // 특수 단이 실린 채로는 접을 수 없다. 챔버를 닫는 것은 그 모드를 내려놓는 일이다.
+    if (atSpecial) onChange(ordinaryFallbackRef.current);
+  }, [atSpecial, breakGesture, onChange]);
 
   const handleKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
     const direction = event.key === "ArrowLeft" || event.key === "ArrowDown"
@@ -129,15 +225,33 @@ export function EffortTrack({ row, value, onChange, onConfirmCurrent, autoLabel,
     let next: number | null = null;
     // 방향키는 그 방향으로 고를 수 있는 다음 단까지 건너뛴다 — 비어 있는 자리에 멈추지 않는다.
     if (direction !== 0) {
-      for (let i = index + direction; i >= 0 && i <= last; i += direction) {
+      for (let i = index + direction; i >= 0 && i <= activeLast; i += direction) {
         if (slots[i]!.selectable) { next = i; break; }
+      }
+      // 접힌 천장에서 더 오른쪽으로 가려는 키는 게이트로 초점을 넘긴다. 챔버를 열어 주지는
+      // 않는다 — 방향키가 비싼 모드를 여는 손잡이가 되면 그 문은 문이 아니다.
+      if (next === null && direction === 1 && !open && hasChamber) {
+        event.preventDefault();
+        event.stopPropagation();
+        gateRef.current?.focus();
+        return;
       }
     }
     if (event.key === "Home") next = 0;
-    if (event.key === "End") next = nearestSelectable(last);
-    if (event.key === "Enter" && onConfirmCurrent) {
+    if (event.key === "End") next = nearestSelectable(activeLast);
+    if (event.key === "Escape" && open) {
       event.preventDefault();
       event.stopPropagation();
+      closeChamber();
+      return;
+    }
+    if (event.key === "Enter" && onConfirmCurrent) {
+      // 눌린 채 반복되는 Enter는 확정 의사가 아니다.
+      if (event.repeat) return;
+      event.preventDefault();
+      event.stopPropagation();
+      // 챔버 안의 단은 장전까지만이다 — 실행은 이름을 밝힌 별도 행위가 맡는다.
+      if (atSpecial) return;
       onConfirmCurrent();
       return;
     }
@@ -146,78 +260,134 @@ export function EffortTrack({ row, value, onChange, onConfirmCurrent, autoLabel,
     // 트랙은 메뉴 안에 산다. 방향키가 위로 새면 메뉴가 항목 이동으로 받아 함께 움직인다.
     event.stopPropagation();
     commit(next);
-  }, [commit, index, last, nearestSelectable, onConfirmCurrent, slots]);
+  }, [activeLast, atSpecial, closeChamber, commit, hasChamber, index, nearestSelectable, onConfirmCurrent, open, slots]);
 
   const ratio = last === 0 ? 0 : index / last;
+  // 레일이 덮는 길이. 접혀 있으면 평범한 천장에서 끊기고, 남은 폭이 챔버다.
+  const laneRatio = last === 0 ? 1 : activeLast / last;
+  const laneWidth = open ? "100%" : `calc(${EDGE * 2}px + ${laneRatio} * (100% - ${EDGE * 2}px))`;
+  const specialDescription = current.id === null ? undefined : specialDescriptions?.[current.id];
 
   return (
-    <div className={`effort-track-shell${className ? ` ${className}` : ""}`}>
-      <div
-        ref={trackRef}
-        className="effort-track"
-        role="slider"
-        tabIndex={0}
-        aria-label={ariaLabel}
-        aria-valuemin={0}
-        aria-valuemax={last}
-        aria-valuenow={index}
-        aria-valuetext={isAuto ? autoValueText : current.label}
-        data-at-max={index === last && !isAuto ? true : undefined}
-        // 자동은 사다리의 최소 단이 아니라 "사다리를 쓰지 않음"이다. 파선 테두리·빈 손잡이·채움 0이
-        // 한 어휘로 그것을 말한다 — 채움이 조금이라도 남으면 맨 왼쪽 단을 고른 것으로 읽힌다.
-        data-auto={isAuto ? true : undefined}
-        onKeyDown={handleKeyDown}
-        onPointerDown={(event) => {
-          // 주 접촉만 받는다. 터치 두 번째 손가락도 button===0이라 isPrimary·활성 제스처로 막는다.
-          if (!event.isPrimary || event.button !== 0 || gestureRef.current) return;
-          event.preventDefault();
-          event.currentTarget.setPointerCapture(event.pointerId);
-          event.currentTarget.focus();
-          gestureRef.current = { pointerId: event.pointerId, originIndex: liveIndexRef.current, dirty: false };
-          fromPointer(event);
-        }}
-        onPointerMove={(event) => {
-          const next = indexFromPointer(event.clientX);
-          if (next !== null) setPreviewIndex(next);
-          const gesture = gestureRef.current;
-          if (!gesture || gesture.pointerId !== event.pointerId) return;
-          if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
-          fromPointer(event);
-        }}
-        onPointerUp={(event) => endGesture(event, { confirm: true })}
-        onPointerLeave={() => setPreviewIndex(null)}
-        onPointerCancel={(event) => endGesture(event, { confirm: false })}
-      >
+    <div className={`effort-track-shell${className ? ` ${className}` : ""}`} data-open={open ? true : undefined}>
+      {/* 채움·스톱·손잡이는 레일이 아니라 이 상자를 기준으로 자리를 잰다 — 레일이 챔버로 자라도
+          이미 고른 단이 제자리에 남아야 하므로 레일의 자식으로 둘 수 없다. 상태는 그대로 레일이
+          지고, 형제 선택자로 이 안의 조각들에 닿는다. */}
+      <div className="effort-track-frame" ref={frameRef}>
+        <div
+          ref={trackRef}
+          className="effort-track"
+          role="slider"
+          tabIndex={0}
+          aria-label={ariaLabel}
+          aria-valuemin={0}
+          aria-valuemax={activeLast}
+          aria-valuenow={index}
+          aria-valuetext={isAuto ? autoValueText : specialDescription ?? current.label}
+          // 자동은 사다리의 최소 단이 아니라 "사다리를 쓰지 않음"이다. 파선 테두리·빈 손잡이·채움 0이
+          // 한 어휘로 그것을 말한다 — 채움이 조금이라도 남으면 맨 왼쪽 단을 고른 것으로 읽힌다.
+          data-auto={isAuto ? true : undefined}
+          // 최고 단 텍스처는 축의 끝이 아니라 지금 고를 수 있는 천장을 말한다. 축의 끝자리로 읽으면
+          // 챔버가 열려 있을 때만 켜져, 접힌 레일의 천장이 천장으로 보이지 않는다.
+          data-at-max={index === activeLast && !isAuto ? true : undefined}
+          data-special={atSpecial ? current.id : undefined}
+          style={{ width: laneWidth }}
+          onKeyDown={handleKeyDown}
+          onPointerDown={(event) => {
+            // 주 접촉만 받는다. 터치 두 번째 손가락도 button===0이라 isPrimary·활성 제스처로 막는다.
+            if (!event.isPrimary || event.button !== 0 || gestureRef.current) return;
+            event.preventDefault();
+            event.currentTarget.setPointerCapture(event.pointerId);
+            event.currentTarget.focus();
+            gestureRef.current = { pointerId: event.pointerId, originIndex: liveIndexRef.current, epoch: epochRef.current, dirty: false };
+            fromPointer(event);
+          }}
+          onPointerMove={(event) => {
+            const next = indexFromPointer(event.clientX);
+            if (next !== null) setPreviewIndex(next);
+            const gesture = gestureRef.current;
+            if (!gesture || gesture.pointerId !== event.pointerId) return;
+            if (gesture.epoch !== epochRef.current) return;
+            if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
+            fromPointer(event);
+          }}
+          onPointerUp={(event) => endGesture(event, { confirm: true })}
+          onPointerLeave={() => setPreviewIndex(null)}
+          onPointerCancel={(event) => endGesture(event, { confirm: false })}
+        />
         {/* 자동은 폭 0이다. 손잡이 여백(EDGE)만큼이라도 남기면 트랙 왼쪽 끝에 brass 조각이 비쳐,
-            비운 상태가 최소 강도를 고른 것처럼 보인다. */}
+            비운 상태가 최소 강도를 고른 것처럼 보인다. 고른 단이 레일 끝을 넘지 못하므로 이 채움은
+            레일 밖으로 새지 않는다 — 잘라내지 않아도 된다. */}
         <span
           className="effort-track-fill"
           style={{ width: isAuto ? 0 : `calc(${EDGE}px + ${ratio} * (100% - ${EDGE * 2}px))` }}
           aria-hidden="true"
         />
+        {/* 챔버가 열릴 때 한 번만 지나가는 빛. 열림에 매달아 두면 상시 루프가 되지 않는다 —
+            계속 움직이는 표면은 값이 아직 정해지지 않았다고 말한다. */}
+        {open ? <span className="effort-track-reveal-sheen" aria-hidden="true" /> : null}
         <span className="effort-track-stops" aria-hidden="true">
           {slots.map((slot, position) => (
-            <span
-              key={slot.id ?? "auto"}
-              className="effort-track-stop"
-              style={{ left: last === 0 ? "50%" : `${(position / last) * 100}%` }}
-              data-filled={position <= index && !isAuto ? true : undefined}
-              data-gap={slot.selectable ? undefined : true}
-              data-previewed={position === previewIndex ? true : undefined}
-            />
+            position <= activeLast ? (
+              <span
+                key={slot.id ?? "auto"}
+                className="effort-track-stop"
+                style={{ left: last === 0 ? "50%" : `calc(${EDGE}px + ${position / last} * (100% - ${EDGE * 2}px))` }}
+                data-filled={position <= index && !isAuto ? true : undefined}
+                data-gap={slot.selectable ? undefined : true}
+                data-special={slot.special ? slot.id : undefined}
+                data-previewed={position === previewIndex ? true : undefined}
+              />
+            ) : null
           ))}
         </span>
         <span
           className="effort-track-knob"
           style={{ left: `calc(${EDGE}px + ${ratio} * (100% - ${EDGE * 2}px))` }}
           data-auto={isAuto ? true : undefined}
+          data-special={atSpecial ? current.id : undefined}
           aria-hidden="true"
         />
+        {hasChamber && !open ? (
+          <button
+            ref={gateRef}
+            type="button"
+            className="effort-track-gate"
+            style={{ left: `calc(${EDGE * 2}px + ${laneRatio} * (100% - ${EDGE * 2}px))` }}
+            aria-expanded={false}
+            aria-label={revealLabel}
+            title={revealLabel}
+            onClick={openChamber}
+          >
+            <span className="effort-track-gate-leaf" aria-hidden="true" />
+            <span className="effort-track-gate-leaf" aria-hidden="true" />
+          </button>
+        ) : null}
       </div>
       {/* 단계 톤은 CSS가 이 속성 하나로 읽는다 — 라벨 문자열은 번역·모델마다 달라 색의 기준이 될 수 없다. */}
       <span className="effort-track-value" data-auto={isAuto} data-effort-level={current.id ?? "auto"}>
         {current.label}
       </span>
+      {/* 비싼 모드가 열려 있는 동안에는 왜 비싼지 화면에도 남는다 — 게이트를 지난 뒤에 사라지면
+          고르는 순간에는 아무 말도 하지 않는 경고가 된다. 닫는 손잡이도 여기 함께 띄운다: 트랙
+          옆에 흐름대로 놓으면 열릴 때마다 프레임이 그만큼 좁아져, 움직이지 않아야 할 평범한
+          단들이 제자리에서 밀린다. */}
+      {hasChamber && open ? (
+        <div className="effort-track-chamber-note">
+          {specialWarning ? <span role="status">{specialWarning}</span> : null}
+          <button
+            ref={gateRef}
+            type="button"
+            className="effort-track-collapse"
+            aria-expanded
+            aria-label={collapseLabel}
+            title={collapseLabel}
+            onClick={closeChamber}
+          >
+            <span aria-hidden="true">‹</span>
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -235,17 +405,43 @@ function ladderRungs(row: OperationLaunchVariantRow): readonly string[] {
 /**
  * 사다리 위 이 강도의 자리. 트랙을 열지 않고도 몇 번째 단인지 보여야 하는 표식(캔버스 실행 메뉴의
  * 강도 손잡이)이 쓴다. 자동은 0단이다 — 사다리를 쓰지 않는 상태이지 최소 단이 아니다.
+ *
+ * 눈금은 평범한 레일까지만 센다. 챔버 안의 단을 막대 하나로 더 얹으면 "여섯 칸이니 더 깊다"는
+ * 거짓을 그리게 되는데, ultracode는 xhigh 깊이에 오케스트레이션을 얹은 모드다. 그래서 특수 단은
+ * 칸이 아니라 별도 표식으로 나간다.
  */
 export function effortLadderPosition(row: OperationLaunchVariantRow, effort: string | null): {
   readonly rung: number;
   readonly total: number;
+  readonly special: string | null;
 } {
   const rungs = ladderRungs(row);
-  return { rung: effort === null ? 0 : rungs.indexOf(effort) + 1, total: rungs.length };
+  const specials = new Set(row.effortExpansion?.rungs ?? []);
+  const ordinary = rungs.filter((id) => !specials.has(id));
+  if (effort !== null && specials.has(effort)) {
+    return { rung: ordinary.length, total: ordinary.length, special: effort };
+  }
+  return {
+    rung: effort === null ? 0 : ordinary.indexOf(effort) + 1,
+    total: ordinary.length,
+    special: null,
+  };
 }
 
-/** 기억해 둔 강도가 이 모델 사다리에 없으면 비운 상태로 떨어진다. */
+/**
+ * 기억해 둔 강도가 이 모델 사다리에 없으면 비운 상태로 떨어진다.
+ *
+ * 챔버 뒤의 특수 단은 사다리에 있어도 물려받지 않는다. 챔버가 있는 이유가 "그 값은 스쳐서
+ * 닿을 수 없어야 한다"인데, 디스크나 직전 모델에서 실려 오는 값은 정의상 고른 것이 아니다.
+ */
 export function resolveRowEffort(row: OperationLaunchVariantRow | null, effort: string | null): string | null {
   if (!row || effort === null) return null;
+  if (isSpecialEffort(row, effort)) return null;
   return row.chips?.some((chip) => chip.id === effort) ? effort : null;
+}
+
+/** 이 강도가 챔버 뒤의 특수 모드인가. 저장·복원 경계가 이 판정을 공유해야 한다. */
+export function isSpecialEffort(row: OperationLaunchVariantRow | null, effort: string | null): boolean {
+  if (!row || effort === null) return false;
+  return (row.effortExpansion?.rungs ?? []).includes(effort);
 }

--- a/runtime/fleet-console/core/client/src/components/effort-track.tsx
+++ b/runtime/fleet-console/core/client/src/components/effort-track.tsx
@@ -10,8 +10,6 @@ interface EffortSlot {
   readonly label: string;
   /** 이 자리를 고를 수 있는가. 모델이 내놓지 않은 단은 자리만 지키고 비어 있다. */
   readonly selectable: boolean;
-  /** 평범한 레일 뒤 챔버에 사는 단인가. 스쳐 지나간 제스처가 닿아서는 안 되는 자리다. */
-  readonly special: boolean;
 }
 
 export interface EffortTrackProps {
@@ -32,9 +30,8 @@ export interface EffortTrackProps {
   readonly autoLabel: string;
   readonly ariaLabel: string;
   readonly autoValueText: string;
-  /** 챔버를 여는 게이트에 붙는 이름. 무엇이 그 뒤에 있는지 이름이 다 말해야 한다. */
+  /** 챔버를 여닫는 게이트에 붙는 이름. 무엇이 그 뒤에 있는지 이름이 다 말해야 한다. */
   readonly revealLabel?: string;
-  /** 챔버가 열린 뒤 닫는 컨트롤의 이름. */
   readonly collapseLabel?: string;
   /** 챔버 안의 단이 왜 비싼지 한 줄로 밝히는 경고. 열렸을 때만 보인다. */
   readonly specialWarning?: string;
@@ -48,9 +45,10 @@ export interface EffortTrackProps {
  * 모델이 내놓지 않은 단도 자리를 지킨다 — low/high/max만 있는 모델에서 셋을 균등히 벌리면
  * high가 한가운데 서서, 실제로는 3/5 지점인 단을 절반이라고 말하게 된다.
  *
- * 축의 꼬리(`effortExpansion`)는 레일 밖 챔버에 산다. 챔버 자리는 접혀 있을 때도 비워 두므로
- * 펼쳐도 평범한 단들의 좌표가 움직이지 않는다 — 축 전체가 다시 눈금을 그리면 방금 고른 값이
- * 옮겨 간 것처럼 읽힌다.
+ * 축의 꼬리(`effortExpansion`)는 레일에 실리지 않는다. 비싼 모드를 눈금 한두 칸으로 더 얹으면
+ * 같은 폭에 단만 늘어 간격이 좁아지고, 손잡이가 이웃 단을 덮어 스쳐도 닿는 자리가 된다 —
+ * 게이트를 둔 이유와 정반대다. 레일은 언제나 평범한 천장에서 끝나고, 그 뒤는 흐름 안에 펼쳐지는
+ * 별도의 면(챔버)이 맡는다.
  */
 export function EffortTrack({
   row,
@@ -67,85 +65,101 @@ export function EffortTrack({
   className,
 }: EffortTrackProps) {
   const trackRef = useRef<HTMLDivElement | null>(null);
-  // 좌표는 레일이 아니라 프레임에서 읽는다. 접힌 레일은 축의 일부만 덮으므로 그 폭으로 나누면
-  // 같은 자리가 다른 단을 가리켜, 펼치는 순간 평범한 단들이 제자리에서 옮겨 간 것처럼 읽힌다.
   const frameRef = useRef<HTMLDivElement | null>(null);
-  const gateRef = useRef<HTMLButtonElement | null>(null);
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
   const [expanded, setExpanded] = useState(false);
   // 제스처 동안 React 커밋을 기다리지 않고 고른 단을 추적한다 — 같은 포인터 시퀀스에서
   // "다른 단으로 옮겼다"와 "처음부터 이 단을 다시 눌렀다"를 갈라야 한다.
   const liveIndexRef = useRef(0);
   // pointerId까지 묶어 두면 터치에서 두 번째 손가락(button===0)이 제스처를 덮어 쓰지 못한다.
-  const gestureRef = useRef<{ readonly pointerId: number; readonly originIndex: number; readonly epoch: number; dirty: boolean } | null>(null);
-  // 펼침은 고를 수 있는 범위를 바꾼다. 그 경계를 넘어 살아남은 제스처는 방금 생긴 특수 단에
-  // 손을 얹은 채 놓게 되므로, epoch을 올려 이전 제스처의 이동·해제를 모두 버린다.
-  const epochRef = useRef(0);
+  const gestureRef = useRef<{ readonly pointerId: number; readonly originIndex: number; dirty: boolean } | null>(null);
+
+  const chips = useMemo(
+    () => new Map<string, OperationLaunchVariantChip>((row.chips ?? []).map((chip) => [chip.id, chip])),
+    [row],
+  );
 
   const slots = useMemo<readonly EffortSlot[]>(() => {
-    const byId = new Map<string, OperationLaunchVariantChip>((row.chips ?? []).map((chip) => [chip.id, chip]));
-    const specials = new Set(row.effortExpansion?.rungs ?? []);
     const rungs = ladderRungs(row).map((id) => ({
       id,
-      label: byId.get(id)?.label ?? id.toUpperCase(),
-      selectable: byId.has(id),
-      special: specials.has(id),
+      label: chips.get(id)?.label ?? id.toUpperCase(),
+      selectable: chips.has(id),
     }));
-    return [{ id: null, label: autoLabel, selectable: true, special: false }, ...rungs];
-  }, [autoLabel, row]);
+    return [{ id: null, label: autoLabel, selectable: true }, ...rungs];
+  }, [autoLabel, chips, row]);
 
-  const last = slots.length - 1;
-  // 평범한 레일의 끝. 챔버가 없는 행에서는 축의 끝과 같다.
+  /**
+   * 레일의 끝. 경계는 `rungs`가 아니라 `after`가 정한다 — `rungs`는 이 모델이 실제로 내주는
+   * 챔버 단만 담으므로, xhigh까지만 내주는 모델(`{after:"xhigh", rungs:["ultracode"]}`)에서
+   * `rungs`로 경계를 잡으면 축에 남아 있는 MAX가 평범한 빈 단으로 레일에 실려, 게이트가 서기도
+   * 전에 레일이 천장을 넘어간다.
+   */
   const ordinaryLast = useMemo(() => {
-    const firstSpecial = slots.findIndex((slot) => slot.special);
-    return firstSpecial < 0 ? last : firstSpecial - 1;
-  }, [last, slots]);
-  const hasChamber = ordinaryLast < last;
+    const after = row.effortExpansion?.after;
+    if (after === undefined) return slots.length - 1;
+    const boundary = slots.findIndex((slot) => slot.id === after);
+    return boundary < 0 ? slots.length - 1 : boundary;
+  }, [row, slots]);
 
-  const index = Math.max(0, slots.findIndex((slot) => slot.id === value));
-  const current = slots[index]!;
-  const isAuto = current.id === null;
-  const atSpecial = current.special;
+  /** 챔버가 맡는 자리. 축에는 있지만 이 모델이 내주지 않는 단도 자리를 지킨다. */
+  const chamberSlots = useMemo(() => {
+    const offered = new Set(row.effortExpansion?.rungs ?? []);
+    return slots.slice(ordinaryLast + 1).map((slot) => ({
+      ...slot,
+      selectable: slot.selectable && slot.id !== null && offered.has(slot.id),
+    }));
+  }, [ordinaryLast, row, slots]);
+  const hasChamber = chamberSlots.length > 0;
+
+  const armed = chamberSlots.find((slot) => slot.id === value) ?? null;
+  const atSpecial = armed !== null;
+  // 특수 강도가 실려 있으면 레일은 천장을 가리킨다 — 축 밖의 값이므로 눈금으로는 말할 수 없고,
+  // 무엇이 실렸는지는 값 라벨과 aria-valuetext가 맡는다.
+  const index = atSpecial ? ordinaryLast : Math.max(0, slots.findIndex((slot) => slot.id === value));
+  const current = atSpecial ? armed! : slots[index]!;
+  const isAuto = !atSpecial && current.id === null;
   liveIndexRef.current = index;
 
-  // 특수 단이 실려 있으면 챔버는 열린 채로 둔다. 접힌 레일이 비싼 모드를 숨기고 있으면 아무도
+  // 특수 단이 실려 있으면 챔버는 열린 채로 둔다. 접힌 면이 비싼 모드를 숨기고 있으면 아무도
   // 고르지 않은 값으로 다음 실행이 나간다.
   const open = expanded || atSpecial;
-  const activeLast = open ? last : ordinaryLast;
 
-  // 접힌 동안 남겨 두는 평범한 폴백. 챔버를 닫을 때 특수 단을 이 값으로 되돌린다.
+  // 접힌 동안 남겨 두는 평범한 폴백. 챔버를 닫거나 장전을 풀 때 이 값으로 되돌린다.
   const ordinaryFallbackRef = useRef<string | null>(null);
   useEffect(() => {
     if (!atSpecial) ordinaryFallbackRef.current = value;
   }, [atSpecial, value]);
 
   const nearestSelectable = useCallback((target: number): number => {
-    const bounded = Math.max(0, Math.min(target, activeLast));
+    const bounded = Math.max(0, Math.min(target, ordinaryLast));
     if (slots[bounded]?.selectable) return bounded;
     for (let step = 1; step <= slots.length; step += 1) {
       if (bounded - step >= 0 && slots[bounded - step]?.selectable) return bounded - step;
-      if (bounded + step <= activeLast && slots[bounded + step]?.selectable) return bounded + step;
+      if (bounded + step <= ordinaryLast && slots[bounded + step]?.selectable) return bounded + step;
     }
     return liveIndexRef.current;
-  }, [activeLast, slots]);
+  }, [ordinaryLast, slots]);
 
   const commit = useCallback((next: number) => {
     const slot = slots[next];
-    if (!slot || slot.id === slots[liveIndexRef.current]?.id) return false;
+    if (!slot) return false;
+    // 특수 강도가 실린 채 레일을 만지는 것은 그 모드를 내려놓는 일이다 — 같은 id로 보여도
+    // 지금 실린 값은 축 밖에 있으므로 "이미 고른 단"이 아니다.
+    if (!atSpecial && slot.id === slots[liveIndexRef.current]?.id) return false;
     liveIndexRef.current = next;
     onChange(slot.id);
     return true;
-  }, [onChange, slots]);
+  }, [atSpecial, onChange, slots]);
 
   const indexFromPointer = useCallback((clientX: number): number | null => {
     const frame = frameRef.current;
-    if (!frame || last === 0) return null;
+    if (!frame || ordinaryLast === 0) return null;
     const rect = frame.getBoundingClientRect();
     const span = rect.width - EDGE * 2;
     if (span <= 0) return null;
     const ratio = Math.max(0, Math.min((clientX - rect.left - EDGE) / span, 1));
-    return nearestSelectable(Math.round(ratio * last));
-  }, [last, nearestSelectable]);
+    return nearestSelectable(Math.round(ratio * ordinaryLast));
+  }, [nearestSelectable, ordinaryLast]);
 
   const fromPointer = useCallback((event: PointerEvent<HTMLDivElement>) => {
     const next = indexFromPointer(event.clientX);
@@ -161,8 +175,6 @@ export function EffortTrack({
     // 시작한 포인터만 끝낸다 — 다른 접촉의 up이 활성 제스처를 지우면 안 된다.
     if (!gesture || gesture.pointerId !== event.pointerId) return;
     gestureRef.current = null;
-    // 펼침 경계를 넘어온 제스처는 값을 고르는 의사로 읽지 않는다.
-    if (gesture.epoch !== epochRef.current) return;
     if (!confirm || gesture.dirty || !onConfirmCurrent) return;
     // 주버튼으로 트랙 안에서 손을 뗄 때만 확정한다 — 우클릭·가운데 클릭이나
     // 세로로 트랙 밖까지 끌어 뺀 해제는 값을 고르는 실수가 되지 않게 막는다.
@@ -178,45 +190,15 @@ export function EffortTrack({
     ) {
       return;
     }
-    const next = indexFromPointer(event.clientX);
-    // 챔버 안의 단은 다시 눌러도 실행되지 않는다.
-    if (next !== null && slots[next]?.special) return;
     // 처음부터 고른 단을 다시 눌렀고, 그 사이 다른 단으로 옮기지 않았을 때만 확정한다.
-    if (next === gesture.originIndex) onConfirmCurrent();
-  }, [indexFromPointer, onConfirmCurrent, slots]);
+    if (indexFromPointer(event.clientX) === gesture.originIndex) onConfirmCurrent();
+  }, [indexFromPointer, onConfirmCurrent]);
 
-  /** 펼침·접힘은 제스처 경계다. 붙잡고 있던 포인터를 여기서 끊어야 방금 생긴 단에 착지하지 않는다. */
-  const breakGesture = useCallback(() => {
-    epochRef.current += 1;
-    gestureRef.current = null;
-    setPreviewIndex(null);
-  }, []);
-
-  // 게이트를 누르면 그 게이트가 사라진다. 초점을 옮겨 두지 않으면 body로 떨어져, 키보드로 온
-  // 사람이 방금 연 챔버 앞에서 조작할 대상을 잃는다. 버튼이 실제로 붙은 뒤에 옮겨야 하므로
-  // 의사만 남기고 커밋 이후에 처리한다.
-  const focusIntentRef = useRef<"rail" | "gate" | null>(null);
-  useEffect(() => {
-    const intent = focusIntentRef.current;
-    if (intent === null) return;
-    focusIntentRef.current = null;
-    if (intent === "rail") trackRef.current?.focus();
-    else gateRef.current?.focus();
-  }, [open]);
-
-  const openChamber = useCallback(() => {
-    breakGesture();
-    focusIntentRef.current = "rail";
-    setExpanded(true);
-  }, [breakGesture]);
-
+  /** 챔버를 닫는 것은 장전을 푸는 일이다 — 접힌 면 뒤에 비싼 모드가 남아 있으면 안 된다. */
   const closeChamber = useCallback(() => {
-    breakGesture();
-    focusIntentRef.current = "gate";
     setExpanded(false);
-    // 특수 단이 실린 채로는 접을 수 없다. 챔버를 닫는 것은 그 모드를 내려놓는 일이다.
     if (atSpecial) onChange(ordinaryFallbackRef.current);
-  }, [atSpecial, breakGesture, onChange]);
+  }, [atSpecial, onChange]);
 
   const handleKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
     const direction = event.key === "ArrowLeft" || event.key === "ArrowDown"
@@ -225,20 +207,12 @@ export function EffortTrack({
     let next: number | null = null;
     // 방향키는 그 방향으로 고를 수 있는 다음 단까지 건너뛴다 — 비어 있는 자리에 멈추지 않는다.
     if (direction !== 0) {
-      for (let i = index + direction; i >= 0 && i <= activeLast; i += direction) {
+      for (let i = index + direction; i >= 0 && i <= ordinaryLast; i += direction) {
         if (slots[i]!.selectable) { next = i; break; }
-      }
-      // 접힌 천장에서 더 오른쪽으로 가려는 키는 게이트로 초점을 넘긴다. 챔버를 열어 주지는
-      // 않는다 — 방향키가 비싼 모드를 여는 손잡이가 되면 그 문은 문이 아니다.
-      if (next === null && direction === 1 && !open && hasChamber) {
-        event.preventDefault();
-        event.stopPropagation();
-        gateRef.current?.focus();
-        return;
       }
     }
     if (event.key === "Home") next = 0;
-    if (event.key === "End") next = nearestSelectable(activeLast);
+    if (event.key === "End") next = nearestSelectable(ordinaryLast);
     if (event.key === "Escape" && open) {
       event.preventDefault();
       event.stopPropagation();
@@ -260,136 +234,145 @@ export function EffortTrack({
     // 트랙은 메뉴 안에 산다. 방향키가 위로 새면 메뉴가 항목 이동으로 받아 함께 움직인다.
     event.stopPropagation();
     commit(next);
-  }, [activeLast, atSpecial, closeChamber, commit, hasChamber, index, nearestSelectable, onConfirmCurrent, open, slots]);
+  }, [atSpecial, closeChamber, commit, index, nearestSelectable, onConfirmCurrent, open, ordinaryLast, slots]);
 
-  const ratio = last === 0 ? 0 : index / last;
-  // 레일이 덮는 길이. 접혀 있으면 평범한 천장에서 끊기고, 남은 폭이 챔버다.
-  const laneRatio = last === 0 ? 1 : activeLast / last;
-  const laneWidth = open ? "100%" : `calc(${EDGE * 2}px + ${laneRatio} * (100% - ${EDGE * 2}px))`;
-  const specialDescription = current.id === null ? undefined : specialDescriptions?.[current.id];
+  const ratio = ordinaryLast === 0 ? 0 : index / ordinaryLast;
+  const specialDescription = armed?.id === undefined || armed?.id === null ? undefined : specialDescriptions?.[armed.id];
 
   return (
     <div className={`effort-track-shell${className ? ` ${className}` : ""}`} data-open={open ? true : undefined}>
-      {/* 채움·스톱·손잡이는 레일이 아니라 이 상자를 기준으로 자리를 잰다 — 레일이 챔버로 자라도
-          이미 고른 단이 제자리에 남아야 하므로 레일의 자식으로 둘 수 없다. 상태는 그대로 레일이
-          지고, 형제 선택자로 이 안의 조각들에 닿는다. */}
-      <div className="effort-track-frame" ref={frameRef}>
-        <div
-          ref={trackRef}
-          className="effort-track"
-          role="slider"
-          tabIndex={0}
-          aria-label={ariaLabel}
-          aria-valuemin={0}
-          aria-valuemax={activeLast}
-          aria-valuenow={index}
-          aria-valuetext={isAuto ? autoValueText : specialDescription ?? current.label}
-          // 자동은 사다리의 최소 단이 아니라 "사다리를 쓰지 않음"이다. 파선 테두리·빈 손잡이·채움 0이
-          // 한 어휘로 그것을 말한다 — 채움이 조금이라도 남으면 맨 왼쪽 단을 고른 것으로 읽힌다.
-          data-auto={isAuto ? true : undefined}
-          // 최고 단 텍스처는 축의 끝이 아니라 지금 고를 수 있는 천장을 말한다. 축의 끝자리로 읽으면
-          // 챔버가 열려 있을 때만 켜져, 접힌 레일의 천장이 천장으로 보이지 않는다.
-          data-at-max={index === activeLast && !isAuto ? true : undefined}
-          data-special={atSpecial ? current.id : undefined}
-          style={{ width: laneWidth }}
-          onKeyDown={handleKeyDown}
-          onPointerDown={(event) => {
-            // 주 접촉만 받는다. 터치 두 번째 손가락도 button===0이라 isPrimary·활성 제스처로 막는다.
-            if (!event.isPrimary || event.button !== 0 || gestureRef.current) return;
-            event.preventDefault();
-            event.currentTarget.setPointerCapture(event.pointerId);
-            event.currentTarget.focus();
-            gestureRef.current = { pointerId: event.pointerId, originIndex: liveIndexRef.current, epoch: epochRef.current, dirty: false };
-            fromPointer(event);
-          }}
-          onPointerMove={(event) => {
-            const next = indexFromPointer(event.clientX);
-            if (next !== null) setPreviewIndex(next);
-            const gesture = gestureRef.current;
-            if (!gesture || gesture.pointerId !== event.pointerId) return;
-            if (gesture.epoch !== epochRef.current) return;
-            if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
-            fromPointer(event);
-          }}
-          onPointerUp={(event) => endGesture(event, { confirm: true })}
-          onPointerLeave={() => setPreviewIndex(null)}
-          onPointerCancel={(event) => endGesture(event, { confirm: false })}
-        />
-        {/* 자동은 폭 0이다. 손잡이 여백(EDGE)만큼이라도 남기면 트랙 왼쪽 끝에 brass 조각이 비쳐,
-            비운 상태가 최소 강도를 고른 것처럼 보인다. 고른 단이 레일 끝을 넘지 못하므로 이 채움은
-            레일 밖으로 새지 않는다 — 잘라내지 않아도 된다. */}
-        <span
-          className="effort-track-fill"
-          style={{ width: isAuto ? 0 : `calc(${EDGE}px + ${ratio} * (100% - ${EDGE * 2}px))` }}
-          aria-hidden="true"
-        />
-        {/* 챔버가 열릴 때 한 번만 지나가는 빛. 열림에 매달아 두면 상시 루프가 되지 않는다 —
-            계속 움직이는 표면은 값이 아직 정해지지 않았다고 말한다. */}
-        {open ? <span className="effort-track-reveal-sheen" aria-hidden="true" /> : null}
-        <span className="effort-track-stops" aria-hidden="true">
-          {slots.map((slot, position) => (
-            position <= activeLast ? (
-              <span
-                key={slot.id ?? "auto"}
-                className="effort-track-stop"
-                style={{ left: last === 0 ? "50%" : `calc(${EDGE}px + ${position / last} * (100% - ${EDGE * 2}px))` }}
-                data-filled={position <= index && !isAuto ? true : undefined}
-                data-gap={slot.selectable ? undefined : true}
-                data-special={slot.special ? slot.id : undefined}
-                data-previewed={position === previewIndex ? true : undefined}
-              />
-            ) : null
-          ))}
+      {/* 레일 행의 구성은 상태와 무관하게 고정이다 — 게이트가 붙었다 떨어지면 레일이 그만큼
+          넓어졌다 좁아져, 움직이지 않아야 할 단들이 제자리에서 밀린다. */}
+      <div className="effort-track-row">
+        {/* 채움·스톱·손잡이는 레일이 아니라 이 상자를 기준으로 자리를 잰다. 상태는 그대로 레일이
+            지고, 형제 선택자로 이 안의 조각들에 닿는다. */}
+        <div className="effort-track-frame" ref={frameRef}>
+          <div
+            ref={trackRef}
+            className="effort-track"
+            role="slider"
+            tabIndex={0}
+            aria-label={ariaLabel}
+            aria-valuemin={0}
+            aria-valuemax={ordinaryLast}
+            aria-valuenow={index}
+            aria-valuetext={isAuto ? autoValueText : specialDescription ?? current.label}
+            // 자동은 사다리의 최소 단이 아니라 "사다리를 쓰지 않음"이다. 파선 테두리·빈 손잡이·채움 0이
+            // 한 어휘로 그것을 말한다 — 채움이 조금이라도 남으면 맨 왼쪽 단을 고른 것으로 읽힌다.
+            data-auto={isAuto ? true : undefined}
+            data-at-max={index === ordinaryLast && !isAuto && !atSpecial ? true : undefined}
+            data-special={armed?.id ?? undefined}
+            onKeyDown={handleKeyDown}
+            onPointerDown={(event) => {
+              // 주 접촉만 받는다. 터치 두 번째 손가락도 button===0이라 isPrimary·활성 제스처로 막는다.
+              if (!event.isPrimary || event.button !== 0 || gestureRef.current) return;
+              event.preventDefault();
+              event.currentTarget.setPointerCapture(event.pointerId);
+              event.currentTarget.focus();
+              gestureRef.current = { pointerId: event.pointerId, originIndex: liveIndexRef.current, dirty: false };
+              fromPointer(event);
+            }}
+            onPointerMove={(event) => {
+              const next = indexFromPointer(event.clientX);
+              if (next !== null) setPreviewIndex(next);
+              const gesture = gestureRef.current;
+              if (!gesture || gesture.pointerId !== event.pointerId) return;
+              if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
+              fromPointer(event);
+            }}
+            onPointerUp={(event) => endGesture(event, { confirm: true })}
+            onPointerLeave={() => setPreviewIndex(null)}
+            onPointerCancel={(event) => endGesture(event, { confirm: false })}
+          />
+          {/* 자동은 폭 0이다. 손잡이 여백(EDGE)만큼이라도 남기면 트랙 왼쪽 끝에 brass 조각이 비쳐,
+              비운 상태가 최소 강도를 고른 것처럼 보인다. 특수 강도는 축 밖이므로 레일을 끝까지 채운다. */}
+          <span
+            className="effort-track-fill"
+            style={{ width: isAuto ? 0 : atSpecial ? "auto" : `calc(${EDGE}px + ${ratio} * (100% - ${EDGE * 2}px))` }}
+            data-flood={atSpecial ? true : undefined}
+            aria-hidden="true"
+          />
+          <span className="effort-track-stops" aria-hidden="true">
+            {slots.map((slot, position) => (
+              position <= ordinaryLast ? (
+                <span
+                  key={slot.id ?? "auto"}
+                  className="effort-track-stop"
+                  style={{ left: ordinaryLast === 0 ? "50%" : `calc(${EDGE}px + ${position / ordinaryLast} * (100% - ${EDGE * 2}px))` }}
+                  data-filled={(position <= index && !isAuto) || atSpecial ? true : undefined}
+                  data-gap={slot.selectable ? undefined : true}
+                  data-previewed={position === previewIndex ? true : undefined}
+                />
+              ) : null
+            ))}
+          </span>
+          <span
+            className="effort-track-knob"
+            style={{ left: `calc(${EDGE}px + ${ratio} * (100% - ${EDGE * 2}px))` }}
+            data-auto={isAuto ? true : undefined}
+            data-special={armed?.id ?? undefined}
+            aria-hidden="true"
+          />
+        </div>
+        {/* 단계 톤은 CSS가 이 속성 하나로 읽는다 — 라벨 문자열은 번역·모델마다 달라 색의 기준이 될 수 없다. */}
+        <span className="effort-track-value" data-auto={isAuto} data-effort-level={current.id ?? "auto"}>
+          {current.label}
         </span>
-        <span
-          className="effort-track-knob"
-          style={{ left: `calc(${EDGE}px + ${ratio} * (100% - ${EDGE * 2}px))` }}
-          data-auto={isAuto ? true : undefined}
-          data-special={atSpecial ? current.id : undefined}
-          aria-hidden="true"
-        />
-        {hasChamber && !open ? (
+        {hasChamber ? (
           <button
-            ref={gateRef}
             type="button"
             className="effort-track-gate"
-            style={{ left: `calc(${EDGE * 2}px + ${laneRatio} * (100% - ${EDGE * 2}px))` }}
-            aria-expanded={false}
-            aria-label={revealLabel}
-            title={revealLabel}
-            onClick={openChamber}
+            aria-expanded={open}
+            aria-label={open ? collapseLabel : revealLabel}
+            title={open ? collapseLabel : revealLabel}
+            data-armed={atSpecial ? true : undefined}
+            onClick={() => (open ? closeChamber() : setExpanded(true))}
           >
             <span className="effort-track-gate-leaf" aria-hidden="true" />
             <span className="effort-track-gate-leaf" aria-hidden="true" />
           </button>
         ) : null}
       </div>
-      {/* 단계 톤은 CSS가 이 속성 하나로 읽는다 — 라벨 문자열은 번역·모델마다 달라 색의 기준이 될 수 없다. */}
-      <span className="effort-track-value" data-auto={isAuto} data-effort-level={current.id ?? "auto"}>
-        {current.label}
-      </span>
-      {/* 비싼 모드가 열려 있는 동안에는 왜 비싼지 화면에도 남는다 — 게이트를 지난 뒤에 사라지면
-          고르는 순간에는 아무 말도 하지 않는 경고가 된다. 닫는 손잡이도 여기 함께 띄운다: 트랙
-          옆에 흐름대로 놓으면 열릴 때마다 프레임이 그만큼 좁아져, 움직이지 않아야 할 평범한
-          단들이 제자리에서 밀린다. */}
+      {/* 챔버는 흐름 안에 펼쳐진다. 레일 위로 띄우면 플라이아웃의 overflow가 잘라 내 — 비용을
+          밝히겠다고 만든 면이 정작 화면에 없다. */}
       {hasChamber && open ? (
-        <div className="effort-track-chamber-note">
-          {specialWarning ? <span role="status">{specialWarning}</span> : null}
-          <button
-            ref={gateRef}
-            type="button"
-            className="effort-track-collapse"
-            aria-expanded
-            aria-label={collapseLabel}
-            title={collapseLabel}
-            onClick={closeChamber}
-          >
-            <span aria-hidden="true">‹</span>
-          </button>
+        <div className="effort-track-chamber" role="group" aria-label={revealLabel}>
+          {specialWarning ? <p className="effort-track-chamber-warning">{specialWarning}</p> : null}
+          <div className="effort-track-chamber-tiles">
+            {chamberSlots.map((slot) => (
+              <button
+                key={slot.id ?? "chamber"}
+                type="button"
+                className="effort-track-chamber-tile"
+                data-effort-level={slot.id ?? undefined}
+                // 고르는 것과 내보내는 것을 가른다. 눌린 타일은 장전이지 실행이 아니므로
+                // 상태는 pressed로 말하고, 다시 누르면 장전을 푼다.
+                aria-pressed={slot.id === value}
+                disabled={!slot.selectable}
+                onClick={() => onChange(slot.id === value ? ordinaryFallbackRef.current : slot.id)}
+              >
+                <span className="effort-track-chamber-tile-name">{slot.label}</span>
+                {slot.id !== null && specialDescriptions?.[slot.id] ? (
+                  <span className="effort-track-chamber-tile-note">
+                    {stripLabelPrefix(specialDescriptions[slot.id]!, slot.label)}
+                  </span>
+                ) : null}
+              </button>
+            ))}
+          </div>
         </div>
       ) : null}
     </div>
   );
+}
+
+/**
+ * 설명 문장은 보조기술이 단 이름 없이 듣는 자리(aria-valuetext)를 겸하므로 "MAX — …" 꼴로 이름을
+ * 앞에 달고 있다. 이름이 이미 제목으로 선 타일에서는 그 앞머리를 걷어 낸다.
+ */
+function stripLabelPrefix(description: string, label: string): string {
+  const prefix = `${label} — `;
+  return description.startsWith(prefix) ? description.slice(prefix.length) : description;
 }
 
 /**
@@ -400,6 +383,18 @@ function ladderRungs(row: OperationLaunchVariantRow): readonly string[] {
   const offered = (row.chips ?? []).map((chip) => chip.id);
   const axis = row.effortAxis ?? offered;
   return [...axis, ...offered.filter((id) => !axis.includes(id))];
+}
+
+/**
+ * 챔버가 맡는 단들. 경계는 `after`가 정하고 `rungs`는 그중 무엇을 실제로 내주는지만 고른다 —
+ * 저장·복원 경계가 `rungs`만 보면, 모델이 내주지 않아 축에만 남은 단이 평범한 단으로 새어 나간다.
+ */
+function chamberRungs(row: OperationLaunchVariantRow): readonly string[] {
+  const after = row.effortExpansion?.after;
+  if (after === undefined) return [];
+  const rungs = ladderRungs(row);
+  const boundary = rungs.indexOf(after);
+  return boundary < 0 ? [] : rungs.slice(boundary + 1);
 }
 
 /**
@@ -415,9 +410,8 @@ export function effortLadderPosition(row: OperationLaunchVariantRow, effort: str
   readonly total: number;
   readonly special: string | null;
 } {
-  const rungs = ladderRungs(row);
-  const specials = new Set(row.effortExpansion?.rungs ?? []);
-  const ordinary = rungs.filter((id) => !specials.has(id));
+  const specials = new Set(chamberRungs(row));
+  const ordinary = ladderRungs(row).filter((id) => !specials.has(id));
   if (effort !== null && specials.has(effort)) {
     return { rung: ordinary.length, total: ordinary.length, special: effort };
   }
@@ -443,5 +437,5 @@ export function resolveRowEffort(row: OperationLaunchVariantRow | null, effort: 
 /** 이 강도가 챔버 뒤의 특수 모드인가. 저장·복원 경계가 이 판정을 공유해야 한다. */
 export function isSpecialEffort(row: OperationLaunchVariantRow | null, effort: string | null): boolean {
   if (!row || effort === null) return false;
-  return (row.effortExpansion?.rungs ?? []).includes(effort);
+  return chamberRungs(row).includes(effort);
 }

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -150,7 +150,9 @@ export function QuickLaunch() {
     const variant: Record<string, string> = { prompt: text };
     if (model) variant.model = model;
     if (effort) variant.effort = effort;
-    writeQuickLaunchSelection({ theaterId, model, effort });
+    // 실행에는 실리되 디스크에는 남지 않는다. 챔버 뒤의 강도는 이 세션 한정이므로, 저장해 두면
+    // 다음에 컴포저를 열 때 아무도 고르지 않은 고비용 모드가 복원돼 게이트를 지나지 않고 나간다.
+    writeQuickLaunchSelection({ theaterId, model, effort: isSpecialEffort(selectedRow, effort) ? null : effort });
     // 대상 Theater로 전환한 뒤 Operations로 이동한다. 실행은 그 화면이 자기 지오메트리·포커스 규율로
     // 수행한다(pendingOperationFocus와 같은 request/consume 계약) — 컴포저는 의도만 넘긴다.
     setActiveTheater(theaterId);

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -12,7 +12,7 @@ import { findVariantLaunchKind, QUICK_LAUNCH_DEFAULT_MODEL, QUICK_LAUNCH_PROMPT_
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
 import { closeQuickLaunch, consumeQuickLaunchDraft, requestQuickLaunch, setActiveTheater } from "../store.js";
 import { launchProviderFromGroupId, launchProviderFromModelId, launchProviderGlyph } from "./launch-provider-glyphs.js";
-import { EffortTrack, resolveRowEffort } from "./effort-track.js";
+import { EffortTrack, isSpecialEffort, resolveRowEffort } from "./effort-track.js";
 
 // 카드 폭은 팔레트(920px)보다 좁다 — 팔레트는 결과 목록을 담고, 여기는 한 문단을 담는다.
 const CARD_WIDTH_FALLBACK = 760;
@@ -274,11 +274,23 @@ export function QuickLaunch() {
               value={effort}
               onChange={(nextEffort) => {
                 setEffort(nextEffort);
-                writeQuickLaunchModelEffort(model, nextEffort);
+                // 챔버 뒤의 단은 이 실행에만 실린다. 디스크에 남기면 다음 세션이 아무도 고르지 않은
+                // 비싼 모드로 열려, 게이트를 둔 이유가 그대로 사라진다.
+                writeQuickLaunchModelEffort(
+                  model,
+                  isSpecialEffort(selectedRow, nextEffort) ? null : nextEffort,
+                );
               }}
               autoLabel={t("launchVariants.effort.auto")}
               ariaLabel={t("launchVariants.effort.track")}
               autoValueText={t("launchVariants.effort.autoValue")}
+              revealLabel={t("launchVariants.effort.reveal")}
+              collapseLabel={t("launchVariants.effort.collapse")}
+              specialWarning={t("launchVariants.effort.specialWarning")}
+              specialDescriptions={{
+                max: t("launchVariants.effort.maxValue"),
+                ultracode: t("launchVariants.effort.ultracodeValue"),
+              }}
               className="quick-launch-effort-track"
             />
           ) : null}

--- a/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
@@ -278,7 +278,7 @@ export const canvasKo: Record<keyof typeof canvasEn, string> = {
   "canvas.plugin.companionFailed": "Plugin Companion을 렌더하지 못했습니다.",
 
   "canvas.menu.aria": "Operation 실행 메뉴",
-  "canvas.menu.etc": "Etc",
+  "canvas.menu.etc": "기타",
   "canvas.menu.empty": "사용 가능한 Operation이 없습니다.",
 
   "canvas.minimap.open": "Map 열기",

--- a/runtime/fleet-console/core/client/src/i18n/messages/common.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/common.ts
@@ -74,6 +74,11 @@ export const commonEn = {
   "launchVariants.effort.auto": "AUTO",
   "launchVariants.effort.autoValue": "Automatic — the model's own default",
   "launchVariants.effort.confirmTip": "Press the knob again to launch.",
+  "launchVariants.effort.reveal": "Reveal high-cost efforts — MAX and ULTRACODE",
+  "launchVariants.effort.collapse": "Put the high-cost efforts away",
+  "launchVariants.effort.specialWarning": "High cost — spends far more of your allowance per run.",
+  "launchVariants.effort.maxValue": "MAX — the deepest reasoning this model offers, at the highest cost per run",
+  "launchVariants.effort.ultracodeValue": "ULTRACODE — XHIGH reasoning plus multi-agent workflow orchestration, for this session only",
 } as const;
 
 export const commonKo: Record<keyof typeof commonEn, string> = {
@@ -151,4 +156,9 @@ export const commonKo: Record<keyof typeof commonEn, string> = {
   "launchVariants.effort.auto": "자동",
   "launchVariants.effort.autoValue": "자동 — 모델 자체 기본값",
   "launchVariants.effort.confirmTip": "노브를 다시 누르면 실행됩니다.",
+  "launchVariants.effort.reveal": "비용이 큰 강도 펼치기 — MAX와 ULTRACODE",
+  "launchVariants.effort.collapse": "비용이 큰 강도 접기",
+  "launchVariants.effort.specialWarning": "비용이 큽니다 — 실행 한 번에 할당량을 훨씬 많이 씁니다.",
+  "launchVariants.effort.maxValue": "MAX — 이 모델이 내놓는 가장 깊은 추론, 실행당 비용도 가장 큽니다",
+  "launchVariants.effort.ultracodeValue": "ULTRACODE — XHIGH 추론에 다중 에이전트 워크플로우 오케스트레이션을 얹은 모드, 이 세션에만 걸립니다",
 };

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7407,12 +7407,14 @@
 
 /* 소등 칸은 켜진 칸과 확실히 갈릴 만큼 물러서야 한다 — 램프의 낮은 단은 톤 자체가 판독 하한
    근처라, 소등이 그 근처에 있으면 LOW에서 몇 칸이 켜졌는지 읽히지 않는다. */
-.operation-launch-variant-effort-gauge rect {
+.operation-launch-variant-effort-gauge rect,
+.operation-launch-variant-effort-gauge circle {
   fill: color-mix(in oklch, var(--text-tertiary) 24%, transparent);
   transition: fill var(--duration-fast) var(--ease-spring);
 }
 
-.operation-launch-variant-effort-gauge rect[data-lit="true"] {
+.operation-launch-variant-effort-gauge rect[data-lit="true"],
+.operation-launch-variant-effort-gauge circle[data-lit="true"] {
   fill: var(--effort-tone, var(--brass-ink));
 }
 
@@ -7473,27 +7475,40 @@
 [data-effort-level="high"] { --effort-tone: color-mix(in oklab, var(--brass-ink) 64%, var(--text-tertiary)); }
 [data-effort-level="xhigh"] { --effort-tone: color-mix(in oklab, var(--brass-ink) 84%, var(--text-tertiary)); }
 [data-effort-level="max"] { --effort-tone: var(--brass-ink); }
+/* ultracode는 램프의 한 칸 더가 아니다 — xhigh 깊이에 오케스트레이션을 얹은 모드다. brass를 더
+   태우면 max보다 깊게 생각한다는 거짓이 되므로, 깊이 채널에서 내려 비용 채널로 옮긴다. */
+[data-effort-level="ultracode"] { --effort-tone: var(--warn-ink); }
 
 .effort-track-shell {
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--space-2);
   min-width: 0;
 }
 
-.effort-track {
+/* 축의 좌표계. 채움·스톱·손잡이는 모두 이 상자를 기준으로 자리를 재므로, 레일이 챔버로 자라도
+   이미 고른 단이 제자리에 남는다 — 레일을 기준으로 재면 펼치는 순간 축 전체가 눈금을 다시
+   그려, 방금 고른 값이 옮겨 간 것처럼 읽힌다. */
+.effort-track-frame {
   position: relative;
   flex: 1;
   min-width: 116px;
   height: 26px;
-  padding: 0 13px;
-  display: flex;
-  align-items: center;
+}
+
+.effort-track {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
   border: 1px solid var(--surface-rim);
   border-radius: 999px;
   background: color-mix(in oklch, var(--surface-pillar) 55%, transparent);
   cursor: pointer;
   touch-action: none;
+  /* 펼침은 레일이 챔버로 자라는 일이다. 폭 하나만 움직이므로 스톱과 손잡이는 흔들리지 않는다. */
+  transition: width var(--duration-base) var(--ease-spring);
 }
 
 .effort-track:focus-visible {
@@ -7524,7 +7539,7 @@
 
 /* 최고 단은 색을 갈지 않는다 — 채도가 뛰면 신호로 읽힌다. 최대 출력에 든 계기처럼
    결만 얹고, 광택은 한 번 훑고 지나간다. */
-.effort-track[data-at-max="true"] .effort-track-fill {
+.effort-track[data-at-max="true"] ~ .effort-track-fill {
   background:
     repeating-linear-gradient(
       115deg,
@@ -7533,7 +7548,7 @@
     var(--brass);
 }
 
-.effort-track[data-at-max="true"] .effort-track-fill::after {
+.effort-track[data-at-max="true"] ~ .effort-track-fill::after {
   content: "";
   position: absolute;
   inset: 0;
@@ -7552,9 +7567,8 @@
 }
 
 .effort-track-stops {
-  position: relative;
-  flex: 1;
-  height: 100%;
+  position: absolute;
+  inset: 0;
   pointer-events: none;
 }
 
@@ -7609,7 +7623,9 @@
   pointer-events: none;
 }
 
-.effort-track:hover .effort-track-knob {
+/* 레일 위에 손이 있을 때만이다. 프레임 전체로 넓히면 챔버의 게이트를 스쳐도 손잡이가 커져,
+   레일을 만지고 있다고 말하게 된다. */
+.effort-track:hover ~ .effort-track-knob {
   box-shadow: 0 2px 8px oklch(0% 0 0 / 62%);
   transform: scale(1.1);
 }
@@ -7634,9 +7650,145 @@
 }
 
 /* 최고 단은 램프의 끝이라 색만으로는 바로 아랫단과 갈리지 않는다 — 무게가 그 마지막 한 칸을 맡는다. */
-.effort-track-value[data-effort-level="max"] {
+.effort-track-value[data-effort-level="max"],
+.effort-track-value[data-effort-level="ultracode"] {
   font-weight: var(--weight-medium);
 }
+
+/* ── 챔버: 평범한 레일 뒤에 사는 비싼 단들 ────────────────────────────────────────────── */
+
+/* 게이트는 챔버가 차지할 자리를 그대로 지킨다. 접혀 있을 때 그 폭을 비워 두므로 펼쳐도 평범한
+   단들이 움직이지 않고, 사용자는 무엇이 어디로 자랄지 미리 본다. */
+.effort-track-gate {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  min-width: 0;
+  padding: 0;
+  border: 1px dashed color-mix(in oklch, var(--warn) 38%, var(--surface-rim));
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--warn) 6%, transparent);
+  color: var(--warn-ink);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-spring),
+    border-color var(--duration-fast) var(--ease-spring);
+}
+
+.effort-track-gate:hover {
+  background: color-mix(in oklch, var(--warn) 13%, transparent);
+  border-color: color-mix(in oklch, var(--warn) 62%, var(--surface-rim));
+}
+
+.effort-track-gate:focus-visible {
+  outline: 2px solid var(--brass);
+  outline-offset: 2px;
+}
+
+/* 두 겹의 꺾쇠. 안쪽으로 모여 있다가 손이 오면 벌어져, 여는 방향을 화살표 하나보다 분명히 말한다. */
+.effort-track-gate-leaf {
+  width: 4px;
+  height: 4px;
+  border-top: 1.25px solid currentcolor;
+  border-right: 1.25px solid currentcolor;
+  transform: rotate(45deg);
+  transition: transform var(--duration-fast) var(--ease-spring);
+}
+
+.effort-track-gate:hover .effort-track-gate-leaf:first-child { transform: rotate(45deg) translate(-1px, 1px); }
+.effort-track-gate:hover .effort-track-gate-leaf:last-child { transform: rotate(45deg) translate(1px, -1px); }
+
+/* 챔버 안의 스톱은 눈금이 아니라 문턱이다 — 비용 채널로 칠해, 축을 훑는 눈이 여기서 멈춘다. */
+.effort-track-stop[data-special] {
+  background: none;
+  box-shadow: 0 0 0 1.5px var(--warn);
+}
+
+.effort-track-stop[data-special][data-filled="true"] {
+  background: var(--warn);
+  box-shadow: 0 0 0 2px var(--warn-glow);
+}
+
+/* 비싼 단을 쥔 손잡이. 색을 갈지 않고 비용 채널의 테를 두른다 — 손잡이 본체가 물들면 어느 단을
+   쥐었는지가 아니라 "경고"가 먼저 읽힌다. */
+.effort-track-knob[data-special] {
+  box-shadow:
+    0 0 0 2px var(--warn),
+    0 0 10px var(--warn-glow),
+    0 1px 3px oklch(0% 0 0 / 55%);
+}
+
+/* 챔버가 열릴 때 한 번 지나가는 빛. 열림에 매달려 있으므로 루프가 없다 — 계속 움직이는 표면은
+   값이 아직 정해지지 않았다고 말한다. */
+.effort-track-reveal-sheen {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: linear-gradient(
+    100deg,
+    transparent 38%,
+    color-mix(in oklch, var(--warn) 30%, transparent) 50%,
+    transparent 62%);
+  animation: effort-track-reveal var(--duration-slow) var(--ease-spring) 1;
+  pointer-events: none;
+}
+
+@keyframes effort-track-reveal {
+  from { opacity: 0; transform: translateX(-40%); }
+  60% { opacity: 1; }
+  to { opacity: 0; transform: translateX(40%); }
+}
+
+/* 흐름 밖으로 띄운다. 트랙 옆에 흐름대로 놓으면 챔버를 열 때마다 프레임이 그만큼 좁아져,
+   움직이지 않아야 할 평범한 단들이 제자리에서 밀린다 — 펼침이 축을 다시 눈금 그리는 일이 된다. */
+.effort-track-chamber-note {
+  position: absolute;
+  bottom: calc(100% + var(--space-1));
+  left: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  max-width: 280px;
+  padding: 2px var(--space-2);
+  border: 1px solid color-mix(in oklch, var(--warn) 32%, var(--surface-rim));
+  border-radius: var(--radius-sm);
+  background: var(--surface-frame);
+  color: var(--warn-ink);
+  font-size: 10.5px;
+  line-height: 1.35;
+}
+
+.effort-track-collapse {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: none;
+  color: var(--text-tertiary);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--ease-spring);
+}
+
+.effort-track-collapse:hover { color: var(--text-secondary); }
+
+.effort-track-collapse:focus-visible {
+  outline: 2px solid var(--brass);
+  outline-offset: 2px;
+}
+
 
 /* 파선 밑줄은 트랙의 파선 테두리와 같은 말이다: 이 값은 사다리 위의 단이 아니라 모델에 맡긴 자리다. */
 .effort-track-value[data-auto="true"] {
@@ -7664,7 +7816,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .effort-track[data-at-max="true"] .effort-track-fill::after {
+  .effort-track[data-at-max="true"] ~ .effort-track-fill::after {
     animation: none;
     opacity: 0.22;
   }
@@ -11280,18 +11432,30 @@ body[data-codex-reading="true"] .operations-side-bar {
 
   .quick-launch-chip,
   .quick-launch-submit,
+  .effort-track,
   .effort-track-fill,
   .effort-track-knob,
   .effort-track-stop,
   .effort-track-value,
+  .effort-track-gate,
+  .effort-track-gate-leaf,
+  .effort-track-collapse,
   .operation-launch-variant-effort,
   .operation-launch-variant-effort-handle,
-  .operation-launch-variant-effort-gauge rect {
+  .operation-launch-variant-effort-gauge rect,
+  .operation-launch-variant-effort-gauge circle {
     animation: none;
     transition: none;
   }
 
-  .effort-track:hover .effort-track-knob,
+  /* 펼침의 빛은 지나가는 움직임 그 자체다 — 멈춰 세우면 트랙 위에 흰 띠로 남으므로 지운다.
+     비싼 단이라는 사실은 색·테·경고문이 이미 말하고 있어 잃는 것이 없다. */
+  .effort-track-reveal-sheen {
+    display: none;
+  }
+
+  .effort-track:hover ~ .effort-track-knob,
+  .effort-track-gate:hover .effort-track-gate-leaf,
   .effort-track-stop[data-previewed="true"] {
     transform: none;
   }

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7482,18 +7482,25 @@
 .effort-track-shell {
   position: relative;
   display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+/* 레일 행의 구성은 상태와 무관하게 고정이다 — 게이트가 붙었다 떨어지면 flex 레일이 그만큼
+   넓어졌다 좁아져, 움직이지 않아야 할 단들이 제자리에서 밀린다. */
+.effort-track-row {
+  display: flex;
   align-items: center;
   gap: var(--space-2);
   min-width: 0;
 }
 
-/* 축의 좌표계. 채움·스톱·손잡이는 모두 이 상자를 기준으로 자리를 재므로, 레일이 챔버로 자라도
-   이미 고른 단이 제자리에 남는다 — 레일을 기준으로 재면 펼치는 순간 축 전체가 눈금을 다시
-   그려, 방금 고른 값이 옮겨 간 것처럼 읽힌다. */
+/* 축의 좌표계. 채움·스톱·손잡이가 모두 이 상자를 기준으로 자리를 잰다. */
 .effort-track-frame {
   position: relative;
   flex: 1;
-  min-width: 116px;
+  min-width: 96px;
   height: 26px;
 }
 
@@ -7501,14 +7508,13 @@
   position: absolute;
   left: 0;
   top: 0;
+  width: 100%;
   height: 100%;
   border: 1px solid var(--surface-rim);
   border-radius: 999px;
   background: color-mix(in oklch, var(--surface-pillar) 55%, transparent);
   cursor: pointer;
   touch-action: none;
-  /* 펼침은 레일이 챔버로 자라는 일이다. 폭 하나만 움직이므로 스톱과 손잡이는 흔들리지 않는다. */
-  transition: width var(--duration-base) var(--ease-spring);
 }
 
 .effort-track:focus-visible {
@@ -7657,13 +7663,12 @@
 
 /* ── 챔버: 평범한 레일 뒤에 사는 비싼 단들 ────────────────────────────────────────────── */
 
-/* 게이트는 챔버가 차지할 자리를 그대로 지킨다. 접혀 있을 때 그 폭을 비워 두므로 펼쳐도 평범한
-   단들이 움직이지 않고, 사용자는 무엇이 어디로 자랄지 미리 본다. */
+/* 게이트는 여닫이 하나다 — 열림과 닫힘에 서로 다른 버튼을 세우면, 한쪽이 사라질 때 행이
+   재배치되어 레일이 넓어졌다 좁아진다. 같은 자리에 남아 aria-expanded만 뒤집는다. */
 .effort-track-gate {
-  position: absolute;
-  right: 0;
-  top: 0;
-  bottom: 0;
+  flex: 0 0 auto;
+  width: 26px;
+  height: 26px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -7703,98 +7708,156 @@
 .effort-track-gate:hover .effort-track-gate-leaf:first-child { transform: rotate(45deg) translate(-1px, 1px); }
 .effort-track-gate:hover .effort-track-gate-leaf:last-child { transform: rotate(45deg) translate(1px, -1px); }
 
-/* 챔버 안의 스톱은 눈금이 아니라 문턱이다 — 비용 채널로 칠해, 축을 훑는 눈이 여기서 멈춘다. */
-.effort-track-stop[data-special] {
-  background: none;
-  box-shadow: 0 0 0 1.5px var(--warn);
+/* 열린 게이트는 되돌리는 손잡이다 — 꺾쇠를 뒤집어 가리키는 방향이 곧 하는 일이 된다. */
+.effort-track-gate[aria-expanded="true"] .effort-track-gate-leaf { transform: rotate(225deg); }
+.effort-track-gate[aria-expanded="true"]:hover .effort-track-gate-leaf:first-child { transform: rotate(225deg) translate(-1px, 1px); }
+.effort-track-gate[aria-expanded="true"]:hover .effort-track-gate-leaf:last-child { transform: rotate(225deg) translate(1px, -1px); }
+
+/**
+ * 장전된 게이트는 스펙트럼을 두른다. 게이트는 접힌 뒤에도 남는 유일한 표식이므로, 여기서까지
+ * 조용하면 비싼 모드가 실린 채 평범한 행처럼 보인다.
+ */
+.effort-track-gate[data-armed] {
+  border-style: solid;
+  border-color: transparent;
+  background: var(--effort-spectrum-ultracode) border-box;
+  background-size: 220% 100%;
+  color: var(--text-on-brass);
+  animation: effort-spectrum-drift 7s linear infinite;
 }
 
-/* 실린 챔버 단은 채움 위에 앉는다. 이 팔레트에서 비용 채널은 brass의 이웃이라(밝은 테마는 색상각까지
-   같다) 그 위에 warn을 칠하면 평범한 눈금과 갈리지 않는다. 그래서 대비 기준은 brass 위에서 읽히도록
-   정의된 토큰이 맡고, 비용 채널은 그 테 밖에서 말한다 — 색상 하나에 판정을 걸지 않는다. */
-.effort-track-stop[data-special][data-filled="true"] {
+/**
+ * 특수 강도가 실리면 레일 전체가 스펙트럼으로 흐른다.
+ *
+ * 도트린 예외(의도): 이 앱의 표면은 값이 정해지면 움직임을 멈춘다 — 계속 도는 표면은 "아직
+ * 정해지지 않았다"는 뜻이기 때문이다. 세션 한정 고비용 모드는 그 반대다. 정해졌다는 사실 자체가
+ * 계속 알려야 할 상태이므로, 이 한 곳에서만 상시 애니메이션을 허용한다. 색도 마찬가지로 단계
+ * 램프(brass)나 상태 채널(warn/coral)이 아니라, 이 모드에만 쓰는 별도 스펙트럼 토큰을 쓴다 —
+ * 램프를 더 태우면 "더 깊다"는 거짓이 되고, 상태 채널을 쓰면 경고와 구분되지 않는다.
+ */
+.effort-track-fill[data-flood] {
+  right: 1px;
+  background: var(--effort-spectrum, var(--effort-spectrum-ultracode));
+  background-size: 220% 100%;
+  animation: effort-spectrum-drift 7s linear infinite;
+}
+
+.effort-track[data-special="max"] ~ .effort-track-fill { --effort-spectrum: var(--effort-spectrum-max); }
+.effort-track[data-special="ultracode"] ~ .effort-track-fill { --effort-spectrum: var(--effort-spectrum-ultracode); }
+
+@keyframes effort-spectrum-drift {
+  from { background-position: 0% 50%; }
+  to { background-position: -220% 50%; }
+}
+
+/* 스펙트럼 위의 스톱과 손잡이. 무채색 대비 기준으로만 서야 한다 — 흐르는 색 위에서 유채색 표식은
+   매 프레임 다른 대비를 갖는다. */
+.effort-track-fill[data-flood] ~ .effort-track-stops .effort-track-stop[data-filled="true"] {
+  background: color-mix(in oklab, var(--text-on-brass) 72%, transparent);
+}
+
+.effort-track-knob[data-special] {
   background: var(--text-on-brass);
   box-shadow:
-    0 0 0 2px var(--text-on-brass),
-    0 0 0 3.5px var(--warn);
-}
-
-/* 비싼 단을 쥔 손잡이. 색을 갈지 않고 비용 채널의 테를 두른다 — 손잡이 본체가 물들면 어느 단을
-   쥐었는지가 아니라 "경고"가 먼저 읽힌다. 이 테도 채움 위에 앉으므로 홀로 서지 못한다:
-   brass 위에서 읽히는 테를 먼저 두르고 그 밖에 비용 채널을 둔다. */
-.effort-track-knob[data-special] {
-  box-shadow:
-    0 0 0 2px var(--text-on-brass),
-    0 0 0 4px var(--warn),
-    0 0 10px var(--warn-glow),
+    0 0 0 2px oklch(0% 0 0 / 45%),
     0 1px 3px oklch(0% 0 0 / 55%);
 }
 
-/* 챔버가 열릴 때 한 번 지나가는 빛. 열림에 매달려 있으므로 루프가 없다 — 계속 움직이는 표면은
-   값이 아직 정해지지 않았다고 말한다. */
-.effort-track-reveal-sheen {
-  position: absolute;
-  inset: 0;
-  border-radius: 999px;
-  /* 빛은 무채색이다 — 최고 단 스윕과 같은 어휘이고, 채움을 지날 때 비용 채널처럼 brass에 녹지 않는다. */
-  background: linear-gradient(
-    100deg,
-    transparent 38%,
-    color-mix(in oklab, var(--text-primary) 30%, transparent) 50%,
-    transparent 62%);
-  animation: effort-track-reveal var(--duration-slow) var(--ease-spring) 1;
-  pointer-events: none;
-}
+/* ── 챔버 면: 비싼 모드를 고르는 자리 ────────────────────────────────────────────────── */
 
-@keyframes effort-track-reveal {
-  from { opacity: 0; transform: translateX(-40%); }
-  60% { opacity: 1; }
-  to { opacity: 0; transform: translateX(40%); }
-}
-
-/* 흐름 밖으로 띄운다. 트랙 옆에 흐름대로 놓으면 챔버를 열 때마다 프레임이 그만큼 좁아져,
-   움직이지 않아야 할 평범한 단들이 제자리에서 밀린다 — 펼침이 축을 다시 눈금 그리는 일이 된다. */
-.effort-track-chamber-note {
-  position: absolute;
-  bottom: calc(100% + var(--space-1));
-  left: 0;
-  z-index: 2;
+/**
+ * 흐름 안에 편다. 레일 위로 띄우면 플라이아웃의 `overflow-y: auto`가 잘라 내 — 비용을 밝히려고
+ * 만든 면이 정작 화면에 없다. 흐름 안에 있으면 팝업이 그만큼 높아질 뿐 잘리지 않는다.
+ */
+.effort-track-chamber {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: var(--space-2);
-  max-width: 280px;
-  padding: 2px var(--space-2);
-  border: 1px solid color-mix(in oklch, var(--warn) 32%, var(--surface-rim));
-  border-radius: var(--radius-sm);
-  background: var(--surface-frame);
+  padding: var(--space-2);
+  border: 1px solid color-mix(in oklch, var(--warn) 30%, var(--surface-rim));
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--warn) 5%, var(--surface-frame));
+  animation: effort-chamber-open var(--duration-base) var(--ease-spring) 1;
+}
+
+@keyframes effort-chamber-open {
+  from { opacity: 0; transform: translateY(-6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.effort-track-chamber-warning {
+  margin: 0;
   color: var(--warn-ink);
   font-size: 10.5px;
-  line-height: 1.35;
+  line-height: 1.4;
 }
 
-.effort-track-collapse {
-  flex: 0 0 auto;
+.effort-track-chamber-tiles {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  height: 16px;
-  padding: 0;
-  border: none;
-  border-radius: 999px;
-  background: none;
-  color: var(--text-tertiary);
-  font-size: 12px;
-  line-height: 1;
-  cursor: pointer;
-  transition: color var(--duration-fast) var(--ease-spring);
+  flex-direction: column;
+  gap: var(--space-1);
 }
 
-.effort-track-collapse:hover { color: var(--text-secondary); }
+/* 타일은 레일의 눈금이 아니라 카드다 — 손잡이 하나가 이웃을 덮던 자리를, 오해할 수 없는 폭으로 바꾼다. */
+.effort-track-chamber-tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: var(--space-2);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  background: var(--surface-pillar);
+  text-align: left;
+  cursor: pointer;
+  overflow: hidden;
+  transition:
+    border-color var(--duration-fast) var(--ease-spring),
+    background var(--duration-fast) var(--ease-spring);
+}
 
-.effort-track-collapse:focus-visible {
+.effort-track-chamber-tile:hover:not(:disabled) { border-color: var(--brass); }
+
+.effort-track-chamber-tile:focus-visible {
   outline: 2px solid var(--brass);
   outline-offset: 2px;
+}
+
+.effort-track-chamber-tile:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+/* 장전된 타일. 스펙트럼은 테두리로만 흐른다 — 본문까지 물들이면 설명 문장이 매 프레임 다른
+   바탕 위에 놓여 읽히지 않는다. */
+.effort-track-chamber-tile[aria-pressed="true"] {
+  border-color: transparent;
+  background:
+    linear-gradient(var(--surface-pillar), var(--surface-pillar)) padding-box,
+    var(--effort-spectrum-ultracode) border-box;
+  background-size: auto, 220% 100%;
+  animation: effort-spectrum-drift 7s linear infinite;
+}
+
+.effort-track-chamber-tile[data-effort-level="max"][aria-pressed="true"] {
+  background:
+    linear-gradient(var(--surface-pillar), var(--surface-pillar)) padding-box,
+    var(--effort-spectrum-max) border-box;
+  background-size: auto, 220% 100%;
+}
+
+.effort-track-chamber-tile-name {
+  color: var(--effort-tone, var(--text-primary));
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.effort-track-chamber-tile-note {
+  color: var(--text-tertiary);
+  font-size: 10.5px;
+  line-height: 1.35;
 }
 
 
@@ -11447,7 +11510,8 @@ body[data-codex-reading="true"] .operations-side-bar {
   .effort-track-value,
   .effort-track-gate,
   .effort-track-gate-leaf,
-  .effort-track-collapse,
+  .effort-track-chamber,
+  .effort-track-chamber-tile,
   .operation-launch-variant-effort,
   .operation-launch-variant-effort-handle,
   .operation-launch-variant-effort-gauge rect,
@@ -11456,10 +11520,13 @@ body[data-codex-reading="true"] .operations-side-bar {
     transition: none;
   }
 
-  /* 펼침의 빛은 지나가는 움직임 그 자체다 — 멈춰 세우면 트랙 위에 흰 띠로 남으므로 지운다.
-     비싼 단이라는 사실은 색·테·경고문이 이미 말하고 있어 잃는 것이 없다. */
-  .effort-track-reveal-sheen {
-    display: none;
+  /* 스펙트럼은 멈춰도 스펙트럼이다 — 흐름만 걷어 내고 색은 남긴다. 비싼 모드가 실렸다는 사실을
+     움직임에만 실어 두면, 모션을 끈 사람에게는 그 상태가 아예 전달되지 않는다. */
+  .effort-track-fill[data-flood],
+  .effort-track-gate[data-armed],
+  .effort-track-chamber-tile[aria-pressed="true"] {
+    animation: none;
+    background-position: 50% 50%;
   }
 
   .effort-track:hover ~ .effort-track-knob,

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7709,16 +7709,23 @@
   box-shadow: 0 0 0 1.5px var(--warn);
 }
 
+/* 실린 챔버 단은 채움 위에 앉는다. 이 팔레트에서 비용 채널은 brass의 이웃이라(밝은 테마는 색상각까지
+   같다) 그 위에 warn을 칠하면 평범한 눈금과 갈리지 않는다. 그래서 대비 기준은 brass 위에서 읽히도록
+   정의된 토큰이 맡고, 비용 채널은 그 테 밖에서 말한다 — 색상 하나에 판정을 걸지 않는다. */
 .effort-track-stop[data-special][data-filled="true"] {
-  background: var(--warn);
-  box-shadow: 0 0 0 2px var(--warn-glow);
+  background: var(--text-on-brass);
+  box-shadow:
+    0 0 0 2px var(--text-on-brass),
+    0 0 0 3.5px var(--warn);
 }
 
 /* 비싼 단을 쥔 손잡이. 색을 갈지 않고 비용 채널의 테를 두른다 — 손잡이 본체가 물들면 어느 단을
-   쥐었는지가 아니라 "경고"가 먼저 읽힌다. */
+   쥐었는지가 아니라 "경고"가 먼저 읽힌다. 이 테도 채움 위에 앉으므로 홀로 서지 못한다:
+   brass 위에서 읽히는 테를 먼저 두르고 그 밖에 비용 채널을 둔다. */
 .effort-track-knob[data-special] {
   box-shadow:
-    0 0 0 2px var(--warn),
+    0 0 0 2px var(--text-on-brass),
+    0 0 0 4px var(--warn),
     0 0 10px var(--warn-glow),
     0 1px 3px oklch(0% 0 0 / 55%);
 }
@@ -7729,10 +7736,11 @@
   position: absolute;
   inset: 0;
   border-radius: 999px;
+  /* 빛은 무채색이다 — 최고 단 스윕과 같은 어휘이고, 채움을 지날 때 비용 채널처럼 brass에 녹지 않는다. */
   background: linear-gradient(
     100deg,
     transparent 38%,
-    color-mix(in oklch, var(--warn) 30%, transparent) 50%,
+    color-mix(in oklab, var(--text-primary) 30%, transparent) 50%,
     transparent 62%);
   animation: effort-track-reveal var(--duration-slow) var(--ease-spring) 1;
   pointer-events: none;

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -54,6 +54,17 @@
   --brass-halo: 0 0 18px var(--brass-glow);
   --positive-halo: 0 0 12px var(--positive-glow);
 
+  /* 특수 강도 스펙트럼 — 세션 한정 고비용 모드 전용 연출 채널.
+     단계 램프(brass)도 상태 채널(warn/coral)도 아닌 별도 채널인 이유는 둘 다 거짓을 말하기
+     때문이다: 램프를 더 태우면 "더 깊다"가 되고, 상태색을 쓰면 경고와 구분되지 않는다. 이
+     스펙트럼은 오직 "평범한 사다리 밖의 모드가 실렸다"만 말하며 다른 표면에서 쓰지 않는다.
+     양 끝 색상각을 맞물려 두어 흐를 때 이음매가 보이지 않는다. */
+  --effort-spectrum-max: linear-gradient(90deg,
+    oklch(80% 0.13 60), oklch(74% 0.16 25), oklch(72% 0.17 350), oklch(74% 0.16 25), oklch(80% 0.13 60));
+  --effort-spectrum-ultracode: linear-gradient(90deg,
+    oklch(80% 0.15 40), oklch(84% 0.14 95), oklch(80% 0.15 150), oklch(80% 0.13 210),
+    oklch(72% 0.16 285), oklch(74% 0.18 340), oklch(80% 0.15 40));
+
   /* Operations 캔버스(Map)는 bg0 근방의 저채도 심층 계조만 사용한다. */
   --canvas-abyss: oklch(11% 0.014 245);
   --canvas-sea-core: oklch(13% 0.018 245);
@@ -346,6 +357,14 @@
   --positive-ink: oklch(42% 0.11 160);
   --brass-halo: none;
   --positive-halo: none;
+
+  /* 라이트 테마의 스펙트럼은 어둡게 내린다 — 이 위에 앉는 표식이 near-white(--text-on-brass)라
+     다크와 같은 밝기로 두면 채움 위 눈금과 손잡이가 사라진다. */
+  --effort-spectrum-max: linear-gradient(90deg,
+    oklch(58% 0.13 60), oklch(52% 0.16 25), oklch(50% 0.17 350), oklch(52% 0.16 25), oklch(58% 0.13 60));
+  --effort-spectrum-ultracode: linear-gradient(90deg,
+    oklch(57% 0.15 40), oklch(58% 0.14 95), oklch(54% 0.15 150), oklch(53% 0.13 210),
+    oklch(48% 0.16 285), oklch(52% 0.18 340), oklch(57% 0.15 40));
 
   --canvas-abyss: oklch(97.8% 0.003 100);
   --canvas-sea-core: oklch(94% 0.006 98);

--- a/runtime/fleet-console/sdk/operations/launch-variants.ts
+++ b/runtime/fleet-console/sdk/operations/launch-variants.ts
@@ -28,6 +28,7 @@ function readLaunchVariantRow(value: unknown): OperationLaunchVariantRow | null 
   const effortAxis = Array.isArray(value.effortAxis)
     ? value.effortAxis.filter((rung): rung is string => typeof rung === "string" && rung.length > 0)
     : [];
+  const effortExpansion = readEffortExpansion(value.effortExpansion, effortAxis);
   return {
     id: value.id,
     label: value.label,
@@ -35,7 +36,28 @@ function readLaunchVariantRow(value: unknown): OperationLaunchVariantRow | null 
     launch,
     ...(chips.length > 0 ? { chips } : {}),
     ...(chips.length > 0 && effortAxis.length > 0 ? { effortAxis } : {}),
+    ...(chips.length > 0 && effortExpansion ? { effortExpansion } : {}),
   };
+}
+
+/**
+ * 펼침 경계는 축 위의 좌표라서 축 없이는 뜻이 없다. `after`가 축에 없거나 그 뒤에 남는 단이 없으면
+ * 경계를 세울 수 없으므로 통째로 버린다 — 반쯤 살려 두면 표면이 평범한 레일의 천장을 잘못 잡는다.
+ */
+function readEffortExpansion(
+  value: unknown,
+  effortAxis: readonly string[],
+): OperationLaunchVariantRow["effortExpansion"] | null {
+  if (!isRecord(value) || typeof value.after !== "string") return null;
+  const boundary = effortAxis.indexOf(value.after);
+  if (boundary < 0 || boundary === effortAxis.length - 1) return null;
+  const declared = Array.isArray(value.rungs)
+    ? value.rungs.filter((rung): rung is string => typeof rung === "string" && rung.length > 0)
+    : [];
+  const tail = effortAxis.slice(boundary + 1);
+  // 공표된 순서가 축의 꼬리와 어긋나면 축을 따른다. 축이 자리의 유일한 근거다.
+  const rungs = declared.length > 0 && declared.every((rung) => tail.includes(rung)) ? declared : tail;
+  return rungs.length > 0 ? { after: value.after, rungs } : null;
 }
 
 function readLaunchVariantChip(value: unknown): OperationLaunchVariantChip | null {

--- a/runtime/fleet-console/sdk/operations/types.ts
+++ b/runtime/fleet-console/sdk/operations/types.ts
@@ -61,6 +61,16 @@ export interface OperationLaunchVariantRow {
    * surface has nothing but `chips` to go on and should treat them as the axis.
    */
   readonly effortAxis?: readonly string[];
+  /**
+   * The tail of `effortAxis` that a surface must not offer on the ordinary track. Everything
+   * after `after` sits behind a deliberate reveal, because those rungs cost enough that reaching
+   * them by a stray drag would be a misfire rather than a choice. Absent means the whole axis is
+   * ordinary. `rungs` is the revealed order, so a surface never has to re-derive it from `after`.
+   */
+  readonly effortExpansion?: {
+    readonly after: string;
+    readonly rungs: readonly string[];
+  };
 }
 
 export interface OperationLaunchVariantGroup {

--- a/runtime/fleet-console/tests/effort-track.test.tsx
+++ b/runtime/fleet-console/tests/effort-track.test.tsx
@@ -379,6 +379,10 @@ describe("EffortTrack high-cost chamber", () => {
     return document.querySelector<HTMLElement>(".effort-track-gate");
   }
 
+  function tiles(): HTMLElement[] {
+    return [...document.querySelectorAll<HTMLElement>(".effort-track-chamber-tile")];
+  }
+
   it("caps the ordinary rail at the expansion boundary and reserves the rest for the gate", () => {
     render(chamberRow(), "high");
 
@@ -403,36 +407,58 @@ describe("EffortTrack high-cost chamber", () => {
     expect(onChange.mock.calls.map((call) => call[0])).toEqual(["xhigh"]);
   });
 
-  it("opens the chamber only on the gate, and keeps the ordinary rungs on the same coordinates", () => {
+  it("opens the chamber onto its own surface without touching the rail", () => {
     render(chamberRow(), "high");
-    const highLeft = stops()[3]!.style.left;
+    const before = stops().map((stop) => stop.style.left);
 
     act(() => gate()!.dispatchEvent(new MouseEvent("click", { bubbles: true })));
 
-    expect(stops()).toHaveLength(7);
-    expect(track().getAttribute("aria-valuemax")).toBe("6");
-    expect(gate()).toBeNull();
-    // 펼쳐도 xhigh는 제자리다 — 축이 눈금을 다시 그리면 방금 고른 값이 옮겨 간 것처럼 읽힌다.
-    expect(stops()[3]!.style.left).toBe(highLeft);
-    // 비용은 챔버가 열려 있는 동안 계속 화면에 남고, 닫는 손잡이도 그 알림과 함께 흐름 밖에 뜬다.
-    const note = document.querySelector(".effort-track-chamber-note");
-    expect(note?.querySelector("[role='status']")?.textContent).toBe("High cost");
-    expect(note?.querySelector(".effort-track-collapse")).not.toBeNull();
-    // 게이트가 사라지므로 초점은 레일로 옮겨 간다 — body로 떨어지면 키보드 경로가 끊긴다.
-    expect(document.activeElement).toBe(track());
+    /**
+     * 레일은 자라지 않는다. 같은 폭에 단만 늘리면 간격이 좁아져 손잡이가 이웃 단을 덮고,
+     * 게이트를 세운 이유(스쳐서 닿을 수 없어야 한다)가 그대로 무너진다.
+     */
+    expect(stops().map((stop) => stop.style.left)).toEqual(before);
+    expect(track().getAttribute("aria-valuemax")).toBe("4");
+
+    // 비싼 단은 흐름 안의 별도 면에 카드로 선다 — 띄우면 플라이아웃의 overflow가 잘라 낸다.
+    const chamber = document.querySelector(".effort-track-chamber");
+    expect(chamber).not.toBeNull();
+    expect(chamber!.querySelector(".effort-track-chamber-warning")?.textContent).toBe("High cost");
+    expect([...chamber!.querySelectorAll(".effort-track-chamber-tile-name")].map((node) => node.textContent))
+      .toEqual(["MAX", "ULTRACODE"]);
+
+    // 여닫이는 하나다 — 게이트가 사라졌다 나타나면 그 폭만큼 레일이 흔들린다.
+    expect(gate()).not.toBeNull();
+    expect(gate()!.getAttribute("aria-expanded")).toBe("true");
   });
 
-  it("lets the pointer reach a chamber rung once the chamber is open", () => {
+  it("arms a chamber rung from its tile, and disarms it on a second press", () => {
     const onChange = render(chamberRow(), "high");
     act(() => gate()!.dispatchEvent(new MouseEvent("click", { bubbles: true })));
-    const element = stubTrackPointer();
 
-    act(() => {
-      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 113, clientY: 13 }));
-      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 113, clientY: 13 }));
-    });
-
+    act(() => tiles()[1]!.dispatchEvent(new MouseEvent("click", { bubbles: true })));
     expect(onChange.mock.calls.map((call) => call[0])).toEqual(["ultracode"]);
+
+    // 실린 타일을 다시 누르면 장전이 풀리고, 챔버에 들어오기 전 딛고 있던 평범한 단으로 돌아간다.
+    const armed = render(chamberRow(), "ultracode");
+    act(() => tiles()[1]!.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(armed.mock.calls.map((call) => call[0])).toEqual(["high"]);
+  });
+
+  /**
+   * 경계는 `rungs`가 아니라 `after`가 정한다. `rungs`로 잡으면 이 모델이 내주지 않는 MAX가
+   * 평범한 빈 단으로 레일에 실려, 게이트가 서기도 전에 레일이 천장을 넘어간다.
+   */
+  it("draws the chamber boundary from `after`, not from what the model happens to offer", () => {
+    render(chamberRow({ effortExpansion: { after: "xhigh", rungs: ["ultracode"] } }), "high");
+    expect(track().getAttribute("aria-valuemax")).toBe("4");
+
+    act(() => gate()!.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+    // MAX는 축에 남아 자리를 지키되 고를 수 없다 — 조용히 지우면 사다리가 거짓말을 한다.
+    expect(tiles().map((tile) => tile.textContent?.startsWith("MAX") ?? false)).toEqual([true, false]);
+    expect(tiles()[0]!.hasAttribute("disabled")).toBe(true);
+    expect(tiles()[1]!.hasAttribute("disabled")).toBe(false);
   });
 
   it("arms a chamber rung without launching it, however the press arrives", () => {
@@ -461,24 +487,27 @@ describe("EffortTrack high-cost chamber", () => {
     expect(onConfirmCurrent).toHaveBeenCalledTimes(1);
   });
 
-  it("hands the arrow key at the ceiling to the gate instead of opening the chamber", () => {
+  it("never lets an arrow key walk into the chamber", () => {
     const onChange = render(chamberRow(), "xhigh");
 
     act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })));
+    act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true })));
 
     // 방향키가 비싼 모드를 여는 손잡이가 되면 그 문은 문이 아니다.
     expect(onChange).not.toHaveBeenCalled();
-    expect(stops()).toHaveLength(5);
-    expect(document.activeElement).toBe(gate());
+    expect(document.querySelector(".effort-track-chamber")).toBeNull();
   });
 
-  it("never leaves a chamber rung armed behind a closed rail", () => {
-    // 이미 특수 단이 실려 들어오면 챔버는 열린 채로 그려진다 — 접힌 레일이 비싼 모드를 숨기면
+  it("never leaves a chamber rung armed behind a closed chamber", () => {
+    // 이미 특수 단이 실려 들어오면 챔버는 열린 채로 그려진다 — 접힌 면이 비싼 모드를 숨기면
     // 아무도 고르지 않은 값으로 다음 실행이 나간다.
     const onChange = render(chamberRow(), "max");
-    expect(stops()).toHaveLength(7);
-    expect(gate()).toBeNull();
+    expect(document.querySelector(".effort-track-chamber")).not.toBeNull();
     expect(track().dataset.special).toBe("max");
+    // 레일은 천장을 가리키고 채움은 축 밖을 뜻하는 스펙트럼으로 넘어간다.
+    expect(track().getAttribute("aria-valuenow")).toBe("4");
+    expect(document.querySelector<HTMLElement>(".effort-track-fill")!.dataset.flood).toBe("true");
+    expect(gate()!.dataset.armed).toBe("true");
 
     // 접는 것은 그 모드를 내려놓는 일이다. 값이 남은 채 사라질 수는 없다.
     act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })));

--- a/runtime/fleet-console/tests/effort-track.test.tsx
+++ b/runtime/fleet-console/tests/effort-track.test.tsx
@@ -40,6 +40,25 @@ function row(overrides: Partial<OperationLaunchVariantRow> = {}): OperationLaunc
   };
 }
 
+const CHAMBER_AXIS = ["low", "medium", "high", "xhigh", "max", "ultracode"] as const;
+
+/** 평범한 레일이 xhigh에서 끊기고 max·ultracode가 챔버 뒤에 사는 행. */
+function chamberRow(overrides: Partial<OperationLaunchVariantRow> = {}): OperationLaunchVariantRow {
+  return {
+    id: "claude--fable",
+    label: "FABLE-1M",
+    launch: { model: "fable[1m]" },
+    effortAxis: [...CHAMBER_AXIS],
+    effortExpansion: { after: "xhigh", rungs: ["max", "ultracode"] },
+    chips: CHAMBER_AXIS.map((id) => ({
+      id,
+      label: id.toUpperCase(),
+      launch: { model: "fable[1m]", effort: id },
+    })),
+    ...overrides,
+  };
+}
+
 function render(
   node: OperationLaunchVariantRow,
   value: string | null,
@@ -55,6 +74,9 @@ function render(
       autoLabel="AUTO"
       ariaLabel="Reasoning effort"
       autoValueText="Automatic"
+      revealLabel="Reveal high-cost efforts"
+      collapseLabel="Put the high-cost efforts away"
+      specialWarning="High cost"
     />,
   ));
   return onChange;
@@ -63,10 +85,14 @@ function render(
 function stubTrackPointer(width = 126) {
   const element = track();
   let captured: number | null = null;
+  const rect = (box: number) => () => ({ left: 0, right: box, top: 0, bottom: 26, width: box, height: 26, x: 0, y: 0, toJSON: () => ({}) });
+  // 좌표계는 프레임이 소유한다 — 접힌 레일은 축의 일부만 덮으므로 그 폭으로 자리를 잴 수 없다.
+  const frame = document.querySelector<HTMLElement>(".effort-track-frame");
+  if (frame) Object.defineProperty(frame, "getBoundingClientRect", { configurable: true, value: rect(width) });
   Object.defineProperties(element, {
     getBoundingClientRect: {
       configurable: true,
-      value: () => ({ left: 0, right: width, top: 0, bottom: 26, width, height: 26, x: 0, y: 0, toJSON: () => ({}) }),
+      value: rect(width),
     },
     setPointerCapture: {
       configurable: true,
@@ -115,7 +141,8 @@ describe("EffortTrack", () => {
     const marks = stops();
     expect(marks).toHaveLength(6);
     expect(marks.map((mark) => mark.dataset.gap ?? null)).toEqual([null, null, "true", null, "true", null]);
-    expect(marks[3]!.style.left).toBe("60%");
+    // 자리는 손잡이 여백을 뺀 폭 위에서 잰다 — 양 끝 스톱에서 손잡이가 트랙을 넘지 않아야 한다.
+    expect(marks[3]!.style.left).toBe("calc(13px + 0.6 * (100% - 26px))");
   });
 
   it("falls back to the offered rungs when the row carries no axis", () => {
@@ -203,13 +230,8 @@ describe("EffortTrack", () => {
 
   it("previews the selectable rung that a pointer action would choose", () => {
     const onChange = render(row(), "low");
-    Object.defineProperties(track(), {
-      getBoundingClientRect: {
-        configurable: true,
-        value: () => ({ left: 0, right: 126, top: 0, bottom: 26, width: 126, height: 26, x: 0, y: 0, toJSON: () => ({}) }),
-      },
-      hasPointerCapture: { configurable: true, value: () => false },
-    });
+    // 아직 잡은 포인터가 없으므로 hasPointerCapture는 false다 — 이동만으로는 값이 바뀌지 않는다.
+    stubTrackPointer();
 
     // medium(2) 자리를 가리켜도 이 모델이 실제로 고를 수 있는 가까운 low(1)를 비춘다.
     act(() => track().dispatchEvent(new PointerEvent("pointermove", { bubbles: true, clientX: 53 })));
@@ -332,14 +354,166 @@ describe("EffortTrack", () => {
 describe("effortLadderPosition", () => {
   it("counts the rung on the canonical axis, not on the rungs this model happens to offer", () => {
     // high는 이 모델이 내놓는 세 단 중 둘째지만, 축 위에서는 다섯 중 셋째다.
-    expect(effortLadderPosition(row(), "high")).toEqual({ rung: 3, total: 5 });
-    expect(effortLadderPosition(row(), "max")).toEqual({ rung: 5, total: 5 });
+    expect(effortLadderPosition(row(), "high")).toEqual({ rung: 3, total: 5, special: null });
+    expect(effortLadderPosition(row(), "max")).toEqual({ rung: 5, total: 5, special: null });
     // 자동은 0단이다 — 사다리를 쓰지 않는 상태이지 최소 단이 아니다.
-    expect(effortLadderPosition(row(), null)).toEqual({ rung: 0, total: 5 });
+    expect(effortLadderPosition(row(), null)).toEqual({ rung: 0, total: 5, special: null });
   });
 
   it("falls back to the offered rungs when the row carries no axis", () => {
-    expect(effortLadderPosition(row({ effortAxis: undefined }), "high")).toEqual({ rung: 2, total: 3 });
+    expect(effortLadderPosition(row({ effortAxis: undefined }), "high")).toEqual({ rung: 2, total: 3, special: null });
+  });
+
+  // 챔버 안의 단은 눈금 하나가 아니다. 막대를 더 얹으면 "칸이 많으니 더 깊다"를 그리는데,
+  // ultracode는 xhigh 깊이에 오케스트레이션을 얹은 모드다.
+  it("counts the gauge only up to the ordinary rail and reports the special mode apart from it", () => {
+    expect(effortLadderPosition(chamberRow(), "xhigh")).toEqual({ rung: 4, total: 4, special: null });
+    expect(effortLadderPosition(chamberRow(), "max")).toEqual({ rung: 4, total: 4, special: "max" });
+    expect(effortLadderPosition(chamberRow(), "ultracode")).toEqual({ rung: 4, total: 4, special: "ultracode" });
+  });
+});
+
+// 챔버는 값을 숨기는 장치가 아니라 스쳐서 닿지 않게 하는 장치다. 아래 성질들이 그 구분을 진다.
+describe("EffortTrack high-cost chamber", () => {
+  function gate(): HTMLElement | null {
+    return document.querySelector<HTMLElement>(".effort-track-gate");
+  }
+
+  it("caps the ordinary rail at the expansion boundary and reserves the rest for the gate", () => {
+    render(chamberRow(), "high");
+
+    // AUTO + low..xhigh만 선다. max·ultracode는 자리를 잡아 두고도 아직 눈에 없다.
+    expect(stops()).toHaveLength(5);
+    expect(track().getAttribute("aria-valuemax")).toBe("4");
+    expect(gate()).not.toBeNull();
+    expect(document.querySelector(".effort-track-chamber-note")).toBeNull();
+  });
+
+  it("cannot reach a chamber rung by dragging past the end of the collapsed rail", () => {
+    const onChange = render(chamberRow(), "low");
+    const element = stubTrackPointer();
+
+    act(() => {
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 30, clientY: 13 }));
+      // 트랙 끝을 지나 한참 밖까지 끌어도 평범한 천장에서 멈춘다.
+      element.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 400, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 400, clientY: 13 }));
+    });
+
+    expect(onChange.mock.calls.map((call) => call[0])).toEqual(["xhigh"]);
+  });
+
+  it("opens the chamber only on the gate, and keeps the ordinary rungs on the same coordinates", () => {
+    render(chamberRow(), "high");
+    const highLeft = stops()[3]!.style.left;
+
+    act(() => gate()!.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+    expect(stops()).toHaveLength(7);
+    expect(track().getAttribute("aria-valuemax")).toBe("6");
+    expect(gate()).toBeNull();
+    // 펼쳐도 xhigh는 제자리다 — 축이 눈금을 다시 그리면 방금 고른 값이 옮겨 간 것처럼 읽힌다.
+    expect(stops()[3]!.style.left).toBe(highLeft);
+    // 비용은 챔버가 열려 있는 동안 계속 화면에 남고, 닫는 손잡이도 그 알림과 함께 흐름 밖에 뜬다.
+    const note = document.querySelector(".effort-track-chamber-note");
+    expect(note?.querySelector("[role='status']")?.textContent).toBe("High cost");
+    expect(note?.querySelector(".effort-track-collapse")).not.toBeNull();
+    // 게이트가 사라지므로 초점은 레일로 옮겨 간다 — body로 떨어지면 키보드 경로가 끊긴다.
+    expect(document.activeElement).toBe(track());
+  });
+
+  it("lets the pointer reach a chamber rung once the chamber is open", () => {
+    const onChange = render(chamberRow(), "high");
+    act(() => gate()!.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    const element = stubTrackPointer();
+
+    act(() => {
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 113, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 113, clientY: 13 }));
+    });
+
+    expect(onChange.mock.calls.map((call) => call[0])).toEqual(["ultracode"]);
+  });
+
+  it("arms a chamber rung without launching it, however the press arrives", () => {
+    const onChange = vi.fn();
+    const onConfirmCurrent = vi.fn();
+    render(chamberRow(), "ultracode", onChange, onConfirmCurrent);
+    const element = stubTrackPointer();
+
+    // 이미 실린 단을 다시 눌러도 실행되지 않는다 — 평범한 단이라면 여기서 확정된다.
+    act(() => {
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 113, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 113, clientY: 13 }));
+    });
+    act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true })));
+
+    expect(onConfirmCurrent).not.toHaveBeenCalled();
+  });
+
+  it("still confirms an ordinary rung while the chamber is open", () => {
+    const onConfirmCurrent = vi.fn();
+    render(chamberRow(), "xhigh", vi.fn(), onConfirmCurrent);
+    act(() => gate()!.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+    act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true })));
+
+    expect(onConfirmCurrent).toHaveBeenCalledTimes(1);
+  });
+
+  it("hands the arrow key at the ceiling to the gate instead of opening the chamber", () => {
+    const onChange = render(chamberRow(), "xhigh");
+
+    act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })));
+
+    // 방향키가 비싼 모드를 여는 손잡이가 되면 그 문은 문이 아니다.
+    expect(onChange).not.toHaveBeenCalled();
+    expect(stops()).toHaveLength(5);
+    expect(document.activeElement).toBe(gate());
+  });
+
+  it("never leaves a chamber rung armed behind a closed rail", () => {
+    // 이미 특수 단이 실려 들어오면 챔버는 열린 채로 그려진다 — 접힌 레일이 비싼 모드를 숨기면
+    // 아무도 고르지 않은 값으로 다음 실행이 나간다.
+    const onChange = render(chamberRow(), "max");
+    expect(stops()).toHaveLength(7);
+    expect(gate()).toBeNull();
+    expect(track().dataset.special).toBe("max");
+
+    // 접는 것은 그 모드를 내려놓는 일이다. 값이 남은 채 사라질 수는 없다.
+    act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })));
+    expect(onChange.mock.calls.map((call) => call[0])).toEqual([null]);
+  });
+
+  it("keeps the top of the collapsed rail reading as the ceiling", () => {
+    render(chamberRow(), "xhigh");
+    expect(track().dataset.atMax).toBe("true");
+
+    render(chamberRow(), "high");
+    expect(track().dataset.atMax).toBeUndefined();
+  });
+
+  it("reads the chamber rung by what the mode is, not by its short label", () => {
+    act(() => root.render(
+      <EffortTrack
+        row={chamberRow()}
+        value="ultracode"
+        onChange={vi.fn()}
+        autoLabel="AUTO"
+        ariaLabel="Reasoning effort"
+        autoValueText="Automatic"
+        specialDescriptions={{ ultracode: "XHIGH plus orchestration" }}
+      />,
+    ));
+
+    expect(track().getAttribute("aria-valuetext")).toBe("XHIGH plus orchestration");
+  });
+
+  it("leaves rows without a chamber exactly as they were", () => {
+    render(row(), "max");
+    expect(gate()).toBeNull();
+    expect(track().getAttribute("aria-valuemax")).toBe("5");
+    expect(track().dataset.atMax).toBe("true");
   });
 });
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1652,7 +1652,8 @@ describe("Effort track interaction grammar", () => {
     const quickLaunch = source("components/quick-launch.tsx");
     const canvasMenu = source("canvas/canvas-context-menu.tsx");
     const preview = components.match(/\.effort-track-stop\[data-previewed="true"\] \{[^}]*\}/)?.[0] ?? "";
-    const knobHover = components.match(/\.effort-track:hover \.effort-track-knob \{[^}]*\}/)?.[0] ?? "";
+    // 손잡이는 레일의 형제다 — 프레임이 좌표계를 지고, 레일은 그 위에서 챔버로 자란다.
+    const knobHover = components.match(/\.effort-track:hover ~ \.effort-track-knob \{[^}]*\}/)?.[0] ?? "";
 
     // 한 공유 계기가 Quick Launch와 캔버스 실행 메뉴 양쪽의 hover 문법을 소유한다.
     expect(quickLaunch).toContain("<EffortTrack");
@@ -1661,8 +1662,36 @@ describe("Effort track interaction grammar", () => {
     expect(preview).toContain("transform: scale(3)");
     expect(knobHover).toContain("transform: scale(1.1)");
     // 모션을 줄인 환경에서도 어떤 단을 가리키는지는 정적인 brass ring으로 남는다.
-    expect(components).toMatch(/@media \(prefers-reduced-motion: reduce\)[\s\S]*\.effort-track:hover \.effort-track-knob,[\s\S]*\.effort-track-stop\[data-previewed="true"\] \{\s*transform: none;/);
+    expect(components).toMatch(/@media \(prefers-reduced-motion: reduce\)[\s\S]*\.effort-track:hover ~ \.effort-track-knob,[\s\S]*\.effort-track-stop\[data-previewed="true"\] \{\s*transform: none;/);
     expect(components).toMatch(/@media \(prefers-reduced-motion: reduce\)[\s\S]*\.effort-track-stop\[data-previewed="true"\] \{\s*box-shadow: 0 0 0 2px var\(--brass\);/);
+  });
+
+  it("grows the rail into the reserved chamber without re-ruling the axis", () => {
+    const components = source("styles/components.css");
+    const frame = components.match(/\.effort-track-frame \{[^}]*\}/)?.[0] ?? "";
+    const rail = components.match(/\n\.effort-track \{[^}]*\}/)?.[0] ?? "";
+    const note = components.match(/\.effort-track-chamber-note \{[^}]*\}/)?.[0] ?? "";
+    const gate = components.match(/\.effort-track-gate \{[^}]*\}/)?.[0] ?? "";
+
+    // 좌표계는 프레임이 진다. 레일은 그 위에서 폭만 자라므로 스톱과 손잡이가 흔들리지 않는다.
+    expect(frame).toContain("position: relative");
+    expect(rail).toContain("position: absolute");
+    expect(rail).toMatch(/transition:[^;]*width/);
+
+    // 게이트는 챔버가 차지할 자리를 지킨다 — 접혀 있을 때 그 폭이 비어 있어야 펼쳐도 축이 그대로다.
+    expect(gate).toContain("position: absolute");
+
+    /**
+     * 비용 알림과 닫는 손잡이는 흐름 밖에 뜬다. 트랙 옆에 흐름대로 놓으면 챔버를 열 때마다
+     * 프레임이 그만큼 좁아져, 평범한 단들이 제자리에서 밀린다 — 펼침이 축을 다시 눈금 그리는
+     * 일이 되어 방금 고른 값이 옮겨 간 것처럼 읽힌다.
+     */
+    expect(note).toContain("position: absolute");
+
+    // 펼침의 빛은 한 번만 지나간다. 상시 루프는 값이 아직 정해지지 않았다고 말한다.
+    const sheen = components.match(/\.effort-track-reveal-sheen \{[^}]*\}/)?.[0] ?? "";
+    expect(sheen).toMatch(/animation:[^;]*\b1\b/);
+    expect(sheen).not.toContain("infinite");
   });
 });
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1314,7 +1314,8 @@ describe("Instrument core design contract", () => {
       const declarations = block.match(/^\s{2}[^\n:]+:/gm) ?? [];
       expect(declarations.length).toBeGreaterThan(0);
       for (const declaration of declarations) {
-        expect(declaration.trim()).toMatch(/^(?:--(?:ink|brass|aurora|coral|warn|positive|canvas|surface|hairline|text|id|provider|shadow|scrollbar)[a-z-]*|--weight-regular|color-scheme):$/);
+        // --effort-spectrum-*: 라이트만 따로 내려 앉히는 특수 강도 전용 채널 — 다크 3종은 base를 그대로 쓴다.
+        expect(declaration.trim()).toMatch(/^(?:--(?:ink|brass|aurora|coral|warn|positive|canvas|surface|hairline|text|id|provider|shadow|scrollbar|effort-spectrum)[a-z-]*|--weight-regular|color-scheme):$/);
       }
     }
     // 신호 ink 티어는 base에서 별칭으로 존재해 다크 3종이 var 간접으로 base 신호색을 상속한다.
@@ -1666,53 +1667,80 @@ describe("Effort track interaction grammar", () => {
     expect(components).toMatch(/@media \(prefers-reduced-motion: reduce\)[\s\S]*\.effort-track-stop\[data-previewed="true"\] \{\s*box-shadow: 0 0 0 2px var\(--brass\);/);
   });
 
-  it("grows the rail into the reserved chamber without re-ruling the axis", () => {
+  /**
+   * 챔버는 레일에 눈금을 더 얹는 방식이 될 수 없다. 같은 폭에 단만 늘면 간격이 좁아져 손잡이가
+   * 이웃 단을 덮고, 게이트를 세운 이유(스쳐서 닿을 수 없어야 한다)가 그대로 무너진다. 레일은
+   * 고정 폭으로 평범한 천장에서 끝나고, 비싼 단은 흐름 안의 별도 면이 맡는다.
+   */
+  it("keeps the rail fixed and gives the chamber its own surface in flow", () => {
     const components = source("styles/components.css");
-    const frame = components.match(/\.effort-track-frame \{[^}]*\}/)?.[0] ?? "";
     const rail = components.match(/\n\.effort-track \{[^}]*\}/)?.[0] ?? "";
-    const note = components.match(/\.effort-track-chamber-note \{[^}]*\}/)?.[0] ?? "";
+    const row = components.match(/\.effort-track-row \{[^}]*\}/)?.[0] ?? "";
+    const frame = components.match(/\.effort-track-frame \{[^}]*\}/)?.[0] ?? "";
     const gate = components.match(/\.effort-track-gate \{[^}]*\}/)?.[0] ?? "";
+    const chamber = components.match(/\.effort-track-chamber \{[^}]*\}/)?.[0] ?? "";
 
-    // 좌표계는 프레임이 진다. 레일은 그 위에서 폭만 자라므로 스톱과 손잡이가 흔들리지 않는다.
+    // 좌표계는 프레임이 지고, 레일은 그 위에 고정 폭으로 눕는다 — 폭이 움직이면 눈금이 다시 그려진다.
     expect(frame).toContain("position: relative");
     expect(rail).toContain("position: absolute");
-    expect(rail).toMatch(/transition:[^;]*width/);
+    expect(rail).toContain("width: 100%");
+    expect(rail).not.toMatch(/transition:[^;]*width/);
 
-    // 게이트는 챔버가 차지할 자리를 지킨다 — 접혀 있을 때 그 폭이 비어 있어야 펼쳐도 축이 그대로다.
-    expect(gate).toContain("position: absolute");
+    // 게이트는 여닫이 하나로 행에 상주한다. 열림/닫힘에 서로 다른 버튼을 세우면 그 붙고 떨어짐이
+    // 레일 폭을 흔들어, 움직이지 않아야 할 단들이 제자리에서 밀린다.
+    expect(row).toContain("display: flex");
+    expect(gate).toContain("flex: 0 0 auto");
+    expect(gate).not.toContain("position: absolute");
+    expect(components).toContain('.effort-track-gate[aria-expanded="true"] .effort-track-gate-leaf');
+    expect(components).not.toContain(".effort-track-collapse");
 
     /**
-     * 비용 알림과 닫는 손잡이는 흐름 밖에 뜬다. 트랙 옆에 흐름대로 놓으면 챔버를 열 때마다
-     * 프레임이 그만큼 좁아져, 평범한 단들이 제자리에서 밀린다 — 펼침이 축을 다시 눈금 그리는
-     * 일이 되어 방금 고른 값이 옮겨 간 것처럼 읽힌다.
+     * 챔버는 흐름 안에 선다. 레일 위로 띄우면 플라이아웃의 `overflow-y: auto`가 잘라 내 —
+     * 비용을 밝히려고 만든 면이 정작 화면에 없다.
      */
-    expect(note).toContain("position: absolute");
-
-    // 펼침의 빛은 한 번만 지나간다. 상시 루프는 값이 아직 정해지지 않았다고 말한다.
-    const sheen = components.match(/\.effort-track-reveal-sheen \{[^}]*\}/)?.[0] ?? "";
-    expect(sheen).toMatch(/animation:[^;]*\b1\b/);
-    expect(sheen).not.toContain("infinite");
-    // 채움을 지나는 빛은 무채색이다. 비용 채널로 칠하면 brass에 녹아 아무것도 지나가지 않은 것으로 보인다.
-    expect(sheen).toContain("var(--text-primary)");
-    expect(sheen).not.toContain("var(--warn)");
+    expect(chamber).not.toContain("position: absolute");
+    expect(components).not.toContain(".effort-track-chamber-note");
+    const menu = components.match(/\.canvas-context-menu \{[^}]*\}/)?.[0] ?? "";
+    expect(menu).toContain("overflow-y: auto");
   });
 
   /**
-   * 비용 채널은 이 팔레트에서 brass의 이웃이다 — `whites`는 색상각(82°)까지 같고 명도만 1% 다르다.
-   * 그래서 채움 위에 앉는 챔버 표식은 warn 하나로 설 수 없다: brass 위에서 읽히도록 정의된 토큰이
-   * 대비를 지고, 비용 채널은 그 테 밖에서 말해야 실린 단이 평범한 눈금과 갈린다.
+   * 특수 강도는 단계 램프(brass)로도 상태 채널(warn)로도 말할 수 없다. 램프를 더 태우면 "더 깊다"는
+   * 거짓이 되고 — ultracode는 xhigh 깊이에 오케스트레이션을 얹은 모드다 — 상태색을 쓰면 경고와
+   * 갈리지 않는다. 그래서 이 모드만 쓰는 별도 스펙트럼 채널을 두고, 그 위에 앉는 표식은 흐르는
+   * 색에 기대지 않도록 무채색 대비 기준으로만 선다.
    */
-  it("rides the cost mark on a brass-readable ring instead of hue alone", () => {
+  it("speaks the special efforts on their own spectrum channel", () => {
     const components = source("styles/components.css");
-    const armedStop = components.match(/\.effort-track-stop\[data-special\]\[data-filled="true"\] \{[^}]*\}/)?.[0] ?? "";
-    const armedKnob = components.match(/\.effort-track-knob\[data-special\] \{[^}]*\}/)?.[0] ?? "";
+    const theme = source("styles/theme.css");
 
-    for (const rule of [armedStop, armedKnob]) {
-      expect(rule).toContain("var(--text-on-brass)");
-      expect(rule).toContain("var(--warn)");
-      // 대비 기준이 비용 채널보다 안쪽에 있어야 warn 테가 채움이 아니라 그 테를 등지고 선다.
-      expect(rule.indexOf("var(--text-on-brass)")).toBeLessThan(rule.indexOf("var(--warn)"));
+    // 유채색 리터럴은 theme.css의 토큰 정의에만 산다.
+    for (const token of ["--effort-spectrum-max", "--effort-spectrum-ultracode"]) {
+      expect(theme).toContain(`${token}: linear-gradient`);
+      expect(components).not.toMatch(new RegExp(`${token}:\\s*linear-gradient`));
     }
+    // 라이트 테마는 따로 내려 앉힌다 — 이 위에 앉는 표식이 near-white라 같은 밝기로 두면 사라진다.
+    expect(theme.split('[data-theme="whites"]')[1] ?? "").toContain("--effort-spectrum-ultracode:");
+
+    const flood = components.match(/\.effort-track-fill\[data-flood\] \{[^}]*\}/)?.[0] ?? "";
+    expect(flood).toContain("var(--effort-spectrum");
+    expect(flood).not.toContain("var(--brass)");
+    expect(flood).not.toContain("var(--warn)");
+
+    // 흐르는 색 위의 표식은 무채색 대비 기준으로만 선다 — 유채색 표식은 매 프레임 대비가 달라진다.
+    const armedKnob = components.match(/\.effort-track-knob\[data-special\] \{[^}]*\}/)?.[0] ?? "";
+    expect(armedKnob).toContain("var(--text-on-brass)");
+    expect(armedKnob).not.toContain("var(--warn)");
+
+    /**
+     * 도트린 예외(의도): 이 앱의 표면은 값이 정해지면 멈춘다. 세션 한정 고비용 모드는 정해졌다는
+     * 사실 자체가 계속 알려야 할 상태라, 이 채널에만 상시 애니메이션을 허용한다. 다만 모션을 끈
+     * 환경에서는 흐름만 걷고 색은 남긴다 — 상태를 움직임에만 실으면 그 사람에게는 전달되지 않는다.
+     */
+    expect(flood).toContain("infinite");
+    expect(components).toMatch(
+      /@media \(prefers-reduced-motion: reduce\)[\s\S]*\.effort-track-fill\[data-flood\],[\s\S]*\{\s*animation: none;\s*background-position:/,
+    );
   });
 });
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1692,6 +1692,27 @@ describe("Effort track interaction grammar", () => {
     const sheen = components.match(/\.effort-track-reveal-sheen \{[^}]*\}/)?.[0] ?? "";
     expect(sheen).toMatch(/animation:[^;]*\b1\b/);
     expect(sheen).not.toContain("infinite");
+    // 채움을 지나는 빛은 무채색이다. 비용 채널로 칠하면 brass에 녹아 아무것도 지나가지 않은 것으로 보인다.
+    expect(sheen).toContain("var(--text-primary)");
+    expect(sheen).not.toContain("var(--warn)");
+  });
+
+  /**
+   * 비용 채널은 이 팔레트에서 brass의 이웃이다 — `whites`는 색상각(82°)까지 같고 명도만 1% 다르다.
+   * 그래서 채움 위에 앉는 챔버 표식은 warn 하나로 설 수 없다: brass 위에서 읽히도록 정의된 토큰이
+   * 대비를 지고, 비용 채널은 그 테 밖에서 말해야 실린 단이 평범한 눈금과 갈린다.
+   */
+  it("rides the cost mark on a brass-readable ring instead of hue alone", () => {
+    const components = source("styles/components.css");
+    const armedStop = components.match(/\.effort-track-stop\[data-special\]\[data-filled="true"\] \{[^}]*\}/)?.[0] ?? "";
+    const armedKnob = components.match(/\.effort-track-knob\[data-special\] \{[^}]*\}/)?.[0] ?? "";
+
+    for (const rule of [armedStop, armedKnob]) {
+      expect(rule).toContain("var(--text-on-brass)");
+      expect(rule).toContain("var(--warn)");
+      // 대비 기준이 비용 채널보다 안쪽에 있어야 warn 테가 채움이 아니라 그 테를 등지고 선다.
+      expect(rule.indexOf("var(--text-on-brass)")).toBeLessThan(rule.indexOf("var(--warn)"));
+    }
   });
 });
 

--- a/runtime/fleet-console/tests/operations.test.ts
+++ b/runtime/fleet-console/tests/operations.test.ts
@@ -285,6 +285,39 @@ describe("operations platform", () => {
     expect(bare?.rows[0]).not.toHaveProperty("effortAxis");
   });
 
+  // 펼침 경계는 축 위의 좌표라서 축 없이는 뜻이 없다. 반쯤 살려 두면 표면이 평범한 레일의 천장을
+  // 잘못 잡아, 비싼 단이 게이트 없이 레일 위에 서거나 고를 수 있는 단이 사라진다.
+  it("keeps the expansion boundary only when the axis can carry it", () => {
+    function rowWith(effortExpansion: unknown) {
+      const [group] = readLaunchVariantGroups([{
+        id: "native",
+        label: "Claude",
+        rows: [{
+          id: "fable[1m]",
+          label: "Fable",
+          launch: { model: "fable[1m]" },
+          effortAxis: ["low", "high", "xhigh", "max", "ultracode"],
+          chips: [{ id: "low", label: "LOW", launch: { model: "fable[1m]", effort: "low" } }],
+          effortExpansion,
+        }],
+      }]);
+      return group?.rows[0];
+    }
+
+    expect(rowWith({ after: "xhigh", rungs: ["max", "ultracode"] })?.effortExpansion)
+      .toEqual({ after: "xhigh", rungs: ["max", "ultracode"] });
+
+    // 축에 없는 경계, 축의 끝을 가리키는 경계, 형태가 아닌 값은 모두 버린다.
+    expect(rowWith({ after: "medium", rungs: ["max"] })).not.toHaveProperty("effortExpansion");
+    expect(rowWith({ after: "ultracode", rungs: [] })).not.toHaveProperty("effortExpansion");
+    expect(rowWith({ rungs: ["max"] })).not.toHaveProperty("effortExpansion");
+    expect(rowWith("xhigh")).not.toHaveProperty("effortExpansion");
+
+    // 공표된 꼬리가 축과 어긋나면 축을 따른다 — 자리의 근거는 축 하나다.
+    expect(rowWith({ after: "xhigh", rungs: ["max", "invented"] })?.effortExpansion)
+      .toEqual({ after: "xhigh", rungs: ["max", "ultracode"] });
+  });
+
   it("strictly reconstructs launch variants from the browser catalog response", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
       plugins: [{

--- a/runtime/fleet-console/tests/quick-launch-layout.test.tsx
+++ b/runtime/fleet-console/tests/quick-launch-layout.test.tsx
@@ -77,7 +77,8 @@ describe("Quick Launch effort surface", () => {
 
   it("writes the normalized model and effort at selection time", () => {
     expect(quickLaunch).toMatch(/const nextEffort = resolveRowEffort\(row, effort\);[\s\S]*setModel\(nextModel\);[\s\S]*setEffort\(nextEffort\);[\s\S]*writeQuickLaunchModelEffort\(nextModel, nextEffort\);/u);
-    expect(quickLaunch).toMatch(/onChange=\{\(nextEffort\) => \{[\s\S]*setEffort\(nextEffort\);[\s\S]*writeQuickLaunchModelEffort\(model, nextEffort\);/u);
+    // 챔버 뒤의 단은 이 실행에만 실린다 — 디스크로 새면 다음 세션이 아무도 고르지 않은 비싼 모드로 열린다.
+    expect(quickLaunch).toMatch(/onChange=\{\(nextEffort\) => \{[\s\S]*setEffort\(nextEffort\);[\s\S]*writeQuickLaunchModelEffort\(\s*model,\s*isSpecialEffort\(selectedRow, nextEffort\) \? null : nextEffort,\s*\);/u);
   });
 
   it("waits for the seeded model to resolve against the catalog before submission", () => {

--- a/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
@@ -8,7 +8,12 @@ import {
   type GatewayModel,
   type GatewayProvider,
 } from "@dotobokuri/core-ai-gateway";
-import { NATIVE_CLAUDE_EFFORTS, NATIVE_CLAUDE_MODEL_ALIASES } from "@dotobokuri/fleet-admiral";
+import {
+  NATIVE_CLAUDE_EFFORTS,
+  NATIVE_CLAUDE_LAUNCH_EFFORTS,
+  NATIVE_CLAUDE_MODEL_ALIASES,
+  NATIVE_CLAUDE_SPECIAL_EFFORTS,
+} from "@dotobokuri/fleet-admiral";
 
 import type { AgentCliLaunchMetadata } from "./agent-cli-launch-metadata.js";
 
@@ -18,6 +23,8 @@ const EFFORT_LABELS: Readonly<Record<string, string>> = {
   high: "HIGH",
   xhigh: "XHIGH",
   max: "MAX",
+  // 특수 강도는 줄여 쓰지 않는다 — 무엇을 켜는지 이름이 다 말해야 한다.
+  ultracode: "ULTRACODE",
 };
 
 const NATIVE_MODEL_LABELS: Readonly<Record<(typeof NATIVE_CLAUDE_MODEL_ALIASES)[number], string>> = {
@@ -57,7 +64,8 @@ export function buildClaudeGatewayLaunchVariants(selection?: AiGatewaySelection)
       label: NATIVE_MODEL_LABELS[model],
       launch: { model },
       effortAxis: EFFORT_AXIS,
-      chips: NATIVE_CLAUDE_EFFORTS.map((effort) => ({
+      ...(NATIVE_EFFORT_EXPANSION ? { effortExpansion: NATIVE_EFFORT_EXPANSION } : {}),
+      chips: NATIVE_CLAUDE_LAUNCH_EFFORTS.map((effort) => ({
         id: effort,
         label: EFFORT_LABELS[effort]!,
         launch: { model, effort },
@@ -84,16 +92,35 @@ export function buildClaudeGatewayLaunchVariants(selection?: AiGatewaySelection)
 
 // 강도 축은 사다리 어휘를 아는 이쪽이 소유한다. 한 모델이 그 일부만 내놓아도(low/high/max)
 // 축은 그대로라, 표면이 내놓은 단을 균등히 벌리는 대신 제자리에 세울 수 있다.
-const EFFORT_AXIS: readonly string[] = NATIVE_CLAUDE_EFFORTS;
+const EFFORT_AXIS: readonly string[] = NATIVE_CLAUDE_LAUNCH_EFFORTS;
+
+/**
+ * 평범한 레일의 천장. 이 뒤(max·ultracode)는 한 번 더 펼쳐야 닿는다 — 값이 비싸서가 아니라
+ * 스쳐 지나간 드래그가 그 값을 고르는 일이 사고이기 때문이다.
+ */
+const EFFORT_EXPANSION_AFTER = "xhigh";
+
+function effortExpansionFor(offered: readonly string[]): { readonly after: string; readonly rungs: readonly string[] } | undefined {
+  const boundary = EFFORT_AXIS.indexOf(EFFORT_EXPANSION_AFTER);
+  const rungs = EFFORT_AXIS.slice(boundary + 1).filter((rung) => offered.includes(rung));
+  return rungs.length > 0 ? { after: EFFORT_EXPANSION_AFTER, rungs } : undefined;
+}
+
+const NATIVE_EFFORT_EXPANSION = effortExpansionFor(NATIVE_CLAUDE_LAUNCH_EFFORTS);
 
 function providerGroupId(provider: GatewayProvider): string {
   return `gateway:${provider}`;
 }
 
 function toGatewayRow(model: GatewayModel, selection: AiGatewaySelection) {
-  const efforts = (selection.effortExposure[model.id] ?? exposableEffortLadder(model))
+  const ladder = selection.effortExposure[model.id] ?? exposableEffortLadder(model);
+  const efforts: string[] = ladder
     .filter((effort): effort is (typeof NATIVE_CLAUDE_EFFORTS)[number] =>
       NATIVE_CLAUDE_EFFORTS.includes(effort as (typeof NATIVE_CLAUDE_EFFORTS)[number]));
+  // ultracode는 이 모델의 단이 아니라 Claude Code 세션 모드이고 상류에는 xhigh로 나간다.
+  // xhigh를 내놓는 모델에만 걸어 주지 않으면 고른 단이 조용히 깎인다.
+  if (efforts.includes("xhigh")) efforts.push(...NATIVE_CLAUDE_SPECIAL_EFFORTS);
+  const expansion = effortExpansionFor(efforts);
   return {
     id: model.id,
     label: bareModelName(model),
@@ -101,6 +128,7 @@ function toGatewayRow(model: GatewayModel, selection: AiGatewaySelection) {
     launch: { model: model.id },
     ...(efforts.length > 0 ? {
       effortAxis: EFFORT_AXIS,
+      ...(expansion ? { effortExpansion: expansion } : {}),
       chips: efforts.map((effort) => ({
         id: effort,
         label: EFFORT_LABELS[effort] ?? effort.toUpperCase(),

--- a/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
@@ -14,6 +14,7 @@ import {
   injectAgentCliProfile,
   prepareAiGatewayLaunchProfile,
   NATIVE_CLAUDE_EFFORTS,
+  NATIVE_CLAUDE_SPECIAL_EFFORTS,
   resolveAgentCliId,
   resolveAgentCliProfile,
   resolveNativeClaudeModelAlias,
@@ -87,8 +88,14 @@ export function isGatewayLaunchEffortAllowed(
   model: GatewayModel,
   effort: string,
 ): boolean {
-  if (!NATIVE_CLAUDE_EFFORTS.includes(effort as (typeof NATIVE_CLAUDE_EFFORTS)[number])) return false;
   const efforts = selection.effortExposure[model.id] ?? exposableEffortLadder(model);
+  // ultracode는 게이트웨이 사다리의 단이 아니라 Claude Code 세션 모드이고, 상류에는 언제나
+  // xhigh로 나간다. 그래서 xhigh를 내놓지 못하는 모델에는 걸어 줄 수 없다 — 걸면 사용자가 고른
+  // 단이 상류에서 조용히 깎인다.
+  if (NATIVE_CLAUDE_SPECIAL_EFFORTS.includes(effort as (typeof NATIVE_CLAUDE_SPECIAL_EFFORTS)[number])) {
+    return efforts.includes("xhigh");
+  }
+  if (!NATIVE_CLAUDE_EFFORTS.includes(effort as (typeof NATIVE_CLAUDE_EFFORTS)[number])) return false;
   return efforts.includes(effort as GatewayReasoningEffort);
 }
 

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import path from "node:path";
 import process from "node:process";
 
-import { buildGatewayModelsToolSpec, createDelayedPtyWriter, createFleetGatewayAgentRuntimeLifecycle, formatPtyMessage, getAgentCliIds, getAgentCliMetadata, LaunchPromptError, MAX_LAUNCH_PROMPT_CHARS, NATIVE_CLAUDE_EFFORTS, parseAgentCliId, resolveNativeClaudeModelAlias, sanitizeLaunchPrompt, sanitizePtyMessageText, type AgentCliId } from "@dotobokuri/fleet-admiral";
+import { buildGatewayModelsToolSpec, createDelayedPtyWriter, createFleetGatewayAgentRuntimeLifecycle, formatPtyMessage, getAgentCliIds, getAgentCliMetadata, LaunchPromptError, MAX_LAUNCH_PROMPT_CHARS, NATIVE_CLAUDE_LAUNCH_EFFORTS, parseAgentCliId, resolveNativeClaudeModelAlias, sanitizeLaunchPrompt, sanitizePtyMessageText, type AgentCliId } from "@dotobokuri/fleet-admiral";
 import type { AgentToolSpec } from "@dotobokuri/core-agent";
 import { ensureWorkspaceDirectory, withDirectoryLock, type GlobalOptionsService } from "@dotobokuri/core-infra";
 import { createWikiWorkspaceResolver, getWikiToolSpecs } from "@dotobokuri/fleet-wiki";
@@ -364,7 +364,7 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
     }
     const nativeAlias = resolveNativeClaudeModelAlias(model);
     if (nativeAlias) {
-      if (effort !== undefined && !NATIVE_CLAUDE_EFFORTS.includes(effort as (typeof NATIVE_CLAUDE_EFFORTS)[number])) {
+      if (effort !== undefined && !NATIVE_CLAUDE_LAUNCH_EFFORTS.includes(effort as (typeof NATIVE_CLAUDE_LAUNCH_EFFORTS)[number])) {
         ctx.host.http.writeJson(res, 400, { error: "invalid_effort" });
         return false;
       }

--- a/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
@@ -5,7 +5,11 @@ import { buildAgentCliLaunchKinds } from "../server/agent-api/agent-cli-launch-k
 
 // 축은 사다리 어휘 그대로다. 한 모델이 그 일부만 내놓아도 축은 줄지 않는다 — 그래야 표면이
 // 내놓은 단을 균등히 벌리는 대신 제자리에 세울 수 있다.
-const EFFORT_AXIS = ["low", "medium", "high", "xhigh", "max"];
+const EFFORT_AXIS = ["low", "medium", "high", "xhigh", "max", "ultracode"];
+
+// 평범한 레일은 xhigh에서 끊긴다. 그 뒤의 단들은 값이 비싸서 한 번 더 펼쳐야 닿고, 표면은 이
+// 경계를 다시 계산하지 않는다 — 자리의 근거는 축 하나다.
+const EFFORT_EXPANSION = { after: "xhigh", rungs: ["max", "ultracode"] };
 
 const builtinVariants = {
   id: "native",
@@ -65,12 +69,15 @@ describe("buildAgentCliLaunchKinds", () => {
             label: "GPT-5.6-Sol-Fast",
             launch: { model: "codex--gpt-5.6-sol-fast" },
             effortAxis: EFFORT_AXIS,
+            // xhigh를 내놓는 모델이라 ultracode를 걸어 줄 수 있다 — 상류에는 xhigh로 나가므로.
+            effortExpansion: EFFORT_EXPANSION,
             chips: [
               gatewayChip("codex--gpt-5.6-sol-fast", "low", "LOW"),
               gatewayChip("codex--gpt-5.6-sol-fast", "medium", "MED"),
               gatewayChip("codex--gpt-5.6-sol-fast", "high", "HIGH"),
               gatewayChip("codex--gpt-5.6-sol-fast", "xhigh", "XHIGH"),
               gatewayChip("codex--gpt-5.6-sol-fast", "max", "MAX"),
+              gatewayChip("codex--gpt-5.6-sol-fast", "ultracode", "ULTRACODE"),
             ],
           },
         ],
@@ -84,14 +91,18 @@ describe("buildAgentCliLaunchKinds", () => {
             label: "K3-1M",
             starred: true,
             launch: { model: "kimi--k3" },
-            // 노출은 MAX 한 단뿐이지만 축은 다섯 단 그대로다.
+            // 노출은 MAX 한 단뿐이지만 축은 그대로다.
             effortAxis: EFFORT_AXIS,
+            // xhigh를 내놓지 못하는 모델에는 ultracode를 걸지 않는다 — 걸면 사용자가 고른 단이
+            // 상류에서 조용히 깎인다. 챔버에는 MAX만 남는다.
+            effortExpansion: { after: "xhigh", rungs: ["max"] },
             chips: [gatewayChip("kimi--k3", "max", "MAX")],
           },
         ],
       },
     ]);
-    expect(JSON.stringify(result)).not.toContain("ultra");
+    // 게이트웨이 사다리의 `ultra`는 여전히 새지 않는다 — ultracode와는 다른 값이다.
+    expect(JSON.stringify(result)).not.toContain("\"effort\":\"ultra\"");
   });
 
   it("keeps disabled reasons and does not attach variants to a disabled gateway kind", () => {
@@ -118,12 +129,14 @@ function builtinRow(model: string, label: string) {
     label,
     launch: { model },
     effortAxis: EFFORT_AXIS,
+    effortExpansion: EFFORT_EXPANSION,
     chips: [
       gatewayChip(model, "low", "LOW"),
       gatewayChip(model, "medium", "MED"),
       gatewayChip(model, "high", "HIGH"),
       gatewayChip(model, "xhigh", "XHIGH"),
       gatewayChip(model, "max", "MAX"),
+      gatewayChip(model, "ultracode", "ULTRACODE"),
     ],
   };
 }

--- a/runtime/fleet-plugins/terminal/tests/gateway-launch-effort.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/gateway-launch-effort.test.ts
@@ -1,0 +1,57 @@
+import { resolveAiGatewaySelection } from "@dotobokuri/core-ai-gateway";
+import { describe, expect, it } from "vitest";
+
+import { isGatewayLaunchEffortAllowed } from "../server/agent-api/launch.js";
+import { nativeClaudeAnalystModels } from "../server/agent-api/analysis-types.js";
+
+function selectionFor(models: readonly { id: string; efforts?: readonly string[] }[]) {
+  return resolveAiGatewaySelection({
+    version: 1,
+    models: models.map((model) => ({ id: model.id, ...(model.efforts ? { efforts: [...model.efforts] } : {}) })),
+  });
+}
+
+function modelIn(selection: ReturnType<typeof resolveAiGatewaySelection>, id: string) {
+  const model = selection.models.find((candidate) => candidate.id === id);
+  if (!model) throw new Error(`Expected ${id} to be enabled`);
+  return model;
+}
+
+describe("isGatewayLaunchEffortAllowed", () => {
+  it("accepts the rungs the model actually exposes", () => {
+    const selection = selectionFor([{ id: "codex--gpt-5.6-sol-fast" }]);
+    const model = modelIn(selection, "codex--gpt-5.6-sol-fast");
+
+    expect(isGatewayLaunchEffortAllowed(selection, model, "high")).toBe(true);
+    expect(isGatewayLaunchEffortAllowed(selection, model, "xhigh")).toBe(true);
+    // 게이트웨이 사다리의 `ultra`는 Claude Code가 받지 않는 값이다.
+    expect(isGatewayLaunchEffortAllowed(selection, model, "ultra")).toBe(false);
+    expect(isGatewayLaunchEffortAllowed(selection, model, "nonsense")).toBe(false);
+  });
+
+  /**
+   * ultracode는 이 모델의 단이 아니라 Claude Code 세션 모드이고, 상류에는 언제나 xhigh로 나간다.
+   * 그래서 xhigh를 내놓는 모델에만 걸어 줄 수 있다 — 걸지 못하는 모델에 허용하면 사용자가 고른
+   * 단이 상류에서 조용히 깎인다.
+   */
+  it("allows ultracode exactly where the model can honour xhigh", () => {
+    const wide = selectionFor([{ id: "codex--gpt-5.6-sol-fast" }]);
+    expect(isGatewayLaunchEffortAllowed(wide, modelIn(wide, "codex--gpt-5.6-sol-fast"), "ultracode")).toBe(true);
+
+    const narrow = selectionFor([{ id: "kimi--k3", efforts: ["max"] }]);
+    expect(isGatewayLaunchEffortAllowed(narrow, modelIn(narrow, "kimi--k3"), "max")).toBe(true);
+    expect(isGatewayLaunchEffortAllowed(narrow, modelIn(narrow, "kimi--k3"), "ultracode")).toBe(false);
+  });
+});
+
+describe("Analyst model options", () => {
+  /**
+   * Analyst는 강도를 깊이로만 읽고 워크플로우 오케스트레이션을 켤 수 없다. 실행 강도 목록과 추론
+   * 사다리를 다시 하나로 합치면, 이 표면이 아무 변경 없이 ultracode를 내놓게 된다.
+   */
+  it("offers the depth ladder only, never the session mode", () => {
+    for (const option of nativeClaudeAnalystModels()) {
+      expect(option.effort.levels).toEqual(["low", "medium", "high", "xhigh", "max"]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- 실행 강도 게이지의 평범한 레일을 XHIGH에서 끊고, MAX와 ULTRACODE를 그 뒤 챔버에 두었습니다. 게이트를 열면 축의 눈금이 다시 그려지지 않습니다 — 접혀 있을 때도 챔버 자리를 비워 두므로 평범한 단들의 좌표가 그대로입니다. 챔버 안의 단은 고르는 것까지만이고 실행은 별도 행위가 맡습니다.
- `ultracode`는 Claude Code가 `--effort` 인자로 받는 값입니다(CLI 2.1.226 실측: `ultracode`·`xhigh` 수용, `ultra`·`minimal` 거부). 게이트웨이 변경은 없습니다 — `--effort`는 이미 일반적으로 전달되고, Fleet의 자체 허용 목록만 막고 있었습니다. Analyst와 Cowork는 `NATIVE_CLAUDE_EFFORTS`를 그대로 쓰므로 구조적으로 제외됩니다.
- dynamic workflow에서 `opts.model` 리터럴 pin이 없는 `agent()` 호출을 PreToolUse 훅이 하드 차단합니다. pin 없는 호출은 세션 모델을 물려받아 세션 자체 allowance를 쓰는데, 이는 선택이 아니라 누락으로 도달합니다. 값 검사는 문자열·주석을 구분하므로 프롬프트 산문 속 모델 이름은 더 이상 오탐하지 않습니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console test` — 1853 pass / 24 skipped
- [x] `pnpm --filter @dotobokuri/fleet-admiral test` — 200 pass
- [x] `pnpm --filter @fleet-plugins/terminal test` — 540 pass
- [x] typecheck·build 3패키지 전부 통과 (`tsc --noEmit` 포함)
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 6건 검증
- [x] `pnpm check:core-boundary`
- [x] 격리 콘솔 헤디드 실측: 캔버스 실행 메뉴와 Quick Launch 바 두 표면 모두에서 게이트 열림 시 평범한 스톱 좌표 불변(551.5–631.5 / 536.1–620.1), `aria-valuemax` 4→6, 초점이 레일→게이트로 이동, ULTRACODE 장전 후 Enter가 실행하지 않음(op 0건), 접으면 평범한 폴백으로 복귀
- [x] 4개 테마 전부에서 장전 표식 대비 실측 — `whites`는 brass와 warn의 색상각이 같아(82°) 명도 1% 차이뿐이었고, brass 위에서 읽히는 테를 안쪽에 둬 해결