### PR TITLE
feat(fleet-console): name the running model in the command band

### DIFF
--- a/.changelog.d/command-band-model-name.md
+++ b/.changelog.d/command-band-model-name.md
@@ -1,0 +1,8 @@
+---
+branch: command-band-model-name
+---
+
+### fleet-console
+#### Changed
+- Name the model an Operation is actually running in the command band and its Operation menu, so a breadcrumb reads GPT-5.6-Sol-Fast or Opus instead of the launcher it went through.
+  ko: 커맨드 밴드와 Operation 메뉴가 실행 경로 이름 대신 실제로 돌고 있는 모델 이름을 답니다. 브레드크럼에 GPT-5.6-Sol-Fast나 Opus가 그대로 보입니다.

--- a/runtime/fleet-console/core/client/src/components/command-band-guards.ts
+++ b/runtime/fleet-console/core/client/src/components/command-band-guards.ts
@@ -1,3 +1,5 @@
+import type { OperationCatalogPlugin } from "@fleet-console/sdk/operations";
+
 import { flattenGroupedOrder } from "../store.js";
 import type { OperationGroup, OperationNode } from "../types.js";
 
@@ -30,6 +32,41 @@ export function commandBandActiveOperation(
   if (activeOperationId === null || activeTheaterId === null) return null;
   const operation = operations.find((candidate) => candidate.id === activeOperationId) ?? null;
   return operation !== null && operation.theaterId === activeTheaterId ? operation : null;
+}
+
+// 실행 카탈로그가 선언한 모델 행을 `launch.model → 표시 이름` 색인으로 접는다.
+// 표시 이름의 출처는 실행 메뉴·Quick Launch 칩과 같은 카탈로그 행 라벨이다 — 게이트웨이 행은
+// models.json의 `name`(provider 접두를 벗긴 소재 이름), 네이티브 Claude 행은 Opus/Fable/Sonnet.
+// 브라우저 코드는 core-ai-gateway를 끌어올 수 없어 카탈로그가 유일한 통로이고, 라벨을 Operation
+// payload에 복제해 두면 카탈로그가 바뀐 뒤 옛 Operation이 스테일 문자열을 안고 남는다.
+export function commandBandLaunchModelLabels(catalog: readonly OperationCatalogPlugin[]): ReadonlyMap<string, string> {
+  const labels = new Map<string, string>();
+  for (const plugin of catalog) {
+    for (const kind of plugin.kinds) {
+      for (const group of kind.variants ?? []) {
+        for (const row of group.rows) {
+          const model = row.launch.model;
+          if (typeof model === "string" && model !== "" && !labels.has(model)) labels.set(model, row.label);
+        }
+      }
+    }
+  }
+  return labels;
+}
+
+// 브레드크럼 속성 칩이 말할 한 줄. 어떤 모델 좌표로 띄웠는지가 payload에 남아 있고 카탈로그가
+// 그 이름을 알면 모델 이름이 CLI 라벨을 대신한다 — "Claude (Gateway)"는 지금 무엇이 돌고 있는지
+// 말해 주지 않는다. 좌표가 없거나(옛 payload) 카탈로그가 모르는 모델(꺼진 모델·개편된 id)일
+// 때만 CLI 라벨로 물러난다.
+export function commandBandOperationAttribute(
+  payload: Record<string, unknown>,
+  modelLabels: ReadonlyMap<string, string>,
+): string | null {
+  const launchModel = typeof payload.launchModel === "string" ? payload.launchModel : null;
+  const modelLabel = launchModel === null ? undefined : modelLabels.get(launchModel);
+  if (modelLabel !== undefined && modelLabel !== "") return modelLabel;
+  if (typeof payload.cliLabel === "string") return payload.cliLabel;
+  return typeof payload.cliId === "string" ? payload.cliId : null;
 }
 
 // Tab 등으로 포커스가 스위처 래퍼(트리거+메뉴) 밖으로 나가면 메뉴를 닫는다.

--- a/runtime/fleet-console/core/client/src/components/command-band-switcher.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band-switcher.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useEffect, type CSSProperties, type KeyboardEvent, type RefObject } from "react";
 
