### PR TITLE
fix(ai-gateway): buffer incomplete Grok tool calls

### DIFF
--- a/.changelog.d/grok-cli-provider.md
+++ b/.changelog.d/grok-cli-provider.md
@@ -4,8 +4,8 @@ branch: grok-cli-provider
 
 ### fleet-cli
 #### Added
-- Added Grok 4.6 through the official Grok CLI subscription, reusing its local sign-in without API keys or a Fleet-managed OAuth flow and matching the CLI proxy's client contract.
-  ko: API key나 Fleet 관리 OAuth 흐름 없이 공식 Grok CLI의 로컬 로그인을 재사용하고 CLI proxy의 client 계약을 준수하는 Grok 4.6 지원을 추가했습니다.
+- Added Grok 4.6 through the official Grok CLI subscription, reusing its local sign-in without API keys or a Fleet-managed OAuth flow, matching the CLI proxy's client contract, and rejecting incomplete tool calls before they can appear as running work.
+  ko: API key나 Fleet 관리 OAuth 흐름 없이 공식 Grok CLI의 로컬 로그인을 재사용하고 CLI proxy의 client 계약을 준수하며, 불완전한 도구 호출이 실행 중인 작업으로 나타나기 전에 거부하는 Grok 4.6 지원을 추가했습니다.
 
 ### fleet-console
 #### Added

--- a/packages/core-ai-gateway/src/xai/responses/adapter.ts
+++ b/packages/core-ai-gateway/src/xai/responses/adapter.ts
@@ -26,6 +26,7 @@ export const XAI_CLI_RESPONSES_URL = "https://cli-chat-proxy.grok.com/v1/respons
 export const XAI_CLI_CLIENT_VERSION = "1.0.3";
 export const DEFAULT_XAI_RESPONSES_MAX_UPSTREAM_BODY_BYTES = 64 * 1024 * 1024;
 export const DEFAULT_XAI_RESPONSES_UPSTREAM_IDLE_TIMEOUT_MS = 30_000;
+export const DEFAULT_XAI_RESPONSES_FUNCTION_CALL_TIMEOUT_MS = 30_000;
 
 /**
  * Grok CLI's Responses wire accepts the canonical OpenAI-shaped request after
@@ -46,6 +47,7 @@ export interface XaiResponsesAdapterOptions {
   fetch?: FetchLike;
   maxBodyBytes?: number;
   idleTimeoutMs?: number;
+  functionCallTimeoutMs?: number;
   /** 구독 경로가 요구하는 추가 헤더. */
   headers?: Readonly<Record<string, string>>;
 }
@@ -55,6 +57,7 @@ export class XaiResponsesAdapter implements AiGatewayAdapter {
   private readonly fetchImpl: FetchLike;
   private readonly maxBodyBytes: number;
   private readonly idleTimeoutMs: number;
+  private readonly functionCallTimeoutMs: number;
   private readonly url: string;
   private readonly extraHeaders: Readonly<Record<string, string>>;
 
@@ -71,6 +74,10 @@ export class XaiResponsesAdapter implements AiGatewayAdapter {
     this.idleTimeoutMs = positiveInteger(
       options.idleTimeoutMs ?? DEFAULT_XAI_RESPONSES_UPSTREAM_IDLE_TIMEOUT_MS,
       "idleTimeoutMs"
+    );
+    this.functionCallTimeoutMs = positiveInteger(
+      options.functionCallTimeoutMs ?? DEFAULT_XAI_RESPONSES_FUNCTION_CALL_TIMEOUT_MS,
+      "functionCallTimeoutMs"
     );
   }
 
@@ -140,7 +147,7 @@ export class XaiResponsesAdapter implements AiGatewayAdapter {
         idleTimeoutMs: this.idleTimeoutMs,
         maxBodyBytes: this.maxBodyBytes,
         onClose: unlinkAbort
-      })
+      }, this.functionCallTimeoutMs)
     };
   }
 }
