### PR TITLE
feat(fleet-console): mark Operations with their launch provider glyph

### DIFF
--- a/.changelog.d/operation-provider-glyph.md
+++ b/.changelog.d/operation-provider-glyph.md
@@ -1,0 +1,8 @@
+---
+branch: operation-provider-glyph
+---
+
+### fleet-console
+#### Changed
+- Mark each Agent Operation with the provider whose model launched it, so the sidebar, the command band, and the search palette all show that provider's glyph in its own carrier colour instead of one uniform Claude mark.
+  ko: 각 Agent Operation에 어떤 공급자의 모델로 실행되었는지를 새겨, 사이드바와 커맨드 밴드, 검색 팔레트가 모두 하나의 획일적인 Claude 마크 대신 그 공급자의 글리프를 고유한 캐리어 색으로 보여 줍니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -411,7 +411,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
                 const kindKey = itemKey(plugin.id, kind.id);
                 return (
                   <div key={kindKey} role="group" aria-label={kind.title}>
-                    {variantKindCount > 1 ? <p className="canvas-context-menu-plugin">{kind.title}</p> : null}
+                    {variantKindCount > 1 ? <p className="operation-launch-variant-caption">{kind.title}</p> : null}
                     {kind.variants!.map((group, groupIndex) => (
                       <div key={group.id} className="operation-launch-variant-group">
                         {directKinds.length > 0 || kindIndex > 0 || groupIndex > 0
@@ -544,7 +544,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
           {terminalShellKinds.length > 0 ? (
             <div role="group" aria-label={t("canvas.menu.etc")}>
               {primaryCatalog.length > 0 ? <div className="theater-menu-divider" role="separator" /> : null}
-              <p className="canvas-context-menu-plugin canvas-context-menu-plugin--etc">
+              <p className="operation-launch-variant-caption">
                 <span className="operation-launch-provider-glyph operation-launch-provider-glyph--etc" aria-hidden="true">
                   {launchEtcGlyph()}
                 </span>

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -10,6 +10,7 @@ import { cycleTriageDeckZoomPreset } from "../canvas/triage-watch-deck.js";
 import { COMMAND_BAND_RAIL_STRIP_PX, commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandMapControlsAnchor, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "./command-band-guards.js";
 import { CommandBandOperationMenu, CommandBandTheaterMenu, CommandBandTriggerCaret, type CommandBandSwitcherMenu } from "./command-band-switcher.js";
 import { CommandBandSystemCluster } from "./command-band-system-cluster.js";
+import { launchProviderFromOperationPayload, launchProviderGlyph } from "./launch-provider-glyphs.js";
 import { useGlobalSettingsStore } from "../global-settings-store.js";
 import { useConsoleState } from "../hooks/use-store.js";
 import { setRailChromeExpanded, toggleRailChrome, useRailChromeExpanded } from "../rail/rail-store.js";
@@ -133,7 +134,14 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const globalSettings = useGlobalSettingsStore();
   const language = resolveConsoleLanguage(globalSettings.state?.language ?? "auto");
   const activeKindTitle = activeKind ? resolveLocalizedText(activeKind.title, language) : null;
-  const activeOperationIcon = activeOperation && activePlugin?.renderLaunchIcon ? activePlugin.renderLaunchIcon({ id: activeCliId ?? activeOperation.type, type: activeOperation.type, title: activeKindTitle ?? activeOperation.type }) : null;
+  // 사이드바 칩과 같은 규율: 실행된 공급자가 기록된 Operation은 그 공급자의 마크가
+  // 플러그인 실행 종류 아이콘을 대신하고, 캐리어 시그니처 톤을 함께 입는다.
+  const activeLaunchProvider = launchProviderFromOperationPayload(activeOperation?.payload);
+  const activeOperationIcon = activeLaunchProvider
+    ? launchProviderGlyph(activeLaunchProvider)
+    : activeOperation && activePlugin?.renderLaunchIcon
+      ? activePlugin.renderLaunchIcon({ id: activeCliId ?? activeOperation.type, type: activeOperation.type, title: activeKindTitle ?? activeOperation.type })
+      : null;
   const environmentTriggerRef = useRef<HTMLButtonElement>(null);
   const environmentPopoverRef = useRef<HTMLDivElement>(null);
   const commandBandRef = useRef<HTMLElement>(null);
@@ -611,7 +619,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
                 <span className="command-band-segment-label">{activeOperation.title}</span>
                 <CommandBandTriggerCaret />
               </button>}
-              {activeCliLabel ? <span className="command-band-operation-attribute" title={activeKindTitle ?? activeCliLabel}>{activeOperationIcon ? <span className="command-band-operation-kind" aria-hidden="true">{activeOperationIcon}</span> : null}{activeCliLabel}</span> : null}
+              {activeCliLabel ? <span className="command-band-operation-attribute" title={activeKindTitle ?? activeCliLabel}>{activeOperationIcon ? <span className={`command-band-operation-kind${activeLaunchProvider ? ` operation-provider-mark is-${activeLaunchProvider}` : ""}`} aria-hidden="true">{activeOperationIcon}</span> : null}{activeCliLabel}</span> : null}
             </> : <button
               ref={operationTriggerRef}
               type="button"

--- a/runtime/fleet-console/core/client/src/components/launch-provider-glyphs.tsx
+++ b/runtime/fleet-console/core/client/src/components/launch-provider-glyphs.tsx
@@ -79,6 +79,29 @@ export function launchProviderFromGroupId(groupId: string): LaunchProviderGlyphI
   return null;
 }
 
+/**
+ * Read the provider an Operation was launched with from its payload.
+ *
+ * The launching plugin records this once at launch, so chrome marks the supplier that
+ * actually ran without asking the plugin to re-derive it per surface. Operations whose
+ * plugin does not record a provider return `null` and keep their plugin-owned kind icon.
+ */
+export function launchProviderFromOperationPayload(
+  payload: Readonly<Record<string, unknown>> | undefined,
+): LaunchProviderGlyphId | null {
+  const provider = payload?.launchProvider;
+  if (
+    provider === "claude"
+    || provider === "codex"
+    || provider === "cursor"
+    || provider === "kimi"
+    || provider === "opencode"
+  ) {
+    return provider;
+  }
+  return null;
+}
+
 /** Resolve the provider glyph for a selected launch-model id (`fable` or `cursor--grok-4.5`). */
 export function launchProviderFromModelId(modelId: string | null | undefined): LaunchProviderGlyphId | null {
   if (!modelId) return null;

--- a/runtime/fleet-console/core/client/src/components/operation-search.tsx
+++ b/runtime/fleet-console/core/client/src/components/operation-search.tsx
@@ -5,6 +5,7 @@ import type { FleetClientPlugin } from "@fleet-console/sdk/plugin";
 import type { RailPanelDescriptor, RailSearchResult } from "@fleet-console/sdk/rail";
 
 import { fetchSearch } from "../codex/api.js";
+import { launchProviderGlyph } from "./launch-provider-glyphs.js";
 import { propagateSettingsEntryIndex, recordSettingsEntryIndex } from "./command-band-system-cluster.js";
 import { setGlobalSettingsField } from "../global-settings-store.js";
 import { toggleCommandBandDocked } from "../fullscreen-band-store.js";
@@ -659,6 +660,11 @@ export function OperationSearch({
                           onMouseEnter={() => setSelectedIndex(index)}
                           onClick={() => selectEntry(entry.operationId)}
                         >
+                          {entry.launchProvider ? (
+                            <span className={`operation-search-op-mark operation-provider-mark is-${entry.launchProvider}`} aria-hidden="true">
+                              {launchProviderGlyph(entry.launchProvider)}
+                            </span>
+                          ) : null}
                           <span className="operation-search-result-text">
                             <strong>{highlightText(entry.operationName, tokens)}</strong>
                             <small>{operationMeta(entry)}</small>

--- a/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/canvas.ts
@@ -278,7 +278,7 @@ export const canvasKo: Record<keyof typeof canvasEn, string> = {
   "canvas.plugin.companionFailed": "Plugin Companion을 렌더하지 못했습니다.",
 
   "canvas.menu.aria": "Operation 실행 메뉴",
-  "canvas.menu.etc": "Etc",
+  "canvas.menu.etc": "기타",
   "canvas.menu.empty": "사용 가능한 Operation이 없습니다.",
 
   "canvas.minimap.open": "Map 열기",

--- a/runtime/fleet-console/core/client/src/operation-search.ts
+++ b/runtime/fleet-console/core/client/src/operation-search.ts
@@ -2,6 +2,7 @@ import { resolveLocalizedText } from "@fleet-console/sdk/i18n/translate";
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
 import type { RailPanelDescriptor, RailSearchResult } from "@fleet-console/sdk/rail";
 
+import { launchProviderFromOperationPayload, type LaunchProviderGlyphId } from "./components/launch-provider-glyphs.js";
 import { getGlobalSettingsStoreState } from "./global-settings-store.js";
 import { resolveOperationActivity } from "./operation-activity.js";
 import type { ConsoleState, OperationNode, TheaterInfo } from "./types.js";
@@ -15,6 +16,8 @@ export interface OperationSearchEntry {
   readonly pluginId: string;
   readonly status: string;
   readonly activity: OperationActivity;
+  /** 실행된 공급자. 기록하지 않는 플러그인의 Operation은 null이고 마크를 그리지 않는다. */
+  readonly launchProvider: LaunchProviderGlyphId | null;
 }
 
 export interface OperationSearchGroup {
@@ -142,6 +145,7 @@ function toOperationSearchEntry(
     pluginId: operation.pluginId,
     status: "operation",
     activity: resolveOperationActivity(operation, operationStatus),
+    launchProvider: launchProviderFromOperationPayload(operation.payload),
   };
 }
 

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar-chip.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, type CSSProperties, type PointerEvent as ReactPointe
 
 import type { OperationActivity } from "@fleet-console/sdk/plugin";
 
+import type { LaunchProviderGlyphId } from "../components/launch-provider-glyphs.js";
 import { useT } from "../i18n/index.js";
 import { operationActivityLabel, operationActivityVisual } from "../operation-activity.js";
 import { useInlineRename } from "../use-inline-rename.js";
@@ -18,6 +19,8 @@ export interface SideBarEntry {
   readonly notificationCount: number;
   readonly status?: OperationActivity;
   readonly icon: ReactNode;
+  /** 실행된 공급자. 있으면 마크가 그 공급자의 캐리어 시그니처 톤을 입는다. */
+  readonly launchProvider?: LaunchProviderGlyphId | null;
 }
 
 interface SideBarChipProps {
@@ -221,7 +224,7 @@ export function OperationsSideBarChip({
       }}
     >
       <span className="side-bar-chip-beacon-button" aria-hidden="true">
-        <span className="side-bar-chip-op-icon">
+        <span className={`side-bar-chip-op-icon${entry.launchProvider ? ` operation-provider-mark is-${entry.launchProvider}` : ""}`}>
           {entry.icon ?? <DefaultOpIcon />}
         </span>
       </span>

--- a/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
+++ b/runtime/fleet-console/core/client/src/sidebar/operations-side-bar.tsx
@@ -11,6 +11,7 @@ import type { OperationGroup, OperationNode, OperationNotification, TheaterInfo 
 import { CanvasContextMenu } from "../canvas/canvas-context-menu.js";
 import { focusCommandBandToggleWhenPanelContainsActiveElement } from "../focus-guards.js";
 import { DirectoryBrowserModal } from "../components/directory-browser-modal.js";
+import { launchProviderFromOperationPayload, launchProviderGlyph, type LaunchProviderGlyphId } from "../components/launch-provider-glyphs.js";
 import { useConsoleState } from "../hooks/use-store.js";
 import { GroupContextMenu } from "../canvas/group-context-menu.js";
 import { operationAccentFromNode, resolveAccentColor } from "../canvas/operation-accent.js";
@@ -393,18 +394,14 @@ export function OperationsSideBar({
   const activeGroups = groups.filter((group) => group.theaterId === activeTheaterId);
   const minimizedSet = new Set(minimized);
   const collapsedGroupSet = new Set(collapsedGroups);
-  const allEntries: SideBarEntry[] = sortOperationsByOrder(activeOperations, canvas.operationOrder).map((operation) => {
-    const kind = resolveOperationLaunchKind(catalog, operation);
-    const icon = kind ? renderKindIcon(operation.pluginId, kind) : null;
-    return {
-      operation,
-      active: activeOperationId === operation.id,
-      minimized: minimizedSet.has(operation.id),
-      notificationCount: operationNotifications[operation.id] ? 1 : 0,
-      status: resolveOperationActivity(operation, operationStatus),
-      icon,
-    };
-  });
+  const allEntries: SideBarEntry[] = sortOperationsByOrder(activeOperations, canvas.operationOrder).map((operation) => ({
+    operation,
+    active: activeOperationId === operation.id,
+    minimized: minimizedSet.has(operation.id),
+    notificationCount: operationNotifications[operation.id] ? 1 : 0,
+    status: resolveOperationActivity(operation, operationStatus),
+    ...resolveOperationMark(operation, catalog, renderKindIcon),
+  }));
   const groupedSections = groupOperations(allEntries, activeGroups, canvas.operationOrder);
   const { living: statusSections, minimized: minimizedSection, dormant: dormantSection } = groupTheaterStatusEntries(
     allEntries,
@@ -1348,18 +1345,30 @@ export function buildTheaterEntries({
   return sortOperationsByOrder(
     operations.filter((operation) => operation.theaterId === theaterId),
     operationOrder,
-  ).map((operation) => {
-    const kind = resolveOperationLaunchKind(catalog, operation);
-    const icon = kind ? renderKindIcon(operation.pluginId, kind) : null;
-    return {
-      operation,
-      active: activeOperationId === operation.id,
-      minimized: minimizedSet.has(operation.id),
-      notificationCount: operationNotifications[operation.id] ? 1 : 0,
-      status: resolveOperationActivity(operation, operationStatus),
-      icon,
-    };
-  });
+  ).map((operation) => ({
+    operation,
+    active: activeOperationId === operation.id,
+    minimized: minimizedSet.has(operation.id),
+    notificationCount: operationNotifications[operation.id] ? 1 : 0,
+    status: resolveOperationActivity(operation, operationStatus),
+    ...resolveOperationMark(operation, catalog, renderKindIcon),
+  }));
+}
+
+/**
+ * 칩이 쓸 마크. 실행된 공급자가 기록된 Operation은 그 공급자의 글리프가 실행 종류 아이콘을
+ * 대신한다 — 같은 실행 종류라도 어느 공급자의 모델이 돌았는지가 목록에서 먼저 읽혀야 한다.
+ * 공급자를 기록하지 않는 플러그인은 그대로 자기 아이콘을 그린다.
+ */
+function resolveOperationMark(
+  operation: OperationNode,
+  catalog: readonly OperationCatalogPlugin[],
+  renderKindIcon: (pluginId: string, kind: OperationLaunchKind) => ReactNode,
+): { readonly icon: ReactNode; readonly launchProvider: LaunchProviderGlyphId | null } {
+  const launchProvider = launchProviderFromOperationPayload(operation.payload);
+  if (launchProvider) return { icon: launchProviderGlyph(launchProvider), launchProvider };
+  const kind = resolveOperationLaunchKind(catalog, operation);
+  return { icon: kind ? renderKindIcon(operation.pluginId, kind) : null, launchProvider: null };
 }
 
 function TheaterSectionHeader({

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3737,27 +3737,6 @@
   background: color-mix(in oklch, var(--brass) 12%, transparent);
 }
 
-/* 플러그인이 둘 이상일 때만 서는 그룹 라벨. 하나뿐이면 헤더 줄에 병합돼 이 행 자체가 없다. */
-.canvas-context-menu-plugin {
-  margin: var(--space-1) 0 0;
-  padding: var(--space-1) var(--space-2) 0;
-  color: color-mix(in oklch, var(--brass) 72%, var(--text-tertiary));
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.canvas-context-menu-plugin--etc {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.operation-launch-provider-glyph--etc {
-  --launch-provider-tone: color-mix(in oklch, var(--brass) 72%, var(--text-tertiary));
-}
-
 .canvas-context-menu-help {
   display: grid;
   gap: var(--space-2);
@@ -7240,14 +7219,20 @@
   white-space: nowrap;
 }
 
+/* 세로 인셋은 모델 행 껍데기(.operation-launch-variant-entry)와 같은 값이어야 한다 — 한 목록에
+   두 껍데기가 서므로, 값이 갈리면 머리글~첫 행과 행~행 간격이 그룹마다 어긋난다. 가로는 비운다:
+   여기에 인셋을 주면 항목 라벨이 모델 행 라벨보다 그만큼 밀려 왼쪽 글자 열이 둘로 갈린다. */
 .operation-launch-menu-item-wrap {
   position: relative;
+  padding: 1px 0;
 }
 
 .operation-launch-menu-item-wrap > .operation-launch-menu-item {
   width: 100%;
 }
 
+/* 캔버스 메뉴의 모든 그룹 머리글이 이 한 규칙을 쓴다 — 공급자 밴드, 실행 종류 이름, 최하단 Etc가
+   각자 머리글 문법을 가지면 같은 목록 안에서 머리글과 첫 항목 사이 간격이 그룹마다 달라진다. */
 .operation-launch-variant-caption {
   display: flex;
   align-items: center;
@@ -7272,6 +7257,11 @@
 .quick-launch-pop-band.is-kimi { --launch-provider-tone: var(--provider-kimi); }
 .operation-launch-variant-caption.is-opencode,
 .quick-launch-pop-band.is-opencode { --launch-provider-tone: var(--provider-opencode); }
+
+/* Etc는 공급자가 아니므로 캐리어 색을 빌리지 않고 머리글 잉크를 그대로 쓴다. */
+.operation-launch-provider-glyph--etc {
+  --launch-provider-tone: color-mix(in oklch, var(--brass) 72%, var(--text-tertiary));
+}
 
 .operation-launch-provider-glyph {
   display: inline-flex;
@@ -7303,6 +7293,16 @@
 .quick-launch-kind-icon.is-cursor { --launch-provider-tone: var(--provider-cursor); }
 .quick-launch-kind-icon.is-kimi { --launch-provider-tone: var(--provider-kimi); }
 .quick-launch-kind-icon.is-opencode { --launch-provider-tone: var(--provider-opencode); }
+
+/* 실행된 공급자 마크 — Operation 글리프는 어느 공급자의 모델로 돌았는지를 이름한다. Operation을
+   세는 세 크롬 표면(사이드바 칩·커맨드 밴드·팔레트)이 하나의 캐리어 시그니처 톤을 공유하므로
+   대조표는 여기 한 번만 적고, 각 표면은 자기 치수만 소유한다. 공급자는 정체성 축이라 마크의
+   잉크에만 머문다 — 테두리·상태 표면을 덧칠하지 않고, 포커스나 활성으로 다시 칠하지도 않는다. */
+.operation-provider-mark.is-claude { color: var(--provider-claude); }
+.operation-provider-mark.is-codex { color: var(--provider-codex); }
+.operation-provider-mark.is-cursor { color: var(--provider-cursor); }
+.operation-provider-mark.is-kimi { color: var(--provider-kimi); }
+.operation-provider-mark.is-opencode { color: var(--provider-opencode); }
 
 .operation-launch-variant-entry {
   padding: 1px var(--space-1);
@@ -8616,6 +8616,20 @@
 
 .operation-search-result.is-active .operation-search-command-glyph {
   color: var(--brass-bright);
+}
+
+/* 명령 행의 선행 글리프 슬롯과 같은 자리를 Operation 행에서는 공급자 마크가 쓴다. */
+.operation-search-op-mark {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 16px;
+  height: 16px;
+}
+
+.operation-search-op-mark svg {
+  width: 14px;
+  height: 14px;
 }
 
 .operation-search-panel-open {

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -203,7 +203,7 @@ describe("CanvasContextMenu launch kind attribute", () => {
     expect(document.querySelector(".canvas-context-menu-head")).toBeNull();
     expect(document.querySelector(".canvas-context-menu")?.textContent).not.toContain("Controls");
     expect(document.querySelector(".canvas-context-menu")?.textContent).not.toContain("Terminal");
-    const groupLabels = Array.from(document.querySelectorAll(".canvas-context-menu-plugin")).map((node) => node.textContent?.trim());
+    const groupLabels = Array.from(document.querySelectorAll(".operation-launch-variant-caption")).map((node) => node.textContent?.trim());
     expect(groupLabels).toEqual(["Etc"]);
     const etcGlyph = document.querySelector(".operation-launch-provider-glyph--etc");
     expect(etcGlyph?.querySelectorAll("circle")).toHaveLength(3);
@@ -534,8 +534,8 @@ describe("CanvasContextMenu launch kind attribute", () => {
       .querySelectorAll('[data-operation-launch-kind="shell"], .operation-launch-variant-caption, [data-launch-variant-row]'))
       .map((element) => element.getAttribute("data-launch-variant-row")
         ?? element.getAttribute("data-operation-launch-kind")
-        ?? "caption");
-    expect(order).toEqual(["caption", "fable", "shell"]);
+        ?? `caption:${element.textContent?.trim()}`);
+    expect(order).toEqual(["caption:Claude built-in", "fable", "caption:Etc", "shell"]);
     expect(document.querySelector('[aria-label="Etc"] [data-operation-launch-kind="shell"]')).not.toBeNull();
   });
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -436,6 +436,10 @@ describe("Instrument core design contract", () => {
     expect(contextMenu).not.toContain("canvas-context-menu-head");
     expect(contextMenu).toContain('aria-label={t("canvas.menu.etc")}');
     expect(contextMenu).toContain("operation-launch-provider-glyph--etc");
+    // 그룹 머리글은 캔버스 메뉴 전체에서 한 클래스뿐이다 — 머리글 문법이 갈라지면 머리글과 첫
+    // 항목 사이 간격이 그룹마다 어긋난다(Etc가 하위 항목에 붙어 보였던 회귀).
+    expect(contextMenu).not.toContain("canvas-context-menu-plugin");
+    expect(components).not.toContain(".canvas-context-menu-plugin");
     expect(contextMenu).not.toContain("CanvasContextMenuMode");
     expect(contextMenu).not.toContain("canvas-context-menu-tabs");
     expect(contextMenu).not.toContain("Formation view");
@@ -584,6 +588,30 @@ describe("Instrument core design contract", () => {
     const unclassed = css.match(/\.ai-gateway-class-badge\.is-unclassed \{[^}]*\}/)?.[0] ?? "";
     expect(unclassed).toContain("border-style: dashed;");
     expect(unclassed).not.toContain("border-color:");
+  });
+
+  it("pins the Operation provider mark grammar — one tone table, ink only, no state repaint", () => {
+    // 사이드바 칩·커맨드 밴드·팔레트는 같은 Operation을 세 곳에서 센다. 세 표면이 각자 톤을
+    // 적으면 한 곳만 고쳐도 컴파일은 되고 같은 Operation이 두 색으로 보인다 — 대조표는
+    // .operation-provider-mark 한 곳에만 있어야 하고, 표면 클래스는 치수만 소유한다.
+    const css = source("styles/components.css");
+    for (const provider of ["claude", "codex", "cursor", "kimi", "opencode"]) {
+      expect(css).toContain(`.operation-provider-mark.is-${provider} { color: var(--provider-${provider}); }`);
+    }
+    // 공급자는 정체성 축이다 — 마크의 잉크에만 머물러야 하므로 배경·테두리로 번지지 않고,
+    // 신호색·brass를 빌려 상태·위치 채널과 충돌하지도 않는다.
+    for (const [, body] of css.matchAll(/\.operation-provider-mark[^{}]*\{([^}]*)\}/g)) {
+      expect(body).not.toMatch(/background|border|box-shadow/);
+      expect(body).not.toMatch(/var\(--(aurora|warn|coral|positive|brass)[a-z-]*\)/);
+    }
+    // 정체성은 포커스·활성으로 다시 칠하지 않는다. 명령 행 글리프가 brass로 반응하는 것과
+    // 달리, 공급자 마크는 어느 상태에서도 같은 톤을 유지해야 같은 Operation으로 읽힌다.
+    expect(css).not.toMatch(/\.is-active[^{}]*\.operation-provider-mark/);
+
+    // 세 표면 모두 공용 마크 클래스를 통해 톤을 받는다 — 하나라도 자기 색을 적으면 대조표가 갈라진다.
+    expect(source("sidebar/operations-side-bar-chip.tsx")).toContain("operation-provider-mark is-${entry.launchProvider}");
+    expect(source("components/command-band.tsx")).toContain("operation-provider-mark is-${activeLaunchProvider}");
+    expect(source("components/operation-search.tsx")).toContain("operation-provider-mark is-${entry.launchProvider}");
   });
 
   it("pins the AI Gateway provider-priority toggle grammar — ink rank only, no signal colour, no brass", () => {

--- a/runtime/fleet-console/tests/launch-provider-glyphs.test.ts
+++ b/runtime/fleet-console/tests/launch-provider-glyphs.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { launchProviderFromOperationPayload } from "../core/client/src/components/launch-provider-glyphs.js";
+
+describe("launchProviderFromOperationPayload", () => {
+  it("기록된 공급자를 그대로 읽는다", () => {
+    for (const provider of ["claude", "codex", "cursor", "kimi", "opencode"] as const) {
+      expect(launchProviderFromOperationPayload({ launchProvider: provider })).toBe(provider);
+    }
+  });
+
+  it("공급자를 기록하지 않는 Operation은 null이다", () => {
+    expect(launchProviderFromOperationPayload({})).toBeNull();
+    expect(launchProviderFromOperationPayload(undefined)).toBeNull();
+  });
+
+  // 어휘 밖의 값을 통과시키면 CSS 대조표에 없는 수식 클래스가 붙어 마크가 조용히 색을 잃는다.
+  // 서버가 다른 어휘로 흘러가도 표면은 플러그인 아이콘으로 되돌아가야 한다.
+  it("어휘 밖의 값은 통과시키지 않는다", () => {
+    expect(launchProviderFromOperationPayload({ launchProvider: "gemini" })).toBeNull();
+    expect(launchProviderFromOperationPayload({ launchProvider: "" })).toBeNull();
+    expect(launchProviderFromOperationPayload({ launchProvider: 7 })).toBeNull();
+    expect(launchProviderFromOperationPayload({ launchProvider: { id: "cursor" } })).toBeNull();
+  });
+});

--- a/runtime/fleet-plugins/terminal/server/agent-api/launch-provider.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/launch-provider.ts
@@ -1,0 +1,26 @@
+import { GATEWAY_PROVIDERS, type GatewayProvider } from "@dotobokuri/core-ai-gateway";
+
+/**
+ * 어떤 공급자의 모델로 실행되었는지. Operation payload에 영속되어 Console 크롬이
+ * 사이드바·커맨드 밴드 글리프를 고르는 유일한 근거가 된다. 세션이 도는 동안 CLI 안에서
+ * 모델을 바꿔도 이 값은 실행 시점 사실이라 움직이지 않는다.
+ */
+export type AgentLaunchProvider = "claude" | GatewayProvider;
+
+export const AGENT_LAUNCH_PROVIDER_PAYLOAD_KEY = "launchProvider";
+
+// 게이트웨이 모델 id는 `${provider}--${model}`이고, 구분자가 없는 id는 Claude Code 순정 별칭이다.
+const GATEWAY_MODEL_SEPARATOR = "--";
+
+/** 실행 모델 id에서 공급자를 읽는다. 모델을 고르지 않은 실행은 순정 Claude다. */
+export function agentLaunchProviderFromModel(model: string | undefined): AgentLaunchProvider {
+  if (!model) return "claude";
+  const separator = model.indexOf(GATEWAY_MODEL_SEPARATOR);
+  if (separator <= 0) return "claude";
+  const candidate = model.slice(0, separator);
+  return GATEWAY_PROVIDERS.includes(candidate as GatewayProvider) ? candidate as GatewayProvider : "claude";
+}
+
+export function isAgentLaunchProvider(value: unknown): value is AgentLaunchProvider {
+  return value === "claude" || GATEWAY_PROVIDERS.includes(value as GatewayProvider);
+}

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -25,6 +25,7 @@ import { deriveOperationLabel } from "./agent-api/auto-name.js";
 import { normalizeAttentionReason } from "./agent-api/attention-hook.js";
 import { readBackgroundHookReport } from "./agent-api/background-report.js";
 import { createAgentTerminalLaunchResolver, GatewayLaunchOptionError, isGatewayLaunchEffortAllowed, type ConsoleRuntimeSessionInfo } from "./agent-api/launch.js";
+import { AGENT_LAUNCH_PROVIDER_PAYLOAD_KEY, agentLaunchProviderFromModel, isAgentLaunchProvider } from "./agent-api/launch-provider.js";
 import { createConsoleObservabilityStore } from "./agent-api/observability-store.js";
 import { writeAgentSessionEvents } from "./agent-api/observability-routes.js";
 import { createOscAgentActivityTracker, type OscAgentActivityTracker } from "./agent-api/osc-agent-activity.js";
@@ -78,6 +79,17 @@ export function buildAgentLaunchKindBackfillPatch(operation: AgentLaunchKindBack
   if (typeof cliId !== "string" || cliId.length === 0) return null;
   if (operation.payload.launchKindId !== undefined) return null;
   return { payload: { ...operation.payload, launchKindId: cliId } };
+}
+
+/**
+ * 공급자 기록이 없는 agent Operation을 순정 Claude로 메운다. 이 축이 생기기 전에 실행된
+ * Operation의 실제 모델은 어디에도 남아 있지 않지만, 그때도 크롬은 Claude 마크를 보여 주고
+ * 있었으므로 같은 사실로 메워야 새 실행과 표현이 갈라지지 않는다.
+ */
+export function buildAgentLaunchProviderBackfillPatch(operation: AgentLaunchKindBackfillOperation): Pick<OperationPatchInput, "payload"> | null {
+  if (operation.pluginId !== TERMINAL_PLUGIN_ID || operation.type !== AGENT_OPERATION_TYPE) return null;
+  if (isAgentLaunchProvider(operation.payload[AGENT_LAUNCH_PROVIDER_PAYLOAD_KEY])) return null;
+  return { payload: { ...operation.payload, [AGENT_LAUNCH_PROVIDER_PAYLOAD_KEY]: "claude" } };
 }
 
 // 로스터는 호출 시점에 해석한다. 노출 선별은 세션이 도는 동안에도 사용자가 바꿀 수 있고,
@@ -182,7 +194,7 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
     observability.notifySessionUpdated(dormant);
   });
 
-  backfillAgentOperationLaunchKinds();
+  backfillAgentOperationLaunchAxes();
   rehydrateDormantAgentOperations();
   startIdleAgentDormantSweeper({
     loadGlobalOptions: () => deps.globalOptionsService.load(),
@@ -421,7 +433,12 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
       type: AGENT_OPERATION_TYPE,
       pluginId: ctx.pluginId,
       title: session.label ?? path.basename(cwd),
-      payload: toOperationPayload(undefined, cwd, session),
+      // 공급자는 실행 시점에 한 번 확정되고 이후 어떤 patch도 다시 쓰지 않는다 —
+      // toOperationPayload가 지우는 키 목록 밖이라 resume·복원을 지나도 그대로 남는다.
+      payload: {
+        ...toOperationPayload(undefined, cwd, session),
+        [AGENT_LAUNCH_PROVIDER_PAYLOAD_KEY]: agentLaunchProviderFromModel(launchOptions.model),
+      },
       createdAt: session.createdAt,
     });
     try {
@@ -832,11 +849,15 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
     }
   }
 
-  function backfillAgentOperationLaunchKinds(): void {
+  function backfillAgentOperationLaunchAxes(): void {
     for (const operation of ctx.host.operations.list()) {
-      const patch = buildAgentLaunchKindBackfillPatch(operation);
-      if (!patch) continue;
-      ctx.host.operations.patch(operation.id, patch);
+      // 두 축을 같은 payload 위에 겹쳐 쌓아 한 번만 patch한다 — 축마다 patch하면
+      // 뒤 patch가 읽는 payload가 앞 patch 이전 스냅숏이라 먼저 메운 축이 지워진다.
+      const kindPatch = buildAgentLaunchKindBackfillPatch(operation);
+      const payload = kindPatch?.payload ?? operation.payload;
+      const providerPatch = buildAgentLaunchProviderBackfillPatch({ ...operation, payload });
+      const next = providerPatch?.payload ?? kindPatch?.payload;
+      if (next) ctx.host.operations.patch(operation.id, { payload: next });
     }
   }
 

--- a/runtime/fleet-plugins/terminal/tests/agent-launch-provider.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-launch-provider.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { OperationNode } from "@fleet-console/sdk/operations";
+
+import { buildAgentLaunchProviderBackfillPatch } from "../server/agent.js";
+import { agentLaunchProviderFromModel, isAgentLaunchProvider } from "../server/agent-api/launch-provider.js";
+
+describe("agentLaunchProviderFromModel", () => {
+  it("게이트웨이 모델 id의 접두 공급자를 읽는다", () => {
+    expect(agentLaunchProviderFromModel("cursor--grok-4.5")).toBe("cursor");
+    expect(agentLaunchProviderFromModel("codex--gpt-5.6")).toBe("codex");
+    expect(agentLaunchProviderFromModel("kimi--k2")).toBe("kimi");
+    expect(agentLaunchProviderFromModel("opencode--grok-code")).toBe("opencode");
+  });
+
+  it("순정 Claude 별칭과 모델 미지정 실행은 claude다", () => {
+    expect(agentLaunchProviderFromModel("fable[1m]")).toBe("claude");
+    expect(agentLaunchProviderFromModel("sonnet")).toBe("claude");
+    expect(agentLaunchProviderFromModel(undefined)).toBe("claude");
+  });
+
+  // 카탈로그가 새 공급자를 들이거나 모델 id 문법이 바뀌어도 마크는 조용히 비지 않아야 한다 —
+  // 모르는 접두는 실패가 아니라 순정 Claude로 읽는다.
+  it("알 수 없는 접두는 claude로 되돌린다", () => {
+    expect(agentLaunchProviderFromModel("unknown--model")).toBe("claude");
+    expect(agentLaunchProviderFromModel("--leading")).toBe("claude");
+  });
+});
+
+describe("isAgentLaunchProvider", () => {
+  it("공급자 어휘만 통과시킨다", () => {
+    expect(isAgentLaunchProvider("claude")).toBe(true);
+    expect(isAgentLaunchProvider("cursor")).toBe(true);
+    expect(isAgentLaunchProvider("gemini")).toBe(false);
+    expect(isAgentLaunchProvider(undefined)).toBe(false);
+    expect(isAgentLaunchProvider(7)).toBe(false);
+  });
+});
+
+describe("buildAgentLaunchProviderBackfillPatch", () => {
+  it("공급자 기록이 없는 agent Operation을 claude로 메운다", () => {
+    const operation = makeOperation({ payload: { cliId: "claude-gateway", cwd: "/tmp/work" } });
+
+    expect(buildAgentLaunchProviderBackfillPatch(operation)).toEqual({
+      payload: { cliId: "claude-gateway", cwd: "/tmp/work", launchProvider: "claude" },
+    });
+  });
+
+  it("이미 기록된 공급자는 덮지 않는다", () => {
+    const operation = makeOperation({ payload: { launchProvider: "cursor" } });
+
+    expect(buildAgentLaunchProviderBackfillPatch(operation)).toBeNull();
+  });
+
+  it("어휘 밖의 값은 기록으로 인정하지 않고 claude로 되돌린다", () => {
+    const operation = makeOperation({ payload: { launchProvider: "gemini" } });
+
+    expect(buildAgentLaunchProviderBackfillPatch(operation)).toEqual({
+      payload: { launchProvider: "claude" },
+    });
+  });
+
+  it("terminal agent가 아닌 Operation은 no-op이다", () => {
+    expect(buildAgentLaunchProviderBackfillPatch(makeOperation({ type: "shell" }))).toBeNull();
+    expect(buildAgentLaunchProviderBackfillPatch(makeOperation({ pluginId: "diff" }))).toBeNull();
+  });
+});
+
+function makeOperation(input: Partial<OperationNode> = {}): OperationNode {
+  return {
+    id: "operation-1",
+    theaterId: "theater-1",
+    type: "agent",
+    pluginId: "terminal",
+    title: "Claude",
+    payload: {},
+    geometry: null,
+    ts: { createdAt: 1_000, updatedAt: 1_000 },
+    ...input,
+  };
+}


### PR DESCRIPTION
## Summary
- Agent Operation이 어떤 공급자의 모델로 실행되었는지를 payload에 영속화하고, 이 변경 전에 만들어진 Operation은 `claude`로 백필합니다 — 지금 보이는 Claude 마크의 뜻을 그대로 지키기 위함입니다.
- 사이드바 칩, 커맨드 밴드, Operation 검색 팔레트가 그 공급자를 읽어 Quota 플러그인과 같은 캐리어 톤으로 공급자 글리프를 그립니다. 톤은 `operation-provider-mark` 한 규칙이 소유합니다.
- 캔버스 실행 메뉴의 그룹 머리글을 `operation-launch-variant-caption` 한 클래스로 통합해, Etc 머리글과 첫 항목 사이 간격이 공급자 밴드와 같아집니다. 항목 껍데기에는 모델 행과 같은 세로 인셋만 줍니다(가로를 주면 라벨 열이 갈라짐).
- 한국어 `canvas.menu.etc` 라벨을 번역합니다. canary에서 깨져 있던 로케일 패리티 테스트도 함께 복구됩니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] `runtime/fleet-console` vitest — 1842 passed / 24 skipped
- [x] `pnpm --filter @fleet-plugins/terminal test` — 543 passed
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] boundary gates (core / claude-agent-sdk / core-unified-agent)
- [x] 헤들리스 브라우저 실측: 실행 메뉴 5개 그룹 모두 머리글 높이 24px · 머리글→첫 행 1px · 라벨 좌표 292px 일치 (이전 Etc만 0px)

Made with [Cursor](https://cursor.com)