### PR TITLE
feat(fleet-console): reveal the rail panel header on approach

### DIFF
--- a/.changelog.d/rail-header-hover-reveal.md
+++ b/.changelog.d/rail-header-hover-reveal.md
@@ -1,0 +1,8 @@
+---
+branch: rail-header-hover-reveal
+---
+
+### fleet-console
+#### Changed
+- The right rail panel header no longer occupies a resident row; it now reveals as an overlay when the pointer approaches the panel top (or via keyboard focus and a top-edge tap on touch), returning its full height to panel content, and Escape inside the revealed header closes the panel.
+  ko: 우측 레일 패널 헤더가 상주 줄을 차지하지 않고, 포인터가 패널 상단에 접근할 때(키보드 포커스·터치 상단 가장자리 탭 포함) 오버레이로 나타나 헤더 높이 전체를 패널 콘텐츠에 돌려주며, 표시된 헤더 안에서 Escape로 패널을 닫을 수 있습니다.

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -25,6 +25,13 @@ interface RightRailProps {
 
 const MIN_PANEL_WIDTH = 240;
 const DEFAULT_PANEL_WIDTH = 312;
+// 호버-리빌 헤더 입력 계약: 진입은 pointermove로만 판정하고(스크롤-언더-포인터 오발화 방지)
+// 의도 지연을 거친다. 24px 진입 띠와 64px 이탈 경계 사이는 히스테리시스 중립 지대다.
+const HEAD_REVEAL_ZONE_PX = 24;
+const HEAD_REVEAL_TOUCH_ZONE_PX = 40;
+const HEAD_HIDE_BOUNDARY_PX = 64;
+const HEAD_REVEAL_INTENT_DELAY_MS = 120;
+const HEAD_HIDE_DELAY_MS = 320;
 const PREFS_PANEL_WIDTHS = "fleet-console.rail.panelWidths";
 const LEGACY_PREFS_PANEL_WIDTH = "fleet-console.rail.panelWidth";
 
@@ -130,6 +137,89 @@ export function RightRail({ theaterId, api }: RightRailProps) {
   const panelWidthRef = useRef(panelWidth);
   const [isDragging, setIsDragging] = useState(false);
   const [isSwitching, setIsSwitching] = useState(false);
+  const [headRevealed, setHeadRevealed] = useState(false);
+  const headRevealedRef = useRef(headRevealed);
+  headRevealedRef.current = headRevealed;
+  const revealIntentTimerRef = useRef<number | null>(null);
+  const hideHeadTimerRef = useRef<number | null>(null);
+
+  const cancelRevealIntent = useCallback(() => {
+    if (revealIntentTimerRef.current === null) return;
+    window.clearTimeout(revealIntentTimerRef.current);
+    revealIntentTimerRef.current = null;
+  }, []);
+
+  const cancelHeadHide = useCallback(() => {
+    if (hideHeadTimerRef.current === null) return;
+    window.clearTimeout(hideHeadTimerRef.current);
+    hideHeadTimerRef.current = null;
+  }, []);
+
+  const holdHeadOpen = useCallback(() => {
+    cancelHeadHide();
+    cancelRevealIntent();
+    if (!headRevealedRef.current) setHeadRevealed(true);
+  }, [cancelHeadHide, cancelRevealIntent]);
+
+  const scheduleHeadHide = useCallback(() => {
+    cancelRevealIntent();
+    if (!headRevealedRef.current || hideHeadTimerRef.current !== null) return;
+    hideHeadTimerRef.current = window.setTimeout(() => {
+      hideHeadTimerRef.current = null;
+      setHeadRevealed(false);
+    }, HEAD_HIDE_DELAY_MS);
+  }, [cancelRevealIntent]);
+
+  // 패널이 바뀌거나 닫히면 리빌 상태를 초기화한다.
+  useLayoutEffect(() => {
+    cancelRevealIntent();
+    cancelHeadHide();
+    setHeadRevealed(false);
+  }, [activeId, cancelHeadHide, cancelRevealIntent]);
+
+  useLayoutEffect(() => () => {
+    cancelRevealIntent();
+    cancelHeadHide();
+  }, [cancelHeadHide, cancelRevealIntent]);
+
+  const handleSlotPointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    // 진입 판정은 hover 포인터에만 적용한다. 터치는 pointerdown 폴백이 담당한다.
+    if (event.pointerType === "touch") return;
+    const slotTop = event.currentTarget.getBoundingClientRect().top;
+    const y = event.clientY - slotTop;
+    if (y <= HEAD_REVEAL_ZONE_PX) {
+      cancelHeadHide();
+      if (headRevealedRef.current || revealIntentTimerRef.current !== null) return;
+      revealIntentTimerRef.current = window.setTimeout(() => {
+        revealIntentTimerRef.current = null;
+        setHeadRevealed(true);
+      }, HEAD_REVEAL_INTENT_DELAY_MS);
+      return;
+    }
+    cancelRevealIntent();
+    if (y > HEAD_HIDE_BOUNDARY_PX) scheduleHeadHide();
+  }, [cancelHeadHide, cancelRevealIntent, scheduleHeadHide]);
+
+  const handleSlotPointerLeave = useCallback(() => {
+    cancelRevealIntent();
+    scheduleHeadHide();
+  }, [cancelRevealIntent, scheduleHeadHide]);
+
+  const handleSlotPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.pointerType !== "touch") return;
+    const slotTop = event.currentTarget.getBoundingClientRect().top;
+    const y = event.clientY - slotTop;
+    if (!headRevealedRef.current) {
+      // 상단 가장자리 탭 = 리빌. preventDefault 없이 콘텐츠 탭도 그대로 통과시킨다.
+      if (y <= HEAD_REVEAL_TOUCH_ZONE_PX) holdHeadOpen();
+      return;
+    }
+    const target = event.target instanceof Element ? event.target : null;
+    if (target?.closest(".right-rail-panel-head-reveal") === null) {
+      cancelHeadHide();
+      setHeadRevealed(false);
+    }
+  }, [cancelHeadHide, holdHeadOpen]);
 
   useLayoutEffect(() => {
     const onResize = () => {
@@ -274,6 +364,9 @@ export function RightRail({ theaterId, api }: RightRailProps) {
         style={panelBehavior === "overlay"
           ? { "--right-rail-overlay-alpha": overlayAlpha / 100 } as CSSProperties
           : undefined}
+        onPointerMove={hasPanel ? handleSlotPointerMove : undefined}
+        onPointerLeave={hasPanel ? handleSlotPointerLeave : undefined}
+        onPointerDown={hasPanel ? handleSlotPointerDown : undefined}
       >
         {activePanel && (
           <div
@@ -292,7 +385,15 @@ export function RightRail({ theaterId, api }: RightRailProps) {
         )}
         {activePanel && (
           <>
-            <RailPanelHead activePanelTitle={activePanelTitle} panelBehavior={panelBehavior} overlayAlpha={overlayAlpha} />
+            <RailPanelHead
+              activePanelTitle={activePanelTitle}
+              panelBehavior={panelBehavior}
+              overlayAlpha={overlayAlpha}
+              revealed={headRevealed}
+              onHoldOpen={holdHeadOpen}
+              onRelease={scheduleHeadHide}
+            />
+            <div className="right-rail-panel-peek" aria-hidden="true" />
             <RailPanelBody activePanel={activePanel} activeId={activeId} ctx={ctx} connection={connection} connectionLostAt={connectionLostAt} language={language} />
           </>
         )}
@@ -318,49 +419,81 @@ interface RailPanelHeadProps {
   readonly activePanelTitle: string;
   readonly panelBehavior: "push" | "overlay";
   readonly overlayAlpha: RailOverlayAlpha;
+  readonly revealed: boolean;
+  readonly onHoldOpen: () => void;
+  readonly onRelease: () => void;
 }
 
-function RailPanelHead({ activePanelTitle, panelBehavior, overlayAlpha }: RailPanelHeadProps) {
+// 헤더의 세 통제(타이틀·플로팅·닫기)는 전부 저빈도라 상시 46px 대신 호버-리빌
+// 오버레이로 소환한다. 숨김 상태에서도 DOM에 남아 Tab 진입(focus)이 리빌 경로가 된다.
+function RailPanelHead({ activePanelTitle, panelBehavior, overlayAlpha, revealed, onHoldOpen, onRelease }: RailPanelHeadProps) {
   const t = useT();
 
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    // slot의 진입/이탈 판정으로 버블되면 46px 헤더 하단부(y>24px)가 이탈로 오판된다.
+    event.stopPropagation();
+    onHoldOpen();
+  };
+
+  const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
+    if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) return;
+    onRelease();
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Escape") return;
+    // Esc 닫기는 헤더 포커스 범위로 한정한다 — 패널 본문(Shell PTY 등)의 Esc 어휘를 뺏지 않는다.
+    event.stopPropagation();
+    closeRailPanel();
+  };
+
   return (
-    <div className="right-rail-panel-head">
-      <span className="right-rail-panel-title">{activePanelTitle}</span>
-      <button
-        className={`right-rail-float-toggle${panelBehavior === "overlay" ? " is-active" : ""}`}
-        type="button"
-        aria-pressed={panelBehavior === "overlay"}
-        aria-label={t("rail.chrome.floatToggle")}
-        title={t("rail.chrome.floatLabel")}
-        onClick={toggleRailPanelBehavior}
-      >
-        <svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="1.5" y="2.5" width="13" height="11" rx="1.5" stroke="currentColor" /><rect x="7.5" y="7.5" width="5" height="4" rx="1" fill="currentColor" /></svg>
-      </button>
-      {panelBehavior === "overlay" ? (
-        <div className="right-rail-alpha">
-          <input
-            className="right-rail-alpha-slider"
-            type="range"
-            min={RAIL_OVERLAY_ALPHA_MIN}
-            max={RAIL_OVERLAY_ALPHA_MAX}
-            step={1}
-            value={overlayAlpha}
-            aria-label={t("rail.chrome.opacityAria")}
-            onChange={(event) => setRailOverlayAlpha(Number(event.currentTarget.value))}
-            onDoubleClick={() => setRailOverlayAlpha(RAIL_OVERLAY_ALPHA_DEFAULT)}
-            style={{ "--alpha-fill": `${((overlayAlpha - RAIL_OVERLAY_ALPHA_MIN) / (RAIL_OVERLAY_ALPHA_MAX - RAIL_OVERLAY_ALPHA_MIN)) * 100}%` } as CSSProperties}
-          />
-          <span className="right-rail-alpha-value" aria-hidden="true">{overlayAlpha}%</span>
-        </div>
-      ) : null}
-      <button
-        className="right-rail-close-btn"
-        type="button"
-        aria-label={t("rail.chrome.closePanel", { title: activePanelTitle })}
-        onClick={closeRailPanel}
-      >
-        ✕
-      </button>
+    <div
+      className={`right-rail-panel-head-reveal${revealed ? " is-revealed" : ""}`}
+      onPointerMove={handlePointerMove}
+      onPointerLeave={onRelease}
+      onFocusCapture={onHoldOpen}
+      onBlurCapture={handleBlur}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="right-rail-panel-head">
+        <span className="right-rail-panel-title">{activePanelTitle}</span>
+        <button
+          className={`right-rail-float-toggle${panelBehavior === "overlay" ? " is-active" : ""}`}
+          type="button"
+          aria-pressed={panelBehavior === "overlay"}
+          aria-label={t("rail.chrome.floatToggle")}
+          title={t("rail.chrome.floatLabel")}
+          onClick={toggleRailPanelBehavior}
+        >
+          <svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="1.5" y="2.5" width="13" height="11" rx="1.5" stroke="currentColor" /><rect x="7.5" y="7.5" width="5" height="4" rx="1" fill="currentColor" /></svg>
+        </button>
+        {panelBehavior === "overlay" ? (
+          <div className="right-rail-alpha">
+            <input
+              className="right-rail-alpha-slider"
+              type="range"
+              min={RAIL_OVERLAY_ALPHA_MIN}
+              max={RAIL_OVERLAY_ALPHA_MAX}
+              step={1}
+              value={overlayAlpha}
+              aria-label={t("rail.chrome.opacityAria")}
+              onChange={(event) => setRailOverlayAlpha(Number(event.currentTarget.value))}
+              onDoubleClick={() => setRailOverlayAlpha(RAIL_OVERLAY_ALPHA_DEFAULT)}
+              style={{ "--alpha-fill": `${((overlayAlpha - RAIL_OVERLAY_ALPHA_MIN) / (RAIL_OVERLAY_ALPHA_MAX - RAIL_OVERLAY_ALPHA_MIN)) * 100}%` } as CSSProperties}
+            />
+            <span className="right-rail-alpha-value" aria-hidden="true">{overlayAlpha}%</span>
+          </div>
+        ) : null}
+        <button
+          className="right-rail-close-btn"
+          type="button"
+          aria-label={t("rail.chrome.closePanel", { title: activePanelTitle })}
+          onClick={closeRailPanel}
+        >
+          ✕
+        </button>
+      </div>
     </div>
   );
 }

--- a/runtime/fleet-console/core/client/src/rail/right-rail.tsx
+++ b/runtime/fleet-console/core/client/src/rail/right-rail.tsx
@@ -161,14 +161,22 @@ export function RightRail({ theaterId, api }: RightRailProps) {
     if (!headRevealedRef.current) setHeadRevealed(true);
   }, [cancelHeadHide, cancelRevealIntent]);
 
+  const hideHeadUnlessFocused = useCallback(() => {
+    // 포커스가 헤더 안에 남아 있는 동안은 어떤 경로로도 숨기지 않는다 — 숨기면 포커스가
+    // 투명한 컨트롤에 갇힌다. 포커스가 떠나면 헤더의 블러 핸들러가 숨김을 다시 예약한다.
+    const active = document.activeElement;
+    if (active instanceof Element && active.closest(".right-rail-panel-head-reveal") !== null) return;
+    setHeadRevealed(false);
+  }, []);
+
   const scheduleHeadHide = useCallback(() => {
     cancelRevealIntent();
     if (!headRevealedRef.current || hideHeadTimerRef.current !== null) return;
     hideHeadTimerRef.current = window.setTimeout(() => {
       hideHeadTimerRef.current = null;
-      setHeadRevealed(false);
+      hideHeadUnlessFocused();
     }, HEAD_HIDE_DELAY_MS);
-  }, [cancelRevealIntent]);
+  }, [cancelRevealIntent, hideHeadUnlessFocused]);
 
   // 패널이 바뀌거나 닫히면 리빌 상태를 초기화한다.
   useLayoutEffect(() => {
@@ -217,9 +225,9 @@ export function RightRail({ theaterId, api }: RightRailProps) {
     const target = event.target instanceof Element ? event.target : null;
     if (target?.closest(".right-rail-panel-head-reveal") === null) {
       cancelHeadHide();
-      setHeadRevealed(false);
+      hideHeadUnlessFocused();
     }
-  }, [cancelHeadHide, holdHeadOpen]);
+  }, [cancelHeadHide, hideHeadUnlessFocused, holdHeadOpen]);
 
   useLayoutEffect(() => {
     const onResize = () => {

--- a/runtime/fleet-console/core/client/src/styles/rail.css
+++ b/runtime/fleet-console/core/client/src/styles/rail.css
@@ -51,7 +51,8 @@
   max-width: calc(100vw - 148px);
   overflow: hidden;
   display: grid;
-  grid-template-rows: auto 1fr;
+  /* 헤더는 호버-리빌 오버레이(absolute)로 빠져 본문이 슬롯 전체 높이를 쓴다. */
+  grid-template-rows: minmax(0, 1fr);
   transition: width var(--duration-base) var(--ease-spring);
 }
 
@@ -92,6 +93,54 @@
   pointer-events: none;
 }
 
+/* ── 호버-리빌 헤더 ─────────────────────────────────────────────────
+   세 통제(타이틀·플로팅·닫기)는 전부 저빈도 set-and-forget이라 46px 상주 대신
+   상단 접근 시에만 본문 위 오버레이로 소환한다(진입 판정은 right-rail.tsx의
+   pointermove+의도 지연 계약). 숨김은 opacity+transform으로만 처리해 Tab
+   포커스 진입이 리빌 경로로 남는다. */
+.right-rail-panel-head-reveal {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 3;
+  transform: translateY(-100%);
+  opacity: 0;
+  pointer-events: none;
+  border-bottom: 1px solid var(--surface-rim);
+  /* 본문 위에 얹히는 오버레이라 glass 카드와 같은 불투명 언더레이가 필요하다. */
+  background: color-mix(in oklch, var(--surface-glass-strong) 92%, var(--ink-deep));
+  /* Near-achromatic depth shadow is a sanctioned raw-literal exception. */
+  box-shadow: 0 10px 26px oklch(0% 0 0 / 40%);
+  transition: transform 180ms var(--ease-spring), opacity 140ms ease;
+}
+
+.right-rail-panel-head-reveal.is-revealed {
+  transform: none;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* 리빌 힌트 — 헤더가 숨어 있음을 알리는 유일한 상주 크롬(3px 대시). */
+.right-rail-panel-peek {
+  position: absolute;
+  top: 5px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 30px;
+  height: 3px;
+  border-radius: 2px;
+  z-index: 2;
+  background: var(--text-tertiary);
+  opacity: 0.32;
+  pointer-events: none;
+  transition: opacity 140ms ease;
+}
+
+.right-rail-panel-head-reveal.is-revealed + .right-rail-panel-peek {
+  opacity: 0;
+}
+
 .right-rail-panel-head {
   position: relative;
   z-index: 1;
@@ -100,7 +149,6 @@
   align-items: center;
   gap: 6px;
   padding: 9px 44px 9px 10px;
-  border-bottom: 1px solid var(--surface-rim);
   min-height: 46px;
   min-width: 240px;
 }
@@ -448,7 +496,9 @@
 /* ── prefers-reduced-motion 단락 ───────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   .right-rail,
-  .right-rail-panel-slot {
+  .right-rail-panel-slot,
+  .right-rail-panel-head-reveal,
+  .right-rail-panel-peek {
     transition: none !important;
   }
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -991,6 +991,16 @@ describe("Instrument core design contract", () => {
     expect(rightRail).toContain("right-rail-alpha-slider");
     expect(rightRail).toContain("is-switching");
     expect(railStore).toContain("fleet-console.rail.panelBehavior");
+    // Doctrine: the panel head is hover-reveal chrome, not resident chrome — it hides
+    // with opacity+transform only (never display/visibility) so keyboard focus can
+    // still enter and reveal it, and its reveal entry stays pointermove-gated with an
+    // intent delay so scroll-under-pointer never triggers it.
+    expect(rail).toContain(".right-rail-panel-head-reveal");
+    expect(rail).toMatch(/\.right-rail-panel-head-reveal \{[^}]*pointer-events:\s*none/);
+    expect(rail).toMatch(/\.right-rail-panel-head-reveal\.is-revealed \{[^}]*pointer-events:\s*auto/);
+    expect(rail).toMatch(/@media \(prefers-reduced-motion: reduce\) \{[^{]*\.right-rail-panel-head-reveal/);
+    expect(rightRail).toContain("HEAD_REVEAL_INTENT_DELAY_MS");
+    expect(rightRail).not.toMatch(/onPointerEnter=\{(?:handleSlotPointerMove|holdHeadOpen)/);
   });
 
   it("pins the popup opacity underlay contract", () => {


### PR DESCRIPTION
## Summary
- 우측 레일 패널 헤더(타이틀·플로팅 토글·불투명도·닫기)를 상주 46px 줄에서 **호버-리빌 오버레이**로 전환해 헤더 높이 전체를 패널 콘텐츠에 돌려줍니다. 상주 크롬은 3px 픽 힌트 하나입니다.
- 진입 판정은 pointermove + 120ms 의도 지연(스크롤-언더-포인터 오발화 방지, pointerenter 미사용)이며 24px 진입/64px 이탈 히스테리시스를 둡니다. 키보드 Tab 포커스 진입과 터치 상단 가장자리 탭도 리빌 경로입니다. 숨김은 opacity+transform으로만 처리해 포커스 진입이 살아 있습니다.
- 표시된 헤더 안에서 Escape로 패널을 닫습니다 — Esc 처리는 헤더 포커스 범위로 한정해 패널 본문(Shell PTY 등)의 Esc 어휘를 침범하지 않습니다. 새 리빌 문법은 디자인 계약 테스트에 함께 고정했습니다.

## Test Plan
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck` — 통과 (tsc 0 오류)
- [x] `pnpm --filter @dotobokuri/fleet-console test` — 171 파일 / 1992 테스트 통과
- [x] `pnpm --filter @dotobokuri/fleet-console build` — 통과
- [x] `node scripts/compile-changelog-fragments.mjs --check` — 15개 프래그먼트 검증 통과
- [x] 격리 콘솔 실브라우저 검증 — 본문 486→532px(+46px), 의도 지연(60ms 미발화/250ms 발화), 헤더 유지(stopPropagation), 플로팅 토글·알파 슬라이더 동작, 포커스 리빌, Esc 닫기, 터치 탭 리빌, 콘솔 에러 0