+import { commandBandOperationAttribute } from "./command-band-guards.js";
 import { useT } from "../i18n/index.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
 import type { OperationNode, TheaterInfo } from "../types.js";
@@ -41,6 +42,9 @@ interface CommandBandOperationMenuProps {
   // 활성 Theater 소속 Operation만, 사이드바 표시 순서로 정렬해 전달한다.
   readonly operations: readonly OperationNode[];
   readonly activeOperationId: string | null;
+  // 밴드의 속성 칩과 같은 색인을 받아 같은 문장을 말한다 — 칩은 모델 이름, 메뉴는 CLI 이름이면
+  // 같은 Operation이 한 표면에서 두 이름을 갖는다.
+  readonly launchModelLabels: ReadonlyMap<string, string>;
   readonly theaterLabel: string;
   readonly onSelectOperation: (operationId: string) => void;
   readonly onRenameOperation: (() => void) | null;
@@ -76,7 +80,7 @@ export function CommandBandTheaterMenu({ theaters, operations, activeTheaterId, 
   return <CommandBandMenu menuLabel={t("chrome.commandBand.switchTheater")} sections={sections} style={style} containerRef={containerRef} />;
 }
 
-export function CommandBandOperationMenu({ operations, activeOperationId, theaterLabel, onSelectOperation, onRenameOperation, onNewOperation, style, containerRef }: CommandBandOperationMenuProps) {
+export function CommandBandOperationMenu({ operations, activeOperationId, launchModelLabels, theaterLabel, onSelectOperation, onRenameOperation, onNewOperation, style, containerRef }: CommandBandOperationMenuProps) {
   const t = useT();
   const sections: readonly (readonly CommandBandMenuEntry[])[] = [
     operations.map((operation) => ({
@@ -84,7 +88,7 @@ export function CommandBandOperationMenu({ operations, activeOperationId, theate
       role: "menuitemradio" as const,
       label: operation.title,
       checked: operation.id === activeOperationId,
-      meta: operationCliLabel(operation),
+      meta: commandBandOperationAttribute(operation.payload, launchModelLabels),
       onSelect: () => onSelectOperation(operation.id),
     })),
     [
@@ -179,11 +183,4 @@ export function CommandBandTriggerCaret() {
 
 function MenuCheckIcon() {
   return <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3.5 8.5 6.5 11.5 12.5 4.5" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" /></svg>;
-}
-
-function operationCliLabel(operation: OperationNode): string | null {
-  const cliLabel = operation.payload.cliLabel;
-  if (typeof cliLabel === "string") return cliLabel;
-  const cliId = operation.payload.cliId;
-  return typeof cliId === "string" ? cliId : null;
 }

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -132,7 +132,6 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const activeCliId = typeof activeOperation?.payload.cliId === "string" ? activeOperation.payload.cliId : null;
   const [launchModelLabels, setLaunchModelLabels] = useState(NO_LAUNCH_MODEL_LABELS);
   const activeLaunchModel = typeof activeOperation?.payload.launchModel === "string" ? activeOperation.payload.launchModel : null;
-  const unresolvedLaunchModel = activeLaunchModel !== null && !launchModelLabels.has(activeLaunchModel) ? activeLaunchModel : null;
   // 속성 칩은 CLI 이름이 아니라 실제로 돌고 있는 모델 이름을 말한다(카탈로그가 그 좌표를 알 때).
   const activeOperationAttribute = activeOperation
     ? commandBandOperationAttribute(activeOperation.payload, launchModelLabels)
@@ -236,11 +235,19 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   }, [edgeRevealActive]);
 
   // 모델 이름 색인은 첫 페인트에서 한 번 읽고, 그 뒤로는 색인이 모르는 좌표가 밴드에 올라올 때만
-  // 다시 읽는다(설정에서 모델을 켠 직후 띄운 Operation). 조회 이력을 ref에 적어 두지 않는다 —
-  // 개발 채널의 StrictMode는 이 effect를 setup→cleanup→setup으로 돌리는데, 그때 두 번째 setup이
-  // 첫 setup이 적어 둔 이력을 보고 물러나 색인이 영영 비고, 중단된 요청이 뒤늦게 그 이력을 지워도
-  // 되돌릴 렌더가 없다. 의존만으로 충분하다: 같은 좌표가 그대로면 다시 묻지 않는다.
+  // 다시 읽는다(설정에서 모델을 켠 직후 띄운 Operation).
+  //
+  // 의존은 활성 좌표 하나다. 해결 여부를 의존에 실으면 조회가 성공해 좌표가 해결되는 순간이 곧
+  // 다음 조회의 방아쇠가 되어, 카탈로그가 매번 수행하는 Agent CLI 탐지를 시작마다 두 번 돌린다.
+  // 조회 이력을 ref에 적어 두지도 않는다 — 개발 채널의 StrictMode는 이 effect를
+  // setup→cleanup→setup으로 돌리는데, 그때 두 번째 setup이 첫 setup이 적어 둔 이력을 보고 물러나
+  // 색인이 영영 비고, 중단된 요청이 뒤늦게 그 이력을 지워도 되돌릴 렌더가 없다.
   useEffect(() => {
+    // 좌표가 없는 Operation은 색인이 필요 없다 — 첫 페인트(빈 색인)에서만 읽어 둔다.
+    const needsCatalog = activeLaunchModel === null
+      ? launchModelLabels.size === 0
+      : !launchModelLabels.has(activeLaunchModel);
+    if (!needsCatalog) return;
     const controller = new AbortController();
     fetchOperationCatalog(controller.signal)
       .then((catalog) => {
@@ -248,7 +255,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
       })
       .catch(() => {});
     return () => controller.abort();
-  }, [unresolvedLaunchModel]);
+  }, [activeLaunchModel]);
 
   useEffect(() => {
     if (!rename.renaming || commandBandRenameCommitTarget(renameTargetOperationIdRef.current, displayedOperationId)) return;

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -2,12 +2,13 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProp
 import { Link, useNavigate } from "react-router-dom";
 
 import { resolveLocalizedText } from "@fleet-console/sdk/i18n/translate";
+import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 
 import { fetchConsoleEnvironment, fetchOperations, renameOperation } from "../api.js";
 import { animateViewportTo, clearFormationView, fitAllOperations, selectFormationLayout, setStationKeeping, toggleFormationView, useCanvasState, useFormationLayout, useFormationView, useStationKeeping, type FormationLayout } from "../canvas/canvas-store.js";
 import { enterTriage, focusedTriageOperationId, setTriageActive, setTriageSpotlightEnabled, useTriageActive, useTriageDeckZoomLive, useTriageSpotlightEnabled, visitTriageTheater } from "../canvas/triage-store.js";
 import { cycleTriageDeckZoomPreset } from "../canvas/triage-watch-deck.js";
-import { COMMAND_BAND_RAIL_STRIP_PX, commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandMapControlsAnchor, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "./command-band-guards.js";
+import { COMMAND_BAND_RAIL_STRIP_PX, commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandLaunchModelLabels, commandBandMapControlsAnchor, commandBandMenuClampedLeft, commandBandOperationAttribute, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "./command-band-guards.js";
 import { CommandBandOperationMenu, CommandBandTheaterMenu, CommandBandTriggerCaret, type CommandBandSwitcherMenu } from "./command-band-switcher.js";
 import { CommandBandSystemCluster } from "./command-band-system-cluster.js";
 import { ViewModeToggle } from "./view-mode-toggle.js";
@@ -48,6 +49,10 @@ interface CanvasModeSegment {
 
 // 모드는 낱말로, 모드 전용 도구는 아이콘으로 말한다. 세그먼트에 아이콘을 함께 두면 클러스터가
 // 375px까지 벌어져 1280px 밴드에서 중앙 브레드크럼이 통째로 사라진다(2026-08 실측).
+// 카탈로그가 아직 도착하지 않은 첫 페인트의 빈 색인. 리터럴을 useState에 직접 넘기면 렌더마다
+// 새 Map이 생겨 아래 effect의 의존이 흔들린다.
+const NO_LAUNCH_MODEL_LABELS: ReadonlyMap<string, string> = new Map();
+
 const CANVAS_MODES: readonly CanvasModeSegment[] = [
   { id: "cruise", label: "Cruise", titleKey: "chrome.commandBand.modeCruise" },
   { id: "tactical", label: "Tactical", titleKey: "chrome.commandBand.modeTactical" },
@@ -125,7 +130,14 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const activeOperation = commandBandActiveOperation(state.operations, state.activeOperationId, state.activeTheaterId);
   const activePlugin = activeOperation ? registry.plugins.find((plugin) => plugin.id === activeOperation.pluginId) : null;
   const activeCliId = typeof activeOperation?.payload.cliId === "string" ? activeOperation.payload.cliId : null;
-  const activeCliLabel = typeof activeOperation?.payload.cliLabel === "string" ? activeOperation.payload.cliLabel : activeCliId;
+  const [launchModelLabels, setLaunchModelLabels] = useState(NO_LAUNCH_MODEL_LABELS);
+  const catalogRequestedKeysRef = useRef(new Set<string>());
+  const activeLaunchModel = typeof activeOperation?.payload.launchModel === "string" ? activeOperation.payload.launchModel : null;
+  const unresolvedLaunchModel = activeLaunchModel !== null && !launchModelLabels.has(activeLaunchModel) ? activeLaunchModel : null;
+  // 속성 칩은 CLI 이름이 아니라 실제로 돌고 있는 모델 이름을 말한다(카탈로그가 그 좌표를 알 때).
+  const activeOperationAttribute = activeOperation
+    ? commandBandOperationAttribute(activeOperation.payload, launchModelLabels)
+    : null;
   const activeKind = activeOperation ? activePlugin?.operationKinds?.find((kind) => kind.type === activeOperation.type) ?? null : null;
   const globalSettings = useGlobalSettingsStore();
   const language = resolveConsoleLanguage(globalSettings.state?.language ?? "auto");
@@ -223,6 +235,24 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
     const edge = edgeRevealRef.current;
     if (edge !== null && document.activeElement === edge) edge.blur();
   }, [edgeRevealActive]);
+
+  // 모델 이름 색인은 첫 페인트에서 한 번 읽고, 그 뒤로는 색인이 모르는 좌표가 밴드에 올라올 때만
+  // 다시 읽는다(설정에서 모델을 켠 직후 띄운 Operation). 좌표별로 한 번씩만 물어 실패한 조회가
+  // 매 렌더 재시도로 번지지 않게 하고, 실패·중단은 표를 지워 다음 기회를 남긴다.
+  useEffect(() => {
+    const key = unresolvedLaunchModel ?? "";
+    if (catalogRequestedKeysRef.current.has(key)) return;
+    catalogRequestedKeysRef.current.add(key);
+    const controller = new AbortController();
+    fetchOperationCatalog(controller.signal)
+      .then((catalog) => {
+        if (!controller.signal.aborted) setLaunchModelLabels(commandBandLaunchModelLabels(catalog));
+      })
+      .catch(() => {
+        catalogRequestedKeysRef.current.delete(key);
+      });
+    return () => controller.abort();
+  }, [unresolvedLaunchModel]);
 
   useEffect(() => {
     if (!rename.renaming || commandBandRenameCommitTarget(renameTargetOperationIdRef.current, displayedOperationId)) return;
@@ -615,7 +645,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
                 <span className="command-band-segment-label">{activeOperation.title}</span>
                 <CommandBandTriggerCaret />
               </button>}
-              {activeCliLabel ? <span className="command-band-operation-attribute" title={activeKindTitle ?? activeCliLabel}>{activeOperationIcon ? <span className={`command-band-operation-kind${activeLaunchProvider ? ` operation-provider-mark is-${activeLaunchProvider}` : ""}`} aria-hidden="true">{activeOperationIcon}</span> : null}{activeCliLabel}</span> : null}
+              {activeOperationAttribute ? <span className="command-band-operation-attribute" title={activeKindTitle ?? activeOperationAttribute}>{activeOperationIcon ? <span className={`command-band-operation-kind${activeLaunchProvider ? ` operation-provider-mark is-${activeLaunchProvider}` : ""}`} aria-hidden="true">{activeOperationIcon}</span> : null}{activeOperationAttribute}</span> : null}
             </> : <button
               ref={operationTriggerRef}
               type="button"
@@ -642,6 +672,7 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
           {switcherMenu === "operation" ? <CommandBandOperationMenu
             operations={theaterOperations}
             activeOperationId={activeOperation?.id ?? null}
+            launchModelLabels={launchModelLabels}
             theaterLabel={activeTheater.label}
             onSelectOperation={selectOperationFromMenu}
             onRenameOperation={activeOperation ? beginRename : null}

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -131,7 +131,6 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   const activePlugin = activeOperation ? registry.plugins.find((plugin) => plugin.id === activeOperation.pluginId) : null;
   const activeCliId = typeof activeOperation?.payload.cliId === "string" ? activeOperation.payload.cliId : null;
   const [launchModelLabels, setLaunchModelLabels] = useState(NO_LAUNCH_MODEL_LABELS);
-  const catalogRequestedKeysRef = useRef(new Set<string>());
   const activeLaunchModel = typeof activeOperation?.payload.launchModel === "string" ? activeOperation.payload.launchModel : null;
   const unresolvedLaunchModel = activeLaunchModel !== null && !launchModelLabels.has(activeLaunchModel) ? activeLaunchModel : null;
   // 속성 칩은 CLI 이름이 아니라 실제로 돌고 있는 모델 이름을 말한다(카탈로그가 그 좌표를 알 때).
@@ -237,20 +236,17 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   }, [edgeRevealActive]);
 
   // 모델 이름 색인은 첫 페인트에서 한 번 읽고, 그 뒤로는 색인이 모르는 좌표가 밴드에 올라올 때만
-  // 다시 읽는다(설정에서 모델을 켠 직후 띄운 Operation). 좌표별로 한 번씩만 물어 실패한 조회가
-  // 매 렌더 재시도로 번지지 않게 하고, 실패·중단은 표를 지워 다음 기회를 남긴다.
+  // 다시 읽는다(설정에서 모델을 켠 직후 띄운 Operation). 조회 이력을 ref에 적어 두지 않는다 —
+  // 개발 채널의 StrictMode는 이 effect를 setup→cleanup→setup으로 돌리는데, 그때 두 번째 setup이
+  // 첫 setup이 적어 둔 이력을 보고 물러나 색인이 영영 비고, 중단된 요청이 뒤늦게 그 이력을 지워도
+  // 되돌릴 렌더가 없다. 의존만으로 충분하다: 같은 좌표가 그대로면 다시 묻지 않는다.
   useEffect(() => {
-    const key = unresolvedLaunchModel ?? "";
-    if (catalogRequestedKeysRef.current.has(key)) return;
-    catalogRequestedKeysRef.current.add(key);
     const controller = new AbortController();
     fetchOperationCatalog(controller.signal)
       .then((catalog) => {
         if (!controller.signal.aborted) setLaunchModelLabels(commandBandLaunchModelLabels(catalog));
       })
-      .catch(() => {
-        catalogRequestedKeysRef.current.delete(key);
-      });
+      .catch(() => {});
     return () => controller.abort();
   }, [unresolvedLaunchModel]);
 

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -47,12 +47,12 @@ interface CanvasModeSegment {
   readonly titleKey: CoreMessageKey;
 }
 
-// 모드는 낱말로, 모드 전용 도구는 아이콘으로 말한다. 세그먼트에 아이콘을 함께 두면 클러스터가
-// 375px까지 벌어져 1280px 밴드에서 중앙 브레드크럼이 통째로 사라진다(2026-08 실측).
 // 카탈로그가 아직 도착하지 않은 첫 페인트의 빈 색인. 리터럴을 useState에 직접 넘기면 렌더마다
 // 새 Map이 생겨 아래 effect의 의존이 흔들린다.
 const NO_LAUNCH_MODEL_LABELS: ReadonlyMap<string, string> = new Map();
 
+// 모드는 낱말로, 모드 전용 도구는 아이콘으로 말한다. 세그먼트에 아이콘을 함께 두면 클러스터가
+// 375px까지 벌어져 1280px 밴드에서 중앙 브레드크럼이 통째로 사라진다(2026-08 실측).
 const CANVAS_MODES: readonly CanvasModeSegment[] = [
   { id: "cruise", label: "Cruise", titleKey: "chrome.commandBand.modeCruise" },
   { id: "tactical", label: "Tactical", titleKey: "chrome.commandBand.modeTactical" },

--- a/runtime/fleet-console/tests/command-band-switcher.test.tsx
+++ b/runtime/fleet-console/tests/command-band-switcher.test.tsx
@@ -129,8 +129,10 @@ describe("CommandBandOperationMenu", () => {
       operations: [
         { ...makeOperation("op-1", "theater-a"), payload: { cliLabel: "Claude Code" } },
         makeOperation("op-2", "theater-a"),
+        { ...makeOperation("op-3", "theater-a"), payload: { cliLabel: "Claude (Gateway)", launchModel: "codex--gpt-5.6-sol-fast" } },
       ],
       activeOperationId: "op-1",
+      launchModelLabels: new Map([["codex--gpt-5.6-sol-fast", "GPT-5.6-Sol-Fast"]]),
       theaterLabel: "Alpha",
       onSelectOperation,
       onRenameOperation,
@@ -140,9 +142,11 @@ describe("CommandBandOperationMenu", () => {
 
     const menu = document.querySelector<HTMLElement>('[role="menu"][aria-label="Switch operation"]');
     const radios = Array.from(menu?.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]') ?? []);
-    expect(radios).toHaveLength(2);
+    expect(radios).toHaveLength(3);
     expect(radios[0]?.getAttribute("aria-checked")).toBe("true");
     expect(radios[0]?.querySelector(".command-band-menu-meta")?.textContent).toBe("Claude Code");
+    // 게이트웨이로 띄운 행은 CLI 이름이 아니라 실제로 돌고 있는 모델 이름을 단다.
+    expect(radios[2]?.querySelector(".command-band-menu-meta")?.textContent).toBe("GPT-5.6-Sol-Fast");
     const actionItems = Array.from(menu?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]') ?? []);
     expect(actionItems.map((item) => item.textContent)).toEqual(["Rename current operation…", "New Operation in Alpha…"]);
 
@@ -156,6 +160,7 @@ describe("CommandBandOperationMenu", () => {
     renderMenu(createElement(CommandBandOperationMenu, {
       operations: [],
       activeOperationId: null,
+      launchModelLabels: new Map<string, string>(),
       theaterLabel: "Alpha",
       onSelectOperation: vi.fn(),
       onRenameOperation: null,

--- a/runtime/fleet-console/tests/command-band-v2-guards.test.ts
+++ b/runtime/fleet-console/tests/command-band-v2-guards.test.ts
@@ -5,7 +5,9 @@ import { resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandMapControlsAnchor, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "../core/client/src/components/command-band-guards.js";
+import type { OperationCatalogPlugin } from "../sdk/operations/types.js";
+
+import { commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandLaunchModelLabels, commandBandMapControlsAnchor, commandBandMenuClampedLeft, commandBandOperationAttribute, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "../core/client/src/components/command-band-guards.js";
 import type { OperationGroup, OperationNode } from "../core/client/src/types.js";
 
 describe("Command Band v2 guards", () => {
@@ -173,6 +175,75 @@ describe("Command Band operation menu ordering", () => {
     const groups = [makeGroup("g1", "t1", 0), makeGroup("g9", "t2", 0)];
     const ids = commandBandTheaterOperations(operations, groups, "t1", []).map((op) => op.id);
     expect(ids).toEqual(["op-a"]);
+  });
+});
+
+describe("Command Band Operation attribute", () => {
+  // 실행 카탈로그가 내놓는 모양 그대로다: 네이티브 Claude 그룹과 공급자별 게이트웨이 그룹.
+  // 게이트웨이 행 라벨은 models.json의 `name`(provider 접두를 벗긴 소재 이름)이다.
+  const catalog: readonly OperationCatalogPlugin[] = [
+    {
+      id: "terminal",
+      title: "Terminal",
+      kinds: [
+        { id: "claude", type: "agent", title: "Claude Code" },
+        {
+          id: "claude-gateway",
+          type: "agent",
+          title: "Claude (Gateway)",
+          variants: [
+            {
+              id: "native",
+              label: "Claude",
+              rows: [{ id: "opus[1m]", label: "Opus", launch: { model: "opus[1m]" } }],
+            },
+            {
+              id: "gateway:codex",
+              label: "Codex",
+              rows: [{ id: "codex--gpt-5.6-sol-fast", label: "GPT-5.6-Sol-Fast", launch: { model: "codex--gpt-5.6-sol-fast" } }],
+            },
+          ],
+        },
+      ],
+    },
+  ];
+  const labels = commandBandLaunchModelLabels(catalog);
+
+  it("indexes every launch row by its model coordinate", () => {
+    expect(labels.get("codex--gpt-5.6-sol-fast")).toBe("GPT-5.6-Sol-Fast");
+    expect(labels.get("opus[1m]")).toBe("Opus");
+    expect(labels.size).toBe(2);
+  });
+
+  it("names the model that is actually running instead of the CLI", () => {
+    expect(commandBandOperationAttribute(
+      { cliId: "claude-gateway", cliLabel: "Claude (Gateway)", launchModel: "codex--gpt-5.6-sol-fast" },
+      labels,
+    )).toBe("GPT-5.6-Sol-Fast");
+    expect(commandBandOperationAttribute(
+      { cliId: "claude-gateway", cliLabel: "Claude (Gateway)", launchModel: "opus[1m]" },
+      labels,
+    )).toBe("Opus");
+  });
+
+  it("falls back to the CLI label when the coordinate is missing or unknown", () => {
+    // 옛 payload(launchModel 이전)와 카탈로그가 모르는 좌표(꺼진 모델·개편된 id) 둘 다.
+    expect(commandBandOperationAttribute({ cliId: "claude-gateway", cliLabel: "Claude (Gateway)" }, labels))
+      .toBe("Claude (Gateway)");
+    expect(commandBandOperationAttribute(
+      { cliId: "claude-gateway", cliLabel: "Claude (Gateway)", launchModel: "kimi--k3" },
+      labels,
+    )).toBe("Claude (Gateway)");
+    expect(commandBandOperationAttribute({ cliId: "codex" }, labels)).toBe("codex");
+    expect(commandBandOperationAttribute({}, labels)).toBeNull();
+  });
+
+  it("reads an empty index before the catalog arrives", () => {
+    expect(commandBandLaunchModelLabels([]).size).toBe(0);
+    expect(commandBandOperationAttribute(
+      { cliLabel: "Claude (Gateway)", launchModel: "codex--gpt-5.6-sol-fast" },
+      commandBandLaunchModelLabels([]),
+    )).toBe("Claude (Gateway)");
   });
 });
 


### PR DESCRIPTION
## Summary

- 커맨드 밴드의 Operation 속성 칩이 실행 경로 이름(`Claude (Gateway)`) 대신 실제로 돌고 있는 모델 이름을 답니다. 게이트웨이 행은 `models.json`의 `name`(예: `GPT-5.6-Sol-Fast`, `K3-1M`), 네이티브 Claude 행은 `Opus`/`Fable`/`Sonnet`입니다.
- 이름의 출처는 실행 메뉴·Quick Launch 칩과 같은 실행 카탈로그 행 라벨(`bareModelName()`) 하나입니다. 라벨을 Operation payload에 복제하지 않아 이미 저장된 Operation도 그대로 반영되고, 카탈로그가 바뀐 뒤 옛 payload가 스테일 문자열을 안고 남지 않습니다.
- 밴드에서 열리는 Operation 드롭다운의 meta도 같은 색인을 씁니다 — 한 표면에서 칩과 메뉴가 서로 다른 이름을 말하지 않게 합니다.
- `launchModel`이 없는 옛 Operation과 카탈로그가 모르는 좌표는 기존 CLI 라벨로 물러납니다(회귀 없음).

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과
- [x] `pnpm vitest run tests/command-band-switcher.test.tsx tests/command-band-v2-guards.test.ts` — 31건 통과 (색인·폴백 케이스 신규 포함)
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 7건 검증 통과
- [x] 격리 콘솔 + 헤드리스 브라우저 실측: `codex--gpt-5.6-sol-fast` → `GPT-5.6-Sol-Fast`, `kimi--k3` → `K3-1M`, `opus[1m]` → `Opus`, `launchModel` 없음 → `Claude (Gateway)`. 밴드와 Operation 메뉴 양쪽 동일, 페이지 에러 0건