### PR TITLE
fix(core-ai-gateway): report continuous context usage

### DIFF
--- a/.changelog.d/honest-context-projection.md
+++ b/.changelog.d/honest-context-projection.md
@@ -4,10 +4,10 @@ branch: honest-context-projection
 
 ### fleet-cli
 #### Changed
-- Advertise `[1m]` only for gateway models with a real 1M-or-larger context window, while offset-mapping every model's usage so Claude Code compacts near that model's own context limit in mixed-model sessions.
-  ko: 실제 컨텍스트 윈도우가 1M 이상인 게이트웨이 모델만 `[1m]`으로 표시하고, 혼합 모델 세션에서 각 모델이 자신의 컨텍스트 한계 근처에서 압축되도록 모든 모델의 사용량을 오프셋 매핑합니다.
+- Advertise `[1m]` only for gateway models with a real 1M-or-larger context window, while continuously mapping usage so Claude Code reports approximate context progress and compacts with 16K of each model's real window remaining in mixed-model sessions.
+  ko: 실제 컨텍스트 윈도우가 1M 이상인 게이트웨이 모델만 `[1m]`으로 표시하고, 혼합 모델 세션에서 Claude Code가 대략적인 컨텍스트 진행률을 표시하며 각 모델의 실제 윈도우를 16K 남기고 압축하도록 사용량을 연속 매핑합니다.
 
 ### fleet-console
 #### Changed
-- Advertise `[1m]` only for gateway models with a real 1M-or-larger context window, while offset-mapping every model's usage so Claude Code compacts near that model's own context limit in mixed-model sessions.
-  ko: 실제 컨텍스트 윈도우가 1M 이상인 게이트웨이 모델만 `[1m]`으로 표시하고, 혼합 모델 세션에서 각 모델이 자신의 컨텍스트 한계 근처에서 압축되도록 모든 모델의 사용량을 오프셋 매핑합니다.
+- Advertise `[1m]` only for gateway models with a real 1M-or-larger context window, while continuously mapping usage so Claude Code reports approximate context progress and compacts with 16K of each model's real window remaining in mixed-model sessions.
+  ko: 실제 컨텍스트 윈도우가 1M 이상인 게이트웨이 모델만 `[1m]`으로 표시하고, 혼합 모델 세션에서 Claude Code가 대략적인 컨텍스트 진행률을 표시하며 각 모델의 실제 윈도우를 16K 남기고 압축하도록 사용량을 연속 매핑합니다.

--- a/packages/core-ai-gateway/src/anthropic/claude-context.ts
+++ b/packages/core-ai-gateway/src/anthropic/claude-context.ts
@@ -2,6 +2,8 @@ import { estimateTokens } from "../transport/token-estimate.js";
 
 export const CLAUDE_COMPAT_CONTEXT_WINDOW = 1_000_000;
 export const CLAUDE_DEFAULT_CONTEXT_WINDOW = 200_000;
+export const CLAUDE_COMPACT_RESERVE = 32_000;
+export const PROVIDER_COMPACT_RESERVE = 16_000;
 const DEFAULT_MAX_JSON_BYTES = 16 * 1024 * 1024;
 const DEFAULT_MAX_SSE_FRAME_BYTES = 1024 * 1024;
 const MAX_SSE_SEPARATOR_BYTES = 4;
