### PR TITLE
feat(fleet-console): give apex effort tiers signature motion on an anchored track

### DIFF
--- a/.changelog.d/effort-gauge-rev2.md
+++ b/.changelog.d/effort-gauge-rev2.md
@@ -6,12 +6,10 @@ branch: effort-gauge-rev2
 
 #### Changed
 
-- The apex effort gate now lives inside the track: a light-leak cap on the right rim replaces the external toggle button, and pushing past the last visible rung, by pointer or keyboard, rubber-bands once and opens the gate on a second push.
-  ko: apex 강도 게이트가 트랙 안으로 들어왔습니다. 우측 림의 빛샘 캡이 외부 토글 버튼을 대신하고, 마지막 단 너머로 포인터나 키보드로 밀면 한 번은 버티고 두 번째 밀기에 게이트가 열립니다.
 - MAX and ULTRACODE efforts each carry their own signature motion: the MAX label flickers like embers over a molten copper fill with a breathing knob halo, while the ULTRACODE fill drifts like an aurora with twinkling gate glyphs in place of the white sweep. Reduced-motion environments keep every treatment static.
   ko: MAX와 ULTRACODE 강도가 각자의 시그니처 모션을 갖습니다. MAX 라벨은 용융 구리 채움과 숨쉬는 손잡이 헤일로 위에서 불씨처럼 이글거리고, ULTRACODE 채움은 흰 광택 대신 반짝이는 게이트 글리프와 함께 오로라처럼 흐릅니다. 감속 모션 환경에서는 모든 처리가 정적으로 남습니다.
 
 #### Fixed
 
-- Opening the apex gate no longer shifts the effort track's existing stops and knob: the ladder keeps its closed spacing and only extends to the right, and the label no longer jumps when the gate control changes state.
-  ko: apex 게이트를 열어도 강도 트랙의 기존 스톱과 손잡이가 더는 밀리지 않습니다. 사다리는 닫혀 있을 때의 간격을 그대로 유지한 채 오른쪽으로만 늘어나고, 게이트 컨트롤 상태가 바뀔 때 라벨이 튀던 현상도 사라졌습니다.
+- Opening the apex effort gate no longer shifts the track's existing stops and knob: the ladder keeps its closed spacing and only extends to the right, and the gate control stays one persistent button so the label no longer jumps when it opens.
+  ko: apex 강도 게이트를 열어도 트랙의 기존 스톱과 손잡이가 더는 밀리지 않습니다. 사다리는 닫혀 있을 때의 간격을 그대로 유지한 채 오른쪽으로만 늘어나고, 게이트 컨트롤이 한 버튼으로 유지되어 열릴 때 라벨이 튀던 현상도 사라졌습니다.

--- a/.changelog.d/effort-gauge-rev2.md
+++ b/.changelog.d/effort-gauge-rev2.md
@@ -1,0 +1,17 @@
+---
+branch: effort-gauge-rev2
+---
+
+### fleet-console
+
+#### Changed
+
+- The apex effort gate now lives inside the track: a light-leak cap on the right rim replaces the external toggle button, and pushing past the last visible rung, by pointer or keyboard, rubber-bands once and opens the gate on a second push.
+  ko: apex 강도 게이트가 트랙 안으로 들어왔습니다. 우측 림의 빛샘 캡이 외부 토글 버튼을 대신하고, 마지막 단 너머로 포인터나 키보드로 밀면 한 번은 버티고 두 번째 밀기에 게이트가 열립니다.
+- MAX and ULTRACODE efforts each carry their own signature motion: the MAX label flickers like embers over a molten copper fill with a breathing knob halo, while the ULTRACODE fill drifts like an aurora with twinkling gate glyphs in place of the white sweep. Reduced-motion environments keep every treatment static.
+  ko: MAX와 ULTRACODE 강도가 각자의 시그니처 모션을 갖습니다. MAX 라벨은 용융 구리 채움과 숨쉬는 손잡이 헤일로 위에서 불씨처럼 이글거리고, ULTRACODE 채움은 흰 광택 대신 반짝이는 게이트 글리프와 함께 오로라처럼 흐릅니다. 감속 모션 환경에서는 모든 처리가 정적으로 남습니다.
+
+#### Fixed
+
+- Opening the apex gate no longer shifts the effort track's existing stops and knob: the ladder keeps its closed spacing and only extends to the right, and the label no longer jumps when the gate control changes state.
+  ko: apex 게이트를 열어도 강도 트랙의 기존 스톱과 손잡이가 더는 밀리지 않습니다. 사다리는 닫혀 있을 때의 간격을 그대로 유지한 채 오른쪽으로만 늘어나고, 게이트 컨트롤 상태가 바뀔 때 라벨이 튀던 현상도 사라졌습니다.

--- a/runtime/fleet-console/core/client/src/components/effort-track.tsx
+++ b/runtime/fleet-console/core/client/src/components/effort-track.tsx
@@ -12,9 +12,6 @@ const CLOSED_TRACK_WIDTH = 116;
     간격 산술에서 테두리를 빼먹으면 포인터 적중 판정이 CSS 좌표와 어긋난다. */
 const TRACK_CHROME = EDGE * 2 + 2;
 
