### PR TITLE
fix(ai-gateway): preserve truthful context windows

### DIFF
--- a/.changelog.d/honest-context-projection.md
+++ b/.changelog.d/honest-context-projection.md
@@ -1,0 +1,13 @@
+---
+branch: honest-context-projection
+---
+
+### fleet-cli
+#### Changed
+- Advertise `[1m]` only for gateway models with a real 1M-or-larger context window, while offset-mapping every model's usage so Claude Code compacts near that model's own context limit in mixed-model sessions.
+  ko: 실제 컨텍스트 윈도우가 1M 이상인 게이트웨이 모델만 `[1m]`으로 표시하고, 혼합 모델 세션에서 각 모델이 자신의 컨텍스트 한계 근처에서 압축되도록 모든 모델의 사용량을 오프셋 매핑합니다.
+
+### fleet-console
+#### Changed
+- Advertise `[1m]` only for gateway models with a real 1M-or-larger context window, while offset-mapping every model's usage so Claude Code compacts near that model's own context limit in mixed-model sessions.
+  ko: 실제 컨텍스트 윈도우가 1M 이상인 게이트웨이 모델만 `[1m]`으로 표시하고, 혼합 모델 세션에서 각 모델이 자신의 컨텍스트 한계 근처에서 압축되도록 모든 모델의 사용량을 오프셋 매핑합니다.

