### PR TITLE
fix(core-ai-gateway): retry transient Codex provider errors

### DIFF
--- a/packages/core-ai-gateway/src/codex/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/codex/responses/adapter.ts
@@ -37,7 +37,7 @@ export const OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses";
 export const CHATGPT_CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
 export const DEFAULT_MAX_UPSTREAM_BODY_BYTES = 64 * 1024 * 1024;
 export const DEFAULT_UPSTREAM_IDLE_TIMEOUT_MS = 30_000;
-const CODEX_SOCKET_RETRY_DELAY_MS = 200;
+const CODEX_RETRY_DELAY_MS = 200;
 
 // ChatGPT 백엔드는 Platform API가 받는 샘플링 파라미터를 400으로 거절한다.
 // 실측으로 확정한 거부 목록. metadata는 "Unsupported parameter", 샘플링 필드는 400으로 돌아온다.
@@ -242,7 +242,7 @@ export class CodexResponsesAdapter extends OpenAIResponsesAdapter {
       if (!isRetryableCodexFetchSocketTermination(error, options.signal)) {
         throw error;
       }
-      await abortableDelay(CODEX_SOCKET_RETRY_DELAY_MS, options.signal);
+      await abortableDelay(CODEX_RETRY_DELAY_MS, options.signal);
       return await super.stream(request, options);
     }
     if (!response.ok) {
@@ -250,9 +250,9 @@ export class CodexResponsesAdapter extends OpenAIResponsesAdapter {
     }
     return {
       ...response,
-      events: retryCodexStreamBeforeFirstEvent(response.events, async () => {
-        await abortableDelay(CODEX_SOCKET_RETRY_DELAY_MS, options.signal);
-        const retried = await super.stream(request, options);
+      events: retryCodexStream(response.events, async (retrySignal) => {
+        await abortableDelay(CODEX_RETRY_DELAY_MS, retrySignal);
+        const retried = await super.stream(request, { ...options, signal: retrySignal });
         if (!retried.ok) {
           throw new UpstreamProtocolError(`Codex retry failed with status ${retried.status}`);
         }
@@ -262,22 +262,137 @@ export class CodexResponsesAdapter extends OpenAIResponsesAdapter {
   }
 }
 
-async function* retryCodexStreamBeforeFirstEvent(
+function retryCodexStream(
   events: AsyncIterable<CanonicalResponseEvent>,
-  retry: () => Promise<AsyncIterable<CanonicalResponseEvent>>,
+  retry: (signal: AbortSignal) => Promise<AsyncIterable<CanonicalResponseEvent>>,
+  signal?: AbortSignal,
+): AsyncIterable<CanonicalResponseEvent> {
+  return {
+    [Symbol.asyncIterator]() {
+      const retryController = new AbortController();
+      const unlinkRetryAbort = linkAbortSignal(signal, retryController);
+      const source = events[Symbol.asyncIterator]();
+      const iterator = generateCodexRetryStream(
+        source,
+        retry,
+        retryController,
+        unlinkRetryAbort,
+        signal,
+      );
+      return {
+        next: () => iterator.next(),
+        return: async () => {
+          retryController.abort();
+          return await iterator.return(undefined);
+        },
+        throw: async (error?: unknown) => {
+          retryController.abort(error);
+          return await iterator.throw(error);
+        },
+      };
+    },
+  };
+}
+
+async function* generateCodexRetryStream(
+  source: AsyncIterator<CanonicalResponseEvent>,
+  retry: (signal: AbortSignal) => Promise<AsyncIterable<CanonicalResponseEvent>>,
+  retryController: AbortController,
+  unlinkRetryAbort: () => void,
   signal?: AbortSignal,
 ): AsyncGenerator<CanonicalResponseEvent> {
   let yielded = false;
+  let committedOutput = false;
+  let pendingProviderError: CanonicalResponseEvent | undefined;
   try {
-    for await (const event of events) {
+    while (true) {
+      let result: IteratorResult<CanonicalResponseEvent>;
+      try {
+        result = await source.next();
+      } catch (error) {
+        if (yielded || signal?.aborted === true || !isUndiciSocketTermination(error)) {
+          throw error;
+        }
+        yield* await retry(retryController.signal);
+        return;
+      }
+      if (result.done) {
+        if (pendingProviderError !== undefined) {
+          yield pendingProviderError;
+        }
+        return;
+      }
+      const event = result.value;
+      if (isRetryableCodexServerFailure(event, committedOutput, signal)) {
+        await source.return?.();
+        yield* await retry(retryController.signal);
+        return;
+      }
+      if (pendingProviderError !== undefined) {
+        const matchesFailurePair = event.type === "response.failed"
+          && isRetryableCodexProviderErrorType(event.response.error.type)
+          && signal?.aborted !== true
+          && !committedOutput;
+        if (matchesFailurePair) {
+          await source.return?.();
+          yield* await retry(retryController.signal);
+          return;
+        }
+        yield pendingProviderError;
+        pendingProviderError = undefined;
+        yielded = true;
+        committedOutput = true;
+      }
+      if (isRetryableCodexProviderError(event, committedOutput, signal)) {
+        pendingProviderError = event;
+        continue;
+      }
       yielded = true;
+      committedOutput ||= commitsCodexOutput(event);
       yield event;
     }
-  } catch (error) {
-    if (yielded || signal?.aborted === true || !isUndiciSocketTermination(error)) {
-      throw error;
-    }
-    yield* await retry();
+  } finally {
+    retryController.abort();
+    unlinkRetryAbort();
+    await source.return?.();
+  }
+}
+
+function isRetryableCodexServerFailure(
+  event: CanonicalResponseEvent,
+  committedOutput: boolean,
+  signal?: AbortSignal,
+): boolean {
+  return signal?.aborted !== true
+    && !committedOutput
+    && event.type === "response.failed"
+    && isRetryableCodexProviderErrorType(event.response.error.type);
+}
+
+function isRetryableCodexProviderError(
+  event: CanonicalResponseEvent,
+  committedOutput: boolean,
+  signal?: AbortSignal,
+): boolean {
+  return signal?.aborted !== true
+    && !committedOutput
+    && event.type === "error"
+    && isRetryableCodexProviderErrorType(event.error.type);
+}
+
+function isRetryableCodexProviderErrorType(type: string): boolean {
+  return type === "server_error"
+    || type === "server_is_overloaded"
+    || type === "service_unavailable_error";
+}
+
+function commitsCodexOutput(event: CanonicalResponseEvent): boolean {
+  switch (event.type) {
+    case "response.created":
+    case "response.reasoning_summary_text.delta":
+      return false;
+    default:
+      return true;
   }
 }
 

--- a/packages/core-ai-gateway/src/codex/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/codex/responses/adapter.ts
@@ -415,6 +415,12 @@ function commitsCodexOutput(event: CanonicalResponseEvent): boolean {
     case "response.created":
     case "response.reasoning_summary_text.delta":
       return false;
+    // output_item.added(message)는 메시지 아이템의 시작을 알리는 설정 이벤트일 뿐,
+    // Anthropic 변환에서 caller-visible 출력을 만들지 않는다. server_error retry를
+    // 막지 않도록 lead 버퍼에 보류한다. function_call/web_search 추가와 message done은
+    // 기존대로 출력을 확정한다.
+    case "response.output_item.added":
+      return event.item.type !== "message";
     default:
       return true;
   }

--- a/packages/core-ai-gateway/src/codex/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/codex/responses/adapter.ts
@@ -301,6 +301,11 @@ async function* generateCodexRetryStream(
   unlinkRetryAbort: () => void,
   signal?: AbortSignal,
 ): AsyncGenerator<CanonicalResponseEvent> {
+  // retry 확정 전까지 response.created/reasoning을 보류한다. 이 lead 이벤트들은 Anthropic
+  // 변환에서 message_start/thinking으로 즉시 발화되므로, retry가 r2로 전환된 뒤에도 r1 헤더
+  // 아래 r2 본문이 뒤섞이지 않도록 커밋(committing) 또는 terminal 이벤트에서 한꺼번에
+  // 내보낸다. retry가 확정되면 보류분을 버리고 두 번째 attempt만 atomic하게 노출한다.
+  const bufferedLead: CanonicalResponseEvent[] = [];
   let yielded = false;
   let committedOutput = false;
   let pendingProviderError: CanonicalResponseEvent | undefined;
@@ -313,10 +318,16 @@ async function* generateCodexRetryStream(
         if (yielded || signal?.aborted === true || !isUndiciSocketTermination(error)) {
           throw error;
         }
+        // 아직 아무것도 노출하지 않았다면 r1 lead 버퍼를 폐기하고 재시도한다.
+        bufferedLead.length = 0;
         yield* await retry(retryController.signal);
         return;
       }
       if (result.done) {
+        // attempt가 terminal 없이 끝나면 보류했던 created/reasoning을 원래 순서대로
+        // 내보내고 종료한다(호출측 변환은 미완료 스트림으로 처리한다).
+        yield* bufferedLead;
+        bufferedLead.length = 0;
         if (pendingProviderError !== undefined) {
           yield pendingProviderError;
         }
@@ -325,6 +336,7 @@ async function* generateCodexRetryStream(
       const event = result.value;
       if (isRetryableCodexServerFailure(event, committedOutput, signal)) {
         await source.return?.();
+        bufferedLead.length = 0;
         yield* await retry(retryController.signal);
         return;
       }
@@ -335,9 +347,13 @@ async function* generateCodexRetryStream(
           && !committedOutput;
         if (matchesFailurePair) {
           await source.return?.();
+          bufferedLead.length = 0;
           yield* await retry(retryController.signal);
           return;
         }
+        // 실패 쌍이 아니라면 대기 중이던 error를 terminal로 확정하고 보류분을 먼저 내보낸다.
+        yield* bufferedLead;
+        bufferedLead.length = 0;
         yield pendingProviderError;
         pendingProviderError = undefined;
         yielded = true;
@@ -347,9 +363,16 @@ async function* generateCodexRetryStream(
         pendingProviderError = event;
         continue;
       }
-      yielded = true;
-      committedOutput ||= commitsCodexOutput(event);
-      yield event;
+      if (commitsCodexOutput(event)) {
+        // 출력을 확정하는 이벤트에 도달했으므로 보류 lead를 원래 순서대로 방출한다.
+        yield* bufferedLead;
+        bufferedLead.length = 0;
+        yielded = true;
+        committedOutput = true;
+        yield event;
+      } else {
+        bufferedLead.push(event);
+      }
     }
   } finally {
     retryController.abort();
@@ -386,6 +409,7 @@ function isRetryableCodexProviderErrorType(type: string): boolean {
     || type === "service_unavailable_error";
 }
 
+/** 출력을 확정하는(그 뒤로 retry가 금지되는) 이벤트인지 판정한다. false면 lead 버퍼에 보류된다. */
 function commitsCodexOutput(event: CanonicalResponseEvent): boolean {
   switch (event.type) {
     case "response.created":

--- a/packages/core-ai-gateway/src/codex/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/codex/responses/adapter.ts
@@ -235,29 +235,55 @@ export class CodexResponsesAdapter extends OpenAIResponsesAdapter {
     request: CanonicalResponseRequest,
     options: AdapterCallOptions,
   ): Promise<AdapterResponse> {
+    // 호출자 signal을 내부 per-call 컨트롤러로 옮긴다. 초기 super.stream도 이 컨트롤러의
+    // signal로 호출해야 retry 래퍼가 abort했을 때 대기 중인 초기 read까지 즉시 취소된다.
+    // 호출자 abort는 link로 계속 전파되고, 성공 응답은 소비자가 반복을 시작하기 전에
+    // abort되지 않는다 — 컨트롤러는 래퍼의 return/throw 또는 생성기 종료 시점에만 abort된다.
+    const callController = new AbortController();
+    const unlinkCallAbort = linkAbortSignal(options.signal, callController);
+    const callOptions = { ...options, signal: callController.signal };
+
+    // 최대 2회 호출 예산. fetch-level UND_ERR_SOCKET retry가 이 예산을 소모하면
+    // stream-level retry는 허용하지 않아 3번째 호출을 막는다.
+    let retryAvailable = true;
+
     let response: AdapterResponse;
     try {
-      response = await super.stream(request, options);
+      response = await super.stream(request, callOptions);
     } catch (error) {
-      if (!isRetryableCodexFetchSocketTermination(error, options.signal)) {
+      if (!isRetryableCodexFetchSocketTermination(error, callOptions.signal)) {
+        unlinkCallAbort();
         throw error;
       }
-      await abortableDelay(CODEX_RETRY_DELAY_MS, options.signal);
-      return await super.stream(request, options);
+      // fetch-level retry 전에 예산을 소모한다. 이 뒤로 도착한 응답 스트림은
+      // retry 없이 원본 순서로만 노출된다.
+      retryAvailable = false;
+      wireLog("codex.retry.discarded", {
+        reason: "socket_termination",
+        phase: "fetch",
+      });
+      try {
+        await abortableDelay(CODEX_RETRY_DELAY_MS, callOptions.signal);
+        response = await super.stream(request, callOptions);
+      } catch (retryError) {
+        unlinkCallAbort();
+        throw retryError;
+      }
     }
     if (!response.ok) {
+      unlinkCallAbort();
       return response;
     }
     return {
       ...response,
       events: retryCodexStream(response.events, async (retrySignal) => {
         await abortableDelay(CODEX_RETRY_DELAY_MS, retrySignal);
-        const retried = await super.stream(request, { ...options, signal: retrySignal });
+        const retried = await super.stream(request, { ...callOptions, signal: retrySignal });
         if (!retried.ok) {
           throw new UpstreamProtocolError(`Codex retry failed with status ${retried.status}`);
         }
         return retried.events;
-      }, options.signal),
+      }, callController, unlinkCallAbort, retryAvailable),
     };
   }
 }
@@ -265,28 +291,25 @@ export class CodexResponsesAdapter extends OpenAIResponsesAdapter {
 function retryCodexStream(
   events: AsyncIterable<CanonicalResponseEvent>,
   retry: (signal: AbortSignal) => Promise<AsyncIterable<CanonicalResponseEvent>>,
-  signal?: AbortSignal,
+  callController: AbortController,
+  unlinkCallAbort: () => void,
+  retryAvailable: boolean,
 ): AsyncIterable<CanonicalResponseEvent> {
   return {
     [Symbol.asyncIterator]() {
-      const retryController = new AbortController();
-      const unlinkRetryAbort = linkAbortSignal(signal, retryController);
       const source = events[Symbol.asyncIterator]();
-      const iterator = generateCodexRetryStream(
-        source,
-        retry,
-        retryController,
-        unlinkRetryAbort,
-        signal,
-      );
+      const iterator = generateCodexRetryStream(source, retry, callController, unlinkCallAbort, retryAvailable);
       return {
         next: () => iterator.next(),
         return: async () => {
-          retryController.abort();
+          // 초기 스트림과 진행 중인 retry(지연/fetch) 모두 이 컨트롤러의 signal로
+          // 실행되므로 하나의 abort로 전부 취소된다. caller signal은 stream()에서
+          // 이미 callController에 연결되어 있어 여기서 다시 전파할 필요가 없다.
+          callController.abort();
           return await iterator.return(undefined);
         },
         throw: async (error?: unknown) => {
-          retryController.abort(error);
+          callController.abort(error);
           return await iterator.throw(error);
         },
       };
@@ -297,14 +320,22 @@ function retryCodexStream(
 async function* generateCodexRetryStream(
   source: AsyncIterator<CanonicalResponseEvent>,
   retry: (signal: AbortSignal) => Promise<AsyncIterable<CanonicalResponseEvent>>,
-  retryController: AbortController,
-  unlinkRetryAbort: () => void,
-  signal?: AbortSignal,
+  callController: AbortController,
+  unlinkCallAbort: () => void,
+  retryAvailable: boolean,
 ): AsyncGenerator<CanonicalResponseEvent> {
   // retry 확정 전까지 response.created/reasoning을 보류한다. 이 lead 이벤트들은 Anthropic
   // 변환에서 message_start/thinking으로 즉시 발화되므로, retry가 r2로 전환된 뒤에도 r1 헤더
   // 아래 r2 본문이 뒤섞이지 않도록 커밋(committing) 또는 terminal 이벤트에서 한꺼번에
   // 내보낸다. retry가 확정되면 보류분을 버리고 두 번째 attempt만 atomic하게 노출한다.
+  //
+  // 취소는 stream()이 만든 per-call 컨트롤러 하나로 통일한다. 초기 스트림과 retry
+  // (지연/fetch) 모두 이 signal로 실행되므로 return/throw가 abort하면 대기 중인 read도
+  // 즉시 풀린다. 호출자 abort는 컨트롤러 연결을 통해 같은 경로로 전파된다.
+  //
+  // retryAvailable=false면 (fetch-level retry가 이미 예산을 소모) stream-level retry를
+  // 금지한다. created/reasoning/message setup은 보류하다가 그대로 노출하고, retryable
+  // response.failed/error는 retry/pending 없이 원래 순서로 terminal로 통과시킨다.
   const bufferedLead: CanonicalResponseEvent[] = [];
   let yielded = false;
   let committedOutput = false;
@@ -315,12 +346,23 @@ async function* generateCodexRetryStream(
       try {
         result = await source.next();
       } catch (error) {
-        if (yielded || signal?.aborted === true || !isUndiciSocketTermination(error)) {
+        if (yielded || callController.signal.aborted === true || !isUndiciSocketTermination(error)) {
           throw error;
         }
-        // 아직 아무것도 노출하지 않았다면 r1 lead 버퍼를 폐기하고 재시도한다.
+        if (!retryAvailable) {
+          // 예산이 없으면 보류 lead를 원래 순서대로 내보낸 뒤 소켓 에러를 전파한다.
+          yield* bufferedLead;
+          bufferedLead.length = 0;
+          throw error;
+        }
+        // 아직 아무것도 노출하지 않았다면 r1 lead 버퍼를 폐기하고 재시도한다. 소켓
+        // termination은 canonical 이벤트가 없으므로 phase만 남기는 payload-free 진단.
+        wireLog("codex.retry.discarded", {
+          reason: "socket_termination",
+          phase: "pre_commit",
+        });
         bufferedLead.length = 0;
-        yield* await retry(retryController.signal);
+        yield* await retry(callController.signal);
         return;
       }
       if (result.done) {
@@ -334,21 +376,27 @@ async function* generateCodexRetryStream(
         return;
       }
       const event = result.value;
-      if (isRetryableCodexServerFailure(event, committedOutput, signal)) {
+      if (retryAvailable && isRetryableCodexServerFailure(event, committedOutput, callController.signal)) {
+        // 폐기되는 response.failed가 게이트웨이 wrapper에 도달하기 전에 버려지므로 이
+        // seam에서 증거를 남긴다. 직전에 대기 중인 retryable error도 함께 버려진다면
+        // 둘 다(쌍) 남기고, 아니면 response.failed 단독을 남긴다.
+        wireLog("codex.retry.discarded", pendingProviderError === undefined
+          ? { reason: "response.failed", event }
+          : { reason: "error_failed_pair", events: [pendingProviderError, event] });
         await source.return?.();
         bufferedLead.length = 0;
-        yield* await retry(retryController.signal);
+        yield* await retry(callController.signal);
         return;
       }
       if (pendingProviderError !== undefined) {
         const matchesFailurePair = event.type === "response.failed"
           && isRetryableCodexProviderErrorType(event.response.error.type)
-          && signal?.aborted !== true
+          && callController.signal.aborted !== true
           && !committedOutput;
         if (matchesFailurePair) {
           await source.return?.();
           bufferedLead.length = 0;
-          yield* await retry(retryController.signal);
+          yield* await retry(callController.signal);
           return;
         }
         // 실패 쌍이 아니라면 대기 중이던 error를 terminal로 확정하고 보류분을 먼저 내보낸다.
@@ -359,7 +407,7 @@ async function* generateCodexRetryStream(
         yielded = true;
         committedOutput = true;
       }
-      if (isRetryableCodexProviderError(event, committedOutput, signal)) {
+      if (retryAvailable && isRetryableCodexProviderError(event, committedOutput, callController.signal)) {
         pendingProviderError = event;
         continue;
       }
@@ -375,8 +423,8 @@ async function* generateCodexRetryStream(
       }
     }
   } finally {
-    retryController.abort();
-    unlinkRetryAbort();
+    callController.abort();
+    unlinkCallAbort();
     await source.return?.();
   }
 }

--- a/packages/core-ai-gateway/tests/codex/responses/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/codex/responses/adapter.test.ts
@@ -3,8 +3,9 @@ import { describe, expect, it, vi } from "vitest";
 import {
   CHATGPT_CODEX_RESPONSES_URL,
   CodexResponsesAdapter,
+  encodeAnthropicSse,
 } from "../../../src/index.js";
-import type { CanonicalResponseRequest } from "../../../src/index.js";
+import type { CanonicalResponseEvent, CanonicalResponseRequest } from "../../../src/index.js";
 
 function request(overrides: Partial<CanonicalResponseRequest> = {}): CanonicalResponseRequest {
   return {
@@ -20,6 +21,30 @@ function sse(...frames: string[]): Response {
     status: 200,
     headers: { "content-type": "text/event-stream" },
   });
+}
+
+async function collectBody(body: AsyncIterable<Uint8Array>): Promise<string> {
+  const decoder = new TextDecoder();
+  let text = "";
+  for await (const chunk of body) {
+    text += decoder.decode(chunk, { stream: true });
+  }
+  return text + decoder.decode();
+}
+
+function parseSse(body: string): Array<{ event: string; data: Record<string, unknown> }> {
+  return body
+    .trim()
+    .split(/\r?\n\r?\n/)
+    .map((frameText) => {
+      const lines = frameText.split(/\r?\n/);
+      const event = lines.find((line) => line.startsWith("event: "))?.slice(7);
+      const data = lines.find((line) => line.startsWith("data: "))?.slice(6);
+      if (event === undefined || data === undefined) {
+        throw new Error(`Invalid SSE frame: ${frameText}`);
+      }
+      return { event, data: JSON.parse(data) as Record<string, unknown> };
+    });
 }
 
 describe("codex responses adapter", () => {
@@ -132,14 +157,14 @@ describe("codex responses adapter", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it("does not retry UND_ERR_SOCKET after a canonical event was yielded", async () => {
+  it("does not retry UND_ERR_SOCKET after caller-visible output was yielded", async () => {
     const encoder = new TextEncoder();
     const socketError = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" });
     let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
     const terminated = new ReadableStream<Uint8Array>({
       start(controller) {
         streamController = controller;
-        controller.enqueue(encoder.encode('data: {"type":"response.created","response":{"id":"r","model":"gpt-5.6-luna"}}\n\n'));
+        controller.enqueue(encoder.encode('data: {"type":"response.output_text.delta","item_id":"m","output_index":0,"content_index":0,"delta":"partial"}\n\n'));
       },
     });
     const fetchMock = vi.fn<typeof fetch>(async () => new Response(terminated, { status: 200 }));
@@ -147,13 +172,43 @@ describe("codex responses adapter", () => {
     const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
     if (!response.ok) throw new Error("expected success");
     const iterator = response.events[Symbol.asyncIterator]();
-    await expect(iterator.next()).resolves.toMatchObject({ value: { type: "response.created" } });
+    await expect(iterator.next()).resolves.toMatchObject({ value: { type: "response.output_text.delta" } });
     streamController?.error(new TypeError("terminated", { cause: socketError }));
     await expect(iterator.next()).rejects.toMatchObject({ message: "terminated" });
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("retries one server_error after reasoning but before output", async () => {
+  it("retries UND_ERR_SOCKET while created/reasoning are still buffered", async () => {
+    const encoder = new TextEncoder();
+    const socketError = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" });
+    const terminated = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n'));
+        controller.error(new TypeError("terminated", { cause: socketError }));
+      },
+    });
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(terminated, { status: 200 }))
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r2","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"response.output_text.delta","item_id":"m","output_index":0,"content_index":0,"delta":"OK"}\n\n',
+        'data: {"type":"response.completed","response":{"id":"r2","model":"gpt-5.6-luna","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
+      ));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const events = [];
+    for await (const event of response.events) events.push(event);
+    expect(events.map((event) => event.type)).toEqual([
+      "response.created",
+      "response.output_text.delta",
+      "response.completed",
+    ]);
+    expect(events[0]).toMatchObject({ response: { id: "r2" } });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries one server_error after reasoning but before output and discards the failed attempt's lead", async () => {
     const failed = 'data: {"type":"response.failed","response":{"id":"r1","model":"gpt-5.6-luna","error":{"code":"server_error","message":"An error occurred while processing your request. Please include request ID req-1."}}}\n\n';
     const fetchMock = vi.fn<typeof fetch>()
       .mockResolvedValueOnce(sse(
@@ -171,15 +226,56 @@ describe("codex responses adapter", () => {
     if (!response.ok) throw new Error("expected success");
     const events = [];
     for await (const event of response.events) events.push(event);
+    // 첫 attempt의 created/reasoning은 retry 시 폐기되고 두 번째 attempt만 노출된다.
     expect(events.map((event) => event.type)).toEqual([
-      "response.created",
-      "response.reasoning_summary_text.delta",
       "response.created",
       "response.output_text.delta",
       "response.completed",
     ]);
+    expect(events[0]).toMatchObject({ response: { id: "r2" } });
     expect(events).not.toContainEqual(expect.objectContaining({ type: "response.failed" }));
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("exposes only the retried attempt to the Anthropic SSE caller", async () => {
+    const failed = 'data: {"type":"response.failed","response":{"id":"r1","model":"gpt-5.6-luna","error":{"code":"server_error","message":"An error occurred while processing your request. Please include request ID req-1."}}}\n\n';
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"response.reasoning_text.delta","item_id":"reasoning-1","output_index":0,"delta":"checking"}\n\n',
+        failed,
+      ))
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r2","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"response.output_text.delta","item_id":"message-1","output_index":0,"content_index":0,"delta":"OK"}\n\n',
+        'data: {"type":"response.completed","response":{"id":"r2","model":"gpt-5.6-luna","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
+      ));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const frames = parseSse(await collectBody(encodeAnthropicSse(response.events)));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // r1의 created/reasoning은 retry 시 폐기된다. message_start r1/thinking이 아니라
+    // r2 헤더 아래 r2의 내용과 usage가 atomic하게 실려야 한다.
+    expect(frames.map((frame) => frame.event)).toEqual([
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ]);
+    expect(frames[0]?.data).toMatchObject({
+      type: "message_start",
+      message: { id: "r2", model: "gpt-5.6-luna" },
+    });
+    expect(frames[1]?.data).toMatchObject({ content_block: { type: "text", text: "" } });
+    expect(frames[2]?.data).toMatchObject({ delta: { type: "text_delta", text: "OK" } });
+    expect(frames[4]?.data).toMatchObject({
+      type: "message_delta",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
   });
 
   it("retries the observed overload error pair before output", async () => {
@@ -198,11 +294,12 @@ describe("codex responses adapter", () => {
     if (!response.ok) throw new Error("expected success");
     const events = [];
     for await (const event of response.events) events.push(event);
+    // r1의 created는 retry 시 폐기되고 r2만 노출된다.
     expect(events.map((event) => event.type)).toEqual([
-      "response.created",
       "response.created",
       "response.completed",
     ]);
+    expect(events[0]).toMatchObject({ response: { id: "r2" } });
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
@@ -219,6 +316,49 @@ describe("codex responses adapter", () => {
       type: "error",
       error: { type: "service_unavailable_error", message: "temporarily unavailable" },
     }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves created and reasoning in order when the first attempt succeeds", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => sse(
+      'data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n',
+      'data: {"type":"response.reasoning_text.delta","item_id":"reasoning-1","output_index":0,"delta":"checking"}\n\n',
+      'data: {"type":"response.output_text.delta","item_id":"message-1","output_index":0,"content_index":0,"delta":"OK"}\n\n',
+      'data: {"type":"response.completed","response":{"id":"r1","model":"gpt-5.6-luna","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
+    ));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const events = [];
+    for await (const event of response.events) events.push(event);
+    expect(events.map((event) => event.type)).toEqual([
+      "response.created",
+      "response.reasoning_summary_text.delta",
+      "response.output_text.delta",
+      "response.completed",
+    ]);
+    expect(events[0]).toMatchObject({ response: { id: "r1" } });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves created and reasoning before a non-retryable terminal failure", async () => {
+    const failed = 'data: {"type":"response.failed","response":{"id":"r1","model":"gpt-5.6-luna","error":{"code":"invalid_prompt","message":"bad prompt"}}}\n\n';
+    const fetchMock = vi.fn<typeof fetch>(async () => sse(
+      'data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n',
+      'data: {"type":"response.reasoning_text.delta","item_id":"reasoning-1","output_index":0,"delta":"checking"}\n\n',
+      failed,
+    ));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const events = [];
+    for await (const event of response.events) events.push(event);
+    expect(events.map((event) => event.type)).toEqual([
+      "response.created",
+      "response.reasoning_summary_text.delta",
+      "response.failed",
+    ]);
+    expect(events.at(-1)).toMatchObject({ response: { error: { type: "invalid_prompt" } } });
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -248,7 +388,7 @@ describe("codex responses adapter", () => {
     const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
     if (!response.ok) throw new Error("expected success");
     const iterator = response.events[Symbol.asyncIterator]();
-    await expect(iterator.next()).resolves.toMatchObject({ value: { type: "response.created" } });
+    // 첫 next()가 created를 버퍼링하고 실패를 만나 retry 지연에 진입한다.
     const pendingNext = iterator.next().catch((error: unknown) => error);
     await new Promise((resolve) => setTimeout(resolve, 25));
 
@@ -286,7 +426,7 @@ describe("codex responses adapter", () => {
     const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
     if (!response.ok) throw new Error("expected success");
     const iterator = response.events[Symbol.asyncIterator]();
-    await iterator.next();
+    // 첫 next()가 created를 버퍼링하고 실패를 만나 retry fetch를 시작한다.
     const pendingNext = iterator.next().catch((error: unknown) => error);
     await retryStart;
     await iterator.return?.();

--- a/packages/core-ai-gateway/tests/codex/responses/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/codex/responses/adapter.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  AnthropicMessagesGateway,
   CHATGPT_CODEX_RESPONSES_URL,
   CodexResponsesAdapter,
   encodeAnthropicSse,
+  setWireLogTarget,
 } from "../../../src/index.js";
 import type { CanonicalResponseEvent, CanonicalResponseRequest } from "../../../src/index.js";
 
@@ -45,6 +51,34 @@ function parseSse(body: string): Array<{ event: string; data: Record<string, unk
       }
       return { event, data: JSON.parse(data) as Record<string, unknown> };
     });
+}
+
+const temporaryWireLogDirectories: string[] = [];
+
+afterEach(() => {
+  setWireLogTarget(undefined);
+  for (const directory of temporaryWireLogDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function wireLogFile(): string {
+  const directory = mkdtempSync(path.join(tmpdir(), "fleet-codex-wire-log-"));
+  temporaryWireLogDirectories.push(directory);
+  const filePath = path.join(directory, "wire-log.jsonl");
+  setWireLogTarget({ path: filePath });
+  return filePath;
+}
+
+function readWireLogLines(filePath: string): Array<Record<string, unknown>> {
+  return readFileSync(filePath, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function discardedRetryEntries(filePath: string): Array<Record<string, unknown>> {
+  return readWireLogLines(filePath).filter((entry) => entry.event === "codex.retry.discarded");
 }
 
 describe("codex responses adapter", () => {
@@ -573,5 +607,321 @@ describe("codex responses adapter", () => {
   it("validates explicit zero limits instead of silently accepting them", () => {
     expect(() => new CodexResponsesAdapter({ maxBodyBytes: 0 })).toThrow(TypeError);
     expect(() => new CodexResponsesAdapter({ idleTimeoutMs: 0 })).toThrow(TypeError);
+  });
+
+  it("cancels a pending initial read when the consumer closes the iterator", async () => {
+    const encoder = new TextEncoder();
+    const hanging = new ReadableStream<Uint8Array>({
+      start(controller) {
+        // 첫 프레임은 created(버퍼 lead)만 내보내고 그 뒤로는 hang한다.
+        controller.enqueue(
+          encoder.encode('data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n')
+        );
+      },
+    });
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(hanging, { status: 200 }));
+
+    const response = await new CodexResponsesAdapter({
+      fetch: fetchMock,
+      idleTimeoutMs: 300,
+    }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+
+    const iterator = response.events[Symbol.asyncIterator]();
+    // created가 버퍼되고 source.next()가 초기 스트림에서 hang한 채로 return을 호출한다.
+    const pendingNext = iterator.next().catch(() => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    const startedAt = Date.now();
+    await iterator.return?.();
+    const elapsed = Date.now() - startedAt;
+
+    // return은 per-call 컨트롤러 abort로 초기 read를 즉시 취소하므로 idle timeout(300ms)을
+    // 기다리지 않는다.
+    expect(elapsed).toBeLessThan(150);
+    await pendingNext;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs discarded response.failed retry evidence without duplicating passed events", async () => {
+    const filePath = wireLogFile();
+    const failed = 'data: {"type":"response.failed","response":{"id":"r1","model":"gpt-5.6-luna","error":{"code":"server_error","message":"An error occurred while processing your request. Please include request ID req-1."}}}\n\n';
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"response.reasoning_text.delta","item_id":"reasoning-1","output_index":0,"delta":"checking"}\n\n',
+        failed,
+      ))
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r2","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"response.output_text.delta","item_id":"message-1","output_index":0,"content_index":0,"delta":"OK"}\n\n',
+        'data: {"type":"response.completed","response":{"id":"r2","model":"gpt-5.6-luna","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
+      ));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    for await (const _event of response.events) {
+      // drain
+    }
+
+    // 폐기되는 r1 실패 증거는 게이트웨이 wrapper에 도달하기 전 버려지므로 이 seam에서 남긴다.
+    const discarded = discardedRetryEntries(filePath);
+    expect(discarded).toHaveLength(1);
+    expect(discarded[0]).toMatchObject({
+      event: "codex.retry.discarded",
+      payload: {
+        reason: "response.failed",
+        event: {
+          type: "response.failed",
+          response: {
+            id: "r1",
+            error: { type: "server_error", message: expect.stringContaining("req-1") },
+          },
+        },
+      },
+    });
+    // 성공 응답의 일반 이벤트(r2 delta)는 이 discard 항목에 중복 기록되지 않는다.
+    const serialized = JSON.stringify(discarded);
+    expect(serialized).not.toContain("output_text.delta");
+    expect(serialized).not.toContain('"id":"r2"');
+  });
+
+  it("logs both discarded events for an error + response.failed retry pair", async () => {
+    const filePath = wireLogFile();
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"error","error":{"code":"service_unavailable_error","message":"temporarily unavailable"}}\n\n',
+        'data: {"type":"response.failed","response":{"id":"r1","model":"gpt-5.6-luna","error":{"code":"server_is_overloaded","message":"overloaded"}}}\n\n',
+      ))
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r2","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"response.completed","response":{"id":"r2","model":"gpt-5.6-luna","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
+      ));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    for await (const _event of response.events) {
+      // drain
+    }
+
+    const discarded = discardedRetryEntries(filePath);
+    expect(discarded).toHaveLength(1);
+    expect(discarded[0]).toMatchObject({
+      event: "codex.retry.discarded",
+      payload: { reason: "error_failed_pair" },
+    });
+    const pairEvents = (discarded[0]?.payload as { events?: unknown[] } | undefined)?.events;
+    expect(pairEvents).toMatchObject([
+      { type: "error", error: { type: "service_unavailable_error", message: "temporarily unavailable" } },
+      {
+        type: "response.failed",
+        response: { id: "r1", error: { type: "server_is_overloaded", message: "overloaded" } },
+      },
+    ]);
+  });
+
+  it("logs a payload-light diagnostic for a socket termination retry", async () => {
+    const filePath = wireLogFile();
+    const socketError = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" });
+    const terminated = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new TypeError("terminated", { cause: socketError }));
+      },
+    });
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(terminated, { status: 200 }))
+      .mockResolvedValueOnce(sse("data: [DONE]\n\n"));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    for await (const _event of response.events) {
+      // drain
+    }
+
+    // 소켓 termination은 canonical 이벤트가 없으므로 type+phase만 남긴다.
+    const discarded = discardedRetryEntries(filePath);
+    expect(discarded).toHaveLength(1);
+    expect(discarded[0]).toMatchObject({
+      event: "codex.retry.discarded",
+      payload: { reason: "socket_termination", phase: "pre_commit" },
+    });
+  });
+
+  it("preserves discarded failure evidence before the gateway canonical-event wrapper", async () => {
+    const filePath = wireLogFile();
+    const failed = 'data: {"type":"response.failed","response":{"id":"r1","model":"gpt-5.6-luna","error":{"code":"server_error","message":"An error occurred while processing your request. Please include request ID req-1."}}}\n\n';
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(
+        'data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n'
+        + 'data: {"type":"response.reasoning_text.delta","item_id":"reasoning-1","output_index":0,"delta":"checking"}\n\n'
+        + failed,
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      ))
+      .mockResolvedValueOnce(new Response(
+        'data: {"type":"response.created","response":{"id":"r2","model":"gpt-5.6-luna"}}\n\n'
+        + 'data: {"type":"response.output_text.delta","item_id":"message-1","output_index":0,"content_index":0,"delta":"OK"}\n\n'
+        + 'data: {"type":"response.completed","response":{"id":"r2","model":"gpt-5.6-luna","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      ));
+
+    const gateway = new AnthropicMessagesGateway(new CodexResponsesAdapter({ fetch: fetchMock }));
+    const stream = await gateway.stream(
+      { model: "gpt-5.6-luna", messages: [{ role: "user", content: "hi" }], max_tokens: 1024, stream: true },
+      { apiKey: "k" },
+    );
+    await collectBody(stream.body);
+
+    const entries = readWireLogLines(filePath);
+    // 폐기된 r1 실패 증거는 게이트웨이 wrapper에 도달하기 전 seam에서 남는다.
+    const discarded = entries.filter((entry) => entry.event === "codex.retry.discarded");
+    expect(discarded).toHaveLength(1);
+    expect(discarded[0]?.payload).toMatchObject({
+      reason: "response.failed",
+      event: {
+        type: "response.failed",
+        response: { id: "r1", error: { type: "server_error", message: expect.stringContaining("req-1") } },
+      },
+    });
+    // 통과한 r2 이벤트는 wrapper가 정확히 한 번씩 기록하고, r1 폐기분은 wrapper에 닿지 않는다.
+    const canonicalEvents = entries.filter((entry) => entry.event === "canonical.event");
+    expect(canonicalEvents).toHaveLength(3);
+    expect(canonicalEvents.map((entry) => (entry.payload as { type?: unknown }).type)).toEqual([
+      "response.created",
+      "response.output_text.delta",
+      "response.completed",
+    ]);
+    expect(JSON.stringify(canonicalEvents)).not.toContain('"id":"r1"');
+  });
+
+  it("spends the retry budget on a fetch-level socket retry and passes failures through", async () => {
+    const filePath = wireLogFile();
+    const socketError = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" });
+    const failed = 'data: {"type":"response.failed","response":{"id":"r1","model":"gpt-5.6-luna","error":{"code":"server_error","message":"req-1"}}}\n\n';
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockRejectedValueOnce(new TypeError("terminated", { cause: socketError }))
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"response.reasoning_text.delta","item_id":"reasoning-1","output_index":0,"delta":"checking"}\n\n',
+        failed,
+      ));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const events = [];
+    for await (const event of response.events) events.push(event);
+
+    // fetch-level retry가 예산을 소모했으므로 server_error는 retry되지 않고 원래 순서대로
+    // terminal로 노출된다. created/reasoning lead도 보존된다.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(events.map((event) => event.type)).toEqual([
+      "response.created",
+      "response.reasoning_summary_text.delta",
+      "response.failed",
+    ]);
+    expect(events.at(-1)).toMatchObject({
+      response: { id: "r1", error: { type: "server_error", message: "req-1" } },
+    });
+
+    // fetch-level retry는 payload-light 진단으로 기록되고, stream-level discard는 없다.
+    const discarded = discardedRetryEntries(filePath);
+    expect(discarded).toHaveLength(1);
+    expect(discarded[0]).toMatchObject({
+      event: "codex.retry.discarded",
+      payload: { reason: "socket_termination", phase: "fetch" },
+    });
+  });
+
+  it("does not retry a third time when a fetch-retried stream socket terminates", async () => {
+    const socketError = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" });
+    const encoder = new TextEncoder();
+    let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const terminated = new ReadableStream<Uint8Array>({
+      start(controller) {
+        streamController = controller;
+        controller.enqueue(
+          encoder.encode('data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n')
+        );
+      },
+    });
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockRejectedValueOnce(new TypeError("terminated", { cause: socketError }))
+      .mockResolvedValueOnce(new Response(terminated, { status: 200 }));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const iterator = response.events[Symbol.asyncIterator]();
+    const eventTypes: string[] = [];
+    let caught: unknown;
+    const drain = (async () => {
+      try {
+        for (;;) {
+          const { done, value } = await iterator.next();
+          if (done) break;
+          eventTypes.push(value.type);
+        }
+      } catch (error) {
+        caught = error;
+      }
+    })();
+    // 첫 read가 created를 소비하고 두 번째 read가 대기한 뒤 소켓을 종료시킨다.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    streamController?.error(new TypeError("terminated", { cause: socketError }));
+    await drain;
+
+    // 예산이 소모된 상태의 소켓 termination은 보류 lead를 원래 순서로 내보낸 뒤 에러를
+    // 전파한다. 세 번째 호출은 없다.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(eventTypes).toEqual(["response.created"]);
+    expect(caught).toMatchObject({ message: "terminated" });
+  });
+
+  it("passes a generic retryable error through when the budget is spent", async () => {
+    const socketError = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" });
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockRejectedValueOnce(new TypeError("terminated", { cause: socketError }))
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"error","error":{"code":"service_unavailable_error","message":"temporarily unavailable"}}\n\n',
+      ));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const events = [];
+    for await (const event of response.events) events.push(event);
+
+    // 예산이 소모된 상태의 generic retryable error는 pending 없이 원래 순서로 terminal로
+    // 통과하고, 세 번째 호출은 없다.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(events.map((event) => event.type)).toEqual(["response.created", "error"]);
+    expect(events.at(-1)).toMatchObject({
+      error: { type: "service_unavailable_error", message: "temporarily unavailable" },
+    });
+  });
+
+  it("keeps the stream-level retry at two calls when the retried response also fails", async () => {
+    const failed = 'data: {"type":"response.failed","response":{"id":"r1","model":"gpt-5.6-luna","error":{"code":"server_error","message":"req-1"}}}\n\n';
+    const failedAgain = 'data: {"type":"response.failed","response":{"id":"r2","model":"gpt-5.6-luna","error":{"code":"server_error","message":"req-2"}}}\n\n';
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n',
+        failed,
+      ))
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r2","model":"gpt-5.6-luna"}}\n\n',
+        failedAgain,
+      ));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const events = [];
+    for await (const event of response.events) events.push(event);
+
+    // stream-level retry(2번째 호출)의 응답도 server_error면 그대로 terminal로 노출되며
+    // 세 번째 호출은 없다.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(events.map((event) => event.type)).toEqual(["response.created", "response.failed"]);
+    expect(events[0]).toMatchObject({ response: { id: "r2" } });
+    expect(events.at(-1)).toMatchObject({ response: { id: "r2", error: { type: "server_error" } } });
   });
 });

--- a/packages/core-ai-gateway/tests/codex/responses/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/codex/responses/adapter.test.ts
@@ -153,6 +153,181 @@ describe("codex responses adapter", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("retries one server_error after reasoning but before output", async () => {
+    const failed = 'data: {"type":"response.failed","response":{"id":"r1","model":"gpt-5.6-luna","error":{"code":"server_error","message":"An error occurred while processing your request. Please include request ID req-1."}}}\n\n';
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"response.reasoning_text.delta","item_id":"reasoning-1","output_index":0,"delta":"checking"}\n\n',
+        failed,
+      ))
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r2","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"response.output_text.delta","item_id":"message-1","output_index":0,"content_index":0,"delta":"OK"}\n\n',
+        'data: {"type":"response.completed","response":{"id":"r2","model":"gpt-5.6-luna","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
+      ));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const events = [];
+    for await (const event of response.events) events.push(event);
+    expect(events.map((event) => event.type)).toEqual([
+      "response.created",
+      "response.reasoning_summary_text.delta",
+      "response.created",
+      "response.output_text.delta",
+      "response.completed",
+    ]);
+    expect(events).not.toContainEqual(expect.objectContaining({ type: "response.failed" }));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries the observed overload error pair before output", async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"error","error":{"code":"service_unavailable_error","message":"temporarily unavailable"}}\n\n',
+        'data: {"type":"response.failed","response":{"id":"r1","model":"gpt-5.6-luna","error":{"code":"server_is_overloaded","message":"overloaded"}}}\n\n',
+      ))
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r2","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"response.completed","response":{"id":"r2","model":"gpt-5.6-luna","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
+      ));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const events = [];
+    for await (const event of response.events) events.push(event);
+    expect(events.map((event) => event.type)).toEqual([
+      "response.created",
+      "response.created",
+      "response.completed",
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves a standalone retryable provider error when no failed event follows", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => sse(
+      'data: {"type":"error","error":{"code":"service_unavailable_error","message":"temporarily unavailable"}}\n\n',
+    ));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const events = [];
+    for await (const event of response.events) events.push(event);
+    expect(events).toEqual([{
+      type: "error",
+      error: { type: "service_unavailable_error", message: "temporarily unavailable" },
+    }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry again when the server_error retry fails", async () => {
+    const failed = 'data: {"type":"response.failed","response":{"id":"r1","model":"gpt-5.6-luna","error":{"code":"server_error","message":"internal"}}}\n\n';
+    const socketError = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" });
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(sse(failed))
+      .mockRejectedValueOnce(new TypeError("terminated", { cause: socketError }));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    await expect((async () => {
+      for await (const _event of response.events) {
+        // drain
+      }
+    })()).rejects.toMatchObject({ message: "terminated" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancels a pending retry when the consumer closes the iterator", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => sse(
+      'data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n',
+      'data: {"type":"response.failed","response":{"id":"r1","model":"gpt-5.6-luna","error":{"code":"server_error","message":"internal"}}}\n\n',
+    ));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const iterator = response.events[Symbol.asyncIterator]();
+    await expect(iterator.next()).resolves.toMatchObject({ value: { type: "response.created" } });
+    const pendingNext = iterator.next().catch((error: unknown) => error);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    const closeResult = await Promise.race([
+      iterator.return?.().then(() => "closed" as const),
+      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 150)),
+    ]);
+    expect(closeResult).toBe("closed");
+    await pendingNext;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts an in-flight retry fetch when the consumer closes the iterator", async () => {
+    let retryStarted: (() => void) | undefined;
+    const retryStart = new Promise<void>((resolve) => {
+      retryStarted = resolve;
+    });
+    let retryAborted = false;
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"response.failed","response":{"id":"r1","model":"gpt-5.6-luna","error":{"code":"server_error","message":"internal"}}}\n\n',
+      ))
+      .mockImplementationOnce(async (_input, init) => {
+        retryStarted?.();
+        return await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            retryAborted = true;
+            reject(init.signal?.reason);
+          }, { once: true });
+        });
+      });
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const iterator = response.events[Symbol.asyncIterator]();
+    await iterator.next();
+    const pendingNext = iterator.next().catch((error: unknown) => error);
+    await retryStart;
+    await iterator.return?.();
+    await pendingNext;
+    expect(retryAborted).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry terminal provider errors or server_error after output", async () => {
+    const cases = [
+      { error: { code: "invalid_prompt", message: "bad prompt" }, prefix: [] },
+      { error: { code: "rate_limit_exceeded", message: "try later" }, prefix: [] },
+      {
+        error: { code: "server_error", message: "second terminal error" },
+        prefix: ['data: {"type":"error","error":{"code":"api_error","message":"first terminal error"}}\n\n'],
+      },
+      {
+        error: { code: "server_error", message: "internal" },
+        prefix: ['data: {"type":"response.output_text.delta","item_id":"m","output_index":0,"content_index":0,"delta":"partial"}\n\n'],
+      },
+      {
+        error: { code: "server_error", message: "internal" },
+        prefix: ['data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"f","call_id":"c","name":"Bash","arguments":"{}"}}\n\n'],
+      },
+    ];
+
+    for (const testCase of cases) {
+      const failed = `data: ${JSON.stringify({
+        type: "response.failed",
+        response: { id: "r", model: "gpt-5.6-luna", error: testCase.error },
+      })}\n\n`;
+      const fetchMock = vi.fn<typeof fetch>(async () => sse(...testCase.prefix, failed));
+      const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+      if (!response.ok) throw new Error("expected success");
+      const events = [];
+      for await (const event of response.events) events.push(event);
+      expect(events.at(-1)).toMatchObject({ type: "response.failed" });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    }
+  });
+
   it("does not retry a known HTTP status when its error body socket terminates", async () => {
     const socketError = Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" });
     const terminated = new ReadableStream<Uint8Array>({

--- a/packages/core-ai-gateway/tests/codex/responses/adapter.test.ts
+++ b/packages/core-ai-gateway/tests/codex/responses/adapter.test.ts
@@ -278,6 +278,74 @@ describe("codex responses adapter", () => {
     });
   });
 
+  it("retries a server_error after a message output_item.added setup event", async () => {
+    const failed = 'data: {"type":"response.failed","response":{"id":"r1","model":"gpt-5.6-luna","error":{"code":"server_error","message":"An error occurred while processing your request. Please include request ID req-1."}}}\n\n';
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg-1","role":"assistant"}}\n\n',
+        failed,
+      ))
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r2","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"response.output_text.delta","item_id":"message-1","output_index":0,"content_index":0,"delta":"OK"}\n\n',
+        'data: {"type":"response.completed","response":{"id":"r2","model":"gpt-5.6-luna","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
+      ));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const events = [];
+    for await (const event of response.events) events.push(event);
+    // output_item.added(message)는 caller-visible 출력이 아니므로 retry를 막지 않는다.
+    expect(events.map((event) => event.type)).toEqual([
+      "response.created",
+      "response.output_text.delta",
+      "response.completed",
+    ]);
+    expect(events[0]).toMatchObject({ response: { id: "r2" } });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a message setup event inside the retry lead so the Anthropic caller sees only r2", async () => {
+    const failed = 'data: {"type":"response.failed","response":{"id":"r1","model":"gpt-5.6-luna","error":{"code":"server_error","message":"An error occurred while processing your request. Please include request ID req-1."}}}\n\n';
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg-1","role":"assistant"}}\n\n',
+        failed,
+      ))
+      .mockResolvedValueOnce(sse(
+        'data: {"type":"response.created","response":{"id":"r2","model":"gpt-5.6-luna"}}\n\n',
+        'data: {"type":"response.output_text.delta","item_id":"message-1","output_index":0,"content_index":0,"delta":"OK"}\n\n',
+        'data: {"type":"response.completed","response":{"id":"r2","model":"gpt-5.6-luna","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
+      ));
+
+    const response = await new CodexResponsesAdapter({ fetch: fetchMock }).stream(request(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected success");
+    const frames = parseSse(await collectBody(encodeAnthropicSse(response.events)));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // r1의 created/add(message)는 버퍼에서 폐기된다. message_start는 r2를 싣고
+    // r2의 내용과 usage가 atomic하게 내려온다.
+    expect(frames.map((frame) => frame.event)).toEqual([
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ]);
+    expect(frames[0]?.data).toMatchObject({
+      type: "message_start",
+      message: { id: "r2", model: "gpt-5.6-luna" },
+    });
+    expect(frames[2]?.data).toMatchObject({ delta: { type: "text_delta", text: "OK" } });
+    expect(frames[4]?.data).toMatchObject({
+      type: "message_delta",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+  });
+
   it("retries the observed overload error pair before output", async () => {
     const fetchMock = vi.fn<typeof fetch>()
       .mockResolvedValueOnce(sse(


### PR DESCRIPTION
## Summary
- Retry transient Codex `server_error`, overload, and service-unavailable SSE failures once before caller-visible output begins.
- Preserve terminal and post-output failures without replaying text or tool calls.
- Cancel pending retry delays and in-flight retry requests when the response iterator is closed.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` (601 tests)
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check --allow-empty`
- [x] Deterministic provider-error and iterator-cancellation probes
- [x] Live Codex concurrency probe (40/40 completed, 1.0x clean-path request amplification)
- [x] Independent adversarial review