### PR TITLE
feat(fleet-console): gate apex effort with ultracode CLI delivery

### DIFF
--- a/.changelog.d/ultracode-effort-gauge.md
+++ b/.changelog.d/ultracode-effort-gauge.md
@@ -1,0 +1,10 @@
+---
+branch: ultracode-effort-gauge
+---
+
+### fleet-console
+#### Added
+- The reasoning effort track now closes its everyday ladder at XHIGH and keeps MAX and ULTRACODE behind an apex expander; opening it plays a staged reveal, and an apex pick repaints the gauge in a dedicated violet channel.
+  ko: 추론 강도 트랙의 일상 사다리가 XHIGH에서 닫히고 MAX·ULTRACODE는 apex 확장 버튼 뒤로 숨습니다. 펼치면 단계적 등장 애니메이션이 재생되고, apex 단을 고르면 게이지가 전용 보라 채널로 전환됩니다.
+- ULTRACODE launches the operation with the standing multi-agent orchestration capability enabled and the wire effort pinned to MAX.
+  ko: ULTRACODE로 실행하면 상시 멀티에이전트 오케스트레이션 능력이 켜지고 wire 강도는 MAX로 고정됩니다.

--- a/.changelog.d/ultracode-effort-gauge.md
+++ b/.changelog.d/ultracode-effort-gauge.md
@@ -4,7 +4,7 @@ branch: ultracode-effort-gauge
 
 ### fleet-console
 #### Added