--- a/packages/core-agent/src/claude/launch-env.ts
+++ b/packages/core-agent/src/claude/launch-env.ts
@@ -48,6 +48,9 @@ export function claudeGatewayLaunchEnv(
   env.CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY = "1";
   // Gateway가 tool_reference 계약을 보존한다.
   env.ENABLE_TOOL_SEARCH = "true";
+  // 1M ceiling은 `[1m]` 모델의 선제 압축을 켜고, unmarked custom model에서는
+  // Claude Code의 200k 좌표로 clamp된다. 명시적 운영자 override는 보존한다.
+  env.CLAUDE_CODE_AUTO_COMPACT_WINDOW ??= "1000000";
 
   // 자체 bearer를 주입하지 않는다. 주입하면 Claude Code가 claude.ai OAuth 대신 그것을 보내고,
   // 게이트웨이의 sk-ant-* 호출자 게이트를 통과할 자격증명이 사라진다.

--- a/packages/core-agent/tests/claude-launch-env.test.ts
+++ b/packages/core-agent/tests/claude-launch-env.test.ts
@@ -16,6 +16,7 @@ describe("claudeGatewayLaunchEnv", () => {
     const env = claudeGatewayLaunchEnv({}, { baseUrl: BASE_URL, configDir: CONFIG_DIR });
     expect(env.ANTHROPIC_BASE_URL).toBe(BASE_URL);
     expect(env.CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY).toBe("1");
+    expect(env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("1000000");
     expect(env.ENABLE_TOOL_SEARCH).toBe("true");
   });
 
@@ -41,10 +42,18 @@ describe("claudeGatewayLaunchEnv", () => {
     // fleet-admiral의 launch-env가 이 변수를 세우므로 Fleet 터미널에서 기동된 프로세스는
     // 다른 게이트웨이를 가리키는 값을 상속한다.
     const env = claudeGatewayLaunchEnv(
-      { ANTHROPIC_MODEL: "claude-gateway--codex--gpt-5.6-sol-fast[1m]" },
+      { ANTHROPIC_MODEL: "claude-gateway--codex--gpt-5.6-sol-fast" },
       { baseUrl: BASE_URL, configDir: CONFIG_DIR },
     );
     expect(env).not.toHaveProperty("ANTHROPIC_MODEL");
+  });
+
+  it("preserves an explicit auto-compact ceiling", () => {
+    const env = claudeGatewayLaunchEnv(
+      { CLAUDE_CODE_AUTO_COMPACT_WINDOW: "850000" },
+      { baseUrl: BASE_URL, configDir: CONFIG_DIR },
+    );
+    expect(env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("850000");
   });
 
   it("drops undefined inherited entries rather than forwarding them as empty strings", () => {
@@ -60,7 +69,7 @@ describe("claudeGatewayModelCache", () => {
   });
 
   it("advertises exactly the models it was handed, under their Claude-facing ids", () => {
-    const model = findGatewayModel("claude-gateway--codex--gpt-5.6-luna-fast[1m]");
+    const model = findGatewayModel("claude-gateway--codex--gpt-5.6-luna-fast");
     expect(model).toBeDefined();
     const cache = claudeGatewayModelCache({ baseUrl: BASE_URL, models: [model!], fetchedAt: 1 });
     expect(cache.models).toEqual([

--- a/packages/core-agent/tests/claude-sdk.test.ts
+++ b/packages/core-agent/tests/claude-sdk.test.ts
@@ -24,8 +24,8 @@ vi.mock("../src/claude/vendor-sdk.js", () => ({
 const { createClaudeGatewaySdk } = await import("../src/claude/sdk.js");
 
 const BASE_URL = "http://127.0.0.1:43210/plugins/terminal/ai-gateway";
-const LUNA = "claude-gateway--codex--gpt-5.6-luna-fast[1m]";
-const SOL = "claude-gateway--codex--gpt-5.6-sol-fast[1m]";
+const LUNA = "claude-gateway--codex--gpt-5.6-luna-fast";
+const SOL = "claude-gateway--codex--gpt-5.6-sol-fast";
 const FABLE_1M = "fable[1m]";
 
 async function drain(run: AsyncIterable<unknown>): Promise<void> {

--- a/packages/core-ai-gateway/package.json
+++ b/packages/core-ai-gateway/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "build": "tsup && tsc --emitDeclarationOnly --noEmit false -p tsconfig.build.json",
+    "probe:claude-auto-compact": "pnpm run build 1>&2 && node scripts/probe-claude-auto-compact.mjs",
     "probe:cursor-context": "pnpm run build 1>&2 && node scripts/probe-cursor-context-windows.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.json"

--- a/packages/core-ai-gateway/scripts/probe-claude-auto-compact.mjs
+++ b/packages/core-ai-gateway/scripts/probe-claude-auto-compact.mjs
@@ -1,0 +1,410 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  CLAUDE_COMPAT_CONTEXT_WINDOW,
+  CLAUDE_DEFAULT_CONTEXT_WINDOW,
+  projectClaudeContextInputTokens,
+} from "../dist/index.js";
+
+const DEFAULT_TIMEOUT_MS = 45_000;
+const MODEL_PREFIX = "claude-gateway--";
+const ONE_MILLION_MARKER = "[1m]";
+
+class UsageError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "UsageError";
+  }
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write(`Usage:
+  pnpm --silent --filter @dotobokuri/core-ai-gateway probe:claude-auto-compact -- \\
+    --model <gateway-id> --provider-window <n> --input-tokens <n> \\
+    --expect <compact|no-compact>
+
+Options:
+  --model <id>             Gateway model id; use [1m] only for a real >=1M model
+  --provider-window <n>    Real provider context window
+  --input-tokens <n>       Real input usage returned by the pressure turn
+  --expect <result>        Expected auto-compact result
+  --auto-compact-window <n>  Optional explicit Claude Code compact ceiling
+  --timeout-ms <ms>        Positive process timeout (default: ${DEFAULT_TIMEOUT_MS})
+  --help                   Show this help without launching Claude Code
+
+The probe maps real usage through core-ai-gateway's built implementation, clears
+inherited auto-compact overrides, optionally injects the requested ceiling, and drives
+the installed Claude Code against a local fixture. It contacts no provider or credential.
+`);
+    return;
+  }
+
+  const result = await runProbe(options);
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  const expectedCompacting = options.expect === "compact";
+  if (
+    result.timedOut
+    || result.exit.code !== 0
+    || result.observedContextWindow !== result.expectedContextWindow
+    || result.compacting !== expectedCompacting
+    || (expectedCompacting && result.compactResult !== "success")
+  ) process.exitCode = 1;
+}
+
+function parseArguments(argv) {
+  const normalizedArgv = argv[0] === "--" ? argv.slice(1) : argv;
+  const options = {
+    autoCompactWindow: undefined,
+    expect: undefined,
+    help: false,
+    inputTokens: undefined,
+    model: undefined,
+    providerWindow: undefined,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+  };
+  const seen = new Set();
+
+  for (let index = 0; index < normalizedArgv.length; index += 1) {
+    const argument = normalizedArgv[index];
+    switch (argument) {
+      case "--help":
+        options.help = true;
+        break;
+      case "--model":
+        rejectDuplicate(seen, argument);
+        options.model = readValue(normalizedArgv, index, argument);
+        index += 1;
+        break;
+      case "--provider-window":
+        rejectDuplicate(seen, argument);
+        options.providerWindow = positiveInteger(readValue(normalizedArgv, index, argument), argument);
+        index += 1;
+        break;
+      case "--input-tokens":
+        rejectDuplicate(seen, argument);
+        options.inputTokens = positiveInteger(readValue(normalizedArgv, index, argument), argument);
+        index += 1;
+        break;
+      case "--expect":
+        rejectDuplicate(seen, argument);
+        options.expect = readValue(normalizedArgv, index, argument);
+        index += 1;
+        break;
+      case "--auto-compact-window":
+        rejectDuplicate(seen, argument);
+        options.autoCompactWindow = positiveInteger(readValue(normalizedArgv, index, argument), argument);
+        index += 1;
+        break;
+      case "--timeout-ms":
+        rejectDuplicate(seen, argument);
+        options.timeoutMs = positiveInteger(readValue(normalizedArgv, index, argument), argument);
+        index += 1;
+        break;
+      default:
+        throw new UsageError(`Unknown argument ${JSON.stringify(argument)}`);
+    }
+  }
+
+  if (options.help) return options;
+  if (!options.model?.startsWith(MODEL_PREFIX)) {
+    throw new UsageError(`--model must start with ${JSON.stringify(MODEL_PREFIX)}`);
+  }
+  if (options.providerWindow === undefined) throw new UsageError("--provider-window is required");
+  if (options.inputTokens === undefined) throw new UsageError("--input-tokens is required");
+  if (options.expect !== "compact" && options.expect !== "no-compact") {
+    throw new UsageError("--expect must be compact or no-compact");
+  }
+  const marked = options.model.endsWith(ONE_MILLION_MARKER);
+  if (marked !== (options.providerWindow >= CLAUDE_COMPAT_CONTEXT_WINDOW)) {
+    throw new UsageError("[1m] must exactly match a provider window of at least 1M");
+  }
+  return options;
+}
+
+function readValue(argv, index, option) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) throw new UsageError(`${option} requires a value`);
+  return value;
+}
+
+function positiveInteger(value, option) {
+  if (!/^[1-9]\d*$/.test(value)) throw new UsageError(`${option} must be a positive integer`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) throw new UsageError(`${option} is too large`);
+  return parsed;
+}
+
+function rejectDuplicate(seen, option) {
+  if (seen.has(option)) throw new UsageError(`${option} may be provided only once`);
+  seen.add(option);
+}
+
+async function runProbe(options) {
+  const requests = [];
+  const outputEvents = [];
+  const sessionId = randomUUID();
+  const modelWindow = options.model.endsWith(ONE_MILLION_MARKER)
+    ? CLAUDE_COMPAT_CONTEXT_WINDOW
+    : CLAUDE_DEFAULT_CONTEXT_WINDOW;
+  const projectedInputTokens = projectClaudeContextInputTokens(
+    options.inputTokens,
+    options.providerWindow,
+  );
+  const configDir = await mkdtemp(path.join(os.tmpdir(), "fleet-compact-probe-"));
+  let server;
+  let child;
+  let timedOut = false;
+
+  try {
+    server = http.createServer((req, res) => {
+      void handleFixtureRequest(req, res, {
+        inputTokens: projectedInputTokens,
+        model: options.model,
+        providerWindow: options.providerWindow,
+        requests,
+      }).catch((error) => {
+        if (res.headersSent) return res.end();
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ type: "error", error: { type: "api_error", message: String(error) } }));
+      });
+    });
+    await listen(server);
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Fixture server did not expose a TCP port");
+
+    const environment = { ...process.env };
+    for (const name of [
+      "ANTHROPIC_AUTH_TOKEN",
+      "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE",
+      "CLAUDE_CODE_AUTO_COMPACT",
+      "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
+      "CLAUDE_CODE_CHILD_SESSION",
+      "CLAUDE_CODE_DISABLE_1M_CONTEXT",
+      "CLAUDE_CODE_DISABLE_UNKNOWN_MODEL_WINDOW_ENFORCEMENT",
+      "CLAUDE_CODE_MAX_CONTEXT_TOKENS",
+    ]) delete environment[name];
+    delete environment.INIT_CWD;
+    Object.assign(environment, {
+      ...(options.autoCompactWindow === undefined
+        ? {}
+        : { CLAUDE_CODE_AUTO_COMPACT_WINDOW: String(options.autoCompactWindow) }),
+      ANTHROPIC_API_KEY: "sk-ant-fleet-gateway-smoke",
+      ANTHROPIC_BASE_URL: `http://127.0.0.1:${address.port}`,
+      CLAUDE_CONFIG_DIR: configDir,
+      CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY: "1",
+      CLAUDE_SECURESTORAGE_CONFIG_DIR: "",
+    });
+
+    child = spawn("claude", [
+      "--bare",
+      "--print",
+      "--model", options.model,
+      "--input-format", "stream-json",
+      "--output-format", "stream-json",
+      "--verbose",
+      "--session-id", sessionId,
+      "--tools", "",
+    ], { env: environment, stdio: ["pipe", "pipe", "pipe"] });
+
+    let stdoutBuffer = "";
+    let stderr = "";
+    let sentTurns = 0;
+    const prompts = [
+      "Fixture warmup turn one. Reply with OK.",
+      "Fixture warmup turn two. Reply with OK.",
+      "Fixture warmup turn three. Reply with OK.",
+      "Fixture pressure turn. Reply with OK.",
+      "Fixture trigger turn. Reply with DONE.",
+    ];
+    const sendNext = () => {
+      const content = prompts[sentTurns];
+      if (content === undefined) return child.stdin.end();
+      child.stdin.write(`${JSON.stringify({
+        type: "user",
+        session_id: sessionId,
+        message: { role: "user", content },
+      })}\n`);
+      sentTurns += 1;
+    };
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdoutBuffer += chunk;
+      const lines = stdoutBuffer.split("\n");
+      stdoutBuffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const event = JSON.parse(line);
+          outputEvents.push(event);
+          if (event.type === "result") sendNext();
+        } catch {
+          // Claude's stream-json contract is authoritative; ignore incidental text.
+        }
+      }
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      setTimeout(() => child.exitCode === null && child.kill("SIGKILL"), 2_000).unref();
+    }, options.timeoutMs);
+    sendNext();
+    const exit = await waitForExit(child);
+    clearTimeout(timeout);
+
+    const statusEvents = outputEvents.filter((event) => event.type === "system" && event.subtype === "status");
+    const resultEvents = outputEvents.filter((event) => event.type === "result");
+    const modelUsage = resultEvents.findLast((event) => event.modelUsage?.[options.model])
+      ?.modelUsage?.[options.model];
+    const classified = requests.map(classifyRequest);
+    return {
+      claudeCodeVersion: outputEvents.find((event) => event.type === "system" && event.subtype === "init")
+        ?.claude_code_version ?? null,
+      model: options.model,
+      autoCompactWindow: options.autoCompactWindow ?? null,
+      providerWindow: options.providerWindow,
+      actualInputTokens: options.inputTokens,
+      projectedInputTokens,
+      expected: options.expect,
+      expectedContextWindow: modelWindow,
+      observedContextWindow: modelUsage?.contextWindow ?? null,
+      compacting: statusEvents.some((event) => event.status === "compacting"),
+      compactResult: statusEvents.findLast((event) => Object.hasOwn(event, "compact_result"))
+        ?.compact_result ?? null,
+      requestCounts: {
+        workload: classified.filter((kind) => kind === "workload").length,
+        auxiliary: classified.filter((kind) => kind === "auxiliary").length,
+      },
+      timedOut,
+      exit,
+      stderr: stderr.trim() || null,
+    };
+  } finally {
+    if (child?.exitCode === null) child.kill("SIGKILL");
+    if (server) await closeServer(server);
+    await rm(configDir, { recursive: true, force: true });
+  }
+}
+
+async function handleFixtureRequest(req, res, fixture) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
+  const body = chunks.length > 0 ? JSON.parse(Buffer.concat(chunks).toString("utf8")) : undefined;
+  fixture.requests.push({ body, method: req.method, pathname });
+
+  if ((req.method === "HEAD" || req.method === "GET") && pathname === "/api/hello") {
+    res.writeHead(200, { "content-type": "application/json" }).end("{}");
+    return;
+  }
+  if (req.method === "GET" && pathname === "/v1/models") {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({
+      data: [{
+        type: "model",
+        id: fixture.model,
+        display_name: fixture.model,
+        created_at: "2026-08-11T00:00:00Z",
+        max_input_tokens: fixture.providerWindow,
+      }],
+      has_more: false,
+    }));
+    return;
+  }
+  if (req.method !== "POST" || pathname !== "/v1/messages") {
+    res.writeHead(404).end();
+    return;
+  }
+
+  const kind = classifyRequest({ body, method: req.method, pathname });
+  const lastText = lastUserText(body);
+  const reportedInputTokens = lastText.includes("Fixture pressure turn") ? fixture.inputTokens : 1_000;
+  const text = kind === "auxiliary"
+    ? '{"title":"Context fixture"}'
+    : lastText.includes("Fixture trigger turn") ? "DONE" : "OK";
+  writeAnthropicSse(res, fixture.model, text, reportedInputTokens);
+}
+
+function classifyRequest(request) {
+  if (request.method !== "POST" || request.pathname !== "/v1/messages") return "auxiliary";
+  const systemText = Array.isArray(request.body?.system)
+    ? request.body.system.map((block) => typeof block?.text === "string" ? block.text : "").join("\n")
+    : String(request.body?.system ?? "");
+  if (systemText.includes("Generate a concise, sentence-case title")) return "auxiliary";
+  return "workload";
+}
+
+function lastUserText(body) {
+  const messages = Array.isArray(body?.messages) ? body.messages : [];
+  const user = [...messages].reverse().find((message) => message?.role === "user");
+  if (typeof user?.content === "string") return user.content;
+  if (!Array.isArray(user?.content)) return "";
+  return user.content.map((block) => typeof block?.text === "string" ? block.text : "").join("\n");
+}
+
+function writeAnthropicSse(res, model, text, inputTokens) {
+  const id = `msg_${randomUUID()}`;
+  const events = [
+    ["message_start", { type: "message_start", message: {
+      id,
+      type: "message",
+      role: "assistant",
+      model,
+      content: [],
+      stop_reason: null,
+      stop_sequence: null,
+      usage: {
+        input_tokens: inputTokens,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        output_tokens: 0,
+      },
+    } }],
+    ["content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }],
+    ["content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text } }],
+    ["content_block_stop", { type: "content_block_stop", index: 0 }],
+    ["message_delta", { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 4 } }],
+    ["message_stop", { type: "message_stop" }],
+  ];
+  res.writeHead(200, { "cache-control": "no-cache", "content-type": "text/event-stream" });
+  for (const [event, data] of events) res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+  res.end();
+}
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+function waitForExit(child) {
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.name}: ${error.message}\n`);
+  process.exitCode = 1;
+});

--- a/packages/core-ai-gateway/src/anthropic/claude-context.ts
+++ b/packages/core-ai-gateway/src/anthropic/claude-context.ts
@@ -14,7 +14,7 @@ const ANTHROPIC_INPUT_USAGE_FIELDS = [
 
 export interface AnthropicResponseUsageProjectionOptions {
   readonly contentType?: string | null;
-  /** Usage projection denominator. Omit — or pass a window at or below Claude's 200k default — to skip that projection. */
+  /** Real provider window mapped onto Claude Code's 200k or `[1m]` 1M coordinate. */
   readonly contextWindow?: number;
   /**
    * Client-requested model id to echo back in place of the provider's wire id.
@@ -38,7 +38,7 @@ interface SseSeparator {
   readonly length: number;
 }
 
-/** A provider window that needs Claude Code's 1M compatibility coordinate. */
+/** A provider window whose usage must be mapped onto one of Claude Code's fixed coordinates. */
 export function canProjectClaudeContextWindow(contextWindow: number | undefined): boolean {
   return typeof contextWindow === "number"
     && Number.isFinite(contextWindow)
@@ -61,39 +61,35 @@ export function stripClaudeOneMillionMarker(modelId: string): string {
 }
 
 /**
- * Project a marked provider model's input usage onto Claude Code's 1M coordinate.
- * The projection preserves the provider model's occupied-context ratio.
+ * Map a provider model's occupied input onto the fixed coordinate Claude Code assigns
+ * from its model id: 200k without `[1m]`, 1M with it.
  *
- * The result is capped at the coordinate itself. Claude Code has no representation
- * for an occupancy above the window it was told the model has: past that point it
- * reports `Context exceeds the <limit>-token limit by <n> tokens — run /compact or
- * /clear to continue.`, handing the session back to a manual step (message observed
- * in Claude Code 2.1.221, 2026-08-04; whether its own auto-compaction still fires
- * from that state was not measured, and the cap keeps sessions out of the band
- * where the answer would matter). A denominator that
- * understates the real window — or an upstream that reports more input than the
- * catalog claims the model holds — would otherwise push the session into that
- * state, so the cap is a floor under the whole projection, not a rounding detail.
+ * Claude Code keeps roughly the same absolute reserve on both coordinates (2.1.227
+ * compacted between 166k/168k on 200k and 966k/968k on 1M). Removing only the
+ * provider window's excess over Claude's coordinate therefore preserves that reserve:
+ * a 272k provider maps 240k real input to 168k, rather than sacrificing everything
+ * above 168k or pretending the model itself has a 1M window.
+ *
+ * An upstream-reported window can narrow the catalog value. This matters for routing
+ * aliases whose serving model changes per turn: the reported window, when present,
+ * is the real capacity the current response occupied. The result is capped at the
+ * coordinate so an inconsistent over-window usage cannot strand Claude Code in its
+ * manual "context exceeds the limit" state.
  */
 export function projectClaudeContextInputTokens(
   inputTokens: number,
   advertisedContextWindow: number | undefined,
   upstreamContextWindow: number | undefined = advertisedContextWindow,
 ): number {
-  if (
-    !Number.isFinite(inputTokens)
-    || inputTokens < 0
-    || !canProjectClaudeContextWindow(advertisedContextWindow)
-  ) {
-    return inputTokens;
-  }
-  const projectionWindow = positiveContextWindow(upstreamContextWindow)
-    ?? positiveContextWindow(advertisedContextWindow);
-  if (projectionWindow === undefined) return inputTokens;
-  return Math.min(
-    CLAUDE_COMPAT_CONTEXT_WINDOW,
-    Math.ceil(inputTokens * CLAUDE_COMPAT_CONTEXT_WINDOW / projectionWindow),
-  );
+  if (!Number.isFinite(inputTokens) || inputTokens < 0) return inputTokens;
+  const advertisedWindow = positiveContextWindow(advertisedContextWindow);
+  if (advertisedWindow === undefined) return inputTokens;
+  const projectionWindow = positiveContextWindow(upstreamContextWindow) ?? advertisedWindow;
+  const coordinate = advertisedWindow >= CLAUDE_COMPAT_CONTEXT_WINDOW
+    ? CLAUDE_COMPAT_CONTEXT_WINDOW
+    : CLAUDE_DEFAULT_CONTEXT_WINDOW;
+  if (projectionWindow <= coordinate) return Math.min(coordinate, inputTokens);
+  return Math.min(coordinate, Math.max(0, inputTokens - (projectionWindow - coordinate)));
 }
 
 /**
@@ -105,9 +101,7 @@ export async function* projectAnthropicResponseUsage(
   chunks: AsyncIterable<Uint8Array>,
   options: AnthropicResponseUsageProjectionOptions,
 ): AsyncGenerator<Uint8Array> {
-  const contextWindow = canProjectClaudeContextWindow(options.contextWindow)
-    ? options.contextWindow
-    : undefined;
+  const contextWindow = positiveContextWindow(options.contextWindow);
   const responseModel = typeof options.responseModel === "string"
     && options.responseModel.length > 0
     ? options.responseModel
@@ -341,20 +335,32 @@ function projectUsageProperty(
   const usage = container[property];
   if (!isRecord(usage)) return { changed: false, value: container };
 
-  let projectedUsage = usage;
-  let changed = false;
-  for (const field of ANTHROPIC_INPUT_USAGE_FIELDS) {
+  const coordinates = ANTHROPIC_INPUT_USAGE_FIELDS.map((field) => {
     const tokens = usage[field];
-    if (typeof tokens !== "number" || !Number.isFinite(tokens) || tokens < 0) continue;
-    const projectedTokens = projectClaudeContextInputTokens(tokens, contextWindow);
-    if (projectedTokens === tokens) continue;
-    if (!changed) projectedUsage = { ...usage };
-    projectedUsage[field] = projectedTokens;
-    changed = true;
+    return typeof tokens === "number" && Number.isFinite(tokens) && tokens >= 0
+      ? { field, tokens }
+      : undefined;
+  }).filter((entry): entry is { field: typeof ANTHROPIC_INPUT_USAGE_FIELDS[number]; tokens: number } => (
+    entry !== undefined
+  ));
+  if (coordinates.length === 0) return { changed: false, value: container };
+
+  const total = coordinates.reduce((sum, entry) => sum + entry.tokens, 0);
+  const projectedTotal = projectClaudeContextInputTokens(total, contextWindow);
+  if (projectedTotal === total) return { changed: false, value: container };
+
+  const projectedUsage = { ...usage };
+  let assigned = 0;
+  for (const [index, entry] of coordinates.entries()) {
+    const projectedTokens = index === coordinates.length - 1
+      ? projectedTotal - assigned
+      : total === 0
+        ? 0
+        : Math.floor(entry.tokens * projectedTotal / total);
+    projectedUsage[entry.field] = projectedTokens;
+    assigned += projectedTokens;
   }
-  return changed
-    ? { changed: true, value: { ...container, [property]: projectedUsage } }
-    : { changed: false, value: container };
+  return { changed: true, value: { ...container, [property]: projectedUsage } };
 }
 
 function findSseSeparator(bytes: Uint8Array): SseSeparator | undefined {

--- a/packages/core-ai-gateway/src/anthropic/protocol.ts
+++ b/packages/core-ai-gateway/src/anthropic/protocol.ts
@@ -533,7 +533,7 @@ interface OpenBlock {
 }
 
 export interface ClaudeResponseCompatibilityOptions {
-  /** Picker-advertised window that decides whether Claude uses its 1M compatibility path. */
+  /** Real provider window mapped onto Claude Code's model-id-selected context coordinate. */
   readonly contextWindow?: number;
   /** Rewrites the echoed response model to the client-requested id. */
   readonly model?: string;
@@ -556,9 +556,8 @@ interface AnthropicCacheAwareUsage {
  * (message_start, message_delta) and non-streaming callers share this conversion so their
  * usage shapes never drift apart.
  *
- * When the 1M compatibility projection is active, the three input coordinates are scaled
- * together (by the same ratio used for the plain input-only path) so their sum still equals
- * the projected total input exactly.
+ * When context projection is active, the aggregate input is mapped once and the three
+ * coordinates are redistributed proportionally so their sum equals that projected total.
  */
 function toAnthropicCacheAwareUsage(
   rawInputTokens: number,
@@ -612,8 +611,8 @@ function toAnthropicCacheAwareUsage(
     };
   }
 
-  // Scale each cache coordinate by the same ratio as the total, flooring so the three
-  // parts can never overshoot the projected total; the remainder lands on input_tokens.
+  // Redistribute the projected total by the original cache proportions, flooring so the
+  // three parts cannot overshoot it; the remainder lands on input_tokens.
   const scaledCacheRead = Math.floor((safeCacheRead * projectedTotal) / safeInputTokens);
   const scaledCacheCreation = Math.floor((safeCacheCreation * projectedTotal) / safeInputTokens);
   return {

--- a/packages/core-ai-gateway/src/cursor/native/adapter.ts
+++ b/packages/core-ai-gateway/src/cursor/native/adapter.ts
@@ -2029,13 +2029,13 @@ function recallCursorContextCheckpoint(
  * Refuse a new turn once Cursor's own measurement says the conversation already fills
  * the model's window.
  *
- * This is not a transport budget — it is what keeps Claude Code's occupancy meter
- * informative. That meter reads a projection onto Claude Code's 1M coordinate, and the
- * projection saturates at exactly this point: past it every turn reports 1,000,000 no
- * matter how much further the conversation grew, so the client can no longer see itself
- * approaching its own compaction threshold. Measured on 2026-08-05, a `grok-4.5-fast`
- * session sat at a saturated 1,000,000 across 31 consecutive requests before compaction
- * finally fired from the client's own local accounting, several minutes late.
+ * This is not a transport budget — it keeps Claude Code's occupancy meter informative.
+ * Projection saturates at the model-id-selected coordinate once Cursor's measured window
+ * is full; past that point every turn reports the same ceiling, so the client can no longer
+ * see further growth. Measured on 2026-08-05 under the former synthetic 1M policy, a
+ * `grok-4.5-fast` session sat at a saturated 1,000,000 across 31 consecutive requests
+ * before compaction finally fired from the client's own local accounting, several minutes
+ * late.
  *
  * The refusal restores that signal: it carries the 413 Claude Code arms reactive
  * compaction from, so the turn compacts instead of continuing blind. The count is

--- a/packages/core-ai-gateway/src/gateway-router/router.ts
+++ b/packages/core-ai-gateway/src/gateway-router/router.ts
@@ -6,10 +6,7 @@ import {
   anthropicNativeHeaders,
   ANTHROPIC_MESSAGES_URL,
 } from "../anthropic/native.js";
-import {
-  hasClaudeOneMillionMarker,
-  pruneClaudeSkillPayloads,
-} from "../anthropic/claude-context.js";
+import { pruneClaudeSkillPayloads } from "../anthropic/claude-context.js";
 import type { AnthropicMessagesRequest } from "../anthropic/protocol.js";
 import { UnsupportedReasoningEffortError } from "../canonical/index.js";
 import { CodexResponsesAdapter } from "../codex/responses/adapter.js";
@@ -31,7 +28,6 @@ import {
   findGatewayModel,
   GATEWAY_MODEL_ALIAS_PREFIX,
   GATEWAY_MODELS,
-  toClaudeGatewayModelId,
   upstreamModelId,
 } from "../models.js";
 import type { GatewayModel } from "../models.js";
@@ -307,15 +303,11 @@ export function createAiGatewayRouter(deps: AiGatewayRouteDeps): AiGatewayRouter
         await proxyToAnthropic(req.headers, res, body, fetchImpl, controller.signal);
         return true;
       }
-      // Claude Code may strip the discovery-only `[1m]` suffix before sending a
-      // request. Derive the projection denominator from the resolved registry
-      // model so every alias for the same Cursor/Codex model projects usage in
-      // the same way. It is the model's real window: projecting against anything
-      // smaller maps the remaining capacity above 100% of the 1M coordinate,
-      // which Claude Code reads as an exceeded context and will not compact.
-      const claudeContextWindow = hasClaudeOneMillionMarker(toClaudeGatewayModelId(target))
-        ? target.contextWindow
-        : undefined;
+      // Claude Code meters every custom model on either its unmarked 200k coordinate
+      // or the truthful `[1m]` coordinate. Pass the real catalog window for both: the
+      // compatibility seam removes only the capacity above Claude's chosen coordinate,
+      // so each model reaches its real window minus Claude's own compaction reserve.
+      const claudeContextWindow = target.contextWindow;
       if (target.provider === "kimi") {
         await proxyToKimi(
           req.headers,

--- a/packages/core-ai-gateway/src/models.ts
+++ b/packages/core-ai-gateway/src/models.ts
@@ -4,7 +4,6 @@ import { z } from "zod";
 
 import { clampReasoningEffort, type ReasoningEffort } from "./canonical/index.js";
 import {
-  canProjectClaudeContextWindow,
   hasClaudeOneMillionMarker,
   isClaudeOneMillionContextWindow,
   stripClaudeOneMillionMarker,
@@ -344,31 +343,17 @@ export function toGatewayModelAlias(modelId: string): string {
 }
 
 /**
- * Claude Code only understands its default 200k coordinate and a `[1m]`
- * coordinate. Translated models whose real window is above 200k use the latter
- * while the gateway projects their response usage onto it.
- *
- * The projection divides by the model's real window and nothing else. Dividing by
- * a smaller budget — a provider's own compaction threshold, say — would map the
- * band between that budget and the real window onto 100%+ of the 1M coordinate, a
- * region Claude Code treats as "context exceeds the limit" and refuses to
- * auto-compact out of. Metering against the real window instead lets Claude Code's
- * own reserve compact the session while capacity remains.
- *
- * Anthropic passthrough models (Kimi, and OpenCode's anthropic-wire entries)
- * additionally require a real window of at least 1M, so a synthetic long-context
- * beta never reaches a sub-1M Anthropic-compatible upstream.
+ * Claude Code understands only its default 200k coordinate and the `[1m]` 1M
+ * coordinate. Keep that marker truthful: only a provider model whose real window
+ * reaches 1M is advertised as such. The response compatibility seam maps every
+ * other real window onto the unmarked 200k coordinate while preserving Claude's
+ * absolute compaction reserve.
  */
 export function toClaudeGatewayModelId(model: GatewayModel): string {
   const alias = toGatewayModelAlias(model.id);
-  if (
-    canProjectClaudeContextWindow(model.contextWindow)
-    && (!isAnthropicPassthroughModel(model)
-      || isClaudeOneMillionContextWindow(model.contextWindow))
-  ) {
-    return `${alias}${CLAUDE_ONE_MILLION_MARKER}`;
-  }
-  return alias;
+  return isClaudeOneMillionContextWindow(model.contextWindow)
+    ? `${alias}${CLAUDE_ONE_MILLION_MARKER}`
+    : alias;
 }
 
 function toClaudeGatewayModelDisplayName(model: GatewayModel): string {

--- a/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
@@ -71,7 +71,7 @@ describe("router lifecycle", () => {
         await router.handle(ctx({
           res: response(),
           token: ANTHROPIC_CRED,
-          model: "claude-gateway--cursor--grok-4.5[1m]",
+          model: "claude-gateway--cursor--grok-4.5",
         }));
       }
       expect(adapters).toHaveLength(2);
@@ -168,7 +168,7 @@ describe("upstream credential", () => {
     await router.handle(ctx({
       res,
       token: ANTHROPIC_CRED,
-      model: "claude-gateway--codex--gpt-5.6-sol-fast[1m]",
+      model: "claude-gateway--codex--gpt-5.6-sol-fast",
     }));
 
     expect(streamSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
@@ -212,7 +212,7 @@ describe("upstream credential", () => {
     await router.handle(ctx({
       res: response(),
       token: ANTHROPIC_CRED,
-      model: "claude-gateway--codex--gpt-5.6-luna[1m]",
+      model: "claude-gateway--codex--gpt-5.6-luna",
       thinking: { type: "adaptive" },
       outputConfig: { effort: "ultra" },
     }));
@@ -236,7 +236,7 @@ describe("upstream credential", () => {
     await router.handle(ctx({
       res: response(),
       token: ANTHROPIC_CRED,
-      model: "claude-gateway--cursor--grok-4.5[1m]",
+      model: "claude-gateway--cursor--grok-4.5",
       thinking: { type: "adaptive" },
       outputConfig: { effort: "medium" },
     }));
@@ -362,7 +362,7 @@ describe("upstream credential", () => {
     await router.handle(ctx({
       res,
       token: ANTHROPIC_CRED,
-      model: "claude-gateway--cursor--grok-4.5[1m]",
+      model: "claude-gateway--cursor--grok-4.5",
       metadata: null,
     }));
 
@@ -406,14 +406,12 @@ describe("upstream credential", () => {
 
 describe("model context window", () => {
   it.each([
-    // The guard and the projection both take the model's real window, so a marked
-    // model's occupancy can never be reported above the 1M coordinate.
-    ["claude-gateway--codex--gpt-5.6-sol", 272_000, 272_000],
-    ["claude-gateway--cursor--grok-4.5-fast", 256_000, 256_000],
-    // A 200000-window Cursor native model earns no `[1m]` marker, so it gets no
-    // projection denominator — but the guard still needs its real window.
-    ["claude-gateway--cursor--composer-2.5", 200_000, undefined],
-  ])("passes %s's real window as modelContextWindow", async (model, expected, projected) => {
+    // The guard and Claude-coordinate projection both take the model's real window.
+    // Marker choice only selects Claude's 200k or 1M coordinate.
+    ["claude-gateway--codex--gpt-5.6-sol", 272_000],
+    ["claude-gateway--cursor--grok-4.5-fast", 256_000],
+    ["claude-gateway--cursor--composer-2.5", 200_000],
+  ])("passes %s's real window to both context contracts", async (model, expected) => {
     const gateway = stubGateway();
     const streamSpy = vi.spyOn(gateway, "stream");
     const router = createAiGatewayRouter({
@@ -425,14 +423,9 @@ describe("model context window", () => {
     await router.handle(ctx({ res: response(), token: ANTHROPIC_CRED, model }));
 
     expect(streamSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      contextWindow: expected,
       modelContextWindow: expected,
     }));
-    const options = streamSpy.mock.calls[0]?.[1];
-    if (projected === undefined) {
-      expect(options).not.toHaveProperty("contextWindow");
-    } else {
-      expect(options).toHaveProperty("contextWindow", projected);
-    }
   });
 
   it("answers a pre-flight overflow with Claude's prompt-too-long contract", async () => {
@@ -924,7 +917,7 @@ describe("Kimi passthrough", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("passes sub-1M cache-aware SSE usage through without projection", async () => {
+  it("projects sub-1M cache-aware SSE usage onto the 200k coordinate", async () => {
     const upstreamBody = [
       "event: message_start\r\n",
       `data: ${JSON.stringify({
@@ -966,8 +959,8 @@ describe("Kimi passthrough", () => {
     expect(JSON.parse(payload ?? "null")).toMatchObject({
       message: {
         usage: {
-          input_tokens: 32_768,
-          cache_read_input_tokens: 32_768,
+          input_tokens: 1_696,
+          cache_read_input_tokens: 1_696,
           cache_creation_input_tokens: 0,
           output_tokens: 2,
         },
@@ -1015,7 +1008,7 @@ describe("Kimi passthrough", () => {
       message: {
         id: "msg_kimi",
         model: "claude-gateway--kimi--k3[1m]",
-        usage: { input_tokens: 10, output_tokens: 1 },
+        usage: { input_tokens: 0, output_tokens: 1 },
       },
     });
     // 요청은 여전히 wire id로 나간다.
@@ -1050,7 +1043,7 @@ describe("Kimi passthrough", () => {
       id: "msg_kimi",
       model: "claude-gateway--kimi--k3[1m]",
       content: [{ type: "text", text: "done" }],
-      usage: { input_tokens: 10, output_tokens: 4 },
+      usage: { input_tokens: 0, output_tokens: 4 },
     });
   });
 
@@ -1435,7 +1428,7 @@ describe("route surface", () => {
       }));
 
       expect(JSON.parse(settingsResponse.body).data).toEqual([
-        expect.objectContaining({ id: "claude-gateway--codex--gpt-5.6-sol[1m]" }),
+        expect.objectContaining({ id: "claude-gateway--codex--gpt-5.6-sol" }),
       ]);
       expect(withoutReaderSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
         model: "gpt-5.6-sol",
@@ -1471,21 +1464,21 @@ describe("route surface", () => {
     // picker가 버리지 않도록 모든 항목이 claude- alias로 나가야 한다.
     expect(ids.every((id) => id.startsWith("claude"))).toBe(true);
     expect(list.data).toHaveLength(24);
-    expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast[1m]");
-    expect(ids).toContain("claude-gateway--cursor--auto[1m]");
+    expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast");
+    expect(ids).toContain("claude-gateway--cursor--auto");
     expect(ids).toContain("claude-gateway--cursor--composer-2.5");
     expect(ids).toContain("claude-gateway--cursor--composer-2.5-fast");
-    expect(ids).toContain("claude-gateway--cursor--grok-4.5[1m]");
-    expect(ids).toContain("claude-gateway--cursor--grok-4.5-fast[1m]");
+    expect(ids).toContain("claude-gateway--cursor--grok-4.5");
+    expect(ids).toContain("claude-gateway--cursor--grok-4.5-fast");
     expect(ids).not.toContain("claude-gateway--cursor--gpt-5.6-sol[1m]");
     expect(ids).not.toContain("claude-gateway--cursor--claude-opus-5-1m[1m]");
     expect(ids).not.toContain("claude-gateway--cursor--kimi-k3");
     expect(ids).toContain("claude-gateway--kimi--k3[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3-256k");
     expect(ids).toContain("claude-gateway--opencode--minimax-m3[1m]");
-    expect(ids.some((id) => id.includes("--codex--") && id.endsWith("[1m]"))).toBe(true);
+    expect(ids.some((id) => id.includes("--codex--") && id.endsWith("[1m]"))).toBe(false);
     expect(list.data).toContainEqual(expect.objectContaining({
-      id: "claude-gateway--cursor--grok-4.5[1m]",
+      id: "claude-gateway--cursor--grok-4.5",
       display_name: "Cursor-Grok-4.5",
     }));
     expect(list.data).toContainEqual(expect.objectContaining({
@@ -1517,7 +1510,7 @@ describe("route surface", () => {
     const list = JSON.parse(res.body) as { data: Array<{ id: string }> };
     expect(list.data.map((entry) => entry.id)).toEqual([
       "claude-gateway--cursor--composer-2.5",
-      "claude-gateway--cursor--grok-4.5[1m]",
+      "claude-gateway--cursor--grok-4.5",
       "claude-gateway--kimi--k3-256k",
     ]);
   });
@@ -1542,9 +1535,9 @@ describe("route surface", () => {
     expect(res.status).toBe(200);
     const list = JSON.parse(res.body) as { data: Array<{ id: string }> };
     expect(list.data.map((entry) => entry.id)).toEqual([
-      "claude-gateway--codex--gpt-5.6-sol-fast[1m]",
-      "claude-gateway--codex--gpt-5.6-luna-fast[1m]",
-      "claude-gateway--cursor--grok-4.5-fast[1m]",
+      "claude-gateway--codex--gpt-5.6-sol-fast",
+      "claude-gateway--codex--gpt-5.6-luna-fast",
+      "claude-gateway--cursor--grok-4.5-fast",
       "claude-gateway--kimi--k3[1m]",
     ]);
   });

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -8,7 +8,6 @@ import {
   CURSOR_SUBSCRIPTION_MODELS,
   KIMI_SUBSCRIPTION_MODELS,
   OPENCODE_SUBSCRIPTION_MODELS,
-  isAnthropicPassthroughModel,
   buildAnthropicModelList,
   buildGatewayModelConstraints,
   clampReasoningEffort,
@@ -926,13 +925,13 @@ describe("model catalog", () => {
     );
     // Claude Code는 claude로 시작하지 않는 id를 discovery 결과에서 버린다.
     expect(list.data.every((entry) => entry.id.startsWith("claude"))).toBe(true);
-    expect(list.data.find((entry) => entry.id === "claude-gateway--codex--gpt-5.6-sol[1m]")).toMatchObject({
+    expect(list.data.find((entry) => entry.id === "claude-gateway--codex--gpt-5.6-sol")).toMatchObject({
       display_name: "Codex-GPT-5.6-Sol",
       max_input_tokens: 272_000,
     });
     expect(list.data.some((entry) => entry.id.includes("--codex--") && entry.id.endsWith("[1m]")))
-      .toBe(true);
-    expect(list.data.find((entry) => entry.id.endsWith("cursor--grok-4.5[1m]"))).toMatchObject({
+      .toBe(false);
+    expect(list.data.find((entry) => entry.id.endsWith("cursor--grok-4.5"))).toMatchObject({
       display_name: "Cursor-Grok-4.5",
       max_input_tokens: 256_000,
     });
@@ -948,47 +947,42 @@ describe("model catalog", () => {
       display_name: "Moonshot-Kimi-K3-256K",
       max_input_tokens: 262_144,
     });
-    // Anthropic passthrough models require a real 1M window for the marker:
-    // Claude Code's long-context beta must not reach a sub-1M compatible upstream.
-    // Translated wires (opencode responses/chat) project like Codex/Cursor instead.
+    // `[1m]` describes the provider model, not a synthetic compatibility axis.
+    // Every real window below 1M stays on Claude's unmarked 200k coordinate.
     expect(GATEWAY_MODELS.every((model) => (
       toClaudeGatewayModelId(model).endsWith("[1m]")
-      === (
-        (model.contextWindow ?? 0) > 200_000
-        && (!isAnthropicPassthroughModel(model) || (model.contextWindow ?? 0) >= 1_000_000)
-      )
+      === (model.contextWindow ?? 0) >= 1_000_000
     ))).toBe(true);
     expect(list.data.every((entry) => (
       entry.display_name.endsWith(" (1M Context)") === (entry.max_input_tokens ?? 0) >= 1_000_000
     ))).toBe(true);
   });
 
-  it("projects every marked provider window onto Claude Code's 1M coordinate", () => {
-    expect(projectClaudeContextInputTokens(65_536, 1_048_576)).toBe(62_500);
-    expect(projectClaudeContextInputTokens(50_000, 1_000_000, 800_000)).toBe(62_500);
-    expect(projectClaudeContextInputTokens(221_000, 272_000)).toBe(812_500);
-    expect(projectClaudeContextInputTokens(250_000, 500_000)).toBe(500_000);
-    expect(projectClaudeContextInputTokens(50_000, 256_000, 200_000)).toBe(250_000);
-    expect(projectClaudeContextInputTokens(50_000, 200_000)).toBe(50_000);
+  it("removes only the provider capacity above Claude's truthful coordinate", () => {
+    expect(projectClaudeContextInputTokens(1_016_576, 1_048_576)).toBe(968_000);
+    expect(projectClaudeContextInputTokens(968_000, 1_000_000)).toBe(968_000);
+    expect(projectClaudeContextInputTokens(240_000, 272_000)).toBe(168_000);
+    expect(projectClaudeContextInputTokens(468_000, 500_000)).toBe(168_000);
+    expect(projectClaudeContextInputTokens(224_000, 256_000)).toBe(168_000);
+    expect(projectClaudeContextInputTokens(168_000, 200_000)).toBe(168_000);
     expect(projectClaudeContextInputTokens(50_000, undefined)).toBe(50_000);
   });
 
-  it("never projects past the 1M coordinate Claude Code was told to meter against", () => {
-    // Claude Code reads any occupancy above the advertised window as
-    // "Context exceeds the 1m-token limit" and stops auto-compacting, so an
-    // upstream reporting more input than the catalog window must still land at 100%.
-    expect(projectClaudeContextInputTokens(272_000, 272_000)).toBe(1_000_000);
-    expect(projectClaudeContextInputTokens(300_000, 272_000)).toBe(1_000_000);
+  it("uses a runtime-reported window while capping usage at Claude's coordinate", () => {
+    expect(projectClaudeContextInputTokens(168_000, 256_000, 200_000)).toBe(168_000);
+    expect(projectClaudeContextInputTokens(240_000, 256_000, 272_000)).toBe(168_000);
+    expect(projectClaudeContextInputTokens(272_000, 272_000)).toBe(200_000);
+    expect(projectClaudeContextInputTokens(300_000, 272_000)).toBe(200_000);
     expect(projectClaudeContextInputTokens(2_000_000, 1_048_576)).toBe(1_000_000);
   });
 
   it("advertises the official Anthropic effort capability per gateway model", () => {
     const entries = new Map(buildAnthropicModelList().data.map((entry) => [entry.id, entry]));
-    const sol = entries.get("claude-gateway--codex--gpt-5.6-sol[1m]");
-    const luna = entries.get("claude-gateway--codex--gpt-5.6-luna[1m]");
+    const sol = entries.get("claude-gateway--codex--gpt-5.6-sol");
+    const luna = entries.get("claude-gateway--codex--gpt-5.6-luna");
     const kimi = entries.get("claude-gateway--kimi--k3[1m]");
-    const cursor = entries.get("claude-gateway--cursor--auto[1m]");
-    const cursorGrok = entries.get("claude-gateway--cursor--grok-4.5[1m]");
+    const cursor = entries.get("claude-gateway--cursor--auto");
+    const cursorGrok = entries.get("claude-gateway--cursor--grok-4.5");
     const cursorComposer = entries.get("claude-gateway--cursor--composer-2.5-fast");
 
     expect(sol?.capabilities.effort).toEqual({
@@ -1047,18 +1041,16 @@ describe("model catalog", () => {
     })).toMatchObject({ model: "gpt-5.6-sol", service_tier: "priority" });
   });
 
-  it("accepts current marked ids and their scoped legacy unmarked aliases", () => {
+  it("accepts truthful marked ids and current unmarked aliases", () => {
     const model = findGatewayModel("claude-gateway--kimi--k3[1m]");
     expect(model).toMatchObject({ id: "kimi--k3", upstreamId: "k3" });
     expect(findGatewayModel("claude-gateway--codex--gpt-5.6-luna")).toMatchObject({
       id: "codex--gpt-5.6-luna",
       upstreamId: "gpt-5.6-luna",
     });
-    expect(findGatewayModel("claude-gateway--codex--gpt-5.6-luna[1m]")).toMatchObject({
-      id: "codex--gpt-5.6-luna",
-    });
+    expect(findGatewayModel("claude-gateway--codex--gpt-5.6-luna[1m]")).toBeUndefined();
     expect(findGatewayModel("claude-gateway--kimi--k3")).toMatchObject({ id: "kimi--k3" });
-    expect(findGatewayModel("claude-gateway--cursor--grok-4.5[1m]")).toMatchObject({
+    expect(findGatewayModel("claude-gateway--cursor--grok-4.5")).toMatchObject({
       id: "cursor--grok-4.5",
       upstreamId: "grok-4.5",
       contextWindow: 256_000,
@@ -1093,25 +1085,24 @@ describe("Claude context coordinate", () => {
     ...over,
   } as GatewayModel);
 
-  it("marks a model whose real window clears Claude's default coordinate", () => {
+  it("marks only a model whose real window reaches one million", () => {
     const codex = CODEX_SUBSCRIPTION_MODELS[0]!;
     expect(codex.contextWindow).toBe(272_000);
-    expect(toClaudeGatewayModelId(codex).endsWith("[1m]")).toBe(true);
+    expect(toClaudeGatewayModelId(codex).endsWith("[1m]")).toBe(false);
+    expect(toClaudeGatewayModelId(model({ contextWindow: 1_000_000 })).endsWith("[1m]")).toBe(true);
   });
 
-  it("withholds the marker when there is no window above Claude's default coordinate", () => {
+  it("withholds the marker below one million or without a known window", () => {
     expect(toClaudeGatewayModelId(model({ contextWindow: 200_000 })).endsWith("[1m]")).toBe(false);
+    expect(toClaudeGatewayModelId(model({ contextWindow: 500_000 })).endsWith("[1m]")).toBe(false);
     expect(toClaudeGatewayModelId(model({})).endsWith("[1m]")).toBe(false);
   });
 
-  it("keeps auto-compact reachable inside the real window", () => {
-    // Claude Code compacts at 967_000 of its 1M axis. Dividing by the real window
-    // puts that at 263_024 real tokens — under the 272_000 the backend accepts, so
-    // the session compacts instead of pinning at an exceeded context. A smaller
-    // denominator (Codex's own 258_400 compaction budget) would instead map the
-    // remaining capacity above 100%, where Claude Code refuses to auto-compact.
-    expect(projectClaudeContextInputTokens(272_000, 272_000)).toBe(1_000_000);
-    expect(Math.floor(967_000 * 272_000 / 1_000_000)).toBe(263_024);
+  it("keeps Claude's absolute reserve inside each real window", () => {
+    expect(projectClaudeContextInputTokens(238_000, 272_000)).toBe(166_000);
+    expect(projectClaudeContextInputTokens(240_000, 272_000)).toBe(168_000);
+    expect(projectClaudeContextInputTokens(1_014_576, 1_048_576)).toBe(966_000);
+    expect(projectClaudeContextInputTokens(1_016_576, 1_048_576)).toBe(968_000);
   });
 });
 
@@ -1162,8 +1153,8 @@ describe("Anthropic response context projection", () => {
     expect(events[0]?.data).toMatchObject({
       message: {
         usage: {
-          input_tokens: 31_250,
-          cache_read_input_tokens: 31_250,
+          input_tokens: 8_480,
+          cache_read_input_tokens: 8_480,
           cache_creation_input_tokens: 0,
           output_tokens: 7,
         },
@@ -1171,8 +1162,8 @@ describe("Anthropic response context projection", () => {
     });
     expect(events[1]?.data).toMatchObject({
       usage: {
-        input_tokens: 62_500,
-        cache_read_input_tokens: 125_000,
+        input_tokens: 49_344,
+        cache_read_input_tokens: 98_688,
         cache_creation_input_tokens: 0,
         output_tokens: 11,
       },
@@ -1201,7 +1192,7 @@ describe("Anthropic response context projection", () => {
       id: "msg_json",
       content: [{ type: "text", text: "done" }],
       usage: {
-        input_tokens: 62_500,
+        input_tokens: 16_960,
         cache_read_input_tokens: 0,
         cache_creation_input_tokens: 0,
         output_tokens: 9,
@@ -1256,7 +1247,7 @@ describe("Anthropic response context projection", () => {
     const events = parseSse(output);
 
     expect(events[0]?.data).toMatchObject({ usage: { input_tokens: 65_536, output_tokens: 4 } });
-    expect(events[1]?.data).toMatchObject({ usage: { input_tokens: 31_250, output_tokens: 5 } });
+    expect(events[1]?.data).toMatchObject({ usage: { input_tokens: 0, output_tokens: 5 } });
   });
 });
 
@@ -1289,7 +1280,7 @@ describe("Anthropic response model rewrite", () => {
       message: {
         id: "msg_kimi",
         model: "claude-gateway--kimi--k3[1m]",
-        usage: { input_tokens: 10, output_tokens: 1 },
+        usage: { input_tokens: 0, output_tokens: 1 },
       },
     });
     expect(events[1]?.data).toEqual({ type: "message_stop" });
@@ -1316,7 +1307,7 @@ describe("Anthropic response model rewrite", () => {
       id: "msg_kimi",
       model: "claude-gateway--kimi--k3[1m]",
       content: [{ type: "text", text: "done" }],
-      usage: { input_tokens: 10, output_tokens: 4 },
+      usage: { input_tokens: 0, output_tokens: 4 },
     });
   });
 
@@ -1581,7 +1572,7 @@ describe("Anthropic SSE encoding", () => {
     });
   });
 
-  it("projects streaming input usage for a marked sub-1M model", async () => {
+  it("projects streaming input usage onto an unmarked 200k coordinate", async () => {
     const events = iterable<CanonicalResponseEvent>([
       {
         type: "response.created",
@@ -1606,14 +1597,14 @@ describe("Anthropic SSE encoding", () => {
     })));
 
     expect(frames[0]?.data).toMatchObject({
-      message: { usage: { input_tokens: 812_500, output_tokens: 0 } },
+      message: { usage: { input_tokens: 149_000, output_tokens: 0 } },
     });
     expect(frames[1]?.data).toMatchObject({
-      usage: { input_tokens: 812_500, output_tokens: 6_277 },
+      usage: { input_tokens: 149_000, output_tokens: 6_277 },
     });
   });
 
-  it("projects a marked Cursor runtime checkpoint using its authoritative wire window", async () => {
+  it("projects a Cursor routing alias using its authoritative runtime window", async () => {
     const events = iterable<CanonicalResponseEvent>([
       {
         type: "response.created",
@@ -1638,14 +1629,14 @@ describe("Anthropic SSE encoding", () => {
     })));
 
     expect(frames[0]?.data).toMatchObject({
-      message: { usage: { input_tokens: 195_313 } },
+      message: { usage: { input_tokens: 0 } },
     });
     expect(frames[1]?.data).toMatchObject({
-      usage: { input_tokens: 250_000, output_tokens: 1 },
+      usage: { input_tokens: 50_000, output_tokens: 1 },
     });
   });
 
-  it("preserves the projected input total when a cache breakdown rides the 1M coordinate", async () => {
+  it("preserves the projected input total across a cache breakdown", async () => {
     const events = iterable<CanonicalResponseEvent>([
       {
         type: "response.created",
@@ -1684,13 +1675,13 @@ describe("Anthropic SSE encoding", () => {
       output_tokens: number;
     };
 
-    // Same total as the plain (non-cache-aware) 1M projection test above: the
-    // breakdown must land on the identical coordinate, never inflate or shrink it.
-    expect(usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens).toBe(812_500);
+    // Same total as the plain projection test above: the offset applies once to
+    // the aggregate, then the cache coordinates retain their original proportions.
+    expect(usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens).toBe(149_000);
     expect(usage).toEqual({
-      input_tokens: 261_030,
-      cache_read_input_tokens: 367_647,
-      cache_creation_input_tokens: 183_823,
+      input_tokens: 47_870,
+      cache_read_input_tokens: 67_420,
+      cache_creation_input_tokens: 33_710,
       output_tokens: 6_277,
     });
   });
@@ -3235,7 +3226,7 @@ describe("non-streaming requests", () => {
     });
   });
 
-  it("projects non-streaming usage for a marked sub-1M model", async () => {
+  it("projects non-streaming usage onto an unmarked 200k coordinate", async () => {
     const adapter: AiGatewayAdapter = {
       async stream() {
         return {
@@ -3256,11 +3247,11 @@ describe("non-streaming requests", () => {
     );
 
     expect(JSON.parse(await collectBody(response.body))).toMatchObject({
-      usage: { input_tokens: 812_500, output_tokens: 6_277 },
+      usage: { input_tokens: 149_000, output_tokens: 6_277 },
     });
   });
 
-  it("projects a marked Cursor runtime checkpoint in non-streaming mode", async () => {
+  it("projects a Cursor runtime checkpoint in non-streaming mode", async () => {
     const adapter: AiGatewayAdapter = {
       async stream() {
         return {
@@ -3288,7 +3279,7 @@ describe("non-streaming requests", () => {
     );
 
     expect(JSON.parse(await collectBody(response.body))).toMatchObject({
-      usage: { input_tokens: 250_000, output_tokens: 1 },
+      usage: { input_tokens: 50_000, output_tokens: 1 },
     });
   });
 
@@ -3397,22 +3388,22 @@ describe("response model rewrite", () => {
   });
 
   it("rewrites the streamed message_start model to the client-requested id", async () => {
-    const request = { ...baseRequest(), model: "claude-gateway--cursor--grok-4.5-fast[1m]" };
+    const request = { ...baseRequest(), model: "claude-gateway--cursor--grok-4.5-fast" };
     const response = await new AnthropicMessagesGateway(adapterEchoing()).stream(request, { apiKey: "k" });
     const frames = parseSse(await collectBody(response.body));
     const start = frames.find((item) => item.event === "message_start");
 
     expect(start?.data).toMatchObject({
-      message: { model: "claude-gateway--cursor--grok-4.5-fast[1m]" },
+      message: { model: "claude-gateway--cursor--grok-4.5-fast" },
     });
   });
 
   it("rewrites the non-streaming response model to the client-requested id", async () => {
-    const request = { ...baseRequest(), model: "claude-gateway--cursor--grok-4.5-fast[1m]", stream: false };
+    const request = { ...baseRequest(), model: "claude-gateway--cursor--grok-4.5-fast", stream: false };
     const response = await new AnthropicMessagesGateway(adapterEchoing()).stream(request, { apiKey: "k" });
 
     expect(JSON.parse(await collectBody(response.body))).toMatchObject({
-      model: "claude-gateway--cursor--grok-4.5-fast[1m]",
+      model: "claude-gateway--cursor--grok-4.5-fast",
     });
   });
 });

--- a/packages/fleet-admiral/src/agent-cli/gateway-agents.ts
+++ b/packages/fleet-admiral/src/agent-cli/gateway-agents.ts
@@ -190,7 +190,7 @@ export function toGatewayAgentSelector(modelId: string, effort?: GatewayReasonin
 
 /**
  * Agent 파일 이름과 frontmatter `name`에 쓰는 stem.
- * `claude-gateway--cursor--grok-4.5[1m]` + `high` → `cursor-grok-4-5-1m-high`
+ * `claude-gateway--opencode--deepseek-v4-flash[1m]` + `high` → `opencode-deepseek-v4-flash-1m-high`
  */
 export function toGatewayAgentName(modelId: string, effort?: GatewayReasoningEffort): string {
   const stripped = modelId.startsWith("claude-gateway--")

--- a/packages/fleet-admiral/src/ai-gateway/launch-env.ts
+++ b/packages/fleet-admiral/src/ai-gateway/launch-env.ts
@@ -28,6 +28,10 @@ export function prepareAiGatewayLaunchProfile(
 		ANTHROPIC_BASE_URL: options.baseUrl,
 		// 이게 있어야 /model picker가 게이트웨이의 GET /v1/models를 조회한다.
 		CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY: "1",
+		// 1M ceiling은 `[1m]` 모델의 선제 압축을 켜고, unmarked custom model에서는
+		// Claude Code의 200k 좌표로 clamp된다. 명시적 운영자 override는 보존한다.
+		CLAUDE_CODE_AUTO_COMPACT_WINDOW:
+			profile.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW ?? "1000000",
 		// Gateway가 tool_reference 계약을 보존한다. Cursor는 이를 지연 catalog 선택에 쓰고,
 		// 호환 프로바이더 경계는 각자의 eager wire 형식으로 정규화한다.
 		ENABLE_TOOL_SEARCH: "true",

--- a/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
+++ b/packages/fleet-admiral/tests/agent-cli-gateway.test.ts
@@ -164,11 +164,11 @@ describe("claude-gateway custom agents", () => {
   });
 
   it("embeds CursorBench figures and a role-fit sentence in each identity description", () => {
-    const solHigh = buildGatewayCustomAgents([requireGatewayModel("codex--gpt-5.6-sol-fast")])["codex-gpt-5-6-sol-fast-1m-high"];
+    const solHigh = buildGatewayCustomAgents([requireGatewayModel("codex--gpt-5.6-sol-fast")])["codex-gpt-5-6-sol-fast-high"];
     expect(solHigh?.description).toContain("Bench CursorBench 3.2: 63.5% at high effort, ~14k tokens/task.");
     expect(solHigh?.description).toContain("Class prior: judgment-seat candidate (decide, judge, synthesize) — the figures above, not the label, set its band.");
 
-    const lunaHigh = buildGatewayCustomAgents([requireGatewayModel("codex--gpt-5.6-luna-fast")])["codex-gpt-5-6-luna-fast-1m-high"];
+    const lunaHigh = buildGatewayCustomAgents([requireGatewayModel("codex--gpt-5.6-luna-fast")])["codex-gpt-5-6-luna-fast-high"];
     expect(lunaHigh?.description).toContain("Class prior: light lineup — fits wide mechanical fans (recon, scan, extract, verify), though measured figures can still earn a band seat.");
 
     for (const definition of Object.values(buildGatewayCustomAgents([requireGatewayModel("cursor--grok-4.5")]))) {

--- a/packages/fleet-admiral/tests/ai-gateway-launch-env.test.ts
+++ b/packages/fleet-admiral/tests/ai-gateway-launch-env.test.ts
@@ -47,6 +47,7 @@ describe("prepareAiGatewayLaunchProfile", () => {
 			ANTHROPIC_API_KEY: "key",
 			ANTHROPIC_BASE_URL: "http://127.0.0.1:4310/plugins/terminal/ai-gateway",
 			CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY: "1",
+			CLAUDE_CODE_AUTO_COMPACT_WINDOW: "1000000",
 			ENABLE_TOOL_SEARCH: "true",
 		});
 
@@ -61,6 +62,17 @@ describe("prepareAiGatewayLaunchProfile", () => {
 		expect(statSync(cachePath).mode & 0o777).toBe(0o600);
 	});
 
+	it("preserves an explicit auto-compact ceiling", () => {
+		const homeDir = makeTemporaryDirectory();
+		const prepared = prepareAiGatewayLaunchProfile(makeProfile({
+			CLAUDE_CODE_AUTO_COMPACT_WINDOW: "850000",
+		}), {
+			baseUrl: "http://127.0.0.1:4310/gateway",
+			homeDir,
+		});
+
+		expect(prepared.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("850000");
+	});
 
 	it("throws for an invalid base URL before writing a cache", () => {
 		const homeDir = makeTemporaryDirectory();

--- a/packages/fleet-admiral/tests/workflow-guard-hook.test.ts
+++ b/packages/fleet-admiral/tests/workflow-guard-hook.test.ts
@@ -29,7 +29,7 @@ function runGuard(toolInput: unknown): { readonly status: number; readonly stder
 describe("workflow-guard hook", () => {
   it("passes a full gateway modelId", () => {
     const { status } = runGuard({
-      script: `agent("x", { model: "claude-gateway--codex--gpt-5.6-sol-fast[1m]", effort: "low" })`,
+      script: `agent("x", { model: "claude-gateway--codex--gpt-5.6-sol-fast", effort: "low" })`,
     });
     expect(status).toBe(0);
   });
@@ -55,7 +55,7 @@ describe("workflow-guard hook", () => {
 
   it("blocks agentType usage in a dynamic workflow", () => {
     const { status, stderr } = runGuard({
-      script: `agent("x", { agentType: "fleet:codex-gpt-5-6-sol-fast-1m-high" })`,
+      script: `agent("x", { agentType: "fleet:codex-gpt-5-6-sol-fast-high" })`,
     });
     expect(status).toBe(2);
     expect(stderr).toContain("agentType");
@@ -65,7 +65,7 @@ describe("workflow-guard hook", () => {
     const dir = mkdtempSync(path.join(os.tmpdir(), "workflow-guard-"));
     tempDirs.push(dir);
     const scriptPath = path.join(dir, "wf.js");
-    writeFileSync(scriptPath, `agent("x", { model: "claude-gateway--codex--gpt-5.6-sol-fast[1m]" })`);
+    writeFileSync(scriptPath, `agent("x", { model: "claude-gateway--codex--gpt-5.6-sol-fast" })`);
     expect(runGuard({ scriptPath }).status).toBe(0);
     writeFileSync(scriptPath, `agent("x", { model: "codex--gpt-5.6-sol-fast[1m]" })`);
     expect(runGuard({ scriptPath }).status).toBe(2);

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -208,13 +208,13 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(native.args).toEqual(["--model", "fable[1m]", "--effort", "max"]);
     expect(scoped.args).toEqual([
       "--model",
-      "claude-gateway--cursor--grok-4.5[1m]",
+      "claude-gateway--cursor--grok-4.5",
       "--effort",
       "high",
     ]);
     expect(rowOnly.args).toEqual([
       "--model",
-      "claude-gateway--cursor--grok-4.5[1m]",
+      "claude-gateway--cursor--grok-4.5",
     ]);
     expect(rowOnly.args).not.toContain("--effort");
     for (const spec of [native, scoped, rowOnly]) {
@@ -267,7 +267,7 @@ describe("createDefaultTerminalLaunchResolver", () => {
     });
 
     // 호스트 세션 쪽: 여전히 고를 수 있고, --model args로 배선된다.
-    expect(spec.args).toEqual(["--model", "claude-gateway--cursor--auto[1m]"]);
+    expect(spec.args).toEqual(["--model", "claude-gateway--cursor--auto"]);
     expect(spec.env.ANTHROPIC_MODEL).toBeUndefined();
     // 위임 쪽: 정체성을 만들 목록에서만 빠진다.
     const delegable = (injected?.gatewayDelegationModels ?? []).map((model) => model.id);
@@ -636,24 +636,24 @@ describe("createDefaultTerminalLaunchResolver", () => {
     const ids = cache.models.map((model) => model.id);
 
     expect(spec.env.ANTHROPIC_BASE_URL).toBe("http://127.0.0.1:43210/plugins/terminal/ai-gateway");
-    expect(spec.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined();
+    expect(spec.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("1000000");
     expect(cache.baseUrl).toBe(spec.env.ANTHROPIC_BASE_URL);
     expect(cache.fetchedAt).toEqual(expect.any(Number));
     // core-ai-gateway의 GATEWAY_MODELS 전량이 prewrite되어야 한다 — 카탈로그가 바뀌면 이 수도 함께 맞춘다.
     expect(cache.models).toHaveLength(24);
-    expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast[1m]");
-    expect(ids).toContain("claude-gateway--cursor--auto[1m]");
+    expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast");
+    expect(ids).toContain("claude-gateway--cursor--auto");
     expect(ids).toContain("claude-gateway--cursor--composer-2.5");
-    expect(ids).toContain("claude-gateway--cursor--grok-4.5[1m]");
-    expect(ids).toContain("claude-gateway--cursor--grok-4.5-fast[1m]");
+    expect(ids).toContain("claude-gateway--cursor--grok-4.5");
+    expect(ids).toContain("claude-gateway--cursor--grok-4.5-fast");
     expect(ids).not.toContain("claude-gateway--cursor--claude-opus-5-1m[1m]");
     expect(ids).not.toContain("claude-gateway--cursor--kimi-k3");
     expect(ids).not.toContain("claude-gateway--cursor--gpt-5.6-luna[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3[1m]");
     expect(ids).toContain("claude-gateway--kimi--k3-256k");
-    expect(ids.some((id) => id.includes("--codex--") && id.endsWith("[1m]"))).toBe(true);
+    expect(ids.some((id) => id.includes("--codex--") && id.endsWith("[1m]"))).toBe(false);
     expect(cache.models).toContainEqual(expect.objectContaining({
-      id: "claude-gateway--cursor--grok-4.5[1m]",
+      id: "claude-gateway--cursor--grok-4.5",
       display_name: "Cursor-Grok-4.5",
     }));
     expect(cache.models).toContainEqual(expect.objectContaining({

--- a/runtime/fleet-plugins/terminal/tests/ai-gateway-launch-env.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/ai-gateway-launch-env.test.ts
@@ -72,9 +72,9 @@ describe("Claude gateway launch environment", () => {
       readonly models: readonly { readonly id: string }[];
     };
     expect(cache.models.map((model) => model.id)).toEqual([
-      "claude-gateway--codex--gpt-5.6-sol-fast[1m]",
-      "claude-gateway--codex--gpt-5.6-luna-fast[1m]",
-      "claude-gateway--cursor--grok-4.5-fast[1m]",
+      "claude-gateway--codex--gpt-5.6-sol-fast",
+      "claude-gateway--codex--gpt-5.6-luna-fast",
+      "claude-gateway--cursor--grok-4.5-fast",
       "claude-gateway--kimi--k3[1m]",
     ]);
   });
@@ -116,13 +116,13 @@ describe("Claude gateway launch environment", () => {
       bin: "claude",
       args: [],
       cwd: "/workspace",
-      env: { CLAUDE_CONFIG_DIR: configDir, ANTHROPIC_MODEL: "claude-gateway--codex--gpt-5.6-sol[1m]" },
+      env: { CLAUDE_CONFIG_DIR: configDir, ANTHROPIC_MODEL: "claude-gateway--codex--gpt-5.6-sol" },
       terminalName: "xterm-256color",
     } as const, {
       baseUrl: "http://127.0.0.1:4310/plugins/terminal/ai-gateway",
       selection,
     });
 
-    expect(configured.env.ANTHROPIC_MODEL).toBe("claude-gateway--codex--gpt-5.6-sol[1m]");
+    expect(configured.env.ANTHROPIC_MODEL).toBe("claude-gateway--codex--gpt-5.6-sol");
   });
 });


### PR DESCRIPTION
## Summary
- advertise `[1m]` only for gateway models whose real context window reaches one million tokens
- offset-map real provider usage onto Claude Code's truthful 200K/1M coordinates while preserving a 32K compaction reserve
- enable mixed-model proactive compaction with a clamped 1M launch ceiling and add a local boundary probe

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `pnpm --filter @dotobokuri/core-agent test && pnpm --filter @dotobokuri/core-agent typecheck && pnpm --filter @dotobokuri/core-agent build`
- [x] `pnpm --filter @dotobokuri/fleet-admiral test && pnpm --filter @dotobokuri/fleet-admiral typecheck && pnpm --filter @dotobokuri/fleet-admiral build`
- [x] Fleet Console launch tests, typecheck, and production build
- [x] Terminal gateway launch tests, typecheck, and build
- [x] Claude Code 2.1.227 compact boundaries for DeepSeek, Luna, Composer, and Cursor Auto
- [x] `node scripts/compile-changelog-fragments.mjs --check && git diff --check`