@@ -64,11 +66,11 @@ export function stripClaudeOneMillionMarker(modelId: string): string {
  * Map a provider model's occupied input onto the fixed coordinate Claude Code assigns
  * from its model id: 200k without `[1m]`, 1M with it.
  *
- * Claude Code keeps roughly the same absolute reserve on both coordinates (2.1.227
- * compacted between 166k/168k on 200k and 966k/968k on 1M). Removing only the
- * provider window's excess over Claude's coordinate therefore preserves that reserve:
- * a 272k provider maps 240k real input to 168k, rather than sacrificing everything
- * above 168k or pretending the model itself has a 1M window.
+ * Claude Code 2.1.227 compacted between 166k/168k on 200k and 966k/968k on 1M,
+ * leaving roughly 32k on either coordinate. Scale usage so that observed compact
+ * threshold lands 16k before the real provider window instead. This keeps the status
+ * line increasing from the first token, while letting a 272k model reach 256k and a
+ * 1M model reach 984k before compaction.
  *
  * An upstream-reported window can narrow the catalog value. This matters for routing
  * aliases whose serving model changes per turn: the reported window, when present,
@@ -88,8 +90,13 @@ export function projectClaudeContextInputTokens(
   const coordinate = advertisedWindow >= CLAUDE_COMPAT_CONTEXT_WINDOW
     ? CLAUDE_COMPAT_CONTEXT_WINDOW
     : CLAUDE_DEFAULT_CONTEXT_WINDOW;
-  if (projectionWindow <= coordinate) return Math.min(coordinate, inputTokens);
-  return Math.min(coordinate, Math.max(0, inputTokens - (projectionWindow - coordinate)));
+  const claudeCompactThreshold = coordinate - CLAUDE_COMPACT_RESERVE;
+  const providerCompactThreshold = projectionWindow - PROVIDER_COMPACT_RESERVE;
+  if (providerCompactThreshold <= 0) return Math.min(coordinate, inputTokens);
+  return Math.min(
+    coordinate,
+    Math.ceil(inputTokens * claudeCompactThreshold / providerCompactThreshold),
+  );
 }
 
 /**
@@ -350,16 +357,19 @@ function projectUsageProperty(
   if (projectedTotal === total) return { changed: false, value: container };
 
   const projectedUsage = { ...usage };
+  const remainderField = coordinates.some((entry) => entry.field === "input_tokens")
+    ? "input_tokens"
+    : coordinates[0]!.field;
   let assigned = 0;
-  for (const [index, entry] of coordinates.entries()) {
-    const projectedTokens = index === coordinates.length - 1
-      ? projectedTotal - assigned
-      : total === 0
-        ? 0
-        : Math.floor(entry.tokens * projectedTotal / total);
+  for (const entry of coordinates) {
+    if (entry.field === remainderField) continue;
+    const projectedTokens = total === 0
+      ? 0
+      : Math.floor(entry.tokens * projectedTotal / total);
     projectedUsage[entry.field] = projectedTokens;
     assigned += projectedTokens;
   }
+  projectedUsage[remainderField] = projectedTotal - assigned;
   return { changed: true, value: { ...container, [property]: projectedUsage } };
 }
 

--- a/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
@@ -959,8 +959,8 @@ describe("Kimi passthrough", () => {
     expect(JSON.parse(payload ?? "null")).toMatchObject({
       message: {
         usage: {
-          input_tokens: 1_696,
-          cache_read_input_tokens: 1_696,
+          input_tokens: 22_366,
+          cache_read_input_tokens: 22_365,
           cache_creation_input_tokens: 0,
           output_tokens: 2,
         },
@@ -1008,7 +1008,7 @@ describe("Kimi passthrough", () => {
       message: {
         id: "msg_kimi",
         model: "claude-gateway--kimi--k3[1m]",
-        usage: { input_tokens: 0, output_tokens: 1 },
+        usage: { input_tokens: 10, output_tokens: 1 },
       },
     });
     // 요청은 여전히 wire id로 나간다.
@@ -1043,7 +1043,7 @@ describe("Kimi passthrough", () => {
       id: "msg_kimi",
       model: "claude-gateway--kimi--k3[1m]",
       content: [{ type: "text", text: "done" }],
-      usage: { input_tokens: 0, output_tokens: 4 },
+      usage: { input_tokens: 10, output_tokens: 4 },
     });
   });
 

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -958,21 +958,29 @@ describe("model catalog", () => {
     ))).toBe(true);
   });
 
-  it("removes only the provider capacity above Claude's truthful coordinate", () => {
-    expect(projectClaudeContextInputTokens(1_016_576, 1_048_576)).toBe(968_000);
-    expect(projectClaudeContextInputTokens(968_000, 1_000_000)).toBe(968_000);
-    expect(projectClaudeContextInputTokens(240_000, 272_000)).toBe(168_000);
-    expect(projectClaudeContextInputTokens(468_000, 500_000)).toBe(168_000);
-    expect(projectClaudeContextInputTokens(224_000, 256_000)).toBe(168_000);
-    expect(projectClaudeContextInputTokens(168_000, 200_000)).toBe(168_000);
+  it("reports a continuous approximation of real context occupancy", () => {
+    expect(projectClaudeContextInputTokens(1, 200_000)).toBe(1);
+    expect(projectClaudeContextInputTokens(92_000, 200_000)).toBe(84_000);
+    expect(projectClaudeContextInputTokens(120_000, 256_000)).toBe(84_000);
+    expect(projectClaudeContextInputTokens(128_000, 272_000)).toBe(84_000);
+    expect(projectClaudeContextInputTokens(492_000, 1_000_000)).toBe(484_000);
     expect(projectClaudeContextInputTokens(50_000, undefined)).toBe(50_000);
   });
 
+  it("lands Claude's compact threshold 16k before each real window", () => {
+    expect(projectClaudeContextInputTokens(184_000, 200_000)).toBe(168_000);
+    expect(projectClaudeContextInputTokens(240_000, 256_000)).toBe(168_000);
+    expect(projectClaudeContextInputTokens(256_000, 272_000)).toBe(168_000);
+    expect(projectClaudeContextInputTokens(484_000, 500_000)).toBe(168_000);
+    expect(projectClaudeContextInputTokens(984_000, 1_000_000)).toBe(968_000);
+    expect(projectClaudeContextInputTokens(1_032_576, 1_048_576)).toBe(968_000);
+  });
+
   it("uses a runtime-reported window while capping usage at Claude's coordinate", () => {
-    expect(projectClaudeContextInputTokens(168_000, 256_000, 200_000)).toBe(168_000);
-    expect(projectClaudeContextInputTokens(240_000, 256_000, 272_000)).toBe(168_000);
-    expect(projectClaudeContextInputTokens(272_000, 272_000)).toBe(200_000);
-    expect(projectClaudeContextInputTokens(300_000, 272_000)).toBe(200_000);
+    expect(projectClaudeContextInputTokens(184_000, 256_000, 200_000)).toBe(168_000);
+    expect(projectClaudeContextInputTokens(256_000, 256_000, 272_000)).toBe(168_000);
+    expect(projectClaudeContextInputTokens(272_000, 272_000)).toBe(178_500);
+    expect(projectClaudeContextInputTokens(300_000, 272_000)).toBe(196_875);
     expect(projectClaudeContextInputTokens(2_000_000, 1_048_576)).toBe(1_000_000);
   });
 
@@ -1098,11 +1106,11 @@ describe("Claude context coordinate", () => {
     expect(toClaudeGatewayModelId(model({})).endsWith("[1m]")).toBe(false);
   });
 
-  it("keeps Claude's absolute reserve inside each real window", () => {
-    expect(projectClaudeContextInputTokens(238_000, 272_000)).toBe(166_000);
-    expect(projectClaudeContextInputTokens(240_000, 272_000)).toBe(168_000);
-    expect(projectClaudeContextInputTokens(1_014_576, 1_048_576)).toBe(966_000);
-    expect(projectClaudeContextInputTokens(1_016_576, 1_048_576)).toBe(968_000);
+  it("keeps a 16k provider reserve on both Claude coordinates", () => {
+    expect(projectClaudeContextInputTokens(254_000, 272_000)).toBe(166_688);
+    expect(projectClaudeContextInputTokens(256_000, 272_000)).toBe(168_000);
+    expect(projectClaudeContextInputTokens(1_030_576, 1_048_576)).toBe(966_126);
+    expect(projectClaudeContextInputTokens(1_032_576, 1_048_576)).toBe(968_000);
   });
 });
 
@@ -1153,8 +1161,8 @@ describe("Anthropic response context projection", () => {
     expect(events[0]?.data).toMatchObject({
       message: {
         usage: {
-          input_tokens: 8_480,
-          cache_read_input_tokens: 8_480,
+          input_tokens: 30_719,
+          cache_read_input_tokens: 30_719,
           cache_creation_input_tokens: 0,
           output_tokens: 7,
         },
@@ -1162,8 +1170,8 @@ describe("Anthropic response context projection", () => {
     });
     expect(events[1]?.data).toMatchObject({
       usage: {
-        input_tokens: 49_344,
-        cache_read_input_tokens: 98_688,
+        input_tokens: 61_438,
+        cache_read_input_tokens: 122_875,
         cache_creation_input_tokens: 0,
         output_tokens: 11,
       },
@@ -1192,7 +1200,7 @@ describe("Anthropic response context projection", () => {
       id: "msg_json",
       content: [{ type: "text", text: "done" }],
       usage: {
-        input_tokens: 16_960,
+        input_tokens: 61_438,
         cache_read_input_tokens: 0,
         cache_creation_input_tokens: 0,
         output_tokens: 9,
@@ -1247,7 +1255,7 @@ describe("Anthropic response context projection", () => {
     const events = parseSse(output);
 
     expect(events[0]?.data).toMatchObject({ usage: { input_tokens: 65_536, output_tokens: 4 } });
-    expect(events[1]?.data).toMatchObject({ usage: { input_tokens: 0, output_tokens: 5 } });
+    expect(events[1]?.data).toMatchObject({ usage: { input_tokens: 30_719, output_tokens: 5 } });
   });
 });
 
@@ -1280,7 +1288,7 @@ describe("Anthropic response model rewrite", () => {
       message: {
         id: "msg_kimi",
         model: "claude-gateway--kimi--k3[1m]",
-        usage: { input_tokens: 0, output_tokens: 1 },
+        usage: { input_tokens: 10, output_tokens: 1 },
       },
     });
     expect(events[1]?.data).toEqual({ type: "message_stop" });
@@ -1307,7 +1315,7 @@ describe("Anthropic response model rewrite", () => {
       id: "msg_kimi",
       model: "claude-gateway--kimi--k3[1m]",
       content: [{ type: "text", text: "done" }],
-      usage: { input_tokens: 0, output_tokens: 4 },
+      usage: { input_tokens: 10, output_tokens: 4 },
     });
   });
 
@@ -1597,10 +1605,10 @@ describe("Anthropic SSE encoding", () => {
     })));
 
     expect(frames[0]?.data).toMatchObject({
-      message: { usage: { input_tokens: 149_000, output_tokens: 0 } },
+      message: { usage: { input_tokens: 145_032, output_tokens: 0 } },
     });
     expect(frames[1]?.data).toMatchObject({
-      usage: { input_tokens: 149_000, output_tokens: 6_277 },
+      usage: { input_tokens: 145_032, output_tokens: 6_277 },
     });
   });
 
@@ -1629,10 +1637,10 @@ describe("Anthropic SSE encoding", () => {
     })));
 
     expect(frames[0]?.data).toMatchObject({
-      message: { usage: { input_tokens: 0 } },
+      message: { usage: { input_tokens: 35_000 } },
     });
     expect(frames[1]?.data).toMatchObject({
-      usage: { input_tokens: 50_000, output_tokens: 1 },
+      usage: { input_tokens: 45_653, output_tokens: 1 },
     });
   });
 
@@ -1675,13 +1683,13 @@ describe("Anthropic SSE encoding", () => {
       output_tokens: number;
     };
 
-    // Same total as the plain projection test above: the offset applies once to
-    // the aggregate, then the cache coordinates retain their original proportions.
-    expect(usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens).toBe(149_000);
+    // Same total as the plain projection test above: scaling applies once to the
+    // aggregate, then the cache coordinates retain their original proportions.
+    expect(usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens).toBe(145_032);
     expect(usage).toEqual({
-      input_tokens: 47_870,
-      cache_read_input_tokens: 67_420,
-      cache_creation_input_tokens: 33_710,
+      input_tokens: 46_595,
+      cache_read_input_tokens: 65_625,
+      cache_creation_input_tokens: 32_812,
       output_tokens: 6_277,
     });
   });
@@ -3247,7 +3255,7 @@ describe("non-streaming requests", () => {
     );
 
     expect(JSON.parse(await collectBody(response.body))).toMatchObject({
-      usage: { input_tokens: 149_000, output_tokens: 6_277 },
+      usage: { input_tokens: 145_032, output_tokens: 6_277 },
     });
   });
 
@@ -3279,7 +3287,7 @@ describe("non-streaming requests", () => {
     );
 
     expect(JSON.parse(await collectBody(response.body))).toMatchObject({
-      usage: { input_tokens: 50_000, output_tokens: 1 },
+      usage: { input_tokens: 45_653, output_tokens: 1 },
     });
   });
 


### PR DESCRIPTION
## Summary
- replace the Claude usage offset dead zone with continuous threshold-proportional mapping
- preserve 16K of each provider model's real context before Claude Code compacts
- keep cache-aware usage projection proportional without creating nonzero cache fields from rounding

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` (601 tests)
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] Claude Code 2.1.227 loopback compact probes for DeepSeek, Luna, Composer, and Cursor Auto

Changelog-Amend: honest-context-projection.md