### PR TITLE
feat(fleet-console): give the phone its own Settings screen

### DIFF
--- a/.changelog.d/mobile-settings-drilldown.md
+++ b/.changelog.d/mobile-settings-drilldown.md
@@ -1,0 +1,14 @@
+---
+branch: mobile-settings-drilldown
+---
+
+### fleet-console
+#### Changed
+- Open Settings on a phone as a list of sections, and tap one to give it the whole screen. The section list no longer takes most of the first screen, and each row shows what it currently holds, so the theme, language or gateway in use reads without opening anything.
+  ko: 휴대폰에서 설정이 섹션 목록으로 열리고, 항목을 누르면 그 섹션이 화면 전체를 씁니다. 섹션 목록이 첫 화면 대부분을 차지하지 않으며, 각 행이 현재 값을 함께 보여 주어 테마·언어·게이트웨이를 열어 보지 않고도 확인할 수 있습니다.
+- Size every control on the phone's Settings screens for a fingertip, and stand the theme choices in one column instead of letting them wrap into uneven rows.
+  ko: 휴대폰 설정 화면의 모든 컨트롤을 손가락 기준 크기로 키우고, 테마 선택지를 폭이 제각각인 여러 줄 대신 한 열로 세웁니다.
+
+#### Fixed
+- Stack the desktop Settings rows on any window narrow enough for the mobile layout. Between 721 and 767 pixels the help text was squeezed into a narrow vertical ribbon beside a wide empty gap.
+  ko: 모바일 레이아웃이 켜지는 폭의 창에서는 데스크톱 설정 행도 세로로 쌓입니다. 721~767픽셀 구간에서 설명 문구가 넓은 여백 옆의 좁은 세로 띠로 눌리던 문제를 해결했습니다.

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -105,6 +105,15 @@ export function App() {
   const operationsViewVisible = pathname.startsWith("/operations");
   const mobileLayout = useViewMode().effective === "mobile";
   const mobileSessionOpen = useMobileSessionOpen();
+
+  /*
+   * 모바일 여부는 폭만으로 정해지지 않는다 — Fleet Console 앱은 UA로, 사용자는 명시 선호로 켤 수
+   * 있어 넓은 화면에서도 모바일 셸이 선다. 그 판정을 루트에 실어야 포털로 body에 그려지는 표면처럼
+   * React 트리 밖에 놓인 CSS도 같은 답을 읽는다(미디어 쿼리는 거기서 어긋난다).
+   */
+  useEffect(() => {
+    document.documentElement.dataset.viewMode = mobileLayout ? "mobile" : "desktop";
+  }, [mobileLayout]);
   const navigate = useNavigate();
   // 전역 단축키는 밴드의 패널 토글과 같은 계약을 따른다 — 사이드바·rail은 /operations에만 마운트되므로
   // 다른 경로에서 누르면 조작할 표면이 없다. ref로 읽어 리스너 재설치 없이 최신 경로를 본다.

--- a/runtime/fleet-console/core/client/src/app.tsx
+++ b/runtime/fleet-console/core/client/src/app.tsx
@@ -36,6 +36,7 @@ import { abortReleaseNotesFetch, requestReleaseNotes } from "./release-notes-fet
 import { getSideBarState, setSideBarCollapsed, subscribeOperationActivityTracking } from "./sidebar/operations-side-bar-store.js";
 import { useMobileSessionOpen } from "./mobile/mobile-store.js";
 import { MobileTabBar } from "./mobile/mobile-tab-bar.js";
+import { MobileSettingsPage } from "./mobile/mobile-settings-page.js";
 import { MobileTheaterPage } from "./mobile/mobile-theater-page.js";
 import { getViewModeSnapshot, useViewMode } from "./view-mode-store.js";
 import { useConsoleLocale, useT } from "./i18n/index.js";
@@ -340,7 +341,7 @@ export function App() {
                 {/* Theater is a phone-only destination: the desktop switches Theater from the band
                     and lists every Theater in its sidebar, so this route has nothing to add there. */}
                 <Route path="/theaters" element={mobileLayout ? <MobileTheaterPage state={state} /> : <Navigate to="/operations" replace />} />
-                <Route path="/settings" element={<GlobalSettings />} />
+                <Route path="/settings" element={mobileLayout ? <MobileSettingsPage /> : <GlobalSettings />} />
                 <Route path="*" element={<Navigate to="/operations" replace />} />
               </Routes>
             </main>

--- a/runtime/fleet-console/core/client/src/i18n/messages/pages.ts
+++ b/runtime/fleet-console/core/client/src/i18n/messages/pages.ts
@@ -465,6 +465,11 @@ export const pagesEn = {
   "mobile.status.dormant": "Dormant",
   "mobile.alerts.title": "Alerts",
   "mobile.alerts.empty": "No active alerts.",
+  "mobile.settings.appearance": "Appearance",
+  "mobile.settings.console": "Console",
+  "mobile.settings.back": "Back to settings",
+  "mobile.settings.on": "On",
+  "mobile.settings.off": "Off",
 } as const;
 
 export const pagesKo: Record<keyof typeof pagesEn, string> = {
@@ -926,4 +931,9 @@ export const pagesKo: Record<keyof typeof pagesEn, string> = {
   "mobile.status.dormant": "휴면",
   "mobile.alerts.title": "알림",
   "mobile.alerts.empty": "활성 알림이 없습니다.",
+  "mobile.settings.appearance": "화면과 글꼴",
+  "mobile.settings.console": "콘솔 동작",
+  "mobile.settings.back": "설정으로 돌아가기",
+  "mobile.settings.on": "켜짐",
+  "mobile.settings.off": "꺼짐",
 };

--- a/runtime/fleet-console/core/client/src/mobile/mobile-settings-page.tsx
+++ b/runtime/fleet-console/core/client/src/mobile/mobile-settings-page.tsx
@@ -1,0 +1,286 @@
+import { useEffect, type ReactNode } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import { PluginErrorBoundary } from "@fleet-console/sdk/react/browser";
+
+import { BackendApiSection } from "../components/backend-api-section.js";
+import { loadGlobalSettings, useGlobalSettingsStore } from "../global-settings-store.js";
+import { useConsoleLocale, useT, type CoreMessageKey } from "../i18n/index.js";
+import {
+  collectPluginSettingsSections,
+  GeneralSettingsCard,
+  PluginSettingsSectionBody,
+  RemoteAccessSection,
+  ThemeCard,
+  TypographyCard,
+  type PluginSettingsNavItem,
+} from "../pages/global-settings.js";
+import { usePluginRegistry } from "../plugin-registry.js";
+import { DEFAULT_UI_FONT, UI_FONT_BUILT_INS } from "../ui-font.js";
+import type { GlobalSettingsState, ThemeId } from "../types.js";
+import "../styles/mobile.css";
+
+/**
+ * The phone's Settings surface. The desktop keeps a section list beside the section it opens; on a
+ * phone that list has nowhere to stand beside anything, so it takes the screen and pushes the
+ * section below the fold. Here the two are separate destinations: the list is a screen, and opening
+ * a row is a navigation, so the section that was asked for gets the whole width.
+ *
+ * The section lives in the URL rather than in state, which is what makes the platform back gesture
+ * return to the list instead of leaving Settings.
+ */
+
+type MobileSectionId = "appearance" | "console" | "remote-access" | "backend-api" | `${string}:${string}`;
+
+interface MobileSettingsRow {
+  readonly id: MobileSectionId;
+  readonly title: string;
+  /** What this row currently holds, so the list answers without being opened. */
+  readonly value: string | null;
+  readonly icon: ReactNode;
+}
+
+interface MobileSettingsGroup {
+  readonly key: string;
+  readonly label: string;
+  readonly rows: readonly MobileSettingsRow[];
+}
+
+/** A detail screen was reached from the list here, so its Back retraces that step. */
+interface MobileSettingsLocationState {
+  readonly mobileSettingsEntry?: true;
+}
+
+export function MobileSettingsPage() {
+  const settings = useGlobalSettingsStore();
+  const state = settings.state;
+  const saving = settings.savingField !== null;
+  const registry = usePluginRegistry();
+  const locale = useConsoleLocale();
+  const t = useT();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadGlobalSettings(controller.signal);
+    return () => controller.abort();
+  }, []);
+
+  const pluginSections = collectPluginSettingsSections(registry.plugins, locale, t);
+  const groups = buildMobileSettingsGroups(state, pluginSections, t);
+  const requested = new URLSearchParams(location.search).get("section");
+  const active = groups.flatMap((group) => group.rows).find((row) => row.id === requested) ?? null;
+
+  const open = (id: MobileSectionId) => {
+    const entry: MobileSettingsLocationState = { mobileSettingsEntry: true };
+    navigate({ pathname: "/settings", search: `?section=${encodeURIComponent(id)}` }, { state: entry });
+  };
+  const close = () => {
+    // Popping is only correct when the entry above is this list. A direct load or a reload has no
+    // such entry, and popping there would leave the Console entirely.
+    if ((location.state as MobileSettingsLocationState | null)?.mobileSettingsEntry) { navigate(-1); return; }
+    navigate({ pathname: "/settings", search: "" }, { replace: true });
+  };
+
+  // An unknown section — a stale link, or one whose plugin is gone — resolves to the list rather
+  // than to an empty screen, and the address is corrected so a reload does not repeat the miss.
+  useEffect(() => {
+    if (requested === null || active !== null || state === null) return;
+    navigate({ pathname: "/settings", search: "" }, { replace: true });
+  }, [active, navigate, requested, state]);
+
+  if (active !== null) {
+    return (
+      <section className="mobile-settings-page" aria-labelledby="mobile-settings-detail-title">
+        <header className="mobile-list-header">
+          <button type="button" className="mobile-settings-back" onClick={close} aria-label={t("mobile.settings.back")}>
+            <BackIcon />
+          </button>
+          <h1 id="mobile-settings-detail-title">{active.title}</h1>
+          <span className="mobile-settings-saving" role="status" aria-live="polite">{saving ? t("settings.saving") : ""}</span>
+        </header>
+        <div className="mobile-settings-scroll">
+          <div className="mobile-settings-detail">
+            {settings.error !== null ? <p className="global-settings-error" role="alert">{settings.error}</p> : null}
+            {renderMobileSection(active.id, state, saving, pluginSections, t)}
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mobile-settings-page" aria-labelledby="mobile-settings-title">
+      <header className="mobile-list-header">
+        <h1 id="mobile-settings-title">{t("mobile.tabs.settings")}</h1>
+      </header>
+      <div className="mobile-settings-scroll">
+        <div className="mobile-settings-groups">
+          {settings.error !== null ? <p className="global-settings-error" role="alert">{settings.error}</p> : null}
+          {groups.map((group) => (
+            <div className="mobile-settings-group" key={group.key}>
+              <p className="mobile-settings-group-label">{group.label}</p>
+              <div className="mobile-settings-rows">
+                {group.rows.map((row) => (
+                  <button type="button" className="mobile-settings-row" key={row.id} onClick={() => open(row.id)}>
+                    <span className="mobile-settings-row-icon" aria-hidden="true">{row.icon}</span>
+                    <span className="mobile-settings-row-copy">
+                      <strong>{row.title}</strong>
+                      {row.value === null ? null : <span>{row.value}</span>}
+                    </span>
+                    <span className="mobile-operation-chevron" aria-hidden="true">›</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function renderMobileSection(
+  sectionId: MobileSectionId,
+  state: GlobalSettingsState | null,
+  saving: boolean,
+  pluginSections: readonly PluginSettingsNavItem[],
+  t: (key: CoreMessageKey) => string,
+): ReactNode {
+  if (sectionId.includes(":")) {
+    const plugin = pluginSections.find((section) => section.id === sectionId);
+    return plugin?.render ? (
+      <PluginErrorBoundary fallback={<div className="fc-plugin-error">{t("settings.pluginFailed")}</div>}>
+        <PluginSettingsSectionBody render={plugin.render} />
+      </PluginErrorBoundary>
+    ) : <p className="global-settings-help">{t("settings.pluginUnavailable")}</p>;
+  }
+  switch (sectionId) {
+    case "appearance":
+      return <><ThemeCard state={state} saving={saving} /><TypographyCard state={state} saving={saving} /></>;
+    case "console":
+      return <GeneralSettingsCard state={state} saving={saving} />;
+    case "remote-access":
+      if (state === null) return <p className="global-settings-help">{t("settings.general.loading")}</p>;
+      return state.remoteAccess === undefined ? null : <RemoteAccessSection remote={state.remoteAccess} saving={saving} />;
+    case "backend-api":
+      return <BackendApiSection />;
+  }
+}
+
+/**
+ * The desktop's "General" holds theme, type, port and language in one section because a wide
+ * column can carry all four. A row that stood for all four could not say what it holds, so the
+ * phone splits it where the summaries split: what the Console looks like, and how it runs.
+ */
+function buildMobileSettingsGroups(
+  state: GlobalSettingsState | null,
+  pluginSections: readonly PluginSettingsNavItem[],
+  t: (key: CoreMessageKey) => string,
+): readonly MobileSettingsGroup[] {
+  const consoleRows: MobileSettingsRow[] = [
+    { id: "appearance", title: t("mobile.settings.appearance"), value: describeAppearance(state, t), icon: <AppearanceIcon /> },
+    { id: "console", title: t("mobile.settings.console"), value: describeConsole(state, t), icon: <ConsoleIcon /> },
+  ];
+  // Absent remoteAccess means this Console does not carry the feature at all; the desktop drops the
+  // section rather than showing an empty one, and the phone follows that reading.
+  if (state === null || state.remoteAccess !== undefined) {
+    consoleRows.push({
+      id: "remote-access",
+      title: t("settings.core.remoteAccess.label"),
+      value: state?.remoteAccess === undefined ? null : t(state.remoteAccess.enabled ? "mobile.settings.on" : "mobile.settings.off"),
+      icon: <RemoteIcon />,
+    });
+  }
+  consoleRows.push({ id: "backend-api", title: t("settings.core.backendApi.label"), value: null, icon: <ApiIcon /> });
+
+  const groups: MobileSettingsGroup[] = [{ key: "console", label: t("settings.nav.console"), rows: consoleRows }];
+  for (const section of pluginSections) {
+    const last = groups.at(-1);
+    const row: MobileSettingsRow = { id: section.id, title: section.sectionTitle, value: null, icon: <PluginIcon /> };
+    if (last !== undefined && last.key === section.pluginId) {
+      groups[groups.length - 1] = { ...last, rows: [...last.rows, row] };
+      continue;
+    }
+    groups.push({ key: section.pluginId, label: section.pluginLabel, rows: [row] });
+  }
+  return groups;
+}
+
+function describeAppearance(state: GlobalSettingsState | null, t: (key: CoreMessageKey) => string): string | null {
+  if (state === null) return null;
+  return [themeLabel(state.theme, t), fontLabel(state)].join(" · ");
+}
+
+function describeConsole(state: GlobalSettingsState | null, t: (key: CoreMessageKey) => string): string | null {
+  if (state === null) return null;
+  const language = state.language === "auto" ? t("settings.language.auto") : state.language === "ko" ? t("settings.language.ko") : t("settings.language.en");
+  return [language, t(state.consolePortMode === "static" ? "settings.port.static" : "settings.port.dynamic")].join(" · ");
+}
+
+function themeLabel(theme: ThemeId, t: (key: CoreMessageKey) => string): string {
+  switch (theme) {
+    case "maritime": return t("settings.theme.maritime");
+    case "carbon": return t("settings.theme.carbon");
+    case "whites": return t("settings.theme.whites");
+    default: return t("settings.theme.instrument");
+  }
+}
+
+function fontLabel(state: GlobalSettingsState): string {
+  const uiFont = state.uiFont ?? DEFAULT_UI_FONT;
+  if (uiFont.source === "system") return uiFont.familyName;
+  return UI_FONT_BUILT_INS.find((font) => font.id === uiFont.id)?.label ?? uiFont.id;
+}
+
+function BackIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M12 4.5 6.5 10l5.5 5.5" />
+    </svg>
+  );
+}
+
+function AppearanceIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="10" cy="10" r="6.4" />
+      <path d="M10 3.6v12.8" />
+    </svg>
+  );
+}
+
+function ConsoleIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="3" y="4.5" width="14" height="11" rx="2" />
+      <path d="M6.5 9 8.5 11l-2 2M11 13h3" />
+    </svg>
+  );
+}
+
+function RemoteIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M4.4 12.4a5.6 5.6 0 0 1 11.2 0M1.9 9.4a9 9 0 0 1 16.2 0" />
+      <circle cx="10" cy="15.1" r="1.2" />
+    </svg>
+  );
+}
+
+function ApiIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M7.2 4 3.6 10l3.6 6M12.8 4l3.6 6-3.6 6" />
+    </svg>
+  );
+}
+
+function PluginIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M10 3.2 16 6.6v6.8L10 16.8 4 13.4V6.6Z" />
+    </svg>
+  );
+}

