### PR TITLE
fix(fleet-console): open cowork effort flyout to the right first

### DIFF
--- a/.changelog.d/cowork-effort-flyout-right.md
+++ b/.changelog.d/cowork-effort-flyout-right.md
@@ -1,0 +1,8 @@
+---
+branch: cowork-effort-flyout-right
+---
+
+### fleet-console
+#### Changed
+- The codex workspace agent menu now opens the effort track to the right of the model rows first, falling back to the left only when the right side lacks room.
+  ko: Codex 작업공간 에이전트 메뉴의 강도 트랙이 모델 행 오른쪽으로 먼저 열리고, 오른쪽 공간이 부족할 때만 왼쪽으로 열립니다.

--- a/runtime/fleet-console/core/client/src/codex/cowork-agent-menu.tsx
+++ b/runtime/fleet-console/core/client/src/codex/cowork-agent-menu.tsx
@@ -71,15 +71,16 @@ export function CoworkAgentMenu({ models, efforts, model, effort, onSelect }: Co
     const root = rootRef.current;
     const row = rowRefs.current.get(rowModel);
     if (!root || !row) return;
-    // 도크는 대개 문서 중앙에 떠 왼쪽이 넓다 — 왼쪽부터 재고, 안 되면 오른쪽을 재고, 좁은
-    // 화면(≤720px에서 팝오버가 도크 폭으로 늘어난다)처럼 양쪽 다 폭이 안 나오면 화면 밖으로
-    // 여는 대신 메뉴 위에 겹쳐 행 아래로 연다 — 가려지는 것은 조작 불능보다 낫다.
+    // 강도 손잡이가 행 오른쪽 끝에 있으니 트랙은 같은 방향으로 이어지는 오른쪽부터 재고, 안
+    // 되면 왼쪽을 재고, 좁은 화면(≤720px에서 팝오버가 도크 폭으로 늘어난다)처럼 양쪽 다 폭이
+    // 안 나오면 화면 밖으로 여는 대신 메뉴 위에 겹쳐 행 아래로 연다 — 가려지는 것은 조작
+    // 불능보다 낫다.
     const rect = root.getBoundingClientRect();
     const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
-    const placement = rect.left >= FLYOUT_WIDTH + 8
-      ? "left"
-      : viewportWidth - rect.right >= FLYOUT_WIDTH + 8
-        ? "right"
+    const placement = viewportWidth - rect.right >= FLYOUT_WIDTH + 8
+      ? "right"
+      : rect.left >= FLYOUT_WIDTH + 8
+        ? "left"
         : "overlay";
     const top = placement === "overlay" ? row.offsetTop + row.offsetHeight + 4 : row.offsetTop;
     setFlyout({ model: rowModel, top, placement });

--- a/runtime/fleet-console/tests/codex-cowork-ui.test.ts
+++ b/runtime/fleet-console/tests/codex-cowork-ui.test.ts
@@ -729,6 +729,59 @@ describe("Cowork inline copilot", () => {
     controller.destroy();
   });
 
+  it("opens the effort flyout to the right first, then left, then overlay as space runs out", async () => {
+    localStorage.removeItem("fleet.codex.cowork.settings");
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/cowork/entries/")) return new Response(JSON.stringify({ error: "cowork_session_not_found" }), { status: 404 });
+      if (url.includes("/options")) {
+        return new Response(JSON.stringify({ models: ["gpt"], efforts: ["low", "medium", "high"], defaultModel: "gpt", defaultEffort: "low" }));
+      }
+      return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { article, body } = host();
+    const controller = mountCoworkInline({ theaterId: "theater", entryId: "entry", title: "Entry", article, body, onApplied: () => {} });
+    article.querySelector<HTMLButtonElement>('[data-cowork-action="toggle-config"]')!.click();
+    await vi.waitFor(() => expect(article.querySelectorAll(".cowork-agent-row")).toHaveLength(1));
+
+    const menu = article.querySelector<HTMLElement>(".cowork-agent-menu")!;
+    const handle = article.querySelector<HTMLElement>(".cowork-agent-effort-handle")!;
+    const setMenuRect = (left: number, right: number) => {
+      menu.getBoundingClientRect = () => ({ left, right, top: 0, bottom: 0, width: right - left, height: 0, x: left, y: 0, toJSON: () => ({}) }) as DOMRect;
+    };
+    const flyoutClass = async () => {
+      await vi.waitFor(() => expect(article.querySelector(".cowork-effort-flyout")).not.toBeNull());
+      return article.querySelector(".cowork-effort-flyout")!.className;
+    };
+    const toggleClosed = async () => {
+      handle.click();
+      await vi.waitFor(() => expect(article.querySelector(".cowork-effort-flyout")).toBeNull());
+    };
+
+    // 양쪽 다 넓으면 오른쪽 — 강도 손잡이가 행 오른쪽 끝이라 트랙이 같은 방향으로 이어진다.
+    vi.stubGlobal("innerWidth", 1200);
+    setMenuRect(400, 700);
+    handle.click();
+    expect(await flyoutClass()).toBe("cowork-effort-flyout");
+
+    // 오른쪽이 좁고 왼쪽만 넓으면 왼쪽으로 돌아간다.
+    await toggleClosed();
+    vi.stubGlobal("innerWidth", 1024);
+    setMenuRect(600, 1000);
+    handle.click();
+    expect(await flyoutClass()).toContain("is-left");
+
+    // 양쪽 다 폭이 안 나오면 화면 밖으로 여는 대신 메뉴 위에 겹친다.
+    await toggleClosed();
+    vi.stubGlobal("innerWidth", 500);
+    setMenuRect(100, 400);
+    handle.click();
+    expect(await flyoutClass()).toContain("is-overlay");
+
+    controller.destroy();
+  });
+
   it("serializes session settings writes during a drag: one in flight, latest wins", async () => {
     localStorage.removeItem("fleet.codex.cowork.settings");
     const listeners = new Map<string, EventListener>();


### PR DESCRIPTION
## Summary
- Codex 작업공간(cowork) 에이전트 메뉴의 강도 트랙 플라이아웃 배치 우선순위를 왼쪽 우선에서 오른쪽 우선으로 바꿉니다 — 강도 손잡이가 행 오른쪽 끝에 있으므로 트랙이 같은 방향으로 이어집니다.
- 오른쪽 공간이 부족하면 왼쪽, 양쪽 모두 부족하면 기존처럼 메뉴 위 오버레이로 폴백합니다.

## Test Plan
- [x] `pnpm vitest run tests/codex-cowork-ui.test.ts` — 20/20 통과 (신규 배치 우선순위 회귀 테스트 포함)
- [x] `pnpm exec tsc --noEmit -p core/client` — 오류 없음
- [x] 돌연변이 검사 — 옛 배치 로직에서 신규 테스트 실패 확인
