### PR TITLE
fix(ai-gateway): add Cursor Grok 4.6 models

### DIFF
--- a/.changelog.d/fix-cursor-grok-4-6.md
+++ b/.changelog.d/fix-cursor-grok-4-6.md
@@ -1,0 +1,13 @@
+---
+branch: fix-cursor-grok-4-6
+---
+
+### fleet-cli
+#### Added
+- Add Cursor Grok 4.6 and Grok 4.6 Fast with Low, Medium, High, and Extra High reasoning levels while retaining Grok 4.5.
+  ko: Cursor Grok 4.5를 유지하면서 Grok 4.6과 Grok 4.6 Fast를 Low, Medium, High, Extra High 추론 강도로 추가합니다.
+
+### fleet-console
+#### Added
+- Offer Cursor Grok 4.6 and Grok 4.6 Fast in AI Gateway model selection with CursorBench 3.2 quality evidence.
+  ko: AI Gateway 모델 선택에 Cursor Grok 4.6과 Grok 4.6 Fast를 CursorBench 3.2 품질 근거와 함께 제공합니다.

--- a/packages/core-ai-gateway/benchmarks.json
+++ b/packages/core-ai-gateway/benchmarks.json
@@ -4,7 +4,7 @@
     "cursorbench": {
       "name": "CursorBench",
       "benchVersion": "3.2",
-      "observedAt": "2026-07-30T00:00:00Z",
+      "observedAt": "2026-08-13T00:00:00Z",
       "url": "https://cursor.com/cursorbench",
       "method": "Third-party agentic-coding benchmark: ambiguous multi-file tasks from real Cursor sessions, run in Cursor's own harness. Scores are evidence about the vendor model and transfer across gateway providers serving it; token and step figures are harness-relative efficiency signals, not billing facts.",
       "routingTieBandPoints": 2
@@ -121,6 +121,31 @@
         }
       },
       "caveat": "Bench footnote: an earlier snapshot of Cursor's codebase was unintentionally present in this model's training data, inflating scores by an unknown amount; the advantage does not transfer to other repositories."
