### PR TITLE
feat(fleet-console): move provider glyph onto the Operation name

### DIFF
--- a/.changelog.d/command-band-op-provider-glyph.md
+++ b/.changelog.d/command-band-op-provider-glyph.md
@@ -1,0 +1,10 @@
+---
+branch: command-band-op-provider-glyph
+---
+
+### fleet-console
+
+#### Changed
+
+- Move the provider glyph onto the Command Band Operation name and drop the trailing model chip. The mark sits to the left of the name the way the sidebar chip already does; which model is running stays in the Operation switcher list.
+  ko: Command Band Operation 이름 왼쪽으로 공급자 글리프를 옮기고, 이름 오른쪽의 모델명 칩은 떼었습니다. 사이드바 칩과 같이 이름 옆에 마크가 붙고, 돌고 있는 모델 이름은 Operation 전환 목록에 남습니다.

--- a/runtime/fleet-console/core/client/src/components/command-band.tsx
+++ b/runtime/fleet-console/core/client/src/components/command-band.tsx
@@ -1,29 +1,25 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type FocusEvent, type ReactElement } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
-import { resolveLocalizedText } from "@fleet-console/sdk/i18n/translate";
 import { fetchOperationCatalog } from "@fleet-console/sdk/operations/browser";
 
 import { fetchConsoleEnvironment, fetchOperations, renameOperation } from "../api.js";
 import { animateViewportTo, clearFormationView, fitAllOperations, selectFormationLayout, setStationKeeping, toggleFormationView, useCanvasState, useFormationLayout, useFormationView, useStationKeeping, type FormationLayout } from "../canvas/canvas-store.js";
 import { enterTriage, focusedTriageOperationId, setTriageActive, setTriageSpotlightEnabled, useTriageActive, useTriageDeckZoomLive, useTriageSpotlightEnabled, visitTriageTheater } from "../canvas/triage-store.js";
 import { cycleTriageDeckZoomPreset } from "../canvas/triage-watch-deck.js";
-import { COMMAND_BAND_RAIL_STRIP_PX, commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandLaunchModelLabels, commandBandMapControlsAnchor, commandBandMenuClampedLeft, commandBandOperationAttribute, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "./command-band-guards.js";
+import { COMMAND_BAND_RAIL_STRIP_PX, commandBandActiveOperation, commandBandCenterFits, commandBandCenterGutter, commandBandLaunchModelLabels, commandBandMapControlsAnchor, commandBandMenuClampedLeft, commandBandRenameCommitTarget, commandBandSwitcherFocusLeft, commandBandTheaterOperations } from "./command-band-guards.js";
 import { CommandBandOperationMenu, CommandBandTheaterMenu, CommandBandTriggerCaret, type CommandBandSwitcherMenu } from "./command-band-switcher.js";
 import { CommandBandSystemCluster } from "./command-band-system-cluster.js";
 import { ViewModeToggle } from "./view-mode-toggle.js";
 import { launchProviderFromOperationPayload, launchProviderGlyph } from "./launch-provider-glyphs.js";
-import { useGlobalSettingsStore } from "../global-settings-store.js";
 import { useConsoleState } from "../hooks/use-store.js";
 import { setRailChromeExpanded, toggleRailChrome, useRailChromeExpanded } from "../rail/rail-store.js";
-import { usePluginRegistry } from "../plugin-registry.js";
 import { theaterInitials } from "../sidebar/operations-side-bar.js";
 import { setSideBarCollapsed, useSideBarState } from "../sidebar/operations-side-bar-store.js";
 import { focusOperation, hydrateOperations, requestSideBarAddTheater, requestSideBarTheaterLaunch, setActiveTheater, toggleOperationSearch } from "../store.js";
 import type { ConsoleEnvironmentDiagnostics } from "../types.js";
 import { useInlineRename } from "../use-inline-rename.js";
 import { useT, type CoreMessageKey } from "../i18n/index.js";
-import { resolveConsoleLanguage } from "../whatsnew-i18n.js";
 import { useViewMode } from "../view-mode-store.js";
 import { useFullscreenCommandBand } from "./use-fullscreen-command-band.js";
 
@@ -72,7 +68,6 @@ const TACTICAL_LAYOUTS: readonly {
 export function CommandBand({ operationsViewVisible: requestedOperationsViewVisible }: CommandBandProps) {
   const t = useT();
   const state = useConsoleState();
-  const registry = usePluginRegistry();
   const sideBar = useSideBarState();
   const railChromeExpanded = useRailChromeExpanded();
   const viewMode = useViewMode();
@@ -128,26 +123,14 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
   };
   const activeTheater = state.theaters.find((theater) => theater.id === state.activeTheaterId) ?? null;
   const activeOperation = commandBandActiveOperation(state.operations, state.activeOperationId, state.activeTheaterId);
-  const activePlugin = activeOperation ? registry.plugins.find((plugin) => plugin.id === activeOperation.pluginId) : null;
-  const activeCliId = typeof activeOperation?.payload.cliId === "string" ? activeOperation.payload.cliId : null;
   const [launchModelLabels, setLaunchModelLabels] = useState(NO_LAUNCH_MODEL_LABELS);
   const activeLaunchModel = typeof activeOperation?.payload.launchModel === "string" ? activeOperation.payload.launchModel : null;
-  // 속성 칩은 CLI 이름이 아니라 실제로 돌고 있는 모델 이름을 말한다(카탈로그가 그 좌표를 알 때).
-  const activeOperationAttribute = activeOperation
-    ? commandBandOperationAttribute(activeOperation.payload, launchModelLabels)
-    : null;
-  const activeKind = activeOperation ? activePlugin?.operationKinds?.find((kind) => kind.type === activeOperation.type) ?? null : null;
-  const globalSettings = useGlobalSettingsStore();
-  const language = resolveConsoleLanguage(globalSettings.state?.language ?? "auto");
-  const activeKindTitle = activeKind ? resolveLocalizedText(activeKind.title, language) : null;
-  // 사이드바 칩과 같은 규율: 실행된 공급자가 기록된 Operation은 그 공급자의 마크가
-  // 플러그인 실행 종류 아이콘을 대신하고, 캐리어 시그니처 톤을 함께 입는다.
+  // 사이드바 칩과 같은 규율: 실행된 공급자가 기록된 Operation은 그 마크를
+  // 이름 왼쪽에 붙인다. 모델 이름은 스위처 메뉴 메타로만 남긴다.
   const activeLaunchProvider = launchProviderFromOperationPayload(activeOperation?.payload);
-  const activeOperationIcon = activeLaunchProvider
-    ? launchProviderGlyph(activeLaunchProvider)
-    : activeOperation && activePlugin?.renderLaunchIcon
-      ? activePlugin.renderLaunchIcon({ id: activeCliId ?? activeOperation.type, type: activeOperation.type, title: activeKindTitle ?? activeOperation.type })
-      : null;
+  const activeOperationProviderMark = activeLaunchProvider
+    ? <span className={`command-band-operation-kind operation-provider-mark is-${activeLaunchProvider}`} aria-hidden="true">{launchProviderGlyph(activeLaunchProvider)}</span>
+    : null;
   const environmentTriggerRef = useRef<HTMLButtonElement>(null);
   const environmentPopoverRef = useRef<HTMLDivElement>(null);
   const commandBandRef = useRef<HTMLElement>(null);
@@ -234,8 +217,8 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
     if (edge !== null && document.activeElement === edge) edge.blur();
   }, [edgeRevealActive]);
 
