### PR TITLE
fix(quota): accept the six-card provider order after Grok

### DIFF
--- a/runtime/fleet-plugins/quota/client/quota.css
+++ b/runtime/fleet-plugins/quota/client/quota.css
@@ -164,7 +164,7 @@
 
 /* ── 공급자 재배열 ─────────────────────────────
    그립을 잡는 순간 전 카드가 헤더 한 줄로 접혀(quota-body--compact) 드롭 타깃
-   다섯 개가 모두 한 화면에 들어온다. 놓으면 원래 밀도로 복귀한다. */
+   전부가 한 화면에 들어온다. 놓으면 원래 밀도로 복귀한다. */
 .quota-grip {
   display: grid;
   place-items: center;
@@ -202,7 +202,7 @@
 }
 
 /* 접힘은 grid-template-rows 1fr→0fr 전환으로 만든다 — 높이 애니메이션 없이
-   내용 높이가 제각각인 카드 다섯 장을 같은 문법으로 접는다. */
+   내용 높이가 제각각인 카드를 같은 문법으로 접는다. */
 .quota-card__collapse {
   display: grid;
   grid-template-rows: 1fr;

--- a/runtime/fleet-plugins/quota/client/rail-panel.tsx
+++ b/runtime/fleet-plugins/quota/client/rail-panel.tsx
@@ -5,12 +5,20 @@ import type { Translate } from "@fleet-console/sdk/i18n";
 import type { RailPanelContext, RailPanelDescriptor } from "@fleet-console/sdk/rail";
 
 import type { ProviderDto, QuotaSummaryDto, QuotaWindow } from "@dotobokuri/core-ai-gateway";
+import {
+  isProviderId,
+  PROVIDER_ORDER_DEFAULT,
+  sanitizeProviderOrder,
+  type ProviderId,
+} from "../provider-order.js";
 import { providerGlyph } from "./cli-glyphs.js";
 import { getT, type QuotaMessageKey } from "./i18n/index.js";
 import "./quota.css";
 
+export { PROVIDER_ORDER_DEFAULT, sanitizeProviderOrder };
+export type { ProviderId };
+
 type T = Translate<QuotaMessageKey>;
-type ProviderId = "claude" | "codex" | "cursor" | "kimi" | "opencode" | "xai";
 /** Providers whose credential read is gated behind an explicit connect. */
 type ConnectableProviderId = "claude" | "cursor";
 
@@ -54,30 +62,6 @@ export const NO_SUBSCRIPTION_KEY: Readonly<Record<ProviderId, QuotaMessageKey>> 
 
 function isConnectable(id: ProviderId): id is ConnectableProviderId {
   return id === "claude" || id === "cursor";
-}
-
-export const PROVIDER_ORDER_DEFAULT: readonly ProviderId[] = ["claude", "codex", "xai", "cursor", "opencode", "kimi"];
-
-function isProviderId(value: unknown): value is ProviderId {
-  return (PROVIDER_ORDER_DEFAULT as readonly unknown[]).includes(value);
-}
-
-/**
- * 서버가 보낸 순서를 그대로 믿지 않는다: 옛 릴리스의 설정 파일이 모르는 id를 담거나
- * 새 공급자를 빠뜨릴 수 있다. 모르는 id는 버리고 빠진 id는 기본 순서로 덧붙여
- * 카드 다섯 장이 전부, 정확히 한 번씩 그려지게 한다. (서버 sanitize의 미러)
- */
-export function sanitizeProviderOrder(value: unknown): ProviderId[] {
-  const order: ProviderId[] = [];
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      if (isProviderId(entry) && !order.includes(entry)) order.push(entry);
-    }
-  }
-  for (const id of PROVIDER_ORDER_DEFAULT) {
-    if (!order.includes(id)) order.push(id);
-  }
-  return order;
 }
 
 /** 한 칸 이동. 경계 밖이면 null — 호출자가 저장·공지를 건너뛴다. */

--- a/runtime/fleet-plugins/quota/provider-order.ts
+++ b/runtime/fleet-plugins/quota/provider-order.ts
@@ -1,0 +1,24 @@
+export const PROVIDER_ORDER_DEFAULT = ["claude", "codex", "xai", "cursor", "opencode", "kimi"] as const;
+export type ProviderId = (typeof PROVIDER_ORDER_DEFAULT)[number];
+
+export function isProviderId(value: unknown): value is ProviderId {
+  return (PROVIDER_ORDER_DEFAULT as readonly unknown[]).includes(value);
+}
+
+/**
+ * 저장된 순서는 릴리스 경계를 넘는다: 공급자가 추가·제거된 뒤에도 옛 설정이 남는다.
+ * 읽기 쪽에서 모르는 id를 버리고 빠진 id를 기본 순서로 덧붙여야, 어떤 설정 파일이
+ * 남아 있어도 카드가 전부 그리고 정확히 한 번씩 그려진다.
+ */
+export function sanitizeProviderOrder(value: unknown): ProviderId[] {
+  const order: ProviderId[] = [];
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      if (isProviderId(entry) && !order.includes(entry)) order.push(entry);
+    }
+  }
+  for (const id of PROVIDER_ORDER_DEFAULT) {
+    if (!order.includes(id)) order.push(id);
+  }
+  return order;
+}

