### PR TITLE
feat(fleet-console): close operations from the mobile session title

### DIFF
--- a/.changelog.d/mobile-session-close.md
+++ b/.changelog.d/mobile-session-close.md
@@ -1,0 +1,8 @@
+---
+branch: mobile-session-close
+---
+
+### fleet-console
+#### Added
+- Close an Operation from the mobile session title with the same two-tap arm and undo window as the desktop frame.
+  ko: 모바일 세션 제목줄에서 데스크톱 프레임과 같은 두 번 탭 무장과 실행 취소 창으로 Operation을 닫습니다.

--- a/runtime/fleet-console/core/client/src/mobile/mobile-session-view.tsx
+++ b/runtime/fleet-console/core/client/src/mobile/mobile-session-view.tsx
@@ -1,22 +1,30 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { ConsoleTheme } from "@fleet-console/sdk/plugin";
 
+import { useT } from "../i18n/index.js";
 import type { OperationGeometry, OperationNode } from "../types.js";
 import { OperationBodySlot, type OperationBodyConfig } from "./operation-body-pool.js";
 
+// Same two-tap arm as OperationFrame — a single tap names the intent, a second tap disposes.
+const CLOSE_ARM_DURATION_MS = 1500;
+
 /**
- * An open operation is the terminal and nothing else. The title stays as a line above it so the
- * session is named, but it carries no controls: leaving is the platform's own back gesture, which
- * this shell already answers, and a bar of buttons would spend height the terminal needs.
+ * An open operation is the terminal plus a named title. Leave remains the platform back
+ * gesture, which this shell already answers. Close is a separate two-tap control on that
+ * title row so the phone can dispose the Operation the same way the desktop frame does.
  */