-  // 모델 이름 색인은 첫 페인트에서 한 번 읽고, 그 뒤로는 색인이 모르는 좌표가 밴드에 올라올 때만
-  // 다시 읽는다(설정에서 모델을 켠 직후 띄운 Operation).
+  // 모델 이름 색인은 첫 페인트에서 한 번 읽고, 그 뒤로는 색인이 모르는 좌표가 스위처 메뉴에
+  // 올라올 때만 다시 읽는다(설정에서 모델을 켠 직후 띄운 Operation).
   //
   // 의존은 활성 좌표 하나다. 해결 여부를 의존에 실으면 조회가 성공해 좌표가 해결되는 순간이 곧
   // 다음 조회의 방아쇠가 되어, 카탈로그가 매번 수행하는 Agent CLI 탐지를 시작마다 두 번 돌린다.
@@ -635,7 +618,10 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
             </button>
             <span className="command-band-theater-separator" aria-hidden="true">›</span>
             {activeOperation ? <>
-              {rename.renaming ? <input ref={rename.inputRef} className="command-band-rename-input" value={rename.draftTitle} aria-label={t("chrome.commandBand.renameOperationAria", { title: activeOperation.title })} onChange={(event) => rename.setDraftTitle(event.target.value)} onKeyDown={rename.handleKeyDown} onBlur={rename.handleBlur} /> : <button
+              {rename.renaming ? <>
+                {activeOperationProviderMark}
+                <input ref={rename.inputRef} className="command-band-rename-input" value={rename.draftTitle} aria-label={t("chrome.commandBand.renameOperationAria", { title: activeOperation.title })} onChange={(event) => rename.setDraftTitle(event.target.value)} onKeyDown={rename.handleKeyDown} onBlur={rename.handleBlur} />
+              </> : <button
                 ref={operationTriggerRef}
                 type="button"
                 className={`command-band-operation-name command-band-segment-trigger${switcherMenu === "operation" ? " is-open" : ""}`}
@@ -645,10 +631,10 @@ export function CommandBand({ operationsViewVisible: requestedOperationsViewVisi
                 onClick={() => toggleSwitcherMenu("operation")}
                 onDoubleClick={beginRename}
               >
+                {activeOperationProviderMark}
                 <span className="command-band-segment-label">{activeOperation.title}</span>
                 <CommandBandTriggerCaret />
               </button>}
-              {activeOperationAttribute ? <span className="command-band-operation-attribute" title={activeKindTitle ?? activeOperationAttribute}>{activeOperationIcon ? <span className={`command-band-operation-kind${activeLaunchProvider ? ` operation-provider-mark is-${activeLaunchProvider}` : ""}`} aria-hidden="true">{activeOperationIcon}</span> : null}{activeOperationAttribute}</span> : null}
             </> : <button
               ref={operationTriggerRef}
               type="button"

--- a/runtime/fleet-console/core/client/src/styles/layout.css
+++ b/runtime/fleet-console/core/client/src/styles/layout.css
@@ -579,20 +579,7 @@ body:has(.operations-side-bar[data-resizing="true"]) .command-band-map-controls 
   font-weight: var(--weight-medium);
 }
 
-.command-band-operation-attribute {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  flex: none;
-  padding: 2px 6px;
-  border-radius: var(--radius-xs);
-  background: color-mix(in oklch, var(--ink-fog) 10%, transparent);
-  color: var(--text-tertiary);
-  font-family: var(--font-mono);
-  font-size: 9.5px;
-}
-
-.command-band-operation-kind { display: flex; align-items: center; line-height: 0; }
+.command-band-operation-kind { display: flex; align-items: center; flex: none; line-height: 0; }
 .command-band-operation-kind svg { display: block; width: 13px; height: 13px; }
 
 /* ===== Command Band 세그먼트 드롭다운 전환기 — 메뉴 문법은 components.css .theater-menu 계열의 밴드 스코프 미러 ===== */

--- a/runtime/fleet-console/tests/command-band-v2-guards.test.ts
+++ b/runtime/fleet-console/tests/command-band-v2-guards.test.ts
@@ -75,6 +75,17 @@ describe("Command Band switcher disclosure", () => {
     expect(caretRule).toContain("opacity: 0.75");
     expect(styles).not.toContain(".command-band-segment-trigger:hover .command-band-trigger-caret");
   });
+
+  it("places the provider glyph on the Operation name and drops the trailing model chip", () => {
+    const source = readFileSync(resolve(process.cwd(), "core/client/src/components/command-band.tsx"), "utf8");
+    const styles = readFileSync(resolve(process.cwd(), "core/client/src/styles/layout.css"), "utf8");
+
+    expect(source).toContain("command-band-operation-kind operation-provider-mark is-${activeLaunchProvider}");
+    expect(source).toContain("{activeOperationProviderMark}");
+    expect(source).not.toContain("command-band-operation-attribute");
+    expect(styles).not.toContain(".command-band-operation-attribute");
+    expect(styles).toContain(".command-band-operation-kind { display: flex; align-items: center; flex: none; line-height: 0; }");
+  });
 });
 
 describe("Command Band switcher focusout close decision", () => {

--- a/runtime/fleet-console/tests/instrument-design-contract.test.ts
+++ b/runtime/fleet-console/tests/instrument-design-contract.test.ts
@@ -1699,8 +1699,10 @@ describe("Instrument core design contract", () => {
     expect(canvas).toContain('glanceVisible ? "is-glance" : ""');
     expect(canvas).toContain('window.addEventListener("blur", clearGlance)');
     expect(canvas).toContain('document.addEventListener("visibilitychange", handleVisibilityChange)');
-    expect(source("styles/layout.css")).toContain(".command-band-operation-kind { display: flex; align-items: center; line-height: 0; }");
-    expect(source("styles/layout.css")).toContain("background: color-mix(in oklch, var(--ink-fog) 10%, transparent);");
+    expect(source("styles/layout.css")).toContain(".command-band-operation-kind { display: flex; align-items: center; flex: none; line-height: 0; }");
+    expect(source("styles/layout.css")).not.toContain(".command-band-operation-attribute");
+    expect(commandBand).not.toContain("command-band-operation-attribute");
+    expect(commandBand).toContain("command-band-operation-kind operation-provider-mark is-${activeLaunchProvider}");
     expect(commandBand).toContain('<rect x="1.75" y="3" width="12.5" height="10" rx="2.4"');
     expect(rail).toContain("width: 44px");
   });


### PR DESCRIPTION
## Summary

- Command Band 중앙 브레드크럼에서 Operation 이름 오른쪽의 공급자 글리프·모델명 칩을 제거합니다.
- 공급자 글리프는 Operation 이름 왼쪽에 붙습니다. 사이드바 칩과 같은 공용 `operation-provider-mark` 톤을 쓰고, 돌고 있는 모델 이름은 Operation 전환 목록 메타에 남깁니다.
- 이름 변경 중에도 글리프는 입력 왼쪽에 그대로 보입니다.

## Test Plan

- [x] `pnpm --filter @dotobokuri/fleet-console exec vitest run tests/command-band-v2-guards.test.ts tests/instrument-design-contract.test.ts tests/command-band-switcher.test.tsx`
- [x] `pnpm --filter @dotobokuri/fleet-console typecheck`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [ ] Operations 화면에서 활성 Operation의 Command Band 이름이 글리프 + 제목만 보이는지 확인
- [ ] Operation 전환 메뉴에서 모델명이 메타로 남아 있는지 확인
- [ ] 더블클릭 이름 변경 중에도 글리프가 입력 왼쪽에 남는지 확인