### PR TITLE
fix(ai-gateway): parse omitted Grok 0% credits and refresh tokens

### DIFF
--- a/packages/core-ai-gateway/src/xai/credentials.ts
+++ b/packages/core-ai-gateway/src/xai/credentials.ts
@@ -94,16 +94,23 @@ async function persistRefreshedEntry(
   deps: CredentialResolverDeps,
   filePath: string,
   entryKey: string,
+  expected: { readonly accessToken: string; readonly refreshToken?: string },
   patch: Record<string, string>,
   writeAuthFile: (filePath: string, contents: string) => Promise<void>,
 ): Promise<void> {
   // Re-read so a concurrent `grok login` / CLI refresh is not replaced by a
-  // reconstructed object that would drop the other profiles' fields.
+  // reconstructed object that would drop the other profiles' fields. Skip the
+  // write when this entry's tokens already moved: Fleet's response may be from
+  // the refresh grant we started with, and overwriting a rotated pair revokes
+  // the file owner's newer session.
   const raw = await deps.readBounded(filePath, MAX_CREDENTIAL_BYTES);
   if (raw === null) return;
   const auth = credentialRecord(JSON.parse(raw));
   if (!auth) return;
-  const current = credentialRecord(auth[entryKey]) ?? {};
+  const current = credentialRecord(auth[entryKey]);
+  if (!current) return;
+  if (optionalTrimmedString(current.key) !== expected.accessToken) return;
+  if (expected.refreshToken !== undefined && refreshToken(current) !== expected.refreshToken) return;
   auth[entryKey] = { ...current, ...patch };
   await writeAuthFile(filePath, `${JSON.stringify(auth, null, 2)}\n`);
 }
@@ -193,7 +200,14 @@ export async function resolveXaiCliAuth(
           };
           if (refreshed.refreshToken !== undefined) patch.refresh_token = refreshed.refreshToken;
           try {
-            await persistRefreshedEntry(deps, filePath, entryKey, patch, writeAuthFile);
+            await persistRefreshedEntry(
+              deps,
+              filePath,
+              entryKey,
+              { accessToken, refreshToken: refreshToken(entry) },
+              patch,
+              writeAuthFile,
+            );
           } catch {
             // In-memory token is still usable this probe; the next read retries persist.
           }