--- a/runtime/fleet-plugins/quota/server/handlers.ts
+++ b/runtime/fleet-plugins/quota/server/handlers.ts
@@ -3,32 +3,16 @@ import type http from "node:http";
 import type { FleetPluginServerContext } from "@fleet-console/sdk/plugin";
 import type { QuotaService } from "@dotobokuri/core-ai-gateway";
 
+import {
+  isProviderId,
+  PROVIDER_ORDER_DEFAULT,
+  sanitizeProviderOrder,
+  type ProviderId,
+} from "../provider-order.js";
+
 export type SettingsSerializer = <T>(operation: () => Promise<T>) => Promise<T>;
-
-export const PROVIDER_ORDER_DEFAULT = ["claude", "codex", "cursor", "kimi", "opencode"] as const;
-export type OrderableProviderId = (typeof PROVIDER_ORDER_DEFAULT)[number];
-
-function isOrderableProviderId(value: unknown): value is OrderableProviderId {
-  return (PROVIDER_ORDER_DEFAULT as readonly unknown[]).includes(value);
-}
-
-/**
- * 저장된 순서는 릴리스 경계를 넘는다: 공급자가 추가·제거된 뒤에도 옛 설정이 남는다.
- * 읽기 쪽에서 모르는 id를 버리고 빠진 id를 기본 순서로 덧붙여야, 어떤 설정 파일이
- * 남아 있어도 카드 다섯 장이 전부 그리고 정확히 한 번씩 그려진다.
- */
-export function sanitizeProviderOrder(value: unknown): OrderableProviderId[] {
-  const order: OrderableProviderId[] = [];
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      if (isOrderableProviderId(entry) && !order.includes(entry)) order.push(entry);
-    }
-  }
-  for (const id of PROVIDER_ORDER_DEFAULT) {
-    if (!order.includes(id)) order.push(id);
-  }
-  return order;
-}
+export { PROVIDER_ORDER_DEFAULT, sanitizeProviderOrder };
+export type { ProviderId as OrderableProviderId };
 
 interface StoredSettings {
   readonly claudeConnected?: unknown;
@@ -152,21 +136,21 @@ export async function handleOrder(
   } catch {
     body = null;
   }
-  // 클라이언트는 항상 다섯 id의 완전한 순열을 보낸다. 그보다 느슨한 입력은 버그의
-  // 증거이므로 관용하지 않는다 — 미래 호환의 관용은 읽기 쪽 sanitize가 담당한다.
+  // 클라이언트는 항상 현재 공급자 id의 완전한 순열을 보낸다. 그보다 느슨한 입력은
+  // 버그의 증거이므로 관용하지 않는다 — 미래 호환의 관용은 읽기 쪽 sanitize가 담당한다.
   const order = body?.order;
   if (
     !body
     || Object.keys(body).length !== 1
     || !Array.isArray(order)
     || order.length !== PROVIDER_ORDER_DEFAULT.length
-    || !order.every(isOrderableProviderId)
+    || !order.every(isProviderId)
     || new Set(order).size !== order.length
   ) {
     ctx.host.http.writeJson(res, 400, { error: "invalid_order_request" });
     return;
   }
-  const providerOrder = order as OrderableProviderId[];
+  const providerOrder = order as ProviderId[];
   await serializeSettings(async () => {
     const next = {
       ...retainedSettings(await readStoredSettings(ctx)),

--- a/runtime/fleet-plugins/quota/tests/handlers.test.ts
+++ b/runtime/fleet-plugins/quota/tests/handlers.test.ts
@@ -185,11 +185,25 @@ describe("quota route handlers", () => {
     test.readJson.mockResolvedValue({ providerOrder: ["opencode", "bogus", "claude", "opencode"] });
     await handleSummary(test.req, test.res, test.ctx, test.service);
     expect((test.writes[0]?.payload as { providerOrder: unknown }).providerOrder)
-      .toEqual(["opencode", "claude", "codex", "cursor", "kimi"]);
+      .toEqual(["opencode", "claude", "codex", "xai", "cursor", "kimi"]);
   });
 
   it("persists a full provider order while preserving connection flags", async () => {
-    const order = ["opencode", "kimi", "cursor", "codex", "claude"];
+    const order = ["opencode", "kimi", "cursor", "xai", "codex", "claude"];
+    const test = harness("POST", "/plugins/quota/order", { order });
+    await handleOrder(test.req, test.res, test.ctx, test.serializeSettings);
+    expect(test.writeJson).toHaveBeenCalledWith("quota", "settings", {
+      claudeConnected: true,
+      cursorConnected: false,
+      providerOrder: order,
+    });
+    expect(test.writes).toEqual([{ status: 200, payload: { providerOrder: order } }]);
+  });
+
+  it("accepts the six-card permutation the panel posts after a drag", async () => {
+    // #668이 클라이언트에 xai를 넣었는데 서버는 옛 다섯 장만 받으면 POST /order가
+    // 400으로 거절되고, 패널은 summary로 되돌려 드래그가 적용되지 않은 것처럼 보인다.
+    const order = ["kimi", "claude", "codex", "xai", "cursor", "opencode"];
     const test = harness("POST", "/plugins/quota/order", { order });
     await handleOrder(test.req, test.res, test.ctx, test.serializeSettings);
     expect(test.writeJson).toHaveBeenCalledWith("quota", "settings", {
@@ -202,9 +216,10 @@ describe("quota route handlers", () => {
 
   it("rejects partial, duplicated, unknown, or non-array provider orders", async () => {
     const invalid: unknown[] = [
-      ["claude", "codex", "cursor", "kimi"],
-      ["claude", "claude", "codex", "cursor", "kimi"],
-      ["claude", "codex", "cursor", "kimi", "bogus"],
+      ["claude", "codex", "cursor", "kimi", "opencode"],
+      ["claude", "codex", "xai", "cursor", "kimi"],
+      ["claude", "claude", "codex", "xai", "cursor", "kimi"],
+      ["claude", "codex", "xai", "cursor", "kimi", "bogus"],
       "claude",
     ];
     for (const order of invalid) {
@@ -219,12 +234,12 @@ describe("quota route handlers", () => {
     const test = harness("POST", "/plugins/quota/connect", { provider: "claude", connected: true });
     test.readJson.mockResolvedValue({
       claudeConnected: false,
-      providerOrder: ["kimi", "claude", "codex", "cursor", "opencode"],
+      providerOrder: ["kimi", "claude", "codex", "xai", "cursor", "opencode"],
     });
     await handleConnect(test.req, test.res, test.ctx, test.service, test.serializeSettings);
     expect(test.writeJson).toHaveBeenCalledWith("quota", "settings", {
       claudeConnected: true,
-      providerOrder: ["kimi", "claude", "codex", "cursor", "opencode"],
+      providerOrder: ["kimi", "claude", "codex", "xai", "cursor", "opencode"],
     });
   });
 

--- a/runtime/fleet-plugins/quota/tests/rail-panel.test.ts
+++ b/runtime/fleet-plugins/quota/tests/rail-panel.test.ts
@@ -159,7 +159,7 @@ describe("provider status copy", () => {
 
 describe("provider order", () => {
   // 옛 릴리스의 설정 파일이 살아남는다: 모르는 id를 담거나 그 사이 추가된 공급자를
-  // 빠뜨린 순서라도 카드 다섯 장이 전부, 정확히 한 번씩 그려져야 한다.
+  // 빠뜨린 순서라도 카드가 전부, 정확히 한 번씩 그려져야 한다.
   it("drops unknown ids, dedupes, and appends missing providers in default order", () => {
     expect(sanitizeProviderOrder(["opencode", "bogus", "claude", "opencode"]))
       .toEqual(["opencode", "claude", "codex", "xai", "cursor", "kimi"]);

--- a/runtime/fleet-plugins/quota/tsconfig.json
+++ b/runtime/fleet-plugins/quota/tsconfig.json
@@ -23,5 +23,5 @@
       "react/jsx-runtime": ["../../fleet-console/node_modules/@types/react/jsx-runtime.d.ts"]
     }
   },
-  "include": ["routes.ts", "server/**/*.ts", "client/**/*.ts", "client/**/*.tsx", "tests/**/*.ts", "tests/**/*.tsx"]
+  "include": ["provider-order.ts", "routes.ts", "server/**/*.ts", "client/**/*.ts", "client/**/*.tsx", "tests/**/*.ts", "tests/**/*.tsx"]
 }


### PR DESCRIPTION
## Summary

- Grok CLI (#668) added a sixth quota card (`xai`) on the client, but `POST /order` still required the pre-Grok five-id permutation and rejected every drag or arrow-key reorder.
- The panel then re-synced from summary, so the optimistic reorder snapped back and looked like the drop never applied.
- Share one provider-order list between the panel and the order route so a new card cannot leave the two sides on different contracts.

## Test Plan

- [x] `pnpm --filter @fleet-plugins/quota typecheck`
- [x] `pnpm --filter @fleet-plugins/quota test` (covers the six-card permutation the panel posts after a drag)
- [ ] Drag a quota provider card past another and confirm the new order stays after the drop and after a panel refresh