### PR TITLE
feat(quota): drag-reorder provider cards and proper loading state

### DIFF
--- a/.changelog.d/quota-provider-reorder.md
+++ b/.changelog.d/quota-provider-reorder.md
@@ -1,0 +1,15 @@
+---
+branch: quota-provider-reorder
+---
+
+### fleet-console
+
+#### Added
+
+- Reorder provider cards in the usage limits panel by dragging their grip — cards collapse into single rows while dragging so every drop target stays visible, the order persists across sessions, and the grip also moves cards with the arrow keys.
+  ko: 사용 한도 패널의 공급자 카드를 그립으로 드래그해 순서를 바꿀 수 있습니다 — 드래그하는 동안 카드가 한 줄로 접혀 모든 드롭 위치가 보이고, 순서는 세션을 넘어 유지되며, 그립에서 화살표 키로도 이동합니다.
+
+#### Changed
+
+- The usage limits panel now shows a proper loading state — a card explaining that provider usage is being read — instead of a bare "…" while the first summary loads.
+  ko: 사용 한도 패널이 첫 조회 중 "…" 대신 사용량을 읽는 중임을 설명하는 로딩 상태 카드를 표시합니다.

--- a/.changelog.d/quota-provider-reorder.md
+++ b/.changelog.d/quota-provider-reorder.md
@@ -6,10 +6,10 @@ branch: quota-provider-reorder
 
 #### Added
 
-- Reorder provider cards in the usage limits panel by dragging their grip — cards collapse into single rows while dragging so every drop target stays visible, the order persists across sessions, and the grip also moves cards with the arrow keys.
+- Reorder provider cards in the usage limits panel by dragging their grip: cards collapse into single rows while dragging so every drop target stays visible, the order persists across sessions, and the grip also moves cards with the arrow keys.
   ko: 사용 한도 패널의 공급자 카드를 그립으로 드래그해 순서를 바꿀 수 있습니다 — 드래그하는 동안 카드가 한 줄로 접혀 모든 드롭 위치가 보이고, 순서는 세션을 넘어 유지되며, 그립에서 화살표 키로도 이동합니다.
 
 #### Changed
 
-- The usage limits panel now shows a proper loading state — a card explaining that provider usage is being read — instead of a bare "…" while the first summary loads.
+- The usage limits panel now shows a proper loading state that explains provider usage is being read, instead of a bare "..." while the first summary loads.
   ko: 사용 한도 패널이 첫 조회 중 "…" 대신 사용량을 읽는 중임을 설명하는 로딩 상태 카드를 표시합니다.

--- a/runtime/fleet-plugins/quota/client/i18n/messages.ts
+++ b/runtime/fleet-plugins/quota/client/i18n/messages.ts
@@ -45,6 +45,11 @@ export const quotaEn = {
   "quota.credits": "{n} rate-limit resets available",
   "quota.credits.expiry": "Next expires in {t}",
   "quota.privacy": "Reads usage with your local CLI sign-in. Requests go only to each provider; nothing else leaves this machine.",
+  "quota.loading.title": "Reading provider usage",
+  "quota.loading.body": "Querying each provider with your local CLI sign-in. Nothing else leaves this machine.",
+  "quota.reorder.handle": "Reorder {provider}. Use the arrow keys to move it.",
+  "quota.reorder.moved": "{provider} moved to position {n}",
+  "quota.reorder.error": "Couldn't save the order.",
 } as const;
 
 export const quotaKo: Record<keyof typeof quotaEn, string> = {
@@ -94,6 +99,11 @@ export const quotaKo: Record<keyof typeof quotaEn, string> = {
   "quota.credits": "rate-limit 재설정 {n}회 사용 가능",
   "quota.credits.expiry": "다음 만료까지 {t}",
   "quota.privacy": "로컬 CLI 로그인 정보로 사용량을 조회합니다. 요청은 각 공급자에게만 전송되며 그 외에는 이 기기를 떠나지 않습니다.",
+  "quota.loading.title": "사용량을 읽는 중",
+  "quota.loading.body": "로컬 CLI 로그인 정보로 각 공급자에 사용량을 조회합니다. 그 외에는 이 기기를 떠나지 않습니다.",
+  "quota.reorder.handle": "{provider} 순서 변경. 화살표 키로 이동합니다.",
+  "quota.reorder.moved": "{provider} — {n}번째로 이동",
+  "quota.reorder.error": "순서를 저장하지 못했습니다.",
 };
 
 export const QUOTA_MESSAGES = { en: quotaEn, ko: quotaKo } as const;

--- a/runtime/fleet-plugins/quota/client/quota.css
+++ b/runtime/fleet-plugins/quota/client/quota.css
@@ -7,7 +7,10 @@
   color: var(--text-primary);
 }
 