+    },
+    "grok-4.6": {
+      "source": "cursorbench",
+      "rungs": {
+        "low": {
+          "score": 61.0,
+          "tokensPerTask": 10658,
+          "stepsPerTask": 23
+        },
+        "medium": {
+          "score": 67.1,
+          "tokensPerTask": 17942,
+          "stepsPerTask": 29
+        },
+        "high": {
+          "score": 69.9,
+          "tokensPerTask": 32449,
+          "stepsPerTask": 39
+        },
+        "xhigh": {
+          "score": 70.8,
+          "tokensPerTask": 41136,
+          "stepsPerTask": 46
+        }
+      }
     },
     "kimi-k3": {
       "source": "cursorbench",

--- a/packages/core-ai-gateway/models.json
+++ b/packages/core-ai-gateway/models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-08-11T00:00:00Z",
+  "updatedAt": "2026-08-13T00:00:00Z",
   "providers": {
     "codex": {
       "name": "Codex",
@@ -142,7 +142,7 @@
     "cursor": {
       "name": "Cursor",
       "defaultModel": "auto",
-      "source": "Cursor GetUsableModels + Run conversationCheckpointUpdate.token_details.max_tokens (cli-2026.07.08-0c04a8a; auto, composer-2.5, and grok-4.5 families observed 2026-08-01); quotaScope from DashboardService/GetCurrentPeriodUsage autoBucketModels (2026-08-05)",
+      "source": "Cursor GetUsableModels + Run conversationCheckpointUpdate.token_details.max_tokens (cli-2026.07.08-0c04a8a; auto, composer-2.5, and grok-4.5 families observed 2026-08-01); cursor-agent 2026.08.11-e8db854 observed 2026-08-13 for grok-4.6; quotaScope from DashboardService/GetCurrentPeriodUsage autoBucketModels (2026-08-05)",
       "models": [
         {
           "modelId": "auto",
@@ -200,6 +200,41 @@
               "high"
             ],
             "upstreamModelIdTemplate": "cursor-grok-4.5-{effort}-fast"
+          }
+        },
+        {
+          "modelId": "grok-4.6",
+          "name": "Grok-4.6",
+          "capabilityClass": "flagship",
+          "quotaScope": "auto",
+          "contextWindow": 256000,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
+            "upstreamModelIdTemplate": "cursor-grok-4.6-{effort}"
+          },
+          "benchmarkKey": "grok-4.6"
+        },
+        {
+          "modelId": "grok-4.6-fast",
+          "name": "Grok-4.6-Fast",
+          "capabilityClass": "light",
+          "quotaScope": "auto",
+          "contextWindow": 256000,
+          "effort": {
+            "supported": true,
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
+            "upstreamModelIdTemplate": "cursor-grok-4.6-{effort}-fast"
           }
         }
       ]

--- a/packages/core-ai-gateway/tests/cursor/native/live-run.test.ts
+++ b/packages/core-ai-gateway/tests/cursor/native/live-run.test.ts
@@ -33,7 +33,15 @@ afterEach(() => {
 });
 
 describe("Cursor live client-tool Run bridge", () => {
-  it.each(["grok-4.5", "grok-4.5-fast", "auto", "composer-2.5", "composer-2.5-fast"])(
+  it.each([
+    "grok-4.5",
+    "grok-4.5-fast",
+    "grok-4.6",
+    "grok-4.6-fast",
+    "auto",
+    "composer-2.5",
+    "composer-2.5-fast",
+  ])(
     "parks and attaches %s without opening a resume Run",
     async (model) => {
       const call = cursorCall("call-read-1", 21);

--- a/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
+++ b/packages/core-ai-gateway/tests/gateway-router/routes.test.ts
@@ -246,6 +246,31 @@ describe("upstream credential", () => {
     expect(streamSpy.mock.calls[0]?.[1]).not.toHaveProperty("reasoningEfforts");
   });
 
+  it("routes Cursor Grok 4.6 xhigh to its exact wire model id", async () => {
+    let canonical: CanonicalResponseRequest | undefined;
+    const gateway = stubGateway((request) => {
+      canonical = request;
+    });
+    const streamSpy = vi.spyOn(gateway, "stream");
+    const router = createAiGatewayRouter({
+      gateway,
+      readAuth,
+      readCursorToken: () => "cursor-subscription-token",
+    });
+
+    await router.handle(ctx({
+      res: response(),
+      token: ANTHROPIC_CRED,
+      model: "claude-gateway--cursor--grok-4.6",
+      thinking: { type: "adaptive" },
+      outputConfig: { effort: "xhigh" },
+    }));
+
+    expect(canonical?.model).toBe("grok-4.6");
+    expect(canonical?.reasoning).toEqual({ summary: "auto", effort: "xhigh" });
+    expect(streamSpy.mock.calls[0]?.[1]).not.toHaveProperty("reasoningEfforts");
+  });
+
   // 이 케이스가 보는 것은 진단 옵트인이지만, 설정을 실어 주는 순간 노출 선별도 함께 선다 —
   // 요청하는 모델을 켜 두지 않으면 진단 단언에 닿기 전에 실행이 거절된다.
   it.each([
@@ -1463,13 +1488,15 @@ describe("route surface", () => {
     const ids = list.data.map((entry) => entry.id);
     // picker가 버리지 않도록 모든 항목이 claude- alias로 나가야 한다.
     expect(ids.every((id) => id.startsWith("claude"))).toBe(true);
-    expect(list.data).toHaveLength(24);
+    expect(list.data).toHaveLength(26);
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast");
     expect(ids).toContain("claude-gateway--cursor--auto");
     expect(ids).toContain("claude-gateway--cursor--composer-2.5");
     expect(ids).toContain("claude-gateway--cursor--composer-2.5-fast");
     expect(ids).toContain("claude-gateway--cursor--grok-4.5");
     expect(ids).toContain("claude-gateway--cursor--grok-4.5-fast");
+    expect(ids).toContain("claude-gateway--cursor--grok-4.6");
+    expect(ids).toContain("claude-gateway--cursor--grok-4.6-fast");
     expect(ids).not.toContain("claude-gateway--cursor--gpt-5.6-sol[1m]");
     expect(ids).not.toContain("claude-gateway--cursor--claude-opus-5-1m[1m]");
     expect(ids).not.toContain("claude-gateway--cursor--kimi-k3");

--- a/packages/core-ai-gateway/tests/gateway.test.ts
+++ b/packages/core-ai-gateway/tests/gateway.test.ts
@@ -713,6 +713,18 @@ describe("model catalog", () => {
     expect(findGatewayModel("cursor--auto")?.benchmark).toBeUndefined();
     expect(findGatewayModel("cursor--grok-4.5-fast")?.benchmark).toBeUndefined();
 
+    const grok46 = findGatewayModel("cursor--grok-4.6");
+    expect(grok46?.benchmark?.source).toBe("CursorBench 3.2");
+    expect(grok46?.benchmark?.rungs).toEqual({
+      low: { score: 61.0, tokensPerTask: 10658, stepsPerTask: 23 },
+      medium: { score: 67.1, tokensPerTask: 17942, stepsPerTask: 29 },
+      high: { score: 69.9, tokensPerTask: 32449, stepsPerTask: 39 },
+      xhigh: { score: 70.8, tokensPerTask: 41136, stepsPerTask: 46 },
+    });
+    expect(grok46?.benchmark?.caveat).toBeUndefined();
+    expect(findGatewayModel("cursor--grok-4.6-fast")?.benchmark).toBeUndefined();
+    expect(grok46?.benchmark?.observedAt).toBe("2026-08-13T00:00:00Z");
+
     const constraints = buildGatewayModelConstraints(findGatewayModel("codex--gpt-5.6-sol")!);
     expect(constraints.benchmark).toEqual(base?.benchmark);
   });
@@ -790,9 +802,9 @@ describe("model catalog", () => {
     expect(() => validateBenchmarkCoverage(parseGatewayModelsRegistry(orphanBench))).toThrow(/benchmark entry is orphaned/);
   });
 
-  it("contains only the approved latest provider families", () => {
+  it("contains only the approved provider families", () => {
     expect(CODEX_SUBSCRIPTION_MODELS).toHaveLength(6);
-    expect(CURSOR_SUBSCRIPTION_MODELS).toHaveLength(5);
+    expect(CURSOR_SUBSCRIPTION_MODELS).toHaveLength(7);
     expect(KIMI_SUBSCRIPTION_MODELS).toHaveLength(2);
     expect(OPENCODE_SUBSCRIPTION_MODELS).toHaveLength(11);
     expect(CODEX_SUBSCRIPTION_MODELS.every((model) => model.upstreamId?.startsWith("gpt-5.6-"))).toBe(true);
@@ -803,6 +815,8 @@ describe("model catalog", () => {
       "composer-2.5-fast",
       "grok-4.5",
       "grok-4.5-fast",
+      "grok-4.6",
+      "grok-4.6-fast",
     ]);
     expect(Object.fromEntries(CURSOR_SUBSCRIPTION_MODELS.map((model) => [
       model.upstreamId,
@@ -812,6 +826,8 @@ describe("model catalog", () => {
       "composer-2.5-fast": 200_000,
       "grok-4.5": 256_000,
       "grok-4.5-fast": 256_000,
+      "grok-4.6": 256_000,
+      "grok-4.6-fast": 256_000,
       default: 256_000,
     });
     expect(KIMI_SUBSCRIPTION_MODELS.map((model) => model.upstreamId)).toEqual(["k3", "k3-256k"]);
@@ -868,6 +884,16 @@ describe("model catalog", () => {
       levels: ["low", "medium", "high"],
       upstreamModelIdTemplate: "cursor-grok-4.5-{effort}-fast",
     });
+    expect(efforts["cursor--grok-4.6"]).toEqual({
+      supported: true,
+      levels: ["low", "medium", "high", "xhigh"],
+      upstreamModelIdTemplate: "cursor-grok-4.6-{effort}",
+    });
+    expect(efforts["cursor--grok-4.6-fast"]).toEqual({
+      supported: true,
+      levels: ["low", "medium", "high", "xhigh"],
+      upstreamModelIdTemplate: "cursor-grok-4.6-{effort}-fast",
+    });
     expect(efforts["cursor--auto"]).toEqual({ supported: false });
     expect(efforts["cursor--composer-2.5"]).toEqual({ supported: false });
   });
@@ -877,6 +903,11 @@ describe("model catalog", () => {
     ["grok-4.5", "medium", "cursor-grok-4.5-medium"],
     ["grok-4.5", undefined, "cursor-grok-4.5-high"],
     ["grok-4.5-fast", "low", "cursor-grok-4.5-low-fast"],
+    ["grok-4.6", "low", "cursor-grok-4.6-low"],
+    ["grok-4.6", "medium", "cursor-grok-4.6-medium"],
+    ["grok-4.6", "high", "cursor-grok-4.6-high"],
+    ["grok-4.6", "xhigh", "cursor-grok-4.6-xhigh"],
+    ["grok-4.6-fast", "xhigh", "cursor-grok-4.6-xhigh-fast"],
     ["composer-2.5", "high", "composer-2.5"],
     ["unknown-model", "high", "unknown-model"],
   ] as const)("resolves Cursor base model %s at effort %s to %s", (model, effort, expected) => {
@@ -991,6 +1022,7 @@ describe("model catalog", () => {
     const kimi = entries.get("claude-gateway--kimi--k3[1m]");
     const cursor = entries.get("claude-gateway--cursor--auto");
     const cursorGrok = entries.get("claude-gateway--cursor--grok-4.5");
+    const cursorGrok46 = entries.get("claude-gateway--cursor--grok-4.6");
     const cursorComposer = entries.get("claude-gateway--cursor--composer-2.5-fast");
 
     expect(sol?.capabilities.effort).toEqual({
@@ -1029,6 +1061,15 @@ describe("model catalog", () => {
       max: { supported: false },
       xhigh: { supported: false },
     });
+    expect(cursorGrok46?.capabilities.effort).toEqual({
+      supported: true,
+      low: { supported: true },
+      medium: { supported: true },
+      high: { supported: true },
+      max: { supported: false },
+      xhigh: { supported: true },
+    });
+    expect(cursorGrok46?.max_input_tokens).toBe(256_000);
   });
 
   it("unwraps the alias a picked model comes back as", () => {
@@ -1061,6 +1102,11 @@ describe("model catalog", () => {
     expect(findGatewayModel("claude-gateway--cursor--grok-4.5")).toMatchObject({
       id: "cursor--grok-4.5",
       upstreamId: "grok-4.5",
+      contextWindow: 256_000,
+    });
+    expect(findGatewayModel("claude-gateway--cursor--grok-4.6")).toMatchObject({
+      id: "cursor--grok-4.6",
+      upstreamId: "grok-4.6",
       contextWindow: 256_000,
     });
     expect(findGatewayModel("claude-gateway--cursor--composer-2.5")).toMatchObject({

--- a/runtime/fleet-console/tests/launch.test.ts
+++ b/runtime/fleet-console/tests/launch.test.ts
@@ -640,12 +640,14 @@ describe("createDefaultTerminalLaunchResolver", () => {
     expect(cache.baseUrl).toBe(spec.env.ANTHROPIC_BASE_URL);
     expect(cache.fetchedAt).toEqual(expect.any(Number));
     // core-ai-gateway의 GATEWAY_MODELS 전량이 prewrite되어야 한다 — 카탈로그가 바뀌면 이 수도 함께 맞춘다.
-    expect(cache.models).toHaveLength(24);
+    expect(cache.models).toHaveLength(26);
     expect(ids).toContain("claude-gateway--codex--gpt-5.6-sol-fast");
     expect(ids).toContain("claude-gateway--cursor--auto");
     expect(ids).toContain("claude-gateway--cursor--composer-2.5");
     expect(ids).toContain("claude-gateway--cursor--grok-4.5");
     expect(ids).toContain("claude-gateway--cursor--grok-4.5-fast");
+    expect(ids).toContain("claude-gateway--cursor--grok-4.6");
+    expect(ids).toContain("claude-gateway--cursor--grok-4.6-fast");
     expect(ids).not.toContain("claude-gateway--cursor--claude-opus-5-1m[1m]");
     expect(ids).not.toContain("claude-gateway--cursor--kimi-k3");
     expect(ids).not.toContain("claude-gateway--cursor--gpt-5.6-luna[1m]");


### PR DESCRIPTION
## Summary
- retain Cursor Grok 4.5 while adding Grok 4.6 and Grok 4.6 Fast
- expose Low, Medium, High, and Extra High effort routes with CursorBench 3.2 evidence
- cover model discovery, exact wire routing, live tool bridge support, and Console launch cache generation

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `pnpm --filter @dotobokuri/fleet-admiral test`
- [x] `pnpm --filter @dotobokuri/fleet-admiral typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/launch.test.ts`
- [x] `pnpm --filter @fleet-plugins/terminal exec vitest run tests/settings-routes.test.ts`
- [x] `pnpm --filter @fleet-plugins/terminal typecheck`
- [x] live Cursor gateway probe resolves Grok 4.6 xhigh to `cursor-grok-4.6-xhigh` with a 256k checkpoint
- [x] built Fleet CLI agent request returns `GROK46_E2E_OK` through Grok 4.6 xhigh