### PR TITLE
feat(fleet-console): give touch terminals the keys a soft keyboard omits

### DIFF
--- a/.changelog.d/fleet-mobile-term-keys.md
+++ b/.changelog.d/fleet-mobile-term-keys.md
@@ -1,0 +1,12 @@
+---
+branch: fleet-mobile-term-keys
+---
+
+### fleet-console
+#### Added
+- Give a terminal opened on a touch screen a bar of the keys a soft keyboard leaves out: Escape, Tab, arrows, and latching Ctrl and Alt, with function keys, paging keys, and shell punctuation behind one more tap.
+  ko: 터치 화면에서 연 터미널에 소프트 키보드에 없는 키를 한 줄로 제공합니다. Esc·Tab·방향키와 눌러서 걸어두는 Ctrl·Alt를 놓고, 한 번 더 누르면 펑션키·이동키·셸 기호까지 펼쳐집니다.
+
+#### Fixed
+- Show the terminal at full height on a phone; an open session had collapsed to a sliver above empty space.
+  ko: 폰에서 터미널이 화면 전체 높이로 표시됩니다. 이전에는 세션을 열어도 빈 공간 위 한 줄 높이로 접혀 있었습니다.

--- a/runtime/fleet-console/core/client/src/styles/mobile.css
+++ b/runtime/fleet-console/core/client/src/styles/mobile.css
@@ -33,6 +33,17 @@
   height: 100%;
 }
 
+/* A plugin body sizes itself with flex — the terminal's stage, shell, and viewport are a flex chain
+   whose height comes from the parent. A block mount gives that chain nothing to divide, so the
+   whole session collapses to the height of its own padding and the terminal disappears. The canvas
+   layout already declares this for its own mount; the phone needs the same statement. */
+.mobile-session-body,
+.mobile-operation-body-slot,
+.mobile-session-body .operation-body-mount {
+  display: flex;
+  flex-direction: column;
+}
+
 .mobile-shell-content {
   overflow: auto;
 }