+/* position: relative는 드롭 인디케이터의 기준 상자다 — 인디케이터는 스크롤 콘텐츠
+   좌표(offsetTop)로 놓이므로 기준이 이 스크롤 컨테이너 자신이어야 한다. */
 .quota-body {
+  position: relative;
   display: flex;
   flex: 1;
   flex-direction: column;
@@ -157,6 +160,133 @@
   align-items: center;
   gap: 8px;
   min-height: 22px;
+}
+
+/* ── 공급자 재배열 ─────────────────────────────
+   그립을 잡는 순간 전 카드가 헤더 한 줄로 접혀(quota-body--compact) 드롭 타깃
+   다섯 개가 모두 한 화면에 들어온다. 놓으면 원래 밀도로 복귀한다. */
+.quota-grip {
+  display: grid;
+  place-items: center;
+  width: 18px;
+  height: 22px;
+  margin-left: -4px;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  color: var(--text-tertiary);
+  background: transparent;
+  opacity: 0.35;
+  cursor: grab;
+  touch-action: none;
+}
+
+.quota-provider:hover .quota-grip,
+.quota-connect-card:hover .quota-grip,
+.quota-grip:focus-visible {
+  opacity: 1;
+}
+
+.quota-grip:hover,
+.quota-grip:focus-visible {
+  color: var(--brass);
+}
+
+.quota-grip:focus-visible {
+  outline: 1px solid var(--brass);
+  outline-offset: 1px;
+}
+
+.quota-grip:active {
+  cursor: grabbing;
+}
+
+/* 접힘은 grid-template-rows 1fr→0fr 전환으로 만든다 — 높이 애니메이션 없이
+   내용 높이가 제각각인 카드 다섯 장을 같은 문법으로 접는다. */
+.quota-card__collapse {
+  display: grid;
+  grid-template-rows: 1fr;
+  transition: grid-template-rows 180ms ease;
+}
+
+.quota-card__rest {
+  overflow: hidden;
+  min-height: 0;
+}
+
+.quota-body--compact {
+  user-select: none;
+}
+
+.quota-body--compact .quota-card__collapse {
+  grid-template-rows: 0fr;
+}
+
+.quota-body--compact .quota-provider,
+.quota-body--compact .quota-connect-card {
+  padding: 8px 12px;
+}
+
+/* 접힌 행에서는 헤더 우측 컨트롤을 치운다 — 드래그 중 남는 정보는 정체뿐이다. */
+.quota-body--compact .quota-plan,
+.quota-body--compact .quota-disconnect {
+  display: none;
+}
+
+.quota-card--dragging {
+  border-color: var(--brass);
+  opacity: 0.5;
+}
+
+.quota-drop-line {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  z-index: 3;
+  height: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--brass);
+  box-shadow: var(--brass-halo);
+}
+
+/* 스크린리더 전용 이동 공지. */
+.quota-live {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+/* 로딩 상태 카드 — Ledger의 상태 카드 문법(ledger-state) 미러. */
+.quota-state {
+  padding: 20px 16px;
+  border: 1px dashed var(--hairline);
+  border-radius: var(--radius-md);
+  text-align: center;
+}
+
+.quota-state > strong {
+  display: block;
+  font-size: 13.5px;
+  font-weight: var(--weight-medium);
+}
+
+.quota-state > p {
+  margin: 6px 0 0;
+  color: var(--text-tertiary);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+.quota-state__mark {
+  display: block;
+  width: 8px;
+  height: 8px;
+  margin: 0 auto 12px;
+  border-radius: var(--radius-pill);
+  background: var(--aurora);
 }
 
 .quota-provider__header h3,
@@ -429,8 +559,7 @@
 }
 
 .quota-error,
-.quota-signed-out,
-.quota-loading {
+.quota-signed-out {
   margin-top: 12px;
   color: var(--text-tertiary);
   font-size: 12.5px;
@@ -471,7 +600,8 @@
 
 @media (prefers-reduced-motion: reduce) {
   .quota-meter__fill,
-  .quota-legend__bubble {
+  .quota-legend__bubble,
+  .quota-card__collapse {
     transition: none;
   }
 }

--- a/runtime/fleet-plugins/quota/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/quota/client/rail-panel.tsx
@@ -439,7 +439,7 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
   const requestGenerationRef = useRef(0);
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const dropLineRef = useRef<HTMLSpanElement | null>(null);
-  const dragRef = useRef<{ id: ProviderId; pointerY: number; raf: number } | null>(null);
+  const dragRef = useRef<{ id: ProviderId; pointerY: number; startY: number; moved: boolean; raf: number } | null>(null);
   // 저장 요청 체인. 연속 이동의 POST가 서로를 추월하면 서버는 도착순으로 기록해
   // 옛 순열이 최종본이 될 수 있다 — 앞 요청이 끝난 뒤에만 다음을 보낸다.
   const orderSaveRef = useRef<Promise<void>>(Promise.resolve());
@@ -503,7 +503,7 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
     dragRef.current = null;
     setDraggingId(null);
     const body = bodyRef.current;
-    if (!commit || !body) return;
+    if (!commit || !body || !drag.moved) return;
     const cards = [...body.querySelectorAll<HTMLElement>("[data-provider]")];
     const domOrder = cards.map((card) => card.dataset.provider).filter(isProviderId);
     const rest = cards.filter((card) => card.dataset.provider !== drag.id);
@@ -527,14 +527,21 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
     const grip = target?.closest(".quota-grip");
     const body = bodyRef.current;
     if (!grip || !body || dragRef.current) return;
+    // 보조 버튼(우클릭·미들클릭)과 비주 포인터는 드래그가 아니다 — 컨텍스트 메뉴를
+    // 여는 동작이 재배열을 저장해 버리면 안 된다.
+    if (event.button !== 0 || !event.isPrimary) return;
     const id = grip.closest<HTMLElement>("[data-provider]")?.dataset.provider;
     if (!isProviderId(id)) return;
     event.preventDefault();
-    const drag = { id, pointerY: event.clientY, raf: 0 };
+    /* moved 전에는 커밋·인디케이터·오토스크롤을 모두 보류한다. 누르는 순간 카드가
+       접히며 눌렀던 좌표가 접힌 레이아웃의 몇 행 아래를 가리키게 되므로, 이동 없이
+       놓았을 때 그 스테일 좌표를 드롭으로 해석하면 의도 없는 재배열이 저장된다. */
+    const drag = { id, pointerY: event.clientY, startY: event.clientY, moved: false, raf: 0 };
     dragRef.current = drag;
     setDraggingId(id);
     const onMove = (moveEvent: PointerEvent) => {
       drag.pointerY = moveEvent.clientY;
+      if (!drag.moved && Math.abs(moveEvent.clientY - drag.startY) > 4) drag.moved = true;
     };
     const detach = () => {
       document.removeEventListener("pointermove", onMove);
@@ -556,11 +563,18 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
        흔들릴 때마다 카드가 밀려 판정 자체가 떨리기 때문에 absolute 오버레이로만 그린다. */
     const tick = () => {
       if (dragRef.current !== drag) return;
+      if (!drag.moved) {
+        const idleLine = dropLineRef.current;
+        if (idleLine) idleLine.style.visibility = "hidden";
+        drag.raf = requestAnimationFrame(tick);
+        return;
+      }
       const bodyRect = body.getBoundingClientRect();
       if (drag.pointerY < bodyRect.top + 48) body.scrollTop -= 9;
       else if (drag.pointerY > bodyRect.bottom - 48) body.scrollTop += 9;
       const line = dropLineRef.current;
       if (line) {
+        line.style.visibility = "visible";
         const rest = [...body.querySelectorAll<HTMLElement>("[data-provider]")]
           .filter((card) => card.dataset.provider !== drag.id);
         let top: number | null = null;

--- a/runtime/fleet-plugins/quota/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/quota/client/rail-panel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
 
 import type { Translate } from "@fleet-console/sdk/i18n";
 import type { RailPanelContext, RailPanelDescriptor } from "@fleet-console/sdk/rail";
@@ -49,6 +50,45 @@ export const NO_SUBSCRIPTION_KEY: Readonly<Record<ProviderId, QuotaMessageKey>> 
 
 function isConnectable(id: ProviderId): id is ConnectableProviderId {
   return id === "claude" || id === "cursor";
+}
+
+export const PROVIDER_ORDER_DEFAULT: readonly ProviderId[] = ["claude", "codex", "cursor", "kimi", "opencode"];
+
+function isProviderId(value: unknown): value is ProviderId {
+  return (PROVIDER_ORDER_DEFAULT as readonly unknown[]).includes(value);
+}
+
+/**
+ * 서버가 보낸 순서를 그대로 믿지 않는다: 옛 릴리스의 설정 파일이 모르는 id를 담거나
+ * 새 공급자를 빠뜨릴 수 있다. 모르는 id는 버리고 빠진 id는 기본 순서로 덧붙여
+ * 카드 다섯 장이 전부, 정확히 한 번씩 그려지게 한다. (서버 sanitize의 미러)
+ */
+export function sanitizeProviderOrder(value: unknown): ProviderId[] {
+  const order: ProviderId[] = [];
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      if (isProviderId(entry) && !order.includes(entry)) order.push(entry);
+    }
+  }
+  for (const id of PROVIDER_ORDER_DEFAULT) {
+    if (!order.includes(id)) order.push(id);
+  }
+  return order;
+}
+
+/** 한 칸 이동. 경계 밖이면 null — 호출자가 저장·공지를 건너뛴다. */
+export function movedProviderOrder(
+  order: readonly ProviderId[],
+  id: ProviderId,
+  delta: -1 | 1,
+): ProviderId[] | null {
+  const index = order.indexOf(id);
+  const target = index + delta;
+  if (index < 0 || target < 0 || target >= order.length) return null;
+  const next = [...order];
+  next.splice(index, 1);
+  next.splice(target, 0, id);
+  return next;
 }
 
 interface RequestGeneration {
@@ -287,18 +327,36 @@ function BarLegend({ t }: { readonly t: T }) {
   );
 }
 
+/* 드래그와 키보드 이동이 같은 자리에서 시작한다. 실제 조작은 패널이 위임으로 받고,
+   버튼인 이유는 키보드 포커스가 앉을 실재하는 자리가 필요해서다. */
+function GripButton({ name, t }: { readonly name: string; readonly t: T }) {
+  return (
+    <button type="button" className="quota-grip" aria-label={t("quota.reorder.handle", { provider: name })}>
+      <svg width="8" height="13" viewBox="0 0 8 13" aria-hidden="true">
+        <g fill="currentColor">
+          <circle cx="1.5" cy="1.5" r="1.3" /><circle cx="6.5" cy="1.5" r="1.3" />
+          <circle cx="1.5" cy="6.5" r="1.3" /><circle cx="6.5" cy="6.5" r="1.3" />
+          <circle cx="1.5" cy="11.5" r="1.3" /><circle cx="6.5" cy="11.5" r="1.3" />
+        </g>
+      </svg>
+    </button>
+  );
+}
+
 function ProviderCard({
   id,
   provider,
   now,
   t,
   connect,
+  dragging,
 }: {
   readonly id: ProviderId;
   readonly provider: ProviderDto;
   readonly now: number;
   readonly t: T;
   readonly connect: (provider: ConnectableProviderId, connected: boolean) => void;
+  readonly dragging: boolean;
 }) {
   const name = PROVIDER_NAME[id];
   if (isConnectable(id) && provider.status === "not_connected") {
@@ -306,25 +364,33 @@ function ProviderCard({
     const bodyKey = id === "claude" ? "quota.connect.body" : "quota.connect.body.cursor";
     const actionKey = id === "claude" ? "quota.connect.action" : "quota.connect.action.cursor";
     return (
-      <section className="quota-connect-card">
-        <h3>
+      <section className={`quota-connect-card${dragging ? " quota-card--dragging" : ""}`} data-provider={id}>
+        <header className="quota-provider__header">
+          <GripButton name={name} t={t} />
           <span className={`quota-provider__mark quota-provider__mark--${id}`}>{providerGlyph(id)}</span>
-          {t(titleKey)}
-        </h3>
-        <p>{t(bodyKey)}</p>
-        {provider.method === "keychain" ? <p className="quota-connect-card__hint">{t("quota.connect.keychain")}</p> : null}
-        <button type="button" className="quota-button quota-button--primary" onClick={() => connect(id, true)}>{t(actionKey)}</button>
+          <h3>{t(titleKey)}</h3>
+        </header>
+        <div className="quota-card__collapse">
+          <div className="quota-card__rest">
+            <p>{t(bodyKey)}</p>
+            {provider.method === "keychain" ? <p className="quota-connect-card__hint">{t("quota.connect.keychain")}</p> : null}
+            <button type="button" className="quota-button quota-button--primary" onClick={() => connect(id, true)}>{t(actionKey)}</button>
+          </div>
+        </div>
       </section>
     );
   }
   return (
-    <section className="quota-provider" data-provider={id}>
+    <section className={`quota-provider${dragging ? " quota-card--dragging" : ""}`} data-provider={id}>
       <header className="quota-provider__header">
+        <GripButton name={name} t={t} />
         <span className={`quota-provider__mark quota-provider__mark--${id}`}>{providerGlyph(id)}</span>
         <h3>{name}</h3>
         {isConnectable(id) ? <button type="button" className="quota-disconnect" onClick={() => connect(id, false)}>{t("quota.disconnect.action")}</button> : null}
         {provider.plan ? <span className="quota-plan">{provider.plan}</span> : null}
       </header>
+      <div className="quota-card__collapse">
+      <div className="quota-card__rest">
       {provider.status === "signed_out" ? <div className="quota-signed-out">{t(SIGNED_OUT_KEY[id])}</div> : null}
       {provider.status === "no_subscription" ? <div className="quota-signed-out">{t(NO_SUBSCRIPTION_KEY[id])}</div> : null}
       {provider.status === "expired" ? <StatusStrip kind="expired">{t(EXPIRED_KEY[id])}</StatusStrip> : null}
@@ -351,9 +417,14 @@ function ProviderCard({
           {provider.credits.nextExpiresAt !== undefined ? <small>{t("quota.credits.expiry", { t: formatCountdown(provider.credits.nextExpiresAt, now) })}</small> : null}
         </div>
       ) : null}
+      </div>
+      </div>
     </section>
   );
 }
+
+/** summary 계열 응답은 코어 DTO에 플러그인 소유의 저장 순서를 얹어 온다. */
+type SummaryResponse = QuotaSummaryDto & { readonly providerOrder?: unknown };
 
 function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
   const t = useMemo(() => getT(ctx.language), [ctx.language]);
@@ -361,8 +432,14 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
   const [requestError, setRequestError] = useState(false);
   const [now, setNow] = useState(Date.now());
   const [refreshNonce, setRefreshNonce] = useState(0);
+  const [order, setOrder] = useState<readonly ProviderId[]>(PROVIDER_ORDER_DEFAULT);
+  const [draggingId, setDraggingId] = useState<ProviderId | null>(null);
+  const [announcement, setAnnouncement] = useState("");
   const forceRef = useRef(false);
   const requestGenerationRef = useRef(0);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const dropLineRef = useRef<HTMLSpanElement | null>(null);
+  const dragRef = useRef<{ id: ProviderId; pointerY: number; raf: number } | null>(null);
 
   const refresh = useCallback((forceRequest = false) => {
     forceRef.current = forceRequest;
@@ -379,11 +456,12 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
     })
       .then((response) => {
         if (!response.ok) throw new Error("connect_failed");
-        return response.json() as Promise<QuotaSummaryDto>;
+        return response.json() as Promise<SummaryResponse>;
       })
       .then((result) => {
         if (isLatestRequestGeneration(requestGenerationRef, generation)) {
           setData(result);
+          setOrder(sanitizeProviderOrder(result.providerOrder));
           setRequestError(false);
           setNow(Date.now());
         }
@@ -393,6 +471,121 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
       });
   }, [ctx.api]);
 
+  const persistOrder = useCallback((next: readonly ProviderId[], movedId: ProviderId) => {
+    setOrder(next);
+    setAnnouncement(t("quota.reorder.moved", { provider: PROVIDER_NAME[movedId], n: next.indexOf(movedId) + 1 }));
+    ctx.api.fetch("quota", "order", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ order: next }),
+    })
+      .then((response) => {
+        if (!response.ok) throw new Error("order_failed");
+      })
+      .catch(() => {
+        // 낙관 반영을 손으로 되돌리지 않는다 — summary가 실어 오는 서버 진실로 재동기화한다.
+        setAnnouncement(t("quota.reorder.error"));
+        refresh(false);
+      });
+  }, [ctx.api, t, refresh]);
+
+  /* 드롭 판정은 상태가 아니라 DOM에서 읽는다. 카드가 order 상태를 그대로 그리는 동안은
+     둘이 같지만, 드래그 중 도착한 connect 응답이 순서를 바꿔도 화면에 보이던 그대로가
+     판정 기준으로 남는다. */
+  const endDrag = useCallback((commit: boolean) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    cancelAnimationFrame(drag.raf);
+    dragRef.current = null;
+    setDraggingId(null);
+    const body = bodyRef.current;
+    if (!commit || !body) return;
+    const cards = [...body.querySelectorAll<HTMLElement>("[data-provider]")];
+    const domOrder = cards.map((card) => card.dataset.provider).filter(isProviderId);
+    const rest = cards.filter((card) => card.dataset.provider !== drag.id);
+    let index = rest.length;
+    for (const [position, card] of rest.entries()) {
+      const rect = card.getBoundingClientRect();
+      if (drag.pointerY < rect.top + rect.height / 2) {
+        index = position;
+        break;
+      }
+    }
+    const restIds = rest.map((card) => card.dataset.provider).filter(isProviderId);
+    const next = [...restIds.slice(0, index), drag.id, ...restIds.slice(index)];
+    if (next.some((id, position) => id !== domOrder[position])) persistOrder(next, drag.id);
+  }, [persistOrder]);
+
+  const onBodyPointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const target = event.target instanceof HTMLElement ? event.target : null;
+    const grip = target?.closest(".quota-grip");
+    const body = bodyRef.current;
+    if (!grip || !body || dragRef.current) return;
+    const id = grip.closest<HTMLElement>("[data-provider]")?.dataset.provider;
+    if (!isProviderId(id)) return;
+    event.preventDefault();
+    const drag = { id, pointerY: event.clientY, raf: 0 };
+    dragRef.current = drag;
+    setDraggingId(id);
+    const onMove = (moveEvent: PointerEvent) => {
+      drag.pointerY = moveEvent.clientY;
+    };
+    const detach = () => {
+      document.removeEventListener("pointermove", onMove);
+      document.removeEventListener("pointerup", onDrop);
+      document.removeEventListener("pointercancel", onCancel);
+    };
+    const onDrop = () => {
+      detach();
+      endDrag(true);
+    };
+    const onCancel = () => {
+      detach();
+      endDrag(false);
+    };
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", onDrop);
+    document.addEventListener("pointercancel", onCancel);
+    /* 인디케이터는 매 프레임 DOM 좌표로 다시 놓는다. 레이아웃에 참여시키면 삽입 지점이
+       흔들릴 때마다 카드가 밀려 판정 자체가 떨리기 때문에 absolute 오버레이로만 그린다. */
+    const tick = () => {
+      if (dragRef.current !== drag) return;
+      const bodyRect = body.getBoundingClientRect();
+      if (drag.pointerY < bodyRect.top + 48) body.scrollTop -= 9;
+      else if (drag.pointerY > bodyRect.bottom - 48) body.scrollTop += 9;
+      const line = dropLineRef.current;
+      if (line) {
+        const rest = [...body.querySelectorAll<HTMLElement>("[data-provider]")]
+          .filter((card) => card.dataset.provider !== drag.id);
+        let top: number | null = null;
+        for (const card of rest) {
+          const rect = card.getBoundingClientRect();
+          if (drag.pointerY < rect.top + rect.height / 2) {
+            top = card.offsetTop - 8;
+            break;
+          }
+        }
+        if (top === null) {
+          const last = rest[rest.length - 1];
+          top = last ? last.offsetTop + last.offsetHeight + 6 : 0;
+        }
+        line.style.top = `${top}px`;
+      }
+      drag.raf = requestAnimationFrame(tick);
+    };
+    drag.raf = requestAnimationFrame(tick);
+  }, [endDrag]);
+
+  const onBodyKeyDown = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
+    const target = event.target instanceof HTMLElement ? event.target : null;
+    const id = target?.closest(".quota-grip")?.closest<HTMLElement>("[data-provider]")?.dataset.provider;
+    if (!isProviderId(id)) return;
+    event.preventDefault();
+    const next = movedProviderOrder(order, id, event.key === "ArrowUp" ? -1 : 1);
+    if (next) persistOrder(next, id);
+  }, [order, persistOrder]);
+
   useEffect(() => {
     const generation = beginRequestGeneration(requestGenerationRef);
     if (isLatestRequestGeneration(requestGenerationRef, generation)) setRequestError(false);
@@ -401,11 +594,12 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
     ctx.api.fetch("quota", force ? "summary?force=1" : "summary")
       .then((response) => {
         if (!response.ok) throw new Error("summary_failed");
-        return response.json() as Promise<QuotaSummaryDto>;
+        return response.json() as Promise<SummaryResponse>;
       })
       .then((result) => {
         if (isLatestRequestGeneration(requestGenerationRef, generation)) {
           setData(result);
+          setOrder(sanitizeProviderOrder(result.providerOrder));
           setRequestError(false);
           setNow(Date.now());
         }
@@ -445,21 +639,36 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
   const updatedMinutes = Math.max(0, Math.floor((now - fetchedAt) / 60_000));
   return (
     <div className="quota-root">
-      <div className="quota-body">
+      <div
+        className={`quota-body${draggingId !== null ? " quota-body--compact" : ""}`}
+        ref={bodyRef}
+        onPointerDown={onBodyPointerDown}
+        onKeyDown={onBodyKeyDown}
+      >
         {requestError ? <div className="quota-error">{t("quota.error.summary")}</div> : null}
-        {!data && !requestError ? <div className="quota-loading" aria-live="polite">…</div> : null}
-        {data ? (
-          <>
-            <ProviderCard id="claude" provider={data.providers.claude} now={now} t={t} connect={connect} />
-            <ProviderCard id="codex" provider={data.providers.codex} now={now} t={t} connect={connect} />
-            <ProviderCard id="cursor" provider={data.providers.cursor} now={now} t={t} connect={connect} />
-            <ProviderCard id="kimi" provider={data.providers.kimi} now={now} t={t} connect={connect} />
-            <ProviderCard id="opencode" provider={data.providers.opencode} now={now} t={t} connect={connect} />
-          </>
+        {!data && !requestError ? (
+          <div className="quota-state" role="status">
+            <span className="quota-state__mark" aria-hidden="true" />
+            <strong>{t("quota.loading.title")}</strong>
+            <p>{t("quota.loading.body")}</p>
+          </div>
         ) : null}
+        {data ? order.map((id) => (
+          <ProviderCard
+            key={id}
+            id={id}
+            provider={data.providers[id]}
+            now={now}
+            t={t}
+            connect={connect}
+            dragging={draggingId === id}
+          />
+        )) : null}
+        {draggingId !== null ? <span className="quota-drop-line" ref={dropLineRef} aria-hidden="true" /> : null}
       </div>
       <footer className="quota-footer">
         <div className="quota-footer__row">
+          <span className="quota-live" aria-live="polite">{announcement}</span>
           {fetchedAt > 0 ? <span>{updatedMinutes < 1 ? t("quota.updated.now") : t("quota.updated.ago", { m: updatedMinutes })}</span> : null}
           <BarLegend t={t} />
           <button type="button" className="quota-refresh" onClick={() => refresh(true)}>{t("quota.refresh")}</button>

--- a/runtime/fleet-plugins/quota/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/quota/client/rail-panel.tsx
@@ -440,6 +440,9 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const dropLineRef = useRef<HTMLSpanElement | null>(null);
   const dragRef = useRef<{ id: ProviderId; pointerY: number; raf: number } | null>(null);
+  // 저장 요청 체인. 연속 이동의 POST가 서로를 추월하면 서버는 도착순으로 기록해
+  // 옛 순열이 최종본이 될 수 있다 — 앞 요청이 끝난 뒤에만 다음을 보낸다.
+  const orderSaveRef = useRef<Promise<void>>(Promise.resolve());
 
   const refresh = useCallback((forceRequest = false) => {
     forceRef.current = forceRequest;
@@ -474,7 +477,7 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
   const persistOrder = useCallback((next: readonly ProviderId[], movedId: ProviderId) => {
     setOrder(next);
     setAnnouncement(t("quota.reorder.moved", { provider: PROVIDER_NAME[movedId], n: next.indexOf(movedId) + 1 }));
-    ctx.api.fetch("quota", "order", {
+    const save = () => ctx.api.fetch("quota", "order", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ order: next }),
@@ -487,6 +490,7 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
         setAnnouncement(t("quota.reorder.error"));
         refresh(false);
       });
+    orderSaveRef.current = orderSaveRef.current.then(save, save);
   }, [ctx.api, t, refresh]);
 
   /* 드롭 판정은 상태가 아니라 DOM에서 읽는다. 카드가 order 상태를 그대로 그리는 동안은
@@ -517,7 +521,9 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
   }, [persistOrder]);
 
   const onBodyPointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    const target = event.target instanceof HTMLElement ? event.target : null;
+    // 그립을 누르면 타깃은 대개 내부 <svg>/<circle>(SVGElement)다 — Element로 받아야
+    // 보이는 글리프 자체에서 드래그가 시작된다.
+    const target = event.target instanceof Element ? event.target : null;
     const grip = target?.closest(".quota-grip");
     const body = bodyRef.current;
     if (!grip || !body || dragRef.current) return;
@@ -578,7 +584,7 @@ function QuotaPanel({ ctx }: { readonly ctx: RailPanelContext }) {
 
   const onBodyKeyDown = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
     if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
-    const target = event.target instanceof HTMLElement ? event.target : null;
+    const target = event.target instanceof Element ? event.target : null;
     const id = target?.closest(".quota-grip")?.closest<HTMLElement>("[data-provider]")?.dataset.provider;
     if (!isProviderId(id)) return;
     event.preventDefault();

--- a/runtime/fleet-plugins/quota/routes.ts
+++ b/runtime/fleet-plugins/quota/routes.ts
@@ -5,7 +5,7 @@ import {
 } from "@dotobokuri/core-ai-gateway";
 import { createAuthService, DEFAULT_AUTH_PATH } from "@dotobokuri/core-infra";
 
-import { handleConnect, handleSummary } from "./server/handlers.js";
+import { handleConnect, handleOrder, handleSummary } from "./server/handlers.js";
 
 export default definePlugin({
   id: "quota",
@@ -39,5 +39,9 @@ export default definePlugin({
       await handleConnect(req, res, ctx, service, serializeSettings);
       return true;
     }, { method: "POST", path: "", summary: "Update provider quota connection state.", category: "Quota Plugin", gate: "origin-write", transport: "http" });
+    registerRouter(ctx, "order", async ({ req, res }) => {
+      await handleOrder(req, res, ctx, serializeSettings);
+      return true;
+    }, { method: "POST", path: "", summary: "Persist the provider card order.", category: "Quota Plugin", gate: "origin-write", transport: "http" });
   },
 });

--- a/runtime/fleet-plugins/quota/server/handlers.ts
+++ b/runtime/fleet-plugins/quota/server/handlers.ts
@@ -5,6 +5,53 @@ import type { QuotaService } from "@dotobokuri/core-ai-gateway";
 
 export type SettingsSerializer = <T>(operation: () => Promise<T>) => Promise<T>;
 
+export const PROVIDER_ORDER_DEFAULT = ["claude", "codex", "cursor", "kimi", "opencode"] as const;
+export type OrderableProviderId = (typeof PROVIDER_ORDER_DEFAULT)[number];
+
+function isOrderableProviderId(value: unknown): value is OrderableProviderId {
+  return (PROVIDER_ORDER_DEFAULT as readonly unknown[]).includes(value);
+}
+
+/**
+ * 저장된 순서는 릴리스 경계를 넘는다: 공급자가 추가·제거된 뒤에도 옛 설정이 남는다.
+ * 읽기 쪽에서 모르는 id를 버리고 빠진 id를 기본 순서로 덧붙여야, 어떤 설정 파일이
+ * 남아 있어도 카드 다섯 장이 전부 그리고 정확히 한 번씩 그려진다.
+ */
+export function sanitizeProviderOrder(value: unknown): OrderableProviderId[] {
+  const order: OrderableProviderId[] = [];
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      if (isOrderableProviderId(entry) && !order.includes(entry)) order.push(entry);
+    }
+  }
+  for (const id of PROVIDER_ORDER_DEFAULT) {
+    if (!order.includes(id)) order.push(id);
+  }
+  return order;
+}
+
+interface StoredSettings {
+  readonly claudeConnected?: unknown;
+  readonly cursorConnected?: unknown;
+  readonly providerOrder?: unknown;
+}
+
+async function readStoredSettings(ctx: FleetPluginServerContext): Promise<StoredSettings> {
+  const stored = await ctx.host.storage.readJson("quota", "settings");
+  return stored !== null && typeof stored === "object" && !Array.isArray(stored)
+    ? stored as StoredSettings
+    : {};
+}
+
+// connect와 order가 서로의 키를 보존하지 않으면 한쪽 저장이 다른 쪽 설정을 지운다.
+function retainedSettings(settings: StoredSettings): Record<string, unknown> {
+  return {
+    ...(typeof settings.claudeConnected === "boolean" ? { claudeConnected: settings.claudeConnected } : {}),
+    ...(typeof settings.cursorConnected === "boolean" ? { cursorConnected: settings.cursorConnected } : {}),
+    ...(Array.isArray(settings.providerOrder) ? { providerOrder: sanitizeProviderOrder(settings.providerOrder) } : {}),
+  };
+}
+
 export async function handleSummary(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -20,7 +67,9 @@ export async function handleSummary(
     return;
   }
   const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
-  ctx.host.http.writeJson(res, 200, await service.getSummary({ force: url.searchParams.get("force") === "1" }));
+  const summary = await service.getSummary({ force: url.searchParams.get("force") === "1" });
+  const providerOrder = sanitizeProviderOrder((await readStoredSettings(ctx)).providerOrder);
+  ctx.host.http.writeJson(res, 200, { ...summary, providerOrder });
 }
 
 export async function handleConnect(
@@ -62,18 +111,68 @@ export async function handleConnect(
     return;
   }
   await serializeSettings(async () => {
-    const stored = await ctx.host.storage.readJson("quota", "settings");
-    const settings = stored !== null && typeof stored === "object" && !Array.isArray(stored)
-      ? stored as { readonly claudeConnected?: unknown; readonly cursorConnected?: unknown }
-      : {};
     const next = {
-      ...(typeof settings.claudeConnected === "boolean" ? { claudeConnected: settings.claudeConnected } : {}),
-      ...(typeof settings.cursorConnected === "boolean" ? { cursorConnected: settings.cursorConnected } : {}),
+      ...retainedSettings(await readStoredSettings(ctx)),
       ...(body.provider === "claude"
         ? { claudeConnected: body.connected }
         : { cursorConnected: body.connected }),
     };
     await ctx.host.storage.writeJson("quota", "settings", next);
   });
-  ctx.host.http.writeJson(res, 200, await service.getSummary({ forceProvider: body.provider }));
+  const summary = await service.getSummary({ forceProvider: body.provider });
+  const providerOrder = sanitizeProviderOrder((await readStoredSettings(ctx)).providerOrder);
+  ctx.host.http.writeJson(res, 200, { ...summary, providerOrder });
+}
+
+export async function handleOrder(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  ctx: FleetPluginServerContext,
+  serializeSettings: SettingsSerializer,
+): Promise<void> {
+  if (req.method !== "POST") {
+    ctx.host.http.writeJson(res, 405, { error: "method_not_allowed" });
+    return;
+  }
+  if (!ctx.host.security.isTerminalAuthorized(req)) {
+    ctx.host.http.writeJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  const contentType = req.headers["content-type"];
+  const mediaType = typeof contentType === "string"
+    ? contentType.split(";", 1)[0]?.trim().toLowerCase()
+    : undefined;
+  if (mediaType !== "application/json") {
+    ctx.host.http.writeJson(res, 415, { error: "unsupported_media_type" });
+    return;
+  }
+  let body: { readonly order?: unknown } | null;
+  try {
+    body = await ctx.host.http.readJsonBody(req);
+  } catch {
+    body = null;
+  }
+  // 클라이언트는 항상 다섯 id의 완전한 순열을 보낸다. 그보다 느슨한 입력은 버그의
+  // 증거이므로 관용하지 않는다 — 미래 호환의 관용은 읽기 쪽 sanitize가 담당한다.
+  const order = body?.order;
+  if (
+    !body
+    || Object.keys(body).length !== 1
+    || !Array.isArray(order)
+    || order.length !== PROVIDER_ORDER_DEFAULT.length
+    || !order.every(isOrderableProviderId)
+    || new Set(order).size !== order.length
+  ) {
+    ctx.host.http.writeJson(res, 400, { error: "invalid_order_request" });
+    return;
+  }
+  const providerOrder = order as OrderableProviderId[];
+  await serializeSettings(async () => {
+    const next = {
+      ...retainedSettings(await readStoredSettings(ctx)),
+      providerOrder,
+    };
+    await ctx.host.storage.writeJson("quota", "settings", next);
+  });
+  ctx.host.http.writeJson(res, 200, { providerOrder });
 }

--- a/runtime/fleet-plugins/quota/tests/handlers.test.ts
+++ b/runtime/fleet-plugins/quota/tests/handlers.test.ts
@@ -4,7 +4,7 @@ import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 import type { QuotaService } from "@dotobokuri/core-ai-gateway";
 import { describe, expect, it, vi } from "vitest";
 
-import { handleConnect, handleSummary } from "../server/handlers.js";
+import { handleConnect, handleOrder, handleSummary } from "../server/handlers.js";
 import type { SettingsSerializer } from "../server/handlers.js";
 
 function createSerializer(): SettingsSerializer {
@@ -24,7 +24,7 @@ function harness(
 ) {
   const writes: Array<{ status: number; payload: unknown }> = [];
   const writeJson = vi.fn(async () => {});
-  const readJson = vi.fn(async () => ({ claudeConnected: true, cursorConnected: false }));
+  const readJson = vi.fn(async (): Promise<Record<string, unknown>> => ({ claudeConnected: true, cursorConnected: false }));
   const ctx = {
     host: {
       security: { isTerminalAuthorized: () => true },
@@ -178,6 +178,54 @@ describe("quota route handlers", () => {
     const wrongMethod = harness("POST");
     await handleSummary(wrongMethod.req, wrongMethod.res, wrongMethod.ctx, wrongMethod.service);
     expect(wrongMethod.writes[0]?.status).toBe(405);
+  });
+
+  it("appends the stored provider order to summary responses after sanitizing it", async () => {
+    const test = harness("GET", "/plugins/quota/summary");
+    test.readJson.mockResolvedValue({ providerOrder: ["opencode", "bogus", "claude", "opencode"] });
+    await handleSummary(test.req, test.res, test.ctx, test.service);
+    expect((test.writes[0]?.payload as { providerOrder: unknown }).providerOrder)
+      .toEqual(["opencode", "claude", "codex", "cursor", "kimi"]);
+  });
+
+  it("persists a full provider order while preserving connection flags", async () => {
+    const order = ["opencode", "kimi", "cursor", "codex", "claude"];
+    const test = harness("POST", "/plugins/quota/order", { order });
+    await handleOrder(test.req, test.res, test.ctx, test.serializeSettings);
+    expect(test.writeJson).toHaveBeenCalledWith("quota", "settings", {
+      claudeConnected: true,
+      cursorConnected: false,
+      providerOrder: order,
+    });
+    expect(test.writes).toEqual([{ status: 200, payload: { providerOrder: order } }]);
+  });
+
+  it("rejects partial, duplicated, unknown, or non-array provider orders", async () => {
+    const invalid: unknown[] = [
+      ["claude", "codex", "cursor", "kimi"],
+      ["claude", "claude", "codex", "cursor", "kimi"],
+      ["claude", "codex", "cursor", "kimi", "bogus"],
+      "claude",
+    ];
+    for (const order of invalid) {
+      const test = harness("POST", "/plugins/quota/order", { order });
+      await handleOrder(test.req, test.res, test.ctx, test.serializeSettings);
+      expect(test.writes, JSON.stringify(order)).toEqual([{ status: 400, payload: { error: "invalid_order_request" } }]);
+      expect(test.writeJson, JSON.stringify(order)).not.toHaveBeenCalled();
+    }
+  });
+
+  it("keeps a stored provider order when a connection flag changes", async () => {
+    const test = harness("POST", "/plugins/quota/connect", { provider: "claude", connected: true });
+    test.readJson.mockResolvedValue({
+      claudeConnected: false,
+      providerOrder: ["kimi", "claude", "codex", "cursor", "opencode"],
+    });
+    await handleConnect(test.req, test.res, test.ctx, test.service, test.serializeSettings);
+    expect(test.writeJson).toHaveBeenCalledWith("quota", "settings", {
+      claudeConnected: true,
+      providerOrder: ["kimi", "claude", "codex", "cursor", "opencode"],
+    });
   });
 
   it("requires the exact JSON media type while accepting parameters", async () => {

--- a/runtime/fleet-plugins/quota/tests/rail-panel.test.ts
+++ b/runtime/fleet-plugins/quota/tests/rail-panel.test.ts
@@ -10,9 +10,12 @@ import {
   formatPace,
   isLatestRequestGeneration,
   meterSeverity,
+  movedProviderOrder,
   NO_SUBSCRIPTION_KEY,
   projectedSpan,
+  PROVIDER_ORDER_DEFAULT,
   riskNote,
+  sanitizeProviderOrder,
   SIGNED_OUT_KEY,
 } from "../client/rail-panel.js";
 import { QUOTA_MESSAGES } from "../client/i18n/messages.js";
@@ -138,5 +141,25 @@ describe("provider status copy", () => {
     expect(en[NO_SUBSCRIPTION_KEY.kimi]).toContain("Kimi");
     expect(en[NO_SUBSCRIPTION_KEY.kimi]).not.toContain("Cursor");
     expect(en[NO_SUBSCRIPTION_KEY.cursor]).toContain("Cursor");
+  });
+});
+
+describe("provider order", () => {
+  // 옛 릴리스의 설정 파일이 살아남는다: 모르는 id를 담거나 그 사이 추가된 공급자를
+  // 빠뜨린 순서라도 카드 다섯 장이 전부, 정확히 한 번씩 그려져야 한다.
+  it("drops unknown ids, dedupes, and appends missing providers in default order", () => {
+    expect(sanitizeProviderOrder(["opencode", "bogus", "claude", "opencode"]))
+      .toEqual(["opencode", "claude", "codex", "cursor", "kimi"]);
+    expect(sanitizeProviderOrder(undefined)).toEqual([...PROVIDER_ORDER_DEFAULT]);
+    expect(sanitizeProviderOrder("claude")).toEqual([...PROVIDER_ORDER_DEFAULT]);
+  });
+
+  it("moves a provider one step and refuses to cross the list boundary", () => {
+    expect(movedProviderOrder(PROVIDER_ORDER_DEFAULT, "cursor", -1))
+      .toEqual(["claude", "cursor", "codex", "kimi", "opencode"]);
+    expect(movedProviderOrder(PROVIDER_ORDER_DEFAULT, "cursor", 1))
+      .toEqual(["claude", "codex", "kimi", "cursor", "opencode"]);
+    expect(movedProviderOrder(PROVIDER_ORDER_DEFAULT, "claude", -1)).toBeNull();
+    expect(movedProviderOrder(PROVIDER_ORDER_DEFAULT, "opencode", 1)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- 사용 한도(quota) 패널의 공급자 카드를 그립(⠿)으로 드래그해 재배열할 수 있습니다. 그립을 잡는 순간 카드 5장이 한 줄 행으로 접혀 모든 드롭 타깃이 한 화면에 들어오고, 놓으면 원래 밀도로 복귀합니다. 드롭 인디케이터·그립 hover/focus는 brass 채널만 사용합니다.
- 순서는 quota 설정(`providerOrder`)에 영속화되며, connect/order 핸들러가 서로의 설정 키를 보존합니다. 읽기 쪽 sanitize가 모르는 id 제거·누락 id 기본순 append를 보장해 공급자 증감 릴리스에도 안전합니다.
- 접근성: 그립은 포커스 가능한 버튼으로 ↑/↓ 키 이동을 지원하고, 이동 결과를 aria-live로 공지합니다. 접힘 전환은 `prefers-reduced-motion`에서 단락됩니다.
- 로딩 상태를 기존 "…" 텍스트에서 Ledger 상태 카드 문법을 미러한 카드(도트+제목+본문, i18n en/ko)로 교체했습니다.

## Test Plan
- [x] `pnpm --filter @fleet-plugins/quota typecheck` / `vitest run` (25 tests) green
- [x] `pnpm --filter @dotobokuri/fleet-console build` + `typecheck` (tsc exit 0)
- [x] 격리 콘솔 실브라우저 QA: 드래그 재배열(접힘·드롭라인·낙관 반영), 리로드 후 순서 복원, 디스크 `settings.json`에 `providerOrder` 영속화 확인
- [x] 키보드 ↑/↓ 이동 + aria-live 공지 + 포커스 유지 실측
- [x] 지연 주입으로 로딩 상태 카드 렌더링 실측 (ko 로케일)