### PR TITLE
feat(fleet-console): replace launch menu scrollbar with edge strips

### DIFF
--- a/.changelog.d/launch-menu-scroll-strips.md
+++ b/.changelog.d/launch-menu-scroll-strips.md
@@ -1,0 +1,8 @@
+---
+branch: launch-menu-scroll-strips
+---
+
+### fleet-console
+#### Changed
+- Replace the launch menu's native scrollbar with directional edge strips: hover a strip to glide through a long model list, click it to jump a page, and a slim gauge shows the position while scrolling. Wheel and arrow-key scrolling keep working, and reduced-motion setups get click-step jumps instead of the glide.
+  ko: 실행 메뉴의 네이티브 스크롤바를 방향 스트립으로 교체합니다. 긴 모델 목록에서 스트립에 마우스를 올리면 부드럽게 흐르고, 클릭하면 한 페이지씩 이동하며, 스크롤 중에는 얇은 게이지가 위치를 표시합니다. 휠·방향키 스크롤은 그대로 동작하고, 모션 축소 환경에서는 글라이드 대신 클릭 이동을 제공합니다.

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -156,14 +156,18 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     glideRef.current.raf = requestAnimationFrame(step);
   };
   const updateEdgeDepth = (event: { readonly clientY: number; readonly currentTarget: Element }, direction: -1 | 1) => {
-    const rect = event.currentTarget.getBoundingClientRect();
-    if (rect.height <= 0) return;
+    // 스트립 호스트는 height:0(sticky 앵커)이라 재면 항상 0이 나온다 — 보이는 fill(26px)을 잰다.
+    const rect = event.currentTarget.querySelector(".canvas-context-menu-edge-fill")?.getBoundingClientRect();
+    if (!rect || rect.height <= 0) return;
     const into = direction === 1 ? (event.clientY - rect.top) / rect.height : (rect.bottom - event.clientY) / rect.height;
     glideRef.current.depth = Math.max(0, Math.min(1, into));
   };
   const jumpEdgePage = (direction: -1 | 1) => {
     const menu = menuRef.current;
     if (!menu) return;
+    // 클릭 직전의 pointermove가 이미 글라이드를 돌리고 있다 — rAF의 scrollTop 직접 대입이
+    // smooth 스크롤을 끊어 점프가 잘리므로, 점프는 글라이드를 멈추고 시작한다.
+    stopEdgeGlide();
     menu.scrollBy({
       top: direction * menu.clientHeight * EDGE_PAGE_JUMP_RATIO,
       behavior: prefersReducedMotion() ? "auto" : "smooth",

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -47,6 +47,19 @@ const ASIDE_WIDTH = 208;
 const ASIDE_GAP = 8;
 // 방향키가 훑는 항목. 실행 종류 행과 모델 행은 이제 같은 목록의 형제라 한 집합으로 돈다.
 const MENU_ITEM_SELECTOR = ".canvas-context-menu-item, .operation-launch-variant-row";
+// 방향 스트립 hover 글라이드 속도(px/frame). 스트립 안쪽으로 깊이 들어갈수록 가속한다 —
+// 스트립 가장자리를 스치면 천천히, 끝까지 밀어 넣으면 빠르게.
+const EDGE_GLIDE_BASE_SPEED = 2.2;
+const EDGE_GLIDE_DEPTH_SPEED = 4.8;
+// 스트립 클릭 한 번이 넘기는 분량 — 한 화면의 80%. 정확히 한 화면이면 경계 행이 화면을
+// 건널 때 연속성이 끊겨 어디까지 봤는지 잃는다.
+const EDGE_PAGE_JUMP_RATIO = 0.8;
+// 스크롤 게이지가 마지막 스크롤 뒤 사라지기까지의 대기.
+const SCROLL_GAUGE_HIDE_MS = 650;
+
+function prefersReducedMotion(): boolean {
+  return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+}
 
 export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor", fixed = false, catalog, canLaunch, renderKindIcon, onLaunchKind, onClose }: CanvasContextMenuProps) {
   const t = useT();
@@ -74,6 +87,13 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   const effortAnchorRefs = useRef(new Map<string, HTMLDivElement>());
   const effortMenuRef = useRef<HTMLDivElement | null>(null);
   const effortCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // 잘린 방향에만 서는 스트립. 네이티브 스크롤바를 걷어냈으므로(components.css) 이 스트립이
+  // 유일한 상시 절단 신호이자 포인터 항해 조작면이다.
+  const [edgeState, setEdgeState] = useState<{ readonly up: boolean; readonly down: boolean }>({ up: false, down: false });
+  const glideRef = useRef<{ raf: number | null; depth: number }>({ raf: null, depth: 0.5 });
+  const gaugeRef = useRef<HTMLDivElement | null>(null);
+  const gaugeThumbRef = useRef<HTMLDivElement | null>(null);
+  const gaugeHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const seenFeatureTours = globalSettings.state?.seenFeatureTours ?? [];
   const effortConfirmTipSeen = seenFeatureTours.includes(EFFORT_CONFIRM_TIP_SEEN_KEY);
   const openEffortValue = openEffortRow === null ? null : (rowEfforts[openEffortRow] ?? null);
@@ -110,6 +130,45 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     setEffortPosition({ id: rowId, ...placement });
     setOpenEffortRow(rowId);
   };
+  const stopEdgeGlide = useCallback(() => {
+    if (glideRef.current.raf === null) return;
+    cancelAnimationFrame(glideRef.current.raf);
+    glideRef.current.raf = null;
+  }, []);
+  const startEdgeGlide = (direction: -1 | 1) => {
+    // reduced-motion에서는 연속 이동을 접는다 — 클릭 스텝·휠·키보드가 그대로 남는다.
+    if (prefersReducedMotion()) return;
+    // 이미 흐르는 중이면 그대로 둔다 — pointermove마다 재시작하면 프레임이 리셋된다.
+    if (glideRef.current.raf !== null) return;
+    const menu = menuRef.current;
+    if (!menu) return;
+    const step = () => {
+      const max = menu.scrollHeight - menu.clientHeight;
+      // 끝에 닿으면 루프를 끊는다 — 스트립이 사라져도 pointerleave는 포인터가 움직여야
+      // 발화하므로, 여기서 멈추지 않으면 빈 rAF가 hover 내내 돈다.
+      if ((direction === -1 && menu.scrollTop <= 0) || (direction === 1 && menu.scrollTop >= max)) {
+        stopEdgeGlide();
+        return;
+      }
+      menu.scrollTop += direction * (EDGE_GLIDE_BASE_SPEED + glideRef.current.depth * EDGE_GLIDE_DEPTH_SPEED);
+      glideRef.current.raf = requestAnimationFrame(step);
+    };
+    glideRef.current.raf = requestAnimationFrame(step);
+  };
+  const updateEdgeDepth = (event: { readonly clientY: number; readonly currentTarget: Element }, direction: -1 | 1) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    if (rect.height <= 0) return;
+    const into = direction === 1 ? (event.clientY - rect.top) / rect.height : (rect.bottom - event.clientY) / rect.height;
+    glideRef.current.depth = Math.max(0, Math.min(1, into));
+  };
+  const jumpEdgePage = (direction: -1 | 1) => {
+    const menu = menuRef.current;
+    if (!menu) return;
+    menu.scrollBy({
+      top: direction * menu.clientHeight * EDGE_PAGE_JUMP_RATIO,
+      behavior: prefersReducedMotion() ? "auto" : "smooth",
+    });
+  };
   const scheduleEffortClose = () => {
     cancelEffortClose();
     // Cascade leave must wait for the grace window: closing the effort menu
@@ -138,6 +197,60 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     const observer = new ResizeObserver(measure);
     observer.observe(element);
     return () => observer.disconnect();
+  }, []);
+
+  // 잘린 방향 판정 — 목록 내용(카탈로그)·상자 크기·스크롤 위치가 바뀔 때마다 다시 센다.
+  // ResizeObserver는 뷰포트 clamp로 상자 높이가 변한 경우를, scroll 리스너는 항해를 좇는다.
+  useLayoutEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) return;
+    const sync = () => {
+      const max = menu.scrollHeight - menu.clientHeight;
+      const up = menu.scrollTop > 2;
+      const down = menu.scrollTop < max - 2;
+      setEdgeState((previous) => (previous.up === up && previous.down === down ? previous : { up, down }));
+    };
+    sync();
+    menu.addEventListener("scroll", sync, { passive: true });
+    if (typeof ResizeObserver === "undefined") return () => menu.removeEventListener("scroll", sync);
+    const observer = new ResizeObserver(sync);
+    observer.observe(menu);
+    return () => {
+      menu.removeEventListener("scroll", sync);
+      observer.disconnect();
+    };
+  }, [catalog, canLaunch]);
+
+  // 스크롤 게이지 — 굴리는 동안에만 나타나는 표시 전용 위치 표식. 매 스크롤 프레임의 기하는
+  // React 상태를 거치지 않고 DOM에 직접 쓴다(triage 덱 줌의 applyZoom과 같은 이유: 프레임당
+  // 재렌더를 피한다). is-on 클래스는 이 효과만 만지므로 정적 className과 충돌하지 않는다.
+  useEffect(() => {
+    const menu = menuRef.current;
+    const gauge = gaugeRef.current;
+    const thumb = gaugeThumbRef.current;
+    if (!menu || !gauge || !thumb) return;
+    const paint = () => {
+      const max = menu.scrollHeight - menu.clientHeight;
+      if (max <= 0) return;
+      const track = menu.clientHeight - 16;
+      const height = Math.max(24, (track * menu.clientHeight) / menu.scrollHeight);
+      thumb.style.height = `${height}px`;
+      thumb.style.top = `${8 + (menu.scrollTop / max) * (track - height)}px`;
+      gauge.classList.add("is-on");
+      if (gaugeHideTimerRef.current !== null) clearTimeout(gaugeHideTimerRef.current);
+      gaugeHideTimerRef.current = setTimeout(() => {
+        gaugeHideTimerRef.current = null;
+        gauge.classList.remove("is-on");
+      }, SCROLL_GAUGE_HIDE_MS);
+    };
+    menu.addEventListener("scroll", paint, { passive: true });
+    return () => {
+      menu.removeEventListener("scroll", paint);
+      if (gaugeHideTimerRef.current !== null) {
+        clearTimeout(gaugeHideTimerRef.current);
+        gaugeHideTimerRef.current = null;
+      }
+    };
   }, []);
 
   // Effort submenu uses a measured-height clamp — opening near the bottom would