--- a/runtime/fleet-plugins/terminal/client/i18n/index.ts
+++ b/runtime/fleet-plugins/terminal/client/i18n/index.ts
@@ -273,6 +273,16 @@ export const terminalEn = {
   "terminal.viewer.readOnly": "Another device is using this terminal — read-only",
   "terminal.viewer.takeBack": "Take back control",
   "terminal.viewer.remoteControlled": "A remote device has control — read-only",
+  "terminal.keyBar.aria": "Terminal keys",
+  "terminal.keyBar.more": "More keys",
+  "terminal.keyBar.fewer": "Hide extra keys",
+  "terminal.keyBar.key.up": "Arrow up",
+  "terminal.keyBar.key.down": "Arrow down",
+  "terminal.keyBar.key.left": "Arrow left",
+  "terminal.keyBar.key.right": "Arrow right",
+  "terminal.keyBar.key.enter": "Enter",
+  "terminal.keyBar.key.backspace": "Backspace",
+  "terminal.keyBar.key.shiftTab": "Shift Tab",
 } as const;
 
 export const terminalKo: Record<keyof typeof terminalEn, string> = {
@@ -544,6 +554,16 @@ export const terminalKo: Record<keyof typeof terminalEn, string> = {
   "terminal.viewer.readOnly": "다른 기기가 이 터미널을 쓰고 있습니다 — 읽기 전용",
   "terminal.viewer.takeBack": "제어권 가져오기",
   "terminal.viewer.remoteControlled": "원격 기기가 제어 중입니다 — 읽기 전용",
+  "terminal.keyBar.aria": "터미널 키",
+  "terminal.keyBar.more": "키 더 보기",
+  "terminal.keyBar.fewer": "추가 키 숨기기",
+  "terminal.keyBar.key.up": "위쪽 화살표",
+  "terminal.keyBar.key.down": "아래쪽 화살표",
+  "terminal.keyBar.key.left": "왼쪽 화살표",
+  "terminal.keyBar.key.right": "오른쪽 화살표",
+  "terminal.keyBar.key.enter": "엔터",
+  "terminal.keyBar.key.backspace": "백스페이스",
+  "terminal.keyBar.key.shiftTab": "시프트 탭",
 };
 
 export const TERMINAL_MESSAGES = { en: terminalEn, ko: terminalKo } as const;

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-key-bar.css
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-key-bar.css
@@ -1,0 +1,78 @@
+/* On-screen terminal keys.
+   Every colour here is a theme token, so the bar retunes with instrument, maritime, carbon, and
+   whites rather than carrying a palette of its own — it sits directly against the terminal, which
+   is the one surface where a fixed colour would read as a foreign panel in three of four themes. */
+
+.terminal-key-bar {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding-top: var(--space-1);
+}
+
+/* Equal columns, explicitly floored at 0: an auto-sized track lets one wide label (F10, PgDn)
+   stretch its column and push the row past the panel width. */
+.terminal-key-row {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(0, 1fr);
+  gap: var(--space-1);
+}
+
+.terminal-key-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.terminal-key {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  min-height: 42px;
+  padding: 0 2px;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: var(--weight-medium);
+  white-space: nowrap;
+  background: var(--surface-glass-strong);
+  border: 1px solid var(--surface-rim);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+  /* A key is tapped repeatedly; without this the browser waits for a double-tap zoom and every
+     press lands late. */
+  touch-action: manipulation;
+  transition:
+    background var(--duration-fast) var(--ease-glide),
+    border-color var(--duration-fast) var(--ease-glide),
+    color var(--duration-fast) var(--ease-glide);
+}
+
+.terminal-key-row-primary .terminal-key {
+  color: var(--text-primary);
+}
+
+.terminal-key:active {
+  background: color-mix(in oklch, var(--brass) 20%, var(--surface-glass-strong));
+  border-color: color-mix(in oklch, var(--brass) 55%, var(--surface-rim));
+  color: var(--brass-ink);
+}
+
+/* A latched Ctrl or Alt, and the open panel, speak the same brass fill every other pressed toggle
+   in the product uses. */
+.terminal-key[aria-pressed="true"] {
+  background: color-mix(in oklch, var(--brass) 12%, transparent);
+  border-color: color-mix(in oklch, var(--brass) 45%, var(--surface-rim));
+  color: var(--brass-ink);
+}
+
+.terminal-key:focus-visible {
+  outline: 2px solid var(--brass);
+  outline-offset: 1px;
+}

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-key-bar.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-key-bar.tsx
@@ -1,0 +1,174 @@
+import type { ConsoleLocale } from "@fleet-console/sdk/i18n";
+
+import { getT } from "../i18n/index.js";
+import type { TerminalKeyId } from "./terminal-key-sequences.js";
+
+/**
+ * The keys a phone keyboard leaves out, laid over the terminal.
+ *
+ * A soft keyboard is a text field's keyboard: it has letters and punctuation and nothing a terminal
+ * reads as a command. Without Escape there is no leaving a mode, without arrows there is no history
+ * or menu, and without Ctrl there is no interrupting anything. So this bar carries them.
+ *
+ * One row stays visible because those keys are needed constantly, and the rest live behind a toggle
+ * that takes the keyboard's place rather than stacking on top of it — a phone cannot afford both and
+ * still show a session.
+ *
+ * Ctrl and Alt latch instead of being held: a finger cannot press two keys at once, so they arm the
+ * next key — whether it comes from this bar or from the letters of the soft keyboard — and release.
+ */
+
+export interface TerminalKeyBarModifiers {
+  readonly ctrl: boolean;
+  readonly alt: boolean;
+}
+
+export const NO_LATCHED_MODIFIERS: TerminalKeyBarModifiers = { ctrl: false, alt: false };
+
+export interface TerminalKeyBarProps {
+  readonly locale?: ConsoleLocale;
+  readonly modifiers: TerminalKeyBarModifiers;
+  readonly expanded: boolean;
+  readonly onToggleModifier: (modifier: "ctrl" | "alt") => void;
+  readonly onToggleExpanded: () => void;
+  readonly onKey: (id: TerminalKeyId) => void;
+  readonly onText: (text: string) => void;
+}
+
+interface KeySpec {
+  readonly id: TerminalKeyId;
+  readonly label: string;
+  /** Set when the label is a glyph a screen reader cannot name on its own. */
+  readonly nameKey?: "up" | "down" | "left" | "right" | "enter" | "backspace" | "shiftTab";
+}
+
+const ARROW_KEYS: readonly KeySpec[] = [
+  { id: "left", label: "←", nameKey: "left" },
+  { id: "up", label: "↑", nameKey: "up" },
+  { id: "down", label: "↓", nameKey: "down" },
+  { id: "right", label: "→", nameKey: "right" },
+];
+
+const EDIT_KEYS: readonly KeySpec[] = [
+  { id: "shiftTab", label: "⇧Tab", nameKey: "shiftTab" },
+  { id: "enter", label: "↵", nameKey: "enter" },
+  { id: "backspace", label: "⌫", nameKey: "backspace" },
+  { id: "delete", label: "Del" },
+  { id: "insert", label: "Ins" },
+];
+
+const NAVIGATION_KEYS: readonly KeySpec[] = [
+  { id: "home", label: "Home" },
+  { id: "end", label: "End" },
+  { id: "pageUp", label: "PgUp" },
+  { id: "pageDown", label: "PgDn" },
+  { id: "space", label: "Space" },
+];
+
+const FUNCTION_KEYS: readonly (readonly KeySpec[])[] = [
+  [
+    { id: "f1", label: "F1" },
+    { id: "f2", label: "F2" },
+    { id: "f3", label: "F3" },
+    { id: "f4", label: "F4" },
+    { id: "f5", label: "F5" },
+    { id: "f6", label: "F6" },
+  ],
+  [
+    { id: "f7", label: "F7" },
+    { id: "f8", label: "F8" },
+    { id: "f9", label: "F9" },
+    { id: "f10", label: "F10" },
+    { id: "f11", label: "F11" },
+    { id: "f12", label: "F12" },
+  ],
+];
+
+/**
+ * Punctuation a phone hides two layouts deep, chosen for what a shell needs: pipes and redirects,
+ * paths and flags, globs and variables.
+ */
+const SYMBOL_ROWS: readonly string[] = [
+  "|\\/~-_:;",
+  "?!@$*#&%",
+];
+
+export function TerminalKeyBar({ locale, modifiers, expanded, onToggleModifier, onToggleExpanded, onKey, onText }: TerminalKeyBarProps) {
+  const t = getT(locale);
+  const nameFor = (key: KeySpec): string | undefined => (
+    key.nameKey === undefined ? undefined : t(`terminal.keyBar.key.${key.nameKey}`)
+  );
+
+  return (
+    <div className="terminal-key-bar" role="group" aria-label={t("terminal.keyBar.aria")}>
+      <div className="terminal-key-row terminal-key-row-primary">
+        <KeyBarButton label="Esc" onActivate={() => onKey("escape")} />
+        <KeyBarButton label="Tab" onActivate={() => onKey("tab")} />
+        <KeyBarButton label="Ctrl" pressed={modifiers.ctrl} onActivate={() => onToggleModifier("ctrl")} />
+        <KeyBarButton label="Alt" pressed={modifiers.alt} onActivate={() => onToggleModifier("alt")} />
+        {ARROW_KEYS.map((key) => (
+          <KeyBarButton key={key.id} label={key.label} name={nameFor(key)} onActivate={() => onKey(key.id)} />
+        ))}
+        <KeyBarButton
+          label="⋯"
+          name={t(expanded ? "terminal.keyBar.fewer" : "terminal.keyBar.more")}
+          pressed={expanded}
+          onActivate={onToggleExpanded}
+        />
+      </div>
+      {expanded ? (
+        <div className="terminal-key-panel">
+          <KeyRow keys={EDIT_KEYS} nameFor={nameFor} onKey={onKey} />
+          <KeyRow keys={NAVIGATION_KEYS} nameFor={nameFor} onKey={onKey} />
+          {FUNCTION_KEYS.map((row, index) => (
+            <KeyRow key={`function-${index}`} keys={row} nameFor={nameFor} onKey={onKey} />
+          ))}
+          {SYMBOL_ROWS.map((row) => (
+            <div className="terminal-key-row" key={row}>
+              {Array.from(row).map((symbol) => (
+                <KeyBarButton key={symbol} label={symbol} onActivate={() => onText(symbol)} />
+              ))}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function KeyRow({ keys, nameFor, onKey }: {
+  readonly keys: readonly KeySpec[];
+  readonly nameFor: (key: KeySpec) => string | undefined;
+  readonly onKey: (id: TerminalKeyId) => void;
+}) {
+  return (
+    <div className="terminal-key-row">
+      {keys.map((key) => (
+        <KeyBarButton key={key.id} label={key.label} name={nameFor(key)} onActivate={() => onKey(key.id)} />
+      ))}
+    </div>
+  );
+}
+
+function KeyBarButton({ label, name, pressed, onActivate }: {
+  readonly label: string;
+  readonly name?: string;
+  readonly pressed?: boolean;
+  readonly onActivate: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="terminal-key"
+      aria-label={name}
+      aria-pressed={pressed}
+      /* Focus must stay on the terminal. Letting the press move it closes the soft keyboard, and
+         the next letter typed would land on this button instead of the session. */
+      onPointerDown={(event) => event.preventDefault()}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={onActivate}
+    >
+      {label}
+    </button>
+  );
+}

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-key-sequences.ts
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-key-sequences.ts
@@ -1,0 +1,187 @@
+/**
+ * The bytes a terminal expects for the keys a phone keyboard does not have.
+ *
+ * A soft keyboard sends characters, not keys: there is no Escape, no arrow, no Ctrl, so a TUI that
+ * reads those is unreachable from a phone. The key bar sends them directly, which means this module
+ * has to produce what xterm would have produced from a real key press — including the modifier
+ * encodings, since Ctrl+C on a runaway process and Alt+B in a line editor are the reason the bar
+ * exists at all.
+ *
+ * Sequences follow xterm's own conventions: DECCKM decides whether a cursor key is CSI or SS3, and
+ * a modified key always takes the CSI form with an encoded parameter, because SS3 has nowhere to
+ * carry one.
+ *
+ * Control bytes are built from their code points rather than written as literals — a literal one in
+ * the source makes git treat the file as binary, and a reviewer cannot see which byte it is.
+ */
+
+const ESC = String.fromCharCode(0x1b);
+const TAB = String.fromCharCode(0x09);
+const CR = String.fromCharCode(0x0d);
+const BS = String.fromCharCode(0x08);
+const DEL = String.fromCharCode(0x7f);
+const NUL = String.fromCharCode(0x00);
+const CSI = `${ESC}[`;
+const SS3 = `${ESC}O`;
+
+export interface TerminalKeyModifiers {
+  readonly ctrl: boolean;
+  readonly alt: boolean;
+  readonly shift: boolean;
+}
+
+export const NO_TERMINAL_MODIFIERS: TerminalKeyModifiers = { ctrl: false, alt: false, shift: false };
+
+export type TerminalKeyId =
+  | "escape"
+  | "tab"
+  | "shiftTab"
+  | "enter"
+  | "backspace"
+  | "space"
+  | "up"
+  | "down"
+  | "left"
+  | "right"
+  | "home"
+  | "end"
+  | "pageUp"
+  | "pageDown"
+  | "insert"
+  | "delete"
+  | "f1" | "f2" | "f3" | "f4" | "f5" | "f6"
+  | "f7" | "f8" | "f9" | "f10" | "f11" | "f12";
+
+/** Cursor and editing keys whose CSI form ends in a letter. */
+const CSI_FINAL: Partial<Record<TerminalKeyId, string>> = {
+  up: "A",
+  down: "B",
+  right: "C",
+  left: "D",
+  home: "H",
+  end: "F",
+};
+
+/** Keys encoded as CSI <code> ~, where the code identifies the key. */
+const TILDE_CODE: Partial<Record<TerminalKeyId, number>> = {
+  insert: 2,
+  delete: 3,
+  pageUp: 5,
+  pageDown: 6,
+  f5: 15,
+  f6: 17,
+  f7: 18,
+  f8: 19,
+  f9: 20,
+  f10: 21,
+  f11: 23,
+  f12: 24,
+};
+
+/** F1–F4 are SS3 when unmodified and CSI 1;<mod> <final> when not. */
+const SS3_FINAL: Partial<Record<TerminalKeyId, string>> = {
+  f1: "P",
+  f2: "Q",
+  f3: "R",
+  f4: "S",
+};
+
+/**
+ * xterm's modifier parameter: 1 plus a bit per held modifier. A value of 1 means "no modifier",
+ * which is also the signal to use the shorter unmodified form of the sequence.
+ */
+export function terminalModifierParameter(modifiers: TerminalKeyModifiers): number {
+  return 1 + (modifiers.shift ? 1 : 0) + (modifiers.alt ? 2 : 0) + (modifiers.ctrl ? 4 : 0);
+}
+
+/**
+ * The control byte a character carries under Ctrl, or null when the pairing has no control code.
+ * Returning null rather than a guess matters: a Ctrl the terminal has no encoding for must reach
+ * the session as the plain character, not as a byte that means something else.
+ */
+export function controlCharacterFor(character: string): string | null {
+  if (Array.from(character).length !== 1) return null;
+  const code = character.codePointAt(0);
+  if (code === undefined) return null;
+  // Both cases fold onto the same control byte, the way a physical Ctrl+C and Ctrl+Shift+C do.
+  if (code >= 0x61 && code <= 0x7a) return String.fromCharCode(code - 0x60);
+  if (code >= 0x41 && code <= 0x5a) return String.fromCharCode(code - 0x40);
+  switch (character) {
+    case "@":
+    case " ":
+      return NUL;
+    case "[": return ESC;
+    case "\\": return String.fromCharCode(0x1c);
+    case "]": return String.fromCharCode(0x1d);
+    case "^": return String.fromCharCode(0x1e);
+    case "_": return String.fromCharCode(0x1f);
+    case "?": return DEL;
+    default: return null;
+  }
+}
+
+/**
+ * Applies bar-held modifiers to text the soft keyboard produced. Only a single character is
+ * transformed: a paste, an IME commit, or an emoji is several code points, and prefixing that with
+ * Escape or folding it to one control byte would corrupt it — those pass through untouched.
+ */
+export function applyTerminalModifiers(data: string, modifiers: TerminalKeyModifiers): string {
+  if (!modifiers.ctrl && !modifiers.alt) return data;
+  if (Array.from(data).length !== 1) return data;
+  const controlled = modifiers.ctrl ? controlCharacterFor(data) ?? data : data;
+  return modifiers.alt ? `${ESC}${controlled}` : controlled;
+}
+
+/**
+ * The bytes for one bar key. `applicationCursor` is DECCKM: full-screen programs turn it on and
+ * then read SS3 rather than CSI for the cursor keys, so a bar that always sent CSI would move the
+ * cursor in a shell and do nothing in an editor.
+ */
+export function terminalKeySequence(
+  id: TerminalKeyId,
+  modifiers: TerminalKeyModifiers = NO_TERMINAL_MODIFIERS,
+  applicationCursor = false,
+): string {
+  if (id === "shiftTab") return terminalKeySequence("tab", { ...modifiers, shift: true }, applicationCursor);
+
+  const parameter = terminalModifierParameter(modifiers);
+  const modified = parameter !== 1;
+
+  const csiFinal = CSI_FINAL[id];
+  if (csiFinal !== undefined) {
+    if (modified) return `${CSI}1;${parameter}${csiFinal}`;
+    return applicationCursor ? `${SS3}${csiFinal}` : `${CSI}${csiFinal}`;
+  }
+
+  const tildeCode = TILDE_CODE[id];
+  if (tildeCode !== undefined) {
+    return modified ? `${CSI}${tildeCode};${parameter}~` : `${CSI}${tildeCode}~`;
+  }
+
+  const ss3Final = SS3_FINAL[id];
+  if (ss3Final !== undefined) {
+    return modified ? `${CSI}1;${parameter}${ss3Final}` : `${SS3}${ss3Final}`;
+  }
+
+  // The remaining keys already exist as characters, so Ctrl and Alt compose onto them the same way
+  // they compose onto anything typed — Alt prefixes an Escape, Ctrl folds to a control byte.
+  const base = plainKeyCharacter(id, modifiers);
+  if (base === null) return "";
+  // Shift+Tab is already a CSI sequence, not a character, so Ctrl must not fold it to a byte.
+  const foldable = base.length === 1;
+  const controlled = modifiers.ctrl && foldable ? controlCharacterFor(base) ?? base : base;
+  return modifiers.alt ? `${ESC}${controlled}` : controlled;
+}
+
+function plainKeyCharacter(id: TerminalKeyId, modifiers: TerminalKeyModifiers): string | null {
+  switch (id) {
+    case "escape": return ESC;
+    // CSI Z is Shift+Tab's own sequence; it displaces the plain tab character rather than modifying it.
+    case "tab": return modifiers.shift ? `${CSI}Z` : TAB;
+    case "enter": return CR;
+    // Terminals read DEL as the erasing backspace; Ctrl+Backspace is the older BS byte.
+    case "backspace": return modifiers.ctrl ? BS : DEL;
+    case "space": return " ";
+    default: return null;
+  }
+}

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -448,7 +448,10 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
         // 마운트(셸 열기·세션 전환) 직후 xterm에 포커스를 줘 마우스 클릭 없이 바로 입력되게 한다.
         // 단, Map의 비활성 패널(active===false)은 건너뛴다 — 여러 패널이 마운트되며 포커스를 다투지 않게 한다.
         // 단일 셸 터미널(active===undefined)은 기존대로 포커스한다.
-        if (activeRef.current !== false) terminal.focus();
+        // 확장 패널이 열려 있을 때도 건너뛴다: 패널은 소프트 키보드를 대체한 것이라, 여기서 포커스를
+        // 돌려주면 패널 아래에서 키보드가 다시 열려 터미널이 몇 줄로 줄어든다. 터미널 마운트는 폰트
+        // 대기 뒤에 끝나므로 그 사이에 패널을 연 경우가 실제로 이 경로를 밟는다.
+        if (activeRef.current !== false && !keyPanelOpenRef.current) terminal.focus();
       };
 
       resizeObserver = new ResizeObserver(scheduleFitAndResize);
@@ -506,7 +509,8 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
   useEffect(() => {
     outputSchedulerRef.current?.setActive(active !== false);
     if (!active) return;
-    terminalRef.current?.focus();
+    // 포커스만 패널 상태를 존중한다 — 출력 따라가기는 패널 개폐와 무관하게 이어져야 한다.
+    if (!keyPanelOpenRef.current) terminalRef.current?.focus();
     scrollFollowRef.current?.resumeFollowing();
   }, [active, keyboardFocusRequestId, inputReadyEpoch]);
 

--- a/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
+++ b/runtime/fleet-plugins/terminal/client/shared/terminal-surface.tsx
@@ -4,8 +4,10 @@ import { FitAddon } from "@xterm/addon-fit";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal as XtermTerminal, type ITheme } from "@xterm/xterm";
-import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
 
+import { NO_LATCHED_MODIFIERS, TerminalKeyBar, type TerminalKeyBarModifiers } from "./terminal-key-bar.js";
+import { applyTerminalModifiers, terminalKeySequence, type TerminalKeyId } from "./terminal-key-sequences.js";
 import { createImeShiftEnterHandler } from "./ime-shift-enter.js";
 import { createTerminalConnection, type TerminalConnection } from "./terminal-connection.js";
 import { createTerminalCopyOnSelect } from "./terminal-copy-on-select.js";
@@ -20,6 +22,7 @@ import { createTerminalScrollFollow, type TerminalScrollFollowController } from 
 import { createTerminalStatusDetailReporter, type TerminalStatusDetailReporter } from "./status-detail.js";
 import { createWindowsSelectionCopyHandler } from "./windows-selection-copy.js";
 import { waitForSymbolsNerdFontMono } from "./symbols-font.js";
+import "./terminal-key-bar.css";
 
 type TerminalThemeId = "instrument" | "maritime" | "carbon" | "whites";
 
@@ -197,6 +200,18 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
   const [touchFontScale, setTouchFontScale] = useState(() => (prefersTouchTerminal() ? MIN_FONT_SCALE : 1));
   const touchFontScaleRef = useRef(touchFontScale);
   touchFontScaleRef.current = touchFontScale;
+  // A touch keyboard has no Escape, no arrows, and no Ctrl, so the surface carries them itself.
+  // The check is read once at mount: a device does not grow a keyboard mid-session, and re-reading
+  // it every render would flip the bar in and out under a hybrid's changing pointer.
+  const [keyBarVisible] = useState(prefersTouchTerminal);
+  const [keyPanelOpen, setKeyPanelOpen] = useState(false);
+  const keyPanelOpenRef = useRef(keyPanelOpen);
+  keyPanelOpenRef.current = keyPanelOpen;
+  // Ctrl and Alt latch rather than being held — a finger cannot press two keys at once — so they
+  // arm the next key and release on it, wherever that key comes from.
+  const [latchedModifiers, setLatchedModifiers] = useState<TerminalKeyBarModifiers>(NO_LATCHED_MODIFIERS);
+  const latchedModifiersRef = useRef(latchedModifiers);
+  latchedModifiersRef.current = latchedModifiers;
   // onExit는 매 렌더 새 함수일 수 있으므로 ref로 고정해 connection effect의 의존성에서 제외한다.
   const onExitRef = useRef(onExit);
   onExitRef.current = onExit;
@@ -220,6 +235,55 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
   const [mountedTerminalEpoch, setMountedTerminalEpoch] = useState(0);
   // 포커스 요청은 xterm 생성만으로는 충분하지 않고 입력 transport가 시작된 뒤에 처리해야 한다.
   const [inputReadyEpoch, setInputReadyEpoch] = useState(0);
+
+  /**
+   * Reads the latch and clears it in the same synchronous step. The clear has to land on the ref
+   * rather than waiting for the state update, because the very next thing to run is xterm's data
+   * listener — a latch still set there would apply the modifier a second time.
+   */
+  const consumeLatchedModifiers = useCallback((): TerminalKeyBarModifiers => {
+    const modifiers = latchedModifiersRef.current;
+    if (modifiers.ctrl || modifiers.alt) {
+      latchedModifiersRef.current = NO_LATCHED_MODIFIERS;
+      setLatchedModifiers(NO_LATCHED_MODIFIERS);
+    }
+    return modifiers;
+  }, []);
+  // 마운트 effect는 재실행되지 않으므로(재실행하면 세션이 끊긴다) 최신 콜백을 ref로 읽는다.
+  const consumeLatchedModifiersRef = useRef(consumeLatchedModifiers);
+  consumeLatchedModifiersRef.current = consumeLatchedModifiers;
+
+  const sendBarKey = useCallback((id: TerminalKeyId) => {
+    const terminal = terminalRef.current;
+    if (!terminal) return;
+    const { ctrl, alt } = consumeLatchedModifiers();
+    const sequence = terminalKeySequence(id, { ctrl, alt, shift: false }, terminal.modes.applicationCursorKeysMode);
+    terminal.input(sequence, true);
+  }, [consumeLatchedModifiers]);
+
+  const sendBarText = useCallback((text: string) => {
+    const terminal = terminalRef.current;
+    if (!terminal) return;
+    const { ctrl, alt } = consumeLatchedModifiers();
+    terminal.input(applyTerminalModifiers(text, { ctrl, alt, shift: false }), true);
+  }, [consumeLatchedModifiers]);
+
+  const toggleBarModifier = useCallback((modifier: "ctrl" | "alt") => {
+    const current = latchedModifiersRef.current;
+    const next = { ...current, [modifier]: !current[modifier] };
+    latchedModifiersRef.current = next;
+    setLatchedModifiers(next);
+  }, []);
+
+  const toggleKeyPanel = useCallback(() => {
+    const next = !keyPanelOpenRef.current;
+    keyPanelOpenRef.current = next;
+    setKeyPanelOpen(next);
+    // The panel takes the soft keyboard's place instead of stacking above it: a phone showing both
+    // leaves the session two or three rows tall, which is no longer a terminal.
+    if (next) terminalRef.current?.blur();
+    else terminalRef.current?.focus();
+  }, []);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -334,7 +398,12 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
             // xterm's normal scrollOnUserInput behavior resumes follow for every local input,
             // not only Enter. Keep the explicit follow state in lockstep with it.
             scrollFollow.resumeFollowing();
-            listener(data);
+            // A latched Ctrl or Alt applies to whatever arrives next, and on a phone that is
+            // usually a letter from the soft keyboard — which is the only way Ctrl+C exists there.
+            // Keys sent from the bar clear the latch before calling input(), so they arrive here
+            // already carrying their modifier and pass through untouched.
+            const { ctrl, alt } = consumeLatchedModifiersRef.current();
+            listener(ctrl || alt ? applyTerminalModifiers(data, { ctrl, alt, shift: false }) : data);
           }),
           write: (data) => {
             statusDetailReporter.push(data);
@@ -582,6 +651,19 @@ export function TerminalSurface({ operationId, ticketPath, wsPath, theme = "inst
         <div className="terminal-viewport">
           <div className="terminal-canvas" ref={containerRef} style={zoomStyle} />
         </div>
+        {/* A read-only session takes no input, so the bar stays away rather than offering keys that
+            would go nowhere. */}
+        {keyBarVisible && !isViewing ? (
+          <TerminalKeyBar
+            locale={locale}
+            modifiers={latchedModifiers}
+            expanded={keyPanelOpen}
+            onToggleModifier={toggleBarModifier}
+            onToggleExpanded={toggleKeyPanel}
+            onKey={sendBarKey}
+            onText={sendBarText}
+          />
+        ) : null}
       </div>
     </section>
   );

--- a/runtime/fleet-plugins/terminal/tests/terminal-key-bar.test.tsx
+++ b/runtime/fleet-plugins/terminal/tests/terminal-key-bar.test.tsx
@@ -1,0 +1,287 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ESC = String.fromCharCode(0x1b);
+
+const terminalMocks = vi.hoisted(() => ({
+  blur: vi.fn(),
+  focus: vi.fn(),
+  /** What the connection would put on the wire — the only place a double-applied modifier shows. */
+  sent: vi.fn<(data: string) => void>(),
+  emitData: null as ((data: string) => void) | null,
+  applicationCursorKeysMode: false,
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class Terminal {
+    readonly buffer = { active: { baseY: 0, viewportY: 0 } };
+    readonly cols = 80;
+    readonly rows = 24;
+    readonly unicode = { activeVersion: "" };
+    readonly parser = { registerOscHandler: () => ({ dispose() {} }) };
+    readonly options: Record<string, unknown> = {};
+    readonly modes = {
+      get applicationCursorKeysMode() { return terminalMocks.applicationCursorKeysMode; },
+    };
+    readonly blur = terminalMocks.blur;
+    readonly focus = terminalMocks.focus;
+    #listeners: Array<(data: string) => void> = [];
+    attachCustomKeyEventHandler() {}
+    dispose() {}
+    getSelection() { return ""; }
+    /** Real xterm routes input() back through onData, so the mock must too — that round trip is
+        exactly where a latch cleared too late would apply a modifier a second time. */
+    input(data: string) {
+      for (const listener of this.#listeners) listener(data);
+    }
+    loadAddon() {}
+    onData(listener: (data: string) => void) {
+      this.#listeners.push(listener);
+      terminalMocks.emitData = (data: string) => {
+        for (const registered of this.#listeners) registered(data);
+      };
+      return { dispose: () => { this.#listeners = []; } };
+    }
+    open() {}
+    refresh() {}
+    scrollToBottom() {}
+    scrollToLine() {}
+    write(_data: Uint8Array, callback?: () => void) { callback?.(); }
+  },
+}));
+vi.mock("@xterm/addon-fit", () => ({ FitAddon: class FitAddon { fit() {} } }));
+vi.mock("@xterm/addon-unicode11", () => ({ Unicode11Addon: class Unicode11Addon {} }));
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: class WebglAddon {
+    dispose() {}
+    onContextLoss() {}
+  },
+}));
+vi.mock("../client/shared/ime-shift-enter.js", () => ({
+  createImeShiftEnterHandler: () => ({
+    dispose() {},
+    handleKeyEvent: () => true,
+    onCompositionCancel() {},
+    onCompositionEnd() {},
+    onCompositionStart() {},
+  }),
+}));
+vi.mock("../client/shared/symbols-font.js", () => ({ waitForSymbolsNerdFontMono: () => Promise.resolve() }));
+vi.mock("../client/shared/terminal-connection.js", () => ({
+  createTerminalConnection: (options: { terminal: { onData: (listener: (data: string) => void) => unknown } }) => {
+    options.terminal.onData((data) => terminalMocks.sent(data));
+    return { dispose() {}, resize() {}, start() {} };
+  },
+}));
+vi.mock("../client/shared/terminal-copy-on-select.js", () => ({
+  createTerminalCopyOnSelect: () => ({ dispose() {} }),
+}));
+vi.mock("../client/shared/terminal-osc52-clipboard.js", () => ({
+  createTerminalOsc52Clipboard: () => ({ dispose() {} }),
+}));
+vi.mock("../client/shared/terminal-preferences.js", () => ({
+  useTerminalPrefs: () => ({ renderer: "dom", inactiveFlush: "balanced", font: { family: "monospace", size: 14 } }),
+  terminalInactiveFlushMs: () => 250,
+}));
+vi.mock("../client/shared/terminal-scroll-follow.js", () => ({
+  createTerminalScrollFollow: () => ({
+    dispose() {},
+    preserveAfterGeometryChange: (action: () => void) => action(),
+    recordUserViewportChange() {},
+    restoreAfterOutputParsing() {},
+    resumeFollowing() {},
+  }),
+}));
+vi.mock("../client/shared/windows-selection-copy.js", () => ({
+  createWindowsSelectionCopyHandler: () => ({ handleKeyEvent: () => true }),
+}));
+
+import { TerminalSurface } from "../client/shared/terminal-surface.js";
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+let fontsDescriptor: PropertyDescriptor | undefined;
+let matchMediaDescriptor: PropertyDescriptor | undefined;
+let resizeObserverDescriptor: PropertyDescriptor | undefined;
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function useCoarsePointer(coarse: boolean): void {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: (query: string) => ({
+      matches: coarse && query.includes("coarse"),
+      media: query,
+      addEventListener() {},
+      removeEventListener() {},
+    }),
+  });
+}
+
+beforeEach(() => {
+  terminalMocks.blur.mockClear();
+  terminalMocks.focus.mockClear();
+  terminalMocks.sent.mockClear();
+  terminalMocks.emitData = null;
+  terminalMocks.applicationCursorKeysMode = false;
+  fontsDescriptor = Object.getOwnPropertyDescriptor(document, "fonts");
+  Object.defineProperty(document, "fonts", { configurable: true, value: { ready: Promise.resolve() } });
+  matchMediaDescriptor = Object.getOwnPropertyDescriptor(window, "matchMedia");
+  useCoarsePointer(true);
+  resizeObserverDescriptor = Object.getOwnPropertyDescriptor(globalThis, "ResizeObserver");
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    configurable: true,
+    value: class ResizeObserver {
+      disconnect() {}
+      observe() {}
+    },
+  });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  restore(document, "fonts", fontsDescriptor);
+  restore(window, "matchMedia", matchMediaDescriptor);
+  restore(globalThis, "ResizeObserver", resizeObserverDescriptor);
+  container?.remove();
+  container = null;
+  root = null;
+});
+
+describe("TerminalKeyBar on a touch terminal", () => {
+  it("carries the keys a soft keyboard has no room for", async () => {
+    await renderSurface();
+
+    expect(keyLabels()).toEqual(["Esc", "Tab", "Ctrl", "Alt", "←", "↑", "↓", "→", "⋯"]);
+  });
+
+  it("stays away from a pointer that has a real keyboard behind it", async () => {
+    useCoarsePointer(false);
+
+    await renderSurface();
+
+    expect(container?.querySelector(".terminal-key-bar")).toBeNull();
+  });
+
+  it("sends a key's own bytes, and follows DECCKM for the cursor keys", async () => {
+    await renderSurface();
+
+    await press("Esc");
+    expect(terminalMocks.sent).toHaveBeenLastCalledWith(ESC);
+
+    await press("↑");
+    expect(terminalMocks.sent).toHaveBeenLastCalledWith(`${ESC}[A`);
+
+    terminalMocks.applicationCursorKeysMode = true;
+    await press("↑");
+    expect(terminalMocks.sent).toHaveBeenLastCalledWith(`${ESC}OA`);
+  });
+
+  it("applies a latched Ctrl to the letter the soft keyboard sends next", async () => {
+    await renderSurface();
+
+    await press("Ctrl");
+    expect(button("Ctrl")?.getAttribute("aria-pressed")).toBe("true");
+
+    await act(async () => { terminalMocks.emitData?.("c"); });
+
+    expect(terminalMocks.sent).toHaveBeenLastCalledWith(String.fromCharCode(0x03));
+    // The latch is spent on that one key, so the next letter is itself again.
+    expect(button("Ctrl")?.getAttribute("aria-pressed")).toBe("false");
+    await act(async () => { terminalMocks.emitData?.("c"); });
+    expect(terminalMocks.sent).toHaveBeenLastCalledWith("c");
+  });
+
+  it("applies a latched modifier to a bar key exactly once", async () => {
+    await renderSurface();
+
+    await press("Ctrl");
+    await press("←");
+
+    // input() re-enters the same data listener, so a latch cleared too late would encode twice.
+    expect(terminalMocks.sent).toHaveBeenCalledTimes(1);
+    expect(terminalMocks.sent).toHaveBeenLastCalledWith(`${ESC}[1;5D`);
+  });
+
+  it("opens the extra keys in the keyboard's place rather than above it", async () => {
+    await renderSurface();
+
+    await press("⋯");
+
+    expect(terminalMocks.blur).toHaveBeenCalledTimes(1);
+    expect(keyLabels()).toContain("PgUp");
+    expect(keyLabels()).toContain("F12");
+    expect(keyLabels()).toContain("|");
+
+    const focusCallsWhileOpen = terminalMocks.focus.mock.calls.length;
+    await press("⋯");
+
+    expect(keyLabels()).not.toContain("PgUp");
+    expect(terminalMocks.focus.mock.calls.length).toBe(focusCallsWhileOpen + 1);
+  });
+
+  it("sends a symbol as itself", async () => {
+    await renderSurface();
+    await press("⋯");
+
+    await press("|");
+
+    expect(terminalMocks.sent).toHaveBeenLastCalledWith("|");
+  });
+
+  it("keeps focus on the terminal when a key is pressed", async () => {
+    await renderSurface();
+    const escape = button("Esc");
+    const event = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+
+    escape?.dispatchEvent(event);
+
+    // A press that moved focus would close the soft keyboard mid-session.
+    expect(event.defaultPrevented).toBe(true);
+  });
+});
+
+async function renderSurface(): Promise<void> {
+  await act(async () => {
+    root!.render(createElement(TerminalSurface, {
+      operationId: "operation-a",
+      ticketPath: "/ticket",
+      wsPath: "/terminal",
+      active: true,
+    }));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function keyButtons(): readonly HTMLButtonElement[] {
+  return Array.from(container?.querySelectorAll<HTMLButtonElement>(".terminal-key") ?? []);
+}
+
+function keyLabels(): readonly string[] {
+  return keyButtons().map((element) => element.textContent ?? "");
+}
+
+function button(label: string): HTMLButtonElement | undefined {
+  return keyButtons().find((element) => element.textContent === label);
+}
+
+async function press(label: string): Promise<void> {
+  const target = button(label);
+  if (!target) throw new Error(`No key labelled ${label}`);
+  await act(async () => {
+    target.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await Promise.resolve();
+  });
+}
+
+function restore(target: object, property: string, descriptor: PropertyDescriptor | undefined): void {
+  if (descriptor) Object.defineProperty(target, property, descriptor);
+  else Reflect.deleteProperty(target, property);
+}

--- a/runtime/fleet-plugins/terminal/tests/terminal-key-bar.test.tsx
+++ b/runtime/fleet-plugins/terminal/tests/terminal-key-bar.test.tsx
@@ -13,6 +13,8 @@ const terminalMocks = vi.hoisted(() => ({
   sent: vi.fn<(data: string) => void>(),
   emitData: null as ((data: string) => void) | null,
   applicationCursorKeysMode: false,
+  /** Swapped for a deferred promise to hold the terminal in its pre-mount state. */
+  symbolsReady: Promise.resolve(),
 }));
 
 vi.mock("@xterm/xterm", () => ({
@@ -69,7 +71,7 @@ vi.mock("../client/shared/ime-shift-enter.js", () => ({
     onCompositionStart() {},
   }),
 }));
-vi.mock("../client/shared/symbols-font.js", () => ({ waitForSymbolsNerdFontMono: () => Promise.resolve() }));
+vi.mock("../client/shared/symbols-font.js", () => ({ waitForSymbolsNerdFontMono: () => terminalMocks.symbolsReady }));
 vi.mock("../client/shared/terminal-connection.js", () => ({
   createTerminalConnection: (options: { terminal: { onData: (listener: (data: string) => void) => unknown } }) => {
     options.terminal.onData((data) => terminalMocks.sent(data));
@@ -127,6 +129,7 @@ beforeEach(() => {
   terminalMocks.sent.mockClear();
   terminalMocks.emitData = null;
   terminalMocks.applicationCursorKeysMode = false;
+  terminalMocks.symbolsReady = Promise.resolve();
   fontsDescriptor = Object.getOwnPropertyDescriptor(document, "fonts");
   Object.defineProperty(document, "fonts", { configurable: true, value: { ready: Promise.resolve() } });
   matchMediaDescriptor = Object.getOwnPropertyDescriptor(window, "matchMedia");
@@ -226,6 +229,39 @@ describe("TerminalKeyBar on a touch terminal", () => {
     expect(terminalMocks.focus.mock.calls.length).toBe(focusCallsWhileOpen + 1);
   });
 
+  it("does not refocus the terminal while the panel stands in for the keyboard", async () => {
+    await renderSurface();
+    await press("⋯");
+    const focusCallsWhileOpen = terminalMocks.focus.mock.calls.length;
+
+    // A focus request — reselecting the operation, the session becoming active again — must not
+    // reopen the soft keyboard underneath the open panel.
+    await renderSurface({ keyboardFocusRequestId: 2 });
+
+    expect(terminalMocks.focus.mock.calls.length).toBe(focusCallsWhileOpen);
+  });
+
+  it("does not let a terminal that mounts later steal focus back", async () => {
+    // The bar renders before xterm finishes mounting, so the panel can open while terminalRef is
+    // still null — the blur lands nowhere, and the mount's own focus would undo the replacement.
+    let releaseSymbols!: () => void;
+    terminalMocks.symbolsReady = new Promise<void>((resolve) => { releaseSymbols = () => resolve(); });
+
+    await renderSurface();
+    await press("⋯");
+    expect(terminalMocks.focus).not.toHaveBeenCalled();
+
+    await act(async () => {
+      releaseSymbols();
+      await terminalMocks.symbolsReady;
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(terminalMocks.focus).not.toHaveBeenCalled();
+  });
+
   it("sends a symbol as itself", async () => {
     await renderSurface();
     await press("⋯");
@@ -247,13 +283,14 @@ describe("TerminalKeyBar on a touch terminal", () => {
   });
 });
 
-async function renderSurface(): Promise<void> {
+async function renderSurface(overrides: { readonly keyboardFocusRequestId?: number } = {}): Promise<void> {
   await act(async () => {
     root!.render(createElement(TerminalSurface, {
       operationId: "operation-a",
       ticketPath: "/ticket",
       wsPath: "/terminal",
       active: true,
+      ...overrides,
     }));
     await Promise.resolve();
     await Promise.resolve();

--- a/runtime/fleet-plugins/terminal/tests/terminal-key-sequences.test.ts
+++ b/runtime/fleet-plugins/terminal/tests/terminal-key-sequences.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyTerminalModifiers,
+  controlCharacterFor,
+  terminalKeySequence,
+  terminalModifierParameter,
+  type TerminalKeyModifiers,
+} from "../client/shared/terminal-key-sequences.js";
+
+const ESC = String.fromCharCode(0x1b);
+const NONE: TerminalKeyModifiers = { ctrl: false, alt: false, shift: false };
+const CTRL: TerminalKeyModifiers = { ctrl: true, alt: false, shift: false };
+const ALT: TerminalKeyModifiers = { ctrl: false, alt: true, shift: false };
+
+describe("terminalKeySequence", () => {
+  it("sends cursor keys as CSI, and as SS3 once the program turns on DECCKM", () => {
+    expect(terminalKeySequence("up", NONE, false)).toBe(`${ESC}[A`);
+    expect(terminalKeySequence("left", NONE, false)).toBe(`${ESC}[D`);
+    expect(terminalKeySequence("up", NONE, true)).toBe(`${ESC}OA`);
+    expect(terminalKeySequence("home", NONE, true)).toBe(`${ESC}OH`);
+  });
+
+  it("encodes a modified cursor key as CSI with a parameter, never as SS3", () => {
+    // SS3 has nowhere to carry a modifier, so even under DECCKM the modified form is CSI.
+    expect(terminalKeySequence("left", CTRL, true)).toBe(`${ESC}[1;5D`);
+    expect(terminalKeySequence("right", ALT, false)).toBe(`${ESC}[1;3C`);
+    expect(terminalKeySequence("end", { ctrl: true, alt: true, shift: false }, false)).toBe(`${ESC}[1;7F`);
+  });
+
+  it("numbers the tilde-encoded keys the way xterm does", () => {
+    expect(terminalKeySequence("insert")).toBe(`${ESC}[2~`);
+    expect(terminalKeySequence("delete")).toBe(`${ESC}[3~`);
+    expect(terminalKeySequence("pageUp")).toBe(`${ESC}[5~`);
+    expect(terminalKeySequence("pageDown")).toBe(`${ESC}[6~`);
+    expect(terminalKeySequence("delete", CTRL)).toBe(`${ESC}[3;5~`);
+  });
+
+  it("splits the function keys between SS3 and tilde forms at F5", () => {
+    expect(terminalKeySequence("f1")).toBe(`${ESC}OP`);
+    expect(terminalKeySequence("f4")).toBe(`${ESC}OS`);
+    expect(terminalKeySequence("f5")).toBe(`${ESC}[15~`);
+    expect(terminalKeySequence("f12")).toBe(`${ESC}[24~`);
+    // 16 is skipped in xterm's numbering; F6 must not drift onto it.
+    expect(terminalKeySequence("f6")).toBe(`${ESC}[17~`);
+    expect(terminalKeySequence("f1", CTRL)).toBe(`${ESC}[1;5P`);
+  });
+
+  it("keeps Shift+Tab as its own sequence rather than a modified tab", () => {
+    expect(terminalKeySequence("tab")).toBe(String.fromCharCode(0x09));
+    expect(terminalKeySequence("shiftTab")).toBe(`${ESC}[Z`);
+    // Ctrl must not fold a multi-byte sequence down to a single control byte.
+    expect(terminalKeySequence("shiftTab", CTRL)).toBe(`${ESC}[Z`);
+  });
+
+  it("composes Ctrl and Alt onto the keys that are characters", () => {
+    expect(terminalKeySequence("escape")).toBe(ESC);
+    expect(terminalKeySequence("escape", ALT)).toBe(`${ESC}${ESC}`);
+    expect(terminalKeySequence("enter")).toBe(String.fromCharCode(0x0d));
+    expect(terminalKeySequence("backspace")).toBe(String.fromCharCode(0x7f));
+    expect(terminalKeySequence("backspace", CTRL)).toBe(String.fromCharCode(0x08));
+    expect(terminalKeySequence("space", CTRL)).toBe(String.fromCharCode(0x00));
+  });
+});
+
+describe("controlCharacterFor", () => {
+  it("folds letters onto their control bytes in either case", () => {
+    expect(controlCharacterFor("c")).toBe(String.fromCharCode(0x03));
+    expect(controlCharacterFor("C")).toBe(String.fromCharCode(0x03));
+    expect(controlCharacterFor("d")).toBe(String.fromCharCode(0x04));
+  });
+
+  it("knows the punctuation that carries a control byte, and refuses the rest", () => {
+    expect(controlCharacterFor("[")).toBe(ESC);
+    expect(controlCharacterFor("?")).toBe(String.fromCharCode(0x7f));
+    expect(controlCharacterFor(" ")).toBe(String.fromCharCode(0x00));
+    // A pairing with no control code must not be guessed into some other byte.
+    expect(controlCharacterFor("가")).toBeNull();
+    expect(controlCharacterFor("ab")).toBeNull();
+  });
+});
+
+describe("applyTerminalModifiers", () => {
+  it("applies a latched Ctrl to a character the soft keyboard produced", () => {
+    expect(applyTerminalModifiers("c", CTRL)).toBe(String.fromCharCode(0x03));
+    expect(applyTerminalModifiers("b", ALT)).toBe(`${ESC}b`);
+    expect(applyTerminalModifiers("x", { ctrl: true, alt: true, shift: false })).toBe(`${ESC}${String.fromCharCode(0x18)}`);
+  });
+
+  it("passes text through untouched with no modifier latched", () => {
+    expect(applyTerminalModifiers("c", NONE)).toBe("c");
+  });
+
+  it("leaves a character Ctrl has no encoding for as itself", () => {
+    expect(applyTerminalModifiers("가", CTRL)).toBe("가");
+  });
+
+  it("never rewrites multi-character input", () => {
+    // A paste or an IME commit arrives as one data event; prefixing or folding it would corrupt it.
+    expect(applyTerminalModifiers("hello", CTRL)).toBe("hello");
+    expect(applyTerminalModifiers("hello", ALT)).toBe("hello");
+  });
+});
+
+describe("terminalModifierParameter", () => {
+  it("encodes each modifier as its own bit above 1", () => {
+    expect(terminalModifierParameter(NONE)).toBe(1);
+    expect(terminalModifierParameter({ ctrl: false, alt: false, shift: true })).toBe(2);
+    expect(terminalModifierParameter(ALT)).toBe(3);
+    expect(terminalModifierParameter(CTRL)).toBe(5);
+    expect(terminalModifierParameter({ ctrl: true, alt: true, shift: true })).toBe(8);
+  });
+});


### PR DESCRIPTION
## Summary
- 터치 화면에서 연 터미널에 소프트 키보드가 빠뜨리는 키를 얹습니다. 상시 한 줄에 `Esc Tab Ctrl Alt ← ↑ ↓ →`, `⋯` 뒤에 `⇧Tab ↵ ⌫ Del Ins` · `Home End PgUp PgDn Space` · `F1~F12` · 셸 기호 16종을 둡니다. 확장 패널은 소프트 키보드 위에 쌓이지 않고 그 자리를 대신합니다.
- Ctrl·Alt는 누르고 있을 수 없는 손가락을 위해 래치식입니다. 다음 키 하나 — 키 바에서 오든 소프트 키보드 문자로 오든 — 에 적용되고 소비됩니다. 커서 키는 DECCKM을 따라 CSI/SS3를 가르고, 수정자가 붙으면 CSI 파라미터 형식으로 보냅니다.
- 폰에서 터미널이 26px로 접히던 문제를 함께 고쳤습니다. `.operation-body-mount`가 block이라 `.terminal-stage`의 `flex:1`이 아무것도 나눠 받지 못했고, Canvas 경로에만 있던 선언을 폰 경로에도 둡니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/terminal typecheck` — 0 오류
- [x] `pnpm --filter @fleet-plugins/terminal test` — 579건 통과 (신규 21건 포함: 시퀀스 매핑·래치 1회 소비·이중 적용 방지·포커스 유지·비터치 미표시)
- [x] `pnpm --filter @dotobokuri/fleet-console vitest run tests/instrument-design-contract.test.ts` — 56건 통과 (신규 CSS 포함 스캔, 하드코딩 색 0)
- [x] `node scripts/compile-changelog-fragments.mjs --check` — OK
- [x] Android 에뮬레이터 + 격리 콘솔 LAN 페어링 실측
  - `cat -v`에 `^[` · 탭 · `^[[D^[[A^[[B^[[C` 도달
  - 셸 라인 편집에서 ← 5회 후 삽입 위치가 실제로 이동
  - Claude Code(Gateway, Opus): 신뢰 프롬프트에서 ↓로 선택 마커 이동, ⇧Tab으로 `bypass permissions on` → `auto mode on` 순환
  - Ctrl 래치 후 소프트 키보드 `a` → `^A`, 이후 자동 해제
  - instrument · maritime · carbon · whites 4개 테마에서 키 캡과 래치 강조가 각 테마 토큰으로 재조율
- [ ] 실기기 검증 (에뮬레이터만 수행)