--- a/packages/core-ai-gateway/src/xai/credentials.ts
+++ b/packages/core-ai-gateway/src/xai/credentials.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 
 import {
@@ -7,12 +8,31 @@ import {
   type CredentialResolverDeps,
 } from "../transport/credentials.js";
 
-const XAI_OIDC_ISSUER = "https://auth.x.ai";
+export const XAI_OIDC_ISSUER = "https://auth.x.ai";
+export const XAI_CLI_REFRESH_URL = "https://auth.x.ai/oauth2/token";
+export const XAI_CLI_DEFAULT_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+/** Same 5-minute early-refresh window the Grok CLI and OpenUsage use. */
+export const XAI_CLI_REFRESH_BUFFER_MS = 5 * 60 * 1_000;
+const REFRESH_TIMEOUT_MS = 15_000;
+const FALLBACK_ACCESS_TOKEN_TTL_MS = 3_600_000;
 
 export interface XaiCliCredentials {
   readonly accessToken: string;
   readonly expiresAt?: number;
   readonly userId?: string;
+}
+
+export type XaiCliAuthResult =
+  | { readonly status: "ok"; readonly credentials: XaiCliCredentials }
+  | { readonly status: "signed_out" }
+  | { readonly status: "expired" };
+
+export interface ResolveXaiCliOptions {
+  readonly now?: () => number;
+  readonly fetch?: typeof fetch;
+  readonly writeAuthFile?: (filePath: string, contents: string) => Promise<void>;
+  /** After a 401/403, refresh even if the local clock still thinks the token is good. */
+  readonly forceRefresh?: boolean;
 }
 
 /** The auth file written and refreshed by the official Grok CLI. */
@@ -27,38 +47,198 @@ function expiry(value: unknown): number | undefined {
   return parsed < 1e12 ? Math.round(parsed * 1_000) : Math.round(parsed);
 }
 
-/**
- * Read the credential the Grok CLI owns. Fleet never starts OAuth and never
- * rewrites this vendor-owned file; an expired session is repaired with `grok login`.
- */
-export async function resolveXaiCliCredentials(
-  deps: CredentialResolverDeps,
-  now: () => number = Date.now,
-): Promise<XaiCliCredentials | null> {
+function jwtExpiry(token: string): number | undefined {
+  const parts = token.split(".");
+  if (parts.length < 2) return undefined;
   try {
-    const raw = await deps.readBounded(xaiCliAuthFilePath(deps), MAX_CREDENTIAL_BYTES);
-    if (raw === null || raw.length > MAX_CREDENTIAL_BYTES) return null;
-    const auth = credentialRecord(JSON.parse(raw));
-    if (!auth) return null;
+    const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString("utf8")) as unknown;
+    const record = credentialRecord(payload);
+    const exp = record?.exp;
+    if (typeof exp !== "number" || !Number.isFinite(exp)) return undefined;
+    return Math.round(exp * 1_000);
+  } catch {
+    return undefined;
+  }
+}
 
+function effectiveExpiry(entry: Record<string, unknown>, accessToken: string): number | undefined {
+  const fromEntry = expiry(entry.expires_at) ?? expiry(entry.expires);
+  const fromJwt = jwtExpiry(accessToken);
+  if (fromEntry !== undefined && fromJwt !== undefined) return Math.min(fromEntry, fromJwt);
+  return fromEntry ?? fromJwt;
+}
+
+function clientId(entryKey: string, entry: Record<string, unknown>): string {
+  const fromEntry = optionalTrimmedString(entry.oidc_client_id);
+  if (fromEntry) return fromEntry;
+  const suffix = optionalTrimmedString(entryKey.split("::").at(-1));
+  return suffix ?? XAI_CLI_DEFAULT_CLIENT_ID;
+}
+
+function refreshToken(entry: Record<string, unknown>): string | undefined {
+  return optionalTrimmedString(entry.refresh_token) ?? optionalTrimmedString(entry.refresh);
+}
+
+async function defaultWriteAuthFile(filePath: string, contents: string): Promise<void> {
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    await fs.writeFile(tmpPath, contents, { encoding: "utf8", mode: 0o600 });
+    await fs.rename(tmpPath, filePath);
+  } catch (error) {
+    await fs.unlink(tmpPath).catch(() => undefined);
+    throw error;
+  }
+}
+
+async function persistRefreshedEntry(
+  deps: CredentialResolverDeps,
+  filePath: string,
+  entryKey: string,
+  patch: Record<string, string>,
+  writeAuthFile: (filePath: string, contents: string) => Promise<void>,
+): Promise<void> {
+  // Re-read so a concurrent `grok login` / CLI refresh is not replaced by a
+  // reconstructed object that would drop the other profiles' fields.
+  const raw = await deps.readBounded(filePath, MAX_CREDENTIAL_BYTES);
+  if (raw === null) return;
+  const auth = credentialRecord(JSON.parse(raw));
+  if (!auth) return;
+  const current = credentialRecord(auth[entryKey]) ?? {};
+  auth[entryKey] = { ...current, ...patch };
+  await writeAuthFile(filePath, `${JSON.stringify(auth, null, 2)}\n`);
+}
+
+async function refreshAccessToken(
+  entryKey: string,
+  entry: Record<string, unknown>,
+  fetchImpl: typeof fetch,
+  now: () => number,
+): Promise<{ readonly accessToken: string; readonly expiresAt: number; readonly refreshToken?: string } | null> {
+  const token = refreshToken(entry);
+  if (!token) return null;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REFRESH_TIMEOUT_MS);
+  try {
+    const body = new URLSearchParams({
+      grant_type: "refresh_token",
+      client_id: clientId(entryKey, entry),
+      refresh_token: token,
+    });
+    const response = await fetchImpl(XAI_CLI_REFRESH_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+      body,
+      signal: controller.signal,
+    });
+    if (!response.ok) return null;
+    const payload = credentialRecord(await response.json());
+    const accessToken = optionalTrimmedString(payload?.access_token);
+    if (!accessToken) return null;
+    const expiresIn = payload?.expires_in;
+    const expiresAt = typeof expiresIn === "number" && Number.isFinite(expiresIn) && expiresIn > 0
+      ? now() + Math.round(expiresIn * 1_000)
+      : jwtExpiry(accessToken) ?? now() + FALLBACK_ACCESS_TOKEN_TTL_MS;
+    const rotated = optionalTrimmedString(payload?.refresh_token);
+    return {
+      accessToken,
+      expiresAt,
+      ...(rotated === undefined ? {} : { refreshToken: rotated }),
+    };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Read the credential the Grok CLI owns. Fleet never starts OAuth; it may persist
+ * a silent refresh into this same vendor file (the CLI and OpenUsage do too) so a
+ * still-renewable session is not reported as signed out.
+ */
+export async function resolveXaiCliAuth(
+  deps: CredentialResolverDeps,
+  options: ResolveXaiCliOptions = {},
+): Promise<XaiCliAuthResult> {
+  const now = options.now ?? Date.now;
+  const fetchImpl = options.fetch ?? fetch;
+  const writeAuthFile = options.writeAuthFile ?? defaultWriteAuthFile;
+  const filePath = xaiCliAuthFilePath(deps);
+  try {
+    const raw = await deps.readBounded(filePath, MAX_CREDENTIAL_BYTES);
+    if (raw === null || raw.length > MAX_CREDENTIAL_BYTES) return { status: "signed_out" };
+    const auth = credentialRecord(JSON.parse(raw));
+    if (!auth) return { status: "signed_out" };
+
+    let sawExpired = false;
     for (const [entryKey, value] of Object.entries(auth)) {
       if (!entryKey.startsWith(`${XAI_OIDC_ISSUER}::`)) continue;
       const entry = credentialRecord(value);
       const issuer = optionalTrimmedString(entry?.oidc_issuer);
       const accessToken = optionalTrimmedString(entry?.key);
-      if (issuer !== XAI_OIDC_ISSUER || !accessToken) continue;
-      const expiresAt = expiry(entry?.expires_at);
-      if (expiresAt !== undefined && expiresAt <= now()) continue;
-      const userId = optionalTrimmedString(entry?.user_id)
-        ?? optionalTrimmedString(entry?.principal_id);
+      if (!entry || issuer !== XAI_OIDC_ISSUER || !accessToken) continue;
+      const expiresAt = effectiveExpiry(entry, accessToken);
+      const expired = expiresAt !== undefined && expiresAt <= now();
+      const needsRefresh = options.forceRefresh === true
+        || (expiresAt !== undefined && expiresAt - now() <= XAI_CLI_REFRESH_BUFFER_MS);
+
+      if (needsRefresh) {
+        const refreshed = await refreshAccessToken(entryKey, entry, fetchImpl, now);
+        if (refreshed) {
+          const userId = optionalTrimmedString(entry.user_id)
+            ?? optionalTrimmedString(entry.principal_id);
+          const patch: Record<string, string> = {
+            key: refreshed.accessToken,
+            expires_at: new Date(refreshed.expiresAt).toISOString(),
+          };
+          if (refreshed.refreshToken !== undefined) patch.refresh_token = refreshed.refreshToken;
+          try {
+            await persistRefreshedEntry(deps, filePath, entryKey, patch, writeAuthFile);
+          } catch {
+            // In-memory token is still usable this probe; the next read retries persist.
+          }
+          return {
+            status: "ok",
+            credentials: {
+              accessToken: refreshed.accessToken,
+              expiresAt: refreshed.expiresAt,
+              ...(userId === undefined ? {} : { userId }),
+            },
+          };
+        }
+        if (options.forceRefresh === true || expired) {
+          sawExpired = true;
+          continue;
+        }
+      } else if (expired) {
+        sawExpired = true;
+        continue;
+      }
+
+      const userId = optionalTrimmedString(entry.user_id)
+        ?? optionalTrimmedString(entry.principal_id);
       return {
-        accessToken,
-        ...(expiresAt === undefined ? {} : { expiresAt }),
-        ...(userId === undefined ? {} : { userId }),
+        status: "ok",
+        credentials: {
+          accessToken,
+          ...(expiresAt === undefined ? {} : { expiresAt }),
+          ...(userId === undefined ? {} : { userId }),
+        },
       };
     }
-    return null;
+    return { status: sawExpired ? "expired" : "signed_out" };
   } catch {
-    return null;
+    return { status: "signed_out" };
   }
+}
+
+export async function resolveXaiCliCredentials(
+  deps: CredentialResolverDeps,
+  nowOrOptions: (() => number) | ResolveXaiCliOptions = Date.now,
+): Promise<XaiCliCredentials | null> {
+  const options: ResolveXaiCliOptions = typeof nowOrOptions === "function"
+    ? { now: nowOrOptions }
+    : nowOrOptions;
+  const result = await resolveXaiCliAuth(deps, options);
+  return result.status === "ok" ? result.credentials : null;
 }