@@ -169,13 +176,162 @@ type ReadOptions = UpstreamReadOptions;
 
 function parseXaiEventStream(
   body: ReadableStream<Uint8Array> | null,
-  options: ReadOptions & { onClose: () => void }
+  options: ReadOptions & { onClose: () => void },
+  functionCallTimeoutMs: number
 ): AsyncGenerator<CanonicalResponseEvent> {
-  return parseUpstreamSseStream(
-    body,
-    { ...options, missingBodyMessage: "Grok CLI streaming response had no body" },
-    parseEventFrame,
+  return assembleXaiFunctionCalls(
+    parseUpstreamSseStream(
+      body,
+      { ...options, missingBodyMessage: "Grok CLI streaming response had no body" },
+      parseEventFrame,
+    ),
+    options.controller,
+    functionCallTimeoutMs,
   );
+}
+
+interface PendingXaiFunctionCall {
+  readonly added: Extract<CanonicalResponseEvent, { type: "response.output_item.added" }>;
+  readonly deadlineAt: number;
+  argumentsDone?: Extract<CanonicalResponseEvent, { type: "response.function_call_arguments.done" }>;
+}
+
+async function* assembleXaiFunctionCalls(
+  source: AsyncIterable<CanonicalResponseEvent>,
+  controller: AbortController,
+  timeoutMs: number,
+): AsyncGenerator<CanonicalResponseEvent> {
+  const iterator = source[Symbol.asyncIterator]();
+  const pending = new Map<string, PendingXaiFunctionCall>();
+  let completedNormally = false;
+  try {
+    while (true) {
+      const deadlineAt = earliestXaiFunctionCallDeadline(pending);
+      const result = deadlineAt === undefined
+        ? await iterator.next()
+        : await nextXaiEventBeforeDeadline(iterator, deadlineAt, controller, timeoutMs);
+      if (result.done) {
+        if (pending.size > 0) {
+          throw incompleteXaiFunctionCall("stream ended before function call output_item.done");
+        }
+        completedNormally = true;
+        return;
+      }
+
+      const event = result.value;
+      if (event.type === "response.completed" && pending.size > 0) {
+        throw incompleteXaiFunctionCall("response.completed arrived before function call output_item.done");
+      }
+      if (event.type === "response.output_item.added" && event.item.type === "function_call") {
+        const key = xaiFunctionCallKey(event.output_index, event.item.id);
+        pending.set(key, {
+          added: event,
+          // Each call gets a full timeout from its own added event. Waiting uses the
+          // earliest active deadline, so a later parallel call is never shortened by
+          // an earlier call's age.
+          deadlineAt: Date.now() + timeoutMs,
+        });
+        continue;
+      }
+      if (event.type === "response.function_call_arguments.done") {
+        const call = pending.get(xaiFunctionCallKey(event.output_index, event.item_id));
+        if (call !== undefined) {
+          call.argumentsDone = event;
+          continue;
+        }
+      }
+      if (event.type === "response.output_item.done" && event.item.type === "function_call") {
+        const key = xaiFunctionCallKey(event.output_index, event.item.id);
+        const call = pending.get(key);
+        if (call !== undefined) {
+          pending.delete(key);
+          yield call.added;
+          if (call.argumentsDone !== undefined) {
+            yield call.argumentsDone;
+          } else if (event.item.arguments.length > 0) {
+            yield {
+              type: "response.function_call_arguments.done",
+              item_id: event.item.id,
+              output_index: event.output_index,
+              arguments: event.item.arguments,
+            };
+          }
+          yield event;
+          continue;
+        }
+      }
+      yield event;
+    }
+  } finally {
+    // A normal source completion must retain the existing lifecycle: the caller's
+    // signal is not aborted just because the response ended successfully. On an
+    // error or early consumer return, abort first so any pending upstream read is
+    // released before returning the iterator.
+    if (!completedNormally && !controller.signal.aborted) {
+      controller.abort();
+    }
+    const returned = iterator.return?.();
+    if (returned !== undefined) {
+      await returned.catch(() => undefined);
+    }
+  }
+}
+
+function earliestXaiFunctionCallDeadline(
+  pending: ReadonlyMap<string, PendingXaiFunctionCall>,
+): number | undefined {
+  let earliest: number | undefined;
+  for (const call of pending.values()) {
+    if (earliest === undefined || call.deadlineAt < earliest) {
+      earliest = call.deadlineAt;
+    }
+  }
+  return earliest;
+}
+
+async function nextXaiEventBeforeDeadline(
+  iterator: AsyncIterator<CanonicalResponseEvent>,
+  deadlineAt: number,
+  controller: AbortController,
+  timeoutMs: number,
+): Promise<IteratorResult<CanonicalResponseEvent>> {
+  const remainingMs = deadlineAt - Date.now();
+  if (remainingMs <= 0) {
+    const error = incompleteXaiFunctionCall(`function call assembly exceeded ${timeoutMs}ms`);
+    controller.abort(error);
+    throw error;
+  }
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const next = iterator.next();
+  // A timeout wins the race by design, but aborting the upstream reader rejects
+  // this losing read shortly afterwards. Consume that rejection so timeout
+  // cleanup never leaks an unhandled promise.
+  void next.catch(() => undefined);
+  try {
+    return await Promise.race([
+      next,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          const error = incompleteXaiFunctionCall(`function call assembly exceeded ${timeoutMs}ms`);
+          controller.abort(error);
+          reject(error);
+        }, remainingMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function incompleteXaiFunctionCall(reason: string): UpstreamProtocolError {
+  return new UpstreamProtocolError(`Grok CLI ${reason}`);
+}
+
+function xaiFunctionCallKey(outputIndex: number, itemId: string): string {
+  return `${outputIndex}:${itemId}`;
 }
 
 function parseEventFrame(frame: string): CanonicalResponseEvent | undefined {

--- a/packages/core-ai-gateway/tests/xai.test.ts
+++ b/packages/core-ai-gateway/tests/xai.test.ts
@@ -10,7 +10,123 @@ import {
   resolveXaiCliCredentials,
   xaiCliAuthFilePath,
 } from "../src/index.js";
-import type { CanonicalResponseRequest, CredentialResolverDeps } from "../src/index.js";
+import type {
+  CanonicalResponseEvent,
+  CanonicalResponseRequest,
+  CredentialResolverDeps,
+} from "../src/index.js";
+
+function xaiRequest(overrides: Partial<CanonicalResponseRequest> = {}): CanonicalResponseRequest {
+  return {
+    model: "grok-4.6",
+    input: [{ type: "message", role: "user", content: "hi" }],
+    stream: true,
+    ...overrides,
+  };
+}
+
+function xaiFrame(event: CanonicalResponseEvent | Record<string, unknown>): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+function xaiResponse(...frames: string[]): Response {
+  return new Response(frames.join(""), {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function xaiSnapshot(id = "r1"): { id: string; model: string; usage: null } {
+  return { id, model: "grok-4.6", usage: null };
+}
+
+async function collectXaiEvents(events: AsyncIterable<CanonicalResponseEvent>): Promise<CanonicalResponseEvent[]> {
+  const collected: CanonicalResponseEvent[] = [];
+  for await (const event of events) collected.push(event);
+  return collected;
+}
+
+function controlledXaiResponse(): {
+  response: Response;
+  push: (chunk: string) => void;
+  close: () => void;
+  wasCancelled: () => boolean;
+} {
+  let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+  let cancelled = false;
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      streamController = controller;
+    },
+    cancel() {
+      cancelled = true;
+    },
+  });
+  return {
+    response: new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } }),
+    push(chunk) {
+      streamController?.enqueue(encoder.encode(chunk));
+    },
+    close() {
+      streamController?.close();
+    },
+    wasCancelled() {
+      return cancelled;
+    },
+  };
+}
+
+function functionCallAdded(id: string, outputIndex = 0): CanonicalResponseEvent {
+  return {
+    type: "response.output_item.added",
+    output_index: outputIndex,
+    item: { type: "function_call", id, call_id: id, name: "Read", arguments: "" },
+  };
+}
+
+function functionCallDone(id: string, outputIndex = 0, argumentsValue = "{}"): CanonicalResponseEvent {
+  return {
+    type: "response.output_item.done",
+    output_index: outputIndex,
+    item: { type: "function_call", id, call_id: id, name: "Read", arguments: argumentsValue },
+  };
+}
+
+function responseCompleted(): CanonicalResponseEvent {
+  return { type: "response.completed", response: xaiSnapshot() };
+}
+
+function responseCreated(): CanonicalResponseEvent {
+  return { type: "response.created", response: xaiSnapshot() };
+}
+
+function textDelta(delta: string): CanonicalResponseEvent {
+  return { type: "response.output_text.delta", item_id: "m1", output_index: 0, content_index: 0, delta };
+}
+
+function textDone(text: string): CanonicalResponseEvent {
+  return { type: "response.output_text.done", item_id: "m1", output_index: 0, content_index: 0, text };
+}
+
+function argumentsDone(id: string, outputIndex = 0, value = "{}"): CanonicalResponseEvent {
+  return { type: "response.function_call_arguments.done", item_id: id, output_index: outputIndex, arguments: value };
+}
+
+async function flushXaiStream(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function functionCallRequest(): CanonicalResponseRequest {
+  return xaiRequest({
+    tools: [{ type: "function", name: "Read", parameters: { type: "object" } }],
+  });
+}
+
+function eventTypes(events: readonly CanonicalResponseEvent[]): string[] {
+  return events.map((event) => event.type);
+}
 
 function deps(raw: string | null, env: NodeJS.ProcessEnv = {}): CredentialResolverDeps {
   return {
@@ -121,6 +237,141 @@ describe("Grok quota", () => {
     expect(headers.get("x-xai-token-auth")).toBe("xai-grok-cli");
     expect(headers.get("x-userid")).toBe("user-1");
     expect(result).toMatchObject({ status: "ok", windows: [{ id: "weekly", usedPercent: 42 }] });
+  });
+});
+
+describe("Grok Responses function-call assembly", () => {
+  it("emits a function call atomically only after output_item.done", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => xaiResponse(
+      xaiFrame(responseCreated()),
+      xaiFrame(functionCallAdded("call-1")),
+      xaiFrame(argumentsDone("call-1", 0, '{"path":"a.ts"}')),
+      xaiFrame(functionCallDone("call-1", 0, '{"path":"a.ts"}')),
+      xaiFrame(responseCompleted()),
+    ));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(functionCallRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+    const events = await collectXaiEvents(response.events);
+    expect(eventTypes(events)).toEqual([
+      "response.created",
+      "response.output_item.added",
+      "response.function_call_arguments.done",
+      "response.output_item.done",
+      "response.completed",
+    ]);
+    const addedIndex = events.findIndex((event) => event.type === "response.output_item.added");
+    const doneIndex = events.findIndex((event) => event.type === "response.output_item.done");
+    expect(addedIndex).toBeLessThan(doneIndex);
+    expect(events[1]).toMatchObject({ type: "response.output_item.added", item: { id: "call-1" } });
+  });
+
+  it("does not emit an added call when response.completed arrives first", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => xaiResponse(
+      xaiFrame(functionCallAdded("call-1")),
+      xaiFrame(responseCompleted()),
+    ));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(functionCallRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+    await expect(collectXaiEvents(response.events)).rejects.toThrow("response.completed arrived before");
+  });
+
+  it("reports EOF while a function call is pending", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => xaiResponse(xaiFrame(functionCallAdded("call-1"))));
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(functionCallRequest(), { apiKey: "k" });
+    if (!response.ok) throw new Error("expected ok");
+    await expect(collectXaiEvents(response.events)).rejects.toThrow("stream ended before");
+  });
+
+  it("times out a pending call despite keepalive and unrelated canonical events", async () => {
+    vi.useFakeTimers();
+    try {
+      const controlled = controlledXaiResponse();
+      const fetchMock = vi.fn<typeof fetch>(async () => controlled.response);
+      const response = await new XaiResponsesAdapter({ fetch: fetchMock, functionCallTimeoutMs: 20 }).stream(functionCallRequest(), { apiKey: "k" });
+      if (!response.ok) throw new Error("expected ok");
+      const events = collectXaiEvents(response.events);
+      const eventsExpectation = expect(events).rejects.toThrow("assembly exceeded 20ms");
+      controlled.push(xaiFrame(functionCallAdded("call-1")));
+      await flushXaiStream();
+      controlled.push(": keepalive\n\n");
+      controlled.push(xaiFrame(textDelta("still alive")));
+      await flushXaiStream();
+      await vi.advanceTimersByTimeAsync(20);
+      await eventsExpectation;
+      expect(controlled.wasCancelled()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("gives staggered parallel calls independent full deadlines", async () => {
+    vi.useFakeTimers();
+    try {
+      const controlled = controlledXaiResponse();
+      const fetchMock = vi.fn<typeof fetch>(async () => controlled.response);
+      const response = await new XaiResponsesAdapter({ fetch: fetchMock, functionCallTimeoutMs: 50 }).stream(functionCallRequest(), { apiKey: "k" });
+      if (!response.ok) throw new Error("expected ok");
+      const events = collectXaiEvents(response.events);
+      controlled.push(xaiFrame(functionCallAdded("call-1", 0)));
+      await flushXaiStream();
+      await vi.advanceTimersByTimeAsync(30);
+      controlled.push(xaiFrame(functionCallAdded("call-2", 1)));
+      controlled.push(xaiFrame(functionCallDone("call-1", 0)));
+      await flushXaiStream();
+      controlled.push(xaiFrame(functionCallDone("call-2", 1)));
+      controlled.push(xaiFrame(responseCompleted()));
+      controlled.close();
+      await expect(events).resolves.toEqual(expect.arrayContaining([
+        expect.objectContaining({ type: "response.output_item.done", output_index: 1 }),
+      ]));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("caller abort cancels the upstream read and leaves no pending timer", async () => {
+    vi.useFakeTimers();
+    try {
+      const controlled = controlledXaiResponse();
+      const fetchMock = vi.fn<typeof fetch>(async () => controlled.response);
+      const caller = new AbortController();
+      const response = await new XaiResponsesAdapter({ fetch: fetchMock, functionCallTimeoutMs: 100 }).stream(functionCallRequest(), { apiKey: "k", signal: caller.signal });
+      if (!response.ok) throw new Error("expected ok");
+      const events = collectXaiEvents(response.events);
+      controlled.push(xaiFrame(functionCallAdded("call-1")));
+      await flushXaiStream();
+      caller.abort(new Error("caller stopped"));
+      await expect(events).rejects.toThrow("caller stopped");
+      expect(controlled.wasCancelled()).toBe(true);
+      await vi.advanceTimersByTimeAsync(200);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves text-only streaming unchanged and preserves normal completion lifecycle", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => xaiResponse(
+      xaiFrame(responseCreated()),
+      xaiFrame(textDelta("hi")),
+      xaiFrame(textDone("hi")),
+      xaiFrame(responseCompleted()),
+    ));
+    const caller = new AbortController();
+    const response = await new XaiResponsesAdapter({ fetch: fetchMock }).stream(xaiRequest(), { apiKey: "k", signal: caller.signal });
+    if (!response.ok) throw new Error("expected ok");
+    await expect(collectXaiEvents(response.events)).resolves.toEqual([
+      responseCreated(),
+      textDelta("hi"),
+      textDone("hi"),
+      responseCompleted(),
+    ]);
+    expect(caller.signal.aborted).toBe(false);
+  });
+
+  it("requires a positive function-call timeout option", () => {
+    expect(() => new XaiResponsesAdapter({ functionCallTimeoutMs: 0 })).toThrow("functionCallTimeoutMs must be a positive integer");
+    expect(() => new XaiResponsesAdapter({ functionCallTimeoutMs: -1 })).toThrow("functionCallTimeoutMs must be a positive integer");
+    expect(() => new XaiResponsesAdapter({ functionCallTimeoutMs: 1.5 })).toThrow("functionCallTimeoutMs must be a positive integer");
   });
 });
 


### PR DESCRIPTION
## Summary
- Buffer Grok Responses function calls until `response.output_item.done` so incomplete upstream calls never open a caller-visible tool execution.
- Fail closed on premature completion, EOF, or a per-call 30-second assembly deadline while preserving independent parallel-call deadlines and cancellation cleanup.
- Extend the unreleased Grok CLI provider note with the incomplete-call guarantee.

## Test Plan
- [x] `pnpm --filter @dotobokuri/core-ai-gateway test` (31 files, 626 tests)
- [x] `pnpm --filter @dotobokuri/core-ai-gateway typecheck`
- [x] `pnpm --filter @dotobokuri/core-ai-gateway build`
- [x] `pnpm check:core-boundary`
- [x] `pnpm --filter @dotobokuri/fleet-console build`
- [x] `node scripts/compile-changelog-fragments.mjs --check`
- [x] xAI Grok 4.6 low: five successful before and five successful after trials, each with 3 calls / 3 results / 0 errors and 1.00 caller-call amplification

Changelog-Amend: grok-cli-provider.md