-- The reasoning effort track now closes its everyday ladder at XHIGH and keeps MAX and ULTRACODE behind an apex expander; opening it plays a staged reveal, and an apex pick repaints the gauge in a dedicated violet channel.
-  ko: 추론 강도 트랙의 일상 사다리가 XHIGH에서 닫히고 MAX·ULTRACODE는 apex 확장 버튼 뒤로 숨습니다. 펼치면 단계적 등장 애니메이션이 재생되고, apex 단을 고르면 게이지가 전용 보라 채널로 전환됩니다.
-- ULTRACODE launches the operation with the standing multi-agent orchestration capability enabled and the wire effort pinned to MAX.
-  ko: ULTRACODE로 실행하면 상시 멀티에이전트 오케스트레이션 능력이 켜지고 wire 강도는 MAX로 고정됩니다.
+- The reasoning effort track now closes its everyday ladder at XHIGH and keeps MAX and ULTRACODE behind an apex expander; opening it plays a staged reveal, MAX uses a molten-copper crest channel, and ULTRACODE paints the gauge violet with a flowing label wave.
+  ko: 추론 강도 트랙의 일상 사다리가 XHIGH에서 닫히고 MAX·ULTRACODE는 apex 확장 버튼 뒤로 숨습니다. 펼치면 단계적 등장 애니메이션이 재생되고, MAX는 용융 구리 crest 채널로, ULTRACODE는 보라 게이지와 흐르는 라벨 물결로 표현됩니다.
+- ULTRACODE launches the operation with Claude Code `--effort ultracode`, which applies xhigh effort and standing multi-agent orchestration together.
+  ko: ULTRACODE로 실행하면 Claude Code에 `--effort ultracode`가 전달되어 xhigh 강도와 상시 멀티에이전트 오케스트레이션이 함께 적용됩니다.

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "updatedAt": "2026-08-10T00:00:00Z",
+  "updatedAt": "2026-08-11T00:00:00Z",
   "providers": {
     "codex": {
       "name": "Codex",
       "defaultModel": "gpt-5.6-sol",
-      "source": "codex app-server model/list (codex-cli 0.146.0, 2026-08-01) for model/effort/service-tier; contextWindow=272000 is codex debug models context_window/max_context_window (codex-cli 0.146.0, 2026-08-02)",
+      "source": "codex app-server model/list (codex-cli 0.147.0, 2026-08-11 — ultra advertised for sol/sol-wm/terra, luna stops at max) for model/effort/service-tier; contextWindow=272000 is codex debug models context_window/max_context_window (codex-cli 0.146.0, 2026-08-02)",
       "models": [
         {
           "modelId": "gpt-5.6-sol",

--- a/packages/core-ai-gateway/src/models.ts
+++ b/packages/core-ai-gateway/src/models.ts
@@ -846,12 +846,17 @@ function registerLookupId(lookupIds: Set<string>, id: string, owner: string): vo
   lookupIds.add(id);
 }
 
+// 이 집합은 두 곳을 먹인다 — 콘솔 실행 행의 기본 노출 사다리(exposableEffortLadder 경유)와
+// fleet-admiral의 위임 신원 로스터(constraints.effortLadder 경유). ultra를 추가하면 카탈로그가
+// ultra를 낸 모델(Codex Sol/Terra 계열)에 -ultra 위임 신원이 기본 노출로 늘어난다; 노출 폭은
+// 사용자의 effort exposure 설정이 그대로 상한을 쥔다.
 const ANTHROPIC_EFFORT_RUNGS = new Set<GatewayReasoningEffort>([
   "low",
   "medium",
   "high",
   "xhigh",
   "max",
+  "ultra",
 ]);
 
 function freezeGatewayModelEffort(

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -614,10 +614,10 @@ describe("model catalog", () => {
       if (!model) throw new Error(`missing catalog model: ${id}`);
       return buildGatewayModelConstraints(model);
     };
-    // `ultra` exists in the Codex ladder but discovery never advertises it, so a
-    // caller offered that rung would have it silently clamped upstream.
+    // `ultra` is advertised by discovery since codex-cli 0.147.0 (measured 2026-08-11:
+    // sol/sol-wm/terra advertise it, luna stops at max) — the ladder follows the catalog.
     const codex = constraintsFor("codex--gpt-5.6-sol");
-    expect(codex.effortLadder).toEqual(["low", "medium", "high", "xhigh", "max"]);
+    expect(codex.effortLadder).toEqual(["low", "medium", "high", "xhigh", "max", "ultra"]);
     expect(codex.effortSupported).toBe(true);
     // Kimi's ladder has no `medium`; assuming one would be clamped without notice.
     expect(constraintsFor("kimi--k3").effortLadder).toEqual(["low", "high", "max"]);

--- a/packages/fleet-admiral/src/agent-cli/claude/factory.ts
+++ b/packages/fleet-admiral/src/agent-cli/claude/factory.ts
@@ -48,12 +48,11 @@ function buildModelArgs(model: string | undefined): string[] {
   return model === undefined ? [] : ["--model", model];
 }
 
-// ultracode는 wire effort가 아니라 하네스 능력(standing multi-agent orchestration)이다.
-// Claude Code CLI 2.1.226의 --effort는 max에서 닫히고 알 수 없는 값은 경고 후 기본값으로
-// 떨어지므로(2026-08-11 와이어 실측: --effort/--settings 모두 ultra→xhigh 클램프),
-// wire effort는 유효 최고 단인 max로 고정하고 능력은 settings 병합 채널로 켠다.
+// Console의 ultra 단은 Claude Code의 --effort ultracode다. CLI가 그 값으로 xhigh 강도와
+// standing dynamic-workflow orchestration을 함께 켠다 — max로 바꾸거나 settings로
+// ultracode를 우회 주입하지 않는다.
 function buildEffortArgs(effort: string | undefined): string[] {
   if (effort === undefined) return [];
-  if (effort === "ultra") return ["--effort", "max", "--settings", "{\"ultracode\":true}"];
+  if (effort === "ultra") return ["--effort", "ultracode"];
   return ["--effort", effort];
 }

--- a/packages/fleet-admiral/src/agent-cli/claude/factory.ts
+++ b/packages/fleet-admiral/src/agent-cli/claude/factory.ts
@@ -48,6 +48,12 @@ function buildModelArgs(model: string | undefined): string[] {
   return model === undefined ? [] : ["--model", model];
 }
 
+// ultracode는 wire effort가 아니라 하네스 능력(standing multi-agent orchestration)이다.
+// Claude Code CLI 2.1.226의 --effort는 max에서 닫히고 알 수 없는 값은 경고 후 기본값으로
+// 떨어지므로(2026-08-11 와이어 실측: --effort/--settings 모두 ultra→xhigh 클램프),
+// wire effort는 유효 최고 단인 max로 고정하고 능력은 settings 병합 채널로 켠다.
 function buildEffortArgs(effort: string | undefined): string[] {
-  return effort === undefined ? [] : ["--effort", effort];
+  if (effort === undefined) return [];
+  if (effort === "ultra") return ["--effort", "max", "--settings", "{\"ultracode\":true}"];
+  return ["--effort", effort];
 }

--- a/packages/fleet-admiral/src/agent-cli/gateway-agents.ts
+++ b/packages/fleet-admiral/src/agent-cli/gateway-agents.ts
@@ -90,13 +90,11 @@ export type { GatewayEffortExposure } from "@dotobokuri/core-ai-gateway";
  * 선택이 없거나 사다리와 하나도 겹치지 않으면 전체 사다리로 되돌린다 — 정체성이
  * 0개인 모델은 노출해 놓고 쓸 수 없는 상태라 어떤 선택보다도 나쁘다.
  *
- * ultra는 위임 정체성으로 내지 않는다. ultracode는 wire effort rung이 아니라 하네스
- * 능력(standing orchestration)이라, 커스텀 Agent frontmatter의 effort로는 전달할 수 없고
- * (claude CLI 2.1.226은 다섯 단 밖의 값을 경고 후 기본값으로 떨어뜨린다 — 2026-08-11 와이어
- * 실측) 정체성만 세우면 요청한 단이 아닌 것이 조용히 서빙된다. ultra의 전달 경로는 Operation
- * launch factory(--effort max + --settings {"ultracode":true})뿐이다. 이 사다리는 정체성 생성
- * (buildGatewayCustomAgents)과 로스터 셀렉터(model-loadout)가 함께 타는 깔때기라, 여기서
- * 걸러야 둘이 어긋나지 않는다.
+ * ultra는 위임 정체성으로 내지 않는다. ultracode는 커스텀 Agent frontmatter의 일상 사다리
+ * 단이 아니라 Operation launch factory가 `--effort ultracode`로 넘기는 세션 능력이다.
+ * 정체성 로스터에 ultra를 올리면 frontmatter effort가 CLI 일상 단과 어긋난다. 이 사다리는
+ * 정체성 생성(buildGatewayCustomAgents)과 로스터 셀렉터(model-loadout)가 함께 타는
+ * 깔때기라, 여기서 걸러야 둘이 어긋나지 않는다.
  */
 export function exposedEffortLadder(
   modelId: string,

--- a/packages/fleet-admiral/src/agent-cli/gateway-agents.ts
+++ b/packages/fleet-admiral/src/agent-cli/gateway-agents.ts
@@ -89,16 +89,25 @@ export type { GatewayEffortExposure } from "@dotobokuri/core-ai-gateway";
  * 사용자가 고른 강도만 남긴 사다리. 순서는 카탈로그 사다리를 따른다.
  * 선택이 없거나 사다리와 하나도 겹치지 않으면 전체 사다리로 되돌린다 — 정체성이
  * 0개인 모델은 노출해 놓고 쓸 수 없는 상태라 어떤 선택보다도 나쁘다.
+ *
+ * ultra는 위임 정체성으로 내지 않는다. ultracode는 wire effort rung이 아니라 하네스
+ * 능력(standing orchestration)이라, 커스텀 Agent frontmatter의 effort로는 전달할 수 없고
+ * (claude CLI 2.1.226은 다섯 단 밖의 값을 경고 후 기본값으로 떨어뜨린다 — 2026-08-11 와이어
+ * 실측) 정체성만 세우면 요청한 단이 아닌 것이 조용히 서빙된다. ultra의 전달 경로는 Operation
+ * launch factory(--effort max + --settings {"ultracode":true})뿐이다. 이 사다리는 정체성 생성
+ * (buildGatewayCustomAgents)과 로스터 셀렉터(model-loadout)가 함께 타는 깔때기라, 여기서
+ * 걸러야 둘이 어긋나지 않는다.
  */
 export function exposedEffortLadder(
   modelId: string,
   ladder: readonly GatewayReasoningEffort[],
   exposure: GatewayEffortExposure | undefined,
 ): readonly GatewayReasoningEffort[] {
+  const deliverable = ladder.filter((rung) => rung !== "ultra");
   const chosen = exposure?.[modelId];
-  if (chosen === undefined || chosen.length === 0) return ladder;
-  const narrowed = ladder.filter((rung) => chosen.includes(rung));
-  return narrowed.length > 0 ? narrowed : ladder;
+  if (chosen === undefined || chosen.length === 0) return deliverable;
+  const narrowed = deliverable.filter((rung) => chosen.includes(rung));
+  return narrowed.length > 0 ? narrowed : deliverable;
 }
 
 /**

--- a/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
@@ -128,6 +128,17 @@ describe("claude-gateway custom agents", () => {
     expect(toGatewayAgentName(agents[withEffort!]!.model, "high")).toBe(withEffort);
   });
 
+  it("never registers an ultra identity — ultracode is a capability, not a wire rung", () => {
+    // codex--gpt-5.6-sol의 카탈로그 사다리는 ultra까지 닿지만, 커스텀 Agent frontmatter의
+    // effort로는 ultra를 전달할 수 없다(CLI가 클램프). 정체성 사다리는 max에서 닫혀야 한다.
+    const model = requireGatewayModel("codex--gpt-5.6-sol");
+    const agents = buildGatewayCustomAgents([model]);
+    const names = Object.keys(agents);
+    expect(names.some((name) => name.endsWith("-ultra"))).toBe(false);
+    expect(names.some((name) => name.endsWith("-max"))).toBe(true);
+    for (const name of names) expect(agents[name]!.effort).not.toBe("ultra");
+  });
+
   it("builds identities only for the models the caller provides", () => {
     const included = requireGatewayModel("cursor--claude-opus-5");
     const omittedModelId = "claude-gateway--opencode--deepseek-v4-flash";

--- a/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
@@ -68,7 +68,7 @@ describe("claude-gateway profile", () => {
     });
   });
 
-  it("delivers ultra as the ultracode capability with wire effort pinned to max", async () => {
+  it("delivers ultra as Claude Code --effort ultracode", async () => {
     const profile = await resolveAgentCliProfile({
       CLAUDE_BIN: process.execPath,
     }, "/tmp", {
@@ -77,10 +77,9 @@ describe("claude-gateway profile", () => {
       effort: "ultra",
     });
 
-    // CLI 2.1.226은 --effort ultra를 경고 후 기본값으로 떨어뜨린다 — wire는 max로 고정하고
-    // 능력(standing orchestration)은 settings 병합으로 켠다.
+    // CLI가 ultracode를 xhigh + standing orchestration으로 해석한다 — max/settings로 우회하지 않는다.
     expect(profile).toMatchObject({
-      args: ["--model", "claude-gateway--codex--gpt-5.6-sol", "--effort", "max", "--settings", "{\"ultracode\":true}"],
+      args: ["--model", "claude-gateway--codex--gpt-5.6-sol", "--effort", "ultracode"],
     });
   });
 });
@@ -128,9 +127,9 @@ describe("claude-gateway custom agents", () => {
     expect(toGatewayAgentName(agents[withEffort!]!.model, "high")).toBe(withEffort);
   });
 
-  it("never registers an ultra identity — ultracode is a capability, not a wire rung", () => {
-    // codex--gpt-5.6-sol의 카탈로그 사다리는 ultra까지 닿지만, 커스텀 Agent frontmatter의
-    // effort로는 ultra를 전달할 수 없다(CLI가 클램프). 정체성 사다리는 max에서 닫혀야 한다.
+  it("never registers an ultra identity — ultracode is a launch --effort, not a roster rung", () => {
+    // codex--gpt-5.6-sol의 카탈로그 사다리는 ultra까지 닿지만, 커스텀 Agent frontmatter
+    // 일상 사다리에는 올리지 않는다. ultracode는 Operation launch의 --effort ultracode 경로다.
     const model = requireGatewayModel("codex--gpt-5.6-sol");
     const agents = buildGatewayCustomAgents([model]);
     const names = Object.keys(agents);

--- a/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
@@ -67,6 +67,22 @@ describe("claude-gateway profile", () => {
       KEEP_ME: "yes",
     });
   });
+
+  it("delivers ultra as the ultracode capability with wire effort pinned to max", async () => {
+    const profile = await resolveAgentCliProfile({
+      CLAUDE_BIN: process.execPath,
+    }, "/tmp", {
+      cliId: "claude-gateway",
+      model: "claude-gateway--codex--gpt-5.6-sol",
+      effort: "ultra",
+    });
+
+    // CLI 2.1.226은 --effort ultra를 경고 후 기본값으로 떨어뜨린다 — wire는 max로 고정하고
+    // 능력(standing orchestration)은 settings 병합으로 켠다.
+    expect(profile).toMatchObject({
+      args: ["--model", "claude-gateway--codex--gpt-5.6-sol", "--effort", "max", "--settings", "{\"ultracode\":true}"],
+    });
+  });
 });
 
 describe("claude-gateway custom agents", () => {

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -31,10 +31,9 @@ interface CanvasContextMenuProps {
 // 되고 치수만 조용히 어긋난다.
 const MENU_WIDTH = 264;
 const FLYOUT_GAP = 10;
-// 트랙과 그 값 라벨이 나란히 들어가는 폭이다.
-// 열린 apex 트랙(7스톱)+접힘 셰브론+ULTRACODE 라벨이 스크롤 없이 들어가는, 게이트가
-// 열린 상태의 폭. 닫힘 폭(216)은 CSS가 쥐고, 배치는 이 최악 폭을 기준으로 잡는다.
-const EFFORT_SUBMENU_WIDTH = 376;
+// 트랙·접힘 셰브론·ULTRACODE 라벨이 나란히 들어가는 최악 폭(게이트 열림). CSS는
+// width:max-content라 콘텐츠에 맞추고, 배치는 이 상한으로 뷰포트 clamp한다.
+const EFFORT_SUBMENU_WIDTH = 320;
 // components.css의 같은 선언과 짝이다. 계약 시험이 그 짝을 지킨다.
 export const OPERATION_LAUNCH_EFFORT_MENU_WIDTH = EFFORT_SUBMENU_WIDTH;
 const FLYOUT_CLOSE_GRACE_MS = 160;

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -32,7 +32,8 @@ interface CanvasContextMenuProps {
 const MENU_WIDTH = 264;
 const FLYOUT_GAP = 10;
 // 트랙과 그 값 라벨이 나란히 들어가는 폭이다.
-// 열린 apex 트랙(7스톱)+접힘 셰브론+ULTRACODE 라벨이 스크롤 없이 들어가는 폭.
+// 열린 apex 트랙(7스톱)+접힘 셰브론+ULTRACODE 라벨이 스크롤 없이 들어가는, 게이트가
+// 열린 상태의 폭. 닫힘 폭(216)은 CSS가 쥐고, 배치는 이 최악 폭을 기준으로 잡는다.
 const EFFORT_SUBMENU_WIDTH = 376;
 // components.css의 같은 선언과 짝이다. 계약 시험이 그 짝을 지킨다.
 export const OPERATION_LAUNCH_EFFORT_MENU_WIDTH = EFFORT_SUBMENU_WIDTH;

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -32,7 +32,8 @@ interface CanvasContextMenuProps {
 const MENU_WIDTH = 264;
 const FLYOUT_GAP = 10;
 // 트랙과 그 값 라벨이 나란히 들어가는 폭이다.
-const EFFORT_SUBMENU_WIDTH = 216;
+// 열린 apex 트랙(7스톱)+접힘 셰브론+ULTRACODE 라벨이 스크롤 없이 들어가는 폭.
+const EFFORT_SUBMENU_WIDTH = 376;
 // components.css의 같은 선언과 짝이다. 계약 시험이 그 짝을 지킨다.
 export const OPERATION_LAUNCH_EFFORT_MENU_WIDTH = EFFORT_SUBMENU_WIDTH;
 const FLYOUT_CLOSE_GRACE_MS = 160;
@@ -631,6 +632,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
               ariaLabel={t("launchVariants.effort.track")}
               autoValueText={t("launchVariants.effort.autoValue")}
               apexToggleLabel={t("launchVariants.effort.apexToggle")}
+              apexCollapseLabel={t("launchVariants.effort.apexCollapse")}
             />
             {showEffortConfirmTip ? (
               <p className="operation-launch-effort-confirm-tip" role="status">

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -630,6 +630,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
               autoLabel={t("launchVariants.effort.auto")}
               ariaLabel={t("launchVariants.effort.track")}
               autoValueText={t("launchVariants.effort.autoValue")}
+              apexToggleLabel={t("launchVariants.effort.apexToggle")}
             />
             {showEffortConfirmTip ? (
               <p className="operation-launch-effort-confirm-tip" role="status">

--- a/runtime/fleet-console/core/client/src/components/effort-track.tsx
+++ b/runtime/fleet-console/core/client/src/components/effort-track.tsx
@@ -312,9 +312,11 @@ export function EffortTrack({
           }}
         >✦</button>
       ) : null}
-      {hasGate && apexOpen ? (
+      {hasGate && apexOpen && !isApex ? (
         // 열림에서는 ✦가 사라지고 트랙이 그 자리까지 늘어난다 — 접힘은 이 얇은 셰브론과
-        // 일상 단 선택(자동 접힘)만이 담당한다.
+        // 일상 단 선택(자동 접힘)만이 담당한다. apex 단이 선택된 동안은 셰브론도 숨긴다:
+        // 접으면 선택된 단이 슬롯에서 사라져, 트랙은 AUTO를 그리면서 제출은 apex 값을 내는
+        // 모순 상태가 된다.
         <button
           type="button"
           className="effort-track-apex-collapse"

--- a/runtime/fleet-console/core/client/src/components/effort-track.tsx
+++ b/runtime/fleet-console/core/client/src/components/effort-track.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent, type PointerEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type KeyboardEvent, type PointerEvent } from "react";
 
 import type { OperationLaunchVariantChip, OperationLaunchVariantRow } from "@fleet-console/sdk/operations";
 
@@ -209,6 +209,9 @@ export function EffortTrack({
 
   const ratio = last === 0 ? 0 : index / last;
   const seamRatio = ladder.length === 0 ? 0 : (ordinaryRungs.length + 0.5) / ladder.length;
+  // 닫힌 사다리(일상 단) 간격 폭을 열린 뒤에도 유지한다 — 스톱 수를 늘릴 때 트랙만
+  // 비례해 넓히고, 셸이 남는 폭을 트랙에 밀어 넣어 간격을 벌리지 않는다.
+  const closedIntervals = Math.max(ordinaryRungs.length, 1);
 
   return (
     <div className={`effort-track-shell${className ? ` ${className}` : ""}`}>
@@ -228,6 +231,11 @@ export function EffortTrack({
         // 자동은 사다리의 최소 단이 아니라 "사다리를 쓰지 않음"이다. 파선 테두리·빈 손잡이·채움 0이
         // 한 어휘로 그것을 말한다 — 채움이 조금이라도 남으면 맨 왼쪽 단을 고른 것으로 읽힌다.
         data-auto={isAuto ? true : undefined}
+        data-effort-level={current.id ?? "auto"}
+        style={{
+          "--effort-intervals": Math.max(last, 1),
+          "--effort-closed-intervals": closedIntervals,
+        } as CSSProperties}
         onKeyDown={handleKeyDown}
         onPointerDown={(event) => {
           // 주 접촉만 받는다. 터치 두 번째 손가락도 button===0이라 isPrimary·활성 제스처로 막는다.
@@ -312,11 +320,10 @@ export function EffortTrack({
           }}
         >✦</button>
       ) : null}
-      {hasGate && apexOpen && !isApex ? (
-        // 열림에서는 ✦가 사라지고 트랙이 그 자리까지 늘어난다 — 접힘은 이 얇은 셰브론과
-        // 일상 단 선택(자동 접힘)만이 담당한다. apex 단이 선택된 동안은 셰브론도 숨긴다:
-        // 접으면 선택된 단이 슬롯에서 사라져, 트랙은 AUTO를 그리면서 제출은 apex 값을 내는
-        // 모순 상태가 된다.
+      {hasGate && apexOpen ? (
+        // 열림에서는 ✦가 사라지고 트랙이 그 자리까지 늘어난다 — 접힘은 이 얇은 셰브론이
+        // 맡는다. apex 단이 선택된 동안에도 셰브론은 남긴다: 접으면 일상 사다리의 마지막
+        // 고를 수 있는 단으로 내려, 숨은 apex 값을 제출하는 모순을 만들지 않는다.
         <button
           type="button"
           className="effort-track-apex-collapse"
@@ -324,6 +331,12 @@ export function EffortTrack({
           title={apexCollapseLabel}
           onClick={() => {
             clearCollapseTimer();
+            if (isApex) {
+              const fallback = [...ordinaryRungs]
+                .reverse()
+                .find((id) => (row.chips ?? []).some((chip) => chip.id === id));
+              onChange(fallback ?? null);
+            }
             setApexOpen(false);
           }}
         >‹</button>

--- a/runtime/fleet-console/core/client/src/components/effort-track.tsx
+++ b/runtime/fleet-console/core/client/src/components/effort-track.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState, type KeyboardEvent, type PointerEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent, type PointerEvent } from "react";
 
 import type { OperationLaunchVariantChip, OperationLaunchVariantRow } from "@fleet-console/sdk/operations";
 
@@ -27,6 +27,7 @@ export interface EffortTrackProps {
   readonly autoLabel: string;
   readonly ariaLabel: string;
   readonly autoValueText: string;
+  readonly apexToggleLabel?: string;
   readonly className?: string;
 }
 
@@ -35,29 +36,69 @@ export interface EffortTrackProps {
  * 모델이 내놓지 않은 단도 자리를 지킨다 — low/high/max만 있는 모델에서 셋을 균등히 벌리면
  * high가 한가운데 서서, 실제로는 3/5 지점인 단을 절반이라고 말하게 된다.
  */
-export function EffortTrack({ row, value, onChange, onConfirmCurrent, autoLabel, ariaLabel, autoValueText, className }: EffortTrackProps) {
+export function EffortTrack({
+  row,
+  value,
+  onChange,
+  onConfirmCurrent,
+  autoLabel,
+  ariaLabel,
+  autoValueText,
+  apexToggleLabel,
+  className,
+}: EffortTrackProps) {
   const trackRef = useRef<HTMLDivElement | null>(null);
+  const collapseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+  const ladder = useMemo(() => ladderRungs(row), [row]);
+  const gatedRungs = useMemo(() => {
+    const gated = new Set(row.gatedEfforts ?? []);
+    return ladder.filter((id) => gated.has(id));
+  }, [ladder, row]);
+  const hasGate = gatedRungs.length > 0;
+  const ordinaryRungs = useMemo(
+    () => ladder.filter((id) => !gatedRungs.includes(id)),
+    [gatedRungs, ladder],
+  );
+  const [apexOpen, setApexOpen] = useState(() => value !== null && gatedRungs.includes(value));
+  const [burstKey, setBurstKey] = useState(0);
+  const [burstLeft, setBurstLeft] = useState("50%");
   // 제스처 동안 React 커밋을 기다리지 않고 고른 단을 추적한다 — 같은 포인터 시퀀스에서
   // "다른 단으로 옮겼다"와 "처음부터 이 단을 다시 눌렀다"를 갈라야 한다.
   const liveIndexRef = useRef(0);
   // pointerId까지 묶어 두면 터치에서 두 번째 손가락(button===0)이 제스처를 덮어 쓰지 못한다.
   const gestureRef = useRef<{ readonly pointerId: number; readonly originIndex: number; dirty: boolean } | null>(null);
 
+  const clearCollapseTimer = useCallback(() => {
+    if (collapseTimerRef.current === null) return;
+    clearTimeout(collapseTimerRef.current);
+    collapseTimerRef.current = null;
+  }, []);
+
+  useEffect(() => clearCollapseTimer, [clearCollapseTimer]);
+
+  useEffect(() => {
+    if (value === null || !gatedRungs.includes(value)) return;
+    clearCollapseTimer();
+    setApexOpen(true);
+  }, [clearCollapseTimer, gatedRungs, value]);
+
   const slots = useMemo<readonly EffortSlot[]>(() => {
     const byId = new Map<string, OperationLaunchVariantChip>((row.chips ?? []).map((chip) => [chip.id, chip]));
-    const rungs = ladderRungs(row).map((id) => ({
+    const visibleRungs = apexOpen ? ladder : ordinaryRungs;
+    const rungs = visibleRungs.map((id) => ({
       id,
       label: byId.get(id)?.label ?? id.toUpperCase(),
       selectable: byId.has(id),
     }));
     return [{ id: null, label: autoLabel, selectable: true }, ...rungs];
-  }, [autoLabel, row]);
+  }, [apexOpen, autoLabel, ladder, ordinaryRungs, row]);
 
   const last = slots.length - 1;
   const index = Math.max(0, slots.findIndex((slot) => slot.id === value));
   const current = slots[index]!;
   const isAuto = current.id === null;
+  const isApex = value !== null && gatedRungs.includes(value);
   liveIndexRef.current = index;
 
   const nearestSelectable = useCallback((target: number): number => {
@@ -71,12 +112,27 @@ export function EffortTrack({ row, value, onChange, onConfirmCurrent, autoLabel,
   }, [last, slots]);
 
   const commit = useCallback((next: number) => {
+    clearCollapseTimer();
     const slot = slots[next];
-    if (!slot || slot.id === slots[liveIndexRef.current]?.id) return false;
+    const previous = slots[liveIndexRef.current];
+    if (!slot || slot.id === previous?.id) return false;
+    const entersApex = slot.id !== null
+      && gatedRungs.includes(slot.id)
+      && (previous?.id == null || !gatedRungs.includes(previous.id));
     liveIndexRef.current = next;
+    if (entersApex) {
+      const ratio = last === 0 ? 0 : next / last;
+      setBurstLeft(`calc(${EDGE}px + ${ratio} * (100% - ${EDGE * 2}px))`);
+      setBurstKey((key) => key + 1);
+    } else if (apexOpen && (slot.id === null || !gatedRungs.includes(slot.id))) {
+      collapseTimerRef.current = setTimeout(() => {
+        collapseTimerRef.current = null;
+        setApexOpen(false);
+      }, 600);
+    }
     onChange(slot.id);
     return true;
-  }, [onChange, slots]);
+  }, [apexOpen, clearCollapseTimer, gatedRungs, last, onChange, slots]);
 
   const indexFromPointer = useCallback((clientX: number): number | null => {
     const track = trackRef.current;
@@ -149,6 +205,7 @@ export function EffortTrack({ row, value, onChange, onConfirmCurrent, autoLabel,
   }, [commit, index, last, nearestSelectable, onConfirmCurrent, slots]);
 
   const ratio = last === 0 ? 0 : index / last;
+  const seamRatio = ladder.length === 0 ? 0 : (ordinaryRungs.length + 0.5) / ladder.length;
 
   return (
     <div className={`effort-track-shell${className ? ` ${className}` : ""}`}>
@@ -162,7 +219,9 @@ export function EffortTrack({ row, value, onChange, onConfirmCurrent, autoLabel,
         aria-valuemax={last}
         aria-valuenow={index}
         aria-valuetext={isAuto ? autoValueText : current.label}
-        data-at-max={index === last && !isAuto ? true : undefined}
+        data-apex-open={hasGate && apexOpen ? true : undefined}
+        data-apex={isApex ? true : undefined}
+        data-at-max={hasGate ? (isApex ? true : undefined) : (index === last && !isAuto ? true : undefined)}
         // 자동은 사다리의 최소 단이 아니라 "사다리를 쓰지 않음"이다. 파선 테두리·빈 손잡이·채움 0이
         // 한 어휘로 그것을 말한다 — 채움이 조금이라도 남으면 맨 왼쪽 단을 고른 것으로 읽힌다.
         data-auto={isAuto ? true : undefined}
@@ -196,17 +255,40 @@ export function EffortTrack({ row, value, onChange, onConfirmCurrent, autoLabel,
           aria-hidden="true"
         />
         <span className="effort-track-stops" aria-hidden="true">
-          {slots.map((slot, position) => (
-            <span
-              key={slot.id ?? "auto"}
-              className="effort-track-stop"
-              style={{ left: last === 0 ? "50%" : `${(position / last) * 100}%` }}
-              data-filled={position <= index && !isAuto ? true : undefined}
-              data-gap={slot.selectable ? undefined : true}
-              data-previewed={position === previewIndex ? true : undefined}
-            />
-          ))}
+          {slots.map((slot, position) => {
+            const gatedIndex = slot.id === null ? -1 : gatedRungs.indexOf(slot.id);
+            return (
+              <span
+                key={slot.id ?? "auto"}
+                className="effort-track-stop"
+                style={{
+                  left: last === 0 ? "50%" : `${(position / last) * 100}%`,
+                  animationDelay: gatedIndex >= 0 ? `${(gatedIndex + 1) * 90}ms` : undefined,
+                }}
+                data-apex-rung={gatedIndex >= 0 ? true : undefined}
+                data-filled={position <= index && !isAuto ? true : undefined}
+                data-gap={slot.selectable ? undefined : true}
+                data-previewed={position === previewIndex ? true : undefined}
+              />
+            );
+          })}
         </span>
+        {hasGate ? (
+          <span
+            className="effort-track-apex-seam"
+            style={{ left: `calc(${EDGE}px + ${seamRatio} * (100% - ${EDGE * 2}px))` }}
+            aria-hidden="true"
+          />
+        ) : null}
+        {burstKey > 0 ? (
+          <span
+            key={burstKey}
+            className="effort-track-apex-burst"
+            style={{ left: burstLeft }}
+            onAnimationEnd={() => setBurstKey(0)}
+            aria-hidden="true"
+          />
+        ) : null}
         <span
           className="effort-track-knob"
           style={{ left: `calc(${EDGE}px + ${ratio} * (100% - ${EDGE * 2}px))` }}
@@ -214,6 +296,19 @@ export function EffortTrack({ row, value, onChange, onConfirmCurrent, autoLabel,
           aria-hidden="true"
         />
       </div>
+      {hasGate ? (
+        <button
+          type="button"
+          className="effort-track-apex-toggle"
+          aria-pressed={apexOpen}
+          aria-label={apexToggleLabel}
+          title={apexToggleLabel}
+          onClick={() => {
+            clearCollapseTimer();
+            setApexOpen((open) => !open);
+          }}
+        >✦</button>
+      ) : null}
       {/* 단계 톤은 CSS가 이 속성 하나로 읽는다 — 라벨 문자열은 번역·모델마다 달라 색의 기준이 될 수 없다. */}
       <span className="effort-track-value" data-auto={isAuto} data-effort-level={current.id ?? "auto"}>
         {current.label}

--- a/runtime/fleet-console/core/client/src/components/effort-track.tsx
+++ b/runtime/fleet-console/core/client/src/components/effort-track.tsx
@@ -28,6 +28,8 @@ export interface EffortTrackProps {
   readonly ariaLabel: string;
   readonly autoValueText: string;
   readonly apexToggleLabel?: string;
+  /** 게이트가 열린 동안 ✦ 자리를 물려받는 접힘 셰브론의 라벨. */
+  readonly apexCollapseLabel?: string;
   readonly className?: string;
 }
 
@@ -45,6 +47,7 @@ export function EffortTrack({
   ariaLabel,
   autoValueText,
   apexToggleLabel,
+  apexCollapseLabel,
   className,
 }: EffortTrackProps) {
   const trackRef = useRef<HTMLDivElement | null>(null);
@@ -296,7 +299,7 @@ export function EffortTrack({
           aria-hidden="true"
         />
       </div>
-      {hasGate ? (
+      {hasGate && !apexOpen ? (
         <button
           type="button"
           className="effort-track-apex-toggle"
@@ -305,9 +308,23 @@ export function EffortTrack({
           title={apexToggleLabel}
           onClick={() => {
             clearCollapseTimer();
-            setApexOpen((open) => !open);
+            setApexOpen(true);
           }}
         >✦</button>
+      ) : null}
+      {hasGate && apexOpen ? (
+        // 열림에서는 ✦가 사라지고 트랙이 그 자리까지 늘어난다 — 접힘은 이 얇은 셰브론과
+        // 일상 단 선택(자동 접힘)만이 담당한다.
+        <button
+          type="button"
+          className="effort-track-apex-collapse"
+          aria-label={apexCollapseLabel}
+          title={apexCollapseLabel}
+          onClick={() => {
+            clearCollapseTimer();
+            setApexOpen(false);
+          }}
+        >‹</button>
       ) : null}
       {/* 단계 톤은 CSS가 이 속성 하나로 읽는다 — 라벨 문자열은 번역·모델마다 달라 색의 기준이 될 수 없다. */}
       <span className="effort-track-value" data-auto={isAuto} data-effort-level={current.id ?? "auto"}>

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -279,6 +279,7 @@ export function QuickLaunch() {
               autoLabel={t("launchVariants.effort.auto")}
               ariaLabel={t("launchVariants.effort.track")}
               autoValueText={t("launchVariants.effort.autoValue")}
+              apexToggleLabel={t("launchVariants.effort.apexToggle")}
               className="quick-launch-effort-track"
             />
           ) : null}

--- a/runtime/fleet-console/core/client/src/components/quick-launch.tsx
+++ b/runtime/fleet-console/core/client/src/components/quick-launch.tsx
@@ -280,6 +280,7 @@ export function QuickLaunch() {
               ariaLabel={t("launchVariants.effort.track")}
               autoValueText={t("launchVariants.effort.autoValue")}
               apexToggleLabel={t("launchVariants.effort.apexToggle")}
+              apexCollapseLabel={t("launchVariants.effort.apexCollapse")}
               className="quick-launch-effort-track"
             />
           ) : null}
@@ -300,8 +301,6 @@ export function QuickLaunch() {
               )}
             </span>
           ) : null}
-          {/* 힌트일 뿐 누를 수 있는 것이 아니다 — 테두리를 두르면 바 안에서 액션 행세를 한다. */}
-          <span className="quick-launch-esc" aria-hidden="true">{t("chrome.quickLaunch.escHint")}</span>
           <button
             type="button"
             className="quick-launch-submit"

--- a/runtime/fleet-console/core/client/src/i18n/messages/chrome.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/chrome.ts
@@ -91,7 +91,6 @@ export const chromeEn = {
   "chrome.quickLaunch.run": "Run",
   // 아이콘만 남은 실행 버튼의 접근 이름 — 시각 레이블이 없으므로 단축키까지 이 이름이 싣는다.
   "chrome.quickLaunch.runWithKey": "Run (Enter)",
-  "chrome.quickLaunch.escHint": "esc to close",
   "chrome.quickLaunch.tooLong": "{over} characters over the limit",
   "chrome.quickLaunch.errorUnsafePrompt": "Remove \" & < > ( ) @ ^ | % — the Windows command shim would rewrite them",
   "chrome.quickLaunch.errorPromptUnsupported": "This Console runs a custom terminal command, which cannot carry a prompt",
@@ -352,7 +351,6 @@ export const chromeKo: Record<keyof typeof chromeEn, string> = {
   "chrome.quickLaunch.modelUnset": "기본 모델",
   "chrome.quickLaunch.run": "실행",
   "chrome.quickLaunch.runWithKey": "실행 (Enter)",
-  "chrome.quickLaunch.escHint": "esc 닫기",
   "chrome.quickLaunch.tooLong": "{over}자 초과",
   "chrome.quickLaunch.errorUnsafePrompt": "\" & < > ( ) @ ^ | % 를 지워 주세요 — Windows 명령 shim이 다시 해석합니다",
   "chrome.quickLaunch.errorPromptUnsupported": "이 Console은 사용자 지정 터미널 명령으로 실행돼 프롬프트를 실을 수 없습니다",

--- a/runtime/fleet-console/core/client/src/i18n/messages/common.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/common.ts
@@ -73,6 +73,7 @@ export const commonEn = {
   "launchVariants.effort.track": "Reasoning effort",
   "launchVariants.effort.auto": "AUTO",
   "launchVariants.effort.autoValue": "Automatic — the model's own default",
+  "launchVariants.effort.apexToggle": "Show Max and Ultracode",
   "launchVariants.effort.confirmTip": "Press the knob again to launch.",
 } as const;
 
@@ -150,5 +151,6 @@ export const commonKo: Record<keyof typeof commonEn, string> = {
   "launchVariants.effort.track": "추론 강도",
   "launchVariants.effort.auto": "자동",
   "launchVariants.effort.autoValue": "자동 — 모델 자체 기본값",
+  "launchVariants.effort.apexToggle": "MAX·ULTRACODE 펼치기",
   "launchVariants.effort.confirmTip": "노브를 다시 누르면 실행됩니다.",
 };

--- a/runtime/fleet-console/core/client/src/i18n/messages/common.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/common.ts
@@ -74,6 +74,7 @@ export const commonEn = {
   "launchVariants.effort.auto": "AUTO",
   "launchVariants.effort.autoValue": "Automatic — the model's own default",
   "launchVariants.effort.apexToggle": "Show Max and Ultracode",
+  "launchVariants.effort.apexCollapse": "Hide Max and Ultracode",
   "launchVariants.effort.confirmTip": "Press the knob again to launch.",
 } as const;
 
@@ -152,5 +153,6 @@ export const commonKo: Record<keyof typeof commonEn, string> = {
   "launchVariants.effort.auto": "자동",
   "launchVariants.effort.autoValue": "자동 — 모델 자체 기본값",
   "launchVariants.effort.apexToggle": "MAX·ULTRACODE 펼치기",
+  "launchVariants.effort.apexCollapse": "MAX·ULTRACODE 접기",
   "launchVariants.effort.confirmTip": "노브를 다시 누르면 실행됩니다.",
 };

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7419,20 +7419,14 @@
 .operation-launch-effort-menu.theater-menu {
   --flyout-enter-x: -4px;
   z-index: 42;
-  /* 닫힘 폭은 게이트 이전 그대로다. canvas-context-menu.tsx의 EFFORT_SUBMENU_WIDTH는
-     열림 폭(아래 :has 규칙)과 같은 값으로, 뷰포트 배치가 최악 폭을 기준으로 잡히게 한다. */
-  width: 216px;
+  /* 콘텐츠(트랙·토글·라벨)에 맞춘다 — 고정 폭이면 짧을 때 라벨이 잘리고 길면
+     오른쪽에 빈 칸이 남는다. 배치 최악 폭은 canvas-context-menu의 EFFORT_SUBMENU_WIDTH. */
+  width: max-content;
   max-height: var(--canvas-menu-max-height, 520px);
-  overflow-y: auto;
-  overflow-x: hidden;
+  /* auto가 아니다 — apex burst의 transform scale이 스크롤 높이를 잠깐 밀어 세로
+     스크롤바가 깜빡인다. 트랙+팁은 max-height 아래에 남는다. */
+  overflow: hidden;
   animation: operation-launch-flyout-in var(--duration-fast) var(--ease-spring) both;
-  transition: width var(--duration-slow) var(--ease-spring);
-}
-
-/* 게이트가 열리면 상자가 트랙과 함께 넓어진다 — 열린 7스톱과 ULTRACODE 라벨이
-   가로 스크롤 없이 들어가는 폭. */
-.operation-launch-effort-menu.theater-menu:has(.effort-track[data-apex-open="true"]) {
-  width: 376px;
 }
 
 .operation-launch-effort-menu.theater-menu.is-left {
@@ -7443,7 +7437,11 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  min-width: 0;
+  min-width: max-content;
+}
+
+.operation-launch-effort-menu .effort-track-shell {
+  min-width: max-content;
 }
 
 /* 같은 단을 다시 눌러 실행한다는 숨은 확정 제스처를 처음 비-AUTO를 고른 순간에만 알려 준다.
@@ -7481,7 +7479,7 @@
 [data-effort-level="medium"] { --effort-tone: color-mix(in oklab, var(--brass-ink) 42%, var(--text-tertiary)); }
 [data-effort-level="high"] { --effort-tone: color-mix(in oklab, var(--brass-ink) 64%, var(--text-tertiary)); }
 [data-effort-level="xhigh"] { --effort-tone: color-mix(in oklab, var(--brass-ink) 84%, var(--text-tertiary)); }
-[data-effort-level="max"] { --effort-tone: var(--brass-ink); }
+[data-effort-level="max"] { --effort-tone: var(--crest-ink); }
 [data-effort-level="ultra"] { --effort-tone: var(--apex-ink); }
 
 .effort-track-shell {
@@ -7493,8 +7491,13 @@
 
 .effort-track {
   position: relative;
-  flex: 1;
-  min-width: 116px;
+  /* 남는 셸 폭을 먹어 스톱 간격을 벌리지 않는다 — 폭은 닫힌 간격×현재 구간 수.
+     Quick Launch와 캔버스 추론강도 트랙이 같은 값을 쓴다. */
+  flex: 0 0 auto;
+  --effort-closed-track-width: 116px;
+  --effort-intervals: 1;
+  --effort-closed-intervals: 1;
+  width: calc(var(--effort-closed-track-width) * var(--effort-intervals) / var(--effort-closed-intervals));
   height: 26px;
   padding: 0 13px;
   display: flex;
@@ -7505,6 +7508,7 @@
   cursor: pointer;
   touch-action: none;
   transition:
+    width var(--duration-slow) var(--ease-spring),
     border-color var(--duration-base) var(--ease-spring),
     box-shadow var(--duration-base) var(--ease-spring);
 }
@@ -7564,16 +7568,32 @@
   55%, 100% { transform: translateX(100%); }
 }
 
-/* 최고 단이 색을 갈지 않는다는 위 결정은 max가 일상 사다리의 끝이던 때의 것이다. 게이트 뒤
-   티어에는 상태 신호와 구분되는 별도 강도 채널(--apex)을 둔다. */
-.effort-track[data-apex="true"] {
+/* 게이트 뒤 티어: MAX는 용융 구리(--crest), ULTRACODE는 보라(--apex). 같은 data-apex라도
+   단이 다르면 채널을 갈라, 둘을 한 색으로 읽히지 않게 한다. */
+.effort-track[data-apex="true"][data-effort-level="max"] {
+  border-color: color-mix(in oklch, var(--crest) 55%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in oklch, var(--crest) 22%, transparent),
+    0 0 22px -4px var(--crest-glow);
+}
+
+.effort-track[data-apex="true"][data-effort-level="max"] .effort-track-fill {
+  background:
+    repeating-linear-gradient(
+      115deg,
+      color-mix(in oklch, var(--text-on-brass) 9%, transparent) 0 1.5px,
+      transparent 1.5px 10px),
+    linear-gradient(90deg, var(--brass) 0%, var(--crest) 82%);
+}
+
+.effort-track[data-apex="true"][data-effort-level="ultra"] {
   border-color: color-mix(in oklch, var(--apex) 55%, transparent);
   box-shadow:
     0 0 0 1px color-mix(in oklch, var(--apex) 22%, transparent),
     0 0 22px -4px var(--apex-glow);
 }
 
-.effort-track[data-apex="true"] .effort-track-fill {
+.effort-track[data-apex="true"][data-effort-level="ultra"] .effort-track-fill {
   background:
     repeating-linear-gradient(
       115deg,
@@ -7751,7 +7771,14 @@
   transform: scale(1.1);
 }
 
-.effort-track[data-apex="true"] .effort-track-knob {
+.effort-track[data-apex="true"][data-effort-level="max"] .effort-track-knob {
+  box-shadow:
+    0 0 0 2.5px var(--crest),
+    var(--crest-halo),
+    0 1px 3px oklch(0% 0 0 / 55%);
+}
+
+.effort-track[data-apex="true"][data-effort-level="ultra"] .effort-track-knob {
   box-shadow:
     0 0 0 2.5px var(--apex),
     var(--apex-halo),
@@ -7767,24 +7794,46 @@
 }
 
 .effort-track-value {
-  min-width: 44px;
+  /* ULTRACODE 한 줄이 들어가는 칸. 짧은 단은 가운데. */
+  flex: 0 0 auto;
+  min-width: 9.5ch;
   color: var(--effort-tone, var(--text-secondary));
   font-family: var(--font-mono);
   font-size: 10.5px;
   letter-spacing: 0.06em;
+  text-align: center;
   text-transform: uppercase;
   white-space: nowrap;
   transition: color var(--duration-fast) var(--ease-spring);
 }
 
-/* 최고 단은 램프의 끝이라 색만으로는 바로 아랫단과 갈리지 않는다 — 무게가 그 마지막 한 칸을 맡는다. */
 .effort-track-value[data-effort-level="max"] {
   font-weight: var(--weight-medium);
+  text-shadow: 0 0 12px var(--crest-glow);
 }
 
+/* ULTRACODE — 그라데이션이 글자를 가로질러 흘러 물결처럼 읽힌다. */
 .effort-track-value[data-effort-level="ultra"] {
-  min-width: 64px;
   font-weight: var(--weight-medium);
+  background-image: linear-gradient(
+    105deg,
+    var(--apex-ink) 0%,
+    color-mix(in oklch, var(--apex) 55%, white) 16%,
+    var(--apex-ink) 32%,
+    color-mix(in oklch, var(--apex) 65%, var(--brass)) 48%,
+    var(--apex-ink) 64%,
+    color-mix(in oklch, var(--apex) 55%, white) 80%,
+    var(--apex-ink) 100%
+  );
+  background-size: 240% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: effort-ultracode-wave 2.6s linear infinite;
+}
+
+@keyframes effort-ultracode-wave {
+  to { background-position: -240% 0; }
 }
 
 /* 파선 밑줄은 트랙의 파선 테두리와 같은 말이다: 이 값은 사다리 위의 단이 아니라 모델에 맡긴 자리다. */
@@ -7805,25 +7854,13 @@
   transition: color var(--duration-fast) var(--ease-spring);
 }
 
-/* 바 안에서는 자리를 정해 준다. 남는 폭을 두고 spacer와 겨루게 두면 트랙이 스톱 간격보다
-   좁아져, 손잡이가 이웃 스톱을 덮는다. */
+/* 바 안에서는 자리를 정해 준다. 트랙 폭은 캔버스 추론강도 트랙과 같은 116px 비례 규칙을
+   그대로 쓰고, 셸은 트랙·토글·라벨만 품는 max-content다. */
 .quick-launch-effort-track {
   flex: 0 0 auto;
-  width: 204px;
+  width: max-content;
+  min-width: max-content;
   transition: width var(--duration-slow) var(--ease-spring);
-}
-
-/* 게이트 토글(26px)과 양쪽 간격(8px×2)은 셸이 추가로 품는다 — 토글을 트랙 안에 넣고 폭을
-   그대로 두면 일상 트랙이 204→118px로 쪼그라든다(2026-08-11 실측). 열림에서는 트랙이
-   288px이 되도록 셸을 374px로 늘린다. */
-.quick-launch-effort-track:has(.effort-track-apex-toggle) {
-  width: 290px;
-}
-
-.quick-launch-effort-track:has(.effort-track[data-apex-open="true"]) {
-  /* 374px는 Theater 칩 라벨이 길 때 바의 콘텐츠 폭(730px)을 6px 넘겨 실행 버튼을 다음 줄로
-     밀었다(2026-08-11 실측) — 360px면 가장 긴 조합에서도 한 줄에 남는다. */
-  width: 360px;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -7836,10 +7873,19 @@
     animation: none;
   }
 
+  .effort-track-value[data-effort-level="ultra"] {
+    animation: none;
+    background-image: none;
+    -webkit-background-clip: unset;
+    background-clip: unset;
+    color: var(--apex-ink);
+  }
+
   .effort-track-stop[data-apex-rung="true"] {
     animation: none;
   }
 
+  .effort-track,
   .effort-track-apex-seam,
   .effort-track-apex-toggle,
   .quick-launch-effort-track {

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7419,13 +7419,20 @@
 .operation-launch-effort-menu.theater-menu {
   --flyout-enter-x: -4px;
   z-index: 42;
-  /* canvas-context-menu.tsx의 EFFORT_SUBMENU_WIDTH와 같은 값이어야 한다. 열린 apex 트랙
-     (7스톱)과 ULTRACODE 라벨이 가로 스크롤 없이 들어가는 폭이다. */
-  width: 376px;
+  /* 닫힘 폭은 게이트 이전 그대로다. canvas-context-menu.tsx의 EFFORT_SUBMENU_WIDTH는
+     열림 폭(아래 :has 규칙)과 같은 값으로, 뷰포트 배치가 최악 폭을 기준으로 잡히게 한다. */
+  width: 216px;
   max-height: var(--canvas-menu-max-height, 520px);
   overflow-y: auto;
   overflow-x: hidden;
   animation: operation-launch-flyout-in var(--duration-fast) var(--ease-spring) both;
+  transition: width var(--duration-slow) var(--ease-spring);
+}
+
+/* 게이트가 열리면 상자가 트랙과 함께 넓어진다 — 열린 7스톱과 ULTRACODE 라벨이
+   가로 스크롤 없이 들어가는 폭. */
+.operation-launch-effort-menu.theater-menu:has(.effort-track[data-apex-open="true"]) {
+  width: 376px;
 }
 
 .operation-launch-effort-menu.theater-menu.is-left {

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7473,6 +7473,7 @@
 [data-effort-level="high"] { --effort-tone: color-mix(in oklab, var(--brass-ink) 64%, var(--text-tertiary)); }
 [data-effort-level="xhigh"] { --effort-tone: color-mix(in oklab, var(--brass-ink) 84%, var(--text-tertiary)); }
 [data-effort-level="max"] { --effort-tone: var(--brass-ink); }
+[data-effort-level="ultra"] { --effort-tone: var(--apex-ink); }
 
 .effort-track-shell {
   display: flex;
@@ -7494,6 +7495,9 @@
   background: color-mix(in oklch, var(--surface-pillar) 55%, transparent);
   cursor: pointer;
   touch-action: none;
+  transition:
+    border-color var(--duration-base) var(--ease-spring),
+    box-shadow var(--duration-base) var(--ease-spring);
 }
 
 .effort-track:focus-visible {
@@ -7551,6 +7555,92 @@
   55%, 100% { transform: translateX(100%); }
 }
 
+/* 최고 단이 색을 갈지 않는다는 위 결정은 max가 일상 사다리의 끝이던 때의 것이다. 게이트 뒤
+   티어에는 상태 신호와 구분되는 별도 강도 채널(--apex)을 둔다. */
+.effort-track[data-apex="true"] {
+  border-color: color-mix(in oklch, var(--apex) 55%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in oklch, var(--apex) 22%, transparent),
+    0 0 22px -4px var(--apex-glow);
+}
+
+.effort-track[data-apex="true"] .effort-track-fill {
+  background:
+    repeating-linear-gradient(
+      115deg,
+      color-mix(in oklch, var(--text-on-brass) 9%, transparent) 0 1.5px,
+      transparent 1.5px 10px),
+    linear-gradient(90deg, var(--brass) 0%, var(--apex) 82%);
+}
+
+.effort-track-apex-toggle {
+  flex: 0 0 26px;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 1px dashed color-mix(in oklch, var(--text-tertiary) 65%, transparent);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    border-color var(--duration-base) var(--ease-spring),
+    border-style var(--duration-base) var(--ease-spring),
+    color var(--duration-base) var(--ease-spring),
+    box-shadow var(--duration-base) var(--ease-spring);
+}
+
+.effort-track-apex-toggle:hover,
+.effort-track-apex-toggle[aria-pressed="true"] {
+  border-color: var(--apex);
+  border-style: solid;
+  color: var(--apex-ink);
+  box-shadow: var(--apex-halo);
+}
+
+.effort-track-apex-toggle:focus-visible {
+  outline: 2px solid var(--brass);
+  outline-offset: 2px;
+}
+
+.effort-track-apex-seam {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  width: 1px;
+  background: linear-gradient(to bottom, transparent, var(--apex) 40% 60%, transparent);
+  opacity: 0;
+  transform: scaleY(0.2);
+  transition: opacity 360ms var(--ease-spring) 120ms, transform 360ms var(--ease-spring) 120ms;
+  pointer-events: none;
+}
+
+.effort-track[data-apex-open="true"] .effort-track-apex-seam {
+  opacity: 0.9;
+  transform: scaleY(1);
+}
+
+.effort-track-apex-burst {
+  position: absolute;
+  top: 50%;
+  width: 20px;
+  height: 20px;
+  margin: -10px 0 0 -10px;
+  border: 2px solid var(--apex);
+  border-radius: 999px;
+  opacity: 0;
+  animation: effort-track-apex-burst 620ms var(--ease-spring) 1;
+  pointer-events: none;
+}
+
+@keyframes effort-track-apex-burst {
+  0% { opacity: 0.95; transform: scale(1); }
+  100% { opacity: 0; transform: scale(3.2); }
+}
+
 .effort-track-stops {
   position: relative;
   flex: 1;
@@ -7574,6 +7664,18 @@
 
 .effort-track-stop[data-filled="true"] {
   background: color-mix(in oklch, var(--text-on-brass) 42%, transparent);
+}
+
+/* apex 스톱은 게이트가 열리는 그 커밋에서 새로 삽입된다 — 새 요소의 첫 계산값은 transition을
+   타지 않으므로, 캐스케이드는 keyframes로 연다. fill은 backwards: 지연 구간에만 from 값을 들고
+   끝나면 기본 스타일로 돌려, preview의 scale(3) transition과 충돌하지 않는다. */
+.effort-track-stop[data-apex-rung="true"] {
+  animation: effort-track-apex-stop-in var(--duration-base) var(--ease-spring) backwards;
+}
+
+@keyframes effort-track-apex-stop-in {
+  from { opacity: 0; transform: scale(0); }
+  to { opacity: 1; transform: scale(1); }
 }
 
 /* 이 모델이 내놓지 않은 단. 자리는 지키되 비어 있어야, 고를 수 있는 단이 축 위 제자리에 선다. */
@@ -7614,6 +7716,13 @@
   transform: scale(1.1);
 }
 
+.effort-track[data-apex="true"] .effort-track-knob {
+  box-shadow:
+    0 0 0 2.5px var(--apex),
+    var(--apex-halo),
+    0 1px 3px oklch(0% 0 0 / 55%);
+}
+
 /* 값을 쥐지 않은 손잡이는 속이 비어 있다 — 꽉 찬 손잡이는 어느 자리에 있든 "이 단을 골랐다"로 읽힌다. */
 .effort-track-knob[data-auto="true"] {
   background: var(--surface-pillar);
@@ -7635,6 +7744,11 @@
 
 /* 최고 단은 램프의 끝이라 색만으로는 바로 아랫단과 갈리지 않는다 — 무게가 그 마지막 한 칸을 맡는다. */
 .effort-track-value[data-effort-level="max"] {
+  font-weight: var(--weight-medium);
+}
+
+.effort-track-value[data-effort-level="ultra"] {
+  min-width: 64px;
   font-weight: var(--weight-medium);
 }
 
@@ -7661,12 +7775,38 @@
 .quick-launch-effort-track {
   flex: 0 0 auto;
   width: 204px;
+  transition: width var(--duration-slow) var(--ease-spring);
+}
+
+/* 게이트 토글(26px)과 양쪽 간격(8px×2)은 셸이 추가로 품는다 — 토글을 트랙 안에 넣고 폭을
+   그대로 두면 일상 트랙이 204→118px로 쪼그라든다(2026-08-11 실측). 열림에서는 트랙이
+   288px이 되도록 셸을 374px로 늘린다. */
+.quick-launch-effort-track:has(.effort-track-apex-toggle) {
+  width: 290px;
+}
+
+.quick-launch-effort-track:has(.effort-track[data-apex-open="true"]) {
+  width: 374px;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .effort-track[data-at-max="true"] .effort-track-fill::after {
     animation: none;
     opacity: 0.22;
+  }
+
+  .effort-track-apex-burst {
+    animation: none;
+  }
+
+  .effort-track-stop[data-apex-rung="true"] {
+    animation: none;
+  }
+
+  .effort-track-apex-seam,
+  .effort-track-apex-toggle,
+  .quick-launch-effort-track {
+    transition: none;
   }
 }
 
@@ -11278,8 +11418,16 @@ body[data-codex-reading="true"] .operations-side-bar {
     animation: none;
   }
 
+  .effort-track-apex-burst {
+    animation: none;
+  }
+
   .quick-launch-chip,
   .quick-launch-submit,
+  .effort-track-apex-seam,
+  .effort-track-stop[data-apex-rung="true"],
+  .effort-track-apex-toggle,
+  .quick-launch-effort-track,
   .effort-track-fill,
   .effort-track-knob,
   .effort-track-stop,

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7419,10 +7419,12 @@
 .operation-launch-effort-menu.theater-menu {
   --flyout-enter-x: -4px;
   z-index: 42;
-  /* canvas-context-menu.tsx의 EFFORT_SUBMENU_WIDTH와 같은 값이어야 한다. */
-  width: 216px;
+  /* canvas-context-menu.tsx의 EFFORT_SUBMENU_WIDTH와 같은 값이어야 한다. 열린 apex 트랙
+     (7스톱)과 ULTRACODE 라벨이 가로 스크롤 없이 들어가는 폭이다. */
+  width: 376px;
   max-height: var(--canvas-menu-max-height, 520px);
   overflow-y: auto;
+  overflow-x: hidden;
   animation: operation-launch-flyout-in var(--duration-fast) var(--ease-spring) both;
 }
 
@@ -7602,6 +7604,32 @@
 }
 
 .effort-track-apex-toggle:focus-visible {
+  outline: 2px solid var(--brass);
+  outline-offset: 2px;
+}
+
+/* 열린 동안 ✦를 대신하는 접힘 컨트롤 — 게이트는 한 번 열리면 트랙이 그 자리를 물려받아
+   늘어나므로, 닫기 장치는 시각 무게를 거의 갖지 않는 얇은 셰브론이다. */
+.effort-track-apex-collapse {
+  flex: 0 0 18px;
+  width: 18px;
+  height: 26px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--ease-spring);
+}
+
+.effort-track-apex-collapse:hover {
+  color: var(--apex-ink);
+}
+
+.effort-track-apex-collapse:focus-visible {
   outline: 2px solid var(--brass);
   outline-offset: 2px;
 }
@@ -7786,7 +7814,9 @@
 }
 
 .quick-launch-effort-track:has(.effort-track[data-apex-open="true"]) {
-  width: 374px;
+  /* 374px는 Theater 칩 라벨이 길 때 바의 콘텐츠 폭(730px)을 6px 넘겨 실행 버튼을 다음 줄로
+     밀었다(2026-08-11 실측) — 360px면 가장 긴 조합에서도 한 줄에 남는다. */
+  width: 360px;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -11272,12 +11302,6 @@ body[data-codex-reading="true"] .operations-side-bar {
 
 /* 단축키 힌트는 읽히되 만져지지 않아야 한다. 테두리를 두른 배지로 두면 바 위에서 칩·전송과
    같은 액션 문법을 입어, 누를 수 있는 것으로 읽힌다. */
-.quick-launch-esc {
-  color: var(--text-tertiary);
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  letter-spacing: 0.06em;
-}
 
 /* 전송은 아이콘 하나짜리 원이다 — 컴포저의 유일한 확정 동작이라 이름을 글자로 되풀이하지 않고,
    이름과 단축키는 접근 이름이 싣는다. */

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -47,6 +47,11 @@
   --apex-ink: var(--apex);
   --apex-glow: oklch(75% 0.13 295 / 14%);
   --apex-halo: 0 0 16px var(--apex-glow);
+  /* crest 채널은 MAX 단 전용 — brass보다 뜨겁고 apex(295)와 갈린 용융 구리(hue ~48). */
+  --crest: oklch(78% 0.14 48);
+  --crest-ink: var(--crest);
+  --crest-glow: oklch(78% 0.14 48 / 16%);
+  --crest-halo: 0 0 16px var(--crest-glow);
 
   /* 신호 ink 티어 — 텍스트로 쓰이는 신호색 전용 채널. 다크 3종은 base 신호색을 그대로 별칭하고,
      라이트(Whites)만 L 42~46% 리터럴로 오버라이드해 자기 glow 틴트 위에서도 AA(4.5:1)를 지킨다.
@@ -222,6 +227,8 @@
   /* apex 채널은 강도 사다리의 게이트 뒤 티어 전용이며, 신호가 아니라 비어 있던 hue 295의 티어를 말한다. */
   --apex: oklch(80% 0.14 295);
   --apex-glow: oklch(80% 0.14 295 / 22%);
+  --crest: oklch(82% 0.15 48);
+  --crest-glow: oklch(82% 0.15 48 / 24%);
 
   --canvas-abyss: oklch(7% 0.015 246);
   --canvas-sea-core: oklch(15% 0.03 235);
@@ -278,6 +285,8 @@
   /* apex 채널은 강도 사다리의 게이트 뒤 티어 전용이며, 신호가 아니라 비어 있던 hue 295의 티어를 말한다. */
   --apex: oklch(76% 0.12 292);
   --apex-glow: oklch(76% 0.12 292 / 20%);
+  --crest: oklch(78% 0.14 46);
+  --crest-glow: oklch(78% 0.14 46 / 22%);
 
   --canvas-abyss: oklch(8% 0.006 255);
   --canvas-sea-core: oklch(15% 0.012 250);
@@ -361,6 +370,10 @@
   --apex-ink: oklch(43% 0.13 296);
   --apex-glow: oklch(52% 0.14 296 / 15%);
   --apex-halo: none;
+  --crest: oklch(54% 0.15 48);
+  --crest-ink: oklch(44% 0.14 48);
+  --crest-glow: oklch(54% 0.15 48 / 16%);
+  --crest-halo: none;
   --brass-halo: none;
   --positive-halo: none;
 

--- a/runtime/fleet-console/core/client/src/styles/theme.css
+++ b/runtime/fleet-console/core/client/src/styles/theme.css
@@ -41,6 +41,12 @@
   --warn-glow: oklch(75% 0.08 90 / 13%);
   --positive: oklch(76% 0.11 160);
   --positive-glow: oklch(76% 0.11 160 / 13%);
+  /* apex 채널은 강도 사다리의 게이트 뒤 티어 전용이다 — 신호가 아니라 티어를 말한다.
+     hue 295는 brass 78·warn 85·coral 25·positive 160·aurora 200이 점유하지 않은 유일한 공백이다. */
+  --apex: oklch(75% 0.13 295);
+  --apex-ink: var(--apex);
+  --apex-glow: oklch(75% 0.13 295 / 14%);
+  --apex-halo: 0 0 16px var(--apex-glow);
 
   /* 신호 ink 티어 — 텍스트로 쓰이는 신호색 전용 채널. 다크 3종은 base 신호색을 그대로 별칭하고,
      라이트(Whites)만 L 42~46% 리터럴로 오버라이드해 자기 glow 틴트 위에서도 AA(4.5:1)를 지킨다.
@@ -213,6 +219,9 @@
   --warn-glow: oklch(80% 0.13 85 / 22%);
   --positive: oklch(80% 0.15 152);
   --positive-glow: oklch(80% 0.15 152 / 24%);
+  /* apex 채널은 강도 사다리의 게이트 뒤 티어 전용이며, 신호가 아니라 비어 있던 hue 295의 티어를 말한다. */
+  --apex: oklch(80% 0.14 295);
+  --apex-glow: oklch(80% 0.14 295 / 22%);
 
   --canvas-abyss: oklch(7% 0.015 246);
   --canvas-sea-core: oklch(15% 0.03 235);
@@ -266,6 +275,9 @@
   --warn-glow: oklch(79% 0.12 80 / 22%);
   --positive: oklch(78% 0.13 158);
   --positive-glow: oklch(78% 0.13 158 / 24%);
+  /* apex 채널은 강도 사다리의 게이트 뒤 티어 전용이며, 신호가 아니라 비어 있던 hue 295의 티어를 말한다. */
+  --apex: oklch(76% 0.12 292);
+  --apex-glow: oklch(76% 0.12 292 / 20%);
 
   --canvas-abyss: oklch(8% 0.006 255);
   --canvas-sea-core: oklch(15% 0.012 250);
@@ -344,6 +356,11 @@
   --coral-ink: oklch(44% 0.15 25);
   --warn-ink: oklch(44% 0.1 82);
   --positive-ink: oklch(42% 0.11 160);
+  /* apex 채널은 강도 사다리의 게이트 뒤 티어 전용이며, 신호가 아니라 비어 있던 hue 295의 티어를 말한다. */
+  --apex: oklch(52% 0.14 296);
+  --apex-ink: oklch(43% 0.13 296);
+  --apex-glow: oklch(52% 0.14 296 / 15%);
+  --apex-halo: none;
   --brass-halo: none;
   --positive-halo: none;
 

--- a/runtime/fleet-console/sdk/operations/launch-variants.ts
+++ b/runtime/fleet-console/sdk/operations/launch-variants.ts
@@ -28,13 +28,19 @@ function readLaunchVariantRow(value: unknown): OperationLaunchVariantRow | null 
   const effortAxis = Array.isArray(value.effortAxis)
     ? value.effortAxis.filter((rung): rung is string => typeof rung === "string" && rung.length > 0)
     : [];
+  const gatedEfforts = Array.isArray(value.gatedEfforts)
+    ? value.gatedEfforts.filter((effort): effort is string => typeof effort === "string" && effort.length > 0)
+    : [];
   return {
     id: value.id,
     label: value.label,
     ...(typeof value.starred === "boolean" ? { starred: value.starred } : {}),
     launch,
     ...(chips.length > 0 ? { chips } : {}),
-    ...(chips.length > 0 && effortAxis.length > 0 ? { effortAxis } : {}),
+    ...(chips.length > 0 && effortAxis.length > 0 ? {
+      effortAxis,
+      ...(gatedEfforts.length > 0 ? { gatedEfforts } : {}),
+    } : {}),
   };
 }
 

--- a/runtime/fleet-console/sdk/operations/types.ts
+++ b/runtime/fleet-console/sdk/operations/types.ts
@@ -61,6 +61,8 @@ export interface OperationLaunchVariantRow {
    * surface has nothing but `chips` to go on and should treat them as the axis.
    */
   readonly effortAxis?: readonly string[];
+  /** 게이트 뒤로 숨는 apex 티어의 강도 id들(사다리 순). 비어 있거나 생략되면 트랙은 게이트 없이 전체 축을 보인다. */
+  readonly gatedEfforts?: readonly string[];
 }
 
 export interface OperationLaunchVariantGroup {

--- a/runtime/fleet-console/tests/effort-track.test.tsx
+++ b/runtime/fleet-console/tests/effort-track.test.tsx
@@ -390,7 +390,9 @@ describe("EffortTrack", () => {
 
     expect(track().dataset.apexOpen).toBe("true");
     expect(document.querySelector(".effort-track-apex-toggle")).toBeNull();
-    expect(required(".effort-track-apex-collapse")).toBeTruthy();
+    // apex 값이 선택된 동안은 접힘 셰브론도 숨는다 — 접으면 트랙이 AUTO를 그리면서
+    // 제출은 apex 값을 내는 모순 상태가 된다.
+    expect(document.querySelector(".effort-track-apex-collapse")).toBeNull();
     expect(document.querySelectorAll("[data-apex-rung=true]")).toHaveLength(1);
   });
 

--- a/runtime/fleet-console/tests/effort-track.test.tsx
+++ b/runtime/fleet-console/tests/effort-track.test.tsx
@@ -355,6 +355,9 @@ describe("EffortTrack", () => {
     expect(required(".effort-track-apex-collapse").getAttribute("aria-label")).toBe("Hide Max and Ultracode");
     expect(document.querySelectorAll("[data-apex-rung=true]")).toHaveLength(2);
     expect(track().getAttribute("aria-valuemax")).toBe("6");
+    // 열린 뒤에도 닫힌 사다리 간격 비율을 유지한다 — 셸 여분을 트랙이 먹어 간격을 벌리지 않는다.
+    expect(track().style.getPropertyValue("--effort-intervals")).toBe("6");
+    expect(track().style.getPropertyValue("--effort-closed-intervals")).toBe("4");
   });
 
   it("marks a selected gated rung as apex and maximum", () => {
@@ -390,10 +393,17 @@ describe("EffortTrack", () => {
 
     expect(track().dataset.apexOpen).toBe("true");
     expect(document.querySelector(".effort-track-apex-toggle")).toBeNull();
-    // apex 값이 선택된 동안은 접힘 셰브론도 숨는다 — 접으면 트랙이 AUTO를 그리면서
-    // 제출은 apex 값을 내는 모순 상태가 된다.
-    expect(document.querySelector(".effort-track-apex-collapse")).toBeNull();
+    // apex 값이 선택된 동안에도 접힘 셰브론은 남는다 — 접으면 일상 단으로 내려
+    // 숨은 apex 제출 모순을 만들지 않는다.
+    expect(required(".effort-track-apex-collapse").getAttribute("aria-label")).toBe("Hide Max and Ultracode");
     expect(document.querySelectorAll("[data-apex-rung=true]")).toHaveLength(1);
+  });
+
+  it("demotes a gated value to the last ordinary rung when collapsed", () => {
+    const onChange = render(row({ gatedEfforts: ["max"] }), "max");
+    act(() => required(".effort-track-apex-collapse").click());
+    // 이 모델의 일상 사다리에서 고를 수 있는 마지막 단은 high다(xhigh는 gap).
+    expect(onChange).toHaveBeenLastCalledWith("high");
   });
 
   it("preserves the gate-free rendering contract", () => {

--- a/runtime/fleet-console/tests/effort-track.test.tsx
+++ b/runtime/fleet-console/tests/effort-track.test.tsx
@@ -19,6 +19,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   act(() => root.unmount());
   container.remove();
 });
@@ -55,6 +56,7 @@ function render(
       autoLabel="AUTO"
       ariaLabel="Reasoning effort"
       autoValueText="Automatic"
+      apexToggleLabel="Show Max and Ultracode"
     />,
   ));
   return onChange;
@@ -326,6 +328,76 @@ describe("EffortTrack", () => {
       element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 73, clientY: 13 }));
     });
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("hides gated stops behind the apex toggle", () => {
+    render(row({ gatedEfforts: ["max", "ultra"] }), "high");
+
+    const toggle = required(".effort-track-apex-toggle");
+    expect(toggle.getAttribute("aria-pressed")).toBe("false");
+    expect(toggle.getAttribute("aria-label")).toBe("Show Max and Ultracode");
+    expect(stops()).toHaveLength(5);
+    expect(document.querySelector("[data-apex-rung=true]")).toBeNull();
+    expect(track().getAttribute("aria-valuemax")).toBe("4");
+  });
+
+  it("reveals gated stops and extends the slider range when toggled", () => {
+    render(row({
+      effortAxis: [...AXIS, "ultra"],
+      chips: [...row().chips!, { id: "ultra", label: "ULTRA", launch: { model: "kimi--k3", effort: "ultra" } }],
+      gatedEfforts: ["max", "ultra"],
+    }), "high");
+
+    act(() => required(".effort-track-apex-toggle").click());
+    expect(required(".effort-track-apex-toggle").getAttribute("aria-pressed")).toBe("true");
+    expect(document.querySelectorAll("[data-apex-rung=true]")).toHaveLength(2);
+    expect(track().getAttribute("aria-valuemax")).toBe("6");
+  });
+
+  it("marks a selected gated rung as apex and maximum", () => {
+    const gatedRow = row({ gatedEfforts: ["max"] });
+    const onChange = render(gatedRow, "xhigh");
+    act(() => required(".effort-track-apex-toggle").click());
+    act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true })));
+    expect(onChange).toHaveBeenLastCalledWith("max");
+
+    render(gatedRow, "max", onChange);
+    expect(track().dataset.apex).toBe("true");
+    expect(track().dataset.atMax).toBe("true");
+  });
+
+  it("collapses 600ms after selecting an ordinary rung while open", () => {
+    vi.useFakeTimers();
+    const gatedRow = row({ gatedEfforts: ["max"] });
+    const onChange = render(gatedRow, "max");
+    act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true })));
+    expect(onChange).toHaveBeenLastCalledWith("high");
+    expect(track().dataset.apexOpen).toBe("true");
+
+    render(gatedRow, "high", onChange);
+    act(() => vi.advanceTimersByTime(599));
+    expect(track().dataset.apexOpen).toBe("true");
+    act(() => vi.advanceTimersByTime(1));
+    expect(track().dataset.apexOpen).toBeUndefined();
+    expect(document.querySelector("[data-apex-rung=true]")).toBeNull();
+  });
+
+  it("mounts open when the controlled value is gated", () => {
+    render(row({ gatedEfforts: ["max"] }), "max");
+
+    expect(track().dataset.apexOpen).toBe("true");
+    expect(required(".effort-track-apex-toggle").getAttribute("aria-pressed")).toBe("true");
+    expect(document.querySelectorAll("[data-apex-rung=true]")).toHaveLength(1);
+  });
+
+  it("preserves the gate-free rendering contract", () => {
+    render(row(), "high");
+
+    expect(document.querySelector(".effort-track-apex-toggle")).toBeNull();
+    expect(document.querySelector(".effort-track-apex-seam")).toBeNull();
+    expect(track().dataset.apexOpen).toBeUndefined();
+    expect(track().dataset.apex).toBeUndefined();
+    expect(stops()).toHaveLength(6);
   });
 });
 

--- a/runtime/fleet-console/tests/effort-track.test.tsx
+++ b/runtime/fleet-console/tests/effort-track.test.tsx
@@ -57,6 +57,7 @@ function render(
       ariaLabel="Reasoning effort"
       autoValueText="Automatic"
       apexToggleLabel="Show Max and Ultracode"
+      apexCollapseLabel="Hide Max and Ultracode"
     />,
   ));
   return onChange;
@@ -349,7 +350,9 @@ describe("EffortTrack", () => {
     }), "high");
 
     act(() => required(".effort-track-apex-toggle").click());
-    expect(required(".effort-track-apex-toggle").getAttribute("aria-pressed")).toBe("true");
+    // 열리면 ✦는 사라지고 그 자리를 트랙이 물려받는다 — 접힘은 얇은 셰브론이 맡는다.
+    expect(document.querySelector(".effort-track-apex-toggle")).toBeNull();
+    expect(required(".effort-track-apex-collapse").getAttribute("aria-label")).toBe("Hide Max and Ultracode");
     expect(document.querySelectorAll("[data-apex-rung=true]")).toHaveLength(2);
     expect(track().getAttribute("aria-valuemax")).toBe("6");
   });
@@ -386,7 +389,8 @@ describe("EffortTrack", () => {
     render(row({ gatedEfforts: ["max"] }), "max");
 
     expect(track().dataset.apexOpen).toBe("true");
-    expect(required(".effort-track-apex-toggle").getAttribute("aria-pressed")).toBe("true");
+    expect(document.querySelector(".effort-track-apex-toggle")).toBeNull();
+    expect(required(".effort-track-apex-collapse")).toBeTruthy();
     expect(document.querySelectorAll("[data-apex-rung=true]")).toHaveLength(1);
   });
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1302,7 +1302,7 @@ describe("Instrument core design contract", () => {
       const declarations = block.match(/^\s{2}[^\n:]+:/gm) ?? [];
       expect(declarations.length).toBeGreaterThan(0);
       for (const declaration of declarations) {
-        expect(declaration.trim()).toMatch(/^--(?:ink|brass|aurora|coral|warn|positive|canvas|surface|hairline|text|id)[a-z-]*:$/);
+        expect(declaration.trim()).toMatch(/^--(?:ink|brass|aurora|coral|warn|positive|apex|canvas|surface|hairline|text|id)[a-z-]*:$/);
       }
     }
     // Light 테마만 팔레트 + 광학(color-scheme/shadow/scrollbar/신호 ink·halo/본문 regular 굵기 보정)을 허용한다.
@@ -1314,7 +1314,7 @@ describe("Instrument core design contract", () => {
       const declarations = block.match(/^\s{2}[^\n:]+:/gm) ?? [];
       expect(declarations.length).toBeGreaterThan(0);
       for (const declaration of declarations) {
-        expect(declaration.trim()).toMatch(/^(?:--(?:ink|brass|aurora|coral|warn|positive|canvas|surface|hairline|text|id|provider|shadow|scrollbar)[a-z-]*|--weight-regular|color-scheme):$/);
+        expect(declaration.trim()).toMatch(/^(?:--(?:ink|brass|aurora|coral|warn|positive|apex|canvas|surface|hairline|text|id|provider|shadow|scrollbar)[a-z-]*|--weight-regular|color-scheme):$/);
       }
     }
     // 신호 ink 티어는 base에서 별칭으로 존재해 다크 3종이 var 간접으로 base 신호색을 상속한다.
@@ -1647,6 +1647,22 @@ describe("Instrument core design contract", () => {
 });
 
 describe("Effort track interaction grammar", () => {
+  it("pins the apex tier channel and its reduced-motion cutoff", () => {
+    const components = source("styles/components.css");
+    const theme = source("styles/theme.css");
+    const apexRule = components.match(/\.effort-track\[data-apex="true"\] \{[^}]*\}/)?.[0] ?? "";
+    expect(apexRule).toContain("var(--apex)");
+
+    const themeBlocks = [theme.slice(0, theme.indexOf(':root[data-theme="'))];
+    for (const name of ["maritime", "carbon", "whites"]) {
+      const start = theme.lastIndexOf(`:root[data-theme="${name}"] {`);
+      themeBlocks.push(theme.slice(start, theme.indexOf("\n}", start)));
+    }
+    for (const block of themeBlocks) expect(block).toContain("--apex:");
+
+    expect(components).toMatch(/\.effort-track-apex-burst \{\s*animation: none;\s*\}/);
+  });
+
   it("pins the shared effort track's pointer preview motion", () => {
     const components = source("styles/components.css");
     const quickLaunch = source("components/quick-launch.tsx");

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1302,7 +1302,7 @@ describe("Instrument core design contract", () => {
       const declarations = block.match(/^\s{2}[^\n:]+:/gm) ?? [];
       expect(declarations.length).toBeGreaterThan(0);
       for (const declaration of declarations) {
-        expect(declaration.trim()).toMatch(/^--(?:ink|brass|aurora|coral|warn|positive|apex|canvas|surface|hairline|text|id)[a-z-]*:$/);
+        expect(declaration.trim()).toMatch(/^--(?:ink|brass|aurora|coral|warn|positive|apex|crest|canvas|surface|hairline|text|id)[a-z-]*:$/);
       }
     }
     // Light 테마만 팔레트 + 광학(color-scheme/shadow/scrollbar/신호 ink·halo/본문 regular 굵기 보정)을 허용한다.
@@ -1314,7 +1314,7 @@ describe("Instrument core design contract", () => {
       const declarations = block.match(/^\s{2}[^\n:]+:/gm) ?? [];
       expect(declarations.length).toBeGreaterThan(0);
       for (const declaration of declarations) {
-        expect(declaration.trim()).toMatch(/^(?:--(?:ink|brass|aurora|coral|warn|positive|apex|canvas|surface|hairline|text|id|provider|shadow|scrollbar)[a-z-]*|--weight-regular|color-scheme):$/);
+        expect(declaration.trim()).toMatch(/^(?:--(?:ink|brass|aurora|coral|warn|positive|apex|crest|canvas|surface|hairline|text|id|provider|shadow|scrollbar)[a-z-]*|--weight-regular|color-scheme):$/);
       }
     }
     // 신호 ink 티어는 base에서 별칭으로 존재해 다크 3종이 var 간접으로 base 신호색을 상속한다.
@@ -1650,17 +1650,24 @@ describe("Effort track interaction grammar", () => {
   it("pins the apex tier channel and its reduced-motion cutoff", () => {
     const components = source("styles/components.css");
     const theme = source("styles/theme.css");
-    const apexRule = components.match(/\.effort-track\[data-apex="true"\] \{[^}]*\}/)?.[0] ?? "";
-    expect(apexRule).toContain("var(--apex)");
+    const ultraRule = components.match(/\.effort-track\[data-apex="true"\]\[data-effort-level="ultra"\] \{[^}]*\}/)?.[0] ?? "";
+    const maxRule = components.match(/\.effort-track\[data-apex="true"\]\[data-effort-level="max"\] \{[^}]*\}/)?.[0] ?? "";
+    expect(ultraRule).toContain("var(--apex)");
+    expect(maxRule).toContain("var(--crest)");
 
     const themeBlocks = [theme.slice(0, theme.indexOf(':root[data-theme="'))];
     for (const name of ["maritime", "carbon", "whites"]) {
       const start = theme.lastIndexOf(`:root[data-theme="${name}"] {`);
       themeBlocks.push(theme.slice(start, theme.indexOf("\n}", start)));
     }
-    for (const block of themeBlocks) expect(block).toContain("--apex:");
+    for (const block of themeBlocks) {
+      expect(block).toContain("--apex:");
+      expect(block).toContain("--crest:");
+    }
 
     expect(components).toMatch(/\.effort-track-apex-burst \{\s*animation: none;\s*\}/);
+    expect(components).toMatch(/effort-ultracode-wave/);
+    expect(components).toMatch(/\.effort-track-value\[data-effort-level="ultra"\] \{\s*animation: none;/);
   });
 
   it("pins the shared effort track's pointer preview motion", () => {

--- a/runtime/fleet-console/tests/operations.test.ts
+++ b/runtime/fleet-console/tests/operations.test.ts
@@ -270,19 +270,28 @@ describe("operations platform", () => {
         id: "kimi--k3",
         label: "K3-1M",
         launch: { model: "kimi--k3" },
-        effortAxis: ["low", "medium", "high", "xhigh", "max", 7],
+        effortAxis: ["low", "medium", "high", "xhigh", "max", "ultra", 7],
+        gatedEfforts: ["max", "ultra", 7],
         chips: [{ id: "low", label: "LOW", launch: { model: "kimi--k3", effort: "low" } }],
       }],
     }]);
-    expect(group?.rows[0]?.effortAxis).toEqual(["low", "medium", "high", "xhigh", "max"]);
+    expect(group?.rows[0]?.effortAxis).toEqual(["low", "medium", "high", "xhigh", "max", "ultra"]);
+    expect(group?.rows[0]?.gatedEfforts).toEqual(["max", "ultra"]);
 
     // 축은 칩이 놓인 자리를 말한다 — 칩이 없으면 말할 자리도 없다.
     const [bare] = readLaunchVariantGroups([{
       id: "gateway:cursor",
       label: "Cursor",
-      rows: [{ id: "cursor--auto", label: "Auto", launch: { model: "cursor--auto" }, effortAxis: ["low"] }],
+      rows: [{
+        id: "cursor--auto",
+        label: "Auto",
+        launch: { model: "cursor--auto" },
+        effortAxis: ["low"],
+        gatedEfforts: ["max"],
+      }],
     }]);
     expect(bare?.rows[0]).not.toHaveProperty("effortAxis");
+    expect(bare?.rows[0]).not.toHaveProperty("gatedEfforts");
   });
 
   it("strictly reconstructs launch variants from the browser catalog response", async () => {

--- a/runtime/fleet-console/tests/quick-launch-layout.test.tsx
+++ b/runtime/fleet-console/tests/quick-launch-layout.test.tsx
@@ -95,9 +95,12 @@ describe("Quick Launch effort surface", () => {
 });
 
 describe("canvas effort submenu", () => {
-  it("keeps the rendered width in step with the placement constant", () => {
-    const declared = /\.operation-launch-effort-menu\.theater-menu\s*\{[^}]*?width:\s*(\d+)px;/u.exec(css)?.[1];
-    expect(Number(declared)).toBe(OPERATION_LAUNCH_EFFORT_MENU_WIDTH);
+  it("keeps the rendered open width in step with the placement constant", () => {
+    // 배치 상수는 게이트가 열린 최악 폭과 보조를 맞춘다 — 닫힘 폭은 더 좁다.
+    const open = /\.operation-launch-effort-menu\.theater-menu:has\([^)]*\)\s*\{[^}]*?width:\s*(\d+)px;/u.exec(css)?.[1];
+    expect(Number(open)).toBe(OPERATION_LAUNCH_EFFORT_MENU_WIDTH);
+    const closed = /\.operation-launch-effort-menu\.theater-menu\s*\{[^}]*?width:\s*(\d+)px;/u.exec(css)?.[1];
+    expect(Number(closed)).toBeLessThan(OPERATION_LAUNCH_EFFORT_MENU_WIDTH);
   });
 });
 

--- a/runtime/fleet-console/tests/quick-launch-layout.test.tsx
+++ b/runtime/fleet-console/tests/quick-launch-layout.test.tsx
@@ -87,20 +87,25 @@ describe("Quick Launch effort surface", () => {
   });
 
   it("gives the track a fixed berth instead of letting it compete with the spacer", () => {
-    // 남는 폭을 두고 겨루게 두면 트랙이 스톱 간격보다 좁아져 손잡이가 이웃 스톱을 덮는다.
+    // 셸은 max-content, 트랙 폭은 캔버스 추론강도와 같은 116px 비례 규칙을 쓴다.
     const rule = ruleFor(".quick-launch-effort-track");
     expect(rule).toMatch(/flex:\s*0 0 auto/u);
-    expect(rule).toMatch(/width:\s*204px/u);
+    expect(rule).toMatch(/width:\s*max-content/u);
+    expect(css).not.toMatch(/\.quick-launch-effort-track \.effort-track \{[^}]*flex:\s*1/u);
+    expect(css).toMatch(/\.effort-track \{[^}]*--effort-closed-track-width:\s*116px/u);
   });
 });
 
 describe("canvas effort submenu", () => {
-  it("keeps the rendered open width in step with the placement constant", () => {
-    // 배치 상수는 게이트가 열린 최악 폭과 보조를 맞춘다 — 닫힘 폭은 더 좁다.
-    const open = /\.operation-launch-effort-menu\.theater-menu:has\([^)]*\)\s*\{[^}]*?width:\s*(\d+)px;/u.exec(css)?.[1];
-    expect(Number(open)).toBe(OPERATION_LAUNCH_EFFORT_MENU_WIDTH);
-    const closed = /\.operation-launch-effort-menu\.theater-menu\s*\{[^}]*?width:\s*(\d+)px;/u.exec(css)?.[1];
-    expect(Number(closed)).toBeLessThan(OPERATION_LAUNCH_EFFORT_MENU_WIDTH);
+  it("sizes the flyout to its content so labels are not clipped", () => {
+    // 고정 폭이면 짧을 때 잘리고 길면 빈 칸이 남는다 — max-content가 둘을 막는다.
+    const rule = ruleFor(".operation-launch-effort-menu.theater-menu");
+    expect(rule).toMatch(/width:\s*max-content/u);
+    expect(css).not.toMatch(/\.operation-launch-effort-menu\.theater-menu:has\([^)]*\)\s*\{[^}]*width:\s*\d+px/u);
+  });
+
+  it("keeps the placement constant as an open-state ceiling", () => {
+    expect(OPERATION_LAUNCH_EFFORT_MENU_WIDTH).toBeGreaterThanOrEqual(300);
   });
 });
 

--- a/runtime/fleet-console/tests/quick-launch-layout.test.tsx
+++ b/runtime/fleet-console/tests/quick-launch-layout.test.tsx
@@ -28,16 +28,15 @@ describe("Quick Launch composer layout", () => {
     expect(css).toMatch(/\.quick-launch-pop--model\s*\{[^}]*width:\s*216px;/u);
   });
 
-  it("keeps the send control an icon-only circle and the key hint untouchable", () => {
+  it("keeps the send control an icon-only circle", () => {
     const submit = ruleFor(".quick-launch-submit");
     expect(submit).toMatch(/border-radius:\s*999px/u);
     expect(submit).toMatch(/width:\s*32px/u);
     // 버튼 안에 또 배지를 얹으면 하나의 표면이 두 겹이 된다.
     expect(css).not.toMatch(/\.quick-launch-submit\s+kbd/u);
-    // 힌트는 읽히되 만져지지 않는다 — 테두리나 배경을 주면 바 위에서 액션 행세를 한다.
-    const esc = ruleFor(".quick-launch-esc");
-    expect(esc).not.toMatch(/border/u);
-    expect(esc).not.toMatch(/background/u);
+    // esc 힌트는 제거됐다 — apex 확장이 바를 넓히면서 힌트가 바를 두 줄로 밀었다.
+    expect(css).not.toMatch(/\.quick-launch-esc/u);
+    expect(quickLaunch).not.toMatch(/escHint/u);
   });
 
   it("names the send control for assistive tech, since it carries no visible label", () => {

--- a/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
@@ -7,6 +7,7 @@ import {
   type AiGatewaySelection,
   type GatewayModel,
   type GatewayProvider,
+  type GatewayReasoningEffort,
 } from "@dotobokuri/core-ai-gateway";
 import { NATIVE_CLAUDE_EFFORTS, NATIVE_CLAUDE_MODEL_ALIASES } from "@dotobokuri/fleet-admiral";
 
@@ -18,7 +19,11 @@ const EFFORT_LABELS: Readonly<Record<string, string>> = {
   high: "HIGH",
   xhigh: "XHIGH",
   max: "MAX",
+  ultra: "ULTRACODE",
 };
+
+/** 게이트 뒤에 숨는 apex 티어 — 일상 다이얼은 xhigh에서 닫고, 이 단들은 트랙의 확장 제스처가 연다. */
+const APEX_EFFORTS = ["max", "ultra"] as const;
 
 const NATIVE_MODEL_LABELS: Readonly<Record<(typeof NATIVE_CLAUDE_MODEL_ALIASES)[number], string>> = {
   // Claude Code's 1M coordinates stay under their plain menu labels.
@@ -57,6 +62,7 @@ export function buildClaudeGatewayLaunchVariants(selection?: AiGatewaySelection)
       label: NATIVE_MODEL_LABELS[model],
       launch: { model },
       effortAxis: EFFORT_AXIS,
+      gatedEfforts: APEX_EFFORTS,
       chips: NATIVE_CLAUDE_EFFORTS.map((effort) => ({
         id: effort,
         label: EFFORT_LABELS[effort]!,
@@ -83,8 +89,10 @@ export function buildClaudeGatewayLaunchVariants(selection?: AiGatewaySelection)
 }
 
 // 강도 축은 사다리 어휘를 아는 이쪽이 소유한다. 한 모델이 그 일부만 내놓아도(low/high/max)
-// 축은 그대로라, 표면이 내놓은 단을 균등히 벌리는 대신 제자리에 세울 수 있다.
-const EFFORT_AXIS: readonly string[] = NATIVE_CLAUDE_EFFORTS;
+// 축은 그대로라, 표면이 내놓은 단을 균등히 벌리는 대신 제자리에 세울 수 있다. 게이트웨이
+// 카탈로그는 max 뒤에 ultra 단을 두므로(GATEWAY_REASONING_EFFORTS), 축은 그 끝까지 세운다.
+// 네이티브 Claude 행의 칩은 max에서 닫히므로 ultra 칩은 카탈로그가 낸 게이트웨이 행에만 선다.
+const EFFORT_AXIS: readonly string[] = [...NATIVE_CLAUDE_EFFORTS, "ultra"];
 
 function providerGroupId(provider: GatewayProvider): string {
   return `gateway:${provider}`;
@@ -92,14 +100,15 @@ function providerGroupId(provider: GatewayProvider): string {
 
 function toGatewayRow(model: GatewayModel, selection: AiGatewaySelection) {
   const efforts = (selection.effortExposure[model.id] ?? exposableEffortLadder(model))
-    .filter((effort): effort is (typeof NATIVE_CLAUDE_EFFORTS)[number] =>
-      NATIVE_CLAUDE_EFFORTS.includes(effort as (typeof NATIVE_CLAUDE_EFFORTS)[number]));
+    .filter((effort): effort is Extract<GatewayReasoningEffort, (typeof EFFORT_AXIS)[number]> =>
+      EFFORT_AXIS.includes(effort));
   return {
     id: model.id,
     label: bareModelName(model),
     launch: { model: model.id },
     ...(efforts.length > 0 ? {
       effortAxis: EFFORT_AXIS,
+      gatedEfforts: APEX_EFFORTS,
       chips: efforts.map((effort) => ({
         id: effort,
         label: EFFORT_LABELS[effort] ?? effort.toUpperCase(),

--- a/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/agent-cli-launch-kinds.ts
@@ -63,7 +63,10 @@ export function buildClaudeGatewayLaunchVariants(selection?: AiGatewaySelection)
       launch: { model },
       effortAxis: EFFORT_AXIS,
       gatedEfforts: APEX_EFFORTS,
-      chips: NATIVE_CLAUDE_EFFORTS.map((effort) => ({
+      // 네이티브 행도 ultra 칩을 낸다 — ultracode는 모델 사다리의 단이 아니라 하네스
+      // 능력(standing orchestration)이라 모델 독립이다. wire 번역(max + settings)은
+      // launch factory가 담당한다.
+      chips: EFFORT_AXIS.map((effort) => ({
         id: effort,
         label: EFFORT_LABELS[effort]!,
         launch: { model, effort },
@@ -91,7 +94,6 @@ export function buildClaudeGatewayLaunchVariants(selection?: AiGatewaySelection)
 // 강도 축은 사다리 어휘를 아는 이쪽이 소유한다. 한 모델이 그 일부만 내놓아도(low/high/max)
 // 축은 그대로라, 표면이 내놓은 단을 균등히 벌리는 대신 제자리에 세울 수 있다. 게이트웨이
 // 카탈로그는 max 뒤에 ultra 단을 두므로(GATEWAY_REASONING_EFFORTS), 축은 그 끝까지 세운다.
-// 네이티브 Claude 행의 칩은 max에서 닫히므로 ultra 칩은 카탈로그가 낸 게이트웨이 행에만 선다.
 const EFFORT_AXIS: readonly string[] = [...NATIVE_CLAUDE_EFFORTS, "ultra"];
 
 function providerGroupId(provider: GatewayProvider): string {

--- a/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
+++ b/runtime/fleet-plugins/terminal/server/agent-api/launch.ts
@@ -87,7 +87,8 @@ export function isGatewayLaunchEffortAllowed(
   model: GatewayModel,
   effort: string,
 ): boolean {
-  if (!NATIVE_CLAUDE_EFFORTS.includes(effort as (typeof NATIVE_CLAUDE_EFFORTS)[number])) return false;
+  // 첫 검사는 어휘만 판별하고, 실제 모델이 그 단을 제공하는지는 아래 카탈로그 사다리가 판다.
+  if (!([...NATIVE_CLAUDE_EFFORTS, "ultra"] as readonly string[]).includes(effort)) return false;
   const efforts = selection.effortExposure[model.id] ?? exposableEffortLadder(model);
   return efforts.includes(effort as GatewayReasoningEffort);
 }

--- a/runtime/fleet-plugins/terminal/server/agent.ts
+++ b/runtime/fleet-plugins/terminal/server/agent.ts
@@ -363,7 +363,9 @@ async function createAgentApi(ctx: FleetPluginServerContext, terminalRuntime: Te
     }
     const nativeAlias = resolveNativeClaudeModelAlias(model);
     if (nativeAlias) {
-      if (effort !== undefined && !NATIVE_CLAUDE_EFFORTS.includes(effort as (typeof NATIVE_CLAUDE_EFFORTS)[number])) {
+      // ultracode는 wire effort가 아니라 하네스 능력이라 네이티브 행도 ultra를 받는다 —
+      // wire로의 번역(max + settings)은 launch factory가 담당한다.
+      if (effort !== undefined && !([...NATIVE_CLAUDE_EFFORTS, "ultra"] as readonly string[]).includes(effort)) {
         ctx.host.http.writeJson(res, 400, { error: "invalid_effort" });
         return false;
       }

--- a/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
@@ -127,12 +127,14 @@ function builtinRow(model: string, label: string) {
     launch: { model },
     effortAxis: EFFORT_AXIS,
     gatedEfforts: APEX_EFFORTS,
+    // ultracode는 하네스 능력이라 네이티브 행도 ultra 칩을 낸다.
     chips: [
       gatewayChip(model, "low", "LOW"),
       gatewayChip(model, "medium", "MED"),
       gatewayChip(model, "high", "HIGH"),
       gatewayChip(model, "xhigh", "XHIGH"),
       gatewayChip(model, "max", "MAX"),
+      gatewayChip(model, "ultra", "ULTRACODE"),
     ],
   };
 }

--- a/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-cli-launch-kinds.test.ts
@@ -5,7 +5,8 @@ import { buildAgentCliLaunchKinds } from "../server/agent-api/agent-cli-launch-k
 
 // 축은 사다리 어휘 그대로다. 한 모델이 그 일부만 내놓아도 축은 줄지 않는다 — 그래야 표면이
 // 내놓은 단을 균등히 벌리는 대신 제자리에 세울 수 있다.
-const EFFORT_AXIS = ["low", "medium", "high", "xhigh", "max"];
+const EFFORT_AXIS = ["low", "medium", "high", "xhigh", "max", "ultra"];
+const APEX_EFFORTS = ["max", "ultra"];
 
 const builtinVariants = {
   id: "native",
@@ -39,13 +40,20 @@ describe("buildAgentCliLaunchKinds", () => {
   });
 
   it("adds enabled gateway models in provider order with their exposed effort ladders", () => {
-    const selection = resolveAiGatewaySelection({
+    const resolved = resolveAiGatewaySelection({
       version: 1,
       models: [
         { id: "kimi--k3", efforts: ["max"] },
         { id: "codex--gpt-5.6-sol-fast" },
       ],
     });
+    const selection = {
+      ...resolved,
+      effortExposure: {
+        ...resolved.effortExposure,
+        "codex--gpt-5.6-sol-fast": ["low", "medium", "high", "xhigh", "max", "ultra"] as const,
+      },
+    };
 
     const result = buildAgentCliLaunchKinds(
       [{ id: "claude-gateway", label: "Claude (Gateway)", available: true, signedIn: true }],
@@ -64,12 +72,14 @@ describe("buildAgentCliLaunchKinds", () => {
             label: "GPT-5.6-Sol-Fast",
             launch: { model: "codex--gpt-5.6-sol-fast" },
             effortAxis: EFFORT_AXIS,
+            gatedEfforts: APEX_EFFORTS,
             chips: [
               gatewayChip("codex--gpt-5.6-sol-fast", "low", "LOW"),
               gatewayChip("codex--gpt-5.6-sol-fast", "medium", "MED"),
               gatewayChip("codex--gpt-5.6-sol-fast", "high", "HIGH"),
               gatewayChip("codex--gpt-5.6-sol-fast", "xhigh", "XHIGH"),
               gatewayChip("codex--gpt-5.6-sol-fast", "max", "MAX"),
+              gatewayChip("codex--gpt-5.6-sol-fast", "ultra", "ULTRACODE"),
             ],
           },
         ],
@@ -82,14 +92,14 @@ describe("buildAgentCliLaunchKinds", () => {
             id: "kimi--k3",
             label: "K3-1M",
             launch: { model: "kimi--k3" },
-            // 노출은 MAX 한 단뿐이지만 축은 다섯 단 그대로다.
+            // 노출은 MAX 한 단뿐이지만 축은 여섯 단 그대로다.
             effortAxis: EFFORT_AXIS,
+            gatedEfforts: APEX_EFFORTS,
             chips: [gatewayChip("kimi--k3", "max", "MAX")],
           },
         ],
       },
     ]);
-    expect(JSON.stringify(result)).not.toContain("ultra");
   });
 
   it("keeps disabled reasons and does not attach variants to a disabled gateway kind", () => {
@@ -116,6 +126,7 @@ function builtinRow(model: string, label: string) {
     label,
     launch: { model },
     effortAxis: EFFORT_AXIS,
+    gatedEfforts: APEX_EFFORTS,
     chips: [
       gatewayChip(model, "low", "LOW"),
       gatewayChip(model, "medium", "MED"),

--- a/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
@@ -3,14 +3,14 @@ import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import type { AiGatewayStoredSettings } from "@dotobokuri/core-ai-gateway";
+import { resolveAiGatewaySelection, type AiGatewayStoredSettings } from "@dotobokuri/core-ai-gateway";
 import { MAX_LAUNCH_PROMPT_CHARS } from "@dotobokuri/fleet-admiral";
 import type { OperationCreateInput, OperationNode, OperationPatchInput } from "@fleet-console/sdk/operations";
 import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 import type { RouteHandler } from "@fleet-console/sdk/routing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { GatewayLaunchOptionError } from "../server/agent-api/launch.js";
+import { GatewayLaunchOptionError, isGatewayLaunchEffortAllowed } from "../server/agent-api/launch.js";
 import { registerAgentRoutes } from "../server/agent.js";
 import type { TerminalRuntime } from "../server/shared/index.js";
 import { createPluginTerminalTicketRegistry } from "../server/shared/tickets.js";
@@ -54,19 +54,17 @@ describe("agent launch variants", () => {
     expect(harness.attach).not.toHaveBeenCalled();
   });
 
-  it("rejects ultra even when the gateway model catalog includes it", async () => {
-    const harness = await createHarness({
-      body: { cliId: "claude-gateway", model: "codex--gpt-5.6-sol-fast", effort: "ultra" },
-      aiGatewaySettings: {
-        version: 1,
-        models: [{ id: "codex--gpt-5.6-sol-fast" }],
-      },
+  it("accepts ultra when the gateway model catalog includes it", () => {
+    const selection = resolveAiGatewaySelection({
+      version: 1,
+      models: [{ id: "codex--gpt-5.6-sol-fast" }],
     });
+    const model = selection.models[0]!;
 
-    await harness.postSessions();
-
-    expect(harness.responses.at(-1)).toEqual({ status: 400, body: { error: "invalid_effort" } });
-    expect(harness.attach).not.toHaveBeenCalled();
+    expect(isGatewayLaunchEffortAllowed({
+      ...selection,
+      effortExposure: { [model.id]: ["ultra"] },
+    }, model, "ultra")).toBe(true);
   });
 
   it("threads a valid scoped gateway model and effort into attach", async () => {

--- a/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/agent-dormant-ticket.test.ts
@@ -28,7 +28,8 @@ describe("agent launch variants", () => {
   it.each([
     [{ cliId: "claude-gateway", model: 5 }, 400, "invalid_launch_option"],
     [{ cliId: "claude-gateway", model: "cursor--missing" }, 409, "gateway_model_not_enabled"],
-    [{ cliId: "claude-gateway", model: "fable", effort: "ultra" }, 400, "invalid_effort"],
+    // 네이티브 행의 ultra는 하네스 능력이라 허용된다 — 사다리 어휘 밖의 값만 거부한다.
+    [{ cliId: "claude-gateway", model: "fable", effort: "minimal" }, 400, "invalid_effort"],
     [{ cliId: "claude-gateway", effort: "max" }, 400, "invalid_launch_option"],
   ] as const)("rejects invalid launch body %#", async (body, status, error) => {
     const harness = await createHarness({ body });


### PR DESCRIPTION
## Summary
- 강도 게이지의 일상 사다리를 XHIGH에서 닫고, MAX·ULTRACODE를 apex 확장 뒤의 게이트 티어로 분리합니다. Quick Launch와 캔버스 컨텍스트 메뉴가 같은 트랙 폭 규칙을 쓰고, 펼쳐도 스톱 간격은 유지됩니다.
- MAX는 molten-copper crest 채널, ULTRACODE는 apex violet 게이지와 흐르는 라벨 물결로 구분됩니다.
- ULTRACODE 실행은 Claude Code에 `--effort ultracode`를 전달해 xhigh와 상시 멀티에이전트 오케스트레이션을 함께 적용합니다.

## Test Plan
- [x] fleet-admiral / fleet-console scoped tests green (effort track, layout, design contract, gateway spawn)
- [x] changelog fragment validated (`compile-changelog-fragments.mjs --check`)
- [x] isolated console dogfood: apex expand/collapse, crest vs apex paint, ULTRACODE spawn uses `--effort ultracode`