### PR TITLE
docs(skills): drop Carrier-era names from agent skill guides

### DIFF
--- a/.agents/skills/clean-code/SKILL.md
+++ b/.agents/skills/clean-code/SKILL.md
@@ -40,8 +40,8 @@ Present a before/after table (files, barrels, lines) and await user approval.
 
 ### Execution
 
-- **≤ 2 merge groups**: Genesis direct.
-- **≥ 3 merge groups or cross-directory deps**: host-authored execution plan → Genesis execution with artifact inspection and QA after each wave.
+- **≤ 2 merge groups**: execute directly after approval.
+- **≥ 3 merge groups or cross-directory deps**: execute in waves; inspect the diff and run QA after each wave before starting the next.
 - Wave order: consolidate imported-from directories first. Per wave: relocate → update imports → delete absorbed files → typecheck/test/build → residual grep.
 
 ## Pass 2 — Functional Deduplication
@@ -58,7 +58,7 @@ After Pass 1, scan the consolidated files for:
 
 ### Execution
 
-Present the list with estimated line savings. After approval, dispatch Genesis. Extract shared helpers to the most downstream common file. Preserve public export symbols via re-export aliases where needed.
+Present the list with estimated line savings. After approval, execute. Extract shared helpers to the most downstream common file. Preserve public export symbols via re-export aliases where needed.
 
 ## Verification (both passes)
 

--- a/.agents/skills/design-sweep/SKILL.md
+++ b/.agents/skills/design-sweep/SKILL.md
@@ -21,7 +21,7 @@ Living sources — always re-read these in Phase 1; the numbers below are exampl
 
 1. **Signal = state only** — `aurora` (awaiting), `warn` (turn/progress), `coral` (danger), `positive` (complete). Never used for identity, branding, or decoration (e.g. a LOCAL/NEW badge is not a state).
 2. **Location/Focus = brass only** — current location, keyboard focus, hover affordance. Brass never idles at full strength ("소등" rule: no permanently lit brass ornaments).
-3. **Identity = `--id-*` only** — the 8-tone theme-tuned palette (crimson/amber/moss/teal/cerulean/indigo/plum/rose), painted exclusively through the **spine+mark grammar**: left 3px spine + small nameplate mark + ~10% titlebar wash. Borders stay state-owned — `border-color: var(--user-accent)` is a hard violation. Captain colors map 1:1 onto `--id-*`; raw hex captain colors are defects.
+3. **Identity = `--id-*` only** — the 8-tone theme-tuned palette (crimson/amber/moss/teal/cerulean/indigo/plum/rose), painted exclusively through the **spine+mark grammar**: left 3px spine + small nameplate mark + ~10% titlebar wash. Borders stay state-owned — `border-color: var(--user-accent)` is a hard violation. Identity tones map 1:1 onto `--id-*`; raw hex identity colors are defects.
 
 **Control grammar.** The dominant control pattern is mono 10px 700 uppercase · min-height 34px · `--radius-xs` · brass-mix hover. Heights snap to {24, 28, 34, 44}; radius vocabulary is {`--radius-xs`, `--radius-md`, `--radius-pill` for dots/pills only}. Raw px radii and off-snap heights are drift.
 
@@ -39,7 +39,7 @@ Living sources — always re-read these in Phase 1; the numbers below are exampl
 - A **periodic product-wide design health check** ("훑어보고 개선") — quarterly, after a release train, or on user request.
 - **After a large feature lands** — new surfaces are the main drift inlet.
 - The user reports the UI "튄다 / 따로 논다 / 올드하다" without naming a specific element.
-- **NOT for**: designing a brand-new visual feature (→ `product-proposal`); a single already-diagnosed CSS bug (→ direct fix); non-visual code quality (→ `sentinel`).
+- **NOT for**: designing a brand-new visual feature (→ `product-proposal`); a single already-diagnosed CSS bug (→ direct fix); non-visual code quality.
 
 ## Inputs
 
@@ -55,7 +55,7 @@ Re-read the living sources above. The contract test tells you what is **already 
 
 ### Phase 2 — Static detector sweep
 
-Run the detectors over `<scope>` — dispatch `vanguard` per surface for `full` depth (parallel, one dispatch per surface family), or run directly for `quick`:
+Run the detectors over `<scope>` — for `full` depth, sweep each surface family (in parallel when useful); for `quick`, run directly:
 
 - **Raw color literals**: `oklch\([0-9]` and hex literals in any CSS outside `theme.css` token definitions. Near-achromatic shadow/scrim/sheen literals are doctrine-sanctioned depth effects (console AGENTS.md Design invariants) — classify them out instead of reporting them. Plugins (`runtime/fleet-plugins/*`) are the historical drift reservoir — always include them.
 - **Signal misuse**: `warn|aurora|positive|coral` tokens on non-state surfaces (badges, chips, avatars, identity marks, version labels).
@@ -112,9 +112,6 @@ Do not start implementation before the user picks a direction.
 - **Proportionality**: `quick` depth is a report, not a repaint — resist expanding a periodic check into an unapproved redesign.
 - Output language follows the session working language; token names, file paths, and grammar terms stay as-is.
 
-## Delegation
+## Related skills
 
-- `vanguard` — Phase 2 detector sweeps (parallel per surface family) and code recon behind a measured behavior.
-- `genesis` — Phase 6 multi-file conformance batches, unless the user directs direct execution.
-- `sentinel` — post-implementation review of the changed CSS + contract test.
-- `console-e2e`, `product-proposal`, `git-worktree`, `pr-workflow` — invoked as skills at their phases; never inline their procedures (one home per procedure).
+- `console-e2e`, `product-proposal`, `git-worktree`, `pr-workflow` — follow those skills at their phases; do not inline their procedures.

--- a/.agents/skills/desktop-e2e/SKILL.md
+++ b/.agents/skills/desktop-e2e/SKILL.md
@@ -13,7 +13,7 @@ Test the thin Electron shell without re-testing the entire Console product. Coll
 - **Native:** menu accelerators, native dialogs, single-instance behavior, window close/show, tray, quit/relaunch.
 - **Runtime:** Desktop-owned Console lock, child process, log, shutdown, conflict behavior.
 - **Package:** unpacked artifact, ASAR boundary, fuses, architecture, signing/release evidence.
-- **Console UI:** delegate any post-handoff SPA-only scenario to `console-e2e`.
+- **Console UI:** follow `console-e2e` for any post-handoff SPA-only scenario.
 
 State the target OS and lane before testing. Never claim Windows/Linux native results from macOS or treat unsigned local packaging as release-signing evidence.
 

