### PR TITLE
feat(core-ai-gateway): trim Cursor catalog to auto, composer, and grok

### DIFF
--- a/.changelog.d/cursor-provider-trim.md
+++ b/.changelog.d/cursor-provider-trim.md
@@ -1,0 +1,13 @@
+---
+branch: cursor-provider-trim
+---
+
+### fleet-cli
+#### Removed
+- Drop unsupported Cursor AI Gateway models from discovery. The Cursor catalog keeps Auto, Composer 2.5, and Grok 4.5 (including their fast variants); Claude, GPT, and Kimi entries no longer appear on the Cursor provider.
+  ko: 지원하지 않는 Cursor AI Gateway 모델을 디스커버리에서 제거합니다. Cursor 카탈로그는 Auto·Composer 2.5·Grok 4.5(및 fast 변형)만 유지하며, Claude·GPT·Kimi 항목은 Cursor 공급자에 더 이상 나타나지 않습니다.
+
+### fleet-console
+#### Removed
+- Drop unsupported Cursor AI Gateway models from the settings catalog and launch pickers. The Cursor provider keeps Auto, Composer 2.5, and Grok 4.5 (including their fast variants); Claude, GPT, and Kimi entries no longer appear under Cursor.
+  ko: 설정 카탈로그와 실행 선택기에서 지원하지 않는 Cursor AI Gateway 모델을 제거합니다. Cursor 공급자는 Auto·Composer 2.5·Grok 4.5(및 fast 변형)만 유지하며, Claude·GPT·Kimi 항목은 Cursor 아래에 더 이상 나타나지 않습니다.

--- a/packages/core-ai-gateway/benchmarks.json
+++ b/packages/core-ai-gateway/benchmarks.json
@@ -14,81 +14,157 @@
     "gpt-5.6-sol": {
       "source": "cursorbench",
       "rungs": {
-        "low": { "score": 52.6, "tokensPerTask": 5104, "stepsPerTask": 19 },
-        "medium": { "score": 60.0, "tokensPerTask": 9747, "stepsPerTask": 27 },
-        "high": { "score": 63.5, "tokensPerTask": 13867, "stepsPerTask": 32 },
-        "xhigh": { "score": 64.5, "tokensPerTask": 19699, "stepsPerTask": 38 },
-        "max": { "score": 67.2, "tokensPerTask": 28320, "stepsPerTask": 48 }
+        "low": {
+          "score": 52.6,
+          "tokensPerTask": 5104,
+          "stepsPerTask": 19
+        },
+        "medium": {
+          "score": 60.0,
+          "tokensPerTask": 9747,
+          "stepsPerTask": 27
+        },
+        "high": {
+          "score": 63.5,
+          "tokensPerTask": 13867,
+          "stepsPerTask": 32
+        },
+        "xhigh": {
+          "score": 64.5,
+          "tokensPerTask": 19699,
+          "stepsPerTask": 38
+        },
+        "max": {
+          "score": 67.2,
+          "tokensPerTask": 28320,
+          "stepsPerTask": 48
+        }
       }
     },
     "gpt-5.6-terra": {
       "source": "cursorbench",
       "rungs": {
-        "low": { "score": 46.9, "tokensPerTask": 5312, "stepsPerTask": 19 },
-        "medium": { "score": 50.3, "tokensPerTask": 6222, "stepsPerTask": 20 },
-        "high": { "score": 54.2, "tokensPerTask": 9468, "stepsPerTask": 23 },
-        "xhigh": { "score": 59.2, "tokensPerTask": 16089, "stepsPerTask": 29 },
-        "max": { "score": 64.9, "tokensPerTask": 32969, "stepsPerTask": 47 }
+        "low": {
+          "score": 46.9,
+          "tokensPerTask": 5312,
+          "stepsPerTask": 19
+        },
+        "medium": {
+          "score": 50.3,
+          "tokensPerTask": 6222,
+          "stepsPerTask": 20
+        },
+        "high": {
+          "score": 54.2,
+          "tokensPerTask": 9468,
+          "stepsPerTask": 23
+        },
+        "xhigh": {
+          "score": 59.2,
+          "tokensPerTask": 16089,
+          "stepsPerTask": 29
+        },
+        "max": {
+          "score": 64.9,
+          "tokensPerTask": 32969,
+          "stepsPerTask": 47
+        }
       }
     },
     "gpt-5.6-luna": {
       "source": "cursorbench",
       "rungs": {
-        "low": { "score": 37.6, "tokensPerTask": 3209, "stepsPerTask": 17 },
-        "medium": { "score": 47.7, "tokensPerTask": 7095, "stepsPerTask": 28 },
-        "high": { "score": 56.8, "tokensPerTask": 15141, "stepsPerTask": 40 },
-        "xhigh": { "score": 57.7, "tokensPerTask": 22480, "stepsPerTask": 48 },
-        "max": { "score": 61.1, "tokensPerTask": 87973, "stepsPerTask": 61 }
+        "low": {
+          "score": 37.6,
+          "tokensPerTask": 3209,
+          "stepsPerTask": 17
+        },
+        "medium": {
+          "score": 47.7,
+          "tokensPerTask": 7095,
+          "stepsPerTask": 28
+        },
+        "high": {
+          "score": 56.8,
+          "tokensPerTask": 15141,
+          "stepsPerTask": 40
+        },
+        "xhigh": {
+          "score": 57.7,
+          "tokensPerTask": 22480,
+          "stepsPerTask": 48
+        },
+        "max": {
+          "score": 61.1,
+          "tokensPerTask": 87973,
+          "stepsPerTask": 61
+        }
       }
     },
     "grok-4.5": {
       "source": "cursorbench",
       "rungs": {
-        "low": { "score": 63.5, "tokensPerTask": 15841, "stepsPerTask": 31 },
-        "medium": { "score": 65.4, "tokensPerTask": 18914, "stepsPerTask": 34 },
-        "high": { "score": 66.7, "tokensPerTask": 19521, "stepsPerTask": 33 }
+        "low": {
+          "score": 63.5,
+          "tokensPerTask": 15841,
+          "stepsPerTask": 31
+        },
+        "medium": {
+          "score": 65.4,
+          "tokensPerTask": 18914,
+          "stepsPerTask": 34
+        },
+        "high": {
+          "score": 66.7,
+          "tokensPerTask": 19521,
+          "stepsPerTask": 33
+        }
       },
       "caveat": "Bench footnote: an earlier snapshot of Cursor's codebase was unintentionally present in this model's training data, inflating scores by an unknown amount; the advantage does not transfer to other repositories."
     },
     "kimi-k3": {
       "source": "cursorbench",
       "rungs": {
-        "low": { "score": 50.5, "tokensPerTask": 13007, "stepsPerTask": 33 },
-        "high": { "score": 59.7, "tokensPerTask": 26846, "stepsPerTask": 47 },
-        "max": { "score": 60.8, "tokensPerTask": 38428, "stepsPerTask": 57 }
+        "low": {
+          "score": 50.5,
+          "tokensPerTask": 13007,
+          "stepsPerTask": 33
+        },
+        "high": {
+          "score": 59.7,
+          "tokensPerTask": 26846,
+          "stepsPerTask": 47
+        },
+        "max": {
+          "score": 60.8,
+          "tokensPerTask": 38428,
+          "stepsPerTask": 57
+        }
       }
     },
     "composer-2.5": {
       "source": "cursorbench",
-      "overall": { "score": 56.1, "tokensPerTask": 14286, "stepsPerTask": 33 }
+      "overall": {
+        "score": 56.1,
+        "tokensPerTask": 14286,
+        "stepsPerTask": 33
+      }
     },
     "glm-5.2": {
       "source": "cursorbench",
       "rungs": {
-        "high": { "score": 51.5, "tokensPerTask": 21829, "stepsPerTask": 49 },
-        "max": { "score": 55.0, "tokensPerTask": 35946, "stepsPerTask": 58 }
+        "high": {
+          "score": 51.5,
+          "tokensPerTask": 21829,
+          "stepsPerTask": 49
+        },
+        "max": {
+          "score": 55.0,
+          "tokensPerTask": 35946,
+          "stepsPerTask": 58
+        }
       },
       "caveat": "Measured per reasoning rung, but the gateway serves this model without effort control; which rung the serving path reaches is unknown."
-    },
-    "claude-opus-5": {
-      "source": "cursorbench",
-      "rungs": {
-        "low": { "score": 62.8, "tokensPerTask": 18529, "stepsPerTask": 37 },
-        "medium": { "score": 64.3, "tokensPerTask": 23612, "stepsPerTask": 44 },
-        "high": { "score": 66.7, "tokensPerTask": 27932, "stepsPerTask": 48 },
-        "xhigh": { "score": 69.3, "tokensPerTask": 54239, "stepsPerTask": 72 },
-        "max": { "score": 70.0, "tokensPerTask": 61838, "stepsPerTask": 78 }
-      }
-    },
-    "claude-fable-5": {
-      "source": "cursorbench",
-      "rungs": {
-        "low": { "score": 62.1, "tokensPerTask": 18182, "stepsPerTask": 31 },
-        "medium": { "score": 65.2, "tokensPerTask": 30366, "stepsPerTask": 41 },
-        "high": { "score": 66.5, "tokensPerTask": 43747, "stepsPerTask": 48 },
-        "xhigh": { "score": 68.4, "tokensPerTask": 64971, "stepsPerTask": 56 },
-        "max": { "score": 70.5, "tokensPerTask": 103525, "stepsPerTask": 72 }
-      }
     }
   }
 }

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -142,7 +142,7 @@
     "cursor": {
       "name": "Cursor",
       "defaultModel": "auto",
-      "source": "Cursor GetUsableModels + Run conversationCheckpointUpdate.token_details.max_tokens (cli-2026.07.08-0c04a8a; standard and Max Mode observed 2026-08-01, gpt-5.6-sol observed 2026-08-05 on cursor-agent 2026.07.23-e383d2b, claude-opus-5 and claude-fable-5 standard/Max Mode windows observed 2026-08-10); quotaScope from DashboardService/GetCurrentPeriodUsage autoBucketModels (2026-08-05)",
+      "source": "Cursor GetUsableModels + Run conversationCheckpointUpdate.token_details.max_tokens (cli-2026.07.08-0c04a8a; auto, composer-2.5, and grok-4.5 families observed 2026-08-01); quotaScope from DashboardService/GetCurrentPeriodUsage autoBucketModels (2026-08-05)",
       "models": [
         {
           "modelId": "auto",
@@ -201,139 +201,6 @@
             ],
             "upstreamModelIdTemplate": "cursor-grok-4.5-{effort}-fast"
           }
-        },
-        {
-          "modelId": "gpt-5.6-sol",
-          "name": "GPT-5.6-Sol",
-          "capabilityClass": "flagship",
-          "quotaScope": "api",
-          "contextWindow": 272000,
-          "effort": {
-            "supported": true,
-            "levels": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
-            "upstreamModelIdTemplate": "gpt-5.6-sol-{effort}"
-          },
-          "benchmarkKey": "gpt-5.6-sol"
-        },
-        {
-          "modelId": "claude-opus-5",
-          "name": "Opus-5",
-          "capabilityClass": "flagship",
-          "quotaScope": "api",
-          "contextWindow": 300000,
-          "effort": {
-            "supported": true,
-            "levels": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
-            "upstreamModelIdTemplate": "claude-opus-5-{effort}",
-            "upstreamModelIds": {
-              "xhigh": "claude-opus-5-thinking-xhigh",
-              "max": "claude-opus-5-thinking-max"
-            }
-          },
-          "benchmarkKey": "claude-opus-5"
-        },
-        {
-          "modelId": "claude-opus-5-1m",
-          "name": "Opus-5-1M",
-          "capabilityClass": "flagship",
-          "quotaScope": "api",
-          "contextWindow": 1000000,
-          "cursorMaxMode": true,
-          "effort": {
-            "supported": true,
-            "levels": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
-            "upstreamModelIdTemplate": "claude-opus-5-{effort}",
-            "upstreamModelIds": {
-              "xhigh": "claude-opus-5-thinking-xhigh",
-              "max": "claude-opus-5-thinking-max"
-            }
-          },
-          "benchmarkKey": "claude-opus-5"
-        },
-        {
-          "modelId": "claude-fable-5",
-          "name": "Fable-5",
-          "capabilityClass": "flagship",
-          "quotaScope": "api",
-          "description": "NO ZDR",
-          "contextWindow": 300000,
-          "effort": {
-            "supported": true,
-            "levels": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
-            "upstreamModelIdTemplate": "claude-fable-5-{effort}"
-          },
-          "benchmarkKey": "claude-fable-5"
-        },
-        {
-          "modelId": "claude-fable-5-1m",
-          "name": "Fable-5-1M",
-          "capabilityClass": "flagship",
-          "quotaScope": "api",
-          "description": "NO ZDR",
-          "contextWindow": 1000000,
-          "cursorMaxMode": true,
-          "effort": {
-            "supported": true,
-            "levels": [
-              "low",
-              "medium",
-              "high",
-              "xhigh",
-              "max"
-            ],
-            "upstreamModelIdTemplate": "claude-fable-5-{effort}"
-          },
-          "benchmarkKey": "claude-fable-5"
-        },
-        {
-          "modelId": "kimi-k3-1m",
-          "name": "Kimi-K3-1M",
-          "capabilityClass": "flagship",
-          "quotaScope": "api",
-          "providerModelId": "kimi-k3-max",
-          "contextWindow": 1048576,
-          "cursorMaxMode": true,
-          "benchmarkKey": "kimi-k3"
-        },
-        {
-          "modelId": "kimi-k3",
-          "name": "Kimi-K3",
-          "capabilityClass": "flagship",
-          "quotaScope": "api",
-          "contextWindow": 200000,
-          "effort": {
-            "supported": true,
-            "levels": [
-              "low",
-              "high"
-            ],
-            "upstreamModelIdTemplate": "kimi-k3-{effort}"
-          },
-          "benchmarkKey": "kimi-k3"
         }
       ]
     },