-export function MobileSessionView({ operation, theme, language, active, onActivate }: {
+export function MobileSessionView({ operation, theme, language, active, onActivate, onClose }: {
   readonly operation: OperationNode;
   readonly theme: ConsoleTheme;
   readonly language: "en" | "ko";
   readonly active: boolean;
   readonly onActivate: () => void;
+  readonly onClose: () => void;
 }) {
+  const t = useT();
+  const closeArmTimeoutRef = useRef<number | null>(null);
+  const [isCloseArmed, setIsCloseArmed] = useState(false);
   const [geometry, setGeometry] = useState<OperationGeometry>({ x: 0, y: 0, width: 390, height: 640, zIndex: 0 });
   const measure = useCallback((element: HTMLDivElement | null) => {
     if (!element) return;
@@ -34,6 +42,46 @@ export function MobileSessionView({ operation, theme, language, active, onActiva
   const [measureTarget, setMeasureTarget] = useState<HTMLDivElement | null>(null);
   useEffect(() => measure(measureTarget), [measure, measureTarget]);
 
+  const clearCloseArmTimer = () => {
+    if (closeArmTimeoutRef.current === null) return;
+    window.clearTimeout(closeArmTimeoutRef.current);
+    closeArmTimeoutRef.current = null;
+  };
+
+  const disarmClose = () => {
+    clearCloseArmTimer();
+    setIsCloseArmed(false);
+  };
+
+  const armClose = () => {
+    clearCloseArmTimer();
+    setIsCloseArmed(true);
+    closeArmTimeoutRef.current = window.setTimeout(() => {
+      closeArmTimeoutRef.current = null;
+      setIsCloseArmed(false);
+    }, CLOSE_ARM_DURATION_MS);
+  };
+
+  useEffect(() => {
+    setIsCloseArmed(false);
+    if (closeArmTimeoutRef.current !== null) {
+      window.clearTimeout(closeArmTimeoutRef.current);
+      closeArmTimeoutRef.current = null;
+    }
+    return () => {
+      if (closeArmTimeoutRef.current !== null) window.clearTimeout(closeArmTimeoutRef.current);
+    };
+  }, [operation.id]);
+
+  const close = () => {
+    if (!isCloseArmed) {
+      armClose();
+      return;
+    }
+    disarmClose();
+    onClose();
+  };
+
   const config: OperationBodyConfig = {
     active,
     geometry,
@@ -42,19 +90,40 @@ export function MobileSessionView({ operation, theme, language, active, onActiva
     language,
     zoom: 1,
     onActivate,
-    onClose: () => {},
+    onClose,
     onGeometryChange: setGeometry,
     // This layout gives the whole surface to the session, so it opens no companion panels. The
     // callbacks stay out rather than being no-ops: their absence is how a plugin reads a host
     // without companions, and a no-op would have it advertise a panel that never opens.
   };
 
+  const title = operation.title;
+
   return (
     <section className="mobile-session-view">
-      <h1 className="mobile-session-title">{operation.title}</h1>
+      <div className="mobile-session-bar">
+        <h1 className="mobile-session-title">{title}</h1>
+        <button
+          type="button"
+          className={`mobile-session-close${isCloseArmed ? " is-armed" : ""}`}
+          onClick={close}
+          aria-label={isCloseArmed ? t("canvas.frame.confirmCloseAria", { title }) : t("canvas.frame.closeAria", { title })}
+          title={isCloseArmed ? t("canvas.frame.confirmCloseTitle") : t("canvas.frame.closeTitle")}
+        >
+          {isCloseArmed ? t("canvas.frame.closeArmed") : <CloseIcon />}
+        </button>
+      </div>
       <div className="mobile-session-body" ref={setMeasureTarget}>
         <OperationBodySlot operationId={operation.id} config={config} className="mobile-operation-body-slot" />
       </div>
     </section>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M4.6 4.6 11.4 11.4M11.4 4.6 4.6 11.4" fill="none" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" />
+    </svg>
   );
 }

--- a/runtime/fleet-console/core/client/src/mobile/mobile-shell.tsx
+++ b/runtime/fleet-console/core/client/src/mobile/mobile-shell.tsx
@@ -9,7 +9,7 @@ import { MobileSessionView } from "./mobile-session-view.js";
 import { setMobileSessionOpen, useMobileTab } from "./mobile-store.js";
 import "../styles/mobile.css";
 
-export function MobileShell({ operations, activeOperationId, operationStatus, operationNotifications, theaterLabel, theme, language, onSelectOperation }: {
+export function MobileShell({ operations, activeOperationId, operationStatus, operationNotifications, theaterLabel, theme, language, onSelectOperation, onCloseOperation }: {
   readonly operations: readonly OperationNode[];
   readonly activeOperationId: string | null;
   readonly operationStatus: Readonly<Record<string, OperationActivity>>;
@@ -18,6 +18,7 @@ export function MobileShell({ operations, activeOperationId, operationStatus, op
   readonly theme: ConsoleTheme;
   readonly language: "en" | "ko";
   readonly onSelectOperation: (operationId: string | null) => void;
+  readonly onCloseOperation: (operationId: string) => void;
 }) {
   const t = useT();
   const activeTab = useMobileTab();
@@ -72,6 +73,14 @@ export function MobileShell({ operations, activeOperationId, operationStatus, op
     setSelectedOperationId(operationId);
     onSelectOperation(operationId);
   };
+  const closeOperation = (operationId: string) => {
+    // Leave the session immediately so Close is not stuck on a disposing terminal, then
+    // dispose through the same host path the canvas and palette already use.
+    replaceOperationId(null);
+    setSelectedOperationId(null);
+    onSelectOperation(null);
+    onCloseOperation(operationId);
+  };
   let content;
   if (selectedOperation) {
     content = (
@@ -81,6 +90,7 @@ export function MobileShell({ operations, activeOperationId, operationStatus, op
         language={language}
         active={activeOperationId === selectedOperation.id}
         onActivate={() => onSelectOperation(selectedOperation.id)}
+        onClose={() => closeOperation(selectedOperation.id)}
       />
     );
   } else if (activeTab === "operations") {

--- a/runtime/fleet-console/core/client/src/pages/operations.tsx
+++ b/runtime/fleet-console/core/client/src/pages/operations.tsx
@@ -593,6 +593,7 @@ export function Operations({ state, claimBootPanelMinimization, onDeferredDeleti
       theme={state.activeTheme}
       language={language}
       onSelectOperation={setActiveOperation}
+      onCloseOperation={handleClose}
     />
   ) : (
     <div className="console-body is-canvas">

--- a/runtime/fleet-console/core/client/src/styles/mobile.css
+++ b/runtime/fleet-console/core/client/src/styles/mobile.css
@@ -58,11 +58,12 @@
 }
 
 /* The session names itself and offers Close on the same row. Leave is still the platform
-   back gesture; Close is the two-tap dispose the desktop frame already owns. Side tracks
-   share leftover equally so arming "Close?" cannot shift the centered title. */
+   back gesture; Close is the two-tap dispose the desktop frame already owns. Three equal
+   shrinkable tracks keep the title centered when Close arms, and stop a long nowrap title
+   from covering the control. */
 .mobile-session-bar {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, auto) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
   align-items: center;
   min-height: 44px;
   padding-inline: var(--space-1);

--- a/runtime/fleet-console/core/client/src/styles/mobile.css
+++ b/runtime/fleet-console/core/client/src/styles/mobile.css
@@ -57,11 +57,22 @@
   background: var(--ink-deep);
 }
 
-/* The session names itself and stops there — no band, no border, nothing that reads as a second
-   surface above the terminal. Leaving the session is the platform's back gesture. */
+/* The session names itself and offers Close on the same row. Leave is still the platform
+   back gesture; Close is the two-tap dispose the desktop frame already owns. Side tracks
+   share leftover equally so arming "Close?" cannot shift the centered title. */
+.mobile-session-bar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, auto) minmax(0, 1fr);
+  align-items: center;
+  min-height: 44px;
+  padding-inline: var(--space-1);
+  background: var(--canvas-sea-core);
+}
+
 .mobile-session-title {
+  grid-column: 2;
   margin: 0;
-  padding: var(--space-2) var(--space-4);
+  min-width: 0;
   overflow: hidden;
   color: var(--text-primary);
   font-size: 15px;
@@ -69,7 +80,54 @@
   text-align: center;
   text-overflow: ellipsis;
   white-space: nowrap;
-  background: var(--canvas-sea-core);
+}
+
+.mobile-session-close {
+  grid-column: 3;
+  justify-self: end;
+  display: grid;
+  place-items: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-pill);
+}
+
+.mobile-session-close svg {
+  width: 16px;
+  height: 16px;
+}
+
+.mobile-session-close:focus-visible {
+  color: var(--text-primary);
+  outline: 2px solid color-mix(in srgb, var(--brass) 55%, transparent);
+  outline-offset: 2px;
+}
+
+/* chip-close-arm lives in components.css — same 1.5s coral arm as the desktop frame. */
+.mobile-session-close.is-armed {
+  padding: 0 10px;
+  border: 1px solid color-mix(in oklch, var(--coral) 50%, transparent);
+  background: color-mix(in oklch, var(--coral) 20%, transparent);
+  color: var(--coral-ink);
+  font-size: 11px;
+  font-weight: var(--weight-bold);
+  animation: chip-close-arm 1.5s linear forwards;
+}
+
+.mobile-session-close.is-armed:focus-visible {
+  background: color-mix(in oklch, var(--coral) 32%, transparent);
+  color: var(--coral-ink);
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mobile-session-close.is-armed {
+    animation: none;
+  }
 }
 
 .mobile-list-header {
@@ -756,7 +814,6 @@
   }
 
   .mobile-session-title {
-    padding-block: var(--space-1);
     font-size: 14px;
   }
 

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1757,6 +1757,23 @@ describe("Instrument core design contract", () => {
     expect(Number("--z-rail: 10;".match(/\d+/)?.[0])).toBeLessThan(40);
     expect(40).toBeLessThan(60);
   });
+
+  // 모바일 세션 Close는 coral 무장·brass 포커스·44px 바닥을 데스크톱 프레임과 공유한다.
+  // mobile.css는 OWNED_SOURCES에 올리지 않는다 — 탭 레일도 같은 파일에 있고, 이 문법은 이 핀이 담당한다.
+  it("pins the mobile session close arm grammar — coral danger, brass focus, 44px floor", () => {
+    const css = source("styles/mobile.css");
+    const close = css.match(/^\.mobile-session-close \{[^}]*\}/m)?.[0] ?? "";
+    expect(close).toContain("min-width: 44px;");
+    expect(close).toContain("min-height: 44px;");
+    const armed = css.match(/^\.mobile-session-close\.is-armed \{[^}]*\}/m)?.[0] ?? "";
+    expect(armed).toContain("border: 1px solid color-mix(in oklch, var(--coral) 50%, transparent);");
+    expect(armed).toContain("background: color-mix(in oklch, var(--coral) 20%, transparent);");
+    expect(armed).toContain("color: var(--coral-ink);");
+    expect(armed).toContain("animation: chip-close-arm 1.5s linear forwards;");
+    const focus = css.match(/^\.mobile-session-close:focus-visible \{[^}]*\}/m)?.[0] ?? "";
+    expect(focus).toContain("outline: 2px solid color-mix(in srgb, var(--brass) 55%, transparent);");
+    expect(css).toMatch(/@media \(prefers-reduced-motion: reduce\) \{\s*\.mobile-session-close\.is-armed \{\s*animation: none;/);
+  });
 });
 
 describe("Effort track interaction grammar", () => {

--- a/runtime/fleet-console/tests/mobile-session-close.test.ts
+++ b/runtime/fleet-console/tests/mobile-session-close.test.ts
@@ -56,7 +56,7 @@ describe("mobile session close", () => {
   });
 
   it("keeps the title centered when Close arms", () => {
-    expect(MOBILE_CSS).toContain("grid-template-columns: minmax(0, 1fr) minmax(0, auto) minmax(0, 1fr)");
+    expect(MOBILE_CSS).toContain("grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr)");
     expect(MOBILE_CSS).toContain("grid-column: 2");
     expect(MOBILE_CSS).toContain("grid-column: 3");
     expect(SESSION).not.toContain("mobile-session-bar-slot");

--- a/runtime/fleet-console/tests/mobile-session-close.test.ts
+++ b/runtime/fleet-console/tests/mobile-session-close.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(fileURLToPath(new URL(path, import.meta.url)), "utf8");
+
+const SESSION = read("../core/client/src/mobile/mobile-session-view.tsx");
+const SHELL = read("../core/client/src/mobile/mobile-shell.tsx");
+const OPERATIONS = read("../core/client/src/pages/operations.tsx");
+const MOBILE_CSS = read("../core/client/src/styles/mobile.css");
+
+/**
+ * Mobile session chrome used to name the Operation and stop there, so Close existed only on
+ * desktop frames and in a keyboard palette the phone does not surface. These pin leave vs close
+ * as two jobs, and the two-tap coral arm that matches OperationFrame.
+ */
+describe("mobile session close", () => {
+  it("hands the host close path into the mobile shell", () => {
+    expect(OPERATIONS).toContain("onCloseOperation={handleClose}");
+    expect(SHELL).toContain("readonly onCloseOperation: (operationId: string) => void;");
+  });
+
+  it("leaves the session without disposing when the platform back or a tab press fires", () => {
+    const pop = SHELL.match(/const onPopState = \(\) => \{[\s\S]*?\};/)?.[0] ?? "";
+    expect(pop).toContain("setSelectedOperationId(operationId)");
+    expect(pop).toContain("onSelectOperation(operationId)");
+    expect(pop).not.toContain("onCloseOperation");
+
+    const tab = SHELL.match(/previousTabRef[\s\S]*?}, \[activeTab, onSelectOperation, selectedOperationId\]\)/)?.[0] ?? "";
+    expect(tab).toContain("replaceOperationId(null)");
+    expect(tab).toContain("onSelectOperation(null)");
+    expect(tab).not.toContain("onCloseOperation");
+  });
+
+  it("disposes through the host path after leaving the session", () => {
+    expect(SHELL).toContain("onCloseOperation(operationId)");
+    expect(SHELL).toMatch(/const closeOperation = \(operationId: string\) => \{[\s\S]*replaceOperationId\(null\);[\s\S]*onCloseOperation\(operationId\);/);
+    expect(SHELL).toContain("onClose={() => closeOperation(selectedOperation.id)}");
+  });
+
+  it("arms Close for 1.5s before disposing, with the desktop frame copy", () => {
+    expect(SESSION).toContain("const CLOSE_ARM_DURATION_MS = 1500");
+    expect(SESSION).toContain("if (!isCloseArmed)");
+    expect(SESSION).toContain('t("canvas.frame.closeArmed")');
+    expect(SESSION).toContain('t("canvas.frame.closeAria", { title })');
+    expect(SESSION).toContain('t("canvas.frame.confirmCloseAria", { title })');
+    expect(SESSION).not.toContain("onClose: () => {}");
+  });
+
+  it("keeps the close control at the 44px touch floor and paints the arm on coral", () => {
+    expect(MOBILE_CSS).toMatch(/\.mobile-session-close \{[\s\S]{0,280}min-width: 44px;[\s\S]{0,80}min-height: 44px;/);
+    expect(MOBILE_CSS).toContain("color: var(--coral-ink);");
+    expect(MOBILE_CSS).toContain("animation: chip-close-arm 1.5s linear forwards;");
+    expect(MOBILE_CSS).toMatch(/prefers-reduced-motion: reduce[\s\S]{0,120}\.mobile-session-close\.is-armed \{[\s\S]{0,80}animation: none;/);
+  });
+
+  it("keeps the title centered when Close arms", () => {
+    expect(MOBILE_CSS).toContain("grid-template-columns: minmax(0, 1fr) minmax(0, auto) minmax(0, 1fr)");
+    expect(MOBILE_CSS).toContain("grid-column: 2");
+    expect(MOBILE_CSS).toContain("grid-column: 3");
+    expect(SESSION).not.toContain("mobile-session-bar-slot");
+  });
+});


### PR DESCRIPTION
## Summary

- 모바일 세션 제목줄에 데스크톱 프레임과 같은 두 번 탭 coral Close를 둡니다. 첫 탭은 1.5초 무장(`Close?`), 두 번째 탭이 Operation을 닫습니다.
- 닫기는 기존 `handleClose`와 8초 undo 창을 그대로 씁니다. 뒤로가기·탭은 세션만 떠나고 dispose하지 않습니다. Close는 세션을 먼저 떠난 뒤 dispose해서 종료 중인 터미널에 머무르지 않습니다.
- Close가 무장되어도 제목이 가운데에 남도록 세션 바를 `1fr | auto | 1fr` 그리드로 맞춥니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `pnpm --filter @dotobokuri/fleet-console test` (전체 스위트 통과; 그리드 수정 후 `mobile-session-close` + `instrument-design-contract` 재실행)
- [ ] 좁은 뷰에서 Operation을 열고 Close를 한 번 탭하면 `Close?`가 뜨고, 1.5초 안에 다시 탭하면 목록으로 돌아가며 undo toast가 뜬다
- [ ] 플랫폼 뒤로가기 또는 탭 전환은 Operation을 닫지 않고 세션만 떠난다
- [ ] `prefers-reduced-motion`에서 무장 애니메이션이 꺼진다