--- a/.agents/skills/git-worktree/SKILL.md
+++ b/.agents/skills/git-worktree/SKILL.md
@@ -14,7 +14,7 @@ Replace each `<placeholder>` before running. The LLM must infer whether the requ
 - `<mode>` — `create` | `remove`. Required by interpretation. Route phrases like "make/create/new worktree" to `create`; route phrases like "remove/delete/cleanup current worktree" to `remove`.
 - `<worktree-name>` — Required for `create`. Use as the directory name under `.fleet/worktrees/` and as the default branch name. Sanitize by trimming whitespace, lowercasing only when the user did not provide a deliberate case-sensitive token, replacing spaces with `-`, and rejecting values containing `/`, `..`, leading `.`, shell metacharacters, or path separators. Allowed safe shape: `[A-Za-z0-9._-]+`.
 - `<new-branch>` — Optional for `create`. Default `<worktree-name>`. Apply the same safety rejection as `<worktree-name>`; branch names must not be `main` or `master`.
-- `<base-branch>` — Optional for `create`. Default `canary`. Reject `main` and `master`. Non-standard bases require Nimitz judgment before proceeding.
+- `<base-branch>` — Optional for `create`. Default `canary`. Reject `main` and `master`. Non-standard bases require explicit user confirmation before proceeding.
 - `<force>` — Optional for `remove`. Default `yes` (autonomous cleanup). The remove flow self-applies `git worktree remove --force` and `git branch -D` as needed — including a squash-merged branch that `-d` rejects as unmerged — after reporting any dirty/unpushed/unmerged state. It never pauses for confirmation; the only hard stops are the main checkout and protected branches.
 - `<delete-remote>` — Optional for `remove`. Default `no`. Delete the remote tracking branch (`git push origin --delete <branch>`) only when the user's request explicitly asks for remote cleanup.
 
@@ -48,16 +48,16 @@ Create or remove a Fleet git worktree safely, without mutating unrelated files, 
 4. **Input validation**:
    - Validate `<worktree-name>` and `<new-branch>` using the sanitization rules from Inputs.
    - Reject `<base-branch>` when it is `main` or `master`.
-   - Unless Nimitz has approved a non-standard base, use `canary`.
+   - Unless the user has confirmed a non-standard base, use `canary`.
 
 5. **Fetch the base**:
    - `git fetch origin canary`
-   - For a Nimitz-approved non-standard `<base-branch>`, use `git fetch origin <base-branch>` instead.
+   - For a user-confirmed non-standard `<base-branch>`, use `git fetch origin <base-branch>` instead.
 
 6. **Create the worktree**:
    - `abs_worktree_path="$repo_root/.fleet/worktrees/<worktree-name>"`
    - `git worktree add -b <new-branch> .fleet/worktrees/<worktree-name> origin/canary`
-   - For a Nimitz-approved non-standard `<base-branch>`, replace `origin/canary` with `origin/<base-branch>`.
+   - For a user-confirmed non-standard `<base-branch>`, replace `origin/canary` with `origin/<base-branch>`.
 
 7. **Fix the active command context**:
    - Run `cd <abs-worktree-path>`.
@@ -66,7 +66,7 @@ Create or remove a Fleet git worktree safely, without mutating unrelated files, 
 
 8. **Complete mandatory project setup inside the worktree**:
    - From `<abs-worktree-path>`, always run `pnpm install --frozen-lockfile` before reporting create-mode completion.
-   - If installation fails, stop immediately and report the command failure. Do not report the worktree as ready and do not proceed to delegation.
+   - If installation fails, stop immediately and report the command failure. Do not report the worktree as ready and do not proceed with further work.
 
 9. **Report in Korean**:
    - Worktree path.
@@ -138,9 +138,8 @@ Create or remove a Fleet git worktree safely, without mutating unrelated files, 
 - Do not use destructive git commands such as `git reset --hard` or `git checkout --` to clean a worktree.
 - Do not bypass hooks or hide command failures.
 
-## Delegation Guidance
+## Stop and report
 
-- **Nimitz** — consult before proceeding with any non-standard `<base-branch>` request. This is especially important when the requested base changes branch policy or release flow.
-- **Stop and report** — when a worktree path or branch is already present or in use. Do not resolve collisions autonomously.
-- Skip delegation for clean create/remove operations that follow the standard `origin/canary` path and have no conflict or policy issue.
-- **Delegated edits inside the new worktree** — after `create`, a run that edits files must be given the **absolute worktree path** as its working directory so its repo-relative paths resolve here; a run left to default lands in the **main checkout**. Before delegating, confirm `pnpm install --frozen-lockfile` succeeded in this worktree, identify every target package, and run each package's declared `typecheck` and `build` scripts from this worktree. If either preflight script is absent or fails, stop and report instead of delegating. After each return run `git -C <main-checkout> status --short` to confirm the main checkout stayed clean, and trust the real `git status` over any run's own report of what it changed.
+- Stop and ask the user before proceeding with any non-standard `<base-branch>` request. This is especially important when the requested base changes branch policy or release flow.
+- Stop and report when a worktree path or branch is already present or in use. Do not resolve collisions autonomously.
+- After `create`, every subsequent repository command and file edit must use the **absolute worktree path**. Work left in the default directory lands in the **main checkout**. Confirm `pnpm install --frozen-lockfile` succeeded before further work. After later edits, `git -C <main-checkout> status --short` must stay clean — trust that status over any report of what changed.