@@ -194,7 +307,8 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
 
   useEffect(() => () => {
     cancelEffortClose();
-  }, []);
+    stopEdgeGlide();
+  }, [stopEdgeGlide]);
 
   // 강도 서브메뉴는 fixed라 목록이 굴러도 제자리에 남는다. 짚고 있던 행이 스크롤로 올라가면
   // 그 상자는 엉뚱한 행 옆에 붙어 그 행의 강도인 척한다 — 행을 눌러 실행하는 표면에서는
@@ -266,6 +380,8 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   }, []);
 
   const handleMenuKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    // 키보드가 개입하면 흐르던 글라이드를 끊는다 — 두 항해 수단이 같은 스크롤을 다투지 않게.
+    stopEdgeGlide();
     const target = event.target as HTMLElement;
     const onItem = target.matches?.(MENU_ITEM_SELECTOR) === true;
     switch (event.key) {
@@ -360,6 +476,29 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
         }}
         {...{ [FEATURE_TOUR_BOUNDARY_ATTRIBUTE]: "" }}
       >
+        {/* 게이지·스트립은 sticky라 배치 변형(cursor/above/triage fixed)과 무관하게 스크롤 포트
+            가장자리에 붙고, height:0이라 목록 흐름을 밀지 않는다. 전부 aria-hidden 포인터 전용
+            장치다 — 키보드는 기존 방향키 포커스 추적이, 보조기술은 목록 자체가 담당한다. */}
+        <div ref={gaugeRef} className="canvas-context-menu-gauge" aria-hidden="true">
+          <div ref={gaugeThumbRef} className="canvas-context-menu-gauge-thumb" />
+        </div>
+        <div
+          className={`canvas-context-menu-edge canvas-context-menu-edge--top${edgeState.up ? " is-on" : ""}`}
+          aria-hidden="true"
+          // 글라이드는 실제 포인터 이동에만 시작한다. pointerenter는 키보드·휠 스크롤이 정지한
+          // 포인터 아래로 스트립을 데려와도(재히트테스트) 발화하므로, enter로 걸면 키보드 탐색
+          // 중에 목록이 저 혼자 흐른다.
+          onPointerMove={(event) => {
+            updateEdgeDepth(event, -1);
+            startEdgeGlide(-1);
+          }}
+          onPointerLeave={stopEdgeGlide}
+          // 포커스를 뺏지 않는다 — 메뉴 컨테이너 포커스가 흔들리면 blur 닫힘 규율과 겨룬다.
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => jumpEdgePage(-1)}
+        >
+          <div className="canvas-context-menu-edge-fill"><EdgeChevron direction="up" /></div>
+        </div>
         {catalog.length > 0 ? <>
           {primaryCatalog.map((plugin, index) => {
             // 모델 밴드를 펼치는 실행 종류와 바로 실행되는 종류를 갈라 세운다. Terminal Shell은
@@ -577,6 +716,19 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
             </div>
           ) : null}
         </> : <p className="theater-menu-empty">{t("canvas.menu.empty")}</p>}
+        <div
+          className={`canvas-context-menu-edge canvas-context-menu-edge--bottom${edgeState.down ? " is-on" : ""}`}
+          aria-hidden="true"
+          onPointerMove={(event) => {
+            updateEdgeDepth(event, 1);
+            startEdgeGlide(1);
+          }}
+          onPointerLeave={stopEdgeGlide}
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => jumpEdgePage(1)}
+        >
+          <div className="canvas-context-menu-edge-fill"><EdgeChevron direction="down" /></div>
+        </div>
       </div>
       {activeDescription && asideSide
         ? (
@@ -831,6 +983,21 @@ function itemKey(pluginId: string, kindId: string): string {
 }
 
 // 플러그인이 아이콘을 등록하지 않았을 때의 일반 폴백 마크 — 특정 플러그인 지식이 아니다.
+function EdgeChevron({ direction }: { readonly direction: "up" | "down" }) {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path
+        d={direction === "up" ? "M3.5 10 8 5.5 12.5 10" : "M3.5 6 8 10.5 12.5 6"}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 function FallbackGlyph() {
   return (
     <svg viewBox="0 0 16 16" aria-hidden="true">

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -47,10 +47,14 @@ const ASIDE_WIDTH = 208;
 const ASIDE_GAP = 8;
 // 방향키가 훑는 항목. 실행 종류 행과 모델 행은 이제 같은 목록의 형제라 한 집합으로 돈다.
 const MENU_ITEM_SELECTOR = ".canvas-context-menu-item, .operation-launch-variant-row";
-// 방향 스트립 hover 글라이드 속도(px/frame). 스트립 안쪽으로 깊이 들어갈수록 가속한다 —
-// 스트립 가장자리를 스치면 천천히, 끝까지 밀어 넣으면 빠르게.
-const EDGE_GLIDE_BASE_SPEED = 2.2;
-const EDGE_GLIDE_DEPTH_SPEED = 4.8;
+// 방향 스트립 hover 글라이드 속도(px/초). 스트립 안쪽으로 깊이 들어갈수록 가속한다 —
+// 스트립 가장자리를 스치면 천천히, 끝까지 밀어 넣으면 빠르게. rAF 타임스탬프로 경과 시간을
+// 곱해 이동하므로 60Hz든 120Hz든 초당 속도가 같다.
+const EDGE_GLIDE_BASE_SPEED = 132;
+const EDGE_GLIDE_DEPTH_SPEED = 288;
+// 한 프레임으로 인정하는 경과 시간 상한(초) — 탭 비활성 등으로 rAF가 오래 멈췄다 돌아와도
+// 그 공백만큼 목록이 한 번에 튀지 않게 자른다.
+const EDGE_GLIDE_MAX_FRAME_SECONDS = 0.064;
 // 스트립 클릭 한 번이 넘기는 분량 — 한 화면의 80%. 정확히 한 화면이면 경계 행이 화면을
 // 건널 때 연속성이 끊겨 어디까지 봤는지 잃는다.
 const EDGE_PAGE_JUMP_RATIO = 0.8;
@@ -90,7 +94,7 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
   // 잘린 방향에만 서는 스트립. 네이티브 스크롤바를 걷어냈으므로(components.css) 이 스트립이
   // 유일한 상시 절단 신호이자 포인터 항해 조작면이다.
   const [edgeState, setEdgeState] = useState<{ readonly up: boolean; readonly down: boolean }>({ up: false, down: false });
-  const glideRef = useRef<{ raf: number | null; depth: number }>({ raf: null, depth: 0.5 });
+  const glideRef = useRef<{ raf: number | null; depth: number; lastTime: number | null }>({ raf: null, depth: 0.5, lastTime: null });
   const gaugeRef = useRef<HTMLDivElement | null>(null);
   const gaugeThumbRef = useRef<HTMLDivElement | null>(null);
   const gaugeHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -142,7 +146,8 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
     if (glideRef.current.raf !== null) return;
     const menu = menuRef.current;
     if (!menu) return;
-    const step = () => {
+    glideRef.current.lastTime = null;
+    const step = (now: number) => {
       const max = menu.scrollHeight - menu.clientHeight;
       // 끝에 닿으면 루프를 끊는다 — 스트립이 사라져도 pointerleave는 포인터가 움직여야
       // 발화하므로, 여기서 멈추지 않으면 빈 rAF가 hover 내내 돈다.
@@ -150,7 +155,12 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
         stopEdgeGlide();
         return;
       }
-      menu.scrollTop += direction * (EDGE_GLIDE_BASE_SPEED + glideRef.current.depth * EDGE_GLIDE_DEPTH_SPEED);
+      // 이동량은 프레임 수가 아니라 경과 시간에 비례한다 — 120Hz에서 두 배로 흐르지 않게.
+      const elapsed = glideRef.current.lastTime === null
+        ? 0
+        : Math.min((now - glideRef.current.lastTime) / 1000, EDGE_GLIDE_MAX_FRAME_SECONDS);
+      glideRef.current.lastTime = now;
+      menu.scrollTop += direction * (EDGE_GLIDE_BASE_SPEED + glideRef.current.depth * EDGE_GLIDE_DEPTH_SPEED) * elapsed;
       glideRef.current.raf = requestAnimationFrame(step);
     };
     glideRef.current.raf = requestAnimationFrame(step);

--- a/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
+++ b/runtime/fleet-console/core/client/src/canvas/canvas-context-menu.tsx
@@ -473,6 +473,9 @@ export function CanvasContextMenu({ anchor, viewportBounds, placement = "cursor"
         tabIndex={-1}
         ref={menuRef}
         onKeyDown={handleMenuKeyDown}
+        // 휠·트랙패드가 개입하면 흐르던 글라이드를 끊는다(키보드와 같은 규율) — 스트립 위에서
+        // 역방향 제스처가 rAF 가산과 싸우지 않게. 네이티브 휠 스크롤은 그대로 흐른다.
+        onWheel={stopEdgeGlide}
         onMouseLeave={() => setHoverKey(null)}
         // 항목이 전부 tabIndex=-1이라 Tab은 메뉴를 건너뛴다. 그때 메뉴만 열린 채 남으면 사용자는
         // 다른 컨트롤에 포커스를 둔 채 떠 있는 실행 메뉴를 보게 된다 — 포커스가 떠나면 닫는다.

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -3760,6 +3760,110 @@
   /* 상한은 뷰포트 높이에서 산출된 geometry 변수가 소유한다 — 짧은 화면에서도 메뉴가 잘리지 않는다. */
   max-height: var(--canvas-menu-max-height, 520px);
   overflow-y: auto;
+  /* 네이티브 스크롤바는 걷어낸다 — 떠 있는 실행 메뉴 안의 OS풍 스크롤바는 제품 밖 장치처럼
+     읽힌다. 절단 신호와 포인터 항해는 방향 스트립이, 위치 표시는 스크롤 게이지가 잇는다.
+     휠·키보드 스크롤과 강도 플라이아웃의 scroll-follow는 스크롤 포트 그대로라 영향이 없다. */
+  scrollbar-width: none;
+}
+
+.canvas-context-menu::-webkit-scrollbar {
+  display: none;
+}
+
+/* 방향 스트립 — 잘린 방향에만 서는 절단 신호이자 hover 글라이드/클릭 페이지 점프 조작면.
+   sticky+height:0이라 배치 변형(cursor/above/triage fixed)과 무관하게 스크롤 포트 가장자리에
+   붙고 목록 흐름을 밀지 않는다. 음수 오프셋은 메뉴 패딩(--space-1)을 넘어 테두리 안쪽까지
+   덮기 위한 것이다. */
+.canvas-context-menu-edge {
+  position: sticky;
+  z-index: 3;
+  height: 0;
+  margin: 0 var(--space-1);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.18s ease;
+}
+
+.canvas-context-menu-edge--top {
+  top: calc(-1 * var(--space-1));
+}
+
+.canvas-context-menu-edge--bottom {
+  bottom: calc(-1 * var(--space-1));
+}
+
+.canvas-context-menu-edge.is-on {
+  opacity: 1;
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.canvas-context-menu-edge-fill {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 26px;
+  border-radius: var(--radius-sm);
+  color: var(--text-tertiary);
+}
+
+/* 페이드는 메뉴 언더레이(.theater-menu의 불투명 --ink-deep 믹스)와 같은 식이어야 한다 —
+   다른 색으로 접으면 접힘선이 띠처럼 분리돼 보인다. */
+.canvas-context-menu-edge--top .canvas-context-menu-edge-fill {
+  background: linear-gradient(color-mix(in oklch, var(--ink-deep) 60%, var(--surface-pillar)) 35%, transparent);
+}
+
+.canvas-context-menu-edge--bottom .canvas-context-menu-edge-fill {
+  transform: translateY(-100%);
+  background: linear-gradient(transparent, color-mix(in oklch, var(--ink-deep) 60%, var(--surface-pillar)) 65%);
+}
+
+/* brass는 위치/hover 채널 — 스트립 hover 강조는 그 문법 그대로다. */
+.canvas-context-menu-edge.is-on:hover .canvas-context-menu-edge-fill {
+  color: var(--brass);
+}
+
+.canvas-context-menu-edge-fill svg {
+  width: 14px;
+  height: 14px;
+  display: block;
+}
+
+/* 스크롤 게이지 — 굴리는 동안에만 나타나는 표시 전용 위치 표식(is-on은 TSX 스크롤 핸들러가
+   토글). 기하(top/height)는 프레임당 재렌더를 피해 TSX가 직접 쓴다. */
+.canvas-context-menu-gauge {
+  position: sticky;
+  top: calc(-1 * var(--space-1));
+  z-index: 4;
+  height: 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+}
+
+.canvas-context-menu-gauge.is-on {
+  opacity: 1;
+}
+
+.canvas-context-menu-gauge-thumb {
+  position: absolute;
+  right: -1px;
+  width: 2px;
+  border-radius: 999px;
+  background: var(--scrollbar-thumb-hover);
+}
+
+/* 방향키 포커스 스크롤이 목표 행을 스트립(26px) 아래에 두고 멈추지 않게 여유를 준다. */
+.canvas-context-menu .canvas-context-menu-item,
+.canvas-context-menu .operation-launch-variant-row {
+  scroll-margin-block: 28px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .canvas-context-menu-edge,
+  .canvas-context-menu-gauge {
+    transition: none;
+  }
 }
 
 /* 바깥 패딩은 캔버스 메뉴에서만 좁힌다 — 공유 .theater-menu를 고치면 사이드바 Theater 메뉴까지

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -852,6 +852,63 @@ describe("CanvasContextMenu effort confirm tip", () => {
   });
 });
 
+describe("CanvasContextMenu edge strips", () => {
+  // jsdom은 레이아웃이 없어 scrollHeight/clientHeight가 0이다 — 오버플로를 인스턴스 속성으로 흉내 낸다.
+  function mockOverflow(menu: Element, { scrollHeight, clientHeight }: { readonly scrollHeight: number; readonly clientHeight: number }): void {
+    Object.defineProperty(menu, "scrollHeight", { value: scrollHeight, configurable: true });
+    Object.defineProperty(menu, "clientHeight", { value: clientHeight, configurable: true });
+  }
+  const stripOn = (side: "top" | "bottom"): boolean =>
+    document.querySelector(`.canvas-context-menu-edge--${side}`)!.classList.contains("is-on");
+
+  it("raises only the strip pointing at hidden content", () => {
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, gatewayVariantCatalog());
+    const menu = document.querySelector(".canvas-context-menu")!;
+    mockOverflow(menu, { scrollHeight: 640, clientHeight: 320 });
+
+    menu.scrollTop = 0;
+    act(() => { menu.dispatchEvent(new Event("scroll")); });
+    expect(stripOn("top")).toBe(false);
+    expect(stripOn("bottom")).toBe(true);
+
+    menu.scrollTop = 160;
+    act(() => { menu.dispatchEvent(new Event("scroll")); });
+    expect(stripOn("top")).toBe(true);
+    expect(stripOn("bottom")).toBe(true);
+
+    menu.scrollTop = 320;
+    act(() => { menu.dispatchEvent(new Event("scroll")); });
+    expect(stripOn("top")).toBe(true);
+    expect(stripOn("bottom")).toBe(false);
+  });
+
+  it("keeps both strips down when the list fits", () => {
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, gatewayVariantCatalog());
+    const menu = document.querySelector(".canvas-context-menu")!;
+    mockOverflow(menu, { scrollHeight: 320, clientHeight: 320 });
+
+    act(() => { menu.dispatchEvent(new Event("scroll")); });
+    expect(stripOn("top")).toBe(false);
+    expect(stripOn("bottom")).toBe(false);
+  });
+
+  it("lights the scroll gauge while the list is scrolling", () => {
+    renderMenu({ x: 520, y: 156 }, { width: 1116, height: 856 }, gatewayVariantCatalog());
+    const menu = document.querySelector(".canvas-context-menu")!;
+    mockOverflow(menu, { scrollHeight: 640, clientHeight: 320 });
+
+    const gauge = document.querySelector(".canvas-context-menu-gauge")!;
+    expect(gauge.classList.contains("is-on")).toBe(false);
+
+    menu.scrollTop = 160;
+    act(() => { menu.dispatchEvent(new Event("scroll")); });
+    expect(gauge.classList.contains("is-on")).toBe(true);
+    const thumb = document.querySelector<HTMLElement>(".canvas-context-menu-gauge-thumb")!;
+    expect(thumb.style.height).not.toBe("");
+    expect(thumb.style.top).not.toBe("");
+  });
+});
+
 function renderMenu(
   anchor: { readonly x: number; readonly y: number },
   viewportBounds: { readonly width: number; readonly height: number },

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -383,6 +383,31 @@ describe("Instrument core design contract", () => {
     expect(contextMenu).toContain("menuRef.current?.focus({ preventScroll: true });");
   });
 
+  it("replaces the launch menu's native scrollbar with edge strips and a scroll gauge", () => {
+    const components = source("styles/components.css");
+    const contextMenu = source("canvas/canvas-context-menu.tsx");
+    const menuBlock = components.match(/\n\.canvas-context-menu \{[\s\S]*?\n\}/)?.[0] ?? "";
+
+    // 떠 있는 실행 메뉴 안의 OS풍 스크롤바는 제품 밖 장치처럼 읽힌다 — 스크롤 포트(휠·키보드·
+    // 플라이아웃 scroll-follow)는 남기고 시각 장치만 메뉴 문법으로 바꾼다.
+    expect(menuBlock).toContain("overflow-y: auto;");
+    expect(menuBlock).toContain("scrollbar-width: none;");
+    expect(components).toContain(".canvas-context-menu::-webkit-scrollbar");
+
+    // 절단 신호·포인터 항해는 방향 스트립이, 위치 표시는 스크롤 게이지가 잇는다. 전부 포인터
+    // 전용 장치라 aria-hidden이어야 한다 — 키보드는 방향키 포커스 추적이, 보조기술은 목록
+    // 자체가 담당한다.
+    expect(contextMenu).toContain("canvas-context-menu-edge canvas-context-menu-edge--top");
+    expect(contextMenu).toContain("canvas-context-menu-edge canvas-context-menu-edge--bottom");
+    expect(contextMenu).toContain('className="canvas-context-menu-gauge"');
+
+    // 스트립 hover 강조는 brass(위치/hover 채널) 문법 그대로다.
+    expect(components).toContain(".canvas-context-menu-edge.is-on:hover .canvas-context-menu-edge-fill");
+
+    // reduced-motion에서는 연속 글라이드를 접는다 — 클릭 스텝·휠·키보드만 남긴다.
+    expect(contextMenu).toContain("if (prefersReducedMotion()) return;");
+  });
+
   it("keeps minimap navigation and collapse controls while hiding Map in Formation and maximize", () => {
     const minimap = source("canvas/canvas-minimap.tsx");
     const canvas = source("canvas/canvas.tsx");


### PR DESCRIPTION
## Summary
- 캔버스 실행 메뉴(우클릭·`+` 런처·triage 공용)의 네이티브 스크롤바를 걷어내고, 잘린 방향에만 서는 방향 스트립(페이드+셰브론)으로 교체합니다. 스트립에 포인터를 올리면 깊이 비례 속도로 부드럽게 흐르고, 클릭하면 한 페이지(80%)씩 이동합니다.
- 휠·방향키 스크롤은 그대로 동작합니다. 글라이드는 실제 `pointermove`에만 시작해 키보드·휠이 정지한 포인터 아래로 목록을 굴려도 오발화하지 않고, 키 입력은 흐르던 글라이드를 끊습니다. `prefers-reduced-motion`에서는 글라이드 대신 클릭 스텝만 남습니다.
- 스크롤 중에만 2px 게이지가 위치를 표시하며, 방향키 포커스 스크롤은 `scroll-margin`으로 스트립을 넘겨 섭니다. 강도 플라이아웃의 scroll-follow는 동일 scroll 이벤트 경로라 그대로 호환됩니다.

## Test Plan
- [x] `pnpm exec tsc --noEmit` (fleet-console) — 0 errors
- [x] `pnpm exec vitest run tests/canvas-context-menu-anchor.test.tsx tests/instrument-design-contract.test.ts` — 95 passed (스트립 방향별 점등·게이지 단위 테스트 3건 신규, 디자인 계약 핀 1건 신규)
- [x] `pnpm build` (fleet-console)
- [x] 격리 콘솔 실측(게이트웨이 모델 8종 시드, 내용 643px/창 518px): 스크롤바 은폐(거터 12px→2px), 방향별 스트립 점등·소등, hover 글라이드(0→125 및 역방향)·경계 자기 종료, 클릭 페이지 점프(메뉴 유지·오실행 없음), trusted CDP 휠 0→125, 방향키 포커스 추적, 정지 포인터 아래 재히트테스트 오발화 없음(1초간 0px)