@@ -383,7 +250,7 @@
     "opencode": {
       "name": "OpenCode",
       "defaultModel": "minimax-m3",
-      "source": "live GET https://opencode.ai/zen/go/v1/models + per-model wire probes on /messages, /responses, /chat/completions (2026-08-03); contextWindow cross-checked against models.dev api.json opencode-go entries and oh-my-pi packages/catalog/src/models.json (2026-08-03, both agree). Excluded: mimo-v2-pro/mimo-v2-omni (upstream server_error), hy3-preview (listed but Router.ModelNotFound); superseded generations removed 2026-08-08 — the catalog keeps each lineup's current generation only",
+      "source": "live GET https://opencode.ai/zen/go/v1/models + per-model wire probes on /messages, /responses, /chat/completions (2026-08-03); contextWindow cross-checked against models.dev api.json opencode-go entries and oh-my-pi packages/catalog/src/models.json (2026-08-03, both agree). Excluded: mimo-v2-pro/mimo-v2-omni (upstream server_error), hy3-preview (listed but Router.ModelNotFound); superseded generations removed 2026-08-08 \u2014 the catalog keeps each lineup's current generation only",
       "models": [
         {
           "modelId": "minimax-m3",

--- a/packages/core-ai-gateway/src/settings/index.ts
+++ b/packages/core-ai-gateway/src/settings/index.ts
@@ -300,7 +300,7 @@ export interface AiGatewayCatalogProvider {
 }
 
 export interface AiGatewayCatalogModel {
-  /** Scoped gateway model id, e.g. `cursor--claude-opus-5`. */
+  /** Scoped gateway model id, e.g. `cursor--grok-4.5`. */
   readonly id: string;
   /** Bare model label without the provider prefix. */
   readonly name: string;

--- a/packages/core-ai-gateway/tests/cursor/diagnostic-log.test.ts
+++ b/packages/core-ai-gateway/tests/cursor/diagnostic-log.test.ts
@@ -50,13 +50,13 @@ describe("Cursor diagnostic log", () => {
     const log = createCursorDiagnosticLog(path.join(root, "ai-gateway"));
     const event = diagnosticEvent({
       event: "server.frame",
-      model: "claude-opus-5",
-      wireModel: "claude-opus-5-thinking-xhigh",
-      requestedEffort: "xhigh",
+      model: "grok-4.5",
+      wireModel: "cursor-grok-4.5-high",
+      requestedEffort: "high",
       frame: "interactionUpdate.toolCallStarted",
       sequence: 1,
       contextTokens: 42_000,
-      contextWindow: 300_000,
+      contextWindow: 256_000,
       argumentRepairCount: 1,
     });
     log.write({
@@ -69,13 +69,13 @@ describe("Cursor diagnostic log", () => {
     const contents = await readFile(log.path, "utf8");
     expect(JSON.parse(contents)).toEqual(expect.objectContaining({
       event: "server.frame",
-      model: "claude-opus-5",
-      wireModel: "claude-opus-5-thinking-xhigh",
-      requestedEffort: "xhigh",
+      model: "grok-4.5",
+      wireModel: "cursor-grok-4.5-high",
+      requestedEffort: "high",
       frame: "interactionUpdate.toolCallStarted",
       sequence: 1,
       contextTokens: 42_000,
-      contextWindow: 300_000,
+      contextWindow: 256_000,
       argumentRepairCount: 1,
     }));
     expect(contents).not.toContain("SECRET_PROMPT");
@@ -111,8 +111,8 @@ describe("Cursor diagnostic log", () => {
 
     log.write(diagnosticEvent({
       event: "transport.semantic_timeout",
-      model: "claude-fable-5",
-      wireModel: "claude-fable-5-high",
+      model: "composer-2.5-fast",
+      wireModel: "composer-2.5-fast",
       requestedEffort: "high",
       outcome: "semantic_stall_timeout",
     }));
@@ -120,8 +120,8 @@ describe("Cursor diagnostic log", () => {
 
     expect(JSON.parse(await readFile(log.path, "utf8"))).toMatchObject({
       event: "transport.semantic_timeout",
-      model: "claude-fable-5",
-      wireModel: "claude-fable-5-high",
+      model: "composer-2.5-fast",
+      wireModel: "composer-2.5-fast",
       requestedEffort: "high",
       outcome: "semantic_stall_timeout",
     });
@@ -133,9 +133,9 @@ describe("Cursor diagnostic log", () => {
 
     log.write(diagnosticEvent({
       event: "model.switch",
-      model: "claude-opus-5",
-      wireModel: "claude-opus-5-thinking-max",
-      previousWireModel: "claude-opus-5-thinking-xhigh",
+      model: "grok-4.5",
+      wireModel: "cursor-grok-4.5-high",
+      previousWireModel: "cursor-grok-4.5-low",
       turn: "prompt",
     }));
     await log.flush();
@@ -143,9 +143,9 @@ describe("Cursor diagnostic log", () => {
     const contents = await readFile(log.path, "utf8");
     expect(JSON.parse(contents)).toEqual(expect.objectContaining({
       event: "model.switch",
-      model: "claude-opus-5",
-      wireModel: "claude-opus-5-thinking-max",
-      previousWireModel: "claude-opus-5-thinking-xhigh",
+      model: "grok-4.5",
+      wireModel: "cursor-grok-4.5-high",
+      previousWireModel: "cursor-grok-4.5-low",
       turn: "prompt",
     }));
     expect(contents).not.toContain("claude-session");

--- a/packages/core-ai-gateway/tests/cursor/native/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/cursor/native/adapter.test.ts
@@ -30,15 +30,10 @@ describe("Cursor request budgets", () => {
   });
 
   it.each([
-    ["kimi-k3", "medium", "kimi-k3-low"],
-    ["kimi-k3", "xhigh", "kimi-k3-high"],
-    ["kimi-k3-1m", "low", "kimi-k3-max"],
-    ["claude-opus-5", "xhigh", "claude-opus-5-thinking-xhigh"],
-    ["claude-opus-5", "max", "claude-opus-5-thinking-max"],
-    ["claude-opus-5-1m", "xhigh", "claude-opus-5-thinking-xhigh"],
-    ["claude-fable-5-1m", "high", "claude-fable-5-high"],
+    ["grok-4.5", "low", "cursor-grok-4.5-low"],
+    ["grok-4.5", "medium", "cursor-grok-4.5-medium"],
     ["grok-4.5-fast", "low", "cursor-grok-4.5-low-fast"],
-    ["gpt-5.6-sol", "max", "gpt-5.6-sol-max"],
+    ["composer-2.5", "high", "composer-2.5"],
   ] as const)("writes Cursor model %s with effort %s as %s", (model, effort, expected) => {
     const plan = buildCursorRunPlan(request({
       model,
@@ -49,31 +44,15 @@ describe("Cursor request budgets", () => {
   });
 
   it("uses the registry default when a Cursor reasoning model has no explicit effort", () => {
-    const plan = buildCursorRunPlan(request({ model: "kimi-k3" }), "conversation-default-effort");
+    const plan = buildCursorRunPlan(request({ model: "grok-4.5" }), "conversation-default-effort");
 
-    expect(runRequest(plan).modelDetails.modelId).toBe("kimi-k3-high");
+    expect(runRequest(plan).modelDetails.modelId).toBe("cursor-grok-4.5-high");
   });
 
-  it.each([
-    ["kimi-k3-1m", undefined, "kimi-k3-max"],
-    ["claude-opus-5-1m", "high", "claude-opus-5-high"],
-    ["claude-fable-5-1m", "high", "claude-fable-5-high"],
-  ] as const)("encodes Cursor Max Mode for catalog model %s", (model, effort, wireModel) => {
-    const plan = buildCursorRunPlan(request({
-      model,
-      ...(effort ? { reasoning: { summary: "auto" as const, effort } } : {}),
-    }), `conversation-${model}`);
+  it("keeps supported Cursor catalog models out of Max Mode unless explicitly enabled", () => {
+    const plan = buildCursorRunPlan(request({ model: "grok-4.5" }), "conversation-grok-standard");
 
-    expect(encodedRunRequest(plan).modelDetails).toMatchObject({
-      modelId: wireModel,
-      maxMode: true,
-    });
-  });
-
-  it("keeps the standard Kimi K3 catalog model out of Cursor Max Mode", () => {
-    const plan = buildCursorRunPlan(request({ model: "kimi-k3" }), "conversation-kimi-standard");
-
-    expect(encodedRunRequest(plan).modelDetails).toMatchObject({ modelId: "kimi-k3-high" });
+    expect(encodedRunRequest(plan).modelDetails).toMatchObject({ modelId: "cursor-grok-4.5-high" });
     expect(encodedRunRequest(plan).modelDetails).not.toHaveProperty("maxMode");
   });
 
@@ -598,7 +577,7 @@ describe("Cursor request budgets", () => {
 
   it("replays an external-model tool result through the same structured tool step", () => {
     const plan = buildCursorRunPlan(request({
-      model: "kimi-k3",
+      model: "grok-4.5",
       input: [
         { type: "message", role: "user", content: "Run pwd" },
         { type: "function_call", call_id: "call-pwd", name: "exec_command", arguments: '{"cmd":"pwd"}' },

--- a/packages/core-ai-gateway/tests/cursor/native/live-run.test.ts
+++ b/packages/core-ai-gateway/tests/cursor/native/live-run.test.ts
@@ -33,7 +33,7 @@ afterEach(() => {
 });
 
 describe("Cursor live client-tool Run bridge", () => {
-  it.each(["kimi-k3-1m", "claude-opus-5", "grok-4.5", "auto", "composer-2.5"])(
+  it.each(["grok-4.5", "grok-4.5-fast", "auto", "composer-2.5", "composer-2.5-fast"])(
     "parks and attaches %s without opening a resume Run",
     async (model) => {
       const call = cursorCall("call-read-1", 21);
@@ -415,7 +415,7 @@ describe("Cursor live client-tool Run bridge", () => {
     const harness = cursorHarness([stream], {
       diagnostics: (event) => diagnostics.push(event),
     });
-    const initial = cursorRequest("session-first-exec", "claude-opus-5");
+    const initial = cursorRequest("session-first-exec", "grok-4.5");
 
     try {
       await collectCursorResponseWithDiagnostics(harness.adapter, initial, true);
@@ -452,7 +452,7 @@ describe("Cursor live client-tool Run bridge", () => {
     const harness = cursorHarness([stream], {
       diagnostics: (event) => diagnostics.push(event),
     });
-    const initial = cursorRequest("session-diagnostics-on", "kimi-k3-1m");
+    const initial = cursorRequest("session-diagnostics-on", "grok-4.5");
 
     try {
       await collectCursorResponseWithDiagnostics(harness.adapter, initial, true);
@@ -483,7 +483,7 @@ describe("Cursor live client-tool Run bridge", () => {
     const harness = cursorHarness([stream], {
       diagnostics: (event) => diagnostics.push(event),
     });
-    const initial = cursorRequest("session-diagnostics-off", "kimi-k3-1m");
+    const initial = cursorRequest("session-diagnostics-off", "grok-4.5");
 
     try {
       await collectCursorResponseWithDiagnostics(harness.adapter, initial, false);
@@ -511,14 +511,14 @@ describe("Cursor live client-tool Run bridge", () => {
     try {
       await collectCursorResponseWithDiagnostics(
         harness.adapter,
-        cursorRequest("session-diagnostics-next-off", "kimi-k3"),
+        cursorRequest("session-diagnostics-next-off", "grok-4.5-fast"),
         false,
       );
       expect(diagnostics).toEqual([]);
 
       await collectCursorResponseWithDiagnostics(
         harness.adapter,
-        cursorRequest("session-diagnostics-next-on", "kimi-k3"),
+        cursorRequest("session-diagnostics-next-on", "grok-4.5-fast"),
         true,
       );
       expect(diagnostics).toContainEqual(expect.objectContaining({ event: "turn.start" }));
@@ -600,7 +600,7 @@ describe("Cursor live client-tool Run bridge", () => {
       calls.length,
     );
     const harness = cursorHarness([stream]);
-    const initial = cursorRequest("session-parallel", "kimi-k3");
+    const initial = cursorRequest("session-parallel", "grok-4.5-fast");
 
     try {
       await collectCursorResponse(harness.adapter, initial);
@@ -709,7 +709,7 @@ describe("Cursor live client-tool Run bridge", () => {
       1,
     );
     const harness = cursorHarness([stream]);
-    const initial = cursorRequest("session-exec-first", "kimi-k3-1m");
+    const initial = cursorRequest("session-exec-first", "grok-4.5");
 
     try {
       const initialEvents = await collectCursorResponse(harness.adapter, initial);
@@ -751,7 +751,7 @@ describe("Cursor live client-tool Run bridge", () => {
       2,
     );
     const harness = cursorHarness([stream]);
-    const initial = cursorRequest("session-reordered-parallel", "claude-opus-5");
+    const initial = cursorRequest("session-reordered-parallel", "grok-4.5");
 
     try {
       await collectCursorResponse(harness.adapter, initial);
@@ -797,7 +797,7 @@ describe("Cursor live client-tool Run bridge", () => {
       [{ afterMcpResults: 2, frames: cursorCompletionFrames("two cycles complete") }],
     );
     const harness = cursorHarness([stream]);
-    const initial = cursorRequest("session-checkpoint-cycle", "kimi-k3-1m");
+    const initial = cursorRequest("session-checkpoint-cycle", "grok-4.5");
     const firstContinuation = cursorContinuation(initial, [first], [
       cursorResult(first, "first result"),
     ]);
@@ -849,7 +849,7 @@ describe("Cursor live client-tool Run bridge", () => {
       cursorCompletionFrames("compacted turn complete"),
     );
     const harness = cursorHarness([largeStream, compactedStream]);
-    const base = cursorRequest("session-checkpoint-staleness", "kimi-k3-1m");
+    const base = cursorRequest("session-checkpoint-staleness", "grok-4.5");
     const large: CanonicalResponseRequest = {
       ...base,
       input: [{ type: "message", role: "user", content: "x".repeat(60_000) }],
@@ -882,7 +882,7 @@ describe("Cursor live client-tool Run bridge", () => {
       ...cursorCompletionFrames("window is full"),
     ]);
     const harness = cursorHarness([saturating]);
-    const request = cursorRequest("session-window-saturated", "kimi-k3-1m");
+    const request = cursorRequest("session-window-saturated", "grok-4.5");
 
     try {
       await collectCursorResponse(harness.adapter, request);
@@ -912,7 +912,7 @@ describe("Cursor live client-tool Run bridge", () => {
       ...cursorToolFrames([call]),
     ]);
     const harness = cursorHarness([stream]);
-    const initial = cursorRequest("session-window-continuation", "kimi-k3-1m");
+    const initial = cursorRequest("session-window-continuation", "grok-4.5");
 
     try {
       await collectCursorResponse(harness.adapter, initial);
@@ -949,7 +949,7 @@ describe("Cursor live client-tool Run bridge", () => {
     );
     const cold = new BridgeCursorStream(cursorCompletionFrames("cold run opened"));
     const harness = cursorHarness([parked, cold]);
-    const base = cursorRequest("session-window-retry", "kimi-k3-1m");
+    const base = cursorRequest("session-window-retry", "grok-4.5");
     const large: CanonicalResponseRequest = {
       ...base,
       input: [{ type: "message", role: "user", content: "x".repeat(60_000) }],
@@ -993,7 +993,7 @@ describe("Cursor live client-tool Run bridge", () => {
     );
     const cold = new BridgeCursorStream(cursorCompletionFrames("cold run opened"));
     const harness = cursorHarness([parked, cold]);
-    const base = cursorRequest("session-window-selfcompact", "kimi-k3-1m");
+    const base = cursorRequest("session-window-selfcompact", "grok-4.5");
     const large: CanonicalResponseRequest = {
       ...base,
       input: [{ type: "message", role: "user", content: "x".repeat(60_000) }],
@@ -1026,7 +1026,7 @@ describe("Cursor live client-tool Run bridge", () => {
     ]);
     const next = new BridgeCursorStream(cursorCompletionFrames("second turn complete"));
     const harness = cursorHarness([belowWindow, next]);
-    const request = cursorRequest("session-window-under", "kimi-k3-1m");
+    const request = cursorRequest("session-window-under", "grok-4.5");
 
     try {
       await collectCursorResponse(harness.adapter, request);
@@ -1055,7 +1055,7 @@ describe("Cursor live client-tool Run bridge", () => {
     ]);
     const compacted = new BridgeCursorStream(cursorCompletionFrames("compacted turn complete"));
     const harness = cursorHarness([saturating, compacted]);
-    const base = cursorRequest("session-window-compacted", "kimi-k3-1m");
+    const base = cursorRequest("session-window-compacted", "grok-4.5");
     const large: CanonicalResponseRequest = {
       ...base,
       input: [{ type: "message", role: "user", content: "x".repeat(60_000) }],
@@ -1082,7 +1082,7 @@ describe("Cursor live client-tool Run bridge", () => {
       const parked = new BridgeCursorStream(cursorToolFrames(calls));
       const fallback = new BridgeCursorStream(cursorCompletionFrames("cold fallback"));
       const harness = cursorHarness([parked, fallback]);
-      const initial = cursorRequest(`session-${kind}`, "kimi-k3-1m");
+      const initial = cursorRequest(`session-${kind}`, "grok-4.5");
       const exact = calls.map((call) => cursorResult(call, `${call.callId} result`));
       const results = kind === "partial"
         ? exact.slice(0, 1)
@@ -1121,11 +1121,11 @@ describe("Cursor live client-tool Run bridge", () => {
       const harness = cursorHarness([parked, fallback]);
       const initial = cursorRequest(
         `session-separation-${partition}`,
-        partition === "effort" ? "kimi-k3" : "kimi-k3-1m",
+        partition === "effort" ? "grok-4.5-fast" : "grok-4.5",
         partition === "effort" ? "low" : undefined,
       );
       let continuation = cursorContinuation(initial, [call], [cursorResult(call, "done")]);
-      if (partition === "model") continuation = { ...continuation, model: "claude-opus-5" };
+      if (partition === "model") continuation = { ...continuation, model: "composer-2.5" };
       if (partition === "effort") {
         continuation = { ...continuation, reasoning: { summary: "auto", effort: "high" } };
       }
@@ -1151,7 +1151,7 @@ describe("Cursor live client-tool Run bridge", () => {
 
   it("cold-resumes a live model when ToolSearch activates deferred tools", async () => {
     const initial: CanonicalResponseRequest = {
-      model: "claude-opus-5",
+      model: "grok-4.5",
       instructions: "Use ToolSearch before calling a deferred Fleet tool.",
       input: [{ type: "message", role: "user", content: "Read a Fleet Wiki entry." }],
       tools: [
@@ -1242,7 +1242,7 @@ describe("Cursor live client-tool Run bridge", () => {
       cursorCompletionFrames("credential B cold fallback"),
     );
     const harness = cursorHarness([credentialARun, credentialBRun]);
-    const initial = cursorRequest("shared-credential-conversation", "kimi-k3-1m");
+    const initial = cursorRequest("shared-credential-conversation", "grok-4.5");
     const continuation = cursorContinuation(initial, [call], [cursorResult(call, "done")]);
 
     try {
@@ -1291,13 +1291,13 @@ describe("Cursor live client-tool Run bridge", () => {
     const harness = cursorHarness([credentialARun, credentialBRun], {
       diagnostics: (event) => diagnostics.push(event),
     });
-    const initial = cursorRequest("shared-prompt-conversation", "kimi-k3-1m");
+    const initial = cursorRequest("shared-prompt-conversation", "grok-4.5");
 
     try {
       await collectCursorResponse(harness.adapter, initial, credentialA);
       const credentialBEvents = await collectCursorResponse(harness.adapter, {
         ...initial,
-        model: "claude-opus-5",
+        model: "grok-4.5",
         input: [{ type: "message", role: "user", content: "Start another task." }],
       }, credentialB);
 
@@ -1324,9 +1324,9 @@ describe("Cursor live client-tool Run bridge", () => {
     const parked = new BridgeCursorStream(cursorToolFrames([call]));
     const separate = new BridgeCursorStream(cursorCompletionFrames("other conversation"));
     const harness = cursorHarness([parked, separate]);
-    const initial = cursorRequest("conversation-a", "kimi-k3-1m");
+    const initial = cursorRequest("conversation-a", "grok-4.5");
     const other = cursorContinuation(
-      cursorRequest("conversation-b", "kimi-k3-1m"),
+      cursorRequest("conversation-b", "grok-4.5"),
       [call],
       [cursorResult(call, "wrong conversation")],
     );
@@ -1349,7 +1349,7 @@ describe("Cursor live client-tool Run bridge", () => {
     );
     const fallback = new BridgeCursorStream(cursorCompletionFrames("duplicate fallback"));
     const harness = cursorHarness([parked, fallback]);
-    const initial = cursorRequest("session-atomic", "claude-fable-5");
+    const initial = cursorRequest("session-atomic", "composer-2.5-fast");
     const continuation = cursorContinuation(initial, [call], [cursorResult(call, "once")]);
 
     try {
@@ -1381,7 +1381,7 @@ describe("Cursor live client-tool Run bridge", () => {
 
     await collectCursorResponse(
       harness.adapter,
-      cursorRequest("session-expire", "kimi-k3-1m"),
+      cursorRequest("session-expire", "grok-4.5"),
     );
     await waitFor(() => parked.closed);
 
@@ -1401,8 +1401,8 @@ describe("Cursor live client-tool Run bridge", () => {
     const streamB = new BridgeCursorStream(cursorToolFrames([callB]));
     const harness = cursorHarness([streamA, streamB], { pendingLiveRunCapacity: 1 });
 
-    await collectCursorResponse(harness.adapter, cursorRequest("capacity-a", "kimi-k3-1m"));
-    await collectCursorResponse(harness.adapter, cursorRequest("capacity-b", "kimi-k3-1m"));
+    await collectCursorResponse(harness.adapter, cursorRequest("capacity-a", "grok-4.5"));
+    await collectCursorResponse(harness.adapter, cursorRequest("capacity-b", "grok-4.5"));
     expect(streamA.closed).toBe(true);
     expect(streamA.closeCode).toBe(http2.constants.NGHTTP2_CANCEL);
     expect(streamB.closed).toBe(false);
@@ -1429,8 +1429,8 @@ describe("Cursor live client-tool Run bridge", () => {
       pendingLiveRunCapacity: 1,
       diagnostics: (event) => diagnostics.push(event),
     });
-    const requestA = cursorRequest("capacity-owner", "kimi-k3-1m");
-    const requestB = cursorRequest("capacity-pressure", "kimi-k3-1m");
+    const requestA = cursorRequest("capacity-owner", "grok-4.5");
+    const requestB = cursorRequest("capacity-pressure", "grok-4.5");
 
     try {
       await collectCursorResponse(harness.adapter, requestA, credentialA);
@@ -1488,7 +1488,7 @@ describe("Cursor live client-tool Run bridge", () => {
     const stream = new BridgeCursorStream(cursorToolFrames([call]), [], 1);
     const harness = cursorHarness([stream]);
     const firstController = new AbortController();
-    const initial = cursorRequest("session-abort-segment", "kimi-k3-1m");
+    const initial = cursorRequest("session-abort-segment", "grok-4.5");
 
     await collectCursorResponse(
       harness.adapter,
@@ -1517,7 +1517,7 @@ describe("Cursor live client-tool Run bridge", () => {
     const harness = cursorHarness([stream]);
     const controller = new AbortController();
     const response = await harness.adapter.stream(
-      cursorRequest("session-abort-before", "kimi-k3-1m"),
+      cursorRequest("session-abort-before", "grok-4.5"),
       { apiKey: "cursor-test-token", signal: controller.signal },
     );
     const collecting = collectAdapterEvents(response);
@@ -1575,7 +1575,7 @@ describe("Cursor live client-tool Run bridge", () => {
     const parked = new BridgeCursorStream(cursorToolFrames([call]));
     const nextRun = new BridgeCursorStream(cursorCompletionFrames("new prompt complete"));
     const harness = cursorHarness([parked, nextRun]);
-    const initial = cursorRequest("session-new-prompt", "kimi-k3-1m");
+    const initial = cursorRequest("session-new-prompt", "grok-4.5");
 
     try {
       await collectCursorResponse(harness.adapter, initial);
@@ -1656,7 +1656,7 @@ describe("Cursor live client-tool Run bridge", () => {
       1,
     );
     const harness = cursorHarness([stream]);
-    const initial = cursorRequest("session-parked-tail", "claude-opus-5");
+    const initial = cursorRequest("session-parked-tail", "grok-4.5");
 
     try {
       await collectCursorResponse(harness.adapter, initial);
@@ -1681,7 +1681,7 @@ describe("Cursor live client-tool Run bridge", () => {
     const parked = new BridgeCursorStream(cursorToolFrames([call]));
     const fallback = new BridgeCursorStream(cursorCompletionFrames("cold fallback"));
     const harness = cursorHarness([parked, fallback]);
-    const initial = cursorRequest("session-runs-ahead", "claude-opus-5");
+    const initial = cursorRequest("session-runs-ahead", "grok-4.5");
 
     try {
       await collectCursorResponse(harness.adapter, initial);
@@ -1715,7 +1715,7 @@ describe("Cursor live client-tool Run bridge", () => {
     const harness = cursorHarness([stream], {
       diagnostics: (event) => diagnostics.push(event),
     });
-    const initial = cursorRequest("session-echo", "claude-opus-5");
+    const initial = cursorRequest("session-echo", "grok-4.5");
     const afterFirst = cursorContinuation(initial, [first], [cursorResult(first, "first result")]);
     const afterSecond: CanonicalResponseRequest = {
       ...afterFirst,
@@ -1757,7 +1757,7 @@ async function expectCorrelationBatchColdFallback(
   const rejected = new BridgeCursorStream(frames);
   const fallback = new BridgeCursorStream(cursorCompletionFrames("correlation cold fallback"));
   const harness = cursorHarness([rejected, fallback]);
-  const initial = cursorRequest(userId, "kimi-k3-1m");
+  const initial = cursorRequest(userId, "grok-4.5");
 
   try {
     await collectCursorResponse(harness.adapter, initial);

--- a/packages/core-ai-gateway/tests/cursor/native/tool-stream.test.ts
+++ b/packages/core-ai-gateway/tests/cursor/native/tool-stream.test.ts
@@ -238,21 +238,21 @@ describe("Cursor client tool suspension", () => {
 
     await runSyntheticCursorTurn(firstFrames, {
       ...request("claude-session-model-switch"),
-      model: "kimi-k3",
+      model: "grok-4.5",
       reasoning: { summary: "auto", effort: "low" },
     }, { diagnostics: (event) => diagnostics.push(event) });
     const second = await runSyntheticCursorTurn(secondFrames, {
       ...request("claude-session-model-switch"),
-      model: "kimi-k3",
+      model: "grok-4.5",
       reasoning: { summary: "auto", effort: "high" },
     }, { diagnostics: (event) => diagnostics.push(event) });
 
     expect(diagnostics.filter((event) => event.event === "model.switch")).toEqual([
       expect.objectContaining({
         event: "model.switch",
-        model: "kimi-k3",
-        previousWireModel: "kimi-k3-low",
-        wireModel: "kimi-k3-high",
+        model: "grok-4.5",
+        previousWireModel: "cursor-grok-4.5-low",
+        wireModel: "cursor-grok-4.5-high",
       }),
     ]);
     expect(completedCursorUsage(second.events).input_tokens).toBeLessThan(90_000);
@@ -1030,7 +1030,7 @@ describe("Cursor client tool suspension", () => {
       { interactionUpdate: { turnEnded: {} } },
     ], {
       ...request("SECRET_SESSION_ID"),
-      model: "claude-opus-5",
+      model: "grok-4.5",
       reasoning: { summary: "auto", effort: "xhigh" },
     }, {
       diagnostics: (event) => diagnostics.push(event),
@@ -1039,8 +1039,9 @@ describe("Cursor client tool suspension", () => {
     expect(events.at(-1)?.type).toBe("response.completed");
     expect(diagnostics).toContainEqual(expect.objectContaining({
       event: "turn.start",
-      model: "claude-opus-5",
-      wireModel: "claude-opus-5-thinking-xhigh",
+      model: "grok-4.5",
+      // Grok's ladder tops out at high, so xhigh clamps onto that wire suffix.
+      wireModel: "cursor-grok-4.5-high",
       requestedEffort: "xhigh",
       turn: "prompt",
       toolCount: 1,

--- a/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
@@ -71,7 +71,7 @@ describe("router lifecycle", () => {
         await router.handle(ctx({
           res: response(),
           token: ANTHROPIC_CRED,
-          model: "claude-gateway--cursor--kimi-k3",
+          model: "claude-gateway--cursor--grok-4.5[1m]",
         }));
       }
       expect(adapters).toHaveLength(2);
@@ -236,12 +236,12 @@ describe("upstream credential", () => {
     await router.handle(ctx({
       res: response(),
       token: ANTHROPIC_CRED,
-      model: "claude-gateway--cursor--kimi-k3",
+      model: "claude-gateway--cursor--grok-4.5[1m]",
       thinking: { type: "adaptive" },
       outputConfig: { effort: "medium" },
     }));
 
-    expect(canonical?.model).toBe("kimi-k3");
+    expect(canonical?.model).toBe("grok-4.5");
     expect(canonical?.reasoning).toEqual({ summary: "auto", effort: "medium" });
     expect(streamSpy.mock.calls[0]?.[1]).not.toHaveProperty("reasoningEfforts");
   });
@@ -362,7 +362,7 @@ describe("upstream credential", () => {
     await router.handle(ctx({
       res,
       token: ANTHROPIC_CRED,
-      model: "claude-gateway--cursor--kimi-k3-1m[1m]",
+      model: "claude-gateway--cursor--grok-4.5[1m]",
       metadata: null,
     }));
 
@@ -412,7 +412,7 @@ describe("model context window", () => {
     ["claude-gateway--cursor--grok-4.5-fast", 256_000, 256_000],
     // A 200000-window Cursor native model earns no `[1m]` marker, so it gets no
     // projection denominator — but the guard still needs its real window.
-    ["claude-gateway--cursor--kimi-k3", 200_000, undefined],
+    ["claude-gateway--cursor--composer-2.5", 200_000, undefined],
   ])("passes %s's real window as modelContextWindow", async (model, expected, projected) => {
     const gateway = stubGateway();
     const streamSpy = vi.spyOn(gateway, "stream");
@@ -1470,21 +1470,23 @@ describe("route surface", () => {
     const ids = list.data.map((entry) => entry.id);
     // picker가 버리지 않도록 모든 항목이 claude- alias로 나가야 한다.
     expect(ids.every((id) => id.startsWith("claude"))).toBe(true);
-    expect(list.data).toHaveLength(31);
+    expect(list.data).toHaveLength(24);
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast[1m]");
     expect(ids).toContain("claude-gateway--cursor--auto[1m]");
-    expect(ids).toContain("claude-gateway--cursor--gpt-5.6-sol[1m]");
-    expect(ids).toContain("claude-gateway--cursor--claude-opus-5-1m[1m]");
-    expect(ids).toContain("claude-gateway--cursor--claude-fable-5-1m[1m]");
-    expect(ids).toContain("claude-gateway--cursor--kimi-k3");
-    expect(ids).toContain("claude-gateway--cursor--kimi-k3-1m[1m]");
+    expect(ids).toContain("claude-gateway--cursor--composer-2.5");
+    expect(ids).toContain("claude-gateway--cursor--composer-2.5-fast");
+    expect(ids).toContain("claude-gateway--cursor--grok-4.5[1m]");
+    expect(ids).toContain("claude-gateway--cursor--grok-4.5-fast[1m]");
+    expect(ids).not.toContain("claude-gateway--cursor--gpt-5.6-sol[1m]");
+    expect(ids).not.toContain("claude-gateway--cursor--claude-opus-5-1m[1m]");
+    expect(ids).not.toContain("claude-gateway--cursor--kimi-k3");
     expect(ids).toContain("claude-gateway--kimi--k3[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3-256k");
     expect(ids).toContain("claude-gateway--opencode--minimax-m3[1m]");
     expect(ids.some((id) => id.includes("--codex--") && id.endsWith("[1m]"))).toBe(true);
     expect(list.data).toContainEqual(expect.objectContaining({
-      id: "claude-gateway--cursor--kimi-k3-1m[1m]",
-      display_name: "Cursor-Kimi-K3-1M (1M Context)",
+      id: "claude-gateway--cursor--grok-4.5[1m]",
+      display_name: "Cursor-Grok-4.5",
     }));
     expect(list.data).toContainEqual(expect.objectContaining({
       id: "claude-gateway--kimi--k3[1m]",
@@ -1500,9 +1502,9 @@ describe("route surface", () => {
       readAiGatewaySettings: aiGatewaySettingsStub({
         version: 1,
         models: [
-          { id: "cursor--claude-opus-5" },
-          // Cursor 경유 Kimi와 Kimi 프로바이더는 별개 경로 — 동시 노출을 보존한다.
-          { id: "cursor--kimi-k3-1m" },
+          { id: "cursor--grok-4.5" },
+          // Cursor composer와 Kimi 프로바이더는 별개 경로 — 동시 노출을 보존한다.
+          { id: "cursor--composer-2.5" },
           { id: "kimi--k3-256k" },
           { id: "kimi--no-longer-in-catalog" },
         ],
@@ -1514,8 +1516,8 @@ describe("route surface", () => {
     expect(res.status).toBe(200);
     const list = JSON.parse(res.body) as { data: Array<{ id: string }> };
     expect(list.data.map((entry) => entry.id)).toEqual([
-      "claude-gateway--cursor--claude-opus-5[1m]",
-      "claude-gateway--cursor--kimi-k3-1m[1m]",
+      "claude-gateway--cursor--composer-2.5",
+      "claude-gateway--cursor--grok-4.5[1m]",
       "claude-gateway--kimi--k3-256k",
     ]);
   });

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -593,7 +593,7 @@ describe("model catalog", () => {
     expect(identityOf("codex--gpt-5.6-sol-fast")).toBe(identityOf("codex--gpt-5.6-sol"));
     expect(identityOf("codex--gpt-5.6-terra-fast")).toBe(identityOf("codex--gpt-5.6-terra"));
     // Same vendor name, different transport and upstream — these stay separate.
-    expect(identityOf("cursor--kimi-k3")).not.toBe(identityOf("kimi--k3"));
+    expect(identityOf("opencode--grok-4.5")).not.toBe(identityOf("cursor--grok-4.5"));
     expect(identityOf("cursor--grok-4.5-fast")).not.toBe(identityOf("cursor--grok-4.5"));
   });
 
@@ -624,8 +624,8 @@ describe("model catalog", () => {
     expect(constraintsFor("cursor--auto")).toMatchObject({ effortLadder: [], effortSupported: false });
     // Same lineage as a Claude session's own model: useful for moving spend,
     // worthless for a panel that needs independent judgement.
-    expect(constraintsFor("cursor--claude-opus-5").homolineage).toBe(true);
     expect(constraintsFor("cursor--grok-4.5").homolineage).toBe(false);
+    expect(constraintsFor("cursor--composer-2.5").homolineage).toBe(false);
     expect(constraintsFor("kimi--k3").homolineage).toBe(false);
   });
 
@@ -694,9 +694,7 @@ describe("model catalog", () => {
     expect(fast?.benchmark).toEqual(base?.benchmark);
     expect(base?.benchmark?.source).toBe("CursorBench 3.2");
 
-    const cursorKimi = findGatewayModel("cursor--kimi-k3");
     const moonshotKimi = findGatewayModel("kimi--k3");
-    expect(cursorKimi?.benchmark?.rungs && Object.keys(cursorKimi.benchmark.rungs).sort()).toEqual(["high", "low"]);
     expect(moonshotKimi?.benchmark?.rungs && Object.keys(moonshotKimi.benchmark.rungs).sort()).toEqual(["high", "low", "max"]);
 
     // CursorBench가 측정하지 않은 모델은 벤치 항목 없이 class 폴백으로만 판정된다 —
@@ -788,14 +786,14 @@ describe("model catalog", () => {
       modelId: "codex-model",
       name: "Model",
       capabilityClass: "standard",
-      benchmarkKey: "claude-fable-5",
+      benchmarkKey: "gpt-5.6-sol",
     };
     expect(() => validateBenchmarkCoverage(parseGatewayModelsRegistry(orphanBench))).toThrow(/benchmark entry is orphaned/);
   });
 
   it("contains only the approved latest provider families", () => {
     expect(CODEX_SUBSCRIPTION_MODELS).toHaveLength(6);
-    expect(CURSOR_SUBSCRIPTION_MODELS).toHaveLength(12);
+    expect(CURSOR_SUBSCRIPTION_MODELS).toHaveLength(5);
     expect(KIMI_SUBSCRIPTION_MODELS).toHaveLength(2);
     expect(OPENCODE_SUBSCRIPTION_MODELS).toHaveLength(11);
     expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.upstreamId?.startsWith("gpt-5.6-"))).toBe(true);
@@ -806,39 +804,17 @@ describe("model catalog", () => {
       "composer-2.5-fast",
       "grok-4.5",
       "grok-4.5-fast",
-      "gpt-5.6-sol",
-      "claude-opus-5",
-      "claude-opus-5-1m",
-      "claude-fable-5",
-      "claude-fable-5-1m",
-      "kimi-k3-max",
-      "kimi-k3",
     ]);
     expect(Object.fromEntries(CURSOR_SUBSCRIPTION_MODELS.map((model) => [
       model.upstreamId,
       model.contextWindow,
     ]))).toEqual({
-      "claude-opus-5": 300_000,
-      "claude-opus-5-1m": 1_000_000,
-      "claude-fable-5": 300_000,
-      "claude-fable-5-1m": 1_000_000,
-      "gpt-5.6-sol": 272_000,
       "composer-2.5": 200_000,
       "composer-2.5-fast": 200_000,
       "grok-4.5": 256_000,
       "grok-4.5-fast": 256_000,
-      "kimi-k3-max": 1_048_576,
-      "kimi-k3": 200_000,
       default: 256_000,
     });
-    for (const id of [
-      "cursor--claude-opus-5-1m",
-      "cursor--claude-fable-5-1m",
-      "cursor--kimi-k3-1m",
-    ]) {
-      expect(CURSOR_SUBSCRIPTION_MODELS.find((model) => model.id === id))
-        .toMatchObject({ cursorMaxMode: true });
-    }
     expect(KIMI_SUBSCRIPTION_MODELS.map((model) => model.upstreamId)).toEqual(["k3", "k3-256k"]);
     // OpenCode Go의 서비스 가능 전 모델(2026-08-03 라이브 프로브). wire 미선언 =
     // Anthropic passthrough, 그 외에는 선언된 네이티브 wire의 번역 경로를 탄다.
@@ -883,43 +859,24 @@ describe("model catalog", () => {
       supported: true,
       levels: ["low", "high", "max"],
     });
-    expect(efforts["cursor--kimi-k3"]).toEqual({
+    expect(efforts["cursor--grok-4.5"]).toEqual({
       supported: true,
-      levels: ["low", "high"],
-      upstreamModelIdTemplate: "kimi-k3-{effort}",
+      levels: ["low", "medium", "high"],
+      upstreamModelIdTemplate: "cursor-grok-4.5-{effort}",
     });
-    expect(efforts["cursor--kimi-k3-1m"]).toEqual({ supported: false });
-    expect(efforts["cursor--claude-opus-5"]).toEqual({
+    expect(efforts["cursor--grok-4.5-fast"]).toEqual({
       supported: true,
-      levels: ["low", "medium", "high", "xhigh", "max"],
-      upstreamModelIdTemplate: "claude-opus-5-{effort}",
-      upstreamModelIds: {
-        xhigh: "claude-opus-5-thinking-xhigh",
-        max: "claude-opus-5-thinking-max",
-      },
+      levels: ["low", "medium", "high"],
+      upstreamModelIdTemplate: "cursor-grok-4.5-{effort}-fast",
     });
-    expect(efforts["cursor--claude-opus-5-1m"]).toEqual(efforts["cursor--claude-opus-5"]);
-    expect(efforts["cursor--claude-fable-5"]).toEqual({
-      supported: true,
-      levels: ["low", "medium", "high", "xhigh", "max"],
-      upstreamModelIdTemplate: "claude-fable-5-{effort}",
-    });
-    expect(efforts["cursor--claude-fable-5-1m"]).toEqual(efforts["cursor--claude-fable-5"]);
     expect(efforts["cursor--auto"]).toEqual({ supported: false });
+    expect(efforts["cursor--composer-2.5"]).toEqual({ supported: false });
   });
 
   it.each([
-    ["kimi-k3", "medium", "kimi-k3-low"],
-    ["kimi-k3", "xhigh", "kimi-k3-high"],
-    ["kimi-k3", undefined, "kimi-k3-high"],
-    ["kimi-k3-1m", "low", "kimi-k3-max"],
-    ["claude-opus-5", "high", "claude-opus-5-high"],
-    ["claude-opus-5", "xhigh", "claude-opus-5-thinking-xhigh"],
-    ["claude-opus-5", "max", "claude-opus-5-thinking-max"],
-    ["claude-opus-5-1m", "high", "claude-opus-5-high"],
-    ["claude-opus-5-1m", "xhigh", "claude-opus-5-thinking-xhigh"],
-    ["claude-opus-5-1m", "max", "claude-opus-5-thinking-max"],
-    ["claude-fable-5-1m", "high", "claude-fable-5-high"],
+    ["grok-4.5", "low", "cursor-grok-4.5-low"],
+    ["grok-4.5", "medium", "cursor-grok-4.5-medium"],
+    ["grok-4.5", undefined, "cursor-grok-4.5-high"],
     ["grok-4.5-fast", "low", "cursor-grok-4.5-low-fast"],
     ["composer-2.5", "high", "composer-2.5"],
     ["unknown-model", "high", "unknown-model"],
@@ -929,7 +886,7 @@ describe("model catalog", () => {
 
   it("never raises a requested effort while clamping a sparse ladder", () => {
     expect(clampReasoningEffort("xhigh", ["low", "medium", "high", "max"])).toBe("high");
-    expect(resolveCursorUpstreamModelId("kimi-k3", "medium")).toBe("kimi-k3-low");
+    expect(resolveCursorUpstreamModelId("grok-4.5", "medium")).toBe("cursor-grok-4.5-medium");
   });
 
   it("resolves a compatibility alias to its provider wire id", () => {
@@ -975,17 +932,13 @@ describe("model catalog", () => {
     });
     expect(list.data.some((entry) => entry.id.includes("--codex--") && entry.id.endsWith("[1m]")))
       .toBe(true);
-    expect(list.data.find((entry) => entry.id.endsWith("cursor--claude-opus-5-1m[1m]"))).toMatchObject({
-      display_name: "Cursor-Opus-5-1M (1M Context)",
-      max_input_tokens: 1_000_000,
+    expect(list.data.find((entry) => entry.id.endsWith("cursor--grok-4.5[1m]"))).toMatchObject({
+      display_name: "Cursor-Grok-4.5",
+      max_input_tokens: 256_000,
     });
-    expect(list.data.find((entry) => entry.id.endsWith("cursor--claude-fable-5-1m[1m]"))).toMatchObject({
-      display_name: "Cursor-Fable-5-1M (1M Context)",
-      max_input_tokens: 1_000_000,
-    });
-    expect(list.data.find((entry) => entry.id.endsWith("cursor--kimi-k3-1m[1m]"))).toMatchObject({
-      display_name: "Cursor-Kimi-K3-1M (1M Context)",
-      max_input_tokens: 1_048_576,
+    expect(list.data.find((entry) => entry.id.endsWith("cursor--composer-2.5"))).toMatchObject({
+      display_name: "Cursor-Composer-2.5",
+      max_input_tokens: 200_000,
     });
     expect(list.data.find((entry) => entry.id === "claude-gateway--kimi--k3[1m]")).toMatchObject({
       display_name: "Moonshot-Kimi-K3-1M (1M Context)",
@@ -1035,8 +988,7 @@ describe("model catalog", () => {
     const luna = entries.get("claude-gateway--codex--gpt-5.6-luna[1m]");
     const kimi = entries.get("claude-gateway--kimi--k3[1m]");
     const cursor = entries.get("claude-gateway--cursor--auto[1m]");
-    const cursorKimi = entries.get("claude-gateway--cursor--kimi-k3");
-    const cursorKimi1m = entries.get("claude-gateway--cursor--kimi-k3-1m[1m]");
+    const cursorGrok = entries.get("claude-gateway--cursor--grok-4.5[1m]");
     const cursorComposer = entries.get("claude-gateway--cursor--composer-2.5-fast");
 
     expect(sol?.capabilities.effort).toEqual({
@@ -1067,15 +1019,14 @@ describe("model catalog", () => {
     });
     expect(cursor?.capabilities.thinking.supported).toBe(false);
     expect(cursorComposer?.max_input_tokens).toBe(200_000);
-    expect(cursorKimi?.capabilities.effort).toEqual({
+    expect(cursorGrok?.capabilities.effort).toEqual({
       supported: true,
       low: { supported: true },
-      medium: { supported: false },
+      medium: { supported: true },
       high: { supported: true },
       max: { supported: false },
       xhigh: { supported: false },
     });
-    expect(cursorKimi1m?.capabilities.effort).toEqual(cursor?.capabilities.effort);
   });
 
   it("unwraps the alias a picked model comes back as", () => {
@@ -1107,28 +1058,18 @@ describe("model catalog", () => {
       id: "codex--gpt-5.6-luna",
     });
     expect(findGatewayModel("claude-gateway--kimi--k3")).toMatchObject({ id: "kimi--k3" });
-    expect(findGatewayModel("claude-gateway--cursor--claude-opus-5-1m[1m]")).toMatchObject({
-      id: "cursor--claude-opus-5-1m",
-      upstreamId: "claude-opus-5-1m",
-      contextWindow: 1_000_000,
-      cursorMaxMode: true,
+    expect(findGatewayModel("claude-gateway--cursor--grok-4.5[1m]")).toMatchObject({
+      id: "cursor--grok-4.5",
+      upstreamId: "grok-4.5",
+      contextWindow: 256_000,
     });
-    expect(findGatewayModel("claude-gateway--cursor--claude-fable-5-1m[1m]")).toMatchObject({
-      id: "cursor--claude-fable-5-1m",
-      upstreamId: "claude-fable-5-1m",
-      contextWindow: 1_000_000,
-      cursorMaxMode: true,
+    expect(findGatewayModel("claude-gateway--cursor--composer-2.5")).toMatchObject({
+      id: "cursor--composer-2.5",
+      upstreamId: "composer-2.5",
+      contextWindow: 200_000,
     });
-    expect(findGatewayModel("claude-gateway--cursor--kimi-k3-1m[1m]")).toMatchObject({
-      id: "cursor--kimi-k3-1m",
-      upstreamId: "kimi-k3-max",
-      cursorMaxMode: true,
-    });
-    expect(findGatewayModel("claude-gateway--cursor--kimi-k3")).toMatchObject({
-      id: "cursor--kimi-k3",
-      upstreamId: "kimi-k3",
-    });
-    expect(findGatewayModel("claude-gateway--cursor--kimi-k3[1m]")).toBeUndefined();
+    expect(findGatewayModel("claude-gateway--cursor--claude-opus-5-1m[1m]")).toBeUndefined();
+    expect(findGatewayModel("claude-gateway--cursor--kimi-k3")).toBeUndefined();
     expect(findGatewayModel("claude-gateway--cursor--glm-5.2[1m]")).toBeUndefined();
     expect(findGatewayModel("claude-gateway--k3[1m]")).toBeUndefined();
     expect(findGatewayModel("k3[1m]")).toBeUndefined();

--- a/packages/core-ai-gateway/tests/settings/index.test.ts
+++ b/packages/core-ai-gateway/tests/settings/index.test.ts
@@ -127,9 +127,9 @@ describe("ai-gateway settings", () => {
   it("resolves stale ids out of the exposed selection", () => {
     const selection = resolveAiGatewaySelection({
       version: 1,
-      models: [{ id: "cursor--claude-opus-5" }, { id: "cursor--retired-model" }],
+      models: [{ id: "cursor--grok-4.5" }, { id: "cursor--claude-opus-5" }],
     });
-    expect(selection.models.map((model) => model.id)).toEqual(["cursor--claude-opus-5"]);
+    expect(selection.models.map((model) => model.id)).toEqual(["cursor--grok-4.5"]);
   });
 
   it("keeps host-only models on the wire while provider-sorting the delegation subset", () => {

--- a/packages/core-ai-gateway/tests/settings/store.test.ts
+++ b/packages/core-ai-gateway/tests/settings/store.test.ts
@@ -48,10 +48,10 @@ describe("ai-gateway settings store", () => {
     // 읽기만으로는 파일이 생기지 않는다 — 미구성과 "빈 설정을 저장함"은 다른 상태다.
     expect(existsSync(store.path)).toBe(false);
 
-    store.write({ models: [{ id: "cursor--claude-opus-5" }] });
+    store.write({ models: [{ id: "cursor--grok-4.5" }] });
     expect(JSON.parse(readFileSync(store.path, "utf-8"))).toEqual({
       version: 1,
-      models: [{ id: "cursor--claude-opus-5" }],
+      models: [{ id: "cursor--grok-4.5" }],
     });
   });
 
@@ -75,11 +75,11 @@ describe("ai-gateway settings store", () => {
   it("keeps each setting axis independent across writes", () => {
     const store = createAiGatewaySettingsStore({ dataDir: createDataDir() });
 
-    store.write({ models: [{ id: "cursor--claude-opus-5" }] });
+    store.write({ models: [{ id: "cursor--grok-4.5" }] });
     store.writeCursorDiagnosticsEnabled(true);
     expect(store.read()).toEqual({
       version: 1,
-      models: [{ id: "cursor--claude-opus-5" }],
+      models: [{ id: "cursor--grok-4.5" }],
       cursorDiagnosticsEnabled: true,
     });
     store.write({ models: [{ id: "cursor--auto" }] });

--- a/packages/core-infra/tests/data-dir-settings-store.test.ts
+++ b/packages/core-infra/tests/data-dir-settings-store.test.ts
@@ -170,7 +170,7 @@ describe("data-dir settings store", () => {
     // AI Gateway 선별은 core-ai-gateway가 소유하는 별도 파일(`<dataDir>/ai-gateway.json`)로 이전됐다.
     expect(sanitizeGlobalOptionsData({
       version: 1,
-      aiGateway: { models: [{ id: "cursor--claude-opus-5" }] },
+      aiGateway: { models: [{ id: "cursor--grok-4.5" }] },
     })).toEqual({
       changed: true,
       data: { version: 1, claudeGatewaySystemPromptMode: "append" },

--- a/packages/fleet-admiral/src/agent-cli/gateway-agents.ts
+++ b/packages/fleet-admiral/src/agent-cli/gateway-agents.ts
@@ -183,7 +183,7 @@ export function toGatewayAgentSelector(modelId: string, effort?: GatewayReasonin
 
 /**
  * Agent 파일 이름과 frontmatter `name`에 쓰는 stem.
- * `claude-gateway--cursor--claude-opus-5[1m]` + `high` → `cursor-claude-opus-5-1m-high`
+ * `claude-gateway--cursor--grok-4.5[1m]` + `high` → `cursor-grok-4-5-1m-high`
  */
 export function toGatewayAgentName(modelId: string, effort?: GatewayReasoningEffort): string {
   const stripped = modelId.startsWith("claude-gateway--")

--- a/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
@@ -85,7 +85,7 @@ describe("claude-gateway custom agents", () => {
   });
 
   it("expands exposed models into claude-gateway-- agents with GP prompt", () => {
-    const model = requireGatewayModel("cursor--claude-opus-5");
+    const model = requireGatewayModel("cursor--grok-4.5");
     const agents = buildGatewayCustomAgents([model]);
     const names = Object.keys(agents);
     expect(names.length).toBeGreaterThan(0);
@@ -113,7 +113,7 @@ describe("claude-gateway custom agents", () => {
   });
 
   it("builds identities only for the models the caller provides", () => {
-    const included = requireGatewayModel("cursor--claude-opus-5");
+    const included = requireGatewayModel("cursor--grok-4.5");
     const omittedModelId = "claude-gateway--opencode--deepseek-v4-flash";
 
     const agents = buildGatewayCustomAgents([included]);
@@ -164,7 +164,7 @@ describe("claude-gateway custom agents", () => {
 
   it("registers gateway identities as plugin agent files, and never disables a built-in agent", async () => {
     const root = createTempRoot("fleet-admiral-gateway-agents-");
-    const model = requireGatewayModel("cursor--claude-opus-5");
+    const model = requireGatewayModel("cursor--grok-4.5");
     const gateway = baseProfile("claude-gateway", {
       args: [],
       cwd: root,
@@ -265,7 +265,7 @@ describe("claude-gateway system prompt mode", () => {
   it("composes append, replace, and off without disabling gateway assets", async () => {
     const root = createTempRoot("fleet-admiral-gateway-system-prompt-");
     const profile = baseProfile("claude-gateway", { args: [], cwd: root, env: { HOME: root } });
-    const model = requireGatewayModel("cursor--claude-opus-5");
+    const model = requireGatewayModel("cursor--grok-4.5");
     let builtPrompts = 0;
     const hook: FleetHookExec = { command: process.execPath, args: ["hook"] };
     const options = (systemPromptMode: "append" | "replace" | "off") => ({

--- a/packages/fleet-admiral/tests/ai-gateway-model-loadout.test.ts
+++ b/packages/fleet-admiral/tests/ai-gateway-model-loadout.test.ts
@@ -38,7 +38,7 @@ describe("gateway loadout agent type selectors", () => {
   // 로스터는 호스트가 매 run 직전에 읽는 유일한 권위다. 여기에 이름이 없으면 호스트는
   // 이름을 요구하는 자리에 넣을 값을 회수할 방법이 없어 모델 id를 넣고 실패한다.
   it("keys selectors by the model's own ladder and matches the registered agents", () => {
-    const exposed = [model("cursor--claude-opus-5"), model("opencode--deepseek-v4-pro")];
+    const exposed = [model("cursor--grok-4.5"), model("opencode--deepseek-v4-pro")];
     const registered = registeredSelectors(exposed);
     const loadout = buildGatewayLoadout({ exposed });
 

--- a/packages/fleet-admiral/tests/native-claude-model-alias.test.ts
+++ b/packages/fleet-admiral/tests/native-claude-model-alias.test.ts
@@ -20,6 +20,6 @@ describe("resolveNativeClaudeModelAlias", () => {
 
   it("rejects unrecognized aliases", () => {
     expect(resolveNativeClaudeModelAlias("haiku")).toBeUndefined();
-    expect(resolveNativeClaudeModelAlias("cursor--claude-opus-5")).toBeUndefined();
+    expect(resolveNativeClaudeModelAlias("cursor--grok-4.5")).toBeUndefined();
   });
 });

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -166,7 +166,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
     const root = makeTempDir("fleet-gateway-launch-variant-");
     const settings = {
       version: 1 as const,
-      models: [{ id: "cursor--claude-opus-5" }],
+      models: [{ id: "cursor--grok-4.5" }],
     };
     const resolve = createDefaultTerminalLaunchResolver({
       cwd: root,
@@ -195,26 +195,26 @@ describe("createDefaultTerminalLaunchResolver", () => {
     });
     const scoped = await resolve(root, {
       cliId: "claude-gateway",
-      model: "cursor--claude-opus-5",
-      effort: "xhigh",
+      model: "cursor--grok-4.5",
+      effort: "high",
       sessionId: "gateway-scoped-variant",
     });
     const rowOnly = await resolve(root, {
       cliId: "claude-gateway",
-      model: "cursor--claude-opus-5",
+      model: "cursor--grok-4.5",
       sessionId: "gateway-scoped-row",
     });
 
     expect(native.args).toEqual(["--model", "fable[1m]", "--effort", "max"]);
     expect(scoped.args).toEqual([
       "--model",
-      "claude-gateway--cursor--claude-opus-5[1m]",
+      "claude-gateway--cursor--grok-4.5[1m]",
       "--effort",
-      "xhigh",
+      "high",
     ]);
     expect(rowOnly.args).toEqual([
       "--model",
-      "claude-gateway--cursor--claude-opus-5[1m]",
+      "claude-gateway--cursor--grok-4.5[1m]",
     ]);
     expect(rowOnly.args).not.toContain("--effort");
     for (const spec of [native, scoped, rowOnly]) {
@@ -233,7 +233,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
     const settings = {
       version: 1 as const,
       models: [
-        { id: "cursor--claude-opus-5", hostOnly: true },
+        { id: "cursor--auto", hostOnly: true },
         { id: "cursor--grok-4.5" },
       ],
     };
@@ -262,12 +262,12 @@ describe("createDefaultTerminalLaunchResolver", () => {
 
     const spec = await resolve(root, {
       cliId: "claude-gateway",
-      model: "cursor--claude-opus-5",
+      model: "cursor--auto",
       sessionId: "gateway-host-only",
     });
 
     // 호스트 세션 쪽: 여전히 고를 수 있고, --model args로 배선된다.
-    expect(spec.args).toEqual(["--model", "claude-gateway--cursor--claude-opus-5[1m]"]);
+    expect(spec.args).toEqual(["--model", "claude-gateway--cursor--auto[1m]"]);
     expect(spec.env.ANTHROPIC_MODEL).toBeUndefined();
     // 위임 쪽: 정체성을 만들 목록에서만 빠진다.
     const delegable = (injected?.gatewayDelegationModels ?? []).map((model) => model.id);
@@ -640,20 +640,21 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(cache.baseUrl).toBe(spec.env.ANTHROPIC_BASE_URL);
     expect(cache.fetchedAt).toEqual(expect.any(Number));
     // core-ai-gateway의 GATEWAY_MODELS 전량이 prewrite되어야 한다 — 카탈로그가 바뀌면 이 수도 함께 맞춘다.
-    expect(cache.models).toHaveLength(31);
+    expect(cache.models).toHaveLength(24);
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast[1m]");
     expect(ids).toContain("claude-gateway--cursor--auto[1m]");
-    expect(ids).toContain("claude-gateway--cursor--claude-opus-5-1m[1m]");
-    expect(ids).toContain("claude-gateway--cursor--claude-fable-5-1m[1m]");
-    expect(ids).toContain("claude-gateway--cursor--kimi-k3");
-    expect(ids).toContain("claude-gateway--cursor--kimi-k3-1m[1m]");
+    expect(ids).toContain("claude-gateway--cursor--composer-2.5");
+    expect(ids).toContain("claude-gateway--cursor--grok-4.5[1m]");
+    expect(ids).toContain("claude-gateway--cursor--grok-4.5-fast[1m]");
+    expect(ids).not.toContain("claude-gateway--cursor--claude-opus-5-1m[1m]");
+    expect(ids).not.toContain("claude-gateway--cursor--kimi-k3");
     expect(ids).not.toContain("claude-gateway--cursor--gpt-5.6-luna[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3-256k");
     expect(ids.some((id) => id.includes("--codex--") && id.endsWith("[1m]"))).toBe(true);
     expect(cache.models).toContainEqual(expect.objectContaining({
-      id: "claude-gateway--cursor--kimi-k3-1m[1m]",
-      display_name: "Cursor-Kimi-K3-1M (1M Context)",
+      id: "claude-gateway--cursor--grok-4.5[1m]",
+      display_name: "Cursor-Grok-4.5",
     }));
     expect(cache.models).toContainEqual(expect.objectContaining({
       id: "claude-gateway--kimi--k3[1m]",

--- a/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/settings-routes.test.ts
@@ -48,16 +48,22 @@ describe("terminal settings routes", () => {
     const providers = body.aiGatewayCatalog.providers;
     expect(providers.map((provider) => provider.id)).toEqual(["codex", "cursor", "kimi", "opencode"]);
     const allIds = providers.flatMap((provider) => provider.models.map((model) => model.id));
-    // Cursor 경유 Kimi와 Kimi 프로바이더는 다른 경로다 — 둘 다 노출한다.
+    // Cursor는 auto/composer/grok만 지원하고, Kimi 프로바이더는 별개 경로로 그대로 노출한다.
     expect(allIds).toContain("kimi--k3");
     for (const id of [
-      "cursor--claude-opus-5-1m",
-      "cursor--claude-fable-5-1m",
-      "cursor--kimi-k3-1m",
+      "cursor--auto",
+      "cursor--composer-2.5",
+      "cursor--composer-2.5-fast",
+      "cursor--grok-4.5",
+      "cursor--grok-4.5-fast",
     ]) {
       expect(allIds).toContain(id);
-      expect(providers[1]?.models.find((model) => model.id === id)?.maxMode).toBe(true);
     }
+    expect(allIds).not.toContain("cursor--claude-opus-5-1m");
+    expect(allIds).not.toContain("cursor--claude-fable-5-1m");
+    expect(allIds).not.toContain("cursor--kimi-k3-1m");
+    // 남은 Cursor 라인업에는 Max Mode 경로가 없다 — 제거된 1M Max Mode 모델을 되살리지 않는다.
+    expect(providers[1]?.models.every((model) => model.maxMode === false)).toBe(true);
     const fastIds = allIds.filter((id) => id.endsWith("-fast"));
     expect(fastIds.length).toBeGreaterThan(0);
     // 등급은 이 응답으로만 브라우저에 닿는다 — 투영에서 잘리면 로스터 배지가 사라진다.
@@ -195,7 +201,7 @@ describe("terminal settings routes", () => {
       body: {
         aiGateway: {
           models: [
-            { id: "cursor--claude-opus-5" },
+            { id: "cursor--grok-4.5" },
             { id: "kimi--k3-256k" },
           ],
         },
@@ -207,7 +213,7 @@ describe("terminal settings routes", () => {
     expect(harness.writes[0]?.body).toMatchObject({
       aiGateway: {
         models: [
-          { id: "cursor--claude-opus-5" },
+          { id: "cursor--grok-4.5" },
           { id: "kimi--k3-256k" },
         ],
       },
@@ -216,7 +222,7 @@ describe("terminal settings routes", () => {
     expect(harness.currentAiGateway()).toEqual({
       version: 1,
       models: [
-        { id: "cursor--claude-opus-5" },
+        { id: "cursor--grok-4.5" },
         { id: "kimi--k3-256k" },
       ],
     });
@@ -293,7 +299,7 @@ describe("terminal settings routes", () => {
         aiGateway: {
           models: [
             { id: "cursor--auto", hostOnly: true },
-            { id: "cursor--claude-opus-5", efforts: ["high"] },
+            { id: "cursor--grok-4.5", efforts: ["high"] },
           ],
         },
       },
@@ -301,7 +307,7 @@ describe("terminal settings routes", () => {
         version: 1,
         models: [
           { id: "cursor--auto", hostOnly: true },
-          { id: "cursor--claude-opus-5", efforts: ["high"] },
+          { id: "cursor--grok-4.5", efforts: ["high"] },
         ],
       },
     });
@@ -311,7 +317,7 @@ describe("terminal settings routes", () => {
       aiGateway: {
         models: [
           { id: "cursor--auto", hostOnly: true },
-          { id: "cursor--claude-opus-5" },
+          { id: "cursor--grok-4.5" },
         ],
       },
     });
@@ -319,7 +325,7 @@ describe("terminal settings routes", () => {
       version: 1,
       models: [
         { id: "cursor--auto", hostOnly: true },
-        { id: "cursor--claude-opus-5", efforts: ["high"] },
+        { id: "cursor--grok-4.5", efforts: ["high"] },
       ],
     });
   });
@@ -401,7 +407,7 @@ describe("terminal settings routes", () => {
       body: { cursorDiagnosticsEnabled: true },
       aiGateway: {
         version: 1,
-        models: [{ id: "cursor--claude-opus-5" }],
+        models: [{ id: "cursor--grok-4.5" }],
       },
     });
     await harness.handle({ req: jsonReq("PUT"), res: res(), pathname: "/plugins/terminal/settings" });
@@ -411,13 +417,13 @@ describe("terminal settings routes", () => {
       body: {
         cursorDiagnosticsEnabled: true,
         aiGateway: {
-          models: [{ id: "cursor--claude-opus-5" }],
+          models: [{ id: "cursor--grok-4.5" }],
         },
       },
     });
     expect(harness.currentAiGateway()).toEqual({
       version: 1,
-      models: [{ id: "cursor--claude-opus-5" }],
+      models: [{ id: "cursor--grok-4.5" }],
       cursorDiagnosticsEnabled: true,
     });
   });
@@ -504,8 +510,8 @@ describe("terminal settings routes", () => {
     for (const aiGateway of [
       { models: [{ id: "cursor--no-such-model" }] },
       // 모델별 effort는 폐기된 계약 — 잔존 필드는 거부한다.
-      { models: [{ id: "cursor--claude-opus-5", effort: "max" }] },
-      { models: [{ id: "cursor--claude-opus-5" }, { id: "cursor--claude-opus-5" }] },
+      { models: [{ id: "cursor--grok-4.5", effort: "max" }] },
+      { models: [{ id: "cursor--grok-4.5" }, { id: "cursor--grok-4.5" }] },
       { models: "all" },
       { extra: true },
       [],

--- a/runtime/fleet-plugins/terminal/tests/system-prompt-settings-api.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/system-prompt-settings-api.test.ts
@@ -9,15 +9,15 @@ const CATALOG = {
       id: "cursor",
       models: [
         {
-          id: "cursor--claude-opus-5",
-          name: "Opus-5",
-          contextWindow: 300000,
+          id: "cursor--grok-4.5",
+          name: "Grok-4.5",
+          contextWindow: 256000,
           oneMillion: true,
           maxMode: false,
           fast: false,
           capabilityClass: "flagship",
           description: null,
-          effort: { levels: ["low", "medium", "high", "xhigh", "max"] },
+          effort: { levels: ["low", "medium", "high"] },
         },
       ],
     },
@@ -159,7 +159,7 @@ describe("system prompt settings api", () => {
 
   it("saves the aiGateway selection to the plugin route", async () => {
     const aiGateway = {
-      models: [{ id: "cursor--claude-opus-5" }],
+      models: [{ id: "cursor--grok-4.5" }],
     };
     const fetchMock = vi.fn(async () => jsonResponse({
       agentIdleDormantMinutes: 60,


### PR DESCRIPTION
## Summary
- Cursor AI Gateway 카탈로그에서 미지원 모델(Claude/GPT/Kimi)을 제거하고 Auto·Composer 2.5·Grok 4.5(및 fast)만 남깁니다.
- discovery·설정·런처 픽커와 관련 테스트/벤치마크를 유지 모델 기준으로 정렬합니다.
- 사용자에게 보이는 카탈로그 축소이므로 `.changelog.d/cursor-provider-trim.md`를 함께 둡니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` (578 passed)
- [x] `pnpm --filter @dotobokuri/fleet-admiral --filter @dotobokuri/core-infra test`
- [x] `pnpm --filter @fleet-plugins/terminal test` (535 passed; gateway dist rebuild 후)
- [x] `runtime/fleet-console/tests/launch.test.ts` (26 passed)
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] 격리 콘솔 `serve` → `/console/operations` 200