--- a/.agents/skills/learning-harvest/SKILL.md
+++ b/.agents/skills/learning-harvest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: learning-harvest
-description: After substantive work, run a compounding-engineering learning-harvest loop — retrospect the task, extract reusable learnings under a three-condition gate (recurrence, cost, generality), route each to its single best persistent home (an AGENTS.md rule, a new or edited skill, a test, a wiki-history ADR, persistent memory, or a skill's gotchas), encode it as "symptom -> action -> why", and prune weak or stale rules. Propose candidates for the Admiral of the Navy's approval and encode only approved ones, so the next task starts from a higher baseline. Use at the end of substantive work, when friction is detected, or on a periodic pruning pass. This is a meta-skill that produces other skills and assets, not product code.
+description: After substantive work, run a compounding-engineering learning-harvest loop — retrospect the task, extract reusable learnings under a three-condition gate (recurrence, cost, generality), route each to its single best persistent home (an AGENTS.md rule, a new or edited skill, a test, a wiki-history ADR, persistent memory, or a skill's gotchas), encode it as "symptom -> action -> why", and prune weak or stale rules. Propose candidates for the user's approval and encode only approved ones, so the next task starts from a higher baseline. Use at the end of substantive work, when friction is detected, or on a periodic pruning pass. This is a meta-skill that produces other skills and assets, not product code.
 ---
 
 # Learning Harvest (compounding engineering)
@@ -19,7 +19,7 @@ This is a **meta-skill**: its product is other skills, rules, tests, ADRs, or me
 
 ## Trigger discipline (skill + self-trigger)
 
-Invoked explicitly (`/learning-harvest`) OR **self-triggered by the Admiral at the end of substantive work** — propose the harvest without being asked. It is deliberately **not** an automatic task-end hook; that hook is a possible next step, not the current contract. Keep the proposal short, and gate it on Admiral approval before encoding anything.
+Invoked explicitly (`/learning-harvest`) OR **self-triggered at the end of substantive work** — propose the harvest without being asked. It is deliberately **not** an automatic task-end hook; that hook is a possible next step, not the current contract. Keep the proposal short, and gate it on user approval before encoding anything.
 
 ## The harvest loop (four stages)
 
@@ -73,7 +73,7 @@ Both paths obey the same guards: propose-then-approve, validate-before-encode, a
 
 ## Guards (do not skip)
 
-1. **Propose, then approve** - surface candidates; the Admiral of the Navy approves; encode only approved items. No silent auto-encoding.
+1. **Propose, then approve** - surface candidates; the user approves; encode only approved items. No silent auto-encoding.
 2. **Validate before encoding** - encode only what the work proved, never speculation.
 3. **SSoT + migration** - one home per fact; migrate, do not duplicate.
 4. **Pruning is mandatory** - encoding and deletion are a pair.
@@ -87,21 +87,16 @@ Both paths obey the same guards: propose-then-approve, validate-before-encode, a
 2. **Extract** - apply the three-condition gate; drop what fails.
 3. **Route** - assign each survivor a single home (Stage 2 table); check for an existing duplicate first.
 4. **Draft encodings** - write each as `symptom -> action -> why` at the most-actionable layer.
-5. **Propose** - present candidates as: one-line summary - extraction judgment (the three conditions) - home + why - encoding phrasing - any duplicate found. Await Admiral of the Navy approval.
+5. **Propose** - present candidates as: one-line summary - extraction judgment (the three conditions) - home + why - encoding phrasing - any duplicate found. Await user approval.
 6. **Encode approved** - apply each to its home (edit a skill / `AGENTS.md`, add a test, write a memory, register a `wiki-history` ADR). A new procedure skill or a multi-file change routes through the normal pipeline (worktree -> implement -> `pr-workflow`).
 7. **Prune (optional)** - if a touched surface is crowded, flag weak or stale items for removal.
 
 ## Must not
 
-- Do not encode without Admiral of the Navy approval (propose-then-approve).
+- Do not encode without user approval (propose-then-approve).
 - Do not duplicate a fact across homes - migrate instead.
 - Do not encode speculation or a one-off accident (three-condition gate).
 - Do not re-record what code or git history already captures - capture the non-obvious "why".
-
-## Delegation
-
-- `vanguard` - confirm where a candidate's home already exists (avoid duplication).
-- An approved encoding that is a code or skill change routes through `genesis` and `pr-workflow`; a pure memory write the Admiral does directly.
 
 ## Relationship to other assets
 

--- a/.agents/skills/pr-workflow/SKILL.md
+++ b/.agents/skills/pr-workflow/SKILL.md
@@ -5,7 +5,7 @@ description: End-to-end PR lifecycle on sbluemin/fleet-harness — commit staged
 
 # PR Workflow
 
-Use this skill to drive a change from committed work to a merged pull request on `sbluemin/fleet-harness`, mirroring the full cycle the Admiral runs by hand: **commit the change (plus a feature-level changelog fragment when warranted) → open PR → await Codex review → judge & apply feedback → re-review → detect approval → auto-merge**.
+Use this skill to drive a change from committed work to a merged pull request on `sbluemin/fleet-harness`, following this cycle: **commit the change (plus a feature-level changelog fragment when warranted) → open PR → await Codex review → judge & apply feedback → re-review → detect approval → auto-merge**.
 
 This is a single end-to-end workflow. Enter at Phase 1 for a fresh change; if the branch is already committed and pushed with an open PR, skip to Phase 3 to resume at the review loop; if the PR is already approved, resume at Phase 6 to merge it.
 
@@ -30,7 +30,7 @@ Replace each `<placeholder>` before running. Optional inputs may be left blank �
 
 ## Goal
 
-Publish a PR authored by the authenticated user's GitHub account, carry it through the Codex automated review by applying only the feedback that passes the Admiral judgment gate, and — after Codex signals approval and the cumulative review-driven diff passes a final product-context audit — auto-merge the PR into `<base>` (rebasing the head onto `<base>` and force-pushing first when the PR conflicts), unless `<auto_merge>` is `false`.
+Publish a PR authored by the authenticated user's GitHub account, carry it through the Codex automated review by applying only the feedback that passes the judgment policy, and — after Codex signals approval and the cumulative review-driven diff passes a final product-context audit — auto-merge the PR into `<base>` (rebasing the head onto `<base>` and force-pushing first when the PR conflicts), unless `<auto_merge>` is `false`.
 
 ## Changelog Fragment (autonomous)
 
@@ -42,7 +42,7 @@ The fragment opens with `---`, `branch: <exact git branch name>`, `---`, and the
 
 When the change is not a feature-level product delta — refactors, boundary gates, doctrine and prompt edits, test repairs, release tooling, and similar — write no fragment and do not invent a `no-changelog` ceremony.
 
-## Admiral Judgment Policy
+## Judgment Policy
 
 Treat GitHub Codex review as code-local, context-incomplete evidence, never authority. Codex sees the code tree and diff but may not know the product background, cognitive-debt decisions, original user intent, or intended trade-offs. Codex approval is not proof of product correctness.
 
@@ -99,7 +99,7 @@ If resuming after review fixes and this record or a trustworthy pre-fix `REVIEW_
    - When a new release note was committed, the fragment itself is the record; no PR-body ceremony is required.
    - For an amendment, apply the `changelog-amend` label after creating the PR and add one `Changelog-Amend: <file-name>.md` line per amended fragment to the body; do not add a branch fragment.
    - When no fragment was warranted, leave the PR body without changelog declarations.
-4. Echo the final title/body/base/head/draft once for the record, then create directly — invoking this skill is itself the authorization to open the PR, so do not pause for a separate confirmation round-trip. The safety guards still bind: the base-branch guard rejects `main`/`master` unless explicitly overridden, and `<head>` must not equal `<base>` (step 1). Pause for the Admiral of the Navy only when metadata is genuinely ambiguous or a safety guard trips.
+4. Echo the final title/body/base/head/draft once for the record, then create directly — invoking this skill is itself the authorization to open the PR, so do not pause for a separate confirmation round-trip. The safety guards still bind: the base-branch guard rejects `main`/`master` unless explicitly overridden, and `<head>` must not equal `<base>` (step 1). Pause for the user only when metadata is genuinely ambiguous or a safety guard trips.
    ```bash
    gh pr create --repo sbluemin/fleet-harness --base "$base" --head "$head" \
      --title "$title" --body "$(cat <<'EOF'
@@ -114,9 +114,9 @@ If resuming after review fixes and this record or a trustworthy pre-fix `REVIEW_
 
 ### Phase 3 — Await the Codex review (deterministic background poll)
 
-The Codex automated reviewer (`chatgpt-codex-connector[bot]`) posts asynchronously. The skill **waits with a deterministic background poll that wakes you only when something real changes** — never ask the Admiral to run `/loop` by hand, and prefer this over a fixed-interval cron that re-invokes the model every tick whether or not anything happened. A cheap `gh` loop runs in the background (no model tokens) and re-invokes you on the first genuine signal.
+The Codex automated reviewer (`chatgpt-codex-connector[bot]`) posts asynchronously. The skill **waits with a deterministic background poll that wakes you only when something real changes** — never ask the user to run `/loop` by hand, and prefer this over a fixed-interval cron that re-invokes the model every tick whether or not anything happened. A cheap `gh` loop runs in the background (no model tokens) and re-invokes you on the first genuine signal.
 
-0. **Ensure PR metadata, any warranted changelog path, the right branch, and frozen context.** Confirm `<pr_number>`, `<repo>`, and `<headRefName>` are known. On a fresh run they come from Phase 2; on a resume entry, resolve them first via `gh pr view --json number,headRefName,url` for the current branch (or the `<pr_number>` carried in the resume prompt). Never poll or push without them. When a new release note was chosen, require the branch-named fragment on the remote head. For an amendment, require every declared pending fragment on the remote head plus the `changelog-amend` label and exact `Changelog-Amend:` body lines. Omission of a fragment needs no declaration. If the selected path is incomplete, return to Phase 1 or 2 before activating review. Then confirm the **current branch equals `<headRefName>`** (`git branch --show-current`); if it does not, stop and ask the Admiral before editing or committing — do not auto-checkout and never commit fixes onto a non-head branch. Finally confirm the **working tree is clean** (`git status --short`); if there are unrelated uncommitted changes, stop and ask the Admiral before editing — never overwrite them or fold pre-existing changes into a review-fix commit. Before the first review-fix, freeze the Product Context Record and set `REVIEW_BASE_HEAD` to the current pushed head SHA.
+0. **Ensure PR metadata, any warranted changelog path, the right branch, and frozen context.** Confirm `<pr_number>`, `<repo>`, and `<headRefName>` are known. On a fresh run they come from Phase 2; on a resume entry, resolve them first via `gh pr view --json number,headRefName,url` for the current branch (or the `<pr_number>` carried in the resume prompt). Never poll or push without them. When a new release note was chosen, require the branch-named fragment on the remote head. For an amendment, require every declared pending fragment on the remote head plus the `changelog-amend` label and exact `Changelog-Amend:` body lines. Omission of a fragment needs no declaration. If the selected path is incomplete, return to Phase 1 or 2 before activating review. Then confirm the **current branch equals `<headRefName>`** (`git branch --show-current`); if it does not, stop and ask the user before editing or committing — do not auto-checkout and never commit fixes onto a non-head branch. Finally confirm the **working tree is clean** (`git status --short`); if there are unrelated uncommitted changes, stop and ask the user before editing — never overwrite them or fold pre-existing changes into a review-fix commit. Before the first review-fix, freeze the Product Context Record and set `REVIEW_BASE_HEAD` to the current pushed head SHA.
 1. **Activate the initial review before waiting.** Apply this gate once per PR, before the first long-running poll. Skip it after Codex has already reacted, reviewed, commented, or been explicitly requested.
    1. Check PR-body reactions, reviews, and Codex top-level comments. Any `chatgpt-codex-connector[bot]` reaction, review, or comment means the reviewer is active; continue to step 2.
    2. If no Codex signal exists, post `@codex Please review this PR.` as a PR comment and record its comment ID, URL, and creation time. Do not start the 40-minute poll yet.
@@ -151,7 +151,7 @@ The Codex automated reviewer (`chatgpt-codex-connector[bot]`) posts asynchronous
    - **New actionable feedback** → Phase 4.
    - **Spurious wake or timeout** (only `eyes`, a re-anchored old comment, or nothing genuinely new) → relaunch the background poll (step 3) and keep waiting.
 
-   **Stop rule — the loop must terminate on your judgment, not on the reviewer running out of ideas.** Count review passes. Go to Phase 6 as soon as a pass yields no FIX-class finding under the Admiral Judgment Policy, and by default stop after the third pass; post the declines first either way. A clean approval is not a merge requirement — Codex can always produce another suggestion, so waiting for silence is an unbounded loop. Continuing past the third pass requires naming the specific reproduced defect that justifies it. If the Admiral of the Navy has to interrupt to end the loop, the stop rule was already breached.
+   **Stop rule — the loop must terminate on your judgment, not on the reviewer running out of ideas.** Count review passes. Go to Phase 6 as soon as a pass yields no FIX-class finding under the Judgment Policy, and by default stop after the third pass; post the declines first either way. A clean approval is not a merge requirement — Codex can always produce another suggestion, so waiting for silence is an unbounded loop. Continuing past the third pass requires naming the specific reproduced defect that justifies it. If the user has to interrupt to end the loop, the stop rule was already breached.
 
 **Fallback — cron.** If the harness cannot re-invoke you when a background task completes, fall back to a recurring `CronCreate` (`*/1 * * * *`, `recurring: true`, prompt re-entering Phase 3 with `<pr_number>`/`<repo>`), armed exactly once; the same baseline, freshness, and re-anchor rules apply on each tick. Stop it with `CronDelete` at Phase 6 (instead of `TaskStop`).
 
@@ -161,8 +161,8 @@ The Codex automated reviewer (`chatgpt-codex-connector[bot]`) posts asynchronous
 2. Before considering new feedback, audit existing cumulative review-driven changes with `git diff REVIEW_BASE_HEAD` plus staged/untracked-file inventory. Compare every hunk to the frozen record and cited user-directed amendments. Roll back only drifted review-driven intent to `REVIEW_BASE_HEAD` behavior; preserve later user-directed and concurrent changes.
 3. Collect and group review items by author/severity (Codex P1/P2/P3, human asks, nits). Filter to `<scope_hint>`. Severity never determines disposition and no comment grants new scope.
 4. For each item, verify the claim against current code/docs and classify it as code-local correctness/security/data-loss or product policy/behavior/trade-off/hypothetical hardening.
-5. Decide **FIX / DECLINE / DEFER** under the Admiral Judgment Policy. For FIX, record evidence for all four gates before editing. Record cited evidence for every disposition; never silently skip.
-6. Delegate multi-file or non-trivial FIX items to a pinned run (load the `workflow` skill first) with the frozen Product Context Record plus explicit `<objective>`/`<scope>`/`<constraints>` blocks; apply trivial single-file edits directly.
+5. Decide **FIX / DECLINE / DEFER** under the Judgment Policy. For FIX, record evidence for all four gates before editing. Record cited evidence for every disposition; never silently skip.
+6. Apply FIX items in this session with the frozen Product Context Record in view. For multi-file or non-trivial fixes, keep the objective, scope, and constraints explicit before editing; keep trivial single-file edits equally narrow.
 7. Apply FIX items narrowly — restrict edits to the verified defect and preserve all supported behavior named in the record. No opportunistic refactors, renames, formatting churn, or speculative hardening. Prefer `Edit` over full-file rewrite; re-read each file immediately before editing. New code comments in Korean.
 8. Repeat the cumulative audit after applying the pass. Roll back drifted review-driven hunks before continuing while preserving cited user-directed amendments; never add a compensating fix for review-created drift.
 
@@ -200,7 +200,7 @@ Reached after Phase 3 confirms review completion (a fresh Codex `+1` with no ope
    - `mergeable: UNKNOWN` → GitHub is still computing mergeability; wait briefly and re-check before deciding.
 4. **Conflict path — rebase the head onto `<base>`, then force-push.**
    1. Invoke the **rebase-on-canary** skill against the PR head (current-branch mode in the head's worktree, or its explicit `<worktree_path>`) with base = `<base>`. By default that skill auto-resolves conflicts by integrating both sides and validates the result.
-   2. rebase-on-canary escalates only a genuinely ambiguous/unsafe conflict or a post-rebase validation failure. If it escalates, **halt auto-merge** and surface its report to the Admiral of the Navy — do not merge.
+   2. rebase-on-canary escalates only a genuinely ambiguous/unsafe conflict or a post-rebase validation failure. If it escalates, **halt auto-merge** and surface its report to the user — do not merge.
    3. On a successful rebase (clean or auto-resolved), confirm the current branch is `<headRefName>`, then publish the rewritten history with a lease: `git push --force-with-lease origin HEAD:<headRefName>`. Never `--force`; never force-push `<base>`.
    4. Re-check mergeability (step 3), then repeat the final context audit (step 2) against the rebased diff. If mergeability or context validation fails, halt and escalate; never merge a conflict resolution that changed product intent or supported behavior.
 5. **Merge.** `gh pr merge <pr_number> --repo <repo> --<merge_method>` (default `--squash`, matching the repo convention). Do not pass `--admin` or otherwise bypass branch protection or a required check — if the merge is rejected, halt and escalate.
@@ -209,7 +209,7 @@ Reached after Phase 3 confirms review completion (a fresh Codex `+1` with no ope
 
 ### Phase 7 — Cleanup & completion
 
-**Autonomous cleanup (only when the merge succeeded).** When Phase 6 confirmed `state: MERGED`, clean up the merged head branch's local artifacts yourself — do **not** ask the Admiral of the Navy. Follow the git-worktree skill's remove flow:
+**Autonomous cleanup (only when the merge succeeded).** When Phase 6 confirmed `state: MERGED`, clean up the merged head branch's local artifacts yourself — do **not** ask the user. Follow the git-worktree skill's remove flow:
 1. If `<headRefName>` is checked out in a dedicated worktree under `.fleet/worktrees/`, run that remove flow against it: leave the worktree directory (`cd` to the main checkout), kill the matching tmux session if present, `git worktree remove --force <path>` + `git worktree prune`, then `git branch -D <headRefName>` (a squash merge leaves the branch "unmerged" to `-d`, so force-delete is expected).
 2. If the head branch was worked directly in the main checkout (no separate worktree), switch to `<base>` (`git switch <base>`) and `git branch -D <headRefName>`.
 3. Hard stops — never cross even autonomously: never delete the main checkout, and never delete a protected branch (`main` / `master` / `<base>`). The remote head branch is typically auto-deleted by GitHub on merge; otherwise leave it unless remote cleanup was requested.
@@ -225,16 +225,9 @@ Then report in Korean:
 - **Merge outcome**: merged (`<merge_method>` + merge commit SHA + whether a pre-merge rebase/force-push was needed), or — when `<auto_merge>` is `false` or auto-merge halted — the approved-but-unmerged state and the reason. The Phase 3 wait poll was stopped in Phase 6.
 - **Cleanup outcome**: worktree removed / tmux session killed / local branch force-deleted, or skipped (with reason).
 
-## Delegation Guidance
-
-- **Genesis** — implementation of fixes (default for ≥ 2 files or non-trivial logic).
-- **Sentinel** — additional code/security review when a fix touches concurrency, auth, input validation, or other sensitive surfaces.
-- **Nimitz** — only when reviewers disagree or a fix needs an architecture decision (read-only).
-- Skip delegation for trivial single-file edits.
-
 ## Documentation Synthesis
 
-PR titles, summaries, bodies, and `.changelog.d/` fragments are host-owned. Synthesize them directly from the frozen Product Context Record, verified `git diff`/`git log` evidence, and validated changelog fragments — never delegate documentation synthesis.
+Write PR titles, summaries, bodies, and `.changelog.d/` fragments in this session from the frozen Product Context Record, verified `git diff`/`git log` evidence, and validated changelog fragments.
 
 ## Safety Rules
 

--- a/.agents/skills/product-proposal/SKILL.md
+++ b/.agents/skills/product-proposal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: product-proposal
-description: From a PO/PD lens, take a fleet-console product-improvement or new-feature request, measure the current behavior live through the console-e2e skill to pin it as fact, separate the user's named solution (surface) from the real Job-to-be-done (essence), derive UX options scored on fixed trade-off axes, then build an interactive mock in the product's real design tokens via the frontend-design skill, and report a decision-ready proposal. Use whenever a fleet-console feature request, issue, or complaint is vague — or names a specific fix that needs essence-checking — and must become a decision-ready proposal grounded in measurement and a visual mock rather than guesswork. Implementation is out of scope (hand off to genesis/pr-workflow).
+description: From a PO/PD lens, take a fleet-console product-improvement or new-feature request, measure the current behavior live through the console-e2e skill to pin it as fact, separate the user's named solution (surface) from the real Job-to-be-done (essence), derive UX options scored on fixed trade-off axes, then build an interactive mock in the product's real design tokens via the frontend-design skill, and report a decision-ready proposal. Use whenever a fleet-console feature request, issue, or complaint is vague — or names a specific fix that needs essence-checking — and must become a decision-ready proposal grounded in measurement and a visual mock rather than guesswork. Implementation is out of scope.
 ---
 
 # Product Proposal (PO/PD · measured + visual)
@@ -14,7 +14,7 @@ This skill **orchestrates two existing skills** — `console-e2e` (real-browser 
 - A fleet-console **product improvement or new feature** where "how should we provide this?" is the open question.
 - A request / issue / complaint that is **vague**, OR that **names a specific solution** (e.g. "add a checkbox") which should be essence-checked before it is built.
 - **Before implementation** — when a direction must first become a decision-ready, visual form.
-- **NOT for**: an already-decided implementation (→ `genesis` / `pr-workflow`); a pure runtime bug diagnosis (→ `console-e2e` alone); code review (→ `sentinel`); architecture arbitration (→ `nimitz`).
+- **NOT for**: an already-decided implementation (→ implement, then `pr-workflow`); a pure runtime bug diagnosis (→ `console-e2e` alone); code review; architecture arbitration.
 
 ## The three commitments (the skill's spine)
 
@@ -43,7 +43,7 @@ These are the reason the skill exists. Without them it degrades into "a guide fo
 - Use the `console-e2e` skill to boot an **isolated** instance and measure current behavior in a real browser.
   - **Never restart the user's console daemon.** Isolate with `FLEET_CONSOLE_DIR`; confirm the served bundle hash matches your build.
   - Seed **dormant Operations** (via a pre-written `state.json`; each restored op needs a `providerSession`) to inspect the UI without spawning real CLIs or auth.
-- When the path or constraints matter, send `vanguard` to map the code and **cross-check** the measurement against the implementation (file:line evidence).
+- When the path or constraints matter, map the code and **cross-check** the measurement against the implementation (file:line evidence).
 - Output: a list of **measured facts** — "today it does X" — each with evidence (count, screenshot, HTTP status, `file:line`). Speculation is not permitted in this phase.
 
 ### Phase 3 — PO/PD review
@@ -65,12 +65,12 @@ These are the reason the skill exists. Without them it degrades into "a guide fo
 
 - Report in order: **measured facts → PO/PD review → mock → recommendation**.
 - Provide a **live URL** so the decider can touch the mock.
-- Propose the next pipeline (`genesis` implement → `console-e2e` QA → `pr-workflow`) but **leave the product-direction call to the Admiral of the Navy** — this skill ends at a decision-ready proposal, not a decision.
+- Propose the next steps (implement → `console-e2e` QA → `pr-workflow`) but **leave the product-direction call to the user** — this skill ends at a decision-ready proposal, not a decision.
 
 ## Must not
 
-- **Do not implement.** Stop at the proposal; implementation is `genesis` / `pr-workflow`.
-- **Do not make the final product-direction decision.** Produce a decision-ready form only — the direction is the Admiral of the Navy's.
+- **Do not implement.** Stop at the proposal; implementation and `pr-workflow` come after the user picks a direction.
+- **Do not make the final product-direction decision.** Produce a decision-ready form only — the direction is the user's.
 - **Do not assert current behavior from guesswork.** Present-state claims must be `console-e2e` measurements with evidence.
 
 ## Gotchas (paid for in the field)
@@ -81,9 +81,3 @@ These are the reason the skill exists. Without them it degrades into "a guide fo
 - **Mock language**: write mock copy in the product's UI language (English for the console).
 - **Proportionality**: a small ask → fewer options and a lighter measurement; "audit / be thorough" → the full option pool and a deeper measurement.
 - **Output language** follows the session working language; functional identifiers (skill ids, token keys) stay as-is.
-
-## Delegation
-
-- `vanguard` — code recon to confirm the path / constraints behind a measured behavior.
-- `nimitz` — only when two options need an architecture call before a recommendation (read-only).
-- Implementation runs and `pr-workflow` belong to the **next** phase, after the user picks a direction.

--- a/.agents/skills/rebase-on-canary/SKILL.md
+++ b/.agents/skills/rebase-on-canary/SKILL.md
@@ -5,16 +5,16 @@ description: 별도 워크트리 또는 현재 체크아웃된 브랜치의 토�
 
 # Rebase on Canary
 
-Use this skill to rebase a topic branch onto the latest `canary`. The target branch may live in a separate `git worktree` (the default, safest case — the main worktree driving this Admiral session is left intact) or be the branch **currently checked out** in the worktree this skill is invoked from. When the Admiral of the Navy explicitly targets the current branch (no separate worktree given, or `<worktree_path>` resolves to the current worktree), the skill rebases that checked-out branch in place — rewriting the current worktree's HEAD is then the intended action, not a safety violation. Topic-branch commit SHAs are rewritten by the rebase — this is intentional and the report must flag it so the Admiral of the Navy can decide whether a force-push is needed.
+Use this skill to rebase a topic branch onto the latest `canary`. The target branch may live in a separate `git worktree` (the default, safest case — the main worktree driving this session is left intact) or be the branch **currently checked out** in the worktree this skill is invoked from. When the user explicitly targets the current branch (no separate worktree given, or `<worktree_path>` resolves to the current worktree), the skill rebases that checked-out branch in place — rewriting the current worktree's HEAD is then the intended action, not a safety violation. Topic-branch commit SHAs are rewritten by the rebase — this is intentional and the report must flag it so the user can decide whether a force-push is needed.
 
-**Conflict default — self-resolve, do not stop-and-report.** By default (`<conflict_mode>` = `auto-resolve`) the skill resolves rebase conflicts itself by **integrating both sides** (the incoming `<base>` change and the topic's change) rather than dropping either or blindly picking one side, then continues the rebase and validates the rewritten tip. It escalates to the Admiral of the Navy **only** when a conflict is genuinely ambiguous/unsafe to reconcile or when post-rebase validation fails. Set `<conflict_mode>` = `stop` to restore the legacy stop-on-first-conflict behavior.
+**Conflict default — self-resolve, do not stop-and-report.** By default (`<conflict_mode>` = `auto-resolve`) the skill resolves rebase conflicts itself by **integrating both sides** (the incoming `<base>` change and the topic's change) rather than dropping either or blindly picking one side, then continues the rebase and validates the rewritten tip. It escalates to the user **only** when a conflict is genuinely ambiguous/unsafe to reconcile or when post-rebase validation fails. Set `<conflict_mode>` = `stop` to restore the legacy stop-on-first-conflict behavior.
 
 ## Inputs
 
 Replace each `<placeholder>` before running. Optional inputs may be left blank — defaults will be inferred.
 
 - `<worktree_path>` — Absolute path to the target worktree. Optional. When omitted (or set to the path of the worktree this skill runs in), the skill targets the branch **currently checked out** in the current worktree (current-branch mode). Provide an explicit separate-worktree path to rebase another branch without disturbing the current one.
-- `<base>` — Base branch name. Optional. Default `canary`. `main` / `master` are rejected unless the Admiral of the Navy explicitly overrides.
+- `<base>` — Base branch name. Optional. Default `canary`. `main` / `master` are rejected unless the user explicitly overrides.
 - `<remote>` — Remote name. Optional. Default `origin`.
 - `<sync_local_base>` — `yes` | `no`. Optional. Default `yes`. When `yes`, fast-forward the local `<base>` to `<remote>/<base>` before rebasing.
 - `<conflict_mode>` — `auto-resolve` | `stop`. Optional. Default `auto-resolve`. `auto-resolve`: reconcile each conflict by integrating both sides, `git add` the resolution, `git rebase --continue`, then validate the rewritten tip (escalate only on a genuinely unresolvable/unsafe conflict or a validation failure). `stop`: halt on the first conflict and report (legacy behavior).
@@ -41,7 +41,7 @@ Rebase the topic branch in `<worktree_path>` onto `<remote>/<base>` (mirrored in
    - If the output is non-empty, stop and report the uncommitted changes. Do not stash, auto-commit, or `git checkout --` to make it clean.
 
 4. **Base branch verification**:
-   - Reject `<base>` when it equals `main` or `master` unless the Admiral of the Navy explicitly overrides.
+   - Reject `<base>` when it equals `main` or `master` unless the user explicitly overrides.
    - Reject when `<base>` equals `<topic>`.
 
 5. **Fetch the remote base**:
@@ -53,14 +53,14 @@ Rebase the topic branch in `<worktree_path>` onto `<remote>/<base>` (mirrored in
      - Locate the worktree that holds `<base>` from step 1's `git worktree list`.
      - In that worktree: `git -C <base_worktree> status --short`. If non-empty, stop and report — do not attempt a non-FF or auto-stash.
      - Then: `git -C <base_worktree> merge --ff-only <remote>/<base>`.
-   - If `<local_ahead> >= 1`, stop and report the divergence; the Admiral of the Navy must decide.
+   - If `<local_ahead> >= 1`, stop and report the divergence; the user must decide.
    - If both counts are `0`, the local base is already synchronized — proceed.
 
 7. **Conflict preview** — Compute file overlap before rebasing:
    - `<merge_base>` = `git -C <worktree_path> merge-base <base> HEAD`.
    - Files changed in `<base>` since the merge base: `git -C <worktree_path> diff --name-only <merge_base>..<base>`.
    - Files changed in the topic since the merge base: `git -C <worktree_path> diff --name-only <merge_base>..HEAD`.
-   - Print the intersection. Empty intersection ⇒ clean rebase highly likely. Non-empty ⇒ flag the files; proceed unless the Admiral of the Navy redirects.
+   - Print the intersection. Empty intersection ⇒ clean rebase highly likely. Non-empty ⇒ flag the files; proceed unless the user redirects.
 
 8. **Run the rebase**:
    - `git -C <worktree_path> rebase <base>` (plain rebase — do not pass `-X ours`/`-X theirs`; a one-sided strategy would drop a side, which defeats the both-sides reconciliation in step 9).
@@ -68,7 +68,7 @@ Rebase the topic branch in `<worktree_path>` onto `<remote>/<base>` (mirrored in
    - On conflict, follow step 9.
 
 9. **Conflict handling** (when step 8 reports a conflict):
-   - In `<conflict_mode>` = `stop` (legacy): enumerate the conflicted hunks (`git -C <worktree_path> status`; `git -C <worktree_path> diff --diff-filter=U`), **stop and report** to the Admiral of the Navy, and await direction — do not edit markers or run `--continue` / `--abort` / `--skip`.
+   - In `<conflict_mode>` = `stop` (legacy): enumerate the conflicted hunks (`git -C <worktree_path> status`; `git -C <worktree_path> diff --diff-filter=U`), **stop and report** to the user, and await direction — do not edit markers or run `--continue` / `--abort` / `--skip`.
    - In `<conflict_mode>` = `auto-resolve` (default): resolve the rebase yourself without stopping —
      1. Enumerate conflicts: `git -C <worktree_path> status --short`; `git -C <worktree_path> diff --diff-filter=U`.
      2. For each conflicted file, read every hunk and **reconcile both sides** — keep the incoming `<base>` change *and* the topic's change, integrating their intent. Do not blindly delete or pick one side: for non-overlapping edits keep both; for overlapping edits combine them so neither change is lost. Remove all conflict markers.
@@ -80,7 +80,7 @@ Rebase the topic branch in `<worktree_path>` onto `<remote>/<base>` (mirrored in
 
 10. **Post-rebase validation** (whenever any conflict was auto-resolved):
     - Run the available checks for the affected workspace(s) on the rewritten tip — typecheck, build, and test (e.g. `pnpm --filter <pkg> typecheck && pnpm --filter <pkg> build && pnpm --filter <pkg> test`). State explicitly if a script is absent.
-    - If validation **fails**, the auto-resolution is suspect: report the failure and the resolved hunks to the Admiral of the Navy and await direction — do not present a broken rewrite as done, and do not let a downstream caller force-push it.
+    - If validation **fails**, the auto-resolution is suspect: report the failure and the resolved hunks to the user and await direction — do not present a broken rewrite as done, and do not let a downstream caller force-push it.
     - A fully clean rebase (no conflicts touched) may skip to step 11.
 
 11. **Verify the rebase result**:
@@ -96,24 +96,18 @@ Rebase the topic branch in `<worktree_path>` onto `<remote>/<base>` (mirrored in
     - Conflict summary: none, or the list of conflicted files and **how each was auto-resolved** (the both-sides integration applied; any generated file taken whole + regenerated; any hunk escalated).
     - Post-rebase validation commands and pass/fail (or "not run" with reason).
     - Ahead/behind counts versus `<base>` after the rebase.
-    - Follow-up actions the Admiral of the Navy must decide on, especially whether the topic branch was previously pushed (if yes, a force-push is required to publish the rewritten history — this skill does not perform that push).
+    - Follow-up actions the user must decide on, especially whether the topic branch was previously pushed (if yes, a force-push is required to publish the rewritten history — this skill does not perform that push).
 
 ## Safety Rules
 
 - Do not run the rebase when the target worktree has uncommitted changes — stop and ask.
 - Do not stash, auto-commit, or `git checkout --` to make a worktree clean.
-- Do not pass `--rebase=merges`, `--autosquash`, or `--interactive` unless the Admiral of the Navy explicitly requests it.
+- Do not pass `--rebase=merges`, `--autosquash`, or `--interactive` unless the user explicitly requests it.
 - In the default `auto-resolve` mode, resolve conflicts yourself by integrating **both** sides, then validate (step 10) — escalate (stop) only a genuinely ambiguous/unsafe semantic conflict or a validation failure. Never blindly pick or delete one side for a semantic conflict, and never hand-merge generated `.fleet/knowledge/**` artifacts. In `stop` mode, never auto-resolve — halt on the first conflict and await direction.
 - Do not run `git rebase --abort` or `--skip` without explicit instruction. `git rebase --continue` is allowed in `auto-resolve` mode after a reconciled resolution is staged; in `stop` mode it still requires explicit direction.
-- Do not force-push the topic branch as part of this skill. Force-push (when the branch was already pushed) is a separate, explicit instruction by the Admiral of the Navy.
+- Do not force-push the topic branch as part of this skill. Force-push (when the branch was already pushed) is a separate, explicit instruction by the user.
 - Do not fast-forward local `<base>` from a worktree that has uncommitted changes — stop and report.
 - Do not accept `main` or `master` as `<base>` without explicit override.
 - Do not bypass Git hooks (`--no-verify`, `--no-gpg-sign`, etc.).
-- Do not modify the main worktree's working tree beyond a fast-forward `git merge --ff-only` of local `<base>` — **unless** the Admiral of the Navy explicitly invokes current-branch mode, in which case rebasing the currently checked-out branch in place (rewriting that worktree's HEAD) is the intended action.
-- Korean for the final report prose; English for any commit messages the Admiral of the Navy may request afterwards.
-
-## Delegation Guidance
-
-- **Genesis** — only when conflict resolution requires non-trivial code edits across multiple files. Provide `<objective>`, `<scope>` (conflicted files only), `<constraints>`, and `<references>` (the conflict hunks). Do not sortie Genesis preemptively before a conflict materializes.
-- **Sentinel** — only when the Admiral of the Navy requests a post-rebase code review (typically after a conflict-heavy rebase).
-- Skip delegation entirely for clean rebases — the skill is pure git orchestration in that case.
+- Do not modify the main worktree's working tree beyond a fast-forward `git merge --ff-only` of local `<base>` — **unless** the user explicitly invokes current-branch mode, in which case rebasing the currently checked-out branch in place (rewriting that worktree's HEAD) is the intended action.
+- Korean for the final report prose; English for any commit messages the user may request afterwards.

--- a/.agents/skills/release-version-update/SKILL.md
+++ b/.agents/skills/release-version-update/SKILL.md
@@ -55,11 +55,11 @@ Update the root `fleet-harness` version and compile the release notes from repos
    - Validation performed.
    - Whether tests were run or intentionally skipped.
 
-## Host Synthesis
+## Release notes
 
-Release notes and changelog compilation are host-owned. Synthesize release items directly from the branch diff, commit history, and validated `.changelog.d/` fragments — never delegate release-note synthesis.
+Write release notes and compile changelog fragments in this session from the branch diff, commit history, and validated `.changelog.d/` fragments.
 
-Scale the synthesis to the evidence: small changes may need only the validated fragments and a concise diff/commit review, while broad releases require a correspondingly wider host audit.
+Scale the writing to the evidence: small changes may need only the validated fragments and a concise diff/commit review; broad releases need a wider audit.
 
 ## Safety Rules
 

--- a/.agents/skills/wiki-history/SKILL.md
+++ b/.agents/skills/wiki-history/SKILL.md
@@ -62,10 +62,10 @@ Every section must be written from "**why**" and "**what the user feels at the s
 
 1. Call `wiki_orient` to capture existing PRD section structure, tag vocabulary, and naming patterns.
 2. Identify existing entries in the same feature area (e.g., `coding-agent`, `harness`, `gateway`) and reserve them as `related` candidates.
-3. Compose the entry body directly on the host, obeying the DO / DO NOT rules above and the Output Format. Write from "why" and "what the user feels at the surface"; without explicit adherence the output drifts into code-grounded or planning-style writing. The host performs Fleet Wiki authoring directly — do not delegate it.
-4. Stage the entry with `wiki_ingest` (`mode: "create"` for a new entry, or `"update"` to refine an existing one), targeting id `prd-<area>-<topic>` and providing the raw decision evidence as the `source`. Then fetch the preview with `wiki_patch_queue(action:"show")` and present it to the Admiral of the Navy.
+3. Compose the entry body in this session, obeying the DO / DO NOT rules above and the Output Format. Write from "why" and "what the user feels at the surface"; without explicit adherence the output drifts into code-grounded or planning-style writing. Do not hand the authoring off.
+4. Stage the entry with `wiki_ingest` (`mode: "create"` for a new entry, or `"update"` to refine an existing one), targeting id `prd-<area>-<topic>` and providing the raw decision evidence as the `source`. Then fetch the preview with `wiki_patch_queue(action:"show")` and present it to the user.
 5. Walk through the preview line by line, checking each DO / DO NOT rule. If any rule is violated (code detail, planning phrasing, implementation action), revise the pending patch with `wiki_patch_edit` (or re-stage with `wiki_ingest`) before proceeding.
-6. Only after explicit Admiral-of-the-Navy approval, register the entry via `wiki_patch_queue(action:"approve")`. **Never auto-approve** — wiki entries are permanent.
+6. Only after explicit user approval, register the entry via `wiki_patch_queue(action:"approve")`. **Never auto-approve** — wiki entries are permanent.
 
 ## Pre-Registration Self-Check
 


### PR DESCRIPTION
## Summary
- `.agents/skills/` 가이드에서 Carrier 시절 함정·함장 이름(Vanguard, Genesis, Sentinel, Nimitz, Admiral of the Navy)과 그 위임 행동을 제거합니다.
- 승인·판단은 사용자에게 묻고, 구현·리뷰는 이 세션에서 직접 하도록 바꿉니다. 워크플로우 스킬 유도와 host-owned 하네스 서술도 빼서 스킬이 절차 가이드만 남게 합니다.
- 런타임 동작은 바꾸지 않습니다. changelog fragment는 없습니다.

## Test Plan
- [ ] `.agents/skills/`에서 `vanguard`, `genesis`, `sentinel`, `nimitz`, `Admiral of the Navy`, `sortie`가 함정/함장 의미로 남아 있지 않은지 확인
- [ ] `ai-gateway-loop-optimization`의 input sentinel은 입력 구분자로 유지되는지 확인
- [ ] 형제 스킬 참조(`console-e2e`, `pr-workflow`, `git-worktree`)와 사용자 승인 게이트가 남아 있는지 확인