--- a/packages/core-ai-gateway/src/xai/quota.ts
+++ b/packages/core-ai-gateway/src/xai/quota.ts
@@ -8,57 +8,106 @@ import {
   safeTimestamp,
   type ProviderDeps,
 } from "../quota/windows.js";
-import { resolveXaiCliCredentials } from "./credentials.js";
+import { resolveXaiCliAuth, type XaiCliCredentials } from "./credentials.js";
 
 export const XAI_CLI_CREDITS_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
 const WEEKLY_PERIOD = "USAGE_PERIOD_TYPE_WEEKLY";
 
-export function parseXaiCredits(payload: unknown): QuotaWindow | null {
+export type ParsedXaiCredits =
+  | { readonly status: "weekly"; readonly window: QuotaWindow }
+  | { readonly status: "other" };
+
+/**
+ * Decode `GET /v1/billing?format=credits`. The body is proto3 JSON: a genuine 0%
+ * omits `creditUsagePercent` entirely. A present non-finite value is schema drift.
+ * Non-weekly periods (legacy monthly) are valid but have no shared weekly pool.
+ */
+export function parseXaiCredits(payload: unknown): ParsedXaiCredits | null {
   const root = object(payload);
   const config = object(root?.config);
   const period = object(config?.currentPeriod);
-  if (!config || !period || period.type !== WEEKLY_PERIOD) return null;
+  const periodType = typeof period?.type === "string" ? period.type.trim() : "";
+  if (!config || !period || periodType.length === 0) return null;
   const startsAt = safeTimestamp(period.start);
   const resetsAt = safeTimestamp(period.end);
   if (startsAt === undefined || resetsAt === undefined || resetsAt <= startsAt) return null;
-  if (typeof config.creditUsagePercent !== "number"
-    || !Number.isFinite(config.creditUsagePercent)) return null;
+  if (periodType !== WEEKLY_PERIOD) return { status: "other" };
+
+  let usedPercent = 0;
+  if (config.creditUsagePercent !== undefined) {
+    if (typeof config.creditUsagePercent !== "number" || !Number.isFinite(config.creditUsagePercent)) {
+      return null;
+    }
+    usedPercent = percent(config.creditUsagePercent);
+  }
+
   return {
-    id: "weekly",
-    usedPercent: percent(config.creditUsagePercent),
-    resetsAt,
-    period: {
-      durationMs: resetsAt - startsAt,
-      durationBasis: "upstream",
-      startsAt,
-      startsAtBasis: "upstream",
+    status: "weekly",
+    window: {
+      id: "weekly",
+      usedPercent,
+      resetsAt,
+      period: {
+        durationMs: resetsAt - startsAt,
+        durationBasis: "upstream",
+        startsAt,
+        startsAtBasis: "upstream",
+      },
     },
   };
 }
 
+function creditsHeaders(credentials: XaiCliCredentials): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    Authorization: `Bearer ${credentials.accessToken}`,
+    "X-XAI-Token-Auth": "xai-grok-cli",
+  };
+  if (credentials.userId) headers["x-userid"] = credentials.userId;
+  return headers;
+}
+
 export async function fetchXaiUsage(deps: ProviderDeps = {}): Promise<ProviderResult> {
-  const credentials = await resolveXaiCliCredentials(
-    deps.credentials ?? defaultCredentialDeps,
-    deps.now ?? Date.now,
+  const credentialDeps = deps.credentials ?? defaultCredentialDeps;
+  const now = deps.now ?? Date.now;
+  const fetchImpl = deps.fetch ?? fetch;
+  const auth = await resolveXaiCliAuth(credentialDeps, { now, fetch: fetchImpl });
+  if (auth.status !== "ok") return { status: auth.status };
+
+  const load = (credentials: XaiCliCredentials) => getJson(
+    fetchImpl,
+    XAI_CLI_CREDITS_URL,
+    creditsHeaders(credentials),
   );
-  if (!credentials) return { status: "signed_out" };
+
   try {
-    const headers: Record<string, string> = {
-      Accept: "application/json",
-      Authorization: `Bearer ${credentials.accessToken}`,
-      "X-XAI-Token-Auth": "xai-grok-cli",
-    };
-    if (credentials.userId) headers["x-userid"] = credentials.userId;
-    const window = parseXaiCredits(await getJson(
-      deps.fetch ?? fetch,
-      XAI_CLI_CREDITS_URL,
-      headers,
-    ));
-    if (!window) throw new Error("Grok returned an unsupported quota response");
+    let credentials = auth.credentials;
+    let payload: unknown;
+    try {
+      payload = await load(credentials);
+    } catch (error) {
+      if (!expired(error)) throw error;
+      const retried = await resolveXaiCliAuth(credentialDeps, {
+        now,
+        fetch: fetchImpl,
+        forceRefresh: true,
+      });
+      if (retried.status !== "ok") return { status: "expired" };
+      credentials = retried.credentials;
+      try {
+        payload = await load(credentials);
+      } catch (retryError) {
+        const result = expired(retryError);
+        if (result) return result;
+        throw retryError;
+      }
+    }
+    const parsed = parseXaiCredits(payload);
+    if (!parsed) throw new Error("Grok returned an unsupported quota response");
     return {
       status: "ok",
-      windows: [window],
-      fetchedAt: (deps.now ?? Date.now)(),
+      windows: parsed.status === "weekly" ? [parsed.window] : [],
+      fetchedAt: now(),
     };
   } catch (error) {
     const result = expired(error);

--- a/packages/core-ai-gateway/tests/xai.test.ts
+++ b/packages/core-ai-gateway/tests/xai.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it, vi } from "vitest";
 import {
   XAI_CLI_CLIENT_VERSION,
   XAI_CLI_CREDITS_URL,
+  XAI_CLI_REFRESH_URL,
   XAI_CLI_RESPONSES_URL,
   XaiResponsesAdapter,
   fetchXaiUsage,
   parseXaiCredits,
+  resolveXaiCliAuth,
   resolveXaiCliCredentials,
   xaiCliAuthFilePath,
 } from "../src/index.js";
@@ -20,6 +22,32 @@ function deps(raw: string | null, env: NodeJS.ProcessEnv = {}): CredentialResolv
     readBounded: vi.fn(async () => raw),
     execFile: vi.fn(async () => ""),
   };
+}
+
+function jwtWithExp(expSeconds: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ exp: expSeconds })).toString("base64url");
+  return `${header}.${payload}.sig`;
+}
+
+const WEEKLY_PERIOD = {
+  type: "USAGE_PERIOD_TYPE_WEEKLY",
+  start: "2026-08-10T00:00:00Z",
+  end: "2026-08-17T00:00:00Z",
+};
+
+function creditsResponse(config: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify({ config }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function refreshResponse(accessToken: string, expiresIn = 3600): Response {
+  return new Response(JSON.stringify({ access_token: accessToken, expires_in: expiresIn }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
 }
 
 describe("Grok CLI credentials", () => {
@@ -62,45 +90,103 @@ describe("Grok CLI credentials", () => {
       accessToken: "active-token",
     });
   });
+
+  it("silently refreshes a still-renewable token and persists the replacement", async () => {
+    const auth = {
+      "https://auth.x.ai::profile": {
+        key: jwtWithExp(Math.floor(Date.parse("2026-08-14T00:04:00Z") / 1_000)),
+        oidc_issuer: "https://auth.x.ai",
+        expires_at: "2026-08-14T00:04:00Z",
+        refresh_token: "refresh-1",
+        oidc_client_id: "client-1",
+        user_id: "user-1",
+      },
+    };
+    const credentialDeps = deps(JSON.stringify(auth));
+    const writeAuthFile = vi.fn(async () => {});
+    const fetchMock = vi.fn<typeof fetch>(async (url) => {
+      expect(String(url)).toBe(XAI_CLI_REFRESH_URL);
+      return refreshResponse("fresh-token", 7_200);
+    });
+    const result = await resolveXaiCliAuth(credentialDeps, {
+      now: () => Date.parse("2026-08-14T00:00:00Z"),
+      fetch: fetchMock,
+      writeAuthFile,
+    });
+    expect(result).toEqual({
+      status: "ok",
+      credentials: {
+        accessToken: "fresh-token",
+        expiresAt: Date.parse("2026-08-14T02:00:00Z"),
+        userId: "user-1",
+      },
+    });
+    expect(writeAuthFile).toHaveBeenCalledTimes(1);
+    const written = writeAuthFile.mock.calls.at(0)?.at(1);
+    expect(JSON.parse(String(written))["https://auth.x.ai::profile"]).toMatchObject({
+      key: "fresh-token",
+      refresh_token: "refresh-1",
+      user_id: "user-1",
+    });
+    const init = fetchMock.mock.calls[0]?.[1];
+    expect(String(init?.body)).toContain("grant_type=refresh_token");
+    expect(String(init?.body)).toContain("client_id=client-1");
+    expect(String(init?.body)).toContain("refresh_token=refresh-1");
+  });
+
+  it("reports expired when every renewable profile fails to refresh", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response("invalid_grant", { status: 400 }));
+    await expect(resolveXaiCliAuth(deps(JSON.stringify({
+      "https://auth.x.ai::profile": {
+        key: "stale",
+        oidc_issuer: "https://auth.x.ai",
+        expires_at: "2026-08-13T00:00:00Z",
+        refresh_token: "refresh-1",
+      },
+    })), {
+      now: () => Date.parse("2026-08-14T00:00:00Z"),
+      fetch: fetchMock,
+    })).resolves.toEqual({ status: "expired" });
+  });
 });
 
 describe("Grok quota", () => {
   it("parses the weekly credits window", () => {
     expect(parseXaiCredits({ config: {
       creditUsagePercent: 42.4,
-      currentPeriod: {
-        type: "USAGE_PERIOD_TYPE_WEEKLY",
-        start: "2026-08-10T00:00:00Z",
-        end: "2026-08-17T00:00:00Z",
-      },
+      currentPeriod: WEEKLY_PERIOD,
     } })).toMatchObject({
-      id: "weekly",
-      usedPercent: 42,
-      resetsAt: Date.parse("2026-08-17T00:00:00Z"),
-      period: { durationBasis: "upstream", startsAtBasis: "upstream" },
+      status: "weekly",
+      window: {
+        id: "weekly",
+        usedPercent: 42,
+        resetsAt: Date.parse("2026-08-17T00:00:00Z"),
+        period: { durationBasis: "upstream", startsAtBasis: "upstream" },
+      },
     });
     expect(XAI_CLI_CREDITS_URL).toContain("billing?format=credits");
   });
 
-  it("rejects a credits response without a finite usage percentage", () => {
-    const period = {
-      type: "USAGE_PERIOD_TYPE_WEEKLY",
-      start: "2026-08-10T00:00:00Z",
-      end: "2026-08-17T00:00:00Z",
-    };
-    expect(parseXaiCredits({ config: { currentPeriod: period } })).toBeNull();
-    expect(parseXaiCredits({ config: { creditUsagePercent: Number.NaN, currentPeriod: period } })).toBeNull();
+  it("treats an omitted creditUsagePercent as a genuine 0%", () => {
+    // proto3 JSON drops zeros. OpenUsage documents the same shape: absent means 0, not drift.
+    expect(parseXaiCredits({ config: { currentPeriod: WEEKLY_PERIOD } })).toMatchObject({
+      status: "weekly",
+      window: { id: "weekly", usedPercent: 0 },
+    });
+  });
+
+  it("rejects a present non-finite usage percentage and accepts a non-weekly period as empty", () => {
+    expect(parseXaiCredits({ config: { creditUsagePercent: Number.NaN, currentPeriod: WEEKLY_PERIOD } })).toBeNull();
+    expect(parseXaiCredits({ config: {
+      currentPeriod: { ...WEEKLY_PERIOD, type: "USAGE_PERIOD_TYPE_MONTHLY" },
+    } })).toEqual({ status: "other" });
   });
 
   it("reads weekly credits with Grok CLI subscription headers", async () => {
-    const fetchMock = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({ config: {
+    const fetchMock = vi.fn<typeof fetch>(async () => creditsResponse({
       creditUsagePercent: 42.4,
-      currentPeriod: {
-        type: "USAGE_PERIOD_TYPE_WEEKLY",
-        start: "2026-08-10T00:00:00Z",
-        end: "2026-08-17T00:00:00Z",
-      },
-    } }), { status: 200, headers: { "content-type": "application/json" } }));
+      currentPeriod: WEEKLY_PERIOD,
+    }));
     const result = await fetchXaiUsage({
       credentials: deps(JSON.stringify({
         "https://auth.x.ai::profile": {
@@ -121,6 +207,54 @@ describe("Grok quota", () => {
     expect(headers.get("x-xai-token-auth")).toBe("xai-grok-cli");
     expect(headers.get("x-userid")).toBe("user-1");
     expect(result).toMatchObject({ status: "ok", windows: [{ id: "weekly", usedPercent: 42 }] });
+  });
+
+  it("returns an empty weekly window when proto-JSON omitted the 0% field", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => creditsResponse({ currentPeriod: WEEKLY_PERIOD }));
+    await expect(fetchXaiUsage({
+      credentials: deps(JSON.stringify({
+        "https://auth.x.ai::profile": {
+          key: "access-token",
+          oidc_issuer: "https://auth.x.ai",
+          expires_at: "2026-08-15T00:00:00Z",
+        },
+      })),
+      fetch: fetchMock,
+      now: () => Date.parse("2026-08-14T00:00:00Z"),
+    })).resolves.toMatchObject({ status: "ok", windows: [{ id: "weekly", usedPercent: 0 }] });
+  });
+
+  it("refreshes once after a 401 and retries the credits request", async () => {
+    const auth = {
+      "https://auth.x.ai::profile": {
+        key: "stale-token",
+        oidc_issuer: "https://auth.x.ai",
+        expires_at: "2026-08-15T00:00:00Z",
+        refresh_token: "refresh-1",
+        user_id: "user-1",
+      },
+    };
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      throw new Error("unexpected fetch");
+    });
+    fetchMock
+      .mockImplementationOnce(async () => new Response("unauthorized", { status: 401 }))
+      .mockImplementationOnce(async (url) => {
+        expect(String(url)).toBe(XAI_CLI_REFRESH_URL);
+        return refreshResponse("fresh-token");
+      })
+      .mockImplementationOnce(async (url, init) => {
+        expect(String(url)).toBe(XAI_CLI_CREDITS_URL);
+        expect(new Headers(init?.headers).get("authorization")).toBe("Bearer fresh-token");
+        return creditsResponse({ creditUsagePercent: 7, currentPeriod: WEEKLY_PERIOD });
+      });
+    const result = await fetchXaiUsage({
+      credentials: deps(JSON.stringify(auth)),
+      fetch: fetchMock,
+      now: () => Date.parse("2026-08-14T00:00:00Z"),
+    });
+    expect(result).toMatchObject({ status: "ok", windows: [{ usedPercent: 7 }] });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/packages/core-ai-gateway/tests/xai.test.ts
+++ b/packages/core-ai-gateway/tests/xai.test.ts
@@ -134,6 +134,43 @@ describe("Grok CLI credentials", () => {
     expect(String(init?.body)).toContain("refresh_token=refresh-1");
   });
 
+  it("does not persist a refresh when the file owner already rotated the same entry", async () => {
+    const original = {
+      "https://auth.x.ai::profile": {
+        key: jwtWithExp(Math.floor(Date.parse("2026-08-14T00:04:00Z") / 1_000)),
+        oidc_issuer: "https://auth.x.ai",
+        expires_at: "2026-08-14T00:04:00Z",
+        refresh_token: "refresh-1",
+        user_id: "user-1",
+      },
+    };
+    const rotated = {
+      "https://auth.x.ai::profile": {
+        key: "cli-newer-access",
+        oidc_issuer: "https://auth.x.ai",
+        expires_at: "2026-08-14T02:00:00Z",
+        refresh_token: "refresh-2",
+        user_id: "user-1",
+      },
+    };
+    let reads = 0;
+    const credentialDeps = deps(JSON.stringify(original));
+    const readBounded = vi.fn(async () => {
+      reads += 1;
+      return JSON.stringify(reads === 1 ? original : rotated);
+    });
+    const sequentialDeps: CredentialResolverDeps = { ...credentialDeps, readBounded };
+    const writeAuthFile = vi.fn(async () => {});
+    const result = await resolveXaiCliAuth(sequentialDeps, {
+      now: () => Date.parse("2026-08-14T00:00:00Z"),
+      fetch: vi.fn<typeof fetch>(async () => refreshResponse("fleet-stale-access", 7_200)),
+      writeAuthFile,
+    });
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") expect(result.credentials.accessToken).toBe("fleet-stale-access");
+    expect(writeAuthFile).not.toHaveBeenCalled();
+  });
+
   it("reports expired when every renewable profile fails to refresh", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => new Response("invalid_grant", { status: 400 }));
     await expect(resolveXaiCliAuth(deps(JSON.stringify({


### PR DESCRIPTION
## Summary
- Grok weekly quota treated proto3 JSON omission of `creditUsagePercent` (a genuine 0%) as an unsupported response, so the quota card and `gateway_models` reported `error` until any spend made the field reappear.
- Renew a still-valid Grok CLI session through `auth.x.ai` before expiry (5-minute buffer) or after a 401/403, matching the official CLI / OpenUsage path, and persist the replacement into `~/.grok/auth.json` without dropping other profiles.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test tests/xai.test.ts tests/quota/service.test.ts tests/gateway-router/routes.test.ts tests/provider-boundaries.test.ts`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @fleet-plugins/quota test`
- [x] Live `GET https://cli-chat-proxy.grok.com/v1/billing?format=credits` on this machine returned 200; the previous `error` reproduced as a parse rejection of an omitted 0%, not a network/auth failure.