-/** 오버트래블 2연타 개방 창(ms) — 첫 밀기는 저항, 이 창 안의 두 번째 밀기가 게이트를 연다. */
-const OVERTRAVEL_WINDOW = 900;
-
 interface EffortSlot {
   readonly id: string | null;
   readonly label: string;
@@ -37,9 +34,9 @@ export interface EffortTrackProps {
   readonly autoLabel: string;
   readonly ariaLabel: string;
   readonly autoValueText: string;
-  /** 닫힌 게이트의 빛샘 캡(트랙 우측 림)이 가지는 개방 라벨. */
+  /** 닫힌 게이트의 ✦ 토글이 가지는 개방 라벨. */
   readonly apexToggleLabel?: string;
-  /** 게이트가 열린 동안 같은 캡이 가지는 접힘 라벨. */
+  /** 게이트가 열린 동안 같은 토글이 가지는 접힘 라벨. */
   readonly apexCollapseLabel?: string;
   readonly className?: string;
 }
@@ -77,16 +74,11 @@ export function EffortTrack({
   const [apexOpen, setApexOpen] = useState(() => value !== null && gatedRungs.includes(value));
   const [burstKey, setBurstKey] = useState(0);
   const [burstLeft, setBurstLeft] = useState("50%");
-  // 오버트래블 무장 상태. 끝 단 너머로 미는 첫 제스처는 트랙이 버티고(러버밴드), 창 안의
-  // 두 번째 밀기가 봉인을 연다 — 시간 기준은 ref가, 시각 상태는 state가 든다.
-  const [armed, setArmed] = useState(false);
-  const armedAtRef = useRef(0);
-  const disarmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // 제스처 동안 React 커밋을 기다리지 않고 고른 단을 추적한다 — 같은 포인터 시퀀스에서
   // "다른 단으로 옮겼다"와 "처음부터 이 단을 다시 눌렀다"를 갈라야 한다.
   const liveIndexRef = useRef(0);
   // pointerId까지 묶어 두면 터치에서 두 번째 손가락(button===0)이 제스처를 덮어 쓰지 못한다.
-  const gestureRef = useRef<{ readonly pointerId: number; readonly originIndex: number; dirty: boolean; overtravelled: boolean } | null>(null);
+  const gestureRef = useRef<{ readonly pointerId: number; readonly originIndex: number; dirty: boolean } | null>(null);
 
   const clearCollapseTimer = useCallback(() => {
     if (collapseTimerRef.current === null) return;
@@ -95,14 +87,6 @@ export function EffortTrack({
   }, []);
 
   useEffect(() => clearCollapseTimer, [clearCollapseTimer]);
-
-  const clearDisarmTimer = useCallback(() => {
-    if (disarmTimerRef.current === null) return;
-    clearTimeout(disarmTimerRef.current);
-    disarmTimerRef.current = null;
-  }, []);
-
-  useEffect(() => clearDisarmTimer, [clearDisarmTimer]);
 
   useEffect(() => {
     if (value === null || !gatedRungs.includes(value)) return;
@@ -178,41 +162,6 @@ export function EffortTrack({
     return nearestSelectable(Math.round((clientX - rect.left - EDGE) / gap));
   }, [gap, last, nearestSelectable]);
 
-  /** 포인터가 보이는 마지막 단 너머(닫힌 게이트의 봉인 구역)를 가리키는가. */
-  const pointerBeyondEnd = useCallback((clientX: number): boolean => {
-    const track = trackRef.current;
-    if (!track || last === 0) return false;
-    const rect = track.getBoundingClientRect();
-    return Math.round((clientX - rect.left - EDGE) / gap) > last;
-  }, [gap, last]);
-
-  const tryOvertravel = useCallback(() => {
-    if (!hasGate || apexOpen) return;
-    clearDisarmTimer();
-    if (armedAtRef.current !== 0 && Date.now() - armedAtRef.current < OVERTRAVEL_WINDOW) {
-      // 두 번째 밀기 — 봉인이 풀리고, 민 방향 그대로 첫 게이트 단에 올라선다.
-      armedAtRef.current = 0;
-      setArmed(false);
-      clearCollapseTimer();
-      setApexOpen(true);
-      const target = gatedRungs.find((id) => (row.chips ?? []).some((chip) => chip.id === id));
-      if (target !== undefined) {
-        const openIndex = 1 + ladder.indexOf(target);
-        liveIndexRef.current = openIndex;
-        setBurstLeft(leftAt(openIndex));
-        setBurstKey((key) => key + 1);
-        onChange(target);
-      }
-      return;
-    }
-    armedAtRef.current = Date.now();
-    setArmed(true);
-    disarmTimerRef.current = setTimeout(() => {
-      disarmTimerRef.current = null;
-      armedAtRef.current = 0;
-      setArmed(false);
-    }, OVERTRAVEL_WINDOW);
-  }, [apexOpen, clearCollapseTimer, clearDisarmTimer, gatedRungs, hasGate, ladder, leftAt, onChange, row]);
 
   const fromPointer = useCallback((event: PointerEvent<HTMLDivElement>) => {
     const next = indexFromPointer(event.clientX);
@@ -228,8 +177,7 @@ export function EffortTrack({
     // 시작한 포인터만 끝낸다 — 다른 접촉의 up이 활성 제스처를 지우면 안 된다.
     if (!gesture || gesture.pointerId !== event.pointerId) return;
     gestureRef.current = null;
-    // 오버트래블 제스처는 봉인을 미는 것이지 현재 단을 다시 누른 것이 아니다 — 확정 금지.
-    if (!confirm || gesture.dirty || gesture.overtravelled || !onConfirmCurrent) return;
+    if (!confirm || gesture.dirty || !onConfirmCurrent) return;
     // 주버튼으로 트랙 안에서 손을 뗄 때만 확정한다 — 우클릭·가운데 클릭이나
     // 세로로 트랙 밖까지 끌어 뺀 해제는 값을 고르는 실수가 되지 않게 막는다.
     if (event.button !== 0) return;
@@ -260,14 +208,6 @@ export function EffortTrack({
         if (slots[i]!.selectable) { next = i; break; }
       }
     }
-    // 위쪽 방향키가 보이는 사다리 밖으로 나가는 것은 닫힌 게이트를 미는 것이다 —
-    // 포인터의 오버트래블과 같은 규칙(1회 저항, 창 안의 2회째 개방)을 탄다.
-    if (direction > 0 && next === null && hasGate && !apexOpen) {
-      event.preventDefault();
-      event.stopPropagation();
-      tryOvertravel();
-      return;
-    }
     if (event.key === "Home") next = 0;
     if (event.key === "End") next = nearestSelectable(last);
     if (event.key === "Enter" && onConfirmCurrent) {
@@ -281,7 +221,7 @@ export function EffortTrack({
     // 트랙은 메뉴 안에 산다. 방향키가 위로 새면 메뉴가 항목 이동으로 받아 함께 움직인다.
     event.stopPropagation();
     commit(next);
-  }, [apexOpen, commit, hasGate, index, last, nearestSelectable, onConfirmCurrent, slots, tryOvertravel]);
+  }, [commit, index, last, nearestSelectable, onConfirmCurrent, slots]);
 
 
   return (
@@ -297,7 +237,6 @@ export function EffortTrack({
         aria-valuenow={index}
         aria-valuetext={isAuto ? autoValueText : current.label}
         data-apex-open={hasGate && apexOpen ? true : undefined}
-        data-armed={armed ? true : undefined}
         data-apex={isApex ? true : undefined}
         data-at-max={hasGate ? (isApex ? true : undefined) : (index === last && !isAuto ? true : undefined)}
         // 자동은 사다리의 최소 단이 아니라 "사다리를 쓰지 않음"이다. 파선 테두리·빈 손잡이·채움 0이
@@ -315,12 +254,7 @@ export function EffortTrack({
           event.preventDefault();
           event.currentTarget.setPointerCapture(event.pointerId);
           event.currentTarget.focus();
-          const beyond = !apexOpen && hasGate && pointerBeyondEnd(event.clientX);
-          gestureRef.current = { pointerId: event.pointerId, originIndex: liveIndexRef.current, dirty: false, overtravelled: beyond };
-          if (beyond) {
-            tryOvertravel();
-            return;
-          }
+          gestureRef.current = { pointerId: event.pointerId, originIndex: liveIndexRef.current, dirty: false };
           fromPointer(event);
         }}
         onPointerMove={(event) => {
@@ -329,14 +263,6 @@ export function EffortTrack({
           const gesture = gestureRef.current;
           if (!gesture || gesture.pointerId !== event.pointerId) return;
           if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
-          if (!apexOpen && hasGate && pointerBeyondEnd(event.clientX)) {
-            // 드래그로 끝 너머를 미는 것도 같은 오버트래블 규칙을 탄다 — 한 제스처당 1회만.
-            if (!gesture.overtravelled) {
-              gesture.overtravelled = true;
-              tryOvertravel();
-            }
-            return;
-          }
           fromPointer(event);
         }}
         onPointerUp={(event) => endGesture(event, { confirm: true })}
@@ -391,38 +317,35 @@ export function EffortTrack({
           data-auto={isAuto ? true : undefined}
           aria-hidden="true"
         />
-        {hasGate ? (
-          // 게이트 장치는 트랙 밖 버튼이 아니라 트랙 우측 림 안쪽의 빛샘 캡이다 — 닫힌 동안
-          // 아펙스 빛이 새어 "봉인된 구획"을 암시하고, 클릭이 봉인을 연다. 열린 뒤에는 같은
-          // 캡이 ‹ 접힘 손잡이가 된다. apex 단이 선택된 채 접으면 일상 사다리의 마지막
-          // 고를 수 있는 단으로 내려, 숨은 apex 값을 제출하는 모순을 만들지 않는다.
-          <button
-            type="button"
-            className="effort-track-apex-cap"
-            aria-expanded={apexOpen}
-            aria-label={apexOpen ? apexCollapseLabel : apexToggleLabel}
-            title={apexOpen ? apexCollapseLabel : apexToggleLabel}
-            onPointerDown={(event) => event.stopPropagation()}
-            onClick={() => {
-              clearCollapseTimer();
-              clearDisarmTimer();
-              armedAtRef.current = 0;
-              setArmed(false);
-              if (!apexOpen) {
-                setApexOpen(true);
-                return;
-              }
-              if (isApex) {
-                const fallback = [...ordinaryRungs]
-                  .reverse()
-                  .find((id) => (row.chips ?? []).some((chip) => chip.id === id));
-                onChange(fallback ?? null);
-              }
-              setApexOpen(false);
-            }}
-          >‹</button>
-        ) : null}
       </div>
+      {hasGate ? (
+        // 게이트 장치는 트랙 우측의 ✦ 토글이다. 닫힘·열림이 한 버튼의 두 상태라(마운트 교체
+        // 없음) 라벨이 밀리지 않고, 열린 동안은 같은 자리의 ‹ 접힘 글리프가 된다. apex 단이
+        // 선택된 채 접으면 일상 사다리의 마지막 고를 수 있는 단으로 내려, 숨은 apex 값을
+        // 제출하는 모순을 만들지 않는다.
+        <button
+          type="button"
+          className="effort-track-apex-toggle"
+          aria-expanded={apexOpen}
+          aria-label={apexOpen ? apexCollapseLabel : apexToggleLabel}
+          title={apexOpen ? apexCollapseLabel : apexToggleLabel}
+          data-open={apexOpen ? true : undefined}
+          onClick={() => {
+            clearCollapseTimer();
+            if (!apexOpen) {
+              setApexOpen(true);
+              return;
+            }
+            if (isApex) {
+              const fallback = [...ordinaryRungs]
+                .reverse()
+                .find((id) => (row.chips ?? []).some((chip) => chip.id === id));
+              onChange(fallback ?? null);
+            }
+            setApexOpen(false);
+          }}
+        >{apexOpen ? "‹" : "✦"}</button>
+      ) : null}
       {/* 단계 톤은 CSS가 이 속성 하나로 읽는다 — 라벨 문자열은 번역·모델마다 달라 색의 기준이 될 수 없다.
           data-apex는 게이트 뒤 티어의 라벨 모션 전용이다: 게이트 없는 모델의 최고 단(max)은 같은
           data-effort-level이라도 정적 글로우에 머문다. */}

--- a/runtime/fleet-console/core/client/src/components/effort-track.tsx
+++ b/runtime/fleet-console/core/client/src/components/effort-track.tsx
@@ -5,6 +5,16 @@ import type { OperationLaunchVariantChip, OperationLaunchVariantRow } from "@fle
 /** 트랙 좌우 안쪽 여백 — 손잡이 반지름과 같아야 양 끝 스톱에서 손잡이가 트랙을 넘지 않는다. */
 const EDGE = 13;
 
+/** 닫힌 트랙의 외곽 폭. CSS의 --effort-closed-track-width와 같은 값이어야 한다. */
+const CLOSED_TRACK_WIDTH = 116;
+
+/** 스톱 스팬이 아닌 외곽 폭 — 좌우 패딩(EDGE×2)과 1px 테두리 둘. box-sizing이 border-box라
+    간격 산술에서 테두리를 빼먹으면 포인터 적중 판정이 CSS 좌표와 어긋난다. */
+const TRACK_CHROME = EDGE * 2 + 2;
+
+/** 오버트래블 2연타 개방 창(ms) — 첫 밀기는 저항, 이 창 안의 두 번째 밀기가 게이트를 연다. */
+const OVERTRAVEL_WINDOW = 900;
+
 interface EffortSlot {
   readonly id: string | null;
   readonly label: string;
@@ -27,8 +37,9 @@ export interface EffortTrackProps {
   readonly autoLabel: string;
   readonly ariaLabel: string;
   readonly autoValueText: string;
+  /** 닫힌 게이트의 빛샘 캡(트랙 우측 림)이 가지는 개방 라벨. */
   readonly apexToggleLabel?: string;
-  /** 게이트가 열린 동안 ✦ 자리를 물려받는 접힘 셰브론의 라벨. */
+  /** 게이트가 열린 동안 같은 캡이 가지는 접힘 라벨. */
   readonly apexCollapseLabel?: string;
   readonly className?: string;
 }
@@ -66,11 +77,16 @@ export function EffortTrack({
   const [apexOpen, setApexOpen] = useState(() => value !== null && gatedRungs.includes(value));
   const [burstKey, setBurstKey] = useState(0);
   const [burstLeft, setBurstLeft] = useState("50%");
+  // 오버트래블 무장 상태. 끝 단 너머로 미는 첫 제스처는 트랙이 버티고(러버밴드), 창 안의
+  // 두 번째 밀기가 봉인을 연다 — 시간 기준은 ref가, 시각 상태는 state가 든다.
+  const [armed, setArmed] = useState(false);
+  const armedAtRef = useRef(0);
+  const disarmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // 제스처 동안 React 커밋을 기다리지 않고 고른 단을 추적한다 — 같은 포인터 시퀀스에서
   // "다른 단으로 옮겼다"와 "처음부터 이 단을 다시 눌렀다"를 갈라야 한다.
   const liveIndexRef = useRef(0);
   // pointerId까지 묶어 두면 터치에서 두 번째 손가락(button===0)이 제스처를 덮어 쓰지 못한다.
-  const gestureRef = useRef<{ readonly pointerId: number; readonly originIndex: number; dirty: boolean } | null>(null);
+  const gestureRef = useRef<{ readonly pointerId: number; readonly originIndex: number; dirty: boolean; overtravelled: boolean } | null>(null);
 
   const clearCollapseTimer = useCallback(() => {
     if (collapseTimerRef.current === null) return;
@@ -79,6 +95,14 @@ export function EffortTrack({
   }, []);
 
   useEffect(() => clearCollapseTimer, [clearCollapseTimer]);
+
+  const clearDisarmTimer = useCallback(() => {
+    if (disarmTimerRef.current === null) return;
+    clearTimeout(disarmTimerRef.current);
+    disarmTimerRef.current = null;
+  }, []);
+
+  useEffect(() => clearDisarmTimer, [clearDisarmTimer]);
 
   useEffect(() => {
     if (value === null || !gatedRungs.includes(value)) return;
@@ -114,6 +138,17 @@ export function EffortTrack({
     return liveIndexRef.current;
   }, [last, slots]);
 
+  // 닫힌 사다리(일상 단) 간격을 열린 뒤에도 그대로 쓴다. 좌표는 전부 픽셀 앵커다 —
+  // 비율(index/last) 좌표는 게이트가 열려 슬롯 수가 바뀌는 순간 %가 즉시 점프해,
+  // 폭 전이(360ms)를 따라 기존 스톱·손잡이가 미끄러진다. 픽셀 좌표에서는 기존 단이
+  // 단 1px도 움직이지 않고 오른쪽 봉인만 늘어난다. CSS 쪽 같은 값은 --effort-track-gap.
+  const closedIntervals = Math.max(ordinaryRungs.length, 1);
+  const gap = (CLOSED_TRACK_WIDTH - TRACK_CHROME) / closedIntervals;
+  const leftAt = useCallback(
+    (position: number) => `calc(${EDGE}px + var(--effort-track-gap) * ${position})`,
+    [],
+  );
+
   const commit = useCallback((next: number) => {
     clearCollapseTimer();
     const slot = slots[next];
@@ -124,8 +159,7 @@ export function EffortTrack({
       && (previous?.id == null || !gatedRungs.includes(previous.id));
     liveIndexRef.current = next;
     if (entersApex) {
-      const ratio = last === 0 ? 0 : next / last;
-      setBurstLeft(`calc(${EDGE}px + ${ratio} * (100% - ${EDGE * 2}px))`);
+      setBurstLeft(leftAt(next));
       setBurstKey((key) => key + 1);
     } else if (apexOpen && (slot.id === null || !gatedRungs.includes(slot.id))) {
       collapseTimerRef.current = setTimeout(() => {
@@ -141,11 +175,44 @@ export function EffortTrack({
     const track = trackRef.current;
     if (!track || last === 0) return null;
     const rect = track.getBoundingClientRect();
-    const span = rect.width - EDGE * 2;
-    if (span <= 0) return null;
-    const ratio = Math.max(0, Math.min((clientX - rect.left - EDGE) / span, 1));
-    return nearestSelectable(Math.round(ratio * last));
-  }, [last, nearestSelectable]);
+    return nearestSelectable(Math.round((clientX - rect.left - EDGE) / gap));
+  }, [gap, last, nearestSelectable]);
+
+  /** 포인터가 보이는 마지막 단 너머(닫힌 게이트의 봉인 구역)를 가리키는가. */
+  const pointerBeyondEnd = useCallback((clientX: number): boolean => {
+    const track = trackRef.current;
+    if (!track || last === 0) return false;
+    const rect = track.getBoundingClientRect();
+    return Math.round((clientX - rect.left - EDGE) / gap) > last;
+  }, [gap, last]);
+
+  const tryOvertravel = useCallback(() => {
+    if (!hasGate || apexOpen) return;
+    clearDisarmTimer();
+    if (armedAtRef.current !== 0 && Date.now() - armedAtRef.current < OVERTRAVEL_WINDOW) {
+      // 두 번째 밀기 — 봉인이 풀리고, 민 방향 그대로 첫 게이트 단에 올라선다.
+      armedAtRef.current = 0;
+      setArmed(false);
+      clearCollapseTimer();
+      setApexOpen(true);
+      const target = gatedRungs.find((id) => (row.chips ?? []).some((chip) => chip.id === id));
+      if (target !== undefined) {
+        const openIndex = 1 + ladder.indexOf(target);
+        liveIndexRef.current = openIndex;
+        setBurstLeft(leftAt(openIndex));
+        setBurstKey((key) => key + 1);
+        onChange(target);
+      }
+      return;
+    }
+    armedAtRef.current = Date.now();
+    setArmed(true);
+    disarmTimerRef.current = setTimeout(() => {
+      disarmTimerRef.current = null;
+      armedAtRef.current = 0;
+      setArmed(false);
+    }, OVERTRAVEL_WINDOW);
+  }, [apexOpen, clearCollapseTimer, clearDisarmTimer, gatedRungs, hasGate, ladder, leftAt, onChange, row]);
 
   const fromPointer = useCallback((event: PointerEvent<HTMLDivElement>) => {
     const next = indexFromPointer(event.clientX);
@@ -161,7 +228,8 @@ export function EffortTrack({
     // 시작한 포인터만 끝낸다 — 다른 접촉의 up이 활성 제스처를 지우면 안 된다.
     if (!gesture || gesture.pointerId !== event.pointerId) return;
     gestureRef.current = null;
-    if (!confirm || gesture.dirty || !onConfirmCurrent) return;
+    // 오버트래블 제스처는 봉인을 미는 것이지 현재 단을 다시 누른 것이 아니다 — 확정 금지.
+    if (!confirm || gesture.dirty || gesture.overtravelled || !onConfirmCurrent) return;
     // 주버튼으로 트랙 안에서 손을 뗄 때만 확정한다 — 우클릭·가운데 클릭이나
     // 세로로 트랙 밖까지 끌어 뺀 해제는 값을 고르는 실수가 되지 않게 막는다.
     if (event.button !== 0) return;
@@ -192,6 +260,14 @@ export function EffortTrack({
         if (slots[i]!.selectable) { next = i; break; }
       }
     }
+    // 위쪽 방향키가 보이는 사다리 밖으로 나가는 것은 닫힌 게이트를 미는 것이다 —
+    // 포인터의 오버트래블과 같은 규칙(1회 저항, 창 안의 2회째 개방)을 탄다.
+    if (direction > 0 && next === null && hasGate && !apexOpen) {
+      event.preventDefault();
+      event.stopPropagation();
+      tryOvertravel();
+      return;
+    }
     if (event.key === "Home") next = 0;
     if (event.key === "End") next = nearestSelectable(last);
     if (event.key === "Enter" && onConfirmCurrent) {
@@ -205,15 +281,8 @@ export function EffortTrack({
     // 트랙은 메뉴 안에 산다. 방향키가 위로 새면 메뉴가 항목 이동으로 받아 함께 움직인다.
     event.stopPropagation();
     commit(next);
-  }, [commit, index, last, nearestSelectable, onConfirmCurrent, slots]);
+  }, [apexOpen, commit, hasGate, index, last, nearestSelectable, onConfirmCurrent, slots, tryOvertravel]);
 
-  const ratio = last === 0 ? 0 : index / last;
-  // 심은 열린 트랙의 슬롯 좌표로 둔다 — 전체 사다리 길이로 나누면 게이트 부분집합
-  // (max만 등)에서 심이 max/ultra 사이가 아니라 엉뚱한 자리에 선다.
-  const seamRatio = !apexOpen || last === 0 ? 0 : (ordinaryRungs.length + 0.5) / last;
-  // 닫힌 사다리(일상 단) 간격 폭을 열린 뒤에도 유지한다 — 스톱 수를 늘릴 때 트랙만
-  // 비례해 넓히고, 셸이 남는 폭을 트랙에 밀어 넣어 간격을 벌리지 않는다.
-  const closedIntervals = Math.max(ordinaryRungs.length, 1);
 
   return (
     <div className={`effort-track-shell${className ? ` ${className}` : ""}`}>
@@ -228,6 +297,7 @@ export function EffortTrack({
         aria-valuenow={index}
         aria-valuetext={isAuto ? autoValueText : current.label}
         data-apex-open={hasGate && apexOpen ? true : undefined}
+        data-armed={armed ? true : undefined}
         data-apex={isApex ? true : undefined}
         data-at-max={hasGate ? (isApex ? true : undefined) : (index === last && !isAuto ? true : undefined)}
         // 자동은 사다리의 최소 단이 아니라 "사다리를 쓰지 않음"이다. 파선 테두리·빈 손잡이·채움 0이
@@ -245,7 +315,12 @@ export function EffortTrack({
           event.preventDefault();
           event.currentTarget.setPointerCapture(event.pointerId);
           event.currentTarget.focus();
-          gestureRef.current = { pointerId: event.pointerId, originIndex: liveIndexRef.current, dirty: false };
+          const beyond = !apexOpen && hasGate && pointerBeyondEnd(event.clientX);
+          gestureRef.current = { pointerId: event.pointerId, originIndex: liveIndexRef.current, dirty: false, overtravelled: beyond };
+          if (beyond) {
+            tryOvertravel();
+            return;
+          }
           fromPointer(event);
         }}
         onPointerMove={(event) => {
@@ -254,6 +329,14 @@ export function EffortTrack({
           const gesture = gestureRef.current;
           if (!gesture || gesture.pointerId !== event.pointerId) return;
           if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
+          if (!apexOpen && hasGate && pointerBeyondEnd(event.clientX)) {
+            // 드래그로 끝 너머를 미는 것도 같은 오버트래블 규칙을 탄다 — 한 제스처당 1회만.
+            if (!gesture.overtravelled) {
+              gesture.overtravelled = true;
+              tryOvertravel();
+            }
+            return;
+          }
           fromPointer(event);
         }}
         onPointerUp={(event) => endGesture(event, { confirm: true })}
@@ -264,7 +347,7 @@ export function EffortTrack({
             비운 상태가 최소 강도를 고른 것처럼 보인다. */}
         <span
           className="effort-track-fill"
-          style={{ width: isAuto ? 0 : `calc(${EDGE}px + ${ratio} * (100% - ${EDGE * 2}px))` }}
+          style={{ width: isAuto ? 0 : leftAt(index) }}
           aria-hidden="true"
         />
         <span className="effort-track-stops" aria-hidden="true">
@@ -275,7 +358,7 @@ export function EffortTrack({
                 key={slot.id ?? "auto"}
                 className="effort-track-stop"
                 style={{
-                  left: last === 0 ? "50%" : `${(position / last) * 100}%`,
+                  left: `calc(var(--effort-track-gap) * ${position})`,
                   animationDelay: gatedIndex >= 0 ? `${(gatedIndex + 1) * 90}ms` : undefined,
                 }}
                 data-apex-rung={gatedIndex >= 0 ? true : undefined}
@@ -289,7 +372,7 @@ export function EffortTrack({
         {hasGate ? (
           <span
             className="effort-track-apex-seam"
-            style={{ left: `calc(${EDGE}px + ${seamRatio} * (100% - ${EDGE * 2}px))` }}
+            style={{ left: leftAt(ordinaryRungs.length + 0.5) }}
             aria-hidden="true"
           />
         ) : null}
@@ -304,47 +387,51 @@ export function EffortTrack({
         ) : null}
         <span
           className="effort-track-knob"
-          style={{ left: `calc(${EDGE}px + ${ratio} * (100% - ${EDGE * 2}px))` }}
+          style={{ left: leftAt(index) }}
           data-auto={isAuto ? true : undefined}
           aria-hidden="true"
         />
+        {hasGate ? (
+          // 게이트 장치는 트랙 밖 버튼이 아니라 트랙 우측 림 안쪽의 빛샘 캡이다 — 닫힌 동안
+          // 아펙스 빛이 새어 "봉인된 구획"을 암시하고, 클릭이 봉인을 연다. 열린 뒤에는 같은
+          // 캡이 ‹ 접힘 손잡이가 된다. apex 단이 선택된 채 접으면 일상 사다리의 마지막
+          // 고를 수 있는 단으로 내려, 숨은 apex 값을 제출하는 모순을 만들지 않는다.
+          <button
+            type="button"
+            className="effort-track-apex-cap"
+            aria-expanded={apexOpen}
+            aria-label={apexOpen ? apexCollapseLabel : apexToggleLabel}
+            title={apexOpen ? apexCollapseLabel : apexToggleLabel}
+            onPointerDown={(event) => event.stopPropagation()}
+            onClick={() => {
+              clearCollapseTimer();
+              clearDisarmTimer();
+              armedAtRef.current = 0;
+              setArmed(false);
+              if (!apexOpen) {
+                setApexOpen(true);
+                return;
+              }
+              if (isApex) {
+                const fallback = [...ordinaryRungs]
+                  .reverse()
+                  .find((id) => (row.chips ?? []).some((chip) => chip.id === id));
+                onChange(fallback ?? null);
+              }
+              setApexOpen(false);
+            }}
+          >‹</button>
+        ) : null}
       </div>
-      {hasGate && !apexOpen ? (
-        <button
-          type="button"
-          className="effort-track-apex-toggle"
-          aria-pressed={apexOpen}
-          aria-label={apexToggleLabel}
-          title={apexToggleLabel}
-          onClick={() => {
-            clearCollapseTimer();
-            setApexOpen(true);
-          }}
-        >✦</button>
-      ) : null}
-      {hasGate && apexOpen ? (
-        // 열림에서는 ✦가 사라지고 트랙이 그 자리까지 늘어난다 — 접힘은 이 얇은 셰브론이
-        // 맡는다. apex 단이 선택된 동안에도 셰브론은 남긴다: 접으면 일상 사다리의 마지막
-        // 고를 수 있는 단으로 내려, 숨은 apex 값을 제출하는 모순을 만들지 않는다.
-        <button
-          type="button"
-          className="effort-track-apex-collapse"
-          aria-label={apexCollapseLabel}
-          title={apexCollapseLabel}
-          onClick={() => {
-            clearCollapseTimer();
-            if (isApex) {
-              const fallback = [...ordinaryRungs]
-                .reverse()
-                .find((id) => (row.chips ?? []).some((chip) => chip.id === id));
-              onChange(fallback ?? null);
-            }
-            setApexOpen(false);
-          }}
-        >‹</button>
-      ) : null}
-      {/* 단계 톤은 CSS가 이 속성 하나로 읽는다 — 라벨 문자열은 번역·모델마다 달라 색의 기준이 될 수 없다. */}
-      <span className="effort-track-value" data-auto={isAuto} data-effort-level={current.id ?? "auto"}>
+      {/* 단계 톤은 CSS가 이 속성 하나로 읽는다 — 라벨 문자열은 번역·모델마다 달라 색의 기준이 될 수 없다.
+          data-apex는 게이트 뒤 티어의 라벨 모션 전용이다: 게이트 없는 모델의 최고 단(max)은 같은
+          data-effort-level이라도 정적 글로우에 머문다. */}
+      <span
+        className="effort-track-value"
+        data-auto={isAuto}
+        data-apex={isApex ? true : undefined}
+        data-effort-level={current.id ?? "auto"}
+      >
         {current.label}
       </span>
     </div>

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7854,102 +7854,50 @@
   50% { opacity: 0.95; transform: translateY(-50%) scale(1.1); }
 }
 
-/* 게이트 장치는 트랙 밖 버튼이 아니라 트랙 우측 림 안쪽의 캡이다. 닫힌 동안 아펙스 빛이
-   림 틈으로 새어 "봉인된 구획이 있다"를 상시 암시하고(호버가 강화), 클릭이 봉인을 연다.
-   열린 뒤에는 같은 캡이 ‹ 접힘 손잡이가 된다 — 외부 ✦ 버튼 시절의 마운트 교체(26px→18px)가
-   사라져 라벨 점프도 함께 사라진다. 시맨틱은 버튼 그대로라 접근성 표면은 변하지 않는다. */
-.effort-track-apex-cap {
-  position: absolute;
-  top: 1px;
-  bottom: 1px;
-  right: 1px;
-  width: 12px;
+/* 게이트 장치는 트랙 우측의 ✦ 토글이다. 닫힘·열림이 한 버튼의 두 상태라(마운트 교체 없음)
+   26px 자리가 늘 지켜지고, 게이트가 열려도 라벨이 밀리지 않는다 — 트랙의 픽셀 앵커와 같은
+   약속이다. 열린 상태는 테두리를 지운 ‹ 접힘 글리프로 시각 무게만 낮춘다. */
+.effort-track-apex-toggle {
+  flex: 0 0 26px;
+  width: 26px;
+  height: 26px;
   padding: 0;
-  border: none;
-  border-radius: 0 999px 999px 0;
+  border: 1px dashed color-mix(in oklch, var(--text-tertiary) 65%, transparent);
+  border-radius: 999px;
   background: transparent;
-  color: transparent;
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 11px;
   line-height: 1;
   cursor: pointer;
+  transition:
+    border-color var(--duration-base) var(--ease-spring),
+    border-style var(--duration-base) var(--ease-spring),
+    color var(--duration-base) var(--ease-spring),
+    box-shadow var(--duration-base) var(--ease-spring);
 }
 
-/* 림 안쪽의 봉인선 — 닫힌 동안의 유일한 정적 단서. */
-.effort-track-apex-cap::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 3px;
-  bottom: 3px;
-  width: 1px;
-  background: linear-gradient(to bottom, transparent, var(--apex) 35% 65%, transparent);
-  opacity: 0.5;
-  transition: opacity var(--duration-base) var(--ease-spring);
+.effort-track-apex-toggle:hover {
+  border-color: var(--apex);
+  border-style: solid;
+  color: var(--apex-ink);
+  box-shadow: var(--apex-halo);
 }
 
-/* 봉인 틈으로 새는 빛 — 3.2s 호흡. 신호가 아니라 티어 채널(apex)이다. */
-.effort-track-apex-cap::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: radial-gradient(10px 120% at 100% 50%, var(--apex-glow), transparent 70%);
-  animation: effort-apex-leak 3.2s ease-in-out infinite;
-}
-
-@keyframes effort-apex-leak {
-  0%, 100% { opacity: 0.55; }
-  50% { opacity: 1; }
-}
-
-.effort-track-apex-cap:hover::before {
-  opacity: 1;
-}
-
-.effort-track-apex-cap:hover::after {
-  animation: none;
-  opacity: 1;
-  background: radial-gradient(
-    14px 130% at 100% 50%,
-    color-mix(in oklch, var(--apex) 28%, transparent),
-    transparent 75%);
-}
-
-.effort-track-apex-cap:focus-visible {
+.effort-track-apex-toggle:focus-visible {
   outline: 2px solid var(--brass);
   outline-offset: 2px;
 }
 
-/* 열린 캡은 접힘 손잡이다 — 글리프가 드러나고 빛샘은 잦아든다. */
-.effort-track[data-apex-open="true"] .effort-track-apex-cap {
-  color: var(--text-tertiary);
-  transition: color var(--duration-fast) var(--ease-spring);
+.effort-track-apex-toggle[data-open="true"] {
+  border-color: transparent;
+  font-size: 13px;
 }
 
-.effort-track[data-apex-open="true"] .effort-track-apex-cap:hover {
+.effort-track-apex-toggle[data-open="true"]:hover {
+  border-color: transparent;
   color: var(--apex-ink);
-}
-
-.effort-track[data-apex-open="true"] .effort-track-apex-cap::after {
-  animation: none;
-  opacity: 0.35;
-}
-
-/* 오버트래블 — 끝 단 너머로 미는 첫 제스처는 트랙이 버틴다(러버밴드). 봉인선이 함께 밝아져
-   "여기가 잠겨 있다"를 답한다. 창 안의 두 번째 밀기는 TSX가 게이트를 연다. */
-.effort-track[data-armed="true"] {
-  animation: effort-track-overtravel 260ms ease-out 1;
-}
-
-.effort-track[data-armed="true"] .effort-track-apex-cap::before {
-  opacity: 1;
-}
-
-@keyframes effort-track-overtravel {
-  0% { transform: translateX(0); }
-  35% { transform: translateX(4px); }
-  100% { transform: translateX(0); }
+  box-shadow: none;
 }
 
 .effort-track-apex-seam {
@@ -8202,7 +8150,7 @@
 }
 
 /* 바 안에서는 자리를 정해 준다. 트랙 폭은 캔버스 추론강도 트랙과 같은 픽셀 앵커 규칙을
-   그대로 쓰고, 셸은 트랙(캡 포함)·라벨만 품는 max-content다. */
+   그대로 쓰고, 셸은 트랙·토글·라벨만 품는 max-content다. */
 .quick-launch-effort-track {
   flex: 0 0 auto;
   width: max-content;
@@ -8242,12 +8190,10 @@
     animation: none;
   }
 
-  /* 티어 모션 전부 정지 — 결·오로라·별·헤일로·빛샘·러버밴드는 정적 상태로 남는다. */
+  /* 티어 모션 전부 정지 — 결·오로라·별·헤일로는 정적 상태로 남는다. */
   .effort-track[data-apex="true"][data-effort-level="max"] .effort-track-fill::before,
   .effort-track[data-apex="true"][data-effort-level="max"] .effort-track-knob,
-  .effort-track[data-apex="true"][data-effort-level="ultra"] .effort-track-fill,
-  .effort-track-apex-cap::after,
-  .effort-track[data-armed="true"] {
+  .effort-track[data-apex="true"][data-effort-level="ultra"] .effort-track-fill {
     animation: none;
   }
 
@@ -8259,7 +8205,7 @@
 
   .effort-track,
   .effort-track-apex-seam,
-  .effort-track-apex-cap::before,
+  .effort-track-apex-toggle,
   .quick-launch-effort-track {
     transition: none;
   }
@@ -11889,7 +11835,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   .quick-launch-submit,
   .effort-track-apex-seam,
   .effort-track-stop[data-apex-rung="true"],
-  .effort-track-apex-cap,
+  .effort-track-apex-toggle,
   .quick-launch-effort-track,
   .effort-track-fill,
   .effort-track-knob,

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -11889,7 +11889,7 @@ body[data-codex-reading="true"] .operations-side-bar {
   .quick-launch-submit,
   .effort-track-apex-seam,
   .effort-track-stop[data-apex-rung="true"],
-  .effort-track-apex-toggle,
+  .effort-track-apex-cap,
   .quick-launch-effort-track,
   .effort-track-fill,
   .effort-track-knob,

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -7667,13 +7667,17 @@
 
 .effort-track {
   position: relative;
-  /* 남는 셸 폭을 먹어 스톱 간격을 벌리지 않는다 — 폭은 닫힌 간격×현재 구간 수.
-     Quick Launch와 캔버스 추론강도 트랙이 같은 값을 쓴다. */
+  /* 폭은 픽셀 앵커다: 크롬(패딩 26px + 테두리 2px) + 닫힌 간격 × 현재 구간 수. 게이트가 열려도
+     --effort-track-gap이 변하지 않아 기존 스톱·손잡이는 제자리에 남고 오른쪽 봉인만 늘어난다 —
+     예전의 폭 비례 확대(116 × last / 닫힌 구간)는 크롬까지 비례시켜 간격 자체를 벌렸다.
+     Quick Launch와 캔버스 추론강도 트랙이 같은 값을 쓰고, TSX의 픽셀 산술(EDGE·TRACK_CHROME)과
+     같은 상수여야 한다. */
   flex: 0 0 auto;
   --effort-closed-track-width: 116px;
   --effort-intervals: 1;
   --effort-closed-intervals: 1;
-  width: calc(var(--effort-closed-track-width) * var(--effort-intervals) / var(--effort-closed-intervals));
+  --effort-track-gap: calc((var(--effort-closed-track-width) - 28px) / var(--effort-closed-intervals));
+  width: calc(28px + var(--effort-track-gap) * var(--effort-intervals));
   height: 26px;
   padding: 0 13px;
   display: flex;
@@ -7754,12 +7758,37 @@
 }
 
 .effort-track[data-apex="true"][data-effort-level="max"] .effort-track-fill {
-  background:
-    repeating-linear-gradient(
-      115deg,
-      color-mix(in oklch, var(--text-on-brass) 9%, transparent) 0 1.5px,
-      transparent 1.5px 10px),
-    linear-gradient(90deg, var(--brass) 0%, var(--crest) 82%);
+  background: linear-gradient(90deg, var(--brass) 0%, var(--crest) 82%);
+}
+
+/* MAX의 결은 용융 금속처럼 손잡이 쪽으로 흐른다. 115° 스트라이프(주기 10px)의 수평 주기는
+   10px / sin(115°) ≈ 11.03px — 정확히 1주기를 옮겨 이음매 없이 순환하고, 왼쪽 12px 블리드가
+   이동분을 가린다. 정지 시(감속 모션) 결은 base 규칙 없이 이 레이어의 정적 상태로 남는다. */
+.effort-track[data-apex="true"][data-effort-level="max"] .effort-track-fill::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -12px;
+  right: 0;
+  background: repeating-linear-gradient(
+    115deg,
+    color-mix(in oklch, var(--text-on-brass) 9%, transparent) 0 1.5px,
+    transparent 1.5px 10px);
+  animation: effort-max-molten-drift 1.15s linear infinite;
+}
+
+@keyframes effort-max-molten-drift {
+  to { transform: translateX(11.03px); }
+}
+
+/* MAX의 광택 스윕은 공용 흰색이 아니라 구리빛으로 데워진다 — 라벨과 같은 열을 말한다. */
+.effort-track[data-apex="true"][data-effort-level="max"] .effort-track-fill::after {
+  background: linear-gradient(
+    100deg,
+    transparent 35%,
+    color-mix(in oklch, var(--crest) 45%, oklch(100% 0 0 / 30%)) 50%,
+    transparent 65%);
 }
 
 .effort-track[data-apex="true"][data-effort-level="ultra"] {
@@ -7769,72 +7798,158 @@
     0 0 22px -4px var(--apex-glow);
 }
 
+/* ULTRACODE의 채움은 오로라처럼 유영한다 — 넓은 그라데이션이 3.6s 왕복으로 흐르고 결은 정지. */
 .effort-track[data-apex="true"][data-effort-level="ultra"] .effort-track-fill {
   background:
     repeating-linear-gradient(
       115deg,
       color-mix(in oklch, var(--text-on-brass) 9%, transparent) 0 1.5px,
       transparent 1.5px 10px),
-    linear-gradient(90deg, var(--brass) 0%, var(--apex) 82%);
+    linear-gradient(
+      90deg,
+      var(--brass) 0%,
+      var(--apex) 40%,
+      color-mix(in oklch, var(--apex) 62%, white) 58%,
+      var(--apex) 76%,
+      color-mix(in oklch, var(--apex) 75%, var(--brass)) 100%);
+  background-size: 100% 100%, 180% 100%;
+  animation: effort-ultra-aurora-drift 3.6s ease-in-out infinite alternate;
 }
 
-.effort-track-apex-toggle {
-  flex: 0 0 26px;
-  width: 26px;
-  height: 26px;
+@keyframes effort-ultra-aurora-drift {
+  from { background-position: 0 0, 0% 0; }
+  to { background-position: 0 0, 100% 0; }
+}
+
+/* 이 티어의 흰 스윕은 별빛으로 대체된다 — 게이트 글리프 ✦가 위상이 다른 두 별로 반짝인다.
+   공용 스윕 규칙(data-at-max ::after)을 이 selector가 특이도로 덮는다. */
+.effort-track[data-apex="true"][data-effort-level="ultra"] .effort-track-fill::before,
+.effort-track[data-apex="true"][data-effort-level="ultra"] .effort-track-fill::after {
+  content: "✦";
+  position: absolute;
+  inset: auto;
+  top: 50%;
+  border-radius: 0;
+  background: none;
+  font-size: 7px;
+  line-height: 1;
+  color: color-mix(in oklch, var(--text-primary) 70%, var(--apex));
+  transform: translateY(-50%);
+  animation: effort-ultra-twinkle 2.3s ease-in-out infinite 0.4s;
+}
+
+.effort-track[data-apex="true"][data-effort-level="ultra"] .effort-track-fill::after {
+  right: 22%;
+}
+
+.effort-track[data-apex="true"][data-effort-level="ultra"] .effort-track-fill::before {
+  right: 45%;
+  font-size: 5px;
+  animation-duration: 3.1s;
+  animation-delay: 1.2s;
+}
+
+@keyframes effort-ultra-twinkle {
+  0%, 100% { opacity: 0; transform: translateY(-50%) scale(0.6); }
+  50% { opacity: 0.95; transform: translateY(-50%) scale(1.1); }
+}
+
+/* 게이트 장치는 트랙 밖 버튼이 아니라 트랙 우측 림 안쪽의 캡이다. 닫힌 동안 아펙스 빛이
+   림 틈으로 새어 "봉인된 구획이 있다"를 상시 암시하고(호버가 강화), 클릭이 봉인을 연다.
+   열린 뒤에는 같은 캡이 ‹ 접힘 손잡이가 된다 — 외부 ✦ 버튼 시절의 마운트 교체(26px→18px)가
+   사라져 라벨 점프도 함께 사라진다. 시맨틱은 버튼 그대로라 접근성 표면은 변하지 않는다. */
+.effort-track-apex-cap {
+  position: absolute;
+  top: 1px;
+  bottom: 1px;
+  right: 1px;
+  width: 12px;
   padding: 0;
-  border: 1px dashed color-mix(in oklch, var(--text-tertiary) 65%, transparent);
-  border-radius: 999px;
+  border: none;
+  border-radius: 0 999px 999px 0;
   background: transparent;
-  color: var(--text-tertiary);
+  color: transparent;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 12px;
   line-height: 1;
   cursor: pointer;
-  transition:
-    border-color var(--duration-base) var(--ease-spring),
-    border-style var(--duration-base) var(--ease-spring),
-    color var(--duration-base) var(--ease-spring),
-    box-shadow var(--duration-base) var(--ease-spring);
 }
 
-.effort-track-apex-toggle:hover,
-.effort-track-apex-toggle[aria-pressed="true"] {
-  border-color: var(--apex);
-  border-style: solid;
-  color: var(--apex-ink);
-  box-shadow: var(--apex-halo);
+/* 림 안쪽의 봉인선 — 닫힌 동안의 유일한 정적 단서. */
+.effort-track-apex-cap::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 3px;
+  bottom: 3px;
+  width: 1px;
+  background: linear-gradient(to bottom, transparent, var(--apex) 35% 65%, transparent);
+  opacity: 0.5;
+  transition: opacity var(--duration-base) var(--ease-spring);
 }
 
-.effort-track-apex-toggle:focus-visible {
+/* 봉인 틈으로 새는 빛 — 3.2s 호흡. 신호가 아니라 티어 채널(apex)이다. */
+.effort-track-apex-cap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(10px 120% at 100% 50%, var(--apex-glow), transparent 70%);
+  animation: effort-apex-leak 3.2s ease-in-out infinite;
+}
+
+@keyframes effort-apex-leak {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}
+
+.effort-track-apex-cap:hover::before {
+  opacity: 1;
+}
+
+.effort-track-apex-cap:hover::after {
+  animation: none;
+  opacity: 1;
+  background: radial-gradient(
+    14px 130% at 100% 50%,
+    color-mix(in oklch, var(--apex) 28%, transparent),
+    transparent 75%);
+}
+
+.effort-track-apex-cap:focus-visible {
   outline: 2px solid var(--brass);
   outline-offset: 2px;
 }
 
-/* 열린 동안 ✦를 대신하는 접힘 컨트롤 — 게이트는 한 번 열리면 트랙이 그 자리를 물려받아
-   늘어나므로, 닫기 장치는 시각 무게를 거의 갖지 않는 얇은 셰브론이다. */
-.effort-track-apex-collapse {
-  flex: 0 0 18px;
-  width: 18px;
-  height: 26px;
-  padding: 0;
-  border: none;
-  background: transparent;
+/* 열린 캡은 접힘 손잡이다 — 글리프가 드러나고 빛샘은 잦아든다. */
+.effort-track[data-apex-open="true"] .effort-track-apex-cap {
   color: var(--text-tertiary);
-  font-family: var(--font-mono);
-  font-size: 13px;
-  line-height: 1;
-  cursor: pointer;
   transition: color var(--duration-fast) var(--ease-spring);
 }
 
-.effort-track-apex-collapse:hover {
+.effort-track[data-apex-open="true"] .effort-track-apex-cap:hover {
   color: var(--apex-ink);
 }
 
-.effort-track-apex-collapse:focus-visible {
-  outline: 2px solid var(--brass);
-  outline-offset: 2px;
+.effort-track[data-apex-open="true"] .effort-track-apex-cap::after {
+  animation: none;
+  opacity: 0.35;
+}
+
+/* 오버트래블 — 끝 단 너머로 미는 첫 제스처는 트랙이 버틴다(러버밴드). 봉인선이 함께 밝아져
+   "여기가 잠겨 있다"를 답한다. 창 안의 두 번째 밀기는 TSX가 게이트를 연다. */
+.effort-track[data-armed="true"] {
+  animation: effort-track-overtravel 260ms ease-out 1;
+}
+
+.effort-track[data-armed="true"] .effort-track-apex-cap::before {
+  opacity: 1;
+}
+
+@keyframes effort-track-overtravel {
+  0% { transform: translateX(0); }
+  35% { transform: translateX(4px); }
+  100% { transform: translateX(0); }
 }
 
 .effort-track-apex-seam {
@@ -7952,6 +8067,24 @@
     0 0 0 2.5px var(--crest),
     var(--crest-halo),
     0 1px 3px oklch(0% 0 0 / 55%);
+  /* 헤일로가 2.2s로 숨쉰다 — 감속 모션에서는 animation만 꺼져 위의 정적 링이 남는다. */
+  animation: effort-max-crest-breathe 2.2s ease-in-out infinite;
+}
+
+@keyframes effort-max-crest-breathe {
+  0%, 100% {
+    box-shadow:
+      0 0 0 2.5px var(--crest),
+      0 0 10px var(--crest-glow),
+      0 1px 3px oklch(0% 0 0 / 55%);
+  }
+
+  50% {
+    box-shadow:
+      0 0 0 2.5px var(--crest),
+      0 0 22px var(--crest-glow),
+      0 1px 3px oklch(0% 0 0 / 55%);
+  }
 }
 
 .effort-track[data-apex="true"][data-effort-level="ultra"] .effort-track-knob {
@@ -7986,6 +8119,44 @@
 .effort-track-value[data-effort-level="max"] {
   font-weight: var(--weight-medium);
   text-shadow: 0 0 12px var(--crest-glow);
+}
+
+/* 게이트 뒤의 MAX — 용융 구리가 글자 위를 흐르고(웨이브 2.1s) 광량이 불규칙하게 맥동한다
+   (플리커 1.7s). 두 주기가 달라 결합 위상은 35.7s마다 돌아온다 — 루프가 보이지 않는 "이글거림".
+   data-apex 없는 max(게이트 없는 모델의 최고 단)는 위의 정적 글로우에 머문다. */
+.effort-track-value[data-apex="true"][data-effort-level="max"] {
+  background-image: linear-gradient(
+    100deg,
+    var(--crest-ink) 0%,
+    color-mix(in oklch, var(--crest) 45%, white) 14%,
+    var(--crest-ink) 30%,
+    color-mix(in oklch, var(--crest) 60%, var(--brass)) 52%,
+    color-mix(in oklch, var(--crest) 40%, white) 72%,
+    var(--crest-ink) 100%
+  );
+  background-size: 220% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  text-shadow: none;
+  animation:
+    effort-max-ember-wave 2.1s linear infinite,
+    effort-max-ember-flicker 1.7s linear infinite;
+}
+
+@keyframes effort-max-ember-wave {
+  to { background-position: -220% 0; }
+}
+
+@keyframes effort-max-ember-flicker {
+  0%, 100% { filter: drop-shadow(0 0 3px var(--crest-glow)) brightness(1); }
+  9% { filter: drop-shadow(0 0 8px var(--crest-glow)) brightness(1.18); }
+  23% { filter: drop-shadow(0 0 2px var(--crest-glow)) brightness(0.96); }
+  36% { filter: drop-shadow(0 0 6px var(--crest-glow)) brightness(1.12); }
+  51% { filter: drop-shadow(0 0 3px var(--crest-glow)) brightness(1.02); }
+  62% { filter: drop-shadow(0 0 9px var(--crest-glow)) brightness(1.22); }
+  78% { filter: drop-shadow(0 0 2px var(--crest-glow)) brightness(0.98); }
+  88% { filter: drop-shadow(0 0 6px var(--crest-glow)) brightness(1.1); }
 }
 
 /* ULTRACODE — 그라데이션이 글자를 가로질러 흘러 물결처럼 읽힌다. */
@@ -8030,8 +8201,8 @@
   transition: color var(--duration-fast) var(--ease-spring);
 }
 
-/* 바 안에서는 자리를 정해 준다. 트랙 폭은 캔버스 추론강도 트랙과 같은 116px 비례 규칙을
-   그대로 쓰고, 셸은 트랙·토글·라벨만 품는 max-content다. */
+/* 바 안에서는 자리를 정해 준다. 트랙 폭은 캔버스 추론강도 트랙과 같은 픽셀 앵커 규칙을
+   그대로 쓰고, 셸은 트랙(캡 포함)·라벨만 품는 max-content다. */
 .quick-launch-effort-track {
   flex: 0 0 auto;
   width: max-content;
@@ -8057,13 +8228,38 @@
     color: var(--apex-ink);
   }
 
+  /* 게이트 뒤 MAX 라벨은 정적 crest 글로우로 돌아간다 — 게이트 없는 max와 같은 모습. */
+  .effort-track-value[data-apex="true"][data-effort-level="max"] {
+    animation: none;
+    background-image: none;
+    -webkit-background-clip: unset;
+    background-clip: unset;
+    color: var(--crest-ink);
+    text-shadow: 0 0 12px var(--crest-glow);
+  }
+
   .effort-track-stop[data-apex-rung="true"] {
     animation: none;
   }
 
+  /* 티어 모션 전부 정지 — 결·오로라·별·헤일로·빛샘·러버밴드는 정적 상태로 남는다. */
+  .effort-track[data-apex="true"][data-effort-level="max"] .effort-track-fill::before,
+  .effort-track[data-apex="true"][data-effort-level="max"] .effort-track-knob,
+  .effort-track[data-apex="true"][data-effort-level="ultra"] .effort-track-fill,
+  .effort-track-apex-cap::after,
+  .effort-track[data-armed="true"] {
+    animation: none;
+  }
+
+  .effort-track[data-apex="true"][data-effort-level="ultra"] .effort-track-fill::before,
+  .effort-track[data-apex="true"][data-effort-level="ultra"] .effort-track-fill::after {
+    animation: none;
+    opacity: 0.6;
+  }
+
   .effort-track,
   .effort-track-apex-seam,
-  .effort-track-apex-toggle,
+  .effort-track-apex-cap::before,
   .quick-launch-effort-track {
     transition: none;
   }

--- a/runtime/fleet-console/tests/effort-track.test.tsx
+++ b/runtime/fleet-console/tests/effort-track.test.tsx
@@ -333,29 +333,30 @@ describe("EffortTrack", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it("hides gated stops behind the apex cap", () => {
+  it("hides gated stops behind the apex toggle", () => {
     render(row({ gatedEfforts: ["max", "ultra"] }), "high");
 
-    // 게이트 장치는 트랙 밖 버튼이 아니라 트랙 우측 림 안쪽의 빛샘 캡이다.
-    const cap = required(".effort-track-apex-cap");
-    expect(cap.getAttribute("aria-expanded")).toBe("false");
-    expect(cap.getAttribute("aria-label")).toBe("Show Max and Ultracode");
+    const toggle = required(".effort-track-apex-toggle");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(toggle.getAttribute("aria-label")).toBe("Show Max and Ultracode");
+    expect(toggle.textContent).toBe("✦");
     expect(stops()).toHaveLength(5);
     expect(document.querySelector("[data-apex-rung=true]")).toBeNull();
     expect(track().getAttribute("aria-valuemax")).toBe("4");
   });
 
-  it("reveals gated stops and extends the slider range when the cap is pressed", () => {
+  it("reveals gated stops and extends the slider range when toggled", () => {
     render(row({
       effortAxis: [...AXIS, "ultra"],
       chips: [...row().chips!, { id: "ultra", label: "ULTRA", launch: { model: "kimi--k3", effort: "ultra" } }],
       gatedEfforts: ["max", "ultra"],
     }), "high");
 
-    act(() => required(".effort-track-apex-cap").click());
-    // 같은 캡이 접힘 손잡이가 된다 — 마운트 교체가 없어 라벨이 점프하지 않는다.
-    expect(required(".effort-track-apex-cap").getAttribute("aria-expanded")).toBe("true");
-    expect(required(".effort-track-apex-cap").getAttribute("aria-label")).toBe("Hide Max and Ultracode");
+    act(() => required(".effort-track-apex-toggle").click());
+    // 같은 버튼이 ‹ 접힘 상태가 된다 — 마운트 교체가 없어 26px 자리가 지켜지고 라벨이 밀리지 않는다.
+    expect(required(".effort-track-apex-toggle").getAttribute("aria-expanded")).toBe("true");
+    expect(required(".effort-track-apex-toggle").getAttribute("aria-label")).toBe("Hide Max and Ultracode");
+    expect(required(".effort-track-apex-toggle").textContent).toBe("‹");
     expect(document.querySelectorAll("[data-apex-rung=true]")).toHaveLength(2);
     expect(track().getAttribute("aria-valuemax")).toBe("6");
     // 열린 뒤에도 닫힌 사다리 간격을 그대로 쓴다 — CSS 폭 공식이 이 두 값에서 간격을 만든다.
@@ -367,7 +368,7 @@ describe("EffortTrack", () => {
     render(row({ gatedEfforts: ["max"] }), "high");
 
     const closedAnchors = stops().map((mark) => mark.style.left);
-    act(() => required(".effort-track-apex-cap").click());
+    act(() => required(".effort-track-apex-toggle").click());
     // 픽셀 앵커의 요지: 열림이 기존 스톱의 좌표 문자열을 한 글자도 바꾸지 않는다.
     expect(stops().slice(0, closedAnchors.length).map((mark) => mark.style.left)).toEqual(closedAnchors);
   });
@@ -375,7 +376,7 @@ describe("EffortTrack", () => {
   it("marks a selected gated rung as apex and maximum", () => {
     const gatedRow = row({ gatedEfforts: ["max"] });
     const onChange = render(gatedRow, "xhigh");
-    act(() => required(".effort-track-apex-cap").click());
+    act(() => required(".effort-track-apex-toggle").click());
     act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true })));
     expect(onChange).toHaveBeenLastCalledWith("max");
 
@@ -404,23 +405,23 @@ describe("EffortTrack", () => {
     render(row({ gatedEfforts: ["max"] }), "max");
 
     expect(track().dataset.apexOpen).toBe("true");
-    // apex 값이 선택된 동안에도 캡은 접힘 손잡이로 남는다 — 접으면 일상 단으로 내려
+    // apex 값이 선택된 동안에도 토글은 접힘 상태로 남는다 — 접으면 일상 단으로 내려
     // 숨은 apex 제출 모순을 만들지 않는다.
-    expect(required(".effort-track-apex-cap").getAttribute("aria-expanded")).toBe("true");
-    expect(required(".effort-track-apex-cap").getAttribute("aria-label")).toBe("Hide Max and Ultracode");
+    expect(required(".effort-track-apex-toggle").getAttribute("aria-expanded")).toBe("true");
+    expect(required(".effort-track-apex-toggle").getAttribute("aria-label")).toBe("Hide Max and Ultracode");
     expect(document.querySelectorAll("[data-apex-rung=true]")).toHaveLength(1);
   });
 
   it("demotes a gated value to the last ordinary rung when collapsed", () => {
     const onChange = render(row({ gatedEfforts: ["max"] }), "max");
-    act(() => required(".effort-track-apex-cap").click());
+    act(() => required(".effort-track-apex-toggle").click());
     // 이 모델의 일상 사다리에서 고를 수 있는 마지막 단은 high다(xhigh는 gap).
     expect(onChange).toHaveBeenLastCalledWith("high");
   });
 
   it("places the apex seam between ordinary and gated stops when only max is gated", () => {
     render(row({ gatedEfforts: ["max"] }), "xhigh");
-    act(() => required(".effort-track-apex-cap").click());
+    act(() => required(".effort-track-apex-toggle").click());
 
     // auto + low/med/high/xhigh + max → ordinary 4단 → 심은 4.5번째 간격 위에 선다.
     expect(track().getAttribute("aria-valuemax")).toBe("5");
@@ -432,67 +433,11 @@ describe("EffortTrack", () => {
   it("preserves the gate-free rendering contract", () => {
     render(row(), "high");
 
-    expect(document.querySelector(".effort-track-apex-cap")).toBeNull();
+    expect(document.querySelector(".effort-track-apex-toggle")).toBeNull();
     expect(document.querySelector(".effort-track-apex-seam")).toBeNull();
     expect(track().dataset.apexOpen).toBeUndefined();
     expect(track().dataset.apex).toBeUndefined();
     expect(stops()).toHaveLength(6);
-  });
-
-  it("arms on the first push past the ladder and opens on the second", () => {
-    const gatedRow = row({ gatedEfforts: ["max"] });
-    const onChange = render(gatedRow, "high");
-
-    // 끝 단(high)에서 →: 보이는 사다리 밖 = 닫힌 게이트를 미는 것. 첫 밀기는 저항만 한다.
-    act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })));
-    expect(onChange).not.toHaveBeenCalled();
-    expect(track().dataset.armed).toBe("true");
-    expect(track().dataset.apexOpen).toBeUndefined();
-
-    // 창 안의 두 번째 밀기 — 봉인이 풀리고 민 방향 그대로 첫 게이트 단에 올라선다.
-    act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })));
-    expect(onChange).toHaveBeenLastCalledWith("max");
-    expect(track().dataset.apexOpen).toBe("true");
-  });
-
-  it("disarms when the overtravel window lapses", () => {
-    vi.useFakeTimers();
-    const gatedRow = row({ gatedEfforts: ["max"] });
-    const onChange = render(gatedRow, "high");
-
-    act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })));
-    expect(track().dataset.armed).toBe("true");
-    act(() => vi.advanceTimersByTime(900));
-    expect(track().dataset.armed).toBeUndefined();
-
-    // 창이 지난 뒤의 밀기는 다시 저항이다 — 오래전 밀기가 게이트를 열어 두지 않는다.
-    act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })));
-    expect(onChange).not.toHaveBeenCalled();
-    expect(track().dataset.apexOpen).toBeUndefined();
-  });
-
-  it("treats a pointer push past the ladder as overtravel, never as confirm", () => {
-    const onChange = vi.fn();
-    const onConfirmCurrent = vi.fn();
-    render(row({ gatedEfforts: ["max"] }), "high", onChange, onConfirmCurrent);
-    const element = stubTrackPointer();
-
-    // gap 22px(=88/4) 기준 last(4) 너머: x=130 → round((130-13)/22)=5 > 4.
-    act(() => {
-      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 130, clientY: 13 }));
-      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 130, clientY: 13 }));
-    });
-    expect(track().dataset.armed).toBe("true");
-    expect(onChange).not.toHaveBeenCalled();
-    // 봉인을 민 제스처는 현재 단 재클릭이 아니다 — 확정 금지.
-    expect(onConfirmCurrent).not.toHaveBeenCalled();
-
-    act(() => {
-      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 2, button: 0, isPrimary: true, clientX: 130, clientY: 13 }));
-      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 2, button: 0, isPrimary: true, clientX: 130, clientY: 13 }));
-    });
-    expect(onChange).toHaveBeenLastCalledWith("max");
-    expect(onConfirmCurrent).not.toHaveBeenCalled();
   });
 });
 

--- a/runtime/fleet-console/tests/effort-track.test.tsx
+++ b/runtime/fleet-console/tests/effort-track.test.tsx
@@ -115,10 +115,11 @@ describe("EffortTrack", () => {
 
     // AUTO + 5단 축. low/high/max만 고를 수 있고 medium·xhigh는 자리만 지킨다 —
     // 셋을 균등히 벌리면 high가 한가운데 서서 3/5 지점인 단을 절반이라고 말하게 된다.
+    // 좌표는 %가 아니라 픽셀 앵커다: 게이트가 열려 슬롯 수가 바뀌어도 %처럼 점프하지 않는다.
     const marks = stops();
     expect(marks).toHaveLength(6);
     expect(marks.map((mark) => mark.dataset.gap ?? null)).toEqual([null, null, "true", null, "true", null]);
-    expect(marks[3]!.style.left).toBe("60%");
+    expect(marks[3]!.style.left).toBe("calc(var(--effort-track-gap) * 3)");
   });
 
   it("falls back to the offered rungs when the row carries no axis", () => {
@@ -246,7 +247,8 @@ describe("EffortTrack", () => {
     render(row(), "high", onChange, onConfirmCurrent);
     const element = stubTrackPointer();
 
-    // high(3) 자리: EDGE 13 + 0.6 × (126 − 26) = 73. 같은 단을 다시 누르면 값이 아니라 확정이다.
+    // high(3) 자리: EDGE 13 + 간격 17.6px(=88/5) × 3 ≈ 66 — 73은 round로 같은 3에 떨어진다.
+    // 같은 단을 다시 누르면 값이 아니라 확정이다.
     act(() => {
       element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 73, clientY: 13 }));
       element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 73, clientY: 13 }));
@@ -331,39 +333,49 @@ describe("EffortTrack", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it("hides gated stops behind the apex toggle", () => {
+  it("hides gated stops behind the apex cap", () => {
     render(row({ gatedEfforts: ["max", "ultra"] }), "high");
 
-    const toggle = required(".effort-track-apex-toggle");
-    expect(toggle.getAttribute("aria-pressed")).toBe("false");
-    expect(toggle.getAttribute("aria-label")).toBe("Show Max and Ultracode");
+    // 게이트 장치는 트랙 밖 버튼이 아니라 트랙 우측 림 안쪽의 빛샘 캡이다.
+    const cap = required(".effort-track-apex-cap");
+    expect(cap.getAttribute("aria-expanded")).toBe("false");
+    expect(cap.getAttribute("aria-label")).toBe("Show Max and Ultracode");
     expect(stops()).toHaveLength(5);
     expect(document.querySelector("[data-apex-rung=true]")).toBeNull();
     expect(track().getAttribute("aria-valuemax")).toBe("4");
   });
 
-  it("reveals gated stops and extends the slider range when toggled", () => {
+  it("reveals gated stops and extends the slider range when the cap is pressed", () => {
     render(row({
       effortAxis: [...AXIS, "ultra"],
       chips: [...row().chips!, { id: "ultra", label: "ULTRA", launch: { model: "kimi--k3", effort: "ultra" } }],
       gatedEfforts: ["max", "ultra"],
     }), "high");
 
-    act(() => required(".effort-track-apex-toggle").click());
-    // 열리면 ✦는 사라지고 그 자리를 트랙이 물려받는다 — 접힘은 얇은 셰브론이 맡는다.
-    expect(document.querySelector(".effort-track-apex-toggle")).toBeNull();
-    expect(required(".effort-track-apex-collapse").getAttribute("aria-label")).toBe("Hide Max and Ultracode");
+    act(() => required(".effort-track-apex-cap").click());
+    // 같은 캡이 접힘 손잡이가 된다 — 마운트 교체가 없어 라벨이 점프하지 않는다.
+    expect(required(".effort-track-apex-cap").getAttribute("aria-expanded")).toBe("true");
+    expect(required(".effort-track-apex-cap").getAttribute("aria-label")).toBe("Hide Max and Ultracode");
     expect(document.querySelectorAll("[data-apex-rung=true]")).toHaveLength(2);
     expect(track().getAttribute("aria-valuemax")).toBe("6");
-    // 열린 뒤에도 닫힌 사다리 간격 비율을 유지한다 — 셸 여분을 트랙이 먹어 간격을 벌리지 않는다.
+    // 열린 뒤에도 닫힌 사다리 간격을 그대로 쓴다 — CSS 폭 공식이 이 두 값에서 간격을 만든다.
     expect(track().style.getPropertyValue("--effort-intervals")).toBe("6");
     expect(track().style.getPropertyValue("--effort-closed-intervals")).toBe("4");
+  });
+
+  it("keeps ordinary stop anchors identical while the gate opens", () => {
+    render(row({ gatedEfforts: ["max"] }), "high");
+
+    const closedAnchors = stops().map((mark) => mark.style.left);
+    act(() => required(".effort-track-apex-cap").click());
+    // 픽셀 앵커의 요지: 열림이 기존 스톱의 좌표 문자열을 한 글자도 바꾸지 않는다.
+    expect(stops().slice(0, closedAnchors.length).map((mark) => mark.style.left)).toEqual(closedAnchors);
   });
 
   it("marks a selected gated rung as apex and maximum", () => {
     const gatedRow = row({ gatedEfforts: ["max"] });
     const onChange = render(gatedRow, "xhigh");
-    act(() => required(".effort-track-apex-toggle").click());
+    act(() => required(".effort-track-apex-cap").click());
     act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true })));
     expect(onChange).toHaveBeenLastCalledWith("max");
 
@@ -392,27 +404,27 @@ describe("EffortTrack", () => {
     render(row({ gatedEfforts: ["max"] }), "max");
 
     expect(track().dataset.apexOpen).toBe("true");
-    expect(document.querySelector(".effort-track-apex-toggle")).toBeNull();
-    // apex 값이 선택된 동안에도 접힘 셰브론은 남는다 — 접으면 일상 단으로 내려
+    // apex 값이 선택된 동안에도 캡은 접힘 손잡이로 남는다 — 접으면 일상 단으로 내려
     // 숨은 apex 제출 모순을 만들지 않는다.
-    expect(required(".effort-track-apex-collapse").getAttribute("aria-label")).toBe("Hide Max and Ultracode");
+    expect(required(".effort-track-apex-cap").getAttribute("aria-expanded")).toBe("true");
+    expect(required(".effort-track-apex-cap").getAttribute("aria-label")).toBe("Hide Max and Ultracode");
     expect(document.querySelectorAll("[data-apex-rung=true]")).toHaveLength(1);
   });
 
   it("demotes a gated value to the last ordinary rung when collapsed", () => {
     const onChange = render(row({ gatedEfforts: ["max"] }), "max");
-    act(() => required(".effort-track-apex-collapse").click());
+    act(() => required(".effort-track-apex-cap").click());
     // 이 모델의 일상 사다리에서 고를 수 있는 마지막 단은 high다(xhigh는 gap).
     expect(onChange).toHaveBeenLastCalledWith("high");
   });
 
   it("places the apex seam between ordinary and gated stops when only max is gated", () => {
     render(row({ gatedEfforts: ["max"] }), "xhigh");
-    act(() => required(".effort-track-apex-toggle").click());
+    act(() => required(".effort-track-apex-cap").click());
 
-    // auto + low/med/high/xhigh + max → last=5, ordinary=4 → seam at 4.5/5 = 0.9.
+    // auto + low/med/high/xhigh + max → ordinary 4단 → 심은 4.5번째 간격 위에 선다.
     expect(track().getAttribute("aria-valuemax")).toBe("5");
-    expect(required(".effort-track-apex-seam").style.left).toContain("0.9");
+    expect(required(".effort-track-apex-seam").style.left).toBe("calc(13px + var(--effort-track-gap) * 4.5)");
     expect(document.querySelectorAll("[data-apex-rung=true]")).toHaveLength(1);
     expect(stops()).toHaveLength(6);
   });
@@ -420,11 +432,67 @@ describe("EffortTrack", () => {
   it("preserves the gate-free rendering contract", () => {
     render(row(), "high");
 
-    expect(document.querySelector(".effort-track-apex-toggle")).toBeNull();
+    expect(document.querySelector(".effort-track-apex-cap")).toBeNull();
     expect(document.querySelector(".effort-track-apex-seam")).toBeNull();
     expect(track().dataset.apexOpen).toBeUndefined();
     expect(track().dataset.apex).toBeUndefined();
     expect(stops()).toHaveLength(6);
+  });
+
+  it("arms on the first push past the ladder and opens on the second", () => {
+    const gatedRow = row({ gatedEfforts: ["max"] });
+    const onChange = render(gatedRow, "high");
+
+    // 끝 단(high)에서 →: 보이는 사다리 밖 = 닫힌 게이트를 미는 것. 첫 밀기는 저항만 한다.
+    act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(track().dataset.armed).toBe("true");
+    expect(track().dataset.apexOpen).toBeUndefined();
+
+    // 창 안의 두 번째 밀기 — 봉인이 풀리고 민 방향 그대로 첫 게이트 단에 올라선다.
+    act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })));
+    expect(onChange).toHaveBeenLastCalledWith("max");
+    expect(track().dataset.apexOpen).toBe("true");
+  });
+
+  it("disarms when the overtravel window lapses", () => {
+    vi.useFakeTimers();
+    const gatedRow = row({ gatedEfforts: ["max"] });
+    const onChange = render(gatedRow, "high");
+
+    act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })));
+    expect(track().dataset.armed).toBe("true");
+    act(() => vi.advanceTimersByTime(900));
+    expect(track().dataset.armed).toBeUndefined();
+
+    // 창이 지난 뒤의 밀기는 다시 저항이다 — 오래전 밀기가 게이트를 열어 두지 않는다.
+    act(() => track().dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(track().dataset.apexOpen).toBeUndefined();
+  });
+
+  it("treats a pointer push past the ladder as overtravel, never as confirm", () => {
+    const onChange = vi.fn();
+    const onConfirmCurrent = vi.fn();
+    render(row({ gatedEfforts: ["max"] }), "high", onChange, onConfirmCurrent);
+    const element = stubTrackPointer();
+
+    // gap 22px(=88/4) 기준 last(4) 너머: x=130 → round((130-13)/22)=5 > 4.
+    act(() => {
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 130, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, button: 0, isPrimary: true, clientX: 130, clientY: 13 }));
+    });
+    expect(track().dataset.armed).toBe("true");
+    expect(onChange).not.toHaveBeenCalled();
+    // 봉인을 민 제스처는 현재 단 재클릭이 아니다 — 확정 금지.
+    expect(onConfirmCurrent).not.toHaveBeenCalled();
+
+    act(() => {
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 2, button: 0, isPrimary: true, clientX: 130, clientY: 13 }));
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 2, button: 0, isPrimary: true, clientX: 130, clientY: 13 }));
+    });
+    expect(onChange).toHaveBeenLastCalledWith("max");
+    expect(onConfirmCurrent).not.toHaveBeenCalled();
   });
 });
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1739,6 +1739,48 @@ describe("Effort track interaction grammar", () => {
     expect(components).toMatch(/\.effort-track-apex-burst \{\s*animation: none;\s*\}/);
     expect(components).toMatch(/effort-ultracode-wave/);
     expect(components).toMatch(/\.effort-track-value\[data-effort-level="ultra"\] \{\s*animation: none;/);
+
+    // 티어 모션은 전부 티어 채널(crest/apex) 안에서만 놀고, 감속 모션에서 정적 상태로 남는다.
+    for (const keyframes of [
+      "effort-max-ember-wave",
+      "effort-max-ember-flicker",
+      "effort-max-molten-drift",
+      "effort-max-crest-breathe",
+      "effort-ultra-aurora-drift",
+      "effort-ultra-twinkle",
+      "effort-apex-leak",
+      "effort-track-overtravel",
+    ]) {
+      expect(components).toContain(`@keyframes ${keyframes}`);
+    }
+    // 게이트 뒤 MAX 라벨(엠버)은 감속 모션에서 정적 crest 글로우로 돌아간다 —
+    // 게이트 없는 max 라벨과 같은 모습이 되는 것이 계약이다.
+    expect(components).toMatch(/\.effort-track-value\[data-apex="true"\]\[data-effort-level="max"\] \{\s*animation: none;/);
+    expect(components).toMatch(/@media \(prefers-reduced-motion: reduce\)[\s\S]*\.effort-track\[data-apex="true"\]\[data-effort-level="ultra"\] \.effort-track-fill,[\s\S]*\.effort-track\[data-armed="true"\] \{\s*animation: none;/);
+  });
+
+  it("pins the in-track apex cap and the pixel-anchored gap", () => {
+    const components = source("styles/components.css");
+    const trackSource = source("components/effort-track.tsx");
+
+    // 게이트 장치는 트랙 안 캡이다 — 외부 토글/셰브론 문법은 되돌아오면 안 된다(마운트 교체가
+    // 라벨을 8px 점프시키던 원인). 버튼 시맨틱과 개방 상태는 aria로 남는다.
+    expect(components).toContain(".effort-track-apex-cap");
+    expect(components).not.toContain("effort-track-apex-toggle");
+    expect(components).not.toContain("effort-track-apex-collapse");
+    expect(trackSource).toContain('className="effort-track-apex-cap"');
+    expect(trackSource).not.toContain("effort-track-apex-toggle");
+    expect(trackSource).toContain("aria-expanded={apexOpen}");
+
+    // 폭과 모든 좌표가 한 간격 변수를 공유한다 — 게이트가 열려도 기존 스톱·손잡이가 움직이지
+    // 않는 픽셀 앵커의 근거. 크롬 28px = 패딩 26px + 1px 테두리 둘(border-box).
+    expect(components).toContain("--effort-track-gap: calc((var(--effort-closed-track-width) - 28px) / var(--effort-closed-intervals));");
+    expect(components).toContain("width: calc(28px + var(--effort-track-gap) * var(--effort-intervals));");
+    expect(trackSource).toContain("var(--effort-track-gap)");
+
+    // 스윕의 티어 분화: MAX는 구리빛 스윕, ULTRACODE는 스윕 대신 ✦ 별빛.
+    expect(components).toMatch(/data-effort-level="max"\] \.effort-track-fill::after \{[^}]*var\(--crest\)/);
+    expect(components).toMatch(/data-effort-level="ultra"\] \.effort-track-fill::before,[\s\S]{0,120}::after \{[^}]*content: "✦"/);
   });
 
   it("pins the shared effort track's pointer preview motion", () => {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1748,28 +1748,25 @@ describe("Effort track interaction grammar", () => {
       "effort-max-crest-breathe",
       "effort-ultra-aurora-drift",
       "effort-ultra-twinkle",
-      "effort-apex-leak",
-      "effort-track-overtravel",
     ]) {
       expect(components).toContain(`@keyframes ${keyframes}`);
     }
     // 게이트 뒤 MAX 라벨(엠버)은 감속 모션에서 정적 crest 글로우로 돌아간다 —
     // 게이트 없는 max 라벨과 같은 모습이 되는 것이 계약이다.
     expect(components).toMatch(/\.effort-track-value\[data-apex="true"\]\[data-effort-level="max"\] \{\s*animation: none;/);
-    expect(components).toMatch(/@media \(prefers-reduced-motion: reduce\)[\s\S]*\.effort-track\[data-apex="true"\]\[data-effort-level="ultra"\] \.effort-track-fill,[\s\S]*\.effort-track\[data-armed="true"\] \{\s*animation: none;/);
+    expect(components).toMatch(/@media \(prefers-reduced-motion: reduce\)[\s\S]*\.effort-track\[data-apex="true"\]\[data-effort-level="ultra"\] \.effort-track-fill \{\s*animation: none;/);
   });
 
-  it("pins the in-track apex cap and the pixel-anchored gap", () => {
+  it("pins the persistent apex toggle and the pixel-anchored gap", () => {
     const components = source("styles/components.css");
     const trackSource = source("components/effort-track.tsx");
 
-    // 게이트 장치는 트랙 안 캡이다 — 외부 토글/셰브론 문법은 되돌아오면 안 된다(마운트 교체가
-    // 라벨을 8px 점프시키던 원인). 버튼 시맨틱과 개방 상태는 aria로 남는다.
-    expect(components).toContain(".effort-track-apex-cap");
-    expect(components).not.toContain("effort-track-apex-toggle");
+    // 게이트 장치는 트랙 우측의 ✦ 토글 하나다. 닫힘·열림이 같은 26px 버튼의 두 상태라
+    // 마운트 교체(26px→18px)가 없고, 게이트가 열려도 라벨이 밀리지 않는다.
+    expect(components).toContain(".effort-track-apex-toggle");
     expect(components).not.toContain("effort-track-apex-collapse");
-    expect(trackSource).toContain('className="effort-track-apex-cap"');
-    expect(trackSource).not.toContain("effort-track-apex-toggle");
+    expect(trackSource).toContain('className="effort-track-apex-toggle"');
+    expect(trackSource).not.toContain("effort-track-apex-collapse");
     expect(trackSource).toContain("aria-expanded={apexOpen}");
 
     // 폭과 모든 좌표가 한 간격 변수를 공유한다 — 게이트가 열려도 기존 스톱·손잡이가 움직이지


### PR DESCRIPTION
## Summary
- 강도 트랙 기하를 픽셀 앵커로 전환: 폭·스톱·손잡이·심·버스트가 단일 `--effort-track-gap`(닫힘 폭 116px − 크롬 28px 기준)을 공유해, 게이트가 열려도 기존 스톱·손잡이가 1px도 움직이지 않고 오른쪽으로만 늘어납니다(기존 공식은 간격이 22→24.33px로 팽창하며 전 요소가 점프 후 미끄러졌음).
- 게이트 토글을 단일 지속 버튼으로 통합: ✦(닫힘)↔‹(열림)이 같은 26px 버튼의 두 상태가 되어(aria-expanded), 마운트 교체(26px→18px)로 라벨이 8px 튀던 현상이 사라집니다.
- 게이트 뒤 티어에 시그니처 모션 부여: MAX는 엠버 플리커 라벨(웨이브 2.1s+플리커 1.7s 이중 주기) + 용융 드리프트 결(11.03px/주기, 이음매 없음) + 크레스트 헤일로 호흡, ULTRACODE는 오로라 드리프트 채움 + 흰 스윕을 대체하는 ✦ 트윙클 2점. 신규 모션 전부 crest/apex 티어 채널만 소비하며 `prefers-reduced-motion`에서 정적으로 단락됩니다.

## Test Plan
- [x] `vitest run tests/effort-track.test.tsx tests/instrument-design-contract.test.ts` — 81 passed (스톱 앵커 불변·토글 aria·티어 keyframes·감속 모션 핀 포함)
- [x] fleet-console 전체 스위트 1915 passed / typecheck (tsc 양 프로젝트) 클린
- [x] 격리 콘솔 헤디드 실측: 개방 시 폭 116→160px·기존 스톱 offsetLeft `[-1,21,43,65,87]` 완전 부동·신규 스톱 +22px 간격·토글 26px 유지·MAX/ULTRACODE 애니메이션 실동작·페이지 오류 0