--- a/runtime/fleet-console/core/client/src/pages/global-settings.tsx
+++ b/runtime/fleet-console/core/client/src/pages/global-settings.tsx
@@ -48,7 +48,7 @@ interface SettingsSectionNavItem {
   readonly eyebrow: string;
 }
 
-interface PluginSettingsNavItem {
+export interface PluginSettingsNavItem {
   readonly id: PluginSettingsSectionId;
   readonly pluginId: string;
   readonly pluginLabel: string;
@@ -216,7 +216,7 @@ export function GlobalSettings() {
 }
 
 // 플러그인 render()를 경계 자손의 렌더 단계에서 호출해야 동기 throw가 PluginErrorBoundary에 잡힌다.
-function PluginSettingsSectionBody({ render }: { readonly render: () => ReactNode }) {
+export function PluginSettingsSectionBody({ render }: { readonly render: () => ReactNode }) {
   return <>{render()}</>;
 }
 
@@ -247,7 +247,7 @@ function renderSettingsSection(sectionId: SettingsSectionId, state: GlobalSettin
   }
 }
 
-function collectPluginSettingsSections(
+export function collectPluginSettingsSections(
   plugins: readonly { readonly id: string; readonly settingsSections?: readonly { readonly id: string; readonly title: LocalizedText; readonly render?: () => ReactNode }[] }[],
   locale: ConsoleLocale,
   t: T,
@@ -281,7 +281,7 @@ function formatPluginLabel(pluginId: string, t: T): string {
   return pluginId.split(/[-_]/g).filter(Boolean).map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(" ") || pluginId;
 }
 
-function ThemeCard({
+export function ThemeCard({
   state,
   saving,
 }: {
@@ -367,7 +367,7 @@ function ThemeCard({
   );
 }
 
-function TypographyCard({
+export function TypographyCard({
   state,
   saving,
 }: {
@@ -478,7 +478,7 @@ function TypographyCard({
   );
 }
 
-function GeneralSettingsCard({
+export function GeneralSettingsCard({
   state,
   saving,
 }: {
@@ -542,7 +542,7 @@ const ROTATE_ARM_TIMEOUT_MS = 5_000;
 /** README와 같은 최신 Desktop 아티팩트 진입점 — bare /releases가 아니라 latest로 바로 보낸다. */
 const FLEET_DESKTOP_RELEASES_URL = "https://github.com/sbluemin/fleet-harness/releases/latest";
 
-function RemoteAccessSection({ remote, saving }: { readonly remote: RemoteAccessState; readonly saving: boolean }) {
+export function RemoteAccessSection({ remote, saving }: { readonly remote: RemoteAccessState; readonly saving: boolean }) {
   const t = useT();
   const [status, setStatus] = useState<RemoteAccessStatus | null>(null);
   const [link, setLink] = useState<RemoteAccessLink | null>(null);

--- a/runtime/fleet-console/core/client/src/styles/components.css
+++ b/runtime/fleet-console/core/client/src/styles/components.css
@@ -335,7 +335,10 @@
   }
 }
 
-@media (max-width: 720px) {
+/* 경계는 모바일 셸이 켜지는 폭(view-mode-store의 max-width: 767px)과 같아야 한다. 720px에 두면
+   721~767px 구간이 모바일 셸 안에서 데스크톱 가로 배치로 남아, 설명 문단이 세로 리본으로 눌린다
+   (실측 65px 폭). Fleet Console 앱은 폭과 무관하게 모바일 셸을 켜므로 그 구간이 실제로 열린다. */
+@media (max-width: 767px) {
   .global-settings-page {
     width: min(100vw - 28px, 760px);
   }

--- a/runtime/fleet-console/core/client/src/styles/mobile.css
+++ b/runtime/fleet-console/core/client/src/styles/mobile.css
@@ -428,6 +428,232 @@
   border-radius: var(--radius-sm);
 }
 
+/* ===== Settings — 목록 화면과 상세 화면 ===== */
+
+.mobile-settings-page {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  height: 100%;
+  min-height: 0;
+}
+
+.mobile-settings-scroll {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.mobile-settings-back {
+  display: grid;
+  place-items: center;
+  min-width: 40px;
+  min-height: 40px;
+  margin-left: calc(var(--space-2) * -1);
+  padding: 0;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-pill);
+}
+
+.mobile-settings-back svg {
+  width: 20px;
+  height: 20px;
+}
+
+.mobile-settings-back:focus-visible {
+  color: var(--text-primary);
+  outline: 2px solid color-mix(in srgb, var(--brass) 55%, transparent);
+  outline-offset: 2px;
+}
+
+/* 헤더는 뒤로가기·제목·저장 표시 세 자리다. 제목이 가운데 자리를 다 쓰도록 남은 둘은 늘어나지 않는다. */
+.mobile-settings-page .mobile-list-header {
+  justify-content: flex-start;
+  gap: var(--space-2);
+}
+
+.mobile-settings-page .mobile-list-header h1 {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobile-settings-saving {
+  flex: none;
+  color: var(--aurora-ink);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mobile-settings-groups {
+  display: grid;
+  align-content: start;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-4) var(--space-8);
+}
+
+.mobile-settings-group {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.mobile-settings-group-label {
+  margin: 0;
+  padding: 0 var(--space-1);
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+/* 한 그룹은 이어진 한 판이고 행 사이의 선이 경계다 — 행마다 카드를 세우면 목록이 다시 더미가 된다. */
+.mobile-settings-rows {
+  display: grid;
+  overflow: hidden;
+  background: var(--ink-deep);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+}
+
+.mobile-settings-row {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  min-height: 56px;
+  padding: var(--space-2) var(--space-3);
+  color: var(--text-primary);
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-top: 1px solid var(--hairline);
+}
+
+.mobile-settings-row:first-child {
+  border-top: 0;
+}
+
+.mobile-settings-row:focus-visible,
+.mobile-settings-row:active {
+  background: var(--ink-mid);
+  outline: none;
+}
+
+.mobile-settings-row-icon {
+  display: grid;
+  place-items: center;
+  color: var(--brass);
+}
+
+.mobile-settings-row-icon svg {
+  width: 17px;
+  height: 17px;
+}
+
+.mobile-settings-row-copy {
+  display: grid;
+  min-width: 0;
+}
+
+.mobile-settings-row-copy strong,
+.mobile-settings-row-copy span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobile-settings-row-copy strong {
+  font-weight: var(--weight-medium);
+}
+
+.mobile-settings-row-copy span {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+/*
+ * 상세는 데스크톱 섹션 본문을 그대로 싣는다. 그 본문의 카드는 넓은 열 안에서 서로를 가르는
+ * 껍질이지만, 한 섹션만 있는 화면에서는 자기 자신을 한 번 더 감싸는 테두리일 뿐이다 — 폰에서
+ * 카드 껍질을 벗기면 그 안쪽 카드(remote-card 등)가 유일한 카드 층으로 남고, 실측 268px까지
+ * 좁아졌던 본문 폭이 화면 폭으로 돌아온다.
+ */
+.mobile-settings-detail {
+  display: grid;
+  align-content: start;
+  gap: var(--space-6);
+  padding: var(--space-4) var(--space-4) var(--space-8);
+}
+
+.mobile-settings-detail .global-settings-card {
+  gap: var(--space-5);
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.mobile-settings-detail .global-settings-row {
+  align-items: stretch;
+  flex-direction: column;
+}
+
+.mobile-settings-detail .global-settings-row-text {
+  max-width: none;
+}
+
+/*
+ * 손가락이 닿는 최소 치수. 데스크톱 값은 포인터를 기준으로 정해져 있어 폰에서는 21~38px까지
+ * 내려가므로(실측), 이 화면 안에서만 44px 바닥을 깐다. 라디오·체크박스는 자기 라벨 전체가
+ * 타깃이라 여기서 늘리면 상자만 커지고 정렬이 깨진다.
+ */
+.mobile-settings-detail button,
+.mobile-settings-detail select,
+.mobile-settings-detail input:not([type="radio"]):not([type="checkbox"]) {
+  min-height: 44px;
+}
+
+.mobile-settings-detail label:has(> input[type="radio"]),
+.mobile-settings-detail label:has(> input[type="checkbox"]) {
+  min-height: 44px;
+  align-items: center;
+}
+
+/*
+ * 데스크톱에서 테마 카드는 남는 가로를 채우며 흐르지만, 폰에서는 그 흐름이 카드마다 다른 폭의
+ * 계단이 된다(실측 158·145·132px 2행). 선택지가 셋뿐이라 한 열로 세우면 계단도 사라지고 각
+ * 카드가 이름 전체를 싣는다.
+ */
+.mobile-settings-detail .theme-picker,
+.mobile-settings-detail .theme-dark-tray {
+  flex-flow: column;
+  /* 가로였을 때의 align-items: center가 세로에서는 교차축이 되어 각 항목이 제 글자 폭으로
+     가운데 정렬된다 — 그러면 열로 세운 의미가 없으므로 교차축을 다시 늘린다. */
+  align-items: stretch;
+}
+
+/* 행이 세로로 서면 뒤따르는 액션은 stretch를 상속해 폭 전체를 먹는 판이 된다 — 자기 글자만큼만 쓴다. */
+.mobile-settings-detail .global-settings-row > button {
+  align-self: flex-start;
+}
+
+/* 상호배타 선택지는 열 폭을 균등하게 나눈다 — 늘어난 껍질 안에서 글자 폭 그대로 왼쪽에 몰리면
+   빈 오른쪽이 눌리는 자리로 보인다. */
+.mobile-settings-detail .theme-mode-seg > button,
+.mobile-settings-detail .segmented > .segmented-option {
+  flex: 1;
+}
+
 .operation-body-parking {
   position: fixed;
   left: -10000px;

--- a/runtime/fleet-console/core/client/src/styles/mobile.css
+++ b/runtime/fleet-console/core/client/src/styles/mobile.css
@@ -654,6 +654,24 @@
   flex: 1;
 }
 
+/*
+ * 호스트 추가 팝업은 createPortal로 body에 그려지므로 위의 자손 선택자가 닿지 않는다 — 원격 접속
+ * 상세에서 열어도 닫기 28px·액션 32px·입력 40px 그대로 남는다(실측). 조상으로 좁힐 수 없으니
+ * 모바일 셸이 켜지는 폭을 경계로 삼는다. 스위처에서 연 같은 팝업도 함께 손가락 치수가 된다.
+ */
+@media (max-width: 767px) {
+  .add-host-close {
+    width: 44px;
+    height: 44px;
+  }
+
+  .add-host-field input,
+  .add-host-cancel,
+  .add-host-submit {
+    min-height: 44px;
+  }
+}
+
 .operation-body-parking {
   position: fixed;
   left: -10000px;

--- a/runtime/fleet-console/core/client/src/styles/mobile.css
+++ b/runtime/fleet-console/core/client/src/styles/mobile.css
@@ -667,22 +667,28 @@
   flex: 1;
 }
 
+/* 글자 없는 버튼은 높이만 깔아서는 손끝에 닿지 않는다 — 글꼴 크기 스테퍼가 2.2em(실측 31px)로
+   남는다. 폭 바닥은 글자 폭에 기대는 텍스트 버튼을 늘리지 않도록 이 두 개에만 건다. */
+.mobile-settings-detail .fc-font-browser__stepper {
+  min-width: 44px;
+}
+
 /*
  * 호스트 추가 팝업은 createPortal로 body에 그려지므로 위의 자손 선택자가 닿지 않는다 — 원격 접속
  * 상세에서 열어도 닫기 28px·액션 32px·입력 40px 그대로 남는다(실측). 조상으로 좁힐 수 없으니
- * 모바일 셸이 켜지는 폭을 경계로 삼는다. 스위처에서 연 같은 팝업도 함께 손가락 치수가 된다.
+ * 루트가 싣는 뷰 모드를 읽는다. 폭으로 대신하면 앱(UA)이나 명시 선호로 넓은 화면에서 모바일 셸이
+ * 선 경우를 놓친다 — 1024px에서 넷 다 데스크톱 치수로 돌아갔다(실측). 스위처에서 연 같은 팝업도
+ * 함께 손가락 치수가 된다.
  */
-@media (max-width: 767px) {
-  .add-host-close {
-    width: 44px;
-    height: 44px;
-  }
+:root[data-view-mode="mobile"] .add-host-close {
+  width: 44px;
+  height: 44px;
+}
 
-  .add-host-field input,
-  .add-host-cancel,
-  .add-host-submit {
-    min-height: 44px;
-  }
+:root[data-view-mode="mobile"] .add-host-field input,
+:root[data-view-mode="mobile"] .add-host-cancel,
+:root[data-view-mode="mobile"] .add-host-submit {
+  min-height: 44px;
 }
 
 .operation-body-parking {

--- a/runtime/fleet-console/core/client/src/styles/mobile.css
+++ b/runtime/fleet-console/core/client/src/styles/mobile.css
@@ -444,6 +444,7 @@
 }
 
 .mobile-settings-back {
+  position: relative;
   display: grid;
   place-items: center;
   min-width: 40px;
@@ -454,6 +455,18 @@
   background: transparent;
   border: 0;
   border-radius: var(--radius-pill);
+}
+
+/*
+ * 상세를 나가는 주 내비게이션이므로 손끝 치수(44px)를 지켜야 하지만, 상자를 키우면 헤더가 함께
+ * 자란다 — 세로에서는 목록 헤더(48px)와의 단차가 벌어지고, 가로 압축 구간에서는 세로 공간을
+ * 아끼려고 44px로 줄여 둔 헤더를 넘는다. 그래서 그려지는 크기는 다른 헤더 아이콘 버튼(40px)에
+ * 맞춰 두고, 닿는 영역만 넓힌다.
+ */
+.mobile-settings-back::after {
+  content: "";
+  position: absolute;
+  inset: -2px;
 }
 
 .mobile-settings-back svg {

--- a/runtime/fleet-console/tests/mobile-settings-drilldown.test.ts
+++ b/runtime/fleet-console/tests/mobile-settings-drilldown.test.ts
@@ -62,6 +62,19 @@ describe("mobile settings", () => {
   });
 
   /**
+   * Back is how a detail is left, so it owes the same 44px. Growing the box was not the way: the
+   * header grows with it, widening the step from the 48px list header and overrunning the 44px
+   * height the landscape rail query compacts the header to. The drawn size stays with the other
+   * header icons and only the hit area reaches 44.
+   */
+  it("gives Back a 44px hit area without growing the header", () => {
+    const back = MOBILE_CSS.slice(MOBILE_CSS.indexOf(".mobile-settings-back {"));
+    expect(back).toMatch(/\.mobile-settings-back \{[^}]*min-width: 40px;/);
+    expect(back).toMatch(/\.mobile-settings-back::after \{[^}]*inset: -2px;/);
+    expect(back).toMatch(/\.mobile-settings-back::after \{[^}]*position: absolute;/);
+  });
+
+  /**
    * The add-host dialog is portaled to the body, so no ancestor of the detail reaches it. Reached
    * from Remote access on a phone it kept a 28px close button until the floor was written against
    * width instead.

--- a/runtime/fleet-console/tests/mobile-settings-drilldown.test.ts
+++ b/runtime/fleet-console/tests/mobile-settings-drilldown.test.ts
@@ -79,11 +79,17 @@ describe("mobile settings", () => {
    * from Remote access on a phone it kept a 28px close button until the floor was written against
    * width instead.
    */
-  it("floors the portaled add-host dialog too", () => {
-    const scoped = MOBILE_CSS.slice(MOBILE_CSS.indexOf(".add-host-close"));
-    expect(MOBILE_CSS.slice(0, MOBILE_CSS.indexOf(".add-host-close"))).toMatch(/@media \(max-width: 767px\) \{\s*$/m);
-    expect(scoped).toContain("height: 44px");
-    expect(scoped).toMatch(/\.add-host-cancel,\s*\n\s*\.add-host-submit \{\s*\n\s*min-height: 44px;/);
+  it("floors the portaled add-host dialog by view mode, not by width", () => {
+    // Width misses the app (UA) and the explicit preference, which keep the mobile shell up on a
+    // wide screen; at 1024px all four dialog controls fell back to the desktop sizes.
+    expect(APP).toContain('document.documentElement.dataset.viewMode = mobileLayout ? "mobile" : "desktop"');
+    expect(MOBILE_CSS).toContain('[data-view-mode="mobile"] .add-host-close');
+    expect(MOBILE_CSS).toMatch(/\[data-view-mode="mobile"\] \.add-host-submit \{\s*\n\s*min-height: 44px;/);
+  });
+
+  /** A control with no text is only as wide as its box, so a height floor alone leaves it narrow. */
+  it("floors the width of icon-only controls", () => {
+    expect(MOBILE_CSS).toMatch(/\.mobile-settings-detail \.fc-font-browser__stepper \{\s*\n\s*min-width: 44px;/);
   });
 
   /** Selection groups laid out for a wide column wrap into uneven steps at phone width. */

--- a/runtime/fleet-console/tests/mobile-settings-drilldown.test.ts
+++ b/runtime/fleet-console/tests/mobile-settings-drilldown.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(fileURLToPath(new URL(path, import.meta.url)), "utf8");
+
+const MOBILE_CSS = read("../core/client/src/styles/mobile.css");
+const COMPONENTS_CSS = read("../core/client/src/styles/components.css");
+const APP = read("../core/client/src/app.tsx");
+const VIEW_MODE = read("../core/client/src/view-mode-store.ts");
+const PAGE = read("../core/client/src/mobile/mobile-settings-page.tsx");
+
+/**
+ * The phone had no Settings screen of its own: the desktop page rendered inside the mobile frame,
+ * where its section list took 59% of the first viewport and wrapped into a ragged pile. These pin
+ * the parts of the fix that would fail silently — a layout regression shows up as a screenshot
+ * nobody takes, not as a thrown error.
+ */
+describe("mobile settings", () => {
+  it("routes /settings to the mobile page only while the mobile layout is on", () => {
+    expect(APP).toContain('<Route path="/settings" element={mobileLayout ? <MobileSettingsPage /> : <GlobalSettings />} />');
+  });
+
+  it("keeps the section in the address so the platform back gesture returns to the list", () => {
+    expect(PAGE).toContain('navigate({ pathname: "/settings", search: `?section=${encodeURIComponent(id)}` }');
+    // A direct load has no list entry above it, and popping there would leave the Console.
+    expect(PAGE).toContain("mobileSettingsEntry");
+    expect(PAGE).toContain('navigate({ pathname: "/settings", search: "" }, { replace: true })');
+  });
+
+  /**
+   * The desktop page still renders below the mobile shell's own boundary — a viewer who forces the
+   * desktop view on a narrow window. When the two boundaries disagreed, the band between them
+   * squeezed the help text into a 65px-wide ribbon 324px tall.
+   */
+  it("stacks the desktop settings rows at the same width the mobile shell begins", () => {
+    const shellBoundary = /\(max-width:\s*(\d+)px\)/.exec(VIEW_MODE.slice(VIEW_MODE.indexOf("narrowViewportQuery")));
+    expect(shellBoundary).not.toBeNull();
+    expect(COMPONENTS_CSS).toContain(`@media (max-width: ${shellBoundary![1]}px)`);
+    const stack = COMPONENTS_CSS.slice(COMPONENTS_CSS.indexOf(`@media (max-width: ${shellBoundary![1]}px)`));
+    expect(stack).toContain(".global-settings-row");
+    expect(stack).toContain("flex-direction: column");
+  });
+
+  /**
+   * The detail screen carries the desktop section body. That body's card is a shell meant to divide
+   * one wide column into parts; on a phone it wraps a screen that already holds one part, and its
+   * padding stacked with the inner cards until the text ran in a 268px gutter.
+   */
+  it("drops the desktop card shell inside the mobile detail", () => {
+    const detail = MOBILE_CSS.slice(MOBILE_CSS.indexOf(".mobile-settings-detail {"));
+    expect(detail).toContain(".mobile-settings-detail .global-settings-card");
+    expect(detail).toMatch(/\.mobile-settings-detail \.global-settings-card \{[^}]*padding: 0;/);
+    expect(detail).toMatch(/\.mobile-settings-detail \.global-settings-card \{[^}]*border: 0;/);
+  });
+
+  it("floors every pointer target in the detail at the touch minimum", () => {
+    expect(MOBILE_CSS).toMatch(/\.mobile-settings-detail button,[\s\S]{0,200}min-height: 44px;/);
+    // Rows in the list are the other half of the same contract.
+    expect(MOBILE_CSS).toMatch(/\.mobile-settings-row \{[\s\S]{0,400}min-height: 56px;/);
+  });
+
+  /** Selection groups laid out for a wide column wrap into uneven steps at phone width. */
+  it("stands the theme choices in one column", () => {
+    expect(MOBILE_CSS).toContain(".mobile-settings-detail .theme-dark-tray");
+    const tray = MOBILE_CSS.slice(MOBILE_CSS.indexOf(".mobile-settings-detail .theme-picker"));
+    expect(tray).toContain("flex-flow: column");
+    expect(tray).toContain("align-items: stretch");
+  });
+});

--- a/runtime/fleet-console/tests/mobile-settings-drilldown.test.ts
+++ b/runtime/fleet-console/tests/mobile-settings-drilldown.test.ts
@@ -61,6 +61,18 @@ describe("mobile settings", () => {
     expect(MOBILE_CSS).toMatch(/\.mobile-settings-row \{[\s\S]{0,400}min-height: 56px;/);
   });
 
+  /**
+   * The add-host dialog is portaled to the body, so no ancestor of the detail reaches it. Reached
+   * from Remote access on a phone it kept a 28px close button until the floor was written against
+   * width instead.
+   */
+  it("floors the portaled add-host dialog too", () => {
+    const scoped = MOBILE_CSS.slice(MOBILE_CSS.indexOf(".add-host-close"));
+    expect(MOBILE_CSS.slice(0, MOBILE_CSS.indexOf(".add-host-close"))).toMatch(/@media \(max-width: 767px\) \{\s*$/m);
+    expect(scoped).toContain("height: 44px");
+    expect(scoped).toMatch(/\.add-host-cancel,\s*\n\s*\.add-host-submit \{\s*\n\s*min-height: 44px;/);
+  });
+
   /** Selection groups laid out for a wide column wrap into uneven steps at phone width. */
   it("stands the theme choices in one column", () => {
     expect(MOBILE_CSS).toContain(".mobile-settings-detail .theme-dark-tray");


### PR DESCRIPTION
## Summary

- 폰에서 `/settings`가 데스크톱 2단 레이아웃 대신 모바일 전용 화면으로 열립니다. 섹션 목록이 한 화면이고, 항목을 누르면 상세가 화면 전체를 씁니다. 각 행은 현재 값(테마·글꼴, 언어·포트, 원격 접속 상태)을 함께 보여 줍니다.
- 섹션을 주소(`?section=`)에 담아 플랫폼 뒤로 제스처가 목록으로 돌아옵니다. 직접 진입·새로고침처럼 목록 항목이 위에 없는 경우에는 replace로 목록에 안착해 Console을 벗어나지 않습니다.
- 상세 안에서 데스크톱 카드 껍질을 벗겨 중첩 패딩이 먹던 본문 폭을 되찾고, 모든 컨트롤에 터치 최소 치수를 깔고, 테마 선택지를 한 열로 세웁니다.
- 데스크톱 설정의 세로 정렬 breakpoint를 모바일 셸 경계(767px)에 맞춰, 721~767px 구간에서 설명 문구가 세로 리본으로 눌리던 문제를 닫습니다.

### 실측 (격리 인스턴스, 390×844 @3x)

| | 이전 | 이후 |
|---|---|---|
| 첫 화면의 설정 콘텐츠 비중 | 20% | 88% |
| 탐색 항목 좌측 기준선 × 폭 | 3 × 5 | 1 × 1 |
| 목록 화면 스크롤 | 2543px | 739px (스크롤 없음) |
| 상세 본문 폭 | 268px | 348px |
| 44px 미만 컨트롤 (화면과 글꼴) | 58 / 58 | 0 / 52 |
| 44px 미만 컨트롤 (AI Gateway) | 17 / 17 | 0 / 17 |
| 721~767px 설명 문단 | 65 × 324px | 410 × 113px |

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 1975 passed / 24 skipped
- [x] `pnpm --filter @dotobokuri/fleet-console boundary:guard`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] 실브라우저(격리 콘솔, Chromium 헤드리스): 390×844에서 목록→상세→뒤로 왕복, 플랫폼 뒤로 제스처, 직접 URL 진입 후 뒤로, 없는 섹션 리다이렉트, 원격 접속·AI Gateway 섹션 렌더, 767px 구간, 1440px 데스크톱 무영향 — 콘솔 오류 0건, 가로 오버플로 0px