### PR TITLE
fix(fleet-console): drop built-in suffix from Claude launch group

### DIFF
--- a/.changelog.d/claude-builtin-label-cleanup.md
+++ b/.changelog.d/claude-builtin-label-cleanup.md
@@ -1,0 +1,8 @@
+---
+branch: claude-builtin-label-cleanup
+---
+
+### fleet-console
+#### Changed
+- Show the Claude launch group as Claude instead of Claude built-in.
+  ko: Claude 실행 그룹을 Claude 내장 대신 Claude로 표시합니다.

--- a/runtime/fleet-console/core/client/src/i18n/messages/common.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/common.ts
@@ -68,7 +68,7 @@ export const commonEn = {
   "launchKind.claudeGateway.description": "Runs Claude Code with built-in Claude and enabled Gateway models",
   // 실행 종류 옆에 늘 보이는 짧은 설명. 긴 설명 문장은 항목을 짚었을 때만 펼친다.
   "launchKind.claudeGateway.brief": "Built-in + Gateway",
-  "launchVariants.group.native": "Claude built-in",
+  "launchVariants.group.native": "Claude",
   "launchVariants.group.gateway": "Gateway — models you enabled",
   "launchVariants.effort.track": "Reasoning effort",
   "launchVariants.effort.auto": "AUTO",
@@ -147,7 +147,7 @@ export const commonKo: Record<keyof typeof commonEn, string> = {
   "common.experimental": "실험 기능",
   "launchKind.claudeGateway.description": "Claude Code 내장 Claude와 설정에서 켠 Gateway 모델을 실행",
   "launchKind.claudeGateway.brief": "내장 + Gateway",
-  "launchVariants.group.native": "Claude 내장",
+  "launchVariants.group.native": "Claude",
   "launchVariants.group.gateway": "Gateway — 설정에서 켠 모델",
   "launchVariants.effort.track": "추론 강도",
   "launchVariants.effort.auto": "자동",

--- a/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
+++ b/runtime/fleet-console/tests/canvas-context-menu-anchor.test.tsx
@@ -457,7 +457,7 @@ describe("CanvasContextMenu launch kind attribute", () => {
 
     // 실행 종류를 짚어 여는 단이 사라졌다 — 모델 밴드가 메뉴의 첫 단이다.
     expect(document.querySelector(".operation-launch-flyout")).toBeNull();
-    expect(document.querySelector(".operation-launch-variant-caption")?.textContent).toBe("Claude built-in");
+    expect(document.querySelector(".operation-launch-variant-caption")?.textContent).toBe("Claude");
     expect(document.querySelector(".canvas-context-menu-aside")).toBeNull();
 
     const row = document.querySelector<HTMLButtonElement>('[data-launch-variant-row="fable"]')!;
@@ -533,7 +533,7 @@ describe("CanvasContextMenu launch kind attribute", () => {
       .map((element) => element.getAttribute("data-launch-variant-row")
         ?? element.getAttribute("data-operation-launch-kind")
         ?? `caption:${element.textContent?.trim()}`);
-    expect(order).toEqual(["caption:Claude built-in", "fable", "caption:Etc", "shell"]);
+    expect(order).toEqual(["caption:Claude", "fable", "caption:Etc", "shell"]);
     expect(document.querySelector('[aria-label="Etc"] [data-operation-launch-kind="shell"]')).not.toBeNull();
   });
 

--- a/runtime/fleet-console/tests/quick-launch.test.ts
+++ b/runtime/fleet-console/tests/quick-launch.test.ts
@@ -19,7 +19,7 @@ function makeTheater(id: string): TheaterInfo {
 const GROUPS: readonly OperationLaunchVariantGroup[] = [
   {
     id: "builtin",
-    label: "Claude 내장",
+    label: "Claude",
     rows: [
       {
         id: "fable",


### PR DESCRIPTION
## Summary
- Right-click launch menu의 Claude 그룹 캡션을 `Claude 내장` / `Claude built-in`에서 다른 그룹과 같이 `Claude`로 정리합니다.
- i18n `launchVariants.group.native`와 관련 테스트 fixture/기대를 함께 맞춥니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/canvas-context-menu-anchor.test.tsx tests/quick-launch.test.ts`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [ ] Codex review